### PR TITLE
feat(agent): reconciliación RAG Co ↔ NON-Co con etiquetado de origen (#35)

### DIFF
--- a/src/services/__tests__/agentPromptBase.test.js
+++ b/src/services/__tests__/agentPromptBase.test.js
@@ -84,6 +84,37 @@ describe('buildCorpusContext', () => {
     expect(b).toContain('cafe arabica');
     expect(b).toContain('REFERENCIA AGRONÓMICA');
   });
+
+  it('#35: separa el pasaje foráneo en un bloque marcado como complemento', () => {
+    const chunks = [
+      { text: 'En Cundinamarca se renueva con estolones propios.', key: 'diferenciador_colombiano' },
+      { text: 'En otros climas se usa otra densidad.', continente: 'Asia' },
+    ];
+    const b = buildCorpusContext(chunks);
+    expect(b).toContain('REFERENCIA AGRONÓMICA');
+    expect(b).toContain('REFERENCIA FORÁNEA');
+    // El colombiano aparece antes que el foráneo en el prompt.
+    expect(b.indexOf('estolones propios')).toBeLessThan(b.indexOf('otra densidad'));
+    // El foráneo lleva la marca de origen estructurado real.
+    expect(b).toContain('[origen: Asia]');
+    expect(b).toContain('en otros países se reporta');
+  });
+
+  it('#35: solo foráneo → avisa que NO hay validación local', () => {
+    const chunks = [{ text: 'Práctica reportada afuera.', origin: 'foreign' }];
+    const b = buildCorpusContext(chunks);
+    expect(b).toContain('REFERENCIA FORÁNEA');
+    expect(b).not.toContain('REFERENCIA AGRONÓMICA (contexto colombiano');
+    expect(b).toContain('NO hay referencia validada en Colombia');
+    expect(b).toContain('[origen: fuera de Colombia]');
+  });
+
+  it('#35: pasajes sin señal de origen NO se marcan como foráneos (van al bloque principal)', () => {
+    const chunks = [{ text: 'Dato sin origen estructurado conocido.' }];
+    const b = buildCorpusContext(chunks);
+    expect(b).toContain('REFERENCIA AGRONÓMICA');
+    expect(b).not.toContain('REFERENCIA FORÁNEA');
+  });
 });
 
 describe('buildCorpusVariants', () => {

--- a/src/services/__tests__/ragOriginReconciler.test.js
+++ b/src/services/__tests__/ragOriginReconciler.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyPassageOrigin,
+  tagPassagesOrigin,
+  reconcileOrigins,
+  foreignOriginSuffix,
+} from '../ragOriginReconciler.js';
+
+describe('classifyPassageOrigin', () => {
+  it('sin señal estructurada → unknown (NUNCA asume Colombia)', () => {
+    expect(classifyPassageOrigin({ species: 'x', text: 'algo', key: 'valor_pedagogico' }))
+      .toEqual({ tag: 'unknown', label: null });
+  });
+
+  it('input inválido → unknown', () => {
+    expect(classifyPassageOrigin(null)).toEqual({ tag: 'unknown', label: null });
+    expect(classifyPassageOrigin(undefined)).toEqual({ tag: 'unknown', label: null });
+    expect(classifyPassageOrigin('no-object')).toEqual({ tag: 'unknown', label: null });
+  });
+
+  it('campo origin explícito "co" → co', () => {
+    expect(classifyPassageOrigin({ text: 'x', origin: 'co' }).tag).toBe('co');
+    expect(classifyPassageOrigin({ text: 'x', origin: 'Colombia' }).tag).toBe('co');
+    expect(classifyPassageOrigin({ text: 'x', origen: 'NACIONAL' }).tag).toBe('co');
+  });
+
+  it('campo origin explícito foráneo → foreign', () => {
+    expect(classifyPassageOrigin({ text: 'x', origin: 'foreign' }).tag).toBe('foreign');
+    expect(classifyPassageOrigin({ text: 'x', origin: 'foráneo' }).tag).toBe('foreign');
+    expect(classifyPassageOrigin({ text: 'x', origin: 'non-co' }).tag).toBe('foreign');
+  });
+
+  it('país/continente estructurado no colombiano → foreign con label real', () => {
+    expect(classifyPassageOrigin({ text: 'x', continente: 'Asia' }))
+      .toEqual({ tag: 'foreign', label: 'Asia' });
+    expect(classifyPassageOrigin({ text: 'x', pais: 'México' }))
+      .toEqual({ tag: 'foreign', label: 'México' });
+  });
+
+  it('país estructurado = Colombia → co (sin label)', () => {
+    expect(classifyPassageOrigin({ text: 'x', pais: 'Colombia' }))
+      .toEqual({ tag: 'co', label: null });
+  });
+
+  it('campo origin foráneo conserva el país estructurado como label', () => {
+    expect(classifyPassageOrigin({ text: 'x', origin: 'foreign', pais: 'Perú' }))
+      .toEqual({ tag: 'foreign', label: 'Perú' });
+  });
+
+  it('key con marcador colombiano estructurado → co', () => {
+    expect(classifyPassageOrigin({ text: 'x', key: 'diferenciador_colombiano' }).tag).toBe('co');
+    expect(classifyPassageOrigin({ text: 'x', key: 'convergencia_dr_034' }).tag).toBe('co');
+    expect(classifyPassageOrigin({ text: 'x', key: 'leccion_agroecologica' }).tag).toBe('co');
+  });
+
+  it('origin explícito tiene precedencia sobre key', () => {
+    // key dice Co pero origin dice foráneo → gana origin (más autoritativo)
+    expect(classifyPassageOrigin({ text: 'x', key: 'diferenciador_colombiano', origin: 'foreign' }).tag)
+      .toBe('foreign');
+  });
+
+  it('establishment_means NO fuerza clasificación (anti-alucinación)', () => {
+    // nativo no implica "conocimiento colombiano"; introducido no implica foráneo
+    const nat = classifyPassageOrigin({ text: 'x' }, { establishmentMeans: { x: 'nativo' } });
+    expect(nat.tag).toBe('unknown');
+    const intro = classifyPassageOrigin({ text: 'x' }, { establishmentMeans: { x: 'introducido' } });
+    expect(intro.tag).toBe('unknown');
+  });
+});
+
+describe('tagPassagesOrigin', () => {
+  it('etiqueta sin mutar los originales', () => {
+    const passages = [{ text: 'a', key: 'diferenciador_colombiano' }, { text: 'b' }];
+    const tagged = tagPassagesOrigin(passages);
+    expect(tagged[0]._origin).toBe('co');
+    expect(tagged[1]._origin).toBe('unknown');
+    expect(passages[0]).not.toHaveProperty('_origin'); // original intacto
+  });
+
+  it('input no-array → []', () => {
+    expect(tagPassagesOrigin(null)).toEqual([]);
+    expect(tagPassagesOrigin('x')).toEqual([]);
+  });
+});
+
+describe('reconcileOrigins', () => {
+  it('coloca colombiano primero, luego desconocido; foráneo aparte', () => {
+    const tagged = [
+      { text: 'foraneo1', _origin: 'foreign' },
+      { text: 'co1', _origin: 'co' },
+      { text: 'desconocido1', _origin: 'unknown' },
+      { text: 'co2', _origin: 'co' },
+    ];
+    const r = reconcileOrigins(tagged);
+    expect(r.local.map((p) => p.text)).toEqual(['co1', 'co2', 'desconocido1']);
+    expect(r.foreign.map((p) => p.text)).toEqual(['foraneo1']);
+    expect(r.onlyForeign).toBe(false);
+    expect(r.counts).toEqual({ co: 2, unknown: 1, foreign: 1 });
+  });
+
+  it('preserva el orden por score dentro de cada grupo', () => {
+    const tagged = [
+      { text: 'co-alto', _origin: 'co' },
+      { text: 'co-medio', _origin: 'co' },
+      { text: 'co-bajo', _origin: 'co' },
+    ];
+    const r = reconcileOrigins(tagged);
+    expect(r.local.map((p) => p.text)).toEqual(['co-alto', 'co-medio', 'co-bajo']);
+  });
+
+  it('onlyForeign=true cuando SOLO hay pasajes foráneos', () => {
+    const tagged = [
+      { text: 'f1', _origin: 'foreign' },
+      { text: 'f2', _origin: 'foreign' },
+    ];
+    const r = reconcileOrigins(tagged);
+    expect(r.local).toEqual([]);
+    expect(r.foreign.length).toBe(2);
+    expect(r.onlyForeign).toBe(true);
+  });
+
+  it('onlyForeign=false cuando hay solo desconocidos (no foráneos)', () => {
+    const r = reconcileOrigins([{ text: 'u', _origin: 'unknown' }]);
+    expect(r.onlyForeign).toBe(false);
+    expect(r.local.length).toBe(1);
+  });
+
+  it('lista vacía / inválida → grupos vacíos, onlyForeign false', () => {
+    expect(reconcileOrigins([])).toEqual({
+      local: [], foreign: [], onlyForeign: false, counts: { co: 0, unknown: 0, foreign: 0 },
+    });
+    expect(reconcileOrigins(null).onlyForeign).toBe(false);
+  });
+
+  it('pasaje sin _origin se trata como unknown (no como co)', () => {
+    const r = reconcileOrigins([{ text: 'sin-tag' }]);
+    expect(r.counts.unknown).toBe(1);
+    expect(r.counts.co).toBe(0);
+  });
+});
+
+describe('foreignOriginSuffix', () => {
+  it('usa el label estructurado real cuando existe', () => {
+    expect(foreignOriginSuffix({ _originLabel: 'Asia' })).toBe(' [origen: Asia]');
+  });
+
+  it('genérico cuando NO hay label (no inventa geografía)', () => {
+    expect(foreignOriginSuffix({})).toBe(' [origen: fuera de Colombia]');
+    expect(foreignOriginSuffix({ _originLabel: '' })).toBe(' [origen: fuera de Colombia]');
+    expect(foreignOriginSuffix(null)).toBe(' [origen: fuera de Colombia]');
+  });
+});
+
+describe('integración tag → reconcile (flujo real)', () => {
+  it('clasifica y reconcilia un lote mixto del corpus', () => {
+    const passages = [
+      { species: 'fresa', text: 'Cundinamarca produce el 73%...', key: 'diferenciador_colombiano' },
+      { species: 'jamaica', text: 'originaria de África occidental...', continente: 'África' },
+      { species: 'cafe', text: 'crece entre 1200-1800 msnm', key: 'valor_pedagogico' },
+    ];
+    const r = reconcileOrigins(tagPassagesOrigin(passages));
+    expect(r.counts).toEqual({ co: 1, unknown: 1, foreign: 1 });
+    expect(r.local.map((p) => p.species)).toEqual(['fresa', 'cafe']);
+    expect(r.foreign[0].species).toBe('jamaica');
+    expect(r.foreign[0]._originLabel).toBe('África');
+    expect(foreignOriginSuffix(r.foreign[0])).toBe(' [origen: África]');
+  });
+});

--- a/src/services/agentPromptBase.js
+++ b/src/services/agentPromptBase.js
@@ -31,6 +31,11 @@ import {
   generateAgronomicGuidanceRules,
   buildProfileContext,
 } from './agentService.js';
+import {
+  tagPassagesOrigin,
+  reconcileOrigins,
+  foreignOriginSuffix,
+} from './ragOriginReconciler.js';
 
 // Cap defensivo para inyectar evidencia del sidecar como context turn
 // sin reventar la ventana de contexto. ~1500 chars ≈ 500-580 tokens —
@@ -523,16 +528,55 @@ REGLA: este análisis es autoritativo para ESTA query. Si dice "Es enumerativa: 
  * delimitar EXPLÍCITAMENTE + instrucción literal de no citarlo como del
  * usuario.
  *
+ * #35 (reconciliación Co ↔ NON-Co): tras ingerir DRs continentales (#34), el
+ * corpus mezcla conocimiento colombiano con foráneo. Aquí se ETIQUETA cada
+ * pasaje por origen y se RECONCILIA: lo colombiano/general va primero como
+ * referencia principal; lo foráneo se separa en un bloque marcado para que el
+ * agente lo presente como complemento ("en otros países se reporta…") y NUNCA
+ * como práctica local validada en Colombia. El origen sale SOLO de señales
+ * estructuradas (ver ragOriginReconciler): si no hay señal, es desconocido —
+ * jamás se asume Colombia (anti-alucinación).
+ *
  * @param {Array<{text:string}>} contextCorpus — chunks recuperados por el RAG.
  * @returns {string} bloque delimitado, o '' si no hay corpus.
  */
 export function buildCorpusContext(contextCorpus) {
   if (!Array.isArray(contextCorpus) || contextCorpus.length === 0) return '';
-  return `
 
-=== INFORMACIÓN DE REFERENCIA AGRONÓMICA (NO viene del usuario, NO citarla como si el usuario te lo hubiera contado) ===
-${contextCorpus.map((c) => c.text).join('\n\n---\n\n')}
-=== FIN REFERENCIA ===
+  const tagged = tagPassagesOrigin(contextCorpus);
+  const { local, foreign, onlyForeign } = reconcileOrigins(tagged);
+
+  // Bloque principal: contexto colombiano + general (origen desconocido).
+  // Si solo hay foráneo, este bloque queda vacío y el foráneo lleva la marca
+  // de "sin validación local" — el agente debe aclararlo.
+  const localText = local.map((c) => c.text).join('\n\n---\n\n');
+  const principal = localText
+    ? `
+
+=== INFORMACIÓN DE REFERENCIA AGRONÓMICA (contexto colombiano / general — NO viene del usuario, NO citarla como si el usuario te lo hubiera contado) ===
+${localText}
+=== FIN REFERENCIA ===`
+    : '';
+
+  // Bloque foráneo (#35): separado y marcado SIEMPRE como complemento.
+  let foraneo = '';
+  if (foreign.length > 0) {
+    const foraneoText = foreign
+      .map((c) => `${c.text}${foreignOriginSuffix(c)}`)
+      .join('\n\n---\n\n');
+    const aviso = onlyForeign
+      ? 'ATENCIÓN: para esta consulta NO hay referencia validada en Colombia, SOLO la siguiente información de OTROS PAÍSES. Preséntala explícitamente como práctica foránea ("en otros países se reporta…") y aclara que no está validada localmente. NO la presentes como práctica colombiana.'
+      : 'La siguiente información es de OTROS PAÍSES, como complemento. Si la usas, preséntala explícitamente como foránea ("en otros países se reporta…"), NUNCA como práctica local validada en Colombia. El contexto colombiano de arriba tiene prioridad.';
+    foraneo = `
+
+=== INFORMACIÓN DE REFERENCIA FORÁNEA (origen fuera de Colombia — complemento, NO equivalente al contexto colombiano) ===
+${aviso}
+
+${foraneoText}
+=== FIN REFERENCIA FORÁNEA ===`;
+  }
+
+  return `${principal}${foraneo}
 
 Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el usuario preguntó. NO menciones síntomas ni observaciones que no estén en su mensaje.`;
 }

--- a/src/services/ragOriginReconciler.js
+++ b/src/services/ragOriginReconciler.js
@@ -1,0 +1,192 @@
+/**
+ * ragOriginReconciler.js — etiquetado de ORIGEN y reconciliación Co ↔ NON-Co
+ * de los pasajes RAG (#35).
+ *
+ * CONTEXTO (#34 → #35): tras ingerir DRs continentales (Oceanía, Sudamérica,
+ * Asia, Europa, …) al grafo AGE, el sistema tiene conocimiento NO colombiano.
+ * El agente NO debe presentar lo foráneo como práctica local validada en
+ * Colombia. Este módulo:
+ *
+ *   1. ETIQUETA cada pasaje recuperado con su ORIGEN — usando SOLO señales
+ *      estructuradas deterministas presentes en el pasaje/corpus. NUNCA
+ *      infiere origen del texto libre (eso alucinaría país/continente).
+ *   2. RECONCILIA: el contexto colombiano va PRIMERO; lo foráneo se presenta
+ *      como complemento explícito y NUNCA mezclado como equivalente.
+ *
+ * ANTI-ALUCINACIÓN (innegociable):
+ *   - Sin señal estructurada de origen → 'unknown'. JAMÁS se asume 'co'.
+ *   - No se inventa país/continente: el bloque foráneo dice "en otros países
+ *     / fuera de Colombia se reporta…" en términos genéricos salvo que el
+ *     pasaje traiga un país/continente estructurado (campo `pais`/`continente`/
+ *     `origin`). El LLM recibe la etiqueta, no una geografía inventada.
+ *
+ * FORMA del pasaje (lo que produce ragRetriever.retrieve):
+ *   { species, text, key, score, ...extra }
+ *
+ * Este módulo es LÓGICA PURA (sin red, sin IndexedDB) salvo el lookup
+ * opcional de `establishment_means`, que se pasa inyectado (no se importa
+ * grafoRelations aquí para mantener la función testeable sin red).
+ */
+
+/** @typedef {'co'|'foreign'|'unknown'} OriginTag */
+
+/**
+ * Campos estructurados del pasaje que, si están presentes y con valor, marcan
+ * ORIGEN colombiano validado. Derivados del corpus real (cycle-content):
+ * - `diferenciador_colombiano`: contexto agronómico específico de Colombia.
+ * - `convergencia_dr_034`: hecho proveniente del DR-034 (corpus base colombiano).
+ * Si el pasaje proviene de uno de estos `key` paths, es contexto Co.
+ */
+const CO_KEY_MARKERS = ['diferenciador_colombiano', 'convergencia_dr_034', 'leccion_agroecologica'];
+
+/**
+ * Valores del campo estructurado `origin`/`origen` (si el pasaje lo trae,
+ * típicamente desde el grafo AGE vía sidecar #34) que clasifican como foráneo.
+ * Se mantiene como lista para extender sin tocar la lógica.
+ */
+const FOREIGN_ORIGIN_VALUES = new Set([
+  'foreign', 'foraneo', 'foráneo', 'non-co', 'nonco', 'non_co',
+  'internacional', 'extranjero', 'fuera-colombia',
+]);
+
+const CO_ORIGIN_VALUES = new Set([
+  'co', 'colombia', 'colombiano', 'local', 'nacional',
+]);
+
+/**
+ * Normaliza un valor de origen a minúsculas sin acentos para comparar.
+ * @param {unknown} v
+ * @returns {string}
+ */
+function normOrigin(v) {
+  if (typeof v !== 'string') return '';
+  return v.trim().toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '');
+}
+
+/**
+ * Clasifica el ORIGEN de un pasaje RAG usando SOLO señales estructuradas.
+ *
+ * Precedencia (de más a menos autoritativa):
+ *   1. Campo explícito `origin`/`origen`/`pais`/`continente` en el pasaje
+ *      (lo aporta el grafo AGE #34 cuando exista). foreign vs co vs unknown.
+ *   2. `key` del pasaje en un marcador Co estructurado del corpus.
+ *   3. `establishmentMeans` inyectado (mapa species→'nativo'/'introducido'):
+ *      'nativo' es señal DÉBIL de relevancia local → NO clasifica 'co' por sí
+ *      solo (un introducido como el tomate es local en la práctica). Solo se
+ *      usa para desempatar hacia 'unknown' explícito, nunca para inventar.
+ *   4. Sin señal → 'unknown'. NUNCA 'co' por defecto.
+ *
+ * @param {object} passage — { species, text, key, origin?, origen?, pais?, continente? }
+ * @param {object} [opts]
+ * @param {Record<string,string>} [opts.establishmentMeans] — species→means (opcional, no usado para forzar co/foreign).
+ * @returns {{ tag: OriginTag, label: string|null }} etiqueta + label geográfico
+ *   estructurado SI existe (país/continente real del dato), o null.
+ */
+export function classifyPassageOrigin(passage, opts = {}) {
+  if (!passage || typeof passage !== 'object') return { tag: 'unknown', label: null };
+
+  // 1) Campo explícito de origen del dato (grafo AGE #34). Autoritativo.
+  const rawOrigin = passage.origin ?? passage.origen ?? null;
+  const pais = typeof passage.pais === 'string' ? passage.pais.trim() : null;
+  const continente = typeof passage.continente === 'string' ? passage.continente.trim() : null;
+  const label = pais || continente || null;
+
+  const o = normOrigin(rawOrigin);
+  if (o) {
+    if (CO_ORIGIN_VALUES.has(o)) return { tag: 'co', label: null };
+    if (FOREIGN_ORIGIN_VALUES.has(o)) return { tag: 'foreign', label };
+  }
+  // País/continente estructurado presente sin campo origin: clasifica por país.
+  if (label) {
+    const lp = normOrigin(label);
+    if (CO_ORIGIN_VALUES.has(lp)) return { tag: 'co', label: null };
+    // Cualquier otro país/continente estructurado = foráneo, con su label real.
+    return { tag: 'foreign', label };
+  }
+
+  // 2) Marcador Co estructurado en el key del pasaje (corpus colombiano base).
+  const key = typeof passage.key === 'string' ? passage.key : '';
+  if (key && CO_KEY_MARKERS.some((m) => key.includes(m))) {
+    return { tag: 'co', label: null };
+  }
+
+  // 3) establishment_means: señal demasiado débil para forzar clasificación.
+  //    Se ignora a propósito (anti-alucinación: nativo≠"conocimiento Co",
+  //    introducido≠"conocimiento foráneo"). Reservado para futura telemetría.
+  void opts.establishmentMeans;
+
+  // 4) Sin señal estructurada → desconocido. NUNCA se asume Colombia.
+  return { tag: 'unknown', label: null };
+}
+
+/**
+ * Etiqueta una lista de pasajes con su origen (no muta los originales).
+ * @param {Array<object>} passages
+ * @param {object} [opts] — ver classifyPassageOrigin.
+ * @returns {Array<object>} pasajes con `_origin: OriginTag` y `_originLabel`.
+ */
+export function tagPassagesOrigin(passages, opts = {}) {
+  if (!Array.isArray(passages)) return [];
+  return passages.map((p) => {
+    const { tag, label } = classifyPassageOrigin(p, opts);
+    return { ...p, _origin: tag, _originLabel: label };
+  });
+}
+
+/**
+ * RECONCILIA pasajes Co ↔ NON-Co para presentarlos al LLM sin mezclarlos.
+ *
+ * Política (#35):
+ *   - El contexto colombiano (`co`) y el de origen desconocido (`unknown`) van
+ *     PRIMERO, como referencia principal. `unknown` se trata como referencia
+ *     general (no se afirma que sea local NI que sea foránea).
+ *   - Lo foráneo (`foreign`) se separa en un bloque APARTE marcado
+ *     explícitamente, para que la respuesta lo presente como complemento
+ *     ("en otros países se reporta…"), nunca como práctica local validada.
+ *   - Si NO hay ningún pasaje co/unknown y SOLO hay foráneo, el bloque foráneo
+ *     se conserva pero con la marca de que NO hay validación local (el LLM debe
+ *     aclararlo). NO se descarta — sería peor no responder; pero se marca.
+ *
+ * Conserva el orden por score dentro de cada grupo (los pasajes ya vienen
+ * ordenados por el retriever).
+ *
+ * @param {Array<object>} taggedPassages — salida de tagPassagesOrigin (o con `_origin`).
+ * @returns {{
+ *   local: Array<object>,        // co + unknown, en orden
+ *   foreign: Array<object>,      // foreign, en orden
+ *   onlyForeign: boolean,        // true si no hay nada local/unknown
+ *   counts: { co:number, unknown:number, foreign:number }
+ * }}
+ */
+export function reconcileOrigins(taggedPassages) {
+  const list = Array.isArray(taggedPassages) ? taggedPassages : [];
+  const counts = { co: 0, unknown: 0, foreign: 0 };
+  const co = [];
+  const unknown = [];
+  const foreign = [];
+
+  for (const p of list) {
+    const tag = p && p._origin;
+    if (tag === 'co') { co.push(p); counts.co += 1; }
+    else if (tag === 'foreign') { foreign.push(p); counts.foreign += 1; }
+    else { unknown.push(p); counts.unknown += 1; }
+  }
+
+  // Local = colombiano primero, luego desconocido (referencia general).
+  const local = [...co, ...unknown];
+  const onlyForeign = local.length === 0 && foreign.length > 0;
+
+  return { local, foreign, onlyForeign, counts };
+}
+
+/**
+ * Construye el SUFIJO de etiqueta de origen para un pasaje foráneo, usando SOLO
+ * el label estructurado (país/continente) si existe. Sin label → genérico.
+ * NUNCA inventa geografía.
+ * @param {object} passage — con `_originLabel` opcional.
+ * @returns {string} ej. " [origen: Asia]" o " [origen: fuera de Colombia]".
+ */
+export function foreignOriginSuffix(passage) {
+  const label = passage && typeof passage._originLabel === 'string' ? passage._originLabel.trim() : '';
+  return label ? ` [origen: ${label}]` : ' [origen: fuera de Colombia]';
+}


### PR DESCRIPTION
## Feature
El agente no distinguía conocimiento colombiano (local, prioritario) del foráneo ingerido al grafo AGE en #34 (DRs continentales: Oceanía, Sudamérica, Asia, Europa…). Esta PR hace que el agente sepa el ORIGEN de cada pasaje RAG y lo reconcilie: el contexto colombiano va primero; lo foráneo se presenta como complemento explícito, nunca como práctica local validada en Colombia.

## Estado real encontrado (verificado, no asumido)
- El corpus `public/cycle-content/*.json` (493 docs) **NO tiene** campo estructurado de origen/país/continente. Solo menciona origen geográfico en prosa libre, de forma inconsistente (parsearlo alucinaría origen → descartado).
- Señales estructuradas Co existentes en el corpus: `diferenciador_colombiano`, `convergencia_dr_034`, `leccion_agroecologica` (escasas pero deterministas).
- El conocimiento NON-Co de #34 vive en el **grafo AGE detrás del sidecar agro-mcp (chagra-pro)**, no en el JSON estático de este repo público. Para exponer su origen al frontend hace falta el "MCP origin param" → entregado como PLAN (abajo), no editado a ciegas.
- `grafo-relations.json` (offline) trae `establishment_means` (nativo/introducido), pero es señal biogeográfica débil, NO equivale a "origen del conocimiento" (el tomate es `introducido` pero práctica local). Se ignora a propósito para no alucinar.

## Cambios
- `src/services/ragOriginReconciler.js` (nuevo): lógica PURA de etiquetado + reconciliación.
  - `classifyPassageOrigin` — clasifica `co`/`foreign`/`unknown` usando SOLO señales estructuradas (campo `origin`/`origen`/`pais`/`continente`, o `key` con marcador Co). Sin señal → `unknown` (jamás asume Colombia).
  - `tagPassagesOrigin`, `reconcileOrigins` — agrupan: colombiano primero, desconocido como referencia general, foráneo aparte.
  - `foreignOriginSuffix` — etiqueta el pasaje foráneo con su país/continente estructurado real si existe; genérico ("fuera de Colombia") si no. NUNCA inventa geografía.
- `src/services/agentPromptBase.js` — `buildCorpusContext` ahora es origin-aware: bloque "REFERENCIA AGRONÓMICA (contexto colombiano / general)" + bloque separado "REFERENCIA FORÁNEA" con instrucción explícita de presentarlo como complemento ("en otros países se reporta…"). Si SOLO hay foráneo, avisa que NO hay validación local. Se cablea solo vía `buildCorpusVariants` ya consumido por `AgentScreen` (sin tocar el componente).

## Anti-alucinación (innegociable)
- Origen solo de señales estructuradas; sin señal → desconocido, no Colombia.
- No se inventa país/continente: el LLM recibe la etiqueta, no una geografía fabricada.
- Lo foráneo nunca se mezcla como equivalente a lo local; va marcado y subordinado.

## Tests
- 8+ casos en `ragOriginReconciler.test.js` (clasificación, precedencia origin>key, establishment_means no fuerza, reconciliación, onlyForeign, integración) + 3 casos nuevos en `agentPromptBase.test.js` (bloque foráneo marcado, solo-foráneo, unknown no marcado como foráneo).
- 61 tests passing en el scope tocado (reconciler + prompt + budget). ESLint 0 warnings.
- Nota: 2 fallos pre-existentes en `ragRetriever.test.js` (tier-gate SEC-002) son ajenos a esta PR (archivo no tocado; entorno node_modules del worktree).

## PLAN sidecar (chagra-pro, repo privado — NO editado en esta PR)
"MCP origin param" para exponer el origen del grafo AGE al frontend:
- **Tool**: `get_subgrafo_relacional` (y/o `resolve-entities`) en chagra-pro agro-mcp.
- **Param nuevo**: incluir por cada nodo/arista devuelto un campo `origin` (`co`|`foreign`) y, cuando exista en el grafo, `pais`/`continente` reales. Opcionalmente un param de request `prefer_origin=co` para ordenar/filtrar.
- **Query AGE**: las aristas/nodos ingeridos en #34 deben portar una propiedad de procedencia (p. ej. `source_dr` continental → `continente`/`pais`). La query Cypher/AGE proyecta esa propiedad: `MATCH ... RETURN n.*, n.continente, n.pais, n.source_origin`. Si el nodo carece de la propiedad, devolver `origin: unknown` (no inferir).
- **Frontend ya listo**: `classifyPassageOrigin` lee `origin`/`pais`/`continente` del pasaje, así que cuando el sidecar los emita, el bloque foráneo del prompt se llena automáticamente sin más cambios en este repo.

Refs: task #35, #34 (ingesta DRs continentales AGE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)