### PR TITLE
ci(playwright): alinear imagen visual-regression a v1.60.0-jammy + pin @playwright/test exacto

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -22,7 +22,7 @@ jobs:
     name: Playwright visual snapshots
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.59.1-jammy
+      image: mcr.microsoft.com/playwright:v1.60.0-jammy
     timeout-minutes: 60
     continue-on-error: ${{ github.event_name == 'pull_request' }}
     env:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
     "@eslint/js": "^9.39.4",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
La imagen del job de snapshots usaba v1.59.1-jammy pero el lock resuelve
@playwright/test 1.60.0 (caret ^1.59.1) → el navegador no lanza ('Executable
doesn't exist') y 'Playwright visual snapshots' falla en TODOS los PRs. Se
alinea la imagen a v1.60.0-jammy y se fija la dependencia a exacto para que
no vuelvan a desincronizarse.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
