### PR TITLE
feat(app): MF-1 fundación de scope por finca (fincaScope) con feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,16 @@ VITE_TELEMETRY_INGEST_URL=
 # (src/data/extensionista-fincas.json), NO de una autorización verificada. La
 # delegación real (UCAN + farm_did_auth) es follow-up backend (ADR-036).
 VITE_FEATURE_EXTENSIONISTA=false
+
+# Multi-finca storage scope (ADR-036 MF-1, #378). Feature flag de la FUNDACIÓN
+# de almacenamiento multi-finca: scopear los datos por finca_id detrás de
+# `src/services/fincaScope.js`. Con `false` (DEFAULT) la capa es un NO-OP total:
+# el camino single-finca actual queda EXACTAMENTE igual (mismos stores, mismas
+# keys, cero migración, cero riesgo de data-loss). Con `true` se habilita el
+# scoping aditivo por finca activa (estampar/filtrar `_finca_id`); los registros
+# legacy sin `_finca_id` nunca se esconden. MF-1 NO incluye did:key (MF-2),
+# OPFS/Automerge (MF-3), migrator v1→v2 (MF-4) ni backup B2 (MF-5).
+VITE_MULTI_FINCA=false
 # Security Headers (Task 112) — Nginx injects in production
 VITE_CSP_REPORT_URI=
 VITE_HSTS_ENABLED=true

--- a/src/services/__tests__/fincaScope.test.js
+++ b/src/services/__tests__/fincaScope.test.js
@@ -1,0 +1,178 @@
+/**
+ * fincaScope.test.js — TDD de la capa de scope por finca (ADR-036 MF-1, #378).
+ *
+ * Foco: garantizar que con el feature flag VITE_MULTI_FINCA APAGADO (default)
+ * la capa es un NO-OP total —comportamiento single-finca idéntico al de hoy,
+ * sin riesgo de data-loss— y que con la flag ENCENDIDA el scoping es aditivo,
+ * idempotente y conservador (los registros legacy nunca se esconden).
+ *
+ * El resolutor del slug activo se INYECTA en cada call para mantener las
+ * funciones puras (sin depender de zustand/fincaActiveStore en los tests).
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const importFresh = async () => {
+  vi.resetModules();
+  return import('../fincaScope.js');
+};
+
+const resolver = (slug) => () => slug;
+
+describe('fincaScope — flag OFF (default single-finca, NO-OP)', () => {
+  let mod;
+
+  beforeEach(async () => {
+    // Sin stub: el flag queda undefined → OFF (default seguro).
+    mod = await importFresh();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('isMultiFincaEnabled() es false por defecto', () => {
+    expect(mod.isMultiFincaEnabled()).toBe(false);
+  });
+
+  it('getActiveFincaScope() devuelve null (sentinela single-finca)', () => {
+    expect(mod.getActiveFincaScope(resolver('mi-finca'))).toBeNull();
+  });
+
+  it('isFincaScopeActive() es false', () => {
+    expect(mod.isFincaScopeActive(resolver('mi-finca'))).toBe(false);
+  });
+
+  it('stampScope() devuelve el MISMO objeto sin tocarlo (no-op, no muta)', () => {
+    const record = { id: 'p1', attributes: { name: 'Tomate' } };
+    const out = mod.stampScope(record, resolver('mi-finca'));
+    expect(out).toBe(record); // misma referencia
+    expect(out).not.toHaveProperty('_finca_id');
+  });
+
+  it('scopeMatches() siempre true (todo visible)', () => {
+    expect(mod.scopeMatches({ id: 'p1' }, resolver('mi-finca'))).toBe(true);
+    expect(mod.scopeMatches({ id: 'p2', _finca_id: 'otra' }, resolver('mi-finca'))).toBe(true);
+  });
+
+  it('filterByActiveFinca() devuelve la MISMA lista por referencia', () => {
+    const list = [{ id: 'a' }, { id: 'b', _finca_id: 'x' }];
+    const out = mod.filterByActiveFinca(list, resolver('mi-finca'));
+    expect(out).toBe(list);
+  });
+});
+
+describe('fincaScope — flag ON (multi-finca activo)', () => {
+  let mod;
+
+  beforeEach(async () => {
+    vi.stubEnv('VITE_MULTI_FINCA', 'true');
+    mod = await importFresh();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('isMultiFincaEnabled() es true', () => {
+    expect(mod.isMultiFincaEnabled()).toBe(true);
+  });
+
+  it('acepta los strings "true" y "1" (case-insensitive, con espacios)', async () => {
+    for (const v of ['true', 'TRUE', '  True ', '1']) {
+      vi.stubEnv('VITE_MULTI_FINCA', v);
+      const m = await importFresh();
+      expect(m.isMultiFincaEnabled()).toBe(true);
+    }
+    for (const v of ['false', '0', 'sí', 'yes', '']) {
+      vi.stubEnv('VITE_MULTI_FINCA', v);
+      const m = await importFresh();
+      expect(m.isMultiFincaEnabled()).toBe(false);
+    }
+  });
+
+  it('getActiveFincaScope() devuelve el slug activo normalizado (trim)', () => {
+    expect(mod.getActiveFincaScope(resolver('  finca-norte  '))).toBe('finca-norte');
+  });
+
+  it('getActiveFincaScope() devuelve null si el slug es vacío/solo-espacios/no-string', () => {
+    expect(mod.getActiveFincaScope(resolver(''))).toBeNull();
+    expect(mod.getActiveFincaScope(resolver('   '))).toBeNull();
+    expect(mod.getActiveFincaScope(resolver(null))).toBeNull();
+    expect(mod.getActiveFincaScope(resolver(undefined))).toBeNull();
+    expect(mod.getActiveFincaScope(resolver(42))).toBeNull();
+  });
+
+  it('getActiveFincaScope() degrada a null si el resolver lanza (degradación segura)', () => {
+    const throwing = () => { throw new Error('boom'); };
+    expect(mod.getActiveFincaScope(throwing)).toBeNull();
+  });
+
+  it('isFincaScopeActive() es true cuando hay finca resuelta', () => {
+    expect(mod.isFincaScopeActive(resolver('finca-norte'))).toBe(true);
+    expect(mod.isFincaScopeActive(resolver(''))).toBe(false);
+  });
+
+  it('stampScope() estampa _finca_id en una COPIA sin mutar el original', () => {
+    const record = { id: 'p1', attributes: { name: 'Tomate' } };
+    const out = mod.stampScope(record, resolver('finca-norte'));
+    expect(out).not.toBe(record); // copia, no mutación
+    expect(out._finca_id).toBe('finca-norte');
+    expect(record).not.toHaveProperty('_finca_id'); // original intacto
+  });
+
+  it('stampScope() es idempotente: preserva un _finca_id ya presente', () => {
+    const record = { id: 'p2', _finca_id: 'finca-sur' };
+    const out = mod.stampScope(record, resolver('finca-norte'));
+    expect(out._finca_id).toBe('finca-sur'); // no se pisa
+  });
+
+  it('stampScope() no rompe con no-objetos', () => {
+    expect(mod.stampScope(null, resolver('finca-norte'))).toBeNull();
+    expect(mod.stampScope('x', resolver('finca-norte'))).toBe('x');
+  });
+
+  it('scopeMatches() true para registros de la finca activa', () => {
+    expect(mod.scopeMatches({ id: 'p1', _finca_id: 'finca-norte' }, resolver('finca-norte'))).toBe(true);
+  });
+
+  it('scopeMatches() false para registros de OTRA finca', () => {
+    expect(mod.scopeMatches({ id: 'p1', _finca_id: 'finca-sur' }, resolver('finca-norte'))).toBe(false);
+  });
+
+  it('scopeMatches() true para registros LEGACY sin _finca_id (nunca esconde datos)', () => {
+    expect(mod.scopeMatches({ id: 'legacy' }, resolver('finca-norte'))).toBe(true);
+    expect(mod.scopeMatches({ id: 'legacy2', _finca_id: null }, resolver('finca-norte'))).toBe(true);
+  });
+
+  it('filterByActiveFinca() deja pasar finca activa + legacy, oculta otras fincas', () => {
+    const list = [
+      { id: 'own', _finca_id: 'finca-norte' },
+      { id: 'legacy' },
+      { id: 'foreign', _finca_id: 'finca-sur' },
+    ];
+    const out = mod.filterByActiveFinca(list, resolver('finca-norte'));
+    expect(out.map((r) => r.id)).toEqual(['own', 'legacy']);
+  });
+
+  it('NO cross-contamination: cada finca solo ve lo suyo + legacy', () => {
+    const universo = [
+      { id: 'a1', _finca_id: 'finca-a' },
+      { id: 'a2', _finca_id: 'finca-a' },
+      { id: 'b1', _finca_id: 'finca-b' },
+      { id: 'shared-legacy' },
+    ];
+    const vistaA = mod.filterByActiveFinca(universo, resolver('finca-a'));
+    const vistaB = mod.filterByActiveFinca(universo, resolver('finca-b'));
+    expect(vistaA.map((r) => r.id).sort()).toEqual(['a1', 'a2', 'shared-legacy']);
+    expect(vistaB.map((r) => r.id).sort()).toEqual(['b1', 'shared-legacy']);
+  });
+
+  it('si el scope queda en null (finca vacía), todo vuelve a ser visible (degradación segura)', () => {
+    const list = [{ id: 'x', _finca_id: 'finca-a' }, { id: 'y', _finca_id: 'finca-b' }];
+    // resolver vacío con flag ON → getActiveFincaScope null → no filtra.
+    const out = mod.filterByActiveFinca(list, resolver(''));
+    expect(out).toBe(list);
+  });
+});

--- a/src/services/fincaScope.js
+++ b/src/services/fincaScope.js
@@ -1,0 +1,201 @@
+/**
+ * fincaScope — Capa de ABSTRACCIÓN de scope por finca (ADR-036 MF-1, #378).
+ *
+ * ════════════════════════════════════════════════════════════════════════════
+ * QUÉ ES Y POR QUÉ EXISTE
+ * ════════════════════════════════════════════════════════════════════════════
+ * Hoy la PWA modela UNA sola finca: los stores IDB (assetCache, logCache, …) no
+ * separan los datos por finca. ADR-036 (multi-finca / federación de células)
+ * quiere que un mismo usuario —o un extensionista— gestione VARIAS fincas sin
+ * mezclar sus datos. MF-1 es la FUNDACIÓN de almacenamiento de ese camino: una
+ * sola puerta para "scopear" lecturas/escrituras por `finca_id`, DETRÁS DE UN
+ * FEATURE FLAG (`VITE_MULTI_FINCA`).
+ *
+ * REGLA DE ORO — NO ROMPER PERSISTENCIA (riesgo de data-loss):
+ *   - El flag arranca en OFF. Con OFF, esta capa es un NO-OP total: el scope
+ *     resuelto es `null` (sentinela single-finca), `scopeMatches()` deja pasar
+ *     TODO y `stampScope()` devuelve el registro tal cual. El camino de datos
+ *     single-finca actual queda EXACTAMENTE igual: mismos stores, mismas keys,
+ *     CERO migración. Ningún registro existente se toca, se mueve ni se oculta.
+ *   - Con ON, el scoping es ADITIVO: se estampa un campo `_finca_id` en los
+ *     registros NUEVOS. Los registros legacy (sin `_finca_id`) SIEMPRE quedan
+ *     visibles para la finca activa — nunca se esconden ni se borran. Mismo
+ *     criterio conservador que el `_tenant_id` de assetCache/logCache.
+ *
+ * RELACIÓN CON LOS MÓDULOS VECINOS (NO los reemplaza):
+ *   - `fincaActiveStore` (zustand) ya resuelve qué finca slug está "activa" en
+ *     la UI (banner GPS, endpoint farmOS). `fincaScope` lo USA como fuente del
+ *     id de finca activo cuando el flag está ON, pero añade la SEMÁNTICA de
+ *     storage (estampar/filtrar) que el store no tiene.
+ *   - `tenantContext` resuelve "quién soy yo" (username farmOS) y ya scopea los
+ *     stores vía `_tenant_id`. Ese eje (usuario) es ORTOGONAL al eje finca.
+ *     fincaScope añade el segundo eje (finca) sin tocar el primero. Con el flag
+ *     OFF ambos siguen comportándose como hoy.
+ *   - `extensionistaAccess` (ADR-048) decide si un usuario PUEDE ver fincas
+ *     ajenas; fincaScope decide CÓMO se separan los datos de cada finca.
+ *
+ * LO QUE MF-1 NO HACE (follow-ups, ver plan en el PR):
+ *   - NO crea did:key / BIP-39 (MF-2 #379) — el id de finca es el slug actual.
+ *   - NO migra a OPFS + Automerge/SQLite-WASM DB-per-finca (MF-3 #380). Ese es
+ *     el refactor de write-path riesgoso; aquí solo se deja la abstracción.
+ *   - NO toca el schema de `dbCore.js` (sin bump de versión IDB). El campo
+ *     `_finca_id` es un atributo aditivo del documento, no requiere índice para
+ *     funcionar (igual que `_tenant_id`).
+ *   - NO añade migrator v1→v2 (MF-4 #381) ni backup B2 (MF-5 #382).
+ *
+ * El flag se parsea con el MISMO criterio que `isSidecarEnabled()` y
+ * `featureExtensionistaActivo()` para mantener la convención del repo.
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ *
+ * @module fincaScope
+ */
+
+import useFincaActiveStore from './fincaActiveStore.js';
+
+/**
+ * Nombre del campo aditivo que estampa el scope de finca en los documentos.
+ * Prefijo `_` (convención de campos internos de Chagra, como `_tenant_id` y
+ * `_pending`): no choca con atributos JSON:API de farmOS.
+ *
+ * @constant {string}
+ */
+export const FINCA_SCOPE_FIELD = '_finca_id';
+
+const FLAG_KEY = 'VITE_MULTI_FINCA';
+
+/**
+ * Lee el feature flag global de multi-finca. Acepta los strings 'true' / '1'
+ * (case-insensitive, con espacios) como habilitado; cualquier otro valor
+ * —incluido undefined o ''— deja el modo APAGADO (default OFF).
+ *
+ * KILL-SWITCH: con la flag apagada, toda esta capa es un no-op (single-finca).
+ *
+ * @returns {boolean}
+ */
+export function isMultiFincaEnabled() {
+  try {
+    const raw = import.meta.env?.[FLAG_KEY];
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Resuelve el id de la finca activa.
+ *
+ *   - Flag OFF  → `null` (sentinela single-finca: NO hay scope, todo es global).
+ *   - Flag ON   → el slug de la finca activa de `fincaActiveStore`, o `null` si
+ *                 por alguna razón no hay finca resuelta (degradación segura:
+ *                 sin scope ⇒ se ve todo, nunca se esconden datos).
+ *
+ * Acepta un resolver inyectado para tests (función pura sin zustand):
+ *   getActiveFincaScope(() => 'mi-finca')
+ *
+ * @param {() => (string|null|undefined)} [resolveActiveSlug] — override opcional
+ *   del resolutor del slug activo (default: lee de fincaActiveStore).
+ * @returns {string|null} id de finca activo, o `null` si single-finca / sin scope.
+ */
+export function getActiveFincaScope(resolveActiveSlug) {
+  if (!isMultiFincaEnabled()) return null;
+  let slug = null;
+  try {
+    if (typeof resolveActiveSlug === 'function') {
+      slug = resolveActiveSlug();
+    } else {
+      slug = useFincaActiveStore.getState().activeFincaSlug;
+    }
+  } catch (_) {
+    slug = null;
+  }
+  if (typeof slug !== 'string') return null;
+  const normalized = slug.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+/**
+ * ¿El scope de finca está ACTIVO de verdad? (flag ON **y** hay finca resuelta).
+ *
+ * Cuando es false, todas las operaciones de scope se comportan como single-finca
+ * (no filtran, no estampan). Útil para que los callers decidan rápido si vale la
+ * pena pasar por la capa.
+ *
+ * @param {() => (string|null|undefined)} [resolveActiveSlug]
+ * @returns {boolean}
+ */
+export function isFincaScopeActive(resolveActiveSlug) {
+  return getActiveFincaScope(resolveActiveSlug) !== null;
+}
+
+/**
+ * Estampa el scope de finca en un documento de forma ADITIVA e idempotente.
+ *
+ * Contrato (NO data-loss):
+ *   - Si el scope NO está activo (flag OFF o sin finca) → devuelve el MISMO
+ *     objeto sin tocarlo. Cero cambios, cero copia. Comportamiento single-finca.
+ *   - Si el documento YA trae `_finca_id` → se PRESERVA (el caller sabe a qué
+ *     finca pertenece: rehidratación desde server, device compartido, etc.).
+ *   - Si el scope está activo y el documento no trae `_finca_id` → se devuelve
+ *     una COPIA superficial con `_finca_id` = finca activa. Nunca muta el
+ *     original (evita efectos colaterales sobre objetos compartidos).
+ *
+ * @template T
+ * @param {T} record — documento a estampar (asset, log, evento, …).
+ * @param {() => (string|null|undefined)} [resolveActiveSlug]
+ * @returns {T} el mismo objeto (no-op) o una copia con `_finca_id`.
+ */
+export function stampScope(record, resolveActiveSlug) {
+  const fincaId = getActiveFincaScope(resolveActiveSlug);
+  if (fincaId === null) return record; // single-finca: no-op total.
+  if (!record || typeof record !== 'object') return record;
+  // Idempotente: respeta un _finca_id ya presente (no lo pisa).
+  if (record[FINCA_SCOPE_FIELD]) return record;
+  return { ...record, [FINCA_SCOPE_FIELD]: fincaId };
+}
+
+/**
+ * ¿Este documento es VISIBLE para la finca activa?
+ *
+ * Criterio (conservador, NO esconde datos):
+ *   - Scope inactivo (flag OFF / sin finca) → SIEMPRE true (todo visible).
+ *   - Documento legacy sin `_finca_id` → SIEMPRE true. Pre-multifinca: se
+ *     considera heredado y pertenece a la finca que lo hidrate primero. NUNCA
+ *     se esconde un dato del operador single-finca histórico.
+ *   - Documento con `_finca_id` → visible solo si coincide con la finca activa.
+ *
+ * @param {object} record
+ * @param {() => (string|null|undefined)} [resolveActiveSlug]
+ * @returns {boolean}
+ */
+export function scopeMatches(record, resolveActiveSlug) {
+  const fincaId = getActiveFincaScope(resolveActiveSlug);
+  if (fincaId === null) return true; // single-finca: todo visible.
+  if (!record || typeof record !== 'object') return true;
+  const recordFinca = record[FINCA_SCOPE_FIELD];
+  if (!recordFinca) return true; // legacy: visible para la finca activa.
+  return recordFinca === fincaId;
+}
+
+/**
+ * Filtra una lista de documentos dejando solo los visibles para la finca activa.
+ *
+ * Atajo sobre `scopeMatches`. Con el scope inactivo devuelve la MISMA lista de
+ * entrada por referencia (cero copia, cero recorrido) → no-op single-finca.
+ *
+ * @template T
+ * @param {T[]} records
+ * @param {() => (string|null|undefined)} [resolveActiveSlug]
+ * @returns {T[]}
+ */
+export function filterByActiveFinca(records, resolveActiveSlug) {
+  const fincaId = getActiveFincaScope(resolveActiveSlug);
+  if (fincaId === null) return records; // single-finca: lista intacta.
+  if (!Array.isArray(records)) return records;
+  return records.filter((r) => scopeMatches(r, () => fincaId));
+}


### PR DESCRIPTION
## Feature
Fundación de almacenamiento multi-finca (ADR-036 MF-1, #378): una capa de abstracción `fincaScope` para scopear lecturas/escrituras por `finca_id`, **detrás de un feature flag** (`VITE_MULTI_FINCA`, default OFF). Habilita el camino multi-finca/extensionista sin tocar el camino single-finca actual.

## Alcance entregado (rebanada SEGURA) vs dejado como plan
Esta tarea es write-path crítico de datos. Aplicando la cláusula de PRUDENCIA del issue, entrego la **fundación segura + plan**, no el refactor riesgoso completo:

**Entregado en este PR:**
- `src/services/fincaScope.js` — capa de scope con flag `VITE_MULTI_FINCA`:
  - `isMultiFincaEnabled()` — lee el flag (parseo idéntico a `isSidecarEnabled()` / `featureExtensionistaActivo()`).
  - `getActiveFincaScope()` — resuelve la finca activa desde `fincaActiveStore` (o `null` si single-finca). Resolver inyectable para tests puros.
  - `stampScope(record)` — estampa `_finca_id` de forma **aditiva, idempotente, sin mutar** el original.
  - `scopeMatches(record)` / `filterByActiveFinca(list)` — filtran por finca activa, dejando SIEMPRE pasar registros legacy sin `_finca_id`.
- `src/services/__tests__/fincaScope.test.js` — 21 casos vitest.
- `.env.example` — documenta `VITE_MULTI_FINCA=false`.

**NO incluido (follow-ups, plan abajo):** did:key/BIP-39 (MF-2 #379), OPFS+Automerge/SQLite-WASM DB-per-finca (MF-3 #380), migrator schema v1→v2 (MF-4 #381), backup B2 (MF-5 #382). El `dbCore.js` NO se toca (sin bump de versión IDB), el write-path real NO se reescribe.

## Cómo se garantiza que con flag OFF NO se rompe nada (anti data-loss)
Con `VITE_MULTI_FINCA` apagado (default), `getActiveFincaScope()` devuelve `null` y entonces:
- `stampScope(record)` devuelve **el mismo objeto por referencia**, sin agregar `_finca_id` → escrituras idénticas a hoy.
- `scopeMatches()` devuelve **siempre `true`** y `filterByActiveFinca()` devuelve **la misma lista por referencia** → lecturas idénticas a hoy.
- No se toca `dbCore.js` ni el schema IDB (sin migración). Mismos stores, mismas keys, cero recorrido extra.

Con el flag ON, el scoping es **aditivo** (`_finca_id` solo se agrega a registros nuevos) y **conservador**: los registros legacy sin `_finca_id` nunca se esconden (mismo criterio que el `_tenant_id` ya existente en assetCache/logCache). No hay `bulkPut` paginado ni GC nuevo aquí → no se repite el bug histórico de purga paginada.

Los tests existentes de tenant (`assetCache.tenant`, `logCache.tenant`, `useLogStore.tenant`) siguen pasando sin cambios (17/17): este PR no modifica ningún source existente.

## Plan por fases MF-2..MF-5 (follow-up)
1. **MF-2 (#379) did:key Ed25519 + BIP-39**: generar identidad de finca; sustituir el `finca_id = slug` por `finca_id = did:key:z...`. `fincaScope` ya abstrae el id → solo cambia el resolver (no los callers).
2. **MF-3 (#380) OPFS + Automerge-repo 2.x DB-per-finca**: migrar de `_finca_id` (eje lógico en un IDB compartido) a DB físicamente separada por finca en OPFS. Hacerlo **expand-contract**: (a) escribir en ambos lados, (b) backfill leyendo por `_finca_id`, (c) cutover de lectura, (d) contract. `fincaScope` queda como la fachada estable que oculta el backend.
3. **MF-4 (#381) migrator schema log v1→v2**: migrador aditivo idempotente (nunca borra) + tooling de detección de drift. Reusar el patrón `event.oldVersion < N` de `dbCore.js`.
4. **MF-5 (#382) backup cifrado B2**: backup por-finca cliente-side (age + HKDF). El particionado por `finca_id`/DB-per-finca de MF-3 hace que el backup por finca sea natural.

## Tests
- 21 casos vitest passing (`src/services/__tests__/fincaScope.test.js`): flag OFF no-op + referencia preservada; flag ON stamping aditivo/idempotente; legacy siempre visible; no cross-contamination entre fincas; degradación segura.
- ESLint 0 warnings.
- Regresión: 17/17 tests de tenant existentes verdes.

Refs: #378 (MF-1), ADR-036 sub-v