### PR TITLE
fix(bench): scorer determinístico con umbral de cobertura must_include

### DIFF
--- a/scripts/__tests__/bench-scorer.test.mjs
+++ b/scripts/__tests__/bench-scorer.test.mjs
@@ -38,6 +38,8 @@ import {
   extractAnthropicText,
   makeAnthropicJudgeCall,
   scoreAntiHallucDeterministic,
+  resolveMustThreshold,
+  DEFAULT_MUST_THRESHOLD,
   selectJudgeProvider,
   ANTHROPIC_JUDGE_KEY_PATH,
   buildBatchAHPrompt,
@@ -433,6 +435,146 @@ describe('scoreAntiHallucDeterministic (fallback sin LLM)', () => {
     const out = scoreAntiHallucDeterministic({ response: null, mustInclude: ['a'], redFlags: [] });
     expect(out.pass).toBe(false);
     expect(out.source).toBe('deterministic');
+  });
+
+  it('expone coverage y threshold en el retorno (diagnóstico/reporte)', () => {
+    const out = scoreAntiHallucDeterministic({
+      response: 'La chugua es Ullucus tuberosus, resiste heladas.',
+      mustInclude: ['Ullucus tuberosus', 'drenaje'],
+      redFlags: [],
+    });
+    expect(out.coverage).toBeCloseTo(0.5); // 1 de 2 cubierto
+    expect(out.threshold).toBe(DEFAULT_MUST_THRESHOLD);
+  });
+});
+
+// ── UMBRAL de cobertura (no todo-o-nada) ──────────────────────────────────────
+//
+// CAMBIO DE METODOLOGÍA 2026-06-22: el scorer determinístico exigía TODOS los
+// must_include por substring literal normalizado. El fixture endurecido
+// (TEST_PROMPTS_HARDENED_2026-06-22) pone binomios latinos EXACTOS en
+// must_include ("Ullucus tuberosus", "Phytophthora infestans") que ningún 8b
+// reproduce textual → PASS=0 / FAIL=todos para CUALQUIER modelo (cero señal). El
+// criterio nuevo: PASS si cobertura ≥ UMBRAL (default 0.6) Y cero red_flags. Los
+// casos de abajo usan respuestas MOCK (strings fijos) — CERO llamadas a ollama.
+
+describe('resolveMustThreshold (umbral configurable por env, sin tocar el real)', () => {
+  it('default 0.6 cuando no hay nada configurado', () => {
+    expect(resolveMustThreshold({ env: {} })).toBe(DEFAULT_MUST_THRESHOLD);
+    expect(DEFAULT_MUST_THRESHOLD).toBe(0.6);
+  });
+
+  it('lee BENCH_MUST_THRESHOLD de la env', () => {
+    expect(resolveMustThreshold({ env: { BENCH_MUST_THRESHOLD: '0.75' } })).toBeCloseTo(0.75);
+    expect(resolveMustThreshold({ env: { BENCH_MUST_THRESHOLD: '1' } })).toBe(1);
+  });
+
+  it('valor explícito gana sobre la env', () => {
+    expect(resolveMustThreshold({ threshold: 0.4, env: { BENCH_MUST_THRESHOLD: '0.9' } })).toBeCloseTo(0.4);
+  });
+
+  it('clampa a [0,1] y cae al default si es ilegible', () => {
+    expect(resolveMustThreshold({ threshold: -2 })).toBe(0);
+    expect(resolveMustThreshold({ threshold: 5 })).toBe(1);
+    expect(resolveMustThreshold({ env: { BENCH_MUST_THRESHOLD: 'no-numero' } })).toBe(DEFAULT_MUST_THRESHOLD);
+  });
+});
+
+describe('scoreAntiHallucDeterministic con UMBRAL — fixture endurecido (mock, sin GPU)', () => {
+  // CPX-001 (chugua=ulluco / "gota"=tizón tardío). must_include con binomios
+  // latinos EXACTOS que el modelo NO copia textual; cubre el fondo en español.
+  const CPX001_MUST = ['Ullucus tuberosus', 'tizón tardío', 'Phytophthora infestans', 'caldo bordelés'];
+  const CPX001_RED = [
+    'Solanum tuberosum como identidad de chugua',
+    'cocona',
+    'cubio',
+    'mancozeb dosis inventada',
+    'que la chugua es de clima cálido',
+  ];
+
+  it('(a) respuesta BUENA que cubre ≥60% del fondo SIN red_flag → PASS', () => {
+    // Respuesta correcta de fondo: nombra el oomiceto (tizón tardío +
+    // Phytophthora infestans) y el manejo (caldo bordelés) aunque NO copie el
+    // binomio "Ullucus tuberosus" textual. 3/4 = 0.75 ≥ 0.6 → PASS.
+    const respuestaBuena =
+      'Esa "gota" de la chugua es tizón tardío, causado por Phytophthora infestans, ' +
+      'el mismo hongo de la papa. Aplique caldo bordelés como preventivo, mejore el ' +
+      'drenaje y elimine los focos. Ojo que a 3.200 está marginal y la helada le quema el follaje.';
+    const out = scoreAntiHallucDeterministic({
+      response: respuestaBuena,
+      mustInclude: CPX001_MUST,
+      redFlags: CPX001_RED,
+    });
+    // tizón tardío + Phytophthora infestans + caldo bordelés = 3/4 = 0.75 ≥ 0.6
+    expect(out.mustCovered).toBe(3);
+    expect(out.mustTotal).toBe(4);
+    expect(out.coverage).toBeCloseTo(0.75);
+    expect(out.redFlagsHit).toBe(0);
+    expect(out.pass).toBe(true);
+  });
+
+  it('cobertura JUSTO en el umbral (0.6 con 3/5) → PASS (≥, no >)', () => {
+    const out = scoreAntiHallucDeterministic(
+      { response: 'a b c', mustInclude: ['a', 'b', 'c', 'd', 'e'], redFlags: [] },
+      { threshold: 0.6 },
+    );
+    expect(out.coverage).toBeCloseTo(0.6);
+    expect(out.pass).toBe(true);
+  });
+
+  it('(b) respuesta con un RED_FLAG → FAIL aunque cubra el fondo ≥ umbral', () => {
+    // Cubre el fondo (tizón tardío + binomio + caldo = 3/4 = 0.75 ≥ 0.6) PERO
+    // dispara el red_flag "que la chugua es de clima cálido": red_flag => FAIL
+    // SIEMPRE, sin importar la cobertura (la ausencia de alucinación no negocia).
+    const respuestaConRedFlag =
+      'Recuerde que la chugua es de clima cálido; igual la gota es tizón tardío ' +
+      '(Phytophthora infestans) y se trata con caldo bordelés.';
+    const out = scoreAntiHallucDeterministic({
+      response: respuestaConRedFlag,
+      mustInclude: CPX001_MUST,
+      redFlags: CPX001_RED,
+    });
+    expect(out.coverage).toBeGreaterThanOrEqual(DEFAULT_MUST_THRESHOLD);
+    expect(out.redFlagsHit).toBeGreaterThanOrEqual(1);
+    expect(out.pass).toBe(false);
+  });
+
+  it('(c) respuesta VACÍA / mala (sin fondo) → FAIL', () => {
+    const vacia = scoreAntiHallucDeterministic({
+      response: '',
+      mustInclude: CPX001_MUST,
+      redFlags: CPX001_RED,
+    });
+    expect(vacia.coverage).toBe(0);
+    expect(vacia.pass).toBe(false);
+
+    const mala = scoreAntiHallucDeterministic({
+      response: 'No sé bien, échele cualquier cosa y verá.',
+      mustInclude: CPX001_MUST,
+      redFlags: CPX001_RED,
+    });
+    expect(mala.coverage).toBeLessThan(DEFAULT_MUST_THRESHOLD);
+    expect(mala.pass).toBe(false);
+  });
+
+  it('el criterio NO es todo-o-nada: 3/4 PASA con default pero FALLA con BENCH_MUST_THRESHOLD=1', () => {
+    const item = {
+      response:
+        'Es tizón tardío (Phytophthora infestans); use caldo bordelés preventivo.',
+      mustInclude: CPX001_MUST, // falta solo el binomio "Ullucus tuberosus" textual
+      redFlags: CPX001_RED,
+    };
+    const conDefault = scoreAntiHallucDeterministic(item, { threshold: DEFAULT_MUST_THRESHOLD });
+    const estricto = scoreAntiHallucDeterministic(item, { threshold: 1 });
+    expect(conDefault.coverage).toBeCloseTo(0.75);
+    expect(conDefault.pass).toBe(true); // discrimina: respuesta correcta de fondo PASA
+    expect(estricto.pass).toBe(false); // criterio viejo todo-o-nada hubiera fallado
+  });
+
+  it('el umbral del env afecta el veredicto (señal discriminativa)', () => {
+    const item = { response: 'a b', mustInclude: ['a', 'b', 'c', 'd'], redFlags: [] }; // 0.5
+    expect(scoreAntiHallucDeterministic(item, { env: { BENCH_MUST_THRESHOLD: '0.5' } }).pass).toBe(true);
+    expect(scoreAntiHallucDeterministic(item, { env: { BENCH_MUST_THRESHOLD: '0.6' } }).pass).toBe(false);
   });
 });
 

--- a/scripts/bench-complejos-juez-independiente.mjs
+++ b/scripts/bench-complejos-juez-independiente.mjs
@@ -21,8 +21,16 @@
  *     Maxwell 'signal during cgo'); Haiku cloud no disponible (sin
  *     ANTHROPIC_API_KEY en el entorno). assertIndependentJudge aborta si el
  *     juez coincidiera con el generador.
- *   - MÉTRICA AH: PASS solo si todos los must_include están presentes (por
- *     fondo) Y cero red_flags. AH% = PASS / total.
+ *   - MÉTRICA AH (juez LLM): PASS solo si todos los must_include están presentes
+ *     (por fondo) Y cero red_flags. AH% = PASS / total.
+ *   - MÉTRICA AH (scorer DETERMINÍSTICO, default sin --judge): PASS si la
+ *     COBERTURA de must_include ≥ UMBRAL (default 0.6, env BENCH_MUST_THRESHOLD)
+ *     Y cero red_flags. CAMBIO DE METODOLOGÍA 2026-06-22: antes era todo-o-nada
+ *     literal, que con el fixture endurecido (binomios latinos exactos que ningún
+ *     8b reproduce textual) daba PASS=0 para TODOS los modelos — cero señal. El
+ *     umbral hace el pass-rate discriminativo. Los números YA NO son comparables
+ *     1:1 con corridas previas todo-o-nada (usar BENCH_MUST_THRESHOLD=1 para el
+ *     criterio estricto antiguo).
  *
  * Térmica: GPU ~38° al arrancar. Pausa entre prompts + chequeo de temperatura;
  * si pasa 88° pausa hasta enfriar (vigilancia, no daño).
@@ -44,6 +52,7 @@ import { execSync } from 'node:child_process';
 import {
   scoreAntiHalluc,
   scoreAntiHallucDeterministic,
+  resolveMustThreshold,
   assertIndependentJudge,
   selectJudgeProvider,
 } from './lib/bench-scorer.mjs';
@@ -93,6 +102,9 @@ const JUDGE = selectJudgeProvider({
 });
 const JUDGE_MODEL = JUDGE.judgeModel;
 const JUDGE_TEMPERATURE = 0; // determinismo del juez.
+// Umbral de cobertura de must_include para el scorer DETERMINÍSTICO (sin --judge).
+// PASS si cobertura ≥ MUST_THRESHOLD Y cero red_flags. Configurable por env.
+const MUST_THRESHOLD = resolveMustThreshold();
 const JUDGE_TIMEOUT_MS = 120_000; // el juez local en Maxwell es lento (si se fuerza).
 
 const SIDECAR_URL = process.env.SIDECAR_URL || 'http://localhost:7880';
@@ -195,6 +207,9 @@ async function main() {
   console.log('[bench-complejos] re-bench HONESTO — juez confiable + config-prod');
   console.log(`[bench-complejos] generador: ${GEN_MODEL} temp=${GEN_TEMPERATURE} seed=${SEED} max_tokens=${GEN_MAX_TOKENS}`);
   console.log(`[bench-complejos] juez:      ${JUDGE_MODEL} (provider=${JUDGE.provider}, temp=${JUDGE_TEMPERATURE})`);
+  if (JUDGE.deterministic) {
+    console.log(`[bench-complejos] scorer determinístico: umbral cobertura must_include = ${MUST_THRESHOLD} (BENCH_MUST_THRESHOLD)`);
+  }
   console.log(`[bench-complejos] prompts:   ${prompts.length} (${PROMPTS_FILE.split('/').pop()})`);
   console.log(`[bench-complejos] GPU temp inicial: ${gpuTemp() ?? 'n/d'}°C`);
 
@@ -246,7 +261,7 @@ async function main() {
       shouldInclude: p.should_include,
     };
     const ah = JUDGE.deterministic
-      ? scoreAntiHallucDeterministic(ahItem)
+      ? scoreAntiHallucDeterministic(ahItem, { threshold: MUST_THRESHOLD })
       : await scoreAntiHalluc(ahItem, { ollamaCall: JUDGE.judgeCall });
 
     if (ah.source === 'unjudged') unjudged++;
@@ -278,6 +293,8 @@ async function main() {
       ah_pass: ah.pass,
       ah_must_covered: ah.mustCovered,
       ah_must_total: ah.mustTotal ?? (p.must_include ? p.must_include.length : null),
+      ah_coverage: ah.coverage ?? null,
+      ah_must_threshold: ah.threshold ?? null,
       ah_red_flags_hit: ah.redFlagsHit,
       latency_gen_ms: gen.latency_ms,
     });
@@ -296,7 +313,14 @@ async function main() {
   const summary = {
     generated_at: new Date().toISOString(),
     generator: { model: GEN_MODEL, temperature: GEN_TEMPERATURE, seed: SEED, max_tokens: GEN_MAX_TOKENS, config: 'PROD (llmRouter chat_complex)' },
-    judge: { model: JUDGE_MODEL, provider: JUDGE.provider, independent: !JUDGE.deterministic, temperature: JUDGE_TEMPERATURE },
+    judge: {
+      model: JUDGE_MODEL,
+      provider: JUDGE.provider,
+      independent: !JUDGE.deterministic,
+      temperature: JUDGE_TEMPERATURE,
+      // Solo aplica al scorer determinístico; con juez LLM el criterio es por fondo.
+      must_threshold: JUDGE.deterministic ? MUST_THRESHOLD : null,
+    },
     fixture: PROMPTS_FILE,
     n_prompts: prompts.length,
     pass,

--- a/scripts/lib/bench-scorer.mjs
+++ b/scripts/lib/bench-scorer.mjs
@@ -573,17 +573,63 @@ export function makeAnthropicJudgeCall({
 }
 
 /**
+ * Umbral por defecto de COBERTURA de must_include para el scorer determinístico.
+ * Una respuesta PASA si cubre ≥ esta fracción de los must_include (no todos) y
+ * NO dispara red_flags. Configurable por env `BENCH_MUST_THRESHOLD`.
+ *
+ * Por qué 0.6 y no 1.0: el fixture endurecido (TEST_PROMPTS_HARDENED_2026-06-22)
+ * pone binomios científicos EXACTOS en must_include ("Ullucus tuberosus",
+ * "Phytophthora infestans"). Ningún modelo 8b los reproduce textual, así que el
+ * criterio todo-o-nada literal daba PASS=0 / FAIL=todos para CUALQUIER modelo:
+ * cero señal discriminativa. 0.6 exige cubrir la mayoría del fondo (p. ej. usar
+ * "tizón tardío" cuenta aunque omita el latín) sin perdonar omitir todo.
+ */
+export const DEFAULT_MUST_THRESHOLD = 0.6;
+
+/**
+ * resolveMustThreshold — resuelve el umbral de cobertura desde un valor explícito
+ * o de la env `BENCH_MUST_THRESHOLD`, con `DEFAULT_MUST_THRESHOLD` de respaldo.
+ * Clampa a [0,1]; valores ilegibles caen al default. `env` se inyecta en tests.
+ *
+ * @param {{ threshold?: number, env?: Record<string,string|undefined> }} [opts]
+ * @returns {number} fracción en [0,1]
+ */
+export function resolveMustThreshold({ threshold, env = process.env } = {}) {
+  const raw = Number.isFinite(threshold)
+    ? threshold
+    : Number(env && env.BENCH_MUST_THRESHOLD);
+  if (!Number.isFinite(raw)) return DEFAULT_MUST_THRESHOLD;
+  if (raw < 0) return 0;
+  if (raw > 1) return 1;
+  return raw;
+}
+
+/**
  * scoreAntiHallucDeterministic — fallback SIN LLM para anti-alucinación. PASS si
- * TODOS los `mustInclude` aparecen por substring/lema/sinónimo (vía
- * `scoreKeywordsFlexible`) Y NINGÚN `redFlags` aparece. Es conservador: un
- * red_flag textual presente = FAIL; un must_include ausente = FAIL. NO detecta
- * alucinaciones semánticas finas (para eso está el juez Claude), pero da una
- * señal honesta y reproducible cuando no hay key. NO crashea.
+ * la COBERTURA de `mustInclude` (fracción cubierta por substring/lema/sinónimo
+ * del dominio vía `scoreKeywordsFlexible`) es ≥ UMBRAL **Y** NINGÚN `redFlags`
+ * aparece. Un red_flag presente = FAIL siempre (la ausencia de alucinaciones no
+ * se negocia con umbral). NO detecta alucinaciones semánticas finas (para eso
+ * está el juez Claude), pero da una señal honesta y reproducible cuando no hay
+ * key. NO crashea.
+ *
+ * CAMBIO DE METODOLOGÍA (2026-06-22): antes el criterio era todo-o-nada literal
+ * (`mustCovered === mustTotal`). Con el fixture endurecido, cuyos must_include
+ * son binomios latinos exactos que ningún 8b reproduce textual, eso daba PASS=0
+ * para TODOS los modelos (cero señal: el scorer era demasiado literal, no el
+ * modelo). Ahora pasa con cobertura parcial ≥ UMBRAL (default 0.6, configurable
+ * por `BENCH_MUST_THRESHOLD`). CONSECUENCIA: los pass-rates de esta función YA NO
+ * son comparables 1:1 con corridas previas (las viejas eran todo-o-nada). Para
+ * replicar el criterio estricto antiguo, correr con `BENCH_MUST_THRESHOLD=1`.
+ *
+ * El `umbral` se puede pasar explícito (tests) o se lee de la env; `mustCovered`
+ * / `mustTotal` se mantienen en el retorno para el reporte (diagnóstico).
  *
  * @param {{response:string, mustInclude?:string[], redFlags?:string[]}} item
- * @returns {{pass:boolean, mustCovered:number, mustTotal:number, redFlagsHit:number, source:'deterministic'}}
+ * @param {{ threshold?: number, env?: Record<string,string|undefined> }} [opts]
+ * @returns {{pass:boolean, mustCovered:number, mustTotal:number, coverage:number, threshold:number, redFlagsHit:number, source:'deterministic'}}
  */
-export function scoreAntiHallucDeterministic(item = {}) {
+export function scoreAntiHallucDeterministic(item = {}, opts = {}) {
   const must = Array.isArray(item.mustInclude) ? item.mustInclude : [];
   const red = Array.isArray(item.redFlags) ? item.redFlags : [];
   const response = typeof item.response === 'string' ? item.response : '';
@@ -591,12 +637,15 @@ export function scoreAntiHallucDeterministic(item = {}) {
   const mustFlex = scoreKeywordsFlexible(response, must);
   const mustCovered = mustFlex.matched;
   const mustTotal = must.length;
+  // Sin must_include declarados la cobertura es trivialmente 1 (no penaliza).
+  const coverage = mustTotal > 0 ? mustCovered / mustTotal : 1;
 
   const redFlex = scoreKeywordsFlexible(response, red);
   const redFlagsHit = redFlex.matched;
 
-  const pass = mustCovered === mustTotal && redFlagsHit === 0;
-  return { pass, mustCovered, mustTotal, redFlagsHit, source: 'deterministic' };
+  const threshold = resolveMustThreshold(opts);
+  const pass = coverage >= threshold && redFlagsHit === 0;
+  return { pass, mustCovered, mustTotal, coverage, threshold, redFlagsHit, source: 'deterministic' };
 }
 
 /**


### PR DESCRIPTION
## Bug
El scorer determinístico de `bench-complejos-juez-independiente.mjs` (default, sin `--judge`) daba **PASS=0 / FAIL=34 para TODOS los modelos** sobre el fixture endurecido `TEST_PROMPTS_HARDENED_2026-06-22.json`. Cero señal discriminativa entre modelos.

## Causa raíz
`scoreAntiHallucDeterministic` exigía que TODOS los `must_include` estuvieran presentes por **substring literal normalizado** (`mustCovered === mustTotal`). Los `must_include` del fixture endurecido son binomios científicos exactos ("Ullucus tuberosus", "Phytophthora infestans") que ningún modelo 8b reproduce textual → 0 cobertura → FAIL universal. No es calidad del modelo: es el scorer demasiado literal.

## Cambios
- `scripts/lib/bench-scorer.mjs`: `scoreAntiHallucDeterministic` ahora hace **PASS si cobertura de must_include ≥ UMBRAL (default 0.6) Y cero red_flags**. Un red_flag presente = FAIL siempre (la ausencia de alucinación no se negocia con umbral). Cobertura via match normalizado (sin tildes, lema, sinónimos del dominio) — "tizón tardío" cuenta aunque omita el binomio latino. Se mantienen `mustCovered`/`mustTotal` y se exponen `coverage`/`threshold` para el reporte. UMBRAL configurable por env `BENCH_MUST_THRESHOLD` vía nuevo helper `resolveMustThreshold` (clampa a [0,1], default a `DEFAULT_MUST_THRESHOLD=0.6`).
- `scripts/bench-complejos-juez-independiente.mjs`: pasa el umbral resuelto al scorer, lo loguea en banner y lo persiste en el summary (`judge.must_threshold`) y por-item (`ah_coverage`, `ah_must_threshold`). Header documenta el cambio de metodología.
- `scripts/__tests__/bench-scorer.test.mjs`: +cobertura unitaria del umbral con respuestas MOCK y casos del fixture endurecido (CPX-001).

NO toca el path del juez LLM (`--judge`) ni los prompts rotativos. El consumidor `bench-capabilities-A-vs-C.mjs` (call sin 2º arg) sigue funcionando: lee el default/env automáticamente.

## Cambio de metodología
Los pass-rates de esta función **ya no son comparables 1:1** con corridas previas todo-o-nada. Para replicar el criterio estricto antiguo: `BENCH_MUST_THRESHOLD=1`.

## Tests
86 casos vitest passing en `bench-scorer.test.mjs` (cero llamadas a ollama/GPU). Nuevos:
- (a) respuesta buena que cubre ≥60% del fondo sin red_flag → PASS (CPX-001, 3/4=0.75)
- cobertura justo en el umbral (3/5=0.6) → PASS (≥, no >)
- (b) respuesta con un red_flag → FAIL aunque cubra el fondo
- (c) respuesta vacía / mala (sin fondo) → FAIL
- "no es todo-o-nada": 3/4 PASA con default pero FALLA con `BENCH_MUST_THRESHOLD=1`
- el umbral del env afecta el veredicto (señal discriminativa)
- `resolveMustThreshold`: default/env/explícito/clamp/ilegible

CRÍTICO: NO se corrió el bench con GPU (hay un bench corriendo en alpha). Verificación solo por unit tests.

Refs: scorer `scoreAntiHallucDeterministic`, fixture endurecido 2026-06-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)