### PR TITLE
test(app): sanear deuda de tests rotos preexistentes (stale/mecánicos)

### DIFF
--- a/src/components/__tests__/Asociaciones.test.jsx
+++ b/src/components/__tests__/Asociaciones.test.jsx
@@ -60,8 +60,9 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     const milpaCard = screen.getByRole('article', { name: /Milpa de maíz, fríjol y ahuyama/ });
     const withinMilpa = within(milpaCard);
 
-    // Verificar métricas específicas de datos reales
-    expect(withinMilpa.getByText(/LER/)).toBeInTheDocument();
+    // Verificar métricas específicas de datos reales. LER aparece en el badge
+    // y en las métricas comparativas (varios nodos) → getAllByText.
+    expect(withinMilpa.getAllByText(/LER/).length).toBeGreaterThan(0);
     expect(withinMilpa.getByText(/fijación N/)).toBeInTheDocument();
   });
 
@@ -77,10 +78,11 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     const cafeCard = screen.getByRole('article', { name: /Café con guamo y plátano/ });
     expect(cafeCard).toBeInTheDocument();
 
-    // Verificar elementos específicos del café
+    // Verificar elementos específicos del café. "guamo"/"plátano" aparecen en
+    // el título del sistema y en los chips de compañeros → getAllByText.
     const withinCafe = within(cafeCard);
-    expect(withinCafe.getByText(/guamo/)).toBeInTheDocument();
-    expect(withinCafe.getByText(/plátano/)).toBeInTheDocument();
+    expect(withinCafe.getAllByText(/guamo/).length).toBeGreaterThan(0);
+    expect(withinCafe.getAllByText(/plátano/).length).toBeGreaterThan(0);
   });
 
   test('detecta cultivos de la finca y muestra indicador', () => {
@@ -98,10 +100,12 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
 
     render(<Asociaciones profile={{ rol: 'campesino' }} />);
 
-    // Verificar que se detecte el cultivo
+    // Verificar que se detecte el cultivo. "café" aparece también como opción
+    // del selector → acotamos al indicador "Detectado en tu finca".
     expect(screen.getByLabelText(/¿Qué cultivo quieres planear?/)).toHaveValue('cafe');
-    expect(screen.getByText(/Detectado en tu finca/)).toBeInTheDocument();
-    expect(screen.getByText(/café/)).toBeInTheDocument();
+    const indicador = screen.getByText(/Detectado en tu finca/).closest('div').parentElement;
+    expect(indicador).toBeInTheDocument();
+    expect(within(indicador).getByText(/café/)).toBeInTheDocument();
   });
 
   test('muestra múltiples cultivos de la finca cuando existen', () => {
@@ -126,10 +130,11 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
 
     render(<Asociaciones profile={{ rol: 'campesino' }} />);
 
-    // Debería detectar ambos cultivos
-    expect(screen.getByText(/Detectado en tu finca/)).toBeInTheDocument();
-    expect(screen.getByText(/maíz/)).toBeInTheDocument();
-    expect(screen.getByText(/fríjol/)).toBeInTheDocument();
+    // Debería detectar ambos cultivos. Los nombres aparecen también como
+    // opciones del selector → acotamos al indicador "Detectado en tu finca".
+    const indicador = screen.getByText(/Detectado en tu finca/).closest('div').parentElement;
+    expect(within(indicador).getByText(/maíz/)).toBeInTheDocument();
+    expect(within(indicador).getByText(/fríjol/)).toBeInTheDocument();
   });
 
   test('muestra estado vacío cuando no hay asociaciones disponibles', () => {
@@ -174,8 +179,9 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     // Verificar que se muestren antagonistas
     expect(withinMilpa.getByText(/Evitar estas combinaciones/)).toBeInTheDocument();
 
-    // Para maíz, debería evitar hinojo
-    expect(withinMilpa.getByText(/hinojo/)).toBeInTheDocument();
+    // Para maíz, debería evitar hinojo. El nombre aparece en el título del
+    // antagonista y en la razón → getAllByText.
+    expect(withinMilpa.getAllByText(/hinojo/).length).toBeGreaterThan(0);
   });
 
   test('muestra mensaje cuando no hay antagonistas conocidos', () => {

--- a/src/components/__tests__/CicloCultivoScreen.test.jsx
+++ b/src/components/__tests__/CicloCultivoScreen.test.jsx
@@ -104,7 +104,9 @@ describe('CicloCultivoScreen — ciclo del cultivo (fenología wired)', () => {
       expect(screen.getByRole('button', { name: /Café/ })).toBeTruthy();
     });
 
-    expect(hydrateCyclesFromFarmOS).toHaveBeenCalledWith(localCycles);
+    // La firma ganó un 2º arg de opciones { altitudeM } (derivado del perfil:
+    // finca_altitud 2600). El test antiguo solo asertaba el 1er argumento.
+    expect(hydrateCyclesFromFarmOS).toHaveBeenCalledWith(localCycles, { altitudeM: 2600 });
   });
 
   it('backfill: tolera errores de hidratación y muestra solo locales', async () => {

--- a/src/components/__tests__/InputLog.validation.test.jsx
+++ b/src/components/__tests__/InputLog.validation.test.jsx
@@ -33,12 +33,12 @@ describe('InputLog — validacion de cantidad positiva', () => {
     const materialSelect = screen.getByRole('combobox', { name: /tipo de insumo/i });
     fireEvent.change(materialSelect, { target: { value: 'mat-bio' } });
 
-    const saveBtn = screen.getByRole('button', { name: /registrar aplicacion/i });
+    const saveBtn = screen.getByRole('button', { name: /registrar aplicación/i });
     fireEvent.click(saveBtn);
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledWith(
-        'Completa Ubicacion, Tipo de Insumo y Cantidad',
+        'Completa Ubicación, Tipo de Insumo y Cantidad',
         true
       );
     });
@@ -56,7 +56,7 @@ describe('InputLog — validacion de cantidad positiva', () => {
     const qtyInput = screen.getByPlaceholderText('0.00');
     fireEvent.change(qtyInput, { target: { value: '5' } });
 
-    const saveBtn = screen.getByRole('button', { name: /registrar aplicacion/i });
+    const saveBtn = screen.getByRole('button', { name: /registrar aplicación/i });
     fireEvent.click(saveBtn);
 
     await waitFor(() => {
@@ -73,12 +73,12 @@ describe('InputLog — validacion de cantidad positiva', () => {
     const qtyInput = screen.getByPlaceholderText('0.00');
     fireEvent.change(qtyInput, { target: { value: '3' } });
 
-    const saveBtn = screen.getByRole('button', { name: /registrar aplicacion/i });
+    const saveBtn = screen.getByRole('button', { name: /registrar aplicación/i });
     fireEvent.click(saveBtn);
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledWith(
-        'Completa Ubicacion, Tipo de Insumo y Cantidad',
+        'Completa Ubicación, Tipo de Insumo y Cantidad',
         true
       );
     });

--- a/src/components/__tests__/OnboardingHero.validation.test.jsx
+++ b/src/components/__tests__/OnboardingHero.validation.test.jsx
@@ -30,13 +30,17 @@ describe('OnboardingHero — validacion de campos requeridos', () => {
   });
 
   it('con altitud sin confirmar: muestra confirmacion obligatoria antes de registrar', () => {
+    // La clave real del perfil es `chagra:profile:v1` (userProfileService),
+    // no `chagra_profile`. El test antiguo escribía la clave equivocada y el
+    // perfil quedaba vacío → nunca se mostraba la confirmación de piso.
     window.localStorage.setItem(
-      'chagra_profile',
+      'chagra:profile:v1',
       JSON.stringify({ finca_altitud: '1800' })
     );
     render(<OnboardingHero onNavigate={vi.fn()} />);
     expect(screen.getByTestId('onboarding-piso-confirm')).toBeTruthy();
-    expect(screen.getByText(/correcto/i)).toBeTruthy();
+    // "correcto" aparece en "¿Es correcto?" y en el botón "Sí, es correcto".
+    expect(screen.getAllByText(/correcto/i).length).toBeGreaterThan(0);
   });
 
   it('las 3 rutas de registro estan presentes tras los pasos de validacion', () => {
@@ -54,7 +58,7 @@ describe('OnboardingHero — validacion de campos requeridos', () => {
 
   it('compact con piso confirmado: no renderiza nada', () => {
     window.localStorage.setItem(
-      'chagra_profile',
+      'chagra:profile:v1',
       JSON.stringify({ finca_altitud: '2200', piso_confirmado: '1' })
     );
     const { container } = render(<OnboardingHero onNavigate={vi.fn()} compact />);

--- a/src/components/__tests__/PlanEditor.validation.test.jsx
+++ b/src/components/__tests__/PlanEditor.validation.test.jsx
@@ -77,7 +77,10 @@ describe('PlanEditor — validación de dosis positiva', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('50')).toBeTruthy();
+      // Para el asesor (rol por defecto) la dosis se renderiza como <input>
+      // editable (defaultValue), no como texto suelto. Verificamos el valor
+      // del campo en vez de un nodo de texto "50".
+      expect(screen.getByLabelText(/Dosis/i)).toHaveValue(50);
     });
   });
 
@@ -108,10 +111,10 @@ describe('PlanEditor — validación de dosis positiva', () => {
     );
 
     await waitFor(() => {
-      // El componente muestra el valor 0 tal cual; la validación de > 0
-      // debe implementarse en el handler onBlur. Este test verifica que
-      // el valor se renderiza para que el usuario pueda corregirlo.
-      expect(screen.getByText('0')).toBeTruthy();
+      // El componente muestra el valor 0 tal cual en el <input> de dosis; la
+      // validación de > 0 debe implementarse en el handler onBlur. Este test
+      // verifica que el valor se renderiza para que el usuario pueda corregirlo.
+      expect(screen.getByLabelText(/Dosis/i)).toHaveValue(0);
     });
   });
 

--- a/src/components/__tests__/TaskScreen.validation.test.jsx
+++ b/src/components/__tests__/TaskScreen.validation.test.jsx
@@ -70,7 +70,7 @@ describe('TaskScreen — validacion de formulario', () => {
 
     render(<TaskScreen onBack={onBack} onSave={onSave} />);
 
-    const nameInput = screen.getByPlaceholderText(/riego fertiorganico/i);
+    const nameInput = screen.getByPlaceholderText(/riego fertiorgánico/i);
     fireEvent.change(nameInput, { target: { value: 'Riego manana' } });
 
     const saveBtn = screen.getByRole('button', { name: /programar tarea/i });

--- a/src/components/juego/__tests__/MilpaSimulator.test.jsx
+++ b/src/components/juego/__tests__/MilpaSimulator.test.jsx
@@ -21,6 +21,14 @@ describe('MilpaSimulator', () => {
     fireEvent.click(screen.getByRole('button', { name: /Milpa \(Tres Hermanas\)/ }));
   };
 
+  // Tras iniciar la temporada, el flujo pasa por la fase "seleccion-evento"
+  // (el jugador elige 1 de 3 eventos antes de que golpee). Elegimos el primero.
+  const enfrentarPrimerEvento = () => {
+    const panel = screen.getByTestId('milpa-seleccion-evento');
+    const enfrentarBtns = within(panel).getAllByRole('button', { name: /Enfrentar/ });
+    fireEvent.click(enfrentarBtns[0]);
+  };
+
   it('arranca en selección y entra a siembra con seis parcelas vacías', () => {
     render(<MilpaSimulator />);
     expect(screen.getByTestId('milpa-simulator')).toBeInTheDocument();
@@ -68,6 +76,8 @@ describe('MilpaSimulator', () => {
     fireEvent.click(screen.getByTestId('milpa-sembrar-ahuyama'));
 
     fireEvent.click(screen.getByTestId('milpa-iniciar-temporada'));
+    // Nueva fase: elegir el evento antes de que golpee la temporada.
+    enfrentarPrimerEvento();
     expect(screen.getByTestId('milpa-panel-evento')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('milpa-ver-resultado'));
@@ -86,6 +96,7 @@ describe('MilpaSimulator', () => {
     elegirMilpa();
     fireEvent.click(screen.getByTestId('milpa-sembrar-maiz'));
     fireEvent.click(screen.getByTestId('milpa-iniciar-temporada'));
+    enfrentarPrimerEvento();
     fireEvent.click(screen.getByTestId('milpa-ver-resultado'));
 
     fireEvent.click(screen.getByRole('button', { name: /Siguiente temporada/ }));

--- a/src/services/__tests__/conversationMemory.test.js
+++ b/src/services/__tests__/conversationMemory.test.js
@@ -21,122 +21,40 @@
  * Nota: shouldStartNewSession, getLastTurnTimestamp y computeSourceMetadata
  * ya están cubiertos en tests separados (.session.test.js y .sourceMetadata.test.js)
  */
-import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+// `fake-indexeddb/auto` ya está cargado globalmente por tests/unit/setup.js
+// (instala indexedDB, IDBKeyRange, IDBObjectStore, etc. en globalThis). Usamos
+// la implementación real en memoria — fiel a la spec — en vez del fake hecho a
+// mano que rompía en vitest 4.x por timing de oncomplete/onerror. Mismo patrón
+// que el resto del repo (no toca código de prod: solo el openDB mockeado).
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+
+const STORE_NAME = 'conversation_memory';
+let memoryDB = null;
+
+// Crea una DB real de fake-indexeddb con el store `conversation_memory`
+// (keyPath: id) + índice `operator_id`, igual al schema de src/db/dbCore.js.
+function createMemoryDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('ChagraDB-conversationMemory-test', 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      store.createIndex('operator_id', 'operator_id', { unique: false });
+      store.createIndex('timestamp', 'timestamp', { unique: false });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
 
 // ─── Mocks ────────────────────────────────────────────────────────────────
-// Fake IndexedDB compatible con conversationMemory.js
-let fakeStorage = [];
-
-const makeFakeDB = () => ({
-  transaction(_storeName, _mode) {
-    const tx = { oncomplete: null, onerror: null, error: null };
-    let opsScheduled = 0;
-    let opsCompleted = 0;
-    const maybeComplete = () => {
-      if (opsScheduled === opsCompleted) {
-        setTimeout(() => tx.oncomplete?.(), 0);
-      }
-    };
-    const trackOp = (fn) => {
-      opsScheduled += 1;
-      setTimeout(() => {
-        fn();
-        opsCompleted += 1;
-        maybeComplete();
-      }, 0);
-    };
-    setTimeout(() => {
-      if (opsScheduled === 0) tx.oncomplete?.();
-    }, 1);
-
-    return {
-      get oncomplete() { return tx.oncomplete; },
-      set oncomplete(fn) { tx.oncomplete = fn; },
-      get onerror() { return tx.onerror; },
-      set onerror(fn) { tx.onerror = fn; },
-      get error() { return tx.error; },
-      objectStore(_name) {
-        return {
-          add(turn) {
-            const req = { onsuccess: null, onerror: null };
-            trackOp(() => {
-              fakeStorage.push(turn);
-              req.result = turn;
-              req.onsuccess?.({ target: req });
-            });
-            return req;
-          },
-          delete(id) {
-            const req = { onsuccess: null, onerror: null };
-            trackOp(() => {
-              fakeStorage = fakeStorage.filter((t) => t.id !== id);
-              req.onsuccess?.({ target: req });
-            });
-            return req;
-          },
-          index(_indexName) {
-            return {
-              getAll(range) {
-                const req = { onsuccess: null, onerror: null };
-                trackOp(() => {
-                  const target = range?._only;
-                  req.result = fakeStorage.filter((t) => t.operator_id === target);
-                  req.onsuccess?.({ target: req });
-                });
-                return req;
-              },
-              openCursor(range) {
-                const req = { onsuccess: null, onerror: null };
-                opsScheduled += 1;
-                const target = range?._only;
-                let entries;
-                let idx = 0;
-                const step = () => {
-                  if (entries === undefined) {
-                    entries = fakeStorage.filter((t) => t.operator_id === target);
-                  }
-                  if (idx >= entries.length) {
-                    setTimeout(() => {
-                      req.onsuccess?.({ target: { result: null } });
-                      opsCompleted += 1;
-                      maybeComplete();
-                    }, 0);
-                    return;
-                  }
-                  const entry = entries[idx];
-                  idx += 1;
-                  const cursor = {
-                    value: entry,
-                    delete() {
-                      fakeStorage = fakeStorage.filter((t) => t.id !== entry.id);
-                    },
-                    continue() {
-                      step();
-                    },
-                  };
-                  setTimeout(() => req.onsuccess?.({ target: { result: cursor } }), 0);
-                };
-                setTimeout(step, 0);
-                return req;
-              },
-            };
-          },
-        };
-      },
-    };
-  },
-});
-
+// openDB devuelve la DB real de fake-indexeddb sembrada por test.
 vi.mock('../../db/dbCore', () => ({
-  openDB: vi.fn(() => Promise.resolve(makeFakeDB())),
+  openDB: vi.fn(() => Promise.resolve(memoryDB)),
   STORES: { CONVERSATION_MEMORY: 'conversation_memory' },
 }));
-
-if (typeof globalThis.IDBKeyRange === 'undefined') {
-  globalThis.IDBKeyRange = {
-    only: (value) => ({ _only: value }),
-  };
-}
 
 import {
   addTurn,
@@ -146,8 +64,36 @@ import {
   clearMemory,
 } from '../conversationMemory';
 
-beforeEach(() => {
-  fakeStorage = [];
+// Reloj monótono: addTurn usa Date.now() como timestamp y getRecentContext
+// ordena por él. En un loop tight, varios addTurn comparten el mismo
+// milisegundo y, con fake-indexeddb real, getAll del índice los devuelve por
+// clave primaria (id aleatorio), no por inserción → orden no determinista.
+// En producción los turnos están separados por segundos, así que avanzar el
+// reloj 1ms por llamada reproduce el orden real sin tocar código de prod.
+let clockTick = 0;
+let dateNowSpy = null;
+
+beforeEach(async () => {
+  // DB en memoria fresca por test → aislamiento total. Reseteamos el factory
+  // global para que la base anterior no persista entre tests.
+  globalThis.indexedDB = new IDBFactory();
+  memoryDB = await createMemoryDB();
+
+  clockTick = 0;
+  const realNow = Date.now();
+  dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realNow + clockTick++);
+});
+
+afterEach(() => {
+  if (dateNowSpy) {
+    dateNowSpy.mockRestore();
+    dateNowSpy = null;
+  }
+  if (memoryDB) {
+    memoryDB.close();
+    memoryDB = null;
+  }
+  vi.clearAllMocks();
 });
 
 describe('addTurn', () => {

--- a/src/services/__tests__/hoyEnFincaService.test.js
+++ b/src/services/__tests__/hoyEnFincaService.test.js
@@ -6,7 +6,6 @@ import {
   agendaPorDia,
   agendaPorSemana,
   ensoTaskPhase,
-  STAGE_LABELS,
 } from '../hoyEnFincaService';
 
 const DAY_MS = 86400000;
@@ -116,7 +115,12 @@ describe('buildTareasSemana', () => {
     expect(grupos).toHaveLength(1);
     const g = grupos[0];
     expect(g.etiqueta).toBe('Papa pastusa');
-    expect(g.stageLabel).toBe(STAGE_LABELS[g.stageCode]);
+    // El template de la especie puede aportar una etiqueta más específica
+    // (p. ej. "Emergencia" para papa) que prevalece sobre el map genérico
+    // STAGE_LABELS ("Brote"). Solo exigimos un stageCode + label no vacíos.
+    expect(g.stageCode).toBeTruthy();
+    expect(typeof g.stageLabel).toBe('string');
+    expect(g.stageLabel.length).toBeGreaterThan(0);
     expect(g.tareas.length).toBeGreaterThan(0);
     // Cada tarea trae nombre + prioridad (sin fabricar campos vacíos).
     for (const t of g.tareas) {

--- a/src/services/__tests__/profilePresets.test.js
+++ b/src/services/__tests__/profilePresets.test.js
@@ -79,12 +79,13 @@ describe('profilePresets — getActivePresetId / applyProfilePreset (con localSt
     expect(mod.getActivePresetId({ rol: 'tecnico' })).toBe('corporativo');
   });
 
-  it('applyProfilePreset: persiste rol + perfil_demo y emite el evento', () => {
+  it('applyProfilePreset: persiste rol + perfil_demo y emite el evento', async () => {
     const events = [];
     const handler = (e) => events.push(e.detail);
     window.addEventListener(mod.PROFILE_CHANGED_EVENT, handler);
 
-    const result = mod.applyProfilePreset('corporativo');
+    // applyProfilePreset es async (espera seedProfileData) → await.
+    const result = await mod.applyProfilePreset('corporativo');
     expect(result.rol).toBe('tecnico');
     expect(result.perfil_demo).toBe('corporativo');
 
@@ -98,10 +99,11 @@ describe('profilePresets — getActivePresetId / applyProfilePreset (con localSt
     window.removeEventListener(mod.PROFILE_CHANGED_EVENT, handler);
   });
 
-  it('applyProfilePreset: id inválido → null y NO toca el perfil', () => {
-    mod.applyProfilePreset('cafetero');
+  it('applyProfilePreset: id inválido → null y NO toca el perfil', async () => {
+    await mod.applyProfilePreset('cafetero');
     const before = mod.getActivePresetId();
-    expect(mod.applyProfilePreset('no-existe')).toBeNull();
+    // id inválido se rechaza antes del await → la promesa resuelve a null.
+    await expect(mod.applyProfilePreset('no-existe')).resolves.toBeNull();
     expect(mod.getActivePresetId()).toBe(before); // sin cambios
   });
 });

--- a/src/services/__tests__/ragRetriever.test.js
+++ b/src/services/__tests__/ragRetriever.test.js
@@ -14,6 +14,11 @@
  *     como passages indexables por BM25.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+// IDBFactory para resetear el IndexedDB entre tests (fake-indexeddb/auto ya
+// está cargado por tests/unit/setup.js). El índice del corpus se persiste en
+// el store rag_corpus_cache y sobrevive a vi.resetModules() → hay que limpiar
+// la base para que no se filtre entre tests con el MISMO manifestStamp.
+import { IDBFactory } from 'fake-indexeddb';
 
 const MANIFEST = {
   generated_at: '2026-05-18T00:00:00Z',
@@ -408,6 +413,11 @@ describe('ragRetriever — tier-gate del catalogo (SEC-002 / UXC-004)', () => {
 
   beforeEach(() => {
     vi.resetModules();
+    // El índice del corpus persistido (store rag_corpus_cache, key 'corpus')
+    // sobrevive a resetModules. Todos los casos SEC-002 usan el MISMO
+    // manifestStamp, así que un índice de un test anterior (con otro tier de
+    // catálogo) se hidrataba en el siguiente → conteos cruzados. Base fresca.
+    globalThis.indexedDB = new IDBFactory();
   });
 
   afterEach(() => {

--- a/tests/unit/sw-offline-precache-extended.test.js
+++ b/tests/unit/sw-offline-precache-extended.test.js
@@ -20,11 +20,14 @@ const SW_PATH = path.resolve(__dirnameLocal, '../../public/sw.js');
 // Mock de Cache Storage para tests unitarios sin cargar el SW completo.
 // Verifica que los nombres de cache y su estructura son correctos.
 describe('SW cache bucket names', () => {
-  it('define CACHE_NAME para el shell', async () => {
+  it('define CACHE_NAME para el shell (derivado del SHA de build)', async () => {
     const code = await import('node:fs').then((fs) =>
       fs.readFileSync(SW_PATH, 'utf8'),
     );
-    expect(code).toMatch(/const CACHE_NAME\s*=\s*'chagra-v\d+'/);
+    // Desde #1716 el shell se versiona por SHA del bundle (chagra-<sha>),
+    // no por chagra-v<N>. CACHE_NAME es un ternario sobre SW_BUILD_SHA.
+    expect(code).toMatch(/const CACHE_NAME\s*=[\s\S]*?`chagra-\$\{SW_BUILD_SHA\}`/);
+    expect(code).toContain("'chagra-dev'");
   });
 
   it('define RAG_GROUNDING_CACHE como bucket separado', async () => {

--- a/tests/unit/sw-precache-audit.test.js
+++ b/tests/unit/sw-precache-audit.test.js
@@ -2,7 +2,7 @@
  * sw-precache-audit.test.js — verifica el contrato de precache del SW.
  *
  * Lee public/sw.js y audita:
- *   1. CACHE_NAME sigue el patron `chagra-v<N>`.
+ *   1. CACHE_NAME se deriva del SHA de build (`chagra-${SW_BUILD_SHA}`).
  *   2. RAG_GROUNDING_CACHE existe con prefijo y version correctos.
  *   3. MAP_TILES_CACHE existe con prefijo y version.
  *   4. ASSETS_TO_CACHE contiene app shell esencial.
@@ -55,10 +55,14 @@ function extractArray(name) {
 }
 
 describe('SW precache contract', () => {
-  it('CACHE_NAME sigue el patron chagra-v<N>', () => {
-    const name = extractConst('CACHE_NAME');
-    expect(name).toBeTruthy();
-    expect(name).toMatch(/^chagra-v\d+$/);
+  it('CACHE_NAME se deriva del SHA de build (chagra-${SW_BUILD_SHA})', () => {
+    // Desde #1716 el shell se versiona por SHA del bundle, no por chagra-v<N>.
+    // CACHE_NAME es un ternario: chagra-<sha> en prod, chagra-dev cuando el
+    // placeholder no fue sustituido. Verificamos el contrato de derivacion.
+    const placeholder = extractConst('SW_BUILD_SHA');
+    expect(placeholder).toBe('__CHAGRA_SW_BUILD_SHA__');
+    expect(swSource).toMatch(/const CACHE_NAME\s*=[\s\S]*?`chagra-\$\{SW_BUILD_SHA\}`/);
+    expect(swSource).toMatch(/'chagra-dev'/);
   });
 
   it('RAG_GROUNDING_PREFIX y RAG_GROUNDING_CACHE tienen formato correcto', () => {

--- a/tests/visual/visualTestUtils.js
+++ b/tests/visual/visualTestUtils.js
@@ -342,7 +342,10 @@ function fixtureResponse(pathname) {
 async function seedIndexedDb(page, state) {
   await page.evaluate(async ({ state, fixedMs }) => {
     const DB_NAME = 'ChagraDB';
-    const DB_VERSION = 24;
+    // Debe coincidir con DB_VERSION exportado en src/db/dbCore.js. Corre en
+    // contexto de browser (page.evaluate) → no se puede importar; mantener
+    // sincronizado a mano. Abrir con version < existente lanza VersionError.
+    const DB_VERSION = 25;
     const db = await new Promise((resolve, reject) => {
       const req = indexedDB.open(DB_NAME, DB_VERSION);
       req.onsuccess = () => resolve(req.result);


### PR DESCRIPTION
## Feature
Reducir la deuda de tests rotos preexistentes que CI esconde: `unit-tests.yml` solo corre 5 archivos curados, mientras `npx vitest run` completo tenía ~49 fallos. Este PR arregla SOLO los claramente stale/mecánicos.

## Causa raíz (resumen)
La mayoría son asserts que quedaron atrás de cambios de producción legítimos: nombres de schema/cache, acentos, firmas que se volvieron async o ganaron args, fakes de IndexedDB hechos a mano que rompen en vitest 4.x, y fuga de estado IndexedDB entre tests. **Cero cambios de producción** (REGLA DE ORO: si el test está mal, se arregla el test).

## Cambios (todos en tests/harness)
- `tests/visual/visualTestUtils.js`: `DB_VERSION` 24→25 (fuente real: `src/db/dbCore.js`) → fin del `VersionError` en snapshots Playwright.
- `tests/unit/sw-precache-audit.test.js` + `sw-offline-precache-extended.test.js`: asserts actualizados al esquema `chagra-${SW_BUILD_SHA}` (desde #1716; ya no `chagra-v<N>`).
- `InputLog.validation` + `TaskScreen.validation`: queries con acento (`Aplicación`, `fertiorgánico`) para coincidir con el componente.
- `conversationMemory.test.js`: migrado a `fake-indexeddb` (`IDBFactory`) en vez del fake manual que rompía en vitest 4.x; reloj monótono (`Date.now`) para orden determinista de turnos.
- `CicloCultivoScreen.test.jsx`: `hydrateCyclesFromFarmOS(cycles, { altitudeM })` (la firma ganó opciones).
- `OnboardingHero.validation`: clave de perfil real `chagra:profile:v1`; `getAllByText` donde "correcto" aparece en 2 nodos.
- `PlanEditor.validation`: la dosis del asesor es `<input>` editable, no texto suelto.
- `Asociaciones.test.jsx`: `getAllByText`/`within()` donde el texto es legítimo en varios nodos (opción + chip + título).
- `MilpaSimulator.test.jsx`: el flujo reconecta la nueva fase de selección de evento.
- `hoyEnFincaService.test.js`: la etiqueta de etapa puede venir del template de la especie (prevalece sobre el map genérico).
- `profilePresets.test.js`: `applyProfilePreset` es async → `await`.
- `ragRetriever.test.js` (SEC-002): reset de IndexedDB entre casos para evitar fuga del índice del corpus persistido con el mismo `manifestStamp` (pasaban en aislamiento, fallaban en conjunto).

## Tests
Rojos de `npx vitest run`: **49 → 9**. 7456 passing.

Los **9 restantes NO se tocan**:

**Posibles bugs REALES de producción (reportados, no parchados):**
- `fincaEvolutionService` (5 fallos): `calcularEstabilidadResilienciaMESMIS`, `calcularResilienciaTAPE` y `metadata.active_processes_count` filtran por `p.attributes?.status`, pero el motor recibe procesos YA APLANADOS (`flattenProcess` en `fincaGameService`, y el resto del módulo lee shape plano: `process.current_stage`, `process.process_type`). Resultado: en producción esos indicadores son siempre `null`/0. Los tests (shape plano = contrato documentado) están correctos.
- `Asociaciones` (1 fallo, `¡Ya tienes este cultivo!`): el indicador compara `cultivosFinca.includes(selected)`, pero `cultivosFinca` guarda slugs crudos (`zea_mays`) y `selected` es el id del cultivo (`maiz`) → el mensaje nunca aparece cuando el slug de la planta difiere del id del cultivo.

**Guards de seguridad (requieren visto bueno del operador):**
- BORDE-017 / BORDE-020 / BORDE-027: el comportamiento de seguridad sigue intacto (se suprime/reemplaza el contenido peligroso) pero asertan reason-code/wording viejos. No reescritos sin OK.

Refs: PR #1806 (auditoría de suite huérfana)