### PR TITLE
fix(copy): voseo en placeholder-species.svg (Agregá→Agrega)

### DIFF
--- a/public/placeholder-species.svg
+++ b/public/placeholder-species.svg
@@ -25,6 +25,6 @@
     <circle r="14" fill="none" stroke="#0f1f1a" stroke-width="2"/>
     <path d="M-6,0 L6,0 M0,-6 L0,6" stroke="#fff" stroke-width="2.5" stroke-linecap="round"/>
   </g>
-  <text x="100" y="170" text-anchor="middle" font-family="-apple-system,system-ui,sans-serif" font-size="11" font-weight="600" fill="#a7f3d0" letter-spacing="1">Agregá una foto</text>
+  <text x="100" y="170" text-anchor="middle" font-family="-apple-system,system-ui,sans-serif" font-size="11" font-weight="600" fill="#a7f3d0" letter-spacing="1">Agrega una foto</text>
   <text x="100" y="184" text-anchor="middle" font-family="-apple-system,system-ui,sans-serif" font-size="9" fill="#34d399" opacity="0.7" letter-spacing="0.5">verás cómo crece tu planta</text>
 </svg>


### PR DESCRIPTION
El asset estático tenía voseo argentino 'Agregá una foto' que escapó al filtro de
copy (toda la copy JSX usa 'Agrega'). Detectado por el test visual por-perfil en stg.
Español de Colombia (tú/usted).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
