### PR TITLE
fix(finca-evolution): leer status plano (p.status) en procesos ya aplanados

### DIFF
--- a/src/services/fincaEvolutionService.js
+++ b/src/services/fincaEvolutionService.js
@@ -179,7 +179,7 @@ function calcularProductividadMESMIS(processes) {
  * @returns {number|null} 0-4 o null si no hay datos
  */
 function calcularEstabilidadResilienciaMESMIS(processes) {
-  const activeProcesses = processes.filter(p => p.attributes?.status === 'active');
+  const activeProcesses = processes.filter(p => (p.status ?? p.attributes?.status) === 'active');
   if (activeProcesses.length === 0) return null;
   
   // Contar etapas distintas
@@ -329,7 +329,7 @@ function calcularEficienciaTAPE() {
  * @returns {number|null} 0-4 o null si no hay datos
  */
 function calcularResilienciaTAPE(processes) {
-  const activeProcesses = processes.filter(p => p.attributes?.status === 'active');
+  const activeProcesses = processes.filter(p => (p.status ?? p.attributes?.status) === 'active');
   if (activeProcesses.length === 0) return null;
   
   // Contar tipos de proceso distintos
@@ -516,7 +516,7 @@ export function evaluarEvolucionFinca({ processes = [], observations = [] } = {}
   // Metadata para debug/validación
   const metadata = {
     processes_count: processes.length,
-    active_processes_count: processes.filter(p => p.attributes?.status === 'active').length,
+    active_processes_count: processes.filter(p => (p.status ?? p.attributes?.status) === 'active').length,
     observations_count: observations.length,
     mesmis_non_null_count: Object.values(mesmis).filter(v => v !== null).length,
     tape_non_null_count: Object.values(tape).filter(v => v !== null).length,


### PR DESCRIPTION
calcularEstabilidadResilienciaMESMIS/calcularResilienciaTAPE/metadata filtraban
p.attributes?.status pero el motor las llama con procesos ya aplanados por
flattenProcess (p.status). Resultado: estabilidad_resiliencia (MESMIS), resiliencia
(TAPE) y active_processes_count quedaban siempre null/0 en producción. Fix robusto:
(p.status ?? p.attributes?.status) — sirve plano y anidado. 58/58 tests verde.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
