### PR TITLE
fix(asociaciones): resolver slug→id en '¡Ya tienes este cultivo!'

### DIFF
--- a/src/components/Asociaciones.jsx
+++ b/src/components/Asociaciones.jsx
@@ -517,7 +517,12 @@ export default function Asociaciones({ profile = {}, esOperador = false }) {
                 ))}
               </div>
               <p className="mt-1 text-xs font-semibold text-emerald-700">
-                {selected && cultivosFinca.includes(selected) ? '¡Ya tienes este cultivo!' : 'Selecciona uno para ver recomendaciones'}
+                {selected && cultivosFinca.some((slug) => {
+                  // cultivosFinca son slugs crudos (zea_mays); `selected` es id/nombre (maiz).
+                  // Resolver slug→cultivo igual que el resto del componente para que el match funcione.
+                  const c = findCultivoInItems(arquetipos, slug);
+                  return slug === selected || c?.id === selected || c?.nombre === selected;
+                }) ? '¡Ya tienes este cultivo!' : 'Selecciona uno para ver recomendaciones'}
               </p>
             </div>
           )}


### PR DESCRIPTION
cultivosFinca guarda slugs crudos (zea_mays) pero selected es id/nombre (maiz);
cultivosFinca.includes(selected) nunca matcheaba → el indicador no aparecía. Ahora
resuelve slug→cultivo con findCultivoInItems (igual que el resto del componente).
15/15 tests verde.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
