### PR TITLE
fix(hyta): panel GPU — legibilidad + datos reales + smoke tests

### DIFF
--- a/src/components/HytaPanel.jsx
+++ b/src/components/HytaPanel.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Cpu, Zap, RefreshCw, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { Cpu, Zap, RefreshCw, AlertTriangle } from 'lucide-react';
 import { getGpuSnapshot } from '../services/gpuTelemetryService';
 
 /**
@@ -22,10 +22,10 @@ import { getGpuSnapshot } from '../services/gpuTelemetryService';
  */
 
 const PROCESSOR_STYLES = {
-  gpu: { label: 'GPU', color: 'bg-emerald-900/40 text-emerald-300 border-emerald-700/50' },
-  partial: { label: 'Parcial', color: 'bg-amber-900/40 text-amber-300 border-amber-700/50' },
-  cpu: { label: 'CPU', color: 'bg-slate-700/40 text-slate-300 border-slate-600/50' },
-  unknown: { label: '?', color: 'bg-slate-800/40 text-slate-500 border-slate-700/50' },
+  gpu: { label: 'GPU', color: 'bg-emerald-900/40 text-emerald-400 border-emerald-700/50 font-bold' },
+  partial: { label: 'Parcial', color: 'bg-amber-900/40 text-amber-400 border-amber-700/50 font-bold' },
+  cpu: { label: 'CPU', color: 'bg-slate-700/40 text-slate-300 border-slate-600/50 font-bold' },
+  unknown: { label: '?', color: 'bg-slate-800/40 text-slate-400 border-slate-700/50 font-bold' },
 };
 
 const formatVram = (mb) => {
@@ -50,23 +50,37 @@ export default function HytaPanel() {
   const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
-    try {
-      const snap = await getGpuSnapshot({ force: true });
-      setGpuSnapshot(snap);
-      if (!snap.available) {
-        setError(snap.error || 'GPU info no disponible');
-      }
-    } catch (err) {
-      console.error('[HytaPanel] Error al obtener snapshot GPU:', err);
-      setError('GPU info no disponible');
-    } finally {
-      setLoading(false);
-    }
+    getGpuSnapshot({ force: true })
+      .then((snap) => {
+        setGpuSnapshot(snap);
+        if (!snap.available) {
+          setError(snap.error || 'GPU info no disponible');
+        }
+      })
+      .catch(() => {
+        setError('GPU info no disponible');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, []);
 
   useEffect(() => {
-    refresh();
-  }, [refresh]);
+    let cancelled = false;
+    getGpuSnapshot({ force: true })
+      .then((snap) => {
+        if (cancelled) return;
+        setGpuSnapshot(snap);
+        if (!snap.available) setError(snap.error || 'GPU info no disponible');
+      })
+      .catch(() => {
+        if (!cancelled) setError('GPU info no disponible');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
 
   return (
     <div className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
@@ -77,7 +91,7 @@ export default function HytaPanel() {
         </h3>
       </div>
 
-      <p className="text-[11px] text-slate-500 px-1 leading-relaxed">
+      <p className="text-xs text-slate-400 px-1 leading-relaxed">
         Estado del acelerador GPU y modelos cargados en VRAM. Privacy-safe:
         solo muestra modelo y uso de memoria, nunca prompts ni respuestas.
       </p>
@@ -118,7 +132,7 @@ export default function HytaPanel() {
               </p>
             ) : (
               <div className="space-y-2 mt-3">
-                <p className="text-[10px] text-slate-600 uppercase tracking-wide font-bold">
+                <p className="text-xs text-slate-400 uppercase tracking-wide font-bold">
                   Modelos cargados ({gpuSnapshot.models.length})
                 </p>
                 {gpuSnapshot.models.map((m) => {
@@ -129,15 +143,15 @@ export default function HytaPanel() {
                       className="flex items-center justify-between gap-3 p-2 rounded-lg bg-slate-800/40 border border-slate-800"
                     >
                       <div className="flex-1 min-w-0">
-                        <div className="text-xs font-bold text-white truncate">{m.name}</div>
-                        <div className="text-[9px] text-slate-500">
-                          {m.details.parameterSize || '?'} · {m.details.quantization || '?'}
+                        <div className="text-xs font-bold text-slate-100 truncate">{m.name}</div>
+                        <div className="text-xs text-slate-400">
+                          {m.details.parameterSize || '—'} · {m.details.quantization || '—'}
                         </div>
                       </div>
                       <div className="text-right shrink-0">
                         <div className="text-xs font-mono text-emerald-400">{formatVram(m.vramMB)}</div>
                       </div>
-                      <span className={`text-[9px] px-2 py-1 rounded-full border font-mono ${procStyle.color}`}>
+                      <span className={`text-[10px] px-2 py-1 rounded-full border font-mono ${procStyle.color}`}>
                         {procStyle.label}
                       </span>
                     </div>
@@ -147,7 +161,7 @@ export default function HytaPanel() {
             )}
 
             {/* Timestamp */}
-            <p className="text-[9px] text-slate-600 mt-2">
+            <p className="text-xs text-slate-500 mt-2">
               Actualizado: {formatTs(gpuSnapshot.ts)}
             </p>
           </div>
@@ -175,7 +189,7 @@ export default function HytaPanel() {
       </button>
 
       {/* Nota sobre privacidad */}
-      <p className="text-[9px] text-slate-600 text-center leading-tight">
+      <p className="text-xs text-slate-500 text-center leading-tight">
         La telemetría LLM detallada vive en el panel privado del operador (ADR-020 / ADR-029).
       </p>
     </div>

--- a/src/components/__tests__/HytaPanel.smoke.test.jsx
+++ b/src/components/__tests__/HytaPanel.smoke.test.jsx
@@ -1,0 +1,128 @@
+/**
+ * HytaPanel.smoke.test.jsx — smoke tests del panel GPU/Ollama.
+ *
+ * Verifica los tres estados observables del panel:
+ *   1. loading — spinner + texto "Detectando…"
+ *   2. error   — aviso "GPU info no disponible" cuando available=false
+ *   3. datos   — VRAM + modelos cuando available=true
+ *
+ * El fetch real a Ollama se mockea via gpuTelemetryService.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+vi.mock('../../services/gpuTelemetryService', () => ({
+  getGpuSnapshot: vi.fn(),
+}));
+
+import { getGpuSnapshot } from '../../services/gpuTelemetryService';
+import HytaPanel from '../HytaPanel';
+
+const snapAvailable = {
+  ts: '2026-06-23T10:00:00.000Z',
+  available: true,
+  models: [
+    {
+      name: 'granite3.3:8b',
+      sizeMB: 4800,
+      vramMB: 4800,
+      processor: 'gpu',
+      gpuShare: 1,
+      expiresAt: null,
+      details: { family: 'granite', parameterSize: '8B', quantization: 'Q4_K_M' },
+    },
+  ],
+  totalVramMB: 4800,
+  hasGpu: true,
+};
+
+const snapUnavailable = {
+  ts: '2026-06-23T10:00:00.000Z',
+  available: false,
+  error: 'connection refused',
+  models: [],
+  totalVramMB: 0,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('HytaPanel — estados observables', () => {
+  it('muestra el estado de carga inicial (spinner)', async () => {
+    // getGpuSnapshot nunca resuelve durante este test
+    getGpuSnapshot.mockReturnValue(new Promise(() => {}));
+    render(<HytaPanel />);
+    // Hay dos textos "Detectando": el del panel interno y el del botón.
+    const detectandoEls = screen.getAllByText(/detectando/i);
+    expect(detectandoEls.length).toBeGreaterThanOrEqual(1);
+    // El botón debe estar deshabilitado mientras carga.
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+  });
+
+  it('muestra aviso cuando GPU no está disponible (available=false)', async () => {
+    getGpuSnapshot.mockResolvedValue(snapUnavailable);
+    render(<HytaPanel />);
+    await waitFor(() =>
+      expect(screen.getByText(/GPU info no disponible/i)).toBeInTheDocument()
+    );
+  });
+
+  it('muestra VRAM y nombre del modelo cuando available=true', async () => {
+    getGpuSnapshot.mockResolvedValue(snapAvailable);
+    render(<HytaPanel />);
+    await waitFor(() =>
+      expect(screen.getByText(/VRAM total ocupada/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText('granite3.3:8b')).toBeInTheDocument();
+    // 4.7 GB aparece dos veces: total VRAM y VRAM del modelo individual.
+    const gbEls = screen.getAllByText(/4\.7 GB/);
+    expect(gbEls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('muestra "—" cuando parameterSize/quantization son null', async () => {
+    const snapNoDetails = {
+      ...snapAvailable,
+      models: [
+        {
+          name: 'model-sin-detalles',
+          sizeMB: 2048,
+          vramMB: 2048,
+          processor: 'cpu',
+          gpuShare: 0,
+          expiresAt: null,
+          details: { family: null, parameterSize: null, quantization: null },
+        },
+      ],
+      hasGpu: false,
+    };
+    getGpuSnapshot.mockResolvedValue(snapNoDetails);
+    render(<HytaPanel />);
+    await waitFor(() =>
+      expect(screen.getByText('model-sin-detalles')).toBeInTheDocument()
+    );
+    // Los detalles sin info muestran "—" honestamente (anti-alucinación UI).
+    const detailsEl = screen.getByText(/—\s*·\s*—/);
+    expect(detailsEl).toBeInTheDocument();
+  });
+
+  it('el botón "Ver GPU detectada" dispara un nuevo snapshot', async () => {
+    getGpuSnapshot.mockResolvedValue(snapUnavailable);
+    render(<HytaPanel />);
+    await waitFor(() =>
+      expect(screen.getByText(/GPU info no disponible/i)).toBeInTheDocument()
+    );
+
+    getGpuSnapshot.mockResolvedValue(snapAvailable);
+    const btn = screen.getByRole('button', { name: /ver gpu detectada/i });
+    await act(async () => { btn.click(); });
+
+    await waitFor(() =>
+      expect(screen.getByText(/VRAM total ocupada/i)).toBeInTheDocument()
+    );
+    expect(getGpuSnapshot).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Resumen

- Cablea stats GPU a datos reales vía `gpuTelemetryService` → Ollama `/api/ps`. No había mocks ni valores hardcodeados — el panel ya estaba conectado. Diagnóstico: los problemas eran de calidad de código y legibilidad.
- Elimina import no usado `CheckCircle2` (eslint)
- Refactoriza `useEffect` inicial de `refresh()` a `.then()/.catch()` para corregir error `react-hooks/set-state-in-effect`
- `text-white` → `text-slate-100` (theme-aware; el blanco hardcodeado desaparece en temas claros nature/minimalista)
- Fuentes `text-[9px]`/`text-[10px]`/`text-[11px]` → `text-xs` (mínimo 12px legible)
- `text-slate-600` en fondo oscuro → `text-slate-400/500` (pasa WCAG AA)
- Parámetros sin dato Ollama → `"—"` honesto en lugar de `"?"` (anti-alucinación UI)
- Badges procesador: `text-emerald-300/amber-300` → `400` + `font-bold` (mayor contraste en todos los temas)
- Añade `HytaPanel.smoke.test.jsx`: 5 tests (loading / error / datos / detalle-null / refresh)

## Plan de verificación

- [ ] Perfil → Avanzado → activar "Mostrar información GPU"
- [ ] El panel muestra spinner y luego datos reales de Ollama (o "GPU info no disponible" si Ollama está down)
- [ ] Verificar legibilidad en tema **biopunk** (oscuro) y **nature/minimalista** (claros)
- [ ] Los badges GPU/Parcial/CPU/? tienen contraste legible en ambos temas
- [ ] Los tamaños de texto son legibles en móvil
- [ ] Botón "Ver GPU detectada" refresca el panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)