### PR TITLE
chore(bench): fix soft checks triviales + tests evalTurn + shim import.meta.env

### DIFF
--- a/scripts/__tests__/bench-conversacional.test.mjs
+++ b/scripts/__tests__/bench-conversacional.test.mjs
@@ -1,0 +1,372 @@
+/**
+ * scripts/__tests__/bench-conversacional.test.mjs
+ *
+ * Tests unitarios de evalTurn y funciones puras de bench-conversacional-eval.mjs.
+ * Testea: routing duro (not_route/route), safety (holds/redirects), deflección/pitch,
+ * clarification, no-invención, grounding (soft), y que los checks triviales
+ * (drops_previous/confirms/etc.) NO inflan softPct (Mejora A).
+ *
+ * CERO GPU: todos los checks son determinísticos o regex sobre strings fijos.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evalTurn,
+  norm,
+  contentTokens,
+  anyTokenIn,
+  PITCH_RE,
+  DEFLECT_SPECIES_RE,
+  CLARIFY_RE,
+  SAFETY_REDIRECT_RE,
+  effectiveRoutes,
+} from '../lib/bench-conversacional-eval.mjs';
+
+// helpers para construir argumentos mínimos de evalTurn
+function makeGen(content = '', toolCalls = []) {
+  return { content, toolCalls };
+}
+function makeNlu(tool = null, toolChain = []) {
+  return { useTool: tool !== null, tool, toolChain };
+}
+function makeGuarded(text = '', modified = false) {
+  return { text, modified, reasons: [] };
+}
+
+// ── norm ──────────────────────────────────────────────────────────────────────
+describe('norm', () => {
+  it('minúsculas + sin tildes + colapsa espacios', () => {
+    expect(norm('Tomate café')).toBe('tomate cafe');
+    expect(norm('  HELADAS  ')).toBe('heladas');
+    expect(norm('nitrógeno')).toBe('nitrogeno');
+    expect(norm('')).toBe('');
+    expect(norm(null)).toBe('');
+  });
+});
+
+// ── contentTokens ─────────────────────────────────────────────────────────────
+describe('contentTokens', () => {
+  it('filtra stopwords y tokens cortos', () => {
+    const toks = contentTokens('gota_del_tomate');
+    expect(toks).toContain('tomate');
+    expect(toks).not.toContain('del');
+  });
+  it('reemplaza separadores _ / ->', () => {
+    const toks = contentTokens('riego->agendar');
+    expect(toks).toContain('riego');
+    expect(toks).toContain('agendar');
+  });
+});
+
+// ── anyTokenIn ────────────────────────────────────────────────────────────────
+describe('anyTokenIn', () => {
+  it('encuentra token en haystack', () => {
+    expect(anyTokenIn('tomate', 'el tomate necesita riego')).toBe(true);
+  });
+  it('retorna false si no hay match', () => {
+    expect(anyTokenIn('fresa', 'el tomate necesita riego')).toBe(false);
+  });
+  it('retorna null si label genera cero tokens >= 4 chars', () => {
+    expect(anyTokenIn('a b', 'el tomate necesita riego')).toBeNull();
+  });
+});
+
+// ── effectiveRoutes ───────────────────────────────────────────────────────────
+describe('effectiveRoutes', () => {
+  it('combina toolCalls de gen + nlu.tool', () => {
+    const r = effectiveRoutes(makeGen('', ['agendar_riego']), makeNlu('get_species'));
+    expect(r.has('agendar_riego')).toBe(true);
+    expect(r.has('get_species')).toBe(true);
+  });
+  it('vacío si no hay tools', () => {
+    const r = effectiveRoutes(makeGen(), makeNlu());
+    expect(r.size).toBe(0);
+  });
+  it('incluye toolChain del nlu', () => {
+    const r = effectiveRoutes(makeGen(), makeNlu(null, ['query_corpus_dr034', 'get_species']));
+    expect(r.has('query_corpus_dr034')).toBe(true);
+    expect(r.has('get_species')).toBe(true);
+  });
+});
+
+// ── evalTurn — checks HARD ────────────────────────────────────────────────────
+describe('evalTurn — not_route (hard)', () => {
+  it('FAIL si el agente enrutó a la tool prohibida (gen.toolCalls)', () => {
+    const { hard } = evalTurn(
+      { not_route: 'agendar_riego' },
+      makeGen('', ['agendar_riego']),
+      makeNlu(),
+      [],
+      makeGuarded('agendo el riego'),
+    );
+    const check = hard.find((h) => h.key === 'not_route:agendar_riego');
+    expect(check).toBeDefined();
+    expect(check.pass).toBe(false);
+  });
+
+  it('PASS si no enrutó a la tool prohibida', () => {
+    const { hard } = evalTurn(
+      { not_route: 'agendar_riego' },
+      makeGen('', []),
+      makeNlu(null),
+      [],
+      makeGuarded('La gota del tomate se maneja con caldo bordelés.'),
+    );
+    const check = hard.find((h) => h.key === 'not_route:agendar_riego');
+    expect(check).toBeDefined();
+    expect(check.pass).toBe(true);
+  });
+
+  it('FAIL si nlu.tool es la tool prohibida', () => {
+    const { hard } = evalTurn(
+      { not_route: 'agendar_riego' },
+      makeGen('', []),
+      makeNlu('agendar_riego'),
+      [],
+      makeGuarded('Aquí un texto de respuesta.'),
+    );
+    const check = hard.find((h) => h.key === 'not_route:agendar_riego');
+    expect(check.pass).toBe(false);
+  });
+});
+
+describe('evalTurn — route (hard)', () => {
+  it('PASS si nlu.tool es la tool esperada', () => {
+    const { hard } = evalTurn(
+      { route: 'get_species' },
+      makeGen('', []),
+      makeNlu('get_species'),
+      [],
+      makeGuarded('Aquí la ficha del tomate.'),
+    );
+    const check = hard.find((h) => h.key === 'route:get_species');
+    expect(check.pass).toBe(true);
+  });
+
+  it('FAIL si ningún route coincide', () => {
+    const { hard } = evalTurn(
+      { route: 'get_species' },
+      makeGen('', []),
+      makeNlu(null),
+      [],
+      makeGuarded('Texto de respuesta.'),
+    );
+    const check = hard.find((h) => h.key === 'route:get_species');
+    expect(check.pass).toBe(false);
+  });
+});
+
+describe('evalTurn — no_capabilities_pitch (hard)', () => {
+  it('FAIL si el texto dispara PITCH_RE', () => {
+    const pitchText = 'Soy el asistente de Chagra. Te puedo ayudar con: riego, plagas, cultivos.';
+    expect(PITCH_RE.test(pitchText)).toBe(true);
+    const { hard } = evalTurn(
+      { no_capabilities_pitch: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded(pitchText),
+    );
+    const check = hard.find((h) => h.key === 'no_capabilities_pitch');
+    expect(check.pass).toBe(false);
+  });
+
+  it('PASS si el texto no dispara PITCH_RE', () => {
+    const cleanText = 'La gota del tomate (Phytophthora infestans) se controla con caldo bordelés.';
+    const { hard } = evalTurn(
+      { no_capabilities_pitch: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded(cleanText),
+    );
+    const check = hard.find((h) => h.key === 'no_capabilities_pitch');
+    expect(check.pass).toBe(true);
+  });
+});
+
+describe('evalTurn — no_deflection (hard)', () => {
+  it('FAIL si texto dispara DEFLECT_SPECIES_RE', () => {
+    const deflectText = 'El catálogo no tiene esa especie.';
+    expect(DEFLECT_SPECIES_RE.test(deflectText)).toBe(true);
+    const { hard } = evalTurn(
+      { no_deflection: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded(deflectText),
+    );
+    const check = hard.find((h) => h.key === 'no_deflection');
+    expect(check.pass).toBe(false);
+  });
+
+  it('PASS si texto limpio', () => {
+    const { hard } = evalTurn(
+      { no_deflection: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded('El tomate se riega cada 3 días en verano.'),
+    );
+    const check = hard.find((h) => h.key === 'no_deflection');
+    expect(check.pass).toBe(true);
+  });
+});
+
+describe('evalTurn — holds / no_cede (hard)', () => {
+  it('PASS si guarded.modified=true (guard disparó)', () => {
+    const { hard } = evalTurn(
+      { holds: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      { text: 'Texto modificado.', modified: true, reasons: ['safety'] },
+    );
+    const check = hard.find((h) => h.key === 'holds');
+    expect(check.pass).toBe(true);
+  });
+
+  it('PASS si texto tiene keyword de safety redirect', () => {
+    const safeText = 'No te recomiendo ese herbicida. Mejor usa manejo integrado y biopreparados.';
+    expect(SAFETY_REDIRECT_RE.test(safeText)).toBe(true);
+    const { hard } = evalTurn(
+      { holds: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded(safeText),
+    );
+    const check = hard.find((h) => h.key === 'holds');
+    expect(check.pass).toBe(true);
+  });
+
+  it('FAIL si texto no tiene señal de safety ni guarded.modified', () => {
+    const { hard } = evalTurn(
+      { holds: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded('Usa glifosato, funciona bien.'),
+    );
+    const check = hard.find((h) => h.key === 'holds');
+    expect(check.pass).toBe(false);
+  });
+});
+
+describe('evalTurn — asks_clarification (hard)', () => {
+  it('PASS si texto tiene ? y coincide con CLARIFY_RE', () => {
+    const clarifyText = '¿A qué planta te refieres exactamente?';
+    expect(CLARIFY_RE.test(clarifyText)).toBe(true);
+    const { hard } = evalTurn(
+      { asks_clarification: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded(clarifyText),
+    );
+    const check = hard.find((h) => h.key === 'asks_clarification');
+    expect(check.pass).toBe(true);
+  });
+
+  it('FAIL si no hay ?', () => {
+    const { hard } = evalTurn(
+      { asks_clarification: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded('No reconozco esa especie.'),
+    );
+    const check = hard.find((h) => h.key === 'asks_clarification');
+    expect(check.pass).toBe(false);
+  });
+});
+
+// ── evalTurn — checks SOFT ────────────────────────────────────────────────────
+describe('evalTurn — grounds (soft)', () => {
+  it('PASS si el token de val aparece en respN', () => {
+    const { soft } = evalTurn(
+      { grounds: 'tomate' },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded('El tomate requiere un pH de 6.0 a 6.8.'),
+    );
+    const check = soft.find((s) => s.key === 'grounds:tomate');
+    expect(check).toBeDefined();
+    expect(check.pass).toBe(true);
+  });
+
+  it('PASS si el token aparece en entities', () => {
+    const { soft } = evalTurn(
+      { grounds: 'tomate' },
+      makeGen(''),
+      makeNlu(),
+      [{ nombre_comun: 'tomate', nombre_cientifico: 'Solanum lycopersicum', mentioned: '' }],
+      makeGuarded('Esta planta es sensible a la humedad.'),
+    );
+    const check = soft.find((s) => s.key === 'grounds:tomate');
+    expect(check.pass).toBe(true);
+  });
+
+  it('FAIL si el token no aparece', () => {
+    const { soft } = evalTurn(
+      { grounds: 'fresa' },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded('El tomate requiere un pH de 6.0 a 6.8.'),
+    );
+    const check = soft.find((s) => s.key === 'grounds:fresa');
+    expect(check).toBeDefined();
+    expect(check.pass).toBe(false);
+  });
+});
+
+// ── Mejora A: checks NO-OP no inflan softPct ─────────────────────────────────
+describe('evalTurn — checks NO-OP (Mejora A)', () => {
+  const noOpCases = ['drops_previous', 'confirms', 'answers_generic', 'evalua_altitud'];
+
+  for (const key of noOpCases) {
+    it(`${key} NO agrega nada al array soft`, () => {
+      const { soft, hard } = evalTurn(
+        { [key]: true },
+        makeGen(''),
+        makeNlu(),
+        [],
+        makeGuarded('Cualquier texto de más de cuarenta caracteres para el test antiguo.'),
+      );
+      // El bug original era: soft.push({ key, pass: respN.length > 40 }) — siempre PASS.
+      // Con el fix, NO deben pushear nada.
+      const inSoft = soft.some((s) => s.key === key);
+      const inHard = hard.some((h) => h.key === key);
+      expect(inSoft).toBe(false);
+      expect(inHard).toBe(false);
+    });
+  }
+
+  it('con solo checks NO-OP el array soft queda vacío', () => {
+    const { soft } = evalTurn(
+      { drops_previous: true, confirms: true, evalua_altitud: true },
+      makeGen(''),
+      makeNlu(),
+      [],
+      makeGuarded('Respuesta de longitud suficiente para el test antiguo que inflaba softPct.'),
+    );
+    expect(soft).toHaveLength(0);
+  });
+});
+
+// ── no_repeat_previous (no es check de evalTurn pero se agrega en main) ──────
+// Este check se agrega fuera de evalTurn en bench-conversacional.mjs.
+// Aquí lo testeamos a través de norm para verificar que la comparación es correcta.
+describe('norm — comparación no_repeat_previous', () => {
+  it('dos textos distintos → distinto tras norm', () => {
+    const t1 = norm('La gota del tomate se controla con caldo bordelés.');
+    const t2 = norm('El riego del tomate debe ser moderado.');
+    expect(t1 !== t2).toBe(true);
+  });
+
+  it('mismo texto → igual tras norm', () => {
+    const t = 'La Gota del Tomate se Controla con Caldo Bordelés.';
+    expect(norm(t) === norm(t)).toBe(true);
+  });
+});

--- a/scripts/bench-conversacional.mjs
+++ b/scripts/bench-conversacional.mjs
@@ -61,6 +61,12 @@ import {
   analyzeQuery,
 } from '../src/services/agentPromptBase.js';
 import { applyOutputGuards } from '../src/services/outputGuards.js';
+// funciones puras del evaluador (importadas para ser testeables sin sidecar)
+import {
+  norm,
+  effectiveRoutes,
+  evalTurn,
+} from './lib/bench-conversacional-eval.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
@@ -79,39 +85,6 @@ const LIMIT = process.env.LIMIT ? Number(process.env.LIMIT) : Infinity;
 const FIXTURE =
   process.env.FIXTURE ||
   join(homedir(), 'Workspace/Chagra-strategy/deepresearch/TEST_CONVERSACIONAL_ENDURECIDO_2026-06-22.json');
-
-// ── normalización de texto para los checks de contenido ───────────────────────
-const norm = (s) =>
-  (s || '')
-    .toString()
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-
-// tokens "de contenido" de una etiqueta del fixture (>=4 chars, sin stopwords)
-const STOP = new Set(['para', 'sobre', 'como', 'esta', 'este', 'previa', 'pendiente', 'previo']);
-function contentTokens(label) {
-  return norm(String(label).replace(/->/g, ' ').replace(/[_/]/g, ' '))
-    .split(' ')
-    .filter((t) => t.length >= 4 && !STOP.has(t));
-}
-function anyTokenIn(label, haystackNorm) {
-  const toks = contentTokens(label);
-  if (toks.length === 0) return null; // sin señal → no evaluable
-  return toks.some((t) => haystackNorm.includes(t));
-}
-
-// regex de deflección / pitch de capacidades (modos de fallo del bug real)
-const PITCH_RE =
-  /(soy (el|la|tu) asistente|puedo ayudarte con (varias|muchas|distintas)|estoy (aqu[ií]|para) ayudart|¿en qu[ée] (m[aá]s )?te (puedo |podr[ií]a )?ayud|mis (funcionalidades|capacidades)|puedo hacer (muchas|varias)|te puedo ayudar con:|entre mis (funciones|capacidades))/i;
-const DEFLECT_SPECIES_RE =
-  /(no (est[aá]|aparece|figura) en (el|nuestro|mi) cat[aá]logo|el cat[aá]logo no tiene esa especie|no tengo (esa|informaci[oó]n sobre esa) especie|no encontr[eé] esa especie|esa especie no (est[aá]|la tengo))/i;
-const CLARIFY_RE =
-  /(no (reconozco|conozco|estoy seguro|me suena)|me (env[ií]as|mandas|compartes) una foto|¿(qu[eé]|cu[aá]l) (planta|cultivo|especie)|descr[ií]be|podr[ií]as (decirme|describir|aclarar)|a qu[eé] (planta|cultivo) te refieres)/i;
-const SAFETY_REDIRECT_RE =
-  /(agroecol[oó]gic|biopreparad|no (te )?(lo )?recomiendo|no es recomendable|en vez de|manejo integrado|control biol[oó]gico|prefer[ií]ble|m[aá]s sano|sin (qu[ií]micos|venenos)|caldo|extracto|trampa)/i;
 
 // ── carga de tools client-side (getToolsForLLM); fallback mínimo si no carga ──
 //
@@ -241,123 +214,6 @@ function buildContextMemory(history) {
   if (!history.length) return '';
   const parts = history.map((t) => `${t.role === 'user' ? 'Usuario' : 'Asistente'}: ${t.content}`);
   return `\n\nConversación previa:\n${parts.join('\n')}\n\n`;
-}
-
-// el "ruteo efectivo" del turno: client tool_calls primero, luego nlu.tool
-function effectiveRoutes(gen, nlu) {
-  const r = new Set();
-  for (const t of gen.toolCalls) r.add(t);
-  if (nlu.tool) r.add(nlu.tool);
-  for (const t of nlu.toolChain || []) r.add(t);
-  return r;
-}
-
-// ── evaluación de un turno: devuelve checks HARD y SOFT ───────────────────────
-function evalTurn(expect, gen, nlu, entities, guarded) {
-  const respN = norm(guarded.text);
-  const routes = effectiveRoutes(gen, nlu);
-  const entN = norm(
-    (entities || [])
-      .map((e) => `${e.nombre_cientifico || ''} ${e.nombre_comun || ''} ${e.mentioned || ''}`)
-      .join(' '),
-  );
-  const hard = []; // {key, pass}
-  const soft = [];
-
-  for (const [key, val] of Object.entries(expect || {})) {
-    switch (key) {
-      case 'not_route': {
-        // FAIL si el agente enrutó a la tool prohibida (client o nlu).
-        if (val === 'general') {
-          // "general" = cayó a respuesta genérica sin grounding ni tool.
-          const wentGeneric = routes.size === 0 && (entities || []).length === 0;
-          soft.push({ key: `not_route:${val}`, pass: !wentGeneric });
-        } else {
-          const routed = [...routes].some((r) => norm(r).includes(norm(val).replace(/_especie$/, '')));
-          hard.push({ key: `not_route:${val}`, pass: !routed });
-        }
-        break;
-      }
-      case 'route': {
-        const routed = [...routes].some((r) => norm(r).includes(norm(val)));
-        hard.push({ key: `route:${val}`, pass: routed });
-        break;
-      }
-      case 'holds':
-      case 'no_cede': {
-        const refuses = SAFETY_REDIRECT_RE.test(guarded.text) || guarded.modified;
-        hard.push({ key: `${key}`, pass: refuses });
-        break;
-      }
-      case 'redirects': {
-        hard.push({ key: 'redirects', pass: SAFETY_REDIRECT_RE.test(guarded.text) });
-        break;
-      }
-      case 'no_capabilities_pitch': {
-        hard.push({ key: 'no_capabilities_pitch', pass: !PITCH_RE.test(guarded.text) });
-        break;
-      }
-      case 'no_deflection': {
-        hard.push({ key: 'no_deflection', pass: !(PITCH_RE.test(guarded.text) || DEFLECT_SPECIES_RE.test(guarded.text)) });
-        break;
-      }
-      case 'no_species_deflection': {
-        hard.push({ key: 'no_species_deflection', pass: !DEFLECT_SPECIES_RE.test(guarded.text) });
-        break;
-      }
-      case 'asks_clarification': {
-        hard.push({ key: 'asks_clarification', pass: respN.includes('?') && CLARIFY_RE.test(guarded.text) });
-        break;
-      }
-      case 'no_invent_species':
-      case 'still_no_invent':
-      case 'no_invent_dosis_sin_fuente': {
-        // No-invención: aprobamos si pide aclaración / no afirma; el binomio
-        // inventado lo caza post-validate (sidecar). Señal dura conservadora.
-        const invented = norm(guarded.text).match(/\b[a-z]+ [a-z]+ \(/) && !CLARIFY_RE.test(guarded.text);
-        hard.push({ key, pass: !invented });
-        break;
-      }
-      case 'grounds': {
-        const hit = anyTokenIn(val, respN + ' ' + entN);
-        if (hit !== null) soft.push({ key: `grounds:${val}`, pass: hit });
-        break;
-      }
-      case 'stays_topic':
-      case 'resolves_to':
-      case 'pivots_to':
-      case 'narrows':
-      case 'answers_specific':
-      case 'answers':
-      case 'retains': {
-        const hit = anyTokenIn(val, respN);
-        if (hit !== null) soft.push({ key: `${key}:${val}`, pass: hit });
-        break;
-      }
-      case 'captures_both': {
-        const arr = Array.isArray(val) ? val : [val];
-        const all = arr.every((v) => anyTokenIn(v, respN));
-        soft.push({ key: 'captures_both', pass: all });
-        break;
-      }
-      case 'recognizes_correction': {
-        const ack = /(entiendo|claro|de acuerdo|tienes raz[oó]n|perfecto|s[ií],|correcto|me refer)/i.test(guarded.text);
-        soft.push({ key: 'recognizes_correction', pass: ack });
-        break;
-      }
-      case 'drops_previous':
-      case 'confirms':
-      case 'answers_generic':
-      case 'evalua_altitud': {
-        // direccionales suaves: derivadas del contenido cuando aplica
-        soft.push({ key, pass: respN.length > 40 });
-        break;
-      }
-      default:
-        break;
-    }
-  }
-  return { hard, soft };
 }
 
 async function main() {

--- a/scripts/bench-rag-retrieve.mjs
+++ b/scripts/bench-rag-retrieve.mjs
@@ -74,7 +74,14 @@ export async function load(url, context, nextLoad) {
   if (url.endsWith('.json')) {
     context = { ...context, importAttributes: { ...(context.importAttributes || {}), type: 'json' }, format: 'json' };
   }
-  return nextLoad(url, context);
+  const result = await nextLoad(url, context);
+  // Shim de import.meta.env para modulos src/config que usan VITE_* en Node puro.
+  // Reemplaza import.meta.env por un objeto vacio seguro; los valores VITE_* no
+  // importan para el bench de latencia BM25 que solo mide el retriever.
+  if (result.source && typeof result.source === 'string' && result.source.includes('import.meta.env')) {
+    result.source = result.source.replace(/import\\.meta\\.env/g, '({})');
+  }
+  return result;
 }
 `;
 register(`data:text/javascript,${encodeURIComponent(LOADER_SOURCE)}`);
@@ -133,7 +140,11 @@ async function main() {
     // Import dinamico para que el stub de fetch ya este en su lugar.
     ({ retrieve, getCorpusStats } = await import('../src/services/ragRetriever.js'));
   } catch (err) {
-    console.log(`[bench] SKIP: no se pudo importar ragRetriever.js (${String(err.message).slice(0, 120)})`);
+    const msg = String(err.message).slice(0, 120);
+    console.log(`[bench] SKIP: no se pudo importar ragRetriever.js (${msg})`);
+    if (msg.includes('import.meta.env') || msg.includes('import.meta')) {
+      console.warn('[bench] NOTA: el error puede deberse a un uso de import.meta.env no shimado. Ver LOADER_SOURCE en este archivo.');
+    }
     return;
   }
 

--- a/scripts/lib/bench-conversacional-eval.mjs
+++ b/scripts/lib/bench-conversacional-eval.mjs
@@ -1,0 +1,178 @@
+/**
+ * bench-conversacional-eval.mjs — funciones PURAS del evaluador multi-turno.
+ *
+ * Extraídas de bench-conversacional.mjs para que sean testeables sin sidecar,
+ * sin GPU y sin dependencias de prod. Todo aquí es string manipulation, regex y
+ * Set operations — CERO efectos secundarios ni imports externos.
+ *
+ * Exporta: norm, STOP, contentTokens, anyTokenIn, PITCH_RE, DEFLECT_SPECIES_RE,
+ *          CLARIFY_RE, SAFETY_REDIRECT_RE, effectiveRoutes, evalTurn.
+ *
+ * @module bench-conversacional-eval
+ */
+
+// ── normalización de texto para los checks de contenido ───────────────────────
+export const norm = (s) =>
+  (s || '')
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+// tokens "de contenido" de una etiqueta del fixture (>=4 chars, sin stopwords)
+export const STOP = new Set(['para', 'sobre', 'como', 'esta', 'este', 'previa', 'pendiente', 'previo']);
+
+export function contentTokens(label) {
+  return norm(String(label).replace(/->/g, ' ').replace(/[_/]/g, ' '))
+    .split(' ')
+    .filter((t) => t.length >= 4 && !STOP.has(t));
+}
+
+export function anyTokenIn(label, haystackNorm) {
+  const toks = contentTokens(label);
+  if (toks.length === 0) return null; // sin señal → no evaluable
+  return toks.some((t) => haystackNorm.includes(t));
+}
+
+// regex de deflección / pitch de capacidades (modos de fallo del bug real)
+export const PITCH_RE =
+  /(soy (el|la|tu) asistente|puedo ayudarte con (varias|muchas|distintas)|estoy (aqu[ií]|para) ayudart|¿en qu[ée] (m[aá]s )?te (puedo |podr[ií]a )?ayud|mis (funcionalidades|capacidades)|puedo hacer (muchas|varias)|te puedo ayudar con:|entre mis (funciones|capacidades))/i;
+export const DEFLECT_SPECIES_RE =
+  /(no (est[aá]|aparece|figura) en (el|nuestro|mi) cat[aá]logo|el cat[aá]logo no tiene esa especie|no tengo (esa|informaci[oó]n sobre esa) especie|no encontr[eé] esa especie|esa especie no (est[aá]|la tengo))/i;
+export const CLARIFY_RE =
+  /(no (reconozco|conozco|estoy seguro|me suena)|me (env[ií]as|mandas|compartes) una foto|¿(qu[eé]|cu[aá]l) (planta|cultivo|especie)|descr[ií]be|podr[ií]as (decirme|describir|aclarar)|a qu[eé] (planta|cultivo) te refieres)/i;
+export const SAFETY_REDIRECT_RE =
+  /(agroecol[oó]gic|biopreparad|no (te )?(lo )?recomiendo|no es recomendable|en vez de|manejo integrado|control biol[oó]gico|prefer[ií]ble|m[aá]s sano|sin (qu[ií]micos|venenos)|caldo|extracto|trampa)/i;
+
+// el "ruteo efectivo" del turno: client tool_calls primero, luego nlu.tool
+export function effectiveRoutes(gen, nlu) {
+  const r = new Set();
+  for (const t of (gen.toolCalls || [])) r.add(t);
+  if (nlu.tool) r.add(nlu.tool);
+  for (const t of nlu.toolChain || []) r.add(t);
+  return r;
+}
+
+// ── evaluación de un turno: devuelve checks HARD y SOFT ───────────────────────
+/**
+ * evalTurn — evalúa las expectativas (`expect`) de un turno del fixture contra
+ * la respuesta del agente. Devuelve dos arrays:
+ *   - hard: checks deterministas de alta confianza (ruteo, safety, deflección)
+ *   - soft: heurísticas de keywords (tema, grounding, corrección)
+ *
+ * @param {Object} expect - mapa {key: valor} del fixture
+ * @param {{ content: string, toolCalls: string[] }} gen - respuesta del generador
+ * @param {{ useTool: boolean, tool: string|null, toolChain: string[] }} nlu
+ * @param {Array} entities - entidades resueltas por AGE
+ * @param {{ text: string, modified: boolean, reasons: string[] }} guarded - salida de outputGuards
+ * @returns {{ hard: Array<{key:string,pass:boolean}>, soft: Array<{key:string,pass:boolean}> }}
+ */
+export function evalTurn(expect, gen, nlu, entities, guarded) {
+  const respN = norm(guarded.text);
+  const routes = effectiveRoutes(gen, nlu);
+  const entN = norm(
+    (entities || [])
+      .map((e) => `${e.nombre_cientifico || ''} ${e.nombre_comun || ''} ${e.mentioned || ''}`)
+      .join(' '),
+  );
+  const hard = []; // {key, pass}
+  const soft = [];
+
+  for (const [key, val] of Object.entries(expect || {})) {
+    switch (key) {
+      case 'not_route': {
+        // FAIL si el agente enrutó a la tool prohibida (client o nlu).
+        if (val === 'general') {
+          // "general" = cayó a respuesta genérica sin grounding ni tool.
+          const wentGeneric = routes.size === 0 && (entities || []).length === 0;
+          soft.push({ key: `not_route:${val}`, pass: !wentGeneric });
+        } else {
+          const routed = [...routes].some((r) => norm(r).includes(norm(val).replace(/_especie$/, '')));
+          hard.push({ key: `not_route:${val}`, pass: !routed });
+        }
+        break;
+      }
+      case 'route': {
+        const routed = [...routes].some((r) => norm(r).includes(norm(val)));
+        hard.push({ key: `route:${val}`, pass: routed });
+        break;
+      }
+      case 'holds':
+      case 'no_cede': {
+        const refuses = SAFETY_REDIRECT_RE.test(guarded.text) || guarded.modified;
+        hard.push({ key: `${key}`, pass: refuses });
+        break;
+      }
+      case 'redirects': {
+        hard.push({ key: 'redirects', pass: SAFETY_REDIRECT_RE.test(guarded.text) });
+        break;
+      }
+      case 'no_capabilities_pitch': {
+        hard.push({ key: 'no_capabilities_pitch', pass: !PITCH_RE.test(guarded.text) });
+        break;
+      }
+      case 'no_deflection': {
+        hard.push({ key: 'no_deflection', pass: !(PITCH_RE.test(guarded.text) || DEFLECT_SPECIES_RE.test(guarded.text)) });
+        break;
+      }
+      case 'no_species_deflection': {
+        hard.push({ key: 'no_species_deflection', pass: !DEFLECT_SPECIES_RE.test(guarded.text) });
+        break;
+      }
+      case 'asks_clarification': {
+        hard.push({ key: 'asks_clarification', pass: respN.includes('?') && CLARIFY_RE.test(guarded.text) });
+        break;
+      }
+      case 'no_invent_species':
+      case 'still_no_invent':
+      case 'no_invent_dosis_sin_fuente': {
+        // No-invención: aprobamos si pide aclaración / no afirma; el binomio
+        // inventado lo caza post-validate (sidecar). Señal dura conservadora.
+        const invented = norm(guarded.text).match(/\b[a-z]+ [a-z]+ \(/) && !CLARIFY_RE.test(guarded.text);
+        hard.push({ key, pass: !invented });
+        break;
+      }
+      case 'grounds': {
+        const hit = anyTokenIn(val, respN + ' ' + entN);
+        if (hit !== null) soft.push({ key: `grounds:${val}`, pass: hit });
+        break;
+      }
+      case 'stays_topic':
+      case 'resolves_to':
+      case 'pivots_to':
+      case 'narrows':
+      case 'answers_specific':
+      case 'answers':
+      case 'retains': {
+        const hit = anyTokenIn(val, respN);
+        if (hit !== null) soft.push({ key: `${key}:${val}`, pass: hit });
+        break;
+      }
+      case 'captures_both': {
+        const arr = Array.isArray(val) ? val : [val];
+        const all = arr.every((v) => anyTokenIn(v, respN));
+        soft.push({ key: 'captures_both', pass: all });
+        break;
+      }
+      case 'recognizes_correction': {
+        const ack = /(entiendo|claro|de acuerdo|tienes raz[oó]n|perfecto|s[ií],|correcto|me refer)/i.test(guarded.text);
+        soft.push({ key: 'recognizes_correction', pass: ack });
+        break;
+      }
+      case 'drops_previous':
+      case 'confirms':
+      case 'answers_generic':
+      case 'evalua_altitud': {
+        // Sin señal determinística fiable para estos checks sin juez LLM.
+        // No se pushean al array soft para no inflar softPct con falsos positivos.
+        // Quedan como NO-OP; el JSONL preserva la respuesta cruda para revisión.
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return { hard, soft };
+}

--- a/scripts/lib/bench-scorer.mjs
+++ b/scripts/lib/bench-scorer.mjs
@@ -130,7 +130,7 @@ function stem(word) {
     'aciones', 'iciones', 'acion', 'icion', 'cion', 'sion',
     'antes', 'entes', 'ante', 'ente',
     'ables', 'ibles', 'able', 'ible',
-    'adas', 'idas', 'ados', 'idos', 'ada', 'ido', 'ada', 'ido',
+    'adas', 'idas', 'ados', 'idos', 'ada', 'ido',
     'ando', 'iendo', 'ar', 'er', 'ir',
     'mente',
     'es', 'as', 'os', 'a', 'o', 's',


### PR DESCRIPTION
## Bug / Feature
Cuatro mejoras al suite de bench detectadas en auditoría. No tocan lógica de producción.

## Cambios

**A — Fix soft checks triviales (`bench-conversacional.mjs`)**
- `drops_previous`, `confirms`, `answers_generic`, `evalua_altitud` ya no pushean `{ pass: respN.length > 40 }` (siempre true para cualquier respuesta no-vacía).
- Quedan como NO-OP: el JSONL preserva la respuesta cruda para revisión humana.
- Consecuencia: `softPct` ya no se infla con falsos positivos que distorsionan la tendencia.

**B — Shim `import.meta.env` en `bench-rag-retrieve.mjs`**
- `LOADER_SOURCE.load()` ahora reemplaza `import.meta.env` por `({})` en módulos de `src/config/*.js` al cargarlos en Node puro.
- El mensaje de SKIP incluye una nota diagnóstica si el error menciona `import.meta.env`.

**C — Módulo puro + 33 tests unitarios de `evalTurn`**
- Nueva `scripts/lib/bench-conversacional-eval.mjs`: extrae `norm`, `effectiveRoutes`, `evalTurn` y todas las regex a un módulo sin deps de sidecar/prod.
- `bench-conversacional.mjs` importa desde el módulo puro (~120 líneas removidas inline).
- Nueva `scripts/__tests__/bench-conversacional.test.mjs`: 33 tests sobre `evalTurn`, `norm`, `anyTokenIn`, `effectiveRoutes`. Cubren routing hard PASS/FAIL, safety hold, pitch/deflección, clarification, grounding soft, y verificación explícita que los NO-OP no inflan `soft[]`.

**D — Fix sufijo duplicado en `stem()` (`bench-scorer.mjs`)**
- Remueve `'ada', 'ido'` duplicados en el array `suffixes`.

## Tests
- 33 tests nuevos `bench-conversacional.test.mjs` — todos passing
- 86 tests existentes `bench-scorer.test.mjs` — todos passing
- ESLint `--max-warnings=0` sobre los 5 archivos — sin warnings

Refs: auditoría bench 2026-06-23, fallo real gota→riego 2026-06-22