### PR TITLE
feat(ui): tiles Suelo, Semilleros y Seguridad — pantallas huérfanas con entrada en Home

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@
  */
 /* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import React, { lazy, Suspense, useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { Sprout, MapPin, Eye, Package, Clock, NotebookPen, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette, FileText, Network, Beaker, PawPrint } from 'lucide-react';
+import { Sprout, MapPin, Eye, Package, Clock, NotebookPen, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette, FileText, Network, Beaker, PawPrint, Layers, TestTube, ShieldAlert } from 'lucide-react';
 import localforage from 'localforage';
 import { useTheme } from './hooks/useTheme';
 import { useClimaAtmosphere } from './hooks/useClimaAtmosphere';
@@ -150,6 +150,9 @@ const NAV_TILES = [
   { id: 'biodiversidad', label: 'Flora y fauna', icon: Leaf, accent: 'emerald', desc: 'Ecosistema, estratos y gremios' },
   { id: 'animales', label: 'Animales', icon: PawPrint, accent: 'rose', desc: 'Gallinas, vacas, cerdos, abejas y ciclo cerrado' },
   { id: 'fermentos', label: 'Fermentos', icon: Beaker, accent: 'orange', desc: 'Recetas tradicionales y seguridad' },
+  { id: 'suelo', label: 'Suelo', icon: Layers, accent: 'amber', desc: 'Diagnóstico y salud del suelo' },
+  { id: 'germinacion', label: 'Semilleros', icon: TestTube, accent: 'teal', desc: 'Prueba de semillas y germinación' },
+  { id: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, accent: 'rose', desc: 'Toxicidad de insumos y riesgo de suelo' },
   { id: 'reportar_invasora', label: 'Plagas', icon: AlertCircle, accent: 'amber', desc: 'Reporte de plagas y malezas' },
   { id: 'casos', label: 'Casos', icon: FileText, accent: 'amber', desc: 'Seguimiento de problemas y tratamientos' },
   { id: 'informes', label: 'Informes', icon: FileText, accent: 'lime', desc: 'Descargas de reportes en CSV' },


### PR DESCRIPTION
## Bug / Feature
Tres pantallas construidas con ruta hash en `HASH_VIEW_ROUTES` no tenían ningún botón/tile en el Home. El usuario solo podía llegar tecleando la URL.

## Auditoría completa de vistas huérfanas

| Vista | Hash | Categoría | Justificación |
|-------|------|-----------|---------------|
| `suelo` | `#suelo` | **A — tile nuevo** | Módulo primario de diagnóstico de tierra. El agente la tiene como `heroRoute` en `CAPABILITY_MANIFEST` pero el Home no la exponía. |
| `germinacion` | `#germinacion` | **A — tile nuevo** | Flujo pre-siembra muy común; `CicloCultivoScreen` tiene botón interno pero muchos usuarios empiezan por semillas sin pasar antes por el ciclo de cultivo. |
| `toxicologia` | `#toxicologia` | **A — tile nuevo** | Seguridad de insumos es transversal (fermentos + suelo + animales). La única entrada era desde `SoilDiagnosticScreen` → pestaña suelo, pero la pestaña de insumos quedaba totalmente inaccesible. |
| `ciclo_nutrientes` | `#ciclo-nutrientes` | B — contextual OK | `AnimalesScreen` tiene botón directo. Es vista complementaria del módulo animal, no punto de entrada independiente. |
| `cromatografia` | `#cromatografia` | B — contextual OK | `SoilDiagnosticScreen` tiene dos botones internos. Con el tile Suelo nuevo se alcanza naturalmente en dos toques. |
| `evolucion` | `#evolucion` | B — contextual OK | `FincaCards` + `HoyEnFincaStrip` en el Dashboard ya la enlazan. Es vista de detalle de "Hoy en finca". |
| `glaciar` | `#glaciar` | C — admin/gating | Acceso restringido por `tieneAccesoGlaciarActual()`. Ya tiene botón en `DashboardLive` para los beta testers autorizados. |
| `glaciar_historial` | `#glaciar-historial` | C — admin/gating | Sub-vista del módulo glaciar, mismo gating. |
| `doom_finca` | `#doom-finca` | C — juego/debug | Mini-juego dentro del hub de juegos (`MiFincaVivaScreen`). Entrada correcta es via hub. |
| `usage_stats` | `#usage-stats` | C — admin/debug | Dashboard interno de telemetría. Sin punto de entrada contextual intencionalmente. |
| `extensionista` | — | C — feature flag | Gateado por `VITE_FEATURE_EXTENSIONISTA` + rol. Entrada correcta via `ProfileScreen` → CustomEvent. |

## Cambios
- `src/App.jsx` línea 10: añade `Layers`, `TestTube`, `ShieldAlert` al import de `lucide-react`
- `src/App.jsx` `NAV_TILES`: inserta 3 tiles después de Fermentos y antes de Plagas
  - `{ id: 'suelo', label: 'Suelo', icon: Layers, accent: 'amber', desc: 'Diagnóstico y salud del suelo' }`
  - `{ id: 'germinacion', label: 'Semilleros', icon: TestTube, accent: 'teal', desc: 'Prueba de semillas y germinación' }`
  - `{ id: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, accent: 'rose', desc: 'Toxicidad de insumos y riesgo de suelo' }`
- No se añaden accents nuevos a `ACCENT_CLASSES`; se reutilizan amber/teal/rose ya definidos
- Los tres `case` en el switch ya existían (`case 'suelo'`, `case 'germinacion'`, `case 'toxicologia'`) — sin cambios en la lógica de routing

## Decisión UX — sin submenú
Con 16 tiles totales el Home sigue siendo navegable en scroll vertical en móvil. Se eligió tiles directos sobre agrupación "Laboratorio" porque suelo y semilleros son acciones primarias del campesino (no sub-herramientas), y toxicología tiene dos pestañas independientes (insumos + suelo) que no pertenecen exclusivamente a ninguno de los otros módulos.

## Tests
- ESLint `--max-warnings=0`: pasa limpio
- Lefthook pre-commit: todos los hooks OK (secret-scan, infra-refs-scan, strategic-content-scan, eslint, conventional)
- Screenshot del Home: pendiente visto-bueno visual del operador (requiere sesión autenticada en prod o stg)

Refs: auditoría pantallas huérfanas solicitada por operador 2026-06-23