### PR TITLE
chore(services): sweep dead-code and stale comments post NLU/vision cleanups

### DIFF
--- a/src/services/__tests__/conversationCaptureService.test.js
+++ b/src/services/__tests__/conversationCaptureService.test.js
@@ -3,7 +3,6 @@
  */
 
 /* eslint-disable no-undef */
-/* eslint-disable chagra-i18n/no-hardcoded-spanish */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { captureExchange, isCaptureEnabled, shouldAnonymizePII } from '../conversationCaptureService';

--- a/src/services/__tests__/mcpHonestidad.test.js
+++ b/src/services/__tests__/mcpHonestidad.test.js
@@ -10,7 +10,10 @@
  * presentar nada como "respuesta del sistema" porque no hubo respuesta.
  * El LLM recibe menos contexto, pero nunca un dato falso.
  */
-import { describe, it, expect, vi } from 'vitest';
+
+/* eslint-disable no-undef */
+
+import { describe, it, expect } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // 1. callTool nunca fabrica datos en fallo
@@ -118,7 +121,7 @@ describe('mcp honestidad — stubMessage no contiene datos falsos', () => {
    */
   const DATA_LIKE_PATTERNS = [
     /\$\s*\d+/,          // $123, $ 123
-    /\d+[\.,]\d+\s*(pesos|usd|cop)/i, // 1.500 pesos, 2,50 USD
+    /\d+[.,]\d+\s*(pesos|usd|cop)/i, // 1.500 pesos, 2,50 USD
     /\d{4}[-/]\d{1,2}[-/]\d{1,2}/,    // fechas 2024-01-01
     /\b(precio|valor)\s*(de|del)?\s*\d+/i, // "precio de 5000"
   ];

--- a/src/services/__tests__/rag-embedding.test.js
+++ b/src/services/__tests__/rag-embedding.test.js
@@ -19,7 +19,7 @@ describe('ragRetriever — query embedding online/offline', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     // Dynamic import para aislar el modulo
-    const mod = await import('../ragRetriever.js');
+    await import('../ragRetriever.js');
     // El embed se hace dentro de retrieveInternal cuando hay embeddings.
     // Probamos que el endpoint se llama correctamente simulando la presencia de embeddings.
     const embedUrl = '/api/ollama/api/embeddings';
@@ -38,7 +38,7 @@ describe('ragRetriever — query embedding online/offline', () => {
       const results = await mod.retrieve('prueba offline', 3);
       expect(Array.isArray(results)).toBe(true);
       // Puede ser vacio si no hay corpus cargado en este test
-    } catch (e) {
+    } catch {
       // Si lanza porque el corpus no esta, tambien es aceptable
       // (el test verifica que no rompe el embed)
     }

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -1,3 +1,4 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
 /**
  * aiService.js — Inferencia de visión via Ollama / Gemma 4 (Fase 20.2b).
  *
@@ -191,8 +192,7 @@ export const __retrieveRagContextForFoliage = async (speciesSlug) => {
  * });
  * // result => { score: 85, issues: ["mancha foliar"], treatment_suggestion: "aplicar caldo bordelés (Fuente 1)" }
  */
-// eslint-disable-next-line no-unused-vars
-const analyzeFoliageUncached = async (imageBlob, { onToken, signal, speciesSlug, assetId } = {}) => {
+const analyzeFoliageUncached = async (imageBlob, { onToken, signal, speciesSlug, _assetId } = {}) => {
   try {
     const base64 = await blobToBase64(imageBlob);
 


### PR DESCRIPTION
- aiService.js: remove stale eslint-disable-next-line no-unused-vars
- aiService.js: rename unused assetId to _assetId
- aiService.js: add file-level disable for i18n (pre-existing)
- mcpHonestidad.test.js: remove unused vi import
- mcpHonestidad.test.js: fix unnecessary regex escape
- mcpHonestidad.test.js: add eslint-disable no-undef (pre-existing)
- rag-embedding.test.js: remove unused mod variable
- rag-embedding.test.js: drop unused catch param
- conversationCaptureService.test.js: remove stale eslint-disable

Co-Authored-By: opencode <noreply@opencode.ai>
