### PR TITLE
chore(bench): migrate stale GEN_MODEL defaults from granite3.1-dense:8b to granite3.3:8b

### DIFF
--- a/scripts/__tests__/bench-judge-wiring.test.mjs
+++ b/scripts/__tests__/bench-judge-wiring.test.mjs
@@ -54,15 +54,15 @@ describe('normalizeBenchData — transforma el JSONL real del bench a items eval
     query: '¿Qué cuidados requiere la fresa en clima frío?',
     expected_keywords: ['drenaje', 'riego', 'heladas', 'poda'],
     timestamp: '2026-06-03T00:00:00.000Z',
-    granite3_1_8b: {
-      model: 'granite3.1-dense:8b',
+    granite3_3_8b: {
+      model: 'granite3.3:8b',
       response: 'La fresa necesita buen drenaje y protección contra heladas.',
       keywords_matched: 3,
       keywords_total: 4,
       halluc_count: 0,
       error: null,
     },
-    winner: 'granite3_1_8b',
+    winner: 'granite3_3_8b',
   };
 
   it('extrae la respuesta del modelo objetivo (granite por defecto) a model_response', () => {
@@ -103,7 +103,7 @@ describe('normalizeBenchData — transforma el JSONL real del bench a items eval
   it('omite items donde el modelo objetivo falló (error != null) sin crashear', () => {
     const errored = {
       ...benchLine,
-      granite3_1_8b: { model: 'granite3.1-dense:8b', response: null, error: 'Timeout' },
+      granite3_3_8b: { model: 'granite3.3:8b', response: null, error: 'Timeout' },
     };
     const norm = normalizeBenchData([errored]);
     expect(norm.results).toHaveLength(0);
@@ -134,14 +134,14 @@ describe('loadBenchData — lee el JSONL real, NO cae a mock cuando --from exist
           category: 'species',
           query: '¿Cuidados de la fresa?',
           expected_keywords: ['drenaje', 'heladas'],
-          granite3_1_8b: { model: 'granite3.1-dense:8b', response: 'Buen drenaje.', error: null },
+          granite3_3_8b: { model: 'granite3.3:8b', response: 'Buen drenaje.', error: null },
         }),
         JSON.stringify({
           prompt_id: 2,
           category: 'species',
           query: '¿Roya del café?',
           expected_keywords: ['variedades resistentes'],
-          granite3_1_8b: { model: 'granite3.1-dense:8b', response: 'Variedades resistentes.', error: null },
+          granite3_3_8b: { model: 'granite3.3:8b', response: 'Variedades resistentes.', error: null },
         }),
       ];
       writeFileSync(path, lines.join('\n') + '\n');
@@ -165,7 +165,7 @@ describe('loadBenchData — lee el JSONL real, NO cae a mock cuando --from exist
       const path = join(dir, 'legacy.json');
       const payload = {
         timestamp: '2026-06-03T00:00:00.000Z',
-        model: 'granite3.1-dense:8b',
+        model: 'granite3.3:8b',
         results: [
           { id: 1, query: '¿Q?', ground_truth: 'GT.', model_response: 'R.' },
         ],

--- a/scripts/__tests__/bench-nocturno-farm-process.test.mjs
+++ b/scripts/__tests__/bench-nocturno-farm-process.test.mjs
@@ -28,7 +28,6 @@ describe('bench nocturno farm process scenarios', () => {
       'gemma3:12b',
       'qwen3.5:9b',
       'gemma3:4b',
-      'granite3.1-dense:8b',
     ]);
     expect(SMOKE_ONLY_MODELS).toContain('qwen3:30b');
   });

--- a/scripts/agent-loop-bench.mjs
+++ b/scripts/agent-loop-bench.mjs
@@ -106,7 +106,7 @@ async function queryAgent(prompt, maxIterations = 3) {
         headers,
         body: JSON.stringify({
           query: currentPrompt,
-          model: 'granite3.1-dense:8b',
+          model: 'granite3.3:8b',
         }),
       });
 

--- a/scripts/bench-capabilities-A-vs-C.mjs
+++ b/scripts/bench-capabilities-A-vs-C.mjs
@@ -60,7 +60,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
 const BENCH_RUNS_DIR = join(ROOT_DIR, 'data', 'bench-runs');
 
-const GEN_MODEL = process.env.GEN_MODEL || 'granite3.1-dense:8b';
+const GEN_MODEL = process.env.GEN_MODEL || 'granite3.3:8b';
 const GEN_TEMPERATURE = 0.3;
 const GEN_MAX_TOKENS = 768;
 const SEED = Number(process.env.SEED || 42);

--- a/scripts/bench-llm-judge.mjs
+++ b/scripts/bench-llm-judge.mjs
@@ -47,13 +47,13 @@ const JUDGE_MODEL = process.env.JUDGE_MODEL || 'gemma3:4b';
 const TIMEOUT_MS = 60_000;
 
 // Modelo cuyo turno se evalúa cuando el JSONL es per-model (bench-agente-completo).
-// Default granite3.1-dense:8b = el chat de PROD (llmRouter chat_complex).
-const TARGET_MODEL = process.env.TARGET_MODEL || 'granite3.1-dense:8b';
+const TARGET_MODEL = process.env.TARGET_MODEL || 'granite3.3:8b';
 
 // Mapa modelKey (clave del objeto per-model en el JSONL) → nombre ollama, para
 // poder seleccionar por nombre real del modelo cuando TARGET_MODEL es un nombre.
 const MODEL_KEY_BY_NAME = {
   'gemma3:4b': 'gemma3_4b',
+  'granite3.3:8b': 'granite3_3_8b',
   'granite3.1-dense:8b': 'granite3_1_8b',
   'ministral-3:latest': 'ministral_3b',
   'aya:8b': 'aya_8b',

--- a/scripts/lib/bench-nocturno-scenarios.mjs
+++ b/scripts/lib/bench-nocturno-scenarios.mjs
@@ -6,7 +6,6 @@ export const PRIMARY_MODELS = [
   'gemma3:12b',
   'qwen3.5:9b',
   'gemma3:4b',
-  'granite3.1-dense:8b',
 ];
 
 export const SMOKE_ONLY_MODELS = [

--- a/scripts/lib/bench-scorer.mjs
+++ b/scripts/lib/bench-scorer.mjs
@@ -81,7 +81,7 @@ export const RECOMMENDED_JUDGE_MODEL = RECOMMENDED_ANTHROPIC_JUDGE_MODEL;
 export const RECOMMENDED_OLLAMA_JUDGE_MODEL = 'qwen2.5:14b';
 
 /** El generador del bench cuyo uso como juez = auto-evaluación (prohibido). */
-export const GENERATOR_MODEL = 'granite3.1-dense:8b';
+export const GENERATOR_MODEL = 'granite3.3:8b';
 
 /**
  * assertIndependentJudge — lanza si el modelo juez es el mismo que generó la


### PR DESCRIPTION
Updates the default generator/judge model from the deprecated
granite3.1-dense:8b to granite3.3:8b across bench scripts and
their test fixtures:
- bench-scorer.mjs: GENERATOR_MODEL default
- bench-capabilities-A-vs-C.mjs: GEN_MODEL env default
- bench-llm-judge.mjs: TARGET_MODEL env default + MODEL_KEY_BY_NAME
- bench-nocturno-scenarios.mjs: PRIMARY_MODELS list cleanup
- agent-loop-bench.mjs: hardcoded model in agent loop query
- Test fixtures updated to use granite3_3_8b keys

Co-Authored-By: opencode <noreply@opencode.ai>
