### PR TITLE
feat(guards): anti-variedad enumerada sin evidencia (CASO C)

### DIFF
--- a/src/services/__tests__/outputGuards.casoC.test.js
+++ b/src/services/__tests__/outputGuards.casoC.test.js
@@ -1,0 +1,198 @@
+/**
+ * outputGuards.casoC.test.js — GUARD CASO C: variedad/cultivar enumerado SIN
+ * bloque EVIDENCIA AUTORITATIVA.
+ *
+ * Cuando la respuesta enumera variedades/cultivares de una planta SIN que el
+ * prompt contuviera un bloque "=== EVIDENCIA AUTORITATIVA ===" respaldando
+ * tales enumeraciones, SUPRIME el cuerpo y lo REEMPLAZA por la deflexión
+ * honesta definida en CASO C:
+ *   "El catálogo Chagra todavía no tiene un inventario de variedades de
+ *    [planta] documentado todavía. ¿Quieres información general del cultivo,
+ *    o prefieres registrar las variedades que tengas en tu finca?"
+ *
+ * Anti-FP: respuesta que YA niega tener info de variedades; userMessage que
+ * ya listaba variedades (eco); respuesta sin enumeración de variedades.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  guardVarietyWithoutEvidence,
+  applyOutputGuards,
+  resetOutputGuardTelemetry,
+  getOutputGuardTelemetry,
+} from '../outputGuards.js';
+
+const CASO_C_REPLACEMENT_MARKER = /no tiene un inventario de variedades de/i;
+const CASO_C_REASON_MARKER = /variedad_sin_evidencia/i;
+
+beforeEach(() => {
+  resetOutputGuardTelemetry();
+});
+
+describe('guardVarietyWithoutEvidence — CASO C (variedad/cultivar enumerado sin EVIDENCIA)', () => {
+  it('CASO BENCH: "las variedades de café son: Castillo, Colombia, Caturra" → suprime y reemplaza', () => {
+    const llm =
+      'Las variedades de café son: Castillo, Colombia, Caturra, Típica y Borbón. ' +
+      'Cada una tiene características diferentes de resistencia a la roya y calidad de taza.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(CASO_C_REASON_MARKER);
+    expect(out.text).toMatch(CASO_C_REPLACEMENT_MARKER);
+    expect(out.text).not.toMatch(/castillo|colombia|caturra|típica|borbón/i);
+  });
+
+  it('VARIANTE: "el café tiene 3 variedades" + enumeración', () => {
+    const llm =
+      'El café tiene 3 variedades principales: Castillo, Colombia y Caturra. ' +
+      'Son las más sembradas en Colombia por su resistencia a la roya.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(CASO_C_REPLACEMENT_MARKER);
+    expect(out.text).toMatch(/cafe/i);
+  });
+
+  it('VARIANTE: "existen 5 variedades de papa" + nombres', () => {
+    const llm =
+      'Existen 5 variedades de papa en Colombia: Pastusa, Criolla, Sabanera, Diacol Capiro y Parda Pastusa.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(CASO_C_REPLACEMENT_MARKER);
+    expect(out.text).toMatch(/papa/i);
+  });
+
+  it('VARIANTE: "principales variedades de maíz son" + nombres', () => {
+    const llm =
+      'Las principales variedades de maíz son: Capio, Porva, Cariaco, Amagaceño y Chococito.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(CASO_C_REPLACEMENT_MARKER);
+    expect(out.text).toMatch(/ma[ií]z/i);
+  });
+
+  it('VARIANTE: "cultivares de frijol incluyen" + nombres', () => {
+    const llm =
+      'Los cultivares de frijol incluyen Cargamanto, Bolo Radical y Calima, ' +
+      'cada uno con diferente adaptación a pisos térmicos.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(CASO_C_REPLACEMENT_MARKER);
+    expect(out.text).toContain('frijol');
+  });
+
+  it('VARIANTE: "el café tiene 3 variedades" sin enumeración directa también dispara', () => {
+    const llm =
+      'El café tiene 3 variedades: la Castillo es resistente a roya, ' +
+      'la Colombia tiene buena taza y la Caturra es precoz.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(CASO_C_REPLACEMENT_MARKER);
+  });
+
+  it('extrae nombre compuesto "frijol cargamanto" con pattern tiene+N', () => {
+    // Pattern 3 "<PLANT> tiene N variedades" captura dos palabras
+    const llm =
+      'El frijol cargamanto tiene 3 variedades: rojo, negro y blanco.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(CASO_C_REPLACEMENT_MARKER);
+    expect(out.text).toMatch(/frijol cargamanto/i);
+  });
+
+  it('telemetría: registra el gatillo del guard', () => {
+    const llm = 'Las variedades de café son: Castillo, Colombia, Caturra.';
+    guardVarietyWithoutEvidence(llm);
+    const tel = getOutputGuardTelemetry();
+    expect(tel.variety_without_evidence).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── CONTROLES anti-falso-positivo ───────────────────────────────────
+
+  it('CONTROL: respuesta que YA niega tener info de variedades NO dispara', () => {
+    const llm =
+      'No tengo información sobre las variedades de café documentadas en el catálogo. ' +
+      'Chagra no registra variedades por especie todavía.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL: respuesta que usa "no tenemos registro de variedades" NO dispara', () => {
+    const llm =
+      'En el catálogo Chagra no tenemos un registro de las variedades de papa ' +
+      'todavía. ¿Quieres información general del cultivo?';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL: respuesta normal sin enumeración de variedades NO dispara', () => {
+    const llm =
+      'El café (Coffea arabica) se da muy bien en clima templado entre 1.200 y 1.800 msnm. ' +
+      'Necesita buen drenaje y sombra moderada.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL: userMessage ya enumera variedades → respuesta puede repetirlas (eco)', () => {
+    const userMsg = '¿Qué tal la papa criolla, pastusa y sabanera para mi finca?';
+    const llm =
+      'La papa criolla, pastusa y sabanera se dan bien en clima frío. ' +
+      'La criolla es precoz y la pastusa rinde más.';
+    const out = guardVarietyWithoutEvidence(llm, { userMessage: userMsg });
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL: "el café tiene varias variedades" sin número ni enumeración NO dispara', () => {
+    const llm =
+      'El café tiene varias variedades, pero no tengo ese dato en el catálogo.';
+    const out = guardVarietyWithoutEvidence(llm);
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL: idempotente — no re-dispara sobre su propio reemplazo', () => {
+    const llm = 'Las variedades de café son: Castillo, Colombia, Caturra.';
+    const once = guardVarietyWithoutEvidence(llm);
+    expect(once.modified).toBe(true);
+    const twice = guardVarietyWithoutEvidence(once.text);
+    expect(twice.modified).toBe(false);
+    expect(twice.text).toBe(once.text);
+  });
+
+  it('CONTROL: texto vacío no dispara', () => {
+    const out = guardVarietyWithoutEvidence('');
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe('');
+  });
+
+  it('CONTROL: consulta de precio pasa sin tocar', () => {
+    const llm =
+      'El café variedad Castillo se paga a $2.300 la carga en la plaza de mercado.';
+    const out = guardVarietyWithoutEvidence(llm);
+    // "café variedad Castillo" no es enumeración → no dispara
+    expect(out.modified).toBe(false);
+  });
+});
+
+describe('guardVarietyWithoutEvidence via applyOutputGuards — integración', () => {
+  it('aplica el guard via applyOutputGuards en modo siembra', () => {
+    const resp =
+      'Las variedades de café son: Castillo, Colombia y Caturra. Son resistentes a la roya.';
+    const out = applyOutputGuards(resp, {
+      userMessage: '¿Qué variedades de café recomiendas?',
+    });
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(CASO_C_REPLACEMENT_MARKER);
+    // guardInventedVariety NO debe disparar (no hay clima opuesto)
+    expect(out.text).not.toMatch(/Bactris gasipaes/);
+  });
+
+  it('no interfiere con guardInventedVariety (BORDE-007) cuando ese es más específico', () => {
+    const resp =
+      'Existe una variedad de chontaduro de clima frío que se da hasta 2.600 m, ' +
+      'es la accesión Pacífico tolerante al frío.';
+    const out = applyOutputGuards(resp, {
+      userMessage: 'Tengo semilla de chontaduro de clima frío, ¿la subo a 2.600 m?',
+    });
+    // Debe disparar guardInventedVariety (BORDE-007), no CASO C
+    expect(out.modified).toBe(true);
+    expect(out.text).toContain('Bactris gasipaes');
+  });
+});

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -4542,6 +4542,171 @@ export function guardInventedVariety(responseText, { userMessage = null } = {}) 
   };
 }
 
+// ── CASO C: variedad/cultivar enumerada SIN bloque EVIDENCIA AUTORITATIVA ─────
+
+/**
+ * Marcador de idempotencia para guardVarietyWithoutEvidence.
+ * Si el texto ya contiene esta frase, no re-procesar.
+ */
+const CASO_C_MARKER = 'no tiene un inventario de variedades de';
+
+/** La respuesta YA niega tener info de variedades (el modelo acertó CASO C). */
+const CASO_C_DENIED_RE = /no\s+(?:t(?:engo|enemos)|hay|est[áa]n\s+(?:documentad|registrad|catalogad)|se\s+(?:tiene|encuentran?))\s+(?:informaci[oó]n|datos|registro|inventario)\s+(?:sobre\s+)?(?:las\s+)?(?:variedades?|cultivares?)/i;
+
+/**
+ * Patrones de enumeración de variedades/cultivares de una planta.
+ * El nombre de la planta SIEMPRE es el grupo de captura 1.
+ *
+ * Cubre:
+ *   - "variedades/cultivares de <PLANT>: A, B, C…"
+ *   - "principales variedades de <PLANT> son/incluyen"
+ *   - "<PLANT> tiene [N] variedades/cultivares"
+ *   - "existen [N] variedades de <PLANT>"
+ *
+ * NO cubre "tipos de" para evitar FP con "tipos de suelo/abono/riego".
+ * NO cubre "varias/muchas" sin número para evitar FP con "tiene varias
+ * variedades" (declaración genérica, no enumeración).
+ */
+const CASO_C_PLANT_PATTERNS = [
+  // "variedades/cultivares de <PLANT>: <word>…"
+  // Plant name en grupo 1.
+  /\b(?:variedades?|cultivares?)\s+de\s+(?:la\s+|el\s+|los\s+|las\s+|del\s+)?([a-záéíóúñ]+(?:\s+[a-záéíóúñ]+)?)\s*:\s*\w+/i,
+  // "variedades/cultivares de <PLANT> son/incluyen <word>…"
+  // Plant name en grupo 1.
+  /\b(?:variedades?|cultivares?)\s+de\s+(?:la\s+|el\s+|los\s+|las\s+|del\s+)?([a-záéíóúñ]+(?:\s+[a-záéíóúñ]+)?)\s+(?:son\s+(?:las?\s+siguientes\s*)?:?\s*|incluyen?|comprenden?|abarcan?)\s+\w+/i,
+  // "principales variedades de <PLANT>: <word>" o "son <word>"
+  // Plant name en grupo 1.
+  /\b(?:principales?|diferentes|distintas)\s+(?:variedades?|cultivares?)\s+de\s+(?:la\s+|el\s+|los\s+|las\s+|del\s+)?([a-záéíóúñ]+(?:\s+[a-záéíóúñ]+)?)\s*(?::\s*\w+|son\s+(?:las?\s+siguientes\s*)?:?\s*\w+|incluyen?\s+\w+|comprenden?\s+\w+|abarcan?\s+\w+)/i,
+  // "<PLANT> tiene <N> variedades/cultivares"
+  // Plant name en grupo 1.
+  /\b([a-záéíóúñ]+(?:\s+[a-záéíóúñ]+)?)\s+tiene\s+\d+\s+(?:variedades?|cultivares?)\b/i,
+  // "existen/hay <N> variedades de <PLANT>"
+  // Plant name en grupo 1.
+  /\b(?:existen|hay)\s+\d+\s+(?:variedades?|cultivares?)\s+de\s+(?:la\s+|el\s+|los\s+|las\s+|del\s+)?([a-záéíóúñ]+(?:\s+[a-záéíóúñ]+)?)\b/i,
+];
+
+/**
+ * Artículos y partículas que pueden prefijar el nombre de planta capturado.
+ */
+const CASO_C_LEADING_ARTICLES = /\b(?:el\s+|la\s+|los\s+|las\s+|del\s+|un\s+|una\s+)/i;
+
+/** Palabras-función que NO son parte del nombre de la planta (cortas o stop). */
+const CASO_C_TRAILING_STOP = /\s+(?:en|de|del|con|para|por|sin|son|hay|tiene|las|los|sus|las|sus|ese|esa|eso|este|esta|esto|son|como|pero)\s*$/i;
+
+/**
+ * Limpia el nombre de planta capturado: quita artículos iniciales y palabras
+ * función que el matching greedy se llevó de más.
+ * @param {string} raw
+ * @returns {string}
+ */
+function _cleanPlantName(raw) {
+  let s = raw.trim();
+  s = s.replace(CASO_C_LEADING_ARTICLES, '');
+  s = s.replace(CASO_C_TRAILING_STOP, '');
+  return s.trim();
+}
+
+/**
+ * Busca en texto normalizado un patrón de enumeración de variedades/
+ * cultivares y extrae el nombre de la planta limpio.
+ * @param {string} norm
+ * @returns {string|null}
+ */
+function _findVarietyEnumPlant(norm) {
+  for (const re of CASO_C_PLANT_PATTERNS) {
+    const m = norm.match(re);
+    if (m && m[1]) {
+      const plant = _cleanPlantName(m[1]);
+      if (plant && plant.length <= 40) return plant;
+    }
+  }
+  return null;
+}
+
+/** ¿El texto normalizado contiene un patrón de enumeración de variedades? */
+function _hasVarietyEnumeration(norm) {
+  return CASO_C_PLANT_PATTERNS.some((re) => re.test(norm));
+}
+
+/**
+ * Construye la deflexión honesta para CASO C.
+ * @param {string} plantName
+ * @returns {string}
+ */
+function _casoCReplacement(plantName) {
+  const p = plantName.trim();
+  return (
+    `El catálogo Chagra todavía no tiene un inventario de variedades de ${p} documentado todavía. ` +
+    `¿Quieres información general del cultivo, o prefieres registrar las variedades que tengas en tu finca?`
+  );
+}
+
+/**
+ * guardVarietyWithoutEvidence — CASO C. ANTI-VARIEDAD/CULTIVAR ENUMERADO SIN
+ * EVIDENCIA AUTORITATIVA.
+ *
+ * Cuando la respuesta enumera variedades/cultivares de una planta SIN que el
+ * prompt contuviera un bloque "=== EVIDENCIA AUTORITATIVA ===" respaldando
+ * tales enumeraciones (cf. REGLA CASO C de agentPromptBase), SUPRIME el cuerpo
+ * y lo REEMPLAZA por la deflexión honesta:
+ *   "El catálogo Chagra todavía no tiene un inventario de variedades de
+ *    [planta] documentado todavía."
+ *
+ * GATING:
+ *   1. La respuesta contiene un patrón de enumeración de variedades o
+ *      cultivares para una especie.
+ *   2. La respuesta NO niega ya que carece de info de variedades (el modelo
+ *      ya acertó → idempotencia sobre la regla).
+ *   3. Idempotencia: nuestro reemplazo no está presente ya.
+ *   4. Anti-FP userMessage: si el usuario mencionó variedades específicas
+ *      en su pregunta, la respuesta puede repetirlas sin ser invento.
+ *
+ * Firma propia (necesita userMessage) → se invoca aparte en applyOutputGuards,
+ * justo tras guardInventedVariety y dentro del mismo gate de siembra.
+ * SUPPRESS-AND-REPLACE (early-return).
+ *
+ * @param {string} responseText
+ * @param {{userMessage?: string|null}} [ctx]
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardVarietyWithoutEvidence(responseText, { userMessage = null } = {}) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  // Idempotencia: nuestro reemplazo ya está → no re-suprimir.
+  if (responseText.includes(CASO_C_MARKER)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const respNorm = _stripDiacritics(responseText);
+  const userNorm = typeof userMessage === 'string' ? _stripDiacritics(userMessage) : '';
+
+  // Gate 1: ¿hay un patrón de enumeración de variedades/cultivares en la respuesta?
+  const plant = _findVarietyEnumPlant(respNorm);
+  if (!plant) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Gate 2: si la respuesta YA niega tener info de variedades, el modelo acertó.
+  if (CASO_C_DENIED_RE.test(respNorm)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Gate 4 (anti-FP): si el usuario preguntó/listó variedades, permitir eco.
+  if (userNorm && _hasVarietyEnumeration(userNorm)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('variety_without_evidence');
+  // SUPPRESS-AND-REPLACE: descartamos la enumeración inventada y devolvemos
+  // el mensaje honesto de CASO C.
+  return {
+    text: _casoCReplacement(plant),
+    modified: true,
+    reason: `variedad_sin_evidencia: ${plant}`,
+  };
+}
+
 // ── GUARD: viabilidad FALSO-NEGATIVO (cultivo viable marcado inviable) ──────
 
 /**
@@ -8454,6 +8619,21 @@ export function applyOutputGuards(
     const iv = guardInventedVariety(text, { userMessage });
     if (iv && iv.modified) {
       return { text: iv.text, modified: true, reasons: iv.reason ? [iv.reason] : [] };
+    }
+  }
+
+  // GUARD CASO C: variedad/cultivar enumerado SIN EVIDENCIA AUTORITATIVA. Si la
+  // respuesta enumera variedades/cultivares de una planta SIN que el prompt
+  // tuviera un bloque "=== EVIDENCIA AUTORITATIVA ===" respaldándolas (el
+  // catálogo Chagra no tiene inventario de variedades por especie), SUPRIME el
+  // cuerpo y REEMPLAZA por la deflexión honesta de CASO C. Complementa a
+  // guardInventedVariety (que cubre el sub-caso de variedad climáticamente
+  // imposible). Es un suppress-and-replace con firma propia (userMessage) →
+  // early-return. Guard de SIEMBRA/identidad.
+  if (runPlantingGuards && !(vis && vis.modified)) {
+    const ve = guardVarietyWithoutEvidence(text, { userMessage });
+    if (ve && ve.modified) {
+      return { text: ve.text, modified: true, reasons: ve.reason ? [ve.reason] : [] };
     }
   }
 


### PR DESCRIPTION
Cuando la respuesta enumera variedades/cultivares de una planta SIN que el
prompt contuviera un bloque '=== EVIDENCIA AUTORITATIVA ===' respaldando
tales enumeraciones, SUPRIME el cuerpo y lo REEMPLAZA por la deflexion
honesta: 'El catalogo Chagra no tiene un inventario de variedades de
[planta] documentado todavia.'

- Nuevo guardVarietyWithoutEvidence en outputGuards.js
- 4 patrones de deteccion (variedades: <*, son/incluyen, tiene+N, existen+N)
- 4 gates anti-FP: idempotencia, denial, userMessage-eco, vacio
- Telemetria variety_without_evidence
- Wired en applyOutputGuards tras guardInventedVariety (BORDE-007)
- 18 tests unitarios (8 trigger + 10 control/anti-FP/integracion)
