### PR TITLE
fix(ui): cablear módulo "Aprende con el agente" (#1824 quedó huérfano sin ruta)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,6 +110,7 @@ const OnboardingHero = lazy(() => import('./components/OnboardingHero'));
 const WelcomeStatsHero = lazy(() => import('./components/WelcomeStatsHero'));
 const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
+const AprenderConAgente = lazy(() => import('./components/Aprende/AprenderConAgente'));
 const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
 const MiFincaEvolucionScreen = lazy(() => import('./components/hoy/MiFincaEvolucionScreen'));
 const MiFincaVivaScreen = lazy(() => import('./components/juego/MiFincaVivaScreen'));
@@ -203,6 +204,7 @@ const HASH_VIEW_ROUTES = {
   'doom-finca': 'doom_finca',
   toxicologia: 'toxicologia',
   suelo: 'suelo',
+  aprende: 'aprende',
   'usage-stats': 'usage_stats',
 };
 
@@ -213,7 +215,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
   'hoy_finca', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'suelo', 'toxicologia',
+  'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'suelo', 'toxicologia', 'aprende',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia',
   'usage_stats',
@@ -1251,6 +1253,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Cromatografia de Suelo">
               <CromatografiaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'aprende':
+        // Módulo "Aprende con el agente" (#1824): 5 lecciones agroecológicas
+        // (suelo · asociaciones · biopreparados · MIP · fenología) con datos
+        // verificados y fuente, más InsightCards al cierre de cada lección.
+        // Componente autocontenido (maneja su propio estado interno).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Aprende con el agente">
+              <AprenderConAgente onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -17,7 +17,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -103,6 +103,7 @@ const HERRAMIENTAS_TILES = [
     { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Diagnóstico y salud del suelo', accent: 'text-amber-400 border-l-amber-500' },
     { view: 'germinacion', label: 'Semilleros', icon: TestTube, desc: 'Prueba de semillas y germinación', accent: 'text-teal-400 border-l-teal-500' },
     { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo de suelo', accent: 'text-rose-400 border-l-rose-500' },
+    { view: 'aprende', label: 'Aprende', icon: BookOpen, desc: 'Lecciones agroecológicas con fuente', accent: 'text-emerald-400 border-l-emerald-500' },
 ];
 
 function SortableSection({ id, onNavigate, sensors }) {


### PR DESCRIPTION
El módulo educativo `AprenderConAgente` (#1824) se construyó completo (5 lecciones + InsightCards + tests que pasan) pero **nunca se cableó a la navegación**, así que el operador no podía verlo: `App.jsx` no lo importaba, no tenía `case` en el router de vistas, `"aprende"` no estaba en las vistas válidas, y ningún tile lo abría.

## Cableado mínimo (sin reconstruir nada)
- **`src/App.jsx`**
  - `import` lazy de `AprenderConAgente`.
  - `case "aprende"` en el switch de vistas → `<AprenderConAgente onBack={() => navigate("dashboard")} />`, envuelto en `ErrorBoundary`/`ErrorFallback` como el resto de módulos.
  - `"aprende"` en `HASH_VIEW_ROUTES` (ruta `#aprende`) y en `MODULE_VIEWS` (telemetría + vista válida).
- **`src/components/dashboard/DashboardLive.jsx`**
  - Tile **"Aprende"** (icono `BookOpen`) en el bloque **Herramientas de finca**, junto a Suelo/Semilleros/Seguridad (mismo patrón que #1845), navegando a la vista `"aprende"`.

No se tocó el componente, las lecciones (`agro-lecciones.json`) ni las cards (`agro-insight-cards.json`).

## Verificación (Playwright headless vs build local)
Operador activado, contra `dist/` servido en puerto efímero:
- El tile **"Aprende"** aparece en el home (Herramientas de finca).
- Al click navega al módulo y renderiza el header "Aprende con el agente" + las **5 lecciones** (suelo · asociaciones · biopreparados · MIP · fenología).
- Entrar a una lección muestra los bloques de contenido y la vista de **datos verificados** (InsightCards).
- Sin `pageErrors` del módulo (los únicos errores de consola son del backend FarmOS inalcanzable en el test estático, no del cambio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)