### PR TITLE
feat(home): descubribilidad — borrar dashboard muerto, rescatar huérfanos, reparar mano radial

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,12 +6,11 @@
  * errores reales de ESLint siguen activos.
  */
 /* eslint-disable chagra-i18n/no-hardcoded-spanish */
-import React, { lazy, Suspense, useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { Sprout, MapPin, Eye, Package, Clock, NotebookPen, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette, FileText, Network, Beaker, PawPrint, Layers, TestTube, ShieldAlert } from 'lucide-react';
+import React, { lazy, Suspense, useState, useEffect, useCallback, useRef } from 'react';
+import { MapPin, Eye, Package, CheckCircle, WifiOff, Mic, AlertCircle, Network, Beaker } from 'lucide-react';
 import localforage from 'localforage';
 import { useTheme } from './hooks/useTheme';
 import { useClimaAtmosphere } from './hooks/useClimaAtmosphere';
-import { useScrollRestoration } from './hooks/useScrollRestoration';
 import useIdleDetection from './hooks/useIdleDetection';
 import useGlobalKeyboardShortcuts from './hooks/useGlobalKeyboardShortcuts';
 import BiopunkBackground from './components/dashboard/BiopunkBackground';
@@ -59,7 +58,6 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { ErrorFallback } from './components/common/ErrorFallback';
 
 // Lazy-loaded route components
-const TelemetryAlerts = lazy(() => import('./components/TelemetryAlerts'));
 const LoginScreen = lazy(() => import('./components/LoginScreen'));
 const OAuthCallback = lazy(() => import('./components/OAuthCallback'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
@@ -104,10 +102,7 @@ const GlaciarHistorialScreen = lazy(() => import('./components/GlaciarHistorialS
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
 const CaseStudyScreen = lazy(() => import('./components/CaseStudyScreen'));
 const CaseStudyDetail = lazy(() => import('./components/CaseStudyDetail'));
-const CaseStudyTopWidget = lazy(() => import('./components/CaseStudyTopWidget'));
 const HelpManual = lazy(() => import('./components/HelpManual'));
-const OnboardingHero = lazy(() => import('./components/OnboardingHero'));
-const WelcomeStatsHero = lazy(() => import('./components/WelcomeStatsHero'));
 const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
 const AprenderConAgente = lazy(() => import('./components/Aprende/AprenderConAgente'));
@@ -134,46 +129,15 @@ const LoadingFallback = () => (
   </div>
 );
 
-// NAV tiles, vocabulario user-facing post DR-030 QW2 (decisión D3+D4 del DR).
-// Tile "Voz" eliminada: la captura por voz vive dentro del agente / compositor
-// (el FAB global MicFab se removió 2026-05-30 por decisión del operador).
-// Iconos canónicos: Sprout para plantas, NotebookPen para bitácora.
-// Card-sort n>=5 con usuarios 0-contexto colombianos pendiente para
-// validar empíricamente, esta release ships con hipótesis cultural
-// (lenguaje agronómico colombiano) y se itera post-feedback.
-const NAV_TILES = [
-  { id: 'activos', label: 'Plantas', icon: Sprout, accent: 'teal', desc: 'Cultivos, zonas e infraestructura' },
-  { id: 'mapa', label: 'Mapa', icon: MapPin, accent: 'blue', desc: 'Vista espacial de la finca' },
-  { id: 'javier', label: 'Hoy en finca', icon: Eye, accent: 'green', desc: `Tareas por proximidad (${PRIMARY_WORKER_NAME})` },
-  { id: 'bodega', label: 'Insumos', icon: Package, accent: 'sky', desc: 'Stock de biopreparados' },
-  { id: 'task_log', label: 'Tareas', icon: Clock, accent: 'rose', desc: 'Cola de pendientes' },
-  { id: 'historial', label: 'Bitácora', icon: NotebookPen, accent: 'indigo', desc: 'Historial de actividades' },
-  { id: 'biodiversidad', label: 'Flora y fauna', icon: Leaf, accent: 'emerald', desc: 'Ecosistema, estratos y gremios' },
-  { id: 'animales', label: 'Animales', icon: PawPrint, accent: 'rose', desc: 'Gallinas, vacas, cerdos, abejas y ciclo cerrado' },
-  { id: 'fermentos', label: 'Fermentos', icon: Beaker, accent: 'orange', desc: 'Recetas tradicionales y seguridad' },
-  { id: 'suelo', label: 'Suelo', icon: Layers, accent: 'amber', desc: 'Diagnóstico y salud del suelo' },
-  { id: 'germinacion', label: 'Semilleros', icon: TestTube, accent: 'teal', desc: 'Prueba de semillas y germinación' },
-  { id: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, accent: 'rose', desc: 'Toxicidad de insumos y riesgo de suelo' },
-  { id: 'reportar_invasora', label: 'Plagas', icon: AlertCircle, accent: 'amber', desc: 'Reporte de plagas y malezas' },
-  { id: 'casos', label: 'Casos', icon: FileText, accent: 'amber', desc: 'Seguimiento de problemas y tratamientos' },
-  { id: 'informes', label: 'Informes', icon: FileText, accent: 'lime', desc: 'Descargas de reportes en CSV' },
-  { id: 'perfil', label: 'Perfil', icon: Palette, accent: 'indigo', desc: 'Temas y configuración' },
-];
-
-// Mapa de accents → clases Tailwind (para que el JIT genere los estilos).
-// Keeping static literals so Tailwind purgue funcione.
-const ACCENT_CLASSES = {
-  teal: { border: 'border-l-teal-500', text: 'text-teal-400' },
-  blue: { border: 'border-l-blue-500', text: 'text-blue-400' },
-  green: { border: 'border-l-green-500', text: 'text-green-400' },
-  sky: { border: 'border-l-sky-500', text: 'text-sky-400' },
-  rose: { border: 'border-l-rose-500', text: 'text-rose-400' },
-  indigo: { border: 'border-l-indigo-500', text: 'text-indigo-400' },
-  emerald: { border: 'border-l-emerald-500', text: 'text-emerald-400' },
-  lime: { border: 'border-l-lime-500', text: 'text-lime-400' },
-  amber: { border: 'border-l-amber-500', text: 'text-amber-400' },
-  orange: { border: 'border-l-orange-500', text: 'text-orange-400' },
-};
+// CÓDIGO MUERTO REMOVIDO 2026-06-24 (descubribilidad): `NAV_TILES` +
+// `ACCENT_CLASSES` solo los consumía `DashboardView` (la grilla de 16 tiles del
+// dashboard legacy), que NUNCA se montaba — `case 'dashboard'` renderiza
+// `DashboardLiveView`. La home viva es `DashboardLive.jsx` (HERRAMIENTAS_TILES +
+// FincaCards + mano radial). Los launchers que SOLO vivían en ese código muerto
+// (`casos` vía CaseStudyTopWidget, `javier` vía el tile) se rescataron a la home
+// viva (HERRAMIENTAS_TILES en DashboardLive). Las rutas `casos`/`caso_detail`/
+// `javier`/`usage_stats` siguen vivas en el router (más abajo) y por hash.
+// Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
@@ -285,149 +249,6 @@ const DashboardLiveView = React.memo(function DashboardLiveView({ onNavigate, on
           `}</style>
         </div>
       )}
-    </div>
-  );
-});
-
-const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, lastLogMessage }) {
-  // Feedback piloto #103: preservar scroll al volver de Voz/FieldFeedback/sub-screens.
-  // Sin esto, navegar dashboard → vista_X → dashboard volvía siempre al top.
-  useScrollRestoration('dashboard');
-
-  // Selectores shallow: solo re-renderiza cuando las longitudes cambian
-  const plantsCount = useAssetStore((s) => s.plants.length);
-  const landsCount = useAssetStore((s) => s.lands.length);
-  const structuresCount = useAssetStore((s) => s.structures.length);
-  const materialsCount = useAssetStore((s) => s.materials.length);
-  const plants = useAssetStore((s) => s.plants);
-  const structures = useAssetStore((s) => s.structures);
-  const lands = useAssetStore((s) => s.lands);
-  const hydrate = useAssetStore((s) => s.hydrate);
-  const syncFromServer = useAssetStore((s) => s.syncFromServer);
-
-  // T2: Hidratación al montar, llena contadores desde IndexedDB inmediatamente
-  useEffect(() => {
-    hydrate().then(() => {
-      if (navigator.onLine) syncFromServer(fetchFromFarmOS);
-    });
-  }, [hydrate, syncFromServer]);
-
-  const noGeoCount = useMemo(() => {
-    const allAssets = [...plants, ...structures, ...lands];
-    return allAssets.filter((a) => {
-      const geo = a.attributes?.intrinsic_geometry;
-      return !geo || !(typeof geo === 'object' ? geo.value : geo);
-    }).length;
-  }, [plants, structures, lands]);
-
-  const assetCounts = useMemo(() => [
-    { label: 'Cultivos', count: plantsCount, color: 'text-lime-400' },
-    { label: 'Zonas', count: landsCount, color: 'text-amber-400' },
-    { label: 'Infraestructura', count: structuresCount, color: 'text-emerald-400' },
-    { label: 'Insumos', count: materialsCount, color: 'text-sky-400' },
-  ], [plantsCount, landsCount, structuresCount, materialsCount]);
-
-  return (
-    <div className="h-[100dvh] w-full app-scrim-strong text-white flex flex-col overflow-hidden">
-      {/* DR-030 QW2: TopBar persistente con identidad operador + acciones
-          globales. Reemplaza el header inline previo. La info ambiental
-          (msnm/luna/sol) pasó al EnvironmentalCard colapsable bajo el TopBar.
-          2026-05-18: wrapper translúcido (.app-scrim-strong, scrim por token)
-          para que se vea la imagen de fondo agroecológica aplicada al body en
-          App.jsx — navy en bio-punk, velo crema sutil en temas claros. */}
-      <TopBar onNavigate={onNavigate} onLogout={onLogout} />
-      <HomeRegionalGreeting />
-
-      {/* Feedback piloto #116: estadísticas al header (siempre visibles).
-          Antes: el bloque assetCounts vivía dentro del <main scrollable>,
-          se perdía al scrollear hacia abajo. usuaria piloto pidió "deberían ir al
-          inicio en el header", ahora es hermano del TopBar (queda fuera
-          del overflow del main, sticky de facto al top siempre). */}
-      {plantsCount > 0 && (
-        <button
-          type="button"
-          onClick={() => onNavigate('activos')}
-          aria-label="Ver inventario de activos"
-          className="w-full bg-slate-900/95 backdrop-blur-md border-b border-slate-800 hover:bg-slate-800/50 transition-colors shrink-0"
-        >
-          <div className="grid grid-cols-4 divide-x divide-slate-800 py-2">
-            {assetCounts.map((ac) => (
-              <div key={ac.label} className="text-center px-2">
-                <p className={`text-xl font-black tabular-nums ${ac.color}`}>{ac.count}</p>
-                <p className="text-[10px] text-slate-500 uppercase font-bold tracking-wider">{ac.label}</p>
-              </div>
-            ))}
-          </div>
-        </button>
-      )}
-
-      {/* Feedback piloto #5 (Lili 2026-05-18): pb-4 no era suficiente —
-          los FABs flotantes (Agent) tapaban el final del scroll. Cambio a
-          calc seguro con safe-area iOS notch + 120px para que el último
-          widget quede accesible al tap. */}
-      <main className="flex-1 px-4 pt-3 pb-[calc(env(safe-area-inset-bottom,0px)+120px)] flex flex-col overflow-y-auto gap-3">
-        {/* Bug 2026-05-18 (operator): TelemetryAlerts mostraba errores IoT +
-            sync no resueltos como PRIMERA cosa visible post-login. Mal first
-            impression — Chagra debe arrancar con stats positivos (especies,
-            plantas cuidadas, fichas pedagógicas, biopreparados).
-            Ahora: WelcomeStatsHero como hero card SIEMPRE primera.
-            OnboardingHero (CTAs 📸/🎤/✍) sigue mostrándose si plantsCount=0
-            (junto al WelcomeStatsHero, para guiar al primer registro).
-            TelemetryAlerts se mueve más abajo (problemas técnicos visibles
-            pero no como hero). */}
-        <ErrorBoundary>
-          <WelcomeStatsHero mode="post-login" onNavigate={onNavigate} />
-        </ErrorBoundary>
-
-        {plantsCount === 0 && (
-          <OnboardingHero onNavigate={onNavigate} />
-        )}
-
-        {plantsCount > 0 && (
-          <ErrorBoundary>
-            <TelemetryAlerts onNavigate={onNavigate} lastFarmOsLog={lastLogMessage} />
-          </ErrorBoundary>
-        )}
-
-        {/* Top problemas activos casos de estudio (DR-044 sub-iv). */}
-        {/* Se auto-oculta cuando no hay casos activos (KISS, zero footprint). */}
-        <ErrorBoundary>
-          <CaseStudyTopWidget onNavigate={onNavigate} maxItems={3} />
-        </ErrorBoundary>
-
-        {noGeoCount > 0 && (
-          <button
-            onClick={() => onNavigate('activos')}
-            className="w-full p-3 rounded-xl bg-amber-900/20 border border-amber-800/50 flex items-center justify-between hover:bg-amber-900/30 transition-colors"
-          >
-            <span className="text-xs text-amber-400 font-bold flex items-center gap-2">
-              <MapPin size={14} aria-hidden="true" />
-              {noGeoCount} activo{noGeoCount > 1 ? 's' : ''} sin ubicación registrada
-            </span>
-            <span className="text-2xs text-amber-400/60">Tocar para corregir</span>
-          </button>
-        )}
-
-        <div className="h-4 shrink-0" />
-
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-          {NAV_TILES.map((tile) => {
-            const a = ACCENT_CLASSES[tile.accent] || ACCENT_CLASSES.teal;
-            return (
-              <button
-                key={tile.id}
-                onClick={() => onNavigate(tile.id)}
-                aria-label={`${tile.label}: ${tile.desc}`}
-                className={`bg-slate-900/60 border border-slate-800 border-l-4 ${a.border} rounded-xl p-4 text-left min-h-[80px] active:bg-slate-800/70 transition-colors`}
-              >
-                <tile.icon size={28} strokeWidth={2} className={`mb-2 ${a.text}`} aria-hidden="true" />
-                <span className={`text-lg font-black block ${a.text}`}>{tile.label}</span>
-                <span className="text-2xs text-slate-500 block mt-0.5">{tile.desc}</span>
-              </button>
-            );
-          })}
-        </div>
-      </main>
     </div>
   );
 });
@@ -970,10 +791,16 @@ export default function App() {
         );
       case 'biopreparados':
         // Galería de recetas de biopreparados PASO A PASO (no la pantalla de
-        // insumos/inventario). La misión "Prepárale comida natural" navega acá.
+        // insumos/inventario). Dos entradas: (1) la misión "Prepárale comida
+        // natural" del juego (sin `back` → vuelve al juego, default) y (2) la
+        // home viva (Herramientas de finca → Biopreparados, rescatada
+        // 2026-06-24, pasa back:'dashboard'). El botón Volver respeta de dónde
+        // se vino: por defecto al juego (back-compat de la misión); desde la
+        // home, al dashboard. Antes onBack iba SIEMPRE a 'juego', así que desde
+        // la home el usuario caía en el juego (huérfano).
         return (
           <ErrorBoundary>
-            <ScreenShell title="Biopreparados" onBack={() => navigate('juego')} onHome={() => navigate('dashboard')}>
+            <ScreenShell title="Biopreparados" onBack={() => navigate(currentViewData?.back || 'juego')} onHome={() => navigate('dashboard')}>
               <div className="px-4 pt-3 pb-10 max-w-2xl mx-auto flex flex-col gap-4">
                 {/* Acceso a la toxicología de insumos (EPI, dosis seguras,
                     restricción ICA). Caso crítico: caldo bordelés / sulfocálcico. */}
@@ -1062,6 +889,14 @@ export default function App() {
           </ErrorBoundary>
         );
       case 'mapa':
+        // #mapa renderiza el MAPA real (Leaflet, FarmMap). VERIFICADO 2026-06-24:
+        // NO colapsa a la vista Activos. Si no hay activos georreferenciados,
+        // FarmMap sigue mostrando el mapa de la finca (centrado por defecto) con
+        // un aviso honesto "Sin activos georreferenciados aún." encima — no es un
+        // fallback ni una redirección. El único salto a 'activos' es el
+        // drill-down al TOCAR un activo del mapa (onAssetClick). La premisa de
+        // "colapso a Activos" era un hallazgo de auditoría stale.
+        // Ref: CAPABILITIES_STATUS.md §1/§7.4.
         return (
           <ErrorBoundary>
             <ScreenShell title="Mapa de la Finca" icon={MapPin} onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')}>

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -1,3 +1,12 @@
+/*
+ * i18n (ADR-050): DashboardLive.jsx contiene etiquetas de navegación de la home
+ * en español Colombia (títulos de tiles/bloques: Suelo, Semilleros, Cosechar,
+ * Insumos aplicados, "Registrar en la finca"…) pendientes de migrar a
+ * src/config/messages.js. La regla chagra-i18n es soft (warn); se desactiva a
+ * nivel de archivo para no bloquear el pre-commit con deuda preexistente —
+ * mismo criterio que App.jsx. Los errores reales de ESLint siguen activos.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useScrollRestoration } from '../../hooks/useScrollRestoration';
 import {
@@ -17,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -36,6 +45,11 @@ import {
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import SelectedBackgroundReveal from './SelectedBackgroundReveal';
 import MiFincaVivaHomeCard from './MiFincaVivaHomeCard';
+// Rescate huérfano 2026-06-24 (descubribilidad): CaseStudyTopWidget vivía solo
+// en el DashboardView MUERTO de App.jsx (única vía a `casos`). Se trae a la home
+// viva; se auto-oculta si no hay casos activos (KISS, zero footprint). Ref:
+// CAPABILITIES_STATUS.md §2.
+import CaseStudyTopWidget from '../CaseStudyTopWidget';
 import ClimaStrip from './ClimaStrip';
 import HoyEnFincaStrip from './HoyEnFincaStrip';
 import AIStatusFooter from './AIStatusFooter';
@@ -104,6 +118,28 @@ const HERRAMIENTAS_TILES = [
     { view: 'germinacion', label: 'Semilleros', icon: TestTube, desc: 'Prueba de semillas y germinación', accent: 'text-teal-400 border-l-teal-500' },
     { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo de suelo', accent: 'text-rose-400 border-l-rose-500' },
     { view: 'aprende', label: 'Aprende', icon: BookOpen, desc: 'Lecciones agroecológicas con fuente', accent: 'text-emerald-400 border-l-emerald-500' },
+    // Huérfanos rescatados 2026-06-24 (descubribilidad). Eran rutas vivas en el
+    // router pero sin entrada en la home viva (CAPABILITIES_STATUS.md §2):
+    //  · biopreparados → galería de recetas paso a paso (antes solo desde el juego).
+    //  · ciclo_nutrientes → plan de alimentación / ciclo cerrado (antes solo
+    //    desde dentro de AnimalesScreen).
+    //  · casos → casos de estudio (antes solo desde el DashboardView muerto / #casos).
+    // `data: { back: 'dashboard' }`: la galería de biopreparados también se abre
+    // desde el juego (misión, sin back → vuelve al juego). Desde la home pasamos
+    // back:'dashboard' para que el botón Volver regrese acá y no al juego
+    // (corrige el onBack huérfano). Ver App.jsx case 'biopreparados'.
+    { view: 'biopreparados', label: 'Biopreparados', icon: FlaskConical, desc: 'Recetas caseras paso a paso', accent: 'text-lime-400 border-l-lime-500', data: { back: 'dashboard' } },
+    { view: 'ciclo_nutrientes', label: 'Nutrientes', icon: Recycle, desc: 'Ciclo cerrado: del animal al suelo y la planta', accent: 'text-emerald-400 border-l-emerald-500' },
+    { view: 'casos', label: 'Casos', icon: ClipboardList, desc: 'Seguimiento de problemas y tratamientos', accent: 'text-amber-400 border-l-amber-500' },
+];
+
+// Acciones de gestión sin launcher directo en la home (huérfanas):
+// cosechar / insumos / mantenimiento. Eran alcanzables solo por back-nav interno
+// o por la mano. Se exponen como tiles propios (CAPABILITIES_STATUS.md §2).
+const GESTION_TILES = [
+    { view: 'cosechar', label: 'Cosechar', icon: Wheat, desc: 'Registrar una cosecha', accent: 'text-amber-400 border-l-amber-500' },
+    { view: 'insumos', label: 'Insumos aplicados', icon: Droplets, desc: 'Registrar una aplicación de bioinsumo', accent: 'text-sky-400 border-l-sky-500' },
+    { view: 'mantenimiento', label: 'Mantenimiento', icon: Wrench, desc: 'Labores de mantenimiento de la finca', accent: 'text-slate-300 border-l-slate-500' },
 ];
 
 function SortableSection({ id, onNavigate, sensors }) {
@@ -227,6 +263,19 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
             return !esPerfilUrbano(getProfile());
         } catch (_) {
             return true; // Fail-open: no esconder el módulo por un error.
+        }
+    });
+    // Rescate huérfano 2026-06-24 (descubribilidad): "Campo, Javier"
+    // (WorkerDashboard) era HUÉRFANO — solo accesible desde el NAV_TILES del
+    // DashboardView muerto o por #javier. Es una vista de SUPERVISOR/trabajador
+    // (nicho), así que la exponemos gateada al OPERADOR (no se la mostramos al
+    // campesino dueño para no ensuciar la home). La ruta #javier sigue viva en el
+    // router. Ref: CAPABILITIES_STATUS.md §2.
+    const [mostrarJavier] = useState(() => {
+        try {
+            return esOperadorActual();
+        } catch (_) {
+            return false; // Fail-closed: vista de nicho, no exponer por error.
         }
     });
     const iotAlerts = useAssetStore((s) => s.iotAlerts) || [];
@@ -410,6 +459,14 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                 </div>
             )}
 
+            {/* Top problemas activos (casos de estudio, DR-044). Rescate huérfano
+                2026-06-24: vivía solo en el DashboardView muerto. Se auto-oculta
+                si no hay casos activos (retorna null) → zero footprint. Abre
+                'casos' al tocarlo. */}
+            <div className="px-4 pt-3">
+                <CaseStudyTopWidget onNavigate={onNavigate} maxItems={3} />
+            </div>
+
             {/* Seguimiento de procesos de finca (2026-06-15): TARJETAS en el
                 home — Reforestación · Silvopastoreo · Páramo · Cerdos — al estilo
                 de "Mis plantas". Cada una abre su VISTA de seguimiento (iniciar
@@ -458,6 +515,35 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                         <button
                             key={tile.view}
                             type="button"
+                            onClick={() => onNavigate(tile.view, tile.data)}
+                            aria-label={`${tile.label}: ${tile.desc}`}
+                            className={`bg-slate-900/60 border border-slate-800 border-l-4 ${tile.accent} rounded-xl p-3 text-left min-h-[88px] active:bg-slate-800/70 transition-colors flex flex-col`}
+                        >
+                            <tile.icon size={24} strokeWidth={2} className={`mb-1.5 ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
+                            <span className={`text-sm font-black block leading-tight ${tile.accent.split(' ')[0]}`}>{tile.label}</span>
+                            <span className="text-2xs text-slate-500 block mt-0.5 leading-tight">{tile.desc}</span>
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {/* GESTIÓN — acciones de registro sin launcher directo en la home
+                (cosechar · insumos aplicados · mantenimiento). Rescate huérfano
+                2026-06-24: eran alcanzables solo por back-nav interno o la mano
+                (CAPABILITIES_STATUS.md §2). Las rutas ya existen en App.jsx. */}
+            <div className="px-4 pt-3">
+                <p className="flex items-center gap-2 text-xs font-bold text-slate-400 uppercase tracking-wider mb-2.5">
+                    <span
+                        aria-hidden="true"
+                        className="h-3.5 w-1 rounded-full bg-gradient-to-b from-sky-400 to-emerald-400"
+                    />
+                    Registrar en la finca
+                </p>
+                <div className="grid grid-cols-3 gap-3" data-testid="gestion-tiles">
+                    {GESTION_TILES.map((tile) => (
+                        <button
+                            key={tile.view}
+                            type="button"
                             onClick={() => onNavigate(tile.view)}
                             aria-label={`${tile.label}: ${tile.desc}`}
                             className={`bg-slate-900/60 border border-slate-800 border-l-4 ${tile.accent} rounded-xl p-3 text-left min-h-[88px] active:bg-slate-800/70 transition-colors flex flex-col`}
@@ -469,6 +555,31 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                     ))}
                 </div>
             </div>
+
+            {/* "Campo, Javier" (WorkerDashboard) — rescate huérfano 2026-06-24,
+                gateado al OPERADOR (vista de supervisor/trabajador, nicho). La
+                ruta #javier sigue viva en el router. Ref: CAPABILITIES_STATUS §2. */}
+            {mostrarJavier && (
+                <div className="px-4 pt-3">
+                    <button
+                        type="button"
+                        onClick={() => onNavigate('javier')}
+                        className="w-full flex items-center gap-3 p-3.5 rounded-2xl border border-slate-700/60 bg-slate-900/40 hover:bg-slate-800/50 active:scale-[0.99] transition text-left"
+                        aria-label="Campo, Javier: panel de trabajo en finca"
+                    >
+                        <span className="shrink-0 w-11 h-11 rounded-xl bg-emerald-500/15 grid place-items-center">
+                            <Eye size={24} className="text-emerald-300" />
+                        </span>
+                        <span className="flex-1 min-w-0">
+                            <span className="block font-bold text-slate-100 leading-tight">Campo, Javier</span>
+                            <span className="block text-xs text-slate-400 leading-tight">
+                                Panel de trabajo: tareas por proximidad y registro en finca
+                            </span>
+                        </span>
+                        <ChevronRight size={20} className="text-slate-400/70 shrink-0" />
+                    </button>
+                </div>
+            )}
 
             {/* MÓDULO ANIMALES (finca integrada): gallinas, cerdos y abejas, con
                 el ciclo cerrado (estiércol → biopreparado → suelo → planta) y la

--- a/src/services/__tests__/capabilityHealth.test.js
+++ b/src/services/__tests__/capabilityHealth.test.js
@@ -74,9 +74,11 @@ describe('getCapabilityHealth — estado real por capacidad', () => {
     expect(getCapabilityHealth('voz', deps)).toBe('live');
   });
 
-  it('foto retorna soon (manifest: identificacion por foto necesita GPU >=8GB)', () => {
-    // foto es status:'soon' en el manifiesto (hardware insuficiente en Maxwell);
-    // el manifest manda, sin importar el estado del sidecar.
+  it('foto retorna soon (manifest: foto-desde-la-mano aun sin cablear al chat)', () => {
+    // foto es status:'soon' en el manifiesto, pero NO por hardware: la visión
+    // groundeada ya corre en el chat (GPU 12GB). Falta cablear el acceso directo
+    // por foto desde la mano al flujo de foto-en-chat (ver stubMessage corregido
+    // 2026-06-24). El manifest manda, sin importar el estado del sidecar.
     const deps = makeDeps({ isSidecarEnabled: false });
     expect(getCapabilityHealth('foto', deps)).toBe('soon');
     expect(getCapabilityHealth('foto', makeDeps({ isSidecarEnabled: true }))).toBe('soon');

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -1,3 +1,12 @@
+/*
+ * i18n (ADR-050): agentCapabilities.js es el MANIFIESTO de capacidades — labels,
+ * descripciones, placeholders y stubMessages user-facing en español Colombia,
+ * pendientes de migrar a src/config/messages.js. La regla chagra-i18n es soft
+ * (warn); se desactiva a nivel de archivo para no bloquear el pre-commit con
+ * deuda preexistente — mismo criterio que App.jsx. Los errores reales de ESLint
+ * siguen activos.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
 /**
  * agentCapabilities.js — Manifiesto ÚNICO de capacidades de Chagra.
  *
@@ -88,7 +97,15 @@ export const CAPABILITY_MANIFEST = Object.freeze([
       'sin consulta directa. Si quieres, te oriento a la fuente o a Corabastos.',
     group: 'vender',
     status: 'soon',
-    hero: true,
+    // hero:false (descubribilidad 2026-06-24) — `precio` SIGUE siendo chip
+    // honesto en el ChipsToolbar (stub con stubMessage que orienta a SIPSA/
+    // Corabastos), pero se RETIRA de la mano radial: era la ÚNICA hoja del grupo
+    // "vender" y, al ser status:'soon' (no-op → solo toast "por lanzar"), dejaba
+    // una rama muerta. Sin backing real de precios, se quita la rama de la mano
+    // (el grupo "vender" desaparece: GROUPS filtra grupos sin hojas hero). El día
+    // que exista precio real, se vuelve a poner hero:true con heroRoute live.
+    // Ref: CAPABILITIES_STATUS.md §7.4 (reparar ramas muertas).
+    hero: false,
     heroRoute: { kind: 'unavailable' },
   },
   {
@@ -221,6 +238,24 @@ export const CAPABILITY_MANIFEST = Object.freeze([
   // AGENTHERO ACTIONS — aparecen solo en menú Ⓐ del AgentHero
   // ═══════════════════════════════════════════════════════════════════════
   {
+    // CONTENIDO DE APRENDIZAJE (descubribilidad 2026-06-24): la rama "aprender"
+    // de la mano era SOLO `deep` (status:'soon' → no-op, solo toast). Esta hoja
+    // LIVE la conecta al contenido real de aprendizaje (módulo "Aprende con el
+    // agente", ruta 'aprende': 5 lecciones agroecológicas con fuente/DOI). Así
+    // la rama "Aprender" navega a algo real en vez de quedar muerta; `deep`
+    // sigue presente como stub honesto ("por lanzar"). No tiene `intent` → NO es
+    // chip, solo acción de la mano. Ref: CAPABILITIES_STATUS.md §7.4.
+    id: 'aprender_hub',
+    group: 'aprender',
+    status: 'live',
+    icon: '📚',
+    label: 'Aprender con el agente',
+    desc: 'Lecciones de agroecología con fuente: suelo, asociaciones, biopreparados, MIP, fenología.',
+    tool: null,
+    hero: true,
+    heroRoute: { kind: 'nav', view: 'aprende' },
+  },
+  {
     id: 'foto',
     group: 'observar',
     status: 'soon',
@@ -230,10 +265,21 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     tool: 'vision_identify',
     hero: true,
     heroRoute: { kind: 'photo' },
+    // stubMessage corregido 2026-06-24 (descubribilidad): el motivo anterior
+    // ("requiere GPU con ≥8GB VRAM") era FALSO — la GPU es de 12GB y la visión
+    // groundeada YA funciona dentro del chat (recognizeSpeciesGrounded /
+    // validate_visual_match). Lo que falta es cablear la foto-desde-la-mano al
+    // flujo de foto-en-chat; mientras tanto, en vez de mentir sobre el hardware,
+    // orientamos al usuario a la vía que SÍ funciona (foto dentro del chat) y a
+    // las alternativas (voz/manual). Se deja status:'soon' a propósito: promover
+    // la hoja de la mano a 'live' es más invasivo (requiere rutearla al
+    // compositor de foto del chat) y se hará en el replanteo. Ref:
+    // CAPABILITIES_STATUS.md §7.3 (foto soon con motivo falso).
     stubMessage:
-      'La identificación por foto necesita mejor hardware (GPU con ≥8GB VRAM). ' +
-      'Por ahora puedes usar la voz o el formulario manual para registrar tus plantas. ' +
-      'Próximamente estará disponible por la nube.',
+      'Para identificar una planta por foto, abre el chat de Chagra y envíale la ' +
+      'foto desde ahí: la reconoce y verifica contra el catálogo. Esa vía ya ' +
+      'funciona. También puedes registrarla por voz o con el formulario manual. ' +
+      'El acceso directo por foto desde este menú llegará pronto.',
   },
   {
     // MÓDULO UNIFICADO de voz (2026-06-15): único punto de entrada desde la mano


### PR DESCRIPTION
## Feature
Sprint de **descubribilidad** (CAPABILITIES_STATUS.md §2/§4/§7): borrar código de navegación muerto, rescatar capacidades huérfanas a la home viva y reparar las ramas muertas de la mano radial. Cambios **aditivos y limpios** — el layout lo reorganizará un rediseño posterior; esto no rediseña, solo rescata/rutea.

## Cambios

### a) Código muerto borrado (`src/App.jsx`)
- `DashboardView` + `NAV_TILES` + `ACCENT_CLASSES` **nunca se renderizaban** (`case 'dashboard'` monta `DashboardLiveView`). Borrados.
- Imports huérfanos eliminados: `useScrollRestoration`, `useMemo`, `TelemetryAlerts`, `WelcomeStatsHero`, `OnboardingHero` (lazy), `CaseStudyTopWidget` (lazy) y 10 íconos lucide sin uso.
- Las rutas `casos`/`caso_detail`/`javier`/`usage_stats` siguen **vivas** en el router y por hash.

### b) Huérfanos rescatados a la home viva (`DashboardLive.jsx`)
- **casos** → nuevo tile en "Herramientas de finca" + `CaseStudyTopWidget` rescatado (se auto-oculta sin casos activos, zero footprint).
- **ciclo_nutrientes** → nuevo tile (antes solo accesible desde dentro de `AnimalesScreen`).
- **biopreparados** → nuevo tile; su `onBack` ahora respeta `currentViewData.back` (vuelve al **dashboard** desde la home; sigue volviendo al **juego** desde la misión, back-compat).
- **cosechar / insumos / mantenimiento** → nuevo bloque "Registrar en la finca" (antes sin launcher directo).
- **javier** (`WorkerDashboard`) → entrada **gateada al operador** (vista de supervisor/trabajador, nicho).

### c) Ramas muertas de la mano reparadas (`agentCapabilities.js`)
- **"aprender"** era solo `deep[soon]` (no-op): se añade `aprender_hub[live]` → ruta `aprende` (5 lecciones con fuente/DOI). `deep` se conserva como stub honesto.
- **"vender"** era solo `precio[soon]` (no-op): `precio` pasa a `hero:false` → la rama **desaparece** de la mano (sin backing real). `precio` sigue siendo **chip honesto** en el toolbar (orienta a SIPSA/Corabastos).

### d) Foto reconciliada
- El `stubMessage` de "Agregar planta por foto" decía **falsamente** "requiere GPU ≥8GB". La GPU es de 12GB y la visión groundeada **ya corre en el chat**. Se **corrige el mensaje** (orienta a la foto-en-chat que sí funciona) y se mantiene `status:'soon'` — promover la hoja a `live` requiere rutearla al compositor de foto del chat (más invasivo, se hará en el replanteo). Decisión **segura**: cero mentira, cero riesgo.

### e) #mapa investigado
- **Verificado: `#mapa` NO colapsa a Activos.** `FarmMap` renderiza el mapa real (Leaflet, centrado en la finca) y muestra un aviso honesto cuando no hay activos georreferenciados. El único salto a `activos` es el drill-down al tocar un activo. La premisa de "colapso" era un hallazgo de auditoría stale. Se documenta en el `case 'mapa'` (no se tocó `FarmMap` para no arrastrar deuda de lint pre-existente ajena a esta tarea).

## Decisiones tomadas
- **foto**: opción segura → corregir el `stubMessage` mentiroso, mantener `soon`. Promover a `live` lo bloqueaban tests (`capabilityHealth.test.js` ancla `foto`→`soon`) y es más invasivo.
- **vender**: quitar la rama de la mano (`hero:false`), conservar `precio` como chip honesto (tests lo anclan a `soon`).
- **javier**: rescatado gateado al operador (nicho), no al campesino.

## Tests
- 138 vitest passing (dashboard + capability + chip + App routes): `capabilityHealth`, `agentCapabilities.audit`, `ChipsToolbar.smoke`, `agentUserFlow.smoke`, `DashboardLive.*`, `AgentRedMenu.smoke`, `App.*-route`.
- `eslint --max-warnings=0` limpio en los 4 archivos cambiados.
- Invariante de la mano verificado: 0 hero dead-ends; `aprender` tiene hoja live; `vender` ya no existe en la mano.

Refs: CAPABILITIES_STATUS.md §2 (huérfanos), §4 (deuda navegación), §7.3 (foto soon falso), §7.4 (ramas muertas mano)

🤖 Generated with [Claude Code](https://claude.com/claude-code)