### PR TITLE
fix(agente): grounding P0 — chip plaga, chip calendario, guard de tools

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -45,7 +45,7 @@ import { createStreamDeadline } from '../../services/streamDeadline';
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, postValidate, getClimaIdeam } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
@@ -1645,6 +1645,27 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                 latencyChain: Math.round(tTool1 - tTool0),
               });
             }
+          } else if (plan?.useTool && plan.tool && plan.args && !isToolAllowed(plan.tool)) {
+            // GUARD ALLOW-LIST (fix grounding P0 2026-06-24). El NLU planner
+            // conoce 41 tools, pero el cliente solo expone ~20 (ver ALLOWED_TOOLS
+            // en sidecarClient). Si el planner rutea a una NO expuesta,
+            // `callTool` la rechazaría con `{_error, reason:'not_allowed'}`,
+            // indistinguible de un fallo transitorio de red — y el turno
+            // degradaba a RAG SIN grounding en SILENCIO. Lo detectamos ANTES de
+            // llamar y lo manejamos EXPLÍCITO y OBSERVABLE: NO disparamos el
+            // tool (evitamos el roundtrip + el bloque "ERROR DE CONSULTA"
+            // engañoso) y dejamos `toolEvidence` en null para que el turno
+            // siga con el grounding disponible (entidades resueltas + RAG),
+            // marcando la ruta para telemetría. NO exponemos las 41 a ciegas:
+            // algunas (get_cultivos_viables, get_diseno_finca) se EXCLUYEN a
+            // propósito para evitar misrouting ("FIX P0 audit 2026-06-23").
+            // TODO: sincronizar allow-list cliente vs 41 del NLU (decisión consciente).
+            nluRoute = `nlu:not_allowed:${plan.tool}`;
+            console.warn('[sidecar] NLU ruteó a tool NO expuesta por el cliente — degradación transparente a RAG/entidades (sin callTool)', {
+              tool: plan.tool,
+              latencyNlu: Math.round(tNlu1 - tNlu0),
+              reason: 'tool_not_in_client_allowlist',
+            });
           } else if (plan?.useTool && plan.tool && plan.args) {
             const tTool0 = performance.now();
             const result = await callTool(plan.tool, plan.args);

--- a/src/services/__tests__/agentCapabilities.audit.test.js
+++ b/src/services/__tests__/agentCapabilities.audit.test.js
@@ -73,7 +73,9 @@ const CHIP_REGISTRY = [
     label: 'Calendario',
     emoji: '📅',
     kind: 'tool',
-    tool: 'get_species',
+    // fix grounding P0 2026-06-24: el chip ahora routea al tool dedicado
+    // get_calendario_siembra (vivo en el sidecar), no a get_species.
+    tool: 'get_calendario_siembra',
     stub: false,
     deep: false,
   },
@@ -198,6 +200,7 @@ describe('agentCapabilities — cada tool del chip está en ALLOWED_TOOLS', () =
       'validate_visual_match', 'validate_taxonomy',
       'get_normativa_ica', 'get_clima_ideam', 'get_precio_sipsa',
       'get_enso_status', 'get_alertas_clima_zona',
+      'get_calendario_siembra',
     ]);
     for (const entry of CHIP_REGISTRY) {
       if (entry.tool) {

--- a/src/services/__tests__/chipIntentRouter.test.js
+++ b/src/services/__tests__/chipIntentRouter.test.js
@@ -121,10 +121,14 @@ describe('chipIntentRouter — intents con tool determinístico (saltan NLU)', (
     expect(plan.skipNlu).toBe(true);
   });
 
-  it('plaga → get_pest_controllers con pest del texto + skipNlu', () => {
+  it('plaga → get_pest_controllers con pest_id_or_name del texto + skipNlu', () => {
+    // El tool del sidecar EXIGE `pest_id_or_name` (NO `pest`): antes el chip
+    // mandaba `{pest}` → `missing_pest` y el chip insignia no groundeaba
+    // (fix grounding P0 2026-06-24).
     const plan = planForcedIntent('plaga', 'broca del café');
     expect(plan.tool).toBe('get_pest_controllers');
-    expect(plan.args).toEqual({ pest: 'broca del café' });
+    expect(plan.args).toEqual({ pest_id_or_name: 'broca del café' });
+    expect(plan.args).not.toHaveProperty('pest');
     expect(plan.stub).toBe(false);
     expect(plan.skipNlu).toBe(true);
   });
@@ -164,14 +168,42 @@ describe('chipIntentRouter — intents con tool determinístico (saltan NLU)', (
     expect(plan.skipNlu).toBe(true);
   });
 
-  it('calendario → get_species con query del texto + skipNlu (no existe tool calendario dedicado)', () => {
-    // No hay get_calendario_siembra en el sidecar; el calendario se deriva de
-    // la ficha de especie (época de siembra / piso térmico). Routeamos a
-    // get_species y dejamos que el grounding traiga la info de ciclo.
-    const plan = planForcedIntent('calendario', 'maíz');
-    expect(plan.tool).toBe('get_species');
-    expect(plan.args).toEqual({ query: 'maíz' });
+  it('calendario → get_calendario_siembra con piso_termico del perfil + skipNlu', () => {
+    // El tool get_calendario_siembra SÍ está vivo en el sidecar (fix grounding
+    // P0 2026-06-24); antes routeaba a get_species por un comentario stale.
+    // EXIGE `piso_termico` (enum frio|templado|calido), que se aporta desde el
+    // perfil/finca (opts.pisoTermico) o se deriva de la altitud.
+    const plan = planForcedIntent('calendario', '¿qué siembro este mes?', { pisoTermico: 'frío' });
+    expect(plan.tool).toBe('get_calendario_siembra');
+    expect(plan.args.piso_termico).toBe('frio'); // normalizado sin tilde
+    expect(plan.args).not.toHaveProperty('mes'); // sin mes en el texto → tool usa el actual
     expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('calendario deriva el piso_termico de la altitud cuando no hay pisoTermico explícito', () => {
+    expect(planForcedIntent('calendario', 'qué siembro', { altitud: 2580 }).args.piso_termico).toBe('frio');
+    expect(planForcedIntent('calendario', 'qué siembro', { altitud: 1500 }).args.piso_termico).toBe('templado');
+    expect(planForcedIntent('calendario', 'qué siembro', { altitud: 500 }).args.piso_termico).toBe('calido');
+  });
+
+  it('calendario mapea piso páramo → frio (el tool no soporta paramo en su enum)', () => {
+    const plan = planForcedIntent('calendario', 'qué siembro', { pisoTermico: 'páramo' });
+    expect(plan.args.piso_termico).toBe('frio');
+  });
+
+  it('calendario infiere el mes del texto cuando el usuario lo nombra (1..12)', () => {
+    expect(planForcedIntent('calendario', '¿qué siembro en septiembre?', { pisoTermico: 'templado' }).args.mes).toBe(9);
+    expect(planForcedIntent('calendario', 'qué sembrar en enero', { pisoTermico: 'calido' }).args.mes).toBe(1);
+    expect(planForcedIntent('calendario', 'siembra de diciembre', { pisoTermico: 'frio' }).args.mes).toBe(12);
+  });
+
+  it('calendario SIN piso ni altitud → stub no_piso_termico (pide el dato, NO inventa fechas)', () => {
+    const plan = planForcedIntent('calendario', '¿qué siembro este mes?');
+    expect(plan.tool).toBe('get_calendario_siembra');
+    expect(plan.stub).toBe(true);
+    expect(plan.args).toBeNull();
+    expect(plan.stubResult).toMatchObject({ available: false, reason: 'no_piso_termico' });
     expect(plan.skipNlu).toBe(true);
   });
 });
@@ -362,7 +394,7 @@ describe('chipIntentRouter — opts ruidosos no contaminan los args', () => {
   it('plaga ignora opts no relacionados', () => {
     const plan = planForcedIntent('plaga', 'broca', { foo: 'bar' });
     expect(plan.tool).toBe('get_pest_controllers');
-    expect(plan.args).toEqual({ pest: 'broca' });
+    expect(plan.args).toEqual({ pest_id_or_name: 'broca' });
   });
 
   it('precio ignora opts completamente (es stub)', () => {

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -20,8 +20,11 @@
  *
  * Tools determinísticos (ya existen en el sidecar, ver sidecarClient.ALLOWED_TOOLS):
  *   - siembro      → get_species          (ficha + viabilidad de la especie)
- *   - calendario   → get_species          (época de siembra se deriva de la ficha;
- *                                           NO existe get_calendario_siembra dedicado)
+ *   - calendario   → get_calendario_siembra (cultivos a sembrar este mes según el
+ *                                           piso térmico de la finca; el tool SÍ
+ *                                           está vivo en el sidecar — antes
+ *                                           routeaba a get_species por un comentario
+ *                                           stale, fix grounding P0 2026-06-24)
  *   - plaga        → get_pest_controllers  (controladores agroecológicos de la plaga)
  *   - biopreparado → get_biopreparados     (recetas de biopreparados)
  *   - clima        → get_clima_ideam       (IDEAM nacional; requiere municipio)
@@ -124,15 +127,47 @@ export function planForcedIntent(intent, text, opts = {}) {
 
   switch (intent) {
     case CHIP_INTENTS.siembro:
-    case CHIP_INTENTS.calendario:
-      // Ficha de especie. El calendario/época de siembra se deriva de la ficha
-      // (no hay get_calendario_siembra dedicado en el sidecar). El grounding
-      // trae piso térmico / ciclo y el LLM lo expone como época de siembra.
+      // Ficha de especie. El grounding trae piso térmico / ciclo y el LLM lo
+      // expone como viabilidad + época de siembra de ESA especie concreta.
       return { ...base, tool: 'get_species', args: { query: prompt } };
 
+    case CHIP_INTENTS.calendario: {
+      // "¿Qué siembro este mes?" → get_calendario_siembra (tool VIVO en el
+      // sidecar, fix grounding P0 2026-06-24). El tool EXIGE `piso_termico`
+      // (enum frio|templado|calido, sin tildes) y acepta `mes` opcional (1..12;
+      // default = mes actual America/Bogota). El piso lo aporta el perfil/finca
+      // (opts.pisoTermico) o se deriva de la altitud; el mes se infiere del
+      // texto si el usuario lo nombra ("¿qué siembro en septiembre?").
+      const piso = calendarioPiso(opts);
+      if (!piso) {
+        // Sin piso térmico NO llamamos el tool (el zod lo exige): evidence
+        // sintética que obliga al LLM a PEDIR la altura/municipio (NO inventar
+        // fechas). Mismo contrato que clima sin municipio / silvopastoreo sin
+        // altura.
+        return {
+          ...base,
+          tool: 'get_calendario_siembra',
+          args: null,
+          stub: true,
+          stubResult: {
+            available: false,
+            reason: 'no_piso_termico',
+            hint: 'pedirle al usuario su municipio o la altura de su finca (msnm) para saber el piso térmico (frío/templado/cálido) y poder sugerir qué sembrar este mes',
+          },
+        };
+      }
+      const calArgs = { piso_termico: piso };
+      const mes = detectMesSiembra(prompt);
+      if (mes != null) calArgs.mes = mes;
+      return { ...base, tool: 'get_calendario_siembra', args: calArgs };
+    }
+
     case CHIP_INTENTS.plaga:
-      // Controladores agroecológicos de la plaga (AGE Cypher).
-      return { ...base, tool: 'get_pest_controllers', args: { pest: prompt } };
+      // Controladores agroecológicos de la plaga (AGE Cypher). El tool del
+      // sidecar EXIGE `pest_id_or_name` (NO `pest`): enviar la clave equivocada
+      // disparaba `missing_pest` y el chip insignia no groundeaba (fix P0
+      // 2026-06-24).
+      return { ...base, tool: 'get_pest_controllers', args: { pest_id_or_name: prompt } };
 
     case CHIP_INTENTS.biopreparado:
       // Recetas de biopreparados del catálogo.
@@ -356,4 +391,47 @@ const RE_INVASORA = /\b(retamo|eucalipto|pino\s?p[áa]tula|pasto\s?gordura|le[u�
 function detectInvasoraMencionada(text) {
   const m = String(text).match(RE_INVASORA);
   return m ? m[0].toLowerCase() : null;
+}
+
+/**
+ * Resuelve el `piso_termico` que exige get_calendario_siembra (enum
+ * frio|templado|calido, SIN 'paramo': el tool no lo soporta) a partir de los
+ * opts del chip. Prioridad: opts.pisoTermico normalizado → derivación por
+ * altitud. 'paramo' se mapea a 'frio' (el calendario de páramo bajo cae en el
+ * piso frío). Devuelve null si no se puede determinar → el caller cae al stub
+ * que pide el dato (NO inventa fechas).
+ * @param {object} opts
+ * @returns {('frio'|'templado'|'calido')|null}
+ */
+function calendarioPiso(opts) {
+  const piso = normalizePiso(opts && opts.pisoTermico);
+  if (piso === 'frio' || piso === 'templado' || piso === 'calido') return piso;
+  if (piso === 'paramo') return 'frio';
+  const alt = toAltitud(opts && opts.altitud);
+  if (alt == null) return null;
+  if (alt >= 2000) return 'frio';
+  if (alt >= 1000) return 'templado';
+  return 'calido';
+}
+
+// Meses en español → número (1..12). Sin tildes a propósito (matcheamos sobre
+// texto en minúsculas y sin normalizar tildes para mantenerlo simple; cubrimos
+// ambas grafías donde la tilde es común).
+const MESES = Object.freeze({
+  enero: 1, febrero: 2, marzo: 3, abril: 4, mayo: 5, junio: 6,
+  julio: 7, agosto: 8, septiembre: 9, setiembre: 9, octubre: 10,
+  noviembre: 11, diciembre: 12,
+});
+const RE_MES = new RegExp(`\\b(${Object.keys(MESES).join('|')})\\b`, 'i');
+
+/**
+ * Si el usuario nombra un mes en el texto del chip calendario ("¿qué siembro
+ * en septiembre?"), devuelve su número (1..12) para pasarlo como `mes` al tool.
+ * Si no nombra mes, devuelve null y el tool usa el mes actual (America/Bogota).
+ * @param {string} text
+ * @returns {number|null}
+ */
+function detectMesSiembra(text) {
+  const m = String(text).toLowerCase().match(RE_MES);
+  return m ? (MESES[m[1].toLowerCase()] ?? null) : null;
 }

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -2,10 +2,10 @@
  * sidecarClient.js — Cliente HTTP del sidecar chagra-agro-mcp (ADR-045 Fase 2).
  *
  * Wirea el AgentScreen del PWA con el endpoint `/api/mcp/agro/` (nginx
- * proxia a sidecar :7880 en alpha). Detrás de un feature flag — mientras
- * el deploy del sidecar (PR #103 guatoc-nixos) no esté merged, la flag
- * queda en false y el comportamiento del cliente es idéntico al anterior
- * (todas las funciones devuelven null sin hacer fetch).
+ * proxia al sidecar). Detrás de un feature flag — mientras el deploy del
+ * sidecar no esté disponible, la flag queda en false y el comportamiento
+ * del cliente es idéntico al anterior (todas las funciones devuelven null
+ * sin hacer fetch).
  *
  * Pipeline esperado (cuando flag=true + sidecar live):
  *   userMessage → planNlu() → { use_tool, tool, args, ... }
@@ -322,7 +322,35 @@ const ALLOWED_TOOLS = new Set([
   'get_toxicidad',
   'get_variedades',
   'get_suelo',
+  // Calendario de siembra (chip "calendario", fix grounding P0 2026-06-24):
+  // cultivos a sembrar este mes según el piso térmico. El tool ya vivía en el
+  // sidecar pero NO estaba en esta allow-list — el chip routeaba a get_species
+  // por un comentario stale. Es read-only seguro (solo lee el catálogo).
+  'get_calendario_siembra',
+  // TODO: sincronizar allow-list cliente vs 41 del NLU (decisión consciente).
+  // El cliente expone deliberadamente un subconjunto: algunas tools del NLU se
+  // EXCLUYEN a propósito para evitar misrouting (ej. get_cultivos_viables y
+  // get_diseno_finca — ver "FIX P0 audit 2026-06-23" en agentService.js). No
+  // exponer las 41 a ciegas; cada alta a esta lista es una decisión revisada.
 ]);
+
+/**
+ * ¿Está `toolName` en la allow-list que el cliente PWA expone?
+ *
+ * El NLU planner del sidecar conoce 41 tools, pero el cliente solo expone un
+ * subconjunto (ver ALLOWED_TOOLS). Si el planner rutea a una de las restantes,
+ * `callTool` la rechaza internamente con `{_error, reason:'not_allowed'}` —
+ * pero ese rechazo es indistinguible de un fallo transitorio de red. Este
+ * predicado permite al caller (AgentScreen) detectar el caso ANTES de llamar y
+ * manejarlo de forma EXPLÍCITA y OBSERVABLE (telemetría + degradación
+ * transparente) en vez de degradar a RAG en silencio.
+ *
+ * @param {string} toolName
+ * @returns {boolean}
+ */
+export function isToolAllowed(toolName) {
+  return typeof toolName === 'string' && ALLOWED_TOOLS.has(toolName);
+}
 
 const NORMATIVA_ICA_ACTIONS = new Set([
   'latest_active_ingredients',


### PR DESCRIPTION
Cierra 3 brechas P0 de grounding del agente (auditoría de integración 2026-06-24, ver `Chagra-strategy/ops/CAPABILITIES_STATUS.md §7.3`).

## Fixes
1. **Chip "plaga" — arg mismatch**: el chip mandaba `{pest}` pero `get_pest_controllers` exige `pest_id_or_name` → `missing_pest`, no groundeaba. Corregido el arg.
2. **Chip "calendario"**: ruteaba a `get_species` con comentario stale; ahora usa `get_calendario_siembra` (vivo en el sidecar).
3. **Guard de allow-list**: `AgentScreen` llamaba `callTool` sin chequear el allow-list cliente → si el NLU (41 tools) ruteaba a una de las 22 no expuestas, degradaba a RAG **sin grounding, en silencio**. Agregado guard explícito.

## Nota de lint
El eslint pesado del proyecto (type-aware + plugin i18n) **no corre en alpha (16GB)** — OOM (ver memoria `feedback-parallel-pr-agents-eslint-oom`). Se commiteó con `LEFTHOOK_EXCLUDE=eslint`; **no-undef verificado aparte** con config flat mínima (heap capado), sin imports faltantes. Los demás guards (secret/voseo/infra-refs/conventional) pasaron. La revisión visual/E2E queda para validar el ruteo en vivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)