### PR TITLE
fix(onboarding): per-user keying del perfil — usuarios nuevos ya no heredan perfil global

### DIFF
--- a/src/services/__tests__/userProfileService.test.js
+++ b/src/services/__tests__/userProfileService.test.js
@@ -24,6 +24,7 @@ import {
   setModuleOrder,
   hasManualModuleOrder,
   __PROFILE_KEYS__,
+  _resetProfileMigration,
 } from '../userProfileService.js';
 
 describe('userProfileService (#200)', () => {
@@ -596,5 +597,146 @@ describe('orden de módulos del Home (reorder por drag, 2026-06-15)', () => {
       setModuleOrder(desired);
       expect(getModuleOrder().slice(0, 4)).toEqual(desired);
     });
+  });
+});
+
+describe('per-user keying del perfil (onboarding por usuario)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetProfileMigration();
+  });
+
+  it('sin usuario logueado usa claves globales (comportamiento actual)', () => {
+    saveProfile({ nombre: 'Test' });
+    expect(localStorage.getItem('chagra:profile:v1')).toBeTruthy();
+    expect(getProfile().nombre).toBe('Test');
+    expect(hasSeenProfileOnboarding()).toBe(false);
+    markProfileDone();
+    expect(hasSeenProfileOnboarding()).toBe(true);
+  });
+
+  it('usuario logueado usa claves con sufijo del tenantId', () => {
+    localStorage.setItem('chagra:active_tenant_id', 'alice');
+    saveProfile({ nombre: 'Alice' });
+    // El perfil se guarda bajo clave per-user, no global
+    expect(localStorage.getItem('chagra:profile:v1:alice')).toBeTruthy();
+    expect(localStorage.getItem('chagra:profile:v1')).toBeNull();
+    expect(getProfile().nombre).toBe('Alice');
+  });
+
+  it('done/skipped keys tambien llevan sufijo por usuario', () => {
+    localStorage.setItem('chagra:active_tenant_id', 'alice');
+    expect(hasSeenProfileOnboarding()).toBe(false);
+    markProfileDone();
+    expect(localStorage.getItem('chagra:profile:done:v1:alice')).toBe('1');
+    expect(localStorage.getItem('chagra:profile:done:v1')).toBeNull();
+    expect(hasSeenProfileOnboarding()).toBe(true);
+
+    _resetProfileMigration();
+    localStorage.setItem('chagra:active_tenant_id', 'bob');
+    expect(hasSeenProfileOnboarding()).toBe(false);
+  });
+
+  it('dos usuarios logueados no comparten perfil', () => {
+    localStorage.setItem('chagra:active_tenant_id', 'alice');
+    saveProfile({ nombre: 'Alice' });
+    markProfileDone();
+    expect(hasSeenProfileOnboarding()).toBe(true);
+
+    // Cambiar a otro usuario
+    _resetProfileMigration();
+    localStorage.setItem('chagra:active_tenant_id', 'bob');
+    const bobProfile = getProfile();
+    expect(bobProfile).toEqual({});
+    expect(bobProfile.nombre).toBeUndefined();
+    expect(hasSeenProfileOnboarding()).toBe(false);
+  });
+
+  it('saveProfile hace merge correcto con perfil per-user', () => {
+    localStorage.setItem('chagra:active_tenant_id', 'alice');
+    saveProfile({ nombre: 'Alice' });
+    saveProfile({ region: 'Cauca' });
+    const p = getProfile();
+    expect(p.nombre).toBe('Alice');
+    expect(p.region).toBe('Cauca');
+    expect(p.updatedAt).toBeTruthy();
+  });
+});
+
+describe('migracion suave de claves globales a per-user', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetProfileMigration();
+  });
+
+  it('usuario nuevo (sin clave propia) NO hereda clave global vieja', () => {
+    // Simular estado previo: claves globales del operador
+    localStorage.setItem('chagra:profile:v1', JSON.stringify({ nombre: 'Miguel', region: 'Choachí' }));
+    localStorage.setItem('chagra:profile:done:v1', '1');
+
+    // Ana entra al mismo navegador
+    localStorage.setItem('chagra:active_tenant_id', 'ana');
+    expect(hasSeenProfileOnboarding()).toBe(false);
+    expect(getProfile()).toEqual({});
+
+    // Las claves globales no deben haberse limpiado (aún hay anonymous fallback)
+    expect(localStorage.getItem('chagra:profile:v1')).toBeTruthy();
+  });
+
+  it('usuario sin VITE_OPERATOR_USERNAME no migra (seguro por defecto)', () => {
+    // Sin env var de operador, nadie migra
+    localStorage.setItem('chagra:profile:v1', JSON.stringify({ nombre: 'Op' }));
+    localStorage.setItem('chagra:profile:done:v1', '1');
+
+    localStorage.setItem('chagra:active_tenant_id', 'cualquier');
+    expect(getProfile()).toEqual({});
+    expect(hasSeenProfileOnboarding()).toBe(false);
+  });
+
+  it('migra datos globales al perfil del operador cuando coincide VITE_OPERATOR_USERNAME', () => {
+    localStorage.setItem('chagra:profile:v1', JSON.stringify({ nombre: 'Op', region: 'Cauca' }));
+    localStorage.setItem('chagra:profile:done:v1', '1');
+
+    // Simular que el operador se loguea
+    import.meta.env.VITE_OPERATOR_USERNAME = 'operador';
+    localStorage.setItem('chagra:active_tenant_id', 'operador');
+
+    expect(hasSeenProfileOnboarding()).toBe(true);
+    const p = getProfile();
+    expect(p.nombre).toBe('Op');
+    expect(p.region).toBe('Cauca');
+
+    // Claves globales se limpiaron tras la migración
+    expect(localStorage.getItem('chagra:profile:v1')).toBeNull();
+    expect(localStorage.getItem('chagra:profile:done:v1')).toBeNull();
+
+    delete import.meta.env.VITE_OPERATOR_USERNAME;
+  });
+
+  it('migracion con múltiples operadores (VITE_OPERATOR_USERNAME lista separada por coma)', () => {
+    localStorage.setItem('chagra:profile:v1', JSON.stringify({ nombre: 'Richi' }));
+    localStorage.setItem('chagra:profile:done:v1', '1');
+
+    import.meta.env.VITE_OPERATOR_USERNAME = 'miguel,richi,ana';
+    localStorage.setItem('chagra:active_tenant_id', 'richi');
+
+    expect(hasSeenProfileOnboarding()).toBe(true);
+    expect(getProfile().nombre).toBe('Richi');
+    expect(localStorage.getItem('chagra:profile:v1')).toBeNull();
+
+    delete import.meta.env.VITE_OPERATOR_USERNAME;
+  });
+
+  it('migracion respeta case-insensitive en username', () => {
+    localStorage.setItem('chagra:profile:v1', JSON.stringify({ nombre: 'Admin' }));
+    localStorage.setItem('chagra:profile:done:v1', '1');
+
+    import.meta.env.VITE_OPERATOR_USERNAME = 'Admin';
+    localStorage.setItem('chagra:active_tenant_id', 'admin');
+
+    expect(hasSeenProfileOnboarding()).toBe(true);
+    expect(getProfile().nombre).toBe('Admin');
+
+    delete import.meta.env.VITE_OPERATOR_USERNAME;
   });
 });

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -26,6 +26,7 @@
  */
 
 import { findMunicipio } from '../utils/colombiaLocations.js';
+import { getActiveTenantId } from './tenantContext.js';
 
 const PROFILE_PREFIX = 'chagra:profile:';
 const PROFILE_KEY = `${PROFILE_PREFIX}v1`;
@@ -33,6 +34,91 @@ const PROFILE_DONE_KEY = `${PROFILE_PREFIX}done:v1`;
 const PROFILE_SKIPPED_KEY = `${PROFILE_PREFIX}skipped:v1`;
 
 const hasStorage = () => typeof window !== 'undefined' && !!window.localStorage;
+
+/**
+ * Deriva un userKey estable del usuario logueado (farmOS username).
+ * @returns {string|null} username del tenant activo, o null si no hay sesión.
+ */
+function getUserKey() {
+  try {
+    const id = getActiveTenantId();
+    return id && typeof id === 'string' && id.trim().length > 0 ? id.trim() : null;
+  } catch { return null; }
+}
+
+function getProfileKey() {
+  const uk = getUserKey();
+  return uk ? `${PROFILE_KEY}:${uk}` : PROFILE_KEY;
+}
+
+function getProfileDoneKey() {
+  const uk = getUserKey();
+  return uk ? `${PROFILE_DONE_KEY}:${uk}` : PROFILE_DONE_KEY;
+}
+
+function getProfileSkippedKey() {
+  const uk = getUserKey();
+  return uk ? `${PROFILE_SKIPPED_KEY}:${uk}` : PROFILE_SKIPPED_KEY;
+}
+
+/** @type {boolean} flag module-level para ejecutar la migración una sola vez. */
+let _migrated = false;
+
+function _getOperatorUsernames() {
+  try {
+    return (import.meta.env.VITE_OPERATOR_USERNAME || '')
+      .split(',')
+      .map(s => s.trim().toLowerCase())
+      .filter(Boolean);
+  } catch { return []; }
+}
+
+function _cleanupLegacyKeys() {
+  try {
+    window.localStorage.removeItem(PROFILE_KEY);
+    window.localStorage.removeItem(PROFILE_DONE_KEY);
+    window.localStorage.removeItem(PROFILE_SKIPPED_KEY);
+  } catch (_) { /* noop */ }
+}
+
+/**
+ * Migración suave: si existe la clave GLOBAL vieja y NO existe la del
+ * usuario actual, NO la hereda para usuarios nuevos (que vean onboarding).
+ * Solo migra si el usuario actual es identificable como operador via
+ * VITE_OPERATOR_USERNAME. Si no hay usuario logueado (pre-login), mantiene
+ * el comportamiento actual con claves globales.
+ */
+function migrateLegacyProfile() {
+  if (!hasStorage() || _migrated) return;
+  _migrated = true;
+
+  const uk = getUserKey();
+  if (!uk) return;
+
+  const oldDone = window.localStorage.getItem(PROFILE_DONE_KEY);
+  const oldSkipped = window.localStorage.getItem(PROFILE_SKIPPED_KEY);
+  const oldProfile = window.localStorage.getItem(PROFILE_KEY);
+
+  if (!oldDone && !oldSkipped && !oldProfile) return;
+
+  // Si el usuario ya tiene datos per-user, solo limpiar legado
+  const hasUserDone = window.localStorage.getItem(getProfileDoneKey());
+  const hasUserSkipped = window.localStorage.getItem(getProfileSkippedKey());
+  if (hasUserDone || hasUserSkipped) {
+    _cleanupLegacyKeys();
+    return;
+  }
+
+  // Solo migrar si el usuario actual es el operador
+  const opNames = _getOperatorUsernames();
+  if (opNames.length > 0 && opNames.includes(uk.toLowerCase())) {
+    if (oldDone) window.localStorage.setItem(getProfileDoneKey(), oldDone);
+    if (oldSkipped) window.localStorage.setItem(getProfileSkippedKey(), oldSkipped);
+    if (oldProfile) window.localStorage.setItem(getProfileKey(), oldProfile);
+    _cleanupLegacyKeys();
+  }
+  // Usuarios nuevos (no operador): NO heredan — ven onboarding.
+}
 
 /**
  * Catálogo de preguntas del onboarding extendido.
@@ -357,8 +443,10 @@ export function getApplicableQuestions(answers = {}) {
  */
 export function getProfile() {
   if (!hasStorage()) return {};
+  migrateLegacyProfile();
+  const key = getProfileKey();
   try {
-    const raw = window.localStorage.getItem(PROFILE_KEY);
+    const raw = window.localStorage.getItem(key);
     if (!raw) return {};
     const parsed = JSON.parse(raw);
     return parsed && typeof parsed === 'object' ? parsed : {};
@@ -453,10 +541,11 @@ export function resolveAltitudToSave({
  */
 export function saveProfile(partial = {}) {
   if (!hasStorage()) return { ...partial };
+  migrateLegacyProfile();
   const current = getProfile();
   const next = { ...current, ...partial, updatedAt: new Date().toISOString() };
   try {
-    window.localStorage.setItem(PROFILE_KEY, JSON.stringify(next));
+    window.localStorage.setItem(getProfileKey(), JSON.stringify(next));
   } catch (e) {
     console.warn('[userProfile] No se pudo guardar el perfil:', e);
   }
@@ -507,8 +596,9 @@ export function setNotificationStyle(style) {
 /** Marca el onboarding de perfil como completado. */
 export function markProfileDone() {
   if (!hasStorage()) return;
+  migrateLegacyProfile();
   try {
-    window.localStorage.setItem(PROFILE_DONE_KEY, '1');
+    window.localStorage.setItem(getProfileDoneKey(), '1');
   } catch (e) {
     console.warn('[userProfile] markProfileDone:', e);
   }
@@ -531,8 +621,9 @@ export function markProfileDone() {
 /** Marca que el usuario saltó el onboarding (respeta #283). */
 export function markProfileSkipped() {
   if (!hasStorage()) return;
+  migrateLegacyProfile();
   try {
-    window.localStorage.setItem(PROFILE_SKIPPED_KEY, '1');
+    window.localStorage.setItem(getProfileSkippedKey(), '1');
   } catch (e) {
     console.warn('[userProfile] markProfileSkipped:', e);
   }
@@ -541,9 +632,10 @@ export function markProfileSkipped() {
 /** @returns {boolean} si el usuario ya completó o saltó el onboarding. */
 export function hasSeenProfileOnboarding() {
   if (!hasStorage()) return false;
+  migrateLegacyProfile();
   return (
-    window.localStorage.getItem(PROFILE_DONE_KEY) === '1' ||
-    window.localStorage.getItem(PROFILE_SKIPPED_KEY) === '1'
+    window.localStorage.getItem(getProfileDoneKey()) === '1' ||
+    window.localStorage.getItem(getProfileSkippedKey()) === '1'
   );
 }
 
@@ -1019,3 +1111,8 @@ export const __PROFILE_KEYS__ = {
   PROFILE_SKIPPED_KEY,
   TELEMETRY_CONSENT_KEY,
 };
+
+/** Resetea el flag de migración para tests. */
+export function _resetProfileMigration() {
+  _migrated = false;
+}


### PR DESCRIPTION
Bug: el perfil de onboarding se guardaba GLOBAL en localStorage
(claves chagra:profile:v1, chagra:profile:done:v1, chagra:profile:skipped:v1).
Un usuario nuevo en el mismo navegador heredaba el perfil del operador
y no veia el onboarding.

Fix:
1. Keying POR USUARIO: se deriva userKey del tenantId (username farmOS)
   via getActiveTenantId(). Las claves pasan a:
   - chagra:profile:v1:<userKey>
   - chagra:profile:done:v1:<userKey>
   - chagra:profile:skipped:v1:<userKey>
2. Migracion suave: si existe clave GLOBAL vieja y NO existe la del
   usuario actual, NO se hereda. Solo migra si el usuario actual es
   el operador (coincide con VITE_OPERATOR_USERNAME).
3. Sin usuario logueado (pre-login): mantiene comportamiento actual
   con claves globales (sin romper).
4. Tests unitarios del keying y migracion (73 tests, 10 nuevos).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
