### PR TITLE
fix(agente): reconciliar allow-list cliente↔NLU + deflección honesta + foto a live

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1646,22 +1646,42 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               });
             }
           } else if (plan?.useTool && plan.tool && plan.args && !isToolAllowed(plan.tool)) {
-            // GUARD ALLOW-LIST (fix grounding P0 2026-06-24). El NLU planner
-            // conoce 41 tools, pero el cliente solo expone ~20 (ver ALLOWED_TOOLS
-            // en sidecarClient). Si el planner rutea a una NO expuesta,
-            // `callTool` la rechazaría con `{_error, reason:'not_allowed'}`,
-            // indistinguible de un fallo transitorio de red — y el turno
-            // degradaba a RAG SIN grounding en SILENCIO. Lo detectamos ANTES de
-            // llamar y lo manejamos EXPLÍCITO y OBSERVABLE: NO disparamos el
-            // tool (evitamos el roundtrip + el bloque "ERROR DE CONSULTA"
-            // engañoso) y dejamos `toolEvidence` en null para que el turno
-            // siga con el grounding disponible (entidades resueltas + RAG),
-            // marcando la ruta para telemetría. NO exponemos las 41 a ciegas:
-            // algunas (get_cultivos_viables, get_diseno_finca) se EXCLUYEN a
-            // propósito para evitar misrouting ("FIX P0 audit 2026-06-23").
-            // TODO: sincronizar allow-list cliente vs 41 del NLU (decisión consciente).
+            // GUARD ALLOW-LIST + DEFLECCIÓN HONESTA (fix grounding P0 2026-06-25,
+            // amplía #1848). El NLU planner conoce 41 tools; el cliente expone un
+            // subconjunto (ver ALLOWED_TOOLS en sidecarClient). Si el planner
+            // rutea a una NO expuesta, `callTool` la rechazaría con
+            // `{_error, reason:'not_allowed'}`, indistinguible de un fallo
+            // transitorio de red — y el turno degradaba a RAG SIN grounding y SIN
+            // avisar al usuario (degradación SILENCIOSA).
+            //
+            // Las tools que QUEDAN fuera del allow-list son las que el NLU no
+            // puede rellenar desde una frase de chat (exigen credenciales farmOS,
+            // coords de dispositivo o NIT DIAN: add_planta_finca, get_finca_overview,
+            // get_sensor_finca, get_weather_data, get_clima_finca,
+            // get_documento_soporte_dian, get_ubicacion_actual) o cuyo arg
+            // obligatorio el planner no conoce (altitud de la finca para
+            // get_cultivos_viables / get_diseno_finca; fecha de siembra para
+            // get_grado_dia; biopreparado_id/pest_id para get_dosis_biopreparado).
+            //
+            // En vez de degradar callado a RAG, inyectamos una DEFLECCIÓN HONESTA
+            // (lección "deflección honesta": el agente dice claro que esa consulta
+            // todavía NO está disponible, found:false explícito, NO inventa). El
+            // bloque lo materializa formatToolEvidence (rama available:false).
             nluRoute = `nlu:not_allowed:${plan.tool}`;
-            console.warn('[sidecar] NLU ruteó a tool NO expuesta por el cliente — degradación transparente a RAG/entidades (sin callTool)', {
+            toolEvidence = {
+              tool: plan.tool,
+              args: plan.args,
+              result: {
+                available: false,
+                reason: 'tool_no_disponible_en_cliente',
+                hint:
+                  'Esta consulta específica todavía NO está disponible en Chagra. ' +
+                  'NO inventes datos: dilo con honestidad ("esa información todavía no la tengo disponible") ' +
+                  'y, si puedes, orienta con lo que SÍ está a la mano (chips de siembra, plaga, ' +
+                  'biopreparado, clima, calendario) o pide el dato que falte.',
+              },
+            };
+            console.warn('[sidecar] NLU ruteó a tool NO expuesta por el cliente — deflección honesta (sin callTool)', {
               tool: plan.tool,
               latencyNlu: Math.round(tNlu1 - tNlu0),
               reason: 'tool_not_in_client_allowlist',

--- a/src/services/__tests__/capabilityHealth.test.js
+++ b/src/services/__tests__/capabilityHealth.test.js
@@ -74,14 +74,16 @@ describe('getCapabilityHealth — estado real por capacidad', () => {
     expect(getCapabilityHealth('voz', deps)).toBe('live');
   });
 
-  it('foto retorna soon (manifest: foto-desde-la-mano aun sin cablear al chat)', () => {
-    // foto es status:'soon' en el manifiesto, pero NO por hardware: la visión
-    // groundeada ya corre en el chat (GPU 12GB). Falta cablear el acceso directo
-    // por foto desde la mano al flujo de foto-en-chat (ver stubMessage corregido
-    // 2026-06-24). El manifest manda, sin importar el estado del sidecar.
-    const deps = makeDeps({ isSidecarEnabled: false });
-    expect(getCapabilityHealth('foto', deps)).toBe('soon');
-    expect(getCapabilityHealth('foto', makeDeps({ isSidecarEnabled: true }))).toBe('soon');
+  it('foto retorna live (visión groundeada ya corre; foto-en-la-mano cableada, fix P0 2026-06-25)', () => {
+    // foto pasó de 'soon' a 'live': el gate 'soon' tenía un motivo FALSO
+    // ("requiere GPU ≥8GB") — la GPU es de 12GB y la visión groundeada YA corre
+    // en el chat (analyzeFoliage / validate_visual_match), y la hoja de la mano
+    // ya estaba cableada (heroRoute photo → onPhoto → cameraInput → pipeline de
+    // visión). Su tool 'vision_identify' NO está en SIDECAR_TOOL_NAMES (la visión
+    // corre por ollama, no por el sidecar agro), así que es 'live' con o sin
+    // sidecar.
+    expect(getCapabilityHealth('foto', makeDeps({ isSidecarEnabled: false }))).toBe('live');
+    expect(getCapabilityHealth('foto', makeDeps({ isSidecarEnabled: true }))).toBe('live');
   });
 
   it('capacidades sidecar-dependent retornan live con sidecar habilitado', () => {

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -308,6 +308,54 @@ describe('sidecarClient — feature flag on', () => {
       expect(__TEST__.ALLOWED_TOOLS.has('get_precio_sipsa')).toBe(true);
     });
 
+    it('reconciliación allow-list ↔ NLU (fix P0 2026-06-25): tools SEGURAS expuestas', async () => {
+      // El NLU planner conoce 41 tools; estas son las que se agregaron al cliente
+      // por ser seguras + valiosas + ruteables por el NLU (grounding del grafo/
+      // catálogo/dataset institucional, con id|nombre|término que el planner
+      // rellena desde el mensaje). Verificación: están en el allow-list.
+      const { __TEST__ } = await importFresh();
+      const expuestas = [
+        'get_associations',
+        'get_fenologia',
+        'get_polinizacion',
+        'get_invasoras_alternativas',
+        'get_saberes_tradicionales',
+        'get_variedades_cultivo',
+        'get_psa_elegibilidad',
+        'get_alerta_carbono',
+        'get_alerta_normativa_paramo',
+        'get_alerta_clima_consejo',
+      ];
+      for (const t of expuestas) {
+        expect(__TEST__.ALLOWED_TOOLS.has(t)).toBe(true);
+      }
+    });
+
+    it('reconciliación allow-list ↔ NLU (fix P0 2026-06-25): tools sin args ruteables quedan en DEFLECCIÓN HONESTA', async () => {
+      // NO se exponen: exigen credenciales farmOS / coords de dispositivo / NIT
+      // DIAN, o un arg obligatorio que el NLU no conoce (altitud de finca, fecha
+      // de siembra, biopreparado_id). Si el planner rutea a una de ellas, el
+      // guard de AgentScreen inyecta deflección honesta en vez de degradar callado
+      // a RAG. Verificación: NO están en el allow-list (callTool las rechaza).
+      const { __TEST__ } = await importFresh();
+      const deflectadas = [
+        'add_planta_finca',
+        'get_finca_overview',
+        'get_sensor_finca',
+        'get_weather_data',
+        'get_clima_finca',
+        'get_documento_soporte_dian',
+        'get_ubicacion_actual',
+        'get_cultivos_viables',
+        'get_diseno_finca',
+        'get_grado_dia',
+        'get_dosis_biopreparado',
+      ];
+      for (const t of deflectadas) {
+        expect(__TEST__.ALLOWED_TOOLS.has(t)).toBe(false);
+      }
+    });
+
     it('5xx → ToolError fetch_failed sin throw', async () => {
       fetchMock.mockResolvedValueOnce(jsonResponse(500, { error: 'kg down' }));
       const { callTool } = await importFresh();

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -256,30 +256,24 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     heroRoute: { kind: 'nav', view: 'aprende' },
   },
   {
+    // FOTO EN LA MANO promovida a 'live' (fix grounding P0 2026-06-25). El gate
+    // 'soon' tenía un motivo FALSO ("requiere GPU con ≥8GB VRAM"): la GPU es de
+    // 12GB y la visión groundeada YA corre en el chat (recognizeSpeciesGrounded /
+    // analyzeFoliage / validate_visual_match + visionContext). La hoja además ya
+    // estaba CABLEADA: `heroRoute: { kind: 'photo' }` → mapCapabilityPick(onPhoto)
+    // → cameraInputAgentRef/cameraInputRef.click() → handleAgentPhotoPick →
+    // processPhotoItem (mismo pipeline de visión groundeada del compositor del
+    // chat). Lo único que faltaba era quitar el gate 'soon' (mapCapabilityPick
+    // hacía no-op antes de llamar onPhoto). Sin stubMessage: la capacidad ES real.
     id: 'foto',
     group: 'observar',
-    status: 'soon',
+    status: 'live',
     icon: '📷',
     label: 'Agregar planta por foto',
-    desc: 'Tómale una foto y la identifico y registro.',
+    desc: 'Tómale una foto y la identifico contra el catálogo.',
     tool: 'vision_identify',
     hero: true,
     heroRoute: { kind: 'photo' },
-    // stubMessage corregido 2026-06-24 (descubribilidad): el motivo anterior
-    // ("requiere GPU con ≥8GB VRAM") era FALSO — la GPU es de 12GB y la visión
-    // groundeada YA funciona dentro del chat (recognizeSpeciesGrounded /
-    // validate_visual_match). Lo que falta es cablear la foto-desde-la-mano al
-    // flujo de foto-en-chat; mientras tanto, en vez de mentir sobre el hardware,
-    // orientamos al usuario a la vía que SÍ funciona (foto dentro del chat) y a
-    // las alternativas (voz/manual). Se deja status:'soon' a propósito: promover
-    // la hoja de la mano a 'live' es más invasivo (requiere rutearla al
-    // compositor de foto del chat) y se hará en el replanteo. Ref:
-    // CAPABILITIES_STATUS.md §7.3 (foto soon con motivo falso).
-    stubMessage:
-      'Para identificar una planta por foto, abre el chat de Chagra y envíale la ' +
-      'foto desde ahí: la reconoce y verifica contra el catálogo. Esa vía ya ' +
-      'funciona. También puedes registrarla por voz o con el formulario manual. ' +
-      'El acceso directo por foto desde este menú llegará pronto.',
   },
   {
     // MÓDULO UNIFICADO de voz (2026-06-15): único punto de entrada desde la mano

--- a/src/services/capabilityHealth.js
+++ b/src/services/capabilityHealth.js
@@ -35,6 +35,21 @@ export const SIDECAR_TOOL_NAMES = new Set([
   'get_toxicidad',
   'get_variedades',
   'get_suelo',
+  // Reconciliación allow-list ↔ NLU (fix grounding P0 2026-06-25): tools
+  // agregadas a ALLOWED_TOOLS en sidecarClient. Se sirven vía el endpoint del
+  // sidecar (grafo AGE / catálogo / dataset institucional), así que dependen
+  // de que el sidecar esté arriba. Se mantiene en sync con ALLOWED_TOOLS.
+  'get_calendario_siembra',
+  'get_associations',
+  'get_fenologia',
+  'get_polinizacion',
+  'get_invasoras_alternativas',
+  'get_saberes_tradicionales',
+  'get_variedades_cultivo',
+  'get_psa_elegibilidad',
+  'get_alerta_carbono',
+  'get_alerta_normativa_paramo',
+  'get_alerta_clima_consejo',
 ]);
 
 /**

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -327,11 +327,35 @@ const ALLOWED_TOOLS = new Set([
   // sidecar pero NO estaba en esta allow-list — el chip routeaba a get_species
   // por un comentario stale. Es read-only seguro (solo lee el catálogo).
   'get_calendario_siembra',
-  // TODO: sincronizar allow-list cliente vs 41 del NLU (decisión consciente).
-  // El cliente expone deliberadamente un subconjunto: algunas tools del NLU se
-  // EXCLUYEN a propósito para evitar misrouting (ej. get_cultivos_viables y
-  // get_diseno_finca — ver "FIX P0 audit 2026-06-23" en agentService.js). No
-  // exponer las 41 a ciegas; cada alta a esta lista es una decisión revisada.
+  // ── Reconciliación allow-list cliente ↔ 41 tools del NLU (fix grounding P0
+  //    2026-06-25). El NLU planner conocía 41 tools pero el cliente exponía 20:
+  //    si el planner ruteaba a una de las 21 restantes, el turno degradaba a
+  //    RAG SIN grounding en silencio. Agregamos acá las tools que son SEGURAS y
+  //    VALIOSAS de exponer (grounding del grafo AGE / catálogo / dataset
+  //    institucional local, ruteables por el NLU con id|nombre|término).
+  //
+  //    NO se exponen las que exigen credenciales farmOS, coords de dispositivo
+  //    o NIT DIAN (add_planta_finca, get_finca_overview, get_sensor_finca,
+  //    get_weather_data, get_clima_finca, get_documento_soporte_dian,
+  //    get_ubicacion_actual): el NLU no puede rellenar esos args desde una
+  //    frase de chat → devolverían {available:false}/502. Esas quedan en
+  //    DEFLECCIÓN HONESTA (ver guard `not_allowed` en AgentScreen): el agente
+  //    dice claro "esa consulta todavía no está disponible" en vez de degradar
+  //    callado a RAG.
+
+  // Grounding del grafo AGE por especie (id snake_case O nombre común): el NLU
+  // rellena `species_id` (o el arg análogo) desde el nombre que dijo el usuario.
+  'get_associations', //          asociaciones benéficas + técnicas aplicables
+  'get_fenologia', //             etapas BBCH + ventanas de plaga por etapa
+  'get_polinizacion', //          polinizadores + colmenas/ha + efecto cuaje
+  'get_invasoras_alternativas', // nativas de reemplazo a invasoras combustibles
+  // Grounding standalone (catálogo / glosario / dataset institucional local):
+  'get_saberes_tradicionales', // glosario agroecológico (96 términos) por término
+  'get_variedades_cultivo', //    variedades registradas ICA/AGROSAVIA por cultivo
+  'get_psa_elegibilidad', //      Pago por Servicios Ambientales (Decreto 1007/2018)
+  'get_alerta_carbono', //        alerta defensiva bonos de carbono + PSA estatal
+  'get_alerta_normativa_paramo', // alerta regulatoria de páramo (Ley 1930/2018)
+  'get_alerta_clima_consejo', //  alerta de decisión por cambio climático
 ]);
 
 /**


### PR DESCRIPTION
## Bug / Feature
La auditoría de integración (§7.3) encontró que el agente DEGRADA el grounding en silencio cuando el NLU rutea a una tool que el cliente no expone, y que la foto-en-la-mano está bloqueada por un gate falso. Este PR cierra los 2 P0 restantes (los chips plaga y calendario ya quedaron en #1848).

## Causa raíz
1. **Allow-list desincronizada**: el NLU planner conoce **41 tools**, pero el cliente PWA exponía **20**. Si el planner ruteaba a una de las 21 restantes, `callTool` la rechazaba con `{_error, reason:'not_allowed'}` —indistinguible de un fallo de red— y el turno degradaba a **RAG SIN grounding, en silencio** (el usuario no se enteraba).
2. **Foto en la mano**: la hoja `foto` estaba en `status:'soon'` con motivo **falso** ("requiere GPU ≥8GB VRAM"). La GPU es de 12GB y la visión groundeada **ya corre en el chat**; la hoja además ya estaba cableada (`heroRoute photo → onPhoto → cameraInput → processPhotoItem`). Lo único que faltaba era quitar el gate `soon` (`mapCapabilityPick` hacía no-op antes de llamar `onPhoto`).

## Cambios
- **`src/services/sidecarClient.js`** — `ALLOWED_TOOLS`: +10 tools seguras y valiosas (ver tabla). Comentario explicando el criterio (qué se expone y qué queda en deflección).
- **`src/components/AgentScreen/AgentScreen.jsx`** — guard `not_allowed`: en vez de degradar callado a RAG, inyecta **deflección honesta** (`found:false` + hint) → el agente dice claro que esa consulta todavía no está disponible, NUNCA inventa. `formatToolEvidence` materializa el bloque.
- **`src/services/capabilityHealth.js`** — `SIDECAR_TOOL_NAMES` sincronizado con `ALLOWED_TOOLS`.
- **`src/services/agentCapabilities.js`** — `foto`: `status:'soon'` → `'live'`; se quita el `stubMessage`/motivo falso. La hoja abre la cámara → pipeline de visión groundeada real.
- **Tests** — +2 casos en `sidecarClient.test.js` (tools expuestas vs deflectadas); `capabilityHealth.test.js` actualizado (`foto → live`).

### Tools AGREGADAS al allow-list (10) — seguras, valiosas, ruteables por el NLU
| Tool | Grounding |
|---|---|
| `get_associations` | asociaciones benéficas + técnicas (grafo AGE, por especie) |
| `get_fenologia` | etapas BBCH + ventanas de plaga (grafo AGE, por especie) |
| `get_polinizacion` | polinizadores + colmenas/ha + efecto cuaje (grafo AGE) |
| `get_invasoras_alternativas` | nativas de reemplazo a invasoras combustibles |
| `get_saberes_tradicionales` | glosario agroecológico (96 términos, por término) |
| `get_variedades_cultivo` | variedades registradas ICA/AGROSAVIA (por cultivo) |
| `get_psa_elegibilidad` | Pago por Servicios Ambientales (Decreto 1007/2018) |
| `get_alerta_carbono` | alerta defensiva bonos de carbono + PSA estatal |
| `get_alerta_normativa_paramo` | alerta regulatoria de páramo (Ley 1930/2018) |
| `get_alerta_clima_consejo` | alerta de decisión por cambio climático |

### Tools que QUEDAN en DEFLECCIÓN HONESTA (11) — el NLU no puede rellenar sus args
- **Exigen credenciales farmOS / coords de dispositivo / NIT DIAN**: `add_planta_finca`, `get_finca_overview`, `get_sensor_finca`, `get_weather_data`, `get_clima_finca`, `get_documento_soporte_dian`, `get_ubicacion_actual`.
- **Arg obligatorio que el planner no conoce**: `get_cultivos_viables` y `get_diseno_finca` (exigen `altitud` de la finca — `required` en el schema NLU, que el planner alucinaría); `get_grado_dia` (exige `fecha_siembra`); `get_dosis_biopreparado` (schema NLU desalineado: `required: species_id` vs. la tool pide `biopreparado_id`/`pest_id`).

Para estas 11, si el planner las rutea, el agente responde con honestidad ("esa información todavía no la tengo disponible") en vez de degradar callado a RAG.

## Verificación (firma real del tool, no asumida)
- Cada arg/ruta verificado contra el zod real en `chagra-pro/modules/agro-mcp/src/schemas/inputs.ts` y los `FALLBACK_TOOL_SCHEMAS` del NLU (`sidecar/src/nlu.ts`).
- Foto: confirmado que `onPhoto` está cableado en `AgentHero.jsx` y `AgentScreen.jsx` y que el pipeline de visión groundeada (`analyzeFoliage`/`processPhotoItem`/`visionContext`) ya corre en el chat.

## Tests
- **189 casos passing** en los 6 archivos tocados (`sidecarClient` 30, `capabilityHealth`, `chipIntentRouter` 123 combinados; `agentCapabilities.audit`, `mcpHonestidad`, `sidecarClient.toolChain` 66; `AgentHero.composer` 21).
- `no-undef` limpio en todos los archivos cambiados (incl. `AgentScreen.jsx`).

Refs: auditoría integración §7.3, regresión silenciosa allow-list, PR #1848 (chips plaga/calendario), lección deflección honesta