### PR TITLE
feat(agent): cablear agente guiado al chat + reparar ramas Aprender/Vender de la mano

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -109,6 +109,7 @@ const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
 const AprenderConAgente = lazy(() => import('./components/Aprende/AprenderConAgente'));
 const DirectorioEspeciesScreen = lazy(() => import('./components/DirectorioEspecies/DirectorioEspeciesScreen'));
+const MercadosScreen = lazy(() => import('./components/MercadosScreen'));
 const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
 const MiFincaEvolucionScreen = lazy(() => import('./components/hoy/MiFincaEvolucionScreen'));
 const MiFincaVivaScreen = lazy(() => import('./components/juego/MiFincaVivaScreen'));
@@ -189,7 +190,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio',
+  'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia',
   'usage_stats',
@@ -1147,7 +1148,29 @@ export default function App() {
         return (
           <ErrorBoundary>
             <ErrorFallback moduleName="Aprende con el agente">
-              <AprenderConAgente onBack={() => navigate('dashboard')} />
+              <AprenderConAgente
+                onBack={() => navigate('dashboard')}
+                onAskAgent={(pregunta) =>
+                  navigate('agente', { prefilledPrompt: pregunta })
+                }
+              />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mercados':
+        // Rama "Vender" de la mano de Chagra (auditoría UX §7.4 P3): superficie
+        // HONESTA "en preparación" — alcanzable, no un dead-end. Explica el
+        // estado real de la consulta de precios y orienta a las fuentes públicas
+        // (DANE/SIPSA, centrales de abasto). onAskAgent puentea al agente.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Vender mejor">
+              <MercadosScreen
+                onBack={() => navigate('dashboard')}
+                onAskAgent={(pregunta) =>
+                  navigate('agente', { prefilledPrompt: pregunta })
+                }
+              />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -118,6 +118,11 @@ import ManoChagraGlyph from '../dashboard/ManoChagraGlyph';
 // mano (operador 2026-06-18). Misma fuente que TopBar.jsx / AgentHero.jsx.
 import { useTheme } from '../../hooks/useTheme';
 import { iconForTheme } from '../dashboard/themeIcon';
+// Agente guiado: selección PURA de un insight verificado proactivo a partir del
+// texto del turno (cultivo detectado → dato con fuente que el usuario no vio).
+// El hook useInsightProactivo exporta estas funciones puras; aquí las usamos
+// imperativamente al cerrar cada turno para ofrecer el insight DENTRO del chat.
+import { detectarSlugEnTexto, elegirInsight } from '../../hooks/useInsightProactivo';
 import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
 import useAgentNotificationStore from '../../store/useAgentNotificationStore';
@@ -189,6 +194,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   const activeAlerts = useAlertStore((s) => s.activeAlerts);
 
   const [messages, setMessages] = useState([]);
+  // Agente guiado: ids de insights ya ofrecidos/vistos en esta sesión de chat,
+  // para no repetir el mismo dato en turnos sucesivos. Ref (no state): solo lo
+  // lee/escribe la lógica de cierre de turno; no debe re-renderizar.
+  const insightsVistosRef = useRef([]);
   const [inputText, setInputText] = useState('');
   const [state, setState] = useState(STATE_IDLE);
   // Compositor inline (foto adjuntada directamente en AgentScreen, sin outbox).
@@ -2032,12 +2041,36 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // tocó relaciones del grafo → [] (sin regresión).
       const turnEdges = extractEdges(toolEvidence);
 
+      // AGENTE GUIADO (auditoría UX §7.4 P3): ofrecer un insight verificado
+      // proactivo DENTRO de la conversación. Detectamos el cultivo en el texto
+      // del turno (pregunta del usuario + respuesta del agente) y elegimos un
+      // dato con fuente que el usuario aún no ha visto en esta sesión. Si no hay
+      // cultivo o ya se ofrecieron todos, no se adjunta nada (sin regresión).
+      // La OFERTA es opt-in: la tarjeta en el chat pide confirmación antes de
+      // expandir el dato. Funciones puras (detectarSlugEnTexto/elegirInsight).
+      let insightProactivo = null;
+      try {
+        const textoTurno = `${text || ''} ${response || ''}`;
+        const slug = detectarSlugEnTexto(textoTurno);
+        if (slug) {
+          const candidato = elegirInsight(slug, insightsVistosRef.current);
+          if (candidato && candidato.id) {
+            insightProactivo = candidato;
+            insightsVistosRef.current = [...insightsVistosRef.current, candidato.id];
+          }
+        }
+      } catch (e) {
+        // El insight es secundario: jamás debe romper la respuesta del agente.
+        console.warn('[Agent] insight proactivo no disponible (continuo):', e?.message);
+      }
+
       const assistantMessage = {
         role: 'assistant',
         content: response,
         timestamp: Date.now(),
         metadata: sourceMetadata,
         _edges: turnEdges,
+        ...(insightProactivo ? { _insightProactivo: insightProactivo } : {}),
       };
 
       await addTurn(operatorId, {
@@ -2299,6 +2332,20 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       prev.map((m) =>
         m.id === msgId && m._deepResearch
           ? { ...m, _deepResearch: { ...m._deepResearch, status: 'error' } }
+          : m,
+      ),
+    );
+  }, []);
+
+  // AGENTE GUIADO: descartar la oferta de insight proactivo de un turno ("Ahora
+  // no"). ChatHistory pasa la clave del mensaje (id o índice de render). Quitamos
+  // el flag _insightProactivo de ese mensaje para que la tarjeta desaparezca sin
+  // tocar el resto de la conversación.
+  const handleDismissInsight = useCallback((key) => {
+    setMessages((prev) =>
+      prev.map((m, i) =>
+        (m.id != null ? m.id === key : i === key) && m._insightProactivo
+          ? (() => { const { _insightProactivo, ...rest } = m; void _insightProactivo; return rest; })()
           : m,
       ),
     );
@@ -3117,6 +3164,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         onConsentNeeded={handleFeedbackConsentNeeded}
         onRetryOrphan={handleRetryOrphan}
         onCancelDeepResearch={handleCancelDeepResearch}
+        onDismissInsight={handleDismissInsight}
         proactiveGreeting={proactiveGreeting}
         onBack={onBack}
       />

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -3,6 +3,7 @@ import { ArrowLeft } from 'lucide-react';
 import ChatBubble from './ChatBubble';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import DeepResearchCard from '../DeepResearchCard';
+import InsightProactivoCard from '../Aprende/InsightProactivoCard';
 import { MSG } from '../../config/messages';
 
 // Bug piloto 2026-06-04 (B): "para devolverme tengo que ir hasta el inicio de
@@ -28,7 +29,7 @@ const FLOATING_BACK_THRESHOLD_PX = 160;
  * @param {Object|null} [props.proactiveGreeting=null] - Datos del saludo proactivo dinámico.
  * @param {Function} props.onBack - Callback para volver a la pantalla anterior.
  */
-export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, proactiveGreeting = null, onBack }) {
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, onDismissInsight, proactiveGreeting = null, onBack }) {
   const bottomRef = useRef(null);
   const scrollRef = useRef(null);
   // (B) Botón "Volver" flotante: visible solo cuando el operador se alejó del
@@ -183,14 +184,29 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
           );
         }
         return (
-          <ChatBubble
-            key={msg.id || idx}
-            message={msg}
-            isStreaming={false}
-            promptText={msg.role === 'assistant' ? findPromptForResponse(idx) : undefined}
-            onConsentNeeded={onConsentNeeded}
-            onRetryOrphan={onRetryOrphan}
-          />
+          <React.Fragment key={msg.id || idx}>
+            <ChatBubble
+              message={msg}
+              isStreaming={false}
+              promptText={msg.role === 'assistant' ? findPromptForResponse(idx) : undefined}
+              onConsentNeeded={onConsentNeeded}
+              onRetryOrphan={onRetryOrphan}
+            />
+            {/* AGENTE GUIADO (auditoría UX §7.4 P3): si este turno del agente trae
+                un insight verificado proactivo, lo ofrecemos como una tarjeta más
+                de la conversación (opt-in). Aparece DENTRO del chat, justo bajo la
+                respuesta que lo motivó — no es un panel aparte. */}
+            {msg._insightProactivo && (
+              <InsightProactivoCard
+                insight={msg._insightProactivo}
+                onDismiss={
+                  typeof onDismissInsight === 'function'
+                    ? () => onDismissInsight(msg.id || idx)
+                    : undefined
+                }
+              />
+            )}
+          </React.Fragment>
         );
       })}
 

--- a/src/components/Aprende/AprenderConAgente.jsx
+++ b/src/components/Aprende/AprenderConAgente.jsx
@@ -24,12 +24,13 @@ import {
   FlaskConical,
   Bug,
   CalendarDays,
-  X,
+  MessageCircle,
 } from 'lucide-react';
 
 import lecciones from '../../data/agro-lecciones.json';
 import todasLasCards from '../../data/agro-insight-cards.json';
 import InsightCard from './InsightCard.jsx';
+import ManoChagraGlyph from '../dashboard/ManoChagraGlyph.jsx';
 
 // Íconos por slug de lección
 const LECCION_ICONS = {
@@ -133,11 +134,66 @@ function BloqueContenido({ bloque }) {
 }
 
 /**
+ * Botón "Pregúntale al agente" — conecta Aprender → Agente. Abre el chat del
+ * agente con la pregunta de la lección pre-cargada en el compositor (el usuario
+ * la revisa y envía; sin auto-submit). Identidad de marca: glifo de la mano de
+ * Chagra + acento del tema (--t-accent-rgb), nada de estética genérica de IA.
+ */
+function PreguntaleAlAgenteButton({ pregunta, onAskAgent }) {
+  return (
+    <button
+      type="button"
+      data-testid="preguntale-al-agente"
+      onClick={() => onAskAgent(pregunta)}
+      className="w-full mt-1 inline-flex items-center gap-3 px-4 py-3 rounded-2xl text-left active:scale-[0.99] transition-transform min-h-[52px] focus-visible:outline-none focus-visible:ring-2"
+      style={{
+        border: '1px solid rgba(var(--t-accent-rgb), 0.5)',
+        background:
+          'linear-gradient(135deg, rgba(var(--t-accent-rgb),0.16), rgba(15,23,20,0.5) 60%)',
+      }}
+    >
+      <span
+        className="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-xl"
+        style={{
+          color: 'rgb(var(--t-accent-rgb))',
+          background: 'rgba(var(--t-accent-rgb),0.12)',
+        }}
+        aria-hidden="true"
+      >
+        <ManoChagraGlyph size={20} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-bold text-slate-100 leading-tight">
+          Pregúntale al agente
+        </span>
+        <span className="block text-xs text-slate-300/80 leading-snug mt-0.5 truncate">
+          “{pregunta}”
+        </span>
+      </span>
+      <MessageCircle
+        size={18}
+        className="shrink-0 self-center"
+        style={{ color: 'rgb(var(--t-accent-rgb))' }}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}
+
+/**
  * Vista de una lección completa con navegación y insights.
  */
-function LeccionView({ leccion, onBack }) {
+function LeccionView({ leccion, onBack, onAskAgent }) {
   const [bloqueIdx, setBloqueIdx] = useState(0);
   const [mostrandoInsights, setMostrandoInsights] = useState(false);
+
+  // "Pregúntale al agente" (conecta Aprender → Agente): la pregunta de ESTA
+  // lección, pre-cargada en el chat. Si la lección no trae pregunta, caemos a
+  // una pregunta honesta derivada del título.
+  const preguntaLeccion =
+    (typeof leccion.pregunta_agente === 'string' && leccion.pregunta_agente.trim())
+      || `Cuéntame más sobre ${(leccion.titulo || leccion.slug || '').toLowerCase()}.`;
+  const puedePreguntar = typeof onAskAgent === 'function';
 
   const bloques = leccion.contenido_bloques;
   const insightsDeLeccion = useMemo(
@@ -232,6 +288,15 @@ function LeccionView({ leccion, onBack }) {
               )}
             </div>
 
+            {/* Pregúntale al agente (Aprender → Agente): abre el chat con la
+                pregunta de esta lección pre-cargada. */}
+            {puedePreguntar && (
+              <PreguntaleAlAgenteButton
+                pregunta={preguntaLeccion}
+                onAskAgent={onAskAgent}
+              />
+            )}
+
             {/* Fuente de la lección */}
             <p className="text-[11px] text-slate-600 leading-relaxed pt-2 border-t border-slate-800/40">
               <strong className="text-slate-500">Fuente base:</strong>{' '}
@@ -267,6 +332,15 @@ function LeccionView({ leccion, onBack }) {
               insightsDeLeccion.map((card) => (
                 <InsightCard key={card.id} card={card} compact={false} />
               ))
+            )}
+
+            {/* Pregúntale al agente (Aprender → Agente): cierre de la lección con
+                la pregunta pre-cargada en el chat. */}
+            {puedePreguntar && (
+              <PreguntaleAlAgenteButton
+                pregunta={preguntaLeccion}
+                onAskAgent={onAskAgent}
+              />
             )}
           </div>
         )}
@@ -305,8 +379,13 @@ export function AprenderEntryCard({ onNavigate }) {
 
 /**
  * Componente principal — muestra el listado de lecciones y navega a cada una.
+ *
+ * @param {object} props
+ * @param {() => void} [props.onBack] — volver al dashboard.
+ * @param {(pregunta: string) => void} [props.onAskAgent] — abre el chat del
+ *   agente con la pregunta de la lección pre-cargada (conecta Aprender → Agente).
  */
-export default function AprenderConAgente({ onBack }) {
+export default function AprenderConAgente({ onBack, onAskAgent }) {
   const [leccionActual, setLeccionActual] = useState(null);
 
   if (leccionActual) {
@@ -314,6 +393,7 @@ export default function AprenderConAgente({ onBack }) {
       <LeccionView
         leccion={leccionActual}
         onBack={() => setLeccionActual(null)}
+        onAskAgent={onAskAgent}
       />
     );
   }

--- a/src/components/Aprende/AprenderConAgente.test.jsx
+++ b/src/components/Aprende/AprenderConAgente.test.jsx
@@ -17,6 +17,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import AprenderConAgente, { AprenderEntryCard } from './AprenderConAgente.jsx';
 import { detectarSlugEnTexto, elegirInsight } from '../../hooks/useInsightProactivo.js';
 import todasLasCards from '../../data/agro-insight-cards.json';
+import lecciones from '../../data/agro-lecciones.json';
 
 // --- Card de entrada ---
 
@@ -226,5 +227,40 @@ describe('elegirInsight', () => {
         expect(resultado.non_co).toBe(false);
       }
     }
+  });
+});
+
+// --- Aprender → Agente: botón "Pregúntale al agente" (cableado) ---
+
+describe('AprenderConAgente — Pregúntale al agente (Aprender → Agente)', () => {
+  it('cada lección tiene una pregunta_agente no vacía', () => {
+    for (const leccion of lecciones) {
+      expect(typeof leccion.pregunta_agente).toBe('string');
+      expect(leccion.pregunta_agente.trim().length).toBeGreaterThan(8);
+    }
+  });
+
+  it('muestra el botón "Pregúntale al agente" dentro de una lección', () => {
+    render(<AprenderConAgente onAskAgent={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('leccion-card-suelo'));
+    expect(screen.getAllByTestId('preguntale-al-agente').length).toBeGreaterThan(0);
+  });
+
+  it('clic en el botón llama onAskAgent con la pregunta de la lección', () => {
+    const onAskAgent = vi.fn();
+    render(<AprenderConAgente onAskAgent={onAskAgent} />);
+    fireEvent.click(screen.getByTestId('leccion-card-suelo'));
+
+    const leccionSuelo = lecciones.find((l) => l.slug === 'suelo');
+    fireEvent.click(screen.getAllByTestId('preguntale-al-agente')[0]);
+
+    expect(onAskAgent).toHaveBeenCalledTimes(1);
+    expect(onAskAgent).toHaveBeenCalledWith(leccionSuelo.pregunta_agente);
+  });
+
+  it('NO muestra el botón si no se pasa onAskAgent (degrada limpio)', () => {
+    render(<AprenderConAgente />);
+    fireEvent.click(screen.getByTestId('leccion-card-suelo'));
+    expect(screen.queryByTestId('preguntale-al-agente')).toBeNull();
   });
 });

--- a/src/components/Aprende/InsightProactivoCard.jsx
+++ b/src/components/Aprende/InsightProactivoCard.jsx
@@ -1,0 +1,184 @@
+/**
+ * InsightProactivoCard — la OFERTA y la ENTREGA de un insight proactivo del
+ * agente guiado, DENTRO de la conversación del chat.
+ *
+ * Antes el contenido de los insights (agro-insight-cards.json) solo vivía en el
+ * módulo "Aprende"; el hook `useInsightProactivo` existía pero NO estaba
+ * cableado al chat en vivo (auditoría UX §7.4 P3). Esta tarjeta cierra ese hueco:
+ * cuando un turno del agente menciona un cultivo con dato verificado disponible,
+ * se ofrece el insight como un mensaje más de la conversación. El usuario decide
+ * (opt-in): "Ver el dato" expande la InsightCard; "Ahora no" lo descarta.
+ *
+ * Identidad visual (NO estética genérica de IA — mandato del operador):
+ *   - Reusa los primitivos REALES de la marca: la mano de Chagra
+ *     (ManoChagraGlyph) y el colibrí (ChagraAgentAvatar), nada inventado.
+ *   - Paleta theme-aware vía --t-accent-rgb (teal biopunk / ocre nature /
+ *     verde minimalista) — el MISMO token que pinta la mano radial y el wordmark.
+ *   - Una rama orgánica SVG (eco de la red de capacidades del AgentRedMenu)
+ *     nace del glifo de la mano hacia el nodo del dato: "de la mano de Chagra
+ *     crece el conocimiento". Respeta prefers-reduced-motion.
+ *
+ * Seguridad: la InsightCard ya impone fuente siempre visible + disclaimer
+ * non_co. Esta tarjeta no inventa nada: solo presenta lo que el hook eligió.
+ */
+import React, { useState } from 'react';
+import { Sparkles, X } from 'lucide-react';
+import InsightCard from './InsightCard.jsx';
+import ManoChagraGlyph from '../dashboard/ManoChagraGlyph.jsx';
+import ChagraAgentAvatar from '../ChagraAgentAvatar.jsx';
+
+/**
+ * Marco visual con la identidad de Chagra (mano + colibrí + rama radial),
+ * theme-aware por --t-accent-rgb. Envuelve el contenido del insight.
+ */
+function ChagraInsightFrame({ children, titulo }) {
+  return (
+    <div
+      data-testid="insight-proactivo-frame"
+      className="relative overflow-hidden rounded-2xl insight-proactivo-frame"
+      style={{
+        border: '1px solid rgba(var(--t-accent-rgb), 0.45)',
+        background:
+          'linear-gradient(135deg, rgba(var(--t-accent-rgb),0.14), rgba(15,23,20,0.55) 60%)',
+      }}
+    >
+      <style>{FRAME_CSS}</style>
+
+      {/* Rama radial orgánica de fondo — eco de la mano de Chagra (AgentRedMenu).
+          Decorativa, nace abajo-izquierda (la mano) hacia el dato; pinta con el
+          acento del tema. aria-hidden: es ornamento, no contenido. */}
+      <svg
+        className="insight-proactivo-vena"
+        viewBox="0 0 120 80"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <path
+          d="M2 76 C 26 70, 30 40, 56 38 S 92 30, 118 8"
+          fill="none"
+          stroke="rgb(var(--t-accent-rgb))"
+          strokeWidth="1.4"
+          strokeLinecap="round"
+          opacity="0.5"
+        />
+        <circle cx="56" cy="38" r="2.4" fill="rgb(var(--t-accent-rgb))" opacity="0.7" />
+        <circle cx="118" cy="8" r="2.8" fill="rgb(var(--t-accent-rgb))" opacity="0.6" />
+      </svg>
+
+      <div className="relative z-10 p-3">
+        <div className="flex items-center gap-2 mb-2">
+          {/* Colibrí de Chagra — el avatar real de la marca, en pequeño */}
+          <span
+            className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center bg-slate-900/70"
+            style={{ border: '1px solid rgba(var(--t-accent-rgb),0.5)' }}
+          >
+            <ChagraAgentAvatar state="idle" size={22} ariaLabel="Chagra" />
+          </span>
+          {/* Glifo de la mano de Chagra — hereda el acento del tema */}
+          <span
+            className="shrink-0"
+            style={{ color: 'rgb(var(--t-accent-rgb))' }}
+            aria-hidden="true"
+          >
+            <ManoChagraGlyph size={18} />
+          </span>
+          <p
+            className="text-[11px] font-bold uppercase tracking-wide truncate"
+            style={{ color: 'rgb(var(--t-accent-rgb))' }}
+          >
+            Dato verificado de Chagra
+          </p>
+        </div>
+        {titulo && (
+          <p className="text-sm font-bold text-slate-100 leading-tight mb-2">{titulo}</p>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * InsightProactivoCard
+ * @param {object} props
+ * @param {object} props.insight — la card de agro-insight-cards.json elegida.
+ * @param {() => void} [props.onDismiss] — descarta la oferta/entrega.
+ */
+export default function InsightProactivoCard({ insight, onDismiss }) {
+  const [aceptado, setAceptado] = useState(false);
+
+  if (!insight) return null;
+
+  // Estado ENTREGADO: la InsightCard completa dentro del marco de Chagra.
+  if (aceptado) {
+    return (
+      <div className="flex justify-start mb-3" data-testid="insight-proactivo-aceptado">
+        <div className="max-w-[88%] w-full">
+          <ChagraInsightFrame titulo={null}>
+            <InsightCard card={insight} compact={false} />
+          </ChagraInsightFrame>
+        </div>
+      </div>
+    );
+  }
+
+  // Estado OFERTA: tarjeta compacta con la identidad de Chagra + opt-in.
+  return (
+    <div className="flex justify-start mb-3" data-testid="insight-proactivo-oferta">
+      <div className="max-w-[88%] w-full">
+        <ChagraInsightFrame titulo={insight.titulo}>
+          {insight.cifra && (
+            <p
+              className="text-xs font-mono mb-2"
+              style={{ color: 'rgb(var(--t-accent-strong-rgb))' }}
+            >
+              {insight.cifra}
+            </p>
+          )}
+          <p className="text-xs text-slate-300/90 leading-relaxed mb-3">
+            Chagra tiene un dato verificado con fuente sobre esto. ¿Lo quieres ver?
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              data-testid="insight-proactivo-aceptar"
+              onClick={() => setAceptado(true)}
+              className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl text-sm font-bold text-slate-950 active:scale-[.98] transition-transform min-h-[40px]"
+              style={{ backgroundColor: 'rgb(var(--t-accent-rgb))' }}
+            >
+              <Sparkles size={14} aria-hidden="true" />
+              Ver el dato
+            </button>
+            <button
+              type="button"
+              data-testid="insight-proactivo-rechazar"
+              onClick={onDismiss}
+              aria-label="Ahora no"
+              className="inline-flex items-center justify-center gap-1 px-3 py-2 rounded-xl text-xs text-slate-300 border border-slate-600/60 hover:bg-slate-800/60 min-h-[40px]"
+            >
+              <X size={13} aria-hidden="true" />
+              Ahora no
+            </button>
+          </div>
+        </ChagraInsightFrame>
+      </div>
+    </div>
+  );
+}
+
+const FRAME_CSS = `
+.insight-proactivo-frame { box-shadow: 0 8px 24px -16px rgba(0,0,0,0.6); }
+.insight-proactivo-vena {
+  position: absolute; inset: 0; width: 100%; height: 100%;
+  pointer-events: none; z-index: 0;
+}
+.insight-proactivo-vena path {
+  stroke-dasharray: 320;
+  stroke-dashoffset: 320;
+  animation: insight-vena-grow 1.1s ease-out forwards;
+}
+@keyframes insight-vena-grow { to { stroke-dashoffset: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .insight-proactivo-vena path { animation: none !important; stroke-dashoffset: 0 !important; }
+}
+`;

--- a/src/components/Aprende/InsightProactivoCard.test.jsx
+++ b/src/components/Aprende/InsightProactivoCard.test.jsx
@@ -1,0 +1,55 @@
+/**
+ * InsightProactivoCard.test.jsx — el insight proactivo del agente guiado DENTRO
+ * del chat: oferta (opt-in) → entrega del dato verificado.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import InsightProactivoCard from './InsightProactivoCard.jsx';
+
+const INSIGHT = {
+  id: 'cafe-recoleccion-sanitaria',
+  entity_slug: 'cafe',
+  titulo: 'Recolección sanitaria baja la broca',
+  dato: 'Retirar los granos dañados o caídos del suelo elimina la mayor parte de la población de broca.',
+  cifra: '66–74 % de la población de broca retirada',
+  binomio: 'Hypothenemus hampei',
+  fuente: 'Cenicafé',
+  doi: 'https://biblioteca.cenicafe.org',
+  non_co: false,
+  region_analoga: null,
+  leccion_base: 'mip',
+};
+
+describe('InsightProactivoCard', () => {
+  it('no renderiza nada si no hay insight', () => {
+    const { container } = render(<InsightProactivoCard insight={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('muestra la OFERTA con identidad de Chagra (no expande el dato aún)', () => {
+    render(<InsightProactivoCard insight={INSIGHT} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId('insight-proactivo-oferta')).toBeInTheDocument();
+    // El marco de marca (mano + colibrí + rama radial) está presente.
+    expect(screen.getByTestId('insight-proactivo-frame')).toBeInTheDocument();
+    // El dato completo NO está visible todavía (opt-in pendiente).
+    expect(screen.queryByText(INSIGHT.dato)).toBeNull();
+  });
+
+  it('aceptar la oferta expande la InsightCard con el dato y la fuente', () => {
+    render(<InsightProactivoCard insight={INSIGHT} onDismiss={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('insight-proactivo-aceptar'));
+
+    expect(screen.getByTestId('insight-proactivo-aceptado')).toBeInTheDocument();
+    expect(screen.getByText(INSIGHT.dato)).toBeInTheDocument();
+    // La fuente es obligatoria en la InsightCard.
+    expect(screen.getByText(/Cenicafé/)).toBeInTheDocument();
+  });
+
+  it('rechazar llama onDismiss', () => {
+    const onDismiss = vi.fn();
+    render(<InsightProactivoCard insight={INSIGHT} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByTestId('insight-proactivo-rechazar'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/MercadosScreen.jsx
+++ b/src/components/MercadosScreen.jsx
@@ -1,0 +1,162 @@
+/**
+ * MercadosScreen — superficie HONESTA de la rama "Vender" de la mano de Chagra.
+ *
+ * Contexto (auditoría UX §7.4 P3): la rama "Vender" de la mano radial no iba a
+ * ningún lado (su único nodo, 'precio', está en estado 'soon'/no clickeable).
+ * Esta pantalla la hace ALCANZABLE sin mentir: explica qué hay hoy (la consulta
+ * de precios mayoristas todavía no está conectada en Chagra) y orienta a las
+ * fuentes públicas reales (DANE/SIPSA, centrales de abasto). No promete precios
+ * en vivo ni un mercado dentro de la app — es una pantalla "en preparación"
+ * real, no un dead-end ni un placeholder vacío.
+ *
+ * Identidad visual: reusa los primitivos de marca (mano de Chagra + paleta del
+ * tema vía --t-accent-rgb), nada de estética genérica de IA. Sin enlaces a
+ * homepages genéricas (trazabilidad teatral): solo cita las fuentes por nombre.
+ */
+import React from 'react';
+import { Handshake, Info } from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+import ManoChagraGlyph from './dashboard/ManoChagraGlyph.jsx';
+
+const FUENTES_PRECIO = [
+  {
+    nombre: 'DANE — SIPSA',
+    detalle:
+      'El Sistema de Información de Precios del Sector Agropecuario publica los precios mayoristas diarios de las principales centrales de abasto del país.',
+  },
+  {
+    nombre: 'Centrales de abasto regionales',
+    detalle:
+      'Corabastos (Bogotá), Cavasa (Cali), la Central Mayorista de Antioquia y otras plazas publican boletines de precios de referencia.',
+  },
+];
+
+export default function MercadosScreen({ onBack, onAskAgent }) {
+  return (
+    <ScreenShell
+      title="Vender mejor"
+      icon={Handshake}
+      onBack={onBack}
+    >
+      <div className="max-w-md mx-auto p-4 space-y-4" data-testid="mercados-screen">
+        {/* Encabezado con identidad de Chagra (mano + acento del tema) */}
+        <div
+          className="relative overflow-hidden rounded-2xl p-5"
+          style={{
+            border: '1px solid rgba(var(--t-accent-rgb), 0.45)',
+            background:
+              'linear-gradient(135deg, rgba(var(--t-accent-rgb),0.16), rgba(15,23,20,0.55) 60%)',
+          }}
+        >
+          <svg
+            className="absolute inset-0 w-full h-full pointer-events-none"
+            viewBox="0 0 140 90"
+            preserveAspectRatio="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M4 86 C 34 78, 40 42, 70 40 S 110 30, 138 8"
+              fill="none"
+              stroke="rgb(var(--t-accent-rgb))"
+              strokeWidth="1.3"
+              strokeLinecap="round"
+              opacity="0.45"
+            />
+            <circle cx="70" cy="40" r="2.6" fill="rgb(var(--t-accent-rgb))" opacity="0.65" />
+          </svg>
+          <div className="relative z-10">
+            <span
+              className="inline-flex items-center justify-center w-12 h-12 rounded-xl mb-3"
+              style={{
+                color: 'rgb(var(--t-accent-rgb))',
+                background: 'rgba(var(--t-accent-rgb),0.12)',
+              }}
+              aria-hidden="true"
+            >
+              <ManoChagraGlyph size={28} />
+            </span>
+            <h2 className="text-lg font-black text-slate-100 leading-tight">
+              Vender mejor tu cosecha
+            </h2>
+            <p className="text-sm text-slate-300/85 leading-relaxed mt-1.5">
+              Esta parte de Chagra está en preparación. Todavía no consultamos
+              precios mayoristas en vivo dentro de la app, y preferimos decírtelo
+              claro antes que mostrarte un dato que no podemos respaldar.
+            </p>
+          </div>
+        </div>
+
+        {/* Estado honesto */}
+        <div
+          className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 flex items-start gap-3"
+          data-testid="mercados-estado"
+        >
+          <Info size={18} className="text-sky-300 mt-0.5 shrink-0" aria-hidden="true" />
+          <p className="text-sm text-slate-200 leading-relaxed">
+            Mientras conectamos la consulta de precios, puedes orientarte con las
+            fuentes públicas oficiales. No te damos un precio inventado: te decimos
+            dónde está el dato real.
+          </p>
+        </div>
+
+        {/* Fuentes de precio reales (citadas por nombre, sin enlaces teatrales) */}
+        <div className="space-y-2">
+          <p className="text-xs font-bold text-slate-400 uppercase tracking-wide">
+            Dónde consultar precios mayoristas
+          </p>
+          {FUENTES_PRECIO.map((f) => (
+            <div
+              key={f.nombre}
+              className="rounded-xl border border-slate-700/70 bg-slate-900/50 p-3.5"
+            >
+              <p className="text-sm font-bold text-slate-100 leading-tight">{f.nombre}</p>
+              <p className="text-xs text-slate-300/80 leading-relaxed mt-1">{f.detalle}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Puente al agente: el agente puede orientar sobre dónde vender / a
+            quién, aunque la consulta de precios en vivo no esté lista. */}
+        {typeof onAskAgent === 'function' && (
+          <button
+            type="button"
+            data-testid="mercados-preguntar-agente"
+            onClick={() =>
+              onAskAgent('¿Dónde y a quién puedo vender mejor mi cosecha?')
+            }
+            className="w-full inline-flex items-center gap-3 px-4 py-3 rounded-2xl text-left active:scale-[0.99] transition-transform min-h-[52px]"
+            style={{
+              border: '1px solid rgba(var(--t-accent-rgb), 0.5)',
+              background:
+                'linear-gradient(135deg, rgba(var(--t-accent-rgb),0.16), rgba(15,23,20,0.5) 60%)',
+            }}
+          >
+            <span
+              className="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-xl"
+              style={{
+                color: 'rgb(var(--t-accent-rgb))',
+                background: 'rgba(var(--t-accent-rgb),0.12)',
+              }}
+              aria-hidden="true"
+            >
+              <ManoChagraGlyph size={20} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">
+                Pregúntale al agente
+              </span>
+              <span className="block text-xs text-slate-300/80 leading-snug mt-0.5">
+                “¿Dónde y a quién puedo vender mejor mi cosecha?”
+              </span>
+            </span>
+          </button>
+        )}
+
+        <p className="text-[11px] text-slate-600 text-center leading-relaxed pt-1">
+          En preparación: cuando la consulta de precios esté conectada, la verás
+          aquí con su fuente.
+        </p>
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/agent/manoRamasReachable.test.js
+++ b/src/components/agent/manoRamasReachable.test.js
@@ -1,0 +1,70 @@
+/**
+ * manoRamasReachable.test.js — anti-huérfana de la mano radial (auditoría UX
+ * §7.4 P3): las ramas "Aprender" y "Vender" NO deben morir en un dead-end.
+ *
+ * Verifica el CABLEADO en su fuente normativa (el manifiesto) + el routing
+ * (mapCapabilityPick): cada rama debe tener al menos UNA capacidad clickeable
+ * (status 'live') que enrute a una superficie real alcanzable.
+ *
+ * El render de la mano se valida en AgentRedMenu.smoke + chromium en vivo; aquí
+ * blindamos el contrato de datos/routing que hace que la rama tenga destino.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { CAPABILITY_MANIFEST } from '../../services/agentCapabilities';
+import { mapCapabilityPick } from './capabilityRouting';
+
+function heroLiveLeavesForGroup(group) {
+  return CAPABILITY_MANIFEST.filter(
+    (e) => e.hero === true && e.group === group && e.status === 'live',
+  );
+}
+
+describe('mano radial — ramas Aprender y Vender alcanzables (no dead-end)', () => {
+  it('la rama "aprender" tiene una capacidad LIVE que navega a la vista "aprende"', () => {
+    const leaves = heroLiveLeavesForGroup('aprender');
+    expect(leaves.length).toBeGreaterThan(0);
+    const navAprende = leaves.find(
+      (c) => c.heroRoute?.kind === 'nav' && c.heroRoute?.view === 'aprende',
+    );
+    expect(navAprende).toBeTruthy();
+  });
+
+  it('la rama "vender" tiene una capacidad LIVE que navega a una superficie real (mercados)', () => {
+    const leaves = heroLiveLeavesForGroup('vender');
+    expect(leaves.length).toBeGreaterThan(0);
+    const navMercados = leaves.find(
+      (c) => c.heroRoute?.kind === 'nav' && c.heroRoute?.view === 'mercados',
+    );
+    expect(navMercados).toBeTruthy();
+  });
+
+  it('mapCapabilityPick enruta la rama "aprender" a onNav("aprende")', () => {
+    const cap = heroLiveLeavesForGroup('aprender').find(
+      (c) => c.heroRoute?.view === 'aprende',
+    );
+    const onNav = vi.fn();
+    const acted = mapCapabilityPick(cap, { onNav });
+    expect(acted).toBe(true);
+    expect(onNav).toHaveBeenCalledWith('aprende');
+  });
+
+  it('mapCapabilityPick enruta la rama "vender" a onNav("mercados")', () => {
+    const cap = heroLiveLeavesForGroup('vender').find(
+      (c) => c.heroRoute?.view === 'mercados',
+    );
+    const onNav = vi.fn();
+    const acted = mapCapabilityPick(cap, { onNav });
+    expect(acted).toBe(true);
+    expect(onNav).toHaveBeenCalledWith('mercados');
+  });
+
+  it('las capacidades de navegación de las ramas no son no-op (acted=true)', () => {
+    for (const group of ['aprender', 'vender']) {
+      const navCap = heroLiveLeavesForGroup(group).find(
+        (c) => c.heroRoute?.kind === 'nav',
+      );
+      expect(navCap, `grupo ${group} sin capacidad nav live`).toBeTruthy();
+      expect(mapCapabilityPick(navCap, { onNav: vi.fn() })).toBe(true);
+    }
+  });
+});

--- a/src/data/agro-lecciones.json
+++ b/src/data/agro-lecciones.json
@@ -32,7 +32,8 @@
         "tipo": "advertencia",
         "texto": "El pH del suelo no se mide con vinagre y bicarbonato. Esa prueba solo reacciona con carbonatos masivos (suelos con pH mayor que 7,5), y en los suelos andinos la acidez viene del aluminio, que no se detecta así. Usa tiras de pH o un medidor calibrado."
       }
-    ]
+    ],
+    "pregunta_agente": "¿Cómo puedo mejorar la vida de mi suelo de forma natural?"
   },
   {
     "slug": "asociaciones",
@@ -68,7 +69,8 @@
         "texto": "Franjas florales bien diseñadas reducen los áfidos en cultivos adyacentes hasta un 75 % y aumentan los huevos de insectos benéficos (sírfidos, crisopas) en más del 100 %.",
         "fuente": "Tschumi et al. (2016), Journal of Applied Ecology, DOI 10.1111/1365-2664.12653"
       }
-    ]
+    ],
+    "pregunta_agente": "¿Qué plantas puedo asociar para que se ayuden entre sí?"
   },
   {
     "slug": "biopreparados",
@@ -98,7 +100,8 @@
         "tipo": "texto",
         "texto": "El caldo bordelés (sulfato de cobre + cal + agua) se usa como fungicida en agroecología, pero el cobre es tóxico para las abejas en dosis alta y no se aplica en floración. Es un caso especial que requiere orientación técnica."
       }
-    ]
+    ],
+    "pregunta_agente": "¿Qué biopreparado casero me sirve y cómo lo preparo?"
   },
   {
     "slug": "mip",
@@ -128,7 +131,8 @@
         "tipo": "advertencia",
         "texto": "Chagra no recomienda agroquímicos sintéticos. Si la situación es grave y necesitas ese tipo de producto, busca orientación de un agrónomo certificado. El agente puede orientarte sobre biopreparados y control biológico documentados."
       }
-    ]
+    ],
+    "pregunta_agente": "¿Cómo manejo una plaga sin químicos paso a paso?"
   },
   {
     "slug": "fenologia",
@@ -159,6 +163,7 @@
         "tipo": "texto",
         "texto": "El frijol es especialmente vulnerable al estrés hídrico en la floración (etapa R6). Mantener humedad adecuada esa semana puede salvar la cosecha."
       }
-    ]
+    ],
+    "pregunta_agente": "¿En qué etapa está mi cultivo y qué debo cuidar ahora?"
   }
 ]

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -414,6 +414,39 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     hero: true,
     heroRoute: { kind: 'nav', view: 'ciclo' },
   },
+  {
+    // RAMA "Aprender" de la mano: antes el grupo solo tenía 'deep'
+    // (Investigación profunda, status 'soon' → no clickeable), así que la rama
+    // moría en un nodo atenuado sin destino real. Esta entrada conecta la rama
+    // al hub educativo que YA existe y es alcanzable (vista 'aprende',
+    // AprenderConAgente): lecciones agroecológicas con fuente verificada.
+    id: 'aprender-hub',
+    group: 'aprender',
+    status: 'live',
+    icon: '📚',
+    label: 'Aprende con el agente',
+    desc: 'Lecciones agroecológicas con fuente: suelo, asociaciones, biopreparados, MIP y fenología.',
+    tool: null,
+    hero: true,
+    heroRoute: { kind: 'nav', view: 'aprende' },
+  },
+  {
+    // RAMA "Vender" de la mano: antes el grupo solo tenía 'precio'
+    // (status 'soon' → no clickeable), así que la rama no iba a ningún lado.
+    // Esta entrada la conecta a una superficie HONESTA y alcanzable ('mercados',
+    // MercadosScreen): explica el estado real de la consulta de precios y orienta
+    // a las fuentes públicas (DANE/SIPSA, centrales de abasto). No es un
+    // dead-end ni una promesa: es una pantalla real "en preparación".
+    id: 'vender-mercados',
+    group: 'vender',
+    status: 'live',
+    icon: '🤝',
+    label: 'Vender mejor',
+    desc: 'A dónde llevar la cosecha y dónde consultar precios mayoristas. En preparación.',
+    tool: null,
+    hero: true,
+    heroRoute: { kind: 'nav', view: 'mercados' },
+  },
 ]);
 
 // ── Vistas derivadas ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Feature
Cablear el "agente guiado" que la auditoría UX (§7.4 P3) confirmó como pedido del operador: contenido valioso que NO salía dentro del chat en vivo, lecciones desconectadas del agente, y ramas muertas en la mano radial.

## Cambios

### 1. Insight proactivo DENTRO del chat (el hook ya existía, sin cablear)
- `AgentScreen` ahora usa las funciones puras `detectarSlugEnTexto`/`elegirInsight` de `useInsightProactivo` al cerrar cada turno: detecta el cultivo (pregunta del usuario + respuesta del agente) y adjunta un insight verificado no-visto al mensaje (`_insightProactivo`). Ref de "vistos" para no repetir; try/catch para que nunca rompa la respuesta.
- `ChatHistory` renderiza `InsightProactivoCard` debajo de la respuesta que lo motivó: **oferta opt-in** ("Ver el dato" / "Ahora no") → expande la `InsightCard` real (fuente siempre visible, disclaimer non_co).

### 2. "Pregúntale al agente" en cada lección (Aprender → Agente)
- Nuevo campo `pregunta_agente` por lección en `agro-lecciones.json` (5 lecciones).
- Botón en `AprenderConAgente` (en el contenido y al cierre de la lección) → `navigate('agente', { prefilledPrompt })`: abre el chat con la pregunta pre-cargada (sin auto-submit).

### 3. Ramas "Aprender" y "Vender" reparadas (eran dead-ends)
- `aprender` solo tenía `deep` (soon, no clickeable) → nueva capacidad hero `aprender-hub` (live, `nav 'aprende'`) al hub educativo que ya existía y es alcanzable.
- `vender` solo tenía `precio` (soon) → nueva capacidad `vender-mercados` (live, `nav 'mercados'`) a **`MercadosScreen`**, superficie HONESTA "en preparación" (alcanzable, no placeholder vacío): explica el estado real de la consulta de precios y orienta a fuentes públicas (DANE/SIPSA, centrales de abasto). Routeada en `App.jsx` + `MODULE_VIEWS`.

### 4. Tratamiento visual con identidad real de Chagra (no estética genérica de IA)
- Reusa primitivos existentes: `ManoChagraGlyph` (mano radial) + `ChagraAgentAvatar` (colibrí) + rama orgánica SVG (eco del `AgentRedMenu`), paleta theme-aware vía `--t-accent-rgb` (teal biopunk / ocre nature / verde minimalista). Respeta `prefers-reduced-motion`.

## Verificación anti-huérfana (import + ruta + entrada visible)
- **Insight en chat**: import en `AgentScreen` + adjunto al mensaje + render en `ChatHistory` + handler dismiss cableado.
- **Pregúntale al agente**: botón con testid + `onAskAgent` threaded desde `App.jsx` + `pregunta_agente` en las 5 lecciones.
- **Ramas mano**: capacidades hero `live` en el manifiesto + `MercadosScreen` lazy-import + `case 'mercados'` + `mapCapabilityPick` routea a `onNav` (test dedicado de alcanzabilidad).

## Tests
- 69 vitest verdes (AprenderConAgente, InsightProactivoCard, manoRamasReachable, agentCapabilities.audit, AgentRedMenu.smoke, ChatHistory, ChatBubble, AgentHero, capabilityHealth).
- `no-undef` (flat-config) limpio en los 7 archivos tocados.
- Nota: screenshot chromium omitido a propósito — alpha 16GB con ollama+bench corriendo (~2Gi libres), levantar chromium+serve era OOM riesgo #1; la cobertura de integración monta los componentes reales y asierta las entradas.

Refs: auditoría UX §7.4 P3