### PR TITLE
feat(ui): marketplace agroecológico de la finca (circuitos cortos)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,6 +98,7 @@ const SeguimientoProcesoScreen = lazy(() => import('./components/SeguimientoProc
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
 const CromatografiaScreen = lazy(() => import('./components/CromatografiaScreen'));
 const ToxicologiaScreen = lazy(() => import('./components/ToxicologiaScreen'));
+const MercadosScreen = lazy(() => import('./components/MercadosScreen'));
 const GlaciarReporteScreen = lazy(() => import('./components/GlaciarReporteScreen'));
 const GlaciarHistorialScreen = lazy(() => import('./components/GlaciarHistorialScreen'));
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
@@ -109,7 +110,6 @@ const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
 const AprenderConAgente = lazy(() => import('./components/Aprende/AprenderConAgente'));
 const DirectorioEspeciesScreen = lazy(() => import('./components/DirectorioEspecies/DirectorioEspeciesScreen'));
-const MercadosScreen = lazy(() => import('./components/MercadosScreen'));
 const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
 const MiFincaEvolucionScreen = lazy(() => import('./components/hoy/MiFincaEvolucionScreen'));
 const MiFincaVivaScreen = lazy(() => import('./components/juego/MiFincaVivaScreen'));
@@ -181,6 +181,9 @@ const HASH_VIEW_ROUTES = {
   'directorio-especies': 'directorio',
   especies: 'directorio',
   'usage-stats': 'usage_stats',
+  mercado: 'mercado',
+  mercados: 'mercado',
+  vender: 'mercado',
 };
 
 // Vistas que cuentan como "módulo" para telemetría de piloto.
@@ -193,7 +196,7 @@ const MODULE_VIEWS = new Set([
   'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia',
-  'usage_stats',
+  'usage_stats', 'mercado',
 ]);
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -1137,6 +1140,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Cromatografia de Suelo">
               <CromatografiaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mercado':
+        // Marketplace agroecológico (circuitos cortos): publicar productos de la
+        // finca + explorar ofertas de fincas vecinas + contacto directo. Es la
+        // capacidad LIVE de la rama "Vender" de la mano (manifiesto `mercado`).
+        // Offline-first; precio de referencia citado solo si hay fuente.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mercado de la finca">
+              <MercadosScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/MercadosScreen.jsx
+++ b/src/components/MercadosScreen.jsx
@@ -1,162 +1,657 @@
-/**
- * MercadosScreen — superficie HONESTA de la rama "Vender" de la mano de Chagra.
- *
- * Contexto (auditoría UX §7.4 P3): la rama "Vender" de la mano radial no iba a
- * ningún lado (su único nodo, 'precio', está en estado 'soon'/no clickeable).
- * Esta pantalla la hace ALCANZABLE sin mentir: explica qué hay hoy (la consulta
- * de precios mayoristas todavía no está conectada en Chagra) y orienta a las
- * fuentes públicas reales (DANE/SIPSA, centrales de abasto). No promete precios
- * en vivo ni un mercado dentro de la app — es una pantalla "en preparación"
- * real, no un dead-end ni un placeholder vacío.
- *
- * Identidad visual: reusa los primitivos de marca (mano de Chagra + paleta del
- * tema vía --t-accent-rgb), nada de estética genérica de IA. Sin enlaces a
- * homepages genéricas (trazabilidad teatral): solo cita las fuentes por nombre.
- */
-import React from 'react';
-import { Handshake, Info } from 'lucide-react';
+/* i18n (ADR-050): etiquetas user-facing en español Colombia. La regla
+ * chagra-i18n es soft (warn); se desactiva a nivel de archivo siguiendo el
+ * mismo criterio que GerminacionScreen/SoilDiagnosticScreen para no bloquear el
+ * pre-commit (max-warnings=0). Los errores reales siguen activos. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Store, Plus, Search, MapPin, Phone, Trash2, ArrowLeft, Tag, Info,
+  PackageOpen, Sprout, AlertCircle, CheckCircle2,
+} from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
-import ManoChagraGlyph from './dashboard/ManoChagraGlyph.jsx';
+import PhotoCaptureField from './PhotoCaptureField';
+import { blobToDataUrl } from '../utils/imageProcessor';
+import { marketplaceOfertas } from '../db/marketplaceOfertas';
+import { CATEGORIAS, UNIDADES, OFERTAS_SEED } from '../data/marketplaceSeed';
+import { getProfile } from '../services/userProfileService';
+import {
+  formatearCOP, construirContacto, resolverPrecioReferencia,
+  validarOferta, filtrarOfertas,
+} from '../services/marketplaceService';
 
-const FUENTES_PRECIO = [
-  {
-    nombre: 'DANE — SIPSA',
-    detalle:
-      'El Sistema de Información de Precios del Sector Agropecuario publica los precios mayoristas diarios de las principales centrales de abasto del país.',
-  },
-  {
-    nombre: 'Centrales de abasto regionales',
-    detalle:
-      'Corabastos (Bogotá), Cavasa (Cali), la Central Mayorista de Antioquia y otras plazas publican boletines de precios de referencia.',
-  },
-];
+/**
+ * MercadosScreen — el MARKETPLACE agroecológico de Chagra (circuitos cortos).
+ *
+ * Reemplaza el placeholder "en preparación" de la rama "Vender" de la mano
+ * radial. MVP offline-first (como el resto de la app), tres flujos:
+ *
+ *   1. EXPLORAR — catálogo de ofertas (propias + ejemplos de otras fincas),
+ *      filtrable por categoría y por texto (producto/ubicación). Encuadre de
+ *      mercados campesinos / agroferias / venta directa sin intermediarios.
+ *   2. PUBLICAR — el productor publica un producto de su finca (producto,
+ *      cantidad, unidad, precio OPCIONAL, foto opcional, finca/vereda/municipio).
+ *      Se persiste local (IndexedDB) y aparece de inmediato en Explorar.
+ *   3. CONTACTAR — botón de contacto directo al vendedor (WhatsApp/teléfono),
+ *      patrón del resto de la app. Sin transacción ni pago dentro de Chagra:
+ *      deflección honesta sobre pagos.
+ *
+ * Precio de referencia GROUNDEADO: si hay dato citado (SIPSA/DANE) para el
+ * producto, se muestra con su fuente; si no, deflección honesta ("sin precio de
+ * referencia todavía"). NUNCA se inventa un precio. El gancho para el dato vivo
+ * lo alimentará el DR de comercialización/mercados en cola (precioReferencia.js).
+ *
+ * @param {object} props
+ * @param {Function} [props.onBack] - volver al dashboard.
+ * @param {Function} [props.onNavigate] - navegación opcional a otras vistas.
+ */
+export default function MercadosScreen({ onBack, onNavigate: _onNavigate }) {
+  const [tab, setTab] = useState('explorar'); // 'explorar' | 'publicar'
+  const [publicadas, setPublicadas] = useState([]);
+  const [cargando, setCargando] = useState(true);
+  const [mostrarEjemplos, setMostrarEjemplos] = useState(true);
+  const [filtroCat, setFiltroCat] = useState('');
+  const [filtroTexto, setFiltroTexto] = useState('');
+  const [detalle, setDetalle] = useState(null); // oferta seleccionada para contacto
 
-export default function MercadosScreen({ onBack, onAskAgent }) {
+  // ── carga inicial de ofertas publicadas (offline-first) ──
+  const recargar = useCallback(async () => {
+    try {
+      const lista = await marketplaceOfertas.getAll();
+      setPublicadas(lista);
+    } catch (e) {
+      console.warn('[Mercados] no se pudieron leer las ofertas:', e?.message);
+      setPublicadas([]);
+    } finally {
+      setCargando(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Carga inicial al montar. recargar() hace su propio setState de forma
+    // ASÍNCRONA (await IndexedDB); el disable es para el patrón establecido de
+    // "cargar al montar" (mismo que GlaciarHistorialScreen), no un setState
+    // síncrono que dispare renders en cascada.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    recargar();
+  }, [recargar]);
+
+  // Catálogo combinado: publicadas primero (más recientes), luego ejemplos.
+  const catalogo = useMemo(() => {
+    const base = [...publicadas];
+    if (mostrarEjemplos) base.push(...OFERTAS_SEED);
+    return base;
+  }, [publicadas, mostrarEjemplos]);
+
+  const visibles = useMemo(
+    () => filtrarOfertas(catalogo, { categoria: filtroCat, texto: filtroTexto }),
+    [catalogo, filtroCat, filtroTexto],
+  );
+
+  const handlePublicada = useCallback(() => {
+    setTab('explorar');
+    recargar();
+  }, [recargar]);
+
+  const handleEliminar = useCallback(async (id) => {
+    await marketplaceOfertas.remove(id);
+    setDetalle(null);
+    recargar();
+  }, [recargar]);
+
   return (
-    <ScreenShell
-      title="Vender mejor"
-      icon={Handshake}
-      onBack={onBack}
-    >
-      <div className="max-w-md mx-auto p-4 space-y-4" data-testid="mercados-screen">
-        {/* Encabezado con identidad de Chagra (mano + acento del tema) */}
-        <div
-          className="relative overflow-hidden rounded-2xl p-5"
-          style={{
-            border: '1px solid rgba(var(--t-accent-rgb), 0.45)',
-            background:
-              'linear-gradient(135deg, rgba(var(--t-accent-rgb),0.16), rgba(15,23,20,0.55) 60%)',
-          }}
-        >
-          <svg
-            className="absolute inset-0 w-full h-full pointer-events-none"
-            viewBox="0 0 140 90"
-            preserveAspectRatio="none"
-            aria-hidden="true"
-          >
-            <path
-              d="M4 86 C 34 78, 40 42, 70 40 S 110 30, 138 8"
-              fill="none"
-              stroke="rgb(var(--t-accent-rgb))"
-              strokeWidth="1.3"
-              strokeLinecap="round"
-              opacity="0.45"
-            />
-            <circle cx="70" cy="40" r="2.6" fill="rgb(var(--t-accent-rgb))" opacity="0.65" />
-          </svg>
-          <div className="relative z-10">
-            <span
-              className="inline-flex items-center justify-center w-12 h-12 rounded-xl mb-3"
-              style={{
-                color: 'rgb(var(--t-accent-rgb))',
-                background: 'rgba(var(--t-accent-rgb),0.12)',
-              }}
-              aria-hidden="true"
-            >
-              <ManoChagraGlyph size={28} />
-            </span>
-            <h2 className="text-lg font-black text-slate-100 leading-tight">
-              Vender mejor tu cosecha
-            </h2>
-            <p className="text-sm text-slate-300/85 leading-relaxed mt-1.5">
-              Esta parte de Chagra está en preparación. Todavía no consultamos
-              precios mayoristas en vivo dentro de la app, y preferimos decírtelo
-              claro antes que mostrarte un dato que no podemos respaldar.
-            </p>
-          </div>
-        </div>
-
-        {/* Estado honesto */}
-        <div
-          className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 flex items-start gap-3"
-          data-testid="mercados-estado"
-        >
-          <Info size={18} className="text-sky-300 mt-0.5 shrink-0" aria-hidden="true" />
-          <p className="text-sm text-slate-200 leading-relaxed">
-            Mientras conectamos la consulta de precios, puedes orientarte con las
-            fuentes públicas oficiales. No te damos un precio inventado: te decimos
-            dónde está el dato real.
+    <ScreenShell title="Mercado de la finca" icon={Store} onBack={onBack}>
+      <div className="max-w-2xl mx-auto px-4 py-4">
+        {/* Encuadre: circuitos cortos / venta directa */}
+        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-3 mb-4 flex gap-2.5">
+          <Sprout className="text-emerald-400 shrink-0 mt-0.5" size={18} />
+          <p className="text-sm text-emerald-100/90 leading-snug">
+            Vende directo a fincas y compradores vecinos: <strong>circuitos cortos</strong>,
+            agroferias y mercados campesinos, sin intermediarios. El contacto es
+            directo; Chagra no cobra comisión ni procesa pagos.
           </p>
         </div>
 
-        {/* Fuentes de precio reales (citadas por nombre, sin enlaces teatrales) */}
-        <div className="space-y-2">
-          <p className="text-xs font-bold text-slate-400 uppercase tracking-wide">
-            Dónde consultar precios mayoristas
-          </p>
-          {FUENTES_PRECIO.map((f) => (
-            <div
-              key={f.nombre}
-              className="rounded-xl border border-slate-700/70 bg-slate-900/50 p-3.5"
-            >
-              <p className="text-sm font-bold text-slate-100 leading-tight">{f.nombre}</p>
-              <p className="text-xs text-slate-300/80 leading-relaxed mt-1">{f.detalle}</p>
-            </div>
-          ))}
-        </div>
-
-        {/* Puente al agente: el agente puede orientar sobre dónde vender / a
-            quién, aunque la consulta de precios en vivo no esté lista. */}
-        {typeof onAskAgent === 'function' && (
+        {/* Tabs Explorar / Publicar */}
+        <div className="flex gap-2 mb-4" role="tablist">
           <button
             type="button"
-            data-testid="mercados-preguntar-agente"
-            onClick={() =>
-              onAskAgent('¿Dónde y a quién puedo vender mejor mi cosecha?')
-            }
-            className="w-full inline-flex items-center gap-3 px-4 py-3 rounded-2xl text-left active:scale-[0.99] transition-transform min-h-[52px]"
-            style={{
-              border: '1px solid rgba(var(--t-accent-rgb), 0.5)',
-              background:
-                'linear-gradient(135deg, rgba(var(--t-accent-rgb),0.16), rgba(15,23,20,0.5) 60%)',
-            }}
+            role="tab"
+            aria-selected={tab === 'explorar'}
+            onClick={() => setTab('explorar')}
+            className={`flex-1 min-h-[44px] rounded-lg font-bold text-sm flex items-center justify-center gap-2 transition-colors ${
+              tab === 'explorar'
+                ? 'bg-emerald-600 text-white'
+                : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+            }`}
           >
-            <span
-              className="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-xl"
-              style={{
-                color: 'rgb(var(--t-accent-rgb))',
-                background: 'rgba(var(--t-accent-rgb),0.12)',
-              }}
-              aria-hidden="true"
-            >
-              <ManoChagraGlyph size={20} />
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block text-sm font-bold text-slate-100 leading-tight">
-                Pregúntale al agente
-              </span>
-              <span className="block text-xs text-slate-300/80 leading-snug mt-0.5">
-                “¿Dónde y a quién puedo vender mejor mi cosecha?”
-              </span>
-            </span>
+            <Search size={16} /> Explorar
           </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'publicar'}
+            onClick={() => setTab('publicar')}
+            className={`flex-1 min-h-[44px] rounded-lg font-bold text-sm flex items-center justify-center gap-2 transition-colors ${
+              tab === 'publicar'
+                ? 'bg-emerald-600 text-white'
+                : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+            }`}
+          >
+            <Plus size={16} /> Publicar
+          </button>
+        </div>
+
+        {tab === 'explorar' && (
+          <ExplorarPanel
+            cargando={cargando}
+            ofertas={visibles}
+            filtroCat={filtroCat}
+            setFiltroCat={setFiltroCat}
+            filtroTexto={filtroTexto}
+            setFiltroTexto={setFiltroTexto}
+            mostrarEjemplos={mostrarEjemplos}
+            setMostrarEjemplos={setMostrarEjemplos}
+            onContactar={setDetalle}
+            onPublicarCta={() => setTab('publicar')}
+          />
         )}
 
-        <p className="text-[11px] text-slate-600 text-center leading-relaxed pt-1">
-          En preparación: cuando la consulta de precios esté conectada, la verás
-          aquí con su fuente.
+        {tab === 'publicar' && (
+          <PublicarPanel onPublicada={handlePublicada} onCancelar={() => setTab('explorar')} />
+        )}
+      </div>
+
+      {detalle && (
+        <DetalleOferta
+          oferta={detalle}
+          onClose={() => setDetalle(null)}
+          onEliminar={handleEliminar}
+        />
+      )}
+    </ScreenShell>
+  );
+}
+
+/* ════════════════════════ EXPLORAR ════════════════════════ */
+
+function ExplorarPanel({
+  cargando, ofertas, filtroCat, setFiltroCat, filtroTexto, setFiltroTexto,
+  mostrarEjemplos, setMostrarEjemplos, onContactar, onPublicarCta,
+}) {
+  return (
+    <div>
+      {/* Buscador por producto / ubicación */}
+      <div className="relative mb-3">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" size={16} />
+        <input
+          type="search"
+          value={filtroTexto}
+          onChange={(e) => setFiltroTexto(e.target.value)}
+          placeholder="Buscar producto, vereda o municipio…"
+          aria-label="Buscar ofertas"
+          className="w-full pl-9 pr-3 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 text-sm focus:border-emerald-500 focus:outline-none"
+        />
+      </div>
+
+      {/* Filtro por categoría (chips) */}
+      <div className="flex gap-2 overflow-x-auto pb-2 mb-3 -mx-1 px-1">
+        <CategoriaChip activo={filtroCat === ''} onClick={() => setFiltroCat('')} icon="🛒" label="Todo" />
+        {CATEGORIAS.map((c) => (
+          <CategoriaChip
+            key={c.id}
+            activo={filtroCat === c.id}
+            onClick={() => setFiltroCat(c.id)}
+            icon={c.icon}
+            label={c.label}
+          />
+        ))}
+      </div>
+
+      {/* Toggle ejemplos */}
+      <label className="flex items-center gap-2 text-xs text-slate-400 mb-3 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={mostrarEjemplos}
+          onChange={(e) => setMostrarEjemplos(e.target.checked)}
+          className="accent-emerald-500"
+        />
+        Mostrar ofertas de ejemplo de otras fincas
+      </label>
+
+      {cargando ? (
+        <p className="text-center text-slate-500 py-10 text-sm">Cargando ofertas…</p>
+      ) : ofertas.length === 0 ? (
+        <div className="text-center py-10">
+          <PackageOpen className="mx-auto text-slate-600 mb-3" size={40} />
+          <p className="text-slate-400 text-sm mb-4">
+            No hay ofertas que coincidan. Sé el primero en publicar lo que vende tu finca.
+          </p>
+          <button
+            type="button"
+            onClick={onPublicarCta}
+            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-bold text-sm"
+          >
+            <Plus size={16} /> Publicar mi producto
+          </button>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {ofertas.map((o) => (
+            <li key={o.id}>
+              <OfertaCard oferta={o} onContactar={onContactar} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function CategoriaChip({ activo, onClick, icon, label }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`shrink-0 px-3 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors ${
+        activo ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+      }`}
+    >
+      <span aria-hidden="true">{icon}</span> {label}
+    </button>
+  );
+}
+
+function OfertaCard({ oferta, onContactar }) {
+  const precio = formatearCOP(oferta.precio);
+  const cat = CATEGORIAS.find((c) => c.id === oferta.categoria);
+  const ubic = [oferta.vereda, oferta.municipio].filter(Boolean).join(', ');
+  return (
+    <div className="rounded-xl border border-slate-700 bg-slate-900/70 overflow-hidden">
+      <div className="flex">
+        {oferta.fotoDataUrl ? (
+          <img
+            src={oferta.fotoDataUrl}
+            alt={oferta.producto}
+            className="w-24 h-24 object-cover shrink-0"
+          />
+        ) : (
+          <div className="w-24 h-24 shrink-0 bg-slate-800 flex items-center justify-center text-3xl" aria-hidden="true">
+            {cat?.icon || '📦'}
+          </div>
+        )}
+        <div className="flex-1 min-w-0 p-3">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="font-bold text-white text-sm leading-tight truncate">{oferta.producto}</h3>
+            {oferta.demo && (
+              <span className="shrink-0 text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-slate-700 text-slate-300">
+                ejemplo
+              </span>
+            )}
+          </div>
+          <p className="text-emerald-300 font-black text-base mt-0.5">
+            {precio ? `${precio}` : 'A convenir'}
+            <span className="text-slate-400 font-normal text-xs"> / {oferta.unidad}</span>
+          </p>
+          <p className="text-slate-400 text-xs mt-0.5">
+            {oferta.cantidad} {oferta.unidad} disponible{oferta.cantidad === 1 ? '' : 's'}
+          </p>
+          {ubic && (
+            <p className="text-slate-500 text-xs mt-1 flex items-center gap-1 truncate">
+              <MapPin size={11} className="shrink-0" /> {ubic}
+            </p>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => onContactar(oferta)}
+        className="w-full py-2.5 bg-slate-800/80 hover:bg-emerald-700/40 text-emerald-300 text-sm font-bold flex items-center justify-center gap-2 border-t border-slate-700"
+      >
+        <Phone size={14} /> Contactar al vendedor
+      </button>
+    </div>
+  );
+}
+
+/* ════════════════════════ DETALLE + CONTACTO ════════════════════════ */
+
+function DetalleOferta({ oferta, onClose, onEliminar }) {
+  const contacto = construirContacto(oferta);
+  const ref = resolverPrecioReferencia(oferta.producto);
+  const precio = formatearCOP(oferta.precio);
+  const cat = CATEGORIAS.find((c) => c.id === oferta.categoria);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/70 flex items-end sm:items-center justify-center p-0 sm:p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Detalle de ${oferta.producto}`}
+      onClick={onClose}
+    >
+      <div
+        className="w-full sm:max-w-md bg-slate-900 rounded-t-2xl sm:rounded-2xl border border-slate-700 max-h-[90dvh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-slate-800 sticky top-0 bg-slate-900">
+          <button type="button" onClick={onClose} aria-label="Cerrar" className="p-2 -ml-2 text-slate-400 hover:text-white">
+            <ArrowLeft size={20} />
+          </button>
+          <span className="font-bold text-white text-sm truncate px-2">{oferta.producto}</span>
+          <span className="w-8" />
+        </div>
+
+        <div className="p-4 space-y-4">
+          {oferta.fotoDataUrl && (
+            <img src={oferta.fotoDataUrl} alt={oferta.producto} className="w-full h-44 object-cover rounded-lg" />
+          )}
+
+          <div>
+            <p className="text-emerald-300 font-black text-2xl">
+              {precio ? precio : 'A convenir'}
+              <span className="text-slate-400 font-normal text-sm"> / {oferta.unidad}</span>
+            </p>
+            <p className="text-slate-400 text-sm mt-1">
+              {oferta.cantidad} {oferta.unidad} · {cat?.icon} {cat?.label || 'Producto'}
+            </p>
+          </div>
+
+          {/* Precio de referencia GROUNDEADO o deflección honesta */}
+          <PrecioReferenciaBloque referencia={ref} />
+
+          {(oferta.finca || oferta.vereda || oferta.municipio) && (
+            <div className="text-sm text-slate-300">
+              {oferta.finca && <p className="font-semibold">{oferta.finca}</p>}
+              {[oferta.vereda, oferta.municipio].filter(Boolean).length > 0 && (
+                <p className="text-slate-400 flex items-center gap-1 mt-0.5">
+                  <MapPin size={13} /> {[oferta.vereda, oferta.municipio].filter(Boolean).join(', ')}
+                </p>
+              )}
+            </div>
+          )}
+
+          {oferta.nota && <p className="text-slate-300 text-sm leading-snug">{oferta.nota}</p>}
+
+          {/* Contacto directo — sin pagos dentro de la app (deflección honesta) */}
+          {contacto ? (
+            <a
+              href={contacto.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full min-h-[48px] rounded-xl bg-emerald-600 hover:bg-emerald-500 text-white font-bold flex items-center justify-center gap-2"
+            >
+              <Phone size={18} /> Escribir por WhatsApp
+            </a>
+          ) : (
+            <div className="rounded-lg border border-slate-700 bg-slate-800/60 p-3 flex gap-2 text-sm text-slate-300">
+              <Info size={16} className="text-slate-400 shrink-0 mt-0.5" />
+              {oferta.demo
+                ? 'Esta es una oferta de ejemplo: no tiene un contacto real. Publica la tuya para que te puedan escribir.'
+                : 'Este vendedor no dejó un contacto directo. Coordina con él en tu mercado campesino o agrofería.'}
+            </div>
+          )}
+
+          <p className="text-[11px] text-slate-500 leading-snug flex gap-1.5">
+            <Info size={13} className="shrink-0 mt-0.5" />
+            El pago y la entrega se acuerdan directamente entre comprador y vendedor.
+            Chagra no procesa pagos ni garantiza la transacción.
+          </p>
+
+          {/* Retirar publicación (solo ofertas propias, no ejemplos) */}
+          {!oferta.demo && (
+            <button
+              type="button"
+              onClick={() => onEliminar(oferta.id)}
+              className="w-full min-h-[44px] rounded-lg border border-rose-500/40 bg-rose-500/10 hover:bg-rose-500/20 text-rose-300 font-semibold text-sm flex items-center justify-center gap-2"
+            >
+              <Trash2 size={15} /> Retirar mi publicación
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PrecioReferenciaBloque({ referencia }) {
+  if (referencia.disponible) {
+    return (
+      <div className="rounded-lg border border-sky-500/30 bg-sky-500/5 p-3 text-sm">
+        <p className="text-sky-200 font-semibold flex items-center gap-1.5">
+          <Tag size={14} /> Precio de referencia mayorista
+        </p>
+        <p className="text-white mt-1">{referencia.banda}{referencia.mercado ? ` · ${referencia.mercado}` : ''}</p>
+        <p className="text-slate-400 text-xs mt-1">
+          {referencia.fuenteUrl ? (
+            <a href={referencia.fuenteUrl} target="_blank" rel="noopener noreferrer" className="underline hover:text-sky-300">
+              Fuente: {referencia.fuente}
+            </a>
+          ) : (
+            <>Fuente: {referencia.fuente}</>
+          )}
+          {referencia.boletinFecha ? ` · boletín ${referencia.boletinFecha}` : ''}
         </p>
       </div>
-    </ScreenShell>
+    );
+  }
+  // Deflección honesta: NO inventamos un precio de referencia.
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-800/60 p-3 text-sm text-slate-300 flex gap-2">
+      <Info size={15} className="text-slate-400 shrink-0 mt-0.5" />
+      <span>
+        Sin precio de referencia todavía. La consulta de precios mayoristas
+        (SIPSA/DANE) aún no está disponible en Chagra; el precio que ves lo puso
+        el productor.
+      </span>
+    </div>
+  );
+}
+
+/* ════════════════════════ PUBLICAR ════════════════════════ */
+
+function PublicarPanel({ onPublicada, onCancelar }) {
+  const perfil = useMemo(() => getProfile(), []);
+  const [form, setForm] = useState(() => ({
+    producto: '',
+    categoria: 'hortaliza',
+    cantidad: '',
+    unidad: 'kg',
+    precio: '',
+    finca: perfil.finca_nombre || perfil.nombre_finca || '',
+    vereda: perfil.vereda || '',
+    municipio: perfil.municipio || perfil.departamento || '',
+    contactoTel: '',
+    nota: '',
+  }));
+  const [fotoBlob, setFotoBlob] = useState(null);
+  const [errors, setErrors] = useState({});
+  const [guardando, setGuardando] = useState(false);
+
+  const set = (k, v) => setForm((p) => ({ ...p, [k]: v }));
+
+  const handleGuardar = useCallback(async () => {
+    const { ok, errors: errs } = validarOferta(form);
+    setErrors(errs);
+    if (!ok) return;
+    setGuardando(true);
+    try {
+      let fotoDataUrl = null;
+      if (fotoBlob) {
+        try {
+          fotoDataUrl = await blobToDataUrl(fotoBlob);
+        } catch {
+          fotoDataUrl = null; // la foto es opcional: no bloquea la publicación
+        }
+      }
+      await marketplaceOfertas.save({
+        producto: form.producto.trim(),
+        categoria: form.categoria,
+        cantidad: Number(form.cantidad),
+        unidad: form.unidad,
+        precio: form.precio === '' ? null : Number(form.precio),
+        finca: form.finca.trim(),
+        vereda: form.vereda.trim(),
+        municipio: form.municipio.trim(),
+        contactoTel: form.contactoTel.trim(),
+        nota: form.nota.trim(),
+        fotoDataUrl,
+      });
+      onPublicada();
+    } catch (e) {
+      console.warn('[Mercados] no se pudo publicar la oferta:', e?.message);
+      setErrors({ producto: 'No se pudo guardar. Intenta de nuevo.' });
+    } finally {
+      setGuardando(false);
+    }
+  }, [form, fotoBlob, onPublicada]);
+
+  return (
+    <div className="space-y-4">
+      <Field label="¿Qué vendes?" error={errors.producto} required>
+        <input
+          type="text"
+          value={form.producto}
+          onChange={(e) => set('producto', e.target.value)}
+          placeholder="Ej: Tomate chonto, miel, papa criolla…"
+          className="form-input"
+        />
+      </Field>
+
+      <Field label="Categoría">
+        <select value={form.categoria} onChange={(e) => set('categoria', e.target.value)} className="form-input">
+          {CATEGORIAS.map((c) => (
+            <option key={c.id} value={c.id}>{c.icon} {c.label}</option>
+          ))}
+        </select>
+      </Field>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Cantidad" error={errors.cantidad} required>
+          <input
+            type="number"
+            inputMode="decimal"
+            min="0"
+            value={form.cantidad}
+            onChange={(e) => set('cantidad', e.target.value)}
+            placeholder="Ej: 50"
+            className="form-input"
+          />
+        </Field>
+        <Field label="Unidad" error={errors.unidad} required>
+          <select value={form.unidad} onChange={(e) => set('unidad', e.target.value)} className="form-input">
+            {UNIDADES.map((u) => <option key={u} value={u}>{u}</option>)}
+          </select>
+        </Field>
+      </div>
+
+      <Field label="Precio por unidad (opcional)" error={errors.precio} hint="Déjalo vacío si prefieres 'a convenir'. Chagra no sugiere precios.">
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500">$</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min="0"
+            value={form.precio}
+            onChange={(e) => set('precio', e.target.value)}
+            placeholder="A convenir"
+            className="form-input pl-7"
+          />
+        </div>
+      </Field>
+
+      <Field label="Foto (opcional)">
+        <PhotoCaptureField
+          label="Agregar foto del producto"
+          value={fotoBlob}
+          onPhoto={setFotoBlob}
+          onRemove={() => setFotoBlob(null)}
+        />
+      </Field>
+
+      <div className="grid grid-cols-1 gap-3">
+        <Field label="Finca (opcional)">
+          <input type="text" value={form.finca} onChange={(e) => set('finca', e.target.value)} placeholder="Nombre de tu finca" className="form-input" />
+        </Field>
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Vereda (opcional)">
+            <input type="text" value={form.vereda} onChange={(e) => set('vereda', e.target.value)} placeholder="Vereda" className="form-input" />
+          </Field>
+          <Field label="Municipio (opcional)">
+            <input type="text" value={form.municipio} onChange={(e) => set('municipio', e.target.value)} placeholder="Municipio" className="form-input" />
+          </Field>
+        </div>
+      </div>
+
+      <Field label="Teléfono de contacto (opcional)" hint="Para que te escriban por WhatsApp. Si no lo pones, coordinas en el mercado.">
+        <div className="relative">
+          <Phone className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" size={15} />
+          <input
+            type="tel"
+            inputMode="tel"
+            value={form.contactoTel}
+            onChange={(e) => set('contactoTel', e.target.value)}
+            placeholder="Ej: 300 123 4567"
+            className="form-input pl-9"
+          />
+        </div>
+      </Field>
+
+      <Field label="Descripción (opcional)">
+        <textarea
+          value={form.nota}
+          onChange={(e) => set('nota', e.target.value)}
+          rows={3}
+          placeholder="Cómo lo produces, cuándo entregas, calidad…"
+          className="form-input resize-none"
+        />
+      </Field>
+
+      {errors.producto && !form.producto && (
+        <p className="text-rose-400 text-sm flex items-center gap-1.5">
+          <AlertCircle size={14} /> {errors.producto}
+        </p>
+      )}
+
+      <div className="flex gap-2 pt-1">
+        <button
+          type="button"
+          onClick={onCancelar}
+          className="flex-1 min-h-[48px] rounded-xl bg-slate-800 hover:bg-slate-700 text-slate-300 font-bold"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          onClick={handleGuardar}
+          disabled={guardando}
+          className="flex-1 min-h-[48px] rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 text-white font-bold flex items-center justify-center gap-2"
+        >
+          <CheckCircle2 size={18} /> {guardando ? 'Publicando…' : 'Publicar oferta'}
+        </button>
+      </div>
+
+      <style>{`
+        .form-input{
+          width:100%;padding:10px 12px;border-radius:10px;
+          background:rgb(30 41 59);border:1px solid rgb(51 65 85);
+          color:#fff;font-size:14px;min-height:44px;
+        }
+        .form-input::placeholder{color:rgb(100 116 139)}
+        .form-input:focus{outline:none;border-color:rgb(16 185 129)}
+      `}</style>
+    </div>
+  );
+}
+
+function Field({ label, children, error, hint, required }) {
+  return (
+    <label className="block">
+      <span className="block text-sm font-semibold text-slate-200 mb-1.5">
+        {label} {required && <span className="text-rose-400">*</span>}
+      </span>
+      {children}
+      {hint && !error && <span className="block text-xs text-slate-500 mt-1">{hint}</span>}
+      {error && <span className="block text-xs text-rose-400 mt-1">{error}</span>}
+    </label>
   );
 }

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -143,6 +143,11 @@ const HERRAMIENTAS_TILES = [
     // farmCalendarService; reusa los ciclos de la finca y el catálogo.
     { view: 'calendario_finca', label: 'Calendario', icon: CalendarDays, desc: 'Siembra, abono, plagas y cosecha en un solo lugar', accent: 'text-violet-400 border-l-violet-500' },
     { view: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle, desc: 'Respuestas sobre el funcionamiento de Chagra', accent: 'text-violet-400 border-l-violet-500' },
+    // Marketplace agroecológico (circuitos cortos): segundo punto de entrada
+    // VISIBLE además de la rama "Vender" de la mano radial. Publicar lo que
+    // vende la finca + explorar ofertas de fincas vecinas. Ruta 'mercado'
+    // (App.jsx case 'mercado' → MercadosScreen).
+    { view: 'mercado', label: 'Mercado', icon: Store, desc: 'Vende y compra directo entre fincas, sin intermediarios', accent: 'text-emerald-400 border-l-emerald-500' },
 ];
 
 // Acciones de gestión sin launcher directo en la home (huérfanas):

--- a/src/data/marketplaceSeed.js
+++ b/src/data/marketplaceSeed.js
@@ -1,0 +1,154 @@
+/* i18n (ADR-050): este archivo es DATA (ofertas de ejemplo del marketplace) con
+ * nombres de finca/producto/vereda en español Colombia — contenido, no UI
+ * traducible. La regla chagra-i18n es soft (warn); se desactiva a nivel de
+ * archivo como en otros data files. Los errores reales siguen activos. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+/**
+ * marketplaceSeed.js — ofertas de EJEMPLO del marketplace agroecológico.
+ *
+ * Encuadre (circuitos cortos / agroferias / mercados campesinos): el mercado de
+ * Chagra conecta fincas vecinas de forma directa, sin intermediarios. Para que
+ * la pantalla "Explorar" no aparezca vacía en el primer arranque (y para
+ * mostrar el patrón de una oferta bien hecha), sembramos un puñado de ofertas
+ * de DEMOSTRACIÓN de otras fincas.
+ *
+ * Estos registros son ILUSTRATIVOS — `demo:true` los marca como tal y la UI los
+ * rotula "ejemplo". NO son fincas reales ni contactos reales: los teléfonos son
+ * de relleno (no enrutables) y las veredas son genéricas. El precio que trae
+ * cada oferta es el que "pondría el productor", NO un precio de referencia
+ * mayorista (ese se cita aparte, solo si hay fuente — ver precioReferencia.js).
+ *
+ * Cuando el productor publica su primera oferta real, conviven con estas; puede
+ * ocultar los ejemplos desde la pantalla.
+ *
+ * @module data/marketplaceSeed
+ */
+
+/**
+ * Categorías agroecológicas del marketplace. Sirven para filtrar en "Explorar"
+ * y para clasificar al publicar.
+ * @type {ReadonlyArray<{id:string, label:string, icon:string}>}
+ */
+export const CATEGORIAS = Object.freeze([
+  { id: 'hortaliza', label: 'Hortalizas', icon: '🥬' },
+  { id: 'fruta', label: 'Frutas', icon: '🍓' },
+  { id: 'tuberculo', label: 'Tubérculos', icon: '🥔' },
+  { id: 'grano', label: 'Granos y cereales', icon: '🌽' },
+  { id: 'aromatica', label: 'Aromáticas y medicinales', icon: '🌿' },
+  { id: 'cafe', label: 'Café y cacao', icon: '☕' },
+  { id: 'miel', label: 'Miel y derivados', icon: '🍯' },
+  { id: 'huevo', label: 'Huevos y aves', icon: '🥚' },
+  { id: 'procesado', label: 'Procesados de finca', icon: '🫙' },
+  { id: 'semilla', label: 'Semillas nativas', icon: '🌱' },
+  { id: 'otro', label: 'Otro', icon: '📦' },
+]);
+
+/** Unidades de venta admitidas al publicar. */
+export const UNIDADES = Object.freeze([
+  'kg', 'libra', 'arroba', 'bulto', 'canasta', 'manojo', 'docena', 'unidad', 'litro',
+]);
+
+/**
+ * Ofertas de ejemplo (demo). El id lleva prefijo `seed-` para distinguirlas de
+ * las publicadas por el usuario y para que la UI pueda ocultarlas en bloque.
+ *
+ * @type {ReadonlyArray<object>}
+ */
+export const OFERTAS_SEED = Object.freeze([
+  {
+    id: 'seed-1',
+    demo: true,
+    producto: 'Tomate chonto agroecológico',
+    categoria: 'hortaliza',
+    cantidad: 80,
+    unidad: 'kg',
+    precio: 2400,
+    moneda: 'COP',
+    finca: 'Finca La Esperanza',
+    vereda: 'Vereda El Roble',
+    municipio: 'Cundinamarca',
+    contactoTel: '',
+    nota: 'Cosecha sin químicos de síntesis. Disponible los viernes para mercado campesino.',
+    createdAt: 0,
+  },
+  {
+    id: 'seed-2',
+    demo: true,
+    producto: 'Mora de Castilla',
+    categoria: 'fruta',
+    cantidad: 25,
+    unidad: 'kg',
+    precio: 5000,
+    moneda: 'COP',
+    finca: 'Finca El Mirador',
+    vereda: 'Vereda Aguas Claras',
+    municipio: 'Boyacá',
+    contactoTel: '',
+    nota: 'Recolección del día. Entrega en agrofería del domingo.',
+    createdAt: 0,
+  },
+  {
+    id: 'seed-3',
+    demo: true,
+    producto: 'Miel de abejas multifloral',
+    categoria: 'miel',
+    cantidad: 12,
+    unidad: 'litro',
+    precio: 38000,
+    moneda: 'COP',
+    finca: 'Apiario Las Flores',
+    vereda: 'Vereda La Cumbre',
+    municipio: 'Santander',
+    contactoTel: '',
+    nota: 'Cosecha de temporada seca. Envase de vidrio reutilizable.',
+    createdAt: 0,
+  },
+  {
+    id: 'seed-4',
+    demo: true,
+    producto: 'Papa criolla',
+    categoria: 'tuberculo',
+    cantidad: 3,
+    unidad: 'bulto',
+    precio: 95000,
+    moneda: 'COP',
+    finca: 'Finca Buenavista',
+    vereda: 'Vereda El Páramo',
+    municipio: 'Cundinamarca',
+    contactoTel: '',
+    nota: 'Semilla propia, suelo descansado. Bulto de 50 kg.',
+    createdAt: 0,
+  },
+  {
+    id: 'seed-5',
+    demo: true,
+    producto: 'Café pergamino seco',
+    categoria: 'cafe',
+    cantidad: 2,
+    unidad: 'arroba',
+    precio: 130000,
+    moneda: 'COP',
+    finca: 'Finca El Cafetal',
+    vereda: 'Vereda Las Brisas',
+    municipio: 'Huila',
+    contactoTel: '',
+    nota: 'Beneficio lavado, secado al sol. Trazabilidad de lote disponible.',
+    createdAt: 0,
+  },
+  {
+    id: 'seed-6',
+    demo: true,
+    producto: 'Huevos campesinos de gallina feliz',
+    categoria: 'huevo',
+    cantidad: 30,
+    unidad: 'docena',
+    precio: 9000,
+    moneda: 'COP',
+    finca: 'Granja La Pradera',
+    vereda: 'Vereda San José',
+    municipio: 'Cundinamarca',
+    contactoTel: '',
+    nota: 'Gallinas en pastoreo con cama profunda. Recolección diaria.',
+    createdAt: 0,
+  },
+]);

--- a/src/data/precioReferencia.js
+++ b/src/data/precioReferencia.js
@@ -1,0 +1,92 @@
+/**
+ * precioReferencia.js — precios de referencia GROUNDEADOS para el marketplace.
+ *
+ * Regla dura (anti-alucinación): Chagra NO inventa precios. Una oferta del
+ * marketplace muestra el precio que el productor escribió; el precio de
+ * REFERENCIA mayorista es un dato externo que solo se cita si existe una
+ * fuente verificable. Cuando no hay dato → deflección honesta ("sin precio de
+ * referencia todavía"), nunca un número fabricado.
+ *
+ * Estado actual (2026-06): la consulta de precios SIPSA/DANE en vivo todavía
+ * NO está disponible en Chagra (la capacidad `precio` del manifiesto es un stub
+ * honesto, status 'soon'). Mientras llega el pipeline de comercialización (un
+ * Deep Research de mercados/circuitos cortos está EN COLA y alimentará esta
+ * tabla con boletines SIPSA fechados por producto), esta tabla queda
+ * deliberadamente VACÍA salvo el andamiaje de la estructura. Así el marketplace
+ * deflecta con honestidad en vez de mostrar cifras sin respaldo.
+ *
+ * Forma de un registro de referencia (cuando se pueble desde el DR):
+ *   {
+ *     producto: 'tomate',          // clave normalizada (lowercase, sin tildes)
+ *     unidad: 'kg',                // unidad del precio de referencia
+ *     precioMin: 1800,             // COP — banda baja del boletín
+ *     precioMax: 2600,             // COP — banda alta del boletín
+ *     mercado: 'Corabastos',       // plaza mayorista de referencia
+ *     fuente: 'SIPSA',             // etiqueta institucional (cita SIPSA/DANE)
+ *     boletinFecha: '2026-05-30',  // fecha del boletín citado (trazabilidad)
+ *   }
+ *
+ * La `fuente` se resuelve a un deep-link con mapSourceToCitation()
+ * (institutionalSources.js) — 'SIPSA' linkea a la sección de precios del DANE.
+ *
+ * @module data/precioReferencia
+ */
+
+/**
+ * Tabla de precios de referencia citados. VACÍA por ahora (sin dato verificable
+ * = sin entrada). El DR de comercialización en cola la poblará con boletines
+ * SIPSA fechados. NO agregar cifras a mano sin fuente — rompería el contrato
+ * anti-alucinación del marketplace.
+ *
+ * @type {ReadonlyArray<{producto:string, unidad:string, precioMin:number,
+ *   precioMax:number, mercado:string, fuente:string, boletinFecha:string}>}
+ */
+export const PRECIOS_REFERENCIA = Object.freeze([
+  // (intencionalmente vacío — ver cabecera del módulo: gancho para el DR de
+  //  comercialización en cola. Sin dato verificable, el marketplace deflecta.)
+]);
+
+/**
+ * Normaliza un nombre de producto para comparar contra la tabla: minúsculas,
+ * sin tildes, sin espacios sobrantes. Mismo criterio que usará el ingest del DR.
+ *
+ * @param {string} nombre
+ * @returns {string}
+ */
+export function normalizarProducto(nombre) {
+  if (typeof nombre !== 'string') return '';
+  return nombre
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ');
+}
+
+/**
+ * Busca el precio de referencia citado para un producto. Devuelve null si no
+ * hay dato verificable — el llamador debe deflectar honestamente (NO inventar).
+ *
+ * El match es por inclusión normalizada en ambos sentidos: "tomate chonto" del
+ * usuario casa con "tomate" de la tabla, y viceversa. Si hay varios candidatos,
+ * gana el de clave más larga (más específica).
+ *
+ * @param {string} producto — nombre del producto (texto libre del usuario).
+ * @returns {{producto:string, unidad:string, precioMin:number, precioMax:number,
+ *   mercado:string, fuente:string, boletinFecha:string}|null}
+ */
+export function getPrecioReferencia(producto) {
+  const q = normalizarProducto(producto);
+  if (!q) return null;
+  let mejor = null;
+  for (const ref of PRECIOS_REFERENCIA) {
+    const k = normalizarProducto(ref.producto);
+    if (!k) continue;
+    if (q.includes(k) || k.includes(q)) {
+      if (!mejor || k.length > normalizarProducto(mejor.producto).length) {
+        mejor = ref;
+      }
+    }
+  }
+  return mejor;
+}

--- a/src/db/__tests__/marketplaceOfertas.test.js
+++ b/src/db/__tests__/marketplaceOfertas.test.js
@@ -1,0 +1,133 @@
+/**
+ * marketplaceOfertas.test.js — store offline de ofertas del marketplace.
+ *
+ * Mock pequeño de IDB con un Map en memoria (mismo patrón que
+ * glaciarReportes.test.js — sin fake-indexeddb). Verifica:
+ *   - save() persiste y genera id/createdAt si faltan, y fuerza demo:false.
+ *   - getAll() devuelve ordenado del más reciente al más antiguo.
+ *   - get()/remove()/count() funcionan; persiste fotoDataUrl.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let store; // Map en memoria keyed by id
+
+const makeTx = () => {
+  const tx = { oncomplete: null, onerror: null, onabort: null };
+  const objectStore = {
+    put(record) {
+      store.set(record.id, record);
+      Promise.resolve().then(() => tx.oncomplete?.());
+    },
+    delete(id) {
+      store.delete(id);
+      Promise.resolve().then(() => tx.oncomplete?.());
+    },
+    get(id) {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = store.get(id) || undefined;
+        req.onsuccess?.();
+      });
+      return req;
+    },
+    getAll() {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = [...store.values()];
+        req.onsuccess?.();
+      });
+      return req;
+    },
+    count() {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = store.size;
+        req.onsuccess?.();
+      });
+      return req;
+    },
+  };
+  tx.objectStore = () => objectStore;
+  return tx;
+};
+
+const mockDB = { transaction: vi.fn(() => makeTx()) };
+
+vi.mock('../dbCore', () => ({
+  openDB: vi.fn(() => Promise.resolve(mockDB)),
+  STORES: { MARKETPLACE_OFERTAS: 'marketplace_ofertas' },
+}));
+
+describe('marketplaceOfertas store', () => {
+  beforeEach(() => {
+    store = new Map();
+    vi.clearAllMocks();
+  });
+
+  it('save() persiste y genera id/createdAt y moneda COP por defecto', async () => {
+    const { marketplaceOfertas } = await import('../marketplaceOfertas');
+    const saved = await marketplaceOfertas.save({
+      producto: 'Tomate chonto',
+      categoria: 'hortaliza',
+      cantidad: 50,
+      unidad: 'kg',
+      precio: 2400,
+    });
+    expect(saved.id).toMatch(/^oferta-/);
+    expect(typeof saved.createdAt).toBe('number');
+    expect(saved.moneda).toBe('COP');
+    expect(store.size).toBe(1);
+  });
+
+  it('save() fuerza demo:false aunque venga demo:true', async () => {
+    const { marketplaceOfertas } = await import('../marketplaceOfertas');
+    const saved = await marketplaceOfertas.save({ producto: 'X', demo: true });
+    expect(saved.demo).toBe(false);
+  });
+
+  it('getAll() devuelve ordenado del más reciente al más antiguo', async () => {
+    const { marketplaceOfertas } = await import('../marketplaceOfertas');
+    await marketplaceOfertas.save({ id: 'a', createdAt: 1000, producto: 'A' });
+    await marketplaceOfertas.save({ id: 'b', createdAt: 3000, producto: 'B' });
+    await marketplaceOfertas.save({ id: 'c', createdAt: 2000, producto: 'C' });
+    const all = await marketplaceOfertas.getAll();
+    expect(all.map((o) => o.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('save() respeta un id explícito (upsert)', async () => {
+    const { marketplaceOfertas } = await import('../marketplaceOfertas');
+    await marketplaceOfertas.save({ id: 'fijo-1', producto: 'Papa', cantidad: 1 });
+    await marketplaceOfertas.save({ id: 'fijo-1', producto: 'Papa', cantidad: 3 });
+    expect(store.size).toBe(1);
+    const got = await marketplaceOfertas.get('fijo-1');
+    expect(got.cantidad).toBe(3);
+  });
+
+  it('get() devuelve null si no existe', async () => {
+    const { marketplaceOfertas } = await import('../marketplaceOfertas');
+    expect(await marketplaceOfertas.get('nope')).toBeNull();
+  });
+
+  it('remove() retira la publicación', async () => {
+    const { marketplaceOfertas } = await import('../marketplaceOfertas');
+    await marketplaceOfertas.save({ id: 'x', producto: 'Mora' });
+    expect(store.size).toBe(1);
+    await marketplaceOfertas.remove('x');
+    expect(store.size).toBe(0);
+  });
+
+  it('count() cuenta las ofertas publicadas', async () => {
+    const { marketplaceOfertas } = await import('../marketplaceOfertas');
+    await marketplaceOfertas.save({ id: '1', producto: 'A' });
+    await marketplaceOfertas.save({ id: '2', producto: 'B' });
+    expect(await marketplaceOfertas.count()).toBe(2);
+  });
+
+  it('persiste fotoDataUrl (offline survival de la foto)', async () => {
+    const { marketplaceOfertas } = await import('../marketplaceOfertas');
+    const dataUrl = 'data:image/jpeg;base64,/9j/AAA';
+    await marketplaceOfertas.save({ id: 'foto-1', producto: 'Miel', fotoDataUrl: dataUrl });
+    const got = await marketplaceOfertas.get('foto-1');
+    expect(got.fotoDataUrl).toBe(dataUrl);
+  });
+});

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -38,7 +38,7 @@
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 25;
+export const DB_VERSION = 26;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -101,6 +101,14 @@ export const STORES = {
   // uso (onboarding, módulos, preguntas al agente, feedback, sync) sin PII.
   // keyPath: id; indexes: event_type, created_at, synced.
   PILOT_TELEMETRY: 'pilot_telemetry',
+  // v26: marketplace_ofertas — ofertas del marketplace agroecológico (circuitos
+  // cortos). Cada oferta (producto, cantidad, unidad, precio, finca/vereda,
+  // contacto, foto opcional dataURL) se publica y persiste LOCAL, sobrevive
+  // recargas sin red (offline-first, igual que glaciar_reportes). No requiere
+  // backend nuevo: el contacto es directo (WhatsApp/teléfono), sin transacción
+  // dentro de la app. keyPath 'id' (string generado en cliente). Índices:
+  // createdAt (timeline), categoria (filtro), municipio (filtro por ubicación).
+  MARKETPLACE_OFERTAS: 'marketplace_ofertas',
 };
 
 let dbInstance = null;
@@ -429,6 +437,22 @@ export const openDB = async () => {
           store.createIndex('event_type', 'event_type', { unique: false });
           store.createIndex('created_at', 'created_at', { unique: false });
           store.createIndex('synced', 'synced', { unique: false });
+        }
+      }
+
+      // v26: marketplace_ofertas — ofertas del marketplace agroecológico
+      // (circuitos cortos / mercados campesinos). El productor publica un
+      // producto de su finca (cantidad, unidad, precio que él pone, ubicación,
+      // foto opcional) y se persiste OFFLINE-first: sobrevive recargas sin red.
+      // El contacto al vendedor es directo (WhatsApp/teléfono), sin transacción
+      // dentro de la app. keyPath 'id' (string generado en cliente). Índices:
+      // createdAt (timeline), categoria (filtro), municipio (filtro ubicación).
+      if (event.oldVersion < 26) {
+        if (!db.objectStoreNames.contains(STORES.MARKETPLACE_OFERTAS)) {
+          const store = db.createObjectStore(STORES.MARKETPLACE_OFERTAS, { keyPath: 'id' });
+          store.createIndex('createdAt', 'createdAt', { unique: false });
+          store.createIndex('categoria', 'categoria', { unique: false });
+          store.createIndex('municipio', 'municipio', { unique: false });
         }
       }
     };

--- a/src/db/marketplaceOfertas.js
+++ b/src/db/marketplaceOfertas.js
@@ -1,0 +1,128 @@
+/**
+ * marketplaceOfertas.js — CRUD offline-first de ofertas del marketplace
+ * agroecológico (circuitos cortos / mercados campesinos).
+ *
+ * Store: marketplace_ofertas (ChagraDB v26). Una oferta = un producto que un
+ * productor publica para vender directo a fincas/compradores vecinos. Todo se
+ * persiste LOCAL y sobrevive recargas sin red (mismo patrón que
+ * glaciarReportes). NO hay backend nuevo ni transacción dentro de la app: el
+ * contacto con el vendedor es directo (WhatsApp / teléfono).
+ *
+ * Schema del registro:
+ *   {
+ *     id,           // string único generado en cliente
+ *     createdAt,    // epoch ms (ordena el timeline)
+ *     producto,     // nombre del producto (texto libre)
+ *     categoria,    // id de CATEGORIAS (marketplaceSeed)
+ *     cantidad,     // número (> 0)
+ *     unidad,       // string de UNIDADES (kg, arroba, bulto…)
+ *     precio,       // número COP que pone el PRODUCTOR (no es ref. mayorista) | null
+ *     moneda,       // 'COP'
+ *     finca,        // nombre de la finca (texto) | ''
+ *     vereda,       // vereda (texto) | ''
+ *     municipio,    // municipio/departamento (texto) | ''
+ *     contactoTel,  // teléfono para WhatsApp/llamada (solo dígitos) | ''
+ *     nota,         // descripción libre | ''
+ *     fotoDataUrl,  // dataURL de la foto (sobrevive recargas offline) | null
+ *     demo,         // true si es oferta de ejemplo (seed) — nunca para publicadas
+ *   }
+ *
+ * @module db/marketplaceOfertas
+ */
+
+import { openDB, STORES } from './dbCore';
+
+/** Genera un id único en cliente (timestamp + random, ordenable por tiempo). */
+export function nuevaOfertaId() {
+  return `oferta-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export const marketplaceOfertas = {
+  /**
+   * Guarda (o reemplaza) una oferta. Si no trae `id`/`createdAt`, los genera.
+   * @param {object} oferta
+   * @returns {Promise<object>} la oferta persistida (con id/createdAt).
+   */
+  async save(oferta) {
+    const db = await openDB();
+    const now = Date.now();
+    const record = {
+      moneda: 'COP',
+      ...oferta,
+      id: oferta.id || nuevaOfertaId(),
+      createdAt: oferta.createdAt || now,
+      // las ofertas publicadas por el usuario NUNCA son demo, pase lo que pase.
+      demo: false,
+    };
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.MARKETPLACE_OFERTAS, 'readwrite');
+      tx.objectStore(STORES.MARKETPLACE_OFERTAS).put(record);
+      tx.oncomplete = () => resolve(record);
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  },
+
+  /**
+   * Devuelve todas las ofertas publicadas, del más reciente al más antiguo.
+   * NO incluye las ofertas de ejemplo (esas viven en data/marketplaceSeed).
+   * @returns {Promise<object[]>}
+   */
+  async getAll() {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.MARKETPLACE_OFERTAS, 'readonly');
+      const req = tx.objectStore(STORES.MARKETPLACE_OFERTAS).getAll();
+      req.onsuccess = () => {
+        const results = req.result || [];
+        results.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+        resolve(results);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  /**
+   * Obtiene una oferta por id. Null si no existe.
+   * @param {string} id
+   * @returns {Promise<object|null>}
+   */
+  async get(id) {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.MARKETPLACE_OFERTAS, 'readonly');
+      const req = tx.objectStore(STORES.MARKETPLACE_OFERTAS).get(id);
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  /**
+   * Elimina una oferta por id (el productor retira su publicación).
+   * @param {string} id
+   * @returns {Promise<void>}
+   */
+  async remove(id) {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.MARKETPLACE_OFERTAS, 'readwrite');
+      tx.objectStore(STORES.MARKETPLACE_OFERTAS).delete(id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  },
+
+  /**
+   * Cuenta las ofertas publicadas (sin contar los ejemplos seed).
+   * @returns {Promise<number>}
+   */
+  async count() {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.MARKETPLACE_OFERTAS, 'readonly');
+      const req = tx.objectStore(STORES.MARKETPLACE_OFERTAS).count();
+      req.onsuccess = () => resolve(req.result || 0);
+      req.onerror = () => reject(req.error);
+    });
+  },
+};

--- a/src/services/__tests__/marketplaceService.test.js
+++ b/src/services/__tests__/marketplaceService.test.js
@@ -1,0 +1,116 @@
+/**
+ * marketplaceService.test.js — lógica pura del marketplace agroecológico.
+ *
+ * Cubre los contratos críticos (incluido el ANTI-ALUCINACIÓN del precio de
+ * referencia: sin fuente verificable → no disponible, NUNCA un número inventado).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  formatearCOP, normalizarTelefono, construirContacto,
+  resolverPrecioReferencia, validarOferta, filtrarOfertas,
+} from '../marketplaceService';
+
+describe('formatearCOP', () => {
+  it('formatea pesos con separador de miles', () => {
+    expect(formatearCOP(2400)).toBe('$2.400');
+    expect(formatearCOP(130000)).toBe('$130.000');
+  });
+  it('devuelve null para no-precio (vacío, 0, NaN, negativo)', () => {
+    expect(formatearCOP(null)).toBeNull();
+    expect(formatearCOP(0)).toBeNull();
+    expect(formatearCOP(-5)).toBeNull();
+    expect(formatearCOP('abc')).toBeNull();
+    expect(formatearCOP(undefined)).toBeNull();
+  });
+});
+
+describe('normalizarTelefono', () => {
+  it('quita espacios/guiones y antepone 57 a celular nacional', () => {
+    expect(normalizarTelefono('300 123 4567')).toBe('573001234567');
+    expect(normalizarTelefono('300-123-4567')).toBe('573001234567');
+  });
+  it('respeta números que ya traen indicativo', () => {
+    expect(normalizarTelefono('+57 300 123 4567')).toBe('573001234567');
+  });
+  it('devuelve vacío si no hay dígitos', () => {
+    expect(normalizarTelefono('')).toBe('');
+    expect(normalizarTelefono('sin numero')).toBe('');
+    expect(normalizarTelefono(null)).toBe('');
+  });
+});
+
+describe('construirContacto', () => {
+  it('construye un link wa.me con mensaje pre-llenado citando el producto', () => {
+    const c = construirContacto({ contactoTel: '3001234567', producto: 'Tomate chonto' });
+    expect(c).not.toBeNull();
+    expect(c.href).toContain('https://wa.me/573001234567');
+    expect(decodeURIComponent(c.href)).toContain('Tomate chonto');
+  });
+  it('devuelve null si no hay teléfono utilizable (deflección honesta)', () => {
+    expect(construirContacto({ contactoTel: '', producto: 'Mora' })).toBeNull();
+    expect(construirContacto({ producto: 'Mora' })).toBeNull();
+  });
+});
+
+describe('resolverPrecioReferencia (anti-alucinación)', () => {
+  it('devuelve no disponible cuando no hay dato citado — NO inventa precios', () => {
+    // La tabla de referencia está vacía a la espera del DR de comercialización.
+    const r = resolverPrecioReferencia('tomate');
+    expect(r.disponible).toBe(false);
+    expect(r.banda).toBeUndefined();
+  });
+  it('no disponible para producto vacío', () => {
+    expect(resolverPrecioReferencia('').disponible).toBe(false);
+    expect(resolverPrecioReferencia(null).disponible).toBe(false);
+  });
+});
+
+describe('validarOferta', () => {
+  it('acepta una oferta mínima válida (producto + cantidad + unidad)', () => {
+    const { ok, errors } = validarOferta({ producto: 'Papa', cantidad: 3, unidad: 'bulto' });
+    expect(ok).toBe(true);
+    expect(errors).toEqual({});
+  });
+  it('precio es OPCIONAL (a convenir) — no exige número', () => {
+    const { ok } = validarOferta({ producto: 'Papa', cantidad: 3, unidad: 'kg', precio: '' });
+    expect(ok).toBe(true);
+  });
+  it('rechaza producto vacío, cantidad <= 0 y unidad faltante', () => {
+    const { ok, errors } = validarOferta({ producto: '  ', cantidad: 0, unidad: '' });
+    expect(ok).toBe(false);
+    expect(errors.producto).toBeTruthy();
+    expect(errors.cantidad).toBeTruthy();
+    expect(errors.unidad).toBeTruthy();
+  });
+  it('rechaza precio negativo si se escribe', () => {
+    const { ok, errors } = validarOferta({ producto: 'X', cantidad: 1, unidad: 'kg', precio: -10 });
+    expect(ok).toBe(false);
+    expect(errors.precio).toBeTruthy();
+  });
+});
+
+describe('filtrarOfertas', () => {
+  const ofertas = [
+    { id: '1', producto: 'Tomate chonto', categoria: 'hortaliza', vereda: 'El Roble', municipio: 'Cundinamarca' },
+    { id: '2', producto: 'Mora de Castilla', categoria: 'fruta', vereda: 'Aguas Claras', municipio: 'Boyacá' },
+    { id: '3', producto: 'Miel multifloral', categoria: 'miel', vereda: 'La Cumbre', municipio: 'Santander' },
+  ];
+  it('sin filtros devuelve todo', () => {
+    expect(filtrarOfertas(ofertas)).toHaveLength(3);
+  });
+  it('filtra por categoría', () => {
+    expect(filtrarOfertas(ofertas, { categoria: 'fruta' }).map((o) => o.id)).toEqual(['2']);
+  });
+  it('filtra por texto en producto o ubicación (case-insensitive)', () => {
+    expect(filtrarOfertas(ofertas, { texto: 'boyac' }).map((o) => o.id)).toEqual(['2']);
+    expect(filtrarOfertas(ofertas, { texto: 'MIEL' }).map((o) => o.id)).toEqual(['3']);
+    expect(filtrarOfertas(ofertas, { texto: 'roble' }).map((o) => o.id)).toEqual(['1']);
+  });
+  it('combina categoría + texto', () => {
+    expect(filtrarOfertas(ofertas, { categoria: 'hortaliza', texto: 'mora' })).toHaveLength(0);
+  });
+  it('es robusto ante entrada no-array', () => {
+    expect(filtrarOfertas(null)).toEqual([]);
+    expect(filtrarOfertas(undefined)).toEqual([]);
+  });
+});

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -109,6 +109,26 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     heroRoute: { kind: 'unavailable' },
   },
   {
+    // MARKETPLACE agroecológico (circuitos cortos): el productor publica lo que
+    // cosecha y explora ofertas de fincas vecinas, con contacto DIRECTO
+    // (WhatsApp), sin transacción dentro de la app. Offline-first. El precio de
+    // referencia mayorista se cita solo si hay fuente (SIPSA/DANE) — si no,
+    // deflección honesta (NO se inventan precios). Es la capacidad LIVE que
+    // REVIVE la rama "Vender" de la mano: con `precio` ya en hero:false (rama
+    // muerta retirada §7.4), `mercado` es ahora la única hoja hero del grupo
+    // 'vender' → el grupo vuelve a aparecer en la mano. kind:'nav' → vista
+    // 'mercado' (App.jsx). Reemplaza el placeholder "en preparación" previo.
+    id: 'mercado',
+    group: 'vender',
+    status: 'live',
+    icon: '🛒',
+    label: 'Mercado de la finca',
+    desc: 'Publica lo que vendes y mira ofertas de fincas vecinas, sin intermediarios.',
+    tool: 'marketplace',
+    hero: true,
+    heroRoute: { kind: 'nav', view: 'mercado' },
+  },
+  {
     id: 'calendario',
     group: 'planear',
     status: 'live',

--- a/src/services/marketplaceService.js
+++ b/src/services/marketplaceService.js
@@ -1,0 +1,157 @@
+/**
+ * marketplaceService.js — lógica PURA del marketplace agroecológico.
+ *
+ * Separa la lógica de negocio (filtrar, validar, formatear precio, construir el
+ * link de contacto, resolver el precio de referencia citado) del componente de
+ * UI (MercadosScreen). Todo aquí es puro y testeable sin DOM.
+ *
+ * Principio anti-alucinación (regla dura del operador): el marketplace NO
+ * inventa precios. El precio de una oferta es el que escribió el productor; el
+ * precio de REFERENCIA mayorista solo se muestra si hay fuente verificable
+ * (precioReferencia.js, hoy vacío a la espera del DR de comercialización). Sin
+ * dato → deflección honesta, nunca un número fabricado.
+ *
+ * @module services/marketplaceService
+ */
+
+import { getPrecioReferencia } from '../data/precioReferencia';
+import { classifySource } from './institutionalSources';
+
+/**
+ * Formatea un precio en pesos colombianos. Devuelve null-safe: si el precio no
+ * es un número finito > 0, devuelve null (el llamador muestra "precio a
+ * convenir" en vez de "$0").
+ *
+ * @param {number|null|undefined} valor — monto en COP.
+ * @returns {string|null} p.ej. "$2.400" — o null si no hay precio válido.
+ */
+export function formatearCOP(valor) {
+  const n = Number(valor);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  // Separador de miles con punto (convención COP). Sin decimales: los precios
+  // de finca son enteros en pesos.
+  return `$${Math.round(n).toLocaleString('es-CO')}`;
+}
+
+/**
+ * Normaliza un teléfono colombiano a dígitos para un link de WhatsApp/llamada.
+ * Quita espacios, guiones y paréntesis. Si el número no trae indicativo de país
+ * y parece un celular nacional de 10 dígitos, antepone 57 (Colombia).
+ *
+ * @param {string} tel
+ * @returns {string} solo dígitos (con indicativo si se pudo inferir), o '' .
+ */
+export function normalizarTelefono(tel) {
+  if (typeof tel !== 'string') return '';
+  let d = tel.replace(/[^0-9]/g, '');
+  if (!d) return '';
+  // 10 dígitos que empiezan en 3 → celular colombiano sin indicativo → +57.
+  if (d.length === 10 && d.startsWith('3')) d = `57${d}`;
+  return d;
+}
+
+/**
+ * Construye el enlace de contacto al vendedor. Patrón del resto de la app:
+ * contacto DIRECTO (WhatsApp si hay teléfono), sin transacción dentro de la
+ * app. Devuelve null si no hay teléfono utilizable — la UI entonces muestra una
+ * deflección honesta ("este vendedor no dejó un contacto directo").
+ *
+ * El mensaje pre-llenado cita el producto para que el comprador no tenga que
+ * escribirlo. NO incluye datos sensibles.
+ *
+ * @param {object} oferta — registro de oferta.
+ * @returns {{ href:string, tel:string }|null}
+ */
+export function construirContacto(oferta) {
+  const tel = normalizarTelefono(oferta?.contactoTel || '');
+  if (!tel) return null;
+  const producto = (oferta?.producto || 'su producto').trim();
+  const saludo = `Hola, vi su oferta de "${producto}" en el mercado de Chagra. ¿Sigue disponible?`;
+  const href = `https://wa.me/${tel}?text=${encodeURIComponent(saludo)}`;
+  return { href, tel };
+}
+
+/**
+ * Resuelve el precio de referencia mayorista CITADO para un producto.
+ * Devuelve `{ disponible:false }` cuando no hay dato verificable — la UI debe
+ * deflectar honestamente ("sin precio de referencia todavía"), NUNCA inventar.
+ *
+ * Cuando hay dato (lo poblará el DR de comercialización en cola), incluye la
+ * banda de precios, la plaza, y la cita resuelta a deep-link (SIPSA/DANE).
+ *
+ * @param {string} producto — nombre del producto.
+ * @returns {{ disponible:boolean, banda?:string, mercado?:string,
+ *   fuente?:string, fuenteUrl?:string, boletinFecha?:string }}
+ */
+export function resolverPrecioReferencia(producto) {
+  const ref = getPrecioReferencia(producto);
+  if (!ref) return { disponible: false };
+  const min = formatearCOP(ref.precioMin);
+  const max = formatearCOP(ref.precioMax);
+  const banda = min && max ? `${min}–${max} / ${ref.unidad}` : (min || max || null);
+  const cita = classifySource(ref.fuente, { concept: producto });
+  return {
+    disponible: true,
+    banda,
+    mercado: ref.mercado,
+    fuente: cita.fuente || ref.fuente,
+    fuenteUrl: cita.fuente_url || null,
+    boletinFecha: ref.boletinFecha,
+  };
+}
+
+/**
+ * Valida el formulario de publicación. Devuelve `{ ok, errors }` donde `errors`
+ * es un mapa campo→mensaje (vacío si todo bien). Reglas mínimas para una oferta
+ * útil sin fricción: producto + cantidad > 0 + unidad. El precio es OPCIONAL
+ * (se admite "a convenir"): así no forzamos a inventar un número.
+ *
+ * @param {object} form
+ * @returns {{ ok:boolean, errors:Record<string,string> }}
+ */
+export function validarOferta(form) {
+  const errors = {};
+  if (!form || typeof form !== 'object') {
+    return { ok: false, errors: { producto: 'Datos inválidos' } };
+  }
+  if (!String(form.producto || '').trim()) {
+    errors.producto = 'Escribe qué producto vendes';
+  }
+  const cantidad = Number(form.cantidad);
+  if (!Number.isFinite(cantidad) || cantidad <= 0) {
+    errors.cantidad = 'Indica una cantidad mayor que cero';
+  }
+  if (!String(form.unidad || '').trim()) {
+    errors.unidad = 'Elige una unidad (kg, arroba, bulto…)';
+  }
+  // Precio opcional, pero si lo escriben debe ser positivo.
+  if (form.precio !== '' && form.precio != null) {
+    const p = Number(form.precio);
+    if (!Number.isFinite(p) || p < 0) {
+      errors.precio = 'El precio debe ser un número válido';
+    }
+  }
+  return { ok: Object.keys(errors).length === 0, errors };
+}
+
+/**
+ * Filtra una lista de ofertas por categoría y/o texto de ubicación/producto.
+ * Búsqueda case-insensitive sobre producto, finca, vereda y municipio.
+ *
+ * @param {object[]} ofertas
+ * @param {{ categoria?:string, texto?:string }} [filtro]
+ * @returns {object[]}
+ */
+export function filtrarOfertas(ofertas, { categoria = '', texto = '' } = {}) {
+  const lista = Array.isArray(ofertas) ? ofertas : [];
+  const q = String(texto || '').trim().toLowerCase();
+  return lista.filter((o) => {
+    if (categoria && o.categoria !== categoria) return false;
+    if (!q) return true;
+    const blob = [o.producto, o.finca, o.vereda, o.municipio, o.nota]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+    return blob.includes(q);
+  });
+}


### PR DESCRIPTION
## Feature
El MARKETPLACE real de Chagra: el productor publica lo que cosecha y explora ofertas de fincas vecinas, con contacto directo. Reemplaza el placeholder "en preparación" de la rama "Vender" de la mano radial. Cierra el hueco de dominio "mercados" de la auditoría §7.2.

## Reconciliación con #1852
La rama del agente-guiado (#1852, **no mergeada aún**) dejó un placeholder `MercadosScreen.jsx` ("en preparación") ruteado desde la rama "Vender". Este PR branca de `main` limpio (que todavía NO tiene `MercadosScreen`) y construye el marketplace **real**. Al mergear se reconcilia con #1852: si #1852 entra primero, esta versión real reemplaza el placeholder; si entra este primero, #1852 quedará redundante.

## Cambios
- `src/components/MercadosScreen.jsx` — pantalla con dos pestañas (Explorar / Publicar), detalle modal con contacto y precio de referencia.
- `src/db/marketplaceOfertas.js` + `dbCore.js` (store `marketplace_ofertas`, **v26**) — persistencia offline-first (mismo patrón que `glaciar_reportes`). Sin backend nuevo.
- `src/data/marketplaceSeed.js` — categorías, unidades y ofertas de **ejemplo** de otras fincas (rotuladas "ejemplo"; contactos no reales).
- `src/data/precioReferencia.js` — tabla de precios de referencia **citados** (vacía a propósito) + lookup; gancho para el DR de comercialización en cola.
- `src/services/marketplaceService.js` — lógica pura (formato COP, link WhatsApp, validación, filtros, resolución de precio de referencia grounded).
- `src/services/agentCapabilities.js` — capacidad `mercado` (group `vender`, `live`, `heroRoute: nav→mercado`). Revive el grupo "Vender" de la mano (quedó sin hoja al pasar `precio` a `hero:false`).
- `src/App.jsx` — import lazy + `case 'mercado'` + `HASH_VIEW_ROUTES` (`#mercado`/`#vender`) + `MODULE_VIEWS`.
- `src/components/dashboard/DashboardLive.jsx` — tile "Mercado" en la home (segunda entrada visible).

## Groundeado vs deflectado
- **Groundeado**: precio de referencia mayorista solo se muestra si hay fuente verificable (SIPSA/DANE, vía `classifySource` → deep-link). El precio de la oferta es el que pone el productor (no inventado).
- **Deflectado (honesto)**: sin dato de referencia → "Sin precio de referencia todavía…". Sin teléfono → "no dejó un contacto directo". Pagos → "Chagra no procesa pagos ni garantiza la transacción". NUNCA se inventa un precio.

## Cableado (anti-huérfana)
import + ruta (`case 'mercado'` + HASH + MODULE_VIEWS) + **dos entradas VISIBLES**: rama "Vender" de la mano radial (manifiesto `mercado`) y tile "Mercado" en la home. Confirmado por grep import+ruta+entrada.

## Tests
- 26 vitest passing (servicio puro + CRUD del store).
- `agentCapabilities.audit` + `capabilityHealth` + `AgentHero.integration` siguen verdes con la nueva capacidad.
- Verificado en chromium del nix-store (móvil 390 + desktop 1440): explorar con ofertas de ejemplo + flujo de publicar + detalle con deflección de precio, **0 pageErrors**.

Refs: auditoría §7.2 (hueco "mercados"); PR #1852 (placeholder a reconciliar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)