### PR TITLE
feat(catalog): directorio de especies — explorador visual del catálogo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,6 +107,7 @@ const HelpManual = lazy(() => import('./components/HelpManual'));
 const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
 const AprenderConAgente = lazy(() => import('./components/Aprende/AprenderConAgente'));
+const DirectorioEspeciesScreen = lazy(() => import('./components/DirectorioEspecies/DirectorioEspeciesScreen'));
 const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
 const MiFincaEvolucionScreen = lazy(() => import('./components/hoy/MiFincaEvolucionScreen'));
 const MiFincaVivaScreen = lazy(() => import('./components/juego/MiFincaVivaScreen'));
@@ -173,6 +174,9 @@ const HASH_VIEW_ROUTES = {
   toxicologia: 'toxicologia',
   suelo: 'suelo',
   aprende: 'aprende',
+  directorio: 'directorio',
+  'directorio-especies': 'directorio',
+  especies: 'directorio',
   'usage-stats': 'usage_stats',
 };
 
@@ -183,7 +187,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
   'hoy_finca', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende',
+  'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia',
   'usage_stats',
@@ -1142,6 +1146,22 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Aprende con el agente">
               <AprenderConAgente onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'directorio':
+        // Directorio de especies: explorador visual del catálogo. Buscador con
+        // resolución de nombre (matcher canónico del proyecto) + ficha grounded
+        // por especie (foto, piso térmico, asociaciones, biopreparados,
+        // plagas/control biológico, saberes), todo offline-first desde
+        // catalog.sqlite + grafo-relations.json. initialQuery vía deep-link.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Directorio de especies">
+              <DirectorioEspeciesScreen
+                onBack={() => navigate('dashboard')}
+                initialQuery={currentViewData?.query || ''}
+              />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -1,0 +1,229 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { ChevronLeft, Search, Sprout, Leaf, X, BookOpen } from 'lucide-react';
+import { searchSpecies, buildSpeciesFicha } from '../../services/directorioEspecies.js';
+import SpeciesFicha from './SpeciesFicha.jsx';
+
+/**
+ * DirectorioEspeciesScreen — explorador visual del catálogo de especies.
+ *
+ * Flujo:
+ *   1. Buscador con resolución de nombre (reutiliza el matcher canónico del
+ *      proyecto). Si hay varios candidatos, los lista para que el usuario elija.
+ *   2. Al seleccionar, monta la FICHA grounded (foto + piso térmico +
+ *      asociaciones + biopreparados + plagas/control + saberes), con deflección
+ *      honesta donde falte el dato.
+ *
+ * Todo es OFFLINE-first: catálogo SQLite + grafo-relations.json + imágenes CC
+ * locales. No depende del sidecar/GPU.
+ *
+ * @param {object} props
+ * @param {() => void} [props.onBack]
+ * @param {string} [props.initialQuery] — consulta inicial (ej. deep-link).
+ */
+export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) {
+  const [query, setQuery] = useState(initialQuery);
+  const [results, setResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const [selected, setSelected] = useState(null); // ficha construida
+  const [loadingFicha, setLoadingFicha] = useState(false);
+  const [touched, setTouched] = useState(false);
+  const debounceRef = useRef(null);
+
+  const runSearch = useCallback(async (q) => {
+    if (!q || q.trim().length < 2) {
+      setResults([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    try {
+      const found = await searchSpecies(q);
+      setResults(found);
+    } catch (_) {
+      setResults([]);
+    } finally {
+      setSearching(false);
+    }
+  }, []);
+
+  // Búsqueda con debounce mientras el usuario escribe.
+  useEffect(() => {
+    if (selected) return; // no buscar mientras se ve una ficha
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => runSearch(query), 220);
+    return () => debounceRef.current && clearTimeout(debounceRef.current);
+  }, [query, runSearch, selected]);
+
+  const selectSpecies = useCallback(async (id) => {
+    setLoadingFicha(true);
+    try {
+      const ficha = await buildSpeciesFicha(id);
+      setSelected(ficha);
+      if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'auto' });
+    } catch (_) {
+      setSelected(null);
+    } finally {
+      setLoadingFicha(false);
+    }
+  }, []);
+
+  // Si un solo candidato exacto, abrir directo al presionar Enter.
+  const onSubmit = useCallback(
+    async (e) => {
+      e.preventDefault();
+      setTouched(true);
+      const found = await searchSpecies(query);
+      setResults(found);
+      if (found.length === 1) selectSpecies(found[0].id);
+    },
+    [query, selectSpecies],
+  );
+
+  const backToSearch = useCallback(() => {
+    setSelected(null);
+  }, []);
+
+  // VISTA FICHA -------------------------------------------------------------
+  if (selected) {
+    return (
+      <div className="min-h-[100dvh] text-white">
+        <header className="sticky top-0 z-10 flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2 bg-slate-950/85 backdrop-blur border-b border-slate-800/60">
+          <button
+            type="button"
+            onClick={backToSearch}
+            aria-label="Volver a la búsqueda"
+            className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
+          >
+            <ChevronLeft size={20} />
+          </button>
+          <div className="flex items-center gap-2 min-w-0">
+            <Leaf size={20} className="text-emerald-400 shrink-0" aria-hidden="true" />
+            <div className="min-w-0">
+              <h1 className="text-base font-bold leading-tight text-white truncate">{selected.comun}</h1>
+              <p className="text-xs text-slate-400 leading-tight italic truncate">{selected.cientifico}</p>
+            </div>
+          </div>
+        </header>
+        <SpeciesFicha ficha={selected} onSelectSpecies={selectSpecies} />
+      </div>
+    );
+  }
+
+  // VISTA BÚSQUEDA ----------------------------------------------------------
+  return (
+    <div className="min-h-[100dvh] text-white">
+      <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
+        {onBack ? (
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Volver"
+            className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
+          >
+            <ChevronLeft size={20} />
+          </button>
+        ) : null}
+        <div className="flex items-center gap-2">
+          <Sprout size={22} className="text-emerald-400 shrink-0" aria-hidden="true" />
+          <div>
+            <h1 className="text-lg font-bold leading-tight text-white">Directorio de especies</h1>
+            <p className="text-xs text-slate-400 leading-tight">Explora el catálogo: clima, asociaciones, biopreparados y plagas.</p>
+          </div>
+        </div>
+      </header>
+
+      {/* Buscador */}
+      <form onSubmit={onSubmit} className="px-4 pt-2">
+        <div className="relative">
+          <Search size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" aria-hidden="true" />
+          <input
+            type="text"
+            inputMode="search"
+            value={query}
+            onChange={(e) => { setQuery(e.target.value); setTouched(true); }}
+            placeholder="Frailejón, mandarina, frijol cargamanto…"
+            aria-label="Buscar especie por nombre"
+            data-testid="directorio-search-input"
+            className="w-full min-h-[48px] pl-10 pr-10 rounded-xl bg-slate-900 border border-slate-700 text-white placeholder:text-slate-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500/50"
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => { setQuery(''); setResults([]); }}
+              aria-label="Limpiar búsqueda"
+              className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full hover:bg-slate-800 flex items-center justify-center text-slate-400"
+            >
+              <X size={16} />
+            </button>
+          )}
+        </div>
+      </form>
+
+      {/* Resultados / estados */}
+      <div className="px-4 pt-4">
+        {loadingFicha && (
+          <p className="text-sm text-slate-400" data-testid="directorio-loading-ficha">Abriendo la ficha…</p>
+        )}
+
+        {!loadingFicha && searching && (
+          <p className="text-sm text-slate-400">Buscando…</p>
+        )}
+
+        {!loadingFicha && !searching && touched && query.trim().length >= 2 && results.length === 0 && (
+          <div className="text-center py-10" data-testid="directorio-empty">
+            <Leaf size={32} className="mx-auto text-slate-700 mb-2" aria-hidden="true" />
+            <p className="text-sm text-slate-400">
+              No encontramos “{query.trim()}” en el catálogo todavía.
+            </p>
+            <p className="text-xs text-slate-500 mt-1">
+              Prueba con otro nombre común o el nombre científico.
+            </p>
+          </div>
+        )}
+
+        {!loadingFicha && results.length > 0 && (
+          <>
+            {results.length > 1 && (
+              <p className="text-xs text-slate-400 mb-2">
+                {results.length} coincidencias — elige una:
+              </p>
+            )}
+            <ul className="space-y-2" data-testid="directorio-results">
+              {results.map((r) => (
+                <li key={r.id}>
+                  <button
+                    type="button"
+                    onClick={() => selectSpecies(r.id)}
+                    className="w-full text-left rounded-xl bg-slate-900/60 border border-slate-800 hover:border-emerald-600/60 active:bg-slate-800/70 p-3 transition-colors flex items-center gap-3"
+                  >
+                    <Leaf size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />
+                    <span className="min-w-0">
+                      <span className="block text-sm font-bold text-emerald-100 leading-tight truncate">{r.comun || r.id}</span>
+                      {r.cientifico && (
+                        <span className="block text-xs italic text-slate-400 leading-tight truncate">{r.cientifico}</span>
+                      )}
+                      {r.familia && (
+                        <span className="block text-[10px] text-slate-500 leading-tight">{r.familia}</span>
+                      )}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+
+        {/* Estado inicial vacío — guía */}
+        {!loadingFicha && !searching && !touched && results.length === 0 && (
+          <div className="text-center py-12" data-testid="directorio-hint">
+            <BookOpen size={34} className="mx-auto text-slate-700 mb-3" aria-hidden="true" />
+            <p className="text-sm text-slate-400 max-w-xs mx-auto leading-relaxed">
+              Busca cualquier especie del catálogo y mira su piso térmico, con qué
+              se asocia, qué biopreparados le sirven y qué plagas la afectan.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/DirectorioEspecies/PisoTermicoBand.jsx
+++ b/src/components/DirectorioEspecies/PisoTermicoBand.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { Mountain, Thermometer, Droplets } from 'lucide-react';
+import { PISOS_TERMICOS, altitudToPct, __ALTITUD_TECHO_M } from '../../services/directorioEspecies.js';
+
+// Clases Tailwind estáticas por tono (el JIT necesita literales para purgar).
+const TONE = {
+  orange: { band: 'bg-orange-500/70', chip: 'bg-orange-500/20 text-orange-200 border-orange-500/40', dot: 'bg-orange-400' },
+  amber: { band: 'bg-amber-500/70', chip: 'bg-amber-500/20 text-amber-200 border-amber-500/40', dot: 'bg-amber-400' },
+  emerald: { band: 'bg-emerald-500/70', chip: 'bg-emerald-500/20 text-emerald-200 border-emerald-500/40', dot: 'bg-emerald-400' },
+  indigo: { band: 'bg-indigo-500/70', chip: 'bg-indigo-500/20 text-indigo-200 border-indigo-500/40', dot: 'bg-indigo-400' },
+};
+
+const ZONE_LABEL = { calido: 'Cálido', templado: 'Templado', frio: 'Frío', paramo: 'Páramo' };
+
+/**
+ * PisoTermicoBand — franja vertical de piso térmico + rango de altitud donde
+ * prospera la especie. Datos REALES del catálogo (altitud_msnm + thermal_zones
+ * + temperatura_c). Si no hay rango de altitud, cae a las zonas térmicas; si no
+ * hay ninguno, muestra deflección honesta.
+ *
+ * @param {object} props
+ * @param {{ thermalZones: string[], altitud: object|null, temperatura: object|null, agua: string|null }} props.pisoTermico
+ */
+export default function PisoTermicoBand({ pisoTermico }) {
+  const { thermalZones = [], altitud = null, temperatura = null, agua = null } = pisoTermico || {};
+  const zonesSet = new Set(thermalZones);
+
+  const sinDato = !altitud && thermalZones.length === 0;
+  if (sinDato) {
+    return (
+      <p className="text-sm text-slate-400 italic" data-testid="piso-sin-dato">
+        Sin datos de piso térmico todavía para esta especie.
+      </p>
+    );
+  }
+
+  // Banda visual: 0 (abajo) → techo (arriba). Posicionamos la franja óptima
+  // y los absolutos cuando hay altitud real.
+  const top = altitud?.max_absoluto ?? altitud?.optimo_max ?? null;
+  const bottom = altitud?.min_absoluto ?? altitud?.optimo_min ?? null;
+  const optTop = altitud?.optimo_max ?? null;
+  const optBottom = altitud?.optimo_min ?? null;
+
+  const pctTop = altitudToPct(top);
+  const pctOptTop = altitudToPct(optTop);
+  const pctOptBottom = altitudToPct(optBottom);
+
+  return (
+    <div data-testid="piso-termico-band">
+      <div className="flex gap-3">
+        {/* Banda vertical de pisos térmicos */}
+        <div className="relative w-16 shrink-0 h-44 rounded-xl overflow-hidden border border-slate-700/60 bg-slate-900">
+          {/* Estratos de fondo (techo arriba → cálido abajo) */}
+          <div className="absolute inset-0 flex flex-col-reverse">
+            {PISOS_TERMICOS.map((p) => {
+              const frac = (p.maxM - p.minM) / __ALTITUD_TECHO_M;
+              const active = zonesSet.has(p.id);
+              const tone = TONE[p.tone];
+              return (
+                <div
+                  key={p.id}
+                  className={`relative ${active ? tone.band : 'bg-slate-800/40'} transition-colors`}
+                  style={{ flexGrow: frac }}
+                  title={`${p.label} · ${p.minM}–${p.maxM} msnm`}
+                >
+                  {active && (
+                    <span className="absolute inset-0 flex items-center justify-center text-[9px] font-black text-white/90 tracking-tight uppercase">
+                      {p.label}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Marcador del rango óptimo de altitud de la especie */}
+          {pctOptBottom !== null && pctOptTop !== null && (
+            <div
+              className="absolute left-0 right-0 border-y-2 border-white/80 bg-white/10"
+              style={{
+                bottom: `${pctOptBottom}%`,
+                height: `${Math.max(2, pctOptTop - pctOptBottom)}%`,
+              }}
+              aria-hidden="true"
+            />
+          )}
+        </div>
+
+        {/* Lectura del rango */}
+        <div className="flex-1 min-w-0 flex flex-col justify-center gap-2">
+          {altitud ? (
+            <div className="flex items-start gap-2">
+              <Mountain size={18} className="text-slate-300 mt-0.5 shrink-0" aria-hidden="true" />
+              <div className="text-sm leading-tight">
+                <p className="font-bold text-slate-100">
+                  {fmtRange(optBottom, optTop)} <span className="font-normal text-slate-400">óptimo</span>
+                </p>
+                {(bottom !== null || top !== null) && (
+                  <p className="text-xs text-slate-400">
+                    Tolera {fmtRange(bottom, top)} msnm
+                  </p>
+                )}
+                {pctTop !== null && (
+                  <p className="text-[10px] text-slate-500 mt-0.5">en la franja sobre el nivel del mar</p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <p className="text-xs text-slate-400 italic">Sin rango de altitud exacto; pisos térmicos referenciales.</p>
+          )}
+
+          {temperatura && (temperatura.optimo_min != null || temperatura.optimo_max != null) && (
+            <div className="flex items-center gap-2 text-sm text-slate-200">
+              <Thermometer size={16} className="text-rose-300 shrink-0" aria-hidden="true" />
+              <span>
+                {fmtTemp(temperatura.optimo_min, temperatura.optimo_max)}
+                {typeof temperatura.helada_letal === 'number' && (
+                  <span className="text-xs text-slate-400"> · helada letal {temperatura.helada_letal} °C</span>
+                )}
+              </span>
+            </div>
+          )}
+
+          {agua && (
+            <div className="flex items-center gap-2 text-sm text-slate-200">
+              <Droplets size={16} className="text-sky-300 shrink-0" aria-hidden="true" />
+              <span className="capitalize">Requerimiento de agua: {agua}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Chips de pisos donde prospera */}
+      {thermalZones.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-3">
+          {thermalZones.map((z) => {
+            const piso = PISOS_TERMICOS.find((p) => p.id === z);
+            const tone = piso ? TONE[piso.tone] : TONE.emerald;
+            return (
+              <span
+                key={z}
+                className={`px-2 py-0.5 rounded-md border text-[11px] font-bold ${tone.chip}`}
+              >
+                {ZONE_LABEL[z] || z}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function fmtRange(a, b) {
+  if (a != null && b != null) return `${a.toLocaleString('es-CO')}–${b.toLocaleString('es-CO')}`;
+  if (a != null) return `desde ${a.toLocaleString('es-CO')}`;
+  if (b != null) return `hasta ${b.toLocaleString('es-CO')}`;
+  return '—';
+}
+
+function fmtTemp(a, b) {
+  if (a != null && b != null) return `${a}–${b} °C óptimo`;
+  if (a != null) return `desde ${a} °C`;
+  if (b != null) return `hasta ${b} °C`;
+  return '—';
+}

--- a/src/components/DirectorioEspecies/SpeciesFicha.jsx
+++ b/src/components/DirectorioEspecies/SpeciesFicha.jsx
@@ -1,0 +1,305 @@
+import React from 'react';
+import {
+  Leaf,
+  Sprout,
+  ShieldCheck,
+  Ban,
+  FlaskConical,
+  Bug,
+  ShieldAlert,
+  BookOpen,
+  Mountain,
+  Sparkles,
+  ImageOff,
+} from 'lucide-react';
+import PisoTermicoBand from './PisoTermicoBand.jsx';
+
+/**
+ * SpeciesFicha — ficha visual completa y grounded de una especie del Directorio.
+ *
+ * Identidad Chagra, mobile-first. Cada sección se autocontiene y muestra
+ * deflección honesta ("sin datos de X todavía") cuando la fuente no tiene el
+ * dato. NUNCA inventa. Recibe la ficha ya construida por
+ * `buildSpeciesFicha(speciesId)`.
+ *
+ * @param {object} props
+ * @param {object} props.ficha — salida de buildSpeciesFicha.
+ * @param {(id: string) => void} [props.onSelectSpecies] — navegar a otra especie
+ *   (al tocar una asociación que está en el catálogo).
+ */
+export default function SpeciesFicha({ ficha, onSelectSpecies }) {
+  if (!ficha) return null;
+  const {
+    comun, cientifico, familia, estrato, nombresRegionales = [],
+    imagen, pisoTermico, asociaciones, biopreparados = [], amenazas = [],
+    fenologia, fuentes = [],
+  } = ficha;
+
+  return (
+    <article className="max-w-2xl mx-auto pb-10" data-testid="species-ficha">
+      {/* FOTO / fallback ilustrado */}
+      <SpeciesPhoto imagen={imagen} comun={comun} />
+
+      {/* Identidad */}
+      <header className="px-4 pt-4">
+        <h2 className="text-2xl font-black text-emerald-100 leading-tight">{comun}</h2>
+        {cientifico && (
+          <p className="text-sm italic text-emerald-300/80">{cientifico}</p>
+        )}
+        <div className="flex flex-wrap gap-1.5 mt-2">
+          {familia && <Pill icon={Leaf} tone="emerald">{familia}</Pill>}
+          {estrato && <Pill icon={Mountain} tone="slate">Estrato {estrato}</Pill>}
+        </div>
+        {nombresRegionales.length > 0 && (
+          <p className="text-xs text-slate-400 mt-2">
+            También: {nombresRegionales.join(' · ')}
+          </p>
+        )}
+      </header>
+
+      {/* PISO TÉRMICO / ALTITUD */}
+      <Section icon={Mountain} title="Piso térmico y clima" accent="amber">
+        <PisoTermicoBand pisoTermico={pisoTermico} />
+      </Section>
+
+      {/* ASOCIACIONES */}
+      <Section icon={Sprout} title="Asociaciones de cultivo" accent="emerald">
+        <div className="space-y-3">
+          <AssocGroup
+            label="Asociar (favorables)"
+            icon={ShieldCheck}
+            tone="emerald"
+            items={asociaciones?.compatibles}
+            emptyText="Sin asociaciones favorables registradas todavía."
+            onSelectSpecies={onSelectSpecies}
+          />
+          <AssocGroup
+            label="Evitar (antagonistas)"
+            icon={Ban}
+            tone="rose"
+            items={asociaciones?.antagonistas}
+            emptyText="Sin antagonistas registrados todavía."
+            onSelectSpecies={onSelectSpecies}
+          />
+        </div>
+      </Section>
+
+      {/* BIOPREPARADOS */}
+      <Section icon={FlaskConical} title="Biopreparados asociados" accent="teal">
+        {biopreparados.length === 0 ? (
+          <Empty>Sin biopreparados asociados en el grafo todavía.</Empty>
+        ) : (
+          <ul className="space-y-2" data-testid="ficha-biopreparados">
+            {biopreparados.map((b) => (
+              <li
+                key={b.id || b.nombre}
+                className="rounded-lg border border-teal-700/40 bg-teal-950/30 p-2.5"
+              >
+                <p className="text-sm font-bold text-teal-100 leading-tight flex items-center gap-1.5">
+                  <FlaskConical size={14} className="text-teal-300 shrink-0" aria-hidden="true" />
+                  {b.nombre}
+                </p>
+                {b.tipo && (
+                  <span className="text-[10px] uppercase tracking-wide text-teal-400/80">{b.tipo}</span>
+                )}
+                {b.dosis && (
+                  <p className="text-xs text-slate-300 mt-1"><span className="font-semibold text-slate-200">Dosis:</span> {b.dosis}</p>
+                )}
+                {b.uso && (
+                  <p className="text-xs text-slate-400 mt-0.5">{b.uso}</p>
+                )}
+                {!b.enCatalogo && (
+                  <p className="text-[10px] text-slate-500 italic mt-0.5">Receta detallada no curada en el catálogo todavía.</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      {/* PLAGAS / ENFERMEDADES + CONTROLADORES */}
+      <Section icon={Bug} title="Plagas, enfermedades y control biológico" accent="rose">
+        {amenazas.length === 0 ? (
+          <Empty>Sin plagas o enfermedades registradas todavía.</Empty>
+        ) : (
+          <ul className="space-y-2" data-testid="ficha-amenazas">
+            {amenazas.map((a) => (
+              <li
+                key={`${a.tipo}-${a.nombre}`}
+                className="rounded-lg border border-rose-800/40 bg-rose-950/20 p-2.5"
+              >
+                <p className="text-sm font-bold text-rose-100 leading-tight flex items-center gap-1.5">
+                  {a.tipo === 'enfermedad'
+                    ? <ShieldAlert size={14} className="text-rose-300 shrink-0" aria-hidden="true" />
+                    : <Bug size={14} className="text-rose-300 shrink-0" aria-hidden="true" />}
+                  {a.nombre}
+                  <span className="text-[10px] uppercase tracking-wide text-rose-400/70">{a.tipo}</span>
+                </p>
+                {a.controladores && a.controladores.length > 0 ? (
+                  <p className="text-xs text-emerald-200/90 mt-1">
+                    <ShieldCheck size={12} className="inline -mt-0.5 mr-1 text-emerald-300" aria-hidden="true" />
+                    Control: {a.controladores.join(' · ')}
+                  </p>
+                ) : (
+                  <p className="text-[11px] text-slate-500 italic mt-1">Sin controlador biológico registrado todavía.</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      {/* FENOLOGÍA / SABERES */}
+      {fenologia?.valorPedagogico && (
+        <Section icon={BookOpen} title="Manejo y saberes" accent="indigo">
+          <p className="text-sm text-slate-300 leading-relaxed whitespace-pre-line">
+            {fenologia.valorPedagogico}
+          </p>
+        </Section>
+      )}
+
+      {/* FUENTES */}
+      {fuentes.length > 0 && (
+        <div className="px-4 pt-5">
+          <p className="text-[11px] text-slate-500 flex items-start gap-1.5">
+            <Sparkles size={12} className="text-slate-500 mt-0.5 shrink-0" aria-hidden="true" />
+            <span>
+              Fuentes: {fuentes.map((f) => f.title).join(' · ')}. Datos del catálogo y
+              del grafo de conocimiento de Chagra; sin datos no se inventa nada.
+            </span>
+          </p>
+        </div>
+      )}
+    </article>
+  );
+}
+
+/* ---------------------------------------------------------------- subcomp. */
+
+function SpeciesPhoto({ imagen, comun }) {
+  if (imagen?.url) {
+    return (
+      <figure className="relative w-full aspect-[16/10] sm:aspect-[2/1] bg-slate-900 overflow-hidden">
+        <img
+          src={imagen.thumbUrl || imagen.url}
+          alt={`Foto de ${comun}`}
+          className="w-full h-full object-cover"
+          loading="lazy"
+        />
+        <figcaption className="absolute bottom-0 inset-x-0 px-3 py-1 text-[10px] text-white/80 bg-gradient-to-t from-black/70 to-transparent">
+          {imagen.source} · {imagen.license} · {imagen.rightsHolder}
+        </figcaption>
+      </figure>
+    );
+  }
+  // Fallback ilustrado elegante (SVG inline) — nunca imagen rota.
+  return (
+    <div
+      className="relative w-full aspect-[16/10] sm:aspect-[2/1] flex flex-col items-center justify-center bg-gradient-to-br from-emerald-950 via-slate-900 to-teal-950 overflow-hidden"
+      data-testid="species-photo-fallback"
+      role="img"
+      aria-label={`Sin foto de ${comun}; ilustración`}
+    >
+      <svg viewBox="0 0 120 120" className="w-24 h-24 opacity-80" aria-hidden="true">
+        <defs>
+          <linearGradient id="leafGrad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="#34d399" />
+            <stop offset="100%" stopColor="#0d9488" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M60 105 C60 70 42 58 30 40 C58 44 70 60 70 80 C84 60 86 40 90 22 C96 52 84 78 64 92 Z"
+          fill="url(#leafGrad)"
+        />
+        <path d="M60 105 L60 70" stroke="#065f46" strokeWidth="3" strokeLinecap="round" />
+      </svg>
+      <p className="mt-1 flex items-center gap-1.5 text-[11px] text-emerald-200/70">
+        <ImageOff size={12} aria-hidden="true" /> Sin foto en el catálogo todavía
+      </p>
+    </div>
+  );
+}
+
+function Section({ icon, title, accent, children }) {
+  const Icon = icon;
+  const ACC = {
+    amber: 'from-amber-400 to-orange-400',
+    emerald: 'from-emerald-400 to-teal-400',
+    teal: 'from-teal-400 to-cyan-400',
+    rose: 'from-rose-400 to-pink-400',
+    indigo: 'from-indigo-400 to-violet-400',
+  }[accent] || 'from-slate-400 to-slate-500';
+  return (
+    <section className="px-4 pt-5">
+      <h3 className="flex items-center gap-2 text-xs font-black text-slate-300 uppercase tracking-wider mb-2.5">
+        <span aria-hidden="true" className={`h-3.5 w-1 rounded-full bg-gradient-to-b ${ACC}`} />
+        <Icon size={15} className="text-slate-400" aria-hidden="true" />
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function AssocGroup({ label, icon, tone, items, emptyText, onSelectSpecies }) {
+  const Icon = icon;
+  const TONE = {
+    emerald: 'border-emerald-700/40 bg-emerald-950/30 text-emerald-100',
+    rose: 'border-rose-800/40 bg-rose-950/20 text-rose-100',
+  }[tone];
+  const list = Array.isArray(items) ? items : [];
+  return (
+    <div>
+      <p className="text-xs font-bold text-slate-400 mb-1.5 flex items-center gap-1.5">
+        <Icon size={13} aria-hidden="true" /> {label}
+      </p>
+      {list.length === 0 ? (
+        <Empty>{emptyText}</Empty>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {list.map((s) => {
+            const clickable = s.enCatalogo && typeof onSelectSpecies === 'function';
+            const content = (
+              <>
+                <span className="font-bold">{s.comun || s.id}</span>
+                {s.cientifico && <span className="italic text-[10px] text-slate-400 ml-1">{s.cientifico}</span>}
+              </>
+            );
+            return clickable ? (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => onSelectSpecies(s.id)}
+                className={`px-2 py-1 rounded-md border text-[11px] leading-tight ${TONE} hover:brightness-125 transition`}
+              >
+                {content}
+              </button>
+            ) : (
+              <span key={s.id} className={`px-2 py-1 rounded-md border text-[11px] leading-tight ${TONE} opacity-90`}>
+                {content}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Pill({ icon, tone, children }) {
+  const Icon = icon;
+  const TONE = {
+    emerald: 'bg-emerald-500/15 text-emerald-200 border-emerald-500/30',
+    slate: 'bg-slate-700/40 text-slate-300 border-slate-600/40',
+  }[tone] || 'bg-slate-700/40 text-slate-300 border-slate-600/40';
+  return (
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md border text-[11px] font-bold ${TONE}`}>
+      {Icon && <Icon size={11} aria-hidden="true" />}
+      {children}
+    </span>
+  );
+}
+
+function Empty({ children }) {
+  return <p className="text-xs text-slate-500 italic">{children}</p>;
+}

--- a/src/components/DirectorioEspecies/SpeciesFicha.test.jsx
+++ b/src/components/DirectorioEspecies/SpeciesFicha.test.jsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SpeciesFicha from './SpeciesFicha.jsx';
+
+const FICHA_COMPLETA = {
+  id: 'phaseolus_vulgaris',
+  comun: 'Frijol arbustivo',
+  cientifico: 'Phaseolus vulgaris L.',
+  familia: 'Fabaceae',
+  estrato: 'medio',
+  nombresRegionales: ['Cargamanto', 'Bola roja'],
+  imagen: null,
+  pisoTermico: {
+    thermalZones: ['frio', 'templado'],
+    altitud: { min_absoluto: 0, optimo_min: 1500, optimo_max: 2400, max_absoluto: 2800 },
+    temperatura: { helada_letal: 0, optimo_min: 16, optimo_max: 24 },
+    agua: 'medio',
+  },
+  asociaciones: {
+    compatibles: [{ id: 'zea_mays', comun: 'Maíz', cientifico: 'Zea mays', enCatalogo: true }],
+    antagonistas: [{ id: 'allium_cepa', comun: 'Cebolla', cientifico: 'Allium cepa', enCatalogo: false }],
+  },
+  biopreparados: [
+    { id: 'caldo_bordeles', nombre: 'Caldo bordelés', tipo: 'caldo', dosis: '1%', uso: 'Foliar', ingredientes: ['cobre'], enCatalogo: true },
+  ],
+  amenazas: [
+    { nombre: 'Bemisia tabaci', tipo: 'plaga', controladores: ['Encarsia formosa'] },
+    { nombre: 'Roya', tipo: 'enfermedad', controladores: [] },
+  ],
+  fenologia: { valorPedagogico: 'El frijol fija nitrógeno.' },
+  fuentes: [{ id: 'agrosavia', title: 'Agrosavia' }],
+};
+
+const FICHA_VACIA = {
+  id: 'x', comun: 'Especie sin datos', cientifico: 'Ignota sp.', familia: '', estrato: '',
+  nombresRegionales: [], imagen: null,
+  pisoTermico: { thermalZones: [], altitud: null, temperatura: null, agua: null },
+  asociaciones: { compatibles: [], antagonistas: [] },
+  biopreparados: [], amenazas: [],
+  fenologia: { valorPedagogico: '' }, fuentes: [],
+};
+
+describe('SpeciesFicha', () => {
+  it('renderiza identidad y secciones con datos', () => {
+    render(<SpeciesFicha ficha={FICHA_COMPLETA} />);
+    expect(screen.getByText('Frijol arbustivo')).toBeInTheDocument();
+    expect(screen.getByText('Phaseolus vulgaris L.')).toBeInTheDocument();
+    expect(screen.getByTestId('ficha-biopreparados')).toBeInTheDocument();
+    expect(screen.getByText('Caldo bordelés')).toBeInTheDocument();
+    expect(screen.getByText(/1%/)).toBeInTheDocument();
+    expect(screen.getByTestId('ficha-amenazas')).toBeInTheDocument();
+    expect(screen.getByText(/Encarsia formosa/)).toBeInTheDocument();
+  });
+
+  it('muestra el fallback ilustrado cuando no hay foto', () => {
+    render(<SpeciesFicha ficha={FICHA_COMPLETA} />);
+    expect(screen.getByTestId('species-photo-fallback')).toBeInTheDocument();
+  });
+
+  it('renderiza la banda de piso térmico con altitud', () => {
+    render(<SpeciesFicha ficha={FICHA_COMPLETA} />);
+    expect(screen.getByTestId('piso-termico-band')).toBeInTheDocument();
+    expect(screen.getAllByText(/óptimo/).length).toBeGreaterThan(0);
+    // rango óptimo de altitud (separador de miles depende de ICU: 1.500 / 1,500 / 1500)
+    expect(screen.getByText(/1[.,]?500/)).toBeInTheDocument();
+  });
+
+  it('asociación en catálogo es clickeable y navega', () => {
+    const onSelect = vi.fn();
+    render(<SpeciesFicha ficha={FICHA_COMPLETA} onSelectSpecies={onSelect} />);
+    fireEvent.click(screen.getByText('Maíz'));
+    expect(onSelect).toHaveBeenCalledWith('zea_mays');
+  });
+
+  it('deflección honesta en secciones sin datos', () => {
+    render(<SpeciesFicha ficha={FICHA_VACIA} />);
+    expect(screen.getByTestId('piso-sin-dato')).toBeInTheDocument();
+    expect(screen.getByText(/Sin biopreparados asociados/)).toBeInTheDocument();
+    expect(screen.getByText(/Sin plagas o enfermedades/)).toBeInTheDocument();
+    expect(screen.getByText(/Sin asociaciones favorables/)).toBeInTheDocument();
+  });
+
+  it('controlador ausente muestra deflección, no inventa', () => {
+    render(<SpeciesFicha ficha={FICHA_COMPLETA} />);
+    expect(screen.getByText(/Sin controlador biológico registrado/)).toBeInTheDocument();
+  });
+
+  it('renderiza foto cuando existe imagen', () => {
+    const ficha = { ...FICHA_COMPLETA, imagen: { url: 'https://x/a.jpg', license: 'CC-BY', rightsHolder: 'A', source: 'iNaturalist' } };
+    render(<SpeciesFicha ficha={ficha} />);
+    const img = screen.getByAltText(/Foto de Frijol/);
+    expect(img).toBeInTheDocument();
+  });
+
+  it('no rompe con ficha null', () => {
+    const { container } = render(<SpeciesFicha ficha={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -123,6 +123,7 @@ const HERRAMIENTAS_TILES = [
     { view: 'germinacion', label: 'Semilleros', icon: TestTube, desc: 'Prueba de semillas y germinación', accent: 'text-teal-400 border-l-teal-500' },
     { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo de suelo', accent: 'text-rose-400 border-l-rose-500' },
     { view: 'aprende', label: 'Aprende', icon: BookOpen, desc: 'Lecciones agroecológicas con fuente', accent: 'text-emerald-400 border-l-emerald-500' },
+    { view: 'directorio', label: 'Especies', icon: Sprout, desc: 'Directorio: clima, asociaciones y plagas', accent: 'text-lime-400 border-l-lime-500' },
     // Huérfanos rescatados 2026-06-24 (descubribilidad). Eran rutas vivas en el
     // router pero sin entrada en la home viva (CAPABILITIES_STATUS.md §2):
     //  · biopreparados → galería de recetas paso a paso (antes solo desde el juego).

--- a/src/services/__tests__/directorioEspecies.test.js
+++ b/src/services/__tests__/directorioEspecies.test.js
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock de las fuentes de datos: catálogo SQLite, grafo offline e imágenes.
+vi.mock('../../db/catalogDB.js', () => ({
+  getAllSpecies: vi.fn(),
+  getSpeciesById: vi.fn(),
+  getAllBiopreparados: vi.fn(),
+}));
+vi.mock('../grafoRelations.js', () => ({
+  getRelationsForSpecies: vi.fn(),
+}));
+vi.mock('../../utils/speciesImageResolver.js', () => ({
+  findLocalImage: vi.fn(),
+}));
+
+import {
+  getAllSpecies,
+  getSpeciesById,
+  getAllBiopreparados,
+} from '../../db/catalogDB.js';
+import { getRelationsForSpecies } from '../grafoRelations.js';
+import { findLocalImage } from '../../utils/speciesImageResolver.js';
+import {
+  searchSpecies,
+  buildSpeciesFicha,
+  altitudToPct,
+  __resetDirectorioCache,
+} from '../directorioEspecies.js';
+
+const FRIJOL = {
+  id: 'phaseolus_vulgaris',
+  nombre_comun: 'Frijol arbustivo / voluble',
+  nombre_cientifico: 'Phaseolus vulgaris L.',
+  nombre_comunes_regionales: ['Frijol cargamanto', 'Bola roja'],
+  familia_botanica: 'Fabaceae',
+  thermal_zones: ['frio', 'templado', 'calido'],
+  altitud_msnm: { min_absoluto: 0, optimo_min: 1500, optimo_max: 2400, max_absoluto: 2800 },
+  temperatura_c: { helada_letal: 0, optimo_min: 16, optimo_max: 24, max_tolerable: 30 },
+  agua: 'medio',
+  estrato: 'medio',
+  plagas_criticas: ['Empoasca kraemeri', 'Bemisia tabaci'],
+  enfermedades_criticas: ['Uromyces appendiculatus'],
+  companions: ['zea_mays', 'cucurbita_maxima'],
+  antagonists: ['allium_cepa'],
+  valor_pedagogico: 'El frijol común fija nitrógeno con Rhizobium.',
+  source_ids: ['agrosavia-manual', 'gbif'],
+};
+const MAIZ = { id: 'zea_mays', nombre_comun: 'Maíz criollo', nombre_cientifico: 'Zea mays L.', familia_botanica: 'Poaceae' };
+const CALABAZA = { id: 'cucurbita_maxima', nombre_comun: 'Zapallo', nombre_cientifico: 'Cucurbita maxima Duchesne' };
+const CEBOLLA = { id: 'allium_cepa', nombre_comun: 'Cebolla cabezona', nombre_cientifico: 'Allium cepa L.' };
+
+const CATALOG = [FRIJOL, MAIZ, CALABAZA, CEBOLLA];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetDirectorioCache();
+  getAllSpecies.mockResolvedValue(CATALOG);
+  getSpeciesById.mockImplementation(async (id) => CATALOG.find((s) => s.id === id) || null);
+  getAllBiopreparados.mockResolvedValue([]);
+  getRelationsForSpecies.mockResolvedValue(null);
+  findLocalImage.mockResolvedValue(null);
+});
+
+describe('searchSpecies', () => {
+  it('encuentra por nombre común exacto', async () => {
+    const res = await searchSpecies('Zapallo');
+    expect(res[0].id).toBe('cucurbita_maxima');
+    expect(res[0].match).toBe('exact');
+  });
+
+  it('encuentra por nombre regional', async () => {
+    const res = await searchSpecies('Frijol cargamanto');
+    expect(res.some((r) => r.id === 'phaseolus_vulgaris')).toBe(true);
+  });
+
+  it('resuelve alias curado (frijol → phaseolus_vulgaris) sin ambigüedad', async () => {
+    const res = await searchSpecies('frijol');
+    expect(res).toHaveLength(1);
+    expect(res[0].id).toBe('phaseolus_vulgaris');
+    expect(res[0].match).toBe('alias');
+  });
+
+  it('lista varios candidatos por palabra completa', async () => {
+    const res = await searchSpecies('cebolla');
+    expect(res.some((r) => r.id === 'allium_cepa')).toBe(true);
+  });
+
+  it('devuelve [] para consultas demasiado cortas', async () => {
+    expect(await searchSpecies('a')).toEqual([]);
+    expect(await searchSpecies('')).toEqual([]);
+  });
+
+  it('no cruza géneros (sin coincidencias = lista vacía)', async () => {
+    const res = await searchSpecies('orquídea galáctica');
+    expect(res).toEqual([]);
+  });
+
+  it('degrada a [] si el catálogo no carga', async () => {
+    getAllSpecies.mockRejectedValueOnce(new Error('db down'));
+    expect(await searchSpecies('frijol')).toEqual([]);
+  });
+});
+
+describe('buildSpeciesFicha', () => {
+  it('null si la especie no existe', async () => {
+    getSpeciesById.mockResolvedValueOnce(null);
+    expect(await buildSpeciesFicha('inexistente')).toBeNull();
+  });
+
+  it('construye identidad + piso térmico desde el catálogo', async () => {
+    const f = await buildSpeciesFicha('phaseolus_vulgaris');
+    expect(f.comun).toBe('Frijol arbustivo / voluble');
+    expect(f.cientifico).toBe('Phaseolus vulgaris L.');
+    expect(f.familia).toBe('Fabaceae');
+    expect(f.pisoTermico.thermalZones).toEqual(['frio', 'templado', 'calido']);
+    expect(f.pisoTermico.altitud.optimo_min).toBe(1500);
+    expect(f.pisoTermico.temperatura.optimo_max).toBe(24);
+  });
+
+  it('resuelve nombres de asociaciones contra el catálogo', async () => {
+    const f = await buildSpeciesFicha('phaseolus_vulgaris');
+    const compat = f.asociaciones.compatibles;
+    const maiz = compat.find((c) => c.id === 'zea_mays');
+    expect(maiz.comun).toBe('Maíz criollo');
+    expect(maiz.enCatalogo).toBe(true);
+    expect(f.asociaciones.antagonistas.find((a) => a.id === 'allium_cepa').comun).toBe('Cebolla cabezona');
+  });
+
+  it('biopreparados vacíos cuando el grafo no tiene datos (deflección)', async () => {
+    const f = await buildSpeciesFicha('phaseolus_vulgaris');
+    expect(f.biopreparados).toEqual([]);
+  });
+
+  it('une plagas del catálogo con controladores del grafo', async () => {
+    getRelationsForSpecies.mockResolvedValueOnce({
+      compatible_with: ['zea_mays'],
+      antagonist_of: [],
+      biopreparados: [{ id: 'beauveria_bassiana', nombre: 'Beauveria bassiana' }],
+      pest_controllers: [
+        { plaga: 'Bemisia tabaci', controladores: ['Encarsia formosa', 'Trampa amarilla'] },
+      ],
+    });
+    const f = await buildSpeciesFicha('phaseolus_vulgaris');
+    const bemisia = f.amenazas.find((a) => a.nombre.toLowerCase().includes('bemisia'));
+    expect(bemisia.controladores).toContain('Encarsia formosa');
+    expect(f.biopreparados[0].nombre).toBe('Beauveria bassiana');
+  });
+
+  it('enriquece biopreparado con dosis del catálogo si el id coincide', async () => {
+    getAllBiopreparados.mockResolvedValueOnce([
+      {
+        id: 'caldo_bordeles',
+        nombre: 'Caldo bordelés',
+        data: JSON.stringify({ tipo: 'caldo', dosis: '1%', uso: 'Foliar preventivo', ingredientes: ['sulfato de cobre', 'cal'] }),
+      },
+    ]);
+    getRelationsForSpecies.mockResolvedValueOnce({
+      biopreparados: [{ id: 'caldo_bordeles', nombre: 'Caldo bordelés' }],
+      pest_controllers: [],
+    });
+    const f = await buildSpeciesFicha('phaseolus_vulgaris');
+    expect(f.biopreparados[0].dosis).toBe('1%');
+    expect(f.biopreparados[0].enCatalogo).toBe(true);
+    expect(f.biopreparados[0].ingredientes).toContain('sulfato de cobre');
+  });
+
+  it('expone la imagen cuando el resolver la encuentra', async () => {
+    findLocalImage.mockResolvedValueOnce({
+      url: 'https://x/img.jpg', thumbUrl: 'https://x/thumb.jpg',
+      license: 'CC-BY', rightsHolder: 'Foto', source: 'iNaturalist', sourceUrl: 'https://x',
+    });
+    const f = await buildSpeciesFicha('phaseolus_vulgaris');
+    expect(f.imagen.url).toBe('https://x/img.jpg');
+  });
+
+  it('imagen null cuando no hay foto (la UI usa fallback)', async () => {
+    const f = await buildSpeciesFicha('phaseolus_vulgaris');
+    expect(f.imagen).toBeNull();
+  });
+
+  it('no lanza si el grafo cae; degrada secciones a vacío', async () => {
+    getRelationsForSpecies.mockRejectedValueOnce(new Error('grafo offline'));
+    const f = await buildSpeciesFicha('phaseolus_vulgaris');
+    expect(f).toBeTruthy();
+    expect(f.biopreparados).toEqual([]);
+  });
+});
+
+describe('altitudToPct', () => {
+  it('mapea altitud a porcentaje sobre la franja', () => {
+    expect(altitudToPct(0)).toBe(0);
+    expect(altitudToPct(2100)).toBe(50);
+    expect(altitudToPct(4200)).toBe(100);
+    expect(altitudToPct(9999)).toBe(100); // clamp
+    expect(altitudToPct('x')).toBeNull();
+  });
+});

--- a/src/services/directorioEspecies.js
+++ b/src/services/directorioEspecies.js
@@ -1,0 +1,439 @@
+/**
+ * directorioEspecies.js — orquestación de datos del Directorio de Especies.
+ *
+ * Explorador visual del catálogo: dado un nombre libre ("frailejón",
+ * "mandarina", "frijol cargamanto"), resuelve la(s) especie(s) del catálogo y
+ * construye una FICHA grounded uniendo TODAS las fuentes locales/offline que ya
+ * existen en el cliente — sin reinventar resolvers ni tocar el sidecar GPU:
+ *
+ *   - catalog.sqlite (getAllSpecies/getSpeciesById)  → identidad, piso térmico,
+ *       altitud, asociaciones (companions/antagonists), plagas/enfermedades,
+ *       fenología (valor_pedagogico), familia, estrato.
+ *   - grafo-relations.json (grafoRelations)          → biopreparados y
+ *       controladores biológicos por plaga (aristas del grafo AGE exportadas).
+ *   - species-images.json (speciesImageResolver)     → foto CC del binomio.
+ *   - catalog.sqlite biopreparados                   → dosis/uso/ingredientes
+ *       cuando el id del grafo coincide con una receta curada del catálogo.
+ *
+ * Regla anti-alucinación: si una fuente no tiene el dato, la sección queda
+ * vacía y la UI muestra una deflección honesta ("sin datos de X todavía").
+ * NUNCA se inventa relación, dosis ni foto.
+ *
+ * Búsqueda: REUSA `normalizeForMatch` / `containsWholeWord` / `CURATED_ALIASES`
+ * de utils/speciesResolver (el matcher canónico del proyecto) para devolver
+ * candidatos ranqueados cuando la consulta es ambigua, sin cruzar géneros.
+ */
+
+import {
+  getAllSpecies,
+  getSpeciesById,
+  getAllBiopreparados,
+} from '../db/catalogDB.js';
+import { getRelationsForSpecies } from './grafoRelations.js';
+import { findLocalImage } from '../utils/speciesImageResolver.js';
+import { normalizeForMatch, __TEST__ as RESOLVER_TEST } from '../utils/speciesResolver.js';
+
+const { containsWholeWord, CURATED_ALIASES } = RESOLVER_TEST;
+
+// Etiquetas, iconografía conceptual y rango canónico de cada piso térmico
+// colombiano. El rango msnm es referencial (frontera difusa); la franja visual
+// usa la altitud REAL de la especie cuando existe, esto es solo el telón.
+export const PISOS_TERMICOS = [
+  { id: 'calido', label: 'Cálido', minM: 0, maxM: 1000, tempC: '24–28 °C', tone: 'orange' },
+  { id: 'templado', label: 'Templado', minM: 1000, maxM: 2000, tempC: '17–24 °C', tone: 'amber' },
+  { id: 'frio', label: 'Frío', minM: 2000, maxM: 3000, tempC: '12–17 °C', tone: 'emerald' },
+  { id: 'paramo', label: 'Páramo', minM: 3000, maxM: 4200, tempC: '< 12 °C', tone: 'indigo' },
+];
+
+const ALTITUD_TECHO_M = 4200; // techo de la franja visual (alto-andino).
+
+/**
+ * Nombre legible de una especie del catálogo (común + científico).
+ * @param {object} sp — row del catálogo (data JSON).
+ * @returns {{ id: string, comun: string, cientifico: string }}
+ */
+function speciesLabel(sp) {
+  if (!sp) return { id: '', comun: '', cientifico: '' };
+  return {
+    id: sp.id || sp.slug || '',
+    comun: sp.nombre_comun || sp.name_es || sp.id || '',
+    cientifico: sp.nombre_cientifico || sp.name_la || '',
+  };
+}
+
+/**
+ * Convierte la lista de ids de asociación (companions/antagonists) en
+ * objetos legibles resolviendo cada id contra el índice del catálogo. Los ids
+ * sin entrada se muestran con el id "humanizado" (nunca se descartan en
+ * silencio — el dato existe en el grafo aunque la especie no esté poblada).
+ *
+ * @param {string[]} ids
+ * @param {Map<string, object>} byId — índice id → species row.
+ * @returns {Array<{ id: string, comun: string, cientifico: string, enCatalogo: boolean }>}
+ */
+function resolveAssociationIds(ids, byId) {
+  if (!Array.isArray(ids)) return [];
+  return ids
+    .filter((id) => typeof id === 'string' && id)
+    .map((id) => {
+      const sp = byId.get(id);
+      if (sp) return { ...speciesLabel(sp), enCatalogo: true };
+      return {
+        id,
+        comun: humanizeId(id),
+        cientifico: '',
+        enCatalogo: false,
+      };
+    });
+}
+
+/** "solanum_tuberosum_sabanera" → "Solanum tuberosum sabanera" (fallback legible). */
+function humanizeId(id) {
+  return String(id || '')
+    .split('_')
+    .filter(Boolean)
+    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+
+let biopreparadoIndexCache = null;
+/** Índice id → receta del catálogo de biopreparados (lazy, una vez). */
+async function getBiopreparadoIndex() {
+  if (biopreparadoIndexCache) return biopreparadoIndexCache;
+  const idx = new Map();
+  try {
+    const all = await getAllBiopreparados();
+    for (const bp of all || []) {
+      if (bp && bp.id) idx.set(bp.id, bp);
+    }
+  } catch (e) {
+    console.warn('[directorioEspecies] biopreparados no disponibles:', e?.message || e);
+  }
+  biopreparadoIndexCache = idx;
+  return idx;
+}
+
+/** Invalida caches internos (tests / cambios de catálogo). */
+export function __resetDirectorioCache() {
+  biopreparadoIndexCache = null;
+}
+
+/**
+ * Busca especies por texto libre y devuelve candidatos RANQUEADOS.
+ *
+ * Estrategia (reusa el matcher canónico del proyecto, sin cruzar géneros):
+ *   0. Alias curado exacto (frijol→phaseolus_vulgaris, limón→cítrico, …).
+ *   1. id exacto.
+ *   2. Nombre común/científico/regional EXACTO normalizado.
+ *   3. Palabra completa con frontera (consulta = palabra entera del nombre, o
+ *      el nombre = palabra entera de la consulta). Ranqueado por especificidad.
+ *
+ * @param {string} query — texto libre del buscador.
+ * @param {object} [opts]
+ * @param {number} [opts.limit=12] — máximo de candidatos devueltos.
+ * @returns {Promise<Array<{ id, comun, cientifico, familia, match: 'alias'|'exact'|'word' }>>}
+ */
+export async function searchSpecies(query, opts = {}) {
+  const { limit = 12 } = opts;
+  const q = normalizeForMatch(query);
+  if (!q || q.length < 2) return [];
+
+  let list;
+  try {
+    list = await getAllSpecies();
+  } catch (e) {
+    console.warn('[directorioEspecies] catálogo no disponible:', e?.message || e);
+    return [];
+  }
+  if (!Array.isArray(list) || list.length === 0) return [];
+
+  // 0) Alias curado → si el destino existe, gana solo (sin ambigüedad).
+  const aliasTarget = CURATED_ALIASES[q];
+  if (aliasTarget) {
+    const hit = list.find((s) => s?.id === aliasTarget || s?.slug === aliasTarget);
+    if (hit) return [{ ...labelWithFamilia(hit), match: 'alias' }];
+  }
+
+  const exact = [];
+  const word = [];
+  const seen = new Set();
+
+  for (const sp of list) {
+    if (!sp) continue;
+    const id = sp.id || sp.slug;
+    if (!id || seen.has(id)) continue;
+
+    const names = collectNames(sp);
+    const normalizedNames = names.map(normalizeForMatch).filter(Boolean);
+
+    // 1/2) match exacto por id o por cualquier nombre normalizado.
+    if (normalizeForMatch(id) === q || normalizedNames.includes(q)) {
+      exact.push({ ...labelWithFamilia(sp), match: 'exact' });
+      seen.add(id);
+      continue;
+    }
+
+    // 3) palabra completa con frontera (≥3 chars para evitar ruido).
+    if (q.length >= 3) {
+      const hit = normalizedNames.some(
+        (n) => containsWholeWord(n, q) || containsWholeWord(q, n),
+      );
+      if (hit) {
+        // peso = longitud del nombre más corto que matcheó (más corto = más
+        // genérico/relevante).
+        const matchedLen = Math.min(
+          ...normalizedNames
+            .filter((n) => containsWholeWord(n, q) || containsWholeWord(q, n))
+            .map((n) => n.length),
+        );
+        word.push({ ...labelWithFamilia(sp), match: 'word', _w: matchedLen });
+        seen.add(id);
+      }
+    }
+  }
+
+  word.sort((a, b) => a._w - b._w);
+  const ranked = [...exact, ...word.map(({ _w, ...rest }) => rest)];
+  return ranked.slice(0, limit);
+}
+
+/** Recolecta todos los nombres buscables de una especie del catálogo. */
+function collectNames(sp) {
+  const out = [];
+  if (sp.nombre_comun) {
+    // El catálogo lista variantes con "/": "Frijol arbustivo / voluble".
+    for (const part of String(sp.nombre_comun).split('/')) out.push(part.trim());
+  }
+  if (sp.name_es) out.push(sp.name_es);
+  if (sp.nombre_cientifico) out.push(sp.nombre_cientifico);
+  if (sp.name_la) out.push(sp.name_la);
+  if (Array.isArray(sp.nombre_comunes_regionales)) out.push(...sp.nombre_comunes_regionales);
+  if (Array.isArray(sp.nombres_comunes)) out.push(...sp.nombres_comunes);
+  return out.filter(Boolean);
+}
+
+function labelWithFamilia(sp) {
+  return {
+    ...speciesLabel(sp),
+    familia: sp.familia_botanica || sp.family || '',
+  };
+}
+
+/**
+ * Normaliza el rango de altitud de una especie a la forma estándar
+ * { min_absoluto, optimo_min, optimo_max, max_absoluto } sin importar si vino
+ * como `altitud_msnm` (catálogo SQLite) o `requirements.altitud_msnm`
+ * (cycle-content). Devuelve null si no hay dato.
+ */
+function normalizeAltitud(sp) {
+  const a = sp?.altitud_msnm || sp?.requirements?.altitud_msnm || null;
+  if (!a || typeof a !== 'object') return null;
+  const pick = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+  const out = {
+    min_absoluto: pick(a.min_absoluto),
+    optimo_min: pick(a.optimo_min),
+    optimo_max: pick(a.optimo_max),
+    max_absoluto: pick(a.max_absoluto),
+  };
+  // Si TODO es null, no hay rango útil.
+  if (Object.values(out).every((v) => v === null)) return null;
+  return out;
+}
+
+/**
+ * Construye la FICHA completa y grounded de una especie por su id.
+ *
+ * Une catálogo + grafo + imagen. Cada sección reporta su propia presencia para
+ * que la UI muestre deflección honesta donde falte el dato. NUNCA lanza:
+ * cualquier fuente caída degrada esa sección a vacía.
+ *
+ * @param {string} speciesId
+ * @returns {Promise<null | object>} null si la especie no existe en el catálogo.
+ */
+export async function buildSpeciesFicha(speciesId) {
+  if (!speciesId || typeof speciesId !== 'string') return null;
+
+  let sp = null;
+  try {
+    sp = await getSpeciesById(speciesId);
+  } catch (e) {
+    console.warn('[directorioEspecies] getSpeciesById falló:', e?.message || e);
+  }
+  if (!sp) return null;
+
+  // Índice id → species para resolver nombres de asociaciones.
+  let byId = new Map();
+  try {
+    const all = await getAllSpecies();
+    for (const s of all || []) {
+      if (s?.id) byId.set(s.id, s);
+      else if (s?.slug) byId.set(s.slug, s);
+    }
+  } catch (_) {
+    /* sin índice → las asociaciones se muestran humanizadas por id */
+  }
+
+  // --- Relaciones del grafo (offline) — biopreparados + controladores. ---
+  let rel = null;
+  try {
+    rel = await getRelationsForSpecies(speciesId);
+  } catch (_) {
+    /* sin grafo → secciones de biopreparados/controladores vacías */
+  }
+
+  // --- Imagen CC (binomio) ---
+  let imagen = null;
+  try {
+    imagen = await findLocalImage(sp.nombre_cientifico || sp.name_la || speciesId);
+  } catch (_) {
+    imagen = null;
+  }
+
+  // --- Asociaciones (catálogo manda; grafo complementa) ---
+  const compatibleIds = uniqueStrings([
+    ...(Array.isArray(sp.companions) ? sp.companions : []),
+    ...(rel && Array.isArray(rel.compatible_with) ? rel.compatible_with : []),
+  ]);
+  const antagonistIds = uniqueStrings([
+    ...(Array.isArray(sp.antagonists) ? sp.antagonists : []),
+    ...(rel && Array.isArray(rel.antagonist_of) ? rel.antagonist_of : []),
+  ]);
+
+  // --- Biopreparados (grafo) enriquecidos con receta del catálogo si existe ---
+  const bioIndex = await getBiopreparadoIndex();
+  const biopreparados = (rel && Array.isArray(rel.biopreparados) ? rel.biopreparados : [])
+    .filter((b) => b && !b.disputed && (b.id || b.nombre))
+    .map((b) => {
+      const receta = b.id ? bioIndex.get(b.id) : null;
+      const data = receta?.data ? safeParse(receta.data) : null;
+      return {
+        id: b.id || '',
+        nombre: b.nombre || (data?.nombre) || humanizeId(b.id),
+        // Detalle curado del catálogo (solo si el id coincide):
+        tipo: data?.tipo || null,
+        dosis: data?.dosis || null,
+        uso: data?.uso || null,
+        ingredientes: Array.isArray(data?.ingredientes) ? data.ingredientes : null,
+        enCatalogo: Boolean(receta),
+      };
+    });
+
+  // --- Plagas/enfermedades (catálogo) + controladores (grafo) ---
+  const controllersByPlaga = new Map();
+  if (rel && Array.isArray(rel.pest_controllers)) {
+    for (const pc of rel.pest_controllers) {
+      if (pc && pc.plaga && !pc.disputed && Array.isArray(pc.controladores)) {
+        controllersByPlaga.set(
+          normalizeForMatch(pc.plaga),
+          { plaga: pc.plaga, controladores: pc.controladores.filter(Boolean) },
+        );
+      }
+    }
+  }
+  const amenazas = buildAmenazas(sp, controllersByPlaga);
+
+  return {
+    id: speciesId,
+    ...speciesLabel(sp),
+    familia: sp.familia_botanica || sp.family || '',
+    categoria: sp.category || '',
+    estrato: sp.estrato || '',
+    cultivable: sp.cultivable !== false,
+    nombresRegionales: uniqueStrings([
+      ...(Array.isArray(sp.nombre_comunes_regionales) ? sp.nombre_comunes_regionales : []),
+      ...(rel && Array.isArray(rel.nombres_comunes) ? rel.nombres_comunes : []),
+    ]),
+    imagen, // { url, thumbUrl, license, rightsHolder, source, sourceUrl } | null
+    pisoTermico: {
+      thermalZones: Array.isArray(sp.thermal_zones) ? sp.thermal_zones : [],
+      altitud: normalizeAltitud(sp),
+      temperatura: sp.temperatura_c || null,
+      agua: sp.agua || null,
+    },
+    asociaciones: {
+      compatibles: resolveAssociationIds(compatibleIds, byId),
+      antagonistas: resolveAssociationIds(antagonistIds, byId),
+    },
+    biopreparados,
+    amenazas, // [{ nombre, tipo: 'plaga'|'enfermedad', controladores: [str] }]
+    fenologia: {
+      valorPedagogico: sp.valor_pedagogico || '',
+      cycleMonths: sp.cycleMonths ?? null,
+      propagation: sp.propagation || null,
+      harvestType: sp.harvest_type || null,
+    },
+    fuentes: collectSources(sp),
+  };
+}
+
+/** Une plagas/enfermedades del catálogo con sus controladores del grafo. */
+function buildAmenazas(sp, controllersByPlaga) {
+  const out = [];
+  const push = (nombre, tipo) => {
+    if (!nombre) return;
+    const key = normalizeForMatch(nombre);
+    // match por palabra completa contra las plagas del grafo (los nombres no
+    // son idénticos: catálogo "Bemisia tabaci" vs grafo "mosca blanca").
+    let controladores = [];
+    const direct = controllersByPlaga.get(key);
+    if (direct) {
+      controladores = direct.controladores;
+    } else {
+      for (const [, pc] of controllersByPlaga) {
+        const pk = normalizeForMatch(pc.plaga);
+        if (containsWholeWord(key, pk) || containsWholeWord(pk, key)) {
+          controladores = pc.controladores;
+          break;
+        }
+      }
+    }
+    out.push({ nombre, tipo, controladores });
+  };
+  if (Array.isArray(sp.plagas_criticas)) for (const p of sp.plagas_criticas) push(p, 'plaga');
+  if (Array.isArray(sp.enfermedades_criticas)) for (const e of sp.enfermedades_criticas) push(e, 'enfermedad');
+  // Plagas que SOLO trae el grafo (no listadas como críticas en el catálogo).
+  for (const [, pc] of controllersByPlaga) {
+    const ya = out.some((a) => {
+      const ak = normalizeForMatch(a.nombre);
+      const pk = normalizeForMatch(pc.plaga);
+      return containsWholeWord(ak, pk) || containsWholeWord(pk, ak) || ak === pk;
+    });
+    if (!ya) out.push({ nombre: pc.plaga, tipo: 'plaga', controladores: pc.controladores });
+  }
+  return out;
+}
+
+function collectSources(sp) {
+  const raw = Array.isArray(sp.sources) ? sp.sources
+    : Array.isArray(sp.source_ids) ? sp.source_ids.map((id) => ({ id, title: id }))
+    : [];
+  return raw
+    .map((s) => (typeof s === 'string' ? { id: s, title: s } : s))
+    .filter((s) => s && (s.id || s.title))
+    .map((s) => ({ id: s.id || s.title, title: s.title || s.id, url: s.url || null, tier: s.tier || null }));
+}
+
+function uniqueStrings(arr) {
+  return [...new Set((arr || []).filter((x) => typeof x === 'string' && x))];
+}
+
+function safeParse(json) {
+  try {
+    return typeof json === 'string' ? JSON.parse(json) : json;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Resuelve la posición porcentual [0..100] de un valor de altitud sobre la
+ * franja visual (0 → ALTITUD_TECHO_M). Útil para posicionar marcadores en la
+ * banda de piso térmico.
+ */
+export function altitudToPct(msnm) {
+  if (typeof msnm !== 'number' || !Number.isFinite(msnm)) return null;
+  const clamped = Math.max(0, Math.min(ALTITUD_TECHO_M, msnm));
+  return Math.round((clamped / ALTITUD_TECHO_M) * 100);
+}
+
+export const __ALTITUD_TECHO_M = ALTITUD_TECHO_M;


### PR DESCRIPTION
## Feature
Vista nueva **Directorio de especies**: explorador visual del catálogo. Buscador con resolución de nombre + ficha grounded por especie (foto, piso térmico, asociaciones, biopreparados, plagas/control biológico, saberes), mobile-first con identidad Chagra.

## Cambios
- `src/services/directorioEspecies.js` — orquestación de datos. `searchSpecies` (reutiliza el matcher canónico `normalizeForMatch`/`containsWholeWord` + `CURATED_ALIASES` de `utils/speciesResolver`; ranquea candidatos, no cruza géneros) y `buildSpeciesFicha` (une catálogo + grafo + imagen).
- `src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx` — buscador con debounce; si hay varios candidatos los lista para elegir; abre la ficha.
- `src/components/DirectorioEspecies/SpeciesFicha.jsx` — ficha completa con foto (fallback SVG ilustrado, nunca rota), secciones y deflección honesta por sección.
- `src/components/DirectorioEspecies/PisoTermicoBand.jsx` — banda visual de piso térmico / altitud / temperatura.
- `src/App.jsx` — lazy import + ruta `case 'directorio'` + alias de hash (`directorio`/`directorio-especies`/`especies`) + `MODULE_VIEWS`.
- `src/components/dashboard/DashboardLive.jsx` — tile visible **"Especies"** en `HERRAMIENTAS_TILES`.

## Fuentes / tools por sección (todo offline-first, sin sidecar/GPU)
| Sección | Fuente |
|---|---|
| Foto | `speciesImageResolver.findLocalImage` (species-images.json, CC) + fallback SVG |
| Piso térmico / altitud / clima | `catalog.sqlite` → `altitud_msnm` + `thermal_zones` + `temperatura_c` + `agua` |
| Asociaciones ✅/⛔ | `companions`/`antagonists` (catálogo) ∪ `compatible_with`/`antagonist_of` (grafo-relations.json) |
| Biopreparados | `grafoRelations` `biopreparados`, enriquecidos con dosis/uso/ingredientes del catálogo si el id coincide |
| Plagas/enfermedades + control | `plagas_criticas`/`enfermedades_criticas` (catálogo) + `pest_controllers` (grafo) |
| Manejo y saberes | `valor_pedagogico`, `familia_botanica`, `estrato` + `sources` |

## Anti-alucinación
Cada sección muestra deflección honesta ("sin datos de X todavía") cuando la fuente no tiene el dato. Nunca inventa relación, dosis ni foto.

## Cableado (anti-huérfana)
Confirmado por grep: **import** (lazy en App.jsx) + **ruta** (switch `case 'directorio'` + hash + MODULE_VIEWS) + **entrada visible** (tile "Especies" en HERRAMIENTAS_TILES del home).

## Tests
- 25 vitest pasando: `directorioEspecies.test.js` (search/ficha/altitud, degradación sin lanzar) + `SpeciesFicha.test.jsx` (render poblado, fallback foto, deflección, navegación entre asociaciones).

## Verificación visual
Captura Chromium (nix-store) de la ficha POBLADA de **frijol** (datos reales del catálogo) en móvil 390 + desktop 1440, mostrando piso térmico + asociaciones + plagas + biopreparados (enviadas al operador por Telegram).

🤖 Generated with [Claude Code](https://claude.com/claude-code)