### PR TITLE
feat(faq): componente FAQ con buscador, categorias y navegacion desde dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,6 +103,7 @@ const GlaciarHistorialScreen = lazy(() => import('./components/GlaciarHistorialS
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
 const CaseStudyScreen = lazy(() => import('./components/CaseStudyScreen'));
 const CaseStudyDetail = lazy(() => import('./components/CaseStudyDetail'));
+const FaqScreen = lazy(() => import('./components/FaqScreen'));
 const HelpManual = lazy(() => import('./components/HelpManual'));
 const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
@@ -144,6 +145,7 @@ const LoadingFallback = () => (
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
+  faq: 'faq',
   inventario: 'activos',
   activos: 'activos',
   biodiversidad: 'biodiversidad',
@@ -185,7 +187,7 @@ const MODULE_VIEWS = new Set([
   'activos', 'mapa', 'javier', 'bodega', 'task_log', 'historial',
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
-  'hoy_finca', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
+  'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
@@ -1271,6 +1273,14 @@ export default function App() {
               onBack={() => navigate('casos')}
               onHome={() => navigate('dashboard')}
             />
+          </ErrorBoundary>
+        );
+      case 'faq':
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Preguntas Frecuentes">
+              <FaqScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'help':

--- a/src/components/FaqScreen.jsx
+++ b/src/components/FaqScreen.jsx
@@ -1,0 +1,103 @@
+import { useState, useMemo } from 'react';
+import { ChevronLeft, Search, MessageCircle, ChevronRight } from 'lucide-react';
+import faqData from '../data/faqChagra.json';
+
+const normalize = (s) => s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+export default function FaqScreen({ onBack, onNavigate }) {
+  const [query, setQuery] = useState('');
+
+  const items = useMemo(() => {
+    if (!query) return faqData.items;
+    const nq = normalize(query);
+    return faqData.items.filter(
+      (item) => normalize(item.q).includes(nq) || normalize(item.a).includes(nq)
+    );
+  }, [query]);
+
+  const grouped = useMemo(() => {
+    const map = {};
+    for (const item of items) {
+      if (!map[item.categoria]) map[item.categoria] = [];
+      map[item.categoria].push(item);
+    }
+    return map;
+  }, [items]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 pt-3 pb-2 flex items-center gap-2 shrink-0 border-b border-slate-800/60 bg-slate-950/60">
+        {onBack && (
+          <button type="button" onClick={onBack} aria-label="Volver"
+            className="p-2 -ml-2 rounded-lg active:bg-slate-800 min-h-[40px] min-w-[40px] flex items-center justify-center">
+            <ChevronLeft size={20} className="text-sky-400" />
+          </button>
+        )}
+        <MessageCircle size={16} className="text-emerald-400" aria-hidden="true" />
+        <p className="text-sm font-bold text-slate-200">Preguntas frecuentes</p>
+      </div>
+
+      <div className="px-4 pt-3 pb-2 shrink-0">
+        <div className="relative">
+          <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" aria-hidden="true" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Buscar pregunta..."
+            className="w-full bg-slate-900/80 border border-slate-700/60 rounded-xl pl-9 pr-3 py-2.5 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/20"
+            aria-label="Buscar preguntas frecuentes"
+          />
+        </div>
+      </div>
+
+      <main className="flex-1 overflow-y-auto px-4 py-3 space-y-5">
+        {faqData.categorias.map((cat) => {
+          const catItems = grouped[cat.id];
+          if (!catItems || catItems.length === 0) return null;
+          return (
+            <div key={cat.id}>
+              <h2 className="flex items-center gap-2 text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                <span aria-hidden="true">{cat.emoji}</span>
+                {cat.label}
+              </h2>
+              <div className="space-y-2">
+                {catItems.map((item) => (
+                  <div key={item.id} className="bg-slate-900/60 border border-slate-800 rounded-xl overflow-hidden">
+                    <details className="group">
+                      <summary className="flex items-start gap-2 p-3 cursor-pointer list-none active:bg-slate-800/50 transition-colors min-h-[52px]">
+                        <span className="flex-1 text-sm font-bold text-slate-100 leading-snug">{item.q}</span>
+                        {item.estado === 'construccion' && (
+                          <span className="shrink-0 text-[10px] font-bold text-amber-400/70 bg-amber-400/10 px-1.5 py-0.5 rounded-full mt-0.5 leading-tight">
+                            en preparación
+                          </span>
+                        )}
+                        <ChevronRight size={16} className="shrink-0 text-slate-500 mt-0.5 group-open:rotate-90 transition-transform" />
+                      </summary>
+                      <div className="px-3 pb-3 pt-0">
+                        <p className="text-sm text-slate-300 leading-relaxed">{item.a}</p>
+                        {item.destino && onNavigate && (
+                          <button
+                            type="button"
+                            onClick={() => onNavigate(item.destino.ruta)}
+                            className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-500/15 border border-emerald-600/30 text-emerald-300 text-xs font-bold active:bg-emerald-500/25 transition-colors"
+                          >
+                            {item.destino.label}
+                            <ChevronRight size={14} />
+                          </button>
+                        )}
+                      </div>
+                    </details>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+        {items.length === 0 && (
+          <p className="text-sm text-slate-500 text-center py-8">No encontramos preguntas con ese termino.</p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -142,6 +142,7 @@ const HERRAMIENTAS_TILES = [
     // 'calendario_finca' → CalendarioFincaScreen). Groundeado en
     // farmCalendarService; reusa los ciclos de la finca y el catálogo.
     { view: 'calendario_finca', label: 'Calendario', icon: CalendarDays, desc: 'Siembra, abono, plagas y cosecha en un solo lugar', accent: 'text-violet-400 border-l-violet-500' },
+    { view: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle, desc: 'Respuestas sobre el funcionamiento de Chagra', accent: 'text-violet-400 border-l-violet-500' },
 ];
 
 // Acciones de gestión sin launcher directo en la home (huérfanas):

--- a/src/data/faqChagra.json
+++ b/src/data/faqChagra.json
@@ -1,0 +1,193 @@
+{
+  "version": "1.0-draft-2026-06-25",
+  "fuente": "Basado en la auditoría 3 ejes (Chagra-strategy/ops/CAPABILITIES_STATUS.md §7) + mapa de capacidades real. Cada respuesta apunta a DÓNDE en la app y refleja capacidades reales (honesto: lo que está en construcción se marca).",
+  "nota_integracion": "Borrador de contenido para el componente FAQ de Chagra (tarea #18). El agente que lo cablee debe: render con buscador, agrupar por categoría, y que cada item 'destino' sea un botón que navega a la ruta indicada. 'estado' = vivo | construccion (mostrar etiqueta suave si construccion).",
+  "categorias": [
+    { "id": "catalogo", "label": "Catálogo y especies", "emoji": "🌿" },
+    { "id": "agente", "label": "El agente", "emoji": "🤖" },
+    { "id": "sanidad", "label": "Plagas, enfermedades y biopreparados", "emoji": "🐛" },
+    { "id": "calendario", "label": "Calendario y ciclos", "emoji": "📅" },
+    { "id": "finca", "label": "Mi finca", "emoji": "🏡" },
+    { "id": "mercado", "label": "Vender y mercados", "emoji": "🛒" },
+    { "id": "aprender", "label": "Aprender", "emoji": "📚" },
+    { "id": "confianza", "label": "Datos, privacidad y offline", "emoji": "🔒" }
+  ],
+  "items": [
+    {
+      "id": "buscar-especie",
+      "categoria": "catalogo",
+      "q": "¿Dónde busco la información de una especie del catálogo Chagra?",
+      "a": "En el Directorio de especies. Buscas el nombre (ej. \"frailejón\" o \"mandarina\") y, si hay varias opciones, te las lista; al elegir una ves su ficha con foto, piso térmico donde prospera, asociaciones, antagonistas, biopreparados, enfermedades y fenología.",
+      "destino": { "label": "Directorio de especies", "ruta": "especies" },
+      "estado": "construccion"
+    },
+    {
+      "id": "pisos-termicos",
+      "categoria": "catalogo",
+      "q": "¿En qué pisos térmicos o altitud prospera un cultivo (ej. mandarina)?",
+      "a": "En la ficha de la especie (Directorio de especies) hay un componente visual de piso térmico con el rango de altitud y clima donde el cultivo es exitoso. También puedes preguntárselo al agente.",
+      "destino": { "label": "Directorio de especies", "ruta": "especies" },
+      "estado": "construccion"
+    },
+    {
+      "id": "asociaciones",
+      "categoria": "catalogo",
+      "q": "¿Qué puedo sembrar junto a un cultivo (asociaciones) y qué evitar (antagonistas)?",
+      "a": "La ficha de la especie muestra las asociaciones favorables (✅) y los antagonistas (⛔) que están en el grafo de Chagra. Si no hay dato confirmado para una especie, te lo dice con honestidad en vez de inventar.",
+      "destino": { "label": "Directorio de especies", "ruta": "especies" },
+      "estado": "construccion"
+    },
+    {
+      "id": "saberes-polinizacion",
+      "categoria": "catalogo",
+      "q": "¿Dónde veo saberes tradicionales, polinizadores o variedades de un cultivo?",
+      "a": "Pregúntaselo al agente o míralo en la ficha de la especie. El agente usa herramientas groundeadas (saberes tradicionales, polinización, variedades) y cita la fuente cuando existe.",
+      "destino": { "label": "Hablar con el agente", "ruta": "agente" },
+      "estado": "vivo"
+    },
+    {
+      "id": "agente-inventa",
+      "categoria": "agente",
+      "q": "¿El agente se inventa los datos?",
+      "a": "No. El agente responde apoyado en el grafo de conocimiento de Chagra (721 especies y 12.325 relaciones) más documentos verificados, con una cadena anti-alucinación. Cuando no tiene el dato, lo dice (\"todavía no tengo esa información\") en lugar de inventar.",
+      "destino": { "label": "Hablar con el agente", "ruta": "agente" },
+      "estado": "vivo"
+    },
+    {
+      "id": "como-preguntar",
+      "categoria": "agente",
+      "q": "¿Cómo le pregunto algo al agente?",
+      "a": "Escríbele en lenguaje natural desde el portal Agente o el compositor del inicio. También hay un botón \"pregúntale al agente\" dentro de cada lección de Aprender para llevar tu duda al chat.",
+      "destino": { "label": "Hablar con el agente", "ruta": "agente" },
+      "estado": "vivo"
+    },
+    {
+      "id": "foto-planta",
+      "categoria": "agente",
+      "q": "¿Puedo tomar una foto de mi planta para que el agente la analice?",
+      "a": "Sí. Desde la mano de Chagra eliges la opción de foto y el agente la analiza con visión groundeada dentro del chat (ya está activo, no requiere nada extra).",
+      "destino": { "label": "Tomar foto", "ruta": "agente" },
+      "estado": "vivo"
+    },
+    {
+      "id": "plaga-sin-quimicos",
+      "categoria": "sanidad",
+      "q": "¿Cómo controlo una plaga sin químicos?",
+      "a": "Pregúntale al agente por la plaga o el cultivo: te da el manejo integrado (MIP) groundeado — umbral económico y control cultural y biológico, con referencias ICA cuando aplica. Si la plaga no está en el catálogo, te lo dice con honestidad.",
+      "destino": { "label": "Hablar con el agente", "ruta": "agente" },
+      "estado": "vivo"
+    },
+    {
+      "id": "enfermedades",
+      "categoria": "sanidad",
+      "q": "¿Qué enfermedades o plagas afectan a un cultivo y quién las controla?",
+      "a": "En la ficha de la especie ves las enfermedades/plagas que la afectan y sus controladores biológicos. También se lo puedes preguntar al agente.",
+      "destino": { "label": "Directorio de especies", "ruta": "especies" },
+      "estado": "construccion"
+    },
+    {
+      "id": "biopreparados",
+      "categoria": "sanidad",
+      "q": "¿Qué biopreparado uso y en qué dosis?",
+      "a": "Pregúntale al agente o míralo en la ficha de la especie (sección biopreparados). Cuando hay dosis con fuente autoritativa (Restrepo Rivera, Agrosavia, ICA) te la da con unidades; si la dosis no está confirmada, te lo aclara en vez de improvisar.",
+      "destino": { "label": "Hablar con el agente", "ruta": "agente" },
+      "estado": "vivo"
+    },
+    {
+      "id": "cuando-sembrar",
+      "categoria": "calendario",
+      "q": "¿Cuándo siembro un cultivo según mi altitud?",
+      "a": "En el Calendario de finca o preguntándole al agente. El calendario de siembra está groundeado por piso térmico y altitud de tu finca.",
+      "destino": { "label": "Calendario de finca", "ruta": "calendario" },
+      "estado": "construccion"
+    },
+    {
+      "id": "calendario-finca",
+      "categoria": "calendario",
+      "q": "¿Dónde está el calendario de mi finca?",
+      "a": "En el Calendario de finca: unifica en una sola vista la siembra, la cosecha, el ciclo fenológico, las tareas de alimentación/nutrición de las plantas, el riego y la sanidad, según el perfil y la altitud de tu finca.",
+      "destino": { "label": "Calendario de finca", "ruta": "calendario" },
+      "estado": "construccion"
+    },
+    {
+      "id": "ciclo-perenne",
+      "categoria": "calendario",
+      "q": "¿Cómo manejo un cultivo perenne (establecimiento y ciclo anual)?",
+      "a": "Chagra tiene cálculo de ciclo perenne (establecimiento + calendario anual) para los cultivos perennes con datos. Lo ves en el Calendario de finca y en la ficha de la especie.",
+      "destino": { "label": "Calendario de finca", "ruta": "calendario" },
+      "estado": "construccion"
+    },
+    {
+      "id": "disenar-finca",
+      "categoria": "finca",
+      "q": "¿Chagra me ayuda a diseñar mi finca (restauración, silvopastoril)?",
+      "a": "Sí. Pregúntale al agente: el diseño de finca, restauración y silvopastoril está respaldado 100% por el grafo de conocimiento.",
+      "destino": { "label": "Hablar con el agente", "ruta": "agente" },
+      "estado": "vivo"
+    },
+    {
+      "id": "registrar-finca",
+      "categoria": "finca",
+      "q": "¿Cómo registro mi finca y mis cultivos?",
+      "a": "Desde el portal Gestionar manejas tu finca y tus plantas (respaldado por farmOS). Tu inventario alimenta el resto de la app (calendario, recomendaciones).",
+      "destino": { "label": "Gestionar mi finca", "ruta": "gestionar" },
+      "estado": "vivo"
+    },
+    {
+      "id": "agua-riego",
+      "categoria": "finca",
+      "q": "¿Chagra me ayuda con el manejo del agua y el riego?",
+      "a": "Está en construcción: es uno de los temas que estamos ampliando con investigación groundeada. Por ahora el agente responde lo que ya está en el catálogo y te avisa cuando no tiene el dato.",
+      "destino": { "label": "Hablar con el agente", "ruta": "agente" },
+      "estado": "construccion"
+    },
+    {
+      "id": "vender",
+      "categoria": "mercado",
+      "q": "¿Cómo vendo los productos de mi finca?",
+      "a": "En el Marketplace publicas tus productos (qué, cuánto, precio, vereda) y exploras ofertas de otras fincas con enfoque de circuitos cortos y mercados campesinos. El contacto con el comprador es por WhatsApp; por ahora no se cobra dentro de la app.",
+      "destino": { "label": "Marketplace", "ruta": "mercados" },
+      "estado": "construccion"
+    },
+    {
+      "id": "precio-referencia",
+      "categoria": "mercado",
+      "q": "¿Chagra me dice a qué precio vender?",
+      "a": "Cuando hay un precio de referencia con fuente (SIPSA/DANE) te lo muestra citado. Si no hay dato confirmado para ese producto, te lo dice con honestidad en vez de inventar un precio.",
+      "destino": { "label": "Marketplace", "ruta": "mercados" },
+      "estado": "construccion"
+    },
+    {
+      "id": "aprender",
+      "categoria": "aprender",
+      "q": "¿Dónde aprendo de agroecología en Chagra?",
+      "a": "En el hub Aprender: lecciones con ilustraciones (micorrizas, milpa, fenología, ciclo de nutrientes), casos de estudio y galería de biopreparados. Cada lección tiene un botón para llevar tu duda al agente.",
+      "destino": { "label": "Aprender", "ruta": "aprende" },
+      "estado": "vivo"
+    },
+    {
+      "id": "offline",
+      "categoria": "confianza",
+      "q": "¿Chagra funciona sin internet?",
+      "a": "Sí. Chagra es una app offline-first: guarda tus datos en tu dispositivo y funciona sin conexión; sincroniza cuando vuelve el internet.",
+      "destino": null,
+      "estado": "vivo"
+    },
+    {
+      "id": "energia-solar",
+      "categoria": "confianza",
+      "q": "¿Cómo se sostiene la infraestructura de Chagra?",
+      "a": "Todo el sistema de Chagra corre sobre energía solar autogenerada, fuera de la red. Es soberanía energética: la inteligencia de la finca no depende de la red eléctrica.",
+      "destino": null,
+      "estado": "vivo"
+    },
+    {
+      "id": "mano-chagra",
+      "categoria": "confianza",
+      "q": "¿Qué es la mano de Chagra?",
+      "a": "Es el menú de capacidades: un emblema en forma de mano radial desde donde llegas al agente, la foto, aprender, gestionar y vender.",
+      "destino": null,
+      "estado": "vivo"
+    }
+  ]
+}


### PR DESCRIPTION
Nuevo componente FaqScreen que:
- Importa datos desde src/data/faqChagra.json (FAQ groundeado)
- Buscador en vivo que filtra por pregunta y respuesta (con normalizacion
  de acentos)
- Agrupa items por categoria con emoji y label
- Cada item desplegable con pregunta y respuesta
- Boton de navegacion a destino.ruta si el item tiene destino
- Etiqueta "en preparacion" si estado === "construccion"
- Lazy import + ruta #faq en App.jsx (HASH_VIEW_ROUTES + MODULE_VIEWS +
  case "faq")
- Tile "Preguntas frecuentes" en HERRAMIENTAS_TILES de DashboardLive.jsx

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
