### PR TITLE
ci(dev): arreglar deploy a dev que dejaba pantalla negra (stomping + mockups)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,14 +1,21 @@
 name: Deploy Chagra PWA (DEV)
 
-# Deploy automatico a entorno DEV en alpha para ramas dev/*, feat/*, fix/*.
+# Deploy automatico a entorno DEV en alpha para la rama de preview designada.
 # Target: /mnt/fast/appdata/farmos-pwa-dev. Concurrency por branch
 # (cancel-in-progress: true) para que pushes rapidos a la misma rama solo
 # deplieguen el ultimo build. Sin lint step (a diferencia de prod/QA), para
 # iteracion rapida.
+#
+# IMPORTANTE: este workflow ya NO dispara en cada feat/*|fix/*. Antes lo hacia
+# y TODAS las ramas de feature deployaban al MISMO target farmos-pwa-dev,
+# pisandose entre si (stomping) -> el index.html de una rama quedaba sirviendo
+# assets /assets/*.js|css de otra que ya no existian -> pantalla negra. Ahora
+# solo la rama de preview ('dev' / 'dev/*') auto-deploya. Para previsualizar
+# una feature en dev, mergeala a la rama de preview.
 
 on:
   push:
-    branches: ['dev/*', 'feat/*', 'fix/*']
+    branches: ['dev', 'dev/*']
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -66,7 +73,14 @@ jobs:
           #   2) sincronizar /assets/ SIN --delete (agregar chunks nuevos,
           #      conservar viejos; los hashes no colisionan).
           #   3) GC de chunks con mtime > 30 dias para no crecer infinito.
-          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' dist/ "$TARGET/"
+          #
+          # --exclude='/mockups/': el dir mockups/ del target NO es
+          # group-writable y NO viene en dist/. Sin excluirlo, rsync intenta
+          # tocar sus permisos/borrarlo con --delete y aborta con exit 23
+          # (partial transfer) -> deploy PARCIAL -> index.html referencia
+          # assets que nunca se copiaron -> pantalla negra. Lo dejamos intacto.
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 \
+            --exclude='/assets/' --exclude='/mockups/' dist/ "$TARGET/"
           rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ "$TARGET/assets/"
           find "$TARGET/assets/" -type f -mtime +30 -delete || true
           find "$TARGET" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
@@ -78,6 +92,46 @@ jobs:
           test -f "$TARGET/index.html" || exit 1
           HASH=$(sha256sum "$TARGET/index.html" | cut -d' ' -f1)
           echo "DEV Deploy OK: $(date -Iseconds) | index.html sha256: ${HASH:0:12}"
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Verify referenced assets exist
+        run: |
+          set -euo pipefail
+          # Antipantalla-negra: extrae cada referencia /assets/*.js|css del
+          # index.html DESPLEGADO y verifica que el fichero exista en disco.
+          # Si el deploy quedo parcial (p.ej. rsync exit 23 por mockups, o un
+          # stomp), faltara algun chunk hasheado y el job debe FALLAR aqui en
+          # vez de dejar dev sirviendo una pantalla negra silenciosa.
+          TARGET=/mnt/fast/appdata/farmos-pwa-dev
+          INDEX="$TARGET/index.html"
+          test -f "$INDEX" || { echo "index.html ausente en $TARGET"; exit 1; }
+
+          # Captura href/src que apunten a /assets/....js|css (con o sin query).
+          refs=$(grep -oE '/assets/[A-Za-z0-9._/-]+\.(js|css)' "$INDEX" | sort -u || true)
+          if [ -z "$refs" ]; then
+            echo "Advertencia: no se hallaron referencias /assets/*.js|css en index.html"
+            exit 0
+          fi
+
+          missing=0
+          while IFS= read -r ref; do
+            [ -z "$ref" ] && continue
+            # ref es ruta absoluta web -> ruta en disco bajo TARGET.
+            file="$TARGET${ref}"
+            if [ -f "$file" ]; then
+              echo "ok   $ref"
+            else
+              echo "FALTA $ref  (esperado en $file)"
+              missing=$((missing + 1))
+            fi
+          done <<< "$refs"
+
+          if [ "$missing" -gt 0 ]; then
+            echo "Deploy INCOMPLETO: $missing asset(s) referenciados por index.html no existen en disco."
+            echo "dev quedaria en pantalla negra -> fallando el job a proposito."
+            exit 1
+          fi
+          echo "Integridad de assets OK: todos los /assets/*.js|css referenciados existen."
 
       - if: env.SKIP_DEPLOY != '1'
         name: Bump SW cache version (dev)


### PR DESCRIPTION
## Bug
El deploy automatico al entorno DEV (`farmos-pwa-dev`) dejaba la app en **pantalla negra**. Solo se modifica `dev-deploy.yml`; el deploy de **prod (`deploy.yml`) NO se toca**.

## Causa raíz
Dos fallos componiéndose, ambos en `dev-deploy.yml`:

1. **Stomping de ramas.** El trigger era `branches: ['dev/*', 'feat/*', 'fix/*']`, así que **cada** rama de feature deployaba al **mismo** target `/mnt/fast/appdata/farmos-pwa-dev/`. Las ramas se pisaban entre sí: el `index.html` desplegado por una rama quedaba referenciando assets `/assets/*.js|css` hasheados de otra rama que ya no existían → el cliente no podía cargar los chunks → pantalla negra.
2. **rsync parcial por `mockups/`.** Cuando el dir `mockups/` del target no era group-writable, el `rsync --delete` intentaba ajustarle permisos/borrarlo y abortaba con **exit 23** (partial transfer) → deploy **parcial** → faltaban assets referenciados por `index.html` → misma pantalla negra.

## Cambios (solo `dev-deploy.yml`)
- **Trigger restringido** a la rama de preview designada: `branches: ['dev', 'dev/*']`. Las ramas `feat/*`/`fix/*` ya **no** auto-deployan a dev (se previsualizan mergeándolas a la rama de preview). Elimina el stomping. Comentario de cabecera explica el porqué.
- **rsync robusto**: se añade `--exclude='/mockups/'` al rsync con `--delete` (deja el dir no-writable intacto, evita el exit 23), manteniendo los flags defensivos existentes (`--no-perms --no-group --chmod=F644 --delete`, `umask 022`) y el patrón append-only de `/assets/`.
- **Check post-deploy de integridad de assets**: nuevo step que extrae cada referencia `/assets/*.js|css` del `index.html` desplegado y **falla el job** si alguno no existe en disco. Evita dejar dev en pantalla negra silenciosa ante un deploy parcial.

## Tests
N/A — cambio de CI sin lógica de app. Validado: YAML well-formed (`yq`), `branches` = `['dev','dev/*']`, secuencia de steps correcta, lefthook pre-commit verde. El workflow sigue **deshabilitado** (no se re-habilita en este PR).

Refs: pantalla negra dev por stomping + rsync exit 23 (mockups no group-writable)