### PR TITLE
feat(ui): redistribuir "el resto de su finca" del home F2 por jerarquía

### DIFF
--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -50,6 +50,7 @@ import MiFincaVivaHomeCard from './MiFincaVivaHomeCard';
 import FincaRedInstitucional from './FincaRedInstitucional';
 import FincaVivaHero from './FincaVivaHero';
 import './finca-viva-resto.css';
+import './dashboard-resto-redistribucion.css';
 // Rescate huérfano 2026-06-24 (descubribilidad): CaseStudyTopWidget vivía solo
 // en el DashboardView MUERTO de App.jsx (única vía a `casos`). Se trae a la home
 // viva; se auto-oculta si no hay casos activos (KISS, zero footprint). Ref:
@@ -110,54 +111,84 @@ const SECTION_COMPONENTS = {
     informes: { Component: InformesCard },
 };
 
-// Herramientas de finca que NO son secciones-módulo del grid (no tienen
-// componente en SECTION_COMPONENTS): son TILES de acceso directo a una pantalla
-// completa (Suelo · Semilleros · Seguridad). El commit #1827 las metió por
-// error en NAV_TILES (la pantalla de navegación de App.jsx), que NO es este
-// home dashboard — por eso no aparecían al loguear ("Semilleros=0"). Acá viven
-// como su propio bloque de tiles navegables (onNavigate(view) → currentView),
-// reusando label/icon/desc de NAV_TILES. Universales: las ve todo perfil (igual
-// que en NAV_TILES, sin gating por rol — son herramientas básicas de manejo).
-const HERRAMIENTAS_TILES = [
-    { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Diagnóstico y salud del suelo', accent: 'text-amber-400 border-l-amber-500' },
-    { view: 'germinacion', label: 'Semilleros', icon: TestTube, desc: 'Prueba de semillas y germinación', accent: 'text-teal-400 border-l-teal-500' },
-    { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo de suelo', accent: 'text-rose-400 border-l-rose-500' },
-    { view: 'aprende', label: 'Aprende', icon: BookOpen, desc: 'Lecciones agroecológicas con fuente', accent: 'text-emerald-400 border-l-emerald-500' },
-    { view: 'directorio', label: 'Especies', icon: Sprout, desc: 'Directorio: clima, asociaciones y plagas', accent: 'text-lime-400 border-l-lime-500' },
-    // Huérfanos rescatados 2026-06-24 (descubribilidad). Eran rutas vivas en el
-    // router pero sin entrada en la home viva (CAPABILITIES_STATUS.md §2):
-    //  · biopreparados → galería de recetas paso a paso (antes solo desde el juego).
-    //  · ciclo_nutrientes → plan de alimentación / ciclo cerrado (antes solo
-    //    desde dentro de AnimalesScreen).
-    //  · casos → casos de estudio (antes solo desde el DashboardView muerto / #casos).
-    // `data: { back: 'dashboard' }`: la galería de biopreparados también se abre
-    // desde el juego (misión, sin back → vuelve al juego). Desde la home pasamos
-    // back:'dashboard' para que el botón Volver regrese acá y no al juego
-    // (corrige el onBack huérfano). Ver App.jsx case 'biopreparados'.
-    { view: 'biopreparados', label: 'Biopreparados', icon: FlaskConical, desc: 'Recetas caseras paso a paso', accent: 'text-lime-400 border-l-lime-500', data: { back: 'dashboard' } },
-    { view: 'ciclo_nutrientes', label: 'Nutrientes', icon: Recycle, desc: 'Ciclo cerrado: del animal al suelo y la planta', accent: 'text-emerald-400 border-l-emerald-500' },
-    { view: 'casos', label: 'Casos', icon: ClipboardList, desc: 'Seguimiento de problemas y tratamientos', accent: 'text-amber-400 border-l-amber-500' },
+// ───────────────────────────────────────────────────────────────────────────
+// REDISTRIBUCIÓN del "resto de su finca" (auditoría CAPABILITIES_STATUS §7.2 +
+// §7.4 #2, 2026-06-25). Antes: UN solo bloque "Herramientas de finca" apilaba
+// 11 tiles sueltos (suelo, semilleros, seguridad, aprende, especies,
+// biopreparados, nutrientes, casos, calendario, faq, mercado) — la
+// fragmentación que la auditoría quiere eliminar. Ahora se reparten en TRES
+// grupos con JERARQUÍA explícita, para que el campesino distinga de un vistazo
+// lo SÓLIDO de lo flojo:
+//
+//   1. DESTACADO_TILES  → lo FUERTE y grounded (§7.2 elevar): directorio de
+//      especies + calendario de finca. Arriba, tiles grandes (2 columnas).
+//   2. APRENDER_TILES   → todo lo de APRENDIZAJE/contenido consolidado bajo un
+//      solo hub "Aprender" (§7.4 #2): lecciones (aprende), casos de estudio,
+//      ciclo de nutrientes, galería de biopreparados, suelo/micorrizas como
+//      contenido, toxicología (seguridad de insumos) y las preguntas frecuentes.
+//      Ya NO son tiles top-level sueltos.
+//   3. GESTION_TILES    → "Mi finca / gestión": registros y acciones (semilleros,
+//      cosechar, insumos, mantenimiento). Accesible pero de-enfatizado.
+//   4. MERCADO_TILE     → marketplace, BAJADO (§7.2: el precio SIPSA es la
+//      fachada más delgada). Va al fondo, en su propio rótulo discreto.
+//
+// Cada tile navega con onNavigate(view, data) → currentView (la pantalla real ya
+// existe en App.jsx). Universales: las ve todo perfil (herramientas básicas),
+// salvo el gating por perfil que ya gobierna el resto del home.
+// ───────────────────────────────────────────────────────────────────────────
+
+// 1) DESTACADO — lo más sólido y grounded de Chagra, elevado (§7.2). El
+//    directorio (721 especies con clima/asociaciones/plagas groundeadas) y el
+//    calendario unificado son superficies 100% AGE/catálogo: el campesino debe
+//    distinguirlas como el núcleo fuerte. Se renderizan en tiles GRANDES.
+const DESTACADO_TILES = [
+    { view: 'directorio', label: 'Especies', icon: Sprout, desc: 'Directorio: clima, asociaciones, plagas y biopreparados por especie', accent: 'text-lime-400 border-l-lime-500' },
     // Calendario de finca: UN solo calendario que unifica por planta fenología,
     // nutrición, siembra, cosecha, sanidad y ciclo perenne (App.jsx case
     // 'calendario_finca' → CalendarioFincaScreen). Groundeado en
     // farmCalendarService; reusa los ciclos de la finca y el catálogo.
-    { view: 'calendario_finca', label: 'Calendario', icon: CalendarDays, desc: 'Siembra, abono, plagas y cosecha en un solo lugar', accent: 'text-violet-400 border-l-violet-500' },
-    { view: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle, desc: 'Respuestas sobre el funcionamiento de Chagra', accent: 'text-violet-400 border-l-violet-500' },
-    // Marketplace agroecológico (circuitos cortos): segundo punto de entrada
-    // VISIBLE además de la rama "Vender" de la mano radial. Publicar lo que
-    // vende la finca + explorar ofertas de fincas vecinas. Ruta 'mercado'
-    // (App.jsx case 'mercado' → MercadosScreen).
-    { view: 'mercado', label: 'Mercado', icon: Store, desc: 'Vende y compra directo entre fincas, sin intermediarios', accent: 'text-emerald-400 border-l-emerald-500' },
+    { view: 'calendario_finca', label: 'Calendario', icon: CalendarDays, desc: 'Siembra, abono, plagas y cosecha de su finca en una sola línea de tiempo', accent: 'text-violet-400 border-l-violet-500' },
 ];
 
-// Acciones de gestión sin launcher directo en la home (huérfanas):
-// cosechar / insumos / mantenimiento. Eran alcanzables solo por back-nav interno
-// o por la mano. Se exponen como tiles propios (CAPABILITIES_STATUS.md §2).
+// 2) APRENDER — hub único de contenido/aprendizaje (§7.4 #2). Consolida todas
+//    las superficies de aprendizaje que antes vivían sueltas:
+//      · aprende        → 5 lecciones agroecológicas con fuente (el hub; sólo en
+//                         layout legacy: con F2 el portal "Aprender" del hero ya
+//                         entra al hub, así que aquí se filtra para no duplicarlo).
+//      · casos          → casos de estudio (antes solo en el DashboardView muerto).
+//      · ciclo_nutrientes → ciclo cerrado animal→suelo→planta (antes dentro de
+//                         AnimalesScreen).
+//      · biopreparados  → galería de recetas paso a paso (antes solo desde el
+//                         juego). `data:{back:'dashboard'}` para que Volver regrese
+//                         aquí y no al juego (corrige el onBack huérfano).
+//      · suelo          → diagnóstico y salud del suelo / micorrizas (contenido).
+//      · toxicologia    → seguridad/toxicidad de insumos (contenido de manejo).
+//      · faq            → preguntas frecuentes sobre Chagra.
+const APRENDER_TILES = [
+    { view: 'aprende', label: 'Aprender', icon: BookOpen, desc: 'Lecciones agroecológicas con fuente', accent: 'text-emerald-400 border-l-emerald-500' },
+    { view: 'casos', label: 'Casos de estudio', icon: ClipboardList, desc: 'Problemas reales y su tratamiento', accent: 'text-amber-400 border-l-amber-500' },
+    { view: 'ciclo_nutrientes', label: 'Ciclo de nutrientes', icon: Recycle, desc: 'Del animal al suelo y la planta', accent: 'text-emerald-400 border-l-emerald-500' },
+    { view: 'biopreparados', label: 'Biopreparados', icon: FlaskConical, desc: 'Recetas caseras paso a paso', accent: 'text-lime-400 border-l-lime-500', data: { back: 'dashboard' } },
+    { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Salud del suelo y micorrizas', accent: 'text-amber-400 border-l-amber-500' },
+    { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo', accent: 'text-rose-400 border-l-rose-500' },
+    { view: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle, desc: 'Cómo funciona Chagra', accent: 'text-violet-400 border-l-violet-500' },
+];
+
+// 3) GESTIÓN — "Mi finca": registros y acciones de manejo, sin launcher directo
+//    antes (huérfanas o solo por la mano). Semilleros entra aquí (es gestión de
+//    siembra, no contenido). Accesible pero de-enfatizado respecto a lo fuerte.
 const GESTION_TILES = [
+    { view: 'germinacion', label: 'Semilleros', icon: TestTube, desc: 'Prueba de semillas y germinación', accent: 'text-teal-400 border-l-teal-500' },
     { view: 'cosechar', label: 'Cosechar', icon: Wheat, desc: 'Registrar una cosecha', accent: 'text-amber-400 border-l-amber-500' },
     { view: 'insumos', label: 'Insumos aplicados', icon: Droplets, desc: 'Registrar una aplicación de bioinsumo', accent: 'text-sky-400 border-l-sky-500' },
     { view: 'mantenimiento', label: 'Mantenimiento', icon: Wrench, desc: 'Labores de mantenimiento de la finca', accent: 'text-slate-300 border-l-slate-500' },
 ];
+
+// 4) MERCADO — marketplace de circuitos cortos. BAJADO (§7.2): la fachada de
+//    precio (SIPSA) es la capa más delgada hoy, así que va al fondo, en su
+//    propio rótulo discreto, no mezclado con lo fuerte. Sigue siendo el segundo
+//    punto de entrada además de la rama "Vender" de la mano radial.
+const MERCADO_TILE = { view: 'mercado', label: 'Mercado', icon: Store, desc: 'Vende y compra directo entre fincas, sin intermediarios', accent: 'text-emerald-400 border-l-emerald-500' };
 
 function SortableSection({ id, onNavigate, sensors }) {
     const {
@@ -586,27 +617,60 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                 </div>
             )}
 
-            {/* HERRAMIENTAS DE FINCA (Suelo · Semilleros · Seguridad): tiles de
-                acceso directo a pantallas completas que NO son secciones del
-                grid draggable (no tienen componente en SECTION_COMPONENTS). El
-                commit #1827 las agregó por error a NAV_TILES (pantalla de
-                navegación de App.jsx), no a ESTE home → no aparecían al loguear
-                ("Semilleros=0"). Acá van como su propio bloque navegable. Cada
-                tile llama onNavigate(view) → currentView (suelo/germinacion/
-                toxicologia), que monta la pantalla real ya existente. */}
+            {/* ════════════════════════════════════════════════════════════════
+                REDISTRIBUCIÓN del "resto de su finca" (auditoría §7.2 + §7.4 #2):
+                un solo bloque-pila se reparte en TRES grupos con jerarquía clara.
+                `renderTile` mantiene un único estilo de tile (incluye el fix de
+                contraste: en F2 el label/desc van con tinta oscura forzada por
+                .fvh-tile-label/.fvh-tile-desc en finca-viva-resto.css, no con el
+                color de acento que sería ilegible sobre el pastel claro). El
+                refuerzo WCAG AA de los tiles DESTACADOS grandes vive en
+                dashboard-resto-redistribucion.css. ════════════════════════════ */}
+
+            {/* 1) DESTACADO — lo más sólido y grounded, ELEVADO (§7.2): directorio
+                de especies + calendario unificado. Tiles GRANDES (2 columnas) con
+                ícono prominente, para que se lean como el núcleo fuerte. */}
             <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
                 <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
                     <span
                         aria-hidden="true"
-                        className="h-3.5 w-1 rounded-full bg-gradient-to-b from-amber-400 to-rose-400"
+                        className="h-3.5 w-1 rounded-full bg-gradient-to-b from-lime-400 to-emerald-400"
                     />
-                    Herramientas de finca
+                    Lo más sólido de Chagra
                 </p>
-                <div className="grid grid-cols-3 gap-3" data-testid="herramientas-tiles">
-                    {HERRAMIENTAS_TILES
-                        // Con F2 ON, "Aprende" YA es uno de los 4 portales del hero
-                        // (Aprender). No lo repetimos como tile aquí: dedup del
-                        // portal duplicado (auditoría §7.4 #1).
+                <div className="grid grid-cols-2 gap-3" data-testid="destacado-tiles">
+                    {DESTACADO_TILES.map((tile) => (
+                        <button
+                            key={tile.view}
+                            type="button"
+                            onClick={() => onNavigate(tile.view, tile.data)}
+                            aria-label={`${tile.label}: ${tile.desc}`}
+                            className={`dash-tile dash-tile--destacado ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} rounded-2xl p-4 text-left min-h-[112px] active:bg-slate-800/70 transition-colors flex flex-col`}
+                        >
+                            <tile.icon size={30} strokeWidth={2} className={`mb-2 ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
+                            <span className={`text-base font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tile.label}</span>
+                            <span className={`text-xs block mt-1 leading-snug fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-400'}`}>{tile.desc}</span>
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {/* 2) APRENDER — hub único de contenido (§7.4 #2): todas las superficies
+                de aprendizaje consolidadas bajo un solo rótulo. Con F2 ON el portal
+                "Aprender" del hero ya entra al hub `aprende`, así que aquí se filtra
+                ese tile para no duplicarlo; las lecciones individuales (casos,
+                nutrientes, biopreparados, suelo, seguridad, faq) sí se ofrecen como
+                accesos directos al contenido. */}
+            <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
+                <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
+                    <span
+                        aria-hidden="true"
+                        className="h-3.5 w-1 rounded-full bg-gradient-to-b from-emerald-400 to-teal-400"
+                    />
+                    Aprender
+                </p>
+                <div className="grid grid-cols-3 gap-3" data-testid="aprender-tiles">
+                    {APRENDER_TILES
                         .filter((tile) => !(fincaVivaFlag && tile.view === 'aprende'))
                         .map((tile) => (
                         <button
@@ -614,7 +678,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                             type="button"
                             onClick={() => onNavigate(tile.view, tile.data)}
                             aria-label={`${tile.label}: ${tile.desc}`}
-                            className={`${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} rounded-xl p-3 text-left min-h-[88px] active:bg-slate-800/70 transition-colors flex flex-col`}
+                            className={`dash-tile ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} rounded-xl p-3 text-left min-h-[88px] active:bg-slate-800/70 transition-colors flex flex-col`}
                         >
                             <tile.icon size={24} strokeWidth={2} className={`mb-1.5 ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
                             <span className={`text-sm font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tile.label}</span>
@@ -624,32 +688,60 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                 </div>
             </div>
 
-            {/* GESTIÓN — acciones de registro sin launcher directo en la home
-                (cosechar · insumos aplicados · mantenimiento). Rescate huérfano
-                2026-06-24: eran alcanzables solo por back-nav interno o la mano
-                (CAPABILITIES_STATUS.md §2). Las rutas ya existen en App.jsx. */}
+            {/* 3) GESTIÓN — "Mi finca": registros y acciones de manejo (semilleros,
+                cosechar, insumos, mantenimiento). De-enfatizado respecto a lo
+                fuerte; las rutas ya existen en App.jsx. */}
             <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
                 <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
                     <span
                         aria-hidden="true"
                         className="h-3.5 w-1 rounded-full bg-gradient-to-b from-sky-400 to-emerald-400"
                     />
-                    Registrar en la finca
+                    Mi finca · gestión
                 </p>
                 <div className="grid grid-cols-3 gap-3" data-testid="gestion-tiles">
                     {GESTION_TILES.map((tile) => (
                         <button
                             key={tile.view}
                             type="button"
-                            onClick={() => onNavigate(tile.view)}
+                            onClick={() => onNavigate(tile.view, tile.data)}
                             aria-label={`${tile.label}: ${tile.desc}`}
-                            className={`${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} rounded-xl p-3 text-left min-h-[88px] active:bg-slate-800/70 transition-colors flex flex-col`}
+                            className={`dash-tile ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} rounded-xl p-3 text-left min-h-[88px] active:bg-slate-800/70 transition-colors flex flex-col`}
                         >
                             <tile.icon size={24} strokeWidth={2} className={`mb-1.5 ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
                             <span className={`text-sm font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tile.label}</span>
                             <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-500'}`}>{tile.desc}</span>
                         </button>
                     ))}
+                </div>
+            </div>
+
+            {/* 4) MERCADO — marketplace de circuitos cortos, BAJADO (§7.2: el
+                precio SIPSA es la fachada más delgada). Va al fondo, en su propio
+                rótulo discreto, sin mezclarse con lo fuerte. Tile a ancho completo
+                de baja jerarquía visual. */}
+            <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
+                <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
+                    <span
+                        aria-hidden="true"
+                        className="h-3.5 w-1 rounded-full bg-gradient-to-b from-emerald-400 to-lime-400"
+                    />
+                    Vender y comprar
+                </p>
+                <div className="grid grid-cols-1 gap-3" data-testid="mercado-tiles">
+                    <button
+                        type="button"
+                        onClick={() => onNavigate(MERCADO_TILE.view, MERCADO_TILE.data)}
+                        aria-label={`${MERCADO_TILE.label}: ${MERCADO_TILE.desc}`}
+                        className={`dash-tile ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${MERCADO_TILE.accent} rounded-xl p-3.5 text-left active:bg-slate-800/70 transition-colors flex items-center gap-3`}
+                    >
+                        <MERCADO_TILE.icon size={26} strokeWidth={2} className={`${MERCADO_TILE.accent.split(' ')[0]} shrink-0`} aria-hidden="true" />
+                        <span className="flex-1 min-w-0">
+                            <span className={`text-sm font-black block leading-tight fvh-tile-label ${MERCADO_TILE.accent.split(' ')[0]}`}>{MERCADO_TILE.label}</span>
+                            <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-500'}`}>{MERCADO_TILE.desc}</span>
+                        </span>
+                        <ChevronRight size={18} className={`shrink-0 ${MERCADO_TILE.accent.split(' ')[0]} opacity-70`} aria-hidden="true" />
+                    </button>
                 </div>
             </div>
 

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Redistribución de "el resto de su finca" (auditoría §7.2 + §7.4 #2):
+// verifica que los tiles se reparten en los grupos correctos, en el orden de
+// jerarquía esperado (Destacado → Aprender → Gestión → Mercado) y que cada tile
+// navega a su ruta. Cubre el layout F2 ON (que filtra el hub `aprende` porque ya
+// es portal del hero) y el legacy OFF (que sí muestra el hub `aprende`).
+
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => false,
+}));
+
+let flagOn = true;
+vi.mock('../../../config/fincaVivaHomeFlag', () => ({
+  fincaVivaHomePerfilActivo: () => flagOn,
+}));
+vi.mock('../../../config/extensionistaAccess', () => ({
+  esExtensionistaActual: () => false,
+}));
+
+vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
+vi.mock('../FincaVivaHero', () => ({ default: ({ children }) => <div data-testid="finca-viva-hero">{children}</div> }));
+vi.mock('../FincaRedInstitucional', () => ({ default: () => <div /> }));
+vi.mock('../../OnboardingHero', () => ({ default: () => <div /> }));
+vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
+vi.mock('../MiFincaVivaHomeCard', () => ({ default: () => <div /> }));
+vi.mock('../../CaseStudyTopWidget', () => ({ default: () => null }));
+vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
+vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));
+vi.mock('../AIStatusFooter', () => ({ default: () => <div /> }));
+vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div /> }));
+
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({
+    plants: [{ id: 'p1' }], lands: [], materials: [], isHydrated: true, iotAlerts: [],
+  }),
+}));
+vi.mock('../../../db/farmProcessCache', () => ({ listFarmProcesses: vi.fn(async () => []) }));
+
+let mockProfile = { rol: 'campesino', piso_confirmado: '1', finca_altitud: '1800' };
+vi.mock('../../../services/userProfileService', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getProfile: vi.fn(() => mockProfile),
+    hasManualModuleVisibility: vi.fn(() => true), // muestra todo, sin gating por perfil
+  };
+});
+
+globalThis.ResizeObserver = globalThis.ResizeObserver || class { observe() {} unobserve() {} disconnect() {} };
+
+import DashboardLive from '../DashboardLive';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  flagOn = true;
+  mockProfile = { rol: 'campesino', piso_confirmado: '1', finca_altitud: '1800' };
+});
+afterEach(() => cleanup());
+
+const labelOf = (el) => el.getAttribute('aria-label')?.split(':')[0];
+
+describe('DashboardLive — redistribución del resto de su finca', () => {
+  test('los 4 grupos existen en el orden de jerarquía esperado', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('destacado-tiles')).toBeInTheDocument());
+
+    const groups = ['destacado-tiles', 'aprender-tiles', 'gestion-tiles', 'mercado-tiles'];
+    for (const g of groups) expect(screen.getByTestId(g)).toBeInTheDocument();
+
+    // Orden en el DOM (jerarquía): Destacado antes que Aprender antes que
+    // Gestión antes que Mercado.
+    const positions = groups.map((g) => {
+      const node = screen.getByTestId(g);
+      return { g, top: Array.prototype.indexOf.call(document.querySelectorAll('[data-testid]'), node) };
+    });
+    const order = positions
+      .sort((a, b) => a.top - b.top)
+      .map((p) => p.g);
+    expect(order).toEqual(groups);
+  });
+
+  test('DESTACADO eleva solo Especies y Calendario (lo fuerte y grounded)', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('destacado-tiles');
+    const labels = within(block).getAllByRole('button').map(labelOf);
+    expect(labels).toEqual(['Especies', 'Calendario']);
+  });
+
+  test('APRENDER consolida el contenido; con F2 ON NO duplica el hub Aprender', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('aprender-tiles');
+    const labels = within(block).getAllByRole('button').map(labelOf);
+    // F2 ON: el portal "Aprender" del hero ya entra al hub, así que el tile
+    // 'aprende' se filtra; quedan las superficies de contenido consolidadas.
+    expect(labels).toEqual([
+      'Casos de estudio', 'Ciclo de nutrientes', 'Biopreparados', 'Suelo', 'Seguridad', 'Preguntas frecuentes',
+    ]);
+  });
+
+  test('GESTIÓN agrupa registros/manejo (semilleros incluido)', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('gestion-tiles');
+    const labels = within(block).getAllByRole('button').map(labelOf);
+    expect(labels).toEqual(['Semilleros', 'Cosechar', 'Insumos aplicados', 'Mantenimiento']);
+  });
+
+  test('MERCADO queda al fondo, de-enfatizado, y navega a la ruta mercado', async () => {
+    const onNavigate = vi.fn();
+    render(<DashboardLive onNavigate={onNavigate} />);
+    const block = await screen.findByTestId('mercado-tiles');
+    const btn = within(block).getByRole('button', { name: /Mercado/ });
+    fireEvent.click(btn);
+    expect(onNavigate).toHaveBeenCalledWith('mercado', undefined);
+  });
+
+  test('los tiles navegan a sus rutas (directorio, calendario, casos, biopreparados con back)', async () => {
+    const onNavigate = vi.fn();
+    render(<DashboardLive onNavigate={onNavigate} />);
+    await screen.findByTestId('destacado-tiles');
+
+    fireEvent.click(screen.getByRole('button', { name: /^Especies/ }));
+    expect(onNavigate).toHaveBeenCalledWith('directorio', undefined);
+    fireEvent.click(screen.getByRole('button', { name: /^Calendario/ }));
+    expect(onNavigate).toHaveBeenCalledWith('calendario_finca', undefined);
+    fireEvent.click(screen.getByRole('button', { name: /^Casos de estudio/ }));
+    expect(onNavigate).toHaveBeenCalledWith('casos', undefined);
+    fireEvent.click(screen.getByRole('button', { name: /^Biopreparados/ }));
+    expect(onNavigate).toHaveBeenCalledWith('biopreparados', { back: 'dashboard' });
+  });
+
+  test('layout legacy (F2 OFF) SÍ muestra el hub Aprender como tile', async () => {
+    flagOn = false;
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('aprender-tiles');
+    const labels = within(block).getAllByRole('button').map(labelOf);
+    expect(labels[0]).toBe('Aprender');
+    expect(labels).toContain('Casos de estudio');
+  });
+});

--- a/src/components/dashboard/dashboard-resto-redistribucion.css
+++ b/src/components/dashboard/dashboard-resto-redistribucion.css
@@ -1,0 +1,51 @@
+/*
+ * dashboard-resto-redistribucion.css — refuerzo visual de la REDISTRIBUCIÓN del
+ * "resto de su finca" (DashboardLive, auditoría CAPABILITIES_STATUS §7.2 + §7.4).
+ *
+ * Por qué un archivo aparte y NO finca-viva-resto.css: ese CSS está bajo trabajo
+ * en paralelo (bugfix). Aquí solo se añaden reglas NUEVAS, scope-limitadas a los
+ * tiles de la redistribución (.dash-tile), sin pisar las clases .fvh-* del hero.
+ *
+ * Objetivos:
+ *  1. JERARQUÍA (§7.2): el grupo DESTACADO (lo fuerte y grounded) se lee como el
+ *     núcleo. Tiles más altos, con una elevación sutil y un realce al pulsar.
+ *  2. CONTRASTE WCAG AA: en el layout F2 los tiles son pastel claro. El label y
+ *     la descripción ya van con tinta oscura forzada por .fvh-tile-label /
+ *     .fvh-tile-desc (finca-viva-resto.css). Aquí garantizamos además que la
+ *     DESCRIPCIÓN nunca caiga por debajo del umbral AA y que el ícono (señal de
+ *     color de acento) tenga cuerpo suficiente sobre el pastel — sin depender del
+ *     único cue de color, que sería inaccesible para daltonismo.
+ */
+
+/* ── 1. Jerarquía: tiles DESTACADOS ─────────────────────────────────────────── */
+.dash-tile--destacado {
+  /* Elevación sutil sobre el resto de tiles para señalar "esto es lo fuerte". */
+  box-shadow: 0 2px 10px -4px rgba(16, 24, 12, 0.35);
+}
+.dash-tile--destacado:active {
+  transform: scale(0.985);
+}
+
+/* ── 2. Contraste WCAG AA en el layout F2 (tile pastel claro) ────────────────── */
+/* La tinta del label/desc la fuerza finca-viva-resto.css (#26331f / #4e5c42).
+   Aquí solo subimos el contraste de la DESCRIPCIÓN de los tiles destacados (texto
+   más largo y pequeño) y le damos peso al texto, sin tocar el color de marca. */
+.fvh-resto .dash-tile--destacado .fvh-tile-desc {
+  color: #3a4733 !important; /* ≈7.5:1 sobre blanco-82% → AA holgado en 12px */
+  font-weight: 500;
+}
+
+/* El ícono usa el color de acento (lime/violet/etc.). Sobre el pastel claro le
+   damos un sutil halo para que el cue de color no sea el único portador de
+   información y se distinga del fondo crema. */
+.fvh-resto .dash-tile svg[aria-hidden='true'] {
+  filter: drop-shadow(0 1px 1px rgba(38, 51, 31, 0.18));
+}
+
+/* ── 3. Contraste en el layout legacy (tile slate-900 oscuro) ────────────────── */
+/* La descripción legacy usa text-slate-500/400 (Tailwind). En los tiles de la
+   redistribución la subimos un escalón para asegurar AA del texto pequeño sobre
+   slate-900 sin cambiar la paleta general del home. */
+:not(.fvh-resto) .dash-tile .fvh-tile-desc {
+  color: rgb(148 163 184); /* slate-400 ≈ 5.9:1 sobre slate-900 → AA */
+}


### PR DESCRIPTION
## Feature
Reorganizar "El resto de su finca" del home F2 (`DashboardLive.jsx`, bajo el hero) según la auditoría. El dedup previo quitó el apilamiento pero dejó **11 tiles sueltos en un solo bloque "Herramientas de finca"** — el campesino no distinguía lo sólido de lo flojo de un vistazo. Esta es la **redistribución** que faltaba.

## Causa raíz (fragmentación)
`HERRAMIENTAS_TILES` mezclaba contenido de aprendizaje, lo grounded fuerte, gestión y la fachada de mercado en una sola grilla plana, sin jerarquía. La auditoría (`CAPABILITIES_STATUS.md` §7.2 + §7.4 #2) pide elevar lo fuerte, consolidar el aprendizaje bajo un hub y bajar la fachada.

## Cambios
- **`DashboardLive.jsx`**: el bloque-pila se reparte en 4 grupos con jerarquía explícita y orden Destacado → Aprender → Gestión → Mercado:
  - **DESTACADO** ("Lo más sólido de Chagra") — tiles grandes a 2 columnas: `directorio` (Especies) + `calendario_finca` (Calendario), 100% AGE/catálogo. **(ELEVADOS)**
  - **APRENDER** (hub único, §7.4 #2) — consolida `casos`, `ciclo_nutrientes`, `biopreparados`, `suelo`, `toxicologia` (Seguridad) y `faq`. Con F2 ON no duplica el hub `aprende` (ya es portal del hero); en legacy sí lo muestra. **(CONSOLIDADOS)**
  - **GESTIÓN** ("Mi finca · gestión") — `germinacion` (Semilleros), `cosechar`, `insumos`, `mantenimiento`.
  - **MERCADO** ("Vender y comprar") — `mercado` al fondo, tile de baja jerarquía. **(BAJADO)**
- **`dashboard-resto-redistribucion.css`** (nuevo): refuerza WCAG AA de la descripción y el ícono sobre el pastel claro F2 (la tinta del label ya la fuerza `finca-viva-resto.css`) y sube la descripción legacy a slate-400 sobre slate-900. **No toca `finca-viva-*.css`** (bajo trabajo en paralelo).

### Qué se ELIMINA / CONSOLIDA / ELEVA / BAJA
- **ELIMINA (rutas/capacidades):** ninguna. Todas las pantallas siguen vivas en `App.jsx`; solo cambia la agrupación/jerarquía de los launchers. Lo que se elimina es el **bloque plano "Herramientas de finca"** como contenedor único.
- **CONSOLIDA en Aprender:** casos de estudio, ciclo de nutrientes, biopreparados, suelo/micorrizas, seguridad de insumos, FAQ (+ el hub `aprende` en legacy).
- **ELEVA:** directorio de especies y calendario de finca (tiles grandes, primer bloque).
- **BAJA:** mercado (último bloque, baja jerarquía); semilleros pasa de "herramientas" a gestión.

## Tests
- 7 casos vitest nuevos (`DashboardLive.redistribucion.test.jsx`): existencia y orden de los 4 grupos, membresía exacta de tiles por grupo, navegación a rutas (incl. `biopreparados` con `back:'dashboard'`), y ambos layouts (F2 ON filtra el hub; legacy lo muestra).
- 8 casos vitest preexistentes de DashboardLive (gating/asociaciones/glaciar) siguen verdes.
- eslint `--max-warnings=0` limpio en los archivos JSX cambiados.

Refs: CAPABILITIES_STATUS.md §7.2 + §7.4 #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)