### PR TITLE
docs(ui): actualizar la ayuda a la app de la ola 1.1.0 (4 lugares + pantallas nuevas)

### DIFF
--- a/src/components/HelpAgentSection.jsx
+++ b/src/components/HelpAgentSection.jsx
@@ -93,10 +93,17 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
             </p>
             <p>
               Para conversar usa un modelo de inteligencia artificial abierto
-              llamado <strong className="text-sky-300">Granite 3.1</strong> (de
-              IBM) que corre en nuestros servidores en Colombia. Lo anclamos al
-              catálogo: si un dato no está en las fichas, el agente lo dice en
-              vez de inventarlo.
+              llamado <strong className="text-sky-300">Granite 3.3</strong> (de
+              IBM) que corre en nuestros servidores en Colombia, con energía
+              solar. Lo anclamos a un catálogo de especies y a un mapa de
+              relaciones entre ellas: si un dato no está ahí, el agente lo dice
+              en vez de inventarlo.
+            </p>
+            <p>
+              Le puede escribir, hablarle (toca el micrófono) o mandarle una
+              foto. Vive en el lugar <strong className="text-sky-300">Agente</strong>{' '}
+              del inicio, y también aparece como burbuja para preguntarle desde
+              cualquier pantalla.
             </p>
           </div>
         </section>
@@ -127,8 +134,10 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
                 </p>
                 <p className="text-xs text-slate-400 mt-1">
                   Ejemplo: pregúntale &ldquo;qué plantas van con el
-                  café&rdquo; y te responde con datos del catálogo Chagra (263
-                  especies curadas a la fecha, incluidas 60 de páramo).
+                  café&rdquo; y te responde con datos del catálogo Chagra (más
+                  de 700 especies curadas a la fecha, incluidas plantas de
+                  páramo). Para ver la ficha completa de una planta, entra al{' '}
+                  <strong className="text-emerald-300">Directorio de especies</strong>.
                 </p>
               </div>
             </li>
@@ -144,8 +153,10 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
                   agroecológicos (caldos, abonos, repelentes naturales).
                 </p>
                 <p className="text-xs text-slate-400 mt-1">
-                  Fuente: 36 biopreparados curados con literatura y prácticas
-                  campesinas registradas. Cita la fuente cuando la tiene.
+                  Fuente: biopreparados curados con literatura y prácticas
+                  campesinas registradas. Cuando tiene la dosis y la frecuencia,
+                  te las dice; cuando no, lo confiesa. Cita la fuente cuando la
+                  tiene.
                 </p>
               </div>
             </li>
@@ -174,7 +185,12 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
               <div>
                 <p>
                   <strong>Te recuerda fechas importantes</strong> de siembra y
-                  cosecha según la especie y tu zona térmica.
+                  cosecha según la especie y tu altitud.
+                </p>
+                <p className="text-xs text-slate-400 mt-1">
+                  Todo eso reunido lo ves en el{' '}
+                  <strong className="text-amber-300">Calendario de finca</strong>:
+                  cuándo sembrar, abonar, cuidar de plagas y cosechar.
                 </p>
               </div>
             </li>
@@ -282,10 +298,19 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
                 className="text-rose-400 mt-1 shrink-0"
                 aria-hidden="true"
               />
-              <p>
-                <strong>NO sabe los precios del mercado</strong> en tiempo
-                real. Todavía no. Algún día tal vez.
-              </p>
+              <div>
+                <p>
+                  <strong>NO te dice un precio de venta exacto</strong> ni el
+                  precio del mercado en tiempo real. Esa parte aún está en
+                  construcción.
+                </p>
+                <p className="text-xs text-slate-400 mt-1">
+                  Lo que SÍ puedes hacer: publicar tu cosecha y venderla por
+                  circuitos cortos en el{' '}
+                  <strong className="text-rose-300">Mercado de la finca</strong>{' '}
+                  (lugar Gestionar → Vender). El precio lo pones tú.
+                </p>
+              </div>
             </li>
             <li className="flex items-start gap-2">
               <XCircle
@@ -374,9 +399,11 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
           </h3>
           <ul className="space-y-3 text-sm text-slate-200 leading-relaxed">
             <li>
-              <strong>El catálogo abierto tiene 263 especies hoy</strong>{' '}
-              (incluidas 60 de páramo). Si tu planta no está, el agente te lo
-              dirá. Crece con aportes de la comunidad.
+              <strong>El catálogo abierto tiene más de 700 especies hoy</strong>{' '}
+              (incluidas plantas de páramo), conectadas por más de doce mil
+              relaciones (qué se lleva con qué, qué controla qué plaga). Si tu
+              planta no está, el agente te lo dirá. Crece con aportes de la
+              comunidad.
             </li>
             <li>
               <strong>El modelo se equivoca</strong> en cierto porcentaje de

--- a/src/components/HelpDictionary.jsx
+++ b/src/components/HelpDictionary.jsx
@@ -164,8 +164,8 @@ export default function HelpDictionary({ onBackToHome }) {
           {filtered.length === 0 && (
             <div className="rounded-xl bg-slate-900/60 border border-slate-800 p-6 text-center text-slate-400">
               <p className="text-sm leading-relaxed">
-                No encontré ese término. ¿Te falta uno importante? Cuéntamelo con el botón flotante 💬
-                — el diccionario crece con tu uso.
+                No encontré ese término. ¿Te falta uno importante? Cuéntamelo en
+                &ldquo;Cómo usar Chagra → Reportar problema&rdquo; — el diccionario crece con tu uso.
               </p>
             </div>
           )}
@@ -337,7 +337,7 @@ export default function HelpDictionary({ onBackToHome }) {
         {/* Footer educativo */}
         <p className="text-[11px] text-slate-600 text-center mt-6 italic leading-relaxed">
           Diccionario v1 · {DICTIONARY.length} términos · Curado con fuentes verificables — sin alucinaciones.<br />
-          Si te falta un término, pídelo con el botón flotante 💬.
+          Si te falta un término, pídelo en &ldquo;Cómo usar Chagra → Reportar problema&rdquo;.
         </p>
       </main>
     </div>

--- a/src/components/HelpHomeScreen.jsx
+++ b/src/components/HelpHomeScreen.jsx
@@ -1,5 +1,8 @@
 import React, { useState, useMemo } from 'react';
-import { Mic, BookOpen, Sprout, ChevronRight, Library, Bot, Database, Search, X } from 'lucide-react';
+import {
+  Mic, BookOpen, Sprout, ChevronRight, Library, Bot, Database, Search, X,
+  Leaf, CalendarDays, Store, HelpCircle, Gamepad2, MessageSquare,
+} from 'lucide-react';
 import HelpRegionSelector from './HelpRegionSelector.jsx';
 
 /**
@@ -12,9 +15,27 @@ import HelpRegionSelector from './HelpRegionSelector.jsx';
  *
  * El buscador NO usa IA: es un filtro de texto plano sobre título, resumen
  * y palabras clave de cada tema. Sin red, sin latencia, sin sorpresas.
+ *
+ * Actualización ola 1.1.0 (2026-06-25): la app se reorganizó en cuatro
+ * lugares (Gestionar / Aprender / Jugar / Agente) y estrenó directorio de
+ * especies, calendario de finca, mercado y FAQ. El Manual ahora:
+ *   - explica de entrada los cuatro lugares (mapa mental del campesino),
+ *   - ofrece atajos que ABREN esas pantallas nuevas (no solo las describen),
+ *   - mantiene los seis temas guía (voz/uso/ciclo/diccionario/agente/datos).
+ * Consistente con el FAQ groundeado (src/data/faqChagra.json, #1856).
+ *
+ * @param {Function} props.onSelect    cambia de sub-vista DENTRO del Manual.
+ * @param {Function} [props.onNavigate] cierra el Manual y abre una pantalla
+ *   real de la app (atajos a especies / calendario / mercados / faq...).
  */
-export default function HelpHomeScreen({ onSelect }) {
+export default function HelpHomeScreen({ onSelect, onNavigate }) {
   const [query, setQuery] = useState('');
+
+  // Atajos que SALEN del Manual hacia una pantalla real de la app (las
+  // rutas existen en App.jsx y son las mismas que usa el FAQ groundeado).
+  const go = (route) => {
+    if (typeof onNavigate === 'function') onNavigate(route);
+  };
 
   const cards = [
     {
@@ -47,8 +68,8 @@ export default function HelpHomeScreen({ onSelect }) {
       key: 'ciclo',
       icon: Sprout,
       title: 'Aprende sembrando',
-      sub: 'Lechuga, fresa, tomate y los próximos. Corpus consolidado y voz IA con guardrails.',
-      keywords: 'aprender sembrar cultivar ciclo lechuga fresa tomate germinar cosechar biopreparado bocashi compañeros',
+      sub: 'El ciclo de un cultivo paso a paso: germinar, crecer, florecer, cosechar. Con su fuente.',
+      keywords: 'aprender sembrar cultivar ciclo lechuga fresa tomate germinar cosechar floracion fenologia biopreparado bocashi compañeros perenne',
       accent: 'from-pink-900/40 to-rose-950/80',
       border: 'border-pink-600/40 hover:border-pink-400/70',
       iconBg: 'bg-pink-700/30 border-pink-500/40',
@@ -102,6 +123,93 @@ export default function HelpHomeScreen({ onSelect }) {
     },
   ];
 
+  // Los cuatro lugares de Chagra (home F2 "Finca Viva"): el mapa mental que
+  // un campesino nuevo necesita para no perderse. Cada uno abre una pantalla
+  // real. Mismos nombres que los portales del home (FincaVivaHero).
+  const lugares = [
+    {
+      key: 'gestionar',
+      icon: Sprout,
+      title: 'Gestionar',
+      sub: 'Registre y cuide sus siembras, zonas, animales y bitácora.',
+      route: 'juego',
+      iconColor: 'text-emerald-300',
+      ring: 'border-emerald-600/40 hover:border-emerald-400/70',
+    },
+    {
+      key: 'aprender',
+      icon: BookOpen,
+      title: 'Aprender',
+      sub: 'Suelo vivo, milpa, biopreparados, MIP y fenología. Cinco lecciones.',
+      route: 'aprende',
+      iconColor: 'text-amber-300',
+      ring: 'border-amber-600/40 hover:border-amber-400/70',
+    },
+    {
+      key: 'jugar',
+      icon: Gamepad2,
+      title: 'Jugar',
+      sub: 'Haga crecer su finca y defiéndala jugando: Mi Finca Viva.',
+      route: 'juego',
+      iconColor: 'text-pink-300',
+      ring: 'border-pink-600/40 hover:border-pink-400/70',
+    },
+    {
+      key: 'agente',
+      icon: MessageSquare,
+      title: 'Agente',
+      sub: 'Pregunte lo que sea por texto, voz o foto. Respuestas con su fuente.',
+      route: 'agente',
+      iconColor: 'text-sky-300',
+      ring: 'border-sky-600/40 hover:border-sky-400/70',
+    },
+  ];
+
+  // Atajos a las pantallas nuevas de la ola 1.1.0 (rutas reales, mismas que
+  // el FAQ groundeado). No describen: ABREN la pantalla.
+  const shortcuts = [
+    {
+      key: 'especies',
+      icon: Leaf,
+      title: 'Directorio de especies',
+      sub: 'Ficha de cada planta: piso térmico, asociaciones, plagas y biopreparados.',
+      keywords: 'especie especies catalogo catálogo directorio ficha planta cultivo piso termico térmico altitud asociaciones compañeras plaga biopreparado buscar',
+      route: 'especies',
+      iconColor: 'text-emerald-300',
+      ring: 'border-emerald-600/40 hover:border-emerald-400/70',
+    },
+    {
+      key: 'calendario',
+      icon: CalendarDays,
+      title: 'Calendario de finca',
+      sub: 'Cuándo sembrar, abonar, cuidar de plagas y cosechar, según su altitud.',
+      keywords: 'calendario fecha cuando sembrar cosechar abonar nutricion nutrición fenologia fenología mip plaga perenne mes temporada',
+      route: 'calendario',
+      iconColor: 'text-amber-300',
+      ring: 'border-amber-600/40 hover:border-amber-400/70',
+    },
+    {
+      key: 'mercados',
+      icon: Store,
+      title: 'Vender mi cosecha',
+      sub: 'Publique lo que produce y véndalo por circuitos cortos (WhatsApp).',
+      keywords: 'vender venta mercado marketplace cosecha precio circuito corto whatsapp comprador feria plaza',
+      route: 'mercados',
+      iconColor: 'text-rose-300',
+      ring: 'border-rose-600/40 hover:border-rose-400/70',
+    },
+    {
+      key: 'faq',
+      icon: HelpCircle,
+      title: 'Preguntas frecuentes',
+      sub: 'Una pregunta corta y le decimos dónde está la respuesta en la app.',
+      keywords: 'faq pregunta preguntas frecuentes duda respuesta donde dónde como cómo busco encuentro',
+      route: 'faq',
+      iconColor: 'text-violet-300',
+      ring: 'border-violet-600/40 hover:border-violet-400/70',
+    },
+  ];
+
   // Filtro de texto plano (sin IA). Normaliza tildes para que "camara"
   // encuentre "cámara". Vacío = muestra todas las tarjetas.
   const normalize = (s) =>
@@ -110,22 +218,68 @@ export default function HelpHomeScreen({ onSelect }) {
       .normalize('NFD')
       .replace(/[̀-ͯ]/g, '');
 
+  const matches = (c, terms) => {
+    const haystack = normalize(`${c.title} ${c.sub} ${c.keywords || ''}`);
+    return terms.every((t) => haystack.includes(t));
+  };
+
   const visibleCards = useMemo(() => {
     const q = normalize(query).trim();
     if (!q) return cards;
     const terms = q.split(/\s+/);
-    return cards.filter((c) => {
-      const haystack = normalize(`${c.title} ${c.sub} ${c.keywords || ''}`);
-      return terms.every((t) => haystack.includes(t));
-    });
+    return cards.filter((c) => matches(c, terms));
     // eslint-disable-next-line react-hooks/exhaustive-deps -- cards es constante (definido arriba), no cambia por referencia
   }, [query]);
+
+  const visibleShortcuts = useMemo(() => {
+    const q = normalize(query).trim();
+    if (!q) return shortcuts;
+    const terms = q.split(/\s+/);
+    return shortcuts.filter((c) => matches(c, terms));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- shortcuts es constante (definido arriba)
+  }, [query]);
+
+  // "Sin resultados" solo si NI temas NI atajos coinciden.
+  const noResults = query && visibleCards.length === 0 && visibleShortcuts.length === 0;
 
   return (
     <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-4">
       <p className="text-sm text-slate-300 leading-relaxed">
         Una mano rápida para entrar a Chagra. Toca lo que necesites o busca tu pregunta.
       </p>
+
+      {/* Mapa mental: los cuatro lugares de Chagra (home F2). Solo cuando no
+          hay búsqueda activa — es orientación, no un resultado buscable. */}
+      {!query && (
+        <section
+          aria-labelledby="lugares-chagra"
+          className="rounded-2xl border border-emerald-800/40 bg-gradient-to-br from-emerald-950/60 to-slate-950/70 p-4"
+        >
+          <p id="lugares-chagra" className="text-[11px] uppercase tracking-wider text-emerald-400/90 font-bold mb-1">
+            Chagra tiene cuatro lugares
+          </p>
+          <p className="text-xs text-slate-400 leading-relaxed mb-3">
+            En la pantalla de inicio (su finca dibujada) toca uno de estos lugares. Aquí los abre directo:
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            {lugares.map((l) => {
+              const Icon = l.icon;
+              return (
+                <button
+                  key={l.key}
+                  type="button"
+                  onClick={() => go(l.route)}
+                  className={`rounded-xl bg-slate-900/60 border ${l.ring} active:scale-[0.99] transition-all p-3 text-left flex flex-col gap-1.5 min-h-[96px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60`}
+                >
+                  <Icon size={22} className={`${l.iconColor} shrink-0`} />
+                  <p className="text-sm font-black text-slate-100 leading-tight">{l.title}</p>
+                  <p className="text-[11px] text-slate-400 leading-snug">{l.sub}</p>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      )}
 
       {/* Buscador simple (filtro de texto, sin IA) */}
       <div className="relative">
@@ -149,6 +303,43 @@ export default function HelpHomeScreen({ onSelect }) {
           </button>
         )}
       </div>
+
+      {/* Atajos a las pantallas nuevas (abren la app, no describen). */}
+      {visibleShortcuts.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {!query && (
+            <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold mt-1">
+              Ir directo a…
+            </p>
+          )}
+          {visibleShortcuts.map((s) => {
+            const Icon = s.icon;
+            return (
+              <button
+                key={s.key}
+                type="button"
+                onClick={() => go(s.route)}
+                className={`rounded-xl bg-slate-900/60 border ${s.ring} active:scale-[0.99] transition-all p-4 text-left flex items-center gap-3 min-h-[72px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60`}
+              >
+                <span className="shrink-0 inline-flex items-center justify-center w-11 h-11 rounded-lg bg-slate-800/60 border border-slate-700/60">
+                  <Icon size={22} className={s.iconColor} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-black text-slate-100 leading-tight">{s.title}</p>
+                  <p className="text-[11px] text-slate-400 leading-snug mt-0.5">{s.sub}</p>
+                </div>
+                <ChevronRight size={18} className="shrink-0 text-slate-500" />
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {visibleCards.length > 0 && !query && (
+        <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold mt-1">
+          Guías y temas
+        </p>
+      )}
 
       <div className="flex flex-col gap-3">
         {visibleCards.map((c) => {
@@ -174,7 +365,7 @@ export default function HelpHomeScreen({ onSelect }) {
       </div>
 
       {/* Sin resultados: invita a reportar en lugar de dejar pantalla vacía */}
-      {query && visibleCards.length === 0 && (
+      {noResults && (
         <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-5 text-center">
           <p className="text-sm text-slate-300 leading-relaxed">
             No encontramos un tema con esa palabra.
@@ -182,8 +373,8 @@ export default function HelpHomeScreen({ onSelect }) {
           <p className="text-xs text-slate-500 leading-relaxed mt-1.5">
             Prueba con otra (ej. <strong className="text-slate-300">datos</strong>,{' '}
             <strong className="text-slate-300">voz</strong>,{' '}
-            <strong className="text-slate-300">cosecha</strong>) o usa el botón
-            flotante 💬 para preguntarnos directo.
+            <strong className="text-slate-300">cosecha</strong>) o repórtalo en{' '}
+            <strong className="text-slate-300">Cómo usar Chagra → Reportar problema</strong>.
           </p>
         </div>
       )}
@@ -194,7 +385,7 @@ export default function HelpHomeScreen({ onSelect }) {
       )}
 
       <p className="text-[11px] text-slate-600 text-center mt-4 italic leading-relaxed">
-        Si algo no está aquí, toca el botón flotante 💬 para reportarlo. La app aprende contigo.
+        Si algo no está aquí, repórtalo desde el tema de uso → &ldquo;Reportar problema&rdquo;. La app aprende contigo.
       </p>
     </main>
   );

--- a/src/components/HelpManual.jsx
+++ b/src/components/HelpManual.jsx
@@ -18,12 +18,19 @@ import HelpDatosScreen from './HelpDatosScreen.jsx';
  * Rediseño 2026-05-08 (queue/039 + UX feedback): router interno con 3
  * sub-vistas grandes en lugar de 12 secciones planas apiladas.
  *
- *   Home        → 5 botones grandes (voz / uso / ciclo / diccionario / agente)
+ *   Home        → cuatro lugares de Chagra + atajos a pantallas nuevas
+ *                 (especies/calendario/mercados/faq) + 6 temas guía
  *   Voz         → tutorial híbrido + CTA "Probar voz ahora"
- *   Uso         → FAQs reorganizadas en 6 temas (incluye Reportar bug)
+ *   Uso         → FAQs reorganizadas en temas (incluye Reportar problema)
  *   Ciclo       → wrapper de HelpCycleSection (accordion por especie, PR #201)
  *   Diccionario → ~70 términos curados (identidad/microorg/biopreparados/...)
  *   Agente      → "Sobre el agente Chagra" cero hype, qué SÍ y qué NO puede (task #123)
+ *
+ * Actualización ola 1.1.0 (2026-06-25): el home se reorganizó en cuatro
+ * lugares (Gestionar/Aprender/Jugar/Agente) y se estrenaron directorio de
+ * especies, calendario de finca, mercado y FAQ groundeado (#1849, #1853-#1856).
+ * El Manual ahora apunta a esas pantallas y describe el agente real
+ * (granite3.3, catálogo grande, voz y foto en el chat).
  *
  * Principios aplicados (UX guidelines internos del proyecto):
  *   P1 tono "tú" cercano (anti-ladrillo)
@@ -72,7 +79,7 @@ export default function HelpManual({ onBack, onNavigate }) {
 
       {/* Sub-vistas */}
       {section === 'home' && (
-        <HelpHomeScreen onSelect={setSection} />
+        <HelpHomeScreen onSelect={setSection} onNavigate={closeAndNavigate} />
       )}
       {section === 'voz' && (
         <HelpVozScreen onBackToHome={goHome} onNavigate={closeAndNavigate} />

--- a/src/components/HelpUsoScreen.jsx
+++ b/src/components/HelpUsoScreen.jsx
@@ -1,17 +1,23 @@
 import React, { useState } from 'react';
 import {
   ArrowLeft, ChevronDown, ChevronRight, Sprout, Camera, MapPin, Bug, Apple,
-  MessageCircle, Wrench,
+  MessageCircle, Wrench, Compass, Mic, CalendarDays, Leaf, Store,
 } from 'lucide-react';
 import FieldFeedback from './FieldFeedback';
 
 /**
  * Sub-vista del Manual: cómo usar Chagra (FAQs reorganizadas).
  *
- * Reorganización 2026-05-08: 6 temas en lugar de 12 secciones planas.
- * Tono migrado a "tú" cercano (P1). "Reportar bug" dentro de FAQs (no
- * cuarto botón). "Field test cases" + "Novedades mayo 2026" salieron
- * del Manual público (movidos a docs operativos internos + CHANGELOG.md).
+ * Reorganización 2026-05-08: temas en lugar de secciones planas. Tono "tú"
+ * cercano (P1). "Reportar bug" dentro de FAQs (no cuarto botón). "Field test
+ * cases" + "Novedades" salieron del Manual público (docs internos + CHANGELOG).
+ *
+ * Actualización ola 1.1.0 (2026-06-25): la app se reorganizó en cuatro
+ * lugares (Gestionar/Aprender/Jugar/Agente) y estrenó registro por voz
+ * unificado, directorio de especies, calendario de finca y mercado. Este
+ * tema ahora orienta primero (los cuatro lugares) y agrega esas pantallas.
+ * Consistente con el FAQ groundeado (src/data/faqChagra.json, #1856) y con
+ * "Sobre el agente Chagra" (HelpAgentSection).
  */
 
 // eslint-disable-next-line no-unused-vars -- Icon SE USA en JSX, eslint react-jsx detection falla con destructuring rename
@@ -88,8 +94,34 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
 
       <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-3">
         <p className="text-sm text-slate-300 leading-relaxed">
-          Toca cada tema para abrir o cerrar. Si algo no está aquí, usa el botón flotante 💬 para reportarlo.
+          Toca cada tema para abrir o cerrar. Si algo no está aquí, usa el tema &ldquo;Reportar problema&rdquo; al final.
         </p>
+
+        {/* 0. Orientación — los cuatro lugares de Chagra (home F2). Esto va
+            primero porque es el mapa mental que el campesino nuevo necesita
+            para no perderse. Mismos nombres que los portales del inicio. */}
+        <Section icon={Compass} title="🧭 Los cuatro lugares de Chagra" defaultOpen>
+          <p>
+            Al abrir Chagra ves <strong className="text-emerald-200">su finca dibujada</strong> (la pantalla de inicio). Ahí toca uno de estos cuatro lugares:
+          </p>
+          <ul className="mt-2 space-y-2 text-sm">
+            <li>
+              <strong className="text-emerald-300">🌱 Gestionar</strong> — registrar y cuidar sus siembras, zonas, animales y la bitácora. También vender su cosecha.
+            </li>
+            <li>
+              <strong className="text-amber-300">📚 Aprender</strong> — lecciones de agroecología con fuente: suelo vivo, milpa, biopreparados, MIP, fenología.
+            </li>
+            <li>
+              <strong className="text-pink-300">🎮 Jugar</strong> — haga crecer su finca y defiéndala jugando (Mi Finca Viva).
+            </li>
+            <li>
+              <strong className="text-sky-300">💬 Agente</strong> — pregúntele lo que sea por texto, voz o foto. Responde con su fuente. Mira el tema &ldquo;Sobre el agente Chagra&rdquo; en el Manual.
+            </li>
+          </ul>
+          <p className="text-xs text-slate-400 italic mt-2">
+            Para volver al inicio en cualquier momento, toca el ícono de la casa o la mano de Chagra arriba.
+          </p>
+        </Section>
 
         {/* 1. Inicio rápido */}
         <Section icon={Sprout} title="🌱 Inicio rápido (primera vez)" action={quickAction('Crear primera planta', 'plant_asset')}>
@@ -159,12 +191,13 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
         {/* 4. Plagas y cosechas */}
         <Section icon={Bug} title="🐛 Plagas y 🍎 cosecha">
           <p className="font-bold text-emerald-200">Reportar plaga / invasora</p>
-          <p>Toca menú principal → <strong>&ldquo;Plagas&rdquo;</strong>. Selecciona la especie invasora del catálogo, captura foto y geolocalización.</p>
-          <p>Después de guardar te aparece una pantalla con <strong>sugerencias de especies nativas para reemplazar</strong>. Toca &ldquo;Sembrar aquí&rdquo; y vas al flow de siembra precargado con la nativa + las coordenadas del invasor.</p>
+          <p>En el lugar <strong className="text-emerald-300">Gestionar</strong> toca <strong>&ldquo;Reportar plaga&rdquo;</strong>. Selecciona la especie del catálogo, captura foto y ubicación.</p>
+          <p>Después de guardar te aparece una pantalla con <strong>sugerencias de especies nativas para reemplazar</strong>. Toca &ldquo;Sembrar aquí&rdquo; y vas al registro de siembra ya cargado con la nativa + las coordenadas.</p>
+          <p className="text-xs text-slate-400 mt-1">¿No sabes cómo controlarla sin químicos? Pregúntale al <strong className="text-sky-300">Agente</strong>: te sugiere control biológico y biopreparados con su fuente.</p>
 
           <p className="font-bold text-emerald-200 mt-3">Registrar cosecha</p>
-          <p>Activos → selecciona la planta → en la card aparece &ldquo;Registrar cosecha&rdquo;. Captura cantidad cosechada (kg / unidades) + fecha. Se agrega como log de cosecha a la hoja de vida.</p>
-          <p>También por voz: &ldquo;coseché 5 kilos de gulupas&rdquo; con el botón micrófono.</p>
+          <p>En <strong className="text-emerald-300">Gestionar</strong> → tus plantas → selecciona la planta → &ldquo;Registrar cosecha&rdquo;. Captura cuánto cosechaste (kg / unidades) + fecha. Queda en la hoja de vida de la planta.</p>
+          <p>También por voz: di &ldquo;coseché 5 kilos de gulupas&rdquo; con el botón micrófono. Ver el tema &ldquo;Cómo usar la voz&rdquo;.</p>
 
           <div className="mt-3 flex flex-wrap gap-2">
             <button
@@ -184,7 +217,45 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
           </div>
         </Section>
 
-        {/* 5. Reportar problema / sugerir mejora — embed del FieldFeedback
+        {/* 5. Registrar por voz — atajo al tema completo + tipos. */}
+        <Section icon={Mic} title="🎤 Registrar por voz (con las manos sucias)" action={quickAction('Probar la voz', 'voz')}>
+          <p>La forma más rápida en campo. Toca el micrófono, habla normal y Chagra entiende y te deja confirmar antes de guardar.</p>
+          <p className="mt-1">Con la voz puedes registrar:</p>
+          <ul className="list-disc pl-5 space-y-1 mt-1">
+            <li><strong className="text-emerald-200">Sembrar</strong>: &ldquo;sembré 5 tomates en el invernadero&rdquo;.</li>
+            <li><strong className="text-emerald-200">Cosechar</strong>: &ldquo;coseché 3 kilos de gulupas&rdquo;.</li>
+            <li><strong className="text-emerald-200">Insumo</strong>: &ldquo;apliqué bocashi al tomate de ayer&rdquo;.</li>
+            <li><strong className="text-emerald-200">Mantenimiento</strong>: &ldquo;podé el aguacate&rdquo;.</li>
+            <li><strong className="text-emerald-200">Observación</strong>: &ldquo;vi una broca en el café&rdquo;.</li>
+          </ul>
+          <p className="text-xs text-slate-400 italic mt-2">El tema completo, paso a paso, está en el Manual → &ldquo;Cómo usar la voz&rdquo;.</p>
+        </Section>
+
+        {/* 6. Directorio de especies — pantalla nueva (#1855). */}
+        <Section icon={Leaf} title="🌿 Buscar una especie (directorio)" action={quickAction('Abrir directorio de especies', 'especies')} isNew>
+          <p>El <strong className="text-emerald-200">Directorio de especies</strong> es el catálogo de Chagra como fichas. Busca una planta y mira:</p>
+          <ul className="list-disc pl-5 space-y-1 mt-1">
+            <li>en qué <strong>piso térmico / altitud</strong> prospera,</li>
+            <li>con qué se lleva bien y qué evitar (<strong>asociaciones</strong>),</li>
+            <li>qué <strong>plagas</strong> la afectan y quién las controla,</li>
+            <li>qué <strong>biopreparados</strong> le sirven.</li>
+          </ul>
+          <p className="text-xs text-slate-400 italic mt-2">Si quieres preguntar en palabras (&ldquo;¿qué va con el café?&rdquo;), usa el Agente.</p>
+        </Section>
+
+        {/* 7. Calendario de finca — pantalla nueva (#1853). */}
+        <Section icon={CalendarDays} title="📅 Calendario de finca" action={quickAction('Abrir calendario', 'calendario')} isNew>
+          <p>El <strong className="text-emerald-200">Calendario de finca</strong> reúne en un solo lugar cuándo <strong>sembrar, abonar, cuidar de plagas y cosechar</strong>, según tu altitud y tus cultivos.</p>
+          <p className="mt-1">Junta la fenología, la nutrición, la siembra/cosecha, el manejo de plagas (MIP) y los cultivos perennes. Así sabes qué toca este mes sin tener que adivinar.</p>
+        </Section>
+
+        {/* 8. Vender / Mercado — pantalla nueva (#1854). */}
+        <Section icon={Store} title="🛒 Vender mi cosecha (mercado)" action={quickAction('Abrir el mercado de la finca', 'mercados')} isNew>
+          <p>En el <strong className="text-emerald-200">Mercado de la finca</strong> publicas lo que produces y lo vendes por <strong>circuitos cortos</strong> (de tu finca a quien come), coordinando por WhatsApp.</p>
+          <p className="text-xs text-slate-400 italic mt-2">El precio lo pones tú. Chagra todavía no te dice un precio de mercado exacto — esa parte está en construcción.</p>
+        </Section>
+
+        {/* 9. Reportar problema / sugerir mejora — embed del FieldFeedback
             form. Antes vivía como FAB flotante 💬 global; movido aquí
             2026-05-21 por feedback usuario (más discoverable + no tapa
             contenido). isNew=true para resaltar la nueva ubicación. */}
@@ -270,7 +341,7 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
             </div>
             <div>
               <p className="font-bold text-amber-300">📷 La foto no aparece tras adjuntarla</p>
-              <p className="text-xs text-slate-400 leading-relaxed">Recarga la pantalla, IndexedDB puede tardar en flush. Si persiste, repórtalo via 💬.</p>
+              <p className="text-xs text-slate-400 leading-relaxed">Recarga la pantalla; los datos pueden tardar un momento en aparecer. Si persiste, repórtalo en &ldquo;Reportar problema&rdquo; aquí mismo.</p>
             </div>
             <div>
               <p className="font-bold text-amber-300">🌱 Creé planta y no aparece en la zona</p>
@@ -284,7 +355,7 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
         </Section>
 
         <p className="text-[11px] text-slate-600 text-center mt-4 italic leading-relaxed">
-          Manual v2.0 · Rediseño 2026-05-08 · Colombia es el país de la belleza.
+          Manual v2.1 · Actualizado 2026-06-25 · Colombia es el país de la belleza.
         </p>
       </main>
     </div>

--- a/src/components/HelpVozScreen.jsx
+++ b/src/components/HelpVozScreen.jsx
@@ -106,6 +106,18 @@ export default function HelpVozScreen({ onBackToHome, onNavigate }) {
           })}
         </div>
 
+        {/* Qué puedes registrar por voz — los tipos del registro unificado */}
+        <div className="rounded-xl bg-slate-900/70 border border-emerald-800/40 p-4 mt-2">
+          <p className="text-[11px] uppercase tracking-wider text-emerald-400 font-bold mb-2">Con la voz puedes registrar</p>
+          <ul className="text-sm text-slate-200 space-y-1.5 leading-relaxed">
+            <li>🌱 <strong className="text-emerald-200">Sembrar</strong> — lo que pusiste en tierra.</li>
+            <li>🍎 <strong className="text-emerald-200">Cosechar</strong> — cuánto recogiste.</li>
+            <li>🧪 <strong className="text-emerald-200">Insumo</strong> — qué abono o biopreparado aplicaste.</li>
+            <li>🔧 <strong className="text-emerald-200">Mantenimiento</strong> — poda, deshierbe, riego.</li>
+            <li>👀 <strong className="text-emerald-200">Observación</strong> — lo que viste en campo (una plaga, una flor, un daño).</li>
+          </ul>
+        </div>
+
         {/* Ejemplos */}
         <div className="rounded-xl bg-emerald-950/60 border border-emerald-800/40 p-4 mt-2">
           <p className="text-[11px] uppercase tracking-wider text-emerald-400 font-bold mb-2">Ejemplos que entiende bien</p>
@@ -114,7 +126,8 @@ export default function HelpVozScreen({ onBackToHome, onNavigate }) {
             <li>&ldquo;Planté 100 cafés en la parcela tres&rdquo;</li>
             <li>&ldquo;Puse 10 fresas y 30 lechugas en la cama uno&rdquo; <span className="text-emerald-400/70 text-[11px]">(multi-especie OK)</span></li>
             <li>&ldquo;Coseché 3 kilos de gulupas&rdquo;</li>
-            <li>&ldquo;Aplicué bocashi a la mata de tomate de ayer&rdquo;</li>
+            <li>&ldquo;Apliqué bocashi a la mata de tomate de ayer&rdquo;</li>
+            <li>&ldquo;Podé el aguacate y vi una broca en el café&rdquo;</li>
           </ul>
         </div>
 


### PR DESCRIPTION
## Feature
La ayuda (Manual de uso, accesible desde el TopBar `?`) quedó desactualizada tras el rediseño de la ola 1.1.0. Este PR la corrige y la pone al día con la app actual, **sin tocar `App.jsx`/`DashboardLive.jsx`** (limitado a archivos `Help*`).

## Qué estaba desactualizado (corregido)
- **`HelpAgentSection`** ("Sobre el agente Chagra"):
  - Modelo "Granite **3.1**" → **3.3** (el real en prod).
  - "**263** especies / 60 de páramo" → **más de 700 especies** + más de doce mil relaciones (cifras vivas del grafo).
  - El item "**NO sabe los precios del mercado… Algún día tal vez**" era engañoso ahora que existe el mercado → reescrito honesto: el agente aún no da un precio exacto (en construcción), pero **sí** puedes vender por circuitos cortos en el **Mercado de la finca**. Ahora también apunta a **Calendario** y **Directorio de especies**.
- **`HelpVozScreen`**: typo "Aplicué" → "Apliqué".
- **UI muerta**: el "**botón flotante 💬**" ya no existe (el formulario de feedback vive dentro de "Reportar problema") — corregido en `HelpHomeScreen`, `HelpUsoScreen` y `HelpDictionary`. "menú principal → Plagas" → lugar **Gestionar**.

## Qué se actualizó/mejoró (app actual)
- **`HelpHomeScreen`**: bloque **"Chagra tiene cuatro lugares"** (Gestionar/Aprender/Jugar/Agente) como mapa mental + **atajos que ABREN las pantallas nuevas** (Directorio de especies, Calendario de finca, Vender mi cosecha, Preguntas frecuentes) vía `onNavigate`. El buscador filtra también los atajos.
- **`HelpUsoScreen`**: orientación de los 4 lugares primero; nuevas secciones **Registrar por voz** (sembrar/cosechar/insumo/mantenimiento/observación), **Directorio**, **Calendario** y **Mercado**, cada una con CTA a su ruta real.
- **`HelpVozScreen`**: tipos del registro por voz unificado + ejemplo de observación.
- Lenguaje sencillo (tú/usted colombiano, **sin voseo**), identidad real de Chagra (íconos lucide, paleta emerald/amber/sky/rose, cabecera de la mano/libro).

## Consistencia con el FAQ
Mismas rutas y etiquetas que el FAQ groundeado (`src/data/faqChagra.json`, #1856): `especies`, `calendario`, `mercados`, `aprende`, `faq`, `agente`. Ayuda y FAQ se complementan, no se contradicen.

## Verificación
- Captura **chromium del nix-store, móvil 390** de las 3 vistas (home/uso/agente) — render correcto con la identidad real (enviada al operador por Telegram).
- **14 smoke tests de ayuda en verde** (`HelpHomeScreen`, `HelpAgentSection`, `HelpDatosScreen`).
- eslint sobre los archivos cambiados: **0 errores** (sin `no-undef`); solo warnings preexistentes de `chagra-i18n/no-hardcoded-spanish` (patrón de todo el Manual).
- Acceso intacto: **TopBar `?` → `navigate('help')` → `HelpManual`** (router interno; import+ruta+entrada verificados).

Refs: `CAPABILITIES_STATUS.md` §1/§2 (ola 1.1.0); PRs #1849, #1853–#1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)