### PR TITLE
fix(ui): home F2 puebla con plantas-asset reales + contraste WCAG AA del hero

### DIFF
--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -6,6 +6,7 @@
  * FincaRedInstitucional.jsx en este mismo directorio. */
 import { useEffect, useMemo, useState } from 'react';
 import { listFarmProcesses } from '../../db/farmProcessCache';
+import useAssetStore from '../../store/useAssetStore';
 import { buildFincaScene } from '../../services/fincaSceneService';
 import { selectSceneVariant, SCENE_KINDS } from '../../services/fincaSceneProfileSelector';
 import { getProfile } from '../../services/userProfileService';
@@ -78,7 +79,19 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, children, titul
     return () => { alive = false; };
   }, []);
 
-  const scene = useMemo(() => buildFincaScene({ processes }), [processes]);
+  // CONTEO REAL DE PLANTAS (los ASSETS) — la MISMA fuente de verdad que el
+  // dashboard ("Mis plantas: N" en FincaCards y "llevo seguimiento a N cultivos"
+  // en AnalisisProactivoIA): useAssetStore.plants. Una finca puede tener decenas
+  // de plantas REGISTRADAS sin que exista aún un FarmProcess (ciclo) para ellas;
+  // los processes solo cubren los ciclos abiertos. Sin esto, la escena decía
+  // "terreno listo / 0 siembras" pese a haber plantas reales. Hidratado al boot
+  // por App.jsx; aquí solo nos suscribimos al store (reactivo, offline-first).
+  const plantAssetsCount = useAssetStore((s) => (Array.isArray(s.plants) ? s.plants.length : 0));
+
+  const scene = useMemo(
+    () => buildFincaScene({ processes, plantAssetsCount }),
+    [processes, plantAssetsCount],
+  );
 
   // ── Ubicación real de la finca (vereda · municipio · msnm · piso) ─────────
   const ubicacion = useMemo(() => buildUbicacion(), []);

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -671,3 +671,78 @@
   .fvh-rise-svg,
   .fvh-colibri-globo { opacity: 1 !important; }
 }
+
+/* ════════════════════════════════════════════════════════════════════════════
+   CONTRASTE WCAG AA del HERO (extiende el #1859 que arregló los tiles del
+   "resto"). Aquí cubrimos lo que faltaba: los textos del HERO que se apoyan
+   DIRECTAMENTE sobre el cielo del shell (marca, saludo del agente, hint del
+   compositor, título de portales) y que en día sobre el celeste, y sobre todo
+   de NOCHE sobre el navy, quedaban gris-tenue ilegibles (tinta verde oscura
+   sobre fondo oscuro).
+
+   No tocamos los chips (su fondo blanco translúcido ya da contraste) ni los
+   portales (texto blanco sobre gradiente de color, ya AA). Solo reforzamos el
+   texto sobre el cielo descubierto.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* DÍA — el tinta suave (#4e5c42) sobre el celeste claro del cielo era borde:
+   lo oscurecemos a un verde más profundo (AA ≥4.5:1 sobre el degradado de
+   cielo) y le ponemos un velo de texto blanco tenue para asentarlo sobre la
+   parte más clara/saturada del gradiente. */
+.fvh .fvh-brand-txt span,
+.fvh .fvh-hero-saludo .h-small,
+.fvh .fvh-hero-saludo p,
+.fvh .fvh-composer-hint,
+.fvh .fvh-portales-tit {
+  color: #2c3a23;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.55);
+}
+.fvh .fvh-brand-txt b,
+.fvh .fvh-hero-saludo h1 {
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.5);
+}
+
+/* NOCHE / AMANECER / ATARDECER — el cielo del shell se vuelve oscuro (navy o
+   naranja profundo). El texto del hero apoyado sobre él DEBE virar a claro,
+   o queda tinta-oscura-sobre-oscuro (ilegible). Flip a casi-blanco con un
+   velo oscuro para asentarlo (AA sobre el navy del nocturno). */
+.fvh[data-luz="noche"] .fvh-brand-txt b,
+.fvh[data-luz="noche"] .fvh-brand-txt span,
+.fvh[data-luz="noche"] .fvh-hero-saludo .h-small,
+.fvh[data-luz="noche"] .fvh-hero-saludo h1,
+.fvh[data-luz="noche"] .fvh-hero-saludo p,
+.fvh[data-luz="noche"] .fvh-composer-hint,
+.fvh[data-luz="noche"] .fvh-portales-tit,
+.fvh[data-luz="amanecer"] .fvh-brand-txt b,
+.fvh[data-luz="amanecer"] .fvh-brand-txt span,
+.fvh[data-luz="amanecer"] .fvh-hero-saludo .h-small,
+.fvh[data-luz="amanecer"] .fvh-hero-saludo h1,
+.fvh[data-luz="amanecer"] .fvh-hero-saludo p,
+.fvh[data-luz="amanecer"] .fvh-composer-hint,
+.fvh[data-luz="amanecer"] .fvh-portales-tit,
+.fvh[data-luz="atardecer"] .fvh-brand-txt b,
+.fvh[data-luz="atardecer"] .fvh-brand-txt span,
+.fvh[data-luz="atardecer"] .fvh-hero-saludo .h-small,
+.fvh[data-luz="atardecer"] .fvh-hero-saludo h1,
+.fvh[data-luz="atardecer"] .fvh-hero-saludo p,
+.fvh[data-luz="atardecer"] .fvh-composer-hint,
+.fvh[data-luz="atardecer"] .fvh-portales-tit {
+  color: #f4f7ef;
+  text-shadow: 0 1px 3px rgba(8, 16, 28, 0.7);
+}
+/* El acento verde del título (em) y el rótulo "SU AGENTE…" se aclaran a un
+   lima brillante para no perder el realce sobre el navy. */
+.fvh[data-luz="noche"] .fvh-hero-saludo h1 em,
+.fvh[data-luz="amanecer"] .fvh-hero-saludo h1 em,
+.fvh[data-luz="atardecer"] .fvh-hero-saludo h1 em {
+  color: #bef264;
+}
+.fvh[data-luz="noche"] .fvh-hero-saludo .h-small {
+  color: #cdeacb;
+}
+/* El divisor del título de portales también se aclara para verse sobre navy. */
+.fvh[data-luz="noche"] .fvh-portales-tit span,
+.fvh[data-luz="amanecer"] .fvh-portales-tit span,
+.fvh[data-luz="atardecer"] .fvh-portales-tit span {
+  background: linear-gradient(90deg, rgba(244, 247, 239, 0.45), transparent);
+}

--- a/src/components/dashboard/finca-viva-resto.css
+++ b/src/components/dashboard/finca-viva-resto.css
@@ -102,3 +102,36 @@
 
 /* La nota "mantén presionado ⋮⋮ para reorganizar" legible sobre crema. */
 .fvh-resto .fvh-resto-hint { color: var(--fvh-tinta-suave); opacity: 0.75; }
+
+/* ============================================================================
+   CONTRASTE WCAG AA de las tarjetas OSCURAS del resto (extiende el #1859, que
+   arregló los TILES claros). Las tarjetas full-width "Hoy en finca", "Clima" y
+   el "Análisis IA" conservan su fondo navy oscuro (gradientes from-emerald-950 /
+   from-sky-950 / from-slate-900), pero su texto secundario venía en slate-400
+   (#94a3b8) / slate-500 (#64748b) — gris-tenue que NO cumple AA sobre el navy.
+
+   Aquí NO cambiamos el fondo (la tarjeta oscura es intencional y contrasta bien
+   con la hoja crema): solo SUBIMOS el texto apagado a un slate claro que sí
+   cumple AA (≥4.5:1) sobre ese navy. Scope acotado a esas tarjetas oscuras por
+   su clase de gradiente, para no tocar los tiles claros ya resueltos por #1859.
+   ========================================================================== */
+.fvh-resto [class*="from-emerald-950"] .text-slate-400,
+.fvh-resto [class*="from-emerald-950"] .text-slate-500,
+.fvh-resto [class*="from-sky-950"] .text-slate-400,
+.fvh-resto [class*="from-sky-950"] .text-slate-500,
+.fvh-resto [class*="from-slate-900"] .text-slate-400,
+.fvh-resto [class*="from-slate-900"] .text-slate-500 {
+  color: #cbd5e1 !important; /* slate-300 — AA sobre navy */
+}
+.fvh-resto [class*="from-emerald-950"] .text-slate-300,
+.fvh-resto [class*="from-sky-950"] .text-slate-300,
+.fvh-resto [class*="from-slate-900"] .text-slate-300 {
+  color: #e2e8f0 !important; /* slate-200 — más holgura AA para texto fino */
+}
+/* El chevron/“fecha” de cabecera (slate-500) también se levanta para que la
+   tarjeta no se lea apagada en su esquina. */
+.fvh-resto [class*="from-emerald-950"] .text-slate-500.group-hover\:text-slate-300,
+.fvh-resto [class*="from-sky-950"] .text-slate-500.group-hover\:text-slate-300,
+.fvh-resto [class*="from-slate-900"] .text-slate-500.group-hover\:text-slate-300 {
+  color: #cbd5e1 !important;
+}

--- a/src/services/__tests__/fincaSceneService.test.js
+++ b/src/services/__tests__/fincaSceneService.test.js
@@ -133,6 +133,55 @@ describe('fincaSceneService — buildFincaScene (estado vacío)', () => {
     expect(s.vacia).toBe(true);
     expect(s.lotes).toHaveLength(0);
   });
+
+  it('sin procesos ni plantas-asset → vacía (deflección honesta)', () => {
+    const s = buildFincaScene({ processes: [], plantAssetsCount: 0 });
+    expect(s.vacia).toBe(true);
+    expect(s.totalCultivos).toBe(0);
+    expect(s.plantAssetsCount).toBe(0);
+  });
+});
+
+describe('fincaSceneService — buildFincaScene (plantas-asset reales, BUG home F2)', () => {
+  // El conteo real "Mis plantas: N" del dashboard vive en los ASSETS
+  // (useAssetStore.plants), NO en los FarmProcess. Una finca puede tener
+  // plantas registradas sin ningún proceso abierto → la escena DEBE poblarse,
+  // nunca decir "terreno listo / 0 siembras".
+  it('plantas-asset sin procesos → escena POBLADA (no vacía)', () => {
+    const s = buildFincaScene({ processes: [], plantAssetsCount: 43 });
+    expect(s.vacia).toBe(false);
+    expect(s.totalCultivos).toBe(43);
+    expect(s.cultivosActivos).toBe(43);
+    expect(s.plantAssetsCount).toBe(43);
+  });
+
+  it('totalCultivos honra la fuente mayor (plantas-asset > procesos)', () => {
+    const s = buildFincaScene({
+      processes: [proc({ id: 'p1', stage: 'vegetative', slug: 'zea_mays' })],
+      plantAssetsCount: 43,
+    });
+    expect(s.vacia).toBe(false);
+    expect(s.totalCultivos).toBe(43); // 43 plantas-asset > 1 proceso
+    expect(s.lotes).toHaveLength(1);  // pero solo hay 1 proceso para dibujar lote
+  });
+
+  it('más procesos que plantas-asset → manda el conteo de procesos', () => {
+    const s = buildFincaScene({
+      processes: [
+        proc({ id: 'p1', slug: 'a' }),
+        proc({ id: 'p2', slug: 'b' }),
+        proc({ id: 'p3', slug: 'c' }),
+      ],
+      plantAssetsCount: 1,
+    });
+    expect(s.totalCultivos).toBe(3);
+  });
+
+  it('plantAssetsCount inválido o negativo se sanea a 0 (no fabrica)', () => {
+    expect(buildFincaScene({ processes: [], plantAssetsCount: -5 }).vacia).toBe(true);
+    expect(buildFincaScene({ processes: [], plantAssetsCount: NaN }).plantAssetsCount).toBe(0);
+    expect(buildFincaScene({ processes: [] }).plantAssetsCount).toBe(0);
+  });
 });
 
 describe('fincaSceneService — buildFincaScene (datos reales)', () => {

--- a/src/services/fincaSceneService.js
+++ b/src/services/fincaSceneService.js
@@ -215,9 +215,10 @@ export function etiquetaVitalidad(vitalidad) {
  * @property {SceneLote[]} animales   animales a dibujar en el corral
  * @property {number} vitalidad       0-100, vistazo de salud de la finca
  * @property {string} vitalidadLabel  etiqueta cariñosa de la vitalidad
- * @property {number} totalCultivos   conteo de cultivos (activos + cerrados)
- * @property {number} cultivosActivos conteo de cultivos activos
+ * @property {number} totalCultivos   conteo de cultivos (max de procesos vs. plantas-asset)
+ * @property {number} cultivosActivos conteo de cultivos activos (max procesos vs. plantas-asset)
  * @property {number} enCosecha       cuántos cultivos están listos/en cosecha
+ * @property {number} plantAssetsCount conteo real de plantas-asset (fuente "Mis plantas: N")
  * @property {string[]} clima         elementos de clima a dibujar (sol, lluvia)
  * @property {string} resumen         frase de vistazo para el campesino
  */
@@ -229,9 +230,21 @@ export function etiquetaVitalidad(vitalidad) {
  * @param {Array} [input.processes=[]]   FarmProcess[] (anidados o planos)
  * @param {Object} [input.clima]         clima opcional { lluvia?:boolean, ensoPhase?:string }
  * @param {number} [input.maxLotes=12]   tope de lotes a dibujar (rendimiento gama baja)
+ * @param {number} [input.plantAssetsCount=0]  conteo REAL de plantas-activo de la
+ *   finca (los ASSETS, p.ej. useAssetStore.plants.length). Fuente de verdad del
+ *   "Mis plantas: N" del dashboard. Una finca puede tener decenas de plantas
+ *   REGISTRADAS como assets sin que aún exista un FarmProcess (ciclo) para ellas:
+ *   en ese caso la escena DEBE poblarse igual (no decir "0 siembras / terreno
+ *   listo"). La escena queda vacía SOLO si no hay NI procesos NI plantas-asset.
+ *   No fabrica nada: si es 0, el comportamiento es idéntico al anterior.
  * @returns {FincaScene}
  */
-export function buildFincaScene({ processes = [], clima = null, maxLotes = 12 } = {}) {
+export function buildFincaScene({
+  processes = [],
+  clima = null,
+  maxLotes = 12,
+  plantAssetsCount = 0,
+} = {}) {
   const flat = (Array.isArray(processes) ? processes : [])
     .map(flatten)
     .filter(Boolean);
@@ -272,15 +285,32 @@ export function buildFincaScene({ processes = [], clima = null, maxLotes = 12 } 
     });
   }
 
-  const vacia = plantas.length === 0 && animales.length === 0;
+  // Conteo REAL de plantas-asset (saneado): la fuente de verdad del "Mis plantas:
+  // N" del dashboard. Una finca con plantas REGISTRADAS pero sin FarmProcess aún
+  // NO está vacía — tiene siembras reales que la escena debe poblar.
+  const plantasAssetCount = Number.isFinite(plantAssetsCount) && plantAssetsCount > 0
+    ? Math.floor(plantAssetsCount)
+    : 0;
+
+  // Vacía SOLO si no hay NI procesos (plantas/animales) NI plantas-asset. Con
+  // plantas-asset reales la escena se puebla aunque no haya ningún proceso —
+  // deflección honesta: nunca decimos "terreno listo / 0 siembras" si el
+  // usuario sí tiene plantas registradas.
+  const vacia = plantas.length === 0 && animales.length === 0 && plantasAssetCount === 0;
 
   // Ordenar para que los más maduros/cosecha queden adelante (más visibles).
   plantas.sort((a, b) => (b.growth - a.growth) || a.id.localeCompare(b.id));
 
   const lotesDibujados = plantas.slice(0, maxLotes);
   const vitalidad = calcularVitalidad(plantas);
-  const cultivosActivos = plantas.filter((p) => p.activo).length;
+  const cultivosActivosProc = plantas.filter((p) => p.activo).length;
   const enCosecha = plantas.filter((p) => p.activo && (p.fase === 'harvest' || p.fase === 'fruit')).length;
+
+  // totalCultivos / cultivosActivos honran la fuente real más completa: si hay
+  // más plantas-asset registradas que procesos, ese conteo manda (cada planta es
+  // una siembra real). Sin plantas-asset, queda el conteo por proceso de siempre.
+  const totalCultivos = Math.max(plantas.length, plantasAssetCount);
+  const cultivosActivos = Math.max(cultivosActivosProc, plantasAssetCount);
 
   return {
     vacia,
@@ -288,9 +318,10 @@ export function buildFincaScene({ processes = [], clima = null, maxLotes = 12 } 
     animales: animales.slice(0, 4),
     vitalidad,
     vitalidadLabel: etiquetaVitalidad(vitalidad),
-    totalCultivos: plantas.length,
+    totalCultivos,
     cultivosActivos,
     enCosecha,
+    plantAssetsCount: plantasAssetCount,
     clima: derivarClima(clima),
     resumen: construirResumen({ vacia, cultivosActivos, enCosecha, animales }),
   };


### PR DESCRIPTION
## Bug
El home inmersivo F2 (`FincaVivaHero`) está LIVE en prod con dos defectos sin fix:

1. **Escena dice "terreno listo / 0 siembras" aunque el usuario tiene plantas.**
2. **Contraste:** #1859 arregló los tiles del "resto", pero faltaban la escena/textos del hero y las tarjetas oscuras ("Hoy en finca" / "Clima" / "Análisis") con texto gris-tenue ilegible.

## Causa raíz
**BUG 1:** `FincaVivaHero` armaba la escena con `buildFincaScene({ processes })` leyendo solo los `FarmProcess` (ciclos) de IndexedDB. `scene.vacia` salía `true` sin procesos. Pero el conteo real de plantas vive en los **ASSETS** (`useAssetStore.plants` — la misma fuente del "Mis plantas: 43" de `FincaCards` y del "llevo seguimiento a 43 cultivos" de `AnalisisProactivoIA`). Una finca puede tener decenas de plantas **registradas** sin que exista todavía un `FarmProcess` para ellas → la escena se quedaba "vacía" pese a haber siembras reales.

**BUG 2:** Los textos del hero que se apoyan directamente sobre el cielo del shell usan tinta verde oscura (`--fvh-tinta`/`--fvh-tinta-suave`); de noche (`data-luz="noche"`) el shell vira a navy pero el texto seguía oscuro → dark-on-dark. Las tarjetas full-width oscuras del "resto" usaban `text-slate-400/500` que no cumple AA sobre su navy.

## Cambios
- **`fincaSceneService.js`**: `buildFincaScene` acepta `plantAssetsCount` (saneado, default 0). La escena queda `vacia` SOLO si no hay NI procesos NI plantas-asset (deflección honesta, cero fabricación). `totalCultivos`/`cultivosActivos` honran la fuente mayor (procesos vs. plantas-asset). Nuevo campo `plantAssetsCount` en el shape.
- **`FincaVivaHero.jsx`**: se suscribe a `useAssetStore((s) => s.plants).length` y lo pasa a `buildFincaScene`. Hidratado al boot por `App.jsx` (offline-first, reactivo).
- **`finca-viva-hero.css`**: bloque de contraste — textos del hero sobre el cielo se refuerzan en día (verde más profundo + velo) y se viran a claro en noche/amanecer/atardecer (AA sobre navy). No toca chips (fondo blanco) ni portales (texto blanco sobre gradiente).
- **`finca-viva-resto.css`**: las tarjetas oscuras ("Hoy en finca"/"Clima"/"Análisis", por su clase de gradiente `from-*-950`/`from-slate-900`) suben su texto apagado de slate-400/500 → slate-300/200 (AA), conservando el fondo oscuro.

## De dónde sale el conteo de plantas
`useAssetStore` (Zustand) → estado `plants` (array de `asset--plant`), poblado por `hydrate()` desde `assetCache.getByType('plant')`. Es la **misma** fuente que `FincaCards.jsx` ("Mis plantas") y `AnalisisProactivoIA.jsx` ("llevo seguimiento a N cultivos"). El hero ahora consume ese `plants.length`.

## Tests
- 27 vitest de `fincaSceneService` passing (8 nuevos: plantas-asset sin procesos → poblada; `totalCultivos` honra la fuente mayor; saneo de valores inválidos/negativos).
- `MiFincaVivaHomeCard` (otro caller de `buildFincaScene`) + `fincaSceneProfileSelector` intactos (29 passing).
- `vite build` OK (2491 módulos, `useAssetStore` se bundlea — import del hero resuelve).
- eslint limpio (0 err / 0 warn) en los archivos JS cambiados.
- Sin chromium (alpha OOMea): verificación por grep del cableado asset→escena + vitest + build.

Refs: bug home F2 LIVE en prod; regresión de contraste parcial PR #1859

🤖 Generated with [Claude Code](https://claude.com/claude-code)