### PR TITLE
fix(directorio): listar todas las especies del alias + fondo oscuro legible

### DIFF
--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -86,7 +86,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
   // VISTA FICHA -------------------------------------------------------------
   if (selected) {
     return (
-      <div className="min-h-[100dvh] text-white">
+      <div className="min-h-[100dvh] bg-slate-950 text-white">
         <header className="sticky top-0 z-10 flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2 bg-slate-950/85 backdrop-blur border-b border-slate-800/60">
           <button
             type="button"
@@ -111,7 +111,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
 
   // VISTA BÚSQUEDA ----------------------------------------------------------
   return (
-    <div className="min-h-[100dvh] text-white">
+    <div className="min-h-[100dvh] bg-slate-950 text-white">
       <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
         {onBack ? (
           <button
@@ -194,7 +194,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
                   <button
                     type="button"
                     onClick={() => selectSpecies(r.id)}
-                    className="w-full text-left rounded-xl bg-slate-900/60 border border-slate-800 hover:border-emerald-600/60 active:bg-slate-800/70 p-3 transition-colors flex items-center gap-3"
+                    className="w-full text-left rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-600/60 active:bg-slate-800/70 p-3 transition-colors flex items-center gap-3"
                   >
                     <Leaf size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />
                     <span className="min-w-0">

--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.test.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import DirectorioEspeciesScreen from './DirectorioEspeciesScreen.jsx';
+
+// El servicio de datos se mockea: estos tests verifican SUPERFICIE/CONTRASTE de
+// la pantalla (fondo oscuro opaco en ambas vistas), no la orquestación de datos.
+vi.mock('../../services/directorioEspecies.js', () => ({
+  searchSpecies: vi.fn(),
+  buildSpeciesFicha: vi.fn(),
+}));
+
+import { searchSpecies, buildSpeciesFicha } from '../../services/directorioEspecies.js';
+
+const FICHA = {
+  id: 'solanum_lycopersicum_cerasiforme',
+  comun: 'Tomate cherry silvestre',
+  cientifico: 'Solanum lycopersicum var. cerasiforme',
+  familia: 'Solanaceae',
+  estrato: 'bajo',
+  nombresRegionales: [],
+  imagen: null,
+  pisoTermico: { thermalZones: [], altitud: null, temperatura: null, agua: null },
+  asociaciones: { compatibles: [], antagonistas: [] },
+  biopreparados: [],
+  amenazas: [],
+  fenologia: { valorPedagogico: '' },
+  fuentes: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  searchSpecies.mockResolvedValue([]);
+  buildSpeciesFicha.mockResolvedValue(FICHA);
+});
+
+describe('DirectorioEspeciesScreen — superficie / contraste', () => {
+  it('la vista de búsqueda tiene fondo oscuro opaco (contraste AA en cualquier tema)', () => {
+    const { container } = render(<DirectorioEspeciesScreen />);
+    const root = container.firstElementChild;
+    // Fondo sólido oscuro: garantiza que el texto blanco/emerald-100 sea legible
+    // aunque el tema activo de la app sea claro (crema/durazno).
+    expect(root).toHaveClass('bg-slate-950');
+    expect(root).toHaveClass('text-white');
+  });
+
+  it('la vista de ficha también tiene fondo oscuro opaco', async () => {
+    // Forzamos selección: con un único resultado, Enter abre la ficha.
+    searchSpecies.mockResolvedValue([{ id: FICHA.id, comun: FICHA.comun, cientifico: FICHA.cientifico }]);
+    const { container } = render(<DirectorioEspeciesScreen initialQuery="tomate cherry silvestre" />);
+    const form = container.querySelector('form');
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await waitFor(() => expect(buildSpeciesFicha).toHaveBeenCalled());
+    await waitFor(() => {
+      const root = container.firstElementChild;
+      expect(root).toHaveClass('bg-slate-950');
+      expect(root).toHaveClass('text-white');
+    });
+  });
+
+  it('el header de la búsqueda y el título se montan (no es página en blanco)', () => {
+    render(<DirectorioEspeciesScreen />);
+    expect(screen.getByText('Directorio de especies')).toBeInTheDocument();
+    expect(screen.getByLabelText('Buscar especie por nombre')).toBeInTheDocument();
+  });
+});

--- a/src/services/__tests__/directorioEspecies.test.js
+++ b/src/services/__tests__/directorioEspecies.test.js
@@ -49,7 +49,52 @@ const MAIZ = { id: 'zea_mays', nombre_comun: 'Maíz criollo', nombre_cientifico:
 const CALABAZA = { id: 'cucurbita_maxima', nombre_comun: 'Zapallo', nombre_cientifico: 'Cucurbita maxima Duchesne' };
 const CEBOLLA = { id: 'allium_cepa', nombre_comun: 'Cebolla cabezona', nombre_cientifico: 'Allium cepa L.' };
 
-const CATALOG = [FRIJOL, MAIZ, CALABAZA, CEBOLLA];
+// Familia "tomate": el alias curado `tomate` apunta al cerasiforme (tomate de
+// mesa silvestre). El explorador debe LISTAR todos los tomates del catálogo, con
+// el alias ranqueado primero. Incluimos también el tomate de ÁRBOL (otro
+// género/especie) para verificar que NO se promueve por encima del alias.
+const TOMATE_CERASIFORME = {
+  id: 'solanum_lycopersicum_cerasiforme',
+  nombre_comun: 'Tomate cherry silvestre',
+  nombre_cientifico: 'Solanum lycopersicum var. cerasiforme',
+  familia_botanica: 'Solanaceae',
+};
+const TOMATE_CHONTO = {
+  id: 'solanum_lycopersicum_chonto',
+  nombre_comun: 'Tomate chonto',
+  nombre_cientifico: 'Solanum lycopersicum L.',
+  familia_botanica: 'Solanaceae',
+};
+const TOMATE_SAN_MARZANO = {
+  id: 'solanum_lycopersicum_san_marzano',
+  nombre_comun: 'Tomate San Marzano',
+  nombre_cientifico: 'Solanum lycopersicum L.',
+  familia_botanica: 'Solanaceae',
+};
+const TOMATE_SUNGOLD = {
+  id: 'solanum_lycopersicum_sungold',
+  nombre_comun: 'Tomate cherry amarillo / Sungold',
+  nombre_cientifico: 'Solanum lycopersicum L.',
+  familia_botanica: 'Solanaceae',
+};
+const TOMATE_ARBOL = {
+  id: 'solanum_betaceum',
+  nombre_comun: 'Tomate de árbol / Tamarillo',
+  nombre_cientifico: 'Solanum betaceum Cav.',
+  familia_botanica: 'Solanaceae',
+};
+
+const CATALOG = [
+  FRIJOL,
+  MAIZ,
+  CALABAZA,
+  CEBOLLA,
+  TOMATE_CERASIFORME,
+  TOMATE_CHONTO,
+  TOMATE_SAN_MARZANO,
+  TOMATE_SUNGOLD,
+  TOMATE_ARBOL,
+];
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -73,11 +118,30 @@ describe('searchSpecies', () => {
     expect(res.some((r) => r.id === 'phaseolus_vulgaris')).toBe(true);
   });
 
-  it('resuelve alias curado (frijol → phaseolus_vulgaris) sin ambigüedad', async () => {
+  it('resuelve alias curado (frijol → phaseolus_vulgaris) ranqueado primero', async () => {
     const res = await searchSpecies('frijol');
-    expect(res).toHaveLength(1);
+    // El alias gana el primer lugar; no hay otros "frijol" en el catálogo de
+    // prueba, así que es el único resultado, pero la garantía es el orden.
     expect(res[0].id).toBe('phaseolus_vulgaris');
     expect(res[0].match).toBe('alias');
+  });
+
+  it('alias NO corta-circuita: "tomate" lista TODOS los tomates con el alias primero', async () => {
+    const res = await searchSpecies('tomate');
+    // (a) explorador: debe traer varios tomates, no solo el de mesa.
+    expect(res.length).toBeGreaterThanOrEqual(4);
+    // (b) el alias curado (tomate de mesa) queda en el primer lugar (tier tope).
+    expect(res[0].id).toBe('solanum_lycopersicum_cerasiforme');
+    expect(res[0].match).toBe('alias');
+    // (c) incluye al menos otro tomate distinto del alias (San Marzano, chonto…).
+    const ids = res.map((r) => r.id);
+    expect(ids).toContain('solanum_lycopersicum_san_marzano');
+    expect(ids).toContain('solanum_lycopersicum_chonto');
+    // El alias aparece UNA sola vez (no duplicado por el loop de palabra).
+    expect(ids.filter((id) => id === 'solanum_lycopersicum_cerasiforme')).toHaveLength(1);
+    // El tomate de árbol existe en la lista pero NO por encima del alias de mesa.
+    expect(ids).toContain('solanum_betaceum');
+    expect(ids.indexOf('solanum_betaceum')).toBeGreaterThan(0);
   });
 
   it('lista varios candidatos por palabra completa', async () => {

--- a/src/services/directorioEspecies.js
+++ b/src/services/directorioEspecies.js
@@ -147,16 +147,28 @@ export async function searchSpecies(query, opts = {}) {
   }
   if (!Array.isArray(list) || list.length === 0) return [];
 
-  // 0) Alias curado → si el destino existe, gana solo (sin ambigüedad).
-  const aliasTarget = CURATED_ALIASES[q];
-  if (aliasTarget) {
-    const hit = list.find((s) => s?.id === aliasTarget || s?.slug === aliasTarget);
-    if (hit) return [{ ...labelWithFamilia(hit), match: 'alias' }];
-  }
-
+  const aliasFirst = [];
   const exact = [];
   const word = [];
   const seen = new Set();
+
+  // 0) Alias curado → si el destino existe, lo PROMOVEMOS al primer lugar
+  // (tier tope) pero NO corta-circuita: el explorador debe seguir listando los
+  // demás candidatos (todos los tomates, no solo el de mesa). El alias resuelve
+  // el "default esperado" (tomate → cerasiforme, no tomate de árbol); el resto
+  // se recolecta debajo por match exacto/palabra. Lo metemos en `seen` para no
+  // duplicarlo cuando el loop lo vuelva a encontrar por nombre.
+  const aliasTarget = CURATED_ALIASES[q];
+  if (aliasTarget) {
+    const hit = list.find((s) => s?.id === aliasTarget || s?.slug === aliasTarget);
+    if (hit) {
+      const aliasId = hit.id || hit.slug;
+      if (aliasId) {
+        aliasFirst.push({ ...labelWithFamilia(hit), match: 'alias' });
+        seen.add(aliasId);
+      }
+    }
+  }
 
   for (const sp of list) {
     if (!sp) continue;
@@ -193,7 +205,7 @@ export async function searchSpecies(query, opts = {}) {
   }
 
   word.sort((a, b) => a._w - b._w);
-  const ranked = [...exact, ...word.map(({ _w, ...rest }) => rest)];
+  const ranked = [...aliasFirst, ...exact, ...word.map(({ _w, ...rest }) => rest)];
   return ranked.slice(0, limit);
 }
 


### PR DESCRIPTION
## Bug
Dos defectos en el **Directorio de Especies** (explorador del catálogo):

1. **Búsqueda "tomate" devolvía 1 solo resultado.** El branch de alias curado corta-circuitaba con `return [único]`, ocultando todos los demás tomates del catálogo (chonto, San Marzano, cherry, de árbol).
2. **Nombre del resultado ilegible.** Los roots de ambas vistas (búsqueda y ficha) no tenían fondo opaco; el diseño dark-on-dark (`text-white`, título `text-emerald-100`, slate) se transparentaba sobre el tema CLARO de la app → "Tomate cherry silvestre" en cyan pálido casi invisible.

## Causa raíz
1. `searchSpecies` en `src/services/directorioEspecies.js`: el alias existe para que el AGENTE resuelva "tomate" → un tomate de mesa (no de árbol), pero el DIRECTORIO es un explorador y debe LISTAR todos. El `return` temprano lo impedía.
2. `DirectorioEspeciesScreen.jsx`: la pantalla está diseñada dark-on-dark pero sin superficie oscura propia, así que dependía de la atmósfera del tema activo. En tema claro (crema/durazno) el contraste se rompe.

## Cambios
- `src/services/directorioEspecies.js` — el alias ya NO corta-circuita: se promueve al **primer lugar** (`match:'alias'`, tier tope) y se mete en `seen`; el loop CONTINÚA recolectando los demás matches (exact + word). Orden final: **alias → exact → word** (word ordenado por especificidad). Sin duplicar el alias.
- `src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx` — los dos roots (ficha + búsqueda) pasan de `min-h-[100dvh] text-white` a `min-h-[100dvh] bg-slate-950 text-white`. Las tarjetas de resultado pasan de `bg-slate-900/60` (semi-transparente) a `bg-slate-900` (opaca). Garantiza contraste AA en **cualquier tema activo** (emerald-100 `#d1fae5` sobre slate-950 `#020617` = ratio muy alto).

## Tests
- `src/services/__tests__/directorioEspecies.test.js`: nuevo caso `searchSpecies('tomate')` que afirma (a) ≥4 resultados, (b) el primero es `solanum_lycopersicum_cerasiforme` con `match:'alias'`, (c) incluye San Marzano y chonto, (d) el alias aparece una sola vez, (e) el tomate de árbol existe pero NO por encima del alias. Fixture ampliado con 5 tomates reales.
- `src/components/DirectorioEspecies/DirectorioEspeciesScreen.test.jsx` (nuevo): afirma que ambos roots (búsqueda y ficha) llevan `bg-slate-950` + `text-white`, y que la pantalla monta (no es página en blanco).
- vitest verde en todos los archivos del directorio (29/29 service+componentes). `vite build` verde. eslint `--max-warnings=0` limpio en los 4 archivos.

Evidencia del fix 1 (probe): `searchSpecies('tomate')` ahora devuelve 5 tomates → `cerasiforme(alias)`, `chonto(word)`, `betaceum(word)`, `san_marzano(word)`, `sungold(word)`.

Refs: bug "tomate=1 resultado" + "Tomate cherry silvestre ilegible"

🤖 Generated with [Claude Code](https://claude.com/claude-code)