### PR TITLE
fix(login): el prompt de instalación PWA ya no se encima sobre el formulario de login

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1385,14 +1385,29 @@ export default function App() {
     }
   };
 
+  // Vistas pre-autenticación: el formulario manda y NO debe quedar tapado ni
+  // empujado por overlays flotantes. Mismo conjunto que ya gatea showBg,
+  // DataLossBanner, CriticalAlertBanner, SyncProgressIndicator, etc.
+  const isPreAuthView =
+    currentView === 'loading' ||
+    currentView === 'login' ||
+    currentView === 'oauth-callback';
+
   return (
     <>
       {/* Transición colibrí home→conversación (~2s). Encima de todo (z alto);
           la conversación monta detrás y queda limpia al terminar. */}
       <ColibriTransition active={colibriTransition} onDone={() => setColibriTransition(false)} />
       <NetworkStatusBar />
-      <IosInstallBanner />
-      <AndroidInstallBanner />
+      {/* Banners de instalación PWA: NO en las vistas pre-auth (login /
+          loading / oauth-callback). En el login son un overlay `fixed`
+          z-50 que se encimaba sobre el formulario —en desktop tapaba e
+          interceptaba el clic del campo "Usuario"; en móvil empujaba
+          Usuario/Contraseña/Ingresar bajo el fold—. La instalación se
+          ofrece una vez dentro de la app, igual que DataLossBanner y
+          los demás flotantes (mismo guard de vista). */}
+      {!isPreAuthView && <IosInstallBanner />}
+      {!isPreAuthView && <AndroidInstallBanner />}
       <UpdateAvailableBanner />
       <Confetti />
       <GpsFincaBanner />

--- a/src/__tests__/App.install-banner-login-gate.test.jsx
+++ b/src/__tests__/App.install-banner-login-gate.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Test de REGRESIÓN VISUAL (bug prod 2026-06-25): el prompt de instalación PWA
+// (IosInstallBanner / AndroidInstallBanner) es un overlay `fixed bottom-24
+// left-1/2 z-50` y se renderizaba en TODAS las vistas, incluida la de login.
+// Sobre el formulario de login (campos Usuario/Contraseña/Ingresar) se encimaba:
+// en desktop tapaba e interceptaba el clic del campo "Usuario"; en móvil empujaba
+// el login bajo el fold. El fix gatea ambos banners con `!isPreAuthView`, igual
+// que los demás flotantes (DataLossBanner, CriticalAlertBanner, etc.).
+//
+// Acá montamos App SIN sesión (→ navega a 'login') y verificamos que NINGÚN
+// banner de instalación se monta. Stubeamos los banners para que SIEMPRE
+// rendericen un marcador (ignorando su lógica interna de beforeinstallprompt):
+// así el test mide el GUARD DE VISTA de App, no el estado del evento PWA.
+// Los efectos pesados de boot (catálogo, RAG, alertas, warm-up) se mockean.
+
+vi.mock('../services/authService', () => ({
+  isAuthenticated: () => Promise.resolve(false), // sin sesión → vista 'login'
+  logoutUser: () => Promise.resolve(),
+}));
+vi.mock('../db/catalogDB', () => ({ initCatalog: () => Promise.resolve() }));
+vi.mock('../services/ragRetriever', () => ({
+  prewarmCorpus: () => {},
+  retrieve: () => Promise.resolve([]),
+}));
+vi.mock('../services/alertEngine', () => ({ alertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/cropAlertEngine', () => ({ cropAlertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/apiService', () => ({
+  fetchFromFarmOS: () => Promise.resolve(null),
+  fetchWithAuthRetry: () => Promise.resolve({ ok: true }),
+}));
+vi.mock('../db/farmProcessCache', () => ({ listFarmProcesses: () => Promise.resolve([]) }));
+
+// Banners de instalación: stubs que SIEMPRE rinden un marcador. Si App los
+// gatea bien en login, estos marcadores NO deben aparecer en el DOM.
+vi.mock('../components/IosInstallBanner', () => ({
+  default: () => <div data-testid="ios-install-banner">ios install stub</div>,
+}));
+vi.mock('../components/AndroidInstallBanner', () => ({
+  default: () => <div data-testid="android-install-banner">android install stub</div>,
+}));
+
+// LoginScreen es lazy + pesado (OAuth/PKCE, stores). Stub liviano que delata la
+// vista de login para anclar el waitFor.
+vi.mock('../components/LoginScreen', () => ({
+  default: () => <div data-testid="login-screen">login stub</div>,
+}));
+
+import App from '../App';
+
+describe('App — banners de instalación PWA en la vista de login', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+    localStorage.clear();
+  });
+  afterEach(() => {
+    window.location.hash = '';
+    vi.clearAllMocks();
+  });
+
+  it('sin sesión, monta LoginScreen y NO monta ningún banner de instalación', async () => {
+    render(<App />);
+    // La vista de login montó.
+    await waitFor(
+      () => expect(screen.getByTestId('login-screen')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+    // El bug: estos overlays `fixed z-50` se encimaban sobre el formulario.
+    expect(screen.queryByTestId('ios-install-banner')).toBeNull();
+    expect(screen.queryByTestId('android-install-banner')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Bug
En `chagra.app` (verificado con navegador real) la tarjeta "Instala Chagra" (prompt de instalación PWA) se encima sobre el formulario de login. En desktop tapa e intercepta el clic del campo "Usuario"; en móvil empuja Usuario/Contraseña/Ingresar bajo el fold. El usuario lo reportó como "Chagra se ve roto".

## Causa raíz
`IosInstallBanner` y `AndroidInstallBanner` son overlays `fixed bottom-24 left-1/2 -translate-x-1/2 z-50` y se renderizaban en el árbol global de `App.jsx` (líneas ~1394-1395), **sin gatear por vista**. En la vista de login —donde el formulario es un layout centrado sin scroll— el card flotante (desktop 1366px: top≈717, bottom≈804) solapaba el input "Usuario" (top≈735, bottom≈809); `document.elementFromPoint` en el centro del campo devolvía `P.text-slate-400` (el párrafo "Tenla en tu pantalla de inicio…" del banner Android), no el input. En móvil 390x844 el banner empujaba el login bajo el fold.

Todos los demás flotantes del mismo bloque (`DataLossBanner`, `CriticalAlertBanner`, `SyncProgressIndicator`, el fondo `showBg`) ya estaban gateados con `currentView !== 'login' && !== 'loading' && !== 'oauth-callback'`. Los dos banners de instalación eran el único descuido.

## Cambios
- `src/App.jsx`: nuevo `const isPreAuthView` (login / loading / oauth-callback) — mismo conjunto que ya usa `showBg` y los otros banners. `IosInstallBanner` y `AndroidInstallBanner` ahora se montan solo cuando `!isPreAuthView`. La instalación se sigue ofreciendo una vez dentro de la app, donde no hay formulario que tapar. Los componentes de banner quedan intactos.
- `src/__tests__/App.install-banner-login-gate.test.jsx`: test de regresión — monta `App` sin sesión (→ navega a `login`), stubea los banners para que **siempre** renderizarían un marcador, y afirma que ninguno aparece en el DOM. Así el test mide el guard de vista de App, no el estado interno de `beforeinstallprompt`.

## Verificación (sin chromium — OOM en la caja; razonado por orden DOM / z-index / geometría)
- El fix es de **render condicional**: en login el subárbol de los banners no se monta → cero nodos `fixed z-50` sobre el formulario → no hay solape posible ni interceptación de `pointer-events`, y nada empuja el login bajo el fold. Geometría del bug eliminada en la raíz.
- En dashboard y demás vistas autenticadas el banner se comporta igual que antes (`!isPreAuthView` = true).
- `vitest`: 16/16 en los tests tocados (gate nuevo + AndroidInstallBanner + IosInstallBanner) y 23/23 en `src/__tests__/` (suite de rutas de App). El test de `AndroidInstallBanner` sin cambios sigue verde (componente intacto).
- `vite build`: verde (solo warnings preexistentes de `INEFFECTIVE_DYNAMIC_IMPORT`, ajenos a este cambio).
- `eslint --max-warnings=0` sobre los archivos tocados: limpio (0 no-undef / no-unused).
- lefthook pre-commit + commit-msg: todos los hooks en verde.

Refs: bug prod chagra.app 2026-06-25 (probe Playwright geométrico)