### PR TITLE
fix(home-f2): el portal Gestionar lleva a la gestión de la finca, no al juego

### DIFF
--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -447,6 +447,21 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
         });
     }, []);
 
+    // Portal "Gestionar" del hero F2 → la GESTIÓN de la finca (registrar y cuidar
+    // siembras, zonas y animales) vive como la sección #finca-gestion en ESTA
+    // misma página, bajo el hero. La revelamos con un scroll suave (no es otra
+    // vista; antes el portal navegaba por error al juego). Movemos también el
+    // foco al rótulo de la sección para teclado y lector de pantalla.
+    const revelarGestion = useCallback(() => {
+        if (typeof document === 'undefined') return;
+        const seccion = document.getElementById('finca-gestion');
+        if (!seccion) return;
+        if (seccion.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        if (seccion.focus) {
+            try { seccion.focus({ preventScroll: true }); } catch (_) { /* preventScroll no soportado */ }
+        }
+    }, []);
+
     return (
         <div
             className="relative flex flex-col w-full h-full overflow-y-auto pb-6"
@@ -469,6 +484,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                 <FincaVivaHero
                     onNavigate={onNavigate}
                     onOpenAgent={() => onNavigate('agente')}
+                    onGestionar={revelarGestion}
                     titulo={esExtensionista ? 'Red de fincas que acompaño' : 'Mi finca viva'}
                 >
                     {esExtensionista ? (
@@ -690,8 +706,18 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
 
             {/* 3) GESTIÓN — "Mi finca": registros y acciones de manejo (semilleros,
                 cosechar, insumos, mantenimiento). De-enfatizado respecto a lo
-                fuerte; las rutas ya existen en App.jsx. */}
-            <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
+                fuerte; las rutas ya existen en App.jsx.
+
+                ANCLA #finca-gestion: el portal "Gestionar" del hero F2 hace scroll
+                hasta aquí (revelarGestion). `tabIndex=-1` permite mover el foco
+                programáticamente (teclado/lector) sin volverlo tabulable; el
+                scroll-margin-top deja aire bajo el topbar flotante. */}
+            <div
+                id="finca-gestion"
+                tabIndex={-1}
+                style={{ scrollMarginTop: '88px', outline: 'none' }}
+                className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}
+            >
                 <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
                     <span
                         aria-hidden="true"

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -60,13 +60,32 @@ import './finca-viva-hero.css';
  * @param {Object} props
  * @param {Function} [props.onNavigate]   navegación de la app.
  * @param {Function} [props.onOpenAgent]  abre el agente (globo + composer + portal).
+ * @param {Function} [props.onGestionar]  abre la GESTIÓN de la finca (registros y
+ *   acciones). En el home F2 la gestión vive como una sección (GESTION_TILES) en
+ *   la MISMA página, bajo el hero, así que el portal "Gestionar" la REVELA con un
+ *   scroll a su ancla — NO navega a otra vista (mucho menos al juego). Si no se
+ *   pasa, cae a un scroll directo al ancla #finca-gestion (mismo destino).
  * @param {React.ReactNode} [props.children]  escena alterna (red institucional).
  * @param {string} [props.titulo]  título accesible (default "Mi finca viva").
  */
-export default function FincaVivaHero({ onNavigate, onOpenAgent, children, titulo }) {
+export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, children, titulo }) {
   const abrirAgente = () => {
     if (onOpenAgent) onOpenAgent();
     else onNavigate?.('agente');
+  };
+
+  // El portal "Gestionar" lleva a la GESTIÓN de la finca (siembras, zonas,
+  // animales), que en el home F2 es la sección #finca-gestion de ESTA misma
+  // página (bajo el hero). Lo correcto es revelarla con un scroll suave, no
+  // navegar a otra vista. `onGestionar` (lo provee DashboardLive) hace ese
+  // scroll; si faltara, caemos a un scroll directo al ancla por id para que
+  // "Gestionar" NUNCA termine en la pantalla equivocada (el juego, el bug viejo).
+  const irAGestion = () => {
+    if (onGestionar) { onGestionar(); return; }
+    if (typeof document !== 'undefined') {
+      const seccion = document.getElementById('finca-gestion');
+      if (seccion?.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
   };
 
   // ── Datos reales de la finca (offline-first) ─────────────────────────────
@@ -196,7 +215,13 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, children, titul
           )}
 
           <div className="fvh-top-pills">
-            <button type="button" className="fvh-pill" title="Ayuda" aria-label="Ayuda">
+            <button
+              type="button"
+              className="fvh-pill"
+              title="Ayuda"
+              aria-label="Ayuda"
+              onClick={() => onNavigate?.('ayuda')}
+            >
               <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
                 <circle cx="12" cy="12" r="9" stroke="#3a4a3a" strokeWidth="2" />
                 <path d="M9.2 9.2a2.8 2.8 0 1 1 4 2.5c-.9.5-1.2 1-1.2 1.9" stroke="#3a4a3a" strokeWidth="2" strokeLinecap="round" fill="none" />
@@ -328,7 +353,7 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, children, titul
         {/* ── 4 PORTALES = LUGARES DE LA FINCA ───────────────────────────────── */}
         <div className="fvh-portales-tit">Lugares de su finca <span /></div>
         <nav className="fvh-portales" aria-label="Lugares de su finca" data-testid="finca-viva-portales">
-          {buildPortales({ onNavigate, abrirAgente, scene, poblada, escala }).map((p) => (
+          {buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, escala }).map((p) => (
             <button
               key={p.id}
               type="button"
@@ -662,7 +687,7 @@ const COLIBRI = {
  * Los 4 portales/lugares del home F2. El badge de "Gestionar" refleja el DATO
  * REAL de la finca (0 siembras → "EMPIECE AQUÍ"; con siembras → resumen real).
  */
-function buildPortales({ onNavigate, abrirAgente, scene, poblada, escala }) {
+function buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, escala }) {
   const total = Number(scene?.totalCultivos) || 0;
   const animales = Array.isArray(scene?.animales) ? scene.animales.length : 0;
   let badgeGestionar;
@@ -689,7 +714,10 @@ function buildPortales({ onNavigate, abrirAgente, scene, poblada, escala }) {
       delay: '.1s',
       badge: badgeGestionar,
       placeSvg: <PlaceGestionar />,
-      onClick: () => onNavigate?.('juego'),
+      // GESTIÓN, no el juego: revela la sección de registros/acciones de la
+      // finca (siembras, zonas, animales) en esta misma página. El bug viejo
+      // mandaba a onNavigate('juego') — el mismo destino que el portal "Jugar".
+      onClick: () => irAGestion(),
     },
     {
       id: 'aprender',

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -23,7 +23,23 @@ vi.mock('../../../config/extensionistaAccess', () => ({
 }));
 
 vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
-vi.mock('../FincaVivaHero', () => ({ default: ({ children }) => <div data-testid="finca-viva-hero">{children}</div> }));
+// Capturamos las props del hero para verificar el cableado del portal "Gestionar"
+// (onGestionar) sin montar todo el hero. El botón expuesto invoca onGestionar tal
+// como lo haría el portal real.
+let lastHeroProps = null;
+vi.mock('../FincaVivaHero', () => ({
+  default: (props) => {
+    lastHeroProps = props;
+    return (
+      <div data-testid="finca-viva-hero">
+        <button type="button" data-testid="hero-gestionar" onClick={() => props.onGestionar?.()}>
+          Gestionar
+        </button>
+        {props.children}
+      </div>
+    );
+  },
+}));
 vi.mock('../FincaRedInstitucional', () => ({ default: () => <div /> }));
 vi.mock('../../OnboardingHero', () => ({ default: () => <div /> }));
 vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
@@ -131,6 +147,31 @@ describe('DashboardLive — redistribución del resto de su finca', () => {
     expect(onNavigate).toHaveBeenCalledWith('casos', undefined);
     fireEvent.click(screen.getByRole('button', { name: /^Biopreparados/ }));
     expect(onNavigate).toHaveBeenCalledWith('biopreparados', { back: 'dashboard' });
+  });
+
+  test('la sección de gestión expone el ancla #finca-gestion (destino del portal Gestionar)', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('gestion-tiles');
+    const ancla = document.getElementById('finca-gestion');
+    // El ancla existe y CONTIENE los tiles de gestión (es la sección, no otra cosa).
+    expect(ancla).toBeInTheDocument();
+    expect(ancla).toContainElement(block);
+  });
+
+  test('el hero recibe onGestionar y, al invocarlo, hace scroll al ancla de gestión (no navega al juego)', async () => {
+    const onNavigate = vi.fn();
+    render(<DashboardLive onNavigate={onNavigate} />);
+    await screen.findByTestId('gestion-tiles');
+
+    const ancla = document.getElementById('finca-gestion');
+    ancla.scrollIntoView = vi.fn();
+    ancla.focus = vi.fn();
+
+    expect(typeof lastHeroProps.onGestionar).toBe('function');
+    fireEvent.click(screen.getByTestId('hero-gestionar'));
+
+    expect(ancla.scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalledWith('juego');
   });
 
   test('layout legacy (F2 OFF) SÍ muestra el hub Aprender como tile', async () => {

--- a/src/components/dashboard/__tests__/FincaVivaHero.portales.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaHero.portales.test.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Home F2 "Finca Viva" — los 4 portales del hero deben llevar a SU destino:
+//   · Gestionar → la GESTIÓN de la finca (registros/acciones), NO el juego.
+//                 (bug: iba a onNavigate('juego'), igual que el portal "Jugar".)
+//   · Aprender  → la vista 'aprende'.
+//   · Jugar     → la vista 'juego' (ese SÍ es el juego).
+//   · Agente    → abre el agente (onOpenAgent).
+// Y el resto del shell F2 (chip de ubicación, pastilla de ayuda, pastilla de
+// perfil) debe navegar a su ruta, sin botones muertos.
+
+// La escena lee la finca de farmProcessCache y el store; mockeamos a "vacía"
+// para un render determinista (no necesitamos datos reales para probar el ruteo).
+vi.mock('../../../db/farmProcessCache', () => ({ listFarmProcesses: vi.fn(async () => []) }));
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [], lands: [], materials: [], isHydrated: true }),
+}));
+vi.mock('../../../services/userProfileService', () => ({ getProfile: () => ({ rol: 'campesino' }) }));
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => false,
+}));
+
+import FincaVivaHero from '../FincaVivaHero';
+
+const portalLabel = (el) => el.getAttribute('aria-label')?.split(':')[0];
+
+afterEach(() => cleanup());
+beforeEach(() => vi.clearAllMocks());
+
+describe('FincaVivaHero — los 4 portales llevan a su destino correcto', () => {
+  function renderHero(extra = {}) {
+    const onNavigate = vi.fn();
+    const onOpenAgent = vi.fn();
+    const onGestionar = vi.fn();
+    render(
+      <FincaVivaHero
+        onNavigate={onNavigate}
+        onOpenAgent={onOpenAgent}
+        onGestionar={onGestionar}
+        {...extra}
+      />,
+    );
+    return { onNavigate, onOpenAgent, onGestionar };
+  }
+
+  const getPortal = (nombre) => {
+    const nav = screen.getByTestId('finca-viva-portales');
+    return within(nav)
+      .getAllByRole('button')
+      .find((b) => portalLabel(b) === nombre);
+  };
+
+  test('el portal "Gestionar" NO navega al juego', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPortal('Gestionar'));
+    expect(onNavigate).not.toHaveBeenCalledWith('juego');
+  });
+
+  test('el portal "Gestionar" abre la GESTIÓN de la finca (onGestionar), no otra vista', () => {
+    const { onNavigate, onOpenAgent, onGestionar } = renderHero();
+    fireEvent.click(getPortal('Gestionar'));
+    expect(onGestionar).toHaveBeenCalledTimes(1);
+    // No se cuela a ninguna otra ruta ni al agente.
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(onOpenAgent).not.toHaveBeenCalled();
+  });
+
+  test('sin onGestionar, "Gestionar" hace scroll al ancla #finca-gestion (no al juego)', () => {
+    const onNavigate = vi.fn();
+    const seccion = document.createElement('div');
+    seccion.id = 'finca-gestion';
+    seccion.scrollIntoView = vi.fn();
+    document.body.appendChild(seccion);
+
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
+    fireEvent.click(getPortal('Gestionar'));
+
+    expect(seccion.scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalledWith('juego');
+    document.body.removeChild(seccion);
+  });
+
+  test('el portal "Aprender" navega a la vista aprende', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPortal('Aprender'));
+    expect(onNavigate).toHaveBeenCalledWith('aprende');
+  });
+
+  test('el portal "Jugar" SÍ navega al juego', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPortal('Jugar'));
+    expect(onNavigate).toHaveBeenCalledWith('juego');
+  });
+
+  test('el portal "Agente" abre el agente (onOpenAgent), no navega a una vista', () => {
+    const { onNavigate, onOpenAgent } = renderHero();
+    fireEvent.click(getPortal('Agente'));
+    expect(onOpenAgent).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  test('cada portal mapea a un destino distinto (Gestionar ≠ Jugar)', () => {
+    const { onNavigate, onOpenAgent, onGestionar } = renderHero();
+    fireEvent.click(getPortal('Gestionar'));
+    fireEvent.click(getPortal('Jugar'));
+    // Gestionar fue a la gestión; Jugar al juego. No coinciden.
+    expect(onGestionar).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith('juego');
+    expect(onNavigate).not.toHaveBeenCalledWith('gestionar');
+    expect(onOpenAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe('FincaVivaHero — barra superior sin botones muertos', () => {
+  test('la pastilla de Ayuda navega a la vista ayuda (no era un botón muerto)', () => {
+    const onNavigate = vi.fn();
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Ayuda' }));
+    expect(onNavigate).toHaveBeenCalledWith('ayuda');
+  });
+
+  test('la pastilla de Perfil navega a la vista perfil', () => {
+    const onNavigate = vi.fn();
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Perfil' }));
+    expect(onNavigate).toHaveBeenCalledWith('perfil');
+  });
+});


### PR DESCRIPTION
## Bug
En el home F2 "Finca Viva" (gateado por `VITE_FINCA_VIVA_HOME_PERFIL`: ON en dev, OFF en prod), el portal **Gestionar** (🌱 "Registre y cuide sus siembras, zonas y animales") abría el **juego** — el mismo destino que el portal "Jugar". El operador lo reportó: "entro a Gestionar y va a una mierda que no es".

## Causa raíz
En `FincaVivaHero.jsx`, `buildPortales()` definía el portal Gestionar con `onClick: () => onNavigate?.('juego')`, idéntico al portal Jugar. No existe ruta `gestionar`/`registro` en `onNavigate`; la gestión real vive como la sección `GESTION_TILES` (semilleros, cosechar, insumos, mantenimiento) **dentro del mismo home**, bajo el hero. El destino correcto era esa sección de la misma página, no otra vista.

## Cambios
- `DashboardLive.jsx`: la sección de gestión recibe el ancla `id="finca-gestion"` (con `tabIndex=-1` + `scroll-margin-top` bajo el topbar). Nuevo callback `revelarGestion` que hace `scrollIntoView({behavior:'smooth'})` + mueve el foco al rótulo (teclado/lector). Se pasa al hero como `onGestionar`.
- `FincaVivaHero.jsx`: el portal **Gestionar** ahora invoca `irAGestion()` → `onGestionar` (scroll a la sección). Si la prop faltara, cae a un scroll directo al ancla `#finca-gestion` por id — **nunca** al juego.
- `FincaVivaHero.jsx`: la pastilla **Ayuda** del topbar era un **botón muerto** (sin `onClick`) pese a existir la ruta `'ayuda'`; ahora navega a esa vista.
- Tests nuevos/actualizados (ver abajo).

## Otros flujos del F2 auditados
- **Aprender** → `onNavigate('aprende')` — OK.
- **Jugar** → `onNavigate('juego')` — OK (ese SÍ es el juego).
- **Agente** → `onOpenAgent()` — OK.
- Chip de ubicación (2 variantes) → `'perfil'` — OK. Pastilla Perfil → `'perfil'` — OK.
- Composer + globo del colibrí → abren el agente — OK.
- **Ayuda** → era botón muerto, **arreglado** en este PR.
- No quedan otros botones sin handler en el hero.

## Tests
- `FincaVivaHero.portales.test.jsx` (nuevo, 9 casos): Gestionar NO llama `onNavigate('juego')`; Gestionar invoca `onGestionar`; fallback hace scroll a `#finca-gestion`; los 4 portales mapean a su destino; Gestionar ≠ Jugar; pastillas Ayuda/Perfil navegan.
- `DashboardLive.redistribucion.test.jsx`: 2 casos nuevos — existe el ancla `#finca-gestion` y contiene los gestion-tiles; el hero recibe `onGestionar` y al invocarlo hace scroll al ancla sin navegar al juego.
- `npx vitest run src/components/dashboard/__tests__/` → **122 passing**. `vite build` verde. eslint=0 por archivo.

## Seguridad para prod
**El cambio queda DARK en prod**: el home F2 está detrás de `VITE_FINCA_VIVA_HOME_PERFIL` (OFF en prod). Solo activo en dev. No afecta producción. Seguro de mergear con CI requerido verde.