### PR TITLE
fix(juego): rutear y exponer MundoSubsuelo (huérfano del ux-audit P1-1)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,6 +117,7 @@ const MiFincaVivaScreen = lazy(() => import('./components/juego/MiFincaVivaScree
 const DefensoresFincaScreen = lazy(() => import('./components/juego/DefensoresFincaScreen'));
 const MilpaSimulator = lazy(() => import('./components/juego/MilpaSimulator'));
 const DoomFincaScreen = lazy(() => import('./components/juego/DoomFincaScreen'));
+const MundoSubsuelo = lazy(() => import('./components/juego/MundoSubsuelo'));
 // Modo extensionista (panel supervisor multi-finca, ADR-048 MVP). Gateado por
 // feature flag VITE_FEATURE_EXTENSIONISTA + rol (ver config/extensionistaAccess).
 const ExtensionistaScreen = lazy(() => import('./components/ExtensionistaScreen'));
@@ -175,6 +176,8 @@ const HASH_VIEW_ROUTES = {
   'animales-abejas': 'animales_abejas',
   'animales-vacas': 'animales_vacas',
   'doom-finca': 'doom_finca',
+  subsuelo: 'subsuelo',
+  'mundo-subsuelo': 'subsuelo',
   toxicologia: 'toxicologia',
   suelo: 'suelo',
   aprende: 'aprende',
@@ -192,7 +195,7 @@ const MODULE_VIEWS = new Set([
   'activos', 'mapa', 'javier', 'bodega', 'task_log', 'historial',
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
-  'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
+  'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
@@ -802,6 +805,20 @@ export default function App() {
                 onBack={() => navigate('juego')}
                 onHome={() => navigate('dashboard')}
               />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'subsuelo':
+        // Sub-mundo del juego (huérfano del ux-audit P1-1): la entrada vive en
+        // MiFincaVivaScreen (irAccion('subsuelo')) pero faltaba el case → caía en
+        // "Vista no disponible". MundoSubsuelo no acepta props de navegación; lo
+        // envolvemos en ScreenShell (como 'biopreparados') para dar Volver/Inicio.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mundo Subsuelo">
+              <ScreenShell title="Mundo Subsuelo" onBack={() => navigate('juego')} onHome={() => navigate('dashboard')}>
+                <MundoSubsuelo />
+              </ScreenShell>
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/__tests__/App.subsuelo-route.test.jsx
+++ b/src/__tests__/App.subsuelo-route.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Test de RUTA: verifica que App rutea 'subsuelo' → MundoSubsuelo (ux-audit
+// P1-1). La entrada de MiFincaVivaScreen llama onNavigate('subsuelo') y un
+// chagraNavigate{subsuelo} también lo dispara; sin el case en el switch de App
+// esa navegación caía en "Vista no disponible" (huérfano). Acá montamos App con
+// #subsuelo + sesión autenticada y comprobamos que la pantalla monta (no el
+// fallback de vista no disponible).
+//
+// Los efectos pesados de boot (auth, catálogo SQLite WASM, motores de alerta,
+// RAG, warm-up de Ollama) se mockean para que App arranque limpio en jsdom sin
+// tocar red/IDB. No probamos esos sistemas acá; solo el wiring de la ruta.
+
+vi.mock('../services/authService', () => ({
+  isAuthenticated: () => Promise.resolve(true),
+  logoutUser: () => Promise.resolve(),
+}));
+vi.mock('../db/catalogDB', () => ({ initCatalog: () => Promise.resolve() }));
+vi.mock('../services/ragRetriever', () => ({
+  prewarmCorpus: () => {},
+  retrieve: () => Promise.resolve([]),
+}));
+vi.mock('../services/alertEngine', () => ({ alertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/cropAlertEngine', () => ({ cropAlertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/apiService', () => ({
+  fetchFromFarmOS: () => Promise.resolve(null),
+  fetchWithAuthRetry: () => Promise.resolve({ ok: true }),
+}));
+
+// La pantalla destino: stub liviano que delata que se montó. Probamos el WIRING
+// de la ruta, no el render interno del juego (ya cubierto en su propio test).
+vi.mock('../components/juego/MundoSubsuelo', () => ({
+  default: () => <div data-testid="mundo-subsuelo">subsuelo stub</div>,
+}));
+
+// Procesos vacíos (sin IDB).
+vi.mock('../db/farmProcessCache', () => ({ listFarmProcesses: () => Promise.resolve([]) }));
+
+import App from '../App';
+
+describe('App — ruta "subsuelo"', () => {
+  beforeEach(() => {
+    window.location.hash = '#subsuelo';
+    localStorage.clear();
+  });
+  afterEach(() => {
+    window.location.hash = '';
+    vi.clearAllMocks();
+  });
+
+  it('con sesión autenticada y #subsuelo monta MundoSubsuelo (no "Vista no disponible")', async () => {
+    render(<App />);
+    await waitFor(
+      () => expect(screen.getByTestId('mundo-subsuelo')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+    expect(screen.queryByText('Vista no disponible')).toBeNull();
+  });
+});

--- a/src/components/juego/MiFincaVivaScreen.jsx
+++ b/src/components/juego/MiFincaVivaScreen.jsx
@@ -280,6 +280,26 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           <Crosshair size={22} className="text-orange-200 shrink-0" aria-hidden="true" />
         </button>
 
+        {/* Mundo Subsuelo: cartas de decisión sobre la vida del suelo (compost,
+            micorrizas, lombrices vs labranza/químico). Rescatado del ux-audit
+            P1-1: el componente existía pero no tenía entrada ni ruta. */}
+        <button
+          type="button"
+          data-testid="entrada-subsuelo"
+          onClick={() => irAccion('subsuelo')}
+          className="w-full text-left rounded-2xl p-4 bg-gradient-to-br from-cyan-600/40 to-amber-800/40 border-2 border-cyan-400/40 hover:border-cyan-300/60 active:scale-[0.99] transition flex items-center gap-3"
+        >
+          <span className="text-4xl shrink-0" aria-hidden="true">🪱</span>
+          <span className="flex-1 min-w-0">
+            <span className="block text-base font-black text-white">Mundo Subsuelo</span>
+            <span className="block text-sm text-cyan-100/90 leading-snug">
+              Baja bajo tus botas: alimenta la tierra con compost, conecta raíces
+              con hongos y despierta a las lombrices. Mira cómo revive el suelo.
+            </span>
+          </span>
+          <Sparkles size={22} className="text-cyan-200 shrink-0" aria-hidden="true" />
+        </button>
+
         {/* Barra de progreso del mundo (alegre, pero honesta: % real) */}
         <div>
           <div className="flex items-center justify-between mb-1.5">

--- a/src/components/juego/__tests__/MiFincaVivaScreen.test.jsx
+++ b/src/components/juego/__tests__/MiFincaVivaScreen.test.jsx
@@ -97,6 +97,15 @@ describe('MiFincaVivaScreen', () => {
     expect(onNavigate).toHaveBeenCalledWith('sembrar');
   });
 
+  it('expone la entrada a Mundo Subsuelo y navega a su ruta (ux-audit P1-1)', async () => {
+    const onNavigate = vi.fn();
+    render(<MiFincaVivaScreen onNavigate={onNavigate} />);
+    const entrada = await screen.findByTestId('entrada-subsuelo');
+    expect(entrada).toBeTruthy();
+    fireEvent.click(entrada);
+    expect(onNavigate).toHaveBeenCalledWith('subsuelo');
+  });
+
   it('siempre muestra la galería de criaturas (con siluetas si vacía)', async () => {
     render(<MiFincaVivaScreen />);
     expect(await screen.findByTestId('criatura-collection')).toBeTruthy();


### PR DESCRIPTION
## Bug
La pantalla `MundoSubsuelo` del juego estaba huérfana (ux-audit P1-1): `chagraNavigate{subsuelo}` caía en "Vista no disponible" y no había ninguna entrada visible para descubrirla.

## Causa raíz
`MundoSubsuelo.jsx` existía, tenía tests y se exportaba en el barrel `src/components/juego/index.js`, pero el switch de `App.jsx` solo ruteaba `juego`/`defensores`/`milpa`/`doom_finca` — nunca montaba `<MundoSubsuelo>` ni había `case 'subsuelo'`. Además no existía un CTA para llegar (solo era ruteable, no descubrible).

## Cambios
- `src/App.jsx`: lazy import de `MundoSubsuelo` + `case 'subsuelo'` que lo monta dentro de `ScreenShell`. El componente no acepta props de navegación, así que el shell le da Volver→`juego` / Inicio→`dashboard` (mismo patrón que `biopreparados`).
- `src/App.jsx`: `HASH_VIEW_ROUTES` gana `subsuelo`/`mundo-subsuelo` (deep-link directo) y `MODULE_VIEWS` gana `'subsuelo'` (telemetría consistente con los otros sub-mundos).
- `src/components/juego/MiFincaVivaScreen.jsx`: CTA visible **Mundo Subsuelo** (`data-testid="entrada-subsuelo"`) que navega a `'subsuelo'`, replicando el patrón exacto de las entradas `defensores`/`milpa`/`doom_finca`.
- Tests nuevos/ampliados.

## Tests
- `src/__tests__/App.subsuelo-route.test.jsx`: con sesión autenticada y `#subsuelo`, App monta `MundoSubsuelo` (no "Vista no disponible").
- `src/components/juego/__tests__/MiFincaVivaScreen.test.jsx`: la entrada `entrada-subsuelo` existe y al click navega a `'subsuelo'`.
- Suite local: 24/24 en `src/__tests__/`, 17/17 en los tests tocados del juego. `vite build` verde. eslint sin errores/warnings nuevos en archivos tocados (no-undef/no-unused limpio).

Refs: ux-audit P1-1 (pantalla huérfana)

🤖 Generated with [Claude Code](https://claude.com/claude-code)