### PR TITLE
feat(temas): pantallas secundarias adoptan la disposición F2 + piel del tema activo (gated, dev-only)

### DIFF
--- a/src/components/NotificationsBell.jsx
+++ b/src/components/NotificationsBell.jsx
@@ -95,7 +95,7 @@ function mapSensorAlertsToIot(alerts) {
   });
 }
 
-const NotificationsBell = React.memo(function NotificationsBell({ onNavigate }) {
+const NotificationsBell = React.memo(function NotificationsBell({ onNavigate, variant }) {
     const [open, setOpen] = useState(false);
     const [tick, setTick] = useState(0);
     // PoC #316 — tabs Notificaciones / Clima. Default "notif" para no romper
@@ -294,11 +294,18 @@ const NotificationsBell = React.memo(function NotificationsBell({ onNavigate }) 
     // expansivo, icono Bell shake suave. Si warning: ámbar steady. Si info: sky.
     const hasCritical = criticalCount > 0;
     const hasWarning = warningCount > 0;
+    // Variante F2 (modo "Finca Viva", gateado en ScreenShell): la campana toma
+    // la forma REDONDA del demo del home (paridad ux-audit P1-3) en vez del
+    // rectángulo clásico. Las clases siguen resolviendo color contra los
+    // tokens --c-* del tema activo, así que respeta nature/biopunk/minimalista.
+    // El estilo 'actual' (default, sin variant) NO cambia → prod intacto.
+    const isF2 = variant === 'f2';
+    const f2Shape = isF2 ? 'rounded-full' : 'rounded-lg';
     const buttonClass = hasCritical
-        ? 'relative p-2 rounded-lg bg-red-900/40 border-2 border-red-500 text-red-200 min-h-[44px] min-w-[44px] flex items-center justify-center chagra-bell-critical'
+        ? `relative p-2 ${f2Shape} bg-red-900/40 border-2 border-red-500 text-red-200 min-h-[44px] min-w-[44px] flex items-center justify-center chagra-bell-critical`
         : hasWarning
-            ? 'relative p-2 rounded-lg bg-amber-900/30 border border-amber-600/60 text-amber-200 min-h-[44px] min-w-[44px] flex items-center justify-center'
-            : 'relative p-2 rounded-lg bg-slate-800/60 hover:bg-slate-700/60 active:bg-slate-700 border border-slate-700 text-slate-300 min-h-[44px] min-w-[44px] flex items-center justify-center';
+            ? `relative p-2 ${f2Shape} bg-amber-900/30 border border-amber-600/60 text-amber-200 min-h-[44px] min-w-[44px] flex items-center justify-center`
+            : `relative p-2 ${f2Shape} bg-slate-800/60 hover:bg-slate-700/60 active:bg-slate-700 border border-slate-700 text-slate-300 min-h-[44px] min-w-[44px] flex items-center justify-center`;
 
     const badgeBg = hasCritical ? 'bg-red-600' : hasWarning ? 'bg-amber-500' : 'bg-sky-500';
 

--- a/src/components/common/ScreenShell.jsx
+++ b/src/components/common/ScreenShell.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { ArrowLeft, Home, HelpCircle } from 'lucide-react';
 import NotificationsBell from '../NotificationsBell';
+import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
+import { useTheme } from '../../hooks/useTheme';
+import { iconForTheme } from '../dashboard/themeIcon';
+import './screen-shell-f2.css';
 
 /**
  * Helper para navegación global desde ScreenShell sin necesidad de prop
@@ -28,6 +32,22 @@ function navigateGlobal(view) {
  * solo en el dashboard. Click → dispatchEvent('chagra:nav', view).
  * App.jsx tiene el listener que llama setCurrentView correspondiente.
  *
+ * ──────────────────────────────────────────────────────────────────────────
+ * MODO "Finca Viva" (F2) — fase 1 de la integración de temas (2026-06-24):
+ * cuando la flag VITE_FINCA_VIVA_HOME_PERFIL está ON, el shell adopta la
+ * DISPOSICIÓN del home F2 (topbar con aire, marca con el ícono del agente del
+ * tema, pastillas redondas) y hereda la PIEL del tema activo (nature cálido /
+ * biopunk neón-oscuro / minimalista claro-sobrio) en vez de las cards slate
+ * oscuras fijas. La piel sale de la indirección --c-* (themes.css/index.css) +
+ * el lenguaje del home (screen-shell-f2.css), reaccionando a data-luz noche
+ * igual que la portada. Arregla los hallazgos de paridad del ux-audit
+ * (P1-3 campana, P2-1 cards slate). DECISIÓN del operador: la finca-viva es la
+ * disposición; los temas son la piel.
+ *
+ * Con la flag OFF (default, PROD) el shell conserva EXACTAMENTE su markup y
+ * comportamiento actual — esta feature se shippa DARK en producción.
+ * ──────────────────────────────────────────────────────────────────────────
+ *
  * Props:
  *   - title:    string (obligatorio)
  *   - onBack:   handler del botón de regreso (un paso atrás)
@@ -38,6 +58,24 @@ function navigateGlobal(view) {
  */
 export const ScreenShell = ({ title, onBack, onHome, icon: Icon, children, actions }) => {
     const handleHome = onHome || (() => navigateGlobal('dashboard'));
+
+    // La flag se evalúa una sola vez (no cambia en runtime: import.meta.env).
+    // Con OFF se cae al shell legacy idéntico al de prod.
+    const fincaViva = fincaVivaHomePerfilActivo();
+    if (fincaViva) {
+        return (
+            <ScreenShellF2
+                title={title}
+                onBack={onBack}
+                handleHome={handleHome}
+                Icon={Icon}
+                actions={actions}
+            >
+                {children}
+            </ScreenShellF2>
+        );
+    }
+
     return (
         // FIX fondo (2026-05-28): el wrapper era `bg-slate-950` SÓLIDO y tapaba
         // por completo la imagen `--app-bg-image` que App.jsx escribe en el
@@ -100,5 +138,79 @@ export const ScreenShell = ({ title, onBack, onHome, icon: Icon, children, actio
         </div>
     );
 };
+
+/**
+ * ScreenShellF2 — variante "Finca Viva" del shell (solo flag ON). Misma API
+ * funcional que el shell legacy (back/home/help/bell + título + ícono), pero
+ * con la DISPOSICIÓN del home F2 y la PIEL del tema activo. Las clases
+ * .screen-shell-f2-* (screen-shell-f2.css) resuelven color contra los tokens
+ * --c-* del tema, así que una sola estructura sirve a las 3 pieles.
+ */
+function ScreenShellF2({ title, onBack, handleHome, Icon, actions, children }) {
+    const { theme } = useTheme();
+    return (
+        <div className="screen-shell-f2" data-testid="screen-shell-f2">
+            <header className="screen-shell-f2-topbar">
+                <div className="screen-shell-f2-left">
+                    {onBack && (
+                        <button
+                            type="button"
+                            onClick={onBack}
+                            className="screen-shell-f2-pill"
+                            aria-label="Volver"
+                        >
+                            <ArrowLeft size={20} />
+                        </button>
+                    )}
+                    {/* Marca: la A del agente del tema activo (la misma del home
+                        F2 / TopBar). Decorativa (el botón Inicio de al lado hace
+                        la navegación); aria-hidden para no duplicar el control. */}
+                    <button
+                        type="button"
+                        onClick={handleHome}
+                        className="screen-shell-f2-brand"
+                        aria-label="Chagra: ir al inicio"
+                        title="Chagra"
+                    >
+                        <span aria-hidden="true">{iconForTheme(theme)}</span>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleHome}
+                        className="screen-shell-f2-pill is-home"
+                        aria-label="Inicio"
+                        title="Inicio"
+                    >
+                        <Home size={18} />
+                    </button>
+                    <h1 className="screen-shell-f2-title">
+                        {Icon && (
+                            <span className="screen-shell-f2-title-icon">
+                                <Icon size={20} />
+                            </span>
+                        )}
+                        {title}
+                    </h1>
+                </div>
+                <div className="screen-shell-f2-right">
+                    {actions}
+                    <button
+                        type="button"
+                        onClick={() => navigateGlobal('help')}
+                        aria-label="Manual de uso: cómo usar Chagra"
+                        title="Manual de uso"
+                        className="screen-shell-f2-help"
+                    >
+                        <HelpCircle size={22} aria-hidden="true" strokeWidth={2.5} />
+                    </button>
+                    {/* Campana REDONDA del demo del home (ux-audit P1-3) — misma
+                        lógica de notificaciones, forma F2 theme-aware. */}
+                    <NotificationsBell onNavigate={navigateGlobal} variant="f2" />
+                </div>
+            </header>
+            <main className="screen-shell-f2-main">{children}</main>
+        </div>
+    );
+}
 
 export default ScreenShell;

--- a/src/components/common/__tests__/ScreenShell.theme.test.jsx
+++ b/src/components/common/__tests__/ScreenShell.theme.test.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+// La flag VITE_FINCA_VIVA_HOME_PERFIL gobierna el shell F2. La mockeamos con un
+// let mutable para probar ON (dev) y OFF (prod) en el MISMO archivo.
+let flagOn = false;
+vi.mock('../../../config/fincaVivaHomeFlag', () => ({
+  fincaVivaHomePerfilActivo: () => flagOn,
+}));
+
+// useTheme: controla el tema activo para verificar que el shell F2 elige el
+// ícono de marca del tema (THEME_ICON) correcto. Devuelve un objeto estable.
+let activeTheme = 'biopunk';
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: activeTheme, setTheme: vi.fn() }),
+}));
+
+// NotificationsBell es un componente pesado (stores, clima, sync). Lo stubbeamos
+// para aislar el SHELL: el stub solo refleja la prop `variant` que el shell le
+// pasa, así verificamos el cableado F2 sin montar el subsistema de notificaciones.
+vi.mock('../../NotificationsBell', () => ({
+  default: ({ variant }) => (
+    <div data-testid="notif-bell" data-variant={variant || 'actual'} />
+  ),
+}));
+
+// THEME_ICON: stub identificable por tema para aseverar el ícono de marca.
+vi.mock('../../dashboard/themeIcon', () => ({
+  iconForTheme: (theme) => <svg data-testid={`brand-icon-${theme}`} />,
+}));
+
+import { ScreenShell } from '../ScreenShell';
+
+function renderShell(extra = {}) {
+  return render(
+    <ScreenShell title="Biodiversidad" onBack={vi.fn()} {...extra}>
+      <div data-testid="contenido">contenido</div>
+    </ScreenShell>,
+  );
+}
+
+beforeEach(() => {
+  flagOn = false;
+  activeTheme = 'biopunk';
+  document.documentElement.removeAttribute('data-theme');
+  document.documentElement.removeAttribute('data-luz');
+});
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('ScreenShell — gate de la flag VITE_FINCA_VIVA_HOME_PERFIL', () => {
+  test('flag OFF (prod): conserva el shell legacy, SIN la disposición F2', () => {
+    flagOn = false;
+    renderShell();
+    // El shell F2 NO debe montarse → prod intacto.
+    expect(screen.queryByTestId('screen-shell-f2')).not.toBeInTheDocument();
+    // El contenido y el título siguen presentes (comportamiento sin cambios).
+    expect(screen.getByTestId('contenido')).toBeInTheDocument();
+    expect(screen.getByText('Biodiversidad')).toBeInTheDocument();
+    // La campana legacy NO lleva variante F2.
+    expect(screen.getByTestId('notif-bell')).toHaveAttribute('data-variant', 'actual');
+  });
+
+  test('flag ON (dev): adopta la disposición F2 y mantiene el contenido', () => {
+    flagOn = true;
+    renderShell();
+    expect(screen.getByTestId('screen-shell-f2')).toBeInTheDocument();
+    expect(screen.getByTestId('contenido')).toBeInTheDocument();
+    expect(screen.getByText('Biodiversidad')).toBeInTheDocument();
+  });
+});
+
+describe('ScreenShell F2 — piel del tema activo', () => {
+  test('aplica el ícono de marca del agente del tema biopunk', () => {
+    flagOn = true;
+    activeTheme = 'biopunk';
+    renderShell();
+    expect(screen.getByTestId('brand-icon-biopunk')).toBeInTheDocument();
+  });
+
+  test('aplica el ícono de marca del agente del tema nature', () => {
+    flagOn = true;
+    activeTheme = 'nature';
+    renderShell();
+    expect(screen.getByTestId('brand-icon-nature')).toBeInTheDocument();
+  });
+
+  test('aplica el ícono de marca del agente del tema minimalista', () => {
+    flagOn = true;
+    activeTheme = 'minimalista';
+    renderShell();
+    expect(screen.getByTestId('brand-icon-minimalista')).toBeInTheDocument();
+  });
+
+  test('monta la campana en variante F2 (campana redonda del demo, ux-audit P1-3)', () => {
+    flagOn = true;
+    renderShell();
+    expect(screen.getByTestId('notif-bell')).toHaveAttribute('data-variant', 'f2');
+  });
+
+  test('el lienzo principal usa la clase de piel del tema (no slate fijo)', () => {
+    flagOn = true;
+    const { container } = renderShell();
+    const main = container.querySelector('main.screen-shell-f2-main');
+    expect(main).toBeInTheDocument();
+    // El scrim sale de la indirección --c-*; NO debe quedar el bg-slate-950/55
+    // fijo del shell legacy (esa es la causa raíz de P2-1 cards slate oscuras).
+    expect(main.className).not.toMatch(/bg-slate-950/);
+  });
+});
+
+describe('ScreenShell F2 — cableado de navegación (paridad con legacy)', () => {
+  test('onBack se invoca al pulsar Volver', () => {
+    flagOn = true;
+    const onBack = vi.fn();
+    renderShell({ onBack });
+    fireEvent.click(screen.getByLabelText('Volver'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  test('Ayuda dispara el evento global chagra:nav → help', () => {
+    flagOn = true;
+    const spy = vi.fn();
+    window.addEventListener('chagra:nav', spy);
+    renderShell();
+    fireEvent.click(screen.getByLabelText('Manual de uso: cómo usar Chagra'));
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][0].detail).toBe('help');
+    window.removeEventListener('chagra:nav', spy);
+  });
+
+  test('onHome se respeta cuando se pasa explícito (sino, default dashboard)', () => {
+    flagOn = true;
+    const onHome = vi.fn();
+    renderShell({ onHome });
+    fireEvent.click(screen.getByLabelText('Inicio'));
+    expect(onHome).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/common/screen-shell-f2.css
+++ b/src/components/common/screen-shell-f2.css
@@ -1,0 +1,171 @@
+/* ============================================================================
+   screen-shell-f2.css — PIEL del shell de pantallas secundarias en modo
+   "Finca Viva" (F2). Gateado tras VITE_FINCA_VIVA_HOME_PERFIL: SOLO se aplica
+   cuando ScreenShell se monta con la variante F2 (clase `.screen-shell-f2`).
+   Con la flag OFF el shell conserva su markup/estilo actual (prod intacto).
+
+   DECISIÓN del operador (2026-06-24): la finca-viva es la DISPOSICIÓN (layout);
+   los TEMAS son la PIEL (color, cielo, ícono del agente). Por eso este archivo
+   NO hardcodea color de tema: bebe de la indirección `--c-*` (index.css; biopunk
+   en :root, nature/minimalista en [data-theme]) y del lenguaje del home F2
+   (finca-viva-hero.css: --fvh-tinta, --fvh-sello, --fvh-crema, data-luz noche).
+   Así, una sola hoja resuelve las 3 pieles:
+     · nature       → crema cálida, café/salvia (las --c-* viran a papel cálido).
+     · biopunk      → oscuro neón teal (las --c-* base; foto del body se ve).
+     · minimalista  → papel claro sobrio (las --c-* viran a blanco/tinta).
+
+   Reacciona a html[data-luz="noche"] igual que el home F2 (cielo nocturno),
+   para coherencia con la portada. Español de Colombia (tú/usted), sin voseo.
+   ========================================================================== */
+
+/* ── Tokens-puente F2 ↔ tema. Reusan los --c-* del tema activo (resueltos por
+   index.css) y el lenguaje cálido del home (--fvh-*). El default de cada var()
+   garantiza que biopunk (sin data-theme) tenga su valor sin depender de nada. */
+.screen-shell-f2 {
+  /* Topbar: superficie elevada del tema con un velo translúcido (deja ver la
+     foto/fondo del body detrás, como el home). */
+  --ssf2-topbar-bg: rgb(var(--c-surface-card, 15 23 42) / 0.72);
+  --ssf2-topbar-border: rgb(var(--c-surface-border, 51 65 85) / 0.55);
+  /* Lienzo principal: scrim suave del tema (NO slate-950 fijo). En claros vira
+     a crema/papel translúcido; en biopunk a navy translúcido. */
+  --ssf2-main-scrim: rgb(var(--c-slate-950, 2 6 23) / 0.42);
+  /* Botones de chrome (back/home): pastilla redonda del tema. */
+  --ssf2-pill-bg: rgb(var(--c-surface-raised, 30 41 59) / 0.85);
+  --ssf2-pill-bg-hover: rgb(var(--c-surface-raised, 30 41 59) / 1);
+  --ssf2-pill-tinta: rgb(var(--c-slate-100, 241 245 249));
+  /* Acento (Home, ícono de título): emerald del tema (vira cálido en nature). */
+  --ssf2-acento: rgb(var(--c-emerald-400, 52 211 153));
+  --ssf2-titulo: rgb(var(--c-slate-100, 241 245 249));
+}
+
+/* En temas CLAROS el velo translúcido del lienzo debe quedar muy tenue para no
+   lavar el papel cálido del demo (nature) / el blanco sobrio (minimalista). */
+[data-theme="nature"] .screen-shell-f2,
+[data-theme="minimalista"] .screen-shell-f2 {
+  --ssf2-main-scrim: rgb(var(--c-slate-950) / 0.10);
+  --ssf2-topbar-bg: rgb(var(--c-surface-card) / 0.86);
+}
+
+/* Noche (mismo data-luz del home F2): el velo se profundiza un poco para
+   sostener legibilidad cuando el cielo del fondo se oscurece. */
+html[data-luz="noche"] .screen-shell-f2 {
+  --ssf2-main-scrim: rgb(var(--c-slate-950, 2 6 23) / 0.52);
+}
+html[data-luz="noche"][data-theme="nature"] .screen-shell-f2,
+html[data-luz="noche"][data-theme="minimalista"] .screen-shell-f2 {
+  --ssf2-main-scrim: rgb(var(--c-slate-950) / 0.18);
+}
+
+.screen-shell-f2 {
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: var(--ssf2-titulo);
+}
+
+/* ── TOPBAR estilo F2: aire, jerarquía, marca con el ícono del agente ──────── */
+.screen-shell-f2-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: calc(env(safe-area-inset-top, 0px) + 12px) 16px 12px;
+  background: var(--ssf2-topbar-bg);
+  border-bottom: 1px solid var(--ssf2-topbar-border);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  flex-shrink: 0;
+}
+.screen-shell-f2-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+.screen-shell-f2-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* Marca: la A del agente del tema activo (la misma que el home F2 / TopBar). */
+.screen-shell-f2-brand {
+  width: 38px;
+  height: 38px;
+  flex: 0 0 auto;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  padding: 6px;
+  background: rgb(var(--c-surface-raised, 30 41 59) / 0.7);
+}
+.screen-shell-f2-brand svg { width: 100%; height: 100%; display: block; }
+
+/* Pastillas de chrome (back/home): redondas, del tema (no slate fijo). */
+.screen-shell-f2-pill {
+  min-height: 44px;
+  min-width: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid var(--ssf2-topbar-border);
+  background: var(--ssf2-pill-bg);
+  color: var(--ssf2-pill-tinta);
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, transform 0.1s ease;
+}
+.screen-shell-f2-pill:hover { background: var(--ssf2-pill-bg-hover); }
+.screen-shell-f2-pill:active { transform: scale(0.94); }
+.screen-shell-f2-pill.is-home { color: var(--ssf2-acento); }
+
+/* Título: tinta del tema + ícono en el acento del tema. */
+.screen-shell-f2-title {
+  font-size: 1.18rem;
+  font-weight: 800;
+  line-height: 1.1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--ssf2-titulo);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.screen-shell-f2-title-icon {
+  color: var(--ssf2-acento);
+  flex-shrink: 0;
+  display: inline-flex;
+}
+
+/* Botón de ayuda: ámbar del tema (la indirección lo lleva al ámbar correcto). */
+.screen-shell-f2-help {
+  min-height: 44px;
+  min-width: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px solid rgb(var(--c-amber-500, 245 158 11) / 0.42);
+  background: rgb(var(--c-amber-500, 245 158 11) / 0.18);
+  color: rgb(var(--c-amber-300, 252 211 77));
+  cursor: pointer;
+}
+.screen-shell-f2-help:hover { background: rgb(var(--c-amber-500, 245 158 11) / 0.3); }
+
+/* ── LIENZO principal: scrim del tema (deja ver el fondo del body) ─────────── */
+.screen-shell-f2-main {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--ssf2-main-scrim);
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 120px);
+}
+
+/* prefers-reduced-motion: sin transiciones de pastilla. */
+@media (prefers-reduced-motion: reduce) {
+  .screen-shell-f2-pill { transition: none; }
+}


### PR DESCRIPTION
## Feature
Fase 1 (fundación) de la integración de temas: que el **resto de pantallas** adopte la disposición del home F2 "finca-viva" **y** respete el tema activo (nature / biopunk / minimalista). Decisión del operador: **la finca-viva es la DISPOSICIÓN (layout); los temas son la PIEL** (color, cielo, ícono del agente).

## ⛔ Gate (dark en prod)
Todo el cambio de disposición va **gateado tras `fincaVivaHomePerfilActivo()`** (`VITE_FINCA_VIVA_HOME_PERFIL`). `dev-deploy.yml` la pone `"true"` → activo en dev; **prod NO la pone → este PR es DARK en producción**. Con la flag OFF, `ScreenShell` conserva **exactamente** su markup y comportamiento actual (verificado por test). Seguro de mergear con CI requerido verde.

## Causa raíz (paridad rota)
El shell común de pantallas secundarias (`ScreenShell`) montaba cards **slate oscuras fijas** + una **campana rectangular** ajena al lenguaje del home. Aunque el color resuelve por la indirección `--c-*`, la disposición y la jerarquía no eran las del demo F2 → ux-audit **P1-3** (campana) y **P2-1** (cards slate oscuras que rompen nature/minimalista).

## Cambios
- **`src/components/common/ScreenShell.jsx`**: branch gateado por la flag. Con ON renderiza `ScreenShellF2` (topbar con aire, marca con el ícono del agente del tema activo vía `iconForTheme(theme)`, pastillas redondas, ayuda ámbar, campana redonda). Con OFF → shell legacy idéntico a hoy.
- **`src/components/common/screen-shell-f2.css`**: hoja de la PIEL F2. No hardcodea color de tema: bebe de la indirección `--c-*` (biopunk en `:root`, nature/minimalista en `[data-theme]`) + el lenguaje del home. Una sola hoja resuelve las 3 pieles y reacciona a `html[data-luz="noche"]` como la portada.
- **`src/components/NotificationsBell.jsx`**: prop `variant="f2"` → forma **redonda** del demo del home (ux-audit P1-3), reusando toda la lógica de notificaciones. Sin `variant` el estilo es idéntico al actual.
- **`src/components/common/__tests__/ScreenShell.theme.test.jsx`**: 10 casos.

## Tests
- 10 vitest casos passing: flag OFF conserva shell legacy (sin F2, campana `actual`); flag ON adopta F2; ícono de marca correcto por tema (biopunk/nature/minimalista); campana en `variant="f2"`; lienzo sin `bg-slate-950` fijo; cableado back/home/help intacto.
- `vite build` verde · eslint `--max-warnings=0` verde · sin regresión en consumidores (`HoyEnFincaScreen`, `MiFincaEvolucionScreen`, `DashboardLive.redistribucion`).
- Evidencia visual sin chromium: rasterización rsvg de las 3 pieles (misma disposición, distinta piel por tema).

## Mapa por pantalla (para planear Fase 2)
**Adaptadas en esta fase** (heredan `ScreenShell` → reciben la piel F2 de una): Asociaciones, Biodiversidad, Ciclo de nutrientes, Perfil, Calendario de la finca, Informes, Mercados, Germinación, Abejas, Gallinas, Vacas, Animales, Extensionista, Glaciar (historial), Hoy en la finca, Mi finca evolución, Case Study (lista + detalle), Mapa de la finca, Bodega, Fermentos, Biopreparados, Registro por voz, Campo del trabajador.

**Necesitan trabajo individual en Fase 2** (superficie propia, no heredan la piel del shell):
- **Juegos**: Defensores de la finca, Milpa, Subsuelo (`#fff8e8` hardcoded), Mi Finca Viva, Doom Finca — montan `ScreenShell` pero su lienzo de juego tiene tokens propios (ux-audit P2-3).
- **AgentScreen**: superficie propia del agente.
- **FAB global del agente** (`AgentFab` → `ChagraAgentAvatarColibriPhoto`, la "foto biopunk"): avatar por preferencia de usuario, no por tema → el "FAB biopunk que aparece en otros temas" del ux-audit requiere decidir su skin por tema (cambio en el sistema de prefs, no en el shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)