### PR TITLE
feat(calendario): ciclo fenológico grounded para tomate, fresa y guayaba (cultivos pilares)

### DIFF
--- a/src/services/__tests__/calendarCultivosOperador.test.js
+++ b/src/services/__tests__/calendarCultivosOperador.test.js
@@ -1,0 +1,104 @@
+/**
+ * calendarCultivosOperador — guarda de regresión para los CULTIVOS PILARES de la
+ * finca del operador en el "Calendario de la finca".
+ *
+ * Bug (2026-06-25): el calendario salía VACÍO ("No tengo datos de ciclo … no
+ * invento fechas") para Tomate, Tomate Cherry, Fresa y Guayaba cuando el operador
+ * nombraba sus plantas con un calificador de estructura/ubicación predial
+ * ("Fresa - Invernadero #1", "Guayaba - Invernadero"). El nombre no resolvía a
+ * ninguna especie del catálogo → sin plantilla → no_data. La fenología/ciclo
+ * perenne YA existían y estaban grounded; el fallo era la resolución nombre→slug.
+ *
+ * Este test recorre la MISMA cadena que CalendarioFincaScreen
+ * (matchSpeciesInCatalog → buildPlantCalendar) contra el catálogo OSS REAL que
+ * ships en la app (subset v3.2 → catalog.sqlite), no un fixture sintético, para
+ * que cualquier regresión en la resolución o en los datos grounded lo rompa.
+ *
+ * Invariante anti-alucinación (también cubierto): una planta sin datos de ciclo
+ * NO inventa fechas; cae a no_data y la UI deflexiona honestamente.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { matchSpeciesInCatalog } from '../../utils/speciesResolver';
+import { buildPlantCalendar } from '../farmCalendarService';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const SUBSET_PATH = path.join(REPO_ROOT, 'catalog/chagra-catalog-oss-subset-v3.2.json');
+const catalog = JSON.parse(readFileSync(SUBSET_PATH, 'utf8')).species || [];
+
+// Fecha fija y siembra fija para reproducibilidad.
+const NOW = new Date('2026-06-25T12:00:00Z').getTime();
+const SOWN = new Date('2026-03-01T12:00:00Z').getTime();
+
+/** Reproduce el paso de CalendarioFincaScreen: nombre del asset → calendario. */
+function calendarFor(name, slug) {
+  const species = matchSpeciesInCatalog(catalog, slug, name);
+  const speciesSlug = species?.id || species?.slug || slug;
+  return buildPlantCalendar({
+    id: slug,
+    name,
+    speciesSlug,
+    species,
+    sowingDate: SOWN,
+    altitudeM: 1800,
+    now: NOW,
+  });
+}
+
+describe('Calendario de finca — cultivos pilares del operador', () => {
+  // [nombre del asset como lo escribe el operador, slug derivado, kind esperado]
+  const PILARES = [
+    ['Tomate (Solanum lycopersicum)', 'tomate', 'annual'],
+    ['Tomate Cherry (Solanum lycopersicum var. cerasiforme)', 'tomate_cherry', 'annual'],
+    ['Fresa (Fragaria × ananassa)', 'fresa', 'annual'],
+    ['Fresa - Invernadero #1', 'fresa_invernadero', 'annual'],
+    ['Fresa - Invernadero #10', 'fresa_invernadero', 'annual'],
+    ['Guayaba (Psidium guajava)', 'guayaba', 'perennial'],
+    ['Guayaba - Invernadero', 'guayaba_invernadero', 'perennial'],
+  ];
+
+  for (const [name, slug, expectedKind] of PILARES) {
+    it(`"${name}" produce calendario (no "sin ciclo")`, () => {
+      const cal = calendarFor(name, slug);
+      expect(cal.status).toBe('ok');
+      expect(cal.kind).toBe(expectedKind);
+      expect(cal.entries.length).toBeGreaterThan(0);
+      // Cada entrada lleva una fuente real (grounding, anti-alucinación).
+      for (const e of cal.entries) {
+        expect(typeof e.source).toBe('string');
+        expect(e.source.length).toBeGreaterThan(0);
+      }
+    });
+  }
+
+  it('Fresa usa la plantilla fenológica grounded (Agrosavia), no genérica', () => {
+    const cal = calendarFor('Fresa - Invernadero #1', 'fresa_invernadero');
+    expect(cal.isGeneric).toBe(false);
+    const sources = cal.entries.map((e) => e.source).join(' | ');
+    expect(sources.toLowerCase()).toContain('fresa');
+  });
+
+  it('Tomate usa la plantilla fenológica grounded de tomate (Agrosavia)', () => {
+    const cal = calendarFor('Tomate (Solanum lycopersicum)', 'tomate');
+    expect(cal.isGeneric).toBe(false);
+    const sources = cal.entries.map((e) => e.source).join(' | ');
+    expect(sources.toLowerCase()).toContain('tomate');
+  });
+
+  it('Guayaba usa el ciclo PERENNE grounded (floración + cosecha de Agrosavia)', () => {
+    const cal = calendarFor('Guayaba - Invernadero', 'guayaba_invernadero');
+    expect(cal.kind).toBe('perennial');
+    expect(cal.perennial).toBeTruthy();
+    const layers = new Set(cal.entries.map((e) => e.layer));
+    expect(layers.has('cosecha')).toBe(true); // tiene ventana de cosecha real
+  });
+
+  it('ANTI-ALUCINACIÓN: una especie sin datos de ciclo NO inventa fechas', () => {
+    const cal = calendarFor('Planta Marciana Inexistente', 'planta_marciana_xyz');
+    expect(cal.status).toBe('no_data');
+    expect(cal.entries).toHaveLength(0);
+  });
+});

--- a/src/utils/speciesResolver.js
+++ b/src/utils/speciesResolver.js
@@ -34,20 +34,74 @@
  */
 
 /**
+ * Calificadores de estructura/ubicación que el operador agrega al nombre de un
+ * cultivo de su finca y que NO son parte del nombre de la ESPECIE. El campesino
+ * nombra sus plantas por dónde están o en qué unidad: "Fresa - Invernadero #1",
+ * "Tomate - Era 3", "Guayaba - Lote 2", "Mora - Cama 4". El nombre de la especie
+ * es siempre lo que va ANTES del " - "; lo de después es ubicación/manejo.
+ *
+ * Estas palabras también aparecen a veces sin guion ("Fresa Invernadero 1") y se
+ * recortan como sufijo cuando son la última palabra significativa. Lista cerrada
+ * y conservadora: solo términos de estructura predial inequívocos, NUNCA nombres
+ * de especie (anti-confusión: no recortar "árbol" porque "Tomate de árbol" es una
+ * especie distinta — por eso "arbol" NO está aquí).
+ */
+const FARM_STRUCTURE_WORDS = [
+  'invernadero', 'era', 'eras', 'cama', 'camas', 'lote', 'lotes',
+  'surco', 'surcos', 'bancal', 'bancales', 'parcela', 'parcelas',
+  'huerta', 'huerto', 'maceta', 'macetas', 'bolsa', 'bolsas',
+  'tunel', 'mesa', 'mesas', 'hilera', 'hileras', 'planta', 'plantas',
+];
+
+const STRUCTURE_RE = new RegExp(`^(?:${FARM_STRUCTURE_WORDS.join('|')})\\b`);
+
+/**
  * Normaliza un string para comparación laxa: minúsculas, sin acentos, sin
- * sufijos de conteo (`#3`), guiones-bajos/espacios colapsados.
+ * sufijos de conteo (`#3`, `#01`, ` 3`), sin calificadores de estructura/
+ * ubicación de finca ("- Invernadero"), guiones-bajos/espacios colapsados.
+ *
+ * Reduce el nombre que escribe el operador ("Fresa - Invernadero #1") al nombre
+ * de la ESPECIE ("fresa") para que matchee el catálogo, sin tocar nombres
+ * científicos entre paréntesis ("Tomate (Solanum lycopersicum)" → se conserva
+ * para que el paso 2/3 los aproveche).
+ *
  * @param {string} value
  * @returns {string}
  */
 export function normalizeForMatch(value) {
   if (!value || typeof value !== 'string') return '';
-  return value
+  let s = value
     .normalize('NFD')
     .replace(/[̀-ͯ]/g, '') // quita acentos/diacríticos
     .toLowerCase()
-    .replace(/\s+#\d+\s*$/, '') // sufijo de conteo "#3"
     .replace(/[_\s]+/g, ' ')
     .trim();
+
+  // 1) Recorta el calificador de estructura/ubicación introducido por " - "
+  //    cuando lo que sigue es una palabra de estructura predial conocida.
+  //    "fresa - invernadero #1" → "fresa"; "guayaba - invernadero" → "guayaba".
+  //    No recorta separadores que no sean estructura ("aji - dulce" se conserva).
+  const dashIdx = s.indexOf(' - ');
+  if (dashIdx > 0) {
+    const tail = s.slice(dashIdx + 3).trim();
+    if (STRUCTURE_RE.test(tail)) {
+      s = s.slice(0, dashIdx).trim();
+    }
+  }
+
+  // 2) Recorta un sufijo de estructura sin guion como última palabra significativa
+  //    ("fresa invernadero 1" → "fresa"), respetando que quede al menos una
+  //    palabra (no vaciar el nombre).
+  s = s.replace(/\s+#?\d+\s*$/, '').trim(); // primero el conteo final "#3"/"3"/"#01"
+  const words = s.split(' ');
+  if (words.length > 1 && STRUCTURE_RE.test(words[words.length - 1])) {
+    words.pop();
+    s = words.join(' ').trim();
+  }
+
+  // 3) Recorta cualquier conteo residual (#01) que haya quedado tras el calificador.
+  s = s.replace(/\s*#\d+\s*$/, '').trim();
+  return s;
 }
 
 /**

--- a/src/utils/speciesResolver.test.js
+++ b/src/utils/speciesResolver.test.js
@@ -79,6 +79,17 @@ describe('matchSpeciesInCatalog', () => {
     expect(matchSpeciesInCatalog(CATALOG, 'xyz', 'Especie Marciana')).toBeNull();
   });
 
+  it('resuelve cultivos del operador con calificador de estructura ("Fresa - Invernadero #1")', () => {
+    // Antes del fix, "Fresa - Invernadero #1" normalizaba a "fresa - invernadero"
+    // y NO matcheaba ninguna especie → calendario vacío.
+    expect(
+      matchSpeciesInCatalog(CATALOG, 'fresa_invernadero', 'Fresa - Invernadero #1')?.id,
+    ).toBe('fragaria_ananassa');
+    expect(
+      matchSpeciesInCatalog(CATALOG, 'fresa_invernadero', 'Fresa - Invernadero #10')?.id,
+    ).toBe('fragaria_ananassa');
+  });
+
   it('tolera lista vacía o inválida', () => {
     expect(matchSpeciesInCatalog([], 'fresa', 'Fresa')).toBeNull();
     expect(matchSpeciesInCatalog(null, 'fresa', 'Fresa')).toBeNull();
@@ -200,5 +211,41 @@ describe('normalizeForMatch — ampliado', () => {
 
   it('passthrough: string ya limpio queda igual', () => {
     expect(normalizeForMatch('fresa organica')).toBe('fresa organica');
+  });
+});
+
+describe('normalizeForMatch — calificadores de estructura de finca (cultivos del operador)', () => {
+  it('recorta "- Invernadero #N" al nombre de la especie', () => {
+    expect(normalizeForMatch('Fresa - Invernadero #1')).toBe('fresa');
+    expect(normalizeForMatch('Fresa - Invernadero #10')).toBe('fresa');
+    expect(normalizeForMatch('Guayaba - Invernadero')).toBe('guayaba');
+  });
+
+  it('recorta otros calificadores de ubicación predial', () => {
+    expect(normalizeForMatch('Tomate - Era 3')).toBe('tomate');
+    expect(normalizeForMatch('Mora - Cama 4')).toBe('mora');
+    expect(normalizeForMatch('Cilantro - Lote 2')).toBe('cilantro');
+  });
+
+  it('recorta el calificador de estructura aunque venga sin guion', () => {
+    expect(normalizeForMatch('Fresa Invernadero #1')).toBe('fresa');
+  });
+
+  it('recorta conteo con cero a la izquierda (#01)', () => {
+    expect(normalizeForMatch('Fresa #01')).toBe('fresa');
+  });
+
+  it('CONSERVA el nombre científico entre paréntesis (lo usa el paso 2/3)', () => {
+    expect(normalizeForMatch('Tomate (Solanum lycopersicum)')).toBe('tomate (solanum lycopersicum)');
+    expect(normalizeForMatch('Guayaba (Psidium guajava)')).toBe('guayaba (psidium guajava)');
+  });
+
+  it('NO recorta separadores que no son estructura predial (anti-falso-positivo)', () => {
+    // "Ají - dulce" NO es ubicación; el guion separa una variedad, se conserva.
+    expect(normalizeForMatch('Ají - dulce')).toBe('aji - dulce');
+  });
+
+  it('anti-confusión: NO recorta "árbol" (Tomate de árbol es OTRA especie)', () => {
+    expect(normalizeForMatch('Tomate de árbol')).toBe('tomate de arbol');
   });
 });


### PR DESCRIPTION
## Problema
El **Calendario de la finca** salía VACÍO ("No tengo datos de ciclo para estas especies; no invento fechas") para los cultivos pilares del operador cuando los nombraba con un calificador de estructura predial: `Fresa - Invernadero #1`, `Guayaba - Invernadero`, etc.

## Diagnóstico (cadena real nombre→slug→categoría→plantilla)
Tracé la cadena completa contra el catálogo OSS que **ships en la app** (`chagra-catalog-oss-subset-v3.2.json` → `public/catalog.sqlite`):

| Plant del operador | Antes | Causa |
|---|---|---|
| `Tomate` / `Tomate Cherry` | OK | resolvía a `solanum_lycopersicum_cerasiforme` |
| `Fresa` / `Fresa #1` | OK | resolvía a `fragaria_ananassa_monterrey` |
| `Fresa - Invernadero #1` | ❌ no_data | nombre no resolvía |
| `Guayaba` | OK | resolvía a `psidium_guajava_manzana` (perenne) |
| `Guayaba - Invernadero` | ❌ no_data | nombre no resolvía |

**La fenología y el ciclo perenne YA existían y estaban grounded** (plantillas Agrosavia de tomate/fresa; ciclo perenne Agrosavia de guayaba). El fallo **no era falta de datos**: era la **resolución nombre→especie**. `normalizeForMatch` solo recortaba el contador final `" #N"`, pero NO el calificador de estructura `"- Invernadero"`. Así `"Fresa - Invernadero #1"` → `"fresa - invernadero"`, que no matchea ninguna especie → `matchSpeciesInCatalog` = null → sin plantilla → `no_data` → calendario vacío.

## Fix (solo resolución; cero datos inventados)
`normalizeForMatch` (`src/utils/speciesResolver.js`) ahora reduce el nombre que escribe el operador al nombre de la **especie**: recorta calificadores de estructura predial (`invernadero, era, cama, lote, surco, bancal, parcela, maceta, bolsa, túnel, mesa, hilera`…) tanto con guion (`" - Invernadero"`) como sin él (`"Fresa Invernadero 1"`), más el contador con cero a la izquierda (`#01`). Conserva el binomio entre paréntesis y **NO** recorta `"árbol"` (anti-confusión: *Tomate de árbol* es otra especie). Verificado: **ningún** nombre común del catálogo termina en una palabra de estructura, así que el recorte es seguro en todo el catálogo.

## Resultado (verificado contra el subset real)
- **Tomate / Tomate Cherry** → `solanum_lycopersicum_cerasiforme` (anual, plantilla **Agrosavia** tomate).
- **Fresa / `Fresa - Invernadero #N`** → `fragaria_ananassa_monterrey` (anual, plantilla **Agrosavia + FAO** fresa).
- **Guayaba / `Guayaba - Invernadero`** → `psidium_guajava_manzana` (**perenne**: floración + cosecha de **Agrosavia**).

Los 4 cultivos pilares ya muestran calendario con fuentes Tier A. El invariante anti-alucinación se mantiene: una especie sin datos de ciclo cae a `no_data` y la UI deflexiona honestamente (test lo cubre).

## Tests
- `src/services/__tests__/calendarCultivosOperador.test.js`: guarda de regresión que recorre la **misma cadena** que `CalendarioFincaScreen` (`matchSpeciesInCatalog → buildPlantCalendar`) contra el catálogo OSS **real**, para los 7 nombres del operador + el caso anti-alucinación.
- `src/utils/speciesResolver.test.js`: casos nuevos de `normalizeForMatch` (estructura predial, anti-confusión) y `matchSpeciesInCatalog`.

Blast radius (12 archivos, 257 tests) verde. `vite build` verde. eslint 0 no-undef/no-unused. Sin tocar seeds → no se regenera sqlite.

## Notas
- No gateado: es DATO grounded que mejora el calendario en dev y prod.
- **Nota lateral solicitada** (no la arreglé, solo reporto): el operador tiene muchas entradas de fresa (`Fresa - Invernadero #1..10`, `Fresa (Fragaria x ananassa) #01..10`, `#1..10`, `#1..2`). Por el patrón de naming repetido y solapado parecen **duplicados de datos de prueba**, no cultivos distintos; conviene revisarlo aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)