### PR TITLE
feat(temas): 4º tema "Verde Vivo" + escena finca-viva en todos los temas (gated dev-only)

### DIFF
--- a/src/components/common/ThemeSelector.jsx
+++ b/src/components/common/ThemeSelector.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { useTheme, THEMES } from '../../hooks/useTheme';
+import { useTheme, getSelectableThemes } from '../../hooks/useTheme';
+import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
 
 /**
  * ThemeSelector — switcher de tema visual (skin) de la app.
  * Vive en Perfil. Default bio-punk; el usuario puede cambiar a Nature o
  * Minimalista (persistido en localStorage vía useTheme). El tema se aplica
  * app-wide desde el login mediante data-theme en <html>.
+ *
+ * El 4º tema "Verde Vivo" (la piel de la finca viva) aparece SOLO cuando la
+ * flag VITE_FINCA_VIVA_HOME_PERFIL está ON (dev): getSelectableThemes lo añade
+ * al final. Con la flag OFF (prod) el selector muestra EXACTO los 3 temas + auto
+ * de hoy, sin cambios para el usuario de producción.
  *
  * Cada tema muestra un swatch con sus colores característicos para que el
  * cambio sea evidente antes de aplicarlo.
@@ -18,15 +24,18 @@ const SWATCHES = {
   biopunk: ['#0a0e14', '#19c79a', '#3be8a6'],
   nature: ['#f6efe0', '#d98a4f', '#7a8f4a'],
   minimalista: ['#f6f3ec', '#2f6e5a', '#878d86'],
+  // Verde Vivo: crema frondosa + verde-hoja vivo + sol/ocre cálido.
+  'verde-vivo': ['#eef3e2', '#2e8b3d', '#e0922e'],
 };
 
 export default function ThemeSelector() {
   const { theme, setTheme } = useTheme();
+  const themes = getSelectableThemes(fincaVivaHomePerfilActivo());
 
   return (
     <div className="space-y-3">
       <div className="flex flex-col gap-2">
-        {THEMES.map((t) => {
+        {themes.map((t) => {
           const active = theme === t.id;
           const swatch = SWATCHES[t.id] || SWATCHES.biopunk;
           return (

--- a/src/components/common/__tests__/ThemeSelector.verdeVivo.test.jsx
+++ b/src/components/common/__tests__/ThemeSelector.verdeVivo.test.jsx
@@ -1,0 +1,61 @@
+/**
+ * ThemeSelector — gate del 4º tema "Verde Vivo" tras la flag de finca viva.
+ *
+ * Con la flag VITE_FINCA_VIVA_HOME_PERFIL:
+ *   · ON  (dev)  → el selector muestra los 3 temas + auto + Verde Vivo, y se
+ *                  puede seleccionar (persiste + aplica data-theme="verde-vivo").
+ *   · OFF (prod) → el selector es EXACTO el de hoy: NO aparece Verde Vivo.
+ *
+ * Innegociable: con la flag OFF, prod intacto (selector como hoy).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { vi } from 'vitest';
+
+// Flag mutable para probar ON y OFF en el mismo archivo.
+let flagOn = false;
+vi.mock('../../../config/fincaVivaHomeFlag', () => ({
+  fincaVivaHomePerfilActivo: () => flagOn,
+}));
+
+import ThemeSelector from '../ThemeSelector';
+import { STORAGE_KEY } from '../../../hooks/useTheme';
+
+describe('ThemeSelector — 4º tema Verde Vivo gateado por flag', () => {
+  beforeEach(() => {
+    flagOn = false;
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+  afterEach(() => {
+    cleanup();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  const verdeBtn = () => screen.queryByRole('button', { name: /^Verde Vivo/i });
+
+  it('flag OFF (prod): NO muestra el 4º tema, y siguen los 3 + auto', () => {
+    flagOn = false;
+    render(<ThemeSelector />);
+    expect(verdeBtn()).toBeNull();
+    expect(screen.getByRole('button', { name: /^Bio-Punk/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^Nature/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^Minimalista/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^Autom/i })).toBeTruthy();
+  });
+
+  it('flag ON (dev): muestra el 4º tema "Verde Vivo"', () => {
+    flagOn = true;
+    render(<ThemeSelector />);
+    expect(verdeBtn()).toBeTruthy();
+  });
+
+  it('flag ON: al elegir Verde Vivo persiste y aplica data-theme="verde-vivo"', () => {
+    flagOn = true;
+    render(<ThemeSelector />);
+    fireEvent.click(verdeBtn());
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('verde-vivo');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('verde-vivo');
+    expect(verdeBtn().getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -14,7 +14,8 @@ import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciar
 import { deriveAtmosphere } from '../../services/atmosphereService';
 import { resolveClimaLocation, getCachedClimaSnapshot, CLIMA_UPDATED_EVENT } from '../../services/climaService';
 import { clasificarPisoTermico } from '../../services/pisoTermicoClassifier';
-import { THEME_ICON } from './themeIcon';
+import { useTheme } from '../../hooks/useTheme';
+import { iconForTheme } from './themeIcon';
 import './finca-viva-hero.css';
 
 /**
@@ -69,6 +70,11 @@ import './finca-viva-hero.css';
  * @param {string} [props.titulo]  título accesible (default "Mi finca viva").
  */
 export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, children, titulo }) {
+  // Piel del tema activo: el ícono de marca del agente (la A roja en biopunk, la
+  // sol-mano en verde-vivo, etc.) sigue al tema, igual que la escena toma su piel
+  // del tema vía los tokens --c-*/--fvh-* del CSS. Con la flag OFF este hero no se
+  // monta, así que esto solo corre en dev.
+  const { theme } = useTheme();
   const abrirAgente = () => {
     if (onOpenAgent) onOpenAgent();
     else onNavigate?.('agente');
@@ -170,8 +176,10 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
         {/* ── TOPBAR (con jerarquía y aire — feedback #3) ───────────────────── */}
         <header className="fvh-topbar">
           <div className="fvh-brand">
-            {/* La A ROJA del agente (THEME_ICON.biopunk) — feedback #4 */}
-            <span className="fvh-brand-a" aria-hidden="true">{THEME_ICON.biopunk}</span>
+            {/* Ícono de marca del agente del TEMA ACTIVO (feedback #4): la A roja
+                en biopunk, la sol-mano frondosa en verde-vivo, etc. — la escena
+                toma la piel del tema. */}
+            <span className="fvh-brand-a" data-theme-icon={theme} aria-hidden="true">{iconForTheme(theme)}</span>
             <div className="fvh-brand-txt">
               <b>Chagra</b>
               <span>Su finca viva</span>

--- a/src/components/dashboard/__tests__/FincaVivaHero.theme.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaHero.theme.test.jsx
@@ -1,0 +1,57 @@
+/**
+ * FincaVivaHero — la ESCENA/hero toma la PIEL del TEMA ACTIVO (los 4 temas).
+ *
+ * La escena se ve bajo CUALQUIER tema (la monta la flag de finca viva, no el
+ * tema). Aquí verificamos que el hero adopta la piel del tema activo: el ícono
+ * de marca del agente sigue al tema (la A roja en biopunk, la sol-mano frondosa
+ * en verde-vivo, el frailejón en nature, el monoline en minimalista). La piel de
+ * COLOR (cielo/sol/paleta) sale de los tokens "--c-" y "--fvh-" del CSS (contrato
+ * de estilos cubierto aparte; aquí basta con que el cableado por tema sea correcto).
+ */
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Datos de finca deterministas (no necesitamos datos reales para el cableado).
+vi.mock('../../../db/farmProcessCache', () => ({ listFarmProcesses: vi.fn(async () => []) }));
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [], lands: [], materials: [], isHydrated: true }),
+}));
+vi.mock('../../../services/userProfileService', () => ({ getProfile: () => ({ rol: 'campesino' }) }));
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => false,
+}));
+
+// Tema activo controlable: el hero debe pedirle al tema su ícono de marca.
+let activeTheme = 'biopunk';
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: activeTheme, setTheme: vi.fn() }),
+}));
+
+// themeIcon stub identificable por tema para aseverar el ícono efectivo.
+vi.mock('../themeIcon', () => ({
+  iconForTheme: (theme) => <svg data-testid={`brand-icon-${theme}`} />,
+}));
+
+import FincaVivaHero from '../FincaVivaHero';
+
+beforeEach(() => {
+  activeTheme = 'biopunk';
+  vi.clearAllMocks();
+});
+afterEach(() => cleanup());
+
+describe('FincaVivaHero — piel del tema activo (los 4 temas)', () => {
+  for (const theme of ['biopunk', 'nature', 'minimalista', 'verde-vivo']) {
+    test(`con tema "${theme}" la escena usa el ícono de marca de ese tema`, () => {
+      activeTheme = theme;
+      render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+      // El hero/escena se renderiza bajo el tema activo…
+      expect(screen.getByTestId('finca-viva-hero')).toBeInTheDocument();
+      // …y su marca toma el ícono del tema activo (la piel del tema).
+      expect(screen.getByTestId(`brand-icon-${theme}`)).toBeInTheDocument();
+    });
+  }
+});

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -32,19 +32,29 @@
   src: url('/fonts/nunito-latin.woff2') format('woff2');
 }
 
-/* ── Variables de paleta REAL Mi Finca Viva (WORLD_STAGES nivel 3) ─────────── */
+/* ── Variables de paleta de Mi Finca Viva — PIEL POR TEMA ───────────────────
+   La escena/hero ya se ve bajo CUALQUIER tema (la monta la flag, no el tema).
+   Para que tome la PIEL del tema activo (como los bocetos aprobados: misma
+   disposición+escena, distinta piel), la paleta del hero deriva de los tokens
+   --c-* del tema (index.css/themes.css) con un FALLBACK al look "Verde Vivo"
+   original. Así cambian con el tema: el cielo del shell, la marca, el título de
+   portales, el hero text, las sombras. Cada tema afina además el cielo/verde/
+   sol de la ESCENA en su bloque [data-theme] más abajo.
+
+   Default (sin data-theme = bio-punk base) y verde-vivo comparten el look vivo
+   original; nature y minimalista lo retiñen a su piel cálida/papel. */
 .fvh {
   --fvh-cielo-a: #7ac3da;
   --fvh-cielo-b: #c8e8cb;
-  --fvh-verde-1: #3f8f4e;
+  --fvh-verde-1: rgb(var(--c-emerald-400, 63 143 78));
   --fvh-sol-a: #fff3c4;
   --fvh-sol-b: #ffd24d;
   --fvh-lima: #a3e635;
   --fvh-lima-claro: #bef264;
-  --fvh-crema: #fbf6e9;
-  --fvh-tinta: #26331f;
-  --fvh-tinta-suave: #4e5c42;
-  --fvh-sello: #2f6b3a;
+  --fvh-crema: rgb(var(--c-surface-card, 251 246 233));
+  --fvh-tinta: rgb(var(--c-slate-100, 38 51 31));
+  --fvh-tinta-suave: rgb(var(--c-slate-300, 78 92 66));
+  --fvh-sello: rgb(var(--c-emerald-500, 47 107 58));
   --fvh-sombra-iso: rgba(60, 44, 20, 0.30);
   --fvh-r: 24px;
   --fvh-max: 1180px;          /* ancho máximo del shell en desktop */
@@ -76,6 +86,49 @@
 .fvh[data-luz="amanecer"] { --fvh-cielo-a: #f3b58c; }
 .fvh[data-luz="atardecer"] { --fvh-cielo-a: #f0a072; }
 
+/* ── PIEL DE LA ESCENA POR TEMA (operador 2026-06-24) ──────────────────────
+   La MISMA escena/disposición, distinta piel: cada tema retiñe el cielo, el
+   verde y el sol del shell de la escena para que combine con su paleta. El
+   contenido (las plantas, los animales, el colibrí) es el mismo; lo que cambia
+   es la ATMÓSFERA de color, como en los bocetos aprobados.
+
+   · Default (sin data-theme = bio-punk base) y VERDE VIVO → cielo fresco vivo +
+     verde-hoja + sol dorado (el look original de la finca viva).
+   · NATURE → cielo crema cálido + verde salvia + sol ámbar (piel terrosa).
+   · MINIMALISTA → cielo papel claro + verde sobrio + sol pálido (piel limpia).
+   El acento --fvh-verde-1/--fvh-sello ya salen de --c-* (arriba); aquí ajustamos
+   el degradado del cielo del shell, que es lo que más "tiñe" la escena. */
+
+/* VERDE VIVO — refuerza el cielo fresco-verde y el sol dorado de la identidad. */
+[data-theme="verde-vivo"] .fvh {
+  --fvh-cielo-a: #8fd1c2;     /* turquesa-verde fresco */
+  --fvh-cielo-b: #e2f0cf;     /* verde-crema frondoso */
+  --fvh-sol-a: #fff3c4;
+  --fvh-sol-b: #f2b441;       /* sol cálido de la identidad */
+  --fvh-lima: #6cc24a;
+  --fvh-lima-claro: #a7e17a;
+}
+
+/* NATURE — cielo crema cálido + sol ámbar (piel terrosa del tema). */
+[data-theme="nature"] .fvh {
+  --fvh-cielo-a: #ead7b0;     /* crema cálida */
+  --fvh-cielo-b: #f6efe0;     /* crema base del tema */
+  --fvh-sol-a: #ffe6a8;
+  --fvh-sol-b: #d9742a;       /* ocre quemado del tema */
+  --fvh-lima: #c8a02f;
+  --fvh-lima-claro: #e6c873;
+}
+
+/* MINIMALISTA — cielo papel claro + verde sobrio + sol pálido. */
+[data-theme="minimalista"] .fvh {
+  --fvh-cielo-a: #d8e2da;     /* gris-salvia claro */
+  --fvh-cielo-b: #f6f3ec;     /* papel del tema */
+  --fvh-sol-a: #f4efd8;
+  --fvh-sol-b: #cbb96a;       /* dorado apagado */
+  --fvh-lima: #6f9a85;
+  --fvh-lima-claro: #b6d3c4;
+}
+
 /* ── SHELL de ancho máximo (clave del responsive desktop #7) ───────────────── */
 .fvh-shell {
   position: relative;
@@ -102,7 +155,10 @@
   gap: 11px;
   flex: 0 0 auto;
 }
-/* A ROJA del agente (THEME_ICON.biopunk) — feedback #4 */
+/* Ícono de marca del agente del tema activo — feedback #4. Plinto OSCURO por
+   defecto (la A roja biopunk luce sobre fondo oscuro). Para los temas de piel
+   CLARA (nature, minimalista, verde-vivo) el ícono es verde/tierra/monoline y
+   debe ir sobre un plinto CLARO del tema, no sobre el cuadro negro rojizo. */
 .fvh-brand-a {
   width: 46px;
   height: 46px;
@@ -114,6 +170,14 @@
   background: radial-gradient(circle at 32% 26%, #2a2024, #140d10);
   box-shadow: 0 6px 16px rgba(120, 20, 20, 0.32),
               0 0 0 1.5px rgba(231, 76, 60, 0.55) inset;
+}
+/* Temas de piel clara → plinto claro del tema (superficie + borde --c-*). */
+[data-theme="verde-vivo"] .fvh-brand-a,
+[data-theme="nature"] .fvh-brand-a,
+[data-theme="minimalista"] .fvh-brand-a {
+  background: rgb(var(--c-surface-card));
+  box-shadow: 0 6px 16px rgba(40, 60, 30, 0.18),
+              0 0 0 1.5px rgb(var(--c-surface-border)) inset;
 }
 .fvh-brand-a svg { width: 100%; height: 100%; display: block; }
 .fvh-brand-txt { line-height: 1.04; }

--- a/src/components/dashboard/themeIcon.jsx
+++ b/src/components/dashboard/themeIcon.jsx
@@ -15,6 +15,9 @@
  *     Las clases `aforge`/`aforge-fill` activan la animación de forja
  *     one-shot (stroke-dashoffset) definida en index.css.
  *   - minimalista: círculo + brote-horqueta monoline, acento verde sobrio
+ *   - verde-vivo: SOL-MANO radial de la finca viva — hojas frondosas que
+ *     irradian de un centro solar cálido (identidad Chagra: mano radial +
+ *     solar/soberanía). Verde-hoja vivo + sol/ocre cálido. rsvg-safe.
  */
 
 import React from 'react';
@@ -107,6 +110,37 @@ export const THEME_ICON = {
             <circle cx="60" cy="60" r="46" fill="none" stroke="#2b2b2b" strokeWidth="7" />
             <path d="M60 90 V58 M60 58 L44 40 M60 58 L76 40" fill="none" stroke="#2b2b2b" strokeWidth="7" strokeLinecap="round" strokeLinejoin="round" />
             <circle cx="44" cy="40" r="7" fill="#19a585" /><circle cx="76" cy="40" r="7" fill="#19a585" />
+        </svg>
+    ),
+    // Verde Vivo — SOL-MANO radial de la finca viva: hojas frondosas que
+    // irradian de un centro solar cálido (mano de Chagra + solar/soberanía).
+    // Verde-hoja vivo (#2e8b3d/#3fae54) + sol/ocre cálido (#e0922e/#f2b441).
+    'verde-vivo': (
+        <svg viewBox="0 0 120 120" fill="none" width="100%" height="100%" aria-hidden="true">
+            {/* sol cálido central (centro de la mano radial) */}
+            <circle cx="60" cy="60" r="15" fill="#f2b441" />
+            <circle cx="60" cy="60" r="9.5" fill="#e0922e" />
+            {/* hojas frondosas que irradian del centro — la "mano" de la finca */}
+            <g fill="#2e8b3d">
+                {/* arriba */}
+                <path d="M60 50 C52 38 53 22 60 12 C67 22 68 38 60 50 Z" />
+                {/* arriba-derecha */}
+                <path d="M68 54 C77 46 91 42 104 44 C97 55 84 62 71 60 Z" />
+                {/* abajo-derecha */}
+                <path d="M67 67 C78 70 90 80 95 92 C82 92 70 85 63 74 Z" />
+                {/* abajo-izquierda */}
+                <path d="M53 67 C42 70 30 80 25 92 C38 92 50 85 57 74 Z" />
+                {/* arriba-izquierda */}
+                <path d="M52 54 C43 46 29 42 16 44 C23 55 36 62 49 60 Z" />
+            </g>
+            {/* nervaduras vivas (verde claro) sobre las hojas */}
+            <g stroke="#bdf38a" strokeWidth="2.4" strokeLinecap="round" opacity="0.85">
+                <path d="M60 46 V18" />
+                <path d="M70 56 L98 47" />
+                <path d="M64 70 L90 88" />
+                <path d="M56 70 L30 88" />
+                <path d="M50 56 L22 47" />
+            </g>
         </svg>
     ),
 };

--- a/src/hooks/__tests__/useTheme.verdeVivo.test.js
+++ b/src/hooks/__tests__/useTheme.verdeVivo.test.js
@@ -1,0 +1,78 @@
+/**
+ * useTheme — 4º tema "Verde Vivo" (la piel de la finca viva).
+ * ============================================================
+ * El 4º tema existe y se registra como id VÁLIDO siempre (para que una
+ * selección persistida sobreviva y applyTheme la pueda escribir), pero su
+ * VISIBILIDAD en el selector la gobierna la flag de finca viva:
+ *
+ *   · getSelectableThemes(true)  → 3 temas + auto + Verde Vivo (dev).
+ *   · getSelectableThemes(false) → EXACTO los 3 temas + auto de hoy (prod).
+ *
+ * Innegociable: con la flag OFF el selector es idéntico al de hoy.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useTheme,
+  applyTheme,
+  THEME_IDS,
+  THEMES,
+  VERDE_VIVO_THEME,
+  getSelectableThemes,
+  normalizeTheme,
+  STORAGE_KEY,
+} from '../useTheme';
+
+describe('useTheme — 4º tema Verde Vivo', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('el 4º tema existe y se registra (id verde-vivo válido)', () => {
+    expect(VERDE_VIVO_THEME.id).toBe('verde-vivo');
+    expect(VERDE_VIVO_THEME.label).toBe('Verde Vivo');
+    expect(THEME_IDS).toContain('verde-vivo');
+    // normalizeTheme lo acepta (NO cae al default): una selección persistida
+    // de verde-vivo sobrevive a un reload.
+    expect(normalizeTheme('verde-vivo')).toBe('verde-vivo');
+  });
+
+  it('NO va en el catálogo base THEMES (los 3 temas + auto de siempre)', () => {
+    expect(THEMES.map((t) => t.id)).toEqual([
+      'auto',
+      'biopunk',
+      'nature',
+      'minimalista',
+    ]);
+    expect(THEMES.map((t) => t.id)).not.toContain('verde-vivo');
+  });
+
+  it('flag ON (dev): el selector muestra el 4º tema al final', () => {
+    const ids = getSelectableThemes(true).map((t) => t.id);
+    expect(ids).toEqual(['auto', 'biopunk', 'nature', 'minimalista', 'verde-vivo']);
+  });
+
+  it('flag OFF (prod): el selector es EXACTO el de hoy (sin verde-vivo)', () => {
+    const ids = getSelectableThemes(false).map((t) => t.id);
+    expect(ids).toEqual(['auto', 'biopunk', 'nature', 'minimalista']);
+    expect(ids).not.toContain('verde-vivo');
+  });
+
+  it('applyTheme(verde-vivo) escribe data-theme="verde-vivo" en <html>', () => {
+    const resolved = applyTheme('verde-vivo');
+    expect(resolved).toBe('verde-vivo');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('verde-vivo');
+  });
+
+  it('setTheme(verde-vivo) persiste y aplica (es un id seleccionable)', () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => result.current.setTheme('verde-vivo'));
+    expect(result.current.theme).toBe('verde-vivo');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('verde-vivo');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('verde-vivo');
+  });
+});

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -11,6 +11,11 @@ import { useEffect, useState, useCallback } from 'react';
  *                           Es el estilo BASE de la app → NO escribe data-theme.
  *   - nature              → cálido botánico (terracota/salvia/ocre).
  *   - minimalista         → limpio, crema, monoline verde #2f6e5a.
+ *   - verde-vivo          → la PIEL propia de la finca viva: verde frondoso +
+ *                           sol cálido + tierra/ocre (identidad Chagra). SOLO
+ *                           visible en el selector con la flag de finca viva ON
+ *                           (VITE_FINCA_VIVA_HOME_PERFIL); con la flag OFF el
+ *                           selector muestra EXACTO los 3 temas de hoy.
  *
  * Más un modo `auto` que alterna entre minimalista (día) y bio-punk (noche).
  *
@@ -49,8 +54,42 @@ export const THEMES = Object.freeze([
   }),
 ]);
 
-/** Ids válidos seleccionables (los 3 temas curados + auto). */
-export const THEME_IDS = Object.freeze(THEMES.map((t) => t.id));
+/**
+ * VERDE VIVO — 4º tema, la PIEL propia de la finca viva. NO va en `THEMES`
+ * (el catálogo base de los 3 temas + auto que ve todo el mundo): es un tema
+ * gateado tras la flag de finca viva. El selector lo añade SOLO cuando la flag
+ * está ON (ver getSelectableThemes); con la flag OFF, el selector es EXACTO el
+ * de hoy (3 temas + auto). Su id sí es válido siempre en THEME_IDS para que una
+ * selección persistida sobreviva y applyTheme la pueda escribir.
+ */
+export const VERDE_VIVO_THEME = Object.freeze({
+  id: 'verde-vivo',
+  label: 'Verde Vivo',
+  desc: 'Verde frondoso, sol cálido y tierra — la piel de tu finca viva.',
+});
+
+/**
+ * Ids válidos seleccionables (los 3 temas curados + auto + verde-vivo). El 4º
+ * tema es id VÁLIDO siempre (normalizeTheme/setTheme lo aceptan) aunque su
+ * VISIBILIDAD en el selector dependa de la flag de finca viva.
+ */
+export const THEME_IDS = Object.freeze([
+  ...THEMES.map((t) => t.id),
+  VERDE_VIVO_THEME.id,
+]);
+
+/**
+ * Catálogo de temas VISIBLES en el selector según la flag de finca viva.
+ * Con la flag ON (dev) aparece el 4º tema "Verde Vivo" al final; con la flag
+ * OFF (prod) devuelve EXACTO los 3 temas + auto de hoy — sin cambios para el
+ * usuario de producción.
+ *
+ * @param {boolean} fincaVivaOn  resultado de fincaVivaHomePerfilActivo().
+ * @returns {ReadonlyArray<{id:string,label:string,desc:string}>}
+ */
+export function getSelectableThemes(fincaVivaOn) {
+  return fincaVivaOn ? [...THEMES, VERDE_VIVO_THEME] : THEMES;
+}
 
 /**
  * Normaliza un id persistido: cualquier valor desconocido o legado

--- a/src/index.css
+++ b/src/index.css
@@ -198,6 +198,62 @@
   --scrim-opacity: 0.12;
 }
 
+/* VERDE VIVO — la PIEL propia de la finca viva (operador 2026-06-24): verde
+ * frondoso + sol cálido + tierra/ocre. Es la identidad por defecto del home F2
+ * (mano radial, solar/soberanía Chagra) como su skin. Tema CLARO y vivo: fondo
+ * crema con tinte verde fresco, tinta bosque profundo, acento verde-hoja
+ * vibrante (#2e8b3d) + sol/ocre cálido (#e0922e / #f2b441 / tierra #8a5a2b).
+ * Rampa slate invertida y entonada verde-cálida (como nature, pero más viva y
+ * más verde). Cumple AA: tinta bosque sobre crema = 13.3:1 (sonda). */
+[data-theme="verde-vivo"] {
+  --c-slate-950: 238 243 226;  /* fondo base = crema frondosa (#eef3e2) */
+  --c-slate-900: 251 253 244;  /* card / superficie (blanco hueso verdoso) */
+  --c-slate-800: 233 240 216;  /* raised (#e9f0d8) */
+  --c-slate-700: 200 214 168;  /* línea / borde (verde salvia claro #c8d6a8) */
+  --c-slate-600: 214 224 188;  /* borde suave (#d6e0bc) */
+  --c-slate-500: 106 122 78;   /* terciario / placeholder (verde-oliva #6a7a4e) */
+  --c-slate-400: 86 100 60;    /* secundario (#56643c) */
+  --c-slate-300: 64 80 44;     /* texto fuerte (verde bosque medio #40502c) */
+  --c-slate-200: 40 56 26;     /* casi tinta */
+  --c-slate-100: 28 42 22;     /* tinta = bosque profundo (#1c2a16) */
+  --c-slate-50: 18 30 14;      /* tinta más oscura */
+  --c-emerald-200: 220 236 200; /* verde claro suave */
+  --c-emerald-300: 58 132 70;   /* verde-hoja medio (AA sobre crema) */
+  --c-emerald-400: 46 139 61;   /* VERDE VIVO frondoso (acento) #2e8b3d */
+  --c-emerald-500: 40 122 52;   /* verde profundo */
+  --c-emerald-600: 34 102 44;
+  --c-emerald-700: 34 84 40;    /* verde bosque (números impacto, AA sobre crema) */
+  --c-emerald-800: 26 64 32;
+  --c-emerald-900: 220 236 200;
+  --c-amber-200: 250 226 170;
+  --c-amber-300: 235 170 70;
+  --c-amber-400: 242 180 65;   /* sol dorado (#f2b441) */
+  --c-amber-500: 224 146 46;   /* sol cálido / ocre (#e0922e) */
+  --c-amber-600: 196 122 42;
+  --c-amber-700: 138 90 43;    /* tierra / ocre profundo (#8a5a2b) */
+  --c-amber-900: 245 230 200;
+  --c-surface: 238 243 226;
+  --c-surface-card: 251 253 244;
+  --c-surface-raised: 233 240 216;
+  --c-surface-border: 200 214 168;
+  /* acentos: verde-hoja vivo + sol/ocre cálido + tierra. */
+  --c-muzo: 46 139 61;          /* verde vivo */
+  --c-muzo-glow: 88 176 96;
+  --c-morpho: 46 139 61;        /* verde vivo */
+  --c-morpho-glow: 88 176 96;
+  --c-orchid: 224 146 46;       /* sol cálido / ocre (acento secundario) */
+  --c-orchid-glow: 242 180 65;
+  --c-frog: 242 180 65;
+  --c-frog-glow: 250 200 90;
+  /* FX OFF — verde-vivo es un degradado vivo, no confeti/glow neón. El velo de
+   * fondo es un crema verdoso sutil que NO lava la escena. */
+  --fx-particles: 0;
+  --fx-glow-opacity: 0;
+  --fx-bg-pattern: 0;
+  --scrim-bg: 238 243 226;  /* velo = crema frondosa del tema → vela suave */
+  --scrim-opacity: 0.12;
+}
+
 @layer base {
   :root {
     font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/src/styles/__tests__/themes.coverage.test.js
+++ b/src/styles/__tests__/themes.coverage.test.js
@@ -54,7 +54,7 @@ describe('temas claros — indirección CSS-var (index.css)', () => {
     const uniqueBase = [...new Set(baseVars)];
     expect(uniqueBase.length, 'pocas vars --c-* en :root').toBeGreaterThan(25);
 
-    for (const theme of ['minimalista', 'nature']) {
+    for (const theme of ['minimalista', 'nature', 'verde-vivo']) {
       const blockMatch = indexCss.match(
         new RegExp(`\\[data-theme="${theme}"\\]\\s*\\{([\\s\\S]*?)\\}`)
       );
@@ -73,7 +73,7 @@ describe('temas claros — indirección CSS-var (index.css)', () => {
       const m = block.match(new RegExp(`${varName}:\\s*([0-9]+)\\s+([0-9]+)\\s+([0-9]+)`));
       return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
     };
-    for (const theme of ['minimalista', 'nature']) {
+    for (const theme of ['minimalista', 'nature', 'verde-vivo']) {
       const [r, g, b] = grab(theme, '--c-slate-950');
       const avg = (r + g + b) / 3;
       expect(avg, `${theme} --c-slate-950 debe ser claro`).toBeGreaterThan(200);
@@ -144,7 +144,7 @@ describe('contrato de efectos (FX) gateados por tema (index.css)', () => {
   it('redefine TODOS los --fx-*/--scrim-* en cada tema (sin tokens huérfanos)', () => {
     // Si un tema NO redefine un --fx-*, hereda el 1 de :root → FX bio-punk
     // sangrando sobre el tema claro. El contrato exige redefinición explícita.
-    for (const theme of ['minimalista', 'nature']) {
+    for (const theme of ['minimalista', 'nature', 'verde-vivo']) {
       const block = themeBlock(theme);
       expect(block, `falta bloque [data-theme="${theme}"]`).toBeTruthy();
       for (const v of [...FX_VARS, ...SCRIM_VARS]) {
@@ -154,7 +154,7 @@ describe('contrato de efectos (FX) gateados por tema (index.css)', () => {
   });
 
   it('los temas CLAROS apagan partículas, patrón y glow (--fx-*: 0)', () => {
-    for (const theme of ['minimalista', 'nature']) {
+    for (const theme of ['minimalista', 'nature', 'verde-vivo']) {
       const block = themeBlock(theme);
       expect(readScalar(block, '--fx-particles'), `${theme} --fx-particles`).toBe('0');
       expect(readScalar(block, '--fx-bg-pattern'), `${theme} --fx-bg-pattern`).toBe('0');
@@ -165,7 +165,7 @@ describe('contrato de efectos (FX) gateados por tema (index.css)', () => {
   it('el scrim de los temas claros es CLARO (velo crema, no navy que lava)', () => {
     // En claros el --scrim-bg debe ser claro (promedio > 200) → un velo sutil
     // sobre la imagen, nunca el navy 2 6 23 que oscurecía la foto.
-    for (const theme of ['minimalista', 'nature']) {
+    for (const theme of ['minimalista', 'nature', 'verde-vivo']) {
       const block = themeBlock(theme);
       const rgb = readRgb(block, '--scrim-bg');
       expect(rgb, `${theme} --scrim-bg ausente`).toBeTruthy();
@@ -182,6 +182,7 @@ describe('contraste AA del texto principal de cada tema (sonda numérica)', () =
     { theme: ':root', name: 'bio-punk' },
     { theme: 'minimalista', name: 'minimalista' },
     { theme: 'nature', name: 'nature' },
+    { theme: 'verde-vivo', name: 'verde-vivo' },
   ];
   for (const { theme, name } of cases) {
     it(`${name}: texto principal ≥4.5 sobre fondo y card`, () => {

--- a/src/styles/__tests__/verdeVivo.theme.test.js
+++ b/src/styles/__tests__/verdeVivo.theme.test.js
@@ -1,0 +1,118 @@
+/**
+ * Verde Vivo — contrato del 4º tema (la piel de la finca viva).
+ *
+ * Verifica que:
+ *   (a) index.css define el bloque [data-theme="verde-vivo"] con TODO el mapa
+ *       --c-* (ninguna var cae al default biopunk → "Frankenstein") + FX OFF +
+ *       scrim claro (es un tema de piel CLARA, como nature/minimalista).
+ *   (b) el texto principal pasa AA (≥4.5) sobre fondo y card.
+ *   (c) finca-viva-hero.css retiñe la ESCENA por tema (los 4 temas tienen su
+ *       piel de cielo/sol) y deriva la paleta del hero de los tokens --c-*.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexCss = readFileSync(join(__dirname, '..', '..', 'index.css'), 'utf8');
+const heroCss = readFileSync(
+  join(__dirname, '..', '..', 'components', 'dashboard', 'finca-viva-hero.css'),
+  'utf8',
+);
+
+function themeBlock(selector) {
+  const m = indexCss.match(
+    new RegExp(`\\[data-theme="${selector}"\\]\\s*\\{([\\s\\S]*?)\\}`),
+  );
+  return m ? m[1] : null;
+}
+function readScalar(block, varName) {
+  const m = block.match(new RegExp(`${varName}\\s*:\\s*([^;]+);`));
+  return m ? m[1].trim() : null;
+}
+function readRgb(block, varName) {
+  const m = block.match(
+    new RegExp(`${varName}\\s*:\\s*([0-9]+)\\s+([0-9]+)\\s+([0-9]+)`),
+  );
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+function contrastRatio(a, b) {
+  const lin = (c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const lum = ([r, g, b2]) => 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b2);
+  const l1 = lum(a);
+  const l2 = lum(b);
+  const hi = Math.max(l1, l2);
+  const lo = Math.min(l1, l2);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe('Verde Vivo — tokens del 4º tema (index.css)', () => {
+  it('define el bloque [data-theme="verde-vivo"]', () => {
+    expect(themeBlock('verde-vivo'), 'falta bloque verde-vivo').toBeTruthy();
+  });
+
+  it('redefine el mapa --c-* completo (ninguna var hereda biopunk)', () => {
+    const baseVars = [...new Set(
+      [...indexCss.matchAll(/(--c-[a-z0-9-]+)\s*:/g)].map((m) => m[1]),
+    )];
+    const block = themeBlock('verde-vivo');
+    for (const v of baseVars) {
+      expect(block.includes(`${v}:`), `verde-vivo no redefine ${v}`).toBe(true);
+    }
+  });
+
+  it('es un tema de piel CLARA: fondo y card claros (promedio > 200)', () => {
+    const block = themeBlock('verde-vivo');
+    for (const v of ['--c-slate-950', '--c-slate-900']) {
+      const [r, g, b] = readRgb(block, v);
+      expect((r + g + b) / 3, `verde-vivo ${v} debe ser claro`).toBeGreaterThan(200);
+    }
+  });
+
+  it('apaga los FX neón (partículas/glow/patrón = 0) y usa scrim claro', () => {
+    const block = themeBlock('verde-vivo');
+    expect(readScalar(block, '--fx-particles')).toBe('0');
+    expect(readScalar(block, '--fx-bg-pattern')).toBe('0');
+    expect(readScalar(block, '--fx-glow-opacity')).toBe('0');
+    const scrim = readRgb(block, '--scrim-bg');
+    expect((scrim[0] + scrim[1] + scrim[2]) / 3, 'scrim claro').toBeGreaterThan(200);
+  });
+
+  it('texto principal ≥4.5 (AA) sobre fondo y card', () => {
+    const block = themeBlock('verde-vivo');
+    const text = readRgb(block, '--c-slate-100');
+    const bg = readRgb(block, '--c-slate-950');
+    const card = readRgb(block, '--c-slate-900');
+    expect(contrastRatio(text, bg)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(text, card)).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe('Verde Vivo — la escena/hero toma la piel del tema (finca-viva-hero.css)', () => {
+  it('la paleta del hero deriva de los tokens --c-* del tema (no hex fijo)', () => {
+    // El verde, la tinta y el sello del hero salen de la indirección --c-*.
+    expect(heroCss).toMatch(/--fvh-verde-1:\s*rgb\(var\(--c-emerald-400/);
+    expect(heroCss).toMatch(/--fvh-tinta:\s*rgb\(var\(--c-slate-100/);
+    expect(heroCss).toMatch(/--fvh-sello:\s*rgb\(var\(--c-emerald-500/);
+  });
+
+  it('cada tema retiñe la ESCENA (cielo/sol) — los 4 temas tienen piel', () => {
+    // Default (.fvh sin data-theme) + un bloque por cada tema claro.
+    for (const sel of ['verde-vivo', 'nature', 'minimalista']) {
+      expect(
+        heroCss.includes(`[data-theme="${sel}"] .fvh`),
+        `falta la piel de escena del tema ${sel}`,
+      ).toBe(true);
+    }
+  });
+
+  it('el plinto del ícono de marca es claro en los temas de piel clara', () => {
+    expect(heroCss).toMatch(
+      /\[data-theme="verde-vivo"\] \.fvh-brand-a[\s\S]{0,200}--c-surface-card/,
+    );
+  });
+});

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -69,6 +69,17 @@
   --t-bg-rgb: 251, 245, 234;     /* crema */
 }
 
+/* VERDE VIVO — la piel de la finca viva: acento VERDE-HOJA vivo (#2e8b3d) para
+ * el botón enviar/wordmark/halo, con matices más profundos para el wordmark y
+ * el hint (AA sobre la crema frondosa). El --t-bg-rgb es el crema verdoso del
+ * tema (para el agujero del halo del agente). */
+[data-theme="verde-vivo"] {
+  --t-accent-rgb: 46, 139, 61;   /* verde vivo frondoso (#2e8b3d) */
+  --t-accent-strong-rgb: 34, 102, 44;   /* verde profundo (wordmark) */
+  --t-accent-deep-rgb: 34, 84, 40;      /* verde bosque (hint/marca) */
+  --t-bg-rgb: 238, 243, 226;     /* crema frondosa del tema */
+}
+
 /* ===========================================================================
  * 0b. ELEMENTOS DE MARCA con el acento del tema (botón enviar + wordmark).
  *    Antes usaban un degradé lime/emerald fijo (no theme-aware en `lime`) → se
@@ -82,8 +93,10 @@
   background-color: rgb(var(--t-accent-rgb)) !important;
   color: #04231b !important;  /* tinta oscura — AA sobre teal/ocre claros */
 }
-/* Sobre acentos oscuros (verde minimalista) la tinta oscura no contrasta → blanco */
-[data-theme="minimalista"] .agent-send-accent {
+/* Sobre acentos oscuros (verde minimalista / verde-vivo) la tinta oscura no
+   contrasta → blanco */
+[data-theme="minimalista"] .agent-send-accent,
+[data-theme="verde-vivo"] .agent-send-accent {
   color: #fff !important;
 }
 
@@ -214,7 +227,8 @@
   color: rgb(var(--c-slate-100));
 }
 
-[data-theme="minimalista"] .onboarding-piso-primary {
+[data-theme="minimalista"] .onboarding-piso-primary,
+[data-theme="verde-vivo"] .onboarding-piso-primary {
   color: #fff;
 }
 
@@ -263,7 +277,8 @@
   z-index: -1;
 }
 [data-theme="nature"] .agent-immersive-topbar::before,
-[data-theme="minimalista"] .agent-immersive-topbar::before {
+[data-theme="minimalista"] .agent-immersive-topbar::before,
+[data-theme="verde-vivo"] .agent-immersive-topbar::before{
   background: linear-gradient(180deg, rgb(var(--c-surface-raised) / 0.7) 0%, rgb(var(--c-surface-raised) / 0) 100%);
 }
 
@@ -276,12 +291,14 @@
  * =========================================================================== */
 
 [data-theme="nature"] .login-bg-photo,
-[data-theme="minimalista"] .login-bg-photo {
+[data-theme="minimalista"] .login-bg-photo,
+[data-theme="verde-vivo"] .login-bg-photo{
   display: none !important;
 }
 
 [data-theme="nature"] .bg-biopunk-pattern,
-[data-theme="minimalista"] .bg-biopunk-pattern {
+[data-theme="minimalista"] .bg-biopunk-pattern,
+[data-theme="verde-vivo"] .bg-biopunk-pattern{
   background-image: none !important;
 }
 
@@ -295,7 +312,8 @@
  * =========================================================================== */
 
 [data-theme="nature"] .chagra-hero-halo,
-[data-theme="minimalista"] .chagra-hero-halo {
+[data-theme="minimalista"] .chagra-hero-halo,
+[data-theme="verde-vivo"] .chagra-hero-halo{
   background: conic-gradient(
     from 0deg,
     rgba(var(--t-accent-rgb), 0.42),
@@ -306,7 +324,8 @@
 }
 
 [data-theme="nature"] .chagra-hero-halo-inner,
-[data-theme="minimalista"] .chagra-hero-halo-inner {
+[data-theme="minimalista"] .chagra-hero-halo-inner,
+[data-theme="verde-vivo"] .chagra-hero-halo-inner{
   background: radial-gradient(
     circle,
     rgba(var(--t-bg-rgb), 0) 50%,
@@ -338,7 +357,14 @@
 [data-theme="nature"] .bg-sky-950\/40,
 [data-theme="nature"] .bg-orange-950\/40,
 [data-theme="nature"] .bg-violet-950\/40,
-[data-theme="nature"] .bg-yellow-950\/40 {
+[data-theme="nature"] .bg-yellow-950\/40,
+[data-theme="verde-vivo"] .bg-cyan-950\/40,
+[data-theme="verde-vivo"] .bg-lime-950\/40,
+[data-theme="verde-vivo"] .bg-fuchsia-950\/40,
+[data-theme="verde-vivo"] .bg-sky-950\/40,
+[data-theme="verde-vivo"] .bg-orange-950\/40,
+[data-theme="verde-vivo"] .bg-violet-950\/40,
+[data-theme="verde-vivo"] .bg-yellow-950\/40{
   background-color: rgb(var(--c-surface-raised)) !important;
 }
 
@@ -355,7 +381,14 @@
 [data-theme="nature"] .border-sky-800\/60,
 [data-theme="nature"] .border-orange-800\/60,
 [data-theme="nature"] .border-violet-800\/60,
-[data-theme="nature"] .border-yellow-800\/60 {
+[data-theme="nature"] .border-yellow-800\/60,
+[data-theme="verde-vivo"] .border-cyan-800\/60,
+[data-theme="verde-vivo"] .border-lime-800\/60,
+[data-theme="verde-vivo"] .border-fuchsia-800\/60,
+[data-theme="verde-vivo"] .border-sky-800\/60,
+[data-theme="verde-vivo"] .border-orange-800\/60,
+[data-theme="verde-vivo"] .border-violet-800\/60,
+[data-theme="verde-vivo"] .border-yellow-800\/60{
   border-color: rgb(var(--c-surface-border)) !important;
 }
 
@@ -381,7 +414,15 @@
 [data-theme="nature"] .text-orange-300,
 [data-theme="nature"] .text-violet-300,
 [data-theme="nature"] .text-violet-400,
-[data-theme="nature"] .text-yellow-300 {
+[data-theme="nature"] .text-yellow-300,
+[data-theme="verde-vivo"] .text-cyan-300,
+[data-theme="verde-vivo"] .text-lime-300,
+[data-theme="verde-vivo"] .text-fuchsia-300,
+[data-theme="verde-vivo"] .text-sky-300,
+[data-theme="verde-vivo"] .text-orange-300,
+[data-theme="verde-vivo"] .text-violet-300,
+[data-theme="verde-vivo"] .text-violet-400,
+[data-theme="verde-vivo"] .text-yellow-300{
   color: rgb(var(--c-emerald-700)) !important;  /* verde profundo cálido (AA) */
   text-shadow: none !important;
 }
@@ -412,7 +453,9 @@
 [data-theme="minimalista"] [data-testid="altitude-badge"],
 [data-theme="nature"] [data-testid="altitude-badge"],
 [data-theme="minimalista"] [data-testid="ai-beta-badge"][data-confidence-level="low"],
-[data-theme="nature"] [data-testid="ai-beta-badge"][data-confidence-level="low"] {
+[data-theme="nature"] [data-testid="ai-beta-badge"][data-confidence-level="low"],
+[data-theme="verde-vivo"] [data-testid="altitude-badge"],
+[data-theme="verde-vivo"] [data-testid="ai-beta-badge"][data-confidence-level="low"]{
   background-color: rgb(var(--c-surface-raised)) !important;
   border-color: rgb(var(--c-surface-border)) !important;
 }
@@ -426,7 +469,9 @@
   text-shadow: none !important;
 }
 [data-theme="nature"] [data-testid="altitude-badge"],
-[data-theme="nature"] [data-testid="ai-beta-badge"][data-confidence-level="low"] {
+[data-theme="nature"] [data-testid="ai-beta-badge"][data-confidence-level="low"],
+[data-theme="verde-vivo"] [data-testid="altitude-badge"],
+[data-theme="verde-vivo"] [data-testid="ai-beta-badge"][data-confidence-level="low"]{
   color: rgb(var(--c-emerald-700)) !important;  /* verde profundo cálido (AA) */
   text-shadow: none !important;
 }
@@ -443,7 +488,8 @@
 
 /* Superficie: matar el gradiente sky/indigo → tarjeta del tema */
 [data-theme="nature"] .from-sky-950\/70,
-[data-theme="minimalista"] .from-sky-950\/70 {
+[data-theme="minimalista"] .from-sky-950\/70,
+[data-theme="verde-vivo"] .from-sky-950\/70{
   background-image: none !important;
   background-color: rgb(var(--c-surface-card)) !important;
 }
@@ -452,13 +498,16 @@
 [data-theme="nature"] .border-sky-800\/40,
 [data-theme="nature"] .border-sky-500\/40,
 [data-theme="minimalista"] .border-sky-800\/40,
-[data-theme="minimalista"] .border-sky-500\/40 {
+[data-theme="minimalista"] .border-sky-500\/40,
+[data-theme="verde-vivo"] .border-sky-800\/40,
+[data-theme="verde-vivo"] .border-sky-500\/40{
   border-color: rgb(var(--c-surface-border)) !important;
 }
 
 /* Texto sky claro → tinta del tema (AA sobre crema/papel) */
 [data-theme="nature"] .text-sky-200,
-[data-theme="minimalista"] .text-sky-200 {
+[data-theme="minimalista"] .text-sky-200,
+[data-theme="verde-vivo"] .text-sky-200{
   color: rgb(var(--c-slate-100)) !important;
 }
 
@@ -466,7 +515,9 @@
 [data-theme="nature"] .bg-sky-700\/30,
 [data-theme="nature"] .bg-sky-600\/40,
 [data-theme="minimalista"] .bg-sky-700\/30,
-[data-theme="minimalista"] .bg-sky-600\/40 {
+[data-theme="minimalista"] .bg-sky-600\/40,
+[data-theme="verde-vivo"] .bg-sky-700\/30,
+[data-theme="verde-vivo"] .bg-sky-600\/40{
   background-color: rgb(var(--t-accent-rgb)) !important;
   color: #fff !important;
 }
@@ -484,7 +535,14 @@
 [data-theme="nature"] .bg-sky-500,
 [data-theme="nature"] .bg-orange-500,
 [data-theme="nature"] .bg-violet-500,
-[data-theme="nature"] .bg-yellow-500 {
+[data-theme="nature"] .bg-yellow-500,
+[data-theme="verde-vivo"] .bg-cyan-500,
+[data-theme="verde-vivo"] .bg-lime-500,
+[data-theme="verde-vivo"] .bg-fuchsia-500,
+[data-theme="verde-vivo"] .bg-sky-500,
+[data-theme="verde-vivo"] .bg-orange-500,
+[data-theme="verde-vivo"] .bg-violet-500,
+[data-theme="verde-vivo"] .bg-yellow-500{
   background-color: rgb(var(--c-emerald-400)) !important;
 }
 
@@ -506,13 +564,16 @@
 
 /* Texto blanco → tinta legible del tema (slate-100 ya es tinta en claro). */
 [data-theme="minimalista"] .text-white,
-[data-theme="nature"] .text-white {
+[data-theme="nature"] .text-white,
+[data-theme="verde-vivo"] .text-white{
   color: rgb(var(--c-slate-100)) !important;
 }
 [data-theme="minimalista"] .text-white\/70,
 [data-theme="minimalista"] .text-white\/60,
 [data-theme="nature"] .text-white\/70,
-[data-theme="nature"] .text-white\/60 {
+[data-theme="nature"] .text-white\/60,
+[data-theme="verde-vivo"] .text-white\/70,
+[data-theme="verde-vivo"] .text-white\/60{
   color: rgb(var(--c-slate-300)) !important; /* secundario, un punto más suave */
 }
 
@@ -528,7 +589,11 @@
 [data-theme="nature"] .bg-emerald-500.text-white,
 [data-theme="nature"] .bg-emerald-600.text-white,
 [data-theme="nature"] .bg-sky-500.text-white,
-[data-theme="nature"] .bg-muzo.text-white {
+[data-theme="nature"] .bg-muzo.text-white,
+[data-theme="verde-vivo"] .bg-emerald-500.text-white,
+[data-theme="verde-vivo"] .bg-emerald-600.text-white,
+[data-theme="verde-vivo"] .bg-sky-500.text-white,
+[data-theme="verde-vivo"] .bg-muzo.text-white{
   color: #fff !important;
 }
 
@@ -549,7 +614,12 @@
 [data-theme="nature"] .text-amber-200,
 [data-theme="nature"] .text-amber-300,
 [data-theme="nature"] .text-amber-400,
-[data-theme="nature"] .text-amber-500 {
+[data-theme="nature"] .text-amber-500,
+[data-theme="verde-vivo"] .text-amber-100,
+[data-theme="verde-vivo"] .text-amber-200,
+[data-theme="verde-vivo"] .text-amber-300,
+[data-theme="verde-vivo"] .text-amber-400,
+[data-theme="verde-vivo"] .text-amber-500{
   color: rgb(160, 76, 20) !important;
   text-shadow: none !important;
 }
@@ -558,7 +628,9 @@
 [data-theme="minimalista"] .border-white,
 [data-theme="minimalista"] [class*="border-white\/"],
 [data-theme="nature"] .border-white,
-[data-theme="nature"] [class*="border-white\/"] {
+[data-theme="nature"] [class*="border-white\/"],
+[data-theme="verde-vivo"] .border-white,
+[data-theme="verde-vivo"] [class*="border-white\/"]{
   border-color: rgb(var(--c-surface-border)) !important;
 }
 
@@ -567,7 +639,8 @@
  * se distingue del fondo crema en vez de desaparecer. NO tocamos `bg-white`
  * SÓLIDO (sin barra de opacidad) que es la card clara correcta. */
 [data-theme="minimalista"] [class*="bg-white\/"],
-[data-theme="nature"] [class*="bg-white\/"] {
+[data-theme="nature"] [class*="bg-white\/"],
+[data-theme="verde-vivo"] [class*="bg-white\/"]{
   background-color: rgb(var(--c-surface-raised) / 0.55) !important;
 }
 
@@ -621,7 +694,8 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
   border-color: rgb(var(--c-emerald-600) / 0.5);
 }
 [data-theme="minimalista"] .glaciar-estado-estable,
-[data-theme="nature"] .glaciar-estado-estable {
+[data-theme="nature"] .glaciar-estado-estable,
+[data-theme="verde-vivo"] .glaciar-estado-estable{
   background-color: rgb(var(--c-emerald-200) / 0.4);
   border-color: rgb(var(--c-emerald-500) / 0.6);
 }
@@ -631,7 +705,8 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
   border-color: rgb(var(--c-amber-600) / 0.5);
 }
 [data-theme="minimalista"] .glaciar-estado-precaucion,
-[data-theme="nature"] .glaciar-estado-precaucion {
+[data-theme="nature"] .glaciar-estado-precaucion,
+[data-theme="verde-vivo"] .glaciar-estado-precaucion{
   background-color: rgb(var(--c-amber-200) / 0.4);
   border-color: rgb(var(--c-amber-500) / 0.6);
 }
@@ -641,7 +716,8 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
   border-color: rgb(var(--c-emerald-500) / 0.6);
 }
 [data-theme="minimalista"] .glaciar-estado-peligro,
-[data-theme="nature"] .glaciar-estado-peligro {
+[data-theme="nature"] .glaciar-estado-peligro,
+[data-theme="verde-vivo"] .glaciar-estado-peligro{
   background-color: rgb(254 226 226 / 0.55);
   border-color: rgb(239 68 68 / 0.7);
 }
@@ -651,7 +727,8 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
   border-color: rgb(var(--c-morpho) / 0.5);
 }
 [data-theme="minimalista"] .glaciar-estado-observacion,
-[data-theme="nature"] .glaciar-estado-observacion {
+[data-theme="nature"] .glaciar-estado-observacion,
+[data-theme="verde-vivo"] .glaciar-estado-observacion{
   background-color: rgb(var(--c-morpho) / 0.15);
   border-color: rgb(var(--c-morpho) / 0.5);
 }
@@ -662,7 +739,8 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
   border-color: rgb(var(--c-morpho-glow) / 0.7);
 }
 [data-theme="minimalista"] .glaciar-dureza-mano,
-[data-theme="nature"] .glaciar-dureza-mano {
+[data-theme="nature"] .glaciar-dureza-mano,
+[data-theme="verde-vivo"] .glaciar-dureza-mano{
   background-color: rgb(var(--c-emerald-200) / 0.5);
   border-color: rgb(var(--c-emerald-500) / 0.6);
 }
@@ -672,7 +750,8 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
   border-color: rgb(var(--c-orchid-glow) / 0.7);
 }
 [data-theme="minimalista"] .glaciar-dureza-piolet,
-[data-theme="nature"] .glaciar-dureza-piolet {
+[data-theme="nature"] .glaciar-dureza-piolet,
+[data-theme="verde-vivo"] .glaciar-dureza-piolet{
   background-color: rgb(var(--c-emerald-300) / 0.5);
   border-color: rgb(var(--c-emerald-600) / 0.6);
 }
@@ -682,7 +761,8 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
   color: rgb(var(--c-slate-100));
 }
 [data-theme="minimalista"] .glaciar-estado-texto,
-[data-theme="nature"] .glaciar-estado-texto {
+[data-theme="nature"] .glaciar-estado-texto,
+[data-theme="verde-vivo"] .glaciar-estado-texto{
   color: rgb(var(--c-slate-200));
 }
 
@@ -706,7 +786,8 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
 
 /* Pastilla del compositor → superficie clara del tema (= --superf del demo). */
 [data-theme="nature"] .as-bar,
-[data-theme="minimalista"] .as-bar {
+[data-theme="minimalista"] .as-bar,
+[data-theme="verde-vivo"] .as-bar{
   background: rgb(var(--c-surface-raised) / 0.97);
   border-color: rgb(var(--c-surface-border));
   box-shadow: 0 10px 30px -14px rgba(0, 0, 0, 0.22);
@@ -714,18 +795,21 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
 /* Texto que escribe el productor: el textarea es text-white (invisible sobre
  * crema). En claros = café/tinta del tema. El placeholder ya sale de --c-*. */
 [data-theme="nature"] .as-bar textarea,
-[data-theme="minimalista"] .as-bar textarea {
+[data-theme="minimalista"] .as-bar textarea,
+[data-theme="verde-vivo"] .as-bar textarea{
   color: rgb(var(--c-slate-100));
 }
 /* Botones de ícono del compositor → blanco/papel con ícono café del tema. */
 [data-theme="nature"] .as-iconbtn,
-[data-theme="minimalista"] .as-iconbtn {
+[data-theme="minimalista"] .as-iconbtn,
+[data-theme="verde-vivo"] .as-iconbtn{
   background: rgb(var(--c-surface-card));
   border-color: rgb(var(--c-surface-border));
   color: rgb(var(--c-slate-300));
 }
 [data-theme="nature"] .as-iconbtn:hover,
-[data-theme="minimalista"] .as-iconbtn:hover {
+[data-theme="minimalista"] .as-iconbtn:hover,
+[data-theme="verde-vivo"] .as-iconbtn:hover{
   color: rgb(var(--c-slate-100));
   border-color: rgb(var(--t-accent-rgb) / 0.55);
 }
@@ -733,7 +817,8 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
 /* ContextTip ("¿Una mata enferma? Mándeme una foto") — tarjeta clara del tema
  * en vez del verde-oscuro Tailwind (no hay --c-emerald-950 en claros). */
 [data-theme="nature"] .bg-emerald-950\/50,
-[data-theme="minimalista"] .bg-emerald-950\/50 {
+[data-theme="minimalista"] .bg-emerald-950\/50,
+[data-theme="verde-vivo"] .bg-emerald-950\/50{
   background-color: rgb(var(--c-surface-raised) / 0.92) !important;
   border-color: rgb(var(--c-emerald-400) / 0.5) !important;
 }
@@ -741,6 +826,7 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
  * blanco de Tailwind, ilegible sobre la tarjeta clara). En claros = verde
  * profundo del tema, que sí pasa AA sobre la crema. */
 [data-theme="nature"] .bg-emerald-950\/50 .text-emerald-100,
-[data-theme="minimalista"] .bg-emerald-950\/50 .text-emerald-100 {
+[data-theme="minimalista"] .bg-emerald-950\/50 .text-emerald-100,
+[data-theme="verde-vivo"] .bg-emerald-950\/50 .text-emerald-100{
   color: rgb(var(--c-emerald-700));
 }


### PR DESCRIPTION
## Feature
Agrega un 4º tema seleccionable **"Verde Vivo"** (la PIEL propia de la finca viva: verde frondoso + sol cálido + tierra/ocre, identidad Chagra) y hace que la **ESCENA del hero finca-viva se vea en TODOS los temas**, tomando la piel del tema activo (misma disposición + escena, distinta piel — como los bocetos aprobados).

Continúa la Fase 1 (#1869: ScreenShell theme-aware vía `--c-*`, gated tras `fincaVivaHomePerfilActivo()`).

## Gate (prod intacto — innegociable)
Todo va gateado tras `fincaVivaHomePerfilActivo()` (`VITE_FINCA_VIVA_HOME_PERFIL`): **ON en dev-deploy, OFF en prod**. Con la flag **OFF (prod)** el selector es EXACTO el de hoy (3 temas + auto, sin disposición F2 ni Verde Vivo). El 4º tema SOLO aparece con la flag ON. **El PR va "dark" en prod.**

## Cambios
- **`src/index.css`**: bloque `[data-theme="verde-vivo"]` con el mapa `--c-*` completo. Tema CLARO y vivo: tinta bosque (#1c2a16) AA 13.3:1 sobre crema frondosa (#eef3e2), acento verde-hoja (#2e8b3d), sol/ocre cálido, FX off, scrim claro.
- **`src/styles/themes.css`**: acento `--t-*` de verde-vivo (verde-hoja) + se clonan los overrides no-var-aware de `nature` a `verde-vivo` (text-white, ámbar, paneles sky, cards de impacto, compositor) para evitar el "Frankenstein" en las ~25 clases que la indirección `--c-*` no cubre.
- **`src/hooks/useTheme.js`**: `VERDE_VIVO_THEME` + `getSelectableThemes(flag)`. El id `verde-vivo` es válido SIEMPRE en `THEME_IDS` (la selección persistida sobrevive), pero su VISIBILIDAD en el selector la gobierna la flag.
- **`src/components/common/ThemeSelector.jsx`**: usa `getSelectableThemes(fincaVivaHomePerfilActivo())` → 4º tema solo con flag ON.
- **`src/components/dashboard/themeIcon.jsx`**: ícono `verde-vivo` = SOL-MANO radial frondosa (mano de Chagra + solar/soberanía). rsvg-safe.
- **`src/components/dashboard/FincaVivaHero.jsx`**: el ícono de marca del agente sigue al TEMA ACTIVO (`iconForTheme(theme)`), no hardcodeado a biopunk.
- **`src/components/dashboard/finca-viva-hero.css`**: la paleta del hero deriva de `--c-*`; cada tema retiñe el cielo/sol de la ESCENA (4 pieles) + plinto claro del ícono en temas de piel clara.

## Escena en los 4 temas
La escena/hero ya se monta bajo cualquier tema (la gobierna la flag, no el tema). Antes su paleta (`--fvh-*`) estaba hardcodeada → se veía idéntica en los 3 temas. Ahora deriva de `--c-*` + retinte de cielo/sol por tema, así cada uno de los 4 temas le da su piel. **Evidencia visual (rsvg, sin chromium) enviada a Telegram**: misma disposición + escena, distinta piel en Verde Vivo / Bio-Punk / Nature / Minimalista.

## Tests
- `useTheme.verdeVivo.test.js`: el 4º tema existe y se registra; `getSelectableThemes(true)` lo muestra, `getSelectableThemes(false)` NO; applyTheme/setTheme.
- `ThemeSelector.verdeVivo.test.jsx`: flag ON muestra Verde Vivo y lo selecciona; flag OFF NO (selector como hoy).
- `FincaVivaHero.theme.test.jsx`: la escena/hero aplica el ícono del tema activo en los **4 temas**.
- `verdeVivo.theme.test.js`: contrato de tokens (mapa `--c-*` completo, AA ≥4.5, FX off, scrim claro) + la escena retiñe por tema.
- `themes.coverage.test.js`: verde-vivo añadido al contrato AA/FX de temas claros.
- vitest verde (todas las suites de temas + hero), `vite build` verde, eslint `--max-warnings=0` limpio.

## Pendiente Fase 2 (otra ola)
Juegos / AgentScreen / FAB skineados por tema (lo hará el operador esta noche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)