### PR TITLE
feat(juego): plagas y curas más claras y didácticas (grounded AGE/catálogo)

### DIFF
--- a/src/components/juego/DefensoresFincaScreen.jsx
+++ b/src/components/juego/DefensoresFincaScreen.jsx
@@ -88,6 +88,12 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
     [nivel],
   );
   const beneficos = useMemo(() => pares.map((p) => p.benefico), [pares]);
+  // Benéfico → su par completo, para decir QUÉ plaga controla cuando el jugador
+  // suelta el aliado equivocado (microcopy didáctico, no solo "fallaste").
+  const parPorBenefico = useMemo(
+    () => Object.fromEntries(pares.map((p) => [p.benefico.id, p])),
+    [pares],
+  );
   const leccionPorBenefico = useMemo(
     () => Object.fromEntries(pares.map((p) => [p.benefico.id, p.leccion])),
     [pares],
@@ -261,9 +267,16 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
       setLeccion(leccionPorBenefico[id] || '');
       beep('good');
     } else {
-      setLeccion('Ese benéfico controla otra plaga. Mira cuál bicho malo hay cerca.');
+      // No acertó: en vez de un "fallaste" seco, le enseñamos qué controla SÍ
+      // el aliado que soltó, para que aprenda el emparejamiento correcto.
+      const par = parPorBenefico[id];
+      setLeccion(
+        par
+          ? `${par.benefico.nombre} controla al ${par.plaga.nombre.toLowerCase()}. Apunta a ese bicho o cambia de aliado.`
+          : 'Ese aliado controla otra plaga. Mira cuál bicho malo tienes cerca.',
+      );
     }
-  }, [estado, leccionPorBenefico, beep]);
+  }, [estado, leccionPorBenefico, parPorBenefico, beep]);
 
   // ── Bucle principal de juego (canvas 2D) ───────────────────────────
   useEffect(() => {
@@ -615,21 +628,29 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
       )}
 
       {/* Selector de benéficos (control biológico) */}
-      <div className="df-beneficios" role="group" aria-label="Elige el organismo benéfico">
-        {beneficos.map((b) => (
-          <button
-            key={b.id}
-            type="button"
-            data-testid={`beneficio-${b.id}`}
-            data-selected={beneficoSel === b.id}
-            onClick={() => setBeneficoSel(b.id)}
-            aria-pressed={beneficoSel === b.id}
-            className="df-beneficio"
-          >
-            <span className="df-beneficio-emoji" aria-hidden="true">{b.emoji}</span>
-            <span className="df-beneficio-nombre">{b.nombre}</span>
-          </button>
-        ))}
+      <div className="df-beneficios" role="group" aria-label="Elige el aliado que controla cada plaga">
+        {beneficos.map((b) => {
+          const plagaQueControla = parPorBenefico[b.id]?.plaga?.nombre;
+          const ayuda = plagaQueControla
+            ? `${b.nombre}: controla al ${plagaQueControla.toLowerCase()}`
+            : b.nombre;
+          return (
+            <button
+              key={b.id}
+              type="button"
+              data-testid={`beneficio-${b.id}`}
+              data-selected={beneficoSel === b.id}
+              onClick={() => setBeneficoSel(b.id)}
+              aria-pressed={beneficoSel === b.id}
+              aria-label={ayuda}
+              title={ayuda}
+              className="df-beneficio"
+            >
+              <span className="df-beneficio-emoji" aria-hidden="true">{b.emoji}</span>
+              <span className="df-beneficio-nombre">{b.nombre}</span>
+            </button>
+          );
+        })}
       </div>
 
       {/* Controles táctiles (mobile-first) + teclado en desktop */}

--- a/src/components/juego/DoomFincaScreen.jsx
+++ b/src/components/juego/DoomFincaScreen.jsx
@@ -1091,9 +1091,17 @@ export default function DoomFincaScreen({ onBack, onHome }) {
                 <b className="text-amber-200">{ficha.benefico}</b>
                 <span className="text-white/60"> ({ficha.beneficoCientifico})</span>
                 <span className="text-emerald-300"> controla a </span>
-                <b className="text-red-200">{ficha.plaga}</b>.
+                <b className="text-red-200">{ficha.plaga}</b>
+                {ficha.cultivo ? <span className="text-white/70"> en {ficha.cultivo}</span> : null}.
               </p>
-              <p className="text-2xs text-emerald-100/90 leading-snug mt-1">{ficha.porQue}</p>
+              {ficha.dano ? (
+                <p className="text-2xs text-red-200/80 leading-snug mt-1">
+                  <b className="text-red-300">El dano:</b> {ficha.dano}
+                </p>
+              ) : null}
+              <p className="text-2xs text-emerald-100/90 leading-snug mt-1">
+                <b className="text-emerald-300">Por que funciona:</b> {ficha.porQue}
+              </p>
             </div>
           )}
 
@@ -1238,6 +1246,9 @@ export default function DoomFincaScreen({ onBack, onHome }) {
                     <span aria-hidden="true">{plaga.emoji}</span>
                     <b className="text-white/85">{plaga.nombre}</b>
                     <span className="text-slate-600 italic">({plaga.cientifico})</span>
+                    {plaga.cultivo ? (
+                      <span className="text-amber-300/70">en {plaga.cultivo}</span>
+                    ) : null}
                     <ChevronRight size={11} className="text-slate-600" aria-hidden="true" />
                     <span aria-hidden="true">{benef?.emoji}</span>
                     <span className="text-emerald-300">{benef?.nombre || plaga.controladoPor}</span>

--- a/src/components/juego/__tests__/defensoresFincaData.test.js
+++ b/src/components/juego/__tests__/defensoresFincaData.test.js
@@ -94,6 +94,54 @@ describe('PARES_CONTROL — shape, unicidad y relaciones', () => {
   });
 });
 
+// ── DIDÁCTICA grounded (cultivos, daño, cómo, fuente) ───────────────
+
+describe('PARES_CONTROL — didáctica grounded para el pilar campesino', () => {
+  const FUENTES_VALIDAS = ['grafo', 'cenicafe', 'ica-ciat', 'ecologia'];
+
+  it('cada plaga declara los cultivos que ataca (lista no vacía)', () => {
+    for (const par of PARES_CONTROL) {
+      expect(Array.isArray(par.plaga.cultivos)).toBe(true);
+      expect(par.plaga.cultivos.length).toBeGreaterThan(0);
+      for (const c of par.plaga.cultivos) {
+        expect(typeof c).toBe('string');
+        expect(c.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('cada par marca una fuente honesta del par plaga↔cura', () => {
+    for (const par of PARES_CONTROL) {
+      expect(par).toHaveProperty('fuente');
+      expect(FUENTES_VALIDAS).toContain(par.fuente);
+    }
+  });
+
+  it('el daño y el cómo son frases claras (no etiquetas sueltas)', () => {
+    for (const par of PARES_CONTROL) {
+      // una frase explicativa, no una palabra técnica suelta
+      expect(par.plaga.dano.length).toBeGreaterThan(15);
+      expect(par.benefico.como.length).toBeGreaterThan(15);
+      expect(par.leccion.length).toBeGreaterThan(15);
+    }
+  });
+
+  it('la mayoría de los pares está grounded en el grafo AGE', () => {
+    const enGrafo = PARES_CONTROL.filter((p) => p.fuente === 'grafo').length;
+    // al menos la mitad debe venir verificado del grafo (el resto es control
+    // biológico institucional documentado o depredación ecológica rotulada).
+    expect(enGrafo).toBeGreaterThanOrEqual(Math.ceil(PARES_CONTROL.length / 2));
+  });
+
+  it('sin voseo argentino en el microcopy (tú/usted colombiano)', () => {
+    const VOSEO = /\b(usá|usás|tenés|querés|empezá|empezás|elegí|fijate|mirá|soltá|hacé|poné)\b/i;
+    for (const par of PARES_CONTROL) {
+      const texto = `${par.plaga.dano} ${par.benefico.como} ${par.leccion}`;
+      expect(texto).not.toMatch(VOSEO);
+    }
+  });
+});
+
 // ── NIVELES — forma y progresión ───────────────────────────────────
 
 describe('NIVELES — campos obligatorios sin undefined', () => {

--- a/src/components/juego/__tests__/doomFinca.test.js
+++ b/src/components/juego/__tests__/doomFinca.test.js
@@ -37,6 +37,24 @@ describe('PLAGAS_DOOM — shape y par de control real', () => {
     const ids = PLAGAS_DOOM.map((p) => p.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
+
+  it('cada plaga lista los cultivos que ataca y declara su fuente honesta', () => {
+    const FUENTES = ['grafo', 'cenicafe', 'ica-ciat', 'ecologia'];
+    for (const p of PLAGAS_DOOM) {
+      expect(Array.isArray(p.cultivos)).toBe(true);
+      expect(p.cultivos.length).toBeGreaterThan(0);
+      expect(FUENTES).toContain(p.fuente);
+      // el dano es una frase clara, no una etiqueta suelta
+      expect(p.dano.length).toBeGreaterThan(15);
+    }
+  });
+
+  it('no hay voseo argentino en el dano de las plagas (es-CO)', () => {
+    const VOSEO = /\b(usá|usás|tenés|querés|empezá|elegí)\b/i;
+    for (const p of PLAGAS_DOOM) {
+      expect(`${p.dano} ${p.porQue}`).not.toMatch(VOSEO);
+    }
+  });
 });
 
 describe('BENEFICOS_DOOM — shape', () => {

--- a/src/components/juego/defensoresFincaData.js
+++ b/src/components/juego/defensoresFincaData.js
@@ -6,6 +6,22 @@
  * Chagra). El jugador invoca un benéfico y este elimina EXACTAMENTE la plaga que
  * de verdad controla — enseña control biológico real, no fabricado.
  *
+ * DIDÁCTICA (para que un niño y un campesino lo entiendan):
+ *   - Cada PLAGA dice su nombre común + científico, QUÉ CULTIVOS ataca y QUÉ
+ *     DAÑO les hace, en una línea clara (tú/usted colombiano).
+ *   - Cada CURA (benéfico) explica CÓMO controla a esa plaga: el "porqué" del
+ *     control biológico, no solo que la mata.
+ *   - El campo `fuente` es honesto sobre de dónde sale la relación:
+ *       'grafo'    → relación CONTROLS verificada en el grafo AGE de Chagra
+ *                    (public/grafo-relations.json, pest_controllers).
+ *       'cenicafe' → control biológico del café documentado por Cenicafé
+ *                    Colombia (par no incluido en el subset OSS del grafo).
+ *       'ica-ciat' → control biológico del maíz documentado por ICA / CIAT /
+ *                    EMBRAPA (par clásico no incluido en el subset del grafo).
+ *       'ecologia' → depredación natural real pero GENÉRICA (no es una receta
+ *                    MIP dirigida); se rotula como "depredador general" para no
+ *                    enseñar una recomendación que no existe como tal.
+ *
  * Fuentes de las relaciones (control biológico clásico, ampliamente documentado
  * por ICA Colombia, CIAT, FAO, Cenicafé y la literatura de manejo integrado de
  * plagas): coccinélidos depredan áfidos; crisopas depredan mosca blanca y
@@ -41,14 +57,17 @@ export const CULTIVOS = [
  * @property {string} plaga.nombre   Nombre común campesino.
  * @property {string} plaga.cientifico
  * @property {string} plaga.emoji
- * @property {string} plaga.dano     Qué le hace al cultivo (1 línea).
+ * @property {string[]} plaga.cultivos Cultivos que ataca (nombre claro).
+ * @property {string} plaga.dano     Qué le hace al cultivo (1 línea clara).
  * @property {Object} benefico       El "bicho bueno" que la controla.
  * @property {string} benefico.id
  * @property {string} benefico.nombre
  * @property {string} benefico.cientifico
  * @property {string} benefico.emoji
- * @property {string} benefico.como  Cómo controla la plaga (1 línea).
+ * @property {string} benefico.como  Cómo controla la plaga (1 línea: el porqué).
  * @property {string} leccion        Mensaje pedagógico al limpiar la plaga.
+ * @property {'grafo'|'cenicafe'|'ica-ciat'|'ecologia'} fuente Origen de la
+ *           relación plaga↔cura (ver cabecera del archivo).
  */
 
 /** @type {ParControl[]} */
@@ -60,16 +79,18 @@ export const PARES_CONTROL = [
       nombre: 'Pulgón',
       cientifico: 'Aphididae',
       emoji: '🦟',
-      dano: 'Chupa la savia y enrolla las hojas tiernas.',
+      cultivos: ['Frijol', 'Tomate', 'Hortalizas'],
+      dano: 'Chupa la savia de los brotes; la hoja tierna se enrolla y se pone pegajosa.',
     },
     benefico: {
       id: 'catarina',
       nombre: 'Mariquita',
       cientifico: 'Coccinellidae',
       emoji: '🐞',
-      como: 'La mariquita y sus larvas se comen cientos de pulgones.',
+      como: 'La mariquita y sus larvas se comen colonias enteras de pulgón, hasta decenas al día.',
     },
-    leccion: 'La mariquita controla el pulgón: es control biológico de verdad.',
+    leccion: 'Para el pulgón, suelta mariquitas: se los comen vivos. Eso es control biológico, no veneno.',
+    fuente: 'grafo',
   },
   {
     id: 'moscablanca-crisopa',
@@ -78,16 +99,18 @@ export const PARES_CONTROL = [
       nombre: 'Mosca blanca',
       cientifico: 'Bemisia tabaci',
       emoji: '🪰',
-      dano: 'Chupa savia y transmite virus al tomate.',
+      cultivos: ['Tomate', 'Frijol', 'Ahuyama'],
+      dano: 'Chupa savia por debajo de la hoja y transmite virus que la enrollan y amarillan.',
     },
     benefico: {
       id: 'crisopa',
       nombre: 'Crisopa',
       cientifico: 'Chrysoperla',
       emoji: '🦗',
-      como: 'La larva de crisopa devora mosca blanca y áfidos.',
+      como: 'La larva de crisopa ("león de los áfidos") atrapa mosca blanca y pulgones con sus mandíbulas curvas.',
     },
-    leccion: 'La crisopa (león de los áfidos) limpia la mosca blanca.',
+    leccion: 'Para la mosca blanca, suelta crisopas: su larva caza los bichos que chupan la hoja.',
+    fuente: 'grafo',
   },
   {
     id: 'cogollero-trichogramma',
@@ -96,16 +119,18 @@ export const PARES_CONTROL = [
       nombre: 'Gusano cogollero',
       cientifico: 'Spodoptera frugiperda',
       emoji: '🐛',
-      dano: 'Se come el cogollo del maíz y deja huecos.',
+      cultivos: ['Maíz'],
+      dano: 'Se mete en el cogollo del maíz, se come el centro tierno y deja la hoja con huecos.',
     },
     benefico: {
       id: 'trichogramma',
       nombre: 'Avispita Trichogramma',
       cientifico: 'Trichogramma',
       emoji: '🐝',
-      como: 'Pone sus huevos dentro de los huevos del gusano y los anula.',
+      como: 'Pone su huevo DENTRO del huevo del gusano: la larva nunca nace, así no hay quién coma el cogollo.',
     },
-    leccion: 'Trichogramma parasita los huevos del cogollero antes de que nazca.',
+    leccion: 'Suelta la avispita Trichogramma cuando veas las posturas: ataca el huevo del cogollero antes de que nazca.',
+    fuente: 'grafo',
   },
   {
     id: 'trips-amblyseius',
@@ -114,34 +139,38 @@ export const PARES_CONTROL = [
       nombre: 'Trips',
       cientifico: 'Thysanoptera',
       emoji: '🦠',
-      dano: 'Raspa las hojas y deja manchas plateadas.',
+      cultivos: ['Cebolla', 'Tomate', 'Hortalizas'],
+      dano: 'Raspa la hoja y la flor para chupar; deja manchas plateadas y puntos negros.',
     },
     benefico: {
       id: 'amblyseius',
       nombre: 'Ácaro Amblyseius',
       cientifico: 'Amblyseius',
       emoji: '🕷️',
-      como: 'Este ácaro benéfico depreda los trips jóvenes.',
+      como: 'Es un ácaro bueno que se come a los trips chiquitos antes de que se vuelvan plaga.',
     },
-    leccion: 'El ácaro Amblyseius controla los trips sin venenos.',
+    leccion: 'Para los trips, suelta el ácaro bueno Amblyseius: caza los trips jóvenes sin un solo veneno.',
+    fuente: 'grafo',
   },
   {
     id: 'acaro-phytoseiulus',
     plaga: {
       id: 'acaro',
-      nombre: 'Ácaro rojo',
+      nombre: 'Ácaro rojo (araña roja)',
       cientifico: 'Tetranychus urticae',
       emoji: '🔴',
-      dano: 'Teje telarañas finas y amarillea las hojas.',
+      cultivos: ['Tomate', 'Frijol', 'Mora', 'Fresa'],
+      dano: 'Pica el envés de la hoja, la puntea y la seca; teje telarañas finas en los bordes.',
     },
     benefico: {
       id: 'phytoseiulus',
       nombre: 'Ácaro depredador',
       cientifico: 'Phytoseiulus persimilis',
       emoji: '🕷️',
-      como: 'Caza y devora al ácaro rojo plaga.',
+      como: 'Es un ácaro cazador que persigue y se come a la araña roja plaga, huevo por huevo.',
     },
-    leccion: 'Phytoseiulus es un ácaro bueno que se come al ácaro rojo.',
+    leccion: 'Para la araña roja, suelta el ácaro depredador: un ácaro bueno se come al ácaro malo.',
+    fuente: 'grafo',
   },
   {
     id: 'afido-sirfido',
@@ -150,16 +179,18 @@ export const PARES_CONTROL = [
       nombre: 'Áfido del frijol',
       cientifico: 'Aphis fabae',
       emoji: '🦟',
-      dano: 'Forma colonias y debilita la planta de frijol.',
+      cultivos: ['Frijol'],
+      dano: 'Forma colonias pegajosas en los brotes, chupa savia y debilita la mata de frijol.',
     },
     benefico: {
       id: 'sirfido',
-      nombre: 'Mosca de las flores',
+      nombre: 'Mosca de las flores (sírfido)',
       cientifico: 'Syrphidae',
       emoji: '🪰',
-      como: 'Su larva se come los áfidos; el adulto poliniza.',
+      como: 'Su larva se come los áfidos uno a uno; el adulto, además, poliniza las flores.',
     },
-    leccion: 'La larva del sírfido devora áfidos y el adulto poliniza.',
+    leccion: 'El sírfido es doble ayuda: la cría se come los áfidos y el adulto poliniza tu cultivo.',
+    fuente: 'grafo',
   },
   {
     id: 'saltamontes-mantis',
@@ -168,16 +199,18 @@ export const PARES_CONTROL = [
       nombre: 'Saltamontes',
       cientifico: 'Caelifera',
       emoji: '🦗',
-      dano: 'Mastica hojas y brotes tiernos.',
+      cultivos: ['Maíz', 'Hortalizas'],
+      dano: 'Mastica las hojas y los brotes tiernos; en grupo deja la planta pelada.',
     },
     benefico: {
       id: 'mantis',
       nombre: 'Mantis religiosa',
       cientifico: 'Mantodea',
       emoji: '🦂',
-      como: 'La mantis caza y se come al saltamontes.',
+      como: 'Es una cazadora general: atrapa al saltamontes con sus patas y se lo come.',
     },
-    leccion: 'La mantis religiosa es una cazadora que controla saltamontes.',
+    leccion: 'La mantis es una cazadora general que atrapa saltamontes; cuídala, no la mates: ayuda a tu finca.',
+    fuente: 'ecologia',
   },
   // ── Plagas y aliados del CAFETAL (nivel 3) ─────────────────────────────
   // Control biológico documentado por Cenicafé Colombia para el café.
@@ -188,16 +221,18 @@ export const PARES_CONTROL = [
       nombre: 'Broca del café',
       cientifico: 'Hypothenemus hampei',
       emoji: '🪲',
-      dano: 'Perfora el grano de café y arruina la cosecha.',
+      cultivos: ['Café'],
+      dano: 'Es un escarabajito que perfora el grano de café por dentro y daña la calidad de la cosecha.',
     },
     benefico: {
       id: 'cephalonomia',
       nombre: 'Avispa Cephalonomia',
       cientifico: 'Cephalonomia stephanoderis',
       emoji: '🐝',
-      como: 'Esta avispita entra al grano y parasita a la broca.',
+      como: 'Esta avispita entra al grano picado, parasita a la broca y corta su reproducción.',
     },
-    leccion: 'La avispa Cephalonomia controla la broca dentro del grano de café.',
+    leccion: 'Para la broca, la avispa Cephalonomia entra al grano y la ataca donde el veneno no llega.',
+    fuente: 'cenicafe',
   },
   {
     id: 'minador-closterocerus',
@@ -206,16 +241,18 @@ export const PARES_CONTROL = [
       nombre: 'Minador de la hoja',
       cientifico: 'Leucoptera coffeella',
       emoji: '🐛',
-      dano: 'Hace galerías cafés en la hoja del café y la seca.',
+      cultivos: ['Café'],
+      dano: 'Su larva cava galerías cafés por dentro de la hoja del café; la hoja se seca y se cae.',
     },
     benefico: {
       id: 'closterocerus',
       nombre: 'Avispa Closterocerus',
       cientifico: 'Closterocerus coffeellae',
       emoji: '🐝',
-      como: 'Esta avispita parasita a la larva del minador en la hoja.',
+      como: 'Es una avispita que busca la larva del minador dentro de la galería y la parasita.',
     },
-    leccion: 'La avispa Closterocerus controla el minador de la hoja del café.',
+    leccion: 'Para el minador del café, la avispa Closterocerus encuentra la larva en la hoja y la controla.',
+    fuente: 'cenicafe',
   },
   {
     id: 'cochinilla-cryptolaemus',
@@ -224,16 +261,18 @@ export const PARES_CONTROL = [
       nombre: 'Cochinilla harinosa',
       cientifico: 'Planococcus citri',
       emoji: '🐌',
-      dano: 'Forma motas blancas y chupa la savia de las ramas.',
+      cultivos: ['Café', 'Frutales'],
+      dano: 'Forma motas blancas pegajosas en ramas y raíces, chupa la savia y atrae hormigas.',
     },
     benefico: {
       id: 'cryptolaemus',
       nombre: 'Escarabajo come-cochinillas',
       cientifico: 'Cryptolaemus montrouzieri',
       emoji: '🐞',
-      como: 'Este escarabajo y sus larvas devoran las cochinillas.',
+      como: 'Este escarabajo y sus larvas (parecidas a la cochinilla) devoran las motas blancas.',
     },
-    leccion: 'El escarabajo Cryptolaemus se come la cochinilla harinosa.',
+    leccion: 'Para la cochinilla, el escarabajo Cryptolaemus se la come; le dicen "destructor de cochinillas".',
+    fuente: 'grafo',
   },
   // ── Plagas y aliados del MAIZAL (nivel 4) ────────────────────────────────
   // Control biológico documentado por CIAT, EMBRAPA e ICA Colombia para el maíz.
@@ -244,34 +283,38 @@ export const PARES_CONTROL = [
       nombre: 'Chicharrita del maíz',
       cientifico: 'Dalbulus maidis',
       emoji: '🦗',
-      dano: 'Chupa la savia y transmite el achaparramiento del maíz.',
+      cultivos: ['Maíz'],
+      dano: 'Chupa la savia y le pega al maíz el achaparramiento, una enfermedad que enana la planta.',
     },
     benefico: {
       id: 'doru',
       nombre: 'Tijereta',
       cientifico: 'Doru luteipes',
       emoji: '🪲',
-      como: 'La tijereta caza de noche y devora chicharritas y huevos de plaga.',
+      como: 'La tijereta patrulla el cogollo de noche y devora chicharritas y huevos de otras plagas.',
     },
-    leccion: 'La tijereta Doru luteipes es guardiana nocturna del maizal.',
+    leccion: 'La tijereta Doru es la guardiana nocturna del maizal: come chicharritas mientras usted duerme.',
+    fuente: 'ica-ciat',
   },
   {
     id: 'elotero-telenomus',
     plaga: {
       id: 'elotero',
-      nombre: 'Gusano elotero',
+      nombre: 'Gusano elotero (de la mazorca)',
       cientifico: 'Helicoverpa zea',
       emoji: '🐛',
-      dano: 'Se mete en la mazorca y devora los granos tiernos.',
+      cultivos: ['Maíz'],
+      dano: 'Entra por la punta de la mazorca y se come los granos tiernos en formación.',
     },
     benefico: {
       id: 'telenomus',
       nombre: 'Avispita Telenomus',
       cientifico: 'Telenomus remus',
       emoji: '🐝',
-      como: 'Parasita los huevos del elotero antes de que nazca la larva.',
+      como: 'Pone su huevo dentro del huevo del elotero: el gusano no alcanza a nacer ni a entrar a la mazorca.',
     },
-    leccion: 'La avispa Telenomus remus destruye los huevos del gusano elotero.',
+    leccion: 'Para el elotero, la avispita Telenomus ataca el huevo: sin huevo no hay gusano en la mazorca.',
+    fuente: 'ica-ciat',
   },
   {
     id: 'barrenador-cotesia',
@@ -280,16 +323,18 @@ export const PARES_CONTROL = [
       nombre: 'Barrenador del tallo',
       cientifico: 'Diatraea saccharalis',
       emoji: '🐛',
-      dano: 'Perfora el tallo del maíz por dentro y lo debilita.',
+      cultivos: ['Maíz'],
+      dano: 'Hace túneles por dentro del tallo del maíz; la planta se debilita y se quiebra con el viento.',
     },
     benefico: {
       id: 'cotesia',
       nombre: 'Avispita Cotesia',
       cientifico: 'Cotesia flavipes',
       emoji: '🐝',
-      como: 'Busca las larvas del barrenador dentro del tallo y las parasita.',
+      como: 'Rastrea la larva del barrenador dentro del tallo y la parasita en su propio túnel.',
     },
-    leccion: 'La avispa Cotesia flavipes controla el barrenador del tallo del maíz.',
+    leccion: 'Para el barrenador, la avispa Cotesia lo persigue dentro del tallo, donde nada más lo alcanza.',
+    fuente: 'ica-ciat',
   },
 ];
 

--- a/src/components/juego/doomFincaData.js
+++ b/src/components/juego/doomFincaData.js
@@ -8,6 +8,14 @@
  * del grafo de conocimiento de Chagra (Apache AGE, fuentes ICA / CIAT /
  * Cenicafe / FAO; ver public/grafo-relations.json, relacion pest_controllers).
  *
+ * DIDACTICA: cada plaga dice QUE CULTIVO ataca y QUE DANO le hace; cada cura
+ * explica COMO actua (el porque del control biologico). El campo `dano` y el
+ * `porQue` se muestran en la ficha que sale al controlar bien una plaga, para
+ * que el jugador (nino o campesino) entienda "para esta plaga, este control".
+ * Lenguaje claro tu/usted colombiano. Si una relacion no esta en el subset OSS
+ * del grafo, viene de literatura institucional documentada (Cenicafe para cafe,
+ * estandar Bt/Beauveria para orugas y mosca blanca); nunca se inventa un par.
+ *
  * El escenario muestra el "kit completo" de la finca: setos vivos, corral de
  * animales, compostera, camas de cultivo, colmena, girasoles para
  * polinizadores; todo se puede mirar para leer su rol en el ciclo.
@@ -128,7 +136,7 @@ export const BENEFICOS_DOOM = [
     emoji: '🐝',
     color: '#f5c842',
     tipo: 'avispa',
-    desc: 'Parasitoide de huevos.',
+    desc: 'Avispita que ataca los HUEVOS de los gusanos.',
     mecanismo: 'La avispita pone su huevo DENTRO del huevo de la mariposa-polilla. La larva nunca nace: no hay gusano que coma el cultivo.',
   },
   {
@@ -138,7 +146,7 @@ export const BENEFICOS_DOOM = [
     emoji: '🐞',
     color: '#e74c3c',
     tipo: 'mariquita',
-    desc: 'Depredador de pulgones.',
+    desc: 'Se come pulgones y cochinillas.',
     mecanismo: 'Adultos y larvas de mariquita devoran colonias enteras de pulgones y cochinillas: hasta 50 al dia.',
   },
   {
@@ -148,8 +156,8 @@ export const BENEFICOS_DOOM = [
     emoji: '🦗',
     color: '#7ed957',
     tipo: 'crisopa',
-    desc: 'Depredador generalista.',
-    mecanismo: 'La larva de crisopa, el "leon de afidos", chupa pulgones, huevos y acaros con sus mandibulas curvas.',
+    desc: 'Caza pulgones, mosca blanca y aranita.',
+    mecanismo: 'La larva de crisopa, el "leon de afidos", chupa pulgones, huevos, mosca blanca y aranita con sus mandibulas curvas.',
   },
   {
     id: 'beauveria',
@@ -158,8 +166,8 @@ export const BENEFICOS_DOOM = [
     emoji: '🍄',
     color: '#eef0e6',
     tipo: 'hongo',
-    desc: 'Hongo entomopatogeno.',
-    mecanismo: 'El hongo germina sobre el insecto, lo penetra y lo coloniza por dentro hasta secarlo. Estandar contra broca y mosca blanca.',
+    desc: 'Hongo bueno: enferma broca y mosca blanca.',
+    mecanismo: 'El hongo germina sobre el insecto, lo penetra y lo coloniza por dentro hasta secarlo. Es el estandar de Cenicafe contra broca y mosca blanca.',
   },
   {
     id: 'bt',
@@ -168,15 +176,18 @@ export const BENEFICOS_DOOM = [
     emoji: '🧫',
     color: '#9bd3ff',
     tipo: 'bacteria',
-    desc: 'Bioinsecticida para orugas.',
-    mecanismo: 'La oruga come la hoja con Bt; el cristal de la bacteria rompe su intestino y deja de comer en horas. No afecta abejas ni gente.',
+    desc: 'Bioinsecticida para gusanos (orugas).',
+    mecanismo: 'La oruga come la hoja con Bt; el cristal de la bacteria le rompe el intestino y deja de comer en horas. No afecta abejas, gallinas ni gente.',
   },
 ];
 
 /**
  * PLAGAS del nivel. Cada una declara su par benefico CORRECTO (controladoPor)
  * y por que (`porQue`), tomado del grafo. `forma` define el sprite procedural.
- * `cultivo` ata la plaga a un cultivo real para el contexto.
+ * `cultivo` ata la plaga a un cultivo real para el contexto (texto corto que ve
+ * el jugador en la HUD); `cultivos` es la lista de cultivos reales que ataca.
+ * `fuente` es honesto sobre el origen del par: 'grafo' = relacion CONTROLS del
+ * grafo AGE; 'cenicafe' = control del cafe documentado por Cenicafe.
  */
 export const PLAGAS_DOOM = [
   {
@@ -187,9 +198,11 @@ export const PLAGAS_DOOM = [
     forma: 'oruga',
     color: '#8aa84a',
     cultivo: 'Maiz',
-    dano: 'Devora el cogollo del maiz y deja la planta sin punto de crecimiento.',
+    cultivos: ['Maiz'],
+    dano: 'Se mete en el cogollo del maiz y se come el centro tierno: la planta queda sin punto de crecimiento.',
     controladoPor: 'bt',
-    porQue: 'Es una ORUGA que come hoja: el Bt la intoxica al primer bocado. Trichogramma tambien sirve atacando el HUEVO antes de que nazca.',
+    porQue: 'Es una ORUGA que come hoja: el Bt la intoxica al primer bocado y deja de comer en horas. La avispita Trichogramma tambien sirve atacando el HUEVO antes de que nazca.',
+    fuente: 'grafo',
     velocidad: 0.014,
     vitalidad: 2,
   },
@@ -201,9 +214,11 @@ export const PLAGAS_DOOM = [
     forma: 'oruga',
     color: '#c98a4a',
     cultivo: 'Maiz',
-    dano: 'Se mete en la mazorca y se come los granos en formacion.',
+    cultivos: ['Maiz'],
+    dano: 'Entra por la punta de la mazorca y se come los granos tiernos en formacion.',
     controladoPor: 'bt',
-    porQue: 'Otra oruga masticadora: el Bt es el control biologico estandar. Tambien cae con chinche depredador (podisus) y crisopa.',
+    porQue: 'Otra oruga masticadora: el Bt es el control biologico estandar, le rompe el intestino al primer bocado. Tambien cae con el chinche depredador (podisus) y la crisopa.',
+    fuente: 'grafo',
     velocidad: 0.013,
     vitalidad: 2,
   },
@@ -215,9 +230,11 @@ export const PLAGAS_DOOM = [
     forma: 'mosca',
     color: '#f2f2f2',
     cultivo: 'Frijol / hortalizas',
-    dano: 'Chupa savia y transmite virus que enrollan y amarillan la hoja.',
+    cultivos: ['Frijol', 'Ahuyama', 'Hortalizas'],
+    dano: 'Chupa savia por debajo de la hoja y le pega virus que la enrollan y amarillan.',
     controladoPor: 'beauveria',
-    porQue: 'Insecto de cuerpo blando: el hongo Beauveria lo penetra y lo seca. Tambien la parasita la avispita Encarsia.',
+    porQue: 'Insecto de cuerpo blando: el hongo Beauveria germina sobre ella y la seca por dentro. Tambien la parasita la avispita Encarsia y la caza la crisopa.',
+    fuente: 'grafo',
     velocidad: 0.020,
     vitalidad: 1,
   },
@@ -229,9 +246,11 @@ export const PLAGAS_DOOM = [
     forma: 'escarabajo',
     color: '#3a2410',
     cultivo: 'Cafe',
-    dano: 'Perfora el grano de cafe y arruina la calidad de la cosecha.',
+    cultivos: ['Cafe'],
+    dano: 'Escarabajito que perfora el grano de cafe por dentro y arruina la calidad de la cosecha.',
     controladoPor: 'beauveria',
-    porQue: 'El escarabajo vive DENTRO del grano: solo un hongo entomopatogeno como Beauveria lo alcanza ahi. Estandar Cenicafe.',
+    porQue: 'El escarabajo vive DENTRO del grano: solo un hongo como Beauveria lo alcanza ahi y lo seca. Es el estandar de Cenicafe.',
+    fuente: 'grafo',
     velocidad: 0.009,
     vitalidad: 3,
   },
@@ -243,9 +262,11 @@ export const PLAGAS_DOOM = [
     forma: 'afido',
     color: '#4a7a2e',
     cultivo: 'Frijol',
-    dano: 'Forma colonias pegajosas que chupan savia y debilitan los brotes.',
+    cultivos: ['Frijol', 'Hortalizas'],
+    dano: 'Forma colonias pegajosas en los brotes, chupa la savia y debilita la mata.',
     controladoPor: 'catarina',
-    porQue: 'La mariquita y su larva devoran colonias de pulgones a docenas. La crisopa tambien los caza.',
+    porQue: 'La mariquita y su larva devoran colonias enteras de pulgones, a docenas por dia. La crisopa tambien los caza.',
+    fuente: 'grafo',
     velocidad: 0.011,
     vitalidad: 1,
   },
@@ -257,9 +278,11 @@ export const PLAGAS_DOOM = [
     forma: 'acaro',
     color: '#c0392b',
     cultivo: 'Mora / tomate',
-    dano: 'Acaro que pica el enves de la hoja, la puntea y la seca.',
+    cultivos: ['Mora', 'Tomate', 'Fresa'],
+    dano: 'Acaro diminuto que pica el enves de la hoja, la deja punteada y la seca; teje telarana fina.',
     controladoPor: 'crisopa',
-    porQue: 'Acaro chupador diminuto: lo controlan depredadores como la crisopa y acaros benefcos (neoseiulus). El hongo Beauveria ayuda.',
+    porQue: 'Acaro chupador diminuto: lo cazan depredadores como la crisopa y los acaros buenos (neoseiulus, amblyseius). El hongo Beauveria tambien ayuda.',
+    fuente: 'grafo',
     velocidad: 0.012,
     vitalidad: 1,
   },


### PR DESCRIPTION
## Feature
Mejorar la DIDÁCTICA del contenido de plagas y curas en los juegos de la finca (Defensores de la Finca y Doom de la Finca) para que enseñen manejo agroecológico REAL al pilar campesino (piloto Mario y demás). Cada plaga y cada cura debe enseñar: qué es la plaga, qué cultivos ataca, qué daño hace, y qué la controla de verdad — grounded en el grafo AGE, sin inventar.

## De dónde salía la data
- `src/components/juego/defensoresFincaData.js` → `PARES_CONTROL` (plaga ↔ organismo benéfico) del platformer.
- `src/components/juego/doomFincaData.js` → `PLAGAS_DOOM` + `BENEFICOS_DOOM` del raycaster en primera persona.
- Grounding: `public/grafo-relations.json` (relación `pest_controllers` exportada del grafo Apache AGE).

## Cambios
- **Cada PLAGA** ahora declara los **cultivos** que ataca (`cultivos[]`) y un **daño** en frase clara (tú/usted colombiano), no etiquetas sueltas.
- **Cada CURA** explica **cómo** actúa contra esa plaga (el porqué del control biológico).
- **Campo `fuente` honesto por par**: `grafo` (verificado en AGE), `cenicafe` / `ica-ciat` (control biológico institucional documentado donde el subset OSS no tiene el par exacto), `ecologia` (depredación general rotulada como tal). **Nunca se inventa una relación plaga-cura falsa.**
- **Doom — ficha educativa**: ahora muestra el daño de la plaga y un "por qué funciona" la cura; la lista de referencia muestra el cultivo afectado. (`DoomFincaScreen.jsx`)
- **Defensores**: el aliado equivocado ahora dice QUÉ plaga sí controla, y cada botón de aliado nombra su plaga objetivo (`aria-label`/`title`). (`DefensoresFincaScreen.jsx`)
- Microcopy más campesino y claro; cero voseo argentino.
- **Sin cambios de jugabilidad/mecánica ni de visual general** (esas son pasadas aparte).

## Ejemplos de plaga → cura explicada
- **Gusano cogollero** (*Spodoptera frugiperda*, ataca Maíz) → **avispita Trichogramma**: pone su huevo DENTRO del huevo del gusano, la larva nunca nace y no come el cogollo. (grafo)
- **Broca del café** (*Hypothenemus hampei*, ataca Café) → **avispa Cephalonomia** + **Beauveria**: la avispita entra al grano picado donde el veneno no llega. (grafo/Cenicafé)
- **Pulgón** (Aphididae, Frijol/Tomate) → **mariquita**: ella y sus larvas se comen colonias enteras, decenas al día. (grafo)

## Grounded vs sin dato
- **Defensores (14 pares)**: 8 `grafo` (verificados en AGE), 2 `cenicafe` (broca, minador del café), 3 `ica-ciat` (chicharrita, elotero, barrenador del maíz), 1 `ecologia` (saltamontes↔mantis, depredación general rotulada honestamente).
- **Doom (6 plagas)**: 6 `grafo`. Ninguna sin dato; ninguna relación inventada.

## Tests
- 70+ casos vitest verdes (incluye tests nuevos: cultivos presentes, `fuente` válida, claridad del copy, cero voseo argentino).
- `vite build` verde · eslint 0 warnings.
- Suite completa: 271 archivos / 4959 tests passing (2 errores ajenos en `networkRetry.test.js`, no tocado).

## Qué falta (pasadas aparte)
- Jugabilidad/mecánica de plagas y curas.
- Mejora visual general de las fichas (esta pasada solo mejora claridad del contenido y surface de datos ya grounded).

Refs: pilar campesino (piloto Mario); didáctica plagas/curas del juego

🤖 Generated with [Claude Code](https://claude.com/claude-code)