### PR TITLE
fix(test): DB_VERSION del visual suite en sync con dbCore (26)

### DIFF
--- a/tests/visual/visualTestUtils.js
+++ b/tests/visual/visualTestUtils.js
@@ -345,7 +345,7 @@ async function seedIndexedDb(page, state) {
     // Debe coincidir con DB_VERSION exportado en src/db/dbCore.js. Corre en
     // contexto de browser (page.evaluate) → no se puede importar; mantener
     // sincronizado a mano. Abrir con version < existente lanza VersionError.
-    const DB_VERSION = 25;
+    const DB_VERSION = 26;
     const db = await new Promise((resolve, reject) => {
       const req = indexedDB.open(DB_NAME, DB_VERSION);
       req.onsuccess = () => resolve(req.result);


### PR DESCRIPTION
## Bug
El suite "Playwright visual snapshots" reventaba en TODOS los PRs con `VersionError: requested version (25) < existing (26)` dentro de `loginAndSeed`, antes de tomar cualquier captura.

## Causa raíz
`tests/visual/visualTestUtils.js` (línea 348) tenía `const DB_VERSION = 25;` hardcodeado, que quedó stale frente a `src/db/dbCore.js` (línea 41: `export const DB_VERSION = 26;`). Abrir IndexedDB con una versión menor a la existente lanza `VersionError` → bloquea el seed y, con él, todos los snapshots visuales.

El literal corre dentro de `page.evaluate` (contexto del browser), así que **no se puede importar** desde `dbCore.js`; se mantiene el número a mano con el comentario de sync que ya estaba presente.

## Cambios
- `tests/visual/visualTestUtils.js`: `DB_VERSION` 25 → 26, en sync con `dbCore.js`.

## Tests
- `vite build` verde.
- `eslint tests/visual/visualTestUtils.js --max-warnings=0` exit 0.
- N/A correr Playwright (requiere chromium); el fix es alinear el literal con `dbCore.js` (26), que es la condición que desbloquea el seed.

Refs: regresión visual suite, dbCore DB_VERSION=26

🤖 Generated with [Claude Code](https://claude.com/claude-code)