### PR TITLE
fix(temas): contraste de texto en juego/directorio/Doom para temas claros (Fase 2.1, gated)

### DIFF
--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { ChevronLeft, Search, Sprout, Leaf, X, BookOpen } from 'lucide-react';
 import { searchSpecies, buildSpeciesFicha } from '../../services/directorioEspecies.js';
 import SpeciesFicha from './SpeciesFicha.jsx';
+import { fvhSkinClass } from '../../config/fvhSkin.js';
 
 /**
  * DirectorioEspeciesScreen — explorador visual del catálogo de especies.
@@ -86,8 +87,8 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
   // VISTA FICHA -------------------------------------------------------------
   if (selected) {
     return (
-      <div className="min-h-[100dvh] bg-slate-950 text-white">
-        <header className="sticky top-0 z-10 flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2 bg-slate-950/85 backdrop-blur border-b border-slate-800/60">
+      <div className={fvhSkinClass('jp-directorio min-h-[100dvh] bg-slate-950 text-white')}>
+        <header className="jp-dir-header sticky top-0 z-10 flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2 bg-slate-950/85 backdrop-blur border-b border-slate-800/60">
           <button
             type="button"
             onClick={backToSearch}
@@ -99,8 +100,8 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
           <div className="flex items-center gap-2 min-w-0">
             <Leaf size={20} className="text-emerald-400 shrink-0" aria-hidden="true" />
             <div className="min-w-0">
-              <h1 className="text-base font-bold leading-tight text-white truncate">{selected.comun}</h1>
-              <p className="text-xs text-slate-400 leading-tight italic truncate">{selected.cientifico}</p>
+              <h1 className="jp-tinta text-base font-bold leading-tight text-white truncate">{selected.comun}</h1>
+              <p className="jp-tinta-suave text-xs text-slate-400 leading-tight italic truncate">{selected.cientifico}</p>
             </div>
           </div>
         </header>
@@ -111,7 +112,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
 
   // VISTA BÚSQUEDA ----------------------------------------------------------
   return (
-    <div className="min-h-[100dvh] bg-slate-950 text-white">
+    <div className={fvhSkinClass('jp-directorio min-h-[100dvh] bg-slate-950 text-white')}>
       <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
         {onBack ? (
           <button
@@ -126,8 +127,8 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
         <div className="flex items-center gap-2">
           <Sprout size={22} className="text-emerald-400 shrink-0" aria-hidden="true" />
           <div>
-            <h1 className="text-lg font-bold leading-tight text-white">Directorio de especies</h1>
-            <p className="text-xs text-slate-400 leading-tight">Explora el catálogo: clima, asociaciones, biopreparados y plagas.</p>
+            <h1 className="jp-tinta text-lg font-bold leading-tight text-white">Directorio de especies</h1>
+            <p className="jp-tinta-suave text-xs text-slate-400 leading-tight">Explora el catálogo: clima, asociaciones, biopreparados y plagas.</p>
           </div>
         </div>
       </header>
@@ -144,7 +145,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
             placeholder="Frailejón, mandarina, frijol cargamanto…"
             aria-label="Buscar especie por nombre"
             data-testid="directorio-search-input"
-            className="w-full min-h-[48px] pl-10 pr-10 rounded-xl bg-slate-900 border border-slate-700 text-white placeholder:text-slate-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500/50"
+            className="jp-dir-input w-full min-h-[48px] pl-10 pr-10 rounded-xl bg-slate-900 border border-slate-700 text-white placeholder:text-slate-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500/50"
           />
           {query && (
             <button
@@ -162,20 +163,20 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
       {/* Resultados / estados */}
       <div className="px-4 pt-4">
         {loadingFicha && (
-          <p className="text-sm text-slate-400" data-testid="directorio-loading-ficha">Abriendo la ficha…</p>
+          <p className="jp-tinta-suave text-sm text-slate-400" data-testid="directorio-loading-ficha">Abriendo la ficha…</p>
         )}
 
         {!loadingFicha && searching && (
-          <p className="text-sm text-slate-400">Buscando…</p>
+          <p className="jp-tinta-suave text-sm text-slate-400">Buscando…</p>
         )}
 
         {!loadingFicha && !searching && touched && query.trim().length >= 2 && results.length === 0 && (
           <div className="text-center py-10" data-testid="directorio-empty">
             <Leaf size={32} className="mx-auto text-slate-700 mb-2" aria-hidden="true" />
-            <p className="text-sm text-slate-400">
+            <p className="jp-tinta text-sm text-slate-400">
               No encontramos “{query.trim()}” en el catálogo todavía.
             </p>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="jp-tinta-suave text-xs text-slate-500 mt-1">
               Prueba con otro nombre común o el nombre científico.
             </p>
           </div>
@@ -184,7 +185,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
         {!loadingFicha && results.length > 0 && (
           <>
             {results.length > 1 && (
-              <p className="text-xs text-slate-400 mb-2">
+              <p className="jp-tinta-suave text-xs text-slate-400 mb-2">
                 {results.length} coincidencias — elige una:
               </p>
             )}
@@ -194,16 +195,16 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
                   <button
                     type="button"
                     onClick={() => selectSpecies(r.id)}
-                    className="w-full text-left rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-600/60 active:bg-slate-800/70 p-3 transition-colors flex items-center gap-3"
+                    className="jp-dir-card w-full text-left rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-600/60 active:bg-slate-800/70 p-3 transition-colors flex items-center gap-3"
                   >
                     <Leaf size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />
                     <span className="min-w-0">
-                      <span className="block text-sm font-bold text-emerald-100 leading-tight truncate">{r.comun || r.id}</span>
+                      <span className="jp-tinta block text-sm font-bold text-emerald-100 leading-tight truncate">{r.comun || r.id}</span>
                       {r.cientifico && (
-                        <span className="block text-xs italic text-slate-400 leading-tight truncate">{r.cientifico}</span>
+                        <span className="jp-tinta-suave block text-xs italic text-slate-400 leading-tight truncate">{r.cientifico}</span>
                       )}
                       {r.familia && (
-                        <span className="block text-[10px] text-slate-500 leading-tight">{r.familia}</span>
+                        <span className="jp-tinta-suave block text-[10px] text-slate-500 leading-tight">{r.familia}</span>
                       )}
                     </span>
                   </button>
@@ -217,7 +218,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
         {!loadingFicha && !searching && !touched && results.length === 0 && (
           <div className="text-center py-12" data-testid="directorio-hint">
             <BookOpen size={34} className="mx-auto text-slate-700 mb-3" aria-hidden="true" />
-            <p className="text-sm text-slate-400 max-w-xs mx-auto leading-relaxed">
+            <p className="jp-tinta-suave text-sm text-slate-400 max-w-xs mx-auto leading-relaxed">
               Busca cualquier especie del catálogo y mira su piso térmico, con qué
               se asocia, qué biopreparados le sirven y qué plagas la afectan.
             </p>

--- a/src/components/juego/DoomFincaScreen.jsx
+++ b/src/components/juego/DoomFincaScreen.jsx
@@ -999,7 +999,7 @@ export default function DoomFincaScreen({ onBack, onHome }) {
         </div>
 
         {/* Barra de vitalidad */}
-        <div className="flex items-center gap-2 text-xs font-bold shrink-0">
+        <div className="jp-doom-vital flex items-center gap-2 text-xs font-bold shrink-0">
           <Heart size={13} className="text-emerald-300" aria-hidden="true" />
           <div className="jp-doom-vital-riel flex-1 h-3.5 bg-slate-800/60 rounded-full overflow-hidden border border-emerald-900/40">
             <div
@@ -1085,25 +1085,25 @@ export default function DoomFincaScreen({ onBack, onHome }) {
               aria-live="polite"
             >
               <div className="flex items-center justify-between gap-2 mb-1">
-                <span className="flex items-center gap-1 text-emerald-300 font-black text-xs">
+                <span className="jp-acento-vida flex items-center gap-1 text-emerald-300 font-black text-xs">
                   <GraduationCap size={14} aria-hidden="true" /> ¡Control biologico!
                 </span>
-                <span className="text-lime-300 font-black text-xs">+{ficha.puntos}{ficha.combo > 1 ? ` · combo x${ficha.combo}` : ''}</span>
+                <span className="jp-acento-vida text-lime-300 font-black text-xs">+{ficha.puntos}{ficha.combo > 1 ? ` · combo x${ficha.combo}` : ''}</span>
               </div>
-              <p className="text-2xs text-white/90 leading-snug">
-                <b className="text-amber-200">{ficha.benefico}</b>
-                <span className="text-white/60"> ({ficha.beneficoCientifico})</span>
-                <span className="text-emerald-300"> controla a </span>
-                <b className="text-red-200">{ficha.plaga}</b>
-                {ficha.cultivo ? <span className="text-white/70"> en {ficha.cultivo}</span> : null}.
+              <p className="jp-tinta text-2xs text-white/90 leading-snug">
+                <b className="jp-doom-benefico text-amber-200">{ficha.benefico}</b>
+                <span className="jp-tinta-suave text-white/60"> ({ficha.beneficoCientifico})</span>
+                <span className="jp-acento-vida text-emerald-300"> controla a </span>
+                <b className="jp-doom-plaga text-red-200">{ficha.plaga}</b>
+                {ficha.cultivo ? <span className="jp-tinta-suave text-white/70"> en {ficha.cultivo}</span> : null}.
               </p>
               {ficha.dano ? (
-                <p className="text-2xs text-red-200/80 leading-snug mt-1">
-                  <b className="text-red-300">El dano:</b> {ficha.dano}
+                <p className="jp-doom-plaga text-2xs text-red-200/80 leading-snug mt-1">
+                  <b className="jp-doom-plaga text-red-300">El dano:</b> {ficha.dano}
                 </p>
               ) : null}
-              <p className="text-2xs text-emerald-100/90 leading-snug mt-1">
-                <b className="text-emerald-300">Por que funciona:</b> {ficha.porQue}
+              <p className="jp-tinta text-2xs text-emerald-100/90 leading-snug mt-1">
+                <b className="jp-acento-vida text-emerald-300">Por que funciona:</b> {ficha.porQue}
               </p>
             </div>
           )}
@@ -1190,9 +1190,9 @@ export default function DoomFincaScreen({ onBack, onHome }) {
 
         {/* ── Tarjeta de la decoracion mirada (ciclo de la finca) ── */}
         {fase === 'jugando' && leccion && (
-          <div className="bg-amber-950/50 border border-amber-600/40 rounded-xl p-2.5 text-center" role="status">
+          <div className="jp-doom-leccion bg-amber-950/50 border border-amber-600/40 rounded-xl p-2.5 text-center" role="status">
             <Sprout size={13} className="inline-block mr-1 text-amber-300" aria-hidden="true" />
-            <span className="text-xs text-amber-100 font-medium">{leccion}</span>
+            <span className="jp-tinta text-xs text-amber-100 font-medium">{leccion}</span>
           </div>
         )}
 
@@ -1219,25 +1219,25 @@ export default function DoomFincaScreen({ onBack, onHome }) {
                   backgroundColor: sel ? `${b.color}22` : 'rgba(255,255,255,0.05)',
                 }}
               >
-                <span className="absolute top-0.5 left-1 text-2xs text-white/40 font-bold">{i + 1}</span>
+                <span className="jp-tinta-suave absolute top-0.5 left-1 text-2xs text-white/40 font-bold">{i + 1}</span>
                 <span className="text-lg" aria-hidden="true">{b.emoji}</span>
-                <span className="text-2xs font-bold text-white/80 leading-none text-center">{b.nombre.split(' ')[0]}</span>
+                <span className="jp-tinta text-2xs font-bold text-white/80 leading-none text-center">{b.nombre.split(' ')[0]}</span>
               </button>
             );
           })}
         </div>
-        <p className="text-2xs text-emerald-400/70 text-center -mt-1">
+        <p className="jp-acento-vida text-2xs text-emerald-400/70 text-center -mt-1">
           Verde = recomendado para esta ronda. Toca para equipar.
         </p>
 
         {/* ── Controles desktop ── */}
-        <div className="text-2xs text-slate-500 text-center leading-relaxed">
+        <div className="jp-tinta-suave text-2xs text-slate-500 text-center leading-relaxed">
           WASD = mover · Q/E = lateral · raton = girar · barra/F = soltar · 1-5 = elegir benefico
         </div>
 
         {/* ── Referencia: pares plaga-benefico reales (control biologico) ── */}
-        <details className="text-2xs text-slate-400">
-          <summary className="cursor-pointer font-bold text-emerald-400/80">
+        <details className="jp-tinta-suave text-2xs text-slate-400">
+          <summary className="jp-acento-vida cursor-pointer font-bold text-emerald-400/80">
             Pares plaga → control biologico (datos del grafo de Chagra)
           </summary>
           <ul className="mt-2 space-y-1.5 pl-1">
@@ -1247,14 +1247,14 @@ export default function DoomFincaScreen({ onBack, onHome }) {
                 <li key={plaga.id} className="leading-snug">
                   <span className="flex items-center gap-1 flex-wrap">
                     <span aria-hidden="true">{plaga.emoji}</span>
-                    <b className="text-white/85">{plaga.nombre}</b>
-                    <span className="text-slate-600 italic">({plaga.cientifico})</span>
+                    <b className="jp-tinta text-white/85">{plaga.nombre}</b>
+                    <span className="jp-tinta-suave text-slate-600 italic">({plaga.cientifico})</span>
                     {plaga.cultivo ? (
-                      <span className="text-amber-300/70">en {plaga.cultivo}</span>
+                      <span className="jp-tinta-suave text-amber-300/70">en {plaga.cultivo}</span>
                     ) : null}
                     <ChevronRight size={11} className="text-slate-600" aria-hidden="true" />
                     <span aria-hidden="true">{benef?.emoji}</span>
-                    <span className="text-emerald-300">{benef?.nombre || plaga.controladoPor}</span>
+                    <span className="jp-acento-vida text-emerald-300">{benef?.nombre || plaga.controladoPor}</span>
                   </span>
                 </li>
               );

--- a/src/components/juego/MiFincaVivaScreen.jsx
+++ b/src/components/juego/MiFincaVivaScreen.jsx
@@ -186,10 +186,10 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
         {/* Encabezado lúdico + botón de audio grande */}
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
-            <p className="text-xs font-bold text-emerald-300/80 uppercase tracking-widest">
+            <p className="jp-tinta-suave text-xs font-bold text-emerald-300/80 uppercase tracking-widest">
               Nivel {game.nivel} de 4
             </p>
-            <h2 className="text-2xl font-black text-white leading-tight flex items-center gap-2">
+            <h2 className="jp-tinta text-2xl font-black text-white leading-tight flex items-center gap-2">
               <span aria-hidden="true">{mundo.emoji}</span>
               {mundo.nombreNino}
             </h2>
@@ -219,8 +219,8 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
             <Volume2 size={22} aria-hidden="true" />
           </button>
           <div className="flex-1">
-            <p className="text-base text-emerald-50 font-medium leading-relaxed">{mundo.mensaje}</p>
-            <p className="text-xs text-emerald-300/70 mt-1">
+            <p className="jp-tinta text-base text-emerald-50 font-medium leading-relaxed">{mundo.mensaje}</p>
+            <p className="jp-tinta-suave text-xs text-emerald-300/70 mt-1">
               Esto es de verdad: tu finca está en la etapa «{mundo.nombreReal}».
             </p>
           </div>
@@ -236,8 +236,8 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           <span className="text-4xl shrink-0" aria-hidden="true">🛡️</span>
           <span className="flex-1 min-w-0">
             {/* eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- nombre del juego, ES-CO. */}
-            <span className="block text-base font-black text-white">Defensores de la Finca</span>
-            <span className="block text-sm text-teal-100/90 leading-snug">
+            <span className="jp-tinta block text-base font-black text-white">Defensores de la Finca</span>
+            <span className="jp-tinta-suave block text-sm text-teal-100/90 leading-snug">
               Corre y salta por la finca, recoge cultivos y suelta los bichos
               buenos que controlan a las plagas. Así aprendes control biológico.
             </span>
@@ -254,8 +254,8 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
         >
           <span className="text-4xl shrink-0" aria-hidden="true">🌽</span>
           <span className="flex-1 min-w-0">
-            <span className="block text-base font-black text-white">La Milpa</span>
-            <span className="block text-sm text-lime-100/90 leading-snug">
+            <span className="jp-tinta block text-base font-black text-white">La Milpa</span>
+            <span className="jp-tinta-suave block text-sm text-lime-100/90 leading-snug">
               Siembra maíz, fríjol y ahuyama juntos (las tres hermanas) y mira
               cómo se ayudan y rinden más que sembrar cada uno solo.
             </span>
@@ -272,8 +272,9 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
         >
           <span className="text-4xl shrink-0" aria-hidden="true">🎯</span>
           <span className="flex-1 min-w-0">
-            <span className="block text-base font-black text-white">Doom de la Finca</span>
-            <span className="block text-sm text-orange-100/90 leading-snug">
+            {/* eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- nombre del juego, ES-CO. */}
+            <span className="jp-tinta block text-base font-black text-white">Doom de la Finca</span>
+            <span className="jp-tinta-suave block text-sm text-orange-100/90 leading-snug">
               Recorre el invernadero en primera persona, identifica las plagas y
               lanza el controlador biologico correcto. Protege tu cultivo.
             </span>
@@ -292,8 +293,8 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
         >
           <span className="text-4xl shrink-0" aria-hidden="true">🪱</span>
           <span className="flex-1 min-w-0">
-            <span className="block text-base font-black text-white">Mundo Subsuelo</span>
-            <span className="block text-sm text-cyan-100/90 leading-snug">
+            <span className="jp-tinta block text-base font-black text-white">Mundo Subsuelo</span>
+            <span className="jp-tinta-suave block text-sm text-cyan-100/90 leading-snug">
               Baja bajo tus botas: alimenta la tierra con compost, conecta raíces
               con hongos y despierta a las lombrices. Mira cómo revive el suelo.
             </span>
@@ -304,8 +305,8 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
         {/* Barra de progreso del mundo (alegre, pero honesta: % real) */}
         <div>
           <div className="flex items-center justify-between mb-1.5">
-            <span className="text-sm font-bold text-emerald-200">Tu finca crece</span>
-            <span className="text-sm font-black text-emerald-300">{game.progreso}%</span>
+            <span className="jp-tinta text-sm font-bold text-emerald-200">Tu finca crece</span>
+            <span className="jp-acento-vida text-sm font-black text-emerald-300">{game.progreso}%</span>
           </div>
           <div className="h-4 bg-slate-800/60 rounded-full overflow-hidden border border-emerald-900/40">
             <div
@@ -319,7 +320,7 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
             />
           </div>
           {game.mundoSiguiente && !game.vacia && (
-            <p className="text-xs text-emerald-300/70 mt-1.5">
+            <p className="jp-tinta-suave text-xs text-emerald-300/70 mt-1.5">
               Lo que sigue: {game.mundoSiguiente.emoji} {game.mundoSiguiente.nombreNino}
             </p>
           )}
@@ -332,8 +333,8 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
             className="bg-gradient-to-br from-amber-900/30 to-emerald-900/30 border-2 border-amber-400/40 rounded-3xl p-5 text-center"
           >
             <div className="text-5xl mb-2" aria-hidden="true">🌱</div>
-            <h3 className="text-xl font-black text-white">¡Empieza tu finca!</h3>
-            <p className="text-sm text-amber-50 mt-2 leading-relaxed">
+            <h3 className="jp-tinta text-xl font-black text-white">¡Empieza tu finca!</h3>
+            <p className="jp-tinta text-sm text-amber-50 mt-2 leading-relaxed">
               Tu finca está esperando. Siembra tu primera planta y mira cómo cobra
               vida: llegarán mariposas, abejas y muchas criaturas más.
             </p>
@@ -349,7 +350,7 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           <>
             {/* Misiones */}
             <section data-testid="misiones-juego" className="flex flex-col gap-3">
-              <h3 className="text-lg font-black text-white flex items-center gap-2">
+              <h3 className="jp-tinta text-lg font-black text-white flex items-center gap-2">
                 🎯 Mis misiones
                 <span className="text-sm font-bold text-emerald-300 bg-emerald-800/50 rounded-full px-3 py-0.5">
                   {game.misiones.filter((m) => m.cumplida).length} / {game.misiones.length}
@@ -382,7 +383,7 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
             data-testid="insignias-juego"
             className="jp-mfv-panel bg-gradient-to-br from-amber-950/50 to-yellow-950/30 border border-amber-700/40 rounded-3xl p-4"
           >
-            <h3 className="text-lg font-black text-white flex items-center gap-2 mb-3">
+            <h3 className="jp-tinta text-lg font-black text-white flex items-center gap-2 mb-3">
               <Trophy size={20} className="text-amber-300" aria-hidden="true" />
               Mis insignias
             </h3>
@@ -407,7 +408,7 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
         {/* Nota honesta para acompañantes (anti-paternalismo, cariño real) */}
         <div className="flex items-start gap-2 pt-1">
           <Sparkles size={14} className="text-emerald-500 shrink-0 mt-0.5" aria-hidden="true" />
-          <p className="text-xs text-slate-400 leading-relaxed">
+          <p className="jp-tinta-suave text-xs text-slate-400 leading-relaxed">
             Este juego no inventa premios: tu finca crece de verdad con el trabajo
             real. Cada planta que siembras, cada cosecha y cada cuidado sin venenos
             hace que tu mundo florezca. 🌿

--- a/src/components/juego/__tests__/temas-fase2-1-contraste.test.jsx
+++ b/src/components/juego/__tests__/temas-fase2-1-contraste.test.jsx
@@ -1,0 +1,142 @@
+/**
+ * temas-fase2-1-contraste.test.jsx — Fase 2.1: CONTRASTE de texto por tema.
+ *
+ * El test visual integral encontró que en los TEMAS CLAROS (nature/minimalista),
+ * con la flag VITE_FINCA_VIVA_HOME_PERFIL ON, varios textos del HUB de juego, del
+ * Directorio y del Doom quedaban ILEGIBLES: el FONDO de los paneles ya viraba a
+ * superficie clara del tema (Fase 2), pero el TEXTO seguía en utilidades Tailwind
+ * pensadas para fondo oscuro (text-white / text-emerald-50/100/200…) → claro
+ * sobre claro.
+ *
+ * El fix tona ese texto vía las CSS vars del tema, marcándolo con clases
+ * semánticas (`jp-tinta` principal, `jp-tinta-suave` secundario, `jp-acento-vida`
+ * para el verde legible). Las reglas viven en juego-pulido.css bajo `.fvh-skin`
+ * y solo se ACTIVAN con la flag ON (la clase fvh-skin se monta en el contenedor).
+ * Con la flag OFF (prod), el contenedor NO lleva fvh-skin → el texto conserva su
+ * utilidad Tailwind original (dark) y prod queda EXACTO como hoy.
+ *
+ * Este test verifica el CONTRATO estructural: (1) el texto-cuerpo afectado lleva
+ * la clase semántica de tinta (toma var del tema, no un color lavado fijo); y
+ * (2) el gating fvh-skin ON/OFF en el contenedor raíz. NO renderiza pixeles
+ * (sin chromium): la legibilidad real (ratios AA) se valida aparte con rsvg.
+ *
+ * Español de Colombia (tú/usted), sin voseo.
+ */
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Flag mockeable: ON (dev) vs OFF (prod) en el mismo archivo.
+let flagOn = false;
+vi.mock('../../../config/fincaVivaHomeFlag', () => ({
+  fincaVivaHomePerfilActivo: () => flagOn,
+}));
+
+// IDB de procesos: finca vacía por defecto → el hub muestra la invitación.
+const listFarmProcessesMock = vi.fn(() => Promise.resolve([]));
+const getFarmEventsMock = vi.fn(() => Promise.resolve([]));
+vi.mock('../../../db/farmProcessCache', () => ({
+  listFarmProcesses: (...a) => listFarmProcessesMock(...a),
+  getFarmEvents: (...a) => getFarmEventsMock(...a),
+}));
+vi.mock('../../../services/userProfileService', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, getProfile: () => ({ fincaSlug: 'finca-juli' }) };
+});
+vi.mock('../../../services/ttsService', () => ({
+  speak: vi.fn(), stop: vi.fn(), isSupported: () => false,
+}));
+vi.mock('../../../services/agentSoundService', () => ({
+  agentSounds: { chime: vi.fn(), listen: vi.fn(), start: vi.fn(), error: vi.fn(), cancel: vi.fn() },
+  isSoundEnabled: () => false,
+  setSoundEnabled: vi.fn(),
+}));
+vi.mock('../../../services/usageTelemetryService', () => ({
+  recordGameStart: vi.fn(), recordGameComplete: vi.fn(),
+}));
+
+// Directorio: catálogo mockeado para un resultado de búsqueda determinista.
+const searchSpeciesMock = vi.fn(() => Promise.resolve([
+  { id: 'coffea_arabica', comun: 'Café', cientifico: 'Coffea arabica', familia: 'Rubiaceae' },
+]));
+vi.mock('../../../services/directorioEspecies.js', () => ({
+  searchSpecies: (...a) => searchSpeciesMock(...a),
+  buildSpeciesFicha: vi.fn(() => Promise.resolve(null)),
+}));
+
+import MiFincaVivaScreen from '../MiFincaVivaScreen';
+import DirectorioEspeciesScreen from '../../DirectorioEspecies/DirectorioEspeciesScreen';
+
+beforeEach(() => {
+  flagOn = false;
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+});
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('Fase 2.1 — Mi Finca Viva (hub): texto-cuerpo toma tinta del tema', () => {
+  it('el título del mundo y el mensaje llevan la clase de tinta del tema', () => {
+    flagOn = true;
+    render(<MiFincaVivaScreen />);
+    // "La tierra que despierta" (estado vacío): el título del mundo.
+    const titulo = screen.getByText('La tierra que despierta');
+    expect(titulo).toHaveClass('jp-tinta');
+    // El mensaje del mundo también vira a tinta del tema.
+    const mensaje = screen.getByText(/Tu finca está empezando/);
+    expect(mensaje).toHaveClass('jp-tinta');
+  });
+
+  it('las descripciones de los subjuegos llevan tinta SUAVE (legible AA)', () => {
+    flagOn = true;
+    render(<MiFincaVivaScreen />);
+    const desc = screen.getByText(/Corre y salta por la finca/);
+    expect(desc).toHaveClass('jp-tinta-suave');
+    const descMilpa = screen.getByText(/Siembra maíz, fríjol y ahuyama/);
+    expect(descMilpa).toHaveClass('jp-tinta-suave');
+    const descDoom = screen.getByText(/Recorre el invernadero/);
+    expect(descDoom).toHaveClass('jp-tinta-suave');
+  });
+
+  it('flag ON: el contenedor raíz del hub adopta fvh-skin (reglas de tinta activas)', () => {
+    flagOn = true;
+    render(<MiFincaVivaScreen />);
+    expect(screen.getByTestId('mi-finca-viva-screen')).toHaveClass('fvh-skin');
+  });
+
+  it('flag OFF (prod): el hub NO lleva fvh-skin → las reglas de tinta no aplican', () => {
+    flagOn = false;
+    render(<MiFincaVivaScreen />);
+    expect(screen.getByTestId('mi-finca-viva-screen')).not.toHaveClass('fvh-skin');
+  });
+});
+
+describe('Fase 2.1 — Directorio de especies: título de resultado toma tinta del tema', () => {
+  it('flag ON: el contenedor raíz adopta fvh-skin (jp-directorio)', () => {
+    flagOn = true;
+    const { container } = render(<DirectorioEspeciesScreen />);
+    const root = container.firstChild;
+    expect(root).toHaveClass('jp-directorio');
+    expect(root).toHaveClass('fvh-skin');
+  });
+
+  it('flag OFF (prod): el contenedor NO lleva fvh-skin → dark intacto', () => {
+    flagOn = false;
+    const { container } = render(<DirectorioEspeciesScreen />);
+    const root = container.firstChild;
+    expect(root).toHaveClass('jp-directorio');
+    expect(root).not.toHaveClass('fvh-skin');
+  });
+
+  it('el nombre común (título) lleva jp-tinta — ya NO el emerald lavado', async () => {
+    flagOn = true;
+    render(<DirectorioEspeciesScreen initialQuery="café" />);
+    const titulo = await waitFor(() => screen.getByText('Café'));
+    expect(titulo).toHaveClass('jp-tinta');
+    // El binomio (científico) usa tinta suave (legible, secundario).
+    const binomio = screen.getByText('Coffea arabica');
+    expect(binomio).toHaveClass('jp-tinta-suave');
+  });
+});

--- a/src/styles/juego-pulido.css
+++ b/src/styles/juego-pulido.css
@@ -31,10 +31,18 @@
   --jp-raised: rgb(var(--c-surface-raised, 30 41 59));
   --jp-tinta: rgb(var(--c-slate-100, 241 245 249));
   --jp-tinta-2: rgb(var(--c-slate-200, 226 232 240));
+  /* Tinta SECUNDARIA (texto suave/meta). En claros vira a --c-slate-400 (café/
+     stone, AA ≥4.7 sobre superficie del tema); en oscuros queda slate-400 claro.
+     Es la pareja de --jp-tinta para el cuerpo de los paneles retiñidos. */
+  --jp-tinta-3: rgb(var(--c-slate-400, 148 163 184));
   --jp-sol: rgb(var(--c-amber-500, 245 158 11));
   --jp-sol-suave: rgb(var(--c-amber-500, 245 158 11) / 0.16);
   --jp-vida: rgb(var(--c-emerald-500, 16 185 129));
   --jp-vida-clara: rgb(var(--c-emerald-400, 52 211 153));
+  /* Acento de vida para TEXTO (legible AA). En oscuros = emerald-300 vivo; en
+     claros lo afinamos a emerald-500 (salvia profunda AA ≥4.7 sobre superficie
+     clara) en el bloque [data-theme] de abajo. */
+  --jp-vida-texto: rgb(var(--c-emerald-300, 110 231 183));
   --jp-vida-suave: rgb(var(--c-emerald-500, 16 185 129) / 0.14);
   --jp-velo: rgb(var(--scrim-bg, 8 30 22));
   /* Sombras consistentes (escalera de elevación) para todo el juego. */
@@ -309,6 +317,99 @@
   transition: transform 0.12s ease;
 }
 .fvh-skin .jp-mfv-insignia:hover { transform: translateY(-2px); }
+
+/* ════════════════════════════════════════════════════════════════════════════
+   CONTRASTE DE TEXTO POR TEMA (Fase 2.1) — los paneles de arriba retiñen su
+   FONDO a la superficie del tema (blanco/crema en nature/minimalista), pero el
+   texto de cuerpo seguía en utilidades Tailwind pensadas para fondo OSCURO
+   (text-white, text-emerald-50/100/200…) → claro-sobre-claro = ILEGIBLE en los
+   temas claros. Aquí tonamos ESE texto vía las vars del tema (--jp-tinta /
+   --jp-tinta-3, derivadas de --c-slate-100/400 que ya viran AA por tema).
+
+   Regla de oro: SOLO el texto de CUERPO sobre superficie del tema. NO tocamos
+   el texto sobre botones de ACENTO saturado (bg-emerald-500 → text-emerald-950,
+   que ya es oscuro-sobre-claro y se lee), ni el texto sobre el canvas/overlays
+   NEGROS del Doom (bg-black/80, etiqueta del objetivo, intro) que son oscuros
+   en los 4 temas. Verde-vivo y biopunk (oscuros) no cambian: --jp-tinta vuelve
+   a slate-100 claro → idénticos a hoy. Gated bajo .fvh-skin (prod intacto).
+
+   Las clases `jp-tinta`/`jp-tinta-suave` marcan el texto-cuerpo en el JSX; aquí
+   las resolvemos al tono correcto del tema con !important (vencen la utilidad
+   Tailwind de igual especificidad). El icono/acento decorativo se deja aparte. */
+
+/* Texto-cuerpo PRINCIPAL de los paneles del juego (títulos de mundo, mensajes,
+   descripciones de subjuegos, nombre/cuerpo de fichas). */
+.fvh-skin .jp-tinta { color: var(--jp-tinta) !important; }
+/* Texto-cuerpo SECUNDARIO (kickers, meta, notas, leyendas, ayuda). */
+.fvh-skin .jp-tinta-suave { color: var(--jp-tinta-3) !important; }
+/* Acento de VIDA (verde del tema) para piezas de TEXTO legibles (no decorativas):
+   en oscuros es el emerald vivo; en claros la salvia profunda AA del tema. Útil
+   para etiquetas tipo "controla a" / "por qué funciona" / "%". */
+.fvh-skin .jp-acento-vida { color: var(--jp-vida-texto) !important; }
+[data-theme="nature"] .fvh-skin,
+[data-theme="minimalista"] .fvh-skin { --jp-vida-texto: rgb(var(--c-emerald-500, 16 185 129)); }
+
+/* ── MI FINCA VIVA (hub): kicker de nivel, título del mundo, mensaje del mundo,
+   descripciones de las tarjetas de subjuego, barra de progreso, misiones,
+   insignias y la nota para acompañantes. El panel de mensaje (.jp-mfv-panel) y
+   las tarjetas (.jp-mfv-entrada) ya tienen fondo del tema; tonamos su texto. */
+.fvh-skin .jp-mfv-panel .jp-tinta,
+.fvh-skin .jp-mfv-entrada .jp-tinta { color: var(--jp-tinta) !important; }
+.fvh-skin .jp-mfv-panel .jp-tinta-suave,
+.fvh-skin .jp-mfv-entrada .jp-tinta-suave { color: var(--jp-tinta-3) !important; }
+
+/* ── DOOM: la ficha educativa tras un acierto (.jp-doom-ficha) tiene fondo del
+   tema (claro en nature/minimalista) por el !important de arriba → su texto debe
+   virar. El cuerpo va a --jp-tinta; el "controla a"/"por qué" usan el acento de
+   vida del tema. Los <b> de plaga (rojo) y benéfico (ámbar) son CUE semántico:
+   se leen sobre superficie clara/oscura, no se tocan. */
+.fvh-skin .jp-doom-ficha .jp-tinta { color: var(--jp-tinta) !important; }
+.fvh-skin .jp-doom-ficha .jp-tinta-suave { color: var(--jp-tinta-3) !important; }
+
+/* CUE de color plaga (rojo) / benéfico (ámbar): conserva su SEMÁNTICA en los 4
+   temas. En oscuros (biopunk/verde-vivo) queda su tono claro original (no se
+   toca). En CLAROS (nature/minimalista) la ficha tiene fondo blanco/crema → el
+   rojo/ámbar pálido se lavaba; lo bajamos a un tono profundo AA (≥4.8) que sigue
+   leyéndose como rojo/ámbar (CUE intacto). */
+[data-theme="nature"] .fvh-skin .jp-doom-plaga,
+[data-theme="minimalista"] .fvh-skin .jp-doom-plaga { color: rgb(190 30 30) !important; }
+[data-theme="nature"] .fvh-skin .jp-doom-benefico,
+[data-theme="minimalista"] .fvh-skin .jp-doom-benefico { color: rgb(var(--c-amber-700, 180 83 9)) !important; }
+
+/* Banner de lección del Doom (la decoración mirada): tenía fondo amber-950/50
+   (oscuro translúcido). En claros lo asentamos sobre superficie del tema con un
+   tinte solar para que el texto-tinta se lea. En oscuros queda como hoy. */
+[data-theme="nature"] .fvh-skin .jp-doom-leccion,
+[data-theme="minimalista"] .fvh-skin .jp-doom-leccion {
+  background: linear-gradient(180deg, var(--jp-raised), var(--jp-card)) !important;
+  border-color: rgb(var(--c-amber-500, 245 158 11) / 0.45) !important;
+}
+
+/* HUD superior del Doom (ronda/plagas/puntaje/combo/vitalidad): vive sobre
+   .jp-doom-hud, cuyo fondo ya viró a superficie del tema. Sus números usaban
+   utilidades vivas (emerald-200/amber-300/lime-300/orange-300/white) que se
+   lavaban en claros. Las tonamos a la tinta del tema SOLO en claros; el color
+   se mantiene en oscuros (donde el fondo es navy). */
+[data-theme="nature"] .fvh-skin .jp-doom-hud [class*="text-"],
+[data-theme="minimalista"] .fvh-skin .jp-doom-hud [class*="text-"],
+[data-theme="nature"] .fvh-skin .jp-doom-vital [class*="text-"],
+[data-theme="minimalista"] .fvh-skin .jp-doom-vital [class*="text-"] {
+  color: var(--jp-tinta) !important;
+}
+
+/* ── DIRECTORIO DE ESPECIES (versión skineada): el contenedor raíz pasa a
+   superficie del tema; tonamos título (nombre común), binomio, familia, header
+   y estados (buscando/vacío/guía). El nombre común usaba text-emerald-100 que
+   se lavaba sobre cream → ahora tinta del tema (AA en los 4). */
+.fvh-skin.jp-directorio { background: rgb(var(--c-surface, 2 6 23)) !important; }
+.fvh-skin.jp-directorio,
+.fvh-skin.jp-directorio .jp-tinta { color: var(--jp-tinta) !important; }
+.fvh-skin.jp-directorio .jp-tinta-suave { color: var(--jp-tinta-3) !important; }
+/* Cabecera y tarjetas de resultado del directorio: superficie + borde del tema
+   (vencen los bg-slate-9xx fijos del componente). */
+.fvh-skin.jp-directorio .jp-dir-header { background: rgb(var(--c-surface, 2 6 23) / 0.85) !important; border-color: var(--jp-borde) !important; }
+.fvh-skin.jp-directorio .jp-dir-card { background: var(--jp-card) !important; border-color: var(--jp-borde) !important; }
+.fvh-skin.jp-directorio .jp-dir-input { background: var(--jp-card) !important; border-color: var(--jp-borde) !important; color: var(--jp-tinta) !important; }
 
 /* ── Accesibilidad: nada de esto introduce movimiento autónomo; las únicas
    transiciones son de hover/active (inocuas) y respetan el resto del sistema.


### PR DESCRIPTION
## Bug
En los TEMAS CLAROS (nature/minimalista/verde-vivo, flag `VITE_FINCA_VIVA_HOME_PERFIL` ON) varios textos quedaban ILEGIBLES (contraste 1.0–1.2:1): la Fase 2 retiñó el FONDO de los paneles del juego a superficie clara, pero el TEXTO seguía hardcodeado para fondo OSCURO (`text-white`, `text-emerald-50/100/200`, `text-teal/lime/orange/cyan-100`…). Lo marcó el test visual integral en el hub "Mi Finca Viva", los títulos del Directorio y las fichas/leyenda del Doom. Biopunk (oscuro) estaba bien.

## Causa raíz
Color de texto hardcodeado para superficie oscura, sin mapear a las CSS vars del tema (`--c-*`) — al revés que home/calendario/mercado/perfil, que ya derivan su tinta del tema y por eso se ven bien en los 4.

## Cambios
- **`src/styles/juego-pulido.css`**: clases semánticas de tinta (`jp-tinta` principal / `jp-tinta-suave` secundaria / `jp-acento-vida` verde legible) resueltas vía `--c-slate-100/400` y `--c-emerald-500`, que ya viran AA por tema. El CUE plaga(rojo)/benéfico(ámbar) del Doom baja a tono profundo AA **solo en claros** (semántica de color preservada). HUD/ficha/leyenda del Doom y contenedor del Directorio toman superficie+tinta del tema.
- **`MiFincaVivaScreen.jsx`** (CRÍTICO): tona título del mundo ("La tierra que despierta"), mensaje ("Tu finca está empezando…"), descripciones de subjuegos (Defensores/Milpa/Doom/Subsuelo), progreso, misiones, insignias, nota e invitación.
- **`DirectorioEspeciesScreen.jsx`** (ALTO): aplica `fvhSkinClass` (gated) al raíz; tona el título (nombre común, antes `emerald-100` lavado sobre cream), binomio, familia, header, input y estados (buscando/vacío/guía).
- **`DoomFincaScreen.jsx`** (MEDIO): tona ficha educativa tras acierto, leyenda inferior (Avispita/Mariquita/Crisopa/Beauveria/Bt), selector de benéficos, controles y details de pares.

## Ratios AA logrados (texto de cuerpo sobre superficie del tema)
| Token | biopunk | verde-vivo | nature | minimalista |
|---|---|---|---|---|
| Tinta principal (`--c-slate-100`) | 16.3 | 16.3 | 10.9 | 15.8 |
| Tinta suave (`--c-slate-400`) | 6.96 | 6.96 | 6.97 | 4.74 |
| Acento vida texto (`--c-emerald-500` en claros) | — | — | 4.73 | 8.18 |

Todos ≥4.5 (AA) en los 4 temas para el texto de cuerpo afectado. CUE plaga/benéfico en claros: rojo ~4.8 / ámbar 5.0–7.1.

## Gate
Todo va bajo `.fvh-skin` (clase que solo se monta con la flag ON, dev). **Flag OFF (prod) = dark intacto**; biopunk/verde-vivo (oscuros) sin cambios.

## Tests
- `temas-fase2-1-contraste.test.jsx` — 7 casos: el texto-cuerpo afectado lleva la clase de tinta (toma var del tema, no color lavado) + gating `fvh-skin` ON/OFF en hub y directorio.
- 153 tests de juego/directorio verdes (cero regresión). `vite build` verde. eslint 0 no-undef/no-unused en archivos tocados.
- Evidencia visual (rsvg, no chromium): hub + directorio + Doom en nature ANTES/DESPUÉS → enviada por Telegram.

Refs: hallazgos del test visual integral (contraste Fase 2.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)