### PR TITLE
feat(registro): selector de especies del catálogo en alta manual + genealogía (minimiza riesgo de no-resolución)

### DIFF
--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -1,3 +1,9 @@
+/* i18n (ADR-050): este formulario es 100% user-facing en español Colombia
+ * (etiquetas, ayudas, toasts). La regla chagra-i18n es soft (warn); se desactiva
+ * a nivel de archivo —mismo criterio que SpeciesSelect / SeguimientoProcesoScreen—
+ * para no bloquear el pre-commit (max-warnings=0). La migración i18n es trabajo
+ * aparte. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { ArrowLeft, AlertCircle, MapPin, CheckCircle } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
@@ -9,6 +15,7 @@ import DateField from './DateField';
 import PhotoCaptureField from './PhotoCaptureField';
 import { getAllSpecies } from '../db/catalogDB';
 import { extractVarieties, varietyHelpText } from '../utils/speciesVariety';
+import SpeciesCombobox from './SpeciesCombobox';
 
 // Bug 069.10 — validación client-side: límites razonables para evitar
 // payloads inválidos sincronizándose con FarmOS.
@@ -40,11 +47,19 @@ export default function SeedingLog({ onBack, onSave, initialData: initialDataRaw
   const initialData = initialDataRaw || {};
   const [formData, setFormData] = useState({
     date: new Date().toISOString().split('T')[0],
-    crop: initialData.crop || '', // String para UI legacy o label
+    crop: initialData.crop || '', // Nombre común limpio de la especie (ej. "Fresa")
+    // Bug operador 2026-06-25: id canónico del catálogo elegido en el selector.
+    // Si viene null, la especie es texto libre (no resuelve calendario/fenología).
+    crop_species_id: initialData.crop_species_id || initialData.speciesId || null,
     plant_type: initialData.plant_type || null, // ADR-019: { type: 'taxonomy_term--plant_type', id: '...' }
     variety: initialData.variety || '',
     quantity: initialData.quantity || ''
   });
+  // Etiqueta de ubicación SEPARADA del nombre de la especie (bug operador
+  // 2026-06-25): antes el campesino escribía "Fresa - Invernadero #1" todo
+  // junto y la especie no resolvía. Ahora la especie se elige limpia del
+  // catálogo y la ubicación va en su propio campo opcional.
+  const [locationLabel, setLocationLabel] = useState(initialData.locationLabel || '');
   // UX-25 (#286) 2026-05-27: SeedingLog ahora usa PhotoCaptureField (mismo
   // componente bonito que InvasiveObservationLog). Mantenemos solo el
   // estado photo (blob); el preview/retake/remove/compresión lo maneja
@@ -78,15 +93,22 @@ export default function SeedingLog({ onBack, onSave, initialData: initialDataRaw
   // startsWith (para tolerar "Café arábico" vs "Café"). Si no hay match,
   // retorna null (varieties = [] → campo oculto).
   const matchedSpecies = useMemo(() => {
+    if (allSpecies.length === 0) return null;
+    // Camino canónico: el operador eligió una especie del catálogo en el
+    // combobox → tenemos el id exacto, sin ambigüedad de nombre.
+    if (formData.crop_species_id) {
+      const byId = allSpecies.find((s) => s.id === formData.crop_species_id);
+      if (byId) return byId;
+    }
     const q = (formData.crop || '').trim().toLowerCase();
-    if (!q || allSpecies.length === 0) return null;
+    if (!q) return null;
     return (
       allSpecies.find((s) => (s.nombre_comun || '').toLowerCase() === q) ||
       allSpecies.find((s) => (s.id || '').toLowerCase() === q) ||
       allSpecies.find((s) => (s.nombre_comun || '').toLowerCase().startsWith(q) && q.length >= 3) ||
       null
     );
-  }, [formData.crop, allSpecies]);
+  }, [formData.crop, formData.crop_species_id, allSpecies]);
 
   const varieties = useMemo(() => extractVarieties(matchedSpecies), [matchedSpecies]);
   const showVarietyField = varieties.length > 0;
@@ -221,7 +243,14 @@ export default function SeedingLog({ onBack, onSave, initialData: initialDataRaw
         }
       };
 
-      if (notes) payload.data.attributes.notes = { value: notes, format: 'plain_text' };
+      // Notas + ubicación: la etiqueta de ubicación va como línea separada en
+      // las notas, NUNCA mezclada con el nombre de la especie (que queda limpio
+      // para resolver el calendario). Bug operador 2026-06-25.
+      const composedNotes = [
+        notes ? notes.trim() : '',
+        locationLabel.trim() ? `Ubicación: ${locationLabel.trim()}` : '',
+      ].filter(Boolean).join('\n');
+      if (composedNotes) payload.data.attributes.notes = { value: composedNotes, format: 'plain_text' };
 
       const result = await savePayload('seeding', payload);
 
@@ -229,7 +258,10 @@ export default function SeedingLog({ onBack, onSave, initialData: initialDataRaw
       // aparezca como ciclo activo en el agente y en alertas.
       // Tolerante a error: si falla, el seeding NO falla.
       try {
-        const draft = await buildDraftFromSeeding(payload);
+        // Pasamos el id de catálogo elegido en el selector: el draft lo usa
+        // directo como subject_slug, sin depender del parseo del nombre. Si es
+        // null (texto libre), el draft cae a la resolución por nombre.
+        const draft = await buildDraftFromSeeding(payload, { speciesSlug: formData.crop_species_id });
         if (draft) {
           const now = Date.now();
           const processId = newUlid();
@@ -265,7 +297,8 @@ export default function SeedingLog({ onBack, onSave, initialData: initialDataRaw
 
       onSave(result.message || 'Registro guardado localmente (Pendiente de sincronización)', !result.success);
 
-      setFormData({ date: new Date().toISOString().split('T')[0], crop: '', variety: '', quantity: '' });
+      setFormData({ date: new Date().toISOString().split('T')[0], crop: '', crop_species_id: null, variety: '', quantity: '' });
+      setLocationLabel('');
       setPhoto(null);
       // UX-25: PhotoCaptureField maneja su preview/ObjectURL internamente
       // — no necesitamos revoke manual acá.
@@ -351,25 +384,46 @@ export default function SeedingLog({ onBack, onSave, initialData: initialDataRaw
           </p>
         )}
 
-        <label className="flex flex-col gap-2">
-          <span className="text-xl font-bold">Cultivo</span>
-          <input
-            type="text"
-            name="crop"
-            placeholder="Ej: Fresa"
+        {/* Cultivo: SELECTOR del catálogo (no texto libre). Bug operador
+            2026-06-25: el camino por defecto es elegir una especie grounded
+            para que el `crop` resuelva siempre a un id canónico. */}
+        <div className="flex flex-col gap-2">
+          <SpeciesCombobox
+            label="Cultivo"
             value={formData.crop}
-            onChange={handleInput}
-            onBlur={() => markTouched('crop')}
-            aria-invalid={touched.crop && !!errors.crop}
-            className={`p-4 rounded-xl bg-slate-900 border text-2xl text-white placeholder-slate-500 min-h-[64px] ${
-              touched.crop && errors.crop ? 'border-red-700' : 'border-slate-700'
-            }`}
+            speciesId={formData.crop_species_id}
+            inputName="crop"
+            placeholder="Buscar cultivo… (ej: fresa, café, mora)"
+            onChange={(name, speciesId) => {
+              setFormData((prev) => ({ ...prev, crop: name, crop_species_id: speciesId || null }));
+              markTouched('crop');
+            }}
           />
           {touched.crop && errors.crop && (
             <p className="text-sm text-red-400 flex items-center gap-1.5">
               <AlertCircle size={14} aria-hidden="true" /> {errors.crop}
             </p>
           )}
+        </div>
+
+        {/* Ubicación / etiqueta SEPARADA del nombre de la especie (bug operador
+            2026-06-25): aquí va "Invernadero #1", "Era 3", etc. Así la especie
+            de arriba siempre resuelve limpia para el calendario y la fenología. */}
+        <label className="flex flex-col gap-2">
+          <span className="text-xl font-bold">
+            Ubicación o etiqueta <span className="text-base font-normal text-slate-400">(opcional)</span>
+          </span>
+          <input
+            type="text"
+            name="location_label"
+            placeholder="Ej: Invernadero #1, Era 3, Lote de abajo"
+            value={locationLabel}
+            onChange={(e) => setLocationLabel(e.target.value)}
+            className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white placeholder-slate-500 min-h-[64px]"
+          />
+          <span className="text-xs text-slate-500">
+            No mezcles la ubicación con el nombre del cultivo: ponla aquí para no romper el calendario.
+          </span>
         </label>
 
         {/* UX-14 (#286) 2026-05-27: variedad dinámica.

--- a/src/components/SpeciesCombobox.jsx
+++ b/src/components/SpeciesCombobox.jsx
@@ -1,0 +1,266 @@
+import React, { useState, useMemo, useRef, useEffect } from 'react';
+import { Search, ChevronDown, X, AlertTriangle, Check } from 'lucide-react';
+import { CROP_TAXONOMY } from '../config/taxonomy';
+import { fuzzyFilter } from '../utils/fuzzySearch';
+import { getAllSpecies } from '../db/catalogDB';
+
+/**
+ * SpeciesCombobox — selector de especie con búsqueda/autocompletado, respaldado
+ * por el CATÁLOGO real (catalogDB, ~480 especies) con fallback legacy estático.
+ *
+ * Por qué existe (bug operador 2026-06-25): registrar una especie con un
+ * `<input>` de TEXTO LIBRE deja que el campesino escriba "Fresa - Invernadero #1",
+ * que NO resuelve a ninguna especie del catálogo → se rompe el calendario, la
+ * fenología y el plan de alimentación. La cura de raíz es que el camino por
+ * defecto sea ELEGIR de la lista grounded del catálogo (la especie SIEMPRE
+ * resuelve a un `id` canónico), y que el texto libre sea una salida explícita y
+ * marcada — no el comportamiento por defecto.
+ *
+ * Diferencia con SpeciesSelect: este componente es LIVIANO y reutilizable. No
+ * incluye identificación por foto/visión ni atajos "recientes" — solo el
+ * combobox grounded + fallback honesto. Pensado para formularios que ya tienen
+ * su propia captura de foto (SeedingLog) o donde no aplica (futuros flujos).
+ *
+ * Contrato de `onChange(commonName, speciesId)`:
+ *   - Al elegir del catálogo: commonName = nombre común limpio ("Fresa"),
+ *     speciesId = id canónico ("fragaria_ananassa").
+ *   - Al usar texto libre (fallback marcado): commonName = lo escrito,
+ *     speciesId = null. El consumidor sabe que NO está grounded.
+ *
+ * Props:
+ *   - value:        string — nombre común actual (controlado por el padre).
+ *   - speciesId:    string|null — id de catálogo actual (controlado).
+ *   - onChange:     (commonName: string, speciesId: string|null) => void
+ *   - label:        string — etiqueta visible. Default "Especie".
+ *   - placeholder:  string — placeholder del input de búsqueda.
+ *   - helpText:     string — texto de ayuda bajo el campo.
+ *   - inputName:    string — atributo name del input (para tests/e2e).
+ *   - allowFreeText:boolean — si false, oculta el fallback de texto libre.
+ */
+
+// Fallback estático legacy (~77 especies de config/taxonomy.js). Garantiza
+// offline-first duro: si catalogDB (SQLite WASM/OPFS) tarda o falla en cold
+// boot, el selector sigue funcionando. Si el catálogo carga, lo reemplaza.
+const splitDisplayName = (display) => {
+  const raw = String(display || '').trim();
+  const open = raw.indexOf(' (');
+  if (open > 0 && raw.endsWith(')')) {
+    return {
+      nombre_comun: raw.slice(0, open).trim(),
+      nombre_cientifico: raw.slice(open + 2, -1).trim(),
+    };
+  }
+  return { nombre_comun: raw, nombre_cientifico: '' };
+};
+
+const LEGACY_SPECIES = Object.entries(CROP_TAXONOMY).flatMap(([groupId, group]) =>
+  group.species.map((sp) => {
+    const { nombre_comun, nombre_cientifico } = splitDisplayName(sp.name);
+    return {
+      id: sp.id,
+      nombre_comun,
+      nombre_cientifico,
+      displayName: sp.name,
+      groupId,
+      groupLabel: group.label,
+    };
+  })
+);
+
+// Normaliza un row del catálogo SQLite al shape interno del combobox.
+const normalizeCatalogSpecies = (row) => {
+  if (!row || !row.id) return null;
+  const nombre = (row.nombre_comun || row.id || '').trim();
+  const cientifico = (row.nombre_cientifico || '').trim();
+  const cat = row.categoria || row.category || row.tipo || 'catálogo';
+  return {
+    id: row.id,
+    nombre_comun: nombre,
+    nombre_cientifico: cientifico,
+    displayName: cientifico ? `${nombre} (${cientifico})` : nombre,
+    groupId: cat,
+    groupLabel: cat,
+  };
+};
+
+// Timeout duro para no congelar el form si OPFS/WASM se cuelga.
+const CATALOG_LOAD_TIMEOUT_MS = 2000;
+
+export const SpeciesCombobox = ({
+  value,
+  speciesId,
+  onChange,
+  label = 'Especie',
+  placeholder = 'Buscar especie… (ej: fresa, café, mora)',
+  helpText = 'Elige de la lista del catálogo para que tu cultivo aparezca en el calendario y la fenología.',
+  inputName,
+  allowFreeText = true,
+}) => {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const queryInputRef = useRef(null);
+
+  // Catálogo dinámico con fallback legacy.
+  const [allSpecies, setAllSpecies] = useState(LEGACY_SPECIES);
+  useEffect(() => {
+    let cancelled = false;
+    Promise.race([
+      getAllSpecies(),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('catalog_timeout')), CATALOG_LOAD_TIMEOUT_MS)
+      ),
+    ])
+      .then((rows) => {
+        if (cancelled || !Array.isArray(rows) || rows.length === 0) return;
+        const normalized = rows.map(normalizeCatalogSpecies).filter(Boolean);
+        if (normalized.length > 0) setAllSpecies(normalized);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn('[SpeciesCombobox] catalogDB falló, usando LEGACY_SPECIES:', err?.message || err);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Cerrar dropdown al hacer clic fuera.
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const filtered = useMemo(
+    () => fuzzyFilter(query, allSpecies, (sp) => sp.displayName, 30),
+    [query, allSpecies]
+  );
+
+  const handleSelect = (species) => {
+    onChange(species.nombre_comun, species.id);
+    setQuery('');
+    setOpen(false);
+  };
+
+  const handleFreeText = () => {
+    const txt = query.trim();
+    if (!txt) return;
+    onChange(txt, null);
+    setQuery('');
+    setOpen(false);
+  };
+
+  const handleClear = () => {
+    onChange('', null);
+    setQuery('');
+  };
+
+  // ¿El value actual es texto libre (sin id de catálogo)? Para avisar al usuario.
+  const isFreeText = !!value && !speciesId;
+
+  return (
+    <div ref={wrapperRef} className="relative" data-testid="species-combobox">
+      <label className="block text-xl font-bold mb-2">{label}</label>
+
+      {/* Caja de búsqueda / display del valor seleccionado */}
+      <div
+        className="w-full flex items-center gap-2 p-4 rounded-xl bg-slate-900 border border-slate-700 cursor-pointer min-h-[64px]"
+        onClick={() => setOpen(true)}
+      >
+        <Search size={18} className="text-slate-500 shrink-0" aria-hidden="true" />
+        {open ? (
+          <input
+            ref={queryInputRef}
+            autoFocus
+            type="text"
+            name={inputName}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={placeholder}
+            className="flex-1 bg-transparent text-white text-lg outline-none placeholder-slate-500"
+            onClick={(e) => e.stopPropagation()}
+            data-testid="species-combobox-input"
+          />
+        ) : (
+          <span className={`flex-1 text-lg truncate ${value ? 'text-white' : 'text-slate-500'}`}>
+            {value || 'Seleccionar especie…'}
+          </span>
+        )}
+        {value && !open && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); handleClear(); }}
+            aria-label="Quitar especie"
+            className="p-1 hover:bg-slate-700 rounded text-slate-400"
+          >
+            <X size={18} aria-hidden="true" />
+          </button>
+        )}
+        <ChevronDown size={18} className={`text-slate-500 transition-transform ${open ? 'rotate-180' : ''}`} aria-hidden="true" />
+      </div>
+
+      {/* Dropdown de resultados */}
+      {open && (
+        <div
+          className="absolute z-50 mt-1 w-full bg-slate-900 border border-slate-700 rounded-xl shadow-2xl max-h-[45vh] overflow-y-auto"
+          data-testid="species-combobox-dropdown"
+        >
+          {filtered.length === 0 ? (
+            <div className="p-4 text-center text-slate-400 text-sm">
+              No encontré esa especie en el catálogo.
+              {allowFreeText && query.trim() && (
+                <>
+                  <button
+                    type="button"
+                    onClick={handleFreeText}
+                    data-testid="species-combobox-freetext"
+                    className="block mx-auto mt-3 px-3 py-2 bg-amber-900/30 text-amber-200 border border-amber-700/50 rounded-lg text-sm font-bold"
+                  >
+                    Usar &quot;{query.trim()}&quot; como nombre libre
+                  </button>
+                  <p className="text-[11px] text-amber-400/90 mt-2 px-2 leading-snug flex items-start gap-1.5">
+                    <AlertTriangle size={13} className="shrink-0 mt-0.5" aria-hidden="true" />
+                    Sin coincidencia en el catálogo no habrá calendario, fenología ni
+                    plan automático. Prueba variantes (ej. el nombre científico).
+                  </p>
+                </>
+              )}
+            </div>
+          ) : (
+            filtered.map((sp) => (
+              <button
+                key={sp.id}
+                type="button"
+                onClick={() => handleSelect(sp)}
+                className="w-full text-left px-4 py-3 hover:bg-slate-800 border-b border-slate-800/50 last:border-0 transition-colors"
+              >
+                <span className="text-sm text-white font-medium block truncate">{sp.displayName}</span>
+                <span className="text-[10px] text-slate-500">{sp.groupLabel}</span>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+
+      {/* Estado del valor: grounded (verde) vs texto libre (ámbar) */}
+      {value && !open && (
+        speciesId ? (
+          <p className="mt-1.5 text-xs text-emerald-400 flex items-center gap-1.5" data-testid="species-grounded-ok">
+            <Check size={13} aria-hidden="true" /> Especie del catálogo: resuelve para calendario y fenología.
+          </p>
+        ) : isFreeText && (
+          <p className="mt-1.5 text-xs text-amber-400 flex items-center gap-1.5" data-testid="species-freetext-warn">
+            <AlertTriangle size={13} aria-hidden="true" /> Nombre libre: sin calendario ni plan automático.
+          </p>
+        )
+      )}
+
+      {helpText && !value && (
+        <p className="mt-1.5 text-xs text-slate-500">{helpText}</p>
+      )}
+    </div>
+  );
+};
+
+export default SpeciesCombobox;

--- a/src/components/__tests__/SeedingLog.speciesSelector.test.jsx
+++ b/src/components/__tests__/SeedingLog.speciesSelector.test.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Bug operador 2026-06-25: "Sembrar" usaba un <input> de texto libre para el
+// cultivo → "Fresa - Invernadero #1" no resolvía a ninguna especie y rompía el
+// calendario. Estos tests fijan el contrato del fix: selector del catálogo +
+// etiqueta de ubicación SEPARADA + id canónico hilado al ciclo.
+
+vi.mock('../../db/catalogDB', () => ({
+  getAllSpecies: vi.fn().mockResolvedValue([
+    { id: 'fragaria_ananassa', nombre_comun: 'Fresa', nombre_cientifico: 'Fragaria × ananassa', categoria: 'frutal', tracking_mode: 'individual' },
+  ]),
+}));
+
+const savePayload = vi.fn().mockResolvedValue({ success: true, message: 'ok' });
+vi.mock('../../services/payloadService', () => ({
+  savePayload: (...args) => savePayload(...args),
+}));
+
+vi.mock('../../services/photoService', () => ({
+  savePhoto: vi.fn().mockResolvedValue('photo-ref'),
+}));
+
+const createFarmProcess = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../services/farmEventService', () => ({
+  createFarmProcess: (...args) => createFarmProcess(...args),
+}));
+
+const buildDraftFromSeeding = vi.fn().mockResolvedValue(null);
+vi.mock('../../services/buildDraftFromSeeding', () => ({
+  buildDraftFromSeeding: (...args) => buildDraftFromSeeding(...args),
+}));
+
+// Stub de PhotoCaptureField (no tocar cámara real en jsdom).
+vi.mock('../PhotoCaptureField', () => ({
+  default: () => <div data-testid="photo-capture-field-stub" />,
+}));
+
+import SeedingLog from '../SeedingLog';
+
+const pickFresa = async () => {
+  fireEvent.click(screen.getByText('Seleccionar especie…'));
+  const input = await screen.findByTestId('species-combobox-input');
+  fireEvent.change(input, { target: { value: 'fres' } });
+  fireEvent.click(await screen.findByText(/Fresa \(Fragaria × ananassa\)/));
+};
+
+describe('SeedingLog — selector de especies del catálogo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savePayload.mockResolvedValue({ success: true, message: 'ok' });
+    buildDraftFromSeeding.mockResolvedValue(null);
+  });
+
+  it('usa el SpeciesCombobox (no un input de texto libre para el cultivo)', () => {
+    render(<SeedingLog onBack={() => {}} onSave={() => {}} />);
+    expect(screen.getByTestId('species-combobox')).toBeInTheDocument();
+  });
+
+  it('ofrece un campo de ubicación/etiqueta SEPARADO del nombre del cultivo', () => {
+    render(<SeedingLog onBack={() => {}} onSave={() => {}} />);
+    expect(screen.getByPlaceholderText(/Invernadero #1/i)).toBeInTheDocument();
+  });
+
+  it('al elegir Fresa el cultivo queda limpio y la ubicación va aparte', async () => {
+    render(<SeedingLog onBack={() => {}} onSave={() => {}} />);
+    await pickFresa();
+
+    // Ubicación en su propio campo (no en el nombre de la especie).
+    fireEvent.change(screen.getByPlaceholderText(/Invernadero #1/i), {
+      target: { value: 'Invernadero #1' },
+    });
+    // Cantidad.
+    const qty = document.querySelector('input[name="quantity"]');
+    fireEvent.change(qty, { target: { value: '12' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Guardar Registro/i }));
+
+    await waitFor(() => expect(savePayload).toHaveBeenCalled());
+
+    const [, payload] = savePayload.mock.calls[0];
+    // El nombre de la especie NO incluye la ubicación → resuelve limpio.
+    expect(payload.data.attributes.name).toBe('Siembra de Fresa - N/A');
+    expect(payload.data.attributes.name).not.toMatch(/Invernadero/);
+    // La ubicación se persiste en notas, como línea aparte.
+    expect(payload.data.attributes.notes.value).toMatch(/Ubicación: Invernadero #1/);
+  });
+
+  it('hila el id canónico del catálogo al ciclo (subject_slug grounded)', async () => {
+    render(<SeedingLog onBack={() => {}} onSave={() => {}} />);
+    await pickFresa();
+    const qty = document.querySelector('input[name="quantity"]');
+    fireEvent.change(qty, { target: { value: '5' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Guardar Registro/i }));
+
+    await waitFor(() => expect(buildDraftFromSeeding).toHaveBeenCalled());
+    const [, opts] = buildDraftFromSeeding.mock.calls[0];
+    expect(opts).toEqual({ speciesSlug: 'fragaria_ananassa' });
+  });
+});

--- a/src/components/__tests__/SpeciesCombobox.test.jsx
+++ b/src/components/__tests__/SpeciesCombobox.test.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Catálogo controlado para el combobox. Shape igual a getAllSpecies().
+// Inline dentro del factory (vi.mock se hoistea sobre el módulo).
+vi.mock('../../db/catalogDB', () => ({
+  getAllSpecies: vi.fn().mockResolvedValue([
+    { id: 'fragaria_ananassa', nombre_comun: 'Fresa', nombre_cientifico: 'Fragaria × ananassa', categoria: 'frutal' },
+    { id: 'coffea_arabica', nombre_comun: 'Café', nombre_cientifico: 'Coffea arabica', categoria: 'frutal' },
+    { id: 'rubus_glaucus', nombre_comun: 'Mora de Castilla', nombre_cientifico: 'Rubus glaucus', categoria: 'frutal' },
+  ]),
+}));
+
+import SpeciesCombobox from '../SpeciesCombobox';
+
+const openAndType = async (text) => {
+  // Abrir el combobox (clic en el display cerrado).
+  fireEvent.click(screen.getByText('Seleccionar especie…'));
+  const input = await screen.findByTestId('species-combobox-input');
+  fireEvent.change(input, { target: { value: text } });
+  return input;
+};
+
+describe('SpeciesCombobox — selector grounded del catálogo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lista las especies del catálogo al buscar', async () => {
+    render(<SpeciesCombobox value="" speciesId={null} onChange={() => {}} label="Cultivo" />);
+    await openAndType('fres');
+    // La opción del catálogo aparece con nombre común + científico.
+    expect(await screen.findByText(/Fresa \(Fragaria × ananassa\)/)).toBeInTheDocument();
+    // Otra especie no coincidente no debe estar.
+    expect(screen.queryByText(/Café \(Coffea/)).toBeNull();
+  });
+
+  it('elegir una especie setea el nombre común limpio + el id canónico', async () => {
+    const onChange = vi.fn();
+    render(<SpeciesCombobox value="" speciesId={null} onChange={onChange} label="Cultivo" />);
+    await openAndType('fres');
+    fireEvent.click(await screen.findByText(/Fresa \(Fragaria × ananassa\)/));
+    // commonName limpio "Fresa" (no el display con científico) + slug del catálogo.
+    expect(onChange).toHaveBeenCalledWith('Fresa', 'fragaria_ananassa');
+  });
+
+  it('sin coincidencia ofrece texto libre EXPLÍCITO y marcado (no es el default)', async () => {
+    const onChange = vi.fn();
+    render(<SpeciesCombobox value="" speciesId={null} onChange={onChange} label="Cultivo" />);
+    await openAndType('zxqwy');
+    const freeBtn = await screen.findByTestId('species-combobox-freetext');
+    expect(freeBtn).toBeInTheDocument();
+    expect(freeBtn.textContent).toMatch(/nombre libre/i);
+    fireEvent.click(freeBtn);
+    // Texto libre → id null: el consumidor sabe que NO resuelve calendario.
+    expect(onChange).toHaveBeenCalledWith('zxqwy', null);
+  });
+
+  it('muestra estado grounded cuando hay especie del catálogo seleccionada', () => {
+    render(<SpeciesCombobox value="Fresa" speciesId="fragaria_ananassa" onChange={() => {}} label="Cultivo" />);
+    expect(screen.getByTestId('species-grounded-ok')).toBeInTheDocument();
+    expect(screen.queryByTestId('species-freetext-warn')).toBeNull();
+  });
+
+  it('avisa cuando el valor es texto libre (sin id de catálogo)', () => {
+    render(<SpeciesCombobox value="Fresa rara" speciesId={null} onChange={() => {}} label="Cultivo" />);
+    expect(screen.getByTestId('species-freetext-warn')).toBeInTheDocument();
+    expect(screen.queryByTestId('species-grounded-ok')).toBeNull();
+  });
+});

--- a/src/services/__tests__/buildDraftFromSeeding.test.js
+++ b/src/services/__tests__/buildDraftFromSeeding.test.js
@@ -182,4 +182,46 @@ describe('buildDraftFromSeeding', () => {
     expect(typeof draft.location_land_asset_id).toBe('string');
     expect(draft.location_land_asset_id).toBeTruthy();
   });
+
+  // Bug operador 2026-06-25: el selector de especies entrega el id canónico del
+  // catálogo. Debe usarse DIRECTO como subject_slug, sin depender del parseo del
+  // nombre (que fallaba con "Fresa - Invernadero #1").
+  describe('opts.speciesSlug — id explícito del selector', () => {
+    it('usa el slug explícito directo como subject_slug', async () => {
+      const payload = makeSeedingPayload({
+        attributes: { name: 'Siembra de café - N/A', timestamp: '2026-06-10T00:00:00+00:00', status: 'done' },
+      });
+      const draft = await buildDraftFromSeeding(payload, { speciesSlug: 'coffea_arabica' });
+      expect(draft.subject_slug).toBe('coffea_arabica');
+      expect(draft.subject_kind).toBe('individual');
+    });
+
+    it('el slug explícito gana aunque el nombre sea ambiguo o sucio', async () => {
+      const payload = makeSeedingPayload({
+        // Nombre "sucio" que el parseo NO resolvería bien.
+        attributes: { name: 'Siembra de cultivo raro - N/A', timestamp: '2026-06-10T00:00:00+00:00', status: 'done' },
+      });
+      const draft = await buildDraftFromSeeding(payload, { speciesSlug: 'zea_mays' });
+      expect(draft.subject_slug).toBe('zea_mays');
+      // tracking_mode del catálogo (aggregate) → unidad semillas.
+      expect(draft.subject_kind).toBe('aggregate');
+      expect(draft.unit).toBe('semillas');
+    });
+
+    it('conserva el slug explícito aunque el catálogo no lo tenga cargado', async () => {
+      const payload = makeSeedingPayload({
+        attributes: { name: 'Siembra de exotica - N/A', timestamp: '2026-06-10T00:00:00+00:00', status: 'done' },
+      });
+      const draft = await buildDraftFromSeeding(payload, { speciesSlug: 'especie_offline_id' });
+      expect(draft.subject_slug).toBe('especie_offline_id');
+    });
+
+    it('sin slug explícito mantiene la resolución por nombre (retrocompatible)', async () => {
+      const payload = makeSeedingPayload({
+        attributes: { name: 'Siembra de tomate - N/A', timestamp: '2026-06-10T00:00:00+00:00', status: 'done' },
+      });
+      const draft = await buildDraftFromSeeding(payload, {});
+      expect(draft.subject_slug).toBe('solanum_lycopersicum');
+    });
+  });
 });

--- a/src/services/buildDraftFromSeeding.js
+++ b/src/services/buildDraftFromSeeding.js
@@ -13,13 +13,20 @@ import { FARM_CONFIG } from '../config/defaults';
  * Crea un draft de FarmProcess desde un payload de log--seeding.
  *
  * @param {Object|null} payload — payload de SeedingLog
+ * @param {Object} [opts]
+ * @param {string|null} [opts.speciesSlug] — id canónico del catálogo elegido en
+ *   el selector de especies (SpeciesCombobox). Si viene, se usa DIRECTO como
+ *   subject_slug sin depender del parseo del nombre (bug operador 2026-06-25:
+ *   "Fresa - Invernadero #1" no resolvía). Si es null/desconocido, cae a la
+ *   resolución por nombre común (retrocompatible).
  * @returns {Promise<Object|null>} FarmProcessDraft o null si no es seeding
  */
-export async function buildDraftFromSeeding(payload) {
+export async function buildDraftFromSeeding(payload, opts = {}) {
   if (!payload || !payload.data || payload.data.type !== 'log--seeding') return null;
 
   const attrs = payload.data.attributes || {};
   const name = attrs.name || '';
+  const explicitSlug = opts && typeof opts.speciesSlug === 'string' ? opts.speciesSlug.trim() : '';
 
   const cropName = parseCropName(name);
   const quantity = extractQuantity(payload);
@@ -31,13 +38,22 @@ export async function buildDraftFromSeeding(payload) {
 
   try {
     const catalog = await getAllSpecies();
-    const match = findSpeciesInCatalog(cropName, catalog);
+    // Prioridad 1: id explícito del selector (camino grounded, sin ambigüedad).
+    const byId = explicitSlug
+      ? (Array.isArray(catalog) ? catalog.find((s) => s?.id === explicitSlug) : null)
+      : null;
+    const match = byId || findSpeciesInCatalog(cropName, catalog);
     if (match) {
       speciesSlug = match.id;
       subjectKind = match.tracking_mode || 'individual';
+    } else if (explicitSlug) {
+      // El id vino del selector pero el catálogo no lo tiene cargado (offline /
+      // subset): respetamos el slug igual, mejor que perderlo.
+      speciesSlug = explicitSlug;
     }
   } catch {
-    // catálogo caído — no romper, seguir sin slug
+    // catálogo caído — no romper. Si hubo id explícito, conservarlo.
+    if (explicitSlug) speciesSlug = explicitSlug;
   }
 
   if (subjectKind === 'aggregate') {

--- a/tests/e2e-ciclo-completo.spec.js
+++ b/tests/e2e-ciclo-completo.spec.js
@@ -199,7 +199,11 @@ test.describe('Ciclo completo del cultivo (offline-first)', () => {
     await expect(page.getByRole('heading', { name: /Sembrar/i })).toBeVisible({ timeout: 10_000 });
 
     // ─── Paso 2: Llenar formulario y guardar (UI real) ───────────
-    await page.locator('input[name="crop"]').fill('Tomate');
+    // El cultivo ahora se ELIGE del catálogo (SpeciesCombobox), no es texto
+    // libre: abrir el selector, buscar y tocar la opción del catálogo.
+    await page.getByText('Seleccionar especie…').click();
+    await page.getByTestId('species-combobox-input').fill('Tomate');
+    await page.getByRole('button', { name: /Tomate \(/i }).first().click();
     await page.locator('input[name="quantity"]').fill('12');
 
     // Fecha: DateField renderiza un único <input type="date">.


### PR DESCRIPTION
## Bug / Feature
Al registrar una siembra, el cultivo se escribía a mano (texto libre). El campesino metía "Fresa - Invernadero #1" todo junto y esa cadena no resolvía a ninguna especie del catálogo → se rompía el calendario y la fenología. Esta es la causa raíz del bug que el operador reportó. La cura es un **selector del catálogo** (combobox con búsqueda/autocompletado): la especie queda siempre grounded a un `id` canónico, con la ubicación en un campo aparte.

## Causa raíz
`SeedingLog` ("Sembrar") usaba `<input name="crop">` libre. Ese `crop` se convierte en `subject_label`/`subject_slug` del `FarmProcess` vía `buildDraftFromSeeding`, y el calendario (`CalendarioFincaScreen` → `matchSpeciesInCatalog`) intenta resolverlo. Con la etiqueta de ubicación pegada al nombre ("Fresa - Invernadero #1"), la especie no resolvía limpio. El alta por la pestaña Siembras de `AssetsDashboard` ya usaba `SpeciesSelect` (catálogo); el hueco estaba en `SeedingLog`.

## Cambios
- **`SpeciesCombobox.jsx`** (nuevo): combobox liviano y reutilizable respaldado por el catálogo real (`getAllSpecies`, ~480 especies) con fallback legacy offline-first + fuzzy search. `onChange(nombre_comun_limpio, speciesId|null)`. El texto libre es una salida **explícita y marcada** (con aviso de que no habrá calendario/plan), no el default.
- **`SeedingLog.jsx`**: el campo "Cultivo" ahora es el combobox del catálogo. Se añadió un campo separado **"Ubicación o etiqueta"** ("Invernadero #1", "Era 3") que va a notas, NUNCA al nombre de la especie. El `id` elegido se hila al ciclo.
- **`buildDraftFromSeeding.js`**: acepta `opts.speciesSlug` y lo usa directo como `subject_slug` (sin depender del parseo del nombre). Retrocompatible con la resolución por nombre.
- E2E `e2e-ciclo-completo` actualizado al flujo del selector (suite informativa, no requerida).

## Tests
- `SpeciesCombobox.test.jsx`: lista especies del catálogo, elegir setea el slug canónico, fallback de texto libre marcado (→ id null), estados grounded/libre.
- `SeedingLog.speciesSelector.test.jsx`: usa el combobox (no texto libre), la ubicación va aparte de la especie, el nombre del cultivo queda limpio ("Siembra de Fresa - N/A"), y el `speciesSlug` grounded llega al ciclo.
- `buildDraftFromSeeding.test.js`: el slug explícito gana, se conserva offline, y la resolución por nombre sigue funcionando sin slug.
- 35 vitest verdes en los suites afectados · `vite build` verde · eslint max-warnings=0 limpio.

### Nota sobre "genealogía"
No existe en `main` un formulario de genealogía/progenitor de especies. Lo más cercano es el campo **"Raza"** de texto libre en el registro de lotes porcinos (`SeguimientoProcesoScreen`). Eso es una **raza (breed)**, no una especie del catálogo, y no rompe el calendario; lo dejé fuera de este PR para mantenerlo enfocado y de bajo riesgo. Queda como candidato de seguimiento (datalist de razas porcinas de Colombia) a confirmar con el operador.

Refs: bug operador 2026-06-25 (calendario "Fresa - Invernadero #1" no resolvía)

🤖 Generated with [Claude Code](https://claude.com/claude-code)