### PR TITLE
fix(home-f2): la hoja "resto" ya no tapa los portales + selector de especie en registro por voz

### DIFF
--- a/src/components/RegistroVozConfirm.jsx
+++ b/src/components/RegistroVozConfirm.jsx
@@ -1,11 +1,19 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish --
+ * Los textos de UI de este paso de confirmación (rótulos de campos, botones
+ * "Cancelar"/"Guardar registro", avisos de GPS) son strings de interfaz. Su
+ * migración a src/config/messages.js es la TAREA i18n de ADR-050 (transversal a
+ * toda la app), fuera del alcance de este fix — mismo criterio que los hermanos
+ * de este flujo (DashboardLive.jsx, FincaVivaHero.jsx, FincaCards.jsx,
+ * MiFincaVivaHomeCard.jsx). Los errores reales de ESLint siguen activos. */
 import React, { lazy, Suspense, useMemo, useRef, useState } from 'react';
 import {
-  Check, X, MapPin, LocateFixed, Leaf, AlertTriangle, Sprout, Pencil,
+  Check, X, MapPin, LocateFixed, AlertTriangle, Sprout, Pencil,
 } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { useGeolocation } from '../hooks/useGeolocation';
 import { geoJsonToWkt, latLngToPoint, wktToGeoJson } from '../utils/geo';
 import { INTENTS, INTENT_META } from '../services/voiceFieldExtractor';
+import SpeciesCombobox from './SpeciesCombobox';
 
 const MapPicker = lazy(() => import('./MapPicker').then((m) => ({ default: m.MapPicker || m.default })));
 
@@ -43,7 +51,14 @@ export default function RegistroVozConfirm({ record, onConfirm, onCancel, isSavi
   const primary = (record.species && record.species[0]) || null;
 
   const [intent, setIntent] = useState(record.intent);
+  // Especie: NOMBRE común (subject) + SLUG del catálogo (speciesId) separados.
+  // Se precargan con lo que la voz extrajo (ej. "Durazno" → prunus_persica),
+  // pero el usuario CONFIRMA/CAMBIA desde el catálogo con SpeciesCombobox, igual
+  // que en SeedingLog. Así la especie del registro por voz resuelve siempre a un
+  // slug canónico para calendario/fenología (texto libre = salida explícita,
+  // marcada por el propio combobox, con slug null).
   const [subject, setSubject] = useState(primary?.common || record.speciesHint || primary?.raw || '');
+  const [speciesId, setSpeciesId] = useState(primary?.slug || null);
   const [cantidad, setCantidad] = useState(record.measures?.cantidad ?? '');
   const [alturaM, setAlturaM] = useState(record.measures?.altura_m ?? '');
   const [anchoM, setAnchoM] = useState(record.measures?.ancho_m ?? '');
@@ -87,18 +102,33 @@ export default function RegistroVozConfirm({ record, onConfirm, onCancel, isSavi
     }
   }, [georef, requestGps]);
 
-  const slug = primary?.slug || null;
-  const subjectEdited = subject.trim() && subject.trim().toLowerCase() !== (primary?.common || '').toLowerCase();
-
   const handleConfirm = () => {
     if (isSaving) return;
-    // Reconstruye el registro editado preservando lo no-editable.
+    // Reconstruye el registro editado preservando lo no-editable. La especie sale
+    // del SpeciesCombobox: `subject` = nombre común, `speciesId` = slug del
+    // catálogo (o null si el usuario eligió texto libre marcado).
     let species = record.species || [];
     let speciesHint = record.speciesHint || null;
     const typed = subject.trim();
     if (typed) {
-      if (species.length > 0) species = [{ ...species[0], common: typed }, ...species.slice(1)];
-      else speciesHint = typed;
+      const base = species[0] || {};
+      if (speciesId) {
+        // Especie grounded del catálogo: hila el slug canónico (calendario,
+        // fenología, plan). Si cambió respecto a lo extraído, descartamos el
+        // `canonical` viejo para no mezclar nombre científico de otra especie.
+        const canonical = base.slug === speciesId ? (base.canonical || null) : null;
+        species = [{ ...base, common: typed, slug: speciesId, canonical }, ...species.slice(1)];
+        speciesHint = null;
+      } else if (species.length > 0) {
+        // Texto libre marcado: sin slug (el combobox ya advirtió que no resuelve).
+        species = [{ ...base, common: typed, slug: null, canonical: null }, ...species.slice(1)];
+      } else {
+        speciesHint = typed;
+      }
+    } else {
+      // Sin especie: no inventamos ninguna.
+      species = [];
+      speciesHint = null;
     }
     const num = (v) => (v === '' || v == null ? null : Number(v));
     const edited = {
@@ -154,30 +184,18 @@ export default function RegistroVozConfirm({ record, onConfirm, onCancel, isSavi
         </div>
       </section>
 
-      {/* Sujeto / especie */}
-      <Field label="Cultivo o especie">
-        <div className="flex items-center gap-2">
-          <input
-            type="text"
-            value={subject}
-            onChange={(e) => setSubject(e.target.value)}
-            placeholder="ej. durazno"
-            className={`${INPUT_CLS} flex-1`}
-            disabled={isSaving}
-          />
-          {slug && !subjectEdited && (
-            <span className="inline-flex items-center gap-1 text-2xs text-emerald-300/90 shrink-0" title={primary?.canonical || ''}>
-              <Leaf size={12} /> catálogo ✓
-            </span>
-          )}
-        </div>
-        {primary?.canonical && !subjectEdited && (
-          <span className="text-2xs text-lime-300/80">{primary.canonical}</span>
-        )}
-        {record.speciesHint && !slug && (
-          <span className="text-2xs text-slate-500">Oí: "{record.speciesHint}" — no está en el catálogo, queda como texto.</span>
-        )}
-      </Field>
+      {/* Sujeto / especie — SELECTOR del catálogo (no texto libre). Mismo
+          SpeciesCombobox que SeedingLog (#1879): precargado con lo que la voz
+          extrajo, pero el usuario ELIGE/confirma del catálogo → resuelve al slug
+          canónico. El texto libre queda como salida explícita y marcada. */}
+      <SpeciesCombobox
+        label="Cultivo o especie"
+        value={subject}
+        speciesId={speciesId}
+        inputName="voz-cultivo"
+        placeholder="Buscar especie… (ej: durazno, mora, café)"
+        onChange={(name, id) => { setSubject(name); setSpeciesId(id || null); }}
+      />
 
       {/* Medidas contextuales */}
       <div className="grid grid-cols-3 gap-2">

--- a/src/components/__tests__/RegistroVozConfirm.test.jsx
+++ b/src/components/__tests__/RegistroVozConfirm.test.jsx
@@ -5,6 +5,11 @@
  * Render del paso de confirmación del botón único de voz (#23). Verifica que el
  * árbol monta (geo utils, useGeolocation, store), que prefill los campos
  * extraídos, y que al confirmar entrega el registro editado + contexto.
+ *
+ * Bug 1b (operador 2026-06-25): el campo "Cultivo o especie" era un <input> de
+ * TEXTO LIBRE → riesgo de no-resolución a un slug del catálogo. El fix usa el
+ * MISMO SpeciesCombobox de SeedingLog (#1879): precargado con lo que la voz
+ * extrajo, pero resolviendo al slug canónico del catálogo.
  */
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
@@ -13,8 +18,17 @@ import { render, screen, fireEvent } from '@testing-library/react';
 vi.mock('../../store/useAssetStore', () => ({
   default: (selector) => selector({ lands: [{ id: 'land-1', attributes: { name: 'Lote Norte' } }] }),
 }));
+// useGeolocation es un export NOMBRADO (export function useGeolocation). El mock
+// debe proveerlo con ese nombre (vitest 4.x valida los exports nombrados).
 vi.mock('../../hooks/useGeolocation', () => ({
-  default: () => ({ position: null, loading: false, error: null, request: vi.fn() }),
+  useGeolocation: () => ({ position: null, loading: false, error: null, request: vi.fn() }),
+}));
+// Catálogo controlado para el SpeciesCombobox (shape de getAllSpecies()).
+vi.mock('../../db/catalogDB', () => ({
+  getAllSpecies: vi.fn().mockResolvedValue([
+    { id: 'prunus_persica', nombre_comun: 'Durazno', nombre_cientifico: 'Prunus persica', categoria: 'frutal' },
+    { id: 'rubus_glaucus', nombre_comun: 'Mora de Castilla', nombre_cientifico: 'Rubus glaucus', categoria: 'frutal' },
+  ]),
 }));
 
 import RegistroVozConfirm from '../RegistroVozConfirm';
@@ -31,8 +45,8 @@ describe('RegistroVozConfirm', () => {
     const onConfirm = vi.fn();
     render(<RegistroVozConfirm record={record} onConfirm={onConfirm} onCancel={vi.fn()} isSaving={false} />);
 
-    // Especie prefilled desde el catálogo.
-    expect(screen.getByDisplayValue('Durazno')).toBeInTheDocument();
+    // Especie prefilled desde el catálogo (el combobox la muestra como valor).
+    expect(screen.getByText('Durazno')).toBeInTheDocument();
     // Altura extraída prefilled.
     expect(screen.getByDisplayValue('2')).toBeInTheDocument();
 
@@ -43,6 +57,41 @@ describe('RegistroVozConfirm', () => {
     expect(edited.species[0].slug).toBe('prunus_persica');
     expect(ctx).toHaveProperty('locationAssetId');
     expect(ctx).toHaveProperty('wkt');
+  });
+
+  it('Bug 1b: el combobox precarga la especie de la voz GROUNDED al slug del catálogo', () => {
+    const record = classifyAndExtractLocal(
+      'al lado tengo un durazno que tiene como dos metros de ancho',
+      { now: NOW },
+    );
+    // La voz ya resolvió la especie al slug del catálogo.
+    expect(record.species[0].slug).toBe('prunus_persica');
+
+    render(<RegistroVozConfirm record={record} onConfirm={vi.fn()} onCancel={vi.fn()} isSaving={false} />);
+
+    // Es un SpeciesCombobox (no un input de texto libre) y marca el valor como
+    // grounded (resuelve a slug del catálogo), no como texto libre.
+    expect(screen.getByTestId('species-combobox')).toBeInTheDocument();
+    expect(screen.getByTestId('species-grounded-ok')).toBeInTheDocument();
+    expect(screen.queryByTestId('species-freetext-warn')).toBeNull();
+  });
+
+  it('Bug 1b: cambiar la especie desde el catálogo re-resuelve el slug al confirmar', async () => {
+    const record = classifyAndExtractLocal('aquí tengo un durazno', { now: NOW });
+    const onConfirm = vi.fn();
+    render(<RegistroVozConfirm record={record} onConfirm={onConfirm} onCancel={vi.fn()} isSaving={false} />);
+
+    // El usuario abre el combobox y elige OTRA especie del catálogo (mora).
+    fireEvent.click(screen.getByText('Durazno'));
+    const input = await screen.findByTestId('species-combobox-input');
+    fireEvent.change(input, { target: { value: 'mora' } });
+    fireEvent.click(await screen.findByText(/Mora de Castilla \(Rubus glaucus\)/));
+
+    fireEvent.click(screen.getByRole('button', { name: /Guardar registro/i }));
+    const [edited] = onConfirm.mock.calls[0];
+    // El slug se re-resolvió a la especie elegida (no queda el durazno viejo).
+    expect(edited.species[0].slug).toBe('rubus_glaucus');
+    expect(edited.species[0].common).toBe('Mora de Castilla');
   });
 
   it('la georreferencia sigue a la intención EDITADA, no a la clasificada', () => {

--- a/src/components/dashboard/__tests__/FincaVivaResto.noSolapa.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaResto.noSolapa.test.jsx
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+/**
+ * Bug 2 (operador 2026-06-25, home F2 "finca-viva"): la hoja deslizable
+ * "El resto de su finca" tapaba los 2 portales de abajo (Jugar y Agente).
+ *
+ * Causa raíz: `.fvh` (el hero) es un flex-item del scroller de DashboardLive
+ * (App.jsx lo envuelve en `h-[100dvh] flex-col` con la flag F2). En móvil el
+ * contenido del hero —escena 360px + compositor + saludo + los 4 portales—
+ * supera el viewport; con `flex-shrink:1` (default) el algoritmo flex encogía
+ * `.fvh` hasta su `min-height:100dvh` y `overflow:hidden` RECORTABA la fila
+ * inferior de portales. La hoja `.fvh-resto` (margin-top:-22px) caía sobre esa
+ * zona recortada y los tapaba.
+ *
+ * Fix: `.fvh { flex-shrink: 0 }` (el hero crece hasta su contenido → los 4
+ * portales SIEMPRE completos) + `.fvh-fill { min-height }` (colchón bajo los
+ * portales para que la "subida" de la hoja se solape sobre vacío, no sobre las
+ * tarjetas).
+ *
+ * jsdom no calcula layout, así que cubrimos el bug en DOS planos:
+ *   (1) CSS-source: el fix (flex-shrink:0 + colchón) está presente en el CSS.
+ *   (2) DOM: con la flag F2 ON, DashboardLive renderiza los 4 portales y la hoja
+ *       "resto" como superficies SEPARADAS (la hoja no contiene los portales) y
+ *       en el orden correcto (portales antes que la hoja).
+ */
+import React from 'react';
+import { describe, it, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, within, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// ── (1) CSS-source: el fix está presente ────────────────────────────────────
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const heroCss = readFileSync(join(__dirname, '..', 'finca-viva-hero.css'), 'utf8');
+
+function ruleBody(css, selector) {
+  // Bloque de la PRIMERA regla cuyo encabezado es EXACTAMENTE `selector`.
+  const re = new RegExp(`(^|})\\s*${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{([^}]*)\\}`, 'm');
+  const m = css.match(re);
+  return m ? m[2] : null;
+}
+
+describe('Bug 2 · CSS — la hoja "resto" no recorta los portales del hero', () => {
+  it('.fvh no se comprime por debajo de su contenido (flex-shrink:0)', () => {
+    const body = ruleBody(heroCss, '.fvh');
+    expect(body).toBeTruthy();
+    expect(body).toMatch(/flex-shrink:\s*0/);
+  });
+
+  it('.fvh-fill garantiza un colchón bajo los portales (min-height)', () => {
+    const body = ruleBody(heroCss, '.fvh-fill');
+    expect(body).toBeTruthy();
+    expect(body).toMatch(/min-height:\s*\d+px/);
+  });
+});
+
+// ── (2) DOM: los 4 portales y la hoja "resto" son superficies separadas ──────
+vi.mock('../../../config/fincaVivaHomeFlag', () => ({
+  fincaVivaHomePerfilActivo: () => true,
+}));
+vi.mock('../../../config/extensionistaAccess', () => ({
+  esExtensionistaActual: () => false,
+}));
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => false,
+}));
+vi.mock('../../../db/farmProcessCache', () => ({
+  listFarmProcesses: vi.fn(async () => []),
+}));
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({
+    plants: [{ id: 'p1' }], lands: [], materials: [], isHydrated: true, iotAlerts: [],
+  }),
+}));
+vi.mock('../../../services/userProfileService', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getProfile: () => ({ rol: 'campesino' }),
+    hasManualModuleVisibility: () => false,
+  };
+});
+
+// Hijos pesados de la hoja "resto" → stubs livianos (probamos la SEPARACIÓN de
+// superficies, no su contenido). El hero (FincaVivaHero) NO se mockea: queremos
+// los 4 portales reales.
+vi.mock('../FincaCards', () => ({
+  PlantasCard: () => <div />, ZonasCard: () => <div />, InsumosCard: () => <div />,
+  BitacoraCard: () => <div />, HoyCard: () => <div />, PlagasCard: () => <div />,
+  BiodiversidadCard: () => <div />, AsociacionesCard: () => <div />, InformesCard: () => <div />,
+  FermentosCard: () => <div />, AnimalesCard: () => <div />, SeguimientoCards: () => <div />,
+}));
+vi.mock('../CaseStudyTopWidget', () => ({ default: () => <div /> }));
+vi.mock('../../CaseStudyTopWidget', () => ({ default: () => <div /> }));
+vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
+vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));
+vi.mock('../AIStatusFooter', () => ({ default: () => <div /> }));
+vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div /> }));
+vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
+vi.mock('../MiFincaVivaHomeCard', () => ({ default: () => <div /> }));
+vi.mock('../FincaRedInstitucional', () => ({ default: () => <div /> }));
+
+globalThis.ResizeObserver = globalThis.ResizeObserver || class {
+  observe() {} unobserve() {} disconnect() {}
+};
+
+import DashboardLive from '../DashboardLive';
+
+afterEach(() => cleanup());
+beforeEach(() => vi.clearAllMocks());
+
+describe('Bug 2 · DOM — hero F2: 4 portales visibles + hoja "resto" separada', () => {
+  test('renderiza los 4 portales del hero (ninguno queda sin montar)', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const nav = await screen.findByTestId('finca-viva-portales');
+    const portales = within(nav).getAllByRole('button');
+    expect(portales).toHaveLength(4);
+    const labels = portales.map((b) => b.getAttribute('aria-label')?.split(':')[0]);
+    expect(labels).toEqual(['Gestionar', 'Aprender', 'Jugar', 'Agente']);
+  });
+
+  test('la hoja "El resto de su finca" NO contiene los portales (superficies separadas)', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const nav = await screen.findByTestId('finca-viva-portales');
+    const hoja = screen.getByText('El resto de su finca').closest('.fvh-resto');
+    expect(hoja).toBeTruthy();
+    // La hoja "resto" es un contenedor distinto: NO envuelve la grilla de portales
+    // (si la envolviera, los taparía/empujaría dentro de su superficie).
+    expect(hoja.contains(nav)).toBe(false);
+  });
+
+  test('en orden de documento, los portales van ANTES de la hoja "resto"', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const nav = await screen.findByTestId('finca-viva-portales');
+    const tit = screen.getByText('El resto de su finca');
+    await waitFor(() => expect(nav).toBeInTheDocument());
+    // compareDocumentPosition: nav precede a tit → DOCUMENT_POSITION_FOLLOWING.
+    const rel = nav.compareDocumentPosition(tit);
+    expect(rel & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -67,6 +67,17 @@
   flex-direction: column;
   align-items: center;        /* centra el shell de ancho máximo en desktop */
   min-height: 100dvh;
+  /* NO COMPRIMIR el hero por debajo de su contenido (fix hoja "resto" tapa los
+     portales, 2026-06-25). El hero es un flex-item del scroller de DashboardLive
+     (h-[100dvh] flex-col en App.jsx con la flag F2). En móvil el contenido
+     —escena 360px + compositor + saludo + los 4 PORTALES— supera el viewport;
+     con flex-shrink:1 (default) el algoritmo flex encogía .fvh hasta 100dvh
+     (su min-height explícita) y `overflow:hidden` RECORTABA la fila inferior de
+     portales (Jugar/Agente). La hoja .fvh-resto (margin-top:-22px) caía entonces
+     sobre esa zona recortada y los tapaba. flex-shrink:0 hace que el hero crezca
+     hasta su contenido (los 4 portales SIEMPRE completos) y la hoja arranque
+     debajo del último portal. */
+  flex-shrink: 0;
   overflow: hidden;
   font-family: var(--fvh-body);
   color: var(--fvh-tinta);
@@ -642,7 +653,13 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
-.fvh-fill { flex: 1 1 auto; }
+/* Aire bajo los portales: garantiza un colchón SIEMPRE presente entre el último
+   portal y el borde inferior del hero, para que la "subida" de la hoja .fvh-resto
+   (su margin-top:-22px) se solape sobre este colchón vacío del hero —el efecto
+   "hoja que sube"— y NUNCA sobre las tarjetas de los portales. Cuando el
+   contenido excede el viewport (flex-shrink:0 arriba), el flex-grow no aporta
+   espacio, así que la cota mínima es lo que asegura el colchón. */
+.fvh-fill { flex: 1 1 auto; min-height: 36px; }
 
 /* ── Vista institucional (slot children del extensionista) ─────────────────── */
 .fvh-institucional {


### PR DESCRIPTION
## Bug / Feature
Dos bugs verificados con capturas del operador en el home F2 "finca-viva" (flag `VITE_FINCA_VIVA_HOME_PERFIL` ON, dev-only).

## Bug 2 (CRÍTICO) — la hoja "El resto de su finca" tapaba los portales
En el home F2, el bottom-sheet "El resto de su finca" se montaba ENCIMA de la grilla de los 4 portales y tapaba **Jugar** y **Agente** (en la captura solo se veían completos Gestionar y Aprender).

### Causa raíz
`.fvh` (el hero `FincaVivaHero`) es un flex-item del scroller de `DashboardLive`, que App.jsx envuelve en `h-[100dvh] flex-col overflow-hidden` con la flag F2. En móvil (390×844) el contenido del hero —escena 360px + compositor + saludo + los 4 portales— **supera el viewport**. Con `flex-shrink: 1` (default), el algoritmo flex encogía `.fvh` hasta su `min-height: 100dvh` (que sobrescribe el min-height auto por contenido) y `overflow: hidden` **RECORTABA la fila inferior de portales**. La hoja `.fvh-resto` (con `margin-top: -22px`) caía entonces sobre esa zona recortada y los tapaba.

### Fix (qué valor cambié)
En `finca-viva-hero.css`:
- `.fvh { flex-shrink: 0 }` → el hero ya **no se comprime por debajo de su contenido**: crece hasta abarcar los 4 portales completos, así que la hoja arranca **debajo del último portal**.
- `.fvh-fill { min-height: 36px }` → colchón garantizado bajo los portales para que la "subida" de la hoja (su `-22px`) se solape sobre **vacío del hero**, no sobre las tarjetas.

Resultado: los 4 portales quedan visibles y clickeables; la hoja sigue su efecto "sube desde el hero" sin tapar nada.

## Bug 1b — selector de especie en el registro por VOZ
`RegistroVozConfirm.jsx` ("LO QUE OÍ… ¿QUÉ ESTÁS REGISTRANDO?… CULTIVO O ESPECIE") tenía el campo "Cultivo o especie" como **texto libre** (editable a mano → riesgo de no-resolución al slug).

### Fix
Se reemplaza el `<input>` por el **mismo `SpeciesCombobox`** que ya usa `SeedingLog` (#1879): precargado con lo que la voz extrajo (ej. "Durazno") pero resolviendo al slug canónico del catálogo (`prunus_persica`). El texto libre queda como salida explícita y marcada (slug `null`). Así la especie del registro por voz hila limpio al slug para calendario/fenología.

## Cambios
- `finca-viva-hero.css` — `.fvh { flex-shrink: 0 }` + `.fvh-fill { min-height: 36px }` (fix de posición/recorte de la hoja).
- `RegistroVozConfirm.jsx` — usa `SpeciesCombobox` (estado `subject` + `speciesId`), reconstruye `species[0].slug` al confirmar; quita el input de texto libre y el badge manual.
- `RegistroVozConfirm.test.jsx` — actualizado al combobox + casos Bug 1b (precarga grounded + re-resolución del slug al cambiar de especie).
- `FincaVivaResto.noSolapa.test.jsx` (nuevo) — Bug 2: CSS-source (flex-shrink:0 + colchón) + DOM (4 portales montados, hoja "resto" como superficie separada).

## Tests
- 4 vitest en `RegistroVozConfirm.test.jsx` (incl. 2 nuevos Bug 1b) passing.
- 5 vitest en `FincaVivaResto.noSolapa.test.jsx` (Bug 2) passing.
- `SeedingLog.speciesSelector` / `SpeciesCombobox` / `FincaVivaHero.portales` / `DashboardLive.homeGating` / `DashboardLive.redistribucion` siguen verdes (sin regresión).
- `vite build` verde · eslint `--max-warnings=0` limpio (0 errores no-undef/no-unused; i18n soft-debt cubierta con disable a nivel de archivo, igual que los hermanos del flujo F2).
- Español Colombia, cero voseo. jsdom no calcula layout → Bug 2 se cubre por CSS-source + estructura DOM (no se usó chromium por OOM).

Refs: capturas operador 2026-06-25 (home F2 dev), PR #1879 (SpeciesCombobox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)