### PR TITLE
feat(home): reorganizar el resto del home en 5 bloques + copy campesino (audit botones/distribución, gated dev-only)

### DIFF
--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -112,42 +112,50 @@ const SECTION_COMPONENTS = {
 };
 
 // ───────────────────────────────────────────────────────────────────────────
-// REDISTRIBUCIÓN del "resto de su finca" (auditoría CAPABILITIES_STATUS §7.2 +
-// §7.4 #2, 2026-06-25). Antes: UN solo bloque "Herramientas de finca" apilaba
-// 11 tiles sueltos (suelo, semilleros, seguridad, aprende, especies,
-// biopreparados, nutrientes, casos, calendario, faq, mercado) — la
-// fragmentación que la auditoría quiere eliminar. Ahora se reparten en TRES
-// grupos con JERARQUÍA explícita, para que el campesino distinga de un vistazo
-// lo SÓLIDO de lo flojo:
+// REORGANIZACIÓN DEL HOME F2 EN 5 BLOQUES (auditoría botones/distribución
+// 2026-06-26, docs/audit-botones-distribucion-2026-06-26.md). Antes el "resto de
+// su finca" eran ~44 botones en 10 bloques bajo el fold: un índice del producto,
+// no un home. La auditoría lo reordena por el FLUJO MENTAL DEL CAMPESINO
+// (estado → tengo → hago → consulto → vendo), con copy concreto campesino:
 //
-//   1. DESTACADO_TILES  → lo FUERTE y grounded (§7.2 elevar): directorio de
-//      especies + calendario de finca. Arriba, tiles grandes (2 columnas).
-//   2. APRENDER_TILES   → todo lo de APRENDIZAJE/contenido consolidado bajo un
-//      solo hub "Aprender" (§7.4 #2): lecciones (aprende), casos de estudio,
-//      ciclo de nutrientes, galería de biopreparados, suelo/micorrizas como
-//      contenido, toxicología (seguridad de insumos) y las preguntas frecuentes.
-//      Ya NO son tiles top-level sueltos.
-//   3. GESTION_TILES    → "Mi finca / gestión": registros y acciones (semilleros,
-//      cosechar, insumos, mantenimiento). Accesible pero de-enfatizado.
-//   4. MERCADO_TILE     → marketplace, BAJADO (§7.2: el precio SIPSA es la
-//      fachada más delgada). Va al fondo, en su propio rótulo discreto.
+//   BLOQUE 1 "Cómo va su finca hoy" → el día + clima + el aviso de Chagra,
+//            FUNDIDOS (antes: dos paneles de IA duplicados — AnalisisProactivoIA
+//            "IA local" + AIStatusFooter "Status proactivo IA" — y "Hoy en finca"
+//            DUPLICADO: strip `hoyfinca` + tile `hoy`). Sube ARRIBA.
+//   BLOQUE 2 "Sus plantas y animales" → plantas, zonas, plagas, asociaciones,
+//            flora/fauna + animales (antes 5 superficies de plantas revueltas).
+//   BLOQUE 3 "Registrar en la finca" → semilleros, cosechar, abonos e insumos
+//            (UNIFICADO), labores, bitácora (GESTION_TILES, el ancla #finca-gestion).
+//   BLOQUE 4 "Consultar y aprender" → especies/catálogo, calendario, casos,
+//            biopreparados, suelo, seguridad, sacar reportes, FAQ
+//            (DESTACADO + APRENDER + reportes). De consulta ocasional.
+//   BLOQUE 5 "Vender y comprar" → Mercado (al fondo, ya estaba bien).
+//   CONDICIONAL, MÁS ABAJO: "Sus proyectos de finca" (Reforestación /
+//            Silvopastoreo / Páramo / Cerdos) — gateado por perfil, BAJADO.
 //
-// Cada tile navega con onNavigate(view, data) → currentView (la pantalla real ya
-// existe en App.jsx). Universales: las ve todo perfil (herramientas básicas),
-// salvo el gating por perfil que ya gobierna el resto del home.
+// GATE: TODO lo nuevo va tras `fincaVivaHomePerfilActivo()` (flag ON dev / OFF
+// prod). Con la flag OFF el home queda EXACTO como hoy (layout legacy intacto:
+// grid draggable + AIStatusFooter + los rótulos viejos). Las tablas de tiles
+// llevan `labelF2`/`descF2` que SOLO se usan con la flag ON, para que el copy
+// campesino no toque prod. Cada tile navega con onNavigate(view, data) →
+// currentView (la pantalla real ya existe en App.jsx).
 // ───────────────────────────────────────────────────────────────────────────
 
 // 1) DESTACADO — lo más sólido y grounded de Chagra, elevado (§7.2). El
 //    directorio (721 especies con clima/asociaciones/plagas groundeadas) y el
 //    calendario unificado son superficies 100% AGE/catálogo: el campesino debe
 //    distinguirlas como el núcleo fuerte. Se renderizan en tiles GRANDES.
+// `labelF2`/`descF2` (opcionales): copy CAMPESINO que se usa SOLO con la home F2
+// activa (flag ON). Con la flag OFF se conserva `label`/`desc` tal cual (el
+// dashboard legacy queda intacto, audit "flag OFF = home actual"). Así el copy de
+// la auditoría no rompe el layout de prod ni sus tests.
 const DESTACADO_TILES = [
-    { view: 'directorio', label: 'Especies', icon: Sprout, desc: 'Directorio: clima, asociaciones, plagas y biopreparados por especie', accent: 'text-lime-400 border-l-lime-500' },
+    { view: 'directorio', label: 'Especies', labelF2: 'Qué puedo sembrar', icon: Sprout, desc: 'Directorio: clima, asociaciones, plagas y biopreparados por especie', descF2: 'Qué crece en su clima, con qué se lleva y sus plagas', accent: 'text-lime-400 border-l-lime-500' },
     // Calendario de finca: UN solo calendario que unifica por planta fenología,
     // nutrición, siembra, cosecha, sanidad y ciclo perenne (App.jsx case
     // 'calendario_finca' → CalendarioFincaScreen). Groundeado en
     // farmCalendarService; reusa los ciclos de la finca y el catálogo.
-    { view: 'calendario_finca', label: 'Calendario', icon: CalendarDays, desc: 'Siembra, abono, plagas y cosecha de su finca en una sola línea de tiempo', accent: 'text-violet-400 border-l-violet-500' },
+    { view: 'calendario_finca', label: 'Calendario', labelF2: 'Calendario de la finca', icon: CalendarDays, desc: 'Siembra, abono, plagas y cosecha de su finca en una sola línea de tiempo', descF2: 'Cuándo sembrar, abonar y cosechar, todo junto', accent: 'text-violet-400 border-l-violet-500' },
 ];
 
 // 2) APRENDER — hub único de contenido/aprendizaje (§7.4 #2). Consolida todas
@@ -166,22 +174,33 @@ const DESTACADO_TILES = [
 //      · faq            → preguntas frecuentes sobre Chagra.
 const APRENDER_TILES = [
     { view: 'aprende', label: 'Aprender', icon: BookOpen, desc: 'Lecciones agroecológicas con fuente', accent: 'text-emerald-400 border-l-emerald-500' },
-    { view: 'casos', label: 'Casos de estudio', icon: ClipboardList, desc: 'Problemas reales y su tratamiento', accent: 'text-amber-400 border-l-amber-500' },
+    { view: 'casos', label: 'Casos de estudio', labelF2: 'Casos reales', icon: ClipboardList, desc: 'Problemas reales y su tratamiento', descF2: 'Problemas de otras fincas y cómo los resolvieron', accent: 'text-amber-400 border-l-amber-500' },
     { view: 'ciclo_nutrientes', label: 'Ciclo de nutrientes', icon: Recycle, desc: 'Del animal al suelo y la planta', accent: 'text-emerald-400 border-l-emerald-500' },
     { view: 'biopreparados', label: 'Biopreparados', icon: FlaskConical, desc: 'Recetas caseras paso a paso', accent: 'text-lime-400 border-l-lime-500', data: { back: 'dashboard' } },
-    { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Salud del suelo y micorrizas', accent: 'text-amber-400 border-l-amber-500' },
-    { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo', accent: 'text-rose-400 border-l-rose-500' },
+    { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Salud del suelo y micorrizas', descF2: 'Cómo está su tierra y cómo cuidarla', accent: 'text-amber-400 border-l-amber-500' },
+    { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo', descF2: 'Qué es peligroso y cómo cuidarse', accent: 'text-rose-400 border-l-rose-500' },
     { view: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle, desc: 'Cómo funciona Chagra', accent: 'text-violet-400 border-l-violet-500' },
 ];
+
+// Reportes para imprimir/llevar a la cooperativa. Antes vivía solo como tarjeta
+// "Informes/CSV" en el grid del vistazo (audit: jerga); en F2 se trae al bloque
+// "Consultar y aprender" con copy campesino ("Sacar reportes"). `informes` es la
+// ruta real (App.jsx). Solo se ofrece como tile en la home F2.
+const REPORTES_TILE_F2 = { view: 'informes', label: 'Sacar reportes', icon: FileText, desc: 'Para imprimir o llevar al banco o la cooperativa', accent: 'text-slate-300 border-l-slate-500' };
 
 // 3) GESTIÓN — "Mi finca": registros y acciones de manejo, sin launcher directo
 //    antes (huérfanas o solo por la mano). Semilleros entra aquí (es gestión de
 //    siembra, no contenido). Accesible pero de-enfatizado respecto a lo fuerte.
+// El copy campesino (labelF2/descF2) SOLO aplica con la home F2 ON; con OFF se
+// conservan label/desc legacy intactos (prod no cambia).
 const GESTION_TILES = [
-    { view: 'germinacion', label: 'Semilleros', icon: TestTube, desc: 'Prueba de semillas y germinación', accent: 'text-teal-400 border-l-teal-500' },
-    { view: 'cosechar', label: 'Cosechar', icon: Wheat, desc: 'Registrar una cosecha', accent: 'text-amber-400 border-l-amber-500' },
-    { view: 'insumos', label: 'Insumos aplicados', icon: Droplets, desc: 'Registrar una aplicación de bioinsumo', accent: 'text-sky-400 border-l-sky-500' },
-    { view: 'mantenimiento', label: 'Mantenimiento', icon: Wrench, desc: 'Labores de mantenimiento de la finca', accent: 'text-slate-300 border-l-slate-500' },
+    { view: 'germinacion', label: 'Semilleros', icon: TestTube, desc: 'Prueba de semillas y germinación', descF2: 'Pruebe sus semillas y vea cuáles nacen', accent: 'text-teal-400 border-l-teal-500' },
+    { view: 'cosechar', label: 'Cosechar', icon: Wheat, desc: 'Registrar una cosecha', descF2: 'Anote lo que recogió', accent: 'text-amber-400 border-l-amber-500' },
+    // "Abonos e insumos" (F2) UNIFICA lo que antes eran dos puertas solapadas
+    // (audit §3.1): "Insumos aplicados" (registrar la aplicación) y la tarjeta
+    // "Insumos" del vistazo (ver el inventario). Una sola entrada, dos acciones.
+    { view: 'insumos', label: 'Insumos aplicados', labelF2: 'Abonos e insumos', icon: Droplets, desc: 'Registrar una aplicación de bioinsumo', descF2: 'Anote un abono o aplicación y vea lo que tiene', accent: 'text-sky-400 border-l-sky-500' },
+    { view: 'mantenimiento', label: 'Mantenimiento', labelF2: 'Labores de la finca', icon: Wrench, desc: 'Labores de mantenimiento de la finca', descF2: 'Arreglos, limpias y mantenimiento', accent: 'text-slate-300 border-l-slate-500' },
 ];
 
 // 4) MERCADO — marketplace de circuitos cortos. BAJADO (§7.2): la fachada de
@@ -462,6 +481,100 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
         }
     }, []);
 
+    // ── Helpers de render (compartidos entre el layout F2 y el legacy) ────────
+    // Rótulo de bloque con la barrita de color. Función pura que DEVUELVE JSX (no
+    // un componente, para no violar react-hooks/static-components al definirlo
+    // dentro del render). Con F2 ON usa la tinta clara de la hoja
+    // (.fvh-block-label); con OFF, el gris legacy. `bar` es la clase de gradiente
+    // COMPLETA y ESTÁTICA (no construida con template) para que el scanner de
+    // Tailwind la detecte y no la purgue del build.
+    const blockLabel = (children, bar = 'from-emerald-400 to-teal-400') => (
+        <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
+            <span aria-hidden="true" className={`h-3.5 w-1 rounded-full bg-gradient-to-b ${bar}`} />
+            {children}
+        </p>
+    );
+
+    // El texto del tile: copy CAMPESINO (labelF2/descF2) solo con la home F2 ON;
+    // con OFF, el label/desc original (audit: "flag OFF = home actual intacto").
+    const tileLabel = (tile) => (fincaVivaFlag && tile.labelF2) ? tile.labelF2 : tile.label;
+    const tileDesc = (tile) => (fincaVivaFlag && tile.descF2) ? tile.descF2 : tile.desc;
+
+    // Tile estándar (chico) — reusa el ESTILO único de los tiles del resto
+    // (mismo fix de contraste F2: .fvh-tile-label/.fvh-tile-desc fuerzan tinta
+    // oscura sobre el pastel claro). `size` cambia ícono y altura.
+    const renderTile = (tile, { large = false } = {}) => (
+        <button
+            key={tile.view}
+            type="button"
+            onClick={() => onNavigate(tile.view, tile.data)}
+            aria-label={`${tileLabel(tile)}: ${tileDesc(tile)}`}
+            className={`dash-tile ${large ? 'dash-tile--destacado ' : ''}${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} ${large ? 'rounded-2xl p-4 min-h-[112px]' : 'rounded-xl p-3 min-h-[88px]'} text-left active:bg-slate-800/70 transition-colors flex flex-col`}
+        >
+            <tile.icon size={large ? 30 : 24} strokeWidth={2} className={`${large ? 'mb-2' : 'mb-1.5'} ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
+            <span className={`${large ? 'text-base' : 'text-sm'} font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tileLabel(tile)}</span>
+            <span className={`${large ? 'text-xs mt-1 leading-snug' : 'text-2xs mt-0.5 leading-tight'} block fvh-tile-desc ${fincaVivaFlag ? '' : (large ? 'text-slate-400' : 'text-slate-500')}`}>{tileDesc(tile)}</span>
+        </button>
+    );
+
+    // El bloque de Mercado (tile ancho) — idéntico en ambos layouts.
+    const renderMercado = () => (
+        <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
+            {blockLabel('Vender y comprar', 'from-emerald-400 to-lime-400')}
+            <div className="grid grid-cols-1 gap-3" data-testid="mercado-tiles">
+                <button
+                    type="button"
+                    onClick={() => onNavigate(MERCADO_TILE.view, MERCADO_TILE.data)}
+                    aria-label={`${MERCADO_TILE.label}: ${MERCADO_TILE.desc}`}
+                    className={`dash-tile ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${MERCADO_TILE.accent} rounded-xl p-3.5 text-left active:bg-slate-800/70 transition-colors flex items-center gap-3`}
+                >
+                    <MERCADO_TILE.icon size={26} strokeWidth={2} className={`${MERCADO_TILE.accent.split(' ')[0]} shrink-0`} aria-hidden="true" />
+                    <span className="flex-1 min-w-0">
+                        <span className={`text-sm font-black block leading-tight fvh-tile-label ${MERCADO_TILE.accent.split(' ')[0]}`}>{MERCADO_TILE.label}</span>
+                        <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-500'}`}>{MERCADO_TILE.desc}</span>
+                    </span>
+                    <ChevronRight size={18} className={`shrink-0 ${MERCADO_TILE.accent.split(' ')[0]} opacity-70`} aria-hidden="true" />
+                </button>
+            </div>
+        </div>
+    );
+
+    // Banner "Campo, Javier" (gateado al operador) — idéntico en ambos layouts.
+    const renderJavier = () => (mostrarJavier && (
+        <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
+            <button
+                type="button"
+                onClick={() => onNavigate('javier')}
+                className="w-full flex items-center gap-3 p-3.5 rounded-2xl border border-slate-700/60 bg-slate-900/40 hover:bg-slate-800/50 active:scale-[0.99] transition text-left"
+                aria-label="Campo, Javier: panel de trabajo en finca"
+            >
+                <span className="shrink-0 w-11 h-11 rounded-xl bg-emerald-500/15 grid place-items-center">
+                    <Eye size={24} className="text-emerald-300" />
+                </span>
+                <span className="flex-1 min-w-0">
+                    <span className="block font-bold text-slate-100 leading-tight">Campo, Javier</span>
+                    <span className="block text-xs text-slate-400 leading-tight">
+                        Panel de trabajo: tareas por proximidad y registro en finca
+                    </span>
+                </span>
+                <ChevronRight size={20} className="text-slate-400/70 shrink-0" />
+            </button>
+        </div>
+    ));
+
+    // Bloque CONDICIONAL "Sus proyectos de finca" (antes "Seguimiento de
+    // procesos"): Reforestación · Silvopastoreo · Páramo · Cerdos. Gateado por
+    // perfil (un urbano no lo ve). En F2 BAJA (audit: es de nicho, no roba el
+    // primer scroll); con OFF conserva su posición/rótulo legacy.
+    const renderSeguimiento = ({ f2 } = {}) => ((seguimientoKeys === null || seguimientoKeys.length > 0) && (
+        <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
+            {blockLabel(f2 ? 'Sus proyectos de finca' : 'Seguimiento de procesos', 'from-emerald-400 to-teal-400')}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="seguimiento-cards">
+                <SeguimientoCards onNavigate={onNavigate} variant="grid" keys={seguimientoKeys} />
+            </div>
+        </div>
+    ));
+
     return (
         <div
             className="relative flex flex-col w-full h-full overflow-y-auto pb-6"
@@ -537,28 +650,13 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
             {fincaVivaFlag && esExtensionista ? null : (
             <div className={fincaVivaFlag ? 'fvh-resto' : 'contents'}>
             <div className={fincaVivaFlag ? 'fvh-resto-shell' : 'contents'}>
-            {fincaVivaFlag && (
-                <>
-                    <div className="fvh-resto-grip" aria-hidden="true" />
-                    <h2 className="fvh-resto-tit">El resto de su finca</h2>
-                    <p className="fvh-resto-sub">
-                        Sus herramientas, registros y el estado de un vistazo. Para
-                        entrar a un lugar, use los portales de arriba.
-                    </p>
-                </>
-            )}
-
-            {/* Paisaje elegido — la foto de biodiversidad seleccionada. Con la
-                flag F2 ON se omite: el fondo lo gobierna el hero/la hoja clara,
-                la foto oscura de biodiversidad rompería la cohesión. */}
-            {!fincaVivaFlag && <SelectedBackgroundReveal />}
 
             {/* Acceso al módulo "Reporte de Punto Glaciar" (guías de glaciar).
                 Ruta #glaciar. ACCESO RESTRINGIDO a los beta testers de "La
                 Cordada": el banner solo se renderiza si el usuario logueado
                 está en la whitelist (src/config/glaciarAccess.js). Para el resto
                 de usuarios el módulo es invisible. Offline-first (lee el usuario
-                ya guardado en login, sin red). */}
+                ya guardado en login, sin red). Va arriba en ambos layouts. */}
             {tieneAccesoGlaciarActual() && (
                 <div className="px-4 pt-3">
                     <button
@@ -580,269 +678,201 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                 </div>
             )}
 
-            {/* MI FINCA VIVA / RED INSTITUCIONAL — la escena del home.
-                ─────────────────────────────────────────────────────────────
-                Flag VITE_FINCA_VIVA_HOME_PERFIL (fincaVivaHomePerfilActivo):
-                  · ON  → la escena (finca propia o RED institucional) YA es el
-                          HERO inmersivo de arriba (FincaVivaHero), no una tarjeta
-                          aquí abajo. No se repite el bloque (mockup F2).
-                  · OFF (default) → comportamiento actual intacto: la escena 2D
-                          fenológica como TARJETA, solo cuando ya hay algo
-                          sembrado (plantsCount > 0), para no competir con el
-                          OnboardingHero. La tarjeta es autocontenida (lee
-                          farmProcessCache offline-first y abre el juego al
-                          tocarla). */}
-            {!fincaVivaFlag && plantsCount > 0 && (
+            {fincaVivaFlag ? (
+            /* ════════════════════════════════════════════════════════════════
+               HOME F2 EN 5 BLOQUES (audit botones/distribución 2026-06-26).
+               Orden = flujo mental del campesino: estado → tengo → hago →
+               consulto → vendo. Copy campesino. Bloque condicional de proyectos
+               BAJADO. Solo activo con la flag ON; el legacy (else) queda intacto.
+               ════════════════════════════════════════════════════════════════ */
+            <>
+                {/* ── BLOQUE 1 · "Cómo va su finca hoy" ───────────────────────
+                    FUNDE lo que antes eran cuatro superficies solapadas (audit
+                    §3.7/§3.8): el día (HoyEnFincaStrip — UNA sola vez; el tile
+                    duplicado `hoy` ya no se renderiza aquí), el clima
+                    (ClimaStrip) y el aviso/recomendación de Chagra
+                    (AnalisisProactivoIA). El antiguo footer "Status proactivo IA"
+                    (AIStatusFooter) NO se monta en F2: su idea ES este bloque, y
+                    duplicarla era el solape ALTO reportado. Sube ARRIBA: es lo
+                    primero que el campesino quiere ver. */}
+                <div className="px-4 pt-3 fvh-resto-block" data-testid="bloque-finca-hoy">
+                    {blockLabel('Cómo va su finca hoy', 'from-cyan-400 to-emerald-400')}
+                    <div className="space-y-3">
+                        <HoyEnFincaStrip onNavigate={onNavigate} />
+                        <ClimaStrip onNavigate={onNavigate} />
+                        <AnalisisProactivoIA onNavigate={onNavigate} sensors={iotAlerts} />
+                    </div>
+                </div>
+
+                {/* Top problemas activos (casos de estudio, DR-044). Se auto-oculta
+                    si no hay casos → zero footprint. Va tras el estado del día. */}
+                <div className="px-4 pt-3 fvh-resto-block">
+                    <CaseStudyTopWidget onNavigate={onNavigate} maxItems={3} />
+                </div>
+
+                {/* ── BLOQUE 2 · "Sus plantas y animales" ─────────────────────
+                    Agrupa las cinco superficies de plantas que antes estaban
+                    revueltas entre el grid del vistazo y el bloque destacado
+                    (audit §3.4): mis matas (plantas), zonas, plagas, asociaciones
+                    y flora/fauna — más los animales. Así se entiende cuál abrir
+                    para "ver mis matas". */}
+                <div className="px-4 pt-3 fvh-resto-block" data-testid="bloque-plantas-animales">
+                    {blockLabel('Sus plantas y animales', 'from-lime-400 to-emerald-400')}
+                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                        <PlantasCard onNavigate={onNavigate} variant="grid" />
+                        <ZonasCard onNavigate={onNavigate} variant="grid" />
+                        <PlagasCard onNavigate={onNavigate} variant="grid" />
+                        <AsociacionesCard onNavigate={onNavigate} variant="grid" />
+                        <BiodiversidadCard onNavigate={onNavigate} variant="grid" />
+                    </div>
+                    {mostrarAnimales && (
+                        <div className="mt-3">
+                            <AnimalesCard onNavigate={onNavigate} variant="list" />
+                        </div>
+                    )}
+                </div>
+
+                {/* ── BLOQUE 3 · "Registrar en la finca" ──────────────────────
+                    El bloque de ACCIÓN: semilleros, cosechar, abonos e insumos
+                    (UNIFICA los dos insumos que se solapaban, audit §3.1), labores
+                    y la bitácora. Conserva el ancla #finca-gestion: el portal "Mi
+                    finca" del hero hace scroll hasta aquí (revelarGestion). El
+                    botón único de voz (#23) no se toca: solo cambia la
+                    organización/labels. */}
+                <div
+                    id="finca-gestion"
+                    tabIndex={-1}
+                    style={{ scrollMarginTop: '88px', outline: 'none' }}
+                    className="px-4 pt-3 fvh-resto-block"
+                    data-testid="bloque-registrar"
+                >
+                    {blockLabel('Registrar en la finca', 'from-sky-400 to-emerald-400')}
+                    <div className="grid grid-cols-3 gap-3" data-testid="gestion-tiles">
+                        {GESTION_TILES.map((tile) => renderTile(tile))}
+                    </div>
+                    <div className="mt-3">
+                        <BitacoraCard onNavigate={onNavigate} variant="list" />
+                    </div>
+                </div>
+
+                {/* ── BLOQUE 4 · "Consultar y aprender" ───────────────────────
+                    Lo de consulta ocasional, no del primer scroll (audit §4):
+                    catálogo de plantas + calendario (lo fuerte y grounded, en
+                    tiles grandes), las superficies de contenido (casos,
+                    biopreparados, suelo, seguridad, faq) y "Sacar reportes". El
+                    portal "Aprender" del hero ya entra al hub `aprende`, así que
+                    aquí se filtra ese tile para no duplicar el nombre (audit
+                    §3.5). Colapsable: <details> abierto por defecto. */}
+                <div className="px-4 pt-3 fvh-resto-block" data-testid="bloque-consultar">
+                    <details open className="fvh-consultar">
+                        <summary className="list-none cursor-pointer">
+                            {blockLabel('Consultar y aprender', 'from-violet-400 to-emerald-400')}
+                        </summary>
+                        <div className="grid grid-cols-2 gap-3" data-testid="destacado-tiles">
+                            {DESTACADO_TILES.map((tile) => renderTile(tile, { large: true }))}
+                        </div>
+                        <div className="grid grid-cols-3 gap-3 mt-3" data-testid="aprender-tiles">
+                            {APRENDER_TILES
+                                .filter((tile) => tile.view !== 'aprende')
+                                .map((tile) => renderTile(tile))}
+                            {renderTile(REPORTES_TILE_F2)}
+                        </div>
+                    </details>
+                </div>
+
+                {/* ── BLOQUE 5 · "Vender y comprar" ───────────────────────────
+                    Mercado, ya está bien; va al fondo de lo cotidiano. */}
+                {renderMercado()}
+
+                {/* ── CONDICIONAL · "Sus proyectos de finca" (BAJADO) ─────────
+                    Reforestación · Silvopastoreo · Páramo · Cerdos. Es de nicho
+                    (audit §4): gateado por perfil y BAJADO bajo lo cotidiano para
+                    no robarle el primer scroll a "mis plantas/hoy". */}
+                {renderSeguimiento({ f2: true })}
+
+                {/* "Campo, Javier" (gateado al operador), al fondo. */}
+                {renderJavier()}
+            </>
+            ) : (
+            /* ════════════════════════════════════════════════════════════════
+               LAYOUT LEGACY (flag OFF) — EXACTAMENTE como hoy en prod. NO tocar:
+               el grid draggable + AIStatusFooter + los rótulos y el orden viejos.
+               ════════════════════════════════════════════════════════════════ */
+            <>
+            {/* Paisaje elegido — la foto de biodiversidad seleccionada. */}
+            <SelectedBackgroundReveal />
+
+            {/* MI FINCA VIVA — la escena 2D fenológica como TARJETA, solo cuando
+                ya hay algo sembrado (plantsCount > 0). */}
+            {plantsCount > 0 && (
                 <div className="px-4 pt-3">
                     <MiFincaVivaHomeCard onNavigate={onNavigate} />
                 </div>
             )}
 
-            {/* Top problemas activos (casos de estudio, DR-044). Rescate huérfano
-                2026-06-24: vivía solo en el DashboardView muerto. Se auto-oculta
-                si no hay casos activos (retorna null) → zero footprint. Abre
-                'casos' al tocarlo. */}
-            <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
+            {/* Top problemas activos (casos de estudio). */}
+            <div className="px-4 pt-3">
                 <CaseStudyTopWidget onNavigate={onNavigate} maxItems={3} />
             </div>
 
-            {/* Seguimiento de procesos de finca (2026-06-15): TARJETAS en el
-                home — Reforestación · Silvopastoreo · Páramo · Cerdos — al estilo
-                de "Mis plantas". Cada una abre su VISTA de seguimiento (iniciar
-                el proceso, ver etapas con fechas, agregar registros/fotos y ver
-                el avance). El operador las pidió visibles en el home (no escondidas
-                tras la Ⓐ ni iniciables solo por voz). Bloque propio, fuera del
-                grid draggable de módulos.
+            {/* Seguimiento de procesos — gateado por perfil. */}
+            {renderSeguimiento()}
 
-                GATING POR PERFIL: `seguimientoKeys` filtra qué tarjetas se ven
-                ("el usuario solo ve lo que necesita" — un urbano NUNCA ve Cerdos
-                ni Silvopastoreo). Si el perfil no permite ninguna (ej. urbano de
-                balcón), el bloque entero se oculta. null = fail-open (las 4). */}
-            {(seguimientoKeys === null || seguimientoKeys.length > 0) && (
-                <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
-                    <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
-                        <span
-                            aria-hidden="true"
-                            className="h-3.5 w-1 rounded-full bg-gradient-to-b from-emerald-400 to-teal-400"
-                        />
-                        Seguimiento de procesos
-                    </p>
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="seguimiento-cards">
-                        <SeguimientoCards onNavigate={onNavigate} variant="grid" keys={seguimientoKeys} />
-                    </div>
-                </div>
-            )}
-
-            {/* ════════════════════════════════════════════════════════════════
-                REDISTRIBUCIÓN del "resto de su finca" (auditoría §7.2 + §7.4 #2):
-                un solo bloque-pila se reparte en TRES grupos con jerarquía clara.
-                `renderTile` mantiene un único estilo de tile (incluye el fix de
-                contraste: en F2 el label/desc van con tinta oscura forzada por
-                .fvh-tile-label/.fvh-tile-desc en finca-viva-resto.css, no con el
-                color de acento que sería ilegible sobre el pastel claro). El
-                refuerzo WCAG AA de los tiles DESTACADOS grandes vive en
-                dashboard-resto-redistribucion.css. ════════════════════════════ */}
-
-            {/* 1) DESTACADO — lo más sólido y grounded, ELEVADO (§7.2): directorio
-                de especies + calendario unificado. Tiles GRANDES (2 columnas) con
-                ícono prominente, para que se lean como el núcleo fuerte. */}
-            <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
-                <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
-                    <span
-                        aria-hidden="true"
-                        className="h-3.5 w-1 rounded-full bg-gradient-to-b from-lime-400 to-emerald-400"
-                    />
-                    Lo más sólido de Chagra
-                </p>
+            {/* DESTACADO — "Lo más sólido de Chagra": especies + calendario. */}
+            <div className="px-4 pt-3">
+                {blockLabel('Lo más sólido de Chagra', 'from-lime-400 to-emerald-400')}
                 <div className="grid grid-cols-2 gap-3" data-testid="destacado-tiles">
-                    {DESTACADO_TILES.map((tile) => (
-                        <button
-                            key={tile.view}
-                            type="button"
-                            onClick={() => onNavigate(tile.view, tile.data)}
-                            aria-label={`${tile.label}: ${tile.desc}`}
-                            className={`dash-tile dash-tile--destacado ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} rounded-2xl p-4 text-left min-h-[112px] active:bg-slate-800/70 transition-colors flex flex-col`}
-                        >
-                            <tile.icon size={30} strokeWidth={2} className={`mb-2 ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
-                            <span className={`text-base font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tile.label}</span>
-                            <span className={`text-xs block mt-1 leading-snug fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-400'}`}>{tile.desc}</span>
-                        </button>
-                    ))}
+                    {DESTACADO_TILES.map((tile) => renderTile(tile, { large: true }))}
                 </div>
             </div>
 
-            {/* 2) APRENDER — hub único de contenido (§7.4 #2): todas las superficies
-                de aprendizaje consolidadas bajo un solo rótulo. Con F2 ON el portal
-                "Aprender" del hero ya entra al hub `aprende`, así que aquí se filtra
-                ese tile para no duplicarlo; las lecciones individuales (casos,
-                nutrientes, biopreparados, suelo, seguridad, faq) sí se ofrecen como
-                accesos directos al contenido. */}
-            <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
-                <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
-                    <span
-                        aria-hidden="true"
-                        className="h-3.5 w-1 rounded-full bg-gradient-to-b from-emerald-400 to-teal-400"
-                    />
-                    Aprender
-                </p>
+            {/* APRENDER — hub único de contenido (con OFF SÍ incluye 'aprende'). */}
+            <div className="px-4 pt-3">
+                {blockLabel('Aprender', 'from-emerald-400 to-teal-400')}
                 <div className="grid grid-cols-3 gap-3" data-testid="aprender-tiles">
-                    {APRENDER_TILES
-                        .filter((tile) => !(fincaVivaFlag && tile.view === 'aprende'))
-                        .map((tile) => (
-                        <button
-                            key={tile.view}
-                            type="button"
-                            onClick={() => onNavigate(tile.view, tile.data)}
-                            aria-label={`${tile.label}: ${tile.desc}`}
-                            className={`dash-tile ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} rounded-xl p-3 text-left min-h-[88px] active:bg-slate-800/70 transition-colors flex flex-col`}
-                        >
-                            <tile.icon size={24} strokeWidth={2} className={`mb-1.5 ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
-                            <span className={`text-sm font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tile.label}</span>
-                            <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-500'}`}>{tile.desc}</span>
-                        </button>
-                    ))}
+                    {APRENDER_TILES.map((tile) => renderTile(tile))}
                 </div>
             </div>
 
-            {/* 3) GESTIÓN — "Mi finca": registros y acciones de manejo (semilleros,
-                cosechar, insumos, mantenimiento). De-enfatizado respecto a lo
-                fuerte; las rutas ya existen en App.jsx.
-
-                ANCLA #finca-gestion: el portal "Gestionar" del hero F2 hace scroll
-                hasta aquí (revelarGestion). `tabIndex=-1` permite mover el foco
-                programáticamente (teclado/lector) sin volverlo tabulable; el
-                scroll-margin-top deja aire bajo el topbar flotante. */}
+            {/* GESTIÓN — "Mi finca · gestión" (ancla #finca-gestion). */}
             <div
                 id="finca-gestion"
                 tabIndex={-1}
                 style={{ scrollMarginTop: '88px', outline: 'none' }}
-                className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}
+                className="px-4 pt-3"
             >
-                <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
-                    <span
-                        aria-hidden="true"
-                        className="h-3.5 w-1 rounded-full bg-gradient-to-b from-sky-400 to-emerald-400"
-                    />
-                    Mi finca · gestión
-                </p>
+                {blockLabel('Mi finca · gestión', 'from-sky-400 to-emerald-400')}
                 <div className="grid grid-cols-3 gap-3" data-testid="gestion-tiles">
-                    {GESTION_TILES.map((tile) => (
-                        <button
-                            key={tile.view}
-                            type="button"
-                            onClick={() => onNavigate(tile.view, tile.data)}
-                            aria-label={`${tile.label}: ${tile.desc}`}
-                            className={`dash-tile ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} rounded-xl p-3 text-left min-h-[88px] active:bg-slate-800/70 transition-colors flex flex-col`}
-                        >
-                            <tile.icon size={24} strokeWidth={2} className={`mb-1.5 ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
-                            <span className={`text-sm font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tile.label}</span>
-                            <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-500'}`}>{tile.desc}</span>
-                        </button>
-                    ))}
+                    {GESTION_TILES.map((tile) => renderTile(tile))}
                 </div>
             </div>
 
-            {/* 4) MERCADO — marketplace de circuitos cortos, BAJADO (§7.2: el
-                precio SIPSA es la fachada más delgada). Va al fondo, en su propio
-                rótulo discreto, sin mezclarse con lo fuerte. Tile a ancho completo
-                de baja jerarquía visual. */}
-            <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
-                <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
-                    <span
-                        aria-hidden="true"
-                        className="h-3.5 w-1 rounded-full bg-gradient-to-b from-emerald-400 to-lime-400"
-                    />
-                    Vender y comprar
-                </p>
-                <div className="grid grid-cols-1 gap-3" data-testid="mercado-tiles">
-                    <button
-                        type="button"
-                        onClick={() => onNavigate(MERCADO_TILE.view, MERCADO_TILE.data)}
-                        aria-label={`${MERCADO_TILE.label}: ${MERCADO_TILE.desc}`}
-                        className={`dash-tile ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${MERCADO_TILE.accent} rounded-xl p-3.5 text-left active:bg-slate-800/70 transition-colors flex items-center gap-3`}
-                    >
-                        <MERCADO_TILE.icon size={26} strokeWidth={2} className={`${MERCADO_TILE.accent.split(' ')[0]} shrink-0`} aria-hidden="true" />
-                        <span className="flex-1 min-w-0">
-                            <span className={`text-sm font-black block leading-tight fvh-tile-label ${MERCADO_TILE.accent.split(' ')[0]}`}>{MERCADO_TILE.label}</span>
-                            <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-500'}`}>{MERCADO_TILE.desc}</span>
-                        </span>
-                        <ChevronRight size={18} className={`shrink-0 ${MERCADO_TILE.accent.split(' ')[0]} opacity-70`} aria-hidden="true" />
-                    </button>
-                </div>
-            </div>
+            {/* MERCADO. */}
+            {renderMercado()}
 
-            {/* "Campo, Javier" (WorkerDashboard) — rescate huérfano 2026-06-24,
-                gateado al OPERADOR (vista de supervisor/trabajador, nicho). La
-                ruta #javier sigue viva en el router. Ref: CAPABILITIES_STATUS §2. */}
-            {mostrarJavier && (
-                <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
-                    <button
-                        type="button"
-                        onClick={() => onNavigate('javier')}
-                        className="w-full flex items-center gap-3 p-3.5 rounded-2xl border border-slate-700/60 bg-slate-900/40 hover:bg-slate-800/50 active:scale-[0.99] transition text-left"
-                        aria-label="Campo, Javier: panel de trabajo en finca"
-                    >
-                        <span className="shrink-0 w-11 h-11 rounded-xl bg-emerald-500/15 grid place-items-center">
-                            <Eye size={24} className="text-emerald-300" />
-                        </span>
-                        <span className="flex-1 min-w-0">
-                            <span className="block font-bold text-slate-100 leading-tight">Campo, Javier</span>
-                            <span className="block text-xs text-slate-400 leading-tight">
-                                Panel de trabajo: tareas por proximidad y registro en finca
-                            </span>
-                        </span>
-                        <ChevronRight size={20} className="text-slate-400/70 shrink-0" />
-                    </button>
-                </div>
-            )}
+            {/* "Campo, Javier" (gateado al operador). */}
+            {renderJavier()}
 
-            {/* MÓDULO ANIMALES (finca integrada): gallinas, cerdos y abejas, con
-                el ciclo cerrado (estiércol → biopreparado → suelo → planta) y la
-                polinización. Bloque propio, fuera del grid draggable. Gateado por
-                perfil: un urbano de balcón no lo ve (mismo criterio del resto). */}
+            {/* MÓDULO ANIMALES — gateado por perfil. */}
             {mostrarAnimales && (
-                <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
-                    <p className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 ${fincaVivaFlag ? 'fvh-block-label' : 'text-slate-400'}`}>
-                        <span
-                            aria-hidden="true"
-                            className="h-3.5 w-1 rounded-full bg-gradient-to-b from-rose-400 to-pink-400"
-                        />
-                        Animales de la finca
-                    </p>
+                <div className="px-4 pt-3">
+                    {blockLabel('Animales de la finca', 'from-rose-400 to-pink-400')}
                     <AnimalesCard onNavigate={onNavigate} variant="list" />
                 </div>
             )}
 
-            {/* Saludo regional dismissible — bajo el fold. Con la flag F2 ON se
-                OMITE: el hero ya saluda ("Buenas, soy Chagra") y el chip de
-                ubicación ya muestra la región — repetirlo aquí sería un SEGUNDO
-                saludo (la duplicación que reportó el operador). */}
-            {!fincaVivaFlag && regionalGreeting}
+            {/* Saludo regional dismissible — bajo el fold. */}
+            {regionalGreeting}
 
-            {/* Primer uso con piso ya confirmado: las 3 rutas de registro bajo el
-                fold. Con la flag F2 ON se OMITE: el hero ya orienta el primer uso
-                (estado "su finca está empezando" + badge "EMPIECE AQUÍ" en el
-                portal Gestionar). Mostrar también el OnboardingHero duplicaría el
-                "empiece aquí". */}
-            {!fincaVivaFlag && plantsCount === 0 && !needsPisoCapture && (
+            {/* Primer uso con piso ya confirmado: las 3 rutas de registro. */}
+            {plantsCount === 0 && !needsPisoCapture && (
                 <div className="px-4 pt-3">
                     <OnboardingHero onNavigate={onNavigate} />
                 </div>
             )}
 
-            {/* Secciones drag-reorder — el INVENTARIO de un vistazo (plantas,
-                zonas, insumos, bitácora, clima, análisis…). Con F2 ON lleva un
-                rótulo claro para que se lea como "lo que tengo hoy en la finca". */}
-            <div className={`px-4 pt-3 pb-4 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
-                {fincaVivaFlag && (
-                    <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider mb-2.5 fvh-block-label">
-                        <span
-                            aria-hidden="true"
-                            className="h-3.5 w-1 rounded-full bg-gradient-to-b from-emerald-400 to-lime-400"
-                        />
-                        Su finca de un vistazo
-                    </p>
-                )}
+            {/* Secciones drag-reorder — el INVENTARIO de un vistazo. */}
+            <div className="px-4 pt-3 pb-4">
                 <DndContext
                     sensors={sensors}
                     collisionDetection={closestCenter}
@@ -859,25 +889,16 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     </SortableContext>
                 </DndContext>
 
-                <p className={`text-[10px] text-center mt-4 italic ${fincaVivaFlag ? 'fvh-resto-hint' : 'text-slate-600'}`}>
+                <p className="text-[10px] text-center mt-4 italic text-slate-600">
                     Mantén presionado el ⋮⋮ para reorganizar a tu gusto
                 </p>
 
-                {/* AIStatusFooter — barra inferior con status proactivo IA:
-                    SENSORES + CLIMA + AGENTE. Operador 2026-05-28: "el analisis
-                    de ia que da el status proactivo en general ponlo en la parte
-                    de abajo e integralo de la mejor manera acorde a los ultimos
-                    cambios aplicados". Movido del medio del scroll al footer +
-                    expandido de solo-sensores a 3 ejes IA. */}
+                {/* AIStatusFooter — barra inferior con status proactivo IA. */}
                 <AIStatusFooter sensors={iotAlerts} onNavigate={onNavigate} />
-
-                {/* AnalisisProactivoIA (#331) — Operador 2026-05-30: "que el
-                    análisis de IA quede justo debajo del clima y que también
-                    pueda moverse". Pasó de render fijo acá-abajo a sección
-                    DRAGGABLE en SECTION_COMPONENTS, default order = bajo 'clima'
-                    (ver HOME_MODULE_DEFAULT_ORDER en userProfileService). Recibe
-                    `sensors` vía SortableSection. */}
             </div>
+            </>
+            )}
+
             {/* /fvh-resto-shell + /fvh-resto (o /contents con flag OFF) */}
             </div>
             </div>

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable chagra-i18n/no-hardcoded-spanish --
- * Las etiquetas de las tarjetas ("Insumos", "Bitácora", "Informes") y los
+ * Las etiquetas de las tarjetas ("Insumos", "Bitácora", "Informes" — o su copy F2) y los
  * textos de carga/aria ("Cargando…", "Cargando contador") son strings de UI
  * preexistentes de este componente. Su migración a src/config/messages.js es
  * la TAREA i18n de ADR-050 (transversal a toda la app), fuera del alcance de
@@ -11,6 +11,18 @@ import useAssetStore from '../../store/useAssetStore';
 import Skeleton from '../common/Skeleton';
 import { listFarmProcesses } from '../../db/farmProcessCache';
 import { SEGUIMIENTO_PROCESOS, seguimientoRoute } from '../../config/seguimientoProcesos';
+import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
+
+// Copy CAMPESINO de algunas tarjetas (audit botones/distribución 2026-06-26):
+// "Insumos"→"Abonos e insumos", "Flora y fauna"→"Plantas y animales del monte",
+// "Informes/CSV"→"Sacar reportes". Se aplica SOLO con la home F2 ON (flag dev);
+// con la flag OFF se conservan los labels legacy (prod intacto). `f2Label` es un
+// helper local: devuelve el texto F2 cuando la flag está activa, si no el legacy.
+const f2Label = (f2, legacy) => {
+    let on = false;
+    try { on = fincaVivaHomePerfilActivo(); } catch (_) { on = false; }
+    return on ? f2 : legacy;
+};
 
 /**
  * FincaCards — secciones del dashboard re-organizadas con sensibilidad
@@ -376,11 +388,11 @@ export function InsumosCard({ onNavigate, variant }) {
         <Card
             variant={variant}
             section="insumos"
-            title="Insumos"
+            title={f2Label('Abonos e insumos', 'Insumos')}
             subtitle={subtitle}
             value={isHydrated ? count : null}
             loading={!isHydrated}
-            tooltip="Bioinsumos (bocashi, biol, caldos), semillas, herramientas. Stock disponible en bodega."
+            tooltip="Abonos y bioinsumos (bocashi, biol, caldos), semillas, herramientas. Lo que tiene en la bodega."
             onClick={() => onNavigate('bodega')}
         />
     );
@@ -433,9 +445,9 @@ export function BiodiversidadCard({ onNavigate, variant }) {
         <Card
             variant={variant}
             section="biodiversidad"
-            title="Flora y fauna"
-            subtitle="Ecosistema de tu chagra"
-            tooltip="Catálogo de especies nativas, endémicas y polinizadores que viven en tu finca."
+            title={f2Label('Plantas y animales del monte', 'Flora y fauna')}
+            subtitle={f2Label('Lo vivo de su finca', 'Ecosistema de tu chagra')}
+            tooltip="Especies nativas, endémicas y polinizadores que viven en su finca."
             onClick={() => onNavigate('biodiversidad')}
         />
     );
@@ -459,9 +471,9 @@ export function InformesCard({ onNavigate, variant }) {
         <Card
             variant={variant}
             section="informes"
-            title="Informes"
-            subtitle="Descarga reportes en CSV"
-            tooltip="Exporta cuaderno de campo, inventario, registros de cosecha y aplicaciones a CSV/PDF."
+            title={f2Label('Sacar reportes', 'Informes')}
+            subtitle={f2Label('Para imprimir o llevar a la cooperativa', 'Descarga reportes en CSV')}
+            tooltip="Saque su cuaderno de campo, inventario y registros de cosecha y aplicaciones para imprimir o llevar al banco o la cooperativa."
             onClick={() => onNavigate('informes')}
         />
     );

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -9,7 +9,7 @@ import { listFarmProcesses } from '../../db/farmProcessCache';
 import useAssetStore from '../../store/useAssetStore';
 import { buildFincaScene } from '../../services/fincaSceneService';
 import { selectSceneVariant, SCENE_KINDS } from '../../services/fincaSceneProfileSelector';
-import { getProfile } from '../../services/userProfileService';
+import { getProfile, saveProfile } from '../../services/userProfileService';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import { deriveAtmosphere } from '../../services/atmosphereService';
 import { resolveClimaLocation, getCachedClimaSnapshot, CLIMA_UPDATED_EVENT } from '../../services/climaService';
@@ -125,6 +125,27 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
   const operador = useMemo(() => {
     try { return esOperadorActual(); } catch (_) { return false; }
   }, []);
+
+  // ── Nivel de respuestas del agente ("Claro y corto" / "Con detalle") ──────
+  // El toggle vive JUNTO al compositor del agente (es una preferencia de CÓMO
+  // responde Chagra, no una decoración de la barra). Renombrado del antiguo
+  // "🌾 Campesino / 🔬 Experto" del AgentHero (flag OFF) a un nombre sobre la
+  // RESPUESTA, no sobre la persona — de-estigmatiza (audit 2026-06-26 §5). El
+  // cableado es el MISMO motor real: persiste `nivel_respuestas` en el perfil
+  // (simple=claro/corto · detallado=con detalle), el campo que lee
+  // buildUserProfileBlock para el system-prompt del LLM. No reinventa el motor.
+  const [nivelRespuestas, setNivelRespuestas] = useState(() => {
+    try { return getProfile()?.nivel_respuestas === 'detallado' ? 'detallado' : 'simple'; }
+    catch (_) { return 'simple'; }
+  });
+  const detalladoActivo = nivelRespuestas === 'detallado';
+  const cambiarNivel = (next) => {
+    if (next === nivelRespuestas) return;
+    setNivelRespuestas(next);
+    // saveProfile puede no existir en algunos mocks de test (perfil opcional).
+    try { if (typeof saveProfile === 'function') saveProfile({ nivel_respuestas: next }); }
+    catch (_) { /* perfil opcional: el toggle igual refleja la elección en sesión */ }
+  };
 
   // ── Cielo real: hora + clima (REUSA atmosphereService, no inventa motor) ──
   const atmosfera = useAtmosferaEscena();
@@ -347,6 +368,37 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
                 </span>
               </button>
               <div className="fvh-composer-hint">Toque 🎙️ y pregunte en voz alta — o escriba arriba</div>
+
+              {/* NIVEL DE RESPUESTA — junto al agente, porque define CÓMO le
+                  responde Chagra. Renombrado del antiguo "Campesino/Experto"
+                  (que clasificaba a la persona) a un nombre sobre la RESPUESTA:
+                  "Claro y corto" / "Con detalle". Cableado al MISMO
+                  `nivel_respuestas` que arma el system-prompt del LLM. */}
+              <div
+                className="fvh-nivel"
+                role="radiogroup"
+                aria-label="Cómo le responde Chagra"
+                data-testid="finca-viva-nivel-respuestas"
+              >
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={!detalladoActivo}
+                  className={`fvh-nivel-btn ${!detalladoActivo ? 'on' : ''}`}
+                  onClick={() => cambiarNivel('simple')}
+                >
+                  Claro y corto
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={detalladoActivo}
+                  className={`fvh-nivel-btn ${detalladoActivo ? 'on' : ''}`}
+                  onClick={() => cambiarNivel('detallado')}
+                >
+                  Con detalle
+                </button>
+              </div>
             </div>
 
             {/* HERO TEXT */}
@@ -692,7 +744,8 @@ const COLIBRI = {
 };
 
 /**
- * Los 4 portales/lugares del home F2. El badge de "Gestionar" refleja el DATO
+ * Los 4 portales/lugares del home F2 ("Mi finca", "Aprender", "Jugar",
+ * "Pregúntele a Chagra"). El badge del portal "Mi finca" refleja el DATO
  * REAL de la finca (0 siembras → "EMPIECE AQUÍ"; con siembras → resumen real).
  */
 function buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, escala }) {
@@ -715,7 +768,7 @@ function buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, es
   return [
     {
       id: 'gestionar',
-      titulo: 'Gestionar',
+      titulo: 'Mi finca',
       desc: 'Registre y cuide sus siembras, zonas y animales.',
       emoji: '🌱',
       clase: 'p-gestionar',
@@ -751,7 +804,7 @@ function buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, es
     },
     {
       id: 'agente',
-      titulo: 'Agente',
+      titulo: 'Pregúntele a Chagra',
       desc: 'Pregunte lo que sea: respuestas con su fuente.',
       emoji: '💬',
       clase: 'p-agente',

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -3,11 +3,12 @@ import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-li
 import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Redistribución de "el resto de su finca" (auditoría §7.2 + §7.4 #2):
-// verifica que los tiles se reparten en los grupos correctos, en el orden de
-// jerarquía esperado (Destacado → Aprender → Gestión → Mercado) y que cada tile
-// navega a su ruta. Cubre el layout F2 ON (que filtra el hub `aprende` porque ya
-// es portal del hero) y el legacy OFF (que sí muestra el hub `aprende`).
+// Reorganización del HOME F2 EN 5 BLOQUES (audit botones/distribución
+// 2026-06-26). Verifica que, con la flag F2 ON, el "resto de su finca" se ordena
+// por el flujo mental del campesino (estado → tengo → hago → consulto → vendo),
+// con copy campesino, dedup aplicado y el bloque condicional de proyectos BAJADO.
+// Y que con la flag OFF el home conserva su layout legacy (grid draggable +
+// AIStatusFooter + rótulos viejos) — "flag OFF = home actual intacto".
 
 vi.mock('../../../config/glaciarAccess', () => ({
   tieneAccesoGlaciarActual: () => false,
@@ -23,7 +24,7 @@ vi.mock('../../../config/extensionistaAccess', () => ({
 }));
 
 vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
-// Capturamos las props del hero para verificar el cableado del portal "Gestionar"
+// Capturamos las props del hero para verificar el cableado del portal "Mi finca"
 // (onGestionar) sin montar todo el hero. El botón expuesto invoca onGestionar tal
 // como lo haría el portal real.
 let lastHeroProps = null;
@@ -33,7 +34,7 @@ vi.mock('../FincaVivaHero', () => ({
     return (
       <div data-testid="finca-viva-hero">
         <button type="button" data-testid="hero-gestionar" onClick={() => props.onGestionar?.()}>
-          Gestionar
+          Mi finca
         </button>
         {props.children}
       </div>
@@ -45,10 +46,10 @@ vi.mock('../../OnboardingHero', () => ({ default: () => <div /> }));
 vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
 vi.mock('../MiFincaVivaHomeCard', () => ({ default: () => <div /> }));
 vi.mock('../../CaseStudyTopWidget', () => ({ default: () => null }));
-vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
-vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));
-vi.mock('../AIStatusFooter', () => ({ default: () => <div /> }));
-vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div /> }));
+vi.mock('../ClimaStrip', () => ({ default: () => <div data-testid="clima-strip" /> }));
+vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div data-testid="hoy-strip" /> }));
+vi.mock('../AIStatusFooter', () => ({ default: () => <div data-testid="ai-status-footer" /> }));
+vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div data-testid="analisis-ia" /> }));
 
 vi.mock('../../../store/useAssetStore', () => ({
   default: (selector) => selector({
@@ -79,89 +80,134 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 const labelOf = (el) => el.getAttribute('aria-label')?.split(':')[0];
+const indexInDom = (node) =>
+  Array.prototype.indexOf.call(document.querySelectorAll('[data-testid]'), node);
 
-describe('DashboardLive — redistribución del resto de su finca', () => {
-  test('los 4 grupos existen en el orden de jerarquía esperado', async () => {
+describe('Home F2 — reorganización en 5 bloques (audit 2026-06-26)', () => {
+  test('los 5 bloques existen en el orden del flujo del campesino', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    await waitFor(() => expect(screen.getByTestId('destacado-tiles')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('bloque-finca-hoy')).toBeInTheDocument());
 
-    const groups = ['destacado-tiles', 'aprender-tiles', 'gestion-tiles', 'mercado-tiles'];
-    for (const g of groups) expect(screen.getByTestId(g)).toBeInTheDocument();
+    // estado → tengo → hago → consulto → vendo.
+    const blocks = [
+      'bloque-finca-hoy',        // 1. Cómo va su finca hoy
+      'bloque-plantas-animales', // 2. Sus plantas y animales
+      'bloque-registrar',        // 3. Registrar en la finca
+      'bloque-consultar',        // 4. Consultar y aprender
+      'mercado-tiles',           // 5. Vender y comprar
+    ];
+    for (const b of blocks) expect(screen.getByTestId(b)).toBeInTheDocument();
 
-    // Orden en el DOM (jerarquía): Destacado antes que Aprender antes que
-    // Gestión antes que Mercado.
-    const positions = groups.map((g) => {
-      const node = screen.getByTestId(g);
-      return { g, top: Array.prototype.indexOf.call(document.querySelectorAll('[data-testid]'), node) };
-    });
-    const order = positions
-      .sort((a, b) => a.top - b.top)
-      .map((p) => p.g);
-    expect(order).toEqual(groups);
+    const order = blocks
+      .map((b) => ({ b, top: indexInDom(screen.getByTestId(b)) }))
+      .sort((a, z) => a.top - z.top)
+      .map((p) => p.b);
+    expect(order).toEqual(blocks);
   });
 
-  test('DESTACADO eleva solo Especies y Calendario (lo fuerte y grounded)', async () => {
+  test('BLOQUE 1 funde el día + clima + aviso de Chagra y NO duplica IA ni "hoy"', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const block = await screen.findByTestId('destacado-tiles');
-    const labels = within(block).getAllByRole('button').map(labelOf);
-    expect(labels).toEqual(['Especies', 'Calendario']);
+    const block = await screen.findByTestId('bloque-finca-hoy');
+    // El estado del día: UNA sola tira "hoy", el clima y el aviso de Chagra.
+    expect(within(block).getByTestId('hoy-strip')).toBeInTheDocument();
+    expect(within(block).getByTestId('clima-strip')).toBeInTheDocument();
+    expect(within(block).getByTestId('analisis-ia')).toBeInTheDocument();
+    // No hay un SEGUNDO panel de IA al pie (AIStatusFooter "Status proactivo IA"
+    // NO se monta en F2: su idea ES este bloque).
+    expect(screen.queryByTestId('ai-status-footer')).toBeNull();
+    // Y solo hay UNA tira "hoy" en todo el home (dedup del strip + tile).
+    expect(screen.getAllByTestId('hoy-strip')).toHaveLength(1);
   });
 
-  test('APRENDER consolida el contenido; con F2 ON NO duplica el hub Aprender', async () => {
+  test('BLOQUE 2 agrupa plantas, zonas, plagas, asociaciones y flora/fauna', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const block = await screen.findByTestId('aprender-tiles');
-    const labels = within(block).getAllByRole('button').map(labelOf);
-    // F2 ON: el portal "Aprender" del hero ya entra al hub, así que el tile
-    // 'aprende' se filtra; quedan las superficies de contenido consolidadas.
+    const block = await screen.findByTestId('bloque-plantas-animales');
+    const txt = block.textContent;
+    expect(block).toHaveTextContent('Sus plantas y animales');
+    for (const t of ['Mis plantas', 'Mis zonas', 'Plagas', 'Asociaciones', 'Plantas y animales del monte']) {
+      expect(txt).toContain(t);
+    }
+  });
+
+  test('BLOQUE 3 "Registrar" unifica abonos e insumos y usa copy campesino', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('bloque-registrar');
+    const gestion = within(block).getByTestId('gestion-tiles');
+    const tileLabels = within(gestion).getAllByRole('button').map(labelOf);
+    expect(tileLabels).toEqual(['Semilleros', 'Cosechar', 'Abonos e insumos', 'Labores de la finca']);
+    // La bitácora vive en el bloque de acción.
+    expect(block).toHaveTextContent('Bitácora');
+  });
+
+  test('BLOQUE 3 conserva el ancla #finca-gestion (destino del portal Mi finca)', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('bloque-registrar');
+    const ancla = document.getElementById('finca-gestion');
+    expect(ancla).toBeInTheDocument();
+    expect(ancla).toBe(block);
+  });
+
+  test('BLOQUE 4 "Consultar y aprender" con catálogo, calendario, contenido y reportes', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('bloque-consultar');
+
+    // Lo fuerte y grounded, con copy campesino.
+    const destacado = within(block).getByTestId('destacado-tiles');
+    expect(within(destacado).getAllByRole('button').map(labelOf))
+      .toEqual(['Qué puedo sembrar', 'Calendario de la finca']);
+
+    // El contenido consolidado + "Sacar reportes"; NO duplica el hub "Aprender"
+    // (ese es el portal del hero en F2).
+    const aprender = within(block).getByTestId('aprender-tiles');
+    const labels = within(aprender).getAllByRole('button').map(labelOf);
+    expect(labels).not.toContain('Aprender');
     expect(labels).toEqual([
-      'Casos de estudio', 'Ciclo de nutrientes', 'Biopreparados', 'Suelo', 'Seguridad', 'Preguntas frecuentes',
+      'Casos reales', 'Ciclo de nutrientes', 'Biopreparados', 'Suelo', 'Seguridad', 'Preguntas frecuentes', 'Sacar reportes',
     ]);
   });
 
-  test('GESTIÓN agrupa registros/manejo (semilleros incluido)', async () => {
-    render(<DashboardLive onNavigate={vi.fn()} />);
-    const block = await screen.findByTestId('gestion-tiles');
-    const labels = within(block).getAllByRole('button').map(labelOf);
-    expect(labels).toEqual(['Semilleros', 'Cosechar', 'Insumos aplicados', 'Mantenimiento']);
-  });
-
-  test('MERCADO queda al fondo, de-enfatizado, y navega a la ruta mercado', async () => {
+  test('BLOQUE 5 Mercado al fondo y navega a la ruta mercado', async () => {
     const onNavigate = vi.fn();
     render(<DashboardLive onNavigate={onNavigate} />);
     const block = await screen.findByTestId('mercado-tiles');
-    const btn = within(block).getByRole('button', { name: /Mercado/ });
-    fireEvent.click(btn);
+    fireEvent.click(within(block).getByRole('button', { name: /Mercado/ }));
     expect(onNavigate).toHaveBeenCalledWith('mercado', undefined);
   });
 
-  test('los tiles navegan a sus rutas (directorio, calendario, casos, biopreparados con back)', async () => {
+  test('"Sus proyectos de finca" va MÁS ABAJO que lo cotidiano (estado/registrar)', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    await screen.findByTestId('seguimiento-cards');
+    const seguimiento = screen.getByTestId('seguimiento-cards');
+    const registrar = screen.getByTestId('bloque-registrar');
+    const hoy = screen.getByTestId('bloque-finca-hoy');
+    // El bloque condicional de proyectos queda debajo de lo cotidiano.
+    expect(indexInDom(seguimiento)).toBeGreaterThan(indexInDom(registrar));
+    expect(indexInDom(seguimiento)).toBeGreaterThan(indexInDom(hoy));
+    // Y lleva su rótulo campesino renombrado.
+    expect(seguimiento.closest('[class*="px-4"]')).toHaveTextContent('Sus proyectos de finca');
+  });
+
+  test('los tiles navegan a sus rutas reales (directorio, calendario, casos, biopreparados con back, reportes)', async () => {
     const onNavigate = vi.fn();
     render(<DashboardLive onNavigate={onNavigate} />);
-    await screen.findByTestId('destacado-tiles');
+    await screen.findByTestId('bloque-consultar');
 
-    fireEvent.click(screen.getByRole('button', { name: /^Especies/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Qué puedo sembrar/ }));
     expect(onNavigate).toHaveBeenCalledWith('directorio', undefined);
-    fireEvent.click(screen.getByRole('button', { name: /^Calendario/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Calendario de la finca/ }));
     expect(onNavigate).toHaveBeenCalledWith('calendario_finca', undefined);
-    fireEvent.click(screen.getByRole('button', { name: /^Casos de estudio/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Casos reales/ }));
     expect(onNavigate).toHaveBeenCalledWith('casos', undefined);
     fireEvent.click(screen.getByRole('button', { name: /^Biopreparados/ }));
     expect(onNavigate).toHaveBeenCalledWith('biopreparados', { back: 'dashboard' });
-  });
-
-  test('la sección de gestión expone el ancla #finca-gestion (destino del portal Gestionar)', async () => {
-    render(<DashboardLive onNavigate={vi.fn()} />);
-    const block = await screen.findByTestId('gestion-tiles');
-    const ancla = document.getElementById('finca-gestion');
-    // El ancla existe y CONTIENE los tiles de gestión (es la sección, no otra cosa).
-    expect(ancla).toBeInTheDocument();
-    expect(ancla).toContainElement(block);
+    fireEvent.click(screen.getByRole('button', { name: /^Sacar reportes/ }));
+    expect(onNavigate).toHaveBeenCalledWith('informes', undefined);
   });
 
   test('el hero recibe onGestionar y, al invocarlo, hace scroll al ancla de gestión (no navega al juego)', async () => {
     const onNavigate = vi.fn();
     render(<DashboardLive onNavigate={onNavigate} />);
-    await screen.findByTestId('gestion-tiles');
+    await screen.findByTestId('bloque-registrar');
 
     const ancla = document.getElementById('finca-gestion');
     ancla.scrollIntoView = vi.fn();
@@ -173,13 +219,36 @@ describe('DashboardLive — redistribución del resto de su finca', () => {
     expect(ancla.scrollIntoView).toHaveBeenCalledTimes(1);
     expect(onNavigate).not.toHaveBeenCalledWith('juego');
   });
+});
 
-  test('layout legacy (F2 OFF) SÍ muestra el hub Aprender como tile', async () => {
-    flagOn = false;
+describe('Home — flag OFF conserva el layout legacy (prod intacto)', () => {
+  beforeEach(() => { flagOn = false; });
+
+  test('NO existen los bloques F2 nuevos', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const block = await screen.findByTestId('aprender-tiles');
-    const labels = within(block).getAllByRole('button').map(labelOf);
+    await screen.findByTestId('destacado-tiles');
+    expect(screen.queryByTestId('bloque-finca-hoy')).toBeNull();
+    expect(screen.queryByTestId('bloque-plantas-animales')).toBeNull();
+    expect(screen.queryByTestId('bloque-registrar')).toBeNull();
+    expect(screen.queryByTestId('bloque-consultar')).toBeNull();
+  });
+
+  test('conserva el grid draggable + AIStatusFooter + rótulos viejos', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    await screen.findByTestId('destacado-tiles');
+    // Footer de IA legacy presente (en F2 se omite, acá NO).
+    expect(screen.getByTestId('ai-status-footer')).toBeInTheDocument();
+    // Hub "Aprender" como tile (con OFF SÍ se muestra) y labels legacy.
+    const aprender = screen.getByTestId('aprender-tiles');
+    const labels = within(aprender).getAllByRole('button').map(labelOf);
     expect(labels[0]).toBe('Aprender');
-    expect(labels).toContain('Casos de estudio');
+    expect(labels).toContain('Casos de estudio'); // copy legacy, NO "Casos reales"
+    // DESTACADO con labels legacy.
+    const destacado = screen.getByTestId('destacado-tiles');
+    expect(within(destacado).getAllByRole('button').map(labelOf)).toEqual(['Especies', 'Calendario']);
+    // GESTIÓN con label legacy "Insumos aplicados" (no "Abonos e insumos").
+    const gestion = screen.getByTestId('gestion-tiles');
+    expect(within(gestion).getAllByRole('button').map(labelOf))
+      .toEqual(['Semilleros', 'Cosechar', 'Insumos aplicados', 'Mantenimiento']);
   });
 });

--- a/src/components/dashboard/__tests__/FincaVivaHero.nivelRespuestas.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaHero.nivelRespuestas.test.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Toggle de NIVEL DE RESPUESTA del agente en el home F2 (audit 2026-06-26 §5).
+// Antes vivía SOLO en AgentHero (portada flag OFF) y NO existía en F2. Ahora vive
+// JUNTO al compositor del agente del hero F2, renombrado de "Campesino/Experto"
+// (que clasifica a la persona) a "Claro y corto / Con detalle" (describe la
+// RESPUESTA, de-estigmatiza). Cableado al MISMO motor real: persiste
+// `nivel_respuestas` en el perfil (simple/detallado), el campo del system-prompt.
+
+const saveProfile = vi.fn();
+let mockProfile = { rol: 'campesino' };
+vi.mock('../../../services/userProfileService', () => ({
+  getProfile: () => mockProfile,
+  saveProfile: (...a) => saveProfile(...a),
+}));
+vi.mock('../../../db/farmProcessCache', () => ({ listFarmProcesses: vi.fn(async () => []) }));
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [], lands: [], materials: [], isHydrated: true }),
+}));
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => false,
+}));
+
+import FincaVivaHero from '../FincaVivaHero';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockProfile = { rol: 'campesino' };
+});
+afterEach(() => cleanup());
+
+const renderHero = () =>
+  render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+
+const getToggle = () => screen.getByTestId('finca-viva-nivel-respuestas');
+
+describe('FincaVivaHero — toggle "Claro y corto / Con detalle"', () => {
+  test('el toggle EXISTE en el home F2, junto al compositor del agente', () => {
+    renderHero();
+    const toggle = getToggle();
+    expect(toggle).toBeInTheDocument();
+    // El compositor del agente está en el mismo aside.
+    expect(screen.getByTestId('finca-viva-agent-fab')).toBeInTheDocument();
+    // Etiquetas sobre la RESPUESTA, no sobre la persona (de-estigmatizado).
+    expect(within(toggle).getByRole('radio', { name: 'Claro y corto' })).toBeInTheDocument();
+    expect(within(toggle).getByRole('radio', { name: 'Con detalle' })).toBeInTheDocument();
+    // NO conserva el viejo nombre estigmatizante.
+    expect(toggle).not.toHaveTextContent('Campesino');
+    expect(toggle).not.toHaveTextContent('Experto');
+  });
+
+  test('refleja el nivel del perfil (detallado → "Con detalle" activo)', () => {
+    mockProfile = { rol: 'campesino', nivel_respuestas: 'detallado' };
+    renderHero();
+    const toggle = getToggle();
+    expect(within(toggle).getByRole('radio', { name: 'Con detalle' })).toHaveAttribute('aria-checked', 'true');
+    expect(within(toggle).getByRole('radio', { name: 'Claro y corto' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('por defecto (sin preferencia) arranca en "Claro y corto" (simple)', () => {
+    renderHero();
+    const toggle = getToggle();
+    expect(within(toggle).getByRole('radio', { name: 'Claro y corto' })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('tocar "Con detalle" persiste nivel_respuestas=detallado (el MISMO motor)', () => {
+    renderHero();
+    fireEvent.click(within(getToggle()).getByRole('radio', { name: 'Con detalle' }));
+    expect(saveProfile).toHaveBeenCalledWith({ nivel_respuestas: 'detallado' });
+    // Y el control refleja el cambio en la sesión.
+    expect(within(getToggle()).getByRole('radio', { name: 'Con detalle' })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('tocar "Claro y corto" persiste nivel_respuestas=simple', () => {
+    mockProfile = { rol: 'campesino', nivel_respuestas: 'detallado' };
+    renderHero();
+    fireEvent.click(within(getToggle()).getByRole('radio', { name: 'Claro y corto' }));
+    expect(saveProfile).toHaveBeenCalledWith({ nivel_respuestas: 'simple' });
+  });
+
+  test('no re-persiste si ya está en ese nivel (idempotente)', () => {
+    renderHero(); // arranca simple
+    fireEvent.click(within(getToggle()).getByRole('radio', { name: 'Claro y corto' }));
+    expect(saveProfile).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/dashboard/__tests__/FincaVivaHero.portales.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaHero.portales.test.jsx
@@ -4,11 +4,11 @@ import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Home F2 "Finca Viva" — los 4 portales del hero deben llevar a SU destino:
-//   · Gestionar → la GESTIÓN de la finca (registros/acciones), NO el juego.
+//   · Mi finca  → la GESTIÓN de la finca (registros/acciones), NO el juego.
 //                 (bug: iba a onNavigate('juego'), igual que el portal "Jugar".)
 //   · Aprender  → la vista 'aprende'.
 //   · Jugar     → la vista 'juego' (ese SÍ es el juego).
-//   · Agente    → abre el agente (onOpenAgent).
+//   · Pregúntele a Chagra → abre el agente (onOpenAgent).
 // Y el resto del shell F2 (chip de ubicación, pastilla de ayuda, pastilla de
 // perfil) debe navegar a su ruta, sin botones muertos.
 
@@ -54,22 +54,22 @@ describe('FincaVivaHero — los 4 portales llevan a su destino correcto', () => 
       .find((b) => portalLabel(b) === nombre);
   };
 
-  test('el portal "Gestionar" NO navega al juego', () => {
+  test('el portal "Mi finca" NO navega al juego', () => {
     const { onNavigate } = renderHero();
-    fireEvent.click(getPortal('Gestionar'));
+    fireEvent.click(getPortal('Mi finca'));
     expect(onNavigate).not.toHaveBeenCalledWith('juego');
   });
 
-  test('el portal "Gestionar" abre la GESTIÓN de la finca (onGestionar), no otra vista', () => {
+  test('el portal "Mi finca" abre la GESTIÓN de la finca (onGestionar), no otra vista', () => {
     const { onNavigate, onOpenAgent, onGestionar } = renderHero();
-    fireEvent.click(getPortal('Gestionar'));
+    fireEvent.click(getPortal('Mi finca'));
     expect(onGestionar).toHaveBeenCalledTimes(1);
     // No se cuela a ninguna otra ruta ni al agente.
     expect(onNavigate).not.toHaveBeenCalled();
     expect(onOpenAgent).not.toHaveBeenCalled();
   });
 
-  test('sin onGestionar, "Gestionar" hace scroll al ancla #finca-gestion (no al juego)', () => {
+  test('sin onGestionar, "Mi finca" hace scroll al ancla #finca-gestion (no al juego)', () => {
     const onNavigate = vi.fn();
     const seccion = document.createElement('div');
     seccion.id = 'finca-gestion';
@@ -77,7 +77,7 @@ describe('FincaVivaHero — los 4 portales llevan a su destino correcto', () => 
     document.body.appendChild(seccion);
 
     render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
-    fireEvent.click(getPortal('Gestionar'));
+    fireEvent.click(getPortal('Mi finca'));
 
     expect(seccion.scrollIntoView).toHaveBeenCalledTimes(1);
     expect(onNavigate).not.toHaveBeenCalledWith('juego');
@@ -96,18 +96,18 @@ describe('FincaVivaHero — los 4 portales llevan a su destino correcto', () => 
     expect(onNavigate).toHaveBeenCalledWith('juego');
   });
 
-  test('el portal "Agente" abre el agente (onOpenAgent), no navega a una vista', () => {
+  test('el portal "Pregúntele a Chagra" abre el agente (onOpenAgent), no navega a una vista', () => {
     const { onNavigate, onOpenAgent } = renderHero();
-    fireEvent.click(getPortal('Agente'));
+    fireEvent.click(getPortal('Pregúntele a Chagra'));
     expect(onOpenAgent).toHaveBeenCalledTimes(1);
     expect(onNavigate).not.toHaveBeenCalled();
   });
 
-  test('cada portal mapea a un destino distinto (Gestionar ≠ Jugar)', () => {
+  test('cada portal mapea a un destino distinto (Mi finca ≠ Jugar)', () => {
     const { onNavigate, onOpenAgent, onGestionar } = renderHero();
-    fireEvent.click(getPortal('Gestionar'));
+    fireEvent.click(getPortal('Mi finca'));
     fireEvent.click(getPortal('Jugar'));
-    // Gestionar fue a la gestión; Jugar al juego. No coinciden.
+    // Mi finca fue a la gestión; Jugar al juego. No coinciden.
     expect(onGestionar).toHaveBeenCalledTimes(1);
     expect(onNavigate).toHaveBeenCalledWith('juego');
     expect(onNavigate).not.toHaveBeenCalledWith('gestionar');

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -524,6 +524,40 @@
   margin: 9px 16px 0;
 }
 
+/* NIVEL DE RESPUESTA ("Claro y corto" / "Con detalle") — segmented junto al
+   compositor del agente. Píldora clara sobre la escena; el segmento activo se
+   resalta en lima (la piel del agente). */
+.fvh-nivel {
+  display: inline-flex;
+  align-self: center;
+  gap: 2px;
+  margin: 10px auto 0;
+  padding: 3px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 4px 12px rgba(40, 60, 40, 0.16), 0 0 0 1px rgba(38, 51, 31, 0.06);
+}
+.fvh-nivel-btn {
+  border: 0;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 5px 13px;
+  font-family: var(--fvh-body);
+  font-weight: 800;
+  font-size: 11.5px;
+  color: var(--fvh-tinta-suave);
+  background: transparent;
+  transition: background 160ms ease, color 160ms ease;
+}
+.fvh-nivel-btn.on {
+  background: linear-gradient(135deg, var(--fvh-lima), #8fd62e);
+  color: #1f3300;
+  box-shadow: 0 3px 8px rgba(120, 180, 30, 0.4);
+}
+@media (prefers-reduced-motion: reduce) {
+  .fvh-nivel-btn { transition: none; }
+}
+
 /* ── HERO TEXT ─────────────────────────────────────────────────────────────── */
 .fvh-hero-saludo { padding: 14px 20px 0; position: relative; z-index: 3; }
 .fvh-hero-saludo .h-small { font-weight: 800; font-size: 12.5px; color: var(--fvh-sello); letter-spacing: 0.2px; }

--- a/src/components/dashboard/finca-viva-resto.css
+++ b/src/components/dashboard/finca-viva-resto.css
@@ -135,3 +135,23 @@
 .fvh-resto [class*="from-slate-900"] .text-slate-500.group-hover\:text-slate-300 {
   color: #cbd5e1 !important;
 }
+
+/* ── Bloque "Consultar y aprender" colapsable (audit 2026-06-26 §4) ─────────
+   Es de consulta ocasional, no del primer scroll: va en un <details> abierto
+   por defecto pero plegable. Ocultamos el marcador nativo y dejamos el rótulo
+   (BlockLabel) como toda la cabecera clicable; un chevron sutil indica el
+   estado. */
+.fvh-resto .fvh-consultar > summary { list-style: none; }
+.fvh-resto .fvh-consultar > summary::-webkit-details-marker { display: none; }
+.fvh-resto .fvh-consultar > summary > p { margin-bottom: 8px; }
+.fvh-resto .fvh-consultar > summary > p::after {
+  content: "▾";
+  margin-left: auto;
+  font-size: 13px;
+  opacity: 0.7;
+  transition: transform 160ms ease;
+}
+.fvh-resto .fvh-consultar[open] > summary > p::after { transform: rotate(180deg); }
+@media (prefers-reduced-motion: reduce) {
+  .fvh-resto .fvh-consultar > summary > p::after { transition: none; }
+}


### PR DESCRIPTION
## Feature
Reorganizar el home F2 "Finca Viva" según la auditoría `docs/audit-botones-distribucion-2026-06-26.md`: el "resto de su finca" pasaba de ~44 botones en 10 bloques (un índice del producto) a **5 bloques** ordenados por el flujo mental del campesino, con copy concreto campesino y dedup de solapes. Todo gateado tras `fincaVivaHomePerfilActivo()` (flag ON dev / OFF prod).

## Cambios

### Reorganización en 5 bloques (`DashboardLive.jsx`, solo flag ON)
1. **"Cómo va su finca hoy"** — funde `HoyEnFincaStrip` + `ClimaStrip` + `AnalisisProactivoIA`. Dedup: quita el 2º panel de IA (`AIStatusFooter` "Status proactivo IA" NO se monta en F2) y el "Hoy en finca" duplicado (strip + tile). Sube arriba.
2. **"Sus plantas y animales"** — plantas, zonas, plagas, asociaciones, flora/fauna + animales (antes 5 superficies revueltas).
3. **"Registrar en la finca"** — semilleros, cosechar, abonos e insumos (unificados), labores, bitácora. Conserva el ancla `#finca-gestion` (destino del portal "Mi finca"). No toca la mecánica del botón de voz.
4. **"Consultar y aprender"** — catálogo, calendario, casos, biopreparados, suelo, seguridad, "Sacar reportes", FAQ. Colapsable (`<details>`).
5. **"Vender y comprar"** — Mercado.
- Condicional y **más abajo**: **"Sus proyectos de finca"** (seguimiento reforestación/silvopastoreo/páramo/cerdos, ya gateado por perfil).

### Copy campesino (solo F2, vía `labelF2`/`descF2` + `f2Label()`)
| Antes | Después |
|---|---|
| portal "Gestionar" | "Mi finca" |
| portal "Agente" | "Pregúntele a Chagra" |
| "Lo más sólido de Chagra" | "Consultar y aprender" |
| "Status proactivo IA" | "Cómo va su finca hoy" |
| "Seguimiento de procesos" | "Sus proyectos de finca" |
| "Insumos aplicados" + "Insumos" | "Abonos e insumos" (unificado) |
| "Mantenimiento" | "Labores de la finca" |
| "Informes / CSV" | "Sacar reportes" |
| "Flora y fauna" | "Plantas y animales del monte" |
| "Especies" | "Qué puedo sembrar" |

### Toggle "Claro y corto / Con detalle" (`FincaVivaHero.jsx`)
Antes solo existía en `AgentHero` (portada flag OFF) y NO en el home F2. Se agrega al compositor del agente del hero F2, renombrado de "🌾 Campesino / 🔬 Experto" (que clasifica a la persona) a **"Claro y corto / Con detalle"** (describe la respuesta, de-estigmatiza). Cableado al **mismo** `nivel_respuestas` (simple/detallado) del perfil que arma el system-prompt — no reinventa el motor.

## Gate (no toca prod)
Todo tras `fincaVivaHomePerfilActivo()`. **Con flag OFF el home queda exacto como hoy**: layout legacy intacto (grid draggable + `AIStatusFooter` + rótulos y labels viejos). El copy F2 nunca aplica con flag OFF. Dark en prod hasta OK del operador.

## Tests
- `DashboardLive.redistribucion.test.jsx` (reescrito): los 5 bloques, el orden (estado→tengo→hago→consulto→vendo), el dedup (1 sola tira "hoy", sin 2º panel IA), los renombres campesinos, el ruteo, el ancla `#finca-gestion`, y **flag OFF = layout legacy con labels viejos**.
- `FincaVivaHero.nivelRespuestas.test.jsx` (nuevo): el toggle existe en F2 junto al agente, refleja `nivel_respuestas`, persiste simple/detallado vía `saveProfile`, idempotente, y NO usa "Campesino/Experto".
- `FincaVivaHero.portales.test.jsx`: actualizado a los portales renombrados ("Mi finca", "Pregúntele a Chagra").
- vitest verde (dashboard suite), `vite build` verde, eslint `--max-warnings=0` limpio, voseo-scan limpio.

Evidencia visual (antes/después de la estructura) enviada al operador por Telegram.

Refs: docs/audit-botones-distribucion-2026-06-26.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)