### PR TITLE
fix+feat(registro): rediseño profundo de las 4 ventanas (Cosechar/Insumos/Labores/Bitácora) + fix route bitácora

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -192,7 +192,7 @@ const HASH_VIEW_ROUTES = {
 
 // Vistas que cuentan como "módulo" para telemetría de piloto.
 const MODULE_VIEWS = new Set([
-  'activos', 'mapa', 'javier', 'bodega', 'task_log', 'historial',
+  'activos', 'mapa', 'javier', 'bodega', 'task_log', 'historial', 'bitacora',
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
@@ -984,7 +984,12 @@ export default function App() {
             </ErrorFallback>
           </ErrorBoundary>
         );
+      // 'historial' y 'bitacora' son ALIAS de la misma pantalla (WorkerHistory).
+      // Antes solo existía 'historial': AnalisisProactivoIA navegaba a 'bitacora'
+      // (chip "Tareas") y caía en "Vista no disponible". Ahora ambas entradas
+      // llegan a la Bitácora viva. Fix bitácora rota (tarea #22).
       case 'historial':
+      case 'bitacora':
         return (
           <ErrorBoundary>
             <WorkerHistory onBack={() => navigate('dashboard')} onEntryClick={(entry) => navigate('bitacora_detail', { entry })} />

--- a/src/components/HarvestLog.jsx
+++ b/src/components/HarvestLog.jsx
@@ -1,8 +1,11 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { ArrowLeft, AlertCircle, TrendingUp, CheckCircle } from 'lucide-react';
+import { ArrowLeft, AlertCircle, TrendingUp, CheckCircle, Apple } from 'lucide-react';
 import DateField from './DateField';
 import { savePayload } from '../services/payloadService';
 import { logCache } from '../db/logCache';
+import { fincaVivaHomePerfilActivo } from '../config/fincaVivaHomeFlag';
+import RegistroShell from './registro/RegistroShell';
+import { TextField, NumberField, SelectField, TextAreaField } from './registro/RegistroFields';
 
 // Bug 069.10 — sanity caps para evitar typos absurdos (ej. "100kg" → 100000)
 // que rompan analítica downstream sin que el operador lo note.
@@ -219,15 +222,17 @@ export default function HarvestLog({ onBack, onSave }) {
     }
   };
 
+  const redesign = fincaVivaHomePerfilActivo();
+
   if (view === 'success') {
     return (
-      <div className="h-[100dvh] w-full bg-slate-950 text-slate-100 flex flex-col p-6 items-center justify-center gap-6">
+      <div className={`h-[100dvh] w-full ${redesign ? 'registro-shell' : 'bg-slate-950'} text-slate-100 flex flex-col p-6 items-center justify-center gap-6`}>
         <div className="text-center animate-in fade-in zoom-in duration-300">
           <CheckCircle size={64} className="text-emerald-500 mx-auto mb-4" />
           <h3 className="text-2xl font-bold">Cosecha registrada</h3>
           <p className="text-sm text-slate-400 mt-2">
             {syncedOffline ? (
-              <>Se sincronizará con FarmOS cuando haya conexión. Mientras tanto, lo encuentra en <strong className="text-slate-200">Bitácora → Recientes</strong>.</>
+              <>Se sincronizará con FarmOS cuando haya conexión. Mientras tanto, la encuentras en <strong className="text-slate-200">Bitácora → Recientes</strong>.</>
             ) : (
               <>Sincronizado con FarmOS.</>
             )}
@@ -244,15 +249,131 @@ export default function HarvestLog({ onBack, onSave }) {
           )}
           <button
             onClick={() => { setView('form'); setSyncedOffline(false); }}
-            className="p-4 rounded-xl bg-orange-700 hover:bg-orange-600 text-white font-bold flex items-center justify-center gap-2"
+            className={redesign ? 'registro-cta' : 'p-4 rounded-xl bg-orange-700 hover:bg-orange-600 text-white font-bold flex items-center justify-center gap-2'}
           >
-            Nueva Cosecha
+            Nueva cosecha
           </button>
         </div>
       </div>
     );
   }
 
+  // ── REDISEÑO (gated): caparazón Chagra theme-aware ──────────────────────
+  if (redesign) {
+    const showSubArea = !!formData.mainArea;
+    return (
+      <RegistroShell
+        title="Cosechar"
+        subtitle="Anota lo que recogiste hoy de la chagra"
+        Icon={Apple}
+        onBack={onBack}
+        footer={
+          <button
+            onClick={handleSave}
+            disabled={isSaving || hasErrors}
+            aria-busy={isSaving}
+            title={hasErrors ? 'Completa los campos correctamente' : undefined}
+            className="registro-cta"
+          >
+            {isSaving ? 'Guardando…' : 'Guardar cosecha'}
+          </button>
+        }
+      >
+        <div className="registro-tip">
+          <Apple size={18} className="registro-tip__icon" aria-hidden="true" />
+          <span>Registra cada cosecha apenas la recojas: así la Bitácora arma tu historial y el agente aprende cuánto produce tu finca.</span>
+        </div>
+
+        <DateField
+          label="¿Qué día cosechaste?"
+          value={formData.date}
+          onChange={(val) => { setFormData(p => ({ ...p, date: val })); markTouched('date'); }}
+          required
+        />
+        {touched.date && errors.date && (
+          <p className="registro-error -mt-3" role="alert"><AlertCircle size={14} aria-hidden="true" /> {errors.date}</p>
+        )}
+
+        <SelectField
+          label="Lote o área"
+          name="mainArea"
+          value={formData.mainArea}
+          onChange={handleInput}
+          placeholder="-- Escoge el lote --"
+          options={MOCK_AREAS.map(a => ({ value: a.id, label: a.name }))}
+        />
+
+        {showSubArea && (
+          <SelectField
+            label="Cama o segmento"
+            name="subArea"
+            value={formData.subArea}
+            onChange={handleInput}
+            onBlur={() => markTouched('subArea')}
+            placeholder="-- Escoge el segmento --"
+            options={(MOCK_SUB_AREAS[formData.mainArea] || []).map(a => ({ value: a.id, label: a.name }))}
+            error={touched.subArea ? errors.subArea : ''}
+          />
+        )}
+
+        <TextField
+          label="¿Qué cosechaste?"
+          name="product"
+          value={formData.product}
+          onChange={handleInput}
+          onBlur={() => markTouched('product')}
+          placeholder="Ej: Fresa Monterrey"
+          error={touched.product ? errors.product : ''}
+        />
+
+        <div className="grid grid-cols-2 gap-3 items-start">
+          <div className="flex flex-col gap-1">
+            <NumberField
+              label="Cantidad"
+              step="0.01"
+              min="0"
+              name="quantity"
+              value={formData.quantity}
+              onChange={handleInput}
+              onBlur={() => markTouched('quantity')}
+              placeholder="0.00"
+              error={touched.quantity ? errors.quantity : ''}
+            />
+            {medianHint && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-emerald-400 px-1">
+                <TrendingUp size={12} aria-hidden="true" />
+                Sueles cosechar {medianHint.median} {formData.unit.toLowerCase()} ({medianHint.count}× antes)
+              </span>
+            )}
+          </div>
+          <SelectField
+            label="Unidad"
+            name="unit"
+            value={formData.unit}
+            onChange={handleInput}
+            options={[
+              { value: 'Kilogramos', label: 'Kilogramos' },
+              { value: 'Gramos', label: 'Gramos' },
+              { value: 'Unidades', label: 'Unidades' },
+              { value: 'Manojos', label: 'Manojos' },
+            ]}
+          />
+        </div>
+
+        <TextAreaField
+          label="Observaciones"
+          hint="opcional"
+          name="notes"
+          rows="3"
+          value={formData.notes}
+          onChange={handleInput}
+          placeholder="Ej: fruta pequeña, algo picada por pájaros…"
+        />
+      </RegistroShell>
+    );
+  }
+
+  // ── LEGACY (flag OFF): markup 0.1 sin cambios visuales ──────────────────
   return (
     <div className="h-[100dvh] w-full bg-slate-950 text-slate-100 flex flex-col overflow-y-auto">
       <header className="p-4 sticky top-0 bg-slate-950 border-b border-slate-800 flex items-center gap-4 z-10 shrink-0 shadow-md">

--- a/src/components/InputLog.jsx
+++ b/src/components/InputLog.jsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Droplets } from 'lucide-react';
 import DateField from './DateField';
 import { savePayload } from '../services/payloadService';
 import { FARM_CONFIG } from '../config/defaults';
+import { fincaVivaHomePerfilActivo } from '../config/fincaVivaHomeFlag';
+import RegistroShell from './registro/RegistroShell';
+import { SelectField, NumberField, TextAreaField } from './registro/RegistroFields';
 
 const INPUT_MATERIALS = [
   { id: 'mat-bio', name: 'Bioactivador Lácteo' },
@@ -45,11 +48,7 @@ export default function InputLog({ onBack, onSave }) {
 
   const handleInput = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => {
-      const next = { ...prev, [name]: value };
-      if (name === 'mainArea') next.subArea = '';
-      return next;
-    });
+    setFormData(prev => ({ ...prev, [name]: value }));
   };
 
   const handleSave = async () => {
@@ -106,6 +105,92 @@ export default function InputLog({ onBack, onSave }) {
     }
   };
 
+  // ── REDISEÑO (gated): caparazón Chagra theme-aware ──────────────────────
+  if (fincaVivaHomePerfilActivo()) {
+    return (
+      <RegistroShell
+        title="Abonos e insumos"
+        subtitle="Qué le echaste a la finca y cuánto gastaste"
+        Icon={Droplets}
+        onBack={onBack}
+        footer={
+          <button onClick={handleSave} className="registro-cta">
+            Registrar aplicación
+          </button>
+        }
+      >
+        <div className="registro-tip">
+          <Droplets size={18} className="registro-tip__icon" aria-hidden="true" />
+          <span>Anota cada aplicación de abono, biopreparado o riego. Así controlas la bodega y sabes qué le funciona a cada lote.</span>
+        </div>
+
+        <DateField
+          label="¿Qué día aplicaste?"
+          value={formData.date}
+          onChange={(val) => setFormData(p => ({ ...p, date: val }))}
+          required
+        />
+
+        <SelectField
+          label="Ubicación o lote"
+          name="locationId"
+          value={formData.locationId}
+          onChange={handleInput}
+          options={REAL_LAND_ASSETS.map(a => ({ value: a.id, label: a.name }))}
+        />
+
+        <SelectField
+          label="¿Qué aplicaste?"
+          name="materialId"
+          value={formData.materialId}
+          onChange={handleInput}
+          placeholder="-- Escoge el insumo --"
+          options={INPUT_MATERIALS.map(m => ({ value: m.id, label: m.name }))}
+        />
+
+        <SelectField
+          label="¿Cómo lo aplicaste?"
+          name="method"
+          value={formData.method}
+          onChange={handleInput}
+          options={APPLICATION_METHODS.map(m => ({ value: m, label: m }))}
+        />
+
+        <div className="grid grid-cols-2 gap-3">
+          <NumberField
+            label="Cantidad"
+            step="0.01"
+            name="quantity"
+            value={formData.quantity}
+            onChange={handleInput}
+            placeholder="0.00"
+          />
+          <SelectField
+            label="Unidad"
+            name="unit"
+            value={formData.unit}
+            onChange={handleInput}
+            options={[
+              { value: 'Litros', label: 'Litros' },
+              { value: 'Kilogramos', label: 'Kilogramos' },
+            ]}
+          />
+        </div>
+
+        <TextAreaField
+          label="Notas"
+          hint="opcional"
+          name="notes"
+          rows="3"
+          value={formData.notes}
+          onChange={handleInput}
+          placeholder="Ej: el suelo estaba seco, dosis baja…"
+        />
+      </RegistroShell>
+    );
+  }
+
+  // ── LEGACY (flag OFF): markup 0.1 sin cambios visuales ──────────────────
   return (
     <div className="h-[100dvh] w-full bg-slate-950 text-slate-100 flex flex-col overflow-y-auto">
       <header className="p-4 sticky top-0 bg-slate-950 border-b border-slate-800 flex items-center gap-4 z-10 shrink-0 shadow-md">

--- a/src/components/MaintenanceScreen.jsx
+++ b/src/components/MaintenanceScreen.jsx
@@ -1,8 +1,18 @@
 import React, { useState, useRef } from 'react';
-import { ArrowLeft, Camera, Image as ImageIcon } from 'lucide-react';
+import { ArrowLeft, Camera, Image as ImageIcon, Wrench } from 'lucide-react';
 import DateField from './DateField';
 import { syncManager } from '../services/syncManager';
 import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
+import { fincaVivaHomePerfilActivo } from '../config/fincaVivaHomeFlag';
+import RegistroShell from './registro/RegistroShell';
+import { SelectField, TextField, TextAreaField } from './registro/RegistroFields';
+
+const MAINTENANCE_TYPES = [
+  { value: 'routine', label: 'Rutinaria' },
+  { value: 'preventive', label: 'Preventiva' },
+  { value: 'corrective', label: 'Correctiva' },
+  { value: 'emergency', label: 'Emergencia' },
+];
 
 function MaintenanceScreen({ onBack, onSave }) {
   const [formData, setFormData] = useState({
@@ -10,7 +20,8 @@ function MaintenanceScreen({ onBack, onSave }) {
     maintenanceType: 'routine',
     description: '',
     duration: '',
-    cost: ''
+    cost: '',
+    notes: ''
   });
   const [photo, setPhoto] = useState(null);
   const [photoUrl, setPhotoUrl] = useState(null);
@@ -78,7 +89,8 @@ function MaintenanceScreen({ onBack, onSave }) {
         maintenanceType: 'routine',
         description: '',
         duration: '',
-        cost: ''
+        cost: '',
+        notes: ''
       });
       setPhoto(null);
       setPhotoUrl(null);
@@ -89,6 +101,103 @@ function MaintenanceScreen({ onBack, onSave }) {
     }
   };
 
+  // Bloque de foto reutilizable (cámara + galería). Comparte refs/handlers.
+  const photoBlock = (
+    <div className="flex flex-col gap-2">
+      <span className="registro-field__label">Foto (opcional)</span>
+      <input ref={cameraInputRef} type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" aria-label="Tomar foto con camara" />
+      <input ref={galleryInputRef} type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" aria-label="Seleccionar foto de galeria" />
+      <div className="grid grid-cols-2 gap-2">
+        <button type="button" onClick={() => cameraInputRef.current?.click()} className="registro-chip justify-center min-h-[64px]">
+          <Camera size={22} aria-hidden="true" /> Tomar foto
+        </button>
+        <button type="button" onClick={() => galleryInputRef.current?.click()} className="registro-chip justify-center min-h-[64px]">
+          <ImageIcon size={22} aria-hidden="true" /> Desde galería
+        </button>
+      </div>
+      {photo && (
+        <p className="text-sm text-emerald-400">Foto lista ({Math.round(photo.size / 1024)} KB).</p>
+      )}
+    </div>
+  );
+
+  // ── REDISEÑO (gated): caparazón Chagra theme-aware ──────────────────────
+  if (fincaVivaHomePerfilActivo()) {
+    return (
+      <RegistroShell
+        title="Labores de la finca"
+        subtitle="Arreglos, mantenimiento y trabajos del día"
+        Icon={Wrench}
+        onBack={onBack}
+        footer={
+          <button onClick={handleSave} className="registro-cta">
+            Guardar labor
+          </button>
+        }
+      >
+        <div className="registro-tip">
+          <Wrench size={18} className="registro-tip__icon" aria-hidden="true" />
+          <span>Deja constancia de cercas, herramientas, riego o cualquier arreglo. La foto ayuda a recordar cómo quedó.</span>
+        </div>
+
+        <SelectField
+          label="Tipo de labor"
+          name="maintenanceType"
+          value={formData.maintenanceType}
+          onChange={handleInput}
+          options={MAINTENANCE_TYPES}
+        />
+
+        <TextAreaField
+          label="¿Qué hiciste?"
+          name="description"
+          rows="4"
+          value={formData.description}
+          onChange={handleInput}
+          placeholder="Ej: arreglé la cerca del lote norte, cambié la manguera de riego…"
+        />
+
+        <div className="grid grid-cols-2 gap-3">
+          <TextField
+            label="¿Cuánto demoró?"
+            name="duration"
+            value={formData.duration}
+            onChange={handleInput}
+            placeholder="Ej: 2 horas"
+          />
+          <TextField
+            label="Costo"
+            hint="opcional"
+            name="cost"
+            value={formData.cost}
+            onChange={handleInput}
+            placeholder="Ej: $5.000"
+          />
+        </div>
+
+        <DateField
+          label="¿Qué día?"
+          value={formData.date}
+          onChange={(val) => setFormData(p => ({ ...p, date: val }))}
+          required
+        />
+
+        <TextAreaField
+          label="Notas"
+          hint="opcional"
+          name="notes"
+          rows="2"
+          value={formData.notes}
+          onChange={handleInput}
+          placeholder="Ej: pendiente revisar la otra semana…"
+        />
+
+        {photoBlock}
+      </RegistroShell>
+    );
+  }
+
+  // ── LEGACY (flag OFF): markup 0.1 sin cambios visuales ──────────────────
   return (
     <div className="h-[100dvh] w-full bg-slate-950 text-slate-100 flex flex-col overflow-y-auto">
       <header className="p-4 sticky top-0 bg-slate-950 border-b border-slate-800 flex items-center gap-4 z-10 shrink-0 shadow-md">

--- a/src/components/WorkerHistory.jsx
+++ b/src/components/WorkerHistory.jsx
@@ -1,8 +1,14 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { ArrowLeft, CheckCircle, Clock, RefreshCw, Wifi, WifiOff, CloudOff, Cloud, Sprout, Apple, TreePine, Building2, Wrench, Leaf, Droplets, Eye } from 'lucide-react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  ArrowLeft, CheckCircle, Clock, RefreshCw, Wifi, WifiOff, CloudOff, Cloud,
+  Sprout, Apple, TreePine, Building2, Wrench, Leaf, Droplets, Eye, Plus,
+  BookOpen, ListFilter,
+} from 'lucide-react';
 import { syncManager } from '../services/syncManager';
 import { logCache } from '../db/logCache';
 import StatusBadge from './StatusBadge';
+import { fincaVivaHomePerfilActivo } from '../config/fincaVivaHomeFlag';
+import './registro/registro-shell.css';
 
 const TRANSACTION_TYPE_LABELS = {
   asset_plant: 'Cultivo / Árbol',
@@ -46,10 +52,62 @@ const TRANSACTION_TYPE_ICONS = {
   activity: Clock,
 };
 
+// Mapa de tipo de log (crudo o `log--x`) → categoría canónica de la bitácora.
+// Cubre tanto los `type` de transacción pendiente (harvest/input/...) como los
+// `type` JSON:API de los logs sincronizados (`log--harvest`, ...).
+function canonicalType(rawType) {
+  if (!rawType) return 'activity';
+  const t = String(rawType).replace('log--', '').replace('--', '_');
+  if (t.startsWith('asset_plant') || t === 'planting') return 'planting';
+  return t;
+}
+
+// FILTROS por familia de registro para la Bitácora "Todo".
+const FILTERS = [
+  { id: 'all', label: 'Todo', Icon: BookOpen, match: () => true },
+  { id: 'harvest', label: 'Cosechas', Icon: Apple, match: (t) => t === 'harvest' },
+  { id: 'input', label: 'Insumos', Icon: Droplets, match: (t) => t === 'input' },
+  { id: 'planting', label: 'Siembras', Icon: Sprout, match: (t) => t === 'planting' || t === 'seeding' },
+  { id: 'maintenance', label: 'Labores', Icon: Wrench, match: (t) => t === 'maintenance' || t === 'activity' },
+  { id: 'observation', label: 'Observaciones', Icon: Eye, match: (t) => t === 'observation' },
+];
+
+// Accesos para AGREGAR un registro. Navegan a las pantallas de registro vía el
+// evento global `chagraNavigate` (mismo canal que usa HarvestLog para "Ver en
+// Bitácora"), así no dependemos de pasar onNavigate como prop.
+const ADD_ACTIONS = [
+  { view: 'cosechar', label: 'Cosecha', Icon: Apple },
+  { view: 'insumos', label: 'Insumo / abono', Icon: Droplets },
+  { view: 'mantenimiento', label: 'Labor', Icon: Wrench },
+  { view: 'sembrar', label: 'Siembra', Icon: Sprout },
+];
+
+function goTo(view) {
+  window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view } }));
+}
+
+/**
+ * Normaliza un timestamp a MILISEGUNDOS.
+ *
+ * BUG histórico: los logs SINCRONIZADOS guardan `timestamp` en segundos UNIX
+ * (logCache), mientras las transacciones PENDIENTES lo guardan en milisegundos
+ * (`Date.now()`). Mezclarlos sin normalizar hacía que (1) los sincronizados se
+ * vieran fechados en 1970 y (2) el orden cronológico quedara roto. Heurística:
+ * si el valor es menor a ~1e12 lo tratamos como segundos.
+ */
+function toMs(ts) {
+  const n = Number(ts);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return n < 1e12 ? n * 1000 : n;
+}
+
 export default function WorkerHistory({ onBack, onEntryClick }) {
-  const [activeSection, setActiveSection] = useState('recientes');
+  const redesign = fincaVivaHomePerfilActivo();
+
+  const [activeSection, setActiveSection] = useState('todo');
+  const [filter, setFilter] = useState('all');
   const [pendingTx, setPendingTx] = useState([]);
-  const [recentSyncedLogs, setRecentSyncedLogs] = useState([]);
+  const [allLogs, setAllLogs] = useState([]);
   const [completedTasks, setCompletedTasks] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isOnline, setIsOnline] = useState(navigator.onLine);
@@ -58,17 +116,13 @@ export default function WorkerHistory({ onBack, onEntryClick }) {
     try {
       await syncManager.initDB();
       const all = await syncManager.getPendingTransactions();
-      // Mostrar más recientes primero
-      setPendingTx(all.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0)));
+      setPendingTx(all.sort((a, b) => toMs(b.timestamp) - toMs(a.timestamp)));
     } catch (err) {
       console.error('Error cargando transacciones pendientes:', err);
     }
   }, []);
 
   const loadCompletedTasks = useCallback(async () => {
-    // Fase 8.5: consulta unificada al caché local de IndexedDB.
-    // El pull de red ya incluye tareas done (ver syncManager.fetchPendingTasksFromFarmOS).
-    // Si hay conexión, refrescamos antes de leer el store; si no, leemos directo.
     try {
       if (navigator.onLine) {
         await syncManager.fetchPendingTasksFromFarmOS();
@@ -80,32 +134,32 @@ export default function WorkerHistory({ onBack, onEntryClick }) {
           t.attributes?.status === 'done' ||
           t.severity === 'completed'
         )
-        .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+        .sort((a, b) => toMs(b.timestamp) - toMs(a.timestamp));
       setCompletedTasks(historyData);
     } catch (err) {
       console.error('Error cargando tareas completadas:', err);
     }
   }, []);
 
-  const loadRecentSyncedLogs = useCallback(async () => {
+  // FIX utilidad: la Bitácora ahora lista TODO el historial sincronizado
+  // (logCache.getAll), no solo las últimas 24h. Antes, un registro de ayer ya
+  // sincronizado desaparecía de la pantalla → "no me deja ver nada".
+  const loadAllLogs = useCallback(async () => {
     try {
-      const recent = await logCache.getRecent24h();
-      setRecentSyncedLogs(recent);
+      const logs = await logCache.getAll();
+      setAllLogs(logs.filter((l) => !l._pending));
     } catch (err) {
-      console.error('Error cargando logs sincronizados recientes:', err);
+      console.error('Error cargando logs sincronizados:', err);
     }
   }, []);
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
-    await Promise.allSettled([loadPendingTransactions(), loadCompletedTasks(), loadRecentSyncedLogs()]);
+    await Promise.allSettled([loadPendingTransactions(), loadCompletedTasks(), loadAllLogs()]);
     setIsLoading(false);
-  }, [loadPendingTransactions, loadCompletedTasks, loadRecentSyncedLogs]);
+  }, [loadPendingTransactions, loadCompletedTasks, loadAllLogs]);
 
   useEffect(() => {
-    // Sync inicial: hidratar la vista al montar el componente.
-    // setIsLoading + setPendingTx resultantes son la sincronización
-    // legítima entre IndexedDB (sistema externo) y React state.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     loadData();
 
@@ -115,7 +169,7 @@ export default function WorkerHistory({ onBack, onEntryClick }) {
     window.addEventListener('offline', onOffline);
 
     const onTaskAdded = () => loadPendingTransactions();
-    const onSyncCompleted = () => loadRecentSyncedLogs();
+    const onSyncCompleted = () => loadAllLogs();
     window.addEventListener('taskAdded', onTaskAdded);
     window.addEventListener('syncCompleted', onSyncCompleted);
 
@@ -125,14 +179,14 @@ export default function WorkerHistory({ onBack, onEntryClick }) {
       window.removeEventListener('taskAdded', onTaskAdded);
       window.removeEventListener('syncCompleted', onSyncCompleted);
     };
-  }, [loadData, loadPendingTransactions, loadRecentSyncedLogs]);
+  }, [loadData, loadPendingTransactions, loadAllLogs]);
 
   const formatTimestamp = (ts) => {
-    if (!ts) return '';
-    const d = new Date(ts);
+    const ms = toMs(ts);
+    if (!ms) return '';
+    const d = new Date(ms);
     const now = new Date();
-    const diffMs = now - d;
-    const diffMin = Math.floor(diffMs / 60000);
+    const diffMin = Math.floor((now - d) / 60000);
 
     if (diffMin < 1) return 'Ahora mismo';
     if (diffMin < 60) return `Hace ${diffMin} min`;
@@ -147,7 +201,6 @@ export default function WorkerHistory({ onBack, onEntryClick }) {
     const name = tx.payload?.data?.attributes?.name;
     if (!name) return TRANSACTION_TYPE_LABELS[tx.type] || tx.type || 'Registro';
 
-    // Texto descriptivo para cosecha y siembra
     if (tx.type === 'harvest') {
       const qty = tx.payload?.data?.relationships?.quantity?.data?.[0]?.attributes;
       if (qty) return `Cosecha registrada: ${qty.value?.decimal || ''} ${qty.label || ''} de ${name}`;
@@ -158,52 +211,205 @@ export default function WorkerHistory({ onBack, onEntryClick }) {
     return name;
   };
 
+  // Feed UNIFICADO: pendientes + todo lo sincronizado, normalizado a un shape
+  // común, ordenado cronológicamente y filtrado por familia.
+  const unifiedFeed = useMemo(() => {
+    const pendingItems = pendingTx.map((tx) => ({
+      key: tx.id,
+      raw: tx,
+      _source: 'pending',
+      type: tx.type,
+      canon: canonicalType(tx.type),
+      name: getTransactionName(tx),
+      ts: toMs(tx.timestamp),
+    }));
+    const syncedItems = allLogs.map((log) => ({
+      key: log.id,
+      raw: log,
+      _source: 'synced',
+      type: log.type,
+      canon: canonicalType(log.type),
+      name: log.name || (log.type || 'Registro').replace('log--', ''),
+      ts: toMs(log.timestamp),
+    }));
+    const activeFilter = FILTERS.find((f) => f.id === filter) || FILTERS[0];
+    return [...pendingItems, ...syncedItems]
+      .filter((it) => activeFilter.match(it.canon))
+      .sort((a, b) => b.ts - a.ts);
+  }, [pendingTx, allLogs, filter]);
+
+  // Conteos por filtro para los chips (visibilidad del historial).
+  const counts = useMemo(() => {
+    const items = [
+      ...pendingTx.map((tx) => canonicalType(tx.type)),
+      ...allLogs.map((l) => canonicalType(l.type)),
+    ];
+    const map = { all: items.length };
+    FILTERS.forEach((f) => {
+      if (f.id === 'all') return;
+      map[f.id] = items.filter((c) => f.match(c)).length;
+    });
+    return map;
+  }, [pendingTx, allLogs]);
+
+  // ── Barra "Agregar registro": CTA visible para que la Bitácora no sea solo
+  //    un visor. Beneficia prod → UNGATED.
+  const addBar = (
+    <div className="px-3 pt-3">
+      <p className="text-xs font-bold text-slate-400 mb-2 px-1 flex items-center gap-1.5">
+        <Plus size={13} /> Agregar a la bitácora
+      </p>
+      <div className="grid grid-cols-4 gap-2">
+        {ADD_ACTIONS.map((action) => {
+          const ActionIcon = action.Icon;
+          return (
+            <button
+              key={action.view}
+              type="button"
+              onClick={() => goTo(action.view)}
+              className={
+                redesign
+                  ? 'registro-chip flex-col justify-center py-2.5 text-xs'
+                  : 'flex flex-col items-center justify-center gap-1 py-2.5 rounded-xl bg-slate-800 border border-slate-700 text-slate-300 text-xs font-bold active:bg-slate-700'
+              }
+            >
+              <ActionIcon size={20} aria-hidden="true" />
+              <span>{action.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  const renderFeedItem = (item) => {
+    const isPending = item._source === 'pending';
+    const typeColor = TRANSACTION_TYPE_COLORS[item.canon] || 'text-slate-400 bg-slate-700/30';
+    const TxIcon = TRANSACTION_TYPE_ICONS[item.canon] || Clock;
+    const Wrap = onEntryClick ? 'button' : 'div';
+    const wrapProps = onEntryClick
+      ? { type: 'button', onClick: () => onEntryClick(item.raw), 'aria-label': `Ver detalle: ${item.name}` }
+      : {};
+    return (
+      <Wrap
+        key={item.key}
+        {...wrapProps}
+        className={`w-full text-left p-4 rounded-xl border transition-all hover:border-slate-400 active:bg-slate-700 ${
+          isPending ? 'bg-slate-800 border-dashed border-slate-600' : 'bg-slate-800/70 border-slate-700'
+        }`}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className={`p-2 rounded-lg ${typeColor} shrink-0 mt-0.5`}>
+            <TxIcon size={16} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1 flex-wrap">
+              <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${typeColor}`}>
+                {TRANSACTION_TYPE_LABELS[item.canon] || item.canon}
+              </span>
+              {isPending ? (
+                <span className="text-xs text-amber-400 bg-amber-900/30 px-1.5 py-0.5 rounded-full flex items-center gap-1">
+                  <CloudOff size={10} /> Pendiente
+                </span>
+              ) : (
+                <span className="text-xs text-emerald-400 bg-emerald-900/30 px-1.5 py-0.5 rounded-full flex items-center gap-1">
+                  <Cloud size={10} /> Sincronizado
+                </span>
+              )}
+            </div>
+            <h4 className="font-bold text-slate-200 text-base truncate">{item.name}</h4>
+          </div>
+          <span className="text-xs text-slate-500 shrink-0 mt-1">{formatTimestamp(item.ts)}</span>
+        </div>
+      </Wrap>
+    );
+  };
+
+  const shellClass = `h-[100dvh] w-full ${redesign ? 'registro-shell' : 'bg-slate-950'} text-slate-100 flex flex-col overflow-hidden`;
+
   return (
-    <div className="h-[100dvh] w-full bg-slate-950 text-slate-100 flex flex-col overflow-hidden">
+    <div className={shellClass}>
       {/* Header */}
-      <header className="p-4 bg-slate-950 border-b border-slate-800 flex items-center gap-4 shrink-0 shadow-md">
-        <button onClick={onBack} aria-label="Volver" className="p-3 bg-slate-800 rounded-full active:bg-slate-700 min-h-[48px] min-w-[48px] flex justify-center items-center shrink-0">
+      <header className={`p-4 flex items-center gap-3 shrink-0 ${redesign ? 'registro-shell__header' : 'bg-slate-950 border-b border-slate-800 shadow-md'}`}>
+        <button
+          onClick={onBack}
+          aria-label="Volver"
+          className={redesign
+            ? 'registro-shell__back shrink-0 min-h-[48px] min-w-[48px] rounded-2xl flex items-center justify-center'
+            : 'p-3 bg-slate-800 rounded-full active:bg-slate-700 min-h-[48px] min-w-[48px] flex justify-center items-center shrink-0'}
+        >
           <ArrowLeft size={24} />
         </button>
-        <h2 className="text-2xl font-black flex-1">Historial</h2>
-        <div className="flex items-center gap-2">
-          {isOnline ? (
-            <Wifi size={14} className="text-green-400" />
-          ) : (
-            <WifiOff size={14} className="text-red-400" />
-          )}
+        {redesign && (
+          <div className="registro-shell__badge shrink-0 min-h-[48px] min-w-[48px] rounded-2xl flex items-center justify-center" aria-hidden="true">
+            <BookOpen size={24} />
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <h2 className={`font-black truncate ${redesign ? 'registro-shell__title text-2xl' : 'text-2xl'}`}>Bitácora</h2>
+          {redesign && <p className="registro-shell__subtitle text-sm truncate">Todo lo que has registrado en tu finca</p>}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {isOnline ? <Wifi size={14} className="text-green-400" /> : <WifiOff size={14} className="text-red-400" />}
           <button onClick={loadData} disabled={isLoading} aria-label="Recargar datos" className="p-2 bg-slate-800 rounded-lg active:bg-slate-700 disabled:opacity-50 min-h-[40px] min-w-[40px] flex items-center justify-center">
             <RefreshCw size={16} className={isLoading ? 'animate-spin' : ''} />
           </button>
         </div>
       </header>
+      {redesign && <div className="registro-shell__rule shrink-0" aria-hidden="true" />}
 
-      {/* Section Tabs */}
-      <div className="flex border-b border-slate-800 shrink-0">
+      {/* Acceso a AGREGAR registro — la Bitácora ya no es solo lectura. */}
+      {addBar}
+
+      {/* Section Tabs: Todo (historial) vs Completadas (tareas done). */}
+      <div className="flex border-b border-slate-800 shrink-0 mt-3">
         <button
-          onClick={() => setActiveSection('recientes')}
-          className={`flex-1 p-3 font-bold text-sm flex items-center justify-center gap-2 transition-all min-h-[48px] ${activeSection === 'recientes'
-            ? 'text-amber-400 border-b-2 border-amber-500'
-            : 'text-slate-500 hover:text-slate-300'
-            }`}
+          onClick={() => setActiveSection('todo')}
+          className={`flex-1 p-3 font-bold text-sm flex items-center justify-center gap-2 transition-all min-h-[48px] ${
+            activeSection === 'todo' ? 'text-amber-400 border-b-2 border-amber-500' : 'text-slate-500 hover:text-slate-300'
+          }`}
         >
-          <Clock size={16} />
-          Registros Recientes
-          {pendingTx.length > 0 && (
-            <span className="text-xs bg-amber-900/40 text-amber-400 px-1.5 py-0.5 rounded-full">{pendingTx.length}</span>
-          )}
+          <BookOpen size={16} /> Registros
+          {counts.all > 0 && <span className="text-xs bg-amber-900/40 text-amber-400 px-1.5 py-0.5 rounded-full">{counts.all}</span>}
         </button>
         <button
           onClick={() => setActiveSection('completadas')}
-          className={`flex-1 p-3 font-bold text-sm flex items-center justify-center gap-2 transition-all min-h-[48px] ${activeSection === 'completadas'
-            ? 'text-green-400 border-b-2 border-green-500'
-            : 'text-slate-500 hover:text-slate-300'
-            }`}
+          className={`flex-1 p-3 font-bold text-sm flex items-center justify-center gap-2 transition-all min-h-[48px] ${
+            activeSection === 'completadas' ? 'text-green-400 border-b-2 border-green-500' : 'text-slate-500 hover:text-slate-300'
+          }`}
         >
-          <CheckCircle size={16} />
-          Completadas
+          <CheckCircle size={16} /> Tareas hechas
         </button>
       </div>
+
+      {/* Filtros por familia (solo en la pestaña Registros). */}
+      {activeSection === 'todo' && (
+        <div className="flex gap-2 overflow-x-auto px-3 py-2.5 shrink-0 border-b border-slate-800/60">
+          <ListFilter size={16} className="text-slate-500 shrink-0 mt-1.5" aria-hidden="true" />
+          {FILTERS.map((f) => {
+            const FilterIcon = f.Icon;
+            const n = counts[f.id] || 0;
+            if (f.id !== 'all' && n === 0) return null;
+            return (
+              <button
+                key={f.id}
+                type="button"
+                onClick={() => setFilter(f.id)}
+                className={
+                  redesign
+                    ? `registro-chip shrink-0 ${filter === f.id ? 'registro-chip--active' : ''}`
+                    : `shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-bold border ${
+                        filter === f.id ? 'bg-amber-900/30 border-amber-600 text-amber-300' : 'bg-slate-800 border-slate-700 text-slate-400'
+                      }`
+                }
+              >
+                <FilterIcon size={14} aria-hidden="true" /> {f.label}
+                {n > 0 && <span className="opacity-70">{n}</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-3 space-y-2">
@@ -214,97 +420,49 @@ export default function WorkerHistory({ onBack, onEntryClick }) {
           </div>
         )}
 
-        {/* Registros Recientes (pending_transactions) */}
-        {activeSection === 'recientes' && !isLoading && (
+        {/* Registros (feed unificado, filtrado) */}
+        {activeSection === 'todo' && !isLoading && (
           <>
-            {/* Honesty note reemplazada: Parte C fulfilled */}
-            <p className="text-[11px] text-slate-500 italic px-2 py-2 leading-relaxed">
-              Últimas 24h. Para historial completo: Activos, planta, Bitácora.
-            </p>
-            {(() => {
-              // Combinar pending + synced 24h, sort por timestamp desc
-              const pendingItems = pendingTx.map(tx => ({ ...tx, _source: 'pending' }));
-              const syncedItems = recentSyncedLogs.map(log => ({ ...log, _source: 'synced' }));
-              const all = [...pendingItems, ...syncedItems].sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
-
-              if (all.length === 0) {
-                return (
-                  <div className="flex flex-col items-center justify-center py-12 text-slate-500">
-                    <Cloud size={48} className="mb-3 opacity-30" />
-                    <p className="text-lg">Aún no hay registros en las últimas 24h</p>
-                    <p className="text-sm mt-1">Cuando grabes algo, aparece aquí</p>
-                  </div>
-                );
-              }
-
-              return all.map((item, idx) => {
-                const isPending = item._source === 'pending';
-                const txType = item.type;
-                const typeColor = TRANSACTION_TYPE_COLORS[txType] || 'text-slate-400 bg-slate-700/30';
-                const name = isPending ? getTransactionName(item) : (item.name || item.type || 'Registro');
-                const TxIcon = TRANSACTION_TYPE_ICONS[txType] || Clock;
-
-                const Wrap = onEntryClick ? 'button' : 'div';
-                const wrapProps = onEntryClick
-                  ? { type: 'button', onClick: () => onEntryClick(item), 'aria-label': `Ver detalle: ${name}` }
-                  : {};
-                return (
-                  <Wrap
-                    key={item.id || idx}
-                    {...wrapProps}
-                    className={`w-full text-left p-4 rounded-xl border transition-all hover:border-slate-400 active:bg-slate-700 ${
-                      isPending
-                        ? 'bg-slate-800 border-dashed border-slate-600'
-                        : 'bg-slate-800/70 border-slate-700'
-                    }`}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className={`p-2 rounded-lg ${typeColor} shrink-0 mt-0.5`}>
-                        <TxIcon size={16} />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1 flex-wrap">
-                          <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${typeColor}`}>
-                            {isPending ? (TRANSACTION_TYPE_LABELS[item.type] || item.type || 'Registro') : (item.type || 'Registro').replace('log--', '')}
-                          </span>
-                          {isPending ? (
-                            <span className="text-xs text-amber-400 bg-amber-900/30 px-1.5 py-0.5 rounded-full flex items-center gap-1">
-                              <CloudOff size={10} />
-                              Pendiente
-                            </span>
-                          ) : (
-                            <span className="text-xs text-emerald-400 bg-emerald-900/30 px-1.5 py-0.5 rounded-full flex items-center gap-1">
-                              <Cloud size={10} />
-                              Sincronizado
-                            </span>
-                          )}
-                        </div>
-                        <h4 className="font-bold text-slate-200 text-base truncate">{name}</h4>
-                      </div>
-                      <span className="text-xs text-slate-500 shrink-0 mt-1">
-                        {formatTimestamp(item.timestamp)}
-                      </span>
-                    </div>
-                  </Wrap>
-                );
-              });
-            })()}
-
-            {pendingTx.length > 0 && (
-              <div className="p-3 rounded-xl bg-amber-900/10 border border-amber-800/30 text-center">
-                <p className="text-xs text-amber-400/80">
-                  {isOnline
-                    ? 'Estos registros se sincronizarán automáticamente con FarmOS'
-                    : 'Se sincronizarán cuando se restablezca la conexión'}
+            {unifiedFeed.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-10 text-center px-4">
+                <div className={`p-4 rounded-2xl mb-3 ${redesign ? 'registro-shell__badge' : 'bg-slate-800 text-emerald-400'}`}>
+                  <BookOpen size={40} aria-hidden="true" />
+                </div>
+                <p className="text-lg font-bold text-slate-200">
+                  {filter === 'all' ? 'Aún no has registrado nada' : 'Sin registros de este tipo'}
                 </p>
-              </div>
-            )}
-            {recentSyncedLogs.length > 0 && pendingTx.length === 0 && (
-              <div className="p-3 rounded-xl bg-emerald-900/10 border border-emerald-800/30 text-center">
-                <p className="text-xs text-emerald-400/80">
-                  {recentSyncedLogs.length} registro{recentSyncedLogs.length !== 1 ? 's' : ''} sincronizado{recentSyncedLogs.length !== 1 ? 's' : ''} en las últimas 24h
+                <p className="text-sm text-slate-400 mt-1 max-w-xs">
+                  {filter === 'all'
+                    ? 'Empieza por anotar una cosecha, un abono o una labor. Todo lo que registres queda guardado aquí.'
+                    : 'Cambia el filtro o agrega un registro nuevo.'}
                 </p>
+                <div className="grid grid-cols-2 gap-2 mt-5 w-full max-w-xs">
+                  {ADD_ACTIONS.map((action) => {
+                    const ActionIcon = action.Icon;
+                    return (
+                      <button
+                        key={action.view}
+                        type="button"
+                        onClick={() => goTo(action.view)}
+                        className={
+                          redesign
+                            ? 'registro-cta text-base min-h-[56px]'
+                            : 'flex items-center justify-center gap-2 py-3 rounded-xl bg-emerald-700 active:bg-emerald-600 text-white font-bold text-sm'
+                        }
+                      >
+                        <ActionIcon size={18} aria-hidden="true" /> {action.label}
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
+            ) : (
+              <>
+                {unifiedFeed.map(renderFeedItem)}
+                <p className="text-[11px] text-slate-500 text-center pt-2 pb-1">
+                  {unifiedFeed.length} registro{unifiedFeed.length !== 1 ? 's' : ''} en tu bitácora
+                </p>
+              </>
             )}
           </>
         )}
@@ -325,31 +483,29 @@ export default function WorkerHistory({ onBack, onEntryClick }) {
                   ? { type: 'button', onClick: () => onEntryClick(task), 'aria-label': `Ver detalle: ${task.title || task.attributes?.name}` }
                   : {};
                 return (
-                <TaskWrap
-                  key={task.id || idx}
-                  {...taskWrapProps}
-                  className="w-full text-left p-4 rounded-xl bg-slate-800 border border-slate-700 transition-all hover:border-slate-500 active:bg-slate-700"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex items-center gap-3 flex-1 min-w-0">
-                      <div className="p-2 rounded-lg bg-green-900/30 shrink-0">
-                        <CheckCircle size={18} className="text-green-400" />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <h4 className="font-bold text-slate-200 truncate text-base">{task.title || task.attributes?.name}</h4>
-                        <div className="flex items-center gap-2">
-                          <StatusBadge status={task.status || task.attributes?.status} type="task" className="scale-75 origin-left" />
-                          {task.type && (
-                            <span className="text-xs text-slate-500">{task.type.replace('log--', '').replace('--', ' ')}</span>
-                          )}
+                  <TaskWrap
+                    key={task.id || idx}
+                    {...taskWrapProps}
+                    className="w-full text-left p-4 rounded-xl bg-slate-800 border border-slate-700 transition-all hover:border-slate-500 active:bg-slate-700"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-3 flex-1 min-w-0">
+                        <div className="p-2 rounded-lg bg-green-900/30 shrink-0">
+                          <CheckCircle size={18} className="text-green-400" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <h4 className="font-bold text-slate-200 truncate text-base">{task.title || task.attributes?.name}</h4>
+                          <div className="flex items-center gap-2">
+                            <StatusBadge status={task.status || task.attributes?.status} type="task" className="scale-75 origin-left" />
+                            {task.type && (
+                              <span className="text-xs text-slate-500">{task.type.replace('log--', '').replace('--', ' ')}</span>
+                            )}
+                          </div>
                         </div>
                       </div>
+                      <span className="text-xs text-slate-500 shrink-0 mt-1">{formatTimestamp(task.timestamp)}</span>
                     </div>
-                    <span className="text-xs text-slate-500 shrink-0 mt-1">
-                      {formatTimestamp(task.timestamp)}
-                    </span>
-                  </div>
-                </TaskWrap>
+                  </TaskWrap>
                 );
               })
             )}

--- a/src/components/__tests__/WorkerHistory.smoke.test.jsx
+++ b/src/components/__tests__/WorkerHistory.smoke.test.jsx
@@ -1,24 +1,60 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import WorkerHistory from '../WorkerHistory';
 
-describe('WorkerHistory', () => {
-  test('renders header and tabs', () => {
+// La Bitácora consulta IndexedDB vía syncManager + logCache. En jsdom no hay
+// IndexedDB real, así que mockeamos las lecturas a vacío para que monte limpio.
+vi.mock('../../services/syncManager', () => ({
+  syncManager: {
+    initDB: vi.fn().mockResolvedValue(undefined),
+    getPendingTransactions: vi.fn().mockResolvedValue([]),
+    fetchPendingTasksFromFarmOS: vi.fn().mockResolvedValue(undefined),
+    getPendingTasks: vi.fn().mockResolvedValue([]),
+  },
+}));
+vi.mock('../../db/logCache', () => ({
+  logCache: {
+    getAll: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe('WorkerHistory (Bitácora)', () => {
+  test('renders header, tabs and filters', () => {
     render(<WorkerHistory onBack={() => {}} />);
-    expect(screen.getByText(/Historial/i)).toBeInTheDocument();
-    expect(screen.getByText(/Registros Recientes/i)).toBeInTheDocument();
-    expect(screen.getByText(/Completadas/i)).toBeInTheDocument();
+    expect(screen.getByText('Bitácora')).toBeInTheDocument();
+    expect(screen.getByText('Registros')).toBeInTheDocument();
+    expect(screen.getByText('Tareas hechas')).toBeInTheDocument();
+  });
+
+  test('shows "Agregar a la bitácora" CTAs (no es solo lectura)', () => {
+    render(<WorkerHistory onBack={() => {}} />);
+    expect(screen.getByText(/Agregar a la bitácora/i)).toBeInTheDocument();
+    // Accesos rápidos a las pantallas de registro.
+    expect(screen.getAllByText('Cosecha').length).toBeGreaterThan(0);
+    expect(screen.getByText('Insumo / abono')).toBeInTheDocument();
+    expect(screen.getByText('Labor')).toBeInTheDocument();
   });
 
   test('syncCompleted event does not crash', () => {
     render(<WorkerHistory onBack={() => {}} />);
     window.dispatchEvent(new CustomEvent('syncCompleted', { detail: { id: 'log1' } }));
-    expect(screen.getByText(/Historial/i)).toBeInTheDocument();
+    expect(screen.getByText('Bitácora')).toBeInTheDocument();
+  });
+
+  test('estado vacío acogedor con accesos para empezar', async () => {
+    render(<WorkerHistory onBack={() => {}} />);
+    // El feed arranca vacío (mocks devuelven []), tras el load async aparece
+    // el estado vacío con su CTA.
+    expect(await screen.findByText(/Aún no has registrado nada/i)).toBeInTheDocument();
   });
 
   test('online/offline indicator renders', () => {
     render(<WorkerHistory onBack={() => {}} />);
-    expect(screen.getByText(/Historial/i)).toBeInTheDocument();
+    expect(screen.getByText('Bitácora')).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/bitacora-route.test.jsx
+++ b/src/components/__tests__/bitacora-route.test.jsx
@@ -1,0 +1,41 @@
+/**
+ * bitacora-route.test.jsx — Tarea #22, fix de la ruta rota de la Bitácora.
+ *
+ * BUG: AnalisisProactivoIA navegaba a 'bitacora' pero App.jsx solo tenía
+ * `case 'historial'` (+ 'bitacora_detail'), así que la entrada caía en
+ * "Vista no disponible". Este test ancla el contrato: 'bitacora' debe estar
+ * ruteada (alias de 'historial' → WorkerHistory) para que TODA entrada a la
+ * bitácora llegue a una pantalla viva.
+ *
+ * Es un test estático sobre la fuente (App.jsx es demasiado pesado para montar
+ * con todos sus providers en jsdom), suficiente para prevenir la regresión.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appSrc = readFileSync(path.resolve(here, '../../App.jsx'), 'utf8');
+
+describe('Ruta de la Bitácora', () => {
+  it("App.jsx tiene case 'bitacora' (no solo 'historial')", () => {
+    expect(appSrc).toMatch(/case 'bitacora':/);
+  });
+
+  it("'historial' y 'bitacora' caen ambos en WorkerHistory", () => {
+    // Bloque contiguo: case 'historial': case 'bitacora': ... <WorkerHistory
+    const block = appSrc.slice(appSrc.indexOf("case 'historial':"));
+    const head = block.slice(0, 400);
+    expect(head).toMatch(/case 'bitacora':/);
+    expect(head).toMatch(/<WorkerHistory/);
+  });
+
+  it("'bitacora' está registrada en MODULE_VIEWS para analítica", () => {
+    const moduleViews = appSrc.slice(
+      appSrc.indexOf('const MODULE_VIEWS'),
+      appSrc.indexOf('const MODULE_VIEWS') + 900,
+    );
+    expect(moduleViews).toMatch(/'bitacora'/);
+  });
+});

--- a/src/components/__tests__/registro-redesign.test.jsx
+++ b/src/components/__tests__/registro-redesign.test.jsx
@@ -1,0 +1,162 @@
+/**
+ * registro-redesign.test.jsx — Tarea #22.
+ *
+ * Cubre el rediseño de las 4 ventanas de registro (Cosechar, Insumos, Labores,
+ * Bitácora):
+ *   - Con la flag fincaVivaHomePerfilActivo() OFF → markup legacy (sin cambios).
+ *   - Con la flag ON → caparazón Chagra (RegistroShell) theme-aware.
+ *   - Los formularios siguen funcionando (guardan) en ambos modos.
+ *
+ * Español de Colombia (tú/usted), sin voseo.
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let flagOn = false;
+vi.mock('../../config/fincaVivaHomeFlag', () => ({
+  fincaVivaHomePerfilActivo: () => flagOn,
+}));
+
+vi.mock('../../services/payloadService', () => ({
+  savePayload: vi.fn().mockResolvedValue({ success: true, message: 'OK' }),
+}));
+vi.mock('../../config/defaults', () => ({
+  FARM_CONFIG: { LOCATION_ID: 'loc-1', FARM_NAME: 'Finca Test' },
+}));
+vi.mock('../../services/syncManager', () => ({
+  syncManager: {
+    initDB: vi.fn().mockResolvedValue(undefined),
+    getPendingTransactions: vi.fn().mockResolvedValue([]),
+    fetchPendingTasksFromFarmOS: vi.fn().mockResolvedValue(undefined),
+    getPendingTasks: vi.fn().mockResolvedValue([]),
+    saveTransaction: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+vi.mock('../../db/logCache', () => ({
+  logCache: {
+    getAll: vi.fn().mockResolvedValue([]),
+    getByType: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+import HarvestLog from '../HarvestLog';
+import InputLog from '../InputLog';
+import MaintenanceScreen from '../MaintenanceScreen';
+import WorkerHistory from '../WorkerHistory';
+
+beforeEach(() => {
+  flagOn = false;
+});
+afterEach(() => cleanup());
+
+describe('Las 4 pantallas montan sin error (flag OFF y ON)', () => {
+  it.each([false, true])('HarvestLog (Cosechar) monta — flag=%s', (on) => {
+    flagOn = on;
+    render(<HarvestLog onBack={() => {}} onSave={() => {}} />);
+    expect(screen.getByText('Cosechar')).toBeInTheDocument();
+  });
+
+  it.each([false, true])('InputLog (Insumos) monta — flag=%s', (on) => {
+    flagOn = on;
+    render(<InputLog onBack={() => {}} onSave={() => {}} />);
+    expect(screen.getByRole('button', { name: /registrar aplicación/i })).toBeInTheDocument();
+  });
+
+  it.each([false, true])('MaintenanceScreen (Labores) monta — flag=%s', (on) => {
+    flagOn = on;
+    render(<MaintenanceScreen onBack={() => {}} onSave={() => {}} />);
+    expect(screen.getByRole('button', { name: /guardar (mantenimiento|labor)/i })).toBeInTheDocument();
+  });
+
+  it.each([false, true])('WorkerHistory (Bitácora) monta — flag=%s', (on) => {
+    flagOn = on;
+    render(<WorkerHistory onBack={() => {}} />);
+    expect(screen.getByText('Bitácora')).toBeInTheDocument();
+  });
+});
+
+describe('Rediseño (flag ON): caparazón Chagra theme-aware', () => {
+  it('Cosechar usa la clase registro-shell', () => {
+    flagOn = true;
+    const { container } = render(<HarvestLog onBack={() => {}} onSave={() => {}} />);
+    expect(container.querySelector('.registro-shell')).toBeTruthy();
+    expect(container.querySelector('.registro-cta')).toBeTruthy();
+  });
+
+  it('Insumos usa el caparazón y microcopy campesino', () => {
+    flagOn = true;
+    const { container } = render(<InputLog onBack={() => {}} onSave={() => {}} />);
+    expect(container.querySelector('.registro-shell')).toBeTruthy();
+    expect(screen.getByText(/Abonos e insumos/i)).toBeInTheDocument();
+  });
+
+  it('Labores usa el caparazón', () => {
+    flagOn = true;
+    const { container } = render(<MaintenanceScreen onBack={() => {}} onSave={() => {}} />);
+    expect(container.querySelector('.registro-shell')).toBeTruthy();
+    expect(screen.getByText(/Labores de la finca/i)).toBeInTheDocument();
+  });
+});
+
+describe('Los formularios siguen funcionando con el rediseño (flag ON)', () => {
+  it('Insumos guarda con cantidad válida', async () => {
+    flagOn = true;
+    const onSave = vi.fn();
+    render(<InputLog onBack={() => {}} onSave={onSave} />);
+
+    const materialSelect = screen.getByRole('combobox', { name: /qué aplicaste/i });
+    fireEvent.change(materialSelect, { target: { value: 'mat-bio' } });
+    const qtyInput = screen.getByPlaceholderText('0.00');
+    fireEvent.change(qtyInput, { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: /registrar aplicación/i }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith('OK', false));
+  });
+
+  it('Insumos valida campos requeridos vacíos', async () => {
+    flagOn = true;
+    const onSave = vi.fn();
+    render(<InputLog onBack={() => {}} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: /registrar aplicación/i }));
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith('Completa Ubicación, Tipo de Insumo y Cantidad', true),
+    );
+  });
+
+  it('Labores valida descripción requerida', async () => {
+    flagOn = true;
+    const onSave = vi.fn();
+    render(<MaintenanceScreen onBack={() => {}} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: /guardar labor/i }));
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith('Completa tipo de mantenimiento y descripcion', true),
+    );
+  });
+});
+
+describe('Bitácora útil (UNGATED): historial + CTA agregar', () => {
+  it('muestra la barra de "Agregar a la bitácora" aunque la flag esté OFF', () => {
+    flagOn = false;
+    render(<WorkerHistory onBack={() => {}} />);
+    expect(screen.getByText(/Agregar a la bitácora/i)).toBeInTheDocument();
+  });
+
+  it('el estado vacío invita a registrar (no es pantalla muerta)', async () => {
+    flagOn = false;
+    render(<WorkerHistory onBack={() => {}} />);
+    expect(await screen.findByText(/Aún no has registrado nada/i)).toBeInTheDocument();
+  });
+
+  it('un acceso de agregar despacha el evento chagraNavigate al destino correcto', () => {
+    flagOn = false;
+    const spy = vi.fn();
+    window.addEventListener('chagraNavigate', spy);
+    render(<WorkerHistory onBack={() => {}} />);
+    fireEvent.click(screen.getByText('Insumo / abono'));
+    expect(spy).toHaveBeenCalled();
+    const ev = spy.mock.calls[0][0];
+    expect(ev.detail.view).toBe('insumos');
+    window.removeEventListener('chagraNavigate', spy);
+  });
+});

--- a/src/components/registro/RegistroFields.jsx
+++ b/src/components/registro/RegistroFields.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { AlertCircle } from 'lucide-react';
+
+/**
+ * RegistroFields — primitivas de formulario compartidas por las 4 pantallas de
+ * registro rediseñadas (Cosechar, Insumos, Labores). Garantizan que las cuatro
+ * usen la MISMA jerarquía, tamaños táctiles y estilo theme-aware (clases
+ * `registro-*` definidas en registro-shell.css).
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+
+/** Etiqueta + hint opcional sobre un campo. */
+export function FieldLabel({ children, hint, Icon }) {
+  return (
+    <span className="registro-field__label">
+      {Icon && <Icon size={17} aria-hidden="true" />}
+      {children}
+      {hint && <span className="registro-field__hint">· {hint}</span>}
+    </span>
+  );
+}
+
+/** Mensaje de error inline bajo un campo. */
+export function FieldError({ children }) {
+  if (!children) return null;
+  return (
+    <p className="registro-error" role="alert">
+      <AlertCircle size={14} aria-hidden="true" /> {children}
+    </p>
+  );
+}
+
+/** Campo de texto. */
+export function TextField({ label, hint, Icon, error, ...rest }) {
+  return (
+    <label className="registro-field">
+      <FieldLabel hint={hint} Icon={Icon}>{label}</FieldLabel>
+      <input
+        className={`registro-input ${error ? 'registro-input--invalid' : ''}`}
+        aria-invalid={!!error}
+        {...rest}
+      />
+      <FieldError>{error}</FieldError>
+    </label>
+  );
+}
+
+/** Campo numérico (cantidad, costo). */
+export function NumberField({ label, hint, Icon, error, ...rest }) {
+  return (
+    <label className="registro-field">
+      <FieldLabel hint={hint} Icon={Icon}>{label}</FieldLabel>
+      <input
+        type="number"
+        inputMode="decimal"
+        className={`registro-input ${error ? 'registro-input--invalid' : ''}`}
+        aria-invalid={!!error}
+        {...rest}
+      />
+      <FieldError>{error}</FieldError>
+    </label>
+  );
+}
+
+/** Select. `options` = [{ value, label }]. `placeholder` añade opción vacía. */
+export function SelectField({ label, hint, Icon, error, options, placeholder, ...rest }) {
+  return (
+    <label className="registro-field">
+      <FieldLabel hint={hint} Icon={Icon}>{label}</FieldLabel>
+      <select
+        className={`registro-select ${error ? 'registro-select--invalid' : ''}`}
+        aria-invalid={!!error}
+        {...rest}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+      <FieldError>{error}</FieldError>
+    </label>
+  );
+}
+
+/** Área de texto multilínea (observaciones / notas). */
+export function TextAreaField({ label, hint, Icon, error, ...rest }) {
+  return (
+    <label className="registro-field">
+      <FieldLabel hint={hint} Icon={Icon}>{label}</FieldLabel>
+      <textarea
+        className={`registro-textarea ${error ? 'registro-input--invalid' : ''}`}
+        aria-invalid={!!error}
+        {...rest}
+      />
+      <FieldError>{error}</FieldError>
+    </label>
+  );
+}

--- a/src/components/registro/RegistroShell.jsx
+++ b/src/components/registro/RegistroShell.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { ArrowLeft } from 'lucide-react';
+import './registro-shell.css';
+
+/**
+ * RegistroShell — caparazón VISUAL común de las 4 ventanas de registro de
+ * Chagra (Cosechar, Insumos, Labores, Bitácora). Le da a las cuatro la MISMA
+ * familia visual: identidad Chagra, theme-aware (toma la piel del tema activo
+ * vía las CSS vars `--c-*` / `--t-*`), mobile-first, jerarquía clara.
+ *
+ * El acento de cada pantalla es el del TEMA activo (`--t-accent-rgb`), no un
+ * color fijo: en biopunk vira teal, en nature ocre, en minimalista/verde-vivo
+ * verde. Eso hace que las cuatro pantallas se vean coherentes con el resto de
+ * la app en los cuatro temas.
+ *
+ * Va GATED tras `fincaVivaHomePerfilActivo()` en cada call-site: con la flag
+ * apagada (default/prod) cada pantalla conserva su markup legacy; con la flag
+ * encendida (dev) se renderiza este caparazón rediseñado.
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ *
+ * @param {Object} props
+ * @param {string} props.title - Título de la pantalla (ej. "Cosechar").
+ * @param {string} [props.subtitle] - Microcopy campesino bajo el título.
+ * @param {React.ComponentType} props.Icon - Icono lucide de la pantalla.
+ * @param {Function} props.onBack - Callback del botón Volver.
+ * @param {React.ReactNode} props.children - Cuerpo del formulario / contenido.
+ * @param {React.ReactNode} [props.footer] - Barra de acción fija inferior (CTA).
+ * @param {React.ReactNode} [props.headerExtra] - Slot a la derecha del header.
+ * @returns {JSX.Element}
+ */
+export default function RegistroShell({
+  title,
+  subtitle,
+  Icon,
+  onBack,
+  children,
+  footer,
+  headerExtra,
+}) {
+  return (
+    <div className="registro-shell h-[100dvh] w-full flex flex-col bg-slate-950 text-slate-100">
+      {/* Header con sello Chagra: icono en un disco con el acento del tema. */}
+      <header className="registro-shell__header shrink-0 px-4 pt-4 pb-4 flex items-center gap-3">
+        <button
+          onClick={onBack}
+          aria-label="Volver"
+          className="registro-shell__back shrink-0 min-h-[52px] min-w-[52px] rounded-2xl flex items-center justify-center"
+        >
+          <ArrowLeft size={26} aria-hidden="true" />
+        </button>
+        <div className="registro-shell__badge shrink-0 min-h-[52px] min-w-[52px] rounded-2xl flex items-center justify-center" aria-hidden="true">
+          {Icon ? <Icon size={28} /> : null}
+        </div>
+        <div className="flex-1 min-w-0">
+          <h2 className="registro-shell__title text-2xl font-black leading-tight truncate">{title}</h2>
+          {subtitle && (
+            <p className="registro-shell__subtitle text-sm leading-snug mt-0.5 truncate">{subtitle}</p>
+          )}
+        </div>
+        {headerExtra && <div className="shrink-0">{headerExtra}</div>}
+      </header>
+
+      {/* Hairline con el acento del tema, marca de identidad. */}
+      <div className="registro-shell__rule shrink-0" aria-hidden="true" />
+
+      {/* Cuerpo scrolleable. El padding inferior deja aire para el footer fijo. */}
+      <div className={`flex-1 overflow-y-auto px-4 pt-5 ${footer ? 'pb-32' : 'pb-10'}`}>
+        <div className="max-w-xl mx-auto flex flex-col gap-5">{children}</div>
+      </div>
+
+      {/* Barra de acción fija (CTA principal). */}
+      {footer && (
+        <div className="registro-shell__footer shrink-0 px-4 pt-3 pb-5">
+          <div className="max-w-xl mx-auto">{footer}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/registro/registro-shell.css
+++ b/src/components/registro/registro-shell.css
@@ -1,0 +1,222 @@
+/* registro-shell.css
+ * ============================================================================
+ * Piel VISUAL común de las 4 ventanas de registro de Chagra (Cosechar,
+ * Insumos, Labores, Bitácora). Theme-aware: TODO sale de las CSS vars del
+ * tema activo:
+ *   --c-surface / --c-surface-card / --c-surface-raised / --c-surface-border
+ *   --c-slate-* (texto, remapeado por tema en index.css)
+ *   --t-accent-rgb (acento de marca del tema: teal / ocre / verde)
+ * No hay colores hardcodeados: en los 4 temas (biopunk, nature, minimalista,
+ * verde-vivo) se ve coherente y legible (AA).
+ *
+ * Se aplica SOLO cuando la flag `fincaVivaHomePerfilActivo()` está encendida
+ * (el rediseño va gated en dev). Con la flag apagada estos estilos no se
+ * montan porque el JSX legacy no usa estas clases.
+ * ========================================================================== */
+
+.registro-shell {
+  /* Fondo base = superficie del tema, con un sutil halo del acento arriba
+     para dar identidad sin romper contraste. */
+  background:
+    radial-gradient(120% 60% at 50% -10%, rgb(var(--t-accent-rgb) / 0.10), transparent 60%),
+    rgb(var(--c-surface));
+  color: rgb(var(--c-slate-100));
+}
+
+.registro-shell__header {
+  background: linear-gradient(
+    to bottom,
+    rgb(var(--c-surface) / 0.96),
+    rgb(var(--c-surface) / 0.82)
+  );
+  backdrop-filter: blur(6px);
+}
+
+.registro-shell__back {
+  background: rgb(var(--c-surface-raised));
+  border: 1px solid rgb(var(--c-surface-border));
+  color: rgb(var(--c-slate-200));
+}
+.registro-shell__back:active {
+  background: rgb(var(--c-surface-card));
+}
+
+/* Sello Chagra: disco con el acento del tema. */
+.registro-shell__badge {
+  background: rgb(var(--t-accent-rgb) / 0.16);
+  border: 1px solid rgb(var(--t-accent-rgb) / 0.38);
+  color: rgb(var(--t-accent-rgb));
+  box-shadow: inset 0 0 0 1px rgb(var(--t-accent-rgb) / 0.10);
+}
+
+.registro-shell__title {
+  color: rgb(var(--c-slate-100));
+  letter-spacing: -0.01em;
+}
+.registro-shell__subtitle {
+  color: rgb(var(--c-slate-400));
+}
+
+/* Hairline de acento bajo el header — marca de identidad. */
+.registro-shell__rule {
+  height: 3px;
+  background: linear-gradient(
+    to right,
+    rgb(var(--t-accent-rgb)),
+    rgb(var(--t-accent-rgb) / 0.35) 55%,
+    transparent
+  );
+}
+
+.registro-shell__footer {
+  background: linear-gradient(
+    to top,
+    rgb(var(--c-surface)) 60%,
+    rgb(var(--c-surface) / 0)
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * Primitivas de formulario reutilizadas por las 4 pantallas.
+ * ------------------------------------------------------------------------- */
+
+.registro-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.registro-field__label {
+  font-size: 0.95rem;
+  font-weight: 800;
+  color: rgb(var(--c-slate-300));
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  letter-spacing: 0.01em;
+}
+.registro-field__hint {
+  font-size: 0.78rem;
+  color: rgb(var(--c-slate-500));
+  font-weight: 500;
+}
+
+.registro-input,
+.registro-select,
+.registro-textarea {
+  width: 100%;
+  min-height: 60px;
+  padding: 0.9rem 1rem;
+  font-size: 1.15rem;
+  border-radius: 1rem;
+  background: rgb(var(--c-surface-card));
+  border: 1.5px solid rgb(var(--c-surface-border));
+  color: rgb(var(--c-slate-100));
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.registro-textarea {
+  min-height: 92px;
+  line-height: 1.45;
+  resize: vertical;
+}
+.registro-input::placeholder,
+.registro-textarea::placeholder {
+  color: rgb(var(--c-slate-500));
+}
+.registro-input:focus,
+.registro-select:focus,
+.registro-textarea:focus {
+  outline: none;
+  border-color: rgb(var(--t-accent-rgb));
+  box-shadow: 0 0 0 3px rgb(var(--t-accent-rgb) / 0.18);
+}
+.registro-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  padding-right: 2.75rem;
+}
+.registro-input--invalid,
+.registro-select--invalid {
+  border-color: rgb(220 60 60);
+}
+
+.registro-error {
+  font-size: 0.82rem;
+  color: rgb(239 110 110);
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+/* CTA principal: relleno SÓLIDO del acento del tema. El punto focal de acción
+   de la pantalla, coherente con el botón "enviar" del agente. */
+.registro-cta {
+  width: 100%;
+  min-height: 68px;
+  padding: 1rem 1.25rem;
+  border-radius: 1.1rem;
+  font-size: 1.3rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  color: rgb(255 255 255);
+  background: rgb(var(--t-accent-rgb));
+  border: none;
+  box-shadow:
+    0 8px 22px rgb(var(--t-accent-rgb) / 0.30),
+    inset 0 -3px 0 rgb(0 0 0 / 0.18);
+  transition: transform 0.08s ease, filter 0.15s ease;
+}
+.registro-cta:active {
+  transform: translateY(1px);
+  filter: brightness(0.95);
+}
+.registro-cta:disabled {
+  opacity: 0.5;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+/* Tarjeta de "consejo / contexto" — microcopy campesino con identidad. */
+.registro-tip {
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+  background: rgb(var(--t-accent-rgb) / 0.10);
+  border: 1px solid rgb(var(--t-accent-rgb) / 0.28);
+  color: rgb(var(--c-slate-200));
+  font-size: 0.9rem;
+  line-height: 1.45;
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+}
+.registro-tip__icon {
+  color: rgb(var(--t-accent-rgb));
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+/* Chips de selección rápida (segmentos, accesos). */
+.registro-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.92rem;
+  font-weight: 700;
+  background: rgb(var(--c-surface-raised));
+  border: 1.5px solid rgb(var(--c-surface-border));
+  color: rgb(var(--c-slate-300));
+  transition: all 0.12s ease;
+}
+.registro-chip--active {
+  background: rgb(var(--t-accent-rgb) / 0.16);
+  border-color: rgb(var(--t-accent-rgb));
+  color: rgb(var(--t-accent-rgb));
+}


### PR DESCRIPTION
## Bug / Feature
Las 4 ventanas de registro 0.1 (Cosechar, Abonos e insumos, Labores de la finca, Bitácora) nunca se rediseñaron: feas, sin identidad Chagra, sin theme-awareness. Además la **Bitácora estaba rota** (no dejaba ver ni hacer nada). Tarea #22.

## Causa raíz (del fix)
1. **Ruta rota**: `AnalisisProactivoIA` navega a `'bitacora'`, pero App.jsx solo tenía `case 'historial'` (+ `'bitacora_detail'`) → toda esa entrada caía en "Vista no disponible".
2. **Visor muerto**: `WorkerHistory` solo mostraba pendientes + sincronizados de las **últimas 24h** (`logCache.getRecent24h`), nunca el historial completo, y no tenía forma de AGREGAR. Un registro de ayer ya sincronizado desaparecía → "no me deja hacer nada". Bug adicional de **timestamps** (sincronizados en segundos UNIX vs pendientes en ms `Date.now()`) que desordenaba/fechaba mal el feed.

## Cambios
**Fix funcional (UNGATED — va a prod):**
- `App.jsx`: `case 'bitacora'` como alias de `case 'historial'` → `WorkerHistory`; `'bitacora'` añadida a `MODULE_VIEWS` (analítica).
- `WorkerHistory.jsx`: lista **todo** el historial (`logCache.getAll`), filtros por familia (Todo/Cosechas/Insumos/Siembras/Labores/Observaciones), barra **"Agregar a la bitácora"** con accesos a Cosechar/Insumos/Labores/Siembra (vía `chagraNavigate`), estado vacío acogedor con CTAs, feed unificado pendientes+sincronizados, normalización de timestamps (`toMs`).
- Bug menor corregido: `InputLog` (referencia muerta a `subArea`) y `MaintenanceScreen` (`notes` faltaba en el estado inicial → input no controlado).

**Rediseño visual (GATED tras `fincaVivaHomePerfilActivo()`, dev-only):**
- `registro/RegistroShell.jsx` + `RegistroFields.jsx` + `registro-shell.css`: caparazón común y primitivas de formulario, **theme-aware** (todo sale de `--c-*` / `--t-accent-rgb`; coherente y legible AA en biopunk/nature/minimalista/verde-vivo).
- Las 4 pantallas comparten familia visual: sello Chagra con el acento del tema, halo, hairline, microcopy campesino (tú/usted Colombia, cero voseo), CTA sólida del acento, tarjeta de consejo.
- Cosechar/Insumos/Labores: branch `if (flag) <RegistroShell…> else <legacy>` → con la flag **OFF** cada pantalla queda EXACTA como hoy.

## Tests
- 35 vitest passing: las 4 pantallas montan con flag ON/OFF; los formularios siguen guardando/validando con el rediseño; la Bitácora monta desde `'bitacora'` y `'historial'`; estado vacío con CTA; ruta anclada (`bitacora-route.test`).
- `vite build` verde, `eslint` 0 errores (sin no-undef/no-unused/exhaustive-deps).
- Evidencia visual: artboards rasterizados (rsvg) ANTES/DESPUÉS de las 4 pantallas en biopunk + nature, enviados a Telegram del operador para aprobación.

Refs: tarea #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)