### PR TITLE
fix(temas): contraste de registro verde-vivo + bloque finca-viva + juegos en temas claros (gated)

### DIFF
--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -903,7 +903,14 @@
 [data-theme="minimalista"] .fvh {
   --fvh-on-cielo: #20301a;
   --fvh-on-cielo-suave: #33472a;
-  --fvh-on-cielo-acento: rgb(var(--c-emerald-500));
+  /* ACENTO (eyebrow "SU AGENTE AGROECOLÓGICO" + el <em> "su finca viva"): antes
+     era --c-emerald-500, que sobre el cielo del shell de los temas claros daba
+     SOLO 3.08–4.03:1 en el stop superior (turquesa/crema/papel) → bajo AA y se
+     veía "teal/olivo lavado" (audit Bug 1; #1886 cubrió el globo/perfil pero NO
+     este bloque). Subimos a --c-emerald-700 (verde bosque por tema): 5.10:1
+     verde-vivo · 5.80:1 nature · 9.63:1 minimalista en el stop superior = AA en
+     los 4. El <em> es texto grande (26px bold) y de todos modos pasa large-AA. */
+  --fvh-on-cielo-acento: rgb(var(--c-emerald-700));
   --fvh-on-cielo-sombra: 0 1px 2px rgba(255, 255, 255, 0.55);
   --fvh-on-cielo-div: linear-gradient(90deg, rgba(38, 51, 31, 0.2), transparent);
 }

--- a/src/components/registro/registro-shell.css
+++ b/src/components/registro/registro-shell.css
@@ -15,11 +15,17 @@
  * ========================================================================== */
 
 .registro-shell {
-  /* Fondo base = superficie del tema, con un sutil halo del acento arriba
-     para dar identidad sin romper contraste. */
-  background:
-    radial-gradient(120% 60% at 50% -10%, rgb(var(--t-accent-rgb) / 0.10), transparent 60%),
-    rgb(var(--c-surface));
+  /* Fondo base = superficie SÓLIDA del tema, con un sutil halo del acento arriba
+     para dar identidad sin romper contraste. La capa de color del tema es opaca
+     (--c-surface no lleva alpha en ningún tema) y se pinta como `background-color`
+     ADEMÁS del shorthand: así la superficie del tema queda bajo TODO el formulario
+     —labels, intro/tip e inputs por igual— y la foto de fondo de la app jamás se
+     cuela detrás de las etiquetas (audit Bug 2). En verde-vivo la foto biopunk ya
+     no se pinta (index.css la exime como en nature/minimalista), pero dejamos la
+     superficie sólida explícita como cinturón-y-tirantes. */
+  background-color: rgb(var(--c-surface));
+  background-image:
+    radial-gradient(120% 60% at 50% -10%, rgb(var(--t-accent-rgb) / 0.10), transparent 60%);
   color: rgb(var(--c-slate-100));
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -316,12 +316,25 @@
   }
 
   /* CRÍTICO (theming P0 2026-06-04): en temas claros la foto biopunk OSCURA
-   * (/fondo-biopunk-4.jpg) + su overlay slate-950 se filtraba detrás de la UI
-   * clara → "integra pésimo". En minimalista/nature el fondo es liso tipo papel,
-   * como en los demos. Quitamos foto, overlay y patrón biopunk; el color base
-   * sale del token --c-slate-950 (papel/crema del tema). */
+   * (/fondo-biopunk-4.jpg, o /fondo-biopunk-1.jpg por defecto) + su overlay
+   * slate-950 se filtraba detrás de la UI clara → "integra pésimo". En
+   * minimalista/nature el fondo es liso tipo papel, como en los demos. Quitamos
+   * foto, overlay y patrón biopunk; el color base sale del token --c-slate-950
+   * (papel/crema del tema).
+   *
+   * VERDE VIVO (audit Bug 2, P0): es un tema CLARO (crema frondosa #eef3e2) que
+   * se añadió DESPUÉS (#1871) y quedó FUERA de esta exención → seguía pintando
+   * la foto biopunk oscura tras toda la app. Eso es lo que se colaba detrás de
+   * los formularios de Registro (las labels/intro sin tarjeta caían sobre la
+   * foto → ratio 1.34–2.31, ilegible) y lavaba el HUD de Defensores. Con
+   * verde-vivo aquí, su fondo pasa a superficie sólida del tema igual que
+   * nature/minimalista (el patrón de los 4 que ya hace bien el Directorio), y la
+   * superficie sólida de RegistroShell queda bajo TODO el formulario, no solo
+   * los inputs. Su FX ya estaba OFF (index.css §verde-vivo: --fx-bg-pattern:0),
+   * así que esto es coherente con su diseño "degradado vivo, sin foto". */
   [data-theme="minimalista"] body.app-bg-biodiversidad,
-  [data-theme="nature"] body.app-bg-biodiversidad {
+  [data-theme="nature"] body.app-bg-biodiversidad,
+  [data-theme="verde-vivo"] body.app-bg-biodiversidad {
     background-image: none !important;
     background-color: rgb(var(--c-slate-950)) !important;
   }
@@ -340,7 +353,8 @@
   }
 
   [data-theme="minimalista"] .bg-biopunk-pattern,
-  [data-theme="nature"] .bg-biopunk-pattern {
+  [data-theme="nature"] .bg-biopunk-pattern,
+  [data-theme="verde-vivo"] .bg-biopunk-pattern {
     background-image: none !important;
   }
 

--- a/src/styles/clima-atmosfera.css
+++ b/src/styles/clima-atmosfera.css
@@ -81,13 +81,21 @@ html:not([data-theme])[data-luz="noche"] {
   --w-night-a: 0;
 }
 /* TEMAS CLAROS SIEMPRE CLAROS (operador 2026-06-20: "siempre claro como los
- * demos"). nature y minimalista NO adoptan la veladura navy ni el tinte azul
- * de noche: conservan su atmósfera diurna a cualquier hora. !important para
- * ganar sobre las reglas de clima nocturno (p.ej. niebla/lluvia de noche, de
- * igual especificidad) sin depender del orden de declaración. La modulación
- * climática DIURNA (nubes/lluvia/sol) se mantiene intacta. */
+ * demos"). nature, minimalista y verde-vivo NO adoptan la veladura navy ni el
+ * tinte azul de noche: conservan su atmósfera diurna a cualquier hora.
+ * !important para ganar sobre las reglas de clima nocturno (p.ej. niebla/lluvia
+ * de noche, de igual especificidad) sin depender del orden de declaración. La
+ * modulación climática DIURNA (nubes/lluvia/sol) se mantiene intacta.
+ *
+ * VERDE VIVO (audit "OJO"): es un tema CLARO igual que nature/minimalista, pero
+ * quedó FUERA de esta exención (se añadió en #1871, después de #1747). De noche
+ * el velo navy plano (0.25) + tinte azul (0.10) se sumaba sobre su crema y
+ * AGRAVABA el lavado del bloque finca-viva y demás texto claro. Con verde-vivo
+ * aquí, los 3 temas claros quedan exentos por igual. Biopunk (base, sin
+ * data-theme) conserva su modo nocturno por diseño. */
 html[data-theme="nature"][data-luz="noche"],
-html[data-theme="minimalista"][data-luz="noche"] {
+html[data-theme="minimalista"][data-luz="noche"],
+html[data-theme="verde-vivo"][data-luz="noche"] {
   --w-night-a: 0 !important;
   --w-tint-a: 0 !important;
 }

--- a/src/styles/juego-pulido.css
+++ b/src/styles/juego-pulido.css
@@ -303,6 +303,23 @@
 }
 .fvh-skin .jp-mfv-entrada:hover { box-shadow: var(--jp-sombra-2); }
 
+/* En los TEMAS CLAROS la tarjeta conservaba su degradado Tailwind translúcido
+   (p.ej. el Doom: from-orange-600/40 to-amber-800/40 = KHAKI) sobre la crema del
+   tema → la descripción `jp-tinta-suave` oscura caía sobre khaki = ratio 1.8–3.2,
+   bajo AA (audit Bug 3: "Doom intro 'Recorre la finca…' gris-oscuro sobre
+   khaki-oscuro"). El comentario de Fase 2.1 asumía "ya tienen fondo del tema",
+   pero la regla nunca lo seteaba. Aquí SÍ retiñimos el fondo a la superficie del
+   tema (un velo del acento del color de cada tarjeta da identidad sin lavar): la
+   tinta (13.8:1) y la suave (5.9:1 verde-vivo) leen AA. Solo claros; biopunk
+   (sin data-theme) conserva su degradado neón sobre navy. verde-vivo entra como
+   tema CLARO que es (estaba mal agrupado con biopunk). */
+[data-theme="nature"] .fvh-skin .jp-mfv-entrada,
+[data-theme="minimalista"] .fvh-skin .jp-mfv-entrada,
+[data-theme="verde-vivo"] .fvh-skin .jp-mfv-entrada {
+  background-image: linear-gradient(160deg, var(--jp-raised), var(--jp-card)) !important;
+  border-color: var(--jp-borde) !important;
+}
+
 /* Marco del mundo vivo (FincaWorldScene): el halo de identidad + marco pulido
    se aplican vía .fv-scene en temas-fase2.css; aquí solo redondeamos un punto. */
 .fvh-skin.fv-scene { border-radius: 1.35rem !important; }
@@ -344,10 +361,13 @@
 .fvh-skin .jp-tinta-suave { color: var(--jp-tinta-3) !important; }
 /* Acento de VIDA (verde del tema) para piezas de TEXTO legibles (no decorativas):
    en oscuros es el emerald vivo; en claros la salvia profunda AA del tema. Útil
-   para etiquetas tipo "controla a" / "por qué funciona" / "%". */
+   para etiquetas tipo "controla a" / "por qué funciona" / "%".
+   verde-vivo es CLARO (audit Bug 3): con el default emerald-300 daba 4.48:1
+   sobre su tarjeta (bajo AA); --c-emerald-500 (#287a34) sube a 5.21:1 = AA. */
 .fvh-skin .jp-acento-vida { color: var(--jp-vida-texto) !important; }
 [data-theme="nature"] .fvh-skin,
-[data-theme="minimalista"] .fvh-skin { --jp-vida-texto: rgb(var(--c-emerald-500, 16 185 129)); }
+[data-theme="minimalista"] .fvh-skin,
+[data-theme="verde-vivo"] .fvh-skin { --jp-vida-texto: rgb(var(--c-emerald-500, 16 185 129)); }
 
 /* ── MI FINCA VIVA (hub): kicker de nivel, título del mundo, mensaje del mundo,
    descripciones de las tarjetas de subjuego, barra de progreso, misiones,
@@ -367,20 +387,26 @@
 .fvh-skin .jp-doom-ficha .jp-tinta-suave { color: var(--jp-tinta-3) !important; }
 
 /* CUE de color plaga (rojo) / benéfico (ámbar): conserva su SEMÁNTICA en los 4
-   temas. En oscuros (biopunk/verde-vivo) queda su tono claro original (no se
-   toca). En CLAROS (nature/minimalista) la ficha tiene fondo blanco/crema → el
-   rojo/ámbar pálido se lavaba; lo bajamos a un tono profundo AA (≥4.8) que sigue
-   leyéndose como rojo/ámbar (CUE intacto). */
+   temas. En oscuro (biopunk, SIN data-theme) queda su tono claro original (no se
+   toca). En los 3 temas CLAROS (nature/minimalista/VERDE-VIVO) la ficha tiene
+   fondo blanco/crema → el rojo/ámbar pálido se lavaba (red-200 1.41:1 ·
+   amber-200 1.21:1 en verde-vivo); lo bajamos a un tono profundo AA (≥5.7 en
+   verde-vivo) que sigue leyéndose como rojo/ámbar (CUE intacto).
+   verde-vivo es CLARO y estaba ERRÓNEAMENTE agrupado con biopunk (audit Bug 3). */
 [data-theme="nature"] .fvh-skin .jp-doom-plaga,
-[data-theme="minimalista"] .fvh-skin .jp-doom-plaga { color: rgb(190 30 30) !important; }
+[data-theme="minimalista"] .fvh-skin .jp-doom-plaga,
+[data-theme="verde-vivo"] .fvh-skin .jp-doom-plaga { color: rgb(190 30 30) !important; }
 [data-theme="nature"] .fvh-skin .jp-doom-benefico,
-[data-theme="minimalista"] .fvh-skin .jp-doom-benefico { color: rgb(var(--c-amber-700, 180 83 9)) !important; }
+[data-theme="minimalista"] .fvh-skin .jp-doom-benefico,
+[data-theme="verde-vivo"] .fvh-skin .jp-doom-benefico { color: rgb(var(--c-amber-700, 180 83 9)) !important; }
 
 /* Banner de lección del Doom (la decoración mirada): tenía fondo amber-950/50
-   (oscuro translúcido). En claros lo asentamos sobre superficie del tema con un
-   tinte solar para que el texto-tinta se lea. En oscuros queda como hoy. */
+   (oscuro translúcido). En los temas claros lo asentamos sobre superficie del
+   tema con un tinte solar para que el texto-tinta se lea. En biopunk queda como
+   hoy. (verde-vivo incluido: tema claro.) */
 [data-theme="nature"] .fvh-skin .jp-doom-leccion,
-[data-theme="minimalista"] .fvh-skin .jp-doom-leccion {
+[data-theme="minimalista"] .fvh-skin .jp-doom-leccion,
+[data-theme="verde-vivo"] .fvh-skin .jp-doom-leccion {
   background: linear-gradient(180deg, var(--jp-raised), var(--jp-card)) !important;
   border-color: rgb(var(--c-amber-500, 245 158 11) / 0.45) !important;
 }
@@ -388,12 +414,31 @@
 /* HUD superior del Doom (ronda/plagas/puntaje/combo/vitalidad): vive sobre
    .jp-doom-hud, cuyo fondo ya viró a superficie del tema. Sus números usaban
    utilidades vivas (emerald-200/amber-300/lime-300/orange-300/white) que se
-   lavaban en claros. Las tonamos a la tinta del tema SOLO en claros; el color
-   se mantiene en oscuros (donde el fondo es navy). */
+   lavaban en claros (1.09–1.20:1 en verde-vivo). Las tonamos a la tinta del tema
+   (13.81:1) SOLO en los 3 temas claros; el color se mantiene en biopunk (donde
+   el fondo es navy). verde-vivo es CLARO → entra aquí (audit Bug 3). */
 [data-theme="nature"] .fvh-skin .jp-doom-hud [class*="text-"],
 [data-theme="minimalista"] .fvh-skin .jp-doom-hud [class*="text-"],
+[data-theme="verde-vivo"] .fvh-skin .jp-doom-hud [class*="text-"],
 [data-theme="nature"] .fvh-skin .jp-doom-vital [class*="text-"],
-[data-theme="minimalista"] .fvh-skin .jp-doom-vital [class*="text-"] {
+[data-theme="minimalista"] .fvh-skin .jp-doom-vital [class*="text-"],
+[data-theme="verde-vivo"] .fvh-skin .jp-doom-vital [class*="text-"] {
+  color: var(--jp-tinta) !important;
+}
+
+/* HUD de DEFENSORES (.df-hud: corazones de energía + "Puntos"/puntaje) y el
+   subtítulo del nivel: usan utilidades vivas (text-emerald-200/70,
+   text-emerald-300/70, text-white) pensadas para fondo oscuro. En los 3 temas
+   claros el HUD se apoya sobre la superficie del tema (la foto de la app ya no
+   se cuela en verde-vivo) → esos tonos claros se lavaban (audit Bug 3:
+   "Defensores HUD/header lavado en verde-vivo"). Los tonamos a la tinta del tema
+   (≥13:1) SOLO en claros; en biopunk se mantienen vivos sobre el navy. */
+[data-theme="nature"] .fvh-skin .df-hud [class*="text-"],
+[data-theme="minimalista"] .fvh-skin .df-hud [class*="text-"],
+[data-theme="verde-vivo"] .fvh-skin .df-hud [class*="text-"],
+[data-theme="nature"] .fvh-skin [data-testid="defensores-subtitulo"],
+[data-theme="minimalista"] .fvh-skin [data-testid="defensores-subtitulo"],
+[data-theme="verde-vivo"] .fvh-skin [data-testid="defensores-subtitulo"] {
   color: var(--jp-tinta) !important;
 }
 

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -624,6 +624,60 @@
   text-shadow: none !important;
 }
 
+/* ───────────────────────────────────────────────────────────────────────────
+ * PILLS/CHIPS TENUES en temas claros (audit Bug 4, P3): los chips de leyenda del
+ * Calendario (Siembra/Cosecha/Nutrición/Fenología/Sanidad) usan texto
+ * `text-{teal,emerald,violet,rose}-200` (muy claro) sobre un relleno
+ * `bg-{color}-500/20` → en los 3 temas claros quedaba claro-sobre-claro (~1.2:1).
+ * En biopunk (oscuro, sin data-theme) se ven bien y NO se tocan.
+ *
+ * Subimos el texto al tono -800 del color (5.5–6.9:1 sobre el relleno) y ALIGERAMOS
+ * el relleno (de /20 a /14) para que el tono profundo respire. Conserva la
+ * SEMÁNTICA de color de cada capa (sigue leyéndose teal/verde/violeta/rosa/ámbar).
+ * Solo afecta a estos chips por la combinación de clases; el resto de la app que
+ * use estos colores ya tenía sus propias reglas. */
+[data-theme="nature"] .text-teal-200,
+[data-theme="minimalista"] .text-teal-200,
+[data-theme="verde-vivo"] .text-teal-200{ color: rgb(17 94 89) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-emerald-200,
+[data-theme="minimalista"] .text-emerald-200,
+[data-theme="verde-vivo"] .text-emerald-200{ color: rgb(22 101 52) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-violet-200,
+[data-theme="minimalista"] .text-violet-200,
+[data-theme="verde-vivo"] .text-violet-200{ color: rgb(91 33 182) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-rose-200,
+[data-theme="minimalista"] .text-rose-200,
+[data-theme="verde-vivo"] .text-rose-200{ color: rgb(159 18 57) !important; text-shadow: none !important; }
+/* Relleno de los chips de leyenda (bg-{color}-500/20) → /14: más papel, el tono
+ * -800 del texto destaca. (text-amber-200 ya lo cubre la regla de arriba.) */
+[data-theme="nature"] .bg-teal-500\/20,
+[data-theme="minimalista"] .bg-teal-500\/20,
+[data-theme="verde-vivo"] .bg-teal-500\/20{ background-color: rgb(20 184 166 / 0.14) !important; }
+[data-theme="nature"] .bg-emerald-500\/20,
+[data-theme="minimalista"] .bg-emerald-500\/20,
+[data-theme="verde-vivo"] .bg-emerald-500\/20{ background-color: rgb(16 185 129 / 0.14) !important; }
+[data-theme="nature"] .bg-violet-500\/20,
+[data-theme="minimalista"] .bg-violet-500\/20,
+[data-theme="verde-vivo"] .bg-violet-500\/20{ background-color: rgb(139 92 246 / 0.14) !important; }
+[data-theme="nature"] .bg-rose-500\/20,
+[data-theme="minimalista"] .bg-rose-500\/20,
+[data-theme="verde-vivo"] .bg-rose-500\/20{ background-color: rgb(244 63 94 / 0.14) !important; }
+[data-theme="nature"] .bg-amber-500\/20,
+[data-theme="minimalista"] .bg-amber-500\/20,
+[data-theme="verde-vivo"] .bg-amber-500\/20{ background-color: rgb(245 158 11 / 0.14) !important; }
+
+/* Pill "en preparación" del FAQ (text-amber-400/70 sobre bg-amber-400/10): el
+ * alpha /70 la dejaba fantasmal en claros. La afirmamos al ámbar profundo del
+ * tema (color sólido, sin el /70) y reforzamos su relleno para que el chip se
+ * distinga del fondo. El modificador de opacidad /70 es una clase aparte
+ * (.text-amber-400\/70), no la cubre la regla .text-amber-400 de arriba. */
+[data-theme="nature"] .text-amber-400\/70,
+[data-theme="minimalista"] .text-amber-400\/70,
+[data-theme="verde-vivo"] .text-amber-400\/70{ color: rgb(160 76 20) !important; text-shadow: none !important; }
+[data-theme="nature"] .bg-amber-400\/10,
+[data-theme="minimalista"] .bg-amber-400\/10,
+[data-theme="verde-vivo"] .bg-amber-400\/10{ background-color: rgb(245 158 11 / 0.16) !important; }
+
 /* Bordes blancos (sólidos y con opacidad) → línea sutil del tema. */
 [data-theme="minimalista"] .border-white,
 [data-theme="minimalista"] [class*="border-white\/"],


### PR DESCRIPTION
## Bug / Feature
Fixes de contraste/legibilidad en los **temas CLAROS** (nature/minimalista/verde-vivo) hallados por el test visual diferencial. Causa raíz común: **verde-vivo (tema claro) estaba mal agrupado con biopunk (oscuro)** en varias reglas, o quedó fuera de exenciones que sí cubrían nature/minimalista.

## Causa raíz
- **Bug 2 (P0)** Registro verde-vivo: la foto biopunk de fondo de la app (`/fondo-biopunk-1.jpg`) se colaba detrás de los formularios — solo los inputs tenían tarjeta opaca; los labels/intro caían sobre la foto (1.31–1.79:1, ilegible). verde-vivo había quedado **fuera de la supresión de foto** que nature/minimalista ya tienen (`index.css §app-bg-biodiversidad`, theming-P0).
- **Bug 1 (P1)** Bloque finca-viva: el eyebrow "SU AGENTE AGROECOLÓGICO" + el `<em>` "su finca viva" usaban `--c-emerald-500` → **3.08–4.03:1** en el stop superior del cielo (bajo AA). #1886 cubrió globo/perfil pero no este bloque.
- **Bug 3 (P2)** Juegos: Doom HUD/lección/CUE plaga-benéfico + tarjeta de entrada del Doom (texto oscuro sobre khaki, 1.8–3.2:1) + HUD/subtítulo de Defensores se lavaban en verde-vivo (la tarjeta también en minimalista). verde-vivo excluido de las reglas de "claros".
- **Bug 4 (P3)** Pills tenues: chips de leyenda del Calendario (`text-{teal,emerald,violet,rose}-200` sobre relleno `/20`) + pill "en preparación" del FAQ (`amber-400/70`), claro-sobre-claro en temas claros.
- **OJO** verde-vivo no estaba exento del velo nocturno `data-luz=noche` (clima-atmosfera.css, #1747) → el velo navy agravaba el lavado.

## Cambios (solo CSS)
- `src/index.css` — `verde-vivo` entra en la supresión de foto/patrón biopunk → superficie sólida del tema como nature/minimalista (Bug 2 + OJO root).
- `src/components/registro/registro-shell.css` — superficie del tema explícita (`background-color`) bajo TODO el formulario, no solo los inputs (Bug 2).
- `src/components/dashboard/finca-viva-hero.css` — acento del hero `--c-emerald-500` → `--c-emerald-700` en temas claros (Bug 1): 5.10 vv · 5.80 nature · 9.63 min.
- `src/styles/juego-pulido.css` — `verde-vivo` añadido a Doom HUD/lección/plaga/benéfico + `--jp-vida-texto` AA; retint del fondo de `.jp-mfv-entrada` a superficie del tema; HUD/subtítulo de Defensores tonados (Bug 3).
- `src/styles/themes.css` — chips de leyenda del Calendario a tono `-800` (≥5.5:1) + relleno aligerado; pill FAQ afirmada; solo temas claros (Bug 4).
- `src/styles/clima-atmosfera.css` — `verde-vivo` exento del velo nocturno junto a nature/minimalista (OJO).

Todo **gated** tras `fincaVivaHomePerfilActivo()` (registro/finca-viva/juegos) o scopeado a `[data-theme]` claros → **biopunk = prod default queda pixel-idéntico**.

## Ratios logrados (verificados por tokens, WCAG AA ≥4.5)
| Caso | tema | antes | después |
|---|---|---|---|
| Registro labels (¿Qué cosechaste?) | verde-vivo | 1.31 | **7.72** |
| Registro intro/unidad | verde-vivo | 1.79 | **5.65** |
| Registro título | verde-vivo | 1.32 | **13.33** |
| Eyebrow/énfasis finca-viva (stop sup.) | verde-vivo | 3.08 | **5.10** |
| Eyebrow/énfasis finca-viva | nature / min | 3.78 / 4.03 | **5.80 / 9.63** |
| Doom/Defensores HUD | verde-vivo | 1.09–1.20 | **13.81** |
| Doom acento "controla a"/"%" | verde-vivo | 4.48 | **5.21** |
| Doom CUE plaga/benéfico | verde-vivo | 1.21–1.41 | **5.7–6.0** |
| Tarjeta Doom "Recorre…" (descripción) | verde-vivo / min | 1.8–3.2 | **5.85** |
| Chips leyenda Calendario | claros | ~1.2 | **5.5–6.9** |

## Tests
- 356 vitest passing (themes/juego/dashboard/registro/common) — incl. los contratos `temas-fase2-1-contraste`, `themes.coverage`, `registro-redesign`, `ScreenShell.theme`, `FincaVivaResto.noSolapa`.
- `vite build` OK · sin chromium (evidencia rsvg ANTES/DESPUÉS por tokens enviada al operador).

Refs: audit test visual diferencial temas claros; regresión #1886 (no cubrió finca-viva); verde-vivo añadido en #1871 fuera de exenciones de #1747/theming-P0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)