### PR TITLE
feat(app): alerta de precio SIPSA cerca de cosecha (#26)

### DIFF
--- a/src/services/__tests__/cropAlertEngine.test.js
+++ b/src/services/__tests__/cropAlertEngine.test.js
@@ -9,13 +9,15 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { listFarmProcesses, getPestRisksByStage } = vi.hoisted(() => ({
+const { listFarmProcesses, getPestRisksByStage, getPrecioSipsa } = vi.hoisted(() => ({
   listFarmProcesses: vi.fn(),
   getPestRisksByStage: vi.fn(),
+  getPrecioSipsa: vi.fn(),
 }));
 
 vi.mock('../../db/farmProcessCache', () => ({ listFarmProcesses }));
 vi.mock('../climateCycleService', () => ({ getPestRisksByStage }));
+vi.mock('../sidecarClient', () => ({ getPrecioSipsa }));
 
 import { runCropAlerts } from '../cropAlertEngine';
 
@@ -24,10 +26,31 @@ const cycle = (id, stage = 'vegetative', slug = 'coffea_arabica', label = 'Café
   attributes: { current_stage: stage, subject_slug: slug, subject_label: label, status: 'active' },
 });
 
+/** Respuesta del sidecar get_precio_sipsa con precio fresco (latest_price). */
+const precioFresco = (overrides = {}) => ({
+  available: true,
+  action: 'latest_price',
+  price: {
+    fecha: '2026-06-25',
+    producto: 'Papa',
+    producto_id: 'papa',
+    plaza: 'Corabastos, Bogotá',
+    plaza_id: 'corabastos_bogota',
+    precio_promedio_cop_kg: 2300,
+    unidad: 'Kilogramo',
+  },
+  central_abastos: 'Corabastos, Bogotá',
+  frescura: { fecha_dato: '2026-06-25', dias_desde_dato: 1, umbral_dias: 3, desactualizado: false, sello: 'fresco' },
+  especie: 'solanum_tuberosum',
+  ...overrides,
+});
+
 let events;
 beforeEach(() => {
   listFarmProcesses.mockReset();
   getPestRisksByStage.mockReset();
+  getPrecioSipsa.mockReset();
+  getPrecioSipsa.mockResolvedValue(null); // por defecto: sidecar sin dato
   events = [];
   vi.spyOn(window, 'dispatchEvent').mockImplementation((ev) => {
     events.push({ name: ev.type, detail: ev.detail });
@@ -55,8 +78,11 @@ describe('cropAlertEngine.runCropAlerts', () => {
     listFarmProcesses.mockResolvedValue([cycle('p2', 'sowing')]);
     getPestRisksByStage.mockReturnValue([]);
     const res = await runCropAlerts();
-    expect(res.cleared).toBe(1);
+    // 2 limpiezas: la de plaga (crop_pest_p2) + la de precio (crop_price_p2,
+    // etapa 'sowing' no aplica al aviso de precio).
+    expect(res.cleared).toBe(2);
     expect(events.some((e) => e.name === 'alertCleared' && e.detail.type === 'crop_pest_p2')).toBe(true);
+    expect(events.some((e) => e.name === 'alertCleared' && e.detail.type === 'crop_price_p2')).toBe(true);
     expect(events.some((e) => e.name === 'alertTriggered')).toBe(false);
   });
 
@@ -65,5 +91,110 @@ describe('cropAlertEngine.runCropAlerts', () => {
     const res = await runCropAlerts();
     expect(res).toEqual({ emitted: 0, cleared: 0 });
     expect(events.length).toBe(0);
+  });
+});
+
+describe('cropAlertEngine — alerta de precio cerca de cosecha (#26)', () => {
+  beforeEach(() => {
+    // Sin riesgo de plaga: aislamos el track de precio.
+    getPestRisksByStage.mockReturnValue([]);
+  });
+
+  it('emite alertTriggered de precio para un cultivo en cosecha con precio fresco', async () => {
+    listFarmProcesses.mockResolvedValue([
+      cycle('h1', 'harvest_window', 'solanum_tuberosum', 'Papa'),
+    ]);
+    getPrecioSipsa.mockResolvedValue(precioFresco());
+
+    const res = await runCropAlerts();
+
+    expect(getPrecioSipsa).toHaveBeenCalledWith('latest_price', { producto: 'papa' });
+    const triggered = events.find((e) => e.name === 'alertTriggered' && e.detail.type === 'crop_price_h1');
+    expect(triggered).toBeTruthy();
+    expect(triggered.detail.severity).toBe('info');
+    expect(triggered.detail.source).toBe('price');
+    expect(triggered.detail.message).toMatch(/papa está para cosechar/i);
+    expect(triggered.detail.message).toMatch(/\$2\.300 COP\/kg/);
+    expect(triggered.detail.message).toMatch(/Corabastos/);
+    expect(triggered.detail.especie).toBe('solanum_tuberosum');
+    expect(triggered.detail.precioCopKg).toBe(2300);
+    expect(res.emitted).toBe(1);
+  });
+
+  it('en fruiting usa el verbo de llenado de fruto', async () => {
+    listFarmProcesses.mockResolvedValue([
+      cycle('h2', 'fruiting', 'solanum_lycopersicum_cerasiforme', 'Tomate'),
+    ]);
+    getPrecioSipsa.mockResolvedValue(
+      precioFresco({
+        price: { fecha: '2026-06-25', producto: 'Tomate', producto_id: 'tomate', plaza: 'Corabastos', plaza_id: 'corabastos', precio_promedio_cop_kg: 3100, unidad: 'Kilogramo' },
+        central_abastos: 'Corabastos',
+        especie: 'solanum_lycopersicum_cerasiforme',
+      }),
+    );
+
+    await runCropAlerts();
+    const triggered = events.find((e) => e.name === 'alertTriggered' && e.detail.type === 'crop_price_h2');
+    expect(triggered).toBeTruthy();
+    expect(triggered.detail.message).toMatch(/va llenando fruto/i);
+    expect(triggered.detail.message).toMatch(/\$3\.100 COP\/kg/);
+  });
+
+  it('NO emite precio si el dato está desactualizado (anti-alucinación)', async () => {
+    listFarmProcesses.mockResolvedValue([
+      cycle('h3', 'harvest_window', 'solanum_tuberosum', 'Papa'),
+    ]);
+    getPrecioSipsa.mockResolvedValue(
+      precioFresco({
+        frescura: { fecha_dato: '2026-05-01', dias_desde_dato: 55, umbral_dias: 3, desactualizado: true, sello: 'desactualizado' },
+      }),
+    );
+
+    await runCropAlerts();
+    expect(events.some((e) => e.name === 'alertTriggered' && e.detail.type === 'crop_price_h3')).toBe(false);
+    expect(events.some((e) => e.name === 'alertCleared' && e.detail.type === 'crop_price_h3')).toBe(true);
+  });
+
+  it('NO emite precio si el sidecar no devuelve dato (federated/offline → null)', async () => {
+    listFarmProcesses.mockResolvedValue([
+      cycle('h4', 'harvest_window', 'solanum_tuberosum', 'Papa'),
+    ]);
+    getPrecioSipsa.mockResolvedValue(null);
+
+    await runCropAlerts();
+    expect(events.some((e) => e.name === 'alertTriggered' && e.detail.type === 'crop_price_h4')).toBe(false);
+    expect(events.some((e) => e.name === 'alertCleared' && e.detail.type === 'crop_price_h4')).toBe(true);
+  });
+
+  it('NO consulta precio si la especie no tiene producto SIPSA mapeado', async () => {
+    listFarmProcesses.mockResolvedValue([
+      cycle('h5', 'harvest_window', 'coffea_arabica', 'Café'),
+    ]);
+
+    await runCropAlerts();
+    expect(getPrecioSipsa).not.toHaveBeenCalled();
+    expect(events.some((e) => e.name === 'alertTriggered' && e.detail.type === 'crop_price_h5')).toBe(false);
+    expect(events.some((e) => e.name === 'alertCleared' && e.detail.type === 'crop_price_h5')).toBe(true);
+  });
+
+  it('NO consulta precio si la etapa no es de cosecha/llenado', async () => {
+    listFarmProcesses.mockResolvedValue([
+      cycle('h6', 'vegetative', 'solanum_tuberosum', 'Papa'),
+    ]);
+
+    await runCropAlerts();
+    expect(getPrecioSipsa).not.toHaveBeenCalled();
+    expect(events.some((e) => e.name === 'alertCleared' && e.detail.type === 'crop_price_h6')).toBe(true);
+  });
+
+  it('degrada limpio si getPrecioSipsa lanza', async () => {
+    listFarmProcesses.mockResolvedValue([
+      cycle('h7', 'harvest_window', 'solanum_tuberosum', 'Papa'),
+    ]);
+    getPrecioSipsa.mockRejectedValue(new Error('network'));
+
+    await runCropAlerts();
+    expect(events.some((e) => e.name === 'alertTriggered' && e.detail.type === 'crop_price_h7')).toBe(false);
+    expect(events.some((e) => e.name === 'alertCleared' && e.detail.type === 'crop_price_h7')).toBe(true);
   });
 });

--- a/src/services/__tests__/sipsaPriceMap.test.js
+++ b/src/services/__tests__/sipsaPriceMap.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSipsaProduct } from '../sipsaPriceMap.js';
+import { resolveSipsaProduct, resolveProductoFromSlug } from '../sipsaPriceMap.js';
 
 describe('resolveSipsaProduct', () => {
   it('match exacto minusculas', () => {
@@ -64,5 +64,39 @@ describe('resolveSipsaProduct', () => {
 
   it('undefined input retorna null', () => {
     expect(resolveSipsaProduct(undefined)).toBeNull();
+  });
+});
+
+describe('resolveProductoFromSlug (índice inverso slug→producto)', () => {
+  it('slug de especie → producto SIPSA: solanum_tuberosum → papa', () => {
+    expect(resolveProductoFromSlug('solanum_tuberosum')).toBe('papa');
+  });
+
+  it('solanum_phureja → papa criolla', () => {
+    expect(resolveProductoFromSlug('solanum_phureja')).toBe('papa criolla');
+  });
+
+  it('persea_americana → aguacate', () => {
+    expect(resolveProductoFromSlug('persea_americana')).toBe('aguacate');
+  });
+
+  it('round-trip: producto → slug → producto base', () => {
+    const slug = resolveSipsaProduct('tomate');
+    expect(resolveProductoFromSlug(slug)).toBe('tomate');
+  });
+
+  it('especie sin producto SIPSA mapeado → null (honesto)', () => {
+    expect(resolveProductoFromSlug('coffea_arabica')).toBeNull();
+  });
+
+  it('slug compartido (musa_paradisiaca: platano/banano) → primero declarado', () => {
+    // 'banano' aparece antes que 'platano' en el JSON fuente → gana banano.
+    expect(resolveProductoFromSlug('musa_paradisiaca')).toBe('banano');
+  });
+
+  it('input inválido → null', () => {
+    expect(resolveProductoFromSlug('')).toBeNull();
+    expect(resolveProductoFromSlug(null)).toBeNull();
+    expect(resolveProductoFromSlug(undefined)).toBeNull();
   });
 });

--- a/src/services/cropAlertEngine.js
+++ b/src/services/cropAlertEngine.js
@@ -1,5 +1,5 @@
 /**
- * cropAlertEngine — productor de ALERTAS DEL CULTIVO (plaga/etapa).
+ * cropAlertEngine — productor de ALERTAS DEL CULTIVO (plaga/etapa + precio).
  *
  * Cablea el track de alertas del subsistema FarmProcess (PR #1370, ADR-049) que
  * estaba "oscuro". Lee los ciclos activos de IndexedDB (farmProcessCache) y, por
@@ -11,12 +11,38 @@
  * Reusa la infraestructura existente de alertEngine (clima): cada alerta tiene
  * un `type` estable (`crop_pest_<processId>`) para de-dup/limpieza, y emite
  * 'alertCleared' cuando el riesgo desaparece.
+ *
+ * # Alerta de PRECIO cerca de cosecha (chagra #26)
+ *
+ * Cuando un ciclo está en ventana de cosecha (`harvest_window`) o llenado de
+ * fruto (`fruiting`), consulta el precio SIPSA vigente del producto vía el
+ * sidecar (`get_precio_sipsa`, resolver producto→especie cableado en chagra-pro)
+ * y emite un aviso accionable: "tu papa está para cosechar; hoy está a X COP/kg
+ * en <central de abastos>". El producto SIPSA se resuelve desde el `subject_slug`
+ * del ciclo (`resolveProductoFromSlug`, mapa PR #1858).
+ *
+ * Anti-alucinación (regla dura del marketplace, precioReferencia.js): SOLO se
+ * emite si el sidecar devuelve un precio FRESCO (`available:true` + `frescura`
+ * no desactualizada). Sin dato, dato viejo, especie sin producto SIPSA, sidecar
+ * apagado u offline → NO se emite alerta (se limpia la previa). NUNCA un número
+ * inventado.
  */
 import { listFarmProcesses } from '../db/farmProcessCache';
 import { getPestRisksByStage } from './climateCycleService';
 import { getEnsoServicePhase, getEnsoLabel } from './ensoService';
+import { getPrecioSipsa } from './sidecarClient';
+import { resolveProductoFromSlug } from './sipsaPriceMap';
 
 const SEVERITY_BY_RISK = { 'crítico': 'danger', critico: 'danger', alto: 'warning' };
+
+/** Etapas en las que tiene sentido avisar el precio de mercado del producto. */
+const PRECIO_STAGES = new Set(['harvest_window', 'fruiting']);
+
+/** Formatea un precio COP/kg como entero con separador de miles colombiano. */
+function formatCop(valor) {
+  if (typeof valor !== 'number' || !Number.isFinite(valor)) return null;
+  return `$${Math.round(valor).toLocaleString('es-CO')}`;
+}
 
 function emit(name, detail) {
   try {
@@ -26,6 +52,80 @@ function emit(name, detail) {
   } catch {
     /* SSR/test sin window — noop */
   }
+}
+
+/**
+ * Evalúa la alerta de PRECIO cerca de cosecha para un ciclo (#26).
+ *
+ * Solo procede si la etapa es de cosecha/llenado y la especie tiene producto
+ * SIPSA mapeado. Consulta el precio vigente vía sidecar y emite el aviso SOLO
+ * si el dato es fresco. En cualquier otro caso (etapa que no aplica, sin
+ * producto mapeado, sidecar off/offline, sin dato, dato desactualizado) limpia
+ * la alerta previa y NO inventa precio.
+ *
+ * @param {string} id — process_id del ciclo (clave de de-dup de la alerta).
+ * @param {object} a — atributos del ciclo (current_stage, subject_slug, ...).
+ * @returns {Promise<{emitted:number, cleared:number}>}
+ */
+async function evalHarvestPriceAlert(id, a) {
+  const type = `crop_price_${id}`;
+
+  // Etapa que no es de cosecha/llenado → asegurar limpieza, sin tocar red.
+  if (!PRECIO_STAGES.has(a.current_stage)) {
+    emit('alertCleared', { type });
+    return { emitted: 0, cleared: 1 };
+  }
+
+  // Especie sin producto SIPSA mapeado → honesto: no hay con qué cotizar.
+  const producto = resolveProductoFromSlug(a.subject_slug);
+  if (!producto) {
+    emit('alertCleared', { type });
+    return { emitted: 0, cleared: 1 };
+  }
+
+  // Consulta el precio vigente. getPrecioSipsa degrada a null (sidecar off /
+  // offline / HTTP error) sin lanzar; envolvemos por si acaso.
+  let res = null;
+  try {
+    res = await getPrecioSipsa('latest_price', { producto });
+  } catch {
+    res = null;
+  }
+
+  // Sin respuesta utilizable, no disponible (federated/no_matches/unavailable),
+  // o dato desactualizado → no inventamos: limpiamos la alerta previa.
+  const precio = res?.price?.precio_promedio_cop_kg;
+  const fresco = res?.available === true
+    && res?.frescura?.desactualizado === false
+    && typeof precio === 'number'
+    && Number.isFinite(precio);
+
+  if (!fresco) {
+    emit('alertCleared', { type });
+    return { emitted: 0, cleared: 1 };
+  }
+
+  const precioFmt = formatCop(precio);
+  const central = res.central_abastos || res.price?.plaza || 'la central de abastos';
+  const cultivo = a.subject_label || 'tu cultivo';
+  const cosechaVerbo = a.current_stage === 'harvest_window'
+    ? 'está para cosechar'
+    : 'va llenando fruto';
+
+  emit('alertTriggered', {
+    type,
+    severity: 'info',
+    title: `Precio de mercado: ${cultivo}`,
+    message: `Tu ${cultivo.toLowerCase()} ${cosechaVerbo}; hoy está a ${precioFmt} COP/kg en ${central} (precio mayorista SIPSA).`,
+    source: 'price',
+    processId: id,
+    producto,
+    especie: res.especie || a.subject_slug || null,
+    precioCopKg: Math.round(precio),
+    central,
+    fechaDato: res.price?.fecha || res.frescura?.fecha_dato || null,
+  });
+  return { emitted: 1, cleared: 0 };
 }
 
 /**
@@ -71,6 +171,11 @@ export async function runCropAlerts() {
       emit('alertCleared', { type });
       cleared++;
     }
+
+    // Alerta de PRECIO cerca de cosecha (#26) — solo en harvest_window/fruiting.
+    const priceDelta = await evalHarvestPriceAlert(id, a);
+    emitted += priceDelta.emitted;
+    cleared += priceDelta.cleared;
   }
 
   // Alerta de TEMPORADA ENSO (El Niño/La Niña) — una sola, no por ciclo. Solo

--- a/src/services/sipsaPriceMap.js
+++ b/src/services/sipsaPriceMap.js
@@ -5,11 +5,41 @@ const fold = (s) =>
     .toString()
     .toLowerCase()
     .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[̀-ͯ]/g, '')
     .trim()
     .replace(/\s+/g, ' ');
 
 export function resolveSipsaProduct(nombreSipsa) {
   const key = fold(nombreSipsa);
   return sipsaProductMap[key] || null;
+}
+
+/**
+ * Índice inverso slug de especie → nombre de producto SIPSA (la clave del mapa).
+ * Construido una sola vez. Si dos productos comparten slug (p. ej. platano y
+ * banano → musa_paradisiaca; frijol y habichuela → phaseolus_vulgaris), gana el
+ * PRIMERO declarado en el JSON (orden de inserción) — determinista. Excluye la
+ * clave `_comment` del JSON.
+ */
+const slugToProducto = (() => {
+  const idx = {};
+  for (const [producto, slug] of Object.entries(sipsaProductMap)) {
+    if (producto.startsWith('_')) continue;
+    if (!Object.prototype.hasOwnProperty.call(idx, slug)) idx[slug] = producto;
+  }
+  return idx;
+})();
+
+/**
+ * Resuelve el nombre de producto SIPSA a partir del slug de especie del
+ * catálogo (`subject_slug` de un ciclo). Devuelve la clave del mapa (p. ej.
+ * 'papa', 'tomate', 'aguacate') para consultar precios, o `null` si la especie
+ * no tiene producto SIPSA mapeado (honesto, no inventa).
+ *
+ * @param {string} slug — slug de especie (`solanum_tuberosum`).
+ * @returns {string|null} nombre de producto SIPSA o null.
+ */
+export function resolveProductoFromSlug(slug) {
+  if (typeof slug !== 'string' || !slug.trim()) return null;
+  return slugToProducto[slug.trim()] || null;
 }


### PR DESCRIPTION
## Feature
Cierra #26. Cuando un cultivo del usuario está en ventana de cosecha, mostrar un aviso con el precio SIPSA vigente de ese producto — "tu papa está para cosechar; hoy está a \$2.300 COP/kg en Corabastos".

## Cambios
- `src/services/cropAlertEngine.js`: nuevo track de alerta de precio. Para cada ciclo activo en etapa `harvest_window` o `fruiting`, resuelve el producto SIPSA desde `subject_slug`, consulta `get_precio_sipsa` (sidecar) y emite `alertTriggered` con `type: crop_price_<id>`, `severity: 'info'`, `source: 'price'`. Mismo canal que clima/plaga → `useAlertStore` → Hoy en Finca.
- `src/services/sipsaPriceMap.js`: índice inverso `resolveProductoFromSlug(slug)` (slug de especie → producto SIPSA) construido del mapa de PR #1858. Slug compartido (platano/banano) → primero declarado, determinista.

## Anti-alucinación
Regla dura del marketplace (`precioReferencia.js`): la alerta SOLO se emite si el sidecar devuelve precio **fresco** (`available:true` + `frescura.desactualizado === false` + precio numérico). Sin dato / dato viejo / especie sin producto SIPSA / sidecar off / offline → se limpia la alerta previa, **nunca** un número inventado. El precio resuelto depende del resolver producto→especie cableado en chagra-pro PR #270.

## Tests
- `cropAlertEngine.test.js`: +7 casos (cosecha con precio fresco → aviso `info`; `fruiting` usa verbo "llenando fruto"; dato desactualizado → no emite; sidecar null → no emite; especie sin producto SIPSA → no consulta; etapa no-cosecha → no consulta; `getPrecioSipsa` lanza → degrada limpio). Ajustado el conteo de `cleared` del caso existente.
- `sipsaPriceMap.test.js`: +7 casos del índice inverso (papa/aguacate/papa criolla, round-trip, especie sin mapeo → null, slug compartido, input inválido).
- 31/31 verdes en los archivos tocados; suites de alertEngine/HoyEnFinca/store sin regresión (148/148). `vite build` OK · eslint `--max-warnings=0` limpio · cero voseo.

Español Colombia. Refs: #26, chagra-pro PR #270, PR #1858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)