### PR TITLE
feat(home): colibrí 3D de prueba en home Finca Viva + FAB (dev-only)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -53,6 +53,9 @@ jobs:
           VITE_HA_ACCESS_TOKEN: ${{ secrets.VITE_HA_ACCESS_TOKEN }}
           VITE_USE_SIDECAR_AGRO_MCP: "true"
           VITE_FINCA_VIVA_HOME_PERFIL: "true"
+          # PRUEBA dev-only: colibrí 3D en el home Finca Viva + el FAB del agente.
+          # Solo en dev; en prod (deploy.yml) esta flag NO existe → colibrí 2D.
+          VITE_COLIBRI_3D: "true"
           VITE_CHAGRA_MCP_TOKEN: ${{ secrets.VITE_CHAGRA_MCP_TOKEN }}
 
       - if: env.SKIP_DEPLOY != '1'

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -1,11 +1,18 @@
 import React, { useState, useCallback } from 'react';
 import ChagraAgentAvatar from './ChagraAgentAvatar';
+import ChagraColibri3DLite from './ChagraColibri3DLite';
 import useAgentNotificationStore from '../store/useAgentNotificationStore';
 import usePrefsStore from '../store/usePrefsStore';
 import { isSpeaking, stop, replayLast, isKokoroAvailable } from '../services/ttsService';
 import { agentSounds } from '../services/agentSoundService';
 import { fvhSkinClass } from '../config/fvhSkin';
+import { colibri3dActivo } from '../config/colibri3dFlag';
 import './agent-fab-skin.css';
+
+// PRUEBA dev-only: con la flag VITE_COLIBRI_3D ON (dev) el FAB lleva un colibrí
+// 3D que aletea sutil; con la flag OFF (prod) conserva su avatar 2D actual. Flag
+// de build (no cambia en runtime), por eso se evalúa una vez al cargar el módulo.
+const COLIBRI_3D = colibri3dActivo();
 
 /**
  * AgentFab — Floating Action Button para abrir el agente Chagra IA.
@@ -128,7 +135,16 @@ export default function AgentFab({ onNavigate }) {
         transition: 'transform .18s cubic-bezier(.34,1.56,.64,1), box-shadow .25s ease, background .25s ease, border-color .25s ease',
       }}
     >
-      <ChagraAgentAvatar state={state} size={48} ariaLabel="Chagra IA" glow={responseReady} />
+      {COLIBRI_3D ? (
+        <ChagraColibri3DLite
+          variant="fab"
+          state={state}
+          size={50}
+          ariaLabel="Chagra IA"
+        />
+      ) : (
+        <ChagraAgentAvatar state={state} size={48} ariaLabel="Chagra IA" glow={responseReady} />
+      )}
     </button>
   );
 }

--- a/src/components/ChagraColibri3DCanvas.jsx
+++ b/src/components/ChagraColibri3DCanvas.jsx
@@ -1,0 +1,310 @@
+import React, { useRef, useMemo, useEffect } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+
+/**
+ * ChagraColibri3DCanvas — el lienzo Three.js del colibrí 3D ligero. Vive en su
+ * propio módulo para que `ChagraColibri3DLite` lo cargue de forma perezosa
+ * (lazy) y Three.js NO entre al bundle principal cuando la flag está OFF.
+ *
+ * Geometría/materiales destilados de `ChagraAgentAvatarColibri3D` (mismo plumaje
+ * esmeralda iridiscente → cyan, gorget carmesí, pico largo, ojo con catchlight),
+ * pero recortados para correr en gama baja: menos segmentos, sin halo ni
+ * partículas, una sola luz clave + ambiente cálido.
+ *
+ * Render bajo control (`frameloop="demand"`):
+ *   - `<Driver>` llama `invalidate()` a ~máx 45 fps SOLO si `active` (visible +
+ *     tab al frente) y NO `reducedMotion`. Cuando `active` se apaga, el loop
+ *     deja de invalidar → la GPU no hace nada.
+ *   - Con `reducedMotion` se pinta UN frame estático (sin loop, sin batería).
+ */
+
+const PRESETS = {
+  // Home: revolotea con un arco de vuelo suave cerca de las flores.
+  home: {
+    camera: { position: [0, 0.05, 3.4], fov: 32 },
+    dpr: [1, 1.5],
+    antialias: true,
+    bobAmp: 0.06,
+    driftAmp: 0.22, // arco horizontal suave
+    swayAmp: 0.1, // vaivén vertical del arco
+    yawAmp: 0.5, // gira para encarar el sentido del vuelo
+    flapHz: { idle: 24, thinking: 38, speaking: 28 },
+    scale: 1,
+  },
+  // FAB: vuelo estacionario, sin desplazamiento (sprite chico sobre el botón).
+  fab: {
+    camera: { position: [0, 0.0, 3.0], fov: 34 },
+    dpr: [1, 1.5],
+    antialias: false, // sprite pequeño: el AA casi no se nota y cuesta GPU
+    bobAmp: 0.05,
+    driftAmp: 0,
+    swayAmp: 0,
+    yawAmp: 0.18,
+    flapHz: { idle: 22, thinking: 34, speaking: 30 },
+    scale: 1.18,
+  },
+};
+
+const PLUMAGE_BASE = '#10b981';
+const PLUMAGE_HILITE = '#22d3ee';
+const WING_COLOR = '#34d399';
+const GORGET_COLOR = '#dc2626';
+
+/** Ala curva con aleteo rápido + torsión para que no se vea como cartulina. */
+function Wing({ side, flapHzRef }) {
+  const ref = useRef();
+  const geometry = useMemo(() => {
+    const shape = new THREE.Shape();
+    shape.moveTo(0, 0);
+    shape.bezierCurveTo(0.15, 0.45, 0.65, 0.55, 0.95, 0.18);
+    shape.bezierCurveTo(1.05, -0.05, 0.7, -0.2, 0.35, -0.12);
+    shape.bezierCurveTo(0.15, -0.08, 0.05, -0.04, 0, 0);
+    const geom = new THREE.ShapeGeometry(shape, 16);
+    geom.computeVertexNormals();
+    return geom;
+  }, []);
+
+  useFrame((state) => {
+    if (!ref.current) return;
+    const hz = flapHzRef.current;
+    const t = state.clock.elapsedTime;
+    // Aleteo: amplio y rápido (entre ~-55° y +25°), figura de "ocho" sutil.
+    const flap = Math.sin(t * hz * Math.PI * 2) * 0.7 - 0.3;
+    ref.current.rotation.z = side === 'right' ? flap : -flap;
+    ref.current.rotation.y =
+      side === 'right' ? 0.15 + flap * 0.22 : -0.15 - flap * 0.22;
+  });
+
+  const xPos = side === 'right' ? 0.05 : -0.05;
+  const rotY = side === 'right' ? -0.3 : Math.PI + 0.3;
+
+  return (
+    <mesh ref={ref} position={[xPos, 0.15, 0]} rotation={[0, rotY, 0]}>
+      <primitive object={geometry} attach="geometry" />
+      <meshPhysicalMaterial
+        color={WING_COLOR}
+        metalness={0.3}
+        roughness={0.45}
+        transmission={0.18}
+        thickness={0.3}
+        iridescence={0.85}
+        iridescenceIOR={1.6}
+        clearcoat={0.5}
+        clearcoatRoughness={0.25}
+        side={THREE.DoubleSide}
+        transparent
+        opacity={0.82}
+      />
+    </mesh>
+  );
+}
+
+/** Cuerpo torpedo + vientre claro + cola en abanico (3 plumas, low-poly). */
+function Body() {
+  return (
+    <group>
+      <mesh rotation={[0, 0, -0.18]}>
+        <sphereGeometry args={[0.42, 20, 16]} />
+        <meshPhysicalMaterial
+          color={PLUMAGE_BASE}
+          metalness={0.55}
+          roughness={0.35}
+          iridescence={1.0}
+          iridescenceIOR={1.8}
+          iridescenceThicknessRange={[100, 800]}
+          clearcoat={0.8}
+          clearcoatRoughness={0.2}
+          emissive={PLUMAGE_BASE}
+          emissiveIntensity={0.12}
+        />
+      </mesh>
+      <mesh position={[0.05, -0.18, 0.18]} rotation={[0, 0, -0.18]}>
+        <sphereGeometry args={[0.28, 14, 12]} />
+        <meshStandardMaterial color="#fef3c7" roughness={0.6} transparent opacity={0.5} />
+      </mesh>
+      {[-0.16, 0, 0.16].map((spread, i) => (
+        <mesh
+          key={i}
+          position={[-0.55, -0.05 + spread * 0.2, spread * 0.45]}
+          rotation={[0, spread * 0.6, -0.15]}
+        >
+          <boxGeometry args={[0.32, 0.05, 0.08]} />
+          <meshPhysicalMaterial
+            color={PLUMAGE_HILITE}
+            metalness={0.4}
+            roughness={0.4}
+            iridescence={0.7}
+            clearcoat={0.4}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/** Cabeza + gorget carmesí + pico largo + ojo con catchlight (el detalle vivo). */
+function Head() {
+  return (
+    <group position={[0.36, 0.18, 0]}>
+      <mesh>
+        <sphereGeometry args={[0.22, 18, 14]} />
+        <meshPhysicalMaterial
+          color={PLUMAGE_BASE}
+          metalness={0.6}
+          roughness={0.3}
+          iridescence={1.0}
+          iridescenceIOR={1.9}
+          iridescenceThicknessRange={[200, 600]}
+          clearcoat={0.85}
+          clearcoatRoughness={0.18}
+          emissive={PLUMAGE_BASE}
+          emissiveIntensity={0.15}
+        />
+      </mesh>
+      <mesh position={[0.06, -0.08, 0.12]}>
+        <sphereGeometry args={[0.13, 14, 12]} />
+        <meshStandardMaterial
+          color={GORGET_COLOR}
+          metalness={0.7}
+          roughness={0.25}
+          emissive={GORGET_COLOR}
+          emissiveIntensity={0.4}
+        />
+      </mesh>
+      <mesh position={[0.32, -0.02, 0]} rotation={[0, 0, -Math.PI / 2 + 0.1]}>
+        <coneGeometry args={[0.025, 0.45, 8]} />
+        <meshStandardMaterial color="#0f172a" metalness={0.5} roughness={0.4} />
+      </mesh>
+      <group position={[0.08, 0.04, 0.18]}>
+        <mesh>
+          <sphereGeometry args={[0.05, 12, 10]} />
+          <meshStandardMaterial color="#020617" emissive="#0c0a09" emissiveIntensity={0.3} />
+        </mesh>
+        <mesh position={[0.02, 0.018, 0.035]}>
+          <sphereGeometry args={[0.018, 8, 6]} />
+          <meshBasicMaterial color="#ffffff" />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+const STATE_BOB_MULT = { idle: 1, thinking: 1.3, speaking: 1.7 };
+
+/** El colibrí completo: bob de respiración + arco de vuelo + yaw para encarar. */
+function Hummingbird({ variant, state, flapHzRef, reducedMotion }) {
+  const ref = useRef();
+  const cfg = PRESETS[variant] || PRESETS.home;
+  const bobMult = STATE_BOB_MULT[state] || 1;
+
+  useFrame((s) => {
+    const g = ref.current;
+    if (!g) return;
+    if (reducedMotion) {
+      // Pose en reposo, alas semiabiertas, sin movimiento.
+      g.position.set(0, 0, 0);
+      g.rotation.set(0, 0, 0);
+      return;
+    }
+    const t = s.clock.elapsedTime;
+    // Bob de respiración (vertical, suave).
+    const bob = Math.sin(t * 1.6) * cfg.bobAmp * bobMult;
+    // Arco de vuelo: deriva horizontal lenta + leve sube/baja → "revolotea".
+    const drift = Math.sin(t * 0.6) * cfg.driftAmp;
+    const sway = Math.cos(t * 0.45) * cfg.swayAmp;
+    g.position.set(drift, bob + sway, 0);
+    // Yaw: encara levemente el sentido del vuelo (derivada del drift).
+    g.rotation.y = Math.cos(t * 0.6) * cfg.yawAmp;
+    // Cabeceo mínimo para que el vuelo se sienta orgánico.
+    g.rotation.z = Math.sin(t * 1.2) * 0.04;
+  });
+
+  return (
+    <group ref={ref} scale={cfg.scale}>
+      <Body />
+      <Head />
+      <Wing side="left" flapHzRef={flapHzRef} />
+      <Wing side="right" flapHzRef={flapHzRef} />
+    </group>
+  );
+}
+
+/**
+ * Driver del render bajo demanda. Con `frameloop="demand"` el canvas solo pinta
+ * cuando algo llama `invalidate()`. Este componente invalida a un ritmo fijo
+ * mientras `active`, y para por completo cuando no (offscreen / tab oculto /
+ * reduced-motion) → la GPU descansa.
+ */
+function Driver({ active, reducedMotion }) {
+  const invalidate = useThree((s) => s.invalidate);
+  const lastRef = useRef(0);
+
+  useEffect(() => {
+    if (reducedMotion) {
+      // Un único frame estático y nada más.
+      invalidate();
+      return undefined;
+    }
+    if (!active) return undefined;
+    let raf;
+    const FRAME_MS = 1000 / 45; // capear a ~45 fps (suave y barato en gama baja)
+    const tick = (now) => {
+      if (now - lastRef.current >= FRAME_MS) {
+        lastRef.current = now;
+        invalidate();
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [active, reducedMotion, invalidate]);
+
+  return null;
+}
+
+export default function ChagraColibri3DCanvas({
+  variant = 'home',
+  state = 'idle',
+  reducedMotion = false,
+  active = true,
+}) {
+  const cfg = PRESETS[variant] || PRESETS.home;
+  // Hz de aleteo por estado, pasado por ref para no recrear materiales/efectos.
+  const flapHzRef = useRef(cfg.flapHz[state] || cfg.flapHz.idle);
+  useEffect(() => {
+    flapHzRef.current = cfg.flapHz[state] || cfg.flapHz.idle;
+  }, [state, cfg]);
+
+  return (
+    <Canvas
+      frameloop="demand"
+      camera={cfg.camera}
+      dpr={cfg.dpr}
+      gl={{
+        antialias: cfg.antialias,
+        alpha: true,
+        powerPreference: 'low-power',
+        // No crear depth/stencil de más para un sprite chico.
+        stencil: false,
+      }}
+      style={{ background: 'transparent', width: '100%', height: '100%' }}
+      onCreated={({ gl }) => {
+        gl.toneMapping = THREE.ACESFilmicToneMapping;
+        gl.toneMappingExposure = 1.1;
+      }}
+    >
+      {/* Luz clave + ambiente cálido (verde-menta) + un toque cyan de relleno. */}
+      <ambientLight intensity={0.6} color="#a7f3d0" />
+      <directionalLight position={[2.5, 3.5, 2]} intensity={0.95} color="#ffffff" />
+      <directionalLight position={[-2, 0.5, -1.5]} intensity={0.35} color="#67e8f9" />
+      <Hummingbird
+        variant={variant}
+        state={state}
+        flapHzRef={flapHzRef}
+        reducedMotion={reducedMotion}
+      />
+      <Driver active={active} reducedMotion={reducedMotion} />
+    </Canvas>
+  );
+}

--- a/src/components/ChagraColibri3DLite.jsx
+++ b/src/components/ChagraColibri3DLite.jsx
@@ -1,0 +1,169 @@
+import React, { useRef, useState, useEffect, Suspense, lazy } from 'react';
+
+/**
+ * ChagraColibri3DLite — colibrí 3D LIGERO y PULIDO (Three.js + react-three-fiber)
+ * pensado para correr en TELÉFONOS DE GAMA BAJA (usuarios campesinos) sin drenar
+ * batería ni pegar la GPU.
+ *
+ * Es la versión de PRUEBA gateada por `VITE_COLIBRI_3D` (colibri3dFlag.js),
+ * dev-only. Se usa en dos sitios:
+ *   - Home "Finca Viva": revolotea sobre la escena (variant="home"), con un arco
+ *     de vuelo suave y aleteo rápido tipo colibrí real.
+ *   - Botón del agente (FAB): mini colibrí en vuelo estacionario (variant="fab"),
+ *     aleteo sutil que invita a tocar.
+ *
+ * REUSO: comparte la receta de geometría/materiales del avatar
+ * `ChagraAgentAvatarColibri3D` (torpedo iridiscente esmeralda → cyan, gorget
+ * carmesí, pico largo, ojo con catchlight), pero recortado para performance:
+ *   - menos segmentos de esfera, sin halo ni partículas (el avatar grande sí los
+ *     tiene; aquí estorban en un sprite pequeño y cuestan GPU),
+ *   - 1 sola luz direccional + ambiente (no 4 luces),
+ *   - `frameloop="demand"` con un loop controlado que invalida el canvas a un
+ *     ritmo fijo (no "always" → no quema GPU cuando no se ve).
+ *
+ * PERFORMANCE (crítico):
+ *   - dpr capeado [1, 1.5] (no [1, 2]).
+ *   - `frameloop="demand"`: el canvas SOLO renderiza cuando `invalidate()` corre.
+ *     Un loop interno (Driver) llama invalidate() a ~máx 45 fps mientras está
+ *     VISIBLE; al salir de viewport (IntersectionObserver) o con el tab oculto
+ *     (visibilitychange) el loop se PAUSA → 0 trabajo de GPU.
+ *   - `prefers-reduced-motion`: colibrí ESTÁTICO (un solo frame, sin loop).
+ *   - powerPreference 'low-power', antialias off en el FAB (sprite chico).
+ *   - lazy-load del Canvas: Three.js no entra al bundle principal; solo se baja
+ *     cuando la flag está ON y el componente se monta.
+ *
+ * Español de Colombia (tú/usted), sin voseo. SVG/3D rsvg-irrelevante (corre en
+ * la GPU del cliente, no en el render del servidor).
+ */
+
+// Lazy: separa Three.js / R3F en su propio chunk. Con la flag OFF (prod) este
+// import nunca se evalúa, así que el peso de three NO entra al bundle servido.
+const Colibri3DCanvas = lazy(() => import('./ChagraColibri3DCanvas'));
+
+/** Fallback 2D mínimo mientras carga el chunk 3D (o si WebGL no está). */
+function FallbackDot({ size }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display: 'inline-block',
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background:
+          'radial-gradient(circle at 35% 30%, #34d399 0%, #10b981 45%, #06b6d4 100%)',
+        opacity: 0.85,
+      }}
+    />
+  );
+}
+
+/** Lee prefers-reduced-motion de forma reactiva (SSR-safe). */
+function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return undefined;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduced(!!mq.matches);
+    update();
+    // addEventListener moderno con fallback a addListener (Safari viejo).
+    if (mq.addEventListener) mq.addEventListener('change', update);
+    else if (mq.addListener) mq.addListener(update);
+    return () => {
+      if (mq.removeEventListener) mq.removeEventListener('change', update);
+      else if (mq.removeListener) mq.removeListener(update);
+    };
+  }, []);
+  return reduced;
+}
+
+/**
+ * Observa si el contenedor está en viewport y si el tab está visible. El Canvas
+ * lo usa para PAUSAR el loop de animación cuando no se ve (0 GPU).
+ */
+function useVisibility(ref) {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+
+    let inViewport = true;
+    let tabVisible = typeof document === 'undefined' || !document.hidden;
+    const recompute = () => setVisible(inViewport && tabVisible);
+
+    let io;
+    if (typeof IntersectionObserver !== 'undefined') {
+      io = new IntersectionObserver(
+        (entries) => {
+          inViewport = entries.some((e) => e.isIntersecting);
+          recompute();
+        },
+        { threshold: 0.05 },
+      );
+      io.observe(el);
+    }
+
+    const onVis = () => {
+      tabVisible = !document.hidden;
+      recompute();
+    };
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVis);
+    }
+
+    return () => {
+      if (io) io.disconnect();
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', onVis);
+      }
+    };
+  }, [ref]);
+  return visible;
+}
+
+/**
+ * @param {Object} props
+ * @param {'home'|'fab'} [props.variant='home']  preset de tamaño/animación.
+ * @param {number} [props.size]                  px del lado (default por variant).
+ * @param {'idle'|'thinking'|'speaking'} [props.state='idle']  estado del agente.
+ * @param {string} [props.className]
+ * @param {string} [props.ariaLabel]
+ */
+export default function ChagraColibri3DLite({
+  variant = 'home',
+  size,
+  state = 'idle',
+  className = '',
+  ariaLabel,
+}) {
+  const wrapRef = useRef(null);
+  const reducedMotion = usePrefersReducedMotion();
+  const visible = useVisibility(wrapRef);
+  const px = size || (variant === 'fab' ? 52 : 96);
+
+  return (
+    <div
+      ref={wrapRef}
+      className={className}
+      style={{
+        width: px,
+        height: px,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+      }}
+      role="img"
+      aria-label={ariaLabel || 'Colibrí Chagra'}
+    >
+      <Suspense fallback={<FallbackDot size={Math.round(px * 0.55)} />}>
+        <Colibri3DCanvas
+          variant={variant}
+          state={state}
+          reducedMotion={reducedMotion}
+          active={visible}
+        />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -16,7 +16,14 @@ import { resolveClimaLocation, getCachedClimaSnapshot, CLIMA_UPDATED_EVENT } fro
 import { clasificarPisoTermico } from '../../services/pisoTermicoClassifier';
 import { useTheme } from '../../hooks/useTheme';
 import { iconForTheme } from './themeIcon';
+import { colibri3dActivo } from '../../config/colibri3dFlag';
+import ChagraColibri3DLite from '../ChagraColibri3DLite';
 import './finca-viva-hero.css';
+
+// PRUEBA dev-only: ¿mostrar el colibrí 3D que revolotea en la escena (en vez del
+// SVG 2D)? Gateado por VITE_COLIBRI_3D (colibri3dFlag.js). Se evalúa una sola vez
+// al cargar el módulo: la flag es de build, no cambia en runtime.
+const COLIBRI_3D = colibri3dActivo();
 
 /**
  * FincaVivaHero — el HOME INMERSIVO "Finca Viva" (refinado del mockup F2 v2
@@ -335,9 +342,19 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
                       (fauna que prospera) sólo aparecen cuando la finca está
                       poblada. */}
                   <div className="fvh-bichos" aria-hidden="true">
-                    <span className="fvh-bicho fvh-colibri-vuela" style={{ left: '66%', top: '20%' }}>
-                      <ColibriVuela />
-                    </span>
+                    {/* COLIBRÍ insignia: con la flag VITE_COLIBRI_3D ON (dev) sale
+                        el modelo 3D que revolotea; con la flag OFF (prod) el SVG
+                        2D de siempre. El 3D cae a su fallback 2D solo si WebGL
+                        fallara (Suspense interno). Prueba dev-only, NO toca prod. */}
+                    {COLIBRI_3D ? (
+                      <span className="fvh-bicho fvh-colibri-3d" style={{ left: '62%', top: '12%' }}>
+                        <ChagraColibri3DLite variant="home" size={108} state="idle" ariaLabel="Colibrí Chagra" />
+                      </span>
+                    ) : (
+                      <span className="fvh-bicho fvh-colibri-vuela" style={{ left: '66%', top: '20%' }}>
+                        <ColibriVuela />
+                      </span>
+                    )}
                     {poblada && (
                       <>
                         <span className="fvh-bicho" style={{ left: '16%', top: '18%', animationDelay: '.1s' }}>🦋</span>

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -493,6 +493,25 @@
   60%  { transform: translate(-10px, -6px) rotate(-2deg); }
   100% { transform: translate(0, 0) rotate(-3deg); }
 }
+/* COLIBRÍ 3D (PRUEBA dev-only, flag VITE_COLIBRI_3D): el modelo Three.js maneja
+   su propio vuelo/aleteo internamente. El contenedor solo aporta una deriva CSS
+   muy lenta para ampliar el arco, y un drop-shadow tenue para asentarlo en la
+   escena. NO heredamos la animación fvh-flota del .fvh-bicho (chocaría con la
+   animación interna del 3D). */
+.fvh-colibri-3d {
+  animation: fvh-colibri-3d-deriva 9s ease-in-out infinite;
+  filter: drop-shadow(0 6px 7px rgba(20, 40, 20, 0.22));
+  z-index: 8;
+}
+@keyframes fvh-colibri-3d-deriva {
+  0%, 100% { transform: translate(0, 0); }
+  35%      { transform: translate(-22px, 10px); }
+  70%      { transform: translate(8px, -8px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fvh-colibri-3d { animation: none; }
+}
+
 .fvh-colibri-svg .fvh-ala-fron { animation: fvh-ala-flap 0.13s ease-in-out infinite; }
 .fvh-colibri-svg .fvh-ala-tras { animation: fvh-ala-flap-back 0.13s ease-in-out infinite; }
 @keyframes fvh-ala-flap {

--- a/src/config/colibri3dFlag.js
+++ b/src/config/colibri3dFlag.js
@@ -1,0 +1,48 @@
+/**
+ * colibri3dFlag.js — feature flag de PRUEBA del colibrí 3D (Three.js / R3F).
+ *
+ * Es una PRUEBA visual para el operador: monta un colibrí 3D pulido en el home
+ * "Finca Viva" y sobre el botón del agente (FAB). Gateado dev-only, igual que
+ * `VITE_FINCA_VIVA_HOME_PERFIL`, para que NO llegue a producción sin el visto
+ * bueno del operador.
+ *
+ * Con la flag APAGADA (default, prod) el colibrí del home y del FAB conservan su
+ * presentación 2D actual (SVG / avatar foto). Con la flag ENCENDIDA (dev) se
+ * sustituyen por el modelo 3D, que carga de forma perezosa (lazy) para no
+ * engordar el bundle principal. Si Three.js / WebGL fallaran, el 3D cae a su
+ * fallback 2D vía Suspense sin romper la pantalla.
+ *
+ * CÓMO ACTIVARLA (dev): poner en el `.env` (o `.env.local`) del frontend:
+ *
+ *     VITE_COLIBRI_3D=true
+ *
+ * Acepta 'true' / '1' (case-insensitive, con espacios). Mismo criterio de
+ * parseo que `fincaVivaHomePerfilActivo()` (fincaVivaHomeFlag.js) e
+ * `isSidecarEnabled()` (sidecarClient.js) para mantener la convención del repo.
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ *
+ * @module colibri3dFlag
+ */
+
+const FLAG_KEY = 'VITE_COLIBRI_3D';
+
+/**
+ * ¿Está activa la PRUEBA del colibrí 3D?
+ *
+ * @returns {boolean} true si la flag está encendida; false (default) en
+ *   cualquier otro caso, incluido error de acceso a import.meta.env.
+ */
+export function colibri3dActivo() {
+  try {
+    const raw = import.meta.env?.[FLAG_KEY];
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}


### PR DESCRIPTION
## Qué es
PRUEBA visual para el operador: un colibrí 3D pulido (Three.js / react-three-fiber) en dos sitios de la PWA, **gateado por la flag de build dev-only `VITE_COLIBRI_3D`**. NO toca producción (en `deploy.yml` la flag no existe → colibrí 2D de siempre).

## Dónde
- **Home "Finca Viva"** (`FincaVivaHero.jsx`): el colibrí insignia revolotea sobre la escena con aleteo rápido tipo colibrí real + arco de vuelo suave. Flag OFF → conserva el SVG 2D actual (`ColibriVuela`) de fallback.
- **FAB del agente** (`AgentFab.jsx`): mini colibrí 3D con aleteo sutil que invita a tocar. Flag OFF → avatar 2D actual.

## Reuso
Receta de geometría/materiales destilada de `ChagraAgentAvatarColibri3D` (plumaje esmeralda iridiscente, gorget carmesí, pico largo, ojo con catchlight), recortada para gama baja.

## Performance (teléfonos campesinos)
- `frameloop="demand"` con loop capeado a ~45 fps; `dpr [1, 1.5]`; `powerPreference: low-power`.
- Pausa el render cuando está offscreen (`IntersectionObserver`) o el tab está oculto (`visibilitychange`) → 0 GPU.
- `prefers-reduced-motion` → colibrí estático.
- El Canvas Three.js carga **lazy en su propio chunk** (no engorda el bundle servido; con la flag OFF no se descarga en runtime).

## Gates
- `vite build` verde (flag ON y OFF).
- eslint limpio en archivos tocados; lefthook (secret-scan, infra-refs, voseo, conventional) verde.

## Es una PRUEBA
Flag ON solo en `dev-deploy.yml`. Fácil de quitar. **No mergear** hasta el visto bueno del operador.