### PR TITLE
feat(agente): reestructurar la mano — destacadas + dedup + jerga campesina + fix chip calendario

### DIFF
--- a/src/components/agent/manoRamasReachable.test.js
+++ b/src/components/agent/manoRamasReachable.test.js
@@ -29,13 +29,16 @@ describe('mano radial — ramas Aprender y Vender alcanzables (no dead-end)', ()
     expect(navAprende).toBeTruthy();
   });
 
-  it('la rama "vender" tiene una capacidad LIVE que navega a una superficie real (mercados)', () => {
+  it('la rama "vender" tiene una capacidad LIVE que navega a una superficie real (mercado)', () => {
+    // dedup mano 2026-06-28: 'vender-mercados' (vista 'mercados', en preparación)
+    // se retiró de la mano; la rama vive por 'mercado' (marketplace LIVE,
+    // vista 'mercado'). Ambas renderizaban la misma MercadosScreen.
     const leaves = heroLiveLeavesForGroup('vender');
     expect(leaves.length).toBeGreaterThan(0);
-    const navMercados = leaves.find(
-      (c) => c.heroRoute?.kind === 'nav' && c.heroRoute?.view === 'mercados',
+    const navMercado = leaves.find(
+      (c) => c.heroRoute?.kind === 'nav' && c.heroRoute?.view === 'mercado',
     );
-    expect(navMercados).toBeTruthy();
+    expect(navMercado).toBeTruthy();
   });
 
   it('mapCapabilityPick enruta la rama "aprender" a onNav("aprende")', () => {
@@ -48,14 +51,14 @@ describe('mano radial — ramas Aprender y Vender alcanzables (no dead-end)', ()
     expect(onNav).toHaveBeenCalledWith('aprende');
   });
 
-  it('mapCapabilityPick enruta la rama "vender" a onNav("mercados")', () => {
+  it('mapCapabilityPick enruta la rama "vender" a onNav("mercado")', () => {
     const cap = heroLiveLeavesForGroup('vender').find(
-      (c) => c.heroRoute?.view === 'mercados',
+      (c) => c.heroRoute?.view === 'mercado',
     );
     const onNav = vi.fn();
     const acted = mapCapabilityPick(cap, { onNav });
     expect(acted).toBe(true);
-    expect(onNav).toHaveBeenCalledWith('mercados');
+    expect(onNav).toHaveBeenCalledWith('mercado');
   });
 
   it('las capacidades de navegación de las ramas no son no-op (acted=true)', () => {

--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -70,14 +70,40 @@ const GROUP_ORDER = Object.freeze([
   'cultivo', 'cuidar', 'observar', 'restaurar', 'registrar', 'planear', 'aprender', 'vender',
 ]);
 
+/* DESTACADAS (operador 2026-06-28): las 6 funciones clave brotan PRIMERO en el
+   anillo principal como ACCIÓN DIRECTA (sin grupo), para que el primerizo las vea
+   de una. El RESTO de capacidades hero queda un nivel adentro, bajo su grupo
+   ("ver más"). Fuente única: featured===true en el manifiesto. NO se elimina
+   ninguna función — solo cambia la jerarquía de aparición. */
+const FEATURED = CAPABILITY_MANIFEST.filter((e) => e.hero === true && e.featured === true);
+const FEATURED_IDS = new Set(FEATURED.map((c) => c.id));
+
+/* Grupos = el resto de capacidades hero (las NO destacadas), agrupadas. */
 const GROUPS = GROUP_ORDER
   .map((key) => ({
     key,
     icon: GROUP_META[key].icon,
     label: GROUP_META[key].label,
-    leaves: CAPABILITY_MANIFEST.filter((e) => e.hero === true && e.group === key),
+    leaves: CAPABILITY_MANIFEST.filter(
+      (e) => e.hero === true && e.group === key && !FEATURED_IDS.has(e.id),
+    ),
   }))
   .filter((g) => g.leaves.length > 0);
+
+/* Anillo principal = [destacadas (acción directa)] + [grupos (despliegan su
+   resto al enfocar)]. Cada item tiene la MISMA forma que un grupo
+   (key/icon/label/leaves) para que el motor de geometría los trate igual: las
+   destacadas llevan kind:'cap' + cap y leaves:[] (no despliegan, accionan). El
+   orden (destacadas primero) define el orden de sprout: el primerizo ve brotar
+   primero las 6 funciones clave. */
+const RING = [
+  ...FEATURED.map((cap) => ({
+    kind: 'cap', key: cap.id, icon: cap.icon, label: cap.label, cap, leaves: [],
+  })),
+  ...GROUPS.map((g) => ({
+    kind: 'group', key: g.key, icon: g.icon, label: g.label, leaves: g.leaves,
+  })),
+];
 
 /* ══════════════ helpers geométricos (puros, port 1:1) ══════════════ */
 
@@ -309,6 +335,10 @@ const CSS = `
 }
 .arm-node:nth-child(even) .arm-orb{border-radius:var(--orbRadB)}
 .arm-node.arm-leaf .arm-orb{border-color:var(--ringLeaf)}
+/* destacadas (2026-06-28): acción directa en el anillo principal — anillo de
+   hoja (no de grupo) y SIN el latido expansible del grupo, para que se lean como
+   "toque y listo", no como "abra para ver más". */
+.arm-node.arm-feat .arm-orb{border-color:var(--ringLeaf)}
 .arm-node.arm-group .arm-orb::after{
   content:"";position:absolute;inset:-5px;border-radius:inherit;
   border:1px solid var(--pulse);animation:armPing 3.4s ease-out infinite;
@@ -433,7 +463,7 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
     const hintEl = root.querySelector('[data-arm="hint"]');
 
     /* estado de simulación por grupo/hoja (paths SVG creados acá). */
-    const sim = GROUPS.map((g, i) => {
+    const sim = RING.map((g, i) => {
       const el = root.querySelector(`[data-arm-group="${i}"]`);
       return {
         i,
@@ -928,8 +958,25 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
     toastTimerRef.current = setTimeout(() => setToastMsg(null), 1700);
   }
 
-  function handleGroupTap(i) {
+  function handleGroupTap(i, ev) {
     if (disabled) return;
+    const item = RING[i];
+    if (item?.kind === 'cap') {
+      // Destacada = ACCIÓN DIRECTA (no despliega): misma semántica que una hoja.
+      if (ev?.currentTarget) bounce(ev.currentTarget);
+      const cap = item.cap;
+      const health = capabilityHealth.get(cap.id) || 'live';
+      if (health === 'soon') {
+        showToast(`${cap.icon} ${cap.label} — por lanzar`);
+        return;
+      }
+      if (health === 'down') {
+        showToast(`${cap.icon} ${cap.label} — no disponible sin conexión al servidor`);
+        return;
+      }
+      if (onPick) onPick(cap);
+      return;
+    }
     engineRef.current?.toggleFocus(i);
   }
 
@@ -1021,35 +1068,50 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
       </div>
 
       <div className="arm-nodes">
-        {GROUPS.map((g, i) => (
-          <div
-            key={g.key}
-            className="arm-node arm-group"
-            role="button"
-            tabIndex={0}
-            aria-label={g.label}
-            aria-expanded={focusedIdx === i}
-            data-arm-group={i}
-            style={{ opacity: 0, '--pd': `${i * 0.5}s` }}
-            onClick={() => handleGroupTap(i)}
-            onKeyDown={(ev) => pressKey(ev, () => handleGroupTap(i))}
-          >
-            <div className="arm-orb">
-              <i
-                className="arm-ic"
-                style={{
-                  '--swD': `${(4.2 + rand(i + 2) * 2.4).toFixed(1)}s`,
-                  '--swDel': `${(-rand(i + 11) * 4).toFixed(1)}s`,
-                }}
-              >
-                {g.icon}
-              </i>
+        {RING.map((item, i) => {
+          const isCap = item.kind === 'cap';
+          const health = isCap ? (capabilityHealth.get(item.cap.id) || 'live') : 'live';
+          const isDown = health === 'down';
+          const isSoon = health === 'soon';
+          return (
+            <div
+              key={item.key}
+              className={`arm-node ${isCap ? 'arm-feat' : 'arm-group'}${isSoon ? ' arm-soon' : ''}${isDown ? ' arm-down' : ''}`}
+              role="button"
+              tabIndex={isDown ? -1 : 0}
+              aria-label={isCap && isDown ? `${item.label} (sin conexión al servidor)` : item.label}
+              aria-expanded={isCap ? undefined : focusedIdx === i}
+              aria-disabled={isDown || undefined}
+              data-arm-group={i}
+              style={{ opacity: 0, '--pd': `${i * 0.5}s` }}
+              onClick={(ev) => handleGroupTap(i, ev)}
+              onKeyDown={(ev) => pressKey(ev, () => handleGroupTap(i, ev))}
+            >
+              <div className="arm-orb">
+                <i
+                  className="arm-ic"
+                  style={{
+                    '--swD': `${(4.2 + rand(i + 2) * 2.4).toFixed(1)}s`,
+                    '--swDel': `${(-rand(i + 11) * 4).toFixed(1)}s`,
+                  }}
+                >
+                  {item.icon}
+                </i>
+              </div>
+              <div className="arm-lbl">
+                {item.label}
+                {isCap && isDown && (
+                  <>
+                    <br />
+                    <span className="arm-badge arm-badge-down">sin servidor</span>
+                  </>
+                )}
+              </div>
             </div>
-            <div className="arm-lbl">{g.label}</div>
-          </div>
-        ))}
+          );
+        })}
 
-        {GROUPS.map((g, i) =>
+        {RING.map((g, i) =>
           g.leaves.map((cap, j) => {
             const health = capabilityHealth.get(cap.id) || 'live';
             const isSoon = health === 'soon';
@@ -1108,8 +1170,8 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
 
       {focusedIdx != null && (
         <button type="button" className="arm-crumb" onClick={handleRootTap}>
-          ‹ <span>{GROUPS[focusedIdx].icon}</span>
-          <span>{GROUPS[focusedIdx].label}</span>
+          ‹ <span>{RING[focusedIdx].icon}</span>
+          <span>{RING[focusedIdx].label}</span>
         </button>
       )}
 

--- a/src/services/__tests__/agentCapabilities.audit.test.js
+++ b/src/services/__tests__/agentCapabilities.audit.test.js
@@ -91,7 +91,8 @@ const CHIP_REGISTRY = [
   },
   {
     intent: 'restauracion',
-    label: 'Restauración',
+    // jerga campesina 2026-06-28: label renombrado (id/intent intactos).
+    label: 'Sembrar monte nativo',
     emoji: '🌳',
     kind: 'tool',
     tool: 'get_diseno_restauracion',
@@ -100,7 +101,8 @@ const CHIP_REGISTRY = [
   },
   {
     intent: 'silvopastoreo',
-    label: 'Silvopastoreo',
+    // jerga campesina 2026-06-28: label renombrado (id/intent intactos).
+    label: 'Árboles para el ganado',
     emoji: '🐄',
     kind: 'tool',
     tool: 'get_diseno_silvopastoril',

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -35,6 +35,9 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     tool: 'get_species',
     stubMessage: null,
     hero: true,
+    // featured (2026-06-28): una de las 6 funciones clave que brotan primero en
+    // el anillo principal de la mano para el primerizo (resto va bajo grupos).
+    featured: true,
     heroRoute: { kind: 'ask', prompt: '¿Qué puedo sembrar este mes en mi zona?' },
   },
   {
@@ -50,6 +53,7 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     tool: 'get_pest_controllers',
     stubMessage: null,
     hero: true,
+    featured: true, // 1 de las 6 destacadas (anillo principal).
     heroRoute: { kind: 'ask', prompt: '¿Cómo controlo plagas sin químicos?' },
   },
   {
@@ -80,6 +84,7 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     tool: 'get_clima_ideam',
     stubMessage: null,
     hero: true,
+    featured: true, // 1 de las 6 destacadas (anillo principal).
     heroRoute: { kind: 'ask', prompt: 'Dame el reporte del clima de mi zona esta semana.' },
   },
   {
@@ -138,7 +143,11 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     label: 'Calendario',
     desc: 'Cuándo sembrar y cuándo cosechar.',
     placeholder: 'Escribe la planta para ver su época de siembra',
-    tool: 'get_species',
+    // fix chip calendario (2026-06-28): el manifiesto declaraba get_species, pero
+    // la tool dedicada del calendario lunar/estacional es get_calendario_siembra
+    // (viva en el sidecar; el chipIntentRouter ya routeaba ahí). Se alinea el
+    // manifiesto con la tool real — capabilityHealth y auditoría quedan coherentes.
+    tool: 'get_calendario_siembra',
     stubMessage: null,
     hero: true,
     heroRoute: { kind: 'ask', prompt: '¿Cuándo siembro y cuándo cosecho en mi zona?' },
@@ -164,7 +173,13 @@ export const CAPABILITY_MANIFEST = Object.freeze([
       'de siembra, plaga, biopreparado o clima para obtener información curada.',
     group: 'aprender',
     status: 'soon',
-    hero: true,
+    // hero:false (dedup mano 2026-06-28): `deep` es un STUB (status:'soon' → no-op
+    // que solo muestra toast "por lanzar"). Igual que `precio`, se RETIRA de la
+    // mano radial para no dejar una rama muerta — sigue siendo chip honesto en el
+    // ChipsToolbar (stub con stubMessage que orienta). La rama "Aprender" de la
+    // mano vive sana por `aprender_hub` (LIVE → vista 'aprende'). El día que el
+    // backend de deep research se sirva en prod, se vuelve hero:true.
+    hero: false,
     heroRoute: { kind: 'unavailable' },
   },
   {
@@ -179,7 +194,9 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     intent: 'restauracion',
     kind: 'tool',
     icon: '🌳',
-    label: 'Restauración',
+    // jerga campesina (2026-06-28): "Restauración" es término técnico → label
+    // claro para el campo. El id e intent NO cambian (chip/routing intactos).
+    label: 'Sembrar monte nativo',
     desc: 'Recuperar un terreno con nativas, de pioneras a bosque maduro.',
     placeholder: 'Cuéntame qué quieres recuperar: bosque, orilla de quebrada o sitio quemado',
     tool: 'get_diseno_restauracion',
@@ -200,7 +217,9 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     intent: 'silvopastoreo',
     kind: 'tool',
     icon: '🐄',
-    label: 'Silvopastoreo',
+    // jerga campesina (2026-06-28): "Silvopastoreo" es término técnico. id/intent
+    // intactos (chip/routing); solo cambia la etiqueta visible.
+    label: 'Árboles para el ganado',
     desc: 'Forraje y árboles para tu ganado según tu altura.',
     placeholder: 'Escribe tu animal o el forraje que buscas: banco de proteína, cerca viva, sombra',
     tool: 'get_diseno_silvopastoril',
@@ -262,9 +281,11 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     // de la mano era SOLO `deep` (status:'soon' → no-op, solo toast). Esta hoja
     // LIVE la conecta al contenido real de aprendizaje (módulo "Aprende con el
     // agente", ruta 'aprende': 5 lecciones agroecológicas con fuente/DOI). Así
-    // la rama "Aprender" navega a algo real en vez de quedar muerta; `deep`
-    // sigue presente como stub honesto ("por lanzar"). No tiene `intent` → NO es
-    // chip, solo acción de la mano. Ref: CAPABILITIES_STATUS.md §7.4.
+    // la rama "Aprender" navega a algo real en vez de quedar muerta. Tras el
+    // dedup 2026-06-28 es la ÚNICA hoja de la rama "Aprender": 'aprender-hub'
+    // (duplicado) se eliminó y `deep` pasó a hero:false (stub honesto que vive
+    // solo en el ChipsToolbar). No tiene `intent` → NO es chip, solo acción de la
+    // mano. Ref: CAPABILITIES_STATUS.md §7.4.
     id: 'aprender_hub',
     group: 'aprender',
     status: 'live',
@@ -289,10 +310,15 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     group: 'observar',
     status: 'live',
     icon: '📷',
-    label: 'Agregar planta por foto',
-    desc: 'Tómale una foto y la identifico contra el catálogo.',
+    // jerga campesina + alcance real (2026-06-28): la foto NO solo agrega una
+    // planta — identifica la especie Y diagnostica daño foliar/plaga/enfermedad
+    // (visión groundeada: analyzeFoliage / validate_visual_match). El label lo
+    // comunica en usted colombiano.
+    label: 'Tómele foto a una mata',
+    desc: 'Tómele una foto a su planta: le digo qué es y si tiene plaga o enfermedad.',
     tool: 'vision_identify',
     hero: true,
+    featured: true, // 1 de las 6 destacadas (anillo principal).
     heroRoute: { kind: 'photo' },
   },
   {
@@ -310,7 +336,14 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     label: 'Agregar planta por voz',
     desc: 'Dime qué sembraste: lo registro y te muestro su ciclo, bioinsumos y compañeros.',
     tool: 'voice_capture',
-    hero: true,
+    // hero:false (dedup mano 2026-06-28): `procesos` ("Registrar hablando",
+    // vista 'registro_voz' → RegistroVozScreen) YA cubre agregar una planta por
+    // voz — clasifica entre TODOS los tipos incluyendo INTENTS.PLANTA →
+    // saveType 'plant_asset' (verificado en voiceFieldExtractor.INTENT_META). Dos
+    // botones de voz en la mano confundían; se deja solo `procesos`. La vista
+    // 'voz_planta' (PlantaPorVozScreen) sigue viva y enlazada desde otras
+    // pantallas; solo se retira esta puerta duplicada de la mano radial.
+    hero: false,
     heroRoute: { kind: 'nav', view: 'voz_planta' },
   },
   {
@@ -322,6 +355,7 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     desc: 'Ver y manejar lo que tienes en la finca.',
     tool: 'assets',
     hero: true,
+    featured: true, // 1 de las 6 destacadas (anillo principal).
     heroRoute: { kind: 'nav', view: 'activos' },
   },
   {
@@ -373,7 +407,8 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     group: 'observar',
     status: 'live',
     icon: '🦋',
-    label: 'Biodiversidad',
+    // jerga campesina (2026-06-28): "Biodiversidad" es término técnico.
+    label: 'La vida de la finca',
     desc: 'Reconocer y cuidar la vida de la finca.',
     tool: 'biodiversity',
     hero: true,
@@ -395,7 +430,8 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     group: 'cultivo',
     status: 'live',
     icon: '🌱',
-    label: 'Germinación',
+    // jerga campesina (2026-06-28): "Germinación" es término técnico.
+    label: '¿Sirve mi semilla?',
     desc: 'Prueba si tu semilla está viva antes de sembrar.',
     tool: 'germination_test',
     hero: true,
@@ -429,6 +465,7 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     desc: 'Cuéntame qué hiciste o qué viste: siembra, cosecha, insumo, mantenimiento, observación o plaga, y lo guardo.',
     tool: 'farm_process',
     hero: true,
+    featured: true, // 1 de las 6 destacadas (anillo principal) — voz-first.
     heroRoute: { kind: 'nav', view: 'registro_voz' },
   },
   {
@@ -439,25 +476,17 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     label: 'Alertas del cultivo',
     desc: 'Avisos anticipados de riesgo por clima, plagas y etapa.',
     tool: 'crop_alerts',
-    hero: true,
+    // hero:false (dedup mano 2026-06-28): `alertas-cultivo` y `ciclo` apuntaban a
+    // la MISMA vista 'ciclo' → dos puertas al mismo sitio en la mano. Se deja
+    // `ciclo` ("Ciclo del cultivo") como la única hoja de esa vista; las alertas
+    // viven DENTRO de esa pantalla (sección de avisos), no como rama aparte.
+    // status sigue 'live' (capabilityHealth/otros consumidores intactos).
+    hero: false,
     heroRoute: { kind: 'nav', view: 'ciclo' },
   },
-  {
-    // RAMA "Aprender" de la mano: antes el grupo solo tenía 'deep'
-    // (Investigación profunda, status 'soon' → no clickeable), así que la rama
-    // moría en un nodo atenuado sin destino real. Esta entrada conecta la rama
-    // al hub educativo que YA existe y es alcanzable (vista 'aprende',
-    // AprenderConAgente): lecciones agroecológicas con fuente verificada.
-    id: 'aprender-hub',
-    group: 'aprender',
-    status: 'live',
-    icon: '📚',
-    label: 'Aprende con el agente',
-    desc: 'Lecciones agroecológicas con fuente: suelo, asociaciones, biopreparados, MIP y fenología.',
-    tool: null,
-    hero: true,
-    heroRoute: { kind: 'nav', view: 'aprende' },
-  },
+  // NOTA (dedup mano 2026-06-28): la entrada 'aprender-hub' (≡ 'aprender_hub',
+  // mismo destino nav:'aprende') se ELIMINÓ — eran duplicados. Se conserva
+  // 'aprender_hub' ("Aprender con el agente", arriba) como única hoja de la rama.
   {
     // RAMA "Vender" de la mano: antes el grupo solo tenía 'precio'
     // (status 'soon' → no clickeable), así que la rama no iba a ningún lado.
@@ -472,7 +501,13 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     label: 'Vender mejor',
     desc: 'A dónde llevar la cosecha y dónde consultar precios mayoristas. En preparación.',
     tool: null,
-    hero: true,
+    // hero:false (dedup mano 2026-06-28): `mercado` ("Mercado de la finca",
+    // marketplace LIVE) y `vender-mercados` ("Vender mejor", en preparación)
+    // navegan a la MISMA MercadosScreen (App.jsx: vistas 'mercado' y 'mercados'
+    // renderizan el mismo componente). Se deja `mercado` (capacidad real) como la
+    // única hoja de la rama "Vender"; `vender-mercados` se retira de la mano hasta
+    // tener un backend de precios/destinos propio.
+    hero: false,
     heroRoute: { kind: 'nav', view: 'mercados' },
   },
 ]);


### PR DESCRIPTION
## Qué

Reestructura **la mano de Chagra** (menú radial de capacidades del agente) sobre el manifiesto único `agentCapabilities.js` + el render `AgentRedMenu.jsx`. Aprobado por el operador.

### 1) Dedup / ramas muertas (todo vía `hero:false`, sin borrar funciones salvo el duplicado exacto)
- **`aprender-hub` ELIMINADO** (era idéntico a `aprender_hub`, mismo destino `nav:'aprende'`). Se conserva `aprender_hub` ("Aprender con el agente") como única hoja de la rama Aprender.
- **`deep` → `hero:false`** (STUB `status:'soon'`, sin backend en prod). Sale de la mano como `precio`; sigue siendo chip honesto en el ChipsToolbar.
- **`alertas-cultivo` → `hero:false`**: apuntaba a la misma `view:'ciclo'` que `ciclo`. Se deja `ciclo` ("Ciclo del cultivo") como única puerta; las alertas viven dentro de esa pantalla.
- **`voz` → `hero:false`**: `procesos` ("Registrar hablando", `view:'registro_voz'` → RegistroVozScreen) **ya cubre agregar planta por voz** — clasifica entre todos los tipos incluido `INTENTS.PLANTA` → `saveType:'plant_asset'` (verificado en `voiceFieldExtractor.INTENT_META`). Se deja solo `procesos`. La vista `voz_planta` (PlantaPorVozScreen) sigue viva enlazada desde otras pantallas.
- **`vender-mercados` → `hero:false`**: `mercado` ("Mercado de la finca", marketplace LIVE) y `vender-mercados` navegaban a **la misma `MercadosScreen`** (App.jsx: `mercado` y `mercados` renderizan el mismo componente). Se deja `mercado`.

### 2) Jerga campesina (solo `label`; ids/intents intactos → chips/routing sin tocar)
- `silvopastoreo` → **"Árboles para el ganado"**
- `biodiversidad` → **"La vida de la finca"**
- `germinacion` → **"¿Sirve mi semilla?"**
- `restauracion` → **"Sembrar monte nativo"**
- `foto` → **"Tómele foto a una mata"** + desc que comunica diagnóstico: _"Tómele una foto a su planta: le digo qué es y si tiene plaga o enfermedad."_

### 3) Bug chip calendario
- `calendario.tool`: `get_species` → **`get_calendario_siembra`** (la tool dedicada, viva en el sidecar; el chipIntentRouter ya routeaba ahí). Alinea manifiesto ↔ tool real.

### 4) Modo "6 destacadas + resto en grupos"
- Campo nuevo **`featured:true`** en 6 capacidades: `siembro`, `plaga`, `foto`, `clima`, `procesos`, `plantas`.
- En `AgentRedMenu.jsx`: el anillo principal = **`[destacadas (acción directa)] + [grupos]`** (`RING`). Las destacadas son `kind:'cap'` con `leaves:[]` → no despliegan, **accionan directo** (`onPick`); el resto queda bajo su grupo (segundo nivel). Orden: destacadas primero → **brotan primero** en el sprout (el primerizo las ve de una). El motor de geometría las trata igual que un grupo (misma forma `key/icon/label/leaves`), así que la anticolisión/sprout existentes siguen funcionando. Toques ≥44px (nodo 72px + target 92px) y glifo de la mano intactos. Estilo `.arm-feat` (anillo de hoja, sin latido expansible) para que se lean como "toque y listo".

## Decisiones de borde
- **voz vs procesos** → se deja `procesos` y se retira `voz`: verificado en código que `registro_voz` cubre `INTENTS.PLANTA`.
- **mercado vs vender-mercados** → se deja `mercado` (LIVE) y se retira `vender-mercados`: ambas renderizaban la misma `MercadosScreen`.

## Estado
- `npm run build` ✅ (warnings preexistentes de dynamic-import, ajenos)
- Tests relevantes ✅ — manoRamasReachable, agentCapabilities.audit, capabilityHealth, AgentRedMenu.smoke, chipIntentRouter, ChipsToolbar.smoke, AgentHero (integration/composer/demoParity), FincaVivaHero.portales, registro-redesign, AprenderConAgente
- eslint ✅ sobre archivos cambiados + lefthook (voseo-scan/secret-scan/conventional) verde
- Tests ajustados sin romper su intención: `manoRamasReachable` (rama Vender ahora alcanza `view:'mercado'`); `agentCapabilities.audit` (labels renombrados de los chips restauracion/silvopastoreo)

## Pendiente (verificación visual operador)
La interacción fina del anillo (14 nodos: 6 destacadas + 8 grupos, layout en celular) se valida en vivo con chromium — requiere ojo del operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)