### PR TITLE
fix(rag): embeber la query del RAG en CPU (num_gpu:0) — P0 warm #2

### DIFF
--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -450,13 +450,25 @@ async function loadEmbeddings() {
 /**
  * Embebe una query via Ollama (POST /api/ollama/api/embeddings).
  * Si falla (sin red, modelo caído), retorna null → fallback a BM25 solo.
+ *
+ * `options.num_gpu: 0` fuerza el embed a CPU (P0 warm, audit 2026-06-28): evita
+ * que snowflake-arctic-embed2 co-resida en la GPU del chat y dispare OOM.
  */
 async function embedQuery(queryText) {
   try {
     const res = await fetchWithAuthRetry('/api/ollama/api/embeddings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model: 'snowflake-arctic-embed2', prompt: queryText }),
+      // num_gpu:0 → el embedder corre en CPU, NO en la M6000 (12 GiB). La
+      // co-residencia embedder(~4.5G) + granite3.3:8b(~7.2G) > 12G dispara un
+      // cudaMalloc OOM que MATA el runner compartido de granite → los turnos
+      // siguientes quedan fríos. Se conserva snowflake (1024d, mismo espacio que
+      // los vectores precomputados) y el RAG híbrido queda intacto.
+      body: JSON.stringify({
+        model: 'snowflake-arctic-embed2',
+        prompt: queryText,
+        options: { num_gpu: 0 },
+      }),
       signal: AbortSignal.timeout(TOOL_TIMEOUT_MS),
     });
     if (!res.ok) return null;


### PR DESCRIPTION
## Qué

`options:{num_gpu:0}` en el POST del RAG a `/api/ollama/api/embeddings` para que el embedder de la query corra en **CPU**, no en la GPU del chat. P0 #2 de la auditoría warm 2026-06-28.

## Por qué

Cada turno con RAG embebe la query con `snowflake-arctic-embed2`. La co-residencia en VRAM del embedder (~4.5G) + `granite3.3:8b @ num_ctx 8192` (~7.2G) supera los **12 GiB de la M6000** → `cudaMalloc` OOM que **mata el runner compartido de granite** → los turnos siguientes quedan fríos (cold cascade). Es una de las causas raíz medidas.

## Cómo

- Una sola línea de efecto: `options:{ num_gpu: 0 }` en el body del embed.
- **Se conserva `snowflake-arctic-embed2` (1024d)** — mismo espacio que los vectores precomputados en build-time (`public/rag-embeddings.json`), así el coseno y el RAG híbrido quedan intactos. NO se cambia de modelo.
- Intelligence-first: no se achica nada; el RAG sigue idéntico, solo se mueve el cómputo del embed a CPU.

## ⚠️ Requiere smoke en alpha ANTES de mergear

- [ ] Confirmar que **ollama 0.24 honra `num_gpu:0`** en `/api/embeddings` (que NO cargue snowflake en VRAM).
- [ ] Confirmar que la **presión sobre los 16 GiB de RAM de alpha** (cuello #1) es aceptable.

Fallback si ollama ignora `num_gpu:0`: instancia ollama dedicada en CPU (`CUDA_VISIBLE_DEVICES=""`) o `keep_alive:0` en snowflake.

## Verificación local

- `npm run build` ✅ · lefthook pre-commit (secret/pro-import/infra-refs/voseo/strategic/eslint) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)