### PR TITLE
chore(deploy): activar captura de conversaciones en prod (auditoría diaria)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,6 +114,12 @@ jobs:
           # Si sidecar timeout/5xx/red caida, sidecarClient devuelve null y el
           # comportamiento es identico al pre-wiring.
           VITE_USE_SIDECAR_AGRO_MCP: "true"
+          # Captura server-side de conversaciones del agente para la auditoría
+          # diaria (review de respuestas en todas las aristas). Doble gate: esta
+          # flag + hasConsent() por usuario (privacy-first). PII completa (sin
+          # VITE_CAPTURE_ANONYMIZE); el store cae en /var/lib/agro-mcp/conversations
+          # (fuera del rsync --delete del deploy). Habeas Data: Ley 1581.
+          VITE_CAPTURE_CONVERSATIONS: "true"
           # Token X-Chagra-Token shared-secret. NOTA: termina en bundle JS
           # publico - defense-in-depth, NO auth real (auth real = nginx CORS
           # lockdown). Sincronizado con SOPS de alpha; rotacion coordinada.


### PR DESCRIPTION
Enciende `VITE_CAPTURE_CONVERSATIONS=true` en el build de prod (`deploy.yml`) para alimentar la auditoría diaria del agente.

**Doble gate intacto:** flag + `hasConsent()` por usuario (privacy-first). PII completa (sin `VITE_CAPTURE_ANONYMIZE`). Habeas Data: Ley 1581.

⚠️ **Orden de deploy:** mergear/desplegar ANTES los PRs de path seguro (chagra-pro `feat/conversations-safe-path` + guatoc-nixos `feat/conversations-dir-env`). Si no, las conversaciones caen en el target de `rsync --delete` y el primer deploy las borra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)