### PR TITLE
feat(agent): implementar modo campesino con registro oral colombiano

### DIFF
--- a/src/services/__tests__/agentPromptBase.test.js
+++ b/src/services/__tests__/agentPromptBase.test.js
@@ -8,6 +8,7 @@ import {
   buildCorpusVariants,
   formatToolEvidence,
   TOOL_EVIDENCE_MAX_CHARS,
+  buildCampesinoModeBlock,
 } from '../agentPromptBase.js';
 
 describe('analyzeQuery', () => {
@@ -567,5 +568,36 @@ describe('buildBasePrompt — regresión multiturno: anáfora + coherencia', () 
     });
     expect(prompt).toContain('CONTEXTO DE LA CONVERSACIÓN');
     expect(prompt).toContain('2000 msnm');
+  });
+});
+
+describe('buildCampesinoModeBlock', () => {
+  it('exporta buildCampesinoModeBlock', () => {
+    expect(typeof buildCampesinoModeBlock).toBe('function');
+  });
+
+  it('buildCampesinoModeBlock genera bloque con registro campesino colombiano', () => {
+    const block = buildCampesinoModeBlock();
+
+    expect(block).toContain('MODO CAMPESINO');
+    expect(block).toContain('campesino colombiano');
+    expect(block).toContain('tú/usted');
+    expect(block).toContain('NEVER vos/tenés/querés');
+    expect(block).toContain('cuadra');
+    expect(block).toContain('arroba');
+    expect(block).toContain('luna');
+    expect(block).toContain('NO uses binomios científicos');
+    expect(block).toContain('PRINCIPIO FUNDAMENTAL');
+    expect(block).toContain('NO sacrificas');
+  });
+
+  it('buildCampesinoModeBlock prohíbe voseo argentino explícitamente', () => {
+    const block = buildCampesinoModeBlock();
+
+    // Verifica que el bloque contine advertencias explícitas contra voseo argentino
+    expect(block).toMatch(/vos|tenés|querés|dale|acá|che/i);
+    // Debe mencionar que NO se debe usar voseo argentino
+    expect(block).toContain('NEVER vos');
+    expect(block).toContain('argentino');
   });
 });

--- a/src/services/__tests__/promptAssembler.budget.test.js
+++ b/src/services/__tests__/promptAssembler.budget.test.js
@@ -25,6 +25,7 @@ import {
   buildCorpusVariants,
   buildResolvedEntitiesBlock,
   formatToolEvidence,
+  buildCampesinoModeBlock,
 } from '../agentPromptBase.js';
 import {
   buildClimaContext,
@@ -282,6 +283,7 @@ function assembleForQuery({ query, resolvedEntities, suggestedEntities = null, t
 
   const blocks = {
     base: systemPrompt,
+    campesino: { variants: [buildCampesinoModeBlock(), ''] },
     clima: { variants: [buildClimaContext(CLIMA_SNAPSHOT, { region: 'andina' }), ''] },
     finca: { variants: [fincaContext, ''] },
     asociacion: { variants: [buildAssociationContext({ resolvedEntities, groupedCultivos: GROUPED_CULTIVOS }), ''] },
@@ -327,6 +329,8 @@ beforeAll(() => {
 
 // Bloques de grounding y guardas que JAMÁS pueden degradarse por presupuesto
 // (su recorte es exactamente la regresión GR-10 que este test previene).
+// NOTA: 'campesino' NO está en PROTECTED porque es un bloque sacrificable
+// (puede degradarse por presión de presupuesto sin afectar funcionalidad core).
 const PROTECTED = [
   'base',
   'viabilidad',

--- a/src/services/agentPromptBase.js
+++ b/src/services/agentPromptBase.js
@@ -326,6 +326,36 @@ const TOMATE_SAFETY_RULES = [
 ];
 
 /**
+ * buildCampesinoModeBlock — bloque MODO_CAMPESINO para registro oral campesino
+ * colombiano (tu/usted colombiano NUNCA voseo argentino, pasos concretos, frases
+ * cortas, SIN binomios científicos salvo que el usuario los pida, unidades del
+ * campo cuadra/arroba/luna).
+ *
+ * PRINCIPIO CLAVE intelligence-first: NO bajar exactitud ni grounding, solo
+ * cambia el REGISTRO. Bloque SACRIFICABLE que se puede quitar por presión de
+ * presupuesto sin afectar la funcionalidad core.
+ *
+ * @returns {string}
+ */
+export function buildCampesinoModeBlock() {
+  return `=== MODO CAMPESINO (registro oral campesino colombiano) ===
+Habla como un campesino colombiano experimentado, NO como un sistema técnico:
+- Usa tú/usted colombiano (NEVER vos/tenés/querés del argentino/rioplatense)
+- Frases cortas y directas, como habla la gente del campo
+- Unidades del campo: cuadra, arroba, luna, bike de agua, plaza, hueco
+- NO uses binomios científicos (Coffea arabica, Solanum tuberosum) salvo que el usuario los pida explícitamente
+- Usa nombres comunes: café, papa, plátano, tomate, fríjol, maíz
+- Sé respetuoso y cercano, como hablar con un vecino de la finca
+- Explica las cosas con ejemplos prácticos del día a día
+- Conjunto: "mire", "véalo así", "lo que uno hace", "en la finca uno"
+
+PRINCIPIO FUNDAMENTAL: esto es SOLO un cambio de registro. NO sacrificas
+exactitud técnica ni grounding. Si los datos dicen X, dilo X pero con palabras
+sencillas. Si no sabes algo, sé honesto como siempre.
+=== FIN MODO CAMPESINO ===`;
+}
+
+/**
  * buildBasePrompt — system prompt base del agente Chagra (instrucciones +
  * glosarios condicionales + reglas anti-alucinación CASO A/B/C).
  *
@@ -344,6 +374,7 @@ const TOMATE_SAFETY_RULES = [
  * @param {string} [args.query] — query del turno (gatea glosarios/reglas condicionales).
  * @param {string} [args.contextMemory] — historial inyectado (gatea glosarios y turn-aislamiento).
  * @param {boolean} [args.isEnum] — análisis NN2: ¿query enumerativa? (gatea CASO C completo).
+ * @param {string} [args.nivelRespuestas] — 'simple' o 'detallado' (del perfil de usuario).
  * @returns {string}
  */
 export function buildBasePrompt({
@@ -354,7 +385,8 @@ export function buildBasePrompt({
   query = '',
   contextMemory = '',
   isEnum = false,
-}) {
+  nivelRespuestas = '',
+} = {}) {
   const mention = _strip(`${query}\n${contextMemory}`);
   const sections = [];
   const conversationContextPin = buildConversationContextPin(contextMemory);
@@ -486,7 +518,8 @@ Responde en español colombiano (tú/usted, sin voseo argentino). Sé específic
   sections.push(generateAgronomicGuidanceRules());
   // Las alertas climáticas regionales del perfil solo aportan en consultas de
   // clima; en plaga/manejo se omiten para no empujar la truncación (GR-10).
-  sections.push(buildProfileContext(finca, { climaQuery: CLIMA_QUERY_RE.test(mention) }));
+  // Pasa nivelRespuestas para ajustar el nivel de detalle en buildProfileContext.
+  sections.push(buildProfileContext(finca, { climaQuery: CLIMA_QUERY_RE.test(mention), nivelRespuestas }));
 
   return sections.join('\n\n');
 }

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -455,6 +455,9 @@ export function generateUserDataRules() {
  * @param {object} [opts]
  * @param {boolean} [opts.climaQuery=true] - si false, omite el bloque de
  *   alertas climáticas regionales (solo aporta en consultas de clima).
+ * @param {string} [opts.nivelRespuestas=''] - 'simple' o 'detallado' (del perfil).
+ *   Si es 'simple', responde con pasos concretos y frases cortas.
+ *   Si es 'detallado', responde con más contexto técnico.
  * @returns {string} Contexto de perfil para system prompt
  */
 export function buildProfileContext(finca, opts = {}) {
@@ -488,10 +491,42 @@ export function buildProfileContext(finca, opts = {}) {
   // en una pregunta de plaga/manejo es peso muerto que empuja a la truncación
   // del grounding. `climaQuery` por defecto true → callers existentes y tests
   // ven el bloque completo; buildBasePrompt lo pasa false para queries no-clima.
-  const { climaQuery = true } = opts || {};
+  // `nivelRespuestas` controla el nivel de detalle: 'simple' (pasos concretos)
+  // o 'detallado' (más contexto técnico).
+  const { climaQuery = true, nivelRespuestas = '' } = opts || {};
+
+  // Añade bloque de nivel de respuestas si está especificado (ej: 'simple' o
+  // 'detallado'). Esto permite adaptar el nivel de detalle al perfil del usuario.
+  const nivelRespuestasBlock = (() => {
+    if (!nivelRespuestas || typeof nivelRespuestas !== 'string') return '';
+    const nivel = nivelRespuestas.toLowerCase().trim();
+    if (nivel === 'simple') {
+      return `NIVEL DE RESPUESTA: SIMPLE (pasos concretos).
+- Responde con pasos claros y cortos, como hablar con un vecino.
+- Evita tecnicismos innecesarios.
+- Prioriza lo práctico: qué hacer, cuándo, cómo.
+- Usa unidades del campo: cuadra, arroba, luna, bike de agua, plaza.
+- Si necesitas explicar algo técnico, usa ejemplos de la finca.`;
+    }
+    if (nivel === 'detallado') {
+      return `NIVEL DE RESPUESTA: DETALLADO (más contexto técnico).
+- Puedes explicar el porqué de las recomendaciones.
+- Incluye referencias a fuentes técnicas cuando sea relevante.
+- Puedes mencionar conceptos técnicos si aclaras su significado.
+- Mantén el lenguaje accesible pero con más profundidad.`;
+    }
+    return '';
+  })();
 
   if (!finca) {
-    return generateSourceCitationRules() + '\n\n' + generateUserDataRules() + profileSuffix + veredaContext;
+    const blocks = [
+      generateSourceCitationRules(),
+      generateUserDataRules(),
+      nivelRespuestasBlock,
+      profileSuffix,
+      veredaContext,
+    ].filter((s) => s && s.trim());
+    return blocks.join('\n\n');
   }
 
   const bioculturalZone = finca.biocultural_zone;
@@ -501,7 +536,13 @@ export function buildProfileContext(finca, opts = {}) {
   const citationRules = generateSourceCitationRules();
   const userDataRules = generateUserDataRules();
 
-  return [toneContext, climateContext, citationRules, `${userDataRules}${profileSuffix}${veredaContext}`]
+  return [
+    toneContext,
+    climateContext,
+    citationRules,
+    nivelRespuestasBlock,
+    `${userDataRules}${profileSuffix}${veredaContext}`,
+  ]
     .filter((s) => s && s.trim())
     .join('\n\n');
 }

--- a/src/services/promptAssembler.js
+++ b/src/services/promptAssembler.js
@@ -78,6 +78,7 @@ export function estimateTokens(text) {
  */
 export const BLOCK_ORDER = [
   'base', // instrucciones + glosarios + perfil (protegido)
+  'campesino', // MODO CAMPESINO registro oral — sacrificable
   'clima', // contexto ambiental — sacrificable en emergencia
   'finca', // contexto ambiental — sacrificable en emergencia
   'asociacion', // policultivo — sacrificable en emergencia
@@ -106,10 +107,11 @@ export const BLOCK_ORDER = [
 // chunks), luego la MEMORIA EPISÓDICA (personalización: valiosa pero nunca por
 // encima de las guardas ni la evidencia — TIER 2 #6), luego el contexto
 // AMBIENTAL (asociaciones, fase ENSO, riesgo térmico y por último el marco de
-// finca — su altitud también la cita el bloque de viabilidad). El grounding
+// finca — su altitud también la cita el bloque de viabilidad), y finalmente el
+// MODO CAMPESINO (cambio de registro, valioso pero sacrificable). El grounding
 // duro (evidencia, entidades, dosis curadas, cadena del grafo) y las guardas
 // NUNCA están aquí: jamás se recortan.
-const SACRIFICE_ORDER = ['corpus', 'memoria', 'asociacion', 'clima', 'frostHeat', 'finca'];
+const SACRIFICE_ORDER = ['corpus', 'memoria', 'asociacion', 'clima', 'frostHeat', 'finca', 'campesino'];
 
 const _normalize = (t) => (typeof t === 'string' ? t.replace(/^\n+|\n+$/g, '') : '');
 


### PR DESCRIPTION
## Summary

Implementar el modo Campesino REAL con registro oral campesino colombiano (tu/usted colombiano, NUNCA voseo argentino, pasos concretos, frases cortas, SIN binomios cientificos salvo que el usuario los pida, unidades del campo: cuadra/arroba/luna).

## Cambios implementados

1. **agentPromptBase.js**:
   - Anadido `buildCampesinoModeBlock()` que genera el bloque MODO_CAMPESINO con registro oral campesino colombiano
   - Actualizado `buildBasePrompt()` para aceptar parametro `nivelRespuestas` y pasarlo a `buildProfileContext()`

2. **agentService.js**:
   - Actualizado `buildProfileContext()` para soportar parametro `nivelRespuestas`
   - Implementado logica para ajustar nivel de detalle (simple/detallado) segun perfil de usuario

3. **promptAssembler.js**:
   - Anadido 'campesino' a `BLOCK_ORDER` (despues de 'base', antes de 'clima')
   - Anadido 'campesino' a `SACRIFICE_ORDER` como bloque sacrificable (ultimo en orden de sacrificio)

4. **Tests**:
   - Anadidos tests para `buildCampesinoModeBlock()` verificando:
     - Export correcto de la funcion
     - Contenido con registro campesino colombiano
     - Prohibicion explicita de voseo argentino
   - Actualizado `promptAssembler.budget.test.js` para incluir bloque campesino en el ensamblado

## Test plan

- ✅ Todos los tests de agentPromptBase.test.js pasan (56 tests)
- ✅ Todos los tests de promptAssembler.budget.test.js pasan (9 tests) 
- ✅ npm run build exitoso sin errores
- ✅ eslint limpio (0 warnings)
- ✅ Verificado que el bloque campesino se incluye correctamente en BLOCK_ORDER
- ✅ Verificado que el bloque campesino es sacrificable segun SACRIFICE_ORDER
- ✅ Verificado que el presupuesto de 6144 tokens no se revienta con el nuevo bloque

## MCP tools usadas

Ninguna - esta implementacion es puramente de codigo, no requiere MCP tools.

## Principios implementados

- **Intelligence-first**: NO bajar exactitud ni grounding, solo cambia el REGISTRO
- **Bloque SACRIFICABLE**: Se puede quitar por presion de presupuesto sin afectar funcionalidad core
- **Espanol colombiano**: tu/usted, NUNCA voseo argentino (vos/tenes/ques)
- **Registro campesino**: Pasos concretos, frases cortas, unidades del campo
- **Anti-alucinacion**: NO usar binomios cientificos salvo que el usuario los pida explicitamente

## Riesgos conocidos

- El bloque campesino anade ~300 tokens al prompt, pero esta configurado como sacrificable
- Si el presupuesto se reventara, el bloque campesino se degrada primero (despues de corpus/memoria/asociacion/clima/frostHeat/finca)
- El registro campesino esta disenado para NO afectar la exactitud tecnica ni el grounding

## Notas de implementacion

- El bloque 'campesino' esta posicionado en BLOCK_ORDER despues de 'base' para que se aplique el cambio de registro antes del contexto ambiental
- En SACRIFICE_ORDER, 'campesino' es el ultimo en sacrificarse, priorizando corpus/memoria/asociacion primero
- La funcion buildCampesinoModeBlock() es pura y sincrona, sin dependencias externas
