### PR TITLE
feat(multifinca): data-testids + cobertura unit/e2e del selector de finca

### DIFF
--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -1450,6 +1450,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
             onClick={() => setShowFincaModal(true)}
             className="flex items-center gap-1.5 text-[10px] font-bold uppercase text-emerald-400 bg-emerald-900/30 border border-emerald-700/40 rounded-full px-3 py-1.5 shrink-0 hover:bg-emerald-900/50 transition-all active:scale-95 group"
             aria-label={hasMultipleFincas ? `Cambiar de finca (actual: ${fincaNombre})` : `Finca activa: ${fincaNombre}`}
+            data-testid="assets-finca-switcher"
           >
             <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse group-hover:scale-125 transition-transform"></div>
             <span className="truncate max-w-[10ch]">{fincaNombre}</span>

--- a/src/components/FincaCard.jsx
+++ b/src/components/FincaCard.jsx
@@ -31,7 +31,7 @@ export function FincaCard({finca, onSelect, onConfigure}) {
     const estadoClass = estadoColors[finca.estado] || estadoColors.pendiente;
 
     return (
-        <div className="bg-slate-900 border border-slate-800 rounded-xl p-4 space-y-3 hover:border-slate-700 transition-colors">
+        <div className="bg-slate-900 border border-slate-800 rounded-xl p-4 space-y-3 hover:border-slate-700 transition-colors" data-testid={`multifinca-card-${finca.slug}`}>
             <div className="flex items-start justify-between">
                 <div className="space-y-1">
                     <h3 className="font-bold text-lg text-white leading-tight">
@@ -76,6 +76,7 @@ export function FincaCard({finca, onSelect, onConfigure}) {
                     <button
                         onClick={() => onSelect?.(finca)}
                         className="w-full flex items-center justify-center gap-2 py-2.5 bg-emerald-600 text-white rounded-lg font-bold hover:bg-emerald-500 active:scale-95 transition-all"
+                        data-testid={`multifinca-enter-${finca.slug}`}
                     >
                         Entrar a la finca
                         <ArrowRight size={16} />
@@ -84,6 +85,7 @@ export function FincaCard({finca, onSelect, onConfigure}) {
                     <button
                         onClick={() => onConfigure?.(finca)}
                         className="w-full flex items-center justify-center gap-2 py-2.5 bg-amber-600 text-white rounded-lg font-bold hover:bg-amber-500 active:scale-95 transition-all"
+                        data-testid={`multifinca-configure-${finca.slug}`}
                     >
                         <Settings size={16} />
                         Configurar FarmOS

--- a/src/components/MultiFincaModal.jsx
+++ b/src/components/MultiFincaModal.jsx
@@ -54,8 +54,9 @@ export default function MultiFincaModal({ onClose }) {
                 aria-modal="true"
                 className="fixed inset-0 z-[101] bg-black/80 backdrop-blur-md flex items-end sm:items-center justify-center p-0 sm:p-4 transition-all duration-300 animate-in fade-in"
                 onClick={(e) => e.target === e.currentTarget && onClose()}
+                data-testid="multifinca-modal"
             >
-                <div className="w-full max-w-2xl bg-slate-950 border border-slate-800 rounded-t-3xl sm:rounded-3xl flex flex-col max-h-[95vh] sm:max-h-[85vh] overflow-hidden shadow-2xl animate-in slide-in-from-bottom sm:zoom-in-95 duration-300 text-white">
+                <div className="w-full max-w-2xl bg-slate-950 border border-slate-800 rounded-t-3xl sm:rounded-3xl flex flex-col max-h-[95vh] sm:max-h-[85vh] overflow-hidden shadow-2xl animate-in slide-in-from-bottom sm:zoom-in-95 duration-300 text-white" data-testid="multifinca-panel">
                     <header className="p-4 border-b border-slate-800 flex items-center justify-between bg-slate-900/50 shrink-0">
                         <div className="flex items-center gap-3">
                             <div className="p-2 bg-primary/20 rounded-lg text-primary">
@@ -82,6 +83,7 @@ export default function MultiFincaModal({ onClose }) {
                                 className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-bold transition-colors ${
                                     viewMode === 'globe' ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
                                 }`}
+                                data-testid="multifinca-view-globe"
                             >
                                 <Globe size={14} />
                                 Mapa
@@ -91,6 +93,7 @@ export default function MultiFincaModal({ onClose }) {
                                 className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-bold transition-colors ${
                                     viewMode === 'grid' ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
                                 }`}
+                                data-testid="multifinca-view-grid"
                             >
                                 <LayoutGrid size={14} />
                                 Cards
@@ -112,7 +115,7 @@ export default function MultiFincaModal({ onClose }) {
                         )}
                     </div>
 
-                    <footer className="p-4 border-t border-slate-900 bg-slate-900/20 shrink-0 flex justify-between items-center">
+                    <footer className="p-4 border-t border-slate-900 bg-slate-900/20 shrink-0 flex justify-between items-center" data-testid="multifinca-footer">
                         <div className="flex items-center gap-2">
                             <div className="w-2 h-2 rounded-full bg-primary animate-pulse"></div>
                             <span className="text-[10px] text-slate-500 font-mono italic">Nodo Central: Guatoc Choachí</span>

--- a/src/components/__tests__/MultiFincaModal.test.jsx
+++ b/src/components/__tests__/MultiFincaModal.test.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const setActiveFincaManual = vi.fn();
+const setFincas = vi.fn();
+const storeState = {
+  fincas: [
+    {
+      slug: 'guatoc',
+      nombre: 'Guatoc',
+      operador: 'Familia Chagra',
+      estado: 'activo',
+      farmos_endpoint: 'https://guatoc.farmos.net',
+    },
+    {
+      slug: 'la-ceiba',
+      nombre: 'La Ceiba',
+      operador: 'Asociación Ceiba Viva',
+      estado: 'piloto',
+      farmos_endpoint: null,
+    },
+  ],
+  setFincas,
+  setActiveFincaManual,
+};
+
+vi.mock('../MultiFincaGlobe', () => ({
+  default: () => <div data-testid="multifinca-globe-stub" />,
+}));
+
+vi.mock('../OnboardingModal', () => ({
+  default: ({ finca, onClose }) => (
+    <div data-testid="onboarding-modal-stub">
+      <span>{finca?.nombre}</span>
+      <button onClick={onClose}>Cerrar onboarding</button>
+    </div>
+  ),
+}));
+
+vi.mock('../../services/fincaActiveStore', () => ({
+  useFincaActiveStore: () => storeState,
+}));
+
+describe('MultiFincaModal', () => {
+  beforeEach(() => {
+    setActiveFincaManual.mockClear();
+    setFincas.mockClear();
+    storeState.fincas = [
+      {
+        slug: 'guatoc',
+        nombre: 'Guatoc',
+        operador: 'Familia Chagra',
+        estado: 'activo',
+        farmos_endpoint: 'https://guatoc.farmos.net',
+      },
+      {
+        slug: 'la-ceiba',
+        nombre: 'La Ceiba',
+        operador: 'Asociación Ceiba Viva',
+        estado: 'piloto',
+        farmos_endpoint: null,
+      },
+    ];
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('hidrata fincas desde fincas-publicas.json cuando el store viene vacío', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    storeState.fincas = [];
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => storeState.fincas,
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const { default: MultiFincaModal } = await import('../MultiFincaModal');
+
+    render(<MultiFincaModal onClose={onClose} />);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith('/fincas-publicas.json'));
+    expect(setFincas).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('multifinca-globe-stub')).toBeTruthy();
+
+    await user.click(screen.getByTestId('multifinca-view-grid'));
+    expect(screen.getByText(/No hay fincas registradas/i)).toBeTruthy();
+  });
+
+  it('permite cambiar a vista cards y entrar a una finca con endpoint', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const { default: MultiFincaModal } = await import('../MultiFincaModal');
+
+    render(<MultiFincaModal onClose={onClose} />);
+
+    expect(screen.getByTestId('multifinca-globe-stub')).toBeTruthy();
+
+    await user.click(screen.getByTestId('multifinca-view-grid'));
+    expect(screen.getByTestId('multifinca-footer')).toBeTruthy();
+
+    await user.click(screen.getByTestId('multifinca-enter-guatoc'));
+    expect(setActiveFincaManual).toHaveBeenCalledWith('guatoc');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('abre onboarding cuando la finca no tiene endpoint', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const { default: MultiFincaModal } = await import('../MultiFincaModal');
+
+    render(<MultiFincaModal onClose={onClose} />);
+
+    await user.click(screen.getByTestId('multifinca-view-grid'));
+    await user.click(screen.getByTestId('multifinca-configure-la-ceiba'));
+
+    expect(screen.getByTestId('onboarding-modal-stub')).toBeTruthy();
+    expect(screen.getByTestId('onboarding-modal-stub')).toHaveTextContent('La Ceiba');
+    expect(setActiveFincaManual).not.toHaveBeenCalledWith('la-ceiba');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('no vuelve a fetchear fincas si el store ya tiene datos', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const { default: MultiFincaModal } = await import('../MultiFincaModal');
+
+    render(<MultiFincaModal onClose={onClose} />);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId('multifinca-view-grid'));
+    expect(screen.getByTestId('multifinca-card-guatoc')).toBeTruthy();
+  });
+});

--- a/src/services/__tests__/fincaActiveStore.test.js
+++ b/src/services/__tests__/fincaActiveStore.test.js
@@ -3,6 +3,7 @@ import { useFincaActiveStore } from '../fincaActiveStore';
 
 describe('fincaActiveStore', () => {
     beforeEach(() => {
+        localStorage.clear();
         useFincaActiveStore.setState({
             activeFincaSlug: 'guatoc',
             fincas: [
@@ -45,6 +46,15 @@ describe('fincaActiveStore', () => {
         expect(useFincaActiveStore.getState().gpsOverride).toBe(false);
         // Slug debe persistir tras clearGpsOverride
         expect(useFincaActiveStore.getState().activeFincaSlug).toBe('naranjalia');
+    });
+
+    it('persists the active finca slug in localStorage storage payload', () => {
+        useFincaActiveStore.getState().setActiveFincaManual('naranjalia');
+        const raw = localStorage.getItem('chagra:active-finca');
+        expect(raw).toBeTruthy();
+        const parsed = JSON.parse(raw);
+        expect(parsed.state.activeFincaSlug).toBe('naranjalia');
+        expect(parsed.state.gpsOverride).toBe(true);
     });
 
     // Edge: empty fincas[] (boot inicial antes de fetch fincas-publicas.json)

--- a/src/store/__tests__/useAssetStore.test.js
+++ b/src/store/__tests__/useAssetStore.test.js
@@ -32,6 +32,40 @@ describe('useAssetStore', function () {
     expect(useAssetStore.getState().getAllAssets()).toHaveLength(2);
   });
 
+  it('tenantChanged limpia el estado en memoria y rehidrata', async function () {
+    const hydrate = vi.fn().mockResolvedValue(undefined);
+    useAssetStore.setState({
+      plants: [{ id: 'stale-plant' }],
+      structures: [{ id: 'stale-structure' }],
+      equipment: [{ id: 'stale-equipment' }],
+      materials: [{ id: 'stale-material' }],
+      lands: [{ id: 'stale-land' }],
+      taxonomyTerms: [{ id: 'stale-tax' }],
+      lastSync: 123,
+      selectedAssetId: 'selected-stale',
+      syncProgress: { current: 1, total: 1 },
+      error: 'stale-error',
+      hydrate,
+    });
+
+    window.dispatchEvent(
+      new CustomEvent('tenantChanged', { detail: { previous: 'alice', current: 'bob' } }),
+    );
+
+    const s = useAssetStore.getState();
+    expect(s.plants).toEqual([]);
+    expect(s.structures).toEqual([]);
+    expect(s.equipment).toEqual([]);
+    expect(s.materials).toEqual([]);
+    expect(s.lands).toEqual([]);
+    expect(s.taxonomyTerms).toEqual([]);
+    expect(s.lastSync).toBeNull();
+    expect(s.selectedAssetId).toBeNull();
+    expect(s.syncProgress).toBeNull();
+    expect(s.error).toBeNull();
+    expect(hydrate).toHaveBeenCalledTimes(1);
+  });
+
   it('addAssetsBulk rejects empty', async function () {
     await expect(useAssetStore.getState().addAssetsBulk('plant', []))
       .rejects.toThrow('no vac');

--- a/src/store/__tests__/useCaseStudyStore.tenant.test.js
+++ b/src/store/__tests__/useCaseStudyStore.tenant.test.js
@@ -199,6 +199,7 @@ describe('useCaseStudyStore tenant scoping (ADR-036 MVP)', () => {
     const aliceId = makeCase('alice 1');
     setActiveTenantId('bob');
     const bobId = makeCase('bob 1');
+    const before = useCaseStudyStore.getState().cases;
 
     // Disparar el evento simula el switch de login → tenantContext.setActive*.
     setActiveTenantId('alice');
@@ -207,10 +208,41 @@ describe('useCaseStudyStore tenant scoping (ADR-036 MVP)', () => {
     );
 
     // Ambos casos siguen en cases[] (no se borra nada en localStorage).
-    const raw = useCaseStudyStore.getState().cases.map((c) => c.id).sort();
+    const after = useCaseStudyStore.getState().cases;
+    expect(after).not.toBe(before);
+    const raw = after.map((c) => c.id).sort();
     expect(raw).toEqual([aliceId, bobId].sort());
 
     // Pero el selector solo retorna alice.
     expect(useCaseStudyStore.getState().getActive().map((c) => c.title)).toEqual(['alice 1']);
+  });
+
+  it('tenantChanged keeps legacy cases visible for the new active tenant', () => {
+    useCaseStudyStore.setState({
+      cases: [
+        {
+          id: 'LEGACY-2',
+          title: 'legacy visible',
+          finca_slug: 'guatoc',
+          subject: { species_ids: [], count_total: null, count_affected: null },
+          problem: { name_freetext: 'legacy', severity: 'low', detected_at: new Date().toISOString() },
+          treatments_applied: [],
+          event_log_ids: [],
+          photo_asset_ids: [],
+          state: 'open',
+          state_history: [],
+          outcome: { closed_at: null, final_count_affected: null, lessons_learned: '' },
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ],
+    });
+
+    setActiveTenantId('alice');
+    const before = useCaseStudyStore.getState().cases;
+    window.dispatchEvent(new CustomEvent('tenantChanged', { detail: { previous: 'bob', current: 'alice' } }));
+    const after = useCaseStudyStore.getState().cases;
+    expect(after).not.toBe(before);
+    expect(useCaseStudyStore.getState().getById('LEGACY-2')?.title).toBe('legacy visible');
   });
 });

--- a/tests/e2e-integral-logueado.spec.js
+++ b/tests/e2e-integral-logueado.spec.js
@@ -1,0 +1,153 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * e2e-integral-logueado.spec.js
+ *
+ * Smoke integral con usuario logueado y backend mockeado:
+ *   - confirma que el home autenticado renderiza,
+ *   - que el selector de finca activa abre el modal multi-finca,
+ *   - y que el cambio de tenant visible funciona.
+ *
+ * Es una primera pasada útil para el harness "integral logueado":
+ * no sustituye el nightly real, pero sí hace gating local reproducible.
+ */
+
+const ORIGIN = 'http://localhost:5173';
+const USER = 'e2e-integral';
+
+const FINCAS_FIXTURE = [
+  {
+    slug: 'guatoc',
+    nombre: 'Guatoc',
+    operador: 'Familia Chagra',
+    estado: 'activo',
+    farmos_endpoint: 'http://localhost:8080',
+    biocultural_zone: 'andino_alto_páramo',
+  },
+  {
+    slug: 'la-ceiba',
+    nombre: 'La Ceiba',
+    operador: 'Asociación Ceiba Viva',
+    estado: 'piloto',
+    farmos_endpoint: 'http://localhost:8081',
+    biocultural_zone: 'cafetero',
+  },
+];
+
+async function mockBackend(page) {
+  await page.context().route('**/oauth/token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'e2e-integral-token',
+        refresh_token: 'e2e-integral-refresh',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      }),
+    }),
+  );
+
+  const emptyJsonApi = JSON.stringify({ data: [], jsonapi: { version: '1.0' } });
+  for (const pattern of ['**/api/asset/**', '**/api/log/**', '**/api/taxonomy_term/**', '**/api/user/**']) {
+    await page.context().route(pattern, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: emptyJsonApi,
+      }),
+    );
+  }
+
+  await page.context().route('**/fincas-publicas.json', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(FINCAS_FIXTURE),
+    }),
+  );
+
+  await page.context().route('**/nlu', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) }),
+  );
+  await page.context().route('**/resolve-entities', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) }),
+  );
+  await page.context().route('**/post-validate', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) }),
+  );
+}
+
+async function seedSession(page) {
+  await page.addInitScript((username) => {
+    try {
+      window.localStorage.setItem('chagra:active_tenant_id', username);
+      window.localStorage.setItem(
+        'chagra:profile:v1',
+        JSON.stringify({
+          rol: 'operador',
+          vocacion: 'mixta',
+          finca_tipo: 'integral',
+          nivel_respuestas: 'detallado',
+        }),
+      );
+    } catch (_) {
+      /* noop */
+    }
+  }, USER);
+}
+
+async function login(page) {
+  await page.evaluate(async (username) => {
+    const authMod = await import('/src/services/authService.js');
+    const result = await authMod.authenticateUser(username, 'e2e-integral-pwd');
+    if (!result.success) {
+      throw new Error(`Login mock falló: ${result.error || 'sin detalle'}`);
+    }
+    const tenantMod = await import('/src/services/tenantContext.js');
+    tenantMod.setActiveTenantId(username);
+  }, USER);
+}
+
+test.describe('e2e integral logueado', () => {
+  test('home autenticado + multi-finca + navegación básica no se rompen', async ({ page }) => {
+    await seedSession(page);
+    await mockBackend(page);
+
+    await page.goto(ORIGIN, { waitUntil: 'domcontentloaded' });
+    await login(page);
+    await page.goto(ORIGIN, { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle').catch(() => {});
+
+    await expect(page.locator('body')).toContainText(/Agente Chagra|Mis plantas|Home/i);
+
+    const switcher = page.getByTestId('assets-finca-switcher');
+    await expect(switcher).toBeVisible();
+    await expect(switcher).toContainText(/Guatoc/i);
+    await switcher.click();
+
+    const modal = page.getByTestId('multifinca-modal');
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(/Red de Fincas Chagra/i);
+
+    await page.getByTestId('multifinca-view-grid').click();
+    await expect(page.getByTestId('multifinca-footer')).toBeVisible();
+    await page.getByTestId('multifinca-enter-la-ceiba').click();
+    await expect(page.getByTestId('multifinca-modal')).toBeHidden();
+    await expect(switcher).toContainText(/La Ceiba/i);
+
+    // La finca activa debe sobrevivir un reload porque el store persiste en localStorage.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle').catch(() => {});
+    await expect(page.locator('body')).toContainText(/Agente Chagra|Mis plantas|Home/i);
+    await expect(page.getByTestId('assets-finca-switcher')).toContainText(/La Ceiba/i);
+    await expect(page.evaluate(() => window.localStorage.getItem('chagra:active-finca'))).resolves.toContain('la-ceiba');
+
+    // Smoke de cierre: el botón cerrar debe existir y el modal debe cerrar.
+    const switcherAfterReload = page.getByTestId('assets-finca-switcher');
+    await switcherAfterReload.click();
+    await expect(page.getByTestId('multifinca-modal')).toBeVisible();
+    await page.getByRole('button', { name: /Cerrar selector|Cerrar/i }).first().click();
+    await expect(page.getByTestId('multifinca-modal')).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Qué
Estabiliza el flujo multi-finca con `data-testid` estables y cobertura de tests.

- **testids**: `assets-finca-switcher`, `multifinca-modal` (overlay), `multifinca-panel` (panel interno), `multifinca-view-globe/grid`, `multifinca-footer`, `multifinca-card-<slug>`, `multifinca-enter-<slug>`, `multifinca-configure-<slug>`.
- **unit** (`MultiFincaModal.test.jsx`): hidratación desde `fincas-publicas.json`, cambio de vista globe/grid, entrar a finca con endpoint, onboarding cuando no hay endpoint, no-refetch con store poblado.
- **e2e** (`e2e-integral-logueado.spec.js`): smoke logueado + cambio de tenant visible + persistencia (`chagra:active-finca`).
- **store tests**: fincaActiveStore / useAssetStore / useCaseStudyStore.tenant.

## Verificado
- vitest local sobre `main`: **36 tests verdes** (4 archivos).
- Sin voseo; sin secretos reales (tokens de mock).

## Fuera de scope (follow-up)
El snapshot visual se posterga a propósito: el `data-testid` del overlay captura toda la pantalla (incluye toasts transitorios) → baseline frágil. El follow-up apuntará el screenshot a `multifinca-panel` con baseline generado en CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)