### PR TITLE
chore(scripts): tooling ingesta folk fitopatología → AGE (preflight + loader)

### DIFF
--- a/scripts/__tests__/age-etno-preflight.test.mjs
+++ b/scripts/__tests__/age-etno-preflight.test.mjs
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { buildPreflightSummary, extractFolkMappings } from '../age-etno-preflight.mjs';
+
+// El SQL fuente es contenido curado que vive FUERA de este repo público.
+// En CI (sin CHAGRA_AGE_ETNO_SQL) estos casos hacen skip; localmente, con el env
+// apuntando al SQL curado, validan el paquete real.
+const SQL_PATH = process.env.CHAGRA_AGE_ETNO_SQL || '';
+const hasSql = Boolean(SQL_PATH) && existsSync(SQL_PATH);
+
+describe.skipIf(!hasSql)('age-etno-preflight', () => {
+  // Lazy: el cuerpo del describe corre en colección aunque los it() se salten;
+  // sin este guard, el readFileSync eager rompería la colección en CI sin env.
+  const sql = hasSql ? readFileSync(SQL_PATH, 'utf8') : '';
+  const mappings = hasSql ? extractFolkMappings(sql) : [];
+  const summary = hasSql ? buildPreflightSummary() : {};
+
+  it('extrae los 9 mapeos folk↔Pest del SQL fuente', () => {
+    expect(mappings).toHaveLength(10);
+    expect(mappings.map((m) => m.label)).toContain('gota');
+    expect(mappings.map((m) => m.pestId)).toContain('ralstonia_solanacearum');
+  });
+
+  it('resume el preflight con léxico listo y mapeos cerrados', () => {
+    expect(summary.lexicoKind).toBe('chagra-lexico-campesino');
+    expect(summary.lexicoEntries).toBe(39);
+    expect(summary.mappingCount).toBe(10);
+    expect(summary.missingLabels).toEqual([]);
+    expect(summary.missingPests).toEqual([]);
+    expect(summary.ready).toBe(true);
+  });
+});

--- a/scripts/__tests__/ingest_folk_fitopatologia.test.mjs
+++ b/scripts/__tests__/ingest_folk_fitopatologia.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * scripts/__tests__/ingest_folk_fitopatologia.test.mjs
+ *
+ * Guarda de la ingesta folk fitopatología → AGE.
+ * No toca Postgres real; valida que el SQL idempotente mantenga:
+ *   - un nodo FolkSymptom por término folk,
+ *   - una arista FOLK_NAME_OF por mapeo,
+ *   - ids únicos y mapeos explícitos para los términos documentados.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+
+// El SQL fuente es contenido curado que vive FUERA de este repo público.
+// En CI (sin CHAGRA_AGE_ETNO_SQL) la suite hace skip; localmente, con el env
+// apuntando al SQL curado, valida la estructura idempotente real.
+const SQL_PATH = process.env.CHAGRA_AGE_ETNO_SQL || '';
+const hasSql = Boolean(SQL_PATH) && existsSync(SQL_PATH);
+
+function loadSql() {
+  return readFileSync(SQL_PATH, 'utf8');
+}
+
+function extractIds(sql) {
+  return [...sql.matchAll(/MERGE \(f:FolkSymptom \{id: '([^']+)'\}\)/g)].map((m) => m[1]);
+}
+
+function extractLabels(sql) {
+  return [...sql.matchAll(/SET f\.label = '([^']+)'/g)].map((m) => m[1]);
+}
+
+function extractPestIds(sql) {
+  return [...sql.matchAll(/MATCH \(p:Pest \{id: '([^']+)'\}\)/g)].map((m) => m[1]);
+}
+
+describe.skipIf(!hasSql)('ingest_folk_fitopatologia.sql — guarda estructural', () => {
+  // Lazy: el cuerpo del describe corre en colección aunque los it() se salten.
+  const sql = hasSql ? loadSql() : '';
+  const ids = hasSql ? extractIds(sql) : [];
+  const labels = hasSql ? extractLabels(sql) : [];
+  const pestIds = hasSql ? extractPestIds(sql) : [];
+
+  it('existe y tiene contenido útil', () => {
+    expect(sql).toContain('FOLK_NAME_OF');
+    expect(sql).toContain('FolkSymptom');
+    expect(sql.length).toBeGreaterThan(1000);
+  });
+
+  it('mantiene ids únicos de FolkSymptom', () => {
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it('cubre los términos folk documentados en el SQL', () => {
+    const labelSet = new Set(labels);
+    for (const label of [
+      'gota',
+      'ojo de gallo',
+      'candelilla',
+      'monilia',
+      'tizón',
+      'tizón tardío',
+      'mancha de hierro',
+      'escoba de bruja',
+      'se pudre la raíz',
+      'mata triste-mustia',
+    ]) {
+      expect(labelSet.has(label), `falta el término ${label}`).toBe(true);
+    }
+  });
+
+  it('cada bloque FolkSymptom tiene su arista FOLK_NAME_OF correspondiente', () => {
+    const relationCount = (sql.match(/FOLK_NAME_OF/g) || []).length;
+    expect(relationCount).toBeGreaterThanOrEqual(ids.length);
+  });
+
+  it('ancla a Pest canónicos existentes, no a aliases arbitrarios', () => {
+    for (const pestId of [
+      'phytophthora_infestans',
+      'mycena_citricolor',
+      'moniliophthora_roreri',
+      'alternaria_solani',
+      'cercospora_coffeicola',
+      'moniliophthora_perniciosa',
+      'rhizoctonia_solani',
+      'ralstonia_solanacearum',
+    ]) {
+      expect(pestIds).toContain(pestId);
+    }
+  });
+});

--- a/scripts/__tests__/load-age-etno-folk-fitopatologia.test.mjs
+++ b/scripts/__tests__/load-age-etno-folk-fitopatologia.test.mjs
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { buildPsqlInvocation, buildVerificationSql, parseArgs, buildRunReport } from '../load-age-etno-folk-fitopatologia.mjs';
+
+describe('load-age-etno-folk-fitopatologia', () => {
+  it('parsea flags básicos', () => {
+    const opts = parseArgs(['--sql', '/tmp/x.sql', '--dry-run', '--force', '--json']);
+    expect(opts.sql).toBe('/tmp/x.sql');
+    expect(opts.dryRun).toBe(true);
+    expect(opts.force).toBe(true);
+    expect(opts.json).toBe(true);
+  });
+
+  it('parsea --preflight-only', () => {
+    const opts = parseArgs(['--preflight-only']);
+    expect(opts.preflightOnly).toBe(true);
+    expect(opts.dryRun).toBe(false);
+  });
+
+  it('parsea --no-verify', () => {
+    const opts = parseArgs(['--no-verify']);
+    expect(opts.verify).toBe(false);
+  });
+
+  it('usa podman exec por defecto cuando no hay override', () => {
+    const prev = process.env.CHAGRA_AGE_PSQL_COMMAND;
+    delete process.env.CHAGRA_AGE_PSQL_COMMAND;
+    const inv = buildPsqlInvocation();
+    if (prev !== undefined) process.env.CHAGRA_AGE_PSQL_COMMAND = prev;
+    expect(inv.kind).toBe('podman');
+    expect(inv.args).toContain('postgres-farm');
+    expect(inv.args).toContain('psql');
+  });
+
+  it('respeta override shell explícito', () => {
+    const prev = process.env.CHAGRA_AGE_PSQL_COMMAND;
+    process.env.CHAGRA_AGE_PSQL_COMMAND = 'psql -h 127.0.0.1 -p 5432 -U farmos -d chagra_kg';
+    const inv = buildPsqlInvocation();
+    if (prev !== undefined) process.env.CHAGRA_AGE_PSQL_COMMAND = prev;
+    else delete process.env.CHAGRA_AGE_PSQL_COMMAND;
+    expect(inv.kind).toBe('shell');
+    expect(inv.command).toContain('psql -h 127.0.0.1');
+  });
+
+  it('buildVerificationSql emite conteos de aristas y nodos FolkSymptom', () => {
+    const sql = buildVerificationSql('chagra_kg');
+    expect(sql).toContain('FOLK_NAME_OF');
+    expect(sql).toContain('MATCH (f:FolkSymptom) RETURN f');
+    expect(sql).toContain("LOAD 'age'");
+  });
+});
+
+describe('buildRunReport', () => {
+  const mockSummary = {
+    ready: true,
+    mappingCount: 10,
+    uniqueLabelCount: 10,
+    uniquePestCount: 8,
+    missingLabels: [],
+    missingPests: [],
+  };
+
+  it('reporta modo preflight-only', () => {
+    const report = buildRunReport(mockSummary, { preflightOnly: true, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false });
+    expect(report.mode).toBe('preflight-only');
+    expect(report.preflight.ready).toBe(true);
+    expect(report.verify).toBe('on');
+  });
+
+  it('reporta modo dry-run', () => {
+    const report = buildRunReport(mockSummary, { preflightOnly: false, dryRun: true, verify: true, sql: '/tmp/x.sql', force: false });
+    expect(report.mode).toBe('dry-run');
+    expect(report.verify).toBe('on');
+  });
+
+  it('reporta modo real-run', () => {
+    const report = buildRunReport(mockSummary, { preflightOnly: false, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false });
+    expect(report.mode).toBe('real-run');
+    expect(report.preflight.mappingCount).toBe(10);
+  });
+
+  it('reporta missing labels cuando hay', () => {
+    const badSummary = { ...mockSummary, ready: false, missingLabels: ['gota'] };
+    const report = buildRunReport(badSummary, { preflightOnly: true, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false });
+    expect(report.preflight.ready).toBe(false);
+    expect(report.preflight.missingLabels).toEqual(['gota']);
+  });
+
+  it('incluye psql command en el reporte', () => {
+    const report = buildRunReport(mockSummary, { preflightOnly: true, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false });
+    expect(report.psqlCommand).toBeTruthy();
+    expect(typeof report.psqlCommand).toBe('string');
+  });
+
+  it('verificationSql es null cuando verify=off', () => {
+    const report = buildRunReport(mockSummary, { preflightOnly: true, dryRun: false, verify: false, sql: '/tmp/x.sql', force: false });
+    expect(report.verificationSql).toBeNull();
+    expect(report.verify).toBe('off');
+  });
+});

--- a/scripts/age-etno-preflight.mjs
+++ b/scripts/age-etno-preflight.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * scripts/age-etno-preflight.mjs
+ *
+ * Preflight local para la ingesta etnolingüística fitopatológica.
+ * No toca AGE ni red: solo valida que el SQL fuente y el léxico offline
+ * están presentes, que los mapeos folk→Pest son consistentes y que el
+ * paquete documental tiene la estructura esperada para ejecutar la corrida
+ * aplicada luego.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const _here = dirname(fileURLToPath(import.meta.url));
+
+// SQL fuente de la ingesta folk fitopatología: contenido curado que vive FUERA
+// de este repo. Se pasa por env CHAGRA_AGE_ETNO_SQL o por --sql; sin default
+// versionado (por eso el preflight es opcional/gated en CI).
+const SQL_PATH = process.env.CHAGRA_AGE_ETNO_SQL || '';
+// Léxico campesino co-locado en este repo (público).
+const LEXICO_PATH = resolve(_here, '..', 'public', 'lexico-campesino.json');
+
+export function loadJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+export function loadSql(filePath = SQL_PATH) {
+  return readFileSync(filePath, 'utf8');
+}
+
+export function extractFolkMappings(sql) {
+  const blocks = sql
+    .split(/\n--\s+\d+[a-z]?\.\s+/g)
+    .slice(1);
+
+  return blocks.map((block) => {
+    const folkId = block.match(/MERGE \(f:FolkSymptom \{id: '([^']+)'\}\)/)?.[1] || null;
+    const label = block.match(/SET f\.label = '([^']+)'/)?.[1] || null;
+    const pestId = block.match(/MATCH \(p:Pest \{id: '([^']+)'\}\)/)?.[1] || null;
+    return { folkId, label, pestId };
+  }).filter((item) => item.folkId && item.label && item.pestId);
+}
+
+export function buildPreflightSummary({
+  sqlPath = SQL_PATH,
+  lexicoPath = LEXICO_PATH,
+} = {}) {
+  const sql = loadSql(sqlPath);
+  const lexico = loadJson(lexicoPath);
+  const entries = Array.isArray(lexico.entries) ? lexico.entries : [];
+  const mappings = extractFolkMappings(sql);
+  const labels = mappings.map((m) => m.label);
+  const pestIds = mappings.map((m) => m.pestId);
+
+  const requiredLabels = [
+    'gota',
+    'ojo de gallo',
+    'candelilla',
+    'monilia',
+    'tizón',
+    'tizón tardío',
+    'mancha de hierro',
+    'escoba de bruja',
+    'se pudre la raíz',
+    'mata triste-mustia',
+  ];
+
+  const requiredPests = [
+    'phytophthora_infestans',
+    'mycena_citricolor',
+    'moniliophthora_roreri',
+    'alternaria_solani',
+    'cercospora_coffeicola',
+    'moniliophthora_perniciosa',
+    'rhizoctonia_solani',
+    'ralstonia_solanacearum',
+  ];
+
+  const labelSet = new Set(labels);
+  const pestSet = new Set(pestIds);
+  const missingLabels = requiredLabels.filter((label) => !labelSet.has(label));
+  const missingPests = requiredPests.filter((pestId) => !pestSet.has(pestId));
+
+  return {
+    sqlPath,
+    lexicoPath,
+    lexicoKind: lexico?._meta?.kind || null,
+    lexicoEntries: entries.length,
+    lexicoCategories: Array.isArray(lexico?._meta?.categorias) ? lexico._meta.categorias : [],
+    mappingCount: mappings.length,
+    uniqueLabelCount: labelSet.size,
+    uniquePestCount: pestSet.size,
+    mappings,
+    missingLabels,
+    missingPests,
+    ready: sql.includes('FOLK_NAME_OF')
+      && sql.includes('FolkSymptom')
+      && entries.length > 0
+      && mappings.length >= 10
+      && missingLabels.length === 0
+      && missingPests.length === 0,
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const opts = {
+    json: false,
+    sqlPath: SQL_PATH,
+    lexicoPath: LEXICO_PATH,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') opts.json = true;
+    else if (a === '--sql') opts.sqlPath = argv[++i];
+    else if (a === '--lexico') opts.lexicoPath = argv[++i];
+    else if (a === '--help' || a === '-h') {
+      console.error(
+        'Usage: node scripts/age-etno-preflight.mjs [--json] [--sql FILE] [--lexico FILE]',
+      );
+      return { ready: false };
+    }
+  }
+
+  if (!opts.sqlPath) {
+    console.error('age-etno-preflight: falta el SQL. Define CHAGRA_AGE_ETNO_SQL o pasa --sql FILE.');
+    process.exitCode = 1;
+    return { ready: false };
+  }
+
+  const summary = buildPreflightSummary(opts);
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    const lines = [
+      `lexico_kind=${summary.lexicoKind}`,
+      `lexico_entries=${summary.lexicoEntries}`,
+      `lexico_categories=${summary.lexicoCategories.join(',')}`,
+      `mappings=${summary.mappingCount}`,
+      `unique_labels=${summary.uniqueLabelCount}`,
+      `unique_pests=${summary.uniquePestCount}`,
+      `missing_labels=${summary.missingLabels.length ? summary.missingLabels.join(',') : 'none'}`,
+      `missing_pests=${summary.missingPests.length ? summary.missingPests.join(',') : 'none'}`,
+      `ready=${summary.ready ? 'yes' : 'no'}`,
+    ];
+    process.stdout.write(`${lines.join('\n')}\n`);
+  }
+
+  if (!summary.ready) process.exitCode = 1;
+  return summary;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error('age-etno-preflight failed:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/load-age-etno-folk-fitopatologia.mjs
+++ b/scripts/load-age-etno-folk-fitopatologia.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * scripts/load-age-etno-folk-fitopatologia.mjs
+ *
+ * Runner idempotente para aplicar la ingesta folk fitopatología en AGE.
+ * No inventa datos: ejecuta el SQL fuente curado (contenido que vive FUERA de
+ * este repo; ruta por CHAGRA_AGE_ETNO_SQL o --sql) contra `chagra_kg`, pero
+ * primero corre el preflight local para asegurar que el paquete es consistente.
+ *
+ * Por defecto usa el patrón del resto del repo:
+ *   - si `CHAGRA_AGE_PSQL_COMMAND` está definido, lo usa tal cual
+ *   - si no, usa `sudo podman exec -i postgres-farm psql ...`
+ *
+ * Requiere:
+ *   - acceso al host donde corre `postgres-farm`
+ *   - AGE disponible en `chagra_kg`
+ *   - PGPASSWORD en el entorno si el comando lo necesita
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildPreflightSummary } from './age-etno-preflight.mjs';
+
+const DEFAULT_SQL_PATH = process.env.CHAGRA_AGE_ETNO_SQL || '';
+
+export function parseArgs(argv) {
+  const opts = {
+    sql: DEFAULT_SQL_PATH,
+    dryRun: false,
+    force: false,
+    json: false,
+    verify: true,
+    preflightOnly: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--sql') opts.sql = argv[++i];
+    else if (a === '--dry-run') opts.dryRun = true;
+    else if (a === '--force') opts.force = true;
+    else if (a === '--json') opts.json = true;
+    else if (a === '--no-verify') opts.verify = false;
+    else if (a === '--preflight-only') opts.preflightOnly = true;
+    else if (a === '--help' || a === '-h') opts.help = true;
+  }
+  return opts;
+}
+
+export function buildPsqlInvocation() {
+  const override = process.env.CHAGRA_AGE_PSQL_COMMAND;
+  if (override) {
+    return { kind: 'shell', command: override };
+  }
+  return {
+    kind: 'podman',
+    file: 'sudo',
+    args: ['podman', 'exec', '-i', 'postgres-farm', 'psql', '-U', 'farmos', '-d', 'chagra_kg', '-v', 'ON_ERROR_STOP=1', '-f', '-'],
+  };
+}
+
+export function runSql(sql) {
+  const inv = buildPsqlInvocation();
+  if (inv.kind === 'shell') {
+    return spawnSync(inv.command, {
+      input: sql,
+      encoding: 'utf8',
+      shell: true,
+      env: process.env,
+    });
+  }
+  return spawnSync(inv.file, inv.args, {
+    input: sql,
+    encoding: 'utf8',
+    env: process.env,
+  });
+}
+
+export function buildVerificationSql(graph = 'chagra_kg') {
+  return [
+    "LOAD 'age';",
+    'SET search_path = ag_catalog, "$user", public;',
+    `SELECT count(*) AS folk_edges FROM cypher('${graph}', $$ MATCH (f:FolkSymptom)-[:FOLK_NAME_OF]->(p:Pest) RETURN f $$) AS (f agtype);`,
+    `SELECT count(*) AS folk_nodes FROM cypher('${graph}', $$ MATCH (f:FolkSymptom) RETURN f $$) AS (f agtype);`,
+    '',
+  ].join('\n');
+}
+
+export function buildRunReport(summary, opts) {
+  const inv = buildPsqlInvocation();
+  const psqlCmd = inv.kind === 'shell' ? inv.command : `${inv.file} ${inv.args.join(' ')}`;
+  const mode = opts.preflightOnly ? 'preflight-only'
+    : opts.dryRun ? 'dry-run'
+    : 'real-run';
+  const verificationSql = opts.verify ? buildVerificationSql() : null;
+  return {
+    mode,
+    sqlPath: resolve(process.cwd(), opts.sql),
+    psqlCommand: psqlCmd,
+    preflight: {
+      ready: summary.ready,
+      mappingCount: summary.mappingCount,
+      uniqueLabelCount: summary.uniqueLabelCount,
+      uniquePestCount: summary.uniquePestCount,
+      missingLabels: summary.missingLabels,
+      missingPests: summary.missingPests,
+    },
+    verify: opts.verify ? 'on' : 'off',
+    verificationSql,
+    force: opts.force,
+  };
+}
+
+export function printRunReport(summary, opts) {
+  const report = buildRunReport(summary, opts);
+  const lines = [
+    `[age-etno] mode=${report.mode}`,
+    `[age-etno] sql=${report.sqlPath}`,
+    `[age-etno] psql=${report.psqlCommand}`,
+    `[age-etno] ready=${report.preflight.ready ? 'yes' : 'no'}`,
+    `[age-etno] mappings=${report.preflight.mappingCount}`,
+    `[age-etno] labels=${report.preflight.uniqueLabelCount}`,
+    `[age-etno] pests=${report.preflight.uniquePestCount}`,
+  ];
+  if (report.preflight.missingLabels.length) {
+    lines.push(`[age-etno] missing_labels=${report.preflight.missingLabels.join(',')}`);
+  }
+  if (report.preflight.missingPests.length) {
+    lines.push(`[age-etno] missing_pests=${report.preflight.missingPests.join(',')}`);
+  }
+  lines.push(`[age-etno] verify=${report.verify}`);
+  if (report.force) {
+    lines.push('[age-etno] force=yes');
+  }
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  if (opts.help) {
+    console.log('Usage: node scripts/load-age-etno-folk-fitopatologia.mjs [--sql FILE] [--preflight-only] [--dry-run] [--force] [--no-verify] [--json]');
+    return 0;
+  }
+
+  if (!opts.sql) {
+    console.error('ERROR: falta el SQL fuente. Define CHAGRA_AGE_ETNO_SQL o pasa --sql FILE.');
+    return 2;
+  }
+
+  if (!existsSync(resolve(process.cwd(), opts.sql))) {
+    console.error(`ERROR: no existe el SQL: ${resolve(process.cwd(), opts.sql)}`);
+    return 2;
+  }
+
+  const summary = buildPreflightSummary();
+  if (opts.json) {
+    console.log(JSON.stringify(buildRunReport(summary, opts), null, 2));
+  } else {
+    printRunReport(summary, opts);
+  }
+
+  if (!summary.ready && !opts.force) {
+    console.error('[age-etno] ERROR: preflight fallo. Usa --force solo si sabes que quieres ejecutar igual.');
+    return 2;
+  }
+
+  if (opts.preflightOnly) {
+    return 0;
+  }
+
+  if (opts.dryRun) {
+    if (opts.verify) {
+      console.log('[age-etno] verification SQL (dry-run, no ejecutado):');
+      console.log(buildVerificationSql());
+    }
+    return 0;
+  }
+
+  // Pipeamos el CONTENIDO del SQL (no `\i <ruta>`): psql corre DENTRO del
+  // contenedor postgres-farm y una ruta del host no existiría en su filesystem.
+  const sql = readFileSync(resolve(process.cwd(), opts.sql), 'utf8');
+  const result = runSql(sql);
+  if (result.error) {
+    console.error(`ERROR ejecutando carga AGE: ${result.error.message}`);
+    return 1;
+  }
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  if (result.status === 0 && opts.verify) {
+    const verifySql = buildVerificationSql();
+    const verifyResult = runSql(verifySql);
+    if (verifyResult.error) {
+      console.error(`ERROR ejecutando verificación AGE: ${verifyResult.error.message}`);
+      return 1;
+    }
+    if (verifyResult.stdout) process.stdout.write(verifyResult.stdout);
+    if (verifyResult.stderr) process.stderr.write(verifyResult.stderr);
+    return verifyResult.status ?? 0;
+  }
+  return result.status ?? 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}


### PR DESCRIPTION
## Qué
Tooling para cargar el paquete curado de sinonimia campesina (folk↔Pest) en el grafo AGE `chagra_kg`, siguiendo el patrón de `catalog-to-age.mjs`.

- `age-etno-preflight.mjs`: valida **offline** (sin red/DB) los mapeos `folk→Pest` + el léxico co-locado (`public/lexico-campesino.json`).
- `load-age-etno-folk-fitopatologia.mjs`: aplica el SQL vía `podman exec`/psql, **gated por el preflight**, con `--dry-run` / `--preflight-only` / `--force` / `--no-verify`.

## Frontera (auditoría) — sin leak
El SQL fuente es **contenido curado que vive fuera de este repo público**. Se pasa por `CHAGRA_AGE_ETNO_SQL` o `--sql`, **sin ruta versionada** ni referencia al repo privado. Los tests que validan ese contenido hacen **skip en CI** (env ausente) y corren localmente con el env puesto; los tests estructurales del loader corren siempre.

## Fix (auditoría)
El loader **pipea el CONTENIDO** del SQL, no `\i <ruta>`: psql corre **dentro** del contenedor `postgres-farm` y una ruta del host no existiría en su filesystem.

## Verificado
- CI-sim (sin env): **12 pass / 7 skip** — verde, sin ENOENT.
- Local (con `CHAGRA_AGE_ETNO_SQL` → SQL real): **7 pass** — valida el paquete real.
- `node --check` OK; sin voseo; sin rutas privadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)