### PR TITLE
feat(aprender): infográfico por lección (PoC)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,15 @@ VITE_FEATURE_EXTENSIONISTA=false
 # Seguro de mergear: se shippa "dark" a producción y se prueba en dev con `true`.
 VITE_FINCA_VIVA_HOME_PERFIL=false
 
+# Infográfico por lección en el hub "Aprende" (PoC del audit triple: "cero
+# gráficos; los módulos educativos son un muro de texto"). Con `true`, la
+# lección abre con un diagrama de pasos numerados + íconos (tipo Duolingo, para
+# baja alfabetización digital) que RE-EXPRESA el contenido ya verificado; no
+# inventa datos. Con `false` (DEFAULT) la lección conserva sus bloques de texto.
+# Se shippa "dark" a producción y se prueba en dev con `true`.
+# Ver src/config/aprenderInfografiaFlag.js + src/components/LessonInfographic.jsx.
+VITE_APRENDER_INFOGRAFIA=false
+
 # Multi-finca storage scope (ADR-036 MF-1, #378). Feature flag de la FUNDACIÓN
 # de almacenamiento multi-finca: scopear los datos por finca_id detrás de
 # `src/services/fincaScope.js`. Con `false` (DEFAULT) la capa es un NO-OP total:

--- a/src/components/Aprende/AprenderConAgente.jsx
+++ b/src/components/Aprende/AprenderConAgente.jsx
@@ -31,6 +31,12 @@ import lecciones from '../../data/agro-lecciones.json';
 import todasLasCards from '../../data/agro-insight-cards.json';
 import InsightCard from './InsightCard.jsx';
 import ManoChagraGlyph from '../dashboard/ManoChagraGlyph.jsx';
+import LessonInfographic from '../LessonInfographic.jsx';
+import { aprenderInfografiaActivo } from '../../config/aprenderInfografiaFlag.js';
+
+// Infográfico por lección (PoC del audit triple: "cero gráficos"). Gateado
+// dev-only por VITE_APRENDER_INFOGRAFIA; se evalúa una sola vez (flag de build).
+const INFOGRAFIA_ACTIVA = aprenderInfografiaActivo();
 
 // Íconos por slug de lección
 const LECCION_ICONS = {
@@ -228,6 +234,14 @@ function LeccionView({ leccion, onBack, onAskAgent }) {
       <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
         {!mostrandoInsights ? (
           <>
+            {/* Infográfico de apertura (PoC audit triple: "cero gráficos").
+                Solo en el primer bloque, para introducir la lección de un
+                vistazo. Gateado dev-only (VITE_APRENDER_INFOGRAFIA); si la
+                lección no trae `infografia`, no se renderiza nada. */}
+            {INFOGRAFIA_ACTIVA && bloqueIdx === 0 && leccion.infografia && (
+              <LessonInfographic {...leccion.infografia} />
+            )}
+
             {/* Bloque actual */}
             <div
               data-testid="bloque-actual"

--- a/src/components/LessonInfographic.jsx
+++ b/src/components/LessonInfographic.jsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { Sparkles, Flag, ScrollText } from 'lucide-react';
+
+/**
+ * LessonInfographic — infográfico SIMPLE y reusable para una lección del hub
+ * "Aprende". Ataca el hueco de UX del audit triple ("cero gráficos; los módulos
+ * son un muro de texto"): para el campesino de baja alfabetización digital, un
+ * diagrama de pasos numerados con íconos comunica lo que el párrafo no logra
+ * (pedido explícito de una field tester: algo "tipo Duolingo").
+ *
+ * NO inventa contenido: re-expresa visualmente datos que YA viven en la lección
+ * (fenología = germinación → crecimiento → floración → fructificación →
+ * cosecha, etc.). La `fuente` viaja con el infográfico para conservar la
+ * trazabilidad que exige la doctrina del repo (todo dato tiene fuente).
+ *
+ * Sin dependencias nuevas: SVG inline para el número del paso + íconos lucide
+ * para el marco + emoji por paso (universal, funciona en todo dispositivo y no
+ * exige leer). Theme-aware: usa el acento de marca `--t-accent-rgb`.
+ *
+ * Accesible:
+ *   - `<section role="group">` con `aria-label` que resume el infográfico.
+ *   - Pasos en `<ol>`; cada número es un SVG con `role="img"` + `aria-label`.
+ *   - Emojis decorativos con `aria-hidden`; el texto del paso es el contenido
+ *     real que lee el lector de pantalla.
+ *
+ * Props:
+ *   @param {object} props
+ *   @param {string}  props.titulo      — título del infográfico (obligatorio).
+ *   @param {string}  [props.subtitulo] — línea de apoyo bajo el título.
+ *   @param {string}  [props.icono]     — emoji del encabezado (fallback: ícono lucide).
+ *   @param {Array<{emoji?: string, titulo: string, detalle?: string, resaltado?: string}>} props.pasos
+ *                                        — pasos numerados. `resaltado` = píldora
+ *                                          corta (p. ej. duración) junto al título.
+ *   @param {{emoji?: string, titulo?: string, texto: string}} [props.resultado]
+ *                                        — meta/desenlace destacado al final.
+ *   @param {string}  [props.fuente]     — trazabilidad de los datos re-expresados.
+ *   @param {string}  [props.className]  — clases extra para el contenedor.
+ */
+export default function LessonInfographic({
+  titulo,
+  subtitulo = '',
+  icono = '',
+  pasos = [],
+  resultado = null,
+  fuente = '',
+  className = '',
+}) {
+  if (!titulo || !Array.isArray(pasos) || pasos.length === 0) return null;
+
+  const ariaResumen = `Infográfico de la lección: ${titulo}. ${pasos.length} paso${
+    pasos.length !== 1 ? 's' : ''
+  }.`;
+
+  return (
+    <section
+      data-testid="lesson-infographic"
+      role="group"
+      aria-label={ariaResumen}
+      className={`rounded-2xl border border-slate-800 bg-slate-900/50 p-4 space-y-4 ${className}`}
+    >
+      {/* ── Encabezado ─────────────────────────────────────────────────── */}
+      <header className="flex items-start gap-2">
+        <span
+          className="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-xl"
+          style={{
+            color: 'rgb(var(--t-accent-rgb))',
+            background: 'rgba(var(--t-accent-rgb),0.12)',
+          }}
+          aria-hidden="true"
+        >
+          {icono ? (
+            <span className="text-xl leading-none">{icono}</span>
+          ) : (
+            <Sparkles size={18} />
+          )}
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-black leading-tight text-slate-100">
+            {titulo}
+          </h3>
+          {subtitulo && (
+            <p className="text-xs leading-snug text-slate-400 mt-0.5">
+              {subtitulo}
+            </p>
+          )}
+        </div>
+      </header>
+
+      {/* ── Pasos: stepper vertical (número SVG + emoji + texto) ─────────── */}
+      <ol className="space-y-0" data-testid="lesson-infographic-pasos">
+        {pasos.map((paso, idx) => {
+          const n = idx + 1;
+          const isLast = idx === pasos.length - 1;
+          return (
+            <li key={n} data-testid="lesson-infographic-paso" className="flex gap-3">
+              {/* Columna izquierda: badge SVG numerado + línea conectora */}
+              <div className="flex flex-col items-center shrink-0">
+                <svg
+                  width="30"
+                  height="30"
+                  viewBox="0 0 30 30"
+                  role="img"
+                  aria-label={`Paso ${n}`}
+                  className="shrink-0"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14"
+                    style={{ fill: 'rgb(var(--t-accent-rgb))' }}
+                  />
+                  <text
+                    x="15"
+                    y="16"
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    style={{ fill: '#04231b', fontSize: '14px', fontWeight: 700 }}
+                  >
+                    {n}
+                  </text>
+                </svg>
+                {!isLast && (
+                  <span
+                    aria-hidden="true"
+                    className="w-0.5 flex-1 min-h-[1.25rem] bg-slate-700 my-1"
+                  />
+                )}
+              </div>
+
+              {/* Columna derecha: emoji + título + detalle */}
+              <div className="flex-1 pb-4 min-w-0">
+                <div className="flex items-start gap-2">
+                  {paso.emoji && (
+                    <span
+                      className="text-2xl leading-none shrink-0"
+                      aria-hidden="true"
+                    >
+                      {paso.emoji}
+                    </span>
+                  )}
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-slate-100 flex items-center flex-wrap gap-1.5">
+                      {paso.titulo}
+                      {paso.resaltado && (
+                        <span className="text-[11px] font-bold text-emerald-300 bg-emerald-900/40 px-1.5 py-0.5 rounded">
+                          {paso.resaltado}
+                        </span>
+                      )}
+                    </p>
+                    {paso.detalle && (
+                      <p className="text-xs leading-relaxed mt-0.5 text-slate-300">
+                        {paso.detalle}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {/* ── Meta / desenlace destacado ─────────────────────────────────── */}
+      {resultado && resultado.texto && (
+        <div
+          data-testid="lesson-infographic-resultado"
+          className="flex items-start gap-2 rounded-xl border border-emerald-800/60 bg-emerald-900/20 px-3 py-2.5"
+        >
+          <span className="shrink-0 mt-0.5" aria-hidden="true">
+            {resultado.emoji ? (
+              <span className="text-lg leading-none">{resultado.emoji}</span>
+            ) : (
+              <Flag size={16} className="text-emerald-400" />
+            )}
+          </span>
+          <div className="min-w-0">
+            <p className="text-[10px] uppercase tracking-wider text-emerald-400/80 font-bold mb-0.5">
+              {resultado.titulo || 'Para tener en cuenta'}
+            </p>
+            <p className="text-xs text-emerald-100/90 leading-relaxed">
+              {resultado.texto}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Fuente (trazabilidad — no se inventa nada) ─────────────────── */}
+      {fuente && (
+        <div className="flex items-start gap-2 pt-1">
+          <ScrollText
+            size={12}
+            className="text-slate-600 shrink-0 mt-0.5"
+            aria-hidden="true"
+          />
+          <p className="text-[10px] text-slate-500 italic leading-relaxed">
+            {fuente}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/LessonInfographic.test.jsx
+++ b/src/components/LessonInfographic.test.jsx
@@ -1,0 +1,88 @@
+/**
+ * LessonInfographic.test.jsx — render del infográfico por lección (PoC del
+ * hueco de UX del audit triple: "cero gráficos; los módulos son un muro de
+ * texto"). Verifica que los pasos, la numeración accesible, la meta y la
+ * fuente se pinten, y que el componente degrade limpio sin datos.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import LessonInfographic from './LessonInfographic.jsx';
+
+const PASOS = [
+  { emoji: '🌱', titulo: 'Germinación', detalle: 'La semilla despierta.' },
+  { emoji: '🌿', titulo: 'Crecimiento', detalle: 'Forma tallo y hojas.' },
+  { emoji: '🧺', titulo: 'Cosecha', detalle: 'Recoja en el punto justo.' },
+];
+
+const PROPS = {
+  titulo: 'El ritmo del cultivo, paso a paso',
+  subtitulo: 'Mírela de un vistazo.',
+  icono: '🗓️',
+  pasos: PASOS,
+  resultado: { emoji: '👀', titulo: 'El truco', texto: 'Vigile por evento.' },
+  fuente: 'Agrosavia / BBCH / CIP',
+};
+
+describe('LessonInfographic', () => {
+  it('renderiza el contenedor con aria-label descriptivo', () => {
+    render(<LessonInfographic {...PROPS} />);
+    const section = screen.getByTestId('lesson-infographic');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveAttribute('aria-label', expect.stringContaining('El ritmo del cultivo'));
+  });
+
+  it('pinta el título y el subtítulo', () => {
+    render(<LessonInfographic {...PROPS} />);
+    expect(screen.getByText('El ritmo del cultivo, paso a paso')).toBeInTheDocument();
+    expect(screen.getByText('Mírela de un vistazo.')).toBeInTheDocument();
+  });
+
+  it('renderiza un paso por cada elemento con su título y detalle', () => {
+    render(<LessonInfographic {...PROPS} />);
+    const pasos = screen.getAllByTestId('lesson-infographic-paso');
+    expect(pasos).toHaveLength(PASOS.length);
+    expect(screen.getByText('Germinación')).toBeInTheDocument();
+    expect(screen.getByText('La semilla despierta.')).toBeInTheDocument();
+    expect(screen.getByText('Cosecha')).toBeInTheDocument();
+  });
+
+  it('numera cada paso de forma accesible (role img + aria-label "Paso N")', () => {
+    render(<LessonInfographic {...PROPS} />);
+    expect(screen.getByRole('img', { name: 'Paso 1' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Paso 2' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: `Paso ${PASOS.length}` })).toBeInTheDocument();
+  });
+
+  it('muestra la meta/desenlace y su texto', () => {
+    render(<LessonInfographic {...PROPS} />);
+    expect(screen.getByTestId('lesson-infographic-resultado')).toBeInTheDocument();
+    expect(screen.getByText('El truco')).toBeInTheDocument();
+    expect(screen.getByText('Vigile por evento.')).toBeInTheDocument();
+  });
+
+  it('muestra la fuente para conservar trazabilidad', () => {
+    render(<LessonInfographic {...PROPS} />);
+    expect(screen.getByText(/Agrosavia \/ BBCH \/ CIP/)).toBeInTheDocument();
+  });
+
+  it('renderiza la píldora de resaltado cuando un paso la trae', () => {
+    render(
+      <LessonInfographic
+        titulo="Con resaltado"
+        pasos={[{ titulo: 'Fermentar', detalle: 'Espere.', resaltado: '~15 días' }]}
+      />
+    );
+    expect(screen.getByText('~15 días')).toBeInTheDocument();
+  });
+
+  it('degrada limpio (retorna null) sin pasos', () => {
+    const { container } = render(<LessonInfographic titulo="Vacío" pasos={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('degrada limpio (retorna null) sin título', () => {
+    const { container } = render(<LessonInfographic pasos={PASOS} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/config/aprenderInfografiaFlag.js
+++ b/src/config/aprenderInfografiaFlag.js
@@ -1,0 +1,50 @@
+/**
+ * aprenderInfografiaFlag.js — feature flag del INFOGRÁFICO POR LECCIÓN (Aprende).
+ *
+ * El audit triple señaló el hueco de UX más grande del producto: "cero gráficos
+ * en todo el producto; los módulos educativos son un muro de texto". Para el
+ * campesino de baja alfabetización digital eso ES el problema (una field tester
+ * pidió un infográfico tipo Duolingo). El componente `LessonInfographic`
+ * re-expresa visualmente el contenido YA verificado de una lección como pasos
+ * numerados con íconos, sin inventar nada.
+ *
+ * Se shippa "dark" a producción: con la flag APAGADA (default/prod) la lección
+ * conserva su presentación de bloques de texto actual. En dev se enciende para
+ * evaluar el PoC. Mismo criterio y parseo que `registroUnificadoActivo()`
+ * (registroUnificadoFlag.js) y `colibriRealActivo()` (colibriFlag.js) para
+ * mantener la convención del repo.
+ *
+ * CÓMO ACTIVARLO (dev): poner en el `.env` (o `.env.local`) del frontend:
+ *
+ *     VITE_APRENDER_INFOGRAFIA=true
+ *
+ * Acepta 'true' / '1' (case-insensitive, con espacios).
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ *
+ * @module aprenderInfografiaFlag
+ */
+
+const FLAG_KEY = 'VITE_APRENDER_INFOGRAFIA';
+
+/**
+ * ¿Está activo el infográfico por lección en el hub Aprende?
+ *
+ * @returns {boolean} true si la flag está encendida; false (default) en
+ *   cualquier otro caso, incluido error de acceso a import.meta.env.
+ */
+export function aprenderInfografiaActivo() {
+  try {
+    const raw = import.meta.env?.[FLAG_KEY];
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+export default aprenderInfografiaActivo;

--- a/src/data/agro-lecciones.json
+++ b/src/data/agro-lecciones.json
@@ -164,6 +164,44 @@
         "texto": "El frijol es especialmente vulnerable al estrés hídrico en la floración (etapa R6). Mantener humedad adecuada esa semana puede salvar la cosecha."
       }
     ],
-    "pregunta_agente": "¿En qué etapa está mi cultivo y qué debo cuidar ahora?"
+    "pregunta_agente": "¿En qué etapa está mi cultivo y qué debo cuidar ahora?",
+    "infografia": {
+      "titulo": "El ritmo del cultivo, paso a paso",
+      "subtitulo": "Cada etapa pide un cuidado distinto. Mírela de un vistazo.",
+      "icono": "🗓️",
+      "pasos": [
+        {
+          "emoji": "🌱",
+          "titulo": "Germinación",
+          "detalle": "La semilla despierta y salen las primeras raíces y hojas."
+        },
+        {
+          "emoji": "🌿",
+          "titulo": "Crecimiento",
+          "detalle": "La planta forma tallo, hojas y raíces fuertes."
+        },
+        {
+          "emoji": "🌼",
+          "titulo": "Floración",
+          "detalle": "Aparecen las flores. Etapa delicada: cuide el agua, sobre todo en el fríjol."
+        },
+        {
+          "emoji": "🍅",
+          "titulo": "Fructificación",
+          "detalle": "Se forma y se llena el fruto o el tubérculo. Vigile plagas de esta etapa (broca en el café, gota en la papa)."
+        },
+        {
+          "emoji": "🧺",
+          "titulo": "Cosecha",
+          "detalle": "El cultivo llega a su punto. Recoja en el momento justo."
+        }
+      ],
+      "resultado": {
+        "emoji": "👀",
+        "titulo": "El truco",
+        "texto": "Vigile por evento (la primera flor, el cuajado del fruto), no solo por el calendario de días. El Niño o La Niña pueden correr las etapas 2 a 4 semanas."
+      },
+      "fuente": "DR-FENOLOGIA-RECONCILED-2026-06-18; Agrosavia / BBCH / CIP"
+    }
   }
 ]


### PR DESCRIPTION
## Summary

Prueba de concepto que ataca el hueco de UX señalado por el **audit triple**: *"cero gráficos en todo el producto; los módulos educativos son un muro de texto"*. Para el campesino de baja alfabetización digital ese es EL problema — una field tester pidió explícitamente un infográfico tipo Duolingo.

- **`src/components/LessonInfographic.jsx`** — componente reusable que renderiza una lección como **pasos numerados con íconos/emoji**: número en SVG inline + marco con íconos `lucide-react` + emoji por paso, más una "meta" destacada y la fuente. Sin dependencias nuevas. Theme-aware (`--t-accent-rgb`). Props claras: `titulo`, `subtitulo`, `icono`, `pasos[{emoji,titulo,detalle,resaltado}]`, `resultado`, `fuente`.
- **Accesibilidad**: `role="group"` + `aria-label` que resume el infográfico; cada número es un SVG con `role="img"` y `aria-label="Paso N"`; emojis decorativos con `aria-hidden`; el texto del paso es el contenido real para el lector de pantalla.
- **Cableado (PoC)** en la lección **"fenología"** del hub *Aprende* (`AprenderConAgente.jsx`): abre con el diagrama de etapas (germinación → crecimiento → floración → fructificación → cosecha). El infográfico **re-expresa contenido ya verificado** de la lección; no inventa datos y conserva la fuente.
- **Gateado dev-only** con `VITE_APRENDER_INFOGRAFIA` (`src/config/aprenderInfografiaFlag.js`), mismo patrón que `VITE_COLIBRI` / `VITE_REGISTRO_UNIFICADO`. Se shippa "dark" a producción (default `false`).

## Test plan

- [x] `npx vitest run src/components/LessonInfographic.test.jsx` — render, numeración accesible ("Paso N"), meta, fuente, píldora de resaltado y degradación limpia (retorna `null` sin pasos o sin título).
- [x] `npx vitest run src/components/Aprende/AprenderConAgente.test.jsx` — sin regresiones (flag OFF por default: la lección conserva sus bloques de texto). **38 tests passed.**
- [x] `eslint` limpio en los archivos nuevos/modificados.
- Manual (dev): con `VITE_APRENDER_INFOGRAFIA=true`, entrar a Aprende → Fenología muestra el infográfico de apertura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)