### PR TITLE
feat(scripts): auditor de citación milpa (grafo AGE)

### DIFF
--- a/scripts/__tests__/audit-milpa-citations.test.mjs
+++ b/scripts/__tests__/audit-milpa-citations.test.mjs
@@ -1,0 +1,376 @@
+/**
+ * scripts/__tests__/audit-milpa-citations.test.mjs
+ *
+ * Cobertura unitaria del auditor de citación de aristas de asociación/milpa.
+ * NO toca la red ni postgres real: verifica las funciones puras (SQL builder,
+ * parser de salida psql, extractor offline de dump/catálogo, clasificador de
+ * prioridad y agregador de reporte) con datos mock.
+ *
+ * El bloque "live DB" al final hace skip limpio cuando no hay
+ * CHAGRA_AGE_PSQL_COMMAND en el entorno (mismo patrón que
+ * scripts/__tests__/age-etno-preflight.test.mjs).
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  ASSOCIATION_RELATIONS,
+  buildMilpaAuditSql,
+  parseAuditRows,
+  extractAssociationEdges,
+  hasSource,
+  classifyInsignia,
+  buildAuditReport,
+  formatReportText,
+  buildPsqlInvocation,
+  runPsql,
+  parseArgs,
+} from '../audit-milpa-citations.mjs';
+
+describe('buildMilpaAuditSql', () => {
+  it('incluye LOAD/SET y ambos tipos de relacion de asociacion', () => {
+    const sql = buildMilpaAuditSql('chagra_kg');
+    expect(sql).toContain("LOAD 'age'");
+    expect(sql).toContain('SET search_path');
+    expect(sql).toContain('COMPATIBLE_WITH');
+    expect(sql).toContain('ASOCIA_CON');
+    expect(sql).not.toContain('ANTAGONIST_OF');
+  });
+
+  it('trae las propiedades de citacion (fuente, doi, verificado_openalex)', () => {
+    const sql = buildMilpaAuditSql();
+    expect(sql).toContain('r.fuente');
+    expect(sql).toContain('r.doi');
+    expect(sql).toContain('r.verificado_openalex');
+  });
+
+  it('escapa comillas simples en el nombre del grafo', () => {
+    const sql = buildMilpaAuditSql("chagra'kg");
+    expect(sql).toContain("chagra''kg");
+  });
+
+  it('usa el grafo default chagra_kg si no se pasa argumento', () => {
+    const sql = buildMilpaAuditSql();
+    expect(sql).toContain("cypher('chagra_kg'");
+  });
+});
+
+describe('parseAuditRows', () => {
+  it('parsea filas tab-separated e ignora ruido LOAD/SET/(N rows)', () => {
+    const stdout = [
+      'LOAD',
+      'SET',
+      '"zea_mays"\t"Maiz"\t"cereales"\t"phaseolus_vulgaris"\t"Frijol"\t"granos_legumbres"\t"COMPATIBLE_WITH"\tnull\tnull\tnull',
+      '"coffea_arabica"\t"Cafe"\t"frutales_perennes"\t"inga_edulis"\t"Guamo"\t"arboles_sombra"\t"ASOCIA_CON"\t"Zuluaga 2020"\tnull\ttrue',
+      '(2 rows)',
+    ].join('\n');
+
+    const rows = parseAuditRows(stdout);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      origen: 'zea_mays',
+      origenNombre: 'Maiz',
+      destino: 'phaseolus_vulgaris',
+      relacion: 'COMPATIBLE_WITH',
+      fuente: null,
+      doi: null,
+      verificadoOpenalex: null,
+    });
+    expect(rows[1]).toMatchObject({
+      origen: 'coffea_arabica',
+      relacion: 'ASOCIA_CON',
+      fuente: 'Zuluaga 2020',
+      verificadoOpenalex: true,
+    });
+  });
+
+  it('devuelve array vacio para stdout vacio o solo ruido', () => {
+    expect(parseAuditRows('')).toEqual([]);
+    expect(parseAuditRows('LOAD\nSET\n(0 rows)')).toEqual([]);
+  });
+
+  it('descarta filas incompletas sin origen/destino/relacion', () => {
+    const rows = parseAuditRows('\tnull\tnull\t\tnull\tnull\t\tnull\tnull\tnull');
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('extractAssociationEdges — modo catalogo (offline)', () => {
+  it('lee companions[] como aristas COMPATIBLE_WITH sin fuente (el catalogo no la tiene)', () => {
+    const catalog = {
+      species: [
+        { id: 'zea_mays', nombre_comun: 'Maiz', category: 'cereales', companions: ['phaseolus_vulgaris'] },
+        { id: 'phaseolus_vulgaris', nombre_comun: 'Frijol', category: 'granos_legumbres', companions: [] },
+      ],
+    };
+    const rows = extractAssociationEdges(catalog);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      origen: 'zea_mays',
+      destino: 'phaseolus_vulgaris',
+      relacion: 'COMPATIBLE_WITH',
+      fuente: null,
+      doi: null,
+      verificadoOpenalex: null,
+    });
+  });
+
+  it('auto-detecta modo catalogo por presencia de data.species', () => {
+    const catalog = { species: [{ id: 'a', companions: ['b'] }, { id: 'b', companions: [] }] };
+    const rows = extractAssociationEdges(catalog);
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('extractAssociationEdges — modo dump {nodes, edges}', () => {
+  function mkNode(id, props) {
+    return { id, labels: ['Species'], properties: props || {} };
+  }
+  function mkEdge(source, target, label, properties) {
+    return { source, target, label, properties: properties || {} };
+  }
+
+  it('extrae solo aristas de asociacion (ignora ANTAGONIST_OF y otras)', () => {
+    const dump = {
+      nodes: [mkNode('a', { nombre_comun: 'A', categoria: 'cereales' }), mkNode('b', { nombre_comun: 'B' })],
+      edges: [
+        mkEdge('a', 'b', 'COMPATIBLE_WITH'),
+        mkEdge('a', 'b', 'ANTAGONIST_OF'),
+        mkEdge('a', 'b', 'TARGETS_PEST'),
+      ],
+    };
+    const rows = extractAssociationEdges(dump, { catalogMode: false });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].relacion).toBe('COMPATIBLE_WITH');
+    expect(rows[0].origenNombre).toBe('A');
+  });
+
+  it('lee las propiedades de citacion de la arista cuando existen', () => {
+    const dump = {
+      nodes: [mkNode('a'), mkNode('b')],
+      edges: [mkEdge('a', 'b', 'ASOCIA_CON', { fuente: 'Altieri 1999', doi: '10.1234/x' })],
+    };
+    const rows = extractAssociationEdges(dump, { catalogMode: false });
+    expect(rows[0].fuente).toBe('Altieri 1999');
+    expect(rows[0].doi).toBe('10.1234/x');
+  });
+
+  it('respeta ASSOCIATION_RELATIONS exportado (contrato con el SQL builder)', () => {
+    expect(ASSOCIATION_RELATIONS).toEqual(['COMPATIBLE_WITH', 'ASOCIA_CON']);
+  });
+});
+
+describe('hasSource', () => {
+  it('true cuando fuente tiene texto', () => {
+    expect(hasSource({ fuente: 'Altieri 1999', doi: null, verificadoOpenalex: null })).toBe(true);
+  });
+  it('true cuando doi tiene texto', () => {
+    expect(hasSource({ fuente: null, doi: '10.1234/x', verificadoOpenalex: null })).toBe(true);
+  });
+  it('true cuando verificadoOpenalex es boolean true', () => {
+    expect(hasSource({ fuente: null, doi: null, verificadoOpenalex: true })).toBe(true);
+  });
+  it('false cuando verificadoOpenalex es boolean false', () => {
+    expect(hasSource({ fuente: null, doi: null, verificadoOpenalex: false })).toBe(false);
+  });
+  it('false cuando verificadoOpenalex es el string "false"', () => {
+    expect(hasSource({ fuente: null, doi: null, verificadoOpenalex: 'false' })).toBe(false);
+  });
+  it('false cuando todos los campos son null/vacios', () => {
+    expect(hasSource({ fuente: null, doi: '', verificadoOpenalex: null })).toBe(false);
+  });
+});
+
+describe('classifyInsignia', () => {
+  it('tier 1 milpa_clasica cuando origen es maiz', () => {
+    const r = classifyInsignia({ origen: 'zea_mays', origenCategoria: null, destino: 'inga_edulis', destinoCategoria: null });
+    expect(r).toEqual({ tier: 1, label: 'milpa_clasica' });
+  });
+  it('tier 1 milpa_clasica cuando destino es frijol', () => {
+    const r = classifyInsignia({ origen: 'inga_edulis', origenCategoria: null, destino: 'phaseolus_vulgaris', destinoCategoria: null });
+    expect(r.label).toBe('milpa_clasica');
+  });
+  it('tier 1 milpa_clasica para variantes de calabaza (cucurbita_*)', () => {
+    const r = classifyInsignia({ origen: 'cucurbita_moschata', origenCategoria: null, destino: 'x', destinoCategoria: null });
+    expect(r.label).toBe('milpa_clasica');
+  });
+  it('tier 2 cafe cuando alguno es coffea_arabica', () => {
+    const r = classifyInsignia({ origen: 'coffea_arabica', origenCategoria: null, destino: 'inga_edulis', destinoCategoria: 'arboles_sombra' });
+    expect(r.label).toBe('cafe');
+  });
+  it('tier 3 hortalizas por categoria cuando no hay match de id', () => {
+    const r = classifyInsignia({ origen: 'solanum_lycopersicum', origenCategoria: 'hortalizas_fruto_flor', destino: 'x', destinoCategoria: null });
+    expect(r.label).toBe('hortalizas');
+  });
+  it('tier 4 otros cuando nada matchea', () => {
+    const r = classifyInsignia({ origen: 'alnus_acuminata', origenCategoria: 'arboles_sombra', destino: 'lupinus_mutabilis', destinoCategoria: 'granos_legumbres' });
+    expect(r).toEqual({ tier: 4, label: 'otros' });
+  });
+  it('toma la prioridad mas alta (tier menor) entre origen y destino', () => {
+    const r = classifyInsignia({ origen: 'alnus_acuminata', origenCategoria: 'arboles_sombra', destino: 'zea_mays', destinoCategoria: null });
+    expect(r).toEqual({ tier: 1, label: 'milpa_clasica' });
+  });
+});
+
+describe('buildAuditReport', () => {
+  function row(overrides) {
+    return {
+      origen: 'a', origenNombre: 'A', origenCategoria: null,
+      destino: 'b', destinoNombre: 'B', destinoCategoria: null,
+      relacion: 'COMPATIBLE_WITH', fuente: null, doi: null, verificadoOpenalex: null,
+      ...overrides,
+    };
+  }
+
+  it('calcula totales y porcentaje con fuente', () => {
+    const rows = [
+      row({ fuente: 'X' }),
+      row({ doi: 'Y' }),
+      row({}),
+      row({}),
+    ];
+    const report = buildAuditReport(rows, { graph: 'chagra_kg' });
+    expect(report.totalAssociationEdges).toBe(4);
+    expect(report.withSource).toBe(2);
+    expect(report.withoutSource).toBe(2);
+    expect(report.pctWithSource).toBe(50);
+  });
+
+  it('desglosa por tipo de relacion', () => {
+    const rows = [
+      row({ relacion: 'COMPATIBLE_WITH', fuente: 'X' }),
+      row({ relacion: 'COMPATIBLE_WITH' }),
+      row({ relacion: 'ASOCIA_CON' }),
+    ];
+    const report = buildAuditReport(rows);
+    expect(report.byRelation.COMPATIBLE_WITH).toEqual({ total: 2, withSource: 1, pctWithSource: 50 });
+    expect(report.byRelation.ASOCIA_CON).toEqual({ total: 1, withSource: 0, pctWithSource: 0 });
+  });
+
+  it('ordena la lista de faltantes por prioridad (tier asc) y luego por id', () => {
+    const rows = [
+      row({ origen: 'alnus_acuminata', destino: 'lupinus_mutabilis' }), // otros
+      row({ origen: 'coffea_arabica', destino: 'inga_edulis' }), // cafe
+      row({ origen: 'zea_mays', destino: 'phaseolus_vulgaris' }), // milpa_clasica
+    ];
+    const report = buildAuditReport(rows);
+    expect(report.missing.map((m) => m.prioridad)).toEqual(['milpa_clasica', 'cafe', 'otros']);
+  });
+
+  it('cuenta missingByTier correctamente', () => {
+    const rows = [
+      row({ origen: 'zea_mays' }),
+      row({ origen: 'phaseolus_vulgaris' }),
+      row({ origen: 'coffea_arabica' }),
+    ];
+    const report = buildAuditReport(rows);
+    expect(report.missingByTier.milpa_clasica).toBe(2);
+    expect(report.missingByTier.cafe).toBe(1);
+  });
+
+  it('no incluye en missing las filas que si tienen fuente', () => {
+    const rows = [row({ fuente: 'X' })];
+    const report = buildAuditReport(rows);
+    expect(report.missing).toEqual([]);
+    expect(report.withoutSource).toBe(0);
+  });
+
+  it('respeta --limit y marca missingTruncated', () => {
+    const rows = Array.from({ length: 5 }, (_, i) => row({ origen: `sp_${i}`, destino: `sp_${i}_b` }));
+    const report = buildAuditReport(rows, { limit: 2 });
+    expect(report.missing).toHaveLength(2);
+    expect(report.missingTruncated).toBe(true);
+    expect(report.withoutSource).toBe(5);
+  });
+
+  it('reporte vacio no rompe (0 aristas)', () => {
+    const report = buildAuditReport([]);
+    expect(report.totalAssociationEdges).toBe(0);
+    expect(report.pctWithSource).toBe(0);
+    expect(report.missing).toEqual([]);
+  });
+});
+
+describe('formatReportText', () => {
+  it('incluye totales, porcentaje y la lista priorizada', () => {
+    const report = buildAuditReport(
+      [
+        { origen: 'zea_mays', origenNombre: 'Maiz', origenCategoria: null, destino: 'phaseolus_vulgaris', destinoNombre: 'Frijol', destinoCategoria: null, relacion: 'COMPATIBLE_WITH', fuente: null, doi: null, verificadoOpenalex: null },
+      ],
+      { graph: 'chagra_kg' },
+    );
+    const text = formatReportText(report);
+    expect(text).toContain('grafo chagra_kg');
+    expect(text).toContain('Total aristas de asociacion: 1');
+    expect(text).toContain('milpa_clasica');
+    expect(text).toContain('zea_mays (Maiz) -> phaseolus_vulgaris (Frijol)');
+  });
+});
+
+describe('buildPsqlInvocation', () => {
+  it('usa sudo podman exec por defecto cuando no hay override', () => {
+    const prev = process.env.CHAGRA_AGE_PSQL_COMMAND;
+    delete process.env.CHAGRA_AGE_PSQL_COMMAND;
+    const inv = buildPsqlInvocation();
+    if (prev !== undefined) process.env.CHAGRA_AGE_PSQL_COMMAND = prev;
+    expect(inv.kind).toBe('podman');
+    expect(inv.file).toBe('sudo');
+    expect(inv.args).toContain('postgres-farm');
+    expect(inv.args).toContain('chagra_kg');
+  });
+
+  it('respeta CHAGRA_AGE_PSQL_COMMAND cuando esta definido', () => {
+    const prev = process.env.CHAGRA_AGE_PSQL_COMMAND;
+    process.env.CHAGRA_AGE_PSQL_COMMAND = 'psql -h 127.0.0.1 -U farmos -d chagra_kg';
+    const inv = buildPsqlInvocation();
+    if (prev !== undefined) process.env.CHAGRA_AGE_PSQL_COMMAND = prev;
+    else delete process.env.CHAGRA_AGE_PSQL_COMMAND;
+    expect(inv.kind).toBe('shell');
+    expect(inv.command).toContain('psql -h 127.0.0.1');
+  });
+});
+
+describe('parseArgs', () => {
+  it('parsea flags basicos', () => {
+    const opts = parseArgs(['--graph', 'otro_grafo', '--json', '--limit', '10']);
+    expect(opts.graph).toBe('otro_grafo');
+    expect(opts.json).toBe(true);
+    expect(opts.limit).toBe(10);
+  });
+
+  it('parsea --from-dump y --catalog-mode', () => {
+    const opts = parseArgs(['--from-dump', '/tmp/x.json', '--catalog-mode']);
+    expect(opts.fromDump).toBe('/tmp/x.json');
+    expect(opts.catalogMode).toBe(true);
+  });
+
+  it('parsea --print-sql', () => {
+    const opts = parseArgs(['--print-sql']);
+    expect(opts.printSql).toBe(true);
+  });
+
+  it('defaults razonables sin argumentos', () => {
+    const opts = parseArgs([]);
+    expect(opts.graph).toBe('chagra_kg');
+    expect(opts.json).toBe(false);
+    expect(opts.limit).toBe(200);
+    expect(opts.fromDump).toBeNull();
+  });
+});
+
+// =============================================================================
+// Live DB (opcional) — skip limpio en CI sin CHAGRA_AGE_PSQL_COMMAND, mismo
+// patron que scripts/__tests__/age-etno-preflight.test.mjs.
+// =============================================================================
+const hasLivePsql = Boolean(process.env.CHAGRA_AGE_PSQL_COMMAND);
+
+describe.skipIf(!hasLivePsql)('audit-milpa-citations (live DB)', () => {
+  it('ejecuta contra el grafo real y arma un reporte coherente', () => {
+    const sql = buildMilpaAuditSql('chagra_kg');
+    const result = runPsql(sql);
+    expect(result.status).toBe(0);
+    const rows = parseAuditRows(result.stdout);
+    const report = buildAuditReport(rows, { graph: 'chagra_kg' });
+    expect(report.totalAssociationEdges).toBeGreaterThanOrEqual(0);
+    expect(report.withSource + report.withoutSource).toBe(report.totalAssociationEdges);
+  });
+});

--- a/scripts/audit-milpa-citations.mjs
+++ b/scripts/audit-milpa-citations.mjs
@@ -1,0 +1,487 @@
+#!/usr/bin/env node
+/**
+ * scripts/audit-milpa-citations.mjs
+ *
+ * AUDITOR de citación para las aristas de asociación/companion planting
+ * ("milpa") del grafo `chagra_kg` (Apache AGE, postgres-farm).
+ *
+ * Contexto (curación del grafo, 2026-06-30): la relación milpa/asociaciones
+ * es la PEOR citada del grafo — ~19% con fuente/DOI, contra ~55% del control
+ * biológico. Este script NO corrige nada ni inventa fuentes: solo LISTA qué
+ * aristas de asociación carecen de fuente/DOI para alimentar una investigación
+ * (DR) posterior que sí busque las citas reales.
+ *
+ * Qué cuenta como "arista de asociación"
+ * ---------------------------------------
+ * Los dos tipos de relación companion/asociación presentes en el grafo (ver
+ * scripts/catalog-to-age.mjs y scripts/export-graph-to-catalog.mjs):
+ *   - (:Species)-[:COMPATIBLE_WITH]->(:Species)  — companions[] del catálogo.
+ *   - (:Species)-[:ASOCIA_CON]->(:Species)       — asociaciones curadas
+ *                                                   directamente en el grafo.
+ * NO incluye ANTAGONIST_OF (es una relación de conflicto, no de asociación
+ * positiva) ni ninguna otra relación (CONTROLS, TARGETS_PEST, etc.).
+ *
+ * Qué cuenta como "con fuente"
+ * -----------------------------
+ * Se considera citada una arista si trae, como propiedad, alguno de estos
+ * campos con valor no vacío/no falso: `fuente`, `doi`, `verificado_openalex`.
+ * Estos son los campos que el operador identificó en el grafo vivo; el script
+ * NO inventa ni normaliza fuentes, solo verifica presencia.
+ *
+ * Priorización
+ * ------------
+ * La lista de aristas sin fuente se ordena por prioridad de cultivo insignia:
+ *   1. milpa clásica  — maíz (zea_mays), frijol (phaseolus_vulgaris),
+ *                        calabaza (cucurbita_*)
+ *   2. café           — coffea_arabica
+ *   3. hortalizas     — category hortalizas_fruto_flor / hortalizas_hoja
+ *   4. otros
+ * Se toma la prioridad más alta entre origen y destino de cada arista.
+ *
+ * Modos de ejecución
+ * -------------------
+ *   1. LIVE (default): consulta `chagra_kg` vía psql. Por defecto usa
+ *      `sudo podman exec -i postgres-farm psql -U farmos -d chagra_kg`;
+ *      si `CHAGRA_AGE_PSQL_COMMAND` está definido en el entorno, lo usa tal
+ *      cual (mismo patrón que scripts/validate-graph-parity.mjs y
+ *      scripts/load-age-etno-folk-fitopatologia.mjs). Sin credenciales
+ *      hardcodeadas — todo entra por process.env.
+ *   2. OFFLINE (--from-dump FILE): NO toca la DB. Parsea un dump JSON
+ *      `{nodes, edges}` (mismo shape que scripts/check-age-integrity.mjs) o
+ *      un catálogo `{species: [...]}` (companions[] se leen como aristas
+ *      COMPATIBLE_WITH, sin fuente por diseño — el catálogo no tiene campo
+ *      de cita por arista). Este es el modo seguro para CI.
+ *
+ * Uso
+ * ---
+ *   node scripts/audit-milpa-citations.mjs                     # live, texto
+ *   node scripts/audit-milpa-citations.mjs --json               # live, JSON
+ *   node scripts/audit-milpa-citations.mjs --print-sql           # solo el SQL
+ *   node scripts/audit-milpa-citations.mjs --from-dump dump.json # offline
+ *   CHAGRA_AGE_PSQL_COMMAND="psql -h 127.0.0.1 -U farmos -d chagra_kg" \
+ *     node scripts/audit-milpa-citations.mjs
+ *
+ * NO modifica catálogo ni manifest — es de solo lectura/reporte.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// =============================================================================
+// Constantes de dominio
+// =============================================================================
+
+export const ASSOCIATION_RELATIONS = ['COMPATIBLE_WITH', 'ASOCIA_CON'];
+
+const MILPA_CLASICA_ID_RE = /^(zea_mays|phaseolus_vulgaris|cucurbita_)/;
+const CAFE_ID_RE = /^coffea_/;
+const HORTALIZA_CATEGORIAS = new Set(['hortalizas_fruto_flor', 'hortalizas_hoja']);
+
+const DEFAULT_GRAPH = 'chagra_kg';
+const DEFAULT_LIMIT = 200;
+
+// =============================================================================
+// SQL builder (puro — no toca la DB)
+// =============================================================================
+
+/**
+ * Arma el SQL (LOAD + SET + SELECT ... FROM cypher(...)) que trae las
+ * aristas de asociación con sus propiedades de citación + nombre/categoria
+ * de los nodos origen/destino (para priorizar sin depender del catálogo
+ * local, que puede ser un subconjunto del grafo vivo).
+ *
+ * @param {string} [graph='chagra_kg']
+ * @returns {string}
+ */
+export function buildMilpaAuditSql(graph = DEFAULT_GRAPH) {
+  const graphLiteral = String(graph).replace(/'/g, "''");
+  const branches = ASSOCIATION_RELATIONS.map((rel) => `
+  MATCH (a:Species)-[r:${rel}]->(b:Species)
+  RETURN a.id AS origen, a.nombre_comun AS origen_nombre, a.categoria AS origen_categoria,
+         b.id AS destino, b.nombre_comun AS destino_nombre, b.categoria AS destino_categoria,
+         '${rel}' AS relacion,
+         r.fuente AS fuente, r.doi AS doi, r.verificado_openalex AS verificado_openalex`).join('\n  UNION\n');
+
+  return `
+LOAD 'age';
+SET search_path = ag_catalog, "$user", public;
+SELECT origen::text, origen_nombre::text, origen_categoria::text,
+       destino::text, destino_nombre::text, destino_categoria::text,
+       relacion::text, fuente::text, doi::text, verificado_openalex::text
+FROM cypher('${graphLiteral}', $$${branches}
+  ORDER BY relacion, origen, destino
+$$) AS (origen agtype, origen_nombre agtype, origen_categoria agtype,
+        destino agtype, destino_nombre agtype, destino_categoria agtype,
+        relacion agtype, fuente agtype, doi agtype, verificado_openalex agtype);
+`.trim();
+}
+
+// =============================================================================
+// Parsing de salida psql (puro)
+// =============================================================================
+
+function stripAgtype(value) {
+  const raw = String(value ?? '').trim();
+  if (!raw || raw === 'null') return null;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return raw.replace(/^"|"$/g, '');
+}
+
+/**
+ * Parsea la salida de `psql -At -F '\t'` para el SQL de buildMilpaAuditSql.
+ * Ignora líneas de ruido (LOAD/SET/"(N rows)") y filas incompletas.
+ *
+ * @param {string} stdout
+ * @returns {Array<object>} filas normalizadas (mismo shape que extractAssociationEdges)
+ */
+export function parseAuditRows(stdout) {
+  return String(stdout || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => !/^(LOAD|SET|\(\d+ rows?\))$/.test(line))
+    .map((line) => {
+      const parts = line.split('\t');
+      return {
+        origen: stripAgtype(parts[0]),
+        origenNombre: stripAgtype(parts[1]),
+        origenCategoria: stripAgtype(parts[2]),
+        destino: stripAgtype(parts[3]),
+        destinoNombre: stripAgtype(parts[4]),
+        destinoCategoria: stripAgtype(parts[5]),
+        relacion: stripAgtype(parts[6]),
+        fuente: stripAgtype(parts[7]),
+        doi: stripAgtype(parts[8]),
+        verificadoOpenalex: stripAgtype(parts[9]),
+      };
+    })
+    .filter((row) => row.origen && row.destino && row.relacion);
+}
+
+// =============================================================================
+// Modo offline: dump {nodes, edges} o catálogo {species} (puro)
+// =============================================================================
+
+function catalogToAssociationEdges(catalog) {
+  const speciesById = new Map((catalog.species || []).map((sp) => [sp.id, sp]));
+  const rows = [];
+  for (const sp of catalog.species || []) {
+    for (const compId of sp.companions || []) {
+      const dest = speciesById.get(compId);
+      rows.push({
+        origen: sp.id,
+        origenNombre: sp.nombre_comun || null,
+        origenCategoria: sp.category || null,
+        destino: compId,
+        destinoNombre: dest?.nombre_comun || null,
+        destinoCategoria: dest?.category || null,
+        relacion: 'COMPATIBLE_WITH',
+        // El catálogo no tiene campo de cita por arista — por diseño, null.
+        fuente: null,
+        doi: null,
+        verificadoOpenalex: null,
+      });
+    }
+  }
+  return rows;
+}
+
+function dumpToAssociationEdges(dump) {
+  const nodesById = new Map((dump.nodes || []).map((n) => [n.id, n]));
+  const rows = [];
+  for (const edge of dump.edges || []) {
+    if (!ASSOCIATION_RELATIONS.includes(edge.label)) continue;
+    const a = nodesById.get(edge.source);
+    const b = nodesById.get(edge.target);
+    const props = edge.properties || {};
+    rows.push({
+      origen: edge.source,
+      origenNombre: a?.properties?.nombre_comun ?? null,
+      origenCategoria: a?.properties?.categoria ?? null,
+      destino: edge.target,
+      destinoNombre: b?.properties?.nombre_comun ?? null,
+      destinoCategoria: b?.properties?.categoria ?? null,
+      relacion: edge.label,
+      fuente: props.fuente ?? null,
+      doi: props.doi ?? null,
+      verificadoOpenalex: props.verificado_openalex ?? null,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Extrae aristas de asociación normalizadas desde un dump `{nodes, edges}`
+ * o un catálogo `{species}`. Modo offline — no toca la DB.
+ *
+ * @param {object} data
+ * @param {{catalogMode?: boolean}} [opts] - fuerza el modo; si se omite,
+ *   se auto-detecta por presencia de `data.species` (mismo patrón que
+ *   scripts/check-age-integrity.mjs).
+ * @returns {Array<object>}
+ */
+export function extractAssociationEdges(data, opts = {}) {
+  const catalogMode = opts.catalogMode ?? !!data.species;
+  return catalogMode ? catalogToAssociationEdges(data) : dumpToAssociationEdges(data);
+}
+
+// =============================================================================
+// Clasificación: ¿tiene fuente? ¿qué prioridad de cultivo insignia?
+// =============================================================================
+
+function truthyText(v) {
+  if (v === null || v === undefined) return false;
+  if (typeof v === 'boolean') return v;
+  const s = String(v).trim().toLowerCase();
+  return s !== '' && s !== 'false' && s !== 'null' && s !== '0' && s !== 'no';
+}
+
+/**
+ * @param {{fuente?:*, doi?:*, verificadoOpenalex?:*}} row
+ * @returns {boolean}
+ */
+export function hasSource(row) {
+  return truthyText(row.fuente) || truthyText(row.doi) || truthyText(row.verificadoOpenalex);
+}
+
+function tierOfSide(id, categoria) {
+  if (id && MILPA_CLASICA_ID_RE.test(id)) return { tier: 1, label: 'milpa_clasica' };
+  if (id && CAFE_ID_RE.test(id)) return { tier: 2, label: 'cafe' };
+  if (categoria && HORTALIZA_CATEGORIAS.has(categoria)) return { tier: 3, label: 'hortalizas' };
+  return null;
+}
+
+/**
+ * Clasifica una arista por prioridad de cultivo insignia (la más alta entre
+ * origen y destino). tier 1 = más prioritario, tier 4 = "otros".
+ *
+ * @param {object} row
+ * @returns {{tier:number, label:string}}
+ */
+export function classifyInsignia(row) {
+  const a = tierOfSide(row.origen, row.origenCategoria);
+  const b = tierOfSide(row.destino, row.destinoCategoria);
+  const best = [a, b].filter(Boolean).sort((x, y) => x.tier - y.tier)[0];
+  return best || { tier: 4, label: 'otros' };
+}
+
+// =============================================================================
+// Reporte agregado (puro)
+// =============================================================================
+
+/**
+ * @param {Array<object>} rows - filas normalizadas (parseAuditRows o extractAssociationEdges)
+ * @param {{graph?:string, limit?:number}} [opts]
+ */
+export function buildAuditReport(rows, opts = {}) {
+  const graph = opts.graph || DEFAULT_GRAPH;
+  const limit = Number.isFinite(opts.limit) && opts.limit >= 0 ? opts.limit : DEFAULT_LIMIT;
+
+  const total = rows.length;
+  const withSourceRows = rows.filter(hasSource);
+  const withoutSourceRows = rows.filter((r) => !hasSource(r));
+  const pctWithSource = total ? Math.round((withSourceRows.length / total) * 1000) / 10 : 0;
+
+  const byRelation = {};
+  for (const rel of ASSOCIATION_RELATIONS) {
+    const relRows = rows.filter((r) => r.relacion === rel);
+    const relWithSource = relRows.filter(hasSource);
+    byRelation[rel] = {
+      total: relRows.length,
+      withSource: relWithSource.length,
+      pctWithSource: relRows.length
+        ? Math.round((relWithSource.length / relRows.length) * 1000) / 10
+        : 0,
+    };
+  }
+
+  const missingClassified = withoutSourceRows
+    .map((r) => ({ ...r, ...classifyInsignia(r) }))
+    .sort((a, b) => {
+      if (a.tier !== b.tier) return a.tier - b.tier;
+      if (a.origen !== b.origen) return a.origen < b.origen ? -1 : 1;
+      if (a.destino !== b.destino) return a.destino < b.destino ? -1 : 1;
+      return 0;
+    });
+
+  const missingByTier = {};
+  for (const row of missingClassified) {
+    missingByTier[row.label] = (missingByTier[row.label] || 0) + 1;
+  }
+
+  const missingTruncated = missingClassified.length > limit;
+
+  return {
+    graph,
+    totalAssociationEdges: total,
+    withSource: withSourceRows.length,
+    withoutSource: withoutSourceRows.length,
+    pctWithSource,
+    byRelation,
+    missingByTier,
+    missingTruncated,
+    missing: missingClassified.slice(0, limit).map((r) => ({
+      origen: r.origen,
+      origenNombre: r.origenNombre,
+      destino: r.destino,
+      destinoNombre: r.destinoNombre,
+      relacion: r.relacion,
+      prioridad: r.label,
+    })),
+  };
+}
+
+const TIER_ORDER = ['milpa_clasica', 'cafe', 'hortalizas', 'otros'];
+
+/**
+ * @param {ReturnType<typeof buildAuditReport>} report
+ * @returns {string}
+ */
+export function formatReportText(report) {
+  const lines = [];
+  lines.push(`Auditoria de citacion — asociacion/milpa — grafo ${report.graph}`);
+  lines.push(`Total aristas de asociacion: ${report.totalAssociationEdges}`);
+  lines.push(`Con fuente/DOI: ${report.withSource} (${report.pctWithSource}%)`);
+  lines.push(`Sin fuente/DOI: ${report.withoutSource}`);
+  lines.push('');
+  lines.push('Por tipo de relacion:');
+  for (const [rel, stats] of Object.entries(report.byRelation)) {
+    lines.push(`  ${rel}: ${stats.withSource}/${stats.total} con fuente (${stats.pctWithSource}%)`);
+  }
+  lines.push('');
+  lines.push('Sin fuente, por prioridad de cultivo insignia:');
+  for (const label of TIER_ORDER) {
+    if (report.missingByTier[label]) {
+      lines.push(`  ${label}: ${report.missingByTier[label]}`);
+    }
+  }
+  lines.push('');
+  const suffix = report.missingTruncated ? ` [primeras ${report.missing.length} de ${report.withoutSource}]` : '';
+  lines.push(`Lista priorizada sin fuente (origen -> destino)${suffix}:`);
+  for (const m of report.missing) {
+    lines.push(
+      `  [${m.prioridad}] ${m.origen} (${m.origenNombre || 's/n'}) -> ${m.destino} (${m.destinoNombre || 's/n'}) [${m.relacion}]`,
+    );
+  }
+  return lines.join('\n');
+}
+
+// =============================================================================
+// Conexion a AGE — mismo patron que scripts/validate-graph-parity.mjs y
+// scripts/load-age-etno-folk-fitopatologia.mjs: CHAGRA_AGE_PSQL_COMMAND
+// override, o `sudo podman exec -i postgres-farm psql ...` por defecto.
+// Sin credenciales hardcodeadas — todo entra por process.env.
+// =============================================================================
+
+export function buildPsqlInvocation() {
+  const override = process.env.CHAGRA_AGE_PSQL_COMMAND;
+  if (override) {
+    return { kind: 'shell', command: override };
+  }
+  return {
+    kind: 'podman',
+    file: 'sudo',
+    args: [
+      'podman', 'exec', '-i', 'postgres-farm',
+      'psql', '-U', 'farmos', '-d', 'chagra_kg',
+      '-At', '-F', '\t',
+    ],
+  };
+}
+
+export function runPsql(sql) {
+  const inv = buildPsqlInvocation();
+  if (inv.kind === 'shell') {
+    return spawnSync(inv.command, {
+      input: sql,
+      encoding: 'utf8',
+      shell: true,
+      env: process.env,
+    });
+  }
+  return spawnSync(inv.file, inv.args, {
+    input: sql,
+    encoding: 'utf8',
+    env: process.env,
+  });
+}
+
+// =============================================================================
+// CLI
+// =============================================================================
+
+export function parseArgs(argv) {
+  const opts = {
+    graph: DEFAULT_GRAPH,
+    json: false,
+    limit: DEFAULT_LIMIT,
+    printSql: false,
+    fromDump: null,
+    catalogMode: undefined,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--graph') opts.graph = argv[++i];
+    else if (a === '--json') opts.json = true;
+    else if (a === '--limit') opts.limit = Number(argv[++i]);
+    else if (a === '--print-sql') opts.printSql = true;
+    else if (a === '--from-dump') opts.fromDump = argv[++i];
+    else if (a === '--catalog-mode') opts.catalogMode = true;
+    else if (a === '--help' || a === '-h') opts.help = true;
+  }
+  return opts;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  if (opts.help) {
+    console.log(
+      'Usage: node scripts/audit-milpa-citations.mjs [--graph chagra_kg] [--json]\n'
+      + '       [--limit N] [--print-sql] [--from-dump FILE] [--catalog-mode]\n\n'
+      + '  --from-dump FILE  Modo offline (NO toca la DB): parsea {nodes,edges} o\n'
+      + '                    catalogo {species}. Seguro para CI.\n'
+      + '  --print-sql       Imprime el SQL y sale (no ejecuta nada).\n\n'
+      + 'Sin --from-dump, consulta chagra_kg vivo via psql. Override con\n'
+      + 'CHAGRA_AGE_PSQL_COMMAND; por defecto usa sudo podman exec postgres-farm.',
+    );
+    return 0;
+  }
+
+  const sql = buildMilpaAuditSql(opts.graph);
+  if (opts.printSql) {
+    console.log(sql);
+    return 0;
+  }
+
+  let rows;
+  if (opts.fromDump) {
+    const data = JSON.parse(readFileSync(resolve(opts.fromDump), 'utf8'));
+    rows = extractAssociationEdges(data, { catalogMode: opts.catalogMode });
+  } else {
+    const result = runPsql(sql);
+    if (result.error) {
+      console.error(`Error ejecutando psql: ${result.error.message}`);
+      return 2;
+    }
+    if (result.status !== 0) {
+      if (result.stderr) console.error(String(result.stderr).trim());
+      return result.status || 2;
+    }
+    rows = parseAuditRows(result.stdout);
+  }
+
+  const report = buildAuditReport(rows, { graph: opts.graph, limit: opts.limit });
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatReportText(report));
+  }
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}


### PR DESCRIPTION
## Summary
- Agrega `scripts/audit-milpa-citations.mjs`: audita las aristas de asociación/companion planting (`COMPATIBLE_WITH` y `ASOCIA_CON`) del grafo `chagra_kg` y lista cuáles carecen de fuente/DOI (`fuente` / `doi` / `verificado_openalex`).
- Prioriza la lista sin fuente por cultivo insignia: milpa clásica (maíz/frijol/calabaza) > café > hortalizas > otros — pensado para alimentar una DR posterior que busque las citas reales. No inventa fuentes ni modifica el catálogo/grafo.
- Modo LIVE (default): consulta `chagra_kg` vía psql, mismo patrón que `scripts/validate-graph-parity.mjs` / `scripts/load-age-etno-folk-fitopatologia.mjs` (`CHAGRA_AGE_PSQL_COMMAND` override, o `sudo podman exec postgres-farm` por defecto; sin credenciales hardcodeadas).
- Modo OFFLINE (`--from-dump FILE`): parsea un dump `{nodes, edges}` (mismo shape que `scripts/check-age-integrity.mjs`) o un catálogo `{species}` — no toca la DB, seguro para CI.
- Agrega `scripts/__tests__/audit-milpa-citations.test.mjs` cubriendo el SQL builder, el parser de salida psql, el extractor offline, el clasificador de prioridad y el agregador de reporte con datos mock; incluye un bloque "live DB" gated por `CHAGRA_AGE_PSQL_COMMAND` que hace skip limpio en CI.

## Test plan
- [x] `npx vitest run scripts/__tests__/audit-milpa-citations.test.mjs` → 39 passed, 1 skipped (bloque live DB sin env)
- [x] `npx vitest run scripts/__tests__/` completo → sin regresiones (496 passed, 16 skipped)
- [x] `npx eslint scripts/audit-milpa-citations.mjs scripts/__tests__/audit-milpa-citations.test.mjs` → sin errores
- [x] Smoke manual `node scripts/audit-milpa-citations.mjs --print-sql` y `--from-dump` con fixture sintética