### PR TITLE
feat(cicd): releases + rollback rápido (dev/qa/prod)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,19 +167,55 @@ jobs:
         #     3) GC de chunks viejos para no crecer infinito: borra archivos en
         #        TARGET/assets/ con mtime > 30 dias. 30 dias cubre de sobra el
         #        tiempo para que un cliente instalado se actualice.
+        #
+        # CI-1 (2026-07-01) — releases versionadas + symlink `current`:
+        #   Este step YA NO escribe TARGET/ in-place. Escribe a
+        #   TARGET/releases/<version>/ y al final hace swap atómico del
+        #   symlink TARGET/current -> releases/<version>. Rollback
+        #   (rollback.yml) reapunta ese symlink sub-segundo, sin rebuild.
+        #   `assets/` sigue siendo un pool COMPARTIDO fuera de releases/ (NO
+        #   se versiona por release): son content-hashed e inmutables, asi
+        #   que duplicarlos por release solo gastaria espacio. Cada release
+        #   lleva un symlink `assets -> ../../assets` para que, sirviendo
+        #   desde TARGET/current/, /assets/*.js resuelva al pool compartido.
+        #   Se retienen las ultimas 10 releases (por mtime); el resto se borra.
+        #
+        #   CRITICO — nginx (guatoc-nixos, fuera de este repo) debe servir
+        #   TARGET/current como root, NO TARGET directo. Ese cambio de infra
+        #   lo aplica el operador; sin el, este CI deja releases/current
+        #   escritos pero nginx sigue sirviendo el arbol viejo. CI-1 (este
+        #   workflow) + el cambio de nginx se despliegan JUNTOS.
         run: |
+          set -e
           umask 022
-          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' dist/ /mnt/fast/appdata/farmos-pwa/
-          rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ /mnt/fast/appdata/farmos-pwa/assets/
-          find /mnt/fast/appdata/farmos-pwa/assets/ -type f -mtime +30 -delete || true
-          find /mnt/fast/appdata/farmos-pwa -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
+          TARGET=/mnt/fast/appdata/farmos-pwa
+          VERSION=$(jq -r .version package.json)
+          RELEASE_DIR="$TARGET/releases/$VERSION"
+          mkdir -p "$RELEASE_DIR"
+
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' dist/ "$RELEASE_DIR/"
+          rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ "$TARGET/assets/"
+          ln -sfn ../../assets "$RELEASE_DIR/assets"
+
+          find "$RELEASE_DIR" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
+          find "$TARGET/assets/" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
+          find "$TARGET/assets/" -type f -mtime +30 -delete || true
+
+          # Swap atómico: current pasa a apuntar a la release recién escrita.
+          ln -sfn "releases/$VERSION" "$TARGET/current"
+
+          # Retención: conserva solo las últimas 10 releases (por mtime).
+          ( cd "$TARGET/releases" && ls -1dt */ 2>/dev/null | tail -n +11 | xargs -r rm -rf -- )
+
+          echo "Deployed version $VERSION -> $TARGET/current"
 
       - if: env.SKIP_DEPLOY != '1'
         name: Verify deployment
         run: |
-          test -f /mnt/fast/appdata/farmos-pwa/index.html || exit 1
-          HASH=$(sha256sum /mnt/fast/appdata/farmos-pwa/index.html | cut -d' ' -f1)
-          echo "Deploy OK: $(date -Iseconds) | index.html sha256: ${HASH:0:12}"
+          TARGET=/mnt/fast/appdata/farmos-pwa
+          test -f "$TARGET/current/index.html" || exit 1
+          HASH=$(sha256sum "$TARGET/current/index.html" | cut -d' ' -f1)
+          echo "Deploy OK: $(date -Iseconds) | current -> $(readlink "$TARGET/current") | index.html sha256: ${HASH:0:12}"
 
       - if: env.SKIP_DEPLOY != '1'
         name: Notify HA to refresh Nest Hub
@@ -210,8 +246,10 @@ jobs:
         # (RAG_GROUNDING_PREFIX/MAP_TILES_PREFIX viven en otras líneas con su
         # propio versionado v1; no se tocan al limitar el patrón con `0,/.../`.)
         run: |
-          SW_FILE=/mnt/fast/appdata/farmos-pwa/sw.js
-          VERSION_FILE=/mnt/fast/appdata/farmos-pwa/version.json
+          # Rutas a través del symlink `current` (CI-1): editan el archivo
+          # real dentro de releases/<version>/, que es lo que nginx sirve.
+          SW_FILE=/mnt/fast/appdata/farmos-pwa/current/sw.js
+          VERSION_FILE=/mnt/fast/appdata/farmos-pwa/current/version.json
           COMMIT_SHORT=$(git rev-parse --short HEAD)
           if [ -f "$SW_FILE" ]; then
             # 0,/regex/ limita el reemplazo a la PRIMERA línea que matchea

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -64,6 +64,13 @@ jobs:
 
       - if: env.SKIP_DEPLOY != '1'
         name: Deploy to dev
+        # CI-1 (2026-07-01) — releases versionadas + symlink `current`: ver
+        # comentario extenso en deploy.yml (prod). Mismo patrón acá: escribe a
+        # TARGET/releases/<version>/ (version = short SHA) y hace swap atómico
+        # TARGET/current -> releases/<v>. Retiene las últimas 10 releases.
+        #
+        # CRÍTICO — nginx (guatoc-nixos) debe servir TARGET/current, no TARGET
+        # directo. Cambio de infra que aplica el operador junto con este CI.
         run: |
           set -e
           TARGET=/mnt/fast/appdata/farmos-pwa-dev
@@ -87,19 +94,41 @@ jobs:
           # tocar sus permisos/borrarlo con --delete y aborta con exit 23
           # (partial transfer) -> deploy PARCIAL -> index.html referencia
           # assets que nunca se copiaron -> pantalla negra. Lo dejamos intacto.
+          #
+          # mockups/ (igual que assets/) es un pool COMPARTIDO fuera de
+          # releases/, no versionado por release: se linkea SI existe en el
+          # target (dir manual, opcional, no viene del build).
+          VERSION=$(git rev-parse --short HEAD)
+          RELEASE_DIR="$TARGET/releases/$VERSION"
+          mkdir -p "$RELEASE_DIR"
+
           rsync -avzO --no-perms --delete --no-group --chmod=F644 \
-            --exclude='/assets/' --exclude='/mockups/' dist/ "$TARGET/"
+            --exclude='/assets/' --exclude='/mockups/' dist/ "$RELEASE_DIR/"
           rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ "$TARGET/assets/"
+          ln -sfn ../../assets "$RELEASE_DIR/assets"
+          if [ -d "$TARGET/mockups" ]; then
+            ln -sfn ../../mockups "$RELEASE_DIR/mockups"
+          fi
+
+          find "$RELEASE_DIR" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
+          find "$TARGET/assets/" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
           find "$TARGET/assets/" -type f -mtime +30 -delete || true
-          find "$TARGET" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
+
+          # Swap atómico: current pasa a apuntar a la release recién escrita.
+          ln -sfn "releases/$VERSION" "$TARGET/current"
+
+          # Retención: conserva solo las últimas 10 releases (por mtime).
+          ( cd "$TARGET/releases" && ls -1dt */ 2>/dev/null | tail -n +11 | xargs -r rm -rf -- )
+
+          echo "Deployed version $VERSION -> $TARGET/current"
 
       - if: env.SKIP_DEPLOY != '1'
         name: Verify deployment
         run: |
           TARGET=/mnt/fast/appdata/farmos-pwa-dev
-          test -f "$TARGET/index.html" || exit 1
-          HASH=$(sha256sum "$TARGET/index.html" | cut -d' ' -f1)
-          echo "DEV Deploy OK: $(date -Iseconds) | index.html sha256: ${HASH:0:12}"
+          test -f "$TARGET/current/index.html" || exit 1
+          HASH=$(sha256sum "$TARGET/current/index.html" | cut -d' ' -f1)
+          echo "DEV Deploy OK: $(date -Iseconds) | current -> $(readlink "$TARGET/current") | index.html sha256: ${HASH:0:12}"
 
       - if: env.SKIP_DEPLOY != '1'
         name: Verify referenced assets exist
@@ -110,7 +139,9 @@ jobs:
           # Si el deploy quedo parcial (p.ej. rsync exit 23 por mockups, o un
           # stomp), faltara algun chunk hasheado y el job debe FALLAR aqui en
           # vez de dejar dev sirviendo una pantalla negra silenciosa.
-          TARGET=/mnt/fast/appdata/farmos-pwa-dev
+          # CI-1: se verifica a través de current/ (lo que nginx sirve), no
+          # el TARGET raíz — ahí ya no vive index.html directamente.
+          TARGET=/mnt/fast/appdata/farmos-pwa-dev/current
           INDEX="$TARGET/index.html"
           test -f "$INDEX" || { echo "index.html ausente en $TARGET"; exit 1; }
 
@@ -144,7 +175,9 @@ jobs:
       - if: env.SKIP_DEPLOY != '1'
         name: Bump SW cache version (dev)
         run: |
-          SW_FILE=/mnt/fast/appdata/farmos-pwa-dev/sw.js
+          # Ruta a través del symlink `current` (CI-1): edita el archivo real
+          # dentro de releases/<version>/, que es lo que nginx sirve.
+          SW_FILE=/mnt/fast/appdata/farmos-pwa-dev/current/sw.js
           if [ -f "$SW_FILE" ]; then
             COMMIT_SHORT=$(git rev-parse --short HEAD)
             sed -i -E "s/chagra-[0-9a-z]+/chagra-dev-${COMMIT_SHORT}/" "$SW_FILE"

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -59,6 +59,16 @@ jobs:
 
       - if: env.SKIP_DEPLOY != '1'
         name: Deploy to qa
+        # CI-1 (2026-07-01) — releases versionadas + symlink `current`: ver
+        # comentario extenso en deploy.yml (prod). Mismo patrón acá: escribe a
+        # TARGET/releases/<version>/ (version = short SHA, qa no bumpea
+        # package.json) y hace swap atómico TARGET/current -> releases/<v>.
+        # assets/ sigue siendo pool COMPARTIDO fuera de releases/ (append-only,
+        # igual que antes); cada release lleva un symlink assets -> ../../assets.
+        # Retiene las últimas 10 releases.
+        #
+        # CRÍTICO — nginx (guatoc-nixos) debe servir TARGET/current, no TARGET
+        # directo. Cambio de infra que aplica el operador junto con este CI.
         run: |
           set -e
           TARGET=/mnt/fast/appdata/farmos-pwa-qa
@@ -76,23 +86,40 @@ jobs:
           #   2) sincronizar /assets/ SIN --delete (agregar chunks nuevos,
           #      conservar viejos; los hashes no colisionan).
           #   3) GC de chunks con mtime > 30 dias para no crecer infinito.
-          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' dist/ "$TARGET/"
+          VERSION=$(git rev-parse --short HEAD)
+          RELEASE_DIR="$TARGET/releases/$VERSION"
+          mkdir -p "$RELEASE_DIR"
+
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' dist/ "$RELEASE_DIR/"
           rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ "$TARGET/assets/"
+          ln -sfn ../../assets "$RELEASE_DIR/assets"
+
+          find "$RELEASE_DIR" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
+          find "$TARGET/assets/" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
           find "$TARGET/assets/" -type f -mtime +30 -delete || true
-          find "$TARGET" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
+
+          # Swap atómico: current pasa a apuntar a la release recién escrita.
+          ln -sfn "releases/$VERSION" "$TARGET/current"
+
+          # Retención: conserva solo las últimas 10 releases (por mtime).
+          ( cd "$TARGET/releases" && ls -1dt */ 2>/dev/null | tail -n +11 | xargs -r rm -rf -- )
+
+          echo "Deployed version $VERSION -> $TARGET/current"
 
       - if: env.SKIP_DEPLOY != '1'
         name: Verify deployment
         run: |
           TARGET=/mnt/fast/appdata/farmos-pwa-qa
-          test -f "$TARGET/index.html" || exit 1
-          HASH=$(sha256sum "$TARGET/index.html" | cut -d' ' -f1)
-          echo "QA Deploy OK: $(date -Iseconds) | index.html sha256: ${HASH:0:12}"
+          test -f "$TARGET/current/index.html" || exit 1
+          HASH=$(sha256sum "$TARGET/current/index.html" | cut -d' ' -f1)
+          echo "QA Deploy OK: $(date -Iseconds) | current -> $(readlink "$TARGET/current") | index.html sha256: ${HASH:0:12}"
 
       - if: env.SKIP_DEPLOY != '1'
         name: Bump SW cache version (qa)
         run: |
-          SW_FILE=/mnt/fast/appdata/farmos-pwa-qa/sw.js
+          # Ruta a través del symlink `current` (CI-1): edita el archivo real
+          # dentro de releases/<version>/, que es lo que nginx sirve.
+          SW_FILE=/mnt/fast/appdata/farmos-pwa-qa/current/sw.js
           if [ -f "$SW_FILE" ]; then
             COMMIT_SHORT=$(git rev-parse --short HEAD)
             sed -i -E "s/chagra-[0-9a-z]+/chagra-qa-${COMMIT_SHORT}/" "$SW_FILE"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,111 @@
+name: Rollback Chagra PWA
+
+# CI-2 (2026-07-01): rollback manual, sub-segundo, sin rebuild. Re-apunta el
+# symlink TARGET/current a una release ya escrita en TARGET/releases/<v>/
+# (ver CI-1 en dev-deploy.yml / qa-deploy.yml / deploy.yml).
+#
+# CRÍTICO — depende de que nginx (guatoc-nixos, fuera de este repo) sirva
+# TARGET/current como root. Si ese cambio de infra aún no lo aplicó el
+# operador, este workflow reapunta el symlink correctamente pero nginx
+# sigue sirviendo el árbol viejo (sin efecto visible hasta que nginx se
+# actualice). CI-1 + el cambio de nginx se despliegan JUNTOS.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Ambiente a revertir"
+        required: true
+        type: choice
+        options:
+          - dev
+          - qa
+          - prod
+      release:
+        description: "Release a la que volver (ej. 1.0.184 en prod, o abc1234 en dev/qa). Vacío = penúltima release disponible."
+        required: false
+        type: string
+
+concurrency:
+  # prod/qa comparten grupo con su deploy normal (deploy-chagra-prod /
+  # deploy-chagra-qa) para no correr rollback y deploy en simultáneo sobre
+  # el mismo TARGET. dev usa grupo propio: el deploy de dev serializa POR
+  # BRANCH (deploy-chagra-dev-<ref>), así que no hay un único grupo de deploy
+  # con el que cruzar — un rollback en dev igual queda serializado contra
+  # otros rollbacks de dev.
+  group: ${{ inputs.environment == 'prod' && 'deploy-chagra-prod' || inputs.environment == 'qa' && 'deploy-chagra-qa' || 'rollback-chagra-dev' }}
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    runs-on: [self-hosted, alpha]
+    timeout-minutes: 5
+    steps:
+      - name: Detect runner identity
+        # Mismo guard que dev-deploy.yml/qa-deploy.yml/deploy.yml: si GitHub
+        # asigna el job al claude-runner (sin acceso esperado a /mnt/fast),
+        # saltar todos los steps posteriores con success silencioso.
+        run: |
+          if echo "$HOME" | grep -q claude-runner; then
+            echo "::warning::Job matcheado al claude-runner ($HOME). Skipping (success). Re-ejecutar el workflow para forzar otro draw del runner."
+            echo "SKIP_DEPLOY=1" >> "$GITHUB_ENV"
+          else
+            echo "Runner OK ($HOME) — procediendo con rollback."
+          fi
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Resolver TARGET por ambiente
+        run: |
+          case "${{ inputs.environment }}" in
+            dev)  TARGET=/mnt/fast/appdata/farmos-pwa-dev ;;
+            qa)   TARGET=/mnt/fast/appdata/farmos-pwa-qa ;;
+            prod) TARGET=/mnt/fast/appdata/farmos-pwa ;;
+            *)
+              echo "::error::Ambiente desconocido: '${{ inputs.environment }}'"
+              exit 1
+              ;;
+          esac
+          echo "TARGET=$TARGET" >> "$GITHUB_ENV"
+          echo "Ambiente=${{ inputs.environment }} -> TARGET=$TARGET"
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Rollback (swap symlink current)
+        run: |
+          set -euo pipefail
+          if [ ! -d "$TARGET/releases" ]; then
+            echo "::error::No existe $TARGET/releases — este ambiente aún no tiene releases versionadas (CI-1 nunca corrió acá, o es la primera vez)."
+            exit 1
+          fi
+
+          cd "$TARGET/releases"
+          RELEASE_INPUT="${{ inputs.release }}"
+
+          if [ -n "$RELEASE_INPUT" ]; then
+            TARGET_RELEASE="$RELEASE_INPUT"
+            if [ ! -d "$TARGET_RELEASE" ]; then
+              echo "::error::Release '$TARGET_RELEASE' no existe en $TARGET/releases/. Disponibles:"
+              ls -1dt */ | sed 's#/$##'
+              exit 1
+            fi
+          else
+            # Default: penúltima release = la más reciente por mtime que NO
+            # sea la que 'current' apunta hoy.
+            CURRENT_RELEASE=$(readlink "$TARGET/current" 2>/dev/null | sed 's#^releases/##' || true)
+            TARGET_RELEASE=$(ls -1dt */ | sed 's#/$##' | grep -v -x "$CURRENT_RELEASE" | head -n 1 || true)
+            if [ -z "$TARGET_RELEASE" ]; then
+              echo "::error::No se encontró una release anterior para rollback automático (¿solo hay una release?). Especificá 'release' manualmente."
+              exit 1
+            fi
+            echo "Sin 'release' especificado -> penúltima release detectada: $TARGET_RELEASE (current hoy: ${CURRENT_RELEASE:-ninguna})"
+          fi
+
+          echo "Rollback ${{ inputs.environment }}: current -> releases/$TARGET_RELEASE"
+          ln -sfn "releases/$TARGET_RELEASE" "$TARGET/current"
+          echo "OK. current ahora apunta a releases/$TARGET_RELEASE"
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Verify rollback
+        run: |
+          test -f "$TARGET/current/index.html" || exit 1
+          HASH=$(sha256sum "$TARGET/current/index.html" | cut -d' ' -f1)
+          echo "Rollback OK (${{ inputs.environment }}): $(date -Iseconds) | current -> $(readlink "$TARGET/current") | index.html sha256: ${HASH:0:12}"


### PR DESCRIPTION
## Summary

Implementa CI-1 y CI-2 del plan `Chagra-strategy/ops/cicd-environments-plan-2026-07-01.md`:

- **CI-1** — `dev-deploy.yml`, `qa-deploy.yml` y `deploy.yml` ya no escriben `TARGET/` in-place. Cada deploy escribe a `TARGET/releases/<version>/` (prod = `1.0.<git count>` ya calculado; dev/qa = short SHA) y hace un swap atómico `ln -sfn releases/<version> TARGET/current`. Se retienen las últimas 10 releases por ambiente (se borran las más viejas por mtime).
  - `assets/` sigue siendo el pool compartido de siempre (append-only, GC por mtime > 30 días, sin versionar por release — son content-hashed e inmutables). Cada release lleva un symlink `assets -> ../../assets` para que sirviendo desde `current/` los chunks resuelvan al pool compartido.
  - `dev-deploy.yml` conserva el mismo tratamiento especial para `mockups/` (dir manual fuera de `dist/`), ahora también linkeado por release si existe en el target.
  - Los pasos `Verify deployment`, `Verify referenced assets exist` y `Bump SW cache version` ahora leen/escriben a través de `TARGET/current/...`.

- **CI-2** — nuevo `.github/workflows/rollback.yml`: `workflow_dispatch` con inputs `environment` (dev/qa/prod) y `release` (opcional; default = penúltima release detectada por mtime). Re-apunta el symlink `current` en el runner `[self-hosted, alpha]`, mismo guard `SKIP_DEPLOY` del claude-runner. Rollback = re-apuntar symlink, sin rebuild, sub-segundo.

## Nota nginx (CRÍTICO — acción del operador)

Este PR **no toca nginx** (vive en `guatoc-nixos`, fuera de este repo). Hoy nginx sirve `TARGET/` directo (`/mnt/fast/appdata/farmos-pwa[-dev|-qa]`). Con este cambio, el contenido real vive en `TARGET/releases/<version>/` y `TARGET/current` es un symlink a la release activa.

**Antes de que este CI tenga efecto en producción, el operador debe actualizar el `root` de cada vhost nginx de `TARGET` a `TARGET/current`** (los 3 ambientes: dev, qa, prod). Sin ese cambio, este workflow escribe releases + symlink correctamente pero nginx sigue sirviendo el árbol viejo (no hay regresión, pero tampoco efecto visible ni rollback funcional hasta que nginx se actualice).

**CI-1 (este PR) + el cambio de nginx deben desplegarse JUNTOS.** Recomendado: mergear este PR primero contra `dev`/`qa` para validar el layout `releases/` + `current` con tráfico real de bajo riesgo antes de tocar el vhost de prod.

## Test plan

- [ ] Merge/push a `dev` → confirmar que el job crea `farmos-pwa-dev/releases/<sha>/` y `farmos-pwa-dev/current -> releases/<sha>`, y que `index.html`/`assets/` resuelven vía el symlink (`readlink current`, `curl -I` a través de nginx una vez actualizado el vhost dev).
- [ ] Repetir un segundo deploy a `dev` y confirmar que queda una segunda release y `current` se re-apunta (sin borrar la primera — retención es de 10).
- [ ] Ejecutar `rollback.yml` manualmente con `environment=dev` sin especificar `release` → confirmar que `current` vuelve a apuntar a la release anterior (penúltima) y `index.html` sirve el contenido de esa versión.
- [ ] Ejecutar `rollback.yml` con `environment=dev` y `release=<sha explícito>` → confirmar que apunta exactamente a esa release.
- [ ] Repetir el mismo ciclo (deploy → deploy → rollback) contra `qa`.
- [ ] Coordinar con el operador la actualización del vhost nginx (root → `current`) para dev/qa, validar, y recién entonces repetir el ciclo contra `prod` (push a `main` + `rollback.yml environment=prod`).
- [ ] Confirmar que tras varios deploys seguidos solo se retienen 10 releases por ambiente (`ls TARGET/releases | wc -l`).
- [ ] Confirmar que un cliente PWA con Service Worker viejo (con `/assets/*.js` de una release anterior) sigue funcionando tras varios deploys (el pool `assets/` compartido no debe perder chunks recientes por el cambio de layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)