### PR TITLE
feat(agent): modo maestro alcanzable desde UI

### DIFF
--- a/src/services/__tests__/agentPromptBase.test.js
+++ b/src/services/__tests__/agentPromptBase.test.js
@@ -446,6 +446,16 @@ describe('modos de respuesta (campesino/experto/maestro)', () => {
     expect(prompt).toContain('MODO CAMPESINO');
   });
 
+  // Regresión: el modo MAESTRO ya lo soportaba el backend (normalizeMode
+  // reconoce 'maestro'/'profesor'/'mentor'), pero el selector de perfil de la
+  // UI solo exponía simple/detallado. Ahora nivel_respuestas='maestro' (el
+  // valor que guarda la 3ra opción del perfil) debe inyectar el bloque.
+  it('buildBasePrompt inyecta MODO MAESTRO cuando nivelRespuestas es maestro', () => {
+    const prompt = buildBasePrompt({ query: '¿por qué se enferma mi tomate?', nivelRespuestas: 'maestro' });
+    expect(prompt).toContain('MODO MAESTRO');
+    expect(prompt).toContain('Habla como quien enseña');
+  });
+
   it('buildBasePrompt NO duplica el bloque de nivel de detalle (regresión fix dedup)', () => {
     // El registro de respuesta lo maneja MODO EXPERTO; el viejo bloque
     // "NIVEL DE RESPUESTA" no debe reaparecer en paralelo.

--- a/src/services/__tests__/userProfileService.test.js
+++ b/src/services/__tests__/userProfileService.test.js
@@ -57,6 +57,19 @@ describe('userProfileService (#200)', () => {
       const ids = PROFILE_QUESTIONS.map((q) => q.id);
       expect(new Set(ids).size).toBe(ids.length);
     });
+
+    // Regresión: el modo MAESTRO (buildMasterModeBlock en agentPromptBase.js)
+    // ya lo soporta el backend (normalizeMode reconoce 'maestro'), pero el
+    // selector de perfil solo ofrecía simple/detallado. Se agrega la 3ra
+    // opción para que sea alcanzable desde la UI (ProfileScreen → onboarding).
+    it('nivel_respuestas ofrece la opción "maestro" alcanzable desde el perfil', () => {
+      const pregunta = PROFILE_QUESTIONS.find((q) => q.id === 'nivel_respuestas');
+      expect(pregunta).toBeTruthy();
+      const values = pregunta.options.map((o) => o.value);
+      expect(values).toContain('simple');
+      expect(values).toContain('detallado');
+      expect(values).toContain('maestro');
+    });
   });
 
   describe('preguntas condicionales', () => {
@@ -149,6 +162,11 @@ describe('userProfileService (#200)', () => {
     it('preferencia detallado añade directiva técnica', () => {
       const block = buildUserProfileBlock({ nombre: 'X', nivel_respuestas: 'detallado' });
       expect(block).toMatch(/DETALLADAS/);
+    });
+
+    it('preferencia maestro añade directiva de enseñar el porqué', () => {
+      const block = buildUserProfileBlock({ nombre: 'X', nivel_respuestas: 'maestro' });
+      expect(block).toMatch(/enseñes el porqué/);
     });
   });
 });

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -431,6 +431,7 @@ export const PROFILE_QUESTIONS = [
     options: [
       { value: 'simple', label: 'Simple y al grano' },
       { value: 'detallado', label: 'Detallado, con explicación técnica' },
+      { value: 'maestro', label: 'Maestro — me enseña el porqué' },
     ],
   },
   {
@@ -901,6 +902,9 @@ export function buildUserProfileBlock(profile) {
   } else if (p.nivel_respuestas === 'detallado') {
     tono =
       '\nIMPORTANTE: este usuario prefiere respuestas DETALLADAS y técnicas. Puedes profundizar con nombres científicos, dosis, mecanismos y citar fuentes.';
+  } else if (p.nivel_respuestas === 'maestro') {
+    tono =
+      '\nIMPORTANTE: este usuario prefiere que le enseñes el porqué. Explica la lógica detrás de cada recomendación y deja criterio para que decida por su cuenta la próxima vez.';
   }
 
   return `=== PERFIL DEL USUARIO (personaliza tus respuestas a este contexto) ===


### PR DESCRIPTION
## Summary
- El backend ya soportaba el modo MAESTRO (`buildMasterModeBlock` + `normalizeMode` en `src/services/agentPromptBase.js`, mergeado en #1906), pero el selector de perfil solo ofrecía simple/detallado.
- Se agrega la 3ra opción `maestro` ("Maestro — me enseña el porqué") a la pregunta `nivel_respuestas` en `PROFILE_QUESTIONS` (`src/services/userProfileService.js`), alcanzable desde el onboarding/ProfileScreen (`getApplicableQuestions` → `OnboardingProfile.jsx`, que renderiza `options` genéricamente sin cambios adicionales).
- Se completa la directiva de tono en `buildUserProfileBlock` para el valor `maestro` (mismo patrón que simple/detallado).
- Los toggles rápidos de `AgentHero.jsx` y `FincaVivaHero.jsx` quedan binarios (simple/detallado) a propósito: son atajos cosméticos de la portada que no alimentan el system prompt real — `buildBasePrompt` lee `nivel_respuestas` directo del perfil vía `getProfile()`, no del estado local de esos componentes — así que no bloquean ni pisan el modo maestro elegido desde el selector de perfil completo. Ampliarlos a 3 estados tocaría textos de saludo/subtítulo y CSS adicionales fuera del alcance de esta tarea.

## Test plan
- [x] `npx vitest run src/services/__tests__/agentPromptBase.test.js src/services/__tests__/agentPromptBase.expertMode.test.js src/services/__tests__/userProfileService.test.js src/services/__tests__/userProfileService.questions.test.js src/services/__tests__/userProfileService.onboarding.test.js src/services/__tests__/userProfileService.rol.test.js src/components/dashboard/__tests__/AgentHero.integration.test.jsx src/components/dashboard/__tests__/FincaVivaHero.nivelRespuestas.test.jsx` → 245/245 passed
- [x] Nuevo test: `nivel_respuestas` ofrece la opción `maestro`
- [x] Nuevo test: `buildBasePrompt({ nivelRespuestas: 'maestro' })` inyecta `=== MODO MAESTRO ===`
- [x] Nuevo test: `buildUserProfileBlock` con `nivel_respuestas: 'maestro'` añade la directiva de tono