### PR TITLE
perf(assets): virtualizar AssetsDashboard (react-virtuoso)

### DIFF
--- a/src/components/__tests__/AssetsDashboard.virtualizedList.test.jsx
+++ b/src/components/__tests__/AssetsDashboard.virtualizedList.test.jsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * queue/056.1 — Virtualizar AssetsDashboard lista principal.
+ *
+ * La integración de `react-virtuoso` ya vive en `AssetsDashboard.jsx` (merge
+ * previo, PR #1799 — commit aa259ea) sobre las dos listas largas: el
+ * drill-down raíz de zonas y la lista principal de activos/plantas
+ * (`currentAssets`). Lo que faltaba era cobertura de test que probara que,
+ * con `react-virtuoso` mockeado (jsdom no mide layout real, así que Virtuoso
+ * sin mock no expone items), los items siguen siendo visibles y el
+ * comportamiento existente (filtro de búsqueda, tap para abrir detalle,
+ * eliminar, testid del conmutador multifinca) se conserva intacto.
+ *
+ * El mock de `react-virtuoso` sigue el mismo patrón ya establecido en
+ * `AssetTimeline.smoke.test.jsx`: renderiza `itemContent` para todos los
+ * `data[]` recibidos (sin windowing), suficiente para aserciones de jsdom.
+ */
+
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({ data = [], itemContent, components }) => {
+    const Header = components?.Header;
+    return (
+      <div data-testid="virtuoso-mock">
+        {Header ? <Header /> : null}
+        {data.map((item, idx) => (
+          <div key={item?.id ?? idx}>{itemContent(idx, item)}</div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../hooks/useGeolocation', () => ({
+  useGeolocation: () => ({ request: vi.fn() }),
+}));
+vi.mock('../../hooks/usePhotoUrl', () => ({
+  usePhotoUrl: () => ({ loading: false, url: null }),
+  default: () => ({ loading: false, url: null }),
+}));
+vi.mock('../../services/voiceRagEnricher', () => ({
+  enrichEntity: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../../services/apiService', () => ({
+  fetchFromFarmOS: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../../db/catalogDB', () => ({
+  findBiopreparadosByIngredient: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../SpeciesSelect', () => ({ default: () => <div data-testid="species-select-stub" /> }));
+vi.mock('../GuildSuggestions', () => ({ default: () => null }));
+vi.mock('../MapPicker', () => ({ default: () => null }));
+vi.mock('../FarmMap', () => ({ default: () => null }));
+vi.mock('../AssetDetailView', () => ({ default: () => null, AssetDetailView: () => null }));
+vi.mock('../BiopreparadoSuggestionModal', () => ({ default: () => null }));
+vi.mock('../MultiFincaModal', () => ({ default: () => null }));
+
+vi.mock('../../services/fincaActiveStore', () => {
+  const useFincaActiveStore = () => ({
+    activeFincaSlug: 'guatoc',
+    getActiveFinca: () => ({ slug: 'guatoc', nombre: 'Guatoc' }),
+    fincas: [{ slug: 'guatoc', nombre: 'Guatoc' }],
+    setActiveFincaManual: vi.fn(),
+  });
+  return { useFincaActiveStore, default: useFincaActiveStore };
+});
+
+const removeAsset = vi.fn().mockResolvedValue(undefined);
+const setSelectedAsset = vi.fn();
+const mockAssetState = {
+  plants: [],
+  structures: [],
+  equipment: [],
+  materials: [],
+  lands: [],
+  isLoading: false,
+  error: null,
+  hydrate: vi.fn().mockResolvedValue(undefined),
+  syncFromServer: vi.fn(),
+  addAsset: vi.fn(),
+  addAssetsBulk: vi.fn(),
+  removeAsset,
+  addHarvestLog: vi.fn(),
+  setSelectedAsset,
+};
+vi.mock('../../store/useAssetStore', () => ({
+  default: () => mockAssetState,
+}));
+
+import AssetsDashboard from '../AssetsDashboard';
+
+beforeEach(() => {
+  mockAssetState.plants = [];
+  mockAssetState.structures = [];
+  mockAssetState.equipment = [];
+  mockAssetState.materials = [];
+  mockAssetState.lands = [];
+  removeAsset.mockClear();
+  setSelectedAsset.mockClear();
+  vi.spyOn(window, 'confirm').mockReturnValue(true);
+});
+
+describe('AssetsDashboard — lista principal virtualizada (react-virtuoso, queue/056.1)', () => {
+  it('renderiza los items de la lista de insumos a través del mock de Virtuoso', () => {
+    mockAssetState.materials = [
+      { id: 'mat-1', type: 'asset--material', attributes: { name: 'Compost casero' } },
+      { id: 'mat-2', type: 'asset--material', attributes: { name: 'Abono orgánico' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="material" />);
+    expect(screen.getByTestId('virtuoso-mock')).toBeTruthy();
+    expect(screen.getByText('Compost casero')).toBeTruthy();
+    expect(screen.getByText('Abono orgánico')).toBeTruthy();
+  });
+
+  it('el buscador sigue filtrando la lista virtualizada', async () => {
+    const user = userEvent.setup();
+    mockAssetState.materials = [
+      { id: 'mat-1', type: 'asset--material', attributes: { name: 'Compost casero' } },
+      { id: 'mat-2', type: 'asset--material', attributes: { name: 'Abono orgánico' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="material" />);
+    await user.type(screen.getByLabelText('Buscar activo'), 'Compost');
+    expect(screen.getByText('Compost casero')).toBeTruthy();
+    expect(screen.queryByText('Abono orgánico')).toBeNull();
+  });
+
+  it('tap en un item de la lista virtualizada abre el detalle (setSelectedAsset)', async () => {
+    const user = userEvent.setup();
+    mockAssetState.materials = [
+      { id: 'mat-1', type: 'asset--material', attributes: { name: 'Compost casero' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="material" />);
+    const article = screen.getByRole('article');
+    await user.click(within(article).getByText('Compost casero'));
+    expect(setSelectedAsset).toHaveBeenCalledWith('mat-1');
+  });
+
+  it('el botón de eliminar del item virtualizado sigue funcionando', async () => {
+    const user = userEvent.setup();
+    mockAssetState.materials = [
+      { id: 'mat-1', type: 'asset--material', attributes: { name: 'Compost casero' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="material" />);
+    const article = screen.getByRole('article');
+    const buttons = within(article).getAllByRole('button');
+    // Orden DOM del item: [0] botón nombre/detalle, [1] botón eliminar (Trash2).
+    await user.click(buttons[1]);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(removeAsset).toHaveBeenCalledWith('material', 'mat-1');
+  });
+
+  it('conserva el testid del conmutador multifinca junto a la lista virtualizada', () => {
+    mockAssetState.materials = [
+      { id: 'mat-1', type: 'asset--material', attributes: { name: 'Compost casero' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="material" />);
+    expect(screen.getByTestId('assets-finca-switcher')).toBeTruthy();
+  });
+
+  it('renderiza la lista de zonas (drill-down raíz de plantas) y permite ver todos los cultivos', async () => {
+    const user = userEvent.setup();
+    mockAssetState.lands = [
+      { id: 'land-uno', attributes: { name: 'Lote del Río', land_type: 'lote' } },
+    ];
+    mockAssetState.plants = [
+      { id: 'plant-1', type: 'asset--plant', attributes: { name: 'Tomate cherry' } },
+      { id: 'plant-2', type: 'asset--plant', attributes: { name: 'Fríjol cargamanto' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="plant" />);
+    // Root drill-down: la zona se renderiza vía el mock de Virtuoso.
+    expect(screen.getByText('Lote del Río')).toBeTruthy();
+    // "Ver todos" cambia currentZoneId a '__all__' y expone la lista principal
+    // de plantas (segunda instancia de Virtuoso en el árbol).
+    await user.click(screen.getByText(/Ver todos/i));
+    expect(screen.getByText('Tomate cherry')).toBeTruthy();
+    expect(screen.getByText('Fríjol cargamanto')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

La lista larga principal de `src/components/AssetsDashboard.jsx` (activos/plantas — `currentAssets`) y el drill-down raíz de zonas se renderizan con `react-virtuoso` (`Virtuoso`), de modo que con >1000 plantas el render ya no congela la UI (queue/056.1). La integración de `react-virtuoso` ya vive en el componente (merge previo #1799); lo que faltaba de 056.1 era la cobertura de test.

Este PR agrega ese test (`src/components/__tests__/AssetsDashboard.virtualizedList.test.jsx`) que:

- Mockea `react-virtuoso` (jsdom no mide layout real, así que `Virtuoso` sin mock no expone items) para que los items sean visibles bajo test — mismo patrón ya usado en `AssetTimeline.smoke.test.jsx`.
- Verifica que los items de la lista se renderizan.
- Conserva el comportamiento existente: filtro de búsqueda, tap para abrir el detalle (`setSelectedAsset`), botón eliminar (`removeAsset` + confirm), el `data-testid` del conmutador multifinca (`assets-finca-switcher`), y el drill-down de zonas + "Ver todos".

No cambia la lógica de datos, el diseño visual ni ningún `data-testid` existente.

## Test plan

- [x] `npx vitest run` de los tests tocados: `AssetsDashboard.virtualizedList` (nuevo, 6) + `AssetsDashboard.zonaYfinca` + `AssetsDashboard.mount` + `AssetsDashboard.urbanForm` + `estratoCopy` → 27/27 verdes.
- [x] `eslint` limpio sobre el archivo nuevo (también vía hook pre-commit).
- [x] Hooks pre-commit (secret-scan, voseo-scan, infra-refs-scan, strategic-content-scan) verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)