### PR TITLE
feat(fiware): export NGSI-LD AgriPest (ADR-051)

### DIFF
--- a/scripts/__tests__/export-ngsi-ld.test.mjs
+++ b/scripts/__tests__/export-ngsi-ld.test.mjs
@@ -1,11 +1,11 @@
 /**
  * scripts/__tests__/export-ngsi-ld.test.mjs
  *
- * Cobertura unitaria del export NGSI-LD AgriCrop (ADR-051 fase 1). NO toca
- * red ni broker; verifica únicamente que las funciones puras
- * `buildAgriCropEntity(entities)` y `validateAgriCropEntity(entities)`
- * producen/validan entidades NGSI-LD bien-formadas a partir de fixtures
- * sintéticos + de una muestra del catálogo OSS real.
+ * Cobertura unitaria del export NGSI-LD AgriCrop + AgriPest (ADR-051 fase 1).
+ * NO toca red ni broker; verifica únicamente que las funciones puras
+ * `buildAgriCropEntity`/`buildAgriPestEntity` (y sus validadores) producen/
+ * validan entidades NGSI-LD bien-formadas a partir de fixtures sintéticos +
+ * de una muestra del catálogo OSS real.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -24,6 +24,13 @@ import {
   buildAgriCropEntities,
   validateAgriCropEntity,
   validateAgriCropEntities,
+  parsePestNameFromRaw,
+  buildPestMipAttribute,
+  derivePestRecords,
+  buildAgriPestEntity,
+  buildAgriPestEntities,
+  validateAgriPestEntity,
+  validateAgriPestEntities,
 } from '../export-ngsi-ld.mjs';
 
 describe('agriCropUrn / agriPestUrn', () => {
@@ -337,6 +344,340 @@ describe('buildAgriCropEntities — muestra real del catálogo OSS v3.2', () => 
       expect(entity.harvestingInterval).toBeUndefined();
       expect(entity.plantingFrom).toBeUndefined();
       expect(entity.hasAgriSoil).toBeUndefined();
+    }
+  });
+});
+
+// =============================================================================
+// AgriPest (ADR-051 fase 1, Anexo A fila AgriPest)
+// =============================================================================
+
+describe('parsePestNameFromRaw', () => {
+  it('separa "Científico (comun)" en alternateName/name', () => {
+    expect(parsePestNameFromRaw('Hemileia vastatrix (roya)')).toEqual({
+      name: 'roya',
+      alternateName: 'Hemileia vastatrix',
+    });
+    expect(parsePestNameFromRaw('Hypothenemus hampei (broca)')).toEqual({
+      name: 'broca',
+      alternateName: 'Hypothenemus hampei',
+    });
+  });
+
+  it('sin paréntesis, devuelve el string completo como name y alternateName null', () => {
+    expect(parsePestNameFromRaw('Scolytidae')).toEqual({ name: 'Scolytidae', alternateName: null });
+    expect(parsePestNameFromRaw('Pulgones')).toEqual({ name: 'Pulgones', alternateName: null });
+  });
+
+  it('ambiguo (ninguno de los dos segmentos parece binomio): no adivina, conserva el string completo', () => {
+    expect(parsePestNameFromRaw('trps (heliothis)')).toEqual({ name: 'trps (heliothis)', alternateName: null });
+  });
+});
+
+describe('buildPestMipAttribute', () => {
+  it('construye {type:Property, value} con los 3 campos MIP cuando están presentes', () => {
+    const mip = buildPestMipAttribute({
+      umbral_accion: '5% tubérculos dañados en muestreo',
+      control_biologico: ['Trichogramma pretiosum sueltas 100mil/ha'],
+      control_cultural: ['aporque profundo'],
+    });
+    expect(mip).toEqual({
+      type: 'Property',
+      value: {
+        umbral_accion: '5% tubérculos dañados en muestreo',
+        control_biologico: ['Trichogramma pretiosum sueltas 100mil/ha'],
+        control_cultural: ['aporque profundo'],
+      },
+    });
+  });
+
+  it('devuelve null si no hay ningún campo MIP reconocible (no inventa)', () => {
+    expect(buildPestMipAttribute({ nombre_cientifico: 'x', nombre_comun: 'y' })).toBeNull();
+    expect(buildPestMipAttribute({})).toBeNull();
+    expect(buildPestMipAttribute(null)).toBeNull();
+  });
+
+  it('omite campos MIP vacíos/mal tipados sin fallar', () => {
+    const mip = buildPestMipAttribute({ umbral_accion: '', control_biologico: [], control_cultural: ['ok'] });
+    expect(mip).toEqual({ type: 'Property', value: { control_cultural: ['ok'] } });
+  });
+});
+
+describe('buildAgriPestEntity — shape string (catálogo público hoy)', () => {
+  it('mapea "Científico (comun)" -> name/alternateName, sin x-chagra-mip (el string no trae MIP)', () => {
+    const entity = buildAgriPestEntity('Hypothenemus hampei (broca)');
+    expect(entity.id).toBe('urn:ngsi-ld:AgriPest:hypothenemus_hampei_broca');
+    expect(entity.type).toBe('AgriPest');
+    expect(entity.name).toEqual({ type: 'Property', value: 'broca' });
+    expect(entity.alternateName).toEqual({ type: 'Property', value: 'Hypothenemus hampei' });
+    expect(entity['x-chagra-mip']).toBeUndefined();
+    expect(entity['@context']).toEqual(DEFAULT_CONTEXT);
+  });
+
+  it('el slug coincide con normalizePest/derivePestSlugs (join AgriCrop.hasAgriPest <-> AgriPest.id)', () => {
+    const raw = 'Hemileia vastatrix (roya)';
+    const entity = buildAgriPestEntity(raw);
+    const [pestSlug] = derivePestSlugs([raw]);
+    expect(entity.id).toBe(`urn:ngsi-ld:AgriPest:${pestSlug}`);
+  });
+
+  it('devuelve null para string vacío', () => {
+    expect(buildAgriPestEntity('')).toBeNull();
+  });
+});
+
+describe('buildAgriPestEntity — shape objeto enriquecido (MIP)', () => {
+  const mipRecord = {
+    nombre_cientifico: 'Phthorimaea operculella',
+    nombre_comun: 'Polilla guatemalteca',
+    umbral_accion: '5% tubérculos dañados en muestreo',
+    control_biologico: ['asociar minthostachys_mollis a 1m perimetro', 'Trichogramma pretiosum sueltas 100mil/ha'],
+    control_cultural: ['aporque profundo', 'no dejar tubérculos en campo post-cosecha'],
+  };
+
+  it('mapea nombre_comun -> name, nombre_cientifico -> alternateName, MIP -> x-chagra-mip', () => {
+    const entity = buildAgriPestEntity(mipRecord);
+    expect(entity.id).toBe('urn:ngsi-ld:AgriPest:phthorimaea_operculella');
+    expect(entity.type).toBe('AgriPest');
+    expect(entity.name).toEqual({ type: 'Property', value: 'Polilla guatemalteca' });
+    expect(entity.alternateName).toEqual({ type: 'Property', value: 'Phthorimaea operculella' });
+    expect(entity['x-chagra-mip']).toEqual({
+      type: 'Property',
+      value: {
+        umbral_accion: '5% tubérculos dañados en muestreo',
+        control_biologico: mipRecord.control_biologico,
+        control_cultural: mipRecord.control_cultural,
+      },
+    });
+  });
+
+  it('NO agrega x-chagra-mip si el objeto no trae ningún campo MIP', () => {
+    const entity = buildAgriPestEntity({ nombre_cientifico: 'Tecia solanivora', nombre_comun: 'Polilla de la papa' });
+    expect(entity['x-chagra-mip']).toBeUndefined();
+  });
+
+  it('mapea descripcion -> description cuando está presente (no la inventa si falta)', () => {
+    const withDesc = buildAgriPestEntity({ ...mipRecord, descripcion: 'Barrenador del tubérculo de papa.' });
+    expect(withDesc.description).toEqual({ type: 'Property', value: 'Barrenador del tubérculo de papa.' });
+
+    const withoutDesc = buildAgriPestEntity(mipRecord);
+    expect(withoutDesc.description).toBeUndefined();
+  });
+
+  it('devuelve null si no se puede derivar slug ni name', () => {
+    expect(buildAgriPestEntity({ umbral_accion: 'x' })).toBeNull();
+    expect(buildAgriPestEntity(null)).toBeNull();
+    expect(buildAgriPestEntity(undefined)).toBeNull();
+  });
+});
+
+describe('derivePestRecords', () => {
+  it('deduplica por slug entre species distintas', () => {
+    const species = [
+      { id: 'sp_a', plagas_criticas: ['Hemileia vastatrix (roya)'] },
+      { id: 'sp_b', plagas_criticas: ['Hemileia vastatrix (roya)', 'Hypothenemus hampei (broca)'] },
+    ];
+    const records = derivePestRecords(species);
+    expect(records).toHaveLength(2);
+  });
+
+  it('prefiere el objeto enriquecido (con MIP) sobre el string plano para el mismo slug', () => {
+    const mipRecord = {
+      nombre_cientifico: 'Phthorimaea operculella',
+      nombre_comun: 'Polilla guatemalteca',
+      umbral_accion: '5% tubérculos dañados',
+    };
+    const species = [
+      { id: 'sp_a', plagas_criticas: ['Phthorimaea operculella'] },
+      { id: 'sp_b', plagas_criticas: [mipRecord] },
+    ];
+    const records = derivePestRecords(species);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toBe(mipRecord);
+  });
+
+  it('devuelve [] si no hay species o plagas_criticas', () => {
+    expect(derivePestRecords([])).toEqual([]);
+    expect(derivePestRecords([{ id: 'sp_sin_plagas' }])).toEqual([]);
+    expect(derivePestRecords(undefined)).toEqual([]);
+  });
+});
+
+describe('buildAgriPestEntities', () => {
+  const fixture = {
+    species: [
+      { id: 'sp_a', plagas_criticas: ['Hemileia vastatrix (roya)'] },
+      { id: 'sp_b', plagas_criticas: ['Hemileia vastatrix (roya)', 'Hypothenemus hampei (broca)'] },
+      { id: 'sp_c', plagas_criticas: [] },
+      { id: 'sp_d' },
+    ],
+  };
+
+  it('emite una entidad AgriPest por plaga única del catálogo', () => {
+    const { entities, report } = buildAgriPestEntities(fixture);
+    expect(entities).toHaveLength(2);
+    expect(report.total).toBe(2);
+    expect(report.emitted).toBe(2);
+    expect(report.omitted).toEqual([]);
+  });
+
+  it('es determinista: misma entrada produce misma salida (idempotente)', () => {
+    const first = buildAgriPestEntities(fixture);
+    const second = buildAgriPestEntities(fixture);
+    expect(JSON.stringify(first.entities)).toBe(JSON.stringify(second.entities));
+  });
+});
+
+describe('validateAgriPestEntity', () => {
+  it('valida OK una entidad AgriPest bien formada (con x-chagra-mip)', () => {
+    const entity = buildAgriPestEntity({
+      nombre_cientifico: 'Phthorimaea operculella',
+      nombre_comun: 'Polilla guatemalteca',
+      umbral_accion: '5% tubérculos dañados en muestreo',
+    });
+    const { valid, errors } = validateAgriPestEntity(entity);
+    expect(valid).toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  it('valida OK una entidad AgriPest sin x-chagra-mip (shape string)', () => {
+    const entity = buildAgriPestEntity('Hemileia vastatrix (roya)');
+    const { valid, errors } = validateAgriPestEntity(entity);
+    expect(valid).toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  it('rechaza id sin prefijo urn:ngsi-ld:AgriPest:', () => {
+    const { valid, errors } = validateAgriPestEntity({
+      id: 'not-a-urn',
+      type: 'AgriPest',
+      name: { type: 'Property', value: 'roya' },
+      '@context': DEFAULT_CONTEXT,
+    });
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('id inválido'))).toBe(true);
+  });
+
+  it('rechaza type distinto de AgriPest', () => {
+    const { valid, errors } = validateAgriPestEntity({
+      id: 'urn:ngsi-ld:AgriPest:roya',
+      type: 'AgriCrop',
+      name: { type: 'Property', value: 'roya' },
+      '@context': DEFAULT_CONTEXT,
+    });
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('type inválido'))).toBe(true);
+  });
+
+  it('rechaza x-chagra-mip mal formado (sin ningún campo MIP reconocible)', () => {
+    const { valid, errors } = validateAgriPestEntity({
+      id: 'urn:ngsi-ld:AgriPest:roya',
+      type: 'AgriPest',
+      name: { type: 'Property', value: 'roya' },
+      'x-chagra-mip': { type: 'Property', value: {} },
+      '@context': DEFAULT_CONTEXT,
+    });
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('x-chagra-mip'))).toBe(true);
+  });
+
+  it('rechaza x-chagra-mip que no sea {type:Property, value:object}', () => {
+    const { valid, errors } = validateAgriPestEntity({
+      id: 'urn:ngsi-ld:AgriPest:roya',
+      type: 'AgriPest',
+      name: { type: 'Property', value: 'roya' },
+      'x-chagra-mip': { type: 'Property', value: 'no es un objeto' },
+      '@context': DEFAULT_CONTEXT,
+    });
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('x-chagra-mip'))).toBe(true);
+  });
+
+  it('rechaza @context faltante', () => {
+    const { valid, errors } = validateAgriPestEntity({
+      id: 'urn:ngsi-ld:AgriPest:roya',
+      type: 'AgriPest',
+      name: { type: 'Property', value: 'roya' },
+    });
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('@context'))).toBe(true);
+  });
+});
+
+describe('validateAgriPestEntities (agregado)', () => {
+  it('reporta valid=true cuando todas las entidades son válidas', () => {
+    const { entities } = buildAgriPestEntities({
+      species: [{ id: 'sp_a', plagas_criticas: ['Hemileia vastatrix (roya)', 'Hypothenemus hampei (broca)'] }],
+    });
+    const result = validateAgriPestEntities(entities);
+    expect(result.valid).toBe(true);
+    expect(result.invalidCount).toBe(0);
+  });
+
+  it('reporta detalle por entidad inválida', () => {
+    const result = validateAgriPestEntities([
+      { id: 'no-urn', type: 'AgriPest', name: { type: 'Property', value: 'x' }, '@context': DEFAULT_CONTEXT },
+    ]);
+    expect(result.valid).toBe(false);
+    expect(result.invalidCount).toBe(1);
+    expect(result.details[0].errors.length).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// Integración: muestra real del catálogo OSS v3.2 (ADR-051 fase 1)
+// =============================================================================
+
+describe('buildAgriPestEntities — muestra real del catálogo OSS v3.2', () => {
+  const catalogPath = resolve('catalog/chagra-catalog-oss-subset-v3.2.json');
+  let seed = null;
+  try {
+    seed = JSON.parse(readFileSync(catalogPath, 'utf-8'));
+  } catch {
+    seed = null;
+  }
+
+  it.skipIf(!seed)('emite una entidad AgriPest válida por cada plaga única de plagas_criticas[] del catálogo real', () => {
+    const { entities, report } = buildAgriPestEntities(seed);
+    // El catálogo público de hoy solo trae plagas_criticas[] como strings
+    // libres (sin MIP curado — ver nota de proveniencia en export-ngsi-ld.mjs);
+    // aun así debe emitir N entidades AgriPest reales, no cero ni inventadas.
+    expect(report.total).toBeGreaterThan(0);
+    expect(entities.length).toBe(report.total);
+
+    const validation = validateAgriPestEntities(entities);
+    expect(validation.details).toEqual([]);
+    expect(validation.valid).toBe(true);
+  });
+
+  it.skipIf(!seed)('cada entidad emitida tiene id URN AgriPest único', () => {
+    const { entities } = buildAgriPestEntities(seed);
+    const ids = entities.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(id).toMatch(/^urn:ngsi-ld:AgriPest:.+$/);
+    }
+  });
+
+  it.skipIf(!seed)('todo hasAgriPest emitido por AgriCrop resuelve a un id AgriPest emitido (join AGE-safe)', () => {
+    const { entities: crops } = buildAgriCropEntities(seed);
+    const { entities: pests } = buildAgriPestEntities(seed);
+    const pestIds = new Set(pests.map((p) => p.id));
+
+    let checked = 0;
+    for (const crop of crops) {
+      for (const rel of crop.hasAgriPest || []) {
+        expect(pestIds.has(rel.object)).toBe(true);
+        checked++;
+      }
+    }
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  it.skipIf(!seed)('no inventa agroVocConcept (gap documentado en ADR-051 — viene del grafo AGE, fuera de alcance)', () => {
+    const { entities } = buildAgriPestEntities(seed);
+    for (const entity of entities) {
+      expect(entity.agroVocConcept).toBeUndefined();
     }
   });
 });

--- a/scripts/export-ngsi-ld.mjs
+++ b/scripts/export-ngsi-ld.mjs
@@ -4,31 +4,57 @@
  *
  * ADR-051 (FIWARE Smart Data Models como capa de interoperabilidad NGSI-LD),
  * Fase 1: lee el catálogo público (`catalog/chagra-catalog-oss-subset-v3.2.json`)
- * y emite entidades **NGSI-LD `AgriCrop`** (Smart Data Models — Smart AgriFood)
- * para cada `species` cultivable del catálogo.
+ * y emite entidades **NGSI-LD `AgriCrop`** y **`AgriPest`** (Smart Data
+ * Models — Smart AgriFood) para cada `species` cultivable y cada plaga
+ * referenciada en `species.plagas_criticas[]` del catálogo.
  *
  * Análogo de `scripts/catalog-to-age.mjs`: función pura + CLI delgado. NO
  * toca red ni base de datos — es un export offline, no un cliente de un
  * broker Orion-LD (ver ADR-051 §Decisión punto 2: no se despliega runtime
  * FIWARE en Guatoc).
  *
- * Mapeo (Anexo A de ADR-051, fila AgriCrop):
+ * Mapeo AgriCrop (Anexo A de ADR-051, fila AgriCrop):
  *   - `species.id`                  -> id (`urn:ngsi-ld:AgriCrop:<id>`)
  *   - `species.nombre_comun`        -> name
  *   - `species.nombre_cientifico`   -> alternateName
  *   - `species.valor_pedagogico`    -> description (truncado, ver truncText)
  *   - `species.plagas_criticas[]`   -> hasAgriPest (Relationship[] a AgriPest)
  *
+ * Mapeo AgriPest (Anexo A de ADR-051, fila AgriPest):
+ *   - slug de plaga (`normalizePest`) -> id (`urn:ngsi-ld:AgriPest:<slug>`)
+ *   - nombre común / parseado del raw -> name
+ *   - nombre científico (si se puede derivar) -> alternateName
+ *   - descripción (si el registro la trae)    -> description
+ *   - MIP (`umbral_accion`/`control_biologico[]`/`control_cultural[]`) ->
+ *     **`x-chagra-mip`** (Property custom, NO campo FIWARE estándar — ver
+ *     nota junto a `buildPestMipAttribute` más abajo).
+ *
+ * NOTA DE PROVENIENCIA (verificado 2026-07-01): el catálogo público
+ * (`chagra-catalog-oss-subset-v3.2.json`) solo trae `plagas_criticas[]` como
+ * strings libres (ej. "Hemileia vastatrix (roya)"), sin campos MIP — el MIP
+ * curado con `umbral_accion` real vive en el repo *privado* hermano
+ * `chagra-pro` (`data/age/*-mip-*-ingest-*.sql`, marcado explícitamente
+ * "privative data, do not redistribute outside chagra-pro repo") y se
+ * inyecta directo al grafo compartido `chagra_kg`, fuera de este pipeline
+ * público. Por eso `buildAgriPestEntity` acepta también un shape de objeto
+ * enriquecido (`{nombre_cientifico, nombre_comun, umbral_accion,
+ * control_biologico[], control_cultural[]}` — el mismo shape ya usado como
+ * referencia en `catalog/chagra-catalog-seed-v3.0.json`), para quedar listo
+ * el día que el MIP entre al catálogo público por un canal no-privativo,
+ * SIN copiar ni un byte del dataset de `chagra-pro` aquí.
+ *
  * Campos NGSI-LD sin equivalente en Chagra hoy (agroVocConcept,
  * harvestingInterval, plantingFrom, hasAgriSoil) se OMITEN — son opcionales
  * en el schema oficial `dataModel.Agrifood/AgriCrop`. NO se rellenan con
  * datos inventados (regla explícita de ADR-051 y del anti-alucinación
- * general del catálogo).
+ * general del catálogo). `agroVocConcept` en `AgriPest` también se OMITE
+ * (viene del grafo AGE — fuera de alcance de este export).
  *
  * Slugs de plaga: reutiliza `normalizePest`/`classifyBiopreparadoTarget` de
  * `catalog-to-age.mjs` para que el `urn:ngsi-ld:AgriPest:<slug>` quede
  * alineado con el nodo `:Pest` del grafo `chagra_kg` (mismo slug en ambos
- * lados == join gratis entre el export NGSI-LD y el grafo AGE).
+ * lados == join gratis entre el export NGSI-LD y el grafo AGE, y coincide
+ * con los objetos de `hasAgriPest` que emite `buildAgriCropEntity`).
  *
  * Idempotencia: función pura sobre el JSON del catálogo — misma entrada,
  * misma salida byte a byte. Sin red, sin DB, sin estado mutable global.
@@ -36,10 +62,14 @@
  * Uso:
  *   node scripts/export-ngsi-ld.mjs \
  *     --input catalog/chagra-catalog-oss-subset-v3.2.json \
- *     --out /tmp/agricrop-ngsi-ld.json \
+ *     --out /tmp/ngsi-ld.json \
  *     [--json]        # imprime el array de entidades NGSI-LD crudo por stdout
  *     [--limit 10]    # subset de species (default: todas)
  *     [--pretty]      # indenta el JSON (default: 2 espacios; con --json activa igual)
+ *
+ * El array de salida combina entidades `AgriCrop` seguidas de `AgriPest`
+ * (batch mixto — formato aceptado por `entityOperations/upsert` de
+ * Orion-LD; ver ADR-051, no implica correr el broker).
  *
  * Sin `--json` ni `--out`, imprime un reporte humano (conteo, validación)
  * por stdout — pensado para revisión manual del operador antes de un demo.
@@ -219,6 +249,218 @@ export function buildAgriCropEntities(seed, opts = {}) {
 }
 
 // =============================================================================
+// AgriPest — construcción de entidades (ADR-051 Anexo A, fila AgriPest)
+// =============================================================================
+
+/**
+ * Parsea un nombre de plaga en texto libre (formato observado en el catálogo:
+ * `"Nombre científico (nombre común)"`, ej. `"Hemileia vastatrix (roya)"`) en
+ * `{name, alternateName}`. Si no calza el patrón entre paréntesis, o si no se
+ * puede determinar con confianza cuál de los dos segmentos es el binomio
+ * científico, se devuelve el string completo como `name` y `alternateName:
+ * null` — nunca se inventa cuál segmento es cuál.
+ *
+ * @param {string} raw
+ * @returns {{name: string, alternateName: string|null}}
+ */
+export function parsePestNameFromRaw(raw) {
+  const str = String(raw ?? '').trim();
+  const match = str.match(/^(.+?)\s*\(([^()]+)\)\s*$/);
+  if (!match) return { name: str, alternateName: null };
+
+  const [, first, second] = match;
+  const looksLikeBinomial = (s) => /^[A-ZÀ-Ý][a-zà-ÿ]+(?:\s+[a-zà-ÿ.]+){1,3}$/.test(s.trim());
+
+  if (looksLikeBinomial(first) && !looksLikeBinomial(second)) {
+    return { name: second.trim(), alternateName: first.trim() };
+  }
+  if (looksLikeBinomial(second) && !looksLikeBinomial(first)) {
+    return { name: first.trim(), alternateName: second.trim() };
+  }
+  // Ambiguo (ambos o ninguno parecen binomio): no se adivina, se conserva
+  // el string completo tal cual llegó del catálogo.
+  return { name: str, alternateName: null };
+}
+
+/**
+ * Construye el atributo NGSI-LD custom `x-chagra-mip` a partir de un registro
+ * de plaga enriquecido. El MIP (umbral económico de acción + control
+ * biológico/cultural) **no tiene equivalente en ningún schema FIWARE
+ * revisado** — ni `AgriPest` ni `AgriPhytosanitary` lo modelan (ADR-051,
+ * Anexo A fila AgriPest + alternativa #4 descartada: `AgriPhytosanitary.
+ * entrylimit` es un registro fitosanitario tipo SIGPAC, semántica distinta a
+ * un umbral económico agronómico). Por eso se expone como `Property` custom
+ * en vez de forzarlo en un campo FIWARE con otro significado (ADR-051
+ * Decisión punto 4). Devuelve `null` si el registro no trae ningún campo MIP
+ * reconocible (no se rellena con datos inventados).
+ *
+ * @param {object} pestRecord
+ * @returns {{type:'Property', value: object}|null}
+ */
+export function buildPestMipAttribute(pestRecord) {
+  if (!pestRecord || typeof pestRecord !== 'object') return null;
+
+  const value = {};
+  if (typeof pestRecord.umbral_accion === 'string' && pestRecord.umbral_accion.trim()) {
+    value.umbral_accion = pestRecord.umbral_accion.trim();
+  }
+  if (Array.isArray(pestRecord.control_biologico) && pestRecord.control_biologico.length > 0) {
+    value.control_biologico = pestRecord.control_biologico;
+  }
+  if (Array.isArray(pestRecord.control_cultural) && pestRecord.control_cultural.length > 0) {
+    value.control_cultural = pestRecord.control_cultural;
+  }
+
+  if (Object.keys(value).length === 0) return null;
+  return { type: 'Property', value };
+}
+
+/**
+ * Construye una entidad NGSI-LD `AgriPest` a partir de un registro de plaga.
+ * Acepta dos shapes:
+ *
+ *   1. `string` — el shape real de hoy en `species.plagas_criticas[]` del
+ *      catálogo público (ej. `"Hypothenemus hampei (broca)"`). Se parsea con
+ *      `parsePestNameFromRaw`; nunca trae MIP.
+ *   2. `object` — shape enriquecido `{nombre_cientifico, nombre_comun,
+ *      descripcion?, umbral_accion?, control_biologico?, control_cultural?}`
+ *      (mismo shape usado como referencia en
+ *      `catalog/chagra-catalog-seed-v3.0.json`). Si trae `umbral_accion`/
+ *      `control_biologico`/`control_cultural`, se emite `x-chagra-mip`.
+ *
+ * Devuelve `null` si no se puede derivar un slug/id o un `name` — se reporta
+ * como "omitida" por el caller, nunca se rellena con datos inventados.
+ *
+ * @param {string|object} pestRecord
+ * @param {object} [opts]
+ * @param {string[]} [opts.context]
+ * @returns {object|null}
+ */
+export function buildAgriPestEntity(pestRecord, opts = {}) {
+  const context = opts.context || DEFAULT_CONTEXT;
+  if (pestRecord === null || pestRecord === undefined || pestRecord === '') return null;
+
+  let slug = null;
+  let name = null;
+  let alternateName = null;
+  let description = null;
+  let mip = null;
+
+  if (typeof pestRecord === 'string') {
+    slug = normalizePest(pestRecord);
+    const parsed = parsePestNameFromRaw(pestRecord);
+    name = parsed.name;
+    alternateName = parsed.alternateName;
+  } else if (typeof pestRecord === 'object' && !Array.isArray(pestRecord)) {
+    const cientifico = typeof pestRecord.nombre_cientifico === 'string' ? pestRecord.nombre_cientifico.trim() : '';
+    const comun = typeof pestRecord.nombre_comun === 'string' ? pestRecord.nombre_comun.trim() : '';
+    slug = normalizePest(cientifico || comun);
+    name = comun || cientifico || null;
+    alternateName = (comun && cientifico) ? cientifico : null;
+    description = typeof pestRecord.descripcion === 'string' && pestRecord.descripcion.trim()
+      ? pestRecord.descripcion.trim()
+      : null;
+    mip = buildPestMipAttribute(pestRecord);
+  } else {
+    return null;
+  }
+
+  if (!slug || !name) return null;
+
+  const entity = {
+    id: agriPestUrn(slug),
+    type: 'AgriPest',
+  };
+
+  const nameProp = ngsiProperty(name);
+  if (nameProp) entity.name = nameProp;
+
+  const alternateNameProp = ngsiProperty(alternateName);
+  if (alternateNameProp) entity.alternateName = alternateNameProp;
+
+  const descriptionProp = ngsiProperty(description);
+  if (descriptionProp) entity.description = descriptionProp;
+
+  if (mip) entity['x-chagra-mip'] = mip;
+
+  entity['@context'] = context;
+
+  return entity;
+}
+
+/**
+ * Deriva la lista deduplicada (por slug de plaga) de registros de plaga a
+ * partir de `species[].plagas_criticas[]`. Cada entrada puede ser un string
+ * libre o un objeto enriquecido (ver `buildAgriPestEntity`); si el mismo slug
+ * aparece como string en una species y como objeto enriquecido en otra, se
+ * conserva el objeto (superset de información, nunca se descarta MIP real a
+ * favor de un string).
+ *
+ * @param {object[]} speciesArray
+ * @returns {Array<string|object>}
+ */
+export function derivePestRecords(speciesArray) {
+  const bySlug = new Map();
+  for (const sp of Array.isArray(speciesArray) ? speciesArray : []) {
+    for (const raw of Array.isArray(sp?.plagas_criticas) ? sp.plagas_criticas : []) {
+      if (raw === null || raw === undefined || raw === '') continue;
+
+      let slug = null;
+      if (typeof raw === 'string') {
+        slug = normalizePest(raw);
+      } else if (typeof raw === 'object' && !Array.isArray(raw)) {
+        slug = normalizePest(raw.nombre_cientifico || raw.nombre_comun);
+      }
+      if (!slug) continue;
+
+      const existing = bySlug.get(slug);
+      if (!existing || (typeof existing === 'string' && typeof raw === 'object')) {
+        bySlug.set(slug, raw);
+      }
+    }
+  }
+  return Array.from(bySlug.values());
+}
+
+/**
+ * Construye entidades AgriPest para el catálogo, junto a un reporte de
+ * cuántas se omitieron.
+ *
+ * @param {object} seed - catálogo parseado ({ species: [...] })
+ * @param {object} [opts]
+ * @param {number} [opts.limit] - subset de species de las que se derivan
+ *   plagas (default: todas; mismo semántica que `buildAgriCropEntities`)
+ * @param {string[]} [opts.context]
+ * @returns {{entities: object[], report: {total: number, emitted: number, omitted: Array<{raw: string|null, reason: string}>}}}
+ */
+export function buildAgriPestEntities(seed, opts = {}) {
+  const speciesAll = Array.isArray(seed?.species) ? seed.species : [];
+  const species = typeof opts.limit === 'number' ? speciesAll.slice(0, opts.limit) : speciesAll;
+  const pestRecords = derivePestRecords(species);
+
+  const entities = [];
+  const omitted = [];
+  for (const rec of pestRecords) {
+    const entity = buildAgriPestEntity(rec, { context: opts.context });
+    if (entity) {
+      entities.push(entity);
+    } else {
+      const raw = typeof rec === 'string' ? rec : (rec?.nombre_cientifico ?? rec?.nombre_comun ?? null);
+      omitted.push({ raw, reason: 'no se pudo derivar slug o name' });
+    }
+  }
+
+  return {
+    entities,
+    report: {
+      total: pestRecords.length,
+      emitted: entities.length,
+      omitted,
+    },
+  };
+}
+
+// =============================================================================
 // Validación estructural (sin dependencia externa — ver nota abajo)
 // =============================================================================
 
@@ -310,6 +552,89 @@ export function validateAgriCropEntities(entities) {
   return { valid: details.length === 0, invalidCount: details.length, details };
 }
 
+/**
+ * Valida la estructura mínima NGSI-LD de una entidad AgriPest (mismo alcance
+ * y misma nota sobre `ajv` que `validateAgriCropEntity`). Adicionalmente
+ * valida la forma de `x-chagra-mip` si está presente: debe ser
+ * `{type:'Property', value: object}` con al menos uno de
+ * `umbral_accion`/`control_biologico`/`control_cultural` reconocible.
+ *
+ * @param {object} entity
+ * @returns {{valid: boolean, errors: string[]}}
+ */
+export function validateAgriPestEntity(entity) {
+  const errors = [];
+
+  if (!entity || typeof entity !== 'object') {
+    return { valid: false, errors: ['entity no es un objeto'] };
+  }
+
+  if (typeof entity.id !== 'string' || !/^urn:ngsi-ld:AgriPest:.+$/.test(entity.id)) {
+    errors.push(`id inválido (esperado urn:ngsi-ld:AgriPest:*): ${JSON.stringify(entity.id)}`);
+  }
+
+  if (entity.type !== 'AgriPest') {
+    errors.push(`type inválido (esperado 'AgriPest'): ${JSON.stringify(entity.type)}`);
+  }
+
+  if (
+    !entity.name
+    || entity.name.type !== 'Property'
+    || typeof entity.name.value !== 'string'
+    || entity.name.value.length === 0
+  ) {
+    errors.push('name faltante o mal formado (esperado {type:"Property", value: string no vacío})');
+  }
+
+  if (entity.alternateName !== undefined) {
+    if (entity.alternateName.type !== 'Property' || typeof entity.alternateName.value !== 'string') {
+      errors.push('alternateName presente pero mal formado');
+    }
+  }
+
+  if (entity.description !== undefined) {
+    if (entity.description.type !== 'Property' || typeof entity.description.value !== 'string') {
+      errors.push('description presente pero mal formado');
+    }
+  }
+
+  if (entity['x-chagra-mip'] !== undefined) {
+    const mip = entity['x-chagra-mip'];
+    if (!mip || mip.type !== 'Property' || typeof mip.value !== 'object' || mip.value === null) {
+      errors.push('x-chagra-mip presente pero mal formado (esperado {type:"Property", value: object})');
+    } else {
+      const { umbral_accion: umbralAccion, control_biologico: controlBiologico, control_cultural: controlCultural } = mip.value;
+      const hasAnyMipField = (typeof umbralAccion === 'string' && umbralAccion.length > 0)
+        || (Array.isArray(controlBiologico) && controlBiologico.length > 0)
+        || (Array.isArray(controlCultural) && controlCultural.length > 0);
+      if (!hasAnyMipField) {
+        errors.push('x-chagra-mip.value no tiene ningún campo MIP reconocible (umbral_accion/control_biologico/control_cultural)');
+      }
+    }
+  }
+
+  if (!entity['@context'] || (Array.isArray(entity['@context']) && entity['@context'].length === 0)) {
+    errors.push('@context faltante o vacío');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Valida un array de entidades AgriPest. Devuelve un reporte agregado.
+ *
+ * @param {object[]} entities
+ * @returns {{valid: boolean, invalidCount: number, details: Array<{id: string|null, errors: string[]}>}}
+ */
+export function validateAgriPestEntities(entities) {
+  const details = [];
+  for (const entity of entities) {
+    const { valid, errors } = validateAgriPestEntity(entity);
+    if (!valid) details.push({ id: entity?.id ?? null, errors });
+  }
+  return { valid: details.length === 0, invalidCount: details.length, details };
+}
+
 // =============================================================================
 // CLI entry point
 // =============================================================================
@@ -335,10 +660,10 @@ export async function main(argv = process.argv.slice(2)) {
       console.error(
         'Usage: node scripts/export-ngsi-ld.mjs [--input FILE] [--out FILE] [--json] [--limit N]\n\n'
         + '  --input FILE  Catálogo fuente (default: catalog/chagra-catalog-oss-subset-v3.2.json)\n'
-        + '  --out FILE    Escribe el array de entidades NGSI-LD (JSON) a FILE.\n'
+        + '  --out FILE    Escribe el array de entidades NGSI-LD (AgriCrop + AgriPest, JSON) a FILE.\n'
         + '  --json        Imprime el array de entidades NGSI-LD crudo por stdout\n'
         + '                (sin esto, imprime un reporte humano de conteo/validación).\n'
-        + '  --limit N     Subset de species (default: todas).',
+        + '  --limit N     Subset de species de las que se derivan AgriCrop/AgriPest (default: todas).',
       );
       return { outputPath: null, entityCount: 0, valid: true };
     }
@@ -347,42 +672,63 @@ export async function main(argv = process.argv.slice(2)) {
   const seedPath = resolve(opts.input);
   const seed = JSON.parse(readFileSync(seedPath, 'utf-8'));
 
-  const { entities, report } = buildAgriCropEntities(seed, { limit: opts.limit ?? undefined });
-  const validation = validateAgriCropEntities(entities);
+  const cropResult = buildAgriCropEntities(seed, { limit: opts.limit ?? undefined });
+  const cropValidation = validateAgriCropEntities(cropResult.entities);
+
+  const pestResult = buildAgriPestEntities(seed, { limit: opts.limit ?? undefined });
+  const pestValidation = validateAgriPestEntities(pestResult.entities);
+
+  // Batch mixto AgriCrop + AgriPest (formato aceptado por
+  // entityOperations/upsert de Orion-LD; ver nota de cabecera del archivo).
+  const entities = [...cropResult.entities, ...pestResult.entities];
+  const valid = cropValidation.valid && pestValidation.valid;
 
   const jsonOut = JSON.stringify(entities, null, 2) + '\n';
 
   if (opts.out) {
     writeFileSync(opts.out, jsonOut, 'utf-8');
     console.error(
-      `Escrito ${entities.length} entidades AgriCrop a ${opts.out} `
-      + `(omitidas: ${report.omitted.length}, válidas: ${validation.valid ? 'sí' : `NO (${validation.invalidCount})`})`,
+      `Escrito ${entities.length} entidades NGSI-LD (${cropResult.entities.length} AgriCrop + `
+      + `${pestResult.entities.length} AgriPest) a ${opts.out} `
+      + `(válidas: ${valid ? 'sí' : 'NO'})`,
     );
   } else if (opts.json) {
     process.stdout.write(jsonOut);
   } else {
     // Reporte humano por stdout — pensado para revisión manual del operador.
-    console.log('--- export-ngsi-ld: reporte AgriCrop (ADR-051 fase 1) ---');
+    console.log('--- export-ngsi-ld: reporte AgriCrop + AgriPest (ADR-051 fase 1) ---');
     console.log(`Fuente: ${opts.input}`);
-    console.log(`Species leídas: ${report.total}`);
-    console.log(`Entidades AgriCrop emitidas: ${report.emitted}`);
-    console.log(`Omitidas (faltan campos mínimos): ${report.omitted.length}`);
-    if (report.omitted.length > 0) {
-      console.log('  ids omitidos:', report.omitted.map((o) => o.id).join(', '));
+    console.log(`Species leídas: ${cropResult.report.total}`);
+    console.log(`Entidades AgriCrop emitidas: ${cropResult.report.emitted}`);
+    console.log(`Omitidas (faltan campos mínimos): ${cropResult.report.omitted.length}`);
+    if (cropResult.report.omitted.length > 0) {
+      console.log('  ids omitidos:', cropResult.report.omitted.map((o) => o.id).join(', '));
     }
-    console.log(`Validación estructural NGSI-LD: ${validation.valid ? 'OK' : `FALLÓ (${validation.invalidCount} entidad(es))`}`);
-    if (!validation.valid) {
-      for (const d of validation.details.slice(0, 10)) {
+    console.log(`Validación estructural NGSI-LD (AgriCrop): ${cropValidation.valid ? 'OK' : `FALLÓ (${cropValidation.invalidCount} entidad(es))`}`);
+    if (!cropValidation.valid) {
+      for (const d of cropValidation.details.slice(0, 10)) {
+        console.log(`  - ${d.id}: ${d.errors.join(' | ')}`);
+      }
+    }
+    console.log(`Plagas únicas derivadas de plagas_criticas[]: ${pestResult.report.total}`);
+    console.log(`Entidades AgriPest emitidas: ${pestResult.report.emitted}`);
+    console.log(`Omitidas (faltan campos mínimos): ${pestResult.report.omitted.length}`);
+    if (pestResult.report.omitted.length > 0) {
+      console.log('  plagas omitidas:', pestResult.report.omitted.map((o) => o.raw).join(', '));
+    }
+    console.log(`Validación estructural NGSI-LD (AgriPest): ${pestValidation.valid ? 'OK' : `FALLÓ (${pestValidation.invalidCount} entidad(es))`}`);
+    if (!pestValidation.valid) {
+      for (const d of pestValidation.details.slice(0, 10)) {
         console.log(`  - ${d.id}: ${d.errors.join(' | ')}`);
       }
     }
   }
 
-  if (!validation.valid) {
+  if (!valid) {
     process.exitCode = 1;
   }
 
-  return { outputPath: opts.out, entityCount: entities.length, valid: validation.valid };
+  return { outputPath: opts.out, entityCount: entities.length, valid };
 }
 
 // ESM-friendly entry-point check.


### PR DESCRIPTION
## Summary
- Extiende `scripts/export-ngsi-ld.mjs` (AgriCrop, mergeado en #1913) para emitir también entidades **NGSI-LD `AgriPest`** desde `species.plagas_criticas[]` del catálogo público (ADR-051 fase 1, Anexo A fila AgriPest).
- El MIP (`umbral_accion`/`control_biologico[]`/`control_cultural[]`) no tiene equivalente en ningún schema FIWARE revisado (ni `AgriPest` ni `AgriPhytosanitary`), así que se expone como atributo custom NGSI-LD **`x-chagra-mip`** (`Property`), documentado inline, en vez de forzarlo en un campo FIWARE con otra semántica.
- `agroVocConcept` se omite deliberadamente (viene del grafo AGE — otra tarea, fuera de alcance de este PR).
- Reutiliza `normalizePest`/`agriPestUrn` ya existentes, así que `AgriPest.id` coincide exactamente con `hasAgriPest[].object` que ya emite `buildAgriCropEntity` y con el nodo `:Pest` de `chagra_kg` (join sin fricción, verificado con la muestra real: 0 relaciones huérfanas sobre 530 species / 17 plagas únicas).
- `main()` del CLI ahora combina AgriCrop + AgriPest en un único batch de salida (formato aceptado por `entityOperations/upsert` de Orion-LD), con reporte humano separado por tipo.
- **Nota de proveniencia (verificada antes de implementar):** el catálogo público solo trae `plagas_criticas[]` como strings libres, sin MIP curado. El MIP con `umbral_accion` real vive en el repo *privado* hermano `chagra-pro` (`data/age/*-mip-*-ingest-*.sql`, marcado explícitamente "privative data, do not redistribute outside chagra-pro repo") y se inyecta directo al grafo compartido — no se copió nada de ese dataset acá. `buildAgriPestEntity` además acepta un shape de objeto enriquecido (mismo shape ya presente en `catalog/chagra-catalog-seed-v3.0.json`, público) para el día que el MIP entre al catálogo por un canal no-privativo.

## Test plan
- [x] `npx vitest run scripts/__tests__/export-ngsi-ld.test.mjs` — 62/62 tests en verde (AgriCrop existentes + suite nueva AgriPest: parseo de nombre, `x-chagra-mip`, dedup por slug, validación estructural, integración contra el catálogo real `chagra-catalog-oss-subset-v3.2.json`, verificación de join AgriCrop↔AgriPest).
- [x] `node --check scripts/export-ngsi-ld.mjs` y `npx eslint` sobre ambos archivos — sin errores.
- [x] `node scripts/export-ngsi-ld.mjs` contra el catálogo real: 530 AgriCrop + 17 AgriPest emitidas, ambas validaciones estructurales OK.
- [x] Rebase limpio sobre `main` actual, sin conflictos.