### PR TITLE
fix(sync): plan de siembra en seeding offline (070.2)

### DIFF
--- a/src/services/__tests__/payloadService.test.js
+++ b/src/services/__tests__/payloadService.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../apiService.js', () => ({
   sendToFarmOS: vi.fn(),
@@ -7,6 +7,7 @@ vi.mock('../apiService.js', () => ({
 vi.mock('../syncManager.js', () => ({
   syncManager: {
     enqueuePendingTransaction: vi.fn(),
+    saveTransaction: vi.fn(),
   },
 }));
 
@@ -14,12 +15,73 @@ vi.mock('../planGeneratorService.js', () => ({
   tryGeneratePlanFromSeeding: vi.fn(),
 }));
 
+import { sendToFarmOS } from '../apiService.js';
+import { tryGeneratePlanFromSeeding } from '../planGeneratorService.js';
 import { savePayload } from '../payloadService.js';
+
+const PLANT_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
 describe('payloadService', () => {
   describe('savePayload', () => {
     it('es una funcion exportada', () => {
       expect(typeof savePayload).toBe('function');
+    });
+  });
+
+  // ─── savePayload (online) → tryGeneratePlanFromSeeding (audit 070.2) ─────
+  // El path online-directo (sin pasar por syncManager) debe delegar la
+  // generación del plan al mismo helper compartido que usa el path
+  // offline-then-sync, y debe hacerlo una única vez por siembra creada —
+  // nunca cero (planta sin plan) ni más de una (plan duplicado).
+  describe('savePayload — seeding online genera plan (070.2)', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      tryGeneratePlanFromSeeding.mockResolvedValue({ steps: [{ id: 'step-1' }] });
+    });
+
+    const makeSeedingPayload = () => ({
+      data: {
+        type: 'log--seeding',
+        attributes: { name: 'Siembra Tomate Cherry', timestamp: 1_700_000_000 },
+        relationships: {
+          asset: {
+            data: [{
+              type: 'asset--plant',
+              _speciesSlug: 'tomate',
+              attributes: { name: 'Tomate Cherry', status: 'active' },
+            }],
+          },
+        },
+      },
+    });
+
+    it('llama tryGeneratePlanFromSeeding una sola vez con los datos de la siembra', async () => {
+      sendToFarmOS
+        .mockResolvedValueOnce({ data: { id: PLANT_UUID, type: 'asset--plant' } })
+        .mockResolvedValueOnce({ data: { id: 'log-seeding-id', type: 'log--seeding' } });
+
+      await savePayload('seeding', makeSeedingPayload());
+
+      expect(tryGeneratePlanFromSeeding).toHaveBeenCalledOnce();
+      expect(tryGeneratePlanFromSeeding).toHaveBeenCalledWith({
+        assetId: PLANT_UUID,
+        speciesSlug: 'tomate',
+        plantingDate: new Date(1_700_000_000 * 1000).toISOString(),
+        plantName: 'Tomate Cherry',
+      });
+    });
+
+    it('no duplica: una segunda siembra distinta también genera una sola llamada (idempotencia vive en el helper)', async () => {
+      sendToFarmOS
+        .mockResolvedValueOnce({ data: { id: PLANT_UUID, type: 'asset--plant' } })
+        .mockResolvedValueOnce({ data: { id: 'log-seeding-id', type: 'log--seeding' } });
+
+      await savePayload('seeding', makeSeedingPayload());
+
+      // La segunda vez el helper (mockeado aquí, testeado a fondo en
+      // planGeneratorService.test.js) es quien decide si ya existe plan —
+      // savePayload no debe invocarlo más de una vez por llamada.
+      expect(tryGeneratePlanFromSeeding).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Este PR responde a la auditoría **queue/070.2** (payloadService offline no genera plan al sincronizar). Al verificar el estado actual de `main` antes de tocar código, encontré que **el fix funcional ya está implementado y mergeado**:

- `src/services/planGeneratorService.js` expone `tryGeneratePlanFromSeeding({ assetId, speciesSlug, plantingDate, plantName, ... })` — helper idempotente (skip si ya existe plan vía `getPlanForAsset`, nunca `throw`).
- `src/services/payloadService.js` (camino **online**) lo invoca tras resolver el `asset--plant` inline de una siembra.
- `src/services/syncManager.js` (`syncAll`, camino **offline→sync**) lo invoca vía `extractPlanSeed()` tras sincronizar exitosamente una tx `seeding`.

Ambos caminos ya comparten el mismo helper — no hay duplicación de lógica ni de planes.

**Lo que sí faltaba:** `payloadService.test.js` mockeaba `tryGeneratePlanFromSeeding` pero no tenía ninguna aserción real sobre el camino online (solo un smoke test de `savePayload`). Una regresión futura en ese archivo podía dejar de generar el plan sin que ningún test lo detectara. Este PR cierra ese hueco de cobertura:

- Verifica que una siembra online invoque `tryGeneratePlanFromSeeding` **una sola vez** con `assetId`, `speciesSlug`, `plantingDate` y `plantName` correctos.
- Verifica que no se duplique la llamada en el mismo flujo.

No se modificó código de producción — el comportamiento reportado en la auditoría ya estaba corregido.

## Test plan

- [x] `npx vitest run src/services/__tests__/payloadService.test.js src/services/__tests__/planGeneratorService.test.js src/services/__tests__/syncManager.test.js` → 30/30 passed (incluye los 2 tests nuevos).
- [x] Siembra offline sincronizada → genera plan (cubierto en `syncManager.test.js`, ya existente).
- [x] Segunda sincronización de la misma siembra → NO duplica plan (cubierto en `planGeneratorService.test.js`, ya existente).
- [x] Siembra online genera plan una sola vez (cubierto en los 2 tests nuevos de `payloadService.test.js`).
- [x] `npx vitest run` (suite completa): 570 passed, 3 failed, 2 skipped — los 3 fallos (`SeguimientoProcesoScreen.test.jsx`, `dataSchema.fuente.test.js`, `agentService.especieDesconocida.test.js`) son preexistentes en `main`, no relacionados a este cambio (confirmado corriéndolos con este diff stashed).