### PR TITLE
feat(fiware): validación ajv NGSI-LD (ADR-051 fase 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
         "@eslint/js": "^9.39.4",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -37,6 +37,8 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
         "@vitest/coverage-v8": "^4.1.8",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "autoprefixer": "^10.4.27",
         "axe-core": "^4.12.1",
         "better-sqlite3": "^12.10.0",
@@ -2055,6 +2057,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2067,6 +2086,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
@@ -3701,20 +3727,38 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -5165,6 +5209,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "10.4.0",
@@ -6789,9 +6857,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -10714,30 +10782,6 @@
       "peerDependencies": {
         "ajv": ">=8"
       }
-    },
-    "node_modules/workbox-build/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/workbox-build/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/workbox-cacheable-response": {
       "version": "7.4.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "coverage": "vitest run --coverage",
     "audit:bundle": "node scripts/audit-bundle.mjs",
     "grafo:snapshot": "node scripts/snapshot-grafo-crecimiento.mjs",
+    "validate:ngsi": "node scripts/export-ngsi-ld.mjs",
     "hooks:install": "lefthook install",
     "tsc:check": "tsc --noEmit -p jsconfig.json",
     "perf-budget": "node scripts/check-perf-budget.mjs"
@@ -51,6 +52,8 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/coverage-v8": "^4.1.8",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "autoprefixer": "^10.4.27",
     "axe-core": "^4.12.1",
     "better-sqlite3": "^12.10.0",

--- a/scripts/__tests__/ngsi-validate.test.mjs
+++ b/scripts/__tests__/ngsi-validate.test.mjs
@@ -1,0 +1,199 @@
+/**
+ * scripts/__tests__/ngsi-validate.test.mjs
+ *
+ * Cobertura del ítem de fase 1 de ADR-051 "Validación conformidad NGSI-LD
+ * (ajv vs schemas oficiales) en CI": verifica que `validateEntityAjv` /
+ * `validateEntitiesAjv` (scripts/lib/ngsi-validate.mjs) validan las
+ * entidades emitidas por `export-ngsi-ld.mjs` contra los JSON Schema
+ * OFICIALES vendorizados de smart-data-models/dataModel.Agrifood — no
+ * contra una reimplementación propia del schema.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  toSimplifiedEntity,
+  validateEntityAjv,
+  validateEntitiesAjv,
+} from '../lib/ngsi-validate.mjs';
+
+import {
+  buildAgriCropEntity,
+  buildAgriPestEntity,
+} from '../export-ngsi-ld.mjs';
+
+describe('toSimplifiedEntity', () => {
+  it('aplana Property/Relationship a valores planos (keyValues), preserva id/type/@context', () => {
+    const entity = buildAgriCropEntity({
+      id: 'coffea_arabica',
+      nombre_comun: 'Café',
+      nombre_cientifico: 'Coffea arabica',
+      plagas_criticas: ['Hypothenemus hampei (broca)'],
+    });
+
+    const simplified = toSimplifiedEntity(entity);
+
+    expect(simplified.id).toBe('urn:ngsi-ld:AgriCrop:coffea_arabica');
+    expect(simplified.type).toBe('AgriCrop');
+    expect(simplified.name).toBe('Café');
+    expect(simplified.alternateName).toBe('Coffea arabica');
+    expect(simplified.hasAgriPest).toEqual(['urn:ngsi-ld:AgriPest:hypothenemus_hampei_broca']);
+    expect(simplified['@context']).toEqual(entity['@context']);
+  });
+});
+
+describe('validateEntityAjv — AgriCrop', () => {
+  it('(a) valida OK una entidad AgriCrop bien formada contra el schema oficial', () => {
+    const entity = buildAgriCropEntity({
+      id: 'solanum_lycopersicum',
+      nombre_comun: 'Tomate',
+      nombre_cientifico: 'Solanum lycopersicum L.',
+      valor_pedagogico: 'Cultivo indeterminado de alto valor culinario.',
+      plagas_criticas: ['Tuta absoluta (polilla del tomate)'],
+    });
+
+    const { valid, errors } = validateEntityAjv(entity);
+    expect(valid).toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  it('(b) rechaza una entidad malformada sin id ni type', () => {
+    const { valid, errors } = validateEntityAjv({
+      name: { type: 'Property', value: 'Sin id ni type' },
+    });
+
+    expect(valid).toBe(false);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rechaza una entidad AgriCrop sin name (requerido por el schema oficial)', () => {
+    const { valid, errors } = validateEntityAjv({
+      id: 'urn:ngsi-ld:AgriCrop:sin_nombre',
+      type: 'AgriCrop',
+      '@context': ['https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld'],
+    });
+
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('name'))).toBe(true);
+  });
+
+  it('rechaza hasAgriPest con un URN que no calza el patrón de identificador NGSI (ej. contiene espacios)', () => {
+    const entity = buildAgriCropEntity({
+      id: 'coffea_arabica',
+      nombre_comun: 'Café',
+    });
+    // Fuerza un Relationship malformado (URN con espacios, fuera del patrón
+    // EntityIdentifierType del schema oficial) para probar el rechazo.
+    entity.hasAgriPest = [{ type: 'Relationship', object: 'urn:ngsi-ld:AgriPest:no valido' }];
+
+    const { valid, errors } = validateEntityAjv(entity);
+    expect(valid).toBe(false);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('validateEntityAjv — AgriPest', () => {
+  it('(c) valida OK una entidad AgriPest bien formada (shape string del catálogo público)', () => {
+    const entity = buildAgriPestEntity('Hemileia vastatrix (roya)');
+    const { valid, errors } = validateEntityAjv(entity);
+    expect(valid).toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  it('valida OK una entidad AgriPest con x-chagra-mip (atributo custom no restringido por el schema oficial)', () => {
+    const entity = buildAgriPestEntity({
+      nombre_cientifico: 'Hypothenemus hampei',
+      nombre_comun: 'Broca del café',
+      umbral_accion: '5% de frutos infestados',
+      control_biologico: ['Beauveria bassiana'],
+    });
+    const { valid, errors } = validateEntityAjv(entity);
+    expect(valid).toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  it('rechaza una entidad AgriPest malformada sin id', () => {
+    const { valid, errors } = validateEntityAjv({
+      type: 'AgriPest',
+      name: { type: 'Property', value: 'roya' },
+    });
+    expect(valid).toBe(false);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('validateEntityAjv — casos borde', () => {
+  it('rechaza entity no-objeto', () => {
+    expect(validateEntityAjv(null).valid).toBe(false);
+    expect(validateEntityAjv(undefined).valid).toBe(false);
+    expect(validateEntityAjv('no-es-un-objeto').valid).toBe(false);
+  });
+
+  it('rechaza type sin schema oficial vendorizado', () => {
+    const { valid, errors } = validateEntityAjv({ id: 'x', type: 'AgriSoil' });
+    expect(valid).toBe(false);
+    expect(errors[0]).toMatch(/sin schema oficial vendorizado/);
+  });
+});
+
+describe('validateEntitiesAjv (agregado)', () => {
+  it('reporta valid=true cuando AgriCrop + AgriPest son válidas', () => {
+    const crop = buildAgriCropEntity({ id: 'zea_mays', nombre_comun: 'Maíz' });
+    const pest = buildAgriPestEntity('Spodoptera frugiperda (gusano cogollero)');
+
+    const result = validateEntitiesAjv([crop, pest]);
+    expect(result.valid).toBe(true);
+    expect(result.invalidCount).toBe(0);
+  });
+
+  it('reporta detalle por entidad inválida, incluyendo el type', () => {
+    const result = validateEntitiesAjv([
+      { id: 'urn:ngsi-ld:AgriCrop:x', type: 'AgriCrop' }, // sin name
+    ]);
+    expect(result.valid).toBe(false);
+    expect(result.invalidCount).toBe(1);
+    expect(result.details[0].type).toBe('AgriCrop');
+    expect(result.details[0].errors.length).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// Integración: muestra real del catálogo OSS v3.2 (ADR-051 fase 1)
+// =============================================================================
+
+describe('validateEntitiesAjv — muestra real del catálogo OSS v3.2', () => {
+  const catalogPath = resolve('catalog/chagra-catalog-oss-subset-v3.2.json');
+  let seed = null;
+  try {
+    seed = JSON.parse(readFileSync(catalogPath, 'utf-8'));
+  } catch {
+    seed = null; // En CI sin acceso al catálogo (poco probable aquí), skip suave.
+  }
+
+  it.skipIf(!seed)('las primeras 30 species del catálogo OSS producen AgriCrop conformes al schema oficial', () => {
+    const entities = seed.species
+      .slice(0, 30)
+      .map((sp) => buildAgriCropEntity(sp))
+      .filter(Boolean);
+    expect(entities.length).toBeGreaterThan(0);
+
+    const result = validateEntitiesAjv(entities);
+    expect(result.details).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it.skipIf(!seed)('las plagas reales con plagas_criticas producen AgriPest conformes al schema oficial', () => {
+    const conPlagas = seed.species.find((s) => Array.isArray(s.plagas_criticas) && s.plagas_criticas.length > 0);
+    expect(conPlagas).toBeTruthy();
+
+    const entities = conPlagas.plagas_criticas
+      .map((raw) => buildAgriPestEntity(raw))
+      .filter(Boolean);
+    expect(entities.length).toBeGreaterThan(0);
+
+    const result = validateEntitiesAjv(entities);
+    expect(result.details).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/scripts/export-ngsi-ld.mjs
+++ b/scripts/export-ngsi-ld.mjs
@@ -73,12 +73,22 @@
  *
  * Sin `--json` ni `--out`, imprime un reporte humano (conteo, validación)
  * por stdout — pensado para revisión manual del operador antes de un demo.
+ *
+ * Validación de conformidad NGSI-LD (ADR-051 fase 1, ítem CI): además de la
+ * validación estructural propia (`validateAgriCropEntity`/
+ * `validateAgriPestEntity`), `main()` corre `validateEntitiesAjv` (ver
+ * `scripts/lib/ngsi-validate.mjs`) contra los JSON Schema **oficiales** de
+ * `smart-data-models/dataModel.Agrifood` vendorizados en
+ * `scripts/fiware-schemas/`. Si cualquiera de las dos capas falla, el
+ * proceso sale con código 1 — pensado para engancharse a CI vía
+ * `npm run validate:ngsi`.
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { normalizePest, classifyBiopreparadoTarget, truncText } from './catalog-to-age.mjs';
+import { validateEntitiesAjv } from './lib/ngsi-validate.mjs';
 
 // =============================================================================
 // Contexto NGSI-LD
@@ -465,14 +475,17 @@ export function buildAgriPestEntities(seed, opts = {}) {
 // =============================================================================
 
 /**
- * NOTA: `ajv` no está en las dependencias del repo (verificado en
- * package.json). Por ADR-051 + instrucción de la tarea, no se agrega una
- * dependencia nueva solo para esto — se valida la estructura mínima NGSI-LD
- * exigida (id URN `urn:ngsi-ld:AgriCrop:*`, type, name, y forma de
- * hasAgriPest/@context si están presentes). Si en el futuro `ajv` entra al
- * repo (ver `fiware-ngsild-ajv-ci` en queue), esta función puede
- * reemplazarse por validación JSON Schema completa contra los schemas
- * oficiales `smart-data-models` sin cambiar la firma pública.
+ * NOTA (actualizada — ADR-051 fase 1, ítem "Validación conformidad NGSI-LD
+ * (ajv vs schemas oficiales) en CI"): esta función valida solo la
+ * estructura mínima NGSI-LD (id URN `urn:ngsi-ld:AgriCrop:*`, type, name, y
+ * forma de hasAgriPest/@context si están presentes) — es rápida y no
+ * depende de los schemas oficiales, útil como smoke check dentro de
+ * `buildAgriCropEntities`/CLI. La validación **completa** contra los JSON
+ * Schema oficiales de `smart-data-models` (vendorizados en
+ * `scripts/fiware-schemas/`) vive en `scripts/lib/ngsi-validate.mjs`
+ * (`validateEntitiesAjv`) y se corre además en `main()` más abajo — ambas
+ * capas se mantienen porque esta es más barata y da mensajes más
+ * específicos al dominio Chagra (ej. formato de URN de plaga).
  *
  * @param {object} entity
  * @returns {{valid: boolean, errors: string[]}}
@@ -641,7 +654,7 @@ export function validateAgriPestEntities(entities) {
 
 /**
  * @param {string[]} argv - process.argv.slice(2)
- * @returns {Promise<{outputPath: string|null, entityCount: number, valid: boolean}>}
+ * @returns {Promise<{outputPath: string|null, entityCount: number, valid: boolean, ajvValid: boolean}>}
  */
 export async function main(argv = process.argv.slice(2)) {
   const opts = {
@@ -681,7 +694,13 @@ export async function main(argv = process.argv.slice(2)) {
   // Batch mixto AgriCrop + AgriPest (formato aceptado por
   // entityOperations/upsert de Orion-LD; ver nota de cabecera del archivo).
   const entities = [...cropResult.entities, ...pestResult.entities];
-  const valid = cropValidation.valid && pestValidation.valid;
+
+  // Validación de conformidad NGSI-LD contra los schemas OFICIALES de
+  // smart-data-models (ADR-051 fase 1, ítem CI) — capa adicional a la
+  // validación estructural propia de arriba (ver `scripts/lib/ngsi-validate.mjs`).
+  const ajvValidation = validateEntitiesAjv(entities);
+
+  const valid = cropValidation.valid && pestValidation.valid && ajvValidation.valid;
 
   const jsonOut = JSON.stringify(entities, null, 2) + '\n';
 
@@ -722,13 +741,27 @@ export async function main(argv = process.argv.slice(2)) {
         console.log(`  - ${d.id}: ${d.errors.join(' | ')}`);
       }
     }
+    console.log(
+      `Validación ajv vs. schemas oficiales smart-data-models (AgriCrop+AgriPest): `
+      + `${ajvValidation.valid ? 'OK' : `FALLÓ (${ajvValidation.invalidCount} entidad(es))`}`,
+    );
+    if (!ajvValidation.valid) {
+      for (const d of ajvValidation.details.slice(0, 10)) {
+        console.log(`  - [${d.type}] ${d.id}: ${d.errors.join(' | ')}`);
+      }
+    }
   }
 
   if (!valid) {
     process.exitCode = 1;
   }
 
-  return { outputPath: opts.out, entityCount: entities.length, valid };
+  return {
+    outputPath: opts.out,
+    entityCount: entities.length,
+    valid,
+    ajvValid: ajvValidation.valid,
+  };
 }
 
 // ESM-friendly entry-point check.

--- a/scripts/fiware-schemas/AgriCrop.schema.json
+++ b/scripts/fiware-schemas/AgriCrop.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schemaVersion": "0.0.7",
+  "modelTags": "",
+  "$id": "https://smart-data-models.github.io/dataModel.Agrifood/AgriCrop/schema.json",
+  "$comment": "VENDORIZADO (ADR-051 fase 1) desde smart-data-models/dataModel.Agrifood (Apache-2.0, https://github.com/smart-data-models/dataModel.Agrifood). Fuente: https://raw.githubusercontent.com/smart-data-models/dataModel.Agrifood/master/AgriCrop/schema.json . Descargado 2026-07-01. Byte-fiel al original salvo este $comment. Si el schema oficial cambia, re-descargar desde la misma URL (o el equivalente raw.githubusercontent.com/.../master/<Entidad>/schema.json) y actualizar los 4 archivos de este directorio juntos (tienen $ref cruzados).",
+  "title": "Smart Data Models - Agri Food",
+  "description": "This entity contains a harmonised description of a generic crop. This entity is primarily associated with the agricultural vertical and related IoT applications.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
+    },
+    {
+      "$ref": "https://smart-data-models.github.io/dataModel.Agrifood/agrifood-schema.json#/definitions/AgriFood-Commons"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AgriCrop"
+          ],
+          "description": "Property. NGSI Entity Type. it has to be AgriCrop"
+        },
+        "agroVocConcept": {
+          "type": "string",
+          "format": "uri",
+          "description": "Property. Model:'http://schema.org/URL'. The link with the defined concept into the AgroVoc vocabulary"
+        },
+        "hasAgriSoil": {
+          "type": "array",
+          "description": "Relationship. Model:'http://schema.org/URL'. Reference to the recommended types of soil suitable for growing this crop",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+                "description": "Property. Identifier format of any NGSI entity"
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "description": "Property. Identifier format of any NGSI entity"
+              }
+            ]
+          }
+        },
+        "hasAgriFertiliser": {
+          "type": "array",
+          "description": "Relationship. Model:'http://schema.org/URL'. Reference to the recommended types of fertiliser suitable for growing this crop",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+                "description": "Property. Identifier format of any NGSI entity"
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "description": "Property. Identifier format of any NGSI entity"
+              }
+            ]
+          }
+        },
+        "hasAgriPest": {
+          "type": "array",
+          "description": "Relationship. Reference to the pests known to attack this crop. Model:'https://schema.org/URL'",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+                "description": "Property. Identifier format of any NGSI entity"
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "description": "Property. Identifier format of any NGSI entity"
+              }
+            ]
+          }
+        },
+        "harvestingInterval": {
+          "type": "array",
+          "description": "Property. Model:'http://schema.org/URL'. A list of the recommended harvesting interval date(s) for this crop. Specified using ISO8601 repeating date intervals: <br/><br/>**interval, description**<br/><br/>Where **interval** is in the form of **start date/end date**<br/><br/>--MM-DD/--MM-DD<br/><br/>Meaning repeat each year from this start date to this end date",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dateRange": {
+                "type": "string",
+                "pattern": "^-[0-1][0-9]-[0-3][0-9]/-[0-1][0-9]-[0-3][0-9]$",
+                "description": "Property. Range of dates in a string format"
+              },
+              "description": {
+                "type": "string",
+                "description": "Property. Descriptions of the range dates"
+              }
+            }
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "plantingFrom": {
+          "type": "array",
+          "description": "Property. Model:'http://schema.org/URL'. A list of the recommended planting interval date(s) for this crop. Specified using ISO8601 repeating date intervals: <br/><br/>**interval, description**<br/><br/>Where **interval** is in the form of **start date/end date**<br/><br/>--MM-DD/--MM-DD<br/><br/>Meaning repeat each year from this start date to this end date",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dateRange": {
+                "type": "string",
+                "pattern": "^-[0-1][0-9]-[0-3][0-9]/-[0-1][0-9]-[0-3][0-9]$",
+                "description": "Property. Range of dates in a string format"
+              },
+              "description": {
+                "type": "string",
+                "description": "Property. Descriptions of the range dates"
+              }
+            }
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "wateringFrequency": {
+          "type": "string",
+          "description": "Property. Model:'http://schema.org/URL'. Units:''. A description of the recommended watering schedule. A choice from an enumerated list. One of: **daily, weekly, biweekly, monthly, onDemand, other**. Enum:'daily, weekly, biweekly, monthly, onDemand,    other'",
+          "enum": [
+            "daily",
+            "weekly",
+            "biweekly",
+            "monthly",
+            "onDemand",
+            "other"
+          ]
+        }
+      }
+    }
+  ],
+  "required": [
+    "id",
+    "type",
+    "name"
+  ]
+}

--- a/scripts/fiware-schemas/AgriPest.schema.json
+++ b/scripts/fiware-schemas/AgriPest.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schemaVersion": "0.0.2",
+  "modelTags": "",
+  "$id": "https://smart-data-models.github.io/dataModel.Agrifood/AgriPest/schema.json",
+  "$comment": "VENDORIZADO (ADR-051 fase 1) desde smart-data-models/dataModel.Agrifood (Apache-2.0, https://github.com/smart-data-models/dataModel.Agrifood). Fuente: https://raw.githubusercontent.com/smart-data-models/dataModel.Agrifood/master/AgriPest/schema.json . Descargado 2026-07-01. Byte-fiel al original salvo este $comment. Si el schema oficial cambia, re-descargar desde la misma URL (o el equivalente raw.githubusercontent.com/.../master/<Entidad>/schema.json) y actualizar los 4 archivos de este directorio juntos (tienen $ref cruzados).",
+  "title": "Smart Data Models - Agri Pest",
+  "description": "This entity contains a harmonised description of an agricultural pest. ",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
+    },
+    {
+      "$ref": "https://smart-data-models.github.io/dataModel.Agrifood/agrifood-schema.json#/definitions/AgriFood-Commons"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AgriPest"
+          ],
+          "description": "Property. NGSI Entity Type: It has to be AgriPest"
+        },
+        "agroVocConcept": {
+          "type": "string",
+          "format": "uri",
+          "description": "Relationship. Model:'http://schema.org/URL'. Reference to the agrovoc term associated with this item"
+        },
+        "hasAgriProductType": {
+          "type": "array",
+          "description": "Relationship. Model:'http://schema.org/URL'. Reference to the recommended types of product that can be used to treat this pest",
+          "items": {
+            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/EntityIdentifierType"
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "id",
+    "type",
+    "name"
+  ]
+}

--- a/scripts/fiware-schemas/agrifood-schema.json
+++ b/scripts/fiware-schemas/agrifood-schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://smart-data-models.github.io/dataModel.Agrifood/agrifood-schema.json",
+  "$comment": "VENDORIZADO (ADR-051 fase 1) desde smart-data-models/dataModel.Agrifood (Apache-2.0, https://github.com/smart-data-models/dataModel.Agrifood). Fuente: https://smart-data-models.github.io/dataModel.Agrifood/agrifood-schema.json . Descargado 2026-07-01. Byte-fiel al original salvo este $comment. Si el schema oficial cambia, re-descargar desde la misma URL (o el equivalente raw.githubusercontent.com/.../master/<Entidad>/schema.json) y actualizar los 4 archivos de este directorio juntos (tienen $ref cruzados).",
+  "title": "AgriFood Commons schema",
+  "description": "Common definitions to describe agri food data models",
+  "definitions": {
+    "AgriFood-Commons": {
+      "type": "object",
+      "properties": {
+        "relatedSource": {
+          "type": "array",
+          "description": "Property. List of IDs the current entity may have in external applications",
+          "items": {
+            "type": "object",
+            "properties": {
+              "application": {
+                "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/EntityIdentifierType",
+                "description": "Relationship. Identifier of the entity describing the external application"
+              },
+              "applicationEntityId": {
+                "type": "string",
+                "description": "Property. Identifier in the external application"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/fiware-schemas/common-schema.json
+++ b/scripts/fiware-schemas/common-schema.json
@@ -1,0 +1,1050 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://smart-data-models.github.io/data-models/common-schema.json",
+  "$comment": "VENDORIZADO (ADR-051 fase 1) desde smart-data-models/dataModel.Agrifood (Apache-2.0, https://github.com/smart-data-models/dataModel.Agrifood). Fuente: https://smart-data-models.github.io/data-models/common-schema.json . Descargado 2026-07-01. Byte-fiel al original salvo este $comment. Si el schema oficial cambia, re-descargar desde la misma URL (o el equivalente raw.githubusercontent.com/.../master/<Entidad>/schema.json) y actualizar los 4 archivos de este directorio juntos (tienen $ref cruzados).",
+  "title": "Common definitions for  Harmonized Data Models",
+  "definitions": {
+    "EntityIdentifierType": {
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+          "description": "Property. Identifier format of any NGSI entity"
+        },
+        {
+          "type": "string",
+          "format": "uri",
+          "description": "Property. Identifier format of any NGSI entity"
+        }
+      ],
+      "description": "Relationship. Unique identifier of the entity"
+    },
+    "email": {
+      "type": "string",
+      "format": "idn-email",
+      "description": "Property. Email address of owner"
+    },
+    "userAlias": {
+      "type": "string",
+      "description": "Property. An anonymous alias of a user"
+    },
+    "tag": {
+      "type": "string",
+      "description": "Property. Model:'https://schema.org/Text'. An optional text string used to qualify an item"
+    },
+    "timeInstant": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Property. Model:'https://schema.org/Datetime'. Timestamp of the payload . There can be production environments where the attribute type is equal to the `ISO8601` string. If so, it must be considered as a synonym of `DateTime`. This attribute is kept for backwards compatibility with old FIWARE reference implementations"
+    },
+    "dateObserved": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Property. Date of the observed entity defined by the user"
+    },
+    "dateYearLess": {
+      "type": "string",
+      "pattern": "^--((0[13578]|1[02])-31|(0[1,3-9]|1[0-2])-30|(0\\d|1[0-2])-([0-2]\\d))$"
+    },
+    "GSMA-Commons": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/EntityIdentifierType"
+        },
+        "dateCreated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Property. Entity creation timestamp. This will usually be allocated by the storage platform"
+        },
+        "dateModified": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Property. Timestamp of the last modification of the entity. This will usually be allocated by the storage platform"
+        },
+        "source": {
+          "type": "string",
+          "description": "Property. A sequence of characters giving the original source of the entity data as a URL. Recommended to be the fully qualified domain name of the source provider, or the URL to the source object"
+        },
+        "name": {
+          "type": "string",
+          "description": "Property. The name of this item"
+        },
+        "alternateName": {
+          "type": "string",
+          "description": "Property. An alternative name for this item"
+        },
+        "description": {
+          "type": "string",
+          "description": "Property. A description of this item"
+        },
+        "dataProvider": {
+          "type": "string",
+          "description": "Property. A sequence of characters identifying the provider of the harmonised data entity"
+        },
+        "owner": {
+          "type": "array",
+          "description": "Property. A List containing a JSON encoded sequence of characters referencing the unique Ids of the owner(s)",
+          "items": {
+            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/EntityIdentifierType"
+          }
+        },
+        "seeAlso": {
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            {
+              "type": "string",
+              "format": "uri"
+            }
+          ],
+          "description": "Property. list of uri pointing to additional resources about the item"
+        }
+      }
+    },
+    "Location-Commons": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "oneOf": [
+            {
+              "title": "GeoJSON Point",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "description": "GeoProperty. Geojson reference to the item. Point",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Point"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": {
+                    "type": "number"
+                  },
+                  "description": "Property. Coordinates of the Point"
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  },
+                  "description": "Property. BBox of the  Point"
+                }
+              }
+            },
+            {
+              "title": "GeoJSON LineString",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "description": "GeoProperty. Geojson reference to the item. LineString",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "LineString"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "minItems": 2,
+                  "description": "Property. Coordinates of the LineString",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  },
+                  "description": "Property. BBox coordinates of the LineString"
+                }
+              }
+            },
+            {
+              "title": "GeoJSON Polygon",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "description": "GeoProperty. Geojson reference to the item. Polygon",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Polygon"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "description": "Property. Coordinates of the Polygon",
+                  "items": {
+                    "type": "array",
+                    "minItems": 4,
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  },
+                  "description": "Property. BBox coordinates of the Polygon"
+                }
+              }
+            },
+            {
+              "title": "GeoJSON MultiPoint",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "description": "GeoProperty. Geojson reference to the item. MultiPoint",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "MultiPoint"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "description": "Property. Coordinates of the MulitPoint",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  },
+                  "description": "Property. BBox coordinates of the LineString"
+                }
+              }
+            },
+            {
+              "title": "GeoJSON MultiLineString",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "description": "GeoProperty. Geojson reference to the item. MultiLineString",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "MultiLineString"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "description": "Property. Coordinates of the MultiLineString",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  },
+                  "description": "Property. BBox coordinates of the LineString"
+                }
+              }
+            },
+            {
+              "title": "GeoJSON MultiPolygon",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "description": "GeoProperty. Geojson reference to the item. MultiLineString",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "MultiPolygon"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "description": "Property. Coordinates of the MultiPolygon",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 4,
+                      "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          ],
+          "description": "GeoProperty. Geojson reference to the item. It can be Point, LineString, Polygon, MultiPoint, MultiLineString or MultiPolygon"
+        },
+        "address": {
+          "type": "object",
+          "description": "Property. The mailing address. Model:'https://schema.org/address'",
+          "properties": {
+            "streetAddress": {
+              "type": "string",
+              "description": "Property. The street address. Model:'https://schema.org/streetAddress'"
+            },
+            "addressLocality": {
+              "type": "string",
+              "description": "Property. The locality in which the street address is, and which is in the region. Model:'https://schema.org/addressLocality'"
+            },
+            "addressRegion": {
+              "type": "string",
+              "description": "Property. The region in which the locality is, and which is in the country. Model:'https://schema.org/addressRegion'"
+            },
+            "addressCountry": {
+              "type": "string",
+              "description": "Property. The country. For example, Spain. Model:'https://schema.org/addressCountry'"
+            },
+            "postalCode": {
+              "type": "string",
+              "description": "Property. The postal code. For example, 24004. Model:'https://schema.org/https://schema.org/postalCode'"
+            },
+            "postOfficeBoxNumber": {
+              "type": "string",
+              "description": "Property. The post office box number for PO box addresses. For example, 03578. Model:'https://schema.org/postOfficeBoxNumber'"
+            },
+            "streetNr": {
+              "type": "string",
+              "description": "Property. Number identifying a specific property on a public street"
+            },
+            "district": {
+              "type": "string",
+              "description": "Property. A district is a type of administrative division that, in some countries, is managed by the local government"
+            }
+          }
+        },
+        "areaServed": {
+          "type": "string",
+          "description": "Property. The geographic area where a service or offered item is provided. Model:'https://schema.org/Text'"
+        }
+      }
+    },
+    "PhysicalObject-Commons": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string",
+          "description": "Property. The color of the product. Model:'https://schema.org/color'"
+        },
+        "image": {
+          "type": "string",
+          "format": "uri",
+          "description": "Property. An image of the item. Model:'https://schema.org/URL'"
+        },
+        "annotations": {
+          "type": "array",
+          "description": "Property. Annotations about the item. Model:'https://schema.org/Text'",
+          "items": {
+            "type": "string",
+            "description": "Property. Eventy element in the annotations"
+          }
+        }
+      }
+    },
+    "DateTime-Commons": {
+      "type": "object",
+      "description": "Property. All date-time elements in data models unless explicitly stated are ISO 8601 compliant",
+      "properties": {
+        "openingHoursSpecification": {
+          "type": "array",
+          "description": "Property. A structured value providing information about the opening hours of a place or a certain service inside a place. Model:'https://schema.org/openingHoursSpecification'",
+          "items": {
+            "type": "object",
+            "properties": {
+              "opens": {
+                "type": "string",
+                "format": "time",
+                "description": "Property. The opening hour of the place or service on the given day(s) of the week"
+              },
+              "closes": {
+                "type": "string",
+                "format": "time",
+                "description": "Property.  \tThe closing hour of the place or service on the given day(s) of the week"
+              },
+              "dayOfWeek": {
+                "type": "string",
+                "description": "Property. Model:'http://schema.org/dayOfWeek'. The day of the week for which these opening hours are valid. URLs from GoodRelations (http://purl.org/goodrelations/v1) are used (for Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday plus a special entry for PublicHolidays)",
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "Property. Array of days of the week",
+                    "enum": [
+                      "Monday",
+                      "Tuesday",
+                      "Wednesday",
+                      "Thursday",
+                      "Friday",
+                      "Saturday",
+                      "Sunday",
+                      "PublicHolidays"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "description": "Property. Array of days of the week",
+                    "enum": [
+                      "https://schema.org/Monday",
+                      "https://schema.org/Tuesday",
+                      "https://schema.org/Wednesday",
+                      "https://schema.org/Thursday",
+                      "https://schema.org/Friday",
+                      "https://schema.org/Saturday",
+                      "https://schema.org/Sunday",
+                      "https://schema.org/PublicHolidays"
+                    ]
+                  }
+                ]
+              },
+              "validFrom": {
+                "description": "Property. The date when the item becomes valid. A date value in the form CCYY-MM-DD or a combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] in ISO 8601 date format",
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date",
+                    "description": "Property. Model:'http://schema.org/Date"
+                  },
+                  {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Property. Model:'http://schema.org/DateTime"
+                  }
+                ]
+              },
+              "validThrough": {
+                "type": "string",
+                "description": "Property. The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours. A date value in the form CCYY-MM-DD or a combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] in ISO 8601 date format",
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date",
+                    "description": "Property. Model:'http://schema.org/Date"
+                  },
+                  {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Property. Model:'http://schema.org/DateTime"
+                  }
+                ]
+              }
+            }
+          },
+          "minItems": 1
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Property. Model:'https://schema.org/startDate'. The start date and time of the item (in ISO 8601 date format)."
+        },
+        "endDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Property. Model:'https://schema.org/endDate'. The end date and time of the item (in ISO 8601 date format)."
+        },
+        "openingHours": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/openingHours'. The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'. Days are specified using the following two-letter combinations: Mo, Tu, We, Th, Fr, Sa, Su. Times are specified using 24:00 format. For example, 3pm is specified as 15:00, 10am as 10:00. Here is an example: <time itemprop='openingHours' datetime='Tu,Th 16:00-20:00'>Tuesdays and Thursdays 4-8pm</time>. If a business is open 7 days a week, then it can be specified as <time itemprop='openingHours' datetime='Mo-Su'>Monday through Sunday, all day</time>"
+        }
+      }
+    },
+    "Contact-Commons": {
+      "description": "Property. All contact elements in data models unless explicitly stated according to schema.org",
+      "type": "object",
+      "properties": {
+        "contactPoint": {
+          "type": "object",
+          "description": "Property. Model:'https://schema.org/ContactPoint'. The details to contact with the item",
+          "properties": {
+            "contactType": {
+              "type": "string",
+              "description": "Property. Contact type of this item"
+            },
+            "email": {
+              "$ref": "#/definitions/email"
+            },
+            "telephone": {
+              "type": "string",
+              "description": "Property. Telephone of this contact"
+            },
+            "name": {
+              "type": "string",
+              "description": "Property. The name of this item"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "Property. URL which provides a description or further information about this item"
+            },
+            "areaServed": {
+              "type": "string",
+              "description": "Property. The geographic area where a service or offered item is provided. Supersedes serviceArea"
+            },
+            "availableLanguage": {
+              "description": "Property. Model:'http://schema.org/availableLanguage'. A language someone may use with or at the item, service or place. Please use one of the language codes from the IETF BCP 47 standard. It is implemented the Text option but it could be also Language",
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "contactOption": {
+              "description": "Property. Model:'http://schema.org/contactOption'. An option available on this contact point (e.g. a toll-free number or support for hearing-impaired callers)",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "faxNumber": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. The fax number of the item"
+            },
+            "productSupported": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. The product or service this support contact point is related to (such as product support for a particular product line). This can be a specific product or product line (e.g. 'iPhone') or a general category of products or services (e.g. 'smartphones')"
+            },
+            "availabilityRestriction": {
+              "description": "Relationship. Model:'https://schema.org/hoursAvailable'. This property links a contact point to information about when the contact point is not available. The details are provided using the Opening Hours Specification class",
+              "anyOf": [
+                {
+                  "type": "array",
+                  "description": "Property. Array of identifiers format of any NGSI entity",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256,
+                    "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$"
+                  }
+                },
+                {
+                  "type": "array",
+                  "description": "Property. Array of identifiers format of any NGSI entity",
+                  "items": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "Person-Commons": {
+      "description": "Property. All properties to identify a person according to schema.org",
+      "type": "object",
+      "properties": {
+        "person": {
+          "type": "object",
+          "description": "Property. Model:'https://schema.org/Person'. A person (alive, dead, undead, or fictional)",
+          "properties": {
+            "additionalName": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. An additional name for a Person, can be used for a middle name"
+            },
+            "familyName": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. Family name. In the U.S., the last name of a Person"
+            },
+            "givenName": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. Given name. In the U.S., the first name of a Person"
+            },
+            "telephone": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. The telephone number"
+            },
+            "email": {
+              "$ref": "#/definitions/email"
+            }
+          }
+        }
+      }
+    },
+    "Extensible-Commons": {
+      "description": "Property. All properties to allow interoperability with TMForum Open-APIs",
+      "type": "object",
+      "properties": {
+        "Addressable": {
+          "type": "object",
+          "description": "Property. Base schema for addressable entities",
+          "properties": {
+            "href": {
+              "type": "string",
+              "format": "uri",
+              "description": "Relationship. Hyperlink reference"
+            },
+            "id": {
+              "type": "string",
+              "description": "Property. unique identifier"
+            }
+          }
+        },
+        "Extensible": {
+          "type": "object",
+          "description": "Property. Base Extensible schema for use in TMForum Open-APIs",
+          "properties": {
+            "@schemaLocation": {
+              "type": "string",
+              "format": "uri",
+              "description": "Property. A URI to a JSON-Schema file that defines additional attributes and relationships"
+            },
+            "@baseType": {
+              "type": "string",
+              "description": "Property. When sub-classing, this defines the super-class"
+            },
+            "@type": {
+              "type": "string",
+              "description": "Property. When sub-classing, this defines the sub-class Extensible name"
+            }
+          },
+          "dependencies": {
+            "@schemaLocation": [
+              "@baseType",
+              "@type"
+            ]
+          }
+        }
+      }
+    },
+    "TimeSeriesAggregation": {
+      "type": "object",
+      "description": "Property. Object defining the temporal processing of a basic property during a period. It provides Maximum, minimum, instant value and average. Attributes using this should be named with the suffix TSA",
+      "properties": {
+        "avgOverTime": {
+          "type": "number",
+          "description": "Property. Average value over period of time"
+        },
+        "minOverTime": {
+          "type": "number",
+          "description": "Property. Minimum value over period of time"
+        },
+        "maxOverTime": {
+          "type": "number",
+          "description": "Property. Maximum value over period of time"
+        },
+        "instValue": {
+          "type": "number",
+          "description": "Property. Instant value when information is retrieved"
+        }
+      }
+    },
+    "touristType": {
+      "type": "string",
+      "enum": [
+        "ADVENTURE TOURISM",
+        "ASTRONOMY TOURISM",
+        "BACKPACKING TOURISM",
+        "BEACH AND SUN TOURISM",
+        "BEER TOURISM",
+        "BIRDING TOURISM",
+        "BULLFIGHTING TOURISM",
+        "BUSINESS",
+        "COMMUNITY-BASED TOURISM",
+        "CRUISE TOURISM",
+        "CULTURAL TOURISM",
+        "CYCLING TOURISM",
+        "DIVING TOURISM",
+        "ECOTOURISM",
+        "EVENTS AND FESTIVALS TOURISM",
+        "FAMILY TOURISM",
+        "FILM TOURISM",
+        "FISHING TOURISM",
+        "FOOD TOURISM",
+        "GAMBLING TOURISM",
+        "GEOLOGICAL TOURISM",
+        "HERITAGE TOURISM",
+        "HUNTING TOURISM",
+        "INDUSTRIAL TOURISM",
+        "LANGUAGE TOURISM",
+        "LGTBI TOURISM",
+        "LUXURY TOURISM",
+        "MEDICAL TOURISM",
+        "MEMORIAL TOURISM",
+        "MICE TOURISM",
+        "NATURE TOURISM",
+        "OLIVE OIL TOURISM",
+        "PARTY TOURISM",
+        "PHOTOGRAPHY TOURISM",
+        "RELIGIOUS TOURISM",
+        "ROMANTIC TOURISM",
+        "RURAL TOURISM",
+        "SAFARI TOURISM",
+        "SAILING TOURISM",
+        "SENIOR TOURISM",
+        "SHOPPING TOURISM",
+        "SHORT BREAK TOURISM",
+        "SINGLES TOURISM",
+        "SPORTS TOURISM",
+        "TOURISM",
+        "TREKKING TOURISM",
+        "URBAN TOURISM",
+        "WATER SPORTS TOURISM",
+        "WEDDING & HONEYMOON TOURISM",
+        "WELLNESS TOURISM",
+        "WHISKY TOURISM",
+        "WINE TOURISM",
+        "WINTER SPORTS TOURISM",
+        "WOMEN TOURISM"
+      ],
+      "description": "Property. Model:'https://schema.org/Text'. Type of tourism depending on the segment and the motivation of the trip."
+    },
+    "isAccessibleForFree": {
+      "type": "boolean",
+      "description": "Property. Model:'https://schema.org/isAccessibleForFree'. A flag to signal that the item, event, or place is accessible for free."
+    },
+    "publicAccess": {
+      "type": "boolean",
+      "description": "Property. Model:'https://schema.org/publicAccess'. A flag to signal that the Place is open to public visitors. If this property is omitted there is no assumed default boolean value"
+    },
+    "availableLanguage": {
+      "type": "array",
+      "description": "Property. Model:''. A language someone may use with or at the item, service or place. Please use one of the language codes from the IETF BCP 47 standard. ",
+      "items": {
+        "type": "string",
+        "enum": [
+          "AD",
+          "AE",
+          "AF",
+          "AG",
+          "AI",
+          "AL",
+          "AM",
+          "AO",
+          "AQ",
+          "AR",
+          "AS",
+          "AT",
+          "AU",
+          "AW",
+          "AX",
+          "AZ",
+          "BA",
+          "BB",
+          "BD",
+          "BE",
+          "BF",
+          "BG",
+          "BH",
+          "BI",
+          "BJ",
+          "BL",
+          "BM",
+          "BN",
+          "BO",
+          "BQ",
+          "BR",
+          "BS",
+          "BT",
+          "BV",
+          "BW",
+          "BY",
+          "BZ",
+          "CA",
+          "CC",
+          "CD",
+          "CF",
+          "CG",
+          "CH",
+          "CI",
+          "CK",
+          "CL",
+          "CM",
+          "CN",
+          "CO",
+          "CR",
+          "CU",
+          "CV",
+          "CW",
+          "CX",
+          "CY",
+          "CZ",
+          "DE",
+          "DJ",
+          "DK",
+          "DM",
+          "DO",
+          "DZ",
+          "EC",
+          "EE",
+          "EG",
+          "EH",
+          "ER",
+          "ES",
+          "ET",
+          "FI",
+          "FJ",
+          "FK",
+          "FM",
+          "FO",
+          "FR",
+          "GA",
+          "GB",
+          "GD",
+          "GE",
+          "GF",
+          "GG",
+          "GH",
+          "GI",
+          "GL",
+          "GM",
+          "GN",
+          "GP",
+          "GQ",
+          "GR",
+          "GS",
+          "GT",
+          "GU",
+          "GW",
+          "GY",
+          "HK",
+          "HM",
+          "HN",
+          "HR",
+          "HT",
+          "HU",
+          "ID",
+          "IE",
+          "IL",
+          "IM",
+          "IN",
+          "IO",
+          "IQ",
+          "IR",
+          "IS",
+          "IT",
+          "JE",
+          "JM",
+          "JO",
+          "JP",
+          "KE",
+          "KG",
+          "KH",
+          "KI",
+          "KM",
+          "KN",
+          "KP",
+          "KR",
+          "KW",
+          "KY",
+          "KZ",
+          "LA",
+          "LB",
+          "LC",
+          "LI",
+          "LK",
+          "LR",
+          "LS",
+          "LT",
+          "LU",
+          "LV",
+          "LY",
+          "MA",
+          "MC",
+          "MD",
+          "ME",
+          "MF",
+          "MG",
+          "MH",
+          "MK",
+          "ML",
+          "MM",
+          "MN",
+          "MO",
+          "MP",
+          "MQ",
+          "MR",
+          "MS",
+          "MT",
+          "MU",
+          "MV",
+          "MW",
+          "MX",
+          "MY",
+          "MZ",
+          "NA",
+          "NC",
+          "NE",
+          "NF",
+          "NG",
+          "NI",
+          "NL",
+          "NO",
+          "NP",
+          "NR",
+          "NU",
+          "NZ",
+          "OM",
+          "PA",
+          "PE",
+          "PF",
+          "PG",
+          "PH",
+          "PK",
+          "PL",
+          "PM",
+          "PN",
+          "PR",
+          "PS",
+          "PT",
+          "PW",
+          "PY",
+          "QA",
+          "RE",
+          "RO",
+          "RS",
+          "RU",
+          "RW",
+          "SA",
+          "SB",
+          "SC",
+          "SD",
+          "SE",
+          "SG",
+          "SH",
+          "SI",
+          "SJ",
+          "SK",
+          "SL",
+          "SM",
+          "SN",
+          "SO",
+          "SR",
+          "SS",
+          "ST",
+          "SV",
+          "SX",
+          "SY",
+          "SZ",
+          "TC",
+          "TD",
+          "TF",
+          "TG",
+          "TH",
+          "TJ",
+          "TK",
+          "TL",
+          "TM",
+          "TN",
+          "TO",
+          "TR",
+          "TT",
+          "TV",
+          "TW",
+          "TZ",
+          "UA",
+          "UG",
+          "UM",
+          "US",
+          "UY",
+          "UZ",
+          "VA",
+          "VC",
+          "VE",
+          "VG",
+          "VI",
+          "VN",
+          "VU",
+          "WF",
+          "WS",
+          "YE",
+          "YT",
+          "ZA",
+          "ZM",
+          "ZW"
+        ]
+      }
+    },
+    "video": {
+      "type": "string",
+      "format": "uri",
+      "description": "Property. Model:'https://schema.org/URL'. Url with video related to the item"
+    }
+  }
+}

--- a/scripts/lib/ngsi-validate.mjs
+++ b/scripts/lib/ngsi-validate.mjs
@@ -1,0 +1,201 @@
+/**
+ * scripts/lib/ngsi-validate.mjs
+ *
+ * ADR-051 (FIWARE Smart Data Models como capa de interoperabilidad NGSI-LD),
+ * ítem de fase 1 "Validación conformidad NGSI-LD (ajv vs schemas oficiales)
+ * en CI": valida las entidades que emite `scripts/export-ngsi-ld.mjs` contra
+ * los JSON Schema **oficiales** de `smart-data-models/dataModel.Agrifood`,
+ * vendorizados en `scripts/fiware-schemas/` (ver `$comment` de cada archivo
+ * para la URL fuente y fecha de descarga).
+ *
+ * Nota importante sobre representación NGSI-LD vs. el schema oficial:
+ * el `schema.json` que publica smart-data-models valida la representación
+ * **simplificada** (`keyValues`) de la entidad — la misma que se ve en
+ * `AgriCrop/examples/example.json` upstream, donde `name` es un string
+ * plano, no `{type:'Property', value:'...'}`. Nuestro export produce la
+ * representación **normalizada NGSI-LD** (ETSI GS CIM 009, con `Property`/
+ * `Relationship` + `@context`), que es la forma correcta para interoperar
+ * con un broker NGSI-LD real (Orion-LD). Por eso este módulo aplana
+ * (`toSimplifiedEntity`) la entidad normalizada a `keyValues` ANTES de
+ * correr ajv — es el mismo paso que hacen las herramientas de la comunidad
+ * FIWARE (ej. `NGSI-LD keyValues` / `filip`) para poder reusar el schema
+ * oficial sin reescribirlo. El aplanado es solo para efectos de validación:
+ * `export-ngsi-ld.mjs` sigue emitiendo NGSI-LD normalizado tal cual.
+ *
+ * Atributos custom (`x-chagra-mip`) y `@context` no están restringidos por
+ * el schema oficial (no declara `additionalProperties: false`), así que
+ * quedan presentes en el objeto aplanado sin afectar el resultado — es
+ * justo el comportamiento que ADR-051 Decisión punto 4 pide (extensión
+ * propia declarada, no forzada en un campo FIWARE con otro significado).
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCHEMAS_DIR = join(__dirname, '..', 'fiware-schemas');
+
+/** Mapeo `type` NGSI-LD -> nombre de archivo del schema oficial vendorizado. */
+const SCHEMA_FILES_BY_TYPE = {
+  AgriCrop: 'AgriCrop.schema.json',
+  AgriPest: 'AgriPest.schema.json',
+};
+
+/** Cachés de módulo (evita releer/recompilar en cada llamada). */
+let ajvInstance = null;
+const validatorsByType = new Map();
+
+function readSchema(filename) {
+  const path = join(SCHEMAS_DIR, filename);
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+/**
+ * Construye (una sola vez, cacheado a nivel de módulo) la instancia ajv con
+ * los schemas comunes registrados (`common-schema.json`,
+ * `agrifood-schema.json`) que resuelven los `$ref` cruzados de
+ * `AgriCrop.schema.json` / `AgriPest.schema.json`.
+ *
+ * @returns {import('ajv/dist/2020').default}
+ */
+function getAjv() {
+  if (ajvInstance) return ajvInstance;
+
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  addFormats(ajv);
+
+  // Schemas de soporte (definen GSMA-Commons/EntityIdentifierType y
+  // AgriFood-Commons) — se registran por $id para que los `$ref` absolutos
+  // de AgriCrop/AgriPest resuelvan en local, sin red en tiempo de validación.
+  ajv.addSchema(readSchema('common-schema.json'));
+  ajv.addSchema(readSchema('agrifood-schema.json'));
+
+  ajvInstance = ajv;
+  return ajv;
+}
+
+/**
+ * Compila (cacheado) el validador ajv para un `type` NGSI-LD soportado.
+ *
+ * @param {'AgriCrop'|'AgriPest'} type
+ * @returns {import('ajv').ValidateFunction}
+ */
+function getValidatorForType(type) {
+  if (validatorsByType.has(type)) return validatorsByType.get(type);
+
+  const filename = SCHEMA_FILES_BY_TYPE[type];
+  if (!filename) {
+    throw new Error(
+      `No hay schema oficial vendorizado para type=${JSON.stringify(type)} `
+      + `(soportados: ${Object.keys(SCHEMA_FILES_BY_TYPE).join(', ')})`,
+    );
+  }
+
+  const schema = readSchema(filename);
+  const validate = getAjv().compile(schema);
+  validatorsByType.set(type, validate);
+  return validate;
+}
+
+/**
+ * Aplana un atributo NGSI-LD normalizado (`Property`/`Relationship`, o
+ * arrays de estos) a su valor `keyValues` equivalente, para poder validar
+ * contra el schema oficial (ver nota de cabecera del archivo).
+ *
+ * @param {unknown} attr
+ * @returns {unknown}
+ */
+function simplifyAttribute(attr) {
+  if (Array.isArray(attr)) {
+    return attr.map((item) => simplifyAttribute(item));
+  }
+  if (attr && typeof attr === 'object') {
+    if (attr.type === 'Relationship' && 'object' in attr) return attr.object;
+    if ('value' in attr) return attr.value;
+  }
+  return attr;
+}
+
+/**
+ * Convierte una entidad NGSI-LD normalizada (como las que emite
+ * `export-ngsi-ld.mjs`) a su representación `keyValues` simplificada, que es
+ * la que exige el `schema.json` oficial de smart-data-models. `id`/`type` se
+ * copian tal cual (ya son strings planos en ambas representaciones);
+ * `@context` se conserva (el schema oficial no lo prohíbe ni lo exige).
+ *
+ * @param {object} entity
+ * @returns {object}
+ */
+export function toSimplifiedEntity(entity) {
+  if (!entity || typeof entity !== 'object') return entity;
+
+  const simplified = {};
+  for (const [key, value] of Object.entries(entity)) {
+    if (key === 'id' || key === 'type' || key === '@context') {
+      simplified[key] = value;
+      continue;
+    }
+    simplified[key] = simplifyAttribute(value);
+  }
+  return simplified;
+}
+
+/**
+ * Valida una entidad NGSI-LD normalizada contra el JSON Schema oficial de
+ * smart-data-models correspondiente a su `type` (`AgriCrop`/`AgriPest`,
+ * únicos vendorizados hoy — ver `SCHEMA_FILES_BY_TYPE`).
+ *
+ * @param {object} entity - entidad NGSI-LD normalizada (con Property/Relationship)
+ * @returns {{valid: boolean, errors: string[]}}
+ */
+export function validateEntityAjv(entity) {
+  if (!entity || typeof entity !== 'object') {
+    return { valid: false, errors: ['entity no es un objeto'] };
+  }
+
+  const type = entity.type;
+  if (typeof type !== 'string' || !SCHEMA_FILES_BY_TYPE[type]) {
+    return {
+      valid: false,
+      errors: [
+        `type ausente o sin schema oficial vendorizado (soportados: `
+        + `${Object.keys(SCHEMA_FILES_BY_TYPE).join(', ')}): ${JSON.stringify(type)}`,
+      ],
+    };
+  }
+
+  const validate = getValidatorForType(type);
+  const simplified = toSimplifiedEntity(entity);
+  const valid = validate(simplified);
+
+  if (valid) return { valid: true, errors: [] };
+
+  const errors = (validate.errors ?? []).map((err) => {
+    const path = err.instancePath && err.instancePath.length > 0 ? err.instancePath : '(raíz)';
+    return `${path} ${err.message ?? err.keyword}`;
+  });
+  return { valid: false, errors };
+}
+
+/**
+ * Valida un array de entidades NGSI-LD contra los schemas oficiales.
+ * Devuelve un reporte agregado análogo a `validateAgriCropEntities` /
+ * `validateAgriPestEntities` de `export-ngsi-ld.mjs`.
+ *
+ * @param {object[]} entities
+ * @returns {{valid: boolean, invalidCount: number, details: Array<{id: string|null, type: string|null, errors: string[]}>}}
+ */
+export function validateEntitiesAjv(entities) {
+  const details = [];
+  for (const entity of Array.isArray(entities) ? entities : []) {
+    const { valid, errors } = validateEntityAjv(entity);
+    if (!valid) {
+      details.push({ id: entity?.id ?? null, type: entity?.type ?? null, errors });
+    }
+  }
+  return { valid: details.length === 0, invalidCount: details.length, details };
+}


### PR DESCRIPTION
## Summary
- Cierra el ítem de fase 1 de ADR-051 "Validación conformidad NGSI-LD (ajv vs schemas oficiales) en CI": las entidades que emite `scripts/export-ngsi-ld.mjs` (AgriCrop + AgriPest, #1913/#1917) ahora se validan contra los JSON Schema **oficiales** de `smart-data-models/dataModel.Agrifood`, no solo contra la validación estructural propia existente.
- Vendoriza los schemas oficiales en `scripts/fiware-schemas/` (`AgriCrop.schema.json`, `AgriPest.schema.json` + `common-schema.json`/`agrifood-schema.json` de los que dependen vía `$ref`) — descargados de `raw.githubusercontent.com/smart-data-models/dataModel.Agrifood` (Apache-2.0), byte-fieles salvo un `$comment` de proveniencia en cada uno.
- Agrega `scripts/lib/ngsi-validate.mjs` con validación real vía `ajv` (Ajv2020 + ajv-formats). Nota técnica importante documentada en el módulo: el `schema.json` oficial valida la representación NGSI **simplificada** (`keyValues`, valores planos), distinta de la **normalizada** NGSI-LD (`Property`/`Relationship`) que emitimos — el módulo aplana la entidad antes de validar (mismo paso que usan las herramientas de la comunidad FIWARE); el export en sí sigue emitiendo NGSI-LD normalizado sin cambios.
- `export-ngsi-ld.mjs` ahora corre ambas capas de validación (estructural propia + ajv oficial) en `main()` y falla con exit code 1 si cualquiera no pasa.
- Agrega `npm run validate:ngsi` (export + validación) para engancharlo a CI en una tarea aparte (no se tocan workflows de deploy en este PR).

## Test plan
- [x] `npx vitest run scripts/__tests__/ngsi-validate.test.mjs scripts/__tests__/export-ngsi-ld.test.mjs` — 76 tests, todos verdes (incluye: AgriCrop válida pasa, entidad malformada sin id/type falla, AgriPest válida pasa, atributo custom `x-chagra-mip` no rompe la validación oficial, muestra real de 30 species del catálogo OSS conforme al schema).
- [x] `npm run validate:ngsi` sobre el catálogo completo (530 species, 17 plagas) — validación estructural y ajv ambas OK, exit code 0.
- [x] `npx eslint scripts/export-ngsi-ld.mjs scripts/lib/ngsi-validate.mjs scripts/__tests__/ngsi-validate.test.mjs` — limpio.
- [x] Suite completa de vitest del repo corrida en paralelo — sin regresiones atribuibles a este cambio (3 fallas preexistentes en `agentService`/`networkRetry`, no tocadas por este PR).