### PR TITLE
chore(logs): limpiar console.log residuales (069.7)

### DIFF
--- a/src/db/catalogDB.js
+++ b/src/db/catalogDB.js
@@ -6,17 +6,17 @@ let initPromise = null;
 
 async function doInit() {
     const sqlite3 = await sqlite3InitModule({
-        print: console.log,
+        print: console.info,
         printErr: console.error,
     });
-    console.log('[SQLite WASM] Engine loaded successfully.');
+    console.info('[SQLite WASM] Engine loaded successfully.');
 
     // CHAGRA_TIER detection (#74): el blob SQLite puede venir del bundle
     // OSS (`/catalog.sqlite`) o de un CDN Pro override. corpusLoader
     // resuelve la URL, fetchea y valida magic header. Si TIER=PRO sin URL
     // set, hace fallback a OSS (no rompe deploy).
     const { buffer: uint8Array, source } = await loadCatalogBuffer();
-    console.log(`[SQLite WASM] Catalog loaded from ${source.url} (tier=${source.tier}${source.fallback ? ', fallback' : ''})`);
+    console.info(`[SQLite WASM] Catalog loaded from ${source.url} (tier=${source.tier}${source.fallback ? ', fallback' : ''})`);
 
     let db = null;
     if (sqlite3.opfs && typeof navigator !== 'undefined' && navigator.storage && navigator.storage.getDirectory) {
@@ -29,7 +29,7 @@ async function doInit() {
             await writable.close();
 
             db = new sqlite3.oo1.OpfsDb('/catalog.sqlite');
-            console.log('[SQLite WASM] Opened SQLite DB backed by OPFS');
+            console.info('[SQLite WASM] Opened SQLite DB backed by OPFS');
         } catch (e) {
             console.warn('[SQLite WASM] Failed to use OPFS cleanly in this thread. Falling back to memory...', e);
         }
@@ -44,7 +44,7 @@ async function doInit() {
             db.pointer, 'main', p, uint8Array.byteLength, uint8Array.byteLength, deserializeFlag
         );
         if (rc !== 0) throw new Error('Deserialize failed with code ' + rc);
-        console.log('[SQLite WASM] Opened SQLite DB locally from Memory deserialization');
+        console.info('[SQLite WASM] Opened SQLite DB locally from Memory deserialization');
     }
 
     // Validar shape mínimo: tabla species con rows. Si el CDN Pro sirvió un

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -123,7 +123,7 @@ export const openDB = async () => {
 
     request.onupgradeneeded = (event) => {
       const db = event.target.result;
-      console.log(`[DB] Upgrading schema to v${DB_VERSION}…`);
+      console.info(`[DB] Upgrading schema to v${DB_VERSION}…`);
 
       // pending_transactions (cola de salida — autoincrement + string uuids)
       if (!db.objectStoreNames.contains(STORES.PENDING_TX)) {

--- a/src/services/actionExecutor.js
+++ b/src/services/actionExecutor.js
@@ -182,7 +182,7 @@ async function logAuditTrail(proposal, operatorId, actionResult) {
       auditLog.push(entry);
       localStorage.setItem(ACTION_LOG_KEY, JSON.stringify(auditLog.slice(-100)));
     } else {
-      console.log('[ActionAudit]', entry);
+      console.info('[ActionAudit]', entry);
     }
   } catch (e) {
     console.warn('[ActionAudit] Failed to store:', e);

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -217,7 +217,7 @@ const isGoneBundle = (endpoint) =>
 
 export const fetchFromFarmOS = async (endpoint, options = {}, _retried = false) => {
   if (import.meta.env.VITE_DEMO_MODE === 'true') {
-    console.log(`[DEMO] blocked FarmOS call to ${endpoint}`);
+    console.info(`[DEMO] blocked FarmOS call to ${endpoint}`);
     return {};
   }
 

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -102,7 +102,7 @@ export const initiateAuthorizationCodeFlow = async (state) => {
  * @returns {Promise<{success: boolean, error?: string}>}
  */
 export const exchangeCodeForToken = async (code, state) => {
-    console.log('[Auth] Intercambiando code por token (PKCE)');
+    console.info('[Auth] Intercambiando code por token (PKCE)');
 
     // Validar state
     const savedState = await localforage.getItem('oauth_state');
@@ -172,7 +172,7 @@ export const exchangeCodeForToken = async (code, state) => {
  * @returns {Promise<{success: boolean, error?: string, deprecation?: string}>}
  */
 export const authenticateUser = async (username, password) => {
-    console.log('[Auth] Intentando login password grant (DEPRECATED) para:', username);
+    console.warn('[Auth] Intentando login password grant (DEPRECATED) para:', username);
 
     // Aviso de deprecation
     const daysUntilDeprecation = Math.max(0, Math.ceil(
@@ -326,7 +326,7 @@ export const refreshAccessToken = async () => {
             const expiresIn = Number(data.expires_in) || 3600;
             await localforage.setItem('farmos_token_expiry', Date.now() + expiresIn * 1000);
 
-            console.log('[Auth] access token renovado vía refresh_token grant.');
+            console.info('[Auth] access token renovado vía refresh_token grant.');
             return data.access_token;
         } catch (err) {
             // Red caída / timeout: NO es expiración del refresh. Devolvemos null

--- a/src/services/demoPersonaSeeds.js
+++ b/src/services/demoPersonaSeeds.js
@@ -612,7 +612,7 @@ export async function seedProfileData(profileId) {
 
     await new Promise((resolve, reject) => {
       tx.oncomplete = () => {
-        console.log(`[demoPersonaSeeds] Seeded profile: ${profileId} (${assetsToInsert.length} assets, ${processesToInsert.length} processes, ${logsToInsert.length} logs)`);
+        console.info(`[demoPersonaSeeds] Seeded profile: ${profileId} (${assetsToInsert.length} assets, ${processesToInsert.length} processes, ${logsToInsert.length} logs)`);
         resolve(true);
       };
       tx.onerror = () => reject(tx.error);

--- a/src/services/operatorIdentityService.js
+++ b/src/services/operatorIdentityService.js
@@ -36,7 +36,7 @@ export function getOrCreateAccountUUID() {
   if (uuid) return uuid;
   uuid = crypto.randomUUID();
   localStorage.setItem(ACCOUNT_UUID_KEY, uuid);
-  console.log('[operatorIdentity] Generated NEW account_uuid_master. Backup recommended.');
+  console.warn('[operatorIdentity] Generated NEW account_uuid_master. Backup recommended.');
   return uuid;
 }
 

--- a/src/services/payloadService.js
+++ b/src/services/payloadService.js
@@ -26,7 +26,6 @@ const resolveEndpoint = (type) =>
  * @returns {Promise<{success: boolean, message: string, data: any}>} Resultado de la operación
  */
 export const savePayload = async (type, payload) => {
-  console.log(`Payload Chagra (${type}):`, JSON.stringify(payload, null, 2));
   const endpoint = resolveEndpoint(type);
   if (navigator.onLine) {
     try {
@@ -222,7 +221,6 @@ export const savePayload = async (type, payload) => {
  * @param {object} payload - { data: { type, id, attributes, relationships? } }
  */
 export const updatePayload = async (type, logId, payload) => {
-  console.log(`PATCH Chagra (${type} #${logId}):`, JSON.stringify(payload, null, 2));
   const endpoint = `${resolveEndpoint(type)}/${logId}`;
   if (navigator.onLine) {
     try {

--- a/src/services/swRegistration.js
+++ b/src/services/swRegistration.js
@@ -198,7 +198,7 @@ export function registerServiceWorker(opts = {}) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' })
       .then((registration) => {
-        console.log('Service Worker registrado:', registration.scope);
+        console.info('Service Worker registrado:', registration.scope);
         if (typeof registration.update === 'function') {
           registration.update().catch(() => {});
         }

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -1014,10 +1014,10 @@ if (typeof window !== 'undefined') {
             _pending: false,
             _pendingReason: null,
           });
-          console.log(`[Sync] Activo ${id} liberado para actualización oficial.`);
+          console.info(`[Sync] Activo ${id} liberado para actualización oficial.`);
         }
       } else {
-        console.log(`[Sync] Log ${type}/${id} sincronizado — pull ${assetType} para captar inlines.`);
+        console.info(`[Sync] Log ${type}/${id} sincronizado — pull ${assetType} para captar inlines.`);
       }
 
       // 2. Pull dirigido al tipo afectado (no refresca los 4 tipos)

--- a/src/store/useLogStore.js
+++ b/src/store/useLogStore.js
@@ -117,7 +117,7 @@ if (typeof window !== 'undefined') {
         if (localLog.asset_id) {
           await useLogStore.getState().loadLogsForAsset(localLog.asset_id);
         }
-        console.log(`[Log-Sync] Log ${id} liberado y actualizado en UI.`);
+        console.info(`[Log-Sync] Log ${id} liberado y actualizado en UI.`);
       }
     } catch (err) {
       console.error('[LogStore-Listener] Error en liberación de flag:', err);


### PR DESCRIPTION
## Summary
- Auditados los ~19 `console.log` reales en `src/` (excluyendo tests, ejemplos en JSDoc y un string literal usado como término de blocklist).
- **Eliminados (2)**: dumps de payload completo sin condición en `payloadService.js` (`savePayload`/`updatePayload`) — debug residual, no aportaban valor operativo y ensuciaban la consola en cada guardado.
- **Cambiados a `console.info` (15)**: diagnósticos operativos legítimos (carga de SQLite WASM, upgrade de schema IndexedDB, auth flow, seeds de demo, registro de Service Worker, listeners de sync en `useAssetStore`/`useLogStore`), alineados con la convención ya usada en `syncManager.js`/`apiService.js`/`alertEngine.js`.
- **Cambiados a `console.warn` (2)**: `authService.js` (intento de login por flujo password grant DEPRECATED) y `operatorIdentityService.js` (generación de UUID crítico con backup recomendado) — ambos son avisos operativos que ameritan warn, no info.
- No se tocó ningún `console.warn` ni `console.error` existente. No hay cambios de lógica, solo el nivel/uso de los logs.

## Test plan
- [x] `npx vitest run` sobre los 8 archivos de test correspondientes a los módulos tocados (`actionExecutor`, `apiService`, `authService`, `operatorIdentityService`, `payloadService`, `swRegistration`, `useAssetStore`, `useLogStore.tenant`) — 114/114 tests verdes.
- [x] `npx vitest run` sobre `src/db/__tests__/*` (catalogDB/dbCore indirectos) + `voiceTelemetry.test.js` + `feedingAndCycleCoverage.test.js` + `promptAssembler.budget.test.js` — 164/164 tests verdes.
- [x] `npx eslint` sobre los 11 archivos tocados — 0 errores (solo warnings pre-existentes de i18n, no relacionados).