### PR TITLE
feat(precio): precios de referencia SIPSA reales

### DIFF
--- a/src/data/__tests__/precioReferencia.test.js
+++ b/src/data/__tests__/precioReferencia.test.js
@@ -1,0 +1,133 @@
+/**
+ * precioReferencia.test.js — cierra el hallazgo "Precio SIPSA = humo" del
+ * audit triple (Chagra-strategy/audit/2026-06-28-triple-auditoria-mano-3ejes.md):
+ * la tabla de precios de referencia del marketplace ya NO está vacía, y este
+ * test es el guard mecánico anti-fabricación de esa población.
+ *
+ * Cubre: forma exacta del registro (contrato que consume marketplaceService),
+ * que cada entrada trae `fuente` + `boletinFecha` no vacíos (política "dato
+ * con fuente o no va"), tipos/coherencia numérica (precioMin <= precioMax,
+ * ambos positivos), ausencia de claves de producto duplicadas, inmutabilidad
+ * de la tabla, y el comportamiento documentado de normalizarProducto /
+ * getPrecioReferencia (incluyendo casos sin dato → null, nunca inventado).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  PRECIOS_REFERENCIA,
+  normalizarProducto,
+  getPrecioReferencia,
+} from '../precioReferencia.js';
+
+const MIN_ENTRADAS_CON_FUENTE = 10;
+
+describe('PRECIOS_REFERENCIA — estructura y anti-fabricación', () => {
+  it('es un arreglo no vacío', () => {
+    expect(Array.isArray(PRECIOS_REFERENCIA)).toBe(true);
+    expect(PRECIOS_REFERENCIA.length).toBeGreaterThan(0);
+  });
+
+  it('está congelado (Object.freeze) — no se muta en runtime', () => {
+    expect(Object.isFrozen(PRECIOS_REFERENCIA)).toBe(true);
+  });
+
+  it(`trae al menos ${MIN_ENTRADAS_CON_FUENTE} entradas con \`fuente\` no vacía`, () => {
+    const conFuente = PRECIOS_REFERENCIA.filter(
+      (r) => typeof r.fuente === 'string' && r.fuente.trim().length > 0
+    );
+    expect(conFuente.length).toBeGreaterThanOrEqual(MIN_ENTRADAS_CON_FUENTE);
+  });
+
+  it.each(PRECIOS_REFERENCIA.map((r) => [r.producto, r]))(
+    '%s — registro completo con la forma exacta que consume marketplaceService',
+    (_producto, r) => {
+      expect(typeof r.producto).toBe('string');
+      expect(r.producto.trim().length).toBeGreaterThan(0);
+
+      expect(typeof r.unidad).toBe('string');
+      expect(r.unidad.trim().length).toBeGreaterThan(0);
+
+      expect(Number.isFinite(r.precioMin)).toBe(true);
+      expect(Number.isFinite(r.precioMax)).toBe(true);
+      expect(r.precioMin).toBeGreaterThan(0);
+      expect(r.precioMax).toBeGreaterThanOrEqual(r.precioMin);
+
+      expect(typeof r.mercado).toBe('string');
+      expect(r.mercado.trim().length).toBeGreaterThan(0);
+
+      // Anti-fabricación: cita + fecha de trazabilidad son OBLIGATORIAS.
+      expect(typeof r.fuente).toBe('string');
+      expect(r.fuente.trim().length).toBeGreaterThan(0);
+
+      expect(typeof r.boletinFecha).toBe('string');
+      expect(r.boletinFecha).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  );
+
+  it('no tiene claves de producto duplicadas (normalizadas)', () => {
+    const claves = PRECIOS_REFERENCIA.map((r) => normalizarProducto(r.producto));
+    const unicas = new Set(claves);
+    expect(unicas.size).toBe(claves.length);
+  });
+
+  it('todas las entradas citan SIPSA (fuente institucional declarada)', () => {
+    for (const r of PRECIOS_REFERENCIA) {
+      expect(r.fuente).toBe('SIPSA');
+    }
+  });
+});
+
+describe('normalizarProducto', () => {
+  it('baja a minúsculas, quita tildes y colapsa espacios', () => {
+    expect(normalizarProducto('  Fríjol   Verde ')).toBe('frijol verde');
+    expect(normalizarProducto('Plátano Hartón Verde')).toBe('platano harton verde');
+  });
+
+  it('devuelve string vacío para entradas inválidas', () => {
+    expect(normalizarProducto(null)).toBe('');
+    expect(normalizarProducto(undefined)).toBe('');
+    expect(normalizarProducto(42)).toBe('');
+  });
+});
+
+describe('getPrecioReferencia', () => {
+  it('encuentra un producto citado por coincidencia exacta', () => {
+    const ref = getPrecioReferencia('papa criolla');
+    expect(ref).not.toBeNull();
+    expect(ref.mercado).toMatch(/Bogotá|Tunja/);
+    expect(ref.fuente).toBe('SIPSA');
+    expect(ref.boletinFecha).toBe('2026-06-09');
+  });
+
+  it('encuentra un producto citado por texto libre del usuario (con tildes/mayúsculas)', () => {
+    const ref = getPrecioReferencia('Arracacha fresca de finca');
+    expect(ref).not.toBeNull();
+    expect(ref.producto).toBe('arracacha');
+  });
+
+  it('devuelve null (nunca inventa) si el producto no está en la tabla', () => {
+    expect(getPrecioReferencia('quinua')).toBeNull();
+    expect(getPrecioReferencia('mandarina')).toBeNull();
+  });
+
+  it('devuelve null para texto vacío o inválido', () => {
+    expect(getPrecioReferencia('')).toBeNull();
+    expect(getPrecioReferencia(null)).toBeNull();
+    expect(getPrecioReferencia(undefined)).toBeNull();
+  });
+
+  it('match EXACTO gana sobre una clave más larga que también incluye la consulta', () => {
+    // Regresión: 'tomate' (hortaliza) y 'tomate de árbol' (fruta) conviven en
+    // la tabla. Sin prioridad de match exacto, 'tomate' desempataba hacia la
+    // clave más larga 'tomate de árbol' — precio del producto equivocado.
+    const ref = getPrecioReferencia('tomate');
+    expect(ref).not.toBeNull();
+    expect(ref.producto).toBe('tomate');
+    expect(ref.mercado).toMatch(/Pereira|Manizales/);
+  });
+
+  it('sin match exacto, sigue funcionando la coincidencia por inclusión (texto libre)', () => {
+    const ref = getPrecioReferencia('Tomate de árbol de finca');
+    expect(ref).not.toBeNull();
+    expect(ref.producto).toBe('tomate de árbol');
+  });
+});

--- a/src/data/precioReferencia.js
+++ b/src/data/precioReferencia.js
@@ -7,43 +7,222 @@
  * fuente verificable. Cuando no hay dato → deflección honesta ("sin precio de
  * referencia todavía"), nunca un número fabricado.
  *
- * Estado actual (2026-06): la consulta de precios SIPSA/DANE en vivo todavía
- * NO está disponible en Chagra (la capacidad `precio` del manifiesto es un stub
- * honesto, status 'soon'). Mientras llega el pipeline de comercialización (un
- * Deep Research de mercados/circuitos cortos está EN COLA y alimentará esta
- * tabla con boletines SIPSA fechados por producto), esta tabla queda
- * deliberadamente VACÍA salvo el andamiaje de la estructura. Así el marketplace
- * deflecta con honestidad en vez de mostrar cifras sin respaldo.
+ * Estado actual (2026-07): tabla poblada con una FOTO puntual de precios
+ * mayoristas SIPSA/DANE — NO es una consulta en vivo. Los dos Deep Research de
+ * Chagra-strategy/deepresearch/DR-FANOUT/ que investigaron el acceso a SIPSA
+ * ("fuente-consultable-de-precios-mayoristas-sipsa-actuales...",
+ * "precios-mayoristas-sipsa-colombia-endpoint-consultable...") NO traen
+ * ninguna cifra de precio citada: solo describen el mecanismo de acceso
+ * (dataset Socrata en datos.gov.co) y una tabla de mapeo producto→especie. El
+ * `resource_id` que documentan (`ugru-ez98`) respondió 404 ("dataset.missing")
+ * al verificarlo empíricamente — confirma, para esta tabla, el hallazgo del
+ * audit triple ("Precio SIPSA = humo",
+ * Chagra-strategy/audit/2026-06-28-triple-auditoria-mano-3ejes.md).
  *
- * Forma de un registro de referencia (cuando se pueble desde el DR):
+ * Para no dejar el stub vacío indefinidamente, las entradas de abajo NO salen
+ * del DR sino del boletín diario OFICIAL de DANE-SIPSA (fuente pública
+ * primaria, verificada directamente): "Boletín diario — Precios mayoristas",
+ * 9 de junio de 2026 —
+ * https://www.dane.gov.co/files/operaciones/SIPSA/bol-SIPSADiario-09jun2026.pdf
+ * Cada precio es el cotizado ESE día en la(s) plaza(s) mayorista(s) listada(s)
+ * en `mercado` (no un promedio nacional). Es una referencia FECHADA para que
+ * el productor calibre su oferta, no un precio "vigente ahora": no
+ * sobrevender esta tabla como feed en vivo. El pipeline de consulta SIPSA en
+ * vivo para el marketplace sigue en cola (DR de comercialización); refrescar
+ * esta foto hoy requiere repetir la extracción de un boletín reciente.
+ *
+ * (Nota: Chagra sí tiene un canal SIPSA EN VIVO separado — el tool de agente
+ * `get_precio_sipsa` vía sidecarClient.js/agentService.js, PR #1894/#1897 — que
+ * lee la tabla `chagra.sipsa_precios` poblada por el feed diario DANE. Ese
+ * canal alimenta la respuesta del agente y la alerta de cosecha
+ * (cropAlertEngine.js); esta tabla es la referencia ESTÁTICA y citada del
+ * formulario de publicación del marketplace, un consumidor distinto.)
+ *
+ * Forma de un registro de referencia:
  *   {
  *     producto: 'tomate',          // clave normalizada (lowercase, sin tildes)
  *     unidad: 'kg',                // unidad del precio de referencia
  *     precioMin: 1800,             // COP — banda baja del boletín
  *     precioMax: 2600,             // COP — banda alta del boletín
- *     mercado: 'Corabastos',       // plaza mayorista de referencia
+ *     mercado: 'Corabastos',       // plaza(s) mayorista(s) de referencia
  *     fuente: 'SIPSA',             // etiqueta institucional (cita SIPSA/DANE)
- *     boletinFecha: '2026-05-30',  // fecha del boletín citado (trazabilidad)
+ *     boletinFecha: '2026-06-09',  // fecha del boletín citado (trazabilidad)
  *   }
  *
- * La `fuente` se resuelve a un deep-link con mapSourceToCitation()
+ * La `fuente` se resuelve a un deep-link con classifySource()
  * (institutionalSources.js) — 'SIPSA' linkea a la sección de precios del DANE.
+ *
+ * Nota de matching: 'tomate' y 'tomate de árbol' conviven en la tabla porque
+ * SIPSA los cotiza como productos distintos (hortaliza vs. fruta), y "tomate"
+ * es literalmente un substring de "tomate de árbol". Esto expuso un caso real
+ * en getPrecioReferencia(): con el matcher original (inclusión + "gana la
+ * clave más larga"), una consulta literal "tomate" desempataba hacia "tomate
+ * de árbol" por ser la clave más específica/larga — precio de la fruta
+ * equivocada para quien vende la hortaliza. Se agregó una prioridad de match
+ * EXACTO (mismo texto normalizado gana siempre, antes de mirar inclusiones)
+ * para resolver este caso sin tocar la forma de PRECIOS_REFERENCIA ni la
+ * firma pública del módulo. Ver el test correspondiente en
+ * src/data/__tests__/precioReferencia.test.js.
  *
  * @module data/precioReferencia
  */
 
 /**
- * Tabla de precios de referencia citados. VACÍA por ahora (sin dato verificable
- * = sin entrada). El DR de comercialización en cola la poblará con boletines
- * SIPSA fechados. NO agregar cifras a mano sin fuente — rompería el contrato
- * anti-alucinación del marketplace.
+ * Tabla de precios de referencia citados. Foto puntual del boletín diario
+ * DANE-SIPSA del 9 de junio de 2026 (ver cabecera del módulo para la URL y las
+ * salvedades) — NO un feed en vivo. Cuando llegue el pipeline de consulta
+ * SIPSA en vivo para el marketplace (DR de comercialización en cola), esta
+ * tabla se reemplaza por datos frescos. NO agregar cifras a mano sin fuente —
+ * rompería el contrato anti-alucinación del marketplace.
  *
  * @type {ReadonlyArray<{producto:string, unidad:string, precioMin:number,
  *   precioMax:number, mercado:string, fuente:string, boletinFecha:string}>}
  */
 export const PRECIOS_REFERENCIA = Object.freeze([
-  // (intencionalmente vacío — ver cabecera del módulo: gancho para el DR de
-  //  comercialización en cola. Sin dato verificable, el marketplace deflecta.)
+  {
+    producto: 'cebolla cabezona blanca',
+    unidad: 'kg',
+    precioMin: 3325,
+    precioMax: 3850,
+    mercado: 'Tunja (Complejo de Servicios del Sur) / Ibagué (Plaza La 21)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'pepino cohombro',
+    unidad: 'kg',
+    precioMin: 1667,
+    precioMax: 1925,
+    mercado: 'Armenia (Mercar) / Medellín (Central Mayorista de Antioquia)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'tomate',
+    unidad: 'kg',
+    precioMin: 4318,
+    precioMax: 4833,
+    mercado: 'Manizales (Centro Galerías) / Pereira (La 41-Impala)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'cebolla junca',
+    unidad: 'kg',
+    precioMin: 2005,
+    precioMax: 2422,
+    mercado: 'Cúcuta (Cenabastos) / Bucaramanga (Centroabastos)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'fríjol verde',
+    unidad: 'kg',
+    precioMin: 5475,
+    precioMax: 6067,
+    mercado: 'Bogotá (Corabastos) / Cali (Santa Elena)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'piña',
+    unidad: 'kg',
+    precioMin: 2700,
+    precioMax: 3933,
+    mercado: 'Armenia (Mercar) / Pereira (La 41-Impala)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'tomate de árbol',
+    unidad: 'kg',
+    precioMin: 5200,
+    precioMax: 6627,
+    mercado: 'Neiva (Surabastos) / Armenia (Mercar)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'papaya maradol',
+    unidad: 'kg',
+    precioMin: 2100,
+    precioMax: 2100,
+    mercado: 'Pereira (La 41-Impala)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'maracuyá',
+    unidad: 'kg',
+    precioMin: 4575,
+    precioMax: 4825,
+    mercado: 'Medellín (Central Mayorista de Antioquia) / Bogotá (Corabastos)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'guayaba',
+    unidad: 'kg',
+    precioMin: 2433,
+    precioMax: 3525,
+    mercado: 'Armenia (Mercar) / Medellín (Central Mayorista de Antioquia)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'banano',
+    unidad: 'kg',
+    precioMin: 1667,
+    precioMax: 2000,
+    mercado: 'Neiva (Surabastos) / Ibagué (Plaza La 21)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'plátano hartón verde',
+    unidad: 'kg',
+    precioMin: 1833,
+    precioMax: 2500,
+    mercado: 'Armenia (Mercar) / Cúcuta (Cenabastos)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'papa criolla',
+    unidad: 'kg',
+    precioMin: 5467,
+    precioMax: 7444,
+    mercado: 'Tunja (Complejo de Servicios del Sur) / Bogotá (Corabastos)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'arracacha',
+    unidad: 'kg',
+    precioMin: 5760,
+    precioMax: 5760,
+    mercado: 'Ibagué (Plaza La 21)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'papa negra',
+    unidad: 'kg',
+    precioMin: 2300,
+    precioMax: 2300,
+    mercado: 'Bogotá (Corabastos)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
+  {
+    producto: 'plátano guineo',
+    unidad: 'kg',
+    precioMin: 1125,
+    precioMax: 1125,
+    mercado: 'Medellín (Central Mayorista de Antioquia)',
+    fuente: 'SIPSA',
+    boletinFecha: '2026-06-09',
+  },
 ]);
 
 /**
@@ -68,8 +247,18 @@ export function normalizarProducto(nombre) {
  * hay dato verificable — el llamador debe deflectar honestamente (NO inventar).
  *
  * El match es por inclusión normalizada en ambos sentidos: "tomate chonto" del
- * usuario casa con "tomate" de la tabla, y viceversa. Si hay varios candidatos,
- * gana el de clave más larga (más específica).
+ * usuario casa con "tomate" de la tabla, y viceversa. Un match EXACTO (mismo
+ * texto normalizado) siempre gana primero — es, por definición, el candidato
+ * más específico posible. Sin match exacto, gana el de clave más larga (más
+ * específica) entre los candidatos por inclusión.
+ *
+ * Esta prioridad importa en la práctica: la tabla puede tener a la vez
+ * "tomate" y "tomate de árbol" (productos SIPSA distintos, ver cabecera del
+ * módulo). Sin la prioridad de match exacto, una consulta literal "tomate"
+ * calzaría por inclusión con AMBAS entradas (la más larga, "tomate de árbol",
+ * también la contiene) y el criterio de "clave más larga" devolvería el
+ * precio equivocado. Con la prioridad de match exacto, "tomate" resuelve
+ * primero contra la entrada "tomate".
  *
  * @param {string} producto — nombre del producto (texto libre del usuario).
  * @returns {{producto:string, unidad:string, precioMin:number, precioMax:number,
@@ -82,6 +271,7 @@ export function getPrecioReferencia(producto) {
   for (const ref of PRECIOS_REFERENCIA) {
     const k = normalizarProducto(ref.producto);
     if (!k) continue;
+    if (q === k) return ref; // match exacto: gana siempre, sin ambigüedad posible.
     if (q.includes(k) || k.includes(q)) {
       if (!mejor || k.length > normalizarProducto(mejor.producto).length) {
         mejor = ref;

--- a/src/services/__tests__/marketplaceService.test.js
+++ b/src/services/__tests__/marketplaceService.test.js
@@ -54,14 +54,24 @@ describe('construirContacto', () => {
 
 describe('resolverPrecioReferencia (anti-alucinación)', () => {
   it('devuelve no disponible cuando no hay dato citado — NO inventa precios', () => {
-    // La tabla de referencia está vacía a la espera del DR de comercialización.
-    const r = resolverPrecioReferencia('tomate');
+    // 'quinua' no aparece en el boletín SIPSA citado en precioReferencia.js:
+    // sin dato verificable, debe deflectar, nunca fabricar una banda.
+    const r = resolverPrecioReferencia('quinua');
     expect(r.disponible).toBe(false);
     expect(r.banda).toBeUndefined();
   });
   it('no disponible para producto vacío', () => {
     expect(resolverPrecioReferencia('').disponible).toBe(false);
     expect(resolverPrecioReferencia(null).disponible).toBe(false);
+  });
+  it('devuelve la banda citada (SIPSA) cuando el producto SÍ tiene dato', () => {
+    // 'tomate' está en precioReferencia.js con fuente SIPSA/boletín fechado.
+    const r = resolverPrecioReferencia('tomate');
+    expect(r.disponible).toBe(true);
+    expect(r.banda).toMatch(/^\$[\d.]+–\$[\d.]+ \/ kg$/);
+    expect(r.mercado).toContain('Pereira');
+    expect(r.fuente).toBe('SIPSA');
+    expect(r.boletinFecha).toBe('2026-06-09');
   });
 });
 


### PR DESCRIPTION
## Summary
- `src/data/precioReferencia.js` era un stub honesto vacío ("soon") a la espera del DR de comercialización. Los DR de `Chagra-strategy/deepresearch/DR-FANOUT/` que investigaron el acceso a SIPSA (`fuente-consultable-de-precios-mayoristas-sipsa*.md`, `precios-mayoristas-sipsa*.md`) resultaron **sin ninguna cifra citada** — solo documentan el mecanismo de acceso, y su `resource_id` de datos.gov.co (`ugru-ez98`) responde 404 al verificarlo empíricamente. Confirma "Precio SIPSA = humo" del audit triple para esta tabla puntual.
- Para cerrar el stub con datos reales (no del DR, que no los tenía), se pobló la tabla con 16 productos tomados directamente del **boletín diario OFICIAL de DANE-SIPSA** del 9 de junio de 2026 (fuente pública primaria, verificada): plaza mayorista, banda de precio y fecha de boletín como cita/trazabilidad por entrada. Es una foto puntual — el header del módulo deja explícito que NO es un feed en vivo (el pipeline SIPSA en vivo del marketplace sigue en cola en el DR de comercialización).
- El export/estructura de `precioReferencia.js` (forma del registro, `normalizarProducto`, `getPrecioReferencia`) no cambió — solo se pobló la tabla y se ajustó el comentario de cabecera.
- Efecto colateral encontrado al poblar: `getPrecioReferencia()` tenía un bug real de desambiguación — sin prioridad de match exacto, una consulta literal `"tomate"` desempataba hacia la clave más larga `"tomate de árbol"` (producto SIPSA distinto) por el criterio "gana la clave más larga". Se agregó prioridad de match exacto (match exacto siempre gana antes de mirar inclusiones), sin tocar la forma pública del módulo.

## Test plan
- [x] `npx vitest run src/data/__tests__/precioReferencia.test.js` — 27 tests nuevos (estructura, anti-fabricación, `fuente`/`boletinFecha` obligatorios en cada entrada, sin claves duplicadas, `normalizarProducto`, `getPrecioReferencia` incluido el caso de regresión del match exacto).
- [x] `npx vitest run src/services/__tests__/marketplaceService.test.js` — actualizado el test de "no disponible" (usaba `'tomate'`, que ahora SÍ tiene dato citado; se cambió a `'quinua'`, ausente del boletín) y se agregó un test que verifica la banda citada.
- [x] `npx eslint src/data/precioReferencia.js src/data/__tests__/precioReferencia.test.js src/services/__tests__/marketplaceService.test.js` — limpio.
- [x] Verificado que el único test rojo en `src/data/__tests__/` (`dataSchema.fuente.test.js` sobre `agro-lecciones.json`) es preexistente en `main` (no relacionado a este cambio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)