### PR TITLE
feat(age): loader genérico de aristas DR → Cypher chagra_kg (build + dry-run)

### DIFF
--- a/scripts/__tests__/load-age-graph-gaps.test.mjs
+++ b/scripts/__tests__/load-age-graph-gaps.test.mjs
@@ -1,0 +1,346 @@
+/**
+ * scripts/__tests__/load-age-graph-gaps.test.mjs
+ *
+ * Cobertura unitaria del loader/generador de Cypher para DRs "de huecos" y
+ * "de aristas por especie". NO toca red ni postgres real — solo valida los
+ * parsers de tabla markdown, la curación anti-alucinación/CO-strict y la
+ * generación de Cypher determinista sobre fixtures sintéticos que imitan el
+ * formato real observado en las DRs (incluyendo casos degenerados reales:
+ * filas truncadas y tablas de índice de fuentes que NO son aristas).
+ */
+import { describe, it, expect } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  splitTableRow,
+  isSeparatorRow,
+  findMarkdownTables,
+  classifyEdgeHeader,
+  extractRawEdgesFromText,
+  slugifyId,
+  sanitizeRelType,
+  normalizeConfianza,
+  isColombiaScopedText,
+  curateRawEdges,
+  buildCypherStatements,
+  drIdFromPath,
+  processDrFile,
+  buildDryRunReport,
+  formatReportText,
+  parseArgs,
+  KNOWN_RELATION_TYPES,
+  NODE_LABEL,
+} from '../load-age-graph-gaps.mjs';
+
+describe('splitTableRow / isSeparatorRow', () => {
+  it('divide una fila con pipes en celdas trimmeadas', () => {
+    expect(splitTableRow('| a | b  | c|')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('respeta pipes escapados (`\\|`) dentro de una celda — regresión real (aristas-grafo-annonasquamosa)', () => {
+    // Fila real observada: un pipe escapado dentro de "fuente" desplazaba la
+    // columna "confianza" al valor equivocado (bug encontrado corriendo el
+    // dry-run contra el corpus real antes de este fix).
+    const line = '| annona_muricata | ANTAGONIST_OF | annona_squamosa | Annona squamosa (sugar apple) \\| CABI Compendium (sin DOI verificado) | alta |';
+    expect(splitTableRow(line)).toEqual([
+      'annona_muricata',
+      'ANTAGONIST_OF',
+      'annona_squamosa',
+      'Annona squamosa (sugar apple) | CABI Compendium (sin DOI verificado)',
+      'alta',
+    ]);
+  });
+
+  it('reconoce filas separadoras con alineación izquierda/centrada/derecha', () => {
+    expect(isSeparatorRow([':----', '-----', '----:'])).toBe(true);
+    expect(isSeparatorRow(['a', '----'])).toBe(false);
+  });
+});
+
+describe('findMarkdownTables', () => {
+  it('detecta una tabla bien-formada con header + separador + filas', () => {
+    const text = [
+      '# DR x',
+      '',
+      '| origen_id | TIPO | destino_id | fuente | confianza |',
+      '|:----------|:-----|:-----------|:-------|:----------|',
+      '| a | AFFECTS | b | fuente 1 | alta |',
+      '',
+    ].join('\n');
+    const tables = findMarkdownTables(text);
+    expect(tables).toHaveLength(1);
+    expect(tables[0].rows).toEqual([['a', 'AFFECTS', 'b', 'fuente 1', 'alta']]);
+  });
+
+  it('ignora un header sin fila separadora inmediata (caso real: DR degenerado sin filas)', () => {
+    const text = [
+      '### Entregable',
+      '',
+      '| origen_id | TIPO | destino_id | fuente |',
+      '',
+      '',
+    ].join('\n');
+    expect(findMarkdownTables(text)).toHaveLength(0);
+  });
+
+  it('detecta múltiples tablas en el mismo documento', () => {
+    const text = [
+      '| origen_id | TIPO | destino_id | fuente | confianza |',
+      '|:--|:--|:--|:--|:--|',
+      '| a | X | b | f | alta |',
+      '',
+      'prosa en el medio',
+      '',
+      '| Aspecto | Detalle |',
+      '| :--- | :--- |',
+      '| x | y |',
+    ].join('\n');
+    expect(findMarkdownTables(text)).toHaveLength(2);
+  });
+});
+
+describe('classifyEdgeHeader', () => {
+  it('reconoce el header canónico origen_id/TIPO/destino_id/fuente/confianza', () => {
+    const cols = classifyEdgeHeader(['origen_id', 'TIPO', 'destino_id', 'fuente', 'confianza']);
+    expect(cols).toEqual({ origenIdx: 0, tipoIdx: 1, destinoIdx: 2, fuenteIdx: 3, confianzaIdx: 4 });
+  });
+
+  it('reconoce la variante NodoA (slug)/Relación/NodoB (slug)/Fuente/Confianza', () => {
+    const cols = classifyEdgeHeader(['NodoA (slug)', 'Relación', 'NodoB (slug)', 'Fuente', 'Confianza']);
+    expect(cols).not.toBeNull();
+    expect(cols.origenIdx).toBe(0);
+    expect(cols.tipoIdx).toBe(1);
+    expect(cols.destinoIdx).toBe(2);
+  });
+
+  it('reconoce columnas extra al final (p.ej. "slugs genero_especie") sin romper', () => {
+    const cols = classifyEdgeHeader(['origen_id', 'TIPO', 'destino_id', 'fuente', 'confianza', 'slugs genero_especie']);
+    expect(cols).not.toBeNull();
+  });
+
+  it('rechaza una tabla de índice de fuentes (Origen_ID | TIPO | Fuente | Confianza, sin destino) — caso real observado', () => {
+    // Este header aparece en una DR real (micorrizas) como sección "9. Fuentes
+    // (DOIs/URLs)" — comparte nombres de columna con la tabla de aristas pero
+    // NO es una arista (no hay destino). Debe clasificar como null.
+    const cols = classifyEdgeHeader(['Origen_ID', 'TIPO', 'Fuente', 'Confianza']);
+    expect(cols).toBeNull();
+  });
+
+  it('rechaza tablas de dominio no-arista (Cultivo/Problema/Manejo/...)', () => {
+    const cols = classifyEdgeHeader(['Cultivo', 'Problema', 'Agente científico', 'Manejo', 'Dosis', 'Confianza']);
+    expect(cols).toBeNull();
+  });
+});
+
+describe('extractRawEdgesFromText', () => {
+  it('extrae filas válidas y cuenta filas malformadas (fila truncada real: physalisperuviana)', () => {
+    const text = [
+      '| origen_id | TIPO | destino_id | fuente | confianza |',
+      '|:----------|:-----|:-----------|:-------|:----------|',
+      '| fusarium_oxysporum_f_sp_physali | AFFECTS | physalis_peruviana | AGROSAVIA | alta |',
+      '| rhizoglomus_irregulare | CONTROLS | fusarium_oxysporum_f_sp_physali | AGROSAVIA (SciELO) | alta |',
+      '| bacillus_subtilis | CONTROLS',
+    ].join('\n');
+    const { tablesFound, edgeTablesFound, rawEdges, malformedRowCount } = extractRawEdgesFromText(text);
+    expect(tablesFound).toBe(1);
+    expect(edgeTablesFound).toBe(1);
+    expect(rawEdges).toHaveLength(2);
+    expect(malformedRowCount).toBe(1);
+  });
+
+  it('ignora filas con celdas vacías en origen/tipo/destino como malformadas', () => {
+    const text = [
+      '| NodoA | Relación | NodoB | Fuente | Confianza |',
+      '| :---- | :------- | :---- | :----- | :-------- |',
+      '| fuego | AFFECTS | suelo | | Alta |',
+      '|  |  |  | | Alta |',
+    ].join('\n');
+    const { rawEdges, malformedRowCount } = extractRawEdgesFromText(text);
+    expect(rawEdges).toHaveLength(1);
+    expect(rawEdges[0].fuente).toBe('');
+    expect(malformedRowCount).toBe(1);
+  });
+});
+
+describe('sanitizeRelType / slugifyId / normalizeConfianza', () => {
+  it('sanitiza TIPO a mayúsculas + underscore', () => {
+    expect(sanitizeRelType('POLINIZA')).toBe('POLINIZA');
+    expect(sanitizeRelType('Tipo de suelo')).toBe('TIPO_DE_SUELO');
+    expect(sanitizeRelType('  ')).toBeNull();
+    expect(sanitizeRelType('')).toBeNull();
+  });
+
+  it('prefija REL_ si el tipo empieza con dígito', () => {
+    expect(sanitizeRelType('2x_control')).toBe('REL_2X_CONTROL');
+  });
+
+  it('normaliza ids a slug lowercase con espacios->underscore', () => {
+    expect(slugifyId(' Passiflora Ligularis ')).toBe('passiflora_ligularis');
+  });
+
+  it('normaliza confianza conocida y marca desconocida/vacía', () => {
+    expect(normalizeConfianza('Alta')).toBe('alta');
+    expect(normalizeConfianza('MEDIA')).toBe('media');
+    expect(normalizeConfianza('')).toBe('sin_dato');
+    expect(normalizeConfianza('rara')).toBe('sin_normalizar');
+  });
+});
+
+describe('isColombiaScopedText', () => {
+  it('reconoce scope Colombia/Andes/páramo en el título+intro', () => {
+    expect(isColombiaScopedText('# DR foo en Colombia\nintro')).toBe(true);
+    expect(isColombiaScopedText('# DR páramo andino\nintro')).toBe(true);
+    expect(isColombiaScopedText('# DR genérico global\nsin scope regional')).toBe(false);
+  });
+});
+
+describe('curateRawEdges', () => {
+  const raw = [
+    { origen: 'a', tipo: 'AFFECTS', destino: 'b', fuente: 'fuente 1', confianza: 'alta' },
+    { origen: 'a', tipo: 'AFFECTS', destino: 'b', fuente: 'fuente 1', confianza: 'alta' }, // duplicado exacto
+    { origen: 'c', tipo: 'CONTROLS', destino: 'd', fuente: '', confianza: 'alta' }, // sin fuente
+    { origen: '', tipo: 'AFFECTS', destino: 'x', fuente: 'y', confianza: 'alta' }, // nodo vacío
+  ];
+
+  it('acepta la primera ocurrencia y descarta duplicado/sin-fuente/nodo-vacío', () => {
+    const { accepted, rejected, byReason } = curateRawEdges(raw, { drScoped: true, drId: 'dr-test' });
+    expect(accepted).toHaveLength(1);
+    expect(accepted[0]).toMatchObject({ origen: 'a', tipo: 'AFFECTS', destino: 'b', drId: 'dr-test' });
+    expect(byReason.duplicado).toBe(1);
+    expect(byReason.sin_fuente).toBe(1);
+    expect(byReason.nodo_vacio).toBe(1);
+    expect(rejected).toHaveLength(3);
+  });
+
+  it('descarta TODO si el DR no está CO/Andes-scoped (defensivo)', () => {
+    const { accepted, byReason } = curateRawEdges(raw, { drScoped: false, drId: 'dr-test' });
+    expect(accepted).toHaveLength(0);
+    expect(byReason.dr_no_co_scoped).toBe(raw.length);
+  });
+
+  it('marca isKnownRelationType usando el snapshot de INFRA_FACTS', () => {
+    const { accepted } = curateRawEdges(
+      [{ origen: 'a', tipo: 'CONTROLS', destino: 'b', fuente: 'f', confianza: 'alta' }],
+      { drScoped: true, drId: 'x' },
+    );
+    expect(accepted[0].isKnownRelationType).toBe(true);
+    expect(KNOWN_RELATION_TYPES.has('CONTROLS')).toBe(true);
+    expect(KNOWN_RELATION_TYPES.has('POLINIZA')).toBe(false);
+  });
+});
+
+describe('buildCypherStatements', () => {
+  it('dedupea el MERGE de nodo por id repetido entre varias aristas', () => {
+    const accepted = [
+      { origen: 'a', tipo: 'AFFECTS', destino: 'b', fuente: 'f1', confianza: 'alta', drId: 'dr1' },
+      { origen: 'a', tipo: 'CONTROLS', destino: 'c', fuente: 'f2', confianza: 'media', drId: 'dr1' },
+    ];
+    const { statements, nodeCount } = buildCypherStatements(accepted, { dateStr: '2026-07-01' });
+    expect(nodeCount).toBe(3); // a, b, c — 'a' solo una vez pese a aparecer 2 veces
+    const nodeMerges = statements.filter((s) => s.includes(`MERGE (n:${NODE_LABEL}`));
+    expect(nodeMerges).toHaveLength(3);
+    const relMerges = statements.filter((s) => s.includes('MERGE (a)-[r:'));
+    expect(relMerges).toHaveLength(2);
+  });
+
+  it('usa MATCH (no MERGE) para los endpoints de la arista — los nodos ya se mergearon antes', () => {
+    const accepted = [{ origen: 'a', tipo: 'AFFECTS', destino: 'b', fuente: 'f1', confianza: 'alta', drId: 'dr1' }];
+    const { statements } = buildCypherStatements(accepted, { dateStr: '2026-07-01' });
+    const rel = statements.find((s) => s.includes('MERGE (a)-[r:'));
+    expect(rel).toContain(`MATCH (a:${NODE_LABEL} {id: 'a'})`);
+    expect(rel).toContain(`MATCH (b:${NODE_LABEL} {id: 'b'})`);
+  });
+
+  it('escapa comillas simples en la fuente vía cypherLiteral (reuso de catalog-to-age.mjs)', () => {
+    const accepted = [{ origen: 'a', tipo: 'AFFECTS', destino: 'b', fuente: "Restrepo's bocashi", confianza: 'alta', drId: 'dr1' }];
+    const { statements } = buildCypherStatements(accepted, { dateStr: '2026-07-01' });
+    const rel = statements.find((s) => s.includes('MERGE (a)-[r:'));
+    expect(rel).toContain("Restrepo\\'s bocashi");
+  });
+});
+
+describe('drIdFromPath / processDrFile', () => {
+  it('deriva el drId del nombre de archivo sin extensión', () => {
+    expect(drIdFromPath('/x/y/aristas-grafo-foo.md')).toBe('aristas-grafo-foo');
+  });
+
+  it('procesa un DR completo de punta a punta (fixture en disco)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'age-graph-gaps-test-'));
+    const filePath = join(dir, 'aristas-grafo-fixture.md');
+    writeFileSync(filePath, [
+      '# DR aristas-grafo-fixture — colombia',
+      '',
+      'Dossier de prueba en Colombia.',
+      '',
+      '| origen_id | TIPO | destino_id | fuente | confianza |',
+      '|:----------|:-----|:-----------|:-------|:----------|',
+      '| xylocopa_spp | POLINIZA | fixture_species | Fuente real 2020 | alta |',
+      '| thrips_spp | AFFECTS | fixture_species | | media |',
+      '| xylocopa_spp | POLINIZA | fixture_species | Fuente real 2020 | alta |',
+    ].join('\n'), 'utf8');
+
+    try {
+      const result = processDrFile(filePath);
+      expect(result.drId).toBe('aristas-grafo-fixture');
+      expect(result.drScoped).toBe(true);
+      expect(result.edgeTablesFound).toBe(1);
+      expect(result.acceptedCount).toBe(1);
+      expect(result.rejectedByReason.sin_fuente).toBe(1);
+      expect(result.rejectedByReason.duplicado).toBe(1);
+      expect(result.relationTypeCounts.POLINIZA).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildDryRunReport / formatReportText', () => {
+  it('agrega totales, motivos de descarte y tipos nuevos vs conocidos', () => {
+    const perDr = [
+      {
+        drId: 'dr-a',
+        drScoped: true,
+        tablesFound: 1,
+        edgeTablesFound: 1,
+        rawEdgeCount: 2,
+        malformedRowCount: 0,
+        acceptedCount: 1,
+        rejectedCount: 1,
+        rejectedByReason: { sin_fuente: 1 },
+        relationTypeCounts: { POLINIZA: 1 },
+        accepted: [{ origen: 'a', tipo: 'POLINIZA', destino: 'b', fuente: 'f', confianza: 'alta', drId: 'dr-a', isKnownRelationType: false }],
+        rejected: [{ reason: 'sin_fuente' }],
+      },
+    ];
+    const report = buildDryRunReport(perDr);
+    expect(report.totals.accepted).toBe(1);
+    expect(report.totals.rejected).toBe(1);
+    expect(report.totals.newNodeIds).toBe(2);
+    expect(report.rejectedByReason.sin_fuente).toBe(1);
+    expect(report.newRelationTypes).toEqual(['POLINIZA']);
+
+    const text = formatReportText(report);
+    expect(text).toContain('DRY-RUN');
+    expect(text).toContain('POLINIZA');
+    expect(text).toContain('sin_fuente');
+  });
+});
+
+describe('parseArgs', () => {
+  it('acumula múltiples --glob y --file', () => {
+    const opts = parseArgs(['--dr-dir', '/x', '--glob', 'aristas-grafo-*.md', '--file', 'a.md', '--file', 'b.md', '--json']);
+    expect(opts.drDir).toBe('/x');
+    expect(opts.globs).toEqual(['aristas-grafo-*.md']);
+    expect(opts.files).toEqual(['a.md', 'b.md']);
+    expect(opts.json).toBe(true);
+  });
+
+  it('acepta --out-cypher/--out-report/--graph', () => {
+    const opts = parseArgs(['--out-cypher', '/tmp/x.sql', '--out-report', '/tmp/x.json', '--graph', 'otro_grafo']);
+    expect(opts.outCypher).toBe('/tmp/x.sql');
+    expect(opts.outReport).toBe('/tmp/x.json');
+    expect(opts.graph).toBe('otro_grafo');
+  });
+});

--- a/scripts/load-age-graph-gaps.mjs
+++ b/scripts/load-age-graph-gaps.mjs
@@ -1,0 +1,559 @@
+#!/usr/bin/env node
+/**
+ * scripts/load-age-graph-gaps.mjs
+ *
+ * Generalización del patrón de `scripts/load-age-etno-folk-fitopatologia.mjs`
+ * (PR #1907) para ingerir DRs "de huecos" y "de aristas por especie" al grafo
+ * AGE `chagra_kg`. A diferencia de ese loader (que ejecuta SQL curado a mano),
+ * este script PARSEA directamente las tablas markdown de aristas que traen
+ * los DR (`| origen_id | TIPO | destino_id | fuente | confianza |` y variantes
+ * como `NodoA | Relación | NodoB | Fuente | Confianza`), las cura con reglas
+ * anti-alucinación, y genera el Cypher MERGE correspondiente.
+ *
+ * ESTADO: BUILD + DRY-RUN. Este script NUNCA se conecta a postgres/AGE ni
+ * ejecuta nada contra el grafo de producción. Su única salida es:
+ *   1. un archivo .sql con statements `SELECT * FROM cypher(...)` (MERGE,
+ *      no destructivo, idempotente — mismo patrón que catalog-to-age.mjs);
+ *   2. un reporte (JSON + texto) de cuántos nodos/aristas se generarían, por
+ *      DR y por tipo de relación, y cuántas filas se descartaron y por qué.
+ * La aplicación real contra `postgres-farm`/`chagra_kg` es una decisión
+ * posterior (fuera de este script), después de revisión humana del Cypher
+ * generado — igual que el resto del pipeline de ingesta AGE de este repo.
+ *
+ * Anti-alucinación / curación CO-strict:
+ *   - Se descartan aristas sin `fuente` citada (columna vacía).
+ *   - Se descartan aristas cuyo DR de origen no está explícitamente
+ *     circunscrito a Colombia/Andes (heurística sobre título+intro del DR:
+ *     "colombia", "andin", "andes", "páramo"). Todas las DRs objetivo de este
+ *     pipeline ya cumplen esto por diseño (nombre de archivo lo declara),
+ *     pero el chequeo es defensivo por si el script se apunta a otras DRs.
+ *   - Se descartan filas malformadas (columnas requeridas vacías o fila
+ *     truncada por corrupción de generación) y duplicados exactos dentro
+ *     del mismo DR.
+ *
+ * Fuente de las DRs: viven FUERA de este repo (Chagra-strategy, privado).
+ * Este script NO conoce ninguna ruta privada por defecto — se pasan por
+ * `--dr-dir` / env `CHAGRA_AGE_GAPS_DR_DIR`, igual que `CHAGRA_AGE_ETNO_SQL`
+ * en el loader hermano.
+ *
+ * Nodo genérico: las entidades de estas DRs (especies, plagas, polinizadores,
+ * conceptos abstractos como "fuego" o "riesgo_incendio", prácticas de manejo)
+ * son demasiado heterogéneas para inferir su label canónico (Species/Pest/...)
+ * sin consultar el grafo vivo — y esta etapa es offline por diseño. Por eso
+ * se etiquetan bajo un label nuevo y genérico `GraphGapNode` (mismo espíritu
+ * que `FolkSymptom` en el PR #1907: un label explícito para conceptos que
+ * todavía no calzan en la ontología establecida). LIMITACIÓN CONOCIDA: si un
+ * id ya existe como nodo canónico (p.ej. una Species ya catalogada), esto
+ * crea un nodo `GraphGapNode` paralelo con el mismo `id` en vez de fusionarse
+ * con el nodo existente — a resolver en una pasada de reconciliación con
+ * lectura contra el grafo vivo, antes de cualquier aplicación real.
+ *
+ * Uso:
+ *   node scripts/load-age-graph-gaps.mjs \
+ *     --dr-dir /ruta/privada/deepresearch/DR-FANOUT \
+ *     --glob 'aristas-grafo-*.md' \
+ *     --file porcicultura-y-avicultura-....md \
+ *     --file micorrizas-y-salud-de-suelo-....md \
+ *     --file recuperacion-de-suelos-....md \
+ *     --file captacion-de-agua-....md \
+ *     --out-cypher /ruta/privada/ops/age-graph-gaps/gaps.cypher.sql \
+ *     --out-report /ruta/privada/ops/age-graph-gaps/gaps.report.json
+ *
+ * Si no se pasan `--out-cypher`/`--out-report` (ni sus env vars), se escribe
+ * bajo `.local/age-graph-gaps/` (gitignored vía `*.local`) para que nunca
+ * quede contenido derivado de DRs privadas trackeado en este repo público.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { resolve, dirname, join, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { emitNode, emitRel, wrapCypher } from './catalog-to-age.mjs';
+
+const _here = dirname(fileURLToPath(import.meta.url));
+
+export const NODE_LABEL = 'GraphGapNode';
+
+// Snapshot de tipos de arista ya establecidos en chagra_kg — fuente:
+// Chagra-strategy/ops/INFRA_FACTS.md (auditoría en vivo 2026-06-14) +
+// FOLK_NAME_OF (introducido en PR #1907). Solo enriquece el reporte
+// (marca si un TIPO es "conocido" o "nuevo" para el grafo); no gatea la
+// curación — un tipo nuevo no es motivo de descarte.
+export const KNOWN_RELATION_TYPES = new Set([
+  'REFERENCED_BY', 'HAS_ROLE', 'GROWS_IN', 'CONTROLS', 'HAS_FAMILY',
+  'COMPATIBLE_WITH', 'HAS_HABIT', 'USED_AS_BIOPREPARADO', 'IS_VARIETY_OF',
+  'REFERS_TO_SPECIES', 'USED_IN_REGION', 'TARGETS_PEST', 'ANTAGONIST_OF',
+  'HAS_ORIGIN', 'RESISTANT_TO', 'AFFECTS', 'DISAMBIGUATES', 'SUSCEPTIBLE_TO',
+  'SYNONYM_OF', 'FOLK_NAME_OF',
+]);
+
+const CO_SCOPE_RE = /colombia|andin|\bandes\b|p[aá]ramo/i;
+
+// =============================================================================
+// Detección genérica de tablas markdown
+// =============================================================================
+
+// Placeholder para proteger pipes escapados (`\|`, sintaxis GFM válida dentro
+// de una celda — observado en al menos un DR real: "texto \| más texto") del
+// split por `|`. Sin esto, una celda con un pipe escapado corta la fila en el
+// lugar equivocado y desplaza fuente/confianza de las columnas siguientes.
+const ESCAPED_PIPE_PLACEHOLDER = '\u0001';
+
+/** Divide una línea `| a | b | c |` en celdas trimmeadas, respetando `\|` escapado. */
+export function splitTableRow(line) {
+  let s = line.trim().replace(/\\\|/g, ESCAPED_PIPE_PLACEHOLDER);
+  if (s.startsWith('|')) s = s.slice(1);
+  if (s.endsWith('|')) s = s.slice(0, -1);
+  return s.split('|').map((c) => c.trim().split(ESCAPED_PIPE_PLACEHOLDER).join('|'));
+}
+
+/** true si todas las celdas son separadores markdown (`:--`, `---`, `--:`). */
+export function isSeparatorRow(cells) {
+  return cells.length > 0 && cells.every((c) => /^:?-{1,}:?$/.test(c.trim()));
+}
+
+/**
+ * Encuentra todas las tablas markdown bien-formadas (header + fila separadora
+ * + 0..n filas de cuerpo) en un texto. Ignora bloques `| ... |` que no traen
+ * la fila separadora inmediatamente después (p.ej. una tabla degenerada por
+ * un glitch de generación, sin filas de cuerpo reales).
+ */
+export function findMarkdownTables(text) {
+  const lines = text.split(/\r?\n/);
+  const tables = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim().startsWith('|')) {
+      const headerCells = splitTableRow(line);
+      const sepLine = lines[i + 1];
+      if (sepLine && sepLine.trim().startsWith('|') && isSeparatorRow(splitTableRow(sepLine))) {
+        const rows = [];
+        let j = i + 2;
+        while (j < lines.length && lines[j].trim().startsWith('|')) {
+          const cells = splitTableRow(lines[j]);
+          if (!isSeparatorRow(cells)) rows.push(cells);
+          j++;
+        }
+        tables.push({ headerCells, rows, startLine: i + 1 });
+        i = j;
+        continue;
+      }
+    }
+    i++;
+  }
+  return tables;
+}
+
+// =============================================================================
+// Clasificación de encabezados "tabla de aristas" (con alias)
+// =============================================================================
+
+function normalizeHeaderCell(cell) {
+  return String(cell || '')
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, '')
+    .replace(/_/g, ' ')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const ORIGEN_ALIASES = new Set(['origen id', 'origen', 'nodoa', 'nodo a']);
+const TIPO_ALIASES = new Set(['tipo', 'relacion', 'tipo relacion']);
+const DESTINO_ALIASES = new Set(['destino id', 'destino', 'nodob', 'nodo b']);
+const FUENTE_ALIASES = new Set(['fuente']);
+const CONFIANZA_ALIASES = new Set(['confianza']);
+
+/**
+ * Clasifica un header de tabla como "tabla de aristas" si trae, a la vez,
+ * una columna origen-like, una tipo-like y una destino-like (en cualquier
+ * orden/posición). Requerir las tres a la vez es lo que descarta falsos
+ * positivos como una tabla de índice de fuentes `Origen_ID | TIPO | Fuente |
+ * Confianza` (sin destino) que aparece en al menos un DR real.
+ *
+ * @returns {{origenIdx:number,tipoIdx:number,destinoIdx:number,fuenteIdx:number,confianzaIdx:number}|null}
+ */
+export function classifyEdgeHeader(headerCells) {
+  const normalized = headerCells.map(normalizeHeaderCell);
+  const origenIdx = normalized.findIndex((c) => ORIGEN_ALIASES.has(c));
+  const tipoIdx = normalized.findIndex((c) => TIPO_ALIASES.has(c));
+  const destinoIdx = normalized.findIndex((c) => DESTINO_ALIASES.has(c));
+  if (origenIdx === -1 || tipoIdx === -1 || destinoIdx === -1) return null;
+  const fuenteIdx = normalized.findIndex((c) => FUENTE_ALIASES.has(c));
+  const confianzaIdx = normalized.findIndex((c) => CONFIANZA_ALIASES.has(c));
+  return { origenIdx, tipoIdx, destinoIdx, fuenteIdx, confianzaIdx };
+}
+
+// =============================================================================
+// Extracción de aristas crudas
+// =============================================================================
+
+/**
+ * Recorre todas las tablas del texto, clasifica cuáles son tablas de
+ * aristas, y extrae las filas como cuádruplos crudos (sin curar todavía).
+ */
+export function extractRawEdgesFromText(text) {
+  const tables = findMarkdownTables(text);
+  const rawEdges = [];
+  let edgeTablesFound = 0;
+  let malformedRowCount = 0;
+  for (const table of tables) {
+    const cols = classifyEdgeHeader(table.headerCells);
+    if (!cols) continue;
+    edgeTablesFound++;
+    for (const row of table.rows) {
+      const origen = row[cols.origenIdx];
+      const tipo = row[cols.tipoIdx];
+      const destino = row[cols.destinoIdx];
+      if (!origen || !tipo || !destino) {
+        malformedRowCount++;
+        continue;
+      }
+      const fuente = cols.fuenteIdx >= 0 ? (row[cols.fuenteIdx] || '') : '';
+      const confianza = cols.confianzaIdx >= 0 ? (row[cols.confianzaIdx] || '') : '';
+      rawEdges.push({
+        origen: origen.trim(),
+        tipo: tipo.trim(),
+        destino: destino.trim(),
+        fuente: fuente.trim(),
+        confianza: confianza.trim(),
+        tableStartLine: table.startLine,
+      });
+    }
+  }
+  return { tablesFound: tables.length, edgeTablesFound, rawEdges, malformedRowCount };
+}
+
+// =============================================================================
+// Normalización + curación (anti-alucinación, CO-strict)
+// =============================================================================
+
+export function slugifyId(raw) {
+  return String(raw || '').trim().toLowerCase().replace(/\s+/g, '_');
+}
+
+export function sanitizeRelType(tipo) {
+  let s = String(tipo || '')
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9_]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!s) return null;
+  if (/^[0-9]/.test(s)) s = `REL_${s}`;
+  return s;
+}
+
+const CONFIANZA_MAP = { alta: 'alta', media: 'media', baja: 'baja' };
+export function normalizeConfianza(raw) {
+  const s = String(raw || '').trim().toLowerCase();
+  if (CONFIANZA_MAP[s]) return CONFIANZA_MAP[s];
+  return s ? 'sin_normalizar' : 'sin_dato';
+}
+
+/** Heurística de scoping CO/Andes sobre el título + intro del DR (primeros ~4000 chars). */
+export function isColombiaScopedText(text) {
+  return CO_SCOPE_RE.test(text.slice(0, 4000));
+}
+
+/**
+ * Cura una lista de aristas crudas de un mismo DR. Reglas de descarte:
+ *   - dr_no_co_scoped: el DR no declara scope Colombia/Andes.
+ *   - tipo_invalido: TIPO vacío tras sanitizar.
+ *   - nodo_vacio: origen/destino vacío tras slugify.
+ *   - sin_fuente: columna fuente vacía (anti-alucinación — no hay cita).
+ *   - duplicado: mismo (origen,tipo,destino) ya visto en este DR.
+ */
+export function curateRawEdges(rawEdges, { drScoped, drId }) {
+  const accepted = [];
+  const rejected = [];
+  const seen = new Set();
+  for (const raw of rawEdges) {
+    if (!drScoped) { rejected.push({ ...raw, reason: 'dr_no_co_scoped' }); continue; }
+    const tipo = sanitizeRelType(raw.tipo);
+    if (!tipo) { rejected.push({ ...raw, reason: 'tipo_invalido' }); continue; }
+    const origen = slugifyId(raw.origen);
+    const destino = slugifyId(raw.destino);
+    if (!origen || !destino) { rejected.push({ ...raw, reason: 'nodo_vacio' }); continue; }
+    if (!raw.fuente) { rejected.push({ ...raw, reason: 'sin_fuente' }); continue; }
+    const key = `${origen}|${tipo}|${destino}`;
+    if (seen.has(key)) { rejected.push({ ...raw, reason: 'duplicado' }); continue; }
+    seen.add(key);
+    accepted.push({
+      origen,
+      tipo,
+      destino,
+      fuente: raw.fuente,
+      confianza: normalizeConfianza(raw.confianza),
+      confianzaRaw: raw.confianza,
+      drId,
+      isKnownRelationType: KNOWN_RELATION_TYPES.has(tipo),
+    });
+  }
+  const byReason = {};
+  for (const r of rejected) byReason[r.reason] = (byReason[r.reason] || 0) + 1;
+  return { accepted, rejected, byReason };
+}
+
+// =============================================================================
+// Generación de Cypher (reutiliza primitivas de catalog-to-age.mjs)
+// =============================================================================
+
+/**
+ * Construye los statements SQL `SELECT * FROM cypher(...)` para un batch de
+ * aristas ya curadas. Dedupea el MERGE de nodo por id (el mismo id puede
+ * aparecer en decenas de aristas dentro y entre DRs) para no inflar el
+ * archivo de salida con el mismo MERGE repetido.
+ */
+export function buildCypherStatements(acceptedEdges, { graph = 'chagra_kg', dateStr } = {}) {
+  const statements = [];
+  const emittedNodes = new Set();
+  const today = dateStr || new Date().toISOString().slice(0, 10);
+  for (const e of acceptedEdges) {
+    const drRef = `DR-FANOUT:${e.drId}`;
+    for (const nodeId of [e.origen, e.destino]) {
+      if (emittedNodes.has(nodeId)) continue;
+      emittedNodes.add(nodeId);
+      statements.push(wrapCypher(graph, emitNode(NODE_LABEL, {
+        id: nodeId,
+        source: drRef,
+        added_at: today,
+      })));
+    }
+    statements.push(wrapCypher(graph, emitRel(
+      { label: NODE_LABEL, id: e.origen },
+      e.tipo,
+      { label: NODE_LABEL, id: e.destino },
+      {
+        source: e.fuente,
+        confidence: e.confianza,
+        dr: drRef,
+        added_at: today,
+      },
+    )));
+  }
+  return { statements, nodeCount: emittedNodes.size };
+}
+
+// =============================================================================
+// Procesamiento por DR + reporte agregado
+// =============================================================================
+
+export function drIdFromPath(filePath) {
+  return basename(filePath).replace(/\.md$/i, '');
+}
+
+export function processDrFile(filePath) {
+  const text = readFileSync(filePath, 'utf8');
+  const drId = drIdFromPath(filePath);
+  const drScoped = isColombiaScopedText(text);
+  const { tablesFound, edgeTablesFound, rawEdges, malformedRowCount } = extractRawEdgesFromText(text);
+  const { accepted, rejected, byReason } = curateRawEdges(rawEdges, { drScoped, drId });
+  const relationTypeCounts = {};
+  for (const e of accepted) relationTypeCounts[e.tipo] = (relationTypeCounts[e.tipo] || 0) + 1;
+  return {
+    drId,
+    filePath,
+    drScoped,
+    tablesFound,
+    edgeTablesFound,
+    rawEdgeCount: rawEdges.length,
+    malformedRowCount,
+    acceptedCount: accepted.length,
+    rejectedCount: rejected.length,
+    rejectedByReason: byReason,
+    relationTypeCounts,
+    accepted,
+    rejected,
+  };
+}
+
+export function buildDryRunReport(perDrResults, { graph = 'chagra_kg' } = {}) {
+  const allAccepted = perDrResults.flatMap((r) => r.accepted);
+  const relationTypeCounts = {};
+  for (const e of allAccepted) relationTypeCounts[e.tipo] = (relationTypeCounts[e.tipo] || 0) + 1;
+  const rejectedByReason = {};
+  for (const r of perDrResults) {
+    for (const [reason, count] of Object.entries(r.rejectedByReason)) {
+      rejectedByReason[reason] = (rejectedByReason[reason] || 0) + count;
+    }
+  }
+  const newRelationTypes = [...new Set(allAccepted.map((e) => e.tipo))]
+    .filter((t) => !KNOWN_RELATION_TYPES.has(t)).sort();
+  const nodeIds = new Set();
+  for (const e of allAccepted) { nodeIds.add(e.origen); nodeIds.add(e.destino); }
+
+  return {
+    graph,
+    generatedAt: new Date().toISOString(),
+    drCount: perDrResults.length,
+    totals: {
+      tablesFound: perDrResults.reduce((n, r) => n + r.tablesFound, 0),
+      edgeTablesFound: perDrResults.reduce((n, r) => n + r.edgeTablesFound, 0),
+      rawEdges: perDrResults.reduce((n, r) => n + r.rawEdgeCount, 0),
+      malformedRows: perDrResults.reduce((n, r) => n + r.malformedRowCount, 0),
+      accepted: allAccepted.length,
+      rejected: perDrResults.reduce((n, r) => n + r.rejectedCount, 0),
+      newNodeIds: nodeIds.size,
+    },
+    relationTypeCounts,
+    newRelationTypes,
+    rejectedByReason,
+    perDr: perDrResults.map((r) => ({
+      drId: r.drId,
+      drScoped: r.drScoped,
+      tablesFound: r.tablesFound,
+      edgeTablesFound: r.edgeTablesFound,
+      rawEdgeCount: r.rawEdgeCount,
+      malformedRowCount: r.malformedRowCount,
+      acceptedCount: r.acceptedCount,
+      rejectedCount: r.rejectedCount,
+      rejectedByReason: r.rejectedByReason,
+      relationTypeCounts: r.relationTypeCounts,
+    })),
+  };
+}
+
+export function formatReportText(report) {
+  const lines = [];
+  lines.push(`[age-graph-gaps] modo=DRY-RUN (no se tocó ${report.graph})`);
+  lines.push(`[age-graph-gaps] DRs procesadas: ${report.drCount}`);
+  lines.push(`[age-graph-gaps] tablas detectadas: ${report.totals.tablesFound} (de aristas: ${report.totals.edgeTablesFound})`);
+  lines.push(`[age-graph-gaps] aristas crudas: ${report.totals.rawEdges} | filas malformadas: ${report.totals.malformedRows}`);
+  lines.push(`[age-graph-gaps] aristas aceptadas: ${report.totals.accepted} | descartadas: ${report.totals.rejected}`);
+  lines.push(`[age-graph-gaps] nodos nuevos (ids únicos): ${report.totals.newNodeIds}`);
+  lines.push('[age-graph-gaps] descartes por motivo:');
+  for (const [reason, count] of Object.entries(report.rejectedByReason).sort((a, b) => b[1] - a[1])) {
+    lines.push(`  - ${reason}: ${count}`);
+  }
+  lines.push('[age-graph-gaps] aristas aceptadas por tipo de relación:');
+  for (const [tipo, count] of Object.entries(report.relationTypeCounts).sort((a, b) => b[1] - a[1])) {
+    const known = KNOWN_RELATION_TYPES.has(tipo) ? '' : ' (NUEVO)';
+    lines.push(`  - ${tipo}: ${count}${known}`);
+  }
+  lines.push('[age-graph-gaps] por DR:');
+  for (const dr of report.perDr) {
+    lines.push(`  - ${dr.drId}: aceptadas=${dr.acceptedCount} descartadas=${dr.rejectedCount} tablas_aristas=${dr.edgeTablesFound}/${dr.tablesFound} scoped_co=${dr.drScoped ? 'si' : 'no'}`);
+  }
+  return lines.join('\n');
+}
+
+// =============================================================================
+// CLI
+// =============================================================================
+
+function globToRegExp(glob) {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`);
+}
+
+export function parseArgs(argv) {
+  const opts = {
+    drDir: process.env.CHAGRA_AGE_GAPS_DR_DIR || '',
+    globs: [],
+    files: [],
+    outCypher: process.env.CHAGRA_AGE_GAPS_OUT_CYPHER || '',
+    outReport: process.env.CHAGRA_AGE_GAPS_OUT_REPORT || '',
+    graph: 'chagra_kg',
+    json: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dr-dir') opts.drDir = argv[++i];
+    else if (a === '--glob') opts.globs.push(argv[++i]);
+    else if (a === '--file') opts.files.push(argv[++i]);
+    else if (a === '--out-cypher') opts.outCypher = argv[++i];
+    else if (a === '--out-report') opts.outReport = argv[++i];
+    else if (a === '--graph') opts.graph = argv[++i];
+    else if (a === '--json') opts.json = true;
+    else if (a === '--help' || a === '-h') opts.help = true;
+  }
+  return opts;
+}
+
+/** Resuelve la lista final de archivos (unión de --glob y --file, deduplicada). */
+export function resolveFileList(opts) {
+  const resolved = new Set();
+  if (opts.globs.length) {
+    const entries = readdirSync(opts.drDir);
+    const regexes = opts.globs.map(globToRegExp);
+    for (const entry of entries) {
+      if (regexes.some((re) => re.test(entry))) {
+        resolved.add(resolve(opts.drDir, entry));
+      }
+    }
+  }
+  for (const f of opts.files) {
+    resolved.add(resolve(opts.drDir, f));
+  }
+  return [...resolved].sort();
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  if (opts.help) {
+    console.log([
+      'Usage: node scripts/load-age-graph-gaps.mjs --dr-dir DIR [--glob PATTERN]... [--file NAME]... [--out-cypher FILE] [--out-report FILE] [--graph chagra_kg] [--json]',
+      '',
+      'BUILD + DRY-RUN: nunca se conecta a AGE/postgres. Genera Cypher + reporte a archivo.',
+    ].join('\n'));
+    return 0;
+  }
+  if (!opts.drDir) {
+    console.error('ERROR: falta --dr-dir (o env CHAGRA_AGE_GAPS_DR_DIR). Las DRs viven fuera de este repo.');
+    return 2;
+  }
+  if (!opts.globs.length && !opts.files.length) {
+    console.error('ERROR: pasa al menos un --glob o --file para seleccionar qué DRs procesar.');
+    return 2;
+  }
+
+  const files = resolveFileList(opts);
+  if (!files.length) {
+    console.error(`ERROR: no se encontró ningún archivo con los --glob/--file dados bajo ${opts.drDir}`);
+    return 2;
+  }
+
+  const perDrResults = files.map((f) => processDrFile(f));
+  const allAccepted = perDrResults.flatMap((r) => r.accepted);
+  const { statements, nodeCount } = buildCypherStatements(allAccepted, { graph: opts.graph });
+  const report = buildDryRunReport(perDrResults, { graph: opts.graph });
+  report.totals.cypherStatements = statements.length;
+  report.totals.cypherNodeMerges = nodeCount;
+
+  const outCypher = opts.outCypher || join(_here, '..', '.local', 'age-graph-gaps', 'gaps.cypher.sql');
+  const outReport = opts.outReport || join(_here, '..', '.local', 'age-graph-gaps', 'gaps.report.json');
+  mkdirSync(dirname(outCypher), { recursive: true });
+  mkdirSync(dirname(outReport), { recursive: true });
+
+  const cypherHeader = [
+    '-- Generado por scripts/load-age-graph-gaps.mjs — DRY-RUN, NO aplicado.',
+    `-- Grafo destino: ${opts.graph}`,
+    `-- DRs fuente: ${perDrResults.map((r) => r.drId).join(', ')}`,
+    `-- Statements: ${statements.length} (MERGE-only, idempotente, no destructivo)`,
+    '-- Revisión humana requerida antes de ejecutar contra postgres-farm.',
+    '',
+    "LOAD 'age';",
+    'SET search_path = ag_catalog, "$user", public;',
+    '',
+  ].join('\n');
+  writeFileSync(outCypher, `${cypherHeader}${statements.join('\n\n')}\n`, 'utf8');
+  writeFileSync(outReport, JSON.stringify(report, null, 2), 'utf8');
+
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatReportText(report));
+  }
+  console.log(`[age-graph-gaps] Cypher escrito en ${outCypher}`);
+  console.log(`[age-graph-gaps] Reporte escrito en ${outReport}`);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}


### PR DESCRIPTION
## Resumen

- Generaliza el patrón de `scripts/load-age-etno-folk-fitopatologia.mjs` (PR #1907) para ingerir DRs "de huecos" y "de aristas por especie" al grafo `chagra_kg`.
- A diferencia de ese loader (SQL curado a mano), este script **parsea directamente** las tablas markdown de aristas de los DR (`origen_id | TIPO | destino_id | fuente | confianza` y variantes de header como `NodoA | Relación | NodoB | Fuente | Confianza`), aplica curación anti-alucinación / CO-strict, y genera el Cypher MERGE correspondiente reutilizando las primitivas ya probadas de `scripts/catalog-to-age.mjs` (`cypherLiteral`, `emitNode`, `emitRel`, `wrapCypher`).
- **Etapa BUILD + DRY-RUN**: el script nunca se conecta a postgres/AGE. Solo escribe un `.sql` (Cypher MERGE, idempotente, no destructivo) + un reporte JSON/texto a archivo, para revisión humana antes de cualquier aplicación real.
- Env-gated igual que el patrón hermano: `CHAGRA_AGE_GAPS_DR_DIR` (+ `--dr-dir`/`--glob`/`--file`), sin ninguna ruta privada hardcodeada en el script.

## Reporte del dry-run (corrida real contra las DRs objetivo, contenido NO incluido aquí — privado)

Corpus: 39 `aristas-grafo-*.md` (todas las especies) + 4 DRs de huecos (porcicultura/avicultura, micorrizas y salud de suelo, recuperación de suelos post-incendio, captación de agua) = 43 DRs.

```
DRs procesadas: 43
tablas detectadas: 68 (de aristas: 42)
aristas crudas: 717 | filas malformadas: 9
aristas aceptadas: 356 | descartadas: 361
nodos nuevos (ids únicos): 328

Descartes por motivo:
  - dr_no_co_scoped: 287  (3 DRs sin scope CO/Andes declarado en título/intro)
  - sin_fuente: 42        (columna fuente vacía — anti-alucinación)
  - duplicado: 32         (mismo origen/tipo/destino repetido, p.ej. 2 tablas
                            equivalentes en un mismo DR)

Aristas aceptadas por tipo de relación:
  - AFFECTS: 121
  - COMPATIBLE_WITH: 84
  - CONTROLS: 54
  - POLINIZA: 45 (NUEVO — no existía en chagra_kg al 2026-06-14)
  - ANTAGONIST_OF: 20
  - SUSCEPTIBLE_TO: 14
  - RESISTANT_TO: 12
  - ASOCIA_CON: 5 (NUEVO)
  - AFFECTS_SOIL_FERTILITY: 1 (NUEVO)
```

### Los 4 DRs "de huecos" en particular

| DR | tablas de aristas | aceptadas | descartadas | nota |
|---|---|---|---|---|
| porcicultura-y-avicultura | 1/6 | 4 | 0 | única sección con triples reales (§7 Asociaciones/policultivo) |
| micorrizas-y-salud-de-suelo | 0/7 | 0 | 0 | **no tiene tabla de aristas real** — solo tablas de dominio (Problema→manejo, etc.) + una tabla de índice de fuentes que comparte nombres de columna pero no tiene destino (correctamente excluida) |
| recuperación-de-suelos-post-incendio | 1/8 | 1 | 23 (todas `sin_fuente`) | la sección `§Grafo — triples` trae 24 filas pero casi todas con columna `fuente` vacía |
| captación-de-agua-y-riego | 0/0 | 0 | 0 | **DR corrupto/degenerado**: el header de la tabla de aristas quedó con la celda `fuente` rellena con ~190KB de espacios en blanco (glitch de generación) y sin fila separadora ni filas de cuerpo — no hay nada que extraer. Requiere re-generar esta DR. |

### Hallazgo adicional (bug real, corregido en este PR)

Corriendo el dry-run contra el corpus real se encontró una fila en `aristas-grafo-annonasquamosa` con un pipe escapado (`\|`, sintaxis GFM válida) dentro de la celda `fuente`. El primer parser no lo respetaba y desplazaba `confianza` a un valor incorrecto. Se corrigió `splitTableRow` para proteger `\|` antes del split, con test de regresión (`scripts/__tests__/load-age-graph-gaps.test.mjs`).

## Decisión de diseño a revisar (Opus)

Las entidades de estos DRs (especies, plagas, polinizadores, conceptos abstractos como `fuego`/`riesgo_incendio`, prácticas de manejo) son demasiado heterogéneas para inferir su label canónico (`Species`/`Pest`/...) sin consultar el grafo vivo, y esta etapa es offline por diseño. Por eso el loader etiqueta **ambos extremos de toda arista** bajo un label nuevo genérico `GraphGapNode` (mismo espíritu que `FolkSymptom` del PR #1907).

**Limitación conocida**: si un id ya existe como nodo canónico (p. ej. una `Species` ya catalogada — muy probable para las especies foco de cada `aristas-grafo-<especie>.md`), esto crea un nodo `GraphGapNode` paralelo con el mismo `id` en vez de fusionarse con el nodo existente. Resolverlo requiere una pasada de reconciliación con lectura contra el grafo vivo (fuera de scope de un script offline) antes de cualquier aplicación real.

## Anti-leak

Solo el loader genérico (`scripts/load-age-graph-gaps.mjs`) + su test se commitean a este repo público. El Cypher generado y el reporte con contenido derivado de las DRs privadas quedan en `Chagra-strategy/ops/age-graph-gaps/` (repo privado) — no se commiteó nada de eso aquí.

## Test plan

- [x] `npx vitest run scripts/__tests__/load-age-graph-gaps.test.mjs` (29/29 passed)
- [x] `npx eslint scripts/load-age-graph-gaps.mjs scripts/__tests__/load-age-graph-gaps.test.mjs` (clean)
- [x] Corrida real (dry-run) contra las 43 DRs objetivo — sin tocar `chagra_kg` — reporte arriba
- [ ] Revisión de Opus sobre la decisión `GraphGapNode` antes de cualquier `--apply` real (no implementado en este PR)