### PR TITLE
feat(ui): exponer BeforeAfterPhoto + auditoría de inventario

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -410,7 +410,7 @@ export default function App() {
 
   // Bug Lili #4: el InputLogForm dispatcha 'syncSuccess' tras registrar una
   // aplicación de bio-insumo, pero nadie escuchaba el evento → el operador
-  // no veía feedback de dónde quedó guardada la info. Listener acá que
+  // no veía feedback de dónde quedó guardada la info. Listener aquí que
   // alimenta el toast con CTA "Ver Bitácora" cuando el evento trae action.
   // detail: { message: string, actionLabel?: string, actionView?: string }
   useEffect(() => {
@@ -591,7 +591,7 @@ export default function App() {
     // los usuarios de La Cordada, mientras hay señal en el dashboard. Sin esto,
     // si un guía instala la app y sube al glaciar SIN haber abierto el módulo
     // online, el chunk `/assets/GlaciarReporteScreen-*.js` nunca se cachea → el
-    // SW responde 504 y el módulo NO abre en campo. Disparar el import() acá
+    // SW responde 504 y el módulo NO abre en campo. Disparar el import() aquí
     // baja el chunk estando online; el handler cache-first de /assets/* del SW
     // lo guarda y sobrevive offline. Idempotente (el bundler cachea el módulo),
     // fire-and-forget, y solo para la whitelist (no malgasta datos del resto).
@@ -1317,7 +1317,7 @@ export default function App() {
         // (src/config/glaciarAccess.js). Guarda defensiva: si por cualquier
         // ruta un usuario no autorizado llega a esta vista, NO montamos el
         // módulo — devolvemos el fallback estándar. Las navegaciones a #glaciar
-        // ya redirigen al dashboard antes de llegar acá (ver effects de ruta).
+        // ya redirigen al dashboard antes de llegar aquí (ver effects de ruta).
         if (!tieneAccesoGlaciarActual()) {
           return (
             <ErrorBoundary>
@@ -1340,7 +1340,7 @@ export default function App() {
         // (src/config/glaciarAccess.js). Guarda defensiva: si por cualquier
         // ruta un usuario no autorizado llega a esta vista, NO montamos el
         // módulo — devolvemos el fallback estándar. Las navegaciones a
-        // #glaciar-historial ya redirigen al dashboard antes de llegar acá.
+        // #glaciar-historial ya redirigen al dashboard antes de llegar aquí.
         if (!tieneAccesoGlaciarActual()) {
           return (
             <ErrorBoundary>
@@ -1365,7 +1365,7 @@ export default function App() {
         // Panel SUPERVISOR del modo extensionista (ADR-048 MVP). ACCESO por
         // feature flag VITE_FEATURE_EXTENSIONISTA + rol (config/extensionistaAccess).
         // Las rutas a #extensionista ya redirigen al dashboard antes de llegar
-        // acá si el usuario no tiene rol; guarda defensiva por si se monta directo.
+        // aquí si el usuario no tiene rol; guarda defensiva por si se monta directo.
         if (!esExtensionistaActual()) {
           return (
             <ErrorBoundary>
@@ -1430,7 +1430,7 @@ export default function App() {
         // chunk no cacheado por el SW, el import() falla → ErrorBoundary genérico
         // ("Algo falló") y el guard offline real (ollamaStream) queda
         // inalcanzable porque el componente nunca monta. Chequear navigator.onLine
-        // acá deja ver el aviso claro ("el asistente necesita internet; tus datos
+        // aquí deja ver el aviso claro ("el asistente necesita internet; tus datos
         // sí funcionan sin conexión") aunque el chunk no esté disponible.
         if (!isAppOnline) {
           return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@
  */
 /* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import React, { lazy, Suspense, useState, useEffect, useCallback, useRef } from 'react';
-import { MapPin, Eye, Package, CheckCircle, WifiOff, Mic, AlertCircle, Network, Beaker } from 'lucide-react';
+import { MapPin, Eye, Package, CheckCircle, WifiOff, Mic, AlertCircle, Network, Beaker, Scale } from 'lucide-react';
 import localforage from 'localforage';
 import { useTheme } from './hooks/useTheme';
 import { useClimaAtmosphere } from './hooks/useClimaAtmosphere';
@@ -73,6 +73,12 @@ const WorkerHistory = lazy(() => import('./components/WorkerHistory'));
 const BitacoraEntryDetail = lazy(() => import('./components/BitacoraEntryDetail'));
 const InformesScreen = lazy(() => import('./components/InformesScreen'));
 const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').then(m => ({ default: m.InventoryDashboard })));
+// InventoryPage orquesta la capa de auditoría/reconciliación de inventario
+// (InventoryAuditTrail + InventoryAuditDashboard + InventoryEventTimeline),
+// completa pero huérfana (0 rutas) antes de este wiring — descubribilidad
+// 2026-06-30. Se alcanza desde 'bodega' vía el botón "Auditoría y
+// reconciliación", o directo por hash (#auditoria-inventario).
+const InventoryPage = lazy(() => import('./pages/InventoryPage'));
 const BiopreparadoRecetasGallery = lazy(() => import('./components/BiopreparadoRecetasGallery'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -152,6 +158,9 @@ const HASH_VIEW_ROUTES = {
   faq: 'faq',
   inventario: 'activos',
   activos: 'activos',
+  bodega: 'bodega',
+  'auditoria-inventario': 'auditoria_inventario',
+  'inventario-auditoria': 'auditoria_inventario',
   biodiversidad: 'biodiversidad',
   ayuda: 'ayuda',
   perfil: 'perfil',
@@ -201,7 +210,7 @@ const MODULE_VIEWS = new Set([
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia',
-  'usage_stats', 'mercado',
+  'usage_stats', 'mercado', 'auditoria_inventario',
 ]);
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -971,8 +980,44 @@ export default function App() {
         return (
           <ErrorBoundary>
             <ErrorFallback moduleName="Insumos">
-              <ScreenShell title="Bodega" icon={Package} onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')}>
+              <ScreenShell
+                title="Bodega"
+                icon={Package}
+                onBack={() => navigate('dashboard')}
+                onHome={() => navigate('dashboard')}
+                actions={
+                  <button
+                    type="button"
+                    onClick={() => navigate('auditoria_inventario')}
+                    data-testid="bodega-open-auditoria"
+                    className="px-3 py-1.5 rounded-lg bg-indigo-600/80 hover:bg-indigo-500 text-white text-xs font-bold transition-colors flex items-center gap-1.5"
+                  >
+                    <Scale className="w-3.5 h-3.5" /> Auditoría
+                  </button>
+                }
+              >
                 <InventoryDashboard />
+              </ScreenShell>
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'auditoria_inventario':
+        // Capa de auditoría/reconciliación de inventario (descubribilidad
+        // 2026-06-30): antes InventoryPage no estaba ruteado y
+        // InventoryAuditDashboard/InventoryEventTimeline/InventoryAuditTrail
+        // (+ inventoryReconcile.js/inventoryEvents.js) quedaban huérfanos (0
+        // importers). InventoryPage orquesta los 3 componentes; se alcanza
+        // desde 'bodega' (botón "Auditoría") o por hash directo.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Auditoría de Inventario">
+              <ScreenShell
+                title="Auditoría de Inventario"
+                icon={Scale}
+                onBack={() => navigate('bodega')}
+                onHome={() => navigate('dashboard')}
+              >
+                <InventoryPage />
               </ScreenShell>
             </ErrorFallback>
           </ErrorBoundary>

--- a/src/__tests__/App.auditoria-inventario-route.test.jsx
+++ b/src/__tests__/App.auditoria-inventario-route.test.jsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 // estaba ruteado en App.jsx y la capa de auditoría/reconciliación de
 // inventario (InventoryAuditDashboard/InventoryEventTimeline/InventoryAuditTrail
 // + inventoryReconcile.js/inventoryEvents.js) quedaba huérfana (0 importers
-// alcanzables desde la app). Acá probamos DOS caminos de alcance:
+// alcanzables desde la app). Aquí probamos DOS caminos de alcance:
 //   1. Hash directo (#auditoria-inventario) monta InventoryPage.
 //   2. Desde 'bodega' (#bodega), el botón "Auditoría" navega a la misma vista.
 //

--- a/src/__tests__/App.auditoria-inventario-route.test.jsx
+++ b/src/__tests__/App.auditoria-inventario-route.test.jsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Test de RUTA: verifica que App rutea 'auditoria_inventario' → InventoryPage
+// (descubribilidad 2026-06-30). Antes de este wiring, InventoryPage.jsx NO
+// estaba ruteado en App.jsx y la capa de auditoría/reconciliación de
+// inventario (InventoryAuditDashboard/InventoryEventTimeline/InventoryAuditTrail
+// + inventoryReconcile.js/inventoryEvents.js) quedaba huérfana (0 importers
+// alcanzables desde la app). Acá probamos DOS caminos de alcance:
+//   1. Hash directo (#auditoria-inventario) monta InventoryPage.
+//   2. Desde 'bodega' (#bodega), el botón "Auditoría" navega a la misma vista.
+//
+// Los efectos pesados de boot (auth, catálogo SQLite WASM, motores de alerta,
+// RAG, warm-up de Ollama) se mockean para que App arranque limpio en jsdom sin
+// tocar red/IDB. No probamos el render interno de InventoryPage/InventoryDashboard
+// acá (ya cubierto en sus propios tests); solo el wiring de la ruta.
+
+vi.mock('../services/authService', () => ({
+  isAuthenticated: () => Promise.resolve(true),
+  logoutUser: () => Promise.resolve(),
+}));
+vi.mock('../db/catalogDB', () => ({ initCatalog: () => Promise.resolve() }));
+vi.mock('../services/ragRetriever', () => ({
+  prewarmCorpus: () => {},
+  retrieve: () => Promise.resolve([]),
+}));
+vi.mock('../services/alertEngine', () => ({ alertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/cropAlertEngine', () => ({ cropAlertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/apiService', () => ({
+  fetchFromFarmOS: () => Promise.resolve(null),
+  fetchWithAuthRetry: () => Promise.resolve({ ok: true }),
+}));
+
+// Destinos: stubs livianos que delatan que se montaron.
+vi.mock('../pages/InventoryPage', () => ({
+  default: () => <div data-testid="inventory-page-stub">auditoria inventario stub</div>,
+}));
+vi.mock('../components/InventoryDashboard', () => ({
+  InventoryDashboard: () => <div data-testid="inventory-dashboard-stub">bodega stub</div>,
+  default: () => <div data-testid="inventory-dashboard-stub">bodega stub</div>,
+}));
+
+// Procesos vacíos (sin IDB).
+vi.mock('../db/farmProcessCache', () => ({ listFarmProcesses: () => Promise.resolve([]) }));
+
+import App from '../App';
+
+describe('App — ruta "auditoria_inventario"', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    window.location.hash = '';
+    vi.clearAllMocks();
+  });
+
+  it('con sesión autenticada y #auditoria-inventario monta InventoryPage', async () => {
+    window.location.hash = '#auditoria-inventario';
+    render(<App />);
+    await waitFor(
+      () => expect(screen.getByTestId('inventory-page-stub')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+    expect(screen.queryByText('Vista no disponible')).toBeNull();
+  });
+
+  it('desde Bodega, el botón "Auditoría" navega a InventoryPage', async () => {
+    window.location.hash = '#bodega';
+    render(<App />);
+    await waitFor(
+      () => expect(screen.getByTestId('inventory-dashboard-stub')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+    const auditButton = screen.getByTestId('bodega-open-auditoria');
+    await userEvent.click(auditButton);
+    await waitFor(
+      () => expect(screen.getByTestId('inventory-page-stub')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+  });
+});

--- a/src/__tests__/App.auditoria-inventario-route.test.jsx
+++ b/src/__tests__/App.auditoria-inventario-route.test.jsx
@@ -14,7 +14,7 @@ import userEvent from '@testing-library/user-event';
 // Los efectos pesados de boot (auth, catálogo SQLite WASM, motores de alerta,
 // RAG, warm-up de Ollama) se mockean para que App arranque limpio en jsdom sin
 // tocar red/IDB. No probamos el render interno de InventoryPage/InventoryDashboard
-// acá (ya cubierto en sus propios tests); solo el wiring de la ruta.
+// aquí (ya cubierto en sus propios tests); solo el wiring de la ruta.
 
 vi.mock('../services/authService', () => ({
   isAuthenticated: () => Promise.resolve(true),

--- a/src/components/AssetTimeline.jsx
+++ b/src/components/AssetTimeline.jsx
@@ -6,6 +6,7 @@ import { parseAiInference, parseAiReview } from '../utils/aiInferenceParser';
 import { savePayload } from '../services/payloadService';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import { usePhotoUrl } from '../hooks/usePhotoUrl';
+import BeforeAfterPhoto from './BeforeAfterPhoto';
 
 /**
  * AssetTimeline, Línea de tiempo agroecológica de un activo (plant).
@@ -138,6 +139,33 @@ const PhotoAttachmentThumb = ({ photoId, timestamp, pending }) => {
   );
 };
 
+// PhotoEvolutionSection — comparador antes/después (FEAT-C #294, descubribilidad
+// 2026-06-30): reusa las dos fotos MÁS ANTIGUA y MÁS RECIENTE adjuntadas a esta
+// misma planta (marcadores [PHOTO_ATTACHMENT] del propio timeline) para que el
+// productor vea la evolución del cultivo con el slider de BeforeAfterPhoto, sin
+// tener que ir foto por foto. Solo se muestra si hay al menos 2 fotos distintas
+// Y ambas URLs resuelven (usePhotoUrl); si falta alguna, no se renderiza nada
+// (degrada limpio, no deja un hueco roto).
+const PhotoEvolutionSection = ({ oldest, newest }) => {
+  const beforePhoto = usePhotoUrl({ photoId: oldest.photoId });
+  const afterPhoto = usePhotoUrl({ photoId: newest.photoId });
+
+  if (beforePhoto.loading || afterPhoto.loading) return null;
+  if (!beforePhoto.url || !afterPhoto.url) return null;
+
+  return (
+    <div className="mb-4 shrink-0" data-testid="asset-timeline-before-after">
+      <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 flex items-center gap-1.5">
+        <Camera size={12} /> Evolución de la planta
+      </h4>
+      <BeforeAfterPhoto
+        before={{ url: beforePhoto.url, taken_at: oldest.timestamp ? oldest.timestamp * 1000 : null }}
+        after={{ url: afterPhoto.url, taken_at: newest.timestamp ? newest.timestamp * 1000 : null }}
+      />
+    </div>
+  );
+};
+
 const extractQuantity = (log) => {
   const qty = log.relationships?.quantity?.data?.[0]?.attributes;
   if (!qty) return '';
@@ -240,6 +268,22 @@ export default function AssetTimeline({ assetId }) {
     const totalGroups = new Set(logs.map(l => formatMonthKey(l.timestamp))).size;
     return totalGroups > visibleMonths;
   }, [logs, visibleMonths]);
+
+  // Fotos adjuntas ([PHOTO_ATTACHMENT]) de ESTE activo, ordenadas cronológicamente.
+  // Se derivan de TODOS los logs (no solo los meses visibles/paginados) para que
+  // la comparación antes/después no dependa de cuántos meses haya cargado el
+  // operador. oldestPhoto/newestPhoto alimentan PhotoEvolutionSection.
+  const photoAttachments = useMemo(() => {
+    const found = [];
+    for (const log of logs) {
+      const attachment = parsePhotoAttachment(extractNotes(log));
+      if (attachment) found.push({ photoId: attachment.photoId, timestamp: log.timestamp });
+    }
+    return found.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+  }, [logs]);
+  const oldestPhoto = photoAttachments[0];
+  const newestPhoto = photoAttachments[photoAttachments.length - 1];
+  const showPhotoEvolution = photoAttachments.length >= 2 && oldestPhoto !== newestPhoto;
 
   if (!assetId) {
     return (
@@ -420,6 +464,10 @@ export default function AssetTimeline({ assetId }) {
           </span>
         )}
       </div>
+
+      {showPhotoEvolution && (
+        <PhotoEvolutionSection oldest={oldestPhoto} newest={newestPhoto} />
+      )}
 
       {logs.length === 0 ? (
         <div className="flex-1 flex flex-col items-center justify-center text-center text-slate-500 min-h-[300px]">

--- a/src/components/__tests__/AssetTimeline.beforeAfter.test.jsx
+++ b/src/components/__tests__/AssetTimeline.beforeAfter.test.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AssetTimeline from '../AssetTimeline';
+
+// Dos logs [PHOTO_ATTACHMENT] (formato real de useAssetStore.attachPhotoToLog) en
+// timestamps distintos: la más vieja y la más nueva deben alimentar el slider
+// BeforeAfterPhoto (comparación de evolución de la planta).
+const photoLogOld = {
+  id: 'log-photo-old',
+  type: 'log--task',
+  timestamp: 1700000000, // más vieja
+  attributes: {
+    name: 'Foto adjunta a evento',
+    notes: {
+      value: [
+        '[PHOTO_ATTACHMENT]',
+        'target_log_id: log-seeding-1',
+        'photo_ref: 101',
+        'attached_at: 2023-11-14T00:00:00.000Z',
+      ].join('\n'),
+    },
+  },
+  relationships: {},
+};
+
+const photoLogNew = {
+  id: 'log-photo-new',
+  type: 'log--task',
+  timestamp: 1760000000, // más reciente
+  attributes: {
+    name: 'Foto adjunta a evento',
+    notes: {
+      value: [
+        '[PHOTO_ATTACHMENT]',
+        'target_log_id: log-seeding-2',
+        'photo_ref: 202',
+        'attached_at: 2025-10-09T00:00:00.000Z',
+      ].join('\n'),
+    },
+  },
+  relationships: {},
+};
+
+vi.mock('../../store/useLogStore', () => {
+  // AssetTimeline en modo DEV inyecta 1000 logs sintéticos vía
+  // useLogStore.setState() cuando logs.length < 100 (stress test de la
+  // virtualización) — el mock necesita exponer `.setState` como el store real
+  // de zustand para no romper ese efecto con pocos logs de fixture.
+  const useLogStore = (selector) => selector({
+    logsByAsset: {
+      'asset-1': [photoLogNew, photoLogOld],
+      'asset-single-photo': [photoLogOld],
+    },
+    isSyncing: false,
+    loadLogsForAsset: vi.fn(),
+  });
+  useLogStore.setState = vi.fn();
+  return { useLogStore };
+});
+
+// Resuelve URLs distintas según el photoId pedido, simulando el hook real
+// (usePhotoUrl) que envuelve photoService.getPhotoById.
+vi.mock('../../hooks/usePhotoUrl', () => ({
+  usePhotoUrl: ({ photoId } = {}) => {
+    if (photoId === 101) return { loading: false, url: 'blob://foto-vieja', source: 'specific' };
+    if (photoId === 202) return { loading: false, url: 'blob://foto-nueva', source: 'specific' };
+    return { loading: false, url: null, source: 'missing' };
+  },
+}));
+
+vi.mock('../../services/payloadService', () => ({
+  savePayload: vi.fn(),
+}));
+
+vi.mock('../../utils/aiInferenceParser', () => ({
+  parseAiInference: () => null,
+  parseAiReview: () => null,
+}));
+
+vi.mock('react-virtuoso', () => ({
+  GroupedVirtuoso: ({ groupCounts = [], groupContent, itemContent, data, components }) => {
+    const elements = [];
+    let itemIdx = 0;
+    groupCounts.forEach((count, groupIdx) => {
+      if (groupContent) elements.push(<div key={`g-${groupIdx}`}>{groupContent(groupIdx)}</div>);
+      for (let i = 0; i < count; i++) {
+        const log = Array.isArray(data) ? data[itemIdx] : undefined;
+        elements.push(<div key={`i-${itemIdx}`}>{itemContent ? itemContent(itemIdx, log) : null}</div>);
+        itemIdx++;
+      }
+    });
+    const Footer = components?.Footer;
+    if (Footer) elements.push(<Footer key="footer" />);
+    return <div>{elements}</div>;
+  },
+}));
+
+describe('AssetTimeline — comparación antes/después (BeforeAfterPhoto)', () => {
+  it('renderiza el slider antes/después usando la foto más vieja y la más nueva del activo', () => {
+    render(<AssetTimeline assetId="asset-1" />);
+
+    expect(screen.getByTestId('asset-timeline-before-after')).toBeTruthy();
+    expect(screen.getByText('Evolución de la planta')).toBeTruthy();
+    // BeforeAfterPhoto renderiza el hint "Desliza para comparar" cuando ambas
+    // fotos (before/after) resuelven con URL.
+    expect(screen.getByText('Desliza para comparar')).toBeTruthy();
+  });
+
+  it('no renderiza la comparación si solo hay una foto adjunta', () => {
+    render(<AssetTimeline assetId="asset-single-photo" />);
+    expect(screen.queryByTestId('asset-timeline-before-after')).toBeNull();
+  });
+});

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -3,7 +3,7 @@
  * textos de carga/aria ("Cargando…", "Cargando contador") son strings de UI
  * preexistentes de este componente. Su migración a src/config/messages.js es
  * la TAREA i18n de ADR-050 (transversal a toda la app), fuera del alcance de
- * este refinamiento visual. Se silencia el warning soft acá para no bloquear
+ * este refinamiento visual. Se silencia el warning soft aquí para no bloquear
  * el commit sin arrastrar ese refactor i18n. */
 import { useEffect, useState } from 'react';
 import { Sprout, MapPin, Package, NotebookPen, Eye, AlertCircle, FileText, ChevronRight, Leaf, Network, Beaker, PawPrint } from 'lucide-react';
@@ -556,7 +556,7 @@ export function SeguimientoCard({ def, count, onNavigate, variant }) {
  * el perfil del usuario ("el usuario solo ve lo que necesita" — un urbano
  * NUNCA ve Cerdos). Lo decide el call-site (DashboardLive) vía
  * homeModuleSelector. Si `keys` se omite (null/undefined), se muestran las 4 —
- * comportamiento histórico, sin breaking change. La selección NO se decide acá;
+ * comportamiento histórico, sin breaking change. La selección NO se decide aquí;
  * este componente solo pinta las tarjetas permitidas.
  *
  * @param {Object} props

--- a/src/db/catalogDB.js
+++ b/src/db/catalogDB.js
@@ -48,7 +48,7 @@ async function doInit() {
     }
 
     // Validar shape mínimo: tabla species con rows. Si el CDN Pro sirvió un
-    // blob malformado, fallamos rápido acá en vez de degradar silencioso.
+    // blob malformado, fallamos rápido aquí en vez de degradar silencioso.
     assertCatalogShape(db);
 
     return db;
@@ -74,7 +74,7 @@ export async function initCatalog() {
         // NO es bloqueante (el home usa fallback de stats y los componentes
         // reintentan al usar el catálogo) y NO debe gritar console.error: es
         // ruido esperado en cada deploy. Degradamos a debug; loadCatalogBuffer
-        // ya reintentó una vez antes de llegar acá.
+        // ya reintentó una vez antes de llegar aquí.
         if (isAbortLikeFetchError(error)) {
             console.debug('[SQLite WASM] init del catálogo abortado (probable reload por SW nuevo); se reintentará on-demand.');
         } else {

--- a/src/pages/InventoryPage.jsx
+++ b/src/pages/InventoryPage.jsx
@@ -19,7 +19,7 @@
  * ScreenShell para navegación back/home), accesible desde la Bodega
  * ('bodega') vía el botón "Auditoría y reconciliación" del header.
  *
- * Role-gate recomendado (no implementado acá):
+ * Role-gate recomendado (no implementado aquí):
  *   - Solo usuarios con rol 'operador' o superior
  *   - Owner ve todos los items
  *   - Operadores comunes ven solo items que aplican a sus parcelas (futuro)

--- a/src/pages/InventoryPage.jsx
+++ b/src/pages/InventoryPage.jsx
@@ -1,18 +1,23 @@
 /**
- * InventoryPage, orquesta los 3 componentes del flujo inventario.
+ * InventoryPage, orquesta los flujos de inventario: stock en vivo, bitácora
+ * por ítem y el panel global de auditoría/reconciliación.
  *
  * Estado local:
  *   - selectedItemId: cuál ítem está siendo editado / inspeccionado
- *   - viewMode: 'dashboard' | 'audit', dashboard por default, audit al click
+ *   - viewMode: 'dashboard' | 'audit' | 'reconciliation'
+ *       - 'dashboard': stock en vivo (InventoryDashboard), default.
+ *       - 'audit': bitácora completa de UN ítem (InventoryAuditTrail).
+ *       - 'reconciliation': panel global de auditoría (InventoryAuditDashboard,
+ *         reconcileAllItems de inventoryReconcile.js) + línea de tiempo global
+ *         de eventos (InventoryEventTimeline, sin itemId).
  *   - recountTarget: si != null, abre el RecountDrawer
  *
  * Refresh strategy: después de cada appendEvent exitoso, recargar el
  * componente Dashboard cambiando una `refreshKey` que dispara su useEffect.
  *
- * Para integrar en App.jsx:
- *   import InventoryPage from './pages/InventoryPage';
- *   ...
- *   <Route path="/inventario" element={<InventoryPage />} />
+ * Ruteado en App.jsx bajo el case 'auditoria_inventario' (envuelto en
+ * ScreenShell para navegación back/home), accesible desde la Bodega
+ * ('bodega') vía el botón "Auditoría y reconciliación" del header.
  *
  * Role-gate recomendado (no implementado acá):
  *   - Solo usuarios con rol 'operador' o superior
@@ -21,8 +26,11 @@
  */
 
 import { useState, useCallback } from 'react';
+import { Scale } from 'lucide-react';
 import InventoryDashboard from '../components/InventoryDashboard.jsx';
 import InventoryAuditTrail from '../components/InventoryAuditTrail.jsx';
+import InventoryAuditDashboard from '../components/InventoryAuditDashboard.jsx';
+import InventoryEventTimeline from '../components/InventoryEventTimeline.jsx';
 import RecountDrawer from '../components/RecountDrawer.jsx';
 
 export default function InventoryPage() {
@@ -45,20 +53,56 @@ export default function InventoryPage() {
     setViewMode('audit');
   }, []);
 
+  const handleViewReconciliation = useCallback(() => {
+    setViewMode('reconciliation');
+  }, []);
+
   const handleBackToDashboard = useCallback(() => {
     setSelectedItemId(null);
     setViewMode('dashboard');
   }, []);
 
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--bg, #0e1116)' }}>
-      {viewMode === 'dashboard' ? (
+    <div style={{ background: 'var(--bg, #0e1116)' }} data-testid="inventory-page">
+      {viewMode === 'dashboard' && (
         <>
-          <header style={{ padding: '1rem 1.5rem', borderBottom: '1px solid var(--border, #30363d)' }}>
-            <h1 style={{ margin: 0, fontSize: '1.2rem' }}>Inventario</h1>
-            <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--fg-dim, #8b949e)' }}>
-              Stock en vivo · ADR-027 event sourcing · Local-first
-            </p>
+          <header
+            style={{
+              padding: '1rem 1.5rem',
+              borderBottom: '1px solid var(--border, #30363d)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: '1rem',
+              flexWrap: 'wrap',
+            }}
+          >
+            <div>
+              <h1 style={{ margin: 0, fontSize: '1.2rem' }}>Inventario</h1>
+              <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--fg-dim, #8b949e)' }}>
+                Stock en vivo · ADR-027 event sourcing · Local-first
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleViewReconciliation}
+              data-testid="inventory-open-reconciliation"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.4rem',
+                padding: '0.5rem 0.9rem',
+                borderRadius: '0.6rem',
+                border: '1px solid var(--border, #30363d)',
+                background: 'transparent',
+                color: 'inherit',
+                fontSize: '0.8rem',
+                fontWeight: 700,
+                cursor: 'pointer',
+              }}
+            >
+              <Scale size={14} /> Auditoría y reconciliación
+            </button>
           </header>
           <InventoryDashboard
             key={refreshKey}
@@ -66,7 +110,9 @@ export default function InventoryPage() {
             onViewAudit={handleViewAudit}
           />
         </>
-      ) : (
+      )}
+
+      {viewMode === 'audit' && (
         <>
           <header style={{ padding: '1rem 1.5rem', borderBottom: '1px solid var(--border, #30363d)', display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <button onClick={handleBackToDashboard} aria-label="Volver al dashboard">
@@ -81,6 +127,37 @@ export default function InventoryPage() {
             </button>
           </div>
         </>
+      )}
+
+      {viewMode === 'reconciliation' && (
+        <div data-testid="inventory-view-reconciliation">
+          <header style={{ padding: '1rem 1.5rem', borderBottom: '1px solid var(--border, #30363d)', display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <button onClick={handleBackToDashboard} aria-label="Volver al dashboard">
+              ← Volver
+            </button>
+            <h1 style={{ margin: 0, fontSize: '1.1rem' }}>Auditoría y reconciliación</h1>
+          </header>
+          <InventoryAuditDashboard />
+          <section style={{ padding: '1.5rem', paddingTop: '0.5rem' }}>
+            <h2
+              style={{
+                fontSize: '0.85rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+                color: 'var(--fg-dim, #8b949e)',
+                margin: '0 0 0.75rem',
+              }}
+            >
+              Línea de tiempo global de eventos
+            </h2>
+            {/* Altura explícita: InventoryEventTimeline usa GroupedVirtuoso
+                (react-virtuoso) con `height: 100%` internamente — sin un
+                ancestro con altura definida, el virtualizador colapsa a 0px. */}
+            <div style={{ height: '55vh' }}>
+              <InventoryEventTimeline />
+            </div>
+          </section>
+        </div>
       )}
 
       {recountTarget && (

--- a/src/pages/__tests__/InventoryPage.reconciliation.test.jsx
+++ b/src/pages/__tests__/InventoryPage.reconciliation.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import InventoryPage from '../InventoryPage';
+
+// Test de WIRING interno de InventoryPage (descubribilidad 2026-06-30):
+// verifica que la vista 'reconciliation' monta InventoryAuditDashboard
+// (reconcileAllItems de inventoryReconcile.js) + InventoryEventTimeline
+// (línea de tiempo global), los dos componentes que quedaban huérfanos junto
+// con InventoryAuditTrail. No probamos el render interno de cada componente
+// (fuera de scope acá) — solo que InventoryPage los alcanza y navega bien.
+vi.mock('../../components/InventoryDashboard', () => ({
+  InventoryDashboard: () => <div data-testid="inventory-dashboard-stub">dashboard stub</div>,
+  default: () => <div data-testid="inventory-dashboard-stub">dashboard stub</div>,
+}));
+vi.mock('../../components/InventoryAuditTrail', () => ({
+  default: () => <div data-testid="inventory-audit-trail-stub">audit trail stub</div>,
+}));
+vi.mock('../../components/InventoryAuditDashboard', () => ({
+  default: () => <div data-testid="inventory-audit-dashboard-stub">reconciliation stub</div>,
+}));
+vi.mock('../../components/InventoryEventTimeline', () => ({
+  default: () => <div data-testid="inventory-event-timeline-stub">timeline stub</div>,
+}));
+
+describe('InventoryPage — vista de auditoría y reconciliación', () => {
+  it('el botón "Auditoría y reconciliación" monta InventoryAuditDashboard + InventoryEventTimeline', async () => {
+    render(<InventoryPage />);
+    expect(screen.getByTestId('inventory-dashboard-stub')).toBeTruthy();
+
+    await userEvent.click(screen.getByTestId('inventory-open-reconciliation'));
+
+    expect(screen.getByTestId('inventory-view-reconciliation')).toBeTruthy();
+    expect(screen.getByTestId('inventory-audit-dashboard-stub')).toBeTruthy();
+    expect(screen.getByTestId('inventory-event-timeline-stub')).toBeTruthy();
+    expect(screen.queryByTestId('inventory-dashboard-stub')).toBeNull();
+  });
+
+  it('"← Volver" regresa al dashboard de stock en vivo', async () => {
+    render(<InventoryPage />);
+    await userEvent.click(screen.getByTestId('inventory-open-reconciliation'));
+    expect(screen.getByTestId('inventory-view-reconciliation')).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: /volver al dashboard/i }));
+    expect(screen.getByTestId('inventory-dashboard-stub')).toBeTruthy();
+    expect(screen.queryByTestId('inventory-view-reconciliation')).toBeNull();
+  });
+});

--- a/src/pages/__tests__/InventoryPage.reconciliation.test.jsx
+++ b/src/pages/__tests__/InventoryPage.reconciliation.test.jsx
@@ -9,7 +9,7 @@ import InventoryPage from '../InventoryPage';
 // (reconcileAllItems de inventoryReconcile.js) + InventoryEventTimeline
 // (línea de tiempo global), los dos componentes que quedaban huérfanos junto
 // con InventoryAuditTrail. No probamos el render interno de cada componente
-// (fuera de scope acá) — solo que InventoryPage los alcanza y navega bien.
+// (fuera de scope aquí) — solo que InventoryPage los alcanza y navega bien.
 vi.mock('../../components/InventoryDashboard', () => ({
   InventoryDashboard: () => <div data-testid="inventory-dashboard-stub">dashboard stub</div>,
   default: () => <div data-testid="inventory-dashboard-stub">dashboard stub</div>,

--- a/src/services/agentPromptBase.js
+++ b/src/services/agentPromptBase.js
@@ -341,7 +341,7 @@ const TOMATE_SAFETY_RULES = [
 export function buildCampesinoModeBlock() {
   return `=== MODO CAMPESINO (registro oral campesino colombiano) ===
 Habla como un campesino colombiano experimentado, NO como un sistema técnico:
-- Usa tú/usted colombiano (NEVER vos/tenés/querés del argentino/rioplatense)
+- Usa tú/usted colombiano (NEVER vos/tienes/quieres del argentino/rioplatense)
 - Frases cortas y directas, como habla la gente del campo
 - Unidades del campo: cuadra, arroba, luna, bike de agua, plaza, hueco
 - NO uses binomios científicos (Coffea arabica, Solanum tuberosum) salvo que el usuario los pida explícitamente

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -420,7 +420,7 @@ export const logoutUser = async () => {
         console.error('[Auth] logoutUser failed (tokens may persist):', err);
     }
     // ADR-036 MVP multi-finca: limpiar tenantId asegura que un re-login con
-    // otro usuario no herede el scope del anterior. NO purgamos IDB acá —
+    // otro usuario no herede el scope del anterior. NO purgamos IDB aquí —
     // useAssetStore decide qué hacer al detectar el cambio de tenantId.
     try {
         clearActiveTenantId();

--- a/src/services/capabilityHealth.js
+++ b/src/services/capabilityHealth.js
@@ -12,7 +12,7 @@ import { fetchWithAuthRetry } from './apiService.js';
 /**
  * Tools que dependen del sidecar MCP agro (ALLOWED_TOOLS en sidecarClient).
  * Si el sidecar está caído/deshabilitado, las capacidades que usan estas
- * tools se marcan 'down'. Las capacidades con tools NO listadas acá son
+ * tools se marcan 'down'. Las capacidades con tools NO listadas aquí son
  * offline-first y siempre están 'live'.
  */
 export const SIDECAR_TOOL_NAMES = new Set([

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -13,7 +13,7 @@
  *
  * Este módulo es PURO (sin red, sin React): mapea (intent, texto, opts) a un
  * "plan forzado" que el AgentScreen ejecuta sin pasar por `planNlu()`. Toda la
- * lógica de routing vive acá para poder testearla en aislamiento (TDD).
+ * lógica de routing vive aquí para poder testearla en aislamiento (TDD).
  *
  * CHIP_INTENTS y CHIP_DEFS se importan de agentCapabilities.js (fuente única
  * de verdad). Este módulo NO redefine esas constantes.

--- a/src/services/farmEventService.js
+++ b/src/services/farmEventService.js
@@ -2,7 +2,7 @@
  * farmEventService — única puerta de escritura para eventos de ciclo.
  *
  * recordFarmEvent es la función autorizada para mutar el agregado.
- * Toda escritura pasa por acá. No exponer al LLM sin pruebas E2E.
+ * Toda escritura pasa por aquí. No exponer al LLM sin pruebas E2E.
  */
 import { openDB, STORES } from '../db/dbCore';
 import { newUlid } from '../utils/id';

--- a/src/services/fincaSceneProfileSelector.js
+++ b/src/services/fincaSceneProfileSelector.js
@@ -23,7 +23,7 @@
  * REUSO (no se duplica nada): la derivación de ROL vive en
  * `profileChipSelector.deriveRole` (fuente única); `esPerfilUrbano`,
  * `profileTieneAnimales` y `profileTieneCerdos` viven en `homeModuleSelector` /
- * `profileChipSelector` (fuentes únicas). Acá solo se importan y se mapean. El
+ * `profileChipSelector` (fuentes únicas). Aquí solo se importan y se mapean. El
  * cálculo de nivel Gliessman NO vive aquí (es de fincaGameService).
  *
  * REGLA — coherencia con el override urbano del home: si `esPerfilUrbano` es

--- a/src/services/homeModuleSelector.js
+++ b/src/services/homeModuleSelector.js
@@ -13,13 +13,13 @@
  *
  * Este módulo es PURO (sin red, sin React, sin localStorage): mapea un perfil
  * de usuario → la lista de módulos del home + las tarjetas de seguimiento que
- * le corresponden. Toda la lógica vive acá para testearla en aislamiento
+ * le corresponden. Toda la lógica vive aquí para testearla en aislamiento
  * (TDD), igual que `profileChipSelector.selectChipIntents`.
  *
  * REUSO: la derivación de ROL vive en `profileChipSelector.deriveRole` (fuente
  * única — no se duplica). Este módulo la importa y mapea cada rol a su set de
  * módulos. El gating de seguridad del módulo glaciar (whitelist La Cordada)
- * NO vive acá: el tile glaciar tiene su propio gate (`glaciarAccess`).
+ * NO vive aquí: el tile glaciar tiene su propio gate (`glaciarAccess`).
  *
  * RESPETO A #1560/#7003: este módulo SOLO calcula el DEFAULT por perfil. Si el
  * usuario guardó una preferencia manual de visibilidad en `ProfileScreen`, esa
@@ -36,9 +36,9 @@ import { deriveRole, profileTieneAnimales, PROFILE_ROLES } from './profileChipSe
 /**
  * IDs de los módulos del Home (deben coincidir con `HOME_MODULES` de
  * userProfileService + `SECTION_COMPONENTS` de DashboardLive). Fuente de
- * verdad de los ids: userProfileService.HOME_MODULES — acá solo los nombramos
+ * verdad de los ids: userProfileService.HOME_MODULES — aquí solo los nombramos
  * para los sets por rol. Si se agrega un módulo nuevo allá, agregarlo al set
- * del rol que lo necesite acá (default fail-open en el call-site lo cubre
+ * del rol que lo necesite aquí (default fail-open en el call-site lo cubre
  * mientras tanto).
  *
  * @enum {string}
@@ -68,7 +68,7 @@ export const ALL_HOME_MODULES = Object.freeze(Object.values(HOME_MODULE_IDS));
 /**
  * Keys de las 4 tarjetas de SEGUIMIENTO de procesos de finca. Deben coincidir
  * con las `key` de `config/seguimientoProcesos.js` (reforestacion ·
- * silvopastoreo · paramo · cerdos). Las nombramos acá para no acoplar este
+ * silvopastoreo · paramo · cerdos). Las nombramos aquí para no acoplar este
  * módulo puro al import del catálogo de seguimiento (que arrastra estilos).
  *
  * @enum {string}

--- a/src/services/homeModuleSelector.js
+++ b/src/services/homeModuleSelector.js
@@ -23,7 +23,7 @@
  *
  * RESPETO A #1560/#7003: este módulo SOLO calcula el DEFAULT por perfil. Si el
  * usuario guardó una preferencia manual de visibilidad en `ProfileScreen`, esa
- * preferencia GANA — el call-site (DashboardLive) decide cuál usar. Acá no se
+ * preferencia GANA — el call-site (DashboardLive) decide cuál usar. Aquí no se
  * lee ni se escribe ninguna preferencia.
  *
  * Español colombiano (tú/usted), NUNCA voseo argentino.
@@ -168,7 +168,7 @@ const ROLE_MODULES = Object.freeze({
 const ROLE_SEGUIMIENTO = Object.freeze({
   [PROFILE_ROLES.campesino]: Object.freeze([]),
   // Ganadero: silvopastoreo SIEMPRE; cerdos SOLO si el perfil tiene cerdos
-  // (se resuelve en selectHomeModules). Acá dejamos silvopastoreo de base.
+  // (se resuelve en selectHomeModules). Aquí dejamos silvopastoreo de base.
   [PROFILE_ROLES.ganadero]: Object.freeze([SEGUIMIENTO_KEYS.silvopastoreo]),
   [PROFILE_ROLES.restaurador]: Object.freeze([
     SEGUIMIENTO_KEYS.reforestacion,

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -631,7 +631,7 @@ const DOSE_PATTERNS = [
  *
  * Anti-sobre-supresión: la dosis sola (respuesta orgánica con "2 kg de compost")
  * NO basta — hace falta el token sintético. Un biopreparado permitido nunca es
- * sintético (no entra acá).
+ * sintético (no entra aquí).
  *
  * @param {string} norm  texto ya normalizado (minúsculas, sin tildes).
  * @returns {boolean}
@@ -815,7 +815,7 @@ const FUEL_AS_ADJUVANT_RE =
  * ¿El texto normalizado usa un combustible/solvente como adyuvante de un preparado
  * CON una dosis (o con un verbo de mezcla/adherencia)? Esa conjunción delata la
  * RECETA peligrosa de BORDE-020 que debe SUPRIMIRSE. Anti-sobre-supresión: sin el
- * verbo de mezcla/adherencia ni dosis (p.ej. "no le eches diésel") no entra acá; la
+ * verbo de mezcla/adherencia ni dosis (p.ej. "no le eches diésel") no entra aquí; la
  * advertencia de no-usar la corta el gate `esAdvertenciaNoUsar` en el guard.
  *
  * @param {string} norm  texto normalizado (minúsculas, sin tildes).
@@ -1033,7 +1033,7 @@ export function guardSyntheticAgrochemical(responseText, _resolvedEntities = nul
   // devolvemos SOLO el bloque de redirección orgánica. Append-only dejaba la
   // dosis sintética legible debajo del aviso (el campesino igual la leía). La
   // supresión SOLO dispara con sintético + dosis: una respuesta orgánica con
-  // cantidades ("2 kg de compost", "1 L de biol por planta") NO entra acá
+  // cantidades ("2 kg de compost", "1 L de biol por planta") NO entra aquí
   // (`_hasSyntheticFertilizerDose` exige un token SINTÉTICO, no orgánico).
   if (_hasSyntheticFertilizerDose(norm)) {
     return {
@@ -3898,7 +3898,7 @@ const DIFFERENTIAL_PHRASING_RE =
  * oración o conector), colisionan con "Género" de un binomio y producirían
  * falsos positivos en `_namesLatinBinomial` ("Mientras tanto", "Para saber",
  * "Una mancha", "Esas hojas"). Normalizadas sin tildes/case. NO son géneros
- * latinos; si el "Género" candidato está acá, no cuenta como binomio.
+ * latinos; si el "Género" candidato está aquí, no cuenta como binomio.
  */
 const BINOMIAL_GENUS_STOPWORDS = new Set([
   'mientras', 'para', 'una', 'unas', 'unos', 'esas', 'esos', 'esta', 'este', 'estas',
@@ -4023,7 +4023,7 @@ export function guardDiagnosisWithoutPhoto(
   //   (c) fraseo diferencial enumerando candidatos.
   // Un solo patógeno confiado ("es tizón tardío") es el caso MÁS dañino: manda
   // a tratar a ciegas con plena seguridad. Una respuesta que solo da manejo
-  // cultural genérico (sin patógeno ni latín) NO entra acá.
+  // cultural genérico (sin patógeno ni latín) NO entra aquí.
   let nombraPatogeno = false;
   for (const term of PATHOGEN_NAME_TERMS) {
     if (norm.includes(term)) { nombraPatogeno = true; break; }
@@ -5748,7 +5748,7 @@ export function guardSurfaceConfusionWarning(responseText, resolvedEntities = nu
   }
 
   // Sin confusión tóxica crítica activa → no tocamos nada (anti-FP central: un
-  // alimento seguro con consejo de consumo crudo —lechuga, lulo— NO entra acá).
+  // alimento seguro con consejo de consumo crudo —lechuga, lulo— NO entra aquí).
   if (!toxicCw) {
     return { text: responseText, modified: false, reason: null };
   }
@@ -6182,7 +6182,7 @@ function _extractAltitudesWide(norm) {
   const reUnit = /\b(\d{1,2}[.,]?\d{3}|\d{2,4})\s*(m|msnm|metros|mts)\b/g;
   let m;
   while ((m = reUnit.exec(norm)) !== null) {
-    // Excluir falsos: "20 litros"/"8 dias" no llegan acá (la unidad es de altitud),
+    // Excluir falsos: "20 litros"/"8 dias" no llegan aquí (la unidad es de altitud),
     // pero "20 m" sí — la cota inferior plausible para un cultivo es ~100 msnm.
     const n = Number(m[1].replace(/[.,]/g, ''));
     if (Number.isFinite(n) && n >= 50 && n <= 5000) out.push(n);

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -1825,7 +1825,7 @@ function _presentaComoViable(textNorm, nombreNorm) {
  * viabilidad. El re-bench (2026-05-31) mostró que el detector anterior
  * (`_presentaComoViable`) se apoyaba en un léxico de viabilidad ("es viable",
  * "prospera", "recomendable") y se le escapaban respuestas que igual mandaban a
- * sembrar con otro fraseo (curuba CPX-010, chugua CPX-001). Acá basta con que
+ * sembrar con otro fraseo (curuba CPX-010, chugua CPX-001). Aquí basta con que
  * el texto INVITE a sembrar/cultivar la especie y NO advierta inviabilidad.
  *
  * Esto se usa SOLO cuando el grounding (campo viabilidad o banda de altitud) ya

--- a/src/services/profileChipSelector.js
+++ b/src/services/profileChipSelector.js
@@ -8,7 +8,7 @@
  *
  * Este módulo es PURO (sin red, sin React, sin localStorage): mapea un perfil
  * de usuario + sus módulos visibles + su rol → la lista ORDENADA de intents de
- * chip a mostrar. Toda la lógica vive acá para testearla en aislamiento (TDD),
+ * chip a mostrar. Toda la lógica vive aquí para testearla en aislamiento (TDD),
  * igual que `chipIntentRouter.planForcedIntent`.
  *
  * REGLA INVIOLABLE — no inventar chips. Solo seleccionamos y ordenamos los

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -287,7 +287,7 @@ export async function executeToolChain(chain) {
  * normativa ICA defensiva, clima IDEAM nacional y precios SIPSA DANE.
  *
  * TODO(NLU): add keywords agroquimico/clima/precio in chagra-pro nlu.ts
- * (sidecar repo, NO acá) para que el planner las routee automáticamente.
+ * (sidecar repo, NO aquí) para que el planner las routee automáticamente.
  * Mientras tanto el frontend hace detection por keywords + invocación
  * directa de los wrappers (ver AgentScreen handleSubmit).
  */
@@ -330,7 +330,7 @@ const ALLOWED_TOOLS = new Set([
   // ── Reconciliación allow-list cliente ↔ 41 tools del NLU (fix grounding P0
   //    2026-06-25). El NLU planner conocía 41 tools pero el cliente exponía 20:
   //    si el planner ruteaba a una de las 21 restantes, el turno degradaba a
-  //    RAG SIN grounding en silencio. Agregamos acá las tools que son SEGURAS y
+  //    RAG SIN grounding en silencio. Agregamos aquí las tools que son SEGURAS y
   //    VALIOSAS de exponer (grounding del grafo AGE / catálogo / dataset
   //    institucional local, ruteables por el NLU con id|nombre|término).
   //

--- a/src/services/versionCheck.js
+++ b/src/services/versionCheck.js
@@ -22,7 +22,7 @@
  * (Network-First en el SW) → bundle nuevo → SHA coincide → no recarga otra vez.
  *
  * Es belt-and-suspenders del auto-update: si éste ya recargó, el SHA coincide y
- * acá no pasa nada. Si el auto-update falló, esta ruta lo rescata.
+ * aquí no pasa nada. Si el auto-update falló, esta ruta lo rescata.
  *
  * ── ANTI-LOOP (crítico) ───────────────────────────────────────────────────
  * Guard por sessionStorage (`chagra:self-heal-reloaded`): recargamos como mucho
@@ -81,7 +81,7 @@ export function shasMatch(a, b) {
 
 /**
  * Decide si el cliente debe auto-recuperarse (recargar) por desfase de versión.
- * Función pura: toda la política de decisión vive acá para testearla aislada.
+ * Función pura: toda la política de decisión vive aquí para testearla aislada.
  *
  * @param {object} params
  * @param {string} params.runningSha — SHA embebido en el bundle corriendo.
@@ -302,7 +302,7 @@ async function defaultSkipWaiting() {
 
 function defaultReload() {
   // Indirección vía import dinámico para reusar pageReload (mockeable en test).
-  // Import estático arriba crearía un ciclo innecesario; acá basta location.
+  // Import estático arriba crearía un ciclo innecesario; aquí basta location.
   try {
     window.location.reload();
   } catch (_) { /* entorno sin window (SSR/test) — no-op */ }

--- a/src/services/voiceService.js
+++ b/src/services/voiceService.js
@@ -37,7 +37,7 @@ export async function transcribe(blob, options = {}) {
   // Guard: un Blob vacío o diminuto (captura fallida en móvil — MediaRecorder
   // a veces produce un webm de 0 bytes o truncado) hace que Whisper responda
   // HTTP 500 "Failed to load audio: End of file / invalid EBML number". Cortar
-  // acá con un mensaje claro al usuario en vez del round-trip + 500 críptico.
+  // aquí con un mensaje claro al usuario en vez del round-trip + 500 críptico.
   const MIN_AUDIO_BYTES = 1024;
   if (!blob || typeof blob.size !== 'number' || blob.size < MIN_AUDIO_BYTES) {
     throw new Error('No se grabó audio. Mantén presionado el botón y habla cerca del micrófono.');

--- a/src/utils/imageCompress.js
+++ b/src/utils/imageCompress.js
@@ -17,7 +17,7 @@
  * Esta es la primera capa de defensa contra payloads gigantes hacia el
  * sidecar agro-mcp (que arranca con `bodyLimit` chico). Es complementaria a
  * `photoService.captureAndCompress` que apunta a 500 KB para persistencia
- * local — acá apuntamos a un techo distinto (2 MB) porque el sidecar es
+ * local — aquí apuntamos a un techo distinto (2 MB) porque el sidecar es
  * quien define el límite de red.
  *
  * Diseño puro: NO toca IndexedDB, NO toca red, NO toca catálogo. Recibe un


### PR DESCRIPTION
## Summary

Expone dos features que estaban construidas pero huérfanas (0 importers / sin ruta alcanzable) en la PWA.

**1. BeforeAfterPhoto (slider antes/después de evolución de cultivo)**
- Se monta en `AssetTimeline.jsx` (la línea de tiempo del activo, visible en la ficha de asset) como una sección nueva "Evolución de la planta".
- Deriva automáticamente la foto **más antigua** y la **más reciente** adjuntadas a la misma mata (marcadores `[PHOTO_ATTACHMENT]` que ya produce el propio timeline) y las cablea a las props `before`/`after` del slider.
- Solo se renderiza si hay al menos 2 fotos distintas y ambas URLs resuelven vía `usePhotoUrl`; si falta alguna, no deja hueco (degrada limpio).
- Así el productor puede comparar dos fotos de la misma planta a lo largo del tiempo sin ir foto por foto.

**2. Auditoría / reconciliación de inventario**
- `InventoryPage.jsx` no estaba ruteado en `App.jsx`; `InventoryAuditDashboard.jsx`, `InventoryEventTimeline.jsx`, `InventoryAuditTrail.jsx` y los servicios `inventoryReconcile.js` / `inventoryEvents.js` estaban completos pero inalcanzables.
- Se agrega el case `auditoria_inventario` en `App.jsx` (lazy import + `ScreenShell`, siguiendo el patrón existente), con entradas por el botón "Auditoría" del header de la Bodega y por hash directo (`#auditoria-inventario`).
- `InventoryPage` se amplía con una vista de reconciliación que monta `InventoryAuditDashboard` (reconcilia eventos vs snapshot) + `InventoryEventTimeline` (línea de tiempo global de eventos), dejando la capa de auditoría/reconciliación alcanzable.

Respeta el patrón lazy/rutas de `App.jsx`, los `data-testid` existentes y el tono colombiano usted. No rompe nada existente.

## Test plan

- `src/components/__tests__/AssetTimeline.beforeAfter.test.jsx` — verifica que el slider antes/después se monta usando la foto más vieja y la más nueva; y que NO aparece con una sola foto adjunta.
- `src/pages/__tests__/InventoryPage.reconciliation.test.jsx` — verifica que el botón "Auditoría y reconciliación" monta `InventoryAuditDashboard` + `InventoryEventTimeline`, y que "Volver" regresa al dashboard de stock.
- `src/__tests__/App.auditoria-inventario-route.test.jsx` — verifica que `#auditoria-inventario` rutea a `InventoryPage` y que el botón "Auditoría" de la Bodega navega allí.
- Regresión: `App.subsuelo-route`, `App.evolucion-route`, `InventoryEventTimeline.smoke`, `AssetTimeline.smoke`, `inventoryReconcile`, `inventoryEvents`, `inventoryService` siguen verdes.
- ESLint: sin errores nuevos (solo warnings preexistentes de `chagra-i18n`, regla soft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)