### PR TITLE
feat(agent): chips descubribles para tools de grounding

### DIFF
--- a/src/components/ChipsToolbar.jsx
+++ b/src/components/ChipsToolbar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CHIP_DEFS, CHIP_INTENTS } from '../services/chipIntentRouter';
 import { isDeepResearchEnabled } from '../services/deepResearchClient';
 
@@ -51,6 +51,16 @@ import { isDeepResearchEnabled } from '../services/deepResearchClient';
  *                     change. Este componente NO decide la selección: solo
  *                     pinta lo que recibe con su CSS actual (la legibilidad/
  *                     estilo la lleva otro stream).
+ *
+ * Grupo "Más" (grounding oscuro, 2026-07-01): algunos chips del manifiesto
+ * (toxicidad, saberes tradicionales, alerta normativa páramo, variedades,
+ * polinización, fenología — `moreGroup:true` en CHIP_DEFS, derivado de
+ * `chipMore` en agentCapabilities.js) son consultas puntuales del grafo, NO el
+ * núcleo diario. Para no saturar la barra principal se agrupan detrás de un
+ * chip toggle "Más" (`data-testid="mode-chip-more"`): al tocarlo se despliega
+ * un SEGUNDO `role="toolbar"` con esos chips, pintados con el MISMO patrón
+ * (mismo `onSelectIntent`, mismo `data-testid="mode-chip"`, mismo
+ * aria-pressed/disabled) — cero mecanismo nuevo, solo una repisa aparte.
  */
 const ChipsToolbar = React.memo(function ChipsToolbar({
   onSelectIntent,
@@ -60,6 +70,11 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
   isPro = false,
   chipDefs = null,
 }) {
+  // Toggle del grupo "Más" (chips de grounding puntual — ver docstring
+  // arriba). Hook ANTES del early-return de abajo (reglas de hooks: siempre
+  // en el mismo orden, nunca condicional).
+  const [showMore, setShowMore] = useState(false);
+
   if (typeof onSelectIntent !== 'function') return null;
 
   // Selección por perfil (si el call-site la pasa) o catálogo completo (default
@@ -76,6 +91,14 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
     ? sourceDefs
     : sourceDefs.filter((def) => def.intent !== CHIP_INTENTS.deep);
 
+  // Grupo "Más": chips de grounding puntual (toxicidad, saberes tradicionales,
+  // alerta páramo, variedades, polinización, fenología) que NO se pintan en la
+  // fila principal — se agrupan detrás del toggle para no saturar la barra
+  // con el núcleo diario. `coreChipDefs` conserva EXACTAMENTE el comportamiento
+  // histórico (mismo orden, mismo contenido) para no romper nada existente.
+  const coreChipDefs = visibleChipDefs.filter((def) => !def.moreGroup);
+  const moreChipDefs = visibleChipDefs.filter((def) => def.moreGroup);
+
   const baseChip =
     'shrink-0 inline-flex items-center gap-1.5 px-3.5 py-2 rounded-full border ' +
     'text-sm font-semibold whitespace-nowrap transition-all active:scale-95 ' +
@@ -90,6 +113,46 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
   // Chip Pro bloqueado: apariencia visualmente diferenciada para free users.
   const proLockedChip =
     'bg-slate-800 border-slate-700 text-slate-500 cursor-not-allowed';
+
+  // Render de UN chip de modo — compartido entre la fila principal y el
+  // grupo "Más" (mismo mecanismo: onSelectIntent(def.intent), mismo testid,
+  // mismo aria-pressed/disabled). Evita duplicar el markup entre las dos filas.
+  const renderChip = (def) => {
+    const isActive = activeIntent === def.intent;
+    // El chip 🔬 Deep Research es Pro-only. Para usuarios free: deshabilitado
+    // con copy claro "función Pro" y title explicativo. NO se oculta — el
+    // usuario free debe saber que la funcionalidad existe (upsell suave).
+    const isDeepChip = def.intent === CHIP_INTENTS.deep;
+    const isProLocked = isDeepChip && !isPro;
+    const chipDisabled = disabled || isProLocked;
+    const chipClass = isProLocked
+      ? proLockedChip
+      : isActive
+        ? activeChip
+        : inactiveChip;
+    const chipTitle = isProLocked
+      ? 'Función Pro — disponible para usuarios con acceso avanzado'
+      : def.placeholder;
+
+    return (
+      <button
+        key={def.intent}
+        type="button"
+        data-testid="mode-chip"
+        data-intent={def.intent}
+        data-pro-locked={isProLocked ? 'true' : undefined}
+        onClick={() => !isProLocked && onSelectIntent(def.intent)}
+        disabled={chipDisabled}
+        aria-pressed={isActive}
+        aria-label={isProLocked ? `${def.label} — función Pro` : def.label}
+        title={chipTitle}
+        className={`${baseChip} ${chipClass}`}
+      >
+        <span aria-hidden="true">{def.emoji}</span>
+        <span>{isProLocked ? `${def.label} (Pro)` : def.label}</span>
+      </button>
+    );
+  };
 
   return (
     <div
@@ -116,43 +179,38 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
           </button>
         )}
 
-        {visibleChipDefs.map((def) => {
-          const isActive = activeIntent === def.intent;
-          // El chip 🔬 Deep Research es Pro-only. Para usuarios free: deshabilitado
-          // con copy claro "función Pro" y title explicativo. NO se oculta — el
-          // usuario free debe saber que la funcionalidad existe (upsell suave).
-          const isDeepChip = def.intent === CHIP_INTENTS.deep;
-          const isProLocked = isDeepChip && !isPro;
-          const chipDisabled = disabled || isProLocked;
-          const chipClass = isProLocked
-            ? proLockedChip
-            : isActive
-              ? activeChip
-              : inactiveChip;
-          const chipTitle = isProLocked
-            ? 'Función Pro — disponible para usuarios con acceso avanzado'
-            : def.placeholder;
+        {coreChipDefs.map(renderChip)}
 
-          return (
-            <button
-              key={def.intent}
-              type="button"
-              data-testid="mode-chip"
-              data-intent={def.intent}
-              data-pro-locked={isProLocked ? 'true' : undefined}
-              onClick={() => !isProLocked && onSelectIntent(def.intent)}
-              disabled={chipDisabled}
-              aria-pressed={isActive}
-              aria-label={isProLocked ? `${def.label} — función Pro` : def.label}
-              title={chipTitle}
-              className={`${baseChip} ${chipClass}`}
-            >
-              <span aria-hidden="true">{def.emoji}</span>
-              <span>{isProLocked ? `${def.label} (Pro)` : def.label}</span>
-            </button>
-          );
-        })}
+        {/* Toggle "Más": solo aparece si hay chips de grounding puntual para
+            mostrar. Despliega un segundo toolbar debajo con esos chips. */}
+        {moreChipDefs.length > 0 && (
+          <button
+            type="button"
+            data-testid="mode-chip-more"
+            onClick={() => setShowMore((v) => !v)}
+            disabled={disabled}
+            aria-expanded={showMore}
+            aria-controls="chips-toolbar-more"
+            aria-label={showMore ? 'Ocultar más consultas del agente' : 'Más consultas del agente'}
+            title="Más consultas: toxicidad, saberes tradicionales, variedades, polinización, fenología y normativa de páramo"
+            className={`${baseChip} ${showMore ? activeChip : inactiveChip}`}
+          >
+            <span aria-hidden="true">{showMore ? '➖' : '➕'}</span>
+            <span>Más</span>
+          </button>
+        )}
       </div>
+
+      {moreChipDefs.length > 0 && showMore && (
+        <div
+          id="chips-toolbar-more"
+          role="toolbar"
+          aria-label="Más consultas del agente"
+          className="flex flex-wrap gap-2 pt-2 mt-2 border-t border-white/10"
+        >
+          {moreChipDefs.map(renderChip)}
+        </div>
+      )}
     </div>
   );
 });

--- a/src/components/__tests__/ChipsToolbar.groundingChips.test.jsx
+++ b/src/components/__tests__/ChipsToolbar.groundingChips.test.jsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import ChipsToolbar from '../ChipsToolbar';
+import { CHIP_DEFS, planForcedIntent } from '../../services/chipIntentRouter';
+import * as deepResearchClient from '../../services/deepResearchClient';
+
+/**
+ * ChipsToolbar.groundingChips.test.jsx — cobertura dedicada de los chips de
+ * "grounding oscuro" (2026-07-01): tools que YA vivían en el grafo/catálogo
+ * (ver ALLOWED_TOOLS en sidecarClient.js) pero SOLO eran alcanzables por
+ * texto libre en el chat — ningún chip las disparaba.
+ *
+ * Se agrupan bajo el toggle "Más" (`data-testid="mode-chip-more"`) para no
+ * saturar la barra principal con 6 chips nuevos de golpe (ver docstring de
+ * ChipsToolbar.jsx). Este archivo cubre:
+ *   1. Los 6 chips EXISTEN en el manifiesto (CHIP_DEFS) con label/emoji.
+ *   2. Por defecto están OCULTOS (agrupados, no saturan la barra principal).
+ *   3. El toggle "Más" los revela (segundo nivel/second-level UI).
+ *   4. Cada uno, al tocarlo, dispara `onSelectIntent(intent)` — MISMO
+ *      mecanismo que los chips existentes (ninguno nuevo).
+ *   5. `planForcedIntent` mapea cada intent al tool correcto (grounding real,
+ *      no solo un botón decorativo).
+ */
+
+const GROUNDING_CHIPS = [
+  { intent: 'toxicidad', label: 'Toxicidad', tool: 'get_toxicidad' },
+  { intent: 'saberes_tradicionales', label: 'Saberes tradicionales', tool: 'get_saberes_tradicionales' },
+  { intent: 'alerta_paramo', label: 'Alerta normativa páramo', tool: 'get_alerta_normativa_paramo' },
+  { intent: 'variedades', label: 'Variedades', tool: 'get_variedades_cultivo' },
+  { intent: 'polinizacion', label: 'Polinización', tool: 'get_polinizacion' },
+  { intent: 'fenologia', label: 'Fenología', tool: 'get_fenologia' },
+];
+
+describe('ChipsToolbar — grounding oscuro: los chips existen en el manifiesto', () => {
+  test('CHIP_DEFS incluye los 6 chips nuevos, marcados moreGroup:true', () => {
+    for (const { intent, label } of GROUNDING_CHIPS) {
+      const def = CHIP_DEFS.find((d) => d.intent === intent);
+      expect(def, `falta el chip ${intent} en CHIP_DEFS`).toBeTruthy();
+      expect(def.label).toBe(label);
+      expect(def.kind).toBe('tool');
+      expect(def.moreGroup).toBe(true);
+      expect(typeof def.emoji).toBe('string');
+      expect(def.emoji.length).toBeGreaterThan(0);
+      expect(typeof def.placeholder).toBe('string');
+      expect(def.placeholder.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('ningún chip nuevo usa voseo argentino', () => {
+    const VOSEO = /\b(escrib[íi]|tom[áa]|ten[ée]s|quer[ée]s|eleg[íi]|pod[ée]s|dale|sab[ée]s|and[áa]|fij[áa]te)\b/i;
+    for (const { intent } of GROUNDING_CHIPS) {
+      const def = CHIP_DEFS.find((d) => d.intent === intent);
+      expect(def.label).not.toMatch(VOSEO);
+      expect(def.placeholder).not.toMatch(VOSEO);
+    }
+  });
+});
+
+describe('ChipsToolbar — grupo "Más": oculto por defecto, no satura la barra', () => {
+  beforeEach(() => {
+    vi.spyOn(deepResearchClient, 'isDeepResearchEnabled').mockReturnValue(false);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('el toggle "Más" aparece cuando hay chips agrupados', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    expect(screen.getByTestId('mode-chip-more')).toBeInTheDocument();
+  });
+
+  test('sin expandir "Más", ningún chip de grounding oscuro está en el DOM', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    for (const { label } of GROUNDING_CHIPS) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    }
+  });
+
+  test('el toggle "Más" arranca con aria-expanded=false', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    expect(screen.getByTestId('mode-chip-more')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('clickear "Más" revela los 6 chips de grounding oscuro (segundo nivel)', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    fireEvent.click(screen.getByTestId('mode-chip-more'));
+    expect(screen.getByTestId('mode-chip-more')).toHaveAttribute('aria-expanded', 'true');
+    for (const { label } of GROUNDING_CHIPS) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  test('el panel expandido tiene role="toolbar" propio (segundo nivel accesible)', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    fireEvent.click(screen.getByTestId('mode-chip-more'));
+    const panel = document.getElementById('chips-toolbar-more');
+    expect(panel).toBeInTheDocument();
+    expect(panel).toHaveAttribute('role', 'toolbar');
+    expect(screen.getByTestId('mode-chip-more')).toHaveAttribute('aria-controls', 'chips-toolbar-more');
+  });
+
+  test('clickear "Más" de nuevo la vuelve a ocultar (toggle)', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    const toggle = screen.getByTestId('mode-chip-more');
+    fireEvent.click(toggle);
+    expect(screen.getByText('Toxicidad')).toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.queryByText('Toxicidad')).not.toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('los chips agrupados NO afectan los chips existentes (siembro/plaga/clima siguen igual)', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    expect(screen.getByText('¿Qué siembro?')).toBeInTheDocument();
+    expect(screen.getByText('Plaga')).toBeInTheDocument();
+    expect(screen.getByText('Clima')).toBeInTheDocument();
+  });
+});
+
+describe('ChipsToolbar — grupo "Más": cada chip dispara su intención (mismo mecanismo)', () => {
+  beforeEach(() => {
+    vi.spyOn(deepResearchClient, 'isDeepResearchEnabled').mockReturnValue(false);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test.each(GROUNDING_CHIPS)(
+    'clickear "$label" llama onSelectIntent("$intent") — reutiliza onSelectIntent, no un mecanismo nuevo',
+    ({ intent, label }) => {
+      const onSelectIntent = vi.fn();
+      render(<ChipsToolbar onSelectIntent={onSelectIntent} />);
+      fireEvent.click(screen.getByTestId('mode-chip-more'));
+      fireEvent.click(screen.getByText(label));
+      expect(onSelectIntent).toHaveBeenCalledTimes(1);
+      expect(onSelectIntent).toHaveBeenCalledWith(intent);
+    },
+  );
+
+  test('cada chip agrupado usa el testid compartido mode-chip + data-intent (mismo patrón de registro)', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    fireEvent.click(screen.getByTestId('mode-chip-more'));
+    const panel = document.getElementById('chips-toolbar-more');
+    const chipsInPanel = within(panel).getAllByTestId('mode-chip');
+    const intentsInPanel = chipsInPanel.map((el) => el.getAttribute('data-intent'));
+    for (const { intent } of GROUNDING_CHIPS) {
+      expect(intentsInPanel).toContain(intent);
+    }
+  });
+
+  test('el chip activo dentro del grupo "Más" se marca aria-pressed=true', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} activeIntent="toxicidad" />);
+    fireEvent.click(screen.getByTestId('mode-chip-more'));
+    const chip = screen.getByRole('button', { name: 'Toxicidad' });
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('disabled=true deshabilita también los chips del grupo "Más" y el propio toggle', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} disabled />);
+    expect(screen.getByTestId('mode-chip-more')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('mode-chip-more'));
+    // El toggle está disabled: el click no debería expandir el panel.
+    expect(document.getElementById('chips-toolbar-more')).not.toBeInTheDocument();
+  });
+});
+
+describe('ChipsToolbar — grupo "Más": el router dispara la tool correcta (grounding real, no decorativo)', () => {
+  test.each(GROUNDING_CHIPS)(
+    'planForcedIntent("$intent", texto) → tool "$tool" + skipNlu',
+    ({ intent, tool }) => {
+      const plan = planForcedIntent(intent, 'consulta de prueba');
+      expect(plan).not.toBeNull();
+      expect(plan.tool).toBe(tool);
+      expect(plan.stub).toBe(false);
+      expect(plan.skipNlu).toBe(true);
+    },
+  );
+});

--- a/src/components/__tests__/ChipsToolbar.smoke.test.jsx
+++ b/src/components/__tests__/ChipsToolbar.smoke.test.jsx
@@ -16,16 +16,27 @@ import * as deepResearchClient from '../../services/deepResearchClient';
  *
  * Feature flag Deep Research (VITE_DEEP_RESEARCH_ENABLED):
  *   - flag OFF (default) → el chip 🔬 NO se renderiza (evita dead-end
- *     "no disponible en este plan"): quedan 6 chips.
+ *     "no disponible en este plan").
  *   - flag ON → el chip 🔬 reaparece y queda pro-gated (deshabilitado para
  *     free, activo para pro) — tier gate A1.
+ *
+ * Grupo "Más" (grounding oscuro 2026-07-01): los chips con `moreGroup:true`
+ * (toxicidad, saberes tradicionales, alerta páramo, variedades, polinización,
+ * fenología) NO se pintan en la fila principal — viven detrás del toggle
+ * `mode-chip-more`. Los conteos de abajo distinguen "núcleo visible sin
+ * expandir" de "catálogo completo tras expandir Más" (ver
+ * ChipsToolbar.groundingChips.test.jsx para la cobertura dedicada del grupo).
  *
  * Estos tests controlan la flag mockeando `isDeepResearchEnabled` para no
  * depender del entorno de build.
  */
 
-// Cantidad de chips NO-deep (siembro, plaga, biopreparado, clima, precio, calendario).
+// Cantidad de chips NO-deep (siembro, plaga, biopreparado, clima, precio, calendario, ...).
 const NON_DEEP_CHIP_COUNT = CHIP_DEFS.filter((d) => d.intent !== 'deep').length;
+// Núcleo visible SIN expandir "Más" (excluye los chips moreGroup + deep).
+const CORE_NON_DEEP_CHIP_COUNT = CHIP_DEFS.filter(
+  (d) => d.intent !== 'deep' && !d.moreGroup,
+).length;
 
 describe('ChipsToolbar — flag Deep Research OFF (chip 🔬 oculto)', () => {
   beforeEach(() => {
@@ -40,10 +51,10 @@ describe('ChipsToolbar — flag Deep Research OFF (chip 🔬 oculto)', () => {
     expect(screen.queryByText(/investigación profunda/i)).not.toBeInTheDocument();
   });
 
-  test('renderiza solo los chips no-deep (6) con la flag OFF', () => {
+  test('renderiza solo el núcleo no-deep con la flag OFF (grounding oscuro queda tras "Más")', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
     const chips = screen.getAllByTestId('mode-chip');
-    expect(chips).toHaveLength(NON_DEEP_CHIP_COUNT);
+    expect(chips).toHaveLength(CORE_NON_DEEP_CHIP_COUNT);
     expect(screen.getByText('¿Qué siembro?')).toBeInTheDocument();
     expect(screen.getByText('Plaga')).toBeInTheDocument();
   });
@@ -69,11 +80,17 @@ describe('ChipsToolbar — flag Deep Research OFF (chip 🔬 oculto)', () => {
     expect(siembroChip).toHaveAttribute('aria-pressed', 'false');
   });
 
-  test('cada chip no-deep expone un accessible name no vacío', () => {
+  test('cada chip no-deep expone un accessible name no vacío (incluido el grupo "Más")', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} />);
+    // Expandir "Más" para que los chips de grounding puntual también estén
+    // en el DOM (viven detrás del toggle, no en la fila principal).
+    fireEvent.click(screen.getByTestId('mode-chip-more'));
     for (const def of CHIP_DEFS) {
       if (def.intent === 'deep') continue;
-      const chip = screen.getByRole('button', { name: new RegExp(def.label, 'i') });
+      // Match EXACTO (no substring): el aria-label del botón es def.label tal
+      // cual, y algunas etiquetas comparten palabras (ej. "Páramo" vs "Alerta
+      // normativa páramo") — un regex suelto encuentra ambas.
+      const chip = screen.getByRole('button', { name: def.label });
       expect(chip).toBeInTheDocument();
     }
   });
@@ -220,14 +237,18 @@ describe('ChipsToolbar — prop chipDefs (chips adaptativos por perfil)', () => 
 
   test('sin chipDefs (null) cae al catálogo completo — sin breaking change', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} chipDefs={null} />);
+    // Núcleo visible sin expandir "Más" (el grounding oscuro queda agrupado).
     const chips = screen.getAllByTestId('mode-chip');
-    expect(chips).toHaveLength(NON_DEEP_CHIP_COUNT);
+    expect(chips).toHaveLength(CORE_NON_DEEP_CHIP_COUNT);
+    // Tras expandir "Más" aparece el catálogo COMPLETO.
+    fireEvent.click(screen.getByTestId('mode-chip-more'));
+    expect(screen.getAllByTestId('mode-chip')).toHaveLength(NON_DEEP_CHIP_COUNT);
   });
 
   test('chipDefs vacío [] cae al catálogo completo (defensa, nunca barra vacía)', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} chipDefs={[]} />);
     const chips = screen.getAllByTestId('mode-chip');
-    expect(chips).toHaveLength(NON_DEEP_CHIP_COUNT);
+    expect(chips).toHaveLength(CORE_NON_DEEP_CHIP_COUNT);
   });
 });
 
@@ -240,10 +261,14 @@ describe('ChipsToolbar — flag Deep Research ON (chip 🔬 visible, pro-gated)'
     vi.restoreAllMocks();
   });
 
-  test('renderiza todos los chips (incluido 🔬) con la flag ON', () => {
+  test('renderiza todos los chips (incluido 🔬) con la flag ON, sumando el grupo "Más"', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
-    // Con la flag ON se ven los 10 chips del manifiesto (deep incluido, aunque
-    // quede pro-locked para free).
+    // Núcleo (sin expandir "Más"): manifiesto completo MENOS el grupo agrupado.
+    const coreCount = CHIP_DEFS.filter((d) => !d.moreGroup).length;
+    expect(screen.getAllByTestId('mode-chip')).toHaveLength(coreCount);
+    // Al expandir "Más" se ve el catálogo COMPLETO (deep incluido, pro-locked
+    // para free) — el manifiesto entero queda alcanzable.
+    fireEvent.click(screen.getByTestId('mode-chip-more'));
     expect(screen.getAllByTestId('mode-chip')).toHaveLength(CHIP_DEFS.length);
   });
 

--- a/src/components/__tests__/agentUserFlow.smoke.test.jsx
+++ b/src/components/__tests__/agentUserFlow.smoke.test.jsx
@@ -100,10 +100,16 @@ describe('flujo usuario nuevo — estado activo del modo claro', () => {
 
   it('cada chip visible tiene un accessible label descriptivo (no solo emoji)', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} />);
+    // Expandir "Más" para incluir los chips de grounding puntual (viven
+    // detrás del toggle, no en la fila principal — ver docstring del A4).
+    fireEvent.click(screen.getByTestId('mode-chip-more'));
     // Con DR flag OFF, deep no se renderiza
     const visibleDefs = CHIP_DEFS.filter((d) => d.intent !== CHIP_INTENTS.deep);
     for (const def of visibleDefs) {
-      const chip = screen.getByRole('button', { name: new RegExp(def.label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') });
+      // Match EXACTO (no substring): algunas etiquetas comparten palabras
+      // (ej. "Páramo" vs "Alerta normativa páramo") — un regex suelto
+      // encuentra ambas y `getByRole` revienta con "multiple elements".
+      const chip = screen.getByRole('button', { name: def.label });
       expect(chip).toBeInTheDocument();
       expect(chip).toHaveAttribute('aria-label', expect.stringContaining(def.label));
     }

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -3,7 +3,7 @@
  * textos de carga/aria ("Cargando…", "Cargando contador") son strings de UI
  * preexistentes de este componente. Su migración a src/config/messages.js es
  * la TAREA i18n de ADR-050 (transversal a toda la app), fuera del alcance de
- * este refinamiento visual. Se silencia el warning soft acá para no bloquear
+ * este refinamiento visual. Se silencia el warning soft aquí para no bloquear
  * el commit sin arrastrar ese refactor i18n. */
 import { useEffect, useState } from 'react';
 import { Sprout, MapPin, Package, NotebookPen, Eye, AlertCircle, FileText, ChevronRight, Leaf, Network, Beaker, PawPrint } from 'lucide-react';
@@ -556,7 +556,7 @@ export function SeguimientoCard({ def, count, onNavigate, variant }) {
  * el perfil del usuario ("el usuario solo ve lo que necesita" — un urbano
  * NUNCA ve Cerdos). Lo decide el call-site (DashboardLive) vía
  * homeModuleSelector. Si `keys` se omite (null/undefined), se muestran las 4 —
- * comportamiento histórico, sin breaking change. La selección NO se decide acá;
+ * comportamiento histórico, sin breaking change. La selección NO se decide aquí;
  * este componente solo pinta las tarjetas permitidas.
  *
  * @param {Object} props

--- a/src/db/catalogDB.js
+++ b/src/db/catalogDB.js
@@ -48,7 +48,7 @@ async function doInit() {
     }
 
     // Validar shape mínimo: tabla species con rows. Si el CDN Pro sirvió un
-    // blob malformado, fallamos rápido acá en vez de degradar silencioso.
+    // blob malformado, fallamos rápido aquí en vez de degradar silencioso.
     assertCatalogShape(db);
 
     return db;
@@ -74,7 +74,7 @@ export async function initCatalog() {
         // NO es bloqueante (el home usa fallback de stats y los componentes
         // reintentan al usar el catálogo) y NO debe gritar console.error: es
         // ruido esperado en cada deploy. Degradamos a debug; loadCatalogBuffer
-        // ya reintentó una vez antes de llegar acá.
+        // ya reintentó una vez antes de llegar aquí.
         if (isAbortLikeFetchError(error)) {
             console.debug('[SQLite WASM] init del catálogo abortado (probable reload por SW nuevo); se reintentará on-demand.');
         } else {

--- a/src/services/__tests__/chipIntentRouter.test.js
+++ b/src/services/__tests__/chipIntentRouter.test.js
@@ -77,7 +77,7 @@ describe('chipIntentRouter — enum y definiciones', () => {
   });
 
   it('ningún string del chip usa voseo argentino', () => {
-    // tú/usted colombiano — NUNCA escribí/tomá/tenés/querés/elegí/dale/acá.
+    // tú/usted colombiano — NUNCA escribí/tomá/tienes/quieres/elegí/dale/aquí.
     const VOSEO = /\b(escrib[íi]|tom[áa]|ten[ée]s|quer[ée]s|eleg[íi]|pod[ée]s|dale|sab[ée]s|and[áa]|fij[áa]te)\b/i;
     for (const def of CHIP_DEFS) {
       expect(def.label).not.toMatch(VOSEO);

--- a/src/services/__tests__/chipIntentRouter.test.js
+++ b/src/services/__tests__/chipIntentRouter.test.js
@@ -21,7 +21,7 @@ import {
  */
 
 describe('chipIntentRouter — enum y definiciones', () => {
-  it('expone los 11 intents del enum (incluye restauración, silvopastoreo, páramo, incendio)', () => {
+  it('expone los 17 intents del enum (incluye restauración, silvopastoreo, páramo, incendio, grounding oscuro)', () => {
     expect(CHIP_INTENTS).toEqual({
       siembro: 'siembro',
       plaga: 'plaga',
@@ -34,10 +34,18 @@ describe('chipIntentRouter — enum y definiciones', () => {
       silvopastoreo: 'silvopastoreo',
       paramo: 'paramo',
       incendio: 'incendio',
+      // Grounding oscuro (2026-07-01): consultas puntuales del grafo, ahora
+      // discutibles vía el grupo "Más" del ChipsToolbar.
+      toxicidad: 'toxicidad',
+      saberes_tradicionales: 'saberes_tradicionales',
+      alerta_paramo: 'alerta_paramo',
+      variedades: 'variedades',
+      polinizacion: 'polinizacion',
+      fenologia: 'fenologia',
     });
   });
 
-  it('CHIP_DEFS tiene los 11 chips con label en español colombiano (sin voseo)', () => {
+  it('CHIP_DEFS tiene los 17 chips con label en español colombiano (sin voseo)', () => {
     const ids = CHIP_DEFS.map((c) => c.intent);
     expect(ids).toEqual([
       'siembro',
@@ -51,6 +59,12 @@ describe('chipIntentRouter — enum y definiciones', () => {
       'silvopastoreo',
       'paramo',
       'incendio',
+      'toxicidad',
+      'saberes_tradicionales',
+      'alerta_paramo',
+      'variedades',
+      'polinizacion',
+      'fenologia',
     ]);
     // Labels presentes y emoji declarado
     for (const def of CHIP_DEFS) {
@@ -299,6 +313,69 @@ describe('chipIntentRouter — chips de diseño (capacidades antes dark)', () =>
   });
 });
 
+describe('chipIntentRouter — grounding oscuro (chips antes SOLO alcanzables por texto libre)', () => {
+  it('toxicidad → get_toxicidad con species_id_or_name del texto + skipNlu', () => {
+    const plan = planForcedIntent('toxicidad', 'ruda');
+    expect(plan.tool).toBe('get_toxicidad');
+    expect(plan.args).toEqual({ species_id_or_name: 'ruda' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('saberes_tradicionales → get_saberes_tradicionales con termino del texto + skipNlu', () => {
+    const plan = planForcedIntent('saberes_tradicionales', 'bocashi');
+    expect(plan.tool).toBe('get_saberes_tradicionales');
+    expect(plan.args).toEqual({ termino: 'bocashi' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('alerta_paramo → get_alerta_normativa_paramo con contexto del texto + skipNlu', () => {
+    const plan = planForcedIntent('alerta_paramo', 'tengo tierra en el páramo');
+    expect(plan.tool).toBe('get_alerta_normativa_paramo');
+    expect(plan.args).toEqual({ contexto: 'tengo tierra en el páramo' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('variedades → get_variedades_cultivo con cultivo del texto + skipNlu', () => {
+    const plan = planForcedIntent('variedades', 'papa criolla');
+    expect(plan.tool).toBe('get_variedades_cultivo');
+    expect(plan.args).toEqual({ cultivo: 'papa criolla' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('polinizacion → get_polinizacion con species_id del texto + skipNlu', () => {
+    const plan = planForcedIntent('polinizacion', 'fresa');
+    expect(plan.tool).toBe('get_polinizacion');
+    expect(plan.args).toEqual({ species_id: 'fresa' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('fenologia → get_fenologia con species_id del texto + skipNlu', () => {
+    const plan = planForcedIntent('fenologia', 'café');
+    expect(plan.tool).toBe('get_fenologia');
+    expect(plan.args).toEqual({ species_id: 'café' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('los 6 chips de grounding oscuro son kind:tool en CHIP_DEFS (no stub)', () => {
+    const groundingIntents = [
+      'toxicidad', 'saberes_tradicionales', 'alerta_paramo',
+      'variedades', 'polinizacion', 'fenologia',
+    ];
+    for (const intent of groundingIntents) {
+      const def = CHIP_DEFS.find((d) => d.intent === intent);
+      expect(def).toBeTruthy();
+      expect(def.kind).toBe('tool');
+      expect(def.moreGroup).toBe(true);
+    }
+  });
+});
+
 describe('chipIntentRouter — intents STUB (backend no existe aún)', () => {
   it('precio → stub claro "aún no disponible" (NO inventa backend de precio)', () => {
     const plan = planForcedIntent('precio', 'papa');
@@ -362,11 +439,12 @@ describe('chipIntentRouter — Deep Research (B14: stub honesto, backend no serv
 });
 
 describe('chipIntentRouter — contrato de orden y consistencia del índice', () => {
-  it('CHIP_DEFS mantiene el orden de render estable (chips base + restauración/silvopastoreo/páramo/incendio al final)', () => {
+  it('CHIP_DEFS mantiene el orden de render estable (chips base + restauración/silvopastoreo/páramo/incendio + grounding oscuro al final)', () => {
     const order = CHIP_DEFS.map((d) => d.intent);
     expect(order).toEqual([
       'siembro', 'plaga', 'biopreparado', 'clima', 'precio', 'calendario', 'deep',
       'restauracion', 'silvopastoreo', 'paramo', 'incendio',
+      'toxicidad', 'saberes_tradicionales', 'alerta_paramo', 'variedades', 'polinizacion', 'fenologia',
     ]);
   });
 

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -274,6 +274,117 @@ export const CAPABILITY_MANIFEST = Object.freeze([
   },
 
   // ═══════════════════════════════════════════════════════════════════════
+  // GROUNDING OSCURO (2026-07-01) — tools YA vivas en el grafo/catálogo (ver
+  // ALLOWED_TOOLS en sidecarClient.js) pero, hasta ahora, SOLO alcanzables por
+  // texto libre en el chat: el NLU las conoce, pero ningún chip las disparaba
+  // (auditoría chagra-pro allowed-tools.ts: "datos del grafo que estaban
+  // muertos"). Se exponen acá como chips de modo, agrupados bajo el toggle
+  // "Más" del ChipsToolbar (chipMore:true) para NO saturar la barra principal
+  // con 6 chips nuevos de golpe — son consultas de conocimiento puntuales, no
+  // el núcleo diario de siembra/plaga/clima.
+  //
+  // hero:false a propósito: NO se agregan ramas nuevas a la mano radial
+  // (AgentRedMenu solo pinta hero===true) — ese es un cambio de UX aparte que
+  // el operador debe decidir explícitamente. Acá solo se resuelve la
+  // descubribilidad vía chips (el pedido puntual de esta tarea).
+  {
+    id: 'toxicidad',
+    group: 'cuidar',
+    status: 'live',
+    intent: 'toxicidad',
+    kind: 'tool',
+    icon: '☠️',
+    label: 'Toxicidad',
+    desc: 'Si una planta es tóxica o se puede comer, con qué cuidado.',
+    placeholder: 'Escriba la planta de la que quiere saber si es tóxica o comestible',
+    tool: 'get_toxicidad',
+    stubMessage: null,
+    hero: false,
+    chipMore: true,
+    heroRoute: { kind: 'unavailable' },
+  },
+  {
+    id: 'saberes_tradicionales',
+    group: 'aprender',
+    status: 'live',
+    intent: 'saberes_tradicionales',
+    kind: 'tool',
+    icon: '📜',
+    label: 'Saberes tradicionales',
+    desc: 'Glosario de saberes agroecológicos: qué significan y cómo se usan.',
+    placeholder: 'Escriba el término que quiere consultar (ej. bocashi, milpa, pionera)',
+    tool: 'get_saberes_tradicionales',
+    stubMessage: null,
+    hero: false,
+    chipMore: true,
+    heroRoute: { kind: 'unavailable' },
+  },
+  {
+    id: 'alerta_paramo',
+    group: 'restaurar',
+    status: 'live',
+    intent: 'alerta_paramo',
+    kind: 'tool',
+    icon: '⚖️',
+    label: 'Alerta normativa páramo',
+    desc: 'Qué dice la Ley 1930 de 2018 sobre sembrar o hacer quemas en el páramo.',
+    placeholder: 'Cuéntele al agente su situación en el páramo',
+    tool: 'get_alerta_normativa_paramo',
+    stubMessage: null,
+    hero: false,
+    chipMore: true,
+    heroRoute: { kind: 'unavailable' },
+  },
+  {
+    id: 'variedades',
+    group: 'cultivo',
+    status: 'live',
+    intent: 'variedades',
+    kind: 'tool',
+    icon: '🧬',
+    label: 'Variedades',
+    desc: 'Variedades registradas ICA/AGROSAVIA de un cultivo.',
+    placeholder: 'Escriba el cultivo del que quiere ver las variedades',
+    tool: 'get_variedades_cultivo',
+    stubMessage: null,
+    hero: false,
+    chipMore: true,
+    heroRoute: { kind: 'unavailable' },
+  },
+  {
+    id: 'polinizacion',
+    group: 'cultivo',
+    status: 'live',
+    intent: 'polinizacion',
+    kind: 'tool',
+    icon: '🐝',
+    label: 'Polinización',
+    desc: 'Qué la poliniza y cuántas colmenas por hectárea necesita.',
+    placeholder: 'Escriba la planta de la que quiere saber cómo se poliniza',
+    tool: 'get_polinizacion',
+    stubMessage: null,
+    hero: false,
+    chipMore: true,
+    heroRoute: { kind: 'unavailable' },
+  },
+  {
+    id: 'fenologia',
+    group: 'cultivo',
+    status: 'live',
+    intent: 'fenologia',
+    kind: 'tool',
+    icon: '📊',
+    label: 'Fenología',
+    desc: 'Etapas de desarrollo de la planta y en cuáles aparece cada plaga.',
+    placeholder: 'Escriba la planta de la que quiere ver sus etapas de desarrollo',
+    tool: 'get_fenologia',
+    stubMessage: null,
+    hero: false,
+    chipMore: true,
+    heroRoute: { kind: 'unavailable' },
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════
   // AGENTHERO ACTIONS — aparecen solo en menú Ⓐ del AgentHero
   // ═══════════════════════════════════════════════════════════════════════
   {
@@ -531,7 +642,12 @@ export const CHIP_INTENTS = Object.freeze(
 /**
  * CHIP_DEFS — definiciones de chips de modo para ChipsToolbar.
  * Orden = orden del manifiesto (filtrado a entradas con intent).
- * Cada entrada: { intent, emoji, label, kind, placeholder, stubMessage }.
+ * Cada entrada: { intent, emoji, label, kind, placeholder, stubMessage, moreGroup }.
+ *
+ * `moreGroup` (derivado de `chipMore` del manifiesto): true → el chip es
+ * grounding puntual (toxicidad/saberes/variedades/polinización/fenología/
+ * alerta páramo) que ChipsToolbar agrupa bajo el toggle "Más" para no saturar
+ * la barra principal con el núcleo diario (siembro/plaga/clima/...).
  */
 export const CHIP_DEFS = Object.freeze(
   CAPABILITY_MANIFEST
@@ -543,5 +659,6 @@ export const CHIP_DEFS = Object.freeze(
       kind: e.kind,
       placeholder: e.placeholder,
       ...(e.stubMessage ? { stubMessage: e.stubMessage } : {}),
+      ...(e.chipMore ? { moreGroup: true } : {}),
     })),
 );

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -11,7 +11,7 @@
  * agentCapabilities.js — Manifiesto ÚNICO de capacidades de Chagra.
  *
  * Fuente normativa para chips de modo y menú Ⓐ del AgentHero.
- * TODO lo demás (chips, tools, labels, placeholders, rutas) se deriva de acá.
+ * TODO lo demás (chips, tools, labels, placeholders, rutas) se deriva de aquí.
  *
  * Regla inviolable: un cambio en la UI (nuevo chip, nuevo tool, label distinto)
  * se hace editando ESTE archivo. NO en CHIP_DEFS ni en CAPABILITIES de AgentHero.
@@ -278,14 +278,14 @@ export const CAPABILITY_MANIFEST = Object.freeze([
   // ALLOWED_TOOLS en sidecarClient.js) pero, hasta ahora, SOLO alcanzables por
   // texto libre en el chat: el NLU las conoce, pero ningún chip las disparaba
   // (auditoría chagra-pro allowed-tools.ts: "datos del grafo que estaban
-  // muertos"). Se exponen acá como chips de modo, agrupados bajo el toggle
+  // muertos"). Se exponen aquí como chips de modo, agrupados bajo el toggle
   // "Más" del ChipsToolbar (chipMore:true) para NO saturar la barra principal
   // con 6 chips nuevos de golpe — son consultas de conocimiento puntuales, no
   // el núcleo diario de siembra/plaga/clima.
   //
   // hero:false a propósito: NO se agregan ramas nuevas a la mano radial
   // (AgentRedMenu solo pinta hero===true) — ese es un cambio de UX aparte que
-  // el operador debe decidir explícitamente. Acá solo se resuelve la
+  // el operador debe decidir explícitamente. Aquí solo se resuelve la
   // descubribilidad vía chips (el pedido puntual de esta tarea).
   {
     id: 'toxicidad',

--- a/src/services/agentPromptBase.js
+++ b/src/services/agentPromptBase.js
@@ -341,7 +341,7 @@ const TOMATE_SAFETY_RULES = [
 export function buildCampesinoModeBlock() {
   return `=== MODO CAMPESINO (registro oral campesino colombiano) ===
 Habla como un campesino colombiano experimentado, NO como un sistema técnico:
-- Usa tú/usted colombiano (NEVER vos/tenés/querés del argentino/rioplatense)
+- Usa tú/usted colombiano (NEVER vos/tienes/quieres del argentino/rioplatense)
 - Frases cortas y directas, como habla la gente del campo
 - Unidades del campo: cuadra, arroba, luna, bike de agua, plaza, hueco
 - NO uses binomios científicos (Coffea arabica, Solanum tuberosum) salvo que el usuario los pida explícitamente

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -420,7 +420,7 @@ export const logoutUser = async () => {
         console.error('[Auth] logoutUser failed (tokens may persist):', err);
     }
     // ADR-036 MVP multi-finca: limpiar tenantId asegura que un re-login con
-    // otro usuario no herede el scope del anterior. NO purgamos IDB acá —
+    // otro usuario no herede el scope del anterior. NO purgamos IDB aquí —
     // useAssetStore decide qué hacer al detectar el cambio de tenantId.
     try {
         clearActiveTenantId();

--- a/src/services/capabilityHealth.js
+++ b/src/services/capabilityHealth.js
@@ -12,7 +12,7 @@ import { fetchWithAuthRetry } from './apiService.js';
 /**
  * Tools que dependen del sidecar MCP agro (ALLOWED_TOOLS en sidecarClient).
  * Si el sidecar está caído/deshabilitado, las capacidades que usan estas
- * tools se marcan 'down'. Las capacidades con tools NO listadas acá son
+ * tools se marcan 'down'. Las capacidades con tools NO listadas aquí son
  * offline-first y siempre están 'live'.
  */
 export const SIDECAR_TOOL_NAMES = new Set([

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -13,7 +13,7 @@
  *
  * Este módulo es PURO (sin red, sin React): mapea (intent, texto, opts) a un
  * "plan forzado" que el AgentScreen ejecuta sin pasar por `planNlu()`. Toda la
- * lógica de routing vive acá para poder testearla en aislamiento (TDD).
+ * lógica de routing vive aquí para poder testearla en aislamiento (TDD).
  *
  * CHIP_INTENTS y CHIP_DEFS se importan de agentCapabilities.js (fuente única
  * de verdad). Este módulo NO redefine esas constantes.

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -32,6 +32,12 @@
  *                                           objetivo inferido del texto, default bosque)
  *   - silvopastoreo→ get_diseno_silvopastoril (forrajeras CIPAV; requiere altura)
  *   - paramo       → get_diseno_restauracion (objetivo='paramo'; especies ≥3000 msnm)
+ *   - toxicidad    → get_toxicidad (grounding oscuro 2026-07-01: es_toxica/tox_*)
+ *   - saberes_tradicionales → get_saberes_tradicionales (glosario 96 términos, standalone)
+ *   - alerta_paramo → get_alerta_normativa_paramo (Ley 1930/2018, contexto opcional)
+ *   - variedades   → get_variedades_cultivo (ICA/AGROSAVIA por cultivo, catálogo v3.1)
+ *   - polinizacion → get_polinizacion (polinizadores + colmenas/ha)
+ *   - fenologia    → get_fenologia (etapas BBCH + ventana de plaga por etapa)
  *
  * Intents STUB (el backend aún NO existe — NO inventamos endpoints):
  *   - precio → SIPSA/DANE consulta directa no disponible (dataset ZIP federado).
@@ -269,6 +275,36 @@ export function planForcedIntent(intent, text, opts = {}) {
       if (animal) args.animal = animal;
       return { ...base, tool: 'get_diseno_silvopastoril', args };
     }
+
+    case CHIP_INTENTS.toxicidad:
+      // Perfil de toxicidad/comestibilidad (grounding oscuro, fold 2026-06-05):
+      // el grafo devuelve es_toxica + tox_* con disclaimer; found:false si el
+      // grafo no tiene el dato (CERO fabricación).
+      return { ...base, tool: 'get_toxicidad', args: { species_id_or_name: prompt } };
+
+    case CHIP_INTENTS.saberes_tradicionales:
+      // Glosario agroecológico standalone (96 términos in-app), por TÉRMINO —
+      // distinto de get_saberes (grafo, por especie, con disclaimer médico).
+      return { ...base, tool: 'get_saberes_tradicionales', args: { termino: prompt } };
+
+    case CHIP_INTENTS.alerta_paramo:
+      // Alerta normativa de páramo (Ley 1930/2018). `contexto` es OPCIONAL en
+      // el tool: le pasamos el texto libre para que la alerta cite la
+      // situación puntual del campesino; el tool NO lo interpreta legalmente.
+      return { ...base, tool: 'get_alerta_normativa_paramo', args: { contexto: prompt } };
+
+    case CHIP_INTENTS.variedades:
+      // Variedades registradas ICA/AGROSAVIA del catálogo v3.1, por CULTIVO —
+      // distinto de get_variedades (grafo, nodos :Variety, por especie).
+      return { ...base, tool: 'get_variedades_cultivo', args: { cultivo: prompt } };
+
+    case CHIP_INTENTS.polinizacion:
+      // Polinizadores + colmenas/ha + efecto en cuaje (grafo AGE).
+      return { ...base, tool: 'get_polinizacion', args: { species_id: prompt } };
+
+    case CHIP_INTENTS.fenologia:
+      // Etapas BBCH + ventana de plaga por etapa (grafo AGE).
+      return { ...base, tool: 'get_fenologia', args: { species_id: prompt } };
 
     case CHIP_INTENTS.precio:
       // STUB: backend no implementado. NO inventamos endpoint.

--- a/src/services/farmEventService.js
+++ b/src/services/farmEventService.js
@@ -2,7 +2,7 @@
  * farmEventService — única puerta de escritura para eventos de ciclo.
  *
  * recordFarmEvent es la función autorizada para mutar el agregado.
- * Toda escritura pasa por acá. No exponer al LLM sin pruebas E2E.
+ * Toda escritura pasa por aquí. No exponer al LLM sin pruebas E2E.
  */
 import { openDB, STORES } from '../db/dbCore';
 import { newUlid } from '../utils/id';

--- a/src/services/fincaSceneProfileSelector.js
+++ b/src/services/fincaSceneProfileSelector.js
@@ -23,7 +23,7 @@
  * REUSO (no se duplica nada): la derivación de ROL vive en
  * `profileChipSelector.deriveRole` (fuente única); `esPerfilUrbano`,
  * `profileTieneAnimales` y `profileTieneCerdos` viven en `homeModuleSelector` /
- * `profileChipSelector` (fuentes únicas). Acá solo se importan y se mapean. El
+ * `profileChipSelector` (fuentes únicas). Aquí solo se importan y se mapean. El
  * cálculo de nivel Gliessman NO vive aquí (es de fincaGameService).
  *
  * REGLA — coherencia con el override urbano del home: si `esPerfilUrbano` es

--- a/src/services/homeModuleSelector.js
+++ b/src/services/homeModuleSelector.js
@@ -13,17 +13,17 @@
  *
  * Este módulo es PURO (sin red, sin React, sin localStorage): mapea un perfil
  * de usuario → la lista de módulos del home + las tarjetas de seguimiento que
- * le corresponden. Toda la lógica vive acá para testearla en aislamiento
+ * le corresponden. Toda la lógica vive aquí para testearla en aislamiento
  * (TDD), igual que `profileChipSelector.selectChipIntents`.
  *
  * REUSO: la derivación de ROL vive en `profileChipSelector.deriveRole` (fuente
  * única — no se duplica). Este módulo la importa y mapea cada rol a su set de
  * módulos. El gating de seguridad del módulo glaciar (whitelist La Cordada)
- * NO vive acá: el tile glaciar tiene su propio gate (`glaciarAccess`).
+ * NO vive aquí: el tile glaciar tiene su propio gate (`glaciarAccess`).
  *
  * RESPETO A #1560/#7003: este módulo SOLO calcula el DEFAULT por perfil. Si el
  * usuario guardó una preferencia manual de visibilidad en `ProfileScreen`, esa
- * preferencia GANA — el call-site (DashboardLive) decide cuál usar. Acá no se
+ * preferencia GANA — el call-site (DashboardLive) decide cuál usar. Aquí no se
  * lee ni se escribe ninguna preferencia.
  *
  * Español colombiano (tú/usted), NUNCA voseo argentino.
@@ -36,9 +36,9 @@ import { deriveRole, profileTieneAnimales, PROFILE_ROLES } from './profileChipSe
 /**
  * IDs de los módulos del Home (deben coincidir con `HOME_MODULES` de
  * userProfileService + `SECTION_COMPONENTS` de DashboardLive). Fuente de
- * verdad de los ids: userProfileService.HOME_MODULES — acá solo los nombramos
+ * verdad de los ids: userProfileService.HOME_MODULES — aquí solo los nombramos
  * para los sets por rol. Si se agrega un módulo nuevo allá, agregarlo al set
- * del rol que lo necesite acá (default fail-open en el call-site lo cubre
+ * del rol que lo necesite aquí (default fail-open en el call-site lo cubre
  * mientras tanto).
  *
  * @enum {string}
@@ -68,7 +68,7 @@ export const ALL_HOME_MODULES = Object.freeze(Object.values(HOME_MODULE_IDS));
 /**
  * Keys de las 4 tarjetas de SEGUIMIENTO de procesos de finca. Deben coincidir
  * con las `key` de `config/seguimientoProcesos.js` (reforestacion ·
- * silvopastoreo · paramo · cerdos). Las nombramos acá para no acoplar este
+ * silvopastoreo · paramo · cerdos). Las nombramos aquí para no acoplar este
  * módulo puro al import del catálogo de seguimiento (que arrastra estilos).
  *
  * @enum {string}
@@ -168,7 +168,7 @@ const ROLE_MODULES = Object.freeze({
 const ROLE_SEGUIMIENTO = Object.freeze({
   [PROFILE_ROLES.campesino]: Object.freeze([]),
   // Ganadero: silvopastoreo SIEMPRE; cerdos SOLO si el perfil tiene cerdos
-  // (se resuelve en selectHomeModules). Acá dejamos silvopastoreo de base.
+  // (se resuelve en selectHomeModules). Aquí dejamos silvopastoreo de base.
   [PROFILE_ROLES.ganadero]: Object.freeze([SEGUIMIENTO_KEYS.silvopastoreo]),
   [PROFILE_ROLES.restaurador]: Object.freeze([
     SEGUIMIENTO_KEYS.reforestacion,

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -631,7 +631,7 @@ const DOSE_PATTERNS = [
  *
  * Anti-sobre-supresión: la dosis sola (respuesta orgánica con "2 kg de compost")
  * NO basta — hace falta el token sintético. Un biopreparado permitido nunca es
- * sintético (no entra acá).
+ * sintético (no entra aquí).
  *
  * @param {string} norm  texto ya normalizado (minúsculas, sin tildes).
  * @returns {boolean}
@@ -815,7 +815,7 @@ const FUEL_AS_ADJUVANT_RE =
  * ¿El texto normalizado usa un combustible/solvente como adyuvante de un preparado
  * CON una dosis (o con un verbo de mezcla/adherencia)? Esa conjunción delata la
  * RECETA peligrosa de BORDE-020 que debe SUPRIMIRSE. Anti-sobre-supresión: sin el
- * verbo de mezcla/adherencia ni dosis (p.ej. "no le eches diésel") no entra acá; la
+ * verbo de mezcla/adherencia ni dosis (p.ej. "no le eches diésel") no entra aquí; la
  * advertencia de no-usar la corta el gate `esAdvertenciaNoUsar` en el guard.
  *
  * @param {string} norm  texto normalizado (minúsculas, sin tildes).
@@ -1033,7 +1033,7 @@ export function guardSyntheticAgrochemical(responseText, _resolvedEntities = nul
   // devolvemos SOLO el bloque de redirección orgánica. Append-only dejaba la
   // dosis sintética legible debajo del aviso (el campesino igual la leía). La
   // supresión SOLO dispara con sintético + dosis: una respuesta orgánica con
-  // cantidades ("2 kg de compost", "1 L de biol por planta") NO entra acá
+  // cantidades ("2 kg de compost", "1 L de biol por planta") NO entra aquí
   // (`_hasSyntheticFertilizerDose` exige un token SINTÉTICO, no orgánico).
   if (_hasSyntheticFertilizerDose(norm)) {
     return {
@@ -1825,7 +1825,7 @@ function _presentaComoViable(textNorm, nombreNorm) {
  * viabilidad. El re-bench (2026-05-31) mostró que el detector anterior
  * (`_presentaComoViable`) se apoyaba en un léxico de viabilidad ("es viable",
  * "prospera", "recomendable") y se le escapaban respuestas que igual mandaban a
- * sembrar con otro fraseo (curuba CPX-010, chugua CPX-001). Acá basta con que
+ * sembrar con otro fraseo (curuba CPX-010, chugua CPX-001). Aquí basta con que
  * el texto INVITE a sembrar/cultivar la especie y NO advierta inviabilidad.
  *
  * Esto se usa SOLO cuando el grounding (campo viabilidad o banda de altitud) ya
@@ -3898,7 +3898,7 @@ const DIFFERENTIAL_PHRASING_RE =
  * oración o conector), colisionan con "Género" de un binomio y producirían
  * falsos positivos en `_namesLatinBinomial` ("Mientras tanto", "Para saber",
  * "Una mancha", "Esas hojas"). Normalizadas sin tildes/case. NO son géneros
- * latinos; si el "Género" candidato está acá, no cuenta como binomio.
+ * latinos; si el "Género" candidato está aquí, no cuenta como binomio.
  */
 const BINOMIAL_GENUS_STOPWORDS = new Set([
   'mientras', 'para', 'una', 'unas', 'unos', 'esas', 'esos', 'esta', 'este', 'estas',
@@ -4023,7 +4023,7 @@ export function guardDiagnosisWithoutPhoto(
   //   (c) fraseo diferencial enumerando candidatos.
   // Un solo patógeno confiado ("es tizón tardío") es el caso MÁS dañino: manda
   // a tratar a ciegas con plena seguridad. Una respuesta que solo da manejo
-  // cultural genérico (sin patógeno ni latín) NO entra acá.
+  // cultural genérico (sin patógeno ni latín) NO entra aquí.
   let nombraPatogeno = false;
   for (const term of PATHOGEN_NAME_TERMS) {
     if (norm.includes(term)) { nombraPatogeno = true; break; }
@@ -5748,7 +5748,7 @@ export function guardSurfaceConfusionWarning(responseText, resolvedEntities = nu
   }
 
   // Sin confusión tóxica crítica activa → no tocamos nada (anti-FP central: un
-  // alimento seguro con consejo de consumo crudo —lechuga, lulo— NO entra acá).
+  // alimento seguro con consejo de consumo crudo —lechuga, lulo— NO entra aquí).
   if (!toxicCw) {
     return { text: responseText, modified: false, reason: null };
   }
@@ -6182,7 +6182,7 @@ function _extractAltitudesWide(norm) {
   const reUnit = /\b(\d{1,2}[.,]?\d{3}|\d{2,4})\s*(m|msnm|metros|mts)\b/g;
   let m;
   while ((m = reUnit.exec(norm)) !== null) {
-    // Excluir falsos: "20 litros"/"8 dias" no llegan acá (la unidad es de altitud),
+    // Excluir falsos: "20 litros"/"8 dias" no llegan aquí (la unidad es de altitud),
     // pero "20 m" sí — la cota inferior plausible para un cultivo es ~100 msnm.
     const n = Number(m[1].replace(/[.,]/g, ''));
     if (Number.isFinite(n) && n >= 50 && n <= 5000) out.push(n);

--- a/src/services/profileChipSelector.js
+++ b/src/services/profileChipSelector.js
@@ -8,7 +8,7 @@
  *
  * Este módulo es PURO (sin red, sin React, sin localStorage): mapea un perfil
  * de usuario + sus módulos visibles + su rol → la lista ORDENADA de intents de
- * chip a mostrar. Toda la lógica vive acá para testearla en aislamiento (TDD),
+ * chip a mostrar. Toda la lógica vive aquí para testearla en aislamiento (TDD),
  * igual que `chipIntentRouter.planForcedIntent`.
  *
  * REGLA INVIOLABLE — no inventar chips. Solo seleccionamos y ordenamos los

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -287,7 +287,7 @@ export async function executeToolChain(chain) {
  * normativa ICA defensiva, clima IDEAM nacional y precios SIPSA DANE.
  *
  * TODO(NLU): add keywords agroquimico/clima/precio in chagra-pro nlu.ts
- * (sidecar repo, NO acá) para que el planner las routee automáticamente.
+ * (sidecar repo, NO aquí) para que el planner las routee automáticamente.
  * Mientras tanto el frontend hace detection por keywords + invocación
  * directa de los wrappers (ver AgentScreen handleSubmit).
  */
@@ -330,7 +330,7 @@ const ALLOWED_TOOLS = new Set([
   // ── Reconciliación allow-list cliente ↔ 41 tools del NLU (fix grounding P0
   //    2026-06-25). El NLU planner conocía 41 tools pero el cliente exponía 20:
   //    si el planner ruteaba a una de las 21 restantes, el turno degradaba a
-  //    RAG SIN grounding en silencio. Agregamos acá las tools que son SEGURAS y
+  //    RAG SIN grounding en silencio. Agregamos aquí las tools que son SEGURAS y
   //    VALIOSAS de exponer (grounding del grafo AGE / catálogo / dataset
   //    institucional local, ruteables por el NLU con id|nombre|término).
   //

--- a/src/services/versionCheck.js
+++ b/src/services/versionCheck.js
@@ -22,7 +22,7 @@
  * (Network-First en el SW) → bundle nuevo → SHA coincide → no recarga otra vez.
  *
  * Es belt-and-suspenders del auto-update: si éste ya recargó, el SHA coincide y
- * acá no pasa nada. Si el auto-update falló, esta ruta lo rescata.
+ * aquí no pasa nada. Si el auto-update falló, esta ruta lo rescata.
  *
  * ── ANTI-LOOP (crítico) ───────────────────────────────────────────────────
  * Guard por sessionStorage (`chagra:self-heal-reloaded`): recargamos como mucho
@@ -81,7 +81,7 @@ export function shasMatch(a, b) {
 
 /**
  * Decide si el cliente debe auto-recuperarse (recargar) por desfase de versión.
- * Función pura: toda la política de decisión vive acá para testearla aislada.
+ * Función pura: toda la política de decisión vive aquí para testearla aislada.
  *
  * @param {object} params
  * @param {string} params.runningSha — SHA embebido en el bundle corriendo.
@@ -302,7 +302,7 @@ async function defaultSkipWaiting() {
 
 function defaultReload() {
   // Indirección vía import dinámico para reusar pageReload (mockeable en test).
-  // Import estático arriba crearía un ciclo innecesario; acá basta location.
+  // Import estático arriba crearía un ciclo innecesario; aquí basta location.
   try {
     window.location.reload();
   } catch (_) { /* entorno sin window (SSR/test) — no-op */ }

--- a/src/services/voiceService.js
+++ b/src/services/voiceService.js
@@ -37,7 +37,7 @@ export async function transcribe(blob, options = {}) {
   // Guard: un Blob vacío o diminuto (captura fallida en móvil — MediaRecorder
   // a veces produce un webm de 0 bytes o truncado) hace que Whisper responda
   // HTTP 500 "Failed to load audio: End of file / invalid EBML number". Cortar
-  // acá con un mensaje claro al usuario en vez del round-trip + 500 críptico.
+  // aquí con un mensaje claro al usuario en vez del round-trip + 500 críptico.
   const MIN_AUDIO_BYTES = 1024;
   if (!blob || typeof blob.size !== 'number' || blob.size < MIN_AUDIO_BYTES) {
     throw new Error('No se grabó audio. Mantén presionado el botón y habla cerca del micrófono.');

--- a/src/utils/imageCompress.js
+++ b/src/utils/imageCompress.js
@@ -17,7 +17,7 @@
  * Esta es la primera capa de defensa contra payloads gigantes hacia el
  * sidecar agro-mcp (que arranca con `bodyLimit` chico). Es complementaria a
  * `photoService.captureAndCompress` que apunta a 500 KB para persistencia
- * local — acá apuntamos a un techo distinto (2 MB) porque el sidecar es
+ * local — aquí apuntamos a un techo distinto (2 MB) porque el sidecar es
  * quien define el límite de red.
  *
  * Diseño puro: NO toca IndexedDB, NO toca red, NO toca catálogo. Recibe un


### PR DESCRIPTION
## Summary

Seis tools de "grounding oscuro" (ya vivas en el grafo/catálogo y en `ALLOWED_TOOLS` del sidecar, pero SOLO alcanzables por texto libre en el chat — el chip nunca las disparaba) quedan expuestas como chips de modo:

- `get_toxicidad` → chip **Toxicidad** (☠️)
- `get_saberes_tradicionales` → chip **Saberes tradicionales** (📜)
- `get_alerta_normativa_paramo` → chip **Alerta normativa páramo** (⚖️)
- `get_variedades_cultivo` → chip **Variedades** (🧬)
- `get_polinizacion` → chip **Polinización** (🐝)
- `get_fenologia` → chip **Fenología** (📊)

Cada chip nuevo reutiliza el mecanismo EXISTENTE (`chipIntentRouter.planForcedIntent` + `agentCapabilities.CAPABILITY_MANIFEST` + `ChipsToolbar`): salta el NLU y rutea directo al tool determinístico, igual que siembro/plaga/clima. No se inventó ningún mecanismo nuevo.

Para no saturar la barra principal con 6 chips de golpe, se agregó un **segundo nivel**: un toggle "Más" (`data-testid="mode-chip-more"`) en `ChipsToolbar.jsx` que despliega estos 6 chips en un `role="toolbar"` propio. Los chips existentes (siembro, plaga, biopreparado, clima, precio, calendario, restauración, silvopastoreo, páramo, incendio) quedan EXACTAMENTE igual en la fila principal.

**Decisiones de alcance (verificadas antes de tocar código):**
- `get_diseno_restauracion` y `get_diseno_silvopastoril` **ya tenían chip** (`restauracion`/`paramo` y `silvopastoreo` respectivamente) — se confirmó en `chipIntentRouter.js` y NO se duplicó.
- `get_grado_dia` y `get_documento_soporte_dian` quedan **fuera a propósito**: ninguno está en `ALLOWED_TOOLS` del cliente (`sidecarClient.js`) porque exigen datos que un chip de texto libre no puede aportar de forma confiable (fecha de siembra verificada; NIT del vendedor para el Documento Soporte DIAN). Exponer un chip para ellos hoy produciría un botón que siempre cae en deflección de error — no grounding real. Se documentó en el commit; si se quiere resolver, es trabajo aparte (conectar esos datos desde el perfil/finca antes de exponer el chip).
- La curación por perfil (`profileChipSelector.js`) NO se tocó: los 6 chips nuevos quedan disponibles en el catálogo completo de `ChipsToolbar` (default sin `chipDefs`, y bypass operador), pero no se agregaron a los sets fijos por rol para no romper los contratos `toEqual` ya existentes ahí. Afinar por rol queda como follow-up si se quiere.
- Hallazgo aparte (fuera de alcance de esta tarea): `ChipsToolbar` no está montado hoy en el render tree de `AgentScreen.jsx` (el estado `activeIntent`/`setActiveIntent` y `profileChipDefs` ya existen ahí, listos para cablear, pero el JSX del componente no se inserta). Es un gap pre-existente, no introducido por este PR — se deja anotado para que el equipo decida si se cablea en un cambio aparte.

## Test plan

- [x] `src/services/__tests__/chipIntentRouter.test.js` — actualizado el contrato de 11→17 intents/CHIP_DEFS + nueva sección con los 6 casos nuevos (tool + args + skipNlu).
- [x] `src/components/__tests__/ChipsToolbar.groundingChips.test.jsx` (nuevo) — los 6 chips existen en el manifiesto, están ocultos por defecto, el toggle "Más" los revela, cada uno dispara `onSelectIntent(intent)` correcto, aria-pressed/disabled/testids se respetan, y `planForcedIntent` mapea cada uno al tool correcto.
- [x] `ChipsToolbar.smoke.test.jsx` y `agentUserFlow.smoke.test.jsx` — actualizados los conteos que distinguían "núcleo visible" de "catálogo completo tras expandir Más"; sin regresión en los chips existentes.
- [x] `npx vitest run` sobre los 9 archivos de test relacionados (chipIntentRouter, ChipsToolbar, agentUserFlow, profileChipSelector, agentCapabilities.audit, capabilityHealth, sidecarClient, manoRamasReachable, SoilDiagnosticScreen, homeModuleSelector, mcpHonestidad, userProfileService.onboarding) — todo en verde.
- [x] `npx eslint` sobre los archivos tocados — sin warnings/errores.