### PR TITLE
feat(age): reconciliación de labels + sanitizar loader

### DIFF
--- a/scripts/__tests__/load-age-graph-gaps.test.mjs
+++ b/scripts/__tests__/load-age-graph-gaps.test.mjs
@@ -32,6 +32,12 @@ import {
   parseArgs,
   KNOWN_RELATION_TYPES,
   NODE_LABEL,
+  RESEARCH_SOURCE_PREFIX,
+  loadLiveLabelSnapshot,
+  resolveLiveLabel,
+  estimateNewNodeLabel,
+  buildNodeLabelPlan,
+  LABEL_PRIORITY,
 } from '../load-age-graph-gaps.mjs';
 
 describe('splitTableRow / isSeparatorRow', () => {
@@ -259,6 +265,162 @@ describe('buildCypherStatements', () => {
     const rel = statements.find((s) => s.includes('MERGE (a)-[r:'));
     expect(rel).toContain("Restrepo\\'s bocashi");
   });
+
+  it('usa el prefijo genérico RESEARCH_SOURCE_PREFIX (no un nombre de paquete privado) en `dr`/`source`', () => {
+    expect(RESEARCH_SOURCE_PREFIX).not.toMatch(/DR-FANOUT/i);
+    const accepted = [{ origen: 'a', tipo: 'AFFECTS', destino: 'b', fuente: 'f1', confianza: 'alta', drId: 'dr1' }];
+    const { statements } = buildCypherStatements(accepted, { dateStr: '2026-07-01' });
+    const joined = statements.join('\n');
+    expect(joined).toContain(`${RESEARCH_SOURCE_PREFIX}:dr1`);
+    expect(joined).not.toMatch(/DR-FANOUT/);
+  });
+});
+
+describe('resolveLiveLabel', () => {
+  it('devuelve null si no hay labels (id no existe en el grafo vivo)', () => {
+    expect(resolveLiveLabel(undefined)).toBeNull();
+    expect(resolveLiveLabel([])).toBeNull();
+  });
+
+  it('devuelve el único label sin marcar ambigüedad', () => {
+    expect(resolveLiveLabel(['Species'])).toEqual({ label: 'Species', ambiguous: false });
+  });
+
+  it('resuelve ambigüedad real (beauveria_bassiana: BeneficialOrganism + Biopreparado) por LABEL_PRIORITY', () => {
+    const resolved = resolveLiveLabel(['Biopreparado', 'BeneficialOrganism']);
+    expect(resolved.ambiguous).toBe(true);
+    expect(resolved.label).toBe('BeneficialOrganism'); // tiene prioridad sobre Biopreparado
+    expect(resolved.candidates).toEqual(['BeneficialOrganism', 'Biopreparado']);
+    expect(LABEL_PRIORITY.indexOf('BeneficialOrganism')).toBeLessThan(LABEL_PRIORITY.indexOf('Biopreparado'));
+  });
+
+  it('cae a orden alfabético si ningún candidato está en LABEL_PRIORITY', () => {
+    const resolved = resolveLiveLabel(['ZLabel', 'ALabel']);
+    expect(resolved.ambiguous).toBe(true);
+    expect(resolved.label).toBe('ALabel');
+  });
+});
+
+describe('estimateNewNodeLabel', () => {
+  it('reconoce ids de suelo (caso real: soil_fertility, suelo_(...)) — primer nodo Soil (queue/081)', () => {
+    expect(estimateNewNodeLabel('soil_fertility')).toBe('Soil');
+    expect(estimateNewNodeLabel('suelo_(a_través_de_compostaje_de_cama_profunda)')).toBe('Soil');
+  });
+
+  it('reconoce ids de práctica de manejo', () => {
+    expect(estimateNewNodeLabel('practica_rotacion_cultivos')).toBe('Practice');
+    expect(estimateNewNodeLabel('manejo_integrado_plagas')).toBe('Practice');
+  });
+
+  it('usa el TIPO de arista como señal secundaria cuando el id no lo dice explícitamente', () => {
+    expect(estimateNewNodeLabel('id_generico', ['AFFECTS_SOIL_FERTILITY'])).toBe('Soil');
+    expect(estimateNewNodeLabel('id_generico', ['MANAGED_WITH_PRACTICE'])).toBe('Practice');
+  });
+
+  it('cae a GraphGapNode cuando no hay señal de Soil/Practice (caso general: especies, plagas, polinizadores)', () => {
+    expect(estimateNewNodeLabel('bephratelloides_maculicollis', ['AFFECTS'])).toBe(NODE_LABEL);
+    expect(estimateNewNodeLabel('xylocopa_spp', ['POLINIZA'])).toBe(NODE_LABEL);
+  });
+});
+
+describe('loadLiveLabelSnapshot', () => {
+  it('parsea el formato recomendado { labels: {...} }', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'age-graph-gaps-livelabels-'));
+    const filePath = join(dir, 'live-labels.json');
+    writeFileSync(filePath, JSON.stringify({
+      meta: { graph: 'chagra_kg' },
+      labels: { annona_squamosa: ['Species'] },
+    }), 'utf8');
+    try {
+      expect(loadLiveLabelSnapshot(filePath)).toEqual({ annona_squamosa: ['Species'] });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('acepta también un mapa plano sin envoltorio `labels`', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'age-graph-gaps-livelabels-'));
+    const filePath = join(dir, 'live-labels-flat.json');
+    writeFileSync(filePath, JSON.stringify({ annona_squamosa: ['Species'] }), 'utf8');
+    try {
+      expect(loadLiveLabelSnapshot(filePath)).toEqual({ annona_squamosa: ['Species'] });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildNodeLabelPlan', () => {
+  const acceptedEdges = [
+    { origen: 'bephratelloides_maculicollis', tipo: 'AFFECTS', destino: 'annona_squamosa' },
+    { origen: 'flemingia_congesta', tipo: 'AFFECTS', destino: 'soil_fertility' },
+  ];
+  const liveLabels = { annona_squamosa: ['Species'] };
+
+  it('marca reconciliado (isLive=true, label real) el id que existe en el grafo vivo', () => {
+    const { plan } = buildNodeLabelPlan(acceptedEdges, liveLabels);
+    expect(plan.get('annona_squamosa')).toEqual({ label: 'Species', isLive: true, ambiguous: false });
+  });
+
+  it('estima label (Soil/GraphGapNode) para ids nuevos, sin marcarlos como live', () => {
+    const { plan } = buildNodeLabelPlan(acceptedEdges, liveLabels);
+    expect(plan.get('bephratelloides_maculicollis')).toEqual({ label: NODE_LABEL, isLive: false, ambiguous: false });
+    expect(plan.get('soil_fertility')).toEqual({ label: 'Soil', isLive: false, ambiguous: false });
+  });
+
+  it('reporta ambigüedad preexistente del grafo vivo (mismo id con 2 labels)', () => {
+    const { ambiguous } = buildNodeLabelPlan(
+      [{ origen: 'beauveria_bassiana', tipo: 'CONTROLS', destino: 'x' }],
+      { beauveria_bassiana: ['Biopreparado', 'BeneficialOrganism'] },
+    );
+    expect(ambiguous).toEqual([
+      { id: 'beauveria_bassiana', labels: ['BeneficialOrganism', 'Biopreparado'], chosen: 'BeneficialOrganism' },
+    ]);
+  });
+
+  it('regresión real: el TIPO "soil-ish" de una arista NO debe etiquetar como Soil al ORIGEN (solo al destino)', () => {
+    // Caso real del corpus: `cerdo -[AFFECTS_SOIL_FERTILITY]-> suelo_(...)`.
+    // El cerdo es claramente un animal, no un concepto de suelo, aunque
+    // participe (como origen) de una arista con TIPO soil-ish.
+    const { plan } = buildNodeLabelPlan([
+      { origen: 'cerdo_(sus_scrofa_domesticus)', tipo: 'AFFECTS_SOIL_FERTILITY', destino: 'suelo_(via_compostaje)' },
+    ], {});
+    expect(plan.get('cerdo_(sus_scrofa_domesticus)').label).toBe(NODE_LABEL); // NO 'Soil'
+    expect(plan.get('suelo_(via_compostaje)').label).toBe('Soil'); // sí, por texto Y por ser destino
+  });
+});
+
+describe('buildCypherStatements con reconciliación (liveLabels)', () => {
+  const acceptedEdges = [
+    { origen: 'bephratelloides_maculicollis', tipo: 'AFFECTS', destino: 'annona_squamosa', fuente: 'f1', confianza: 'alta', drId: 'dr1' },
+  ];
+  const liveLabels = { annona_squamosa: ['Species'] };
+
+  it('NO emite MERGE de nodo para un id reconciliado (ya existe con label real)', () => {
+    const { statements, reconciledNodeCount, newNodeMergeCount } = buildCypherStatements(
+      acceptedEdges, { dateStr: '2026-07-01', liveLabels },
+    );
+    expect(reconciledNodeCount).toBe(1);
+    expect(newNodeMergeCount).toBe(1);
+    expect(statements.some((s) => s.includes("MERGE (n:Species {id: 'annona_squamosa'}"))).toBe(false);
+    expect(statements.some((s) => s.includes(`MERGE (n:${NODE_LABEL} {id: 'bephratelloides_maculicollis'}`))).toBe(true);
+  });
+
+  it('la arista hace MATCH contra el label real del nodo reconciliado, no contra GraphGapNode', () => {
+    const { statements } = buildCypherStatements(acceptedEdges, { dateStr: '2026-07-01', liveLabels });
+    const rel = statements.find((s) => s.includes('MERGE (a)-[r:'));
+    expect(rel).toContain(`MATCH (a:${NODE_LABEL} {id: 'bephratelloides_maculicollis'})`);
+    expect(rel).toContain("MATCH (b:Species {id: 'annona_squamosa'})");
+  });
+
+  it('sin liveLabels, el comportamiento es idéntico al de antes (todo GraphGapNode, todo MERGE)', () => {
+    const { statements, reconciledNodeCount, newNodeMergeCount } = buildCypherStatements(
+      acceptedEdges, { dateStr: '2026-07-01' },
+    );
+    expect(reconciledNodeCount).toBe(0);
+    expect(newNodeMergeCount).toBe(2);
+    expect(statements.filter((s) => s.includes(`MERGE (n:${NODE_LABEL}`))).toHaveLength(2);
+  });
 });
 
 describe('drIdFromPath / processDrFile', () => {
@@ -342,5 +504,10 @@ describe('parseArgs', () => {
     expect(opts.outCypher).toBe('/tmp/x.sql');
     expect(opts.outReport).toBe('/tmp/x.json');
     expect(opts.graph).toBe('otro_grafo');
+  });
+
+  it('acepta --live-labels para el snapshot de reconciliación', () => {
+    const opts = parseArgs(['--live-labels', '/tmp/live-labels.json']);
+    expect(opts.liveLabels).toBe('/tmp/live-labels.json');
   });
 });

--- a/scripts/load-age-graph-gaps.mjs
+++ b/scripts/load-age-graph-gaps.mjs
@@ -36,26 +36,39 @@
  * `--dr-dir` / env `CHAGRA_AGE_GAPS_DR_DIR`, igual que `CHAGRA_AGE_ETNO_SQL`
  * en el loader hermano.
  *
- * Nodo genérico: las entidades de estas DRs (especies, plagas, polinizadores,
- * conceptos abstractos como "fuego" o "riesgo_incendio", prácticas de manejo)
- * son demasiado heterogéneas para inferir su label canónico (Species/Pest/...)
- * sin consultar el grafo vivo — y esta etapa es offline por diseño. Por eso
- * se etiquetan bajo un label nuevo y genérico `GraphGapNode` (mismo espíritu
- * que `FolkSymptom` en el PR #1907: un label explícito para conceptos que
- * todavía no calzan en la ontología establecida). LIMITACIÓN CONOCIDA: si un
- * id ya existe como nodo canónico (p.ej. una Species ya catalogada), esto
- * crea un nodo `GraphGapNode` paralelo con el mismo `id` en vez de fusionarse
- * con el nodo existente — a resolver en una pasada de reconciliación con
- * lectura contra el grafo vivo, antes de cualquier aplicación real.
+ * Nodo genérico + reconciliación de labels: las entidades de estas DRs
+ * (especies, plagas, polinizadores, conceptos abstractos como "fuego" o
+ * "riesgo_incendio", prácticas de manejo) son demasiado heterogéneas para
+ * inferir su label canónico (Species/Pest/...) sin consultar el grafo vivo
+ * — y esta etapa sigue siendo offline por diseño (este script NUNCA se
+ * conecta a postgres/AGE). Para evitar crear nodos `GraphGapNode` paralelos
+ * que dupliquen un nodo canónico ya existente (p.ej. una Species ya
+ * catalogada), el script acepta opcionalmente un snapshot de solo-lectura
+ * del grafo vivo vía `--live-labels` / env `CHAGRA_AGE_GAPS_LIVE_LABELS`
+ * (JSON `{ labels: { "<id>": ["Species", ...] } }`, generado aparte por el
+ * operador con una query `MATCH (n) RETURN n.id, labels(n)` — nunca por
+ * este script). Con ese snapshot:
+ *   - un id que YA existe en el grafo vivo se reconcilia: la arista hace
+ *     `MATCH` contra el nodo real con su label real (Species/Pest/...) en
+ *     vez de `MERGE` un `GraphGapNode` duplicado. No se toca ni sobreescribe
+ *     ninguna propiedad del nodo existente.
+ *   - un id genuinamente nuevo recibe un label estimado a partir de la
+ *     relación/contenido (`Soil`, `Practice`; ver `estimateNewNodeLabel`),
+ *     con `GraphGapNode` como fallback cuando no hay señal suficiente —
+ *     mismo espíritu que `FolkSymptom` en el PR #1907: un label explícito
+ *     para conceptos que todavía no calzan en la ontología establecida.
+ *   - sin `--live-labels`, el comportamiento es idéntico al de antes de la
+ *     reconciliación (todo trata como nuevo, con el mismo fallback).
  *
  * Uso:
  *   node scripts/load-age-graph-gaps.mjs \
- *     --dr-dir /ruta/privada/deepresearch/DR-FANOUT \
+ *     --dr-dir /ruta/privada/research/edge-tables \
  *     --glob 'aristas-grafo-*.md' \
  *     --file porcicultura-y-avicultura-....md \
  *     --file micorrizas-y-salud-de-suelo-....md \
  *     --file recuperacion-de-suelos-....md \
  *     --file captacion-de-agua-....md \
+ *     --live-labels /ruta/privada/ops/age-graph-gaps/live-labels.json \
  *     --out-cypher /ruta/privada/ops/age-graph-gaps/gaps.cypher.sql \
  *     --out-report /ruta/privada/ops/age-graph-gaps/gaps.report.json
  *
@@ -74,6 +87,12 @@ const _here = dirname(fileURLToPath(import.meta.url));
 
 export const NODE_LABEL = 'GraphGapNode';
 
+// Prefijo genérico para la propiedad `dr` que queda grabada en cada nodo/
+// arista generada (trazabilidad hacia el DR de origen). Deliberadamente
+// genérico — el nombre real del directorio/paquete de DRs vive fuera de
+// este repo público (Chagra-strategy, privado); ver `--dr-dir` más arriba.
+export const RESEARCH_SOURCE_PREFIX = 'research/edge-tables';
+
 // Snapshot de tipos de arista ya establecidos en chagra_kg — fuente:
 // Chagra-strategy/ops/INFRA_FACTS.md (auditoría en vivo 2026-06-14) +
 // FOLK_NAME_OF (introducido en PR #1907). Solo enriquece el reporte
@@ -88,6 +107,149 @@ export const KNOWN_RELATION_TYPES = new Set([
 ]);
 
 const CO_SCOPE_RE = /colombia|andin|\bandes\b|p[aá]ramo/i;
+
+// =============================================================================
+// Reconciliación de labels contra un snapshot de solo-lectura del grafo vivo
+// =============================================================================
+//
+// Este bloque NUNCA abre una conexión: consume un snapshot ya generado
+// (JSON) que otro proceso (fuera de este script) obtuvo con una query
+// read-only contra `chagra_kg`. Objetivo: que el MERGE de un id que YA
+// existe en el grafo apunte a su label real (Species/Pest/BeneficialOrganism/
+// ...) en vez de crear un `GraphGapNode` paralelo con el mismo id.
+
+/**
+ * Carga un snapshot de labels del grafo vivo. Acepta dos formas:
+ *   - `{ labels: { "<id>": ["Species", ...] } }` (formato recomendado, con
+ *     metadata en `meta`).
+ *   - `{ "<id>": ["Species", ...] }` (mapa plano, sin envoltorio).
+ * Un id puede traer más de un label si el grafo vivo ya tiene una
+ * ambigüedad preexistente (mismo id en dos nodos con label distinto) —
+ * ver `resolveLiveLabel`. Esto es una condición preexistente del grafo, no
+ * algo introducido por este loader.
+ *
+ * @param {string} filePath
+ * @returns {Record<string, string[]>}
+ */
+export function loadLiveLabelSnapshot(filePath) {
+  const raw = JSON.parse(readFileSync(filePath, 'utf8'));
+  const labels = raw && typeof raw === 'object' && raw.labels ? raw.labels : raw;
+  return labels && typeof labels === 'object' ? labels : {};
+}
+
+// Orden de preferencia cuando un id ya existe en el grafo vivo bajo MÁS DE
+// un label (ambigüedad preexistente — p.ej. `beauveria_bassiana` catalogado
+// a la vez como `BeneficialOrganism` y `Biopreparado`). No resuelve la
+// ambigüedad de fondo (eso es un problema de calidad de datos del grafo,
+// fuera de alcance de este loader) — solo decide determinísticamente a cuál
+// de los nodos existentes apunta la arista nueva, y lo deja explícito en el
+// reporte (`ambiguousLiveMatches`) para revisión humana.
+export const LABEL_PRIORITY = [
+  'Species', 'Pest', 'Variety', 'Family', 'BeneficialOrganism', 'Biopreparado',
+  'Animal', 'Fermento', 'Origen', 'RoleInGuild', 'PisoTermico', 'Region',
+  'RegionalLabel', 'Source',
+];
+
+/**
+ * Resuelve el label "primario" para un id dado su lista de labels en el
+ * grafo vivo. Si trae un único label, ese es. Si trae varios, se usa
+ * `LABEL_PRIORITY`; si ninguno de los candidatos está priorizado, se elige
+ * el primero en orden alfabético (determinístico, no arbitrario).
+ *
+ * @param {string[]} liveLabelsForId
+ * @returns {{label:string, ambiguous:boolean, candidates?:string[]}|null}
+ */
+export function resolveLiveLabel(liveLabelsForId) {
+  if (!Array.isArray(liveLabelsForId) || liveLabelsForId.length === 0) return null;
+  if (liveLabelsForId.length === 1) return { label: liveLabelsForId[0], ambiguous: false };
+  const candidates = [...liveLabelsForId].sort();
+  const byPriority = LABEL_PRIORITY.find((l) => candidates.includes(l));
+  return { label: byPriority || candidates[0], ambiguous: true, candidates };
+}
+
+// Heurísticas para estimar el label de un id GENUINAMENTE nuevo (no existe
+// en el grafo vivo) a partir de su propio texto. Cubre los dos casos reales
+// vistos en el corpus de "huecos" (agua/riego, incendios, micorrizas-suelo):
+// conceptos de suelo (`suelo_...`, `soil_fertility`) y de prácticas de
+// manejo. Deliberadamente conservador: solo dos labels nuevos con evidencia
+// real en los DR de esta línea de trabajo (ver queue/081 — "micorrizas
+// sería el primer nodo Soil real del grafo"); todo lo demás cae en el
+// fallback `GraphGapNode`, igual que antes de la reconciliación.
+export const NEW_NODE_LABEL_HINTS = [
+  { pattern: /(^|_)(suelo|soil)(_|$)/i, label: 'Soil' },
+  { pattern: /(^|_)(practica|manejo|practice)(_|$)/i, label: 'Practice' },
+];
+
+/**
+ * Estima el label de un id nuevo (no reconciliado contra el grafo vivo).
+ * Primero prueba el propio texto del id (más específico — p.ej.
+ * `soil_fertility` ya lo dice todo aunque el TIPO de la arista sea el
+ * genérico `AFFECTS`); si no matchea, prueba el/los TIPO(s) de arista donde
+ * el id participa como **destino** (objeto de la relación — p.ej. un futuro
+ * `AFFECTS_SOIL_FERTILITY`; el origen de esa arista típicamente es un
+ * animal/práctica que AFECTA el suelo, no el suelo en sí — ver
+ * `buildNodeLabelPlan`, que es quien decide qué TIPOs pasar aquí). Si nada
+ * matchea, fallback a `GraphGapNode`.
+ *
+ * @param {string} nodeId
+ * @param {Iterable<string>} [relTypes] - TIPOs de arista donde el id es destino
+ * @returns {string}
+ */
+export function estimateNewNodeLabel(nodeId, relTypes = []) {
+  for (const hint of NEW_NODE_LABEL_HINTS) {
+    if (hint.pattern.test(nodeId)) return hint.label;
+  }
+  for (const relType of relTypes) {
+    if (/SOIL/.test(relType)) return 'Soil';
+    if (/PRACTIC|MANEJO|MANAGEMENT/.test(relType)) return 'Practice';
+  }
+  return NODE_LABEL;
+}
+
+/**
+ * Construye el plan de labels para todos los ids (origen+destino) de un
+ * batch de aristas curadas: para cada id, decide si ya existe en el grafo
+ * vivo (y con qué label real) o si es nuevo (con label estimado).
+ *
+ * Nota de dirección: el TIPO de arista solo se usa como señal secundaria de
+ * `estimateNewNodeLabel` cuando el id aparece como **destino** (objeto) de
+ * esa relación — no como origen. Ej.: en
+ * `cerdo -[AFFECTS_SOIL_FERTILITY]-> suelo_(...)`, el TIPO "suelo-ish" es
+ * evidencia razonable para `suelo_(...)` (destino) pero NO para `cerdo`
+ * (origen, claramente un animal) — usar el TIPO sin importar la dirección
+ * fue un bug real encontrado corriendo este loader contra el corpus real
+ * (etiquetaba `cerdo_(sus_scrofa_domesticus)` como `Soil`).
+ *
+ * @param {Array<{origen:string,tipo:string,destino:string}>} acceptedEdges
+ * @param {Record<string,string[]>} [liveLabels]
+ * @returns {{plan: Map<string,{label:string,isLive:boolean,ambiguous:boolean}>, ambiguous: Array<{id:string,labels:string[],chosen:string}>}}
+ */
+export function buildNodeLabelPlan(acceptedEdges, liveLabels = {}) {
+  const allNodeIds = new Set();
+  const destinoRelTypesByNode = new Map();
+  for (const e of acceptedEdges) {
+    allNodeIds.add(e.origen);
+    allNodeIds.add(e.destino);
+    if (!destinoRelTypesByNode.has(e.destino)) destinoRelTypesByNode.set(e.destino, new Set());
+    destinoRelTypesByNode.get(e.destino).add(e.tipo);
+  }
+
+  const plan = new Map();
+  const ambiguous = [];
+  for (const nodeId of allNodeIds) {
+    const resolved = resolveLiveLabel(liveLabels[nodeId]);
+    if (resolved) {
+      plan.set(nodeId, { label: resolved.label, isLive: true, ambiguous: resolved.ambiguous });
+      if (resolved.ambiguous) {
+        ambiguous.push({ id: nodeId, labels: resolved.candidates, chosen: resolved.label });
+      }
+    } else {
+      const relTypes = destinoRelTypesByNode.get(nodeId) || new Set();
+      plan.set(nodeId, { label: estimateNewNodeLabel(nodeId, relTypes), isLive: false, ambiguous: false });
+    }
+  }
+  return { plan, ambiguous };
+}
 
 // =============================================================================
 // Detección genérica de tablas markdown
@@ -307,26 +469,53 @@ export function curateRawEdges(rawEdges, { drScoped, drId }) {
  * aristas ya curadas. Dedupea el MERGE de nodo por id (el mismo id puede
  * aparecer en decenas de aristas dentro y entre DRs) para no inflar el
  * archivo de salida con el mismo MERGE repetido.
+ *
+ * Reconciliación (`liveLabels`, opcional): para un id que YA existe en el
+ * grafo vivo, NO se emite un `MERGE` de nodo — la arista se conecta por
+ * `MATCH` directo contra el nodo real (ver `emitRel`), con su label real
+ * (Species/Pest/...). Así el apply es idempotente y no crea un
+ * `GraphGapNode` paralelo ni toca las propiedades del nodo existente. Solo
+ * los ids genuinamente nuevos (no encontrados en `liveLabels`) reciben un
+ * `MERGE` de nodo, con label estimado (`estimateNewNodeLabel`).
+ *
+ * @param {Array<object>} acceptedEdges
+ * @param {{graph?:string, dateStr?:string, liveLabels?:Record<string,string[]>}} [opts]
  */
-export function buildCypherStatements(acceptedEdges, { graph = 'chagra_kg', dateStr } = {}) {
+export function buildCypherStatements(acceptedEdges, { graph = 'chagra_kg', dateStr, liveLabels = {} } = {}) {
   const statements = [];
   const emittedNodes = new Set();
   const today = dateStr || new Date().toISOString().slice(0, 10);
+  const { plan, ambiguous } = buildNodeLabelPlan(acceptedEdges, liveLabels);
+  let newNodeMergeCount = 0;
+  let reconciledNodeCount = 0;
+  const reconciledByLabel = {};
+  const newByEstimatedLabel = {};
+
   for (const e of acceptedEdges) {
-    const drRef = `DR-FANOUT:${e.drId}`;
+    const drRef = `${RESEARCH_SOURCE_PREFIX}:${e.drId}`;
     for (const nodeId of [e.origen, e.destino]) {
       if (emittedNodes.has(nodeId)) continue;
       emittedNodes.add(nodeId);
-      statements.push(wrapCypher(graph, emitNode(NODE_LABEL, {
+      const info = plan.get(nodeId);
+      if (info.isLive) {
+        // Nodo ya existe en chagra_kg — se referencia por MATCH en la
+        // arista (abajo), sin tocar sus propiedades.
+        reconciledNodeCount++;
+        reconciledByLabel[info.label] = (reconciledByLabel[info.label] || 0) + 1;
+        continue;
+      }
+      newNodeMergeCount++;
+      newByEstimatedLabel[info.label] = (newByEstimatedLabel[info.label] || 0) + 1;
+      statements.push(wrapCypher(graph, emitNode(info.label, {
         id: nodeId,
         source: drRef,
         added_at: today,
       })));
     }
     statements.push(wrapCypher(graph, emitRel(
-      { label: NODE_LABEL, id: e.origen },
+      { label: plan.get(e.origen).label, id: e.origen },
       e.tipo,
-      { label: NODE_LABEL, id: e.destino },
+      { label: plan.get(e.destino).label, id: e.destino },
       {
         source: e.fuente,
         confidence: e.confianza,
@@ -335,7 +524,15 @@ export function buildCypherStatements(acceptedEdges, { graph = 'chagra_kg', date
       },
     )));
   }
-  return { statements, nodeCount: emittedNodes.size };
+  return {
+    statements,
+    nodeCount: emittedNodes.size,
+    newNodeMergeCount,
+    reconciledNodeCount,
+    reconciledByLabel,
+    newByEstimatedLabel,
+    ambiguousLiveMatches: ambiguous,
+  };
 }
 
 // =============================================================================
@@ -438,6 +635,29 @@ export function formatReportText(report) {
   for (const dr of report.perDr) {
     lines.push(`  - ${dr.drId}: aceptadas=${dr.acceptedCount} descartadas=${dr.rejectedCount} tablas_aristas=${dr.edgeTablesFound}/${dr.tablesFound} scoped_co=${dr.drScoped ? 'si' : 'no'}`);
   }
+  if (report.reconciliation) {
+    const rc = report.reconciliation;
+    lines.push(`[age-graph-gaps] reconciliación live-labels: snapshot=${rc.liveLabelsProvided ? 'si' : 'no'}`);
+    lines.push(`[age-graph-gaps] nodos referenciados: ${rc.totalNodeIds} | reconciliados (label real): ${rc.reconciledCount} | nuevos (label estimado): ${rc.newCount}`);
+    if (rc.reconciledCount) {
+      lines.push('[age-graph-gaps] reconciliados por label real (MATCH, sin MERGE de nodo):');
+      for (const [label, count] of Object.entries(rc.reconciledByLabel).sort((a, b) => b[1] - a[1])) {
+        lines.push(`  - ${label}: ${count}`);
+      }
+    }
+    if (rc.newCount) {
+      lines.push('[age-graph-gaps] nuevos por label estimado (MERGE de nodo):');
+      for (const [label, count] of Object.entries(rc.newByEstimatedLabel).sort((a, b) => b[1] - a[1])) {
+        lines.push(`  - ${label}: ${count}`);
+      }
+    }
+    if (rc.ambiguousMatches.length) {
+      lines.push(`[age-graph-gaps] AVISO: ${rc.ambiguousMatches.length} id(s) con más de un label en el grafo vivo (ambigüedad preexistente, no introducida por este loader):`);
+      for (const a of rc.ambiguousMatches) {
+        lines.push(`  - ${a.id}: candidatos=[${a.labels.join(', ')}] elegido=${a.chosen}`);
+      }
+    }
+  }
   return lines.join('\n');
 }
 
@@ -457,6 +677,7 @@ export function parseArgs(argv) {
     files: [],
     outCypher: process.env.CHAGRA_AGE_GAPS_OUT_CYPHER || '',
     outReport: process.env.CHAGRA_AGE_GAPS_OUT_REPORT || '',
+    liveLabels: process.env.CHAGRA_AGE_GAPS_LIVE_LABELS || '',
     graph: 'chagra_kg',
     json: false,
     help: false,
@@ -468,6 +689,7 @@ export function parseArgs(argv) {
     else if (a === '--file') opts.files.push(argv[++i]);
     else if (a === '--out-cypher') opts.outCypher = argv[++i];
     else if (a === '--out-report') opts.outReport = argv[++i];
+    else if (a === '--live-labels') opts.liveLabels = argv[++i];
     else if (a === '--graph') opts.graph = argv[++i];
     else if (a === '--json') opts.json = true;
     else if (a === '--help' || a === '-h') opts.help = true;
@@ -497,9 +719,12 @@ export function main(argv = process.argv.slice(2)) {
   const opts = parseArgs(argv);
   if (opts.help) {
     console.log([
-      'Usage: node scripts/load-age-graph-gaps.mjs --dr-dir DIR [--glob PATTERN]... [--file NAME]... [--out-cypher FILE] [--out-report FILE] [--graph chagra_kg] [--json]',
+      'Usage: node scripts/load-age-graph-gaps.mjs --dr-dir DIR [--glob PATTERN]... [--file NAME]... [--live-labels FILE] [--out-cypher FILE] [--out-report FILE] [--graph chagra_kg] [--json]',
       '',
       'BUILD + DRY-RUN: nunca se conecta a AGE/postgres. Genera Cypher + reporte a archivo.',
+      '--live-labels FILE (o env CHAGRA_AGE_GAPS_LIVE_LABELS): snapshot read-only',
+      'del grafo vivo ({ labels: { "<id>": ["Species", ...] } }) para reconciliar',
+      'MERGE contra nodos reales en vez de crear GraphGapNode paralelos.',
     ].join('\n'));
     return 0;
   }
@@ -518,12 +743,26 @@ export function main(argv = process.argv.slice(2)) {
     return 2;
   }
 
+  const liveLabels = opts.liveLabels ? loadLiveLabelSnapshot(opts.liveLabels) : {};
+
   const perDrResults = files.map((f) => processDrFile(f));
   const allAccepted = perDrResults.flatMap((r) => r.accepted);
-  const { statements, nodeCount } = buildCypherStatements(allAccepted, { graph: opts.graph });
+  const {
+    statements, nodeCount, newNodeMergeCount, reconciledNodeCount,
+    reconciledByLabel, newByEstimatedLabel, ambiguousLiveMatches,
+  } = buildCypherStatements(allAccepted, { graph: opts.graph, liveLabels });
   const report = buildDryRunReport(perDrResults, { graph: opts.graph });
   report.totals.cypherStatements = statements.length;
-  report.totals.cypherNodeMerges = nodeCount;
+  report.totals.cypherNodeMerges = newNodeMergeCount;
+  report.reconciliation = {
+    liveLabelsProvided: Boolean(opts.liveLabels),
+    totalNodeIds: nodeCount,
+    reconciledCount: reconciledNodeCount,
+    newCount: newNodeMergeCount,
+    reconciledByLabel,
+    newByEstimatedLabel,
+    ambiguousMatches: ambiguousLiveMatches,
+  };
 
   const outCypher = opts.outCypher || join(_here, '..', '.local', 'age-graph-gaps', 'gaps.cypher.sql');
   const outReport = opts.outReport || join(_here, '..', '.local', 'age-graph-gaps', 'gaps.report.json');
@@ -534,7 +773,9 @@ export function main(argv = process.argv.slice(2)) {
     '-- Generado por scripts/load-age-graph-gaps.mjs — DRY-RUN, NO aplicado.',
     `-- Grafo destino: ${opts.graph}`,
     `-- DRs fuente: ${perDrResults.map((r) => r.drId).join(', ')}`,
-    `-- Statements: ${statements.length} (MERGE-only, idempotente, no destructivo)`,
+    `-- Statements: ${statements.length} (MERGE/MATCH, idempotente, no destructivo)`,
+    `-- Reconciliación live-labels: ${opts.liveLabels ? 'aplicada' : 'NO aplicada (todo id tratado como nuevo)'} — ` +
+      `${reconciledNodeCount} nodo(s) reconciliado(s) contra label real (MATCH, sin MERGE), ${newNodeMergeCount} nodo(s) nuevo(s) (MERGE).`,
     '-- Revisión humana requerida antes de ejecutar contra postgres-farm.',
     '',
     "LOAD 'age';",


### PR DESCRIPTION
## Summary

- `scripts/load-age-graph-gaps.mjs` (PR #1925) etiquetaba **todo** id nuevo bajo `GraphGapNode`, incluso los que ya existen como `Species`/`Pest`/`BeneficialOrganism`/... en `chagra_kg`. Aplicar ese Cypher habría creado nodos paralelos duplicando el grafo vivo.
- Se agrega reconciliación **opcional y offline** (`--live-labels FILE` / env `CHAGRA_AGE_GAPS_LIVE_LABELS`): el script sigue sin conectarse nunca a AGE/postgres — consume un snapshot JSON (`{ labels: { "<id>": ["Species", ...] } }`) generado aparte por una query read-only contra el grafo vivo.
  - Id ya existente → la arista se conecta por `MATCH` contra su **label real**, sin `MERGE` de nodo ni mutación de propiedades del nodo canónico.
  - Id genuinamente nuevo → label estimado (`Soil`/`Practice`, heurística por texto del id + TIPO de arista cuando el id es *destino*; ver `estimateNewNodeLabel`), con `GraphGapNode` como fallback.
  - Ambigüedad preexistente del grafo (mismo id con 2 labels, ej. `beauveria_bassiana` como `BeneficialOrganism` y `Biopreparado`) se resuelve determinísticamente (`LABEL_PRIORITY`) y queda explícita en el reporte (`ambiguousMatches`) para revisión humana — no es un problema introducido por este loader.
  - Sin `--live-labels`, el comportamiento es idéntico al de antes (backward compatible).
- Corrida real contra el corpus de "huecos" (43 DRs, 356 aristas aceptadas, 328 ids únicos) usando un snapshot read-only de `chagra_kg` (alpha, 2026-07-01):

  | | count |
  |---|---|
  | reconciliados (label real, sin MERGE de nodo) | **116** |
  | — Species | 71 |
  | — Pest | 33 |
  | — BeneficialOrganism | 11 |
  | — Animal | 1 |
  | nuevos (label estimado, con MERGE de nodo) | **212** |
  | — Soil | 2 |
  | — GraphGapNode (fallback) | 210 |

  Statements de Cypher generados: 684 → 568 (116 `MERGE` de nodo evitados). Reporte + Cypher reconciliados regenerados en `Chagra-strategy/ops/age-graph-gaps/` (repo privado, no incluido en este PR).
- Sanitiza el literal `deepresearch/DR-FANOUT` (nombre de directorio privado) a un placeholder genérico `research/edge-tables`, tanto en el ejemplo de uso del docstring como en el prefijo de la propiedad `dr` grabada en cada nodo/arista generada. Verificado contra el grafo vivo: ninguna arista aplicada usa aún el prefijo `DR-FANOUT` (nada se rompe con el rename).

## Test plan

- [x] `npx vitest run scripts/__tests__/load-age-graph-gaps.test.mjs` — 48/48 tests, incluye cobertura nueva de `loadLiveLabelSnapshot`, `resolveLiveLabel`, `estimateNewNodeLabel`, `buildNodeLabelPlan` y `buildCypherStatements` con/sin reconciliación.
- [x] Regresión real encontrada y corregida durante la verificación manual: el TIPO de arista `AFFECTS_SOIL_FERTILITY` marcaba como `Soil` tanto al origen (`cerdo_(sus_scrofa_domesticus)`, un animal) como al destino — se corrigió para que la heurística por TIPO solo aplique al lado destino de la relación (test de regresión agregado).
- [x] `npx eslint scripts/load-age-graph-gaps.mjs scripts/__tests__/load-age-graph-gaps.test.mjs` — sin errores.
- [x] Corrida end-to-end contra el corpus real (43 DRs) con snapshot read-only del grafo vivo — resultados arriba, verificados manualmente contra `chagra_kg`.
- [x] Grafo vivo consultado **solo lectura** (`MATCH`/`RETURN`, ningún `INSERT`/`DELETE`/`MERGE` contra `chagra_kg` real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)