### PR TITLE
fix(build): reparar build de prod roto (useAssetStore import)

### DIFF
--- a/src/components/InventoryAuditDashboard.jsx
+++ b/src/components/InventoryAuditDashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { AlertCircle, CheckCircle2, RefreshCw, Save, History, Scale } from 'lucide-react';
-import { useAssetStore } from '../store/useAssetStore';
+import useAssetStore from '../store/useAssetStore';
 import { openDB, STORES } from '../db/dbCore';
 import { reconcileAllItems } from '../services/inventoryReconcile';
 import { savePayload } from '../services/payloadService';


### PR DESCRIPTION
## Problema
El build de prod fallaba con `[MISSING_EXPORT] useAssetStore is not exported by src/store/useAssetStore.js` en `InventoryAuditDashboard.jsx:3`. El componente era huérfano (import roto nunca bundleado); al rutearlo en #1928 el build empezó a incluirlo y a fallar → el Deploy PWA venía rojo.

## Fix
`import { useAssetStore }` → `import useAssetStore` (es `export default`). Un cambio.

## Test plan
Build de prod verde (bundle-sizes + offline-corpus + Deploy dejan de fallar).