### PR TITLE
feat(agent-screen): mount chips toolbar

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe, queueForRetry } from '../../services/voiceService';
 import VoiceStatusStrip from './VoiceStatusStrip';
+import ChipsToolbar from '../ChipsToolbar';
 import ContextTip from '../ContextTip';
 import {
   claimNext as outboxClaimNext,
@@ -290,6 +291,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       return null;
     }
   }, []);
+  const isPro = useMemo(() => getCurrentTier() === 'pro', []);
   // La MANO de Chagra (AgentRedMenu) — MISMA red que el home, no menús de texto.
   // sheetOpen monta/desmonta el overlay de la mano (AgentManoOverlay).
   const [sheetOpen, setSheetOpen] = useState(false);
@@ -3335,6 +3337,17 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           }}
           onStopSpeaking={() => { stop(); agentSounds.cancel(); }}
           onDismissNotice={() => setVoiceNotice('')}
+        />
+
+        <ChipsToolbar
+          activeIntent={activeIntent}
+          hasAttachment={Boolean(agentAttachment)}
+          disabled={state === STATE_RECORDING || queuePending.length >= 1}
+          isPro={isPro}
+          chipDefs={profileChipDefs}
+          onSelectIntent={(intent) => {
+            setActiveIntent((current) => (current === intent ? null : intent));
+          }}
         />
 
         {/* Pill — unified with AgentHero (as-bar CSS tokens) */}

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -1,0 +1,420 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+function createStoreHook(state) {
+  const hook = (selector) => (typeof selector === 'function' ? selector(state) : state);
+  hook.getState = () => state;
+  hook.setState = (patch) => Object.assign(state, patch);
+  return hook;
+}
+
+function buildMockChipDefs() {
+  return [
+    {
+      intent: 'biopreparado',
+      label: 'Biopreparado',
+      emoji: '🧪',
+      placeholder: 'Escribe para que plaga o planta quieres el biopreparado',
+    },
+    {
+      intent: 'clima',
+      label: 'Clima',
+      emoji: '🌤️',
+      placeholder: 'Pregunta por la lluvia o el clima de tu zona',
+    },
+    {
+      intent: 'plaga',
+      label: 'Plaga',
+      emoji: '🐛',
+      placeholder: 'Escribe la plaga o describe el dano que ves',
+    },
+  ];
+}
+
+const mockChipDefs = buildMockChipDefs();
+
+vi.mock('../../../services/chipIntentRouter', () => ({
+  CHIP_INTENTS: { deep: 'deep' },
+  CHIP_DEFS: buildMockChipDefs(),
+  planForcedIntent: vi.fn(),
+  isStubIntent: vi.fn(() => false),
+  isDeepResearchIntent: vi.fn(() => false),
+}));
+
+vi.mock('../../../services/profileChipSelector', () => ({
+  selectChipDefs: vi.fn(() => mockChipDefs),
+}));
+
+vi.mock('../../../services/deepResearchClient', () => ({
+  isDeepResearchEnabled: vi.fn(() => false),
+  submitDeepResearch: vi.fn(),
+  pollDeepResearch: vi.fn(),
+}));
+
+vi.mock('../../../services/tierService', () => ({
+  getCurrentTier: vi.fn(() => 'free'),
+}));
+
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'nature' }),
+}));
+
+vi.mock('../../../hooks/useVoiceRecorder', () => ({
+  default: () => ({
+    durationMs: 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../services/voiceService', () => ({
+  transcribe: vi.fn(),
+  queueForRetry: vi.fn(),
+}));
+
+vi.mock('../../../services/agentOutboxService', () => ({
+  claimNext: vi.fn(() => Promise.resolve(null)),
+  markAnswered: vi.fn(() => Promise.resolve()),
+  markError: vi.fn(() => Promise.resolve()),
+  recoverStaleProcessing: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../../../services/agentOutboxPhoto', () => ({
+  processPhotoItem: vi.fn(),
+  buildPhotoUserMessage: vi.fn(),
+}));
+
+vi.mock('../../../services/agentOutboxAttachment', () => ({
+  isAnalyzableImageAttachment: vi.fn(() => false),
+  buildAttachmentRejection: vi.fn(() => 'No puedo leer ese archivo.'),
+}));
+
+vi.mock('../../../services/aiService', () => ({
+  analyzeFoliage: vi.fn(),
+}));
+
+vi.mock('../../../services/photoService', () => ({
+  captureAndCompress: vi.fn(),
+}));
+
+vi.mock('../../../services/conversationMemory', () => ({
+  addTurn: vi.fn(() => Promise.resolve()),
+  getFullHistory: vi.fn(() => Promise.resolve([])),
+  getContextString: vi.fn(() => Promise.resolve('')),
+  computeSourceMetadata: vi.fn(() => null),
+  mergePostValidateMetadata: vi.fn((value) => value),
+  extractGroundingBadges: vi.fn(() => []),
+  deriveEvidenceSourceLink: vi.fn(() => null),
+  extractEdges: vi.fn(() => []),
+  clearMemory: vi.fn(() => Promise.resolve()),
+  shouldStartNewSession: vi.fn(() => false),
+}));
+
+vi.mock('../../../services/ragRetriever', () => ({
+  retrieve: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('../../../services/agentIntentParser', () => ({
+  parseIntent: vi.fn(() => null),
+  formatIntentDescription: vi.fn(() => ''),
+}));
+
+vi.mock('../../../services/openaiStream', () => ({
+  streamOpenAI: vi.fn(),
+}));
+
+vi.mock('../../../services/llmRouter', () => ({
+  buildLLMRequest: vi.fn(() => ({ url: '/mock', body: { model: 'mock', temperature: 0, max_tokens: 32, keep_alive: '24h' } })),
+  selectChatRoute: vi.fn(() => 'chat'),
+}));
+
+vi.mock('../../../services/streamChatViaSidecar', () => ({
+  streamChatViaSidecar: vi.fn(),
+  isAgentStreamingEnabled: vi.fn(() => false),
+}));
+
+vi.mock('../../../services/streamDeadline', () => ({
+  createStreamDeadline: vi.fn(() => ({
+    start: vi.fn(),
+    onToken: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../services/sidecarClient', () => ({
+  isSidecarEnabled: vi.fn(() => false),
+  planNlu: vi.fn(),
+  callTool: vi.fn(),
+  executeToolChain: vi.fn(),
+  resolveEntities: vi.fn(),
+  fermentoPrefilter: vi.fn(),
+  biopreparadoGrounding: vi.fn(),
+  postValidate: vi.fn(),
+  getClimaIdeam: vi.fn(),
+  isToolAllowed: vi.fn(() => false),
+}));
+
+vi.mock('../../../services/skyConditionService', () => ({
+  summarizeSkyForGrounding: vi.fn(() => null),
+}));
+
+vi.mock('../../../services/promptAssembler', () => ({
+  assembleSystemContent: vi.fn(() => ({ content: 'mock-system' })),
+  TOP_N_RAG: 5,
+}));
+
+vi.mock('../../../services/outputGuards', () => ({
+  applyOutputGuards: vi.fn((text) => text),
+  classifyQueryIntent: vi.fn(() => 'unknown'),
+}));
+
+vi.mock('../../../services/streamGuards', () => ({
+  createStreamGuard: vi.fn(() => ({
+    check: vi.fn((text) => text),
+  })),
+}));
+
+vi.mock('../../../services/userProfileService', () => ({
+  getProfile: vi.fn(() => ({ finca_altitud: 2600 })),
+  getModuleVisibility: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../services/fincaActiveStore', () => ({
+  default: createStoreHook({
+    activeFincaSlug: 'guatoc',
+    fincas: [{ slug: 'guatoc', nombre: 'Guatoc', altitud: 2600 }],
+    indoorZone: null,
+  }),
+}));
+
+vi.mock('../../../services/ensoContext', () => ({
+  regionFromProfile: vi.fn(() => 'andina'),
+  getEnsoOutlook: vi.fn(() => null),
+}));
+
+vi.mock('../../../services/proactiveGreeting', () => ({
+  resolveProactiveGreeting: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock('../../../store/useLogStore', () => ({
+  default: createStoreHook({
+    getPendingTasks: vi.fn(() => []),
+  }),
+}));
+
+vi.mock('../../../store/usePrefsStore', () => ({
+  default: createStoreHook({
+    operatorId: 'operator-1',
+    ttsEnabled: false,
+    setTtsEnabled: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../store/useAssetStore', () => ({
+  default: createStoreHook({
+    plants: [],
+  }),
+}));
+
+vi.mock('../../../store/useAgentNotificationStore', () => ({
+  default: createStoreHook({
+    setResponseReady: vi.fn(),
+    setLastMessage: vi.fn(),
+    markRead: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../store/useOllamaWarmStore', () => ({
+  default: createStoreHook({
+    status: 'warm',
+  }),
+}));
+
+vi.mock('../../../store/useAgentQueueStore', () => ({
+  default: createStoreHook({
+    processing: null,
+    pending: [],
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../store/useAlertStore', () => ({
+  default: createStoreHook({
+    activeAlerts: [],
+  }),
+}));
+
+vi.mock('../../../services/climaService', () => ({
+  getCachedClimaSnapshot: vi.fn(() => null),
+  fetchClimaSnapshot: vi.fn(() => Promise.resolve(null)),
+  resolveClimaLocation: vi.fn(() => null),
+}));
+
+vi.mock('../../../services/ttsService', () => ({
+  speak: vi.fn(),
+  speakSentences: vi.fn(),
+  stop: vi.fn(),
+  init: vi.fn(),
+  isSupported: vi.fn(() => true),
+  isKokoroAvailable: vi.fn(() => Promise.resolve(false)),
+  replayLast: vi.fn(() => Promise.resolve(false)),
+  isSpeaking: vi.fn(() => false),
+  onSpeakingChange: vi.fn(() => () => {}),
+  isAudioPlaying: vi.fn(() => false),
+  getLastSpoken: vi.fn(() => null),
+}));
+
+vi.mock('../../../services/actionExecutor', () => ({
+  executeAction: vi.fn(),
+  setActionGateCallback: vi.fn(),
+}));
+
+vi.mock('../../../services/tipsService', () => ({
+  useRotatingTip: vi.fn(() => ({ tip: null, dismiss: vi.fn() })),
+}));
+
+vi.mock('../../../services/agentRequestQueue', () => ({
+  enqueueRequest: vi.fn(() => Promise.resolve(null)),
+  finalizeRequest: vi.fn(() => Promise.resolve()),
+  failRequest: vi.fn(() => Promise.resolve()),
+  resumePending: vi.fn(() => Promise.resolve()),
+  drainPending: vi.fn(() => Promise.resolve({ processed: 0, failed: 0 })),
+}));
+
+vi.mock('../../../services/agentRequestSender', () => ({
+  createAgentRequestSender: vi.fn(() => vi.fn(() => Promise.resolve({ response: '' }))),
+}));
+
+vi.mock('../../../services/agentService', () => ({
+  normalizeUserInputForRegion: vi.fn((text) => text),
+  buildClimaContext: vi.fn(() => ''),
+  buildFincaContext: vi.fn(() => ''),
+  buildViabilityContext: vi.fn(() => ''),
+  buildFrostHeatContext: vi.fn(() => ''),
+  buildAssociationContext: vi.fn(() => ''),
+  buildInvasiveSafetyContext: vi.fn(() => ''),
+  buildCuratedFactsContext: vi.fn(() => ''),
+  applyVoseoFilter: vi.fn((text) => text),
+  resolveUserRegion: vi.fn(() => null),
+  stripRoleLeak: vi.fn((text) => text),
+  buildPriceDeclineContext: vi.fn(() => ''),
+  buildPriceAnswer: vi.fn(() => ''),
+  buildSuggestedEntitiesContext: vi.fn(() => ''),
+  isLowConfidenceEntity: vi.fn(() => false),
+  buildFallbackResponse: vi.fn(() => ''),
+  pisoTermicoFromAltitud: vi.fn(() => null),
+  groupAndLimitCultivos: vi.fn(() => []),
+}));
+
+vi.mock('../../../services/knowledgeIntentRouter', () => ({
+  planKnowledgeIntent: vi.fn(() => null),
+  hasSoilDiagnosticIntent: vi.fn(() => false),
+  hasWaterDiagnosticIntent: vi.fn(() => false),
+  hasAnimalDiagnosticIntent: vi.fn(() => false),
+  hasRestauracionDiagnosticIntent: vi.fn(() => false),
+  hasIncendioRiskIntent: vi.fn(() => false),
+}));
+
+vi.mock('../../../services/grafoRelations', () => ({
+  buildOfflineGroundingBlock: vi.fn(() => ''),
+}));
+
+vi.mock('../../../services/speciesResolver', () => ({
+  resolveSpecies: vi.fn(() => null),
+}));
+
+vi.mock('../../ChatHistory', () => ({
+  default: () => <div data-testid="chat-history-stub" />,
+}));
+
+vi.mock('../../VoiceStatusStrip', () => ({
+  default: () => <div data-testid="voice-status-stub" />,
+}));
+
+vi.mock('../../ContextTip', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../ActionConfirmModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../FeedbackConsentModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../ChagraAgentAvatar', () => ({
+  default: () => <div data-testid="agent-avatar-stub" />,
+}));
+
+vi.mock('../../ChagraAgentAvatarColibriPhoto', () => ({
+  default: () => <div data-testid="agent-colibri-stub" />,
+}));
+
+vi.mock('../../agent/AgentShell', () => ({
+  AgentManoOverlay: () => null,
+}));
+
+vi.mock('../../agent/capabilityRouting', () => ({
+  mapCapabilityPick: vi.fn(() => false),
+}));
+
+vi.mock('../../dashboard/themeIcon', () => ({
+  iconForTheme: vi.fn(() => <span data-testid="theme-icon-stub" />),
+}));
+
+vi.mock('../../dashboard/ManoChagraGlyph', () => ({
+  default: () => <span data-testid="mano-glyph-stub" />,
+}));
+
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: vi.fn(() => false),
+  esOperadorActual: vi.fn(() => false),
+}));
+
+vi.mock('../../../config/fincaVivaHomeFlag', () => ({
+  fincaVivaHomePerfilActivo: vi.fn(() => false),
+}));
+
+vi.mock('../../../hooks/useInsightProactivo', () => ({
+  detectarSlugEnTexto: vi.fn(() => null),
+  elegirInsight: vi.fn(() => null),
+}));
+
+import AgentScreen from '../AgentScreen';
+
+describe('AgentScreen - chips toolbar', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('monta la barra de chips junto al input y cambia la intencion al tocar un chip', async () => {
+    render(<AgentScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chips-toolbar')).toBeInTheDocument();
+    });
+
+    const toolbar = screen.getByTestId('chips-toolbar');
+    const input = screen.getByTestId('agent-input');
+    expect(toolbar.compareDocumentPosition(input) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+
+    expect(toolbar).toHaveTextContent('Biopreparado');
+    const biopreparadoChip = screen.getByRole('button', { name: /biopreparado/i });
+    fireEvent.click(biopreparadoChip);
+
+    expect(biopreparadoChip).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('agent-input')).toHaveAttribute(
+      'placeholder',
+      'Escribe para que plaga o planta quieres el biopreparado',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Mount `ChipsToolbar` in `AgentScreen` right above the composer input.
- Wire the toolbar to the active chip state, profile chip definitions, and Pro gating.
- Add an integration test that renders `AgentScreen`, verifies the toolbar mounts near the input, and checks a chip click updates the input intent.

## Test plan
- `npx vitest run src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx src/components/__tests__/ChipsToolbar.smoke.test.jsx`
- `npx eslint src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx --max-warnings=0`
- `npm run build`