### PR TITLE
feat(precio): cablear chip a referencia real

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -49,7 +49,7 @@ import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities,
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
-// los chips cuyo backend aún no existe (precio/deep).
+// el chip cuyo backend aún no existe (deep).
 import { planForcedIntent, isStubIntent, isDeepResearchIntent, CHIP_DEFS } from '../../services/chipIntentRouter';
 // #349 — router heurístico de GROUNDING para el path de FALLO del NLU. Cuando
 // `planNlu` devuelve null (timeout/fail del sidecar bajo contención de GPU), el
@@ -74,6 +74,7 @@ import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../
 import { getCurrentTier } from '../../services/tierService';
 import DeepResearchCard from '../DeepResearchCard';
 import { normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildPriceAnswer, buildSuggestedEntitiesContext, isLowConfidenceEntity, buildFallbackResponse, pisoTermicoFromAltitud, groupAndLimitCultivos } from '../../services/agentService';
+import { buildPriceReferenceAnswer } from '../../services/marketplaceService';
 import { buildBasePrompt, analyzeQuery, buildQueryAnalysisBlock, buildCorpusVariants, buildResolvedEntitiesBlock, formatToolEvidence, truncateEdgesBlock } from '../../services/agentPromptBase';
 // Nubosidad real para el grounding (fix Choachí 2026-06) — solo lee caches.
 import { summarizeSkyForGrounding } from '../../services/skyConditionService';
@@ -1554,7 +1555,26 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               altitud: fincaAltitudChip,
               pisoTermico: pisoTermicoChip,
             });
-            if (forcedPlan && forcedPlan.localGrounding === 'incendio') {
+            if (forcedPlan && forcedPlan.localGrounding === 'precio_referencia') {
+              const priceMsg = buildPriceReferenceAnswer(forcedPlan.args?.producto || textForLLM);
+              if (priceMsg) {
+                const userMessage = { role: 'user', content: trimmed, timestamp: Date.now() };
+                const assistantMessage = {
+                  role: 'assistant',
+                  content: priceMsg,
+                  timestamp: Date.now(),
+                };
+                setMessages((prev) => [...prev, userMessage, assistantMessage]);
+                try {
+                  await addTurn(operatorId, { role: 'user', content: trimmed });
+                  await addTurn(operatorId, { role: 'assistant', content: priceMsg });
+                } catch (e) {
+                  console.warn('[Agent] precio addTurn failed (continuo):', e?.message);
+                }
+                setActiveIntent(null);
+                return;
+              }
+            } else if (forcedPlan && forcedPlan.localGrounding === 'incendio') {
               // Riesgo de incendio: estimación client-side (NO tool sidecar, NO
               // API de alerta en tiempo real). Calculamos el bloque honesto y lo
               // inyectamos como evidence; el LLM lo presenta como estimación.
@@ -2368,7 +2388,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
     // VITE_DEEP_RESEARCH_ENABLED + online. B14: mientras la feature no esté
     // servible en prod, 'deep' es kind:'stub' en el manifiesto, así que
     // isDeepResearchIntent('deep') es false y este branch NO se dispara vía chip
-    // — la pregunta cae al stub honesto de abajo (mismo handler que 'precio').
+    // — la pregunta cae al stub honesto de abajo.
     // El branch se conserva intacto: reactivar es volver 'deep' a kind:'deep' en
     // agentCapabilities.js cuando el backend esté live (sin tocar este flujo).
     if (forcedIntent && isDeepResearchIntent(forcedIntent)) {
@@ -2512,11 +2532,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       return;
     }
 
-    // CHIPS DE MODO — STUB (A3): precio no tiene backend todavía. NO
-    // routeamos a un tool fantasma ni gastamos una inferencia del LLM:
+    // CHIPS DE MODO — STUB (A3): solo los chips sin backend van por aquí.
+    // No routeamos a un tool fantasma ni gastamos una inferencia del LLM:
     // pintamos la pregunta del usuario + una respuesta honesta "aún no
-    // disponible" y salimos. Esto evita el misrouting del NLU (que mandaba
-    // "papa" al tool de precio inexistente) y es transparente con el campesino.
+    // disponible" y salimos.
     if (forcedIntent && isStubIntent(forcedIntent)) {
       const stubPlan = planForcedIntent(forcedIntent, trimmed);
       if (stubPlan && stubPlan.stub && stubPlan.stubMessage) {

--- a/src/components/__tests__/ChipsToolbar.smoke.test.jsx
+++ b/src/components/__tests__/ChipsToolbar.smoke.test.jsx
@@ -132,8 +132,8 @@ describe('ChipsToolbar — flag Deep Research OFF (chip 🔬 oculto)', () => {
   });
 });
 
-// ──── Chip precio (stub) — no promete capacidades que no existen ────────────
-describe('ChipsToolbar — chip precio stub no engaña', () => {
+// ──── Chip precio (live) — referencia local groundeada ─────────────────────
+describe('ChipsToolbar — chip precio usa referencia local', () => {
   beforeEach(() => {
     vi.spyOn(deepResearchClient, 'isDeepResearchEnabled').mockReturnValue(false);
   });
@@ -141,14 +141,14 @@ describe('ChipsToolbar — chip precio stub no engaña', () => {
     vi.restoreAllMocks();
   });
 
-  test('chip precio tiene placeholder honesto (sin prometer precio)', () => {
+  test('chip precio tiene placeholder claro para escribir el producto', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} />);
     const precioDef = CHIP_DEFS.find((d) => d.intent === 'precio');
     expect(precioDef.placeholder.toLowerCase()).toMatch(/producto|precio/i);
-    expect(precioDef.placeholder.toLowerCase()).not.toMatch(/consulta\s+exitosa|resultado|dato/i);
+    expect(precioDef.kind).toBe('local');
   });
 
-  test('chip precio es clickable (funciona, solo que el backend es stub)', () => {
+  test('chip precio es clickable y no se bloquea', () => {
     const onSelectIntent = vi.fn();
     render(<ChipsToolbar onSelectIntent={onSelectIntent} />);
     fireEvent.click(screen.getByText('Precio'));

--- a/src/components/__tests__/agentUserFlow.smoke.test.jsx
+++ b/src/components/__tests__/agentUserFlow.smoke.test.jsx
@@ -29,14 +29,6 @@ const JERGA_TECNICA = [
   /\bdisponible en este plan\b/i,
 ];
 
-// Palabras/patrones que DEBEN aparecer en mensajes de fallo para ser útiles
-const FALLO_UTIL = [
-  /no\s+(pude|pudo|está|est[aá]|hay|tengo|encontr)/i,
-  /conexión|red|internet|verifica/i,
-  /intenta|prueba|vuelve/i,
-  /ayuda|orient|fuente|alternativa/i,
-];
-
 describe('flujo usuario nuevo — chips visibles sin jerga técnica', () => {
   beforeEach(() => {
     vi.spyOn(deepResearchClient, 'isDeepResearchEnabled').mockReturnValue(false);
@@ -54,14 +46,10 @@ describe('flujo usuario nuevo — chips visibles sin jerga técnica', () => {
     }
   });
 
-  it('stubMessage de precio es entendible (menciona alternativa concreta)', () => {
+  it('chip precio ya no es stub y usa referencia local', () => {
     const precioDef = CHIP_DEFS.find((d) => d.intent === 'precio');
-    expect(precioDef.stubMessage).toBeTruthy();
-    for (const pattern of JERGA_TECNICA) {
-      expect(precioDef.stubMessage).not.toMatch(pattern);
-    }
-    // Debe mencionar fuentes alternativas concretas (no "vuelva luego")
-    expect(precioDef.stubMessage).toMatch(/SIPSA|DANE|Corabastos|central|fuente/i);
+    expect(precioDef.kind).toBe('local');
+    expect(precioDef.placeholder.toLowerCase()).toMatch(/producto|precio/i);
   });
 
   it('chip "¿Qué siembro?" usa fraseo de pregunta, no comando técnico', () => {
@@ -124,19 +112,15 @@ describe('flujo usuario nuevo — respuesta entendible cuando falla una herramie
     vi.restoreAllMocks();
   });
 
-  it('chip precio (stub) tiene stubMessage útil con alternativas', () => {
+  it('chip precio es local y mantiene contrato visible', () => {
     const precioDef = CHIP_DEFS.find((d) => d.intent === 'precio');
-    const msg = precioDef.stubMessage;
-    // El mensaje debe contener al menos un patrón de "fallo útil"
-    const tieneFalloUtil = FALLO_UTIL.some((re) => re.test(msg));
-    expect(tieneFalloUtil).toBe(true);
+    expect(precioDef.kind).toBe('local');
   });
 
-  it('chip precio stubMessage orienta a fuente real (no solo "no disponible")', () => {
+  it('chip precio conserva una etiqueta clara para consultar referencias', () => {
     const precioDef = CHIP_DEFS.find((d) => d.intent === 'precio');
-    const msg = precioDef.stubMessage;
-    // Debe mencionar una fuente o paso concreto (SIPSA, DANE, Corabastos, DANE)
-    expect(msg).toMatch(/SIPSA|DANE|Corabastos|central\s+de\s+abastos/i);
+    expect(precioDef.label).toBe('Precio');
+    expect(precioDef.placeholder).toMatch(/producto/i);
   });
 
   it('placeholder de clima pide municipio (guía al usuario a dar información útil)', () => {

--- a/src/services/__tests__/agentCapabilities.audit.test.js
+++ b/src/services/__tests__/agentCapabilities.audit.test.js
@@ -13,7 +13,7 @@
  *   - offline: navigator.onLine=false → null (corta antes del LLM)
  *   - MCP caído: fetch falla → null
  *   - MCP sin datos: available:false / found:false → mensaje honesto
- *   - función no disponible por plan → stubMessage claro (ej. precio)
+ *   - función no disponible por plan → stubMessage claro (ej. deep)
  */
 import { describe, it, expect } from 'vitest';
 import { CHIP_INTENTS, CHIP_DEFS, planForcedIntent } from '../chipIntentRouter.js';
@@ -62,11 +62,10 @@ const CHIP_REGISTRY = [
     intent: 'precio',
     label: 'Precio',
     emoji: '💰',
-    kind: 'stub',
+    kind: 'local',
     tool: null,
-    stub: true,
+    stub: false,
     deep: false,
-    expectsStubMessage: true,
   },
   {
     intent: 'calendario',
@@ -253,16 +252,13 @@ describe('agentCapabilities — fallo explícito corta antes del LLM', () => {
 // 4. Stubs — función no disponible explica qué falta y cómo seguir
 // ---------------------------------------------------------------------------
 describe('agentCapabilities — stubs explican con honestidad', () => {
-  it('precio: stubMessage explica que SIPSA es archivo descargable + fuente alternativa', () => {
+  it('precio: plan local resuelve referencia real sin stubMessage', () => {
     const plan = planForcedIntent('precio', 'papa');
-    expect(plan.stub).toBe(true);
+    expect(plan.stub).toBe(false);
     expect(plan.tool).toBeNull();
-    expect(typeof plan.stubMessage).toBe('string');
-    expect(plan.stubMessage.length).toBeGreaterThan(30);
-    // Debe mencionar que NO está disponible y orientar
-    expect(plan.stubMessage.toLowerCase()).toContain('no');
-    expect(plan.stubMessage).toContain('SIPSA');
-    expect(plan.stubMessage).toContain('Corabastos');
+    expect(plan.localGrounding).toBe('precio_referencia');
+    expect(plan.args).toEqual({ producto: 'papa' });
+    expect(plan.stubMessage).toBeNull();
   });
 
   it('clima sin municipio: stubResult con available:false + reason no_municipio', () => {

--- a/src/services/__tests__/capabilityHealth.test.js
+++ b/src/services/__tests__/capabilityHealth.test.js
@@ -104,12 +104,12 @@ describe('getCapabilityHealth — estado real por capacidad', () => {
     expect(getCapabilityHealth('calendario', deps)).toBe('down');
   });
 
-  it('precio retorna soon (explicito en manifest)', () => {
+  it('precio retorna live porque ya es local y no depende del sidecar', () => {
     const deps = makeDeps({ isSidecarEnabled: true });
-    expect(getCapabilityHealth('precio', deps)).toBe('soon');
-    // sidecar no afecta: aunque este habilitado, el manifest dice soon
+    expect(getCapabilityHealth('precio', deps)).toBe('live');
+    // sidecar no afecta: aunque este deshabilitado, la capacidad sigue live
     const depsOff = makeDeps({ isSidecarEnabled: false });
-    expect(getCapabilityHealth('precio', depsOff)).toBe('soon');
+    expect(getCapabilityHealth('precio', depsOff)).toBe('live');
   });
 
   it('deep retorna soon (explicito en manifest, B14: backend no disponible aun)', () => {

--- a/src/services/__tests__/chipIntentRouter.test.js
+++ b/src/services/__tests__/chipIntentRouter.test.js
@@ -376,19 +376,20 @@ describe('chipIntentRouter — grounding oscuro (chips antes SOLO alcanzables po
   });
 });
 
-describe('chipIntentRouter — intents STUB (backend no existe aún)', () => {
-  it('precio → stub claro "aún no disponible" (NO inventa backend de precio)', () => {
+describe('chipIntentRouter — intents local y stub', () => {
+  it('precio → localGrounding de referencia real (NO inventa backend de precio)', () => {
     const plan = planForcedIntent('precio', 'papa');
     expect(plan.intent).toBe('precio');
-    expect(plan.stub).toBe(true);
     expect(plan.tool).toBeNull();
-    expect(typeof plan.stubMessage).toBe('string');
-    expect(plan.stubMessage.toLowerCase()).toContain('no');
+    expect(plan.stub).toBe(false);
+    expect(plan.localGrounding).toBe('precio_referencia');
+    expect(plan.args).toEqual({ producto: 'papa' });
+    expect(plan.stubMessage).toBeNull();
     expect(plan.skipNlu).toBe(true);
   });
 
-  it('isStubIntent reconoce precio y deep como stub (B14: backend no disponible)', () => {
-    expect(isStubIntent('precio')).toBe(true);
+  it('isStubIntent reconoce solo deep como stub (precio ya es local)', () => {
+    expect(isStubIntent('precio')).toBe(false);
     // B14: investigacion profunda aun NO esta servible — es stub honesto
     expect(isStubIntent('deep')).toBe(true);
     expect(isStubIntent('siembro')).toBe(false);
@@ -402,7 +403,7 @@ describe('chipIntentRouter — Deep Research (B14: stub honesto, backend no serv
   it('deep → stub claro "aún no disponible" + skipNlu + tool null (NO path live)', () => {
     // B14: la investigacion profunda no tiene backend servible en prod (el job
     // async vive detras de VITE_DEEP_RESEARCH_ENABLED, off por defecto). El chip
-    // NO routea a un path "live": devuelve el mismo stub honesto que 'precio'.
+    // NO routea a un path "live": devuelve un stub honesto propio.
     const plan = planForcedIntent('deep', 'sistema agroforestal cacao');
     expect(plan.intent).toBe('deep');
     expect(plan.stub).toBe(true);
@@ -432,7 +433,7 @@ describe('chipIntentRouter — Deep Research (B14: stub honesto, backend no serv
     const deepDef = CHIP_DEFS.find((d) => d.intent === 'deep');
     expect(deepDef).toBeTruthy();
     expect(deepDef.kind).toBe('stub');
-    // Como stub, EXPONE stubMessage honesto (igual que 'precio').
+    // Como stub, EXPONE stubMessage honesto.
     expect(typeof deepDef.stubMessage).toBe('string');
     expect(deepDef.stubMessage.length).toBeGreaterThan(0);
   });
@@ -475,11 +476,12 @@ describe('chipIntentRouter — opts ruidosos no contaminan los args', () => {
     expect(plan.args).toEqual({ pest_id_or_name: 'broca' });
   });
 
-  it('precio ignora opts completamente (es stub)', () => {
+  it('precio conserva el texto como producto candidato y no depende de opts', () => {
     const plan = planForcedIntent('precio', 'papa', { municipio: 'Choachí' });
-    expect(plan.stub).toBe(true);
     expect(plan.tool).toBeNull();
-    expect(plan.args).toBeNull();
+    expect(plan.stub).toBe(false);
+    expect(plan.localGrounding).toBe('precio_referencia');
+    expect(plan.args).toEqual({ producto: 'papa' });
   });
 
   it('deep ignora opts completamente (es stub)', () => {

--- a/src/services/__tests__/marketplaceService.test.js
+++ b/src/services/__tests__/marketplaceService.test.js
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   formatearCOP, normalizarTelefono, construirContacto,
-  resolverPrecioReferencia, validarOferta, filtrarOfertas,
+  resolverPrecioReferencia, buildPriceReferenceAnswer, validarOferta, filtrarOfertas,
 } from '../marketplaceService';
 
 describe('formatearCOP', () => {
@@ -72,6 +72,27 @@ describe('resolverPrecioReferencia (anti-alucinación)', () => {
     expect(r.mercado).toContain('Pereira');
     expect(r.fuente).toBe('SIPSA');
     expect(r.boletinFecha).toBe('2026-06-09');
+  });
+});
+
+describe('buildPriceReferenceAnswer', () => {
+  it('devuelve una referencia de mercado legible cuando hay dato', () => {
+    const msg = buildPriceReferenceAnswer('tomate');
+    expect(msg).toContain('tomate');
+    expect(msg).toContain('SIPSA');
+    expect(msg).toContain('central de abastos');
+    expect(msg).toMatch(/\$\d[\d.]*–\$\d[\d.]* \/ kg/);
+  });
+
+  it('declina honestamente cuando no hay dato verificable', () => {
+    const msg = buildPriceReferenceAnswer('quinua');
+    expect(msg).toContain('No encontré una referencia SIPSA');
+    expect(msg).toContain('quinua');
+  });
+
+  it('retorna null para entrada vacia', () => {
+    expect(buildPriceReferenceAnswer('')).toBeNull();
+    expect(buildPriceReferenceAnswer(null)).toBeNull();
   });
 });
 

--- a/src/services/__tests__/mcpHonestidad.test.js
+++ b/src/services/__tests__/mcpHonestidad.test.js
@@ -4,7 +4,7 @@
  * Evita 3 anti-patrones:
  * 1. Presentar datos sintéticos como reales (callTool nunca fabrica).
  * 2. Mensajes idénticos para fallos distintos (available:false ≠ timeout ≠ error).
- * 3. Atribución falsa de fuentes (stubMessage no contiene datos que parezcan reales).
+ * 3. Atribución falsa de fuentes (las respuestas de precio y stub no inventan).
  *
  * Regla: si callTool retorna null, NO hay data. El caller (AgentScreen) no debe
  * presentar nada como "respuesta del sistema" porque no hubo respuesta.
@@ -108,16 +108,15 @@ describe('mcp honestidad — señales de fallo distinguibles', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. Mensajes de stub no contienen datos que parezcan reales
+// 3. Precio de referencia local no inventa cifras
 // ---------------------------------------------------------------------------
-describe('mcp honestidad — stubMessage no contiene datos falsos', () => {
+describe('mcp honestidad — precio de referencia local no inventa cifras', () => {
   /**
-   * Los stubMessage son texto visible para el campesino cuando una función
-   * NO está disponible. No deben contener:
-   *   - Números específicos (precios, fechas, cantidades)
-   *   - Valores monetarios ($, COP, pesos con dígitos)
-   *   - Afirmaciones que suenen a dato real de mercado
-   *   - URLs de afiliación o comerciales (sin validación)
+   * Las respuestas del chip precio son texto visible para el campesino.
+   * No deben:
+   *   - Inventar un valor si no hay dato verificable
+   *   - Omitir la fuente institucional cuando sí hay dato
+   *   - Afirmar que el dato proviene del sidecar si no se usó
    */
   const DATA_LIKE_PATTERNS = [
     /\$\s*\d+/,          // $123, $ 123
@@ -126,34 +125,26 @@ describe('mcp honestidad — stubMessage no contiene datos falsos', () => {
     /\b(precio|valor)\s*(de|del)?\s*\d+/i, // "precio de 5000"
   ];
 
-  it('precio: stubMessage no contiene números que parezcan precios', () => {
+  it('precio: plan local expone una respuesta groundeada', async () => {
     const { planForcedIntent } = require('../chipIntentRouter.js');
     const plan = planForcedIntent('precio', 'papa');
-    expect(plan.stub).toBe(true);
+    expect(plan.stub).toBe(false);
+    expect(plan.localGrounding).toBe('precio_referencia');
+
+    const { buildPriceReferenceAnswer } = await import('../marketplaceService.js');
+    const msg = buildPriceReferenceAnswer(plan.args.producto);
+    expect(msg).toContain('SIPSA');
+    expect(msg).toContain('central de abastos');
+    expect(msg).toMatch(/\$\d[\d.]*–\$\d[\d.]* \/ kg/);
+  });
+
+  it('precio: sin dato verificable, la respuesta declina con honestidad', async () => {
+    const { buildPriceReferenceAnswer } = await import('../marketplaceService.js');
+    const msg = buildPriceReferenceAnswer('quinua');
+    expect(msg).toContain('No encontré una referencia SIPSA');
+    expect(msg).toContain('quinua');
     for (const pattern of DATA_LIKE_PATTERNS) {
-      expect(plan.stubMessage).not.toMatch(pattern);
-    }
-  });
-
-  it('precio: stubMessage menciona que no está disponible', () => {
-    const { planForcedIntent } = require('../chipIntentRouter.js');
-    const plan = planForcedIntent('precio', 'papa');
-    const msg = plan.stubMessage.toLowerCase();
-    // Debe contener palabras que indiquen indisponibilidad
-    expect(msg).toMatch(/no\s+(est[aá]|disponible|tiene|hay|puede)/i);
-    // No debe sonar a que la data existe pero no se muestra ("por ahora",
-    // "todavía", "aún no")
-    expect(msg).toMatch(/(por\s+ahora|todav[ií]a|a[uú]n\s+no)/i);
-  });
-
-  it('todos los CHIP_DEFS con stubMessage cumplen contrato de no-datos-falsos', () => {
-    const { CHIP_DEFS } = require('../chipIntentRouter.js');
-    for (const def of CHIP_DEFS) {
-      if (!def.stubMessage) continue;
-      for (const pattern of DATA_LIKE_PATTERNS) {
-        expect(def.stubMessage).not.toMatch(pattern);
-      }
-      expect(def.stubMessage).not.toMatch(/\$\s*\d+/);
+      expect(msg).not.toMatch(pattern);
     }
   });
 });
@@ -257,18 +248,18 @@ describe('mcp honestidad — _hasUnavailablePriceEvidence defensiva', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. Sin atribución falsa — sidecar responde con datos reales o nada
+// 6. Sin atribucion falsa
 // ---------------------------------------------------------------------------
-describe('mcp honestidad — sin atribución falsa', () => {
-  it('stubMessage de precio no dice "según SIPSA" ni "el DANE reporta"', () => {
+describe('mcp honestidad — sin atribucion falsa', () => {
+  it('precio local no atribuye al sidecar ni promete un backend fantasma', async () => {
     const { planForcedIntent } = require('../chipIntentRouter.js');
     const plan = planForcedIntent('precio', 'papa');
-    const msg = plan.stubMessage.toLowerCase();
-    // No debe afirmar que hay data de SIPSA (no la hay)
-    expect(msg).not.toMatch(/seg[uú]n\s+sipsa/);
-    expect(msg).not.toMatch(/dane\s+reporta/);
-    expect(msg).not.toMatch(/dane\s+dice/);
-    expect(msg).not.toMatch(/sipsa\s+(tiene|reporta|dice|muestra)/);
+    expect(plan.localGrounding).toBe('precio_referencia');
+    expect(plan.tool).toBeNull();
+    const { buildPriceReferenceAnswer } = await import('../marketplaceService.js');
+    const msg = buildPriceReferenceAnswer('papa');
+    expect(msg).toContain('SIPSA');
+    expect(msg).not.toMatch(/sidecar/i);
   });
 
   it('classifyQueryIntent no confunde precio con siembra', async () => {

--- a/src/services/__tests__/profileChipSelector.test.js
+++ b/src/services/__tests__/profileChipSelector.test.js
@@ -114,6 +114,7 @@ describe('profileChipSelector — selectChipIntentsForRole (núcleo puro)', () =
       CHIP_INTENTS.plaga,
       CHIP_INTENTS.biopreparado,
       CHIP_INTENTS.clima,
+      CHIP_INTENTS.precio,
     ]);
     // NO debe mostrar páramo a un campesino que no pidió restauración.
     expect(intents).not.toContain(CHIP_INTENTS.paramo);
@@ -132,6 +133,7 @@ describe('profileChipSelector — selectChipIntentsForRole (núcleo puro)', () =
   it('guía glaciar: clima + páramo + restauración, SIN biopreparado/calendario', () => {
     const intents = selectChipIntentsForRole({ role: PROFILE_ROLES.guia_glaciar });
     expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).toContain(CHIP_INTENTS.precio);
     expect(intents).toContain(CHIP_INTENTS.paramo);
     expect(intents).not.toContain(CHIP_INTENTS.biopreparado);
     expect(intents).not.toContain(CHIP_INTENTS.calendario);
@@ -191,6 +193,7 @@ describe('profileChipSelector — selectChipIntents (perfil completo)', () => {
     });
     expect(intents).toContain(CHIP_INTENTS.siembro);
     expect(intents).toContain(CHIP_INTENTS.silvopastoreo);
+    expect(intents).toContain(CHIP_INTENTS.precio);
     expect(intents).not.toContain(CHIP_INTENTS.paramo);
     // NUNCA chips irrelevantes para este campesino: deep no aparece.
     expect(intents).not.toContain(CHIP_INTENTS.deep);
@@ -210,6 +213,7 @@ describe('profileChipSelector — selectChipIntents (perfil completo)', () => {
   it('guía glaciar por whitelist → clima/páramo, sin biopreparado', () => {
     const intents = selectChipIntents({ vocacion: 'campesino' }, { esGuiaGlaciar: true });
     expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).toContain(CHIP_INTENTS.precio);
     expect(intents).toContain(CHIP_INTENTS.paramo);
     expect(intents).not.toContain(CHIP_INTENTS.biopreparado);
   });
@@ -322,6 +326,7 @@ describe('profileChipSelector — chips POR TIPO DE USUARIO', () => {
     expect(intents).toContain(CHIP_INTENTS.plaga);
     expect(intents).toContain(CHIP_INTENTS.biopreparado);
     expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).toContain(CHIP_INTENTS.precio);
     expect(intents).not.toContain(CHIP_INTENTS.silvopastoreo);
     expect(intents).not.toContain(CHIP_INTENTS.paramo);
   });
@@ -329,6 +334,7 @@ describe('profileChipSelector — chips POR TIPO DE USUARIO', () => {
   it('guia_glaciar: solo clima/paramo/restauracion, sin cultivo', () => {
     const intents = selectChipIntents({}, { esGuiaGlaciar: true });
     expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).toContain(CHIP_INTENTS.precio);
     expect(intents).toContain(CHIP_INTENTS.paramo);
     expect(intents).toContain(CHIP_INTENTS.restauracion);
     expect(intents).not.toContain(CHIP_INTENTS.siembro);
@@ -341,11 +347,12 @@ describe('profileChipSelector — chips POR TIPO DE USUARIO', () => {
     expect(intents).toContain(CHIP_INTENTS.biopreparado);
     expect(intents).toContain(CHIP_INTENTS.siembro);
     expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).toContain(CHIP_INTENTS.precio);
     expect(intents).toContain(CHIP_INTENTS.paramo);
     expect(intents).toContain(CHIP_INTENTS.silvopastoreo);
     expect(intents).toContain(CHIP_INTENTS.restauracion);
     // Los stubs NO aparecen
-    expect(intents).not.toContain(CHIP_INTENTS.precio);
+    expect(intents).not.toContain(CHIP_INTENTS.deep);
   });
 
   it('porcicultor (campesino con cerdos): ve cultivo + silvopastoreo', () => {
@@ -379,7 +386,7 @@ describe('profileChipSelector — chips POR TIPO DE USUARIO', () => {
 });
 
 describe('profileChipSelector — invariantes', () => {
-  it('NUNCA devuelve chips stubs (precio/deep) para ningun perfil no-operador', () => {
+  it('NUNCA devuelve chips stubs para ningun perfil no-operador', () => {
     const perfiles = [
       { rol: 'campesino' },
       { rol: 'restaurador' },
@@ -389,7 +396,6 @@ describe('profileChipSelector — invariantes', () => {
     ];
     for (const p of perfiles) {
       const intents = selectChipIntents(p);
-      expect(intents).not.toContain(CHIP_INTENTS.precio);
       expect(intents).not.toContain(CHIP_INTENTS.deep);
     }
   });

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -90,26 +90,18 @@ export const CAPABILITY_MANIFEST = Object.freeze([
   {
     id: 'precio',
     intent: 'precio',
-    kind: 'stub',
+    kind: 'local',
     icon: '💰',
     label: 'Precio',
     desc: 'Consultar precios mayoristas del día.',
     placeholder: 'Escribe el producto del que quieres saber el precio',
     tool: null,
-    stubMessage:
-      'La consulta de precios todavía no está disponible en Chagra. ' +
-      'Por ahora el precio mayorista lo publica el DANE (SIPSA) como archivo descargable, ' +
-      'sin consulta directa. Si quieres, te oriento a la fuente o a Corabastos.',
+    stubMessage: null,
     group: 'vender',
-    status: 'soon',
-    // hero:false (descubribilidad 2026-06-24) — `precio` SIGUE siendo chip
-    // honesto en el ChipsToolbar (stub con stubMessage que orienta a SIPSA/
-    // Corabastos), pero se RETIRA de la mano radial: era la ÚNICA hoja del grupo
-    // "vender" y, al ser status:'soon' (no-op → solo toast "por lanzar"), dejaba
-    // una rama muerta. Sin backing real de precios, se quita la rama de la mano
-    // (el grupo "vender" desaparece: GROUPS filtra grupos sin hojas hero). El día
-    // que exista precio real, se vuelve a poner hero:true con heroRoute live.
-    // Ref: CAPABILITIES_STATUS.md §7.4 (reparar ramas muertas).
+    status: 'live',
+    // hero:false (descubribilidad 2026-07-01): `precio` ya consulta la
+    // referencia real desde el cliente, pero sigue fuera de la mano radial
+    // para no reabrir la rama "vender" sin una decision de UX aparte.
     hero: false,
     heroRoute: { kind: 'unavailable' },
   },

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -39,11 +39,11 @@
  *   - polinizacion → get_polinizacion (polinizadores + colmenas/ha)
  *   - fenologia    → get_fenologia (etapas BBCH + ventana de plaga por etapa)
  *
- * Intents STUB (el backend aún NO existe — NO inventamos endpoints):
- *   - precio → SIPSA/DANE consulta directa no disponible (dataset ZIP federado).
+ * Intents sin tool sidecar:
+ *   - precio → referencia de mercado calculada localmente desde precioReferencia.
  *   - deep   → investigación profunda multi-fuente sin pipeline implementado.
- *   Ambos devuelven un mensaje honesto "aún no disponible" en vez de routear
- *   a un tool fantasma.
+ *   `precio` no es stub: consulta la referencia groundeada y responde
+ *   determinísticamente sin inventar cifras.
  *
  * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino. Todos los
  * strings visibles al campesino se redactan en neutro colombiano.
@@ -61,9 +61,9 @@ const DEF_BY_INTENT = Object.freeze(
 
 /**
  * ¿Este intent es un STUB (backend no disponible aún)?
- * Devuelve true para 'precio' y 'deep' (kind:'stub' en el manifiesto): ambos
- * carecen de backend servible en esta versión y muestran un mensaje honesto
- * "aún no disponible" en vez de routear a un tool/path fantasma.
+ * Devuelve true para los intents con kind:'stub' en el manifiesto. Hoy ese
+ * contrato aplica a `deep`; `precio` ya se resuelve localmente contra la
+ * referencia de mercado.
  * @param {string} intent
  * @returns {boolean}
  */
@@ -77,10 +77,10 @@ export function isStubIntent(intent) {
  *
  * B14: mientras la investigación profunda NO esté servible, 'deep' es kind
  * 'stub' en el manifiesto, así que esta función devuelve false para 'deep' y el
- * chip cae al stub honesto (mismo handler que 'precio'). La función se conserva
- * como punto de enganche: cuando el backend deep-research esté servido en prod
- * (feature flag VITE_DEEP_RESEARCH_ENABLED), basta volver 'deep' a kind 'deep'
- * en el manifiesto para reactivar el path live SIN tocar el AgentScreen.
+ * chip cae al stub honesto. La función se conserva como punto de enganche:
+ * cuando el backend deep-research esté servido en prod (feature flag
+ * VITE_DEEP_RESEARCH_ENABLED), basta volver 'deep' a kind 'deep' en el
+ * manifiesto para reactivar el path live SIN tocar el AgentScreen.
  * @param {string} intent
  * @returns {boolean}
  */
@@ -307,15 +307,21 @@ export function planForcedIntent(intent, text, opts = {}) {
       return { ...base, tool: 'get_fenologia', args: { species_id: prompt } };
 
     case CHIP_INTENTS.precio:
-      // STUB: backend no implementado. NO inventamos endpoint.
-      return { ...base, stub: true, stubMessage: def.stubMessage };
+      // Ruta local groundeada: usa el mismo resolver de referencia del
+      // marketplace, sin inventar backend ni tocar el sidecar.
+      return {
+        ...base,
+        tool: null,
+        args: { producto: prompt },
+        localGrounding: 'precio_referencia',
+      };
 
     case CHIP_INTENTS.deep:
       // STUB (B14): la investigación profunda aún no tiene backend servible en
       // prod (el job async vive detrás de VITE_DEEP_RESEARCH_ENABLED, off por
-      // defecto). Devolvemos el mismo stub honesto que 'precio' — NO routeamos
-      // a un path "live" inexistente. Coherente con el manifiesto (status 'soon')
-      // y con el menú de capacidades, que ya pinta 'deep' como por-lanzar.
+      // defecto). Devolvemos un stub honesto y no routeamos a un path "live"
+      // inexistente. Coherente con el manifiesto (status 'soon') y con el
+      // menú de capacidades, que ya pinta 'deep' como por-lanzar.
       return { ...base, stub: true, stubMessage: def.stubMessage };
 
     default:

--- a/src/services/marketplaceService.js
+++ b/src/services/marketplaceService.js
@@ -92,12 +92,46 @@ export function resolverPrecioReferencia(producto) {
   const cita = classifySource(ref.fuente, { concept: producto });
   return {
     disponible: true,
+    producto: ref.producto,
     banda,
     mercado: ref.mercado,
     fuente: cita.fuente || ref.fuente,
     fuenteUrl: cita.fuente_url || null,
     boletinFecha: ref.boletinFecha,
   };
+}
+
+/**
+ * Construye una respuesta humana de precio de referencia para el chip Precio.
+ * Usa la misma base groundeada que el marketplace: resolverPrecioReferencia().
+ * Si no hay dato verificable, devuelve una declinacion honesta.
+ *
+ * @param {string} producto
+ * @returns {string|null}
+ */
+export function buildPriceReferenceAnswer(producto) {
+  const query = String(producto || '').trim();
+  if (!query) return null;
+
+  const ref = resolverPrecioReferencia(query);
+  if (!ref.disponible) {
+    return `No encontré una referencia SIPSA para "${query}". Si quiere, escriba el producto exacto y lo reviso de nuevo.`;
+  }
+
+  const fecha = ref.boletinFecha
+    ? new Intl.DateTimeFormat('es-CO', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      timeZone: 'UTC',
+    }).format(new Date(`${ref.boletinFecha}T00:00:00Z`))
+    : null;
+
+  const productoCanonico = ref.producto || query;
+  let msg = `💰 ${productoCanonico} está entre ${ref.banda} en ${ref.mercado}.`;
+  msg += ` (Fuente: ${ref.fuente}${fecha ? `, ${fecha}` : ''}.)`;
+  msg += ' Es precio mayorista en central de abastos; en plaza local puede variar.';
+  return msg;
 }
 
 /**

--- a/src/services/profileChipSelector.js
+++ b/src/services/profileChipSelector.js
@@ -55,6 +55,11 @@ const CULTIVO_CHIPS = Object.freeze([
   CHIP_INTENTS.clima,
 ]);
 
+/** Chips de consulta general. */
+const GENERAL_CHIPS = Object.freeze([
+  CHIP_INTENTS.precio,
+]);
+
 /** Chips de restauración ecológica. @type {readonly string[]} */
 const RESTAURACION_CHIPS = Object.freeze([
   CHIP_INTENTS.restauracion,
@@ -70,11 +75,15 @@ const RESTAURACION_CHIPS = Object.freeze([
  * @type {Record<string, readonly string[]>}
  */
 const ROLE_BASE_CHIPS = Object.freeze({
-  [PROFILE_ROLES.campesino]: Object.freeze([...CULTIVO_CHIPS]),
+  [PROFILE_ROLES.campesino]: Object.freeze([
+    ...CULTIVO_CHIPS,
+    ...GENERAL_CHIPS,
+  ]),
   [PROFILE_ROLES.restaurador]: Object.freeze([
     ...RESTAURACION_CHIPS,
     CHIP_INTENTS.siembro,
     CHIP_INTENTS.clima,
+    ...GENERAL_CHIPS,
   ]),
   [PROFILE_ROLES.guia_glaciar]: Object.freeze([
     // Un guía de glaciar trabaja el clima de alta montaña y la restauración de
@@ -82,12 +91,14 @@ const ROLE_BASE_CHIPS = Object.freeze({
     // "Reporte de Punto Glaciar" es un tile del Home con su propio gate, NO un
     // chip — no existe chip 'glaciar' en el manifiesto, así que no lo inventamos.)
     CHIP_INTENTS.clima,
+    ...GENERAL_CHIPS,
     CHIP_INTENTS.paramo,
     CHIP_INTENTS.restauracion,
   ]),
   [PROFILE_ROLES.ganadero]: Object.freeze([
     CHIP_INTENTS.silvopastoreo,
     CHIP_INTENTS.clima,
+    ...GENERAL_CHIPS,
     CHIP_INTENTS.plaga,
     CHIP_INTENTS.siembro,
   ]),
@@ -95,11 +106,13 @@ const ROLE_BASE_CHIPS = Object.freeze({
   [PROFILE_ROLES.socio]: Object.freeze([
     CHIP_INTENTS.siembro,
     CHIP_INTENTS.clima,
+    ...GENERAL_CHIPS,
     CHIP_INTENTS.plaga,
   ]),
   // Técnico/agrónomo: set amplio (sabe usar todo); orden = cultivo luego ecológico.
   [PROFILE_ROLES.tecnico]: Object.freeze([
     ...CULTIVO_CHIPS,
+    ...GENERAL_CHIPS,
     ...RESTAURACION_CHIPS,
   ]),
 });
@@ -115,8 +128,8 @@ const STUB_INTENTS = new Set(
 /**
  * Catálogo COMPLETO de chips VIVOS (todos los `CHIP_DEFS` con `kind !== 'stub'`),
  * en el orden del manifiesto. Es lo que ve el OPERADOR (bypass del gating por
- * perfil): la caja de herramientas entera, sin estrechar. Los stubs (precio/deep,
- * sin backend) quedan fuera, igual que para cualquier otro perfil.
+ * perfil): la caja de herramientas entera, sin estrechar. Los stubs quedan
+ * fuera, igual que para cualquier otro perfil.
  * @type {readonly string[]}
  */
 const ALL_LIVE_CHIP_INTENTS = Object.freeze(
@@ -217,8 +230,7 @@ export function deriveRole(profile, opts = {}) {
  *   - Si el objetivo incluye restauración/biodiversidad, suma los chips de
  *     restauración al final (sin desordenar el núcleo del rol).
  *   - Filtra a intents válidos del manifiesto.
- *   - Mueve los stubs (precio/deep) al final: existen pero sin backend, no deben
- *     desplazar a las herramientas vivas más arriba.
+ *   - Mueve los stubs al final: hoy solo `deep` cae en ese grupo.
  *   - Dedupe preservando el primer orden visto.
  *
  * @param {Object} args
@@ -254,8 +266,8 @@ export function selectChipIntentsForRole({
     if (STUB_INTENTS.has(intent)) stubs.push(intent);
     else live.push(intent);
   }
-  // Stubs (precio/deep) al final: hoy ningún rol base los incluye, pero si en el
-  // futuro un rol los agrega, quedan después de las herramientas vivas.
+  // Stubs al final: hoy ningún rol base los incluye, pero si en el futuro un
+  // rol los agrega, quedan después de las herramientas vivas.
   return [...live, ...stubs];
 }
 
@@ -278,7 +290,7 @@ export function selectChipIntentsForRole({
  */
 export function selectChipIntents(profile, opts = {}) {
   // BYPASS OPERADOR (primer check): la caja de herramientas completa, sin
-  // estrechar por rol/visibilidad. Solo se omiten los stubs (sin backend),
+  // estrechar por rol/visibilidad. Solo se omiten los stubs (hoy solo deep),
   // igual que para todos. Va antes de deriveRole para que la whitelist Cordada
   // del operador no recorte el set por el rol guia_glaciar.
   if (opts.esOperador) return [...ALL_LIVE_CHIP_INTENTS];


### PR DESCRIPTION
## Summary
- Cableé el chip `precio` para que use una referencia local groundeada con `resolverPrecioReferencia` en vez de un stub.
- `AgentScreen` ahora responde por el camino local de precio y el selector por perfil incluye `precio` como chip general visible.
- Actualicé los tests de router, selector, honestidad y UI para cubrir el nuevo contrato.

## Test plan
- `npx vitest run src/components/__tests__/ChipsToolbar.smoke.test.jsx src/components/__tests__/agentUserFlow.smoke.test.jsx`
- `npx vitest run src/services/__tests__/marketplaceService.test.js src/services/__tests__/chipIntentRouter.test.js src/services/__tests__/agentCapabilities.audit.test.js src/services/__tests__/mcpHonestidad.test.js src/services/__tests__/capabilityHealth.test.js src/services/__tests__/profileChipSelector.test.js`
- `npx eslint src/services/marketplaceService.js --max-warnings=0`
- `npx eslint src/components/__tests__/ChipsToolbar.smoke.test.jsx src/components/__tests__/agentUserFlow.smoke.test.jsx --max-warnings=0`
- `npm run build`
