### PR TITLE
fix(stats): consumir la fuente de verdad en WelcomeStatsHero

### DIFF
--- a/src/components/WelcomeStatsHero.chagraStats.test.jsx
+++ b/src/components/WelcomeStatsHero.chagraStats.test.jsx
@@ -1,0 +1,107 @@
+/**
+ * WelcomeStatsHero.chagraStats.test.jsx — cobertura del fin del drift de cifras.
+ *
+ * El audit encontró que este componente usaba fallbacks hardcodeados
+ * (especies 486, biopreparados 19, fuentes Tier A 52) que contradecían la
+ * fuente de verdad y el one-pager (530/36/53). Este archivo verifica que:
+ *
+ *   1. Cuando `fetch('/chagra-stats.json')` responde con éxito, el componente
+ *      renderiza los números del JSON (no los hardcodeados).
+ *   2. Cuando el fetch falla (archivo aún no desplegado, ver #1938) o
+ *      responde con un status no-ok, el componente cae en un fallback
+ *      razonable en lugar de romperse o mostrar valores vacíos.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import WelcomeStatsHero from './WelcomeStatsHero';
+
+const mockAssetStore = { plants: { length: 0 } };
+vi.mock('../store/useAssetStore', () => ({
+  default: (selector) => selector(mockAssetStore),
+}));
+
+// El catálogo SQLite (dynamic import) no está disponible en el entorno de
+// test (jsdom no carga el WASM); se mockea para resolver rápido y sin ruido
+// en consola, dejando que `chagra-stats.json` sea la única fuente que
+// realmente aporta valores en estos tests.
+vi.mock('../db/catalogDB', () => ({
+  getCatalogStats: vi.fn().mockResolvedValue(null),
+}));
+
+function mockFetchByUrl(responses) {
+  return vi.fn((url) => {
+    const match = Object.keys(responses).find((key) => String(url).includes(key));
+    if (!match) return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    const entry = responses[match];
+    if (entry instanceof Error) return Promise.reject(entry);
+    return Promise.resolve(entry);
+  });
+}
+
+describe('WelcomeStatsHero — consume chagra-stats.json (fuente única de verdad)', () => {
+  beforeEach(() => {
+    mockAssetStore.plants.length = 0;
+    try { globalThis.localStorage.clear(); } catch { /* ignore */ }
+  });
+
+  it('renderiza las cifras de chagra-stats.json cuando el fetch responde OK', async () => {
+    vi.stubGlobal('fetch', mockFetchByUrl({
+      '/chagra-stats.json': {
+        ok: true,
+        json: async () => ({
+          catalogo: { especies: 530, biopreparados: 36, fuentes_tier_a: 53 },
+        }),
+      },
+      '/cycle-content/manifest.json': { ok: true, json: async () => ({ slugs: [] }) },
+      '/fincas-publicas.json': { ok: true, json: async () => [] },
+    }));
+
+    render(<WelcomeStatsHero mode="post-login" onNavigate={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('530')).toBeInTheDocument();
+    });
+    // "486" (fallback hardcodeado) NO debe quedar en pantalla una vez que
+    // la fuente de verdad resolvió.
+    expect(screen.queryByText('486')).not.toBeInTheDocument();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('mantiene un fallback razonable si el fetch de chagra-stats.json falla (archivo aún no desplegado)', async () => {
+    vi.stubGlobal('fetch', mockFetchByUrl({
+      '/chagra-stats.json': new Error('404: chagra-stats.json no existe todavía'),
+      '/cycle-content/manifest.json': new Error('sin manifest en este test'),
+      '/fincas-publicas.json': new Error('sin fincas en este test'),
+    }));
+
+    render(<WelcomeStatsHero mode="post-login" onNavigate={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Chagra · impacto/i)).toBeInTheDocument();
+    });
+    // Fallback conocido del componente (CATALOG_FALLBACK.species) sigue
+    // presente: el fetch fallido no rompe el render ni deja huecos vacíos.
+    await waitFor(() => {
+      expect(screen.getByText('486')).toBeInTheDocument();
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it('mantiene el fallback si chagra-stats.json responde con status no-ok', async () => {
+    vi.stubGlobal('fetch', mockFetchByUrl({
+      '/chagra-stats.json': { ok: false, status: 404, json: async () => ({}) },
+      '/cycle-content/manifest.json': { ok: false, status: 404, json: async () => ({}) },
+      '/fincas-publicas.json': { ok: false, status: 404, json: async () => ({}) },
+    }));
+
+    render(<WelcomeStatsHero mode="post-login" onNavigate={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('486')).toBeInTheDocument();
+    });
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/components/WelcomeStatsHero.jsx
+++ b/src/components/WelcomeStatsHero.jsx
@@ -31,6 +31,15 @@ import { MSG } from '../config/messages.js';
  * - Compacta: hero card rotativa + dots + minor 2x2.
  * - Expandida (modal): full-screen demo-listo, todas las stats visibles
  *   en grid + descripción larga + breakdown federado. Toggle con botón.
+ *
+ * Fuente de verdad de especies/biopreparados/fuentes Tier A (2026-07-01,
+ * cierre de drift de cifras entre superficies): se prioriza
+ * `fetch('/chagra-stats.json')` — el JSON único generado en build por
+ * `scripts/gen-chagra-stats.mjs` (ver #1938) que evita que este componente
+ * contradiga el one-pager u otras superficies con números fabricados. Si
+ * ese archivo todavía no existe en el deploy o el fetch falla, se conserva
+ * el conteo SQLite en vivo (`getCatalogStats`) y, en último caso,
+ * `CATALOG_FALLBACK`.
  */
 
 // Feedback UX usuaria piloto 2026-05-19: 6s era muy poco para leer el card.
@@ -42,8 +51,11 @@ const HERO_PAUSE_AFTER_INTERACTION_MS = 5000;
 const MONITOR_DAYS_PER_PLANT = 90;
 const DRIP_SAVING_L_PER_DAY = 5;
 
-// Fallback inicial: el catálogo seed tiene exactamente estos números.
-// Renderizar valores reales desde el primer paint evita el destello "0".
+// Último recurso: solo se usa si `chagra-stats.json` todavía no existe en
+// este deploy o el fetch falla, y además falla el conteo SQLite en vivo.
+// Renderizar valores razonables desde el primer paint evita el destello "0";
+// NO representan la fuente de verdad actual del catálogo (esa vive en
+// `public/chagra-stats.json`, ver #1938).
 const CATALOG_FALLBACK = {
   species: 486,
   biopreparados: 19,
@@ -53,6 +65,11 @@ const CATALOG_FALLBACK = {
   endemicasCount: 9,
   invasorasCount: 17,
 };
+
+// Fuente única de verdad del catálogo/grafo (generada en build por
+// scripts/gen-chagra-stats.mjs, ver #1938). Se consume vía fetch directo
+// porque el hook de conveniencia `useChagraStats` todavía no está en main.
+const CHAGRA_STATS_URL = '/chagra-stats.json';
 
 // Federación pre-login: cuando no hay store hidratado, usar números globales
 // agregados. Hoy hay 1 finca activa (Guatoc) pero proyectamos crecimiento
@@ -331,6 +348,25 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate }) {
             }
           }
         } catch { /* keep fallback */ }
+
+        // Fuente única de verdad (#1938): pisa species/biopreparados/sourcesTierA
+        // con el JSON generado en build cuando está disponible, para que este
+        // componente nunca contradiga el one-pager ni otra superficie que lea
+        // el mismo archivo. Si el fetch falla o el archivo todavía no existe
+        // en este deploy, quedan los valores ya resueltos arriba (conteo
+        // SQLite en vivo o CATALOG_FALLBACK).
+        try {
+          const chagraStatsRes = await fetch(CHAGRA_STATS_URL, { cache: 'no-cache' });
+          if (chagraStatsRes.ok) {
+            const chagraStats = await chagraStatsRes.json();
+            const catalogo = chagraStats?.catalogo;
+            if (catalogo && typeof catalogo === 'object') {
+              if (typeof catalogo.especies === 'number') species = catalogo.especies;
+              if (typeof catalogo.biopreparados === 'number') biopreparados = catalogo.biopreparados;
+              if (typeof catalogo.fuentes_tier_a === 'number') sourcesTierA = catalogo.fuentes_tier_a;
+            }
+          }
+        } catch { /* JSON aún no existe en este deploy o falló el fetch: se conservan los valores anteriores */ }
 
         if (alive) setCatalogStats({ species, biopreparados, ragDocs, sourcesTierA, endangeredCount, endemicasCount, invasorasCount });
 


### PR DESCRIPTION
## Summary
- El audit de superficies encontró que `WelcomeStatsHero.jsx` usaba fallbacks hardcodeados (especies 486, biopreparados 19, fuentes Tier A 52) que contradecían la fuente de verdad y el one-pager (530/36/53) — cifras que no cuadran entre superficies frente a due-diligence institucional.
- El componente ahora prioriza `fetch('/chagra-stats.json')` (fuente única de verdad de #1938, generada en build por `scripts/gen-chagra-stats.mjs`) para `species`/`biopreparados`/`sourcesTierA`.
- No se usa el hook `useChagraStats` porque todavía no está en `main` (vive en la rama abierta de #1938); se hace fetch directo con el mismo patrón try/catch ya usado en el componente para `ragDocs` y `fincas-publicas.json`.
- Se conserva un fallback en cascada — conteo SQLite en vivo (`getCatalogStats`) y, en último caso, `CATALOG_FALLBACK` — que solo entra en juego si el fetch falla o si `public/chagra-stats.json` todavía no existe en el deploy (se despliega junto con #1938). Ningún valor hardcodeado cambió; solo se agregó la prioridad de la fuente de verdad por encima de ellos.
- Búsqueda de otras superficies con los mismos literales (486/488/19): la única otra coincidencia es el fallback interno de `src/db/catalogDB.js` (usado solo si el motor SQLite en el navegador falla en abrir), que queda fuera de alcance de este PR — no es una superficie visible para el usuario/due-diligence como el hero.

## Test plan
- [x] Nuevo `src/components/WelcomeStatsHero.chagraStats.test.jsx` (fetch mockeado): renderiza las cifras de `chagra-stats.json` cuando el fetch responde OK, y cae al fallback conocido cuando el fetch falla o responde no-ok.
- [x] `npx vitest run src/components/WelcomeStatsHero.test.jsx src/components/WelcomeStatsHero.openAgent.test.jsx src/components/WelcomeStatsHero.chagraStats.test.jsx` — 13/13 verde.
- [x] `npx eslint src/components/WelcomeStatsHero.jsx src/components/WelcomeStatsHero.chagraStats.test.jsx` — limpio.
- [x] `node scripts/scan-voseo-comments.mjs` sobre los archivos tocados — limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)