### PR TITLE
fix(scripts): centralize db podman command

### DIFF
--- a/scripts/__tests__/audit-milpa-citations.test.mjs
+++ b/scripts/__tests__/audit-milpa-citations.test.mjs
@@ -308,22 +308,22 @@ describe('formatReportText', () => {
 
 describe('buildPsqlInvocation', () => {
   it('usa sudo podman exec por defecto cuando no hay override', () => {
-    const prev = process.env.CHAGRA_AGE_PSQL_COMMAND;
-    delete process.env.CHAGRA_AGE_PSQL_COMMAND;
-    const inv = buildPsqlInvocation();
-    if (prev !== undefined) process.env.CHAGRA_AGE_PSQL_COMMAND = prev;
+    const inv = buildPsqlInvocation({
+      CHAGRA_DB_CONTAINER: 'db-container',
+      CHAGRA_DB_USER: 'db-user',
+      CHAGRA_DB_NAME: 'db-name',
+    });
     expect(inv.kind).toBe('podman');
     expect(inv.file).toBe('sudo');
-    expect(inv.args).toContain('postgres-farm');
-    expect(inv.args).toContain('chagra_kg');
+    expect(inv.args).toContain('db-container');
+    expect(inv.args).toContain('db-user');
+    expect(inv.args).toContain('db-name');
   });
 
   it('respeta CHAGRA_AGE_PSQL_COMMAND cuando esta definido', () => {
-    const prev = process.env.CHAGRA_AGE_PSQL_COMMAND;
-    process.env.CHAGRA_AGE_PSQL_COMMAND = 'psql -h 127.0.0.1 -U farmos -d chagra_kg';
-    const inv = buildPsqlInvocation();
-    if (prev !== undefined) process.env.CHAGRA_AGE_PSQL_COMMAND = prev;
-    else delete process.env.CHAGRA_AGE_PSQL_COMMAND;
+    const inv = buildPsqlInvocation({
+      CHAGRA_AGE_PSQL_COMMAND: 'psql -h 127.0.0.1 -U farmos -d chagra_kg',
+    });
     expect(inv.kind).toBe('shell');
     expect(inv.command).toContain('psql -h 127.0.0.1');
   });

--- a/scripts/__tests__/db-cmd.test.mjs
+++ b/scripts/__tests__/db-cmd.test.mjs
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+
+import { getDbCmd } from '../lib/db-cmd.mjs';
+
+describe('getDbCmd', () => {
+  it('arma el comando podman exec desde variables de entorno', () => {
+    const env = {
+      CHAGRA_DB_CONTAINER: 'db-container',
+      CHAGRA_DB_USER: 'db-user',
+      CHAGRA_DB_NAME: 'db-name',
+    };
+    const cmd = getDbCmd(env);
+
+    expect(cmd).toEqual({
+      file: 'sudo',
+      args: ['podman', 'exec', '-i', 'db-container', 'psql', '-U', 'db-user', '-d', 'db-name'],
+    });
+  });
+
+  it('falla con un error claro si falta alguna variable requerida', () => {
+    expect(() => getDbCmd({ CHAGRA_DB_CONTAINER: 'db-container' })).toThrow(
+      /Configura el perfil privado de ops de Chagra/,
+    );
+  });
+});

--- a/scripts/__tests__/load-age-etno-folk-fitopatologia.test.mjs
+++ b/scripts/__tests__/load-age-etno-folk-fitopatologia.test.mjs
@@ -22,21 +22,21 @@ describe('load-age-etno-folk-fitopatologia', () => {
   });
 
   it('usa podman exec por defecto cuando no hay override', () => {
-    const prev = process.env.CHAGRA_AGE_PSQL_COMMAND;
-    delete process.env.CHAGRA_AGE_PSQL_COMMAND;
-    const inv = buildPsqlInvocation();
-    if (prev !== undefined) process.env.CHAGRA_AGE_PSQL_COMMAND = prev;
+    const inv = buildPsqlInvocation({
+      CHAGRA_DB_CONTAINER: 'db-container',
+      CHAGRA_DB_USER: 'db-user',
+      CHAGRA_DB_NAME: 'db-name',
+    });
     expect(inv.kind).toBe('podman');
-    expect(inv.args).toContain('postgres-farm');
-    expect(inv.args).toContain('psql');
+    expect(inv.args).toContain('db-container');
+    expect(inv.args).toContain('db-user');
+    expect(inv.args).toContain('db-name');
   });
 
   it('respeta override shell explícito', () => {
-    const prev = process.env.CHAGRA_AGE_PSQL_COMMAND;
-    process.env.CHAGRA_AGE_PSQL_COMMAND = 'psql -h 127.0.0.1 -p 5432 -U farmos -d chagra_kg';
-    const inv = buildPsqlInvocation();
-    if (prev !== undefined) process.env.CHAGRA_AGE_PSQL_COMMAND = prev;
-    else delete process.env.CHAGRA_AGE_PSQL_COMMAND;
+    const inv = buildPsqlInvocation({
+      CHAGRA_AGE_PSQL_COMMAND: 'psql -h 127.0.0.1 -p 5432 -U farmos -d chagra_kg',
+    });
     expect(inv.kind).toBe('shell');
     expect(inv.command).toContain('psql -h 127.0.0.1');
   });
@@ -58,41 +58,70 @@ describe('buildRunReport', () => {
     missingLabels: [],
     missingPests: [],
   };
+  const mockEnv = {
+    CHAGRA_DB_CONTAINER: 'db-container',
+    CHAGRA_DB_USER: 'db-user',
+    CHAGRA_DB_NAME: 'db-name',
+  };
 
   it('reporta modo preflight-only', () => {
-    const report = buildRunReport(mockSummary, { preflightOnly: true, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false });
+    const report = buildRunReport(
+      mockSummary,
+      { preflightOnly: true, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false },
+      mockEnv,
+    );
     expect(report.mode).toBe('preflight-only');
     expect(report.preflight.ready).toBe(true);
     expect(report.verify).toBe('on');
   });
 
   it('reporta modo dry-run', () => {
-    const report = buildRunReport(mockSummary, { preflightOnly: false, dryRun: true, verify: true, sql: '/tmp/x.sql', force: false });
+    const report = buildRunReport(
+      mockSummary,
+      { preflightOnly: false, dryRun: true, verify: true, sql: '/tmp/x.sql', force: false },
+      mockEnv,
+    );
     expect(report.mode).toBe('dry-run');
     expect(report.verify).toBe('on');
   });
 
   it('reporta modo real-run', () => {
-    const report = buildRunReport(mockSummary, { preflightOnly: false, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false });
+    const report = buildRunReport(
+      mockSummary,
+      { preflightOnly: false, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false },
+      mockEnv,
+    );
     expect(report.mode).toBe('real-run');
     expect(report.preflight.mappingCount).toBe(10);
   });
 
   it('reporta missing labels cuando hay', () => {
     const badSummary = { ...mockSummary, ready: false, missingLabels: ['gota'] };
-    const report = buildRunReport(badSummary, { preflightOnly: true, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false });
+    const report = buildRunReport(
+      badSummary,
+      { preflightOnly: true, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false },
+      mockEnv,
+    );
     expect(report.preflight.ready).toBe(false);
     expect(report.preflight.missingLabels).toEqual(['gota']);
   });
 
   it('incluye psql command en el reporte', () => {
-    const report = buildRunReport(mockSummary, { preflightOnly: true, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false });
+    const report = buildRunReport(
+      mockSummary,
+      { preflightOnly: true, dryRun: false, verify: true, sql: '/tmp/x.sql', force: false },
+      mockEnv,
+    );
     expect(report.psqlCommand).toBeTruthy();
     expect(typeof report.psqlCommand).toBe('string');
   });
 
   it('verificationSql es null cuando verify=off', () => {
-    const report = buildRunReport(mockSummary, { preflightOnly: true, dryRun: false, verify: false, sql: '/tmp/x.sql', force: false });
+    const report = buildRunReport(
+      mockSummary,
+      { preflightOnly: true, dryRun: false, verify: false, sql: '/tmp/x.sql', force: false },
+      mockEnv,
+    );
     expect(report.verificationSql).toBeNull();
     expect(report.verify).toBe('off');
   });

--- a/scripts/audit-milpa-citations.mjs
+++ b/scripts/audit-milpa-citations.mjs
@@ -41,11 +41,11 @@
  * Modos de ejecución
  * -------------------
  *   1. LIVE (default): consulta `chagra_kg` vía psql. Por defecto usa
- *      `sudo podman exec -i postgres-farm psql -U farmos -d chagra_kg`;
+ *      `sudo podman exec -i <container> psql -U <user> -d <db>`;
  *      si `CHAGRA_AGE_PSQL_COMMAND` está definido en el entorno, lo usa tal
  *      cual (mismo patrón que scripts/validate-graph-parity.mjs y
- *      scripts/load-age-etno-folk-fitopatologia.mjs). Sin credenciales
- *      hardcodeadas — todo entra por process.env.
+ *      scripts/load-age-etno-folk-fitopatologia.mjs). Los valores salen de
+ *      CHAGRA_DB_CONTAINER, CHAGRA_DB_USER y CHAGRA_DB_NAME.
  *   2. OFFLINE (--from-dump FILE): NO toca la DB. Parsea un dump JSON
  *      `{nodes, edges}` (mismo shape que scripts/check-age-integrity.mjs) o
  *      un catálogo `{species: [...]}` (companions[] se leen como aristas
@@ -67,6 +67,7 @@
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { getDbCmd } from './lib/db-cmd.mjs';
 
 // =============================================================================
 // Constantes de dominio
@@ -369,42 +370,39 @@ export function formatReportText(report) {
 }
 
 // =============================================================================
-// Conexion a AGE — mismo patron que scripts/validate-graph-parity.mjs y
+// Conexion a AGE - mismo patron que scripts/validate-graph-parity.mjs y
 // scripts/load-age-etno-folk-fitopatologia.mjs: CHAGRA_AGE_PSQL_COMMAND
-// override, o `sudo podman exec -i postgres-farm psql ...` por defecto.
-// Sin credenciales hardcodeadas — todo entra por process.env.
+// override, o `sudo podman exec -i <container> psql ...` por defecto.
+// Los valores de container/user/db salen de CHAGRA_DB_*.
 // =============================================================================
 
-export function buildPsqlInvocation() {
-  const override = process.env.CHAGRA_AGE_PSQL_COMMAND;
+export function buildPsqlInvocation(env = process.env) {
+  const override = env.CHAGRA_AGE_PSQL_COMMAND;
   if (override) {
     return { kind: 'shell', command: override };
   }
+  const dbCmd = getDbCmd(env);
   return {
     kind: 'podman',
-    file: 'sudo',
-    args: [
-      'podman', 'exec', '-i', 'postgres-farm',
-      'psql', '-U', 'farmos', '-d', 'chagra_kg',
-      '-At', '-F', '\t',
-    ],
+    file: dbCmd.file,
+    args: [...dbCmd.args, '-At', '-F', '\t'],
   };
 }
 
-export function runPsql(sql) {
-  const inv = buildPsqlInvocation();
+export function runPsql(sql, env = process.env) {
+  const inv = buildPsqlInvocation(env);
   if (inv.kind === 'shell') {
     return spawnSync(inv.command, {
       input: sql,
       encoding: 'utf8',
       shell: true,
-      env: process.env,
+      env,
     });
   }
   return spawnSync(inv.file, inv.args, {
     input: sql,
     encoding: 'utf8',
-    env: process.env,
+    env,
   });
 }
 
@@ -445,7 +443,7 @@ export function main(argv = process.argv.slice(2)) {
       + '                    catalogo {species}. Seguro para CI.\n'
       + '  --print-sql       Imprime el SQL y sale (no ejecuta nada).\n\n'
       + 'Sin --from-dump, consulta chagra_kg vivo via psql. Override con\n'
-      + 'CHAGRA_AGE_PSQL_COMMAND; por defecto usa sudo podman exec postgres-farm.',
+      + 'CHAGRA_AGE_PSQL_COMMAND; el podman exec sale de CHAGRA_DB_*.',
     );
     return 0;
   }
@@ -483,5 +481,10 @@ export function main(argv = process.argv.slice(2)) {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  process.exitCode = main();
+  try {
+    process.exitCode = main();
+  } catch (e) {
+    console.error('[audit-milpa] ' + e.message);
+    process.exitCode = 2;
+  }
 }

--- a/scripts/bench-grafo-cobertura.mjs
+++ b/scripts/bench-grafo-cobertura.mjs
@@ -11,9 +11,9 @@
  * bench recurrente para que la cobertura sea TENDENCIA visible (memoria
  * project-test-bench-automejorable). NO escribe en el grafo. NO inventa. Solo cuenta.
  *
- * Acceso AGE: `sudo podman exec -i postgres-farm psql` (sin dependencia pg, sin rutas
- * personales en codigo). Salta limpio si postgres-farm no esta (p. ej. en CI): la infra
- * "age" no estara disponible y bench/run.mjs lo salta.
+ * Acceso AGE: `sudo podman exec -i <container> psql` via CHAGRA_DB_* (sin dependencia
+ * pg, sin rutas personales en codigo). Salta limpio si la infra "age" no esta
+ * disponible (p. ej. en CI) y bench/run.mjs lo salta.
  *
  * @module scripts/bench-grafo-cobertura
  */
@@ -21,6 +21,7 @@ import { spawnSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getDbCmd } from './lib/db-cmd.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
@@ -30,9 +31,10 @@ const HISTORY_DIR = join(REPO_ROOT, 'bench', 'history');
 function ageQuery(cypher, ncols) {
   const cols = Array.from({ length: ncols }, (_, i) => `c${i} agtype`).join(', ');
   const sql = `LOAD 'age'; SET search_path=ag_catalog,public; SELECT * FROM cypher('chagra_kg', $$ ${cypher} $$) as (${cols});`;
+  const dbCmd = getDbCmd();
   const r = spawnSync(
-    'sudo',
-    ['podman', 'exec', '-i', 'postgres-farm', 'psql', '-U', 'farmos', '-d', 'chagra_kg', '-tAF', '\t', '-c', sql],
+    dbCmd.file,
+    [...dbCmd.args, '-tAF', '\t', '-c', sql],
     { encoding: 'utf8', maxBuffer: 96 * 1024 * 1024 },
   );
   if (r.status !== 0) throw new Error('AGE no accesible: ' + String(r.stderr || r.error || '').slice(0, 200));

--- a/scripts/bench-prueba-tomate.mjs
+++ b/scripts/bench-prueba-tomate.mjs
@@ -18,6 +18,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getDbCmd } from './lib/db-cmd.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
@@ -32,9 +33,10 @@ const BASICOS = [
 function ageQuery(cypher, ncols) {
   const cols = Array.from({ length: ncols }, (_, i) => `c${i} agtype`).join(', ');
   const sql = `LOAD 'age'; SET search_path=ag_catalog,public; SELECT * FROM cypher('chagra_kg', $$ ${cypher} $$) as (${cols});`;
+  const dbCmd = getDbCmd();
   const r = spawnSync(
-    'sudo',
-    ['podman', 'exec', '-i', 'postgres-farm', 'psql', '-U', 'farmos', '-d', 'chagra_kg', '-tAF', '\t', '-c', sql],
+    dbCmd.file,
+    [...dbCmd.args, '-tAF', '\t', '-c', sql],
     { encoding: 'utf8', maxBuffer: 96 * 1024 * 1024 },
   );
   if (r.status !== 0) throw new Error('AGE no accesible: ' + String(r.stderr || r.error || '').slice(0, 200));

--- a/scripts/lib/db-cmd.mjs
+++ b/scripts/lib/db-cmd.mjs
@@ -1,0 +1,39 @@
+/**
+ * scripts/lib/db-cmd.mjs
+ *
+ * Helper para construir el comando de psql dentro de podman sin hardcodear
+ * valores de infra en el repo publico.
+ */
+
+const REQUIRED_VARS = ['CHAGRA_DB_CONTAINER', 'CHAGRA_DB_USER', 'CHAGRA_DB_NAME'];
+
+function formatMissingEnv(missing) {
+  return (
+    `Faltan variables de entorno requeridas: ${missing.join(', ')}. ` +
+    'Configura el perfil privado de ops de Chagra para exportar ' +
+    'CHAGRA_DB_CONTAINER, CHAGRA_DB_USER y CHAGRA_DB_NAME antes de ejecutar ' +
+    'este script.'
+  );
+}
+
+/**
+ * Devuelve la invocacion base de psql dentro de podman.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env]
+ * @returns {{file:string,args:string[]}}
+ */
+export function getDbCmd(env = process.env) {
+  const container = env.CHAGRA_DB_CONTAINER;
+  const user = env.CHAGRA_DB_USER;
+  const db = env.CHAGRA_DB_NAME;
+  const missing = REQUIRED_VARS.filter((key) => !env[key]);
+
+  if (missing.length > 0) {
+    throw new Error(formatMissingEnv(missing));
+  }
+
+  return {
+    file: 'sudo',
+    args: ['podman', 'exec', '-i', container, 'psql', '-U', user, '-d', db],
+  };
+}

--- a/scripts/load-age-etno-folk-fitopatologia.mjs
+++ b/scripts/load-age-etno-folk-fitopatologia.mjs
@@ -9,10 +9,10 @@
  *
  * Por defecto usa el patrón del resto del repo:
  *   - si `CHAGRA_AGE_PSQL_COMMAND` está definido, lo usa tal cual
- *   - si no, usa `sudo podman exec -i postgres-farm psql ...`
+ *   - si no, arma `sudo podman exec -i <container> psql ...` desde CHAGRA_DB_*
  *
  * Requiere:
- *   - acceso al host donde corre `postgres-farm`
+ *   - acceso al host donde corre el contenedor de base de datos
  *   - AGE disponible en `chagra_kg`
  *   - PGPASSWORD en el entorno si el comando lo necesita
  */
@@ -21,6 +21,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { buildPreflightSummary } from './age-etno-preflight.mjs';
+import { getDbCmd } from './lib/db-cmd.mjs';
 
 const DEFAULT_SQL_PATH = process.env.CHAGRA_AGE_ETNO_SQL || '';
 
@@ -46,32 +47,33 @@ export function parseArgs(argv) {
   return opts;
 }
 
-export function buildPsqlInvocation() {
-  const override = process.env.CHAGRA_AGE_PSQL_COMMAND;
+export function buildPsqlInvocation(env = process.env) {
+  const override = env.CHAGRA_AGE_PSQL_COMMAND;
   if (override) {
     return { kind: 'shell', command: override };
   }
+  const dbCmd = getDbCmd(env);
   return {
     kind: 'podman',
-    file: 'sudo',
-    args: ['podman', 'exec', '-i', 'postgres-farm', 'psql', '-U', 'farmos', '-d', 'chagra_kg', '-v', 'ON_ERROR_STOP=1', '-f', '-'],
+    file: dbCmd.file,
+    args: [...dbCmd.args, '-v', 'ON_ERROR_STOP=1', '-f', '-'],
   };
 }
 
-export function runSql(sql) {
-  const inv = buildPsqlInvocation();
+export function runSql(sql, env = process.env) {
+  const inv = buildPsqlInvocation(env);
   if (inv.kind === 'shell') {
     return spawnSync(inv.command, {
       input: sql,
       encoding: 'utf8',
       shell: true,
-      env: process.env,
+      env,
     });
   }
   return spawnSync(inv.file, inv.args, {
     input: sql,
     encoding: 'utf8',
-    env: process.env,
+    env,
   });
 }
 
@@ -85,8 +87,8 @@ export function buildVerificationSql(graph = 'chagra_kg') {
   ].join('\n');
 }
 
-export function buildRunReport(summary, opts) {
-  const inv = buildPsqlInvocation();
+export function buildRunReport(summary, opts, env = process.env) {
+  const inv = buildPsqlInvocation(env);
   const psqlCmd = inv.kind === 'shell' ? inv.command : `${inv.file} ${inv.args.join(' ')}`;
   const mode = opts.preflightOnly ? 'preflight-only'
     : opts.dryRun ? 'dry-run'
@@ -110,8 +112,8 @@ export function buildRunReport(summary, opts) {
   };
 }
 
-export function printRunReport(summary, opts) {
-  const report = buildRunReport(summary, opts);
+export function printRunReport(summary, opts, env = process.env) {
+  const report = buildRunReport(summary, opts, env);
   const lines = [
     `[age-etno] mode=${report.mode}`,
     `[age-etno] sql=${report.sqlPath}`,
@@ -153,9 +155,9 @@ export function main(argv = process.argv.slice(2)) {
 
   const summary = buildPreflightSummary();
   if (opts.json) {
-    console.log(JSON.stringify(buildRunReport(summary, opts), null, 2));
+    console.log(JSON.stringify(buildRunReport(summary, opts, process.env), null, 2));
   } else {
-    printRunReport(summary, opts);
+    printRunReport(summary, opts, process.env);
   }
 
   if (!summary.ready && !opts.force) {
@@ -176,7 +178,7 @@ export function main(argv = process.argv.slice(2)) {
   }
 
   // Pipeamos el CONTENIDO del SQL (no `\i <ruta>`): psql corre DENTRO del
-  // contenedor postgres-farm y una ruta del host no existiría en su filesystem.
+  // contenedor y una ruta del host no existiría en su filesystem.
   const sql = readFileSync(resolve(process.cwd(), opts.sql), 'utf8');
   const result = runSql(sql);
   if (result.error) {
@@ -201,5 +203,10 @@ export function main(argv = process.argv.slice(2)) {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  process.exitCode = main();
+  try {
+    process.exitCode = main();
+  } catch (e) {
+    console.error('[age-etno] ' + e.message);
+    process.exitCode = 2;
+  }
 }

--- a/scripts/validate-graph-parity.mjs
+++ b/scripts/validate-graph-parity.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import { getDbCmd } from './lib/db-cmd.mjs';
 
 const DEFAULT_GRAPH = 'chagra_kg';
 
@@ -75,33 +76,21 @@ export function formatGraphParityReport(rows) {
   return lines.join('\n');
 }
 
-export function runPsql(sql) {
-  const command = process.env.CHAGRA_AGE_PSQL_COMMAND;
+export function runPsql(sql, env = process.env) {
+  const command = env.CHAGRA_AGE_PSQL_COMMAND;
   if (command) {
     return spawnSync(command, {
       input: sql,
       encoding: 'utf8',
       shell: true,
-      env: process.env,
+      env,
     });
   }
-  return spawnSync('sudo', [
-    'podman',
-    'exec',
-    '-i',
-    'postgres-farm',
-    'psql',
-    '-U',
-    'farmos',
-    '-d',
-    'chagra_kg',
-    '-At',
-    '-F',
-    '\t',
-  ], {
+  const dbCmd = getDbCmd(env);
+  return spawnSync(dbCmd.file, [...dbCmd.args, '-At', '-F', '\t'], {
     input: sql,
     encoding: 'utf8',
-    env: process.env,
+    env,
   });
 }
 
@@ -142,5 +131,10 @@ export function main(argv = process.argv.slice(2)) {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  process.exitCode = main();
+  try {
+    process.exitCode = main();
+  } catch (e) {
+    console.error('[graph-parity] ' + e.message);
+    process.exitCode = 2;
+  }
 }


### PR DESCRIPTION
## Summary
- Added `scripts/lib/db-cmd.mjs` with `getDbCmd()` so podman exec DB commands come from `CHAGRA_DB_CONTAINER`, `CHAGRA_DB_USER`, and `CHAGRA_DB_NAME`.
- Replaced the hardcoded podman DB invocations in the AGE scripts that build queries with the shared helper.
- Added unit coverage for the helper and updated the affected script tests to use explicit env fixtures.

## Test plan
- `npx vitest run scripts/__tests__/db-cmd.test.mjs scripts/__tests__/load-age-etno-folk-fitopatologia.test.mjs scripts/__tests__/audit-milpa-citations.test.mjs`
- `npx eslint scripts/lib/db-cmd.mjs scripts/audit-milpa-citations.mjs scripts/load-age-etno-folk-fitopatologia.mjs scripts/bench-grafo-cobertura.mjs scripts/bench-prueba-tomate.mjs scripts/validate-graph-parity.mjs scripts/__tests__/db-cmd.test.mjs scripts/__tests__/load-age-etno-folk-fitopatologia.test.mjs scripts/__tests__/audit-milpa-citations.test.mjs --max-warnings=0`
- `npm run build`

## Notes
- `npx vitest run` across the full repo surfaced pre-existing failures outside this change set, so I validated the touched scripts directly.
