### PR TITLE
fix(bench): alinear juez, target y flattenDoc

### DIFF
--- a/scripts/__tests__/bench-llm-judge.test.mjs
+++ b/scripts/__tests__/bench-llm-judge.test.mjs
@@ -1,375 +1,146 @@
 /**
- * scripts/__tests__/bench-llm-judge.test.mjs
+ * bench-llm-judge.test.mjs
  *
- * Cobertura unitaria de bench-llm-judge.mjs (smoke test v2).
- * Verifica:
- * - Carga de datos de bench (mock cuando no existen archivos)
- * - Parsing de respuestas del juez (JSON)
- * - Cálculo de promedios
- * - Escritura de archivos de output
+ * Cobertura del judge de bench:
+ * - parsing de `--from` y `--target`
+ * - inferencia de target desde JSONL per-model
+ * - skip de `seed:true` como no-medición
+ * - falla ruidosa cuando el JSONL es ambiguo sin `--target`
+ * - resolución del juez Anthropic con Claude Sonnet 5
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT_DIR = join(__dirname, '..', '..');
 const SCRIPT_PATH = join(__dirname, '..', 'bench-llm-judge.mjs');
 
-// Mock data para tests
-const MOCK_BENCH_DATA = {
-  timestamp: '2026-05-26T10:00:00.000Z',
-  model: 'test-model',
-  results: [
-    {
-      id: 1,
-      category: 1,
-      query: '¿Test?',
-      ground_truth: 'Respuesta correcta.',
-      model_response: 'Respuesta similar.',
-    },
-    {
-      id: 2,
-      category: 2,
-      query: '¿Test 2?',
-      ground_truth: 'Datos correctos.',
-      response: 'Datos similares.',
-    },
-  ],
-};
+function makeTempFile(name, content) {
+  const dir = mkdtempSync(join(tmpdir(), 'bench-llm-judge-test-'));
+  const file = join(dir, name);
+  writeFileSync(file, content, 'utf-8');
+  return { dir, file };
+}
 
-// Mock fetch para Ollama
-const mockFetch = vi.fn();
-
-describe('bench-llm-judge.mjs — smoke test LLM-judge', () => {
-  const tempDir = join(ROOT_DIR, 'data', 'bench-judge-scores-test');
-
+describe('bench-llm-judge.mjs', () => {
   beforeEach(() => {
-    // Setup temp directory
-    if (!existsSync(tempDir)) {
-      mkdirSync(tempDir, { recursive: true });
-    }
-
-    // Mock fetch global
-    globalThis.fetch = mockFetch;
-
-    // Mock console.log para reducir ruido
     vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    // Cleanup temp files
-    try {
-      const files = require('node:fs').readdirSync(tempDir);
-      for (const file of files) {
-        unlinkSync(join(tempDir, file));
-      }
-    } catch (err) {
-      // Ignore cleanup errors
-    }
-
-    // Restore mocks
-    mockFetch.mockReset();
     vi.restoreAllMocks();
   });
 
-  describe('loadBenchData', () => {
-    it('carga datos desde archivo especificado con --from', async () => {
-      const testFile = join(tempDir, 'test-bench.json');
-      writeFileSync(testFile, JSON.stringify(MOCK_BENCH_DATA));
-
-      // Importamos dinámicamente para poder testear
-      const module = await import(SCRIPT_PATH);
-      // Nota: loadBenchData es función interna, no exportada
-      // Este test verifica que el script puede leer el archivo
-
-      const content = readFileSync(testFile, 'utf-8');
-      const data = JSON.parse(content);
-      expect(data).toEqual(MOCK_BENCH_DATA);
-      expect(data.results).toHaveLength(2);
-    });
-
-    it('usa datos mock cuando no existe archivo de bench', () => {
-      // El script incluye MOCK_BENCH_DATA inline
-      // Este test verifica que la estructura es correcta
-      expect(MOCK_BENCH_DATA).toHaveProperty('timestamp');
-      expect(MOCK_BENCH_DATA).toHaveProperty('results');
-      expect(Array.isArray(MOCK_BENCH_DATA.results)).toBe(true);
-      expect(MOCK_BENCH_DATA.results.length).toBeGreaterThan(0);
-    });
-
-    it('maneja items con model_response o response (compatibilidad)', () => {
-      const itemWithResponse = MOCK_BENCH_DATA.results[1];
-      expect(itemWithResponse).toHaveProperty('response');
-      expect(itemWithResponse).not.toHaveProperty('model_response');
-
-      const itemWithModelResponse = MOCK_BENCH_DATA.results[0];
-      expect(itemWithModelResponse).toHaveProperty('model_response');
-    });
+  it('parseFromArg y parseTargetArg aceptan forma separada y con igual', async () => {
+    const mod = await import(SCRIPT_PATH);
+    expect(mod.parseFromArg(['node', 'bench-llm-judge.mjs', '--from', 'data/a.jsonl'])).toBe('data/a.jsonl');
+    expect(mod.parseFromArg(['node', 'bench-llm-judge.mjs', '--from=data/b.jsonl'])).toBe('data/b.jsonl');
+    expect(mod.parseTargetArg(['node', 'bench-llm-judge.mjs', '--target', 'granite3.1-dense:8b'])).toBe('granite3.1-dense:8b');
+    expect(mod.parseTargetArg(['node', 'bench-llm-judge.mjs', '--target=granite3_1_8b'])).toBe('granite3_1_8b');
   });
 
-  describe('parseJudgeResponse', () => {
-    it('extrae JSON válido de respuesta del juez', () => {
-      const rawResponse = `{
-  "factualidad": 85,
-  "claridad_colombiana": 90,
-  "anti_alucinacion": 95,
-  "completitud": 80,
-  "promedio": 87.5,
-  "justificacion_breve": "Buena respuesta con detalles correctos."
-}`;
-
-      const jsonMatch = rawResponse.match(/\{[\s\S]*\}/);
-      expect(jsonMatch).toBeTruthy();
-
-      const parsed = JSON.parse(jsonMatch[0]);
-      expect(parsed.factualidad).toBe(85);
-      expect(parsed.claridad_colombiana).toBe(90);
-      expect(parsed.anti_alucinacion).toBe(95);
-      expect(parsed.completitud).toBe(80);
-      expect(parsed.promedio).toBe(87.5);
-      expect(parsed.justificacion_breve).toBeTruthy();
-    });
-
-    it('calcula promedio si falta el campo promedio', () => {
-      const scoresWithoutAvg = {
-        factualidad: 80,
-        claridad_colombiana: 90,
-        anti_alucinacion: 70,
-        completitud: 85,
-      };
-
-      const avg = (80 + 90 + 70 + 85) / 4;
-      expect(avg).toBe(81.25);
-    });
-
-    it('rechaza JSON inválido', () => {
-      const invalidJson = '{ esto no es json válido }';
-      const jsonMatch = invalidJson.match(/\{[\s\S]*\}/);
-      expect(jsonMatch).toBeTruthy();
-
-      expect(() => {
-        JSON.parse(jsonMatch[0]);
-      }).toThrow();
-    });
-  });
-
-  describe('evaluación de items', () => {
-    it('construye prompt correctamente para el juez', () => {
-      const item = MOCK_BENCH_DATA.results[0];
-      const prompt = `PREGUNTA: "${item.query}"
-
-VERDAD BASE (ground truth): "${item.ground_truth}"
-
-RESPUESTA DEL MODELO: "${item.model_response}"
-
-Evalúa esta respuesta en las 4 dimensiones.`;
-
-      expect(prompt).toContain(item.query);
-      expect(prompt).toContain(item.ground_truth);
-      expect(prompt).toContain(item.model_response);
-      expect(prompt).toContain('Evalúa esta respuesta');
-    });
-
-    it('maneja items sin respuesta (error)', () => {
-      const itemWithoutResponse = {
-        id: 999,
-        query: '¿Test?',
-        ground_truth: 'Respuesta.',
-      };
-
-      expect(itemWithoutResponse.response).toBeUndefined();
-      expect(itemWithoutResponse.model_response).toBeUndefined();
-    });
-
-    it('genera estructura de evaluación correcta', () => {
-      const mockEvaluation = {
-        item_id: 1,
-        scores: {
-          factualidad: 85,
-          claridad_colombiana: 90,
-          anti_alucinacion: 95,
-          completitud: 80,
-          promedio: 87.5,
-        },
-        justificacion: 'Buena respuesta.',
-        judge_latency_ms: 1234,
-      };
-
-      expect(mockEvaluation).toHaveProperty('item_id');
-      expect(mockEvaluation).toHaveProperty('scores');
-      expect(mockEvaluation.scores).toHaveProperty('factualidad');
-      expect(mockEvaluation.scores).toHaveProperty('claridad_colombiana');
-      expect(mockEvaluation.scores).toHaveProperty('anti_alucinacion');
-      expect(mockEvaluation.scores).toHaveProperty('completitud');
-      expect(mockEvaluation.scores).toHaveProperty('promedio');
-      expect(mockEvaluation).toHaveProperty('justificacion');
-      expect(mockEvaluation).toHaveProperty('judge_latency_ms');
-    });
-  });
-
-  describe('cálculo de agregados', () => {
-    it('calcula promedios correctos', () => {
-      const successful = [
-        { scores: { factualidad: 80, claridad_colombiana: 90, anti_alucinacion: 70, completitud: 85, promedio: 81.25 } },
-        { scores: { factualidad: 90, claridad_colombiana: 85, anti_alucinacion: 95, completitud: 80, promedio: 87.5 } },
-        { scores: { factualidad: 85, claridad_colombiana: 88, anti_alucinacion: 92, completitud: 78, promedio: 85.75 } },
-      ];
-
-      const avgFactualidad = (80 + 90 + 85) / 3;
-      const avgClaridad = (90 + 85 + 88) / 3;
-      const avgAnti = (70 + 95 + 92) / 3;
-      const avgCompletitud = (85 + 80 + 78) / 3;
-      const avgPromedio = (81.25 + 87.5 + 85.75) / 3;
-
-      expect(avgFactualidad).toBeCloseTo(85);
-      expect(avgClaridad).toBeCloseTo(87.67);
-      expect(avgAnti).toBeCloseTo(85.67);
-      expect(avgCompletitud).toBeCloseTo(81);
-      expect(avgPromedio).toBeCloseTo(84.83);
-    });
-
-    it('maneja array vacío sin errores', () => {
-      const successful = [];
-      const avg = successful.reduce((sum, r) => sum + (r.scores?.promedio || 0), 0) / (successful.length || 1);
-      expect(avg).toBe(0);
-    });
-  });
-
-  describe('formato de output', () => {
-    it('genera línea JSONL válida', () => {
-      const evaluation = {
-        item_id: 1,
-        scores: {
-          factualidad: 85,
-          claridad_colombiana: 90,
-          anti_alucinacion: 95,
-          completitud: 80,
-          promedio: 87.5,
-        },
-        justificacion: 'Test',
-        judge_latency_ms: 1000,
-      };
-
-      const jsonlLine = JSON.stringify(evaluation);
-      const parsed = JSON.parse(jsonlLine);
-
-      expect(parsed).toEqual(evaluation);
-      expect(jsonlLine).toContain('"item_id":1');
-      expect(jsonlLine).toContain('"factualidad":85');
-    });
-
-    it('genera summary.md con estructura correcta', () => {
-      const dateStr = '2026-05-26';
-      const avgScores = {
-        factualidad: 85.5,
-        claridad_colombiana: 88.3,
-        anti_alucinacion: 82.7,
-        completitud: 84.0,
-        promedio: 85.1,
-      };
-
-      const summaryContent = `# LLM-Judge Summary — ${dateStr}
-
-## Metadata
-- **Timestamp**: 2026-05-26T10:00:00.000Z
-- **Items evaluados**: 10
-- **Exitosos**: 9
-- **Fallidos**: 1
-
-## Scores Promedio
-
-| Dimensión | Score (0-100) |
-|-----------|---------------|
-| **Factualidad** | ${avgScores.factualidad.toFixed(1)} |
-| **Claridad Colombiana** | ${avgScores.claridad_colombiana.toFixed(1)} |
-| **Anti-Alucinación** | ${avgScores.anti_alucinacion.toFixed(1)} |
-| **Completitud** | ${avgScores.completitud.toFixed(1)} |
-| **PROMEDIO GLOBAL** | **${avgScores.promedio.toFixed(1)}** |
-`;
-
-      expect(summaryContent).toContain('# LLM-Judge Summary');
-      expect(summaryContent).toContain('## Metadata');
-      expect(summaryContent).toContain('## Scores Promedio');
-      expect(summaryContent).toContain('| **Factualidad** |');
-      expect(summaryContent).toContain('| **PROMEDIO GLOBAL** |');
-    });
-  });
-
-  describe('integración mock fetch', () => {
-    it('mockea respuesta exitosa del juez', async () => {
-      const mockResponse = {
-        response: JSON.stringify({
-          factualidad: 85,
-          claridad_colombiana: 90,
-          anti_alucinacion: 95,
-          completitud: 80,
-          promedio: 87.5,
-          justificacion_breve: 'Test',
+  it('loadBenchData infiere el target desde JSONL per-model y omite seed:true', async () => {
+    const mod = await import(SCRIPT_PATH);
+    const { dir, file } = makeTempFile(
+      'single-model.jsonl',
+      [
+        JSON.stringify({
+          prompt_id: 1,
+          query: 'Q1',
+          expected_keywords: ['a'],
+          seed: true,
+          granite3_1_8b: { model: 'granite3.1-dense:8b', response: 'respuesta 1', halluc_count: 0 },
         }),
-      };
+        JSON.stringify({
+          prompt_id: 2,
+          query: 'Q2',
+          expected_keywords: ['b'],
+          granite3_1_8b: { model: 'granite3.1-dense:8b', response: 'respuesta 2', halluc_count: 1 },
+        }),
+      ].join('\n') + '\n',
+    );
 
-      mockFetch.mockResolvedValueOnce({
+    try {
+      const data = mod.loadBenchData(file);
+      expect(data.model).toBe('granite3.1-dense:8b');
+      expect(data.results).toHaveLength(1);
+      expect(data.skipped).toBe(1);
+      expect(data.skippedSeeded).toBe(1);
+      expect(data.results[0].model_response).toBe('respuesta 2');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('loadBenchData falla si el JSONL per-model es ambiguo y no hay target explícito', async () => {
+    const mod = await import(SCRIPT_PATH);
+    const { dir, file } = makeTempFile(
+      'ambiguous.jsonl',
+      [
+        JSON.stringify({
+          prompt_id: 1,
+          query: 'Q1',
+          expected_keywords: ['a'],
+          granite3_1_8b: { model: 'granite3.1-dense:8b', response: 'a' },
+          gemma3_4b: { model: 'gemma3:4b', response: 'b' },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    try {
+      expect(() => mod.loadBenchData(file)).toThrow(/--target|TARGET_MODEL/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('loadBenchData respeta --target explícito aunque el JSONL tenga varios modelos', async () => {
+    const mod = await import(SCRIPT_PATH);
+    const { dir, file } = makeTempFile(
+      'multi-model.jsonl',
+      [
+        JSON.stringify({
+          prompt_id: 1,
+          query: 'Q1',
+          expected_keywords: ['a'],
+          granite3_1_8b: { model: 'granite3.1-dense:8b', response: 'respuesta granite' },
+          gemma3_4b: { model: 'gemma3:4b', response: 'respuesta gemma' },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    try {
+      const data = mod.loadBenchData(file, { targetModel: 'granite3.1-dense:8b' });
+      expect(data.model).toBe('granite3.1-dense:8b');
+      expect(data.results).toHaveLength(1);
+      expect(data.results[0].model_response).toBe('respuesta granite');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolveJudgeCall usa Anthropic con Claude Sonnet 5 y falla sin key', async () => {
+    const mod = await import(SCRIPT_PATH);
+    const judge = mod.resolveJudgeCall({
+      env: { JUDGE_PROVIDER: 'anthropic', ANTHROPIC_API_KEY: 'sk-test-FAKE' },
+      fetchImpl: async () => ({
         ok: true,
-        json: async () => mockResponse,
-      });
-
-      // Simular llamada al juez
-      const prompt = 'Test prompt';
-      const result = await fetch('http://localhost:11434/api/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          model: 'test-model',
-          system: 'Test system',
-          prompt: prompt,
-          stream: false,
-        }),
-      });
-
-      expect(result.ok).toBe(true);
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+        json: async () => ({ content: [{ type: 'text', text: '{"factualidad":1,"claridad_colombiana":2,"anti_alucinacion":3,"completitud":4,"promedio":2.5,"justificacion_breve":"ok"}' }] }),
+      }),
     });
 
-    it('mockea respuesta con error del juez', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
+    expect(judge.provider).toBe('anthropic');
+    expect(judge.model).toBe('claude-sonnet-5');
+    const raw = await judge.judgeCall('PREGUNTA DE PRUEBA');
+    expect(raw).toContain('"factualidad":1');
 
-      const result = await fetch('http://localhost:11434/api/generate');
-      expect(result.ok).toBe(false);
-      expect(result.status).toBe(500);
-    });
-  });
-
-  describe('manejo de errores', () => {
-    it('maneja timeout con AbortController', () => {
-      const controller = new AbortController();
-      expect(controller.signal).toHaveProperty('aborted');
-
-      controller.abort();
-      expect(controller.signal.aborted).toBe(true);
-    });
-
-    it('captura errores de parseo JSON', () => {
-      const invalidRaw = 'Esto no es JSON';
-      const jsonMatch = invalidRaw.match(/\{[\s\S]*\}/);
-
-      expect(jsonMatch).toBeNull();
-    });
-
-    it('maneja items con error en evaluación', () => {
-      const failedEvaluation = {
-        error: 'Timeout: request took too long',
-        item_id: 999,
-      };
-
-      expect(failedEvaluation).toHaveProperty('error');
-      expect(failedEvaluation).toHaveProperty('item_id');
-      expect(failedEvaluation.error).toContain('Timeout');
-    });
+    expect(() => mod.resolveJudgeCall({
+      env: { JUDGE_PROVIDER: 'anthropic' },
+      keyPath: '/no/existe',
+      fetchImpl: async () => ({}),
+    })).toThrow(/key de Anthropic/i);
   });
 });

--- a/scripts/__tests__/bench-scorer.test.mjs
+++ b/scripts/__tests__/bench-scorer.test.mjs
@@ -58,19 +58,19 @@ describe('scoreKeywordsFlexible', () => {
   });
 
   it('ignora tildes y mayúsculas', () => {
-    const resp = 'Aplicá CALDO BORDELÉS como preventivo; mejora la AIREACIÓN.';
+    const resp = 'Aplique CALDO BORDELÉS como preventivo; mejora la AIREACIÓN.';
     const out = scoreKeywordsFlexible(resp, ['caldo bordeles', 'aireacion']);
     expect(out.matched).toBe(2);
   });
 
   it('match por LEMA: "podas"/"podar"/"podado" cuentan por keyword "poda"', () => {
-    expect(scoreKeywordsFlexible('Hacé podas de renovación.', ['poda']).matched).toBe(1);
+    expect(scoreKeywordsFlexible('Haga podas de renovación.', ['poda']).matched).toBe(1);
     expect(scoreKeywordsFlexible('Conviene podar las hojas secas.', ['poda']).matched).toBe(1);
     expect(scoreKeywordsFlexible('El cafetal ya está podado.', ['poda']).matched).toBe(1);
   });
 
   it('match por LEMA en la keyword multi-palabra: "variedad resistente" ~ "variedades resistentes"', () => {
-    const resp = 'Usá variedades resistentes como Castillo.';
+    const resp = 'Use variedades resistentes como Castillo.';
     expect(scoreKeywordsFlexible(resp, ['variedades resistentes']).matched).toBe(1);
     // y la forma singular del keyword también casa con el plural del texto
     expect(scoreKeywordsFlexible(resp, ['variedad resistente']).matched).toBe(1);
@@ -84,7 +84,7 @@ describe('scoreKeywordsFlexible', () => {
 
   it('match por SINÓNIMO: "nitrógeno" casa con "fijar nitrógeno"/"abono nitrogenado"/"leguminosas"', () => {
     expect(scoreKeywordsFlexible('Las leguminosas aportan al suelo.', ['nitrógeno']).matched).toBe(1);
-    expect(scoreKeywordsFlexible('Usá un abono nitrogenado.', ['nitrógeno']).matched).toBe(1);
+    expect(scoreKeywordsFlexible('Use un abono nitrogenado.', ['nitrógeno']).matched).toBe(1);
   });
 
   it('NO infla: keyword ausente sin sinónimo ni lema sigue sin contar', () => {
@@ -271,15 +271,15 @@ describe('scoreAntiHalluc (caller inyectado, sin GPU)', () => {
   });
 });
 
-// ── R5: juez Claude Haiku (Anthropic) + fallback determinístico ───────────────
+// ── R5: juez Claude Sonnet (Anthropic) + fallback determinístico ─────────────
 //
 // NOTA DE SEGURIDAD: ningún test usa una API key real ni llama a la red. La
 // llamada HTTP se mockea (`fetchImpl`) y la lectura de la key se inyecta (`env`
 // / `keyPath`). Estos tests pasan en CI SIN ANTHROPIC_API_KEY.
 
-describe('RECOMMENDED_JUDGE_MODEL ahora es Claude Haiku (local roto en Maxwell)', () => {
+describe('RECOMMENDED_JUDGE_MODEL ahora es Claude Sonnet (local roto en Maxwell)', () => {
   it('el default es el modelo Anthropic, no un modelo de ollama', () => {
-    expect(RECOMMENDED_JUDGE_MODEL).toBe('claude-haiku-4-5');
+    expect(RECOMMENDED_JUDGE_MODEL).toBe('claude-sonnet-5');
     expect(RECOMMENDED_JUDGE_MODEL).toBe(RECOMMENDED_ANTHROPIC_JUDGE_MODEL);
   });
 
@@ -357,12 +357,12 @@ describe('makeAnthropicJudgeCall (fetch mockeado, sin key real)', () => {
     const raw = await judgeCall('PROMPT DEL JUEZ');
     expect(raw).toBe('{"pass": true, "must_covered": 2, "must_total": 2, "red_flags_hit": 0}');
 
-    // contrato del request: endpoint + headers anthropic + modelo Haiku + temp 0
+    // contrato del request: endpoint + headers anthropic + modelo Sonnet + temp 0
     expect(captured.url).toBe('https://api.anthropic.com/v1/messages');
     expect(captured.init.headers['x-api-key']).toBe('sk-test-FAKE');
     expect(captured.init.headers['anthropic-version']).toBeTruthy();
     const body = JSON.parse(captured.init.body);
-    expect(body.model).toBe('claude-haiku-4-5');
+    expect(body.model).toBe('claude-sonnet-5');
     expect(body.temperature).toBe(0);
     expect(body.messages[0].content).toBe('PROMPT DEL JUEZ');
   });
@@ -582,7 +582,7 @@ describe('selectJudgeProvider', () => {
   it('AUTO con key → anthropic + judgeCall listo', () => {
     const sel = selectJudgeProvider({ env: { ANTHROPIC_API_KEY: 'sk-test-FAKE' }, fetchImpl: async () => ({}) });
     expect(sel.provider).toBe('anthropic');
-    expect(sel.judgeModel).toBe('claude-haiku-4-5');
+    expect(sel.judgeModel).toBe('claude-sonnet-5');
     expect(typeof sel.judgeCall).toBe('function');
     expect(sel.deterministic).toBe(false);
   });

--- a/scripts/bench-llm-judge.mjs
+++ b/scripts/bench-llm-judge.mjs
@@ -25,16 +25,22 @@
  *      loadBenchData reconoce ambos y prioriza el más reciente.
  *   3. el JSONL real es per-model anidado (sin ground_truth ni model_response
  *      plano). normalizeBenchData lo transforma a items evaluables tomando la
- *      respuesta del modelo objetivo (TARGET_MODEL, default granite) y derivando
- *      un ground_truth de los expected_keywords cuando no hay uno explícito.
+ *      respuesta del modelo objetivo inferido desde el JSONL o pasado por
+ *      `--target`, y derivando un ground_truth de los expected_keywords cuando
+ *      no hay uno explícito.
  *   + Si `--from` apunta a un archivo inexistente, se LANZA (no mock silencioso).
  *
- * Smoke con 10 prompts vs granite/llama/gemma.
+ * Smoke con 10 prompts contra el target resuelto desde el JSONL.
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { performance } from 'node:perf_hooks';
+import {
+  readAnthropicKey,
+  makeAnthropicJudgeCall,
+  RECOMMENDED_ANTHROPIC_JUDGE_MODEL,
+} from './lib/bench-scorer.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
@@ -42,16 +48,12 @@ const DATA_DIR = join(ROOT_DIR, 'data');
 const BENCH_RUNS_DIR = process.env.BENCH_OUTPUT_DIR || join(DATA_DIR, 'bench-runs');
 const OUTPUT_DIR = process.env.BENCH_JUDGE_OUTPUT_DIR || join(DATA_DIR, 'bench-judge-scores');
 
-const OLLAMA_URL = 'http://localhost:11434/api/generate';
-const JUDGE_MODEL = process.env.JUDGE_MODEL || 'gemma3:4b';
 const TIMEOUT_MS = 60_000;
+const JUDGE_PROVIDER = (process.env.JUDGE_PROVIDER || 'anthropic').trim().toLowerCase();
+const ANTHROPIC_JUDGE_MODEL = RECOMMENDED_ANTHROPIC_JUDGE_MODEL;
 
-// Modelo cuyo turno se evalúa cuando el JSONL es per-model (bench-agente-completo).
-const TARGET_MODEL = process.env.TARGET_MODEL || 'granite3.3:8b';
-
-// Mapa modelKey (clave del objeto per-model en el JSONL) → nombre ollama, para
-// poder seleccionar por nombre real del modelo cuando TARGET_MODEL es un nombre.
-const MODEL_KEY_BY_NAME = {
+// Mapas entre nombre de modelo y clave per-model del JSONL.
+const MODEL_NAME_BY_KEY = {
   'gemma3:4b': 'gemma3_4b',
   'granite3.3:8b': 'granite3_3_8b',
   'granite3.1-dense:8b': 'granite3_1_8b',
@@ -61,6 +63,10 @@ const MODEL_KEY_BY_NAME = {
   'ministral-3:14b': 'ministral_14b',
   'qwen3:30b': 'qwen3_30b',
 };
+
+const MODEL_KEY_BY_NAME = Object.fromEntries(
+  Object.entries(MODEL_NAME_BY_KEY).map(([name, key]) => [key, name]),
+);
 
 // Prompts mock para el smoke test si no hay datos reales
 const MOCK_BENCH_DATA = {
@@ -217,6 +223,29 @@ export function parseFromArg(argv = process.argv) {
 }
 
 /**
+ * parseTargetArg — extrae el target explícito para el JSONL.
+ * Acepta `--target <modelo>` y `--target=<modelo>`.
+ *
+ * @param {string[]} argv
+ * @returns {string|null}
+ */
+export function parseTargetArg(argv = process.argv) {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--target') {
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) return next;
+      return null;
+    }
+    if (a.startsWith('--target=')) {
+      const v = a.slice('--target='.length);
+      return v.length > 0 ? v : null;
+    }
+  }
+  return null;
+}
+
+/**
  * derivedGroundTruth — cuando el bench NO trae un ground_truth explícito (el
  * caso de bench-agente-completo, que solo tiene expected_keywords), arma una
  * referencia legible para el juez a partir de los conceptos esperados. No es una
@@ -232,23 +261,64 @@ function derivedGroundTruth(keywords) {
   return `Una respuesta correcta debe cubrir, por fondo: ${kw.join(', ')}.`;
 }
 
-/**
- * pickModelKey — elige la clave per-model del objeto del JSONL para el modelo
- * objetivo. Acepta un nombre ollama (granite3.1-dense:8b) o ya una clave
- * (granite3_1_8b). Devuelve la clave si está presente en el item, o null.
- *
- * @param {Record<string, any>} item
- * @param {string} target
- * @returns {string|null}
- */
+function normalizeTargetToken(target) {
+  return typeof target === 'string' ? target.trim() : '';
+}
+
+function isPerModelEntry(value) {
+  return Boolean(
+    value && typeof value === 'object' && (
+      typeof value.response === 'string' ||
+      typeof value.error === 'string' ||
+      typeof value.model === 'string'
+    ),
+  );
+}
+
 function pickModelKey(item, target) {
-  const asKey = MODEL_KEY_BY_NAME[target] || target;
+  const normalized = normalizeTargetToken(target);
+  if (!normalized) return null;
+  const asKey = MODEL_NAME_BY_KEY[normalized] || normalized;
   if (item[asKey] && typeof item[asKey] === 'object') return asKey;
-  // fallback: buscar cualquier sub-objeto cuyo .model coincida con el nombre.
   for (const [k, v] of Object.entries(item)) {
-    if (v && typeof v === 'object' && v.model === target) return k;
+    if (v && typeof v === 'object' && v.model === normalized) return k;
   }
   return null;
+}
+
+function inferTargetModelKey(lines) {
+  const counts = new Map();
+  for (const item of Array.isArray(lines) ? lines : []) {
+    if (!item || typeof item !== 'object') continue;
+    for (const [key, value] of Object.entries(item)) {
+      if (!isPerModelEntry(value)) continue;
+      counts.set(key, (counts.get(key) || 0) + 1);
+    }
+  }
+
+  if (counts.size === 0) return null;
+  const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const top = ranked[0];
+  const tied = ranked.filter(([, count]) => count === top[1]);
+  if (tied.length !== 1) return null;
+  return top[0];
+}
+
+function resolveTargetDescriptor(lines, { targetModel } = {}) {
+  const explicit = normalizeTargetToken(targetModel);
+  if (explicit) {
+    const keyFromExplicit = MODEL_NAME_BY_KEY[explicit] || explicit;
+    const nameFromExplicit = MODEL_KEY_BY_NAME[keyFromExplicit] || explicit;
+    return { targetKey: keyFromExplicit, targetName: nameFromExplicit, explicit: true };
+  }
+
+  const inferredKey = inferTargetModelKey(lines);
+  if (!inferredKey) return { targetKey: null, targetName: null, explicit: false };
+  return {
+    targetKey: inferredKey,
+    targetName: MODEL_KEY_BY_NAME[inferredKey] || inferredKey,
+    explicit: false,
+  };
 }
 
 /**
@@ -263,13 +333,14 @@ function pickModelKey(item, target) {
  *   (c) modelo objetivo con error → se OMITE (no se evalúa una no-respuesta).
  *
  * @param {Array<Record<string,any>>} lines
- * @param {{ targetModel?: string }} [opts]
- * @returns {{ timestamp:string, model:string, results:Array, skipped:number }}
+ * @param {{ targetModel?: string, targetName?: string }} [opts]
+ * @returns {{ timestamp:string, model:string, results:Array, skipped:number, skippedSeeded:number }}
  */
-export function normalizeBenchData(lines, { targetModel = TARGET_MODEL } = {}) {
+export function normalizeBenchData(lines, { targetModel = null, targetName = null } = {}) {
   const arr = Array.isArray(lines) ? lines : [];
   const results = [];
   let skipped = 0;
+  let skippedSeeded = 0;
 
   for (const item of arr) {
     if (!item || typeof item !== 'object') {
@@ -277,9 +348,16 @@ export function normalizeBenchData(lines, { targetModel = TARGET_MODEL } = {}) {
       continue;
     }
 
+    if (item.seed === true || item.seeded === true) {
+      skipped++;
+      skippedSeeded++;
+      continue;
+    }
+
     // (b) ya está en formato judge plano.
     const flatResponse = item.model_response ?? item.response;
-    const isFlat = typeof flatResponse === 'string' && !pickModelKey(item, targetModel);
+    const resolvedTargetKey = targetModel ? pickModelKey(item, targetModel) : null;
+    const isFlat = typeof flatResponse === 'string' && !resolvedTargetKey;
     if (isFlat) {
       results.push({
         id: item.id ?? item.prompt_id ?? results.length + 1,
@@ -294,7 +372,7 @@ export function normalizeBenchData(lines, { targetModel = TARGET_MODEL } = {}) {
     }
 
     // (a) per-model anidado.
-    const key = pickModelKey(item, targetModel);
+    const key = resolvedTargetKey;
     if (!key) {
       skipped++;
       continue;
@@ -317,9 +395,10 @@ export function normalizeBenchData(lines, { targetModel = TARGET_MODEL } = {}) {
 
   return {
     timestamp: new Date().toISOString(),
-    model: targetModel,
+    model: targetName || targetModel || 'mixed',
     results,
     skipped,
+    skippedSeeded,
   };
 }
 
@@ -337,9 +416,10 @@ export function normalizeBenchData(lines, { targetModel = TARGET_MODEL } = {}) {
  * Marca `usedMock` para que el caller pueda distinguir.
  *
  * @param {string|null} fromPath
+ * @param {{ targetModel?: string }} [opts]
  * @returns {{ timestamp:string, model:string, results:Array, usedMock:boolean, skipped?:number, source?:string }}
  */
-export function loadBenchData(fromPath) {
+export function loadBenchData(fromPath, { targetModel } = {}) {
   if (fromPath) {
     if (!existsSync(fromPath)) {
       throw new Error(
@@ -347,7 +427,7 @@ export function loadBenchData(fromPath) {
           `NO se cae a mock para no enmascarar un path roto.`,
       );
     }
-    return { ...parseBenchFile(fromPath), usedMock: false, source: fromPath };
+    return { ...parseBenchFile(fromPath, { targetModel }), usedMock: false, source: fromPath };
   }
 
   // Auto-discovery: el más reciente .jsonl o .json en bench-runs/.
@@ -367,7 +447,7 @@ export function loadBenchData(fromPath) {
       .sort((a, b) => b.mtime - a.mtime);
     if (candidates.length > 0) {
       const latest = candidates[0].full;
-      return { ...parseBenchFile(latest), usedMock: false, source: latest };
+      return { ...parseBenchFile(latest, { targetModel }), usedMock: false, source: latest };
     }
   }
 
@@ -380,12 +460,21 @@ export function loadBenchData(fromPath) {
  * y devuelve `{ timestamp, model, results, skipped }` normalizado.
  *
  * @param {string} path
+ * @param {{ targetModel?: string }} [opts]
  * @returns {{ timestamp:string, model:string, results:Array, skipped:number }}
  */
-function parseBenchFile(path) {
+function parseBenchFile(path, { targetModel } = {}) {
   const raw = readFileSync(path, 'utf-8');
   const trimmed = raw.trim();
-  if (trimmed.length === 0) return { timestamp: new Date().toISOString(), model: TARGET_MODEL, results: [], skipped: 0 };
+  if (trimmed.length === 0) {
+    return {
+      timestamp: new Date().toISOString(),
+      model: targetModel || 'mixed',
+      results: [],
+      skipped: 0,
+      skippedSeeded: 0,
+    };
+  }
 
   // JSONL: varias líneas, cada una un objeto. Detecta por ≥2 líneas JSON o
   // por extensión .jsonl.
@@ -396,45 +485,64 @@ function parseBenchFile(path) {
     const parsed = lines.map((l) => JSON.parse(l));
     // Si ya viene en formato judge `{ results: [...] }` por línea, aplanar.
     if (parsed.length === 1 && Array.isArray(parsed[0].results)) {
-      return normalizeBenchData(parsed[0].results);
+      return normalizeBenchData(parsed[0].results, { targetModel });
     }
-    return normalizeBenchData(parsed);
+    const resolved = resolveTargetDescriptor(parsed, { targetModel });
+    if (resolved.targetKey === null && parsed.some((item) => Object.values(item || {}).some(isPerModelEntry))) {
+      throw new Error(
+        '[judge] No se pudo inferir el modelo objetivo desde el JSONL. ' +
+          'Use --target <modelo> o TARGET_MODEL para seleccionar una sola tanda.',
+      );
+    }
+    return normalizeBenchData(parsed, {
+      targetModel: resolved.targetKey,
+      targetName: resolved.targetName,
+    });
   }
 
   // JSON: un objeto. Puede ser `{ results: [...] }` (judge) o un único item.
   const obj = JSON.parse(trimmed);
   if (Array.isArray(obj.results)) {
-    const norm = normalizeBenchData(obj.results);
+    const norm = normalizeBenchData(obj.results, { targetModel });
     return { ...norm, timestamp: obj.timestamp ?? norm.timestamp, model: obj.model ?? norm.model };
   }
-  return normalizeBenchData([obj]);
+  return normalizeBenchData([obj], { targetModel });
 }
 
-async function callJudge(prompt, signal) {
-  const start = performance.now();
-  const res = await fetch(OLLAMA_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      model: JUDGE_MODEL,
-      system: JUDGE_PROMPT,
-      prompt: prompt,
-      stream: false,
-      options: {
-        temperature: 0.1, // Baja temperatura para consistencia
-        num_predict: 200,
-      },
-      keep_alive: '30m',
-    }),
-    signal,
-  });
-  const elapsed = performance.now() - start;
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+export function resolveJudgeCall({ env = process.env, fetchImpl = globalThis.fetch } = {}) {
+  const provider = normalizeTargetToken(env?.JUDGE_PROVIDER || JUDGE_PROVIDER || 'anthropic').toLowerCase();
+  if (provider !== 'anthropic') {
+    throw new Error(
+      `[judge] bench-llm-judge requiere JUDGE_PROVIDER=anthropic, no '${provider || '(vacío)'}'.`,
+    );
   }
-  const data = await res.json();
+
+  const apiKey = readAnthropicKey({ env });
+  if (!apiKey) {
+    throw new Error(
+      '[judge] No se pudo leer la key de Anthropic desde ANTHROPIC_API_KEY ni desde ~/.config/chagra-anthropic-judge-key.',
+    );
+  }
+
   return {
-    raw_response: data.response,
+    provider: 'anthropic',
+    model: ANTHROPIC_JUDGE_MODEL,
+    judgeCall: makeAnthropicJudgeCall({
+      apiKey,
+      model: ANTHROPIC_JUDGE_MODEL,
+      fetchImpl,
+      timeoutMs: TIMEOUT_MS,
+      maxTokens: 256,
+    }),
+  };
+}
+
+async function callJudge(prompt, judgeCall) {
+  const start = performance.now();
+  const raw_response = await judgeCall(prompt);
+  const elapsed = performance.now() - start;
+  return {
+    raw_response,
     latency_ms: elapsed,
   };
 }
@@ -457,7 +565,7 @@ function calculateAvg(scores) {
   return values.reduce((a, b) => a + b, 0) / values.length;
 }
 
-async function evaluateItem(item, index, total) {
+async function evaluateItem(item, index, total, judgeCall) {
   const { query, ground_truth, model_response } = item;
   if (!model_response && !item.response) {
     return { error: 'No hay respuesta del modelo para evaluar' };
@@ -473,19 +581,25 @@ RESPUESTA DEL MODELO: "${response}"
 Evalúa esta respuesta en las 4 dimensiones.`;
 
   console.log(`[judge] Evaluando item ${index + 1}/${total}...`);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
   try {
-    const result = await callJudge(prompt, controller.signal);
+    const result = await callJudge(prompt, judgeCall);
     const scores = parseJudgeResponse(result.raw_response);
+    const requiredFields = ['factualidad', 'claridad_colombiana', 'anti_alucinacion', 'completitud'];
+    for (const field of requiredFields) {
+      const value = Number(scores[field]);
+      if (!Number.isFinite(value)) {
+        throw new Error(`Veredicto incompleto del juez: falta ${field}`);
+      }
+      scores[field] = value;
+    }
 
     // Calcular promedio si no está presente
     if (!scores.promedio) {
       scores.promedio = calculateAvg(scores);
+    } else {
+      scores.promedio = Number(scores.promedio);
     }
 
-    clearTimeout(timer);
     return {
       item_id: item.id,
       scores: {
@@ -499,7 +613,6 @@ Evalúa esta respuesta en las 4 dimensiones.`;
       judge_latency_ms: result.latency_ms,
     };
   } catch (err) {
-    clearTimeout(timer);
     console.error(`  → ERROR: ${err.message}`);
     return { error: err.message, item_id: item.id };
   }
@@ -507,29 +620,37 @@ Evalúa esta respuesta en las 4 dimensiones.`;
 
 async function main() {
   console.log('[judge] LLM-Judge smoke test v2');
-  console.log(`[judge] Modelo juez: ${JUDGE_MODEL}`);
+  console.log(`[judge] Proveedor juez: ${JUDGE_PROVIDER}`);
+  console.log(`[judge] Modelo juez: ${ANTHROPIC_JUDGE_MODEL}`);
   console.log(`[judge] Directorio output: ${OUTPUT_DIR}`);
 
   const fromPath = parseFromArg(process.argv);
-  const benchData = loadBenchData(fromPath);
+  const targetModel = parseTargetArg(process.argv) || process.env.TARGET_MODEL || null;
+  const { judgeCall } = resolveJudgeCall();
+  const benchData = loadBenchData(fromPath, { targetModel });
 
   console.log(`[judge] Fuente: ${benchData.source || 'N/A'}${benchData.usedMock ? ' (MOCK — smoke test)' : ' (datos REALES)'}`);
   if (typeof benchData.skipped === 'number' && benchData.skipped > 0) {
-    console.log(`[judge] Items omitidos (modelo objetivo con error/sin respuesta): ${benchData.skipped}`);
+    const skippedSeeded = typeof benchData.skippedSeeded === 'number' ? benchData.skippedSeeded : 0;
+    const skippedFailure = Math.max(0, benchData.skipped - skippedSeeded);
+    console.log(`[judge] Items omitidos por error/sin respuesta: ${skippedFailure}`);
+  }
+  if (typeof benchData.skippedSeeded === 'number' && benchData.skippedSeeded > 0) {
+    console.log(`[judge] Items omitidos (seed:true, no-medición): ${benchData.skippedSeeded}`);
   }
   console.log(`[judge] Datos cargados: ${benchData.results.length} items`);
   console.log(`[judge] Timestamp bench: ${benchData.timestamp}`);
   console.log(`[judge] Modelo evaluado: ${benchData.model || 'N/A'}`);
 
   if (benchData.results.length === 0) {
-    throw new Error('[judge] 0 items evaluables tras normalizar. Revisá el JSONL de origen / TARGET_MODEL.');
+    throw new Error('[judge] 0 items evaluables tras normalizar. Revise el JSONL de origen y el target.');
   }
 
   const results = [];
   const startTime = performance.now();
 
   for (let i = 0; i < benchData.results.length; i++) {
-    const evaluation = await evaluateItem(benchData.results[i], i, benchData.results.length);
+    const evaluation = await evaluateItem(benchData.results[i], i, benchData.results.length, judgeCall);
     results.push(evaluation);
 
     // Pequeña pausa entre items
@@ -541,6 +662,11 @@ async function main() {
   const totalTime = performance.now() - startTime;
   const successful = results.filter((r) => !r.error);
   const failed = results.filter((r) => r.error);
+
+  if (successful.length === 0) {
+    const reasons = failed.slice(0, 3).map((r) => `#${r.item_id}: ${r.error}`).join('; ') || 'sin detalle';
+    throw new Error(`[judge] No se pudo juzgar ningún item. ${reasons}`);
+  }
 
   // Calcular agregados
   const avgScores = {
@@ -574,11 +700,13 @@ async function main() {
 
 ## Metadata
 - **Timestamp**: ${new Date().toISOString()}
-- **Juez**: ${JUDGE_MODEL}
+- **Juez**: ${ANTHROPIC_JUDGE_MODEL} (${JUDGE_PROVIDER})
 - **Modelo evaluado**: ${benchData.model || 'smoke-test'}
 - **Items evaluados**: ${results.length}
 - **Exitosos**: ${successful.length}
 - **Fallidos**: ${failed.length}
+- **Omitidos**: ${typeof benchData.skipped === 'number' ? benchData.skipped : 0}
+- **Omitidos seed:true**: ${typeof benchData.skippedSeeded === 'number' ? benchData.skippedSeeded : 0}
 - **Tiempo total**: ${(totalTime / 1000).toFixed(2)}s
 - **Tiempo promedio por item**: ${(totalTime / results.length).toFixed(2)}ms
 

--- a/scripts/lib/bench-scorer.mjs
+++ b/scripts/lib/bench-scorer.mjs
@@ -33,8 +33,8 @@
  *   - `qwen2.5:14b`      → devuelve respuesta VACÍA (no juzga nada).
  *   - `llama3.1:8b`      → devuelve respuesta VACÍA.
  *   - `mistral-nemo:12b` → aprueba TODO (rubber-stamp; además crash cgo).
- * Por eso el juez confiable por defecto pasa a ser **Claude Haiku** vía la API de
- * Anthropic (`claude-haiku-4-5`: modelo de juez barato y estable). El proveedor
+ * Por eso el juez confiable por defecto pasa a ser **Claude Sonnet** vía la API de
+ * Anthropic (`claude-sonnet-5`: modelo de juez estable y más capaz). El proveedor
  * se elige con la env `JUDGE_PROVIDER` (anthropic|ollama|deterministic). Si NO
  * hay API key disponible, se degrada de forma graceful al scorer DETERMINÍSTICO
  * (substring de must_include + ausencia de red_flags) — nunca crashea.
@@ -56,13 +56,13 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 /**
- * Modelo Anthropic de juez (barato y confiable). Se usa cuando
+ * Modelo Anthropic de juez (estable y más capaz). Se usa cuando
  * `JUDGE_PROVIDER=anthropic` (default si hay API key disponible).
  */
-export const RECOMMENDED_ANTHROPIC_JUDGE_MODEL = 'claude-haiku-4-5';
+export const RECOMMENDED_ANTHROPIC_JUDGE_MODEL = 'claude-sonnet-5';
 
 /**
- * Juez recomendado por defecto: Claude Haiku vía API de Anthropic. Los jueces
+ * Juez recomendado por defecto: Claude Sonnet vía API de Anthropic. Los jueces
  * LOCALES están ROTOS en Maxwell (qwen2.5:14b y llama3.1:8b devuelven vacío;
  * mistral-nemo:12b aprueba todo = rubber-stamp). Cuando no hay API key, el
  * pipeline degrada al scorer determinístico (ver `selectJudgeProvider`).
@@ -98,7 +98,7 @@ export function assertIndependentJudge(judgeModel, generatorModel) {
   if (j && g && j === g) {
     throw new Error(
       `Juez NO independiente: '${judgeModel}' es el generador → auto-evaluación. ` +
-        `Usá un juez de otra familia (recomendado: ${RECOMMENDED_JUDGE_MODEL}).`,
+        `Use un juez de otra familia (recomendado: ${RECOMMENDED_JUDGE_MODEL}).`,
     );
   }
 }
@@ -453,7 +453,7 @@ export async function scoreAntiHalluc(item, { ollamaCall } = {}) {
   }
 }
 
-// ── R5: juez Claude Haiku (Anthropic API) + fallback determinístico ───────────
+// ── R5: juez Claude Sonnet (Anthropic API) + fallback determinístico ──────────
 
 /**
  * Ruta del archivo gitignored con la API key del juez Anthropic. chmod 600. El
@@ -504,7 +504,7 @@ export function extractAnthropicText(data) {
 
 /**
  * makeAnthropicJudgeCall — fabrica un caller de juez `(prompt) => Promise<string>`
- * que llama a la API de Anthropic (Messages) con un modelo Haiku barato y
+ * que llama a la API de Anthropic (Messages) con un modelo Sonnet estable y
  * devuelve el TEXTO del veredicto, con el MISMO contrato que el `ollamaCall`
  * inyectable. Así enchufa directo en `scoreAntiHalluc` / `scoreWithJudge` sin
  * cambiarlos.

--- a/src/services/__tests__/ragRetriever.test.js
+++ b/src/services/__tests__/ragRetriever.test.js
@@ -106,6 +106,25 @@ describe('ragRetriever — corpus extendido v2', () => {
     vi.clearAllMocks();
   });
 
+  it('flattenDoc propaga species desde slug y la conserva en pasajes anidados', async () => {
+    const { flattenDoc } = await import('../ragRetriever.js');
+    const passages = flattenDoc({
+      slug: 'sluggy_test',
+      intro: 'Este es un texto largo de prueba para el passage principal.',
+      sections: [
+        { title: 'Primer pasaje anidado con suficiente longitud para indexar.' },
+      ],
+      nested: {
+        note: 'Otro pasaje largo que debe heredar el slug de la especie.',
+      },
+    });
+
+    expect(passages).toHaveLength(3);
+    passages.forEach((p) => {
+      expect(p.species).toBe('sluggy_test');
+    });
+  });
+
   it('retrieve("plan alimentación fresa") devuelve passage con "### Plan de alimentación"', async () => {
     const { retrieve } = await import('../ragRetriever.js');
     const hits = await retrieve('plan alimentación fresa bocashi humus', 5);

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -107,8 +107,24 @@ function scoreBM25(doc, queryTerms, idf, avgLen) {
   return score;
 }
 
-function flattenDoc(doc, prefix = '', speciesSlug = null) {
-  const slug = speciesSlug || doc.species_slug || '';
+function resolveSpeciesSlug(doc, speciesSlug = null) {
+  if (typeof speciesSlug === 'string' && speciesSlug.trim()) return speciesSlug.trim();
+  if (!doc || typeof doc !== 'object') return '';
+  const candidates = [
+    doc.species_slug,
+    doc.speciesSlug,
+    doc.species_id,
+    doc.slug,
+    typeof doc.species === 'string' ? doc.species : '',
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+  }
+  return '';
+}
+
+export function flattenDoc(doc, prefix = '', speciesSlug = null) {
+  const slug = resolveSpeciesSlug(doc, speciesSlug);
   const passages = [];
   const addPassage = (key, val) => {
     if (typeof val === 'string' && val.length > 20) {


### PR DESCRIPTION
## Summary
- Bench judge now infers the target from JSONL or accepts --target, instead of assuming a hardcoded model.
- Anthropic judge uses claude-sonnet-5 and fails if the key is missing or the provider cannot judge.
- seed:true is treated as non-measurement and flattenDoc preserves species across nested passages.

## Test plan
- npx vitest run scripts/__tests__/bench-scorer.test.mjs scripts/__tests__/bench-llm-judge.test.mjs src/services/__tests__/ragRetriever.test.js
- npx eslint scripts/bench-llm-judge.mjs scripts/lib/bench-scorer.mjs scripts/__tests__/bench-llm-judge.test.mjs scripts/__tests__/bench-scorer.test.mjs src/services/ragRetriever.js src/services/__tests__/ragRetriever.test.js --max-warnings=0
- npm run build

## Notes
- A full npx vitest run surfaced unrelated preexisting failures in src/data/__tests__/dataSchema.fuente.test.js, src/components/__tests__/AssetDetailView.smoke.test.jsx, src/components/__tests__/SeguimientoProcesoScreen.test.jsx, and tests/unit/boundaryAudit.test.js.
