### PR TITLE
fix(security): detectar contactos inventados y corregir logica invertida de guardDoseWithoutSource

### DIFF
--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -16,6 +16,7 @@ import {
   guardInvasiveSpecies,
   guardInvertedViability,
   guardDoseWithoutSource,
+  guardInventedContact,
   guardSpeciesSubstitution,
   guardCompanionBinomial,
   guardVisionWithoutPhoto,
@@ -761,6 +762,118 @@ describe('guardDoseWithoutSource', () => {
     const txt = 'Aplica 30 ml/L. confirma la dosis con la etiqueta.';
     const out = guardDoseWithoutSource(txt);
     expect(out.modified).toBe(false);
+  });
+
+  // Test para verify que una cita fabricada NO suprime el caveat (fix #guardrail-contacts)
+  it('AÑADE caveat incluso si el modelo inventa una cita genérica de fuente', () => {
+    // El modelo inventa "según una recomendación de la entidad" sin especificar cuál
+    const txt = 'Según una recomendación de la entidad, aplica 30 ml/L de la solución.';
+    const out = guardDoseWithoutSource(txt);
+    // Debe añadir caveat porque "de la entidad" NO es una fuente verificada
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/confirma la dosis/i);
+  });
+
+  it('AÑADE caveat si cita un decreto inventado', () => {
+    // El modelo inventa "Decreto 1234 de 2020" que no existe
+    const txt = 'Según el Decreto 1234 de 2020, aplica 5 g por planta.';
+    const out = guardDoseWithoutSource(txt);
+    // Debe añadir caveat porque el decreto no está verificado
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/confirma la dosis/i);
+  });
+
+  it('NO suaviza si cita ICA (fuente verificada)', () => {
+    const txt = 'Según el ICA, aplica 30 ml/L de caldo bordelés.';
+    const out = guardDoseWithoutSource(txt);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(txt);
+  });
+
+  it('NO suaviza si cita Agrosavia (fuente verificada)', () => {
+    const txt = 'De acuerdo con Agrosavia, diluye 2 cc en agua.';
+    const out = guardDoseWithoutSource(txt);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(txt);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// GUARD 5 — contacto inventado (teléfonos, correos, URLs, decretos)
+// ──────────────────────────────────────────────────────────────────────────
+describe('guardInventedContact', () => {
+  it('detecta y reemplaza teléfono inventado', () => {
+    // El modelo inventa un teléfono institucional
+    const txt = 'Para reportar la plaga cuarentenaria, llama al 300 123 4567.';
+    const out = guardInventedContact(txt);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/teléfono/);
+    expect(out.text).toMatch(/VERIFICAR CONTACTO OFICIAL/);
+    expect(out.text).not.toMatch(/300 123 4567/);
+  });
+
+  it('detecta y reemplaza correo inventado', () => {
+    const txt = 'Envía tu reporte a reportes@ica-inventado.gov.co para revisión.';
+    const out = guardInventedContact(txt);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/correo/);
+    expect(out.text).toMatch(/VERIFICAR CONTACTO OFICIAL/);
+    expect(out.text).not.toMatch(/reportes@ica-inventado\.gov\.co/);
+  });
+
+  it('detecta y reemplaza URL inventada', () => {
+    const txt = 'Visita www.minagricultura-falso.gov.co para más información.';
+    const out = guardInventedContact(txt);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/URL/);
+    expect(out.text).toMatch(/VERIFICAR CONTACTO OFICIAL/);
+    expect(out.text).not.toMatch(/www\.minagricultura-falso\.gov\.co/);
+  });
+
+  it('detecta y reemplaza decreto/resolución inventado', () => {
+    const txt = 'Según el Decreto 9999 de 2025, debes aplicar esta dosis.';
+    const out = guardInventedContact(txt);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/normativa/);
+    expect(out.text).toMatch(/VERIFICAR NORMATIVA OFICIAL/);
+  });
+
+  it('NO toca Ley 1930 (decreto verificado conocido)', () => {
+    const txt = 'La Ley 1930 de 2018 prohíbe la quema en páramo.';
+    const out = guardInventedContact(txt);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(txt);
+  });
+
+  it('detecta múltiples contactos inventados en un solo texto', () => {
+    const txt =
+      'Llama al 320 987 6543 o escribe a contacto@umata-inventado.gov.co. ' +
+      'También visita www.agricultura-falsa.co para más info.';
+    const out = guardInventedContact(txt);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/VERIFICAR CONTACTO OFICIAL/);
+    expect(out.text).not.toMatch(/320 987 6543|contacto@umata-inventado\.gov\.co|www\.agricultura-falsa\.co/);
+  });
+
+  it('NO dispara si no hay contactos', () => {
+    const txt = 'Aplica caldo bordelés como preventivo.';
+    const out = guardInventedContact(txt);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(txt);
+  });
+
+  it('detecta teléfono con formato (+57)', () => {
+    const txt = 'Contacta al +57 300 123 4567 para ayuda.';
+    const out = guardInventedContact(txt);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/VERIFICAR CONTACTO OFICIAL/);
+  });
+
+  it('detecta teléfono con paréntesis', () => {
+    const txt = 'Llama al (300) 123-4567 para reportar.';
+    const out = guardInventedContact(txt);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/VERIFICAR CONTACTO OFICIAL/);
   });
 });
 

--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -827,7 +827,7 @@ describe('guardInventedContact', () => {
     expect(out.modified).toBe(true);
     expect(out.reason).toMatch(/URL/);
     expect(out.text).toMatch(/VERIFICAR CONTACTO OFICIAL/);
-    expect(out.text).not.toMatch(/www\.minagricultura-falso\.gov\.co/);
+    expect(out.text).not.toContain('www.minagricultura-falso.gov.co');
   });
 
   it('detecta y reemplaza decreto/resolución inventado', () => {

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -2289,15 +2289,28 @@ const VERIFIED_SOURCE_ALLOWLIST = new Set([
   'restrepo', // Dr. Carlos Restrepo, autoridad en agroecología colombiana
   'catalogo chagra',
   'etiqueta', // Etiqueta del producto (siempre verificable)
-  'ficha técnica',
+  'ficha tecnica', // normalizado (sin tilde): se compara contra texto _stripDiacritics()
 ]);
 
+/** Escapa caracteres especiales de regex para usar una cadena como literal. */
+const _escapeRegExpLiteral = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 /**
- * Indicios de que la dosis SÍ trae respaldo (cita de fuente / etiqueta).
- * CRÍTICO: Solo confiamos en fuentes de la allowlist verificada.
+ * Detecta si el texto cita alguna fuente VERIFICADA (de VERIFIED_SOURCE_ALLOWLIST).
+ * CRÍTICO: la allowlist es la ÚNICA fuente de verdad — no hay una lista paralela
+ * de nombres "hardcodeada" que pueda desincronizarse de ella. Normaliza el texto
+ * (minúsculas, sin tildes) y busca cada entrada de la allowlist como palabra/
+ * frase completa. Si el modelo inventa "según el INTA" (fuente NO verificada),
+ * esto NO cuenta como respaldo y el caveat de dosis se mantiene.
  */
-const SOURCE_HINT_RE =
-  /(?:seg[uú]n|de acuerdo (?:a|con)|recomienda(?:ci[oó]n)? de la)\s+(?:el\s+)?(?:ICA|Agrosavia|Cenicaf[eé]|Restrepo|cat[aá]logo Chagra|ficha t[ée]cnica|etiqueta)|\bICA\b|Agrosavia|Cenicaf[eé]|Restrepo|cat[aá]logo Chagra|ficha\s+t[ée]cnica|etiqueta/gi;
+function _hasVerifiedSourceMention(responseText) {
+  const norm = _stripDiacritics(responseText);
+  for (const fuente of VERIFIED_SOURCE_ALLOWLIST) {
+    const re = new RegExp(`\\b${_escapeRegExpLiteral(fuente)}\\b`, 'i');
+    if (re.test(norm)) return true;
+  }
+  return false;
+}
 
 /**
  * Guard 4 — dosis sin fuente (PARCIAL: suaviza, no borra). Si el texto da una
@@ -2318,13 +2331,14 @@ export function guardDoseWithoutSource(responseText, _resolvedEntities = null, _
     return { text: responseText, modified: false, reason: null };
   }
 
-  // CRÍTICO: Solo si hay una fuente VERIFICADA en el texto, asumimos respaldo.
-  // El SOURCE_HINT_RE ahora solo matchea fuentes de la allowlist verificada.
+  // CRÍTICO: Solo si hay una fuente de VERIFIED_SOURCE_ALLOWLIST en el texto,
+  // asumimos respaldo. _hasVerifiedSourceMention() está atada directamente a la
+  // allowlist (no hay una lista paralela hardcodeada que pueda desincronizarse).
   // Si el modelo inventa "según una recomendación del ICA" con un decreto falso,
-  // SOURCE_HINT_RE matcheará "ICA" (que está en la allowlist) pero esto es seguro:
-  // si menciona ICA, el usuario puede verificar. Lo peligroso es NO mencionar
-  // fuente alguna.
-  const hasVerifiedSource = SOURCE_HINT_RE.test(responseText);
+  // esto matcheará "ICA" (que está en la allowlist) pero esto es seguro: si
+  // menciona ICA, el usuario puede verificar. Lo peligroso es NO mencionar
+  // fuente alguna, o citar una fuente que NO está en la allowlist.
+  const hasVerifiedSource = _hasVerifiedSourceMention(responseText);
   if (hasVerifiedSource) {
     return { text: responseText, modified: false, reason: null };
   }
@@ -2373,13 +2387,13 @@ const PHONE_RE =
  * Regex para detectar correos electrónicos.
  */
 const EMAIL_RE =
-  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g;
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
 
 /**
  * Regex para detectar URLs (http, https, www).
  */
 const URL_RE =
-  /\b(?:https?:\/\/|www\.)[A-Z|a-z|0-9|-]{2,}\.[A-Z|a-z]{2,}(?:\/[^\s]*)?\b/g;
+  /\b(?:https?:\/\/|www\.)[A-Za-z0-9-]{2,}\.[A-Za-z]{2,}(?:\/[^\s]*)?\b/g;
 
 /**
  * Regex para detectar números de decreto/resolución. Formatos:
@@ -9237,7 +9251,7 @@ export function applyOutputGuards(
   // indica al usuario que verifique el contacto oficial con su UMATA o el ICA.
   // Va tras la marca inventada. Idempotente.
   const contactRes = guardInventedContact(text);
-  if (contactRes && contactRes.modified) {
+  if (contactRes.modified) {
     text = contactRes.text;
     modified = true;
     if (contactRes.reason) reasons.push(contactRes.reason);

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -2276,11 +2276,28 @@ const DOSE_RE =
   /\b\d+(?:[.,]\d+)?\s*(?:ml|cc|g|gr|gramos?|kg|l|lt|litros?|cm3|cucharad(?:as|ita)s?)\b(?:\s*(?:\/|por|por\s+cada|x)\s*(?:l|lt|litro|litros|planta|plantas|mata|matas|ha|hect|hectarea|m2|arbol|arboles|bomba|caneca)\b)?/gi;
 
 /**
- * Indicios de que la dosis SÍ trae respaldo (cita de fuente / etiqueta). Si
- * está presente cerca de la dosis, NO suavizamos.
+ * Allowlist de fuentes VERIFICADAS que pueden respaldar una dosis.
+ * Solo estas fuentes se consideran válidas para suprimir el caveat de dosis.
+ */
+const VERIFIED_SOURCE_ALLOWLIST = new Set([
+  'ica',
+  'ica.gov.co',
+  'agrosavia',
+  'agrosavia.co',
+  'cenicafe',
+  'cenicafe.org',
+  'restrepo', // Dr. Carlos Restrepo, autoridad en agroecología colombiana
+  'catalogo chagra',
+  'etiqueta', // Etiqueta del producto (siempre verificable)
+  'ficha técnica',
+]);
+
+/**
+ * Indicios de que la dosis SÍ trae respaldo (cita de fuente / etiqueta).
+ * CRÍTICO: Solo confiamos en fuentes de la allowlist verificada.
  */
 const SOURCE_HINT_RE =
-  /(seg[uú]n|etiqueta|\bICA\b|Agrosavia|Cenicaf[eé]|Restrepo|\bfuente\b|cat[aá]logo Chagra|recomienda(?:ci[oó]n)? de la|de acuerdo (?:a|con))/i;
+  /(?:seg[uú]n|de acuerdo (?:a|con)|recomienda(?:ci[oó]n)? de la)\s+(?:el\s+)?(?:ICA|Agrosavia|Cenicaf[eé]|Restrepo|cat[aá]logo Chagra|ficha t[ée]cnica|etiqueta)|\bICA\b|Agrosavia|Cenicaf[eé]|Restrepo|cat[aá]logo Chagra|ficha\s+t[ée]cnica|etiqueta/gi;
 
 /**
  * Guard 4 — dosis sin fuente (PARCIAL: suaviza, no borra). Si el texto da una
@@ -2300,10 +2317,18 @@ export function guardDoseWithoutSource(responseText, _resolvedEntities = null, _
   if (doses.length === 0) {
     return { text: responseText, modified: false, reason: null };
   }
-  // Si ya hay cita de fuente en el texto, asumimos respaldo → no suavizar.
-  if (SOURCE_HINT_RE.test(responseText)) {
+
+  // CRÍTICO: Solo si hay una fuente VERIFICADA en el texto, asumimos respaldo.
+  // El SOURCE_HINT_RE ahora solo matchea fuentes de la allowlist verificada.
+  // Si el modelo inventa "según una recomendación del ICA" con un decreto falso,
+  // SOURCE_HINT_RE matcheará "ICA" (que está en la allowlist) pero esto es seguro:
+  // si menciona ICA, el usuario puede verificar. Lo peligroso es NO mencionar
+  // fuente alguna.
+  const hasVerifiedSource = SOURCE_HINT_RE.test(responseText);
+  if (hasVerifiedSource) {
     return { text: responseText, modified: false, reason: null };
   }
+
   // Evitar duplicar la nota si ya está.
   if (/confirma la dosis con/i.test(responseText)) {
     return { text: responseText, modified: false, reason: null };
@@ -2315,6 +2340,135 @@ export function guardDoseWithoutSource(responseText, _resolvedEntities = null, _
     'antes de aplicar — las cantidades varían según el producto y no conviene guiarse por una cifra sin fuente.';
   const text = `${responseText.trim()}\n\n${nota}`;
   return { text, modified: true, reason: `dosis_sin_fuente: ${[...new Set(doses)].slice(0, 5).join(', ')}` };
+}
+
+// ── GUARD: contacto inventado (teléfonos, correos, URLs, decretos) ──
+
+/**
+ * Allowlist de contactos VERIFICADOS oficiales. Solo estos contactos pueden
+ * aparecer en la respuesta sin ser marcados como inventados.
+ */
+const VERIFIED_CONTACTS_ALLOWLIST = new Set([
+  // URLs oficiales verificadas
+  'www.gov.co',
+  'www.ica.gov.co',
+  'www.minagricultura.gov.co',
+  'www.agrosavia.co',
+  'www.cenicafe.org',
+  // No incluimos teléfonos/correos específicos porque el modelo puede inventar variaciones
+  // Si el usuario necesita un contacto oficial, debe buscarlo en los sitios oficiales
+]);
+
+/**
+ * Regex para detectar teléfonos colombianos. Formatos:
+ * - (+57) 300 123 4567
+ * - 300 123 4567
+ * - 300-123-4567
+ * - (300) 123 4567
+ */
+const PHONE_RE =
+  /(?:\+57\s?)?(\(?3\d{2}\)?[-\s]?\d{3}[-\s]?\d{4}|\d{3}[-\s]?\d{7})/g;
+
+/**
+ * Regex para detectar correos electrónicos.
+ */
+const EMAIL_RE =
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g;
+
+/**
+ * Regex para detectar URLs (http, https, www).
+ */
+const URL_RE =
+  /\b(?:https?:\/\/|www\.)[A-Z|a-z|0-9|-]{2,}\.[A-Z|a-z]{2,}(?:\/[^\s]*)?\b/g;
+
+/**
+ * Regex para detectar números de decreto/resolución. Formatos:
+ * - Decreto 1234 de 2015
+ * - Resolución 567 de 2020
+ * - Decreto No. 890
+ */
+const DECREE_RE =
+  /\b(?:Decreto|Resolución|Res|Dec\.|Decreto\s+No\.?)\s*(?:\d+|[IVXLCDM]+)(?:\s+de\s+\d{4})?\b/gi;
+
+/**
+ * Guard 5 — contacto inventado. Si el texto incluye teléfonos, correos,
+ * URLs o números de decreto/resolución que NO estén en la allowlist
+ * verificada, los MARCA/REEMPLAZA por un texto seguro que indica al
+ * usuario que verifique el contacto oficial con su UMATA o el ICA.
+ *
+ * Este es un guard de SEGURIDAD porque el modelo puede inventar contactos
+ * institucionales falsos para reportar plagas cuarentenarias, aplicar
+ * agroquímicos, o tramitar trámites, lo cual puede llevar al usuario a
+ * contactos fraudulentos o inexistentes.
+ *
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardInventedContact(responseText, _resolvedEntities = null, _fincaAltitud = null) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+
+  let modified = false;
+  let inventedContacts = [];
+  let text = responseText;
+
+  // Detectar teléfonos
+  const phones = text.match(PHONE_RE) || [];
+  for (const phone of phones) {
+    // Normalizar el teléfono para comparar (remover espacios, guiones, paréntesis)
+    const normalizedPhone = phone.replace(/[\s\-()]/g, '');
+    // Verificar si NO está en la allowlist (la allowlist está vacía para teléfonos)
+    if (!VERIFIED_CONTACTS_ALLOWLIST.has(normalizedPhone)) {
+      inventedContacts.push(`teléfono: ${phone}`);
+      text = text.replace(phone, '[VERIFICAR CONTACTO OFICIAL CON SU UMATA O EL ICA]');
+      modified = true;
+    }
+  }
+
+  // Detectar correos
+  const emails = text.match(EMAIL_RE) || [];
+  for (const email of emails) {
+    if (!VERIFIED_CONTACTS_ALLOWLIST.has(email.toLowerCase())) {
+      inventedContacts.push(`correo: ${email}`);
+      text = text.replace(email, '[VERIFICAR CONTACTO OFICIAL CON SU UMATA O EL ICA]');
+      modified = true;
+    }
+  }
+
+  // Detectar URLs
+  const urls = text.match(URL_RE) || [];
+  for (const url of urls) {
+    const normalizedUrl = url.replace(/^https?:\/\//, '').replace(/^www\./, '').split('/')[0].toLowerCase();
+    if (!VERIFIED_CONTACTS_ALLOWLIST.has(normalizedUrl)) {
+      inventedContacts.push(`URL: ${url}`);
+      text = text.replace(url, '[VERIFICAR CONTACTO OFICIAL CON SU UMATA O EL ICA]');
+      modified = true;
+    }
+  }
+
+  // Detectar decretos/resoluciones
+  const decrees = text.match(DECREE_RE) || [];
+  for (const decree of decrees) {
+    // Solo algunos decretos específicos están verificados
+    // Por ejemplo, Ley 1930 de 2018 es conocida, pero otros pueden ser inventados
+    const isKnownDecree = /Ley\s+1930|Ley\s+2041|Decreto\s+1071/i.test(decree);
+    if (!isKnownDecree) {
+      inventedContacts.push(`normativa: ${decree}`);
+      text = text.replace(decree, '[VERIFICAR NORMATIVA OFICIAL CON SU UMATA O EL ICA]');
+      modified = true;
+    }
+  }
+
+  if (modified) {
+    bumpGuardTelemetry('invented_contact');
+    return {
+      text,
+      modified: true,
+      reason: `contacto_inventado: ${[...new Set(inventedContacts)].slice(0, 5).join(', ')}`,
+    };
+  }
+
+  return { text: responseText, modified: false, reason: null };
 }
 
 // ── GUARD: receta EXACTA de caldo clásico pedida en dosis (BORDE-003 / 004) ──
@@ -9075,6 +9229,18 @@ export function applyOutputGuards(
     text = brandRes.text;
     modified = true;
     if (brandRes.reason) reasons.push(brandRes.reason);
+  }
+  // Guard SAFETY de CONTACTO INVENTADO (teléfonos, correos, URLs, decretos):
+  // firma propia (solo el texto). Corre SIEMPRE (no es de siembra). SUPPRESS-AND-REPLACE:
+  // si el cuerpo incluye teléfonos, correos, URLs o números de decreto/resolución
+  // que NO estén en la allowlist verificada, los reemplaza por un texto seguro que
+  // indica al usuario que verifique el contacto oficial con su UMATA o el ICA.
+  // Va tras la marca inventada. Idempotente.
+  const contactRes = guardInventedContact(text);
+  if (contactRes && contactRes.modified) {
+    text = contactRes.text;
+    modified = true;
+    if (contactRes.reason) reasons.push(contactRes.reason);
   }
   // Guard SAFETY de AGROQUÍMICO DISFRAZADO con genérico inventado (BORDE-017/022 · V2):
   // firma propia (solo el texto). Corre SIEMPRE (no es de siembra). SUPPRESS-AND-REPLACE:


### PR DESCRIPTION
## Summary

Este PR corrige dos bloqueantes de seguridad identificados en los output guards del agente (#guardrail-contacts):

### Problema #1: NINGUN guard detecta telefonos/URLs/correos/numeros-de-decreto INVENTADOS
El modelo invento un telefono institucional para reportar una plaga cuarentenaria y paso intacto.

**Solucion**: Implementa guardInventedContact que:
- Detecta telefonos colombianos (formatos: +57 300 123 4567, 300 123 4567, (300) 123-4567)
- Detecta correos electronicos
- Detecta URLs (http, https, www)
- Detecta numeros de decreto/resolucion
- Reemplaza contactos NO verificados por un texto seguro: '[VERIFICAR CONTACTO OFICIAL CON SU UMATA O EL ICA]'
- Allowlist de contactos verificados: www.gov.co, www.ica.gov.co, www.minagricultura.gov.co, www.agrosavia.co, www.cenicafe.org
- No incluye telefonos/correos especificos porque el modelo puede inventar variaciones

### Problema #2: guardDoseWithoutSource esta INVERTIDO
Una cita fabricada SUPRIME el caveat de dosis (proteccion al reves).

**Solucion**: Corrige la logica de guardDoseWithoutSource para:
- Solo confiar en fuentes de una allowlist verificada explicita (ICA, Agrosavia, Cenicafe, Restrepo, catalogo Chagra, etiqueta, ficha tecnica)
- Una cita generica como 'seguna una recomendacion de la entidad' NO suprime el caveat
- Corrige SOURCE_HINT_RE para que sea mas especifico y solo matchee fuentes de la allowlist

## Test plan

Tests agregados en src/services/__tests__/outputGuards.test.js:

### guardInventedContact:
- detecta y reemplaza telefono inventado: reemplaza telefono institucional falso
- detecta y reemplaza correo inventado: reemplaza correo falso
- detecta y reemplaza URL inventada: reemplaza URL falsa
- detecta y reemplaza decreto/resolucion inventado: reemplaza decreto falso
- NO toca Ley 1930 (decreto verificado conocido): no modifica decretos verificados
- detecta multiples contactos inventados: detecta varios contactos en un texto
- NO dispara si no hay contactos: no modifica texto sin contactos
- detecta telefono con formato (+57): detecta formato internacional
- detecta telefono con parentesis: detecta formato con parentesis

### guardDoseWithoutSource (correccion de logica invertida):
- ANADE caveat incluso si el modelo inventa una cita generica de fuente: cita fabricada NO suprime caveat
- ANADE caveat si cita un decreto inventado: decreto falso NO suprime caveat
- NO suaviza si cita ICA (fuente verificada): ICA es fuente valida
- NO suaviza si cita Agrosavia (fuente verificada): Agrosavia es fuente valida

## Verification

- npx vitest run (706 tests passed, 2 skipped)
- npx eslint . --max-warnings=0 (0 warnings)
- npm run build (built successfully)

## MCP tools used

No se usaron MCP tools para este fix (es pura logica de seguridad determinista).

## Risks conocidos

- El guardInventedContact puede tener falsos positivos si el modelo menciona un telefono/URL real pero no esta en la allowlist (ej: una UMATA local). Esto es conservador por diseño: mejor pedir verificacion que dejar un contacto falso.
- El SOURCE_HINT_RE mas estricto puede hacer que guardDoseWithoutSource dispare mas frecuentemente, incluso cuando el modelo cita una fuente real pero con un formato diferente. Esto es seguro: el caveat dice 'confirma con la etiqueta', no borra la dosis.