### PR TITLE
feat(ciclo-vivo): widget "El Ciclo Vivo" cableado a la fuente de verdad

### DIFF
--- a/public/chagra-stats.json
+++ b/public/chagra-stats.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-01T19:10:38.824Z",
-  "schema_version": "1.0.0",
+  "generated_at": "2026-07-01T22:14:55.258Z",
+  "schema_version": "1.1.0",
   "catalogo": {
     "especies": 530,
     "biopreparados": 36,
@@ -113,6 +113,128 @@
         "numerador": null,
         "denominador": null
       }
+    }
+  },
+  "capacidades": {
+    "que_siembro": {
+      "estado": "activo",
+      "nota": "Qué sembrar según su piso térmico, desde el directorio de especies.",
+      "view": "directorio"
+    },
+    "calendario_siembra": {
+      "estado": "activo",
+      "nota": "Calendario por ciclos con plantillas fenológicas.",
+      "view": "calendario_finca"
+    },
+    "viabilidad_semilla": {
+      "estado": "proximamente",
+      "nota": "Prueba de viabilidad de semilla guiada; aún no está disponible.",
+      "view": null
+    },
+    "saberes": {
+      "estado": "parcial",
+      "nota": "Saberes de origen en la ficha; cobertura del catálogo todavía escasa.",
+      "view": "directorio"
+    },
+    "semilleros": {
+      "estado": "activo",
+      "nota": "Guía y registro de semilleros por especie.",
+      "view": "germinacion"
+    },
+    "riego_agua": {
+      "estado": "parcial",
+      "nota": "Diagnóstico de agua y recordatorio de riego vía el agente; sin pantalla propia.",
+      "view": "agente"
+    },
+    "cromatografia_suelo": {
+      "estado": "activo",
+      "nota": "Guía, registro con foto y comparación temporal; interpretación manual, sin IA.",
+      "view": "cromatografia"
+    },
+    "biopreparados": {
+      "estado": "activo",
+      "nota": "Galería de recetas con diagramas y datos de seguridad.",
+      "view": "biopreparados"
+    },
+    "diagnostico_foto": {
+      "estado": "activo",
+      "nota": "Tómele foto y el agente diagnostica con visión y contexto del catálogo.",
+      "view": "agente"
+    },
+    "mip_plagas": {
+      "estado": "parcial",
+      "nota": "Plagas y control biológico en la ficha; cobertura del grafo incompleta.",
+      "view": "directorio"
+    },
+    "nutricion": {
+      "estado": "activo",
+      "nota": "Ciclo de nutrientes con guía por etapa.",
+      "view": "ciclo_nutrientes"
+    },
+    "asociaciones": {
+      "estado": "activo",
+      "nota": "Asociaciones y antagonismos entre cultivos.",
+      "view": "asociaciones"
+    },
+    "fenologia": {
+      "estado": "activo",
+      "nota": "Deriva y confirma la etapa fenológica con línea de tiempo.",
+      "view": "ciclo"
+    },
+    "polinizacion": {
+      "estado": "activo",
+      "nota": "Abejas y polinización con registro de colmena.",
+      "view": "animales_abejas"
+    },
+    "clima": {
+      "estado": "parcial",
+      "nota": "Alertas de clima y heladas; el canal en vivo depende de disponibilidad.",
+      "view": "agente"
+    },
+    "insumos": {
+      "estado": "activo",
+      "nota": "Registro de insumos aplicados al cultivo.",
+      "view": "insumos"
+    },
+    "registrar_cosecha": {
+      "estado": "activo",
+      "nota": "Registro de cosecha por planta o lote.",
+      "view": "cosechar"
+    },
+    "precio_sipsa": {
+      "estado": "parcial",
+      "nota": "Precio de referencia DANE-SIPSA en foto estática; canal en vivo tras flag.",
+      "view": "mercado"
+    },
+    "mercado": {
+      "estado": "activo",
+      "nota": "Marketplace de circuitos cortos, sin precios inventados.",
+      "view": "mercado"
+    },
+    "guardar_semilla": {
+      "estado": "proximamente",
+      "nota": "Banco de semilla propia con trazabilidad; aún no está disponible.",
+      "view": null
+    },
+    "ciclo_cerrado": {
+      "estado": "parcial",
+      "nota": "Devolver nutrientes al suelo; hoy educativo, sin recomendación automática.",
+      "view": "ciclo_nutrientes"
+    },
+    "bitacora": {
+      "estado": "activo",
+      "nota": "Bitácora de la finca; el ciclo de aprendizaje automático está en camino.",
+      "view": "bitacora"
+    },
+    "rag_grounding": {
+      "estado": "parcial",
+      "nota": "El agente responde apoyado en el corpus; verificación por DOI en expansión.",
+      "view": "agente"
+    },
+    "action_loop": {
+      "estado": "parcial",
+      "nota": "Ejecuta acciones (registrar, agendar) con su confirmación; nivel 1.",
+      "view": "agente"
     }
   },
   "verificacion": {

--- a/scripts/__tests__/gen-chagra-stats.test.mjs
+++ b/scripts/__tests__/gen-chagra-stats.test.mjs
@@ -15,7 +15,9 @@ import { dirname, join } from 'node:path';
 import {
   computeCatalogStats,
   computeGraphStats,
+  computeCapabilities,
   buildStats,
+  CAPABILITIES_STATUS,
   DEFAULT_CATALOG_PATH,
   DEFAULT_GRAPH_SNAPSHOT_PATH,
   DEFAULT_OUTPUT_PATH,
@@ -111,10 +113,27 @@ describe('buildStats', () => {
 
   it('tiene el schema top-level esperado', () => {
     expect(Object.keys(stats).sort()).toEqual(
-      ['_fuente', 'catalogo', 'generated_at', 'grafo', 'schema_version', 'verificacion'].sort(),
+      ['_fuente', 'capacidades', 'catalogo', 'generated_at', 'grafo', 'schema_version', 'verificacion'].sort(),
     );
     expect(stats.schema_version).toBe(SCHEMA_VERSION);
     expect(stats.generated_at).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('incluye el bloque capacidades con las 13 funciones nombradas del pedido', () => {
+    const nombradas = [
+      'diagnostico_foto', 'mip_plagas', 'biopreparados', 'calendario_siembra', 'fenologia',
+      'riego_agua', 'nutricion', 'polinizacion', 'precio_sipsa', 'cromatografia_suelo',
+      'saberes', 'rag_grounding', 'action_loop',
+    ];
+    for (const id of nombradas) {
+      expect(stats.capacidades[id], `falta capacidad ${id}`).toBeTruthy();
+      expect(['activo', 'parcial', 'proximamente']).toContain(stats.capacidades[id].estado);
+    }
+    // Estados verificados contra el código (auditoría 2026-07-01).
+    expect(stats.capacidades.precio_sipsa.estado).toBe('parcial');
+    expect(stats.capacidades.rag_grounding.estado).toBe('parcial');
+    expect(stats.capacidades.action_loop.estado).toBe('parcial');
+    expect(stats.capacidades.biopreparados.estado).toBe('activo');
   });
 
   it('calcula verificacion.doi_pct desde controls (no lo repite del snapshot)', () => {
@@ -138,6 +157,43 @@ describe('buildStats', () => {
     // estricto, más abajo — ver describe('anti-leak — mecanismo interno...').
     const json = JSON.stringify(stats);
     expect(json).not.toMatch(/10\.88\.|password|token|bearer|secret|chagra-pro/i);
+  });
+});
+
+describe('computeCapabilities', () => {
+  it('devuelve un objeto keyed by id con estado/nota/view', () => {
+    const caps = computeCapabilities();
+    expect(Object.keys(caps).length).toBe(CAPABILITIES_STATUS.length);
+    for (const [id, c] of Object.entries(caps)) {
+      expect(typeof id).toBe('string');
+      expect(['activo', 'parcial', 'proximamente']).toContain(c.estado);
+      expect(c).toHaveProperty('nota');
+      expect(c).toHaveProperty('view');
+    }
+  });
+
+  it('cubre las tres categorías de estado (activo, parcial y proximamente)', () => {
+    const caps = computeCapabilities();
+    const estados = new Set(Object.values(caps).map((c) => c.estado));
+    expect(estados.has('activo')).toBe(true);
+    expect(estados.has('parcial')).toBe(true);
+    expect(estados.has('proximamente')).toBe(true);
+  });
+
+  it('falla ruidoso ante un estado inválido (evita shippear un chip impintable)', () => {
+    expect(() => computeCapabilities([{ id: 'x', estado: 'listo', nota: '' }])).toThrow(/estado inválido/);
+  });
+
+  it('falla ante ids duplicados', () => {
+    expect(() => computeCapabilities([
+      { id: 'x', estado: 'activo', nota: '' },
+      { id: 'x', estado: 'parcial', nota: '' },
+    ])).toThrow(/duplicado/);
+  });
+
+  it('no filtra infraestructura en las notas (anti-leak)', () => {
+    const json = JSON.stringify(computeCapabilities());
+    expect(json).not.toMatch(/alpha|postgres|chagra_kg|farmos|10\.88\.|sidecar/i);
   });
 });
 

--- a/scripts/gen-chagra-stats.mjs
+++ b/scripts/gen-chagra-stats.mjs
@@ -74,7 +74,127 @@ export const DEFAULT_CATALOG_PATH = join(ROOT, 'catalog/chagra-catalog-oss-subse
 export const DEFAULT_GRAPH_SNAPSHOT_PATH = join(ROOT, 'src/data/graph-stats-snapshot.json');
 export const DEFAULT_OUTPUT_PATH = join(ROOT, 'public/chagra-stats.json');
 
-export const SCHEMA_VERSION = '1.0.0';
+// 1.1.0 agrega el bloque `capacidades` (estado real por función del ciclo de
+// vida) que consume el widget "El Ciclo Vivo". Aditivo: no rompe consumidores
+// del schema 1.0.0 (WelcomeStatsHero, chagra.bio) — solo agrega una clave.
+export const SCHEMA_VERSION = '1.1.0';
+
+// =============================================================================
+// Capacidades del ciclo de vida — FUENTE ÚNICA DE VERDAD del estado real de
+// cada función que muestra el widget "El Ciclo Vivo" (src/components/CicloVivo).
+//
+// Este bloque es el "interruptor" del pedido del operador: el widget pinta cada
+// chip según el `estado` que se declara AQUÍ. Cuando un artefacto que hoy está
+// 'parcial' o 'proximamente' se termina, se cambia SU estado a 'activo' en esta
+// tabla, se corre `npm run gen:stats` (o el prebuild), y el chip se enciende
+// solo en la UI — sin tocar el componente del widget. Ese es el corazón del
+// diseño: la UI es un reflejo de esta tabla, no una lista hardcodeada aparte.
+//
+// Estados:
+//   'activo'       -> función navegable y funcional end-to-end. Chip encendido,
+//                    navega a `view`.
+//   'parcial'      -> existe pero con stub / dato estático / cobertura incompleta
+//                    / canal en vivo tras flag. Chip atenuado con badge "parcial"
+//                    (sigue navegando si trae `view`).
+//   'proximamente' -> todavía no construido. Chip fantasma con "pronto", no navega.
+//
+// Los estados se asignaron VERIFICANDO el código (auditoría 2026-07-01), no por
+// suposición — regla dura anti-invento del repo. `view` es el slug del router
+// (App.jsx) al que navega el chip cuando aplica.
+//
+// Anti-leak: esta tabla es PÚBLICA (va a public/chagra-stats.json). Solo estados
+// y notas de producto en lenguaje de usuario. Prohibido nombres de host, rutas
+// de infraestructura, nombres de contenedor o de la base del grafo.
+// =============================================================================
+export const CAPABILITIES_STATUS = [
+  // -- Fase Semilla ----------------------------------------------------------
+  { id: 'que_siembro', estado: 'activo', view: 'directorio',
+    nota: 'Qué sembrar según su piso térmico, desde el directorio de especies.' },
+  { id: 'calendario_siembra', estado: 'activo', view: 'calendario_finca',
+    nota: 'Calendario por ciclos con plantillas fenológicas.' },
+  { id: 'viabilidad_semilla', estado: 'proximamente', view: null,
+    nota: 'Prueba de viabilidad de semilla guiada; aún no está disponible.' },
+  { id: 'saberes', estado: 'parcial', view: 'directorio',
+    nota: 'Saberes de origen en la ficha; cobertura del catálogo todavía escasa.' },
+
+  // -- Fase Germinación ------------------------------------------------------
+  { id: 'semilleros', estado: 'activo', view: 'germinacion',
+    nota: 'Guía y registro de semilleros por especie.' },
+  { id: 'riego_agua', estado: 'parcial', view: 'agente',
+    nota: 'Diagnóstico de agua y recordatorio de riego vía el agente; sin pantalla propia.' },
+  { id: 'cromatografia_suelo', estado: 'activo', view: 'cromatografia',
+    nota: 'Guía, registro con foto y comparación temporal; interpretación manual, sin IA.' },
+  { id: 'biopreparados', estado: 'activo', view: 'biopreparados',
+    nota: 'Galería de recetas con diagramas y datos de seguridad.' },
+
+  // -- Fase Crecimiento ------------------------------------------------------
+  { id: 'diagnostico_foto', estado: 'activo', view: 'agente',
+    nota: 'Tómele foto y el agente diagnostica con visión y contexto del catálogo.' },
+  { id: 'mip_plagas', estado: 'parcial', view: 'directorio',
+    nota: 'Plagas y control biológico en la ficha; cobertura del grafo incompleta.' },
+  { id: 'nutricion', estado: 'activo', view: 'ciclo_nutrientes',
+    nota: 'Ciclo de nutrientes con guía por etapa.' },
+  { id: 'asociaciones', estado: 'activo', view: 'asociaciones',
+    nota: 'Asociaciones y antagonismos entre cultivos.' },
+  { id: 'fenologia', estado: 'activo', view: 'ciclo',
+    nota: 'Deriva y confirma la etapa fenológica con línea de tiempo.' },
+
+  // -- Fase Floración --------------------------------------------------------
+  { id: 'polinizacion', estado: 'activo', view: 'animales_abejas',
+    nota: 'Abejas y polinización con registro de colmena.' },
+  { id: 'clima', estado: 'parcial', view: 'agente',
+    nota: 'Alertas de clima y heladas; el canal en vivo depende de disponibilidad.' },
+
+  // -- Fase Fructificación ---------------------------------------------------
+  { id: 'insumos', estado: 'activo', view: 'insumos',
+    nota: 'Registro de insumos aplicados al cultivo.' },
+
+  // -- Fase Cosecha ----------------------------------------------------------
+  { id: 'registrar_cosecha', estado: 'activo', view: 'cosechar',
+    nota: 'Registro de cosecha por planta o lote.' },
+  { id: 'precio_sipsa', estado: 'parcial', view: 'mercado',
+    nota: 'Precio de referencia DANE-SIPSA en foto estática; canal en vivo tras flag.' },
+  { id: 'mercado', estado: 'activo', view: 'mercado',
+    nota: 'Marketplace de circuitos cortos, sin precios inventados.' },
+
+  // -- Fase Poscosecha -------------------------------------------------------
+  { id: 'guardar_semilla', estado: 'proximamente', view: null,
+    nota: 'Banco de semilla propia con trazabilidad; aún no está disponible.' },
+  { id: 'ciclo_cerrado', estado: 'parcial', view: 'ciclo_nutrientes',
+    nota: 'Devolver nutrientes al suelo; hoy educativo, sin recomendación automática.' },
+  { id: 'bitacora', estado: 'activo', view: 'bitacora',
+    nota: 'Bitácora de la finca; el ciclo de aprendizaje automático está en camino.' },
+
+  // -- Motor del agente (transversal, no es un chip de fase) -----------------
+  { id: 'rag_grounding', estado: 'parcial', view: 'agente',
+    nota: 'El agente responde apoyado en el corpus; verificación por DOI en expansión.' },
+  { id: 'action_loop', estado: 'parcial', view: 'agente',
+    nota: 'Ejecuta acciones (registrar, agendar) con su confirmación; nivel 1.' },
+];
+
+const CAPABILITY_ESTADOS = new Set(['activo', 'parcial', 'proximamente']);
+
+/**
+ * Construye el mapa `capacidades` (keyed by id) que va al JSON público. Puro:
+ * no toca disco. Valida que cada estado sea uno de los tres permitidos (falla
+ * ruidoso ante un typo, en vez de shippear un estado que el widget no sabe
+ * pintar). Devuelve un objeto en el mismo orden de declaración.
+ *
+ * @param {Array<{id:string, estado:string, nota:string, view?:string|null}>} [decls]
+ * @returns {Record<string, {estado:string, nota:string, view:string|null}>}
+ */
+export function computeCapabilities(decls = CAPABILITIES_STATUS) {
+  const out = {};
+  for (const c of decls) {
+    if (!c || !c.id) throw new Error('[capacidades] declaración sin id');
+    if (!CAPABILITY_ESTADOS.has(c.estado)) {
+      throw new Error(`[capacidades] estado inválido "${c.estado}" en "${c.id}"`);
+    }
+    if (out[c.id]) throw new Error(`[capacidades] id duplicado "${c.id}"`);
+    out[c.id] = { estado: c.estado, nota: c.nota || '', view: c.view || null };
+  }
+  return out;
+}
 
 // =============================================================================
 // Helpers puros
@@ -175,6 +295,10 @@ export function buildStats({ catalog, graphSnapshot, generatedAt }) {
     schema_version: SCHEMA_VERSION,
     catalogo,
     grafo,
+    // Estado real por función del ciclo de vida — lo consume el widget
+    // "El Ciclo Vivo" para encender/atenuar/apagar cada chip. Ver
+    // CAPABILITIES_STATUS arriba (único lugar donde se cambia un estado).
+    capacidades: computeCapabilities(),
     verificacion: {
       // Moat del producto: % de aristas CONTROLS (biopreparado -> plaga)
       // corroboradas contra OpenAlex con DOI real. Ver auditoría 2026-06-28.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -105,6 +105,7 @@ const CalendarioFincaScreen = lazy(() => import('./components/CalendarioFincaScr
 const SeguimientoProcesoScreen = lazy(() => import('./components/SeguimientoProcesoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
 const CromatografiaScreen = lazy(() => import('./components/CromatografiaScreen'));
+const CicloVivoFullView = lazy(() => import('./components/CicloVivo/CicloVivoFullView'));
 const ToxicologiaScreen = lazy(() => import('./components/ToxicologiaScreen'));
 const MercadosScreen = lazy(() => import('./components/MercadosScreen'));
 const GlaciarReporteScreen = lazy(() => import('./components/GlaciarReporteScreen'));
@@ -155,6 +156,7 @@ const LoadingFallback = () => (
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
+  'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
   inventario: 'activos',
   activos: 'activos',
@@ -209,7 +211,7 @@ const MODULE_VIEWS = new Set([
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
-  'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia',
+  'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
   'usage_stats', 'mercado', 'auditoria_inventario',
 ]);
 
@@ -1231,6 +1233,16 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Cromatografia de Suelo">
               <CromatografiaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'ciclo_vivo':
+        // "El Ciclo Vivo": la rueda de las 7 fases. Cada chip de función se
+        // pinta según su estado real en la fuente de verdad (chagra-stats.json).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El Ciclo Vivo">
+              <CicloVivoFullView onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/CicloVivo/CicloVivoFullView.jsx
+++ b/src/components/CicloVivo/CicloVivoFullView.jsx
@@ -1,0 +1,353 @@
+/**
+ * CicloVivoFullView.jsx — vista full-screen de "El Ciclo Vivo" (rueda v3).
+ * =====================================================================
+ * La planta ES la rueda: la raíz (especie) en el centro, el tallo espirala por
+ * las 7 fases. Cada fase abre un panel con sus chips de función, y cada chip se
+ * pinta según su ESTADO REAL, que sale de la fuente única de verdad
+ * `/chagra-stats.json` → `capacidades` (ver hooks/useChagraStats +
+ * scripts/gen-chagra-stats.mjs). Cuando un artefacto pasa a 'activo' en esa
+ * tabla, su chip se enciende solo — sin tocar este componente.
+ *
+ * Especie: automática por piso térmico, con override que se guarda en el perfil.
+ * Estética: port 1:1 de la v3 aprobada (cicloVivo.css + cicloVivoWheel).
+ */
+import { useEffect, useRef, useState, useCallback } from 'react';
+import './cicloVivo.css';
+import { GLYPHS, EYE_SVG_INNER } from './cicloVivoArte';
+import { buildWheelSvg } from './cicloVivoWheel';
+import {
+  PHASES, SPECIES, SPECIES_ORDER, MOTOR_CAPS, WHEEL_CAPTION, DEFAULT_PHASE_INDEX,
+  resolverEspecie, resolverEstado, ESTADO_BADGE,
+} from './cicloVivoData';
+import { useChagraStats } from '../../hooks/useChagraStats';
+import { getProfile, saveProfile } from '../../services/userProfileService';
+import { pisoTermicoFromAltitud } from '../../data/cropSuggestions';
+import { getDeviceAltitude } from '../../services/altitudeService';
+
+const PISO_LABEL = { calido: 'Cálido', templado: 'Templado', frio: 'Frío', paramo: 'Páramo' };
+const PROFILE_ESPECIE_KEY = 'ciclo_vivo_especie';
+
+/* ---- Iconos utilitarios (misma familia de trazo redondo de la v3) ---- */
+function Chev({ color = '#C98A3D', size = 17 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M9.2,5.4 L15.8,12 L9.2,18.6" fill="none" stroke={color} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function ChevL({ color = '#6B5A47', size = 12 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M14.8,5.4 L8.2,12 L14.8,18.6" fill="none" stroke={color} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function CameraIco() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4,7.5 L8.4,7.5 L10,5.2 L14,5.2 L15.6,7.5 L20,7.5 Q21.5,7.5 21.5,9 L21.5,17.5 Q21.5,19 20,19 L4,19 Q2.5,19 2.5,17.5 L2.5,9 Q2.5,7.5 4,7.5 Z" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinejoin="round" />
+      <circle cx="12" cy="13" r="3.4" fill="none" stroke="currentColor" strokeWidth="1.9" />
+      <circle cx="18.6" cy="10.1" r=".95" fill="currentColor" />
+    </svg>
+  );
+}
+/** Glifo de fase (inner SVG generado por GLYPHS[key]). */
+function PhaseGlyph({ phaseKey, color, size, viewBox }) {
+  return (
+    <svg width={size} height={size} viewBox={viewBox} aria-hidden="true"
+      dangerouslySetInnerHTML={{ __html: GLYPHS[phaseKey](color) }} />
+  );
+}
+
+export default function CicloVivoFullView({ onBack, onNavigate }) {
+  const { data: stats } = useChagraStats();
+  const capacidades = stats && stats.capacidades ? stats.capacidades : null;
+
+  // Especie + piso térmico. Piso: perfil primero; altitud del dispositivo como
+  // refinamiento best-effort (no bloquea el render). Se lee una sola vez.
+  const [profile] = useState(() => { try { return getProfile() || {}; } catch { return {}; } });
+  const [piso, setPiso] = useState(() => {
+    if (profile.piso_termico && PISO_LABEL[profile.piso_termico]) return profile.piso_termico;
+    return pisoTermicoFromAltitud(profile.finca_altitud);
+  });
+  const [altitud, setAltitud] = useState(() => {
+    const n = Number(profile.finca_altitud);
+    return Number.isFinite(n) && n > 0 ? Math.round(n) : null;
+  });
+  const [spKey, setSpKey] = useState(() => resolverEspecie(profile[PROFILE_ESPECIE_KEY], piso));
+
+  // Si el perfil no trae altitud, intentamos la del dispositivo (best-effort).
+  useEffect(() => {
+    if (altitud != null) return undefined;
+    let alive = true;
+    getDeviceAltitude().then((m) => {
+      if (!alive || m == null) return;
+      const p = pisoTermicoFromAltitud(m);
+      setAltitud(Math.round(m));
+      if (p) {
+        setPiso(p);
+        // Solo re-sugerimos la especie si el usuario no tiene override propio.
+        if (!profile[PROFILE_ESPECIE_KEY]) setSpKey((prev) => resolverEspecie(null, p) || prev);
+      }
+    }).catch(() => {});
+    return () => { alive = false; };
+  }, [altitud, profile]);
+
+  const [faseActiva, setFaseActiva] = useState(DEFAULT_PHASE_INDEX);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [panelIndex, setPanelIndex] = useState(DEFAULT_PHASE_INDEX);
+  const [toast, setToast] = useState('');
+  const toastTimer = useRef(null);
+  const wheelRef = useRef(null);
+
+  const sp = SPECIES[spKey] || SPECIES.maiz;
+
+  const showToast = useCallback((msg) => {
+    setToast(msg);
+    clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(''), 2600);
+  }, []);
+  useEffect(() => () => clearTimeout(toastTimer.current), []);
+
+  const openPanel = useCallback((i) => {
+    setPanelIndex(i);
+    setFaseActiva(i);
+    setPanelOpen(true);
+  }, []);
+  const closePanel = useCallback(() => setPanelOpen(false), []);
+
+  // Inyecta el SVG de la rueda de forma imperativa (como la v3) y delega los
+  // clics de nodo por `data-idx`. Se reconstruye al cambiar especie o fase.
+  useEffect(() => {
+    const el = wheelRef.current;
+    if (!el) return undefined;
+    el.innerHTML = buildWheelSvg({ spKey, faseActiva });
+    const onClick = (e) => {
+      const node = e.target.closest('.cv-wnode');
+      if (node) openPanel(Number(node.getAttribute('data-idx')));
+    };
+    const onKey = (e) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      const node = e.target.closest('.cv-wnode');
+      if (node) { e.preventDefault(); openPanel(Number(node.getAttribute('data-idx'))); }
+    };
+    el.addEventListener('click', onClick);
+    el.addEventListener('keydown', onKey);
+    return () => {
+      el.removeEventListener('click', onClick);
+      el.removeEventListener('keydown', onKey);
+    };
+  }, [spKey, faseActiva, openPanel]);
+
+  const cambiarEspecie = useCallback((key) => {
+    if (!SPECIES[key]) return;
+    setSpKey(key);
+    try { saveProfile({ [PROFILE_ESPECIE_KEY]: key }); } catch { /* perfil no disponible: no bloquea */ }
+    showToast('Listo: ahora ve el ciclo de ' + SPECIES[key].su.toLowerCase() + '.');
+  }, [showToast]);
+
+  const navegarCap = useCallback((estado, view, label) => {
+    if (estado === 'proximamente') {
+      showToast('«' + label + '» está en camino. Se lo avisamos cuando lo activemos.');
+      return;
+    }
+    if (view && onNavigate) { onNavigate(view); return; }
+    showToast('«' + label + '»: pronto podrá abrirlo desde aquí.');
+  }, [onNavigate, showToast]);
+
+  const curPhase = PHASES[faseActiva];
+
+  return (
+    <div className="cvivo-root">
+      <div className="cvivo-fullscreen">
+        <div className="cvivo-header">
+          <button className="cvivo-back" onClick={onBack} aria-label="Volver al inicio">
+            <ChevL color="#2F4A34" size={15} />
+          </button>
+          <div className="cvivo-floor-chip">
+            <svg width="12" height="12" viewBox="0 0 24 24" aria-hidden="true">
+              <g stroke="#4A7BA0" strokeWidth="1.7" strokeLinecap="round" fill="none">
+                <path d="M12,3 L12,21 M4.2,7.5 L19.8,16.5 M4.2,16.5 L19.8,7.5" />
+                <path d="M9.8,4.6 L12,6.8 L14.2,4.6 M9.8,19.4 L12,17.2 L14.2,19.4" />
+              </g>
+            </svg>
+            {piso ? PISO_LABEL[piso] : 'Piso térmico'}{altitud != null ? ' · ' + altitud + ' m' : ''}
+          </div>
+          <select
+            className="cvivo-species-select"
+            value={spKey}
+            onChange={(e) => cambiarEspecie(e.target.value)}
+            aria-label="Especie del cultivo"
+          >
+            {SPECIES_ORDER.map((k) => (
+              <option key={k} value={k}>{SPECIES[k].emoji} {SPECIES[k].label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="cvivo-title">
+          <span className="cv-eyebrow">El Ciclo Vivo</span>
+          <h1>El ciclo de {sp.su.toLowerCase()}</h1>
+        </div>
+
+        <div className="cv-wheel-stage">
+          <svg
+            ref={wheelRef}
+            className="cv-wheel-svg"
+            viewBox="0 14 342 318"
+            role="img"
+            aria-label={'Rueda del ciclo de vida de ' + sp.label}
+          />
+        </div>
+
+        <p className="cv-metaphor-caption">{WHEEL_CAPTION}</p>
+
+        <button
+          className="cv-phase-cta"
+          style={{ '--cv-pcolor': curPhase.color }}
+          onClick={() => openPanel(faseActiva)}
+        >
+          <span className="cv-cta-glyph">
+            <PhaseGlyph phaseKey={curPhase.key} color={curPhase.color} size={30} viewBox="-11.5 -11.5 23 23" />
+          </span>
+          <span className="cv-cta-text">
+            <strong>{curPhase.name}</strong> — toque para ver qué hacer en esta fase
+            <small>Cada función se enciende sola cuando queda lista</small>
+          </span>
+          <span className="cv-cta-arrow"><Chev /></span>
+        </button>
+
+        <MotorStrip capacidades={capacidades} onNav={navegarCap} />
+
+        <div className={'cv-backdrop' + (panelOpen ? ' open' : '')} onClick={closePanel} />
+        <PhasePanel
+          open={panelOpen}
+          index={panelIndex}
+          faseActiva={faseActiva}
+          species={sp}
+          capacidades={capacidades}
+          onClose={closePanel}
+          onNav={navegarCap}
+          onJump={(i) => openPanel((i + PHASES.length) % PHASES.length)}
+        />
+
+        <div className={'cv-toast' + (toast ? ' show' : '')} role="status">{toast}</div>
+      </div>
+    </div>
+  );
+}
+
+/* ---- Tira "motor del agente" (capacidades transversales) ---- */
+function MotorStrip({ capacidades, onNav }) {
+  return (
+    <div className="cv-motor">
+      <p className="cv-motor-title">Motor del agente</p>
+      <div className="cv-motor-chips">
+        {MOTOR_CAPS.map((capId) => {
+          const { estado, nota, view } = resolverEstado(capId, capacidades);
+          const badge = ESTADO_BADGE[estado];
+          const label = capId === 'rag_grounding' ? 'Respuestas con fuentes' : 'Acciones del agente';
+          return (
+            <button
+              key={capId}
+              type="button"
+              className={'cv-chip is-' + estado}
+              style={{ '--cv-pcolor': '#5B8A52' }}
+              title={nota}
+              onClick={() => onNav(estado, view, label)}
+            >
+              {label}
+              {badge ? <span className="cv-badge">{badge}</span> : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ---- Panel de fase con sus chips de función ---- */
+function PhasePanel({ open, index, faseActiva, species, capacidades, onClose, onNav, onJump }) {
+  const p = PHASES[index];
+  if (!p) return null;
+  const prev = PHASES[(index + PHASES.length - 1) % PHASES.length];
+  const next = PHASES[(index + 1) % PHASES.length];
+
+  return (
+    <div
+      className={'cv-sheet' + (open ? ' open' : '')}
+      role="dialog"
+      aria-modal="true"
+      aria-label={'Fase ' + p.name}
+      style={{ '--cv-pcolor': p.color }}
+    >
+      <div className="cv-sheet-grip"><div className="cv-sheet-handle" /></div>
+      <button className="cv-sheet-close" aria-label="Cerrar" onClick={onClose}>
+        <svg width="11" height="11" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M6,6 L18,18 M18,6 L6,18" fill="none" stroke="#6B5A47" strokeWidth="2.6" strokeLinecap="round" />
+        </svg>
+      </button>
+
+      <div className="cv-sheet-header">
+        <div className="cv-sheet-glyph">
+          <PhaseGlyph phaseKey={p.key} color={p.color} size={38} viewBox="-12 -12 24 24" />
+        </div>
+        <div>
+          <h2>{p.name}</h2>
+          <div className="cv-sheet-sub">Etapa {index + 1} de 7 · ciclo de {species.su.toLowerCase()}</div>
+        </div>
+      </div>
+
+      <div className="cv-dots">
+        {PHASES.map((ph, idx) => {
+          const cls = idx === index ? 'active' : (idx < faseActiva ? 'done' : '');
+          return <span key={ph.key} className={'cv-dot ' + cls} style={{ '--cv-dc': ph.color }} />;
+        })}
+      </div>
+
+      <h3 className="cv-section-title">Funciones de Chagra en esta etapa</h3>
+      <div className="cv-chips">
+        {p.functions.map((fn, idx) => {
+          const { estado, nota, view } = resolverEstado(fn.cap, capacidades);
+          const badge = ESTADO_BADGE[estado];
+          const isPrimary = idx === 0 && estado === 'activo';
+          const cls = 'cv-chip is-' + estado + (isPrimary ? ' is-primary' : '');
+          return (
+            <button
+              key={fn.cap + ':' + idx}
+              type="button"
+              className={cls}
+              style={{ '--cv-pcolor': p.color }}
+              title={nota}
+              aria-disabled={estado === 'proximamente'}
+              onClick={() => onNav(estado, view, fn.label)}
+            >
+              {fn.camera ? <span className="cv-chip-ico"><CameraIco /></span> : null}
+              {fn.label}
+              {badge ? <span className="cv-badge">{badge}</span> : null}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="cv-observe-box">
+        <svg className="cv-observe-icon" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"
+          dangerouslySetInnerHTML={{ __html: EYE_SVG_INNER }} />
+        <div><strong>Qué observar:</strong> {species.observe[index]}</div>
+      </div>
+
+      <div className="cv-panel-nav">
+        <button style={{ '--cv-npc': prev.color }} onClick={() => onJump(index - 1)}>
+          <span className="cv-nav-chev"><ChevL /></span>
+          <span className="cv-mini-glyph"><PhaseGlyph phaseKey={prev.key} color={prev.color} size={18} viewBox="-11.5 -11.5 23 23" /></span>
+          {prev.name}
+        </button>
+        <button style={{ '--cv-npc': next.color }} onClick={() => onJump(index + 1)}>
+          {next.name}
+          <span className="cv-mini-glyph"><PhaseGlyph phaseKey={next.key} color={next.color} size={18} viewBox="-11.5 -11.5 23 23" /></span>
+          <span className="cv-nav-chev"><Chev color="#6B5A47" size={12} /></span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CicloVivo/CicloVivoFullView.test.jsx
+++ b/src/components/CicloVivo/CicloVivoFullView.test.jsx
@@ -1,0 +1,140 @@
+/**
+ * CicloVivoFullView.test.jsx — la vista full-screen de la rueda.
+ * =====================================================================
+ * Verifica el CORAZÓN del pedido: cada chip de función se pinta según su estado
+ * REAL en `/chagra-stats.json` (mockeado), y cuando ese estado cambia a
+ * 'activo' el chip se enciende y navega — sin tocar el componente.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+
+const saveProfile = vi.fn();
+let profileData = {};
+vi.mock('../../services/userProfileService', () => ({
+  getProfile: () => profileData,
+  saveProfile: (partial) => saveProfile(partial),
+}));
+vi.mock('../../services/altitudeService', () => ({
+  getDeviceAltitude: vi.fn().mockResolvedValue(null),
+}));
+
+import CicloVivoFullView from './CicloVivoFullView';
+import { PHASES } from './cicloVivoData';
+
+function buildCaps(overrides = {}) {
+  const caps = {};
+  for (const fase of PHASES) {
+    for (const fn of fase.functions) {
+      caps[fn.cap] = { estado: 'activo', view: fn.cap === 'nutricion' ? 'ciclo_nutrientes' : fn.cap, nota: '' };
+    }
+  }
+  caps.cromatografia_suelo = { estado: 'activo', view: 'cromatografia', nota: '' };
+  caps.mip_plagas = { estado: 'parcial', view: 'directorio', nota: '' };
+  for (const [id, spec] of Object.entries(overrides)) caps[id] = spec;
+  return caps;
+}
+
+function stubStatsFetch(caps) {
+  vi.stubGlobal('fetch', vi.fn((url) => {
+    if (String(url).includes('/chagra-stats.json')) {
+      return Promise.resolve({ ok: true, json: async () => ({ capacidades: caps }) });
+    }
+    return Promise.reject(new Error('unexpected fetch: ' + url));
+  }));
+}
+
+function openNode(container, idx) {
+  const node = container.querySelector(`.cv-wnode[data-idx="${idx}"]`);
+  expect(node, `nodo de fase ${idx}`).toBeTruthy();
+  fireEvent.click(node);
+}
+
+describe('CicloVivoFullView', () => {
+  beforeEach(() => {
+    profileData = {};
+    saveProfile.mockClear();
+    try { globalThis.localStorage.clear(); } catch { /* ignore */ }
+  });
+  afterEach(() => { vi.unstubAllGlobals(); cleanup(); });
+
+  it('dibuja la rueda con los 7 nodos de fase', async () => {
+    stubStatsFetch(buildCaps());
+    const { container } = render(<CicloVivoFullView onBack={() => {}} onNavigate={() => {}} />);
+    await waitFor(() => {
+      expect(container.querySelectorAll('.cv-wnode')).toHaveLength(7);
+    });
+  });
+
+  it('un chip ACTIVO navega a su vista', async () => {
+    stubStatsFetch(buildCaps());
+    const onNavigate = vi.fn();
+    const { container } = render(<CicloVivoFullView onBack={() => {}} onNavigate={onNavigate} />);
+    await waitFor(() => expect(container.querySelector('.cv-wnode')).toBeTruthy());
+    // Crecimiento (idx 2) trae Nutrición (activo → ciclo_nutrientes).
+    openNode(container, 2);
+    const chip = await screen.findByRole('button', { name: /Nutrición$/ });
+    fireEvent.click(chip);
+    expect(onNavigate).toHaveBeenCalledWith('ciclo_nutrientes');
+  });
+
+  it('un chip PARCIAL muestra el badge "parcial" y aún navega', async () => {
+    stubStatsFetch(buildCaps());
+    const onNavigate = vi.fn();
+    const { container } = render(<CicloVivoFullView onBack={() => {}} onNavigate={onNavigate} />);
+    await waitFor(() => expect(container.querySelector('.cv-wnode')).toBeTruthy());
+    openNode(container, 2); // Crecimiento tiene "Plagas de esta etapa (MIP)" = parcial
+    const chip = await screen.findByRole('button', { name: /Plagas de esta etapa/ });
+    await waitFor(() => expect(chip.className).toMatch(/is-parcial/));
+    expect(chip.textContent).toMatch(/parcial/);
+    fireEvent.click(chip);
+    expect(onNavigate).toHaveBeenCalledWith('directorio');
+  });
+
+  it('un chip PRÓXIMAMENTE sale en fantasma con "pronto" y NO navega', async () => {
+    stubStatsFetch(buildCaps({ cromatografia_suelo: { estado: 'proximamente', view: null, nota: '' } }));
+    const onNavigate = vi.fn();
+    const { container } = render(<CicloVivoFullView onBack={() => {}} onNavigate={onNavigate} />);
+    await waitFor(() => expect(container.querySelector('.cv-wnode')).toBeTruthy());
+    openNode(container, 1); // Germinación tiene "Suelo (cromatografía)"
+    const chip = await screen.findByRole('button', { name: /Suelo \(cromatografía\)/ });
+    await waitFor(() => expect(chip.className).toMatch(/is-proximamente/));
+    expect(chip.textContent).toMatch(/pronto/);
+    fireEvent.click(chip);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('AUTO-LIGHT: el mismo chip se enciende y navega cuando la fuente de verdad lo pasa a activo', async () => {
+    // Estado 1: cromatografía en camino.
+    stubStatsFetch(buildCaps({ cromatografia_suelo: { estado: 'proximamente', view: null, nota: '' } }));
+    let onNavigate = vi.fn();
+    let view = render(<CicloVivoFullView onBack={() => {}} onNavigate={onNavigate} />);
+    await waitFor(() => expect(view.container.querySelector('.cv-wnode')).toBeTruthy());
+    openNode(view.container, 1);
+    const ghost = await screen.findByRole('button', { name: /Suelo \(cromatografía\)/ });
+    await waitFor(() => expect(ghost.className).toMatch(/is-proximamente/));
+    fireEvent.click(ghost);
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    cleanup();
+
+    // Estado 2: se activó el artefacto en la fuente de verdad. Mismo widget.
+    stubStatsFetch(buildCaps({ cromatografia_suelo: { estado: 'activo', view: 'cromatografia', nota: '' } }));
+    onNavigate = vi.fn();
+    view = render(<CicloVivoFullView onBack={() => {}} onNavigate={onNavigate} />);
+    await waitFor(() => expect(view.container.querySelector('.cv-wnode')).toBeTruthy());
+    openNode(view.container, 1);
+    const encendido = await screen.findByRole('button', { name: /Suelo \(cromatografía\)/ });
+    await waitFor(() => expect(encendido.className).toMatch(/is-activo/));
+    fireEvent.click(encendido);
+    expect(onNavigate).toHaveBeenCalledWith('cromatografia');
+  });
+
+  it('cambiar la especie guarda el override en el perfil', async () => {
+    stubStatsFetch(buildCaps());
+    const { container } = render(<CicloVivoFullView onBack={() => {}} onNavigate={() => {}} />);
+    await waitFor(() => expect(container.querySelector('.cv-wnode')).toBeTruthy());
+    const select = screen.getByLabelText('Especie del cultivo');
+    fireEvent.change(select, { target: { value: 'papa' } });
+    expect(saveProfile).toHaveBeenCalledWith({ ciclo_vivo_especie: 'papa' });
+  });
+});

--- a/src/components/CicloVivo/CicloVivoWidget.jsx
+++ b/src/components/CicloVivo/CicloVivoWidget.jsx
@@ -1,0 +1,74 @@
+/**
+ * CicloVivoWidget.jsx — portal de "El Ciclo Vivo" en el home.
+ * =====================================================================
+ * Tarjeta insignia que resume el estado del ciclo y abre la vista full-screen
+ * (`onNavigate('ciclo_vivo')`). El resumen de "cuántas funciones están activas /
+ * parciales / en camino" sale de la MISMA fuente de verdad que la vista
+ * (`/chagra-stats.json` → `capacidades`), así que la tarjeta también se
+ * actualiza sola cuando un artefacto se enciende.
+ */
+import { useMemo } from 'react';
+import './cicloVivo.css';
+import { GLYPHS } from './cicloVivoArte';
+import { PHASES, resolverEstado } from './cicloVivoData';
+import { useChagraStats } from '../../hooks/useChagraStats';
+
+/** Cuenta funciones distintas del ciclo por estado, contra la fuente de verdad. */
+function resumirEstados(capacidades) {
+  const vistos = new Set();
+  const conteo = { activo: 0, parcial: 0, proximamente: 0 };
+  for (const fase of PHASES) {
+    for (const fn of fase.functions) {
+      if (vistos.has(fn.cap)) continue;
+      vistos.add(fn.cap);
+      const { estado } = resolverEstado(fn.cap, capacidades);
+      if (conteo[estado] != null) conteo[estado] += 1;
+    }
+  }
+  return conteo;
+}
+
+export default function CicloVivoWidget({ onNavigate }) {
+  const { data: stats } = useChagraStats();
+  const capacidades = stats && stats.capacidades ? stats.capacidades : null;
+  const conteo = useMemo(() => resumirEstados(capacidades), [capacidades]);
+
+  const abrir = () => { if (onNavigate) onNavigate('ciclo_vivo'); };
+
+  return (
+    <div className="cvivo-root">
+      <button type="button" className="cvivo-card" onClick={abrir} aria-label="El Ciclo Vivo: recorra el ciclo de su cultivo">
+        <span className="cvivo-card-emblem" aria-hidden="true">
+          <svg viewBox="-40 -40 80 80" role="img">
+            <circle r="37" fill="none" stroke="#C98A3D" strokeWidth="1.4" strokeDasharray="1 6" strokeLinecap="round" opacity=".5" />
+            {PHASES.map((p, i) => {
+              const a = (-90 + i * (360 / PHASES.length)) * Math.PI / 180;
+              const x = (30 * Math.cos(a)).toFixed(1);
+              const y = (30 * Math.sin(a)).toFixed(1);
+              return <circle key={p.key} cx={x} cy={y} r="4.4" fill={p.color} opacity={i === 0 ? 1 : 0.85} />;
+            })}
+            <circle r="17" fill="#FFFDF8" stroke="rgba(232,184,75,.7)" strokeWidth="2" />
+            <g dangerouslySetInnerHTML={{ __html: GLYPHS.semilla('#8B5E34') }} />
+          </svg>
+        </span>
+
+        <span className="cvivo-card-body">
+          <span className="cvivo-card-eyebrow">El Ciclo Vivo</span>
+          <span className="cvivo-card-title">La rueda de su cultivo</span>
+          <span className="cvivo-card-sub">De la semilla a la poscosecha: qué hacer y qué observar en cada fase.</span>
+          <span className="cvivo-card-states">
+            <span className="cvivo-state-pill activo">{conteo.activo} listas</span>
+            {conteo.parcial > 0 ? <span className="cvivo-state-pill parcial">{conteo.parcial} parcial</span> : null}
+            {conteo.proximamente > 0 ? <span className="cvivo-state-pill proximamente">{conteo.proximamente} en camino</span> : null}
+          </span>
+        </span>
+
+        <span className="cvivo-card-cta" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24">
+            <path d="M9.2,5.4 L15.8,12 L9.2,18.6" fill="none" stroke="#C98A3D" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/CicloVivo/CicloVivoWidget.test.jsx
+++ b/src/components/CicloVivo/CicloVivoWidget.test.jsx
@@ -1,0 +1,62 @@
+/**
+ * CicloVivoWidget.test.jsx — la tarjeta portal del home.
+ * Verifica que el resumen de estados sale de la fuente de verdad
+ * (`/chagra-stats.json` mockeado) y que abre la vista full-screen.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import CicloVivoWidget from './CicloVivoWidget';
+import { PHASES } from './cicloVivoData';
+
+/** Construye un mapa de capacidades: todo 'activo', con overrides puntuales. */
+function buildCaps(overrides = {}) {
+  const caps = {};
+  for (const fase of PHASES) {
+    for (const fn of fase.functions) {
+      caps[fn.cap] = { estado: 'activo', view: 'x', nota: '' };
+    }
+  }
+  for (const [id, estado] of Object.entries(overrides)) {
+    caps[id] = { estado, view: estado === 'proximamente' ? null : 'x', nota: '' };
+  }
+  return caps;
+}
+
+function stubStatsFetch(caps) {
+  vi.stubGlobal('fetch', vi.fn((url) => {
+    if (String(url).includes('/chagra-stats.json')) {
+      return Promise.resolve({ ok: true, json: async () => ({ capacidades: caps }) });
+    }
+    return Promise.reject(new Error('unexpected fetch: ' + url));
+  }));
+}
+
+describe('CicloVivoWidget', () => {
+  beforeEach(() => { try { globalThis.localStorage.clear(); } catch { /* ignore */ } });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('refleja el conteo de "en camino" desde la fuente de verdad', async () => {
+    stubStatsFetch(buildCaps({ viabilidad_semilla: 'proximamente', guardar_semilla: 'proximamente' }));
+    render(<CicloVivoWidget onNavigate={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText('2 en camino')).toBeInTheDocument();
+    });
+  });
+
+  it('abre la vista full-screen al tocar la tarjeta', async () => {
+    stubStatsFetch(buildCaps());
+    const onNavigate = vi.fn();
+    render(<CicloVivoWidget onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByRole('button', { name: /El Ciclo Vivo/i }));
+    expect(onNavigate).toHaveBeenCalledWith('ciclo_vivo');
+  });
+
+  it('renderiza sin romperse aunque el fetch falle (usa respaldo offline)', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('404'))));
+    render(<CicloVivoWidget onNavigate={() => {}} />);
+    // El respaldo trae 2 funciones 'proximamente' (viabilidad + guardar semilla).
+    await waitFor(() => {
+      expect(screen.getByText(/en camino/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/CicloVivo/cicloVivo.css
+++ b/src/components/CicloVivo/cicloVivo.css
@@ -1,0 +1,326 @@
+/* cicloVivo.css — estética de "El Ciclo Vivo" (rueda v3 aprobada).
+   Todo va scopeado bajo .cvivo-root para no filtrarse al resto del PWA
+   (que usa Tailwind + tema oscuro). Las clases del SVG llevan prefijo cv-. */
+
+.cvivo-root {
+  --cv-cream: #FBF3E4;
+  --cv-cream-2: #F3E9D2;
+  --cv-ink: #2B2118;
+  --cv-ink-soft: #6B5A47;
+  --cv-green-deep: #2F4A34;
+  --cv-brown-dark: #5A3D22;
+  --cv-ocre: #C98A3D;
+  --cv-gold-strong: #F2C744;
+  --cv-card: #FFFDF8;
+  --cv-shadow-card: 0 10px 26px rgba(70, 45, 20, .14);
+  --cv-font-display: Georgia, 'Iowan Old Style', 'Palatino Linotype', 'Times New Roman', serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  color: var(--cv-ink);
+}
+
+/* ============ VISTA COMPLETA ============ */
+.cvivo-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background:
+    radial-gradient(420px 420px at 50% 42%, #F7EDD6 0%, var(--cv-cream) 62%),
+    var(--cv-cream);
+}
+
+.cvivo-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px 8px;
+  flex-shrink: 0;
+}
+.cvivo-back {
+  width: 36px; height: 36px; border-radius: 50%;
+  background: var(--cv-card); box-shadow: var(--cv-shadow-card);
+  font-size: 16px; display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0; color: var(--cv-green-deep); border: none; cursor: pointer;
+}
+.cvivo-floor-chip {
+  display: flex; align-items: center; gap: 5px;
+  background: linear-gradient(135deg, #DCEBFB, #EAF3FB);
+  color: #33566E; font-size: 12px; font-weight: 600;
+  padding: 7px 11px; border-radius: 16px; white-space: nowrap;
+  box-shadow: var(--cv-shadow-card);
+}
+.cvivo-species-select {
+  margin-left: auto;
+  appearance: none; -webkit-appearance: none;
+  background: var(--cv-card) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="6"><path d="M0 0 L5 6 L10 0" fill="none" stroke="%236B5A47" stroke-width="1.4"/></svg>') no-repeat right 10px center;
+  border: 1.5px solid rgba(232, 184, 75, .45);
+  border-radius: 16px; padding: 8px 26px 8px 12px;
+  font-size: 12.5px; font-weight: 600; color: var(--cv-ink);
+  box-shadow: var(--cv-shadow-card); max-width: 140px; cursor: pointer;
+}
+
+.cvivo-title { text-align: center; padding: 2px 20px 0; flex-shrink: 0; }
+.cvivo-title .cv-eyebrow {
+  display: block; font-size: 10.5px; font-weight: 700; letter-spacing: .22em;
+  text-transform: uppercase; color: var(--cv-ocre); margin-bottom: 2px;
+}
+.cvivo-title h1 {
+  font-family: var(--cv-font-display); font-size: 21px; font-weight: 600;
+  margin: 0; color: var(--cv-green-deep);
+}
+
+.cv-wheel-stage {
+  flex: 1; min-height: 0; width: 100%; padding: 2px 0;
+  display: flex; align-items: center; justify-content: center; position: relative;
+}
+.cv-wheel-svg { display: block; width: 366px; max-width: 100%; max-height: 100%; height: auto; overflow: visible; }
+
+.cv-metaphor-caption {
+  text-align: center; font-family: var(--cv-font-display); font-style: italic;
+  color: var(--cv-ink-soft); font-size: 13px; padding: 0 24px; margin: 0 0 10px; flex-shrink: 0;
+}
+
+/* ============ ANIMACIONES SVG ============ */
+.cv-ring-decor { transform-origin: 180px 180px; animation: cvSpin 80s linear infinite; }
+@keyframes cvSpin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+
+.cv-stem-grown {
+  stroke-dasharray: var(--len); stroke-dashoffset: 0;
+  animation: cvStemGrow 1.7s .15s cubic-bezier(.45, .05, .35, 1) both;
+}
+@keyframes cvStemGrow { from { stroke-dashoffset: var(--len); } to { stroke-dashoffset: 0; } }
+
+.cv-leaf-in {
+  transform-box: fill-box; transform-origin: 0% 50%;
+  animation: cvLeafIn .7s both cubic-bezier(.34, 1.55, .64, 1); animation-delay: var(--dl);
+}
+@keyframes cvLeafIn { from { opacity: 0; transform: scale(0); } }
+
+.cv-sway { transform-box: fill-box; transform-origin: 0% 50%; animation: cvSway 4.5s ease-in-out infinite; animation-delay: var(--dl); }
+@keyframes cvSway { 0%, 100% { transform: rotate(0deg); } 50% { transform: rotate(4deg); } }
+
+.cv-wnode { cursor: pointer; }
+.cv-wnode-in {
+  transform-box: fill-box; transform-origin: center;
+  animation: cvNodePop .6s both cubic-bezier(.34, 1.55, .64, 1); animation-delay: var(--dl);
+}
+@keyframes cvNodePop { from { opacity: 0; transform: scale(.2); } }
+.cv-node-bg { transition: filter .15s ease; }
+.cv-wnode:hover .cv-node-bg, .cv-wnode:focus-visible .cv-node-bg { filter: brightness(1.05) drop-shadow(0 3px 5px rgba(70, 45, 20, .28)); }
+.cv-wnode:active .cv-wnode-in { transform: scale(.9); }
+.cv-wnode:focus-visible { outline: none; }
+.cv-wnode:focus-visible .cv-node-bg { stroke-width: 3.2; }
+
+.cv-halo { transform-box: fill-box; transform-origin: center; animation: cvHalo 2.2s ease-in-out infinite; }
+@keyframes cvHalo { 0%, 100% { opacity: .55; transform: scale(1); } 50% { opacity: .1; transform: scale(1.28); } }
+
+.cv-flag-in {
+  transform-box: fill-box; transform-origin: center top;
+  animation: cvFlagIn .6s 1.9s both cubic-bezier(.34, 1.55, .64, 1), cvFlagBob 3.4s 2.6s ease-in-out infinite;
+}
+@keyframes cvFlagIn { from { opacity: 0; transform: translateY(8px) scale(.6); } }
+@keyframes cvFlagBob { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(3px); } }
+
+.cv-core-pop { transform-box: fill-box; transform-origin: center; animation: cvCorePop .8s .05s both cubic-bezier(.34, 1.5, .64, 1); }
+@keyframes cvCorePop { from { opacity: 0; transform: scale(.55); } }
+
+.cv-node-label { font-size: 9.5px; font-weight: 700; fill: var(--cv-ink-soft); text-anchor: middle; letter-spacing: .02em; }
+.cv-core-name { font-size: 8.5px; font-weight: 700; fill: var(--cv-cream); text-anchor: middle; letter-spacing: .24em; }
+
+/* ============ CTA FASE ENFOCADA ============ */
+.cv-phase-cta {
+  display: flex; align-items: center; gap: 12px;
+  margin: 0 18px 18px; padding: 12px 14px;
+  border-radius: 20px; text-align: left; width: calc(100% - 36px);
+  background: linear-gradient(120deg, #FFF8E2 0%, #FDF1D2 100%);
+  border: 1.5px solid rgba(232, 184, 75, .55);
+  box-shadow: 0 8px 20px rgba(201, 138, 61, .18);
+  transition: transform .15s ease; cursor: pointer; flex-shrink: 0;
+}
+.cv-phase-cta:active { transform: scale(.98); }
+.cv-cta-glyph {
+  width: 44px; height: 44px; border-radius: 50%; flex-shrink: 0;
+  background:
+    radial-gradient(circle at 32% 28%, rgba(255, 255, 255, .9), transparent 55%),
+    color-mix(in srgb, var(--cv-pcolor, #E8879C) 16%, #FFFDF8);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--cv-pcolor, #E8879C) 42%, white);
+  display: flex; align-items: center; justify-content: center;
+}
+.cv-cta-text { flex: 1; min-width: 0; font-size: 13.5px; line-height: 1.35; color: var(--cv-ink); }
+.cv-cta-text strong { color: var(--cv-brown-dark); }
+.cv-cta-text small { display: block; font-size: 11.5px; color: var(--cv-ink-soft); margin-top: 1px; }
+.cv-cta-arrow { display: flex; align-items: center; flex-shrink: 0; }
+
+/* ============ TIRA MOTOR DEL AGENTE ============ */
+.cv-motor {
+  margin: 0 18px 18px; padding: 10px 14px; border-radius: 16px; flex-shrink: 0;
+  background: color-mix(in srgb, #5B8A52 8%, #FFFDF8);
+  border: 1.5px solid rgba(91, 138, 82, .28);
+}
+.cv-motor-title { font-size: 10.5px; text-transform: uppercase; letter-spacing: .08em; color: var(--cv-ink-soft); font-weight: 700; margin: 0 0 7px; }
+.cv-motor-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+
+/* ============ SHEET (panel de fase) ============ */
+.cv-backdrop {
+  position: absolute; inset: 0; background: rgba(30, 22, 12, .42);
+  -webkit-backdrop-filter: blur(2.5px); backdrop-filter: blur(2.5px);
+  opacity: 0; pointer-events: none; transition: opacity .32s ease; z-index: 50;
+}
+.cv-backdrop.open { opacity: 1; pointer-events: auto; }
+.cv-sheet {
+  position: absolute; left: 0; right: 0; bottom: 0;
+  background: linear-gradient(180deg, #FFFDF8 0%, var(--cv-cream) 100%);
+  border-radius: 30px 30px 0 0; box-shadow: 0 -18px 44px rgba(30, 22, 12, .35);
+  padding: 8px 20px 24px; z-index: 60;
+  transform: translateY(104%); transition: transform .42s cubic-bezier(.22, 1.18, .36, 1);
+  max-height: 76%; overflow-y: auto; overscroll-behavior: contain;
+}
+.cv-sheet.open { transform: translateY(0); }
+.cv-sheet-grip { padding: 6px 0 10px; margin: -8px -20px 0; cursor: grab; }
+.cv-sheet-handle {
+  width: 44px; height: 5px; border-radius: 3px; margin: 0 auto;
+  background: linear-gradient(90deg, #E2D4B0, #C8B48A 50%, #E2D4B0);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, .55), 0 1px 2px rgba(70, 45, 20, .14);
+}
+.cv-sheet-close {
+  position: absolute; top: 16px; right: 16px; width: 30px; height: 30px; border-radius: 50%;
+  background: var(--cv-cream-2); font-size: 12px; color: var(--cv-ink-soft);
+  display: flex; align-items: center; justify-content: center; border: none; cursor: pointer;
+}
+.cv-sheet-header { display: flex; align-items: center; gap: 13px; margin-bottom: 4px; padding-right: 34px; }
+.cv-sheet-glyph {
+  width: 58px; height: 58px; border-radius: 19px; flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  background:
+    radial-gradient(circle at 32% 28%, rgba(255, 255, 255, .85), transparent 55%),
+    color-mix(in srgb, var(--cv-pcolor) 22%, #FFFDF8);
+  box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--cv-pcolor) 45%, white);
+}
+.cv-sheet-header h2 { font-family: var(--cv-font-display); font-size: 22px; margin: 0 0 2px; color: var(--cv-ink); }
+.cv-sheet-sub { font-size: 11.5px; color: var(--cv-ink-soft); font-weight: 600; }
+
+.cv-dots { display: flex; gap: 6px; justify-content: center; align-items: center; margin: 12px 0 16px; }
+.cv-dot {
+  width: 7px; height: 7px; border-radius: 50%; transition: all .25s ease;
+  background: radial-gradient(circle at 35% 30%, #F0E6CC, #DFD2B0);
+  box-shadow: inset 0 0 0 1px rgba(107, 90, 71, .14);
+}
+.cv-dot.done {
+  background: radial-gradient(circle at 35% 30%, color-mix(in srgb, var(--cv-dc) 40%, white), color-mix(in srgb, var(--cv-dc) 78%, #E3D6B8));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cv-dc) 42%, transparent);
+}
+.cv-dot.active {
+  width: 24px; border-radius: 4px;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--cv-dc, var(--cv-gold-strong)) 68%, white) 0%, var(--cv-dc, var(--cv-gold-strong)) 55%);
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--cv-dc, var(--cv-gold-strong)) 45%, transparent), inset 0 0 0 1px color-mix(in srgb, var(--cv-dc, var(--cv-gold-strong)) 55%, white);
+}
+
+.cv-section-title { font-size: 11.5px; text-transform: uppercase; letter-spacing: .08em; color: var(--cv-ink-soft); margin: 0 0 9px; font-weight: 700; }
+.cv-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+
+/* ---- Chips: aquí se refleja el ESTADO REAL de cada función ---- */
+.cv-chip {
+  font-size: 12.5px; font-weight: 600; padding: 8px 13px; border-radius: 14px;
+  background: var(--cv-card); color: var(--cv-ink);
+  box-shadow: 0 4px 12px rgba(70, 45, 20, .10);
+  border: 1.5px solid color-mix(in srgb, var(--cv-pcolor) 32%, white);
+  transition: transform .12s ease; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.cv-chip:active { transform: scale(.95); }
+.cv-chip .cv-chip-ico { display: inline-flex; }
+.cv-chip .cv-chip-ico svg { display: block; }
+
+/* activo: chip encendido; el primero de la fase, relleno */
+.cv-chip.is-activo.is-primary {
+  background: linear-gradient(135deg, var(--cv-pcolor), color-mix(in srgb, var(--cv-pcolor) 72%, black));
+  color: #fff; border-color: transparent;
+  box-shadow: 0 6px 14px color-mix(in srgb, var(--cv-pcolor) 45%, transparent);
+}
+
+/* parcial: atenuado, con badge "parcial", sigue navegando */
+.cv-chip.is-parcial { opacity: .82; border-style: dashed; }
+
+/* proximamente: fantasma, con "pronto", no navega */
+.cv-chip.is-proximamente {
+  background: repeating-linear-gradient(135deg, #F5EEDD 0 6px, #EFE6D0 6px 12px);
+  color: var(--cv-ink-soft); border-color: rgba(107, 90, 71, .22); border-style: dashed;
+  cursor: default; box-shadow: none;
+}
+.cv-chip.is-proximamente:active { transform: none; }
+
+.cv-badge {
+  font-size: 9.5px; font-weight: 800; letter-spacing: .04em; text-transform: uppercase;
+  padding: 2px 6px; border-radius: 8px;
+}
+.cv-chip.is-parcial .cv-badge { background: var(--cv-gold-strong); color: #3a2a05; }
+.cv-chip.is-proximamente .cv-badge { background: rgba(107, 90, 71, .16); color: var(--cv-ink-soft); }
+
+.cv-observe-box {
+  display: flex; gap: 11px; align-items: flex-start;
+  background: linear-gradient(120deg, #FBF6E6, #F6EED8);
+  border: 1.5px solid rgba(232, 184, 75, .4); border-left: 4px solid var(--cv-gold-strong);
+  border-radius: 14px; padding: 12px 14px; font-size: 13px; line-height: 1.55; color: var(--cv-ink);
+  margin-bottom: 16px;
+}
+.cv-observe-box strong { color: var(--cv-brown-dark); }
+.cv-observe-icon { flex-shrink: 0; margin-top: 1px; }
+
+.cv-panel-nav { display: flex; gap: 10px; }
+.cv-panel-nav button {
+  flex: 1; padding: 11px 8px; border-radius: 16px; font-size: 12.5px; font-weight: 700;
+  background: var(--cv-card); color: var(--cv-green-deep); box-shadow: var(--cv-shadow-card);
+  display: flex; align-items: center; justify-content: center; gap: 7px;
+  border: 1.5px solid color-mix(in srgb, var(--cv-npc, #5B8A52) 30%, white); cursor: pointer;
+}
+.cv-panel-nav button:active { transform: scale(.96); }
+.cv-mini-glyph { display: inline-flex; }
+.cv-nav-chev { display: inline-flex; opacity: .75; }
+
+/* ============ TOAST ============ */
+.cv-toast {
+  position: absolute; left: 50%; bottom: 26px; transform: translate(-50%, 16px);
+  background: #2B2118; color: #F3E9D2; font-size: 12.5px; padding: 10px 18px;
+  border-radius: 20px; opacity: 0; pointer-events: none; transition: all .3s ease;
+  z-index: 70; max-width: 320px; text-align: center; box-shadow: 0 12px 28px rgba(0, 0, 0, .3);
+}
+.cv-toast.show { opacity: 1; transform: translate(-50%, 0); }
+
+/* ============ TARJETA PORTAL (home) ============ */
+.cvivo-card {
+  width: 100%; text-align: left; cursor: pointer; border: none;
+  border-radius: 20px; padding: 14px 16px; overflow: hidden; position: relative;
+  background:
+    radial-gradient(340px 200px at 88% -20%, #E7F0D6 0%, transparent 60%),
+    linear-gradient(120deg, #FFFDF8 0%, #F6EFDD 100%);
+  box-shadow: var(--cv-shadow-card);
+  border: 1.5px solid rgba(232, 184, 75, .4);
+  display: flex; gap: 14px; align-items: center;
+}
+.cvivo-card:active { transform: scale(.99); }
+.cvivo-card-emblem { width: 74px; height: 74px; flex-shrink: 0; }
+.cvivo-card-emblem svg { width: 100%; height: 100%; display: block; overflow: visible; }
+.cvivo-card-body { flex: 1; min-width: 0; }
+.cvivo-card-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: .2em; text-transform: uppercase;
+  color: var(--cv-ocre); margin: 0 0 2px;
+}
+.cvivo-card-title { font-family: var(--cv-font-display); font-size: 17px; color: var(--cv-green-deep); margin: 0 0 4px; font-weight: 600; }
+.cvivo-card-sub { font-size: 12px; color: var(--cv-ink-soft); line-height: 1.35; margin: 0 0 8px; }
+.cvivo-card-states { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.cvivo-state-pill {
+  font-size: 10.5px; font-weight: 700; padding: 3px 8px; border-radius: 10px;
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.cvivo-state-pill.activo { background: color-mix(in srgb, #4C7A3D 16%, white); color: #2F4A34; }
+.cvivo-state-pill.parcial { background: color-mix(in srgb, var(--cv-gold-strong) 26%, white); color: #6b5309; }
+.cvivo-state-pill.proximamente { background: rgba(107, 90, 71, .12); color: var(--cv-ink-soft); }
+.cvivo-card-cta { margin-left: auto; align-self: center; color: var(--cv-ocre); flex-shrink: 0; }
+
+/* Reduce motion */
+@media (prefers-reduced-motion: reduce) {
+  .cvivo-root *, .cvivo-root *::before, .cvivo-root *::after { animation: none !important; transition: none !important; }
+  .cv-stem-grown { stroke-dashoffset: 0 !important; }
+}

--- a/src/components/CicloVivo/cicloVivoArte.js
+++ b/src/components/CicloVivo/cicloVivoArte.js
@@ -72,6 +72,7 @@ export const CENTER_MAIZ = (function build() {
   s += '<path d="M-4.2,3.5 C-7.8,7.5 -8.4,13.4 -5.8,16.8 C-3.2,12.6 -3,7.6 -4.2,3.5 Z" fill="url(#gHusk)"/>';
   s += '<path d="M4.2,3.5 C7.8,7.5 8.4,13.4 5.8,16.8 C3.2,12.6 3,7.6 4.2,3.5 Z" fill="url(#gHusk)" opacity=".85"/>';
   s += '<ellipse rx="5.4" ry="10.6" fill="url(#gCob)"/>';
+  /** @type {Array<[number, number[]]>} filas de la mazorca: [y, xs de granos] */
   const rows = [[-7.3, [-1.8, 0, 1.8]], [-4.9, [-3, -1.05, 0.9, 2.85]], [-2.5, [-3.5, -1.7, 0.1, 1.9, 3.6]], [-0.1, [-3.7, -1.8, 0, 1.8, 3.7]], [2.3, [-3.6, -1.9, -0.1, 1.7, 3.5]], [4.7, [-2.9, -1, 0.9, 2.8]], [7.1, [-1.7, 0, 1.7]]];
   rows.forEach(function eachRow(row, ri) {
     row[1].forEach(function eachCol(x, ci) {

--- a/src/components/CicloVivo/cicloVivoArte.js
+++ b/src/components/CicloVivo/cicloVivoArte.js
@@ -1,0 +1,405 @@
+/**
+ * cicloVivoArte.js — arte SVG de "El Ciclo Vivo" (rueda v3 aprobada).
+ * =====================================================================
+ * Port 1:1 del mockup de decisión v3 (pasada de arte aprobada por el
+ * operador). Todo lo que hay aquí son CONSTANTES de dibujo: gradientes,
+ * ilustraciones botánicas por especie para el núcleo de la rueda, y la
+ * familia unificada de glifos de fase. No hay estado ni datos de usuario.
+ *
+ * Las ilustraciones se generan como strings SVG (igual que el mockup) y
+ * se inyectan con `dangerouslySetInnerHTML` desde los componentes. Es
+ * seguro: son constantes de módulo, sin ninguna interpolación de input
+ * de usuario.
+ */
+
+/* ---- Utilidades de color compartidas por glifos e ilustraciones ---- */
+export function mixHex(a, b, t) {
+  function h(x) {
+    const s = x.replace('#', '');
+    return [parseInt(s.substr(0, 2), 16), parseInt(s.substr(2, 2), 16), parseInt(s.substr(4, 2), 16)];
+  }
+  const A = h(a);
+  const B = h(b);
+  let o = '#';
+  for (let i = 0; i < 3; i++) {
+    o += ('0' + Math.round(A[i] + (B[i] - A[i]) * t).toString(16)).slice(-2);
+  }
+  return o;
+}
+export function tint(c, t) { return mixHex(c, '#FFFDF8', t); }
+export function shade(c, t) { return mixHex(c, '#2B2118', t); }
+export const CREAM = '#FBF3E4';
+
+/* ---- Gradientes compartidos de la paleta botánica (van a <defs>) ---- */
+export const SPECIES_DEFS =
+  '<linearGradient id="gStalk" x1="0" y1="1" x2="0" y2="0"><stop offset="0%" stop-color="#2F4A34"/><stop offset="100%" stop-color="#5B8A52"/></linearGradient>' +
+  '<linearGradient id="gVine" x1="0" y1="1" x2="0" y2="0"><stop offset="0%" stop-color="#3F6B36"/><stop offset="100%" stop-color="#6B9A5B"/></linearGradient>' +
+  '<linearGradient id="gWood" x1="0" y1="1" x2="0" y2="0"><stop offset="0%" stop-color="#4E3620"/><stop offset="100%" stop-color="#8A6238"/></linearGradient>' +
+  '<linearGradient id="gLeafD" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#6B9A5B"/><stop offset="100%" stop-color="#35592C"/></linearGradient>' +
+  '<linearGradient id="gLeafM" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#82AE6C"/><stop offset="100%" stop-color="#46703B"/></linearGradient>' +
+  '<linearGradient id="gLeafL" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#9CC183"/><stop offset="100%" stop-color="#5B8A52"/></linearGradient>' +
+  '<linearGradient id="gLeafCafe" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#45794E"/><stop offset="100%" stop-color="#22422B"/></linearGradient>' +
+  '<linearGradient id="gCob" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#E9B93B"/><stop offset="100%" stop-color="#A8720F"/></linearGradient>' +
+  '<linearGradient id="gHusk" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#5B8A52"/><stop offset="100%" stop-color="#375D2D"/></linearGradient>' +
+  '<linearGradient id="gPod" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#8FBB7C"/><stop offset="100%" stop-color="#4C7A3D"/></linearGradient>' +
+  '<radialGradient id="gTuber" cx="35%" cy="30%" r="90%"><stop offset="0%" stop-color="#F0C287"/><stop offset="55%" stop-color="#DDA55F"/><stop offset="100%" stop-color="#B27939"/></radialGradient>' +
+  '<radialGradient id="gTuberL" cx="35%" cy="30%" r="90%"><stop offset="0%" stop-color="#F4CD96"/><stop offset="100%" stop-color="#C68C48"/></radialGradient>' +
+  '<radialGradient id="gCherry" cx="35%" cy="30%" r="95%"><stop offset="0%" stop-color="#E8705A"/><stop offset="50%" stop-color="#C0392B"/><stop offset="100%" stop-color="#841E15"/></radialGradient>' +
+  '<radialGradient id="gCherryV" cx="35%" cy="30%" r="95%"><stop offset="0%" stop-color="#A9C687"/><stop offset="100%" stop-color="#5F8547"/></radialGradient>' +
+  '<radialGradient id="gBerry" cx="38%" cy="25%" r="100%"><stop offset="0%" stop-color="#F07C5A"/><stop offset="45%" stop-color="#D6402F"/><stop offset="100%" stop-color="#9E2317"/></radialGradient>' +
+  '<radialGradient id="gFlor" cx="35%" cy="30%" r="95%"><stop offset="0%" stop-color="#E7DAF2"/><stop offset="100%" stop-color="#B497CE"/></radialGradient>';
+
+/* ---- Ilustraciones de especie (centro de la rueda) ---- */
+
+export const CENTER_MAIZ = (function build() {
+  let s = '';
+  /* tallo con luz */
+  s += '<path d="M0,16 C1,8 -1,-4 0.5,-21" stroke="url(#gStalk)" stroke-width="3" fill="none" stroke-linecap="round"/>';
+  s += '<path d="M-0.9,14.5 C-0.1,8 -1.9,-3.5 -0.5,-19.5" stroke="#8FBB7C" stroke-width=".8" fill="none" stroke-linecap="round" opacity=".5"/>';
+  /* hoja baja izquierda con nervaduras */
+  s += '<path d="M0,6 C-7,3 -14,4 -20,10 C-16,13.5 -6,12 0,6 Z" fill="url(#gLeafD)"/>';
+  s += '<path d="M-1.2,6.6 C-7,5 -13,5.9 -18.3,9.5" stroke="rgba(251,243,228,.55)" stroke-width=".85" fill="none"/>';
+  s += '<path d="M-2.5,8.2 C-7.5,7 -12,7.6 -16,9.8 M-2,5.4 C-6.6,4.2 -11,4.4 -15,6.2" stroke="rgba(251,243,228,.28)" stroke-width=".6" fill="none"/>';
+  /* hoja alta izquierda */
+  s += '<path d="M0,-12 C-5,-14.5 -11.5,-13.5 -16,-8 C-10,-4.5 -4,-8.5 0,-12 Z" fill="url(#gLeafL)"/>';
+  s += '<path d="M-1.3,-11.6 C-6,-12.6 -10.6,-11.6 -14.3,-8.6" stroke="rgba(251,243,228,.5)" stroke-width=".8" fill="none"/>';
+  /* hoja derecha */
+  s += '<path d="M0,-3 C7,-6.5 15,-6 20.5,0.5 C14,5 5,2 0,-3 Z" fill="url(#gLeafM)"/>';
+  s += '<path d="M1.4,-3.2 C7,-5.2 13.4,-4.6 18.6,-0.6" stroke="rgba(251,243,228,.5)" stroke-width=".85" fill="none"/>';
+  s += '<path d="M2.4,-1.2 C7.6,-2.6 12.6,-2 17,1" stroke="rgba(251,243,228,.25)" stroke-width=".6" fill="none"/>';
+  /* mazorca: capacho atrás, granos en hileras, brillo, barbas y capacho delante */
+  s += '<g transform="translate(10,-6) rotate(24)">';
+  s += '<path d="M-4.2,3.5 C-7.8,7.5 -8.4,13.4 -5.8,16.8 C-3.2,12.6 -3,7.6 -4.2,3.5 Z" fill="url(#gHusk)"/>';
+  s += '<path d="M4.2,3.5 C7.8,7.5 8.4,13.4 5.8,16.8 C3.2,12.6 3,7.6 4.2,3.5 Z" fill="url(#gHusk)" opacity=".85"/>';
+  s += '<ellipse rx="5.4" ry="10.6" fill="url(#gCob)"/>';
+  const rows = [[-7.3, [-1.8, 0, 1.8]], [-4.9, [-3, -1.05, 0.9, 2.85]], [-2.5, [-3.5, -1.7, 0.1, 1.9, 3.6]], [-0.1, [-3.7, -1.8, 0, 1.8, 3.7]], [2.3, [-3.6, -1.9, -0.1, 1.7, 3.5]], [4.7, [-2.9, -1, 0.9, 2.8]], [7.1, [-1.7, 0, 1.7]]];
+  rows.forEach(function eachRow(row, ri) {
+    row[1].forEach(function eachCol(x, ci) {
+      s += '<circle cx="' + x + '" cy="' + row[0] + '" r="1.02" fill="' + (((ri + ci) % 2) ? '#E4AE2C' : '#F7D465') + '"/>';
+    });
+  });
+  s += '<ellipse cx="-1.9" cy="-3.4" rx="1.4" ry="4.4" fill="rgba(255,255,255,.28)" transform="rotate(-10 -1.9 -3.4)"/>';
+  s += '<path d="M0,-10.4 C0.6,-12.8 2.2,-14.2 4,-14.8 M0,-10.4 C-0.4,-13 0.4,-15 1.6,-16.2 M0,-10.4 C-1.4,-12.6 -3,-13.6 -4.6,-13.8" stroke="#C98A3D" stroke-width=".8" fill="none" stroke-linecap="round"/>';
+  s += '<path d="M-1.5,5 C-4.5,9 -4.6,14.5 -2,17.3 C0.6,13 0.8,8.4 -1.5,5 Z" fill="#4C7A3D"/>';
+  s += '<path d="M-1.9,6.6 C-3.4,9.6 -3.5,13.2 -2.5,15.8" stroke="rgba(251,243,228,.35)" stroke-width=".6" fill="none"/>';
+  s += '</g>';
+  /* espiga con anteras y polen */
+  s += '<g stroke="#C9A227" stroke-width="1.3" fill="none" stroke-linecap="round">';
+  s += '<path d="M0.5,-21 C0.5,-25.5 0.5,-29 0.5,-32.5"/><path d="M0.5,-21 C-1.8,-25 -4.8,-27.3 -7.8,-29.2"/><path d="M0.5,-21 C2.8,-25 5.8,-27.3 8.8,-29.2"/><path d="M0.5,-21 C-0.8,-25.8 -2.6,-28.8 -4.2,-30.8"/><path d="M0.5,-21 C1.8,-25.8 3.6,-28.8 5.2,-30.8"/>';
+  s += '</g>';
+  s += '<path d="M-4.4,-26.6 L-5,-25 M3.6,-27 L4.2,-25.4 M-1.6,-29.4 L-2.1,-27.8 M2,-25.4 L2.4,-23.8" stroke="#E8B84B" stroke-width=".8" stroke-linecap="round" fill="none"/>';
+  s += '<g fill="#F2C744"><circle cx="0.5" cy="-33" r="1.1"/><circle cx="-8.3" cy="-29.7" r="1"/><circle cx="9.3" cy="-29.7" r="1"/><circle cx="-4.6" cy="-31.4" r=".85"/><circle cx="5.7" cy="-31.4" r=".85"/></g>';
+  s += '<g fill="#F2C744" opacity=".5"><circle cx="12.2" cy="-26.4" r=".7"/><circle cx="-11.2" cy="-26.8" r=".7"/></g>';
+  return s;
+})();
+
+export const CENTER_PAPA = (function build() {
+  function leaflet(x, y, rot, rx, ry, grad) {
+    return '<g transform="translate(' + x + ',' + y + ') rotate(' + rot + ')">' +
+      '<ellipse rx="' + rx + '" ry="' + ry + '" fill="url(#' + grad + ')"/>' +
+      '<path d="M0,' + (ry * 0.72).toFixed(1) + ' L0,' + (-ry * 0.72).toFixed(1) + '" stroke="rgba(251,243,228,.5)" stroke-width=".6" fill="none"/>' +
+      '</g>';
+  }
+  function florPapa(x, y, sc, rot) {
+    let s = '<g transform="translate(' + x + ',' + y + ') scale(' + sc + ') rotate(' + rot + ')">';
+    [[0, -2.7, 0], [2.57, -0.83, 72], [1.59, 2.18, 144], [-1.59, 2.18, 216], [-2.57, -0.83, 288]].forEach(function eachPetal(p) {
+      s += '<ellipse cx="' + p[0] + '" cy="' + p[1] + '" rx="2" ry="3.1" transform="rotate(' + p[2] + ' ' + p[0] + ' ' + p[1] + ')" fill="url(#gFlor)" stroke="#A98BC4" stroke-width=".4"/>';
+    });
+    return s + '<path d="M0,-1.9 L1.5,1.2 L-1.5,1.2 Z" fill="#E8B84B" stroke="#C9931F" stroke-width=".4"/></g>';
+  }
+  let s = '';
+  /* raicillas hacia los tubérculos */
+  s += '<g stroke="#A87C4F" stroke-width=".9" fill="none" opacity=".9" stroke-linecap="round">';
+  s += '<path d="M0,16 C-4,19 -7,21.5 -9.5,23.5"/><path d="M0,16 C3,19.5 5.5,22.5 7.5,25"/><path d="M0,16 C-0.5,18 -0.8,19.5 -0.8,20.5"/>';
+  s += '<path d="M-4,18.5 C-5.5,19 -6.5,19.8 -7.5,20.6 M3,19.5 C4.5,20 5.5,20.8 6.5,21.4" stroke-width=".6" opacity=".7"/>';
+  s += '</g>';
+  /* tubérculos con volumen, ojos y lenticelas */
+  s += '<g stroke="#7A5230" stroke-width=".9">';
+  s += '<ellipse cx="-11" cy="26" rx="7.6" ry="5.4" fill="url(#gTuber)" transform="rotate(-14 -11 26)"/>';
+  s += '<ellipse cx="9.5" cy="27.5" rx="8" ry="5.6" fill="url(#gTuber)" transform="rotate(11 9.5 27.5)"/>';
+  s += '<ellipse cx="-0.5" cy="21" rx="5" ry="3.8" fill="url(#gTuberL)"/>';
+  s += '</g>';
+  s += '<g stroke="#6E4A28" stroke-width=".75" fill="none" stroke-linecap="round">';
+  s += '<path d="M-14.5,24 q1.1,-1 2.2,-0.3 M-8.6,27.6 q1.1,-.9 2.2,-.2 M6.8,26.4 q1.1,-.9 2.2,-.2 M12.4,29.2 q1.1,-.9 2.2,-.2 M-1.8,20.4 q.9,-.8 1.8,-.2"/>';
+  s += '</g>';
+  s += '<g fill="#C08A4E" opacity=".55"><circle cx="-12.8" cy="28.2" r=".5"/><circle cx="-7.2" cy="24.6" r=".5"/><circle cx="9.8" cy="30" r=".5"/><circle cx="13.6" cy="26.6" r=".5"/><circle cx="1.6" cy="22.4" r=".45"/></g>';
+  /* tallos */
+  s += '<g stroke="url(#gStalk)" stroke-width="1.9" fill="none" stroke-linecap="round">';
+  s += '<path d="M0,16 C-3,9 -7,3 -10,-3"/><path d="M0,16 C0,8 0.5,0 1,-10"/><path d="M0,16 C4,10 8,4 11,-1"/>';
+  s += '</g>';
+  /* follaje compuesto (foliolos con nervadura) */
+  s += leaflet(-12.5, -6.5, -32, 3.4, 4.8, 'gLeafD');
+  s += leaflet(-6.8, -9.8, -14, 3, 4.3, 'gLeafM');
+  s += leaflet(-13, 1.5, -60, 2.8, 4, 'gLeafM');
+  s += leaflet(-5.8, 3, -42, 2.8, 4, 'gLeafD');
+  s += leaflet(-2.8, -6.6, -20, 2.7, 3.9, 'gLeafL');
+  s += leaflet(4.6, -5.8, 18, 2.7, 3.9, 'gLeafM');
+  s += leaflet(13.5, -4.5, 31, 3.4, 4.8, 'gLeafD');
+  s += leaflet(8.2, -8.8, 14, 3, 4.3, 'gLeafM');
+  s += leaflet(13.8, 3, 58, 2.8, 4, 'gLeafM');
+  s += leaflet(6.6, 5, 44, 2.8, 4, 'gLeafD');
+  /* tallito floral y flores de papa (corola lila, antera dorada) */
+  s += '<path d="M1,-10 C0.8,-12.5 0.4,-15 0,-17" stroke="#4C7A3D" stroke-width="1.1" fill="none" stroke-linecap="round"/>';
+  s += '<path d="M0.6,-13.5 C2.4,-14.5 4.2,-15.4 5.6,-16" stroke="#4C7A3D" stroke-width=".8" fill="none" stroke-linecap="round"/>';
+  s += florPapa(0, -20, 1, 0);
+  s += florPapa(6, -16.5, 0.72, 18);
+  s += '<ellipse cx="-4.6" cy="-16" rx="1.5" ry="2" fill="#B497CE" transform="rotate(-18 -4.6 -16)"/>';
+  s += '<path d="M-3.9,-14.3 C-2.9,-13.1 -1.9,-12 -1,-11" stroke="#4C7A3D" stroke-width=".8" fill="none" stroke-linecap="round"/>';
+  return s;
+})();
+
+export const CENTER_CAFE = (function build() {
+  /* hoja de café: brillo, nervadura central y laterales */
+  function hoja(tx, ty, rot, sx, sy) {
+    return '<g transform="translate(' + tx + ',' + ty + ') rotate(' + rot + ') scale(' + sx + ',' + sy + ')">' +
+      '<path d="M0,0 C2.4,-4.4 8,-5.6 11.5,-3 C9.4,1 3.6,1.4 0,0 Z" fill="url(#gLeafCafe)"/>' +
+      '<path d="M0.8,-0.4 C4.4,-2.2 8,-2.9 10.6,-2.8" stroke="rgba(220,235,205,.55)" stroke-width=".7" fill="none"/>' +
+      '<path d="M3,-1.4 C3.6,-2.5 4.4,-3.4 5.4,-4 M5.6,-1.9 C6.2,-2.9 7.1,-3.7 8,-4.2 M3.2,-0.7 C4,-0.3 4.9,-0.1 5.7,0 M6,-1 C6.8,-0.7 7.7,-0.6 8.5,-0.6" stroke="rgba(220,235,205,.3)" stroke-width=".5" fill="none"/>' +
+      '<path d="M1.6,-2.4 C4.6,-4.3 8,-4.9 10.3,-3.6" stroke="rgba(255,255,255,.22)" stroke-width="1.3" fill="none" stroke-linecap="round"/>' +
+      '</g>';
+  }
+  /* cereza con brillo y ombligo */
+  function cereza(x, y, r, grad, st) {
+    return '<circle cx="' + x + '" cy="' + y + '" r="' + r + '" fill="url(#' + grad + ')" stroke="' + st + '" stroke-width=".45"/>' +
+      '<circle cx="' + (x - r * 0.34).toFixed(1) + '" cy="' + (y - r * 0.36).toFixed(1) + '" r=".62" fill="rgba(255,255,255,.55)"/>' +
+      '<circle cx="' + x + '" cy="' + (y + r * 0.74).toFixed(1) + '" r=".4" fill="#4A100B" opacity=".8"/>';
+  }
+  let s = '';
+  /* tronco leñoso y ramas */
+  s += '<path d="M-1,16 C-1,6 0,-8 2,-24" stroke="url(#gWood)" stroke-width="2.6" fill="none" stroke-linecap="round"/>';
+  s += '<path d="M0,-2 C5,-3.5 11,-4.5 16,-3.8" stroke="url(#gWood)" stroke-width="1.7" fill="none" stroke-linecap="round"/>';
+  s += '<path d="M1,-13 C-4,-14.5 -10,-15.5 -15,-14.8" stroke="url(#gWood)" stroke-width="1.7" fill="none" stroke-linecap="round"/>';
+  /* hojas brillantes en pares */
+  s += hoja(16, -3.8, -32, 1, 1);
+  s += hoja(15, -3.2, 26, 0.95, 0.95);
+  s += hoja(-15, -14.8, 30, -1, 1);
+  s += hoja(-14, -14.2, -25, -0.95, 0.95);
+  s += hoja(2, -24, -65, 0.85, 0.85);
+  s += hoja(2, -24, 65, -0.85, 0.85);
+  /* cerezas pegadas a la rama, como en el cafeto real */
+  s += cereza(6, -1.4, 2.6, 'gCherry', '#7A1F16');
+  s += cereza(9.8, -0.6, 2.6, 'gCherry', '#7A1F16');
+  s += cereza(7.6, -4.6, 2.5, 'gCherry', '#7A1F16');
+  s += cereza(11.6, -3.4, 2.4, 'gCherry', '#7A1F16');
+  s += cereza(13.4, -0.4, 2.2, 'gCherryV', '#47702F');
+  s += cereza(-6.5, -12.4, 2.4, 'gCherry', '#7A1F16');
+  s += cereza(-9.9, -11.8, 2.3, 'gCherry', '#7A1F16');
+  s += cereza(-12.6, -13.2, 2.2, 'gCherry', '#7A1F16');
+  /* florecitas blancas de nudo */
+  s += '<g transform="translate(3,-8.6)" fill="#FFFDF8"><circle cx="-1.2" cy="0" r="1"/><circle cx="1.2" cy="0" r="1"/><circle cx="0" cy="-1.2" r="1"/><circle cx="0" cy="1.2" r="1"/><circle r=".7" fill="#F2C744"/></g>';
+  s += '<g transform="translate(-4.2,-10.6) scale(.7)" fill="#FFFDF8"><circle cx="-1.2" cy="0" r="1"/><circle cx="1.2" cy="0" r="1"/><circle cx="0" cy="-1.2" r="1"/><circle cx="0" cy="1.2" r="1"/><circle r=".7" fill="#F2C744"/></g>';
+  return s;
+})();
+
+export const CENTER_FRESA = (function build() {
+  /* foliolo aserrado con nervaduras */
+  function foliolo(rot, sc, grad) {
+    return '<g transform="rotate(' + rot + ') scale(' + sc + ')">' +
+      '<path d="M0,0 C-4.2,-0.8 -6,-4 -5,-8 Q-3.4,-6.9 -2.8,-8.6 Q-1.4,-7.4 0,-9 Q1.4,-7.4 2.8,-8.6 Q3.4,-6.9 5,-8 C6,-4 4.2,-0.8 0,0 Z" fill="url(#' + grad + ')"/>' +
+      '<path d="M0,-1 L0,-7.4 M-0.6,-2.2 C-1.9,-3.3 -3,-4.6 -3.6,-5.9 M0.6,-2.2 C1.9,-3.3 3,-4.6 3.6,-5.9" stroke="rgba(251,243,228,.5)" stroke-width=".6" fill="none"/>' +
+      '</g>';
+  }
+  function hojaTrifoliada(x, y, rot, sc, g1, g2) {
+    return '<g transform="translate(' + x + ',' + y + ') rotate(' + rot + ') scale(' + sc + ')">' +
+      foliolo(-52, 0.8, g2) + foliolo(48, 0.8, g2) + foliolo(0, 1, g1) +
+      '</g>';
+  }
+  let s = '';
+  /* pecíolos desde la corona */
+  s += '<path d="M0,13 C-3,13 -5.6,12.9 -7.8,12.4 M0,13 C3,13 5.8,12.7 8.6,12.2 M0,13 C0.3,12 0.4,11.2 0.5,10.6" stroke="#4C7A3D" stroke-width="1.2" fill="none" stroke-linecap="round"/>';
+  /* estolón con hijuelo (la fresa camina) */
+  s += '<path d="M-1.5,14 C-8,16.6 -14,17 -19,14.6" stroke="#C0625A" stroke-width=".9" fill="none" stroke-linecap="round"/>';
+  s += '<g transform="translate(-19,14.4) scale(.55)"><path d="M0,0 C-1.6,-3.4 -4.8,-4 -6,-1.8 C-4.6,0.4 -1.8,0.6 0,0 Z" fill="url(#gLeafM)"/><path d="M0,0 C1.6,-3.4 4.8,-4 6,-1.8 C4.6,0.4 1.8,0.6 0,0 Z" fill="url(#gLeafD)"/></g>';
+  /* hojas trifoliadas */
+  s += hojaTrifoliada(0.5, 10.8, -2, 0.92, 'gLeafL', 'gLeafM');
+  s += hojaTrifoliada(-8, 12.6, -34, 0.95, 'gLeafD', 'gLeafM');
+  s += hojaTrifoliada(9, 12.2, 32, 1, 'gLeafM', 'gLeafD');
+  /* corona */
+  s += '<path d="M-2.4,13.8 L0,12 L2.4,13.8" stroke="#8B5E34" stroke-width="1.4" fill="none" stroke-linecap="round"/>';
+  /* tallo floral y flor blanca */
+  s += '<path d="M-1,13 C-6,6.5 -9.8,-1 -11.8,-7.6" stroke="#5B8A52" stroke-width="1.2" fill="none" stroke-linecap="round"/>';
+  s += '<g transform="translate(-12,-10)">';
+  [[0, -3, 0], [2.85, -0.93, 72], [1.76, 2.43, 144], [-1.76, 2.43, 216], [-2.85, -0.93, 288]].forEach(function eachPetal(p) {
+    s += '<ellipse cx="' + p[0] + '" cy="' + p[1] + '" rx="2.2" ry="2.9" transform="rotate(' + p[2] + ' ' + p[0] + ' ' + p[1] + ')" fill="#FFFDF8" stroke="#E7D9B8" stroke-width=".5"/>';
+  });
+  s += '<circle r="1.8" fill="#F2C744"/>';
+  [[0, -1.05], [1, -0.32], [0.62, 0.85], [-0.62, 0.85], [-1, -0.32]].forEach(function eachDot(p) {
+    s += '<circle cx="' + p[0] + '" cy="' + p[1] + '" r=".38" fill="#C9931F"/>';
+  });
+  s += '</g>';
+  /* tallo del fruto y fresa madura */
+  s += '<path d="M2,13 C8,8 12.5,2 14.7,-4.8" stroke="#5B8A52" stroke-width="1.2" fill="none" stroke-linecap="round"/>';
+  s += '<g transform="translate(15,-7) scale(.92)">';
+  s += '<path d="M0,-0.5 C5.4,-0.5 7.4,3.6 5.9,7.9 C4.5,12 2,14.4 0,15.8 C-2,14.4 -4.5,12 -5.9,7.9 C-7.4,3.6 -5.4,-0.5 0,-0.5 Z" fill="url(#gBerry)"/>';
+  s += '<path d="M-3.6,2 C-4.6,4.8 -4.2,8 -2.8,10.8" stroke="rgba(255,255,255,.45)" stroke-width="1.1" fill="none" stroke-linecap="round"/>';
+  s += '<g fill="#F2C744" stroke="#A8641A" stroke-width=".3">';
+  [[-2.2, 3.2], [0, 2.6], [2.2, 3.2], [-2.9, 5.9], [-0.8, 5.4], [1.2, 5.4], [3, 5.9], [-1.9, 8.6], [0.2, 8.4], [2.1, 8.6], [-0.8, 11.2], [1.2, 11.2], [0.2, 13.4]].forEach(function eachSeed(p) {
+    s += '<circle cx="' + p[0] + '" cy="' + p[1] + '" r=".58"/>';
+  });
+  s += '</g>';
+  s += '<path d="M-4.8,-0.6 L-2.7,-3.2 L-0.9,-1 L0,-3.9 L0.9,-1 L2.7,-3.2 L4.8,-0.6 Q0,2 -4.8,-0.6 Z" fill="#4C7A3D"/>';
+  s += '<path d="M0,-2.8 L-0.5,-5.2" stroke="#5B8A52" stroke-width="1.1" fill="none" stroke-linecap="round"/>';
+  s += '</g>';
+  return s;
+})();
+
+export const CENTER_FRIJOL = (function build() {
+  /* hoja acorazonada con nervaduras */
+  function hoja(x, y, rot, sc, grad) {
+    return '<g transform="translate(' + x + ',' + y + ') rotate(' + rot + ') scale(' + sc + ')">' +
+      '<path d="M0,-1.5 C-1.8,-4.8 -6.6,-4.8 -6.6,-1.6 C-6.6,1.2 -2.9,3 0,5.4 C2.9,3 6.6,1.2 6.6,-1.6 C6.6,-4.8 1.8,-4.8 0,-1.5 Z" fill="url(#' + grad + ')"/>' +
+      '<path d="M0,-2.4 L0,4.4 M-0.5,-0.3 C-1.9,-0.7 -3.3,-0.9 -4.5,-0.7 M0.5,-0.3 C1.9,-0.7 3.3,-0.9 4.5,-0.7" stroke="rgba(251,243,228,.5)" stroke-width=".6" fill="none"/>' +
+      '</g>';
+  }
+  /* vaina rolliza: cuerpo en trazo grueso, granos marcados, quilla clara y piquito */
+  function vaina(tx, ty, rot, sx) {
+    return '<g transform="translate(' + tx + ',' + ty + ') rotate(' + rot + ') scale(' + sx + ',1)">' +
+      '<path d="M-0.4,0.4 C1.4,3.4 1.8,7.6 0.8,11.6 C0.5,12.8 0,13.8 -0.6,14.5" stroke="url(#gPod)" stroke-width="3.5" fill="none" stroke-linecap="round"/>' +
+      '<path d="M-0.7,14.8 C-1.1,15.4 -1.6,15.8 -2.1,16" stroke="#4C7A3D" stroke-width="1" fill="none" stroke-linecap="round"/>' +
+      '<g fill="#2E5026" opacity=".32"><ellipse cx="0.4" cy="3.2" rx="1.15" ry="1.35"/><ellipse cx="0.8" cy="6.2" rx="1.15" ry="1.35"/><ellipse cx="0.6" cy="9.2" rx="1.1" ry="1.3"/><ellipse cx="0" cy="11.8" rx="1" ry="1.2"/></g>' +
+      '<path d="M1,2 C2.3,5.2 2.5,8.8 1.5,12" stroke="rgba(251,243,228,.55)" stroke-width=".6" fill="none" stroke-linecap="round"/>' +
+      '<path d="M-0.5,-0.7 C-1.1,-1.5 -1.9,-2 -2.8,-2.2" stroke="#4C7A3D" stroke-width="1" fill="none" stroke-linecap="round"/>' +
+      '</g>';
+  }
+  let s = '';
+  /* tutor de madera */
+  s += '<path d="M6,16 L-3,-29" stroke="url(#gWood)" stroke-width="2.8" stroke-linecap="round"/>';
+  /* guía voluble con brillo */
+  s += '<path d="M-5,16 C1,12 9,7.5 3,2.5 C-3,-1.5 8,-6.5 3,-11.5 C-2,-16 7,-19.5 1,-24.5" stroke="url(#gVine)" stroke-width="2.2" fill="none" stroke-linecap="round"/>';
+  s += '<path d="M-5.6,15.3 C0.2,11.4 8,7.2 2.2,2.2" stroke="#8FBB7C" stroke-width=".7" fill="none" opacity=".55" stroke-linecap="round"/>';
+  /* la guía abraza el tutor: segmentos del palo por encima */
+  s += '<path d="M4.72,6.4 L4,10" stroke="url(#gWood)" stroke-width="2.8" stroke-linecap="round"/>';
+  s += '<path d="M-0.92,-18.6 L-0.28,-15.4" stroke="url(#gWood)" stroke-width="2.8" stroke-linecap="round"/>';
+  /* zarcillo */
+  s += '<path d="M1,-24.5 C0,-27.5 3,-29.5 4.2,-27.6 C5.2,-26 3.2,-25.3 3.2,-26.8" stroke="#5B8A52" stroke-width="1.1" fill="none" stroke-linecap="round"/>';
+  /* pedúnculos y hojas */
+  s += '<path d="M-1,-2 C-3,-2.2 -5,-2.4 -6.8,-2.6 M4,-9 C5.6,-9.2 7.2,-9.4 8.6,-9.6 M0.5,-18 C-1,-18.5 -2.6,-19 -4,-19.4" stroke="#4C7A3D" stroke-width="1" fill="none" stroke-linecap="round"/>';
+  s += hoja(-9, -3, -16, 1, 'gLeafD');
+  s += hoja(10.5, -10, 18, 0.92, 'gLeafM');
+  s += hoja(-6.5, -20, -8, 0.72, 'gLeafL');
+  /* florecitas lila de fríjol */
+  s += '<path d="M5,-13.2 C6,-14 7,-14.8 7.5,-15.4" stroke="#4C7A3D" stroke-width=".8" fill="none" stroke-linecap="round"/>';
+  s += '<g transform="translate(7.5,-16)"><circle r="1.7" fill="#D9C6EA"/><ellipse cx="0.3" cy="1.3" rx="1.3" ry=".9" fill="#B99BD4"/><circle cx="-0.3" cy="-0.3" r=".45" fill="#FFFDF8"/></g>';
+  s += '<g transform="translate(10,-14) scale(.75)"><circle r="1.7" fill="#D9C6EA"/><ellipse cx="0.3" cy="1.3" rx="1.3" ry=".9" fill="#B99BD4"/><circle cx="-0.3" cy="-0.3" r=".45" fill="#FFFDF8"/></g>';
+  /* vainas colgando de las axilas, despejadas de la guía */
+  s += vaina(13, -7.5, 14, 1);
+  s += vaina(-13, -5, -4, -0.9);
+  return s;
+})();
+
+/* ---- Glifos de fase: familia unificada ----
+   Reglas de la familia: silueta llena en el color de fase, una capa de luz
+   (tint), detalle interior en crema con trazo .8-.9, tallos a 1.6-1.7,
+   puntas redondas. Cada glifo cuenta su fase de un vistazo. */
+export const GLYPHS = {
+  semilla(c) {
+    return '<path d="M0,-8.3 C5.6,-7.4 8,-2.6 6.6,2.6 C5.3,7.4 -5.3,7.4 -6.6,2.6 C-8,-2.6 -5.6,-7.4 0,-8.3 Z" fill="' + c + '"/>' +
+      '<path d="M-1.2,-7.7 C-4.9,-6.5 -6.7,-2.8 -5.8,1.6 C-5.4,3.7 -4.1,5.3 -2.4,6.1 C-4.4,1.4 -4.1,-3.8 -1.2,-7.7 Z" fill="' + tint(c, 0.32) + '"/>' +
+      '<path d="M1.1,-4.4 C3.3,-2.2 3.6,1.2 1.9,4.5" stroke="' + CREAM + '" stroke-width="1.3" fill="none" stroke-linecap="round"/>' +
+      '<circle cx="1" cy="-4.8" r="1.15" fill="' + CREAM + '"/>';
+  },
+  germinacion(c) {
+    return '<path d="M-1.2,4.4 C-4.5,4 -6.2,5.9 -5.8,8.4 C-3.5,9.1 -1,7.6 -0.3,5.3 Z" fill="#8B5E34"/>' +
+      '<path d="M1.2,4.4 C4.5,4 6.2,5.9 5.8,8.4 C3.5,9.1 1,7.6 0.3,5.3 Z" fill="' + tint('#8B5E34', 0.25) + '"/>' +
+      '<path d="M0,5.6 C0.2,3 0.1,0.4 0,-2" stroke="' + c + '" stroke-width="1.7" fill="none" stroke-linecap="round"/>' +
+      '<path d="M0,-2 C-1.8,-6.6 -6.3,-8.2 -8.9,-6 C-7.5,-2.4 -3.3,-1.2 0,-2 Z" fill="' + c + '"/>' +
+      '<path d="M0,-2 C1.6,-5.9 5.6,-7.5 8.2,-5.5 C6.9,-2.1 3.1,-1.1 0,-2 Z" fill="' + tint(c, 0.28) + '"/>' +
+      '<path d="M-1.3,-2.8 C-3.4,-3.8 -5.5,-4.7 -7.3,-5.3 M1.2,-2.7 C3,-3.6 4.9,-4.4 6.6,-4.9" stroke="' + CREAM + '" stroke-width=".85" fill="none" stroke-linecap="round"/>';
+  },
+  crecimiento(c) {
+    return '<path d="M0,8.8 C0.3,3 0.2,-3 0,-8.4" stroke="' + c + '" stroke-width="1.7" fill="none" stroke-linecap="round"/>' +
+      '<path d="M-0.2,3.4 C-2.2,-0.2 -6.6,-1.4 -9.3,0.6 C-7.7,4 -3.2,4.6 -0.2,3.4 Z" fill="' + c + '"/>' +
+      '<path d="M0.2,-1 C2.2,-4.6 6.6,-5.8 9.3,-3.8 C7.7,-0.4 3.2,0.2 0.2,-1 Z" fill="' + tint(c, 0.22) + '"/>' +
+      '<path d="M0,-8.4 C-0.9,-11 -3.5,-11.9 -5.3,-10.5 C-4.3,-8.3 -2,-7.8 0,-8.4 Z" fill="' + tint(c, 0.38) + '"/>' +
+      '<path d="M0,-8.4 C0.8,-10.4 2.8,-11.2 4.3,-10.2 C3.5,-8.5 1.7,-8 0,-8.4 Z" fill="' + tint(c, 0.5) + '"/>' +
+      '<path d="M-1.4,3 C-3.7,1.9 -5.9,1 -7.8,0.7 M1.4,-1.4 C3.7,-2.5 5.9,-3.4 7.8,-3.7" stroke="' + CREAM + '" stroke-width=".85" fill="none" stroke-linecap="round"/>';
+  },
+  floracion(c) {
+    let s = '';
+    for (let k = 0; k < 5; k++) {
+      const a = (-90 + k * 72) * Math.PI / 180;
+      const x = +(4.9 * Math.cos(a)).toFixed(2);
+      const y = +(4.9 * Math.sin(a)).toFixed(2);
+      s += '<ellipse cx="' + x + '" cy="' + y + '" rx="3.1" ry="4.6" transform="rotate(' + (k * 72) + ' ' + x + ' ' + y + ')" fill="' + (k % 2 ? tint(c, 0.18) : c) + '" stroke="' + CREAM + '" stroke-width=".8"/>';
+    }
+    s += '<circle r="2.75" fill="#F2C744"/>';
+    for (let k = 0; k < 5; k++) {
+      const a = (-90 + k * 72) * Math.PI / 180;
+      s += '<circle cx="' + (1.55 * Math.cos(a)).toFixed(2) + '" cy="' + (1.55 * Math.sin(a)).toFixed(2) + '" r=".5" fill="#C9931F"/>';
+    }
+    return s;
+  },
+  fructificacion(c) {
+    return '<path d="M0.4,-6.2 C1,-8.2 2.2,-9.5 4,-10.1" stroke="#4C7A3D" stroke-width="1.6" fill="none" stroke-linecap="round"/>' +
+      '<path d="M1,-7.5 C3.6,-10.6 8,-10.8 10,-8.6 C8.2,-6 4.2,-5.8 1,-7.5 Z" fill="#5B8A52"/>' +
+      '<path d="M2.4,-7.8 C4.8,-8.9 7,-9.2 8.8,-8.7" stroke="' + CREAM + '" stroke-width=".75" fill="none"/>' +
+      '<circle cy="1.9" r="6.9" fill="' + c + '"/>' +
+      '<ellipse cy="5.4" rx="4.6" ry="2.4" fill="' + shade(c, 0.25) + '" opacity=".45"/>' +
+      '<ellipse cx="-2.5" cy="-0.6" rx="2.1" ry="1.25" fill="rgba(255,255,255,.45)" transform="rotate(-30 -2.5 -0.6)"/>' +
+      '<circle cx="0.3" cy="-4.8" r=".75" fill="' + shade(c, 0.35) + '"/>';
+  },
+  cosecha(c) {
+    return '<circle cx="-3.4" cy="-4.6" r="2.15" fill="#E9B93B"/><circle cx="1.2" cy="-5.9" r="2.15" fill="#D6572A"/><circle cx="5" cy="-3.8" r="1.95" fill="#7CA46B"/>' +
+      '<circle cx="-4.1" cy="-5.3" r=".6" fill="rgba(255,255,255,.6)"/><circle cx="0.5" cy="-6.6" r=".6" fill="rgba(255,255,255,.6)"/><circle cx="4.4" cy="-4.5" r=".55" fill="rgba(255,255,255,.6)"/>' +
+      '<path d="M-8.8,-2.2 C-4.9,-3.6 4.9,-3.6 8.8,-2.2 L6.6,7.3 C4.1,8.5 -4.1,8.5 -6.6,7.3 Z" fill="' + c + '"/>' +
+      '<path d="M-8.8,-2.2 C-4.9,-3.6 4.9,-3.6 8.8,-2.2 L8.4,-0.5 C4.7,-1.8 -4.7,-1.8 -8.4,-0.5 Z" fill="' + shade(c, 0.28) + '"/>' +
+      '<path d="M-7.6,1.7 C-3.2,0.6 3.2,0.6 7.6,1.7 M-6.9,4.6 C-2.9,3.7 2.9,3.7 6.9,4.6" stroke="' + CREAM + '" stroke-width=".85" fill="none" opacity=".75"/>' +
+      '<path d="M-3.2,-2.9 L-2.6,8 M3.2,-2.9 L2.6,8" stroke="' + shade(c, 0.2) + '" stroke-width="1" opacity=".55"/>';
+  },
+  poscosecha(c) {
+    return '<path d="M-3.3,-4.6 C-4.4,-6.7 -3.1,-8.5 -1.1,-8.9 L1.1,-8.9 C3.1,-8.5 4.4,-6.7 3.3,-4.6 Z" fill="' + tint(c, 0.22) + '"/>' +
+      '<path d="M-3.4,-4.6 L3.4,-4.6 C6.8,-2.5 8,1.9 6.6,7.7 L-6.6,7.7 C-8,1.9 -6.8,-2.5 -3.4,-4.6 Z" fill="' + c + '"/>' +
+      '<path d="M-3.4,-4.6 C-6.8,-2.5 -8,1.9 -6.6,7.7 L-4.4,7.7 C-5.5,2.1 -4.9,-1.9 -3.4,-4.6 Z" fill="' + shade(c, 0.18) + '" opacity=".65"/>' +
+      '<path d="M-4.1,-4.6 L4.1,-4.6" stroke="#5A3D22" stroke-width="1.7" stroke-linecap="round"/>' +
+      '<circle cy="-4.6" r=".95" fill="#5A3D22"/>' +
+      '<path d="M0.2,-2.9 L0.2,6.6" stroke="' + CREAM + '" stroke-width="1" stroke-dasharray="1.8 1.7" opacity=".85" fill="none"/>' +
+      '<g fill="' + CREAM + '" opacity=".9"><circle cx="-3.5" cy="3" r=".8"/><circle cx="-2.1" cy="5.5" r=".8"/><circle cx="3" cy="2.4" r=".8"/><circle cx="4.2" cy="5.2" r=".8"/></g>' +
+      '<circle cx="8.3" cy="8.3" r=".85" fill="' + tint(c, 0.3) + '"/><circle cx="6.5" cy="9.2" r=".8" fill="' + tint(c, 0.15) + '"/>';
+  },
+};
+
+/* Ojo de "qué observar": párpado almendrado, iris con brillo y pestañas */
+export const EYE_SVG_INNER =
+  '<path d="M12,4.6 L12,2.4 M6.2,6.1 L4.9,4.3 M17.8,6.1 L19.1,4.3" stroke="#C98A3D" stroke-width="1.6" stroke-linecap="round" fill="none"/>' +
+  '<path d="M2.6,14 C6.5,8 17.5,8 21.4,14 C17.5,20 6.5,20 2.6,14 Z" fill="#FFFDF8" stroke="#C98A3D" stroke-width="1.7" stroke-linejoin="round"/>' +
+  '<circle cx="12" cy="14" r="3.5" fill="#8B5E34"/><circle cx="12" cy="14" r="1.5" fill="#3E2A16"/><circle cx="13.3" cy="12.8" r=".9" fill="#FBF3E4"/>';
+
+/* ================= GEOMETRÍA DE LA RUEDA (v3) ================= */
+export const CX = 180;
+export const CY = 172;
+export const STEP_DEG = 360 / 7; // 51.43°
+export const DEG0 = -90; // semilla arriba
+export const R0 = 62;
+export const RSTEP = 13; // el radio crece con cada fase
+
+export function polar(deg, r) {
+  const a = deg * Math.PI / 180;
+  return { x: CX + r * Math.cos(a), y: CY + r * Math.sin(a) };
+}
+export function phaseDeg(i) { return DEG0 + i * STEP_DEG; }
+export function phaseR(i) { return R0 + i * RSTEP; }
+export function rAtDeg(deg) { return R0 + RSTEP * (deg - DEG0) / STEP_DEG; }
+
+/**
+ * Espiral discretizada como polilínea (igual que el mockup v3). Devuelve
+ * también la longitud total calculada numéricamente — a diferencia del
+ * mockup no necesitamos un <path> temporal del DOM para medirla, porque
+ * la polilínea se mide sumando segmentos (necesaria para la animación
+ * stroke-dasharray de "tallo que crece").
+ */
+export function spiralPath(degFrom, degTo, rFrom, rTo) {
+  const n = Math.max(2, Math.ceil(Math.abs(degTo - degFrom) / 3));
+  const pts = [];
+  let len = 0;
+  let prev = null;
+  for (let j = 0; j <= n; j++) {
+    const t = j / n;
+    const d = degFrom + (degTo - degFrom) * t;
+    const r = rFrom + (rTo - rFrom) * t;
+    const p = polar(d, r);
+    if (prev) len += Math.hypot(p.x - prev.x, p.y - prev.y);
+    prev = p;
+    pts.push(p.x.toFixed(1) + ',' + p.y.toFixed(1));
+  }
+  return { d: 'M' + pts.join(' L'), len: Math.ceil(len) + 2 };
+}

--- a/src/components/CicloVivo/cicloVivoData.js
+++ b/src/components/CicloVivo/cicloVivoData.js
@@ -1,0 +1,258 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- Datos de dominio del ciclo
+   (labels de fase, notas de observación agronómica y notas de respaldo de
+   capacidades). No son strings de UI reutilizables sino contenido; misma
+   convención que src/data/aprendizaje/guias-demo.js y marketplaceSeed.js. */
+/**
+ * cicloVivoData.js — datos de "El Ciclo Vivo" (rueda v3 aprobada).
+ * =====================================================================
+ * Estructura de las 7 fases + su mapeo de funciones (idéntico a la v3), el
+ * catálogo de especies del núcleo, la especie por defecto según piso térmico,
+ * y la tabla de respaldo de capacidades.
+ *
+ * FUENTE DE VERDAD del estado de cada función: `public/chagra-stats.json` →
+ * bloque `capacidades` (generado por scripts/gen-chagra-stats.mjs desde
+ * CAPABILITIES_STATUS). El widget hace fetch de ese JSON y pinta cada chip
+ * según el `estado` que traiga. `FALLBACK_CAPACIDADES` de aquí abajo es SOLO
+ * una red de seguridad para cuando el fetch falla (archivo aún no desplegado,
+ * offline): nunca es la verdad, solo evita que el widget quede en blanco.
+ *
+ * Cada función de fase referencia una capacidad por `cap`; el estado se
+ * resuelve contra el mapa `capacidades`. Así, cuando un artefacto pasa a
+ * 'activo' en la fuente de verdad, el chip se enciende solo — sin tocar este
+ * archivo ni el componente.
+ */
+import {
+  CENTER_MAIZ, CENTER_PAPA, CENTER_CAFE, CENTER_FRESA, CENTER_FRIJOL,
+} from './cicloVivoArte';
+
+/* ================= FASES (mapeo v3, 1:1) ================= */
+/* label: copy agronómico de la v3 (se conserva). cap: id de capacidad en la
+   fuente de verdad. camera: usa el glifo de cámara en el chip. */
+export const PHASES = [
+  {
+    key: 'semilla', name: 'Semilla', short: 'Semilla', color: '#8B5E34',
+    functions: [
+      { label: '¿Qué siembro? (piso térmico)', cap: 'que_siembro' },
+      { label: 'Calendario de siembra', cap: 'calendario_siembra' },
+      { label: '¿Sirve mi semilla?', cap: 'viabilidad_semilla' },
+      { label: 'Saberes de origen', cap: 'saberes' },
+    ],
+  },
+  {
+    key: 'germinacion', name: 'Germinación', short: 'Germina', color: '#7CA46B',
+    functions: [
+      { label: 'Semilleros', cap: 'semilleros' },
+      { label: 'Riego / agua', cap: 'riego_agua' },
+      { label: 'Suelo (cromatografía)', cap: 'cromatografia_suelo' },
+      { label: 'Biopreparados de arranque', cap: 'biopreparados' },
+    ],
+  },
+  {
+    key: 'crecimiento', name: 'Crecimiento', short: 'Crece', color: '#4C7A3D',
+    functions: [
+      { label: 'Tómele foto', cap: 'diagnostico_foto', camera: true },
+      { label: 'Plagas de esta etapa (MIP)', cap: 'mip_plagas' },
+      { label: 'Nutrición', cap: 'nutricion' },
+      { label: 'Asociaciones', cap: 'asociaciones' },
+      { label: '¿En qué fase va?', cap: 'fenologia' },
+    ],
+  },
+  {
+    key: 'floracion', name: 'Floración', short: 'Florece', color: '#E8879C',
+    functions: [
+      { label: 'Polinización (abejas)', cap: 'polinizacion' },
+      { label: 'Plagas de flor', cap: 'mip_plagas' },
+      { label: 'Heladas / clima', cap: 'clima' },
+      { label: 'Biopreparados', cap: 'biopreparados' },
+    ],
+  },
+  {
+    key: 'fructificacion', name: 'Fructificación', short: 'Fruto', color: '#D6572A',
+    functions: [
+      { label: 'Nutrición de llenado', cap: 'nutricion' },
+      { label: 'Plagas de fruto', cap: 'mip_plagas' },
+      { label: 'Madurez', cap: 'fenologia' },
+      { label: 'Insumos aplicados', cap: 'insumos' },
+    ],
+  },
+  {
+    key: 'cosecha', name: 'Cosecha', short: 'Cosecha', color: '#C98A3D',
+    functions: [
+      { label: 'Registrar cosecha', cap: 'registrar_cosecha' },
+      { label: 'Precio SIPSA', cap: 'precio_sipsa' },
+      { label: 'Mercado / circuitos cortos', cap: 'mercado' },
+    ],
+  },
+  {
+    key: 'poscosecha', name: 'Poscosecha', short: 'Guarda', color: '#C9A227',
+    functions: [
+      { label: 'Guardar semilla', cap: 'guardar_semilla' },
+      { label: 'Cerrar el ciclo (nutrientes → suelo)', cap: 'ciclo_cerrado' },
+      { label: 'Bitácora / aprendizaje', cap: 'bitacora' },
+    ],
+  },
+];
+
+/* Capacidades del motor del agente (transversales, no cuelgan de una fase).
+   Se muestran como una tira aparte al pie de la vista completa. */
+export const MOTOR_CAPS = ['rag_grounding', 'action_loop'];
+
+export const WHEEL_CAPTION = '"De la cosecha vuelve a nacer la semilla."';
+
+/* Fase de entrada por defecto (Crecimiento): punto medio visual de la rueda.
+   No es una afirmación sobre el cultivo real del usuario — es solo dónde
+   aterriza la vista. El usuario enfoca otra fase al tocarla. */
+export const DEFAULT_PHASE_INDEX = 2;
+
+/* ================= ESPECIES (núcleo de la rueda) ================= */
+export const SPECIES = {
+  maiz: {
+    key: 'maiz', label: 'Maíz', emoji: '🌽', su: 'Su maíz', center: CENTER_MAIZ,
+    observe: [
+      'Observe que el grano esté firme, sin hongos ni perforaciones, y que el embrión no esté descolorido.',
+      'Observe la humedad del semillero: ni encharcado ni seco. En clima frío la plúmula asoma entre el día 6 y 10.',
+      'Observe el color de las hojas (verde intenso = buena nutrición) y cuente cuántas tiene para saber en qué fase vegetativa va.',
+      'Observe la panoja liberando polen en las mañanas y los pelos de choclo húmedos y receptivos: ahí ocurre la polinización.',
+      'Presione un grano de la mazorca: si sale líquido lechoso, va bien; si sale aguado, le falta nutrición.',
+      'Observe la capacha seca y el grano duro: en clima frío ese es el punto para cosechar, hacia el día 210-240.',
+      'Observe que el grano quede bien seco antes de guardar semilla, para que no se dañe con hongos en el trojero.',
+    ],
+  },
+  papa: {
+    key: 'papa', label: 'Papa', emoji: '🥔', su: 'Su papa', center: CENTER_PAPA,
+    observe: [
+      'Observe que la semilla (tubérculo) tenga brotes cortos y vigorosos, sin pudriciones ni cortes mal cicatrizados.',
+      'Observe la emergencia pareja entre el día 15 y 30 en clima frío; si un surco no brota, revise la humedad del suelo.',
+      'Observe el follaje: hojas verde intenso y parejas. Al aporcar, cubra bien la base para proteger los tubérculos.',
+      'Observe las primeras flores: son la señal de que abajo empezó la tuberización. Cuide el riego en esta etapa.',
+      'Observe el engrose: escarbe con cuidado al borde de una mata y mire el tamaño del tubérculo sin dañar la planta.',
+      'Observe el amarillamiento natural del follaje: cuando la piel del tubérculo ya no se pela con el dedo, está de cosecha.',
+      'Observe que la papa cure en un lugar fresco, seco y oscuro, para que la piel se endurezca y no se enverdezca.',
+    ],
+  },
+  cafe: {
+    key: 'cafe', label: 'Café', emoji: '☕', su: 'Su café', center: CENTER_CAFE,
+    observe: [
+      'Observe que la semilla venga de frutos maduros y sanos; el germinador debe tener arena limpia y buena sombra.',
+      'Observe los "fósforos" y "mariposas" en el germinador: entre 50 y 75 días están listos para pasar a bolsa.',
+      'Observe hojas nuevas brillantes y sin roya (manchas anaranjadas por debajo). Revise el almácigo cada semana.',
+      'Observe la florescencia blanca después de las lluvias: de esas flores saldrá la cosecha en unos 8 meses.',
+      'Observe el llenado del grano y la broca: revise frutos perforados y haga control con trampas.',
+      'Observe el color: coja solo cereza madura, roja y pareja. El grano verde daña la calidad de todo el lote.',
+      'Observe la fermentación y el secado: café bien lavado y secado al punto (11-12% de humedad) paga mejor precio.',
+    ],
+  },
+  fresa: {
+    key: 'fresa', label: 'Fresa', emoji: '🍓', su: 'Su fresa', center: CENTER_FRESA,
+    observe: [
+      'Observe que las plántulas o estolones tengan corona sana y raíz blanca, sin manchas de hongos.',
+      'Observe el prendimiento los primeros 15 días: la corona debe quedar a ras de suelo, ni enterrada ni descubierta.',
+      'Observe las hojas nuevas y retire estolones si quiere fruta: la mata no alcanza para las dos cosas.',
+      'Observe las flores blancas y las abejas trabajando: sin buena polinización la fruta sale deforme.',
+      'Observe el cuajado y el color: proteja la fruta del contacto con el suelo para evitar pudriciones.',
+      'Observe el rojo parejo: coseche con cáliz y un pedacito de tallo, en las horas frescas de la mañana.',
+      'Observe la cadena de frío: la fresa respira rápido; entre más pronto llegue fresca al mercado, mejor precio.',
+    ],
+  },
+  frijol: {
+    key: 'frijol', label: 'Fríjol', emoji: '🫘', su: 'Su fríjol', center: CENTER_FRIJOL,
+    observe: [
+      'Observe que el grano esté entero, brillante y sin gorgojo. Haga una prueba de germinación con 10 semillas.',
+      'Observe la emergencia entre el día 5 y 8: las dos hojitas primarias deben salir enteras y sin cortes de trozadores.',
+      'Observe la guía buscando el tutor y el color de las hojas: amarillamiento entre venas puede ser falta de nutrición.',
+      'Observe los racimos de flores: el fríjol es delicado a la sequía en floración, cuide la humedad del suelo.',
+      'Observe el llenado de las vainas: palpe los granos y revise si hay perforaciones de picudo.',
+      'Observe las vainas secas y quebradizas: coseche en la mañana para que no se abran y se pierda grano.',
+      'Observe el secado final del grano y guárdelo en recipiente hermético con ceniza o cal para el gorgojo.',
+    ],
+  },
+};
+
+export const SPECIES_ORDER = ['maiz', 'papa', 'cafe', 'fresa', 'frijol'];
+
+/**
+ * Especie sugerida por defecto según el piso térmico colombiano. Es solo un
+ * punto de partida razonable; el usuario puede cambiarla y su elección se
+ * guarda en el perfil (override).
+ *   páramo/frío  -> papa, maíz (andinos de altura)
+ *   templado     -> café
+ *   cálido       -> fríjol
+ * Ver src/data/cropSuggestions.js:pisoTermicoFromAltitud para los slugs.
+ */
+export const PISO_ESPECIE_DEFAULT = {
+  paramo: 'papa',
+  frio: 'maiz',
+  templado: 'cafe',
+  calido: 'frijol',
+};
+
+/**
+ * Resuelve la especie a mostrar: override del perfil si es válido, si no la
+ * sugerida por piso térmico, si no maíz.
+ * @param {string|null|undefined} override - key guardada por el usuario.
+ * @param {string|null|undefined} piso - 'calido'|'templado'|'frio'|'paramo'.
+ * @returns {string} key de SPECIES.
+ */
+export function resolverEspecie(override, piso) {
+  if (override && SPECIES[override]) return override;
+  const porPiso = piso && PISO_ESPECIE_DEFAULT[piso];
+  if (porPiso && SPECIES[porPiso]) return porPiso;
+  return 'maiz';
+}
+
+/* ================= CAPACIDADES: respaldo offline ================= */
+/* Espejo de scripts/gen-chagra-stats.mjs:CAPABILITIES_STATUS. NO es la verdad
+   (el JSON generado lo es); solo evita que el widget quede vacío si el fetch
+   falla. El test cicloVivoData.test.js verifica que cubra todas las `cap` de
+   las fases (guard anti-drift). */
+export const FALLBACK_CAPACIDADES = {
+  que_siembro: { estado: 'activo', view: 'directorio', nota: 'Qué sembrar según su piso térmico.' },
+  calendario_siembra: { estado: 'activo', view: 'calendario_finca', nota: 'Calendario por ciclos.' },
+  viabilidad_semilla: { estado: 'proximamente', view: null, nota: 'Prueba de viabilidad de semilla; aún no está disponible.' },
+  saberes: { estado: 'parcial', view: 'directorio', nota: 'Saberes de origen en la ficha; cobertura escasa.' },
+  semilleros: { estado: 'activo', view: 'germinacion', nota: 'Guía y registro de semilleros.' },
+  riego_agua: { estado: 'parcial', view: 'agente', nota: 'Diagnóstico de agua vía el agente; sin pantalla propia.' },
+  cromatografia_suelo: { estado: 'activo', view: 'cromatografia', nota: 'Guía, registro y comparación; interpretación manual.' },
+  biopreparados: { estado: 'activo', view: 'biopreparados', nota: 'Galería de recetas con seguridad.' },
+  diagnostico_foto: { estado: 'activo', view: 'agente', nota: 'Tómele foto y el agente diagnostica.' },
+  mip_plagas: { estado: 'parcial', view: 'directorio', nota: 'Plagas y control biológico; cobertura incompleta.' },
+  nutricion: { estado: 'activo', view: 'ciclo_nutrientes', nota: 'Ciclo de nutrientes por etapa.' },
+  asociaciones: { estado: 'activo', view: 'asociaciones', nota: 'Asociaciones y antagonismos.' },
+  fenologia: { estado: 'activo', view: 'ciclo', nota: 'Etapa fenológica con línea de tiempo.' },
+  polinizacion: { estado: 'activo', view: 'animales_abejas', nota: 'Abejas y polinización.' },
+  clima: { estado: 'parcial', view: 'agente', nota: 'Alertas de clima y heladas; canal en vivo según disponibilidad.' },
+  insumos: { estado: 'activo', view: 'insumos', nota: 'Registro de insumos aplicados.' },
+  registrar_cosecha: { estado: 'activo', view: 'cosechar', nota: 'Registro de cosecha por planta o lote.' },
+  precio_sipsa: { estado: 'parcial', view: 'mercado', nota: 'Precio de referencia estático; canal en vivo tras flag.' },
+  mercado: { estado: 'activo', view: 'mercado', nota: 'Marketplace de circuitos cortos.' },
+  guardar_semilla: { estado: 'proximamente', view: null, nota: 'Banco de semilla propia; aún no está disponible.' },
+  ciclo_cerrado: { estado: 'parcial', view: 'ciclo_nutrientes', nota: 'Devolver nutrientes al suelo; hoy educativo.' },
+  bitacora: { estado: 'activo', view: 'bitacora', nota: 'Bitácora de la finca.' },
+  rag_grounding: { estado: 'parcial', view: 'agente', nota: 'Respuestas apoyadas en el corpus; verificación en expansión.' },
+  action_loop: { estado: 'parcial', view: 'agente', nota: 'Ejecuta acciones con su confirmación; nivel 1.' },
+};
+
+/**
+ * Resuelve el estado de una capacidad contra el mapa de capacidades (el
+ * fetcheado, o el de respaldo). Si el id no existe en ninguno, degrada a
+ * 'proximamente' para no prometer algo que no está declarado.
+ * @param {string} capId
+ * @param {Record<string, {estado:string, nota?:string, view?:string|null}>|null} capacidades
+ * @returns {{estado:'activo'|'parcial'|'proximamente', nota:string, view:string|null}}
+ */
+export function resolverEstado(capId, capacidades) {
+  const fuente = (capacidades && capacidades[capId]) || FALLBACK_CAPACIDADES[capId];
+  if (!fuente) return { estado: 'proximamente', nota: 'Próximamente.', view: null };
+  return {
+    estado: fuente.estado || 'proximamente',
+    nota: fuente.nota || '',
+    view: fuente.view || null,
+  };
+}
+
+/** Etiqueta corta para el badge de estado. */
+export const ESTADO_BADGE = {
+  activo: null,
+  parcial: 'parcial',
+  proximamente: 'pronto',
+};

--- a/src/components/CicloVivo/cicloVivoData.test.js
+++ b/src/components/CicloVivo/cicloVivoData.test.js
@@ -1,0 +1,62 @@
+/**
+ * cicloVivoData.test.js — invariantes puros de los datos del ciclo.
+ * Guarda contra drift entre las fases (los `cap` que referencian) y la tabla
+ * de respaldo offline, y valida la resolución de especie/estado.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  PHASES, SPECIES, SPECIES_ORDER, FALLBACK_CAPACIDADES,
+  resolverEspecie, resolverEstado,
+} from './cicloVivoData';
+
+describe('cicloVivoData — estructura de fases', () => {
+  it('tiene exactamente 7 fases con las claves de la v3', () => {
+    expect(PHASES).toHaveLength(7);
+    expect(PHASES.map((p) => p.key)).toEqual([
+      'semilla', 'germinacion', 'crecimiento', 'floracion', 'fructificacion', 'cosecha', 'poscosecha',
+    ]);
+  });
+
+  it('cada función referencia una capacidad presente en la tabla de respaldo (anti-drift)', () => {
+    for (const fase of PHASES) {
+      for (const fn of fase.functions) {
+        expect(FALLBACK_CAPACIDADES[fn.cap], `falta ${fn.cap} en FALLBACK_CAPACIDADES`).toBeTruthy();
+      }
+    }
+  });
+
+  it('cada especie tiene 7 notas de observación (una por fase)', () => {
+    for (const key of SPECIES_ORDER) {
+      expect(SPECIES[key].observe).toHaveLength(7);
+    }
+  });
+});
+
+describe('resolverEspecie', () => {
+  it('respeta el override del perfil si es una especie válida', () => {
+    expect(resolverEspecie('cafe', 'frio')).toBe('cafe');
+  });
+  it('ignora un override inválido y cae en la sugerida por piso', () => {
+    expect(resolverEspecie('marte', 'templado')).toBe('cafe');
+  });
+  it('sugiere por piso térmico cuando no hay override', () => {
+    expect(resolverEspecie(null, 'paramo')).toBe('papa');
+    expect(resolverEspecie(null, 'calido')).toBe('frijol');
+  });
+  it('cae en maíz sin override ni piso', () => {
+    expect(resolverEspecie(null, null)).toBe('maiz');
+  });
+});
+
+describe('resolverEstado', () => {
+  it('prefiere el mapa fetcheado sobre el respaldo', () => {
+    const fetched = { cromatografia_suelo: { estado: 'proximamente', view: null, nota: 'x' } };
+    expect(resolverEstado('cromatografia_suelo', fetched).estado).toBe('proximamente');
+  });
+  it('cae en el respaldo si el mapa fetcheado no trae la capacidad', () => {
+    expect(resolverEstado('cromatografia_suelo', {}).estado).toBe('activo');
+  });
+  it('degrada a proximamente ante una capacidad desconocida', () => {
+    expect(resolverEstado('no_existe', null).estado).toBe('proximamente');
+  });
+});

--- a/src/components/CicloVivo/cicloVivoWheel.js
+++ b/src/components/CicloVivo/cicloVivoWheel.js
@@ -1,0 +1,146 @@
+/**
+ * cicloVivoWheel.js — construye el SVG de la rueda "El Ciclo Vivo" como string.
+ * =====================================================================
+ * Port parametrizado del `buildWheel` del mockup v3. Devuelve el markup del
+ * <svg> interno (sin tocar el DOM: el componente lo inyecta con
+ * dangerouslySetInnerHTML y delega los clics de nodo por `data-idx`).
+ *
+ * `faseActiva` es solo la fase enfocada (dónde aterriza / enfoca el usuario),
+ * NO una afirmación sobre la semana real del cultivo. El tallo "vivido" crece
+ * hasta ahí y el resto queda punteado, igual que en la v3.
+ */
+import {
+  SPECIES_DEFS, GLYPHS, CX, CY, STEP_DEG,
+  phaseDeg, phaseR, rAtDeg, polar, spiralPath,
+} from './cicloVivoArte';
+import { PHASES, SPECIES } from './cicloVivoData';
+
+function nodeR(i, faseActiva) {
+  return 15 + i * 1.2 + (i === faseActiva ? 2 : 0);
+}
+
+/**
+ * @param {{ spKey: string, faseActiva: number }} args
+ * @returns {string} markup interno del <svg>
+ */
+export function buildWheelSvg({ spKey, faseActiva }) {
+  const sp = SPECIES[spKey] || SPECIES.maiz;
+  const cur = Math.max(0, Math.min(PHASES.length - 1, faseActiva));
+
+  const degStart = phaseDeg(0) - 70; // arranca escondido tras el núcleo
+  const degCur = phaseDeg(cur);
+  const degEnd = phaseDeg(6);
+  const rStart = rAtDeg(degStart);
+
+  const grown = spiralPath(degStart, degCur, rStart, phaseR(cur));
+  const future = spiralPath(degCur, degEnd, phaseR(cur), phaseR(6));
+  const ret = spiralPath(degEnd + 6, degEnd + STEP_DEG - 4, phaseR(6) + 2, phaseR(0) + 8);
+
+  let html = '';
+
+  /* defs */
+  html += '<defs>' +
+    '<linearGradient id="cvStemGrad" x1="0" y1="0" x2="1" y2="1">' +
+      '<stop offset="0%" stop-color="#2F4A34"/><stop offset="60%" stop-color="#4C7A3D"/><stop offset="100%" stop-color="#5B8A52"/>' +
+    '</linearGradient>' +
+    '<radialGradient id="cvCoreGrad" cx="38%" cy="30%" r="80%">' +
+      '<stop offset="0%" stop-color="#FFFDF8"/><stop offset="70%" stop-color="#F3E9D2"/><stop offset="100%" stop-color="#EBDDBB"/>' +
+    '</radialGradient>' +
+    '<linearGradient id="cvSoilGrad" x1="0" y1="0" x2="0" y2="1">' +
+      '<stop offset="0%" stop-color="#8B5E34"/><stop offset="100%" stop-color="#5A3D22"/>' +
+    '</linearGradient>' +
+    SPECIES_DEFS +
+    '<clipPath id="cvCoreClip"><circle cx="' + CX + '" cy="' + CY + '" r="44"/></clipPath>' +
+  '</defs>';
+
+  /* anillo exterior decorativo (horizonte del ciclo) */
+  html += '<g class="cv-ring-decor"><circle cx="' + CX + '" cy="' + CY + '" r="152" fill="none" stroke="#C98A3D" stroke-width="1.6" stroke-dasharray="2 9" stroke-linecap="round" opacity=".4"/></g>';
+
+  /* arco de retorno: poscosecha -> semilla */
+  html += '<path d="' + ret.d + '" fill="none" stroke="#C9A227" stroke-width="2" stroke-dasharray="2 6" stroke-linecap="round" opacity=".5"/>';
+  html += '<circle r="3" fill="#8B5E34" opacity=".85"><animateMotion dur="6s" begin="2.2s" repeatCount="indefinite" path="' + ret.d + '"/></circle>';
+
+  /* tramo futuro (camino por venir) */
+  html += '<path d="' + future.d + '" fill="none" stroke="#C98A3D" stroke-width="3" stroke-dasharray="1.5 8" stroke-linecap="round" opacity=".55"/>';
+
+  /* tallo vivido */
+  html += '<path d="' + grown.d + '" fill="none" stroke="rgba(91,138,82,.16)" stroke-width="11" stroke-linecap="round"/>';
+  html += '<path class="cv-stem-grown" style="--len:' + grown.len + '" d="' + grown.d + '" fill="none" stroke="url(#cvStemGrad)" stroke-width="5" stroke-linecap="round"/>';
+
+  /* hojas que brotan del tallo */
+  const leaves = [
+    { deg: -118, side: 1, s: 0.55, fill: '#6B9A5B' },
+    { deg: -64, side: -1, s: 0.75, fill: '#5B8A52' },
+    { deg: -14, side: 1, s: 0.95, fill: '#4C7A3D' },
+    { deg: 38, side: -1, s: 1.1, fill: '#5B8A52' },
+  ];
+  leaves.forEach(function eachLeaf(lf, k) {
+    const p = polar(lf.deg, rAtDeg(lf.deg));
+    const rot = lf.deg + 90 + (lf.side > 0 ? 30 : 150);
+    const delay = (0.45 + ((lf.deg - degStart) / (degCur - degStart)) * 1.35).toFixed(2);
+    html += '<g transform="translate(' + p.x.toFixed(1) + ',' + p.y.toFixed(1) + ') rotate(' + rot + ') scale(' + lf.s + ')">' +
+      '<g class="cv-leaf-in" style="--dl:' + delay + 's"><g class="cv-sway" style="--dl:' + (k * 0.6) + 's">' +
+      '<path d="M0,0 C5,-7 14,-8 19,-3 C14,3 5,3 0,0 Z" fill="' + lf.fill + '"/>' +
+      '<path d="M1.5,-0.3 C7,-2.8 12,-3.6 16.5,-3" stroke="rgba(251,243,228,.55)" stroke-width=".9" fill="none"/>' +
+      '</g></g></g>';
+  });
+
+  /* núcleo: raíz + especie */
+  html += '<g class="cv-core-pop">' +
+    '<circle cx="' + CX + '" cy="' + CY + '" r="50" fill="none" stroke="#E8B84B" stroke-width="1.4" stroke-dasharray="1 6" stroke-linecap="round" opacity=".55"/>' +
+    '<circle cx="' + CX + '" cy="' + CY + '" r="46" fill="url(#cvCoreGrad)" stroke="rgba(232,184,75,.65)" stroke-width="2.5"/>' +
+    '<g clip-path="url(#cvCoreClip)">' +
+      '<path d="M' + (CX - 46) + ',' + (CY + 16) + ' C' + (CX - 24) + ',' + (CY + 12) + ' ' + (CX - 6) + ',' + (CY + 19) + ' ' + CX + ',' + (CY + 16) + ' C' + (CX + 15) + ',' + (CY + 13) + ' ' + (CX + 30) + ',' + (CY + 19) + ' ' + (CX + 46) + ',' + (CY + 15) + ' L' + (CX + 46) + ',' + (CY + 46) + ' L' + (CX - 46) + ',' + (CY + 46) + ' Z" fill="url(#cvSoilGrad)"/>' +
+      '<g stroke="#3E2A16" stroke-width="1.2" fill="none" stroke-linecap="round" opacity=".55">' +
+        '<path d="M' + CX + ',' + (CY + 17) + ' C' + (CX - 3) + ',' + (CY + 23) + ' ' + (CX - 8) + ',' + (CY + 27) + ' ' + (CX - 12) + ',' + (CY + 32) + '"/>' +
+        '<path d="M' + CX + ',' + (CY + 17) + ' C' + (CX + 2) + ',' + (CY + 24) + ' ' + (CX + 6) + ',' + (CY + 28) + ' ' + (CX + 9) + ',' + (CY + 33) + '"/>' +
+        '<path d="M' + (CX - 1) + ',' + (CY + 17) + ' C' + (CX - 6) + ',' + (CY + 20) + ' ' + (CX - 13) + ',' + (CY + 22) + ' ' + (CX - 18) + ',' + (CY + 24) + '"/>' +
+        '<path d="M' + (CX + 1) + ',' + (CY + 17) + ' C' + (CX + 7) + ',' + (CY + 20) + ' ' + (CX + 13) + ',' + (CY + 22) + ' ' + (CX + 18) + ',' + (CY + 25) + '"/>' +
+        '<path d="M' + CX + ',' + (CY + 19) + ' C' + CX + ',' + (CY + 25) + ' ' + (CX - 1) + ',' + (CY + 30) + ' ' + CX + ',' + (CY + 35) + '"/>' +
+      '</g>' +
+      '<g transform="translate(' + CX + ',' + CY + ')">' + sp.center + '</g>' +
+    '</g>' +
+    '<text x="' + CX + '" y="' + (CY + 40) + '" class="cv-core-name">' + sp.label.toUpperCase() + '</text>' +
+  '</g>';
+
+  /* nodos de fase sobre el tallo */
+  PHASES.forEach(function eachPhase(p, i) {
+    const deg = phaseDeg(i);
+    const r = phaseR(i);
+    const nr = nodeR(i, cur);
+    const pos = polar(deg, r);
+    const lab = polar(deg, r + nr + 13);
+    const isGrown = i < cur;
+    const isCurrent = i === cur;
+    const delay = (0.15 + (isCurrent ? 1.55 : Math.min(i, cur) * 0.34 + (i > cur ? 1.7 + (i - cur) * 0.12 : 0))).toFixed(2);
+    let bgFill;
+    let ring;
+    let dash = '';
+    let gOp = 1;
+    if (isCurrent) { bgFill = '#FFFDF8'; ring = '#F2C744'; }
+    else if (isGrown) { bgFill = 'color-mix(in srgb, ' + p.color + ' 16%, #FFFDF8)'; ring = p.color; }
+    else { bgFill = '#FFFDF8'; ring = p.color; dash = ' stroke-dasharray="3 3.5"'; gOp = 0.62; }
+
+    html += '<g class="cv-wnode" role="button" tabindex="0" data-idx="' + i + '" aria-label="' + p.name + (isCurrent ? ' — fase enfocada' : '') + '" transform="translate(' + pos.x.toFixed(1) + ',' + pos.y.toFixed(1) + ')">' +
+      '<g class="cv-wnode-in" style="--dl:' + delay + 's" opacity="' + gOp + '">' +
+        (isCurrent ? '<circle class="cv-halo" r="' + (nr + 7) + '" fill="none" stroke="#F2C744" stroke-width="3"/>' : '') +
+        '<circle r="' + (nr + 9) + '" fill="transparent"/>' +
+        '<circle class="cv-node-bg" r="' + nr + '" fill="' + bgFill + '" stroke="' + ring + '" stroke-width="' + (isCurrent ? 2.6 : 2) + '"' + dash + '/>' +
+        '<g transform="scale(' + (nr / 13.5).toFixed(2) + ')">' + GLYPHS[p.key](p.color) + '</g>' +
+      '</g>' +
+      (isCurrent ? '' : '<text class="cv-node-label" x="' + (lab.x - pos.x).toFixed(1) + '" y="' + (lab.y - pos.y + 3).toFixed(1) + '">' + p.short + '</text>') +
+    '</g>';
+  });
+
+  /* bandera de la fase enfocada (nombre de la fase, no una semana inventada) */
+  const cpos = polar(degCur, phaseR(cur));
+  const flagText = PHASES[cur].name;
+  const flagW = 8.2 * (flagText + ' ▸').length + 26;
+  html += '<g transform="translate(' + cpos.x.toFixed(1) + ',' + (cpos.y + nodeR(cur, cur) + 5).toFixed(1) + ')"><g class="cv-flag-in">' +
+    '<path d="M0,0 L7,10 L-7,10 Z" fill="#F2C744"/>' +
+    '<rect x="' + (-flagW / 2) + '" y="9" width="' + flagW + '" height="26" rx="13" fill="#F2C744" style="filter:drop-shadow(0 5px 10px rgba(232,184,75,.5))"/>' +
+    '<text x="0" y="26.5" text-anchor="middle" font-size="12" font-weight="700" fill="#3a2a05">' + flagText + ' ▸</text>' +
+  '</g></g>';
+
+  return html;
+}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -57,6 +57,7 @@ import './dashboard-resto-redistribucion.css';
 // viva; se auto-oculta si no hay casos activos (KISS, zero footprint). Ref:
 // CAPABILITIES_STATUS.md §2.
 import CaseStudyTopWidget from '../CaseStudyTopWidget';
+import CicloVivoWidget from '../CicloVivo/CicloVivoWidget';
 import ClimaStrip from './ClimaStrip';
 import HoyEnFincaStrip from './HoyEnFincaStrip';
 import AIStatusFooter from './AIStatusFooter';
@@ -708,6 +709,13 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     </div>
                 </div>
 
+                {/* El Ciclo Vivo: portal a la rueda de las 7 fases. Estado real
+                    por función desde chagra-stats.json (se enciende solo). */}
+                <div className="px-4 pt-3 fvh-resto-block">
+                    {blockLabel('El ciclo de su cultivo', 'from-amber-400 to-lime-400')}
+                    <CicloVivoWidget onNavigate={onNavigate} />
+                </div>
+
                 {/* Top problemas activos (casos de estudio, DR-044). Se auto-oculta
                     si no hay casos → zero footprint. Va tras el estado del día. */}
                 <div className="px-4 pt-3 fvh-resto-block">
@@ -844,6 +852,12 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     <MiFincaVivaHomeCard onNavigate={onNavigate} />
                 </div>
             )}
+
+            {/* El Ciclo Vivo: portal a la rueda de las 7 fases (estado real por
+                función desde chagra-stats.json). */}
+            <div className="px-4 pt-3">
+                <CicloVivoWidget onNavigate={onNavigate} />
+            </div>
 
             {/* Top problemas activos (casos de estudio). */}
             <div className="px-4 pt-3">


### PR DESCRIPTION
Amarra la rueda v3 aprobada a chagra-stats.json para que cada función se
muestre según su estado REAL y se encienda sola cuando el artefacto que
falta se active — sin tocar el componente.

Fuente de verdad:
- gen-chagra-stats.mjs: nuevo bloque `capacidades` (24 funciones del ciclo,
  estado 'activo'|'parcial'|'proximamente' + nota + view). Estados asignados
  verificando el código (auditoría), no por suposición. schema 1.1.0 (aditivo).
  Incluye las 13 nombradas: precio_sipsa/rag_grounding/action_loop=parcial,
  cromatografia_suelo=activo (verificado: pantalla completa, no placeholder).

Widget:
- CicloVivoWidget: portal insignia en el home (ambos layouts de DashboardLive),
  resume estados desde la misma fuente de verdad.
- CicloVivoFullView: vista full-screen con las 7 fases y el mapping v3; chips
  por estado (activo navegable, parcial atenuado con "parcial", proximamente
  fantasma con "pronto"); especie automática por piso térmico + override
  persistido en el perfil; estética v3 portada 1:1 (arte, rueda, CSS).
- Ruta ciclo_vivo en App.jsx (+ MODULE_VIEWS + hash #ciclo-vivo).

Tests: render con fetch mockeado (widget + vista, incl. auto-light del chip al
pasar a activo), datos puros y generador (46 asserts). Build y eslint
--max-warnings=0 en verde.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
