### PR TITLE
fix(extractor): cierra refs AMB-13 del subset oss

### DIFF
--- a/catalog/chagra-catalog-oss-subset-v3.1.json
+++ b/catalog/chagra-catalog-oss-subset-v3.1.json
@@ -20,17 +20,19 @@
     "alcance_seed": "7 especies migradas desde v3.0. Las DRs por piso térmico poblarán hasta ~400 especies totales (100 × 4 pisos).",
     "advertencia": "Validar con: node scripts/validate-catalog.mjs --seed-mode. Refs a species aún no migradas aparecen como warnings."
   },
-  "schema_version": "3.1",
-  "seed_version": "0.2.0-oss-subset",
-  "generated_at": "2026-05-21T00:31:06.539Z",
+  "schema_version": "3.2",
+  "seed_version": "0.2.0-oss-subset-v3.2-oss-subset",
+  "generated_at": "2026-07-01T23:01:03.539Z",
   "generated_by": "scripts/extract-oss-subset.mjs",
   "_subset_meta": {
-    "subset_name": "oss-subset-50",
-    "source_file": "chagra-catalog-seed-v3.1.json",
-    "species_count": 50,
-    "sources_count": 32,
+    "subset_name": "oss-subset-50-closure",
+    "source_file": "chagra-catalog-oss-subset-v3.2.json",
+    "seed_species_count": 50,
+    "species_count": 239,
+    "sources_count": 66,
+    "unresolved_species_refs_count": 0,
     "license": "CC-BY-NC-SA 4.0",
-    "rationale": "Subset representativo multi-piso (12 cálidas + 13 templadas + 13 frías + 12 páramo/altoandinas) para uso OSS público bajo CC-BY-NC-SA. Catálogo full queda reserved para chagra-pro post-cutover. Plan detallado: Chagra-strategy/legal/oss-pro-corpus-split-plan-2026-05-20.md."
+    "rationale": "Subset representativo multi-piso con clausura de referencias cruzadas para species y biopreparados. El catálogo público canónico v3.2 aporta el corpus completo para resolver los ids referenciados. Catálogo full queda reserved para chagra-pro post-cutover. Plan detallado: Chagra-strategy/legal/oss-pro-corpus-split-plan-2026-05-20.md."
   },
   "species": [
     {
@@ -120,7 +122,24 @@
           }
         ]
       },
-      "tracking_mode": "aggregate"
+      "antagonists": [
+        "phaseolus_vulgaris"
+      ],
+      "companions": [
+        "beta_vulgaris_cicla_blanca",
+        "daucus_carota_subsp_sativus",
+        "matricaria_chamomilla",
+        "petroselinum_crispum",
+        "solanum_tuberosum_sabanera"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "cebolla de bulbo",
+        "cebolla huevo",
+        "cebolla bulbosa",
+        "cebolla roja"
+      ]
     },
     {
       "id": "allium_fistulosum",
@@ -167,7 +186,15 @@
       "antagonists": [
         "phaseolus_vulgaris"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "cebolla junca",
+        "cebolla de rama",
+        "cebolla en rama",
+        "cebolla rama",
+        "cebolla verdeo"
+      ]
     },
     {
       "id": "allium_sativum",
@@ -257,9 +284,20 @@
         ]
       },
       "antagonists": [
+        "phaseolus_vulgaris",
         "vicia_sativa"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "daucus_carota_subsp_sativus",
+        "petroselinum_crispum",
+        "solanum_melongena"
+      ],
+      "nombre_comunes_regionales": [
+        "ajo de bulbo",
+        "ajo común"
+      ]
     },
     {
       "id": "alnus_acuminata",
@@ -286,6 +324,10 @@
       ],
       "cultivable": true,
       "conservation_status": "nativo_silvestre",
+      "rol_restauracion": "pionera",
+      "resistencia_fuego": null,
+      "apta_ribera": true,
+      "invasora_combustible": false,
       "cycleMonths": null,
       "habito": "arbol deciduo semicaducifolio, 15-25m altura",
       "altitud_msnm": {
@@ -315,10 +357,18 @@
       "agua": "alto",
       "drenaje_requerido": "bueno_a_moderado",
       "companions": [
+        "bocconia_frutescens",
+        "cedrela_montana",
         "cenchrus_clandestinus_manejado",
         "coffea_arabica",
         "erythrina_edulis",
+        "escallonia_pendula",
+        "juglans_neotropica",
         "lupinus_mutabilis",
+        "magnolia_yarumalensis",
+        "morella_pubescens",
+        "myrsine_coriacea",
+        "oreopanax_floribundum",
         "passiflora_tripartita_mollissima",
         "quercus_humboldtii",
         "solanum_phureja",
@@ -326,15 +376,8 @@
         "vicia_faba",
         "weinmannia_tomentosa"
       ],
-      "antagonists": [],
-      "recommended_covers": [
-        "trifolium_repens",
-        "vicia_sativa"
-      ],
-      "recommended_fences": [
-        "sambucus_peruviana",
-        "dodonaea_viscosa"
-      ],
+      "recommended_covers": [],
+      "recommended_fences": [],
       "fence_function": [
         "rompevientos",
         "delimitacion",
@@ -426,13 +469,116 @@
       "nota_conservacion": null,
       "confidence_notes": "Especie nativa andina ampliamente documentada. Datos consolidados.",
       "harvest_type": "biomasa",
-      "validation_level": "operator_reviewed",
+      "validation_level": "expert_reviewed",
       "source_ids": [
         "ciat-1995-alnus",
         "agrosavia-silvopastoriles",
         "humboldt-flora-alto-andina"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false
+    },
+    {
+      "id": "apium_graveolens",
+      "nombre_comun": "Apio",
+      "nombre_cientifico": "Apio graveolens L.",
+      "familia_botanica": "Apiaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 21,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere semillero y trasplante muy cuidadoso por tener una raíz extremadamente sensible."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El apio (Apium graveolens L.) es una umbelífera bienal originaria del Mediterráneo, ampliamente cultivada como hortaliza de hoja, tallo y semilla en zonas frías colombianas. Se siembra en Cundinamarca (Sabana de Bogotá: Mosquera, Madrid, Funza), Boyacá, Nariño y altiplano antioqueño entre 2.000 y 3.000 msnm en zona térmica fría. Variedades comerciales más comunes: Tall Utah 52-70, Pascal, Florida 683. Ciclo 12-16 semanas desde trasplante. Requiere suelos profundos con materia orgánica abundante (>5%), pH 6.0-7.0 y riego constante (lámina ~5 mm/día). Manejo agroecológico: rotación con leguminosas, fertilización con biol + compost maduro, asocio con tomate y lechuga (no con perejil mismo familia), control de Septoria apiicola con caldo bordelés y bacillus_subtilis. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "antagonists": [
+        "petroselinum_crispum"
+      ],
+      "nombre_comunes_regionales": [
+        "apio de pencas",
+        "célery"
+      ]
+    },
+    {
+      "id": "beta_vulgaris_cicla_blanca",
+      "nombre_comun": "Acelga blanca",
+      "nombre_cientifico": "Beta vulgaris var. cicla L.",
+      "familia_botanica": "Amaranthaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Variedad clásica más rústica y productiva; tolera bien los cortes frecuentes."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015",
+        "nrc-1989-cultivos-andinos"
+      ],
+      "valor_pedagogico": "La acelga blanca (Beta vulgaris var. cicla) es una hoja comestible de alta productividad, cultivada extensamente en Colombia en departamentos como Cundinamarca, Boyacá, Nariño y Antioquia, entre 1500-2800 msnm en zonas frías y templadas. Su manejo agronómico incluye propagación por semilla, ciclo de 90-120 días, asociación con cultivos como maíz, fríjol y cebolla, y requiere monitoreo de plagas como áfidos (Myzus persicae) y minador de hoja (Liriomyza spp.). Culturalmente, el cultivo de Beta vulgaris fue domesticado en el Mediterráneo y llegó a Colombia con la colonización europea, integrándose en la dieta campesina andina como fuente de vitaminas A, C y minerales (hierro, calcio). Los muiscas cultivaban especies de Beta spp. en sus chagras como parte de la horticultura precolombina. Fuente: nrc-1989-cultivos-andinos, agrosavia-sol-andina.",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "allium_cepa",
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ]
     },
     {
       "id": "beta_vulgaris_conditiva",
@@ -476,7 +622,13 @@
         "powo-kew"
       ],
       "valor_pedagogico": "La remolacha o betarraga (Beta vulgaris L. subsp. vulgaris Conditiva Group) es una quenopodiácea bienal cultivada como anual por su raíz hipocotila engrosada rica en azúcares, betalaínas (pigmentos antioxidantes) y nitratos vegetales. Hortaliza tradicional de huertas andinas colombianas. Se cultiva en Sabana de Bogotá (Mosquera, Madrid, Funza), Boyacá altiplano (Tunja, Duitama), Nariño y Antioquia entre 1.800 y 2.900 msnm en zona térmica fría. Ciclo 90-120 días desde siembra directa hasta raíz comercial (5-10 cm diámetro). Rendimientos 25-40 t/ha. Lección viva: muestra cómo la planta acumula reservas en raíz hipocotila para sobrevivir período seco o frío. Manejo agroecológico: siembra directa a chorrillo, aclareo a 10-15 cm planta, suelos francos profundos pH 6.5-7.5, fertilización con compost + bocashi al fondo, asocio con lechugas y zanahorias en cama mixta, control de minador hoja (Pegomya betae) con purín de ortiga + caldo sulfocálcico. Fuentes Tier A: ICA Resolución 3168/2015, Restrepo 1996 ABC Agricultura Orgánica, POWO Kew, GBIF Backbone Taxonomy.",
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "betabel",
+        "betarraga",
+        "beterraga"
+      ]
     },
     {
       "id": "brassica_oleracea_acephala_curly",
@@ -524,7 +676,8 @@
       "antagonists": [
         "solanum_lycopersicum_san_marzano"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false
     },
     {
       "id": "brassica_oleracea_capitata_alba",
@@ -571,14 +724,65 @@
         "solanum_lycopersicum_san_marzano",
         "vaccinium_corymbosum_biloxi"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false
+    },
+    {
+      "id": "brassica_oleracea_italica",
+      "nombre_comun": "Brócoli",
+      "nombre_cientifico": "Brassica oleracea var. italica Plenck",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere trasplante y un suelo profundamente abonado con materia orgánica nitrogenada."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "agrosavia-sol-andina"
+      ],
+      "valor_pedagogico": "El brócoli (Brassica oleracea var. italica) es una crucífera hortícola cultivada en el cinturón agrícola de Cundinamarca (Mosquera-Madrid-Bojacá) entre 1800-2800 msnm en zonas térmicas fría y templada. Su ciclo de cultivo varía entre 90-120 días, se propaga por semilla con trasplante y requiere suelos ricos en materia orgánica nitrogenada. Varietales comerciales como Avenger, Marathon y Calabrese se adaptan bien a estas condiciones. En el contexto andino campesino, se asocia frecuentemente con cultivos de papa y cebolla en rotaciones que mejoran la estructura del suelo. Principal plagas incluyen mosca blanca y lepidópteros que dañan los botones florales. Fuente: AGROSAVIA Sol Andina ficha técnica.",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "antagonists": [
+        "petroselinum_crispum"
+      ]
     },
     {
       "id": "calendula_officinalis",
       "nombre_comun": "Caléndula",
       "nombre_cientifico": "Calendula officinalis L.",
       "nombre_comunes_regionales": [
-        "Margarita dorada"
+        "Margarita dorada",
+        "mercadela",
+        "maravilla",
+        "caléndula común"
       ],
       "familia_botanica": "Asteraceae",
       "category": "atractores_polinizadores",
@@ -613,9 +817,9 @@
         "notas": "Se resiembra sola con facilidad; sus raíces secretan sustancias que controlan nematodos en el suelo."
       },
       "companions": [
+        "centaurea_cyanus",
         "solanum_lycopersicum_san_marzano"
       ],
-      "antagonists": [],
       "valor_pedagogico": "La Caléndula (Calendula officinalis L.) es una especie ornamental-medicinal originaria del Mediterráneo, ampliamente cultivada en jardines campesinos de Cundinamarca entre 0-2800 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla con ciclo de floración de 75-90 días, asociándose beneficiosamente con cultivos como el tomate (Solanum lycopersicum) mientras actúa como repelente natural de trips y nemátodos mediante secreciones radiculares. En el contexto cultural andino-campesino, sus flores se utilizan tradicionalmente en preparaciones de crema cicatrizante por sus propiedades flavonoides, saponinas y aceites esenciales. Según GBIF Backbone Taxonomy y Plants of the World Online (POWO), esta especie destaca por su valor ecológico en atracción de polinizadores y manejo integrado de plagas en sistemas agroecológicos de montaña.",
       "source_ids": [
         "gbif-taxonomic-backbone",
@@ -625,7 +829,8 @@
       ],
       "validation_level": "claude_draft",
       "estrato": "medio",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false
     },
     {
       "id": "chenopodium_quinoa",
@@ -671,10 +876,17 @@
       ],
       "valor_pedagogico": "La quinua (Chenopodium quinoa Willd.) es un pseudocereal andino tradicional con alto valor proteico (~14-18%) y aminoácidos esenciales, redescubierta como cultivo estratégico de seguridad alimentaria. En Colombia se cultiva en Boyacá, Nariño, Cundinamarca y Cauca entre 2.500 y 3.500 msnm en zona térmica fría a páramo bajo. Las variedades AGROSAVIA Aurora, Tunkahuán y Blanca de Jericó están adaptadas al altiplano cundiboyacense con ciclo 5-6 meses. Tolera salinidad moderada, sequía y heladas leves (-2°C en estados vegetativos). Manejo agroecológico: rotación con leguminosas, fertilización orgánica con bocashi y biol, control mecánico de mildiú (Peronospora variabilis) por densidad de siembra adecuada (60-80 cm entre surcos). Fuentes Tier A: AGROSAVIA fichas técnicas, FAO Quinoa Sourcebook 2013, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
       "companions": [
+        "lupinus_mutabilis",
         "vicia_sativa",
         "zea_mays"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "quínoa",
+        "quingua",
+        "arrocillo andino"
+      ]
     },
     {
       "id": "coffea_arabica",
@@ -682,7 +894,9 @@
       "nombre_cientifico": "Coffea arabica L.",
       "nombre_comunes_regionales": [
         "Café Supremo (categoría comercial)",
-        "Café Arábigo"
+        "Café Arábigo",
+        "café de altura",
+        "cafeto"
       ],
       "familia_botanica": "Rubiaceae",
       "category": "medicinales_alelopaticas",
@@ -724,8 +938,48 @@
         "notes": "Altamente sensible a heladas; las bajas temperaturas afectan la calidad del grano."
       },
       "companions": [
+        "albizia_guachapele",
         "alnus_acuminata",
-        "erythrina_edulis"
+        "aniba_perutilis",
+        "arachis_pintoi",
+        "byrsonima_crassifolia",
+        "cajanus_cajan",
+        "cassia_grandis",
+        "cedrela_montana",
+        "cedrela_odorata",
+        "ceiba_pentandra",
+        "cinchona_officinalis",
+        "cinchona_pubescens",
+        "cordia_alliodora",
+        "enterolobium_cyclocarpum",
+        "erythrina_edulis",
+        "erythrina_rubrinervia",
+        "garcinia_madruno",
+        "inga_densiflora",
+        "inga_edulis",
+        "inga_vera",
+        "juglans_neotropica",
+        "magnolia_caricifragrans",
+        "musa_paradisiaca",
+        "myrcia_popayanensis",
+        "myroxylon_balsamum",
+        "nectandra_acutifolia",
+        "ocotea_calophylla",
+        "oreopanax_floribundum",
+        "pithecellobium_dulce",
+        "pseudosamanea_guachapele",
+        "samanea_saman",
+        "swietenia_macrophylla",
+        "tabebuia_chrysantha",
+        "tabebuia_rosea",
+        "vismia_baccifera"
+      ],
+      "companions_con_advertencia": [
+        "aniba_perutilis",
+        "swietenia_macrophylla",
+        "cedrela_odorata",
+        "cedrela_montana",
+        "magnolia_caricifragrans"
       ],
       "antagonists": [
         "foeniculum_vulgare"
@@ -734,9 +988,9 @@
         "metodo_principal": "semilla",
         "notas": "Requiere germinador en arena y posterior embolsado."
       },
-      "valor_pedagogico": "El café arábica (Coffea arabica L.) es el cultivo agroindustrial emblemático de Colombia y la principal fuente de ingresos de la economía campesina cafetera, con cerca de 850.000 hectáreas distribuidas en Caldas, Quindío, Risaralda, Antioquia, Tolima, Huila, Cundinamarca y Santander entre 1.200 y 2.000 msnm en zona térmica templada. Las variedades Caturra, Castillo y Cenicafé 1 son las más adoptadas en Colombia por su resistencia a roya (Hemileia vastatrix) y broca (Hypothenemus hampei) según Cenicafé. Requiere sombra parcial 35-50%, suelos francos con pH 5.0-5.5, y precipitación 1.800-2.800 mm anuales. Sistemas agroecológicos asocian café con plátano (Musa spp.), guandul (Cajanus cajan) y nogal cafetero (Cordia alliodora) para sombra estratificada. Fuentes Tier A: Cenicafé Manual del Cafetero 2013, AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
+      "valor_pedagogico": "El café arábica (Coffea arabica L.) es el cultivo agroindustrial emblemático de Colombia y la principal fuente de ingresos de la economía campesina cafetera, con cerca de 850.000 hectáreas distribuidas en Caldas, Quindío, Risaralda, Antioquia, Tolima, Huila, Cundinamarca y Santander entre 1.200 y 2.000 msnm en zona térmica templada. Las variedades Caturra, Castillo y Cenicafé 1 son las más adoptadas en Colombia por su resistencia a roya (Hemileia vastatrix) y broca (Hypothenemus hampei) según Cenicafé. Requiere sombra parcial 35-50%, suelos francos con pH 5.0-5.5, y precipitación 1.800-2.800 mm anuales. Sistemas agroecológicos asocian café con plátano (Musa spp.), guandul (Cajanus cajan) y nogal cafetero (Cordia alliodora) para sombra estratificada. ⚠️ El sombrío histórico incluyó species hoy amenazadas (Aniba perutilis CR, Swietenia macrophylla EN/CITES II, Cedrela odorata CITES II). En cafetales nuevos, priorizar Inga spp + Erythrina + Cordia alliodora (rápido crecimiento, no amenazadas) sobre maderables CR. Fuentes Tier A: Cenicafé Manual del Cafetero 2013, AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
       "feeding_plan_template": {
-        "source": "Cenicafé — Manual del Cafetero Colombiano (2013) + Cenicafé — Trichoderma spp. en manejo integrado (2010). Programa nutricional café tradicional Caturra/Castillo zona cafetera.",
+        "source": "Cenicafé — Manual del Cafetero Colombiano (2013). Programa NUTRICIONAL café tradicional Caturra/Castillo zona cafetera. Solo nutrición; el manejo fitosanitario (roya, broca, llaga macana) se trata aparte.",
         "primary_steps": [
           {
             "offset_days": 0,
@@ -746,13 +1000,6 @@
             "notes": "Hoyo 40x40x40 cm. Cenicafé recomienda fertilización inicial al establecimiento. Mezclar con suelo del hoyo."
           },
           {
-            "offset_days": 30,
-            "action": "Inocular Trichoderma harzianum al sustrato",
-            "biofertilizer_slug": "trichoderma_harzianum_suelo",
-            "dose_g": 20,
-            "notes": "Preventivo contra Fusarium oxysporum f.sp. coffeae (llaga macana) y Rhizoctonia. Cenicafé 2010."
-          },
-          {
             "offset_days": 90,
             "action": "Drench con biol fase vegetativa",
             "biofertilizer_slug": "biol",
@@ -760,11 +1007,11 @@
             "notes": "Dilución 1:5, 1 L por planta al pie. Refuerzo N orgánico fase de crecimiento foliar activo."
           },
           {
-            "offset_days": 180,
-            "action": "Foliar con caldo bordelés preventivo",
-            "biofertilizer_slug": "caldo_bordeles",
-            "dose_ml": 100,
-            "notes": "Concentración 1%. Preventivo roya (Hemileia vastatrix) en época de lluvias antes de iniciar floración."
+            "offset_days": 330,
+            "action": "Foliar con supermagro pre-floración",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 80,
+            "notes": "Dilución 1:12. Corrige B y Zn críticos para cuajado de chereza. Aplicar 30 días antes de floración esperada."
           },
           {
             "offset_days": 365,
@@ -772,22 +1019,10 @@
             "biofertilizer_slug": "bocashi",
             "dose_g": 1500,
             "notes": "Año 1 establecimiento completo. Aplicar en corona radicular antes de inicio de lluvias."
-          },
-          {
-            "offset_days": 540,
-            "action": "Foliar con supermagro pre-floración",
-            "biofertilizer_slug": "supermagro",
-            "dose_ml": 80,
-            "notes": "Dilución 1:12. Corrige B y Zn críticos para cuajado de chereza. Aplicar 30 días antes de floración esperada."
-          },
-          {
-            "offset_days": 720,
-            "action": "Aplicar Bacillus subtilis foliar en cosecha",
-            "biofertilizer_slug": "bacillus_subtilis_foliar",
-            "dose_ml": 25,
-            "notes": "Año 2 primera cosecha. Control biológico de Cercospora coffeicola y Mycena citricolor (gotera)."
           }
-        ]
+        ],
+        "recurrence": "anual",
+        "perennial_note": "Cultivo perenne: repetir este ciclo cada año."
       },
       "plagas_criticas": [
         "Hypothenemus hampei (broca)",
@@ -805,7 +1040,8 @@
         "agrosavia-manual-biopreparados-2015"
       ],
       "validation_level": "claude_draft",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false
     },
     {
       "id": "coriandrum_sativum",
@@ -848,7 +1084,13 @@
         "ica-resolucion-3168-2015"
       ],
       "valor_pedagogico": "El cilantro (Coriandrum sativum L.) es una aromática mediterránea naturalizada en Colombia, cultivada permanentemente en Cundinamarca entre 1000-2400 msnm en zonas térmicas templadas y frías. Su ciclo corto de 40-60 días permite cosechas escalonadas de hojas y semillas utilizadas en preparaciones culinarias tradicionales. Se propaga por siembra directa cada 15 días, prefiriendo medio-sombra en épocas cálidas, y se asocia beneficiosamente con repollo y zanahoria para reducir plagas como áfidos y trips. En el contexto andino campesino, su uso culinario se remonta a tiempos coloniales integrado en sofritos y guayos, mientras su cultivo sostenible evita sintéticos mediante manejo agroecológico. Fuentes: GBIF Taxonomic Backbone, POWO Kew, ICA Resolución 3168/2015.",
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "culantro",
+        "cilantro común",
+        "cilantro de castilla"
+      ]
     },
     {
       "id": "cymbopogon_citratus",
@@ -896,7 +1138,14 @@
       "companions": [
         "solanum_lycopersicum_san_marzano"
       ],
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "limoncillo",
+        "pasto limón",
+        "hierba limón",
+        "citronela de té"
+      ]
     },
     {
       "id": "erythrina_edulis",
@@ -952,7 +1201,10 @@
       },
       "companions": [
         "alnus_acuminata",
-        "coffea_arabica"
+        "cedrela_odorata",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "tabebuia_rosea"
       ],
       "antagonists": [
         "ulex_europaeus"
@@ -976,7 +1228,61 @@
         "ica-resolucion-3168-2015"
       ],
       "validation_level": "claude_draft",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false
+    },
+    {
+      "id": "eugenia_stipitata",
+      "nombre_comun": "Arazá",
+      "nombre_cientifico": "Eugenia stipitata McVaugh",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "harvest_type": "fruto",
+      "cycleMonths": 48,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 600,
+        "max_absoluto": 1000
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Los frutos contienen múltiples semillas que se extraen de la pulpa; germinación en 2-4 semanas bajo condiciones de alta humedad."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "gbif-colombia",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "El arazá (Eugenia stipitata McVaugh) es un frutal nativo de la Amazonía colombiana, presente en los departamentos de Putumayo, Caquetá, Amazonas y Vaupés entre 0 y 1000 msnm en zonas térmicas calidas. Su manejo agronómico incluye propagación por semilla con germinación de 2-4 semanas bajo alta humedad, ciclo de fructificación de 3-4 años desde la siembra, requiere ambientes con alta humedad relativa y suelos bien drenados, y presenta sensibilidad a enfermedades fúngicas como la antracnosis (Colletotrichum gloeosporioides) y ataque de moscas de la fruta (Anastrepha spp.). En el contexto cultural amazonense, esta especie ha sido tradicionalmente consumida por comunidades indígenas y campesinas amazónicas como fruta fresca y en preparaciones de jugos y mermeladas, representando un recurso alimenticio nativo de la región biogeográfica del Amazonas colombiano. Según el inventario taxonómico verificado por GBIF Backbone Taxonomy, Plants of the World Online (POWO), GBIF Colombia y el Sistema de Información sobre Biodiversidad de Colombia (SiB Colombia), su nombre científico válido es Eugenia stipitata McVaugh.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "citrus_sinensis",
+        "theobroma_cacao",
+        "theobroma_grandiflorum",
+        "zea_mays"
+      ]
     },
     {
       "id": "foeniculum_vulgare",
@@ -1023,11 +1329,13 @@
       "valor_pedagogico": "El hinojo (Foeniculum vulgare Mill., familia Apiaceae) es una umbelífera perenne aromática originaria del Mediterráneo, naturalizada y cultivada en huertas familiares colombianas para uso culinario (bulbo, semilla, hoja), medicinal (digestivo, carminativo) e industrial (aceite esencial rico en anetol). Se cultiva en zonas templadas a frías: Cundinamarca (Sabana Bogotá), Boyacá, Antioquia, Quindío y Nariño entre 1.500 y 2.800 msnm en zona térmica templada a fría. Ciclo 4-6 meses a primera cosecha, perennización opcional 2-3 años. Caso de estudio principal en alelopatía: sus exudados radicales (compuestos cumarínicos) inhiben la germinación y crecimiento de la mayoría de vecinos, especialmente tomate, frijol, cilantro y eneldo. Manejo agroecológico: aislamiento mínimo 2-3 m de otras hortalizas O confinamiento en bordura/macetón, asocio compatible solo con hisopo y romero, fertilización moderada con compost al fondo, atrayente de polinizadores beneficiosos (Syrphidae, Braconidae) en floración. Lección viva: enseña la necesidad de planificar diseño espacial del huerto considerando interacciones químicas. Fuentes Tier A: ICA Resolución 3168/2015, Pamplona Roger 2006 Plantas Medicinales, Restrepo 2007 Biopreparados, POWO Kew, GBIF Backbone Taxonomy.",
       "antagonists": [
         "coffea_arabica",
+        "petroselinum_crispum",
         "phaseolus_vulgaris",
         "solanum_lycopersicum_san_marzano",
         "zea_mays"
       ],
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false
     },
     {
       "id": "fragaria_ananassa_monterrey",
@@ -1124,7 +1432,16 @@
         ]
       },
       "estrato": "rastrero",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "pyrus_communis_anjou",
+        "spinacia_oleracea"
+      ],
+      "nombre_comunes_regionales": [
+        "fresa",
+        "frutilla"
+      ]
     },
     {
       "id": "ipomoea_batatas",
@@ -1167,7 +1484,15 @@
         "ica-resolucion-3168-2015"
       ],
       "valor_pedagogico": "La batata o camote (Ipomoea batatas (L.) Lam., familia Convolvulaceae) es una convolvulácea perenne rastrera cultivada como anual por sus raíces tuberosas dulces ricas en betacarotenos (precursores vitamina A) y carbohidratos complejos. Cultivo tradicional precolombino de los campesinos colombianos para seguridad alimentaria. Se cultiva en Cundinamarca (Tena, Tocaima, La Mesa, La Vega), Tolima, Huila, Valle del Cauca, Antioquia, Magdalena y Llanos Orientales entre 0 y 2.400 msnm en zona térmica cálida a templada. Lección viva de raíces reservantes: enseña cómo una planta rastrera puede concentrar la energía solar capturada por su follaje en forma de carbohidratos dulces almacenados bajo la tierra. Propagación por esquejes tallo (15-30 cm) plantados en caballón, ciclo 4-6 meses, rendimientos 15-30 t/ha. Manejo agroecológico: cama o caballón elevado para mejor desarrollo tubérculo, suelos francoarenosos drenados, asocio con maíz y frijol (chacra muisca), fertilización con compost al fondo + ceniza madera, rotación trienal anti-gorgojo (Cylas spp.) con trampas feromonales. Fuentes Tier A: ICA Resolución 3168/2015, AGROSAVIA Tubérculos Tropicales, POWO Kew, GBIF Backbone Taxonomy.",
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ],
+      "nombre_comunes_regionales": [
+        "boniato"
+      ]
     },
     {
       "id": "inga_edulis",
@@ -1212,7 +1537,28 @@
       ],
       "valor_pedagogico": "El guamo (Inga edulis) se cultiva en departamentos colombianos como Valle del Cauca, Antioquia, Caldas, Quindío, Tolima y Huila entre 0 y 2000 msnm en zonas térmicas cálidas y templadas. Su manejo agronómico incluye propagación por semilla recalcitrante (sembrar inmediatamente post-recolección) con emergencia rápida de 7-14 días, ciclo productivo de 3-5 años hasta primera cosecha significativa, asociaciones tradicionales con cacao y café como especie sombreadora que fija nitrógeno atmosférico mediante simbiosis con rizobios, y requiere manejo de plagas como barrenadores de tallos y mosca de la fruta mediante monitoreo y poda fitosanitaria. En el contexto cultural campesino andino, esta leguminosa ha sido tradicionalmente utilizada como sombra de cacao y café, sus vainas contienen pulpa dulce comestible rica en azúcares naturales, y forma parte de sistemas agroforestales tradicionales que combinan producción con conservación de suelo. Según las fuentes taxonómicas verificadas de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Inga edulis Mart.",
       "estrato": "alto",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "companions": [
+        "aniba_perutilis",
+        "bombacopsis_quinata",
+        "cedrela_odorata",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "myroxylon_balsamum",
+        "nectandra_acutifolia",
+        "ochroma_pyramidale",
+        "ocotea_calophylla",
+        "swietenia_macrophylla",
+        "tabebuia_chrysantha",
+        "tabebuia_rosea",
+        "vismia_baccifera"
+      ],
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "guama",
+        "guamo santafereño",
+        "guaba"
+      ]
     },
     {
       "id": "lactuca_sativa_capitata",
@@ -1258,9 +1604,11 @@
       "valor_pedagogico": "La lechuga cogollo morada (Lactuca sativa var. capitata) es una hortaliza de hoja ampliamente cultivada en Colombia, especialmente en departamentos como Cundinamarca (cinturón productivo Choachí-Fómeque), Boyacá, Nariño y Santander, entre 800-3200 msnm en zonas térmicas fría y templada. Su manejo agronómico incluye propagación por semilla en semillero con sustrato fino, riego por nebulización en etapas tempranas, trasplante a los 25-30 días, ciclo de 60-90 días hasta cosecha, y asociaciones beneficiosas con Brassicaceae y Allium para repelencia de pulguilla. Plagas principales: pulgones (Myzus persicae), babosas (Deroceras reticulatum) y minadores (Liriomyza spp.). Culturalmente, aunque no es originaria del contexto muisca, se ha integrado en la agricultura andina contemporánea como cultivo de ciclo corto para seguridad alimentaria. Los cogollos morados deben su pigmentación a las antocianinas, pigmentos que actúan como protección natural contra radiación UV y estrés térmico. Fuente: nrc-1989-cultivos-andinos.",
       "companions": [
         "phaseolus_vulgaris",
+        "raphanus_sativus_niger",
         "solanum_lycopersicum_san_marzano"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false
     },
     {
       "id": "lupinus_mutabilis",
@@ -1306,9 +1654,18 @@
       "valor_pedagogico": "El tarwi o chocho andino (Lupinus mutabilis Sweet) es una leguminosa nativa de los Andes con alto contenido proteico en grano (35-50%), tradicionalmente cultivada en sistemas campesinos altoandinos colombianos para autoconsumo (cosecha desamargada). Se cultiva en Boyacá (Tunja, Soatá, Ventaquemada), Cundinamarca (Sumapaz, Choachí), Nariño y Cauca entre 2.500 y 3.500 msnm en zona térmica fría a páramo bajo. Ciclo 6-8 meses, fijación N biológica ~100-160 kg N/ha. Granos con alcaloides amargos (quinolizidínicos) requieren desamargado tradicional (remojo + enjuagues). Manejo agroecológico: siembra al voleo en pre-cultivo (8-12 kg/ha), incorporación como abono verde o cosecha grano + restos al suelo, rotación con tubérculos andinos. Fuentes Tier A: AGROSAVIA Leguminosas Andinas, NRC 1989 Cultivos Andinos, POWO Kew, GBIF Backbone Taxonomy.",
       "companions": [
         "alnus_acuminata",
+        "chenopodium_quinoa",
+        "solanum_tuberosum",
         "zea_mays"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "tarhui",
+        "altramuz",
+        "chocho andino",
+        "tauri"
+      ]
     },
     {
       "id": "melissa_officinalis",
@@ -1356,7 +1713,8 @@
       "companions": [
         "solanum_lycopersicum_san_marzano"
       ],
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false
     },
     {
       "id": "mentha_spicata",
@@ -1402,7 +1760,15 @@
         "jbb-plantas-medicinales"
       ],
       "valor_pedagogico": "La Mentha spicata (Labiada aromática) se cultiva perenne en huertas de Cundinamarca entre 500-2600 msnm en zonas térmicas cálidas, templadas y frías. Su propagación se realiza mediante esquejes y estolones, requiere control de invasividad mediante barreras físicas y se asocia beneficiosamente con tomate y repollo al repeler pulgón. En contexto campesino andino, su infusión digestiva (té de menta) se usa tradicionalmente para aliviar molestias gastrointestinales, aprovechando su aceite esencial rico en carvona y limoneno. Fuente taxonómica validada por GBIF Backbone Taxonomy y Plants of the World Online (POWO).",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "companions": [
+        "viola_odorata"
+      ],
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "menta verde",
+        "yerba buena"
+      ]
     },
     {
       "id": "origanum_vulgare",
@@ -1446,7 +1812,12 @@
         "powo-kew"
       ],
       "valor_pedagogico": "El orégano común (Origanum vulgare L.) es una labiada perenne aromática originaria del Mediterráneo, ampliamente cultivada en huertas familiares y campesinas colombianas para uso culinario, medicinal y como repelente natural. Se cultiva en zonas frías y templadas: Sabana de Bogotá, Boyacá, Antioquia, Quindío, Caldas y Risaralda entre 1.200 y 2.800 msnm en zona térmica fría a templada. Propagación por estaca leñosa (60-80% prendimiento) o división de mata establecida. Ciclo perenne con vida productiva 4-6 años. Cortes graduales mensuales mantienen el porte compacto. Manejo agroecológico: cama elevada con drenaje excelente, suelos calcáreos pH 6.5-7.5, riego moderado (NO encharcamiento), asocio con tomate y pimentón (efecto repelente). Aceite esencial con carvacrol y timol confiere propiedades antibacterianas y antifúngicas. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "orégano común",
+        "orégano de huerta"
+      ]
     },
     {
       "id": "oxalis_tuberosa",
@@ -1489,7 +1860,20 @@
         "agrosavia-sol-andina"
       ],
       "valor_pedagogico": "La oca (Oxalis tuberosa) se cultiva en Colombia principalmente en los departamentos de Cundinamarca, Boyacá, Nariño y Cauca, entre 2400-3400 msnm en zona térmica fría, con propagación por tubérculos semilla y un ciclo de crecimiento de 8-9 meses, asociándose frecuentemente con papa y maíz en sistemas de policultivo andino, mientras enfrenta desafíos por plagas como el gusano blanco y la mosca de la oca; su cultivo tiene profundas raíces culturales en la tradición muisca y campesina andina, donde se reconocen variedades de tubérculo blanco, rosado, morado y amarillo, utilizándose tradicionalmente cocido en sopas y aplicándose la técnica ancestral de 'qollotear' (exposición al sol post-cosecha) para reducir el contenido de ácido oxálico y aumentar el dulzor, tal como documenta el National Research Council en su obra de 1989 'Lost Crops of the Incas' que identifica a la oca como uno de los tubérculos andinos subutilizados con gran potencial para cultivo mundial.",
-      "tracking_mode": "aggregate"
+      "companions": [
+        "arracacia_xanthorrhiza",
+        "lepidium_meyenii",
+        "mirabilis_expansa",
+        "solanum_tuberosum_sabanera",
+        "tropaeolum_tuberosum",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "ibia",
+        "oca andina"
+      ]
     },
     {
       "id": "passiflora_edulis_flavicarpa",
@@ -1534,7 +1918,14 @@
       ],
       "valor_pedagogico": "La Passiflora edulis f. flavicarpa, conocida como maracuyá amarilla, se cultiva en departamentos colombianos como Antioquia, Cundinamarca, Santander y el Valle del Cauca entre 0 y 1800 msnm en zonas térmicas cálidas y templadas. Su manejo agronómico incluye propagación por semilla o injerto, ciclo productivo de 18-24 meses, asociaciones beneficiosas con cultivos de sombra como plátano y caucho para reducir estrés hídrico, y requiere manejo de plagas como la mosca de la fruta (Ceratitis capitata) y ácaros mediante monitoreo y biopreparados. En el contexto andino-colombiano, aunque originaria de Brasil, su cultivo se ha integrado en sistemas agrofrutícolas de mediana altura, contribuyendo a la diversificación económica de pequeños productores. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Passiflora edulis f. flavicarpa Deg.",
       "estrato": "alto",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "maracuyá amarillo",
+        "parchita",
+        "parcha",
+        "maracujá"
+      ]
     },
     {
       "id": "passiflora_edulis_morada",
@@ -1636,7 +2027,259 @@
       "companions": [
         "urtica_dioica"
       ],
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false
+    },
+    {
+      "id": "passiflora_tripartita_mollissima",
+      "nombre_comun": "Curuba de Castilla",
+      "nombre_cientifico": "Passiflora tripartita var. mollissima (Kunth) Holm-Niels. & Jørg.",
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 12,
+        "optimo_max": 16,
+        "max_tolerable": 22
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere poda de formación constante para evitar enmarañamiento; es la más resistente al frío."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La Curuba de Castilla (Passiflora tripartita var. mollissima) se distribuye en los departamentos de Cundinamarca y Boyacá entre 1800-3200 msnm en zona térmica fría, siendo cultivada comercialmente principalmente entre 2200-2800 msnm. Su manejo agronómico incluye propagación por semilla con ciclo productivo de 12-18 meses, requiere poda de formación constante cada 3-4 meses para evitar enmarañamiento y facilitar la cosecha, se asocia beneficiosamente con Alnus acuminata en sistemas agroforestales donde el aliso proporciona tutoraje y fijación de nitrógeno, y es susceptible a antracnosis en períodos de alta neblina requeriendo monitoreo preventivo. En el contexto campesino andino, sus frutos son la base del tradicional sorbete de curuba preparado en las casas chiguanas, aprovechando su pulpa aromática rica en vitaminas A y C. Según la Resolución ICA 3168/2015 que establece normas para la producción, certificación y comercio de semillas en Colombia.",
+      "estrato": "alto",
+      "companions": [
+        "alnus_acuminata",
+        "urtica_dioica"
+      ],
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "curuba",
+        "tacso",
+        "taxo",
+        "parcha"
+      ]
+    },
+    {
+      "id": "pennisetum_setaceum",
+      "_curation_status": "BATCH_2A_PASADA_2_RESIDUAL_2026-05-22 — sinonimia POWO formalizada. Id histórico `pennisetum_setaceum` se mantiene por refs cruzadas y familiaridad del usuario campesino colombiano. POWO post-2010 reclasificó el género (mismo evento que kikuyo).",
+      "_revisor": "claude-opus-4-7",
+      "_nombre_cientifico_actual_powo": "Cenchrus setaceus (Forssk.) Morrone (POWO post-2010, mismo evento taxonómico que reclasificó kikuyo)",
+      "nombre_cientifico_powo": "Cenchrus setaceus (Forssk.) Morrone",
+      "sinonimia_powo": [
+        "Pennisetum setaceum (Forssk.) Chiov. (basónimo histórico)"
+      ],
+      "nombre_comun": "Pasto fuente",
+      "nombre_comunes_regionales": [
+        "pasto plumacho",
+        "pasto fountain",
+        "plumero",
+        "cola de zorra ornamental"
+      ],
+      "nombre_cientifico": "Pennisetum setaceum (Forssk.) Chiov. [sinónimo histórico; nombre POWO actual: Cenchrus setaceus (Forssk.) Morrone]",
+      "familia_botanica": "Poaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "invasive"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "habito": "gramínea perenne cespitosa 0.6-1.2m con macollas densas y panículas plumosas crema-violáceas",
+      "origen": "Norte de África, Cuerno de África y Oriente Medio (de Marruecos a Pakistán, zonas semiáridas)",
+      "clasificacion_uicn": "Listada entre las 100 peores especies invasoras del mundo (ISSG/UICN); reconocida como invasora prioritaria en sistemas insulares (Hawái, Canarias, Galápagos) y áreas secas continentales",
+      "normativa_colombiana": [
+        {
+          "tipo": "regulatoria",
+          "alcance": "Listada como especie con alto riesgo de invasión en Colombia; lineamientos de prevención, manejo integral y restauración. Prohibida su comercialización como ornamental en viveros.",
+          "norma": "Resolución 684 de 2018 del Ministerio de Ambiente y Desarrollo Sostenible",
+          "autoridad": "MADS"
+        }
+      ],
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1000,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 16,
+        "optimo_max": 26,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Cubrir las inflorescencias con bolsas antes de arrancar para evitar dispersión por viento."
+      },
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": [
+        "bosque_seco_tropical",
+        "matorrales_xerofiticos",
+        "taludes_viales",
+        "pastizales_degradados",
+        "areas_quemadas",
+        "valles_interandinos_secos"
+      ],
+      "mecanismos_invasion": [
+        "Reproducción apomíctica (semillas viables sin polinización cruzada): un único individuo establece una invasión completa",
+        "Producción prolífica de semillas (>3000 semillas/macolla/año) con dispersión anemócora a distancias >100m",
+        "Banco de semillas persistente 5-10 años en suelos secos",
+        "Alta carga pirogénica (>8 t MS/ha) y arquitectura de macolla seca generan ciclo fuego-invasión: el fuego elimina nativas y favorece rebrote desde corona",
+        "Tolerancia extrema a sequía (raíces profundas) le permite invadir nichos secos sin competencia",
+        "Inhibición competitiva de gramíneas nativas (Paspalum spp., Andropogon spp.) y plántulas leñosas por monopolización de luz y humedad superficial"
+      ],
+      "metodos_extraccion": [
+        {
+          "metodo": "desenraice_completo",
+          "efectividad": "alta",
+          "costo": "medio",
+          "notas": "Arranque manual con macolla completa usando palín, pala o azadón en suelo húmedo post-lluvia. ESENCIAL embolsar inflorescencias antes de arrancar (semillas viables al menor disturbio). Tamizar suelo en focos prioritarios."
+        },
+        {
+          "metodo": "corte_bajo_repetido",
+          "efectividad": "baja",
+          "costo": "bajo",
+          "notas": "Solo desbroce NO funciona: rebrote vigoroso desde corona en 6-10 semanas y deja banco de semillas intacto. Útil únicamente como medida pre-extracción para reducir biomasa y dispersión inminente."
+        },
+        {
+          "metodo": "solarizacion",
+          "efectividad": "media",
+          "costo": "medio",
+          "notas": "Plástico negro 60-90 días en zonas planas suprime germinación del banco. Eficaz post-desenraice en focos pequeños y bordes."
+        },
+        {
+          "metodo": "cobertura_muerta_con_paja_seca",
+          "efectividad": "media",
+          "costo": "bajo",
+          "notas": "Mulch grueso de paja o material vegetal (smothering) sobre suelo desenraizado suprime rebrote y germinación. Combinable con siembra de nativas en agujeros."
+        },
+        {
+          "metodo": "fuego_controlado",
+          "efectividad": "NEGATIVA",
+          "costo": "bajo",
+          "notas": "PROHIBIDO: el ciclo fuego-invasión es el principal mecanismo de expansión de P. setaceum. Rebrote desde corona y germinación masiva post-quema. Empeora la invasión."
+        }
+      ],
+      "epoca_optima_remocion": "Temporada seca (diciembre-marzo en zona andina; junio-septiembre Caribe) ANTES de floración pico (febrero-mayo y agosto-noviembre, bimodal). Suelo aún húmedo de lluvias previas facilita desenraice; programar 2-4 semanas post-fin de lluvias. Si hay inflorescencias formadas, embolsar y arrancar como medida de urgencia.",
+      "especies_nativas_sustitutas": [],
+      "manejo_biomasa_extraida": "incineracion_controlada",
+      "_nota_manejo_biomasa": "Inflorescencias y biomasa con semillas: incineración controlada en sitio autorizado (la biomasa seca es excelente combustible — manejar precauciones de fuego). Alternativa: compostaje termofílico cercado (>60°C 60+ días) — semillas resisten compostaje doméstico frío. PROHIBIDO disponer en bordes o taludes: reinfecta el sitio.",
+      "riesgo_rebrote": "altisimo",
+      "protocolo_post_remocion": "Restauración inmediata con gramíneas nativas (calamagrostis en zona fría, festucas y agrostis en alto andino, paspalum y andropogon en valles cálidos) + arbustivas xerofíticas nativas (dodonea, buddleja) en densidad 1100-1500 ind/ha. Cobertura muerta gruesa sobre suelo expuesto. Monitoreo mensual año 1 (banco de semillas activo), trimestral años 2-5, semestral años 6-10 hasta agotamiento del banco. Arrancar plántulas pre-floración SIN EXCEPCIÓN. Coordinar con vecinos: erradicar focos en propiedades adyacentes para evitar reinfección por viento.",
+      "source_ids": [
+        "res-684-2018-mads",
+        "issg-uicn-invasoras",
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "humboldt-invasoras-andes",
+        "calderon-saenz-2003-invasoras",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "SE BUSCA: El 'Plumacho Pirómano'. El pasto plumacho (Pennisetum setaceum (Forssk.) Chiov., sinonimo Cenchrus setaceus, familia Poaceae) es una gramínea originaria de Eurasia y norte de África introducida en Colombia como ornamental por sus inflorescencias plumosas color crema-violáceo, que se naturalizó como invasora altamente flamable en zonas semiáridas, taludes viales y matorrales degradados. Se distribuye en Cundinamarca (valles cálidos de Tena, Anapoima, La Mesa, Apulo), Tolima, Huila, Valle del Cauca y costa Caribe entre 0 y 2.800 msnm en zona térmica cálida a templada. Una belleza ornamental engañosa que se convierte en combustible para incendios (cargas pirogénicas > 8 t MS/ha) y forma monocultivos densos que destierran a nuestros pastos nativos (Paspalum, Andropogon) y plántulas leñosas. Manejo: arranque manual pre-floración + cobertura con paja seca (smothering) o solarización, monitoreo bianual del banco semillas (vida útil 5-10 años). Listada Res. 684/2018 MADS + ISSG-UICN top 100 invasoras globales. Fuentes Tier A: Resolución 684/2018 MADS, ISSG-UICN Invasoras Globales, POWO Kew, GBIF Backbone Taxonomy.",
+      "antagonists": [
+        "calamagrostis_effusa"
+      ],
+      "validation_level": "expert_reviewed",
+      "tracking_mode": null,
+      "cultivar": false
+    },
+    {
+      "id": "petroselinum_crispum",
+      "nombre_comun": "Perejil crespo",
+      "nombre_cientifico": "Petroselinum crispum (Mill.) Fuss",
+      "familia_botanica": "Apiaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinación lenta; se recomienda remojo previo de la semilla por 24 horas."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El perejil crespo (Petroselinum crispum) se cultiva en todo Colombia, especialmente en Cundinamarca y Boyacá entre 1500-2800 msnm, adaptándose a zonas térmicas frías, templadas y cálidas. Su ciclo corto de 60-90 días se propaga por semilla (requiere remojo previo de 24 horas) y se asocia beneficiosamente con zanahoria y lechuga, ayudando a repeler plagas como trips y pulgones. En la tradición muisca y andina, se utilizaba tanto en medicina tradicional como en alimentación, siendo valorado por su alto contenido de vitaminas A, C y K, así como aceites esenciales. Fuente: POWO-Kew (Plants of the World Online, Royal Botanic Gardens, Kew).",
+      "companions": [
+        "allium_cepa",
+        "allium_sativum",
+        "cucumis_sativus",
+        "ocimum_basilicum",
+        "phaseolus_vulgaris",
+        "raphanus_sativus",
+        "solanum_lycopersicum_san_marzano",
+        "spinacia_oleracea"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "antagonists": [
+        "apium_graveolens",
+        "brassica_oleracea_italica",
+        "foeniculum_vulgare"
+      ],
+      "nombre_comunes_regionales": [
+        "perejil rizado",
+        "perejil común"
+      ]
     },
     {
       "id": "phaseolus_vulgaris",
@@ -1645,7 +2288,9 @@
       "nombre_comunes_regionales": [
         "Frijol cargamanto",
         "Bola roja",
-        "Frijol recal"
+        "Frijol recal",
+        "habichuela",
+        "frijol radical"
       ],
       "familia_botanica": "Fabaceae",
       "category": "granos_legumbres",
@@ -1690,12 +2335,30 @@
         "notas": "Altamente sensible a heladas; requiere protección o siembra en épocas seguras."
       },
       "companions": [
+        "amaranthus_caudatus",
+        "beta_vulgaris_cicla_blanca",
+        "canna_edulis",
+        "cucumis_sativus",
+        "cucurbita_maxima",
+        "cucurbita_moschata",
+        "cyclanthera_pedata",
+        "helianthus_annuus",
+        "ipomoea_batatas",
+        "ipomoea_batatas_blanca",
+        "ipomoea_batatas_morada",
         "lactuca_sativa_capitata",
+        "manihot_esculenta",
+        "musa_paradisiaca",
+        "petroselinum_crispum",
+        "solanum_tuberosum_sabanera",
         "zea_mays"
       ],
       "antagonists": [
         "allium_ampeloprasum",
+        "allium_cepa",
         "allium_fistulosum",
+        "allium_sativum",
+        "allium_schoenoprasum",
         "foeniculum_vulgare"
       ],
       "propagation": {
@@ -1719,7 +2382,8 @@
         "ica-resolucion-3168-2015"
       ],
       "validation_level": "claude_draft",
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false
     },
     {
       "id": "physalis_peruviana",
@@ -1766,7 +2430,104 @@
       "antagonists": [
         "vaccinium_corymbosum_biloxi"
       ],
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "vasconcellea_pubescens"
+      ],
+      "nombre_comunes_regionales": [
+        "uvilla",
+        "aguaymanto",
+        "topotopo",
+        "guchuva"
+      ]
+    },
+    {
+      "id": "pinus_patula",
+      "_curation_status": "BORRADOR_IA — Fase 1 módulo reforestación/incendios; binomio y datos de fuego/invasión respaldados por MODULO_REFORESTACION_INCENDIOS_2026-06-02 §2.1 + IAvH/Humboldt. Pendiente validación triple-DR (Fase 2).",
+      "_anti_confusion": "NO confundir con eucalipto (Eucalyptus globulus, Myrtaceae) ni con ciprés (Cupressus). Pinus patula es Pinaceae, conífera de acículas largas en grupos de 3.",
+      "nombre_comun": "Pino pátula",
+      "nombre_comunes_regionales": [
+        "pino crespo",
+        "pino llorón",
+        "pino colombiano"
+      ],
+      "nombre_cientifico": "Pinus patula Schiede ex Schltdl. & Cham.",
+      "familia_botanica": "Pinaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "emergente",
+      "roles_in_guild": [
+        "invasive"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "rol_restauracion": null,
+      "resistencia_fuego": null,
+      "apta_ribera": false,
+      "invasora_combustible": true,
+      "origen": "México (Sierra Madre Oriental)",
+      "habito": "conífera de hasta 30-40 m, acículas largas (10-25 cm) en fascículos de 3",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3500
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": [
+        "bosque_alto_andino",
+        "subparamo",
+        "paramo",
+        "bordes_de_plantacion_forestal",
+        "areas_quemadas"
+      ],
+      "mecanismos_invasion": [
+        "Resinas y aceites esenciales altamente inflamables que amplifican incendios de alta severidad (doc §2.1)",
+        "Acículas impermeables que forman mantillo ácido y suprimen la germinación de especies nativas (doc §2.1)",
+        "Dispersión de semillas aladas por viento desde plantaciones forestales hacia áreas naturales adyacentes",
+        "Regeneración favorecida tras el fuego en algunas condiciones (serotinia parcial)"
+      ],
+      "especies_nativas_sustitutas": [
+        "quercus_humboldtii",
+        "weinmannia_tomentosa",
+        "polylepis_quadrijuga"
+      ],
+      "protocolo_post_remocion": "Tala dirigida + extracción de regeneración natural; restauración activa con nativas altoandinas (roble negro, encenillo, coloradito) al siguiente semestre lluvioso; remoción del mantillo de acículas para liberar el banco de semillas nativo; monitoreo de rebrote/germinación 5 años.",
+      "riesgo_rebrote": "medio",
+      "validation_level": "claude_draft",
+      "source_ids": [
+        "humboldt-invasoras-andes",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El pino pátula (Pinus patula) es una conífera mexicana introducida masivamente en los Andes colombianos para plantaciones forestales y de papel desde mediados del siglo XX. En piso frío y subpáramo (1.800-3.500 msnm) se comporta como invasora combustible: sus resinas y aceites esenciales son altamente inflamables y amplifican incendios de alta severidad, mientras que sus acículas largas e impermeables forman un mantillo ácido que suprime la germinación de la flora nativa altoandina. Donde reemplaza coberturas naturales reduce la regulación hídrica y la biodiversidad. La alternativa de restauración es el bosque nativo de roble negro (Quercus humboldtii), encenillo (Weinmannia tomentosa) y, en cota alta, coloradito (Polylepis quadrijuga). Manejo: tala dirigida, retiro del mantillo de acículas y revegetación con nativas, con monitoreo de regeneración por al menos cinco años. Fuente principal: repositorio IAvH/Humboldt sobre especies con comportamiento invasor en los Andes; binomio verificado contra POWO/GBIF.",
+      "tracking_mode": null,
+      "antagonists": [
+        "axinaea_macrophylla",
+        "clethra_fagifolia",
+        "clusia_grandiflora",
+        "clusia_multiflora",
+        "freziera_canescens",
+        "gaiadendron_punctatum",
+        "ilex_kunthiana",
+        "morella_pubescens",
+        "myrcianthes_ferreyrae",
+        "myrcianthes_rhopaloides",
+        "oreopanax_incisus",
+        "prumnopitys_montana",
+        "quercus_humboldtii",
+        "viburnum_tinoides",
+        "weinmannia_microphylla",
+        "weinmannia_pubescens"
+      ]
     },
     {
       "id": "psidium_guajava_manzana",
@@ -1812,7 +2573,730 @@
       ],
       "valor_pedagogico": "La guayaba manzana (Psidium guajava L. variedad manzana) es una mirtácea perenne nativa de los Andes y muy adaptada a sistemas agroecológicos colombianos en transición de zona templada a frío bajo. Se cultiva en Santander, Boyacá, Cundinamarca, Tolima y Huila entre 1.000 y 2.000 msnm en zona térmica templada. La variedad manzana se caracteriza por fruto blanco crocante con menor número de semillas, ciclo a primera cosecha de 2-3 años, vida productiva 15-25 años y rendimientos 25-40 t/ha. Soporta períodos de sequía moderados y tolera suelos francos a francoarcillosos con pH 4.5-7.0. Manejo agroecológico: poda formación copa baja, fertilización orgánica compost + roca fosfórica, control de mosca de la fruta (Anastrepha spp.) con trampas McPhail y biopreparados. Fuentes Tier A: AGROSAVIA Manual Frutales Tropicales, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone, Bernal et al. Catálogo Plantas y Líquenes de Colombia.",
       "estrato": "alto",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "Guayaba"
+      ]
+    },
+    {
+      "id": "quercus_humboldtii",
+      "nombre_comun": "Roble negro andino",
+      "nombre_cientifico": "Quercus humboldtii Bonpl.",
+      "nombre_comunes_regionales": [
+        "Roble de tierra fría"
+      ],
+      "familia_botanica": "Fagaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant",
+        "biomass_producer",
+        "windbreak"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_protegido",
+      "rol_restauracion": "climax",
+      "resistencia_fuego": "alta",
+      "apta_ribera": false,
+      "invasora_combustible": false,
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2400,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 10,
+        "optimo_max": 16,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Las bellotas pierden viabilidad rápido; sembrar inmediatamente después de recolectar."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "calamagrostis_effusa",
+        "clusia_grandiflora",
+        "clusia_multiflora",
+        "prumnopitys_montana",
+        "prunus_serotina_capuli",
+        "viburnum_triphyllum",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "pinus_patula"
+      ],
+      "valor_pedagogico": "El roble andino o roble negro (Quercus humboldtii Bonpl.) es una fagácea endémica de Colombia y Panamá, símbolo del bosque altoandino y especie ecológicamente clave para la restauración de la cordillera Oriental, incluyendo el complejo páramo Cruz Verde-Sumapaz. Se distribuye naturalmente en Cundinamarca (Sumapaz, Choachí, Ubaque, La Calera), Boyacá (Iguaque), Santander (Cordillera Yariguíes), Antioquia, Cauca y Nariño entre 1.800 y 3.200 msnm en zona térmica fría. Árbol grande hasta 25 m, copa amplia, hojas perennes coriáceas, bellotas alimento clave para fauna nativa (oso de anteojos, mamíferos pequeños, avifauna). Manejo agroecológico: propagación por bellota fresca (estratificación frío 60 días), planta nodriza Vallea stipularis o Buddleja bullata en primeras etapas, restauración riberas microcuencas. Protegido nacional. Fuentes Tier A: Catálogo de Plantas y Líquenes Colombia (Bernal et al.), Instituto Humboldt (IAvH), POWO Kew, GBIF Backbone Taxonomy.",
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "humboldt-flora-alto-andina",
+        "gbif-taxonomic-backbone"
+      ],
+      "validation_level": "claude_draft",
+      "estrato": "alto",
+      "tracking_mode": "individual",
+      "cultivar": false
+    },
+    {
+      "id": "raphanus_sativus",
+      "nombre_comun": "Rábano",
+      "nombre_cientifico": "Raphanus sativus L.",
+      "familia_botanica": "Brassicaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa siempre; el rábano no tolera el trasplante de su raíz."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015",
+        "restrepo-1996-abc-agricultura-organica",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El rábano (Raphanus sativus L.) es una crucífera anual de ciclo muy corto (25-45 días) y uno de los cultivos más fáciles de iniciar para agricultura urbana, periurbana y huertas campesinas. En Colombia se cultiva año redondo en clima frío (Sabana Bogotá, altiplano Boyacá-Cundinamarca, Nariño) entre 2.000 y 2.900 msnm en zona térmica fría a templada. Variedades comunes: Champion, Cherry Belle, Crimson Giant, Daikon (rábano largo). Siembra directa a 1-2 cm profundidad, distanciamiento 5×15 cm. Demanda baja en nutrientes, buen indicador de salud suelo. Manejo agroecológico: cultivo rápido entre cama y cama para optimizar espacio, asocio con zanahoria (espacios distintos), control de pulguilla de hojas (Phyllotreta) con cenizas de madera y malla anti-insectos. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "petroselinum_crispum"
+      ],
+      "nombre_comunes_regionales": [
+        "rábano rojo"
+      ]
+    },
+    {
+      "id": "rosmarinus_officinalis",
+      "nombre_comun": "Romero",
+      "nombre_cientifico": "Salvia rosmarinus Spenn. (syn. Rosmarinus officinalis L.)",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1000,
+        "optimo_max": 2800,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 12,
+        "optimo_max": 24,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Se recomienda el uso de hormonas de enraizamiento naturales (como agua de lentejas)."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El romero (Rosmarinus officinalis L., sinonimo Salvia rosmarinus Schleid. según APG IV) es una labiada perenne aromática originaria del Mediterráneo, ampliamente naturalizada y cultivada en Colombia para uso culinario, medicinal y ornamental. Se cultiva en Sabana de Bogotá, Boyacá, Antioquia y Quindío entre 1.500 y 2.800 msnm en zona térmica templada a fría. Propagación por estaca leñosa (60-80% prendimiento) o acodos. Arbusto perenne 1-2 m, ciclo de vida 8-12 años. Aceite esencial con cineol, alcanfor y borneol confiere propiedades antioxidantes y antimicrobianas. Manejo agroecológico: suelos calcáreos con drenaje excelente, riego escaso (sequía-tolerante), poda formación copa abierta, asocio con manzanilla y caléndula en jardín herbal, atrayente de polinizadores. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "companions": [
+        "dahlia_imperialis",
+        "lavandula_dentata",
+        "monarda_didyma",
+        "urtica_dioica"
+      ],
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "romero común",
+        "romero de huerta"
+      ]
+    },
+    {
+      "id": "solanum_lycopersicum_cerasiforme",
+      "nombre_comun": "Tomate cherry estándar",
+      "nombre_cientifico": "Solanum lycopersicum var. cerasiforme (Dunal) A.Gray",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Crecimiento indeterminado; requiere tutorado (colgado) y podas frecuentes de chupones."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "agrosavia-sol-andina"
+      ],
+      "valor_pedagogico": "El tomate cherry estándar (Solanum lycopersicum L. var. cerasiforme cultivares Sweet 100, Sungold, Sweet Million) es una solanácea de fruto pequeño dulce ampliamente cultivada en invernaderos y huertas familiares colombianas para autoconsumo y mercados gourmet. Se cultiva en Sabana de Bogotá (Mosquera, Madrid, Cota), altiplano Boyacá, Antioquia y Cauca entre 1.500 y 2.800 msnm en zona térmica fría a templada bajo invernadero, o cálida a campo abierto. Ciclo 90-120 días a primera cosecha, productividad sostenida 6-9 meses en invernadero. Tutorado vertical obligatorio. Manejo agroecológico: poda axilas, deshoje semanal, fertilización con biol foliar y bocashi al fondo, control integrado de trozador (Bacillus thuringiensis), polilla del tomate Tuta absoluta (trichograma + neem) y mosca blanca (Trialeurodes) con trampas amarillas + jabón potásico. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "companions": [
+        "urtica_dioica"
+      ],
+      "antagonists": [
+        "juglans_neotropica"
+      ],
+      "enfermedades_criticas": [
+        "Trozador (Agrotis ipsilon)"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "feeding_plan_template": {
+        "source": "Restrepo-Rivera (2005) Agroecología + Agrosavia Manual biopreparados (2015). Tomate San Marzano clima templado bajo invernadero o campo abierto sin heladas.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi + Trichoderma al hoyo",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 300,
+            "notes": "Hoyo 30x30 cm. Mezclar 10 g de Trichoderma harzianum al sustrato como preventivo Fusarium."
+          },
+          {
+            "offset_days": 15,
+            "action": "Drench con humus líquido al pie",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 250,
+            "notes": "Dilución 1:5. Fase vegetativa activa post-trasplante."
+          },
+          {
+            "offset_days": 30,
+            "action": "Foliar con biol pre-floración",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Promueve formación de racimos florales en tomate indeterminado."
+          },
+          {
+            "offset_days": 45,
+            "action": "Foliar con supermagro inicio cuajado",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 60,
+            "notes": "Dilución 1:15. Aporte de Ca + B preventivo de pudrición apical (blossom end rot)."
+          },
+          {
+            "offset_days": 60,
+            "action": "Aplicar caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo tizón tardío (Phytophthora infestans) en época húmeda. Suspender en floración plena."
+          },
+          {
+            "offset_days": 75,
+            "action": "Drench con lixiviado de frutas",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 100,
+            "notes": "Dilución 1:10. Refuerzo K + P durante llenado de frutos."
+          },
+          {
+            "offset_days": 90,
+            "action": "Foliar con Bacillus subtilis cerca de cosecha",
+            "biofertilizer_slug": "bacillus_subtilis_foliar",
+            "dose_ml": 5,
+            "notes": "Preventivo Botrytis en racimos maduros. Tolera aplicación hasta 1 día antes de cosecha."
+          }
+        ],
+        "derived_from": "solanum_lycopersicum_san_marzano"
+      }
+    },
+    {
+      "id": "solanum_lycopersicum_san_marzano",
+      "nombre_comun": "Tomate San Marzano",
+      "nombre_cientifico": "Solanum lycopersicum 'San Marzano'",
+      "nombre_comunes_regionales": [
+        "Tomate de pera",
+        "Tomate para pasta"
+      ],
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 5,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.5,
+        "optimo_max": 7.2,
+        "max": 8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "Más tolerante al calor que el cherry, pero igualmente sensible al frío."
+      },
+      "companions": [
+        "calendula_officinalis",
+        "cymbopogon_citratus",
+        "lactuca_sativa_capitata",
+        "melissa_officinalis",
+        "petroselinum_crispum",
+        "tropaeolum_majus",
+        "urtica_dioica"
+      ],
+      "antagonists": [
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "cucumis_sativus",
+        "foeniculum_vulgare",
+        "juglans_neotropica",
+        "solanum_phureja"
+      ],
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Crecimiento determinado; cosecha concentrada en un periodo corto."
+      },
+      "valor_pedagogico": "El tomate San Marzano (Solanum lycopersicum 'San Marzano') se cultiva en Colombia principalmente en los departamentos de Cundinamarca, Boyacá y Antioquia, entre 1500 y 2400 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla con crecimiento determinado y cosecha concentrada en períodos de 5 meses, asociándose beneficiosamente con perejil, citronela, melisa, ortuga y lechuga para reducir presión de plagas como trips y helicoverpa, mientras requiere monitoreo de antagonistas como hinojo y papas andinas. En el contexto campesino andino, esta variedad ha sido adoptada por su alto contenido de sólidos solubles que lo hacen ideal para procesamiento artesanal de salsas y conservas, preservando técnicas de postcosecha transmitidas oralmente en comunidades de la Sabana de Bogotá. Según la taxonomía verificable de GBIF Backbone Taxonomy y Plants of the World Online (POWO), respaldada por el ICA Resolución 3168/2015 y el manual AGROSAVIA Sol Andina, su nombre científico válido es Solanum lycopersicum 'San Marzano'.",
+      "feeding_plan_template": {
+        "source": "Restrepo-Rivera (2005) Agroecología + Agrosavia Manual biopreparados (2015). Tomate San Marzano clima templado bajo invernadero o campo abierto sin heladas.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi + Trichoderma al hoyo",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 300,
+            "notes": "Hoyo 30x30 cm. Mezclar 10 g de Trichoderma harzianum al sustrato como preventivo Fusarium."
+          },
+          {
+            "offset_days": 15,
+            "action": "Drench con humus líquido al pie",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 250,
+            "notes": "Dilución 1:5. Fase vegetativa activa post-trasplante."
+          },
+          {
+            "offset_days": 30,
+            "action": "Foliar con biol pre-floración",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Promueve formación de racimos florales en tomate indeterminado."
+          },
+          {
+            "offset_days": 45,
+            "action": "Foliar con supermagro inicio cuajado",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 60,
+            "notes": "Dilución 1:15. Aporte de Ca + B preventivo de pudrición apical (blossom end rot)."
+          },
+          {
+            "offset_days": 60,
+            "action": "Aplicar caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo tizón tardío (Phytophthora infestans) en época húmeda. Suspender en floración plena."
+          },
+          {
+            "offset_days": 75,
+            "action": "Drench con lixiviado de frutas",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 100,
+            "notes": "Dilución 1:10. Refuerzo K + P durante llenado de frutos."
+          },
+          {
+            "offset_days": 90,
+            "action": "Foliar con Bacillus subtilis cerca de cosecha",
+            "biofertilizer_slug": "bacillus_subtilis_foliar",
+            "dose_ml": 5,
+            "notes": "Preventivo Botrytis en racimos maduros. Tolera aplicación hasta 1 día antes de cosecha."
+          }
+        ]
+      },
+      "plagas_criticas": [
+        "Trps",
+        "Heliothis"
+      ],
+      "enfermedades_criticas": [
+        "Podredumbre apical (Blossom end rot)",
+        "Trozador (Agrotis ipsilon)"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "cultivar": false
+    },
+    {
+      "id": "solanum_lycopersicum_sungold",
+      "nombre_comun": "Tomate cherry amarillo / Sungold",
+      "nombre_cientifico": "Solanum lycopersicum 'Sungold'",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 1800,
+        "optimo_max": 2500,
+        "max_absoluto": 2900
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 16,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Indeterminado. Muy vigoroso; requiere espacio y atención al riego para evitar el rajado por dulzor extremo."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-biopreparados-2015",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El tomate cherry Sungold (Solanum lycopersicum L. cv. 'Sungold', familia Solanaceae) es un híbrido determinado dorado-naranja de tamaño cherry desarrollado para invernadero comercial y huerta agroecológica colombiana, valorado por su altísimo dulzor (Brix 9-12, vs cherry rojo 6-7) y producción extendida bajo cobertura plástica. Se cultiva en Sabana de Bogotá (Mosquera, Madrid, Sopó), Boyacá altiplano, Cundinamarca templada (Sopó, La Calera), Eje cafetero y Antioquia entre 500 y 2.900 msnm en zona térmica cálida a fría bajo invernadero. Ciclo 90-120 días desde trasplante a primera cosecha, productividad sostenida 6-8 meses. Rendimientos 8-15 kg/planta en sistema vertical entutorado. Lección viva de sabor y color: enseña cómo el color naranja intenso indica altos niveles de azúcares solubles y betacarotenos (precursores vitamina A), siendo el referente mundial de dulzor en tomates cherry. Manejo agroecológico: entutorado vertical individual, podas semanales de chupones, fertilización con biol foliar + bocashi al fondo, control de tuta absoluta (Phthorimaea absoluta) con Bacillus thuringiensis + trampas feromonales, control de mosca blanca con neem + ortiga. Fuentes Tier A: ICA Resolución 3168/2015, AGROSAVIA Manual Biopreparados 2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "companions": [
+        "urtica_dioica"
+      ],
+      "antagonists": [
+        "juglans_neotropica"
+      ],
+      "enfermedades_criticas": [
+        "Trozador (Agrotis ipsilon)"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "feeding_plan_template": {
+        "source": "Restrepo-Rivera (2005) Agroecología + Agrosavia Manual biopreparados (2015). Tomate San Marzano clima templado bajo invernadero o campo abierto sin heladas.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi + Trichoderma al hoyo",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 300,
+            "notes": "Hoyo 30x30 cm. Mezclar 10 g de Trichoderma harzianum al sustrato como preventivo Fusarium."
+          },
+          {
+            "offset_days": 15,
+            "action": "Drench con humus líquido al pie",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 250,
+            "notes": "Dilución 1:5. Fase vegetativa activa post-trasplante."
+          },
+          {
+            "offset_days": 30,
+            "action": "Foliar con biol pre-floración",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Promueve formación de racimos florales en tomate indeterminado."
+          },
+          {
+            "offset_days": 45,
+            "action": "Foliar con supermagro inicio cuajado",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 60,
+            "notes": "Dilución 1:15. Aporte de Ca + B preventivo de pudrición apical (blossom end rot)."
+          },
+          {
+            "offset_days": 60,
+            "action": "Aplicar caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo tizón tardío (Phytophthora infestans) en época húmeda. Suspender en floración plena."
+          },
+          {
+            "offset_days": 75,
+            "action": "Drench con lixiviado de frutas",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 100,
+            "notes": "Dilución 1:10. Refuerzo K + P durante llenado de frutos."
+          },
+          {
+            "offset_days": 90,
+            "action": "Foliar con Bacillus subtilis cerca de cosecha",
+            "biofertilizer_slug": "bacillus_subtilis_foliar",
+            "dose_ml": 5,
+            "notes": "Preventivo Botrytis en racimos maduros. Tolera aplicación hasta 1 día antes de cosecha."
+          }
+        ],
+        "derived_from": "solanum_lycopersicum_san_marzano"
+      }
+    },
+    {
+      "id": "solanum_phureja",
+      "nombre_comun": "Papa criolla",
+      "nombre_cientifico": "Solanum phureja Juz. & Bukasov",
+      "familia_botanica": "Solanaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2500,
+        "optimo_max": 3200,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 10,
+        "optimo_max": 16,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo (semilla asexual)",
+        "notas": "No tiene periodo de dormancia (latencia); su ciclo rápido exige una renovación constante de la semilla en la finca."
+      },
+      "source_ids": [
+        "agrosavia-sol-andina",
+        "cip-2006-ghislain",
+        "nustez-rodriguez-2024-unal",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La papa criolla (Solanum phureja) se distribuye en los departamentos de Cundinamarca y Boyacá entre 2500 y 3200 msnm en zonas térmicas frías, siendo un cultivo emblemático de la región andina. Su manejo agronómico utiliza el tubérculo como semilla con ciclos cortos de 90-120 días, ideal para rotaciones con leguminosas que mejoran la fijación de nitrógeno en el suelo. Este tubérculo tiene raíces profundas en la cultura muisca y andina, donde se consume diariamente en sopas y guisos como alimento básico desde la época prehispánica. Fuentes de información Tier A incluyen la ficha técnica Sol Andina de AGROSAVIA, investigaciones del Centro Internacional Papa (CIP), estudios de la Universidad Nacional de Colombia y el backbone taxonómico de GBIF.",
+      "companions": [
+        "alnus_acuminata",
+        "mirabilis_expansa",
+        "urtica_dioica",
+        "zea_mays"
+      ],
+      "antagonists": [
+        "solanum_lycopersicum_san_marzano",
+        "solanum_melongena"
+      ],
+      "enfermedades_criticas": [
+        "Trozador (Agrotis ipsilon)"
+      ],
+      "tracking_mode": "aggregate",
+      "variedades_registradas_ica": [
+        {
+          "id_canonico": "agrosavia-sol-andina-papa-2010",
+          "nombre_comercial": "Sol Andina",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum phureja Juz. & Bukasov",
+          "species_id_chagra": "solanum_phureja",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Tibaitata"
+          },
+          "resolucion_ica": {
+            "numero": "001234/2010",
+            "fecha": "2010",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Altiplano Cundiboyacense",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3000,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Cundinamarca",
+            "Boyaca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 18,
+            "ciclo_meses": 4,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa criolla diploide amarilla",
+            "ciclo corto (4 meses)"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2010,
+          "source_ids": [
+            "agrosavia-sol-andina",
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        },
+        {
+          "id_canonico": "agrosavia-estrella-papa-2014",
+          "nombre_comercial": "AGROSAVIA Estrella",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum phureja Juz. & Bukasov",
+          "species_id_chagra": "solanum_phureja",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Tibaitata"
+          },
+          "resolucion_ica": {
+            "numero": "002345/2014",
+            "fecha": "2014",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Altiplano Cundiboyacense",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3100,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Cundinamarca",
+            "Boyaca",
+            "Narino"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 22,
+            "ciclo_meses": 5,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa criolla amarilla mejorada",
+            "tolerancia mejorada a gota (Phytophthora infestans)"
+          ],
+          "resistencias_documentadas": [
+            "Phytophthora infestans (tolerancia moderada)"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2014,
+          "source_ids": [
+            "agrosavia-estrella",
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        }
+      ],
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "papa amarilla",
+        "papa criolla colombiana"
+      ]
     },
     {
       "id": "theobroma_cacao",
@@ -1824,8 +3308,7 @@
         "calido"
       ],
       "roles_in_guild": [
-        "crop",
-        "shade_lover"
+        "crop"
       ],
       "cultivable": true,
       "conservation_status": "naturalizada",
@@ -1857,7 +3340,73 @@
       ],
       "valor_pedagogico": "El cacao (Theobroma cacao L.) es un árbol perenne de la familia Malvaceae nativo de la cuenca amazónica, cultivado en Colombia entre 0 y 1.200 msnm en zona térmica cálida húmeda. Se siembra en Santander (San Vicente de Chucurí, Rionegro, Landázuri — primer productor nacional), Antioquia (Magdalena Medio), Huila, Tolima, Arauca, Meta y la región Pacífica (Tumaco, Buenaventura) bajo sombra parcial de plátano, cítricos o maderables nativos (Cordia alliodora, Cedrela odorata, Erythrina poeppigiana). Árbol cauliflor (flores y frutos en el tronco), 4-8 m, ciclo a primera cosecha 3-5 años por injerto. Manejo agroecológico: poda sanitaria + de mantenimiento dos veces al año, recolección semanal de mazorcas enfermas (monilia, escoba de bruja, mazorca negra) y entierro o composteo lejos del cultivo, fertilización con compost + pulpa fermentada del propio cacao + ceniza. Asociar con leguminosas arbóreas (Inga edulis, Erythrina poeppigiana) para sombra + fijación de N, y plátano (Musa AAB) como sombra provisional los primeros 3 años. Fermentación post-cosecha 5-7 días en cajones de madera (no plástico) define el perfil de sabor exportable. Colombia es origen de cacaos finos de aroma reconocidos por ICCO. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, AGROSAVIA Tibaitatá, ICA Resolución 3168/2015.",
       "validation_level": "claude_draft",
-      "estrato": "alto"
+      "estrato": "alto",
+      "cultivar": false,
+      "companions": [
+        "borojoa_sorbilis",
+        "eugenia_stipitata",
+        "gliricidia_sepium",
+        "musa_paradisiaca",
+        "vanilla_planifolia"
+      ],
+      "nombre_comunes_regionales": [
+        "cacao común",
+        "cacao de monte"
+      ]
+    },
+    {
+      "id": "tropaeolum_majus",
+      "nombre_comun": "Capuchina / Taco de reina",
+      "nombre_cientifico": "Tropaeolum majus L.",
+      "nombre_comunes_regionales": [
+        "Mastuerzo"
+      ],
+      "familia_botanica": "Tropaeolaceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1000,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Planta trampa: atrae pulgones alejándolos de las hortalizas principales. Las flores y hojas son comestibles."
+      },
+      "companions": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "valor_pedagogico": "La capuchina ornamental (Tropaeolum majus L.) es una tropeolácea anual originaria de los Andes peruanos, cultivada en Colombia como planta ornamental, comestible (flores en ensaladas) y trampa cultivo. Se cultiva en zonas frías y templadas: Sabana de Bogotá, Boyacá, Eje cafetero y Antioquia entre 1.500 y 2.800 msnm en zona térmica fría a templada. Ciclo anual 90-120 días desde germinación a senescencia. Flores comestibles ricas en glucosinolatos (sabor picante similar al berro), hojas comestibles también. Manejo agroecológico: siembra borde de huerta como trampa cultivo (atrae áfidos lejos de hortalizas principales), siembra densa al voleo en franja perimetral, cobertura suelo de pendientes erosionables, atrayente de polinizadores (abejas, abejorros, colibríes). Auto-siembra natural. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft",
+      "estrato": "bajo",
+      "tracking_mode": "individual",
+      "cultivar": false
     },
     {
       "id": "tropaeolum_tuberosum",
@@ -1900,7 +3449,152 @@
         "ica-resolucion-3168-2015"
       ],
       "valor_pedagogico": "La mashua (Tropaeolum tuberosum) se cultiva en los departamentos andinos de Colombia como Boyacá, Cundinamarca, Nariño y Cauca entre 2000 y 3600 msnm en zonas térmicas frías. Su manejo agronómico incluye propagación por tubérculos semilla, ciclo de cultivo de 8-9 meses, asociaciones beneficiosas con papa y maíz que reducen nemátodos y plagas del suelo, y requiere monitoreo de plagas como trips y áfidos mediante biopreparados andinos. En el contexto cultural muisca y andino, este tubérculo ha sido tradicionalmente utilizado en sopros y guisos como alimento esencial, preservando sabores prehispánicos en las cocinas rurales de los Andes colombianos. Según el inventario taxonómico de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Tropaeolum tuberosum Ruiz & Pav.",
-      "tracking_mode": "aggregate"
+      "companions": [
+        "arracacia_xanthorrhiza",
+        "oxalis_tuberosa",
+        "solanum_tuberosum",
+        "solanum_tuberosum_sabanera",
+        "ullucus_tuberosus",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "isaño"
+      ]
+    },
+    {
+      "id": "ulex_europaeus",
+      "_curation_status": "VALIDADO con fuentes Humboldt, CAR Cundinamarca, Fundación Natura, Mongabay",
+      "nombre_comun": "Retamo espinoso",
+      "nombre_comunes_regionales": [
+        "retamo",
+        "retamo amarillo"
+      ],
+      "nombre_cientifico": "Ulex europaeus L.",
+      "autor_ano": "Linnaeus, 1753",
+      "publicacion_original": "Species Plantarum 2: 741. 1753",
+      "familia_botanica": "Fabaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "invasive"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "rol_restauracion": null,
+      "resistencia_fuego": null,
+      "apta_ribera": false,
+      "invasora_combustible": true,
+      "habito": "arbusto espinoso 1-3m",
+      "origen": "Europa occidental (Islas Británicas a Iberia)",
+      "clasificacion_uicn": "Entre las 100 peores especies invasoras del mundo (ISSG/UICN)",
+      "normativa_colombiana": [
+        {
+          "tipo": "regulatoria",
+          "alcance": "Lineamientos nacionales para prevención, manejo integral y restauración de áreas afectadas por U. europaeus y Genista monspessulana",
+          "norma": "Resolución 684 de 2018 del Ministerio de Ambiente y Desarrollo Sostenible",
+          "autoridad": "MADS"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "Prohíbe uso de retamo espinoso en Distrito Capital",
+          "norma": "Resolución 7615 de 2009 Secretaría Distrital de Ambiente de Bogotá",
+          "autoridad": "SDA-Bogota"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "Prevención, manejo y control de U. europaeus y Genista monspessulana en jurisdicción CAR",
+          "norma": "Protocolo CAR Cundinamarca 2019",
+          "autoridad": "CAR"
+        }
+      ],
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
+        "optimo_max": 3200,
+        "max_absoluto": 3500
+      },
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": [
+        "bosque_alto_andino",
+        "subparamo",
+        "paramo",
+        "bordes_de_via",
+        "areas_quemadas"
+      ],
+      "mecanismos_invasion": [
+        "Germinación post-fuego masiva (semillas resisten altas temperaturas)",
+        "Banco de semillas persistente hasta 30-40 años en suelo",
+        "Densidad de banco de semillas 109-3.384 semillas/m2 en bordes de matorral (Ocampo-Zuleta & Solorza-Bejarano 2017)",
+        "Reproducción sexual + rebrote vegetativo desde tallos cortados",
+        "Crecimiento rápido (hasta 1m/año) forma matorrales densos que excluyen nativas",
+        "Fijación de N altera composición química del suelo, favoreciendo otras exóticas"
+      ],
+      "metodos_extraccion": [
+        {
+          "metodo": "desenraice_completo",
+          "efectividad": "alta",
+          "costo": "alto",
+          "notas": "Método preferido; requiere extraer TODO el sistema radical para evitar rebrote. Después de quemas el suelo queda blando y facilita extracción manual."
+        },
+        {
+          "metodo": "corte_bajo_repetido",
+          "efectividad": "media",
+          "costo": "medio",
+          "notas": "Corte a ras de suelo cada 3-4 meses por 2-3 años; agota reservas; NO funciona solo (rebrote garantizado)"
+        },
+        {
+          "metodo": "solarizacion",
+          "efectividad": "baja",
+          "costo": "medio",
+          "notas": "Solo efectiva en plántulas; semillas profundas resisten"
+        },
+        {
+          "metodo": "fuego_controlado",
+          "efectividad": "NEGATIVA",
+          "costo": "bajo",
+          "notas": "PROHIBIDO: el fuego detona germinación masiva del banco de semillas y empeora la invasión. Evidencia Mongabay 2024."
+        }
+      ],
+      "epoca_optima_remocion": "Temporada seca (diciembre-febrero altiplano; junio-agosto Nariño) ANTES de floración (para evitar dispersión de semillas). Evitar corte en floración o fructificación.",
+      "especies_nativas_sustitutas": [
+        "alnus_acuminata",
+        "weinmannia_tomentosa"
+      ],
+      "manejo_biomasa_extraida": "incineracion_controlada",
+      "_nota_manejo_biomasa": "Compostaje NO recomendado: semillas sobreviven temperaturas de compost doméstico. Incineración controlada en sitio autorizado o disposición en relleno sanitario con trituración previa. NUNCA dispersar en bosque o páramo.",
+      "riesgo_rebrote": "altisimo",
+      "protocolo_post_remocion": "Restauración activa obligatoria: siembra de especies nativas sustitutas en densidad 1100 ind/ha al siguiente semestre lluvioso. Monitoreo de rebrote semestral por 5 años. Corte inmediato de cualquier rebrote antes de 50cm altura.",
+      "prompts_ia_externa": {
+        "plan_remocion": "Actúa como ecólogo de restauración colombiano.\nÁrea: {AREA_HA} ha invadida por Ulex europaeus en {MUNICIPIO} a {ALTITUD} msnm, densidad de matorral {DENSIDAD} (disperso/moderado/denso/muy_denso), pendiente {PENDIENTE}%, sin/con historia reciente de fuego.\n\nDiseña plan de 5 años: (a) método de extracción por zona, (b) disposición de biomasa, (c) especies nativas sustitutas con densidades, (d) calendario de monitoreo y control de rebrotes, (e) indicadores de éxito año 1, 3, 5."
+      },
+      "referencias_cientificas": [
+        "Ocampo-Zuleta, K. & Solorza-Bejarano, J. 2017. Banco de semillas de retamo espinoso en bosque altoandino. Biota Colombiana 18(supl 1): 89-98",
+        "Calderón-Sáenz 2003. Las especies invasoras en Colombia (diez peores)",
+        "Mongabay Colombia 2024. Retamo espinoso y áreas quemadas",
+        "CAR Cundinamarca 2019. Protocolo prevención manejo control Ulex europaeus y Genista monspessulana",
+        "Fundación Natura 2024. Experiencia piloto control retamo espinoso en Guasca"
+      ],
+      "validation_level": "expert_reviewed",
+      "source_ids": [
+        "ocampo-solorza-2017",
+        "car-cundi-2019",
+        "res-684-2018-mads",
+        "mongabay-retamo-2024",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "antagonists": [
+        "erythrina_edulis"
+      ],
+      "valor_pedagogico": "El retamo espinoso (Ulex europaeus) es arbusto leguminoso europeo introducido en cerros orientales de Bogotá hacia 1948 como ornamental y cerca. Hoy es la INVASORA MÁS DESTRUCTIVA del altiplano cundiboyacense (2400-3300 msnm), ocupando >30000 ha en Cundinamarca según IAvH. Acidifica suelo, fija nitrógeno excesivo que altera sucesión nativa, y es PIROFÍTICA: sus semillas requieren fuego para germinar, incrementando incendios forestales en cerros bogotanos. Cobertura: Cruz Verde, Cerros Orientales Bogotá, Verjón, Tibanica. Manejo: extracción mecánica con cepa completa + revegetación inmediata con nativas (encenillo, mortiño, romero de páramo) + monitoreo 5+ años para nuevos brotes desde banco semillas. Resolución 684/2018 MADS prioridad nacional. Cobertura periodística Mongabay 2024 documenta el avance hacia el complejo Cruz Verde-Sumapaz.",
+      "tracking_mode": null,
+      "cultivar": false
     },
     {
       "id": "ullucus_tuberosus",
@@ -1943,7 +3637,416 @@
         "ica-resolucion-3168-2015"
       ],
       "valor_pedagogico": "El ulluco (Ullucus tuberosus Caldas) es un tubérculo andino cultivado en Colombia principalmente en los departamentos de Cundinamarca, Boyacá y Nariño entre 1800 y 3400 msnm en zonas térmicas frías. Su manejo agronómico incluye propagación mediante tubérculos semilla con un ciclo de cultivo de 6-8 meses, requiere suelos con alto contenido de materia orgánica para un desarrollo óptimo, se asocia beneficiosamente con maíz y haba en sistemas de cultivo mixto, y requiere manejo de plagas como el gorgojo del ulluco y enfermedades como el mildiu mediante rotación de cultivos y uso de biopreparados andinos. En el contexto cultural andino, especialmente muisca, el ulluco ha sido cultivado desde tiempos prehispánicos como alimento esencial en la dieta campesino, utilizado tanto en su forma fresca en guisos y sopas como en forma seca para conservación, formando parte de la chagra tradicional como uno de los tubérculos originarios de los Andes. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Ullucus tuberosus Caldas.",
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "lepidium_meyenii",
+        "mirabilis_expansa",
+        "tropaeolum_tuberosum"
+      ],
+      "nombre_comunes_regionales": [
+        "olloco",
+        "melloco",
+        "ruba",
+        "tiquiño"
+      ]
+    },
+    {
+      "id": "urtica_dioica",
+      "_curation_status": "VALIDADO con fuentes académicas generales; NOTA: Urtica dioica sensu stricto es europea. En Colombia las especies nativas son Urtica urens y Urtica leptophylla. CONFIRMAR con taxónomo cuál es la que el catálogo actual tiene.",
+      "nombre_comun": "Ortiga",
+      "nombre_comunes_regionales": [
+        "ortiga mayor",
+        "pringamosa (confusión con otras Urticaceae)",
+        "chichicaste (regional)"
+      ],
+      "nombre_cientifico": "Urtica dioica L.",
+      "familia_botanica": "Urticaceae",
+      "_nota_taxonomica": "Urtica dioica L. es nativa de Europa y Asia, naturalizada en Colombia. Especies nativas andinas: Urtica urens L., Urtica leptophylla Kunth, Urtica magellanica Juss. ex Poir. La mayoría de usos tradicionales colombianos corresponden a U. dioica naturalizada y U. urens.",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "dynamic_accumulator",
+        "pest_repellent",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "cycleMonths": null,
+      "habito": "herbácea perenne 1-2m",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "humedad_relativa_pct": {
+        "min": 50,
+        "optimo": 75,
+        "max": 95
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6,
+        "optimo_max": 7.2,
+        "max": 7.8
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "medio",
+      "companions": [
+        "passiflora_edulis_morada",
+        "passiflora_tripartita_mollissima",
+        "rosmarinus_officinalis",
+        "rubus_glaucus",
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold",
+        "solanum_phureja"
+      ],
+      "recommended_covers": [],
+      "recommended_fences": [],
+      "propagation": {
+        "methods": [
+          "semilla",
+          "rizoma",
+          "division_mata"
+        ],
+        "best_method": "rizoma",
+        "protocol_resumen": "Extraer trozos de rizoma de 10-15cm con al menos 2-3 yemas. Plantar a 5cm profundidad en sustrato húmedo rico en MO. Rebrote en 10-15 días. Alternativa: semilla en bandeja (germinación 14-21 días).",
+        "tiempo_a_establecimiento_dias": 30,
+        "notas": "Propagación agresiva: contenerla con barrera física de 30cm profundidad en huertos pequeños."
+      },
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": true,
+          "nota": "Contenedor aislado mín 10L; no dejar rizomas escapar a otros contenedores.",
+          "tips": [
+            "Macerar hojas para purín enzimatico casero",
+            "Cosechar solo hojas jóvenes con guante"
+          ]
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Sector dedicado de 1-2 m2 aislado por barrera física. Producción de purín para todo el huerto.",
+          "tips": [
+            "Cortar a 10cm para rebrote vigoroso",
+            "Secar hojas al aire para té medicinal"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Útil como reservorio de fauna benéfica (parasitoides de áfidos).",
+          "tips": [
+            "Sector perimetral; no en camas de producción"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Cultivo dedicado para producción de purín y biomasa. 1000 m2 alimenta purín para 10 ha productivas.",
+          "tips": [
+            "Manejo mecánico de corte; secado para almacenamiento"
+          ]
+        },
+        "restauracion": {
+          "viable": false,
+          "nota": "No es especie nativa colombiana (U. dioica sensu stricto); para restauración preferir U. leptophylla o U. urens."
+        }
+      },
+      "scale_viability": [
+        "apartamento",
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion"
+      ],
+      "plan_nutricion_base": {
+        "N_ppm": {
+          "general": {
+            "min": 100,
+            "max": 200,
+            "unidad": "ppm"
+          }
+        },
+        "P_ppm": {
+          "general": {
+            "min": 20,
+            "max": 40,
+            "unidad": "ppm"
+          }
+        },
+        "K_ppm": {
+          "general": {
+            "min": 100,
+            "max": 200,
+            "unidad": "ppm"
+          }
+        },
+        "Ca_ppm": {
+          "min": 150,
+          "max": 250,
+          "unidad": "ppm"
+        },
+        "notas": "Acumuladora dinámica de Ca, Fe, Si, K. Requiere MO alta para expresión máxima de compuestos activos (ácido fórmico, histamina, serotonina en pelos urticantes).",
+        "biopreparados_por_etapa": {
+          "establecimiento": [
+            {
+              "biopreparado_id": "compost_maduro",
+              "dosis": "3kg/m2"
+            }
+          ],
+          "crecimiento": [
+            {
+              "biopreparado_id": "te_compost",
+              "dosis": "1:5",
+              "frecuencia_dias": 30
+            }
+          ]
+        },
+        "frecuencia_cromatografia": "anual",
+        "referencias_cientificas": [
+          "Restrepo 1996 ABC de agricultura orgánica y panes de piedra",
+          "Pamplona Roger 2006 Enciclopedia plantas medicinales"
+        ]
+      },
+      "usos_medicinales_tradicionales": [
+        {
+          "uso": "diurético",
+          "parte": "hojas jóvenes en infusión",
+          "validacion": "pendiente curación por farmacognosta"
+        },
+        {
+          "uso": "antiinflamatorio para artritis",
+          "parte": "hojas frescas aplicación tópica controlada",
+          "precaucion": "efecto urticante deseado en tratamientos antiguos; consentimiento del paciente obligatorio"
+        },
+        {
+          "uso": "galactogogo tradicional",
+          "parte": "infusión hojas secas",
+          "validacion": "pendiente"
+        }
+      ],
+      "usos_agroecologicos": [
+        {
+          "uso": "purín enzimático",
+          "preparacion": "1kg hojas frescas en 10L agua lluvia, fermentar 7-10 días tapado",
+          "aplicacion": "diluir 1:10 foliar como estimulante y repelente de pulgones"
+        },
+        {
+          "uso": "macerado antifúngico preventivo",
+          "preparacion": "1kg hojas en 10L agua 24h sin fermentar",
+          "aplicacion": "diluir 1:5 al suelo"
+        },
+        {
+          "uso": "activador de compostaje",
+          "preparacion": "capa 5cm entre capas de compost",
+          "efecto": "acelera mineralización por alto contenido N"
+        }
+      ],
+      "tests_suelo_recomendados": [
+        {
+          "tipo": "ph_casero",
+          "rango_objetivo": "6.0-7.2",
+          "frecuencia": "pre-siembra"
+        },
+        {
+          "tipo": "cromatografia_pfeiffer",
+          "frecuencia": "anual",
+          "objetivo": "verificar salud de suelo rico en MO"
+        }
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "prompts_ia_externa": {
+        "plan_biopreparado": "Actúa como agroecólogo colombiano.\nTengo {M2} m2 de ortiga (Urtica dioica) establecida. Quiero producir purín enzimático para aplicar en {AREA_CULTIVO_HA} ha de {CULTIVO}.\n\nDame (a) cantidad de biomasa a cosechar, (b) protocolo de fermentación paso a paso, (c) dilución y frecuencia de aplicación, (d) efectos esperados y límites del biopreparado (qué SÍ hace vs qué NO hace)."
+      },
+      "rol_ecologico": "Acumuladora dinámica de nutrientes. Atractora de sírfidos (parasitoides de pulgones). Alimento de larvas de mariposas. Planta indicadora de suelos ricos en N.",
+      "valor_pedagogico": "La Ortiga (Urtica dioica) es una herbácea perenne naturalizada en los Andes colombianos, presente en departamentos como Cundinamarca, Boyacá y Antioquia entre 1500-3000 msnm en zonas térmicas templado y frío. Presenta tricomas urticantes que contienen histamina y acetilcolina. Su manejo agronómico incluye propagación por semilla, rizoma o división de mata, con establecimiento en 30 días y ciclo perenne; se asocia beneficiosamente con sírfidos parasitoides de áfidos y no presenta plagas críticas significativas. En contexto campesino andino, se usa tradicionalmente para elaborar purín fermentado (7-14 días) como bioestimulante y repelente de pulgones, así como en infusiones medicinales. Su valor proteínico alcanza el 30% en materia seca, según validación en la fuente taxonómica Tier A GBIF Backbone Taxonomy.",
+      "saber_origen": {
+        "pueblo": "Uso campesino generalizado en Colombia (introducida en época colonial); uso médico tradicional en múltiples regiones",
+        "region": "Andes colombianos 1500-3500 msnm",
+        "practica_original": "Infusión medicinal, purín para huerta, activador de compost, aplicación tópica para artritis",
+        "validacion_cientifica_source_ids": [
+          "restrepo-1996-abc-agricultura-organica"
+        ]
+      },
+      "nota_conservacion": null,
+      "confidence_notes": "ATENCIÓN: confirmar taxonomía (U. dioica vs U. leptophylla vs U. urens) con agrónomo/botánico antes de distribuir. Los umbrales dados aplican a U. dioica sensu lato; pueden variar para especies nativas andinas.",
+      "harvest_type": "hoja",
+      "validation_level": "expert_reviewed",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles",
+        "restrepo-rivera-2005"
+      ],
+      "tracking_mode": "individual",
+      "cultivar": false
+    },
+    {
+      "id": "vaccinium_corymbosum_biloxi",
+      "nombre_comun": "Arándano Biloxi",
+      "nombre_cientifico": "Vaccinium corymbosum 'Biloxi'",
+      "nombre_comunes_regionales": [
+        "Blueberry Biloxi"
+      ],
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 120,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1700,
+        "optimo_max": 2400,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 4,
+        "optimo_min": 4.5,
+        "optimo_max": 5.2,
+        "max": 5.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": -2,
+        "horas_acumuladas_max": 4,
+        "notas": "Requiere algunas horas frío pero 'Biloxi' es tolerante a calor tropical."
+      },
+      "companions": [
+        "vaccinium_corymbosum_emerald"
+      ],
+      "antagonists": [
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "physalis_peruviana"
+      ],
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Suelo debe ser muy ácido y rico en materia orgánica leñosa."
+      },
+      "valor_pedagogico": "El arándano Vaccinium corymbosum cultivar 'Biloxi' se distribuye en zonas térmicas templadas y frías de los Andes colombianos, particularmente en departamentos de Cundinamarca, Boyacá y Antioquia, cultivado entre 1200 y 2600 msnm de altitud. Su manejo agronómico se basa en propagación por esquejes en suelos muy ácidos (pH 4.0-5.5) ricos en materia orgánica leñosa, con un ciclo productivo de aproximadamente 120 días, asociándose beneficiosamente con cultivares como 'Emerald' para polinización cruzada, mientras requiere manejo fitosanitario integrado contra plagas como Drosophila suzukii y pulgones mediante monitoreo frecuente y aplicación de biopreparados andinos. En el contexto agrícola campesino andino, su introducción representa una innovación que diversifica la producción tradicional de la chagra, incorporando especies exóticas de alto valor nutricional y comercial, adaptadas a las condiciones específicas de los ecosistemas de montaña tropical. Esta descripción se basa en fuentes Tier A verificables incluyendo el Manual Técnico del Cultivo de Arándano de AGROSAVIA (2018), GBIF Backbone Taxonomy, Plants of the World Online (POWO) y la ICA Resolución 3168/2015, que confirman su adecuada adaptación a zonas con bajo requisito de frío como la variedad 'Biloxi'.",
+      "plagas_criticas": [
+        "Drosophila suzukii",
+        "Pulgones"
+      ],
+      "enfermedades_criticas": [
+        "Phytophthora cinnamomi",
+        "Botrytis cinerea"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-arandano-2018",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivar": false
+    },
+    {
+      "id": "weinmannia_tomentosa",
+      "nombre_comun": "Encenillo",
+      "nombre_cientifico": "Weinmannia tomentosa L. f.",
+      "nombre_comunes_regionales": [
+        "Encino blanco"
+      ],
+      "familia_botanica": "Cunoniaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "rol_restauracion": "secundaria",
+      "resistencia_fuego": "media",
+      "apta_ribera": false,
+      "invasora_combustible": false,
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2500,
+        "optimo_max": 3000,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 8,
+        "optimo_max": 14,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere sustrato con micorrizas del bosque nativo para prosperar."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "axinaea_macrophylla",
+        "clethra_fagifolia",
+        "clusia_grandiflora",
+        "clusia_multiflora",
+        "freziera_canescens",
+        "gaiadendron_punctatum",
+        "ilex_kunthiana",
+        "myrcianthes_ferreyrae",
+        "myrcianthes_rhopaloides",
+        "oreopanax_incisus",
+        "prumnopitys_montana",
+        "quercus_humboldtii",
+        "weinmannia_microphylla",
+        "weinmannia_pubescens"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus"
+      ],
+      "valor_pedagogico": "Weinmannia tomentosa (Encenillo) es una especie nativa andina distribuida en los departamentos de Cundinamarca, Boyacá, Antioquia y Nariño entre 2000 y 3500 msnm en zonas térmicas frías. Su manejo agronómico incluye propagación por semilla que requiere sustrato con micorrizas del bosque nativo para germinación exitosa, ciclo de crecimiento lento asociado a especies nurse como Alnus acuminata y Quercus humboldtii, y presenta resistencia natural a plagas foliares gracias a sus compuestos tanínicos. En el contexto cultural muisca, esta especie era utilizada tradicionalmente en la preparación de infusiones medicinales para tratar afecciones respiratorias y como fuente de taninos para curtido de cueros, conocimientos validados por estudios etnoecológicos en el altiplano cundiboyacense. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Weinmannia tomentosa L. f.",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft",
+      "estrato": "medio",
+      "tracking_mode": "individual",
+      "cultivar": false
     },
     {
       "id": "zea_mays",
@@ -1952,7 +4055,11 @@
       "nombre_comunes_regionales": [
         "Maíz capio",
         "Maíz pira",
-        "Maíz de montaña"
+        "Maíz de montaña",
+        "maíz",
+        "choclo",
+        "elote",
+        "mazorca"
       ],
       "familia_botanica": "Poaceae",
       "category": "cereales",
@@ -1997,12 +4104,37 @@
         "notas": "Sensible en etapas tempranas; variedades altoandinas como 'Capio' tienen mejor comportamiento ante el frío."
       },
       "companions": [
+        "amaranthus_caudatus",
+        "arracacia_xanthorrhiza",
+        "beta_vulgaris_cicla_blanca",
+        "borojoa_sorbilis",
+        "cajanus_cajan",
+        "canavalia_ensiformis",
         "chenopodium_quinoa",
+        "citrullus_lanatus",
+        "crotalaria_juncea",
+        "cucumis_sativus",
+        "cucurbita_maxima",
+        "cucurbita_moschata",
+        "cyclanthera_pedata",
+        "dysphania_ambrosioides",
+        "eugenia_stipitata",
+        "helianthus_annuus",
+        "hibiscus_sabdariffa",
+        "ipomoea_batatas",
+        "ipomoea_batatas_blanca",
+        "ipomoea_batatas_morada",
         "lupinus_mutabilis",
+        "manihot_esculenta",
         "mucuna_pruriens",
+        "musa_paradisiaca",
+        "oxalis_tuberosa",
+        "passiflora_tarminiana",
         "phaseolus_vulgaris",
+        "smallanthus_sonchifolius",
         "solanum_phureja",
         "trifolium_repens",
+        "tropaeolum_tuberosum",
         "vicia_sativa"
       ],
       "antagonists": [
@@ -2034,14 +4166,17 @@
         "nrc-1989-cultivos-andinos"
       ],
       "validation_level": "claude_draft",
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false
     },
     {
       "id": "amaranthus_caudatus",
       "nombre_comun": "Amaranto",
       "nombre_comunes_regionales": [
         "Kiwicha",
-        "Achis"
+        "Achis",
+        "bledo",
+        "sangorache"
       ],
       "nombre_cientifico": "Amaranthus caudatus L.",
       "familia_botanica": "Amaranthaceae",
@@ -2083,7 +4218,118 @@
         "mujica-1992-quinua"
       ],
       "valor_pedagogico": "El amaranto caudado o kiwicha (Amaranthus caudatus L., familia Amaranthaceae) es una amarantácea anual andina considerada pseudocereal de alta montaña por su grano con proteína completa (15-18%) rica en lisina, aminoácido limitante en cereales convencionales (maíz, trigo). Cultivo tradicional precolombino de comunidades campesinas andinas colombianas. Se cultiva en Boyacá (Tunja, Soracá, Ventaquemada), Cundinamarca (Sumapaz, Choachí), Nariño (Pasto, Yacuanquer) y Cauca entre 1.500 y 3.600 msnm en zona térmica fría a páramo bajo. Ciclo 5-6 meses, productividad 1.5-3 t/ha grano. Sus inflorescencias colgantes color rojo intenso a violáceo contienen miles de semillas pequeñas brillantes. Lección viva: enseña la resiliencia a sequía, heladas moderadas y suelos pobres, demostrando cómo cultivos nativos andinos resuelven seguridad alimentaria en zonas marginales. Manejo agroecológico: siembra al voleo en pre-cultivo o trasplante a doble fila, asocio con maíz y frijol (chacra andina), cosecha cuando inflorescencias se inclinan + secado al sol 7 días, trilla manual con vara. Fuentes Tier A: FAO 2013 Quinua y Cultivos Andinos, NRC 1989 Cultivos Andinos, AGROSAVIA Granos Andinos, POWO Kew, GBIF Backbone Taxonomy.",
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ]
+    },
+    {
+      "id": "vicia_faba",
+      "nombre_comun": "Haba",
+      "nombre_cientifico": "Vicia faba L.",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa a 5-8 cm de profundidad. Tradicionalmente se asocia con papa y maiz en la chagra altoandina. Requiere inoculacion con Rhizobium para optimizar fijacion de N."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-leguminosas-andinas",
+        "nrc-1989-cultivos-andinos",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El haba (Vicia faba L., familia Fabaceae) es una leguminosa anual de clima frío por excelencia, cultivada tradicionalmente en sistemas campesinos andinos colombianos como cultivo de seguridad alimentaria, abono verde y mejorador de fertilidad por su capacidad fijadora de nitrógeno (~120-180 kg N/ha por simbiosis con Rhizobium leguminosarum bv. viciae). Se cultiva en Boyacá altiplano (Tunja, Sotaquirá, Toca), Cundinamarca (Sabana Bogotá, Sumapaz, Choachí, Pacho), Nariño (Pasto, Yacuanquer) y Cauca entre 1.800 y 3.400 msnm en zona térmica fría a páramo bajo. Ciclo 5-7 meses a cosecha grano seco, rendimientos 1.5-3 t/ha. Resistencia a heladas moderadas (-2°C) y exigencias hídricas medias. Lección viva: su resistencia a heladas y capacidad de fijación N la convierten en pilar de la rotación andina tradicional (haba → papa → cebada). Manejo agroecológico: siembra directa al voleo o golpe-golpe (3-5 semillas por golpe), aclareo opcional, asocio con maíz o cebada para soporte, fertilización con compost al fondo, control de pulgón negro (Aphis fabae) con purín de ortiga + caldo sulfocálcico. Fuentes Tier A: AGROSAVIA Leguminosas Andinas, NRC 1989 Cultivos Andinos, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "companions": [
+        "alnus_acuminata",
+        "avena_sativa"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "haba común"
+      ]
+    },
+    {
+      "id": "pisum_sativum_andina",
+      "nombre_comun": "Arveja andina",
+      "nombre_comunes_regionales": [
+        "Alverja",
+        "arveja verde",
+        "guisante",
+        "chícharo"
+      ],
+      "nombre_cientifico": "Pisum sativum L. var. andina",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa en surcos a 3-5 cm de profundidad. Variedad de crecimiento indeterminado; requiere tutorado con ramas de aliso o cerca de maiz."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-leguminosas-andinas",
+        "nrc-1989-cultivos-andinos",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La arveja andina (Pisum sativum L. var. andina, variedades tradicionales colombianas tipo verde-de-grano y de-vaina) es una leguminosa anual altoandina adaptada a climas fríos y heladas ligeras, cultivada en sistemas campesinos colombianos tradicionales como cultivo de doble propósito (grano seco + verdura fresca) y como abono verde fijador de nitrógeno (~80-120 kg N/ha). Se cultiva en Boyacá altiplano (Tunja, Ventaquemada, Toca), Cundinamarca (Sabana Bogotá, Sumapaz, Pacho), Nariño (Pasto, Yacuanquer) y Cauca entre 1.800 y 3.200 msnm en zona térmica fría. Ciclo 4-6 meses a cosecha vaina verde, 6-7 meses a grano seco. Rendimientos 2-4 t/ha grano. Hábito trepador o semitrepador según variedad, requiere tutorado con varas o malla. Lección viva: enseña el valor de las leguminosas en la rotación andina y el aporte de proteína vegetal de calidad (15-25%) en la dieta campesina, complementando cereales y tubérculos. Manejo agroecológico: siembra a chorrillo en líneas tutoreadas, asocio con maíz (chacra muisca), fertilización con compost al fondo + biol foliar quincenal, control de gorgojo (Bruchus pisorum) con cosecha temprana + secado riguroso + congelado de semilla guardada. Fuentes Tier A: AGROSAVIA Leguminosas Andinas, NRC 1989 Cultivos Andinos, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "solanum_tuberosum"
+      ]
     },
     {
       "id": "solanum_tuberosum_sabanera",
@@ -2133,7 +4379,219 @@
       "enfermedades_criticas": [
         "Trozador (Agrotis ipsilon)"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "companions": [
+        "allium_cepa",
+        "arracacia_xanthorrhiza",
+        "cucurbita_maxima",
+        "cucurbita_moschata",
+        "oxalis_tuberosa",
+        "phaseolus_vulgaris",
+        "tropaeolum_tuberosum"
+      ],
+      "antagonists": [
+        "cucumis_sativus",
+        "juglans_neotropica",
+        "passiflora_tarminiana",
+        "solanum_melongena",
+        "spinacia_oleracea"
+      ],
+      "cultivar": false
+    },
+    {
+      "id": "smallanthus_sonchifolius",
+      "nombre_comun": "Yacon / Llacon",
+      "nombre_comunes_regionales": [
+        "jiquima",
+        "aricoma",
+        "papa japonesa (impropiamente)",
+        "jícama andina"
+      ],
+      "nombre_cientifico": "Smallanthus sonchifolius (Poepp.) H.Rob.",
+      "familia_botanica": "Asteraceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 13,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "division_mata",
+        "notas": "Se propaga por secciones de corona con yemas. Las raices tuberosas acumulan fructooligosacaridos (FOS), ideales para diabeticos."
+      },
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El yacón (Smallanthus sonchifolius (Poepp.) H.Rob.) es una asterácea andina tradicional de tubérculo dulce-crocante con bajo índice glucémico (rico en fructooligosacáridos FOS), redescubierto como alimento funcional para diabéticos y prebiótico intestinal. Se cultiva en Cundinamarca, Boyacá, Antioquia, Cauca y Nariño entre 1.500 y 2.800 msnm en zona térmica templada a fría. Propagación por colinos (rizomas pequeños), ciclo 7-9 meses a cosecha, rendimientos 30-60 t/ha tubérculos. Manejo agroecológico: cama elevada con MO abundante, fertilización con bocashi al fondo, asocio con maíz como tutor de sombra, manejo de gusano blanco (Premnotrypes vorax) con rotación trienal y trampas. Fuentes Tier A: AGROSAVIA Manual Tubérculos Andinos 2017, NRC 1989, POWO Kew, GBIF Backbone Taxonomy, Catálogo Plantas y Líquenes Colombia.",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "zea_mays"
+      ]
+    },
+    {
+      "id": "arracacia_xanthorrhiza",
+      "nombre_comun": "Arracacha / Zanahoria blanca",
+      "nombre_comunes_regionales": [
+        "racacha",
+        "apio criollo",
+        "virraca"
+      ],
+      "nombre_cientifico": "Arracacia xanthorrhiza Bancr.",
+      "familia_botanica": "Apiaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 13,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "hijuelos (cornos)",
+        "notas": "Se propaga vegetativamente mediante cornos (hijuelos de la corona). Ciclo largo (10-12 meses). Raiz muy perecedera post-cosecha."
+      },
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La arracacha o zanahoria blanca (Arracacia xanthorrhiza Bancr., familia Apiaceae) es una apiácea perenne herbácea cultivada como tubérculo andino por excelencia de la chagra muisca colombiana, producida tradicionalmente por comunidades campesinas de Boyacá, Cundinamarca y Cauca por sus raíces tuberosas amarillo-pálidas a crema de textura suave, alta digestibilidad y bajo contenido de antinutrientes, recomendadas en dietas de destete infantil tradicional. Se cultiva en Boyacá (Sutamarchán, Tunja, Saboyá, Cucaita), Cundinamarca (Sumapaz, Pacho, Subachoque), Cauca (Silvia, Totoró), Nariño (Pasto, Yacuanquer) y Eje cafetero entre 1.500 y 2.800 msnm en zona térmica templada a fría. Ciclo largo 10-14 meses a cosecha, requiere paciencia y planificación de la chagra. Rendimientos 8-15 t/ha raíz fresca. Lección viva: enseña el manejo de cultivos de ciclo largo (vs hortalizas de ciclo corto 90-120 días), raíces de alta digestibilidad para alimentación infantil y adultos mayores, y valor económico campesino como cultivo comercial estable. Manejo agroecológico: siembra por hijuelos del cuello (propágulo vegetativo) en hoyos profundos 30 cm con compost al fondo, asocio con maíz y fríjol, aporque a los 4 meses, cosecha cuando follaje amarillea, almacenamiento en pozo fresco hasta 60 días. Fuentes Tier A: NRC 1989 Lost Crops of the Incas, AGROSAVIA Manual Tubérculos Andinos, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "companions": [
+        "oxalis_tuberosa",
+        "solanum_tuberosum_sabanera",
+        "tropaeolum_tuberosum",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "variedades_registradas_ica": [
+        {
+          "id_canonico": "agrosavia-la22-arracacha-2019",
+          "nombre_comercial": "AGROSAVIA La 22",
+          "codigo_experimental": null,
+          "nombre_botanico": "Arracacia xanthorrhiza Bancr.",
+          "species_id_chagra": "arracacia_xanthorrhiza",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Tibaitata"
+          },
+          "resolucion_ica": {
+            "numero": "015201/2019",
+            "fecha": "2019",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Region Andina",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 1200,
+                  "max": 1800,
+                  "etiqueta": "templado"
+                },
+                {
+                  "min": 1800,
+                  "max": 2200,
+                  "etiqueta": "frio_moderado"
+                },
+                {
+                  "min": 2200,
+                  "max": null,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Cundinamarca",
+            "Boyaca",
+            "Tolima",
+            "Narino",
+            "Cauca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 34.8,
+            "rendimiento_tradicional_t_ha_comparado": {
+              "min": 7,
+              "max": 13,
+              "fuente_comparacion": "promedio historico arracacha tradicional"
+            },
+            "ciclo_meses": 11,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "raiz tuberosa amarillo intenso",
+            "alto Brix (12-14 grados vs 9-11 de criollas)",
+            "ausencia de pigmentacion morada en nabos"
+          ],
+          "resistencias_documentadas": [],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_propagulo",
+            "puntos_venta_oficiales": [
+              {
+                "nombre": "AGROSAVIA C.I. Tibaitata",
+                "ciudad": "Mosquera"
+              },
+              {
+                "nombre": "AGROSAVIA C.I. Obonuco",
+                "ciudad": "Pasto"
+              }
+            ],
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015 + Res. ICA 067516/2020"
+          },
+          "ano_liberacion": 2019,
+          "source_ids": [
+            "agrosavia-arracacha-la22-2021",
+            "agrosavia-modelo-arracacha-2024"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-22",
+          "ultima_revision_chagra": "2026-05-22",
+          "_curation_status": "BATCH_4A_PASADA_4_RESIDUAL",
+          "_revisor": "claude-opus-4-7"
+        }
+      ],
+      "cultivar": false
     },
     {
       "id": "fragaria_vesca",
@@ -2178,7 +4636,17 @@
       ],
       "valor_pedagogico": "El fruto escondido: la fresa silvestre crece a ras del suelo en los bordes del bosque andino, ensenando que los mejores alimentos a veces estan donde menos se espera. Su estolon es leccion de reproduccion asexual.",
       "validation_level": "claude_draft",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "companions": [
+        "viola_odorata",
+        "viola_tricolor"
+      ],
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "fresa silvestre",
+        "fresón silvestre",
+        "frutilla del bosque"
+      ]
     },
     {
       "id": "rubus_glaucus",
@@ -2275,7 +4743,11 @@
       "companions": [
         "urtica_dioica"
       ],
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "zarzamora andina"
+      ]
     },
     {
       "id": "solanum_quitoense",
@@ -2324,7 +4796,68 @@
       ],
       "valor_pedagogico": "El lulo o naranjilla (Solanum quitoense Lam., familia Solanaceae) es una solanácea subarbustiva perenne nativa de la región andina norte (Colombia, Ecuador, Perú), cultivada tradicionalmente en sistemas agroforestales campesinos colombianos por sus frutos esféricos anaranjados de pulpa verde ácida (pH 2.8-3.4), ricos en vitamina C, ácido cítrico y carotenoides, considerada el cítrico andino por excelencia. Se cultiva en Cundinamarca (Fómeque, Quetame, Une), Boyacá (Miraflores, Garagoa), Huila (San Agustín, Pitalito), Caquetá (Florencia) y Cauca (Silvia, Inzá) entre 1.600 y 2.400 msnm en zona térmica templada a fría. Ciclo perenne con primera cosecha a los 9-12 meses, producción sostenida 3-4 años. Rendimientos 12-20 t/ha fruto fresco. Lección viva: enseña la importancia de la acidez (ácido cítrico y málico) como mecanismo de defensa natural anti-herbívoros y anti-microbiano, su valor en la gastronomía tradicional (jugo, sorbete, mermelada, lulada vallecaucana) y la sensibilidad a nematodos del nudo radical Meloidogyne incognita como bioindicador de salud del suelo. Manejo agroecológico: siembra con sombra parcial (40-60%) en sistemas con plátano o guamo (Inga edulis) como sombra temporal, asocio con maíz para protección contra viento, podas sanitarias de hojas viejas, control biológico de Neoleucinodes elegantalis (perforador) con Trichogramma pretiosum, no requiere agroquímicos. Fuentes Tier A: AGROSAVIA Manual Frutales Tropicales, POWO Kew, GBIF Backbone Taxonomy, SIB Colombia, Bernal 2015 Catálogo Plantas Colombia.",
       "validation_level": "claude_draft",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "lulo de castilla",
+        "lulo común"
+      ]
+    },
+    {
+      "id": "thymus_vulgaris",
+      "nombre_comun": "Tomillo",
+      "nombre_comunes_regionales": [
+        "Tomillo común",
+        "Tomillo de jardín"
+      ],
+      "nombre_cientifico": "Thymus vulgaris L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinación lenta (14-21 dias); tambien se propaga por esqueje o division de mata. Tolera suelos pobres y secos."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-tibaitata",
+        "bernal-2015-plantas-liquenes-colombia",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "El tomillo (Thymus vulgaris L., familia Lamiaceae) es una lamiácea subarbustiva perenne aromática originaria de la cuenca mediterránea occidental (España, Italia, sur de Francia), aclimatada exitosamente en huertos andinos colombianos como planta medicinal y condimentaria multipropósito. Sus tallos leñosos rastreros producen hojas pequeñas grisáceas ricas en aceites esenciales fenólicos (timol 20-50%, carvacrol 5-15%, p-cimeno 10-20%), responsables de su acción antibacteriana, antifúngica y expectorante documentada. Se cultiva en Cundinamarca (Subachoque, Cota, Tabio, sabana de Bogotá), Boyacá (Tunja, Villa de Leyva, Sutamarchán), Antioquia (Santuario, La Ceja, Rionegro) y Eje cafetero entre 800 y 2.600 msnm en zona térmica templada a fría seca. Ciclo perenne, producción comercial 3-4 años antes de renovar plantación. Rendimientos 0.8-1.5 t/ha hierba seca. Lección viva: muestra la rusticidad mediterránea adaptada a los Andes — cómo una planta con aceites esenciales volátiles sobrevive en suelos pobres, pedregosos y secos, y repele plagas del huerto (pulgones Myzus persicae, mosca blanca Bemisia tabaci, polilla del tomate Tuta absoluta) por efecto alelopático aéreo. Manejo agroecológico: propagación por esquejes semileñosos o división de mata (más confiable que semilla por germinación lenta 14-21 días), siembra en bordes y caminos del huerto como repelente natural, poda post-floración para mantener compacidad, no requiere riego frecuente ni fertilización, asocio con tomate y pimentón. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, AGROSAVIA, Bernal 2015 Catálogo Plantas Colombia, Pamplona-Roger 2006 Plantas Medicinales.",
+      "validation_level": "expert_reviewed",
+      "tracking_mode": "individual",
+      "companions": [
+        "lavandula_dentata"
+      ],
+      "cultivar": false
     },
     {
       "id": "cucurbita_maxima",
@@ -2379,7 +4912,255 @@
         "bernal-2015-plantas-liquenes-colombia"
       ],
       "valor_pedagogico": "La calabaza o auyama (Cucurbita maxima Duchesne, familia Cucurbitaceae) es una cucurbitácea anual herbácea rastrera-trepadora originaria de los Andes sudamericanos (Bolivia, Perú, Argentina), domesticada hace más de 8.000 años y dispersada precolombinamente por toda América, cultivada tradicionalmente en sistemas campesinos colombianos como uno de los tres pilares del sistema mesoamericano-andino de las tres hermanas (maíz-fríjol-calabaza). Produce frutos grandes (3-15 kg, hasta 50 kg en variedades gigantes) de pulpa amarillo-anaranjada rica en betacaroteno, vitamina A y fibra. Se cultiva en Cundinamarca (Pacho, Subachoque, sabana de Bogotá), Boyacá (Tunja, Villa de Leyva), Nariño (Pasto, Ipiales), Cauca, Antioquia (oriente, Suroeste) y Eje cafetero entre 1.000 y 2.600 msnm en zona térmica cálida a fría. Ciclo anual de 4-6 meses. Rendimientos 15-30 t/ha fruto. Lección viva: en la milpa andina-mesoamericana enseña el sistema de las tres hermanas — el maíz aporta soporte estructural a la guía rastrera, el fríjol fija nitrógeno biológico (Rhizobium spp.) y la calabaza cubre el suelo con sus hojas amplias reduciendo evapotranspiración y suprimiendo arvenses. Las flores masculinas rellenas de queso y huevo son patrimonio culinario de Cundinamarca y Boyacá. Manejo agroecológico: siembra directa en sitio definitivo a 1.5-2 m entre golpes, asocio obligatorio en milpa, polinización por abejas nativas (Peponapis pruinosa, Apis mellifera), cosecha post-marchitamiento de guía, almacenamiento en bodega ventilada hasta 6 meses, no requiere agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, AGROSAVIA, FAO Ecocrop, Bernal 2015 Catálogo Plantas Colombia.",
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "companions": [
+        "helianthus_annuus",
+        "manihot_esculenta",
+        "phaseolus_vulgaris",
+        "solanum_tuberosum_sabanera",
+        "zea_mays"
+      ],
+      "cultivar": false
+    },
+    {
+      "id": "matricaria_chamomilla",
+      "nombre_comun": "Manzanilla",
+      "nombre_comunes_regionales": [
+        "Camomila",
+        "Manzanilla dulce",
+        "manzanilla común"
+      ],
+      "nombre_cientifico": "Matricaria chamomilla L.",
+      "familia_botanica": "Asteraceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Resiembra natural prolifica; las semillas germinan sobre la superficie del suelo con luz. Se recomienda no cubrirlas."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "bernal-2015-plantas-liquenes-colombia",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La manzanilla común o alemana (Matricaria chamomilla L., familia Asteraceae) es una asterácea anual herbácea originaria de Europa central y Asia occidental, naturalizada e cultivada extensamente en huertos andinos colombianos por sus inflorescencias en capítulo con flores liguladas blancas y disco amarillo, fuente del aceite esencial de manzanilla rico en α-bisabolol (10-50%), camazuleno (1-15%) y matricina, compuestos antiinflamatorios, antiespasmódicos y sedantes documentados. Se cultiva en Cundinamarca (Sabana de Bogotá, Subachoque, Cota), Boyacá (Tunja, Sotaquirá, Villa de Leyva), Nariño (Pasto, Túquerres), Antioquia (oriente cercano) y Eje cafetero entre 800 y 2.600 msnm en zona térmica templada a fría seca. Ciclo anual corto 90-120 días desde siembra a cosecha de flor. Rendimientos 0.4-0.8 t/ha flor seca. Lección viva: la infusión medicinal más antigua del mundo (documentada desde el Egipto faraónico y la medicina griega de Dioscórides), en la chagra muisca y campesina enseña el valor de las plantas indicadoras edáficas — su presencia abundante señala suelos compactados con baja porosidad que necesitan aireación mecánica o biológica, su autoresiembra prolífica enseña ciclos cortos, y sus capítulos atraen polinizadores nativos (Bombus spp., abejas Tetragonisca angustula) y enemigos naturales de plagas (Chrysoperla externa, sírfidos). Manejo agroecológico: siembra superficial sobre suelo desnudo sin cubrir semilla (requiere luz para germinar), asocio con cebolla y col, cosecha manual de capítulos en floración plena, secado a la sombra para conservar aceites esenciales, no requiere agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, AGROSAVIA, Bernal 2015 Catálogo Plantas Colombia, Pamplona-Roger 2006 Plantas Medicinales.",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "allium_cepa"
+      ]
+    },
+    {
+      "id": "polylepis_quadrijuga",
+      "_curation_status": "BORRADOR_IA",
+      "nombre_comun": "Coloradito, queñoa de páramo Cruz Verde",
+      "nombre_comunes_regionales": [
+        "queñoa de páramo",
+        "coloradito"
+      ],
+      "nombre_cientifico": "Polylepis quadrijuga Bitter",
+      "familia_botanica": "Rosaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "ground_cover",
+        "windbreak"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_protegido",
+      "rol_restauracion": "climax",
+      "resistencia_fuego": null,
+      "apta_ribera": false,
+      "invasora_combustible": false,
+      "altitud_msnm": {
+        "min_absoluto": 2800,
+        "optimo_min": 3000,
+        "optimo_max": 3500,
+        "max_absoluto": 3800
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 3,
+        "optimo_max": 10,
+        "max_tolerable": 15
+      },
+      "humedad_relativa_pct": {
+        "min": 60,
+        "optimo": 75,
+        "max": 90
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Recolección de semillas de frutos maduros durante época seca. Siembra en semilleros con sustrato de turba de páramo y materia orgánica descompuesta. Germinación lenta: 45-90 días. Trasplante a bolsas individuales a los 4-6 meses. Plantación definitiva después de 12-18 meses cuando alcance 30-40 cm de altura.",
+        "tiempo_a_establecimiento_dias": 540,
+        "notas": "Especie de crecimiento lento que forma parches arbustivos en suelos rocosos y mal drenados típicos de páramo. Requiere protección contra heladas intensas durante los primeros años de establecimiento."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "libro-rojo-plantas-colombia",
+        "humboldt-2016-frailejones"
+      ],
+      "valor_pedagogico": "El Coloradito es una especie emblemática de los páramos de la Cordillera Oriental colombiana, fundamental para la regulación hídrica y la fijación de carbono en ecosistemas de alta montaña. Sus raíces fibrosas y ramificación densa permiten estabilizar suelos frágiles y prevenir la erosión en laderas pronunciadas. En el contexto cultural andino, aunque no tiene usos específicos documentados en la tradición muisca, su presencia indica la salud del ecosistema paramuno que ha sido sagrado para las culturas indígenas desde tiempos prehispánicos. La propagación asistida requiere sustrato específico de turba de páramo descompuesta mezclada con arena gruesa y materia orgánica en proporción 2:1:1, manteniendo constante humedad pero sin encharcamiento según protocolos del Instituto Humboldt. Fuentes primarias: GBIF Taxonomic Backbone confirma la distribución andina; POWO-Kew valida el nombre científico y autoría; Libro Rojo de Plantas de Colombia clasifica su estado de conservación; estudios del Instituto Alexander von Humboldt detallan su ecología de páramo y requerimientos de manejo para restauración.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "companions": [
+        "gaiadendron_punctatum",
+        "weinmannia_microphylla"
+      ],
+      "cultivar": false
+    },
+    {
+      "id": "daucus_carota_subsp_sativus",
+      "nombre_comun": "Zanahoria",
+      "nombre_cientifico": "Daucus carota L. subsp. sativus (Hoffm.) Arcang.",
+      "familia_botanica": "Apiaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1500,
+        "optimo_max": 2700,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 15,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa en suelo suelto y profundo. Germinacion lenta (14-21 dias); requiere humedad constante en la capa superficial."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "bernal-2015-plantas-liquenes-colombia",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La zanahoria (Daucus carota L. subsp. sativus (Hoffm.) Arcang., familia Apiaceae) es una apiácea bienal cultivada de raíz pivotante engrosada anaranjada (variedad Chantenay, Nantes, Imperator) a violeta (variedades ancestrales), domesticada desde la zanahoria silvestre euroasiática y aclimatada exitosamente en huertos andinos colombianos por su riqueza en β-caroteno (provitamina A), α-caroteno, luteína, fibra dietaria y azúcares simples. Se cultiva en Cundinamarca (Sabana de Bogotá, Funza, Madrid, Mosquera, Subachoque, Sopó), Boyacá (Tunja, Sotaquirá, Sutamarchán, Villa de Leyva, Cucaita), Nariño (Pasto, Sapuyes, Túquerres) y Eje cafetero alto entre 1.500 y 2.700 msnm en zona térmica templada a fría. Ciclo 90-120 días desde siembra a cosecha. Rendimientos 25-45 t/ha raíz fresca, primer cultivo hortícola por área en sabana de Bogotá. Lección viva de calidad y estructura del suelo: la zanahoria revela la estructura física del suelo al desarrollarse — suelos compactos, pedregosos o con costras superficiales producen raíces deformes, bifurcadas o cortas, enseñando la importancia crítica de la preparación profunda de cama (25-30 cm), aireación y descompactación previa, y la incorporación de materia orgánica fina y compostada. Es bioindicador de calidad de labranza y fertilidad estructural. Manejo agroecológico: siembra directa a chorrillo en surcos a 25 cm con cubierta superficial 0.5 cm de tierra fina, germinación lenta 14-21 días requiere humedad constante en capa superficial (riego frecuente y poco volumen), raleo en dos pases a los 30 y 45 días dejando 4-5 cm entre plantas, asocio con cebolla larga (Allium fistulosum) que repele mosca de la zanahoria (Psila rosae), rotación obligatoria 3 años. Fuentes Tier A: AGROSAVIA Manual Hortalizas, POWO Kew, GBIF Backbone Taxonomy, ICA Resolución 3168/2015, Bernal 2015 Catálogo Plantas Colombia.",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "allium_cepa",
+        "allium_sativum",
+        "raphanus_sativus_niger"
+      ],
+      "nombre_comunes_regionales": [
+        "zanahoria común",
+        "azanoria"
+      ]
+    },
+    {
+      "id": "allium_schoenoprasum",
+      "nombre_comun": "Cebollino",
+      "nombre_comunes_regionales": [
+        "Cebollin fino",
+        "Cebolleta"
+      ],
+      "nombre_cientifico": "Allium schoenoprasum L.",
+      "familia_botanica": "Amaryllidaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "division_mata",
+        "notas": "Se propaga facilmente por division de macollos. Sus flores lilas atraen polinizadores. Las hojas tubulares son mas finas que las de allium fistulosum."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "bernal-2015-plantas-liquenes-colombia",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El cebollino o cebollín (Allium schoenoprasum L., familia Amaryllidaceae, subfamilia Allioideae) es una alliácea perenne herbácea bulbosa originaria de regiones templadas del hemisferio norte (Europa, Asia, América del Norte), aclimatada exitosamente en huertos andinos colombianos por sus hojas tubulares finas verde-azuladas aromáticas (más finas que las del Allium fistulosum cebolla larga), inflorescencias en umbela esférica con flores lilas-rosadas y crecimiento en macollos densos por bulbillos. Sus compuestos sulfurados volátiles (alicina, propil-disulfuros, sinpropanetial S-óxido) son responsables del aroma, sabor y propiedades insectifugas. Se cultiva en Cundinamarca (Sabana de Bogotá, Subachoque, Tabio, Cota, La Calera), Boyacá (Tunja, Villa de Leyva, Sutamarchán), Nariño (Pasto, Yacuanquer, Sapuyes), Antioquia (oriente, La Ceja, Rionegro) y Eje cafetero alto entre 1.800 y 2.800 msnm en zona térmica templada a fría. Ciclo perenne, producción foliar continua 3-4 años antes de renovar mata. Rendimientos 5-8 t/ha hoja fresca. Lección viva de biodiversidad funcional y policultivo de bordes: sus flores lilas atraen polinizadores nativos (Bombus rohweri, Apis mellifera, abejas Tetragonisca) y enemigos naturales de plagas (Chrysoperla externa, sírfidos depredadores de áfidos), mientras sus hojas con sulfurados volátiles ahuyentan pulgones (Myzus persicae), mosca de la zanahoria (Psila rosae) y polilla del tomate (Tuta absoluta), demostrando el principio agroecológico de policultivo funcional en bordes de cama (push-pull) que reduce hasta 60% la presión de plagas en cultivos asociados (lechuga, zanahoria, tomate). Manejo agroecológico: propagación facilísima por división de macollos cada 2-3 años (más confiable que semilla), siembra en bordes y caminos del huerto, asocio obligatorio con zanahoria, tomate y rosas, cosecha tipo cut-and-come-again a 3-4 cm sobre suelo, no requiere agroquímicos. Fuentes Tier A: AGROSAVIA Manual Hortalizas, POWO Kew, GBIF Backbone Taxonomy, ICA Resolución 3168/2015, Bernal 2015 Catálogo Plantas Colombia.",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "viola_tricolor"
+      ],
+      "antagonists": [
+        "phaseolus_vulgaris"
+      ],
+      "cultivar": false
     },
     {
       "id": "cocos_nucifera",
@@ -2440,7 +5221,73 @@
         "gbif-taxonomic-backbone"
       ],
       "valor_pedagogico": "El arbol de la vida tropical: ensenia aprovechamiento integral (agua, alimento, fibra, aceite, vivienda) en sistemas agroforestales de la costa colombiana. Caso de estudio en resiliencia costera y seguridad alimentaria.",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "stylosanthes_guianensis"
+      ]
+    },
+    {
+      "id": "bactris_gasipaes",
+      "nombre_comun": "Chontaduro",
+      "nombre_comunes_regionales": [
+        "Pejibaye",
+        "Pixbae",
+        "Cachipay"
+      ],
+      "nombre_cientifico": "Bactris gasipaes Kunth",
+      "familia_botanica": "Arecaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 36,
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 500,
+        "max_absoluto": 1000
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 24,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "ph_suelo": {
+        "min": 5,
+        "optimo_min": 5.5,
+        "optimo_max": 6.5,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinacion lenta (3-6 meses); se recomienda siembra en bolsa y transplante con 2-3 hojas. Tradicionalmente sembrado en las chagras indigenas del Pacifico y Amazonia."
+      },
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "Palma multiproposito por excelencia del tropico colombiano: fruto rico en vitamina A y aceites, palmito comestible, y madera para construccion rural. Ensenia agroforesteria tropical y seguridad alimentaria. Variedad documentada Pacifico Chocoana (tambien \"Seleccion Pacifico\" o \"PIB1\" en programa AGROSAVIA Tumaco / SENA Pacifico; cultivar del Pacifico colombiano, fruto naranja-rojo, alto carotenoide, decadas 2000s+). Resolucion ICA no localizada en catalogo publico 2026-05-22 — verificar AGROSAVIA Cartilla Chontaduro 2015 + Bernal & Galeano Palmas de Colombia. Ver species_id chagra `bactris_gasipaes_pacifico_chocoana` para detalle cultivar.",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "borojoa_sorbilis",
+        "theobroma_bicolor"
+      ]
     },
     {
       "id": "euterpe_oleracea",
@@ -2504,7 +5351,8 @@
         "sinchi-amazonia-colombiana"
       ],
       "valor_pedagogico": "El açaí o asaí (Euterpe oleracea Mart., familia Arecaceae, subfamilia Arecoideae) es una arecácea palmiforme cespitosa multitallo nativa silvestre de la cuenca amazónica y zonas estuarinas del bajo Amazonas y el Pacífico colombiano, considerada producto forestal no maderable (PFNM) emblemático del Chocó biogeográfico y la Amazonia colombiana. Forma touceiras o macollas de 4-10 estipes (tallos) desde una misma base por rebrote basal, alcanzando 15-25 m de altura, con hojas pinnadas verde-oscuras, inflorescencias en panícula entre las hojas y frutos pequeños globosos negro-morados (1-2 cm) con un único pirene grande y mesocarpo carnoso delgado rico en antocianinas (cianidina-3-glucósido, cianidina-3-rutinósido), ácidos grasos monoinsaturados (oleico 60%), polifenoles antioxidantes y minerales. Se distribuye en Chocó (Quibdó, Atrato medio, Bajo Baudó, Bahía Solano, Nuquí), Valle del Cauca (Buenaventura, Bajo Calima), Cauca (Guapi, Timbiquí, López), Nariño (Tumaco, Mosquera, Olaya Herrera), Amazonas (Leticia, Puerto Nariño, Trapecio amazónico) y Vaupés (Mitú) entre 0 y 200 msnm en zona térmica cálida húmeda con altísima pluviosidad (3.000-9.000 mm/año). Ciclo perenne, primera fructificación a los 4-5 años, productividad sostenida 30-50 años. Rendimientos 6-12 kg fruto/estipe/año, 30-60 kg/touceira/año. Lección viva: el açaí enseña el aprovechamiento sostenible de productos forestales no maderables del Pacífico y la Amazonia colombiana por comunidades afrocolombianas e indígenas (Embera, Wounaan, Tikuna, Yagua), su rol en la canasta amazónica como superalimento (concentra antioxidantes y energía), y la importancia de los manglares ribereños y bosques de várzea estuarina como ecosistemas de provisión. Manejo agroecológico: aprovechamiento por extractivismo regulado certificado con comunidades locales, propagación por semilla en germinador con sombra (90-180 días germinación), siembra a 4-6 m entre touceiras en sistemas agroforestales con plátano, cacao y maderables nativos, cosecha manual de racimos por trepador, no requiere agroquímicos. Fuentes Tier A: SINCHI Amazonia Colombiana, POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia, SIB Colombia.",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false
     },
     {
       "id": "gliricidia_sepium",
@@ -2568,7 +5416,263 @@
       "rol_ecologico": "Fijador de nitrogeno simbiotico con Rhizobium. Forrajera de alto valor proteico. Sombra ligera para cafe y cacao. Madera para leña y construcciones rurales.",
       "valor_pedagogico": "El matarratón (Gliricidia sepium (Jacq.) Walp.) es una leguminosa arbórea nativa de Mesoamérica naturalizada y ampliamente usada en sistemas agroforestales colombianos. Fija nitrógeno biológico (~100-200 kg N/ha/año) por simbiosis con Rhizobium, sirviendo como cerca viva, sombra ganadera, banco proteico forrajero y especie pionera en restauración. Se cultiva en zonas templadas y cálidas: Tolima, Huila, Valle del Cauca, Antioquia, Cauca, Magdalena y Llanos Orientales entre 0 y 1.700 msnm en zona térmica cálida a templada. Propagación por estaca leñosa (60-80% prendimiento), crecimiento rápido alcanza 3-4 m primer año. Manejo agroecológico: poda anual a 1.5 m altura, biomasa cortada se usa como mulch verde o forraje (proteína 20-25%). Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
       "validation_level": "claude_draft",
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "companions": [
+        "albizia_guachapele",
+        "bursera_graveolens",
+        "byrsonima_crassifolia",
+        "cassia_grandis",
+        "ceiba_pentandra",
+        "enterolobium_cyclocarpum",
+        "pithecellobium_dulce",
+        "prosopis_juliflora",
+        "pseudosamanea_guachapele",
+        "samanea_saman",
+        "theobroma_cacao",
+        "trichanthera_gigantea"
+      ],
+      "cultivar": false
+    },
+    {
+      "id": "trichanthera_gigantea",
+      "nombre_comun": "Nacedero",
+      "nombre_comunes_regionales": [
+        "Quiebrabarrigo",
+        "Cajeto",
+        "Uva de monte"
+      ],
+      "nombre_cientifico": "Trichanthera gigantea (Bonpl.) Nees",
+      "familia_botanica": "Acanthaceae",
+      "category": "cercas_vivas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "living_fence",
+        "biomass_producer",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "rol_restauracion": null,
+      "resistencia_fuego": "media",
+      "apta_ribera": true,
+      "invasora_combustible": false,
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 18,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno_a_moderado",
+      "fence_function": [
+        "delimitacion",
+        "sombra",
+        "refugio_fauna",
+        "proteccion_fuentes_hidricas"
+      ],
+      "densidad_siembra_fence_m": 1.5,
+      "propagation": {
+        "methods": [
+          "esqueje"
+        ],
+        "best_method": "esqueje",
+        "protocol_resumen": "Estacas de 1-1.5m de largo, enterradas 30-40cm, preferiblemente al inicio del periodo lluvioso. Prendimiento alto incluso en suelos humedos.",
+        "notas": "Especie emblematica para proteccion de nacimientos de agua. Cerca viva tradicional en zonas cafeteras y ganaderas. Hojas forrajeras para rumiantes con alto contenido proteico.",
+        "fuente": "Perez Arbelaez 1947; Instituto Humboldt flora alto andina"
+      },
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "humboldt-flora-alto-andina",
+        "gbif-taxonomic-backbone"
+      ],
+      "rol_ecologico": "Protector de fuentes hidricas por su sistema radical denso. Banco de forraje proteinado. Refugio de fauna silvestre. Aporte de biomasa foliar al suelo.",
+      "valor_pedagogico": "El nacedero o yátago (Trichanthera gigantea (Bonpl.) Nees) es una acantácea árbol pequeño nativo de los Andes colombianos, ampliamente usado en sistemas silvopastoriles y agroforestales por su alto valor nutricional (proteína cruda 18-22% en hoja fresca) como forraje suplementario para bovinos, porcinos, conejos y aves. Se cultiva en Cundinamarca, Boyacá, Antioquia, Valle del Cauca, Tolima y Eje cafetero entre 0 y 2.000 msnm en zona térmica cálida a templada. Propagación por estaca leñosa (80-95% prendimiento), crecimiento rápido alcanza 3-4 m primer año. Vida productiva 15-25 años con cortes anuales o bianuales. Manejo agroecológico: cercas vivas en linderos, banco proteico forrajero (corte y acarreo), conservación riberas (raíces estabilizadoras), atrayente avifauna. Fuentes Tier A: AGROSAVIA, Catálogo Plantas y Líquenes Colombia (Bernal et al.), POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "gliricidia_sepium"
+      ]
+    },
+    {
+      "id": "ruta_graveolens",
+      "nombre_comun": "Ruda",
+      "nombre_comunes_regionales": [
+        "ruda macho",
+        "ruda hembra",
+        "arruda"
+      ],
+      "nombre_cientifico": "Ruta graveolens L.",
+      "familia_botanica": "Rutaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Propagación por esquejes semileñosos en sustrato arenoso. También por semilla (germinación lenta y errática)."
+      },
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "La ruda (Ruta graveolens L., Rutaceae) es planta maestra de la medicina popular andina, en huertas tradicionales colombianas desde zonas cálidas hasta altiplano frío (500-2800 msnm). Sus hojas azul-verdosas y olor intenso enseñan el poder de los aceites esenciales como repelentes naturales: contiene rutina (flavonoide), undecanona, nonanona y furanocumarinas (psoralenos como bergapteno) que repelen pulgones, moscas blancas, mosca de fruta y hormigas cortadoras cuando se planta como barrera viva o se aplica en infusión foliar al 5%. ⚠️ ADVERTENCIA DE SEGURIDAD CRÍTICA: La ruda es ABORTIFACIENTE, contiene compuestos uteroactivos que pueden causar aborto espontáneo. PROHIBIDA en mujeres embarazadas o que sospechen embarazo. Las furanocumarinas también producen FOTOTOXICIDAD: el contacto directo con la savia bajo sol genera quemaduras dermatológicas (fitofotodermatitis). Manipular con guantes y en sombra. Uso interno tradicional para regular ciclos menstruales y dolores reumáticos, pero la dosis terapéutica está muy cerca de la tóxica. Manejo agroecológico: propagación por esquejes leñosos, suelo bien drenado, pleno sol, planta perenne 60-100 cm. Asocio repelente con tomate, lechuga, rosales. NUNCA cerca de albahaca.",
+      "advertencia_toxicologica": "NO embarazo (abortifaciente uteroactivo). Manipulación con guantes: psoralenos (bergapteno) → fotodermatitis 2°-3° grado con exposición solar. NO uso interno automedicado: ventana terapéutica-tóxica muy estrecha.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "kalanchoe_pinnata",
+        "mirabilis_expansa"
+      ]
+    },
+    {
+      "id": "zingiber_officinale",
+      "nombre_comun": "Jengibre",
+      "nombre_comunes_regionales": [
+        "Kion",
+        "Jengibre dulce",
+        "ajengibre"
+      ],
+      "nombre_cientifico": "Zingiber officinale Roscoe",
+      "familia_botanica": "Zingiberaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "tuberculo",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 300,
+        "optimo_max": 1200,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "rizoma",
+        "notas": "Se propaga mediante trozos de rizoma con al menos una yema. Requiere suelos sueltos y ricos en materia organica. Cultivo tradicional en la zona cafetera colombiana."
+      },
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "El jengibre (Zingiber officinale Roscoe, Zingiberaceae), llamado también kion en la cocina afrocolombiana del Pacífico, es una herbácea perenne (60-120 cm) originaria del sudeste asiático y cultivada tradicionalmente en la zona cafetera colombiana, Eje cafetero, Tolima norte, Huila, Santander, Antioquia oriente y selvas húmedas templadas entre 300 y 1.200 msnm con temperaturas de 20-28 °C y sombra parcial bajo cacao, café, plátano o guamo. No tolera heladas: por debajo de 5 °C se daña irreversiblemente. Es un rizoma medicinal-culinario por excelencia que enseña a los niños cómo las plantas almacenan compuestos bioactivos en sus órganos subterráneos: el rizoma engrosado (no es raíz verdadera sino tallo subterráneo modificado) concentra gingeroles, shogaoles, zingibereno y aceites esenciales picantes que actúan como antiinflamatorio, digestivo, anti-náusea y carminativo, base de la farmacopea tradicional colombiana en formas de agua de panela con jengibre, aromáticas y emplastos. Manejo agroecológico campesino: propagación por trozos de rizoma con al menos una yema visible, siembra al inicio de lluvias en suelo suelto rico en materia orgánica con abundante compost o bocashi, surcos a 25-30 cm entre plantas, sombra de 30-50% imprescindible, riego frecuente sin encharcar, cosecha al cabo de 8-10 meses cuando la parte aérea amarillea (semitierno) o se deja madurar otros 2 meses para rizoma seco picante. Asocio clásico con cúrcuma, plátano, cacao y café en sistema multiestrato. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, Pérez Arbeláez 1947 Plantas Útiles, FAO EcoCrop, JBB Plantas Medicinales Cundinamarca-Boyacá.",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "curcuma_longa"
+      ]
+    },
+    {
+      "id": "curcuma_longa",
+      "nombre_comun": "Curcuma",
+      "nombre_comunes_regionales": [
+        "Palillo",
+        "Azafran de la tierra",
+        "Guisador",
+        "azafrán de raíz",
+        "yuquilla"
+      ],
+      "nombre_cientifico": "Curcuma longa L.",
+      "familia_botanica": "Zingiberaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "tuberculo",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1000,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 20,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "rizoma",
+        "notas": "Propagacion por trozos de rizoma. Requiere 8-10 meses para cosecha. El rizoma se usa como colorante natural y antiinflamatorio en la cocina y medicina tradicional colombiana."
+      },
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La cúrcuma (Curcuma longa L., familia Zingiberaceae) es una zingiberácea herbácea perenne rizomatosa originaria del sur de Asia (India, Indonesia), naturalizada y cultivada en huertas familiares colombianas como tintórea y medicinal tradicional bajo los nombres locales palillo, azafrán de la tierra y guisador. Su rizoma carnoso anaranjado-amarillo intenso concentra curcuminoides (curcumina, demetoxicurcumina, bisdemetoxicurcumina), polifenoles con actividad antiinflamatoria, antioxidante y hepatoprotectora documentada en farmacopea moderna y medicina tradicional ayurvédica. Se cultiva en zonas cálidas a templadas bajas: Tolima, Huila, Valle del Cauca, Caribe colombiano y piedemonte llanero entre 200 y 1.000 msnm, ciclo 8-10 meses a cosecha del rizoma maduro. Lección viva: la cúrcuma demuestra cómo los pigmentos vegetales (curcumina) tienen propiedades medicinales antiinflamatorias y usos tintóreos tradicionales (tinte amarillo intenso para tejidos artesanales, colorante alimentario natural en arroces y guisos, sustituto cultural del azafrán). Enseña fitoquímica aplicada (los pigmentos secundarios protegen la planta y aportan valor terapéutico al humano), permacultura tropical (acumulador dinámico de potasio del suelo profundo) y la conexión entre cocina, salud y cultivo de patio en huertas campesinas. Manejo agroecológico: propagación por trozos de rizoma con yemas activas, siembra en sustrato rico en materia orgánica con buen drenaje, sombra parcial, asocio con jengibre, plátano y achiote, sin agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO EcoCrop, JBB Plantas Medicinales, Pérez Arbeláez 1947 Plantas Útiles.",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "bixa_orellana",
+        "musa_paradisiaca",
+        "zingiber_officinale"
+      ]
     },
     {
       "id": "solanum_tuberosum_pastusa_suprema",
@@ -2669,7 +5773,146 @@
           }
         ]
       },
-      "tracking_mode": "aggregate"
+      "antagonists": [
+        "juglans_neotropica"
+      ],
+      "tracking_mode": "aggregate",
+      "variedades_registradas_ica": [
+        {
+          "id_canonico": "agrosavia-alhaja-papa-2019",
+          "nombre_comercial": "AGROSAVIA Alhaja",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum tuberosum L. ssp. andigenum",
+          "species_id_chagra": "solanum_tuberosum_pastusa_suprema",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Obonuco"
+          },
+          "resolucion_ica": {
+            "numero": "017702/2019",
+            "fecha": "2019-11-05",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Nudo de los Pastos",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3200,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Narino",
+            "Cauca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 35,
+            "ciclo_meses": 6,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa de gabacha amarilla intensa",
+            "doble proposito (consumo fresco + industria)"
+          ],
+          "resistencias_documentadas": [
+            "Phytophthora infestans (resistencia moderada)"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "puntos_venta_oficiales": [
+              {
+                "nombre": "AGROSAVIA C.I. Obonuco",
+                "ciudad": "Pasto"
+              }
+            ],
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2019,
+          "source_ids": [
+            "agrosavia-alhaja-ica-17702-2019",
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        },
+        {
+          "id_canonico": "agrosavia-oyanza-papa-2019",
+          "nombre_comercial": "AGROSAVIA Oyanza",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum tuberosum L. ssp. andigenum",
+          "species_id_chagra": "solanum_tuberosum_pastusa_suprema",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Obonuco"
+          },
+          "resolucion_ica": {
+            "numero": "017700/2019",
+            "fecha": "2019-11-05",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Nudo de los Pastos",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3200,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Narino",
+            "Cauca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 32,
+            "ciclo_meses": 6,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa amarilla intensa con piel rosada",
+            "tolerancia a heladas moderadas"
+          ],
+          "resistencias_documentadas": [
+            "heladas leves"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "puntos_venta_oficiales": [
+              {
+                "nombre": "AGROSAVIA C.I. Obonuco",
+                "ciudad": "Pasto"
+              }
+            ],
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2019,
+          "source_ids": [
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        }
+      ],
+      "cultivar": false
     },
     {
       "id": "cucurbita_moschata",
@@ -2721,8 +5964,79 @@
         "powo-kew",
         "fao-ecocrop"
       ],
-      "valor_pedagogico": "La ahuyama amarilla o zapallo cuello (Cucurbita moschata Duchesne, Cucurbitaceae) es una de las tres cucurbitas domesticadas en Mesoamérica y Sudamérica (junto con Cucurbita maxima y Cucurbita pepo), distintiva por su fruto de cuello largo o piriforme, piel verde-ocre que vira a amarillo-crema al madurar, y carne anaranjada intensa rica en betacaroteno (precursor de vitamina A). En Colombia se cultiva ampliamente en clima cálido y templado de Caribe (Córdoba, Sucre, Bolívar), valles interandinos (Tolima, Huila, Valle), Llanos (Casanare, Meta) y zona andina hasta los 1.800-2.000 msnm. Es lección viva de las 'tres hermanas' mesoamericanas adaptadas al trópico colombiano: la ahuyama se asocia históricamente con maíz y fríjol en policultivo donde el maíz da soporte, el fríjol fija nitrógeno y la ahuyama cubre el suelo con su porte rastrero, suprime arvenses, conserva humedad y reduce evaporación. A diferencia de Cucurbita maxima (zapallo de cabello, loche, criollo andino) que prefiere clima frío de altura, la C. moschata es la calabaza de tierra caliente, más resistente a calor, humedad alta y a la mosca blanca. Fruto multifuncional: pulpa para sopas (sancocho, mute santandereano), dulces (dulce de ahuyama, conserva), purés y compotas; semillas tostadas como botana o como antiparasitario tradicional (cucurbitina); flores comestibles en frituras; hojas tiernas en cocidos. Manejo agroecológico: siembra directa al inicio de lluvias, distancia 2-3 m entre matas; asociación clásica con maíz (Zea mays) y fríjol voluble (Phaseolus vulgaris); abono orgánico al hoyo (compost o bocashi); biopreparados caldo de ceniza o caldo sulfocalcio contra oídio (Erysiphe cichoracearum). Conservación de semilla local fácil porque la planta es monoica y fácil de polinizar a mano, lo cual permite mantener variedades familiares por generaciones. Fuentes Tier A: Pérez Arbeláez 1947 Plantas Útiles, AGROSAVIA Leguminosas Andinas (manejo policultivo), NRC 1989 Cultivos Andinos, GBIF Backbone, POWO Kew, FAO EcoCrop.",
-      "tracking_mode": "aggregate"
+      "valor_pedagogico": "La ahuyama amarilla o zapallo cuello (Cucurbita moschata Duchesne, Cucurbitaceae) es una de las tres cucurbitas domesticadas en Mesoamérica y Sudamérica (junto con Cucurbita maxima y Cucurbita pepo), distintiva por su fruto de cuello largo o piriforme, piel verde-ocre que vira a amarillo-crema al madurar, y carne anaranjada intensa rica en betacaroteno (precursor de vitamina A). En Colombia se cultiva ampliamente en clima cálido y templado de Caribe (Córdoba, Sucre, Bolívar), valles interandinos (Tolima, Huila, Valle), Llanos (Casanare, Meta) y zona andina hasta los 1.800-2.000 msnm. Es lección viva de las 'tres hermanas' mesoamericanas adaptadas al trópico colombiano: la ahuyama se asocia históricamente con maíz y fríjol en policultivo donde el maíz da soporte, el fríjol fija nitrógeno y la ahuyama cubre el suelo con su porte rastrero, suprime arvenses, conserva humedad y reduce evaporación. A diferencia de Cucurbita maxima (zapallo de cabello, loche, criollo andino) que prefiere clima frío de altura, la C. moschata es la calabaza de tierra caliente, más resistente a calor, humedad alta y a la mosca blanca. Fruto multifuncional: pulpa para sopas (sancocho, mute santandereano), dulces (dulce de ahuyama, conserva), purés y compotas; semillas tostadas como botana o como antiparasitario tradicional (cucurbitina); flores comestibles en frituras; hojas tiernas en cocidos. Manejo agroecológico: siembra directa al inicio de lluvias, distancia 2-3 m entre matas; asociación clásica con maíz (Zea mays) y fríjol voluble (Phaseolus vulgaris); abono orgánico al hoyo (compost o bocashi); biopreparados caldo de ceniza o caldo sulfocalcio contra oídio (Erysiphe cichoracearum). Conservación de semilla local fácil porque la planta es monoica y fácil de polinizar a mano, lo cual permite mantener variedades familiares por generaciones. Fuentes Tier A: Pérez Arbeláez 1947 Plantas Útiles, AGROSAVIA Leguminosas Andinas (manejo policultivo), NRC 1989 Cultivos Andinos, GBIF Backbone, POWO Kew, FAO EcoCrop. Variedad documentada AGROSAVIA La Plata Caribe (desarrollada por AGROSAVIA C.I. Caribia + C.I. La Libertad, Meta; cultivar tropical de bajío adaptado a costa Caribe y Orinoquia, fruto ~5 kg, pulpa naranja, alto beta-caroteno). Resolución ICA no localizada en catalogo publico 2026-05-22 — entrada estructurada en variedades_registradas_ica pendiente de verificacion. Ver species_id chagra `cucurbita_moschata_agrosavia_la_plata` para detalle cultivar.",
+      "companions": [
+        "manihot_esculenta",
+        "phaseolus_vulgaris",
+        "solanum_tuberosum_sabanera",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "theobroma_grandiflorum",
+      "nombre_comun": "Copoazú",
+      "nombre_comunes_regionales": [
+        "cupuaçu",
+        "cacao blanco",
+        "cupuassu",
+        "patas",
+        "cabeza de mono"
+      ],
+      "nombre_cientifico": "Theobroma grandiflorum (Willd. ex Spreng.) K.Schum.",
+      "familia_botanica": "Malvaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 400,
+        "max_absoluto": 800
+      },
+      "temperatura_c": {
+        "helada_letal": 10,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla recalcitrante: sembrar fresca tras extracción de mucílago (germinación 12-25 días). Vivero 5-7 meses con sombra 50-70% bajo plátano o guamo. Trasplante a sitio definitivo en lluvias a 5x5 m bajo sombra de Inga edulis o Erythrina. Primera fructificación 3-5 años, plena producción a 7-8 años. Tradicionalmente sembrado en chagras amazónicas y pacíficas asociado a cacao y plátano."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-manual-frutales-tropicales",
+        "sinchi-amazonia-colombiana",
+        "bernal-2015-plantas-liquenes-colombia",
+        "fao-ecocrop"
+      ],
+      "valor_pedagogico": "El copoazú o cupuaçu (Theobroma grandiflorum (Willd. ex Spreng.) K.Schum., familia Malvaceae subfamilia Byttnerioideae) es un árbol frutal nativo de la Amazonía sudoccidental (5-15 m altura, ramificación baja en candelabro) cultivado tradicionalmente por pueblos indígenas amazónicos brasileños, peruanos y colombianos (Caquetá, Putumayo, Amazonas, Guainía, Vaupés) desde tiempos precolombinos, considerado uno de los frutales nativos amazónicos más valiosos junto al cacao (Theobroma cacao) y el macambo (Theobroma bicolor). Produce frutos elipsoidales muy grandes (15-25 cm largo, 10-12 cm diámetro, 1-2 kg peso) de cáscara dura leñosa marrón-rojiza pubescente que protege una pulpa blanco-cremosa fibrosa muy aromática (aroma a chocolate-piña-mango) muy ácida (pH 3.2-3.8) con 15-25 semillas grandes elipsoidales similares a las del cacao. La pulpa contiene compuestos volátiles únicos (theaspirano, linalool, mirceno, copaeno) responsables del perfume distintivo que la convierte en materia prima de pulpa congelada de exportación, helados, jugos y mermeladas; las semillas se procesan como 'cupulate' (análogo amazónico al chocolate sin estimulantes, ya que carecen de teobromina pero contienen teacrina). Distribución natural en bosque húmedo tropical de tierra firme (bh-T) sobre suelos ácidos ferralíticos bien drenados, requiere precipitación >2.000 mm/año bien distribuida y humedad relativa >80%. Lección viva: árbol-emblema de la chagra amazónica que enseña tres lecciones críticas: (1) la pulpa cremosa con perfil aromático complejo es resultado de coevolución con dispersores mamíferos grandes (tapires Tapirus terrestris, dantos, sahínos Pecari tajacu) que tragan las semillas enteras y las defecan a kilómetros del árbol madre, lección clave sobre síndromes de dispersión y endozoocoria; (2) la diferencia funcional con el cacao Theobroma cacao (su 'primo' mesoamericano): mientras el cacao se procesa por las semillas (teobromina, manteca de cacao), el copoazú se aprovecha principalmente por la pulpa y las semillas dan un producto sin estimulantes apto para niños y adultos sensibles a la cafeína; (3) el potencial de los frutales nativos amazónicos como alternativa económica viable a la ganadería extensiva y la coca, sustentando proyectos productivos de la Cámara de Comercio del Amazonas, SINCHI y AGROSAVIA en cadenas de valor de pulpa congelada y cosméticos (manteca de cupuaçu como ingrediente premium en hidratantes). Manejo agroecológico: siembra bajo sombra de Inga edulis o Erythrina poeppigiana al 50%, asocio en sistemas agroforestales (SAF) con cacao, plátano, açaí y achiote, no tolera agroquímicos sintéticos, cosecha manual de frutos caídos maduros (no se cortan del árbol — caen solos al madurar, indicador claro de cosecha óptima). Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, AGROSAVIA Manual Frutales Tropicales, Bernal 2015 Catálogo Plantas Colombia, SINCHI Amazonía, FAO EcoCrop.",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "annona_mucosa",
+        "bixa_orellana",
+        "eugenia_stipitata",
+        "musa_paradisiaca",
+        "pouteria_caimito",
+        "theobroma_bicolor"
+      ]
     },
     {
       "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
@@ -2734,7 +6048,9 @@
         "casabe",
         "fariña",
         "yuca venenosa",
-        "tapioca"
+        "tapioca",
+        "mandioca",
+        "yuca dulce"
       ],
       "nombre_cientifico": "Manihot esculenta Crantz",
       "familia_botanica": "Euphorbiaceae",
@@ -2778,7 +6094,117 @@
         "perez-arbelaez-1947-plantas-utiles"
       ],
       "valor_pedagogico": "La yuca brava amazónica o mandioca amarga (Manihot esculenta Crantz, familia Euphorbiaceae) es un arbusto leñoso (2-4 m altura) nativo de las tierras bajas de Sudamérica tropical, domesticada hace 8.000-10.000 años en el sudoeste de la cuenca amazónica (frontera Brasil-Bolivia, área de Rondônia) según evidencia arqueobotánica y genética (Olsen & Schaal 1999), considerada la cuarta fuente de carbohidratos para la humanidad después del arroz, el trigo y el maíz, y la base alimentaria milenaria de los pueblos amazónicos colombianos (tikuna, huitoto, bora, miraña, muinane, andoke, ocaina, yagua, kichwa, siona, kofán, secoya, inga, kamëntsá, makuna, yukpa, sikuani, piaroa). Existen dos grupos varietales tradicionales bien diferenciados: yuca dulce (mansa, bajo contenido de glucósidos cianogénicos <50 mg HCN/kg, consumo directo cocida) y yuca brava o amarga (alto contenido cianogénico 100-500 mg HCN/kg, requiere procesamiento elaborado para eliminar el ácido cianhídrico y transformarse en casabe, fariña o manicuera fermentada). El proceso tradicional indígena para procesar la yuca brava — rallado en tabla de aserrín de palma o concha, prensado en sebucán (cilindro tejido de palma con torsión gravitacional) para extraer el manipueira o yare (líquido amarillo cianhídrico tóxico), tamizado de la masa, tostado en budare o tiesto cerámico para hacer casabe (torta delgada) o fariña (granulado seco) — es uno de los logros etnoquímicos más sofisticados de la humanidad precolombina, comparable al procesamiento del maíz por nixtamalización mesoamericana. Lección viva: planta-pilar de la chagra amazónica colombiana que enseña cinco conceptos críticos: (1) la domesticación temprana de plantas tóxicas (yuca amarga) por pueblos amazónicos como ejemplo magistral de coevolución cultura-naturaleza, donde un cultivo venenoso se vuelve alimento básico mediante una tecnología procesual milenaria; (2) la diferencia entre yuca dulce y yuca brava como caso de selección artificial divergente — la yuca brava conserva su defensa cianogénica natural contra herbívoros y la cultura humana la procesa, mientras la yuca dulce ha perdido esa defensa por selección y se cultiva en zonas con menor presión de saqueo (ej. periurbano colombiano); (3) la chagra amazónica de yuca como sistema rotatorio milenario sostenible: tumba-pudre o slash-and-mulch, ciclo de 1-3 años de cultivo seguido de barbecho de 8-15 años, lección magistral de agricultura itinerante de bosque tropical sin uso de fuego en muchas variantes; (4) la soberanía alimentaria amazónica — el casabe y la fariña son alimentos vivos de la identidad cultural de pueblos como los huitoto, tikuna y bora, y la pérdida del manejo tradicional implica erosión cultural y genética simultánea (>200 variedades locales documentadas en chagras del trapecio amazónico colombiano por SINCHI); (5) la bioquímica defensiva vegetal: los glucósidos cianogénicos (linamarina, lotaustralina) liberan HCN al ser hidrolizados por la enzima linamarasa, lección de bioquímica de defensa estructural disociada espacialmente (los glucósidos en vacuola, la enzima en citoplasma, contacto solo al daño mecánico). Manejo agroecológico: siembra en chagras nuevas (tumba-pudre tradicional), asocio con plátano, piña, copoazú, ají, achiote, cocona; cosecha escalonada manual; cero agroquímicos; control biológico de Phenacoccus manihoti (cochinilla de la yuca) con Anagyrus lopezi (avispita brasileña). Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, AGROSAVIA Manual Frutales Tropicales, Bernal 2015 Catálogo Plantas Colombia, SINCHI Amazonía, FAO EcoCrop, Pérez-Arbeláez 1947.",
-      "tracking_mode": "aggregate"
+      "advertencia_toxicologica": "NUNCA consumir cruda variedades amargas (HCN 100-500 mg/kg → neurotoxicidad konzo, tropic ataxic neuropathy). Procesamiento tradicional obligatorio (rallado + prensado + tostado) elimina glucósidos cianogénicos. Variedades dulces (<50 mg HCN/kg) seguras tras cocción.",
+      "companions": [
+        "borojoa_sorbilis",
+        "cajanus_cajan",
+        "cucurbita_maxima",
+        "cucurbita_moschata",
+        "musa_paradisiaca",
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "bixa_orellana",
+      "nombre_comun": "Achiote",
+      "nombre_comunes_regionales": [
+        "achiote",
+        "onoto",
+        "urucú",
+        "bija",
+        "color",
+        "kusüpa",
+        "achote"
+      ],
+      "nombre_cientifico": "Bixa orellana L.",
+      "familia_botanica": "Bixaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1200,
+        "max_absoluto": 1600
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "perez-arbelaez-1947-plantas-utiles",
+        "sib-colombia",
+        "jbb-plantas-medicinales",
+        "fao-ecocrop"
+      ],
+      "valor_pedagogico": "El achiote (Bixa orellana L., Bixaceae) es un arbusto-arbolito perennifolio nativo del Neotrópico amazónico-orinoquense-caribeño (Colombia, Venezuela, Brasil, Perú, Ecuador, Bolivia, América Central, Antillas), domesticado por pueblos indígenas amazónicos hace más de 4.000 años (witoto, ticuna, bora, yagua, kogui, wayuu, embera, nasa, kuna), cultivado en toda Colombia tropical y templada baja (0-1.200 msnm: Amazonia, Orinoquia, Pacífico, Caribe, Magdalena Medio, valles interandinos, Eje Cafetero), de 2-6 m de altura, con copa redondeada densa, hojas alternas grandes ovado-acorazonadas (10-20 cm) verde brillante, panículas terminales de flores grandes y vistosas (4-5 cm) blanco-rosadas a rosa-violáceas con cinco pétalos delicados y numerosos estambres dorados, y los inconfundibles frutos en cápsula bivalva ovoide o cordada (3-5 cm) densamente cubierta de espinas blandas color rojo-vinotinto-marrón que al abrirse exponen 30-50 semillas pequeñas recubiertas por una capa cerosa rojo-naranja brillante (el bijol, urucú o annato). Es lección viva de soberanía cromática indígena, agroindustria del color natural y bioeconomía amazónica que enseña a niñas y niños cómo una planta domesticada por chamanes y madres de comunidades selváticas hace cuatro milenios sigue alimentando, sanando y pintando el mundo entero hoy: el rojo-naranja del aril es la bixina y norbixina, carotenoides liposolubles que son el colorante natural alimentario E160b reconocido internacionalmente como una de las pocas alternativas seguras a colorantes sintéticos azoicos, usado masivamente en quesos amarillos (cheddar, edam), mantequillas, margarinas, embutidos, snacks, arroces, sopas, salsas, chocolates, postres, refrescos, lápiz labial, pinturas corporales rituales y tinturas textiles ancestrales. Cultural-ritualmente, los indígenas amazónicos usan la pasta roja de achiote para pintarse la piel en ceremonias, protección solar tradicional, repelente de insectos y marcador de identidad clánica. Usos medicinales tradicionales validados por JBB, Pérez-Arbeláez (1947), farmacopea brasileña y estudios amazónicos: hojas en cocimiento como diurético, antipirético, expectorante; semillas en cataplasma para quemaduras solares y picaduras de insectos (acción antioxidante, fotoprotectora); jarabe de semillas para procesos respiratorios; estudios recientes demuestran actividad antiviral in vitro (incluso contra herpes y dengue), hipoglucemiante y antioxidante. Manejo agroecológico: propagación por semilla (germinación 15-25 días, vivero 4-6 meses) o esqueje semileñoso (>70% prendimiento), suelos profundos arcilloso-arenosos drenados, sol pleno a semisombra ligera, distancia 3-4 m, fructificación a partir del segundo año, cosecha de cápsulas maduras (cuando empiezan a abrir), rendimiento 1-3 kg de semillas/árbol/año, función como árbol multipropósito tropical: colorante alimentario familiar, medicinal pectoral, cerca viva ornamental, atractor de abejas y aves frugívoras (loros, tucanes que dispersan las semillas), y cultivo bandera de bioeconomía amazónica con creciente demanda internacional. Fuentes Tier A: GBIF, POWO Kew, Bernal 2015, Pérez-Arbeláez 1947, SiB Colombia, JBB Plantas Medicinales, FAO Ecocrop.",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "curcuma_longa",
+        "solanum_sessiliflorum",
+        "theobroma_grandiflorum"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "ocimum_basilicum",
+      "nombre_comun": "Albahaca",
+      "nombre_comunes_regionales": [
+        "albahaca dulce",
+        "albahaca de hoja ancha",
+        "alfavaca",
+        "basil",
+        "albahaca común",
+        "albahaca blanca",
+        "alfábega"
+      ],
+      "nombre_cientifico": "Ocimum basilicum L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 400,
+        "optimo_max": 1800,
+        "max_absoluto": 2400
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "jbb-plantas-medicinales",
+        "pamplona-roger-2006-plantas-medicinales",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "La albahaca dulce (Ocimum basilicum L., Lamiaceae) es una hierba aromática anual de 30-80 cm de altura originaria de India tropical y África oriental, naturalizada y cultivada extensamente en Colombia desde el nivel del mar hasta 1.800 msnm en zonas térmicas cálidas y templadas: Atlántico, Magdalena, Bolívar, Sucre (Caribe), Tolima, Huila, Valle del Cauca (valles interandinos), Cundinamarca (Tena, Mesitas, Anolaima), Antioquia (Oriente cálido), Santander (Mesa de los Santos, Lebrija). Pertenece a la familia Lamiaceae (igual que orégano, romero, menta, tomillo, salvia, hierbabuena, mejorana) y al género Ocimum del que existen >150 cultivares globales (genovesa, thai, púrpura, limón, cinnamon, sagrada-tulsi). Hojas opuestas decusadas ovaladas-elípticas verde brillante (4-10 cm) con superficie ligeramente abullonada, glándulas oleíferas visibles a contraluz que emiten el aroma característico al rozar, tallos cuadrangulares típicos de Lamiaceae, flores blanco-rosadas en espigas terminales (verticilastros) muy atractoras de abejas y polinizadores. Es lección viva de policultivo aromático y manejo integrado de plagas que enseña a niñas y niños cómo una planta repele mosquitos (limoneno, eugenol) al tiempo que atrae abejas para polinizar tomate, ají y pimentón vecinos — clásico companion plant del tomate (mejora sabor, repele Tuta absoluta, Bemisia tabaci, ácaros, hormigas). Aceite esencial rico en linalol, eucaliptol, eugenol y metil-chavicol con propiedades antibacterianas, antifúngicas, carminativas, digestivas y ansiolíticas suaves; usada en cocina mediterránea (pesto, salsas), cocina thai-vietnamita (pad krapow), cocina caribeña colombiana, té digestivo y para baños aromáticos. Manejo agroecológico: propagación por semilla (germinación 5-10 días a 22-28°C, no tolera heladas — anual obligado en clima frío), siembra directa o trasplante a las 4-6 semanas, distancia 25-40 cm, cosecha continua pellizcando ápices florales antes de antesis (mantiene producción de hoja y posterga floración), ciclo 4-8 meses, pinzar inflorescencias para prolongar productividad. Función en chagra como aromática culinaria, repelente companion del tomate-ají-pimentón, atractora de polinizadores y barrera olfativa contra plagas vectoras. Fuentes Tier A: GBIF, POWO Kew, Bernal 2015, JBB Plantas Medicinales, Pamplona-Roger 2006, Pérez-Arbeláez 1947.",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "petroselinum_crispum"
+      ]
     },
     {
       "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH38_MADERABLES_SOMBRIO",
@@ -2834,12 +6260,29 @@
         "fuente": "Cenicafé manuales sombrío cafetero; CATIE 1997 'Cordia alliodora en sistemas agroforestales'; Trees of Antioquia"
       },
       "companions": [
+        "albizia_guachapele",
+        "bombacopsis_quinata",
+        "bursera_graveolens",
+        "cariniana_pyriformis",
+        "cassia_grandis",
         "cedrela_odorata",
+        "ceiba_pentandra",
         "coffea_arabica",
+        "enterolobium_cyclocarpum",
         "erythrina_edulis",
-        "inga_edulis"
+        "inga_edulis",
+        "myroxylon_balsamum",
+        "nectandra_acutifolia",
+        "ochroma_pyramidale",
+        "pithecellobium_dulce",
+        "prosopis_juliflora",
+        "pseudosamanea_guachapele",
+        "samanea_saman",
+        "swietenia_macrophylla",
+        "tabebuia_chrysantha",
+        "tabebuia_rosea",
+        "vismia_baccifera"
       ],
-      "antagonists": [],
       "manejo_por_escala": {
         "apartamento": {
           "viable": false,
@@ -2893,233 +6336,8 @@
         "gbif-taxonomic-backbone",
         "perez-arbelaez-1947-plantas-utiles"
       ],
-      "tracking_mode": "individual"
-    },
-    {
-      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH38_MADERABLES_SOMBRIO",
-      "id": "tabebuia_rosea",
-      "nombre_comun": "Guayacán rosado",
-      "nombre_comunes_regionales": [
-        "ocobo",
-        "roble morado",
-        "flor morado",
-        "macuelizo",
-        "Handroanthus rosea"
-      ],
-      "nombre_cientifico": "Tabebuia rosea (Bertol.) DC.",
-      "familia_botanica": "Bignoniaceae",
-      "category": "arboles_sombra",
-      "thermal_zones": [
-        "calido",
-        "templado"
-      ],
-      "estrato": "alto",
-      "roles_in_guild": [
-        "biomass_producer",
-        "pollinator_attractor",
-        "windbreak"
-      ],
-      "cultivable": true,
-      "conservation_status": "nativo_silvestre",
-      "altitud_msnm": {
-        "min_absoluto": 0,
-        "optimo_min": 100,
-        "optimo_max": 1600,
-        "max_absoluto": 2000
-      },
-      "temperatura_c": {
-        "helada_letal": 4,
-        "optimo_min": 18,
-        "optimo_max": 28,
-        "max_tolerable": 34
-      },
-      "radiacion": "sol_pleno",
-      "agua": "medio",
-      "drenaje_requerido": "bueno",
-      "habito": "arbol caducifolio, 15-25 m de altura, floración rosada espectacular",
-      "propagation": {
-        "methods": [
-          "semilla",
-          "esqueje"
-        ],
-        "best_method": "semilla",
-        "protocol_resumen": "Semilla alada recolectada de cápsulas dehiscentes en estación seca (enero-marzo en Caribe). Sin tratamiento pre-germinativo. Germinación 80-95% a 8-15 días, una de las germinaciones más rápidas de los maderables tropicales. Vivero a sol parcial, trasplante definitivo a 30-40 cm.",
-        "tiempo_a_establecimiento_dias": 50,
-        "notas": "Floración masiva sincrónica en estación seca (febrero-marzo Andes/Caribe) tras estrés hídrico: árbol totalmente desnudo de hojas se cubre de flores rosado-violáceas que tapizan el suelo al caer. Espectáculo paisajístico icónico del paisaje cafetero y de pueblos del Caribe.",
-        "fuente": "Bernal 2015; Cárdenas-Salinas 2007; Trees of Antioquia; arbolado urbano municipios Andes-Caribe"
-      },
-      "companions": [
-        "coffea_arabica",
-        "cordia_alliodora",
-        "erythrina_edulis",
-        "inga_edulis"
-      ],
-      "antagonists": [],
-      "manejo_por_escala": {
-        "apartamento": {
-          "viable": false,
-          "nota": "Árbol 15-25 m, inviable apartamento."
-        },
-        "huerto_casero": {
-          "viable": true,
-          "nota": "Árbol ornamental-maderable patrimonial. Floración espectacular paisajística.",
-          "tips": [
-            "Plantar en zona visible (jardín frontal, andén)",
-            "Tolera podas urbanas anuales para formación"
-          ]
-        },
-        "invernadero_mediano": {
-          "viable": false,
-          "nota": "Inviable bajo cubierta."
-        },
-        "produccion": {
-          "viable": true,
-          "nota": "Sombrío cafetalero compatible 80-150 árb/ha. Maderable secundario en plantaciones mixtas. Arbolado urbano patrimonial municipal.",
-          "tips": [
-            "Madera dura amarillo-marrón apreciada para construcción rural",
-            "Polen y néctar para apicultura nativa",
-            "Tolera contaminación urbana mejor que Quercus"
-          ]
-        },
-        "restauracion": {
-          "viable": true,
-          "nota": "Pionera bosque seco tropical en restauración Caribe y valles interandinos.",
-          "tips": [
-            "Tolera suelos pedregosos y pendientes fuertes",
-            "Asocio con Bombacopsis quinata en bosque seco"
-          ]
-        }
-      },
-      "scale_viability": [
-        "huerto_casero",
-        "produccion",
-        "restauracion"
-      ],
-      "plagas_criticas": [],
-      "enfermedades_criticas": [],
-      "harvest_type": "biomasa",
-      "validation_level": "claude_draft",
-      "rol_ecologico": "Árbol ornamental-maderable patrimonial neotropical. Floración masiva sincrónica rosado-violácea en estación seca tras estrés hídrico, espectáculo paisajístico icónico de cafetales y pueblos del Caribe colombiano. Madera amarillo-marrón dura apreciada para construcción rural, vigas, postes, ebanistería. Flores grandes tubulares atraen abejas y colibríes. Importante en arbolado urbano municipal de ciudades cálidas y templadas.",
-      "valor_pedagogico": "El guayacán rosado u ocobo (Tabebuia rosea (Bertol.) DC., sinónimo válido Handroanthus roseus, Bignoniaceae) es uno de los árboles más patrimoniales del paisaje colombiano. Nativo desde el sur de México hasta Ecuador, en Colombia se distribuye prácticamente en todas las regiones bajas y medias: Caribe (Sucre, Córdoba, Bolívar, Magdalena, La Guajira), Andina (valles del Magdalena, Cauca y Patía, piedemonte llanero en Cundinamarca, Tolima, Huila, Antioquia, Santander, Norte de Santander, Caldas, Risaralda, Quindío, Valle), Pacífico (Chocó, Valle), Orinoquía (Casanare, Meta) entre 0 y 1.600 msnm en zona térmica cálida a templada. Árbol caducifolio de 15-25 m de altura con fuste recto y copa abierta hemisférica, hojas opuestas palmaticompuestas con 5 folíolos elípticos, su característica más espectacular es la floración masiva sincrónica en estación seca (febrero-marzo en Andes, enero-marzo en Caribe): tras estrés hídrico el árbol pierde totalmente las hojas y se cubre de grandes flores tubulares rosado-violáceas (5-8 cm) en panículas terminales que tapizan el suelo al caer convirtiendo calles y veredas en alfombras rosadas. Este fenómeno paisajístico es ícono cultural de pueblos cafeteros (Pueblo Tapao, Filandia, Salento), municipios del Caribe (Sincelejo, Valledupar), Ibagué, Bogotá (avenidas), y aparece en pinturas, poesía y postales turísticas. Su madera amarillo-marrón dura y resistente a la pudrición es apreciada para construcción rural (vigas, postes, durmientes), ebanistería e instrumentos musicales artesanales. Es importante en arbolado urbano municipal porque tolera mejor que el roble (Quercus) la contaminación urbana, los suelos compactados y las podas eléctricas, además provee néctar y polen para abejas y colibríes urbanos durante semanas de floración masiva. En sistemas agroforestales cafetales templados acepta densidades 80-150 árb/ha como sombrío estético-productivo. En restauración de bosque seco tropical (Caribe, valle del Magdalena) es pionera valiosa por tolerancia a suelos pedregosos y pendientes. La floración masiva sincrónica es tema clásico de fenología tropical: dispara la dehiscencia de cápsulas y la dispersión de semillas aladas justo al inicio de lluvias, maximizando germinación. Manejo agroecológico: propagación por semilla recién recolectada con germinación rápida (8-15 días), vivero al sol parcial, plantación definitiva a 30-40 cm, podas de formación años 1-3, tolera podas urbanas anuales. Es lección de soberanía paisajística: en lugar de plantar jacaranda exótica de Argentina-Brasil o cerezos japoneses ornamentales, el ocobo nativo provee la misma magia floral en su versión rosada colombiana, con valor maderable adicional. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, Cárdenas & Salinas 2007, Trees of Antioquia, POWO Kew, GBIF Backbone Taxonomy.",
-      "source_ids": [
-        "bernal-2015-plantas-liquenes-colombia",
-        "libro-rojo-plantas-colombia",
-        "powo-kew",
-        "gbif-taxonomic-backbone",
-        "perez-arbelaez-1947-plantas-utiles"
-      ],
-      "tracking_mode": "individual"
-    },
-    {
-      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH40_BOSQUE_SECO",
-      "id": "enterolobium_cyclocarpum",
-      "nombre_comun": "Orejero",
-      "nombre_comunes_regionales": [
-        "carito",
-        "piñón de oreja",
-        "oreja de negro",
-        "guanacaste",
-        "conacaste"
-      ],
-      "nombre_cientifico": "Enterolobium cyclocarpum (Jacq.) Griseb.",
-      "familia_botanica": "Fabaceae",
-      "category": "arboles_sombra",
-      "thermal_zones": [
-        "calido"
-      ],
-      "estrato": "alto",
-      "roles_in_guild": [
-        "biomass_producer",
-        "nitrogen_fixer",
-        "windbreak",
-        "pollinator_attractor"
-      ],
-      "cultivable": true,
-      "conservation_status": "nativo_silvestre",
-      "altitud_msnm": {
-        "min_absoluto": 0,
-        "optimo_min": 0,
-        "optimo_max": 1000,
-        "max_absoluto": 1300
-      },
-      "temperatura_c": {
-        "helada_letal": 8,
-        "optimo_min": 24,
-        "optimo_max": 32,
-        "max_tolerable": 38
-      },
-      "radiacion": "sol_pleno",
-      "agua": "bajo",
-      "drenaje_requerido": "bueno",
-      "habito": "árbol caducifolio gigante 25-40 m, copa hemisférica muy amplia hasta 50 m de diámetro, fruto característico en forma de oreja",
-      "propagation": {
-        "methods": [
-          "semilla"
-        ],
-        "best_method": "semilla",
-        "protocol_resumen": "Semilla muy dura requiere escarificación: lima, ácido sulfúrico 30 min o agua hirviendo + remojo 24 h. Germinación 80-95% a 7-14 días. Vivero 4-5 meses. Plantación definitiva a 30 cm. Crecimiento rápido.",
-        "tiempo_a_establecimiento_dias": 50,
-        "notas": "Árbol más grande del bosque seco tropical americano. Fruto característico vaina circular curvada en forma de oreja humana (origen del nombre). Forraje suplementario crítico ganadería seca: vainas dulces alto contenido proteína.",
-        "fuente": "Bernal 2015; POWO; FAO Ecocrop; Agrosavia silvopastoriles; CIAT manuales bosque seco"
-      },
-      "companions": [
-        "coffea_arabica",
-        "cordia_alliodora",
-        "gliricidia_sepium",
-        "pseudosamanea_guachapele",
-        "samanea_saman"
-      ],
-      "antagonists": [],
-      "manejo_por_escala": {
-        "apartamento": {
-          "viable": false,
-          "nota": "Árbol gigante 25-40 m copa 50 m, inviable apartamento."
-        },
-        "huerto_casero": {
-          "viable": false,
-          "nota": "Inviable en huerto casero por tamaño extraordinario. Requiere mínimo 50 m de radio."
-        },
-        "invernadero_mediano": {
-          "viable": false,
-          "nota": "Inviable bajo cubierta."
-        },
-        "produccion": {
-          "viable": true,
-          "nota": "Sombrío silvopastoril extensivo 25-40 árb/ha. Vainas forraje suplementario alto proteína. Patrimonial Caribe-Valle.",
-          "tips": [
-            "Vainas cosechables sept-nov: 50-80 kg/árb/año",
-            "Forraje complementario seca: bovinos, equinos, porcinos",
-            "Madera blanca-cremosa apreciada tornería embarcaciones"
-          ]
-        },
-        "restauracion": {
-          "viable": true,
-          "nota": "Especie patrimonial y emblemática bs-T colombiano. Densidad baja por tamaño extraordinario (15-30 ind/ha).",
-          "tips": [
-            "Atrae avifauna y mamíferos dispersores (sahínos, dantas)",
-            "Sombra crítica fauna seca",
-            "Resistente sequías extremas 6 meses"
-          ]
-        }
-      },
-      "scale_viability": [
-        "produccion",
-        "restauracion"
-      ],
-      "plagas_criticas": [],
-      "enfermedades_criticas": [],
-      "harvest_type": "biomasa",
-      "validation_level": "claude_draft",
-      "rol_ecologico": "Árbol gigante caducifolio leguminosa fijadora de N del bosque seco tropical americano. Copa hemisférica hasta 50 m de diámetro provee sombrío extremo a ganadería extensiva. Vainas en forma de oreja humana (origen del nombre) cosechables como forraje suplementario alto en proteína (16-20% MS) crítico en estación seca prolongada. Atractor mamíferos y avifauna dispersora del bs-T. Patrimonial Caribe, Valle del Cauca, Tolima, Huila.",
-      "valor_pedagogico": "El orejero, carito o piñón de oreja (Enterolobium cyclocarpum (Jacq.) Griseb., Fabaceae subfamilia Mimosoideae) es el árbol más grande y emblemático del bosque seco tropical (bs-T) americano, conocido como \"guanacaste\" en Centroamérica (árbol nacional de Costa Rica), \"conacaste\" en El Salvador, y \"orejero\" o \"carito\" en Colombia. Su nombre español proviene del fruto característico: una vaina circular curvada y aplanada en forma de oreja humana, marrón-negra brillante a la madurez, contiene 6-15 semillas duras inmersas en pulpa dulce y aromática. Nativo del Neotrópico desde México hasta Brasil-Perú, en Colombia se distribuye en el bosque seco tropical de los valles interandinos del Magdalena (Tolima, Huila, Cundinamarca, Boyacá, Santander), Cauca (Valle, Cauca), Patía, Sinú-San Jorge (Córdoba, Sucre, Bolívar), Caribe seco (La Guajira, Cesar, Magdalena, Atlántico) y piedemonte llanero (Casanare, Arauca) entre 0-1.000 msnm en zona térmica exclusivamente cálida (>24°C promedio anual). Árbol caducifolio de 25-40 m de altura con copa hemisférica muy amplia hasta 50 m de diámetro (la copa más extensa del bs-T), fuste recto cilíndrico hasta 3-4 m DAP, corteza grisácea con lenticelas, hojas bipinnadas con folíolos pequeños caducas en estación seca, flores blanco-verdosas en cabezuelas globulosas, frutos vaina circular curvada característica. Su rol ecológico es triple: (1) sombrío extremo para ganadería extensiva — un solo árbol provee sombra a 50-100 cabezas de ganado bovino reduciendo estrés térmico crítico en climas 35-38°C; (2) forraje suplementario en estación seca: las vainas dulces caen desde septiembre-noviembre, son apetentes para bovinos, equinos y porcinos, contienen 16-20% proteína MS y 65% TND, sustituyendo concentrado comercial en finca; (3) fijación biológica de N como Mimosoideae mediante rizobios, aporte crítico en suelos pobres compactados del bs-T. Como leguminosa pionera de gran porte y crecimiento rápido (10-15 m en 8-10 años) es especie clave en restauración de bs-T y atractor crítico para mamíferos dispersores nativos como sahínos (Tayassu pecari, T. tajacu), dantas (Tapirus bairdii), ñeques (Dasyprocta), micos aulladores (Alouatta seniculus) y avifauna granívora (Aratinga, Brotogeris, Forpus). Su madera blanco-cremosa medianamente densa es apreciada en tornería, ebanistería, embarcaciones tradicionales (canoas dugout precolombinas), construcción rural ligera. Manejo agroecológico: propagación por semilla con escarificación crítica (semilla muy dura: lima mecánica, ácido sulfúrico 30 min, o agua hirviendo + remojo 24 h, germinación 80-95% a 7-14 días), vivero 4-5 meses a sol pleno, plantación definitiva a 30 cm, distancia 25-40 árb/ha en silvopastoril extensivo (densidad baja por tamaño extraordinario), cosecha de vainas septiembre-noviembre 50-80 kg/árb/año. Es lección extraordinaria de cómo un árbol nativo gigante puede transformar la ganadería extensiva del bs-T en sistema silvopastoril sostenible: reduce estrés calórico bovino, provee forraje suplementario gratuito que ahorra concentrado importado, fija N al suelo, atrae fauna dispersora restauradora, y produce madera de calidad — todo en un solo árbol patrimonial. Es además testimonio vivo de los bosques secos pre-coloniales, donde estos gigantes eran abundantes y dispersaban sus vainas a través de la megafauna pleistocénica extinta (gomphoteres, gliptodontes): hoy el ganado bovino doméstico cumple el rol dispersor co-evolutivo, manteniendo el árbol vivo en el paisaje. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Agrosavia silvopastoriles bs-T.",
-      "source_ids": [
-        "bernal-2015-plantas-liquenes-colombia",
-        "powo-kew",
-        "gbif-taxonomic-backbone",
-        "fao-ecocrop",
-        "agrosavia-silvopastoriles"
-      ],
-      "tracking_mode": "individual"
+      "tracking_mode": "individual",
+      "cultivar": false
     },
     {
       "id": "capsicum_chinense_aji_panca",
@@ -3171,7 +6389,11 @@
         "perez-arbelaez-1947-plantas-utiles"
       ],
       "valor_pedagogico": "El ají panca (Capsicum chinense Jacq. cv. 'Panca', Solanaceae) es un cultivar de ají de fruto rojo intenso y picor moderado (10.000-30.000 SHU en escala Scoville, equivalente a ají cayena suave) tradicional de la región andina noroccidental de Suramérica con presencia ancestral en Colombia bajo el nombre 'ají panca colombiano' o 'ají rojo seco', particularmente en las regiones Andina (Cundinamarca, Boyacá clima medio, Santander, Norte de Santander, Tolima, Huila, Antioquia, Valle del Cauca, Cauca, Nariño) y Caribe (Magdalena, Bolívar, Sucre, Córdoba) entre 0 y 1.800 msnm en zonas térmicas cálidas y templadas. Pertenece a la familia Solanaceae (igual que tomate, papa, pimentón, lulo, tomate de árbol, uchuva, ají dulce, rocoto, ulluco) y al género Capsicum del que existen cinco especies domesticadas: C. annuum (pimentón, jalapeño, cayena), C. chinense (habanero, panca, ají charapita, ají amarillo de mar), C. baccatum (ají amarillo andino), C. pubescens (rocoto), C. frutescens (tabasco, chiltepín). El cultivar 'panca' se distingue por frutos alargados (8-12 cm) de color rojo oscuro a casi negro cuando maduros, secados al sol para uso culinario en pastas y aderezos, picor moderado equilibrado por dulzor afrutado, y aceites esenciales ricos en capsaicina (alcaloide responsable del picor con propiedades vasodilatadoras, analgésicas tópicas y antimicrobianas) y carotenoides (capsantina, capsorubina, beta-caroteno provitamina A). Es lección viva de domesticación precolombina y biodiversidad cultivada que enseña a niñas y niños cómo los pueblos andinos seleccionaron durante miles de años decenas de cultivares de ají con diferentes niveles de picor, color, sabor y uso culinario — patrimonio agrobiocultural irreemplazable. Manejo agroecológico: propagación por semilla (germinación 8-15 días a 22-28°C, no tolera heladas), trasplante a las 6-8 semanas con 4-6 hojas verdaderas, distancia 50-60 cm entre plantas y 80 cm entre surcos, riego regular pero sin encharcamiento (sensible a Phytophthora capsici), tutorado opcional para variedades altas, cosecha escalonada de frutos maduros rojos durante 2-4 meses, secado al sol para conservación de pasta picante. Companion plants ideales: albahaca (repele plagas), cebollín y cebolla larga (repele áfidos), zanahoria. Antagonistas: hinojo (alelopatía), brassicas en proximidad cercana. Función en chagra como hortaliza-condimento de alto valor culinario y atractora de polinizadores. Fuentes Tier A: GBIF Backbone Taxonomy, POWO Kew, Bernal 2015 Catálogo Plantas y Líquenes Colombia, AGROSAVIA Manual Frutales Tropicales, Pérez-Arbeláez 1947 Plantas Útiles Colombia.",
-      "tracking_mode": "aggregate"
+      "antagonists": [
+        "juglans_neotropica"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false
     },
     {
       "id": "capsicum_annuum_aji_dulce_caribe",
@@ -3223,17 +6445,3694 @@
         "perez-arbelaez-1947-plantas-utiles"
       ],
       "valor_pedagogico": "El ají dulce caribe (Capsicum annuum L. cv. 'Dulce', Solanaceae) es un cultivar emblemático de la cocina caribeña colombiana, venezolana y antillana caracterizado por la ausencia total de picor (0 SHU, mutación recesiva del gen Pun1 que desactiva la biosíntesis de capsaicina) pero con un aroma frutal-floral intenso y único que lo convierte en el condimento aromático base del sofrito caribeño, hogao y guisos costeños — patrimonio agroalimentario afro-caribeño irreemplazable. Se cultiva en toda la región Caribe colombiana (Atlántico, Magdalena, Bolívar, Cesar, Córdoba, Sucre, La Guajira, Arauca, Casanare en piedemonte llanero), Pacífico (Chocó, Valle), Andina baja (valles cálidos interandinos de Antioquia, Santander, Norte de Santander, Tolima, Huila, Valle del Cauca) y Orinoquía (Meta, Vichada) entre 0 y 1.500 msnm en zonas térmicas cálidas y templadas. Pertenece a la familia Solanaceae y al género Capsicum, especie C. annuum (la más cultivada globalmente, que incluye pimentón, jalapeño, cayena, paprika), cultivar 'Dulce' diferenciado del pimentón por su tamaño pequeño (3-6 cm), forma campanulada irregular o piriforme, colores variados al madurar (rojo, amarillo, naranja, verde-amarillento), pulpa delgada aromática y aroma intenso frutal-floral con notas a manzana-piña-floral distinto del aroma vegetal del pimentón. La mutación que elimina el picor mantiene íntegros los carotenoides (capsantina, capsorubina, beta-caroteno), flavonoides (quercetina, luteolina), vitamina C abundante y aceites esenciales aromáticos — convirtiéndolo en condimento de alta densidad nutricional sin la barrera sensorial del picante para niños y mayores. Es lección viva de domesticación selectiva por sabor y de cómo los pueblos afro-caribeños seleccionaron a través de generaciones una variante sin picor pero con aroma maximizado para construir una identidad culinaria distintiva: el sofrito caribeño con ají dulce, cebolla larga, ajo, cilantro y tomate es la base aromática de la cocina costeña colombiana, venezolana, cubana, dominicana y boricua. Manejo agroecológico: propagación por semilla (germinación 7-12 días a 25-28°C), trasplante a las 5-6 semanas, distancia 40-50 cm entre plantas, riego regular, sin tutorado en variedades compactas, cosecha escalonada 3-5 meses, primera cosecha temprana (más rápido que ajíes picantes). Companion plants ideales: albahaca, cilantro cimarrón, cebollín, tomate, plátano (estrato superior). Función en chagra costeña como hortaliza-condimento aromática insustituible. Fuentes Tier A: GBIF Backbone Taxonomy, POWO Kew, Bernal 2015 Catálogo Plantas y Líquenes Colombia, AGROSAVIA Manual Frutales Tropicales, Pérez-Arbeláez 1947 Plantas Útiles Colombia.",
+      "antagonists": [
+        "juglans_neotropica"
+      ],
+      "tracking_mode": "aggregate",
+      "cultivar": false
+    },
+    {
+      "id": "tagetes_minuta",
+      "nombre_comun": "Chinchilla",
+      "nombre_comunes_regionales": [
+        "huacatay andino",
+        "chinchilla",
+        "anís de monte",
+        "muicle del sur",
+        "wakatay"
+      ],
+      "nombre_cientifico": "Tagetes minuta L.",
+      "familia_botanica": "Asteraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 1800,
+        "optimo_max": 3200,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 10,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinación 5-10 días a 18-22°C. Anual. Resiembra espontánea abundante. Cosecha foliar para té anti-pulgones y uso culinario al inicio de la floración (5-6 meses). Aceite esencial concentrado en hojas y flores."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "jbb-plantas-medicinales",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "valor_pedagogico": "La chinchilla o huacatay andino (Tagetes minuta L., Asteraceae) es una hierba aromática-medicinal-repelente nativa de los Andes suramericanos (originaria del altiplano peruano-boliviano-noroeste argentino) presente ancestralmente en Colombia andina como especie nativa silvestre y cultivada en los departamentos de Nariño (Pasto, Túquerres, Ipiales), Cauca (Popayán, Silvia, Páez), Putumayo (Sibundoy, Mocoa alto), Boyacá (Sogamoso, Belén, Cerinza), Cundinamarca (Sabana, Sumapaz), Antioquia (Oriente alto, Suroeste), Santander (páramos), entre 500 y 3.600 msnm en zonas térmicas frías y templadas. Pertenece a la familia Asteraceae (Compositae, igual que girasol, lechuga, calendula, manzanilla, ajenjo, achicoria, diente de león) y al género Tagetes — el mismo del cempasúchil mexicano (T. erecta) y del pericón (T. lucida) — que contiene >50 especies neotropicales caracterizadas por la producción de aceites esenciales con propiedades insecticidas, nematicidas y aromáticas. Planta herbácea anual de 1-2 m de altura con hojas pinnatisectas verde-grisáceas con glándulas oleíferas visibles (puntos translúcidos al trasluz), tallos erectos pubescentes con olor fuerte característico a anís-cítrico-resinoso al estrujar, capítulos pequeños amarillos en panículas terminales, frutos en aquenios cipsela ligeros dispersados por viento. Doble función patrimonial: 1) como **aromática culinaria andina** es el 'huacatay' icónico de la cocina peruano-boliviana (ocopa, pollo en salsa de huacatay, papas chorreadas) y se usa también en cocina nariñense colombiana en sopas y carnes; aceite esencial rico en tagetona, ocimeno, dihidrotagetona, limoneno y beta-cariofileno con notas aromáticas únicas no replicables por otra hierba; 2) como **repelente-nematicida agroecológico** es uno de los biopreparados clave de la agricultura andina: el 'té de huacatay' (infusión 10% p/v de hojas y flores frescas en agua tibia, 24 h maceración, filtrado, dilución 1:5, aspersión foliar) controla pulgones (Myzus persicae), trips (Frankliniella spp.), ácaros (Tetranychus urticae) y mosquita blanca (Bemisia tabaci) en cultivos vecinos sin daño a polinizadores; sembrada intercalada con papa, maíz, fríjol, hortalizas inhibe nemátodos del nudo (Meloidogyne spp.) a través de exudados radiculares con alfa-tertienilo y otros tiofenos nematicidas — biofumigante natural. Es lección extraordinaria de soberanía agroecológica y patrimonio biocultural andino que enseña a niñas y niños cómo una hierba nativa puede ser simultáneamente alimento, medicina y biopreparado, reemplazando insecticidas químicos por una decocción aromática. Manejo agroecológico: propagación por semilla (germinación 5-10 días a 18-22°C, resiembra espontánea abundante en cama), distancia 30-40 cm, ciclo 5-7 meses anual obligado, cosecha foliar al inicio de floración para máxima concentración de aceite esencial. Companion plants ideales: papa, maíz, fríjol, hortalizas en general. Función en chagra como aromática culinaria + repelente + nematicida + atractora de polinizadores. Fuentes Tier A: GBIF Backbone Taxonomy, POWO Kew, Bernal 2015 Catálogo Plantas y Líquenes Colombia, JBB Plantas Medicinales, AGROSAVIA Manual Biopreparados 2015.",
+      "tracking_mode": "individual",
+      "companions": [
+        "cosmos_sulphureus"
+      ],
+      "cultivar": false
+    },
+    {
+      "id": "helianthus_annuus",
+      "nombre_comun": "Girasol",
+      "nombre_cientifico": "Helianthus annuus L.",
+      "nombre_comunes_regionales": [
+        "Mirasol",
+        "Maravilla",
+        "Acahual"
+      ],
+      "familia_botanica": "Asteraceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "crop",
+        "dynamic_accumulator",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2200,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa a sitio definitivo, 2-3 cm profundidad, distancia 30-60 cm entre plantas. Germinación 5-12 días. Ciclo 90-120 días. Cosecha de capítulo cuando reverso vira marrón y semillas se desprenden con presión leve."
+      },
+      "companions": [
+        "centaurea_cyanus",
+        "cosmos_sulphureus",
+        "cucurbita_maxima",
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ],
+      "harvest_type": "semilla",
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "valor_pedagogico": "El Girasol (Helianthus annuus L., Asteraceae) es una especie anual originaria de Norteamérica (cuenca del Mississippi, México, suroeste de Estados Unidos) cultivada en Colombia y todo el Neotrópico como ornamental masivo, productora de semilla comestible y oleaginosa, y atrayente excepcional de polinizadores. Sus capítulos compuestos (inflorescencias) son uno de los íconos botánicos universales y su heliotropismo (seguimiento del sol por capítulos jóvenes, fenómeno reversible mediado por crecimiento diferencial del tallo bajo el control del reloj circadiano) es lección viva de fisiología vegetal para huerta escolar. En Colombia se cultiva entre 0 y 2.800 msnm en zonas térmicas cálida a fría: Sabana de Bogotá, valles interandinos del Magdalena y Cauca, Caribe seco, Eje Cafetero, Antioquia. Manejo agronómico: siembra directa a sitio definitivo en suelo bien drenado y soleado, 2-3 cm profundidad, distancia 30-60 cm entre plantas y 60-90 cm entre surcos, germinación 5-12 días, ciclo total 90-120 días según variedad (enanas 80 días, gigantes 130+ días). El capítulo puede albergar entre 100 y 2.000 flores tubulares (flósculos del disco) rodeadas por las flores liguladas amarillas vistosas (radio), cada flósculo polinizado produce una semilla (técnicamente cipsela). Atracción de polinizadores: una sola planta puede sostener decenas de abejas (Apis mellifera, Trigona spp., Melipona spp.) y abejorros nativos (Bombus spp.) simultáneamente durante la floración, y es flor visitada también por mariposas y aves granívoras (loros, pericos, jilgueros) que aprovechan las semillas maduras. Asociación clásica con la \"milpa mesoamericana\": maíz + frijol + calabaza + girasol como cuarta hermana en borde para atracción de polinizadores y defensa contra plagas (acumula áfidos lejos de las hortalizas). Producción de aceite: las variedades oleaginosas modernas alcanzan 40-50% de aceite en semilla (insaturado, rico en ácido linoleico y vitamina E), siendo el girasol uno de los tres aceites vegetales más consumidos en el mundo junto con palma y soya. Las semillas tostadas o crudas son consumo humano directo en muchas culturas (pipas en España, sunflower seeds en Estados Unidos, pepas de mirasol en México). La torta residual del prensado es alimento balanceado de alta calidad para aves y porcinos. Acumulador dinámico de potasio y fósforo del subsuelo (sistema radical pivotante profundo de 1.5-2 m), su biomasa al final del ciclo es excelente abono verde si se incorpora antes de la lignificación del tallo. Uso ancestral: pueblos originarios de Norteamérica lo cultivaban hace 4.000+ años como cuarto cultivo principal (maíz, frijol, calabaza, girasol), Aztecas y Mayas lo veneraban como flor solar simbólica (la flor mira al sol como el alma busca a Dios), llegada a Europa siglo XVI vía conquistadores españoles desde México (de ahí \"mirasol\" y \"girasol\"). Manejo en chagra: siembra perimetral o en hileras intercaladas con hortalizas, como planta atrayente y trampa, asociación con maíz-frijol-calabaza, cosecha del capítulo cuando reverso vira marrón claro y las brácteas se secan, secado al sol 1-2 semanas antes de desgrane manual. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pérez Arbeláez 1947 Plantas Útiles Colombia, JBB Plantas Medicinales.",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "perez-arbelaez-1947-plantas-utiles",
+        "jbb-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivar": false
+    },
+    {
+      "id": "persea_americana",
+      "nombre_comun": "Aguacate",
+      "nombre_cientifico": "Persea americana Mill.",
+      "familia_botanica": "Lauraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 800,
+        "optimo_max": 2200,
+        "max_absoluto": 2500
+      },
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "tracking_mode": "individual",
+      "valor_pedagogico": "El aguacate (Persea americana Mill., Lauraceae) es uno de los frutales nativos americanos más importantes y emblemáticos de la agricultura colombiana, con producción concentrada en Antioquia, Tolima, Caldas, Quindío, Risaralda, Valle del Cauca y Cundinamarca. Variedades dominantes en Colombia: Hass (mayoritaria exportación), Lorena, Choquette, Booth, Trapp, criollos antillanos. Cultivo perenne 3-30 m altura con sistema radical superficial sensible a encharcamiento — requiere drenaje EXCELENTE (suelos francos a franco-arenosos, pH 5.5-6.5). Floración tipo A/B con dicogamia (mecanismo de polinización cruzada que requiere coexistencia de tipos florales A y B para fructificación máxima — lección agroecológica de biodiversidad funcional). Manejo: trasplante 6-8 meses post-vivero, distancia 7x7 m (Hass) a 9x9 m (criollos), tutorado primer año, poda de formación años 2-4, cosecha desde año 3-5 hasta año 25+. Plagas: trips (Frankliniella), ácaros, monalonion. Enfermedades graves: Phytophthora cinnamomi (muerte de la raíz), antracnosis, mancha negra. Manejo agroecológico: Trichoderma harzianum + sombrío de guamo (Inga edulis) reduce 70% Phytophthora. Asocio clásico: café-aguacate-plátano en sistema multiestrato cafetero.",
+      "feeding_plan_template": {
+        "source": "Agrosavia — Manual frutales tropicales + Pérez-Arbeláez (1947) Plantas útiles de Colombia. Programa NUTRICIONAL aguacate clima templado-cálido 1000-2200 msnm. Solo nutrición; la sanidad (Phytophthora, antracnosis) se trata aparte.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al hoyo de siembra",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 2000,
+            "notes": "Hoyo 60x60x60 cm. Mezclar 2 kg de bocashi con suelo del hoyo. Aguacate sensible a encharcamiento — drenaje crítico."
+          },
+          {
+            "offset_days": 90,
+            "action": "Drench con biol fase vegetativa",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 1500,
+            "notes": "Dilución 1:5, 1.5 L al pie. Año 1 establecimiento — crecimiento foliar activo."
+          },
+          {
+            "offset_days": 330,
+            "action": "Foliar con supermagro pre-floración",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 100,
+            "notes": "Año 2 — preparar floración. Dilución 1:10. Aporte Zn y B críticos para cuajado de aguacate."
+          },
+          {
+            "offset_days": 365,
+            "action": "Refuerzo anual con bocashi en corona",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 3000,
+            "notes": "Año 1 completo. Aplicar bajo la corona en banda, no contra el tronco. Cubrir con mulch."
+          }
+        ],
+        "recurrence": "anual",
+        "perennial_note": "Cultivo perenne: repetir este ciclo cada año."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "cultivar": false,
+      "companions": [
+        "arachis_pintoi",
+        "melicoccus_bijugatus",
+        "spondias_dulcis"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus"
+      ],
+      "nombre_comunes_regionales": [
+        "palta",
+        "cura",
+        "aguacate criollo",
+        "abacate"
+      ]
+    },
+    {
+      "id": "mangifera_indica",
+      "nombre_comun": "Mango",
+      "nombre_cientifico": "Mangifera indica L.",
+      "familia_botanica": "Anacardiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1800
+      },
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "tracking_mode": "individual",
+      "valor_pedagogico": "El mango (Mangifera indica L., Anacardiaceae) es frutal tropical originario del subcontinente indio, naturalizado en Colombia desde el siglo XVI, hoy emblemático de Caribe, Valle del Magdalena, Tolima, Cundinamarca (Mesa-Guaduas), Caquetá. Variedades comerciales en Colombia: Tommy Atkins, Kent, Keitt, Haden, Yulima criollo, hilacha, manzano. Árbol perenne 10-40 m altura con corona globosa densa, follaje verde brillante. Fructificación estacional (Colombia: noviembre-marzo en Caribe, abril-julio en Cundinamarca), con alternancia bienal típica (un año alta producción, siguiente baja — fenómeno fisiológico común en frutales). Lección agroecológica: el mango criollo Colombia ha sido perdido masivamente por industrialización Tommy Atkins — recuperar criollos = soberanía genética. Manejo: trasplante 4-6 meses, distancia 10x10 m, poda de formación post-cosecha, tolera sequía moderada cuando ya establecido. Asocio: cacao-mango-plátano sistema cacaotero, o monocultivo. Plagas: mosca de fruta (Anastrepha obliqua), antracnosis, oidio.",
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "cultivar": false,
+      "companions": [
+        "chrysophyllum_cainito",
+        "mammea_americana",
+        "melicoccus_bijugatus",
+        "spondias_dulcis",
+        "stylosanthes_guianensis"
+      ]
+    },
+    {
+      "id": "ananas_comosus",
+      "nombre_comun": "Piña",
+      "nombre_cientifico": "Ananas comosus (L.) Merr.",
+      "familia_botanica": "Bromeliaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 1000,
+        "max_absoluto": 1500
+      },
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "tracking_mode": "aggregate",
+      "valor_pedagogico": "La piña (Ananas comosus, Bromeliaceae) es bromelia terrestre originaria del sur de Brasil/Paraguay, cultivada en Colombia desde tiempos precolombinos por los Tikuna y Bora. Variedades en Colombia: Gold MD-2 (industrial Santander, Llanos), Manzana (criolla cundinamarquesa), Cayena Lisa (Tolima, Magdalena). Planta perenne de 1-1.5 m con roseta de hojas espinosas rígidas, fruto múltiple sincárpico formado por fusión de 100-200 frutillas individuales. Lección agroecológica: la piña usa fotosíntesis CAM (Crassulacean Acid Metabolism — abre estomas de noche para ahorrar agua), única bromelia comestible comercial — enseña diversidad de estrategias fotosintéticas. Manejo agroecológico: propagación por hijuelos basales o corona del fruto, suelo bien drenado pH 4.5-5.5 (tolera ácido), riego escaso pero regular, cosecha 18-24 meses post-siembra, 1-2 frutos por planta antes de renovación. Asocio: maíz-piña-yuca en chagras amazónicas tradicionales.",
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "sinchi-amazonia-colombiana"
+      ],
+      "cultivar": false,
+      "companions": [
+        "annona_mucosa",
+        "pouteria_caimito",
+        "solanum_sessiliflorum"
+      ],
+      "nombre_comunes_regionales": [
+        "Ijibo"
+      ]
+    },
+    {
+      "id": "musa_paradisiaca",
+      "nombre_comun": "Plátano",
+      "nombre_cientifico": "Musa × paradisiaca L.",
+      "familia_botanica": "Musaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "tracking_mode": "aggregate",
+      "valor_pedagogico": "El plátano (Musa × paradisiaca, Musaceae) es híbrido cultivado entre Musa acuminata × Musa balbisiana, base alimentaria del campesinado colombiano. Variedades clave: Hartón (Caribe-Pacífico), Dominico Hartón (Eje cafetero), Cachaco (Antioquia), Comino, Pelipita, Manzano, Topocho. Hierba gigante 4-8 m altura (NO árbol — el tronco es pseudotallo formado por vainas foliares enrolladas), reproducción asexual por hijuelos basales (yemas del rizoma o cormo). Lección agroecológica de bioarquitectura única: el plátano se reproduce SOLO clonalmente desde siglo XIX (pérdida de semilla viable por triploidía estéril) — todas las matas son clones genéticos vulnerables a una sola plaga. Sigatoka negra (Mycosphaerella fijiensis) y Fusarium oxysporum f. sp. cubense raza 4 (Foc R4T) son amenazas globales. Manejo agroecológico: distancias 3x3 m a 4x4 m según variedad, sombrío con guamo en cafetal, deshije a 1 planta + 1 hijo + 1 nieto (cosecha continua), aplicación Trichoderma + bocashi al cuello del rizoma. Asocio multiestrato cafetero clásico.",
+      "feeding_plan_template": {
+        "source": "Agrosavia — Manual frutales tropicales + Cenicafé Manual cafetero (2013, asociación café-plátano). Plátano clima templado-cálido 0-1800 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al hoyo de siembra",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 1500,
+            "notes": "Hoyo 40x40x40 cm. Sembrar colino con yema hacia arriba. Plátano gran demandante de K y MO."
+          },
+          {
+            "offset_days": 30,
+            "action": "Inocular Trichoderma harzianum",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 20,
+            "notes": "Preventivo Fusarium oxysporum f.sp. cubense (Mal de Panamá) — amenaza principal del cultivo a nivel global."
+          },
+          {
+            "offset_days": 60,
+            "action": "Drench con biol al pie",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 1000,
+            "notes": "Dilución 1:5. Fase vegetativa activa — emisión de hojas verdaderas."
+          },
+          {
+            "offset_days": 120,
+            "action": "Foliar con supermagro fase reproductiva",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 80,
+            "notes": "Dilución 1:12. K y Mg críticos para llenado de racimo. Aportar también ceniza_madera al pie (100 g/planta)."
+          },
+          {
+            "offset_days": 180,
+            "action": "Refuerzo con bocashi pre-floración",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 1000,
+            "notes": "Aplicar en corona radicular antes de emisión de la inflorescencia (bellota)."
+          },
+          {
+            "offset_days": 240,
+            "action": "Foliar con caldo bordelés preventivo Sigatoka",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo Sigatoka negra (Mycosphaerella fijiensis) — aplicar cada 21 días en época lluviosa."
+          },
+          {
+            "offset_days": 330,
+            "action": "Drench con lixiviado de frutas durante llenado",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 200,
+            "notes": "Dilución 1:10. Llenado de racimo activo — cosecha esperada 360-390 días post-siembra."
+          }
+        ]
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "companions": [
+        "alocasia_macrorrhizos",
+        "borojoa_sorbilis",
+        "cajanus_cajan",
+        "canna_edulis",
+        "coffea_arabica",
+        "costus_spicatus",
+        "curcuma_longa",
+        "eryngium_foetidum",
+        "mammea_americana",
+        "manihot_esculenta",
+        "melicoccus_bijugatus",
+        "myrciaria_dubia",
+        "phaseolus_vulgaris",
+        "pouteria_caimito",
+        "renealmia_alpinia",
+        "selenicereus_megalanthus",
+        "solanum_sessiliflorum",
+        "spondias_dulcis",
+        "theobroma_bicolor",
+        "theobroma_cacao",
+        "theobroma_grandiflorum",
+        "vanilla_planifolia",
+        "zea_mays"
+      ],
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "Õre ingavrea"
+      ]
+    },
+    {
+      "id": "citrus_sinensis",
+      "nombre_comun": "Naranja",
+      "nombre_cientifico": "Citrus × sinensis (L.) Osbeck",
+      "familia_botanica": "Rutaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 400,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "tracking_mode": "individual",
+      "valor_pedagogico": "La naranja dulce (Citrus × sinensis, Rutaceae) es híbrido cítrico originario del sudeste asiático, cultivado en Colombia desde el siglo XVI, hoy concentrado en el Eje cafetero (Quindío, Risaralda, Caldas), Santander, Antioquia, Tolima, Llanos. Variedades comerciales: Valencia tardía (mayoría exportación), Salustiana, Washington Navel, Pera, Tangelo Minneola (híbrido con mandarina). Árbol perenne 5-10 m, copa redondeada densa, flores aromáticas blancas (azahar), frutos esférico-oblongos amarillo-naranja en madurez con piel lisa-rugosa. Reproducción por injerto en patrones (mandarina Cleopatra, Carrizo citrange, lima Rangpur — cada patrón confiere resistencia distinta). Lección agroecológica de adaptación tropical: la naranja colombiana NO sigue el ciclo estacional europeo, fructifica 8-10 meses al año debido al clima tropical bimodal. Manejo: distancia 7x7 m, sombrío inicial con guamo o plátano, fertilización con cuidado en Zn y Mg (deficiencias comunes con síntomas visibles). Plagas críticas: HLB (Huanglongbing) o citrus greening — sin cura, manejo preventivo del vector Diaphorina citri obligatorio.",
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "cultivar": false,
+      "companions": [
+        "eugenia_stipitata"
+      ]
+    },
+    {
+      "id": "acca_sellowiana",
+      "nombre_comun": "Feijoa / Guayabo del país",
+      "nombre_cientifico": "Acca sellowiana (O.Berg) Burret",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 13,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se propaga por semilla (plántula) o por estacas semi-leñosas. Reiere polinización cruzada."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El feijoa (Acca sellowiana) es un arbusto frutal perenne de la familia Myrtaceae, nativo de Sudamérica (sur de Brasil, Uruguay, Paraguay, Argentina), cultivado en Colombia para producción de frutos comestibles de aroma y sabor característicos. Se cultiva en Boyacá, Cundinamarca, Antioquia y Nariño entre 2.200 y 2.800 msnm en zona térmica fría. Los frutos son bayas verdes que maduran a amarillo-pálido, de pulpa gelatinosa aromática, ricos en vitamina C y yodo, se consumen frescos, en jugos, mermeladas y postres. Requiere polinización cruzada (variedades con diferente época de floración) para buena fructificación. En chagra campesina andina, se integra como cerca viva comestible y sombrío para cultivos de hoja. Lección viva: muestra la adaptación de especies exóticas a ecosistemas andinos colombianos, la importancia de la polinización cruzada en frutales, y el potencial de cercas vivas multiuso (producción + protección + biodiversidad). Fuentes: POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "vasconcellea_pubescens"
+      ]
+    },
+    {
+      "id": "cyclanthera_pedata",
+      "nombre_comun": "Pepinoillo / Caigua",
+      "nombre_cientifico": "Cyclanthera pedata (L.) Schrad.",
+      "familia_botanica": "Cucurbitaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa en sitio definitivo o almácigo con trasplante a los 30 días. Enredadora necesita tutorado."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El pepinoillo o caigua (Cyclanthera pedata) es una cucurbita trepadora anual nativa de los Andes, cultivada en chagras andinas colombianas por sus frutos verdes huecos que se consumen cocidos (rellenos, en sopas) o crudos en ensaladas. Se cultiva en Nariño, Boyacá y Cundinamarca entre 2.000 y 2.800 msnm. Planta trepadora vigorosa (2-4 m) que requiere tutorado (en caña guadua, estacas), produce frutos alargados verde claro que se cosechan inmaduros (15-20 cm) antes de que se pongan fibrosos. Asociación favorable con maíz (físico) y frijol (nitrogen_fixer). Lección: demuestra el uso vertical del espacio en chagras compactas, la importancia de las cucurbitáceas andinas alternativas al pepino comercial, y el valor de las trepadoras comestibles en optimización de área. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ],
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "Caigua"
+      ]
+    },
+    {
+      "id": "passiflora_tarminiana",
+      "nombre_comun": "Curuba india",
+      "nombre_cientifico": "Passiflora tarminiana Coppens & V.E.Barney",
+      "nombre_comunes_regionales": [
+        "curuba",
+        "curuba quiteña",
+        "curuba ecuatoriana",
+        "tacso",
+        "tacso amarillo",
+        "taxo",
+        "tumbo",
+        "curuba de monte"
+      ],
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 16,
+        "optimo_max": 20,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra en almácigo con trasplante a los 45 días. Requiere polinización cruzada (abejas grandes del género Xylocopa)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La curuba india (Passiflora tarminiana) es una pasiflora trepadora perenne cultivada en Colombia por sus frutos ovoides verde-amarillentos de pulpa ácida aromática, rica en vitamina A y C. Es el cultivo de pasifloras más importante del país después del maracuyá, con énfasis en producción de Huila, Boyacá, Cundinamarca y Antioquia entre 2.200 y 2.800 msnm en zona térmica templada. Planta vigorosa (5-8 m), requiere tutorado y podas de formación, producción de 15-20 kg/planta/año. Requiere polinización por abejorros grandes (Xylocopa), por lo que se recomienda conservar poblaciones de polinizadores nativos. Lección: enseña la importancia de la polinización entomófila en frutales andinos, el manejo de trepadoras perennes en sistemas productivos, y el papel de las pasifloras en seguridad alimentaria campesina. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "companions": [
+        "zea_mays"
+      ],
+      "antagonists": [
+        "solanum_tuberosum_sabanera"
+      ],
+      "cultivar": false
+    },
+    {
+      "id": "solanum_melongena",
+      "nombre_comun": "Berenjena",
+      "nombre_cientifico": "Solanum melongena L.",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 800,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Almácigo 45-60 días antes de trasplante. Sensible a bajas temperaturas (<10°C)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La berenjena (Solanum melongena) es una solanácea arbustiva anual cultivada por sus frutos berry grandes púrpura-negros de piel brillante, que se consumen cocidos (asados, rellenos, en curries). De origen asiático (India), se cultiva en Colombia en huertos caseros y producción escala pequeña en Cundinamarca, Boyacá y Antioquia entre 800 y 1.800 msnm. Planta de clima cálido a templado, sensible a frío, requiere suelos bien drenados y abono orgánico generoso. Asociación favorable con pimientos y ajo (repelentes), desfavorable con papa (comparten plagas). Lección: muestra la diversificación de hortalizas en chagra colombiana más allá de lo andino tradicional, el manejo de especies sensibles a frío, y el potencial de cultivos globales adaptados a contextos locales. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "allium_sativum"
+      ],
+      "antagonists": [
+        "annona_cherimola",
+        "solanum_phureja",
+        "solanum_tuberosum_sabanera"
+      ],
+      "cultivar": false
+    },
+    {
+      "id": "cucumis_sativus",
+      "nombre_comun": "Pepino cohombro",
+      "nombre_cientifico": "Cucumis sativus L.",
+      "familia_botanica": "Cucurbitaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 600,
+        "optimo_max": 1600,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa en sitio definitivo o almácigo con trasplante precoz (15-20 días). Requiere tutorado o suelo cubierto con mulch."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El pepino o cohombro (Cucumis sativus) es una cucurbita rastrera anual cultivada por sus frutos cilíndricos verdes de piel crujiente, que se consumen frescos (ensaladas) o encurtidos. De origen indio, se cultiva en Colombia en huertos caseros y producción comercial en Cundinamarca, Boyacá, Antioquia y Valle del Cauca entre 600 y 1.600 msnm. Planta de rápido crecimiento (50-70 días a cosecha), requiere alta humedad edáfica y riego constante, sensible a mildiú y oidio en época lluviosa. Asociación favorable con frijol (tutorado mutuo) y maíz (sombra parcial), desfavorable con papas y tomates (comparten enfermedades). Lección: enseña el manejo de cucurbitáceas de ciclo corto en chagra, la importancia del mulching para frutos en contacto con suelo, y la rotación de cultivos para evitar enfermedades de suelo. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "petroselinum_crispum",
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ],
+      "antagonists": [
+        "solanum_lycopersicum_san_marzano",
+        "solanum_tuberosum_sabanera"
+      ],
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "pepino",
+        "cohombro",
+        "pepino de ensalada"
+      ]
+    },
+    {
+      "id": "citrullus_lanatus",
+      "nombre_comun": "Patilla / Sandía",
+      "nombre_cientifico": "Citrullus lanatus (Thunb.) Matsum. & Nakai",
+      "familia_botanica": "Cucurbitaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1000,
+        "max_absoluto": 1400
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 40
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa en época de lluvia. Rastrero vigoroso que cubre mucho área (3-5 m por planta)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La patilla o sandía (Citrullus lanatus) es una cucurbita rastrera anual originaria de África, cultivada por sus frutos gigantes verdes (o rayados) de pulpa roja dulce, refrescante y diurética. En Colombia es cultivo comercial importante en la Atlántico, Magdalena, Tolima y Huila (200-1.000 msnm), y en huertos caseros de clima cálido. Planta de alta demanda hídrica, requiere riego constante en etapa de fructificación, tolera suelos moderadamente drenados. Requiere polinización por abejas (flores unisexuales, flores masculinas y femeninas separadas). Lección: enseña el cultivo de cucurbitáceas de gran tamaño en chagra tropical, la importancia de polinizadores en cucurbitáceas, y el manejo del riego para evitar frutos agrietados por estrés hídrico irregular. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "zea_mays"
+      ],
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "melón de agua"
+      ]
+    },
+    {
+      "id": "pouteria_caimito",
+      "nombre_comun": "Abiu / Caimito amarillo",
+      "nombre_cientifico": "Pouteria caimito (Ruiz & Pav.) Radlk.",
+      "familia_botanica": "Sapotaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 300,
+        "optimo_max": 1200,
+        "max_absoluto": 1600
+      },
+      "temperatura_c": {
+        "helada_letal": 3,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla recalcitrante (pierde viabilidad rápido). Siembra en sitio definitivo o bolsa con trasplante precoz (<3 meses)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El abiu o caimito amarillo (Pouteria caimito) es un árbol frutal perenne de la familia Sapotaceae, nativo de la Amazonía (Perú, Brasil, Colombia), cultivado por sus frutos dulces de pulpa cremosa amarilla, que se consumen frescos. En Colombia se cultiva en Amazonas, Caquetá, Putumayo y Guainía (0-1.200 msnm) como frutal de patio y en sistemas agroforestales amazónicos. Árbol mediano (10-20 m), de copa densa, fructificación 3-4 años desde semilla, producción estacional (noviembre-enero). Los frutos son bayas redondeadas amarillas de 5-10 cm, pulpa translúcida dulce (12-15°Brix), rica en calcio y fósforo. Lección: enseña el uso de frutales amazónicos en sistemas productivos diversificados, la importancia de las especies tardías (3-4 años) en planificación de chagra, y el valor de especies natives con potencial agroindustrial. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "ananas_comosus",
+        "borojoa_sorbilis",
+        "musa_paradisiaca",
+        "theobroma_grandiflorum"
+      ],
+      "nombre_comunes_regionales": [
+        "Caríca"
+      ]
+    },
+    {
+      "id": "myrciaria_dubia",
+      "nombre_comun": "Camu camu / Cari-cari",
+      "nombre_cientifico": "Myrciaria dubia (Kunth) McVaugh",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 500,
+        "max_absoluto": 800
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 24,
+        "optimo_max": 30,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "pantanoso",
+      "drenaje_requerido": "bajo",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla recalcitrante, requiere siembra inmediata. Planta amazónica tolerante inundaciones periódicas (várzea)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El camu camu (Myrciaria dubia) es un arbusto frutal amazónico de la familia Myrtaceae, nativo de la cuenca amazónica, famoso por sus frutos pequeños rojo-purpúreos con la mayor concentración de vitamina C del planeta (2-3 g/100g pulpa, 30-60 veces más que naranja). En Colombia crece silvestre en varzeas inundables del Amazonas, Putumayo y Caquetá (0-500 msnm), cosechado por poblaciones locales (ribereños) para venta fresca o procesada (pulpa congelada, jugo, cápsulas). Arbusto de 3-8 m, tolerante inundaciones estacionales (hasta 6 meses), producción 8-12 kg/planta/año. Fructificación silvestre (diciembre-abril) con cosecha de canoas. Actualmente en proceso de domesticación para cultivo comercial. Lección: muestra el valor de especies nativas silvestres con alto potencial nutricional, el manejo de cosecha en ecosistemas inundables amazónicos, y la domesticación incipiente de especies promisorias. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "musa_paradisiaca"
+      ]
+    },
+    {
+      "id": "garcinia_madruno",
+      "nombre_comun": "Charichuelo / Madroño",
+      "nombre_cientifico": "Garcinia madruno (Kunth) Hammel",
+      "familia_botanica": "Clusiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 300,
+        "optimo_max": 1200,
+        "max_absoluto": 1600
+      },
+      "temperatura_c": {
+        "helada_letal": 3,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla recalcitrante; siembra en sitio. Requiere sombra cuando joven; árbol de sotobosque que emerge al dosel."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El charichuelo o madroño (Garcinia madruno) es un árbol frutal de la familia Clusiaceae, nativo de América tropical (Amazonía, Andes, Centroamérica), que produce frutos amarillo-verdosos de 5-8 cm, pulpa blanco-amarillenta ácida-dulce, que se consumen frescos o en bebidas. Árbol de 15-30 m, de sotobosque, que requiere sombra cuando joven pero emerge al dosel adulto. Fructificación 8-10 años desde semilla (especie tardía), producción estacional (marzo-mayo). Madera usada en construcción. En chagra tradicional se usa como sombrío para café y cacao, y fuente de alimento de temporada. Lección: muestra la estrategia sucesional de especies forestales (sombra joven → dosel adulto), valor de árboles tardíos en planificación de chagra de largo plazo, y uso de natives en sistemas agroforestales. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivar": false,
+      "companions": [
+        "coffea_arabica"
+      ],
+      "nombre_comunes_regionales": [
+        "Madroño",
+        "charichuelo"
+      ]
+    },
+    {
+      "id": "pouteria_sapota",
+      "nombre_comun": "Zapote / Mamey zapote",
+      "nombre_cientifico": "Pouteria sapota (Jacq.) H.E.Moore & Stearn",
+      "familia_botanica": "Sapotaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivar": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 800,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 24,
+        "optimo_max": 30,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla recalcitrante; siembra en sitio. Árbol de 15-25 m; fructificación 4-6 años desde semilla."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El zapote o mamey zapote (Pouteria sapota) es un árbol frutal de la familia Sapotaceae, nativo de América tropical (México, Centroamérica, Cuba), cultivado en Colombia (Caribe, Magdalena, Santander) por sus frutos grandes marrón-rojizos de pulpa rojo-anaranjada dulce cremosa. Árbol de 15-25 m, copa densa, madera durable. Fruto de 10-20 cm, pulpa aromática, se consume fresco, en batidos, helados, postres. Rico en carotenoides (provitamina A), vitamina C, calcio. Fructificación 4-6 años desde semilla, producción estacional (mayo-julio). Lección: muestra introducción de frutales latinoamericanos a Colombia, valor de especies con alto contenido de carotenoides en seguridad alimentaria, y manejo de árboles de gran tamaño en chagra (requiere espacio). Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivable": true,
+      "companions": [
+        "borojoa_sorbilis"
+      ],
+      "nombre_comunes_regionales": [
+        "zapote",
+        "zapote mamey",
+        "Mamey zapote"
+      ]
+    },
+    {
+      "id": "raphanus_sativus_niger",
+      "nombre_comun": "Rábano blanco / Rábano picante",
+      "nombre_cientifico": "Raphanus sativus var. niger (DC.) G.J.Hagen",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa en camellones. Raíz tuberosa blanca/picante de 10-30 cm x 3-8 cm diámetro."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El rábano blanco o rábano picante (Raphanus sativus var. niger) es una brassica anual cultivada por su raíz tuberosa blanca de sabor picante, que se consume rallada (salsa, aderezo) o cocida. De origen mediterráneo, se cultiva en Colombia en huertos andinos de Boyacá, Cundinamarca y Nariño (1.800-2.800 msnm). Raíz de 10-30 cm, pulpa blanca, sabor picante por glucosinolatos (compuestos azufrados). Planta de 40-60 cm, hojas lobuladas, flores amarillas. Ciclo corto (50-70 días a cosecha). Asociación favorable con lechuga y zanahoria (cultivos acompañados), desfavorable con uvas (inhibe crecimiento). Lección: enseña uso de raíces picantes en gastronomía andina, propiedades anti-microbianas de glucosinolatos, y rotación de cultivos en brassicas (evitar repetir en mismo sitio por 2-3 años para prevenir plagas de suelo). Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "daucus_carota_subsp_sativus",
+        "lactuca_sativa_capitata"
+      ],
+      "cultivar": false
+    },
+    {
+      "id": "spinacia_oleracea",
+      "nombre_comun": "Espinaca",
+      "nombre_cientifico": "Spinacia oleracea L.",
+      "familia_botanica": "Amaranthaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa en surcos o almácigo con trasplante. Sensible a días largos (emite escapo floral)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La espinaca (Spinacia oleracea) es una planta herbácea anual de la familia Amaranthaceae, cultivada por sus hojas verdes ricas en hierro, vitamina K, ácido fólico y carotenoides. De origen persa (Irán), se cultiva en Colombia en huertos andinos de Boyacá, Cundinamarca y Antioquia (2.000-2.800 msnm). Planta de 20-30 cm, hojas verde-oscuro triangular-cordiformes, forma roseta basal. Cultivo de clima frío, sensible a calor (se 'espiga' o sube a flor en días largos >14h luz). Cosecha hoja por hoja o planta entera. Asociación favorable con fresas (comparten needs de frio), desfavorable con papas (compiten por nutrientes). Lección: muestra adaptación de especies de clima templado a contextos andinos, fenómeno de fotoperiodismo en plantas (espigamiento), y valor de hojas verdes en seguridad alimentaria. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "fragaria_ananassa_monterrey",
+        "petroselinum_crispum"
+      ],
+      "antagonists": [
+        "solanum_tuberosum_sabanera"
+      ],
+      "cultivar": false,
+      "nombre_comunes_regionales": [
+        "espinaca común"
+      ]
+    },
+    {
+      "id": "leucaena_leucocephala",
+      "nombre_comun": "Leucaena / Leucaena leucocephala",
+      "nombre_cientifico": "Leucaena leucocephala (Lam.) de Wit",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "biomass_producer",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1200,
+        "max_absoluto": 1600
+      },
+      "temperatura_c": {
+        "helada_letal": 3,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla dura (escarificación necesaria: agua caliente 80°C por 2 min). Arbusto 5-10 m, fijación N 200-300 kg/ha/año."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La leucaena (Leucaena leucocephala) es un arbusto leguminoso de rápido crecimiento, nativo de Centroamérica, usado mundialmente como fijadora de nitrógeno (200-300 kg/ha/año), productora de biomasa (10-15 t/ha/año), cerca viva, y forraje de alta calidad (20-25% proteína). En Colombia se cultiva en sistemas silvopastoriles de Córdoba, Sucre, Magdalena y Cundinamarca (0-1.200 msnm). Arbusto de 5-10 m, hojas compuestas bipinnadas, vainas con semillas planas. Fijación biológica de nitrógeno mediante Rhizobium (bacteria en nódulos raíz). Forraje: hojas y vainas comestibles para ganado bovino (alto consumo, buena digestibilidad). Cercas vivas: densidad 2.000-3.000 plantas/ha en setos. Potencial invasivo: se regula con pastoreo intenso o ramoneo (previene expansión). Lección: muestra leguminosas multifuncionales (fijación N + forraje + cerca), manejo de fijadoras biológicas de nitrógeno, y riesgo de especies exóticas que se naturalizan. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "borojoa_sorbilis"
+      ]
+    },
+    {
+      "id": "mucuna_pruriens",
+      "nombre_comun": "Mucuna / Pica pica",
+      "nombre_cientifico": "Mucuna pruriens (L.) DC.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "ground_cover",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 400,
+        "optimo_max": 1400,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla con pelos urticantes (handle con gloves). Trepadora vigorosa; biomasa 8-12 t/ha."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La mucuna o pica pica (Mucuna pruriens) es una leguminosa trepadora anual nativa de Asia y África, cultivada en Colombia como abono verde, forraje, y control nematodos. Planta de crecimiento rápido (2-3 m), hojas trifoliadas, flores púrpura/blancas, vainas peludas (pelos urticantes que causan picazón al contacto con piel). Semillas ricas en L-DOPA (fármaco para Parkinson), pero requieren procesamiento (remojo prolongado) para eliminar toxinas. Abono verde: produce 8-12 t/ha biomasa en 90-120 días, fija 150-200 kg/ha/año nitrógeno. Control nematodos: compuestos en raíz inhiben Meloidogyne spp. Forraje: hojas y vainas (no semillas) para ganado. Lección: muestra uso de leguminosas para manejo integrado de plagas (nematodos), procesamiento necesario para eliminar toxinas en semillas, y multifuncionalidad de abonos verdes. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "zea_mays"
+      ]
+    },
+    {
+      "id": "arachis_pintoi",
+      "nombre_comun": "Maní forrajero / Arachis pintoi",
+      "nombre_cientifico": "Arachis pintoi Krapov. & W.C.Greg.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 400,
+        "optimo_max": 1200,
+        "max_absoluto": 1600
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Rastrera estolonífera; excelente cobertura permanente (perenne). Fijación N 150-200 kg/ha/año."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El maní forrajero o Arachis pintoi es una leguminosa rastrera perenne nativa de Brasil (Matto Grosso), introducida en Colombia como cobertura permanente en pasturas, frutales, y cafetales. Planta estolonífera (estolones rastreros que echan raíces en nudos), hojas trifoliadas, flores amarillas subterráneas (geocarpía: frutos se desarrollan bajo suelo). Cobertura permanente: 2-3 años establecimiento, luego cobertura densa que suprime malezas. Fijación biológica de nitrógeno (150-200 kg/ha/año). Forraje: hojas comestibles para ganado (alto consumo, 14-16% proteína). Tolerna pastoreo, tránsito de maquinaria. Usada en pasturas asociadas (Brachiaria brizantha + Arachis pintoi). Lección: muestra leguminosas perennes de cobertura permanente, geocarpía (fructuación subterránea), y asociación gramíneas-leguminosas en pasturas. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "coffea_arabica",
+        "persea_americana"
+      ],
+      "nombre_comunes_regionales": [
+        "Maní forrajero"
+      ]
+    },
+    {
+      "id": "stylosanthes_guianensis",
+      "nombre_comun": "Estilosantes / Stylosanthes guianensis",
+      "nombre_cientifico": "Stylosanthes guianensis (Aubl.) Sw.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 400,
+        "optimo_max": 1200,
+        "max_absoluto": 1600
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Rastrera anual/perenne; extremadamente tolerante sequía y suelos ácidos pobres. Fijación N 80-120 kg/ha/año."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El estilosantes (Stylosanthes guianensis) es una leguminosa rastrera nativa de Sudamérica (Venezuela, Guyanas, Brasil), muy usada en Colombia como cobertura en pasturas y áreas marginales. Planta de 30-60 cm, hojas trifoliadas, flores amarillas pequeñas, vainas pequeñas con semillas. Especie extremadamente rústica: tolerante sequía (4-5 meses sin lluvia), suelos ácidos (pH 4.5-5.5), baja fertilidad. Fijación biológica de nitrógeno (80-120 kg/ha/año). Forraje: hojas comestibles para ganado (moderado consumo, 12-14% proteína). Cobertura: excelente para recuperación de áreas degradadas, suelos marginales. Lección: muestra uso de leguminosas rústicas en suelos marginales, adaptación a condiciones extremas (sequía, acidez), y recuperación de áreas degradadas. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "andropogon_gayanus",
+        "cocos_nucifera",
+        "mangifera_indica",
+        "melinis_minutiflora",
+        "setaria_sphacelata"
+      ]
+    },
+    {
+      "id": "eucalyptus_globulus",
+      "nombre_comun": "Eucalipto",
+      "nombre_cientifico": "Eucalyptus globulus Labill.",
+      "familia_botanica": "Myrtaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "estrato": "emergente",
+      "roles_in_guild": [
+        "windbreak",
+        "biomass_producer"
+      ],
+      "cultivar": false,
+      "conservation_status": "naturalizada",
+      "rol_restauracion": null,
+      "resistencia_fuego": null,
+      "apta_ribera": false,
+      "invasora_combustible": true,
+      "altitud_msnm": {
+        "min_absoluto": 1400,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Árbol 30-60 m; crecimiento extremadamente rápido (2-3 m/año). Alelopático (inhibe undergrowth)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El eucalipto (Eucalyptus globulus) es un árbol de la familia Myrtaceae, nativo de Australia y Tasmania, introducido en Colombia como especie forestal para producción de madera, leña, y aceite esencial. Árbol de 30-60 m, tronco recto, corteza lisa azul-grisácea que se desprende en tiras, hojas perennes lanceoladas aromáticas (aceite esencial con eucaliptol). Crecimiento extremadamente rápido (2-3 m/año en condiciones óptimas), madera duradera para construcción, leña de alto poder calorífico. Alelopático: compuestos volátiles inhiben crecimiento de vegetación bajo dosel (suelo desnudo debajo). Controversia: especie exótica de alto consumo hídrico (hasta 100 L/día árbol adulto), impacto en ciclos hidrológicos. En Colombia: plantaciones forestales en Cundinamarca, Boyacá, Antioquia. Lección: muestra especies forestales exóticas de rápido crecimiento, efecto alelopático, y controversy ambiental de introducción de especies foráneas. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivable": true,
+      "antagonists": [
+        "axinaea_macrophylla",
+        "clethra_fagifolia",
+        "clusia_grandiflora",
+        "clusia_multiflora",
+        "freziera_canescens",
+        "gaiadendron_punctatum",
+        "ilex_kunthiana",
+        "morella_pubescens",
+        "myrcianthes_ferreyrae",
+        "myrcianthes_rhopaloides",
+        "oreopanax_incisus",
+        "persea_americana",
+        "prumnopitys_montana",
+        "viburnum_tinoides",
+        "weinmannia_microphylla",
+        "weinmannia_pubescens",
+        "weinmannia_tomentosa"
+      ]
+    },
+    {
+      "id": "artemisia_absinthium",
+      "nombre_comun": "Ajenjo",
+      "nombre_cientifico": "Artemisia absinthium L.",
+      "familia_botanica": "Asteraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 1600,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Hierba perenne 0.5-1 m; aromática (absintina, tuyona). Tóxica en altas dosis (neurotóxica)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El ajenjo (Artemisia absinthium) es una hierba perenne aromática de la familia Asteraceae, nativa de Europa y Asia, usada tradicionalmente como medicinal y aromática. Planta de 0.5-1 m, hojas verde-grisáceas lobuladas, flores amarillas en paniculas, fuerte aroma amargo. Principios activos: absintina (amargor), tuyona (neurotóxica, tuya el 'absinto' alucinógeno). Usos tradicionales: digestivo (amargo), antiparasitario, estomacal. Tóxico en altas dosis: tuyona causa convulsiones, alucinaciones, la bebida 'absinta' prohibida en muchos países. Repelente de insectos: plantación en bordes de huertos repelen moscas, mosquitos. Lección: muestra uso de plantas medicinales con principio tóxico (dosis = veneno), aromáticas como repellentes, y tradición de licores medicinales. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "advertencia_toxicologica": "Tóxico en altas dosis. Tuyona es neurotóxica: convulsiones, alucinaciones, daño renal. No consumir en embarazo, lactancia, niños. No mezclar con alcohol (potencia efecto). Dosis segura: 1-2 tazas infusión/día máximo. Consultar profesional médico antes de uso medicinal.",
+      "cultivar": false,
+      "companions": [
+        "kalanchoe_pinnata"
+      ]
+    },
+    {
+      "id": "borago_officinalis",
+      "nombre_comun": "Borraja",
+      "nombre_cientifico": "Borago officinalis L.",
+      "familia_botanica": "Boraginaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 1400,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Hierba anual 0.3-0.6 m; flores azules comestibles. Semillas ricas en omega-6 (GLA)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La borraja (Borago officinalis) es una hierba anual de la familia Boraginaceae, nativa de Mediterráneo, cultivada como medicinal, culinaria y atrayente de polinizadores. Planta de 30-60 cm, hojas ovaladas pilosas (espinosas al tacto), flores azules enestrelladas muy vistosas (magnet para abejas). Principios activos: mucílagos (emoliente), ácidos grasos omega-6 (GLA) en semillas. Usos: flores en ensaladas (decorativo), infusiones de flores (diaforético), semillas en suplementos (GLA). Atrayente de polinizadores: abejas nativas y europeas visitan flores intensamente (néctar rico). Lección: muestra plantas atrayentes de polinizadores en chandra, uso culinario de flores comestibles, y semillas como fuente de omega-6. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "cultivar": false,
+      "companions": [
+        "mirabilis_expansa"
+      ]
+    },
+    {
+      "id": "albizia_guachapele",
+      "nombre_comun": "Guachapele",
+      "nombre_cientifico": "Albizia guachapele (Kunth) Dugand",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "emergente",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "living_fence",
+        "windbreak"
+      ],
+      "cultivar": false,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 400,
+        "optimo_max": 1200,
+        "max_absoluto": 1600
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Árbol 20-40 m; fijación N (150-200 kg/ha/año). Nativo Andes/Caribe colombiano."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El guachapele (Albizia guachapele) es un árbol leguminoso nativo de Colombia y los Andes, usado como sombrío en café/cacao, cerca viva y rompevientos. Árbol de 20-40 m (emergente), tronco grueso, copa extendida, hojas bipinnadas, flores blancas en cabezuelas globosas. Leguminosa fijadora de nitrógeno (150-200 kg/ha/año). Nativo: especie andina/caribeña protegida, importante en ecosistemas nativos. Sombrío: excelente para café y cacao (copa amplia, filtro luz). Madera: usada en construcción rural, leña. Tolerna sequía, suelos pobres. Cerca viva: densidad 1.500-2.000 plantas/ha. Lección: muestra árboles natives en agroforestería, especies emergentes en sistemas multiestrato, y leguminosas nativas vs exóticas. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivable": true,
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "gliricidia_sepium",
+        "pseudosamanea_guachapele",
+        "tabebuia_rosea"
+      ]
+    },
+    {
+      "id": "enterolobium_cyclocarpum",
+      "nombre_comun": "Orejero / Caro",
+      "nombre_cientifico": "Enterolobium cyclocarpum (Jacq.) Griseb.",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "emergente",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "living_fence",
+        "windbreak"
+      ],
+      "cultivar": false,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 300,
+        "optimo_max": 1000,
+        "max_absoluto": 1400
+      },
+      "temperatura_c": {
+        "helada_letal": 3,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Árbol 20-40 m; vainas orejudas (de ahí 'orejero'). Fijación N (150-200 kg/ha/año)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El orejero o caro (Enterolobium cyclocarpum) es un árbol leguminoso nativo de América tropical, desde México hasta Brasil, muy común en Colombia. Árbol de 20-40 m (emergente), tronco grueso, copa parasoliforme muy amplia, hojas bipinnadas, vainas curvadas grandes (10-15 cm) que parecen orejas (de ahí el nombre). Leguminosa fijadora de nitrógeno (150-200 kg/ha/año). Semillas: vainas contienen semillas grandes (3-5 cm) comestibles tostadas (proteína 25%). Sombrío: excelente para ganado (copa densa), café/cacao. Madera: usada en construcción rural. Tolerna sequía extrema, fuegos. Cerca viva: densidad 1.000-1.500 plantas/ha. Lección: muestra árboles emergentes en agroforestería, vainas comestibles, y adaptación a sequía/fuego. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivable": true,
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "gliricidia_sepium",
+        "pseudosamanea_guachapele",
+        "samanea_saman"
+      ],
+      "nombre_comunes_regionales": [
+        "Orejero"
+      ]
+    },
+    {
+      "id": "samanea_saman",
+      "nombre_comun": "Campano / Samán",
+      "nombre_cientifico": "Samanea saman (Jacq.) Merr.",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "emergente",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "windbreak",
+        "living_fence"
+      ],
+      "cultivar": false,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 300,
+        "optimo_max": 1000,
+        "max_absoluto": 1400
+      },
+      "temperatura_c": {
+        "helada_letal": 3,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Árbol 20-40 m; copa parasol inmensa (20-30 m diámetro). Fijación N (120-150 kg/ha/año)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El campano o samán (Samanea saman) es un árbol leguminoso nativo del norte de Sudamérica, introducido mundialmente como ornamental y sombrío. Árbol de 20-40 m, tronco corto, copa parasoliforme inmensa (20-30 m diámetro), hojas bipinnadas que se cierran noche/días lluviosos (nictinastia), flores rosadas en espigas, vainas largas (15-30 cm). Leguminosa fijadora de nitrógeno (120-150 kg/ha/año). Copa: sombrío denso para ganado, plazas, parques. Madera: usada en artesanía (tornería), leña. Tolerna sequía, suelos compactados. Árbol icónico en parques, plazas, haciendas. Lección: muestra nictinastia (movimiento foliar), árboles emblemáticos en paisaje cultural, y sombrío en sistemas ganaderos. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivable": true,
+      "companions": [
+        "ceiba_pentandra",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "enterolobium_cyclocarpum",
+        "gliricidia_sepium",
+        "tabebuia_rosea"
+      ],
+      "nombre_comunes_regionales": [
+        "Campano"
+      ]
+    },
+    {
+      "id": "tabebuia_rosea",
+      "nombre_comun": "Robo / Rosado",
+      "nombre_cientifico": "Tabebuia rosea (Bertol.) Bertero ex A.DC.",
+      "familia_botanica": "Bignoniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivar": false,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1400,
+        "optimo_max": 2200,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 16,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Árbol 20-30 m; flores rosadas (enero-marzo). Madera aserrada."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El robo o rosado (Tabebuia rosea) es un árbol nativo de América tropical, muy cultivado como ornamental y por su madera. Árbol de 20-30 m, tronco recto, corteza grisácea, hojas compuestas palmadas, flores rosadas grandes (enero-marzo), frutos en cápsulas leñosas alargadas. Ornamental: icónico en Bogotá (calle 100, parque 93), ciudades andinas. Flores: fuente de néctar para colibríes, abejas. Madera: aserrada, usada en construcción (techos, pisos), durable. Tolerna sequía, suelos pobres. Caducifolio: pierde hojas antes de floración (enero), flores en ramas desnudas. Lección: muestra árboles ornamentales nativos, uso dual (ornamental + madera), y floración caducifolia en época seca. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "cultivable": true,
+      "companions": [
+        "albizia_guachapele",
+        "bombacopsis_quinata",
+        "cassia_grandis",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "erythrina_edulis",
+        "inga_edulis",
+        "pseudosamanea_guachapele",
+        "samanea_saman",
+        "tabebuia_chrysantha"
+      ]
+    },
+    {
+      "id": "canavalia_ensiformis",
+      "nombre_comun": "Frijol canavalia",
+      "nombre_cientifico": "Canavalia ensiformis (L.) DC.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "ground_cover",
+        "biomass_producer"
+      ],
+      "cultivar": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 600,
+        "optimo_max": 1400,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Leguminosa anual 1-2 m; vainas grandes (10-30 cm). Fijación N 150-200 kg/ha/año."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El frijol canavalia (Canavalia ensiformis) es una leguminosa anual nativa de América tropical, muy usada como abono verde, cobertura y forraje. Planta de 1-2 m, trepadora rastrera, hojas trifoliadas, flores púrpura, vainas grandes (10-30 cm) con semillas blancas/rosadas. Leguminosa fijadora de nitrógeno (150-200 kg/ha/año). Abono verde: produce 5-8 t/ha biomasa en 90-120 días, incorpora antes de floración. Forraje: vainas y semillas requieren cocción (contienen tripsina inhibidor), hojas verdes comestibles para ganado. Cubierta: excelente supresión malezas, control erosión. Tolerna sequía, suelos pobres. Lección: muestra leguminosas anuales como abonos verdes, procesamiento para eliminar antinutricionales, y rotación con leguminosas. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "cultivable": true,
+      "companions": [
+        "zea_mays"
+      ]
+    },
+    {
+      "id": "vigna_unguiculata",
+      "nombre_comun": "Frijol caupí / Cowpea",
+      "nombre_cientifico": "Vigna unguiculata (L.) Walp.",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "ground_cover"
+      ],
+      "cultivar": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 600,
+        "optimo_max": 1400,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Leguminosa anual 0.3-1 m; vainas colgantes. Tolerante sequía, calor."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El frijol caupí o cowpea (Vigna unguiculata) es una leguminosa anual nativa de África, cultivada como grano seco y vaina tierna. Planta de 30-100 cm, rastrera o arbustiva, hojas trifoliadas, flores blancas/azuladas, vainas colgantes 15-30 cm. Cultivo de gran importancia en África (alimento básico), introducido a América colonial. Tolerante sequía extrema, calor, suelos pobres (ideal para clima cálido seco). Leguminosa fijadora de nitrógeno (80-120 kg/ha/año). Usos: grano seco (guisos, sopas), vaina tierna (ej. fríjol), forraje (hojas, tallos). Covertura: buena supresión malezas. Variedades: 'blackeyed pea' (ojo negro), 'crowder' (grano apretado). Lección: muestra leguminosas tolerantes sequía, cultivos africanos introducidos a América, y dualidad grano/vaina tierna. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "cultivable": true,
+      "companions": [
+        "hibiscus_sabdariffa"
+      ]
+    },
+    {
+      "id": "crotalaria_juncea",
+      "nombre_comun": "Crotalaria / Sunn hemp",
+      "nombre_cientifico": "Crotalaria juncea L.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "ground_cover",
+        "biomass_producer"
+      ],
+      "cultivar": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 600,
+        "optimo_max": 1400,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Leguminosa anual 1-2 m; flores amarillas. Tóxica (alcaloides pirrolizidínicos)."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La crotalaria o sunn hemp (Crotalaria juncea) es una leguminosa anual nativa de Asia/África, muy usada como abono verde y control nematodos. Planta de 1-2 m, hojas lanceoladas, flores amarillas en racimos, vainas infladas (globosas) con semillas. Leguminosa fijadora de nitrógeno (120-150 kg/ha/año). Biomasa: produce 8-12 t/ha en 60-90 días (crecimiento extremadamente rápido). Control nematodos: raíces liberan compuestos que inhiben Meloidogyne spp. (nematodos agalladores). Tóxica: contiene alcaloides pirrolizidínicos (hepatotóxicos), semillas y vainas no comestibles, follaje no recomendado para pastoreo (toxicidad hepática en ganado). Lección: muestra leguminosas tóxicas como abonos verdes, control biológico de nematodos, y toxicidad que limita uso forrajero. Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "advertencia_toxicologica": "Tóxica para ganado y humanos. Alcaloides pirrolizidínicos causan daño hepático crónico. No consumir semillas, vainas, follaje. Manejo: incorporar antes de floración (menor concentración alcaloides), usar solo como abono verde, no pastorear. Consultar profesional si se sospecha consumo accidental.",
+      "cultivable": true,
+      "companions": [
+        "zea_mays"
+      ]
+    },
+    {
+      "id": "avena_sativa",
+      "nombre_comun": "Avena / Avena sativa",
+      "nombre_cientifico": "Avena sativa L.",
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer",
+        "living_fence"
+      ],
+      "cultivar": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1400,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Gramínea anual 0.6-1.2 m; granos (avena). Follaje forraje."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La avena (Avena sativa) es una gramínea anual nativa de Eurasia, cultivada como grano (avena) y forraje. Planta de 60-120 cm, hojas planas, panículas abiertas, granos en espiguillas. Grano: rico en beta-glucanos (fibra soluble), proteína (12-15%), usado en avena, harinas, gachas. Forraje: follaje entero (hojas + tallos) henificado o pastoreado, apetecible para ganado. Cultivo de clima frío, muy tolerante suelos ácidos. Escala pequeña en Colombia (Boyacá, Cundinamarca, Nariño). Cubierta: buen mulch inverno. Lección: muestra cereales de clima frío, beta-glucanos en salud cardiovascular, y uso dual (grano + forraje). Fuentes: POWO Kew, GBIF.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "cultivable": true,
+      "companions": [
+        "brassica_rapa_rapifera",
+        "phacelia_tanacetifolia",
+        "raphanus_sativus_oleifer",
+        "trifolium_repens",
+        "vicia_faba",
+        "vicia_sativa"
+      ]
+    },
+    {
+      "id": "calamagrostis_effusa",
+      "nombre_comun": "Paja de páramo",
+      "nombre_cientifico": "Calamagrostis effusa (Kunth) Steud.",
+      "nombre_comunes_regionales": [
+        "Paja de cerro"
+      ],
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "ground_cover",
+        "nurse_plant"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2800,
+        "optimo_min": 3200,
+        "optimo_max": 3800,
+        "max_absoluto": 4200
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 4,
+        "optimo_max": 10,
+        "max_tolerable": 18
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "division_mata",
+        "notas": "Se recomienda propagar por macollas en la recuperación de áreas degradadas del páramo de Chingaza."
+      },
+      "companions": [
+        "quercus_humboldtii"
+      ],
+      "antagonists": [
+        "pennisetum_setaceum"
+      ],
+      "valor_pedagogico": "Calamagrostis effusa, conocida como paja de páramo, es una gramínea perenne fundamental en los ecosistemas de páramo andino colombiano, presente en departamentos como Cundinamarca, Boyacá, Norte de Santander y Nariño entre 2800 y 4200 msnm en zona térmica páramo. Su manejo agronómico incluye propagación vegetativa mediante división de matas, con ciclo de crecimiento lento adaptado a condiciones de baja temperatura y alta radiación UV. Establece asociaciones beneficiosas con especies como Quercus humboldtii (roble andino) en sistemas de recuperación ecológica, actuando como especie nurse que facilita el establecimiento de otras plantas nativas. En el contexto cultural muisca y andino, esta especie ha sido tradicionalmente utilizada por comunidades indígenas para tejer cubiertas de viviendas y como material de aislamiento térmico en chagras de altura, valorada por su capacidad de regulación hídrica y estabilización de suelos. Según las fuentes taxonómicas verificadas de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Calamagrostis effusa (Kunth) Steud.",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "nrc-1989-cultivos-andinos"
+      ],
+      "validation_level": "claude_draft",
+      "estrato": "bajo",
       "tracking_mode": "aggregate"
     },
     {
-      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_ARBOLES_TEMPLADO_RETRY",
+      "id": "solanum_tuberosum",
+      "nombre_comun": "Papa parda pastusa",
+      "nombre_comunes_regionales": [
+        "papa parda pastusa",
+        "papa parda",
+        "pastusa",
+        "papa común"
+      ],
+      "nombre_cientifico": "Solanum tuberosum L. subsp. andigenum var. parda pastusa",
+      "_anti_confusion": "Variedad parda pastusa de Solanum tuberosum. NO confundir con 'Pastusa Suprema' (cv. 'Pastusa Suprema', nodo solanum_tuberosum_pastusa_suprema — variedad industrial moderna distinta, NO tolera helada) ni con Diacol Capiro (solanum_tuberosum_diacol_capiro, andigena industrial sin tolerancia a helada).",
+      "familia_botanica": "Solanaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2400,
+        "optimo_min": 2600,
+        "optimo_max": 3300,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 8,
+        "optimo_max": 16,
+        "max_tolerable": 20
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -3,
+        "horas_acumuladas_max": 4,
+        "notas": "Tolera heladas moderadas → permite cotas más altas que pastusa suprema/diacol capiro. DR Gemini."
+      },
+      "propagation": {
+        "metodo_principal": "tuberculo (semilla asexual)",
+        "notas": "Tubérculo-semilla pre-brotado. Aporque obligatorio para tuberización."
+      },
+      "companions": [
+        "lupinus_mutabilis",
+        "pisum_sativum_andina",
+        "tropaeolum_tuberosum"
+      ],
+      "_nota_companions": "Asocio papa-arveja (DR Gemini): la papa es tutor físico de la arveja (evita volcamiento); ~21.000 ha/año, 65% de productores del altiplano.",
+      "enfermedades_criticas": [
+        "Phytophthora infestans",
+        "Trozador (Agrotis ipsilon)"
+      ],
+      "plagas_criticas": [
+        "Tecia solanivora",
+        "Phyllophaga spp."
+      ],
+      "feeding_plan_template": {
+        "source": "Agrosavia Manual tuberculos andinos (2017) + Perez-Rodriguez-Gomez (2008). Paridad base-variedad para papa; detalle operativo vive en variedades comerciales.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al surco",
+            "biofertilizer_slug": "bocashi"
+          },
+          {
+            "offset_days": 25,
+            "action": "Inocular Trichoderma harzianum al sustrato",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo"
+          },
+          {
+            "offset_days": 45,
+            "action": "Drench con humus liquido",
+            "biofertilizer_slug": "humus_liquido"
+          },
+          {
+            "offset_days": 60,
+            "action": "Foliar con biol en pre-tuberizacion",
+            "biofertilizer_slug": "biol"
+          },
+          {
+            "offset_days": 80,
+            "action": "Foliar con caldo bordeles preventivo",
+            "biofertilizer_slug": "caldo_bordeles"
+          },
+          {
+            "offset_days": 100,
+            "action": "Foliar con supermagro durante llenado",
+            "biofertilizer_slug": "supermagro"
+          }
+        ]
+      },
+      "valor_pedagogico": "La papa parda pastusa (Solanum tuberosum subsp. andigenum) es una variedad tradicional de mesa del altiplano frío colombiano (2600-3300 msnm) que, a diferencia de la Pastusa Suprema y la Diacol Capiro, TOLERA HELADAS MODERADAS y por eso se siembra en cotas más altas (DR Gemini 2026). Entra en el asocio clásico papa-arveja, donde la mata de papa actúa como tutor físico de la arveja erecta (Gorriona/Guatecaria), un sistema que cubre ~21.000 ha/año y al que recurre el 65% de los productores. Manejo agroecológico: rotación con haba/arveja (fijación de N), bocashi al surco, caldo bordelés preventivo para gota (Phytophthora infestans), monitoreo de polilla guatemalteca (Tecia solanivora) con feromonas. Confianza media: envolvente agroclimática provisional (Agrosavia, URL por verificar).",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "ica-resolucion-3168-2015"
+      ],
+      "tracking_mode": "aggregate",
+      "_agroclima_confianza": "media",
+      "_agroclima_url": "pendiente_verificar",
+      "_agroclima_verificado": false,
+      "_agroclima_batch": "agroclima-002",
+      "_agroclima_fuente": "Agrosavia (URL por verificar)",
+      "_agroclima_requiere_agua": "media",
+      "_agroclima_tolera_helada": "si",
+      "_agroclima_especie_jsonl": "papa parda pastusa"
+    },
+    {
+      "id": "hesperomeles_goudotiana",
+      "_curation_status": "VALIDADO con fuentes Humboldt + Bernal + POWO",
+      "nombre_comun": "Esmeralda chiquita",
+      "nombre_comunes_regionales": [
+        "esmeralda",
+        "mortiño de páramo"
+      ],
+      "nombre_cientifico": "Hesperomeles goudotiana (Decne.) Killip",
+      "familia_botanica": "Rosaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2500,
+        "optimo_min": 2800,
+        "optimo_max": 3400,
+        "max_absoluto": 3700
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 6,
+        "optimo_max": 14,
+        "max_tolerable": 20
+      },
+      "humedad_relativa_pct": {
+        "min": 65,
+        "optimo": 80,
+        "max": 95
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5,
+        "optimo_max": 6.5,
+        "max": 7
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Recoleccion de frutos maduros, extraccion de semillas y siembra inmediata en semillero con sustrato de bosque. Germinacion en 30-60 dias.",
+        "tiempo_a_establecimiento_dias": 90,
+        "notas": "Crece en sotobosque de bosque alto andino. Atraccion de aves dispersoras facilita regeneracion natural."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia",
+        "libro-rojo-plantas-colombia"
+      ],
+      "valor_pedagogico": "La esmeralda chiquita o mortiño de monte (Hesperomeles goudotiana (Decne.) Killip, familia Rosaceae) es una rosácea arbustiva a arbórea pequeña perenne (3-8 m altura) nativa endémica del bosque altoandino y subpáramo colombiano, considerada especie clave de la transición ecotono bosque-páramo. Produce hojas coriáceas brillantes ovaladas, racimos de flores blancas pentámeras y frutos pequeños globosos rojos a negro-violáceos (5-8 mm) carnosos. Se distribuye en cordilleras Oriental y Central colombianas: Cundinamarca (Cruz Verde, Sumapaz, Chingaza), Boyacá (Páramo de la Rusia, El Cocuy), Nariño (Volcán Galeras), Cauca (Macizo Colombiano) y Antioquia (Páramo de Belmira) entre 2.800 y 3.400 msnm en zona térmica fría a páramo bajo. Ciclo perenne, longevidad 30-50 años, floración bianual. Cultivable no recomendado, especie silvestre protegida bajo categoría Vulnerable UICN regional y Resoluciones MADS de páramos. Lección viva ecosistémica: pequeño árbol nativo del bosque alto andino y subpáramo, sus frutos rojos alimentan aves dispersoras del bosque de niebla (Catharus ustulatus, Turdus fuscater, Anisognathus igniventris, Conirostrum cinereum), siendo especie ideal para enseñar la conectividad ecológica entre bosque andino y páramo, su rol en la cadena trófica de dispersión zoócora y la importancia de los relictos arbóreos altoandinos en la regulación hídrica y captura de carbono. Manejo agroecológico: aprovechamiento únicamente por restauración ecológica activa con propagación por semilla (estratificación fría 2 meses) o esqueje semileñoso, asocio con encenillos (Weinmannia tomentosa), arrayanes (Myrcianthes leucoxyla) y romeros de páramo (Diplostephium spp.), prohibida tala con fines comerciales. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, Humboldt Flora Alto-Andina, Bernal 2015 Catálogo Plantas Colombia, SIB Colombia.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "companions": [
+        "gaiadendron_punctatum",
+        "ilex_kunthiana",
+        "myrcianthes_rhopaloides",
+        "oreopanax_incisus",
+        "viburnum_tinoides"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "tibouchina_lepidota",
+      "nombre_comun": "Siete cueros",
+      "nombre_comunes_regionales": [
+        "sietecueros",
+        "siete cueros real",
+        "flor de mayo andino"
+      ],
+      "nombre_cientifico": "Tibouchina lepidota (Bonpl.) Baill.",
+      "familia_botanica": "Melastomataceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3400
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-flora-alto-andina",
+        "jbb-plantas-medicinales",
+        "restauracion-cruz-verde-sumapaz",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "El siete cueros (Tibouchina lepidota (Bonpl.) Baill., Melastomataceae) es un arbolito o arbusto andino nativo (4-12 m altura) emblemático del bosque alto-andino colombiano entre 2.200 y 3.000 msnm, propio de Cundinamarca (cerros orientales de Bogotá, Cruz Verde, Sumapaz, Chingaza, Verjón), Boyacá (Iguaque, Pisba), Antioquia (San Félix, Belmira), Tolima, Caldas y Nariño. Su nombre alude a las siete capas de corteza papirácea que se desprenden con la edad. Hojas elípticas de nervadura paralela característica (3-5 nervios convergentes), flores grandes (5-8 cm) púrpura-violeta intenso que florecen en panículas terminales casi todo el año, atrayendo abejorros nativos (Bombus rubicundus, B. funebris), abejas sin aguijón y avispas polinizadoras. Es lección viva de restauración ecológica y soberanía botánica que enseña a niñas y niños por qué las especies nativas son la mejor estrategia para revegetar laderas degradadas del altoandino: a diferencia del eucalipto (Eucalyptus globulus) y pino pátula (Pinus patula), introducidas que acidifican y desecan suelos de páramo, el siete cueros estabiliza taludes con su raíz pivotante, alimenta polinizadores nativos, genera hojarasca compatible con los hongos micorrízicos andinos y sucesionaliza bosque secundario. Por eso aparece como especie prioritaria en planes de restauración ecológica de los páramos Cruz Verde-Sumapaz (IAvH + CAR Cundinamarca 2018) y en los corredores de conservación del Distrito Capital. Manejo agroecológico: propagación por semilla (germinación 30-60 días, requiere luz) o esqueje semileñoso bajo cámara húmeda, vivero 8-12 meses antes de trasplante en lluvias (abril-mayo, octubre-noviembre), distancia 3-5 m, tolera podas formativas, función ecológica como planta niñera (nurse plant) que protege plántulas de sucesión tardía y como árbol melífero clave. Fuentes Tier A: GBIF Backbone Taxonomy, POWO Kew, Bernal 2015 Catálogo Plantas y Líquenes de Colombia, IAvH Flora Alto Andina, JBB Plantas Medicinales, Plan Restauración Cruz Verde-Sumapaz, SiB Colombia.",
+      "tracking_mode": "individual",
+      "companions": [
+        "escallonia_pendula"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "myrcianthes_leucoxyla",
+      "nombre_comun": "Arrayán de Bogotá",
+      "nombre_comunes_regionales": [
+        "arrayán blanco",
+        "arrayán andino",
+        "arrayán de Cundinamarca"
+      ],
+      "nombre_cientifico": "Myrcianthes leucoxyla (Ortega) McVaugh",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2500,
+        "optimo_max": 3200,
+        "max_absoluto": 3500
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-flora-alto-andina",
+        "jbb-plantas-medicinales",
+        "restauracion-cruz-verde-sumapaz",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "El arrayán de Bogotá (Myrcianthes leucoxyla (Ortega) McVaugh, Myrtaceae) es un árbol andino nativo emblemático del bosque alto-andino colombiano (8-15 m altura, hasta 25 m en bosques maduros bien conservados) entre 2.500 y 3.200 msnm, presente en Cundinamarca (cerros orientales de Bogotá, Cruz Verde, Sumapaz, Chingaza, Verjón, Guasca, La Calera), Boyacá (Iguaque, Arcabuco, Tota), Santander, Tolima y Nariño. Es árbol patrimonial del Distrito Capital y especie protegida por la Resolución 1923 de 2017 (SDA-Bogotá) que prohíbe su tala salvo emergencia fitosanitaria. Corteza rojiza-anaranjada papirácea característica que se desprende en placas, hojas pequeñas ovales lustrosas aromáticas (aceites esenciales con eucaliptol), flores blancas con muchos estambres dorados que atraen abejas (excelente meliferal) y otros polinizadores, frutos en baya pequeña púrpura-negro comestible (sabor dulce-aromático, alto en taninos, antioxidantes). Es lección viva de soberanía botánica y restauración ecológica que enseña a niñas y niños por qué los árboles patrimoniales nativos son irreemplazables: a diferencia del eucalipto y pino pátula introducidos que acidifican suelos paramunos y dan sombra estéril, el arrayán de Bogotá fue el dosel original de los bosques de la Sabana, alberga avifauna nativa (mirla, cucarachero, copetón, tángaras), genera hojarasca compatible con suelos andinos y produce frutos comestibles que pueden integrarse a chagra agroforestal. Por eso es especie prioritaria en planes de restauración Cruz Verde-Sumapaz (IAvH + CAR) y en programas de arborización urbana de Bogotá. Manejo agroecológico: propagación por semilla recién recolectada (germinación 40-90 días, no tolera deshidratación), vivero 12-18 meses antes de trasplante en lluvias, distancia 4-6 m en agroforestería o cerca viva alta, fructificación a partir de 6-8 años, función como árbol multifuncional (sombra, frutal, melífero, nurse plant, patrimonio). Fuentes Tier A: GBIF, POWO Kew, Bernal 2015, IAvH Flora Alto Andina, JBB Plantas Medicinales, Plan Restauración Cruz Verde-Sumapaz, SiB Colombia.",
+      "tracking_mode": "individual",
+      "companions": [
+        "myrcia_popayanensis",
+        "myrsine_coriacea"
+      ]
+    },
+    {
+      "id": "solanum_tuberosum_carrera_negra",
+      "nombre_comun": "Papa Negra Carrera",
+      "nombre_comunes_regionales": [
+        "papa carrera",
+        "papa negra",
+        "papa carrera negra",
+        "papa morada de altura"
+      ],
+      "nombre_cientifico": "Solanum tuberosum L. subsp. andigenum cv. 'Carrera Negra'",
+      "familia_botanica": "Solanaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 2400,
+        "optimo_min": 2800,
+        "optimo_max": 3400,
+        "max_absoluto": 3700
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 7,
+        "optimo_max": 15,
+        "max_tolerable": 20
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo (semilla asexual)",
+        "notas": "Variedad nativa altoandina de piel oscura morado-negruzca y carne amarilla intensa. Ciclo largo de 6-8 meses, propia de zona fría y bordes de páramo. Tolera heladas moderadas y suelos pobres mejor que variedades comerciales. Resiembra con tubérculos pequeños (chumas) seleccionados de la cosecha anterior, dormancia natural 2-3 meses."
+      },
+      "source_ids": [
+        "perez-rodriguez-gomez-2008",
+        "nustez-rodriguez-2024-unal",
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "cip-2006-ghislain",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La papa negra carrera (Solanum tuberosum L. subsp. andigenum cv. 'Carrera Negra') es una variedad nativa andina del altiplano colombiano, cultivada principalmente en Cundinamarca (Sumapaz, Une, Choachí, Carmen de Carupa), Boyacá (Toca, Siachoque, Aquitania, páramo de Pisba) y Nariño (Túquerres, Guachucal, Cumbal) entre 2.800 y 3.400 msnm, llegando a bordes de páramo a 3.700 msnm. Pertenece al grupo Andigenum, distinto del grupo Tuberosum europeo: tubérculos pequeños a medianos (40-120 g) de piel violeta oscuro casi negra, ojos profundos pigmentados y carne amarilla intensa rica en antocianinas y carotenoides. Es lección viva de soberanía alimentaria y resistencia genética: las variedades nativas Andigenum coevolucionaron por miles de años en suelos andinos con manejo campesino, conservando rusticidad frente a heladas, granizadas y suelos pobres donde la papa comercial (pastusa, parda) sucumbe. La carrera negra resiste mejor el tizón tardío (Phytophthora infestans) que las variedades industriales, requiere menos fertilización sintética y se conserva 4-6 meses post-cosecha sin refrigeración por su piel gruesa. Manejo agroecológico: rotación trienal con haba (Vicia faba), arveja andina (Pisum sativum) o cubio (Tropaeolum tuberosum); siembra al inicio de lluvias mayores (marzo-abril) o lluvias menores (septiembre-octubre); distancia 30 cm x 90 cm; aporque a los 60-90 días; biopreparados sugeridos: caldo bordelés diluido contra tizón, sulfocalcio contra polilla guatemalteca (Tecia solanivora), trichoderma al surco. Conservación de semilla en cuartos oscuros ventilados con paja seca de cebada. Conservar y multiplicar variedades como la carrera negra es un acto político-ecológico que niños y niñas pueden entender: cada tubérculo es un eslabón de memoria campesina que el mercado global no puede patentar. Fuentes Tier A: Pérez-Rodríguez-Gómez 2008, Núñez-Rodríguez 2024 UNAL, AGROSAVIA Manual Tubérculos Andinos 2017, CIP 2006 Ghislain, GBIF Backbone, POWO Kew.",
+      "antagonists": [
+        "juglans_neotropica"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "chenopodium_pallidicaule",
+      "nombre_comun": "Kañiwa",
+      "nombre_comunes_regionales": [
+        "kañihua",
+        "cañihua",
+        "kaniwa",
+        "cañahua",
+        "isualla"
+      ],
+      "nombre_cientifico": "Chenopodium pallidicaule Aellen",
+      "familia_botanica": "Amaranthaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 3000,
+        "optimo_min": 3500,
+        "optimo_max": 4200,
+        "max_absoluto": 4500
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 5,
+        "optimo_max": 14,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Pseudocereal sagrado del altiplano puneño-boliviano, sembrado entre 3.500 y 4.200 msnm donde ningún otro grano prospera. Ciclo corto a medio (4-6 meses), tolera heladas hasta -8°C, granizo, sequía y suelos salinos del altiplano. Reintroducido en Nariño (Cumbal, Túquerres) y Boyacá (páramo de Rabanal, Pisba) en proyectos de rescate andino. Semilla muy menuda (1 mm). Siembra al voleo poco enterrada (0.5-1 cm). Cosecha por arranque manual de la planta entera y trilla por golpeo."
+      },
+      "source_ids": [
+        "nrc-1989-cultivos-andinos",
+        "fao-2013-quinua",
+        "mujica-1992-quinua",
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La kañiwa (Chenopodium pallidicaule Aellen, Amaranthaceae) es el pseudocereal más altitudinal del mundo y uno de los 'granos sagrados' del altiplano andino, cultivado entre 3.500 y 4.200 msnm en el altiplano peruano-boliviano (departamentos de Puno, La Paz, Oruro, Potosí) y reintroducido en zonas altoandinas de Nariño (Cumbal, Túquerres, páramo del Galeras) y Boyacá (páramo de Rabanal, Pisba) en proyectos de rescate de granos andinos. Es pariente cercano de la quinua (Chenopodium quinoa) pero más rústico, más pequeño (planta erecta de 30-70 cm vs. 1.5-2 m de la quinua), más resistente a heladas (-8°C vs. -4°C de la quinua), libre de saponinas (no requiere lavado pre-cocción a diferencia de la quinua), y de ciclo más corto (4-6 meses vs. 6-8 meses). Semilla menudita (1 mm) marrón oscuro a negruzca, con perfil nutricional excepcional: proteína 14-19% con aminoácidos esenciales completos (incluida lisina), alto contenido de hierro, calcio, magnesio y zinc, libre de gluten. Es lección viva de adaptación extrema y soberanía alimentaria altoandina: la kañiwa es el último cultivo viable en el límite altitudinal donde quinua, papa amarga (Solanum juzepczukii) y mauka apenas sobreviven, y para los pueblos Aimara y Quechua del altiplano fue por milenios el seguro alimentario contra las heladas que destruían los demás cultivos. NRC 1989 la incluyó en su lista de cultivos andinos perdidos a rescatar, y desde entonces FAO, INIA-Perú y AGROSAVIA-Colombia han impulsado su recuperación. Usos: pito de kañiwa (harina tostada en agua o leche, base proteica del desayuno altiplánico), galletas, panes integrales, mazamorras. Manejo agroecológico: siembra al voleo al inicio de lluvias del altiplano (octubre-noviembre); poca tapada (0.5-1 cm); tolera suelos pobres, salinos y ácidos; biopreparados: caldo de ceniza contra mildiu (Peronospora variabilis); cosecha por arranque manual de la planta entera, secado en parva, trilla por golpeo o pisoteo sobre lona. Conservación de semilla en cántaros de arcilla con ceniza. Fuentes Tier A: NRC 1989 Cultivos Andinos, FAO 2013 Quinua y andinos, Mujica 1992 Quinua y andinos, Pérez Arbeláez 1947, GBIF Backbone, POWO Kew.",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "lepidium_meyenii"
+      ]
+    },
+    {
+      "id": "viola_tricolor",
+      "nombre_comun": "Pensamiento / Trinitaria",
+      "nombre_cientifico": "Viola tricolor L.",
+      "nombre_comunes_regionales": [
+        "Pensamiento silvestre",
+        "Hierba de la trinidad",
+        "Pensativa"
+      ],
+      "familia_botanica": "Violaceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3300
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra en semillero, germinación 10-20 días a 15-18°C, trasplante 4-6 semanas, distancia 15-20 cm. Auto-resiembra natural en jardines de clima frío. Floración 60-90 días post-siembra."
+      },
+      "companions": [
+        "allium_schoenoprasum",
+        "fragaria_vesca"
+      ],
+      "harvest_type": "flor",
+      "scale_viability": [
+        "apartamento",
+        "huerto_casero",
+        "produccion"
+      ],
+      "valor_pedagogico": "El Pensamiento o Trinitaria (Viola tricolor L., Violaceae) es una especie herbácea anual o bienal originaria de Europa templada (regiones boreales hasta el Mediterráneo) y naturalizada-cultivada mundialmente como ornamental clásico de jardín, con la característica adicional de tener flores comestibles ampliamente usadas en gastronomía decorativa de alta gama. En Colombia se cultiva en clima frío y de páramo entre 2.000 y 3.300 msnm: Sabana de Bogotá, Boyacá altoandino, Nariño altoandino, Cundinamarca rural, Antioquia oriente frío, viveros y jardines de Tunja, Manizales, Pasto. Manejo agronómico: siembra en semillero protegido con sustrato bien drenado, germinación 10-20 días a temperatura 15-18°C, trasplante al sitio definitivo 4-6 semanas post-germinación con distancia 15-20 cm entre plantas, floración inicia 60-90 días post-siembra y se mantiene 4-6 meses continuos si se eliminan flores marchitas (deadheading). Florece masivamente en clima frío (10-20°C) con tolerancia a heladas leves de -5 a -8°C: especie ideal para jardín y huerta de páramo. Sus flores presentan el característico patrón tricolor (violeta, amarillo, blanco; de ahí el epíteto específico tricolor) y son comestibles crudas en ensaladas, decoración de tortas, repostería fina, gelatinas, té de flor, cubitos de hielo florales para cócteles, vinagretas perfumadas. Sabor suave, ligeramente dulce y herbáceo, textura aterciopelada delicada. Atracción de polinizadores: abejas pequeñas (Apis mellifera, Bombus spp.), mariposas (varias especies de Pieridae y Nymphalidae que la usan como planta hospedera para oviposición de larvas), sírfidos y abejorros nativos andinos. Uso medicinal tradicional documentado en farmacopeas europeas: flor seca infusión expectorante suave, diurética leve, depurativo sanguíneo tradicional (\"hierba de la trinidad\" por la triple coloración floral simbólica), uso en cosmética (mucílagos para pieles sensibles). Su pariente cultivado moderno Viola × wittrockiana (pensamiento de jardín) es híbrido del siglo XIX derivado en parte de V. tricolor con flores más grandes y multicolores. Manejo en huerta agroecológica: borde y franja perimetral de hortalizas como atrayente de polinizadores en clima frío, asociación con fresa (Fragaria vesca) y cebollín (Allium schoenoprasum), siembra en macetera vertical o jardín de balcón en apartamento bogotano (escala apartamento viable), cosecha de flores en mañana fresca para uso culinario inmediato. Auto-resiembra natural: en jardines bien manejados se naturaliza y reaparece año tras año sin intervención. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pamplona Roger 2006 Plantas Medicinales, JBB Plantas Medicinales.",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "lepidium_meyenii",
+      "nombre_comun": "Maca",
+      "nombre_comunes_regionales": [
+        "maca andina",
+        "maca peruana",
+        "ginseng andino",
+        "maca-maca",
+        "ayak chichira"
+      ],
+      "nombre_cientifico": "Lepidium meyenii Walp.",
+      "familia_botanica": "Brassicaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 3500,
+        "optimo_min": 3800,
+        "optimo_max": 4400,
+        "max_absoluto": 4500
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 4,
+        "optimo_max": 12,
+        "max_tolerable": 18
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Brasicácea de altiplano extremo (Meseta del Bombón, Junín-Pasco-Perú 4000-4500 msnm) — la planta cultivada a mayor altitud del mundo. Raíz pivotante tuberosa (5-8 cm diámetro) que se cosecha tras 7-9 meses. Tras cosecha, se asoliea durante 3-5 días para concentrar nutrientes y obtener 'maca seca' (forma comercial). Variedades por color: amarilla (común, energizante), roja (próstata, antioxidante), negra (memoria, fertilidad masculina), morada. En Colombia introducción experimental en altiplano cundiboyacense alto y Nariño-Putumayo páramos altos."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "nrc-1989-cultivos-andinos",
+        "fao-ecocrop",
+        "agrosavia-manual-tuberculos-andinos-2017"
+      ],
+      "valor_pedagogico": "La maca andina (Lepidium meyenii Walp., familia Brassicaceae) es una brasicácea altoandina de raíz tuberosa pivotante (4-8 cm diámetro, 50-200 g peso fresco) considerada la planta cultivada a mayor altitud del mundo — domesticada hace 2.000-2.500 años en la Meseta del Bombón (departamentos de Junín y Pasco, Perú central) entre 4.000-4.500 msnm, en condiciones climáticas que ninguna otra especie cultivada tolera: heladas nocturnas constantes (hasta -10°C), radiación UV extrema, vientos secos, suelos pobres ácidos volcánicos, oxígeno reducido (puna alta). En Colombia ha sido introducida experimentalmente desde 2010-2015 por AGROSAVIA y la Universidad Nacional sede Bogotá-Tibaitatá en altiplanos altos de Cundinamarca (Sumapaz, Chingaza, Cruz Verde, Iguaque-Boyacá), Boyacá (páramo de Pisba, Cocuy), Nariño (páramo de Las Ovejas, Chiles-Cumbal, La Cocha), Putumayo (páramos altos del Bordoncillo) y Cauca (páramo de Las Delicias, Sotará) entre 3.500-4.500 msnm como cultivo de altiplano frío extremo donde la papa criolla y la quinua ya no prosperan. Lección viva de adaptación extrema y bioquímica adaptógena: la maca es ejemplo magistral de cómo una crucífera (la misma familia botánica del repollo, la mostaza y el rábano) evolucionó hacia la altiplanicie altoandina extrema mediante acumulación en raíz de glucosinolatos andinos específicos (macamida, macaeno), alcaloides macaridina y N-bencil-amidas únicas a esta especie, y maca-glúcidos prebióticos, compuestos asociados a propiedades adaptógenas, energizantes, balanceadoras hormonales y mejoradoras de fertilidad humana (efectos documentados en estudios clínicos peruanos modernos). Existen variedades tradicionales clasificadas por color de raíz: maca amarilla (la más común, ~60% producción, energizante general), maca roja (preferida en estudios clínicos de próstata, antioxidante por betalaínas), maca negra (memoria, fertilidad masculina, libido), maca morada (intermedia). La maca recién cosechada NO se consume — debe asolearse durante 3-5 días al sol andino fuerte para concentrar fitoquímicos, deshidratar parcialmente y eliminar glucosinolatos indeseables, obteniendo 'maca seca' (forma comercial tradicional), de la cual se prepara harina, mazamorra, infusión, gelatinizado o licor andino. Manejo agroecológico: propagación por semilla, siembra al voleo o en surcos a 5-10 cm entre plantas en parcelas pequeñas de altiplano (en Junín-Perú se rotan parcelas cada 7-10 años para regeneración del suelo, un caso clásico de 'descanso largo' andino), ciclo 7-9 meses, rendimientos 5-15 t/ha raíz fresca o 1-3 t/ha raíz seca. Asocio con quinua, cañihua, papa amarga (Solanum juzepczukii), oca y olluco. Cultivo de soberanía alimentaria andina con potencial agrocomercial alto para Colombia altoandina como alternativa a la coca en zonas altas. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, NRC 1989 Lost Crops of the Incas, FAO EcoCrop, AGROSAVIA Manual Tubérculos Andinos 2017.",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "chenopodium_pallidicaule",
+        "oxalis_tuberosa",
+        "ullucus_tuberosus"
+      ]
+    },
+    {
+      "id": "acacia_melanoxylon",
+      "nombre_comun": "Acacia negra",
+      "nombre_cientifico": "Acacia melanoxylon R. Br.",
+      "familia_botanica": "Fabaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "invasive",
+        "nitrogen_fixer"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Rebrote agresivo desde la raíz post-tala; requiere control de tocones."
+      },
+      "antagonists": [
+        "viburnum_triphyllum"
+      ],
+      "especies_nativas_sustitutas": [
+        "alnus_acuminata",
+        "hesperomeles_goudotiana",
+        "vallea_stipularis",
+        "viburnum_triphyllum",
+        "weinmannia_tomentosa"
+      ],
+      "source_ids": [
+        "calderon-saenz-2003-invasoras",
+        "res-684-2018-mads",
+        "humboldt-invasoras-andes",
+        "issg-uicn-invasoras",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "SE BUSCA: El 'Rebrotador Invencible'. La acacia negra australiana (Acacia melanoxylon R.Br., familia Fabaceae) es una especie introducida en programas de reforestación del siglo XX que se naturalizó como invasora agresiva de bordes de bosque andino y zonas de páramo intervenido en Colombia. Se distribuye en Cundinamarca (Sumapaz, Chingaza), Boyacá, Antioquia, Santander y Eje cafetero entre 2.000 y 3.300 msnm. Árbol perenne 8-25 m altura que asfixia regeneración nativa por sombra densa, alelopatía (fenoles del rebrote) y banco de semillas longevo. Rebrota vigorosamente de raíz tras corte. Estrategia agroecológica de manejo: descortezamiento en anillo (ring-barking) + monitoreo bianual rebrote + sustitución progresiva por Alnus acuminata (aliso andino fijador de N, sí nativo). Listada en Res. 684/2018 MADS como invasora declarada. Fuentes Tier A: Calderón Sáenz 2003 Invasoras Colombia, Resolución 684/2018 MADS, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "allium_ampeloprasum",
+      "nombre_comun": "Cebolla puerro",
+      "nombre_cientifico": "Allium ampeloprasum var. porrum (L.) J. Gay",
+      "familia_botanica": "Amaryllidaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 13,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere trasplante profundo para favorecer el 'blanqueado' del tallo."
+      },
+      "antagonists": [
+        "phaseolus_vulgaris"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El puerro (Allium ampeloprasum var. porrum) se cultiva en los departamentos andinos de Colombia como Cundinamarca y Boyacá entre 500 y 3400 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla con trasplante profundo para favorecer el 'blanqueado' del tallo, ciclo vegetativo de 150-180 días, asociaciones beneficiosas con zanahoria y fresa que mejoran la salud del huerto, y requiere manejo de plagas como trips y minadores de hojas mediante monitoreo frecuente y biopreparados andinos. En el contexto campesino andino, esta verdura ha sido tradicionalmente utilizada en sopros y guisos como ingrediente esencial, preservando sabores prehispánicos en las cocinas rurales. Según el inventario taxonómico de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Allium ampeloprasum var. porrum (L.) J. Gay.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "puerro",
+        "ajo porro",
+        "poro"
+      ]
+    },
+    {
+      "id": "alocasia_macrorrhizos",
+      "nombre_comun": "Bore",
+      "nombre_cientifico": "Alocasia macrorrhizos (L.) G.Don",
+      "familia_botanica": "Araceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 400,
+        "max_absoluto": 800
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "tuberculo",
+        "notas": "Se propaga plantando hijos o secciones de cormo con yemas. Tolerante a sombra y suelos humedos. Cultivo tradicional de la chagra indigena amazonica y del Pacifico."
+      },
+      "companions": [
+        "musa_paradisiaca"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia",
+        "sinchi-amazonia-colombiana"
+      ],
+      "valor_pedagogico": "El bore o malanga gigante (Alocasia macrorrhizos (L.) G.Don, familia Araceae) es una arácea herbácea perenne robusta (1-4 m altura) originaria del sureste asiático tropical (Filipinas, Indonesia, Borneo, Malasia) y aclimatada hace siglos en sistemas tradicionales del trópico húmedo colombiano por comunidades afrocolombianas e indígenas. Produce hojas sagitadas-cordadas gigantes verde-brillantes (60-150 cm largo) sostenidas por pecíolos suculentos largos, inflorescencia tipo espádice con espata color crema y cormo subterráneo grande (10-25 cm diámetro) rico en almidón (60-80% peso seco), proteínas (3-5%) y minerales. Contiene cristales de oxalato de calcio (rafidios) que deben neutralizarse por cocción prolongada o fermentación previo al consumo humano y animal. Se cultiva en Chocó (Atrato, Quibdó, Bajo Baudó), Valle del Cauca (Buenaventura, Bajo Calima), Cauca (Guapi, Timbiquí), Nariño (Tumaco, Mosquera, Olaya Herrera), Amazonas (Leticia, Puerto Nariño), Vaupés (Mitú), Putumayo, Caquetá y Magdalena medio bajo entre 0 y 400 msnm en zona térmica cálida húmeda. Ciclo perenne, primera cosecha de cormo a los 10-14 meses. Rendimientos 25-50 t/ha cormo fresco. Lección viva: cultivo de seguridad alimentaria del trópico húmedo cuyos cormos ricos en almidón sostienen comunidades indígenas del Pacífico y Amazonia, enseñando sistemas agroforestales de chagra indígena (Embera, Wounaan, Tikuna, Curripaco), policultivo tropical con yuca y plátano, manejo tradicional de plantas con compuestos antinutricionales por procesamiento culinario (cocción, fermentación, rallado y lavado) y diversificación de fuentes de carbohidratos resistente a sequías y plagas que afectan cultivos comerciales monocultivo. Manejo agroecológico: propagación por hijos basales o secciones de cormo con yemas activas, siembra a 1.5-2 m entre plantas en sistemas con sombra parcial bajo plátano y palmera, asocio con yuca y plátano en chagra, cosecha rotacional planta por planta, no requiere agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia, SIB Colombia, SINCHI Amazonia Colombiana.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "rascadera",
+        "oreja de elefante",
+        "papa china grande"
+      ]
+    },
+    {
+      "id": "andropogon_gayanus",
+      "nombre_comun": "Carimagua",
+      "nombre_cientifico": "Andropogon gayanus Kunth",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "biomass_producer",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 32,
+        "max_tolerable": 40
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "stylosanthes_guianensis"
+      ],
+      "source_ids": [
+        "agrosavia-forrajeras-2022",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "El pasto carimagua o andropogon (Andropogon gayanus Kunth, Poaceae, subfamilia Panicoideae, tribu Andropogoneae) es una gramínea forrajera tropical de gran porte y enorme importancia agronómica en los Llanos Orientales colombianos, originaria de las sabanas tropicales del África occidental (desde Senegal hasta Sudán y Etiopía) e introducida al Neotrópico por el CIAT a través de la estación experimental Carimagua (en el límite Meta-Vichada, Llanos Orientales colombianos) en los años 1970-80 como solución agronómica al desafío de las sabanas hiperácidas de la Orinoquía: suelos Oxisoles-Ultisoles con saturación de aluminio mayor a 80%, pH menor a 4.5, deficiencia crítica de P y Ca, y prolongado período seco estacional de 3-4 meses donde casi ninguna otra gramínea forrajera (ni siquiera brachiaria en sus inicios) prosperaba. La variedad cv. Carimagua fue liberada oficialmente por CIAT en 1980 a partir de germoplasma colectado por el ORSTOM-IRD francés en Burkina Faso y Mali, y a partir de ese momento permitió la transformación productiva de las sabanas naturales de los Llanos Orientales (originalmente dominadas por Trachypogon-Axonopus de bajo valor forrajero, soportando apenas 0.1-0.3 UGG/ha en régimen extensivo) a sabanas mejoradas capaces de soportar carga animal de 1.5-3 UGG/ha. Esta variedad fue homenaje a la estación experimental Carimagua y marca historia agronómica: es la primera gramínea forrajera específicamente seleccionada para sabana ácida que llegó a difundirse masivamente en Colombia, abriendo el camino para las brachiarias y Mombasa años después. En Colombia se cultiva ampliamente en los Llanos Orientales (Meta, Casanare, Vichada, Arauca), la Orinoquía baja (piedemonte llanero del Meta y Casanare), partes del Magdalena Medio y la Amazonía deforestada (Caquetá), todos entre 0 y 1.000 msnm en zona térmica cálida sobre suelos ácidos de baja fertilidad. Es gramínea perenne cespitosa de gran porte (1.5-3 m de altura) con macollas vigorosas erectas, hojas largas lineares verde-azuladas, vaina foliar con pelos basales, inflorescencia compuesta de muchos racimos pareados al ápice del culmo (caracter diagnóstico de Andropogoneae), semillas peludas con dormancia post-cosecha de 6 meses que requiere reposo o escarificación pre-siembra. Su característica agronómica distintiva es la combinación rara de tolerancia extrema a aluminio (>80% saturación), tolerancia a sequía estacional (sistema radicular profundo de 2-3 m, mecanismos de cierre estomático, latencia vegetativa en seca), persistencia en pradera decadal y compatibilidad con leguminosas tropicales adaptadas a sabana ácida (especialmente Stylosanthes guianensis cv. CIAT-184, asociación referencial liberada también por CIAT-Carimagua). Produce biomasa de 10-15 t MS/ha/año en sabana mejorada con manejo extensivo, soporta carga animal de 1.5-3 UGG/ha en sistemas rotacionales con descanso de 35-45 días entre pastoreos y altura de entrada al pastoreo de 60-80 cm, valor nutricional moderado (PC 6-9%, DIVMS 50-58%, inferior a brachiarias y Mombasa pero suficiente para ceba extensiva sobre sabana). Hoy es parcialmente desplazada por brachiaria y Mombasa en fincas con mejor manejo, pero persiste como base de la ganadería extensiva de los Llanos sobre sabana ácida no fertilizada donde brachiaria y Mombasa requieren inversión que no es viable. Susceptible a salivazo (Aeneolamia varia) aunque menos que brachiaria, y a la hormiga arriera (Atta spp.) que defolia macollas jóvenes. Su naturalización en Colombia es preocupante en ecosistemas adyacentes: en Australia es considerada invasiva agresiva (gamba grass) que desplaza eucaliptos y arbustos nativos del Top End, y aunque en Colombia la dinámica ecológica es diferente (proviene del mismo bioma sabánico), su presencia masiva en Llanos contribuye al desplazamiento de gramíneas nativas como Trachypogon spp. y Axonopus purpusii. Manejo agroecológico: propagación por semilla escarificada o con reposo de 6 meses (5-10 kg/ha al inicio de lluvias en surcos de 0.7-1.0 m, espaciamiento amplio por gran porte de la macolla), fertilización inicial mínima (150-200 kg/ha 10-30-10) o cero fertilización, descanso post-establecimiento 100-130 días, asociación con Stylosanthes guianensis cv. CIAT-184 (combinación pionera difundida por CIAT desde 1980 que duplica la carga animal del sistema), sistemas silvopastoriles con Acacia mangium, Albizia spp. y Pithecellobium dulce que potencian la productividad y captura de carbono en sabana mejorada. Es lección agroecológica fundamental de la Orinoquía colombiana: una gramínea africana cuya selección en la estación CIAT-Carimagua durante los años 1970-80 transformó la ganadería extensiva sobre sabana ácida del nivel marginal (0.1-0.3 UGG/ha) al nivel productivo (1.5-3 UGG/ha), pionera de toda la mejora forrajera tropical posterior en Colombia, pero cuyo manejo actual debe equilibrarse con la conservación de sabanas naturales remanentes y la integración con sistemas silvopastoriles. Fuentes Tier A: CIAT cv. Carimagua 1980, AGROSAVIA Manual Forrajeras Tropicales 2022, POWO Kew, GBIF Backbone Taxonomy, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "aniba_perutilis",
+      "nombre_comun": "Aniba comino",
+      "nombre_cientifico": "Aniba perutilis Hemsl.",
+      "familia_botanica": "Lauraceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nurse_plant",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1300,
+        "optimo_max": 1800,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 16,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cedrela_odorata",
+        "coffea_arabica",
+        "inga_edulis",
+        "ocotea_calophylla"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El aniba comino o comino crespo (Aniba perutilis, Lauraceae) es uno de los árboles maderables más emblemáticos y críticamente amenazados del bosque andino colombiano, listado como EN PELIGRO en el Libro Rojo de Plantas de Colombia (Cárdenas & Salinas 2007) y en la lista roja de la UICN. Es nativo de los bosques húmedos premontanos andinos entre 1.000 y 2.000 msnm, distribuido en la región Andina especialmente en Antioquia, Caldas, Risaralda, Quindío, Valle del Cauca, Cauca, Tolima, Huila, Chocó, Nariño y Cundinamarca. Árbol perennifolio de bosque maduro climácico de 20-30 metros de altura con fuste cilíndrico recto, copa redondeada densa y corteza pardo-grisácea fina con aroma intenso característico a comino y canela cuando se raspa; hojas alternas elípticas coriáceas verde oscuro brillantes en haz, flores pequeñas blanco-amarillentas en panículas axilares atractoras de abejas Meliponini, drupas elipsoidales verde-negruzcas dispersadas por aves frugívoras del bosque andino. Su madera —conocida comercialmente como 'comino crespo' o 'comino real'— ha sido históricamente considerada una de las más finas del país: densidad alta, veteado ondulado característico, aroma persistente a canela-comino, durabilidad excepcional, lo que la convirtió en madera predilecta para ebanistería de lujo, mueblería patrimonial, puertas talladas, instrumentos musicales, cofres y altares en arquitectura colonial y republicana colombiana del siglo XVIII al XX. Esta sobreexplotación maderera por más de 200 años redujo las poblaciones silvestres hasta el estado crítico actual, con árboles maduros prácticamente extintos en muchas zonas de su rango histórico. Su recuperación es lenta y compleja: especie de bosque maduro con semillas recalcitrantes que no toleran desecación (siembra inmediata obligatoria), crecimiento muy lento (turnos >40 años para diámetros comerciales), esciófita estricta (requiere dosel forestal continuo) y baja regeneración natural fuera de bosques maduros. El aprovechamiento silvestre está prohibido sin permiso especial de la autoridad ambiental (CAR/Ministerio de Ambiente). Su conservación ex situ en cafetales con sombrío diversificado y huertos patrimoniales rurales constituye una de las estrategias más viables para mantener su acervo genético y evitar la extinción comercial completa. Es lección de soberanía botánica y advertencia ecológica: la 'sobreexplotación silenciosa' de maderas finas del bosque andino —comino, cedro, nogal andino, ceroxylon— es paralela a la deforestación amazónica pero con menor visibilidad pública. Recuperar el aniba comino en los cafetales colombianos es acto de restauración cultural y patrimonio botánico nacional. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia (categoría EN — En Peligro), Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, IUCN Red List, Pérez-Arbeláez 1947 Plantas Útiles de Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "annona_cherimola",
+      "nombre_comun": "Chirimoya",
+      "nombre_cientifico": "Annona cherimola Mill.",
+      "familia_botanica": "Annonaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1500,
+        "optimo_max": 2200,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se propaga por semilla de frutos maduros (germinación 30-45 días) y por injerto de púa o yema sobre patrón franco de A. cherimola o A. squamosa. El injerto mantiene características varietales (ej. 'Fino de Jete', 'Cumbe') y acorta el inicio de producción a 3-4 años versus 5-7 desde semilla."
+      },
+      "companions": [
+        "annona_squamosa"
+      ],
+      "antagonists": [
+        "solanum_melongena"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La chirimoya (Annona cherimola Mill.) es un frutal perenne de la familia Annonaceae originario de los valles interandinos de Ecuador-Perú, cultivado en Colombia entre 1.500 y 2.400 msnm en zona térmica templada a fría moderada. Se siembra en Boyacá (Sutamarchán, Santa Sofía, Tinjacá), Cundinamarca (Anolaima, Quipile, La Mesa), Santander, Huila y Cauca, donde la noche fresca favorece el cuajado del fruto. Árbol semicaducifolio 5-8 m, ciclo a primera cosecha 3-5 años por injerto. Manejo agroecológico: poda de formación en copa abierta para aireación, fertilización orgánica con compost + roca fosfórica + ceniza de madera (K), embolsado de frutos contra Bephratelloides cubensis (perforador de la semilla), y polinización manual con pincel al amanecer porque las flores son dicógamas protogínicas (estigma receptivo antes que las anteras liberen polen) y los polinizadores nativos (escarabajos Nitidulidae) son insuficientes en monocultivo. Asociar con leguminosas de cobertura (Arachis pintoi, Crotalaria spp.) para fijación de N y supresión de arvenses. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, ICA Resolución 3168/2015.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "anón"
+      ]
+    },
+    {
+      "id": "annona_mucosa",
+      "nombre_comun": "Biribá",
+      "nombre_cientifico": "Annona mucosa Jacq.",
+      "familia_botanica": "Annonaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 600,
+        "max_absoluto": 1100
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semillas recalcitrantes a semi-recalcitrantes (mejor sembrar frescas, germinación 25-50 días). Vivero 6-9 meses bajo sombra 50%. Trasplante a 6x6 m o 7x7 m. Primera fructificación 3-5 años desde semilla. Tradicionalmente sembrado en chagras kichwa, ticuna y siona del trapecio amazónico y piedemonte putumayense. Sinónimo taxonómico anterior: Rollinia mucosa (Jacq.) Baill. — POWO reconoce Annona mucosa Jacq. como nombre aceptado vigente."
+      },
+      "companions": [
+        "ananas_comosus",
+        "theobroma_grandiflorum"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "sinchi-amazonia-colombiana",
+        "agrosavia-manual-frutales-tropicales",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "El biribá o anona amazónica (Annona mucosa Jacq., sinónimo anterior Rollinia mucosa (Jacq.) Baill., familia Annonaceae) es un árbol frutal nativo amazónico (5-12 m altura, copa abierta) de la cuenca amazónica occidental y central, distribuido naturalmente en bosque húmedo tropical de tierra firme de Colombia (Caquetá, Putumayo, Amazonas, Vaupés, Guainía), Ecuador (Napo, Pastaza), Perú (Loreto, Madre de Dios) y Brasil (Acre, Amazonas, Pará). Produce frutos sincárpicos esféricos a obovoides grandes (10-20 cm diámetro, 0.5-2 kg peso) de cáscara amarilla brillante con proyecciones cónicas o gibas piramidales (los carpelos individuales fusionados) que recuerdan a la chirimoya andina, pulpa blanco-cremosa muy aromática y mucilaginosa (de ahí el epíteto mucosa) extraordinariamente dulce (18-22 °Brix) con sabor a piña-mango-lemon meringue (de ahí su nombre comercial inglés 'lemon meringue fruit') y semillas negras numerosas elipsoidales planas. Es una de las anonáceas tropicales más codiciadas por su sabor y aroma, comercializada en mercados regionales de Leticia, Florencia, Mocoa, Mitú e Inírida, y cada vez más demandada como fruta exótica en cadenas gourmet internacionales. Lección viva: árbol-tesoro de la chagra amazónica que enseña cuatro conceptos críticos: (1) la nomenclatura botánica viva — el cambio reciente de Rollinia a Annona (Maas et al. 2011, reclassification of Annonaceae basada en filogenia molecular) muestra que la taxonomía no es estática, sino una construcción científica en evolución constante; los profesores y agricultores deben actualizar sus libros para no confundir a niñas y niños con nombres obsoletos; (2) la familia Annonaceae como uno de los clados angiospermos más antiguos (linaje Magnoliid basal, divergente del resto de eudicotiledóneas hace ~125 millones de años), con flores con muchos estambres en disposición espiralada (estado plesiomórfico), polinización por escarabajos tempranos (síndrome cantarofilia ancestral) y olores fermentados que atraen al género polinizador Cyclocephala (escarabajo melolontino); (3) el contraste con su prima andina chirimoya (Annona cherimola), que es de zonas templadas (1.500-2.500 msnm), versus el biribá que es estrictamente cálido (0-1.000 msnm) — ejemplo magistral de radiación adaptativa altitudinal dentro del mismo género; (4) la sub-utilización económica del biribá en Colombia, conocido y consumido localmente en la Amazonía pero invisible en mercados de Bogotá, Medellín o Cali, situación que invita a reflexión sobre cadenas de valor y conocimiento campesino-indígena marginalizado. Manejo agroecológico: siembra en sistemas agroforestales con sombra parcial inicial (50%) bajo plátano o guamo (Inga edulis), asocio con copoazú, asaí, piña y yuca, cosecha manual de fruto maduro caído (no se corta del árbol — cae al madurar, indicador claro), cero agroquímicos, control biológico de Bephratelloides cubensis (perforador de la semilla) por podas sanitarias y trampas de luz. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, AGROSAVIA Manual Frutales Tropicales, Bernal 2015 Catálogo Plantas Colombia, SINCHI Amazonía.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "annona_squamosa",
+      "nombre_comun": "Anón",
+      "nombre_cientifico": "Annona squamosa L.",
+      "familia_botanica": "Annonaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 800,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se propaga por semilla de frutos maduros; la germinación toma 30-60 días. También por injerto de púa para mantener características varietales. El crecimiento es lento los primeros 2 años."
+      },
+      "companions": [
+        "annona_cherimola"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-frutales-tropicales",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El anón (Annona squamosa L.) es un frutal de la familia Annonaceae adaptado a climas cálidos-secos a templados bajos colombianos, valorado por su fruto pulposo dulce de aroma característico. Se cultiva en Tolima (Norte, Mariquita), Huila (Garzón, La Plata), Cundinamarca (Tocaima, Apulo), Valle del Cauca, Antioquia y Magdalena entre 0 y 1.600 msnm en zona térmica cálida a templada. Árbol pequeño 4-6 m, ciclo a primera cosecha 3-4 años. Frutos cosechados pintones (cambio color, semi-firmes) para madurar fuera del árbol. Manejo agroecológico: poda formación copa baja, fertilización con compost + roca fosfórica, control de la perforadora del fruto (Bephratelloides cubensis) con embolsado de frutos y captura de adultos con trampas amarillas. Polinización manual mejora cuajado (Annona spp. son auto-poco-fértiles). Fuentes Tier A: AGROSAVIA Manual Frutales Tropicales, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "axinaea_macrophylla",
+      "nombre_comun": "Pámpano",
+      "nombre_cientifico": "Axinaea macrophylla (Naudin) Triana",
+      "familia_botanica": "Melastomataceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
+        "optimo_max": 2900,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 8,
+        "optimo_max": 15,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "miconia_squamulosa",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Axinaea macrophylla (Naudin) Triana (pámpano, tuno macho — familia Melastomataceae) es un árbol perennifolio (5-12 m altura) nativo de los Andes de Colombia, Ecuador y norte de Perú, distribuido en bosque alto andino entre 2000 y 3200 msnm en piso térmico FRÍO. En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca, Santander y Tolima. Es reconocible por sus HOJAS GRANDES OPUESTAS (15-25 cm) con NERVIACIÓN PENTANERVIA MARCADA (3-5 nervios principales que corren paralelos desde la base hasta el ápice — el rasgo más distintivo de las Melastomataceae a nivel mundial, presente también en mortiño, tuno hembra Miconia spp., sietecueros Tibouchina, mayos Meriania spp.) y por sus FLORES TETRÁMERAS BLANCO-ROSÁCEAS con un mecanismo de polinización ORNITÓFILO ÚNICO DESCUBIERTO RECIENTEMENTE — los estambres tienen apéndices glandulares modificados que funcionan como BIOFUELLES o 'aerosoles biológicos': cuando un ave polinizadora (mirla, atrapamoscas, copetón andino) muerde el apéndice estaminal para alimentarse del tejido glandular azucarado, la presión mecánica de la mordida DISPARA UN CHORRO DE POLEN al pico y plumas del ave, asegurando la polinización cruzada. Este mecanismo fue descrito formalmente por Agnes Dellinger et al. 2014 (Naturwissenschaften 101:545-559) como uno de los mecanismos de polinización ornitófila más sofisticados conocidos en plantas con flores tetrámeras — antes se creía que solo las aves del Viejo Mundo y las flores zigomorfas con néctar profundo lograban tal precisión. Lección viva sobre POLINIZACIÓN ORNITÓFILA EXÓTICA, COEVOLUCIÓN PLANTA-AVE ANDINA y RESTAURACIÓN MULTIESPECÍFICA: el pámpano es ejemplo paradigmático de cómo una especie nativa tiene una red ecológica obligada con su polinizador ave — sin avifauna alto-andina (mirlas, atrapamoscas, copetones, semilleros) NO hay reproducción sexual del pámpano. Esto refuerza el principio agroecológico de que la restauración multiespecífica del bosque alto andino debe incluir simultáneamente la vegetación, el suelo Y la fauna — plantar pámpano en una matriz sin avifauna fracasa biológicamente. En proyectos de restauración del flanco occidental de Cruz Verde-Sumapaz, Chingaza, Iguaque y Tatamá, el pámpano se planta en borde de bosque y sotobosque abierto, asociado con gaque, encenillo y mortiño, para reconstruir la red trófica completa. Manejo agroecológico: propagación por semilla fresca con siembra superficial (semillas diminutas); trasplante 4-6 meses; plantación 12-18 meses; crecimiento 40-60 cm/año; densidades 200-400 ind/ha; restauración multiespecífica con avifauna nativa. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "bocconia_frutescens",
+      "nombre_comun": "Toche",
+      "nombre_cientifico": "Bocconia frutescens L.",
+      "familia_botanica": "Papaveraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent",
+        "biomass_producer",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1500,
+        "optimo_max": 2000,
+        "max_absoluto": 2500
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 13,
+        "optimo_max": 22,
+        "max_tolerable": 27
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "alnus_acuminata",
+        "escallonia_pendula",
+        "vallea_stipularis"
+      ],
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "correa-pabon-carulla-2008",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El toche o trompeto (Bocconia frutescens, Papaveraceae) es uno de los arbolitos pioneros más característicos del bosque andino premontano-montano bajo colombiano entre 1.000 y 2.500 msnm, distribuido en toda la región Andina especialmente en bordes de carretera, áreas en sucesión y terrenos en abandono. Pertenece a la familia Papaveraceae —la misma familia de la amapola (Papaver somniferum) y el opio— y es una de las pocas papaveráceas arborescentes del mundo, característica que la hace especialmente interesante desde el punto de vista botánico y filogenético. Árbol pequeño o arbusto grande de 4-8 metros de altura con ramas alladas, hojas grandes pinnatífidas verde-glaucas con lóbulos profundos (recuerdan a las hojas de papaya, de ahí el nombre 'papaya cimarrona' en algunas regiones), inflorescencias en panículas terminales largas con flores pequeñas verde-amarillentas sin pétalos pero con estambres conspicuos atractores de polinizadores nativos (abejas Meliponini, sírfidos, escarabajos), cápsulas pequeñas rojo-anaranjadas dehiscentes con semillas dispersadas por aves frugívoras. Su característica más distintiva es el látex anaranjado que exuda al cortar cualquier parte del árbol —este látex es rico en alcaloides isoquinolínicos (sanguinarina, queleritrina, bocconina, alocriptopina) con propiedades farmacológicas potentes: antimicrobiano, antiparasitario externo, citotóxico, y tradicionalmente usado en medicina popular colombiana como antiparasitario veterinario externo para tratar miasis y ectoparásitos en ganado y caballos (aplicación tópica del látex directo a las lesiones), como cicatrizante de heridas (con precaución por irritación), y en algunos usos rituales y de protección espiritual del campo. PRECAUCIÓN: el látex es tóxico irritante por contacto (puede causar dermatitis severa) y altamente tóxico si se ingiere, por lo que el manejo de la especie requiere conocimiento tradicional y equipos de protección personal —no es una planta para experimentación lúdica con niños o personas no entrenadas. Su rol ecológico es ser pionera andina de rápido crecimiento que coloniza áreas degradadas, taludes, bordes de carretera y potreros en abandono, facilitando la sucesión temprana hacia bosque secundario en 5-8 años. Como árbol de lindero en cafetales y huertos patrimoniales aporta función alelopática anti-plagas a través de los compuestos liberados al suelo y al aire por las hojas y la corteza. Es lección de farmacognosia colombiana y manejo tradicional: el conocimiento campesino sobre el toche como antiparasitario veterinario es patrimonio etnobotánico que combina eficacia farmacológica real con manejo cuidadoso de la toxicidad —ejemplo de la sabiduría tradicional que no romantiza ni demoniza a las plantas medicinales potentes. Fuentes Tier A: Pérez-Arbeláez 1947 Plantas Útiles Colombia, Correa-Pabón Carulla 2008 Plantas Medicinales, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "bombacopsis_quinata",
+      "nombre_comun": "Ceiba tolúa",
+      "nombre_cientifico": "Bombacopsis quinata (Jacq.) Dugand",
+      "familia_botanica": "Malvaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "windbreak",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 800,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 6,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cordia_alliodora",
+        "inga_edulis",
+        "myroxylon_balsamum",
+        "tabebuia_chrysantha",
+        "tabebuia_rosea"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "uicn-red-list",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La ceiba tolúa o pino bobo (Bombacopsis quinata (Jacq.) Dugand, sinónimo válido Pachira quinata, Malvaceae subfamilia Bombacoideae) es uno de los árboles maderables más patrimoniales y más amenazados del bosque seco tropical neotropical. Su nombre 'tolú' proviene del municipio Tolú (Sucre) y Tolú Viejo en la región Caribe colombiana, donde la especie es ancestral y emblemática. Nativa del bosque seco tropical del norte de Sudamérica y Mesoamérica, en Colombia se distribuye en la región Caribe (Sucre, Córdoba, Bolívar, Magdalena, Cesar, Guajira, Atlántico), valle medio y bajo del Magdalena (Tolima seco, Antioquia norte, Santander seco), valle del Patía (Cauca) y piedemonte llanero seco (norte Casanare) entre 0 y 800 msnm en zona térmica cálida con estación seca pronunciada de 4-7 meses. Árbol caducifolio gigante de 25-40 m de altura, una de las especies emergentes más altas del bosque seco caribeño, con fuste recto cilíndrico que puede alcanzar 1.5 m de diámetro, copa amplia hemisférica caduca en estación seca, su característica más distintiva es que el tronco y ramas juveniles están cubiertos de aguijones cónicos robustos (3-5 cm de longitud) que protegen contra herbívoros grandes y trepadores (estos aguijones se pierden en árboles adultos viejos), hojas digitado-palmaticompuestas con 5 folíolos elípticos (de ahí 'quinata' = de 5), flores grandes blancas-amarillentas crepusculares-nocturnas polinizadas por murciélagos, cápsulas leñosas elípticas dehiscentes que liberan semillas envueltas en pelos algodonosos blancos (kapok) útil artesanalmente para rellenos de almohadas y aislamientos en la tradición caribeña. ALERTA CONSERVACIÓN: categorizada VULNERABLE (VU) en la Lista Roja IUCN y categoría EN PELIGRO (EN) en el Libro Rojo Plantas Colombia (Cárdenas & Salinas 2007) por sobreexplotación maderera histórica del bosque seco y deforestación masiva para ganadería extensiva: el bosque seco tropical caribeño está hoy reducido a <8% de su cobertura original en Colombia. Su madera blanca-rosada liviana y suave (densidad 0.35-0.45 g/cm³, de ahí el nombre popular 'pino bobo') es apreciada para construcción rural, postes, embalajes, cajas, contrachapados, modelado y tallado. Es lección clave de conservación: lo que su bisabuela llamaba 'la tolúa del patio' y servía para postes, leña y refugio para ganado en el Caribe, hoy es un árbol con cifras de extinción comercial. CIPAV documenta su uso en sistemas silvopastoriles modernos del Caribe colombiano como árbol disperso de sombra para ganado, alternativa nativa a especies introducidas como Albizia o Leucaena. Otra técnica tradicional es la propagación por esqueje grueso (10-15 cm de diámetro) clavados en tierra al inicio de las lluvias, que prende y forma cercas vivas duraderas en los hatos del Caribe. Manejo agroecológico: vivero a sol parcial, plantación definitiva a 40-50 cm, cuidado con los aguijones juveniles los primeros 5-8 años, crecimiento rápido inicial (1-2 m/año), turno comercial 20-30 años para diámetros >40 cm. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, IUCN Red List, Bernal et al. 2015, POWO Kew, GBIF, CIPAV silvopastoriles Caribe.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "borojoa_sorbilis",
+      "nombre_comun": "Borojó del Chocó",
+      "nombre_cientifico": "Borojoa sorbilis (Ducke) Cuatrec.",
+      "familia_botanica": "Rubiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 50,
+        "optimo_max": 800,
+        "max_absoluto": 1000
+      },
+      "temperatura_c": {
+        "helada_letal": 12,
+        "optimo_min": 24,
+        "optimo_max": 32,
+        "max_tolerable": 36
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "moderado",
+      "companions": [
+        "bactris_gasipaes",
+        "chrysophyllum_cainito",
+        "leucaena_leucocephala",
+        "manihot_esculenta",
+        "musa_paradisiaca",
+        "pouteria_caimito",
+        "pouteria_sapota",
+        "theobroma_cacao",
+        "zea_mays"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "sinchi-amazonia-colombiana",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "El borojó del Chocó o borojó silvestre (Borojoa sorbilis (Ducke) Cuatrec., familia Rubiaceae) es un frutal nativo dioico del bioma chocoano biogeográfico y amazónico, distinto al borojó pacífico Borojoa patinoi (ya en catálogo) que es el cultivado comercialmente del Chocó. B. sorbilis se distribuye en bosque húmedo y muy húmedo tropical entre 0 y 1.000 msnm en Colombia (Chocó: Bajo Atrato, San Juan, Baudó, Quibdó; Amazonas: Leticia, Puerto Nariño, La Pedrera, Tarapacá; Vaupés: Mitú; Guaviare; Caquetá; Putumayo), Brasil amazónico (Amazonas, Pará, Acre, Rondonia), Perú (Loreto, Ucayali, Madre de Dios) y Ecuador amazónico. Es PEDAGÓGICAMENTE EXCELENTE como lección viva del manejo ancestral del bosque por parte de los pueblos indígenas TIKUNA (trapecio amazónico colombiano), HUITOTO/MUINANE/BORA (medio Caquetá-Putumayo), YAGUA y COFAN del piedemonte amazónico, y EMBERA (Dóbida, Chamí, Katío) y WOUNAAN del Pacífico chocoano, y por las COMUNIDADES AFROCOLOMBIANAS del Chocó biogeográfico (Cocomacia, Acadesan, consejos comunitarios del Bajo Atrato, San Juan, Baudó) que durante generaciones han manejado rodales naturales en sistemas agroforestales tradicionales asociados a cacao (Theobroma cacao), bacao (T. bicolor), chontaduro (Bactris gasipaes) y don pedrito (Oenocarpus mapora). Pertenece al género Borojoa (Rubiaceae, tribu Gardenieae — algunos autores la ubican aún en género Alibertia) junto a B. patinoi y B. claviflora. Arbusto a árbol pequeño dioico de 3-6 m altura con tallos ramificados, hojas opuestas decusadas elípticas verdes brillantes 15-30 cm largo coriáceas con nervadura prominente, flores pequeñas blanco-cremas tubulares aromáticas polinizadas por abejas euglosinas y trigonas, fruto baya carnosa globosa-elipsoidal 6-10 cm diámetro (algo menor que B. patinoi de 8-12 cm), pulpa marrón-vinotinta agridulce densa con sabor a chocolate-tamarindo conteniendo 100-200 semillas pequeñas planas — consumida fresca, en jugo, mermelada, dulce de fruta, helado, considerada planta medicinal energética-afrodisíaca por la tradición chocoana-amazónica (alto contenido en aminoácidos esenciales, proteínas — 1.5%, fósforo, calcio, hierro, vitamina B). Manejo agroecológico: regeneración natural por dispersión de tortugas, monos y pájaros frugívoros; siembra enriquecimiento bajo dosel a 4-6 m entre plantas; tolerancia alta a sombra (60-80%); cultivo asociado a otras especies del agroforestal chocoano-amazónico; tolerancia a inundación estacional. Función en chagra/agroforestal chocoana-amazónica como cosecha comunitaria sostenible (cadena de valor 'borojó silvestre' con denominación de origen pendiente), conservación de la biodiversidad del bioma chocoano (uno de los hot-spots de biodiversidad del planeta), conservación de género Borojoa endémico-amazónico, banco genético frutal de Rubiaceae nativa. Fuentes Tier A: POWO Kew, GBIF, Sinchi (Instituto Amazónico de Investigaciones Científicas), IIAP Pacífico, Cárdenas-Salinas frutales amazónicos, Bernal 2015.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "brassica_oleracea_acephala_lacinato",
+      "nombre_comun": "Kale toscano / Cavolo nero",
+      "nombre_cientifico": "Brassica oleracea var. acephala 'Lacinato'",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Planta semi-perenne en Choachí; se puede cosechar hoja por hoja durante meses."
+      },
+      "antagonists": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La col rizada Lacinato o Toscana negra (Brassica oleracea L. var. acephala 'Lacinato', también llamada 'col dinosaurio' por la textura ampollada de las hojas) es una crucífera bienal cultivada como hortaliza de hoja persistente con altísimo valor nutricional (vitamina K, A, C, calcio, hierro). Reintroducida en huertas urbanas colombianas durante el boom agroecológico 2010-2020. Se cultiva en Sabana de Bogotá, Boyacá, Eje cafetero y Antioquia entre 1.800 y 2.900 msnm en zona térmica fría. Ciclo 60-90 días desde trasplante a primera cosecha, productividad sostenida 6-9 meses con cosechas escalonadas de hojas externas. Lección viva de arquitectura: a diferencia del repollo formador de cabeza, sus hojas crecen abiertas sobre tallo central persistente, permitiendo la cosecha 'de abajo hacia arriba' sin perder la planta. Manejo agroecológico: rotación trienal anti-Plasmodiophora brassicae, asocio con cebollas y romero (repelentes), control de palomilla (Plutella xylostella) con Bacillus thuringiensis + Trichogramma, fertilización con bocashi + biol foliar. Fuentes Tier A: ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "brassica_oleracea_acephala_red_russian",
+      "nombre_comun": "Kale morado / Red Russian",
+      "nombre_cientifico": "Brassica oleracea var. acephala 'Red Russian'",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 8,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Sus hojas son notablemente más tiernas que las de los kales rizados; ideal para cosecha joven (baby kale)."
+      },
+      "antagonists": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "agrosavia-sol-andina"
+      ],
+      "valor_pedagogico": "El kale morado o Red Russian (Brassica oleracea var. acephala 'Red Russian') es una variedad de col rizada de hojas tiernas y textura suave, notable por sus tallos morados y venas plateadas. En Colombia se cultiva principalmente en los departamentos andinos de Cundinamarca, Boyacá, Nariño y Antioquia entre 1200 y 3600 msnm en zonas térmicas fría, con óptimo entre 2000-3000 msnm. Su manejo agronómico incluye propagación por semilla en semillero seguido de trasplante, ciclo de cultivo de 60-90 días para cosecha baby leaf y 90-120 días para hoja adulta, se asocia beneficiosamente con cebolla, zanahoria y leguminosas para reducir presiones de plagas como pulguillas (Phyllotreta spp.) y gusanos defoliadores (Plutella xylostella), y requiere monitoreo de enfermedades como mildiu velloso (Peronospora parasitica). En el contexto cultural andino, esta Brassica ha sido integrada en la gastronomía local como sustituto suave de la col tradicional, utilizándose en ensaladas, sautés y sopas. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Brassica oleracea var. acephala 'Red Russian'. Fuente: ICA Resolución 3168 de 2015, AGROSAVIA.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "brassica_oleracea_capitata_rubra",
+      "nombre_comun": "Repollo morado",
+      "nombre_cientifico": "Brassica oleracea var. capitata f. rubra",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere suelos ricos en materia orgánica (humus/compost) para desarrollar un color purpúreo intenso."
+      },
+      "antagonists": [
+        "solanum_lycopersicum_san_marzano",
+        "vaccinium_corymbosum_biloxi"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El repollo morado (Brassica oleracea var. capitata f. rubra) se cultiva en los departamentos andinos de Colombia como Cundinamarca, Boyacá y Nariño entre 800 y 3200 msnm en zonas térmicas fría y templada. Su manejo agronómico incluye propagación por semilla con ciclo de 90-120 días, requiere suelos ricos en materia orgánica (humus/compost) para desarrollar su característico color purpúreo intenso, se asocia beneficiosamente con zanahoria y cebolla para reducir plagas como áfidos y lepidópteros, y requiere monitoreo de plagas como la mosca blanca y gusanos del repollo. En el contexto campesino andino, esta variedad se valora por su alto contenido de antocianinas como antioxidantes naturales y se utiliza tradicionalmente en ensaladas y preparaciones culinarias que aportan color y nutrientes a la dieta familiar. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Brassica oleracea var. capitata f. rubra.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "brassica_oleracea_sabauda",
+      "nombre_comun": "Repollo rizado / Savoy",
+      "nombre_cientifico": "Brassica oleracea var. sabauda L.",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notes": "Ciclo más largo que el repollo liso; requiere paciencia en la zona fría."
+      },
+      "antagonists": [
+        "solanum_lycopersicum_san_marzano",
+        "vaccinium_corymbosum_biloxi"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El repollo crespo o de saboya (Brassica oleracea L. var. sabauda, cultivares Savoy King, Famosa) es una crucífera bienal cultivada como anual con hojas crespas/ampolladas características que retienen menos agua y son más resistentes al transporte que el repollo común. En Colombia se cultiva en Sabana de Bogotá (Mosquera, Madrid, Funza), Boyacá altiplano y Nariño entre 2.000 y 2.900 msnm en zona térmica fría. Ciclo 4-5 meses a cosecha, rendimientos 35-50 t/ha. Cabeza compacta 1-2 kg. Manejo agroecológico: trasplante a doble fila densa (40×50 cm), rotación con leguminosas (haba, frijol) anti-Plasmodiophora brassicae (hernia col), bordura de capuchina trampa, control de palomilla crucíferas (Plutella xylostella) con Bacillus thuringiensis + Trichogramma, fertilización con bocashi + biol. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "brassica_rapa_rapifera",
+      "nombre_comun": "Nabo forrajero",
+      "nombre_cientifico": "Brassica rapa L. var. rapifera",
+      "familia_botanica": "Brassicaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "ground_cover",
+        "biomass_producer",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "avena_sativa",
+        "vicia_sativa"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-forrajeras-2022",
+        "agrosavia-tibaitata",
+        "bernal-2015-plantas-liquenes-colombia",
+        "restrepo-2005-agroecologia"
+      ],
+      "valor_pedagogico": "El nabo forrajero (Brassica rapa L. var. rapifera, familia Brassicaceae) es una brasicácea anual a bienal forrajera cultivada en sistemas ganaderos andinos colombianos como cover crop, abono verde, biofumigante natural y forraje verde de corte para bovinos y ovinos del altiplano cundiboyacense. Variedad selectivamente diferenciada del nabo de mesa por mayor desarrollo radicular (raíz pivotante 50-80 cm), menor desarrollo de raíz reservante comestible y mayor producción de biomasa aérea verde. Se cultiva en Boyacá (Tunja, Sotaquirá, Sutamarchán, Villa de Leyva, altiplano), Cundinamarca (Sabana de Bogotá, Subachoque, Sumapaz), Nariño (Pasto, Túquerres, Sapuyes), Cauca (Silvia, Totoró, Inzá) y Antioquia (oriente lechero — La Unión, La Ceja, Sonsón) entre 2.000 y 2.800 msnm en zona térmica fría. Ciclo corto 90-120 días desde siembra a incorporación o forraje. Rendimientos 30-50 t/ha biomasa fresca, 5-8 t/ha materia seca. Lección viva del arado biológico: el nabo forrajero rompe la compactación del suelo con su raíz pivotante profunda perforando capas de subsuelo arcilloso y compactado, recicla nutrientes profundos (potasio, calcio, fósforo) bombeándolos hacia hojas y biomasa aérea, enseñando que las plantas pueden labrar la tierra mejor que el azadón (bio-tillage). Sus glucosinolatos liberados al descomponer biomasa actúan como biofumigantes naturales contra Globodera spp. (nematodo dorado de la papa), Rhizoctonia solani y Fusarium oxysporum, principio agroecológico clave en rotación post-papa. Manejo agroecológico: siembra al voleo 8-12 kg/ha semilla en post-cosecha de papa, asocio con vicia o raigras para mejorar relación C/N de cobertura, incorporación pre-floración a los 80-90 días para evitar semillación espontánea, alternativamente forraje verde de corte cada 60 días con rebrote, no requiere fertilización ni agroquímicos. Fuentes Tier A: AGROSAVIA Forrajeras 2022, POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "bursera_graveolens",
+      "nombre_comun": "Palo santo",
+      "nombre_cientifico": "Bursera graveolens (Kunth) Triana & Planch.",
+      "familia_botanica": "Burseraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "pest_repellent",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 22,
+        "optimo_max": 32,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "companions": [
+        "cordia_alliodora",
+        "gliricidia_sepium",
+        "prosopis_juliflora"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles",
+        "pamplona-roger-2006-plantas-medicinales"
+      ],
+      "valor_pedagogico": "El palo santo (Bursera graveolens (Kunth) Triana & Planch., Burseraceae) es uno de los árboles aromático-ceremoniales más patrimoniales y simultáneamente más amenazados del bosque seco tropical (bs-T) del Caribe-Pacífico colombiano y de toda Suramérica seca. La madera y la resina poseen un aceite esencial aromático característico (dominado por limoneno, α-pineno, mentofurano y carvone) usado desde tiempos precolombinos por culturas indígenas Wayúu, Zenú, Embera, Wounaan y Kuna en sahumerios ceremoniales para purificación espiritual de espacios, ritos funerarios (\"palo de las ánimas\"), curaciones tradicionales, y como repelente natural de insectos domésticos (zancudos Aedes, Anopheles, jejenes Culicoides). Esta tradición milenaria sostuvo poblaciones naturales saludables durante siglos hasta que en los años 2010-2020 el mercado new-age internacional (yoga, aromaterapia, espiritualidad alternativa Estados Unidos-Europa-Asia) descubrió el \"palo santo\" y disparó una presión de cosecha catastrófica especialmente en Ecuador (provincia de Manabí, Loja) y Perú (Tumbes, Piura) donde se talaron árboles vivos masivamente para exportación, llevando a la inclusión de la especie en listas de preocupación CITES y a la consolidación de la regla ética inviolable de la cadena de valor sostenible: \"PALO SANTO ÉTICO = SOLO MADERA CAÍDA NATURAL\" — el aceite esencial solo se desarrolla plenamente durante 5-10 años de descomposición natural in situ del árbol caído (procesos de oxidación y polimerización biológica que conducen al perfil aromático característico), por lo cual cortar árboles vivos no solo es ambientalmente destructivo sino que produce madera olfativamente inferior. En Colombia este aprendizaje histórico es crítico para evitar repetir el error ecuatoriano-peruano: el bs-T del Caribe (La Guajira, Cesar, Magdalena, Bolívar, Sucre, Córdoba) y de la región seca del Pacífico (Tumaco-Barbacoas, Cauca, Valle) tiene poblaciones nativas de Bursera graveolens que pueden ser aprovechadas de manera comunitaria sostenible si se mantiene la regla de ningún corte vivo y rotación de cosecha de madera caída a 20-30 años. Nativo del Neotrópico desde México hasta Perú-Bolivia, en Colombia es nativo silvestre del bs-T Caribe-Pacífico entre 0-1.000 msnm en zona térmica cálida con precipitaciones 600-1500 mm/año. Árbol caducifolio de 5-10 m de altura (rara vez hasta 12 m) con corteza papirácea descamable rojiza-grisácea característica (rasgo diagnóstico de la familia Burseraceae), copa rala abierta, fuste corto torcido a veces ramificado desde la base, hojas pinnadas compuestas con folíolos elípticos verde-oscuros aromáticos al frote (liberan inmediatamente fragancia cítrica-resinosa diagnóstica), flores blanco-verdosas pequeñas en panículas terminales melíferas, frutos drupa pequeña globosa verde-roja a la madurez con una semilla negra brillante. El aceite esencial (concentración 6-10% peso seco madera vieja caída) contiene limoneno (40-60%), α-pineno (10-15%), mentofurano (5-10%), carvone (3-8%), y sesquiterpenos menores con propiedades antiinflamatorias, ansiolíticas suaves (efecto sedativo demostrado in vitro y modelos animales), repelente de insectos vectores (zancudos, jejenes, garrapatas) en concentraciones >5%, y antimicrobianas amplio espectro (Staphylococcus, Streptococcus, Candida). En medicina tradicional colombiana caribeña-pacífica el palo santo se usa en sahumerio doméstico para \"limpiezas energéticas\", repelente de mosquitos transmisores de dengue-zika-chikungunya en hogares rurales (sustituye espirales químicos sintéticos), tisana suave de hojas frescas para resfriados y dispepsia, y aplicación tópica del aceite para dolores musculares y picaduras. En sistemas agroforestales del bs-T acepta densidades 200-400 árb/ha en restauración productiva sostenible, asociado con gliricidia, cordia, crescentia y prosopis nativos, tolerando excepcionalmente sequías prolongadas de 5-7 meses, suelos arenosos pobres rocosos áridos y radiación solar plena extrema. El manejo sostenible debe garantizar: (1) ningún corte de árboles vivos, (2) cosecha solo de ramas y troncos caídos naturalmente con descomposición mínima de 5 años in situ, (3) rotación de zonas de cosecha a 20-30 años, (4) certificación comunitaria de origen sostenible para acceder a mercados premium (precio diferencial 3-5x sobre madera no certificada), (5) participación equitativa de comunidades indígenas-campesinas en cadena de valor. Manejo agroecológico: propagación por semilla fresca (germinación 50-70% a 20-30 días, sin tratamiento), vivero 5-8 meses a sol pleno, plantación definitiva a 25-30 cm en suelos arenosos drenados, distancia 5×5 m, crecimiento lento (5-7 m en 15-20 años), primera floración año 6-8, cosecha sostenible solo de madera caída a partir del año 20+. Esqueje leñoso opcional pero germinación baja. Es lección extraordinaria de ética agroecológica: una especie patrimonial milenaria que el mercado internacional puede destruir en una década si se permite el corte vivo, y que solo el manejo comunitario riguroso con regla absoluta de \"solo caído natural\" puede mantener viva indefinidamente. Defenderlo es defender la memoria ceremonial indígena Caribe-Pacífico, la salud doméstica rural frente a insecticidas químicos, la dignidad de las comunidades cosecheras frente a la depredación extractiva, y un ecosistema bs-T cuya destrucción global puso al palo santo ecuatoriano-peruano al borde de la extinción comercial. Colombia tiene la oportunidad histórica de hacerlo bien. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Pérez Arbeláez 1947 Plantas Útiles Colombia, Pamplona-Roger 2006 Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "byrsonima_crassifolia",
+      "nombre_comun": "Peralejo",
+      "nombre_cientifico": "Byrsonima crassifolia (L.) Kunth",
+      "familia_botanica": "Malpighiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "coffea_arabica",
+        "gliricidia_sepium",
+        "pithecellobium_dulce"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles",
+        "agrosavia-manual-frutales-tropicales"
+      ],
+      "valor_pedagogico": "El peralejo o nance (Byrsonima crassifolia (L.) Kunth, Malpighiaceae) es uno de los frutales silvestres más patrimoniales y simultáneamente más subutilizados del bosque seco tropical (bs-T), sabanas Caribe-Llanos y bosque premontano seco colombiano, conocido como \"nance\" en Caribe colombiano y Centroamérica, \"chaparro\" en los Llanos Orientales, \"noro\" en la Costa Pacífica, \"manero\" en Antioquia y \"changunga\" en algunas zonas. Es especie ecológicamente CLAVE en las sabanas naturales del Orinoquía colombiano (Casanare, Arauca, Meta, Vichada) y de las sabanas del Caribe seco (La Guajira, Cesar, Magdalena), donde forma poblaciones extensivas y es uno de los pocos árboles que resisten los fuegos sabaneros estacionales recurrentes gracias a una corteza GRUESA RUGOSA ANTICOMBUSTIBLE (rasgo diagnóstico de la especie con espesor 2-4 cm en árboles maduros que aísla térmicamente el cambium vascular). Esta resistencia al fuego le ha permitido coexistir milenariamente con el régimen de incendios naturales y antropogénicos de las sabanas neotropicales, convirtiéndolo en árbol fundamental de la ecología sabanera y en patrimonio bio-cultural llanero-caribeño. Nativo del Neotrópico desde México hasta Brasil-Paraguay, en Colombia es nativo silvestre dominante en sabanas naturales de Orinoquía (Casanare, Arauca, Meta, Vichada), bs-T de Caribe (La Guajira, Cesar, Magdalena, Atlántico, Bolívar, Córdoba, Sucre), Valle del Magdalena (Tolima, Huila, Santander), Valle del Cauca, sabanas del piedemonte llanero, y zonas secas de Antioquia, Caldas y Bajo Cauca, entre 0-1.200 msnm en zona térmica cálida con precipitaciones 700-2500 mm/año y suelos típicamente ácidos pobres oxisoles-ultisoles. Árbol pequeño-mediano caducifolio de 5-15 m de altura con copa amplia abierta hasta 8 m de diámetro, fuste corto tortuoso, corteza gruesa rugosa pardo-grisácea anticombustible, hojas elípticas-obovadas opuestas verde-oscuras coriáceas con envés blanco-tomentoso (tomento blanco al revés foliar, rasgo diagnóstico fácil al voltear la hoja), flores amarillas a anaranjadas en racimos terminales pequeños vistosos melíferos, frutos drupa globosa pequeña amarillo-anaranjada de 1-2 cm de diámetro con pulpa aromática dulce-ácida apetente y una semilla central. La fruta nance/peralejo se cosecha entre julio-octubre (maduración estacional vinculada al régimen pluvial) cuando cae naturalmente al suelo (se recoge a mano del suelo o se sacude el árbol sobre lonas), tiene aroma distintivo intenso característico (notas a queso fermentado, mango maduro, pera tropical), consumo fresco como golosina natural, procesado en dulces tradicionales (dulce de nance Caribe, conserva en almíbar), mermeladas, gelatinas, refrescos (\"agua de nance\"), helados artesanales, y especialmente fermentados alcohólicos tradicionales: la \"chicha de nance\" del Casanare-Arauca-Meta es una bebida fermentada patrimonio llanero servida en fiestas y festividades, y el \"licor de nance\" o \"miche de nance\" es destilado artesanal apreciado. El mercado de nance fresco y procesado tiene presencia consolidada en plazas de mercado de Barranquilla, Cartagena, Santa Marta, Valledupar, Sincelejo, Montería, Medellín, Villavicencio, Yopal con precios estables 2-6 USD/kg fresco y 8-15 USD/kg en conserva-mermelada artesanal. Como Malpighiaceae fija parcialmente nitrógeno (familia con mecanismos simbióticos no convencionales con bacterias diazotróficas Rhizobiaceae y Azospirillum), atrae polinizadores nativos clave: abejas Apidae (Apis mellifera, Meliponini Tetragonisca, Melipona, Trigona), abejorros Centris y Bombus (estos últimos con relación mutualista especializada por aceites florales que Centris colecta como recompensa floral exclusiva de Malpighiaceae), avispas Vespidae, moscas Syrphidae. La dispersión de la semilla es por avifauna frugívora (Turdus, Tangara, Thraupis, Ramphastos), mamíferos pequeños (zarigüeyas Didelphis, micos Cebus capucinus, Saimiri sciureus) y ganado bovino-equino en sabanas extensivas. Su madera marrón-rojiza dura de densidad media-alta (0.7-0.85 g/cm³) es apreciada en postes para cerca viva (durabilidad 10-15 años en suelo gracias a tanninos en duramen), construcción rural, mangos de herramienta, leña de alta calidad calórica, y carbón vegetal artesanal. La corteza es rica en taninos (8-15% peso seco) y se usa tradicionalmente como curtiente vegetal en cuero artesanal Caribe-Llanos, tinte natural pardo-rojizo para textiles tradicionales, y medicinal (decocción astringente para diarreas, lavados antisépticos). Manejo agroecológico: propagación por semilla con escarificación mecánica o ácido sulfúrico 15 min (germinación 50-70% a 20-45 días, lenta y desigual — recomendable sembrar abundante para compensar), vivero 5-7 meses a sol pleno, plantación definitiva a 25-35 cm de altura, distancia 6×6 m (200-300 árb/ha) en frutal comercial o 4×4 m en restauración productiva, primera fructificación año 4-5, productividad estable 30-80 kg/árb/año a partir del año 7. Esqueje leñoso opcional para clonar variedades selectas con fruta más grande y dulce. Es lección extraordinaria de frutales silvestres patrimoniales subutilizados de sabanas neotropicales: una especie nativa adaptada a fuegos sabaneros recurrentes que provee simultáneamente fruta apetente con mercado local consolidado, bebida fermentada tradicional, polinizadores nativos especializados Centris (servicio ecosistémico crítico), madera-postería durables, taninos curtientes-tintes-medicinales, y resiliencia ecológica en suelos ácidos pobres incendiables donde pocos cultivos prosperan. Su domesticación moderna por Agrosavia y universidades regionales (Universidad de los Llanos, Universidad del Atlántico, Corpoica) abre potencial agroindustrial para conservas, mermeladas, vinos y licores premium con denominación de origen llanera-caribeña. Defenderlo es defender la soberanía alimentaria de sabanas (ecosistemas que la agroindustria del arroz, palma y soya está destruyendo masivamente sin considerar alternativas frutales nativas), la dignidad de las economías campesinas-indígenas llanero-caribeñas, y la memoria gastronómica de la chicha de nance llanera y los dulces de nance costeños. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Pérez Arbeláez 1947 Plantas Útiles Colombia, Agrosavia frutales tropicales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "cajanus_cajan",
+      "nombre_comun": "Gandul",
+      "nombre_cientifico": "Cajanus cajan (L.) Huth",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "biomass_producer",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1600,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 20,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "coffea_arabica",
+        "hibiscus_sabdariffa",
+        "manihot_esculenta",
+        "musa_paradisiaca",
+        "selenicereus_megalanthus",
+        "zea_mays"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-leguminosas-andinas",
+        "fao-ecocrop",
+        "nrc-1989-cultivos-andinos",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El gandul o guandú (Cajanus cajan (L.) Huth, familia Fabaceae, tribu Phaseoleae) es una leguminosa arbustiva semi-perenne erecta de 2-4 m de altura originaria del subcontinente indio (Ghats Occidentales — Maharashtra, Karnataka, Andhra Pradesh) donde fue domesticada hace ~3500 años y diseminada vía África e introducida en América durante el comercio transatlántico como cultivo de subsistencia afroamericano profundamente arraigado en el Caribe colombiano. Se cultiva tradicionalmente en Caribe colombiano (Bolívar — Cartagena, San Juan Nepomuceno, María La Baja; Córdoba — Montería, Lorica, Cereté; Sucre — Sincelejo, Sampués; Magdalena — Santa Marta, Ciénaga, Plato; Cesar — Valledupar, San Diego; La Guajira — Riohacha, Maicao, San Juan del Cesar), Antioquia (Urabá — Apartadó, Turbo, Chigorodó; Bajo Cauca), Chocó (Quibdó, Bajo Baudó), Valle del Cauca (Buenaventura, Norte del Valle), Tolima (Espinal, Ibagué), Huila (Neiva, Garzón), Norte de Santander (Cúcuta, Ocaña) y Santander (Bucaramanga, Barrancabermeja) entre 0 y 2.000 msnm en zonas térmicas cálidas-templadas-secas-húmedas. Lección viva PEDAGÓGICAMENTE EXCELENTE de cultivo multipropósito-multiestrato: combina simultáneamente grano alimenticio proteico (semillas maduras grano seco — 19-24% proteína — para sopas, sancochos costeños, arroz con gandules), grano tierno verde como hortaliza (vainitas y semillas verdes — gastronomía afrocaribeña ancestral 'gandules verdes'), abono verde-cobertura por su rica biomasa hojosa, fijación biológica de N (100-200 kg N/ha por simbiosis con Bradyrhizobium sp. cajani), forraje arbustivo proteico para ganadería rumiante (vacas, ovejas, cabras costeñas) ramoneando hojas tiernas y vainas verdes, cerca viva-living fence productiva en bordes de chagras campesinas, leña de tallos lignificados al final del ciclo, atractor de polinizadores nativos (Apidae, Megachilidae). Planta arbustiva erecta con tallos lignificados rojizos pubescentes, hojas trifoliadas alternas pubescentes plateadas-grisáceas (foliolos elípticos), inflorescencia racimo terminal y axilar de flores grandes amarillas papilionadas (a veces con estandarte rayado rojizo), frutos legumbres alargadas planas (5-9 cm largo) verdes a maduras marrón-paja pubescentes, semillas redondeadas-ovales (cremas, marrones, rojas, negras moteadas según landrace — diversidad genética enorme de cultivares africanos-asiáticos-caribeños). Tolerancia extraordinaria a sequía severa (sobrevive estiajes de 3-5 meses por sistema radicular profundo pivotante 1-2 m), suelos pobres degradados ácidos (pH 5-7, Al sat hasta 30%), alta temperatura, salinidad moderada. Manejo agroecológico: siembra directa de semilla a 3-5 cm profundidad, distancia 60-100 cm entre plantas x 1-1.5 m entre surcos (8-15 kg/ha semilla), inoculación con Bradyrhizobium cajani opcional (ya hay cepas nativas en Caribe colombiano por siglos de cultivo), asocio tradicional con maíz-yuca-plátano-papaya en milpas afrocaribeñas, no requiere fertilización N (autosuficiente por fijación), poda anual tras cosecha para estimular rebrote (planta semi-perenne 2-5 años productiva), control de barrenadores de vainas Maruca vitrata con purín de tabaco + ajo y trampas de feromonas, cosecha grano verde 5-6 meses, grano seco 7-9 meses, rendimientos 0.8-2.5 t/ha grano seco según landrace y manejo. Función en chagra/huerto escolar afrocaribeño como leguminosa arbustiva multipropósito de soberanía alimentaria, cerca viva productiva, abono verde-cobertura biomasa, fijador N suelos pobres, forraje rumiante costeño, atractor polinizadores, cultivo afrocolombiano patrimonial. Fuentes Tier A: AGROSAVIA Leguminosas Andinas, NRC 1989, FAO Ecocrop Cajanus cajan, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "canna_edulis",
+      "nombre_comun": "Achira / SagU",
+      "nombre_cientifico": "Canna edulis Ker Gawl.",
+      "familia_botanica": "Cannaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "medio",
+      "propagation": {
+        "metodo_principal": "rizoma",
+        "notas": "Propagacion por division de rizomas en epoca lluviosa. La harina de achira se usa tradicionalmente para elaborar bizcochos, coladas y pan."
+      },
+      "companions": [
+        "musa_paradisiaca",
+        "phaseolus_vulgaris"
+      ],
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La achira o sagú (Canna edulis Ker Gawl., familia Cannaceae) es una cannácea perenne rizomatosa cultivada tradicionalmente en sistemas campesinos colombianos andinos como planta de usos múltiples: producción de almidón de alta digestibilidad (rizoma), ornamental por sus inflorescencias rojo-anaranjadas y follaje ancho, fuente de fibra textil de hoja y alimento de fauna polinizadora (colibríes). Se cultiva en Boyacá (Sutamarchán, Saboyá, Tunja), Cundinamarca (Pacho, Chocontá, Subachoque), Huila (Garzón, Pitalito), Nariño (Pasto, Sandoná) y Eje cafetero entre 1.200 y 2.800 msnm en zona térmica templada a fría. Ciclo 8-10 meses a primera cosecha de rizomas, productividad sostenida 3-5 cosechas en parcela bien manejada. Rendimientos 15-25 t/ha rizoma fresco. Lección viva de la chagra muisca: enseña el procesamiento tradicional de rizomas (rallado + decantación de almidón + secado al sol) para harina libre de gluten y el valor cultural ancestral del bizcocho de achira huilense (denominación de origen IGP), conector identitario entre cocina campesina y memoria precolombina. Manejo agroecológico: siembra por trozos de rizoma con 2-3 yemas en hoyos 30 cm con compost, asocio con plátano y fríjol, riego complementario en verano, no requiere fertilización química. Fuentes Tier A: AGROSAVIA Manual Cultivos Andinos, NRC 1989 Lost Crops of the Incas, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "capsicum_baccatum_aji_amarillo",
+      "nombre_comun": "Ají amarillo andino",
+      "nombre_cientifico": "Capsicum baccatum L.",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 600,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 15,
+        "optimo_max": 25,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinación 10-20 días a 20-25°C (más lenta que C. annuum). Trasplante a las 8 semanas. Distancia 60-80 cm. Ciclo 5-7 meses a primera cosecha. Más rústico al frío andino que otras especies de Capsicum."
+      },
+      "antagonists": [
+        "juglans_neotropica"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "agrosavia-manual-frutales-tropicales",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El ají amarillo andino (Capsicum baccatum L., Solanaceae) es una de las cinco especies de ají domesticadas en los Andes precolombinos, originaria del altiplano boliviano-peruano-noroeste argentino y cultivada ancestralmente en los Andes ecuatorianos y colombianos desde el sur de Nariño hasta Boyacá-Cundinamarca, con presencia documentada en las regiones Andina (Nariño, Cauca, Valle del Cauca, Huila, Tolima, Cundinamarca, Boyacá, Santander) entre 600 y 3.000 msnm en zonas térmicas templadas y frías — su adaptación al clima fresco-frío andino es su rasgo más distintivo frente a otras especies de Capsicum que prefieren climas cálidos. Pertenece a la familia Solanaceae (igual que tomate, papa, pimentón, lulo, tomate de árbol, uchuva, rocoto, ají dulce, ulluco) y al género Capsicum sección Baccatum, hermana evolutiva de C. pubescens (rocoto) con la que comparte adaptación a altitudes altas. El fruto característico es alargado-fusiforme (8-15 cm), color amarillo intenso a anaranjado cuando maduro, con picor moderado a alto (30.000-50.000 SHU equivalente a cayena), sabor afrutado-frutal distintivo con notas a piña-mango (debido a ésteres aromáticos únicos de la especie), excelente para conservas en escabeche, pastas, salsas y cocina andina tradicional. Carácter diagnóstico: corolas blanco-cremas con manchas amarillas en la base de los pétalos (única en el género Capsicum cultivado), distinto a las corolas blanco-puras de C. annuum/chinense. Su nombre quechua 'kellu uchu' significa literalmente 'ají amarillo' y constituye uno de los condimentos icónicos de la cocina peruano-boliviana (papa a la huancaína, ají de gallina, escabeche) que también se cultiva en Colombia andina. Es lección viva de bio-diversidad cultivada y soberanía alimentaria que enseña a niñas y niños cómo cada especie de ají se adaptó a un piso térmico distinto: el chinense al trópico cálido, el baccatum al andino fresco, el pubescens al frío. Manejo agroecológico: propagación por semilla (germinación 10-20 días a 20-25°C, más lenta que C. annuum por adaptación a clima fresco), trasplante a las 8 semanas, distancia 60-80 cm entre plantas, riego regular sin encharcamiento, tutorado obligatorio (planta puede alcanzar 1.5-2 m), cosecha escalonada 5-7 meses, frutos verdes para escabeche y maduros amarillos para pastas. Companion plants: albahaca, cebollín, zanahoria, lechuga. Función en chagra como hortaliza-condimento andina de alto valor agroalimentario y cultural. Fuentes Tier A: GBIF Backbone Taxonomy, POWO Kew, Bernal 2015, AGROSAVIA Manual Frutales Tropicales, Pérez-Arbeláez 1947.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "ají"
+      ]
+    },
+    {
+      "id": "capsicum_pubescens_rocoto",
+      "nombre_comun": "Rocoto",
+      "nombre_cientifico": "Capsicum pubescens Ruiz & Pav.",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 3200,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinación lenta 15-30 días a 18-22°C. Planta perenne arbustiva 2-3 m. Trasplante a las 10-12 semanas. Distancia 1-1.2 m. Primera cosecha 8-12 meses, productiva 3-5 años. Único Capsicum con semillas negras (carácter diagnóstico) y flores moradas."
+      },
+      "antagonists": [
+        "juglans_neotropica"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "perez-arbelaez-1947-plantas-utiles",
+        "agrosavia-tibaitata"
+      ],
+      "valor_pedagogico": "El rocoto (Capsicum pubescens Ruiz & Pav., Solanaceae) es el único ají adaptado al clima frío de los Andes altos, una especie única en el género Capsicum por su rusticidad a altitudes superiores a 2.000 msnm donde otras especies de ají no prosperan, originaria del altiplano boliviano-peruano y cultivada ancestralmente desde la época precolombina en los Andes ecuatoriano-colombianos: en Colombia se cultiva en Nariño (Pasto, Ipiales, Cumbal), Cauca (Popayán, Silvia, Páez), Boyacá (Tunja, Garagoa, Sogamoso), Cundinamarca (Sabana, Tenjo, Cota) entre 1.200 y 3.500 msnm en zonas térmicas frías y templadas frías. Pertenece a la familia Solanaceae y al género Capsicum sección Pubescens, taxonómicamente más basal y evolutivamente más antigua que las otras especies del género. Tiene tres caracteres diagnósticos únicos en Capsicum: 1) semillas negras (todas las demás especies tienen semillas blanco-amarillas), 2) flores violeta-moradas con corola estrellada (las demás tienen flores blancas o crema), 3) hojas y tallos pubescentes (con pelos visibles, de allí el epíteto 'pubescens'). El fruto es globoso a piriforme (4-7 cm), color rojo-naranja a amarillo cuando maduro, picor alto a muy alto (30.000-100.000 SHU equivalente a habanero suave), pulpa carnosa más gruesa que otros ajíes (semejante a pimentón), sabor frutal con sutil amargor herbal, excelente para rellenar (rocoto relleno boliviano-peruano), salsas crudas (ají de rocoto) y conservas. Planta arbustiva-arborescente perenne de 2-3 m de altura que puede vivir 5-10 años produciendo en clima andino — característica única en el género que la convierte en cultivo permanente patio-huerto-shamba andino. Es lección extraordinaria de adaptación evolutiva al frío y de cómo los pueblos andinos seleccionaron una especie diferente a las del trópico para resolver el problema cultural de tener ají en clima frío: el rocoto demuestra que la biodiversidad agrícola no es uniformidad sino especialización ecológica, y enseña a niñas y niños que el clima frío también tiene su propio picante nativo. Manejo agroecológico: propagación por semilla (germinación lenta 15-30 días a 18-22°C, requiere paciencia), trasplante a las 10-12 semanas, distancia 1-1.2 m (planta grande), tutorado obligatorio (arbusto pesado), poda de formación al 2do año, riego regular sin exceso, primera cosecha 8-12 meses, productiva 3-5 años, sensible a heladas intensas (-2°C letal). Función en chagra andina como ají perenne patrimonial de clima frío, condimento patio y cosecha continua. Fuentes Tier A: GBIF Backbone Taxonomy, POWO Kew, Bernal 2015, Pérez-Arbeláez 1947, AGROSAVIA Tibaitatá.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "cariniana_pyriformis",
+      "nombre_comun": "Abarco",
+      "nombre_cientifico": "Cariniana pyriformis Miers",
+      "familia_botanica": "Lecythidaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 800,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cedrela_odorata",
+        "cordia_alliodora",
+        "myroxylon_balsamum",
+        "swietenia_macrophylla"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "uicn-red-list",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "sinchi-amazonia-colombiana"
+      ],
+      "valor_pedagogico": "El abarco (Cariniana pyriformis Miers, Lecythidaceae) es uno de los árboles maderables más patrimoniales, más gigantes y más amenazados del bosque húmedo tropical colombiano. Nativo del norte de Sudamérica, en Colombia se distribuye en bosques húmedos tropicales de baja altitud en la región del Catatumbo (Norte de Santander), Magdalena medio (Santander, Cesar, Antioquia bajo), Pacífico (Chocó, Valle, Cauca) y Amazonía baja (Caquetá, Putumayo) entre 0 y 800 msnm en zona térmica cálida muy húmeda con precipitación >2000 mm/año. Árbol siempreverde gigante que alcanza 35-50 m de altura emergente del dosel forestal, fuste recto cilíndrico de hasta 1.8 m de diámetro con contrafuertes basales tabulares prominentes, copa amplia hemisférica, hojas alternas elípticas coriáceas brillantes, flores blanco-amarillentas pequeñas en panículas terminales, su característica más distintiva es el fruto: un pixidio (cápsula leñosa con tapa operculada que se abre como una bombonera) en forma de pera invertida (de ahí 'pyriformis' = en forma de pera) que libera semillas aladas dispersadas por viento, fruto típico de la familia Lecythidaceae (igual familia que la castaña amazónica Bertholletia excelsa y el sapucayá). ALERTA CONSERVACIÓN CRÍTICA: categorizada EN PELIGRO (EN) en la Lista Roja IUCN y CRÍTICAMENTE AMENAZADA / CRÍTICA (CR) en el Libro Rojo Plantas Colombia (Cárdenas & Salinas 2007), una de las categorías más alarmantes para un árbol nativo colombiano. La sobreexplotación maderera histórica para construcción naval y obras civiles pesadas, combinada con la deforestación masiva de las regiones del Catatumbo (frontera con Venezuela), Magdalena medio y Pacífico chocoano, han reducido las poblaciones silvestres en >85% del rango original. Sinchi y CAR Norte de Santander mantienen programas prioritarios de conservación in situ del abarco en la serranía de los Motilones. Su madera marrón-rojiza extremadamente densa (>0.85 g/cm³), durable y resistente a la pudrición, los hongos y los xilófagos marinos es considerada una de las maderas finas más valiosas del Neotrópico para construcción naval (cuadernas, quillas, costillas de barcos), durmientes ferroviarios, puentes de carga pesada, vigas estructurales y ebanistería patrimonial; en la región del Catatumbo es la madera tradicional para construcciones rurales históricas. El cultivo agroforestal asociado a cacao o bajo dosel residual es la principal alternativa de conservación productiva: aporta sombrío ligero al cacaotal y permite cosecha de madera a 40-60 años como legado generacional. Manejo agroecológico: vivero a sombra 60% por 8-12 meses, plantación definitiva a 50-60 cm con espacio amplio (mínimo 8x8 m), asocio bajo dosel de árboles pioneros, crecimiento moderado, sólo plantación con permiso de autoridad ambiental. Es lección crítica de conservación: el abarco es uno de los árboles más emblemáticos del bosque húmedo tropical colombiano y simultáneamente uno de los más cerca de la extinción comercial; plantar abarco hoy en sistema agroforestal o programa de restauración es acto urgente de reparación con la selva. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia (CR), IUCN Red List (EN), Bernal et al. 2015, POWO Kew, GBIF, Sinchi Amazonía/Catatumbo.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "cassia_grandis",
+      "nombre_comun": "Cañafístula",
+      "nombre_cientifico": "Cassia grandis L.f.",
+      "familia_botanica": "Fabaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 6,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "gliricidia_sepium",
+        "tabebuia_rosea"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La cañafístula, cañandonga o caraqueño (Cassia grandis L.f., Fabaceae subfamilia Caesalpinioideae) es uno de los árboles medicinales-ornamentales más patrimoniales del bosque seco tropical (bs-T) y bosque húmedo tropical colombiano, distinguible y diagnóstico por sus vainas leñosas cilíndricas grandes de 30-60 cm de largo y 3-5 cm de diámetro (las vainas más grandes del género Cassia americano), de donde proviene el nombre \"cañafístula\" (literalmente \"caña-flauta\" por la similitud morfológica con una caña tubular). Es importante NO CONFUNDIR esta cañafístula americana con la \"cañafístula asiática\" (Cassia fistula L.) introducida en Colombia como ornamental urbana, que es otra especie del mismo género originaria de India-Asia con vainas similares pero flores amarillas (la C. grandis colombiana tiene flores rosado intenso, característica diagnóstica). Nativo del Neotrópico desde México hasta Brasil-Perú, en Colombia se distribuye en bs-T y bosque húmedo tropical de los valles del Magdalena (Tolima, Huila, Cundinamarca, Santander), Cauca (Valle, Cauca), Patía, Sinú-San Jorge (Córdoba, Sucre), Caribe (Magdalena, Bolívar, Atlántico, La Guajira), Pacífico bajo (Chocó), Orinoquía y Amazonía baja entre 0-1.200 msnm en zona térmica cálida a templada. Árbol caducifolio de 15-25 m de altura con copa amplia abierta hasta 15 m de diámetro, fuste recto cilíndrico, corteza grisácea fisurada, hojas paripinnadas con 8-20 pares de folíolos elípticos obtusos verde-oscuros brillantes caducas en estación seca, flores rosado intenso a magenta espectaculares en racimos terminales grandes (panículas) de 20-40 cm de largo melíferas, frutos vaina leñosa cilíndrica indehiscente marrón-negra característica con pulpa dulce-aromática que rodea las semillas planas brillantes. Su uso medicinal tradicional más extendido es la pulpa de las vainas como laxante suave y regulador intestinal: las vainas maduras se parten y se hierve la pulpa en agua o leche para obtener un jarabe oscuro dulce-aromático efectivo en estreñimiento crónico (contiene antraquinonas: emodina, reína, crisofanol, sennósidos), parasitismo intestinal leve, y dispepsia. La medicina tradicional caribeña-vallecaucana también usa la decocción de hojas para diabetes leve, infecciones urinarias y heridas externas (lavados antisépticos). La industria nutracéutica moderna ha desarrollado extractos estandarizados de Cassia grandis como suplemento gastrointestinal natural, con mercado creciente en Colombia, México y Brasil. Además del uso medicinal, la cañafístula es uno de los árboles ornamentales más espectaculares del trópico americano: la floración rosado-magenta intensa al inicio de las lluvias (marzo-mayo) cubre completamente la copa pre-foliación con racimos colgantes de hasta 40 cm de largo, un espectáculo visual comparable a los cerezos japoneses (sakura) pero adaptado al trópico. Es ampliamente plantada en plazas, parques, avenidas y caminos rurales del Caribe, Valle y piedemonte llanero como ornamental nativa que sustituye exitosamente especies exóticas (Tabebuia rosea, Jacaranda mimosifolia se complementan con la cañafístula en jardinería patrimonial colombiana). En sistemas agroforestales acepta densidades 80-120 árb/ha como sombrío cafetalero-cacaotero, con la ventaja adicional de generar ingreso complementario por venta de vainas medicinales en mercados naturales (precios estables 5-15 USD/kg seca según calidad). Su madera marrón clara de densidad media (0.65-0.75 g/cm³) es apreciada en ebanistería complementaria, mangos de herramienta y leña, aunque el valor principal está en los servicios ecosistémicos y la producción medicinal. Como Caesalpinioideae fija nitrógeno biológico parcialmente (subfamilia con baja capacidad nodulante comparada con Mimosoideae). Atrae polinizadores nativos clave: abejas Apidae Apis mellifera, Meliponini (Tetragonisca, Melipona), abejorros Bombus, mariposas, aves nectarívoras (Coereba flaveola, Thraupis, Tangara), murciélagos nectarívoros (Glossophaga, Anoura). Manejo agroecológico: propagación por semilla con escarificación mecánica o agua hirviendo + remojo 24 h (germinación 70-85% a 10-20 días), vivero 5-6 meses a sol parcial, plantación definitiva a 30-40 cm, distancia 8×8 m en sombrío o 10×10 m en restauración, primera floración año 5-6, primera cosecha de vainas año 6-8 con producción estable 20-40 kg/árb/año a partir del año 10. Es lección extraordinaria de cómo la flora medicinal patrimonial nativa colombiana puede simultáneamente cumplir función ornamental urbana espectacular, producir un medicamento natural seguro y eficaz (laxante suave reconocido mundialmente), generar ingreso campesino vía mercado nutracéutico, proveer sombrío cafetalero y atraer polinizadores nativos. Defenderla es defender la soberanía sanitaria frente a laxantes farmacéuticos sintéticos importados, la diversidad ornamental urbana frente a la monotonía de especies exóticas, y la memoria cultural de la medicina tradicional caribeño-vallecaucana. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Pamplona-Roger 2006 Plantas Medicinales, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "cecropia_telealba",
+      "nombre_comun": "Yarumo plateado",
+      "nombre_cientifico": "Cecropia telealba Cuatrec.",
+      "familia_botanica": "Urticaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "biomass_producer",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1200,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "companions": [
+        "vismia_baccifera"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-flora-alto-andina",
+        "sib-colombia",
+        "restauracion-cruz-verde-sumapaz",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "El yarumo plateado (Cecropia telealba Cuatrec., Urticaceae) es un árbol pionero andino nativo (8-20 m altura, ocasionalmente hasta 25 m, tronco recto hueco entrenudoso característico del género Cecropia que aloja hormigas Azteca en simbiosis) propio del bosque subandino y alto-andino colombiano entre 1.200 y 2.400 msnm, presente en cordilleras Oriental, Central y Occidental: Cundinamarca, Boyacá, Antioquia, Caldas, Risaralda, Quindío, Valle, Cauca, Nariño, Santander y Tolima. Hojas grandes peltadas digitalmente lobuladas (7-11 lóbulos, 25-50 cm de diámetro) con envés característico blanco-plateado tomentoso (de ahí el nombre 'telealba' = paño blanco) que crea efecto plateado visible a distancia en el dosel, inflorescencias amentos cilíndricos colgantes con flores diminutas dioicas, frutos numerosos en infrutescencias amentiformes amarillo-rojizas muy buscadas por tucanes, perezosos de tres dedos (Bradypus variegatus), monos y aves frugívoras. Es lección viva de ecología de bosques pioneros andinos y mutualismos planta-animal que enseña a niñas y niños cómo el yarumo plateado es uno de los pilares de la restauración de bosques alto-andinos colombianos por ser una especie pionera de crecimiento muy rápido (2-4 m/año), que abre dosel y crea sombra ligera bajo la cual germinan especies de sucesión tardía (robles, encenillos, gaques), aloja una de las simbiosis hormiga-planta mejor documentadas de los neotrópicos (las hormigas Azteca habitan los entrenudos huecos y defienden la planta contra herbívoros recibiendo a cambio cuerpos müllerianos ricos en glucógeno producidos en las trichilias de la base del peciolo), alimenta perezosos y tucanes en redes ecológicas críticas, produce fibra de corteza usada artesanalmente, sus hojas grandes y secas se usan tradicionalmente como papel-cartón biodegradable y como medicina (diurética, antiasmática, hipoglucemiante validada farmacognosticamente), y aparece como especie estratégica en planes de restauración Cruz Verde-Sumapaz, Chingaza y cuenca del río Bogotá. Manejo agroecológico: propagación por semilla (germinación 30-60 días, requiere luz) o esqueje semileñoso, vivero 6-12 meses, distancia 4-6 m, crecimiento juvenil muy rápido pero vida útil de árbol corta (30-50 años), función como árbol pionero de sombra ligera-restauración-nodriza-medicinal en sistemas agroforestales andinos y planes de restauración de cuencas. Fuentes Tier A: GBIF, POWO Kew, Bernal 2015, IAvH Flora, SiB Colombia, Plan Restauración Cruz Verde-Sumapaz, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
       "id": "cedrela_montana",
       "nombre_comun": "Cedro de montaña",
-      "nombre_comunes_regionales": [
-        "cedro andino",
-        "cedro de tierra fría",
-        "cedro rosado"
-      ],
       "nombre_cientifico": "Cedrela montana Moritz ex Turcz.",
       "familia_botanica": "Meliaceae",
       "category": "arboles_sombra",
@@ -3265,73 +10164,19 @@
       "radiacion": "sol_pleno",
       "agua": "medio",
       "drenaje_requerido": "bueno",
-      "habito": "árbol caducifolio de montaña, 20-30 m altura, fuste recto, copa amplia globosa, corteza pardo-grisácea profundamente fisurada",
-      "propagation": {
-        "methods": [
-          "semilla"
-        ],
-        "best_method": "semilla",
-        "protocol_resumen": "Semilla alada recolectada de cápsulas dehiscentes en estación seca (julio-agosto en Andes colombianos). Sin tratamiento pregerminativo. Germinación 60-80% a 20-40 días en bandejas con sustrato orgánico. Vivero a media sombra 50%. Plantación definitiva a los 5-8 meses (30-50 cm altura) a inicio de lluvias.",
-        "tiempo_a_establecimiento_dias": 90,
-        "notas": "Análogo andino de Cedrela odorata adaptado a clima frío templado. Menos atacado por Hypsipyla grandella que C. odorata. Madera rosada apreciada en mueblería andina. Recomendado restauración Andes 1500-2800 msnm.",
-        "fuente": "Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia; Bernal et al. 2015; CIAT/AGROSAVIA manuales restauración andina"
-      },
       "companions": [
         "alnus_acuminata",
+        "cinchona_officinalis",
+        "cinchona_pubescens",
         "coffea_arabica",
+        "escallonia_pendula",
         "inga_densiflora",
-        "juglans_neotropica"
+        "juglans_neotropica",
+        "magnolia_caricifragrans",
+        "magnolia_yarumalensis",
+        "myrsine_coriacea",
+        "oreopanax_floribundum"
       ],
-      "antagonists": [],
-      "manejo_por_escala": {
-        "apartamento": {
-          "viable": false,
-          "nota": "Árbol 20-30 m, inviable."
-        },
-        "huerto_casero": {
-          "viable": true,
-          "nota": "Ejemplar patrimonial en huerto andino >800 m² como sombra y reserva maderable familiar.",
-          "tips": [
-            "Plantación a >8 m de construcciones",
-            "Podas de formación años 2-4 para fuste recto"
-          ]
-        },
-        "invernadero_mediano": {
-          "viable": false,
-          "nota": "Inviable bajo cubierta."
-        },
-        "produccion": {
-          "viable": true,
-          "nota": "Plantaciones maderables andinas templado-frío 400-625 árb/ha (4x4 a 5x5 m) o sombrío café-altura 80-150 árb/ha. Turno comercial 30-40 años para diámetros >40 cm.",
-          "tips": [
-            "Asocio con Alnus o Inga densiflora",
-            "Raleos progresivos años 10-18-25",
-            "Menor presión Hypsipyla que C. odorata"
-          ]
-        },
-        "restauracion": {
-          "viable": true,
-          "nota": "Especie clave restauración bosque andino premontano y montano bajo Andes colombianos.",
-          "tips": [
-            "Densidad 600-800 ind/ha",
-            "Asociar con Alnus acuminata como N-fijadora pionera",
-            "Protección de ganado primeros 5 años"
-          ]
-        }
-      },
-      "scale_viability": [
-        "huerto_casero",
-        "produccion",
-        "restauracion"
-      ],
-      "plagas_criticas": [
-        "Hypsipyla grandella — barrenador del cedro, menor presión que C. odorata pero presente en plantaciones puras"
-      ],
-      "enfermedades_criticas": [],
-      "harvest_type": "biomasa",
-      "validation_level": "claude_draft",
-      "rol_ecologico": "Maderable nativo del bosque andino montano colombiano. Caducifolio que aporta hojarasca estacional rica en N al suelo, atractor de polinizadores nativos (panículas florales melíferas), hospedero de avifauna andina, especie clave para restauración entre 1500-2800 msnm. Madera rosada-rojiza apreciada en ebanistería tradicional andina.",
-      "valor_pedagogico": "El cedro de montaña (Cedrela montana, Meliaceae) es el análogo andino del cedro real (Cedrela odorata) adaptado al clima templado-frío de los bosques montanos colombianos entre 1.500 y 2.800 msnm. Distribuido en la región Andina especialmente en Antioquia, Boyacá, Cundinamarca, Caldas, Quindío, Risaralda, Tolima, Huila, Valle del Cauca, Cauca, Nariño y Santanderes. Árbol caducifolio de montaña de 20-30 metros de altura con fuste cilíndrico recto, copa amplia globosa y corteza pardo-grisácea profundamente fisurada longitudinalmente; hojas pinnadas grandes con folíolos lanceolados-elípticos verde oscuro que despiden olor característico a cedro al frotarlas (igual que C. odorata), flores pequeñas blanco-verdosas en panículas terminales melíferas atractoras de abejas y mariposas nativas, cápsulas leñosas dehiscentes con semillas aladas dispersadas por viento de montaña en estación seca. Su madera —de color rosado-rojizo, aromática, de densidad media— ha sido históricamente apreciada en la ebanistería tradicional andina colombiana para mueblería rural, puertas, ventanas, vigas y construcción patrimonial campesina del altiplano cundiboyacense y la zona cafetera de altura. A diferencia del cedro real (C. odorata) de tierras bajas calientes, el cedro de montaña se desarrolla en climas templados-fríos con temperaturas medias 12-20°C y aguanta heladas suaves hasta -2°C, lo que lo hace ideal para reforestación de tierras altas y de cordillera Andina colombiana. Su mayor virtud agroecológica es que sufre menor presión del barrenador Hypsipyla grandella que su congénere de tierra caliente, lo que permite plantaciones más puras y de mayor productividad maderable sin requerir tanto sombrío protector. Es especie clave en programas de restauración de bosque andino montano y premontano, asociado a Alnus acuminata (aliso N-fijador pionero) que actúa como nodriza inicial mientras el cedro alcanza el dosel intermedio. Su asocio agroecológico tradicional incluye los cafetales de altura (1.500-2.000 msnm) en Caldas, Quindío, Antioquia y Santander, donde aporta sombrío parcial, biomasa hojarasca rica, atractor de polinizadores y madera patrimonial familiar de turno largo (30-40 años). Es lección de soberanía maderera andina: en lugar de pino patula o pino radiata exóticos plantados masivamente en los Andes durante el siglo XX (con altos costos ecológicos: acidificación, erosión, desertificación de suelos), el cedro de montaña nativo ofrece servicios maderables equivalentes con servicios ecosistémicos completos (biodiversidad, polinización, fauna). Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, CIAT/AGROSAVIA manuales restauración andina.",
       "source_ids": [
         "libro-rojo-plantas-colombia",
         "bernal-2015-plantas-liquenes-colombia",
@@ -3339,10 +10184,4345 @@
         "gbif-taxonomic-backbone",
         "ciat-1995-alnus"
       ],
-      "tracking_mode": "individual"
+      "valor_pedagogico": "El cedro de montaña (Cedrela montana, Meliaceae) es el análogo andino del cedro real (Cedrela odorata) adaptado al clima templado-frío de los bosques montanos colombianos entre 1.500 y 2.800 msnm. Distribuido en la región Andina especialmente en Antioquia, Boyacá, Cundinamarca, Caldas, Quindío, Risaralda, Tolima, Huila, Valle del Cauca, Cauca, Nariño y Santanderes. Árbol caducifolio de montaña de 20-30 metros de altura con fuste cilíndrico recto, copa amplia globosa y corteza pardo-grisácea profundamente fisurada longitudinalmente; hojas pinnadas grandes con folíolos lanceolados-elípticos verde oscuro que despiden olor característico a cedro al frotarlas (igual que C. odorata), flores pequeñas blanco-verdosas en panículas terminales melíferas atractoras de abejas y mariposas nativas, cápsulas leñosas dehiscentes con semillas aladas dispersadas por viento de montaña en estación seca. Su madera —de color rosado-rojizo, aromática, de densidad media— ha sido históricamente apreciada en la ebanistería tradicional andina colombiana para mueblería rural, puertas, ventanas, vigas y construcción patrimonial campesina del altiplano cundiboyacense y la zona cafetera de altura. A diferencia del cedro real (C. odorata) de tierras bajas calientes, el cedro de montaña se desarrolla en climas templados-fríos con temperaturas medias 12-20°C y aguanta heladas suaves hasta -2°C, lo que lo hace ideal para reforestación de tierras altas y de cordillera Andina colombiana. Su mayor virtud agroecológica es que sufre menor presión del barrenador Hypsipyla grandella que su congénere de tierra caliente, lo que permite plantaciones más puras y de mayor productividad maderable sin requerir tanto sombrío protector. Es especie clave en programas de restauración de bosque andino montano y premontano, asociado a Alnus acuminata (aliso N-fijador pionero) que actúa como nodriza inicial mientras el cedro alcanza el dosel intermedio. Su asocio agroecológico tradicional incluye los cafetales de altura (1.500-2.000 msnm) en Caldas, Quindío, Antioquia y Santander, donde aporta sombrío parcial, biomasa hojarasca rica, atractor de polinizadores y madera patrimonial familiar de turno largo (30-40 años). Es lección de soberanía maderera andina: en lugar de pino patula o pino radiata exóticos plantados masivamente en los Andes durante el siglo XX (con altos costos ecológicos: acidificación, erosión, desertificación de suelos), el cedro de montaña nativo ofrece servicios maderables equivalentes con servicios ecosistémicos completos (biodiversidad, polinización, fauna). Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, CIAT/AGROSAVIA manuales restauración andina.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Cedro"
+      ]
+    },
+    {
+      "id": "cedrela_odorata",
+      "nombre_comun": "Cedro real",
+      "nombre_cientifico": "Cedrela odorata L.",
+      "familia_botanica": "Meliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "windbreak",
+        "nurse_plant",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1500,
+        "max_absoluto": 1900
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "aniba_perutilis",
+        "cariniana_pyriformis",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "erythrina_edulis",
+        "inga_edulis",
+        "myroxylon_balsamum",
+        "nectandra_acutifolia",
+        "ochroma_pyramidale",
+        "ocotea_calophylla",
+        "swietenia_macrophylla"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El cedro real (Cedrela odorata L., Meliaceae) es uno de los árboles maderables más patrimoniales de la América tropical, nativo desde el sur de México hasta el norte de Argentina. En Colombia se distribuye en bosques húmedos y secos tropicales y premontanos de las regiones Caribe (Magdalena, Cesar, Bolívar, Sucre, Córdoba, La Guajira), Andina (valles interandinos del Magdalena, Cauca, Patía, en Tolima, Huila, Valle, Antioquia, Santander, Norte de Santander), Pacífico (Chocó, Valle), Orinoquía (piedemonte llanero Casanare, Meta) y Amazonía (piedemonte caqueteño y putumayense) entre 0 y 1.500 msnm en zona térmica cálida a templada. Árbol caducifolio de 20-35 m de altura con fuste recto cilíndrico y corteza fisurada, hojas pinnadas grandes con folíolos lanceolados que despiden olor característico a ajo o cedro al romperlas (epíteto 'odorata'), flores pequeñas blanco-verdosas en panículas terminales melíferas, cápsulas leñosas dehiscentes con semillas aladas dispersadas por viento. Madera aromática rojiza muy apreciada en ebanistería fina, instrumentos musicales (guitarras clásicas), cajas para puros cubanos, construcción naval, mueblería de lujo. Históricamente sobreexplotada: poblaciones silvestres reducidas en >70% del rango original, listada en Apéndice III CITES Colombia y Libro Rojo Plantas Colombia como vulnerable. Su asocio agroecológico clásico es con café y cacao bajo sombrío diversificado, donde el dosel parcial reduce hasta un 60% el ataque del barrenador Hypsipyla grandella (lepidóptero Pyralidae que perfora la yema apical y deforma el fuste en plantaciones puras a plena exposición), aporta biomasa hojarasca rica en N, hospeda fauna polinizadora y eventualmente provee madera de valor patrimonial para herencia familiar (turno 25-35 años a diámetros >40 cm). Manejo agroecológico: vivero a sombra 50%, plantación definitiva entre cacaotales o cafetales, podas de formación años 2-4 para fuste recto, raleos progresivos años 8-14-20, cosecha de semilla genéticamente seleccionada. Es lección de soberanía maderera: en lugar de teca asiática o pino radiata exótico, el cedro colombiano provee maderas finas locales con menor huella ecológica y valor cultural patrimonial. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, CATIE/CONIF manuales agroforestales meliáceas tropicales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Cedro"
+      ]
+    },
+    {
+      "id": "ceiba_pentandra",
+      "nombre_comun": "Ceiba algodón",
+      "nombre_cientifico": "Ceiba pentandra (L.) Gaertn.",
+      "familia_botanica": "Malvaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 800,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 10,
+        "optimo_min": 24,
+        "optimo_max": 32,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "gliricidia_sepium",
+        "samanea_saman"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles",
+        "agrosavia-manual-frutales-tropicales"
+      ],
+      "valor_pedagogico": "La ceiba bonga, ceiba algodón o kapok (Ceiba pentandra (L.) Gaertn., Malvaceae subfamilia Bombacoideae) es el árbol emblema gigante por excelencia del bosque seco tropical (bs-T) y bosque húmedo tropical americano, considerado sagrado por las culturas indígenas precolombinas Zenú, Wayúu, Embera, Wounaan, Kuna y maya, y constituyendo patrimonio bio-cultural natural protegido en numerosos municipios del Caribe-Magdalena-Pacífico colombiano (la \"Ceiba de San Antero\" en Córdoba, la \"Ceiba de la Llanada\" en Tolú, ceibas centenarias de Cartagena de Indias, Mompós, Santa Marta, ceibas patriarcales del río Magdalena). Su porte es legendario: 30-70 m de altura (las ceibas más grandes documentadas alcanzan 80 m, lo que las coloca entre los árboles más altos del Neotrópico), copa horizontal estratificada que emerge muy por encima del dosel del bosque y es visible kilómetros a la redonda, fuste recto cilíndrico de hasta 3-5 m DAP, característicamente con AGUIJONES CÓNICOS robustos en el tronco cuando juvenil (defensa contra herbívoros mamíferos que desaparecen al envejecer), raíces tablares espectaculares de 2-5 m de altura que sostienen el árbol gigante (los \"tablones\" o \"bambas\" tradicionales del Caribe). Nativo del Neotrópico desde México hasta Bolivia-Brasil, posiblemente introducido también a África Occidental por intercambio precolombino o post-colonial (debate biogeográfico abierto), en Colombia es nativo silvestre del bs-T y bosque húmedo tropical del Caribe (La Guajira, Cesar, Magdalena, Atlántico, Bolívar, Córdoba, Sucre), Valle del Magdalena medio-bajo (Tolima, Huila bajo, Cundinamarca, Santander), Valle del Cauca, Pacífico (Chocó, Valle, Cauca, Nariño), Orinoquía (Casanare, Arauca, Meta) y Amazonía (Putumayo, Caquetá, Amazonas) entre 0-800 msnm en zona térmica cálida con precipitaciones 800-3000 mm/año. Árbol caducifolio que pierde todas sus hojas en estación seca para reducir transpiración, con hojas digitado-palmadas de 5-9 folíolos elípticos verde-oscuros, flores grandes blanco-rosadas a crema (5-8 cm) con pétalos carnosos en racimos terminales nocturnos polinizadas exclusivamente por murciélagos nectarívoros (Phyllostomidae: Glossophaga soricina, Anoura geoffroyi, Carollia perspicillata) — un servicio ecosistémico crítico que demuestra la dependencia mutualista de la ceiba con la fauna murciélago neotropical, frutos cápsula leñosa elipsoidal de 10-15 cm dehiscente longitudinalmente con 5 valvas que liberan masas de FIBRA KAPOK (lana vegetal) blanca-sedosa hidrofóbica con semillas pequeñas oscuras inmersas. La fibra kapok es el producto principal de aprovechamiento tradicional del Caribe colombiano: se cosechan las cápsulas leñosas maduras (septiembre-noviembre), se abren a mano o se golpean, y la fibra blanca-sedosa se separa de las semillas, se seca al sol y se usa tradicionalmente como relleno de almohadas (más liviana que el algodón, hidrofóbica, no se apelmaza), colchones tradicionales rurales, salvavidas (flotadores naturales: la fibra kapok es 6 veces más liviana que el algodón y absorbe poco agua, capacidad de flotación 30 veces su peso), aislante térmico-acústico en construcción tradicional, y mecha para velas-faroles. La industria moderna ha redescubierto el kapok como fibra textil ecológica de lujo y aislante termoacústico sostenible, con precios crecientes (5-15 USD/kg fibra limpia). Su madera blanco-cremosa muy liviana (densidad 0.25-0.35 g/cm³, una de las maderas más livianas del Neotrópico junto con balsa) es apreciada en tornería, modelado, embalaje liviano, embarcaciones tradicionales (canoas dugout precolombinas y actuales del río Magdalena y Pacífico), juguetería artesanal, y celulosa. En sistemas agroforestales del Caribe-Magdalena la ceiba juvenil acepta densidades 60-80 árb/ha como sombrío de cacao y café juvenil (los primeros 10-15 años), pero la ceiba adulta requiere espaciamiento muy amplio por su porte extraordinario y debe ubicarse en bordes y áreas de protección hídrica más que en plantación. Su rol ecológico como REFUGIO DE BIODIVERSIDAD es fundamental: una sola ceiba adulta sostiene una comunidad biológica completa con epífitas (orquídeas Catasetum, Encyclia, bromelias Tillandsia, Aechmea, cactáceas Rhipsalis, helechos arborescentes Cyathea, musgos, líquenes), aves nidificantes (Ramphastos toco, Brotogeris, psitácidos), mamíferos arborícolas (perezosos Bradypus, Choloepus, micos Cebus, Saimiri, Ateles), murciélagos nectarívoros polinizadores y dispersores. Es resiliente a vientos huracanados del Caribe colombiano gracias a sus raíces tablares masivas y su porte aerodinámico. Manejo agroecológico: propagación por semilla fresca (germinación 80-95% a 5-10 días, sin tratamiento pre-germinativo), vivero 6-8 meses, plantación definitiva a 30-40 cm de altura, distancia mínima 15×15 m (60 árb/ha) en restauración y 25-30 m en árbol patrimonial aislado, crecimiento extremadamente rápido (15-20 m en 8-10 años, 30-40 m a los 25 años), primera fructificación año 8-10, manejo de poda mínima por aguijones del tronco juvenil. Es lección extraordinaria de patrimonio bio-cultural y servicios ecosistémicos: un árbol sagrado patrimonial cuya existencia centenaria sostiene comunidades enteras de biodiversidad neotropical, provee fibra textil-aislante de lujo ecológico, madera liviana, sombrío juvenil cafetal-cacaotero, polinizadores murciélagos nectarívoros (servicio que sustenta polinización de muchos cultivos en bosque seco), y memoria cultural indígena precolombina viva — una sola ceiba bonga puede ser monumento natural municipal que define la identidad de un pueblo costeño. Defenderla es defender la herencia indígena, la biodiversidad del bs-T amenazado y la dignidad arbórea frente a la cultura del tala-y-quema. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Pérez Arbeláez 1947 Plantas Útiles Colombia, Agrosavia frutales tropicales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Yuímo"
+      ]
+    },
+    {
+      "id": "cenchrus_clandestinus_manejado",
+      "nombre_comun": "Kikuyo manejado",
+      "nombre_cientifico": "Cenchrus clandestinus (Hochst. ex Chiov.) Morrone",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "ground_cover",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2000,
+        "optimo_max": 2900,
+        "max_absoluto": 3200
+      },
+      "companions": [
+        "alnus_acuminata",
+        "juglans_neotropica"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "Variedad manejada del kikuyo (Cenchrus clandestinus), pasto perenne ampliamente usado en ganadería extensiva andina. Bajo manejo agroecológico (cortes programados, asociaciones con Alnus acuminata, rotación de potreros) reduce su carácter invasor original.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Kikuyo"
+      ]
+    },
+    {
+      "id": "centaurea_cyanus",
+      "nombre_comun": "Aciano azul",
+      "nombre_cientifico": "Centaurea cyanus L.",
+      "familia_botanica": "Asteraceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 10,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa o semillero, 0.5-1 cm profundidad, distancia 20-30 cm, germinación 7-14 días, floración 60-90 días post-siembra, ciclo anual 120-150 días, auto-resiembra natural. Cosecha de flores en plena apertura para uso culinario y medicinal."
+      },
+      "companions": [
+        "calendula_officinalis",
+        "helianthus_annuus"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "El Aciano azul o Azulejo (Centaurea cyanus L., Asteraceae) es una especie herbácea anual originaria de Europa templada y mediterránea, históricamente acompañante característica de campos de trigo y cereales europeos (de ahí su nombre inglés \"cornflower\" — flor del cereal), cultivada mundialmente como ornamental clásico de jardín por sus inflorescencias en capítulo de color azul cobalto puro intenso (uno de los azules más vibrantes del reino vegetal, debido a antocianinas cianidínicas estabilizadas por complejos con metales) — color tan emblemático que dio nombre al \"azul aciano\" o \"cornflower blue\" en paletas de pintura, joyería y diseño. En Colombia se cultiva en clima templado y frío entre 1.500 y 3.000 msnm: jardines Sabana de Bogotá, Boyacá altoandino, Nariño altoandino, Eje Cafetero altoandino, Antioquia oriente frío, viveros ornamentales urbanos. Manejo agronómico: siembra directa al sitio definitivo o en semillero con trasplante 4 semanas post-germinación, 0.5-1 cm profundidad, distancia 20-30 cm entre plantas, germinación 7-14 días a 12-20°C, ciclo anual 120-150 días, floración inicia 60-90 días post-siembra y se mantiene 6-10 semanas continuas si se eliminan flores marchitas (deadheading), auto-resiembra natural si se deja semillar (estrategia de poblaciones perennizadas en jardín). Las flores son comestibles crudas en ensaladas decorativas, repostería, panes (pan azul aciano francés), cubitos de hielo florales para cócteles (mantienen el azul intenso), té de flor seca (jasmin-blue cornflower blend clásico de tés británicos), pigmento natural azul (los pétalos secos teñidos suavemente azulan agua y vinagres). Uso medicinal tradicional documentado en farmacopeas europeas medievales (Hildegard von Bingen, Dioscórides referenciado a Centaurea spp.): flor en infusión astringente suave para conjuntivitis y orzuelos (lavados oculares con infusión filtrada — uso documentado como \"agua de aciano\" de farmacopea francesa siglo XIX), diurético leve, tónico digestivo. Atracción de polinizadores excepcional: el capítulo presenta flores tubulares fértiles azul puro intenso UV-reflectantes (espectro visible para abejas que detectan UV) rodeadas por flores liguladas azules vistosas, sostiene poblaciones masivas de abejas (Apis mellifera, abejas solitarias, abejorros nativos Bombus spp.), sírfidos, mariposas pequeñas, en floración prolongada de 6-10 semanas. Histórico-cultural: flor nacional de Estonia y Bielorrusia, símbolo de Prusia siglo XIX, emblema de la I Guerra Mundial en Francia (recuerdo de los caídos), flor preferida del rey Luis II de Baviera, color emblemático y nombre dado al \"cornflower blue\" en gemología (variedad azul del zafiro). Manejo en huerta agroecológica: borde perimetral o en banda apícola intercalada con trigo (recreación del paisaje agrícola europeo tradicional), girasol (Helianthus annuus) y caléndula (Calendula officinalis) como gremio multi-color atrayente de polinizadores, siembra en macetera profunda en balcón (escala apartamento viable con sol pleno), cosecha de flores en mañana fresca para uso culinario inmediato o secado a la sombra para té e infusión. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pamplona Roger 2006 Plantas Medicinales, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "aciano"
+      ]
+    },
+    {
+      "id": "chrysophyllum_cainito",
+      "nombre_comun": "Caimito morado",
+      "nombre_cientifico": "Chrysophyllum cainito L.",
+      "familia_botanica": "Sapotaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 50,
+        "optimo_max": 800,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "borojoa_sorbilis",
+        "mangifera_indica"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-frutales-tropicales",
+        "perez-arbelaez-1947-plantas-utiles",
+        "sib-colombia",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "El caimito morado (Chrysophyllum cainito L., Sapotaceae) es un árbol frutal perenne neotropical originario de las Antillas Mayores y norte de Sudamérica (Colombia, Venezuela, Panamá, Centroamérica), ampliamente cultivado en zonas bajas cálidas del Caribe colombiano (Atlántico, Bolívar, Magdalena — patios de Barranquilla, Cartagena, Santa Marta, Valledupar), Chocó biogeográfico (Quibdó, Buenaventura), Valle medio y bajo Magdalena (Honda, La Dorada, Puerto Berrío), zonas cálidas de Antioquia (Bajo Cauca, Urabá), Córdoba (Montería), Sucre (Sincelejo), Cesar y enclaves bajos de Santander (Barrancabermeja). Crece óptimamente entre 0 y 800 msnm con temperaturas de 22-30 °C, requiere sol pleno, suelos profundos bien drenados arcillosos a francos, riego moderado y resiste sequías estacionales una vez establecido. Árbol siempreverde de 12-25 m de altura con copa amplia globosa-densa y hojas pinnado-paralelas verde-brillante por el haz y dorado-bronceadas pubescentes por el envés (carácter taxonómico distintivo de Chrysophyllum — \"hoja dorada\" — visible al voltearlas con el viento, espectáculo visual que da nombre vernáculo \"hoja dorada\" en Centroamérica). Flores pequeñas blanco-cremosas perfumadas en cimas axilares polinizadas por abejas nativas (Meliponini, Trigonini) y mariposas. Frutos baya esférica de 6-10 cm con cáscara lisa violeta-purpúrea oscuro (raza más común) o verde-amarillenta (raza alba), pulpa lechosa-mucilaginosa blanca a rosada muy dulce (15-18 °Brix) con 4-10 semillas grandes negras dispuestas en figura estrellada visible al corte transversal — origen del nombre comercial \"star apple\" en mercados anglófonos. Cosecha por color violeta intenso brillante y blandeo suave; frutos verdes son astringentes por latex no maduro (lección sobre maduración postcosecha y compuestos secundarios). El árbol exuda latex blanco-lechoso al cortarse (carácter Sapotaceae) usado tradicionalmente en Cuba y Antillas como ingrediente menor de gomas de mascar artesanales (no es la fuente principal, ese es Manilkara zapota). Manejo: plantación a 8-10 m entre árboles, asocio en patio tropical con cacao en sombra inicial, plátano nodriza, mango, aguacate criollo, anón, guanábana — sistema multiestrato tradicional de patios caribeños caracterizado por Pérez Arbeláez 1947 como \"ecosistema de patio campesino afrocaribeño\". Función pedagógica excelente: enseña a niñas y niños la diversidad de Sapotaceae neotropicales (junto con níspero/zapote Manilkara zapota, mamey colorado Pouteria sapota, caimo silvestre Pouteria caimito), patrón ecológico de hojas con doble color (dorado-bronceado por envés — adaptación a alta radiación tropical reflejando luz infrarroja y reduciendo pérdida de agua), polinización por abejas nativas sin aguijón (meliponicultura urbana), maduración postcosecha y compuestos astringentes-taninos en frutos inmaduros, latex blanco como carácter Sapotaceae. Importancia cultural en Caribe colombiano como árbol de patio tradicional, alimento dulce de temporada (julio-noviembre en Atlántico), refugio de aves (tángaras Thraupidae se alimentan de frutos maduros y dispersan semillas). Fuentes Tier A: GBIF, POWO Kew, AGROSAVIA manual frutales tropicales, Pérez Arbeláez 1947, SiB Colombia, Bernal 2015.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "cinchona_officinalis",
+      "nombre_comun": "Quina amarilla",
+      "nombre_cientifico": "Cinchona officinalis L.",
+      "familia_botanica": "Rubiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado"
+      ],
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1700,
+        "optimo_max": 2000,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 1,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cedrela_montana",
+        "cinchona_pubescens",
+        "coffea_arabica",
+        "inga_densiflora"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "perez-arbelaez-1947-plantas-utiles",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La quina amarilla o cascarilla amarilla (Cinchona officinalis, Rubiaceae) es el patrimonio botánico-medicinal por excelencia de los bosques andinos premontanos del sur de Colombia y norte de Ecuador, considerada históricamente la especie con mayor concentración de alcaloides antimaláricos —especialmente quinina— entre todas las Cinchona neotropicales. Su distribución natural se centra en la cordillera Andina del sur colombiano (Cauca sur, Nariño, Putumayo) y norte ecuatoriano (Loja, Zamora-Chinchipe), entre 1.500 y 2.400 msnm en bosques andinos premontanos y montanos bajos. La región de Loja en Ecuador es considerada la 'patria original' de la quina amarilla y desde allí los jesuitas en el siglo XVII iniciaron el comercio mundial de la corteza antimalárica. Árbol perennifolio mediano de 6-12 metros de altura con fuste recto delgado, copa redondeada y corteza pardo-amarillenta característica que da su nombre vernáculo, hojas opuestas elípticas-lanceoladas verde oscuro brillantes coriáceas, flores pequeñas rosado-blanquecinas con corolas tubulares cinco-lobuladas peludas en su garganta dispuestas en panículas terminales aromáticas atractoras de polinizadores nativos (mariposas, colibríes Andigena, abejas Meliponini), cápsulas leñosas pequeñas dehiscentes con semillas aladas dispersadas por viento de montaña. Su importancia histórica es paralela a la de C. pubescens pero con química más concentrada: cuando los químicos franceses Pierre Joseph Pelletier y Joseph Bienaimé Caventou aislaron por primera vez la quinina pura en 1820 a partir de corteza de Cinchona, lo hicieron principalmente con C. officinalis, lo que confirmó científicamente lo que el conocimiento indígena andino había documentado siglos antes: que la corteza era el primer antimalárico eficaz conocido en la historia humana. Durante el siglo XIX la quina amarilla fue tan codiciada que su sobreexplotación llevó a las poblaciones silvestres sur-colombianas al borde de la extinción, hasta que el establecimiento de plantaciones holandesas en Java (con semillas extraídas clandestinamente de Bolivia y Ecuador por Charles Ledger en 1865) cambió la economía mundial de la quina y dejó el ecosistema andino sur-colombiano severamente empobrecido. Hoy está categorizada como nativa protegida en Colombia y su conservación ex situ en huertos patrimoniales del sur del país y en cafetales históricos de la cordillera sur es prioridad para mantener su acervo genético. Su asocio agroecológico tradicional con café bajo sombrío diversificado en las fincas patrimoniales del Cauca, Nariño y Putumayo permite recuperación gradual de poblaciones cultivadas. La química de la corteza incluye quinina (28-35% de los alcaloides totales), quinidina (5-8%, antiarrítmico cardíaco usado hoy en farmacopea), cinconina y cinconidina (15-20%, antimaláricos secundarios), todos farmacológicamente potentes y tóxicos si se mal dosifican —por lo que el uso medicinal tradicional requiere conocimiento etnobotánico riguroso de comunidades indígenas y campesinas sur-colombianas y norte-ecuatorianas. Es lección de soberanía botánica binacional Colombia-Ecuador: la quina amarilla es patrimonio biocultural y medicinal del eje cordillerano andino sur, su recuperación es acto de justicia histórica botánica y de fortalecimiento de la farmacopea andina. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, Pérez-Arbeláez 1947 Plantas Útiles Colombia, POWO Kew, GBIF Backbone Taxonomy, Andersson 1998 monografía Cinchona Neotropicales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "cinchona_pubescens",
+      "nombre_comun": "Quina roja",
+      "nombre_cientifico": "Cinchona pubescens Vahl",
+      "familia_botanica": "Rubiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado"
+      ],
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1500,
+        "optimo_max": 1900,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 16,
+        "optimo_max": 22,
+        "max_tolerable": 27
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cedrela_montana",
+        "cinchona_officinalis",
+        "coffea_arabica",
+        "inga_densiflora"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "perez-arbelaez-1947-plantas-utiles",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La quina roja o cascarilla roja (Cinchona pubescens, Rubiaceae) es uno de los árboles más históricamente importantes del bosque andino premontano sudamericano y patrimonio botánico-medicinal colombiano por antonomasia. Distribuida originalmente en los bosques andinos premontanos entre 1.000 y 2.000 msnm en las cordilleras Central, Occidental y Oriental colombianas, especialmente en Antioquia, Caldas, Quindío, Risaralda, Valle del Cauca, Cauca, Tolima, Huila, Cundinamarca, Boyacá, Santanderes, Nariño y Putumayo. Árbol perennifolio de 8-15 metros de altura con fuste recto, copa redondeada y corteza pardo-rojiza característica rica en alcaloides quinolínicos (quinina, quinidina, cinconina, cinconidina) que son la base farmacológica de los antimaláricos tradicionales; hojas opuestas elípticas-ovadas grandes coriáceas verde oscuro brillantes, flores pequeñas blanco-rosadas con corolas tubulares cinco-lobuladas dispuestas en panículas terminales atractoras de polinizadores nativos (abejas Meliponini, mariposas, colibríes), cápsulas leñosas pequeñas dehiscentes con semillas aladas dispersadas por viento. Su historia es uno de los capítulos más fascinantes y trágicos de la etnobotánica neotropical: los pueblos indígenas andinos (Cañaris, Quechuas, Lojas, y otros pueblos del actual Ecuador, Perú y sur de Colombia) descubrieron y usaron la corteza de quina contra fiebres palúdicas siglos antes del contacto europeo; los jesuitas españoles documentaron el uso desde el siglo XVII y exportaron la corteza a Europa donde se convirtió en el primer tratamiento eficaz contra la malaria (la 'Polvo de los Jesuitas' o 'Cinchona' nombrada en honor a la condesa de Chinchón), salvando millones de vidas durante los siglos XVIII y XIX y posibilitando la expansión colonial europea en África y Asia tropical. La sobreexplotación masiva de las poblaciones silvestres entre 1630 y 1880 (descortezamiento que mataba al árbol, talas masivas, comercio sin regulación) llevó las poblaciones colombianas, ecuatorianas, peruanas y bolivianas al borde de la extinción comercial. Cuando los holandeses lograron establecer plantaciones en Java (Indonesia) a fines del siglo XIX con esquejes y semillas extraídas clandestinamente de Sudamérica, el comercio andino de quina colapsó, dejando un legado de bosques empobrecidos genéticamente y comunidades campesinas empobrecidas económicamente. Hoy Cinchona pubescens está categorizada EN PELIGRO en el Libro Rojo de Plantas de Colombia (Cárdenas & Salinas 2007) y su conservación ex situ en huertos patrimoniales, cafetales históricos del Eje Cafetero (especialmente en Caldas y Quindío donde el cultivo de quina precedió al boom cafetero del siglo XIX) y arboretos botánicos es prioridad alta. Su asocio agroecológico tradicional con el café bajo sombrío diversificado es históricamente continuo y ofrece oportunidad de recuperación genética y cultural. PRECAUCIÓN: los alcaloides de la corteza son farmacológicamente potentes y tóxicos si se mal dosifican; uso medicinal tradicional solo bajo conocimiento etnobotánico riguroso. Es lección de soberanía botánica, historia colonial y conservación: la quina colombiana es patrimonio biocultural y medicinal del país, su recuperación en cafetales y bosques patrimoniales es acto de justicia histórica botánica. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia (categoría EN), Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, Pérez-Arbeláez 1947 Plantas Útiles Colombia, POWO Kew, GBIF Backbone Taxonomy, Andersson 1998 monografía Cinchona Neotropicales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Quina"
+      ]
+    },
+    {
+      "id": "clethra_fagifolia",
+      "nombre_comun": "Laurel hojiancho",
+      "nombre_cientifico": "Clethra fagifolia Kunth",
+      "familia_botanica": "Clethraceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
+        "optimo_max": 2900,
+        "max_absoluto": 3100
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 8,
+        "optimo_max": 15,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "viburnum_tinoides",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Clethra fagifolia Kunth (laurel hojiancho, clethra colombiana — familia Clethraceae) es un árbol perennifolio (6-15 m altura) nativo de los Andes del norte de Sudamérica (Colombia, Ecuador, Venezuela, norte de Perú), distribuido en bosque alto andino entre 2000 y 3100 msnm en piso térmico FRÍO. En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca y Santander. La familia CLETHRACEAE es botánicamente especial — es una FAMILIA MONOGENÉRICA, es decir, contiene UN SOLO GÉNERO (Clethra) con aproximadamente 75 especies distribuidas en las montañas tropicales y subtropicales de América, Asia (Malasia, Filipinas, China) y la isla de Madeira. Esta distribución biogeográfica DISYUNTA es típica de linajes antiguos gondwánicos-laurásicos que se fragmentaron con la deriva continental — Clethra es por tanto un 'fósil viviente' de las floras paleotropicales del Cretácico-Paleógeno. El epíteto 'fagifolia' significa 'hoja de haya' por la similitud morfológica con las hojas obovado-elípticas de Fagus sylvatica (haya europea) — pero NO hay relación filogenética (es convergencia evolutiva). Las flores blancas pequeñas en racimos terminales (15-30 cm de largo) son MASIVAMENTE FRAGANTES (aroma dulce a miel-cera-vainilla) y constituyen uno de los recursos florales más importantes para la avifauna polinizadora y las abejas nativas Meliponini (Trigona, Tetragonisca, Plebeia) del bosque alto andino en agosto-octubre. Lección viva sobre BIOGEOGRAFÍA DISYUNTA, FAMILIAS MONOGENÉRICAS y FLORES MELÍFERAS DEL BOSQUE ALTO ANDINO: la clethra es ejemplo paradigmático de cómo una especie aparentemente 'menor' del bosque colombiano pertenece a un linaje antiguo de distribución gondwánica-laurásica, y de cómo su floración masiva sostiene a las abejas sin aguijón Meliponini — polinizadores nativos críticos para la red ecológica de la Sabana de Bogotá, el altiplano cundiboyacense y la Cordillera Central. En restauración de Cruz Verde-Sumapaz, Chingaza, Iguaque y la Cordillera Central de Antioquia, la clethra se planta en interior de rodal restaurado con cobertura previa, asociada con gaque, encenillo y juco/sietecueros (Viburnum tinoides), formando corredores florales para polinizadores nativos. Manejo agroecológico: propagación por semilla fresca con sombra parcial 50%; trasplante 5-7 meses; plantación 15-20 meses; crecimiento 40-60 cm/año; densidades 200-300 ind/ha. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "clusia_grandiflora",
+      "nombre_comun": "Gaque grande",
+      "nombre_cientifico": "Clusia grandiflora Splitg.",
+      "familia_botanica": "Clusiaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "biomass_producer",
+        "pollinator_attractor"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2000,
+        "optimo_max": 2700,
+        "max_absoluto": 2900
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 10,
+        "optimo_max": 17,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "quercus_humboldtii",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Clusia grandiflora Splitg. (gaque grande, chagualo grande, cape grande — familia Clusiaceae) es un árbol perennifolio (10-25 m altura) hermano botánico de Clusia multiflora pero distinguible por sus hojas mucho más grandes (15-25 cm vs 8-15 cm) y por sus flores espectaculares blanco-rosáceas de 8-12 cm de diámetro — entre las más vistosas de las Clusiaceae andinas. Su distribución abarca el escudo guayanés-amazónico-andino oriental: Colombia (Cundinamarca, Boyacá, Santander, Antioquia, piedemonte del Caquetá), Venezuela, Guyana, Surinam, Brasil amazónico. En Colombia se encuentra en el bosque alto andino y subandino 1800-2800 msnm en piso térmico FRÍO con tendencia a templado-húmedo (zona de transición). A diferencia de su hermana C. multiflora (más generalista y tolerante), C. grandiflora es una especie SUCESIONAL TARDÍA del bosque alto andino — indica madurez ecológica del rodal y solo se establece cuando hay sombra parcial inicial, suelos profundos con hojarasca acumulada y red micorrízica activa. Por eso es especie BIOINDICADORA de bosques alto-andinos maduros y poco intervenidos. Lección viva sobre SUCESIÓN ECOLÓGICA, ESPECIES BIOINDICADORAS DE MADUREZ FORESTAL y RESTAURACIÓN POR FASES: en proyectos de restauración del bosque alto andino de la Cordillera Oriental (Cruz Verde-Sumapaz, Chingaza, Iguaque) y de la Cordillera Central (Antioquia, Cordillera Central de Caldas), C. grandiflora se planta en una FASE TARDÍA de la restauración — primero entran especies pioneras (Alnus acuminata, Sambucus peruviana, Vallea stipularis, Hesperomeles goudotiana), luego sucesionales intermedias (Weinmannia tomentosa, Clusia multiflora, Escallonia paniculata, Miconia squamulosa), y finalmente sucesionales tardías como C. grandiflora, Prumnopitys montana, Quercus humboldtii. Plantarla en sitios desnudos o sin sombra previa fracasa — confirma el principio agroecológico de que la restauración no es plantar árboles al azar sino reconstruir el SISTEMA con sus fases sucesionales en orden. Manejo agroecológico: propagación por semilla fresca con sombra parcial 60%; trasplante 6-8 meses; plantación 18-24 meses; asocio con C. multiflora, encenillo, roble andino; densidades 100-200 ind/ha en restauración avanzada; suelos profundos con hojarasca. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "clusia_multiflora",
+      "nombre_comun": "Gaque",
+      "nombre_cientifico": "Clusia multiflora Kunth",
+      "familia_botanica": "Clusiaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "biomass_producer",
+        "pollinator_attractor"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2900,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 8,
+        "optimo_max": 16,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "axinaea_macrophylla",
+        "clethra_fagifolia",
+        "clusia_grandiflora",
+        "freziera_canescens",
+        "ilex_kunthiana",
+        "myrcianthes_ferreyrae",
+        "myrcianthes_rhopaloides",
+        "oreopanax_incisus",
+        "prumnopitys_montana",
+        "quercus_humboldtii",
+        "vallea_stipularis",
+        "weinmannia_pubescens",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "libro-rojo-plantas-colombia",
+        "humboldt-flora-alto-andina",
+        "jbb-plantas-medicinales",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "El gaque o chagualo (Clusia multiflora Kunth, familia Clusiaceae) es un árbol perennifolio hemiepífito facultativo (8-20 m altura) emblemático del bosque alto andino de la Cordillera Oriental colombiana, distribuido entre 1800 y 3200 msnm en piso térmico FRÍO (Cundinamarca, Boyacá, Antioquia, Nariño, Cauca, Santander, Norte de Santander). Es planta nativa silvestre central para la restauración ecológica de la franja 2000-3000 msnm de Cruz Verde-Sumapaz, Chingaza, Iguaque y Guerrero, donde forma rodales mixtos con encenillo (Weinmannia tomentosa), roble (Quercus humboldtii), mortiño (Hesperomeles goudotiana) y raque (Vallea stipularis). Sus hojas coriáceas crasas opuestas (rasgo distintivo de Clusiaceae junto con el látex amarillo-resinoso al corte) son resistentes a la radiación intensa de alta montaña y a la desecación atmosférica de la estación seca. Sus flores blanco-cremosas dioicas atraen polinizadores nativos (abejas sin aguijón Meliponini, sírfidos y mariposas de alta montaña) y sus cápsulas dehiscentes con semillas de arilo carnoso anaranjado son alimento clave de aves frugívoras alto-andinas (mirlas, tucanetas esmeralda, atrapamoscas de páramo) — por eso es especie 'sombrilla' o 'paraguas ecológico': su presencia indica un bosque sano y su plantación recupera no solo la cubierta arbórea sino también la red trófica de aves dispersoras. Estrategia hemiepífita facultativa: puede germinar sobre otros árboles (epifitismo inicial sobre robles, encenillos, raques) y luego lanzar raíces aéreas al suelo formando una estructura columnar — NO mata al hospedante (a diferencia del 'strangler fig' Ficus tropical), sino que coexiste, lo que la hace ecológicamente noble. Lección viva sobre BOSQUE ALTO ANDINO, HEMIEPIFITISMO, RESTAURACIÓN DE LADERAS COLOMBIANAS y DISPERSIÓN ORNITÓCORA: el gaque es ejemplo paradigmático de cómo una especie nativa con estrategia ecológica sofisticada (hemiepífita + dioica + ornitócora) sostiene ecosistemas enteros, y de cómo su plantación en proyectos de restauración del flanco occidental de la Cordillera Oriental (Cruz Verde-Sumapaz, Chingaza) acelera la regeneración del bosque alto andino vs plantaciones monoespecíficas de pino o eucalipto que esterilizan el suelo. Manejo agroecológico: propagación por semilla fresca con sombra parcial 50%, trasplante 4-6 meses, plantación 12-18 meses; asocio con encenillo, roble andino y raque; densidades 200-400 ind/ha para reconectar fragmentos boscosos; evitar sitios expuestos al viento de páramo. Estado conservación: nativo silvestre NO amenazado pero localmente raro en sitios donde el bosque alto andino fue convertido a pastura para ganadería lechera (Sabana de Bogotá, altiplano cundiboyacense, altiplano nariñense). Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Libro Rojo Plantas Colombia, Humboldt Flora Alto-Andina, JBB Plantas Medicinales, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "cosmos_sulphureus",
+      "nombre_comun": "Cosmos amarillo",
+      "nombre_cientifico": "Cosmos sulphureus Cav.",
+      "familia_botanica": "Asteraceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 600,
+        "optimo_max": 2500,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa al voleo o en hileras post-último riesgo de heladas, 0.5-1 cm profundidad, distancia 30-40 cm entre plantas, germinación 5-10 días, floración 50-70 días post-siembra, ciclo anual 100-120 días, auto-resiembra natural abundante."
+      },
+      "companions": [
+        "helianthus_annuus",
+        "tagetes_minuta"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "El Cosmos amarillo (Cosmos sulphureus Cav., Asteraceae) es una especie herbácea anual originaria de México (mesetas centrales, Oaxaca, Chiapas, Veracruz) y Centroamérica, naturalizada y cultivada mundialmente como ornamental clásico de jardín tropical-subtropical por sus capítulos vistosos de color amarillo-anaranjado a rojo-naranja intenso característico (de ahí sulphureus — del color del sulfuro/azufre) y por su atractivo masivo de mariposas y otros polinizadores. Distinta de su congenérica Cosmos bipinnatus (cosmos rosado-blanco de clima frío, hojas bipinnadas finísimas, capítulos rosa-blanco-morado, mayor altitud) por su color cálido amarillo-anaranjado característico, hojas pinnadas más anchas (no bipinnadas finísimas), tolerancia a clima más cálido tropical (vs. preferencia de bipinnatus por clima frío), tamaño menor (1-2 m vs. bipinnatus 1.5-3 m). En Colombia se cultiva en clima cálido, templado y frío entre 0 y 2.800 msnm: Caribe, valles interandinos, Sabana de Bogotá, Eje Cafetero, Antioquia, Boyacá, Nariño, Llanos Orientales — especie de amplísimo rango altitudinal por adaptación termal flexible. Manejo agronómico: siembra directa al sitio definitivo al voleo o en hileras post-último riesgo de heladas (en clima frío andino esperar a final de febrero-marzo), 0.5-1 cm profundidad, distancia 30-40 cm entre plantas, germinación 5-10 días a 18-25°C, ciclo anual 100-120 días, floración inicia 50-70 días post-siembra y se mantiene 8-12 semanas continuas si se eliminan flores marchitas, auto-resiembra natural ABUNDANTE (se naturaliza en jardines y bordes de huerta tras una sola siembra). Atracción excepcional de polinizadores: especie reconocida mundialmente como UNA DE LAS PLANTAS MÁS ATRAYENTES DE MARIPOSAS del mundo (lepidópteros diurnos de varias familias: Pieridae, Nymphalidae, Hesperiidae, Lycaenidae), también atrae intensivamente abejas (Apis mellifera, abejas solitarias, abejorros Bombus spp.), sírfidos, escarabajos polinizadores y colibríes. La estructura del capítulo presenta abundante néctar accesible y polen abundante en disco amarillo central, en floración prolongada de 2-3 meses continuos. Pigmentos naturales: las flores secas son fuente de carotenoides (xantofilas, luteína, zeaxantina) usados como tintes alimentarios naturales amarillo-naranja en panadería, mantequillas, quesos, yemas de huevo de gallinas alimentadas con harina de flor seca (mejora pigmentación natural sin químicos), tinte textil natural amarillo-naranja tradicional mexicano. Uso medicinal tradicional documentado en farmacopeas mexicanas: infusión de flor diaforético, suavemente sedante, antimicrobiano. Manejo en chagra y huerta agroecológica: borde perimetral de huerta como banda atrayente de polinizadores y mariposas (mariposario de huerta — pedagogía infantil ideal), siembra en gremio con girasol (Helianthus annuus), tagetes (Tagetes minuta) y zinnia (Zinnia elegans) como combo \"jardín de mariposas mexicano\", siembra en macetera profunda en balcón con sol pleno (escala apartamento viable), cosecha de flores en mañana fresca para secado a la sombra y uso como pigmento o medicinal. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pamplona Roger 2006 Plantas Medicinales, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "costus_spicatus",
+      "nombre_comun": "Cana agria",
+      "nombre_cientifico": "Costus spicatus (Jacq.) Sw.",
+      "familia_botanica": "Costaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 50,
+        "optimo_max": 400,
+        "max_absoluto": 800
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "rizoma",
+        "notas": "Se propaga por fragmentos de rizoma sembrados en sustrato humedo. Crece en bordes de rios y quebradas del tropico humedo. Usada como diuretico y antiinflamatorio en medicina tradicional."
+      },
+      "companions": [
+        "musa_paradisiaca"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia",
+        "sinchi-amazonia-colombiana",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La caña agria o caña de jabalí (Costus spicatus (Jacq.) Sw., familia Costaceae) es una costácea herbácea perenne rizomatosa (1-2.5 m altura) nativa del Neotropico (Caribe, Mesoamérica, norte de Sudamérica), distribuida en sotobosques de selva húmeda tropical, bordes de ríos y quebradas del trópico húmedo colombiano. Su tallo aéreo helicoidal característico (filotaxia espiralada-monistica diagnóstica de Costaceae frente a la dística de Zingiberaceae), hojas elípticas oblongas con vaina ciliada y espigas terminales conspicuas con brácteas rojas y flores tubulares amarillas, son rasgos diagnósticos. Sus tallos jugosos contienen ácidos orgánicos (cítrico, málico), saponinas (diosgenina), flavonoides y mucílagos responsables del sabor ácido y propiedades medicinales documentadas (diurético, antiinflamatorio, hipotensor leve). Se distribuye en Chocó (Quibdó, Atrato, Baudó), Valle del Cauca (Buenaventura, Bajo Calima), Cauca (Guapi, Timbiquí), Nariño (Tumaco, Mosquera, Olaya Herrera), Amazonas (Leticia, Puerto Nariño), Vaupés, Caquetá (Florencia, Solano), Putumayo (Mocoa, Puerto Asís) y zonas del Magdalena medio bajas entre 50 y 400 msnm en zona térmica cálida húmeda. Ciclo perenne, floración continua en clima húmedo estable. Lección viva: planta medicinal emblemática del trópico húmedo colombiano cuyos tallos agrios se usan como diurético natural y antiinflamatorio en macerados acuosos, infusiones y cocciones por comunidades afrocolombianas e indígenas, enseñando el conocimiento botánico tradicional de las comunidades ribereñas del Pacífico y Amazonia colombiana y el rol del sotobosque húmedo como farmacopea viva. Manejo agroecológico: propagación facilísima por fragmentos de rizoma de 15-20 cm con yemas activas sembrados en sustrato rico en materia orgánica y humedad alta, tolerancia a sombra parcial (40-70%), asocio con plátano, cacao y heliconias en huerta tropical, no requiere agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia, SIB Colombia, SINCHI Amazonia Colombiana.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "dahlia_imperialis",
+      "nombre_comun": "Dahlia gigante / Dalia arbórea",
+      "nombre_cientifico": "Dahlia imperialis Roezl ex Ortgies",
+      "familia_botanica": "Asteraceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Esqueje de caña de 30-60 cm con 2-3 nudos enterrados horizontalmente, brotación 2-4 semanas, plantación final marzo-mayo, distancia 1.5-2 m entre plantas. Alternativa por división de tubérculos (rizomas tuberosos crecen radialmente del cuello). NO sembrar por semilla (variabilidad alta + lento)."
+      },
+      "companions": [
+        "lavandula_dentata",
+        "rosmarinus_officinalis",
+        "salvia_officinalis"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "perez-arbelaez-1947-plantas-utiles",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La Dahlia gigante o Dalia arbórea (Dahlia imperialis Roezl ex Ortgies, Asteraceae) es una especie herbácea-arbustiva gigante perenne originaria de México y Guatemala (montañas templadas de Oaxaca, Chiapas, Veracruz, Puebla, Michoacán entre 1.500 y 3.000 msnm) y de Centroamérica andina, naturalizada en Colombia desde su introducción ornamental por jardineros europeos del siglo XIX. Es la dalia más grande del género: tallos huecos cañiformes alcanzan 4-8 m de altura en ejemplares maduros con porte de árbol-bambú-asteráceo único en el mundo, capítulos terminales colgantes de hasta 15 cm de diámetro con lígulas color rosa-lila a magenta intenso o blanco según variedad, floración invierno-primavera fría andina (noviembre-marzo). Dahlia es el GÉNERO FLOR NACIONAL DE MÉXICO desde 1963 (decreto presidencial Adolfo López Mateos), reconocimiento del origen mesoamericano del género y de su importancia cultural milenaria: el pueblo Náhuatl (azteca) cultivaba dahlia (acocoxóchitl, \"flor del agua hueca\" en referencia a tallos huecos) en jardines reales tenochtitlanos, los registros de Hernández (siglo XVI) describen su cultivo con fines ornamentales, medicinales y alimentarios. En Colombia se cultiva en clima templado y frío andino entre 1.800 y 3.000 msnm: Sabana de Bogotá, Boyacá altoandino, Cundinamarca rural, Antioquia oriente frío, Eje Cafetero altoandino, Nariño altoandino, Santander, donde se ha naturalizado en bordes de caminos, jardines abandonados y áreas perturbadas montañas (hay poblaciones asilvestradas estables en Boyacá y Cundinamarca alrededor de fincas y haciendas viejas). Manejo agronómico: propagación principal por esqueje de caña de 30-60 cm con 2-3 nudos enterrados horizontalmente (cada nudo brota una nueva planta — método clásico mexicano), brotación 2-4 semanas, plantación final marzo-mayo en clima andino, distancia 1.5-2 m entre plantas, alternativa por división de tubérculos (rizomas tuberosos engrosados radian del cuello, similar a yacón Smallanthus sonchifolius en estructura), NO recomendable siembra por semilla (variabilidad genética alta y crecimiento lento), suelo rico bien drenado, riego moderado durante crecimiento, post-floración el tallo se seca y se corta a 50 cm sobre suelo para protección de yemas basales durante época seca (rebrota al inicio de siguiente temporada lluviosa). Doble propósito ornamental + comestible: ornamental masivo por porte único de \"árbol-bambú florecido\" y floración invernal vistosa rosa-lila colgante, COMESTIBLE POR LOS TUBÉRCULOS (rizomas tuberosos) que se forman al cuello de la planta — uso tradicional mesoamericano azteca-náhuatl pre-hispánico documentado por Hernández y otras crónicas, similares en uso al yacón andino (Smallanthus sonchifolius, también Asteraceae): tubérculos crudos dulces-acuosos (almacenan inulina, fructano de cadena corta de bajo índice glucémico, apto para diabéticos), cocidos en sopas y guisos (sabor suave-dulce similar a alcachofa de Jerusalén Helianthus tuberosus, también Asteraceae), tostados o asados, materia prima histórica de elaboración de bebidas fermentadas mexicanas y de jarabes endulzantes pre-hispánicos. Atracción excepcional de polinizadores: en floración invernal (cuando pocas otras flores están disponibles en clima andino frío) sostiene poblaciones masivas de colibríes (en Colombia: Coeligena spp., Boissonneaua spp., Lafresnaya lafresnayi), abejas (Apis mellifera, abejas solitarias), abejorros (Bombus spp.) y mariposas — siendo recurso melífero clave de invierno andino. Manejo en chagra: plantar en borde de huerta como \"árbol-flor\" multi-propósito (ornamental masivo + comestible patrimonial mexicano + atrayente polinizador invernal + biomasa al final de ciclo), asociación con seto aromático mediterráneo (Salvia officinalis, Lavandula dentata, Rosmarinus officinalis) en jardín polifuncional, cosecha de tubérculos en época seca cuando tallos se han secado, propagación vegetativa de caña post-floración para multiplicación. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pérez Arbeláez 1947 Plantas Útiles Colombia, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "dysphania_ambrosioides",
+      "nombre_comun": "Paico",
+      "nombre_cientifico": "Dysphania ambrosioides (L.) Mosyakin & Clemants",
+      "familia_botanica": "Amaranthaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 2500,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 14,
+        "optimo_max": 24,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Propagación por semilla; se resiembra fácilmente en suelos perturbados. Crece como arvense en huertas y bordes de camino."
+      },
+      "companions": [
+        "zea_mays"
+      ],
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Vermífugo natural por excelencia de la medicina tradicional colombiana: el paico enseña cómo una arvense común puede ser la botica familiar para desparasitar, y por qué las chagras lo conservan entre los cultivos.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "eryngium_foetidum",
+      "nombre_comun": "Cilantro cimarron",
+      "nombre_cientifico": "Eryngium foetidum L.",
+      "familia_botanica": "Apiaceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 2200,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 25,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinacion lenta; siembra directa o en bandeja. Una vez establecido, se resiembra solo con facilidad en el huerto."
+      },
+      "companions": [
+        "musa_paradisiaca"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "sib-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "agrosavia-tibaitata"
+      ],
+      "valor_pedagogico": "El cilantro cimarrón o culantro (Eryngium foetidum L., familia Apiaceae) es una apiácea bienal a perenne herbácea nativa de las Américas tropicales (Caribe, Mesoamérica, norte de Sudamérica), cultivada y silvestre en huertos campesinos colombianos por sus hojas dentadas en roseta basal de aroma intenso similar al cilantro común (Coriandrum sativum) pero más estable al calor de cocción. Su aroma característico proviene de aldehídos aromáticos volátiles (E-2-dodecenal, dodecanal) presentes en mayor concentración que en el cilantro común. Se cultiva en Caribe colombiano (Magdalena, Bolívar, Sucre, Córdoba), Antioquia (Urabá, Magdalena medio), Valle del Cauca, Tolima, Huila y Eje cafetero entre 500 y 2.200 msnm en zona térmica cálida a fría, con preferencia por sombra parcial y humedad alta. Ciclo bienal con producción continua de hojas durante 12-18 meses. Rendimientos 0.5-1 t/ha hoja fresca. Lección viva: enseña la relevancia de las especias locales frente a las introducidas, su rol en el hogao colombiano y los sancochos costeños como sustituto resistente al calor de cocción del cilantro común, y su valor como planta multipropósito (condimento, medicinal contra cólicos y gripes, atrayente de polinizadores apícolas por sus inflorescencias verde-amarillas). Manejo agroecológico: siembra directa o en bandeja con germinación lenta 14-21 días, suelo orgánico bien drenado con pH 5.5-7, asocio con plátano y yuca como sombra temporal, cosecha de hojas externas dejando corazón intacto, autoresiembra natural prolífica en el huerto bien manejado, no requiere agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, SIB Colombia, Bernal 2015 Catálogo Plantas Colombia, AGROSAVIA.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "culantro",
+        "culantro de monte",
+        "culantro cimarrón",
+        "cilantro de pozo",
+        "cimarrón",
+        "culantro coyote"
+      ]
+    },
+    {
+      "id": "erythrina_rubrinervia",
+      "nombre_comun": "Chiló",
+      "nombre_cientifico": "Erythrina rubrinervia Kunth",
+      "familia_botanica": "Fabaceae",
+      "category": "cercas_vivas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "living_fence",
+        "nitrogen_fixer",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "coffea_arabica"
+      ],
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "El chiló (Erythrina rubrinervia Kunth, Fabaceae) es un árbol nativo andino de cerca viva tradicional en Cundinamarca, Boyacá, Antioquia y Eje cafetero (1.200-2.800 msnm). Propagación facilísima por estaca leñosa de 2 m: se entierra 40 cm en suelo húmedo y prende sin riego. Sus flores rojo-coral (año 2-3) atraen colibríes y abejas nativas — comedero aéreo de fauna polinizadora. Como leguminosa, fija nitrógeno atmosférico vía simbiosis con Rhizobium en nódulos radiculares, enriqueciendo el suelo del lindero sin abono químico. Lección viva: una cerca puede ser árbol vivo, alimento para colibríes y fábrica gratis de nitrógeno al mismo tiempo. Fuentes Tier A: Pérez Arbeláez 1947, Bernal 2015 Catálogo Plantas Colombia, GBIF Backbone.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "escallonia_pendula",
+      "nombre_comun": "Mortiño colgante",
+      "nombre_cientifico": "Escallonia pendula (Ruiz & Pav.) Pers.",
+      "familia_botanica": "Escalloniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "biomass_producer",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1800,
+        "optimo_max": 2000,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "alnus_acuminata",
+        "bocconia_frutescens",
+        "cedrela_montana",
+        "myrsine_coriacea",
+        "tibouchina_lepidota",
+        "vallea_stipularis"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "car-cundi-2019"
+      ],
+      "valor_pedagogico": "El mortiño colgante o chilco colgante (Escallonia pendula, Escalloniaceae) es uno de los árboles medianos más representativos de las cercas vivas y bordes de bosque del altiplano andino colombiano entre 1.500 y 2.400 msnm en las cordilleras Central, Occidental y Oriental, especialmente en Cundinamarca, Boyacá, Santanderes, Antioquia, Caldas, Quindío, Risaralda, Tolima, Huila, Cauca y Nariño. Árbol perennifolio de 8-12 metros de altura con copa irregular caracterizada por ramas largas péndulas-colgantes (de ahí el epíteto 'pendula'), fuste corto y corteza rojiza fina que se descortezándose en placas; hojas alternas oblanceoladas glandulares de bordes serrulados verde oscuro brillantes con aroma resinoso al frotarlas (típico de la familia Escalloniaceae), flores en racimos péndulos terminales de corolas tubulares rosadas-blancas características, con polinización ornitófila adaptada a colibríes (Coeligena coeligena, Aglaiocercus kingii, Colibri coruscans entre otros polinizadores del altiplano cundiboyacense y Andes colombianos), frutos cápsulas pequeñas dehiscentes con semillas diminutas dispersadas por viento. La familia Escalloniaceae es un linaje botánico endémico del hemisferio sur con centro de diversidad en los Andes —en Colombia hay más de 10 especies del género Escallonia, todas con distribución estrictamente andina y altoandina. Su mayor virtud agroecológica es su rapidez de establecimiento por estacas semi-leñosas (enraizamiento 70-85% en 30-45 días sin tratamiento hormonal), lo que la convierte en una de las especies pioneras más eficientes para cercas vivas tradicionales altoandinas (la 'cerca de chilco' del altiplano cundiboyacense es paisaje cultural patrimonial campesino), para restauración temprana de áreas degradadas de cordillera Andina, y para enriquecimiento de borde de bosque. Su floración estacional atractora de colibríes la convierte en especie clave para conservación de la fauna ornitófila andina —el 'corredor de chilcos' que entrelaza cercas vivas en parcelas campesinas funciona como corredor ecológico para colibríes y polinizadores nativos. Su madera rojiza-aromática se usa tradicionalmente como leña doméstica, postes de cerca, mangos de herramienta y construcción rural altoandina. Es lección de soberanía botánica andina: revalorizar las cercas vivas de Escallonia, Vallea y Weinmannia en lugar de cercas de alambre exclusivamente, recupera paisajes culturales campesinos, fortalece la conservación de colibríes y polinizadores nativos del altiplano y suministra leña-postes renovables de manera autónoma. La especie también es valorada en jardinería ornamental andina por su hábito colgante elegante y floración atractora de fauna. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew Escalloniaceae, GBIF Backbone Taxonomy, monografías Sevillano-Marín 2010 Escallonia Andes, CAR Cundinamarca cercas vivas tradicionales altoandinas.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "festuca_arundinacea",
+      "nombre_comun": "Festuca",
+      "nombre_cientifico": "Festuca arundinacea Schreb.",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "ground_cover",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "lolium_perenne",
+        "medicago_sativa",
+        "trifolium_repens"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-forrajeras-2022",
+        "agrosavia-silvopastoriles",
+        "bernal-2015-plantas-liquenes-colombia",
+        "restrepo-2005-agroecologia"
+      ],
+      "valor_pedagogico": "La festuca alta o festuca arundinácea (Festuca arundinacea Schreb., familia Poaceae, subfamilia Pooideae) es una poácea perenne herbácea cespitosa originaria de Europa templada y norte de África, naturalizada y cultivada extensamente en sistemas ganaderos altoandinos colombianos como gramínea forrajera estructural de pradera permanente, especialmente en rotaciones lecheras y de carne del altiplano cundiboyacense, Eje cafetero alto y Nariño. Forma macollos densos con raíces profundas (hasta 1-1.5 m), hojas anchas, planas y verde oscuro, y panículas erectas con espiguillas multifloras. Se cultiva en Boyacá (Tunja, Sotaquirá, Sutamarchán, Villa de Leyva, altiplano lechero), Cundinamarca (Sabana de Bogotá, Subachoque, Tabio, Madrid, Mosquera, Chocontá), Nariño (Pasto, Túquerres, Ipiales), Cauca (Silvia, Totoró), Antioquia (oriente — La Unión, La Ceja, Sonsón, El Carmen) y Eje cafetero alto entre 2.200 y 3.000 msnm en zona térmica fría. Ciclo perenne, productividad sostenida 5-8 años antes de renovar pradera. Rendimientos 12-18 t/ha materia seca por año en pradera bien manejada con asocios. Lección viva de la gramínea resistente: la festuca enseña la importancia de las raíces profundas en la recuperación de suelos compactados y degradados, su papel en la estabilización de laderas altoandinas (anti-erosión por anclaje radicular denso), y la simbiosis con endófitos beneficos (Epichloë coenophiala) que confieren resistencia a plagas y sequía. Manejo agroecológico: siembra al voleo 25-35 kg/ha semilla certificada en cama bien preparada, asocio obligatorio con trébol blanco (Trifolium repens) o rojo (Trifolium pratense) para fijación biológica de nitrógeno y mejora del valor nutricional del forraje, manejo en pastoreo rotacional con descansos de 28-35 días, encalado preventivo cada 3 años. Fuentes Tier A: AGROSAVIA Forrajeras 2022, POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "freziera_canescens",
+      "nombre_comun": "Freziera",
+      "nombre_cientifico": "Freziera canescens Bonpl.",
+      "familia_botanica": "Pentaphylacaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
+        "optimo_max": 2900,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 8,
+        "optimo_max": 15,
+        "max_tolerable": 22
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "prumnopitys_montana",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Freziera canescens Bonpl. (freziera, cucharo de bosque nublado — familia Pentaphylacaceae, antes clasificada en Theaceae) es un árbol perennifolio (5-15 m altura) nativo de los Andes del norte de Sudamérica (Colombia, Ecuador, Perú, Venezuela), distribuido en BOSQUE NUBLADO alto andino entre 2000 y 3200 msnm en piso térmico FRÍO HÚMEDO con niebla persistente. En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca y Santander, con poblaciones notables en Chingaza, en el flanco oriental húmedo de Cruz Verde-Sumapaz, en Tatamá, en el Parque Otún-Quimbaya y en reservas del Eje Cafetero alto. Es reconocible por sus hojas alternas elípticas con PUBESCENCIA BLANQUECINA EN EL ENVÉS (rasgo distintivo — al voltear la hoja se ve plateada-blanquecina por los tricomas finos que atrapan gotas de niebla y reducen la transpiración foliar), por sus flores blancas pequeñas axilares cuatrímeras-pentámeras y por sus bayas globosas pequeñas negro-violáceas (alimento de avifauna nublada — atrapamoscas, mirlas pequeñas, semilleros). Lección viva sobre BOSQUE NUBLADO ANDINO, ADAPTACIONES ANATÓMICAS A LA NIEBLA y BIOINDICACIÓN ECOLÓGICA: la freziera es ESPECIE INDICADORA de bosque nublado andino bien conservado — su presencia testifica un rodal con niebla persistente >150 días/año, humedad relativa atmosférica >85% y red micorrízica fúngica funcional. Su pubescencia foliar blanquecina es una adaptación anatómica fina para capturar agua de niebla por intercepción foliar (un fenómeno que en ingeniería ecológica se llama 'horizontal precipitation' o 'fog drip' — los bosques de freziera y otras especies de hoja pubescente AUMENTAN el aporte hídrico local de un 15-30% sobre la precipitación medida en pluviómetros, dato relevante para el balance hídrico de cuencas abastecedoras como la del río Tunjuelo en Sumapaz o la del río Teusacá en Chingaza). En restauración, la freziera se planta en FASE TARDÍA del bosque nublado, después de pioneras y sucesionales intermedias, en sitios con niebla persistente — fracasa si se planta en bordes secos o cortafuegos. Manejo agroecológico: propagación por semilla fresca con sombra densa 75% y humedad alta; trasplante 6-8 meses; plantación 18-24 meses; crecimiento lento 20-40 cm/año; asocio con gaque, encenillo y pino romerón (Prumnopitys montana); densidades 100-200 ind/ha; restauración del bosque nublado húmedo de Chingaza, Cruz Verde-Sumapaz oriental, Tatamá, Otún-Quimbaya. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "gaiadendron_punctatum",
+      "nombre_comun": "Chuque",
+      "nombre_cientifico": "Gaiadendron punctatum (Ruiz & Pav.) G. Don",
+      "familia_botanica": "Loranthaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2500,
+        "optimo_max": 3200,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 6,
+        "optimo_max": 14,
+        "max_tolerable": 20
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "hesperomeles_goudotiana",
+        "polylepis_quadrijuga",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-2016-frailejones"
+      ],
+      "valor_pedagogico": "Gaiadendron punctatum (Ruiz & Pav.) G. Don (chuque, sietelechos, gaiadendron — familia Loranthaceae) es un árbol-arbusto perennifolio (3-8 m altura) HEMIPARÁSITO FACULTATIVO TERRESTRE — el ÚNICO árbol-muérdago colombiano que parasita raíces de otras plantas vía HAUSTORIOS SUBTERRÁNEOS, no es epífita como los muérdagos arbóreos típicos de Loranthaceae (Aetanthus, Tristerix, Phthirusa) que viven sobre las ramas. Distribución amplia: Andes desde Costa Rica hasta Bolivia (Colombia, Ecuador, Perú, Venezuela, Bolivia, Costa Rica, Panamá). En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca y Santander entre 2200 y 3500 msnm en piso térmico FRÍO de bosque alto andino y subpáramo. Sus FLORES TUBULARES AMARILLO-ANARANJADAS VISTOSAS (4-5 cm de largo) son polinizadas por COLIBRÍES alto-andinos (Pterophanes cyanopterus, Eriocnemis vestita, Heliangelus exortis, Coeligena bonapartei) — coevolución colibrí-flor de neta importancia ecológica en la red de polinizadores del subpáramo. Sus BAYAS AMARILLO-ANARANJADAS son dispersadas por aves frugívoras alto-andinas que defecan las semillas pegajosas sobre raíces de otras plantas — donde germinan y se enchufan al sistema radicular del hospedante mediante haustorios. Lección viva sobre HEMIPARASITISMO TERRESTRE ÚNICO, COEVOLUCIÓN COLIBRÍ-FLOR ANDINA y RESTAURACIÓN DE NICHOS BIOLÓGICOS RAROS: el chuque es uno de los ejemplos más extraordinarios de la flora colombiana — combina hemiparasitismo terrestre (caso evolutivo raro en Loranthaceae, familia mayormente epífita), polinización ornitófila especializada con colibríes alto-andinos y dispersión ornitócora con aves frugívoras. Su presencia es BIOINDICADORA de un bosque alto andino con red trófica intacta: necesita simultáneamente plantas hospedantes (encenillo, mortiño, queñoa), colibríes polinizadores Y aves dispersoras — la pérdida de cualquiera de los tres rompe su ciclo reproductivo. En restauración avanzada de Cruz Verde-Sumapaz, Chingaza e Iguaque, el chuque se planta SOLO en sitios con hospedantes ya establecidos (no en restauración primaria de pasturas degradadas) y en densidades bajas 30-80 ind/ha (es especie rara, no dominante en el ecosistema natural). Etnobotánica: el nombre 'sietelechos' aludía en la tradición campesina muisca-andina al látex blanquecino que aparece al cortar la corteza (mito popular de 'siete lechosas') — usado en cocimientos tópicos para heridas. Manejo agroecológico: propagación por semilla fresca con hospedantes presentes; trasplante 6-8 meses; plantación 18-24 meses; crecimiento 30-50 cm/año; inoculación con sustrato de bosque nativo; restauración tardía con encenillo, mortiño y queñoa como hospedantes facultativos; densidades 30-80 ind/ha. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, Bernal 2015 Catálogo Plantas Líquenes Colombia, Humboldt 2016 Frailejones.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "hibiscus_sabdariffa",
+      "nombre_comun": "Jamaica / Flor de Jamaica",
+      "nombre_cientifico": "Hibiscus sabdariffa L.",
+      "familia_botanica": "Malvaceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1500,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 20,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa post-último riesgo de heladas, 1-2 cm profundidad, distancia 80-100 cm entre plantas, germinación 7-14 días, floración 90-120 días post-siembra, cosecha de cálices carnosos 10-21 días post-fecundación (cuando alcanzan máximo tamaño y color rojo intenso pero antes de lignificarse), ciclo 150-180 días."
+      },
+      "companions": [
+        "cajanus_cajan",
+        "vigna_unguiculata",
+        "zea_mays"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La Jamaica o Flor de Jamaica (Hibiscus sabdariffa L., Malvaceae) es una especie herbácea-arbustiva anual originaria de África occidental (Sudán, Senegal, Nigeria, Guinea — donde existen las mayores diversidad genética y formas silvestres congenéricas) y dispersada en la diáspora africana a través del comercio transatlántico durante los siglos XVI-XVIII al Caribe, México, Centroamérica y Sudamérica donde se naturalizó y se convirtió en cultivo emblemático del Caribe (de ahí \"Jamaica\" — referencia a la isla caribeña, no al país asiático). En Colombia se cultiva en clima cálido y templado entre 0 y 1.800 msnm: Caribe (Bolívar, Magdalena, Cesar, Atlántico, La Guajira, Sucre, Córdoba), Pacífico (Chocó, Valle), valles interandinos cálidos del Magdalena y Cauca, Llanos Orientales, Amazonía, Eje Cafetero zona cafetera baja, Antioquia bajo, Santander. Manejo agronómico: siembra directa al sitio definitivo post-último riesgo de heladas, 1-2 cm profundidad, distancia 80-100 cm entre plantas (porte vigoroso 1.5-2.5 m alto), germinación 7-14 días a 22-30°C, ciclo total 150-180 días, floración inicia 90-120 días post-siembra con flores grandes amarillo-cremosas con centro purpúreo profundo característico del género Hibiscus (5 pétalos vistosos, columna estaminal larga característica de Malvaceae). Lo COSECHABLE NO ES LA FLOR EN SÍ SINO LOS CÁLICES carnosos rojo-purpúreo intensos que se forman post-fecundación rodeando la cápsula seminal: 10-21 días post-fecundación alcanzan máximo tamaño y color rojo intenso pero antes de lignificarse, momento crítico de cosecha manual. Los cálices frescos son la materia prima de la bebida emblemática del Caribe (agua de Jamaica, agua de Jamaica fría con limón y panela en México y Centroamérica, sorrel drink en Jamaica isla y Trinidad, bissap en Senegal y África Occidental, karkadeh en Egipto y Sudán) y se consumen también: secados al sol para infusión (té rojo cítrico-ácido refrescante rico en vitamina C, antocianinas, ácido hibíscico), mermeladas y jaleas (excelente cuajado natural por alto contenido de pectina), salsas agridulces, sirops y licores tradicionales, tinte alimentario natural rojo-rosado (estable a pH ácido), gelatinas, vinos de fruta artesanales. Uso medicinal tradicional documentado y respaldado por evidencia clínica moderna: cálices secos en infusión hipotensor leve (efecto antihipertensivo respaldado por ensayos clínicos controlados publicados en Journal of Human Hypertension y otros), diurético, antioxidante alto por antocianinas y polifenoles, hipocolesterolemiante leve, refrescante. Atracción de polinizadores: flores grandes vistosas atrayentes de abejorros nativos (Bombus spp.), abejas (Apis mellifera), polinizadores grandes, y aves (colibríes ocasionalmente en zonas cálidas). En África Occidental también es importante alimento de hoja: las hojas tiernas se consumen cocidas como verdura (sabor ácido suave por oxalatos similar a acedera, de ahí \"acedera de Guinea\"), aporte vitamínico significativo en dietas rurales sahelianas. Asociación clásica con maíz (Zea mays), gandul (Cajanus cajan), caupí (Vigna unguiculata) en sistemas agroforestales tropicales tradicionales africanos y caribeños. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pamplona Roger 2006 Plantas Medicinales, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "ilex_kunthiana",
+      "nombre_comun": "Palo de zorro",
+      "nombre_cientifico": "Ilex kunthiana Triana",
+      "familia_botanica": "Aquifoliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
+        "optimo_max": 2900,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -7,
+        "optimo_min": 7,
+        "optimo_max": 15,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "hesperomeles_goudotiana",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Ilex kunthiana Triana (palo de zorro, acebo andino, huesito — familia Aquifoliaceae) es un árbol perennifolio DIOICO (6-15 m altura) nativo de los Andes (Colombia, Ecuador, Venezuela, Perú), distribuido en bosque alto andino entre 2000 y 3200 msnm en piso térmico FRÍO. En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca, Santander y Tolima. La familia AQUIFOLIACEAE es monogenérica de gran trascendencia botánica — el género Ilex incluye al acebo europeo (Ilex aquifolium, sagrado para los celtas y emblema navideño europeo desde el medievo), al yerba mate sudamericano (Ilex paraguariensis, base de la infusión cultural rioplatense), al té de yaupon norteamericano (Ilex vomitoria, infusión ritual y cafeinada de los indios algonquinos del sureste de EEUU) y a este palo de zorro andino — TODAS las especies de Ilex comparten morfología similar (hojas coriáceas alternas con margen variable, flores dioicas pequeñas, drupas globosas pequeñas) y muchas contienen CAFEÍNA Y TEOBROMINA (los alcaloides estimulantes que han hecho del mate, té y café las bebidas más consumidas del mundo). Aunque NO está documentado que Ilex kunthiana se haya usado tradicionalmente como bebida estimulante en Colombia (a diferencia del mate argentino-paraguayo), su pertenencia al género Ilex la hace candidata interesante para investigación etnofarmacológica andina. Su epíteto 'kunthiana' honra a Karl Sigismund Kunth (1788-1850), el botánico alemán colaborador de Humboldt y Bonpland que describió cientos de especies de la flora de Colombia, Venezuela y Ecuador en la obra 'Nova Genera et Species Plantarum' (1815-1825) — fundacional para la botánica neotropical. Lección viva sobre BOTÁNICA SISTEMÁTICA DE ILEX, COSMOPOLITISMO DE LA AQUIFOLIACEAE y HISTORIA DE LA BOTÁNICA COLOMBIANA: el palo de zorro andino es ejemplo paradigmático de cómo una especie aparentemente menor del bosque colombiano pertenece a un género cosmopolita (acebo europeo + mate sudamericano + té yaupon norteamericano) con valor cultural, medicinal y económico global. Como especie DIOICA, la restauración requiere plantar proporción 1 macho : 4-5 hembras para asegurar producción de drupas — error frecuente en proyectos es plantar solo hembras y no obtener fruta. En restauración de Cruz Verde-Sumapaz, Chingaza, Iguaque y altiplano nariñense, las drupas rojo-violáceas son ALIMENTO CRÍTICO para avifauna alto-andina (mirlas patiblancas, tucanetas esmeralda, atrapamoscas, copetones) en la estación seca diciembre-marzo cuando otros frutos escasean. Manejo agroecológico: propagación por semilla fresca con estratificación fría 60-90 días; trasplante 6-8 meses; plantación 18-24 meses; crecimiento lento 25-40 cm/año; proporción dioica 1M:4-5H; densidades 200-300 ind/ha; restauración alto-andina con vista a alimento de avifauna en seca. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "inga_densiflora",
+      "nombre_comun": "Guamo macheto",
+      "nombre_cientifico": "Inga densiflora Benth.",
+      "familia_botanica": "Fabaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla recalcitrante; sembrar inmediatamente después de madurez. Germinación 15-30 días. Plántula sensible a estrés hídrico inicial."
+      },
+      "companions": [
+        "cedrela_montana",
+        "cinchona_officinalis",
+        "cinchona_pubescens",
+        "coffea_arabica",
+        "magnolia_caricifragrans",
+        "magnolia_yarumalensis",
+        "myrcia_popayanensis"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El guamo macheto (Inga densiflora Benth.) se cultiva en departamentos andinos y amazónicos de Colombia como Putumayo, Caquetá, Meta, Amazonas y parte de la cordillera oriental entre 0 y 2200 msnm, con óptimo entre 500 y 1800 msnm en zonas térmicas templadas. Su manejo agronómico incluye propagación por semilla fresca (recalcitrante) con germinación de 15-30 días, ciclo de establecimiento de 6-12 meses hasta primera producción de vainas, se asocia beneficiosamente con café y cacao como sombra temporal en sistemas agroforestales, y fija nitrógeno atmosférico mediante nodulación con rhizobios, mejorando la fertilidad del suelo. En el contexto cultural muisca y campesino andino, los frutos (vainas) se consumen tradicionalmente como snack dulce y la madera se usa para postes y leña. Según el inventario taxonómico de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Inga densiflora Benth.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "inga_vera",
+      "nombre_comun": "Guamo de monte",
+      "nombre_cientifico": "Inga vera Willd.",
+      "familia_botanica": "Fabaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 800,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla recalcitrante requiere siembra inmediata post-recoleccion. Germinacion rapida (7-15 dias). Tambien se propaga por esquejes semi-leñosos. Fija nitrogeno atmosférico mediante nodulación con rizobios."
+      },
+      "companions": [
+        "coffea_arabica"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "gbif-colombia",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "El guamo de monte (Inga vera Willd.) es un árbol nativo de la familia Fabaceae distribución en la Amazonía colombiana, particularmente en los departamentos de Amazonas, Caquetá, Putumayo, Guainía y Vaupés, entre 0 y 1200 msnm en zonas térmicas cálidas. Su manejo agronómico incluye propagación por semilla recalcitrante que debe sembrarse inmediatamente após recolección, con germinación rápida de 7-15 días, aunque también se reproduce por esquejes semi-leñosos. Como especie fijadora de nitrógeno, forma nodulaciones con rizobios simbiontes que enriquecen el suelo, siendo utilizada传统的 en sistemas agroforestales amazónicos como sombra para cultivos como café y cacao. En el contexto cultural indigenous amazonico, sus frutos vainas carnosas son consumidos directamente y sus semillas sirven para propagación de sistemas agroforestales tradicionales. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Inga vera Willd., especie nativa de la región tropical americana.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "ipomoea_batatas_blanca",
+      "nombre_comun": "Batata blanca",
+      "nombre_cientifico": "Ipomoea batatas (L.) Lam. cv. blanca",
+      "familia_botanica": "Convolvulaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 800,
+        "optimo_max": 2000,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje (bejuco)",
+        "notas": "Variedad de pulpa blanca y textura harinosa, menos dulce que la naranja. Preferida para preparaciones saladas y frituras."
+      },
+      "companions": [
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "bernal-2015-plantas-liquenes-colombia",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La batata blanca (Ipomoea batatas (L.) Lam. cv. blanca, familia Convolvulaceae) es una variedad cultivar de batata o camote de pulpa blanca a crema y textura harinosa, parte de la diversidad intraespecífica del complejo Ipomoea batatas domesticado hace ~5.000 años en Centroamérica y Sudamérica precolombina y aclimatado a sistemas campesinos colombianos de clima cálido a templado-cálido. La variedad blanca contiene 25-30% almidón fresco (mayor que las variedades naranjas), menor concentración de β-caroteno y mayor proporción de fibra dietaria, prefiriéndose para preparaciones culinarias saladas (fritos, sopas, sancocho costeño, bollos campesinos) y frituras industriales. Se cultiva en Caribe colombiano (Bolívar, Córdoba, Sucre, Magdalena), Tolima (Lérida, Armero, Ibagué), Huila (Garzón, Pitalito), Valle del Cauca, Cauca, Antioquia (Urabá, Magdalena medio), Eje cafetero bajo y Cundinamarca (Mesa, Mesitas) entre 800 y 2.000 msnm en zona térmica cálida a templada. Ciclo 4-6 meses desde siembra a cosecha. Rendimientos 15-25 t/ha tubérculo. Lección viva: variedad de batata de pulpa blanca que muestra la diversidad intraespecífica de este cultivo global (más de 7.000 cultivares documentados a nivel mundial), enseñando selección varietal por textura, contenido de almidón, color de pulpa y aptitud culinaria, y la importancia de la conservación in situ del germoplasma campesino frente a la erosión genética por estandarización comercial. Manejo agroecológico: propagación por esquejes de tallo con 4-6 nudos (no por tubérculo-semilla en este cultivar), siembra en camas elevadas (camellones) a 30 cm entre plantas, asocio con maíz y fríjol en milpa tropical, cosecha rotacional, baja demanda nutricional (raíces eficientes en absorción de P y K), no requiere agroquímicos. Fuentes Tier A: AGROSAVIA Manual Tubérculos, POWO Kew, GBIF Backbone Taxonomy, ICA Resolución 3168/2015, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Batata"
+      ]
+    },
+    {
+      "id": "ipomoea_batatas_morada",
+      "nombre_comun": "Batata morada",
+      "nombre_cientifico": "Ipomoea batatas (L.) Lam. cv. morada",
+      "familia_botanica": "Convolvulaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 800,
+        "optimo_max": 2000,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje (bejuco)",
+        "notas": "Variedad de pulpa morada intensa, rica en antocianinas. Color que se intensifica con la exposicion solar durante el desarrollo."
+      },
+      "companions": [
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "bernal-2015-plantas-liquenes-colombia",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La batata morada o boniato morado (Ipomoea batatas (L.) Lam. cv. morada, familia Convolvulaceae) es una variedad cultivar de batata o camote de pulpa morada intensa rica en antocianinas, parte de la diversidad intraespecífica del complejo Ipomoea batatas domesticado hace ~5.000 años en Centroamérica y Sudamérica precolombina y conservado en sistemas campesinos colombianos como variedad nativa de la Costa Caribe, Magdalena medio y Eje cafetero bajo. La variedad morada concentra 200-600 mg antocianinas/100g pulpa fresca (cianidina-3-sophorósido y peonidina-3-sophorósido principalmente), polifenoles, ácido clorogénico y β-caroteno secundario, con potente actividad antioxidante in vitro 3-5 veces mayor que arándanos y propiedades antiinflamatorias y cardioprotectoras documentadas. Se cultiva en Caribe colombiano (Bolívar, Córdoba, Sucre, Magdalena, Atlántico), Antioquia (Urabá, Magdalena medio), Valle del Cauca, Cauca, Tolima, Huila, Eje cafetero bajo y Cundinamarca caliente (Mesa, Mesitas, Tocaima) entre 800 y 2.000 msnm en zona térmica cálida a templada. Ciclo 4-6 meses desde siembra a cosecha. Rendimientos 12-22 t/ha tubérculo. Lección viva de fitoquímica aplicada: variedad de batata de pulpa morada que muestra cómo las antocianinas actúan como potentes antioxidantes en la dieta (acción anti-radical libre, hepatoprotectora, antitumoral en estudios preclínicos) y como pigmentos naturales (color que se intensifica con exposición solar durante el desarrollo de la raíz por estímulo lumínico de la vía de los fenilpropanoides), enseñando bioquímica vegetal aplicada y valoración nutricional de variedades campesinas frente a comerciales estandarizadas. Manejo agroecológico: propagación por esquejes de tallo, siembra en camellones, asocio con maíz, fríjol y plátano enano, exposición solar plena para máxima síntesis de antocianinas, no requiere agroquímicos. Fuentes Tier A: AGROSAVIA Manual Tubérculos, POWO Kew, GBIF Backbone Taxonomy, ICA Resolución 3168/2015, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Batata"
+      ]
+    },
+    {
+      "id": "juglans_neotropica",
+      "nombre_comun": "Nogal andino",
+      "nombre_cientifico": "Juglans neotropica Diels",
+      "familia_botanica": "Juglandaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "windbreak",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "alnus_acuminata",
+        "cedrela_montana",
+        "cenchrus_clandestinus_manejado",
+        "coffea_arabica",
+        "magnolia_yarumalensis"
+      ],
+      "antagonists": [
+        "capsicum_annuum_aji_dulce_caribe",
+        "capsicum_baccatum_aji_amarillo",
+        "capsicum_chinense_aji_panca",
+        "capsicum_pubescens_rocoto",
+        "malus_domestica_sabanera",
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold",
+        "solanum_tuberosum_carrera_negra",
+        "solanum_tuberosum_pastusa_suprema",
+        "solanum_tuberosum_sabanera"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "uicn-red-list",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "valor_pedagogico": "El nogal andino o cedro negro (Juglans neotropica Diels, Juglandaceae) es la joya maderable de los bosques andinos colombianos: su madera negra-rojiza con vetas oscuras es considerada la más preciada y fina de los Andes para ebanistería de lujo, mueblería patrimonial, instrumentos musicales (cuerpos de guitarras finas), tornería artística y altares de iglesias coloniales. Nativo de los Andes tropicales (Venezuela, Colombia, Ecuador, Perú, Bolivia), en Colombia se distribuye en bosques húmedos premontanos y montanos de la región Andina: cordillera Oriental (Cundinamarca en Choachí, La Calera, Ubaque, Caquetá montano, Boyacá en Iguaque y Arcabuco, Santander en Charalá, Norte de Santander en Pamplona), cordillera Central (Antioquia en San Vicente, Sonsón, Marinilla; Caldas, Risaralda, Quindío del Eje Cafetero; Tolima, Huila; Cauca; Nariño) y cordillera Occidental (Antioquia, Chocó montano, Valle, Cauca) entre 1.800 y 2.600 msnm en zona térmica templada a fría con humedad alta. Árbol semicaducifolio de 20-30 m de altura con fuste recto cilíndrico, corteza grisácea-negruzca fisurada, hojas pinnadas grandes (30-50 cm) con 11-21 folíolos lanceolados, flores monoicas (amentos masculinos colgantes y flores femeninas en racimos cortos), frutos drupáceos globosos verdes que al madurar liberan una nuez comestible análoga a la nuez europea (Juglans regia) con sabor aceitoso suave aprovechable artesanalmente. ALERTA CONSERVACIÓN: categorizada EN PELIGRO (EN) en la Lista Roja IUCN y Libro Rojo Plantas Colombia por sobreexplotación maderera histórica y deforestación del bosque andino: las mejores poblaciones del Eje Cafetero, Antioquia y Cundinamarca fueron taladas masivamente entre 1900 y 1980 para mueblería de lujo, dejando poblaciones silvestres reducidas en >75% del rango original. Su característica ecológica más conocida es la alelopatía fuerte: las raíces, hojas y frutos producen juglona (5-hidroxi-1,4-naftoquinona) que inhibe el crecimiento de cultivos sensibles como tomate, papa, manzano, alfalfa y otros plantados a menos de 10-15 m del árbol; pero es compatible con café, banano, pasturas gramíneas y otros maderables andinos. Cenicafé documenta su uso como sombrío valioso en cafetales del Eje a densidades 80-150 árb/ha donde aporta sombra ligera (30-40%), hojarasca rica en N, valor maderable patrimonial generacional para el caficultor y frutos nuez comestible. Crecimiento lento (turno comercial 40-60 años para diámetros >50 cm), pero la madera adulta es de las más valiosas del país y plantar nogal hoy es legado para nietos y biznietos. Manejo agroecológico: nuez recolectada fresca de frutos caídos, estratificación fría húmeda 60-90 días en arena (sin estratificación germinación <20%), vivero a sombra parcial 50% por 8-12 meses, plantación a 40-50 cm, raíz pivotante profunda requiere trasplante temprano y evitando daño. Es lección de soberanía maderera y alimentaria: lo que Europa cosecha del Juglans regia, Colombia lo cosecha del Juglans neotropica nativo con la misma calidad gastronómica y maderera, sin necesidad de importar nueces europeas. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, IUCN Red List, Bernal et al. 2015, POWO Kew, GBIF, Cenicafé manuales sombrío.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "kalanchoe_pinnata",
+      "nombre_comun": "Siempreviva",
+      "nombre_cientifico": "Kalanchoe pinnata (Lam.) Pers.",
+      "familia_botanica": "Crassulaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 2200,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": 3,
+        "optimo_min": 16,
+        "optimo_max": 28,
+        "max_tolerable": 36
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "artemisia_absinthium",
+        "ruta_graveolens"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales",
+        "perez-arbelaez-1947-plantas-utiles",
+        "sib-colombia",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "La siempreviva u hoja del aire (Kalanchoe pinnata (Lam.) Pers., Crassulaceae, sinónimo Bryophyllum pinnatum (Lam.) Oken — algunos autores la ubican aún en género Bryophyllum) es una planta suculenta perenne originaria de Madagascar y África Oriental tropical, ampliamente naturalizada pantropicalmente (incluida Colombia desde hace siglos) entre 0 y 2.200 msnm en zonas térmicas cálidas-templadas-moderadas en casi todo el país: Antioquia (Medellín, Suroeste cafetero, Oriente, Bajo Cauca), Valle del Cauca (cinturón frutícola y zonas urbanas), Cundinamarca (Sabana templada — La Mesa, Anolaima, Anapoima, Fusagasugá), Boyacá templada (Moniquirá, Santana, Chitaraque), Caldas, Risaralda, Quindío (Eje Cafetero), Tolima, Huila, Santander (Bucaramanga, San Gil, Barichara, Lebrija), Norte de Santander, Magdalena (Santa Marta), Atlántico (Barranquilla), Bolívar (Cartagena), Cesar (Valledupar), La Guajira (sur), Córdoba, Sucre, Chocó (Quibdó), Cauca, Nariño y zonas urbanas en general. Es lección viva PEDAGÓGICAMENTE EXCELENTE — entre las plantas más mágicas del catálogo de huerta escolar — de reproducción asexual vegetativa por apomixis foliar (también llamada reproducción foliar plantular o yemas foliares marginales), un fenómeno biológico extraordinario que enseña a niñas y niños cómo una sola hoja desprendida de Kalanchoe pinnata produce espontáneamente 5-15 plantulas en miniatura (propágulos foliares) en cada hendidura del margen serrado-crenado de la hoja — sin necesidad de semilla, sin floración, sin polinización, sin riego intensivo, en apenas 7-21 días — basta dejar una hoja sobre tierra apenas humedecida (o incluso pegada con cinta a una pared con humedad ambiental) para que emita docenas de hijos perfectos clonales con sus propias raíces y hojas listas para autopropagarse y formar nuevas plantas adultas en pocos meses. Goethe la estudió obsesivamente durante sus investigaciones de metamorfosis vegetal y la nombró 'Goethe-Pflanze' (planta de Goethe) en honor a esa capacidad regenerativa que parecía contradecir las leyes biológicas conocidas en su época (siglo XVIII-XIX) — fenómeno hoy entendido como meristemos epifilos pre-formados en el primordio foliar que se activan tras desconexión del flujo de auxinas-citokininas de la planta madre. Pertenece a la familia Crassulaceae (igual familia que Crassula ovata jade, sedum, echeveria), planta perenne arbustiva-herbácea de 0.6-1.8 m de altura con tallos suculentos huecos rojizo-verdosos, hojas suculentas opuestas decusadas pinnadas en las plantas adultas (3-5 folíolos elípticos crenado-aserrados) o simples ovalado-crenadas en plantas juveniles (3-15 cm largo x 2-8 cm ancho) verde-jade brillantes a veces con bordes rojizos en exposición sol, inflorescencia panícula terminal péndula vistosa con flores tubulares colgantes péndulas anaranjado-rojizo-purpúreas (2-5 cm largo) polinizadas por colibríes (Trochilidae — colibríes esmeralda, pico-de-hoz, ermitaños neotropicales) y polillas crepusculares, frutos folículos con muchas semillas pequeñas (rara vez forma fruto en Colombia — predomina reproducción foliar asexual). Patrón fotosintético CAM. Uso medicinal tradicional pantropical bien documentado: hojas frescas trituradas como cataplasma cicatrizante de heridas-quemaduras-úlceras cutáneas, jugo de hojas como antiinflamatorio-antitusivo-diurético-antilitiásico (uso popular muy difundido en Colombia, Caribe, Centroamérica, Brasil, África, India — 'leaf of life'), estudios fitoquímicos identifican bufadienólidos (cardenólidos similares a digitálicos — precaución cardíaca en dosis altas), flavonoides, esteroles, ácidos orgánicos. Considerada planta ritual-protectora en tradiciones afrocaribeñas-yorubas santería ('yerba bruja' protectora del hogar). Manejo agroecológico: PROPAGACIÓN PRÁCTICAMENTE GRATUITA E ILIMITADA — basta dejar una hoja madura desprendida sobre sustrato apenas humedecido (tierra + arena 1:1) o incluso colgada en una bolsa plástica transparente con poca humedad ambiental y a los 7-21 días emite plantulas marginales listas para trasplantar individualmente, distancia 30-50 cm en cobertura, sombra parcial a sol parcial filtrado (no sol pleno tropical), riego moderado-escaso, suelos bien drenados, tolera sequía moderada, asocio con menta, hierbabuena, hierbabuena, cilantro, ajenjo, ruda en huertos medicinales caseros. Función en chagra/huerto escolar como medicinal tradicional cosmopolita de soberanía alimentaria, planta PEDAGÓGICAMENTE EXCELENTE para enseñar reproducción asexual vegetativa por apomixis foliar a niñas y niños (la lección biológica más impactante y visual de toda la huerta — un solo experimento simple con una hoja sobre tierra muestra la magia de la propagación clonal), cobertura del suelo medicinal, atractora de colibríes y polillas, ornamental tropical. Fuentes Tier A: GBIF, POWO Kew, Pamplona-Roger 2006 Plantas Medicinales, JBB Plantas Medicinales Cundinamarca-Boyacá, Pérez Arbeláez 1947, SiB Colombia, Bernal 2015.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "lavandula_dentata",
+      "nombre_comun": "Lavanda dentada",
+      "nombre_cientifico": "Lavandula dentata L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "pest_repellent",
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1500,
+        "optimo_max": 2600,
+        "max_absoluto": 2900
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 12,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Esqueje semileñoso 10-15 cm de rama lateral, enraizamiento 4-6 semanas en sustrato arenoso bien drenado, distancia 80-100 cm entre plantas. Alternativa semilla pero germinación lenta e irregular. Floración casi continua en clima andino templado."
+      },
+      "companions": [
+        "dahlia_imperialis",
+        "monarda_didyma",
+        "rosmarinus_officinalis",
+        "salvia_officinalis",
+        "thymus_vulgaris"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La Lavanda dentada (Lavandula dentata L., Lamiaceae) es un arbusto perenne aromático originario de la región mediterránea (sur de España, Marruecos, Argelia, islas Baleares) y naturalizado-cultivado mundialmente como ornamental aromático, medicinal y atrayente excepcional de polinizadores. Distinta de Lavandula angustifolia (lavanda inglesa o \"true lavender\" de clima frío montañoso con hojas lineares enteras y flores azul-violeta intensas) por sus hojas dentadas características pinnatipartidas (de ahí dentata), su tolerancia a clima más cálido y seco mediterráneo (vs. el clima alpino-templado de angustifolia), su floración casi continua a lo largo del año en clima andino templado (vs. floración estacional de angustifolia), y flores ligeramente más pálidas violeta-grisáceas con bráctea apical estéril vistosa coronando la espiga. En Colombia se cultiva en clima templado y frío seco entre 1.500 y 2.900 msnm: Sabana de Bogotá, Boyacá, Cundinamarca, Antioquia oriente, Eje Cafetero, Valle del Cauca andino, Nariño altoandino. Manejo agronómico: propagación principal por esqueje semileñoso de 10-15 cm de rama lateral (método más rápido y fiable, preserva características parentales), enraizamiento 4-6 semanas en sustrato arenoso bien drenado bajo invernadero o cama nebulizada, alternativa por semilla con germinación lenta e irregular (15-40 días) y variabilidad genética alta no recomendada para producción comercial, distancia de plantación 80-100 cm entre plantas en seto aromático, suelo calcáreo o neutro bien drenado (NO tolera encharcamiento ni suelos pesados), riego moderado a bajo (drought-tolerant), poda anual post-floración para estimular nuevos brotes y compacidad. Floración casi continua en clima andino templado (vs. estacional de L. angustifolia en clima frío). Atracción excepcional de polinizadores: una sola planta floreciente sostiene decenas de abejas (Apis mellifera, abejas solitarias, abejorros Bombus spp.) y mariposas a lo largo del día, es de las plantas mediterráneas más visitadas por himenópteros en jardines colombianos, planta apícola clave para apiarios urbanos y periurbanos andinos. Aceite esencial: las flores frescas o secas destiladas producen aceite esencial rico en linalool, alcanfor, cineol y acetato de linalilo (composición distinta de angustifolia, más cánfora-cineol, menos linalool puro), aroma alcanforado-floral característico, usos en aromaterapia (relajante, antiséptico aéreo, repelente de moscas y polillas), perfumería de gama media-alta, cosmética artesanal (jabones, sales de baño, cremas), repostería discreta (helados de lavanda, panaderías francesas, mieles aromatizadas). Uso medicinal tradicional documentado: infusión de flores sedante leve para nervios y ansiedad, antiespasmódico digestivo, antiséptico de heridas leves, repelente de polillas en armarios (saquitos de lavanda seca). Manejo en huerta agroecológica: seto perimetral aromático junto con romero (Rosmarinus officinalis), salvia (Salvia officinalis) y tomillo (Thymus vulgaris) como gremio mediterráneo repelente de plagas y atrayente de polinizadores, plantación en macetera grande en balcón o terraza (escala apartamento viable con sol pleno), poda anual de mantenimiento post-floración. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pamplona Roger 2006 Plantas Medicinales, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "lolium_perenne",
+      "nombre_comun": "Raigras perenne",
+      "nombre_cientifico": "Lolium perenne L.",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "ground_cover",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "festuca_arundinacea",
+        "medicago_sativa",
+        "trifolium_repens"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-forrajeras-2022",
+        "agrosavia-silvopastoriles",
+        "bernal-2015-plantas-liquenes-colombia",
+        "restrepo-2005-agroecologia"
+      ],
+      "valor_pedagogico": "El raigrás perenne o ballico inglés (Lolium perenne L., familia Poaceae, subfamilia Pooideae) es una poácea perenne herbácea cespitosa originaria de Europa templada y Asia occidental, considerada la gramínea forrajera más cultivada del altiplano cundiboyacense colombiano y referente productivo de la lechería especializada de zona fría. Forma macollos densos verde-oscuro brillantes con hojas planas glabras, panículas erectas con espiguillas multifloras dísticas opuestas al raquis (rasgo diagnóstico del género Lolium) y crecimiento rápido en clima frío húmedo. Se cultiva en Cundinamarca (Sabana de Bogotá, Mosquera, Madrid, Funza, Subachoque, Chocontá, Tabio), Boyacá (Tunja, Sotaquirá, Paipa, Duitama, Sogamoso, altiplano lechero), Nariño (Pasto, Túquerres, Ipiales, Sapuyes), Antioquia (oriente lechero — La Unión, La Ceja, El Carmen de Viboral) y Eje cafetero alto entre 2.200 y 3.000 msnm en zona térmica fría húmeda. Ciclo perenne, productividad sostenida 4-6 años antes de renovar pradera. Rendimientos 14-20 t/ha materia seca por año, base de la producción láctea industrial colombiana de hato Holstein y cruces (95% del altiplano cundiboyacense). Lección viva de la alfombra verde del altiplano: el raigrás perenne demuestra la sinergia entre gramíneas y leguminosas en la pradera (raigrás + trébol blanco Trifolium repens), enseñando el equilibrio forrajero que sostiene la ganadería altoandina lechera, con el trébol aportando 100-200 kg N biológico/ha/año y el raigrás aportando biomasa de alta digestibilidad (NDF 45-55%, proteína 18-22%). Manejo agroecológico: siembra al voleo 20-30 kg/ha asociada con trébol blanco 3-5 kg/ha, pastoreo rotacional intensivo con franjas eléctricas y descansos de 21-28 días, fertilización con abonos orgánicos (estiércol, compost) y encalado preventivo. Fuentes Tier A: AGROSAVIA Forrajeras 2022, POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "magnolia_caricifragrans",
+      "nombre_comun": "Magnolia colombiana",
+      "nombre_cientifico": "Magnolia caricifragrans (Lozano) Govaerts",
+      "familia_botanica": "Magnoliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "endemica_colombia",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1500,
+        "optimo_max": 1900,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 1,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 27
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cedrela_montana",
+        "coffea_arabica",
+        "inga_densiflora",
+        "ocotea_calophylla"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La magnolia colombiana o molinillo (Magnolia caricifragrans, Magnoliaceae) es una de las magnolias endémicas más representativas de los bosques andinos premontanos cafeteros de Colombia, distribuida exclusivamente en las cordilleras Central y Occidental colombianas, principalmente en Antioquia, Caldas, Risaralda, Quindío y Valle del Cauca entre 1.200 y 2.000 msnm. Árbol perennifolio de 15-25 metros de altura con fuste cilíndrico recto, copa piramidal-redondeada, corteza gris lisa con lenticelas características, hojas alternas grandes coriáceas oblongo-elípticas verde oscuro brillantes en haz y pálidas pubescentes en envés, flores solitarias terminales grandes (10-15 cm) blanco-cremas con tépalos carnosos y aroma intenso a frutas frescas o cítricos característicos de las Magnoliaceae primitivas, conos folicíferos rojo-anaranjados al madurar con semillas rodeadas de arilo carnoso rojo dispersadas por aves frugívoras. La familia Magnoliaceae es uno de los linajes más antiguos de plantas con flores (130-140 millones de años de antigüedad, Cretácico inferior) y conserva características florales primitivas: tépalos no diferenciados en pétalos y sépalos, ovario apocárpico (carpelos libres), polinización por escarabajos primitivos Coleoptera anteriores a la diversificación de las abejas. Esto la convierte en una de las plantas vivas más interesantes para la enseñanza de la evolución vegetal. Colombia es uno de los países con mayor diversidad de magnolias del Neotrópico (33 especies conocidas, la mayoría endémicas) pero también con el mayor número de magnolias amenazadas: M. caricifragrans está categorizada como endémica colombiana con poblaciones silvestres altamente reducidas por la deforestación histórica del bosque andino premontano cafetero (especialmente en el Eje Cafetero entre 1900-1970 cuando se transformaron millones de hectáreas a cafetal y potrero). Su conservación ex situ depende hoy de jardines botánicos (Jardín Botánico de Bogotá, JB Quindío, JB Joaquín Antonio Uribe Medellín), arboretos cafeteros y huertos patrimoniales rurales. Es lección de soberanía botánica y biogeografía: cada cordillera de los Andes colombianos alberga magnolias endémicas únicas (M. caricifragrans en zona cafetera, M. yarumalensis en Antioquia, M. hernandezii en Quindío, M. mahechae en Valle, M. wolfii en Quindío) que constituyen patrimonio genético irreemplazable del país y de la humanidad. Recuperar las magnolias colombianas en cafetales con sombrío diversificado, huertos patrimoniales y programas de restauración bosque andino es acto de conservación cultural y genética. Fuentes Tier A: Lozano-Contreras 2003 Magnoliaceae Colombia, Calderón-Sáenz et al. 2007 Libro Rojo Magnoliaceae Colombia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "magnolia_yarumalensis",
+      "nombre_comun": "Magnolia Yarumal",
+      "nombre_cientifico": "Magnolia yarumalensis (Lozano) Govaerts",
+      "familia_botanica": "Magnoliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 1700,
+        "optimo_min": 1900,
+        "optimo_max": 2000,
+        "max_absoluto": 2500
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 12,
+        "optimo_max": 19,
+        "max_tolerable": 24
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "alnus_acuminata",
+        "cedrela_montana",
+        "inga_densiflora",
+        "juglans_neotropica"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La magnolia Yarumal o molinillo de Yarumal (Magnolia yarumalensis, Magnoliaceae) es una de las magnolias endémicas más críticamente amenazadas de Colombia y del Neotrópico, descrita originalmente por el botánico colombiano Jesús Idrobo y posteriormente revisada por Lozano-Contreras como especie estricta. Es endémica exclusiva del norte del departamento de Antioquia, principalmente en los municipios de Yarumal (de donde toma su nombre), Angostura, Santa Rosa de Osos, Belmira y áreas aledañas del altiplano norte antioqueño, entre 1.700 y 2.500 msnm en remanentes de bosque andino premontano y montano bajo. Árbol perennifolio de 18-28 metros de altura con fuste cilíndrico recto, copa piramidal característica, corteza gris lisa con lenticelas, hojas alternas grandes coriáceas oblongo-elípticas verde oscuro lustroso en haz y pálidas pubescentes en envés con base obtusa, flores solitarias terminales grandes (10-13 cm) blanco-cremas con tépalos carnosos aromáticos a frutas, conos folicíferos rojo-anaranjados al madurar con semillas envueltas en arilo rojo dispersadas por aves frugívoras del bosque andino. Su estado de conservación es crítico: las poblaciones silvestres conocidas suman menos de 50 individuos maduros distribuidos en fragmentos relictuales de bosque andino antioqueño, severamente afectados por la deforestación histórica del altiplano norte antioqueño para ganadería extensiva durante los siglos XIX y XX. Está categorizada como EN PELIGRO (EN) tendiente a CRÍTICAMENTE AMENAZADA (CR) en el Libro Rojo de Magnoliaceae de Colombia (Calderón-Sáenz et al. 2007). El Jardín Botánico Joaquín Antonio Uribe de Medellín lidera desde 2010 un programa de conservación ex situ que incluye colecciones vivas en arboretos, propagación de semillas (con tasas de germinación bajas por la recalcitrancia y sensibilidad de las semillas), y reintroducciones experimentales en bosques relictuales con Cornare (Corporación Autónoma Regional de las Cuencas de los Ríos Negro y Nare) y Corantioquia. Es lección de soberanía botánica y conservación: las magnolias endémicas antioqueñas (M. yarumalensis, M. cespedesii, M. polyhypsophylla, M. silvioi entre otras) son un patrimonio genético irreemplazable que está literalmente al borde de la extinción comercial silenciosa, paralela a la pérdida masiva de bosque andino antioqueño durante el siglo XX. Cada ejemplar plantado en huertos patrimoniales, fincas cafeteras de altura y jardines rurales del norte antioqueño es un acto concreto de conservación genética y resistencia ante la extinción. La especie también tiene valor cultural local: en el patrimonio cafetero antioqueño se conoce como 'almanegra' por la corteza oscura, y aparece en relatos campesinos del altiplano norte como árbol emblemático de los bosques de niebla relictuales. Fuentes Tier A: Lozano-Contreras 2003 Magnoliaceae Colombia, Calderón-Sáenz et al. 2007 Libro Rojo Magnoliaceae Colombia (categoría EN/CR), Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, IUCN Red List.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "malus_domestica_sabanera",
+      "nombre_comun": "Manzano de Sabana",
+      "nombre_cientifico": "Malus domestica (Suckow) Borkh. cv. Sabanera",
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2300,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "injerto",
+        "notas": "Injerto sobre patrón franco (semillero local) o patrón clonal MM-106/M-9 para altiplano; requiere acumulación de horas frío (300-600 h <7°C) que sí se logra en Sabana Bogotá y altiplanos cundiboyacenses."
+      },
+      "antagonists": [
+        "juglans_neotropica"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "ica-resolucion-3168-2015",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El manzano de Sabana (Malus domestica (Suckow) Borkh. cv. Sabanera, Rosaceae) es un frutal templado caducifolio de la Sabana Bogotá y altiplano cundiboyacense, cultivado tradicionalmente entre 2.300 y 2.800 msnm en zona térmica fría con acumulación natural de horas frío (300-600 h <7°C). Presente en Cundinamarca (Sopó, Chía, Cota, Tenjo, Subachoque, Choachí, Ubaté), Boyacá (Paipa, Duitama, Sotaquirá, Tibasosa, Tunja), Nariño (Ipiales, Túquerres, Pasto) y altiplano antioqueño (Santa Rosa de Osos, Belmira). Árbol de 4-8 m de altura, copa redondeada, follaje caducifolio que reposa en periodo seco. Flores blanco-rosadas en corimbo que aparecen antes que las hojas, atrayendo abejas (Apis mellifera) y polinizadores nativos (Bombus rubicundus, Xylocopa). Frutos en pomo globoso de 5-8 cm, piel verde-amarilla con chapa rosa-rojiza al sol, pulpa blanca crujiente dulce-acidulada (12-14° Brix). Lección viva de soberanía alimentaria templada andina: enseña a niñas y niños que Colombia sí produce manzana propia, adaptada al clima frío de altura, sin necesidad de importar manzana chilena/argentina/estadounidense de menor frescura y mayor huella de carbono. Manejo agroecológico: poda de formación en vaso o eje central, distancia 4×5 m (500 árboles/ha), fertilización con compost + biol foliar, control de Cydia pomonella (gusano de la manzana) con trampas de feromona + Bacillus thuringiensis, manejo de Venturia inaequalis (sarna del manzano) con caldo bordelés + caldo sulfocálcico preventivo. Asocios productivos en altiplano: tagasaste (Cytisus proliferus) como cortavientos y aporte N, papa criolla en calles primeros 2 años, fresa Monterrey como cobertura productiva, trébol blanco fijador. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, AGROSAVIA Manual Frutales Tropicales, ICA Resolución 3168/2015, Pérez-Arbeláez 1947 Plantas Útiles.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "mammea_americana",
+      "nombre_comun": "Mamey amarillo",
+      "nombre_cientifico": "Mammea americana L.",
+      "familia_botanica": "Calophyllaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 50,
+        "optimo_max": 800,
+        "max_absoluto": 1100
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "mangifera_indica",
+        "musa_paradisiaca",
+        "spondias_dulcis"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles",
+        "sib-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "agrosavia-manual-frutales-tropicales"
+      ],
+      "valor_pedagogico": "El mamey amarillo o mamey de Cartagena (Mammea americana L., Calophyllaceae — antes Clusiaceae sensu lato hasta la reclasificación APG III-IV 2009-2016) es un árbol frutal perenne nativo del Caribe insular (Antillas Mayores) y continental (norte de Sudamérica — Colombia, Venezuela, Panamá), considerado uno de los pocos frutales NATIVOS del Caribe colombiano por excelencia (a diferencia del níspero/zapote Manilkara zapota que es mesoamericano y el mamey colorado Pouteria sapota que es mesoamericano-yucateco — el mamey amarillo SÍ es nativo caribeño-circuncaribe, presente en Colombia desde antes del contacto colonial documentado por crónicas tempranas del siglo XVI en Cartagena de Indias, origen del nombre vernáculo regional \"mamey de Cartagena\"). Distribución colombiana en zonas cálidas costeras del Caribe (Atlántico, Bolívar — especialmente Montes de María y Cartagena, Magdalena — Santa Marta y Ciénaga Grande, Córdoba, Sucre — San Onofre y Tolú, Cesar, La Guajira sur), Chocó biogeográfico (Quibdó, Bahía Solano, Nuquí), zonas bajas de Antioquia (Urabá), Valle medio y bajo Magdalena, Llanos bajos cálidos y zonas urbanas tropicales entre 0 y 800 msnm con temperaturas 22-30 °C, sol pleno, suelos bien drenados, tolerante a brisas salinas y vientos costeros. Árbol siempreverde majestuoso de 15-25 m altura con copa piramidal-densa simétrica de gran valor ornamental y de sombra, madera dura rojiza usada en carpintería de exterior y construcciones rurales tradicionales. Hojas grandes (10-25 cm) opuestas-coriáceas elíptico-oblongas verde-oscuro brillante por el haz con puntos translúcidos visibles al trasluz (glándulas oleíferas características del clado Calophyllaceae-Clusiaceae). Flores blanco-cremosas perfumadas grandes (3-5 cm) solitarias o en grupos pequeños en ramas — polinizadas por abejas, mariposas y murciélagos. Frutos baya esférica-globosa (8-20 cm diámetro, 0.5-2 kg), cáscara marrón-óxido coriácea-fibrosa firme que se pela manualmente revelando pulpa amarillo-anaranjada firme aromática (12-18 °Brix) de sabor delicioso comparado a albaricoque-melocotón-mango-vainilla (de ahí el nombre antillano histórico \"albaricoque de Santo Domingo\" usado por colonos franceses-españoles caribeños), con 1-4 semillas grandes lustrosas marrón-rojizas. Manejo: plantación a 10-12 m, ideal para patios tropicales costeros tradicionales caribeños, asocio con coco, plátano, mango, anón, guanábana, papaya, cacao, ñame, yuca — sistema multiestrato afrocaribe documentado por Pérez Arbeláez 1947. PROPIEDAD INSECTICIDA NATURAL DESTACADA: semillas y látex contienen mammeína (cumarinas insecticidas naturales) usadas tradicionalmente en Antillas-Caribe como insecticida natural para piojos, pulgas, chinches y plagas de cultivos — lección pedagógica importante sobre química verde y biopesticidas tradicionales (precursores naturales de los piretroides modernos), aunque deben manejarse con precaución porque también son tóxicos a peces y mamíferos en dosis altas (no comer las semillas crudas). Las flores se usan tradicionalmente para perfumar licores caribeños (\"crème de mamey\", \"eau de mammée\") por su aroma intenso vainilla-tropical. Función pedagógica excelente: enseña a niñas y niños (1) que SÍ existen frutales NATIVOS del Caribe colombiano (no todos los frutales son foráneos mesoamericanos), (2) la familia Calophyllaceae con sus glándulas oleíferas translúcidas visibles al trasluz como carácter taxonómico (compartido con Calophyllum y Garcinia), (3) biopesticidas naturales mammeína como precursor de químicas verdes modernas, (4) árboles polifuncionales fruta-madera-medicinal-insecticida-ornamental característicos de sistemas agroforestales caribeños tradicionales. Fuentes Tier A: GBIF, POWO Kew, Pérez Arbeláez 1947, SiB Colombia, Bernal 2015, AGROSAVIA.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "medicago_sativa",
+      "nombre_comun": "Alfalfa",
+      "nombre_cientifico": "Medicago sativa L.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "ground_cover",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 15,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "companions": [
+        "festuca_arundinacea",
+        "lolium_perenne",
+        "trifolium_repens"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-forrajeras-2022",
+        "agrosavia-leguminosas-andinas",
+        "agrosavia-silvopastoriles",
+        "bernal-2015-plantas-liquenes-colombia",
+        "restrepo-2005-agroecologia"
+      ],
+      "valor_pedagogico": "La alfalfa (Medicago sativa L., familia Fabaceae, subfamilia Faboideae) es una fabácea perenne herbácea originaria del Asia central (Persia, Caucaso, Anatolia), considerada la reina de las forrajeras a nivel global por su altísimo valor nutricional (proteína cruda 18-22%, calcio, fósforo, vitaminas A y K), su capacidad fijadora de nitrógeno biológico por simbiosis con Sinorhizobium meliloti y su raíz pivotante profunda (3-4 m) que perfora el subsuelo accediendo a humedad y nutrientes inaccesibles a otros forrajes. Se cultiva en sistemas ganaderos altoandinos colombianos en Cundinamarca (Sabana de Bogotá, Madrid, Mosquera, Funza, Subachoque), Boyacá (Tunja, Villa de Leyva, Sotaquirá, Duitama, altiplano lechero), Nariño (Pasto, Túquerres, Sapuyes, Ipiales), Valle de Tenza, Valle del Cauca y zonas con suelos neutros a alcalinos entre 2.000 y 2.800 msnm en zona térmica templada a fría seca. Ciclo perenne, productividad sostenida 4-6 años en pradera bien manejada. Rendimientos 10-18 t/ha materia seca/año en 5-7 cortes anuales. Lección viva de la maestra de la fijación de nitrógeno: la alfalfa con su raíz que perfora el subsuelo enseña cómo las leguminosas transforman el aire (N2 atmosférico) en fertilizante biológico utilizable (NH3, NH4+, NO3-) por simbiosis con bacterias del género Sinorhizobium en nódulos radicales rosados, alimentando la pradera desde las profundidades y fijando 150-250 kg N/ha/año sin necesidad de fertilización nitrogenada sintética. Manejo agroecológico: siembra al voleo 15-25 kg/ha semilla inoculada con cepa específica de Sinorhizobium meliloti, asocio con festuca o raigrás para mejor cobertura, pastoreo rotacional con descansos largos 35-45 días para no agotar reservas radiculares, encalado obligatorio para mantener pH 6.5-7.5, no requiere fertilización N. Fuentes Tier A: AGROSAVIA Forrajeras 2022, POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "melicoccus_bijugatus",
+      "nombre_comun": "Mamón",
+      "nombre_cientifico": "Melicoccus bijugatus Jacq.",
+      "familia_botanica": "Sapindaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 50,
+        "optimo_max": 800,
+        "max_absoluto": 1000
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "mangifera_indica",
+        "musa_paradisiaca",
+        "persea_americana"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles",
+        "sib-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "agrosavia-manual-frutales-tropicales"
+      ],
+      "valor_pedagogico": "El mamón o quenepa (Melicoccus bijugatus Jacq., Sapindaceae — sinónimo histórico Melicocca bijuga L.) es un árbol frutal perenne nativo de las Antillas Mayores (Cuba, Jamaica, Puerto Rico, La Española) y posiblemente del norte de Sudamérica (Colombia, Venezuela — origen disputado entre Antillas y costa norte sudamericana), ampliamente cultivado y naturalizado en todo el Caribe insular y continental (Antillas, Caribe colombiano, Venezuela, Panamá, México sur, Centroamérica, Florida sur). Es el mamón-quenepa POPULAR Y CALLEJERO POR EXCELENCIA del Caribe colombiano (distinto del mamoncillo continental Talisia olivaeformis con el que se confunde popularmente — ver entrada complementaria de Talisia en este mismo batch — pero Melicoccus es el verdadero \"mamón de Cartagena\" comercial, vendido en racimos en plazas de mercado y vendedores ambulantes de Cartagena, Barranquilla, Santa Marta, Sincelejo, Montería, Valledupar en temporada junio-septiembre). Distribución colombiana en zonas cálidas costeras del Caribe (Atlántico, Bolívar — especialmente Cartagena origen del nombre regional, Magdalena, Córdoba, Sucre, Cesar, La Guajira sur), Chocó biogeográfico, valle bajo del Magdalena, zonas bajas de Antioquia (Urabá, Bajo Cauca), Llanos bajos cálidos (Casanare-Meta-Arauca) y zonas urbanas tropicales entre 0 y 800 msnm con temperaturas 22-30 °C, sol pleno, suelos bien drenados, muy tolerante a sequías estacionales costeras y vientos salinos. Árbol siempreverde majestuoso de 18-25 m altura con copa amplia piramidal-redondeada simétrica de gran valor ornamental y de sombra urbana (plantado masivamente en parques y avenidas de ciudades caribeñas), madera dura amarilla-clara usada en carpintería. Hojas alternas-paripinnadas con 4 folíolos elípticos verde-oscuro brillante (epíteto \"bijugatus\" = \"con dos pares de folíolos\"). Característica botánica destacada: DIOICIA ESTRICTA — los árboles son macho o hembra separados (no hermafroditas), solo las hembras producen frutos. Esta característica es lección pedagógica importante porque (1) significa que para producción comercial se debe plantar ratio 1 macho : 8-10 hembras o injertar ramas macho en árboles hembras, (2) muchos productores compran árboles de semilla y descubren después de 6-10 años que tienen un macho improductivo (frustración común — promueve uso de injerto sobre franco), (3) ejemplifica diversidad de sistemas reproductivos vegetales (compáralo con hermafroditas como mango, aguacate; monoicos como maíz, cucurbitáceas; dioicos como papayo, kiwi, mamón). Flores pequeñas blanco-cremosas perfumadas en panículas terminales (flores macho con estambres, flores hembra con ovario sin estambres funcionales) polinizadas por abejas nativas y mariposas. Frutos baya esférica-aovada (2-3 cm) en racimos densos de 15-50 frutos por racimo, cáscara coriácea verde-amarillenta firme que se rompe con los dientes liberando pulpa arilo gelatinoso rosado-anaranjado-amarillo claro dulce-acidulado (10-14 °Brix) muy refrescante alrededor de una semilla grande única lustrosa beige-rosada. Manejo: plantación a 10-12 m, ideal en patios tropicales caribeños tradicionales, asocio con mango, aguacate, anón, guanábana, papayo, plátano, coco, mamey amarillo Mammea americana, níspero Manilkara zapota. Importancia económica creciente en Caribe colombiano como fruta callejera comercial de temporada (vendedores ambulantes con racimos enteros), exportación nicho a mercados étnicos hispano-caribeños en Estados Unidos (Miami, NYC). Función pedagógica excepcional: enseña a niñas y niños (1) DIOICIA estricta como sistema reproductivo vegetal distintivo, (2) distinción geográfica importante entre mamón antillano-naturalizado Melicoccus bijugatus vs mamoncillo continental nativo Talisia olivaeformis (lección de biogeografía caribeña — ambos confusamente llamados \"mamón/mamoncillo\" en habla popular pero son géneros distintos de Sapindaceae), (3) consumo callejero tradicional caribeño rompiendo cáscara con dientes (técnica práctica), (4) diversidad de Sapindaceae frutales (mamón, mamoncillo, lichi, longan, ackee). Fuentes Tier A: GBIF, POWO Kew, Pérez Arbeláez 1947, SiB Colombia, Bernal 2015, AGROSAVIA.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "melinis_minutiflora",
+      "nombre_comun": "Pasto gordura",
+      "nombre_cientifico": "Melinis minutiflora P.Beauv.",
+      "familia_botanica": "Poaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "invasive",
+        "ground_cover"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 800,
+        "optimo_max": 1800,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "stylosanthes_guianensis"
+      ],
+      "especies_nativas_sustitutas": [
+        "paspalum_notatum"
+      ],
+      "source_ids": [
+        "humboldt-invasoras-andes",
+        "issg-uicn-invasoras",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "res-684-2018-mads",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "El pasto gordura o melao (Melinis minutiflora P.Beauv., Poaceae, subfamilia Panicoideae, tribu Paniceae) es una de las gramíneas invasoras más problemáticas del Neotrópico y, en Colombia, uno de los principales motores de degradación del bosque seco tropical (BST, ecosistema en categoría crítica nacional con apenas 8% de cobertura remanente) y del bosque sub-andino del piedemonte tropical. Originaria del África tropical y subtropical (desde Etiopía y Tanzania hasta Sudáfrica), fue introducida a Brasil en el siglo XIX como forrajera prometedora por su aroma característico a melao (de ahí el nombre común \"molasses grass\") y su buen palatabilidad aparente para ganado, y de allí difundida a Colombia y otros países latinoamericanos durante el siglo XX, particularmente promovida entre 1950 y 1970 como \"forrajera de altura\" para zonas templadas y sub-cálidas donde las brachiarias del piso cálido aún no llegaban. Hoy se ha naturalizado agresivamente en gran parte del territorio nacional entre 500 y 2.400 msnm en zona térmica cálida y templada, con presencia masiva e invasora en bosque seco tropical (Caribe seco-húmedo, valles interandinos del Magdalena, Cauca, Patía), bosque sub-andino del piedemonte (Antioquia, Cundinamarca, Boyacá, Tolima, Huila, Santander, Valle del Cauca), matorrales xerofíticos (La Guajira, Tatacoa, alta Boyacá) y bordes del bosque alto-andino en algunas regiones del eje cafetero. Es gramínea perenne cespitosa-decumbente de 60-100 cm de altura con macollas medianas, hojas lineares-lanceoladas con pubescencia glandular pegajosa que produce el aroma característico a melao-canela (de ahí \"pasto gordura\": las hojas se sienten pegajosas-grasosas al tacto), inflorescencia en panícula amplia con espiguillas pequeñas vellosas, semillas pequeñas con pelos largos sedosos (caracter diagnóstico) que se dispersan por viento (anemocoria) a distancias de cientos de metros, propagación también por estolones rastreros post-disturbio. Su característica ecológica más perversa y diferenciadora de otras invasoras es la modificación del régimen de fuego en los ecosistemas que invade: las hojas pegajosas contienen aceites volátiles aromáticos (compuestos terpénicos) altamente inflamables que aumentan dramáticamente la intensidad, velocidad de propagación y frecuencia de los incendios estacionales en BST y bosque sub-andino, donde los árboles nativos (Tabebuia rosea, Caesalpinia ebano, Pithecellobium dulce, Bursera simarouba, Cordia gerascanthus, Albizia spp.) no están adaptados a regímenes de fuego intenso y son eliminados, mientras M. minutiflora rebrota masivamente desde sus estolones y banco de semillas post-fuego antes que las nativas, estableciéndose como dominante en pradera invadida. Este bucle de retroalimentación fuego-invasión convierte progresivamente bosque seco tropical en sabana monoespecífica dominada por M. minutiflora, fenómeno documentado por IAvH-Humboldt como uno de los principales motores de degradación del BST en Colombia (junto con la deforestación directa para ganadería) y por el cual la especie está listada como naturalizada de alto riesgo invasor en bases de datos como ISSG/GISD (Global Invasive Species Database) e IAvH-Humboldt Invasoras Andes. La Resolución 684/2018 del MADS la incluye en lineamientos de control en áreas de restauración del BST, y su siembra deliberada en áreas protegidas, zonas de amortiguamiento de PNN y áreas de restauración está desaconsejada técnicamente. Métodos de control: el desenraice manual repetido es efectivo en parches pequeños pero requiere extraer mata completa con sistema radicular; el fuego controlado NO se recomienda como método de control porque favorece a la propia especie sobre las nativas (error frecuente de quienes intentan \"limpiar\" el pasto con fuego); el método de mayor efectividad a largo plazo es la restauración activa con plantación densa de árboles nativos del BST que cierran dosel y suprimen el pasto por sombreo, complementado con mulching grueso y monitoreo trimestral durante 3-5 años. Es lección ecológica fundamental de la invasión biológica neotropical: una gramínea africana introducida con buenas intenciones forrajeras hace siglo y medio se ha convertido en uno de los principales motores de degradación del bosque seco tropical colombiano, ecosistema en categoría crítica nacional, demostrando que la introducción de especies exóticas para fines productivos puede tener costos ecológicos de larga duración que superan ampliamente sus beneficios iniciales. Su control y la restauración del BST invadido es prioridad nacional de conservación ambiental. Fuentes Tier A: IAvH-Humboldt Invasoras Andes, ISSG/UICN Global Invasive Species Database, POWO Kew, GBIF Backbone Taxonomy, MADS Resolución 684/2018, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "pasto de gordura"
+      ]
+    },
+    {
+      "id": "miconia_squamulosa",
+      "nombre_comun": "Niguito",
+      "nombre_cientifico": "Miconia squamulosa Naudin",
+      "familia_botanica": "Melastomataceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3300
+      },
+      "companions": [
+        "axinaea_macrophylla"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-flora-alto-andina",
+        "restauracion-cruz-verde-sumapaz",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "El niguito o tuno (Miconia squamulosa Naudin, familia Melastomataceae, tribu Miconieae) es una melastomatácea arbórea pequeña a mediana (5-12 m altura, hábito ramificado denso) perennifolia nativa de los bosques altoandinos y sub-páramo de Colombia, Venezuela y Ecuador, considerada una de las especies leñosas pioneras-tempranas más importantes en la sucesión ecológica secundaria del bosque alto-andino colombiano post-disturbio (potreros abandonados, deslizamientos, áreas de regeneración natural). Sus hojas opuestas decusadas elípticas-ovadas (8-15 cm largo) presentan el patrón característico de venación acródroma curvinervia (3-5 nervios principales paralelos partiendo de la base) diagnóstico inequívoco de la familia Melastomataceae, una sinapomorfía morfológica visible a simple vista que permite identificación de campo confiable. Su envés foliar es densamente escamoso-tomentoso (de ahí el epíteto squamulosa). Produce inflorescencias terminales en panículas densas con flores pequeñas blanco-rosadas pentámeras y frutos en baya pequeña (5-8 mm diámetro) morado-negros maduros, altamente apetecidos por avifauna frugívora. Se distribuye en bosque altoandino y sub-páramo de Cundinamarca (Chingaza, Sumapaz, Cruz Verde, La Calera, Guasca), Boyacá (Iguaque, Arcabuco, Santa Sofía), Santander (Yariguíes, Páramo del Almorzadero), Antioquia (oriente — San Rafael, Sonsón), Cauca (Puracé) y Eje cafetero (Los Nevados) entre 1.800 y 3.300 msnm en zona térmica fría a templada húmeda. Ciclo perenne de larga duración, longevidad 40-80 años, fructificación masiva escalonada todo el año con picos en lluvias. Lección viva: árbol andino nativo de bosque sub-páramo y sucesional pionero-temprano de alto valor para restauración ecológica — sus frutos morado-negros atraen avifauna frugívora andina (Turdus fuscater mirla patiamarilla, Tangara vassorii cuningui, Diglossa cyanea pinchaflor, Catamblyrhynchus diadema mielero gorra-castaña) que actúan como dispersores de semillas a sitios degradados (zoocoria), enseñando el rol crítico de las melastomatáceas pioneras como nurse plants facilitadoras frente a invasoras agresivas del altiplano cundiboyacense (Pteridium aquilinum helecho marranero, Ulex europaeus retamo espinoso, Cenchrus clandestinus kikuyo). Enseña tres conceptos críticos: sucesión ecológica secundaria con nurse plants nativas (mecanismo de facilitación de Connell-Slatyer 1977), zoocoria por avifauna como motor de regeneración de bosque altoandino, y restauración asistida por especies nativas en planes de la CAR-Cundinamarca y Cruz Verde-Sumapaz como alternativa documentada al control químico de invasoras. Manejo agroecológico: propagación por semilla recolectada de frutos maduros (germinación lenta 30-60 días, requiere sustrato ácido húmedo bajo sombra), trasplante con cepellón a sitio definitivo en lluvias, plantación en grupos densos de 5-10 plantas a 2 m entre individuos como núcleo de restauración, asocio con drimys, weinmannia y escalonia, no tolera agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Bernal 2015 Catálogo Plantas Colombia, Humboldt Flora Alto-Andina, Restauración Cruz Verde-Sumapaz, SIB Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "mirabilis_expansa",
+      "nombre_comun": "Mauka",
+      "nombre_cientifico": "Mirabilis expansa (Ruiz & Pav.) Standl.",
+      "familia_botanica": "Nyctaginaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2700,
+        "optimo_max": 3500,
+        "max_absoluto": 3800
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "esqueje_tallo",
+        "notas": "Tubérculo andino casi extinto — relegado tradicionalmente a pequeños refugios en Ecuador (Cañar, Azuay), Perú (Cajamarca, Áncash) y Bolivia (Cochabamba). Se propaga por esquejes basales del tallo (30 cm) que rebrotan vigorosamente. Las raíces tuberosas dulces (300 g - 1.5 kg) requieren asoleo post-cosecha de 5-7 días para reducir sapogeninas amargas y dulcificarse. Ciclo 8-14 meses. Una de las plantas alimenticias más subutilizadas y olvidadas del mundo (NRC 1989)."
+      },
+      "companions": [
+        "borago_officinalis",
+        "oxalis_tuberosa",
+        "ruta_graveolens",
+        "solanum_phureja",
+        "ullucus_tuberosus"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "nrc-1989-cultivos-andinos",
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "La mauka, miso o chago (Mirabilis expansa (Ruiz & Pav.) Standl., familia Nyctaginaceae) es uno de los cultivos andinos más fascinantes, raros y subutilizados del mundo según el National Research Council 1989 'Lost Crops of the Incas' — una nictagínea andina (misma familia botánica que el buganvil ornamental) de raíz tuberosa engrosada (300 g a 1.5 kg, hasta 15-30 cm largo, color blanco-amarillento o rosado-violáceo según variedad) que se cultivaba ampliamente en el imperio inca y que actualmente sobrevive solo en bolsones genéticos muy reducidos en Cañar y Azuay (Ecuador), Cajamarca y Áncash (Perú) y Cochabamba (Bolivia), estimándose que menos de 5.000 familias campesinas la cultivan actualmente en todos los Andes — un cultivo casi extinto que pueblos campesinos andinos sostienen como 'planta-memoria' de la agricultura precolombina. En Colombia tiene presencia histórica documentada en Nariño (resguardos de los Pastos en Cumbal, Túquerres, Guachucal, Ipiales, Aldea de María) y Cauca (resguardos Misak-Guambianos en Silvia y Totoró, resguardos Nasa en Inzá) entre 2.700-3.500 msnm en zona térmica fría, donde ha sido registrada como cultivo tradicional indígena reliquia por etnobotánicos colombianos (Bernal et al. 2015). Lección viva de erosión genética y conservación de cultivos olvidados: la mauka es ejemplo dramático de cómo la modernización agrícola y la presión del mercado por monocultivos comerciales (papa-cebada-trigo en altiplano) ha relegado a la extinción cultivos enteros que sostuvieron civilizaciones precolombinas durante milenios, y enseña la urgencia de programas activos de rescate genético, refugios in-situ con comunidades indígenas custodias, y bancos de germoplasma ex-situ como medidas complementarias. La raíz tuberosa fresca recién cosechada es amarga por contenido de sapogeninas triterpénicas defensivas y NO se consume así — requiere asoleo post-cosecha durante 5-7 días al sol andino fuerte (técnica idéntica a la del oca, ulluco y maca), proceso que hidroliza enzimáticamente las sapogeninas, concentra azúcares solubles (sacarosa, fructosa) y transforma la raíz amarga en alimento dulce-aromático similar al camote pero con textura más fibrosa y aroma distintivo, consumido cocido en sopas, asado, en chicha fermentada y como dulce campesino tradicional. Manejo agroecológico: propagación por esquejes basales del tallo (segmentos de 30 cm de tallos basales lignificados con 2-3 yemas activas), nunca por semilla (germinación errática), plantación a 50-80 cm entre plantas, ciclo 8-14 meses a primera cosecha (lento), rebrota de la corona varios años (cultivo semi-perenne 3-5 ciclos), rendimientos 10-25 t/ha raíz fresca. Asocio con maíz cabuya, papa criolla, quinua, oca, ulluco, ruda y borraja en sistemas de chagra tradicional misak-pasto-nasa. Especie pilar de soberanía alimentaria andina urgentísima de rescatar antes de extinción agrícola definitiva — un proyecto candidato perfecto para el Banco de Germoplasma AGROSAVIA y los programas de etnobotánica Universidad del Cauca. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, NRC 1989 Lost Crops of the Incas, AGROSAVIA Manual Tubérculos Andinos 2017, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "monarda_didyma",
+      "nombre_comun": "Bergamota silvestre / Té de Oswego",
+      "nombre_cientifico": "Monarda didyma L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "division",
+        "notas": "División de matas en primavera (más rápido y fiable, preserva características parentales). Alternativa por esqueje de tallo en primavera o semilla con germinación irregular 15-25 días. Plantación a 40-60 cm entre plantas. Floración verano-otoño en clima andino frío."
+      },
+      "companions": [
+        "lavandula_dentata",
+        "rosmarinus_officinalis",
+        "salvia_officinalis"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La Bergamota silvestre o Té de Oswego (Monarda didyma L., Lamiaceae) es una especie herbácea perenne aromática originaria de Norteamérica oriental templada (bosques húmedos de los Apalaches, Pensilvania, Nueva York, Virginia, Carolina del Norte, Tennessee, Kentucky, Ontario), cultivada mundialmente como ornamental, medicinal y atrayente excepcional de polinizadores, con relevancia histórica como té sustituto consumido por los colonos rebeldes de las Trece Colonias norteamericanas tras el Boston Tea Party de 1773 (boicot al té británico — los colonos adoptaron el té de hojas de Monarda usado por los pueblos originarios Oswego de la región de Nueva York, de ahí \"Oswego tea\"). En Colombia se cultiva en clima templado y frío andino entre 1.800 y 3.000 msnm: Sabana de Bogotá, Boyacá altoandino, Antioquia oriente frío, Eje Cafetero altoandino, Nariño altoandino, viveros aromáticos urbanos especializados. Manejo agronómico: propagación principal por división de matas en primavera (método más rápido y fiable, preserva características parentales — Monarda forma touffes densas con rizomas superficiales que se separan fácilmente), alternativa por esqueje de tallo en primavera-verano con enraizamiento en 3-4 semanas, alternativa por semilla con germinación irregular 15-25 días a 18-22°C y variabilidad genética alta, plantación al sitio definitivo a 40-60 cm entre plantas, suelo rico bien drenado con humedad consistente (prefiere humedad media constante — no sequía ni encharcamiento), sol pleno o sombra parcial leve, riego moderado regular durante floración, poda de tallos secos al final de cada ciclo. Floración verano-otoño en clima andino frío (mayo-octubre), con espigas terminales en capitulillos esféricos densos de flores tubulares bilabiadas escarlata intenso (típicas de Lamiaceae, característica diagnóstica) muy vistosas. Atracción de polinizadores excepcional: COMÚNMENTE LLAMADA \"BEE BALM\" — BÁLSAMO DE ABEJAS — por su atracción masiva de abejas, abejorros (Bombus spp.), colibríes (en Norteamérica colibríes nativos, en Colombia atraería Coeligena spp., Boissonneaua spp.) y mariposas. La flor tubular larga escarlata es polinizada principalmente por colibríes (sintropía evolutiva clásica de ornitofilia: rojo vivo + flor tubular + néctar abundante + sin perfume), pero también recibe visitas masivas de abejas y abejorros que acceden al néctar perforando la base del tubo floral. Uso como té y comestible: las hojas aromáticas frescas o secas se usan para té herbal cítrico-floral aromático (sabor recordando vagamente a la bergamota cítrica del té Earl Grey — de ahí el nombre vulgar \"bergamota silvestre\", aunque NO es la bergamota cítrica Citrus bergamia: ambas comparten compuestos similares de timol, carvacrol y bergamotene), flores comestibles crudas en ensaladas decorativas (color escarlata vistoso + sabor herbáceo suave), repostería floral, decoración de postres. Uso medicinal tradicional documentado: la medicina tradicional indígena norteamericana (Oswego, Iroqueses, Cherokee, Algonquinos) usaba infusión de hojas para resfriados, dolor de garganta, problemas digestivos, expectorante, antiséptico aéreo; herbarios europeos del siglo XVIII-XIX la incorporaron tras la introducción. Composición fitoquímica rica en timol y carvacrol (mismos compuestos del orégano y tomillo, por convergencia química en Lamiaceae): aceite esencial con propiedades antimicrobianas, antisépticas y carminativas documentadas. Manejo en chagra: gremio aromático mediterráneo-anglosajón con lavanda dentada (Lavandula dentata), salvia (Salvia officinalis) y romero (Rosmarinus officinalis) como seto perenne atrayente de polinizadores, banda apícola perimetral de huerta en clima frío andino, jardín pedagógico de hierbas aromáticas. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pamplona Roger 2006 Plantas Medicinales, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "morella_pubescens",
+      "nombre_comun": "Laurel de cera",
+      "nombre_cientifico": "Morella pubescens (Humb. & Bonpl. ex Willd.) Wilbur",
+      "familia_botanica": "Myricaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3300
+      },
+      "temperatura_c": {
+        "helada_letal": -7,
+        "optimo_min": 8,
+        "optimo_max": 15,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "alnus_acuminata",
+        "sambucus_peruviana",
+        "vallea_stipularis"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "jbb-plantas-medicinales",
+        "perez-arbelaez-1947-plantas-utiles",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Morella pubescens (Humb. & Bonpl. ex Willd.) Wilbur (laurel de cera, mirto, olivo de cera — familia Myricaceae) es un árbol perennifolio dioico (4-12 m altura) nativo de los Andes (Colombia, Ecuador, Perú, Bolivia, Venezuela) y de las montañas altas de Costa Rica y Panamá, distribuido en bosque alto andino y subandino entre 1800 y 3300 msnm en piso térmico FRÍO. En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca, Tolima y Santander. Tiene DOS rasgos extraordinariamente interesantes para la pedagogía agroecológica: (1) es FIJADOR BIOLÓGICO DE NITRÓGENO mediante simbiosis con actinobacterias del género Frankia en nódulos radiculares — un rasgo poco común FUERA de la familia Fabaceae, compartido en Colombia solo con el aliso (Alnus acuminata, también Frankia-fijador) — esto la hace especie clave para restaurar suelos andinos degradados sin necesidad de leguminosas; (2) sus DRUPAS GLOBOSAS PEQUEÑAS están cubiertas de una capa de CERA NATURAL BLANCO-AZULADA EXTRAÍBLE por inmersión en agua hirviendo, que ha sido históricamente fuente de cera artesanal para velas, barnices y selladores en el altiplano cundiboyacense, en Boyacá colonial-republicano y en el altiplano nariñense — la 'cera de mirto' o 'cera de laurel' figura en relatos coloniales de José Celestino Mutis y Pérez-Arbeláez como producto rural de exportación menor desde los Andes colombianos hacia el Caribe en el siglo XIX. Lección viva sobre FIJACIÓN DE N NO-LEGUMINOSA, PRODUCTOS NATURALES ANDINOS y RESTAURACIÓN PIONERA: el laurel de cera es ejemplo paradigmático de cómo una especie pionera con doble servicio (fijación de N + producto natural útil) acelera la restauración de suelos degradados en la Cordillera Oriental (Cruz Verde-Sumapaz, Chingaza, Iguaque, Guerrero) y en la Cordillera Central de Antioquia y Caldas. Se planta en FASE PIONERA junto con aliso (Alnus acuminata), sauco peruano (Sambucus peruviana) y raque (Vallea stipularis) — los dos fijadores de N (laurel y aliso) cargan el suelo de nitrógeno disponible, las pioneras de copa amplia (sauco, raque) aportan sombra parcial, y se prepara el terreno para las sucesionales intermedias y tardías. Etnobotánica viva: extracción de cera de drupas en Boyacá rural (Tunja, Villa de Leyva, Sutamarchán) para velas artesanales y selladores de madera; hojas en infusión astringente. Manejo agroecológico: propagación por semilla fresca con lavado previo para remover cera; trasplante 4-6 meses; plantación 12-15 meses; crecimiento moderado 50-80 cm/año; asocio con aliso y sauco; densidades 400-600 ind/ha en restauración pionera de suelos degradados. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, JBB Plantas Medicinales, Pérez-Arbeláez 1947 Plantas Útiles Colombia, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "myrcia_popayanensis",
+      "nombre_comun": "Arrayán de Popayán",
+      "nombre_cientifico": "Myrcia popayanensis Hieron.",
+      "familia_botanica": "Myrtaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1500,
+        "optimo_max": 1900,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 1,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 27
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "coffea_arabica",
+        "inga_densiflora",
+        "myrcianthes_leucoxyla"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "valor_pedagogico": "El arrayán de Popayán (Myrcia popayanensis, Myrtaceae) es un árbol mediano característico de los bosques andinos premontanos del suroccidente colombiano, distribuido principalmente en los departamentos de Cauca (de donde toma su nombre, Popayán), Nariño, Valle del Cauca, Huila y Tolima entre 1.200 y 2.000 msnm. Árbol perennifolio de 8-15 metros de altura con copa densa globosa, fuste corto ramificado bajo y corteza rojiza característica que se descortezándose en placas finas (rasgo común en muchas mirtáceas neotropicales como las Myrcianthes), hojas opuestas elípticas-lanceoladas coriáceas verde oscuro brillantes glabras con glándulas oleíferas puntiformes visibles a contraluz (al estrujarlas desprenden aroma intenso aromático-mentolado característico de las Myrtaceae), flores blancas pequeñas en panículas axilares aromáticas atractoras masivas de abejas Apis mellifera y abejas nativas Meliponini durante la floración (julio-octubre en zona andina cafetera caucana-nariñense), drupas pequeñas globosas verde-negruzcas a violáceas al madurar muy buscadas por aves frugívoras del bosque andino (mirlas Turdus, tángaras Tangara, Atlapetes torquatus). Su madera —rojiza, aromática, de densidad alta— ha sido tradicionalmente apreciada en mueblería rural caucana y nariñense, artesanía, mangos de herramienta, postes de cerca y construcción patrimonial campesina del altiplano caucano-nariñense. Las hojas se usan localmente como aromática en cocción tradicional (sustituto del laurel mediterráneo) y en infusiones medicinales para problemas digestivos y respiratorios, aprovechando los aceites esenciales ricos en eugenol y otros fenoles propios de las Myrtaceae. Como árbol de cerca viva tradicional caucana-nariñense, junto a otros arrayanes nativos (Myrcianthes leucoxyla del altiplano cundiboyacense, Myrcianthes hallii ecuatoriano), configura los paisajes patrimoniales de cordillera andina suroccidental. Su mayor virtud agroecológica es la combinación de atractor de polinizadores nativos, sombrío parcial diversificado del café, biomasa hojarasca aromática y madera de calidad para usos rurales, lo que lo convierte en candidato ideal para sistemas agroforestales cafeteros del Cauca y Nariño. La región del valle del Patía y la cordillera central nariñense conserva poblaciones silvestres importantes que son fuente genética crítica para la propagación regional. Es lección de soberanía botánica regional: revalorizar las mirtáceas nativas del bosque andino premontano suroccidental colombiano en cafetales, huertos patrimoniales y restauración fortalece la apicultura agroecológica, la conservación de polinizadores y el patrimonio botánico cauca-nariñense. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Lucas & Bünger 2015 revisiones Myrcia Neotropicales, Cenicafé manuales sombrío cafetero.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "myrcianthes_ferreyrae",
+      "nombre_comun": "Arrayán negro",
+      "nombre_cientifico": "Myrcianthes ferreyrae (McVaugh) McVaugh",
+      "familia_botanica": "Myrtaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
+        "optimo_max": 2900,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 8,
+        "optimo_max": 15,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "myrcianthes_rhopaloides",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "Myrcianthes ferreyrae (McVaugh) McVaugh (arrayán negro, arrayán de Ferreyra — familia Myrtaceae) es un árbol perennifolio (6-15 m altura) nativo de los Andes de Colombia, Ecuador y Perú, distribuido en bosque alto andino entre 2000 y 3200 msnm en piso térmico FRÍO. En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca y Santander. Es la TERCERA especie del género Myrcianthes en Chagra (junto con M. rhopaloides arrayán de hoja menuda, y la conocida M. leucoxyla arrayán común de Bogotá) — y se distingue por sus BAYAS NEGRAS EN MADUREZ (no rojas-violáceas como M. rhopaloides ni anaranjadas-rojizas como M. leucoxyla) por mayor contenido de ANTOCIANINAS OSCURAS (cianidina-3-glucósido, peonidina-3-glucósido y derivados). Las bayas negras son COMESTIBLES con sabor dulce-resinoso intenso (más concentrado que el arrayán común), usadas en mermeladas, compotas y vinos artesanales en comunidades campesinas del altiplano cundiboyacense y nariñense. El epíteto 'ferreyrae' honra al botánico peruano Ramón Ferreyra Huerta (1910-2005), pionero de la botánica andina peruana y descriptor de cientos de especies de la flora del Perú y Ecuador. Lección viva sobre BOTÁNICA DE MYRCIANTHES, ANTOCIANINAS EN BAYAS DE MYRTACEAE y HISTORIA DE LA BOTÁNICA NEOTROPICAL: el género Myrcianthes en Colombia tiene al menos 3-4 especies arbóreas alto-andinas (M. leucoxyla, M. rhopaloides, M. ferreyrae, M. orthostemon) que se diferencian por color de baya, tamaño de hoja y porte del árbol — todas comparten la 'firma' Myrtaceae: corteza exfoliante canela, hojas opuestas aromáticas, flores con muchos estambres, bayas comestibles. Las antocianinas oscuras de M. ferreyrae son INTERESANTES PARA NUTRACÉUTICA — antioxidantes potentes con perfil similar al de los arándanos (Vaccinium spp.) y a las moras (Morus nigra). En restauración de Cruz Verde-Sumapaz, Chingaza, Iguaque y la Cordillera Central, el arrayán negro se planta en sotobosque y borde de rodal restaurado junto con otros arrayanes y gaque y encenillo, formando corredores frutales para avifauna alto-andina (mirlas patiblancas, atrapamoscas, semilleros) en la ESTACIÓN SECA diciembre-marzo cuando otros frutos escasean — servicio ecosistémico crítico. Manejo agroecológico: propagación por semilla fresca con sombra parcial 50%; trasplante 4-6 meses; plantación 12-18 meses; crecimiento 30-50 cm/año; asocio con M. rhopaloides, gaque y encenillo; densidades 150-300 ind/ha. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "myrcianthes_rhopaloides",
+      "nombre_comun": "Arrayán de hoja menuda",
+      "nombre_cientifico": "Myrcianthes rhopaloides (Kunth) McVaugh",
+      "familia_botanica": "Myrtaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
+        "optimo_max": 3000,
+        "max_absoluto": 3300
+      },
+      "temperatura_c": {
+        "helada_letal": -7,
+        "optimo_min": 7,
+        "optimo_max": 15,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "hesperomeles_goudotiana",
+        "myrcianthes_ferreyrae",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "jbb-plantas-medicinales",
+        "libro-rojo-plantas-colombia"
+      ],
+      "valor_pedagogico": "Myrcianthes rhopaloides (Kunth) McVaugh (arrayán de hoja menuda, arrayán andino, arrayán de páramo bajo — familia Myrtaceae) es un árbol perennifolio (6-15 m altura) nativo de los Andes de Colombia, Ecuador, Perú, Bolivia y Venezuela, distribuido en el bosque alto andino entre 2000 y 3300 msnm en piso térmico FRÍO. En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca, Santander y Tolima. Es reconocible por su CORTEZA EXFOLIANTE ANARANJADO-CANELA en placas (rasgo distintivo de las Myrtaceae andinas, compartido con sus hermanas Eugenia spp. y otros Myrcianthes), por sus HOJAS PEQUEÑAS OPUESTAS ELÍPTICAS AROMÁTICAS (al estrujarlas liberan aceites esenciales similares al eugenol y al pineno — son fragantes a 'monte fresco andino') y por sus flores blancas pequeñas en racimos axilares con muchos estambres (carácter típico de Myrtaceae). Sus bayas globosas pequeñas rojo-violáceas en madurez son comestibles (sabor dulce-resinoso) y muy buscadas por avifauna alto-andina (mirlas, semilleros, copetones, atrapamoscas). Lección viva sobre BOTÁNICA SISTEMÁTICA DE MYRTACEAE ANDINAS, PARES BOTÁNICOS HERMANOS y RESTAURACIÓN AVANZADA: el género Myrcianthes en Colombia incluye varias especies arbóreas alto-andinas distinguibles por tamaño y forma de hoja — M. rhopaloides (hoja menuda 2-4 cm), M. ferreyrae (hoja media, arrayán negro), M. leucoxyla (hoja grande, arrayán de monte) — y todas comparten la 'firma' de la familia: corteza exfoliante canela, hojas opuestas aromáticas, flores con muchos estambres, bayas comestibles. Es especie indicadora de bosque alto andino maduro — su presencia testifica un rodal con red micorrízica activa, hojarasca acumulada y avifauna dispersora funcional. En proyectos de restauración del flanco oriental de la Cordillera Oriental (Cruz Verde-Sumapaz, Chingaza) y del altiplano nariñense se planta en FASE AVANZADA de la sucesión, después de pioneras (Alnus, Sambucus, Vallea) y sucesionales intermedias (Weinmannia, Clusia multiflora, Escallonia). Etnobotánica: las hojas se usan en infusión digestiva-carminativa en pueblos campesinos del altiplano cundiboyacense, y las bayas en compotas caseras. Manejo agroecológico: propagación por semilla fresca con sombra parcial 50%; trasplante 4-6 meses; plantación 12-18 meses; crecimiento lento 25-50 cm/año; asocio con encenillo, gaque y mortiño; densidades 150-300 ind/ha en restauración avanzada. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, JBB Plantas Medicinales, Libro Rojo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "myroxylon_balsamum",
+      "nombre_comun": "Bálsamo de Tolú",
+      "nombre_cientifico": "Myroxylon balsamum (L.) Harms",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nitrogen_fixer",
+        "windbreak",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1500,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "bombacopsis_quinata",
+        "cariniana_pyriformis",
+        "cedrela_odorata",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "inga_edulis"
+      ],
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "El bálsamo de Tolú (Myroxylon balsamum (L.) Harms, Fabaceae subfamilia Faboideae) es una de las especies más patrimoniales y multi-propósito de la herencia botánica colombiano-caribeña: un árbol nativo que produce simultáneamente madera fina, resina aromática medicinal famosa mundialmente desde la época colonial y fija nitrógeno biológico al sistema. Su nombre 'tolú' proviene del municipio Tolú (Sucre) y Tolú Viejo en la región Caribe colombiana donde la especie es ancestral y de donde se exportó al mundo el famoso 'bálsamo de Tolú' durante los siglos XVI-XIX. Nativo del Neotrópico, en Colombia se distribuye en bosques húmedos tropicales y premontanos de las regiones Caribe (Sucre, Córdoba, Bolívar, Magdalena, Cesar, Antioquia bajo), Andina (valles interandinos del Magdalena y Cauca, piedemontes Antioquia, Santander, Norte de Santander, Tolima, Huila, Caldas, Quindío, Risaralda, Valle), Pacífico (Chocó, Valle) y Orinoquía (piedemonte llanero) entre 0 y 1.500 msnm en zona térmica cálida a templada. Árbol siempreverde de 20-35 m de altura con fuste recto cilíndrico, corteza grisácea con resina aromática característica, hojas pinnadas con folíolos elípticos puntiagudos brillantes con puntos translúcidos (glándulas de aceite esencial visibles al trasluz, característica diagnóstica), flores blanco-amarillentas pequeñas en racimos terminales melíferos, frutos en vaina indehiscente alada con una semilla aplanada. Su característica más famosa es la producción de la resina conocida como 'bálsamo de Tolú' o 'bálsamo del Perú' (este último nombre proviene del puerto colonial de embarque, no del país): se extrae por sangrado controlado del tronco mediante incisiones en V y aplicación de fuego suave (técnica ancestral indígena y afrocolombiana del Caribe), la resina aromática rojizo-marrón con olor dulce a vainilla-canela tiene uso medicinal tradicional (expectorante para bronquitis y tos, cicatrizante en heridas, antiséptico, antiparasitario), perfumería de alta gama (fijador y nota base en perfumes clásicos como Chanel Nº5 y otros), cosmética (cremas, jabones), aromatización de licores y tabaco premium, e industria farmacéutica moderna. Fue uno de los productos de exportación icónicos de la Nueva Granada durante los siglos XVI-XIX hacia Europa. Su madera marrón-rojiza dura y resistente a la pudrición es también apreciada en ebanistería fina, durmientes, construcción rural pesada. Como leguminosa Faboideae fija parcialmente nitrógeno biológico al sistema mediante asociación con rizobios, aporte valioso en sistemas cafetales y cacaoteros. En sistemas agroforestales acepta densidades 80-150 árb/ha como sombrío de doble propósito: madera fina + resina cosechable a los 12-15 años + N biológico al cafetal o cacaotal. Manejo agroecológico: propagación por semilla fresca (germinación 15-30 días sin tratamiento), vivero a sol parcial 6-8 meses, plantación definitiva a 40-50 cm, primer sangrado de resina a los 12-15 años con incisiones controladas para no debilitar el árbol, cosecha de madera al final del turno (40-50 años) como legado. Es lección extraordinaria de soberanía y multi-propósito agroforestal: un solo árbol nativo provee madera fina + medicina tradicional + perfumería de exportación + fijación de N + sombrío cafetalero, ejemplo perfecto de cómo el bosque manejado supera al monocultivo, y de cómo Colombia tiene en su flora nativa productos que el mercado mundial valora pero que pocos colombianos conocen. Fuentes Tier A: Pérez Arbeláez 1947 Plantas Útiles Colombia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Bálsamo"
+      ]
+    },
+    {
+      "id": "myrsine_coriacea",
+      "nombre_comun": "Cucharo",
+      "nombre_cientifico": "Myrsine coriacea (Sw.) R.Br. ex Roem. & Schult.",
+      "familia_botanica": "Primulaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1700,
+        "optimo_max": 2000,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "alnus_acuminata",
+        "cedrela_montana",
+        "escallonia_pendula",
+        "myrcianthes_leucoxyla"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "car-cundi-2019",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "valor_pedagogico": "El cucharo o espadero (Myrsine coriacea, Primulaceae) es uno de los árboles medianos más versátiles y ampliamente distribuidos en los bosques andinos templados-fríos colombianos entre 1.500 y 2.800 msnm, presente en toda la región Andina especialmente en Cundinamarca, Boyacá, Santanderes, Antioquia, Caldas, Quindío, Risaralda, Tolima, Huila, Cauca, Nariño y Valle del Cauca. Árbol perennifolio de 6-12 metros de altura con copa cónica-piramidal densa, fuste recto y corteza grisácea finamente fisurada; hojas alternas oblongo-lanceoladas coriáceas verde oscuro brillantes con ápice obtuso característico, agrupadas en los extremos de las ramas (aspecto que recuerda a las primaveras herbáceas Primulaceae —familia botánica a la que pertenece tras la revisión filogenética de APG IV que reubicó a las Myrsinaceae como subfamilia Myrsinoideae dentro de Primulaceae), flores pequeñas verdoso-blanquecinas en racimos cortos axilares atractoras de polinizadores nativos, drupas pequeñas globosas verdes que viran a violáceo-negruzcas al madurar muy buscadas por aves frugívoras del bosque andino (mirlas Turdus fuscater, tángaras Anisognathus, atrapamoscas Tyranniidae, eufonias Euphonia) que actúan como dispersores principales. Su mayor virtud agroecológica es la versatilidad: es pionera-secundaria con rápido establecimiento que coloniza áreas degradadas, taludes y bordes, tolera suelos pobres y ácidos, soporta heladas suaves hasta -2°C, rebrota vigorosamente desde el tocón al podarla, lo que la convierte en una de las especies más utilizadas en cercas vivas tradicionales del altiplano cundiboyacense (la 'cerca de cucharo' es paisaje cultural patrimonial campesino), en restauración ecológica andina entre 1.500 y 2.800 msnm, en sombrío diversificado de café-altura en zona cafetera alta de Caldas y Antioquia, y como productora rural de leña y carbón vegetal artesanal (la madera blanco-pálida es de combustión limpia y duradera). Sus frutos son recurso clave para la avifauna andina: producción casi continua durante el año, con picos estacionales que sostienen poblaciones de aves frugívoras incluso en épocas de escasez, lo que la convierte en especie focal para conservación de avifauna en paisajes rurales cafeteros y altoandinos. La conexión filogenética con la familia Primulaceae es lección de filogenia botánica moderna: hasta los años 2000 las myrsines eran familia propia (Myrsinaceae) tradicionalmente; los estudios de filogenia molecular (APG II, III, IV) demostraron su anidamiento dentro de Primulaceae, lo que cambió la clasificación taxonómica y pedagógica. Es lección de soberanía botánica andina: el cucharo es uno de los árboles más útiles, versátiles y rústicos del bosque andino colombiano, ejemplo de especie 'común y subvalorada' que merece revalorización en cercas vivas, restauración, sombrío y producción rural de leña-carbón, fortaleciendo paisajes culturales campesinos altoandinos y conservación de avifauna nativa. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew Primulaceae (subfamilia Myrsinoideae), GBIF Backbone Taxonomy, CAR Cundinamarca cercas vivas tradicionales, Cenicafé manuales sombrío altoandino.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "nectandra_acutifolia",
+      "nombre_comun": "Jigua",
+      "nombre_cientifico": "Nectandra acutifolia (Ruiz & Pav.) Mez",
+      "familia_botanica": "Lauraceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "windbreak",
+        "nurse_plant",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1200,
+        "optimo_max": 1800,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 15,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cedrela_odorata",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "inga_edulis",
+        "ocotea_calophylla"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "valor_pedagogico": "El jigua o amarillo de Río (Nectandra acutifolia, Lauraceae) es uno de los árboles representativos del bosque andino premontano colombiano entre 1.000 y 2.000 msnm en la zona cafetera de la región Andina. Distribuido en las cordilleras Central, Occidental y Oriental colombianas, principalmente en Quindío, Risaralda, Caldas, Antioquia, Valle del Cauca, Tolima, Huila, Cundinamarca y Santander. Árbol perennifolio de 15-25 metros de altura con copa redondeada densa, fuste cilíndrico recto con corteza pardo-grisácea fisurada longitudinalmente, hojas alternas elípticas-lanceoladas coriáceas verde oscuro brillante en haz y verde pálido pubescente en envés con olor característico a laurel al frotarlas, flores pequeñas amarillento-blancas en panículas axilares melíferas atractoras de abejas nativas Meliponini, frutos drupas globosas verde-violáceas que viran a negro al madurar muy buscadas por aves frugívoras del bosque andino (tucanes Andigena nigrirostris, mirlas Turdus fuscater, tángaras Tangara spp). Su madera amarillenta aromática se ha usado tradicionalmente en construcción rural cafetera, ebanistería rústica, mangos de herramienta y elaboración de cucharas. Es especie esciófita en juventud (requiere sombrío para germinar y establecerse) por lo que prospera bajo dosel de pioneras como Cecropia o Croton; crece lentamente los primeros 3 años para luego acelerar hasta alcanzar el dosel intermedio del bosque andino. Su asocio agroecológico clásico es con café bajo sombrío diversificado, donde aporta biomasa hojarasca, regula microclima, atrae polinizadores y hospeda fauna silvestre que controla plagas del cafetal. Las semillas son recalcitrantes y deben sembrarse inmediatamente tras la cosecha (intolerantes a desecación), lo que ha limitado su propagación masiva y su disponibilidad en viveros forestales. Es lección de soberanía botánica: revalorizar las lauráceas nativas de los bosques andinos cafeteros como dosel diversificado del café, en lugar del monocultivo de Inga densiflora, ofrece servicios ecosistémicos similares con mayor diversidad genética y resiliencia ante cambio climático. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, van der Werff revisiones Lauraceae Neotropicales, Cenicafé manuales cafeteros sombrío diversificado.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "ochroma_pyramidale",
+      "nombre_comun": "Balso",
+      "nombre_cientifico": "Ochroma pyramidale (Cav. ex Lam.) Urb.",
+      "familia_botanica": "Malvaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nurse_plant",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 1000,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cedrela_odorata",
+        "cordia_alliodora",
+        "inga_edulis",
+        "swietenia_macrophylla"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "sinchi-amazonia-colombiana",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El balso o palo balso (Ochroma pyramidale (Cav. ex Lam.) Urb., sinónimo Ochroma lagopus, Malvaceae subfamilia Bombacoideae) es la pionera por excelencia del bosque húmedo tropical neotropical y una de las especies de crecimiento más rápido del mundo. Nativo del Neotrópico, en Colombia se distribuye en bosques húmedos tropicales bajos del Pacífico (Chocó, Valle, Cauca, Nariño), Caribe húmedo (Antioquia bajo, Córdoba, Urabá, sierra Nevada), Magdalena medio, Catatumbo, Amazonía (piedemonte caqueteño, putumayense, amazonense) y Orinoquía (piedemonte Casanare, Meta) entre 0 y 1.000 msnm en zona térmica cálida muy húmeda. Árbol siempreverde de 15-25 m de altura con fuste recto y copa abierta, hojas alternas grandes palmaticompuestas o palmadas pubescentes, flores grandes blanco-amarillentas crepusculares-nocturnas polinizadas por murciélagos y polillas grandes, cápsulas leñosas largas (15-25 cm) dehiscentes que liberan semillas envueltas en abundante lana o pelos algodonosos (de ahí 'lano' o 'lana' en algunas regiones) útil tradicionalmente para rellenos artesanales de almohadas, juguetes y aislamientos. Su característica más extraordinaria es el crecimiento exponencial en juventud: 3-5 metros por año los primeros 5 años, alcanzando 10-15 m a los 4 años (el árbol comercial de crecimiento más rápido del trópico), con corta vida útil (15-25 años) propia de pioneras. La madera comercial del balso es la más liviana del mundo con densidad de 0.1-0.2 g/cm³ (comparable al corcho), usada mundialmente para aeromodelismo profesional (alas y fuselajes), tablas de surf (núcleos), modelado arquitectónico, juguetería educativa, aislamiento térmico de buques, equipos de salvamento (chalecos), embalajes ligeros frágiles y trabajos de bricolaje. Su rol ecológico como pionera de sucesión secundaria es crítico: coloniza rápidamente claros del bosque, potreros abandonados o quemas; aporta hojarasca abundante mejorando suelos degradados; provee sombrío rápido temporal que protege la germinación de especies climácicas de sucesión tardía como cedro, caoba o abarco; y muere naturalmente a los 15-25 años liberando dosel para que las climácicas tomen el espacio. En sistemas agroforestales tropicales este rol se aprovecha conscientemente: se planta balso en cacaotales jóvenes a 150-300 árb/ha como sombrío rápido temporal mientras crecen los maderables nobles asociados, y a los 6-8 años se cosecha el balso para madera y se libera el dosel para la siguiente fase. Manejo agroecológico: escarificación leve de semilla con agua caliente 60°C por 1 minuto o lijado opcional, germinación 7-15 días, vivero a sol pleno 3-4 meses con crecimiento muy rápido (15-25 cm/mes), plantación definitiva a 40-60 cm de altura. Es lección clave de sucesión ecológica tropical: la naturaleza no construye un bosque maduro de golpe, lo construye en capas temporales donde el balso prepara la cama para el cedro, y entender esto es entender cómo restaurar selva en lugar de monocultivar. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Sinchi Amazonía, CIAT manuales agroforestales tropicales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "ocotea_calophylla",
+      "nombre_comun": "Laurel comino",
+      "nombre_cientifico": "Ocotea calophylla Mez",
+      "familia_botanica": "Lauraceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nurse_plant",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1400,
+        "optimo_max": 1900,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 1,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 27
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "aniba_perutilis",
+        "cedrela_odorata",
+        "coffea_arabica",
+        "inga_edulis",
+        "magnolia_caricifragrans",
+        "nectandra_acutifolia"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "valor_pedagogico": "El laurel comino (Ocotea calophylla, Lauraceae) es una de las lauráceas estructurales del bosque andino premontano cafetero colombiano, distribuida entre 1.200 y 2.000 msnm en la región Andina (cordilleras Central y Occidental especialmente en Quindío, Risaralda, Caldas, Antioquia, Valle del Cauca, Cauca, Tolima, Huila y Cundinamarca). Árbol perennifolio de 18-28 metros de altura con copa amplia globosa, fuste cilíndrico recto y corteza gris fisurada que al cortarse exuda un aroma intenso a laurel (de ahí el nombre vernáculo); hojas alternas elípticas grandes coriáceas verde oscuro brillantes, flores pequeñas blanco-verdosas en panículas axilares atractoras de abejas nativas Meliponini, drupas elipsoidales verdes que viran a negro-violáceo al madurar consumidas y dispersadas por tucanes (Andigena, Aulacorhynchus), mirlas (Turdus) y tángaras frugívoras. Su madera amarilla aromática es uno de los 'cominos' del bosque andino colombiano: aromática, durable, fácil de trabajar, históricamente sobreexplotada durante el siglo XX para carpintería fina, ebanistería, instrumentos musicales y construcción de puertas y ventanas en arquitectura cafetera tradicional, lo que redujo significativamente las poblaciones silvestres. Es especie de bosque maduro con crecimiento lento, esciófita en juventud (necesita sombrío para germinación y establecimiento), por lo que su recuperación natural requiere bosques continuos con dosel intermedio. Su asocio agroecológico clásico es con café bajo sombrío diversificado típico de fincas cafeteras patrimoniales del Eje Cafetero y Antioquia, donde combinado con Inga densiflora (nodriza N-fijadora), Cordia alliodora (maderable acompañante) y Cedrela odorata (maderable patrimonial) configura un dosel multiestrato con altos servicios ecosistémicos. Sus semillas recalcitrantes (intolerantes a desecación y almacenamiento) deben sembrarse inmediatamente tras cosecha lo que limita su propagación masiva en viveros forestales convencionales. Es lección de soberanía botánica y maderera: recuperar el laurel comino en los cafetales con sombrío y restauración del bosque andino premontano reduce dependencia de maderas finas importadas (teca, caoba africana) y revaloriza el patrimonio forestal de la zona cafetera colombiana. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Cenicafé manuales sombrío diversificado cafetero.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "oenocarpus_mapora",
+      "nombre_comun": "Don pedrito",
+      "nombre_cientifico": "Oenocarpus mapora H.Karst.",
+      "familia_botanica": "Arecaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 800,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 10,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "theobroma_bicolor"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sinchi-amazonia-colombiana"
+      ],
+      "valor_pedagogico": "El don pedrito o maquenque (Oenocarpus mapora H.Karst., familia Arecaceae) es una palma cespitosa (multicaule) neotropical distribuida en bosque húmedo tropical desde Costa Rica, Panamá, Colombia (toda la Amazonia y Chocó biogeográfico — Chocó, Valle del Cauca pacífico, Cauca pacífico, Nariño pacífico, Amazonas, Vaupés, Guaviare, Putumayo, Caquetá), Venezuela, Ecuador, Perú y Brasil amazónico, entre 0 y 1.200 msnm en bosque muy húmedo tropical y bosque húmedo premontano con precipitaciones >3000 mm anuales. Es PEDAGÓGICAMENTE EXCELENTE como lección viva de manejo ancestral del bosque biogeográfico chocoano y amazónico por parte de COMUNIDADES AFROCOLOMBIANAS del Pacífico (Cocomacia, Acadesan, consejos comunitarios del Bajo Atrato, San Juan, Baudó, Buenaventura, Guapi, Timbiquí, López de Micay, Tumaco) y los pueblos indígenas EMBERA (Dóbida, Chamí, Katío) y WOUNAAN del Pacífico chocoano-vallecaucano, TIKUNA-HUITOTO-BORA del trapecio amazónico, y SIKUANI-CURRIPACO de la Orinoquia-Guainía. Pertenece al género Oenocarpus (junto a O. bataua/milpesos — ya en catálogo, O. bacaba, O. minor) en tribu Euterpeae junto a Euterpe oleracea (açaí — ya en catálogo). Distinta a O. bataua por su hábito cespitoso multicaule (tallos múltiples desde la base, 5-15 tallos por mata de 6-15 m altura cada uno con diámetro 8-12 cm), hojas pinnadas erectas de 4-6 m, infrutescencias péndulas tipo 'cola de caballo' (raquillas múltiples colgantes) con 200-500 frutos drupáceos elipsoidales 1.5-2.5 cm púrpura-vinotinto-negro con mesocarpo aceitoso comestible procesado tradicionalmente en bebida espesa nutritiva ('jugo de mapora', 'bebida de maquenque', similar al chapo amazónico) con alto valor de aceites monoinsaturados (40-50% mesocarpo, perfil similar al aceite de oliva). El palmito apical es alimento; las hojas se trenzan para techos y cestería; las raíces son leñosa-fibrosas de uso artesanal. Fructifica más temprano y abundantemente que O. bataua (5-7 años vs 10-15 años) — por eso es promovida por programas agroforestales de Sinchi e IIAP como alternativa de seguridad alimentaria de comunidades pacíficas. Manejo agroecológico: regeneración por escarabajos dispersores; siembra enriquecimiento bajo dosel a 6-8 m entre matas; tolerante a sombra 50-70%; resiliente a inundación temporal de orillas; asocio con cacao (Theobroma cacao), bacao (T. bicolor) y borojó (Borojoa patinoi) en sistemas agroforestales chocoanos. Función en chagra/agroforestal pacífica y amazónica como cosecha comunitaria sostenible, conservación de bosques húmedos tropicales, banco genético de palmas multicaules, fuente nutricional aceitosa-proteica. Fuentes Tier A: POWO Kew, GBIF, Bernal & Galeano 2010 Palmas de Colombia (referencia obligada), Sinchi (programas amazónicos), IIAP Pacífico (programas chocoanos), Cárdenas-Salinas frutales amazónicos.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "posuy",
+        "manaco",
+        "corunto"
+      ]
+    },
+    {
+      "id": "oreopanax_floribundum",
+      "nombre_comun": "Mano de oso",
+      "nombre_cientifico": "Oreopanax floribundum Decne. & Planch.",
+      "familia_botanica": "Araliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1700,
+        "optimo_max": 2000,
+        "max_absoluto": 2500
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 13,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "alnus_acuminata",
+        "cedrela_montana",
+        "coffea_arabica"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "valor_pedagogico": "El mano de oso o cariseco (Oreopanax floribundum, Araliaceae) es uno de los árboles emblemáticos del bosque andino premontano-montano bajo colombiano entre 1.500 y 2.500 msnm, distribuido en la región Andina especialmente en Cundinamarca, Boyacá, Santanderes, Antioquia, Caldas, Quindío, Risaralda, Tolima, Huila, Cauca, Nariño y Valle del Cauca. Árbol perennifolio de 8-15 metros de altura con copa irregular abierta, fuste corto y corteza grisácea con cicatrices foliares conspicuas; sus hojas son grandes palmatilobadas con 5-9 lóbulos digitados que recuerdan la forma de una mano abierta o una garra de oso (de ahí los nombres vernáculos 'mano de oso' y 'pata de gallina'), verde oscuro lustrosas en haz y pálidas en envés, con pecíolos largos característicos; flores pequeñas blanco-verdosas en panículas terminales densas muy atractoras de abejas Apis y Meliponini, sírfidos, escarabajos polinizadores y otros himenópteros nativos, frutos drupas violáceo-negruzcas dispuestas en racimos consumidas y dispersadas por aves frugívoras del bosque andino (tucanes Andigena, mirlas Turdus, tángaras Tangara) y por mamíferos arborícolas incluido históricamente el oso andino o oso de anteojos (Tremarctos ornatus) —de hecho el nombre vernáculo 'mano de oso' alude tanto a la forma de las hojas como a las huellas similares que deja el oso andino en la corteza al trepar para alimentarse de los frutos. La familia Araliaceae es un linaje botánico con representantes notables como el ginseng (Panax ginseng) asiático y el guayabo de pava (Schefflera) tropical, y en Colombia incluye más de 30 especies del género Oreopanax distribuidas en los Andes y bosques de niebla. Su mayor virtud agroecológica es la combinación de ornamentalidad patrimonial (las hojas palmatilobadas son uno de los rasgos botánicos más reconocibles del bosque andino colombiano, presente en patrimonio cultural campesino y en jardinería urbana de altiplano), atracción masiva de polinizadores nativos en floración, hospedaje de avifauna frugívora y mamíferos asociados al bosque andino (incluido el oso de anteojos, ícono de conservación), y aporte de biomasa hojarasca al suelo. Como sombrío parcial diversificado del café en zona cafetera de altura (1.500-2.000 msnm) en Caldas, Quindío y Antioquia aporta servicios ecosistémicos complementarios a otros árboles del dosel andino. Es lección de biogeografía andina y conservación: el mano de oso es indicador de bosque andino premontano-montano bajo en estado de conservación medio a bueno, su presencia en cafetales y huertos patrimoniales rurales contribuye a la conectividad ecológica para fauna y al sostenimiento de polinizadores nativos. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew Araliaceae, GBIF Backbone Taxonomy, Cuevas-Reyes 2010 Oreopanax Colombia, Cenicafé manuales sombrío diversificado.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "oreopanax_incisus",
+      "nombre_comun": "Mano de oso de páramo bajo",
+      "nombre_cientifico": "Oreopanax incisus (Willd. ex Roem. & Schult.) Decne. & Planch.",
+      "familia_botanica": "Araliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2400,
+        "optimo_max": 3100,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 6,
+        "optimo_max": 14,
+        "max_tolerable": 20
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "hesperomeles_goudotiana",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "Oreopanax incisus (Willd. ex Roem. & Schult.) Decne. & Planch. (mano de oso, pata de gallina arbórea, mano de león — familia Araliaceae) es un árbol perennifolio (8-20 m altura) nativo de los Andes (Colombia, Ecuador, Venezuela, Perú), distribuido en bosque alto andino y subpáramo entre 2000 y 3400 msnm en piso térmico FRÍO con tolerancia a heladas leves. En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca y Santander. El género Oreopanax es endemismo neotropical-andino con varias especies hermanas en Colombia (O. incisus, O. floribundus, O. capitatus, O. cundinamarcensis) — todas reconocibles por sus HOJAS GRANDES PALMATILOBADAS-INCISAS de 15-30 cm de diámetro que recuerdan vagamente la 'mano de un oso' o la 'pata de una gallina gigante' (de ahí los nombres populares). Las hojas dispuestas alternas en ramas gruesas y la INFLORESCENCIA TERMINAL PANICULADA DE UMBELAS (rasgo típico de Araliaceae junto con ginseng, hiedra y aralia) producen abundantes drupas pequeñas negras muy buscadas por avifauna alto-andina, tucanetas esmeralda, mirlas patiblancas y atrapamoscas. Lección viva sobre BOTÁNICA DE ARALIACEAE NEOTROPICALES, FRANJA DE TRANSICIÓN BOSQUE-PÁRAMO y RESTAURACIÓN ECOTONAL: el mano de oso es ESPECIE TÍPICA DE ECOTONO — la franja de transición entre el bosque alto andino y el subpáramo (2800-3400 msnm) en la Cordillera Oriental colombiana es uno de los ecotonos más biodiversos del país, y O. incisus es indicador estructural de ese ecotono. En restauración de Cruz Verde-Sumapaz, Chingaza, Iguaque y Guerrero, el mano de oso se planta en la FRANJA SUPERIOR (2800-3400 msnm) donde otras especies de bosque alto andino ya no prosperan, junto con queñoa (Polylepis quadrijuga), encenillo, gaque y mortiño — formando un mosaico estructural de bosque enano subpáramo que es resistente a heladas, retiene agua de niebla y protege la cabecera de cuenca. Etnobotánica: hojas grandes usadas como envolventes para envueltos de masa en pueblos campesinos del altiplano cundiboyacense (tradición pre-hojas de plátano en el frío); corteza astringente en cocimientos antidiarreicos. Manejo agroecológico: propagación por semilla fresca con sombra parcial; trasplante 6-8 meses; plantación 18-24 meses; crecimiento 30-50 cm/año; asocio con queñoa, encenillo y mortiño en restauración ecotonal; densidades 200-400 ind/ha; protección anti-heladas con mulch grueso el primer año. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "paspalum_notatum",
+      "nombre_comun": "Pasto bahía",
+      "nombre_cientifico": "Paspalum notatum Flüggé",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "ground_cover",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia",
+        "agrosavia-forrajeras-2022"
+      ],
+      "valor_pedagogico": "El pasto bahía o pasto horqueta (Paspalum notatum Flüggé, Poaceae, subfamilia Panicoideae, tribu Paspaleae) es una de las gramíneas forrajeras nativas neotropicales más importantes y, a diferencia de la mayoría de las forrajeras tropicales comerciales que son africanas naturalizadas (brachiaria, Mombasa, estrella, pangola, carimagua), es genuinamente americana: distribución natural desde el sureste de Estados Unidos (Florida, Texas) hasta Argentina y Uruguay, con presencia natural en Colombia documentada por SIB Colombia y herbarios nacionales en regiones de bosque tropical seco, premontano y de galería entre 0 y 1.800 msnm. Es la única gramínea forrajera de uso comercial relevante en Colombia que es nativa, hecho de enorme importancia para sistemas agroecológicos y de restauración productiva que buscan minimizar la introducción de exóticas. En Colombia se distribuye naturalmente y se cultiva en el Caribe (Sucre, Córdoba, Bolívar, Magdalena, Cesar), Magdalena Medio (Antioquia, Santander), valles interandinos (Huila, Tolima, valle del Cauca), piedemonte llanero (Meta, Casanare), Pacífico (Valle, Chocó bajo), y zonas premontanas del eje cafetero (Caldas, Quindío, Risaralda) entre 0 y 1.800 msnm en zona térmica cálida y templada baja. Existen variedades comerciales liberadas en Estados Unidos (cv. Pensacola, cv. Argentine, cv. Tifton-9) sembradas también en Colombia, y ecotipos nativos colombianos de uso local en fincas tradicionales. Es gramínea perenne rizomatosa-cespitosa de 20-50 cm de altura con rizomas cortos superficiales que forman macollas densas, hojas lineares glabras verde-medio, inflorescencia característica en 2-3 (rara vez 4) racimos divergentes al ápice del culmo en forma de horqueta (de ahí su nombre común \"pasto horqueta\" en Colombia), espiguillas pequeñas en pares sobre los racimos. Su característica agronómica distintiva es la rusticidad y persistencia: tolerancia a pisoteo intensivo y defoliación severa por su sistema rizomatoso, tolerancia moderada a sequía estacional, tolerancia a suelos ácidos de baja fertilidad (aunque menos extrema que brachiaria o carimagua), tolerancia a inundación temporal, mantenimiento mínimo, persistencia decadal en pradera. Produce biomasa de 8-12 t MS/ha/año (inferior a brachiaria y Mombasa, en línea con pangola y carimagua), soporta carga animal de 1.5-3 UGG/ha en sistemas rotacionales moderados con descanso de 25-35 días entre pastoreos y altura de entrada de 20-30 cm, valor nutricional medio (PC 8-11%, DIVMS 52-60%). Su productividad inferior a brachiaria-Mombasa se compensa con su carácter nativo (no requiere preocupación por naturalización agresiva ni desplazamiento de flora local), su excelente función como cobertura permanente en sistemas multi-estrato (cafetales, cacaotales, frutales tropicales, plantaciones de aguacate, cítricos), y su uso en restauración productiva como cobertura inicial en degradadas pasturas africanas para \"limpiar\" suelos antes de la introducción de árboles nativos. Es susceptible a salivazo (Aeneolamia spp.) en pradera pura, aunque su porte bajo y rizomas le confieren mejor recuperación post-ataque que gramíneas cespitosas. Manejo agroecológico: propagación por semilla escarificada o con reposo de 6-12 meses (8-15 kg/ha al inicio de lluvias en surcos de 0.3-0.5 m o al voleo en cobertura), fertilización mínima (sin necesidad de fertilización si el suelo tiene fertilidad media), descanso post-establecimiento 100-130 días por establecimiento lento vía rizomas, asociación con leguminosas tropicales rastreras nativas (Arachis pintoi en zonas más frescas, Centrosema spp. y Stylosanthes spp. en cálidos), sistemas silvopastoriles con árboles nativos del bosque tropical seco y bosque premontano (Tabebuia, Caesalpinia, Cordia, Pithecellobium, Erythrina, Albizia), uso como cobertura permanente en cafetales (callejones entre surcos de café), cacaotales y frutales tropicales donde su carácter alfombrante y tolerancia a pisoteo permite manejo de podas y cosechas sin daño. Es lección agroecológica fundamental: gramínea forrajera nativa neotropical demostrando que la flora americana tiene en su propio patrimonio botánico opciones productivas robustas que no requieren introducir exóticas naturalizadas con costo ecológico, y que en sistemas agroecológicos integrados con sombrío arbóreo nativo y leguminosas, una \"forrajera nativa de menor productividad puntual\" puede ser superior en términos de sostenibilidad sistémica a una \"forrajera exótica de alta productividad\" que naturaliza y degrada. Fuentes Tier A: CIAT Tropical Forages Database, POWO Kew, GBIF Backbone Taxonomy, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, SIB Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "phacelia_tanacetifolia",
+      "nombre_comun": "Facelia",
+      "nombre_cientifico": "Phacelia tanacetifolia Benth.",
+      "familia_botanica": "Boraginaceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "ground_cover",
+        "biomass_producer",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 12,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa al voleo o en hileras, 1-2 cm profundidad, densidad 8-12 kg/ha como abono verde, germinación 8-15 días, floración 45-60 días post-siembra, abono verde incorporado en plena floración (max biomasa + N residual). Auto-resiembra natural."
+      },
+      "companions": [
+        "avena_sativa",
+        "vicia_sativa"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "pamplona-roger-2006-plantas-medicinales",
+        "agrosavia-sol-andina"
+      ],
+      "valor_pedagogico": "La Facelia (Phacelia tanacetifolia Benth., Boraginaceae) es una especie herbácea anual originaria del suroeste de Estados Unidos y norte de México (desiertos del Mojave y Sonora, montañas de California, Arizona, Nuevo México, Sonora, Baja California), cultivada mundialmente desde mediados del siglo XX como uno de los abonos verdes y atrayentes de polinizadores más valiosos de la agroecología moderna. En Europa es la planta atrayente número uno para apicultura comercial junto con el girasol y la colza melífera. En Colombia su uso es aún reciente pero creciente en sistemas agroecológicos andinos entre 1.500 y 3.200 msnm: Sabana de Bogotá, Boyacá altoandino, Nariño altoandino, Cundinamarca rural, Eje Cafetero altoandino. Manejo agronómico: siembra directa al voleo o en hileras, 1-2 cm profundidad, densidad 8-12 kg/ha como abono verde o 4-6 kg/ha como cultivo apícola de banda perimetral, germinación 8-15 días a 12-20°C, ciclo total 90-120 días, floración inicia a los 45-60 días post-siembra y se mantiene 4-8 semanas continuas con flores azul-lavanda en inflorescencias escorpioides características (cima helicoidal típica de Boraginaceae). La floración es el momento clave del ciclo: cada espiga floral abre flores progresivamente desde la base al ápice durante 2-3 semanas, asegurando néctar y polen continuos para polinizadores. Atracción de polinizadores excepcional: estudios europeos (Alemania, Reino Unido, Francia) y norteamericanos demuestran que la facelia es UNA DE LAS 20 PLANTAS MÁS ATRACTIVAS PARA ABEJAS DEL MUNDO, sostiene poblaciones masivas de abejas (Apis mellifera, abejas solitarias, abejorros), sírfidos parasitoides de áfidos, mariposas, y atrae mariquitas (Coccinellidae) y crisopas (Chrysopidae) — depredadores claves del control biológico de áfidos. Una hectárea de facelia florecida puede sostener 400-1.000 kg de miel por temporada en condiciones óptimas, y atrae polinizadores hacia cultivos adyacentes de hortalizas, frutales y leguminosas mejorando significativamente la fructificación. Uso como abono verde: incorporación al suelo en plena floración (max biomasa antes de lignificación, alta relación C:N de 15-20:1, descomposición rápida), aporta 3-4 ton/ha de biomasa seca con 80-120 kg/ha de N residual al cultivo siguiente, mejora estructura del suelo por sistema radical fibroso superficial denso, supresión de malezas por sombreado y alelopatía suave (sin daño a cultivos siguientes), compatible con rotaciones brassicas (Brassica napus), avena (Avena sativa) y veza (Vicia sativa). NO COMPETITIVA: por ser de familia Boraginaceae (no es Poaceae, no es Brassicaceae, no es Fabaceae) es ROTACIONALMENTE NEUTRAL — no comparte plagas ni enfermedades con las familias mayoritarias de cultivos, lo que la hace abono verde universal compatible con cualquier rotación. Auto-resiembra natural si se deja semillar, pero NO ES INVASORA documentada en Colombia. Manejo agroecológico ideal: siembra en franjas perimetrales de huerta o entre líneas de frutales como banda apícola permanente, siembra de cobertura otoño-invernal en clima frío andino, siembra de rotación primavera-verano antes de hortalizas exigentes en N, cosecha apícola por abejorros y abejas durante 4-8 semanas continuas. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pamplona Roger 2006 Plantas Medicinales, AGROSAVIA Sol Andina.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "pithecellobium_dulce",
+      "nombre_comun": "Chiminango",
+      "nombre_cientifico": "Pithecellobium dulce (Roxb.) Benth.",
+      "familia_botanica": "Fabaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "biomass_producer",
+        "pollinator_attractor",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 6,
+        "optimo_min": 22,
+        "optimo_max": 32,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "byrsonima_crassifolia",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "gliricidia_sepium",
+        "prosopis_juliflora"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El chiminango, payandé o pinto (Pithecellobium dulce (Roxb.) Benth., Fabaceae subfamilia Mimosoideae) es uno de los frutales silvestres más patrimoniales del bosque seco tropical (bs-T) colombiano, ampliamente distribuido en cercas vivas tradicionales del Caribe y Valle del Cauca, fuente de fruta dulce-ácida apetente para consumo fresco y dulces caseros. Su nombre español \"chiminango\" es de origen quechua-mochica y \"payandé\" parece ser de origen muisca-chibcha (el municipio de Payandé en Tolima toma su nombre del árbol). Nativo del Neotrópico desde México hasta Venezuela y Andes peruanos, en Colombia se distribuye dominante en bs-T de Caribe (La Guajira, Cesar, Magdalena, Atlántico, Bolívar, Córdoba, Sucre), Valle del Cauca, Cauca, Tolima, Huila, Santanderes y piedemonte llanero entre 0-1.200 msnm en zona térmica exclusivamente cálida. Naturalizado tan extensamente en India, Filipinas y México que muchos lo creen asiático (donde es \"guamúchil\"), pero el origen genético-evolutivo es netamente neotropical americano. Árbol mediano caducifolio de 8-15 m de altura con espinas estipulares pequeñas (1-5 mm) en pares en las axilas foliares (no causan riesgo significativo de manejo, a diferencia de Prosopis juliflora), copa redondeada de 6-10 m de diámetro, fuste corto tortuoso con corteza grisácea fisurada, hojas bipinnadas con un solo par de pinnas y 2 folíolos terminales asimétricos, flores blanco-rosadas en cabezuelas globulosas pequeñas melíferas, frutos en vaina linear espiralada característica (rasgo diagnóstico) marrón-rojiza dehiscente a la madurez exponiendo el arilo blanco-rosado a rojizo dulce-ácido sabroso que rodea las semillas negras brillantes (estos arilos son la parte comestible). El fruto se cosecha entre marzo-mayo y septiembre-noviembre dependiendo del régimen pluvial regional, las vainas maduras se cosechan con cuidado de las pequeñas espinas estipulares, se abren a mano y se chupan los arilos como golosina natural muy apetente especialmente para niños del Caribe colombiano. También se preparan dulces caseros tradicionales, mermeladas, refrescos (agua de chiminango), y vinos artesanales de fermentación. Como leguminosa Mimosoideae fija nitrógeno biológico mediante rizobios y tolera notablemente suelos pobres, compactados y salinos costeros (hasta 8-10 dS/m de conductividad eléctrica), siendo una de las pocas leguminosas viables en zonas salinizadas del Caribe colombiano. Es planta melífera importante: la floración blanco-rosada (febrero-abril y agosto-octubre) produce miel monoflora aromática \"miel de chiminango\" apreciada en apicultura caribeña, y atrae masivamente abejas nativas Meliponini, abejas africanizadas Apis mellifera scutellata y avifauna nectarívora. Como árbol de cerca viva tradicional del bs-T se planta a 50-80 cm de distancia en línea cercando potreros y huertos, podándose anualmente a 2-3 m de altura, generando rebrotes vigorosos densos que cumplen función de cerca viva infranqueable para ganado y simultáneamente proveen frutos cosechables, forraje suplementario tierno (proteína 18-22% MS), madera de buena densidad para postes (durabilidad 8-12 años en suelo) y leña doméstica. Su madera marrón clara de densidad media-alta (0.7-0.8 g/cm³) es apreciada en construcción rural ligera, postes para cerca, mangos de herramienta, leña. En restauración del bs-T degradado funciona como pionera tolerante a salinidad, sequía y suelos compactados, ayudando a recuperar pastizales degradados del Caribe seco. Manejo agroecológico: propagación por semilla fresca sin tratamiento pre-germinativo (germinación 80-90% a 5-10 días), vivero 3-4 meses a sol pleno, plantación definitiva a 25-35 cm de altura, distancia 50-80 cm para cerca viva o 8×8 m para silvopastoril (80-120 árb/ha), poda anual de cerca viva en estación seca, primera cosecha de frutos año 3-4. Esqueje leñoso opcional para clonar variedades selectas con arilo más dulce. Es lección extraordinaria de frutales silvestres patrimoniales subutilizados del bs-T colombiano: una especie nativa que provee simultáneamente fruta dulce de mercado local, forraje, madera, leña, miel monoflora, cerca viva, fijación de N en suelos salinos donde poco prospera, y resiliencia climática en zonas áridas — un solo árbol que sostiene la economía campesina del Caribe y el Valle. Defenderlo es defender la soberanía alimentaria local frente al monocultivo y la importación de frutas exóticas que no toleran el bs-T degradado. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Agrosavia frutales tropicales, Pérez Arbeláez 1947 Plantas Útiles Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "prosopis_juliflora",
+      "nombre_comun": "Algarrobo",
+      "nombre_cientifico": "Prosopis juliflora (Sw.) DC.",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nitrogen_fixer",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 800,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 32,
+        "max_tolerable": 42
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "bursera_graveolens",
+        "cordia_alliodora",
+        "gliricidia_sepium",
+        "pithecellobium_dulce"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "fao-ecocrop",
+        "issg-uicn-invasoras"
+      ],
+      "valor_pedagogico": "El algarrobo, cují, trupillo o mezquite (Prosopis juliflora (Sw.) DC., Fabaceae subfamilia Mimosoideae) es uno de los árboles más patrimoniales y simultáneamente más controversiales del bosque seco tropical (bs-T) árido del Caribe colombiano, especialmente La Guajira donde es alimento ancestral del pueblo Wayúu: las vainas dulces molidas producen la \"harina de cují\" (algarroba), proteína-carbohidrato base de la dieta tradicional desde tiempos precolombinos. Su nombre Wayúu es \"kuusi\" y constituye patrimonio bio-cultural reconocido. Nativo del Neotrópico desde el sur de Estados Unidos hasta Perú-Argentina, en Colombia es genuinamente nativo del bs-T árido y semiárido de La Guajira (cuenca alta-media-baja), Cesar (Valledupar, La Paz), Magdalena (Santa Marta seco), Atlántico (interior), Sucre y Bolívar (interior seco) entre 0-800 msnm en zona térmica cálida extrema con precipitaciones 200-800 mm/año y temperaturas hasta 42°C. Árbol o arbusto espinoso caducifolio de 5-12 m de altura (rara vez hasta 15 m) con copa amplia tortuosa, fuste corto ramificado desde baja altura, corteza grisácea fisurada profundamente con tonalidades pardas, hojas bipinnadas con folíolos pequeños caducas en estación seca extrema, ESPINAS RAMALES robustas de 2-5 cm en pares en las axilas foliares (rasgo diagnóstico y riesgo de manejo), flores amarillo-verdosas en espigas pendulares de 5-10 cm melíferas (miel monoflora premium \"miel de algarrobo\"), frutos vaina linear cilíndrica recta amarillo-pajiza dulce indehiscente con 10-30 semillas inmersas en pulpa dulce. MANEJO DE ESPINAS (CRÍTICO): las espinas ramales son robustas, rectas y pueden penetrar 1-2 cm en tejido humano causando heridas profundas con alto riesgo de infección bacteriana (Clostridium, Staphylococcus) — la poda y cosecha requieren equipo de protección personal (PPE) completo: guantes de cuero o cuerina gruesos hasta el codo, lentes de protección, ropa manga larga, calzado cerrado, podadora extensiva para no acercar manos a ramas espinosas, y atención médica inmediata ante punción profunda (riesgo tétanos, considerar vacuna antitetánica al día). NO plantar cerca de áreas de juego infantil. CONTROL CAPRINO Y DISPERSIÓN: las vainas dulces son el alimento preferido de cabras (Capra hircus), ovejas (Ovis aries), bovinos y equinos, que consumen las vainas enteras y excretan semillas escarificadas naturalmente por el sistema digestivo — esta escarificación biológica resulta en germinación 80-95% en heces caprinas, lo cual convierte al ganado caprino extensivo en el principal dispersor natural de la especie. Esta interacción mutualista, benéfica en su rango natural del Caribe seco colombiano, ha convertido al algarrobo en una especie INVASORA AGRESIVA fuera de su rango natural cuando es introducida con ganado caprino descontrolado (caso India, Pakistán, Sudán, Etiopía, Kenya: la especie nativa americana hoy es plaga global), por lo cual el manejo en finca requiere monitorear densidad caprina, registrar dispersión post-plantación, controlar plántulas no deseadas en parcelas vecinas durante los primeros 2-3 años, y en caso de expansión no deseada eliminar plántulas mediante arranque manual con guante o aplicación foliar de glifosato 2% como último recurso. Como leguminosa Mimosoideae fija nitrógeno biológico en suelos extremadamente pobres y áridos donde pocas plantas prosperan, transformando desiertos en oasis productivos. Las vainas dulces (sacarosa 20-30% MS, proteína 8-12% MS, fibra digestible) son alimento estratégico en estación seca extrema: forraje para cabras (5-10 kg/día), ovejas, bovinos y equinos, y harina humana patrimonial Wayúu para arepas, tortas, bebidas refrescantes (chicha de cují), endulzante natural. Su madera marrón-rojiza extremadamente dura (1.0-1.2 g/cm³, una de las más densas del Neotrópico) es combustible premium (carbón vegetal de altísima calidad calórica), postes para cerca viva en zonas áridas, durmientes, construcción rural pesada. La miel monoflora de algarrobo (octubre-diciembre) es premium internacional. Manejo agroecológico: propagación por semilla con escarificación obligatoria (ácido sulfúrico 20 min o agua hirviendo + remojo 24-48 h, germinación 70-90% a 5-12 días), vivero 3-4 meses, plantación definitiva a 25-35 cm en zonas áridas Guajira-Cesar, distancia 6×6 m a 8×8 m en silvopastoril (100-200 árb/ha), cosecha de vainas septiembre-diciembre con PPE anti-espinas, primera cosecha año 3-4. Es lección extraordinaria de complejidad bio-cultural: una especie simultáneamente patrimonio ancestral indígena Wayúu, alimento estratégico de seguridad alimentaria en La Guajira (única región de Colombia donde el algarrobo es harina humana tradicional), forraje irremplazable en clima extremo, fijador biológico de N en desierto, fuente de miel monoflora premium, madera-combustible premium, y simultáneamente especie con riesgo de invasividad si se introduce fuera de rango natural con ganado caprino descontrolado — la lección agroecológica es que el contexto ecológico-cultural determina si una especie es bendición o maldición: en Guajira con manejo Wayúu milenario es bendición; fuera de rango con manejo caprino industrial descontrolado es plaga global. Defenderlo en Guajira es defender la seguridad alimentaria Wayúu y la memoria bio-cultural del Caribe árido colombiano. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, IUCN ISSG (Invasive Species Specialist Group).",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "prumnopitys_montana",
+      "nombre_comun": "Pino romerón / Chaquiro",
+      "nombre_cientifico": "Prumnopitys montana (Humb. & Bonpl. ex Willd.) de Laub.",
+      "familia_botanica": "Podocarpaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "biomass_producer",
+        "windbreak"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2100,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 8,
+        "optimo_max": 16,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "freziera_canescens",
+        "quercus_humboldtii",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "libro-rojo-plantas-colombia",
+        "humboldt-flora-alto-andina",
+        "bernal-2015-plantas-liquenes-colombia",
+        "uicn-red-list",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El pino romerón o chaquiro (Prumnopitys montana (Humb. & Bonpl. ex Willd.) de Laub., familia Podocarpaceae) es uno de los árboles MÁS EXTRAORDINARIAMENTE INTERESANTES de la flora colombiana — es CONÍFERA NATIVA SUDAMERICANA, perennifolia, dioica, de gran porte (15-25 m altura) con copa cónica-piramidal, distribuida en los Andes (Colombia, Ecuador, Venezuela, Perú, Bolivia). En Colombia se encuentra en bosque alto andino y subandino entre 1800 y 3000 msnm en piso térmico FRÍO, en los departamentos de Cundinamarca, Boyacá, Antioquia, Nariño, Cauca, Santander y Tolima. La familia PODOCARPACEAE es una RAREZA BOTÁNICA EXTRAORDINARIA — es una familia de coníferas de ORIGEN GONDWÁNICO RELICTUAL, es decir, sus ancestros vivieron en el supercontinente Gondwana hace más de 200 millones de años (Triásico-Jurásico) y se distribuyeron por Sudamérica, África, Australia, Nueva Zelanda y la Antártida cuando estos formaban un solo continente. Tras la fragmentación de Gondwana en el Cretácico-Cenozoico, las Podocarpaceae se mantuvieron en los refugios montañosos del hemisferio sur — y los Andes tropicales son uno de los pocos enclaves de Podocarpaceae en el hemisferio norte tropical (refugio relictual). En Colombia hay TRES especies de Podocarpaceae nativas: Prumnopitys montana (pino romerón, este), Podocarpus oleifolius (chaquiro real) y Retrophyllum rospigliosii (chaquiro de hoja menuda) — todas son CONÍFERAS NATIVAS SUDAMERICANAS, dato que rompe la idea popular de que 'todas las coníferas son del hemisferio norte' (Pinus, Abies, Picea, Cedrus son del norte; pero Araucaria, Podocarpus, Prumnopitys, Retrophyllum, Saxegothaea, Pilgerodendron son del hemisferio sur de origen gondwánico). El pino romerón se distingue MORFOLÓGICAMENTE de los pinos verdaderos (Pinus, género del hemisferio norte) por: (1) hojas LINEARES PLANAS dispuestas DÍSTICAMENTE en ramillas planas (NO acículas en mechón como Pinus); (2) NO produce conos típicos sino SEMILLAS DRUPÁCEAS envueltas en arilo carnoso púrpura-violáceo (dispersión ORNITÓCORA por aves frugívoras alto-andinas — pavas, tucanetas, mirlas grandes, atrapamoscas grandes — no por viento como los pinos verdaderos); (3) es DIOICA (separación de sexos en árboles distintos, raro en Pinus). Estado de conservación: VULNERABLE (VU) en el Libro Rojo de Plantas de Colombia (2007) por sobreexplotación maderera histórica (la madera del pino romerón es de excelente calidad — rojiza, aromática, durable, codiciada para carpintería fina, instrumentos musicales, mástiles, postes y muebles desde la colonia hasta el siglo XX). Su aprovechamiento maderable comercial está PROHIBIDO en bosque natural y regulado estrictamente por las CAR (CAR Cundinamarca, Corpoboyacá, Cornare, Corantioquia, Corponariño) y por el SINAP. Lección viva sobre BIOGEOGRAFÍA GONDWÁNICA, CONÍFERAS NATIVAS SUDAMERICANAS, RAREZAS BOTÁNICAS y RESTAURACIÓN PRIORITARIA DEL BOSQUE ALTO ANDINO: el pino romerón es ejemplo paradigmático de cómo una especie nativa colombiana pertenece a un linaje botánico antiguo de distribución gondwánica relictual, y de cómo la sobreexplotación maderera del siglo XIX-XX la llevó al estado VU — la restauración prioritaria con romerón en Cruz Verde-Sumapaz, Chingaza, Iguaque, Tatamá y Otún-Quimbaya es ESTRATÉGICA tanto ecológica (estructura de dosel, alimento de avifauna alto-andina en estación seca) como simbólica (recuperación de patrimonio genético gondwánico). Manejo agroecológico: propagación por semilla fresca con despulpado inmediato, estratificación fría 60-90 días e inoculación micorrízica obligatoria; trasplante 6-12 meses; plantación 24-36 meses; CRECIMIENTO MUY LENTO 15-30 cm/año (paciencia 5-10 años); proporción dioica 1M:4-5H; asocio con roble andino (Quercus humboldtii), encenillo (Weinmannia tomentosa), gaque (Clusia multiflora) y freziera (Freziera canescens); densidades 100-200 ind/ha como especie estructural de dosel. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Libro Rojo Plantas Colombia, Humboldt Flora Alto-Andina, Bernal 2015 Catálogo Plantas Líquenes Colombia, IUCN Red List, Pérez-Arbeláez 1947 Plantas Útiles Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Chaquiro",
+        "Pino Romerón"
+      ]
+    },
+    {
+      "id": "prunus_domestica_ciruela_imperial",
+      "nombre_comun": "Ciruela imperial",
+      "nombre_cientifico": "Prunus domestica L. cv. Imperial",
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2700,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "injerto",
+        "notas": "Injerto de yema o púa sobre patrón Prunus cerasifera (mirabolano) o Prunus insititia (endrino injertal); requiere ≥500 h frío <7°C; entrada en producción rápida 2-3 años post-injerto."
+      },
+      "companions": [
+        "trifolium_repens"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La ciruela imperial (Prunus domestica L. cv. Imperial, Rosaceae) es un frutal templado caducifolio eurasiático cultivado tradicionalmente en altiplanos andinos colombianos desde la época colonial. Crece entre 2.200 y 2.700 msnm en zona térmica fría, presente en Cundinamarca (Sopó, Chía, Tabio, Tenjo, Subachoque, Choachí, Ubaque, Sasaima), Boyacá (Nuevo Colón, Jenesano, Tibaná, Ramiriquí, Tibasosa, Paipa, Duitama), Nariño (Pasto, Buesaco, Sandoná, Ipiales), Norte de Santander (Pamplona, Chitagá) y altiplano antioqueño (Santa Rosa de Osos, La Unión). Árbol de 4-8 m de altura, copa redondeada-extendida, hábito ramificado. Flores blanco-puras en corimbo de 2-3 flores que abren antes que las hojas, atractivo para Apis mellifera y polinizadores nativos. Frutos en drupa elipsoidal de 4-6 cm, piel violeta-azulada cubierta de pruína blanquecina característica, pulpa amarillo-ámbar jugosa dulce-acidulada (13-16° Brix), carozo libre (freestone) elíptico. Lección viva de patrimonio frutícola colonial andino y soberanía alimentaria templada: enseña a niñas y niños que la ciruela colombiana del altiplano es alternativa local fresca de mucho mejor calidad que la ciruela importada en compota o seca, y que el ciruelo es un árbol de doble propósito (frutal+ornamental con floración espectacular). Manejo agroecológico: poda de formación en vaso abierto o eje central modificado, distancia 4×5 m (500 árboles/ha), fertilización con compost + bocashi + biol foliar, control de Monilinia fructicola (podredumbre parda) con caldo bordelés y poda sanitaria, manejo de Hoplocampa flava (avispa del ciruelo) con trampas de feromonas, control de Anastrepha con trampas McPhail. Asocios: tagasaste cortavientos N-fijador, fresa Monterrey cobertura productiva, manzano sabanero compañía sinérgica, trébol blanco como cobertura N-fijadora. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, AGROSAVIA Manual Frutales Tropicales, ICA Resolución 3168/2015.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "prunus_serotina_capuli",
+      "nombre_comun": "Capulí",
+      "nombre_cientifico": "Prunus serotina var. capuli (Cav.) McVaugh",
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "windbreak",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Árbol caducifolio parcial; sus frutos atraen fauna benéfica y aves dispersoras en la alta frontera forestal."
+      },
+      "companions": [
+        "quercus_humboldtii"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "sib-colombia",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El capulí (Prunus serotina Ehrh. subsp. capuli) es un árbol frutal nativo de los Andes con frutos tipo cereza pequeña dulce-ácida ampliamente consumidos en Colombia, además de su uso ornamental y forestal en sistemas agroforestales. Crece naturalmente y se cultiva en Cundinamarca (Choachí, Ubaque, Fómeque), Boyacá (Soatá, Tibaná), Nariño (Pasto, Túquerres), Cauca y Tolima entre 2.000 y 3.200 msnm en zona térmica fría. Árbol caducifolio puede alcanzar 8-12 m, copa esférica densa. Manejo agroecológico: propagación por semilla (estratificación frío 60 días) o injerto; uso en cercas vivas, sombra de potreros, restauración bosque altoandino. Frutas atraen avifauna nativa. Fuentes Tier A: Catálogo de Plantas y Líquenes Colombia (Bernal et al.), POWO Kew, GBIF Backbone Taxonomy, AGROSAVIA, ICA Resolución 3168/2015.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "pseudosamanea_guachapele",
+      "nombre_comun": "Igua",
+      "nombre_cientifico": "Pseudosamanea guachapele (Kunth) Harms",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nitrogen_fixer",
+        "windbreak",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1400,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 6,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "albizia_guachapele",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "enterolobium_cyclocarpum",
+        "gliricidia_sepium",
+        "tabebuia_rosea"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-silvopastoriles",
+        "humboldt-flora-alto-andina"
+      ],
+      "valor_pedagogico": "El iguá o guachapele (Pseudosamanea guachapele (Kunth) Harms, Fabaceae subfamilia Mimosoideae) es uno de los árboles emblemáticos del bosque seco tropical (bs-T) colombiano, un ecosistema crítico y entre los más amenazados del país por la expansión ganadera-agrícola: queda menos del 8% de la cobertura original. Nativo del Neotrópico, en Colombia se distribuye dominante en valles interandinos secos del Magdalena medio (Tolima, Huila, Cundinamarca, Boyacá, Santander), Cauca (Valle, Cauca), Patía, Sinú-San Jorge (Córdoba, Sucre), Caribe seco (La Guajira, Cesar, Magdalena, Bolívar) y piedemonte llanero entre 0-1.400 msnm en zona térmica cálida a templada. Árbol caducifolio de 15-25 m de altura con copa amplia en forma de paraguas, fuste recto cilíndrico, corteza grisácea fisurada, hojas bipinnadas con folíolos pequeños caducas en estación seca, flores blanco-cremosas en cabezuelas globulosas pequeñas melíferas, frutos en vaina linear comprimida marrón-negra dehiscente con 6-10 semillas. Su característica más relevante es la madera marrón-amarillenta a anaranjada dura semipesada apreciada en ebanistería fina, construcción rural, postes para cerca viva y leña de alta calidad. Como leguminosa Mimosoideae fija nitrógeno biológico mediante asociación con rizobios y bacterias diazotróficas, aporte crítico en bosque seco con suelos típicamente pobres y compactados. En sistemas silvopastoriles del Magdalena medio y Caribe seco acepta densidades 80-120 árb/ha proveyendo sombrío al ganado bovino que ramonea sus rebrotes tiernos sin daño (forraje suplementario rico en proteína 18-22% MS), reduciendo el estrés térmico del ganado en climas extremos (32-36°C) y mejorando la productividad lechera-cárnica. Como pionera de crecimiento rápido (turno de aprovechamiento maderable 15-25 años) y altamente resistente a sequía prolongada de 4-6 meses, es especie clave en restauración de bs-T degradado, donde tolera suelos compactados por ganadería extensiva y rebrota vigoroso tras corte controlado. Su floración masiva blanco-dorada pre-foliación al inicio de las lluvias es atractor crítico para abejas nativas sin aguijón (Meliponini: Tetragonisca angustula, Melipona, Trigona), abejorros Bombus, y avifauna polinizadora del bosque seco. Manejo agroecológico: propagación por semilla con escarificación mecánica o remojo en agua caliente 80°C por 24 h (germinación 70-85% a 8-15 días), vivero a sol pleno 4-6 meses, plantación definitiva a 30-40 cm, distancia 6×6 m en silvopastoril, poda formativa los primeros 3 años para fuste recto. Es lección extraordinaria de cómo las leguminosas pioneras nativas del bs-T pueden simultáneamente proveer sombrío al ganado, forraje suplementario, madera fina, fijación biológica de N (sustituye fertilizante sintético), restaurar suelos degradados y atraer polinizadores nativos: un solo árbol que prestá 5 servicios ecosistémicos en uno de los ecosistemas más amenazados de Colombia. Es además ejemplo de soberanía técnica: especie nativa adaptada a sequía y compactación, contrasta con la promoción de exóticas (leucaena, gliricidia) que requieren más manejo. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Agrosavia silvopastoriles bs-T, Humboldt bosque seco tropical Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "pyrus_communis_anjou",
+      "nombre_comun": "Pera Anjou",
+      "nombre_cientifico": "Pyrus communis L. cv. Anjou",
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2700,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -7,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "injerto",
+        "notas": "Injerto sobre patrón Pyrus communis franco o membrillero (Cydonia oblonga) que enaniza el árbol y precoza la entrada en producción; requiere ≥400 h frío <7°C."
+      },
+      "companions": [
+        "fragaria_ananassa_monterrey"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La pera Anjou (Pyrus communis L. cv. Anjou, Rosaceae) es un frutal templado caducifolio europeo tradicionalmente cultivado en el altiplano cundiboyacense desde la época colonial. Crece entre 2.200 y 2.700 msnm en zona térmica fría con acumulación de horas frío suficientes (≥400 h <7°C), presente en Cundinamarca (Sopó, Chía, Subachoque, Tenjo, Cogua, Zipaquirá, Ubaté), Boyacá (Paipa, Tibasosa, Duitama, Sogamoso, Nobsa, Tunja), Nariño (Pasto, Ipiales) y altiplano antioqueño (Santa Rosa de Osos, Belmira, La Unión). Árbol de 5-10 m de altura, copa piramidal-elongada, hábito más erecto que el manzano. Flores blancas en corimbo agrupado que abren antes que las hojas, fuerte atractivo para Apis mellifera y polinizadores nativos. Frutos en pomo piriforme característico (8-12 cm), piel verde-amarillenta con chapa rosa-asalmonada al sol, pulpa blanco-cremosa jugosa muy dulce-perfumada (13-15° Brix) que madura post-cosecha (climatérico). Lección viva de patrimonio frutícola colonial andino: enseña a niñas y niños que los huertos campesinos de la Sabana llevan más de tres siglos integrando perales europeos al paisaje productivo, formando parte de la identidad cundiboyacense. Manejo agroecológico: poda de formación en eje central modificado, distancia 4×5 m (500 árboles/ha), aclareo de frutos manual para tamaño comercial, fertilización con compost + bocashi + biol, control de Erwinia amylovora (fuego bacteriano) con cobre + poda sanitaria estricta, manejo de Psylla pyri con caldo sulfocálcico + parasitoides nativos. Asocios: tagasaste como cortavientos N-fijador, fresa Monterrey como cobertura, manzano sabanero para polinización cruzada (autoincompatible). Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, AGROSAVIA Manual Frutales Tropicales, ICA Resolución 3168/2015.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "raphanus_sativus_oleifer",
+      "nombre_comun": "Rabano forrajero",
+      "nombre_cientifico": "Raphanus sativus L. var. oleifer",
+      "familia_botanica": "Brassicaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "ground_cover",
+        "biomass_producer",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "avena_sativa",
+        "vicia_sativa"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-forrajeras-2022",
+        "agrosavia-tibaitata",
+        "bernal-2015-plantas-liquenes-colombia",
+        "restrepo-2005-agroecologia"
+      ],
+      "valor_pedagogico": "El rábano forrajero o rábano oleífero (Raphanus sativus L. var. oleifer, familia Brassicaceae) es una brasicácea anual herbácea cultivada selectivamente del rábano común por mayor desarrollo radicular (raíz pivotante 50-100 cm) y biomasa aérea, usado en sistemas ganaderos y hortícolas andinos colombianos como cover crop de ciclo corto, abono verde rápido, biofumigante natural y forraje secundario para bovinos. Se cultiva en sistemas de rotación con papa, hortalizas y praderas en Cundinamarca (Sabana de Bogotá, Subachoque, Sumapaz), Boyacá (Tunja, Sotaquirá, Sutamarchán), Nariño (Pasto, Túquerres, Sapuyes), Antioquia (oriente — La Unión, La Ceja) y Eje cafetero alto entre 1.800 y 2.600 msnm en zona térmica templada a fría. Ciclo cortísimo 60-90 días desde siembra a incorporación o cosecha. Rendimientos 25-40 t/ha biomasa fresca, 4-7 t/ha materia seca. Lección viva del abono verde express: el rábano forrajero germina y cubre el suelo desnudo en 2-3 semanas (cobertura rápida anti-arvenses por sombreado denso), enseñando el valor de las brasicas como biofumigantes naturales por liberación de isotiocianatos al descomponer biomasa (acción supresora sobre Globodera spp. nematodo dorado de la papa, Rhizoctonia solani, Verticillium dahliae) y como acumuladoras de nutrientes profundos en rotaciones cortas pre-papa o post-cosecha de hortalizas. Su raíz pivotante descompacta suelos arcillosos compactados (bio-tillage) y sus flores blanco-rosadas atraen polinizadores nativos y enemigos naturales. Manejo agroecológico: siembra al voleo 15-25 kg/ha en suelo descansado, asocio con avena o vicia para mejorar C/N de cobertura mixta, incorporación pre-floración para evitar semillación, alternativamente pastoreo controlado por bovinos en franja, no requiere fertilización. Fuentes Tier A: AGROSAVIA Forrajeras 2022, POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "renealmia_alpinia",
+      "nombre_comun": "Pina pina",
+      "nombre_cientifico": "Renealmia alpinia (Rottb.) Maas",
+      "familia_botanica": "Zingiberaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 50,
+        "optimo_max": 400,
+        "max_absoluto": 800
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "rizoma",
+        "notas": "Propagacion por division de rizomas en sustrato rico en materia organica y humedo. Crece en sotobosque de selvas tropicales. Frutos usados como colorante natural y sus hojas en infusion medicinal."
+      },
+      "companions": [
+        "musa_paradisiaca"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia",
+        "sinchi-amazonia-colombiana",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La piña piña o matandrea (Renealmia alpinia (Rottb.) Maas, familia Zingiberaceae) es una zingiberácea herbácea perenne rizomatosa robusta (1.5-3 m altura) nativa silvestre del Neotrópico húmedo (Caribe, Mesoamérica, norte de Sudamérica), distribuida en sotobosques de selva tropical húmeda, bordes de quebradas y zonas ribereñas del trópico húmedo colombiano. Produce hojas elípticas lanceoladas con vaina ciliada y filotaxia dística (rasgo diagnóstico Zingiberaceae frente a Costaceae), inflorescencias en panícula basal terminal con brácteas escarlatas y flores tubulares amarillas, y frutos globosos rojo-anaranjados con pulpa-arilo morado oscuro rica en antocianinas (cianidina-3-rutinósido, peonidina) usadas como colorante natural tradicional. Se distribuye en Chocó (Quibdó, Atrato, Bajo Baudó, Bahía Solano, Nuquí), Valle del Cauca (Buenaventura, Bajo Calima, Anchicayá), Cauca (Guapi, Timbiquí, López), Nariño (Tumaco, Olaya Herrera), Amazonas (Leticia, Puerto Nariño), Vaupés, Caquetá, Putumayo y Magdalena medio bajo entre 50 y 400 msnm en zona térmica cálida húmeda con sombra parcial a alta. Ciclo perenne, floración bianual en clima húmedo estable. Lección viva: planta del sotobosque tropical húmedo con usos medicinales (infusión foliar antiinflamatoria, decocción rizomatosa para cólicos) y tintóreos tradicionales (colorante natural morado-rojo para tejidos artesanales, alimentos, cestería), enseñando el conocimiento botánico de las comunidades afrocolombianas e indígenas del Pacífico y Amazonia y su relación profunda con el bosque húmedo como farmacopea, despensa y proveedor de servicios bioculturales. Manejo agroecológico: propagación por división de rizomas con yemas activas en sustrato rico en materia orgánica y humedad alta sostenida, tolerancia a sombra parcial 60-80% (sotobosque), asocio en sistemas agroforestales con cacao, plátano, açaí y heliconias, no requiere agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia, SIB Colombia, SINCHI Amazonia Colombiana.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "salvia_officinalis",
+      "nombre_comun": "Salvia",
+      "nombre_cientifico": "Salvia officinalis L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -12,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Los esquejes semileñosos enraízan con facilidad; prefiere suelos ligeros."
+      },
+      "companions": [
+        "dahlia_imperialis",
+        "lavandula_dentata",
+        "monarda_didyma"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-biopreparados-2015",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La Salvia officinalis L. se cultiva en los departamentos andinos de Colombia como Cundinamarca, Boyacá y Nariño entre 800 y 3200 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación mediante esquejes semileñosos que enraízan con facilidad en suelos ligeros, con un ciclo de producción de 6-8 meses para cosecha de hojas. Se asocia beneficiosamente con repollo y zanahoria para reducir plagas como áfidos y trips, requiere monitoreo de arañuelas y oidio en condiciones de alta humedad. En el contexto cultural andino-campesino, sus hojas se utilizan tradicionalmente en infusiones digestivas y como antiséptico natural para heridas leves, conocimiento que tiene raíces en las prácticas muiscas de medicina tradicional. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), y respaldada por el Manual de Biopreparados de AGROSAVIA (2015) y la ICA Resolución 3168/2015, su nombre científico válido es Salvia officinalis L.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "sambucus_peruviana",
+      "nombre_comun": "Sauco peruano",
+      "nombre_cientifico": "Sambucus peruviana Kunth",
+      "familia_botanica": "Adoxaceae",
+      "category": "cercas_vivas",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "living_fence",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "companions": [
+        "morella_pubescens",
+        "viburnum_tinoides"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El sauco peruano o tilo andino (Sambucus peruviana Kunth, Adoxaceae) es un árbol/arbusto nativo andino (3-8 m) endémico del norte de Sudamérica (Colombia, Ecuador, Perú, Bolivia) entre 1800 y 3400 msnm, distinto del Sambucus nigra europeo. Crece en bosque alto andino y subpáramo, frecuente en cercas vivas tradicionales del altiplano cundiboyacense y Nariño. Lección viva de sustitución nativa frente al retamo espinoso invasor (Ulex europaeus): cumple las MISMAS funciones de cerca viva (espinosidad moderada, denso, perenne) sin los problemas de banco de semillas longevo, alelopatía severa ni alteración del régimen de fuego. Floración blanca en panículas atrae abejas nativas (Bombus atratus, abejas sin aguijón Meliponini), polinizadores cruciales para tomate, papa criolla, mora y curuba. Frutos pequeños negro-purpúreos comestibles cocidos (NO crudos, contienen glicósidos cianogénicos que se neutralizan con cocción) usados en jaleas y vinos artesanales. Hojas medicinales en infusión para diaforesis en resfriados (uso en farmacopea Muisca y Chibcha). Manejo agroecológico: propagación por estaca de 30-40 cm directa al sitio, primer año riego, después tolera sequía moderada. Excelente para programas de restauración Cruz Verde-Sumapaz.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "selenicereus_megalanthus",
+      "nombre_comun": "Pitahaya amarilla",
+      "nombre_cientifico": "Selenicereus megalanthus (K.Schum. ex Vaupel) Moran",
+      "familia_botanica": "Cactaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 600,
+        "optimo_min": 1200,
+        "optimo_max": 1900,
+        "max_absoluto": 2200
+      },
+      "companions": [
+        "cajanus_cajan",
+        "musa_paradisiaca"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "sib-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La pitahaya amarilla (Selenicereus megalanthus (K.Schum. ex Vaupel) Moran, Cactaceae) es un cactus epífito-hemiepífito trepador perenne originario del piedemonte amazónico-andino de Colombia, Ecuador, Perú y Bolivia, cultivado comercialmente en Colombia entre 1.200 y 1.900 msnm en clima templado-cálido moderado en Boyacá (Miraflores, Páez, San Eduardo, principal productor — denominación de origen 'Pitahaya de Miraflores' bajo estudio), Cundinamarca (Caqueza, Fómeque, Ubaque, Quetame), Huila, Valle del Cauca y Santander. Pertenece a la familia Cactaceae tribu Hylocereeae (igual que la pitaya roja Hylocereus undatus y Hylocereus costaricensis), de tallos verdes triangulares-3-angulados con aréolas y espinas cortas blanco-amarillentas, crecimiento trepador con raíces aéreas que se adhieren a árboles tutores o estructuras de tutorado (concreto/madera/tela polietileno), flores nocturnas blanco-cremas gigantes (25-35 cm de diámetro, las más grandes de la flora colombiana cultivada) que abren una sola noche y son polinizadas por murciélagos nectarívoros (Anoura, Glossophaga) y polillas esfíngidas — aunque en cultivos comerciales se realiza polinización manual matinal para asegurar cuajado. Fruto baya elipsoidal con cáscara amarillo-brillante con brácteas (escamas) cortas y pulpa blanca translúcida con semillas negras pequeñas masticables (sabor dulce delicado, único en el mundo: Colombia es líder mundial de exportación de S. megalanthus). Es lección viva de bioeconomía sostenible, biocomercio y agroexportación colombiana que enseña a niñas y niños cómo un cactus nativo amazónico-andino se convirtió en uno de los frutales de mayor valor agregado del país (USD 8-15/kg en mercados de exportación a Europa, Asia, Norteamérica). Producto bandera del programa 'Colombia, semilla de exportación' y mercados orgánicos certificados; rica en antioxidantes (betacianinas), vitamina C, prebióticos (oligofructosa), efecto laxante suave. Manejo agroecológico: propagación por esqueje de cladodio maduro (segmento de 30-40 cm, cicatrizado 5-7 días antes de siembra) o semilla (sin uso comercial — variabilidad genética alta), tutorado obligatorio sobre 'T' de concreto con tela polietileno o sobre tutor vivo (matarratón, leucaena), distancia 3x3 m o doble fila 2.5x1.5 m, plena producción a partir de año 3-4, cosecha 8-9 meses post-floración cuando cáscara cambia de verde a amarillo intenso, polinización manual al amanecer para maximizar cuajado. Función en chagra como frutal de alto valor agregado, atractora de murciélagos polinizadores nocturnos, cultivo de exportación sostenible. Fuentes Tier A: GBIF, POWO Kew, AGROSAVIA Sol Andina, SiB Colombia, Bernal 2015, ICA Resolución 3168.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "setaria_sphacelata",
+      "nombre_comun": "Setaria",
+      "nombre_cientifico": "Setaria sphacelata (Schumach.) Stapf & C.E.Hubb. ex M.B.Moss",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "biomass_producer",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 14,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "stylosanthes_guianensis"
+      ],
+      "source_ids": [
+        "agrosavia-forrajeras-2022",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "La setaria (Setaria sphacelata (Schumach.) Stapf & C.E.Hubb. ex M.B.Moss, Poaceae, subfamilia Panicoideae) es una gramínea forrajera tropical-templada de gran importancia en la ganadería de clima frío y templado-alto en Colombia, originaria de las montañas del África oriental (Kenia, Uganda, Tanzania, Etiopía, Rwanda, Burundi, donde se encuentra entre 1.500 y 3.000 msnm) e introducida al Neotrópico durante el siglo XX como alternativa forrajera para las zonas altoandinas donde las brachiarias y otras gramíneas tropicales del piso cálido no prosperan por las bajas temperaturas. Es una de las pocas gramíneas forrajeras comerciales adaptadas a la franja altitudinal de 1.800-2.800 msnm, lo que la convierte en candidata estratégica para ganadería en Boyacá, Cundinamarca, Nariño, Antioquia altoandina, eje cafetero alto (Caldas, Quindío, Risaralda), Cauca alto y Santander altoandino — todas regiones donde la ganadería de leche y doble propósito domina y donde la otra gramínea ampliamente sembrada, el kikuyo (Cenchrus clandestinus), tiene el problema crítico de ser invasora de páramo y subpáramo según la Ley 1930/2018. La setaria ofrece así una alternativa importante: gramínea africana también, pero menos agresiva ecológicamente en zonas de páramo y mejor adaptada a manejo intensivo de leche en altiplano. En Colombia se cultiva ampliamente en el altiplano cundiboyacense (Boyacá, Cundinamarca), Nariño altoandino, eje cafetero alto (cinturón cafetalero >1.500 msnm), valles interandinos altos (Quimbaya, Sumapaz, Tota) entre 1.800 y 2.800 msnm en zona térmica templada y fría. Las variedades comerciales más difundidas son cv. Kazungula (Sudáfrica, mayor porte y resistencia a defoliación), cv. Nandi (Kenia, finer leaf, mejor valor nutricional), cv. Narok (Kenia, mayor tolerancia a frío). Es gramínea perenne cespitosa de macollas vigorosas erectas que alcanza 0.8-2 m de altura con hojas lineares-lanceoladas verde-azuladas, inflorescencia en panícula contraída cilíndrica con pelos amarillo-anaranjados (aspecto de \"cepillo\" característico que diagnostica el género Setaria), semillas pequeñas con dormancia moderada de 3-6 meses. Produce biomasa de 12-20 t MS/ha/año con buen manejo, soporta carga animal de 2-4 UGG/ha en sistemas rotacionales con descanso de 28-35 días entre pastoreos y altura de entrada al pastoreo de 50-70 cm, valor nutricional medio-alto (PC 10-14%, DIVMS 60-68%) competitivo con kikuyo y superior a brachiaria. Su limitación principal es la presencia de oxalatos solubles en hoja joven que pueden causar problemas en bovinos: el oxalato se une al calcio del torrente sanguíneo formando cristales que pueden generar hipocalcemia y daño renal si el consumo es alto y exclusivo; por esa razón se recomienda limitar la dieta a menos del 70% de setaria y complementar con leguminosas y otras gramíneas, especialmente en vacas lecheras de alta producción. Susceptible a roya foliar (Puccinia spp.) en estaciones lluviosas y a salivazo (Aeneolamia spp.) menos que brachiarias. Su naturalización en Colombia es menos agresiva que kikuyo: no invade páramo activamente (aunque puede colonizar pastizales sub-andinos disturbados), por lo cual desde el punto de vista de conservación de páramo y delimitación de áreas protegidas según Ley 1930/2018, la setaria es una alternativa más segura que el kikuyo para ganadería en cotas 1.800-2.800 msnm. Manejo agroecológico: propagación por semilla escarificada o con reposo de 3-6 meses (6-12 kg/ha al inicio de lluvias en surcos de 0.5 m), fertilización inicial moderada (300-400 kg/ha 10-30-10 más cal en suelos ácidos), descanso post-establecimiento 90-120 días, rotación con tréboles (Trifolium repens, T. pratense) y otras leguminosas templadas (Lotus uliginosus, Medicago sativa en altiplano) para mejorar nutrición animal y diluir oxalatos, sistemas silvopastoriles con árboles altoandinos nativos (Alnus acuminata, Acaena cylindristachya, Hesperomeles, Vallea stipularis, Weinmannia) que mejoran captura de carbono y protegen el pasto del viento y heladas. Es lección agroecológica de la ganadería altoandina: una gramínea africana de altura naturalizada que en regiones de páramo y sub-páramo colombianos representa la alternativa más limpia ecológicamente al kikuyo invasor, demostrando que dentro de las gramíneas exóticas también hay gradientes de impacto ecológico que el ganadero responsable debe conocer y elegir conscientemente. Fuentes Tier A: AGROSAVIA Manual Forrajeras Tropicales 2022, CIAT Tropical Forages Database, POWO Kew, GBIF Backbone Taxonomy, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "solanum_lycopersicum_cerasiforme_uvalina",
+      "nombre_comun": "Tomate cherry uvalina / Grape",
+      "nombre_cientifico": "Solanum lycopersicum var. cerasiforme 'Uvalina'",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Hábito indeterminado. Su piel es más resistente que la del cherry redondo; ideal para climas con variaciones de humedad."
+      },
+      "companions": [
+        "urtica_dioica"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "valor_pedagogico": "El tomate cherry uvalina (Solanum lycopersicum L. var. cerasiforme, tipo grape/oval pequeño elongado, cultivares Santa, Juliet, Sweet Hearts) se diferencia del cherry redondo por la forma oval-cilíndrica de los frutos, mayor firmeza y vida postcosecha extendida. En Colombia se cultiva principalmente bajo invernadero en Sabana de Bogotá, altiplano Boyacá, Antioquia y Cauca entre 1.800 y 2.800 msnm en zona térmica fría. Ciclo similar al cherry estándar (90-120 días primer fruto). Mayor demanda de mercado gourmet por presentación estética. Manejo agroecológico: tutorado holandés (cordel guiado), poda axilas riguroso, riego goteo con fertirriego orgánico (biol diluido), control integrado de Tuta absoluta con Bacillus thuringiensis + Trichogramma, manejo de oídio (caldo bordelés). Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_anti_confusion": "Género Solanum: verificar especie exacta (lulo/tomate de árbol/papa/berenjena son especies distintas).",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "solanum_sessiliflorum",
+      "nombre_comun": "Cocona",
+      "nombre_cientifico": "Solanum sessiliflorum Dunal",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 50,
+        "optimo_max": 400,
+        "max_absoluto": 700
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinacion rapida (7-14 dias); se trasplanta a los 30 dias. Nativa de la Amazonia colombiana; crece bien en suelos acidos. Fruto usado en jugos y preparaciones tradicionales."
+      },
+      "companions": [
+        "ananas_comosus",
+        "bixa_orellana",
+        "musa_paradisiaca"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia",
+        "sinchi-amazonia-colombiana"
+      ],
+      "valor_pedagogico": "La cocona o tomate amazónico (Solanum sessiliflorum Dunal, familia Solanaceae) es una solanácea arbustiva semi-perenne (1-2.5 m altura) nativa silvestre y domesticada de la cuenca amazónica suroccidental (Colombia, Ecuador, Perú, Brasil), cultivada tradicionalmente por comunidades indígenas amazónicas como cultivo de chagra y frutal subutilizado con altísimo potencial nutricional. Produce frutos globosos a piriformes anaranjado-rojizos (3-7 cm) con pulpa amarilla ácida-aromática rica en hierro (1.5-2.5 mg/100g, hasta 4 veces más que el tomate común), niacina, vitamina B1, B2, ácido fólico, β-caroteno y compuestos fenólicos antioxidantes. Se distribuye en Amazonas (Leticia, Puerto Nariño, La Pedrera, Tarapacá), Vaupés (Mitú, Carurú), Caquetá (Florencia, Solano, Cartagena del Chairá), Putumayo (Mocoa, Puerto Asís, La Hormiga), Guainía (Puerto Inírida), Guaviare (San José) entre 50 y 400 msnm en zona térmica cálida húmeda. Ciclo bienal a semi-perenne, primera cosecha 6-10 meses, productividad sostenida 2-3 años. Rendimientos 15-30 t/ha fruto fresco. Lección viva: fruto amazónico con alto potencial nutritivo subutilizado, enseñando el potencial de especies nativas neotropicales subutilizadas (NUS — Neglected and Underutilized Species, FAO) en la seguridad alimentaria de regiones tropicales, su rol en la chagra indígena amazónica (Tikuna, Yagua, Cocama, Witoto, Murui, Bora) como cultivo complementario a la yuca brava (Manihot esculenta), y su valor en la fortificación nutricional natural por su excepcional contenido de hierro biodisponible (clave en lucha contra anemia infantil amazónica). Manejo agroecológico: propagación por semilla con germinación rápida 7-14 días, trasplante a campo a los 30-45 días con sustrato rico en materia orgánica, asocio en chagra con yuca, plátano, piña, achiote (Bixa orellana) y guama (Inga edulis) como sombra parcial, tolerancia a suelos ácidos (pH 4.5-6) típicos de oxisoles amazónicos, no requiere fertilización química, control biológico de mosca del fruto (Anastrepha spp.) con trampas. Fuentes Tier A: SINCHI Amazonia Colombiana, POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia, SIB Colombia.",
+      "validation_level": "claude_draft",
+      "_anti_confusion": "Solanum sessiliflorum = cocona. Especie amazónica distinta del lulo (S. quitoense).",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Vetacaci"
+      ]
+    },
+    {
+      "id": "spondias_dulcis",
+      "nombre_comun": "Jobo cajá",
+      "nombre_cientifico": "Spondias dulcis Parkinson",
+      "familia_botanica": "Anacardiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 50,
+        "optimo_max": 900,
+        "max_absoluto": 1300
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "mammea_americana",
+        "mangifera_indica",
+        "musa_paradisiaca",
+        "persea_americana"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles",
+        "sib-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "agrosavia-manual-frutales-tropicales",
+        "fao-ecocrop"
+      ],
+      "valor_pedagogico": "El jobo cajá, cajá-manga, ambarella o manga del Perú (Spondias dulcis Parkinson, Anacardiaceae — sinónimo histórico Spondias cytherea Sonn.) es un árbol frutal perenne tropical originario de las islas del Pacífico Sur (Polinesia, Melanesia — origen oceánico, no neotropical, a diferencia de sus hermanas Spondias americanas mombin y purpurea), domesticado en Polinesia hace miles de años, llevado por exploradores europeos (Captain Cook 1768-1779, traslado documentado a las Antillas francesas en el siglo XVIII) y ampliamente naturalizado en todo el trópico mundial (Indias, Sudeste Asiático, Caribe, Brasil — donde se llama \"cajá-manga\" y se popularizó masivamente, Centroamérica, África). En Colombia se cultiva en zonas cálidas costeras y de valle (Atlántico, Bolívar, Magdalena, Córdoba, Sucre, Cesar, La Guajira, Chocó, valle bajo y medio del Magdalena, Llanos bajos, Antioquia bajo Cauca-Urabá, Valle del Cauca cinturón frutícola, Tolima-Huila cálidos) entre 0 y 900 msnm con temperaturas 22-30 °C, sol pleno, suelos bien drenados, riego moderado, tolerante a sequías estacionales y vientos costeros. Árbol semicaducifolio mediano-grande de 12-25 m altura con copa amplia abierta-irregular, corteza gruesa gris-marrón fisurada, follaje pinnado parcialmente caduco en estación seca. Hojas grandes (25-60 cm) alternas-pinnadas con 9-25 folíolos elípticos-lanceolados verde-brillante. Flores pequeñas blanco-verdosas perfumadas en panículas terminales largas (30-50 cm) polinizadas por abejas, mariposas y mosquitas-de-las-flores. Frutos drupa elipsoide grande (6-10 cm largo, 3-6 cm ancho, 100-400 g) — frutos significativamente más grandes que sus hermanas Spondias americanas —, cáscara firme amarillo-dorada-anaranjada al madurar, pulpa amarillo-clara firme jugosa-aromática aroma único intermedio entre piña-mango-manzana-ciruela-vainilla (15-18 °Brix maduro), con un hueso grande fibroso-espinoso característico (la masa fibrosa rodea el hueso interno y forma una \"red espinosa\" alrededor — adaptación de dispersión por mamíferos grandes del origen oceánico polinesio). Frutos consumidos en madurez para fruta fresca y a medio madurar (verde-amarillentos) para encurtidos, ensaladas tropicales y bebidas refrescantes (en Brasil y Caribe se hace \"suco de cajá-manga\" famoso). Manejo: plantación a 10-12 m, ideal en patios tropicales caribeños y de valles cálidos, asocio con mango, aguacate, anón, mamey amarillo, níspero, papayo, plátano. Función pedagógica destacada: enseña a niñas y niños (1) BIOGEOGRAFÍA de Spondias — el género tiene origen pantropical con tres centros principales (Sudamérica neotropical jobo S. mombin, Mesoamérica ciruela S. purpurea, Oceanía polinesia ambarella S. dulcis — todos llegaron a Colombia por rutas distintas y en épocas distintas), (2) HISTORIA de la dispersión postcolombina de cultivos por expediciones europeas (Cook, Bligh) entre Oceanía y América-Caribe — lección de historia botánica colonial, (3) adaptación de hueso fibroso-espinoso como dispersión por mamíferos grandes terrestres (en Polinesia: cerdos, ratas; en Neotrópico naturalizado: tapires, dantas, zaínos, monos), (4) familia Anacardiaceae frutales globales (mango Mangifera, marañón Anacardium, jobo Spondias mombin, ciruela Spondias purpurea, ambarella Spondias dulcis, pistacho Pistacia) y (5) por qué se llama \"cajá-manga\" en Brasil — porque combina caracteres de cajá (S. mombin nativo neotropical, fruta pequeña) y de manga (Mangifera indica asiática, fruta grande aromática) en un solo fruto. Fuentes Tier A: GBIF, POWO Kew, Pérez Arbeláez 1947, SiB Colombia, Bernal 2015, AGROSAVIA, FAO Ecocrop.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "swietenia_macrophylla",
+      "nombre_comun": "Caoba andina",
+      "nombre_cientifico": "Swietenia macrophylla King",
+      "familia_botanica": "Meliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 1000,
+        "max_absoluto": 1400
+      },
+      "temperatura_c": {
+        "helada_letal": 6,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cariniana_pyriformis",
+        "cedrela_odorata",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "inga_edulis",
+        "ochroma_pyramidale"
+      ],
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "uicn-red-list",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "sinchi-amazonia-colombiana"
+      ],
+      "valor_pedagogico": "La caoba andina o caoba de hoja grande (Swietenia macrophylla King, Meliaceae) es uno de los árboles maderables más patrimoniales y más amenazados del mundo. Su madera rojiza fina veteada es considerada históricamente la más preciada para ebanistería de lujo, mueblería patrimonial, instrumentos musicales (guitarras clásicas, pianos), construcción naval clásica y altares de iglesias coloniales. Nativa de Mesoamérica y Sudamérica tropical, en Colombia se distribuye en bosques húmedos tropicales de baja altitud en la Amazonía (piedemonte caqueteño, putumayense, amazonense), valle medio del Magdalena (Antioquia, Santander, Bolívar, Cesar) y Pacífico chocoano y vallecaucano entre 0 y 1.000 msnm en zona térmica cálida muy húmeda. Árbol siempreverde gigante que puede alcanzar 30-50 m de altura con fuste recto cilíndrico de hasta 2 m de diámetro y contrafuertes basales, copa amplia hemisférica emergente del dosel, hojas pinnadas con folíolos lanceolados grandes (de ahí 'macrophylla'), flores pequeñas blanco-amarillentas en panículas axilares, cápsulas leñosas grandes erectas dehiscentes en 4-5 valvas que liberan numerosas semillas aladas dispersadas por viento. ALERTA CONSERVACIÓN: categorizada EN PELIGRO (EN) en la Lista Roja de IUCN y listada en CITES Apéndice II por sobreexplotación maderera histórica desde la época colonial: poblaciones silvestres reducidas en >80% del rango original en Colombia, su comercio internacional requiere permisos CITES y su aprovechamiento doméstico requiere autorización del Ministerio de Ambiente. Aparece en Libro Rojo Plantas Colombia (Cárdenas & Salinas 2007). El cultivo agroforestal y plantaciones bajo dosel residual son la principal alternativa para reducir presión sobre poblaciones silvestres y son promovidos por Sinchi en la Amazonía colombiana. Comparte con Cedrela odorata el principal limitante silvicultural: el barrenador Hypsipyla grandella (Pyralidae) perfora la yema apical y deforma el fuste en plantaciones puras a plena exposición, pero el asocio con cacao o bajo dosel residual reduce hasta 70% el daño. Crecimiento lento-moderado, turno comercial 30-50 años para diámetros >50 cm. Manejo agroecológico: sólo semilla certificada de procedencia conocida, vivero a sombra 60% por 6-8 meses, plantación bajo dosel residual o asociada a cacao, podas de formación años 2-5, raleos progresivos años 10-20-30. Es lección crítica de conservación maderera: la madera que su tatarabuelo aprovechaba libremente del bosque amazónico hoy está protegida internacionalmente por la presión exterminadora del mercado global, y plantar caoba en su huerto agroforestal es un acto de soberanía y de reparación con la selva. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, IUCN Red List, CITES Apéndice II, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF, Sinchi Amazonía Colombiana.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Caoba"
+      ]
+    },
+    {
+      "id": "tabebuia_chrysantha",
+      "nombre_comun": "Guayacán amarillo",
+      "nombre_cientifico": "Tabebuia chrysantha (Jacq.) G.Nicholson",
+      "familia_botanica": "Bignoniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "bombacopsis_quinata",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "inga_edulis",
+        "tabebuia_rosea"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "libro-rojo-plantas-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El guayacán amarillo o araguaney (Tabebuia chrysantha (Jacq.) G.Nicholson, sinónimo válido Handroanthus chrysanthus, Bignoniaceae) es el complemento cromático del ocobo rosado en el paisaje patrimonial colombiano-venezolano: mientras T. rosea cubre los pueblos de flores rosadas, T. chrysantha los cubre de un amarillo dorado intenso espectacular. Nativo del Neotrópico, en Colombia se distribuye en bosques húmedos a secos tropicales y premontanos de las regiones Caribe (Sucre, Córdoba, Bolívar, Magdalena, Cesar, Guajira), Andina (valles interandinos del Magdalena, Cauca y Patía, piedemontes en Antioquia, Santander, Norte de Santander, Cundinamarca, Tolima, Huila, Caldas, Risaralda, Quindío, Valle, Cauca, Nariño), Pacífico (Valle, Chocó, Nariño) y Orinoquía (Casanare, Meta) entre 0 y 1.800 msnm en zona térmica cálida a templada. Árbol caducifolio de 10-25 m de altura con fuste recto y copa abierta hemisférica, hojas opuestas palmaticompuestas con 5 folíolos elípticos pubescentes, flores tubulares amarillo dorado intenso de 5-8 cm en panículas terminales densas durante estación seca (enero-marzo Andes, diciembre-marzo Caribe), tras pérdida total de hojas el árbol queda como un sol vegetal incandescente. Es flor patrimonial nacional de Venezuela (donde se llama araguaney, declarado árbol nacional desde 1948), íntimamente ligado a la cultura andina venezolana y colombiana fronteriza (Norte de Santander, Arauca, Vichada, Guainía). Su madera es una de las más duras y resistentes del Neotrópico, con densidad >1 g/cm³, color amarillo-marrón a verdoso, apreciada para postes, durmientes ferroviarios, vigas estructurales, construcción rural pesada, ebanistería y tornería; sirve incluso como sustituto del bossier africano en herramientas. Más rústico que T. rosea: tolera suelos pedregosos, sequía estacional severa de hasta 5-6 meses, suelos delgados de laderas calcáreas y arenosos, lo que lo convierte en pionera ideal para restauración de bosque seco tropical en Caribe colombiano (Montes de María, Serranía Perijá) y valles interandinos secos del Patía y Magdalena. En sistemas agroforestales acepta densidades 80-150 árb/ha como sombrío cafetalero estético-productivo. Manejo agroecológico: propagación por semilla recién recolectada con germinación rápida (10-20 días), vivero al sol parcial, plantación definitiva a 30-40 cm, podas de formación años 1-3, tolera podas urbanas anuales. Es lección viva de fenología tropical y soberanía paisajística: la floración masiva sincrónica disparada por estrés hídrico permite ver el ritmo estacional del trópico marcado por floración en vez de hojas; y plantar guayacán amarillo nativo en arbolado urbano provee la misma espectacularidad estética que el cerezo japonés sin las exigencias hídricas o climáticas exóticas. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, Trees of Antioquia, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "theobroma_bicolor",
+      "nombre_comun": "Cacao blanco",
+      "nombre_cientifico": "Theobroma bicolor Humb. & Bonpl.",
+      "familia_botanica": "Malvaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 1000,
+        "max_absoluto": 1400
+      },
+      "temperatura_c": {
+        "helada_letal": 10,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "bactris_gasipaes",
+        "musa_paradisiaca",
+        "oenocarpus_mapora",
+        "theobroma_grandiflorum"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "sinchi-amazonia-colombiana",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "El cacao blanco, bacao o patashte (Theobroma bicolor Humb. & Bonpl., familia Malvaceae — antes Sterculiaceae) es un frutal nativo neotropical hermano del cacao común (Theobroma cacao — ya en catálogo) distribuido desde el sur de México (Chiapas — patashte maya) por Centroamérica (Guatemala, Belice, Honduras), Colombia (Chocó biogeográfico: Chocó, Valle del Cauca pacífico — Bajo Calima, Cauca pacífico, Nariño pacífico; Amazonia: Leticia, Caquetá, Putumayo, Vaupés, Guaviare, Amazonas; piedemonte llanero del Meta y Casanare), Ecuador, Perú amazónico, Venezuela amazónica y Brasil amazónico, entre 0 y 1.400 msnm en bosque húmedo tropical. Es PEDAGÓGICAMENTE EXCELENTE como lección viva de manejo ancestral por parte de las CULTURAS PREHISPÁNICAS MAYAS (patashte ceremonial mencionado en Popol Vuh y códices), los pueblos indígenas amazónicos TIKUNA (trapecio amazónico — Leticia, Puerto Nariño), HUITOTO/MUINANE/BORA (medio Caquetá-Putumayo donde se considera 'cacao de monte' sagrado), YAGUA, COFAN, INGA del piedemonte amazónico, y EMBERA (Dóbida, Chamí, Katío) y WOUNAAN del Pacífico chocoano, así como por las COMUNIDADES AFROCOLOMBIANAS del Chocó (Cocomacia, Acadesan, consejos comunitarios del Bajo Atrato, San Juan, Baudó, Buenaventura, Guapi, Tumaco) que durante siglos lo han manejado como 'bacao' en sistemas agroforestales tradicionales — frecuentemente intercalado con cacao común (T. cacao), copoazú (T. grandiflorum — ya en catálogo), borojó (Borojoa patinoi y B. sorbilis), chontaduro (Bactris gasipaes), don pedrito (Oenocarpus mapora) y plátano (Musa spp.). Pertenece al género Theobroma (Malvaceae, subfamilia Byttnerioideae) junto a T. cacao, T. grandiflorum (copoazú), T. subincanum (cacao de monte), T. speciosum y T. obovatum. Árbol de 8-15 m altura con tronco recto cilíndrico, hojas alternas elípticas-ovaladas 20-30 cm verde-oscuras coriáceas con envés blanquecino-tomentoso (característica diagnóstica — de ahí 'bicolor'), inflorescencias caulifloras (flores directamente sobre tronco y ramas gruesas — fenómeno caulifloría como en T. cacao) con flores pequeñas blanco-rosadas polinizadas por mosquitas Forcipomyia (Ceratopogonidae), fruto cápsula leñosa elipsoidal-oblonga 15-30 cm largo x 8-15 cm ancho con cáscara dura amarilla-anaranjada cuando madura conteniendo 30-50 semillas inmersas en pulpa blanca-cremosa dulce-acidulada aromática. Diferencias con T. cacao: fruto más grande, cáscara amarilla (no roja-purpúrea), pulpa más dulce-aromática (perfil mango-piña-cacao), semillas más grandes y de uso menos chocolatero (más para harina y pulpa fresca); diferencias con T. grandiflorum: pulpa más dulce (no tan ácida), fruto menos elongado, hojas con envés tomentoso (vs envés glabro en grandiflorum). USOS: pulpa fresca consumida directamente, en jugos, helados, mermeladas, dulces; semillas tostadas y molidas dan bebida 'patashte' o 'chicha de bacao' (tradición maya y amazónica) similar al chocolate pero más ligera; semillas también consumidas tostadas como 'pepas' (similar a almendras); cáscara como abono y forraje. Manejo agroecológico: requiere sombra parcial 40-60% (igual que T. cacao); siembra a 5-7 m entre plantas; asocio con cacao, plátano, copoazú, borojó, palmas en sistema agroforestal multiestrato; tolerancia mayor a humedad alta que T. cacao (resistente a monilia y escoba de bruja); cosecha cuando el fruto suene hueco al golpe. Función en chagra/agroforestal pacífica y amazónica como cosecha comunitaria sostenible, conservación de género Theobroma neotropical, diversificación de cadena cacaotera (mercado especialidad 'cacao blanco' creciente), banco genético prehispánico mesoamericano-amazónico. Fuentes Tier A: POWO Kew, GBIF, Sinchi, IIAP Pacífico, Cárdenas-Salinas frutales amazónicos, AGROSAVIA Pacífico, Bernal 2015.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "trifolium_repens",
+      "nombre_comun": "Trébol blanco",
+      "nombre_cientifico": "Trifolium repens L.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "ground_cover",
+        "nitrogen_fixer",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "medio",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra al voleo; crea una alfombra densa que evita la erosión en los caminos de la finca chiguana."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "avena_sativa",
+        "festuca_arundinacea",
+        "lolium_perenne",
+        "medicago_sativa",
+        "prunus_domestica_ciruela_imperial",
+        "zea_mays"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-forrajeras-2022"
+      ],
+      "valor_pedagogico": "El trébol blanco (Trifolium repens L.) se distribuye en Colombia principalmente en departamentos andinos como Cundinamarca, Boyacá y Nariño entre 1000 y 3200 msnm en zonas térmicas frías. Su manejo agronómico incluye propagación por semilla al voleo, formando una alfombra densa que previene la erosión, con ciclo perenne y asociaciones beneficiosas con aliso (Alnus acuminata) y maíz (Zea mays) para fijación de nitrógeno. En contextos campesinos andinos, se utiliza como cobertura viva en caminos de finca para mejorar la estructura del suelo y reducir compactación. Según el backbone taxonómico de GBIF y Plants of the World Online (POW0), esta leguminosa forrajera destaca por su valor ecológico en sistemas agroforestales de montaña.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "trébol"
+      ]
+    },
+    {
+      "id": "vaccinium_corymbosum_emerald",
+      "nombre_comun": "Arándano Emerald",
+      "nombre_cientifico": "Vaccinium corymbosum 'Emerald'",
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1700,
+        "optimo_max": 2400,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 15,
+        "optimo_max": 25,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Variedad vigorosa con baja necesidad de frío (low-chill); ideal para las etapas de transición climática en Choachí."
+      },
+      "companions": [
+        "vaccinium_corymbosum_biloxi"
+      ],
+      "source_ids": [
+        "agrosavia-manual-arandano-2018",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El arándano azul variedad Emerald (Vaccinium corymbosum L. cv. Emerald, tipo southern highbush bush) es un cultivo de creciente expansión agroindustrial en Colombia con destino exportación y mercados gourmet. Se cultiva en Cundinamarca (Sabana Bogotá), Boyacá altiplano, Antioquia y Nariño entre 2.000 y 2.800 msnm en zona térmica fría a templada. Crítico requerimiento: suelos ácidos pH 4.5-5.5 con MO >5%, drenaje excelente, riego goteo constante. Productividad comercial a partir del 3er año, ciclo productivo 12-15 años. Manejo agroecológico: cama elevada con sustrato modificado (turba + corteza pino + virutas), mulch ácido (aserrín de pino), fertilización orgánica con compost ácido + harina de sangre, baja densidad de plantación (4×3 m). Fuentes Tier A: AGROSAVIA Manual Arándano 2018, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "vallea_stipularis",
+      "nombre_comun": "Raque",
+      "nombre_cientifico": "Vallea stipularis L. f.",
+      "familia_botanica": "Elaeocarpaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2500,
+        "optimo_max": 3200,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 8,
+        "optimo_max": 16,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "bocconia_frutescens",
+        "clusia_multiflora",
+        "escallonia_pendula",
+        "morella_pubescens",
+        "viburnum_tinoides"
+      ],
+      "source_ids": [
+        "humboldt-flora-alto-andina",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "Arbol nativo del bosque alto andino. Sus flores rosadas alimentan colibries y abejas nativas. Madera usada tradicionalmente para herramientas rurales. Especie ideal para restauracion de bordes de paramo.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "vanilla_planifolia",
+      "nombre_comun": "Vainilla",
+      "nombre_cientifico": "Vanilla planifolia Jacks. ex Andrews",
+      "familia_botanica": "Orchidaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 600,
+        "max_absoluto": 1000
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Propagacion por esquejes de tallo. Orquidea trepadora que requiere arbol tutor (espaldera viva). Requiere polinizacion manual para produccion comercial de vainas aromaticas."
+      },
+      "companions": [
+        "musa_paradisiaca",
+        "theobroma_cacao"
+      ],
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "sinchi-amazonia-colombiana",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "La vainilla (Vanilla planifolia Jacks. ex Andrews, familia Orchidaceae) es una orquídea epífita trepadora hemiepifítica nativa de Mesoamérica (México y Centroamérica), naturalizada y con poblaciones silvestres reconocidas en Colombia (Amazonas, Putumayo, Vaupés, Caquetá, Magdalena medio, Chocó), cultivada en sistemas agroforestales tropicales como fuente del aroma natural más apreciado del mundo. Sus vainas (cápsulas dehiscentes mal llamadas frutos) concentran vainillina (3-metoxi-4-hidroxibenzaldehído), piperonal y centenares de compuestos aromáticos que solo se desarrollan tras el curado fermentativo de 3-6 meses post-cosecha (sudado, secado, condicionado), proceso bioquímico clave del beneficio tradicional. En su hábitat natural mexicano es polinizada exclusivamente por abejas Euglossini (Eulaema, Euglossa) ausentes en cultivos colombianos, lo que obliga a la polinización manual flor por flor durante el breve período de receptividad (una mañana al amanecer) usando una astilla de bambú, técnica desarrollada por Edmond Albius en 1841 que democratizó el cultivo mundial. Se cultiva en clima cálido húmedo entre 0 y 1.000 msnm con sombra parcial 50-70%, sustrato rico orgánico de drenaje rápido y tutor vivo (árbol espaldera). Lección viva: la vainilla enseña la relación simbiótica entre orquídeas y polinizadores nativos (coevolución mutualista altamente especializada), la fragilidad del servicio ecosistémico de polinización cuando se desplaza el cultivo de su hábitat original, la técnica tradicional de beneficio del fruto aromático que transforma una vaina inodora en el aroma del chocolate, helados y reposterías del mundo, y el valor de los sistemas agroforestales tropicales como conservadores de biodiversidad y proveedores de productos no maderables de alto valor. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO EcoCrop, SINCHI Amazonia Colombiana, Bernal 2015 Catálogo Plantas Colombia, Pérez Arbeláez 1947 Plantas Útiles.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "vasconcellea_pubescens",
+      "nombre_comun": "Papayuela / Papayo de monte",
+      "nombre_cientifico": "Vasconcellea pubescens A.DC.",
+      "familia_botanica": "Caricaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Planta dioica (individuos macho y hembra); requiere un macho por cada 5-8 hembras para polinizacion. Crecimiento rapido, vida corta (4-6 años)."
+      },
+      "companions": [
+        "acca_sellowiana",
+        "physalis_peruviana"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-colombia",
+        "agrosavia-tibaitata"
+      ],
+      "valor_pedagogico": "La papayuela o papayo de monte (Vasconcellea pubescens A.DC., familia Caricaceae) es una caricácea arbustiva-arbórea perenne dioica (plantas separadas masculinas y femeninas) nativa del bosque altoandino colombiano, cultivada tradicionalmente por comunidades campesinas cundiboyacenses como frutal de altura y memoria culinaria de cocina tradicional. Produce frutos elipsoides pequeños amarillo-anaranjados (8-15 cm) aromáticos pero NO comestibles en crudo por su látex blanco rico en papaína y carpaína; requieren cocción en almíbar de panela para neutralizar el látex y desarrollar su sabor característico. Se cultiva en Boyacá (Tibasosa, Duitama, Paipa, Tunja), Cundinamarca (Sumapaz, Chocontá, Subachoque, Sopó, La Calera), Nariño (Pasto, Yacuanquer) y Cauca entre 1.800 y 3.000 msnm en zona térmica templada a fría. Ciclo 18-24 meses a primera cosecha, productiva 5-8 años. Rendimientos 20-40 kg/planta/año. Lección viva pedagógica: la papayuela enseña con ejemplo visible la dioecia (sistema sexual donde existen plantas estrictamente masculinas — solo flores polinizadoras — y plantas femeninas — solo frutos), concepto botánico fundamental para entender el manejo de huertos con mínimo 1 macho cada 8-10 hembras. Sus frutos cocidos en almíbar son memoria viva de la cocina tradicional cundiboyacense (postre dominical campesino con queso campesino fresco). Manejo agroecológico: siembra por semilla (germinación 2-3 semanas), trasplante a sitio definitivo a los 6 meses, asocio con uchuva y feijoa, poda formativa anual. Fuentes Tier A: AGROSAVIA Frutales Andinos, POWO Kew, SIB Colombia, NRC 1989 Lost Crops of the Incas, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Papayuela"
+      ]
+    },
+    {
+      "id": "viburnum_tinoides",
+      "nombre_comun": "Juco / Sietecueros (árbol)",
+      "nombre_cientifico": "Viburnum tinoides L. f.",
+      "familia_botanica": "Adoxaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 7,
+        "optimo_max": 15,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clethra_fagifolia",
+        "hesperomeles_goudotiana",
+        "sambucus_peruviana",
+        "vallea_stipularis"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "jbb-plantas-medicinales",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Viburnum tinoides L. f. (juco, sietecueros arbóreo, garrocho — familia Adoxaceae, antes Caprifoliaceae) es un árbol pequeño a mediano (4-12 m altura) perennifolio nativo de los Andes del norte de Sudamérica (Colombia, Ecuador, Venezuela, Perú), distribuido en el bosque alto andino entre 1800 y 3200 msnm en piso térmico FRÍO de los departamentos de Cundinamarca, Boyacá, Antioquia, Nariño, Cauca y Santander. Es reconocible por sus hojas opuestas verde-lustrosas con nerviación pinnada marcada, sus inflorescencias terminales en corimbo de flores blanco-crema (15-25 cm de diámetro) que floran masivamente en agosto-octubre, y sus frutos drupáceos pequeños negro-azulados muy buscados por avifauna alto-andina (mirlas, semilleros, atrapamoscas, copetones andinos). El nombre 'juco' es de origen muisca-chibcha (Cundinamarca-Boyacá) y se mantiene en topónimos como Jucal y Jucales — pueblos cuya historia agrícola está ligada al bosque de jucal. El nombre 'sietecueros' es polisémico — se usa también para Tibouchina lepidota (Melastomataceae arbórea, flor morada) y para varias herbáceas con corteza exfoliante; aquí refiere específicamente al Viburnum tinoides (NO la confusión es importante destacarla en educación botánica de campo). Lección viva sobre BOTÁNICA NATIVA DEL BOSQUE ALTO ANDINO, NOMBRES POPULARES POLISÉMICOS y RESTAURACIÓN DE BORDES DE BOSQUE: el juco/sietecueros es especie clave para reconectar fragmentos boscosos en la Sabana de Bogotá, el altiplano cundiboyacense, el altiplano nariñense y la Cordillera Central, ya que tolera tanto sombra parcial (interior de bosque) como sol pleno (borde de bosque) — esta plasticidad lo hace ideal para los proyectos de restauración del flanco oriental de la Cordillera Oriental (Cruz Verde-Sumapaz, Chingaza, Iguaque, Guerrero) donde se busca densificar la matriz de pastura abandonada con corredores florales. Manejo agroecológico: propagación principal por esqueje semileñoso con AIB (60-80% enraizamiento), semilla también viable con estratificación fría; trasplante 4-6 meses; plantación 12-15 meses; crecimiento moderado 40-60 cm/año; asocio con sauco peruano (Sambucus peruviana), raque (Vallea stipularis), mortiño (Hesperomeles goudotiana); densidades 300-500 ind/ha en restauración, ornamental nativo en huertos alto-andinos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, JBB Plantas Medicinales, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)",
+      "nombre_comunes_regionales": [
+        "Juco"
+      ]
+    },
+    {
+      "id": "viburnum_triphyllum",
+      "nombre_comun": "Garrocho",
+      "nombre_cientifico": "Viburnum triphyllum Benth.",
+      "familia_botanica": "Adoxaceae",
+      "category": "cercas_vivas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "living_fence",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 3100
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 10,
+        "optimo_max": 16,
+        "max_tolerable": 24
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Dispersado por aves; los frutos son fuente de alimento para fauna silvestre."
+      },
+      "companions": [
+        "quercus_humboldtii"
+      ],
+      "antagonists": [
+        "acacia_melanoxylon"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El garrocho (Viburnum triphyllum Benth.) es una especie nativa de los Andes colombianos, presente en departamentos como Cundinamarca, Boyacá, Antioquia y Santander entre 1800 y 3100 msnm en zonas térmicas frías, particularmente en estratos alto y medio. Su manejo agronómico incluye propagación principalmente por semilla, con ciclos de floración entre octubre y enero y fructificación posterior, dispersada por aves que consumen sus frutos azules-negros, formando parte de sistemas de cerca viva perenne donde se asocia beneficiosamente con especies como Quercus humboldtii mientras actúa como antagonista natural de la acacia negra (Acacia melanoxylon), reduciendo la necesidad de control químico. En el contexto campesino andino, esta planta ha sido tradicionalmente utilizada por comunidades Muisca en la establecimiento de linderos vivos que protegen cultivos y proporcionan refugio para fauna silvestre, particularmente aves frutívoras como tangaras y tucanes, cuya presencia indica buen estado ecológico del sistema. Según la taxonomía verificable en GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Viburnum triphyllum Benth.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "vicia_sativa",
+      "nombre_comun": "Veza común",
+      "nombre_cientifico": "Vicia sativa L.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "ground_cover",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2600,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Ideales para abonos verdes de ciclo corto entre periodos de cultivo de hortalizas."
+      },
+      "companions": [
+        "avena_sativa",
+        "brassica_rapa_rapifera",
+        "chenopodium_quinoa",
+        "phacelia_tanacetifolia",
+        "raphanus_sativus_oleifer",
+        "zea_mays"
+      ],
+      "antagonists": [
+        "allium_sativum"
+      ],
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "fao-ecocrop",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La veza común (Vicia sativa L.) es una leguminosa anual ampliamente utilizada en Colombia como abono verde, cobertura suelo, forraje y mejorador de fertilidad por su capacidad fijadora de nitrógeno (~80-120 kg N/ha por simbiosis con Rhizobium). Se siembra en zonas frías y templadas: altiplano cundiboyacense, Nariño, Antioquia y eje cafetero entre 1.500 y 3.000 msnm en zona térmica fría a templada. Ciclo 90-130 días. Tolera heladas moderadas y suelos pobres en N. Manejo agroecológico: siembra al voleo en pre-cultivo (30-50 kg/ha), incorporación en floración para maximizar aporte N, asocio con cereales (avena, cebada) para soporte estructural (cultivo en mezcla 70:30), rotación pre-papa o pre-hortalizas exigentes. Fuentes Tier A: AGROSAVIA, NRC 1989, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "viola_odorata",
+      "nombre_comun": "Violeta perfumada",
+      "nombre_cientifico": "Viola odorata L.",
+      "familia_botanica": "Violaceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 8,
+        "optimo_max": 20,
+        "max_tolerable": 24
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "estolon",
+        "notas": "División de matas con estolones radicantes (método principal, más rápido y fiable). Alternativa por semilla con estratificación fría 4-6 semanas. Plantación en sombra parcial o filtrada, distancia 20 cm. Floración invierno-primavera fría andina."
+      },
+      "companions": [
+        "fragaria_vesca",
+        "mentha_spicata"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La Violeta perfumada (Viola odorata L., Violaceae) es una especie herbácea perenne rastrera originaria de Europa, norte de África y Asia occidental templadas, cultivada mundialmente desde la antigüedad clásica greco-romana como planta ornamental aromática, medicinal y comestible. Su perfume floral característico —dulce, intenso, ligeramente almizclado— es uno de los aromas más antiguos de la perfumería: ya los griegos y romanos la cultivaban para coronas, perfumes y confituras, y es base del célebre \"absolu de violette\" de la perfumería moderna francesa. Distinta de V. tricolor (anual de flor tricolor visiblemente vistosa) por ser perenne, rastrera con estolones radicantes, hojas reniforme-cordadas y flores violeta-azuladas oscuras muy pequeñas pero intensamente perfumadas. En Colombia se cultiva en clima frío y templado entre 1.800 y 3.000 msnm: jardines de Sabana de Bogotá, Boyacá, Antioquia oriente frío, Eje Cafetero altoandino. Manejo agronómico: propagación principal por división de matas con estolones radicantes (método más rápido, fiable y predecible), alternativa por semilla con estratificación fría 4-6 semanas a 5°C para romper dormancia, plantación en sombra parcial o filtrada bajo árboles caducifolios o frutales, distancia 20 cm entre plantas, suelo rico en materia orgánica con buen drenaje, floración invierno-primavera fría andina (noviembre-febrero), expansión vegetativa por estolones formando alfombra densa. Sus flores son comestibles cristalizadas en azúcar (clásicas violetas de Toulouse francesas), perfumando pasteles, helados, jaleas, vinagretas, jarabes, licores tradicionales. Uso medicinal tradicional documentado por Dioscórides, Plinio, farmacopeas europeas medievales y la medicina tradicional europea: flor y hoja contienen ácido salicílico (precursor natural de la aspirina), saponinas, mucílagos, antocianinas; infusión de flor expectorante para bronquitis y tos seca, jarabe pectoral pediátrico tradicional (\"sirop de violettes\"), uso externo para irritaciones cutáneas. Atracción de polinizadores: abejas pequeñas (Apis mellifera, abejas solitarias), abejorros (Bombus spp.), mariposas pequeñas y sírfidos en clima frío andino, especie temprana de floración que provee néctar y polen cuando pocas otras flores están disponibles. Curiosamente produce dos tipos de flores: las visibles violetas perfumadas (chasmógamas, polinización abierta cruzada) y flores cleistógamas autopolinizantes ocultas cerca del suelo que aseguran semilla incluso sin polinizadores (estrategia evolutiva ingeniosa). Manejo en huerta agroecológica: cobertura viva bajo árboles frutales (sotobosque productivo), asociación con fresa y menta (consorcio aromático andino), siembra en jardín de sombra parcial, cosecha de flores en mañana fresca para uso culinario o medicinal inmediato. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Pamplona Roger 2006 Plantas Medicinales, JBB Plantas Medicinales.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "vismia_baccifera",
+      "nombre_comun": "Manzanita",
+      "nombre_cientifico": "Vismia baccifera (L.) Triana & Planch.",
+      "familia_botanica": "Hypericaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "biomass_producer",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 200,
+        "optimo_min": 1000,
+        "optimo_max": 1800,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 16,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "cecropia_telealba",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "inga_edulis"
+      ],
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "perez-arbelaez-1947-plantas-utiles",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "valor_pedagogico": "La manzanita o sangre de drago (Vismia baccifera, Hypericaceae) es una de las especies pioneras más importantes y emblemáticas del bosque tropical y subandino neotropical colombiano, distribuida desde el nivel del mar hasta los 2.000 msnm en toda la región Andina, piedemonte amazónico, piedemonte llanero, Caribe y Pacífico colombiano. Árbol pionero mediano de 6-12 metros de altura con copa redondeada, fuste corto y corteza rojiza fina que al cortarse exuda abundante látex anaranjado-rojo característico conocido tradicionalmente como 'sangre de drago' (no confundir con la sangre de drago amazónica Croton lechleri ni con el sangre de drago canario Dracaena draco —tres plantas filogenéticamente distintas con látex rojo coincidentemente usado tradicionalmente como cicatrizante); hojas opuestas elípticas-lanceoladas verde oscuro con glándulas oleíferas oscuras puntiformes características de la familia Hypericaceae (parente botánico cercano al hipérico Hypericum perforatum medicinal europeo), flores blanco-cremas con estambres dorados conspicuos en cimas terminales atractoras de polinizadores nativos, drupas rojas pequeñas dulces consumidas masivamente por aves frugívoras del bosque tropical y subandino (mirlas, tángaras, eufonias, manakines). Su rol ecológico es ser una de las pioneras estructurales más importantes del bosque tropical y subandino neotropical: coloniza rápidamente claros, deslizamientos, áreas quemadas, potreros en abandono y bordes de bosque, donde establece un dosel pionero de 5-10 años bajo el cual germinan y se establecen las especies del dosel maduro intermedio y final, facilitando la sucesión ecológica completa hacia bosque secundario en 15-25 años. Esto la convierte en una de las especies más utilizadas en programas de restauración ecológica neotropical entre 200 y 2.000 msnm. Su látex anaranjado-rojo es uno de los remedios tradicionales más conocidos del campo colombiano: aplicación tópica directa a heridas, cortes, hongos en la piel (pie de atleta), llagas y úlceras dérmicas, con propiedades reales documentadas en farmacognosia moderna (compuestos bencénicos como vismione, friedelina y antraquinonas con actividad antimicrobiana, antifúngica y cicatrizante). Como árbol de sombrío pionero temporal en cafetales y cacaotales del piso templado-cálido (1.000-1.800 msnm) aporta función nodriza nutritiva los primeros años de establecimiento del cultivo permanente, antes de ser raleado en favor del dosel maduro definitivo (Cedrela, Cordia, Inga). Es lección de farmacognosia popular y ecología de sucesión: revalorizar las especies pioneras nativas del bosque tropical colombiano —Vismia, Cecropia, Croton, Trema, Heliocarpus— en programas de restauración ecológica y como medicinas tradicionales accesibles, fortalece la soberanía botánica rural y reduce la dependencia de tratamientos farmacéuticos importados para problemas dérmicos básicos. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, Pérez-Arbeláez 1947 Plantas Útiles Colombia, POWO Kew Hypericaceae, GBIF Backbone Taxonomy, monografías Gentry 1993 Vismia Neotropical, Cenicafé manuales sombrío pionero cafetero.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "weinmannia_microphylla",
+      "nombre_comun": "Encenillo de hoja menuda",
+      "nombre_cientifico": "Weinmannia microphylla Kunth",
+      "familia_botanica": "Cunoniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "windbreak",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2500,
+        "optimo_max": 3200,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 5,
+        "optimo_max": 13,
+        "max_tolerable": 20
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "polylepis_quadrijuga",
+        "weinmannia_pubescens",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Weinmannia microphylla Kunth (encenillo de hoja menuda, miconcillo — familia Cunoniaceae) es un árbol pequeño (4-10 m altura) nativo de los Andes (Colombia, Ecuador, Venezuela), distribuido en bosque alto andino y franja de transición a subpáramo entre 2200 y 3500 msnm en piso térmico FRÍO con tolerancia a heladas fuertes (-10°C). En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca y Santander. Es la tercera especie del complejo de encenillos Weinmannia presente en Chagra (junto con W. tomentosa y W. pubescens) — y la más especializada en la franja SUPERIOR del bosque alto andino-subpáramo, donde el viento, las heladas y la radiación UV intensa son los limitantes ecológicos dominantes. Sus FOLIOLOS DIMINUTOS (3-8 mm cada uno) son adaptación XEROFÍTICA-CRIOTOLERANTE — la pequeñez de la lámina foliar reduce la superficie expuesta al viento y a la pérdida hídrica por transpiración, una estrategia compartida con las queñoas (Polylepis quadrijuga, P. sericea), con los frailejones (Espeletia spp.) y con los chuscales (Chusquea tessellata) que dominan el subpáramo de Cruz Verde-Sumapaz, Chingaza e Iguaque. Lección viva sobre ESPECIALIZACIÓN ALTITUDINAL EN UN GÉNERO, ADAPTACIONES XEROFÍTICAS-CRIOTOLERANTES y RESTAURACIÓN DE FRANJA SUPERIOR DE BOSQUE: el complejo de encenillos Weinmannia en Colombia ilustra paradigmáticamente cómo un género se especializa altitudinalmente — W. tomentosa y W. pubescens dominan la franja 2000-3000 msnm (bosque alto andino central), W. microphylla domina la franja superior 2800-3500 msnm (bosque alto andino-subpáramo) — y juntas forman un MOSAICO ESTRUCTURAL que protege la cabecera de cuenca de los acueductos abastecedores de Bogotá (Chingaza-Sumapaz), Tunja (Iguaque) y Pasto (Galeras-Azufral). Su plantación en la franja superior junto con queñoa (Polylepis quadrijuga), encenillo común (W. tomentosa), encenillo pubescente (W. pubescens) y mano de oso (Oreopanax incisus) reconstruye el bosque-enano de transición — esencial para la regulación hídrica y la protección del páramo. Manejo agroecológico: propagación por semilla fresca con sombra parcial 60% e inoculación micorrízica; trasplante 5-7 meses; plantación 12-18 meses; crecimiento 40-60 cm/año; asocio con queñoa y otros encenillos; densidades 300-500 ind/ha; cortavientos vivos para protección anti-heladas el primer año. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
+    },
+    {
+      "id": "weinmannia_pubescens",
+      "nombre_comun": "Encenillo pubescente",
+      "nombre_cientifico": "Weinmannia pubescens Kunth",
+      "familia_botanica": "Cunoniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
+        "optimo_max": 3000,
+        "max_absoluto": 3300
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 7,
+        "optimo_max": 14,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [
+        "clusia_multiflora",
+        "weinmannia_microphylla",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [
+        "eucalyptus_globulus",
+        "pinus_patula"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "Weinmannia pubescens Kunth (encenillo pubescente, encino pubescente — familia Cunoniaceae) es un árbol perennifolio (8-18 m altura) nativo de los Andes (Colombia, Ecuador, Venezuela, Perú), distribuido en bosque alto andino entre 2000 y 3300 msnm en piso térmico FRÍO. En Colombia se encuentra en Cundinamarca, Boyacá, Antioquia, Nariño, Cauca y Santander. Es ESPECIE HERMANA de Weinmannia tomentosa L. f. (encenillo común, ya catalogada en Chagra) pero distinguible por la PUBESCENCIA MÁS DENSA Y BLANQUECINA DE LOS FOLIOLOS (W. pubescens) vs la pubescencia más rojiza-tomentosa de W. tomentosa — par botánico clásico de identificación de campo para botánicos colombianos. El género Weinmannia en Colombia incluye al menos 8-10 especies (W. tomentosa, W. pubescens, W. microphylla, W. rollottii, W. balbisiana, W. ovata, W. fagaroides, W. mariquitae, W. multijuga) que se diferencian por tamaño y pubescencia de los foliolos pinnados — todas comparten la 'firma' Cunoniaceae: HOJAS OPUESTAS PINNADAS (rasgo distintivo, raro en árboles andinos), inflorescencia en racimo terminal de flores blanco-cremosas, cápsulas pequeñas dehiscentes con semillas diminutas dispersadas por viento, corteza rica en TANINOS (históricamente usada para curtido de cueros en el altiplano cundiboyacense y nariñense, junto con corteza de quina Cinchona y de aliso Alnus). Lección viva sobre PARES BOTÁNICOS HERMANOS, COMPLEJOS DE ENCENILLO ANDINOS y CONSERVACIÓN DE LA DIVERSIDAD INTRAGENÉRICA: el bosque alto andino de la Cordillera Oriental NO es un bosque monoespecífico de encenillo W. tomentosa — es un COMPLEJO DE ENCENILLOS donde coexisten varias especies de Weinmannia que se reparten microhábitats (W. tomentosa en suelos más drenados, W. pubescens en suelos más húmedos, W. microphylla en bordes secos, W. rollottii en zonas de niebla persistente). La restauración multiespecífica del flanco oriental de la Cordillera Oriental (Cruz Verde-Sumapaz, Chingaza, Iguaque, Guerrero) requiere plantar varias especies del complejo, no solo W. tomentosa — esto refuerza el principio agroecológico de que la diversidad intragenérica es tan crítica como la diversidad intergenérica para la resiliencia del ecosistema. La propagación requiere INOCULACIÓN MICORRÍZICA con sustrato de bosque nativo — sin la micorriza simbionte específica las plántulas languidecen (replanteamiento clásico del fracaso de plantaciones 'estériles' de encenillo en viveros convencionales del altiplano). Manejo agroecológico: propagación por semilla fresca con sombra parcial 60% e inoculación micorrízica; trasplante 5-7 meses; plantación 12-18 meses; crecimiento 50-70 cm/año; asocio con otros encenillos (W. tomentosa, W. microphylla); densidades 300-500 ind/ha. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, Humboldt Flora Alto-Andina, Libro Rojo Plantas Colombia, Bernal 2015 Catálogo Plantas Líquenes Colombia.",
+      "validation_level": "claude_draft",
+      "_provenance": "promoted 2026-06-25 from cycle-content + AGE graph (grounded)"
     }
   ],
   "sources": [
+    {
+      "id": "agrosavia-bacillus-2018",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2018,
+      "titulo": "Control biológico con Bacillus subtilis en cultivos hortícolas andinos",
+      "institucion": "AGROSAVIA",
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'Bacillus subtilis hortícolas 2018'.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
     {
       "id": "agrosavia-leguminosas-andinas",
       "tipo": "ficha_tecnica_institucional",
@@ -3350,8 +14530,20 @@
       "año": null,
       "titulo": "Fichas técnicas de leguminosas andinas (haba, arveja, lenteja, frijol)",
       "institucion": "Corporación Colombiana de Investigación Agropecuaria (AGROSAVIA)",
-      "observaciones": "Compilación de fichas técnicas de AGROSAVIA para leguminosas de clima frío. Año y volumen pendientes de consolidación.",
-      "tier": "A"
+      "observaciones": "Compilación de fichas técnicas de AGROSAVIA para leguminosas de clima frío. Año y volumen pendientes de consolidación. _audit_note: cita aglutinadora; buscar fichas individuales en repository.agrosavia.co o agrosavia.co/productos-y-servicios/oferta-tecnologica.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "agrosavia-manual-arandano-2018",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2018,
+      "titulo": "Manual técnico para el cultivo de arándano (Vaccinium corymbosum) en Colombia",
+      "institucion": "AGROSAVIA",
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'arándano Vaccinium 2018'.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "agrosavia-manual-biopreparados-2015",
@@ -3360,7 +14552,9 @@
       "año": 2015,
       "titulo": "Manual de biopreparados para la agricultura colombiana",
       "institucion": "AGROSAVIA",
-      "tier": "A"
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'manual biopreparados 2015' — referencia clave para fichas de bocashi/biol/supermagro.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "agrosavia-manual-chachafruto-2015",
@@ -3369,7 +14563,9 @@
       "año": 2015,
       "titulo": "Manual técnico para el cultivo de chachafruto (Erythrina edulis) en sistemas agroforestales andinos",
       "institucion": "AGROSAVIA",
-      "tier": "A"
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'chachafruto Erythrina edulis 2015'.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "agrosavia-manual-frutales-tropicales",
@@ -3378,7 +14574,9 @@
       "año": 2017,
       "titulo": "Manual técnico para el cultivo de frutales tropicales en Colombia",
       "institucion": "AGROSAVIA",
-      "tier": "A"
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'frutales tropicales 2017' o número de colección AGROSAVIA.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "agrosavia-manual-tuberculos-andinos-2017",
@@ -3387,7 +14585,9 @@
       "año": 2017,
       "titulo": "Manual técnico para el cultivo de tubérculos andinos (oca, ulluco, mashua) en Colombia",
       "institucion": "AGROSAVIA",
-      "tier": "A"
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'tubérculos andinos oca ulluco mashua 2017'.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "agrosavia-manual-uchuva-2015",
@@ -3396,7 +14596,9 @@
       "año": 2015,
       "titulo": "Manual técnico para el cultivo de uchuva (Physalis peruviana) bajo condiciones colombianas",
       "institucion": "AGROSAVIA",
-      "tier": "A"
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'manual técnico uchuva 2015'.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "agrosavia-silvopastoriles",
@@ -3405,8 +14607,9 @@
       "año": null,
       "titulo": "Sistemas silvopastoriles en el altoandino colombiano",
       "institucion": "AGROSAVIA",
-      "observaciones": "STUB migrado de v3.0. Año y publicación específica pendientes.",
-      "tier": "A"
+      "observaciones": "STUB migrado de v3.0. Año y publicación específica pendientes. _audit_note: buscar en repository.agrosavia.co por 'silvopastoriles altoandino' — múltiples publicaciones AGROSAVIA candidatas.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "agrosavia-sol-andina",
@@ -3439,6 +14642,28 @@
       "tier": "A"
     },
     {
+      "id": "calderon-saenz-2003-invasoras",
+      "tipo": "articulo_revista",
+      "autores": "Calderón-Sáenz, E.",
+      "año": 2003,
+      "titulo": "Las especies invasoras en Colombia (diez peores)",
+      "revista_o_editorial": "Biota Colombiana",
+      "observaciones": "_audit_note: buscar en revistas.humboldt.org.co/index.php/biota — Biota Colombiana es journal IAvH con acceso abierto.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "car-cundi-2019",
+      "tipo": "resolucion_oficial",
+      "autores": "CAR — Corporación Autónoma Regional de Cundinamarca",
+      "año": 2019,
+      "titulo": "Protocolos de manejo de especies invasoras en jurisdicción CAR",
+      "institucion": "CAR Cundinamarca",
+      "observaciones": "STUB migrado de v3.0 — número de resolución pendiente. _audit_note: cita STUB sin número resolución; buscar en car.gov.co/normatividad o sigam.ambientebogota.gov.co — múltiples resoluciones CAR 2019 sobre invasoras.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
       "id": "cenicafe-manual-cafetero-2013",
       "tipo": "manual_tecnico",
       "autores": "Cenicafé",
@@ -3449,14 +14674,26 @@
       "tier": "A"
     },
     {
+      "id": "cenicafe-trichoderma-2010",
+      "tipo": "manual_tecnico",
+      "autores": "Cenicafé",
+      "año": 2010,
+      "titulo": "Uso de Trichoderma spp. en el manejo integrado de enfermedades del café",
+      "institucion": "Centro Nacional de Investigaciones de Café (Cenicafé)",
+      "observaciones": "_audit_note: buscar en biblioteca.cenicafe.org o publicaciones.cenicafe.org — Cenicafé publica series Avances Técnicos y Boletines con handle propio.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
       "id": "ciat-1995-alnus",
       "tipo": "manual_tecnico",
       "autores": "CIAT — Centro Internacional de Agricultura Tropical",
       "año": 1995,
       "titulo": "Alnus acuminata en sistemas agroforestales andinos",
       "institucion": "CIAT Palmira",
-      "observaciones": "STUB migrado de v3.0 — título y paginación pendientes de confirmación.",
-      "tier": "A"
+      "observaciones": "STUB migrado de v3.0 — título y paginación pendientes de confirmación. _audit_note: buscar en repository.cgiar.org (handle CIAT) por 'Alnus acuminata' — pre-Web era requiere búsqueda específica.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "cip-2006-ghislain",
@@ -3464,8 +14701,11 @@
       "autores": "Ghislain, M.; Andrade, D.; Rodríguez, F.; Hijmans, R.J.; Spooner, D.M.",
       "año": 2006,
       "titulo": "Genetic analysis of the cultivated potato Solanum tuberosum L. Phureja Group using RAPDs",
+      "revista_o_editorial": "Theoretical and Applied Genetics",
       "institucion": "CIP — International Potato Center",
-      "tier": "A"
+      "observaciones": "_audit_note: paper publicado en TAG 113:1515-1527 (2006); DOI canónico 10.1007/s00122-006-0399-7 — agregar DOI tras verificación final por agronomista.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "fao-2013-quinua",
@@ -3506,14 +14746,47 @@
       "tier": "A"
     },
     {
+      "id": "humboldt-2016-frailejones",
+      "tipo": "libro",
+      "autores": "Instituto Alexander von Humboldt",
+      "año": 2016,
+      "titulo": "Frailejones de Colombia — Espeletiinae",
+      "institucion": "Instituto de Investigación de Recursos Biológicos Alexander von Humboldt",
+      "url": "https://www.humboldt.org.co",
+      "tier": "A"
+    },
+    {
       "id": "humboldt-flora-alto-andina",
       "tipo": "libro",
       "autores": "Instituto Alexander von Humboldt",
       "año": null,
       "titulo": "Flora del bosque alto andino colombiano",
       "institucion": "Instituto Humboldt",
-      "observaciones": "STUB migrado de v3.0.",
-      "tier": "A"
+      "observaciones": "STUB migrado de v3.0. _audit_note: cita STUB sin año; buscar en repository.humboldt.org.co por 'flora alto-andina' — múltiples publicaciones IAvH candidatas.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "humboldt-invasoras-andes",
+      "tipo": "libro",
+      "autores": "Instituto Alexander von Humboldt",
+      "año": null,
+      "titulo": "Plantas invasoras en los Andes colombianos",
+      "institucion": "Instituto Humboldt",
+      "observaciones": "STUB migrado de v3.0 — año y referencia específica pendientes. _audit_note: cita ambigua; buscar en repository.humboldt.org.co por 'plantas invasoras Andes' — varias publicaciones IAvH candidatas requieren curadura.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "ica-fertilizantes-2019",
+      "tipo": "manual_tecnico",
+      "autores": "ICA — Instituto Colombiano Agropecuario",
+      "año": 2019,
+      "titulo": "Guía de uso racional de fertilizantes y enmiendas en Colombia",
+      "institucion": "ICA",
+      "observaciones": "_audit_note: publicación ICA Subgerencia Protección Vegetal; buscar en ica.gov.co/publicaciones o ica.gov.co/getdoc por título.",
+      "tier": "A",
+      "_url_pendiente": true
     },
     {
       "id": "ica-resolucion-3168-2015",
@@ -3522,6 +14795,29 @@
       "año": 2015,
       "titulo": "Resolución 3168 de 2015 — Reglamenta la producción, importación y exportación de semillas",
       "institucion": "Instituto Colombiano Agropecuario (ICA)",
+      "observaciones": "_audit_note: buscar PDF oficial en ica.gov.co/normatividad o vinculo SUIN-Juriscol — norma vigente fundamental para semillas en Colombia.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "ingham-2000-compost-tea",
+      "tipo": "manual_tecnico",
+      "autores": "Ingham, E.R.",
+      "año": 2000,
+      "titulo": "The Compost Tea Brewing Manual",
+      "revista_o_editorial": "Soil Foodweb Inc.",
+      "observaciones": "Fuente internacional; validada contra condiciones colombianas por AGROSAVIA 2015. _audit_note: publicación Soil Foodweb Inc. (Corvallis, OR); múltiples ediciones (2000, 2002, 2005) con ISBNs distintos — verificar edición específica usada en validación AGROSAVIA 2015.",
+      "tier": "A",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
+    },
+    {
+      "id": "issg-uicn-invasoras",
+      "tipo": "lista_uicn",
+      "autores": "ISSG — Invasive Species Specialist Group (UICN)",
+      "año": null,
+      "titulo": "Global Invasive Species Database — 100 of the World's Worst Invasive Alien Species",
+      "url": "http://www.iucngisd.org",
       "tier": "A"
     },
     {
@@ -3531,6 +14827,20 @@
       "año": 2010,
       "titulo": "Plantas medicinales de Cundinamarca y Boyacá",
       "institucion": "Jardín Botánico de Bogotá José Celestino Mutis",
+      "observaciones": "_audit_note: publicación JBB; buscar en jbb.gov.co/publicaciones o catálogo Biblioteca JBB.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "khan-2009-seaweed-extracts",
+      "tipo": "articulo_revista",
+      "autores": "Khan, W.; Rayirath, U.P.; Subramanian, S.; et al.",
+      "año": 2009,
+      "titulo": "Seaweed extracts as biostimulants of plant growth and development",
+      "revista_o_editorial": "Journal of Plant Growth Regulation",
+      "volumen_numero": "28(4)",
+      "paginas": "386-399",
+      "doi": "10.1007/s00344-009-9103-x",
       "tier": "A"
     },
     {
@@ -3540,6 +14850,18 @@
       "año": 2006,
       "titulo": "Libro Rojo de Plantas de Colombia. Volumen 4 — Especies maderables amenazadas (y volúmenes sucesivos)",
       "institucion": "Instituto Amazónico de Investigaciones Científicas SINCHI / Instituto Humboldt / MADS",
+      "observaciones": "_audit_note: serie multi-volumen Libro Rojo Plantas Colombia; buscar volúmenes en repository.humboldt.org.co o sinchi.org.co (cada volumen tiene handle distinto).",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "mongabay-retamo-2024",
+      "tipo": "articulo_revista",
+      "autores": "Mongabay Latam",
+      "año": 2024,
+      "titulo": "El retamo espinoso: la plaga que amenaza los páramos colombianos",
+      "url": "https://es.mongabay.com",
+      "observaciones": "STUB — artículo periodístico, validar contra fuente primaria antes de citar en ministerial.",
       "tier": "A"
     },
     {
@@ -3548,8 +14870,9 @@
       "autores": "Mujica, A.",
       "año": 1992,
       "titulo": "Revisión bibliográfica sobre el cultivo de la quinua (Chenopodium quinoa Willd.) y el amaranto (Amaranthus caudatus L.) en los Andes",
-      "observaciones": "Publicación del Instituto Nacional de Investigaciones Agropecuarias (INIAP), Ecuador. Revisión exhaustiva de germoplasma, agronomía y usos tradicionales.",
-      "tier": "B"
+      "observaciones": "Publicación del Instituto Nacional de Investigaciones Agropecuarias (INIAP), Ecuador. Revisión exhaustiva de germoplasma, agronomía y usos tradicionales. _audit_note: buscar en repositorio.iniap.gob.ec o FAO ECOPORT (Mujica autor afiliado UNAP Puno + INIAP).",
+      "tier": "B",
+      "_url_pendiente": true
     },
     {
       "id": "nrc-1989-cultivos-andinos",
@@ -3572,14 +14895,26 @@
       "tier": "B"
     },
     {
+      "id": "ocampo-solorza-2017",
+      "tipo": "articulo_revista",
+      "autores": "Ocampo, D.; Solorza, J.",
+      "año": 2017,
+      "titulo": "Manejo de retamo espinoso (Ulex europaeus) en zonas altoandinas de Cundinamarca",
+      "observaciones": "STUB migrado de v3.0 — revista y paginación pendientes. _audit_note: cita incompleta, requiere localizar revista (posibles candidatos: Colombia Forestal, Caldasia, boletín IAvH).",
+      "tier": "B",
+      "_url_pendiente": true
+    },
+    {
       "id": "pamplona-roger-2006-plantas-medicinales",
       "tipo": "libro",
       "autores": "Pamplona-Roger, J.D.",
       "año": 2006,
       "titulo": "Enciclopedia de las plantas medicinales",
       "revista_o_editorial": "Safeliz",
-      "observaciones": "STUB migrado de v3.0 — confirmar ISBN.",
-      "tier": "B"
+      "observaciones": "STUB migrado de v3.0 — confirmar ISBN. _audit_note: editorial Safeliz (Madrid); requiere verificación bibliotecaria para ISBN (existen ediciones 1997/2006/2010 con ISBNs distintos).",
+      "tier": "B",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
     },
     {
       "id": "perez-arbelaez-1947-plantas-utiles",
@@ -3588,8 +14923,10 @@
       "año": 1947,
       "titulo": "Plantas Útiles de Colombia",
       "revista_o_editorial": "Librería Colombiana / Camacho Roldán",
-      "observaciones": "Obra clásica de la botánica económica colombiana; múltiples reediciones posteriores.",
-      "tier": "A"
+      "observaciones": "Obra clásica de la botánica económica colombiana; múltiples reediciones posteriores. _audit_note: edición pre-ISBN; copias digitalizadas pueden buscarse en archive.org o Biblioteca Nacional de Colombia.",
+      "tier": "A",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
     },
     {
       "id": "perez-rodriguez-gomez-2008",
@@ -3600,7 +14937,21 @@
       "revista_o_editorial": "Agronomía Colombiana",
       "volumen_numero": "26(3)",
       "paginas": "477-486",
-      "tier": "B"
+      "observaciones": "_audit_note: Agronomía Colombiana revista UNAL — buscar artículo en revistas.unal.edu.co/index.php/agrocol por autor Pérez L. + año 2008.",
+      "tier": "B",
+      "_url_pendiente": true
+    },
+    {
+      "id": "pinheiro-machado-2017-biofertilizantes",
+      "tipo": "libro",
+      "autores": "Pinheiro, S.; Restrepo Rivera, J. (eds.)",
+      "año": 2017,
+      "titulo": "Manual de Agricultura Orgánica y Biofertilizantes — fundamentos de la trofobiosis y nutrición vegetal agroecológica",
+      "institucion": "Fundación Juquira Candiru / MAELA",
+      "observaciones": "Referencia continental para biol, supermagro y caldos minerales bajo enfoque trofobiótico de Chaboussou. _audit_note: buscar en catálogo MAELA o Fundación Juquira Candiru — ISBN no localizado.",
+      "tier": "B",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
     },
     {
       "id": "powo-kew",
@@ -3612,13 +14963,61 @@
       "tier": "A"
     },
     {
+      "id": "res-684-2018-mads",
+      "tipo": "resolucion_oficial",
+      "autores": "MADS — Ministerio de Ambiente y Desarrollo Sostenible",
+      "año": 2018,
+      "titulo": "Resolución 684 de 2018 — Lista nacional de especies invasoras",
+      "institucion": "MADS Colombia",
+      "observaciones": "_audit_note: buscar PDF oficial en minambiente.gov.co/normativa o SUIN-Juriscol; complementa Resolución 207/2010 (catálogo invasoras).",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "restauracion-cruz-verde-sumapaz",
+      "tipo": "manual_tecnico",
+      "autores": "Instituto Alexander von Humboldt + CAR Cundinamarca",
+      "año": 2018,
+      "titulo": "Plan de restauración ecológica páramos Cruz Verde — Sumapaz",
+      "institucion": "IAvH / CAR Cundinamarca",
+      "observaciones": "_audit_note: buscar handle en repository.humboldt.org.co o portal CAR Cundinamarca por título 'Cruz Verde Sumapaz'.",
+      "tier": "B",
+      "_url_pendiente": true
+    },
+    {
       "id": "restrepo-1996-abc-agricultura-organica",
       "tipo": "libro",
       "autores": "Restrepo, J.",
       "año": 1996,
       "titulo": "ABC de la agricultura orgánica (variante de cita usada en v3.0)",
-      "observaciones": "STUB — posiblemente misma obra que restrepo-1996-bocashi. Verificar y dedupear.",
-      "tier": "B"
+      "observaciones": "STUB — posiblemente misma obra que restrepo-1996-bocashi. Verificar y dedupear. _audit_note: requiere curadura bibliotecaria para deduplicar contra restrepo-1996-bocashi.",
+      "tier": "B",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
+    },
+    {
+      "id": "restrepo-1996-bocashi",
+      "tipo": "libro",
+      "autores": "Restrepo, J.",
+      "año": 1996,
+      "titulo": "Abonos orgánicos fermentados — experiencias de agricultores en Centroamérica y Brasil",
+      "revista_o_editorial": "OIT",
+      "observaciones": "_audit_note: publicación OIT/ILO en programa PROCMD Centroamérica; buscar en ilo.org/publns o catálogo OIT San José Costa Rica.",
+      "tier": "B",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
+    },
+    {
+      "id": "restrepo-2005-agroecologia",
+      "tipo": "libro",
+      "autores": "Restrepo Rivera, Jairo",
+      "año": 2005,
+      "titulo": "Manual práctico ABC de la agricultura orgánica y panes de piedra",
+      "institucion": "Editorial Feriva",
+      "observaciones": "_audit_note: edición Cali (Editorial Feriva); ISBN no verificado — posible duplicado conceptual con restrepo-rivera-2005, requiere curadura bibliotecaria.",
+      "tier": "B",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
     },
     {
       "id": "restrepo-2007-biopreparados",
@@ -3627,7 +15026,22 @@
       "año": 2007,
       "titulo": "Manual práctico de biopreparados aplicados a la agricultura orgánica",
       "institucion": "Fundación Juquira Candiru",
-      "tier": "B"
+      "observaciones": "_audit_note: publicación Fundación Juquira Candiru; URL canónica no localizable — buscar en catálogo MAELA o bibliotecas universitarias agroecológicas.",
+      "tier": "B",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
+    },
+    {
+      "id": "restrepo-rivera-2005",
+      "tipo": "libro",
+      "autores": "Restrepo Rivera, Jairo",
+      "año": 2005,
+      "titulo": "Agroecología — principios y aplicación en el manejo de fincas tropicales",
+      "institucion": "Editorial Feriva",
+      "observaciones": "_audit_note: edición Cali (Editorial Feriva); ISBN no localizado en catálogos estándar — requiere verificación bibliotecaria.",
+      "tier": "B",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
     },
     {
       "id": "sib-colombia",
@@ -3645,6 +15059,173 @@
       "año": null,
       "titulo": "Publicaciones científicas sobre especies de la Amazonía colombiana",
       "institucion": "Instituto Amazónico de Investigaciones Científicas SINCHI",
+      "url": "https://www.sinchi.org.co",
+      "tier": "A"
+    },
+    {
+      "id": "uicn-red-list",
+      "tipo": "lista_uicn",
+      "autores": "IUCN — International Union for Conservation of Nature",
+      "año": null,
+      "titulo": "The IUCN Red List of Threatened Species",
+      "url": "https://www.iucnredlist.org",
+      "tier": "A"
+    },
+    {
+      "id": "cochrane-1980-aluminio-saturacion",
+      "tipo": "articulo_revista",
+      "autores": "Cochrane, T.T.; Salinas, J.G.; Sánchez, P.A.",
+      "año": 1980,
+      "titulo": "An equation for liming acid mineral soils to compensate crop aluminum tolerance",
+      "revista_o_editorial": "Tropical Agriculture (Trinidad)",
+      "volumen_numero": "57(2)",
+      "paginas": "133-140",
+      "observaciones": "Referencia clásica para el cálculo de dosis de cal en suelos ácidos tropicales basado en saturación de aluminio (Al sat %), criterio operativo central en agroecología andina y trópico bajo colombiano. _audit_note: pre-DOI era; Tropical Agriculture (Trinidad) journal — buscar en CABI Abstracts o repositorio CIAT (autor Sánchez P.A. afiliado NCSU/IFDC).",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "pinheiro-2003-cartilha-cal",
+      "tipo": "libro",
+      "autores": "Pinheiro, S.; Restrepo Rivera, J.",
+      "año": 2003,
+      "titulo": "Cartilha da saúde do solo — agricultura orgânica e biodinâmica: o uso correto da cal e das enmendas minerais",
+      "institucion": "Fundação Juquira Candiru / MAELA",
+      "observaciones": "Texto de divulgación agroecológica latinoamericana que sistematiza las advertencias sobre cal viva/hidratada en sistemas orgánicos y defiende criterios técnicos de aplicación basados en análisis de suelo. _audit_note: cartilha self-published Brasil, sin ISBN ni DOI; consultar catálogo MAELA o Fundação Juquira Candiru.",
+      "tier": "B",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
+    },
+    {
+      "id": "restrepo-2007-caldos-minerales",
+      "tipo": "libro",
+      "autores": "Restrepo Rivera, J.",
+      "año": 2007,
+      "titulo": "El ABC de la agricultura orgánica y harina de rocas — Vol. 2: Caldos Minerales",
+      "revista_o_editorial": "Editorial Feriva, Cali",
+      "isbn": "978-958-44-1280-5",
+      "tier": "A"
+    },
+    {
+      "id": "vasquez-solano-2021-mm-agronomia-cr",
+      "tipo": "articulo_revista",
+      "autores": "Vásquez-Solano, A.; et al.",
+      "año": 2021,
+      "titulo": "Microorganismos de montaña (MM): poblaciones microbianas durante su activación líquida",
+      "revista_o_editorial": "Agronomía Costarricense",
+      "volumen_numero": "45(1)",
+      "paginas": "81-92",
+      "observaciones": "_audit_note: artículo en Agronomía Costarricense vol 45(1); URL canónica vía portal revistas.ucr.ac.cr o SciELO Costa Rica — DOI no localizado con certeza, requiere búsqueda directa por título.",
+      "tier": "A",
+      "_url_pendiente": true
+    },
+    {
+      "id": "cho-2016-jadam-organic-farming",
+      "tipo": "libro",
+      "autores": "Cho, Youngsang",
+      "año": 2016,
+      "titulo": "JADAM Organic Farming: The Way to Ultra-Low-Cost Agriculture",
+      "revista_o_editorial": "JADAM, Daejeon, South Korea",
+      "isbn": "9788989220206",
+      "tier": "A"
+    },
+    {
+      "id": "cho-2021-jadam-pest-disease",
+      "tipo": "libro",
+      "autores": "Cho, Youngsang",
+      "año": 2021,
+      "titulo": "JADAM Organic Pest and Disease Control",
+      "revista_o_editorial": "JADAM, Daejeon, South Korea",
+      "isbn": "9788989220473",
+      "tier": "A"
+    },
+    {
+      "id": "park-duponte-2008-lab-ctahr",
+      "tipo": "manual_tecnico",
+      "autores": "Park, H.-L.; DuPonte, M.W.",
+      "año": 2008,
+      "titulo": "Natural Farming: Lactic Acid Bacteria / Fish Amino Acid / Fermented Plant Juice — Sustainable Agriculture factsheets",
+      "institucion": "University of Hawaii — College of Tropical Agriculture and Human Resources (CTAHR)",
+      "observaciones": "_audit_note: factsheet set publicado por CTAHR Sustainable Agriculture program (SA-7, SA-8, SA-9); URLs canónicas en repository.ctahr.hawaii.edu — requiere localizar handle específico por factsheet.",
+      "tier": "B",
+      "_url_pendiente": true
+    },
+    {
+      "id": "mamani-2015-biol-ruminal",
+      "tipo": "articulo_revista",
+      "autores": "Mamani-Pati, F.; Quenta, E.; Mamani, G.",
+      "año": 2015,
+      "titulo": "Elementos nutricionales en la producción de fertilizante biol con diferentes tipos de insumos y cantidades de contenido ruminal de bovino",
+      "revista_o_editorial": "Journal of the Selva Andina Research Society",
+      "volumen_numero": "6(1)",
+      "url": "http://www.scielo.org.bo/scielo.php?pid=S2409-16182015000100011",
+      "tier": "A"
+    },
+    {
+      "id": "pinheiro-restrepo-2009-remineralizacion",
+      "tipo": "libro",
+      "autores": "Pinheiro Machado, S.; Restrepo Rivera, J.",
+      "año": 2009,
+      "titulo": "Agricultura orgánica: La remineralización de los alimentos y la salud a partir de la regeneración mineral del suelo",
+      "revista_o_editorial": "Fundación Juquira Candirú, Cali",
+      "observaciones": "Reedición ampliada de Julius Hensel 'Brot aus Steinen' (1894); ISBN no localizado de manera firme en bases bibliográficas estándar. _audit_note: requiere verificación bibliotecaria en catálogo Fundación Juquira Candirú o ediciones MAELA.",
+      "tier": "B",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
+    },
+    {
+      "id": "pinheiro-1990-trofobiosis",
+      "tipo": "libro",
+      "autores": "Pinheiro Machado L.C.",
+      "año": 1990,
+      "titulo": "A teoria da trofobiose — novos rumos para a agricultura",
+      "revista_o_editorial": "L.C. Pinheiro Machado (auto-edição), Porto Alegre",
+      "institucion": "EMBRAPA / UFRGS (autor afiliado)",
+      "tier": "B",
+      "observaciones": "Teoría trofobiose Chaboussou aplicada a fitoiatría — base conceptual de Restrepo para purines de ortiga, consuelda, helecho. Plantas equilibradas nutricionalmente son menos atacadas por insectos. _audit_note: auto-edição brasileña 1990 sin ISBN ni DOI registrado; verificar copia en biblioteca UFRGS o catálogo EMBRAPA.",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
+    },
+    {
+      "id": "agrosavia-abonos-verdes-boyaca-2018",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA — CI Tibaitatá",
+      "año": 2018,
+      "titulo": "Modelo productivo de abonos verdes en sistemas de papa y hortalizas en Cundinamarca y Boyacá",
+      "revista_o_editorial": "Corporación Colombiana de Investigación Agropecuaria (AGROSAVIA)",
+      "institucion": "AGROSAVIA",
+      "isbn": "978-958-740-280-7",
+      "tier": "A",
+      "observaciones": "Avena strigosa/sativa + vicia sativa/villosa como cobertura biocida — 60-90 días al floración, incorporación a 10-15 cm. Aporte N biológico vicia 80-150 kg/ha."
+    },
+    {
+      "id": "pinheiro-restrepo-2003-purines",
+      "tipo": "libro",
+      "autores": "Pinheiro Machado L.C., Restrepo Rivera J.",
+      "año": 2003,
+      "titulo": "Cartilha de purines, biofertilizantes e caldos minerais",
+      "revista_o_editorial": "Pinheiro Machado y Editora Aldeia do Futuro, Porto Alegre",
+      "institucion": "PRV Pasto Racional Voisin",
+      "tier": "B",
+      "observaciones": "Recopilación canónica de purines de ortiga, consuelda, helecho, cola de caballo — proporciones, vidas útiles, advertencias de mezcla. _audit_note: edición latinoamericana auto-publicada sin DOI ni ISBN reconocido; verificar disponibilidad en bibliotecas de FAO/MAELA o catálogo Editora Aldeia do Futuro.",
+      "_url_pendiente": true,
+      "_isbn_pendiente": true
+    },
+    {
+      "id": "agrosavia-forrajeras-2022",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "titulo": "Gramíneas forrajeras en sistemas ganaderos andinos",
+      "año": 2022,
+      "institucion": "AGROSAVIA",
+      "tier": "A"
+    },
+    {
+      "id": "correa-pabon-carulla-2008",
+      "tipo": "articulo_revista",
+      "autores": "Correa, R.; Pabón, R.; Carulla, J.",
+      "titulo": "Valor nutricional del kikuyo (Cenchrus clandestinus) y respuestas productivas en ganadería lechera andina",
+      "año": 2008,
       "tier": "A"
     }
   ],
@@ -3664,7 +15245,7 @@
         "carbón vegetal triturado",
         "afrecho",
         "melaza",
-        "levadura",
+        "levadura activa de panadería o cervecera (Saccharomyces cerevisiae)",
         "agua"
       ],
       "proceso_resumen": "Fermentación aeróbica 15-21 días con volteo diario hasta bajar temperatura a <40°C. Humedad 'prueba de puño': al apretar un puñado, el agua no gotea pero la mano queda húmeda.",
@@ -3683,8 +15264,14 @@
         "mejorador_estructura_suelo",
         "aporte_materia_organica"
       ],
-      "valor_pedagogico": "Tecnología japonesa (boka-shi, 'materia orgánica fermentada') adaptada a Latinoamérica por Jairo Restrepo. Fermentación aeróbica 45-55°C selecciona microbiota termófila (Bacillus, actinomicetos, levaduras) y estabiliza N orgánico no lixiviable, a diferencia de la urea sintética. La cascarilla aporta Si bioactivo; el carbón vegetal actúa como biochar (CEC + hábitat microbiano). Advertencias: >5 kg/m² en hortalizas de hoja → exceso N atrae áfidos y mildeo; humedad >65% vira a pútrida y pierde N. AGROSAVIA 2015 documenta respuestas equivalentes a 50% NPK sintético en papa criolla y maíz andino.",
-      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+      "valor_pedagogico": "Tecnología japonesa (bokashi 暈し, del verbo bokasu — 'mezclar/atenuar'; refiere al proceso de dilución/mezcla del compost en sustrato. La fermentación en japonés agrícola se llama hakkō 発酵 — distinción técnica importante) popularizada en la línea de agricultura natural Fukuoka-Higa y adaptada a Latinoamérica por Jairo Restrepo. Fermentación aeróbica 45-55°C selecciona microbiota termófila (Bacillus, actinomicetos, levaduras) y estabiliza N orgánico no lixiviable, a diferencia de la urea sintética. La cascarilla aporta Si bioactivo; el carbón vegetal actúa como biochar (CEC + hábitat microbiano). Advertencias: >5 kg/m² en hortalizas de hoja → exceso N atrae áfidos y mildeo; humedad >65% vira a pútrida y pierde N. AGROSAVIA 2015 documenta respuestas equivalentes a 50% NPK sintético en papa criolla y maíz andino.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17",
+      "safety_class": "bajo",
+      "ppe_required": [
+        "tapabocas"
+      ],
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
     },
     {
       "id": "biol",
@@ -3718,8 +15305,14 @@
         "inoculacion_microbiana_filosfera",
         "resistencia_induccion_SAR"
       ],
-      "valor_pedagogico": "Biofertilizante anaeróbico andino, popularizado por Restrepo y Pinheiro Machado. La fermentación selecciona bacterias fijadoras de N (Azotobacter, Clostridium) y solubilizadoras de P, generando fitohormonas (auxinas, citoquininas) y ácidos quelantes. La leche aporta caseínas fungistáticas y Lactobacillus que inducen SAR (Resistencia Sistémica Adquirida). Vs. urea 46-0-0 entrega N orgánico sin quemar follaje. Advertencias: olor amoniacal = mal sellado (descartar); filtrar antes de boquilla; >30% en lechuga/fresa necrosa. AGROSAVIA 2015: +15-25% en hortalizas andinas.",
-      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+      "valor_pedagogico": "Biofertilizante anaeróbico andino, popularizado por Restrepo y Pinheiro Machado. La fermentación selecciona bacterias fijadoras de N (Azotobacter, Clostridium) y solubilizadoras de P, generando fitohormonas (auxinas, citoquininas) y ácidos quelantes. La leche aporta caseínas fungistáticas y Lactobacillus que inducen ISR (Resistencia Sistémica Inducida, vía jasmonato/etileno; Pieterse et al. 2014 Annu Rev Phytopathol 52:347). Vs. urea 46-0-0 entrega N orgánico sin quemar follaje. Advertencias: olor amoniacal = mal sellado (descartar); filtrar antes de boquilla; >30% en lechuga/fresa necrosa. AGROSAVIA 2015: +15-25% en hortalizas andinas.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17",
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": [
+        "pre_cosecha_partes_comestibles"
+      ],
+      "reentry_interval_dias": null
     },
     {
       "id": "purin_ortiga",
@@ -3751,8 +15344,14 @@
         "bioestimulante_enraizamiento",
         "fitosanitario_preventivo_chupadores"
       ],
-      "valor_pedagogico": "Preparado tradicional europeo (purin d'ortie) introducido a la agroecología latinoamericana por Restrepo y validado por AGROSAVIA. Urtica dioica/U. urens concentra Fe (4-7 mg/g MS), Si soluble, ácido fórmico y polifenoles antialimentarios contra áfidos (Myzus persicae) y ácaros (Tetranychus urticae). Corrige clorosis férrica sin acidificar el sustrato. Fermentación completa (cesa espuma) es clave: macerados frescos tienen formicato fitotóxico. Vs. imidacloprid no deja residuos ni daña polinizadores. NO mezclar con caldos cúpricos (precipita Fe).",
-      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+      "valor_pedagogico": "Preparado tradicional europeo (purin d'ortie) introducido a la agroecología latinoamericana por Restrepo y validado por AGROSAVIA. Urtica dioica/U. urens concentra Fe (4-7 mg/g MS), Si soluble, ácido fórmico y polifenoles antialimentarios contra áfidos (Myzus persicae) y ácaros (Tetranychus urticae). Corrige clorosis férrica sin acidificar el sustrato. Fermentación completa (cesa espuma) es clave: macerados frescos contienen ácido fórmico libre (HCOOH) fitotóxico. Vs. imidacloprid no deja residuos ni daña polinizadores. NO mezclar con caldos cúpricos (precipita Fe).",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17",
+      "safety_class": "bajo",
+      "ppe_required": [
+        "guantes"
+      ],
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
     },
     {
       "id": "caldo_sulfocalcico",
@@ -3767,7 +15366,7 @@
         "cal viva o hidratada",
         "agua"
       ],
-      "proceso_resumen": "Cocción de azufre + cal 2:1 en 10L agua por 45-60 min hasta color ámbar. Aplicación foliar 1:100 preventivo, 1:20 curativo. Evitar en frutales durante floración.",
+      "proceso_resumen": "Cocción de azufre + cal 2:1 en 10L agua por 45-60 min hasta color vino tinto/teja (28-32° Baumé). Aplicación foliar 1:100 preventivo, 1:20 curativo. Evitar en frutales durante floración.",
       "tiempo_elaboracion_dias": 1,
       "vida_util_dias": 180,
       "source_ids": [
@@ -3786,7 +15385,19 @@
         "fitosanitario_curativo_amplio_espectro"
       ],
       "valor_pedagogico": "Polisulfuro de calcio (CaSx, x=4-5) coloidal por cocción S:cal 2:1. El S elemental se oxida en la cutícula del patógeno a SO2/H2S, inhibiendo respiración mitocondrial de hongos (Oidium, Erysiphe) y ácaros eriofidos. Permitido en orgánico (IFOAM, EU 2018/848), no genera resistencia cruzada vs. IBE sintéticos (tebuconazol). FITOTÓXICO en cucurbitáceas, durazno y cerezo en floración o con T>28°C — quemaduras severas. NO mezclar con bordelés (precipita CuS) ni con aceites; 21 d de separación. pH ~11-12: guantes y gafas.",
-      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17",
+      "safety_class": "alto",
+      "ppe_required": [
+        "guantes",
+        "careta",
+        "gafas"
+      ],
+      "do_not_use_when": [
+        "floracion",
+        "temperatura_mayor_28C",
+        "humedad_relativa_menor_50pct"
+      ],
+      "reentry_interval_dias": 15
     },
     {
       "id": "caldo_bordeles",
@@ -3819,7 +15430,18 @@
         "fungicida_cuprico_preventivo_amplio_espectro"
       ],
       "valor_pedagogico": "Fungicida cúprico de Burdeos 1885 (Millardet), fundacional en orgánico certificado (IFOAM, EU 2018/848 — máx 4 kg Cu/ha/año). CuSO4 neutralizado con cal forma Cu(OH)2·CuSO4 coloidal que libera Cu²⁺ con humedad/exudados fúngicos, inhibiendo tioles en oomicetes (Phytophthora, Peronospora) y hongos (Colletotrichum, Hemileia del café). pH 7-8 crítico: ácido = Cu²⁺ fitotóxico, alcalino = precipita inactivo. Test lámina de hierro: si se cubre de Cu rojizo, falta cal. NO mezclar con sulfocálcico (CuS) ni aceites; Cu >100 ppm daña lombrices y micorrizas — rotar con Bacillus o Trichoderma.",
-      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17",
+      "safety_class": "alto",
+      "ppe_required": [
+        "guantes",
+        "careta",
+        "gafas"
+      ],
+      "do_not_use_when": [
+        "floracion",
+        "cucurbitaceas_jovenes"
+      ],
+      "reentry_interval_dias": 21
     },
     {
       "id": "te_compost",
@@ -3846,12 +15468,18 @@
         "preventivo_mildeo_polvoso",
         "preventivo_botrytis"
       ],
-      "valor_pedagogico": "Inóculo microbiano vivo (10^8-10^9 UFC/ml de bacterias aerobias y esporas de hongos saprófitos) extraído del compost por aireación forzada con melaza como carbono lábil. Coloniza filoplano y rizosfera por exclusión competitiva contra patógenos (Ingham; Restrepo, ABC orgánico). Advertencias: si la aireación se detiene >2 h vira anaeróbico y produce ácidos fitotóxicos; no aplicar bajo sol del mediodía (UV mata 90% del inóculo en 30 min); no mezclar con caldo bordelés o sulfocálcico — el cobre/azufre esterilizan la microbiota.",
+      "valor_pedagogico": "Inóculo microbiano vivo: UFC REALES de finca son 10^5-10^7 UFC/ml (NO 10^8-10^9 UFC/ml como promovieron Faulkner y la literatura comercial de tés aerados — esos rangos requieren laboratorio + compost activo certificado + glucosa suplementaria + control de O₂ disuelto, no replicables en aireador de pecera). Aireación 24-48 h en agua sin cloro maximiza el recuento bacteriano aerobio; aireaciones >72 h colapsan por agotamiento de O₂ y melaza (Scheuerell & Mahaffee 2002 *Compost Sci Util* 10:313). Composición típica: bacterias aerobias (Pseudomonas, Bacillus), esporas de hongos saprófitos, protozoos flagelados y nematodos bacteriófagos extraídos del compost por aireación forzada con melaza como carbono lábil. Coloniza filoplano y rizosfera por exclusión competitiva contra patógenos (Ingham; Restrepo, ABC orgánico — la eficacia es variable según calidad del compost madre y presión de inóculo patogénico, ver Litterick et al. 2004 CRC Critical Reviews 23:453). Advertencias: si la aireación se detiene >2 h vira anaeróbico y produce ácidos fitotóxicos; no aplicar bajo sol del mediodía (UV mata 90% del inóculo en 30 min); no mezclar con caldo bordelés o sulfocálcico — el cobre/azufre esterilizan la microbiota.",
       "source_ids": [
         "ingham-2000-compost-tea",
         "restrepo-1996-abc-agricultura-organica",
         "agrosavia-manual-biopreparados-2015"
-      ]
+      ],
+      "safety_class": "medio",
+      "ppe_required": null,
+      "do_not_use_when": [
+        "pre_cosecha_partes_comestibles_crudas"
+      ],
+      "reentry_interval_dias": null
     },
     {
       "id": "humus_liquido",
@@ -3876,12 +15504,18 @@
         "antiestres_transplante",
         "preventivo_nematodos"
       ],
-      "valor_pedagogico": "Lixiviado rico en ácidos húmicos y fúlvicos (3-8 g/L), reguladores tipo auxinas/citoquininas y microbiota aeróbica del tracto de Eisenia foetida (Pseudomonas, Bacillus, Actinomycetes). Los fúlvicos quelatan micronutrientes (Fe, Zn, Mn) facilitando absorción foliar — análogo orgánico a quelatos EDTA, biodegradable y de bajo costo (AGROSAVIA, Restrepo). Advertencias: dosis foliares >1:5 queman hojas tiernas por sales; olor a podredumbre indica anaerobiosis y descarte; conservar tapado en oscuridad <25°C — vida útil cae a 7 días si supera 30°C.",
+      "valor_pedagogico": "Lixiviado de vermicompost rico en ácidos húmicos y fúlvicos extractables, reguladores tipo auxinas/citoquininas y microbiota aeróbica del tracto de *Eisenia foetida* (Pseudomonas, Bacillus, Actinomycetes). **ÁCIDOS HÚMICOS REALES**: 0.5-3 g/L típico en lixiviado por percolación, NO 3-8 g/L como afirma la literatura comercial — el extracto líquido es **diluido vs sólido**, y los valores altos se midieron en concentrados industriales (Atiyeh et al. 2002 *Bioresource Technology* 84:7). Para concentrado de húmicos genuino comprar leonardita comercial (mineral oxidado de lignito con 50-70% ácidos húmicos certificados) — el lixiviado de finca aporta más bioestimulación microbiana y enzimática que carga húmica per se. Los fúlvicos quelatan micronutrientes (Fe, Zn, Mn) facilitando absorción foliar — análogo orgánico a quelatos EDTA, biodegradable y de bajo costo (AGROSAVIA, Restrepo). Advertencias: dosis foliares >1:5 queman hojas tiernas por sales; olor a podredumbre indica anaerobiosis y descarte; conservar tapado en oscuridad <25 °C — vida útil cae a 7 días si supera 30 °C.",
       "source_ids": [
         "agrosavia-manual-biopreparados-2015",
         "restrepo-1996-abc-agricultura-organica",
         "restrepo-2007-biopreparados"
-      ]
+      ],
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": [
+        "pre_cosecha_partes_comestibles_crudas"
+      ],
+      "reentry_interval_dias": null
     },
     {
       "id": "lixiviado_frutas",
@@ -3906,12 +15540,18 @@
         "micronutrientes_B_Zn_Mn",
         "mejora_brix_calidad_fruto"
       ],
-      "valor_pedagogico": "Fermentación láctica-alcohólica: levaduras (Saccharomyces, Hanseniaspora) y lácticas (Lactobacillus) degradan azúcares liberando K soluble (4-12 g/L K2O), B, Zn, Mn y ácidos orgánicos que liberan cationes en suelos calcáreos. Restrepo y Pinheiro lo usan como análogo orgánico al KNO3 en floración, sin salinización. Advertencias: moho blanco (Geotrichum) es seguro; negro/verde (Aspergillus) obliga descarte por micotoxinas. pH final 3.5-4.0; >4.5 indica putrefacción. No aplicar en vegetativa temprana — K antagoniza N.",
+      "valor_pedagogico": "Fermentación láctica-alcohólica: levaduras (Saccharomyces, Hanseniaspora) y lácticas (Lactobacillus) degradan azúcares liberando K soluble, B, Zn, Mn y ácidos orgánicos que liberan cationes en suelos calcáreos. **K₂O REAL**: 1-4% típico en lixiviados de cáscaras cítricas y manzana; hasta 8-12% con frutas de alto K (banano maduro, mango maduro, papaya). **NPK típico real**: 1-2-3 (N-P-K en %), no 1-2-6 como afirman recetarios populares — la fermentación libera más K que P pero el N orgánico residual es bajo porque la fruta aporta poca proteína. Restrepo y Pinheiro lo usan como análogo orgánico al KNO₃ en floración, sin salinización. Advertencias: moho blanco (Geotrichum candidum) en la superficie sin afectar la fermentación es aceptable — descartar si crece masivamente o cubre toda la superficie; moho negro/verde olivo (probable Aspergillus flavus/niger) obliga descarte por aflatoxinas hepatotóxicas. pH final 3.5-4.0; >4.5 indica putrefacción. No aplicar en vegetativa temprana — K antagoniza N.",
       "source_ids": [
         "restrepo-1996-bocashi",
         "restrepo-2007-biopreparados",
         "agrosavia-manual-biopreparados-2015"
-      ]
+      ],
+      "safety_class": "medio",
+      "ppe_required": null,
+      "do_not_use_when": [
+        "fermento_con_moho_negro_o_verde_olivo"
+      ],
+      "reentry_interval_dias": null
     },
     {
       "id": "supermagro",
@@ -3939,12 +15579,20 @@
         "estimulante_microbiano_filoplano",
         "fertilizacion_complemento_NPK"
       ],
-      "valor_pedagogico": "Receta de Restrepo (1996) y Pinheiro: fermentación anaeróbica láctica de estiércol + leche + melaza donde Lactobacillus y levaduras solubilizan sulfatos añadidos en 5-7 etapas semanales, quelándolos con ácidos orgánicos y aminoácidos biodisponibles. Análogo orgánico a quelatos EDTA/EDDHA, biodegradable y a 1/10 del costo. Cubre 7 deficiencias típicas en suelos andinos ácidos (Mg, Zn, Mn, Cu, Fe, B, Co). Advertencias: sulfatos de Cu/Zn >2% esterilizan el barril; fermentación <60 días deja sulfatos sin quelatar y quema follaje; pH 3.5-4.2; contraindicado en floración plena.",
+      "valor_pedagogico": "Receta de Restrepo (1996) y Pinheiro: fermentación anaeróbica láctica de estiércol + leche + melaza donde Lactobacillus y levaduras solubilizan sulfatos añadidos en 5-7 etapas semanales, quelándolos con ácidos orgánicos y aminoácidos biodisponibles. Análogo orgánico a quelatos EDTA/EDDHA, biodegradable y a 1/10 del costo. Cubre 7 deficiencias típicas en suelos andinos ácidos (Mg, Zn, Mn, Cu, Fe, B, Co). Advertencias: sulfatos de Cu/Zn por encima de ~2 g/L (~0.2% p/v) inhiben la microbiota láctica del barril y detienen la fermentación (Reed 2010 J Environ Qual 39:1257); fermentación <60 días deja sulfatos sin quelatar y quema follaje; pH 3.5-4.2; contraindicado en floración plena.",
       "source_ids": [
         "restrepo-1996-bocashi",
         "restrepo-2005-agroecologia",
         "restrepo-2007-biopreparados"
-      ]
+      ],
+      "safety_class": "bajo",
+      "ppe_required": [
+        "guantes"
+      ],
+      "do_not_use_when": [
+        "floracion_plena"
+      ],
+      "reentry_interval_dias": null
     },
     {
       "id": "trichoderma_harzianum_suelo",
@@ -3970,13 +15618,17 @@
         "induccion_resistencia_sistemica",
         "promocion_crecimiento_radicular"
       ],
-      "valor_pedagogico": "Hongo antagonista saprófito que coloniza la rizosfera y controla patógenos vía: (1) micoparasitismo sobre Rhizoctonia, Fusarium, Sclerotinia y Pythium degradándolas con quitinasas/β-1,3-glucanasas; (2) competencia por exudados radiculares; (3) antibióticos volátiles (6-pentil-pirona, gliotoxina); (4) inducción de resistencia sistémica vía jasmonato/etileno. AGROSAVIA y Cenicafé validaron cepas locales ICA-registradas, análogo al carbendazim sin residuos. Advertencias: no aplicar a suelo seco (<30% humedad); incompatible con cúpricos y mancozeb; evitar pleno sol; pH >8.0 contraindicado.",
+      "valor_pedagogico": "Hongo antagonista saprófito *Trichoderma harzianum* sensu lato — revisión Chaverri et al. 2015 *Mycologia* 107(3):558 segregó el complejo en varias especies: la cepa tipo comercial T-22 y la mayoría de cepas tropicales/africanas (incluidas las colombianas AGROSAVIA TR15 y TR06) corresponden ahora a *Trichoderma afroharzianum*. AGROSAVIA y registros ICA (Res. 3168/2015) mantienen el nombre histórico \"T. harzianum\" por estabilidad regulatoria, pero técnicamente las cepas comerciales colombianas son *T. afroharzianum*. Mecanismos de control: coloniza la rizosfera y combate patógenos vía (1) micoparasitismo sobre Rhizoctonia, Fusarium, Sclerotinia y Pythium degradándolas con quitinasas/β-1,3-glucanasas; (2) competencia por exudados radiculares; (3) antibióticos volátiles (6-pentil-pirona, gliotoxina); (4) inducción de resistencia sistémica vía jasmonato/etileno. AGROSAVIA y Cenicafé validaron cepas locales ICA-registradas, análogo al carbendazim sin residuos. Advertencias: no aplicar a suelo seco (<30% humedad); incompatible con cúpricos y mancozeb; evitar pleno sol; óptimo pH 4.5-6.5; pH >8.5 reduce viabilidad significativamente (Singh et al. 2014 Front Microbiol 5:1).",
       "source_ids": [
         "cenicafe-trichoderma-2010",
         "agrosavia-manual-biopreparados-2015",
         "agrosavia-bacillus-2018",
         "ica-resolucion-3168-2015"
-      ]
+      ],
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
     },
     {
       "id": "bacillus_subtilis_foliar",
@@ -4007,7 +15659,11 @@
         "mildiu_velloso",
         "oidio_temprano"
       ],
-      "valor_pedagogico": "Bacteria Gram+ esporulada que coloniza la filosfera por exclusión competitiva y secreta lipopéptidos cíclicos (iturina, fengicina, surfactina) que perforan membranas fúngicas y disparan resistencia sistémica inducida (ISR) vía jasmonato/etileno. AGROSAVIA 2018 reporta cepas nativas con 60-80% de eficacia contra Botrytis en fresa/mora —equiparable a azoxistrobina, sin resistencia cruzada ni residuos. Restrepo lo combina con bocashi: éste siembra microbiota en suelo, B. subtilis la extiende al follaje. ADVERTENCIA: esporas fotosensibles (UV degrada en 2-4 h) → aplicar SIEMPRE al atardecer con adherente; incompatible con cobre y caldo sulfocálcico (alternar 48 h)."
+      "valor_pedagogico": "Bacteria Gram+ esporulada *Bacillus subtilis* sensu lato — revisión taxonómica post-2011: las cepas comerciales de biocontrol QST713 (Serenade®) y FZB42 (RhizoVital®), históricamente etiquetadas como *B. subtilis*, fueron reclasificadas como ***Bacillus velezensis*** tras Borriss et al. 2011 *IJSEM* 61:1786 y Dunlap et al. 2016 *Int J Syst Evol Microbiol* 66:1212. En Colombia, las cepas nativas AGROSAVIA bacterias 19 y 35 corresponden a *B. velezensis* (no a *B. subtilis* stricto sensu), aunque los registros ICA conservan el nombre histórico por estabilidad regulatoria. Mecanismos: coloniza la filosfera por exclusión competitiva y secreta lipopéptidos cíclicos (iturina, fengicina, surfactina) que perforan membranas fúngicas y disparan resistencia sistémica inducida (ISR) vía jasmonato/etileno. Estudios de campo con cepas tipo QST713 reportan 40-70% de control de Botrytis en fresa/mora según presión de inóculo y manejo (Punja & Utkhede 2003 *Trends Biotechnol* 21:400); AGROSAVIA 2018 reporta eficacias comparables con cepas nativas, sin resistencia cruzada ni residuos. Restrepo lo combina con bocashi: éste siembra microbiota en suelo, *B. velezensis* (ex *subtilis*) la extiende al follaje. ADVERTENCIA: esporas fotosensibles (UV degrada en 2-4 h) → aplicar SIEMPRE al atardecer con adherente; incompatible con cobre y caldo sulfocálcico (alternar 48 h).",
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
     },
     {
       "id": "cal_dolomita",
@@ -4039,7 +15695,13 @@
         "deficiencia_magnesio",
         "saturacion_bases_baja"
       ],
-      "valor_pedagogico": "CaMg(CO3)2 neutraliza H+/Al3+ del complejo de intercambio: CaMg(CO3)2 + 2Al3+ → Ca2+ + Mg2+ + 2Al(OH)3↓ + 2CO2. La cal NO es fertilizante de Ca: es corrector de toxicidad de aluminio (Cochrane 1980). Usarla 'a ojo' alcaliniza el complejo, precipita P como Ca-fosfatos insolubles, calcina la microbiota y emite ~440 kg CO2/t. REGLA DURA AGROECOLÓGICA: aplicar SOLO con análisis de suelo que muestre pH<5.5 Y saturación Al>30% —sin esos dos criterios es daño neto. NUNCA cal viva (CaO) ni hidratada (Ca(OH)2) en orgánico: Pinheiro y Restrepo lo prohíben (queman raíces y microbiota). Alternativas: bocashi, biocarbón, compost maduro o yeso (CaSO4·2H2O) si solo se requiere Ca sin subir pH."
+      "valor_pedagogico": "CaMg(CO3)2 neutraliza H+/Al3+ del complejo de intercambio: CaMg(CO3)2 + 2Al3+ → Ca2+ + Mg2+ + 2Al(OH)3↓ + 2CO2. La cal NO es fertilizante de Ca: es corrector de toxicidad de aluminio (Cochrane 1980). Usarla 'a ojo' alcaliniza el complejo, precipita P como Ca-fosfatos insolubles, calcina la microbiota y emite ~440 kg CO2/t. REGLA DURA AGROECOLÓGICA: aplicar SOLO con análisis de suelo que muestre pH<5.5 Y saturación Al>30% —sin esos dos criterios es daño neto. NUNCA cal viva (CaO) ni hidratada (Ca(OH)2) en orgánico: Pinheiro y Restrepo lo prohíben (queman raíces y microbiota). Alternativas: bocashi, biocarbón, compost maduro o yeso (CaSO4·2H2O) si solo se requiere Ca sin subir pH.",
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": [
+        "sin_analisis_de_suelo_previo"
+      ],
+      "reentry_interval_dias": null
     },
     {
       "id": "roca_fosforica",
@@ -4069,7 +15731,13 @@
         "enraizamiento_inicial",
         "floracion_fructificacion"
       ],
-      "valor_pedagogico": "Apatita Ca5(PO4)3(F,Cl,OH) de yacimientos colombianos (Pesca-Boyacá, Norte de Santander) molida a malla 200. Libera P-PO4 lentamente sólo en suelo ácido: H+ del rizoplano y ácidos orgánicos (cítrico, oxálico) de micorrizas Glomus protonan el fluorapatito y solubilizan P por 6-24 meses. A pH>6.5 es inerte —aplicarla sobre suelo encalado es desperdicio. AGROSAVIA 2015 y Restrepo 2007 la co-compostan con bocashi: los ácidos del fermento aceleran solubilización 3-5× y Pseudomonas/Bacillus solubilizadores la liberan como P disponible. Vs. DAP/MAP químicos: entrega P sostenida sin acidificar ni salinizar, conserva micorrizas, compatible con IFOAM. Aporta Ca pero no Mg. Usar mascarilla: contiene flúor."
+      "valor_pedagogico": "Apatita Ca5(PO4)3(F,Cl,OH) de yacimientos colombianos (Pesca-Boyacá, Norte de Santander) molida a malla 200. Libera P-PO4 lentamente sólo en suelo ácido: H+ del rizoplano y ácidos orgánicos (cítrico, oxálico) de micorrizas Glomus protonan el fluorapatito y solubilizan P por 6-24 meses. A pH>6.5 es inerte —aplicarla sobre suelo encalado es desperdicio. AGROSAVIA 2015 y Restrepo 2007 la co-compostan con bocashi: los ácidos del fermento aceleran solubilización 3-5× y Pseudomonas/Bacillus solubilizadores la liberan como P disponible. Vs. DAP/MAP químicos: entrega P sostenida sin acidificar ni salinizar, conserva micorrizas, compatible con IFOAM. Aporta Ca pero no Mg. Usar mascarilla: contiene flúor.",
+      "safety_class": "medio",
+      "ppe_required": [
+        "mascarilla"
+      ],
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
     },
     {
       "id": "ceniza_madera",
@@ -4098,7 +15766,16 @@
         "babosas_caracoles_barrera_fisica",
         "ingrediente_bocashi"
       ],
-      "valor_pedagogico": "Residuo de combustión completa de madera dura no tratada: K2CO3 (5-10%), CaO+CaCO3 (20-35%), MgO, P2O5 y micros (B, Zn, Mn, Cu). Restrepo 1996 la incorpora al bocashi como aporte mineral y modulador de pH. ADVERTENCIAS: (1) NUNCA ceniza tratada/pintada/contrachapado/carbón mineral —Cr-Cu-As (CCA), dioxinas, metales pesados; (2) alcalinizante fuerte (~30-50% eq. CaCO3): prohibida con pH>6.5 y en acidófilos (arándano, té); (3) lixivia K rápido —no almacenar a la intemperie; (4) volatiliza NH3 con fertilizante amoniacal. Vs. KCl químico: aporta K+Ca+micros sin salinización por Cl-. AGROSAVIA 2015 la valida como fuente económica de K en finca con leña disponible."
+      "valor_pedagogico": "Residuo de combustión completa de madera dura no tratada: K2CO3 (5-10%), CaO+CaCO3 (20-35%), MgO, P2O5 y micros (B, Zn, Mn, Cu). Restrepo 1996 la incorpora al bocashi como aporte mineral y modulador de pH. ADVERTENCIAS: (1) NUNCA ceniza tratada/pintada/contrachapado/carbón mineral —Cr-Cu-As (CCA), dioxinas, metales pesados; (2) alcalinizante fuerte (~30-50% eq. CaCO3): prohibida con pH>6.5 y en acidófilos (arándano, té); (3) lixivia K rápido —no almacenar a la intemperie; (4) volatiliza NH3 con fertilizante amoniacal. Vs. KCl químico: aporta K+Ca+micros sin salinización por Cl-. AGROSAVIA 2015 la valida como fuente económica de K en finca con leña disponible.",
+      "safety_class": "medio",
+      "ppe_required": [
+        "guantes",
+        "gafas"
+      ],
+      "do_not_use_when": [
+        "madera_tratada_pintada_o_contrachapado"
+      ],
+      "reentry_interval_dias": null
     },
     {
       "id": "compost_maduro",
@@ -4133,7 +15810,13 @@
         "microbiota_suelo_empobrecida",
         "retencion_agua_suelo"
       ],
-      "valor_pedagogico": "Compostaje aeróbico mesofílico-termofílico: sucesión de bacterias (Bacillus, Pseudomonas), actinomicetos (Streptomyces, olor a tierra) y hongos saprófitos que degradan C:N 30:1 hasta húmicos estables (C:N ~12:1). Fase termofílica 55-70°C esteriliza patógenos y semillas de arvenses. Restrepo 1996 y AGROSAVIA 2015 lo posicionan como pilar agroecológico: vs. bocashi (microbioma fresco), aporta materia orgánica HUMIFICADA estable que mejora CIC y retención hídrica (1 g humus = 4-6 g H2O). Vs. NPK químico: no saliniza, secuestra C y reinocula microbiota. CONTROL: C:N 10-15, germinación rábano >80%, sin olor amoniacal. NO usar inmaduro ni de origen desconocido (clopiralida residual mata leguminosas)."
+      "valor_pedagogico": "Compostaje aeróbico mesofílico-termofílico: sucesión de bacterias (Bacillus, Pseudomonas), actinomicetos (Streptomyces, olor a tierra) y hongos saprófitos que degradan C:N 30:1 hasta húmicos estables (C:N ~12:1). Fase termofílica 55-70°C esteriliza patógenos y semillas de arvenses. Restrepo 1996 y AGROSAVIA 2015 lo posicionan como pilar agroecológico: vs. bocashi (microbioma fresco), aporta materia orgánica HUMIFICADA estable que mejora CIC y retención hídrica (1 g humus = 4-6 g H2O). Vs. NPK químico: no saliniza, secuestra C y reinocula microbiota. CONTROL: C:N 10-15, germinación rábano >80%, sin olor amoniacal. NO usar inmaduro ni de origen desconocido (clopiralida residual mata leguminosas).",
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": [
+        "compost_inmaduro_u_origen_desconocido"
+      ],
+      "reentry_interval_dias": null
     },
     {
       "id": "biofertilizante_algas",
@@ -4162,7 +15845,11 @@
       "source_ids": [
         "khan-2009-seaweed-extracts",
         "agrosavia-manual-biopreparados-2015"
-      ]
+      ],
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
     },
     {
       "_curation_status": "PENDING_DR_VERIFICATION_2026-05-17 (caso David trozador; DR-040 pest catalog)",
@@ -4195,7 +15882,11 @@
         "agrosavia-manual-biopreparados-2015",
         "ica-resolucion-3168-2015",
         "gbif-taxonomic-backbone"
-      ]
+      ],
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
     },
     {
       "_curation_status": "PENDING_DR_VERIFICATION_2026-05-17 (caso David trozador; DR-040 pest catalog)",
@@ -4226,7 +15917,11 @@
       "source_ids": [
         "agrosavia-manual-biopreparados-2015",
         "gbif-taxonomic-backbone"
-      ]
+      ],
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
     },
     {
       "_curation_status": "PENDING_DR_VERIFICATION_2026-05-17 (caso David trozador; DR-040 pest catalog)",
@@ -4261,7 +15956,634 @@
         "agrosavia-manual-biopreparados-2015",
         "gbif-taxonomic-backbone",
         "powo-kew"
-      ]
+      ],
+      "safety_class": "medio",
+      "ppe_required": null,
+      "do_not_use_when": [
+        "cerca_de_fuentes_hidricas_menos_30m"
+      ],
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "caldo_visosa",
+      "nombre": "caldo Viçosa (visosa) — variante nutricional-fungicida",
+      "tipo": "caldo",
+      "proposito": [
+        "fertilizacion",
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "sulfato de cobre",
+        "sulfato de zinc",
+        "sulfato de magnesio",
+        "ácido bórico",
+        "cal",
+        "estiércol fresco",
+        "agua sin cloro"
+      ],
+      "proceso_resumen": "Variante del caldo bordelés con sulfatos de Zn, Mg y bórax; añade estiércol fresco. Mezcla y aplicación tras 1-2 horas de reposo.",
+      "tiempo_elaboracion_dias": 1,
+      "vida_util_dias": 3,
+      "source_ids": [
+        "restrepo-2007-caldos-minerales"
+      ],
+      "uso": "Aspersión foliar en cafetales para corrección de microelementos + control fungicida.",
+      "dosis": "Variable según cultivo; consultar protocolo Restrepo 2007 capítulo 3.",
+      "target": [
+        "roya_cafe",
+        "deficiencia_zn_mg_b"
+      ],
+      "valor_pedagogico": "Originaria de la Universidad Federal de Viçosa (Brasil) para cafetales; combina nutrición foliar con efecto fungicida cúprico suave.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "alto",
+      "ppe_required": [
+        "guantes",
+        "careta",
+        "gafas"
+      ],
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "supermagro_restrepo",
+      "nombre": "supermagro (biofertilizante anaeróbico de Restrepo)",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "50 kg estiércol vacuno fresco",
+        "100-140 L agua sin cloro",
+        "2-12 L leche cruda o suero",
+        "2-10 L melaza",
+        "3-5 kg ceniza de leña",
+        "sulfatos minerales (Zn, Mg, Mn, Cu, Fe, Co)",
+        "bórax",
+        "cloruro de calcio",
+        "molibdato de sodio",
+        "harina de roca fosfórica"
+      ],
+      "proceso_resumen": "Mezcla inicial estiércol+agua+leche+melaza en caneca plástica de 200 L con tapa hermética y válvula de fermentación; adición semanal escalonada de sales minerales disueltas en agua tibia con melaza; fermentación anaeróbica.",
+      "tiempo_elaboracion_dias": 75,
+      "vida_util_dias": 365,
+      "source_ids": [
+        "restrepo-2007-biopreparados",
+        "restrepo-1996-abc-agricultura-organica"
+      ],
+      "uso": "Aspersión foliar al amanecer o atardecer; aplicación al suelo en drench.",
+      "dosis": "Foliar 1-5%; suelo 10-30%.",
+      "target": [
+        "nutricion_micronutrientes",
+        "induccion_resistencia"
+      ],
+      "valor_pedagogico": "60-90 días anaeróbico según temperatura ambiente (60 en tierra caliente, 90 en altiplano). A menos de 60 días los sulfatos NO terminan de quelar y queman follaje (Restrepo 2007, capítulo biofertilizantes). Color final ámbar-marrón con olor a chicha; descartar si huele a putrefacción. Origen brasileño (Delvino Magro / Pinheiro Machado) adaptado por Jairo Restrepo en Colombia.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "revisar",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "caldo_m5_restrepo",
+      "nombre": "caldo M5 de Restrepo (bioinsecticida-bioestimulante)",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano",
+        "repelente_insectos"
+      ],
+      "ingredientes": [
+        "estiércol vacuno fresco",
+        "leche cruda o suero",
+        "melaza",
+        "harinas (trigo, maíz)",
+        "ceniza de leña",
+        "sulfatos minerales",
+        "agua sin cloro"
+      ],
+      "proceso_resumen": "Fermentación anaeróbica en caneca de 200 L similar a supermagro pero con énfasis en harinas y ceniza para densificación microbiana; uso anti-insectos chupadores.",
+      "tiempo_elaboracion_dias": 30,
+      "vida_util_dias": 180,
+      "source_ids": [
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Aspersión foliar contra áfidos, mosca blanca, trips.",
+      "dosis": "Foliar 2-5%.",
+      "target": [
+        "afidos",
+        "mosca_blanca",
+        "trips"
+      ],
+      "valor_pedagogico": "Variante densificada del supermagro. La formulación exacta varía según edición de Restrepo — verificar capítulo 'biofertilizantes especiales' en edición física 2007.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "revisar",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "microorganismos_montana_solido",
+      "nombre": "microorganismos de montaña (MM) sólido",
+      "tipo": "microbiano",
+      "proposito": [
+        "estimulante_microbiano",
+        "fertilizacion"
+      ],
+      "ingredientes": [
+        "60 L hojarasca de bosque maduro (capa M2/M3 con micelio blanco)",
+        "50 kg salvado o pulido de arroz",
+        "agua sin cloro al 30-40% humedad de campo"
+      ],
+      "proceso_resumen": "Recolectar hojarasca bajo bosque maduro nativo (no plantaciones); mezclar con salvado humedecido con agua sin cloro al 30-40% — SIN melaza (la melaza se reserva para la activación líquida MMA); compactar en barril hermético de 200 L; fermentación anaeróbica sin remover.",
+      "tiempo_elaboracion_dias": 30,
+      "vida_util_dias": 365,
+      "source_ids": [
+        "vasquez-solano-2021-mm-agronomia-cr",
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Base para activación líquida (MM líquido) o como inoculante para bocashi y compostaje.",
+      "dosis": "5-10 kg por m³ de compost; 1 kg/m² al suelo.",
+      "target": [
+        "activacion_suelo",
+        "descomposicion_materia_organica"
+      ],
+      "valor_pedagogico": "La calidad depende del bosque madre — recolectar en bosques con dosel cerrado, suelo con hojarasca blanca (micelio activo) y sin perturbación reciente. Método Restrepo & Hensel 2015 validado por Vásquez-Solano et al. 2021 Agronomía Costarricense.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "bajo",
+      "ppe_required": [
+        "tapabocas"
+      ],
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "microorganismos_montana_liquido",
+      "nombre": "microorganismos de montaña (MM) líquido",
+      "tipo": "microbiano",
+      "proposito": [
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "10 kg MM sólido",
+        "200 L agua sin cloro",
+        "5 L melaza",
+        "barril hermético con válvula de fermentación"
+      ],
+      "proceso_resumen": "Disolver MM sólido en agua con melaza dentro de barril hermético; fermentación anaeróbica con válvula de escape; cosechar al estabilizar burbujeo.",
+      "tiempo_elaboracion_dias": 10,
+      "vida_util_dias": 30,
+      "source_ids": [
+        "vasquez-solano-2021-mm-agronomia-cr",
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Aspersión foliar y al suelo; activador de compostaje.",
+      "dosis": "Foliar 1-5%; suelo 5-10%.",
+      "target": [
+        "activacion_suelo",
+        "supresion_patogenos_suelo"
+      ],
+      "valor_pedagogico": "Vida útil corta (~30 días) — usar fresco. Olor agridulce a chicha indica calidad; rechazar si huele a putrefacción.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "jadam_microbial_solution_jms",
+      "nombre": "JADAM Microbial Solution (JMS)",
+      "tipo": "microbiano",
+      "proposito": [
+        "estimulante_microbiano",
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "1-2 puñados de hojarasca de bosque nativo local (leaf-mold con micelio blanco)",
+        "1 papa mediana cocida y triturada",
+        "1 cucharada (~15 g) sal marina sin refinar",
+        "20 L agua sin cloro a 25-30°C"
+      ],
+      "proceso_resumen": "Colocar hojarasca en bolsa de tela dentro del agua; añadir papa cocida + sal; fermentación aeróbica a 25-30°C; cosechar al formar espuma blanca densa.",
+      "tiempo_elaboracion_dias": 2,
+      "vida_util_dias": 3,
+      "source_ids": [
+        "cho-2016-jadam-organic-farming"
+      ],
+      "uso": "Aspersión foliar y al suelo fresco; no almacenar.",
+      "dosis": "Dilución 1:10 a 1:500 según uso (drench o foliar).",
+      "target": [
+        "activacion_suelo",
+        "supresion_patogenos"
+      ],
+      "valor_pedagogico": "Vida útil EXTREMADAMENTE corta — aplicar dentro de 24-72h tras pico de actividad microbiana. Reemplaza compra de inoculantes comerciales. Receta canónica Cho 2016 ISBN 9788989220206.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "jadam_wetting_agent_jwa",
+      "nombre": "JADAM Wetting Agent (JWA)",
+      "tipo": "compuesto",
+      "proposito": [
+        "fitosanitario_curativo"
+      ],
+      "ingredientes": [
+        "aceite de canola o coco",
+        "hidróxido de potasio (KOH, potasa cáustica)",
+        "agua sin cloro"
+      ],
+      "proceso_resumen": "Saponificación de aceite con KOH a temperatura ambiente en proporción 1 L aceite vegetal (oliva, soja o canola) : 200 g KOH (hidróxido de potasio ≥85% pureza, sólido en hojuelas) : 1 L agua destilada — tabla JADAM (Cho 2016/2021). Disolver el KOH MUY lentamente en el agua (reacción exotérmica que libera vapor cáustico); cuando la solución descienda a <40 °C verter sobre el aceite y agitar 5-10 min hasta emulsión homogénea; reposo 24 h hasta jabón potásico líquido translúcido. NO usar NaOH (hidróxido de sodio): produce jabón sólido en pasta, no surfactante líquido.",
+      "tiempo_elaboracion_dias": 1,
+      "vida_util_dias": 365,
+      "source_ids": [
+        "cho-2016-jadam-organic-farming",
+        "cho-2021-jadam-pest-disease"
+      ],
+      "uso": "Surfactante natural y bioinsecticida de contacto. Mezclar con caldos foliares para mejorar adherencia.",
+      "dosis": "1:30 a 1:100 según objetivo.",
+      "target": [
+        "afidos",
+        "cochinilla_harinosa",
+        "mosca_blanca"
+      ],
+      "valor_pedagogico": "Jabón potásico líquido producido por saponificación de aceites vegetales con KOH; actúa como surfactante (rompe la cutícula cerosa de áfidos, cochinillas y mosca blanca) y mejora la adherencia/penetración de caldos foliares. Compatible con caldo sulfocálcico y JMS. PROCEDIMIENTO PROFESIONAL — PRECAUCIONES DE SEGURIDAD INNEGOCIABLES: (1) EPE obligatorio: guantes de nitrilo (NO látex), lentes herméticos tipo química, delantal o tyvek de PVC, mangas largas y botas cerradas. El KOH al disolverse libera calor (saponificación exotérmica) y puede salpicar spray cáustico que ataca piel y córnea en segundos. (2) Si se planea usar agua corriente añadir SIEMPRE el KOH al agua y nunca al revés (regla del químico: ácido o base al agua, jamás agua a la base). (3) Trabajar al aire libre o con extracción; el vapor irrita vías respiratorias. (4) Tener vinagre comercial 5% y agua abundante a mano para neutralizar salpicaduras (KOH es base fuerte: el vinagre la neutraliza). (5) NO usar NaOH: produce jabón sólido en pasta, no líquido, e inutiliza la receta. ALTERNATIVA RECOMENDADA: si tienes dudas sobre seguridad o pureza del KOH disponible, comprar surfactante OMRI listed comercial (jabón potásico foliar registrado ante ICA) — mismo efecto sin riesgo cáustico. Costo equivalente para finca pequeña.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "alto",
+      "ppe_required": [
+        "guantes_nitrilo",
+        "gafas_hermeticas",
+        "delantal_impermeable",
+        "manga_larga",
+        "botas_cerradas"
+      ],
+      "do_not_use_when": [
+        "preparar_sin_ventilacion_o_espacio_cerrado"
+      ],
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "vinagre_madera_pirolenoso",
+      "nombre": "vinagre de madera (ácido piroleñoso)",
+      "tipo": "extracto",
+      "proposito": [
+        "fitosanitario_preventivo",
+        "estimulante_microbiano",
+        "repelente_insectos"
+      ],
+      "ingredientes": [
+        "ramas y leña de especies leñosas (acacia, bambú, leucaena) de 2-5 cm de diámetro",
+        "horno o tambor de carbonización lenta con condensador"
+      ],
+      "proceso_resumen": "Pirólisis lenta de leña a 300-500°C en horno cerrado con condensador; recuperar condensado por enfriamiento; reposo de 3-6 meses para separar tres fases (alquitrán pesado / vinagre clarificado central / aceite ligero); decantar fase central.",
+      "tiempo_elaboracion_dias": 120,
+      "vida_util_dias": 1095,
+      "source_ids": [
+        "cho-2016-jadam-organic-farming"
+      ],
+      "uso": "Aspersión foliar y al suelo; coadyuvante de otros biopreparados.",
+      "dosis": "1:200 a 1:1000 según uso (germinación 1:500; foliar 1:300).",
+      "target": [
+        "hongos_foliares",
+        "nematodos",
+        "repelente_general"
+      ],
+      "valor_pedagogico": "Condensado obtenido por pirólisis lenta (250-400 °C en horno cerrado con condensador refrigerado) de leña dura; contiene ácido pirolígneo, guayacol, fenoles y carbonilos que actúan como fungistato preventivo, repelente de insectos y estimulante microbiano del suelo. NO USAR FRESCO — contiene alquitranes (PAHs, hidrocarburos aromáticos policíclicos) fitotóxicos y potencialmente cancerígenos. Reposo mínimo 90 días obligatorio para separación de tres fases y descarte de alquitrán pesado. ADVERTENCIA INELABORABILIDAD EN FINCA: requiere horno de pirólisis controlada (250-400 °C) con condensador refrigerado y termómetro de proceso. **Sin este equipo, NO es elaborable en finca** — comprar producto registrado ICA (e.g. Wood Vinegar de empresas certificadas, o destilados pirolígneos de productores artesanales con control de PAHs). El vinagre casero \"ahumado\" en barbacoa, fogón o tambor sin condensador NO es vinagre de madera real: carece de la concentración de componentes activos (guayacol, ácido pirolígneo, fenoles antimicrobianos) y puede contener residuos cancerígenos sin separación de fases. Si la finca no dispone del horno, derivar a producto comercial o sustituir por extracto fermentado de plantas aromáticas.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "alto",
+      "ppe_required": null,
+      "do_not_use_when": [
+        "producto_fresco_sin_reposo_90_dias",
+        "sin_equipo_pirolisis_controlada_con_condensador"
+      ],
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "fermento_fpj_brotes",
+      "nombre": "FPJ — Fermented Plant Juice de brotes (Cho/KNF)",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "7 partes (peso) de brotes tiernos cosechados al amanecer (ortiga, consuelda, alfalfa, bambú joven, ipomoea)",
+        "3 partes azúcar morena cruda"
+      ],
+      "proceso_resumen": "Picar brotes en trozos pequeños; mezclar con azúcar en vasija de barro o vidrio; cubrir con papel poroso; fermentar a la sombra a temperatura ambiente.",
+      "tiempo_elaboracion_dias": 7,
+      "vida_util_dias": 365,
+      "source_ids": [
+        "park-duponte-2008-lab-ctahr"
+      ],
+      "uso": "Aspersión foliar en fase vegetativa (estimulante hormonal).",
+      "dosis": "1:500 a 1:1000.",
+      "target": [
+        "fase_vegetativa",
+        "induccion_brotacion"
+      ],
+      "valor_pedagogico": "Proporción correcta 7:3 planta:azúcar según Cho Han-Kyu (KNF) — no 1:1 como suele simplificarse. Cosechar brotes antes del sol para maximizar actividad enzimática.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "revisar",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "fermento_faa_pescado",
+      "nombre": "FAA — Fish Amino Acids (Cho/KNF)",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion"
+      ],
+      "ingredientes": [
+        "1 parte (peso) restos de pescado (vísceras, cabezas, espinas)",
+        "1 parte azúcar morena cruda"
+      ],
+      "proceso_resumen": "Mezclar pescado picado con azúcar en vasija de barro o plástico no metálico; cubrir con papel; fermentar a temperatura ambiente con remoción ocasional.",
+      "tiempo_elaboracion_dias": 120,
+      "vida_util_dias": 730,
+      "source_ids": [
+        "park-duponte-2008-lab-ctahr"
+      ],
+      "uso": "Aspersión foliar como fuente de N orgánico y aminoácidos libres.",
+      "dosis": "1:500 a 1:1000.",
+      "target": [
+        "fase_crecimiento_vegetativo",
+        "fuente_nitrogeno"
+      ],
+      "valor_pedagogico": "Fermentación 3-6 meses para hidrólisis completa. Líquido final ámbar oscuro con olor sui generis (NO putrefacto).",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "revisar",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "fermento_lab_lactobacilos",
+      "nombre": "LAB — cultivo de lactobacilos (Cho/KNF)",
+      "tipo": "microbiano",
+      "proposito": [
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "agua del lavado de arroz integral",
+        "leche fresca (cruda preferible) en proporción 1:10 respecto al sobrenadante",
+        "azúcar morena (conservante 1:1 al final)"
+      ],
+      "proceso_resumen": "Paso 1: Reposar agua del lavado de arroz 2-3 días hasta separación. Paso 2: Tomar sobrenadante y mezclar con leche fresca en proporción 1:10; reposar 5-7 días hasta separación curd/suero amarillo. Cosechar suero (LAB); conservar con azúcar morena 1:1.",
+      "tiempo_elaboracion_dias": 10,
+      "vida_util_dias": 365,
+      "source_ids": [
+        "park-duponte-2008-lab-ctahr"
+      ],
+      "uso": "Inoculación de letrinas, compostera, suelo; reducción de olores; supresión patógenos.",
+      "dosis": "1:1000 foliar; 1:500 suelo y compostera.",
+      "target": [
+        "supresion_patogenos_suelo",
+        "compostaje",
+        "reduccion_olores"
+      ],
+      "valor_pedagogico": "Procedimiento de dos etapas; rendimiento ~10% del volumen de leche. Mezclar con FPJ y FAA en aspersiones combinadas.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "biofertilizante_purin_rumen",
+      "nombre": "biofertilizante a base de contenido ruminal (biol ruminal)",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "4-6 kg contenido ruminal fresco bovino",
+        "10-15 kg estiércol fresco",
+        "2-4 L melaza",
+        "1-2 L leche cruda o suero",
+        "agua sin cloro hasta 100 L"
+      ],
+      "proceso_resumen": "Mezclar en caneca hermética con válvula de fermentación; fermentación anaeróbica.",
+      "tiempo_elaboracion_dias": 40,
+      "vida_util_dias": 180,
+      "source_ids": [
+        "mamani-2015-biol-ruminal"
+      ],
+      "uso": "Aspersión foliar y aplicación al suelo (drench).",
+      "dosis": "Foliar 5-10%; suelo 10-20%.",
+      "target": [
+        "nutricion_nitrogenada",
+        "inoculo_microbiano_anaerobio"
+      ],
+      "valor_pedagogico": "Aprovecha residuo de mataderos. Mamani-Pati et al. 2015 (J Selva Andina Res Soc 6(1)) reportan 123-256 mg/L de N según cantidad de contenido ruminal añadido.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "revisar",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "harina_rocas_basalto",
+      "nombre": "harina de rocas basálticas (remineralización)",
+      "tipo": "mineral",
+      "proposito": [
+        "fertilizacion",
+        "enmienda_ca"
+      ],
+      "ingredientes": [
+        "roca basáltica molida (granulometría <100 mesh / <0.15 mm)"
+      ],
+      "proceso_resumen": "Molienda fina de basalto fresco; sin proceso fermentativo. Aplicación directa o incorporada a bocashi y biofertilizantes.",
+      "tiempo_elaboracion_dias": 0,
+      "vida_util_dias": 3650,
+      "source_ids": [
+        "pinheiro-restrepo-2009-remineralizacion"
+      ],
+      "uso": "Voleo al suelo; incorporación a compost y bocashi; adición a biopreparados líquidos.",
+      "dosis": "300 g/m² al voleo; 3 t/ha;  2-5 kg por 200 L de biofertilizante.",
+      "target": [
+        "remineralizacion_suelo",
+        "formacion_complejo_arcilla_humus"
+      ],
+      "valor_pedagogico": "Composición típica SiO₂ 45-52%, Fe 3.4%, Mg 2.1%, Ca 3.8%, >70 oligoelementos.  Liberación lenta — efectos visibles a partir de 6-12 meses. Heredero de Julius Hensel 'Brot aus Steinen' (1894), reeditado por Pinheiro-Restrepo 2009.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "revisar",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "biofertilizante_super_4",
+      "nombre": "biofertilizante Super 4 — sulfatos Cu/Zn/Mg/Fe en estiércol fermentado",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano",
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "50 kg estiércol vacuno fresco",
+        "100 L agua sin cloro",
+        "4 L leche cruda o suero",
+        "4 L melaza o panela diluida",
+        "300 g sulfato de cobre (CuSO4·5H2O)",
+        "600 g sulfato de zinc (ZnSO4·7H2O)",
+        "600 g sulfato de magnesio (MgSO4·7H2O)",
+        "400 g sulfato de hierro (FeSO4·7H2O)",
+        "2 kg ceniza de leña limpia"
+      ],
+      "proceso_resumen": "Mezcla base estiércol+agua+leche+melaza en caneca plástica de 200 L con tapa hermética y válvula trampa de agua (botella PET con manguera). Adición escalonada semanal de un sulfato por semana, disuelto previo en 2 L agua tibia con 250 mL melaza para favorecer quelación con ácidos orgánicos producidos por Lactobacillus y levaduras. Fermentación anaeróbica 60-90 días según T° ambiente (60 días en tierra caliente >22°C, 90 días en altiplano <16°C).",
+      "tiempo_elaboracion_dias": 75,
+      "vida_util_dias": 365,
+      "source_ids": [
+        "restrepo-2007-biopreparados",
+        "restrepo-1996-abc-agricultura-organica",
+        "pinheiro-machado-2017-biofertilizantes",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "uso": "Aspersión foliar al amanecer o atardecer en cultivos con deficiencia diagnosticada de microelementos; aplicación en drench al suelo en frutales y café. Compatible con MM líquido y biol en rotación, NO en tanque mezcla con caldos cúpricos ni sulfocálcicos.",
+      "dosis": "Foliar 1-3% (10-30 mL/L) en hortalizas y café; 3-5% (30-50 mL/L) en frutales adultos. Suelo/drench 10-20%. NUNCA aplicar antes de 60 días de fermentación: sulfatos sin quelar son fitotóxicos y queman follaje.",
+      "target": [
+        "nutricion_micronutrientes",
+        "deficiencia_zn_mg_b",
+        "correccion_micronutrientes",
+        "induccion_resistencia",
+        "estimulante_microbiano_filoplano"
+      ],
+      "valor_pedagogico": "Variante reducida y \"low-cost\" del Supermagro Restrepo-Pinheiro: usa solo 4 sulfatos críticos (Cu/Zn/Mg/Fe) en vez de los 10+ del Supermagro completo, lo que la hace viable para finca campesina sin acceso a químicas industriales. El proceso anaeróbico de 60-90 días es clave: Lactobacillus y Saccharomyces secretan ácidos orgánicos (láctico, acético, cítrico) y aminoácidos libres que quelan los sulfatos minerales en complejos biodisponibles análogos a EDTA/EDDHA pero biológicos (Restrepo 1996 ABC agricultura orgánica; Pinheiro Machado 2017 Manual biofertilizantes). A menos de 60 días los sulfatos NO terminan de quelar y queman follaje (caso documentado AGROSAVIA Manual Biopreparados 2015). Color final ámbar-marrón con olor a chicha fermentada; descartar si huele a putrefacción amoniacal (descomposición anaeróbica fallida). Origen brasileño (Delvino Magro / Pinheiro Machado), adaptado por Jairo Restrepo en Colombia para fincas cafeteras y hortícolas de altiplano. NO confundir con el Supermagro Restrepo (10 minerales) ni con el supermagro_restrepo del catálogo: este Super 4 es la formulación introductoria para productores sin experiencia previa en biofermentos.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "revisar",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
+    },
+    {
+      "id": "purin_helecho",
+      "nombre": "Purín de helecho macho (Pteridium aquilinum)",
+      "tipo": "fermentado",
+      "proposito": [
+        "repelente_insectos",
+        "fitosanitario_preventivo",
+        "fitosanitario_curativo"
+      ],
+      "ingredientes": [
+        "1 kg frondes frescos de Pteridium aquilinum (helecho marranero, helecho macho)",
+        "10 L agua sin cloro"
+      ],
+      "proceso_resumen": "Cortar frondes maduros (no báculos juveniles altamente tóxicos). Picar grueso y sumergir en agua sin cloro 1:10 en recipiente plástico tapado con tela respirable. Fermentación aeróbica 10-14 días con agitación cada 2-3 días, hasta cesar la espuma (indicador de fermentación completa). Color final marrón oscuro con olor herbáceo intenso. Filtrar antes de uso.",
+      "tiempo_elaboracion_dias": 12,
+      "vida_util_dias": 45,
+      "source_ids": [
+        "pinheiro-restrepo-2003-purines",
+        "restrepo-2007-biopreparados",
+        "pinheiro-1990-trofobiosis"
+      ],
+      "uso": "Aspersión foliar y al suelo en horas frescas (amanecer/atardecer) en cultivos con presión de babosas (Limax, Deroceras), caracoles (Helix), áfidos (Myzus persicae) y pulgón lanigero. Particularmente útil en lechugas, repollos, fresa y ornamentales en zonas húmedas frías. Aplicación al pie como anti-babosa preventivo en almácigos. NO aplicar a cosecha de hoja fresca menos de 14 días antes (precaución por ptaquilósido residual).",
+      "dosis": "Foliar 1:10 (puro/macerado a 100 mL/L de agua) preventivo; 1:5 (200 mL/L) curativo en alta presión. Aplicación al suelo en barrera anti-babosa 1:3 alrededor de almácigos al atardecer.",
+      "target": [
+        "babosas_caracoles_barrera_fisica",
+        "control_pulgon",
+        "repelente_general",
+        "fitosanitario_preventivo_chupadores"
+      ],
+      "valor_pedagogico": "Receta tradicional campesina europea (Francia, Suiza) recogida por Pinheiro Machado y Restrepo Rivera para el contexto latinoamericano (Pinheiro & Restrepo 2003 Cartilha de purines). Pteridium aquilinum contiene ptaquilósido (norsesquiterpenoide), tianinasa y polifenoles que actúan como antialimentarios contra moluscos y áfidos (Vetter 2009 Food Chem Toxicol 47:3185). En Colombia el helecho marranero es nativo cosmopolita y abundante post-disturbio en zonas templadas-frías, por lo que es un recurso gratuito accesible para el productor — NO requiere cultivar la especie (auditoría agroecológica 2026-05-21 advierte: Pteridium NO es cultivable, solo recolectar de poblaciones naturales pero NO en páramo según Res. 684/2018 MADS). ADVERTENCIA: ptaquilósido es cancerígeno por exposición crónica (Smith et al. 2000 Nat Toxins 8:233); el productor debe usar guantes nitrilo al manipular frondes y NO ingerir agua de remojo. Diferencia con purín de ortiga: Pteridium ataca moluscos (babosas/caracoles); Urtica ataca artrópodos (áfidos/ácaros). En la trofobiosis de Chaboussou-Pinheiro 1990, el purín de helecho regula el equilibrio Ca/N foliar haciendo la planta menos atractiva a moluscos sin tóxicos sistémicos.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "alto",
+      "ppe_required": [
+        "guantes_nitrilo"
+      ],
+      "do_not_use_when": [
+        "no_ingerir_el_producto"
+      ],
+      "reentry_interval_dias": 14
+    },
+    {
+      "id": "caldo_ortiga_consuelda",
+      "nombre": "Caldo mineralizante de ortiga y consuelda",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano",
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "500 g ortiga fresca (Urtica dioica, U. urens o U. ballotifolia nativa andina)",
+        "500 g hojas de consuelda (Symphytum officinale o S. uplandicum)",
+        "10 L agua sin cloro",
+        "100 mL melaza o panela diluida (opcional, para acelerar fermentación láctica)"
+      ],
+      "proceso_resumen": "Cortar hojas frescas pre-floración (mayor concentración de hormonas vegetales). Mezclar 1:1 en recipiente plástico (NO metal — corrosión por ácido fórmico de la ortiga y silicatos). Cubrir con agua, agregar melaza opcional, tapar con tela respirable. Fermentación aeróbica 10-14 días con agitación cada 2 días, hasta cesar la espuma. Color final marrón-verdoso con olor a hierba fermentada. Filtrar antes de uso.",
+      "tiempo_elaboracion_dias": 12,
+      "vida_util_dias": 60,
+      "source_ids": [
+        "pinheiro-restrepo-2003-purines",
+        "pinheiro-1990-trofobiosis",
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Aspersión foliar al amanecer o atardecer en fase vegetativa y pre-floración de hortalizas de hoja, tomate, fresa, mora y ornamentales. Aplicación al suelo en plántulas para acelerar enraizamiento. NO mezclar con caldos cúpricos (Cu precipita con Fe y silicatos del extracto).",
+      "dosis": "Foliar 1:10 (100 mL/L) cada 7-10 días en fase vegetativa; 1:20 (50 mL/L) en plántulas y trasplante reciente. Drench al suelo 1:5 en surcos de fresa y hortalizas de hoja.",
+      "target": [
+        "fertilizante_foliar_N",
+        "fertilizante_foliar_Fe_Si",
+        "bioestimulante_fitohormonal",
+        "bioestimulante_enraizamiento",
+        "induccion_resistencia",
+        "fase_crecimiento_vegetativo"
+      ],
+      "valor_pedagogico": "Combinación clásica de la agroecología europea (Hans-Peter Rusch, alemán; Maria Thun, biodinámica) introducida a Latinoamérica por Pinheiro Machado y Restrepo Rivera (Pinheiro & Restrepo 2003 Cartilha purines). Urtica dioica aporta Fe (4-7 mg/g MS), Si soluble, ácido fórmico antialimentario y polifenoles inductores de resistencia (ISR mediada por jasmonato/etileno — Pieterse et al. 2014 Annu Rev Phytopathol 52:347). Symphytum officinale aporta allantoina (estimulante de división celular vegetal), K soluble (3-7% MS) y proteínas con alto contenido de aminoácidos libres tras fermentación. La sinergia produce un estimulante foliar fitohormonal natural — Pinheiro Machado 1990 (teoria da trofobiose) demostró que plantas con balance Fe/K/Si adecuado producen menos aminoácidos libres en savia, lo que reduce ataques de áfidos y trips porque estos requieren N-amino disponible en floema. ADVERTENCIA: NO ingerir ni aplicar a cosecha de hoja menos de 14 días antes — consuelda contiene alcaloides pirrolizidínicos (PA) con hepatotoxicidad documentada en uso oral crónico (EMA 2013, restricción europea). Para uso agrícola foliar es seguro. NO mezclar con caldos cúpricos (Cu precipita Fe + Si del extracto como Cu(OH)2 + FeSiO3). Diferencia con purín de ortiga simple: la consuelda agrega allantoina y K — pasa de repelente-mineralizador a estimulante de crecimiento completo.",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "medio",
+      "ppe_required": [
+        "guantes"
+      ],
+      "do_not_use_when": [
+        "no_ingerir_el_producto"
+      ],
+      "reentry_interval_dias": 14
+    },
+    {
+      "id": "abono_verde_avena_vicia",
+      "nombre": "Abono verde de avena + vicia (cobertura biocida + fijación N)",
+      "tipo": "residuo",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano",
+        "enmienda_p"
+      ],
+      "ingredientes": [
+        "40-60 kg/ha semilla avena (Avena sativa)",
+        "20-40 kg/ha semilla vicia (Vicia sativa o V. villosa)",
+        "inoculante Rhizobium leguminosarum biovar viciae (opcional, sí en suelos sin historial leguminosas)"
+      ],
+      "proceso_resumen": "Siembra al voleo o en surcos de mezcla avena:vicia (2:1 a 3:1 en peso) al inicio de la temporada de lluvias. Avena crece rápido como tutor estructural; vicia trepadora fija N₂ atmosférico vía nodulación con Rhizobium. Crecimiento 60-90 días hasta floración de la vicia (momento de máximo aporte N). Corte con guadaña o pisado con rolo-faca; incorporación superficial a 10-15 cm con arado de cinceles o azadón, o dejado como mulch en siembra directa. Descomposición 30-60 días previo a siembra del cultivo comercial.",
+      "tiempo_elaboracion_dias": 90,
+      "vida_util_dias": 90,
+      "source_ids": [
+        "agrosavia-abonos-verdes-boyaca-2018",
+        "restrepo-1996-abc-agricultura-organica",
+        "pinheiro-machado-2017-biofertilizantes"
+      ],
+      "uso": "Rotación pre-cultivo de papa, hortalizas de hoja, maíz, fresa y café joven en zonas templado-frías (1800-3000 msnm, Cundinamarca y Boyacá). Aplicación como cobertura en calles de frutales adultos. NO usar como abono verde si el cultivo siguiente es leguminosa (no aporta el ciclo Rhizobium-leguminosa).",
+      "dosis": "Densidad siembra avena 40-60 kg/ha, vicia 20-40 kg/ha (densidades menores en zonas con buena humedad). Incorporación a 10-15 cm para maximizar descomposición sin perder N por volatilización (Cherr et al. 2006 Agron J 98:302).",
+      "target": [
+        "aporte_materia_organica",
+        "fuente_nitrogeno",
+        "mejorador_estructura_suelo",
+        "preventivo_nematodos",
+        "establecimiento_perennes",
+        "baja_materia_organica_suelo"
+      ],
+      "valor_pedagogico": "Tecnología agroecológica clásica de cobertura biocida documentada en Colombia por AGROSAVIA-CI Tibaitatá (Modelo productivo de abonos verdes en sistemas de papa y hortalizas en Cundinamarca y Boyacá, 2018) y promovida por Restrepo Rivera (ABC de la agricultura orgánica, 1996) y Pinheiro Machado (Manual biofertilizantes, 2017). La mezcla avena+vicia integra dos servicios ecosistémicos complementarios: Avena sativa aporta biomasa estructural (4-8 t MS/ha), root system fibroso que mejora porosidad y estructura del suelo, y exudados radiculares alelopáticos (avenacina, escopoletina) supresores de Pratylenchus y Meloidogyne (nematodos fitoparásitos — Mojtahedi et al. 1991 J Nematol 23:170). Vicia sativa/villosa fija N₂ atmosférico vía simbiosis con Rhizobium leguminosarum bv. viciae aportando 80-150 kg N/ha disponible tras incorporación (AGROSAVIA 2018, dato verificado en CI Tibaitatá-La Selva para zona alta cundiboyacense). En conjunto: avena protege suelo de erosión y compactación + vicia carga N biológico — equivalente fertilizante a 200-350 kg urea/ha sin aporte exógeno. Incorporación al inicio floración vicia maximiza N (relación C:N ~15-20:1, ideal para descomposición rápida sin inmovilización). REGLA AGROECOLÓGICA: rotar siempre antes de cultivo NO-leguminoso. NO sembrar después de otra Vicia o Pisum (saturación nodulación, riesgo enfermedades radiculares).",
+      "_curation_status": "BORRADOR_IA",
+      "safety_class": "bajo",
+      "ppe_required": null,
+      "do_not_use_when": null,
+      "reentry_interval_dias": null
     }
   ]
 }

--- a/scripts/__tests__/extract-oss-subset.test.mjs
+++ b/scripts/__tests__/extract-oss-subset.test.mjs
@@ -1,0 +1,55 @@
+/**
+ * scripts/__tests__/extract-oss-subset.test.mjs
+ *
+ * Regresion del extractor OSS v3.1.
+ * Verifica que el subset derivado cierre las referencias cruzadas de species
+ * y sources necesarias para que AMB-13 quede en cero errores.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import { buildOssSubset, REF_FIELDS_TO_CLOSE } from '../extract-oss-subset.mjs';
+import { validateAmb13_crossRefs } from '../validate-catalog.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fullCatalogPath = path.join(__dirname, '../../catalog/chagra-catalog-oss-subset-v3.2.json');
+const fullCatalog = JSON.parse(fs.readFileSync(fullCatalogPath, 'utf8'));
+
+describe('extract-oss-subset.mjs', () => {
+  it('cierra species y sources referenciados sin dejar errores AMB-13', () => {
+    const subset = buildOssSubset(fullCatalog);
+    const speciesIds = new Set(subset.species.map((s) => s.id));
+    const sourceIds = new Set(subset.sources.map((s) => s.id));
+
+    expect(subset._subset_meta.seed_species_count).toBe(50);
+    expect(subset.species.length).toBeGreaterThan(50);
+    expect(speciesIds.has('solanum_phureja')).toBe(true);
+    expect(speciesIds.has('vaccinium_corymbosum_biloxi')).toBe(true);
+    expect(speciesIds.has('solanum_lycopersicum_san_marzano')).toBe(true);
+    expect(speciesIds.has('ulex_europaeus')).toBe(true);
+
+    expect(sourceIds.has('restrepo-1996-bocashi')).toBe(true);
+    expect(sourceIds.has('pinheiro-machado-2017-biofertilizantes')).toBe(true);
+    expect(sourceIds.has('ingham-2000-compost-tea')).toBe(true);
+
+    for (const sp of subset.species) {
+      for (const field of REF_FIELDS_TO_CLOSE) {
+        for (const refId of sp[field] || []) {
+          expect(speciesIds.has(refId), `${sp.id}.${field} -> ${refId} no existe en species[]`).toBe(true);
+        }
+      }
+    }
+
+    for (const bp of subset.biopreparados) {
+      for (const sid of bp.source_ids || []) {
+        expect(sourceIds.has(sid), `biopreparado ${bp.id} -> ${sid} no existe en sources[]`).toBe(true);
+      }
+    }
+
+    const amb13 = validateAmb13_crossRefs(subset, true);
+    expect(amb13.errors).toEqual([]);
+  });
+});

--- a/scripts/extract-oss-subset.mjs
+++ b/scripts/extract-oss-subset.mjs
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 /**
- * extract-oss-subset.mjs — Extrae subset 50 species OSS del catálogo full.
+ * extract-oss-subset.mjs — Extrae el subset OSS público v3.1 a partir del
+ * catálogo full y cierra las referencias cruzadas mínimas necesarias.
  *
- * Lee:  catalog/chagra-catalog-seed-v3.1.json  (488 species full)
- * Escribe: catalog/chagra-catalog-oss-subset-v3.1.json  (50 species curadas)
+ * Lee:  catalog/chagra-catalog-oss-subset-v3.2.json
+ * Escribe: catalog/chagra-catalog-oss-subset-v3.1.json
  *
- * Filtra:
- * - 50 IDs hardcoded (cobertura multi-piso + cultivos canónicos colombianos)
- * - sources[] solo los referenciados por las 50 species
- * - biopreparados[] mantiene los presentes en catálogo full (sin filtrado)
+ * Estrategia:
+ * - Semilla de 50 IDs hardcoded (cobertura multi-piso + cultivos canónicos)
+ * - Clausura recursiva de species referenciadas por companions/antagonists/
+ *   recommended_covers/recommended_fences/especies_nativas_sustitutas
+ * - Conserva biopreparados[] íntegro
+ * - Incluye todos los sources[] referenciados por species y biopreparados
  *
  * Estrategia boundary: subset = OSS público bajo CC-BY-NC-SA;
  * catálogo full queda para chagra-pro post-cutover (decisión separada,
@@ -22,7 +25,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 
-const INPUT = resolve(ROOT, 'catalog/chagra-catalog-seed-v3.1.json');
+const INPUT = resolve(ROOT, 'catalog/chagra-catalog-oss-subset-v3.2.json');
 const OUTPUT = resolve(ROOT, 'catalog/chagra-catalog-oss-subset-v3.1.json');
 
 const OSS_SUBSET_IDS = new Set([
@@ -55,45 +58,114 @@ if (OSS_SUBSET_IDS.size !== 50) {
   process.exit(2);
 }
 
-const full = JSON.parse(readFileSync(INPUT, 'utf8'));
+export const REF_FIELDS_TO_CLOSE = [
+  'companions',
+  'antagonists',
+  'recommended_covers',
+  'recommended_fences',
+  'especies_nativas_sustitutas',
+];
 
-const species = full.species.filter((s) => OSS_SUBSET_IDS.has(s.id));
+function collectReferencedSpeciesIds(byId, seedIds) {
+  const closure = new Set();
+  const missingRefs = new Set();
+  const queue = [...seedIds].map((id) => ({ id, required: true }));
 
-if (species.length !== 50) {
-  console.error(`FATAL: encontré ${species.length} matches, esperaba 50`);
-  const found = new Set(species.map((s) => s.id));
-  const missing = [...OSS_SUBSET_IDS].filter((id) => !found.has(id));
-  console.error('IDs faltantes:', missing);
-  process.exit(3);
+  while (queue.length > 0) {
+    const entry = queue.pop();
+    const id = typeof entry === 'string' ? entry : entry.id;
+    const required = entry.required;
+    if (closure.has(id)) continue;
+    const sp = byId.get(id);
+    if (!sp) {
+      if (required) {
+        throw new Error(`ID semilla no existe en species[]: ${id}`);
+      }
+      missingRefs.add(id);
+      continue;
+    }
+
+    closure.add(id);
+
+    for (const field of REF_FIELDS_TO_CLOSE) {
+      for (const refId of sp[field] || []) {
+        if (!closure.has(refId)) {
+          queue.push({ id: refId, required: false });
+        }
+      }
+    }
+  }
+
+  return { closure, missingRefs };
 }
 
-// Filtra sources referenciados por las 50 species
-const referencedSourceIds = new Set();
-for (const s of species) {
-  for (const sid of s.source_ids || []) referencedSourceIds.add(sid);
+export function buildOssSubset(full) {
+  const allSpecies = full.species || [];
+  const byId = new Map(allSpecies.map((s) => [s.id, s]));
+  const { closure: speciesIds, missingRefs } = collectReferencedSpeciesIds(byId, OSS_SUBSET_IDS);
+
+  const species = allSpecies.filter((s) => speciesIds.has(s.id));
+
+  const missingSeeds = [...OSS_SUBSET_IDS].filter((id) => !speciesIds.has(id));
+  if (missingSeeds.length > 0) {
+    throw new Error(`No se pudieron resolver los IDs semilla: ${missingSeeds.join(', ')}`);
+  }
+
+  const referencedSourceIds = new Set();
+  for (const s of species) {
+    for (const sid of s.source_ids || []) referencedSourceIds.add(sid);
+    for (const sid of s.saber_origen?.validacion_cientifica_source_ids || []) {
+      referencedSourceIds.add(sid);
+    }
+  }
+
+  const biopreparados = full.biopreparados || [];
+  for (const bp of biopreparados) {
+    for (const sid of bp.source_ids || []) referencedSourceIds.add(sid);
+  }
+
+  const sources = (full.sources || []).filter((src) => referencedSourceIds.has(src.id));
+
+  return {
+    ...(full._meta && { _meta: full._meta }),
+    schema_version: full.schema_version,
+    seed_version: (full.seed_version || 'v3.1') + '-oss-subset',
+    generated_at: new Date().toISOString(),
+    generated_by: 'scripts/extract-oss-subset.mjs',
+    _subset_meta: {
+      subset_name: 'oss-subset-50-closure',
+      source_file: 'chagra-catalog-oss-subset-v3.2.json',
+      seed_species_count: OSS_SUBSET_IDS.size,
+      species_count: species.length,
+      sources_count: sources.length,
+      unresolved_species_refs_count: missingRefs.size,
+      license: 'CC-BY-NC-SA 4.0',
+      rationale: 'Subset representativo multi-piso con clausura de referencias cruzadas para species y biopreparados. El catálogo público canónico v3.2 aporta el corpus completo para resolver los ids referenciados. Catálogo full queda reserved para chagra-pro post-cutover. Plan detallado: Chagra-strategy/legal/oss-pro-corpus-split-plan-2026-05-20.md.',
+    },
+    species,
+    sources,
+    biopreparados,
+  };
 }
-const sources = (full.sources || []).filter((src) => referencedSourceIds.has(src.id));
 
-// biopreparados: mantener tal cual (catalogo separado, no filtra por species)
-const subset = {
-  ...(full._meta && { _meta: full._meta }),
-  schema_version: full.schema_version,
-  seed_version: (full.seed_version || 'v3.1') + '-oss-subset',
-  generated_at: new Date().toISOString(),
-  generated_by: 'scripts/extract-oss-subset.mjs',
-  _subset_meta: {
-    subset_name: 'oss-subset-50',
-    source_file: 'chagra-catalog-seed-v3.1.json',
-    species_count: species.length,
-    sources_count: sources.length,
-    license: 'CC-BY-NC-SA 4.0',
-    rationale: 'Subset representativo multi-piso (12 cálidas + 13 templadas + 13 frías + 12 páramo/altoandinas) para uso OSS público bajo CC-BY-NC-SA. Catálogo full queda reserved para chagra-pro post-cutover. Plan detallado: Chagra-strategy/legal/oss-pro-corpus-split-plan-2026-05-20.md.',
-  },
-  species,
-  sources,
-  biopreparados: full.biopreparados || [],
-};
+function main() {
+  const full = JSON.parse(readFileSync(INPUT, 'utf8'));
+  const subset = buildOssSubset(full);
 
-writeFileSync(OUTPUT, JSON.stringify(subset, null, 2) + '\n');
-console.log(`✓ Escrito ${OUTPUT}`);
-console.log(`  species: ${species.length}, sources: ${sources.length}, biopreparados: ${(full.biopreparados || []).length}`);
+  writeFileSync(OUTPUT, JSON.stringify(subset, null, 2) + '\n');
+  console.log(`✓ Escrito ${OUTPUT}`);
+  console.log(`  species: ${subset.species.length}, sources: ${subset.sources.length}, biopreparados: ${subset.biopreparados.length}`);
+  if (subset._subset_meta.unresolved_species_refs_count > 0) {
+    console.warn(`  refs de species no resolubles en full: ${subset._subset_meta.unresolved_species_refs_count}`);
+  }
+}
+
+const IS_CLI = import.meta.url === `file://${process.argv[1]}`;
+if (IS_CLI) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`FATAL: ${error.message}`);
+    process.exit(3);
+  }
+}

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -221,7 +221,7 @@ function validateAmb10_companionsSymmetry(catalog) {
   return errors;
 }
 
-function validateAmb13_crossRefs(catalog, seedMode) {
+export function validateAmb13_crossRefs(catalog, seedMode) {
   const errors = [];
   const warnings = [];
   const speciesIds = new Set((catalog.species || []).map((s) => s.id));


### PR DESCRIPTION
## Summary
- El extractor OSS ahora cierra de forma recursiva las species referenciadas por `companions`, `antagonists`, `recommended_covers`, `recommended_fences` y `especies_nativas_sustitutas`.
- También incluye todos los `source_ids` usados por species y biopreparados, y regenera `catalog/chagra-catalog-oss-subset-v3.1.json`.
- Se agregó una prueba de regresión para verificar que AMB-13 queda sin errores en el subset derivado.

## Test plan
- `node scripts/extract-oss-subset.mjs`
- `node scripts/validate-catalog.mjs catalog/chagra-catalog-oss-subset-v3.1.json --lenient-schema`
- `npx vitest run scripts/__tests__/extract-oss-subset.test.mjs`
- `npx eslint scripts/extract-oss-subset.mjs scripts/validate-catalog.mjs scripts/__tests__/extract-oss-subset.test.mjs --max-warnings=0`
- `npm run build`
