### PR TITLE
fix(tsc-gate): baseline portable entre maquinas (normaliza paths de node_modules)

### DIFF
--- a/scripts/__tests__/tsc-check-gate.test.mjs
+++ b/scripts/__tests__/tsc-check-gate.test.mjs
@@ -34,6 +34,22 @@ describe('parseTscOutput', function () {
   it('empty output has zero errors', function () {
     expect(parseTscOutput('')).toEqual({ total: 0, byFile: {} });
   });
+
+  it('normaliza paths de node_modules resueltos fuera del repo (symlink local vs CI)', function () {
+    var output = [
+      '../../home/alguien/Workspace/chagra/node_modules/fake-indexeddb/auto/index.mjs(3,1): error TS7016: no declaration file.',
+      'node_modules/fake-indexeddb/auto/index.mjs(9,1): error TS7016: no declaration file.',
+      'src/a.js(1,1): error TS2322: Type mismatch.',
+    ].join('\n');
+    var r = parseTscOutput(output);
+    expect(r.total).toBe(3);
+    // La forma local (path resuelto por symlink) y la de CI cuentan como el
+    // MISMO archivo — sin esto el baseline no era portable entre máquinas.
+    expect(r.byFile).toEqual({
+      'node_modules/fake-indexeddb/auto/index.mjs': 2,
+      'src/a.js': 1,
+    });
+  });
 });
 
 describe('compareToBaseline', function () {

--- a/scripts/tsc-baseline.json
+++ b/scripts/tsc-baseline.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-07-02T04:07:31.649Z",
+  "generatedAt": "2026-07-02T04:33:54.406Z",
   "totalErrors": 2351,
   "byFile": {
-    "../../home/kortux/Workspace/chagra/node_modules/fake-indexeddb/auto/index.mjs": 1,
-    "../../home/kortux/Workspace/chagra/node_modules/fake-indexeddb/build/esm/FDBFactory.js": 4,
-    "../../home/kortux/Workspace/chagra/node_modules/fake-indexeddb/build/esm/FDBTransaction.js": 3,
+    "node_modules/fake-indexeddb/auto/index.mjs": 1,
+    "node_modules/fake-indexeddb/build/esm/FDBFactory.js": 4,
+    "node_modules/fake-indexeddb/build/esm/FDBTransaction.js": 3,
     "scripts/lib/bench-scorer.mjs": 22,
     "scripts/seed-demo.ts": 1,
     "src/App.jsx": 16,

--- a/scripts/tsc-check-gate.mjs
+++ b/scripts/tsc-check-gate.mjs
@@ -51,6 +51,24 @@ const BASELINE_PATH = join(import.meta.dirname, 'tsc-baseline.json');
 const ERROR_LINE_RE = /^(.+?)\((\d+),(\d+)\): error (TS\d+):/;
 
 /**
+ * Normaliza el path que reporta tsc para que el baseline sea comparable
+ * entre máquinas. Caso real (PR #1936): en worktrees locales con
+ * node_modules symlinkeado, tsc reporta los .js de dependencias con el
+ * path RESUELTO fuera del repo ("../../home/<user>/.../node_modules/
+ * fake-indexeddb/...") mientras CI reporta "node_modules/fake-indexeddb/
+ * ...". El mismo error contaba como "archivo nuevo" en un lado u otro.
+ * Se recorta todo lo anterior a `node_modules/` para que ambas formas
+ * coincidan.
+ *
+ * @param {string} file
+ * @returns {string}
+ */
+export function normalizeTscFile(file) {
+  const idx = file.indexOf('node_modules/');
+  return idx >= 0 ? file.slice(idx) : file;
+}
+
+/**
  * Parsea la salida cruda de `tsc --noEmit` y agrupa el conteo de errores
  * por archivo. Ignora líneas de continuación (mensajes multilínea) — solo
  * cuenta la línea que abre cada error.
@@ -65,7 +83,7 @@ export function parseTscOutput(output) {
   for (const line of lines) {
     const m = line.match(ERROR_LINE_RE);
     if (!m) continue;
-    const file = m[1];
+    const file = normalizeTscFile(m[1]);
     byFile[file] = (byFile[file] || 0) + 1;
     total++;
   }


### PR DESCRIPTION
## Summary
Seguimiento del PR #1936 (el squash-merge se adelantó al último commit de la rama).

- El gate `tsc:check vs baseline` compara paths por string. En worktrees locales con `node_modules` symlinkeado, tsc reporta los .js de dependencias con el path resuelto fuera del repo (`../../home/<user>/.../node_modules/fake-indexeddb/...`), mientras CI reporta `node_modules/fake-indexeddb/...`. El mismo error contaba como "archivo nuevo" en CI y tumbaba el gate aunque el baseline estuviera al día (así falló en el PR #1936 tras regenerar el baseline en local).
- Fix: `normalizeTscFile()` recorta todo lo anterior a `node_modules/` en `parseTscOutput`, con test unitario que cubre las dos formas.
- Se regenera `tsc-baseline.json` con las claves normalizadas (mismo total: 2351). Bonus: salen del baseline los paths absolutos de la máquina local.

## Test plan
- `npx vitest run scripts/__tests__/tsc-check-gate.test.mjs` (13 pass)
- `node scripts/tsc-check-gate.mjs` → OK sin errores nuevos (local)
- El job `tsc:check vs baseline` de este PR valida el lado CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)