### PR TITLE
fix(catalog): corregir miscategorización plaga/enfermedad (Trozador, roya) en 7 especies

### DIFF
--- a/catalog/chagra-catalog-oss-subset-v3.2.json
+++ b/catalog/chagra-catalog-oss-subset-v3.2.json
@@ -1026,11 +1026,11 @@
       },
       "plagas_criticas": [
         "Hypothenemus hampei (broca)",
-        "Hemileia vastatrix (roya)",
         "Mycena citricolor"
       ],
       "enfermedades_criticas": [
-        "Cercospora coffeicola"
+        "Cercospora coffeicola",
+        "Hemileia vastatrix (roya)"
       ],
       "source_ids": [
         "cenicafe-manual-cafetero-2013",
@@ -3152,9 +3152,6 @@
       "antagonists": [
         "juglans_neotropica"
       ],
-      "enfermedades_criticas": [
-        "Trozador (Agrotis ipsilon)"
-      ],
       "tracking_mode": "aggregate",
       "cultivar": false,
       "feeding_plan_template": {
@@ -3211,7 +3208,10 @@
           }
         ],
         "derived_from": "solanum_lycopersicum_san_marzano"
-      }
+      },
+      "plagas_criticas": [
+        "Trozador (Agrotis ipsilon)"
+      ]
     },
     {
       "id": "solanum_lycopersicum_san_marzano",
@@ -3343,11 +3343,11 @@
       },
       "plagas_criticas": [
         "Trps",
-        "Heliothis"
+        "Heliothis",
+        "Trozador (Agrotis ipsilon)"
       ],
       "enfermedades_criticas": [
-        "Podredumbre apical (Blossom end rot)",
-        "Trozador (Agrotis ipsilon)"
+        "Podredumbre apical (Blossom end rot)"
       ],
       "source_ids": [
         "gbif-taxonomic-backbone",
@@ -3406,9 +3406,6 @@
       "antagonists": [
         "juglans_neotropica"
       ],
-      "enfermedades_criticas": [
-        "Trozador (Agrotis ipsilon)"
-      ],
       "tracking_mode": "aggregate",
       "cultivar": false,
       "feeding_plan_template": {
@@ -3465,7 +3462,10 @@
           }
         ],
         "derived_from": "solanum_lycopersicum_san_marzano"
-      }
+      },
+      "plagas_criticas": [
+        "Trozador (Agrotis ipsilon)"
+      ]
     },
     {
       "id": "solanum_phureja",
@@ -3517,9 +3517,6 @@
       "antagonists": [
         "solanum_lycopersicum_san_marzano",
         "solanum_melongena"
-      ],
-      "enfermedades_criticas": [
-        "Trozador (Agrotis ipsilon)"
       ],
       "tracking_mode": "aggregate",
       "variedades_registradas_ica": [
@@ -3648,6 +3645,9 @@
       "nombre_comunes_regionales": [
         "papa amarilla",
         "papa criolla colombiana"
+      ],
+      "plagas_criticas": [
+        "Trozador (Agrotis ipsilon)"
       ]
     },
     {
@@ -4728,9 +4728,6 @@
         "powo-kew"
       ],
       "valor_pedagogico": "La papa Sabanera (Solanum tuberosum L. variedad Sabanera) es una variedad colombiana de papa de gran adaptación al altiplano cundiboyacense, desarrollada y registrada por ICA y AGROSAVIA. Se cultiva en Cundinamarca (Mosquera, Bojacá, Soacha), Boyacá (Tunja, Ventaquemada, Toca) y Nariño entre 2.500 y 3.200 msnm en zona térmica fría. Ciclo vegetativo 5-6 meses, rendimientos comerciales 25-35 t/ha. Tubérculo grande oblongo con piel crema y carne amarilla suave. Susceptible a Phytophthora infestans (tizón tardío); manejo agroecológico incluye rotación trienal con leguminosas (haba, arveja andina), siembra escalonada, manejo de inóculo de papa-volunta, biopreparados como caldo bordelés y trichoderma. Fuentes Tier A: AGROSAVIA fichas papa, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy, Bernal et al. Catálogo Plantas y Líquenes Colombia.",
-      "enfermedades_criticas": [
-        "Trozador (Agrotis ipsilon)"
-      ],
       "tracking_mode": "aggregate",
       "companions": [
         "allium_cepa",
@@ -4748,7 +4745,10 @@
         "solanum_melongena",
         "spinacia_oleracea"
       ],
-      "cultivar": false
+      "cultivar": false,
+      "plagas_criticas": [
+        "Trozador (Agrotis ipsilon)"
+      ]
     },
     {
       "id": "smallanthus_sonchifolius",
@@ -12848,12 +12848,12 @@
       ],
       "_nota_companions": "Asocio papa-arveja (DR Gemini): la papa es tutor físico de la arveja (evita volcamiento); ~21.000 ha/año, 65% de productores del altiplano.",
       "enfermedades_criticas": [
-        "Phytophthora infestans",
-        "Trozador (Agrotis ipsilon)"
+        "Phytophthora infestans"
       ],
       "plagas_criticas": [
         "Tecia solanivora",
-        "Phyllophaga spp."
+        "Phyllophaga spp.",
+        "Trozador (Agrotis ipsilon)"
       ],
       "feeding_plan_template": {
         "source": "Agrosavia Manual tuberculos andinos (2017) + Perez-Rodriguez-Gomez (2008). Paridad base-variedad para papa; detalle operativo vive en variedades comerciales.",


### PR DESCRIPTION
## Resumen

Fix puntual de datos de catálogo detectado en la auditoría de calidad
de datos del catálogo + grafo (`Chagra-strategy/audit/2026-07-02-contaminacion-cruzada-catalogo-grafo.md`).

- **Trozador (Agrotis ipsilon)** es un lepidóptero (plaga), pero figuraba
  en `enfermedades_criticas` de 6 especies: `solanum_tuberosum`,
  `solanum_tuberosum_sabanera`, `solanum_phureja`,
  `solanum_lycopersicum_cerasiforme`, `solanum_lycopersicum_san_marzano`,
  `solanum_lycopersicum_sungold`. Movido a `plagas_criticas`.
- **Hemileia vastatrix (roya)** es un hongo (enfermedad), pero figuraba
  en `plagas_criticas` de `coffea_arabica`. Movido a `enfermedades_criticas`.

Es un fix de re-categorización de campo únicamente — no toca nombres,
dosis, biopreparados ni relaciones del grafo. `chagra-catalog-oss-subset-v3.2.json`
es el archivo canónico que shipea a producción (ver `catalog/CATALOG_VERSIONS.md`).

Nota de proceso: el pre-commit hook `catalog-validator` corre sin
argumento y valida por defecto `chagra-catalog-seed-v3.1.json` (72
especies, stale), **no** el archivo que shipea — por eso este tipo de
bug no fue atrapado antes. Documentado en el audit doc; no se toca el
gate en este PR (fuera de alcance, requiere decisión de a qué archivo
apuntar CI).

## Test plan

- [x] `node scripts/validate-catalog.mjs --lenient-schema catalog/chagra-catalog-oss-subset-v3.2.json` → `✓ Catálogo válido` (530 especies), mismos warnings pre-existentes (schema estricto / AMB-24 / AMB-27), sin warnings nuevos.
- [x] `npx vitest run src/services/__tests__/directorioEspecies.test.js scripts/__tests__/build-oss-subset.test.mjs` → 23/23 tests pasan.
- [x] `git diff --stat` → solo 23 inserciones / 23 eliminaciones en el JSON (cambio mínimo, sin reformateo colateral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)