### PR TITLE
fix(renderer): reconcile pest names by crop

### DIFF
--- a/src/services/__tests__/directorioEspecies.test.js
+++ b/src/services/__tests__/directorioEspecies.test.js
@@ -8,6 +8,7 @@ vi.mock('../../db/catalogDB.js', () => ({
 }));
 vi.mock('../grafoRelations.js', () => ({
   getRelationsForSpecies: vi.fn(),
+  resolvePestSynonym: vi.fn(),
 }));
 vi.mock('../../utils/speciesImageResolver.js', () => ({
   findLocalImage: vi.fn(),
@@ -18,7 +19,7 @@ import {
   getSpeciesById,
   getAllBiopreparados,
 } from '../../db/catalogDB.js';
-import { getRelationsForSpecies } from '../grafoRelations.js';
+import { getRelationsForSpecies, resolvePestSynonym } from '../grafoRelations.js';
 import { findLocalImage } from '../../utils/speciesImageResolver.js';
 import {
   searchSpecies,
@@ -48,6 +49,13 @@ const FRIJOL = {
 const MAIZ = { id: 'zea_mays', nombre_comun: 'Maíz criollo', nombre_cientifico: 'Zea mays L.', familia_botanica: 'Poaceae' };
 const CALABAZA = { id: 'cucurbita_maxima', nombre_comun: 'Zapallo', nombre_cientifico: 'Cucurbita maxima Duchesne' };
 const CEBOLLA = { id: 'allium_cepa', nombre_comun: 'Cebolla cabezona', nombre_cientifico: 'Allium cepa L.' };
+const PAPA = {
+  id: 'solanum_tuberosum',
+  nombre_comun: 'Papa',
+  nombre_cientifico: 'Solanum tuberosum L.',
+  familia_botanica: 'Solanaceae',
+  plagas_criticas: ['Tizón de la vaina del arroz', 'Gusano blanco del maíz (gallina ciega)'],
+};
 
 // Familia "tomate": el alias curado `tomate` apunta al cerasiforme (tomate de
 // mesa silvestre). El explorador debe LISTAR todos los tomates del catálogo, con
@@ -100,6 +108,7 @@ const CATALOG = [
   MAIZ,
   CALABAZA,
   CEBOLLA,
+  PAPA,
   CEBOLLA_LARGA,
   TOMATE_CERASIFORME,
   TOMATE_CHONTO,
@@ -115,6 +124,7 @@ beforeEach(() => {
   getSpeciesById.mockImplementation(async (id) => CATALOG.find((s) => s.id === id) || null);
   getAllBiopreparados.mockResolvedValue([]);
   getRelationsForSpecies.mockResolvedValue(null);
+  resolvePestSynonym.mockResolvedValue(null);
   findLocalImage.mockResolvedValue(null);
 });
 
@@ -228,6 +238,35 @@ describe('buildSpeciesFicha', () => {
     const bemisia = f.amenazas.find((a) => a.nombre.toLowerCase().includes('bemisia'));
     expect(bemisia.controladores).toContain('Encarsia formosa');
     expect(f.biopreparados[0].nombre).toBe('Beauveria bassiana');
+  });
+
+  it('reconcilia amenazas de papa con el puente de sinonimia del grafo', async () => {
+    getRelationsForSpecies.mockResolvedValueOnce({
+      compatible_with: [],
+      antagonist_of: [],
+      biopreparados: [],
+      pest_controllers: [
+        { plaga: 'Tizón de la vaina del arroz', controladores: ['Trichoderma harzianum'] },
+        { plaga: 'Gusano blanco del maíz (gallina ciega)', controladores: ['Beauveria bassiana'] },
+      ],
+    });
+    resolvePestSynonym.mockImplementation(async (term) => {
+      if (term === 'Tizón de la vaina del arroz') {
+        return { plaga: 'Rhizoctonia solani', especiesAfectadas: ['solanum_tuberosum'] };
+      }
+      if (term === 'Gusano blanco del maíz (gallina ciega)') {
+        return { plaga: 'Phyllophaga spp.', especiesAfectadas: ['solanum_tuberosum'] };
+      }
+      return null;
+    });
+
+    const f = await buildSpeciesFicha('solanum_tuberosum');
+    const nombres = f.amenazas.map((a) => a.nombre);
+
+    expect(nombres).toContain('Rhizoctonia solani');
+    expect(nombres).toContain('Phyllophaga spp.');
+    expect(nombres).not.toContain('Tizón de la vaina del arroz');
+    expect(nombres).not.toContain('Gusano blanco del maíz (gallina ciega)');
   });
 
   it('enriquece biopreparado con dosis del catálogo si el id coincide', async () => {

--- a/src/services/directorioEspecies.js
+++ b/src/services/directorioEspecies.js
@@ -29,7 +29,7 @@ import {
   getSpeciesById,
   getAllBiopreparados,
 } from '../db/catalogDB.js';
-import { getRelationsForSpecies } from './grafoRelations.js';
+import { getRelationsForSpecies, resolvePestSynonym } from './grafoRelations.js';
 import { findLocalImage } from '../utils/speciesImageResolver.js';
 import { normalizeForMatch, __TEST__ as RESOLVER_TEST } from '../utils/speciesResolver.js';
 
@@ -342,7 +342,7 @@ export async function buildSpeciesFicha(speciesId) {
       }
     }
   }
-  const amenazas = buildAmenazas(sp, controllersByPlaga);
+  const amenazas = await buildAmenazas(sp, controllersByPlaga);
 
   return {
     id: speciesId,
@@ -379,9 +379,21 @@ export async function buildSpeciesFicha(speciesId) {
 }
 
 /** Une plagas/enfermedades del catálogo con sus controladores del grafo. */
-function buildAmenazas(sp, controllersByPlaga) {
+async function buildAmenazas(sp, controllersByPlaga) {
   const out = [];
-  const push = (nombre, tipo) => {
+  const speciesId = sp?.id || sp?.slug || '';
+  const resolvedCache = new Map();
+
+  const getResolvedPest = async (nombre) => {
+    const key = normalizeForMatch(nombre);
+    if (!key) return null;
+    if (resolvedCache.has(key)) return resolvedCache.get(key);
+    const resolved = await resolvePestSynonym(nombre);
+    resolvedCache.set(key, resolved);
+    return resolved;
+  };
+
+  const push = async (nombre, tipo) => {
     if (!nombre) return;
     const key = normalizeForMatch(nombre);
     // match por palabra completa contra las plagas del grafo (los nombres no
@@ -399,10 +411,22 @@ function buildAmenazas(sp, controllersByPlaga) {
         }
       }
     }
-    out.push({ nombre, tipo, controladores });
+    const resolved = await getResolvedPest(nombre);
+    const displayName = resolved && speciesId && Array.isArray(resolved.especiesAfectadas) && resolved.especiesAfectadas.includes(speciesId)
+      ? (resolved.plaga || nombre)
+      : nombre;
+    out.push({ nombre: displayName, tipo, controladores });
   };
-  if (Array.isArray(sp.plagas_criticas)) for (const p of sp.plagas_criticas) push(p, 'plaga');
-  if (Array.isArray(sp.enfermedades_criticas)) for (const e of sp.enfermedades_criticas) push(e, 'enfermedad');
+  if (Array.isArray(sp.plagas_criticas)) {
+    for (const p of sp.plagas_criticas) {
+      await push(p, 'plaga');
+    }
+  }
+  if (Array.isArray(sp.enfermedades_criticas)) {
+    for (const e of sp.enfermedades_criticas) {
+      await push(e, 'enfermedad');
+    }
+  }
   // Plagas que SOLO trae el grafo (no listadas como críticas en el catálogo).
   for (const [, pc] of controllersByPlaga) {
     const ya = out.some((a) => {
@@ -410,7 +434,13 @@ function buildAmenazas(sp, controllersByPlaga) {
       const pk = normalizeForMatch(pc.plaga);
       return containsWholeWord(ak, pk) || containsWholeWord(pk, ak) || ak === pk;
     });
-    if (!ya) out.push({ nombre: pc.plaga, tipo: 'plaga', controladores: pc.controladores });
+    if (!ya) {
+      const resolved = await getResolvedPest(pc.plaga);
+      const displayName = resolved && speciesId && Array.isArray(resolved.especiesAfectadas) && resolved.especiesAfectadas.includes(speciesId)
+        ? (resolved.plaga || pc.plaga)
+        : pc.plaga;
+      out.push({ nombre: displayName, tipo: 'plaga', controladores: pc.controladores });
+    }
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- Cablea `buildAmenazas()` al puente `resolvePestSynonym()` para que cada especie vea un nombre de plaga neutro o correcto para su cultivo.
- Mantiene el orden y controladores del grafo, pero cambia el texto renderizado cuando la sinonimia canónica aplica al cultivo consultado.
- Agrega cobertura para papa con dos casos de desambiguacion: `Rhizoctonia solani` y `Phyllophaga spp.`

## Test plan
- `npx vitest run src/services/__tests__/directorioEspecies.test.js`
- `npx eslint src/services/directorioEspecies.js src/services/__tests__/directorioEspecies.test.js --max-warnings=0`
- `npm run build`
- `npx vitest run` completo mostro fallas preexistentes en otros modulos del repo, no en este cambio.

## Notes
- Se restauraron artefactos generados por `npm run build` para dejar el diff acotado al fix funcional.