### PR TITLE
fix(i18n): pluralize broken ternary template strings in messages.js

### DIFF
--- a/src/components/NetworkStatusBar.jsx
+++ b/src/components/NetworkStatusBar.jsx
@@ -141,13 +141,13 @@ export default function NetworkStatusBar() {
       bg: 'bg-frog/10',
       border: 'border-frog/50',
       icon: <WifiOff size={16} className="shrink-0 text-frog" />,
-      text: `Sin conexion. ${pendingCount > 0 ? `${pendingCount} registro${pendingCount > 1 ? 's' : ''} guardado${pendingCount > 1 ? 's' : ''} localmente.` : 'Datos guardados localmente.'}`,
+      text: pendingCount > 0 ? MSG.status.sinConexionPendientes(pendingCount) : MSG.status.sinConexionSinPendientes,
     },
     [STATUS.SYNCING]: {
       bg: 'bg-morpho/10',
       border: 'border-morpho/50',
       icon: <RefreshCw size={16} className="animate-spin shrink-0 text-morpho" />,
-      text: MSG.format(MSG.ui.sincronizandoRegistros, { count: pendingCount }),
+      text: MSG.ui.sincronizandoRegistros(pendingCount),
     },
     [STATUS.SYNCED]: {
       bg: 'bg-muzo/10',
@@ -159,7 +159,7 @@ export default function NetworkStatusBar() {
       bg: 'bg-red-900/90',
       border: 'border-red-700',
       icon: <AlertTriangle size={16} className="shrink-0" />,
-      text: errorMessage || 'Error al sincronizar.',
+      text: errorMessage || MSG.status.errorSincronizar,
     },
     [STATUS.ONLINE]: {
       bg: 'bg-muzo/10',

--- a/src/components/OnboardingHero.jsx
+++ b/src/components/OnboardingHero.jsx
@@ -70,7 +70,7 @@ export default function OnboardingHero({ onNavigate, compact = false }) {
   let title;
   let subtitle;
   if (hasZones) {
-    title = MSG.format(MSG.onboarding.zonasListas, { count: lands.length });
+    title = MSG.onboarding.zonasListas(lands.length);
     subtitle = MSG.onboarding.elegirRegistro;
   } else if (hasFarmContext) {
     title = MSG.onboarding.fincaConfigurada;

--- a/src/components/VoiceConfirmation.jsx
+++ b/src/components/VoiceConfirmation.jsx
@@ -463,7 +463,7 @@ export default function VoiceConfirmation({
           disabled={!allValid || isSaving}
           className="flex-1 px-4 py-3 min-h-[44px] bg-lime-700 hover:bg-lime-600 text-white rounded-xl font-bold flex items-center justify-center gap-2 disabled:opacity-50 disabled:bg-slate-700"
         >
-          <Check size={18} /> {isSaving ? MSG.ui.guardando : MSG.format(MSG.ui.guardarPlantas, { count: totalAssetsToCreate })}
+          <Check size={18} /> {isSaving ? MSG.ui.guardando : MSG.ui.guardarPlantas(totalAssetsToCreate)}
         </button>
       </div>
     </div>

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -79,6 +79,10 @@ const messages = {
     sincronizando: 'Sincronizando...',
     pendientes: 'Pendientes',
     errorGeneral: 'Ocurrio un error',
+    errorSincronizar: 'Error al sincronizar.',
+    sinConexionPendientes: (count) =>
+      `Sin conexion. ${count} registro${count !== 1 ? 's' : ''} guardado${count !== 1 ? 's' : ''} localmente.`,
+    sinConexionSinPendientes: 'Sin conexion. Datos guardados localmente.',
   },
   agente: {
     placeholder: 'Escribe tu consulta...',
@@ -123,7 +127,8 @@ const messages = {
     bienvenido: 'Bienvenido a Chagra',
     comenzar: 'Comenzar',
     primeraPlanta: 'Bienvenido a Chagra. Empiece registrando su primera planta.',
-    zonasListas: 'Tiene {count} {count === 1 ? \'zona\' : \'zonas\'} lista{count === 1 ? \'\' : \'s\'}. Falta su primera planta.',
+    zonasListas: (count) =>
+      `Tiene ${count} ${count === 1 ? 'zona' : 'zonas'} lista${count === 1 ? '' : 's'}. Falta su primera planta.`,
     fincaConfigurada: 'Su finca está configurada. Sembremos la primera planta.',
     elegirRegistro: 'Elija cómo registrarla. Las tres rutas guardan lo mismo.',
     tipZonas: 'Tip: tras la primera, puede crear zonas (parcelas, camas) para organizarlas.',
@@ -137,7 +142,8 @@ const messages = {
     cargandoTareas: 'Cargando tareas...',
     cargandoCatalogo: 'Cargando catálogo...',
     sincronizandoSensores: 'Sincronizando sensores...',
-    sincronizandoRegistros: 'Sincronizando {count} registro{count !== 1 ? \'s\' : \'\'}...',
+    sincronizandoRegistros: (count) =>
+      `Sincronizando ${count} registro${count !== 1 ? 's' : ''}...`,
     sincronizarSensoresBtn: 'Sincronizar Sensores',
     sincronizarOffline: 'Sincronizar Offline...',
     registrarProduccion: 'Registrar Producción',
@@ -147,7 +153,8 @@ const messages = {
     confirmarEliminar: '¿Eliminar este reporte? Esta acción no se puede deshacer.',
     eliminarReporte: 'Eliminar reporte',
     cancelarInvestigacion: 'Cancelar investigación',
-    guardarPlantas: 'Guardar ({count} {count === 1 ? \'planta\' : \'plantas\'})',
+    guardarPlantas: (count) =>
+      `Guardar (${count} ${count === 1 ? 'planta' : 'plantas'})`,
     guardando: 'Guardando…',
     ingresoBitacora: 'Registrar en Bitácora',
     errorReporteCsv: 'No se pudo generar el reporte CSV.',


### PR DESCRIPTION
Three message keys (sincronizandoRegistros, zonasListas, guardarPlantas)
contained JS ternary expressions inside {curly braces} that MSG.format()
cannot evaluate, causing them to render literally as e.g.
"Sincronizando 3 registro{count !== 1 ? s : }..."

Fix: convert these entries from template strings with embedded ternaries
to functions that accept count and return the properly pluralized string.
Update all three call sites to invoke the function directly instead of
passing through MSG.format().

Also migrates two adjacent hardcoded Spanish strings in NetworkStatusBar
(sin conexion offline text, error al sincronizar) to messages.js to
satisfy the pre-commit ESLint --max-warnings=0 gate.
