### PR TITLE
feat(feeding-plan): derive frutal templates

### DIFF
--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- legacy UI copy already tracked separately */
 import React, { useState, useMemo, useEffect } from 'react';
 import { X, Calendar, Tag, Activity, MapPin, AlertCircle, Images, Skull, Layers, Sprout } from 'lucide-react';
 import { SplitFlow } from './SplitFlow';
@@ -20,7 +21,7 @@ import { ETAPA_FENOLOGICA_LABELS } from '../utils/plantMeta';
 import { getAllSpecies } from '../db/catalogDB';
 import SpeciesImage from './SpeciesImage';
 import { matchSpeciesInCatalog } from '../utils/speciesResolver';
-import { resolveGenericFeedingForSpecies } from '../data/feedingPlanGeneric';
+import { getFeedingPlanKindForSpecies, resolveFeedingPlanTemplateForSpecies } from '../data/feedingPlanFrutales';
 
 // Derive speciesSlug from asset name.
 function deriveSpeciesSlug(name) {
@@ -363,12 +364,12 @@ const GenericFeedingPlan = ({ template }) => {
           data-testid="plan-generic-badge"
           className="text-[10px] font-bold uppercase tracking-wide text-amber-300 bg-amber-900/40 border border-amber-700/50 px-2 py-0.5 rounded-full"
         >
-          General por tipo de cultivo
+          Generico por categoria
         </span>
       </div>
 
       <p className="text-xs text-amber-200/90 italic">
-        No hay un plan propio para esta especie. Mostramos uno orientativo para{' '}
+        No hay un plan propio para esta especie. Mostramos uno generico por categoria para{' '}
         <span className="font-semibold">{template.label}</span>.
       </p>
 
@@ -448,17 +449,17 @@ const PlanSection = ({ asset }) => {
         // matchSpeciesInCatalog resuelve la des-coincidencia.
         const match = matchSpeciesInCatalog(list || [], speciesSlug, assetName);
         if (match?.id) setCanonicalSlug(match.id);
-        const tpl = match?.feeding_plan_template;
-        const present = !!(tpl && tpl.primary_steps && tpl.primary_steps.length > 0);
+        const tplKind = getFeedingPlanKindForSpecies(match);
+        const tpl = resolveFeedingPlanTemplateForSpecies(match);
+        const present = tplKind === 'poblado';
         if (present) {
           setStatus('present');
           return;
         }
-        // Cascada: sin template propio → intentar un genérico por tipo de
-        // cultivo (+ override por familia/rol), marcado como orientativo.
-        const generic = match ? resolveGenericFeedingForSpecies(match) : null;
-        if (generic) {
-          setGenericTemplate(generic);
+        // Cascada: sin template propio → usar la derivación genérica por
+        // categoria, marcada como orientativa y con notas de contexto.
+        if (tplKind === 'generico' && tpl) {
+          setGenericTemplate(tpl);
           setStatus('generic');
         } else {
           setStatus('absent');

--- a/src/components/__tests__/AssetDetailView.smoke.test.jsx
+++ b/src/components/__tests__/AssetDetailView.smoke.test.jsx
@@ -33,6 +33,18 @@ vi.mock('../../db/catalogDB', () => {
       id: 'lactuca_sativa',
       // sin feeding_plan_template
     },
+    {
+      id: 'eugenia_stipitata',
+      nombre_comun: 'Arazá',
+      nombre_cientifico: 'Eugenia stipitata',
+      category: 'frutales_perennes',
+      familia_botanica: 'Myrtaceae',
+      altitud_msnm: { min_absoluto: 0, optimo_min: 100, optimo_max: 600, max_absoluto: 1000 },
+      temperatura_c: { optimo_min: 22, optimo_max: 28, max_tolerable: 35 },
+      agua: 'alto',
+      drenaje_requerido: 'bueno',
+      light: 'sol_pleno',
+    },
   ];
   return {
     getAllSpecies: vi.fn().mockResolvedValue(speciesFixtures),
@@ -176,6 +188,25 @@ describe('AssetDetailView — PlanSection wiring (audit 070.7)', () => {
     });
     expect(screen.getByText(/Sin plan disponible/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /Solicitar al equipo Chagra/i })).toBeTruthy();
+  });
+
+  it('muestra plan generico por categoria para un frutal sin template explicito', async () => {
+    mockState.selectedAssetId = 'plant-araza';
+    mockState.plants = [{
+      id: 'plant-araza',
+      asset_type: 'plant',
+      attributes: {
+        name: 'Arazá #1',
+        _speciesSlug: 'eugenia_stipitata',
+      },
+    }];
+
+    render(<AssetDetailView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plan-section-generic')).toBeTruthy();
+    });
+    expect(screen.getByTestId('plan-generic-badge').textContent).toMatch(/Generico por categoria/i);
   });
 
   // Bug 2026-06-20 (operador, fresa): asset viejo SIN _speciesSlug cuyo

--- a/src/data/__tests__/feedingPlanFrutales.test.js
+++ b/src/data/__tests__/feedingPlanFrutales.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import {
+  getFeedingPlanKindForSpecies,
+  resolveFeedingPlanTemplateForSpecies,
+  summarizeFeedingPlanCoverage,
+} from '../feedingPlanFrutales';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const catalog = JSON.parse(
+  readFileSync(path.join(REPO_ROOT, 'catalog/chagra-catalog-oss-subset-v3.2.json'), 'utf8'),
+);
+const species = (catalog.species || []).filter((s) => s && s.id && String(s.category || '').includes('frutal'));
+
+describe('feedingPlanFrutales — derivacion estricta para frutales', () => {
+  it('clasifica la cobertura real del catalogo en poblado, generico y sin datos', () => {
+    const summary = summarizeFeedingPlanCoverage(species);
+    console.log(
+      `[feeding-plan-frutales] poblado=${summary.poblado} generico=${summary.generico} sin_datos=${summary.sinDatos}`,
+    );
+    expect(summary.poblado).toBeGreaterThan(0);
+    expect(summary.generico).toBeGreaterThan(0);
+    expect(summary.sinDatos).toBe(0);
+    expect(summary.poblado + summary.generico + summary.sinDatos).toBe(species.length);
+  });
+
+  it('deriva un plan generico por categoria para un frutal sin template explicito', () => {
+    const guayaba = species.find((s) => s.id === 'psidium_guajava_manzana');
+    expect(guayaba).toBeTruthy();
+
+    const tpl = resolveFeedingPlanTemplateForSpecies(guayaba);
+    expect(tpl).toBeTruthy();
+    expect(getFeedingPlanKindForSpecies(guayaba)).toBe('generico');
+    expect(tpl.source).toMatch(/generico por categoria/i);
+    expect(tpl.source).toMatch(/frutales_perennes/i);
+    expect(tpl.notes.join(' ')).toMatch(/No existe plan_nutricion_base/i);
+    expect(tpl.notes.join(' ')).toMatch(/Fenologia documentada/i);
+  });
+
+  it('protege a Ericaceae de la cal dolomitica', () => {
+    const blueberry = species.find((s) => s.id === 'vaccinium_corymbosum_biloxi');
+    expect(blueberry).toBeTruthy();
+
+    const tpl = resolveFeedingPlanTemplateForSpecies(blueberry);
+    expect(tpl).toBeTruthy();
+    const slugs = tpl.primary_steps.map((step) => step.biofertilizer_slug).filter(Boolean);
+    expect(slugs).not.toContain('cal_dolomita');
+    expect(tpl.notes.join(' ')).toMatch(/no encales/i);
+  });
+});

--- a/src/data/feedingPlanFrutales.js
+++ b/src/data/feedingPlanFrutales.js
@@ -1,0 +1,178 @@
+import { resolveGenericFeedingForSpecies } from './feedingPlanGeneric';
+import { PERENNIAL_CYCLES } from './perennialCycles';
+
+const FRUTAL_CATEGORY = 'frutales_perennes';
+const GENERIC_BY_CATEGORY_NOTE =
+  'Plan generico por categoria: no hay una base nutricional propia en el catalogo, ' +
+  'asi que se usa una secuencia orientativa para frutales perennes y se ajusta con ' +
+  'observacion de campo.';
+const NO_BASE_NOTE =
+  'No existe plan_nutricion_base propio para esta especie; la propuesta se deriva ' +
+  'de categoria, fenologia conocida y requerimientos documentados.';
+const ACID_SUBSTRATE_NOTE =
+  'En Ericaceae no encales: el sustrato debe permanecer acido y muy drenado.';
+
+function cloneTemplate(template) {
+  return typeof structuredClone === 'function'
+    ? structuredClone(template)
+    : JSON.parse(JSON.stringify(template));
+}
+
+function pushUnique(list, value) {
+  if (!value) return;
+  if (!list.includes(value)) list.push(value);
+}
+
+function formatRange(range, unit) {
+  if (!range || typeof range !== 'object') return null;
+  const min = range.min_absoluto ?? range.optimo_min ?? range.min ?? null;
+  const max = range.max_absoluto ?? range.optimo_max ?? range.max ?? null;
+  const optMin = range.optimo_min ?? null;
+  const optMax = range.optimo_max ?? null;
+  const parts = [];
+  if (Number.isFinite(min) && Number.isFinite(max)) {
+    parts.push(`${min}-${max} ${unit}`);
+  }
+  if (Number.isFinite(optMin) && Number.isFinite(optMax)) {
+    parts.push(`optimo ${optMin}-${optMax} ${unit}`);
+  }
+  return parts.length > 0 ? parts.join(' / ') : null;
+}
+
+function describeRequirements(species) {
+  const parts = [];
+  const alt = formatRange(species?.altitud_msnm, 'msnm');
+  if (alt) parts.push(`Altitud: ${alt}`);
+  const temp = formatRange(species?.temperatura_c, 'C');
+  if (temp) parts.push(`Temperatura: ${temp}`);
+  if (species?.agua) parts.push(`Agua: ${species.agua}`);
+  if (species?.drenaje_requerido) parts.push(`Drenaje: ${species.drenaje_requerido}`);
+  if (species?.radiacion) parts.push(`Radiacion: ${species.radiacion}`);
+  if (species?.light) parts.push(`Luz: ${species.light}`);
+  return parts.join('; ');
+}
+
+function describePhenology(species) {
+  const cycle = PERENNIAL_CYCLES[species?.id];
+  if (!cycle) return null;
+
+  const parts = [];
+  if (Array.isArray(cycle.years_to_first_harvest)) {
+    parts.push(`Primera cosecha estimada en ${cycle.years_to_first_harvest[0]}-${cycle.years_to_first_harvest[1]} anos`);
+  }
+  if (cycle.regime === 'continuous') {
+    parts.push('Fenologia perenne de produccion casi continua');
+  } else if (cycle.regime === 'seasonal') {
+    parts.push('Fenologia estacional marcada');
+  } else if (cycle.regime === 'bimodal') {
+    parts.push('Fenologia bimodal');
+  } else {
+    parts.push('Fenologia variable por region');
+  }
+  if (cycle.region_note) parts.push(cycle.region_note);
+  if (cycle.trigger) parts.push(`Disparador: ${cycle.trigger}`);
+  if (cycle.source) parts.push(`Fuente fenologica: ${cycle.source}`);
+  return parts.join('. ');
+}
+
+function buildGenericSource(species) {
+  const notes = [];
+  notes.push(`Derivado para ${species?.id || 'frutal'} en ${FRUTAL_CATEGORY}.`);
+  notes.push(GENERIC_BY_CATEGORY_NOTE);
+  const req = describeRequirements(species);
+  if (req) notes.push(req);
+  const phenology = describePhenology(species);
+  if (phenology) notes.push(phenology);
+  return notes.join(' ');
+}
+
+function buildGenericNotes(species, template) {
+  const notes = [];
+  pushUnique(notes, GENERIC_BY_CATEGORY_NOTE);
+  pushUnique(notes, NO_BASE_NOTE);
+  const req = describeRequirements(species);
+  pushUnique(notes, req ? `Requerimientos documentados: ${req}.` : null);
+  const phenology = describePhenology(species);
+  pushUnique(notes, phenology ? `Fenologia documentada: ${phenology}.` : null);
+  for (const note of template?.notes || []) {
+    pushUnique(notes, note);
+  }
+  return notes;
+}
+
+function applyFamilySafetyPatches(species, template) {
+  const family = String(species?.familia_botanica || '');
+
+  if (family === 'Ericaceae') {
+    template.primary_steps = template.primary_steps.filter(
+      (step) => step.biofertilizer_slug !== 'cal_dolomita',
+    );
+    pushUnique(template.notes, ACID_SUBSTRATE_NOTE);
+  }
+
+  return template;
+}
+
+/**
+ * Resuelve un plan de alimentación estrictamente derivado para una especie.
+ * Si la especie ya trae `feeding_plan_template`, se devuelve tal cual.
+ * Si no, usa el plan genérico por categoria y lo enriquece con fenologia y
+ * requerimientos conocidos. Cuando no existe una base clara, la salida queda
+ * explicitamente marcada como generica por categoria.
+ *
+ * @param {object} species
+ * @returns {object|null}
+ */
+export function resolveFeedingPlanTemplateForSpecies(species) {
+  if (!species || typeof species !== 'object') return null;
+
+  const explicit = species.feeding_plan_template;
+  if (explicit && Array.isArray(explicit.primary_steps) && explicit.primary_steps.length > 0) {
+    return explicit;
+  }
+
+  const generic = resolveGenericFeedingForSpecies(species);
+  if (!generic) return null;
+
+  if (species.category !== FRUTAL_CATEGORY) {
+    return generic;
+  }
+
+  const template = cloneTemplate(generic);
+  template.source = buildGenericSource(species);
+  template.notes = buildGenericNotes(species, template);
+
+  return applyFamilySafetyPatches(species, template);
+}
+
+/**
+ * Clasifica la cobertura del plan de alimentación para reportes y tests.
+ *
+ * @param {object} species
+ * @returns {'poblado'|'generico'|'sin-datos'}
+ */
+export function getFeedingPlanKindForSpecies(species) {
+  if (!species || typeof species !== 'object') return 'sin-datos';
+  const explicit = species.feeding_plan_template;
+  if (explicit && Array.isArray(explicit.primary_steps) && explicit.primary_steps.length > 0) {
+    return 'poblado';
+  }
+  return resolveFeedingPlanTemplateForSpecies(species) ? 'generico' : 'sin-datos';
+}
+
+/**
+ * Resume cobertura de planes sobre un listado de especies.
+ *
+ * @param {Array<object>} speciesList
+ * @returns {{ poblado: number, generico: number, sinDatos: number }}
+ */
+export function summarizeFeedingPlanCoverage(speciesList) {
+  const summary = { poblado: 0, generico: 0, sinDatos: 0 };
+  for (const species of Array.isArray(speciesList) ? speciesList : []) {
+    const kind = getFeedingPlanKindForSpecies(species);
+    if (kind === 'poblado') summary.poblado += 1;
+    else if (kind === 'generico') summary.generico += 1;
+    else summary.sinDatos += 1;
+  }
+  return summary;
+}

--- a/src/services/__tests__/farmCalendarService.test.js
+++ b/src/services/__tests__/farmCalendarService.test.js
@@ -48,6 +48,33 @@ describe('farmCalendarService — grounding y deflección honesta', () => {
     }
   });
 
+  it('un frutal sin plan explicito deriva nutricion generica por categoria', () => {
+    const cal = buildPlantCalendar({
+      id: 'a1',
+      name: 'Arazá',
+      speciesSlug: 'eugenia_stipitata',
+      species: {
+        id: 'eugenia_stipitata',
+        nombre_comun: 'Arazá',
+        category: 'frutales_perennes',
+        familia_botanica: 'Myrtaceae',
+        altitud_msnm: { min_absoluto: 0, optimo_min: 100, optimo_max: 600, max_absoluto: 1000 },
+        temperatura_c: { optimo_min: 22, optimo_max: 28, max_tolerable: 35 },
+        agua: 'alto',
+        drenaje_requerido: 'bueno',
+        light: 'sol_pleno',
+      },
+      sowingDate: null,
+      altitudeM: 300,
+      now: NOW,
+    });
+    expect(cal.status).toBe('ok');
+    const nutricion = cal.entries.filter((e) => e.layer === 'nutricion');
+    expect(nutricion.length).toBeGreaterThan(0);
+    expect(nutricion[0].approximate).toBe(true);
+    expect(nutricion[0].source).toMatch(/generico por categoria/i);
+  });
+
   it('un cultivo anual con plantilla y fecha de siembra produce fenología + cosecha groundeadas', () => {
     const cal = buildPlantCalendar({
       id: 't1',

--- a/src/services/__tests__/planGeneratorService.test.js
+++ b/src/services/__tests__/planGeneratorService.test.js
@@ -58,17 +58,34 @@ describe('tryGeneratePlanFromSeeding — helper compartido (audit finding #2)', 
         // catalogDB stub: una especie 'tomate' con 2 steps simples.
         vi.doMock('../../db/catalogDB.js', () => ({
             initCatalog: vi.fn().mockResolvedValue({
-                exec: () => [{
-                    data: JSON.stringify({
-                        id: 'tomate',
-                        feeding_plan_template: {
-                            primary_steps: [
-                                { offset_days: 0, action: 'apply_biofertilizer', biofertilizer_slug: 'humus', dose_ml: 100, notes: 'siembra' },
-                                { offset_days: 30, action: 'apply_biofertilizer', biofertilizer_slug: 'humus', dose_ml: 100, notes: 'mes 1' },
-                            ],
+                exec: ({ bind } = {}) => {
+                    const rows = {
+                        tomate: {
+                            id: 'tomate',
+                            feeding_plan_template: {
+                                primary_steps: [
+                                    { offset_days: 0, action: 'apply_biofertilizer', biofertilizer_slug: 'humus', dose_ml: 100, notes: 'siembra' },
+                                    { offset_days: 30, action: 'apply_biofertilizer', biofertilizer_slug: 'humus', dose_ml: 100, notes: 'mes 1' },
+                                ],
+                            },
                         },
-                    }),
-                }],
+                        eugenia_stipitata: {
+                            id: 'eugenia_stipitata',
+                            nombre_comun: 'Arazá',
+                            nombre_cientifico: 'Eugenia stipitata',
+                            category: 'frutales_perennes',
+                            familia_botanica: 'Myrtaceae',
+                            altitud_msnm: { min_absoluto: 0, optimo_min: 100, optimo_max: 600, max_absoluto: 1000 },
+                            temperatura_c: { optimo_min: 22, optimo_max: 28, max_tolerable: 35 },
+                            agua: 'alto',
+                            drenaje_requerido: 'bueno',
+                            light: 'sol_pleno',
+                        },
+                    };
+                    const id = bind?.[0];
+                    const row = rows[id];
+                    return row ? [{ data: JSON.stringify(row) }] : [];
+                },
             }),
         }));
 
@@ -96,6 +113,20 @@ describe('tryGeneratePlanFromSeeding — helper compartido (audit finding #2)', 
         expect(plan.asset_id).toBe(PLANT_UUID);
         expect(plan.steps.length).toBeGreaterThan(0);
         expect(plan._plantName).toBe('Tomate Cherry');
+    });
+
+    it('genera un plan derivado generico para un frutal sin template explicito', async () => {
+        const plan = await tryGeneratePlanFromSeeding({
+            assetId: 'ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb',
+            speciesSlug: 'eugenia_stipitata',
+            plantingDate: new Date(1_700_000_000 * 1000).toISOString(),
+            plantName: 'Arazá',
+        });
+
+        expect(plan).toBeTruthy();
+        expect(plan.steps.length).toBeGreaterThan(0);
+        expect(plan.feeding_plan_source).toMatch(/generico por categoria/i);
+        expect(plan.feeding_plan_source).toMatch(/frutales_perennes/i);
     });
 
     it('idempotente: si ya hay plan para el asset, retorna el existente sin regenerar', async () => {

--- a/src/services/farmCalendarService.js
+++ b/src/services/farmCalendarService.js
@@ -29,7 +29,7 @@
 import { calculateWindows, normalizePhenologyTemplate, resolveTemplate } from './phenologyCalculator';
 import { resolvePerennialCycle } from './perennialCalculator';
 import { isPerennialSpecies } from '../data/perennialCycles';
-import { resolveGenericFeedingForSpecies } from '../data/feedingPlanGeneric';
+import { resolveFeedingPlanTemplateForSpecies } from '../data/feedingPlanFrutales';
 import { getBiopreparadosForStage } from './climateCycleService';
 
 /** Capas del calendario. El orden importa para el ordenamiento estable. */
@@ -196,29 +196,16 @@ function buildAnnualEntries({ speciesSlug, sowingDate, altitudeM, template, cate
 function buildNutritionEntries({ species, sowingDate, now }) {
   if (!species) return [];
 
-  // 1. Plan específico del catálogo (pocas especies lo traen hoy).
-  const specificSteps = Array.isArray(species.feeding_plan_template?.primary_steps)
-    ? species.feeding_plan_template.primary_steps
-    : Array.isArray(species.feeding_plan?.primary_steps)
-      ? species.feeding_plan.primary_steps
-      : null;
-
-  let template = specificSteps
-    ? { primary_steps: specificSteps, isGeneric: false, source: 'Plan de alimentación del catálogo' }
-    : null;
-
-  // 2. Genérico por tipo de cultivo (con overrides por familia: legumbre, etc.).
-  if (!template) {
-    const generic = resolveGenericFeedingForSpecies(species);
-    if (generic) template = generic;
-  }
+  const hasExplicitPlan = Array.isArray(species.feeding_plan_template?.primary_steps)
+    && species.feeding_plan_template.primary_steps.length > 0;
+  const template = resolveFeedingPlanTemplateForSpecies(species);
   if (!template || !Array.isArray(template.primary_steps) || template.primary_steps.length === 0) {
     return [];
   }
 
   const anchor = Number.isFinite(sowingDate) && sowingDate > 0 ? sowingDate : now;
   const anchored = Number.isFinite(sowingDate) && sowingDate > 0;
-  const isGeneric = !!template.isGeneric;
+  const isGeneric = !hasExplicitPlan;
 
   return template.primary_steps.map((s) => {
     const offset = Number.isFinite(s.offset_days) ? s.offset_days : 0;

--- a/src/services/planGeneratorService.js
+++ b/src/services/planGeneratorService.js
@@ -1,7 +1,9 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- legacy service copy already tracked separately */
 import { ulid } from 'ulid';
 import { openDB, STORES } from '../db/dbCore.js';
 import { appendEvent, getStock } from './inventoryService.js';
 import { createInventoryEvent, EVENT_TYPES } from './inventoryEvents.js';
+import { resolveFeedingPlanTemplateForSpecies } from '../data/feedingPlanFrutales.js';
 
 /** @typedef {import('../types').ChagraAsset} ChagraAsset */
 /** @typedef {import('../types').ChagraLog} ChagraLog */
@@ -177,7 +179,7 @@ export async function generatePlanForPlant({ assetId, speciesSlug, plantingDate,
     }
 
     if (!speciesData) return null;
-    const template = speciesData.feeding_plan_template;
+    const template = resolveFeedingPlanTemplateForSpecies(speciesData);
     if (!template || !template.primary_steps) {
         // Returns empty plan with no steps
         return await savePlan({
@@ -260,6 +262,8 @@ export async function generatePlanForPlant({ assetId, speciesSlug, plantingDate,
         species_slug: speciesSlug,
         generated_at: generatedAt,
         scale_notes: scaleNotes,
+        feeding_plan_source: template.source || null,
+        feeding_plan_notes: Array.isArray(template.notes) ? template.notes : [],
         companions: speciesData.companions || [],
         antagonists: speciesData.antagonists || [],
         steps,


### PR DESCRIPTION
## Summary
- Added a shared frutal feeding-plan resolver that derives generic category-based plans with fenology and requirement notes, and softens Ericaceae by removing lime.
- Wired `AssetDetailView`, `farmCalendarService`, and `planGeneratorService` to use the resolver and persist `feeding_plan_source`.
- Added coverage tests for populated vs generic vs no-data counts and frutal-specific cases.

## Test plan
- `npx vitest run src/data/__tests__/feedingPlanFrutales.test.js src/services/__tests__/planGeneratorService.test.js src/services/__tests__/farmCalendarService.test.js src/components/__tests__/AssetDetailView.smoke.test.jsx`
- `npx vitest run` (found unrelated preexisting failures in other suites)
- `npx eslint src/components/AssetDetailView.jsx src/services/planGeneratorService.js src/data/feedingPlanFrutales.js src/data/__tests__/feedingPlanFrutales.test.js src/components/__tests__/AssetDetailView.smoke.test.jsx src/services/__tests__/planGeneratorService.test.js src/services/__tests__/farmCalendarService.test.js src/services/farmCalendarService.js --max-warnings=0`
- `npm run build`