### PR TITLE
feat(iconos): set coherente por especie y por etapa de ciclo en catálogo/cards

### DIFF
--- a/src/components/CicloDetalle.jsx
+++ b/src/components/CicloDetalle.jsx
@@ -2,6 +2,7 @@
  * src/config/messages.js (ADR-050 i18n) fuera del alcance de este fix. */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Sprout, FlaskConical, AlertTriangle } from 'lucide-react';
+import EtapaCicloIcon from './icons/EtapaCicloIcon.jsx';
 import FarmProcessSummary from './FarmProcessSummary';
 import PhenologyTimeline from './PhenologyTimeline';
 import PerennialCycleView from './PerennialCycleView';
@@ -202,7 +203,13 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
       {/* Etapa actual + confirmar cambio (stageConfirmationService) */}
       <section className="bg-slate-900 border border-slate-800 rounded-xl p-3">
         <div className="flex items-center justify-between gap-2">
-          <span className="text-sm text-slate-300">Etapa: <strong className="text-emerald-400">{speciesStageLabel(displayStage)}</strong></span>
+          <span className="text-sm text-slate-300 inline-flex items-center gap-1.5">
+            Etapa:
+            <strong className="text-emerald-400 inline-flex items-center gap-1">
+              <EtapaCicloIcon code={displayStage} nombre={speciesStageLabel(displayStage)} size={14} />
+              {speciesStageLabel(displayStage)}
+            </strong>
+          </span>
           <button
             type="button"
             onClick={() => setPickStage((o) => !o)}
@@ -220,8 +227,11 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
                 disabled={busy}
                 onClick={() => handleStage(s)}
                 aria-label={`Confirmar etapa ${speciesStageLabel(s)}`}
-                className="text-xs px-2.5 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-200 disabled:opacity-50"
+                className="text-xs px-2.5 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-200 disabled:opacity-50 inline-flex items-center gap-1.5"
               >
+                {/* Glifo por etapa (set compartido): el selector se escanea
+                    por icono, no solo leyendo cada chip. */}
+                <EtapaCicloIcon code={s} nombre={speciesStageLabel(s)} size={13} className="text-emerald-400/90" />
                 {speciesStageLabel(s)}
               </button>
             ))}

--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -3,6 +3,27 @@ import { ChevronLeft, Search, Sprout, Leaf, X, BookOpen } from 'lucide-react';
 import { searchSpecies, buildSpeciesFicha } from '../../services/directorioEspecies.js';
 import SpeciesFicha from './SpeciesFicha.jsx';
 import { fvhSkinClass } from '../../config/fvhSkin.js';
+import { getSpeciesVisual, SPECIES_TONE_CLASSES } from '../../utils/speciesVisual.js';
+
+/**
+ * Badge de especie: emoji reconocible por especie sobre fondo tonal.
+ * Reemplaza el Leaf genérico que hacía idénticas todas las filas del
+ * catálogo — a 16–24px el emoji distingue papa/café/guayacán de un vistazo.
+ */
+function SpeciesBadge({ sp, size = 'md' }) {
+  const { emoji, tone } = getSpeciesVisual(sp);
+  const toneCls = SPECIES_TONE_CLASSES[tone] || SPECIES_TONE_CLASSES.emerald;
+  const sizeCls = size === 'sm' ? 'w-8 h-8 text-base' : 'w-10 h-10 text-lg';
+  return (
+    <span
+      className={`${sizeCls} rounded-xl border grid place-items-center shrink-0 leading-none ${toneCls}`}
+      aria-hidden="true"
+      data-testid="species-badge"
+    >
+      {emoji}
+    </span>
+  );
+}
 
 /**
  * DirectorioEspeciesScreen — explorador visual del catálogo de especies.
@@ -98,7 +119,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
             <ChevronLeft size={20} />
           </button>
           <div className="flex items-center gap-2 min-w-0">
-            <Leaf size={20} className="text-emerald-400 shrink-0" aria-hidden="true" />
+            <SpeciesBadge sp={selected} size="sm" />
             <div className="min-w-0">
               <h1 className="jp-tinta text-base font-bold leading-tight text-white truncate">{selected.comun}</h1>
               <p className="jp-tinta-suave text-xs text-slate-400 leading-tight italic truncate">{selected.cientifico}</p>
@@ -197,7 +218,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
                     onClick={() => selectSpecies(r.id)}
                     className="jp-dir-card w-full text-left rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-600/60 active:bg-slate-800/70 p-3 transition-colors flex items-center gap-3"
                   >
-                    <Leaf size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />
+                    <SpeciesBadge sp={r} />
                     <span className="min-w-0">
                       <span className="jp-tinta block text-sm font-bold text-emerald-100 leading-tight truncate">{r.comun || r.id}</span>
                       {r.cientifico && (

--- a/src/components/PhenologyTimeline.jsx
+++ b/src/components/PhenologyTimeline.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { Clock, Eye, HelpCircle, AlertTriangle, CheckCircle, Sprout, Timer } from 'lucide-react';
+import EtapaCicloIcon from './icons/EtapaCicloIcon.jsx';
 import { calculateWindows, formatWindow, getCurrentStage } from '../services/phenologyCalculator';
 
 // Colores theme-aware: la rampa slate/emerald/amber y los acentos custom
@@ -13,17 +14,21 @@ const confidenceColor = (c) => {
   return 'text-slate-500';
 };
 
+// Rampa por etapa: bg/border (se conserva la rampa theme-aware) + color del
+// GLIFO de etapa. El icono va claro sobre el disco lleno para ser legible a
+// 11px dentro del badge de 20px (antes era un punto de 12px sin glifo: sin
+// leer el label no se sabía qué etapa era).
 const stageColor = (code) => {
   const map = {
-    sowing: 'bg-emerald-800 border-emerald-600',
-    emergence: 'bg-emerald-700 border-emerald-500',
-    vegetative: 'bg-emerald-600 border-emerald-400',
-    flowering: 'bg-orchid border-orchid',
-    fruiting: 'bg-amber-700 border-amber-500',
-    harvest_window: 'bg-amber-600 border-amber-400',
-    closed: 'bg-slate-700 border-slate-500',
+    sowing: 'bg-emerald-800 border-emerald-600 text-emerald-100',
+    emergence: 'bg-emerald-700 border-emerald-500 text-emerald-100',
+    vegetative: 'bg-emerald-600 border-emerald-400 text-emerald-50',
+    flowering: 'bg-orchid border-orchid text-white',
+    fruiting: 'bg-amber-700 border-amber-500 text-amber-100',
+    harvest_window: 'bg-amber-600 border-amber-400 text-amber-50',
+    closed: 'bg-slate-700 border-slate-500 text-slate-200',
   };
-  return map[code] || 'bg-slate-700 border-slate-500';
+  return map[code] || 'bg-slate-700 border-slate-500 text-slate-200';
 };
 
 /**
@@ -113,10 +118,15 @@ export default function PhenologyTimeline({
 
           return (
             <div key={win.code} className={`flex gap-2 ${compact ? 'items-center' : ''}`}>
-              {/* Indicador de etapa */}
+              {/* Indicador de etapa: badge con GLIFO de la etapa (set
+                  compartido EtapaCicloIcon). Conserva los estados visuales:
+                  observado (ring emerald), estimado (ring morpho + borde
+                  punteado) y pasado (atenuado). */}
               <div className="flex flex-col items-center gap-0.5 shrink-0">
-                <div className={`w-3 h-3 rounded-full border ${stageColor(win.code)} ${isObservedCurrent ? 'ring-2 ring-emerald-400/50' : ''} ${isEstimatedCurrent ? 'ring-2 ring-morpho/40 border-dashed' : ''} ${isPast ? 'opacity-50' : ''}`} />
-                {i < windows.length - 1 && <div className="w-px h-4 bg-slate-700" />}
+                <div className={`w-5 h-5 rounded-full border grid place-items-center ${stageColor(win.code)} ${isObservedCurrent ? 'ring-2 ring-emerald-400/50' : ''} ${isEstimatedCurrent ? 'ring-2 ring-morpho/40 border-dashed' : ''} ${isPast ? 'opacity-50' : ''}`}>
+                  <EtapaCicloIcon code={win.code} nombre={win.label} size={11} strokeWidth={2.25} />
+                </div>
+                {i < windows.length - 1 && <div className="w-px h-3 bg-slate-700" />}
               </div>
 
               {/* Contenido */}

--- a/src/components/SpeciesCombobox.jsx
+++ b/src/components/SpeciesCombobox.jsx
@@ -3,6 +3,7 @@ import { Search, ChevronDown, X, AlertTriangle, Check } from 'lucide-react';
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { fuzzyFilter } from '../utils/fuzzySearch';
 import { getAllSpecies } from '../db/catalogDB';
+import { getSpeciesVisual } from '../utils/speciesVisual';
 
 /**
  * SpeciesCombobox — selector de especie con búsqueda/autocompletado, respaldado
@@ -233,10 +234,17 @@ export const SpeciesCombobox = ({
                 key={sp.id}
                 type="button"
                 onClick={() => handleSelect(sp)}
-                className="w-full text-left px-4 py-3 hover:bg-slate-800 border-b border-slate-800/50 last:border-0 transition-colors"
+                className="w-full text-left px-4 py-3 hover:bg-slate-800 border-b border-slate-800/50 last:border-0 transition-colors flex items-center gap-2.5"
               >
-                <span className="text-sm text-white font-medium block truncate">{sp.displayName}</span>
-                <span className="text-[10px] text-slate-500">{sp.groupLabel}</span>
+                {/* Icono por especie (utils/speciesVisual): distingue las
+                    filas del catálogo de un vistazo — antes eran solo texto. */}
+                <span className="text-lg leading-none shrink-0" aria-hidden="true">
+                  {getSpeciesVisual({ comun: sp.nombre_comun, cientifico: sp.nombre_cientifico, id: sp.id, categoria: sp.groupId }).emoji}
+                </span>
+                <span className="min-w-0">
+                  <span className="text-sm text-white font-medium block truncate">{sp.displayName}</span>
+                  <span className="text-[10px] text-slate-500">{sp.groupLabel}</span>
+                </span>
               </button>
             ))
           )}

--- a/src/components/aprendizaje/GuiaEspecieCards.jsx
+++ b/src/components/aprendizaje/GuiaEspecieCards.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Sprout, AlertTriangle, CheckCircle, ChevronDown, ChevronUp, Bug, Wrench } from 'lucide-react';
+import { Sprout, AlertTriangle, ChevronDown, ChevronUp, Bug, Wrench } from 'lucide-react';
+import EtapaCicloIcon from '../icons/EtapaCicloIcon.jsx';
 import { GUIAS_DEMO } from '../../data/aprendizaje/guias-demo.js';
 
 /**
@@ -56,17 +57,6 @@ export default function GuiaEspecieCards({ especie = 'papa', etapas: etapasProp 
     return colors[orden - 1] || colors[colors.length - 1];
   };
 
-  const getEtapaIcon = (orden) => {
-    const icons = [
-      <Sprout size={16} />,    // Germinación
-      <Sprout size={16} />,    // Vegetativo
-      <CheckCircle size={16} />, // Floración
-      <CheckCircle size={16} />, // Fructificación
-      <CheckCircle size={16} />, // Cosecha
-      <CheckCircle size={16} />  // Producto
-    ];
-    return icons[orden - 1] || icons[icons.length - 1];
-  };
 
   return (
     <div
@@ -107,8 +97,12 @@ export default function GuiaEspecieCards({ especie = 'papa', etapas: etapasProp 
               {/* Header de la tarjeta */}
               <div className="flex items-start justify-between gap-2 mb-2">
                 <div className="flex items-center gap-2">
-                  <div className={`p-1.5 rounded-lg ${getEtapaColor(etapa.orden)}`}>
-                    {getEtapaIcon(etapa.orden)}
+                  <div className={`p-1.5 rounded-lg border ${getEtapaColor(etapa.orden)}`}>
+                    {/* Icono distinto POR etapa (set compartido EtapaCicloIcon):
+                        germina=Sprout, crece=Leaf, florece=Flower2, fruto=Apple,
+                        cosecha=Basket, producto=Package — antes eran Sprout y
+                        CheckCircle repetidos y no se distinguían a 16px. */}
+                    <EtapaCicloIcon nombre={etapa.nombre} size={16} />
                   </div>
                   <div>
                     <h4 className="text-sm font-bold text-slate-100">

--- a/src/components/icons/EtapaCicloIcon.jsx
+++ b/src/components/icons/EtapaCicloIcon.jsx
@@ -1,0 +1,29 @@
+/**
+ * EtapaCicloIcon.jsx — componente del set de iconos por etapa de ciclo.
+ * La lógica de resolución y los mapas viven en ./etapaCicloIcons.js (archivo
+ * sin JSX, exportable a servicios/tests sin romper react-refresh).
+ */
+import React from 'react';
+import { getEtapaIcon } from './etapaCicloIcons.js';
+
+/**
+ * Icono de etapa de ciclo de vida con métrica consistente.
+ *
+ * @param {object} props
+ * @param {string} [props.code] - código de etapa (sowing, flowering…).
+ * @param {string} [props.nombre] - label en español (Floración, Cosecha…).
+ * @param {number} [props.size] - 16 por defecto (legible en cards/chips).
+ * @param {number} [props.strokeWidth] - 2 por defecto (métrica del set).
+ * @param {string} [props.className]
+ */
+export default function EtapaCicloIcon({ code, nombre, size = 16, strokeWidth = 2, className = '' }) {
+  // getEtapaIcon SELECCIONA un componente lucide constante de módulo (no crea
+  // componentes por render) — createElement directo evita el falso positivo
+  // de react-hooks/static-components sin desactivar la regla.
+  return React.createElement(getEtapaIcon({ code, nombre }), {
+    size,
+    strokeWidth,
+    className,
+    'aria-hidden': 'true',
+  });
+}

--- a/src/components/icons/EtapaCicloIcon.test.jsx
+++ b/src/components/icons/EtapaCicloIcon.test.jsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Bean, Sprout, Leaf, Flower2, Apple, ShoppingBasket, Package, Recycle } from 'lucide-react';
+import EtapaCicloIcon from './EtapaCicloIcon.jsx';
+import { getEtapaIcon, ETAPA_CODE_ICONS } from './etapaCicloIcons.js';
+
+// Set compartido de iconos por etapa de ciclo de vida (feedback operador
+// 2026-07): un glifo DISTINTO por etapa, resuelto por código FarmOS o por
+// label en español, con fallback que nunca deja un hueco.
+
+describe('getEtapaIcon — por código', () => {
+  it('cada código de fenología tiene su glifo propio', () => {
+    expect(getEtapaIcon({ code: 'sowing' })).toBe(Bean);
+    expect(getEtapaIcon({ code: 'emergence' })).toBe(Sprout);
+    expect(getEtapaIcon({ code: 'vegetative' })).toBe(Leaf);
+    expect(getEtapaIcon({ code: 'flowering' })).toBe(Flower2);
+    expect(getEtapaIcon({ code: 'fruiting' })).toBe(Apple);
+    expect(getEtapaIcon({ code: 'harvest_window' })).toBe(ShoppingBasket);
+    expect(getEtapaIcon({ code: 'closed' })).toBe(Recycle);
+  });
+
+  it('los 7 códigos de cultivo son glifos únicos entre sí', () => {
+    const codes = ['sowing', 'emergence', 'vegetative', 'flowering', 'fruiting', 'harvest_window', 'closed'];
+    const icons = codes.map((c) => ETAPA_CODE_ICONS[c]);
+    expect(new Set(icons).size).toBe(codes.length);
+  });
+
+  it('tolera el sufijo _confirmed de stageConfirmationService', () => {
+    expect(getEtapaIcon({ code: 'flowering_confirmed' })).toBe(Flower2);
+  });
+});
+
+describe('getEtapaIcon — por nombre en español', () => {
+  it('matchea los labels de guias-demo (Germinación → Producto)', () => {
+    expect(getEtapaIcon({ nombre: 'Germinación' })).toBe(Sprout);
+    expect(getEtapaIcon({ nombre: 'Vegetativo' })).toBe(Leaf);
+    expect(getEtapaIcon({ nombre: 'Floración' })).toBe(Flower2);
+    expect(getEtapaIcon({ nombre: 'Fructificación' })).toBe(Apple);
+    expect(getEtapaIcon({ nombre: 'Cosecha' })).toBe(ShoppingBasket);
+    expect(getEtapaIcon({ nombre: 'Producto' })).toBe(Package);
+  });
+
+  it('Poscosecha NO cae en Cosecha (substring)', () => {
+    expect(getEtapaIcon({ nombre: 'Poscosecha' })).toBe(Package);
+  });
+
+  it('fallback Sprout: nunca un hueco', () => {
+    expect(getEtapaIcon({ nombre: 'etapa inventada' })).toBe(Sprout);
+    expect(getEtapaIcon({})).toBe(Sprout);
+    expect(getEtapaIcon()).toBe(Sprout);
+  });
+});
+
+describe('<EtapaCicloIcon />', () => {
+  it('renderiza un svg aria-hidden con el tamaño pedido', () => {
+    const { container } = render(<EtapaCicloIcon code="flowering" size={13} className="text-emerald-400" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+    expect(svg.getAttribute('width')).toBe('13');
+    expect(svg.classList.contains('text-emerald-400')).toBe(true);
+  });
+});

--- a/src/components/icons/etapaCicloIcons.js
+++ b/src/components/icons/etapaCicloIcons.js
@@ -88,7 +88,7 @@ const normaliza = (s) =>
 /**
  * Resuelve el componente lucide de una etapa.
  * @param {{ code?: string, nombre?: string }} etapa
- * @returns {React.ComponentType} siempre retorna un icono (fallback Sprout).
+ * @returns {import('lucide-react').LucideIcon} siempre retorna un icono (fallback Sprout).
  */
 export function getEtapaIcon({ code, nombre } = {}) {
   const base = normaliza(code).replace(/_confirmed$/, '');

--- a/src/components/icons/etapaCicloIcons.js
+++ b/src/components/icons/etapaCicloIcons.js
@@ -1,0 +1,105 @@
+/**
+ * etapaCicloIcons.js — familia ÚNICA de iconos por etapa de ciclo de vida.
+ *
+ * Problema que resuelve (feedback del operador 2026-07): cada pantalla
+ * inventaba su propio glifo de etapa — GuiaEspecieCards repetía Sprout y
+ * CheckCircle para 6 etapas distintas, PhenologyTimeline pintaba un punto de
+ * color sin glifo, y el selector de etapa de CicloDetalle era solo texto. A
+ * 16–24px (catálogo, cards, timeline) eso obliga a leer el label para saber
+ * en qué etapa se está.
+ *
+ * Este módulo define UN icono lucide por etapa, con métrica consistente
+ * (strokeWidth 2, tamaño por prop), resuelto por:
+ *   1. `code` — códigos FarmOS/fenología del proyecto (sowing, emergence,
+ *      vegetative, flowering, fruiting, harvest_window, closed) + los hitos
+ *      de restauración/silvopastoreo (hoyEnFincaService.STAGE_LABELS).
+ *   2. `nombre` — matching por keyword del label en español (Germinación,
+ *      Floración, Cosecha…) para plantillas con etiquetas propias.
+ *   3. Fallback: Sprout (nunca un hueco).
+ *
+ * Regla de diseño: etapas = iconos de LÍNEA lucide (chrome de UI);
+ * especies = emoji (contenido) — ver utils/speciesVisual.js.
+ */
+import {
+  Bean,
+  Sprout,
+  Leaf,
+  Flower2,
+  Apple,
+  ShoppingBasket,
+  Package,
+  Recycle,
+  TreeDeciduous,
+  Wrench,
+} from 'lucide-react';
+
+/** Iconos por código de etapa (fenología FarmOS + restauración). */
+export const ETAPA_CODE_ICONS = {
+  // Fenología de cultivo (STAGE_ORDER de CicloDetalle / phenologyCalculator).
+  sowing: Bean,
+  emergence: Sprout,
+  vegetative: Leaf,
+  flowering: Flower2,
+  fruiting: Apple,
+  harvest_window: ShoppingBasket,
+  closed: Recycle,
+  // Restauración / silvopastoreo (hoyEnFincaService).
+  establecimiento: Bean,
+  prendimiento: Sprout,
+  mantenimiento: Wrench,
+  monitoreo_sucesion: TreeDeciduous,
+  cierre: Recycle,
+  // Momentos del form de planta (plantMeta.ETAPA_FENOLOGICA_OPTIONS).
+  semillero: Bean,
+  vegetativo: Leaf,
+  floracion: Flower2,
+  fructificacion: Apple,
+  madurez: ShoppingBasket,
+  senescencia: Recycle,
+};
+
+/*
+ * Matching por keyword del NOMBRE de la etapa (normalizado sin tildes).
+ * Orden = prioridad: lo específico primero. Cubre los labels de
+ * guias-demo.js (Germinación → Producto), STAGE_LABELS y plantillas
+ * fenológicas por especie.
+ */
+const ETAPA_NOMBRE_ICONS = [
+  { kw: ['siembra', 'semilla', 'semillero', 'trasplante'], Icon: Bean },
+  { kw: ['germina', 'broto', 'emergencia', 'nacida', 'prendimiento'], Icon: Sprout },
+  { kw: ['vegetat', 'crec', 'macollamiento', 'desarrollo'], Icon: Leaf },
+  { kw: ['flor'], Icon: Flower2 },
+  { kw: ['fruct', 'fruto', 'llenado', 'grano'], Icon: Apple },
+  // 'poscosecha' va ANTES que 'cosecha' (substring): Poscosecha → Package.
+  { kw: ['producto', 'poscosecha', 'guarda', 'almacen', 'secado'], Icon: Package },
+  { kw: ['cosecha', 'madur'], Icon: ShoppingBasket },
+  { kw: ['cerrado', 'cierre', 'terminado', 'senescencia', 'acabandose'], Icon: Recycle },
+  { kw: ['mantenimiento'], Icon: Wrench },
+  { kw: ['sucesion', 'monitoreo'], Icon: TreeDeciduous },
+];
+
+const normaliza = (s) =>
+  String(s || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim();
+
+/**
+ * Resuelve el componente lucide de una etapa.
+ * @param {{ code?: string, nombre?: string }} etapa
+ * @returns {React.ComponentType} siempre retorna un icono (fallback Sprout).
+ */
+export function getEtapaIcon({ code, nombre } = {}) {
+  const base = normaliza(code).replace(/_confirmed$/, '');
+  if (base && ETAPA_CODE_ICONS[base]) return ETAPA_CODE_ICONS[base];
+
+  const n = normaliza(nombre);
+  if (n) {
+    for (const entry of ETAPA_NOMBRE_ICONS) {
+      if (entry.kw.some((k) => n.includes(k))) return entry.Icon;
+    }
+  }
+  return Sprout;
+}
+

--- a/src/utils/speciesVisual.js
+++ b/src/utils/speciesVisual.js
@@ -1,0 +1,217 @@
+/**
+ * speciesVisual.js — icono (emoji) + tono de color POR ESPECIE para el
+ * catálogo y las cards de especie.
+ *
+ * Problema que resuelve (feedback del operador 2026-07): en el Directorio de
+ * especies, el combobox del catálogo y las fichas, TODAS las especies se
+ * pintaban con el mismo glifo genérico (Leaf). A 16–24px eso no distingue una
+ * papa de un guayacán. Este módulo da un emoji reconocible por especie
+ * (keyword sobre nombre común/científico/id) con fallback por CATEGORÍA del
+ * catálogo, y un "tono" para el fondo del badge, consistente con la paleta
+ * slate/emerald/amber de la UI.
+ *
+ * Reglas de diseño:
+ *   - Emoji = contenido (especies) — misma convención que CicloVivo,
+ *     HelpCycleSection y el fallback de SpeciesImage. Los iconos de línea
+ *     (lucide) quedan para el chrome de UI y las etapas de ciclo.
+ *   - Solo emoji ≤ Unicode 14 (🫘 ya está en uso en producción): los
+ *     teléfonos rurales viejos deben poder renderizarlos.
+ *   - Determinístico y puro: sin red, sin estado — igual criterio que
+ *     cropSuggestions.js (regla dura: el home pinta al instante y offline).
+ *
+ * Grounding: keywords derivadas del catálogo real v3.1 (72 especies, 14
+ * categorías). Una especie sin match cae a su categoría; sin categoría cae a
+ * 🌱 emerald — nunca un hueco.
+ *
+ * @module utils/speciesVisual
+ */
+
+/**
+ * Normaliza un texto para matching: minúsculas, sin tildes/diacríticos.
+ * @param {string} s
+ * @returns {string}
+ */
+export function normalizeSpeciesText(s) {
+  if (!s || typeof s !== 'string') return '';
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim();
+}
+
+/*
+ * Mapa de keywords → visual. El ORDEN importa: la primera coincidencia gana,
+ * así que lo específico va antes que lo genérico (ej. "tomate de arbol" y
+ * "tomate" comparten keyword y ambos van a 🍅, pero "tomillo" NO debe caer
+ * en "tomate" — por eso se matchea con includes sobre el texto normalizado
+ * y las keywords se eligen para no colisionar entre sí).
+ *
+ * tone ∈ {'emerald','lime','amber','orange','rose','pink','sky','slate'} —
+ * ver SPECIES_TONE_CLASSES en los componentes consumidores.
+ */
+const KEYWORD_VISUALS = [
+  // --- Cereales y pseudocereales ---
+  { kw: ['maiz', 'zea mays'], emoji: '🌽', tone: 'amber' },
+  { kw: ['arroz', 'oryza'], emoji: '🌾', tone: 'amber' },
+  { kw: ['quinua', 'quinoa', 'chenopodium'], emoji: '🌾', tone: 'amber' },
+  { kw: ['amaranto', 'amaranthus'], emoji: '🌾', tone: 'amber' },
+  { kw: [' chia ', 'salvia hispanica'], emoji: '🌾', tone: 'amber' },
+  { kw: ['trigo', 'cebada', 'avena'], emoji: '🌾', tone: 'amber' },
+
+  // --- Tubérculos y raíces ---
+  // Keywords cortas van ACOTADAS con espacios (el haystack se paddea) para
+  // no matchear substrings: ' papa ' NO matchea "papaya", ' oca ' NO
+  // matchea "cacao", etc.
+  { kw: [' papa ', 'solanum tuberosum'], emoji: '🥔', tone: 'amber' },
+  { kw: ['zanahoria', 'daucus', 'arracacha'], emoji: '🥕', tone: 'orange' },
+  { kw: ['batata', 'camote', 'ipomoea batatas', 'yuca', 'manihot', ' name ', 'dioscorea', ' oca ', 'hibia', 'ulluco', 'chugua', 'oxalis tuberosa', 'ullucus'], emoji: '🍠', tone: 'amber' },
+  { kw: ['remolacha', 'rabano'], emoji: '🥕', tone: 'rose' },
+
+  // --- Hortalizas ---
+  { kw: ['cebolla', 'cebollin', 'allium fistulosum', 'allium cepa'], emoji: '🧅', tone: 'amber' },
+  { kw: ['ajo', 'allium sativum'], emoji: '🧄', tone: 'slate' },
+  { kw: ['lechuga', 'lactuca', 'repollo', ' col ', 'espinaca', 'acelga'], emoji: '🥬', tone: 'emerald' },
+  { kw: ['brocoli', 'coliflor'], emoji: '🥦', tone: 'emerald' },
+  // "tomate" cubre tomate de mesa Y tomate de árbol/tamarillo.
+  { kw: ['tomate', 'lycopersicum', 'betaceum', 'tamarillo'], emoji: '🍅', tone: 'rose' },
+  { kw: ['pepino', 'cucumis'], emoji: '🥒', tone: 'emerald' },
+  { kw: ['ahuyama', 'calabaza', 'zapallo', 'cucurbita'], emoji: '🎃', tone: 'orange' },
+  { kw: ['pimenton', ' aji ', 'capsicum'], emoji: '🌶️', tone: 'rose' },
+  { kw: ['berenjena'], emoji: '🍆', tone: 'rose' },
+
+  // --- Granos y legumbres ---
+  { kw: ['frijol', 'habichuela', 'phaseolus', 'chocho', 'tarwi', 'lupinus', 'gandul', 'cajanus', 'haba', 'lenteja', 'garbanzo', 'mucuna', 'chachafruto', 'balu', 'erythrina edulis'], emoji: '🫘', tone: 'amber' },
+  { kw: ['arveja', 'pisum'], emoji: '🫘', tone: 'emerald' },
+  { kw: ['maranon', 'anacardium', 'sacha inchi', 'plukenetia', ' mani ', 'arachis'], emoji: '🥜', tone: 'amber' },
+
+  // --- Frutales ---
+  // ' cafe ' acotado: NO matchea "nogal cafetero" (cordia alliodora).
+  { kw: [' cafe ', 'coffea'], emoji: '☕', tone: 'amber' },
+  { kw: ['cacao', 'theobroma'], emoji: '🍫', tone: 'amber' },
+  { kw: ['fresa', 'fragaria'], emoji: '🍓', tone: 'rose' },
+  { kw: [' mora', 'rubus', 'arandano', 'agraz', 'mortino', 'vaccinium'], emoji: '🫐', tone: 'sky' },
+  { kw: ['uchuva', 'physalis'], emoji: '🍒', tone: 'orange' },
+  { kw: ['lulo', 'naranjilla', 'quitoense'], emoji: '🍊', tone: 'orange' },
+  { kw: ['naranja', 'mandarina', 'citrus'], emoji: '🍊', tone: 'orange' },
+  { kw: [' limon '], emoji: '🍋', tone: 'amber' },
+  { kw: ['aguacate', 'persea'], emoji: '🥑', tone: 'emerald' },
+  { kw: ['platano', 'banano', 'musa '], emoji: '🍌', tone: 'amber' },
+  { kw: [' mango', 'mangifera'], emoji: '🥭', tone: 'orange' },
+  { kw: [' pina', 'ananas'], emoji: '🍍', tone: 'amber' },
+  { kw: [' uva ', ' vid ', 'vitis'], emoji: '🍇', tone: 'pink' },
+  { kw: ['guanabana', 'annona', 'papaya', 'carica', 'guayaba', 'psidium', 'pitahaya', 'selenicereus', 'granadilla', 'maracuya', 'curuba', 'gulupa', 'passiflora'], emoji: '🍈', tone: 'emerald' },
+  { kw: ['guamo', 'inga edulis'], emoji: '🌳', tone: 'emerald' },
+  { kw: ['palma', 'palmito', 'chontaduro', 'bactris', 'elaeis', ' coco'], emoji: '🌴', tone: 'emerald' },
+
+  // --- Medicinales, aromáticas y alelopáticas ---
+  { kw: ['sabila', 'aloe'], emoji: '🌵', tone: 'emerald' },
+  { kw: ['vainilla', 'vanilla'], emoji: '🌸', tone: 'pink' },
+  { kw: ['manzanilla', 'matricaria', 'calendula', 'boton de oro', 'tithonia', 'girasol', 'helianthus', 'crisantemo', 'chrysanthemum', 'pompon'], emoji: '🌼', tone: 'amber' },
+  { kw: ['toronjil', 'melissa', 'yerbabuena', 'hierbabuena', ' menta', 'mentha', 'oregano', 'origanum', 'ortiga', 'urtica', 'llanten', 'plantago', 'cilantro', 'coriandrum', 'perejil', 'apio', 'ruda', 'romero', 'tomillo', 'albahaca', 'salvia officinalis', 'limonaria'], emoji: '🌿', tone: 'emerald' },
+
+  // --- Flores y atractores de polinizadores ---
+  { kw: [' rosa ', 'rosa x', 'rosa hybrida'], emoji: '🌹', tone: 'rose' },
+  { kw: ['clavel', 'dianthus'], emoji: '🌸', tone: 'pink' },
+  { kw: ['heliconia'], emoji: '🌺', tone: 'rose' },
+  { kw: ['mirto', 'azahar', 'murraya'], emoji: '🌸', tone: 'pink' },
+  { kw: ['orquidea', 'cattleya'], emoji: '🌸', tone: 'pink' },
+
+  // --- Árboles, cercas vivas y coberturas ---
+  { kw: ['guadua', 'bambu'], emoji: '🎋', tone: 'emerald' },
+  { kw: ['iraca', 'toquilla', 'carludovica'], emoji: '🎋', tone: 'emerald' },
+  { kw: ['cedro', 'caoba', 'swietenia', 'nogal', 'cordia', 'guayacan', 'tabebuia', 'aliso', 'alnus', 'roble', 'urapan', 'yarumo', 'eucalipto', 'eucalyptus', ' pino ', 'cipres'], emoji: '🌳', tone: 'emerald' },
+  { kw: ['trebol', 'trifolium', 'alfalfa', 'crotalaria', 'vicia', 'abono verde'], emoji: '☘️', tone: 'lime' },
+  { kw: ['kikuyo', 'pasto', 'cenchrus', 'brachiaria', 'raigras', 'melinis'], emoji: '🌾', tone: 'lime' },
+  { kw: ['helecho', 'pteridium', 'retamo', 'ulex'], emoji: '🌿', tone: 'rose' },
+  { kw: ['taruya', 'buchon', 'eichhornia'], emoji: '🌿', tone: 'sky' },
+  { kw: ['frailejon', 'espeletia'], emoji: '🌼', tone: 'emerald' },
+
+  // --- Organismos no-planta del catálogo ---
+  { kw: ['trichoderma', 'bacillus', 'micorriza', 'microorganismo', 'bacteria', 'levadura'], emoji: '🔬', tone: 'sky' },
+  { kw: ['hongo', 'orellana', ' seta', 'champinon'], emoji: '🍄', tone: 'rose' },
+  { kw: ['broca', 'gorgojo', 'polilla', 'trozador', 'pulgon', 'acaro', 'mosca', 'plaga', 'fusarium', 'roya', 'gota ', 'tizon'], emoji: '🐛', tone: 'rose' },
+  { kw: ['abeja', 'apis'], emoji: '🐝', tone: 'amber' },
+  { kw: ['lombriz', 'eisenia'], emoji: '🪱', tone: 'amber' },
+];
+
+/*
+ * Fallback por categoría del catálogo v3.1 (slugs reales del seed). Cubre
+ * también los alias legacy de config/taxonomy.js (frutales, hortalizas…).
+ */
+const CATEGORY_VISUALS = {
+  frutales_perennes: { emoji: '🍎', tone: 'rose' },
+  frutales: { emoji: '🍎', tone: 'rose' },
+  tuberculos_raices: { emoji: '🥔', tone: 'amber' },
+  tuberculos: { emoji: '🥔', tone: 'amber' },
+  cereales: { emoji: '🌾', tone: 'amber' },
+  granos_legumbres: { emoji: '🫘', tone: 'amber' },
+  leguminosas: { emoji: '🫘', tone: 'amber' },
+  hortalizas_hoja: { emoji: '🥬', tone: 'emerald' },
+  hortalizas_fruto_flor: { emoji: '🍅', tone: 'rose' },
+  hortalizas: { emoji: '🥬', tone: 'emerald' },
+  medicinales_alelopaticas: { emoji: '🌿', tone: 'emerald' },
+  medicinales: { emoji: '🌿', tone: 'emerald' },
+  atractores_polinizadores: { emoji: '🌼', tone: 'pink' },
+  ornamentales_nativas: { emoji: '🌺', tone: 'pink' },
+  abonos_verdes_coberturas: { emoji: '☘️', tone: 'lime' },
+  abonos_verdes: { emoji: '☘️', tone: 'lime' },
+  arboles_sombra: { emoji: '🌳', tone: 'emerald' },
+  cercas_vivas: { emoji: '🌳', tone: 'emerald' },
+  fibras_no_maderables: { emoji: '🎋', tone: 'emerald' },
+  especies_invasoras: { emoji: '🌿', tone: 'rose' },
+  microorganismos: { emoji: '🔬', tone: 'sky' },
+  plagas: { emoji: '🐛', tone: 'rose' },
+};
+
+const DEFAULT_VISUAL = { emoji: '🌱', tone: 'emerald' };
+
+/**
+ * Resuelve el visual (emoji + tono) de una especie del catálogo.
+ *
+ * @param {object} sp
+ * @param {string} [sp.comun] - nombre común ("Mora andina / Mora de Castilla").
+ * @param {string} [sp.cientifico] - nombre científico ("Rubus glaucus Benth.").
+ * @param {string} [sp.id] - id canónico del catálogo ("rubus_glaucus").
+ * @param {string} [sp.familia] - familia botánica (apoyo, poco discriminante).
+ * @param {string} [sp.categoria] - slug de categoría del catálogo.
+ * @returns {{ emoji: string, tone: string }} nunca null — siempre hay visual.
+ */
+export function getSpeciesVisual(sp) {
+  if (!sp || typeof sp !== 'object') return DEFAULT_VISUAL;
+
+  // El id canónico usa "_" (rubus_glaucus) — se vuelve espacio para que las
+  // keywords científicas matcheen también contra el id.
+  const haystack = ` ${normalizeSpeciesText(
+    [sp.comun, sp.cientifico, String(sp.id || '').replace(/_/g, ' '), sp.familia].filter(Boolean).join(' · ')
+  )} `;
+
+  if (haystack.trim()) {
+    for (const entry of KEYWORD_VISUALS) {
+      if (entry.kw.some((k) => haystack.includes(k))) {
+        return { emoji: entry.emoji, tone: entry.tone };
+      }
+    }
+  }
+
+  const cat = normalizeSpeciesText(sp.categoria || '').replace(/\s+/g, '_');
+  if (cat && CATEGORY_VISUALS[cat]) return CATEGORY_VISUALS[cat];
+
+  return DEFAULT_VISUAL;
+}
+
+/**
+ * Clases tailwind por tono para el BADGE del emoji (fondo tenue + borde),
+ * pensadas para fondo slate-900/950. Se declaran literales para que el JIT
+ * de tailwind las incluya en el bundle.
+ */
+export const SPECIES_TONE_CLASSES = {
+  emerald: 'bg-emerald-900/40 border-emerald-700/40',
+  lime: 'bg-lime-900/40 border-lime-700/40',
+  amber: 'bg-amber-900/40 border-amber-700/40',
+  orange: 'bg-orange-900/40 border-orange-700/40',
+  rose: 'bg-rose-900/40 border-rose-700/40',
+  pink: 'bg-pink-900/40 border-pink-700/40',
+  sky: 'bg-sky-900/40 border-sky-700/40',
+  slate: 'bg-slate-800/60 border-slate-600/40',
+};

--- a/src/utils/speciesVisual.test.js
+++ b/src/utils/speciesVisual.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { getSpeciesVisual, normalizeSpeciesText, SPECIES_TONE_CLASSES } from './speciesVisual';
+
+// Set de iconos por especie para el catálogo/cards (feedback operador
+// 2026-07). Estos tests fijan el contrato: determinístico, nunca vacío,
+// keywords acotadas sin colisiones de substring (papa/papaya, uva/uchuva,
+// rosa/rosado, cafe/cafetero) y fallback por categoría del seed v3.1.
+
+describe('normalizeSpeciesText', () => {
+  it('baja a minúsculas y quita tildes', () => {
+    expect(normalizeSpeciesText('Fríjol CARGAMANTO')).toBe('frijol cargamanto');
+    expect(normalizeSpeciesText('Ñame')).toBe('name');
+  });
+
+  it('tolera null/undefined/no-string', () => {
+    expect(normalizeSpeciesText(null)).toBe('');
+    expect(normalizeSpeciesText(undefined)).toBe('');
+    expect(normalizeSpeciesText(42)).toBe('');
+  });
+});
+
+describe('getSpeciesVisual — especies del catálogo v3.1', () => {
+  it('resuelve cultivos núcleo por nombre común', () => {
+    expect(getSpeciesVisual({ comun: 'Maíz criollo' }).emoji).toBe('🌽');
+    expect(getSpeciesVisual({ comun: 'Papa Pastusa Suprema' }).emoji).toBe('🥔');
+    expect(getSpeciesVisual({ comun: 'Café caturra / Castillo' }).emoji).toBe('☕');
+    expect(getSpeciesVisual({ comun: 'Fresa' }).emoji).toBe('🍓');
+    expect(getSpeciesVisual({ comun: 'Frijol arbustivo / voluble' }).emoji).toBe('🫘');
+  });
+
+  it('resuelve por nombre científico y por id canónico con "_"', () => {
+    expect(getSpeciesVisual({ cientifico: 'Solanum lycopersicum' }).emoji).toBe('🍅');
+    expect(getSpeciesVisual({ id: 'rubus_glaucus' }).emoji).toBe('🫐');
+    expect(getSpeciesVisual({ id: 'persea_americana' }).emoji).toBe('🥑');
+  });
+
+  it('NO colisiona substrings: papa/papaya, uva/uchuva, rosa/rosado, cafe/cafetero', () => {
+    expect(getSpeciesVisual({ comun: 'Papaya' }).emoji).not.toBe('🥔');
+    expect(getSpeciesVisual({ comun: 'Uchuva' }).emoji).not.toBe('🍇');
+    // "Guayacán rosado" es árbol de sombra, no una rosa.
+    expect(getSpeciesVisual({ comun: 'Guayacán rosado' }).emoji).toBe('🌳');
+    // "Nogal cafetero" es árbol de sombra, no café.
+    expect(getSpeciesVisual({ comun: 'Nogal cafetero' }).emoji).toBe('🌳');
+    // "Espinaca" no debe caer en piña.
+    expect(getSpeciesVisual({ comun: 'Espinaca' }).emoji).toBe('🥬');
+  });
+
+  it('tomate de árbol y tomate de mesa comparten 🍅', () => {
+    expect(getSpeciesVisual({ comun: 'Tomate de árbol / Tamarillo' }).emoji).toBe('🍅');
+    expect(getSpeciesVisual({ comun: 'Tomate San Marzano' }).emoji).toBe('🍅');
+  });
+
+  it('cae al fallback por categoría cuando no hay keyword', () => {
+    expect(getSpeciesVisual({ comun: 'Especie rara', categoria: 'frutales_perennes' }).emoji).toBe('🍎');
+    expect(getSpeciesVisual({ comun: 'Especie rara', categoria: 'arboles_sombra' }).emoji).toBe('🌳');
+    expect(getSpeciesVisual({ comun: 'Especie rara', categoria: 'abonos_verdes_coberturas' }).emoji).toBe('☘️');
+  });
+
+  it('las invasoras llevan tono rose (alerta suave), sin dejar de ser plantas', () => {
+    const v = getSpeciesVisual({ comun: 'Helecho marranero' });
+    expect(v.emoji).toBe('🌿');
+    expect(v.tone).toBe('rose');
+  });
+
+  it('NUNCA retorna vacío: default 🌱 emerald', () => {
+    expect(getSpeciesVisual({})).toEqual({ emoji: '🌱', tone: 'emerald' });
+    expect(getSpeciesVisual(null)).toEqual({ emoji: '🌱', tone: 'emerald' });
+    expect(getSpeciesVisual({ comun: 'zzz desconocida' })).toEqual({ emoji: '🌱', tone: 'emerald' });
+  });
+
+  it('todo tone emitido tiene clases tailwind declaradas', () => {
+    const especies = [
+      { comun: 'Maíz' }, { comun: 'Papa' }, { comun: 'Café' }, { comun: 'Fresa' },
+      { comun: 'Mora andina' }, { comun: 'Uchuva' }, { comun: 'Ajo' }, { comun: 'Rosa' },
+      { comun: 'Helecho marranero' }, { comun: 'Trébol blanco' }, { comun: 'Taruya' },
+      { comun: 'x', categoria: 'atractores_polinizadores' }, {},
+    ];
+    especies.forEach((sp) => {
+      const { tone } = getSpeciesVisual(sp);
+      expect(SPECIES_TONE_CLASSES[tone], `tone sin clases: ${tone}`).toBeTruthy();
+    });
+  });
+});

--- a/src/utils/speciesVisual.test.js
+++ b/src/utils/speciesVisual.test.js
@@ -15,7 +15,7 @@ describe('normalizeSpeciesText', () => {
   it('tolera null/undefined/no-string', () => {
     expect(normalizeSpeciesText(null)).toBe('');
     expect(normalizeSpeciesText(undefined)).toBe('');
-    expect(normalizeSpeciesText(42)).toBe('');
+    expect(normalizeSpeciesText(/** @type {any} */ (42))).toBe('');
   });
 });
 


### PR DESCRIPTION
## Qué cambia (solo capa visual, cero lógica)

Refina los **iconos por especie** y **por etapa de ciclo de vida** que se ven en todo el catálogo y en las cards de especie. Antes cada pantalla improvisaba: el Directorio pintaba el mismo `Leaf` genérico para las 72 especies, `GuiaEspecieCards` repetía `Sprout`/`CheckCircle` para 6 etapas distintas, `PhenologyTimeline` usaba un punto de color sin glifo y el selector de etapa de `CicloDetalle` era solo texto. A 16–24px nada se distinguía sin leer el label.

### Set nuevo centralizado

| Módulo | Rol |
|---|---|
| `src/utils/speciesVisual.js` | Emoji reconocible **por especie** (keyword sobre nombre común/científico/id, grounded en el catálogo v3.1) + tono de badge de la paleta slate/emerald/amber. Fallback por categoría → default 🌱, nunca un hueco. |
| `src/components/icons/etapaCicloIcons.js` + `EtapaCicloIcon.jsx` | **UN** icono lucide por etapa de ciclo — Bean (siembra) → Sprout (germina) → Leaf (crece) → Flower2 (florece) → Apple (fruto) → ShoppingBasket (cosecha) → Recycle (cierre) — métrica única (strokeWidth 2), resuelto por código FarmOS o por label en español. |

Regla de diseño: **especies = emoji** (contenido, convención ya usada en CicloVivo/HelpCycleSection/SpeciesImage) · **etapas = iconos de línea lucide** (chrome de UI). Emoji ≤ Unicode 14 para teléfonos rurales viejos.

### Antes / después

- **Directorio de especies (catálogo)**: fila = `🍃 Leaf` idéntico en todas → badge tonal con emoji por especie (🥔 papa, ☕ café, 🌳 guayacán, 🫐 mora…), también en el header de la ficha.
- **SpeciesCombobox (selector del catálogo en formularios)**: filas solo-texto → emoji por especie al lado del nombre.
- **GuiaEspecieCards (cards de etapas)**: Sprout, Sprout, CheckCircle, CheckCircle, CheckCircle, CheckCircle → Sprout, Leaf, Flower2, Apple, Basket, Package (+ borde tonal del chip).
- **PhenologyTimeline**: punto de 12px sin glifo → badge de 20px con el glifo de la etapa; conserva la rampa theme-aware (emerald/orchid/amber) y los estados observado (ring emerald) / estimado (ring morpho + borde punteado) / pasado (atenuado).
- **CicloDetalle**: glifo de etapa junto a "Etapa:" y en cada chip del selector "¿Cambió de etapa?".

### Anti-colisión de keywords (con tests)

`' papa '` no matchea *papaya*, `' uva '` no matchea *uchuva*, `' rosa '` no matchea *guayacán rosado*, `' cafe '` no matchea *nogal cafetero*, *poscosecha* no cae en *cosecha*.

## Verificación

- `npx vitest run` sobre las 7 suites afectadas (nuevas + GuiaEspecieCards + PhenologyTimeline + SpeciesCombobox + DirectorioEspeciesScreen + CicloDetalle): **48/48 en verde**.
- `npm run build`: OK (warnings preexistentes de dynamic import, sin relación).
- ESLint limpio en todos los archivos tocados.
- Sin voseo argentino, sin CJK/cirílico, sin strings de UI nuevos user-facing (solo glifos aria-hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)