### PR TITLE
feat(juegos): pasada visual a los 6 juegos educativos

### DIFF
--- a/src/components/juego/DefensoresFincaScreen.jsx
+++ b/src/components/juego/DefensoresFincaScreen.jsx
@@ -56,6 +56,35 @@ function leerSuperados() {
   }
 }
 
+/**
+ * Chispas decorativas (feedback visual de acierto/daño). Viven en `world.fx`
+ * y SOLO se dibujan en el canvas: no tocan física, colisiones ni puntaje.
+ */
+function pushChispas(w, x, y, color, n = 8) {
+  if (!w) return;
+  if (!w.fx) w.fx = [];
+  for (let i = 0; i < n; i += 1) {
+    const ang = (i / n) * Math.PI * 2;
+    const vel = 1.1 + (i % 3) * 0.6;
+    w.fx.push({
+      x,
+      y,
+      vx: Math.cos(ang) * vel,
+      vy: Math.sin(ang) * vel - 1.2,
+      vida: 24 + (i % 5) * 5,
+      vidaMax: 30,
+      r: 2.5 + (i % 2),
+      color,
+    });
+  }
+}
+
+/** Hash determinista 0..1 por posición (decoración estable del terreno). */
+function hashDeco(x) {
+  const s = Math.sin(x * 12.9898) * 43758.5453;
+  return s - Math.floor(s);
+}
+
 /** Marca un nivel como superado en localStorage y devuelve la lista resultante. */
 function guardarSuperado(numero) {
   try {
@@ -221,6 +250,7 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
       puntaje: 0,
       energia: nivel.energiaInicial,
       t: 0,
+      fx: [], // chispas decorativas (solo dibujo, cero lógica)
     };
   }, [nivel, pares]);
 
@@ -269,15 +299,23 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
     if (!w || estado !== 'jugando') return;
     const id = beneficoSelRef.current;
     if (!id) return;
+    const vivasAntes = new Set(w.plagas.filter((p) => p.alive).map((p) => p.id));
     const { plagas, eliminadas } = aplicarBenefico(w.plagas, id);
     w.plagas = plagas;
+    // Chispas verdes donde cayó cada plaga (feedback visual, no lógica).
+    for (const p of plagas) {
+      if (!p.alive && vivasAntes.has(p.id)) pushChispas(w, p.x + 17, p.y + 17, '#6ee7b7', 10);
+    }
 
     let golpeoJefe = false;
     if (w.jefe && w.jefe.vivo) {
       const res = golpearJefe(w.jefe, id);
       w.jefe = res.jefe;
       golpeoJefe = res.golpeo;
-      if (res.golpeo) setJefeVida(w.jefe.vida);
+      if (res.golpeo) {
+        setJefeVida(w.jefe.vida);
+        pushChispas(w, w.jefe.x + w.jefe.w / 2, w.jefe.y + 10, '#fbbf24', 12);
+      }
     }
 
     if (eliminadas > 0 || golpeoJefe) {
@@ -376,6 +414,11 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
       // Recolección de cultivos.
       const rec = recolectarCultivos(w.player, w.cultivos);
       if (rec.recogidos.length > 0) {
+        // Chispas doradas donde estaba cada cultivo (feedback visual).
+        for (const cid of rec.recogidos) {
+          const c = w.cultivos.find((k) => k.id === cid);
+          if (c) pushChispas(w, c.x + 15, c.y + 15, '#fde68a', 8);
+        }
         w.cultivos = rec.cultivos;
         w.cultivosRecogidos += rec.recogidos.length;
         w.puntaje = sumarPuntaje(w.puntaje, { cultivos: rec.recogidos.length });
@@ -405,6 +448,7 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
           w.player.invulnUntil = w.t + 60; // ~1s a 60fps
           setEnergia(w.energia);
           beep('hit');
+          pushChispas(w, w.player.x + w.player.w / 2, w.player.y + 20, '#fca5a5', 7);
         }
       }
 
@@ -453,11 +497,45 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
         }
       }
 
-      // Astro (sol/luna), anclado a la vista.
+      // Astro (sol/luna) con halo suave, anclado a la vista.
+      const astroX = w.camX + VIEW_W - 70;
+      const halo = ctx.createRadialGradient(astroX, 70, 8, astroX, 70, 95);
+      halo.addColorStop(0, 'rgba(255,255,240,0.30)');
+      halo.addColorStop(1, 'rgba(255,255,240,0)');
+      ctx.fillStyle = halo;
+      ctx.fillRect(astroX - 95, -25, 190, 190);
       ctx.fillStyle = esc.astro;
       ctx.beginPath();
-      ctx.arc(w.camX + VIEW_W - 70, 70, 34, 0, Math.PI * 2);
+      ctx.arc(astroX, 70, 34, 0, Math.PI * 2);
       ctx.fill();
+
+      // Nubes suaves que derivan despacio (decoración, ancladas a la vista).
+      ctx.fillStyle = 'rgba(255,255,255,0.55)';
+      for (let i = 0; i < 4; i += 1) {
+        const drift = ((i * 197 + w.t * (0.10 + i * 0.03)) % (VIEW_W + 180)) - 90;
+        const cy = 42 + (i % 3) * 26;
+        const cx = w.camX * 0.92 + drift;
+        ctx.beginPath();
+        ctx.ellipse(cx, cy, 34 + (i % 2) * 12, 10, 0, 0, Math.PI * 2);
+        ctx.ellipse(cx + 22, cy - 6, 20, 9, 0, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      // Cordillera LEJANA con parallax (se mueve más lento que la cámara =
+      // profundidad). Solo decoración de fondo.
+      ctx.globalAlpha = 0.4;
+      ctx.fillStyle = esc.montana;
+      ctx.beginPath();
+      ctx.moveTo(w.camX - 20, GROUND_Y);
+      const parFar = (w.camX * 0.45) % 300;
+      for (let sx = -parFar - 300; sx <= VIEW_W + 300; sx += 300) {
+        ctx.lineTo(w.camX + sx + 140, 210);
+        ctx.lineTo(w.camX + sx + 300, GROUND_Y);
+      }
+      ctx.lineTo(w.camX + VIEW_W + 20, GROUND_Y);
+      ctx.closePath();
+      ctx.fill();
+      ctx.globalAlpha = 1;
 
       // Montañas de fondo (repetidas a lo largo del mundo).
       ctx.fillStyle = esc.montana;
@@ -493,50 +571,149 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
         ctx.fillRect(cursor, GROUND_Y - 6, M - cursor, 10);
       }
 
-      // Plataformas.
+      // Vegetación decorativa del terreno: maticas de pasto y florecitas
+      // deterministas por posición (no cambian entre frames ni afectan nada).
+      const gx0 = Math.floor(w.camX / 26) * 26;
+      for (let gx = gx0 - 26; gx < w.camX + VIEW_W + 26; gx += 26) {
+        const enHueco = huecos.some((h) => gx >= h.x - 8 && gx <= h.x + h.w + 2);
+        if (enHueco || gx < 0 || gx > M) continue;
+        const hsh = hashDeco(gx);
+        const sway = Math.sin(w.t * 0.03 + gx * 0.5) * 1.6;
+        if (hsh < 0.45) {
+          // matica de pasto que se mece
+          ctx.strokeStyle = esc.pasto;
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.moveTo(gx, GROUND_Y + 2);
+          ctx.quadraticCurveTo(gx - 3, GROUND_Y - 6, gx - 4 + sway, GROUND_Y - 12);
+          ctx.moveTo(gx + 3, GROUND_Y + 2);
+          ctx.quadraticCurveTo(gx + 5, GROUND_Y - 5, gx + 6 + sway, GROUND_Y - 11);
+          ctx.stroke();
+        } else if (hsh > 0.88) {
+          // florecita silvestre
+          ctx.strokeStyle = esc.pasto;
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.moveTo(gx, GROUND_Y + 2);
+          ctx.lineTo(gx + sway * 0.6, GROUND_Y - 10);
+          ctx.stroke();
+          ctx.fillStyle = hsh > 0.94 ? '#fda4af' : '#fde68a';
+          ctx.beginPath();
+          ctx.arc(gx + sway * 0.6, GROUND_Y - 12, 3.4, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.fillStyle = '#ffffff';
+          ctx.beginPath();
+          ctx.arc(gx + sway * 0.6, GROUND_Y - 12, 1.3, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+
+      // Plataformas (con borde inferior sombreado para dar volumen).
       for (const p of w.plataformas) {
+        ctx.fillStyle = 'rgba(0,0,0,0.18)';
+        ctx.fillRect(p.x + 2, p.y + p.h, p.w - 4, 3);
         ctx.fillStyle = esc.sueloTop;
         ctx.fillRect(p.x, p.y, p.w, p.h);
         ctx.fillStyle = esc.pasto;
         ctx.fillRect(p.x, p.y - 4, p.w, 6);
       }
 
-      // Cultivos (puntos).
+      // Cultivos (puntos) — flotan suavecito con un brillo cálido debajo.
       for (const c of w.cultivos) {
-        if (!c.recogido) drawEmoji(c.emoji, c.x, c.y, 30);
+        if (c.recogido) continue;
+        const bob = Math.sin(w.t * 0.06 + c.x * 0.13) * 2.5;
+        const gl = ctx.createRadialGradient(c.x + 15, c.y + 15 + bob, 2, c.x + 15, c.y + 15 + bob, 22);
+        gl.addColorStop(0, 'rgba(253,230,138,0.35)');
+        gl.addColorStop(1, 'rgba(253,230,138,0)');
+        ctx.fillStyle = gl;
+        ctx.fillRect(c.x - 8, c.y - 8 + bob, 46, 46);
+        drawEmoji(c.emoji, c.x, c.y + bob, 30);
       }
-      // Plagas vivas.
+      // Plagas vivas (sombra en el piso + leve vaivén al patrullar).
       for (const p of w.plagas) {
-        if (p.alive) drawEmoji(p.emoji, p.x, p.y, 32);
+        if (!p.alive) continue;
+        const bobP = Math.sin(w.t * 0.12 + p.baseX) * 1.5;
+        ctx.fillStyle = 'rgba(0,0,0,0.16)';
+        ctx.beginPath();
+        ctx.ellipse(p.x + p.w / 2, p.y + p.h + 3, p.w * 0.42, 4, 0, 0, Math.PI * 2);
+        ctx.fill();
+        drawEmoji(p.emoji, p.x, p.y + bobP, 32);
       }
-      // Mini-jefe + barra de vida.
+      // Mini-jefe + sombra + barra de vida con marco.
       if (w.jefe && w.jefe.vivo) {
+        ctx.fillStyle = 'rgba(0,0,0,0.2)';
+        ctx.beginPath();
+        ctx.ellipse(w.jefe.x + w.jefe.w / 2, w.jefe.y + w.jefe.h + 2, w.jefe.w * 0.44, 6, 0, 0, Math.PI * 2);
+        ctx.fill();
         drawEmoji(w.jefe.emoji, w.jefe.x, w.jefe.y, 60);
         const bw = w.jefe.w;
-        ctx.fillStyle = 'rgba(0,0,0,0.4)';
+        ctx.fillStyle = 'rgba(0,0,0,0.45)';
+        ctx.fillRect(w.jefe.x - 1, w.jefe.y - 13, bw + 2, 9);
+        ctx.fillStyle = '#7f1d1d';
         ctx.fillRect(w.jefe.x, w.jefe.y - 12, bw, 7);
         ctx.fillStyle = '#ef4444';
         ctx.fillRect(w.jefe.x, w.jefe.y - 12, (bw * w.jefe.vida) / w.jefe.vidaMax, 7);
+        ctx.fillStyle = 'rgba(255,255,255,0.35)';
+        ctx.fillRect(w.jefe.x, w.jefe.y - 12, (bw * w.jefe.vida) / w.jefe.vidaMax, 2);
       }
 
       // Jugador (campesino neutro dibujado a mano — sin nombre propio).
+      // Sombra a los pies + rebote de caminado + piernas que alternan:
+      // todo es DIBUJO (la caja de colisión no cambia).
       const px = w.player.x;
       const py = w.player.y;
       const blink = w.t < w.player.invulnUntil && Math.floor(w.t / 6) % 2 === 0;
+      const caminando = (input.current.left || input.current.right) && w.player.onGround;
+      const bobJ = caminando ? Math.abs(Math.sin(w.t * 0.22)) * 2 : 0;
+      const paso = caminando ? Math.sin(w.t * 0.22) * 4 : 0;
+      ctx.fillStyle = 'rgba(0,0,0,0.2)';
+      ctx.beginPath();
+      ctx.ellipse(px + w.player.w / 2, py + w.player.h + 2, w.player.w * 0.5, 4.5, 0, 0, Math.PI * 2);
+      ctx.fill();
       if (!blink) {
+        const pyd = py - bobJ;
+        // sombrero campesino (ala ancha + copa con cinta)
         ctx.fillStyle = '#a16207';
-        ctx.fillRect(px - 4, py, w.player.w + 8, 8);
-        ctx.fillRect(px + 6, py - 8, w.player.w - 12, 10);
+        ctx.fillRect(px - 4, pyd, w.player.w + 8, 8);
+        ctx.fillRect(px + 6, pyd - 8, w.player.w - 12, 10);
+        ctx.fillStyle = '#7c2d12';
+        ctx.fillRect(px + 6, pyd - 1, w.player.w - 12, 3);
+        // cara
         ctx.fillStyle = '#e8b98a';
-        ctx.fillRect(px + 8, py + 8, w.player.w - 16, 16);
+        ctx.fillRect(px + 8, pyd + 8, w.player.w - 16, 16);
+        // camisa
         ctx.fillStyle = '#15803d';
-        ctx.fillRect(px + 6, py + 24, w.player.w - 12, 20);
+        ctx.fillRect(px + 6, pyd + 24, w.player.w - 12, 20);
+        ctx.fillStyle = 'rgba(255,255,255,0.14)';
+        ctx.fillRect(px + 6, pyd + 24, 4, 20);
+        // piernas (alternan al caminar)
         ctx.fillStyle = '#1e3a5f';
-        ctx.fillRect(px + 8, py + 42, w.player.w - 16, 12);
+        ctx.fillRect(px + 8 + paso, py + 42, 8, 12);
+        ctx.fillRect(px + w.player.w - 16 - paso, py + 42, 8, 12);
+        // ojos + sonrisa mirando hacia donde corre
         ctx.fillStyle = '#1c1917';
         const ex = w.player.face === 1 ? px + 16 : px + 12;
-        ctx.fillRect(ex, py + 14, 3, 3);
-        ctx.fillRect(ex + 8, py + 14, 3, 3);
+        ctx.fillRect(ex, pyd + 14, 3, 3);
+        ctx.fillRect(ex + 8, pyd + 14, 3, 3);
+        ctx.fillRect(ex + 3, pyd + 20, 6, 2);
+      }
+
+      // Chispas decorativas de feedback (se actualizan y pintan aquí; si el
+      // juego está pausado en overlay simplemente terminan de desvanecerse).
+      if (w.fx && w.fx.length > 0) {
+        const vivos = [];
+        for (const s of w.fx) {
+          s.x += s.vx;
+          s.y += s.vy;
+          s.vy += 0.06;
+          s.vida -= 1;
+          if (s.vida > 0) vivos.push(s);
+          ctx.globalAlpha = Math.max(0, s.vida / s.vidaMax);
+          ctx.fillStyle = s.color;
+          ctx.fillRect(s.x, s.y, s.r, s.r);
+        }
+        ctx.globalAlpha = 1;
+        w.fx = vivos;
       }
 
       ctx.restore();

--- a/src/components/juego/DoomFincaScreen.jsx
+++ b/src/components/juego/DoomFincaScreen.jsx
@@ -737,6 +737,25 @@ export default function DoomFincaScreen({ onBack, onHome }) {
 
       ctx.putImageData(imageData, 0, 0);
 
+      // ── Viñeta cinematográfica (solo estética: bordes suaves oscuros) ──
+      const vig = ctx.createRadialGradient(W / 2, H / 2, H * 0.42, W / 2, H / 2, H * 0.88);
+      vig.addColorStop(0, 'rgba(0,0,0,0)');
+      vig.addColorStop(1, 'rgba(8,16,10,0.4)');
+      ctx.fillStyle = vig;
+      ctx.fillRect(0, 0, W, H);
+
+      // ── Aviso de vitalidad baja: halo rojo que respira (urgencia visible) ──
+      const vitFrac = Math.max(0, w.vitalidad / CONFIG_DOOM.vitalidadMax);
+      if (vitFrac < 0.35) {
+        const urgencia = 1 - vitFrac / 0.35;
+        const pulso = (0.12 + 0.12 * (0.5 + 0.5 * Math.sin(w.t * 0.14))) * urgencia;
+        const rojo = ctx.createRadialGradient(W / 2, H / 2, H * 0.32, W / 2, H / 2, H * 0.8);
+        rojo.addColorStop(0, 'rgba(0,0,0,0)');
+        rojo.addColorStop(1, `rgba(190,30,30,${pulso.toFixed(3)})`);
+        ctx.fillStyle = rojo;
+        ctx.fillRect(0, 0, W, H);
+      }
+
       // ── Marcador de color sobre cada plaga cercana (verde/rojo) ──
       for (const r of plagaRects) {
         if (r.dist > 9) continue;
@@ -783,7 +802,10 @@ export default function DoomFincaScreen({ onBack, onHome }) {
       const miraColor = aim.plaga
         ? (aim.correcto ? 'rgba(130,255,130,0.98)' : 'rgba(255,180,70,0.98)')
         : 'rgba(255,255,255,0.7)';
-      const ringR = aim.plaga ? 6 : 4;
+      // La mira "late" suave cuando hay objetivo con el benéfico correcto.
+      const ringR = aim.plaga
+        ? 6 + (aim.correcto ? (0.5 + 0.5 * Math.sin(w.t * 0.22)) * 1.6 : 0)
+        : 4;
       ctx.strokeStyle = miraColor;
       ctx.lineWidth = aim.plaga ? 1.4 : 1;
       ctx.beginPath();
@@ -958,6 +980,13 @@ export default function DoomFincaScreen({ onBack, onHome }) {
   }, [beep]);
 
   const vitalidadPct = Math.round((vitalidad / CONFIG_DOOM.vitalidadMax) * 100);
+  // Color de la barra de vitalidad según el estado (verde → ámbar → rojo):
+  // el número ya estaba, ahora el color también cuenta la historia.
+  const vitalGradiente = vitalidadPct > 60
+    ? 'from-emerald-500 to-lime-400'
+    : vitalidadPct > 30
+      ? 'from-amber-500 to-yellow-400'
+      : 'from-rose-600 to-red-400 animate-pulse';
   const escenarioActual = ESCENARIOS[rondaIdx] || ESCENARIOS[0];
   const sugeridos = escenarioActual.beneficosSugeridos;
   // En la transicion ('ronda') el rondaIdx todavia apunta a la ronda ya
@@ -981,18 +1010,21 @@ export default function DoomFincaScreen({ onBack, onHome }) {
 
         {/* ── HUD superior: ronda, plagas, puntaje, combo ── */}
         <div className="jp-doom-hud flex items-center justify-between gap-2 text-xs font-bold shrink-0">
-          <span className="flex items-center gap-1 text-emerald-200 whitespace-nowrap">
+          <span className="flex items-center gap-1 text-emerald-200 whitespace-nowrap rounded-full bg-emerald-950/60 border border-emerald-700/30 px-2 py-0.5">
             <span aria-hidden="true">{escenarioActual.icono}</span>
             <span>Ronda {rondaIdx + 1}/{ESCENARIOS.length}</span>
           </span>
-          <span className="flex items-center gap-1 text-amber-300 whitespace-nowrap" aria-label={`${plagasRestantes} plagas restantes`}>
+          <span className="flex items-center gap-1 text-amber-300 whitespace-nowrap rounded-full bg-amber-950/50 border border-amber-700/30 px-2 py-0.5" aria-label={`${plagasRestantes} plagas restantes`}>
             <Bug size={13} aria-hidden="true" />{plagasRestantes}
           </span>
-          <span className="flex items-center gap-1 text-lime-300 whitespace-nowrap" aria-label={`Puntaje ${puntaje}`}>
+          <span className="flex items-center gap-1 text-lime-300 whitespace-nowrap rounded-full bg-lime-950/50 border border-lime-700/30 px-2 py-0.5" aria-label={`Puntaje ${puntaje}`}>
             <Trophy size={13} aria-hidden="true" />{puntaje}
           </span>
           {combo > 1 && (
-            <span className="flex items-center gap-0.5 text-orange-300 whitespace-nowrap" aria-label={`Combo ${combo}`}>
+            <span
+              className="flex items-center gap-0.5 text-orange-200 whitespace-nowrap rounded-full bg-orange-500/25 border border-orange-400/40 px-2 py-0.5 animate-pulse"
+              aria-label={`Combo ${combo}`}
+            >
               <Zap size={13} aria-hidden="true" />x{combo}
             </span>
           )}
@@ -1003,7 +1035,7 @@ export default function DoomFincaScreen({ onBack, onHome }) {
           <Heart size={13} className="text-emerald-300" aria-hidden="true" />
           <div className="jp-doom-vital-riel flex-1 h-3.5 bg-slate-800/60 rounded-full overflow-hidden border border-emerald-900/40">
             <div
-              className="h-full bg-gradient-to-r from-emerald-500 to-lime-400 rounded-full transition-all duration-300"
+              className={`h-full bg-gradient-to-r ${vitalGradiente} rounded-full transition-all duration-300`}
               style={{ width: `${vitalidadPct}%` }}
             />
           </div>
@@ -1217,8 +1249,15 @@ export default function DoomFincaScreen({ onBack, onHome }) {
                 style={{
                   borderColor: sel ? b.color : recomendado ? 'rgba(52,211,153,0.5)' : 'rgba(255,255,255,0.15)',
                   backgroundColor: sel ? `${b.color}22` : 'rgba(255,255,255,0.05)',
+                  boxShadow: sel ? `0 0 12px ${b.color}55` : 'none',
                 }}
               >
+                {recomendado && !sel && (
+                  <span
+                    className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-emerald-400 border border-emerald-200"
+                    aria-hidden="true"
+                  />
+                )}
                 <span className="jp-tinta-suave absolute top-0.5 left-1 text-2xs text-white/40 font-bold">{i + 1}</span>
                 <span className="text-lg" aria-hidden="true">{b.emoji}</span>
                 <span className="jp-tinta text-2xs font-bold text-white/80 leading-none text-center">{b.nombre.split(' ')[0]}</span>

--- a/src/components/juego/FincaWorldScene.jsx
+++ b/src/components/juego/FincaWorldScene.jsx
@@ -149,8 +149,9 @@ export default function FincaWorldScene({
         {/* Cielo (común a todas las variantes; el tinte viene del stage real) */}
         <rect x="0" y="0" width="400" height="240" fill={`url(#${gradId})`} />
 
-        {/* Sol — cálido, identidad solar de Chagra */}
+        {/* Sol — cálido, identidad solar de Chagra (con halo exterior suave) */}
         <g className="fv-sun">
+          <circle cx="330" cy="48" r="34" fill="#ffe08a" opacity="0.35" />
           <circle cx="330" cy="48" r="26" fill="#ffe08a" opacity="0.95" />
           <circle cx="330" cy="48" r="18" fill="#ffd24d" />
           {/* rayos sutiles (mano radial / energía solar — motivo Chagra) */}
@@ -172,6 +173,18 @@ export default function FincaWorldScene({
           <ellipse cx="210" cy="64" rx="22" ry="11" />
           <ellipse cx="228" cy="60" rx="16" ry="11" />
         </g>
+
+        {/* Pajaritos cruzando el cielo — aparecen cuando el mundo ya tiene vida */}
+        {!vacia && level >= 2 && (
+          <g stroke="#4a5a68" strokeWidth="1.8" fill="none" strokeLinecap="round">
+            <g className="fv-bird">
+              <path d="M150 56 q4 -5 8 0 q4 -5 8 0" />
+            </g>
+            <g className="fv-bird-2">
+              <path d="M116 74 q3 -4 6 0 q3 -4 6 0" opacity="0.75" />
+            </g>
+          </g>
+        )}
 
         {/* ── BACKDROP POR VARIANTE ──────────────────────────────────────── */}
         {kind === 'balcon' && <BalconBackdrop />}
@@ -245,6 +258,16 @@ export default function FincaWorldScene({
             </g>
           );
         })}
+
+        {/* Florecitas silvestres en el pasto cuando el mundo ya florece */}
+        {!modoRico && !vacia && kind === 'finca' && level >= 2 && (
+          <g className="fv-grow" style={{ animationDelay: '0.6s' }}>
+            <Florecita cx={36} cy={206} color="#ff9ec4" small />
+            <Florecita cx={132} cy={214} color="#fff0f6" small />
+            <Florecita cx={238} cy={208} color="#c9b3f5" small />
+            <Florecita cx={352} cy={216} color="#ffd9e6" small />
+          </g>
+        )}
 
         {/* Animales del juego (MODO MUNDO) — solo finca rural si la variante los habilita */}
         {!modoRico && !vacia && kind === 'finca' && animalesEnEscena && (

--- a/src/components/juego/MiFincaVivaScreen.jsx
+++ b/src/components/juego/MiFincaVivaScreen.jsx
@@ -231,9 +231,9 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           type="button"
           data-testid="entrada-defensores-finca"
           onClick={() => irAccion('defensores')}
-          className="jp-mfv-entrada w-full text-left rounded-2xl p-4 bg-gradient-to-br from-teal-600/40 to-emerald-800/40 border-2 border-teal-400/40 hover:border-teal-300/60 active:scale-[0.99] transition flex items-center gap-3"
+          className="jp-mfv-entrada group w-full text-left rounded-2xl p-4 bg-gradient-to-br from-teal-600/40 to-emerald-800/40 border-2 border-teal-400/40 hover:border-teal-300/60 active:scale-[0.99] transition-all duration-150 hover:-translate-y-0.5 hover:shadow-lg flex items-center gap-3"
         >
-          <span className="text-4xl shrink-0" aria-hidden="true">🛡️</span>
+          <span className="text-4xl shrink-0 transition-transform duration-150 group-hover:scale-110" aria-hidden="true">🛡️</span>
           <span className="flex-1 min-w-0">
             {/* eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- nombre del juego, ES-CO. */}
             <span className="jp-tinta block text-base font-black text-white">Defensores de la Finca</span>
@@ -250,9 +250,9 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           type="button"
           data-testid="entrada-milpa"
           onClick={() => irAccion('milpa')}
-          className="jp-mfv-entrada w-full text-left rounded-2xl p-4 bg-gradient-to-br from-lime-600/40 to-amber-800/40 border-2 border-lime-400/40 hover:border-lime-300/60 active:scale-[0.99] transition flex items-center gap-3"
+          className="jp-mfv-entrada group w-full text-left rounded-2xl p-4 bg-gradient-to-br from-lime-600/40 to-amber-800/40 border-2 border-lime-400/40 hover:border-lime-300/60 active:scale-[0.99] transition-all duration-150 hover:-translate-y-0.5 hover:shadow-lg flex items-center gap-3"
         >
-          <span className="text-4xl shrink-0" aria-hidden="true">🌽</span>
+          <span className="text-4xl shrink-0 transition-transform duration-150 group-hover:scale-110" aria-hidden="true">🌽</span>
           <span className="flex-1 min-w-0">
             <span className="jp-tinta block text-base font-black text-white">La Milpa</span>
             <span className="jp-tinta-suave block text-sm text-lime-100/90 leading-snug">
@@ -268,9 +268,9 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           type="button"
           data-testid="entrada-doom-finca"
           onClick={() => irAccion('doom_finca')}
-          className="jp-mfv-entrada w-full text-left rounded-2xl p-4 bg-gradient-to-br from-orange-600/40 to-amber-800/40 border-2 border-orange-400/40 hover:border-orange-300/60 active:scale-[0.99] transition flex items-center gap-3"
+          className="jp-mfv-entrada group w-full text-left rounded-2xl p-4 bg-gradient-to-br from-orange-600/40 to-amber-800/40 border-2 border-orange-400/40 hover:border-orange-300/60 active:scale-[0.99] transition-all duration-150 hover:-translate-y-0.5 hover:shadow-lg flex items-center gap-3"
         >
-          <span className="text-4xl shrink-0" aria-hidden="true">🎯</span>
+          <span className="text-4xl shrink-0 transition-transform duration-150 group-hover:scale-110" aria-hidden="true">🎯</span>
           <span className="flex-1 min-w-0">
             {/* eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- nombre del juego, ES-CO. */}
             <span className="jp-tinta block text-base font-black text-white">Doom de la Finca</span>
@@ -289,9 +289,9 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           type="button"
           data-testid="entrada-subsuelo"
           onClick={() => irAccion('subsuelo')}
-          className="jp-mfv-entrada w-full text-left rounded-2xl p-4 bg-gradient-to-br from-cyan-600/40 to-amber-800/40 border-2 border-cyan-400/40 hover:border-cyan-300/60 active:scale-[0.99] transition flex items-center gap-3"
+          className="jp-mfv-entrada group w-full text-left rounded-2xl p-4 bg-gradient-to-br from-cyan-600/40 to-amber-800/40 border-2 border-cyan-400/40 hover:border-cyan-300/60 active:scale-[0.99] transition-all duration-150 hover:-translate-y-0.5 hover:shadow-lg flex items-center gap-3"
         >
-          <span className="text-4xl shrink-0" aria-hidden="true">🪱</span>
+          <span className="text-4xl shrink-0 transition-transform duration-150 group-hover:scale-110" aria-hidden="true">🪱</span>
           <span className="flex-1 min-w-0">
             <span className="jp-tinta block text-base font-black text-white">Mundo Subsuelo</span>
             <span className="jp-tinta-suave block text-sm text-cyan-100/90 leading-snug">
@@ -310,7 +310,7 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           </div>
           <div className="h-4 bg-slate-800/60 rounded-full overflow-hidden border border-emerald-900/40">
             <div
-              className="h-full bg-gradient-to-r from-emerald-500 via-lime-400 to-emerald-400 rounded-full transition-all duration-700"
+              className="fv-shimmer h-full bg-gradient-to-r from-emerald-500 via-lime-400 to-emerald-400 rounded-full transition-all duration-700"
               style={{ width: `${Math.max(game.progreso, game.vacia ? 0 : 4)}%` }}
               role="progressbar"
               aria-valuenow={game.progreso}

--- a/src/components/juego/MilpaSimulator.jsx
+++ b/src/components/juego/MilpaSimulator.jsx
@@ -92,7 +92,7 @@ function ParcelaCard({ parcela, salud, seleccionada, onSelect, mostrarTipo }) {
       className={[
         'relative flex min-h-[120px] flex-col items-center justify-center gap-1 rounded-3xl border-2 p-3 transition active:scale-[0.98]',
         seleccionada
-          ? 'border-lime-300 bg-emerald-800/60 ring-2 ring-lime-300'
+          ? 'milpa-parcela-activa border-lime-300 bg-gradient-to-b from-emerald-800/70 to-emerald-900/60 ring-2 ring-lime-300'
           : 'border-emerald-800/50 bg-emerald-950/40 hover:border-emerald-600/60',
       ].join(' ')}
     >
@@ -102,7 +102,18 @@ function ParcelaCard({ parcela, salud, seleccionada, onSelect, mostrarTipo }) {
         </span>
       )}
       {d === 0 ? (
-        <span className="text-3xl opacity-40" aria-hidden="true">🟫</span>
+        // Camita de tierra preparada (dibujada, más cálida que un emoji plano).
+        <svg viewBox="0 0 48 24" className="h-9 w-[72px]" aria-hidden="true">
+          <ellipse cx="24" cy="18" rx="21" ry="5" fill="#4a3520" opacity="0.7" />
+          <path d="M4 18 Q24 4 44 18 Z" fill="#8a6a3a" />
+          <path d="M8 16.5 Q24 7 40 16.5" fill="none" stroke="#a8894f" strokeWidth="1.6" opacity="0.9" />
+          <g fill="#3f2d20">
+            <ellipse cx="15" cy="13.5" rx="2.2" ry="1.2" />
+            <ellipse cx="24" cy="11" rx="2.2" ry="1.2" />
+            <ellipse cx="33" cy="13.5" rx="2.2" ry="1.2" />
+          </g>
+          <circle cx="24" cy="10" r="1.1" fill="#7fce8e" />
+        </svg>
       ) : (
         <span className="flex gap-0.5 text-3xl" aria-hidden="true">
           {cultivos.map((c) => (
@@ -444,12 +455,14 @@ export default function MilpaSimulator({ onBack, onHome }) {
             <span className="text-sm font-bold text-emerald-200">
               Temporada {juego.temporadaActual} de {NUM_TEMPORADAS}
             </span>
-            <div className="flex gap-1">
+            <div className="flex items-center gap-1.5">
               {Array.from({ length: NUM_TEMPORADAS }, (_, i) => (
                 <div
                   key={i}
-                  className={`h-2 w-2 rounded-full ${
-                    i < juego.temporadaActual ? 'bg-lime-400' : 'bg-emerald-800'
+                  className={`rounded-full transition-all duration-500 ${
+                    i < juego.temporadaActual
+                      ? 'h-2.5 w-2.5 bg-lime-400 shadow-[0_0_6px_rgba(163,230,53,0.7)]'
+                      : 'h-2 w-2 bg-emerald-800'
                   }`}
                 />
               ))}
@@ -460,14 +473,20 @@ export default function MilpaSimulator({ onBack, onHome }) {
         {/* FASE SELECCIÓN: intro y selección de sistema */}
         {fase === 'seleccion' && (
           <>
-            <header className="rounded-3xl border border-lime-300/30 bg-gradient-to-br from-emerald-900/60 to-emerald-950/60 p-4 milpa-deslizar-arriba">
+            <header className="relative overflow-hidden rounded-3xl border border-lime-300/30 bg-gradient-to-br from-emerald-900/60 to-emerald-950/60 p-4 milpa-deslizar-arriba">
+              {/* Las tres hermanas saludando (decorativo) */}
+              <div className="pointer-events-none absolute right-3 top-3 flex gap-1 text-3xl opacity-90" aria-hidden="true">
+                <span className="milpa-pulso">🌽</span>
+                <span className="milpa-pulso" style={{ animationDelay: '0.4s' }}>🫘</span>
+                <span className="milpa-pulso" style={{ animationDelay: '0.8s' }}>🎃</span>
+              </div>
               <p className="text-xs font-black uppercase tracking-widest text-lime-300">
                 Asociaciones agroecológicas
               </p>
               <h2 className="mt-1 text-2xl font-black leading-tight text-white">
                 ¿Qué quieres sembrar hoy?
               </h2>
-              <p className="mt-2 text-sm font-medium leading-relaxed text-emerald-100">
+              <p className="mt-2 max-w-[85%] text-sm font-medium leading-relaxed text-emerald-100">
                 Las plantas se ayudan cuando crecen juntas. Elige una asociación
                 y descubre cómo rinde más que sembrar cada cultivo solo.
               </p>
@@ -485,16 +504,21 @@ export default function MilpaSimulator({ onBack, onHome }) {
                     hablar(asoc.nombre);
                     try { agentSounds.start(); } catch { /* noop */ }
                   }}
-                  className="flex items-center gap-3 rounded-2xl border border-emerald-800/50 bg-emerald-950/40 p-4 text-left transition hover:border-emerald-600/60 active:scale-[0.98]"
+                  className="group flex items-center gap-3 rounded-2xl border border-emerald-800/50 bg-gradient-to-br from-emerald-900/50 to-emerald-950/50 p-4 text-left transition hover:border-lime-400/50 hover:from-emerald-800/60 active:scale-[0.98]"
                 >
-                  <span className="text-3xl" aria-hidden="true">{asoc.icono}</span>
+                  <span
+                    className="grid h-14 w-14 shrink-0 place-items-center rounded-2xl bg-lime-400/15 text-3xl ring-1 ring-lime-300/30 transition group-hover:scale-110"
+                    aria-hidden="true"
+                  >
+                    {asoc.icono}
+                  </span>
                   <div className="flex-1">
                     <p className="text-sm font-black text-white">{asoc.nombre}</p>
                     <p className="text-xs text-emerald-300">
                       {asoc.cultivos.length} cultivos que se ayudan
                     </p>
                   </div>
-                  <span className="text-lime-300">→</span>
+                  <span className="text-lime-300 transition group-hover:translate-x-1">→</span>
                 </button>
               ))}
             </section>
@@ -1103,10 +1127,10 @@ function BarraComparacion({ asociacion, monocultivo }) {
         />
       </div>
 
-      {/* Barra asociación (superpuesta) */}
+      {/* Barra asociación (superpuesta, con brillo que la recorre) */}
       <div className="absolute top-0 left-0 h-12 w-full overflow-hidden rounded-xl">
         <div
-          className="h-full rounded-xl bg-gradient-to-r from-lime-500 via-emerald-400 to-lime-300 transition-all duration-1000 ease-out milpa-brota"
+          className="milpa-shimmer h-full rounded-xl bg-gradient-to-r from-lime-500 via-emerald-400 to-lime-300 transition-all duration-1000 ease-out milpa-brota"
           style={{ width: `${porcentajeAsociacion}%` }}
         />
       </div>

--- a/src/components/juego/MonoVsPoliSimulator.jsx
+++ b/src/components/juego/MonoVsPoliSimulator.jsx
@@ -1,5 +1,64 @@
 import { BarChart3, FlaskConical, Leaf, ShieldCheck, Sprout, TrendingUp } from 'lucide-react';
 import asociaciones from '../../data/asociaciones-comparativa.json';
+import './mono-vs-poli.css';
+
+/**
+ * Hero ilustrado del encabezado: a la izquierda un lote de monocultivo
+ * (hileras idénticas), a la derecha un policultivo mezclado (alturas y
+ * colores distintos conviviendo). Decorativo, aria-hidden.
+ */
+function HeroMonoVsPoli() {
+  return (
+    <svg viewBox="0 0 240 84" className="h-20 w-full max-w-[240px]" aria-hidden="true">
+      {/* lote monocultivo: hileras uniformes del mismo verde apagado */}
+      <rect x="2" y="46" width="104" height="34" rx="8" fill="#d6cdb4" />
+      {Array.from({ length: 3 }).map((_, fila) => (
+        <g key={`fila-${fila}`}>
+          {Array.from({ length: 6 }).map((_, col) => (
+            <g key={`m-${fila}-${col}`} transform={`translate(${14 + col * 16} ${58 + fila * 9})`}>
+              <line x1="0" y1="0" x2="0" y2="-7" stroke="#8a9a6a" strokeWidth="1.6" />
+              <circle cx="0" cy="-8" r="3" fill="#9db07c" />
+            </g>
+          ))}
+        </g>
+      ))}
+      {/* vs */}
+      <circle cx="120" cy="62" r="11" fill="#193a2f" />
+      <text x="120" y="66" textAnchor="middle" fontSize="9" fontWeight="800" fill="#d9f99d" fontFamily="system-ui, sans-serif">vs</text>
+      {/* lote policultivo: mezcla viva (maíz alto, fríjol trepador, ahuyama) */}
+      <rect x="134" y="46" width="104" height="34" rx="8" fill="#cfe0b0" />
+      <g className="mvp-planta">
+        <line x1="152" y1="76" x2="152" y2="34" stroke="#4d7c0f" strokeWidth="3" strokeLinecap="round" />
+        <path d="M152 44 q-10 -4 -13 -12" stroke="#65a30d" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        <path d="M152 52 q10 -4 13 -12" stroke="#65a30d" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        <ellipse cx="152" cy="32" rx="4" ry="7" fill="#fbbf24" />
+      </g>
+      <g className="mvp-planta" style={{ animationDelay: '0.8s' }}>
+        <path d="M170 76 Q166 60 172 48" stroke="#16a34a" strokeWidth="2.2" fill="none" strokeLinecap="round" />
+        <circle cx="171" cy="50" r="2.6" fill="#22c55e" />
+        <circle cx="168" cy="60" r="2.6" fill="#22c55e" />
+      </g>
+      <g className="mvp-planta" style={{ animationDelay: '1.4s' }}>
+        <path d="M186 76 q10 -14 22 -8" stroke="#3f8f4e" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        <circle cx="206" cy="70" r="6.5" fill="#e58a3c" />
+        <path d="M206 63 q2 -3 4 -3" stroke="#4d7c0f" strokeWidth="1.8" fill="none" strokeLinecap="round" />
+      </g>
+      <g className="mvp-planta" style={{ animationDelay: '0.4s' }}>
+        <line x1="224" y1="76" x2="224" y2="52" stroke="#4d7c0f" strokeWidth="2.6" strokeLinecap="round" />
+        <circle cx="224" cy="49" r="4.4" fill="#84cc16" />
+      </g>
+      {/* sol compartido */}
+      <circle cx="120" cy="16" r="9" fill="#ffd24d" />
+      <g stroke="#ffd98a" strokeWidth="1.8" strokeLinecap="round">
+        <line x1="120" y1="2" x2="120" y2="6" />
+        <line x1="106" y1="16" x2="110" y2="16" />
+        <line x1="130" y1="16" x2="134" y2="16" />
+        <line x1="110" y1="6" x2="113" y2="9" />
+        <line x1="130" y1="6" x2="127" y2="9" />
+      </g>
+    </svg>
+  );
+}
 
 const confidenceStyles = {
   alta: 'bg-emerald-100 text-emerald-900 border-emerald-300',
@@ -115,7 +174,7 @@ function MetricCard({ icon, label, mono, poli, emphasis }) {
           <p className="text-[0.68rem] font-bold uppercase tracking-wide text-stone-500">Monocultivo</p>
           <p className="mt-1 text-sm font-extrabold leading-tight text-stone-900">{mono}</p>
         </div>
-        <div className="rounded-xl bg-emerald-50 p-2 ring-1 ring-emerald-200">
+        <div className="rounded-xl bg-gradient-to-br from-emerald-50 to-lime-50 p-2 ring-1 ring-emerald-200">
           <p className="text-[0.68rem] font-bold uppercase tracking-wide text-emerald-700">Policultivo</p>
           <p className="mt-1 text-sm font-extrabold leading-tight text-emerald-950">{poli}</p>
         </div>
@@ -125,14 +184,15 @@ function MetricCard({ icon, label, mono, poli, emphasis }) {
   );
 }
 
-function AssociationPanel({ item }) {
+function AssociationPanel({ item, index = 0 }) {
   const confidenceClass = confidenceStyles[item.confianza] || confidenceStyles.media;
   const extra = extraIndicator(item);
 
   return (
     <section
       data-testid={`asociacion-${item.id}`}
-      className="overflow-hidden rounded-[1.75rem] border border-lime-200 bg-stone-50 shadow-[0_20px_60px_rgba(63,72,47,0.14)]"
+      className="mvp-entrar overflow-hidden rounded-[1.75rem] border border-lime-200 bg-stone-50 shadow-[0_20px_60px_rgba(63,72,47,0.14)]"
+      style={{ animationDelay: `${Math.min(index * 0.12, 0.6)}s` }}
     >
       <div className="bg-[linear-gradient(135deg,#193a2f,#386641_52%,#a7c957)] p-4 text-white sm:p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
@@ -224,20 +284,25 @@ function AssociationPanel({ item }) {
 export default function MonoVsPoliSimulator({ data = asociaciones }) {
   return (
     <div data-testid="mono-vs-poli-simulator" className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-3 py-4 sm:px-5">
-      <header className="rounded-[1.75rem] border border-lime-200 bg-[#f7f3e8] p-4 shadow-sm sm:p-6">
-        <p className="text-xs font-black uppercase tracking-[0.22em] text-emerald-800">Juego monocultivo vs policultivo</p>
-        <h2 className="mt-2 text-3xl font-black leading-tight text-stone-950 sm:text-4xl">
-          Compare cifras reales antes de sembrar
-        </h2>
-        <p className="mt-3 max-w-3xl text-base font-semibold leading-relaxed text-stone-700">
-          Cada tarjeta pone el monocultivo y el policultivo lado a lado, con rendimiento, nitrogeno,
-          ahorro de insumos, control de plaga, frase campesina, fuente y confianza.
-        </p>
+      <header className="mvp-entrar rounded-[1.75rem] border border-lime-200 bg-[#f7f3e8] p-4 shadow-sm sm:p-6">
+        <div className="grid gap-4 sm:grid-cols-[1fr_auto] sm:items-center">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.22em] text-emerald-800">Juego monocultivo vs policultivo</p>
+            <h2 className="mt-2 text-3xl font-black leading-tight text-stone-950 sm:text-4xl">
+              Compare cifras reales antes de sembrar
+            </h2>
+            <p className="mt-3 max-w-3xl text-base font-semibold leading-relaxed text-stone-700">
+              Cada tarjeta pone el monocultivo y el policultivo lado a lado, con rendimiento, nitrogeno,
+              ahorro de insumos, control de plaga, frase campesina, fuente y confianza.
+            </p>
+          </div>
+          <HeroMonoVsPoli />
+        </div>
       </header>
 
       <div className="flex flex-col gap-5">
-        {data.map((item) => (
-          <AssociationPanel key={item.id} item={item} />
+        {data.map((item, index) => (
+          <AssociationPanel key={item.id} item={item} index={index + 1} />
         ))}
       </div>
     </div>

--- a/src/components/juego/MundoSubsuelo.jsx
+++ b/src/components/juego/MundoSubsuelo.jsx
@@ -4,6 +4,7 @@ import { recordGameStart, recordGameComplete } from '../../services/usageTelemet
 import { fvhSkinClass } from '../../config/fvhSkin';
 import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
 import { evaluarSubsuelo, mensajeMeta } from '../../services/mundoSubsueloEngine';
+import './mundo-subsuelo.css';
 
 function clamp(value, min = 0, max = 100) {
   return Math.max(min, Math.min(max, value));
@@ -98,7 +99,12 @@ function SoilScene({ soilLife, activeDecision }) {
 
         {[92, 265, 438, 608].map((x, index) => (
           <g key={x}>
-            <path d={`M${x} 153c-8-28 8-49 29-52 20 4 36 24 29 52Z`} fill={index % 2 ? '#84cc16' : '#22c55e'} />
+            <path
+              className="ms-planta"
+              style={{ animationDelay: `${index * 0.6}s` }}
+              d={`M${x} 153c-8-28 8-49 29-52 20 4 36 24 29 52Z`}
+              fill={index % 2 ? '#84cc16' : '#22c55e'}
+            />
             <path d={`M${x + 29} 153v${rootDepth}`} stroke="#f5e8b7" strokeWidth="7" strokeLinecap="round" />
             <path d={`M${x + 29} 205c-${18 + index * 4} 16-${28 + index * 3} 31-${38 + index * 2} 49`} stroke="#f5e8b7" strokeWidth="4" fill="none" strokeLinecap="round" />
             <path d={`M${x + 29} 224c${18 + index * 3} 17 ${31 + index * 2} 34 ${42 + index * 2} 58`} stroke="#f5e8b7" strokeWidth="4" fill="none" strokeLinecap="round" />
@@ -111,6 +117,8 @@ function SoilScene({ soilLife, activeDecision }) {
           return (
             <path
               key={`hifa-${index}`}
+              className="ms-hifa"
+              style={{ animationDelay: `${index * 0.35}s` }}
               d={`M${start} ${y} C${start + 42} ${y - 30}, ${start + 96} ${y + 28}, ${start + 148} ${y - 6}`}
               stroke="#67e8f9"
               strokeWidth={soilLife > 70 ? 5 : 3}
@@ -126,6 +134,8 @@ function SoilScene({ soilLife, activeDecision }) {
           <circle
             key={`spark-${index}`}
             data-testid="nutrient-spark"
+            className="ms-spark"
+            style={{ animationDelay: `${index * 0.45}s` }}
             cx={132 + index * 92}
             cy={238 + (index % 3) * 46}
             r="6"
@@ -137,6 +147,8 @@ function SoilScene({ soilLife, activeDecision }) {
         {Array.from({ length: wormCount }).map((_, index) => (
           <path
             key={`worm-${index}`}
+            className="ms-worm"
+            style={{ animationDelay: `${index * 0.8}s` }}
             d={`M${112 + index * 178} ${345 - (index % 2) * 34}c20-18 45 16 68-4`}
             stroke="#f59e0b"
             strokeWidth="10"
@@ -147,9 +159,9 @@ function SoilScene({ soilLife, activeDecision }) {
 
         {soilLife >= 55 && (
           <g fill="#38bdf8" opacity="0.82">
-            <path d="M641 161c-22 47-24 78-2 116 22-38 21-69 2-116Z" />
-            <path d="M688 154c-18 37-20 62-1 92 18-30 17-56 1-92Z" />
-            <path d="M595 164c-15 33-17 54-1 81 15-27 14-49 1-81Z" />
+            <path className="ms-agua" d="M641 161c-22 47-24 78-2 116 22-38 21-69 2-116Z" />
+            <path className="ms-agua" style={{ animationDelay: '1.2s' }} d="M688 154c-18 37-20 62-1 92 18-30 17-56 1-92Z" />
+            <path className="ms-agua" style={{ animationDelay: '2.1s' }} d="M595 164c-15 33-17 54-1 81 15-27 14-49 1-81Z" />
           </g>
         )}
 
@@ -177,7 +189,11 @@ export default function MundoSubsuelo() {
   const [jugadas, setJugadas] = useState(0);
   const activeDecision = mundoSubsueloDecisions.find((decision) => decision.id === activeId) || mundoSubsueloDecisions[0];
   const stage = getSoilStage(soilLife);
-  const meterColor = soilLife >= 60 ? 'bg-emerald-500' : soilLife >= 35 ? 'bg-amber-500' : 'bg-rose-500';
+  const meterColor = soilLife >= 60
+    ? 'bg-gradient-to-r from-emerald-500 to-lime-400'
+    : soilLife >= 35
+      ? 'bg-gradient-to-r from-amber-500 to-yellow-400'
+      : 'bg-gradient-to-r from-rose-500 to-red-400';
 
   // FEEL gated (dev-only): con la flag ON se enciende la capa de OBJETIVO (meta
   // de suelo vivo + celebración al lograrla). Con OFF el juego queda EXACTO como
@@ -246,8 +262,11 @@ export default function MundoSubsuelo() {
               </div>
               <span className="rounded-full bg-stone-950 px-3 py-1 text-xs font-black uppercase text-white">{stage}</span>
             </div>
-            <div className="mt-3 h-4 overflow-hidden rounded-full bg-stone-200" aria-hidden="true">
-              <div className={`h-full rounded-full ${meterColor}`} style={{ width: `${soilLife}%` }} />
+            <div className="mt-3 h-4 overflow-hidden rounded-full bg-stone-200 shadow-inner" aria-hidden="true">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ease-out ${meterColor}`}
+                style={{ width: `${soilLife}%` }}
+              />
             </div>
             {/* Línea de meta (gated dev-only): marca dónde está "suelo vivo". */}
             {feelOn && (
@@ -302,9 +321,9 @@ export default function MundoSubsuelo() {
                   type="button"
                   onClick={() => chooseDecision(decision)}
                   data-selected={selected ? 'true' : 'false'}
-                  className={`jp-ms-carta min-h-28 rounded-2xl border p-3 text-left shadow-sm transition active:scale-[0.98] ${
+                  className={`jp-ms-carta min-h-28 rounded-2xl border p-3 text-left shadow-sm transition-all duration-150 hover:-translate-y-0.5 hover:shadow-md active:scale-[0.98] ${
                     selected
-                      ? 'border-cyan-400 bg-cyan-50 ring-2 ring-cyan-200'
+                      ? 'border-cyan-400 bg-cyan-50 ring-2 ring-cyan-200 shadow-[0_6px_16px_rgba(34,211,238,0.25)]'
                       : decision.tone === 'good'
                         ? 'border-lime-200 bg-white hover:bg-lime-50'
                         : 'border-rose-200 bg-white hover:bg-rose-50'

--- a/src/components/juego/defensores-finca.css
+++ b/src/components/juego/defensores-finca.css
@@ -14,7 +14,9 @@
   margin: 0 auto;
   border-radius: 1.25rem;
   overflow: hidden;
-  box-shadow: 0 18px 50px rgba(8, 30, 22, 0.35);
+  box-shadow:
+    0 18px 50px rgba(8, 30, 22, 0.35),
+    inset 0 0 0 2px rgba(255, 255, 255, 0.08);
   background: #bde0f5;
   /* Bloquea el scroll-touch del navegador mientras se juega con el pulgar. */
   touch-action: none;
@@ -56,7 +58,8 @@
 }
 .df-nivel[data-selected='true'] {
   border-color: #34d399;
-  background: rgba(16, 185, 129, 0.32);
+  background: linear-gradient(160deg, rgba(16, 185, 129, 0.42), rgba(6, 78, 59, 0.5));
+  box-shadow: 0 0 14px rgba(52, 211, 153, 0.35);
 }
 .df-nivel:disabled {
   opacity: 0.5;
@@ -107,9 +110,23 @@
   line-height: 1;
 }
 
+.df-hearts span {
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.35));
+  animation: df-heart-beat 2.4s ease-in-out infinite;
+}
+.df-hearts span:nth-child(2) { animation-delay: 0.2s; }
+.df-hearts span:nth-child(3) { animation-delay: 0.4s; }
+.df-hearts span:nth-child(4) { animation-delay: 0.6s; }
+@keyframes df-heart-beat {
+  0%, 88%, 100% { transform: scale(1); }
+  92% { transform: scale(1.14); }
+  96% { transform: scale(0.98); }
+}
+
 .df-heart-empty {
   opacity: 0.28;
   filter: grayscale(1);
+  animation: none;
 }
 
 /* ── Progreso de objetivos (cultivos / plagas / jefe) ────────────────── */
@@ -140,6 +157,12 @@
   border-color: rgba(52, 211, 153, 0.75);
   background: rgba(5, 150, 105, 0.45);
   color: #ecfdf5;
+  animation: df-objetivo-pop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+@keyframes df-objetivo-pop {
+  0% { transform: scale(0.85); }
+  60% { transform: scale(1.08); }
+  100% { transform: scale(1); }
 }
 
 /* ── Controles táctiles ──────────────────────────────────────────────── */
@@ -164,7 +187,7 @@
   min-height: 64px;
   border-radius: 1rem;
   border: 2px solid rgba(16, 185, 129, 0.45);
-  background: rgba(6, 78, 59, 0.55);
+  background: linear-gradient(180deg, rgba(6, 95, 70, 0.65), rgba(6, 78, 59, 0.55));
   color: #ecfdf5;
   display: flex;
   align-items: center;
@@ -172,7 +195,8 @@
   font-weight: 900;
   font-size: 1.25rem;
   cursor: pointer;
-  transition: transform 0.08s ease, background 0.12s ease;
+  box-shadow: 0 4px 10px rgba(8, 30, 22, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  transition: transform 0.08s ease, background 0.12s ease, box-shadow 0.12s ease;
   -webkit-tap-highlight-color: transparent;
   touch-action: none;
 }
@@ -181,11 +205,12 @@
 .df-btn[data-pressed='true'] {
   transform: scale(0.92);
   background: rgba(16, 185, 129, 0.7);
+  box-shadow: 0 2px 5px rgba(8, 30, 22, 0.3);
 }
 
 .df-btn-jump {
   min-width: 84px;
-  background: rgba(180, 83, 9, 0.6);
+  background: linear-gradient(180deg, rgba(217, 119, 6, 0.7), rgba(180, 83, 9, 0.6));
   border-color: rgba(251, 191, 36, 0.55);
 }
 .df-btn-jump:active,
@@ -195,7 +220,7 @@
 
 .df-btn-action {
   min-width: 84px;
-  background: rgba(13, 148, 136, 0.6);
+  background: linear-gradient(180deg, rgba(20, 184, 166, 0.7), rgba(13, 148, 136, 0.6));
   border-color: rgba(45, 212, 191, 0.6);
 }
 
@@ -275,7 +300,7 @@
   gap: 0.75rem;
   text-align: center;
   padding: 1.25rem;
-  background: rgba(8, 30, 22, 0.86);
+  background: radial-gradient(circle at 50% 32%, rgba(13, 60, 40, 0.82), rgba(8, 30, 22, 0.92));
   backdrop-filter: blur(4px);
   animation: df-fade-in 0.3s ease both;
 }
@@ -296,7 +321,9 @@
 @media (prefers-reduced-motion: reduce) {
   .df-leccion,
   .df-overlay,
-  .df-overlay-emoji {
+  .df-overlay-emoji,
+  .df-hearts span,
+  .df-objetivo-listo {
     animation: none !important;
   }
 }

--- a/src/components/juego/juego-finca.css
+++ b/src/components/juego/juego-finca.css
@@ -74,6 +74,38 @@
   50% { transform: translateY(-8px); }
 }
 
+/* Pajaritos que cruzan el cielo despacito (ida y vuelta suave). */
+.fv-bird {
+  animation: fv-bird-cruzar 16s ease-in-out infinite;
+}
+.fv-bird-2 {
+  animation: fv-bird-cruzar 22s ease-in-out infinite reverse;
+}
+@keyframes fv-bird-cruzar {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(26px, -5px); }
+  50% { transform: translate(52px, 2px); }
+  75% { transform: translate(26px, -4px); }
+}
+
+/* Brillo que recorre la barra de progreso de la finca (celebra sin ruido). */
+.fv-shimmer {
+  position: relative;
+  overflow: hidden;
+}
+.fv-shimmer::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(105deg, transparent 32%, rgba(255, 255, 255, 0.3) 50%, transparent 68%);
+  transform: translateX(-100%);
+  animation: fv-shimmer-mover 2.8s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes fv-shimmer-mover {
+  to { transform: translateX(100%); }
+}
+
 /* ── Animales vivos de la escena (mockup F2 "Finca Viva") ─────────────── */
 
 /* La gallina picotea: la cabeza baja y vuelve. transform-box para que el
@@ -176,6 +208,9 @@
   .fv-sway,
   .fv-sway-slow,
   .fv-float,
+  .fv-bird,
+  .fv-bird-2,
+  .fv-shimmer::after,
   .fv-peck,
   .fv-wiggle,
   .fv-celebration-emoji,

--- a/src/components/juego/milpa.css
+++ b/src/components/juego/milpa.css
@@ -172,7 +172,36 @@
   100% { transform: translateX(0); opacity: 1; }
 }
 
+/* Brillo que recorre las barras de resultado (celebra sin estorbar). */
+.milpa-shimmer {
+  position: relative;
+  overflow: hidden;
+}
+.milpa-shimmer::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(105deg, transparent 30%, rgba(255, 255, 255, 0.3) 50%, transparent 70%);
+  transform: translateX(-100%);
+  animation: milpa-shimmer-mover 2.6s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes milpa-shimmer-mover {
+  to { transform: translateX(100%); }
+}
+
+/* Halo vivo de la parcela seleccionada (se ve dónde estoy sembrando). */
+.milpa-parcela-activa {
+  animation: milpa-parcela-halo 2s ease-in-out infinite;
+}
+@keyframes milpa-parcela-halo {
+  0%, 100% { box-shadow: 0 0 6px rgba(190, 242, 100, 0.25); }
+  50% { box-shadow: 0 0 18px rgba(190, 242, 100, 0.5); }
+}
+
 @media (prefers-reduced-motion: reduce) {
+  .milpa-shimmer::after,
+  .milpa-parcela-activa,
   .milpa-badge-pop,
   .milpa-brota,
   .milpa-pulso,

--- a/src/components/juego/mono-vs-poli.css
+++ b/src/components/juego/mono-vs-poli.css
@@ -1,0 +1,32 @@
+/*
+ * mono-vs-poli.css — entradas suaves para el simulador Monocultivo vs
+ * Policultivo. CSS puro, offline-first, gama baja (solo transform/opacity).
+ * Respeta prefers-reduced-motion.
+ */
+
+/* Cada tarjeta de asociación entra con un levantamiento suave. */
+.mvp-entrar {
+  animation: mvp-entrar 0.5s ease-out both;
+}
+@keyframes mvp-entrar {
+  0% { transform: translateY(14px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
+/* Las plantas del hero se mecen apenas. */
+.mvp-planta {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  animation: mvp-mecer 5s ease-in-out infinite;
+}
+@keyframes mvp-mecer {
+  0%, 100% { transform: rotate(-2deg); }
+  50% { transform: rotate(2deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mvp-entrar,
+  .mvp-planta {
+    animation: none !important;
+  }
+}

--- a/src/components/juego/mundo-subsuelo.css
+++ b/src/components/juego/mundo-subsuelo.css
@@ -1,0 +1,69 @@
+/*
+ * mundo-subsuelo.css — vida sutil para la escena del suelo de "Mundo Subsuelo".
+ *
+ * Movimientos suaves en CSS puro (offline-first, sin libs), pensados para
+ * gama baja: solo transform/opacity. Respeta prefers-reduced-motion.
+ */
+
+/* Lombrices que ondulan despacito bajo tierra. */
+.ms-worm {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: ms-worm-ondular 3.2s ease-in-out infinite;
+}
+@keyframes ms-worm-ondular {
+  0%, 100% { transform: translateX(0) rotate(0deg); }
+  50% { transform: translateX(5px) rotate(2.5deg); }
+}
+
+/* Hifas de micorriza: el flujo recorre la red (dash animado, se ve "vivo"). */
+.ms-hifa {
+  stroke-dasharray: 12 10;
+  animation: ms-hifa-fluir 3.5s linear infinite;
+}
+@keyframes ms-hifa-fluir {
+  to { stroke-dashoffset: -44; }
+}
+
+/* Chispas de nutrientes que titilan. */
+.ms-spark {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: ms-spark-titilar 1.8s ease-in-out infinite;
+}
+@keyframes ms-spark-titilar {
+  0%, 100% { opacity: 0.55; transform: scale(0.85); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+/* Gotas de agua infiltrándose (bajan suave y vuelven). */
+.ms-agua {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: ms-agua-bajar 4s ease-in-out infinite;
+}
+@keyframes ms-agua-bajar {
+  0%, 100% { transform: translateY(0); opacity: 0.8; }
+  50% { transform: translateY(7px); opacity: 0.95; }
+}
+
+/* Plantas de superficie que se mecen con el viento. */
+.ms-planta {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  animation: ms-planta-mecer 4.5s ease-in-out infinite;
+}
+@keyframes ms-planta-mecer {
+  0%, 100% { transform: rotate(-1.5deg); }
+  50% { transform: rotate(1.5deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ms-worm,
+  .ms-hifa,
+  .ms-spark,
+  .ms-agua,
+  .ms-planta {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
Mejora la capa visual de cada juego sin tocar lógica ni balance:

- Defensores de la Finca: halo del sol/luna, nubes y cordillera lejana
  con parallax, pasto y florecitas que se mecen, sombras bajo jugador/
  plagas/jefe, cultivos que flotan con brillo, campesino con caminado
  animado y sonrisa, chispas de feedback (recoger, controlar plaga,
  golpe al jefe, daño), corazones con latido, botones y overlay pulidos.
- Doom de la Finca: viñeta cinematográfica, halo rojo que respira con
  vitalidad baja, mira que late sobre objetivo correcto, barra de
  vitalidad que cambia de color (verde/ámbar/rojo), HUD en píldoras
  legibles, combo resaltado y glow + punto recomendado en el selector
  de benéficos.
- La Milpa: camita de tierra dibujada en SVG para parcela vacía, halo
  vivo en la parcela seleccionada, tres hermanas saludando en el
  encabezado, tarjetas de sistema con tile y hover, puntos de temporada
  con glow y brillo que recorre la barra de comparación.
- Mundo Subsuelo: lombrices que ondulan, hifas con flujo animado,
  chispas de nutrientes que titilan, agua que se infiltra, plantas que
  se mecen, medidor con gradiente y transición suave, cartas con hover.
- Mono vs Poli: hero ilustrado monocultivo vs policultivo con plantas
  que se mecen, entrada escalonada de tarjetas y celda de policultivo
  con gradiente.
- Mi Finca Viva: halo exterior del sol, pajaritos cruzando el cielo,
  florecitas silvestres desde nivel 2, brillo en la barra de progreso
  y tarjetas de entrada con hover que levanta y escala el ícono.

Todo offline-first, CSS/canvas puro, apto para gama baja y con
prefers-reduced-motion respetado. Tests (261) y build en verde.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
