### PR TITLE
test(registro): cubre ocultado de transcripcion vacia

### DIFF
--- a/src/components/__tests__/RegistroVozConfirm.test.jsx
+++ b/src/components/__tests__/RegistroVozConfirm.test.jsx
@@ -105,4 +105,26 @@ describe('RegistroVozConfirm', () => {
     fireEvent.click(screen.getByRole('button', { name: /Planta/i }));
     expect(screen.getByText(/Usar mi ubicación/i)).toBeInTheDocument();
   });
+
+  it('oculta la caja de transcripcion cuando el registro viene vacio en modo manual', () => {
+    const record = {
+      intent: 'registrar_cosecha',
+      source: 'manual',
+      transcription: '',
+      species: [],
+      speciesHint: null,
+      measures: {},
+      phenology: [],
+      symptoms: [],
+      labors: [],
+      input: null,
+      pest: null,
+      position: { raw: '' },
+      timestampMs: NOW,
+    };
+
+    render(<RegistroVozConfirm record={record} onConfirm={vi.fn()} onCancel={vi.fn()} isSaving={false} />);
+
+    expect(screen.queryByText('Lo que oí')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary\n- Added a regression test for RegistroVozConfirm to ensure the empty "Lo que oí" box stays hidden when the record comes from the manual path.\n\n## Test plan\n- npx vitest run src/components/__tests__/RegistroVozConfirm.test.jsx src/components/__tests__/RegistroUnificadoScreen.test.jsx src/components/dashboard/__tests__/DashboardLive.registroUnificado.test.jsx src/services/__tests__/registroUnificadoManual.test.js src/services/__tests__/voiceRecordPayload.test.js\n- npm run tsc:check (repo has preexisting type errors outside this scope)\n- npx eslint src/components/__tests__/RegistroVozConfirm.test.jsx src/components/__tests__/RegistroUnificadoScreen.test.jsx src/components/dashboard/__tests__/DashboardLive.registroUnificado.test.jsx src/services/__tests__/registroUnificadoManual.test.js src/services/__tests__/voiceRecordPayload.test.js src/components/RegistroVozConfirm.jsx src/components/RegistroUnificadoScreen.jsx src/services/voiceRecordPayload.js src/components/dashboard/DashboardLive.jsx src/App.jsx --max-warnings=0\n- npm run build