### PR TITLE
feat(catalog): completar dosis+intervalo en 7 biopreparados del seed

### DIFF
--- a/catalog/__tests__/biopreparados-seed.test.js
+++ b/catalog/__tests__/biopreparados-seed.test.js
@@ -1,0 +1,186 @@
+/**
+ * biopreparados-seed.test.js — invariantes de DOSIS+INTERVALO derivables para el
+ * catálogo auxiliar de biopreparados (catalog/biopreparados-seed.json).
+ *
+ * Principio (task #biodosis-fuego, 2026-07-02): cada biopreparado con
+ * información de dosis en `proceso_resumen` DEBE llevar su campo `dosis`
+ * derivado de esa prosa. `compost_maduro` se exceptúa: `proceso_resumen` sólo
+ * documenta el proceso de compostaje, no la dosis de campo, por lo que
+ * `dosis` se mantiene ausente (regla anti-invención de toxicidad/dosis sin
+ * base textual). Mismo principio para `frecuencia` y `metodo`.
+ *
+ * Adicionalmente verifica que toda entrada tenga `safety_class` (invariante
+ * del PR #1944) y que `reentry_interval_dias` sea null salvo base textual
+ * explícita en `proceso_resumen` (que sólo la tienen caldo_sulfocalcico=15 y
+ * caldo_bordeles=21).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const seed = JSON.parse(
+  readFileSync(join(__dirname, '..', 'biopreparados-seed.json'), 'utf8'),
+);
+
+const biopreparados = seed.biopreparados;
+
+// Biopreparados cuyo proceso_resumen contiene una dosis de aplicación
+// explícita (valor numérico o dilución). La extracción de la dosis del
+// texto es responsabilidad de la curación; este test sólo verifica que
+// el campo `dosis` esté presente y no vacío.
+const CON_DOSIS_DERIVABLE = [
+  'bocashi',
+  'biol',
+  'purin_ortiga',
+  'caldo_sulfocalcico',
+  'caldo_bordeles',
+  'te_compost',
+  'humus_liquido',
+  'lixiviado_frutas',
+  'supermagro',
+  'trichoderma_harzianum_suelo',
+  'bacillus_subtilis_foliar',
+  'cal_dolomita',
+  'roca_fosforica',
+  'ceniza_madera',
+  'biofertilizante_algas',
+];
+
+// Biopreparados cuyo proceso_resumen SÓLO describe el proceso de producción
+// (compostaje) sin dar una dosis de aplicación de campo. `dosis` se mantiene
+// ausente para no inventar.
+const SIN_DOSIS_DERIVABLE = ['compost_maduro'];
+
+describe('biopreparados-seed — estructura', () => {
+  it('tiene 16 entradas', () => {
+    expect(biopreparados).toHaveLength(16);
+  });
+
+  it('todos los biopreparados tienen id, nombre, tipo y safety_class', () => {
+    for (const b of biopreparados) {
+      expect(b.id, 'id').toBeTruthy();
+      expect(b.nombre, `${b.id}.nombre`).toBeTruthy();
+      expect(b.tipo, `${b.id}.tipo`).toBeTruthy();
+      expect(b.safety_class, `${b.id}.safety_class`).toBeTruthy();
+      expect(['bajo', 'medio', 'alto', 'revisar']).toContain(b.safety_class);
+    }
+  });
+});
+
+describe('biopreparados-seed — dosis derivada de proceso_resumen', () => {
+  it.each(CON_DOSIS_DERIVABLE.map((id) => [id]))(
+    '%s tiene campo dosis no vacío derivado de proceso_resumen',
+    (id) => {
+      const b = biopreparados.find((x) => x.id === id);
+      expect(b, `entry ${id} existe`).toBeTruthy();
+      expect(typeof b.dosis, `${id}.dosis es string`).toBe('string');
+      expect(b.dosis.trim().length, `${id}.dosis no vacío`).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(SIN_DOSIS_DERIVABLE.map((id) => [id]))(
+    '%s NO tiene dosis (proceso_resumen no lo respalda)',
+    (id) => {
+      const b = biopreparados.find((x) => x.id === id);
+      expect(b, `entry ${id} existe`).toBeTruthy();
+      // Ausente o null — pero nunca un string inventado.
+      expect(b.dosis ?? null, `${id}.dosis debe ser null/ausente`).toBeNull();
+    },
+  );
+});
+
+describe('biopreparados-seed — frecuencia sólo cuando proceso_resumen la documenta', () => {
+  // Biopreparados cuyo proceso_resumen menciona cadencia explícita
+  // (cada N días/semanas/meses).
+  const CON_FRECUENCIA_DERIVABLE = [
+    'bocashi', // "cada 1,5 a 3 meses"
+    'biol', // "cada 10 a 15 dias"
+    'purin_ortiga', // "cada 10 a 15 dias"
+    'caldo_sulfocalcico', // "cada 10 a 15 dias"
+    'caldo_bordeles', // "cada 8 a 15 dias"
+    'te_compost', // "cada 10 a 15 dias"
+    'humus_liquido', // "cada 7 a 15 dias"
+    'supermagro', // "cada 8 a 15 dias"
+    'bacillus_subtilis_foliar', // "cada 7-10 días"
+    'cal_dolomita', // "según análisis; 1 aplicación por ciclo"
+    'ceniza_madera', // "cada 8 a 15 dias"
+  ];
+
+  it.each(CON_FRECUENCIA_DERIVABLE.map((id) => [id]))(
+    '%s tiene frecuencia derivada de proceso_resumen',
+    (id) => {
+      const b = biopreparados.find((x) => x.id === id);
+      expect(b, `entry ${id} existe`).toBeTruthy();
+      expect(typeof b.frecuencia, `${id}.frecuencia es string`).toBe('string');
+      expect(b.frecuencia.trim().length, `${id}.frecuencia no vacío`).toBeGreaterThan(0);
+    },
+  );
+});
+
+describe('biopreparados-seed — uso/metodo/fuente/confianza cuando dosis está presente', () => {
+  it.each(CON_DOSIS_DERIVABLE.map((id) => [id]))(
+    '%s tiene uso/metodo/fuente/confianza no vacíos',
+    (id) => {
+      const b = biopreparados.find((x) => x.id === id);
+      expect(b, `entry ${id} existe`).toBeTruthy();
+      for (const f of ['uso', 'metodo', 'fuente', 'confianza']) {
+        expect(b[f], `${id}.${f} presente`).toBeTruthy();
+      }
+      expect(['alta', 'media', 'baja']).toContain(b.confianza);
+    },
+  );
+
+  it.each(SIN_DOSIS_DERIVABLE.map((id) => [id]))(
+    '%s (sin dosis) tiene uso/metodo/fuente/confianza cuando aplica',
+    (id) => {
+      const b = biopreparados.find((x) => x.id === id);
+      expect(b, `entry ${id} existe`).toBeTruthy();
+      // Aunque sin dosis, estos siguen teniendo uso/metodo/fuente/confianza.
+      for (const f of ['uso', 'metodo', 'fuente', 'confianza']) {
+        expect(b[f], `${id}.${f} presente`).toBeTruthy();
+      }
+    },
+  );
+});
+
+describe('biopreparados-seed — anti-invención de toxicidad', () => {
+  // reentry_interval_dias debe ser null salvo base textual explícita en
+  // proceso_resumen/uso. Solo caldo_sulfocalcico (15) y caldo_bordeles (21)
+  // documentan carencia explícita.
+  it('solo caldo_sulfocalcico y caldo_bordeles tienen reentry_interval_dias no null', () => {
+    const conIntervalo = biopreparados.filter(
+      (b) => b.reentry_interval_dias !== null && b.reentry_interval_dias !== undefined,
+    );
+    const ids = conIntervalo.map((b) => b.id).sort();
+    expect(ids).toEqual(['caldo_bordeles', 'caldo_sulfocalcico']);
+  });
+
+  it('caldo_sulfocalcico tiene reentry_interval_dias=15', () => {
+    const b = biopreparados.find((x) => x.id === 'caldo_sulfocalcico');
+    expect(b.reentry_interval_dias).toBe(15);
+  });
+
+  it('caldo_bordeles tiene reentry_interval_dias=21', () => {
+    const b = biopreparados.find((x) => x.id === 'caldo_bordeles');
+    expect(b.reentry_interval_dias).toBe(21);
+  });
+
+  // safety_class "revisar" se mantiene para entradas sin base textual de
+  // seguridad — no se infiere "bajo" por ingrediente.
+  it('entradas sin base de seguridad permanecen en revisar', () => {
+    const revisar = biopreparados.filter((b) => b.safety_class === 'revisar');
+    const idsEsperados = [
+      'lixiviado_frutas',
+      'trichoderma_harzianum_suelo',
+      'bacillus_subtilis_foliar',
+      'cal_dolomita',
+      'roca_fosforica',
+      'compost_maduro',
+      'biofertilizante_algas',
+    ].sort();
+    expect(revisar.map((b) => b.id).sort()).toEqual(idsEsperados);
+  });
+});

--- a/catalog/biopreparados-seed.json
+++ b/catalog/biopreparados-seed.json
@@ -280,6 +280,11 @@
       "source_ids": [
         "restrepo-1996-bocashi"
       ],
+      "dosis": "Foliar: dilución 1:20 con agua (≈50 ml de lixiviado por L).",
+      "uso": "Foliar en fase reproductiva (floración y llenado de fruto) como aporte de potasio y micronutrientes.",
+      "metodo": "foliar diluido",
+      "fuente": "Restrepo Rivera, J. — Manual de biopreparados (referenciado por source_ids); fermentación aeróbica de frutas con dilución foliar 1:20.",
+      "confianza": "media",
       "safety_class": "revisar",
       "ppe_required": null,
       "do_not_use_when": null,
@@ -338,6 +343,11 @@
       "source_ids": [
         "cenicafe-trichoderma-2010"
       ],
+      "dosis": "1 kg/ha de sustrato sólido con cepa propagada, mezclado con compost maduro e incorporado a los primeros 10 cm del suelo.",
+      "uso": "Control biológico al suelo pre-siembra o pre-trasplante contra Rhizoctonia, Fusarium y Sclerotinia.",
+      "metodo": "suelo (incorporado con compost maduro)",
+      "fuente": "Cenicafé 2010 — Uso de Trichoderma spp. en manejo integrado de enfermedades del café.",
+      "confianza": "alta",
       "safety_class": "revisar",
       "ppe_required": null,
       "do_not_use_when": null,
@@ -360,6 +370,12 @@
       "source_ids": [
         "agrosavia-bacillus-2018"
       ],
+      "dosis": "Foliar: 1 L/ha de suspensión 10^9 UFC/ml.",
+      "frecuencia": "Foliar cada 7-10 días.",
+      "uso": "Control biológico foliar contra Botrytis, Alternaria y Monilia; compatible con caldos minerales.",
+      "metodo": "foliar",
+      "fuente": "AGROSAVIA 2018 — Control biológico con Bacillus subtilis en cultivos hortícolas andinos.",
+      "confianza": "alta",
       "safety_class": "revisar",
       "ppe_required": null,
       "do_not_use_when": null,
@@ -382,6 +398,12 @@
       "source_ids": [
         "ica-fertilizantes-2019"
       ],
+      "dosis": "500-2000 kg/ha al suelo según análisis, para subir pH ~0.5 unidades.",
+      "frecuencia": "Según análisis de suelo; típicamente 1 aplicación pre-siembra por ciclo.",
+      "uso": "Enmienda directa al suelo antes de siembra según análisis de suelo.",
+      "metodo": "suelo (incorporado pre-siembra)",
+      "fuente": "ICA 2019 — Guía de uso racional de fertilizantes y enmiendas en Colombia.",
+      "confianza": "alta",
       "safety_class": "revisar",
       "ppe_required": null,
       "do_not_use_when": null,
@@ -404,6 +426,11 @@
       "source_ids": [
         "ica-fertilizantes-2019"
       ],
+      "dosis": "500-1000 kg/ha incorporados pre-siembra.",
+      "uso": "Enmienda de fósforo al suelo pre-siembra en suelos ácidos (pH<5.5), o co-compostaje con ácidos orgánicos para acelerar solubilización.",
+      "metodo": "suelo (incorporado pre-siembra) o co-compostaje",
+      "fuente": "ICA 2019 — Guía de uso racional de fertilizantes y enmiendas en Colombia.",
+      "confianza": "alta",
       "safety_class": "revisar",
       "ppe_required": null,
       "do_not_use_when": null,
@@ -465,6 +492,10 @@
         "restrepo-1996-bocashi",
         "agrosavia-manual-biopreparados-2015"
       ],
+      "uso": "Enmienda orgánica al suelo como producto final del compostaje aeróbico de residuos vegetales y estiércol.",
+      "metodo": "suelo (incorporado)",
+      "fuente": "Restrepo Rivera, J. — ABC de la agricultura orgánica; AGROSAVIA 2015 — Manual de biopreparados para la agricultura sostenible.",
+      "confianza": "alta",
       "safety_class": "revisar",
       "ppe_required": null,
       "do_not_use_when": null,
@@ -487,6 +518,11 @@
       "source_ids": [
         "khan-2009-seaweed-extracts"
       ],
+      "dosis": "Foliar: dilución 1:500 con agua.",
+      "uso": "Foliar como estimulante de enraizamiento; fuente de citoquininas, auxinas y oligoelementos.",
+      "metodo": "foliar diluido",
+      "fuente": "Khan et al. 2009 — Seaweed extracts as biostimulants of plant growth and development (J Plant Growth Regul 28(4):386-399).",
+      "confianza": "alta",
       "safety_class": "revisar",
       "ppe_required": null,
       "do_not_use_when": null,


### PR DESCRIPTION
## Summary

Task #biodosis-fuego: completa dosis+intervalo (y campos derivables: uso, frecuencia, metodo, fuente, confianza) de los 7 biopreparados del catálogo auxiliar (`catalog/biopreparados-seed.json`) que quedaron con estos campos vacíos tras el PR #1944.

Los 7 biopreparados afectados (todos con `safety_class: "revisar"`):

| ID | dosis derivada | fuente citada |
|---|---|---|
| `lixiviado_frutas` | Foliar 1:20 en fase reproductiva | Restrepo Rivera — Manual de biopreparados |
| `trichoderma_harzianum_suelo` | 1 kg/ha al suelo con compost maduro | Cenicafé 2010 |
| `bacillus_subtilis_foliar` | Foliar 1 L/ha cada 7-10 días | AGROSAVIA 2018 |
| `cal_dolomita` | 500-2000 kg/ha según análisis (pH) | ICA 2019 |
| `roca_fosforica` | 500-1000 kg/ha pre-siembra (pH<5.5) | ICA 2019 |
| `biofertilizante_algas` | Foliar 1:500 | Khan et al. 2009 (J Plant Growth Regul 28(4):386-399) |
| `compost_maduro` | **sin dosis** (ver nota abajo) | Restrepo Rivera / AGROSAVIA 2015 |

## Reporte — caso especial: `compost_maduro`

`proceso_resumen` de `compost_maduro` sólo documenta el proceso de compostaje (pila, volteos, madurez), no la dosis de aplicación de campo. Para respetar la regla "no inventar dosis sin base textual", el campo `dosis` se mantiene ausente. Sí se completan `uso`, `metodo`, `fuente`, `confianza` (todos derivables del proceso_resumen + source_ids). ESCALATE_TO_OPUS opcional: si se quiere dosis de campo para `compost_maduro`, requiere cita externa (Restrepo 2005 o AGROSAVIA 2015) — fuera del scope de este PR.

## Regla anti-invención respetada

- `safety_class` se mantiene en `"revisar"` para los 7 (sin base textual de toxicidad en `proceso_resumen`, no se infiere `"bajo"` por ingrediente).
- `reentry_interval_dias` se mantiene `null` (ningún `proceso_resumen` documenta carencia explícita — sólo `caldo_sulfocalcico=15` y `caldo_bordeles=21` la traen).
- `dosis_aplicacion` y `precaucion_seguridad` quedan ausentes en los 7: reproducirlos exigiría inventar prosa curatorial nueva fuera del scope "derivar de prosa existente".

## Test plan

Nuevo archivo: `catalog/__tests__/biopreparados-seed.test.js` — 49 tests que cubren:

- estructura: 16 entradas, todas con `safety_class`
- dosis derivada de `proceso_resumen`: 15 con dosis, 1 sin (`compost_maduro`)
- frecuencia sólo cuando `proceso_resumen` la documenta explícitamente
- `uso`/`metodo`/`fuente`/`confianza` presentes cuando aplica
- anti-invención: sólo `caldo_sulfocalcico` (15) y `caldo_bordeles` (21) tienen `reentry_interval_dias` no null
- anti-invención: las 7 entradas sin base de seguridad permanecen en `"revisar"`

### Verificación local ejecutada

- `npx vitest run catalog/__tests__/biopreparados-seed.test.js` ✓ 49 passed
- `npx vitest run catalog/__tests__/` ✓ 88 passed (3 files)
- `npx vitest run src/data/__tests__/dataSchema.fuente.test.js -t "biopreparados"` ✓ 4 passed
- `npx vitest run src/components/__tests__/BiopreparadoDiagrama.smoke.test.jsx` ✓ 24 passed
- `npx eslint catalog/__tests__/biopreparados-seed.test.js --max-warnings=0` ✓ clean
- `npm run build` ✓ built in 45.87s
- `node scripts/validate-catalog.mjs catalog/chagra-catalog-oss-subset-v3.2.json --lenient-schema` ✓ válido (530 especies, 36 biopreparados)
- `node scripts/validate-catalog.mjs catalog/biopreparados-seed.json --seed-mode --lenient-schema` mismos 18 AMB-13 errores pre-existentes (no introduce nuevos errores)

## MCP tools usadas

No se usaron MCP tools en este PR: el cambio es de catálogo auxiliar (no toca species/plagas ni ADRs).

## Riesgos conocidos

- **Bajo**. El archivo `catalog/biopreparados-seed.json` es el catálogo auxiliar "legacy v3.0" (16 entries). El catálogo canónico es `chagra-catalog-seed-v3.1.json` (36 entries) que ya tiene todos los biopreparados con datos completos. La web app consume del canónico vía SQLite build.
- La sincronización entre `biopreparados-seed.json` y `chagra-catalog-seed-v3.1.json` sigue desalineada (16 vs 19 biopreparados, campos incompletos en el auxiliar). Esa sincronización es fuera de scope de #biodosis-fuego.

## Tests pre-existentes (no introducidos por este PR)

- `scripts/__tests__/validate-catalog.test.mjs`: 2 tests AMB-31 fallan en main (pre-existing, verificados con `git stash`). NO relacionados con biopreparados-seed.
- `src/data/__tests__/dataSchema.fuente.test.js > agro-lecciones.json`: 1 test falla en main (pre-existing). NO relacionado con biopreparados-seed (los 4 tests específicos de biopreparados del mismo archivo sí pasan).