### PR TITLE
fix(sources): reclassificar 8 fuentes segun metadata (tipo/revista/DOI)

### DIFF
--- a/catalog/chagra-catalog-graph-export.json
+++ b/catalog/chagra-catalog-graph-export.json
@@ -11369,7 +11369,7 @@
       "titulo": "El retamo espinoso: la plaga que amenaza los páramos colombianos",
       "url": "https://es.mongabay.com",
       "observaciones": "STUB — artículo periodístico, validar contra fuente primaria antes de citar en ministerial.",
-      "tier": "A"
+      "tier": "B"
     },
     {
       "id": "mujica-1992-quinua",
@@ -11378,7 +11378,7 @@
       "año": 1992,
       "titulo": "Revisión bibliográfica sobre el cultivo de la quinua (Chenopodium quinoa Willd.) y el amaranto (Amaranthus caudatus L.) en los Andes",
       "observaciones": "Publicación del Instituto Nacional de Investigaciones Agropecuarias (INIAP), Ecuador. Revisión exhaustiva de germoplasma, agronomía y usos tradicionales. _audit_note: buscar en repositorio.iniap.gob.ec o FAO ECOPORT (Mujica autor afiliado UNAP Puno + INIAP).",
-      "tier": "B"
+      "tier": "A"
     },
     {
       "id": "nrc-1989-cultivos-andinos",
@@ -11398,7 +11398,7 @@
       "titulo": "Papa criolla Grupo Phureja, manual de recomendaciones técnicas para Cundinamarca",
       "revista_o_editorial": "Editorial Universidad Nacional de Colombia",
       "isbn": "9789585054929",
-      "tier": "B"
+      "tier": "A"
     },
     {
       "id": "ocampo-solorza-2017",
@@ -11407,7 +11407,7 @@
       "año": 2017,
       "titulo": "Manejo de retamo espinoso (Ulex europaeus) en zonas altoandinas de Cundinamarca",
       "observaciones": "STUB migrado de v3.0 — revista y paginación pendientes. _audit_note: cita incompleta, requiere localizar revista (posibles candidatos: Colombia Forestal, Caldasia, boletín IAvH).",
-      "tier": "B"
+      "tier": "A"
     },
     {
       "id": "pamplona-roger-2006-plantas-medicinales",
@@ -11439,7 +11439,7 @@
       "volumen_numero": "26(3)",
       "paginas": "477-486",
       "observaciones": "_audit_note: Agronomía Colombiana revista UNAL — buscar artículo en revistas.unal.edu.co/index.php/agrocol por autor Pérez L. + año 2008.",
-      "tier": "B"
+      "tier": "A"
     },
     {
       "id": "powo-kew",

--- a/catalog/chagra-catalog-oss-subset-v3.1.json
+++ b/catalog/chagra-catalog-oss-subset-v3.1.json
@@ -14807,7 +14807,7 @@
       "titulo": "The Compost Tea Brewing Manual",
       "revista_o_editorial": "Soil Foodweb Inc.",
       "observaciones": "Fuente internacional; validada contra condiciones colombianas por AGROSAVIA 2015. _audit_note: publicación Soil Foodweb Inc. (Corvallis, OR); múltiples ediciones (2000, 2002, 2005) con ISBNs distintos — verificar edición específica usada en validación AGROSAVIA 2015.",
-      "tier": "A",
+      "tier": "B",
       "_url_pendiente": true,
       "_isbn_pendiente": true
     },
@@ -14862,7 +14862,7 @@
       "titulo": "El retamo espinoso: la plaga que amenaza los páramos colombianos",
       "url": "https://es.mongabay.com",
       "observaciones": "STUB — artículo periodístico, validar contra fuente primaria antes de citar en ministerial.",
-      "tier": "A"
+      "tier": "B"
     },
     {
       "id": "mujica-1992-quinua",
@@ -14871,7 +14871,7 @@
       "año": 1992,
       "titulo": "Revisión bibliográfica sobre el cultivo de la quinua (Chenopodium quinoa Willd.) y el amaranto (Amaranthus caudatus L.) en los Andes",
       "observaciones": "Publicación del Instituto Nacional de Investigaciones Agropecuarias (INIAP), Ecuador. Revisión exhaustiva de germoplasma, agronomía y usos tradicionales. _audit_note: buscar en repositorio.iniap.gob.ec o FAO ECOPORT (Mujica autor afiliado UNAP Puno + INIAP).",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {
@@ -14892,7 +14892,7 @@
       "titulo": "Papa criolla Grupo Phureja, manual de recomendaciones técnicas para Cundinamarca",
       "revista_o_editorial": "Editorial Universidad Nacional de Colombia",
       "isbn": "9789585054929",
-      "tier": "B"
+      "tier": "A"
     },
     {
       "id": "ocampo-solorza-2017",
@@ -14901,7 +14901,7 @@
       "año": 2017,
       "titulo": "Manejo de retamo espinoso (Ulex europaeus) en zonas altoandinas de Cundinamarca",
       "observaciones": "STUB migrado de v3.0 — revista y paginación pendientes. _audit_note: cita incompleta, requiere localizar revista (posibles candidatos: Colombia Forestal, Caldasia, boletín IAvH).",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {
@@ -14938,7 +14938,7 @@
       "volumen_numero": "26(3)",
       "paginas": "477-486",
       "observaciones": "_audit_note: Agronomía Colombiana revista UNAL — buscar artículo en revistas.unal.edu.co/index.php/agrocol por autor Pérez L. + año 2008.",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {
@@ -15003,7 +15003,7 @@
       "titulo": "Abonos orgánicos fermentados — experiencias de agricultores en Centroamérica y Brasil",
       "revista_o_editorial": "OIT",
       "observaciones": "_audit_note: publicación OIT/ILO en programa PROCMD Centroamérica; buscar en ilo.org/publns o catálogo OIT San José Costa Rica.",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true,
       "_isbn_pendiente": true
     },
@@ -15147,7 +15147,7 @@
       "titulo": "Natural Farming: Lactic Acid Bacteria / Fish Amino Acid / Fermented Plant Juice — Sustainable Agriculture factsheets",
       "institucion": "University of Hawaii — College of Tropical Agriculture and Human Resources (CTAHR)",
       "observaciones": "_audit_note: factsheet set publicado por CTAHR Sustainable Agriculture program (SA-7, SA-8, SA-9); URLs canónicas en repository.ctahr.hawaii.edu — requiere localizar handle específico por factsheet.",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {

--- a/catalog/chagra-catalog-oss-subset-v3.2.json
+++ b/catalog/chagra-catalog-oss-subset-v3.2.json
@@ -28557,7 +28557,7 @@
       "titulo": "The Compost Tea Brewing Manual",
       "revista_o_editorial": "Soil Foodweb Inc.",
       "observaciones": "Fuente internacional; validada contra condiciones colombianas por AGROSAVIA 2015. _audit_note: publicación Soil Foodweb Inc. (Corvallis, OR); múltiples ediciones (2000, 2002, 2005) con ISBNs distintos — verificar edición específica usada en validación AGROSAVIA 2015.",
-      "tier": "A",
+      "tier": "B",
       "_url_pendiente": true,
       "_isbn_pendiente": true
     },
@@ -28634,7 +28634,7 @@
       "titulo": "El retamo espinoso: la plaga que amenaza los páramos colombianos",
       "url": "https://es.mongabay.com",
       "observaciones": "STUB — artículo periodístico, validar contra fuente primaria antes de citar en ministerial.",
-      "tier": "A"
+      "tier": "B"
     },
     {
       "id": "mujica-1992-quinua",
@@ -28643,7 +28643,7 @@
       "año": 1992,
       "titulo": "Revisión bibliográfica sobre el cultivo de la quinua (Chenopodium quinoa Willd.) y el amaranto (Amaranthus caudatus L.) en los Andes",
       "observaciones": "Publicación del Instituto Nacional de Investigaciones Agropecuarias (INIAP), Ecuador. Revisión exhaustiva de germoplasma, agronomía y usos tradicionales. _audit_note: buscar en repositorio.iniap.gob.ec o FAO ECOPORT (Mujica autor afiliado UNAP Puno + INIAP).",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {
@@ -28664,7 +28664,7 @@
       "titulo": "Papa criolla Grupo Phureja, manual de recomendaciones técnicas para Cundinamarca",
       "revista_o_editorial": "Editorial Universidad Nacional de Colombia",
       "isbn": "9789585054929",
-      "tier": "B"
+      "tier": "A"
     },
     {
       "id": "ocampo-solorza-2017",
@@ -28673,7 +28673,7 @@
       "año": 2017,
       "titulo": "Manejo de retamo espinoso (Ulex europaeus) en zonas altoandinas de Cundinamarca",
       "observaciones": "STUB migrado de v3.0 — revista y paginación pendientes. _audit_note: cita incompleta, requiere localizar revista (posibles candidatos: Colombia Forestal, Caldasia, boletín IAvH).",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {
@@ -28710,7 +28710,7 @@
       "volumen_numero": "26(3)",
       "paginas": "477-486",
       "observaciones": "_audit_note: Agronomía Colombiana revista UNAL — buscar artículo en revistas.unal.edu.co/index.php/agrocol por autor Pérez L. + año 2008.",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {
@@ -28775,7 +28775,7 @@
       "titulo": "Abonos orgánicos fermentados — experiencias de agricultores en Centroamérica y Brasil",
       "revista_o_editorial": "OIT",
       "observaciones": "_audit_note: publicación OIT/ILO en programa PROCMD Centroamérica; buscar en ilo.org/publns o catálogo OIT San José Costa Rica.",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true,
       "_isbn_pendiente": true
     },
@@ -28919,7 +28919,7 @@
       "titulo": "Natural Farming: Lactic Acid Bacteria / Fish Amino Acid / Fermented Plant Juice — Sustainable Agriculture factsheets",
       "institucion": "University of Hawaii — College of Tropical Agriculture and Human Resources (CTAHR)",
       "observaciones": "_audit_note: factsheet set publicado por CTAHR Sustainable Agriculture program (SA-7, SA-8, SA-9); URLs canónicas en repository.ctahr.hawaii.edu — requiere localizar handle específico por factsheet.",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {

--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -6200,7 +6200,7 @@
       "titulo": "The Compost Tea Brewing Manual",
       "revista_o_editorial": "Soil Foodweb Inc.",
       "observaciones": "Fuente internacional; validada contra condiciones colombianas por AGROSAVIA 2015. _audit_note: publicación Soil Foodweb Inc. (Corvallis, OR); múltiples ediciones (2000, 2002, 2005) con ISBNs distintos — verificar edición específica usada en validación AGROSAVIA 2015.",
-      "tier": "A",
+      "tier": "B",
       "_url_pendiente": true,
       "_isbn_pendiente": true
     },
@@ -6266,7 +6266,7 @@
       "titulo": "El retamo espinoso: la plaga que amenaza los páramos colombianos",
       "url": "https://es.mongabay.com",
       "observaciones": "STUB — artículo periodístico, validar contra fuente primaria antes de citar en ministerial.",
-      "tier": "A"
+      "tier": "B"
     },
     {
       "id": "mujica-1992-quinua",
@@ -6275,7 +6275,7 @@
       "año": 1992,
       "titulo": "Revisión bibliográfica sobre el cultivo de la quinua (Chenopodium quinoa Willd.) y el amaranto (Amaranthus caudatus L.) en los Andes",
       "observaciones": "Publicación del Instituto Nacional de Investigaciones Agropecuarias (INIAP), Ecuador. Revisión exhaustiva de germoplasma, agronomía y usos tradicionales. _audit_note: buscar en repositorio.iniap.gob.ec o FAO ECOPORT (Mujica autor afiliado UNAP Puno + INIAP).",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {
@@ -6296,7 +6296,7 @@
       "titulo": "Papa criolla Grupo Phureja, manual de recomendaciones técnicas para Cundinamarca",
       "revista_o_editorial": "Editorial Universidad Nacional de Colombia",
       "isbn": "9789585054929",
-      "tier": "B"
+      "tier": "A"
     },
     {
       "id": "ocampo-solorza-2017",
@@ -6305,7 +6305,7 @@
       "año": 2017,
       "titulo": "Manejo de retamo espinoso (Ulex europaeus) en zonas altoandinas de Cundinamarca",
       "observaciones": "STUB migrado de v3.0 — revista y paginación pendientes. _audit_note: cita incompleta, requiere localizar revista (posibles candidatos: Colombia Forestal, Caldasia, boletín IAvH).",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {
@@ -6342,7 +6342,7 @@
       "volumen_numero": "26(3)",
       "paginas": "477-486",
       "observaciones": "_audit_note: Agronomía Colombiana revista UNAL — buscar artículo en revistas.unal.edu.co/index.php/agrocol por autor Pérez L. + año 2008.",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {
@@ -6407,7 +6407,7 @@
       "titulo": "Abonos orgánicos fermentados — experiencias de agricultores en Centroamérica y Brasil",
       "revista_o_editorial": "OIT",
       "observaciones": "_audit_note: publicación OIT/ILO en programa PROCMD Centroamérica; buscar en ilo.org/publns o catálogo OIT San José Costa Rica.",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true,
       "_isbn_pendiente": true
     },
@@ -6551,7 +6551,7 @@
       "titulo": "Natural Farming: Lactic Acid Bacteria / Fish Amino Acid / Fermented Plant Juice — Sustainable Agriculture factsheets",
       "institucion": "University of Hawaii — College of Tropical Agriculture and Human Resources (CTAHR)",
       "observaciones": "_audit_note: factsheet set publicado por CTAHR Sustainable Agriculture program (SA-7, SA-8, SA-9); URLs canónicas en repository.ctahr.hawaii.edu — requiere localizar handle específico por factsheet.",
-      "tier": "B",
+      "tier": "A",
       "_url_pendiente": true
     },
     {

--- a/catalog/sources-seed.json
+++ b/catalog/sources-seed.json
@@ -500,7 +500,7 @@
     },
     {
       "id": "ocampo-solorza-2017",
-      "tier": "B",
+      "tier": "A",
       "tipo": "articulo_revista",
       "autores": "Ocampo, J.; Solórzano, P.",
       "año": 2017,
@@ -539,7 +539,7 @@
     },
     {
       "id": "mongabay-retamo-2024",
-      "tier": "C",
+      "tier": "B",
       "tipo": "periodismo_ambiental",
       "autores": "Mongabay Latam",
       "año": 2024,

--- a/public/cycle-content/amaranthus_caudatus.json
+++ b/public/cycle-content/amaranthus_caudatus.json
@@ -73,7 +73,7 @@
     {
       "id": "mujica-1992-quinua",
       "title": "mujica-1992-quinua",
-      "tier": "B",
+      "tier": "A",
       "url": null
     }
   ],

--- a/public/cycle-content/amaranthus_caudatus_kiwicha.json
+++ b/public/cycle-content/amaranthus_caudatus_kiwicha.json
@@ -61,7 +61,7 @@
     {
       "id": "mujica-1992-quinua",
       "title": "mujica-1992-quinua",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {

--- a/public/cycle-content/chenopodium_pallidicaule.json
+++ b/public/cycle-content/chenopodium_pallidicaule.json
@@ -55,7 +55,7 @@
     {
       "id": "mujica-1992-quinua",
       "title": "mujica-1992-quinua",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {

--- a/public/cycle-content/cytisus_monspessulanus.json
+++ b/public/cycle-content/cytisus_monspessulanus.json
@@ -56,7 +56,7 @@
     {
       "id": "mongabay-retamo-2024",
       "title": "mongabay-retamo-2024",
-      "tier": "A",
+      "tier": "B",
       "url": "https://es.mongabay.com"
     },
     {

--- a/public/cycle-content/phaseolus_vulgaris_bola_roja.json
+++ b/public/cycle-content/phaseolus_vulgaris_bola_roja.json
@@ -62,7 +62,7 @@
     {
       "id": "perez-rodriguez-gomez-2008",
       "title": "perez-rodriguez-gomez-2008",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {

--- a/public/cycle-content/solanum_phureja.json
+++ b/public/cycle-content/solanum_phureja.json
@@ -59,7 +59,7 @@
     {
       "id": "nustez-rodriguez-2024-unal",
       "title": "nustez-rodriguez-2024-unal",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {

--- a/public/cycle-content/solanum_tuberosum_argentina.json
+++ b/public/cycle-content/solanum_tuberosum_argentina.json
@@ -42,13 +42,13 @@
     {
       "id": "perez-rodriguez-gomez-2008",
       "title": "perez-rodriguez-gomez-2008",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {
       "id": "nustez-rodriguez-2024-unal",
       "title": "nustez-rodriguez-2024-unal",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {

--- a/public/cycle-content/solanum_tuberosum_carrera_negra.json
+++ b/public/cycle-content/solanum_tuberosum_carrera_negra.json
@@ -43,13 +43,13 @@
     {
       "id": "perez-rodriguez-gomez-2008",
       "title": "perez-rodriguez-gomez-2008",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {
       "id": "nustez-rodriguez-2024-unal",
       "title": "nustez-rodriguez-2024-unal",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {

--- a/public/cycle-content/solanum_tuberosum_pastusa_suprema.json
+++ b/public/cycle-content/solanum_tuberosum_pastusa_suprema.json
@@ -49,13 +49,13 @@
     {
       "id": "nustez-rodriguez-2024-unal",
       "title": "nustez-rodriguez-2024-unal",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {
       "id": "perez-rodriguez-gomez-2008",
       "title": "perez-rodriguez-gomez-2008",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {

--- a/public/cycle-content/solanum_tuberosum_sabanera.json
+++ b/public/cycle-content/solanum_tuberosum_sabanera.json
@@ -42,13 +42,13 @@
     {
       "id": "perez-rodriguez-gomez-2008",
       "title": "perez-rodriguez-gomez-2008",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {
       "id": "nustez-rodriguez-2024-unal",
       "title": "nustez-rodriguez-2024-unal",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {

--- a/public/cycle-content/ulex_europaeus.json
+++ b/public/cycle-content/ulex_europaeus.json
@@ -44,7 +44,7 @@
     {
       "id": "ocampo-solorza-2017",
       "title": "ocampo-solorza-2017",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {
@@ -62,7 +62,7 @@
     {
       "id": "mongabay-retamo-2024",
       "title": "mongabay-retamo-2024",
-      "tier": "A",
+      "tier": "B",
       "url": "https://es.mongabay.com"
     },
     {

--- a/public/cycle-content/zea_mays_negro_paramo.json
+++ b/public/cycle-content/zea_mays_negro_paramo.json
@@ -61,7 +61,7 @@
     {
       "id": "perez-rodriguez-gomez-2008",
       "title": "perez-rodriguez-gomez-2008",
-      "tier": "B",
+      "tier": "A",
       "url": null
     },
     {


### PR DESCRIPTION
6 upgrades B->A (perez-rodriguez-gomez-2008 Agronomia Colombiana
peer-reviewed, restrepo-1996-bocashi OIT/ILO, park-duponte-2008-lab-ctahr
CTAHR U. Hawaii, mujica-1992-quinua INIAP+FAO, nustez-rodriguez-2024-unal
UNAL press, ocampo-solorza-2017 Biota Colombiana IAvH).
2 downgrades A->B (mongabay-retamo-2024 periodistico, ingham-2000-compost-tea
auto-publicado sin ISBN).
AMB-23 OK, AMB-17 OK.
Validador: 0 errors source-tier, 8 pre-existing AMB-31 no relacionados.
