### PR TITLE
feat(chivito): chivito de páramo vivo (SVG/CSS) — reemplaza al colibrí (home + botón + transición)

### DIFF
--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -7,12 +7,19 @@ import { agentSounds } from '../services/agentSoundService';
 import { fvhSkinClass } from '../config/fvhSkin';
 import { colibriRealActivo } from '../config/colibriFlag';
 import { BarbuditoPosado } from './colibri/Barbudito';
+import { chivitoMockup } from '../config/chivitoFlag';
+import { ChivitoBoton } from './chivito/Chivito';
 import './agent-fab-skin.css';
 
 // ¿Avatar del FAB = colibrí REAL (barbudito posado)? Gateado por VITE_COLIBRI
 // (dev-only). Con la flag OFF (prod) el FAB conserva su avatar actual
 // (ChagraAgentAvatar). Se evalúa una sola vez (flag de build).
 const COLIBRI_REAL = colibriRealActivo();
+
+// ¿El FAB = CHIVITO de páramo (SVG/CSS vivo)? Gateado por VITE_CHIVITO (dev).
+// Tiene precedencia sobre VITE_COLIBRI. En A/B usa Mockup B (más rico).
+const CHIVITO = chivitoMockup();
+const CHIVITO_FAB = CHIVITO === 'ab' ? 'b' : CHIVITO;
 
 /**
  * AgentFab — Floating Action Button para abrir el agente Chagra IA.
@@ -135,7 +142,10 @@ export default function AgentFab({ onNavigate }) {
         transition: 'transform .18s cubic-bezier(.34,1.56,.64,1), box-shadow .25s ease, background .25s ease, border-color .25s ease',
       }}
     >
-      {COLIBRI_REAL ? (
+      {CHIVITO_FAB ? (
+        // CHIVITO de páramo (SVG/CSS vivo) como avatar del FAB.
+        <ChivitoBoton mockup={CHIVITO_FAB} size={42} state={state} ariaLabel="Chagra IA" />
+      ) : COLIBRI_REAL ? (
         // Colibrí REAL (barbudito POSADO recortado), con un leve flotar. El
         // botón ya es circular y recorta (overflow:hidden).
         <BarbuditoPosado size={46} ariaLabel="Chagra IA" />

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -111,6 +111,8 @@ import ActionConfirmModal from '../ActionConfirmModal';
 import FeedbackConsentModal from '../FeedbackConsentModal';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import ChagraAgentAvatarColibriPhoto from '../ChagraAgentAvatarColibriPhoto';
+import { chivitoMockup } from '../../config/chivitoFlag';
+import { ChivitoBoton } from '../chivito/Chivito';
 import { AgentManoOverlay } from '../agent/AgentShell';
 import { mapCapabilityPick } from '../agent/capabilityRouting';
 import { agentSounds } from '../../services/agentSoundService';
@@ -156,6 +158,12 @@ import { createAgentRequestSender } from '../../services/agentRequestSender';
 const STATE_IDLE = 'idle';
 const STATE_RECORDING = 'recording';
 const STATE_THINKING = 'thinking';
+
+// ¿El botón de enviar/hablar del compositor ES el CHIVITO de páramo? Gateado por
+// VITE_CHIVITO (dev-only). En A/B el botón usa Mockup B (más rico); con 'a'/'b'
+// el elegido. Con la flag OFF, el botón conserva ChagraAgentAvatar de siempre.
+const CHIVITO = chivitoMockup();
+const CHIVITO_BTN = CHIVITO === 'ab' ? 'b' : CHIVITO;
 
 export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // B1: clase de animación de entrada, resuelta UNA vez al montar (no en cada
@@ -3509,11 +3517,21 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                     : '0 0 18px rgba(16,185,129,0.5)',
               }}
             >
-              <ChagraAgentAvatar
-                size={38}
-                state={state === STATE_THINKING ? 'thinking' : 'idle'}
-                ariaLabel="Enviar al agente"
-              />
+              {CHIVITO_BTN ? (
+                // El CHIVITO de páramo ES el botón de enviar (SVG/CSS vivo).
+                <ChivitoBoton
+                  mockup={CHIVITO_BTN}
+                  size={34}
+                  state={state === STATE_THINKING ? 'thinking' : 'idle'}
+                  ariaLabel="Enviar al agente"
+                />
+              ) : (
+                <ChagraAgentAvatar
+                  size={38}
+                  state={state === STATE_THINKING ? 'thinking' : 'idle'}
+                  ariaLabel="Enviar al agente"
+                />
+              )}
             </button>
           </div>
         </div>

--- a/src/components/agent/ColibriTransition.jsx
+++ b/src/components/agent/ColibriTransition.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { colibriRealActivo } from '../../config/colibriFlag';
 import { BarbuditoFlor } from '../colibri/Barbudito';
+import { chivitoMockup } from '../../config/chivitoFlag';
+import { ChivitoCruza } from '../chivito/Chivito';
 
 /**
  * ColibriTransition — transición HIPER LINDA pero LIMPIA del home a la
@@ -40,10 +42,18 @@ export const COLIBRI_TRANSITION_REDUCED_MS = 360;
 // Clip de la FLOR (flag ON): el mp4 dura ~2.5s con su propio fade in/out.
 // Lo dejamos correr casi entero (2.4s) y luego el overlay hace su fade-out.
 export const COLIBRI_TRANSITION_FLOR_HOLD_MS = 2400;
+// Cruce del CHIVITO (VITE_CHIVITO): el ave cruza en ~1.5s; lo dejamos completar
+// y luego el overlay hace su fade-out.
+export const CHIVITO_TRANSITION_HOLD_MS = 1500;
 
 // ¿Transición con el clip de la FLOR del frailejón (barbudito libando néctar)?
 // Gateado por VITE_COLIBRI (dev-only). Se evalúa una sola vez (flag de build).
 const COLIBRI_REAL = colibriRealActivo();
+
+// ¿Transición con el CHIVITO de páramo cruzando aleteando (SVG/CSS vivo)?
+// Gateado por VITE_CHIVITO (dev-only). Tiene precedencia sobre VITE_COLIBRI.
+// 'ab' = cruzan los dos mockups en paralelo (A arriba, B abajo) para comparar.
+const CHIVITO = chivitoMockup();
 
 function prefersReducedMotion() {
   return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
@@ -122,6 +132,10 @@ function ColibriOverlay({ onDone }) {
       // Fade simple y corto, sin video ni cruce.
       timers.push(setTimeout(() => setLeaving(true), 40));
       timers.push(setTimeout(() => doneRef.current?.(), COLIBRI_TRANSITION_REDUCED_MS + 60));
+    } else if (CHIVITO) {
+      // El chivito cruza aleteando (~1.5s) y luego el overlay se desvanece.
+      timers.push(setTimeout(() => setLeaving(true), CHIVITO_TRANSITION_HOLD_MS));
+      timers.push(setTimeout(() => doneRef.current?.(), CHIVITO_TRANSITION_HOLD_MS + COLIBRI_TRANSITION_FADE_MS));
     } else if (COLIBRI_REAL) {
       // Clip de la flor: lo dejamos correr casi entero (~2.4s) y luego el fade.
       timers.push(setTimeout(() => setLeaving(true), COLIBRI_TRANSITION_FLOR_HOLD_MS));
@@ -143,7 +157,18 @@ function ColibriOverlay({ onDone }) {
       data-testid="colibri-transition"
     >
       <style>{CSS}</style>
-      {COLIBRI_REAL && !reduce ? (
+      {CHIVITO ? (
+        // El CHIVITO de páramo cruza aleteando (SVG/CSS vivo, universal). En A/B
+        // cruzan los dos mockups (A arriba, B abajo) para compararlos.
+        CHIVITO === 'ab' ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6vh', alignItems: 'center' }}>
+            <ChivitoCruza mockup="a" size={150} />
+            <ChivitoCruza mockup="b" size={150} />
+          </div>
+        ) : (
+          <ChivitoCruza mockup={CHIVITO} size={190} />
+        )
+      ) : COLIBRI_REAL && !reduce ? (
         // Clip de la FLOR del frailejón: el barbudito tomando néctar, grande y
         // centrado, con fade suave. H.264 sin alpha → universal (incl. iOS).
         <span className="colibri-tx-flor-wrap">

--- a/src/components/chivito/Chivito.jsx
+++ b/src/components/chivito/Chivito.jsx
@@ -1,0 +1,415 @@
+import { useId, useState } from 'react';
+import './chivito.css';
+
+/**
+ * Chivito — el CHIVITO DE PÁRAMO (Oxypogon guerinii, "barbudito paramuno")
+ * dibujado 100% en SVG/CSS. Cero assets, cero red, offline-first, gama baja.
+ * Reemplazo del colibrí en las tres piezas del ave insignia.
+ *
+ * Fiel a la foto real del ave:
+ *   - Cresta erguida, puntiaguda, blanco-crema con base oscura.
+ *   - Cara: capucha marrón oscuro + máscara negra + raya de mejilla clara.
+ *   - BARBA ICÓNICA: larga y puntiaguda, iridiscente VERDE arriba → VIOLETA/
+ *     PÚRPURA en la punta (lo que hace único al chivito).
+ *   - Cuerpo compacto oliva-marrón, vientre pálido, cola larga oscura con
+ *     puntas claras, pico corto y recto negro.
+ *
+ * Dos mockups (dos niveles de detalle) para decidir en chagra-dev:
+ *   - mockup="a" → simple / estilizado (vectorial limpio, plano).
+ *   - mockup="b" → detallado / rico (gradientes, iridiscencia animada,
+ *     plumas, sombras).
+ *
+ * Piezas exportadas:
+ *   - ChivitoAve       → sólo el ave (perfil, mirando a la derecha).
+ *   - ChivitoEscena    → el ave libando la flor amarilla del frailejón (HOME).
+ *   - ChivitoBoton     → el ave como icono del botón enviar/hablar del agente.
+ *   - ChivitoCruza     → el ave cruzando aleteando (TRANSICIÓN home→agente).
+ *
+ * Español colombiano (usted), NUNCA voseo argentino.
+ */
+
+function prefersReducedMotion() {
+  return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : false;
+}
+
+// ID único y estable para los <defs> del SVG (varios chivitos coexisten en el
+// A/B, así que cada uno necesita ids de gradiente propios). `useId` es puro
+// (no hay side-effects en render); se limpian los ':' para que sirvan como
+// fragmento en `fill="url(#...)"`.
+function useUid(prefix) {
+  return `${prefix}-${useId().replace(/:/g, '')}`;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+ *  MOCKUP A — el chivito SIMPLE / ESTILIZADO (vectorial limpio, colores planos)
+ *  Al estilo ilustrado de la escena Finca Viva. Perfil mirando a la derecha.
+ * ════════════════════════════════════════════════════════════════════════ */
+function ChivitoSVG_A() {
+  return (
+    <svg viewBox="0 0 140 132" className="chiv-svg" aria-hidden="true">
+      {/* COLA larga y oscura, barrida hacia abajo-atrás, con puntas claras */}
+      <g>
+        <path d="M50 74 L10 108 L18 110 L14 118 L26 112 L26 120 L40 104 L58 84 Z" fill="#4a3a24" />
+        {/* dos puntas blancas (rectrices externas del chivito) */}
+        <path d="M10 108 L18 110 L15 115 Z" fill="#efe7d4" />
+        <path d="M22 116 L26 112 L26 120 Z" fill="#efe7d4" />
+      </g>
+
+      {/* ALA trasera (batiendo por detrás) */}
+      <g className="chiv-ala-tras">
+        <path d="M74 56 Q48 40 30 54 Q50 70 76 62 Z" fill="#6b5230" opacity="0.85" />
+      </g>
+
+      {/* CUERPO compacto oliva-marrón */}
+      <ellipse cx="66" cy="70" rx="27" ry="20" fill="#8a7346" transform="rotate(-12 66 70)" />
+      {/* vientre pálido */}
+      <path d="M46 78 Q60 96 86 84 Q74 74 54 72 Z" fill="#d9cdaf" opacity="0.9" />
+
+      {/* CABEZA */}
+      <circle cx="98" cy="46" r="16" fill="#7a5c38" />
+      {/* capucha marrón oscuro sobre la coronilla */}
+      <path d="M86 42 Q98 26 112 42 Q104 34 98 33 Q92 34 86 42 Z" fill="#4d3820" />
+      {/* máscara negra alrededor del ojo */}
+      <path d="M92 40 Q100 36 110 44 Q104 50 94 49 Z" fill="#241a10" />
+      {/* raya de mejilla clara */}
+      <path d="M90 52 Q100 56 112 52 Q102 60 90 57 Z" fill="#efe7d4" opacity="0.92" />
+
+      {/* CRESTA erguida, puntiaguda, blanco-crema con base oscura */}
+      <g className="chiv-cresta">
+        {/* base oscura */}
+        <path d="M90 34 Q96 30 104 34 L102 40 L92 40 Z" fill="#3a2a18" />
+        {/* plumas crema puntiagudas */}
+        <path d="M92 36 Q90 22 89 12 Q95 22 96 36 Z" fill="#f2ead6" stroke="#b9a878" strokeWidth="0.6" />
+        <path d="M97 36 Q97 20 98 9 Q101 20 101 36 Z" fill="#f6efdd" stroke="#b9a878" strokeWidth="0.6" />
+        <path d="M101 36 Q104 22 108 14 Q107 24 105 37 Z" fill="#f2ead6" stroke="#b9a878" strokeWidth="0.6" />
+      </g>
+
+      {/* PICO corto y recto negro */}
+      <path d="M112 48 L130 50" fill="none" stroke="#1c130a" strokeWidth="2.6" strokeLinecap="round" />
+
+      {/* OJO */}
+      <circle cx="101" cy="45" r="2.4" fill="#100a05" />
+      <circle cx="100.2" cy="44.2" r="0.8" fill="#fff" opacity="0.9" />
+
+      {/* BARBA ICÓNICA — larga, puntiaguda, verde arriba → violeta en la punta.
+          En Mockup A: dos bloques planos que forman UNA sola barba en punta
+          (verde el tramo alto, violeta la punta), para leerla clara y grande. */}
+      <g>
+        <path d="M95 53 L105 55 L103 71 L98 71 Z" fill="#1f9e63" />
+        <path d="M98 71 L103 71 L100.5 86 Z" fill="#7c3aed" />
+        {/* filito de brillo verde-claro en el borde superior */}
+        <path d="M96 54 L104 55.6 L103.4 58 L96.4 56.5 Z" fill="#3fd68a" opacity="0.8" />
+      </g>
+
+      {/* ALA frontal (batiendo sobre el cuerpo) */}
+      <g className="chiv-ala-fron">
+        <path d="M78 52 Q50 34 28 50 Q52 68 82 60 Z" fill="#5f4a2e" />
+      </g>
+
+      {/* patas mínimas insinuadas */}
+      <path d="M66 89 L64 98 M74 88 L74 97" stroke="#2a1d12" strokeWidth="1.6" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+ *  MOCKUP B — el chivito DETALLADO / RICO (gradientes, iridiscencia animada,
+ *  plumas, sombras). Perfil mirando a la derecha.
+ * ════════════════════════════════════════════════════════════════════════ */
+function ChivitoSVG_B({ id }) {
+  const g = (s) => `${id}-${s}`;
+  return (
+    <svg viewBox="0 0 140 132" className="chiv-svg" aria-hidden="true">
+      <defs>
+        {/* plumaje del cuerpo: oliva cálido → marrón */}
+        <linearGradient id={g('cuerpo')} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#9c8452" />
+          <stop offset="52%" stopColor="#7c6238" />
+          <stop offset="100%" stopColor="#5c4526" />
+        </linearGradient>
+        <linearGradient id={g('vientre')} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#e6dcc2" />
+          <stop offset="100%" stopColor="#c3b590" />
+        </linearGradient>
+        <linearGradient id={g('ala')} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#6f5533" />
+          <stop offset="100%" stopColor="#3f2d18" />
+        </linearGradient>
+        <linearGradient id={g('cola')} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#5a4529" />
+          <stop offset="100%" stopColor="#2f2213" />
+        </linearGradient>
+        <linearGradient id={g('capucha')} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#5a4023" />
+          <stop offset="100%" stopColor="#33240f" />
+        </linearGradient>
+        <linearGradient id={g('cresta')} x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0" stopColor="#c7b485" />
+          <stop offset="45%" stopColor="#f2ead6" />
+          <stop offset="100%" stopColor="#fffdf6" />
+        </linearGradient>
+        {/* BARBA iridiscente: verde esmeralda → violeta/púrpura en la punta */}
+        <linearGradient id={g('barba')} x1="0" y1="0" x2="0.25" y2="1">
+          <stop offset="0" stopColor="#2fe08a" />
+          <stop offset="34%" stopColor="#12b866" />
+          <stop offset="62%" stopColor="#2a8fbf" />
+          <stop offset="82%" stopColor="#7c3aed" />
+          <stop offset="100%" stopColor="#a855f7" />
+        </linearGradient>
+        <linearGradient id={g('barba-brillo')} x1="0" y1="0" x2="0.3" y2="1">
+          <stop offset="0" stopColor="#a7ffd6" />
+          <stop offset="100%" stopColor="#e9c9ff" />
+        </linearGradient>
+        <radialGradient id={g('ojo')} cx="42%" cy="38%" r="60%">
+          <stop offset="0" stopColor="#4a3a2a" />
+          <stop offset="100%" stopColor="#0c0703" />
+        </radialGradient>
+      </defs>
+
+      {/* COLA larga con gradiente + puntas blancas (rectrices externas) */}
+      <g>
+        <path d="M50 74 L8 110 L18 112 L13 121 L28 113 L28 122 L44 104 L60 84 Z" fill={`url(#${g('cola')})`} />
+        <path d="M8 110 L18 112 L14 118 Z" fill="#f3ecda" />
+        <path d="M24 118 L28 113 L28 122 Z" fill="#f3ecda" />
+        {/* nervaduras de las rectrices */}
+        <g stroke="#241a0f" strokeWidth="0.5" opacity="0.4" fill="none">
+          <path d="M52 78 L20 106" /><path d="M56 82 L30 108" />
+        </g>
+      </g>
+
+      {/* ALA trasera batiendo */}
+      <g className="chiv-ala-tras">
+        <path d="M74 55 Q46 37 26 52 Q48 70 78 62 Z" fill={`url(#${g('ala')})`} opacity="0.9" />
+      </g>
+
+      {/* CUERPO con gradiente + moteado de plumas */}
+      <ellipse cx="66" cy="70" rx="28" ry="21" fill={`url(#${g('cuerpo')})`} transform="rotate(-12 66 70)" />
+      {/* vientre pálido afelpado */}
+      <path d="M44 80 Q60 100 90 84 Q76 72 52 72 Z" fill={`url(#${g('vientre')})`} opacity="0.95" />
+      {/* moteado del pecho (pintitas claras y oscuras) */}
+      <g className="chiv-moteado">
+        <g fill="#efe4c8" opacity="0.6">
+          <circle cx="58" cy="74" r="1.4" /><circle cx="66" cy="78" r="1.2" />
+          <circle cx="74" cy="74" r="1.3" /><circle cx="62" cy="70" r="1.1" />
+          <circle cx="70" cy="82" r="1.1" /><circle cx="54" cy="70" r="1.0" />
+        </g>
+        <g fill="#4a3820" opacity="0.4">
+          <circle cx="61" cy="76" r="0.8" /><circle cx="69" cy="76" r="0.8" />
+          <circle cx="65" cy="82" r="0.7" /><circle cx="73" cy="80" r="0.7" />
+        </g>
+      </g>
+
+      {/* CABEZA */}
+      <circle cx="98" cy="46" r="16.5" fill={`url(#${g('cuerpo')})`} />
+      {/* capucha marrón oscuro */}
+      <path d="M84 44 Q98 24 113 43 Q106 31 98 30 Q90 31 84 44 Z" fill={`url(#${g('capucha')})`} />
+      {/* máscara negra alrededor del ojo */}
+      <path d="M91 39 Q101 34 111 44 Q104 51 93 50 Q90 44 91 39 Z" fill="#1a120a" />
+      {/* raya de mejilla clara, difusa */}
+      <path d="M89 53 Q101 58 113 52 Q102 62 89 58 Z" fill="#f1e9d6" opacity="0.95" />
+      {/* pómulo con leve rubor cálido */}
+      <ellipse cx="93" cy="53" rx="4" ry="2.4" fill="#d9b98c" opacity="0.5" />
+
+      {/* CRESTA fina, puntiaguda, crema con base oscura (varias plumas) */}
+      <g className="chiv-cresta">
+        <path d="M88 33 Q98 27 108 33 L106 41 L90 41 Z" fill="#33240f" />
+        <path d="M90 37 Q87 21 86 9 Q92 21 94 37 Z" fill={`url(#${g('cresta')})`} stroke="#a08a5c" strokeWidth="0.5" />
+        <path d="M95 37 Q95 18 96 6 Q100 18 100 37 Z" fill={`url(#${g('cresta')})`} stroke="#a08a5c" strokeWidth="0.5" />
+        <path d="M100 37 Q102 20 106 10 Q106 22 105 38 Z" fill={`url(#${g('cresta')})`} stroke="#a08a5c" strokeWidth="0.5" />
+        <path d="M104 38 Q108 24 113 17 Q112 27 108 39 Z" fill={`url(#${g('cresta')})`} stroke="#a08a5c" strokeWidth="0.5" />
+      </g>
+
+      {/* PICO corto y recto negro, con brillo */}
+      <path d="M113 48 L131 50" fill="none" stroke="#160e06" strokeWidth="2.8" strokeLinecap="round" />
+      <path d="M115 47 L128 49" fill="none" stroke="#5a4a38" strokeWidth="0.7" strokeLinecap="round" opacity="0.6" />
+
+      {/* OJO con catchlight */}
+      <circle cx="101" cy="45" r="2.7" fill={`url(#${g('ojo')})`} />
+      <circle cx="100" cy="44" r="0.9" fill="#fff" opacity="0.95" />
+
+      {/* BARBA ICÓNICA iridiscente verde→violeta, larga y puntiaguda, con
+          barbas finas y una franja de brillo animada (destello metálico). */}
+      <g>
+        <path d="M95 54 Q101 56 105 55 L101 84 Q98 88 96 82 Z" fill={`url(#${g('barba')})`} />
+        {/* barbas finas de la barba */}
+        <g stroke="#0d5a3a" strokeWidth="0.4" opacity="0.5" fill="none">
+          <path d="M98 58 L100 60" /><path d="M99 64 L101 66" /><path d="M99 70 L100 72" />
+        </g>
+        {/* brillo iridiscente que desciende (animado) */}
+        <path className="chiv-barba-brillo" d="M97 56 Q100 57 102 56 L100 80 Q98 82 97 79 Z"
+              fill={`url(#${g('barba-brillo')})`} opacity="0" />
+      </g>
+
+      {/* ALA frontal batiendo, con primarias marcadas */}
+      <g className="chiv-ala-fron">
+        <path d="M78 52 Q48 32 24 50 Q50 70 84 60 Z" fill={`url(#${g('ala')})`} />
+        <g stroke="#2c1e10" strokeWidth="0.6" opacity="0.5" fill="none">
+          <path d="M72 52 Q52 44 30 46" /><path d="M70 56 Q50 50 30 51" /><path d="M68 59 Q50 56 32 56" />
+        </g>
+      </g>
+
+      {/* patas */}
+      <path d="M66 90 L63 99 M75 89 L75 98" stroke="#221708" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/**
+ * ChivitoAve — sólo el ave. `mockup` = 'a' | 'b'. `flap` activa el aleteo/vida
+ * (respeta reduced-motion vía CSS). `size` = ancho en px.
+ */
+export function ChivitoAve({ mockup = 'b', size = 120, flap = true, className = '', ariaLabel }) {
+  const id = useUid('chiv');
+  const isB = mockup === 'b';
+  return (
+    <span
+      className={`chivito ${isB ? 'chiv-b' : 'chiv-a'} ${flap ? 'is-flap' : ''} ${className}`.trim()}
+      style={{ width: size }}
+      role={ariaLabel ? 'img' : undefined}
+      aria-label={ariaLabel || undefined}
+      aria-hidden={ariaLabel ? undefined : 'true'}
+    >
+      {isB ? <ChivitoSVG_B id={id} /> : <ChivitoSVG_A />}
+    </span>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+ *  FRAILEJÓN — roseta plateada afelpada (Espeletia) + racimo de flores
+ *  amarillas. La simbiosis real del páramo: el chivito liba esta flor.
+ * ════════════════════════════════════════════════════════════════════════ */
+function FrailejonSVG({ mockup, id }) {
+  const isB = mockup === 'b';
+  const g = (s) => `${id}-${s}`;
+  return (
+    <svg viewBox="0 0 150 150" className="chiv-frailejon-svg" aria-hidden="true" width="100%">
+      {isB && (
+        <defs>
+          <linearGradient id={g('hoja')} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#c8d2b4" />
+            <stop offset="100%" stopColor="#8ea07a" />
+          </linearGradient>
+          <radialGradient id={g('flor')} cx="42%" cy="38%" r="62%">
+            <stop offset="0" stopColor="#ffe17a" />
+            <stop offset="70%" stopColor="#f4c430" />
+            <stop offset="100%" stopColor="#d59f18" />
+          </radialGradient>
+        </defs>
+      )}
+
+      {/* ROSETA de hojas plateadas afelpadas, radiando desde el centro-abajo */}
+      <g>
+        {[
+          { r: -52, s: 1.0 }, { r: -34, s: 1.08 }, { r: -16, s: 1.12 },
+          { r: 0, s: 1.14 }, { r: 16, s: 1.12 }, { r: 34, s: 1.08 }, { r: 52, s: 1.0 },
+        ].map((leaf, i) => (
+          <g key={i} transform={`translate(75 128) rotate(${leaf.r}) scale(${leaf.s})`}>
+            <path
+              d="M0 0 Q-11 -46 0 -92 Q11 -46 0 0 Z"
+              fill={isB ? `url(#${g('hoja')})` : '#a9b790'}
+              stroke={isB ? '#7d8e68' : '#8ea077'}
+              strokeWidth="1"
+            />
+            {isB && (
+              <>
+                {/* nervadura central */}
+                <path d="M0 -4 L0 -86" stroke="#7d8e68" strokeWidth="0.8" opacity="0.6" fill="none" />
+                {/* pelusa afelpada (líneas finas) */}
+                <g stroke="#e4ecd6" strokeWidth="0.5" opacity="0.55" fill="none">
+                  <path d="M0 -20 L-5 -30" /><path d="M0 -40 L-5 -50" /><path d="M0 -60 L-5 -68" />
+                  <path d="M0 -30 L5 -40" /><path d="M0 -50 L5 -58" />
+                </g>
+              </>
+            )}
+          </g>
+        ))}
+      </g>
+
+      {/* tallo floral que se alza de la roseta */}
+      <path d="M75 60 Q78 40 88 30" fill="none" stroke={isB ? '#8a9a6f' : '#93a377'} strokeWidth="3" strokeLinecap="round" />
+
+      {/* RACIMO de flores amarillas del frailejón (varios capítulos) */}
+      <g>
+        {(isB
+          ? [[88, 28, 11], [74, 34, 9], [100, 36, 8.5], [86, 44, 7.5], [96, 24, 7]]
+          : [[88, 28, 10], [74, 34, 8], [100, 36, 8], [88, 44, 7]]
+        ).map(([cx, cy, r], i) => (
+          <g key={i}>
+            {/* pétalos radiales (rayos del capítulo) */}
+            {isB && Array.from({ length: 12 }).map((_, k) => {
+              const a = (k / 12) * Math.PI * 2;
+              return (
+                <line
+                  key={k}
+                  x1={cx} y1={cy}
+                  x2={cx + Math.cos(a) * (r + 3)} y2={cy + Math.sin(a) * (r + 3)}
+                  stroke="#f4c430" strokeWidth="1.6" strokeLinecap="round"
+                />
+              );
+            })}
+            <circle cx={cx} cy={cy} r={r} fill={isB ? `url(#${g('flor')})` : '#f4c430'} />
+            {/* disco central */}
+            <circle cx={cx} cy={cy} r={r * 0.5} fill={isB ? '#c98f14' : '#d59f18'} opacity="0.9" />
+          </g>
+        ))}
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * ChivitoEscena — HERO del home: el chivito tomando néctar de la flor amarilla
+ * del frailejón (roseta plateada + flores amarillas). La simbiosis real del
+ * páramo. Animado sutil (el ave se acerca/retira de la flor, aletea), respeta
+ * prefers-reduced-motion. `mockup` = 'a' | 'b'.
+ */
+export function ChivitoEscena({ mockup = 'b', size = 200, ariaLabel = 'Chivito de páramo tomando néctar de la flor del frailejón' }) {
+  const id = useUid('chiv-esc');
+  return (
+    <span
+      className="chiv-escena"
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={ariaLabel}
+    >
+      <span className="chiv-frailejon-wrap" style={{ width: size, height: size, display: 'block' }}>
+        <FrailejonSVG mockup={mockup} id={id} />
+      </span>
+      <span className="chiv-ave-wrap">
+        <ChivitoAve mockup={mockup} size={size * 0.62} flap ariaLabel={undefined} />
+      </span>
+    </span>
+  );
+}
+
+/**
+ * ChivitoBoton — el chivito ES el icono del botón enviar/hablar del agente.
+ * Encuadre compacto (cabeza + barba + cuerpo) centrado en el botón circular.
+ * `state` 'thinking'|'speaking' inclina al ave como para libar. `mockup`='a'|'b'.
+ */
+export function ChivitoBoton({ mockup = 'b', size = 38, state = 'idle', ariaLabel = 'Enviar al agente' }) {
+  const active = state === 'thinking' || state === 'speaking';
+  return (
+    <span className={`chiv-boton ${active ? 'is-active' : ''}`} role="img" aria-label={ariaLabel}>
+      <ChivitoAve mockup={mockup} size={size} flap ariaLabel={undefined} />
+    </span>
+  );
+}
+
+/**
+ * ChivitoCruza — TRANSICIÓN home→agente: el chivito cruza aleteando en arco,
+ * UNA pasada. Respeta reduced-motion (sin cruce; el padre acorta la transición).
+ * `mockup` = 'a' | 'b'.
+ */
+export function ChivitoCruza({ mockup = 'b', size = 170, className = '' }) {
+  const [reduce] = useState(() => prefersReducedMotion());
+  return (
+    <span className={`chiv-cruza ${className}`.trim()} style={{ width: size }} aria-hidden="true">
+      <ChivitoAve mockup={mockup} size={size} flap={!reduce} ariaLabel={undefined} />
+    </span>
+  );
+}
+
+export default ChivitoAve;

--- a/src/components/chivito/__tests__/Chivito.smoke.test.jsx
+++ b/src/components/chivito/__tests__/Chivito.smoke.test.jsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ChivitoAve, ChivitoEscena, ChivitoBoton, ChivitoCruza } from '../Chivito';
+import { chivitoMockup } from '../../../config/chivitoFlag';
+
+describe('chivitoFlag', () => {
+  const orig = import.meta.env.VITE_CHIVITO;
+  beforeEach(() => { import.meta.env.VITE_CHIVITO = orig; });
+
+  it('null cuando la flag está apagada o con valor no reconocido', () => {
+    import.meta.env.VITE_CHIVITO = undefined;
+    expect(chivitoMockup()).toBeNull();
+    import.meta.env.VITE_CHIVITO = 'nope';
+    expect(chivitoMockup()).toBeNull();
+  });
+
+  it('mapea a/b/ab y true/1 → ab', () => {
+    import.meta.env.VITE_CHIVITO = 'a';
+    expect(chivitoMockup()).toBe('a');
+    import.meta.env.VITE_CHIVITO = 'B';
+    expect(chivitoMockup()).toBe('b');
+    import.meta.env.VITE_CHIVITO = ' AB ';
+    expect(chivitoMockup()).toBe('ab');
+    import.meta.env.VITE_CHIVITO = '1';
+    expect(chivitoMockup()).toBe('ab');
+    import.meta.env.VITE_CHIVITO = 'true';
+    expect(chivitoMockup()).toBe('ab');
+  });
+});
+
+describe('Chivito piezas SVG', () => {
+  it('ChivitoAve dibuja SVG en ambos mockups (cero assets/red)', () => {
+    const { container: a } = render(<ChivitoAve mockup="a" size={100} />);
+    const { container: b } = render(<ChivitoAve mockup="b" size={100} />);
+    expect(a.querySelector('svg')).toBeTruthy();
+    expect(b.querySelector('svg')).toBeTruthy();
+    // sin <img> ni <video> — es puro vectorial, offline-first.
+    expect(a.querySelector('img,video')).toBeNull();
+    expect(b.querySelector('img,video')).toBeNull();
+  });
+
+  it('ChivitoAve B tiene la barba iridiscente (verde→violeta) y el brillo animado', () => {
+    const { container } = render(<ChivitoAve mockup="b" size={120} />);
+    expect(container.querySelector('.chiv-b')).toBeTruthy();
+    expect(container.querySelector('.chiv-barba-brillo')).toBeTruthy();
+    // gradiente de la barba declarado en <defs>
+    const grads = [...container.querySelectorAll('linearGradient')].map((g) => g.id);
+    expect(grads.some((id) => id.includes('barba'))).toBe(true);
+  });
+
+  it('ChivitoEscena expone el ave y la flor del frailejón con aria-label', () => {
+    const { container } = render(<ChivitoEscena mockup="b" size={180} />);
+    expect(container.querySelector('.chiv-escena')).toBeTruthy();
+    expect(container.querySelector('.chiv-frailejon-svg')).toBeTruthy();
+    expect(container.querySelector('.chiv-ave-wrap')).toBeTruthy();
+    expect(container.querySelector('[aria-label*="frailejón"]')).toBeTruthy();
+  });
+
+  it('ChivitoBoton marca is-active en thinking/speaking y expone aria-label', () => {
+    const { container, rerender } = render(<ChivitoBoton mockup="a" state="idle" ariaLabel="Enviar al agente" />);
+    expect(container.querySelector('.chiv-boton.is-active')).toBeNull();
+    expect(container.querySelector('[aria-label="Enviar al agente"]')).toBeTruthy();
+    rerender(<ChivitoBoton mockup="a" state="thinking" ariaLabel="Enviar al agente" />);
+    expect(container.querySelector('.chiv-boton.is-active')).toBeTruthy();
+  });
+
+  it('ChivitoCruza sin animación cuando prefers-reduced-motion', () => {
+    const spy = vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: true });
+    const { container } = render(<ChivitoCruza mockup="b" />);
+    // el ave no lleva la clase de aleteo cuando se reduce el movimiento
+    expect(container.querySelector('.chivito.is-flap')).toBeNull();
+    spy.mockRestore();
+  });
+});

--- a/src/components/chivito/chivito.css
+++ b/src/components/chivito/chivito.css
@@ -1,0 +1,148 @@
+/*
+ * chivito.css — el CHIVITO DE PÁRAMO vivo (Oxypogon guerinii, "barbudito
+ * paramuno") dibujado 100% en SVG/CSS. Cero assets, cero red, offline-first,
+ * gama baja. Reemplaza al colibrí del A/B en las tres piezas del ave insignia
+ * (home, botón del agente, transición).
+ *
+ * Dos mockups, dos niveles de detalle:
+ *   - Mockup A (`.chiv-a`) → simple / estilizado, colores planos.
+ *   - Mockup B (`.chiv-b`) → detallado / rico, gradientes, barba iridiscente
+ *     verde→violeta con brillo animado, plumas, sombras.
+ *
+ * Todo el movimiento se apaga con prefers-reduced-motion (gama baja + a11y).
+ * Español colombiano (usted), NUNCA voseo.
+ */
+
+/* ── contenedor del ave ──────────────────────────────────────────────────── */
+.chivito {
+  display: inline-block;
+  line-height: 0;
+}
+.chivito svg { display: block; overflow: visible; }
+
+/* aleteo de las alas — rápido, en contrafase, como un colibrí de altura */
+.chivito .chiv-ala-fron { transform-box: fill-box; transform-origin: 78% 30%; }
+.chivito .chiv-ala-tras { transform-box: fill-box; transform-origin: 82% 26%; }
+.chivito.is-flap .chiv-ala-fron { animation: chiv-flap 0.16s ease-in-out infinite; }
+.chivito.is-flap .chiv-ala-tras { animation: chiv-flap-back 0.16s ease-in-out infinite; }
+@keyframes chiv-flap {
+  0%, 100% { transform: rotate(-16deg) scaleY(0.94); }
+  50%      { transform: rotate(20deg) scaleY(1); }
+}
+@keyframes chiv-flap-back {
+  0%, 100% { transform: rotate(14deg); }
+  50%      { transform: rotate(-18deg); }
+}
+
+/* cresta puntiaguda — leve tremor de las plumas, muy sutil */
+.chivito .chiv-cresta { transform-box: fill-box; transform-origin: 50% 100%; }
+.chivito.is-flap .chiv-cresta { animation: chiv-cresta 2.4s ease-in-out infinite; }
+@keyframes chiv-cresta {
+  0%, 100% { transform: rotate(0deg); }
+  50%      { transform: rotate(-3deg); }
+}
+
+/* barba iridiscente (Mockup B) — franja de brillo que baja por la barba
+   pasando de verde a violeta, dando el destello metálico del gorget real */
+.chivito .chiv-barba-brillo { opacity: 0; }
+.chivito.is-flap.chiv-b .chiv-barba-brillo { animation: chiv-barba-brillo 2.8s ease-in-out infinite; }
+@keyframes chiv-barba-brillo {
+  0%, 100% { opacity: 0; transform: translateY(-3px); }
+  45%      { opacity: 0.85; }
+  55%      { opacity: 0.85; }
+  100%     { opacity: 0; transform: translateY(4px); }
+}
+
+/* ── ESCENA DEL HOME — el chivito libando la flor del frailejón ───────────── */
+.chiv-escena {
+  position: relative;
+  display: inline-block;
+  line-height: 0;
+}
+.chiv-escena .chiv-ave-wrap {
+  position: absolute;
+  left: 2%;
+  top: 4%;
+  width: 62%;
+  z-index: 3;
+  /* vuelo estacionario: el ave se acerca y retira de la flor (sip) */
+  animation: chiv-sip 5.6s ease-in-out infinite;
+}
+@keyframes chiv-sip {
+  0%   { transform: translate(0, 0) rotate(-1deg); }
+  35%  { transform: translate(10px, -5px) rotate(1.5deg); }
+  60%  { transform: translate(6px, -2px) rotate(0.5deg); }
+  100% { transform: translate(0, 0) rotate(-1deg); }
+}
+/* el frailejón (roseta plateada + flores amarillas) al fondo-derecha */
+.chiv-escena .chiv-frailejon-wrap {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── BOTÓN — el chivito ES el icono del botón enviar/hablar ───────────────── */
+.chiv-boton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+.chiv-boton .chivito { filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35)); }
+/* estado "thinking/speaking" del botón: el ave se inclina como para libar */
+.chiv-boton.is-active .chivito { animation: chiv-boton-lean 0.9s ease-in-out infinite; }
+@keyframes chiv-boton-lean {
+  0%, 100% { transform: translateX(0) rotate(0deg); }
+  50%      { transform: translateX(1.5px) rotate(3deg); }
+}
+
+/* ── TRANSICIÓN — el chivito cruza aleteando ─────────────────────────────── */
+.chiv-cruza {
+  display: inline-block;
+  will-change: transform, opacity;
+  animation: chiv-cruzar 1.5s cubic-bezier(0.22, 0.61, 0.36, 1) 1 both;
+}
+@keyframes chiv-cruzar {
+  0%   { transform: translate3d(-34vw, 12vh, 0) scale(0.72) rotate(-6deg); opacity: 0; }
+  16%  { opacity: 1; }
+  52%  { transform: translate3d(0, -5vh, 0) scale(1.06) rotate(2deg); opacity: 1; }
+  86%  { opacity: 1; }
+  100% { transform: translate3d(34vw, 3vh, 0) scale(0.78) rotate(-3deg); opacity: 0; }
+}
+
+/* ── A/B del chivito en el home (flag VITE_CHIVITO=ab) ────────────────────── */
+.chiv-ab {
+  animation: none !important;
+  z-index: 8;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+.chiv-ab-tag {
+  font: 600 9px/1 var(--fvh-body, system-ui, sans-serif);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fff;
+  background: rgba(20, 30, 18, 0.6);
+  border: 1px solid rgba(190, 242, 100, 0.4);
+  border-radius: 999px;
+  padding: 2px 7px;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  white-space: nowrap;
+}
+
+/* ── prefers-reduced-motion: nada se mueve (gama baja + a11y) ─────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .chivito .chiv-ala-fron,
+  .chivito .chiv-ala-tras,
+  .chivito .chiv-cresta,
+  .chivito .chiv-barba-brillo,
+  .chiv-escena .chiv-ave-wrap,
+  .chiv-boton.is-active .chivito,
+  .chiv-cruza {
+    animation: none !important;
+    transform: none !important;
+  }
+  .chivito .chiv-barba-brillo { opacity: 0.5 !important; }
+}

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -18,6 +18,8 @@ import { useTheme } from '../../hooks/useTheme';
 import { iconForTheme } from './themeIcon';
 import { colibriRealActivo } from '../../config/colibriFlag';
 import { BarbuditoIlustrado, BarbuditoRealLoop } from '../colibri/Barbudito';
+import { chivitoMockup } from '../../config/chivitoFlag';
+import { ChivitoEscena, ChivitoBoton } from '../chivito/Chivito';
 import './finca-viva-hero.css';
 
 // ¿Modo A/B del colibrí del páramo? Gateado por VITE_COLIBRI (colibriFlag.js),
@@ -30,6 +32,12 @@ import './finca-viva-hero.css';
 // DERECHA el REAL recortado (sprite en loop, sin recuadro). Es un A/B TEMPORAL:
 // cada uno lleva una etiquetita ("ilustrado" / "real") solo en este modo dev.
 const COLIBRI_REAL = colibriRealActivo();
+
+// ¿Modo CHIVITO DE PÁRAMO? Gateado por VITE_CHIVITO (chivitoFlag.js), dev-only.
+// Reemplaza al colibrí del A/B por el chivito vivo (Oxypogon) libando la flor
+// del frailejón, dibujado 100% SVG/CSS. 'ab' = A y B lado a lado; 'a'/'b' = un
+// solo mockup. Tiene precedencia sobre VITE_COLIBRI (es su reemplazo).
+const CHIVITO = chivitoMockup();
 
 /**
  * FincaVivaHero — el HOME INMERSIVO "Finca Viva" (refinado del mockup F2 v2
@@ -378,7 +386,27 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
                         (sprite en loop, sin recuadro). Cada uno con su etiquetita
                         ("ilustrado"/"real"). Con la flag OFF (prod), el colibrí
                         SVG 2D `ColibriVuela` de siempre. */}
-                    {COLIBRI_REAL ? (
+                    {CHIVITO ? (
+                      // CHIVITO DE PÁRAMO libando la flor del frailejón (SVG/CSS
+                      // vivo). 'ab' = los dos mockups lado a lado con etiqueta,
+                      // para que el operador elija; 'a'/'b' = uno solo, centrado.
+                      CHIVITO === 'ab' ? (
+                        <>
+                          <span className="fvh-bicho chiv-ab" style={{ left: '2%', top: '6%' }}>
+                            <ChivitoEscena mockup="a" size={150} />
+                            <span className="chiv-ab-tag">mockup A · simple</span>
+                          </span>
+                          <span className="fvh-bicho chiv-ab" style={{ right: '2%', top: '6%' }}>
+                            <ChivitoEscena mockup="b" size={150} />
+                            <span className="chiv-ab-tag">mockup B · detalle</span>
+                          </span>
+                        </>
+                      ) : (
+                        <span className="fvh-bicho chiv-ab" style={{ left: '50%', top: '6%', transform: 'translateX(-50%)' }}>
+                          <ChivitoEscena mockup={CHIVITO} size={172} />
+                        </span>
+                      )
+                    ) : COLIBRI_REAL ? (
                       <>
                         <span className="fvh-bicho fvh-colibri-ab fvh-colibri-ab-izq" style={{ left: '4%', top: '12%' }}>
                           <BarbuditoIlustrado size={104} ariaLabel="Colibrí del páramo ilustrado" />
@@ -419,7 +447,15 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
                 data-testid="finca-viva-agent-fab"
                 aria-label="Pregúntele a Chagra"
               >
-                <span className="av" aria-hidden="true"><ColibriAvatar /></span>
+                <span className="av" aria-hidden="true">
+                  {CHIVITO ? (
+                    // El chivito ES el icono del acceso al agente (Mockup A si es
+                    // A/B, para leer limpio a tamaño chico; si no, el elegido).
+                    <ChivitoBoton mockup={CHIVITO === 'ab' ? 'a' : CHIVITO} size={34} ariaLabel="Pregúntele a Chagra" />
+                  ) : (
+                    <ColibriAvatar />
+                  )}
+                </span>
                 <span className="ph">Pregúntele a Chagra…</span>
                 <span className="mic" aria-hidden="true">
                   <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">

--- a/src/config/chivitoFlag.js
+++ b/src/config/chivitoFlag.js
@@ -1,0 +1,59 @@
+/**
+ * chivitoFlag.js — feature flag del CHIVITO DE PÁRAMO vivo (Oxypogon guerinii,
+ * "barbudito paramuno"), dibujado 100% en SVG/CSS (cero assets, cero red,
+ * offline-first, gama baja).
+ *
+ * Reemplaza, bajo la flag, al colibrí del A/B anterior (VITE_COLIBRI) en las
+ * TRES piezas donde vive el ave insignia:
+ *   1. HOME  → el chivito tomando néctar de la flor amarilla del frailejón
+ *      (escena SVG animada, `ChivitoEscena`).
+ *   2. BOTÓN → el chivito ES el botón de enviar / hablar del input del agente
+ *      (`ChivitoBoton`, en el compositor del home, en AgentScreen y en el FAB).
+ *   3. TRANSICIÓN home→agente → el chivito cruza aleteando (`ChivitoCruza`).
+ *
+ * DOS MOCKUPS (dos niveles de detalle) para decidir en chagra-dev:
+ *   - Mockup A → simple / estilizado: vectorial limpio, colores planos, al
+ *     estilo ilustrado de la escena Finca Viva.
+ *   - Mockup B → detallado / rico: gradientes, barba iridiscente verde→violeta
+ *     con brillo animado, plumas, texturas del frailejón, sombras.
+ *
+ * CÓMO ACTIVARLO (dev): en el `.env` (o `.env.local`) del frontend:
+ *
+ *     VITE_CHIVITO=ab     → A/B lado a lado en el home (A izq, B der, con
+ *                           etiquetas). Botón del home = A; botones del agente
+ *                           y FAB = B; transición = A y B cruzando en paralelo.
+ *     VITE_CHIVITO=a      → mockup A coherente en las 3 piezas.
+ *     VITE_CHIVITO=b      → mockup B coherente en las 3 piezas.
+ *
+ * También acepta 'true' / '1' (= 'ab'). Con la flag APAGADA (default, prod)
+ * cada sitio conserva su presentación actual (colibrí SVG / avatar / video),
+ * igual que con VITE_COLIBRI apagada. Si ambas flags están prendidas, el
+ * chivito tiene precedencia (es el reemplazo del A/B del colibrí).
+ *
+ * Mismo criterio de parseo que `colibriRealActivo()` (colibriFlag.js) para
+ * mantener la convención del repo. Español colombiano (usted), NUNCA voseo.
+ *
+ * @module chivitoFlag
+ */
+
+const FLAG_KEY = 'VITE_CHIVITO';
+
+/**
+ * ¿Qué mockup del chivito está activo?
+ *
+ * @returns {'a'|'b'|'ab'|null} 'a' | 'b' | 'ab' según la flag; null (default)
+ *   si está apagada, con valor no reconocido o si import.meta.env falla.
+ */
+export function chivitoMockup() {
+  try {
+    const raw = import.meta.env?.[FLAG_KEY];
+    if (raw === true) return 'ab';
+    if (typeof raw !== 'string') return null;
+    const v = raw.trim().toLowerCase();
+    if (v === 'a' || v === 'b' || v === 'ab') return v;
+    if (v === 'true' || v === '1') return 'ab';
+    return null;
+  } catch (_) {
+    return null;
+  }
+}


### PR DESCRIPTION
## El chivito de páramo vivo

Redibuja el **chivito de páramo** (*Oxypogon guerinii*, barbudito paramuno) como pieza viva del ave insignia, **100% SVG/CSS** — cero assets, cero red, offline-first, gama baja — reemplazando al colibrí del A/B bajo una nueva flag `VITE_CHIVITO`.

### Fiel a la referencia real
- Cresta erguida, puntiaguda, blanco-crema con base oscura.
- Cara: capucha marrón + máscara negra + raya de mejilla clara.
- **Barba icónica** iridiscente verde arriba → violeta/púrpura en la punta.
- Cuerpo compacto oliva-marrón, vientre pálido, cola larga con puntas blancas, pico corto y recto negro.
- **Escena hero**: el ave tomando néctar de la **flor amarilla del frailejón** (roseta plateada afelpada + racimos amarillos) — la simbiosis real del páramo.

### Tres piezas coherentes (reemplazan al colibrí)
1. **Home**: el chivito libando la flor del frailejón (`ChivitoEscena`), animado sutil (se acerca/retira + aletea).
2. **Botón**: el chivito ES el icono del botón enviar/hablar del agente (`ChivitoBoton`) + el FAB global.
3. **Transición** home→agente: el chivito cruza aleteando (`ChivitoCruza`).

Todo respeta `prefers-reduced-motion`.

### Dos mockups tras la flag (como el A/B del colibrí)
- `VITE_CHIVITO=ab` → **Mockup A** (simple/plano) y **Mockup B** (detallado: gradientes, barba iridiscente con brillo animado, moteado del pecho, hojas afelpadas, flores radiales) **lado a lado con etiquetas** para decidir en chagra-dev.
- `VITE_CHIVITO=a` | `b` → un solo mockup coherente en las 3 piezas.

Con la flag **apagada** (default/prod) todo queda igual que hoy. Precedencia sobre `VITE_COLIBRI`.

### Verificación
- Tests: `src/components/chivito/` (nuevos), `FincaVivaHero`, `agent/`, `AgentScreen/`, `Settings/`, `ChagraAgentAvatar` → todo verde.
- `npm run build` → OK (sin romper bundle).
- Render inspeccionado contra las fotos reales del ave (Chromium headless): cresta, máscara, barba verde→violeta, cuerpo oliva, cola larga y frailejón plateado con flores amarillas coinciden.

Español colombiano (usted), sin voseo.
