### PR TITLE
feat(home-mano): 4 portales visibles en el primer viewport y ramas de una hoja como acción directa

### DIFF
--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -95,14 +95,25 @@ const GROUPS = GROUP_ORDER
    (key/icon/label/leaves) para que el motor de geometría los trate igual: las
    destacadas llevan kind:'cap' + cap y leaves:[] (no despliegan, accionan). El
    orden (destacadas primero) define el orden de sprout: el primerizo ve brotar
-   primero las 6 funciones clave. */
+   primero las 6 funciones clave.
+
+   RAMAS DE UNA SOLA HOJA → ACCIÓN DIRECTA (redistribución 2026-07-02, replanteo
+   F del audit 06-28): un grupo con exactamente UNA hoja era una fachada de
+   submenú — tocar "Aprender" desplegaba… una única hoja casi homónima (dos
+   toques para un solo destino). La rama se promueve a kind:'cap': conserva su
+   puesto en el anillo y su identidad de rama (icono/rótulo del grupo, alineado
+   con el portal "Aprender" del home), pero actúa de una, como las destacadas.
+   NO cambia el routing: es la MISMA capacidad hoja (mapCapabilityPick la enruta
+   igual) y su salud (soon/down) se sigue evaluando por el id de la hoja. */
 const RING = [
   ...FEATURED.map((cap) => ({
     kind: 'cap', key: cap.id, icon: cap.icon, label: cap.label, cap, leaves: [],
   })),
-  ...GROUPS.map((g) => ({
-    kind: 'group', key: g.key, icon: g.icon, label: g.label, leaves: g.leaves,
-  })),
+  ...GROUPS.map((g) => (
+    g.leaves.length === 1
+      ? { kind: 'cap', key: g.key, icon: g.icon, label: g.label, cap: g.leaves[0], leaves: [] }
+      : { kind: 'group', key: g.key, icon: g.icon, label: g.label, leaves: g.leaves }
+  )),
 ];
 
 /* ══════════════ helpers geométricos (puros, port 1:1) ══════════════ */

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -58,6 +58,12 @@ const COLIBRI_REAL = colibriRealActivo();
  *      la escena y los 4 portales respiran (grilla legible), sin gradientes
  *      estirados (lo gobierna finca-viva-hero.css con un shell --fvh-max).
  *   8. PORTALES con más velo/legibilidad sobre la fauna.
+ *   9. PORTALES VISIBLES EN MÓVIL (replanteo F, audit 2026-06-28): en pantalla
+ *      angosta la escena cede altura y los 4 portales SUBEN justo bajo el
+ *      compositor (el saludo grande cierra el hero). El usuario nuevo entiende
+ *      qué es Chagra en el primer viewport, sin scroll. Reorden 100% CSS
+ *      (display:contents + order en finca-viva-hero.css): el DOM y el desktop
+ *      no cambian.
  *
  * Se monta SOLO con la flag VITE_FINCA_VIVA_HOME_PERFIL ON (lo decide
  * DashboardLive). Con la flag OFF el home conserva su portada actual (AgentHero).

--- a/src/components/dashboard/__tests__/AgentRedMenu.smoke.test.jsx
+++ b/src/components/dashboard/__tests__/AgentRedMenu.smoke.test.jsx
@@ -4,7 +4,7 @@
  * (despliegue de ramas, onPick) se valida en vivo con chromium.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 
 // jsdom no trae ResizeObserver (lo usa el motor de geometría viva).
 globalThis.ResizeObserver = globalThis.ResizeObserver || class {
@@ -154,5 +154,49 @@ describe('AgentRedMenu — smoke', () => {
     const anchorRef = { current: null };
     const { container } = render(<AgentRedMenu onPick={vi.fn()} anchorRef={anchorRef} />);
     expect(container.querySelector('.arm-root')).toBeTruthy();
+  });
+});
+
+describe('AgentRedMenu — ramas de una sola hoja = acción directa (replanteo F, audit 06-28)', () => {
+  // Un grupo con exactamente UNA hoja no despliega submenú (fachada de dos
+  // toques): se promueve a acción directa que dispara onPick con la hoja real.
+  const nodo = (container, label) =>
+    container.querySelector(`.arm-nodes [aria-label="${label}"]`);
+
+  it('"Aprender" es acción directa (sin submenú) y abre el hub real (aprender_hub → aprende)', () => {
+    const onPick = vi.fn();
+    const { container } = render(<AgentRedMenu onPick={onPick} />);
+    const n = nodo(container, 'Aprender');
+    expect(n).toBeTruthy();
+    expect(n.className).toContain('arm-feat');          // acción directa
+    expect(n.getAttribute('aria-expanded')).toBeNull(); // no es submenú
+    fireEvent.click(n);
+    expect(onPick).toHaveBeenCalledTimes(1);
+    const cap = onPick.mock.calls[0][0];
+    expect(cap.id).toBe('aprender_hub');
+    expect(cap.heroRoute).toEqual({ kind: 'nav', view: 'aprende' });
+  });
+
+  it('"Vender mejor" es acción directa y lleva al mercado real (mercado → vista mercado)', () => {
+    const onPick = vi.fn();
+    const { container } = render(<AgentRedMenu onPick={onPick} />);
+    const n = nodo(container, 'Vender mejor');
+    expect(n).toBeTruthy();
+    expect(n.className).toContain('arm-feat');
+    expect(n.getAttribute('aria-expanded')).toBeNull();
+    fireEvent.click(n);
+    expect(onPick).toHaveBeenCalledTimes(1);
+    const cap = onPick.mock.calls[0][0];
+    expect(cap.id).toBe('mercado');
+    expect(cap.heroRoute).toEqual({ kind: 'nav', view: 'mercado' });
+  });
+
+  it('los grupos con VARIAS hojas siguen siendo ramas desplegables (aria-expanded presente)', () => {
+    const { container } = render(<AgentRedMenu onPick={vi.fn()} />);
+    const grupos = container.querySelectorAll('.arm-nodes .arm-group');
+    expect(grupos.length).toBeGreaterThan(0);
+    grupos.forEach((g) => {
+      expect(g.getAttribute('aria-expanded')).not.toBeNull();
+    });
   });
 });

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -1039,6 +1039,49 @@
   .fvh-escena { height: 540px; }
 }
 
+/* ════════════════════════════════════════════════════════════════════════════
+   DISTRIBUCIÓN MÓVIL (replanteo F del audit 2026-06-28 — "4 portales VISIBLES,
+   no escondidos"): en el celular del campesino los 4 portales quedaban ENTEROS
+   bajo el fold (topbar + escena 360px + compositor + saludo ≈ 690px antes del
+   primer portal). El usuario nuevo con 0 plantas veía escena y saludo… y nada
+   de qué ES Chagra. Dos movidas, solo de layout (cero lógica nueva):
+
+   1. La ESCENA cede altura en pantalla angosta (clamp por dvh): sigue siendo la
+      portada inmersiva, pero no se come media pantalla. Si el navegador no
+      soporta dvh/clamp, la declaración se ignora y quedan los 360px de siempre.
+   2. Los 4 PORTALES SUBEN justo bajo el compositor del agente y el saludo
+      grande baja a cerrar el hero. Se logra SIN tocar el DOM (el desktop
+      conserva su grilla escena|columna): .fvh-main/.fvh-aside pasan a
+      display:contents y los bloques se reordenan con `order` sobre la columna
+      flex del shell. Todos los bloques llevan order explícito, de modo que si
+      un navegador viejo ignora display:contents el orden efectivo es EXACTO al
+      de hoy (degradación limpia). El saludo es texto no interactivo: el orden
+      del DOM (y del lector de pantalla / tab) no cambia.
+   Jerarquía resultante para el primerizo: su finca (escena) → pregúntele al
+   agente (compositor) → los 4 portales (Mi finca · Aprender · Jugar · Agente). */
+@media (max-width: 899.98px) {
+  .fvh-main,
+  .fvh-aside { display: contents; }
+
+  .fvh-topbar { order: 1; }
+  .fvh-qa { order: 2; }
+  .fvh-main,
+  .fvh-escena-wrap { order: 3; }
+  .fvh-aside,
+  .fvh-composer-wrap { order: 4; }
+  .fvh-portales-tit { order: 5; }
+  .fvh-portales { order: 6; }
+  .fvh-hero-saludo { order: 7; }
+  .fvh-fill { order: 8; }
+
+  /* La escena respira pero deja ver los portales: ~1/3 del viewport. */
+  .fvh-escena { height: clamp(224px, 32dvh, 340px); }
+
+  /* Aire justo entre compositor → portales → saludo de cierre. */
+  .fvh-portales-tit { margin-top: 14px; }
+  .fvh-hero-saludo { padding-top: 18px; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .fvh *, .fvh *::before, .fvh *::after { animation: none !important; }
   .fvh-portal,

--- a/tests/mano-bloqueo-conversacion.spec.js
+++ b/tests/mano-bloqueo-conversacion.spec.js
@@ -360,7 +360,12 @@ test.describe('La mano de Chagra — conversación real por cada nodo (≥3 mens
       await openMano(page);
       await expectManoNoBloqueada(page);
       // Tocar un grupo distinto responde (la mano sigue interactiva, no muerta).
-      await expandGroup(page, 'Aprender');
+      // 'Restaurar y conservar' y no 'Aprender': desde la redistribución del
+      // replanteo F (2026-07-02) las ramas de UNA sola hoja (Aprender/Vender
+      // mejor) son acción directa (.arm-feat, navegan de una) — ya no son
+      // grupos desplegables. Restaurar conserva varias hojas y sigue siendo
+      // rama con aria-expanded.
+      await expandGroup(page, 'Restaurar y conservar');
       await expectManoNoBloqueada(page);
 
       expect(pageErrors, `pageerrors durante la conversación de ${cap.id}`).toEqual([]);


### PR DESCRIPTION
## Qué hace

Respuesta directa al **replanteo F** de la triple auditoría de la mano (2026-06-28, Eje 2: *"el cuello no es capacidad, es distribución y visualización"*). Solo distribución/layout — cero lógica nueva.

### 1. Home móvil — los 4 portales entran al primer viewport
Los 4 portales (Mi finca · Aprender · Jugar · Pregúntele a Chagra) quedaban **enteros bajo el fold** en móvil (~690px de topbar + escena 360px + compositor + saludo antes del primer portal): el usuario nuevo con 0 plantas no veía qué es Chagra sin scroll.

- La escena cede altura en pantalla angosta: `clamp(224px, 32dvh, 340px)` (sigue siendo la portada inmersiva, ~1/3 del viewport).
- Los portales **suben** justo bajo el compositor del agente; el saludo grande baja a cerrar el hero.
- Reorden **100% CSS** (`display:contents` + `order` en `finca-viva-hero.css`): el DOM, el orden de tabulación y el layout **desktop no cambian**. Todos los bloques llevan `order` explícito → si un navegador viejo ignora `display:contents`, el orden efectivo es exactamente el de hoy (degradación limpia). Si no soporta `dvh`, la declaración se ignora y quedan los 360px actuales.

Jerarquía resultante para el primerizo: su finca (escena) → pregúntele al agente (compositor) → los 4 portales.

### 2. Mano radial — ramas de una sola hoja dejan de ser fachada de submenú
Tras el dedup del 06-28, las ramas **Aprender** (única hoja: `aprender_hub`) y **Vender mejor** (única hoja: `mercado`) abrían un submenú con una sola hoja casi homónima: dos toques para un único destino. Ahora un grupo con exactamente una hoja se **promueve a acción directa** (`kind:'cap'`) en el anillo: conserva su puesto e identidad de rama, mismo routing (`mapCapabilityPick`) y misma salud (`soon`/`down`) por id de la hoja.

### Tests
- 3 casos nuevos en `AgentRedMenu.smoke.test.jsx`: "Aprender"/"Vender mejor" son acción directa y disparan `onPick` con la capacidad real; los grupos multi-hoja siguen desplegables (`aria-expanded`).
- Suites afectadas verdes: AgentRedMenu.smoke, FincaVivaHero.{portales,theme,estructura,nivelRespuestas}, FincaVivaResto.noSolapa, DashboardLive.{redistribucion,homeGating}, AgentHero.{integration,demoParity}, manoRamasReachable (95 tests).
- `npm run build` OK.

### Alcance y pendientes del audit (fuera de este PR)
- Todo queda tras la flag `VITE_FINCA_VIVA_HOME_PERFIL` (gate dev-only existente; encenderla en prod es decisión de producto aparte).
- "Una ilustración por lección" en el hub Aprender (ítem *cero gráficos* del audit) es tarea de contenido aparte — el hub ya tiene icono/color por lección, el infográfico por lección sigue pendiente.

Offline-first intacto · `prefers-reduced-motion` sin cambios · UI en usted colombiano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)