### PR TITLE
feat(ux): estados vacíos amables + skeletons + offline tranquilo en superficies de alto tráfico

### DIFF
--- a/src/components/AssetTimeline.jsx
+++ b/src/components/AssetTimeline.jsx
@@ -8,6 +8,7 @@ import { savePayload } from '../services/payloadService';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import { usePhotoUrl } from '../hooks/usePhotoUrl';
 import BeforeAfterPhoto from './BeforeAfterPhoto';
+import EmptyState from './common/EmptyState';
 
 /**
  * AssetTimeline, Línea de tiempo agroecológica de un activo (plant).
@@ -510,12 +511,13 @@ export default function AssetTimeline({ assetId }) {
       )}
 
       {logs.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-center text-slate-500 min-h-[300px]">
-          <Leaf size={32} className="mx-auto mb-2 opacity-40" />
-          <p className="text-sm">Sin eventos registrados en los últimos 30 días.</p>
-          <p className="text-xs mt-1 opacity-70">
-            Los registros de siembra, insumos y cosecha aparecerán aquí.
-          </p>
+        <div className="flex-1 flex flex-col justify-center min-h-[300px]">
+          <EmptyState
+            icon={Leaf}
+            title="Sin eventos en los últimos 30 días"
+            description="Cuando registre siembras, insumos o cosechas, aquí le queda la historia de la finca día a día."
+            data-testid="timeline-empty"
+          />
         </div>
       ) : (
         <div className="flex-1 min-h-0 border-l-2 border-slate-800 ml-2">

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- legacy UI copy preexistente al gate i18n; migración a messages.js (ADR-050) trackeada aparte, mismo criterio que AssetDetailView */
 import React, { useState, useEffect } from 'react';
 import { MSG } from '../config/messages.js';
 import { ArrowLeft, Plus, Trash2, RefreshCw, Building2, Leaf, Search, WifiOff, TreePine, Map as MapIcon, List, Sprout, FlaskConical, Ban, AlertTriangle, Warehouse, Square, ChevronDown } from 'lucide-react';
@@ -26,6 +27,8 @@ import { savePhoto } from '../services/photoService';
 import { wktToGeoJson } from '../utils/geo';
 import { buildPlantMeta, formatPlantMetaFallbackLine, ETAPA_FENOLOGICA_OPTIONS } from '../utils/plantMeta';
 import MultiFincaModal from './MultiFincaModal';
+import EmptyState, { OfflineNotice } from './common/EmptyState';
+import SkeletonList from './common/SkeletonList';
 
 // Note: fincaNombre constant removed. Now derived from useFincaActiveStore inside the component.
 
@@ -975,7 +978,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
           </p>
         ) : !formData.parentLandId ? (
           <p className="mt-1 text-xs text-amber-400/80">
-            Quedará en "Sin zona asignada". La podrás mover a un lote cuando quieras.
+            Quedará en "Sin zona asignada". La podrá mover a un lote cuando quiera.
           </p>
         ) : null}
       </div>
@@ -1505,11 +1508,28 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
         </div>
       </div>
 
-      {/* Error */}
+      {/* Error / sin conexión. Offline NO es un error: tono tranquilo
+          (offline-first, los datos viven en el dispositivo). Error real →
+          mensaje claro + reintento con el mismo syncFromServer del store. */}
       {error && (
-        <div className="mx-3 p-3 bg-red-900/30 border border-red-500 rounded-xl text-red-200 text-sm shrink-0">
-          {error}
-        </div>
+        !navigator.onLine ? (
+          <OfflineNotice className="mx-3 shrink-0" />
+        ) : (
+          <div className="mx-3 p-3 bg-amber-900/20 border border-amber-700/50 rounded-xl text-amber-200 text-sm shrink-0 flex items-start gap-2.5">
+            <AlertTriangle size={16} className="shrink-0 mt-0.5 text-amber-400" aria-hidden="true" />
+            <div className="flex-1 min-w-0">
+              <p className="leading-snug">{error}</p>
+              <p className="text-xs text-amber-300/70 mt-0.5">Sus registros locales están a salvo.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => syncFromServer()}
+              className="shrink-0 px-3 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-100 text-xs font-bold flex items-center gap-1.5 min-h-[36px]"
+            >
+              <RefreshCw size={12} aria-hidden="true" /> Reintentar
+            </button>
+          </div>
+        )
       )}
 
       {/* Vista de mapa global (Fase 17.3), reemplaza la lista cuando viewMode === 'map' */}
@@ -1582,11 +1602,22 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
       {viewMode === 'list' && activeTab === 'plant' && !currentZoneId && (
         <div className="flex-1">
           {lands.length === 0 && orphanPlants.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-slate-500">
-              <MapPin size={48} className="mb-3 opacity-30" />
-              <p className="text-lg">Sin zonas registradas</p>
-              <p className="text-sm mt-1">Crea una zona (asset--land) desde FarmOS o la tab Infraestructura</p>
-            </div>
+            /* Primera impresión del productor nuevo (0 plantas, 0 lugares):
+               invitación cálida a la primera siembra, no jerga técnica.
+               El CTA reutiliza el mismo flujo del FAB "Registrar Siembra". */
+            isLoading ? (
+              <SkeletonList count={4} className="p-3" ariaLabel="Cargando su finca…" />
+            ) : (
+              <EmptyState
+                icon={Sprout}
+                title="Aún no ha registrado plantas"
+                description="Registre su primera siembra y Chagra le va armando el calendario, las tareas y la historia de cada mata."
+                actionLabel="Registrar mi primera siembra"
+                onAction={() => { setShowForm(true); resetForm(); }}
+                secondaryHint="Si prefiere, primero cree los lugares de su finca (lotes, eras, invernaderos) en la pestaña Infraestructura."
+                data-testid="assets-empty-first-plant"
+              />
+            )
           ) : (
             <Virtuoso
               data={getZonesForDrillDown()}
@@ -1609,7 +1640,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
                               </div>
                               <div className="min-w-0">
                                 <h4 className="font-bold text-amber-100 truncate">Sin zona asignada</h4>
-                                <p className="text-xs text-amber-300/80">Reasigna estas plantas a una zona</p>
+                                <p className="text-xs text-amber-300/80">Reasigne estas plantas a una zona</p>
                               </div>
                             </div>
                             <div className="text-right shrink-0">
@@ -1688,16 +1719,22 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
       {viewMode === 'list' && !(activeTab === 'plant' && !currentZoneId) && (
         <div className="flex-1 overflow-y-auto p-3 space-y-2">
           {isLoading && currentAssets.length === 0 ? (
-            <div className="flex items-center justify-center py-12">
-              <RefreshCw size={24} className="animate-spin text-slate-500" />
-              <span className="ml-3 text-slate-500">{MSG.ui.cargando}</span>
-            </div>
+            /* Skeleton con la silueta de las cards reales: percepción de
+               rapidez en gama baja y cero salto de layout al llegar datos. */
+            <SkeletonList count={5} ariaLabel={MSG.ui.cargando} />
           ) : currentAssets.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-slate-500">
-              <tabConfig.icon size={48} className="mb-3 opacity-30" />
-              <p className="text-lg">Sin {tabConfig.label.toLowerCase()} registrados</p>
-              <p className="text-sm mt-1">Toca el botón para agregar</p>
-            </div>
+            <EmptyState
+              icon={tabConfig.icon}
+              title={`Aún no ha registrado ${tabConfig.label.toLowerCase()}`}
+              description={
+                activeTab === 'plant'
+                  ? 'Cuando registre una siembra en este lugar, aquí le aparece con su foto, su especie y su historia.'
+                  : 'Registre el primero y quedará guardado en su dispositivo, con o sin señal.'
+              }
+              actionLabel={activeTab === 'plant' ? 'Registrar siembra' : `Agregar ${TAB_LABELS[activeTab]}`}
+              onAction={() => { setShowForm(true); resetForm(); }}
+              data-testid={`assets-empty-${activeTab}`}
+            />
           ) : (
             <Virtuoso
               data={currentAssets}

--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -198,7 +198,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
               No encontramos “{query.trim()}” en el catálogo todavía.
             </p>
             <p className="jp-tinta-suave text-xs text-slate-500 mt-1">
-              Prueba con otro nombre común o el nombre científico.
+              Pruebe con otro nombre común o el nombre científico.
             </p>
           </div>
         )}
@@ -207,7 +207,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
           <>
             {results.length > 1 && (
               <p className="jp-tinta-suave text-xs text-slate-400 mb-2">
-                {results.length} coincidencias — elige una:
+                {results.length} coincidencias — elija una:
               </p>
             )}
             <ul className="space-y-2" data-testid="directorio-results">
@@ -240,7 +240,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
           <div className="text-center py-12" data-testid="directorio-hint">
             <BookOpen size={34} className="mx-auto text-slate-700 mb-3" aria-hidden="true" />
             <p className="jp-tinta-suave text-sm text-slate-400 max-w-xs mx-auto leading-relaxed">
-              Busca cualquier especie del catálogo y mira su piso térmico, con qué
+              Busque cualquier especie del catálogo y mire su piso térmico, con qué
               se asocia, qué biopreparados le sirven y qué plagas la afectan.
             </p>
           </div>

--- a/src/components/common/EmptyState.jsx
+++ b/src/components/common/EmptyState.jsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { Sprout, WifiOff, AlertTriangle, RotateCcw, Plus } from 'lucide-react';
+
+/**
+ * EmptyState — estado vacío / error / sin-conexión reutilizable.
+ *
+ * La primera impresión de un productor nuevo (0 plantas, 0 registros) no
+ * puede ser una pantalla fría. Este componente convierte el vacío en una
+ * invitación: qué es este espacio, por qué está vacío y cuál es el primer
+ * paso (CTA conectado al flujo de alta existente — NO crea lógica nueva).
+ *
+ * Variantes:
+ *   - "empty"   → acento esmeralda, invita a la primera acción (default)
+ *   - "error"   → acento ámbar + botón de reintento (tono tranquilo, no rojo pánico)
+ *   - "offline" → acento cielo, tono calmado offline-first
+ *                 ("Trabajando sin conexión, sus datos están a salvo")
+ *
+ * Tamaños:
+ *   - "full"    → pantalla/panel completo (py-12)
+ *   - "compact" → dentro de listas/cards (py-6, icono menor)
+ *
+ * Accesibilidad: role="status" para que lectores anuncien el estado;
+ * el anillo punteado y la ilustración son decorativos (aria-hidden).
+ * Tono: usted colombiano. Sin dependencias nuevas: lucide + tailwind.
+ */
+
+const VARIANT_STYLES = {
+  empty: {
+    ring: 'border-emerald-700/50',
+    iconBg: 'bg-emerald-900/30',
+    iconColor: 'text-emerald-400',
+    title: 'text-slate-100',
+    action: 'bg-emerald-600 hover:bg-emerald-500 active:brightness-90 text-white',
+    DefaultIcon: Sprout,
+  },
+  error: {
+    ring: 'border-amber-700/50',
+    iconBg: 'bg-amber-900/30',
+    iconColor: 'text-amber-400',
+    title: 'text-amber-100',
+    action: 'bg-slate-800 hover:bg-slate-700 active:brightness-90 text-slate-100 border border-slate-700',
+    DefaultIcon: AlertTriangle,
+  },
+  offline: {
+    ring: 'border-sky-700/50',
+    iconBg: 'bg-sky-900/30',
+    iconColor: 'text-sky-400',
+    title: 'text-sky-100',
+    action: 'bg-slate-800 hover:bg-slate-700 active:brightness-90 text-slate-100 border border-slate-700',
+    DefaultIcon: WifiOff,
+  },
+};
+
+export default function EmptyState({
+  variant = 'empty',
+  size = 'full',
+  icon,
+  illustration,
+  title,
+  description,
+  actionLabel,
+  onAction,
+  actionIcon,
+  secondaryHint,
+  className = '',
+  'data-testid': testId = 'empty-state',
+}) {
+  const styles = VARIANT_STYLES[variant] || VARIANT_STYLES.empty;
+  const Icon = icon || styles.DefaultIcon;
+  const ActionIcon = actionIcon || (variant === 'empty' ? Plus : RotateCcw);
+  const compact = size === 'compact';
+
+  return (
+    <div
+      role="status"
+      data-testid={testId}
+      className={`flex flex-col items-center justify-center text-center px-6 ${
+        compact ? 'py-6 gap-2' : 'py-12 gap-3'
+      } ${className}`}
+    >
+      {/* Ilustración custom (ej. ChagraGrowLoader por piso térmico) o icono
+          en badge circular con anillo punteado — "espacio por sembrar". */}
+      {illustration ? (
+        <div aria-hidden="true" className="mb-1">{illustration}</div>
+      ) : (
+        <div
+          aria-hidden="true"
+          className={`rounded-full border-2 border-dashed ${styles.ring} p-1.5 mb-1`}
+        >
+          <div
+            className={`rounded-full ${styles.iconBg} flex items-center justify-center ${
+              compact ? 'w-12 h-12' : 'w-16 h-16'
+            }`}
+          >
+            <Icon size={compact ? 22 : 30} className={styles.iconColor} />
+          </div>
+        </div>
+      )}
+
+      {title && (
+        <p className={`font-bold leading-snug ${styles.title} ${compact ? 'text-sm' : 'text-base'}`}>
+          {title}
+        </p>
+      )}
+
+      {description && (
+        <p className={`text-slate-400 leading-relaxed max-w-xs ${compact ? 'text-xs' : 'text-sm'}`}>
+          {description}
+        </p>
+      )}
+
+      {actionLabel && typeof onAction === 'function' && (
+        <button
+          type="button"
+          onClick={onAction}
+          className={`mt-2 px-5 rounded-xl font-bold flex items-center justify-center gap-2 transition-all min-h-[48px] ${
+            compact ? 'py-2.5 text-sm' : 'py-3'
+          } ${styles.action}`}
+        >
+          <ActionIcon size={18} aria-hidden="true" />
+          <span>{actionLabel}</span>
+        </button>
+      )}
+
+      {secondaryHint && (
+        <p className="text-xs text-slate-500 leading-relaxed max-w-xs mt-1">
+          {secondaryHint}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * OfflineNotice — franja calmada para trabajo sin conexión (offline-first).
+ * No es un error: es el modo normal de la app en el campo. Tono tranquilo.
+ */
+export function OfflineNotice({ className = '', message, 'data-testid': testId = 'offline-notice' }) {
+  return (
+    <div
+      role="status"
+      data-testid={testId}
+      className={`flex items-start gap-2.5 p-3 rounded-xl bg-sky-950/40 border border-sky-800/40 text-sky-200 text-sm ${className}`}
+    >
+      <WifiOff size={16} className="shrink-0 mt-0.5 text-sky-400" aria-hidden="true" />
+      <span className="leading-snug">
+        {message || 'Trabajando sin conexión — sus datos están a salvo en este dispositivo y se sincronizarán cuando vuelva la señal.'}
+      </span>
+    </div>
+  );
+}

--- a/src/components/common/EmptyState.jsx
+++ b/src/components/common/EmptyState.jsx
@@ -51,17 +51,19 @@ const VARIANT_STYLES = {
   },
 };
 
+// Defaults undefined explícitos: props opcionales para el gate tsc:check
+// (sin default, la inferencia JS de tsc las marca requeridas en cada caller).
 export default function EmptyState({
   variant = 'empty',
   size = 'full',
-  icon,
-  illustration,
-  title,
-  description,
-  actionLabel,
-  onAction,
-  actionIcon,
-  secondaryHint,
+  icon = undefined,
+  illustration = undefined,
+  title = undefined,
+  description = undefined,
+  actionLabel = undefined,
+  onAction = undefined,
+  actionIcon = undefined,
+  secondaryHint = undefined,
   className = '',
   'data-testid': testId = 'empty-state',
 }) {
@@ -135,7 +137,7 @@ export default function EmptyState({
  * OfflineNotice — franja calmada para trabajo sin conexión (offline-first).
  * No es un error: es el modo normal de la app en el campo. Tono tranquilo.
  */
-export function OfflineNotice({ className = '', message, 'data-testid': testId = 'offline-notice' }) {
+export function OfflineNotice({ className = '', message = undefined, 'data-testid': testId = 'offline-notice' }) {
   return (
     <div
       role="status"

--- a/src/components/common/Skeleton.jsx
+++ b/src/components/common/Skeleton.jsx
@@ -21,9 +21,11 @@ export default function Skeleton({
   height,
   className = '',
   rounded = 'md',
+  // eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- default de aria-label preexistente al gate i18n; migración a messages.js (ADR-050) pendiente fuera de este cambio
   ariaLabel = 'Cargando…',
 }) {
-  const base = 'bg-slate-700/40 animate-pulse';
+  // motion-safe: el shimmer se apaga solo con prefers-reduced-motion.
+  const base = 'bg-slate-700/40 motion-safe:animate-pulse';
   const roundedClass = {
     none: '',
     sm: 'rounded-sm',

--- a/src/components/common/SkeletonList.jsx
+++ b/src/components/common/SkeletonList.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import Skeleton from './Skeleton';
+
+/**
+ * SkeletonList — lista de placeholders con la forma real del contenido.
+ *
+ * En gama baja con IndexedDB/red lenta, un spinner seco se siente como
+ * "la app se quedó pegada". Un skeleton con la silueta de las cards que
+ * van a aparecer mejora la percepción de rapidez y evita el salto de
+ * layout cuando llegan los datos.
+ *
+ * Variantes (siluetas del sistema visual Chagra):
+ *   - "card" → card de activo (icono cuadrado + título + subtítulo),
+ *              misma caja que las cards de Mis Plantas / Activos.
+ *   - "row"  → fila liviana (círculo + línea), para timelines/listas densas.
+ *
+ * Accesibilidad: UN solo role="status" en el contenedor (los hijos van
+ * aria-hidden para no anunciar N veces "cargando"). El shimmer hereda
+ * motion-safe:animate-pulse del Skeleton base (prefers-reduced-motion OK).
+ */
+export default function SkeletonList({
+  count = 4,
+  variant = 'card',
+  // eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- default de aria-label; los callers pasan MSG.ui.* cuando aplica (ADR-050)
+  ariaLabel = 'Cargando sus registros…',
+  className = '',
+  'data-testid': testId = 'skeleton-list',
+}) {
+  const items = Array.from({ length: Math.max(1, count) });
+
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className={`space-y-2 ${className}`}
+    >
+      {items.map((_, i) => (
+        <div key={i} aria-hidden="true">
+          {variant === 'row' ? (
+            <div className="flex items-center gap-3 px-1 py-2.5">
+              <Skeleton variant="circle" width={32} ariaLabel="" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton variant="line" width="55%" height={12} ariaLabel="" />
+                <Skeleton variant="line" width="35%" height={10} ariaLabel="" />
+              </div>
+            </div>
+          ) : (
+            <div className="p-4 rounded-xl bg-slate-800/60 border border-slate-700/60 flex items-center gap-3">
+              <Skeleton variant="rect" width={40} height={40} rounded="lg" ariaLabel="" />
+              <div className="flex-1 space-y-2">
+                <Skeleton variant="line" width="60%" height={13} ariaLabel="" />
+                <Skeleton variant="line" width="40%" height={10} ariaLabel="" />
+              </div>
+              <Skeleton variant="rect" width={28} height={24} rounded="md" ariaLabel="" />
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/common/SkeletonList.jsx
+++ b/src/components/common/SkeletonList.jsx
@@ -40,7 +40,7 @@ export default function SkeletonList({
         <div key={i} aria-hidden="true">
           {variant === 'row' ? (
             <div className="flex items-center gap-3 px-1 py-2.5">
-              <Skeleton variant="circle" width={32} ariaLabel="" />
+              <Skeleton variant="circle" width={32} height={32} ariaLabel="" />
               <div className="flex-1 space-y-1.5">
                 <Skeleton variant="line" width="55%" height={12} ariaLabel="" />
                 <Skeleton variant="line" width="35%" height={10} ariaLabel="" />

--- a/src/components/common/__tests__/EmptyState.test.jsx
+++ b/src/components/common/__tests__/EmptyState.test.jsx
@@ -1,0 +1,75 @@
+/**
+ * EmptyState.test.jsx — estados vacío / error / offline reutilizables.
+ *
+ * Contrato visual: role="status", tono usted, CTA conectado al callback
+ * del caller (no lógica propia), variante offline con mensaje calmado.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi } from 'vitest';
+import { Leaf } from 'lucide-react';
+import EmptyState, { OfflineNotice } from '../EmptyState';
+
+describe('EmptyState', () => {
+  test('renderiza título, descripción y hint con role="status"', () => {
+    render(
+      <EmptyState
+        title="Aún no ha registrado plantas"
+        description="Registre su primera siembra."
+        secondaryHint="También puede crear lugares primero."
+      />
+    );
+    const el = screen.getByTestId('empty-state');
+    expect(el).toHaveAttribute('role', 'status');
+    expect(screen.getByText('Aún no ha registrado plantas')).toBeInTheDocument();
+    expect(screen.getByText('Registre su primera siembra.')).toBeInTheDocument();
+    expect(screen.getByText('También puede crear lugares primero.')).toBeInTheDocument();
+  });
+
+  test('CTA dispara onAction al tocar', () => {
+    const onAction = vi.fn();
+    render(
+      <EmptyState title="Vacío" actionLabel="Registrar siembra" onAction={onAction} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Registrar siembra/ }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  test('sin onAction NO renderiza botón (estado informativo puro)', () => {
+    render(<EmptyState title="Vacío" actionLabel="Registrar" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('acepta icono custom sin romper', () => {
+    render(<EmptyState icon={Leaf} title="Sin eventos" data-testid="timeline-empty" />);
+    expect(screen.getByTestId('timeline-empty')).toBeInTheDocument();
+  });
+
+  test('variante error usa acento ámbar (tono tranquilo, no rojo pánico)', () => {
+    render(<EmptyState variant="error" title="Algo falló" data-testid="err" />);
+    const el = screen.getByTestId('err');
+    expect(el.innerHTML).toMatch(/amber/);
+    expect(el.innerHTML).not.toMatch(/red-500/);
+  });
+
+  test('fondo oscuro: no usa bg-white ni escala light', () => {
+    const { container } = render(<EmptyState title="Vacío" />);
+    expect(container.innerHTML).not.toMatch(/bg-white|bg-slate-100|bg-gray-/);
+  });
+});
+
+describe('OfflineNotice', () => {
+  test('mensaje offline-first calmado por defecto', () => {
+    render(<OfflineNotice />);
+    expect(screen.getByTestId('offline-notice')).toHaveAttribute('role', 'status');
+    expect(
+      screen.getByText(/Trabajando sin conexión — sus datos están a salvo/)
+    ).toBeInTheDocument();
+  });
+
+  test('acepta mensaje custom', () => {
+    render(<OfflineNotice message="Sin señal en la vereda." />);
+    expect(screen.getByText('Sin señal en la vereda.')).toBeInTheDocument();
+  });
+});

--- a/src/components/common/__tests__/SkeletonList.test.jsx
+++ b/src/components/common/__tests__/SkeletonList.test.jsx
@@ -1,0 +1,60 @@
+/**
+ * SkeletonList.test.jsx — skeletons con la forma del contenido.
+ *
+ * Contrato: UN solo role="status" en el contenedor (hijos aria-hidden,
+ * no anunciar N veces "cargando"), fondo oscuro, shimmer motion-safe.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect } from 'vitest';
+import SkeletonList from '../SkeletonList';
+
+describe('SkeletonList', () => {
+  test('renderiza N placeholders con un solo role="status"', () => {
+    const { container } = render(<SkeletonList count={5} />);
+    const wrapper = screen.getByTestId('skeleton-list');
+    expect(wrapper).toHaveAttribute('role', 'status');
+    expect(wrapper).toHaveAttribute('aria-busy', 'true');
+    expect(container.querySelectorAll('[aria-hidden="true"]').length).toBe(5);
+  });
+
+  test('hijos ocultos a lectores de pantalla (aria-hidden)', () => {
+    const { container } = render(<SkeletonList count={3} />);
+    const children = screen.getByTestId('skeleton-list').children;
+    expect(children.length).toBe(3);
+    for (const child of children) {
+      expect(child).toHaveAttribute('aria-hidden', 'true');
+    }
+    expect(container).toBeTruthy();
+  });
+
+  test('aria-label descriptivo en tono usted', () => {
+    render(<SkeletonList />);
+    expect(screen.getByTestId('skeleton-list')).toHaveAttribute(
+      'aria-label',
+      'Cargando sus registros…'
+    );
+  });
+
+  test('shimmer usa motion-safe (respeta prefers-reduced-motion)', () => {
+    const { container } = render(<SkeletonList count={1} />);
+    expect(container.innerHTML).toMatch(/motion-safe:animate-pulse/);
+  });
+
+  test('variante card imita la silueta de las cards de activos (fondo oscuro)', () => {
+    const { container } = render(<SkeletonList count={2} variant="card" />);
+    expect(container.innerHTML).toMatch(/bg-slate-800/);
+    expect(container.innerHTML).not.toMatch(/bg-white|bg-gray-/);
+  });
+
+  test('variante row renderiza fila liviana con círculo', () => {
+    const { container } = render(<SkeletonList count={2} variant="row" />);
+    expect(container.innerHTML).toMatch(/rounded-full/);
+  });
+
+  test('count mínimo 1 aunque pasen 0', () => {
+    render(<SkeletonList count={0} />);
+    expect(screen.getByTestId('skeleton-list').children.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Primera impresión del productor nuevo (0 plantas, 0 lugares) y momentos
de espera, sin tocar lógica de datos:

- common/EmptyState.jsx: estado vacío/error/offline reutilizable con
  icono en anillo punteado, CTA conectado al flujo existente, variantes
  empty/error/offline, tamaños full/compact, role=status. Incluye
  OfflineNotice (offline-first: 'sus datos están a salvo').
- common/SkeletonList.jsx: skeletons con la silueta real de las cards
  (percepción de rapidez en gama baja, cero salto de layout). Un solo
  role=status; hijos aria-hidden.
- common/Skeleton.jsx: animate-pulse → motion-safe:animate-pulse
  (prefers-reduced-motion).
- AssetsDashboard: vacío raíz de Mis Plantas pasa de jerga técnica
  ('Crea una zona (asset--land) desde FarmOS') a invitación con CTA
  'Registrar mi primera siembra'; spinner de lista → SkeletonList;
  vacío por pestaña con CTA que abre el form existente; banner de error
  con Reintentar (syncFromServer) y modo offline calmado (OfflineNotice).
- AssetTimeline: vacío de 30 días migrado a EmptyState.
- Directorio de especies + strings sueltos: tuteo → usted (Pruebe,
  elija, Busque, Reasigne, La podrá mover).
- Tests: EmptyState (8) + SkeletonList (7); suites afectadas verdes
  (49 tests) y build de producción OK.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
