### PR TITLE
fix(topbar): truncar vereda larga en pill de ubicación, evitar desborde de iconos

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -61,6 +61,14 @@ jobs:
           # deploy.yml (prod) → prod conserva el colibrí 2D / video actual.
           VITE_COLIBRI: "true"
           VITE_CHAGRA_MCP_TOKEN: ${{ secrets.VITE_CHAGRA_MCP_TOKEN }}
+          # AVATAR-ESPIRITU / módulos Pro: mismo valor y patrón que deploy.yml
+          # (prod). Sin esta variable, loadProModules.js ni intenta el import
+          # dinámico y en dev #/espiritu caía SIEMPRE al fallback "no
+          # disponible en su plan" aunque los bundles Pro estuvieran servidos.
+          # Los bundles viven montados en el docroot bajo /pro-modules/ (FUERA
+          # del repo público — anti-leak OSS/Pro); si el path no resuelve, el
+          # import falla en silencio y la UI degrada a build puro OSS.
+          VITE_PRO_MODULES_PATH: "/pro-modules"
 
       - if: env.SKIP_DEPLOY != '1'
         name: Deploy to dev
@@ -87,8 +95,13 @@ jobs:
           # tocar sus permisos/borrarlo con --delete y aborta con exit 23
           # (partial transfer) -> deploy PARCIAL -> index.html referencia
           # assets que nunca se copiaron -> pantalla negra. Lo dejamos intacto.
+          #
+          # --exclude='/pro-modules/': bundles Pro pre-construidos montados
+          # manualmente en el docroot (NO vienen en dist/ — anti-leak OSS/Pro,
+          # ver VITE_PRO_MODULES_PATH arriba y deploy.yml de prod). Sin el
+          # exclude, --delete los borraria en cada deploy de dev.
           rsync -avzO --no-perms --delete --no-group --chmod=F644 \
-            --exclude='/assets/' --exclude='/mockups/' dist/ "$TARGET/"
+            --exclude='/assets/' --exclude='/mockups/' --exclude='/pro-modules/' dist/ "$TARGET/"
           rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ "$TARGET/assets/"
           find "$TARGET/assets/" -type f -mtime +30 -delete || true
           find "$TARGET" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true

--- a/scripts/__tests__/bench-contaminacion.test.mjs
+++ b/scripts/__tests__/bench-contaminacion.test.mjs
@@ -40,6 +40,7 @@ import {
   sidecarReachableLocally,
   generateMarkdownReport,
   buildEnrichedSystemPrompt,
+  companionSpeciesGuard,
 } from '../bench-contaminacion.mjs';
 
 /** Stub por defecto del guard piso térmico: sin desajuste, no-op — evita que
@@ -384,6 +385,34 @@ describe('buildEnrichedSystemPrompt (guard piso térmico chagra-pro #288)', () =
   });
 });
 
+describe('companionSpeciesGuard (post-LLM cross_thermal)', () => {
+  it('devuelve bloque y flag cuando el sidecar corrige una respuesta', async () => {
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        has_companion_species: true,
+        system_prompt_block: '[GUARD COMPANION SPECIES] Corrige la compania.',
+      }),
+    });
+    const res = await companionSpeciesGuard('respuesta del agente', { sidecarUrl: 'http://sidecar', fetchImpl });
+    expect(res).toEqual({
+      has_companion_species: true,
+      system_prompt_block: '[GUARD COMPANION SPECIES] Corrige la compania.',
+    });
+  });
+
+  it('degrada a bloque vacio si el sidecar cae', async () => {
+    const fetchImpl = async () => { throw new Error('down'); };
+    const res = await companionSpeciesGuard('respuesta del agente', { sidecarUrl: 'http://sidecar', fetchImpl });
+    expect(res).toEqual({
+      has_companion_species: false,
+      system_prompt_block: '',
+      error: 'down',
+    });
+  });
+});
+
 // ── orquestación: resolveFn/callFn/validateFn INYECTADOS (sin red real) ────
 
 describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
@@ -555,6 +584,53 @@ describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
       });
       expect(out.error).toBeNull();
       expect(out.pest_vs_disease_guard_fired).toBe(false);
+    });
+  });
+
+  describe('wiring /companion-species-guard (bench honesto, post-LLM cross_thermal)', () => {
+    const crossThermalProbe = { id: 'ct1', type: 'cross_thermal', query: 'respuesta cruzada', subject: 'S' };
+
+    it('has bloque → antepone la correccion y marca companion_species_guard_fired', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      let seenResponse = null;
+      const callFn = async () => ({ response: 'respuesta base', error: null });
+      const validateFn = async (_query, response) => {
+        seenResponse = response;
+        return { hallucinated: [], detected_count: 0 };
+      };
+      const companionSpeciesFn = async () => ({
+        has_companion_species: true,
+        system_prompt_block: '[GUARD COMPANION SPECIES] Corrige la compania.',
+      });
+      const out = await runProbeAgainstAgent(crossThermalProbe, {
+        resolveFn,
+        callFn,
+        validateFn,
+        pisoTermicoFn: noMismatchPisoTermicoFn,
+        confusionEspecieFn: noConfusionEspecieFn,
+        pestVsDiseaseFn: noPestVsDiseaseFn,
+        companionSpeciesFn,
+      });
+      expect(seenResponse.startsWith('[GUARD COMPANION SPECIES] Corrige la compania.')).toBe(true);
+      expect(out.companion_species_guard_fired).toBe(true);
+    });
+
+    it('companionSpeciesFn caido → degrada limpio y no marca firing', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      const callFn = async () => ({ response: 'respuesta base', error: null });
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const companionSpeciesFn = async () => ({ has_companion_species: false, system_prompt_block: '', error: 'ECONNREFUSED' });
+      const out = await runProbeAgainstAgent(crossThermalProbe, {
+        resolveFn,
+        callFn,
+        validateFn,
+        pisoTermicoFn: noMismatchPisoTermicoFn,
+        confusionEspecieFn: noConfusionEspecieFn,
+        pestVsDiseaseFn: noPestVsDiseaseFn,
+        companionSpeciesFn,
+      });
+      expect(out.companion_species_guard_fired).toBe(false);
+      expect(out.error).toBeNull();
     });
   });
 });

--- a/scripts/bench-contaminacion.mjs
+++ b/scripts/bench-contaminacion.mjs
@@ -82,6 +82,7 @@ import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { performance } from 'node:perf_hooks';
+import { prependCorrectionBlock } from '../src/components/AgentScreen/responseGuards.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
@@ -660,6 +661,41 @@ async function pestVsDiseaseGuard(userMessage, { sidecarUrl = SIDECAR_URL } = {}
 }
 
 /**
+ * companionSpeciesGuard — llama al endpoint POST-LLM `/companion-species-guard`.
+ * El bench lo invoca solo para las sondas cross_thermal, sobre la respuesta ya
+ * generada, para medir si el guard hubiera corregido el turno real.
+ *
+ * FAIL-SAFE: cualquier error/timeout/non-2xx degrada a bloque vacio.
+ * @param {string} responseText
+ * @param {{ sidecarUrl?: string }} [opts]
+ * @returns {Promise<{ has_companion_species: boolean, system_prompt_block: string }>}
+ */
+export async function companionSpeciesGuard(
+  responseText,
+  { sidecarUrl = SIDECAR_URL, fetchImpl = fetch } = {},
+) {
+  const token = getSidecarToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+  try {
+    const res = await fetchImpl(`${sidecarUrl}/companion-species-guard`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ response: responseText }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return { has_companion_species: false, system_prompt_block: '' };
+    const data = await res.json();
+    return {
+      has_companion_species: data.has_companion_species === true || data.has_companion === true || data.needs_correction === true,
+      system_prompt_block: typeof data.system_prompt_block === 'string' ? data.system_prompt_block : '',
+    };
+  } catch (err) {
+    return { has_companion_species: false, system_prompt_block: '', error: err.message };
+  }
+}
+
+/**
  * buildEnrichedSystemPrompt — arma el system prompt que ve el modelo en la
  * fase remote-run. `pisoTermicoBlock`/`confusionEspecieBlock`/
  * `pestVsDiseaseBlock` (opcionales) son los `system_prompt_block` YA
@@ -783,6 +819,7 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     pisoTermicoFn = pisoTermicoGuard,
     confusionEspecieFn = confusionEspecieGuard,
     pestVsDiseaseFn = pestVsDiseaseGuard,
+    companionSpeciesFn = companionSpeciesGuard,
   } = opts;
   const t0 = performance.now();
   const [{ entities }, pisoTermico, confusionEspecie, pestVsDisease] = await Promise.all([
@@ -801,7 +838,16 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     ? pestVsDisease.system_prompt_block
     : '';
   const systemPrompt = buildEnrichedSystemPrompt(entities, pisoTermicoBlock, confusionEspecieBlock, pestVsDiseaseBlock);
-  const { response, error } = await callFn(model, systemPrompt, probe.query);
+  const { response: rawResponse, error } = await callFn(model, systemPrompt, probe.query);
+  let response = rawResponse;
+  let companionSpeciesBlock = '';
+  if (!error && probe.type === 'cross_thermal') {
+    const companionSpecies = await companionSpeciesFn(rawResponse);
+    if (companionSpecies && typeof companionSpecies.system_prompt_block === 'string' && companionSpecies.system_prompt_block.trim()) {
+      companionSpeciesBlock = companionSpecies.system_prompt_block;
+      response = prependCorrectionBlock(response, companionSpeciesBlock);
+    }
+  }
   const validation = error ? { hallucinated: [], detected_count: 0 } : await validateFn(probe.query, response);
   return {
     id: probe.id,
@@ -815,6 +861,7 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     piso_termico_guard_fired: Boolean(pisoTermicoBlock),
     confusion_especie_guard_fired: Boolean(confusionEspecieBlock),
     pest_vs_disease_guard_fired: Boolean(pestVsDiseaseBlock),
+    companion_species_guard_fired: Boolean(companionSpeciesBlock),
     halluc_detected_count: validation.detected_count,
     latency_ms: Math.round(performance.now() - t0),
   };

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -47,7 +47,7 @@ import { createStreamDeadline } from '../../services/streamDeadline';
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, pisoTermicoGuard, confusionEspecieGuard, pestVsDiseaseGuard, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, pisoTermicoGuard, confusionEspecieGuard, pestVsDiseaseGuard, companionSpeciesGuard, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
@@ -113,6 +113,7 @@ import { selectChipDefs } from '../../services/profileChipSelector';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import { captureExchange } from '../../services/conversationCaptureService';
 import { regionFromProfile, getEnsoOutlook } from '../../services/ensoContext';
+import { prependCorrectionBlock } from './responseGuards';
 // SALUDO PROACTIVO (#162 alertas + #298 tareas + #331 análisis): el agente, de
 // entrada, lidera con lo MÁS importante (1-2 pendientes) si los hay, o da una
 // idea contextual (cultivo/clima/temporada) sin inventar alarmas. Lógica pura
@@ -2284,7 +2285,26 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // `valid`—. La cobertura taxonómica la dan los guards síncronos de
       // applyOutputGuards (#1332 binomio benéfico + 5/5b sustitución/companion)
       // y el grounding de resolve-entities. Ver outputGuards.js.
-      const responseBody = guarded.text;
+      let responseBody = guarded.text;
+      let responseAutoCorrected = guarded.modified === true;
+      // GUARDA POST-LLM de companion species: valida la respuesta ya generada
+      // contra el catalogo. Si dispara, anteponemos el bloque de correccion al
+      // turno final sin romper el flujo si el sidecar falla.
+      if (isOnline && isSidecarEnabled()) {
+        try {
+          const companionSpecies = await companionSpeciesGuard(responseBody);
+          if (companionSpecies && typeof companionSpecies.system_prompt_block === 'string' && companionSpecies.system_prompt_block.trim()) {
+            responseBody = prependCorrectionBlock(responseBody, companionSpecies.system_prompt_block);
+            responseAutoCorrected = true;
+            console.debug('[sidecar] companion-species-guard', {
+              hasCompanionSpecies: companionSpecies.has_companion_species,
+              reason: companionSpecies.reason,
+            });
+          }
+        } catch (companionErr) {
+          console.debug('[sidecar] companion-species-guard fail (sigo sin bloque):', companionErr?.message);
+        }
+      }
       agentSounds.chime();
 
       const { intent } = parseIntent(text);
@@ -2345,7 +2365,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         ...evidenceSourceLink,
         ...groundingBadges,
         ...groundingSemaphoreMeta,
-        auto_corrected: guarded.modified === true,
+        auto_corrected: responseAutoCorrected,
       };
       const profileMode = (() => {
         try {

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3504,7 +3504,8 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           44px + gaps + padding sumaban más que el viewport → el título se
           encimaba con los íconos y el avatar pisaba el texto; en 412px el
           subtítulo se clipaba sin gracia. Fix: padding/gap compactos bajo
-          400px, botón Home oculto bajo 360px (Volver sigue presente), avatar
+          400px, botón Home oculto bajo 420px (Volver sigue presente; QA temas
+          2026-07-09: en 390px el Home dejaba el título en "Chag…"), avatar
           shrink-0 y subtítulo con truncate (elipsis, nunca encimado). */}
       <header className="px-2 min-[400px]:px-4 py-3 flex items-center gap-1 min-[400px]:gap-2 border-b border-slate-800 agent-bar-surface shrink-0">
         {/* Back */}
@@ -3520,7 +3521,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         <button
           type="button"
           onClick={() => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'dashboard' }))}
-          className="max-[359px]:hidden p-3 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:bg-emerald-700/60 transition-all text-emerald-400 min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
+          className="max-[419px]:hidden p-3 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:bg-emerald-700/60 transition-all text-emerald-400 min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
           aria-label="Volver al inicio"
           title="Inicio"
         >

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -155,6 +155,7 @@ vi.mock('../../../services/sidecarClient', () => ({
   pisoTermicoGuard: vi.fn(),
   confusionEspecieGuard: vi.fn(),
   pestVsDiseaseGuard: vi.fn(),
+  companionSpeciesGuard: vi.fn(),
   postValidate: vi.fn(),
   getClimaIdeam: vi.fn(),
   isToolAllowed: vi.fn(() => false),

--- a/src/components/AgentScreen/__tests__/responseGuards.test.js
+++ b/src/components/AgentScreen/__tests__/responseGuards.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { prependCorrectionBlock } from '../responseGuards';
+
+describe('prependCorrectionBlock', () => {
+  it('antepone un bloque de correccion a la respuesta', () => {
+    const out = prependCorrectionBlock(
+      'Esta es la respuesta original.',
+      '[CORRECCION] La companion species correcta es otra.',
+    );
+    expect(out).toBe('[CORRECCION] La companion species correcta es otra.\n\nEsta es la respuesta original.');
+  });
+
+  it('es idempotente si el bloque ya esta al inicio', () => {
+    const block = '[CORRECCION] La companion species correcta es otra.';
+    const first = prependCorrectionBlock('Respuesta base.', block);
+    const second = prependCorrectionBlock(first, block);
+    expect(second).toBe(first);
+  });
+
+  it('degrada sin romper si no hay bloque util', () => {
+    expect(prependCorrectionBlock('Respuesta base.', '')).toBe('Respuesta base.');
+    expect(prependCorrectionBlock('Respuesta base.', '   ')).toBe('Respuesta base.');
+    expect(prependCorrectionBlock(null, '[CORRECCION] A')).toBe('[CORRECCION] A');
+  });
+});

--- a/src/components/AgentScreen/responseGuards.js
+++ b/src/components/AgentScreen/responseGuards.js
@@ -1,0 +1,22 @@
+/**
+ * Helpers de respuesta del AgentScreen.
+ *
+ * Mantienen la correccion post-LLM como bloque de prefijo, sin duplicarla si
+ * ya entro antes en el mismo turno.
+ */
+
+/**
+ * Antepone un bloque de correccion a la respuesta, de forma idempotente.
+ *
+ * @param {string} responseText
+ * @param {string} correctionBlock
+ * @returns {string}
+ */
+export function prependCorrectionBlock(responseText, correctionBlock) {
+  const response = typeof responseText === 'string' ? responseText : '';
+  const block = typeof correctionBlock === 'string' ? correctionBlock.trim() : '';
+  if (!block) return response;
+  if (!response) return block;
+  if (response.startsWith(block)) return response;
+  return `${block}\n\n${response}`;
+}

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -1645,12 +1645,16 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
   return (
     <div className="h-[100dvh] w-full bg-slate-950 text-slate-100 flex flex-col overflow-hidden">
       {/* Header */}
-      <header className="p-4 bg-slate-950 border-b border-slate-800 flex items-center gap-4 shrink-0 shadow-md">
+      {/* QA temas 2026-07-09: en 390px el título flex-1 no podía encoger (sin
+          min-w-0) y el grupo de acciones empujaba el botón de sincronizar
+          FUERA del borde derecho. Gap/padding compactos en angosto + título
+          truncable + nombre de finca más corto → los 4 controles caben. */}
+      <header className="px-2 py-4 min-[480px]:px-4 bg-slate-950 border-b border-slate-800 flex items-center gap-2 min-[480px]:gap-4 shrink-0 shadow-md">
         <button onClick={/** @type {React.MouseEventHandler<HTMLButtonElement>} */ (onBack)} aria-label="Volver al panel principal" className="p-3 bg-slate-800 rounded-full active:bg-slate-700 min-h-[48px] min-w-[48px] flex justify-center items-center shrink-0">
           <ArrowLeft size={24} aria-hidden="true" />
         </button>
-        <h2 className="text-2xl font-black flex-1">Activos</h2>
-        <div className="flex items-center gap-2">
+        <h2 className="text-xl min-[480px]:text-2xl font-black flex-1 min-w-0 truncate">Activos</h2>
+        <div className="flex items-center gap-1.5 min-[480px]:gap-2 shrink-0">
           {/* Toggle Lista / Mapa (Fase 17.3) */}
           <div className="flex bg-slate-800 rounded-lg p-1">
             <button
@@ -1681,7 +1685,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
             data-testid="assets-finca-switcher"
           >
             <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse group-hover:scale-125 transition-transform"></div>
-            <span className="truncate max-w-[10ch]">{fincaNombre}</span>
+            <span className="truncate max-w-[7ch] min-[480px]:max-w-[10ch]">{fincaNombre}</span>
             {hasMultipleFincas && (
               <ChevronDown size={12} aria-hidden="true" className="-mr-0.5 opacity-80 group-hover:translate-y-0.5 transition-transform" />
             )}
@@ -1810,10 +1814,12 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
       {viewMode === 'list' && activeTab === 'plant' && !currentZoneId && (
         <div className="flex-1">
           {lands.length === 0 && orphanPlants.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-slate-500">
+            <div className="flex flex-col items-center justify-center py-12 px-6 text-center text-slate-500">
+              {/* QA temas 2026-07-09: el empty-state iba pegado al borde (sin
+                  padding lateral ni text-center) y con jerga técnica en tuteo. */}
               <MapPin size={48} className="mb-3 opacity-30" />
               <p className="text-lg">Sin zonas registradas</p>
-              <p className="text-sm mt-1">Crea una zona (asset--land) desde FarmOS o la tab Infraestructura</p>
+              <p className="text-sm mt-1">Cree su primera zona desde la pestaña Infraestructura, o desde farmOS</p>
             </div>
           ) : (
             <Virtuoso

--- a/src/components/SoilDiagnosticScreen.jsx
+++ b/src/components/SoilDiagnosticScreen.jsx
@@ -10,7 +10,7 @@ import {
   Clock3, Lock, RotateCcw, MessageCircle, Beaker, Skull,
 } from 'lucide-react';
 import SOIL_DATA from '../data/soil-diagnostics.json';
-import { diagnosticarSuelo } from '../services/soilDiagnostic';
+import { diagnosticarSuelo, guardarDiagnosticoSuelo } from '../services/soilDiagnostic';
 import useVoiceRecorder from '../hooks/useVoiceRecorder';
 import { transcribe } from '../services/voiceService';
 import ContextTip from './ContextTip';
@@ -183,6 +183,9 @@ export default function SoilDiagnosticScreen({ onBack, onNavigate }) {
     }
     setSinMatch(false);
     setDiag(d);
+    // Persistir el diagnóstico REAL: el home (panel de vitalidad, eje 🪱)
+    // lo lee con getDiagnosticoSueloGuardado — deja de decir "dato en camino".
+    guardarDiagnosticoSuelo(d);
     setPaso('diagnostico');
   }, [descripcion]);
 

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -169,7 +169,7 @@ export default function TopBar({ onNavigate, onLogout }) {
           onClick={() => onNavigate('dashboard')}
           aria-label={isBreathing ? 'Chagra está procesando' : 'Volver al inicio'}
           title={isBreathing ? 'Chagra está pensando…' : 'Volver al inicio'}
-          className="font-bold flex items-center gap-2 shrink-0 rounded-lg px-2 py-1 hover:bg-slate-800/60 active:bg-slate-700 transition-colors min-h-[44px]"
+          className="font-bold flex items-center gap-2 min-w-0 shrink rounded-lg px-2 py-1 hover:bg-slate-800/60 active:bg-slate-700 transition-colors min-h-[44px]"
         >
           {/* Ícono del tema (A de anarquía o similar según tema) */}
           <span
@@ -186,7 +186,7 @@ export default function TopBar({ onNavigate, onLogout }) {
               su mano en el campo
             </span>
             {locationLabel && (
-              <span className="mt-1 inline-block whitespace-normal break-words rounded-lg border border-emerald-400/20 bg-emerald-950/25 px-2 py-1 text-[10px] leading-snug text-emerald-200/95 font-medium max-w-[50vw]">
+              <span className="mt-1 truncate max-w-[min(50vw,200px)] min-w-0 shrink rounded-lg border border-emerald-400/20 bg-emerald-950/25 px-2 py-1 text-[10px] leading-snug text-emerald-200/95 font-medium">
                 {locationLabel}
               </span>
             )}

--- a/src/components/TuberculosScreen.jsx
+++ b/src/components/TuberculosScreen.jsx
@@ -9,6 +9,8 @@ import {
   Shovel, Camera, Utensils, ExternalLink,
 } from 'lucide-react';
 import { TUBERCULOS, getTuberculo, tieneDato, DATO_EN_CAMINO, FUENTES_INSTITUCIONALES } from '../services/tuberculosData';
+import LaminaSiembra from './tuberculos/LaminaSiembra';
+import LaminaAporque from './tuberculos/LaminaAporque';
 
 /**
  * TuberculosScreen — mini-app "Tubérculos y raíces" (mundo Cultivos y semillas).
@@ -175,6 +177,15 @@ function Hub({ onSel }) {
         <p className="mt-1.5 text-sm text-slate-300 leading-relaxed">
           Los tubérculos y raíces se siembran de un pedazo de la misma mata. Estas son las tres formas:
         </p>
+        {/* Lámina propia (SVG de cuaderno de campo): las tres formas de siembra en corte. */}
+        <div className="mt-3 rounded-xl border border-slate-800 bg-slate-950/40 px-2 py-2">
+          <LaminaSiembra />
+          <div className="mt-0.5 grid grid-cols-3 gap-1 text-center text-[10px] font-semibold text-lime-200/90">
+            <span>Tubérculo-semilla</span>
+            <span>Esqueje / estaca</span>
+            <span>Colino</span>
+          </div>
+        </div>
         <div className="mt-3 grid grid-cols-1 sm:grid-cols-3 gap-2.5">
           {FORMAS_SIEMBRA.map((f) => {
             const Icono = f.icon;
@@ -256,6 +267,10 @@ function Ficha({ t, onNavigate }) {
 
       {/* Aporque — propio de los tubérculos */}
       <Bloque icon={Shovel} accent={c} titulo="Aporque">
+        {/* Lámina propia (SVG en corte): arrimar tierra al pie tapa el cuello. */}
+        <div className="mb-2.5 rounded-xl border border-slate-800 bg-slate-950/40 px-2 py-2">
+          <LaminaAporque />
+        </div>
         <p className="text-sm text-slate-200 leading-relaxed">{t.aporque}</p>
       </Bloque>
 

--- a/src/components/TuberculosScreen.test.jsx
+++ b/src/components/TuberculosScreen.test.jsx
@@ -32,6 +32,11 @@ describe('TuberculosScreen — hub', () => {
     // El explicador "casi ninguno se siembra de semilla"
     expect(screen.getByText(/Casi ninguno se siembra de semilla/i)).toBeInTheDocument();
   });
+
+  it('el hub trae la lámina SVG propia de las tres formas de siembra', () => {
+    render(<TuberculosScreen onBack={vi.fn()} onNavigate={vi.fn()} />);
+    expect(screen.getByTestId('lamina-siembra')).toBeInTheDocument();
+  });
 });
 
 describe('TuberculosScreen — ficha de cultivo', () => {
@@ -56,6 +61,9 @@ describe('TuberculosScreen — ficha de cultivo', () => {
     // Plaga insignia de la papa grounded en el grafo + manejo biológico
     expect(screen.getByText(/tizón tardío/i)).toBeInTheDocument();
     expect(screen.getByText(/Polilla guatemalteca de la papa/i)).toBeInTheDocument();
+
+    // La ficha trae la lámina SVG propia del aporque (en corte)
+    expect(screen.getByTestId('lamina-aporque')).toBeInTheDocument();
   });
 
   it('la batata muestra el picudo (Cylas) groundeado con su control biológico', () => {

--- a/src/components/dashboard/ArbolDeMundos.jsx
+++ b/src/components/dashboard/ArbolDeMundos.jsx
@@ -1,0 +1,297 @@
+/*
+ * i18n (ADR-050): copy de navegación del home en español Colombia, pendiente
+ * de migrar a src/config/messages.js — mismo criterio que MundosDeMiFinca.
+ */
+ 
+/**
+ * ArbolDeMundos — el MENÚ-ÁRBOL ORGÁNICO del home biopunk (pieza del mockup
+ * final aprobado #/mockups/avatar-biopunk, "El Espíritu de tu Finca"):
+ * los mundos de la finca como RAMAS VIVAS que brotan del corazón-semilla,
+ * cada rama termina en una VAINA (membrana + núcleo + glifo) que es la
+ * ENTRADA a su mundo, con glow neón y savia fluyendo.
+ *
+ * NO es navegación huérfana ni paralela: la fuente única de mundos y rutas es
+ * mundosFinca.js (la MISMA del menú vivo MundosDeMiFinca) y cada vaina navega
+ * EXACTO igual que su tarjeta: portada → onNavigate(portada) · directo →
+ * onNavigate(view, data) · resto → onNavigate('mundo', { mundo: id }).
+ * La grilla de tarjetas queda INTACTA justo debajo (fallback simple y
+ * contrato de reachability): el árbol es la vista rica del tema biopunk.
+ *
+ * GROUNDED — las ramas dependen de lo que la finca real tiene:
+ *   · el mundo Animales solo brota si el perfil lo tiene (mismo gate
+ *     `mostrarAnimales` de DashboardLive: un urbano de balcón no lo ve);
+ *   · la rama de Cultivos muestra el conteo REAL de matas sembradas
+ *     (useAssetStore.plants vía prop, el mismo sello de la grilla);
+ *   · al pie, el RELOJ DEL FRAILEJÓN cuenta los años REALES de la finca en
+ *     Chagra (un anillo por año — fincaClockService, nunca inventa historia).
+ *
+ * Solo se monta con la piel biopunk (biopunk / biopunk2, la default); en los
+ * demás temas devuelve null y el home queda como está. Accesibilidad: cada
+ * vaina es role=button con Enter/Espacio, target grande (hit-area invisible
+ * r=30 ≈ 60px en móvil) y foco visible; todas las animaciones viven en
+ * arbol-de-mundos.css y respetan prefers-reduced-motion (estado estático
+ * digno, misma receta que SceneFincaOrganismo). SVG rsvg-safe (sin
+ * foreignObject), cero JS por frame.
+ *
+ * @param {Object} props
+ * @param {(view: string, data?: any) => void} props.onNavigate
+ * @param {boolean} [props.mostrarAnimales] gate por perfil del mundo Animales.
+ * @param {number} [props.plantsCount] matas sembradas reales (sello vivo).
+ */
+import { MUNDOS_FINCA } from './mundosFinca';
+import { useTheme, resolveAutoTheme, BASE_SKIN_THEMES } from '../../hooks/useTheme';
+import RelojFrailejon from './RelojFrailejon';
+import './arbol-de-mundos.css';
+
+/* ── Coreografía del árbol (viewBox 390×800) ──────────────────────────────
+ * Cada mundo tiene su lugar en la copa (o en la raíz): `node` = dónde vive
+ * la vaina, `origen` = de qué punto del tronco brota su rama, `s` = escala
+ * (profundidad: arriba lejos/pequeño, abajo cerca/grande), `acc` = acento
+ * neón propio, `raiz` = brota bajo tierra (suelo vivo, abono).
+ * Los ids son los del manifiesto mundosFinca.js; un mundo futuro sin lugar
+ * propio cae a un SLOT de reserva sobre el tronco (nunca queda huérfano). */
+const LAYOUT = {
+  cana: { node: [195, 92], origen: [195, 150], s: 0.86, acc: '#d8ff6a' },
+  clima: { node: [320, 96], origen: [195, 178], s: 0.86, acc: '#b28dff' },
+  cultivos: { node: [64, 128], origen: [195, 210], s: 1.12, acc: '#9dff3f' },
+  mercado: { node: [304, 188], origen: [195, 254], s: 0.9, acc: '#ffb54f' },
+  sanidad: { node: [122, 212], origen: [195, 270], s: 0.9, acc: '#ff4fd8' },
+  disenio: { node: [336, 278], origen: [195, 332], s: 0.94, acc: '#2dffc4' },
+  botica: { node: [52, 292], origen: [195, 346], s: 0.94, acc: '#9dff3f' },
+  animales: { node: [292, 366], origen: [195, 416], s: 1, acc: '#ffb54f' },
+  cafe: { node: [112, 372], origen: [195, 424], s: 1.04, acc: '#ff9d3f' },
+  mango: { node: [340, 448], origen: [195, 494], s: 0.96, acc: '#ffd76a' },
+  agua: { node: [52, 452], origen: [195, 500], s: 1, acc: '#4fd8ff' },
+  citricos: { node: [296, 522], origen: [195, 560], s: 1, acc: '#ff9d3f' },
+  aguacate: { node: [98, 528], origen: [195, 566], s: 1.02, acc: '#9dff3f' },
+  suelo: { node: [112, 722], origen: [195, 654], s: 1.02, acc: '#9dff3f', raiz: true },
+  abono: { node: [278, 726], origen: [195, 657], s: 0.98, acc: '#d8a24f', raiz: true },
+};
+
+/** Slots de reserva (sobre el tronco) para mundos futuros sin lugar propio. */
+const SLOTS_RESERVA = [
+  { node: [195, 244], origen: [195, 292], s: 0.9, acc: '#2dffc4' },
+  { node: [195, 396], origen: [195, 446], s: 0.94, acc: '#2dffc4' },
+  { node: [195, 474], origen: [195, 522], s: 0.94, acc: '#2dffc4' },
+];
+
+/** Curva orgánica tronco→vaina (rama) o tronco→punta (raíz). */
+function ramaD([ox, oy], [nx, ny]) {
+  const dir = ny < oy ? -1 : 1; // -1 = rama que sube · 1 = raíz que baja
+  const dy = Math.abs(oy - ny);
+  const c1x = ox + (nx - ox) * 0.22;
+  const c1y = oy + dir * Math.max(14, dy * 0.18);
+  const c2x = nx - (nx - ox) * 0.24;
+  const c2y = ny - dir * Math.max(16, dy * 0.3);
+  return `M${ox},${oy} C${c1x},${c1y} ${c2x},${c2y} ${nx},${ny}`;
+}
+
+/** Etiqueta-cápsula dentro del SVG (misma receta del mockup aprobado). */
+function TagSvg({ x, y, texto }) {
+  const w = texto.length * 4.6 + 16;
+  return (
+    <g className="adm-tag" aria-hidden="true">
+      <rect x={x - w / 2} y={y} width={w} height="13" rx="6.5" fill="rgba(4,10,28,0.78)" stroke="rgba(45,255,196,0.35)" strokeWidth="0.6" />
+      <text x={x} y={y + 8.8} textAnchor="middle" fontFamily="ui-monospace,monospace" fontSize="6.5" letterSpacing="1.2" fill="#bfffe9">
+        {texto}
+      </text>
+    </g>
+  );
+}
+
+/**
+ * Una rama viva: el trazo con savia + la vaina-entrada del mundo.
+ * La vaina completa es el botón (membrana + núcleo + glifo + etiqueta), con
+ * un hit-area invisible r=30 (~60px en móvil) para dedos de campo.
+ */
+function RamaMundo({ mundo, lugar, sello, onOpen }) {
+  const [nx, ny] = lugar.node;
+  const d = ramaD(lugar.origen, lugar.node);
+  const entrar = () => onOpen(mundo);
+  const tecla = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpen(mundo); }
+  };
+  return (
+    <g className="adm-rama" style={{ '--adm-acc': lugar.acc }}>
+      {/* la rama: corteza + brillo + savia que fluye hacia la vaina */}
+      <path d={d} fill="none" stroke={lugar.raiz ? '#6b8f2f' : '#0f8f6c'} strokeWidth="3.4" strokeLinecap="round" opacity="0.9" />
+      <path d={d} fill="none" stroke={lugar.acc} strokeWidth="1" strokeLinecap="round" opacity="0.45" />
+      <path className="adm-sap" d={d} fill="none" stroke="#9dff3f" strokeWidth="1.2" strokeLinecap="round" opacity="0.9" />
+
+      <g
+        className="adm-vaina adm-nodo"
+        transform={`translate(${nx},${ny}) scale(${lugar.s})`}
+        role="button"
+        tabIndex={0}
+        aria-label={`Entrar al mundo ${mundo.titulo}: ${mundo.lema}`}
+        data-testid={`arbol-rama-${mundo.id}`}
+        onClick={entrar}
+        onKeyDown={tecla}
+      >
+        {/* hit-area generosa (target táctil grande, invisible) */}
+        <circle r="30" fill="transparent" stroke="none" />
+        <ellipse className="adm-vaina-halo" rx="20" ry="24" fill="url(#adm-bulbo)" />
+        <path
+          className="adm-vaina-membrana"
+          d="M0,-20 C11,-18 15.5,-8 14.5,2 C13.5,13 8,20.5 0,22 C-8,20.5 -13.5,13 -14.5,2 C-15.5,-8 -11,-18 0,-20 Z"
+          fill="rgba(7,16,48,0.88)"
+          stroke={lugar.acc}
+          strokeWidth="1.2"
+        />
+        <path d="M0,-16 C5,-9 5,9 0,17" fill="none" stroke="#9dff3f" strokeWidth="0.6" opacity="0.5" />
+        <path d="M0,-16 C-5,-9 -5,9 0,17" fill="none" stroke="#9dff3f" strokeWidth="0.6" opacity="0.5" />
+        <circle className="adm-vaina-nucleo" r="9" fill="url(#adm-nucleo)" />
+        <text y="4.5" textAnchor="middle" fontSize="11" aria-hidden="true">{mundo.emoji}</text>
+        <circle className="adm-espora" cy="-24" r="1.3" fill="#eafff6" />
+        <TagSvg x={0} y={27} texto={mundo.titulo.toUpperCase()} />
+        {/* sello GROUNDED: dato real, nunca inventado (hoy: matas en Cultivos) */}
+        {sello && <TagSvg x={0} y={42} texto={sello.toUpperCase()} />}
+      </g>
+    </g>
+  );
+}
+
+export default function ArbolDeMundos({ onNavigate, mostrarAnimales = true, plantsCount = 0 }) {
+  const { theme } = useTheme();
+  const temaEfectivo = resolveAutoTheme(theme);
+  // Vista rica SOLO de la piel biopunk (biopunk2 = default). En los demás
+  // temas el menú vivo queda como está (la grilla de mundos).
+  if (!BASE_SKIN_THEMES.includes(temaEfectivo)) return null;
+
+  // GROUNDED: mismas reglas de visibilidad que la grilla (gate Animales).
+  const mundos = MUNDOS_FINCA.filter((m) => m.gate !== 'animales' || mostrarAnimales);
+
+  // MISMO enrutado que MundosDeMiFinca.abrir (destinos idénticos, no huérfano).
+  const abrir = (m) => {
+    if (m.portada) onNavigate?.(m.portada);
+    else if (m.directo) onNavigate?.(m.directo.view, m.directo.data);
+    else onNavigate?.('mundo', { mundo: m.id });
+  };
+
+  // Sello vivo (dato real): hoy solo Cultivos lleva el conteo de matas.
+  const sello = (m) => {
+    if (m.id === 'cultivos' && plantsCount > 0) {
+      return plantsCount === 1 ? '1 mata sembrada' : `${plantsCount} matas sembradas`;
+    }
+    return null;
+  };
+
+  // Mundo futuro sin lugar coreografiado → slot de reserva (nunca huérfano).
+  let reservaIdx = 0;
+  const lugarDe = (m) => LAYOUT[m.id]
+    || SLOTS_RESERVA[Math.min(reservaIdx++, SLOTS_RESERVA.length - 1)];
+
+  return (
+    <section
+      className="adm"
+      aria-label="El árbol de los mundos de su finca: cada rama es un mundo, toque una rama para entrar"
+      data-testid="arbol-mundos"
+    >
+      <header className="adm-head">
+        <h2 className="adm-tit">El árbol de su finca</h2>
+        <p className="adm-sub">
+          Del corazón de la finca brota una rama viva por cada mundo —
+          toque una rama para entrar a su mundo.
+        </p>
+      </header>
+
+      <div className="adm-lienzo">
+        <svg
+          className="adm-svg"
+          viewBox="0 0 390 800"
+          role="presentation"
+          focusable="false"
+        >
+          <defs>
+            <radialGradient id="adm-bulbo" cx="0.5" cy="0.5" r="0.5">
+              <stop offset="0" stopColor="#2dffc4" stopOpacity="0.9" />
+              <stop offset="0.55" stopColor="#2dffc4" stopOpacity="0.25" />
+              <stop offset="1" stopColor="#2dffc4" stopOpacity="0" />
+            </radialGradient>
+            <radialGradient id="adm-nucleo" cx="0.5" cy="0.42" r="0.65">
+              <stop offset="0" stopColor="rgba(45,255,196,0.32)" />
+              <stop offset="0.7" stopColor="rgba(45,255,196,0.1)" />
+              <stop offset="1" stopColor="rgba(45,255,196,0)" />
+            </radialGradient>
+            <radialGradient id="adm-corazon" cx="0.5" cy="0.5" r="0.5">
+              <stop offset="0" stopColor="#eafff6" />
+              <stop offset="0.35" stopColor="#2dffc4" />
+              <stop offset="0.8" stopColor="#0a9f74" stopOpacity="0.4" />
+              <stop offset="1" stopColor="#0a9f74" stopOpacity="0" />
+            </radialGradient>
+            <linearGradient id="adm-tallo" x1="0" y1="1" x2="0" y2="0">
+              <stop offset="0" stopColor="#0f8f6c" />
+              <stop offset="1" stopColor="#9dff3f" />
+            </linearGradient>
+            <linearGradient id="adm-suelo-g" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stopColor="rgba(12,16,38,0.96)" />
+              <stop offset="1" stopColor="rgba(2,4,12,0.2)" />
+            </linearGradient>
+          </defs>
+
+          {/* estrellas y cocuyos: la noche viva del biopunk */}
+          <g fill="#dfeffc" aria-hidden="true">
+            <circle className="adm-tw" cx="34" cy="36" r="1.1" />
+            <circle className="adm-tw adm-t2" cx="128" cy="58" r="0.9" />
+            <circle className="adm-tw adm-t3" cx="256" cy="30" r="1" />
+            <circle className="adm-tw" cx="356" cy="150" r="0.9" fill="#2dffc4" />
+            <circle className="adm-tw adm-t2" cx="30" cy="210" r="0.8" fill="#ff4fd8" />
+            <circle className="adm-tw adm-t3" cx="368" cy="330" r="0.9" fill="#9dff3f" />
+            <circle className="adm-tw" cx="22" cy="420" r="0.8" />
+          </g>
+          <circle className="adm-fly" cx="150" cy="300" r="1.6" fill="#d8ff6a" aria-hidden="true" />
+          <circle className="adm-fly adm-f2" cx="250" cy="240" r="1.4" fill="#2dffc4" aria-hidden="true" />
+          <circle className="adm-fly adm-f3" cx="180" cy="440" r="1.4" fill="#ff4fd8" aria-hidden="true" />
+
+          {/* el tronco: del corazón a la yema apical, con savia subiendo */}
+          <g aria-hidden="true">
+            <path d="M186,614 C188,470 190,300 193,150 L197,150 C200,300 202,470 204,614 Z" fill="url(#adm-tallo)" opacity="0.9" />
+            <path d="M186,614 C188,470 190,300 193,150" fill="none" stroke="#2dffc4" strokeWidth="1" opacity="0.55" />
+            <path d="M204,614 C202,470 200,300 197,150" fill="none" stroke="#2dffc4" strokeWidth="1" opacity="0.55" />
+            <path className="adm-sap adm-sap-tronco" d="M195,610 C195,460 195,300 195,152" fill="none" stroke="#d8ff6a" strokeWidth="1.6" strokeLinecap="round" />
+          </g>
+
+          {/* corte de suelo: la tierra donde el árbol hunde sus raíces */}
+          <rect y="650" width="390" height="150" fill="url(#adm-suelo-g)" aria-hidden="true" />
+          <path d="M0,650 L390,650" stroke="#2dffc4" strokeWidth="1.4" opacity="0.55" aria-hidden="true" />
+          <path d="M0,652.5 L390,652.5" stroke="#ff4fd8" strokeWidth="0.7" opacity="0.25" aria-hidden="true" />
+          {/* micelio que teje el subsuelo */}
+          <g fill="none" stroke="#2dffc4" strokeWidth="0.6" opacity="0.35" strokeLinecap="round" aria-hidden="true">
+            <path d="M150,678 C140,672 132,664 128,656 M128,656 C124,648 118,656 110,660" />
+            <path d="M240,682 C252,676 260,668 264,658 M264,658 C268,666 276,662 284,660" />
+            <path d="M60,700 C74,694 88,694 100,700 M290,704 C304,698 318,698 330,704" />
+          </g>
+
+          {/* LAS RAMAS VIVAS: una por mundo real de la finca (fuente única
+              mundosFinca.js — mismo gate y mismas rutas que la grilla) */}
+          {mundos.map((m) => (
+            <RamaMundo key={m.id} mundo={m} lugar={lugarDe(m)} sello={sello(m)} onOpen={abrir} />
+          ))}
+
+          {/* EL CORAZÓN DE LA FINCA: late y bombea savia a todas las ramas */}
+          <g className="adm-corazon-g" aria-hidden="true">
+            <ellipse cx="195" cy="614" rx="38" ry="32" fill="#02040c" opacity="0.55" />
+            <ellipse cx="195" cy="614" rx="38" ry="32" fill="none" stroke="#0f3a30" strokeWidth="1" opacity="0.55" />
+            <circle className="adm-heart-wave" cx="195" cy="614" r="20" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
+            <circle className="adm-heart-wave adm-hw2" cx="195" cy="614" r="20" fill="none" stroke="#ff4fd8" strokeWidth="1" />
+            <circle className="adm-heart" cx="195" cy="614" r="13" fill="url(#adm-corazon)" />
+            <g className="adm-heart">
+              <path d="M195,600 C204,606 204,622 195,628 C186,622 186,606 195,600 Z" fill="#0e5a44" stroke="#2dffc4" strokeWidth="1.4" />
+              <circle cx="195" cy="614" r="4.2" fill="#eafff6" />
+              <circle cx="195" cy="614" r="1.8" fill="#ff8fe4" />
+            </g>
+          </g>
+
+          {/* etiqueta viva del pie (misma voz del mockup aprobado) */}
+          <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity="0.65" aria-hidden="true">
+            <text x="195" y="778" fill="#2dffc4" textAnchor="middle">CORAZÓN DE LA FINCA · VIVO</text>
+            <text x="195" y="790" fill="#5b7f93" textAnchor="middle" letterSpacing="1">toque una rama para entrar a su mundo</text>
+          </g>
+        </svg>
+      </div>
+
+      {/* EL RELOJ DEL FRAILEJÓN: los años reales de la finca, un anillo por año */}
+      <RelojFrailejon onNavigate={onNavigate} />
+    </section>
+  );
+}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -62,6 +62,11 @@ import CicloVivoWidget from '../CicloVivo/CicloVivoWidget';
 // las funciones dispersas del home F2 en 9 mundos coherentes (mundosFinca.js).
 // Solo se monta con la flag F2 ON; el legacy conserva sus tiles.
 import MundosDeMiFinca from './MundosDeMiFinca';
+// SELECTOR DEL GUARDIÁN (espíritu de la finca) — portado del mockup aprobado
+// #/mockups/avatar-biopunk. Fauna nativa colombiana REAL (grounded), la elección
+// persiste en el perfil (userProfileService: guardian_especie). Vive en el menú
+// vivo (ambos layouts) para que sea público, no huérfano.
+import GuardianEspiritu from './GuardianEspiritu';
 import ClimaStrip from './ClimaStrip';
 import HoyEnFincaStrip from './HoyEnFincaStrip';
 import AIStatusFooter from './AIStatusFooter';
@@ -794,6 +799,16 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     </button>
                 </div>
             )}
+
+            {/* SU GUARDIÁN — el espíritu de la finca (mockup #/mockups/avatar-biopunk).
+                Vive en el menú vivo en AMBOS layouts (F2 y legacy/prod) para que sea
+                público y no huérfano. Especies nativas colombianas REALES (grounded);
+                la elección PERSISTE en el perfil (guardian_especie) y re-tiñe su
+                propio HUD + emite chagra:guardian-changed para el saludo/espíritu. */}
+            <div className="px-4 pt-3 fvh-resto-block" data-testid="bloque-guardian">
+                {blockLabel('Su guardián', 'from-teal-400 to-violet-400')}
+                <GuardianEspiritu />
+            </div>
 
             {fincaVivaFlag ? (
             /* ════════════════════════════════════════════════════════════════

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -67,6 +67,7 @@ import MundosDeMiFinca from './MundosDeMiFinca';
 // persiste en el perfil (userProfileService: guardian_especie). Vive en el menú
 // vivo (ambos layouts) para que sea público, no huérfano.
 import GuardianEspiritu from './GuardianEspiritu';
+import ArbolDeMundos from './ArbolDeMundos';
 import ClimaStrip from './ClimaStrip';
 import HoyEnFincaStrip from './HoyEnFincaStrip';
 import AIStatusFooter from './AIStatusFooter';
@@ -901,11 +902,26 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     de Animales por perfil se conserva (mostrarAnimales). */}
                 <div id="bloque-mundos" className="px-4 pt-4 fvh-resto-block" data-testid="bloque-mundos" style={{ scrollMarginTop: '88px' }}>
                     {mundosAbiertos ? (
-                        <MundosDeMiFinca
-                            onNavigate={onNavigate}
-                            mostrarAnimales={mostrarAnimales}
-                            plantsCount={plantsCount}
-                        />
+                        <>
+                            {/* EL ÁRBOL DE SU FINCA (vista rica del tema biopunk,
+                                mockup aprobado #/mockups/avatar-biopunk): los mismos
+                                mundos como RAMAS VIVAS que brotan del corazón + el
+                                RELOJ DEL FRAILEJÓN (años reales, un anillo por año).
+                                Fuente única y rutas = mundosFinca.js; en temas
+                                no-biopunk devuelve null. La grilla de abajo queda
+                                INTACTA (fallback simple y contrato de
+                                reachability). */}
+                            <ArbolDeMundos
+                                onNavigate={onNavigate}
+                                mostrarAnimales={mostrarAnimales}
+                                plantsCount={plantsCount}
+                            />
+                            <MundosDeMiFinca
+                                onNavigate={onNavigate}
+                                mostrarAnimales={mostrarAnimales}
+                                plantsCount={plantsCount}
+                            />
+                        </>
                     ) : (
                         // PLEGADO (default): una sola puerta ancha ≥96px. La
                         // grilla completa se abre aquí o desde la puerta "Toda

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -7,7 +7,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { listFarmProcesses } from '../../db/farmProcessCache';
 import useAssetStore from '../../store/useAssetStore';
+import useCosechaStore from '../../store/useCosechaStore';
 import { buildFincaScene } from '../../services/fincaSceneService';
+import { buildVitalidadEspiritu } from '../../services/vitalidadEspirituService';
+import { getDiagnosticoSueloGuardado } from '../../services/soilDiagnostic';
 import { selectSceneVariant, SCENE_KINDS } from '../../services/fincaSceneProfileSelector';
 import { getProfile, saveProfile, getInvernaderoEstructura, hasManualModuleVisibility } from '../../services/userProfileService';
 import { esPerfilUrbano } from '../../services/homeModuleSelector';
@@ -40,6 +43,11 @@ import NotificationsBell from '../NotificationsBell';
 //   · minimalista → "Un solo trazo" (line-art que se dibuja sobre papel).
 // Las escalas balcon/invernadero conservan sus escenas isométricas intactas.
 import SceneFincaOrganismo from './SceneFincaOrganismo';
+// PANEL DE VITALIDAD DEL ESPÍRITU — la lectura de vida del organismo (mockup
+// aprobado #/mockups/avatar-biopunk), groundeada con los registros REALES de
+// la finca (ver vitalidadEspirituService). Solo se monta con la escena
+// Finca Organismo (biopunk2), debajo de la escena.
+import PanelVitalidadEspiritu from './PanelVitalidadEspiritu';
 import SceneFincaNature from './SceneFincaNature';
 import SceneHuertoVivo from './SceneHuertoVivo';
 import SceneTrazoMinimal from './SceneTrazoMinimal';
@@ -304,6 +312,45 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, on
   // Compat: el modificador histórico del wrap organismo (specs externos lo
   // usan). Tras el split vive en biopunk2 (donde quedó la Finca Organismo).
   const organismoActivo = escenaVivaActiva && temaEfectivo === 'biopunk2';
+
+  // ── PANEL DE VITALIDAD DEL ESPÍRITU (solo con la Finca Organismo) ─────────
+  // Cada valor sale de una fuente REAL (contrato en vitalidadEspirituService):
+  // vitalidad = scene.vitalidad (ciclos reales) · especies = procesos +
+  // plantas-asset · clima = snapshot guardado + condición de la atmósfera (la
+  // MISMA de la escena) · cosechas = useCosechaStore (log--harvest reales) ·
+  // suelo = diagnóstico DR-SUELOS-1 cuando exista (hoy no se persiste →
+  // "dato en camino", nunca un número inventado).
+  const plantAssets = useAssetStore((s) => s.plants);
+  const cosechaSummary = useCosechaStore((s) => s.summary);
+  useEffect(() => {
+    if (!organismoActivo || cosechaSummary) return;
+    // Carga offline-first de los log--harvest (IDB). Si falla, el contador
+    // queda honesto en "dato en camino" (el store guarda el error).
+    useCosechaStore.getState().loadHarvests().catch(() => {});
+    // Solo debe dispararse al activar la escena; el summary llega por el store.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [organismoActivo]);
+  const vitalidadEspiritu = useMemo(() => {
+    if (!organismoActivo) return null;
+    let snapshot = null;
+    try { snapshot = getCachedClimaSnapshot(); } catch (_) { /* sin señal guardada */ }
+    // 🪱 El suelo: el ÚLTIMO diagnóstico REAL que el usuario hizo en la
+    // pantalla de suelo (DR-SUELOS-1), persistido por guardarDiagnosticoSuelo.
+    // Nunca hizo uno → null → el eje queda honesto en "dato en camino".
+    let diagSuelo = null;
+    try { diagSuelo = getDiagnosticoSueloGuardado(); } catch (_) { /* sin diagnóstico */ }
+    return buildVitalidadEspiritu({
+      scene,
+      processes,
+      plants: plantAssets,
+      climaSnapshot: snapshot,
+      condicion: atmosfera?.condicion || null,
+      harvestSummary: cosechaSummary,
+      diagSuelo,
+    });
+    // `atmosfera` también re-lee el snapshot cacheado (se refresca con el
+    // MISMO evento CLIMA_UPDATED_EVENT que alimenta el cielo de la escena).
+  }, [organismoActivo, scene, processes, plantAssets, cosechaSummary, atmosfera]);
 
   // ── GATE DE ANIMALES (potrero de la escena + puerta "Mis animales") ───────
   // Mismo criterio que DashboardLive.mostrarAnimales (el usuario solo ve lo
@@ -610,6 +657,14 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, on
                 <div className="fvh-institucional">{children}</div>
               )}
             </div>
+
+            {/* ── PANEL DE VITALIDAD DEL ESPÍRITU (mockup avatar-biopunk) ──
+                La lectura de vida del organismo, DEBAJO de la escena (no tapa
+                el potrero/la vaca ni el globo del colibrí). Datos 100% reales;
+                lo que falte se pinta "—" = dato en camino. */}
+            {vitalidadEspiritu && tieneFincaPropia && (
+              <PanelVitalidadEspiritu modelo={vitalidadEspiritu} />
+            )}
           </div>
 
           {/* ── COLUMNA derecha en desktop / debajo en móvil ────────────────── */}

--- a/src/components/dashboard/GuardianEspiritu.jsx
+++ b/src/components/dashboard/GuardianEspiritu.jsx
@@ -1,0 +1,314 @@
+/*
+ * i18n (ADR-050): copy del selector del guardián en español Colombia (tú/usted),
+ * pendiente de migrar a src/config/messages.js — mismo criterio que
+ * DashboardLive.jsx / MundosDeMiFinca.jsx.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { getGuardianEspecie, setGuardianEspecie } from '../../services/userProfileService';
+import './guardian-espiritu.css';
+
+/**
+ * GuardianEspiritu — el SELECTOR DEL GUARDIÁN (espíritu de la finca) en el home
+ * vivo (menú vivo). Portado del mockup aprobado #/mockups/avatar-biopunk
+ * (AvatarGameBiopunk / módulo Pro avatar-espiritu): "SU GUARDIÁN — ESCOJA UNA
+ * ESPECIE NATIVA", tarjetas seleccionables de fauna nativa emblemática, la
+ * elegida resaltada con glow neón y nombre científico. El guardián elegido se
+ * vuelve el espíritu de la finca y PERSISTE en el perfil del usuario
+ * (userProfileService: `guardian_especie`).
+ *
+ * GROUNDING (clave): las especies ofrecidas son REALES y del catálogo/grafo de
+ * Chagra (fauna nativa colombiana verificable), con nombre científico correcto
+ * — NUNCA fauna inventada. Cada una lleva su fuente de grounding en el repo.
+ *
+ * @param {Object} props
+ * @param {(id: string, especie: Object) => void} [props.onChange]  callback
+ *   opcional al elegir/cambiar el guardián (además de la persistencia).
+ */
+
+// ─── ROSTER GROUNDED — fauna nativa colombiana REAL con nombre científico ────
+// Cada acento (acc/accRgb) re-tiñe el HUD, igual que en el mockup. `fuente` es la
+// evidencia de grounding en el repo (catálogo/cycle-content/datos).
+const ESPECIES = [
+  {
+    id: 'abeja',
+    nombre: 'Abeja angelita',
+    cientifico: 'Tetragonisca angustula',
+    eje: 'Floración y polinizadores',
+    frase: 'Soy la angelita: cuido su floración y le multiplico la cosecha.',
+    fuente: 'Meliponino nativo sin aguijón · catálogo de fauna de Chagra',
+    acc: '#ffb54f', accRgb: '255, 181, 79',
+  },
+  {
+    id: 'oso',
+    nombre: 'Oso de anteojos',
+    cientifico: 'Tremarctos ornatus',
+    eje: 'Bosque y agroforestería',
+    frase: 'Soy el oso andino: guardo su bosque y la conexión de la montaña.',
+    fuente: 'Único oso de Suramérica (VU) · catálogo de bosque andino de Chagra',
+    acc: '#b28dff', accRgb: '178, 141, 255',
+  },
+  {
+    id: 'chivito',
+    nombre: 'Chivito de páramo',
+    cientifico: 'Oxypogon guerinii',
+    eje: 'Páramo y flores nativas',
+    frase: 'Soy el chivito del páramo: velo por el agua que nace arriba.',
+    fuente: 'Colibrí endémico de Colombia · catálogo de páramo de Chagra',
+    acc: '#2dffc4', accRgb: '45, 255, 196',
+  },
+  {
+    id: 'danta',
+    nombre: 'Danta de montaña',
+    cientifico: 'Tapirus pinchaque',
+    eje: 'Suelo y semillas del bosque',
+    frase: 'Soy la danta de montaña: siembro el bosque con cada semilla que dejo.',
+    fuente: 'Tapir andino endémico (EN) · fauna paramuna del catálogo de Chagra',
+    acc: '#7fd0ff', accRgb: '127, 208, 255',
+  },
+  {
+    id: 'rana',
+    nombre: 'Rana dorada',
+    cientifico: 'Phyllobates terribilis',
+    eje: 'Agua limpia',
+    frase: 'Soy la rana dorada: mi presencia dice que su agua está sana.',
+    fuente: 'Anfibio endémico del Chocó · bioindicadora de agua limpia',
+    acc: '#ffd76a', accRgb: '255, 215, 106',
+  },
+];
+
+const byId = (id) => ESPECIES.find((e) => e.id === id) || ESPECIES[0];
+
+/* ------------------------------------------------------------------------- */
+/* filtros SVG compartidos (glow + blur), portados del mockup                  */
+/* ------------------------------------------------------------------------- */
+function GuardianDefs() {
+  return (
+    <defs>
+      <filter id="ge-glow1" x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.2" result="b" />
+        <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+      </filter>
+      <filter id="ge-blur3"><feGaussianBlur stdDeviation="3" /></filter>
+    </defs>
+  );
+}
+
+/* --------- los avatares (SVG portados 1:1 del mockup biopunk) ------------- */
+
+function AvatarChivito() {
+  return (
+    <g className="ge-av-vuela">
+      <circle className="ge-estela" r="6" fill="#2dffc4" opacity="0.5" filter="url(#ge-blur3)" />
+      <circle r="5" fill="#4fd8ff" opacity="0.4" filter="url(#ge-blur3)" />
+      <g filter="url(#ge-glow1)">
+        <path d="M-6,-0.5 L-17,-4.5 L-12,0 L-17,4.2 Z" fill="#1f9f86" />
+        <path d="M-6.5,0 C0,-6.5 10,-6 14,-1.4 C17,1 17,3 14,4.6 C8.5,8 0,7.6 -6.5,1.4 Z" fill="#2dffc4" />
+        <path d="M-3.5,3 C3,5.3 10,5 14,2.5 C10,6.8 1.5,7.1 -4.8,2.2 Z" fill="#bfffe9" opacity="0.7" />
+        <circle cx="12.6" cy="-2.2" r="4" fill="#9dff3f" />
+        <path d="M11,-5.4 L12.6,-9 L14.4,-5 Z" fill="#4fd8ff" />
+        <path d="M12,1.2 C11.4,5.4 12.2,9 13.6,12 C14.8,8.8 15.6,5 14.8,1 Z" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 4px #eafff6)' }} />
+        <circle cx="13.6" cy="-2.8" r="1.15" fill="#04160f" />
+        <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+        <path d="M16.2,-1.6 C21,-2.1 25,-2.8 28.6,-4.2" stroke="#eafff6" strokeWidth="1.3" fill="none" strokeLinecap="round" />
+        <path className="ge-ala" d="M4,-1.4 C-4,-16 10,-23 17,-14 C14.4,-5.6 8,-1.4 4,-1.4 Z" fill="#ff4fd8" opacity="0.85" />
+        <path className="ge-ala" style={{ animationDelay: '-0.06s' }} d="M5.5,1.7 C0,13 13,17.5 17,10 C14,4.2 9.5,1.7 5.5,1.7 Z" fill="#b28dff" opacity="0.5" />
+      </g>
+    </g>
+  );
+}
+
+function AvatarRana() {
+  return (
+    <g className="ge-av-flota" filter="url(#ge-glow1)">
+      <ellipse cx="0" cy="8" rx="15" ry="3" fill="#000" opacity="0.35" />
+      <path d="M-13,7 C-16,2 -13,-4 -7,-7 C-1,-10 8,-9 12,-4 C15,-1 15,4 12,7 Z" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 8px rgba(255,181,79,0.8))' }} />
+      <path d="M-11,6 C-13,2 -10,-3 -5,-5 C1,-8 8,-7 11,-3" fill="none" stroke="#fff3c9" strokeWidth="1" opacity="0.7" />
+      <circle cx="-4" cy="1" r="1.2" fill="#7a4a10" opacity="0.65" />
+      <circle cx="2" cy="-3" r="1" fill="#7a4a10" opacity="0.6" />
+      <circle cx="5" cy="2" r="1.1" fill="#7a4a10" opacity="0.6" />
+      <path d="M-13,7 C-17,6 -19,3 -18,-1" fill="none" stroke="#ff9d3f" strokeWidth="2.6" strokeLinecap="round" />
+      <path d="M8,7 C12,8 16,7 18,4" fill="none" stroke="#ff9d3f" strokeWidth="2.6" strokeLinecap="round" />
+      <ellipse cx="9" cy="3.4" rx="3.4" ry="2.6" fill="#fff3c9" opacity="0.85" />
+      <circle cx="8.6" cy="-5.4" r="3.4" fill="#04160f" />
+      <circle cx="8.6" cy="-5.4" r="3.4" fill="none" stroke="#ffd76a" strokeWidth="1" />
+      <circle cx="9.6" cy="-6.4" r="1.1" fill="#eafff6" />
+      <path d="M10.8,-1.4 Q13,-0.6 14.6,-1.8" stroke="#7a4a10" strokeWidth="0.8" fill="none" strokeLinecap="round" />
+    </g>
+  );
+}
+
+function AvatarAbeja() {
+  return (
+    <g className="ge-av-flota">
+      <g filter="url(#ge-glow1)">
+        <circle r="5" fill="#ffb54f" opacity="0.4" filter="url(#ge-blur3)" />
+        <ellipse cx="0" cy="0" rx="7.5" ry="4.8" fill="#ffb54f" style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
+        <path d="M-2.8,-4.3 L-2.8,4.3 M0.7,-4.6 L0.7,4.6 M3.9,-3.7 L3.9,3.7" stroke="#3a2410" strokeWidth="1.5" strokeLinecap="round" />
+        <circle cx="7.3" cy="-0.7" r="3" fill="#ffd76a" />
+        <circle cx="8.3" cy="-1.4" r="0.8" fill="#04160f" />
+        <path d="M10,-2 C11.2,-2.9 12.3,-2.9 13.2,-2.2" stroke="#3a2410" strokeWidth="0.6" fill="none" />
+        <ellipse className="ge-aleteo" cx="-1.6" cy="-6.2" rx="5.3" ry="3.2" fill="#4fd8ff" opacity="0.65" />
+        <ellipse className="ge-aleteo" style={{ animationDelay: '-0.06s' }} cx="2" cy="-5.7" rx="4.1" ry="2.5" fill="#bfeaff" opacity="0.5" />
+        <circle cx="-8.4" cy="1.2" r="1.2" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #d8ff6a)' }} />
+      </g>
+    </g>
+  );
+}
+
+function AvatarOso() {
+  return (
+    <g className="ge-av-flota" filter="url(#ge-glow1)">
+      <ellipse cx="0" cy="21" rx="15" ry="3" fill="#000" opacity="0.4" />
+      <path d="M-11,20 C-14,8 -10,-4 0,-6 C10,-4 14,8 11,20 Z" fill="#171030" stroke="#2dffc4" strokeWidth="0.8" strokeOpacity="0.5" />
+      <path d="M-3,6 C-1,10 1,10 3,6 C2,12 -2,12 -3,6 Z" fill="#eafff6" opacity="0.85" />
+      <path d="M-8,20 L-8,14 M8,20 L8,14" stroke="#0f0a20" strokeWidth="4.4" strokeLinecap="round" />
+      <circle cx="0" cy="-9" r="8" fill="#1c1338" stroke="#2dffc4" strokeWidth="0.8" strokeOpacity="0.5" />
+      <path d="M-7,-15 A2.8,2.8 0 1 1 -3,-17.5 M7,-15 A2.8,2.8 0 1 0 3,-17.5" fill="#1c1338" stroke="#2dffc4" strokeWidth="0.7" strokeOpacity="0.5" />
+      <circle cx="-3.2" cy="-10" r="3" fill="none" stroke="#eafff6" strokeWidth="1.3" style={{ filter: 'drop-shadow(0 0 4px #eafff6)' }} />
+      <circle cx="3.2" cy="-10" r="3" fill="none" stroke="#eafff6" strokeWidth="1.3" style={{ filter: 'drop-shadow(0 0 4px #eafff6)' }} />
+      <path d="M-0.4,-10 L0.4,-10" stroke="#eafff6" strokeWidth="1" />
+      <circle cx="-3.2" cy="-10" r="1" fill="#2dffc4" />
+      <circle cx="3.2" cy="-10" r="1" fill="#2dffc4" />
+      <ellipse cx="0" cy="-5.4" rx="2.6" ry="1.9" fill="#d8b48a" />
+      <circle cx="0" cy="-6" r="0.9" fill="#04160f" />
+    </g>
+  );
+}
+
+/* Danta de montaña (Tapirus pinchaque) — avatar NUEVO en la línea biopunk:
+   silueta de tapir con la trompa prensil, borde neón y el labio blanco
+   característico del tapir andino. */
+function AvatarDanta() {
+  return (
+    <g className="ge-av-flota" filter="url(#ge-glow1)">
+      <ellipse cx="0" cy="14" rx="16" ry="3" fill="#000" opacity="0.4" />
+      {/* cuerpo robusto */}
+      <path d="M-14,8 C-16,-2 -8,-9 3,-8 C12,-7 17,-2 16,6 C15,11 8,13 -2,13 C-9,13 -13,12 -14,8 Z"
+        fill="#141a3a" stroke="#7fd0ff" strokeWidth="0.9" strokeOpacity="0.6" />
+      {/* lomo iluminado */}
+      <path d="M-11,-2 C-4,-8 8,-8 14,-1" fill="none" stroke="#bfeaff" strokeWidth="1" opacity="0.55" />
+      {/* patas */}
+      <path d="M-9,12 L-9,7 M-2,13 L-2,7.5 M9,11 L9,6" stroke="#0f0a24" strokeWidth="3.6" strokeLinecap="round" />
+      {/* cabeza + trompa prensil */}
+      <path d="M12,-3 C18,-4 22,-1 23,3 C23.6,5.4 22,7 20,6.6 C21,4 19.4,1.4 16,1 C14,0.8 12.6,-1 12,-3 Z"
+        fill="#1c2350" stroke="#7fd0ff" strokeWidth="0.8" strokeOpacity="0.6" />
+      {/* labio blanco del tapir andino (rasgo diagnóstico) */}
+      <path d="M20.4,5.4 C22,5.2 23,5.8 23.2,6.8 C22,7.2 20.6,7 19.8,6.2 Z" fill="#eafff6" opacity="0.9" />
+      {/* ojo */}
+      <circle cx="14.4" cy="-1.2" r="1.15" fill="#04160f" />
+      <circle cx="14.7" cy="-1.6" r="0.4" fill="#eafff6" />
+      {/* oreja con borde vivo */}
+      <path d="M8,-6 C7,-11 12,-12 13,-8 C12,-6.5 10,-6 8,-6 Z" fill="#1c2350" stroke="#9dff3f" strokeWidth="0.7" strokeOpacity="0.6" />
+    </g>
+  );
+}
+
+const AVATAR = {
+  abeja: AvatarAbeja,
+  rana: AvatarRana,
+  oso: AvatarOso,
+  chivito: AvatarChivito,
+  danta: AvatarDanta,
+};
+
+/** Un avatar aislado dibujado en su propio SVG (para chips y héroe). */
+function GuardianAvatar({ id, size = 46 }) {
+  const Cuerpo = AVATAR[id] || AvatarAbeja;
+  return (
+    <svg viewBox="-26 -24 52 46" width={size} height={size} aria-hidden="true" focusable="false">
+      <GuardianDefs />
+      <Cuerpo />
+    </svg>
+  );
+}
+
+export default function GuardianEspiritu({ onChange = null }) {
+  // Guardián persistido (o el default si aún no ha elegido). El home distingue
+  // "sin elegir" para el copy, pero siempre mostramos un espíritu por defecto.
+  const [elegido, setElegido] = useState(() => getGuardianEspecie());
+  const activoId = elegido || ESPECIES[0].id;
+  const activo = byId(activoId);
+
+  // Re-leer si otra superficie (perfil, otra pestaña) cambia el guardián.
+  useEffect(() => {
+    const handler = () => setElegido(getGuardianEspecie());
+    try {
+      window.addEventListener('chagra:guardian-changed', handler);
+      return () => {
+        try { window.removeEventListener('chagra:guardian-changed', handler); } catch (_) { /* noop */ }
+      };
+    } catch (_) {
+      return () => {};
+    }
+  }, []);
+
+  const escoger = useCallback((especie) => {
+    setElegido(especie.id);
+    setGuardianEspecie(especie.id);
+    if (typeof onChange === 'function') onChange(especie.id, especie);
+  }, [onChange]);
+
+  const accVars = {
+    '--ge-acc': activo.acc,
+    '--ge-acc-rgb': activo.accRgb,
+  };
+
+  return (
+    <section
+      className={`ge ${elegido ? 'on-glow' : ''}`}
+      style={accVars}
+      aria-label="Su guardián: el espíritu de su finca"
+      data-testid="guardian-selector"
+      data-guardian={activoId}
+    >
+      <header className="ge-head">
+        <span className="ge-kicker">SU GUARDIÁN</span>
+        <h2 className="ge-title">Escoja una especie nativa</h2>
+        <p className="ge-sub">
+          El guardián que elija se vuelve el espíritu de su finca. Fauna nativa colombiana, real y verificable.
+        </p>
+      </header>
+
+      {/* héroe: el guardián elegido, en grande, con su nombre científico */}
+      <div className="ge-hero" data-testid="guardian-hero">
+        <span className="ge-hero-avatar">
+          <GuardianAvatar id={activoId} size={78} />
+        </span>
+        <div className="ge-hero-txt">
+          <p className="ge-hero-rol">EL ESPÍRITU DE SU FINCA</p>
+          <h3 className="ge-hero-nombre" data-testid="guardian-nombre">{activo.nombre}</h3>
+          <p className="ge-hero-cientifico" data-testid="guardian-cientifico">{activo.cientifico}</p>
+          <p className="ge-hero-frase">{activo.frase}</p>
+          <span className="ge-hero-fuente">{activo.fuente}</span>
+        </div>
+      </div>
+
+      {/* selector: tarjetas seleccionables con glow neón por acento */}
+      <div className="ge-chips" role="radiogroup" aria-label="Especie del guardián">
+        {ESPECIES.map((e) => {
+          const on = e.id === activoId;
+          return (
+            <button
+              key={e.id}
+              type="button"
+              role="radio"
+              aria-checked={on}
+              aria-label={`${e.nombre} (${e.cientifico}) — ${e.eje}`}
+              className={`ge-chip ${on ? 'on' : ''}`}
+              style={{ '--ge-chip-acc': e.acc, '--ge-chip-acc-rgb': e.accRgb }}
+              data-testid={`guardian-chip-${e.id}`}
+              onClick={() => escoger(e)}
+            >
+              {on && <span className="ge-chip-check" aria-hidden="true">✓</span>}
+              <span className="ge-chip-avatar">
+                <GuardianAvatar id={e.id} size={46} />
+              </span>
+              <span className="ge-chip-nombre">{e.nombre}</span>
+              <span className="ge-chip-eje">{e.eje}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/MundosDeMiFinca.jsx
+++ b/src/components/dashboard/MundosDeMiFinca.jsx
@@ -4,7 +4,36 @@
  */
 import { MUNDOS_FINCA } from './mundosFinca';
 import MundoVineta from './MundoVinetas';
+import { useProCapability } from '../../hooks/useProCapability';
 import './mundos-finca.css';
+
+/**
+ * Glifo del espíritu de la finca: una llama-hoja con su brote adentro,
+ * dibujada a mano (SVG inline, cero assets). Acompaña la entrada Pro de
+ * abajo; el color lo hereda del texto (currentColor).
+ */
+function EspirituGlyph() {
+    return (
+        <svg viewBox="0 0 24 24" width="26" height="26" fill="none" aria-hidden="true">
+            {/* aura exterior (llama/hoja) */}
+            <path
+                d="M12 2.6c3.6 3.4 6.4 6.8 6.4 10.6 0 4.4-2.9 7.6-6.4 8.2-3.5-.6-6.4-3.8-6.4-8.2C5.6 9.4 8.4 6 12 2.6Z"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+                opacity="0.9"
+            />
+            {/* brote interior */}
+            <path
+                d="M12 17.5v-4.2m0 0c0-2 1.3-3.2 3-3.4.1 2.1-1 3.4-3 3.4Zm0-1.2c0-1.6-1-2.6-2.4-2.8-.1 1.7.8 2.8 2.4 2.8Z"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}
 
 /**
  * MundosDeMiFinca — la grilla de LOS MUNDOS DE MI FINCA en el home F2.
@@ -28,6 +57,13 @@ import './mundos-finca.css';
  */
 export default function MundosDeMiFinca({ onNavigate, mostrarAnimales = true, plantsCount = 0 }) {
     const mundos = MUNDOS_FINCA.filter((m) => m.gate !== 'animales' || mostrarAnimales);
+    // Entrada Pro "El espíritu de su finca" (capability avatar-espiritu,
+    // módulo del repo privado chagra-pro). GATE por capability: solo se
+    // renderiza cuando el módulo Pro está cargado en el registry — mismo
+    // criterio permisivo-estructural de EspirituProScreen. Para cuentas /
+    // builds sin Pro: CERO rastro (ni botón muerto ni teaser). Reactivo:
+    // loadProModules es async, la banda aparece sola cuando el módulo llega.
+    const tieneEspiritu = useProCapability('avatar-espiritu');
 
     const abrir = (m) => {
         if (m.portada) onNavigate?.(m.portada);
@@ -99,6 +135,31 @@ export default function MundosDeMiFinca({ onNavigate, mostrarAnimales = true, pl
                     );
                 })}
             </div>
+
+            {/* ── Entrada Pro: EL ESPÍRITU DE SU FINCA (#/espiritu) ──────────
+                Banda discreta DEBAJO de la grilla (no es un mundo más: es la
+                finca ENTERA vista como un solo ser vivo — y la política de la
+                grilla es ~10 tarjetas top-level). El corazón de la escena ya
+                se usó para "Pregunte" (#2230), por eso la entrada vive aquí.
+                Gate arriba (tieneEspiritu): sin módulo Pro no se renderiza. */}
+            {tieneEspiritu && (
+                <button
+                    type="button"
+                    className="mf-espiritu"
+                    data-testid="entrada-espiritu"
+                    onClick={() => onNavigate?.('espiritu_pro')}
+                    aria-label="El espíritu de su finca: véala respirar como un solo ser vivo (experiencia de su plan)"
+                >
+                    <span className="mf-espiritu-glifo" aria-hidden="true">
+                        <EspirituGlyph />
+                    </span>
+                    <span className="mf-espiritu-txt">
+                        <b>El espíritu de su finca</b>
+                        <small>Véala respirar: toda su finca como un solo ser vivo</small>
+                    </span>
+                    <span className="mf-espiritu-sello" aria-hidden="true">Pro</span>
+                </button>
+            )}
         </section>
     );
 }

--- a/src/components/dashboard/PanelVitalidadEspiritu.jsx
+++ b/src/components/dashboard/PanelVitalidadEspiritu.jsx
@@ -1,0 +1,167 @@
+import './panel-vitalidad-espiritu.css';
+
+/**
+ * PanelVitalidadEspiritu — el "VITALIDAD DEL ESPÍRITU" del mockup aprobado
+ * #/mockups/avatar-biopunk (AvatarGameBiopunk, panel `agb-panel`), integrado
+ * al home "menú vivo" (FincaVivaHero, escena Finca Organismo) con GROUNDING
+ * TOTAL: el modelo lo arma vitalidadEspirituService desde los datos REALES
+ * de la finca (ver el contrato "FUENTE REAL DE CADA VALOR" en ese módulo).
+ *
+ * Qué pinta (idéntico al panel del mockup, prefijo `pve-`):
+ *   · Medidor circular de vitalidad (anillo neón + número grande).
+ *   · Badge "N sp. ESPECIES VIVAS".
+ *   · 4 barras horizontales con ícono: 💧 clima · 🪱 suelo · 🦋 biodiversidad
+ *     · 🔥 energía, cada una con su gradiente c1→c2 del mockup.
+ *   · 3 contadores: 🍃 especies registradas · ✦ cosechas anotadas ·
+ *     ◎ anillos del frailejón (anillos concéntricos dibujados).
+ *
+ * SLOT PENDIENTE: cuando un dato real aún no existe, el slot muestra "—" con
+ * riel punteado y el panel cierra con la nota "— = dato en camino". NUNCA un
+ * número inventado. Cada slot lleva su fuente en el `title` (trazabilidad).
+ *
+ * Presentacional puro: recibe el `modelo` ya calculado. SVG/CSS solamente
+ * (rsvg-safe), animaciones en panel-vitalidad-espiritu.css con
+ * prefers-reduced-motion. Español de Colombia (tú/usted), sin voseo.
+ *
+ * @param {Object} props
+ * @param {ReturnType<import('../../services/vitalidadEspirituService').buildVitalidadEspiritu>} props.modelo
+ */
+export default function PanelVitalidadEspiritu({ modelo }) {
+  if (!modelo) return null;
+  const { vitalidad, especiesVivas, ejes, conteos, algunPendiente } = modelo;
+
+  const CIRC = 2 * Math.PI * 26;
+  const vitalidadOk = vitalidad.estado === 'ok';
+  const offset = vitalidadOk ? CIRC * (1 - vitalidad.valor / 100) : CIRC;
+
+  const num = (slot) => (slot.estado === 'ok' ? slot.valor : '—');
+
+  return (
+    <aside
+      className="pve"
+      data-testid="panel-vitalidad-espiritu"
+      aria-label="Vitalidad del espíritu de su finca, calculada con los registros reales"
+    >
+      <p className="pve-cab">VITALIDAD DEL ESPÍRITU</p>
+
+      <div className="pve-cuerpo">
+        {/* ── medidor circular + especies vivas ── */}
+        <div className="pve-vital">
+          <span
+            className="pve-anillo-wrap"
+            title={vitalidad.fuente}
+            data-estado={vitalidad.estado}
+            data-testid="pve-vitalidad"
+          >
+            <svg width="62" height="62" viewBox="0 0 62 62" role="img"
+              aria-label={vitalidadOk
+                ? `Vitalidad de la finca: ${vitalidad.valor} de 100. ${vitalidad.fuente}`
+                : `Vitalidad de la finca: dato en camino. ${vitalidad.fuente}`}
+            >
+              <circle className="pve-ring-track" cx="31" cy="31" r="26" fill="none" strokeWidth="4" />
+              <circle
+                className="pve-ring-val" cx="31" cy="31" r="26" fill="none" strokeWidth="4"
+                strokeLinecap="round" strokeDasharray={CIRC} strokeDashoffset={offset}
+                transform="rotate(-90 31 31)"
+              />
+              <text x="31" y="36" textAnchor="middle" className="pve-ring-num">
+                {vitalidadOk ? vitalidad.valor : '—'}
+              </text>
+            </svg>
+          </span>
+          <div
+            className="pve-vivas"
+            title={especiesVivas.fuente}
+            data-estado={especiesVivas.estado}
+            data-testid="pve-especies-vivas"
+          >
+            <span className="pve-vivas-num">
+              {num(especiesVivas)}
+              <small> sp.</small>
+            </span>
+            <span className="pve-vivas-cap">ESPECIES VIVAS</span>
+          </div>
+        </div>
+
+        {/* ── 4 barras: clima · suelo · biodiversidad · energía ── */}
+        <div className="pve-ejes" role="list">
+          {ejes.map((eje) => {
+            const lectura = eje.estado === 'ok'
+              ? (eje.texto || `${eje.valor} de 100`)
+              : 'dato en camino';
+            return (
+              <div
+                className="pve-eje"
+                key={eje.id}
+                role="listitem"
+                data-eje={eje.id}
+                data-estado={eje.estado}
+                title={`${eje.label}: ${lectura}. ${eje.fuente}`}
+                aria-label={`${eje.label}: ${lectura}`}
+              >
+                <span className="pve-eje-emoji" aria-hidden="true">{eje.emoji}</span>
+                <span className="pve-eje-riel">
+                  {eje.estado === 'ok' && eje.valor != null && (
+                    <span
+                      className="pve-eje-fill"
+                      style={{ width: `${eje.valor}%`, '--pve-c1': eje.c1, '--pve-c2': eje.c2 }}
+                    />
+                  )}
+                </span>
+                <span className="pve-eje-val">
+                  {eje.estado === 'ok' ? (eje.valor != null ? eje.valor : eje.texto) : '—'}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* ── 3 contadores ── */}
+        <div className="pve-conteos">
+          <span title={conteos.especies.fuente} data-estado={conteos.especies.estado} data-testid="pve-conteo-especies">
+            <i aria-hidden="true">🍃</i> <b>{num(conteos.especies)}</b> especies registradas
+          </span>
+          <span title={conteos.cosechas.fuente} data-estado={conteos.cosechas.estado} data-testid="pve-conteo-cosechas">
+            <i aria-hidden="true">✦</i> <b>{num(conteos.cosechas)}</b> cosechas anotadas
+          </span>
+          <span title={conteos.anillos.fuente} data-estado={conteos.anillos.estado} data-testid="pve-conteo-anillos">
+            <AnillosFrailejon anillos={conteos.anillos.estado === 'ok' ? conteos.anillos.valor : 0} />
+            {' '}
+            <b>{num(conteos.anillos)}</b> anillos del frailejón
+          </span>
+        </div>
+      </div>
+
+      {algunPendiente && (
+        <p className="pve-nota" data-testid="pve-nota-pendiente">
+          — = dato en camino: regístrelo en la finca y el espíritu lo siente.
+        </p>
+      )}
+    </aside>
+  );
+}
+
+/**
+ * Anillos concéntricos del frailejón (uno por temporada cuidando la tierra),
+ * la misma idea del mockup VerdeVivo pero con la paleta neón del panel.
+ * Dibuja máximo 8 anillos (más se vuelven ruido a este tamaño); el número
+ * real siempre va en el texto.
+ */
+function AnillosFrailejon({ anillos = 0 }) {
+  const n = Math.max(0, Math.min(8, Math.floor(anillos)));
+  return (
+    <svg className="pve-anillos-svg" viewBox="0 0 30 30" width="15" height="15" aria-hidden="true">
+      {Array.from({ length: n }, (_, i) => (
+        <circle
+          key={i}
+          cx="15" cy="15" r={3.5 + i * 1.55}
+          fill="none"
+          stroke={i % 2 ? '#9dff3f' : '#2dffc4'}
+          strokeWidth="1.1"
+          opacity={Math.max(0.25, 0.95 - i * 0.09)}
+        />
+      ))}
+      <circle cx="15" cy="15" r="1.6" fill="#ffb54f" />
+    </svg>
+  );
+}

--- a/src/components/dashboard/RelojFrailejon.jsx
+++ b/src/components/dashboard/RelojFrailejon.jsx
@@ -1,0 +1,138 @@
+/*
+ * i18n (ADR-050): copy del home en español Colombia, pendiente de migrar a
+ * src/config/messages.js — mismo criterio que MundosDeMiFinca / DashboardLive.
+ */
+ 
+/**
+ * RelojFrailejon — el RELOJ DEL FRAILEJÓN del pie del árbol de mundos
+ * (pieza del mockup aprobado #/mockups/avatar-biopunk, dirección ganadora):
+ * una línea de tiempo de la finca donde CADA ANILLO ES UN AÑO — el frailejón
+ * crece un anillo al año.
+ *
+ * GROUNDED (fincaClockService): los años salen de los REGISTROS REALES de la
+ * finca en Chagra (primer FarmProcess / primera planta registrada). Si la
+ * finca es nueva, muestra el año actual como primer anillo. NUNCA inventa
+ * historia.
+ *
+ * No es decoración huérfana: tocarlo abre "El año de la finca" (`ano_finca`),
+ * la línea de tiempo real del año del usuario (vista existente de App.jsx).
+ *
+ * Accesibilidad: botón real (Enter/Espacio), target grande, texto alterno
+ * completo; animaciones en CSS con prefers-reduced-motion (arbol-de-mundos.css).
+ *
+ * @param {Object} props
+ * @param {(view: string, data?: any) => void} [props.onNavigate]
+ */
+import { useEffect, useState } from 'react';
+import { getAniosFinca } from '../../services/fincaClockService';
+
+/** Radio del anillo i (0 = el primer año, el de adentro). */
+const R_BASE = 9;
+const R_PASO = 6.5;
+/** Tope visual: más de 12 anillos se comprimen (paso más corto). */
+const MAX_ANILLOS_COMODOS = 12;
+
+export default function RelojFrailejon({ onNavigate }) {
+  const [reloj, setReloj] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    getAniosFinca()
+      .then((r) => { if (alive) setReloj(r); })
+      .catch(() => { /* honesto: sin datos no se dibuja nada inventado */ });
+    return () => { alive = false; };
+  }, []);
+
+  if (!reloj) return null;
+
+  const { anios, primerAnio, anioActual, fincaNueva } = reloj;
+  const n = anios.length;
+  const paso = n > MAX_ANILLOS_COMODOS ? (R_PASO * MAX_ANILLOS_COMODOS) / n : R_PASO;
+  const rMax = R_BASE + (n - 1) * paso;
+  const etiquetarCada = n <= 6 ? 1 : n <= 12 ? 2 : Math.ceil(n / 5);
+
+  const abrir = () => onNavigate?.('ano_finca');
+
+  const resumen = fincaNueva
+    ? `${anioActual}: su primer anillo. El frailejón de su finca apenas brota.`
+    : n === 1
+      ? `Un anillo: su finca vive en Chagra desde este año ${anioActual}.`
+      : `${n} anillos: su finca vive en Chagra desde ${primerAnio}.`;
+
+  return (
+    <button
+      type="button"
+      className="adm-reloj"
+      data-testid="reloj-frailejon"
+      onClick={abrir}
+      aria-label={`Reloj del frailejón — un anillo por año. ${resumen} Toque para ver la línea de tiempo de su finca.`}
+    >
+      <svg
+        className="adm-reloj-svg"
+        viewBox="0 0 120 120"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <defs>
+          <radialGradient id="admr-nucleo" cx="0.5" cy="0.42" r="0.7">
+            <stop offset="0" stopColor="#ffd76a" />
+            <stop offset="0.6" stopColor="#ffb54f" />
+            <stop offset="1" stopColor="#ffb54f" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+        {/* halo de vida */}
+        <circle cx="60" cy="60" r={Math.min(rMax + 10, 56)} fill="#2dffc4" opacity="0.06" />
+        {/* un anillo por año — el de adentro es el primer año */}
+        {anios.map((anio, i) => {
+          const r = R_BASE + i * paso;
+          const esActual = anio === anioActual;
+          return (
+            <g key={anio}>
+              <circle
+                className={`adm-reloj-anillo${esActual ? ' adm-reloj-anillo-actual' : ''}`}
+                cx="60"
+                cy="60"
+                r={r}
+                fill="none"
+                stroke={esActual ? '#2dffc4' : i % 2 ? '#9dff3f' : '#57a453'}
+                strokeWidth={esActual ? 2 : 1.5}
+                opacity={esActual ? 0.95 : Math.max(0.35, 0.85 - i * 0.05)}
+                style={{ animationDelay: `${i * 0.18}s` }}
+              />
+              {/* marcador del año: una yema en lo alto del anillo */}
+              {(i % etiquetarCada === 0 || esActual) && (
+                <g style={{ animationDelay: `${i * 0.18}s` }} className="adm-reloj-marca">
+                  <circle cx="60" cy={60 - r} r={esActual ? 2 : 1.4} fill={esActual ? '#eafff6' : '#d8ff6a'} />
+                  <text
+                    x={i % 2 ? 60 + r + 3 : 60 - r - 3}
+                    y="62.2"
+                    textAnchor={i % 2 ? 'start' : 'end'}
+                    fontFamily="ui-monospace,monospace"
+                    fontSize="6"
+                    letterSpacing="0.5"
+                    fill={esActual ? '#eafff6' : '#bfffe9'}
+                    opacity={esActual ? 1 : 0.75}
+                  >
+                    {anio}
+                  </text>
+                </g>
+              )}
+            </g>
+          );
+        })}
+        {/* el corazón del frailejón */}
+        <circle className="adm-reloj-corazon" cx="60" cy="60" r="4" fill="url(#admr-nucleo)" />
+        <circle cx="60" cy="60" r="1.6" fill="#fff3c9" />
+      </svg>
+
+      <span className="adm-reloj-texto">
+        <span className="adm-reloj-cab">EL RELOJ DEL FRAILEJÓN</span>
+        <strong className="adm-reloj-anios" data-testid="reloj-frailejon-anios">
+          {n === 1 ? 'Su primer anillo' : `${n} anillos`} · un anillo por año
+        </strong>
+        <span className="adm-reloj-nota">{resumen}</span>
+        <span className="adm-reloj-ir" aria-hidden="true">Ver el año de su finca →</span>
+      </span>
+    </button>
+  );
+}

--- a/src/components/dashboard/__tests__/ArbolDeMundos.test.jsx
+++ b/src/components/dashboard/__tests__/ArbolDeMundos.test.jsx
@@ -1,0 +1,128 @@
+/**
+ * ArbolDeMundos — el menú-árbol orgánico del home biopunk NO es navegación
+ * huérfana: cada rama enruta EXACTO igual que su tarjeta del menú vivo
+ * (fuente única mundosFinca.js), respeta el gate de Animales, es operable
+ * por teclado y solo se monta con la piel biopunk.
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach, beforeEach } from 'vitest';
+
+// El reloj del frailejón (hijo) consulta IDB — acá se mockea el servicio para
+// aislar el árbol; el reloj tiene su propio spec (RelojFrailejon.test.jsx).
+vi.mock('../../../services/fincaClockService', () => ({
+  getAniosFinca: vi.fn().mockResolvedValue({
+    primerAnio: 2026,
+    anioActual: 2026,
+    anios: [2026],
+    fincaNueva: true,
+    fuente: 'finca-nueva',
+  }),
+}));
+
+import { MUNDOS_FINCA } from '../mundosFinca';
+import ArbolDeMundos from '../ArbolDeMundos';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+beforeEach(() => {
+  // Tema default (biopunk2): el árbol se monta.
+  localStorage.clear();
+});
+
+const rama = (id) => screen.getByTestId(`arbol-rama-${id}`);
+
+describe('ArbolDeMundos — una rama viva por mundo real', () => {
+  test('dibuja una rama-botón por CADA mundo del manifiesto (finca con animales)', () => {
+    render(<ArbolDeMundos onNavigate={vi.fn()} mostrarAnimales plantsCount={0} />);
+    for (const m of MUNDOS_FINCA) {
+      const nodo = rama(m.id);
+      expect(nodo).toBeInTheDocument();
+      expect(nodo).toHaveAttribute('role', 'button');
+      expect(nodo).toHaveAttribute('tabindex', '0');
+      expect(nodo.getAttribute('aria-label')).toContain(`Entrar al mundo ${m.titulo}`);
+    }
+  });
+
+  test('GROUNDED: sin animales en el perfil, esa rama NO brota (mismo gate de la grilla)', () => {
+    render(<ArbolDeMundos onNavigate={vi.fn()} mostrarAnimales={false} plantsCount={0} />);
+    expect(screen.queryByTestId('arbol-rama-animales')).not.toBeInTheDocument();
+    expect(screen.getByTestId('arbol-rama-cultivos')).toBeInTheDocument();
+  });
+
+  test('GROUNDED: la rama de cultivos muestra el conteo REAL de matas', () => {
+    render(<ArbolDeMundos onNavigate={vi.fn()} mostrarAnimales plantsCount={3} />);
+    expect(screen.getByText('3 MATAS SEMBRADAS')).toBeInTheDocument();
+  });
+
+  test('la invitación del mockup está presente: "toque una rama para entrar a su mundo"', () => {
+    render(<ArbolDeMundos onNavigate={vi.fn()} mostrarAnimales plantsCount={0} />);
+    expect(screen.getAllByText(/toque una rama para entrar a su mundo/i).length).toBeGreaterThan(0);
+  });
+});
+
+describe('ArbolDeMundos — enruta a los MISMOS destinos que el menú vivo (no huérfano)', () => {
+  test('mundo con portada (cultivos) → onNavigate(portada)', () => {
+    const onNavigate = vi.fn();
+    render(<ArbolDeMundos onNavigate={onNavigate} mostrarAnimales plantsCount={0} />);
+    fireEvent.click(rama('cultivos'));
+    expect(onNavigate).toHaveBeenCalledWith('mundo_cultivos');
+  });
+
+  test('mundo directo (café) → onNavigate(view, data)', () => {
+    const onNavigate = vi.fn();
+    render(<ArbolDeMundos onNavigate={onNavigate} mostrarAnimales plantsCount={0} />);
+    fireEvent.click(rama('cafe'));
+    expect(onNavigate).toHaveBeenCalledWith('cafe', undefined);
+  });
+
+  test('mundo hub (sanidad) → onNavigate("mundo", { mundo: id })', () => {
+    const onNavigate = vi.fn();
+    render(<ArbolDeMundos onNavigate={onNavigate} mostrarAnimales plantsCount={0} />);
+    fireEvent.click(rama('sanidad'));
+    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'sanidad' });
+  });
+
+  test('TODAS las ramas navegan al destino exacto de su tarjeta', () => {
+    for (const m of MUNDOS_FINCA) {
+      const onNavigate = vi.fn();
+      render(<ArbolDeMundos onNavigate={onNavigate} mostrarAnimales plantsCount={0} />);
+      fireEvent.click(screen.getByTestId(`arbol-rama-${m.id}`));
+      if (m.portada) expect(onNavigate).toHaveBeenCalledWith(m.portada);
+      else if (m.directo) expect(onNavigate).toHaveBeenCalledWith(m.directo.view, m.directo.data);
+      else expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: m.id });
+      cleanup();
+    }
+  });
+
+  test('accesible por teclado: Enter y Espacio entran al mundo', () => {
+    const onNavigate = vi.fn();
+    render(<ArbolDeMundos onNavigate={onNavigate} mostrarAnimales plantsCount={0} />);
+    fireEvent.keyDown(rama('agua'), { key: 'Enter' });
+    expect(onNavigate).toHaveBeenCalledWith('agua', undefined);
+    fireEvent.keyDown(rama('clima'), { key: ' ' });
+    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'clima' });
+  });
+});
+
+describe('ArbolDeMundos — solo la piel biopunk (los demás temas quedan como están)', () => {
+  test('con tema nature NO se monta (la grilla sigue siendo el menú)', () => {
+    localStorage.setItem('chagra:theme', 'nature');
+    render(<ArbolDeMundos onNavigate={vi.fn()} mostrarAnimales plantsCount={0} />);
+    expect(screen.queryByTestId('arbol-mundos')).not.toBeInTheDocument();
+  });
+
+  test('con biopunk (respaldo) y biopunk2 (default) SÍ se monta', () => {
+    localStorage.setItem('chagra:theme', 'biopunk');
+    render(<ArbolDeMundos onNavigate={vi.fn()} mostrarAnimales plantsCount={0} />);
+    expect(screen.getByTestId('arbol-mundos')).toBeInTheDocument();
+    cleanup();
+    localStorage.setItem('chagra:theme', 'biopunk2');
+    render(<ArbolDeMundos onNavigate={vi.fn()} mostrarAnimales plantsCount={0} />);
+    expect(screen.getByTestId('arbol-mundos')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/__tests__/MundosDeMiFinca.espiritu.test.jsx
+++ b/src/components/dashboard/__tests__/MundosDeMiFinca.espiritu.test.jsx
@@ -1,0 +1,91 @@
+/**
+ * MundosDeMiFinca — entrada Pro "El espíritu de su finca" (GATE por capability).
+ *
+ * El avatar-espíritu (#/espiritu, EspirituProScreen) estaba HUÉRFANO: montado y
+ * sirviendo pero sin NINGUNA entrada visible en la UI (la lección de
+ * features-ui-huerfanas-sin-cablear). Este test congela el cableado:
+ *   1. SIN módulo Pro registrado → cero rastro (ni botón muerto ni teaser).
+ *   2. CON módulo Pro (capability avatar-espiritu) → la banda aparece y su
+ *      click navega a la vista real 'espiritu_pro' (case de App.jsx, alias
+ *      hash #/espiritu).
+ *   3. Registro TARDÍO (loadProModules es async) → la banda aparece sola,
+ *      sin remontar el componente.
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+import MundosDeMiFinca from '../MundosDeMiFinca';
+import { registry } from '../../../core/moduleRegistry';
+
+const MODULO_FAKE = {
+  id: 'avatar-espiritu-pro',
+  version: '0.0.0-test',
+  capabilities: ['avatar-espiritu'],
+  mount: async () => ({ default: () => null }),
+};
+
+afterEach(() => {
+  registry.unregister(MODULO_FAKE.id);
+  cleanup();
+});
+
+describe('Entrada Pro — El espíritu de su finca', () => {
+  test('sin módulo Pro registrado NO se renderiza (cero rastro)', () => {
+    render(<MundosDeMiFinca onNavigate={vi.fn()} />);
+    expect(screen.queryByTestId('entrada-espiritu')).not.toBeInTheDocument();
+    expect(screen.queryByText(/espíritu de su finca/i)).not.toBeInTheDocument();
+  });
+
+  test('con capability avatar-espiritu aparece y navega a espiritu_pro', () => {
+    registry.register(MODULO_FAKE);
+    const onNavigate = vi.fn();
+    render(<MundosDeMiFinca onNavigate={onNavigate} />);
+
+    const entrada = screen.getByTestId('entrada-espiritu');
+    expect(entrada).toBeInTheDocument();
+    expect(entrada).toHaveTextContent(/el espíritu de su finca/i);
+    // Sello honesto: la banda declara que es del plan Pro.
+    expect(entrada).toHaveTextContent(/pro/i);
+
+    fireEvent.click(entrada);
+    expect(onNavigate).toHaveBeenCalledWith('espiritu_pro');
+  });
+
+  test('registro TARDÍO del módulo (async) hace aparecer la banda sin remontar', () => {
+    render(<MundosDeMiFinca onNavigate={vi.fn()} />);
+    expect(screen.queryByTestId('entrada-espiritu')).not.toBeInTheDocument();
+
+    // loadProModules corre después del primer render: simular el aterrizaje.
+    act(() => {
+      registry.register(MODULO_FAKE);
+    });
+    expect(screen.getByTestId('entrada-espiritu')).toBeInTheDocument();
+
+    // Y si el módulo se va (unregister), la banda desaparece — sin botón muerto.
+    act(() => {
+      registry.unregister(MODULO_FAKE.id);
+    });
+    expect(screen.queryByTestId('entrada-espiritu')).not.toBeInTheDocument();
+  });
+
+  test('la vista destino espiritu_pro existe en el router real (App.jsx)', async () => {
+    // Anti-huérfano en la otra dirección: la entrada no puede apuntar a una
+    // vista fantasma. Mismo criterio que el test de reachability.
+    // @types/node no está instalado en el repo (gap conocido, mismo criterio y
+    // comentario que MundosDeMiFinca.reachability.test.jsx): tsc no resuelve
+    // los specifiers "node:*", pero vitest/node sí. Irreducible sin sumar la
+    // dependencia @types/node al repo entero.
+    // @ts-expect-error TS2591 — ver comentario arriba.
+    const fs = await import('node:fs');
+    // @ts-expect-error TS2591 — ver comentario arriba.
+    const path = await import('node:path');
+    // @ts-expect-error TS2591 — ver comentario arriba.
+    const { fileURLToPath } = await import('node:url');
+    const __dir = path.dirname(fileURLToPath(import.meta.url));
+    const appSrc = fs.readFileSync(path.resolve(__dir, '../../../App.jsx'), 'utf8');
+    expect(appSrc).toMatch(/case 'espiritu_pro':/);
+    expect(appSrc).toMatch(/espiritu: 'espiritu_pro'/);
+  });
+});

--- a/src/components/dashboard/__tests__/PanelVitalidadEspiritu.test.jsx
+++ b/src/components/dashboard/__tests__/PanelVitalidadEspiritu.test.jsx
@@ -1,0 +1,119 @@
+/**
+ * PanelVitalidadEspiritu — el panel del mockup avatar-biopunk pinta el modelo
+ * groundeado: medidor circular, badge de especies vivas, 4 barras con ícono y
+ * 3 contadores. Los slots sin dato real muestran "—" (dato en camino).
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PanelVitalidadEspiritu from '../PanelVitalidadEspiritu';
+import { buildVitalidadEspiritu } from '../../../services/vitalidadEspirituService';
+import { buildFincaScene } from '../../../services/fincaSceneService';
+
+const NOW = new Date('2026-07-09T10:00:00-05:00');
+
+const procesos = () => [
+  {
+    process_id: 'p-cafe',
+    attributes: {
+      process_type: 'sowing', status: 'active', current_stage: 'flowering',
+      subject_slug: 'coffea_arabica', subject_label: 'Café',
+      created_at: new Date('2025-11-10').getTime(),
+    },
+  },
+  {
+    process_id: 'p-maiz',
+    attributes: {
+      process_type: 'sowing', status: 'active', current_stage: 'harvest',
+      subject_slug: 'zea_mays', subject_label: 'Maíz',
+      created_at: new Date('2026-07-02').getTime(),
+    },
+  },
+];
+
+const modeloSembrado = () => buildVitalidadEspiritu({
+  scene: buildFincaScene({ processes: procesos(), plantAssetsCount: 0 }),
+  processes: procesos(),
+  plants: [],
+  climaSnapshot: {
+    openmeteo: { available: true, forecast_7d: [{ date: '2026-07-09', precip_mm: 5 }] },
+  },
+  condicion: 'nublado',
+  harvestSummary: {
+    totalHarvests: 5,
+    dateRange: { firstMs: new Date('2025-10-05').getTime(), lastMs: NOW.getTime() },
+    trend: { series: [{ period: '2026-07', harvestCount: 3 }] },
+  },
+  now: NOW,
+});
+
+describe('PanelVitalidadEspiritu', () => {
+  it('sin modelo no renderiza nada', () => {
+    const { container } = render(<PanelVitalidadEspiritu modelo={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('finca sembrada: medidor, badge, 4 barras y 3 contadores con datos reales', () => {
+    const modelo = modeloSembrado();
+    render(<PanelVitalidadEspiritu modelo={modelo} />);
+
+    const panel = screen.getByTestId('panel-vitalidad-espiritu');
+    expect(panel).toBeInTheDocument();
+    expect(panel.textContent).toContain('VITALIDAD DEL ESPÍRITU');
+
+    // Medidor circular con el número REAL de vitalidad (buildFincaScene).
+    const vital = screen.getByTestId('pve-vitalidad');
+    expect(vital.getAttribute('data-estado')).toBe('ok');
+    expect(vital.textContent).toContain(String(modelo.vitalidad.valor));
+
+    // Badge de especies vivas (café + maíz = 2).
+    const vivas = screen.getByTestId('pve-especies-vivas');
+    expect(vivas.textContent).toContain('2');
+    expect(vivas.textContent).toContain('ESPECIES VIVAS');
+
+    // 4 barras con su ícono, en el orden del mockup.
+    const ejes = panel.querySelectorAll('.pve-eje');
+    expect(ejes).toHaveLength(4);
+    expect([...ejes].map((e) => e.getAttribute('data-eje')))
+      .toEqual(['clima', 'suelo', 'biodiversidad', 'energia']);
+    expect(panel.textContent).toContain('💧');
+    expect(panel.textContent).toContain('🪱');
+    expect(panel.textContent).toContain('🦋');
+    expect(panel.textContent).toContain('🔥');
+
+    // 3 contadores con el dato real.
+    expect(screen.getByTestId('pve-conteo-especies').textContent).toContain('2');
+    expect(screen.getByTestId('pve-conteo-cosechas').textContent).toContain('5');
+    expect(screen.getByTestId('pve-conteo-anillos').textContent)
+      .toContain('anillos del frailejón');
+    expect(screen.getByTestId('pve-conteo-anillos').getAttribute('data-estado')).toBe('ok');
+
+    // El suelo no tiene diagnóstico persistido → slot pendiente ("—") + nota.
+    const suelo = panel.querySelector('[data-eje="suelo"]');
+    expect(suelo.getAttribute('data-estado')).toBe('pendiente');
+    expect(suelo.textContent).toContain('—');
+    expect(screen.getByTestId('pve-nota-pendiente').textContent).toContain('dato en camino');
+
+    // Trazabilidad: la fuente viaja en el title de cada slot.
+    expect(vital.getAttribute('title')).toBeTruthy();
+    expect(suelo.getAttribute('title')).toContain('DR-SUELOS-1');
+  });
+
+  it('finca vacía: todos los slots en "—" y nota de dato en camino (cero inventos)', () => {
+    const modelo = buildVitalidadEspiritu({
+      scene: buildFincaScene({ processes: [], plantAssetsCount: 0 }),
+      now: NOW,
+    });
+    render(<PanelVitalidadEspiritu modelo={modelo} />);
+    const panel = screen.getByTestId('panel-vitalidad-espiritu');
+
+    expect(screen.getByTestId('pve-vitalidad').getAttribute('data-estado')).toBe('pendiente');
+    for (const eje of panel.querySelectorAll('.pve-eje')) {
+      expect(eje.getAttribute('data-estado')).toBe('pendiente');
+      expect(eje.querySelector('.pve-eje-fill')).toBeNull(); // riel vacío, sin barra fabricada
+    }
+    expect(screen.getByTestId('pve-conteo-cosechas').textContent).toContain('—');
+    expect(screen.getByTestId('pve-nota-pendiente')).toBeInTheDocument();
+    // Ningún dígito inventado en los contadores.
+    expect(screen.getByTestId('pve-conteo-especies').querySelector('b').textContent).toBe('—');
+  });
+});

--- a/src/components/dashboard/__tests__/RelojFrailejon.test.jsx
+++ b/src/components/dashboard/__tests__/RelojFrailejon.test.jsx
@@ -1,0 +1,78 @@
+/**
+ * RelojFrailejon — el anillo temporal del pie del árbol es GROUNDED (años
+ * reales del fincaClockService), un anillo por año, y NO es decoración
+ * huérfana: tocarlo abre "El año de la finca" (vista real ano_finca).
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach, beforeEach } from 'vitest';
+
+vi.mock('../../../services/fincaClockService', () => ({
+  getAniosFinca: vi.fn(),
+}));
+
+import { getAniosFinca } from '../../../services/fincaClockService';
+import RelojFrailejon from '../RelojFrailejon';
+
+afterEach(() => cleanup());
+beforeEach(() => vi.mocked(getAniosFinca).mockReset());
+
+const conAnios = (anios, extra = {}) => {
+  vi.mocked(getAniosFinca).mockResolvedValue({
+    primerAnio: anios[0],
+    anioActual: anios[anios.length - 1],
+    anios,
+    fincaNueva: false,
+    fuente: 'registros',
+    ...extra,
+  });
+};
+
+describe('RelojFrailejon — un anillo por año REAL', () => {
+  test('finca con historia: un anillo por año y los años marcados', async () => {
+    conAnios([2024, 2025, 2026]);
+    const { container } = render(<RelojFrailejon onNavigate={vi.fn()} />);
+    const reloj = await screen.findByTestId('reloj-frailejon');
+    expect(reloj).toBeInTheDocument();
+    // 3 años = 3 anillos
+    expect(container.querySelectorAll('.adm-reloj-anillo')).toHaveLength(3);
+    // los años reales están escritos (marcadores del SVG)
+    expect(container.textContent).toContain('2024');
+    expect(container.textContent).toContain('2026');
+    expect(screen.getByTestId('reloj-frailejon-anios')).toHaveTextContent('3 anillos');
+    expect(screen.getByText(/desde 2024/)).toBeInTheDocument();
+  });
+
+  test('finca nueva: el año actual es el PRIMER anillo (sin historia inventada)', async () => {
+    vi.mocked(getAniosFinca).mockResolvedValue({
+      primerAnio: 2026,
+      anioActual: 2026,
+      anios: [2026],
+      fincaNueva: true,
+      fuente: 'finca-nueva',
+    });
+    const { container } = render(<RelojFrailejon onNavigate={vi.fn()} />);
+    await screen.findByTestId('reloj-frailejon');
+    expect(container.querySelectorAll('.adm-reloj-anillo')).toHaveLength(1);
+    expect(screen.getByTestId('reloj-frailejon-anios')).toHaveTextContent('Su primer anillo');
+    expect(screen.getByText(/2026: su primer anillo/)).toBeInTheDocument();
+  });
+
+  test('no huérfano: tocar el reloj abre "El año de la finca" (ano_finca)', async () => {
+    conAnios([2025, 2026]);
+    const onNavigate = vi.fn();
+    render(<RelojFrailejon onNavigate={onNavigate} />);
+    fireEvent.click(await screen.findByTestId('reloj-frailejon'));
+    expect(onNavigate).toHaveBeenCalledWith('ano_finca');
+  });
+
+  test('servicio sin datos (degradado): no dibuja nada inventado (render null)', async () => {
+    // El contrato del servicio es SIEMPRE resolver (sus fuentes fallidas se
+    // tragan adentro); si aun así llegara vacío, el reloj no inventa nada.
+    vi.mocked(getAniosFinca).mockResolvedValue(null);
+    render(<RelojFrailejon onNavigate={vi.fn()} />);
+    await waitFor(() => expect(getAniosFinca).toHaveBeenCalled());
+    expect(screen.queryByTestId('reloj-frailejon')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/arbol-de-mundos.css
+++ b/src/components/dashboard/arbol-de-mundos.css
@@ -1,0 +1,303 @@
+/*
+ * arbol-de-mundos.css — animaciones y piel del MENÚ-ÁRBOL ORGÁNICO (adm-) y
+ * del RELOJ DEL FRAILEJÓN (adm-reloj-) del home biopunk.
+ *
+ * Todo CSS puro (cero JS por frame), prefijo `adm-` para no chocar con el
+ * resto del home. prefers-reduced-motion apaga TODAS las animaciones dejando
+ * un estado estático digno (misma receta que scene-finca-organismo.css).
+ */
+
+.adm {
+  position: relative;
+  margin: 0 0 1rem;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 90% at 50% 0%, rgba(13, 30, 68, 0.85), rgba(2, 4, 12, 0.95) 70%),
+    #04060f;
+  border: 1px solid rgba(45, 255, 196, 0.22);
+  box-shadow:
+    0 0 0 1px rgba(2, 4, 12, 0.6),
+    0 12px 40px rgba(0, 0, 0, 0.45),
+    inset 0 0 60px rgba(45, 255, 196, 0.04);
+}
+
+.adm-head {
+  padding: 1rem 1.1rem 0.25rem;
+}
+
+.adm-tit {
+  margin: 0;
+  font-family: 'Baloo 2', system-ui, sans-serif;
+  font-size: 1.35rem;
+  font-weight: 800;
+  line-height: 1.15;
+  color: #eafff6;
+  text-shadow: 0 0 18px rgba(45, 255, 196, 0.35);
+}
+
+.adm-sub {
+  margin: 0.3rem 0 0;
+  font-size: 0.82rem;
+  line-height: 1.35;
+  color: #9fd4c4;
+}
+
+.adm-lienzo {
+  position: relative;
+  width: 100%;
+}
+
+.adm-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* ── vainas (las entradas a los mundos) ─────────────────────────────────── */
+
+.adm-nodo {
+  cursor: pointer;
+  outline: none;
+}
+
+.adm-vaina-halo {
+  opacity: 0.55;
+  animation: adm-halo 3.6s ease-in-out infinite;
+}
+
+.adm-vaina-nucleo {
+  animation: adm-nucleo 3.6s ease-in-out infinite;
+}
+
+.adm-espora {
+  animation: adm-espora 5s ease-in-out infinite;
+  opacity: 0.85;
+  filter: drop-shadow(0 0 3px #eafff6);
+}
+
+/* foco/hover visibles: la membrana se enciende (accesibilidad teclado) */
+.adm-nodo:hover .adm-vaina-membrana,
+.adm-nodo:focus-visible .adm-vaina-membrana {
+  stroke: #eafff6;
+  stroke-width: 2.2;
+  filter: drop-shadow(0 0 8px var(--adm-acc, #2dffc4));
+}
+
+.adm-nodo:focus-visible .adm-vaina-halo {
+  opacity: 1;
+}
+
+.adm-nodo:active .adm-vaina-membrana {
+  filter: drop-shadow(0 0 12px var(--adm-acc, #2dffc4));
+}
+
+/* ── savia que fluye por tronco y ramas ─────────────────────────────────── */
+
+.adm-sap {
+  stroke-dasharray: 6 46;
+  animation: adm-sap 3.2s linear infinite;
+}
+
+.adm-sap-tronco {
+  stroke-dasharray: 10 70;
+  animation-duration: 4.2s;
+}
+
+/* ── corazón que late + ondas ───────────────────────────────────────────── */
+
+.adm-heart {
+  transform-origin: 195px 614px;
+  animation: adm-beat 2.4s ease-in-out infinite;
+  filter: drop-shadow(0 0 6px rgba(45, 255, 196, 0.55));
+}
+
+.adm-heart-wave {
+  transform-origin: 195px 614px;
+  animation: adm-wave 2.4s ease-out infinite;
+  opacity: 0;
+}
+
+.adm-hw2 {
+  animation-delay: 0.6s;
+}
+
+/* ── noche viva: estrellas y cocuyos ────────────────────────────────────── */
+
+.adm-tw {
+  animation: adm-tw 3.4s ease-in-out infinite;
+}
+
+.adm-t2 { animation-delay: -1.2s; }
+.adm-t3 { animation-delay: -2.3s; }
+
+.adm-fly {
+  animation: adm-fly 9s ease-in-out infinite;
+  filter: drop-shadow(0 0 4px currentcolor);
+}
+
+.adm-f2 { animation-delay: -3s; animation-duration: 11s; }
+.adm-f3 { animation-delay: -6s; animation-duration: 10s; }
+
+/* ── EL RELOJ DEL FRAILEJÓN (pie del árbol) ─────────────────────────────── */
+
+.adm-reloj {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  width: calc(100% - 2rem);
+  margin: 0 1rem 1rem;
+  padding: 0.7rem 0.9rem;
+  min-height: 96px;
+  border-radius: 1rem;
+  border: 1px solid rgba(157, 255, 63, 0.28);
+  background: rgba(7, 16, 48, 0.55);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.adm-reloj:hover,
+.adm-reloj:focus-visible {
+  border-color: rgba(45, 255, 196, 0.7);
+  box-shadow: 0 0 18px rgba(45, 255, 196, 0.18);
+  outline: none;
+}
+
+.adm-reloj-svg {
+  flex: 0 0 96px;
+  width: 96px;
+  height: 96px;
+}
+
+.adm-reloj-anillo {
+  transform-origin: 60px 60px;
+  animation: adm-anillo 0.9s ease-out backwards;
+}
+
+.adm-reloj-anillo-actual {
+  filter: drop-shadow(0 0 4px rgba(45, 255, 196, 0.8));
+}
+
+.adm-reloj-marca {
+  animation: adm-aparece 0.9s ease-out backwards;
+}
+
+.adm-reloj-corazon {
+  transform-origin: 60px 60px;
+  animation: adm-beat-suave 3.2s ease-in-out infinite;
+  filter: drop-shadow(0 0 6px rgba(255, 181, 79, 0.7));
+}
+
+.adm-reloj-texto {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  min-width: 0;
+}
+
+.adm-reloj-cab {
+  font-family: ui-monospace, monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  color: #9dff3f;
+  opacity: 0.85;
+}
+
+.adm-reloj-anios {
+  font-family: 'Baloo 2', system-ui, sans-serif;
+  font-size: 1.02rem;
+  font-weight: 800;
+  color: #eafff6;
+  line-height: 1.2;
+}
+
+.adm-reloj-nota {
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: #9fd4c4;
+}
+
+.adm-reloj-ir {
+  margin-top: 0.15rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #2dffc4;
+}
+
+/* ── keyframes ──────────────────────────────────────────────────────────── */
+
+@keyframes adm-sap {
+  to { stroke-dashoffset: -52; }
+}
+
+@keyframes adm-halo {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 0.85; }
+}
+
+@keyframes adm-nucleo {
+  0%, 100% { opacity: 0.75; }
+  50% { opacity: 1; }
+}
+
+@keyframes adm-espora {
+  0%, 100% { transform: translate(0, 0); opacity: 0.5; }
+  50% { transform: translate(4px, -5px); opacity: 1; }
+}
+
+@keyframes adm-beat {
+  0%, 100% { transform: scale(1); }
+  12% { transform: scale(1.12); }
+  24% { transform: scale(1); }
+  36% { transform: scale(1.08); }
+  48% { transform: scale(1); }
+}
+
+@keyframes adm-beat-suave {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.14); }
+}
+
+@keyframes adm-wave {
+  0% { transform: scale(0.6); opacity: 0.8; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+
+@keyframes adm-tw {
+  0%, 100% { opacity: 0.25; }
+  50% { opacity: 1; }
+}
+
+@keyframes adm-fly {
+  0%, 100% { transform: translate(0, 0); opacity: 0.4; }
+  25% { transform: translate(16px, -14px); opacity: 1; }
+  55% { transform: translate(-10px, -26px); opacity: 0.6; }
+  80% { transform: translate(8px, -8px); opacity: 0.95; }
+}
+
+@keyframes adm-anillo {
+  from { opacity: 0; transform: scale(0.7); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes adm-aparece {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ── reduced motion: quietud digna, nada desaparece ─────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .adm *,
+  .adm-reloj * {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .adm-heart-wave { opacity: 0.35; }
+  .adm-sap { stroke-dasharray: none; opacity: 0.5; }
+  .adm-reloj-anillo,
+  .adm-reloj-marca { opacity: 1; }
+}

--- a/src/components/dashboard/guardian-espiritu.css
+++ b/src/components/dashboard/guardian-espiritu.css
@@ -1,0 +1,191 @@
+/*
+ * guardian-espiritu.css — el SELECTOR DEL GUARDIÁN (espíritu de la finca) en el
+ * home vivo. Estética biopunk portada 1:1 del mockup aprobado
+ * #/mockups/avatar-biopunk (AvatarGameBiopunk): tarjeta oscura de savia, chips
+ * de especie con glow neón por acento, nombre científico en itálica.
+ *
+ * El acento (--ge-acc / --ge-acc-rgb) lo re-tiñe el guardián elegido, igual que
+ * el HUD del mockup. Respeta prefers-reduced-motion.
+ */
+
+.ge {
+  --ge-savia: #2dffc4;
+  --ge-crema: #eafff6;
+  --ge-tinta: #a9c3d2;
+  --ge-mono: ui-monospace, 'SF Mono', 'Roboto Mono', monospace;
+  --ge-acc: #ffb54f;
+  --ge-acc-rgb: 255, 181, 79;
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+  padding: 14px 14px 16px;
+  border: 1px solid rgba(45, 255, 196, 0.16);
+  background:
+    radial-gradient(120% 90% at 12% -10%, rgba(var(--ge-acc-rgb), 0.14), transparent 60%),
+    linear-gradient(180deg, #071030 0%, #060c22 60%, #04081a 100%);
+  box-shadow: 0 8px 40px rgba(2, 4, 18, 0.55), inset 0 0 40px rgba(45, 255, 196, 0.05);
+  transition: box-shadow 0.5s ease, border-color 0.5s ease;
+}
+.ge.on-glow {
+  border-color: rgba(var(--ge-acc-rgb), 0.4);
+  box-shadow: 0 8px 46px rgba(2, 4, 18, 0.6), 0 0 40px rgba(var(--ge-acc-rgb), 0.14),
+    inset 0 0 40px rgba(45, 255, 196, 0.05);
+}
+
+/* estrellas de fondo, sutiles */
+.ge-stars { position: absolute; inset: 0; pointer-events: none; opacity: 0.7; }
+
+/* ---------------------------- cabecera ----------------------------------- */
+.ge-head { position: relative; display: flex; flex-direction: column; gap: 2px; margin-bottom: 12px; }
+.ge-kicker {
+  font-family: var(--ge-mono);
+  font-size: 9.5px;
+  letter-spacing: 2.4px;
+  color: var(--ge-savia);
+  opacity: 0.85;
+}
+.ge-title {
+  font-weight: 800;
+  font-size: 16px;
+  line-height: 1.15;
+  letter-spacing: 0.2px;
+  color: var(--ge-crema);
+  margin: 0;
+}
+.ge-sub { font-size: 11.5px; color: var(--ge-tinta); margin: 2px 0 0; line-height: 1.35; }
+
+/* --------------------------- héroe (guardián elegido) -------------------- */
+.ge-hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(var(--ge-acc-rgb), 0.1), rgba(var(--ge-acc-rgb), 0.02));
+  border: 1px solid rgba(var(--ge-acc-rgb), 0.28);
+  margin-bottom: 12px;
+}
+.ge-hero-avatar {
+  flex: 0 0 auto;
+  width: 78px;
+  height: 78px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 36%, rgba(var(--ge-acc-rgb), 0.28), rgba(var(--ge-acc-rgb), 0.02) 70%);
+}
+.ge-hero-avatar svg { width: 100%; height: 100%; }
+.ge-hero-txt { min-width: 0; }
+.ge-hero-rol {
+  font-family: var(--ge-mono);
+  font-size: 8.5px;
+  letter-spacing: 1.8px;
+  color: var(--ge-savia);
+  opacity: 0.9;
+  margin: 0 0 1px;
+}
+.ge-hero-nombre { font-size: 17px; font-weight: 800; color: var(--ge-crema); margin: 0; line-height: 1.1; }
+.ge-hero-cientifico {
+  font-style: italic;
+  font-size: 12px;
+  color: var(--ge-acc);
+  margin: 1px 0 0;
+  transition: color 0.4s ease;
+}
+.ge-hero-frase { font-size: 11.5px; color: var(--ge-tinta); margin: 4px 0 0; line-height: 1.35; }
+.ge-hero-fuente {
+  display: inline-block;
+  margin-top: 5px;
+  font-family: var(--ge-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.6px;
+  color: rgba(169, 195, 210, 0.7);
+}
+
+/* --------------------------- chips de especie --------------------------- */
+.ge-chips {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: 8px;
+}
+.ge-chip {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 10px 6px 9px;
+  border-radius: 14px;
+  border: 1px solid rgba(45, 255, 196, 0.18);
+  background: rgba(13, 30, 68, 0.5);
+  color: var(--ge-tinta);
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.18s ease, border-color 0.25s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+.ge-chip-avatar {
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 36%, rgba(45, 255, 196, 0.16), rgba(45, 255, 196, 0.01) 70%);
+}
+.ge-chip-avatar svg { width: 100%; height: 100%; }
+.ge-chip-nombre { font-size: 11px; font-weight: 700; line-height: 1.15; color: var(--ge-crema); }
+.ge-chip-eje { font-size: 8.5px; line-height: 1.2; color: rgba(169, 195, 210, 0.8); }
+.ge-chip:hover { border-color: rgba(45, 255, 196, 0.42); transform: translateY(-1px); }
+.ge-chip.on {
+  border-color: var(--ge-chip-acc, var(--ge-savia));
+  background: linear-gradient(180deg, rgba(var(--ge-chip-acc-rgb), 0.24), rgba(var(--ge-chip-acc-rgb), 0.05));
+  box-shadow: 0 0 20px rgba(var(--ge-chip-acc-rgb), 0.38);
+}
+.ge-chip.on .ge-chip-avatar {
+  background: radial-gradient(circle at 42% 36%, rgba(var(--ge-chip-acc-rgb), 0.4), rgba(var(--ge-chip-acc-rgb), 0.05) 72%);
+}
+.ge-chip.on .ge-chip-nombre { color: #fff; }
+.ge-chip:focus-visible { outline: 2px solid var(--ge-crema); outline-offset: 2px; }
+.ge-chip-check {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 9px;
+  line-height: 1;
+  color: #04160f;
+  background: var(--ge-chip-acc, var(--ge-savia));
+  box-shadow: 0 0 8px rgba(var(--ge-chip-acc-rgb), 0.7);
+}
+
+/* -------------------------- animaciones (biopunk) ------------------------ */
+.ge-av-vuela { animation: ge-vuela 3.4s ease-in-out infinite; transform-origin: center; }
+.ge-av-flota { animation: ge-flota 3.8s ease-in-out infinite; transform-origin: center; }
+.ge-ala { animation: ge-ala 0.28s ease-in-out infinite alternate; transform-origin: 4px 0; }
+.ge-aleteo { animation: ge-aleteo 0.16s ease-in-out infinite alternate; transform-origin: -1px -5px; }
+
+@keyframes ge-vuela {
+  0%, 100% { transform: translateY(0) rotate(-1.5deg); }
+  50% { transform: translateY(-3px) rotate(1.5deg); }
+}
+@keyframes ge-flota {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-2.5px); }
+}
+@keyframes ge-ala {
+  from { transform: scaleY(0.72) rotate(-6deg); }
+  to { transform: scaleY(1) rotate(4deg); }
+}
+@keyframes ge-aleteo {
+  from { transform: scaleX(0.55); opacity: 0.5; }
+  to { transform: scaleX(1); opacity: 0.8; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ge-av-vuela, .ge-av-flota, .ge-ala, .ge-aleteo { animation: none !important; }
+  .ge-chip { transition: none; }
+}

--- a/src/components/dashboard/mundos-finca.css
+++ b/src/components/dashboard/mundos-finca.css
@@ -502,6 +502,82 @@ html[data-theme="biopunk"] .mf-indice-item {
 html:not([data-theme]) .mf-indice-txt small,
 html[data-theme="biopunk"] .mf-indice-txt small { color: rgb(var(--c-slate-300)); }
 
+/* ── Entrada Pro: EL ESPÍRITU DE SU FINCA ─────────────────────────────────────
+   Banda discreta bajo la grilla de mundos (gated por capability
+   avatar-espiritu — sin módulo Pro no se renderiza). No es una lámina de
+   papel más: es una VENTANA DE NOCHE en el cuaderno — la finca entera vista
+   como un solo ser vivo. Autocontenida en oscuro (misma clave #0f172a de la
+   experiencia), así lee igual sobre el cuaderno crema y sobre los temas navy. */
+.mf-espiritu {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 12px;
+  min-height: 58px;
+  padding: 10px 14px;
+  border-radius: 15px;
+  border: 1.5px solid rgba(94, 234, 178, 0.28);
+  background:
+    radial-gradient(120% 160% at 12% 20%, rgba(45, 212, 160, 0.16), transparent 55%),
+    linear-gradient(120deg, #0f172a, #123028);
+  color: #d9f5e6;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.mf-espiritu-glifo {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  color: #5eeab2;
+  background: rgba(94, 234, 178, 0.1);
+  animation: mf-espiritu-respira 4.5s ease-in-out infinite;
+}
+.mf-espiritu-txt { flex: 1 1 auto; min-width: 0; }
+.mf-espiritu-txt b {
+  display: block;
+  font-family: var(--mf-display, 'Baloo 2', 'Nunito', system-ui, sans-serif);
+  font-weight: 800;
+  font-size: 14.5px;
+  color: #eafcf2;
+}
+.mf-espiritu-txt small {
+  display: block;
+  font-size: 12.5px;
+  line-height: 1.35;
+  color: rgba(217, 245, 230, 0.78);
+}
+.mf-espiritu-sello {
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 234, 178, 0.45);
+  color: #5eeab2;
+}
+.mf-espiritu:focus-visible {
+  outline: 3px solid #5eeab2;
+  outline-offset: 2px;
+}
+.mf-espiritu:active { transform: scale(0.99); }
+/* La respiración del espíritu: el aura del glifo crece y afloja, lenta. */
+@keyframes mf-espiritu-respira {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(94, 234, 178, 0.0); transform: scale(1); }
+  50% { box-shadow: 0 0 0 6px rgba(94, 234, 178, 0.12); transform: scale(1.05); }
+}
+/* Sobre los temas navy la banda ya es oscura: solo afinar el borde al sistema. */
+html:not([data-theme]) .mf-espiritu,
+html[data-theme="biopunk"] .mf-espiritu {
+  border-color: color-mix(in srgb, #5eeab2 30%, rgb(var(--c-surface-border, 51 65 85)));
+}
+
 /* ── Accesibilidad de movimiento ──────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .mf-card {
@@ -511,6 +587,8 @@ html[data-theme="biopunk"] .mf-indice-txt small { color: rgb(var(--c-slate-300))
   .mf-card:active,
   .mf-entrada:active { transform: none; }
   .mf-entrada { transition: none; }
+  .mf-espiritu-glifo { animation: none; }
+  .mf-espiritu:active { transform: none; }
   @media (hover: hover) {
     .mf-card:hover { transform: none; }
   }

--- a/src/components/dashboard/panel-vitalidad-espiritu.css
+++ b/src/components/dashboard/panel-vitalidad-espiritu.css
@@ -1,0 +1,219 @@
+/* ===========================================================================
+ * PANEL DE VITALIDAD DEL ESPÍRITU — home "menú vivo" (FincaVivaHero).
+ * ---------------------------------------------------------------------------
+ * Port fiel del panel `agb-panel` del mockup aprobado #/mockups/avatar-biopunk
+ * (avatar-game-biopunk.css) al home real, prefijo `pve-`:
+ * vidrio nocturno con blur, filo superior luminoso, anillo de vitalidad neón,
+ * barras con gradiente c1→c2 + glow, captions monoespaciadas. La paleta va
+ * FIJA (los mismos hex del mockup) porque el panel solo se monta con la
+ * escena Finca Organismo (tema biopunk2) — es SU lectura de vida.
+ * Todo GPU-friendly (transform/opacity/width) y con estado estático digno
+ * bajo prefers-reduced-motion. rsvg-safe (sin foreignObject).
+ * =========================================================================== */
+
+.pve {
+  --pve-savia: #2dffc4;
+  --pve-acido: #9dff3f;
+  --pve-ambar: #ffb54f;
+  --pve-crema: #eafff6;
+  --pve-tinta: #7fa3b8; /* la tinta del mockup (#5b7f93) aclarada un paso:
+                           sobre el home real hay menos negro detrás */
+  --pve-vidrio: rgba(7, 16, 48, 0.72);
+  --pve-borde: rgba(45, 255, 196, 0.28);
+  --pve-acc: var(--pve-ambar); /* acento de la guardiana (la angelita) */
+  --pve-acc-rgb: 255, 181, 79;
+  --pve-mono: ui-monospace, 'SFMono-Regular', Menlo, monospace;
+
+  position: relative;
+  overflow: hidden;
+  margin-top: 10px;
+  border-radius: 16px;
+  border: 1px solid var(--pve-borde);
+  background:
+    radial-gradient(120% 90% at 85% -20%, rgba(45, 255, 196, 0.08), transparent 60%),
+    var(--pve-vidrio);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow:
+    0 6px 30px rgba(2, 4, 18, 0.6),
+    inset 0 0 24px rgba(45, 255, 196, 0.05);
+  padding: 12px 14px 12px;
+  color: var(--pve-crema);
+  opacity: 0;
+  transform: translateY(10px);
+  animation: pve-rise 0.7s 0.25s cubic-bezier(0.2, 0.8, 0.3, 1) forwards;
+}
+
+/* filo superior con el acento: el panel es la lectura de vida del espíritu */
+.pve::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 12px;
+  right: 12px;
+  height: 1.5px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, transparent, var(--pve-acc), transparent);
+  opacity: 0.8;
+}
+
+@keyframes pve-rise {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.pve-cab {
+  font-family: var(--pve-mono);
+  font-size: 9px;
+  letter-spacing: 1.8px;
+  color: var(--pve-savia);
+  opacity: 0.85;
+  margin: 0 0 8px;
+}
+
+/* ── cuerpo: apilado en móvil; en pantalla ancha el medidor y las barras
+      conviven lado a lado y los conteos cierran abajo ─────────────────────── */
+.pve-cuerpo {
+  display: grid;
+  gap: 10px;
+}
+@media (min-width: 480px) {
+  .pve-cuerpo {
+    grid-template-columns: auto 1fr;
+    column-gap: 18px;
+    align-items: center;
+  }
+  .pve-conteos { grid-column: 1 / -1; }
+}
+
+/* ── medidor circular + especies vivas ── */
+.pve-vital {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.pve-ring-track { stroke: rgba(var(--pve-acc-rgb), 0.14); }
+.pve-ring-val {
+  stroke: var(--pve-acc);
+  filter: drop-shadow(0 0 4px rgba(var(--pve-acc-rgb), 0.8));
+  transition: stroke-dashoffset 1.1s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+.pve-ring-num {
+  font-size: 15px;
+  font-weight: 800;
+  fill: var(--pve-crema);
+  font-family: inherit;
+}
+.pve-anillo-wrap[data-estado='pendiente'] .pve-ring-track {
+  stroke-dasharray: 2 5;
+}
+.pve-vivas-num {
+  display: block;
+  font-weight: 800;
+  font-size: 26px;
+  line-height: 1;
+  color: var(--pve-crema);
+  text-shadow: 0 0 14px rgba(var(--pve-acc-rgb), 0.6);
+}
+.pve-vivas-num small {
+  font-size: 12px;
+  opacity: 0.7;
+  font-weight: 600;
+}
+.pve-vivas-cap {
+  display: block;
+  font-family: var(--pve-mono);
+  font-size: 8px;
+  letter-spacing: 1px;
+  color: var(--pve-tinta);
+  margin-top: 3px;
+}
+
+/* ── las 4 barras (💧 🪱 🦋 🔥) ── */
+.pve-ejes {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+.pve-eje {
+  display: grid;
+  grid-template-columns: 16px 1fr 30px;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+}
+.pve-eje-emoji { font-size: 11px; line-height: 1; }
+.pve-eje-riel {
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(45, 255, 196, 0.12);
+  overflow: hidden;
+}
+.pve-eje-fill {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  background: linear-gradient(90deg, var(--pve-c1, var(--pve-savia)), var(--pve-c2, var(--pve-acido)));
+  box-shadow: 0 0 6px var(--pve-c1, var(--pve-savia));
+  transition: width 1.1s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+.pve-eje-val {
+  font-family: var(--pve-mono);
+  font-size: 9px;
+  color: var(--pve-tinta);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* SLOT PENDIENTE: riel punteado, sin fill — "dato en camino", nunca inventado */
+.pve-eje[data-estado='pendiente'] .pve-eje-riel {
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(45, 255, 196, 0.22) 0 5px,
+      transparent 5px 10px
+    );
+  opacity: 0.55;
+}
+
+/* ── conteos (🍃 ✦ ◎ anillos) ── */
+.pve-conteos {
+  margin: 0;
+  padding-top: 9px;
+  border-top: 1px dashed rgba(45, 255, 196, 0.18);
+  font-family: var(--pve-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.4px;
+  color: var(--pve-tinta);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+}
+.pve-conteos b { color: var(--pve-crema); font-weight: 600; }
+.pve-conteos i { font-style: normal; }
+.pve-conteos [data-estado='pendiente'] { opacity: 0.7; }
+.pve-conteos span { display: inline-flex; align-items: center; gap: 4px; }
+.pve-anillos-svg {
+  flex: none;
+  filter: drop-shadow(0 0 3px rgba(45, 255, 196, 0.5));
+}
+
+/* nota de honestidad: qué significa el "—" */
+.pve-nota {
+  margin: 9px 0 0;
+  font-family: var(--pve-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.4px;
+  color: var(--pve-tinta);
+  opacity: 0.85;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pve {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+  .pve-ring-val,
+  .pve-eje-fill { transition: none; }
+}

--- a/src/components/tuberculos/LaminaAporque.jsx
+++ b/src/components/tuberculos/LaminaAporque.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+/**
+ * LaminaAporque — lámina en CORTE del aporque, la labor propia de los
+ * tubérculos. SVG propio de cuaderno de campo: se ve la finca "por dentro",
+ * como si cortáramos el surco con una pala.
+ *
+ *   ANTES  →  la mata con el cuello descubierto y un par de tubérculos
+ *             asomando (los que se enverdecen al sol).
+ *   APORQUE → se arrima tierra al pie tapando el cuello (la flecha).
+ *   DESPUÉS →  el camellón alto: los tubérculos engordan tapados, a oscuras,
+ *             lejos del sol y con menos paso para la polilla.
+ *
+ * Es DECORATIVA (aria-hidden): ilustra la sección "Aporque" de la ficha; el
+ * texto explica el porqué. Trazo redondeado, colores Tailwind sobre
+ * currentColor por grupo para respirar con los temas.
+ */
+export default function LaminaAporque() {
+  return (
+    <svg
+      viewBox="0 0 360 120"
+      role="img"
+      aria-hidden="true"
+      className="w-full h-auto select-none"
+      data-testid="lamina-aporque"
+    >
+      {/* línea del nivel del suelo original (de referencia) */}
+      <line
+        x1="6" y1="70" x2="354" y2="70"
+        stroke="currentColor" strokeWidth="1.5" strokeDasharray="4 5"
+        strokeLinecap="round" className="text-amber-700/50"
+      />
+
+      {/* ── ANTES · cuello descubierto ── */}
+      <g>
+        {/* terrón bajo, plano */}
+        <path d="M14 70 q 44 -6 88 0 v 40 h -88 z" fill="currentColor" className="text-amber-900/45" />
+        {/* la mata */}
+        <g stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" fill="none" className="text-lime-400">
+          <line x1="58" y1="70" x2="58" y2="40" />
+          <path d="M58 56 q -12 -3 -17 -13" />
+          <path d="M58 50 q 12 -3 17 -13" />
+        </g>
+        {/* tubérculos: uno tapado, uno asomando (verde al sol) */}
+        <ellipse cx="44" cy="86" rx="8" ry="5.5" fill="currentColor" className="text-amber-300/85" />
+        <ellipse cx="70" cy="70" rx="8" ry="5.5" fill="currentColor" className="text-lime-500/80" />
+        {/* solecito que enverdece al descubierto */}
+        <g className="text-amber-300" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+          <circle cx="90" cy="30" r="6" fill="currentColor" opacity="0.9" />
+          <line x1="90" y1="18" x2="90" y2="14" />
+          <line x1="101" y1="24" x2="104" y2="21" />
+          <line x1="79" y1="24" x2="76" y2="21" />
+        </g>
+      </g>
+
+      {/* ── FLECHA · se arrima tierra al pie ── */}
+      <g className="text-slate-300" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" fill="none">
+        <path d="M150 52 q 30 -10 60 0" />
+        <path d="M198 45 l 14 7 l -13 8" />
+      </g>
+      <text x="180" y="34" textAnchor="middle" className="fill-current text-slate-400" fontSize="11">aporque</text>
+
+      {/* ── DESPUÉS · camellón alto, cuello tapado ── */}
+      <g>
+        {/* camellón alto (más tierra arrimada) */}
+        <path d="M244 70 q 52 -34 104 0 v 44 h -104 z" fill="currentColor" className="text-amber-800/55" />
+        {/* la mata, ahora con el cuello enterrado */}
+        <g stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" fill="none" className="text-lime-400">
+          <line x1="296" y1="44" x2="296" y2="18" />
+          <path d="M296 32 q -12 -3 -17 -13" />
+          <path d="M296 26 q 12 -3 17 -13" />
+        </g>
+        {/* varios tubérculos engordando tapados, a oscuras */}
+        <g className="text-amber-300/85">
+          <ellipse cx="278" cy="84" rx="8" ry="5.5" fill="currentColor" />
+          <ellipse cx="300" cy="92" rx="9" ry="6" fill="currentColor" />
+          <ellipse cx="316" cy="82" rx="7.5" ry="5" fill="currentColor" />
+        </g>
+        {/* rótulos de la ganancia */}
+        <text x="296" y="112" textAnchor="middle" className="fill-current text-emerald-400/90" fontSize="9">tapados · a oscuras</text>
+      </g>
+    </svg>
+  );
+}

--- a/src/components/tuberculos/LaminaSiembra.jsx
+++ b/src/components/tuberculos/LaminaSiembra.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+
+/**
+ * LaminaSiembra — la ilustración insignia del mundo "Tubérculos y raíces".
+ *
+ * SVG propio (nada de stock), de cuaderno de campo: las TRES formas de sembrar
+ * un tubérculo o raíz, de izquierda a derecha —
+ *
+ *   TUBÉRCULO-SEMILLA  una papa brotada enterrada en el surco   (papa, oca…)
+ *   ESQUEJE / ESTACA   un trozo de tallo (cangre) inclinado     (yuca, batata)
+ *   COLINO (HIJUELO)   el hijuelo del cuello de la mata madre   (arracacha)
+ *
+ * Es DECORATIVA (aria-hidden): acompaña al explicador "casi ninguno se siembra
+ * de semilla" del hub; las tarjetas de al lado son la navegación real. La forma
+ * que se quiera resaltar sube su opacidad y baja la de las otras (prop `activo`),
+ * igual que CaminoDelAgua en el mundo Agua; sin `activo` se ven las tres parejas.
+ *
+ * Trazo: línea redondeada, formas simples, colores en clases Tailwind sobre
+ * currentColor por grupo para respirar con los temas.
+ */
+export default function LaminaSiembra({ activo = null }) {
+  const dim = (id) => (activo && activo !== id ? 'opacity-40' : 'opacity-100');
+  return (
+    <svg
+      viewBox="0 0 360 120"
+      role="img"
+      aria-hidden="true"
+      className="w-full h-auto select-none"
+      data-testid="lamina-siembra"
+    >
+      {/* línea de tierra que une las tres formas */}
+      <path
+        d="M6 84 Q 90 79 180 84 T 354 82"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        className="text-amber-700/60"
+      />
+
+      {/* ── FORMA 1 · tubérculo-semilla: papa brotada en el surco ── */}
+      <g className={`transition-opacity duration-300 ${dim('tuberculo')}`}>
+        {/* montículo de tierra */}
+        <path d="M18 84 q 30 -20 60 0 z" fill="currentColor" className="text-amber-900/40" />
+        {/* la papa-semilla enterrada */}
+        <ellipse cx="48" cy="80" rx="15" ry="10" fill="currentColor" className="text-amber-300/80" />
+        {/* ojos de la papa */}
+        <g className="text-amber-800/70">
+          <circle cx="42" cy="78" r="1.4" fill="currentColor" />
+          <circle cx="52" cy="82" r="1.4" fill="currentColor" />
+          <circle cx="55" cy="76" r="1.4" fill="currentColor" />
+        </g>
+        {/* brotes que salen a la superficie */}
+        <g stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" fill="none" className="text-lime-400">
+          <path d="M45 71 q -3 -14 -8 -22" />
+          <path d="M40 55 q -7 -2 -10 -8" />
+          <path d="M51 71 q 3 -12 9 -18" />
+          <path d="M58 57 q 7 -2 10 -7" />
+        </g>
+      </g>
+
+      {/* ── FORMA 2 · esqueje / estaca: cangre de yuca inclinado ── */}
+      <g className={`transition-opacity duration-300 ${dim('esqueje')}`}>
+        {/* montículo */}
+        <path d="M150 84 q 30 -18 60 0 z" fill="currentColor" className="text-amber-900/40" />
+        {/* la estaca (trozo de tallo) enterrada 2/3, inclinada */}
+        <line x1="168" y1="92" x2="196" y2="44" stroke="currentColor" strokeWidth="6" strokeLinecap="round" className="text-amber-700/80" />
+        {/* nudos / yemas del cangre */}
+        <g className="text-lime-300">
+          <circle cx="176" cy="78" r="2.2" fill="currentColor" />
+          <circle cx="184" cy="64" r="2.2" fill="currentColor" />
+          <circle cx="192" cy="50" r="2.2" fill="currentColor" />
+        </g>
+        {/* brote de la yema de arriba */}
+        <path d="M192 50 q 8 -3 12 -11" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" className="text-lime-400" />
+        {/* raicillas que salen de la parte enterrada */}
+        <g stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" fill="none" className="text-amber-200/70">
+          <path d="M170 86 q -6 5 -8 12" />
+          <path d="M174 88 q 2 7 -1 13" />
+          <path d="M178 88 q 7 5 8 12" />
+        </g>
+      </g>
+
+      {/* ── FORMA 3 · colino: hijuelo del cuello de la mata madre ── */}
+      <g className={`transition-opacity duration-300 ${dim('colino')}`}>
+        {/* montículo */}
+        <path d="M282 84 q 30 -18 60 0 z" fill="currentColor" className="text-amber-900/40" />
+        {/* la cepa / cuello de la arracacha (media enterrada) */}
+        <path d="M300 84 q 12 -16 24 0 z" fill="currentColor" className="text-amber-400/70" />
+        {/* el colino (hijuelo) que se separa, inclinado con su yema arriba */}
+        <line x1="312" y1="72" x2="322" y2="46" stroke="currentColor" strokeWidth="5" strokeLinecap="round" className="text-lime-600/80" />
+        <circle cx="322" cy="45" r="2.6" fill="currentColor" className="text-lime-300" />
+        {/* hojas de la mata madre saliendo del cuello */}
+        <g stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" fill="none" className="text-emerald-400">
+          <path d="M308 70 q -6 -14 -12 -20" />
+          <path d="M312 68 q 0 -16 -2 -24" />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/core/moduleRegistry.js
+++ b/src/core/moduleRegistry.js
@@ -28,6 +28,33 @@
 class ModuleRegistry {
   constructor() {
     this._modules = new Map();
+    // Suscriptores a cambios del registro. Los módulos Pro se cargan ASYNC
+    // (loadProModules corre después del primer render), así que la UI que
+    // gatea por capability necesita enterarse cuando un módulo aterriza —
+    // sin esto, un chequeo único al montar se pierde el registro tardío y
+    // la entrada Pro queda invisible aunque el módulo esté servido.
+    this._listeners = new Set();
+  }
+
+  /**
+   * Suscribe un callback a cambios del registro (register/unregister).
+   * Contrato compatible con useSyncExternalStore: devuelve el unsubscribe.
+   * @param {() => void} fn
+   * @returns {() => void}
+   */
+  subscribe(fn) {
+    this._listeners.add(fn);
+    return () => this._listeners.delete(fn);
+  }
+
+  _notify() {
+    for (const fn of this._listeners) {
+      try {
+        fn();
+      } catch (e) {
+        console.warn('[registry] listener falló:', e);
+      }
+    }
   }
 
   register(module_) {
@@ -39,10 +66,12 @@ class ModuleRegistry {
       console.warn(`[registry] sobreescribiendo módulo existente "${module_.id}"`);
     }
     this._modules.set(module_.id, module_);
+    this._notify();
   }
 
   unregister(id) {
     this._modules.delete(id);
+    this._notify();
   }
 
   has(id) {

--- a/src/hooks/useProCapability.js
+++ b/src/hooks/useProCapability.js
@@ -1,0 +1,29 @@
+/**
+ * useProCapability — ¿hay un módulo Pro registrado con esta capability?
+ * =====================================================================
+ * Gate de UI para entradas Pro (ADR-002/011): la entrada solo se muestra
+ * cuando el módulo Pro correspondiente está CARGADO en el moduleRegistry
+ * (build con VITE_PRO_MODULES_PATH + bundle Pro servido). En el build puro
+ * OSS —o para cuentas sin el plan— el módulo nunca se registra y la UI
+ * degrada a cero rastro (sin botones muertos).
+ *
+ * Reactivo: loadProModules corre DESPUÉS del primer render (async), así que
+ * el hook se suscribe al registry (useSyncExternalStore) y la entrada
+ * aparece sola cuando el módulo aterriza — un chequeo único al montar se lo
+ * perdería (misma lección de features huérfanas: cablear ≠ chequear una vez).
+ *
+ * @param {string} capability  ej. 'avatar-espiritu'
+ * @returns {boolean} true si al menos un módulo registrado la declara.
+ */
+import { useSyncExternalStore } from 'react';
+import { registry } from '../core/moduleRegistry';
+
+export function useProCapability(capability) {
+  return useSyncExternalStore(
+    (onStoreChange) => registry.subscribe(onStoreChange),
+    () => registry.byCapability(capability).length > 0,
+    () => false, // SSR/snapshot de servidor: sin módulos Pro.
+  );
+}
+
+export default useProCapability;

--- a/src/services/__tests__/fincaClockService.test.js
+++ b/src/services/__tests__/fincaClockService.test.js
@@ -1,0 +1,101 @@
+/**
+ * fincaClockService — el RELOJ DEL FRAILEJÓN es GROUNDED: los años salen de
+ * los registros reales (primer FarmProcess / primera planta), y una finca
+ * nueva muestra el año actual como primer anillo. NUNCA inventa historia.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db/farmProcessCache', () => ({
+  listFarmProcesses: vi.fn(),
+}));
+vi.mock('../../db/assetCache', () => ({
+  assetCache: { getByType: vi.fn() },
+}));
+
+import { listFarmProcesses } from '../../db/farmProcessCache';
+import { assetCache } from '../../db/assetCache';
+import { getAniosFinca, anioDeTimestamp } from '../fincaClockService';
+
+const NOW = new Date('2026-07-09T12:00:00-05:00');
+const ANIO = NOW.getFullYear();
+
+beforeEach(() => {
+  vi.mocked(listFarmProcesses).mockResolvedValue([]);
+  vi.mocked(assetCache.getByType).mockResolvedValue([]);
+});
+
+describe('anioDeTimestamp — parseo defensivo', () => {
+  test('unix ms, unix segundos e ISO dan el mismo año', () => {
+    const ms = Date.parse('2024-03-15T10:00:00Z');
+    expect(anioDeTimestamp(ms, ANIO)).toBe(2024);
+    expect(anioDeTimestamp(Math.floor(ms / 1000), ANIO)).toBe(2024);
+    expect(anioDeTimestamp('2024-03-15T10:00:00Z', ANIO)).toBe(2024);
+  });
+
+  test('basura y fechas fuera de la ventana de cordura → null', () => {
+    expect(anioDeTimestamp(null, ANIO)).toBe(null);
+    expect(anioDeTimestamp(undefined, ANIO)).toBe(null);
+    expect(anioDeTimestamp('no-es-fecha', ANIO)).toBe(null);
+    expect(anioDeTimestamp(0, ANIO)).toBe(null);
+    expect(anioDeTimestamp(-5, ANIO)).toBe(null);
+    // año 1999 (< 2000): fuera de cordura
+    expect(anioDeTimestamp(Date.parse('1999-01-01'), ANIO)).toBe(null);
+    // futuro: un registro no puede ser de un año que no ha llegado
+    expect(anioDeTimestamp(Date.parse(`${ANIO + 3}-01-01`), ANIO)).toBe(null);
+  });
+});
+
+describe('getAniosFinca — un anillo por año REAL', () => {
+  test('finca nueva (sin registros): el año actual es el primer anillo', async () => {
+    const r = await getAniosFinca({ now: NOW });
+    expect(r.fincaNueva).toBe(true);
+    expect(r.fuente).toBe('finca-nueva');
+    expect(r.primerAnio).toBe(ANIO);
+    expect(r.anios).toEqual([ANIO]);
+  });
+
+  test('el primer FarmProcess (created_at en ms) fija el primer año', async () => {
+    // Fixtures parciales a propósito (solo el campo que el servicio lee);
+    // el cast evita exigir un FarmProcess completo en el mock.
+    vi.mocked(listFarmProcesses).mockResolvedValue(/** @type {any} */ ([
+      { attributes: { created_at: Date.parse('2025-02-01') } },
+      { attributes: { created_at: Date.parse('2024-06-10') } },
+    ]));
+    const r = await getAniosFinca({ now: NOW });
+    expect(r.fincaNueva).toBe(false);
+    expect(r.fuente).toBe('registros');
+    expect(r.primerAnio).toBe(2024);
+    expect(r.anios).toEqual([2024, 2025, 2026]);
+  });
+
+  test('la primera planta también cuenta: created (segundos farmOS) y _createdAt (ms local)', async () => {
+    vi.mocked(assetCache.getByType).mockResolvedValue([
+      { attributes: { created: Math.floor(Date.parse('2023-11-20') / 1000) } },
+      { _createdAt: Date.parse('2025-01-05') },
+    ]);
+    const r = await getAniosFinca({ now: NOW });
+    expect(r.primerAnio).toBe(2023);
+    expect(r.anios).toEqual([2023, 2024, 2025, 2026]);
+    expect(assetCache.getByType).toHaveBeenCalledWith('plant');
+  });
+
+  test('timestamps basura se ignoran sin romper (degrada a finca nueva)', async () => {
+    vi.mocked(listFarmProcesses).mockResolvedValue(/** @type {any} */ ([
+      { attributes: { created_at: 'zzz' } },
+      { attributes: {} },
+      null,
+    ]));
+    vi.mocked(assetCache.getByType).mockResolvedValue([{ attributes: { created: -1 } }]);
+    const r = await getAniosFinca({ now: NOW });
+    expect(r.fincaNueva).toBe(true);
+    expect(r.anios).toEqual([ANIO]);
+  });
+
+  test('IDB caído no truena: degrada honesto a finca nueva', async () => {
+    vi.mocked(listFarmProcesses).mockRejectedValue(new Error('idb'));
+    vi.mocked(assetCache.getByType).mockRejectedValue(new Error('idb'));
+    const r = await getAniosFinca({ now: NOW });
+    expect(r.fincaNueva).toBe(true);
+    expect(r.anios).toEqual([ANIO]);
+  });
+});

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -1135,3 +1135,44 @@ describe('sidecarClient — getClimaSnapshot elevation (gradiente térmico)', ()
     expect(url).not.toContain('elevation');
   });
 });
+
+describe('sidecarClient — companionSpeciesGuard post-LLM', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  it('200 con bloque de correccion → normaliza has_companion_species y system_prompt_block', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+      has_companion_species: true,
+      system_prompt_block: '[CORRECCION] La especie companera correcta es X.',
+      reason: 'catalog_match',
+    }));
+    const { companionSpeciesGuard } = await importFresh();
+    const res = await companionSpeciesGuard('respuesta del agente ya generada');
+    expect(res).toEqual({
+      has_companion_species: true,
+      system_prompt_block: '[CORRECCION] La especie companera correcta es X.',
+      reason: 'catalog_match',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/mcp/agro/companion-species-guard');
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({ response: 'respuesta del agente ya generada' });
+  });
+
+  it('degrada a null si el endpoint cae o no responde 2xx', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(503, { error: 'down' }));
+    const { companionSpeciesGuard } = await importFresh();
+    expect(await companionSpeciesGuard('respuesta')).toBeNull();
+  });
+
+  it('devuelve null sin fetch cuando la respuesta viene vacia', async () => {
+    const { companionSpeciesGuard } = await importFresh();
+    expect(await companionSpeciesGuard('')).toBeNull();
+    expect(await companionSpeciesGuard('   ')).toBeNull();
+    expect(await companionSpeciesGuard(null)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/soilDiagnostic.test.js
+++ b/src/services/__tests__/soilDiagnostic.test.js
@@ -164,3 +164,39 @@ describe('formatearGroundingSuelo', () => {
     expect(f).toContain('DR-SUELOS-1');
   });
 });
+
+describe('persistencia del último diagnóstico (panel de vitalidad)', () => {
+  it('round-trip: guardar → leer devuelve problemas + ts + fuente', async () => {
+    const { guardarDiagnosticoSuelo, getDiagnosticoSueloGuardado, DIAG_SUELO_STORAGE_KEY } = await import('../soilDiagnostic');
+    localStorage.removeItem(DIAG_SUELO_STORAGE_KEY);
+    expect(getDiagnosticoSueloGuardado()).toBeNull();
+
+    const d = diagnosticarSuelo('tengo tierra amarilla pegajosa y sale helecho');
+    expect(guardarDiagnosticoSuelo(d)).toBe(true);
+
+    const leido = getDiagnosticoSueloGuardado();
+    expect(leido).not.toBeNull();
+    expect(leido.sin_datos).toBe(false);
+    expect(leido.problemas).toEqual(d.problemas);
+    expect(Number.isFinite(leido.ts)).toBe(true);
+    expect(leido.fuente).toContain('DR-SUELOS-1');
+    localStorage.removeItem(DIAG_SUELO_STORAGE_KEY);
+  });
+
+  it('NO persiste sin_datos ni shapes inválidos', async () => {
+    const { guardarDiagnosticoSuelo, getDiagnosticoSueloGuardado, DIAG_SUELO_STORAGE_KEY } = await import('../soilDiagnostic');
+    localStorage.removeItem(DIAG_SUELO_STORAGE_KEY);
+    expect(guardarDiagnosticoSuelo(diagnosticarSuelo(''))).toBe(false);
+    expect(guardarDiagnosticoSuelo(null)).toBe(false);
+    expect(getDiagnosticoSueloGuardado()).toBeNull();
+  });
+
+  it('entrada corrupta en localStorage → null (no revienta el home)', async () => {
+    const { getDiagnosticoSueloGuardado, DIAG_SUELO_STORAGE_KEY } = await import('../soilDiagnostic');
+    localStorage.setItem(DIAG_SUELO_STORAGE_KEY, '{no-es-json');
+    expect(getDiagnosticoSueloGuardado()).toBeNull();
+    localStorage.setItem(DIAG_SUELO_STORAGE_KEY, JSON.stringify({ problemas: 'no-array' }));
+    expect(getDiagnosticoSueloGuardado()).toBeNull();
+    localStorage.removeItem(DIAG_SUELO_STORAGE_KEY);
+  });
+});

--- a/src/services/__tests__/userProfileService.guardian.test.js
+++ b/src/services/__tests__/userProfileService.guardian.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  GUARDIAN_ESPECIE_IDS,
+  DEFAULT_GUARDIAN_ESPECIE,
+  getGuardianEspecie,
+  setGuardianEspecie,
+  getProfile,
+  saveProfile,
+} from '../userProfileService.js';
+
+/**
+ * userProfileService.guardian — el guardián (espíritu de la finca) elegido en el
+ * selector del home vivo PERSISTE en el perfil (`guardian_especie`). Grounding:
+ * el roster de ids corresponde a fauna nativa colombiana REAL (validado por id
+ * en el servicio; la lista canónica con nombre científico vive en
+ * GuardianEspiritu.jsx).
+ */
+describe('userProfileService — guardián / espíritu de la finca', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('define el roster grounded de ids y un default (abeja angelita)', () => {
+    expect(GUARDIAN_ESPECIE_IDS).toEqual(['abeja', 'oso', 'chivito', 'danta', 'rana']);
+    expect(DEFAULT_GUARDIAN_ESPECIE).toBe('abeja');
+    expect(GUARDIAN_ESPECIE_IDS).toContain(DEFAULT_GUARDIAN_ESPECIE);
+  });
+
+  it('sin elección devuelve null (el home decide el fallback)', () => {
+    expect(getGuardianEspecie()).toBeNull();
+  });
+
+  it('persiste el guardián elegido en el perfil (guardian_especie)', () => {
+    setGuardianEspecie('chivito');
+    expect(getGuardianEspecie()).toBe('chivito');
+    expect(getProfile().guardian_especie).toBe('chivito');
+  });
+
+  it('sobreescribe una elección previa (cambiar de guardián)', () => {
+    setGuardianEspecie('oso');
+    setGuardianEspecie('rana');
+    expect(getGuardianEspecie()).toBe('rana');
+  });
+
+  it('ignora ids desconocidos (no corrompe el perfil, no inventa fauna)', () => {
+    setGuardianEspecie('abeja');
+    // Prueba negativa a propósito: un id fuera del roster. El cast evita el
+    // error de tsc (el parámetro es la unión de ids válidos) sin perder la
+    // verificación de que la función RECHAZA en runtime lo que no conoce.
+    const res = setGuardianEspecie(/** @type {any} */ ('unicornio'));
+    expect(res).toBeNull();
+    // El guardián válido previo se conserva.
+    expect(getGuardianEspecie()).toBe('abeja');
+  });
+
+  it('emite chagra:guardian-changed y chagra:profile-changed al elegir', () => {
+    const guardianSpy = vi.fn();
+    const profileSpy = vi.fn();
+    window.addEventListener('chagra:guardian-changed', guardianSpy);
+    window.addEventListener('chagra:profile-changed', profileSpy);
+    try {
+      setGuardianEspecie('danta');
+    } finally {
+      window.removeEventListener('chagra:guardian-changed', guardianSpy);
+      window.removeEventListener('chagra:profile-changed', profileSpy);
+    }
+    expect(guardianSpy).toHaveBeenCalledTimes(1);
+    expect(guardianSpy.mock.calls[0][0].detail).toEqual({ id: 'danta' });
+    expect(profileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('no pisa otros campos del perfil al guardar el guardián', () => {
+    saveProfile({ rol: 'campesino', finca_altitud: '2600', piso_confirmado: '1' });
+    setGuardianEspecie('oso');
+    const p = getProfile();
+    expect(p.guardian_especie).toBe('oso');
+    expect(p.finca_altitud).toBe('2600');
+    expect(p.rol).toBe('campesino');
+  });
+});

--- a/src/services/__tests__/vitalidadEspirituService.test.js
+++ b/src/services/__tests__/vitalidadEspirituService.test.js
@@ -1,0 +1,237 @@
+/**
+ * vitalidadEspirituService — el panel de vitalidad del espíritu se arma SOLO
+ * con datos reales de la finca; lo que falta queda 'pendiente' ("dato en
+ * camino"), NUNCA un número inventado. Contrato anti-alucinación del panel
+ * del home menú vivo (mockup #/mockups/avatar-biopunk).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildVitalidadEspiritu,
+  contarEspecies,
+  contarAnillosFrailejon,
+  ejeClima,
+  ejeSuelo,
+  ejeBiodiversidad,
+  ejeEnergia,
+  PRECIP_ESCALA_MM,
+  ENERGIA_META_MES,
+} from '../vitalidadEspirituService';
+import { buildFincaScene } from '../fincaSceneService';
+
+const NOW = new Date('2026-07-09T10:00:00-05:00');
+
+/** FarmProcess reales (shape anidado de producción). */
+const procesos = () => [
+  {
+    process_id: 'p-cafe',
+    attributes: {
+      process_type: 'sowing',
+      status: 'active',
+      current_stage: 'flowering',
+      subject_slug: 'coffea_arabica',
+      subject_label: 'Café',
+      created_at: new Date('2025-11-10').getTime(),
+    },
+  },
+  {
+    process_id: 'p-maiz',
+    attributes: {
+      process_type: 'sowing',
+      status: 'active',
+      current_stage: 'harvest',
+      subject_slug: 'zea_mays',
+      subject_label: 'Maíz',
+      created_at: new Date('2026-07-02').getTime(), // este mes → energía
+    },
+  },
+  {
+    process_id: 'p-frijol-cerrado',
+    attributes: {
+      process_type: 'sowing',
+      status: 'completed',
+      current_stage: 'closed',
+      subject_slug: 'phaseolus_vulgaris',
+      subject_label: 'Frijol',
+      created_at: new Date('2026-01-15').getTime(),
+    },
+  },
+];
+
+const plantas = () => [
+  { id: 'a1', attributes: { name: 'Fresa #01', status: 'active' } },
+  { id: 'a2', attributes: { name: 'Fresa #02', status: 'active' } },
+  { id: 'a3', attributes: { name: 'Uchuva #01', status: 'active' } },
+];
+
+const resumenCosecha = () => ({
+  totalHarvests: 5,
+  dateRange: { firstMs: new Date('2025-10-05').getTime(), lastMs: new Date('2026-07-03').getTime() },
+  trend: { series: [
+    { period: '2026-06', harvestCount: 2 },
+    { period: '2026-07', harvestCount: 3 },
+  ] },
+});
+
+const snapshotClima = () => ({
+  openmeteo: {
+    available: true,
+    forecast_7d: [
+      { date: '2026-07-09', precip_mm: 5 },
+      { date: '2026-07-10', precip_mm: 12 },
+    ],
+  },
+});
+
+describe('contarEspecies (procesos + plantas-asset reales)', () => {
+  it('cuenta especies distintas: slug del proceso + nombre de planta sin "#N"', () => {
+    // vivas: café + maíz (activos) + fresa + uchuva (assets) = 4 (frijol cerrado NO)
+    expect(contarEspecies(procesos(), plantas(), { soloVivas: true })).toBe(4);
+    // registradas: + frijol (completed cuenta, no cancelado) = 5
+    expect(contarEspecies(procesos(), plantas(), { soloVivas: false })).toBe(5);
+  });
+
+  it('ignora cancelados y no duplica instancias "#N" de la misma especie', () => {
+    const cancelado = [{ attributes: { status: 'cancelled', subject_slug: 'x', created_at: 1 } }];
+    expect(contarEspecies(cancelado, [], {})).toBe(0);
+    expect(contarEspecies([], [
+      { attributes: { name: 'Fresa #01' } },
+      { attributes: { name: 'Fresa #07' } },
+    ])).toBe(1);
+  });
+});
+
+describe('ejeClima — la señal de clima GUARDADA (nunca inventada)', () => {
+  it('con snapshot: lluvia de hoy en mm reales, escala documentada', () => {
+    const eje = ejeClima({ climaSnapshot: snapshotClima(), condicion: 'nublado', now: NOW });
+    expect(eje.estado).toBe('ok');
+    expect(eje.valor).toBe(Math.round((5 / PRECIP_ESCALA_MM) * 100));
+    expect(eje.texto).toBe('5 mm hoy · nublado');
+  });
+
+  it('sin snapshot pero con condición derivada → muestra la condición sin barra', () => {
+    const eje = ejeClima({ climaSnapshot: null, condicion: 'despejado', now: NOW });
+    expect(eje.estado).toBe('ok');
+    expect(eje.valor).toBeNull();
+    expect(eje.texto).toBe('despejado');
+  });
+
+  it('sin ninguna señal → pendiente (dato en camino)', () => {
+    const eje = ejeClima({ climaSnapshot: null, condicion: null, now: NOW });
+    expect(eje.estado).toBe('pendiente');
+    expect(eje.valor).toBeNull();
+  });
+});
+
+describe('ejeSuelo — SOLO con diagnóstico real (DR-SUELOS-1)', () => {
+  it('sin diagnóstico o con sin_datos → pendiente', () => {
+    expect(ejeSuelo(null).estado).toBe('pendiente');
+    expect(ejeSuelo({ sin_datos: true, problemas: [] }).estado).toBe('pendiente');
+  });
+
+  it('con diagnóstico: 100 − 18 por problema, acotado', () => {
+    const eje = ejeSuelo({ sin_datos: false, problemas: ['acidez', 'compactacion'] });
+    expect(eje.estado).toBe('ok');
+    expect(eje.valor).toBe(100 - 2 * 18);
+    expect(eje.texto).toContain('2 señales');
+  });
+});
+
+describe('ejeBiodiversidad — misma saturación (6) que calcularVitalidad', () => {
+  it('3 especies vivas → 50', () => {
+    const eje = ejeBiodiversidad({ especiesVivas: 3, vacia: false });
+    expect(eje.valor).toBe(50);
+    expect(eje.texto).toBe('3 especies');
+  });
+  it('finca vacía → pendiente', () => {
+    expect(ejeBiodiversidad({ especiesVivas: 0, vacia: true }).estado).toBe('pendiente');
+  });
+});
+
+describe('ejeEnergia — registros REALES del mes en curso', () => {
+  it('suma cosechas del mes (serie mensual) + siembras del mes', () => {
+    const eje = ejeEnergia({ processes: procesos(), harvestSummary: resumenCosecha(), now: NOW });
+    // 3 cosechas de 2026-07 + 1 siembra (maíz) este mes = 4 registros
+    expect(eje.estado).toBe('ok');
+    expect(eje.texto).toBe('4 registros este mes');
+    expect(eje.valor).toBe(Math.round((4 / ENERGIA_META_MES) * 100));
+  });
+  it('sin resumen NI procesos → pendiente', () => {
+    expect(ejeEnergia({ processes: [], harvestSummary: null, now: NOW }).estado).toBe('pendiente');
+  });
+});
+
+describe('contarAnillosFrailejon — una temporada (~3 meses) por anillo', () => {
+  it('desde el primer registro real (la cosecha más antigua manda aquí)', () => {
+    // primer registro: 2025-10-05 (cosecha) → 9 meses hasta 2026-07 → 3 temporadas + 1
+    const anillos = contarAnillosFrailejon({
+      processes: procesos(),
+      harvestSummary: resumenCosecha(),
+      now: NOW,
+    });
+    expect(anillos.estado).toBe('ok');
+    expect(anillos.valor).toBe(4);
+  });
+
+  it('sin ningún registro → pendiente (no se inventa historia)', () => {
+    expect(contarAnillosFrailejon({ processes: [], harvestSummary: null, now: NOW }).estado)
+      .toBe('pendiente');
+  });
+});
+
+describe('buildVitalidadEspiritu — modelo completo', () => {
+  it('finca sembrada: vitalidad real de buildFincaScene + slots con fuente', () => {
+    const scene = buildFincaScene({ processes: procesos(), plantAssetsCount: 3 });
+    const m = buildVitalidadEspiritu({
+      scene,
+      processes: procesos(),
+      plants: plantas(),
+      climaSnapshot: snapshotClima(),
+      condicion: 'nublado',
+      harvestSummary: resumenCosecha(),
+      now: NOW,
+    });
+
+    expect(m.vitalidad.estado).toBe('ok');
+    expect(m.vitalidad.valor).toBe(scene.vitalidad); // la MISMA vitalidad honesta
+    expect(m.especiesVivas.valor).toBe(4);
+    expect(m.ejes.map((e) => e.id)).toEqual(['clima', 'suelo', 'biodiversidad', 'energia']);
+    expect(m.conteos.especies.valor).toBe(5);
+    expect(m.conteos.cosechas.valor).toBe(5);
+    expect(m.conteos.anillos.valor).toBe(4);
+    // suelo sin diagnóstico persistido → pendiente (dato en camino)
+    expect(m.ejes.find((e) => e.id === 'suelo').estado).toBe('pendiente');
+    expect(m.algunPendiente).toBe(true);
+    // trazabilidad: todo slot declara su fuente
+    for (const slot of [m.vitalidad, m.especiesVivas, ...m.ejes,
+      m.conteos.especies, m.conteos.cosechas, m.conteos.anillos]) {
+      expect(slot.fuente).toBeTruthy();
+    }
+  });
+
+  it('finca vacía sin señales: TODO pendiente, ningún número inventado', () => {
+    const scene = buildFincaScene({ processes: [], plantAssetsCount: 0 });
+    const m = buildVitalidadEspiritu({ scene, now: NOW });
+    expect(m.vitalidad.estado).toBe('pendiente');
+    expect(m.especiesVivas.estado).toBe('pendiente');
+    for (const eje of m.ejes) {
+      expect(eje.estado).toBe('pendiente');
+      expect(eje.valor).toBeNull();
+    }
+    expect(m.conteos.especies.estado).toBe('pendiente');
+    expect(m.conteos.cosechas.estado).toBe('pendiente');
+    expect(m.conteos.anillos.estado).toBe('pendiente');
+    expect(m.algunPendiente).toBe(true);
+  });
+
+  it('cosechas en 0 con el store CARGADO es un cero real (no pendiente)', () => {
+    const scene = buildFincaScene({ processes: procesos(), plantAssetsCount: 0 });
+    const m = buildVitalidadEspiritu({
+      scene,
+      processes: procesos(),
+      harvestSummary: { totalHarvests: 0, dateRange: { firstMs: null, lastMs: null }, trend: { series: [] } },
+      now: NOW,
+    });
+    expect(m.conteos.cosechas.estado).toBe('ok');
+    expect(m.conteos.cosechas.valor).toBe(0);
+  });
+});

--- a/src/services/fincaClockService.js
+++ b/src/services/fincaClockService.js
@@ -1,0 +1,101 @@
+/**
+ * fincaClockService — los AÑOS REALES de la finca en Chagra, para el
+ * "Reloj del frailejón" del home (el frailejón crece UN anillo al año).
+ *
+ * GROUNDED — nunca inventa historia. El primer año del reloj es el año del
+ * REGISTRO MÁS ANTIGUO que la finca tiene en Chagra:
+ *   · FarmProcess → attributes.created_at  (unix MS — día 0 del ciclo)
+ *   · asset plant → attributes.created     (unix SEGUNDOS — farmOS post-sync)
+ *                 → _createdAt             (MS — optimistic local, aún sin sync)
+ * (mismos campos y semántica que AssetDetailView / anoFincaService).
+ *
+ * Si la finca es NUEVA (sin ningún registro con fecha válida), el reloj
+ * muestra el año actual como su PRIMER anillo — cero historia inventada.
+ *
+ * Offline-first: todo sale de IndexedDB (farmProcessCache + assetCache),
+ * sin red. Cualquier fallo de IDB degrada a "finca nueva" honesta.
+ */
+import { listFarmProcesses } from '../db/farmProcessCache';
+import { assetCache } from '../db/assetCache';
+
+/** Ventana de cordura para años de registros (evita basura de timestamps). */
+const ANIO_MIN_VALIDO = 2000;
+
+/**
+ * Convierte un timestamp heterogéneo (unix s, unix ms o string ISO) al AÑO
+ * calendario, o null si no es una fecha válida dentro de la ventana de
+ * cordura [2000, añoActual].
+ *
+ * @param {number|string|null|undefined} v
+ * @param {number} anioActual
+ * @returns {number|null}
+ */
+export function anioDeTimestamp(v, anioActual) {
+  if (v == null) return null;
+  let ms = null;
+  if (typeof v === 'number' && Number.isFinite(v) && v > 0) {
+    // Heurística estándar del repo: >1e12 ya es ms; si parece unix-segundos
+    // (1e9..1e11 ≈ años 2001..5138 en segundos), pasar a ms.
+    ms = v > 1e11 ? v : v * 1000;
+  } else if (typeof v === 'string' && v.trim() !== '') {
+    const parsed = Date.parse(v);
+    if (Number.isFinite(parsed)) ms = parsed;
+  }
+  if (ms == null) return null;
+  const d = new Date(ms);
+  const y = d.getFullYear();
+  if (!Number.isFinite(y) || y < ANIO_MIN_VALIDO || y > anioActual) return null;
+  return y;
+}
+
+/**
+ * Calcula los años reales de la finca en Chagra.
+ *
+ * @param {Object} [opts]
+ * @param {Date} [opts.now] inyectable para tests.
+ * @returns {Promise<{
+ *   primerAnio: number,
+ *   anioActual: number,
+ *   anios: number[],
+ *   fincaNueva: boolean,
+ *   fuente: 'registros'|'finca-nueva',
+ * }>} un anillo por cada año de `anios` (primerAnio..anioActual, ambos
+ *   incluidos). `fincaNueva` = no hay ningún registro con fecha válida.
+ */
+export async function getAniosFinca({ now } = {}) {
+  const hoy = now instanceof Date && !Number.isNaN(now.getTime()) ? now : new Date();
+  const anioActual = hoy.getFullYear();
+  let primerAnio = null;
+
+  // 1) Ciclos productivos (FarmProcess.created_at, unix ms).
+  try {
+    const procesos = await listFarmProcesses();
+    for (const p of procesos || []) {
+      const y = anioDeTimestamp(p?.attributes?.created_at, anioActual);
+      if (y != null && (primerAnio == null || y < primerAnio)) primerAnio = y;
+    }
+  } catch (_) { /* IDB no disponible: seguimos con las otras fuentes */ }
+
+  // 2) Plantas registradas (assets farmOS: created en segundos; locales: _createdAt ms).
+  try {
+    const plantas = await assetCache.getByType('plant');
+    for (const a of plantas || []) {
+      const y = anioDeTimestamp(a?.attributes?.created, anioActual)
+        ?? anioDeTimestamp(a?._createdAt, anioActual);
+      if (y != null && (primerAnio == null || y < primerAnio)) primerAnio = y;
+    }
+  } catch (_) { /* IDB no disponible */ }
+
+  const fincaNueva = primerAnio == null;
+  const desde = fincaNueva ? anioActual : primerAnio;
+  const anios = [];
+  for (let y = desde; y <= anioActual; y += 1) anios.push(y);
+
+  return {
+    primerAnio: desde,
+    anioActual,
+    anios,
+    fincaNueva,
+    fuente: fincaNueva ? 'finca-nueva' : 'registros',
+  };
+}

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -751,6 +751,33 @@ export async function pestVsDiseaseGuard(userMessage) {
 }
 
 /**
+ * POST-LLM companion species guard. Valida la respuesta ya generada del
+ * agente contra el catalogo y devuelve un bloque de correccion listo para
+ * anteponer. Es fail-safe: si el endpoint cae, el turno sigue igual.
+ *
+ * @param {string} responseText - salida final del LLM ya generada.
+ * @returns {Promise<null | {
+ *   has_companion_species: boolean,
+ *   system_prompt_block: string,
+ *   reason: string,
+ * }>}
+ */
+export async function companionSpeciesGuard(responseText) {
+  if (!responseText || typeof responseText !== 'string' || !responseText.trim()) return null;
+  const raw = await postJson('/companion-species-guard', { response: responseText }, TOOL_TIMEOUT_MS);
+  if (!raw || typeof raw !== 'object') return null;
+  const hasCompanionSpecies =
+    raw.has_companion_species === true ||
+    raw.has_companion === true ||
+    raw.needs_correction === true;
+  return {
+    has_companion_species: hasCompanionSpecies,
+    system_prompt_block: typeof raw.system_prompt_block === 'string' ? raw.system_prompt_block : '',
+    reason: typeof raw.reason === 'string' ? raw.reason : '',
+  };
+}
+
+/**
  * Capa 2 anti-alucinación (cross-check de contexto). Llama
  * `POST ${BASE}/post-validate` con el TEXTO que el LLM ya generó y, opcional,
  * los `nombre_cientifico` de las entidades que la capa 1 resolvió para el turno

--- a/src/services/soilDiagnostic.js
+++ b/src/services/soilDiagnostic.js
@@ -189,6 +189,54 @@ export function diagnosticarSuelo(descripcion) {
   };
 }
 
+/* ── persistencia del último diagnóstico (panel de vitalidad) ────────────── */
+
+/** Clave localStorage del último diagnóstico REAL de suelo del usuario. */
+export const DIAG_SUELO_STORAGE_KEY = 'chagra_diag_suelo_v1';
+
+/**
+ * Guarda el último diagnóstico REAL (no `sin_datos`) para que el home
+ * (PanelVitalidadEspiritu, eje 🪱 El suelo) pueda leerlo sin recalcular.
+ * Solo persiste lo mínimo trazable: problemas + fecha + fuente. Falla en
+ * silencio (incógnito/cuota): el panel simplemente sigue en "dato en camino".
+ *
+ * @param {DiagnosticoResult} diagnostico — resultado de diagnosticarSuelo
+ * @returns {boolean} true si quedó guardado
+ */
+export function guardarDiagnosticoSuelo(diagnostico) {
+  if (!diagnostico || diagnostico.sin_datos || !Array.isArray(diagnostico.problemas)) return false;
+  try {
+    localStorage.setItem(DIAG_SUELO_STORAGE_KEY, JSON.stringify({
+      problemas: diagnostico.problemas,
+      sin_datos: false,
+      ts: Date.now(),
+      fuente: diagnostico.fuente || SOIL_DATA.fuente,
+    }));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Último diagnóstico de suelo guardado (o null si nunca se hizo uno).
+ * Shape compatible con vitalidadEspirituService.ejeSuelo: {problemas[],
+ * sin_datos, ts, fuente}. Entrada corrupta → null (nunca revienta el home).
+ *
+ * @returns {{problemas: string[], sin_datos: boolean, ts: number, fuente: string}|null}
+ */
+export function getDiagnosticoSueloGuardado() {
+  try {
+    const raw = localStorage.getItem(DIAG_SUELO_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.problemas)) return null;
+    return { sin_datos: false, ...parsed };
+  } catch (_) {
+    return null;
+  }
+}
+
 function buscarEnmienda(id) {
   const e = SOIL_DATA.enmiendas.find((enm) => enm.id === id);
   return e ? { id: e.id, nombre: e.nombre, problema_que_corrige: e.problema_que_corrige, dosis_orientativa: e.dosis_orientativa, precaucion: e.precaucion, fuente: e.fuente } : null;

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -825,6 +825,56 @@ export function setNotificationStyle(style) {
   return profile;
 }
 
+// ─── Guardián / espíritu de la finca (selector del home vivo) ───────────────
+
+/**
+ * IDs válidos del GUARDIÁN (espíritu de la finca). Cada uno corresponde a una
+ * especie nativa colombiana REAL y verificable — nombre científico grounded en
+ * el catálogo/grafo de Chagra (fauna emblemática, NUNCA inventada). La lista
+ * canónica con nombre común/científico/fuente vive en el componente
+ * `GuardianEspiritu.jsx` (fuente de verdad visual); acá solo validamos el id
+ * persistido para no corromper el perfil.
+ *
+ *   - abeja:   Tetragonisca angustula (abeja angelita) — grounded animal-diagnostics.json
+ *   - oso:     Tremarctos ornatus (oso andino/de anteojos) — grounded cycle-content, psa.json
+ *   - chivito: Oxypogon guerinii (chivito/barbudito de páramo) — grounded puya_clava_herculis.json
+ *   - danta:   Tapirus pinchaque (danta de montaña) — grounded vaccinium_floribundum.json
+ *   - rana:    Phyllobates terribilis (rana dorada) — endémica del Chocó, real y verificable
+ */
+export const GUARDIAN_ESPECIE_IDS = Object.freeze(['abeja', 'oso', 'chivito', 'danta', 'rana']);
+/** Guardián por defecto: la abeja angelita (protagonista del mockup aprobado). */
+export const DEFAULT_GUARDIAN_ESPECIE = 'abeja';
+
+/**
+ * Lee el guardián (espíritu de la finca) elegido por el usuario. Devuelve el id
+ * persistido si es válido; `null` si el usuario aún no ha elegido (para que el
+ * home pueda distinguir "sin elegir" de "eligió el default").
+ *
+ * @returns {'abeja'|'oso'|'chivito'|'danta'|'rana'|null}
+ */
+export function getGuardianEspecie() {
+  const v = getProfile()?.guardian_especie;
+  return GUARDIAN_ESPECIE_IDS.includes(v) ? v : null;
+}
+
+/**
+ * Persiste el guardián elegido en el perfil (`guardian_especie`). Ignora ids
+ * desconocidos para no corromper el perfil. Emite `chagra:guardian-changed` y
+ * `chagra:profile-changed` para que el home/saludo re-lean el espíritu en vivo.
+ *
+ * @param {'abeja'|'oso'|'chivito'|'danta'|'rana'} id
+ * @returns {Object|null} perfil resultante, o null si el id era inválido
+ */
+export function setGuardianEspecie(id) {
+  if (!GUARDIAN_ESPECIE_IDS.includes(id)) return null;
+  const profile = saveProfile({ guardian_especie: id });
+  try {
+    window.dispatchEvent(new CustomEvent('chagra:guardian-changed', { detail: { id } }));
+    window.dispatchEvent(new CustomEvent('chagra:profile-changed', { detail: { guardian_especie: id } }));
+  } catch (_) { /* SSR/tests sin window — la elección ya quedó persistida */ }
+  return profile;
+}
+
 /** Marca el onboarding de perfil como completado. */
 export function markProfileDone() {
   if (!hasStorage()) return;

--- a/src/services/vitalidadEspirituService.js
+++ b/src/services/vitalidadEspirituService.js
@@ -1,0 +1,387 @@
+/**
+ * vitalidadEspirituService — arma el modelo del PANEL DE VITALIDAD DEL
+ * ESPÍRITU del home "menú vivo" (FincaVivaHero, escena Finca Organismo),
+ * fiel al mockup aprobado #/mockups/avatar-biopunk (AvatarGameBiopunk) pero
+ * con GROUNDING TOTAL: cada número sale de un dato REAL de la finca del
+ * usuario. Si un dato falta, el slot queda `estado: 'pendiente'`
+ * ("dato en camino") — NUNCA se inventa un número.
+ *
+ * FUENTE REAL DE CADA VALOR (contrato anti-alucinación):
+ *   · Vitalidad (medidor circular) → `scene.vitalidad` de
+ *     fincaSceneService.buildFincaScene/calcularVitalidad: avance fenológico
+ *     promedio de los ciclos ACTIVOS (FarmProcess reales) + diversidad de
+ *     especies, saturada a 6. Sin registros (scene.vacia) → pendiente.
+ *   · Especies vivas (badge) → conteo de especies DISTINTAS entre los
+ *     FarmProcess activos (subject_slug/subject_label sin sufijo "#N") y las
+ *     plantas-asset registradas (useAssetStore.plants, misma fuente que
+ *     "Mis plantas: N" del dashboard).
+ *   · 💧 El clima → la señal de clima GUARDADA de su vereda
+ *     (climaService.getCachedClimaSnapshot: pronóstico Open-Meteo cacheado,
+ *     offline-first) + la condición derivada por atmosphereService
+ *     (despejado/nublado/lluvia/niebla — la MISMA del cielo de la escena).
+ *     La barra pinta la lluvia de HOY en escala 0..25 mm (aguacero franco,
+ *     mismo orden del umbral LLUVIA_MM=10 de atmosphereService). Sin
+ *     snapshot → pendiente.
+ *   · 🪱 El suelo → el diagnóstico REAL de soilDiagnostic.diagnosticarSuelo
+ *     (DR-SUELOS-1) hecho sobre la descripción del usuario. Ese diagnóstico
+ *     hoy se calcula bajo demanda (agente/pantalla de suelo) y NO se
+ *     persiste, así que el slot queda pendiente hasta que llegue un
+ *     diagnóstico (`diagSuelo`). Con diagnóstico: valor = 100 − 18 por cada
+ *     problema detectado (fórmula documentada, acotada 0..100). Con
+ *     `sin_datos` → pendiente. NO se fabrica un puntaje sin diagnóstico.
+ *   · 🦋 La biodiversidad → especies distintas VIVAS, con la MISMA
+ *     saturación a 6 especies que usa calcularVitalidad (min(n,6)/6·100).
+ *     El texto lleva el conteo real.
+ *   · 🔥 La energía (constancia) → registros REALES del MES en curso:
+ *     cosechas anotadas este mes (serie mensual de cosechaService
+ *     harvestSummary.trend) + siembras/ciclos abiertos este mes
+ *     (FarmProcess.created_at). Escala documentada: 6 registros/mes =
+ *     fuego pleno. Sin resumen de cosecha NI procesos → pendiente.
+ *   · 🍃 Especies registradas → especies distintas de TODA la finca
+ *     (procesos no cancelados, activos o cerrados, + plantas-asset).
+ *   · ✦ Cosechas anotadas → useCosechaStore.summary.totalHarvests
+ *     (log--harvest reales de logCache, agregados por cosechaService).
+ *     summary null (aún sin cargar / error IDB) → pendiente. 0 con el store
+ *     cargado es un CERO REAL y se muestra.
+ *   · ◎ Anillos del frailejón → un anillo por TEMPORADA del almanaque
+ *     campesino (~3 meses; la zona andina bimodal tiene 4 temporadas/año,
+ *     ver anoFincaService.TEMPORADA_POR_MES) transcurrida desde el PRIMER
+ *     registro real de la finca (la siembra más antigua o la primera
+ *     cosecha anotada, lo que ocurra primero). Sin ningún registro →
+ *     pendiente.
+ *
+ * Todo puro y client-side (sin fetch, sin IDB, sin DOM): la vista
+ * (FincaVivaHero → PanelVitalidadEspiritu) inyecta los datos ya cargados.
+ * Español de Colombia (tú/usted), sin voseo.
+ *
+ * @module services/vitalidadEspirituService
+ */
+
+import { stripInstanceSuffix } from '../utils/agruparEntradas';
+
+/** Escala de la barra de clima: 25 mm de lluvia en el día = barra llena. */
+export const PRECIP_ESCALA_MM = 25;
+/** Saturación de diversidad (la misma de calcularVitalidad): 6 especies = 100. */
+export const BIODIVERSIDAD_SATURACION = 6;
+/** Registros del mes que llenan la barra de energía (constancia). */
+export const ENERGIA_META_MES = 6;
+/** Penalización por problema de suelo detectado (0..100, documentada). */
+export const SUELO_PENALIZACION_POR_PROBLEMA = 18;
+/** Meses por temporada del almanaque andino bimodal (4 temporadas/año). */
+export const MESES_POR_TEMPORADA = 3;
+
+/** Copys de las fuentes (aria/title de cada slot — trazabilidad visible). */
+export const FUENTES = Object.freeze({
+  vitalidad: 'Avance real de sus ciclos de cultivo + diversidad de especies (fincaSceneService)',
+  especies: 'Ciclos de cultivo y plantas registradas en su finca',
+  clima: 'Señal de clima guardada para su vereda (pronóstico Open-Meteo, offline)',
+  suelo: 'Diagnóstico de suelo sin laboratorio (DR-SUELOS-1) — descríbale su suelo al agente',
+  biodiversidad: 'Especies distintas vivas en su finca (saturación a 6, como la vitalidad)',
+  energia: 'Registros de este mes: cosechas anotadas + siembras abiertas',
+  cosechas: 'Cosechas anotadas en «Mi cosecha» (registros reales de su finca)',
+  anillos: 'Una temporada del almanaque (~3 meses) por anillo, desde su primer registro',
+});
+
+const CONDICION_LABEL = Object.freeze({
+  despejado: 'despejado',
+  nublado: 'nublado',
+  lluvia: 'lluvia',
+  niebla: 'niebla',
+});
+
+/* ── helpers ──────────────────────────────────────────────────────────────── */
+
+/**
+ * @typedef {Object} SlotVitalidad
+ * @property {'ok'|'pendiente'} estado  pendiente = "dato en camino" (se pinta
+ *   "—", nunca un número inventado)
+ * @property {number|null} valor
+ * @property {string} [texto]  lectura corta del dato real (aria/title)
+ * @property {string} fuente   de dónde sale el valor (trazabilidad)
+ */
+
+const clamp01 = (v) => Math.max(0, Math.min(100, v));
+const finito = (v) => (Number.isFinite(Number(v)) ? Number(v) : null);
+
+/**
+ * @param {number|null} valor
+ * @param {{texto?: string, fuente?: string}} [extra]
+ * @returns {SlotVitalidad}
+ */
+const ok = (valor, extra = {}) => (
+  /** @type {SlotVitalidad} */ ({ estado: 'ok', valor, fuente: '', ...extra })
+);
+/**
+ * @param {{texto?: string, fuente?: string}} [extra]
+ * @returns {SlotVitalidad}
+ */
+const pendiente = (extra = {}) => (
+  /** @type {SlotVitalidad} */ ({ estado: 'pendiente', valor: null, fuente: '', ...extra })
+);
+
+/** Aplana un FarmProcess (anidado en `.attributes` o plano). */
+function attrs(p) {
+  if (!p || typeof p !== 'object') return null;
+  return p.attributes && typeof p.attributes === 'object' ? p.attributes : p;
+}
+
+/** Clave de especie de un proceso: slug si existe, si no el label sin "#N". */
+function claveEspecieProceso(a) {
+  const slug = typeof a.subject_slug === 'string' ? a.subject_slug.trim() : '';
+  if (slug) return slug.toLowerCase();
+  const label = stripInstanceSuffix(a.subject_label || '');
+  return label ? label.toLowerCase() : '';
+}
+
+/** Clave de especie de una planta-asset: su nombre sin el sufijo "#N". */
+function claveEspeciePlanta(plant) {
+  const name = plant?.attributes?.name || plant?.name || '';
+  const base = stripInstanceSuffix(String(name));
+  return base ? base.toLowerCase() : '';
+}
+
+/**
+ * Especies DISTINTAS de la finca, desde procesos + plantas-asset reales.
+ *
+ * @param {Array} processes  FarmProcess[] (anidados o planos)
+ * @param {Array} plants     plantas-asset (useAssetStore.plants)
+ * @param {{soloVivas?: boolean}} [opts]  true → solo procesos activos y
+ *   plantas no archivadas ("especies vivas"); false → toda la historia
+ *   no cancelada ("especies registradas").
+ * @returns {number}
+ */
+export function contarEspecies(processes = [], plants = [], { soloVivas = false } = {}) {
+  const set = new Set();
+  for (const p of Array.isArray(processes) ? processes : []) {
+    const a = attrs(p);
+    if (!a) continue;
+    const status = a.status || 'active';
+    if (status === 'cancelled') continue;
+    if (soloVivas && status !== 'active') continue;
+    const clave = claveEspecieProceso(a);
+    if (clave) set.add(clave);
+  }
+  for (const plant of Array.isArray(plants) ? plants : []) {
+    const status = plant?.attributes?.status || plant?.status || 'active';
+    if (soloVivas && status === 'archived') continue;
+    const clave = claveEspeciePlanta(plant);
+    if (clave) set.add(clave);
+  }
+  return set.size;
+}
+
+/** 'YYYY-MM-DD' local (mismo criterio que atmosphereService). */
+function isoDiaLocal(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Eje 💧 El clima, desde la señal guardada (snapshot cacheado + condición ya
+ * derivada por atmosphereService). Ver contrato en el docstring del módulo.
+ *
+ * @param {{climaSnapshot?: object|null, condicion?: string|null, now?: Date}} [input]
+ * @returns {SlotVitalidad}
+ */
+export function ejeClima({ climaSnapshot = null, condicion = null, now = new Date() } = {}) {
+  const om = climaSnapshot?.openmeteo;
+  const forecast = om?.available && Array.isArray(om.forecast_7d) ? om.forecast_7d : null;
+  const hoyKey = isoDiaLocal(now);
+  const day = forecast?.find((d) => d?.date === hoyKey) || forecast?.[0] || null;
+  const precip = finito(day?.precip_mm);
+  const condTxt = condicion && CONDICION_LABEL[condicion] ? CONDICION_LABEL[condicion] : null;
+
+  if (precip != null) {
+    const partes = [`${precip} mm hoy`];
+    if (condTxt) partes.push(condTxt);
+    return ok(Math.round(clamp01((precip / PRECIP_ESCALA_MM) * 100)), {
+      texto: partes.join(' · '),
+      fuente: FUENTES.clima,
+    });
+  }
+  if (condTxt) {
+    // Hay condición real (nubosidad/estado) pero sin mm: se muestra la
+    // condición sin inventar una barra numérica.
+    return ok(null, { texto: condTxt, fuente: FUENTES.clima });
+  }
+  return pendiente({ texto: 'dato en camino', fuente: FUENTES.clima });
+}
+
+/**
+ * Eje 🪱 El suelo, desde un resultado REAL de diagnosticarSuelo
+ * (services/soilDiagnostic). Sin diagnóstico o con `sin_datos` → pendiente.
+ * Fórmula documentada: 100 − 18·problemas, acotada 0..100.
+ *
+ * @param {object|null} [diagSuelo]  resultado de diagnosticarSuelo, o null
+ * @returns {SlotVitalidad}
+ */
+export function ejeSuelo(diagSuelo = null) {
+  if (!diagSuelo || diagSuelo.sin_datos) {
+    return pendiente({ texto: 'dato en camino', fuente: FUENTES.suelo });
+  }
+  const problemas = Array.isArray(diagSuelo.problemas) ? diagSuelo.problemas : [];
+  const valor = Math.round(clamp01(100 - problemas.length * SUELO_PENALIZACION_POR_PROBLEMA));
+  const texto = problemas.length === 0
+    ? 'sin señales de alarma'
+    : `${problemas.length} ${problemas.length === 1 ? 'señal' : 'señales'} de cuidado`;
+  return ok(valor, { texto, fuente: FUENTES.suelo });
+}
+
+/**
+ * Eje 🦋 La biodiversidad: especies vivas distintas, saturadas a 6 (la misma
+ * regla de diversidad de calcularVitalidad — no se inventa otra escala).
+ *
+ * @param {{especiesVivas?: number, vacia?: boolean}} [input]
+ * @returns {SlotVitalidad}
+ */
+export function ejeBiodiversidad({ especiesVivas = 0, vacia = true } = {}) {
+  if (especiesVivas <= 0 && vacia) {
+    return pendiente({ texto: 'dato en camino', fuente: FUENTES.biodiversidad });
+  }
+  const valor = Math.round(clamp01((Math.min(especiesVivas, BIODIVERSIDAD_SATURACION) / BIODIVERSIDAD_SATURACION) * 100));
+  return ok(valor, {
+    texto: `${especiesVivas} ${especiesVivas === 1 ? 'especie' : 'especies'}`,
+    fuente: FUENTES.biodiversidad,
+  });
+}
+
+/** 'YYYY-MM' UTC — el MISMO bucket mensual de cosechaService.temporalTrend. */
+function mesBucketUTC(d) {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+/**
+ * Eje 🔥 La energía (constancia de registro): cosechas anotadas este mes
+ * (serie mensual real de harvestSummary.trend) + ciclos abiertos este mes
+ * (created_at de FarmProcess). 6 registros/mes = barra llena (documentado).
+ *
+ * @param {{processes?: Array, harvestSummary?: object|null, now?: Date}} [input]
+ * @returns {SlotVitalidad}
+ */
+export function ejeEnergia({ processes = [], harvestSummary = null, now = new Date() } = {}) {
+  const hayProcesos = Array.isArray(processes) && processes.length > 0;
+  if (!harvestSummary && !hayProcesos) {
+    return pendiente({ texto: 'dato en camino', fuente: FUENTES.energia });
+  }
+  const mesKey = mesBucketUTC(now);
+  const serie = harvestSummary?.trend?.series;
+  const cosechasMes = Array.isArray(serie)
+    ? (serie.find((s) => s?.period === mesKey)?.harvestCount || 0)
+    : 0;
+  let siembrasMes = 0;
+  for (const p of Array.isArray(processes) ? processes : []) {
+    const a = attrs(p);
+    const ts = finito(a?.created_at);
+    if (ts == null || a?.status === 'cancelled') continue;
+    if (mesBucketUTC(new Date(ts)) === mesKey) siembrasMes += 1;
+  }
+  const registros = cosechasMes + siembrasMes;
+  return ok(Math.round(clamp01((Math.min(registros, ENERGIA_META_MES) / ENERGIA_META_MES) * 100)), {
+    texto: `${registros} ${registros === 1 ? 'registro' : 'registros'} este mes`,
+    fuente: FUENTES.energia,
+  });
+}
+
+/**
+ * ◎ Anillos del frailejón: temporadas del almanaque (~3 meses) desde el
+ * primer registro real (siembra más antigua o primera cosecha anotada).
+ *
+ * @param {{processes?: Array, harvestSummary?: object|null, now?: Date}} [input]
+ * @returns {SlotVitalidad}
+ */
+export function contarAnillosFrailejon({ processes = [], harvestSummary = null, now = new Date() } = {}) {
+  let primero = null;
+  for (const p of Array.isArray(processes) ? processes : []) {
+    const a = attrs(p);
+    const ts = finito(a?.created_at);
+    if (ts == null || a?.status === 'cancelled') continue;
+    if (primero == null || ts < primero) primero = ts;
+  }
+  const primeraCosecha = finito(harvestSummary?.dateRange?.firstMs);
+  if (primeraCosecha != null && (primero == null || primeraCosecha < primero)) {
+    primero = primeraCosecha;
+  }
+  if (primero == null || primero > now.getTime()) {
+    return pendiente({ fuente: FUENTES.anillos });
+  }
+  const inicio = new Date(primero);
+  const meses = (now.getFullYear() - inicio.getFullYear()) * 12 + (now.getMonth() - inicio.getMonth());
+  const anillos = Math.floor(Math.max(0, meses) / MESES_POR_TEMPORADA) + 1;
+  return ok(anillos, { fuente: FUENTES.anillos });
+}
+
+/* ── modelo completo del panel ────────────────────────────────────────────── */
+
+/**
+ * Arma el modelo completo del panel. Ver "FUENTE REAL DE CADA VALOR" arriba.
+ *
+ * @param {Object} input
+ * @param {Object|null} [input.scene]  FincaScene de buildFincaScene (vitalidad honesta)
+ * @param {Array} [input.processes]    FarmProcess[] reales (farmProcessCache)
+ * @param {Array} [input.plants]       plantas-asset (useAssetStore.plants)
+ * @param {Object|null} [input.climaSnapshot]  getCachedClimaSnapshot() o null
+ * @param {string|null} [input.condicion]      atmosfera.condicion (deriveAtmosphere)
+ * @param {Object|null} [input.harvestSummary] useCosechaStore.summary o null
+ * @param {Object|null} [input.diagSuelo]      resultado de diagnosticarSuelo (si existe)
+ * @param {Date} [input.now]           inyectable en tests
+ * @returns {{
+ *   vitalidad: SlotVitalidad,
+ *   especiesVivas: SlotVitalidad,
+ *   ejes: Array<SlotVitalidad & {id:string, emoji:string, label:string, c1:string, c2:string}>,
+ *   conteos: {especies: SlotVitalidad, cosechas: SlotVitalidad, anillos: SlotVitalidad},
+ *   algunPendiente: boolean,
+ * }}
+ */
+export function buildVitalidadEspiritu({
+  scene = null,
+  processes = [],
+  plants = [],
+  climaSnapshot = null,
+  condicion = null,
+  harvestSummary = null,
+  diagSuelo = null,
+  now = new Date(),
+} = {}) {
+  const vacia = scene ? !!scene.vacia : true;
+
+  const vitalidad = (scene && !vacia && Number.isFinite(scene.vitalidad))
+    ? ok(Math.round(clamp01(scene.vitalidad)), { fuente: FUENTES.vitalidad })
+    : pendiente({ fuente: FUENTES.vitalidad });
+
+  const vivas = contarEspecies(processes, plants, { soloVivas: true });
+  const especiesVivas = (vivas > 0 || !vacia)
+    ? ok(vivas, { fuente: FUENTES.especies })
+    : pendiente({ fuente: FUENTES.especies });
+
+  // Los 4 ejes del panel del mockup (mismos colores neón c1→c2 del original).
+  const ejes = [
+    { id: 'clima', emoji: '💧', label: 'El clima', c1: '#4fd8ff', c2: '#2dffc4', ...ejeClima({ climaSnapshot, condicion, now }) },
+    { id: 'suelo', emoji: '🪱', label: 'El suelo', c1: '#ffb54f', c2: '#9dff3f', ...ejeSuelo(diagSuelo) },
+    { id: 'biodiversidad', emoji: '🦋', label: 'La biodiversidad', c1: '#ff4fd8', c2: '#b28dff', ...ejeBiodiversidad({ especiesVivas: vivas, vacia }) },
+    { id: 'energia', emoji: '🔥', label: 'La energía', c1: '#9dff3f', c2: '#2dffc4', ...ejeEnergia({ processes, harvestSummary, now }) },
+  ];
+
+  const registradas = contarEspecies(processes, plants, { soloVivas: false });
+  const conteos = {
+    especies: (registradas > 0 || !vacia)
+      ? ok(registradas, { fuente: FUENTES.especies })
+      : pendiente({ fuente: FUENTES.especies }),
+    cosechas: harvestSummary
+      ? ok(Number.isFinite(harvestSummary.totalHarvests) ? harvestSummary.totalHarvests : 0, { fuente: FUENTES.cosechas })
+      : pendiente({ fuente: FUENTES.cosechas }),
+    anillos: contarAnillosFrailejon({ processes, harvestSummary, now }),
+  };
+
+  const slots = [vitalidad, especiesVivas, ...ejes, conteos.especies, conteos.cosechas, conteos.anillos];
+  return {
+    vitalidad,
+    especiesVivas,
+    ejes,
+    conteos,
+    algunPendiente: slots.some((s) => s.estado === 'pendiente'),
+  };
+}
+
+export default buildVitalidadEspiritu;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -636,7 +636,17 @@
 [data-theme="verde-vivo"] .text-amber-200,
 [data-theme="verde-vivo"] .text-amber-300,
 [data-theme="verde-vivo"] .text-amber-400,
-[data-theme="verde-vivo"] .text-amber-500{
+[data-theme="verde-vivo"] .text-amber-500,
+/* Variantes con ALPHA (QA temas 2026-07-09, bug #2): `text-amber-200/90` y
+ * `text-amber-100/90` son clases APARTE que este bloque no cubría → el
+ * subtítulo de la tab activa de los mundos quedaba ámbar pálido sobre
+ * durazno (ilegible en nature/verde-vivo). Mismo ocre oscuro AA. */
+[data-theme="minimalista"] .text-amber-100\/90,
+[data-theme="minimalista"] .text-amber-200\/90,
+[data-theme="nature"] .text-amber-100\/90,
+[data-theme="nature"] .text-amber-200\/90,
+[data-theme="verde-vivo"] .text-amber-100\/90,
+[data-theme="verde-vivo"] .text-amber-200\/90{
   color: rgb(160, 76, 20) !important;
   text-shadow: none !important;
 }
@@ -738,7 +748,17 @@
 [data-theme="verde-vivo"] .text-indigo-300{ color: rgb(55 48 163) !important; text-shadow: none !important; }
 [data-theme="nature"] .text-cyan-200,
 [data-theme="minimalista"] .text-cyan-200,
-[data-theme="verde-vivo"] .text-cyan-200{ color: rgb(21 94 117) !important; text-shadow: none !important; }
+[data-theme="verde-vivo"] .text-cyan-200,
+/* cyan-300 y su variante alpha (QA temas 2026-07-09, bug de Agua): el
+ * subtítulo de la tab activa ("Del techo al tanque…") usa `text-cyan-300/90`
+ * y los titulares de sección `text-cyan-300` — cian claro sin remapear sobre
+ * card clara = ilegible en nature/verde-vivo. Mismo cian profundo AA. */
+[data-theme="nature"] .text-cyan-300,
+[data-theme="minimalista"] .text-cyan-300,
+[data-theme="verde-vivo"] .text-cyan-300,
+[data-theme="nature"] .text-cyan-300\/90,
+[data-theme="minimalista"] .text-cyan-300\/90,
+[data-theme="verde-vivo"] .text-cyan-300\/90{ color: rgb(21 94 117) !important; text-shadow: none !important; }
 [data-theme="nature"] .text-green-300,
 [data-theme="minimalista"] .text-green-300,
 [data-theme="verde-vivo"] .text-green-300{ color: rgb(22 101 52) !important; text-shadow: none !important; }
@@ -832,6 +852,105 @@
 [data-theme="nature"] [class*="bg-white\/"],
 [data-theme="verde-vivo"] [class*="bg-white\/"]{
   background-color: rgb(var(--c-surface-raised) / 0.55) !important;
+}
+
+/* ===========================================================================
+ * §3e. TEXTO SOBRE FOTO (QA temas 2026-07-09, bug #1 — el peor).
+ *    Los mundos "photo-forward" (café/agua/cacao/fique/…) ponen el título del
+ *    héroe SOBRE la foto, protegido por un scrim negro FIJO
+ *    (`bg-gradient-to-t from-black/85 …`, ver FotoCafe/FotoAgua/etc.). Ese
+ *    scrim NO lo vira el remapeo de temas claros, así que ahí la tinta CLARA
+ *    original (blanco/ámbar/cian claro) sigue siendo la correcta — pero los
+ *    remapeos de §3bis/§3d la viraban a tinta oscura → título ilegible sobre
+ *    la foto (medido: "El café, de la semilla a la taza" casi negro sobre
+ *    cerezas en nature/minimalista/verde-vivo).
+ *    CONTEXTO: el scrim siempre es un hermano ANTERIOR del overlay de texto
+ *    (o su contenedor directo, caso SpeciesFicha/SaludSuelo), así que
+ *    `[class*="from-black"]` + `~ *` identifica "estoy sobre una foto" sin
+ *    tocar 20 JSX. Revertimos a los literales Tailwind (paridad exacta con
+ *    biopunk, que el QA validó como "se lee perfecto"). Especificidad (0,3,0)
+ *    > remapeos genéricos (0,2,0). Solo temas claros.
+ * =========================================================================== */
+
+/* Blancos: el título del héroe y sus variantes con alpha vuelven a blanco. */
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-white{ color: #fff !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-white\/70{ color: rgb(255 255 255 / 0.7) !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-white\/60{ color: rgb(255 255 255 / 0.6) !important; }
+
+/* Slate: la rampa está INVERTIDA en claros (slate-100 = tinta oscura) → sobre
+ * el scrim negro quedaba oscuro-sobre-oscuro. Literales Tailwind claros. */
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-100{ color: #f1f5f9 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-100\/95{ color: rgb(241 245 249 / 0.95) !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-200{ color: #e2e8f0 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-300{ color: #cbd5e1 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-300\/90{ color: rgb(203 213 225 / 0.9) !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-400{ color: #94a3b8 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-500{ color: #64748b !important; }
+
+/* Familias de acento que §3bis/§3d viran a tono -700/-800 oscuro (correcto
+ * sobre crema, ilegible sobre el scrim negro): de vuelta al literal claro. */
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-amber-100, .text-amber-100\/90){ color: #fef3c7 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-amber-200, .text-amber-200\/90){ color: #fde68a !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-amber-300{ color: #fcd34d !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-amber-400{ color: #fbbf24 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-emerald-100, .text-emerald-100\/90){ color: #d1fae5 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-emerald-200, .text-emerald-200\/90, .text-emerald-200\/70){ color: #a7f3d0 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-emerald-300{ color: #6ee7b7 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-rose-200{ color: #fecdd3 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-rose-300{ color: #fda4af !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-sky-200{ color: #bae6fd !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-cyan-200, .text-cyan-300, .text-cyan-300\/90){ color: #a5f3fc !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-teal-200{ color: #99f6e4 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-teal-300{ color: #5eead4 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-orange-200{ color: #fed7aa !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-indigo-200{ color: #c7d2fe !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-red-200{ color: #fecaca !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-violet-200{ color: #ddd6fe !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-green-300{ color: #86efac !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-blue-300{ color: #93c5fd !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-pink-300{ color: #f9a8d4 !important; }
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * §3f. PARDO CAFETERO HARD-CODEADO (QA temas 2026-07-09, bug #2): las cards y
+ * tabs de los mundos Café/Almanaque usan `bg-[#241811]/50|60` (tierra tostada,
+ * fuera de la indirección CSS-var). Sobre la crema de los temas claros quedaba
+ * un pardo sucio que no combina con la tinta remapeada (subtítulos de tabs
+ * invisibles). → superficie de card del tema, como el resto de cards. En
+ * biopunk/biopunk2 (sin remap) el pardo original se conserva. */
+[data-theme="minimalista"] [class*="bg-[#241811]"],
+[data-theme="nature"] [class*="bg-[#241811]"],
+[data-theme="verde-vivo"] [class*="bg-[#241811]"]{
+  background-color: rgb(var(--c-surface-card)) !important;
 }
 
 /* ===========================================================================

--- a/tests/e2e-espiritu-entrada.spec.js
+++ b/tests/e2e-espiritu-entrada.spec.js
@@ -1,0 +1,149 @@
+/* global process */
+import { test, expect } from '@playwright/test';
+
+/**
+ * e2e-espiritu-entrada.spec.js — la entrada visible al AVATAR-ESPÍRITU
+ * (#/espiritu) en el home, GATED por capability Pro.
+ *
+ * Contexto: el módulo avatar-espiritu-pro estaba montado y sirviendo pero
+ * HUÉRFANO (cero entradas en la UI — feedback-features-ui-huerfanas-sin-
+ * cablear). La entrada nueva vive bajo la grilla de LOS MUNDOS DE MI FINCA
+ * (MundosDeMiFinca, banda .mf-espiritu) y SOLO se renderiza cuando el
+ * registry tiene un módulo con capability 'avatar-espiritu'.
+ *
+ * Pro SIMULADO: el dev server corre en modo DEV, donde main.jsx expone
+ * window.__chagraRegistry. Registramos un módulo fake con la capability y el
+ * mount devolviendo un componente marcador (los componentes React pueden
+ * devolver string — cero dependencia del React del bundle). Esto ejercita el
+ * MISMO camino que loadProModules en prod: registry.register() → suscripción
+ * (useSyncExternalStore) → la banda aparece sin recargar.
+ *
+ * Patrones de la suite: mock OAuth/API en context.route, ORIGIN 5173,
+ * data-testid como selectores.
+ */
+
+// Servidor 5174 (webServer segundo de playwright.config.js): corre con
+// VITE_FINCA_VIVA_HOME_PERFIL=true — la realidad de prod/stg. La grilla de
+// mundos (y con ella esta entrada) SOLO existe en el home F2; en el 5173
+// legacy (flag OFF) el bloque no se renderiza.
+const ORIGIN = 'http://localhost:5174';
+
+const REGISTRAR_MODULO_FAKE = () => {
+  window.__chagraRegistry.register({
+    id: 'avatar-espiritu-pro',
+    version: '0.0.0-e2e',
+    capabilities: ['avatar-espiritu'],
+    mount: async () => ({ default: () => 'AVATAR ESPIRITU PRO MONTADO (E2E)' }),
+  });
+};
+
+test.describe('Entrada visible al avatar-espíritu (gate Pro)', () => {
+  test.beforeEach(async ({ context }) => {
+    // Mock OAuth — sin FarmOS real.
+    await context.route('**/oauth/token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-espiritu-fake-token',
+          refresh_token: 'e2e-espiritu-fake-refresh',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      }),
+    );
+    // Mock API — offline-first.
+    for (const pattern of ['**/api/**', '**/jsonapi/**']) {
+      await context.route(pattern, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [] }),
+        }),
+      );
+    }
+    // Silenciar sidecar / NLU (el grafo live está OFF y no dependemos de él).
+    await context.route('**/nlu**', (route) => route.abort('blockedbyclient'));
+    await context.route('**/resolve-entities**', (route) => route.abort('blockedbyclient'));
+  });
+
+  // Saltar onboarding + wizard de perfil (mismo patrón de e2e-smoke-pilotos):
+  // sin perfil sembrado, el wizard "Esta chagra es suya" tapa el home.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem('chagra:onboarding:done', '1');
+        window.localStorage.setItem('chagra:bienvenida-vista:v1', '1');
+        window.localStorage.setItem(
+          'chagra:profile:v1',
+          JSON.stringify({
+            rol: 'agricultor',
+            vocacion: 'campesino',
+            animales: [],
+            finca_tipo: 'rural',
+            finca_altitud: '1800',
+            piso_confirmado: '1',
+          }),
+        );
+      } catch (_) {
+        /* noop */
+      }
+    });
+  });
+
+  test('sin Pro no hay rastro; con Pro aparece, navega y monta el avatar', async ({ page }) => {
+    // ── Login ──────────────────────────────────────────────────────────
+    await page.goto(ORIGIN);
+    await page.getByLabel(/usuario/i).fill('e2e-espiritu');
+    await page.getByRole('textbox', { name: /contraseña/i }).fill('e2e-pass');
+    await page.getByRole('button', { name: /ingresar/i }).click();
+    await expect(page.getByTestId('mundos-finca')).toBeVisible({ timeout: 20_000 });
+
+    // ── 1. SIN módulo Pro: cero rastro (ni botón muerto ni teaser) ─────
+    await expect(page.getByTestId('entrada-espiritu')).toHaveCount(0);
+
+    // ── 2. Simular Pro: registrar el módulo fake (camino real de
+    //       loadProModules). La banda debe aparecer SOLA (suscripción). ──
+    await page.waitForFunction(() => !!window.__chagraRegistry);
+    await page.evaluate(REGISTRAR_MODULO_FAKE);
+    const entrada = page.getByTestId('entrada-espiritu');
+    await expect(entrada).toBeVisible({ timeout: 5_000 });
+    await expect(entrada).toContainText(/el espíritu de su finca/i);
+
+    // ── 3. Click → navega a la vista espiritu_pro y monta el avatar ────
+    await entrada.scrollIntoViewIfNeeded();
+    // Captura opcional para revisión del operador (ESPIRITU_SHOTS=dir).
+    if (process.env.ESPIRITU_SHOTS) {
+      await page.waitForTimeout(400);
+      await page.screenshot({ path: `${process.env.ESPIRITU_SHOTS}/espiritu-entrada-home.png` });
+    }
+    await entrada.click();
+    await expect(page.getByText('AVATAR ESPIRITU PRO MONTADO (E2E)')).toBeVisible({
+      timeout: 10_000,
+    });
+    // La grilla del home ya no está: navegó de verdad.
+    await expect(page.getByTestId('mundos-finca')).toHaveCount(0);
+    if (process.env.ESPIRITU_SHOTS) {
+      await page.screenshot({ path: `${process.env.ESPIRITU_SHOTS}/espiritu-vista-montada.png` });
+    }
+  });
+
+  test('la ruta #/espiritu (alias hash) monta la misma vista con Pro', async ({ page }) => {
+    await page.goto(ORIGIN);
+    await page.getByLabel(/usuario/i).fill('e2e-espiritu');
+    await page.getByRole('textbox', { name: /contraseña/i }).fill('e2e-pass');
+    await page.getByRole('button', { name: /ingresar/i }).click();
+    await expect(page.getByTestId('mundos-finca')).toBeVisible({ timeout: 20_000 });
+
+    await page.waitForFunction(() => !!window.__chagraRegistry);
+    await page.evaluate(REGISTRAR_MODULO_FAKE);
+
+    // Deep-link por hash (listener hashchange de App.jsx).
+    await page.evaluate(() => {
+      window.location.hash = '#/espiritu';
+    });
+    await expect(page.getByText('AVATAR ESPIRITU PRO MONTADO (E2E)')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/tests/guardian-selector.spec.js
+++ b/tests/guardian-selector.spec.js
@@ -1,0 +1,169 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * guardian-selector.spec.js — SELECTOR DEL GUARDIÁN (espíritu de la finca) en el
+ * home vivo (menú vivo), portado del mockup aprobado #/mockups/avatar-biopunk.
+ *
+ * Verifica el criterio de éxito del pedido:
+ *   1. El selector "SU GUARDIÁN — ESCOJA UNA ESPECIE NATIVA" aparece en el home
+ *      (no huérfano) con fauna nativa colombiana REAL + nombre científico.
+ *   2. Se puede ELEGIR un guardián (tarjeta con glow neón, aria-checked).
+ *   3. La elección se refleja en el espíritu (héroe: nombre + nombre científico).
+ *   4. PERSISTE: al recargar sigue elegido, y queda en el perfil
+ *      (localStorage: guardian_especie).
+ *
+ * Patrón de login determinístico + mocks: home-operador-ve-todo.spec.js
+ * (A-19: los mocks de red van en page.context().route, no page.route, por el SW).
+ */
+
+const ORIGIN = 'http://localhost:5173';
+const OPERADOR_USERNAME = 'op-test';
+
+async function seedOperador(page) {
+  await page.addInitScript((username) => {
+    try {
+      window.localStorage.setItem('chagra:active_tenant_id', username);
+      // Sembrar el perfil SOLO si no existe (idempotente): addInitScript corre en
+      // CADA navegación —incluido el reload—; si lo reescribiéramos siempre,
+      // clobberíamos el guardián que la app ya guardó (clave tenant-scoped
+      // chagra:profile:v1:<tenant>), rompiendo la prueba de persistencia. En uso
+      // real el onboarding no se resiembra en cada carga.
+      const legacy = window.localStorage.getItem('chagra:profile:v1');
+      const scoped = window.localStorage.getItem(`chagra:profile:v1:${username}`);
+      if (!legacy && !scoped) {
+        window.localStorage.setItem(
+          'chagra:profile:v1',
+          JSON.stringify({
+            rol: 'campesino',
+            finca_tipo: 'finca',
+            finca_altitud: '2600',
+            piso_confirmado: '1',
+          }),
+        );
+      }
+    } catch (_) { /* noop */ }
+  }, OPERADOR_USERNAME);
+}
+
+async function mockBackend(page) {
+  await page.context().route('**/oauth/token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'e2e-guardian-token',
+        refresh_token: 'e2e-guardian-refresh',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      }),
+    }),
+  );
+  for (const pattern of ['**/api/asset/**', '**/api/log/**', '**/api/taxonomy_term/**', '**/api/user/**']) {
+    await page.context().route(pattern, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: JSON.stringify({ data: [], jsonapi: { version: '1.0' } }),
+      }),
+    );
+  }
+  for (const pattern of ['**/nlu', '**/resolve-entities', '**/post-validate']) {
+    await page.context().route(pattern, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) }),
+    );
+  }
+}
+
+/**
+ * goto tolerante al net::ERR_ABORTED de la PRIMERA visita: el SW se registra y
+ * puede abortar la navegación en curso (más probable bajo carga / primer compile
+ * del dev server). Reintenta una vez. En CI el `retries:2` del config ya cubre
+ * el flake; esto lo hace robusto también en local (retries:0).
+ */
+async function gotoReady(page, url) {
+  for (let intento = 0; intento < 2; intento += 1) {
+    try {
+      await page.goto(url, { waitUntil: 'domcontentloaded' });
+      return;
+    } catch (err) {
+      if (intento === 1 || !/ERR_ABORTED|detached/.test(String(err))) throw err;
+      await page.waitForTimeout(800);
+    }
+  }
+}
+
+async function login(page) {
+  await page.evaluate(async (username) => {
+    const authMod = await import('/src/services/authService.js');
+    const result = await authMod.authenticateUser(username, 'e2e-guardian-pwd');
+    if (!result.success) throw new Error('OAuth mock no respondió OK: ' + (result.error || '??'));
+    const tenantMod = await import('/src/services/tenantContext.js');
+    tenantMod.setActiveTenantId(username);
+  }, OPERADOR_USERNAME);
+}
+
+test.describe('Selector del guardián (espíritu de la finca)', () => {
+  test('elegir un guardián nativo lo resalta, muestra el nombre científico y PERSISTE', async ({ page }) => {
+    test.setTimeout(90000);
+    await seedOperador(page);
+    await mockBackend(page);
+
+    await gotoReady(page, ORIGIN);
+    await login(page);
+    await gotoReady(page, ORIGIN);
+    await page.waitForLoadState('networkidle').catch(() => {});
+
+    // 1) El selector existe en el home vivo (no huérfano).
+    const selector = page.locator('[data-testid="guardian-selector"]');
+    await selector.scrollIntoViewIfNeeded();
+    await expect(selector).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Escoja una especie nativa')).toBeVisible();
+
+    // Default grounded: la abeja angelita (Tetragonisca angustula).
+    await expect(selector).toHaveAttribute('data-guardian', 'abeja');
+    await expect(page.locator('[data-testid="guardian-cientifico"]')).toHaveText('Tetragonisca angustula');
+
+    // 2+3) Elegir el chivito de páramo → resaltado (aria-checked) + héroe actualizado.
+    const chivito = page.locator('[data-testid="guardian-chip-chivito"]');
+    await chivito.click();
+    await expect(chivito).toHaveAttribute('aria-checked', 'true');
+    await expect(selector).toHaveAttribute('data-guardian', 'chivito');
+    await expect(page.locator('[data-testid="guardian-nombre"]')).toHaveText('Chivito de páramo');
+    await expect(page.locator('[data-testid="guardian-cientifico"]')).toHaveText('Oxypogon guerinii');
+
+    // La elección quedó persistida en el PERFIL (guardian_especie). Se lee por
+    // la propia API del servicio (la clave es tenant-scoped: chagra:profile:v1:<tenant>).
+    const persisted = await page.evaluate(async () => {
+      const mod = await import('/src/services/userProfileService.js');
+      return mod.getGuardianEspecie();
+    });
+    expect(persisted).toBe('chivito');
+
+    // 4) Recargar → el guardián elegido SOBREVIVE (persistencia real, no de sesión).
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const dbg = await page.evaluate(async () => {
+      const prof = await import('/src/services/userProfileService.js');
+      const ten = await import('/src/services/tenantContext.js');
+      const keys = {};
+      for (let i = 0; i < window.localStorage.length; i += 1) {
+        const k = window.localStorage.key(i);
+        if (k && k.includes('profile')) keys[k] = window.localStorage.getItem(k);
+      }
+      return {
+        tenant: ten.getActiveTenantId(),
+        guardian: prof.getGuardianEspecie(),
+        profile: prof.getProfile(),
+        keys,
+      };
+    });
+    console.log('DBG_RELOAD', JSON.stringify(dbg));
+    const selector2 = page.locator('[data-testid="guardian-selector"]');
+    await selector2.scrollIntoViewIfNeeded();
+    await expect(selector2).toHaveAttribute('data-guardian', 'chivito', { timeout: 15000 });
+    await expect(page.locator('[data-testid="guardian-chip-chivito"]')).toHaveAttribute('aria-checked', 'true');
+
+    await selector2.scrollIntoViewIfNeeded();
+    await page.screenshot({ path: '/tmp/guardian-selector.png', fullPage: true });
+  });
+});

--- a/tests/visual/menu-arbol-reloj.spec.js
+++ b/tests/visual/menu-arbol-reloj.spec.js
@@ -1,0 +1,115 @@
+/**
+ * EL ÁRBOL DE LOS MUNDOS + RELOJ DEL FRAILEJÓN en el home menú vivo (F2,
+ * piel biopunk2 por defecto) — verificación E2E con DATOS REALES:
+ *
+ *   1. Siembra sesión + perfil F2 (f2TestUtils) y crea EN LA IDB real un
+ *      FarmProcess (café, hace ~2 años) por la puerta de producción
+ *      (farmProcessCache.putFarmProcess), para que el reloj tenga historia.
+ *   2. Verifica que el ÁRBOL renderiza DENTRO del bloque de mundos (no
+ *      huérfano): una rama-botón por mundo del manifiesto (fuente única
+ *      mundosFinca.js), enrutando igual que la grilla; y que el RELOJ DEL
+ *      FRAILEJÓN aparece con años reales (un anillo por año).
+ *   3. La grilla/puerta plegable de main sigue accesible debajo (unión).
+ *
+ * Corre en el proyecto `visual` (servidor :5174 con la flag F2 ON), mismo
+ * patrón que panel-vitalidad-espiritu.spec.js.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  seedSession,
+  mockBackendBasico,
+  login,
+  flagF2Activa,
+  filtrarErroresCriticos,
+  trackJsErrors,
+} from './f2TestUtils';
+
+/**
+ * goto tolerante al net::ERR_ABORTED de la PRIMERA visita (el service worker
+ * aborta la navegación en curso bajo carga). Reintenta. Mismo patrón que
+ * guardian-selector.spec.js / panel-vitalidad-espiritu.spec.js.
+ */
+async function gotoReady(page, url = '/') {
+  for (let intento = 0; intento < 3; intento += 1) {
+    try {
+      await page.goto(url, { waitUntil: 'domcontentloaded' });
+      return;
+    } catch (err) {
+      if (intento === 2 || !/ERR_ABORTED|detached/.test(String(err))) throw err;
+      await page.waitForTimeout(800);
+    }
+  }
+}
+
+/** Siembra un ciclo REAL con ~2 años para que el reloj tenga historia. */
+async function sembrarHistoria(page) {
+  await page.evaluate(async () => {
+    const { putFarmProcess } = await import('/src/db/farmProcessCache.js');
+    const now = Date.now();
+    const hace2Anios = now - 2 * 365 * 24 * 60 * 60 * 1000;
+    await putFarmProcess({
+      process_id: 'e2e-arbol-cafe',
+      type: 'farm_process',
+      attributes: {
+        process_type: 'sowing',
+        subject_kind: 'individual',
+        subject_slug: 'coffea_arabica',
+        subject_label: 'Café',
+        quantity: 12,
+        unit: 'plantas',
+        status: 'active',
+        current_stage: 'flowering',
+        created_at: hace2Anios,
+        updated_at: now,
+      },
+    });
+  });
+}
+
+test.describe('El árbol de los mundos + reloj del frailejón (home menú vivo)', () => {
+  test('renderiza el árbol no-huérfano y el reloj con años reales', async ({ page, context }) => {
+    const errors = trackJsErrors(page);
+    await seedSession(page);
+    await mockBackendBasico(context);
+    await gotoReady(page, '/');
+
+    const flagOn = await flagF2Activa(page);
+    test.skip(!flagOn, 'Build sin VITE_FINCA_VIVA_HOME_PERFIL — el home F2 no se monta');
+
+    await login(page);
+    await sembrarHistoria(page);
+    await gotoReady(page, '/');
+    await page.waitForLoadState('networkidle').catch(() => {});
+
+    // El bloque de mundos existe y, DENTRO, el árbol (no huérfano).
+    const bloque = page.getByTestId('bloque-mundos');
+    await bloque.scrollIntoViewIfNeeded();
+    const arbol = page.getByTestId('arbol-mundos');
+    await expect(arbol).toBeVisible({ timeout: 20000 });
+    await expect(page.getByText('El árbol de su finca')).toBeVisible();
+
+    // Ramas vivas: al menos las de cultivos/suelo/agua (fuente única
+    // mundosFinca.js). Cada rama es un botón operable.
+    for (const id of ['cultivos', 'suelo', 'agua', 'clima']) {
+      const rama = page.getByTestId(`arbol-rama-${id}`);
+      await expect(rama).toHaveAttribute('role', 'button');
+    }
+
+    // El reloj del frailejón, con años reales (café sembrado hace ~2 años →
+    // varios anillos). Es un botón que abre "el año de la finca".
+    const reloj = page.getByTestId('reloj-frailejon');
+    await reloj.scrollIntoViewIfNeeded();
+    await expect(reloj).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId('reloj-frailejon-anios')).toContainText('anillo');
+
+    // La grilla/puerta plegable de main sigue presente debajo (unión): la
+    // puerta "Toda mi finca" (plegado por defecto).
+    await expect(page.getByTestId('abrir-mundos')).toBeVisible();
+
+    // Captura para revisión del operador.
+    await page.screenshot({ path: 'test-results/menu-arbol-reloj-home.png', fullPage: true });
+    await arbol.screenshot({ path: 'test-results/menu-arbol-reloj.png' });
+
+    expect(filtrarErroresCriticos(errors)).toEqual([]);
+  });
+});

--- a/tests/visual/panel-vitalidad-espiritu.spec.js
+++ b/tests/visual/panel-vitalidad-espiritu.spec.js
@@ -1,0 +1,195 @@
+/**
+ * PANEL DE VITALIDAD DEL ESPÍRITU en el home menú vivo (F2, Finca Organismo)
+ * — verificación E2E con DATOS REALES de un perfil sembrado:
+ *
+ *   1. Siembra sesión + perfil integral (f2TestUtils) y crea EN LA IDB real
+ *      dos FarmProcess (café en floración, maíz en cosecha) por la puerta
+ *      autorizada (farmProcessCache.putFarmProcess) + un log--harvest real
+ *      (logCache.put), el MISMO camino de producción.
+ *   2. Verifica que el panel renderiza DENTRO del hero (no huérfano) con los
+ *      números que salen de esos registros: vitalidad > 0, "2 sp." vivas,
+ *      4 barras (💧🪱🦋🔥), contadores de especies/cosechas/anillos.
+ *   3. Verifica la honestidad: el eje suelo (sin diagnóstico persistido)
+ *      queda "—" con la nota "dato en camino" — nunca un número inventado.
+ *
+ * Corre en el proyecto `visual` (servidor :5174 con la flag F2 ON). Mismo
+ * patrón de sesión/mocks que click-through-completo.spec.js.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  seedSession,
+  mockBackendBasico,
+  login,
+  flagF2Activa,
+  filtrarErroresCriticos,
+  trackJsErrors,
+} from './f2TestUtils';
+
+/**
+ * goto tolerante al net::ERR_ABORTED de la PRIMERA visita: el service worker se
+ * registra y puede abortar la navegación en curso (más probable bajo carga o en
+ * el primer compile del dev server). Reintenta una vez. Mismo patrón que
+ * guardian-selector.spec.js — hace el spec robusto también en local.
+ */
+async function gotoReady(page, url = '/') {
+  for (let intento = 0; intento < 3; intento += 1) {
+    try {
+      await page.goto(url, { waitUntil: 'domcontentloaded' });
+      return;
+    } catch (err) {
+      if (intento === 2 || !/ERR_ABORTED|detached/.test(String(err))) throw err;
+      await page.waitForTimeout(800);
+    }
+  }
+}
+
+/** Siembra ciclos + cosecha REALES en IndexedDB (la puerta de producción). */
+async function sembrarFincaReal(page) {
+  await page.evaluate(async () => {
+    const { putFarmProcess } = await import('/src/db/farmProcessCache.js');
+    const { logCache } = await import('/src/db/logCache.js');
+    const now = Date.now();
+    const hace8Meses = now - 8 * 30 * 24 * 60 * 60 * 1000;
+
+    await putFarmProcess({
+      process_id: 'e2e-pve-cafe',
+      type: 'farm_process',
+      attributes: {
+        process_type: 'sowing',
+        subject_kind: 'individual',
+        subject_slug: 'coffea_arabica',
+        subject_label: 'Café',
+        quantity: 20,
+        unit: 'plantas',
+        status: 'active',
+        current_stage: 'flowering',
+        created_at: hace8Meses,
+        updated_at: now,
+      },
+    });
+    await putFarmProcess({
+      process_id: 'e2e-pve-maiz',
+      type: 'farm_process',
+      attributes: {
+        process_type: 'sowing',
+        subject_kind: 'individual',
+        subject_slug: 'zea_mays',
+        subject_label: 'Maíz',
+        quantity: 40,
+        unit: 'plantas',
+        status: 'active',
+        current_stage: 'harvest',
+        created_at: now - 3 * 24 * 60 * 60 * 1000,
+        updated_at: now,
+      },
+    });
+    // Cosecha real anotada (log--harvest, shape de producción). `_pending: true`
+    // = registrada localmente y aún sin sincronizar (lo que ES una cosecha
+    // recién anotada por el campesino). Sin esa marca, el GC de logCache.bulkPut
+    // la borra cuando el home sincroniza contra el backend mock (data: []),
+    // dejando el contador en 0 — el mismo camino de producción de un log local.
+    await logCache.put({
+      id: 'e2e-pve-cosecha-1',
+      type: 'log--harvest',
+      name: 'Cosecha: Maíz',
+      timestamp: Math.floor(now / 1000),
+      status: 'done',
+      _pending: true,
+      quantity: [{ measure: 'weight', value: { decimal: '12' }, units: 'kg' }],
+    });
+  });
+}
+
+test.describe('Panel de vitalidad del espíritu (home menú vivo)', () => {
+  test('renderiza con los datos reales del perfil sembrado, sin inventar', async ({ page, context }) => {
+    const errors = trackJsErrors(page);
+    await seedSession(page);
+    await mockBackendBasico(context);
+    await gotoReady(page, '/');
+
+    const flagOn = await flagF2Activa(page);
+    test.skip(!flagOn, 'Build sin VITE_FINCA_VIVA_HOME_PERFIL — el hero F2 no se monta');
+
+    await login(page);
+    await sembrarFincaReal(page);
+    await gotoReady(page, '/');
+    await page.waitForLoadState('networkidle').catch(() => {});
+
+    // El hero F2 y, DENTRO de él, el panel (no huérfano).
+    const hero = page.getByTestId('finca-viva-hero');
+    await expect(hero).toBeVisible({ timeout: 20000 });
+    const panel = hero.getByTestId('panel-vitalidad-espiritu');
+    await expect(panel).toBeVisible({ timeout: 20000 });
+    await expect(panel).toContainText('VITALIDAD DEL ESPÍRITU');
+
+    // Medidor circular con vitalidad REAL (café floreciendo + maíz en
+    // cosecha → calcularVitalidad > 0, nunca "—").
+    const vital = panel.getByTestId('pve-vitalidad');
+    await expect(vital).toHaveAttribute('data-estado', 'ok');
+    const vitalidadNum = Number((await vital.innerText()).trim());
+    expect(vitalidadNum).toBeGreaterThan(0);
+    expect(vitalidadNum).toBeLessThanOrEqual(100);
+
+    // Badge: 2 especies vivas (café + maíz sembrados en la IDB).
+    const vivas = panel.getByTestId('pve-especies-vivas');
+    await expect(vivas).toContainText('2');
+    await expect(vivas).toContainText('ESPECIES VIVAS');
+
+    // Las 4 barras del mockup, en orden, con su ícono.
+    const ejes = panel.locator('.pve-eje');
+    await expect(ejes).toHaveCount(4);
+    for (const [i, id] of ['clima', 'suelo', 'biodiversidad', 'energia'].entries()) {
+      await expect(ejes.nth(i)).toHaveAttribute('data-eje', id);
+    }
+    await expect(panel).toContainText('💧');
+    await expect(panel).toContainText('🪱');
+    await expect(panel).toContainText('🦋');
+    await expect(panel).toContainText('🔥');
+
+    // Biodiversidad sale de las especies reales (2 de 6 → 33).
+    await expect(ejes.nth(2)).toHaveAttribute('data-estado', 'ok');
+    await expect(ejes.nth(2)).toContainText('33');
+
+    // Contadores con los registros reales.
+    await expect(panel.getByTestId('pve-conteo-especies')).toContainText('2');
+    await expect(panel.getByTestId('pve-conteo-especies')).toContainText('especies registradas');
+    await expect(panel.getByTestId('pve-conteo-cosechas')).toContainText('1');
+    await expect(panel.getByTestId('pve-conteo-cosechas')).toContainText('cosechas anotadas');
+    // Anillos: primer registro hace ~8 meses → 2 temporadas cumplidas + 1.
+    const anillos = panel.getByTestId('pve-conteo-anillos');
+    await expect(anillos).toHaveAttribute('data-estado', 'ok');
+    await expect(anillos).toContainText('anillos del frailejón');
+    await expect(anillos.locator('b')).toHaveText('3');
+
+    // HONESTIDAD: suelo sin diagnóstico persistido → "—" + nota, cero inventos.
+    await expect(ejes.nth(1)).toHaveAttribute('data-estado', 'pendiente');
+    await expect(ejes.nth(1)).toContainText('—');
+    await expect(panel.getByTestId('pve-nota-pendiente')).toContainText('dato en camino');
+
+    // Captura para revisión visual del operador.
+    await panel.screenshot({ path: 'test-results/panel-vitalidad-espiritu.png' });
+    await page.screenshot({ path: 'test-results/panel-vitalidad-espiritu-home.png', fullPage: false });
+
+    expect(filtrarErroresCriticos(errors)).toEqual([]);
+  });
+
+  test('finca vacía: el panel no fabrica números (todo "—" o no aparece)', async ({ page, context }) => {
+    await seedSession(page, { user: 'e2e-pve-vacia' });
+    await mockBackendBasico(context);
+    await gotoReady(page, '/');
+    const flagOn = await flagF2Activa(page);
+    test.skip(!flagOn, 'Build sin VITE_FINCA_VIVA_HOME_PERFIL — el hero F2 no se monta');
+
+    await login(page, { user: 'e2e-pve-vacia' });
+    await gotoReady(page, '/');
+    await expect(page.getByTestId('finca-viva-hero')).toBeVisible({ timeout: 20000 });
+
+    const panel = page.getByTestId('panel-vitalidad-espiritu');
+    if (await panel.count()) {
+      // Con el panel visible, NINGÚN contador puede traer un número inventado.
+      await expect(panel.getByTestId('pve-vitalidad')).toHaveAttribute('data-estado', 'pendiente');
+      await expect(panel.getByTestId('pve-conteo-especies').locator('b')).toHaveText('—');
+      await expect(panel.getByTestId('pve-nota-pendiente')).toContainText('dato en camino');
+    }
+  });
+});


### PR DESCRIPTION
- Reemplaza whitespace-normal break-words por truncate en el span de ubicación
- max-w: 200px (o 50vw) para limitar ancho del pill
- min-w-0 + shrink en el pill y en el button padre para permitir
  compresión cuando el nombre de vereda es largo
- Evita que Vereda Potrero Grande (o similar) empuje los iconos
  de usuario/ayuda fuera del viewport
