### PR TITLE
feat(chivito): mockup B definitivo + composición y movimiento refinados en el home

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -60,7 +60,10 @@ jobs:
           # transición. Dev-only para revisión del operador; AUSENTE en
           # deploy.yml (prod) → prod conserva el colibrí 2D / video actual.
           VITE_COLIBRI: "true"
-          VITE_CHIVITO: "ab"
+          # Chivito de páramo (SVG/CSS vivo, diseño definitivo ya elegido) en
+          # home + botón + FAB + transición. Tiene precedencia sobre
+          # VITE_COLIBRI. Dev-only; AUSENTE en deploy.yml (prod).
+          VITE_CHIVITO: "true"
           VITE_CHAGRA_MCP_TOKEN: ${{ secrets.VITE_CHAGRA_MCP_TOKEN }}
 
       - if: env.SKIP_DEPLOY != '1'

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -7,7 +7,7 @@ import { agentSounds } from '../services/agentSoundService';
 import { fvhSkinClass } from '../config/fvhSkin';
 import { colibriRealActivo } from '../config/colibriFlag';
 import { BarbuditoPosado } from './colibri/Barbudito';
-import { chivitoMockup } from '../config/chivitoFlag';
+import { chivitoActivo } from '../config/chivitoFlag';
 import { ChivitoBoton } from './chivito/Chivito';
 import './agent-fab-skin.css';
 
@@ -16,10 +16,9 @@ import './agent-fab-skin.css';
 // (ChagraAgentAvatar). Se evalúa una sola vez (flag de build).
 const COLIBRI_REAL = colibriRealActivo();
 
-// ¿El FAB = CHIVITO de páramo (SVG/CSS vivo)? Gateado por VITE_CHIVITO (dev).
-// Tiene precedencia sobre VITE_COLIBRI. En A/B usa Mockup B (más rico).
-const CHIVITO = chivitoMockup();
-const CHIVITO_FAB = CHIVITO === 'ab' ? 'b' : CHIVITO;
+// ¿El FAB = CHIVITO de páramo (SVG/CSS vivo, diseño definitivo)? Gateado por
+// VITE_CHIVITO (dev). Tiene precedencia sobre VITE_COLIBRI.
+const CHIVITO = chivitoActivo();
 
 /**
  * AgentFab — Floating Action Button para abrir el agente Chagra IA.
@@ -142,9 +141,9 @@ export default function AgentFab({ onNavigate }) {
         transition: 'transform .18s cubic-bezier(.34,1.56,.64,1), box-shadow .25s ease, background .25s ease, border-color .25s ease',
       }}
     >
-      {CHIVITO_FAB ? (
+      {CHIVITO ? (
         // CHIVITO de páramo (SVG/CSS vivo) como avatar del FAB.
-        <ChivitoBoton mockup={CHIVITO_FAB} size={42} state={state} ariaLabel="Chagra IA" />
+        <ChivitoBoton size={42} state={state} ariaLabel="Chagra IA" />
       ) : COLIBRI_REAL ? (
         // Colibrí REAL (barbudito POSADO recortado), con un leve flotar. El
         // botón ya es circular y recorta (overflow:hidden).

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -111,7 +111,7 @@ import ActionConfirmModal from '../ActionConfirmModal';
 import FeedbackConsentModal from '../FeedbackConsentModal';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import ChagraAgentAvatarColibriPhoto from '../ChagraAgentAvatarColibriPhoto';
-import { chivitoMockup } from '../../config/chivitoFlag';
+import { chivitoActivo } from '../../config/chivitoFlag';
 import { ChivitoBoton } from '../chivito/Chivito';
 import { AgentManoOverlay } from '../agent/AgentShell';
 import { mapCapabilityPick } from '../agent/capabilityRouting';
@@ -159,11 +159,10 @@ const STATE_IDLE = 'idle';
 const STATE_RECORDING = 'recording';
 const STATE_THINKING = 'thinking';
 
-// ¿El botón de enviar/hablar del compositor ES el CHIVITO de páramo? Gateado por
-// VITE_CHIVITO (dev-only). En A/B el botón usa Mockup B (más rico); con 'a'/'b'
-// el elegido. Con la flag OFF, el botón conserva ChagraAgentAvatar de siempre.
-const CHIVITO = chivitoMockup();
-const CHIVITO_BTN = CHIVITO === 'ab' ? 'b' : CHIVITO;
+// ¿El botón de enviar/hablar del compositor ES el CHIVITO de páramo (diseño
+// definitivo)? Gateado por VITE_CHIVITO (dev-only). Con la flag OFF, el botón
+// conserva ChagraAgentAvatar de siempre.
+const CHIVITO = chivitoActivo();
 
 export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // B1: clase de animación de entrada, resuelta UNA vez al montar (no en cada
@@ -3517,10 +3516,9 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                     : '0 0 18px rgba(16,185,129,0.5)',
               }}
             >
-              {CHIVITO_BTN ? (
+              {CHIVITO ? (
                 // El CHIVITO de páramo ES el botón de enviar (SVG/CSS vivo).
                 <ChivitoBoton
-                  mockup={CHIVITO_BTN}
                   size={34}
                   state={state === STATE_THINKING ? 'thinking' : 'idle'}
                   ariaLabel="Enviar al agente"

--- a/src/components/agent/ColibriTransition.jsx
+++ b/src/components/agent/ColibriTransition.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { colibriRealActivo } from '../../config/colibriFlag';
 import { BarbuditoFlor } from '../colibri/Barbudito';
-import { chivitoMockup } from '../../config/chivitoFlag';
+import { chivitoActivo } from '../../config/chivitoFlag';
 import { ChivitoCruza } from '../chivito/Chivito';
 
 /**
@@ -50,10 +50,10 @@ export const CHIVITO_TRANSITION_HOLD_MS = 1500;
 // Gateado por VITE_COLIBRI (dev-only). Se evalúa una sola vez (flag de build).
 const COLIBRI_REAL = colibriRealActivo();
 
-// ¿Transición con el CHIVITO de páramo cruzando aleteando (SVG/CSS vivo)?
-// Gateado por VITE_CHIVITO (dev-only). Tiene precedencia sobre VITE_COLIBRI.
-// 'ab' = cruzan los dos mockups en paralelo (A arriba, B abajo) para comparar.
-const CHIVITO = chivitoMockup();
+// ¿Transición con el CHIVITO de páramo cruzando aleteando (SVG/CSS vivo,
+// diseño definitivo)? Gateado por VITE_CHIVITO (dev-only). Tiene precedencia
+// sobre VITE_COLIBRI.
+const CHIVITO = chivitoActivo();
 
 function prefersReducedMotion() {
   return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
@@ -158,16 +158,8 @@ function ColibriOverlay({ onDone }) {
     >
       <style>{CSS}</style>
       {CHIVITO ? (
-        // El CHIVITO de páramo cruza aleteando (SVG/CSS vivo, universal). En A/B
-        // cruzan los dos mockups (A arriba, B abajo) para compararlos.
-        CHIVITO === 'ab' ? (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '6vh', alignItems: 'center' }}>
-            <ChivitoCruza mockup="a" size={150} />
-            <ChivitoCruza mockup="b" size={150} />
-          </div>
-        ) : (
-          <ChivitoCruza mockup={CHIVITO} size={190} />
-        )
+        // El CHIVITO de páramo cruza aleteando (SVG/CSS vivo, universal).
+        <ChivitoCruza size={190} />
       ) : COLIBRI_REAL && !reduce ? (
         // Clip de la FLOR del frailejón: el barbudito tomando néctar, grande y
         // centrado, con fade suave. H.264 sin alpha → universal (incl. iOS).

--- a/src/components/chivito/Chivito.jsx
+++ b/src/components/chivito/Chivito.jsx
@@ -14,10 +14,9 @@ import './chivito.css';
  *   - Cuerpo compacto oliva-marrón, vientre pálido, cola larga oscura con
  *     puntas claras, pico corto y recto negro.
  *
- * Dos mockups (dos niveles de detalle) para decidir en chagra-dev:
- *   - mockup="a" → simple / estilizado (vectorial limpio, plano).
- *   - mockup="b" → detallado / rico (gradientes, iridiscencia animada,
- *     plumas, sombras).
+ * DISEÑO DEFINITIVO (el operador eligió el mockup B en el A/B de chagra-dev):
+ * detallado / rico — gradientes, barba iridiscente con destello animado,
+ * plumas, moteado, sombras. El mockup A (plano) fue retirado.
  *
  * Piezas exportadas:
  *   - ChivitoAve       → sólo el ave (perfil, mirando a la derecha).
@@ -34,91 +33,19 @@ function prefersReducedMotion() {
     : false;
 }
 
-// ID único y estable para los <defs> del SVG (varios chivitos coexisten en el
-// A/B, así que cada uno necesita ids de gradiente propios). `useId` es puro
-// (no hay side-effects en render); se limpian los ':' para que sirvan como
-// fragmento en `fill="url(#...)"`.
+// ID único y estable para los <defs> del SVG (varios chivitos coexisten en la
+// página — home, botón, FAB — así que cada uno necesita ids de gradiente
+// propios). `useId` es puro (no hay side-effects en render); se limpian los
+// ':' para que sirvan como fragmento en `fill="url(#...)"`.
 function useUid(prefix) {
   return `${prefix}-${useId().replace(/:/g, '')}`;
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
- *  MOCKUP A — el chivito SIMPLE / ESTILIZADO (vectorial limpio, colores planos)
- *  Al estilo ilustrado de la escena Finca Viva. Perfil mirando a la derecha.
+ *  EL CHIVITO — detallado / rico (gradientes, iridiscencia animada, plumas,
+ *  sombras). Perfil mirando a la derecha.
  * ════════════════════════════════════════════════════════════════════════ */
-function ChivitoSVG_A() {
-  return (
-    <svg viewBox="0 0 140 132" className="chiv-svg" aria-hidden="true">
-      {/* COLA larga y oscura, barrida hacia abajo-atrás, con puntas claras */}
-      <g>
-        <path d="M50 74 L10 108 L18 110 L14 118 L26 112 L26 120 L40 104 L58 84 Z" fill="#4a3a24" />
-        {/* dos puntas blancas (rectrices externas del chivito) */}
-        <path d="M10 108 L18 110 L15 115 Z" fill="#efe7d4" />
-        <path d="M22 116 L26 112 L26 120 Z" fill="#efe7d4" />
-      </g>
-
-      {/* ALA trasera (batiendo por detrás) */}
-      <g className="chiv-ala-tras">
-        <path d="M74 56 Q48 40 30 54 Q50 70 76 62 Z" fill="#6b5230" opacity="0.85" />
-      </g>
-
-      {/* CUERPO compacto oliva-marrón */}
-      <ellipse cx="66" cy="70" rx="27" ry="20" fill="#8a7346" transform="rotate(-12 66 70)" />
-      {/* vientre pálido */}
-      <path d="M46 78 Q60 96 86 84 Q74 74 54 72 Z" fill="#d9cdaf" opacity="0.9" />
-
-      {/* CABEZA */}
-      <circle cx="98" cy="46" r="16" fill="#7a5c38" />
-      {/* capucha marrón oscuro sobre la coronilla */}
-      <path d="M86 42 Q98 26 112 42 Q104 34 98 33 Q92 34 86 42 Z" fill="#4d3820" />
-      {/* máscara negra alrededor del ojo */}
-      <path d="M92 40 Q100 36 110 44 Q104 50 94 49 Z" fill="#241a10" />
-      {/* raya de mejilla clara */}
-      <path d="M90 52 Q100 56 112 52 Q102 60 90 57 Z" fill="#efe7d4" opacity="0.92" />
-
-      {/* CRESTA erguida, puntiaguda, blanco-crema con base oscura */}
-      <g className="chiv-cresta">
-        {/* base oscura */}
-        <path d="M90 34 Q96 30 104 34 L102 40 L92 40 Z" fill="#3a2a18" />
-        {/* plumas crema puntiagudas */}
-        <path d="M92 36 Q90 22 89 12 Q95 22 96 36 Z" fill="#f2ead6" stroke="#b9a878" strokeWidth="0.6" />
-        <path d="M97 36 Q97 20 98 9 Q101 20 101 36 Z" fill="#f6efdd" stroke="#b9a878" strokeWidth="0.6" />
-        <path d="M101 36 Q104 22 108 14 Q107 24 105 37 Z" fill="#f2ead6" stroke="#b9a878" strokeWidth="0.6" />
-      </g>
-
-      {/* PICO corto y recto negro */}
-      <path d="M112 48 L130 50" fill="none" stroke="#1c130a" strokeWidth="2.6" strokeLinecap="round" />
-
-      {/* OJO */}
-      <circle cx="101" cy="45" r="2.4" fill="#100a05" />
-      <circle cx="100.2" cy="44.2" r="0.8" fill="#fff" opacity="0.9" />
-
-      {/* BARBA ICÓNICA — larga, puntiaguda, verde arriba → violeta en la punta.
-          En Mockup A: dos bloques planos que forman UNA sola barba en punta
-          (verde el tramo alto, violeta la punta), para leerla clara y grande. */}
-      <g>
-        <path d="M95 53 L105 55 L103 71 L98 71 Z" fill="#1f9e63" />
-        <path d="M98 71 L103 71 L100.5 86 Z" fill="#7c3aed" />
-        {/* filito de brillo verde-claro en el borde superior */}
-        <path d="M96 54 L104 55.6 L103.4 58 L96.4 56.5 Z" fill="#3fd68a" opacity="0.8" />
-      </g>
-
-      {/* ALA frontal (batiendo sobre el cuerpo) */}
-      <g className="chiv-ala-fron">
-        <path d="M78 52 Q50 34 28 50 Q52 68 82 60 Z" fill="#5f4a2e" />
-      </g>
-
-      {/* patas mínimas insinuadas */}
-      <path d="M66 89 L64 98 M74 88 L74 97" stroke="#2a1d12" strokeWidth="1.6" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-/* ══════════════════════════════════════════════════════════════════════════
- *  MOCKUP B — el chivito DETALLADO / RICO (gradientes, iridiscencia animada,
- *  plumas, sombras). Perfil mirando a la derecha.
- * ════════════════════════════════════════════════════════════════════════ */
-function ChivitoSVG_B({ id }) {
+function ChivitoSVG({ id }) {
   const g = (s) => `${id}-${s}`;
   return (
     <svg viewBox="0 0 140 132" className="chiv-svg" aria-hidden="true">
@@ -257,21 +184,20 @@ function ChivitoSVG_B({ id }) {
 }
 
 /**
- * ChivitoAve — sólo el ave. `mockup` = 'a' | 'b'. `flap` activa el aleteo/vida
- * (respeta reduced-motion vía CSS). `size` = ancho en px.
+ * ChivitoAve — sólo el ave. `flap` activa el aleteo/vida (respeta
+ * reduced-motion vía CSS). `size` = ancho en px.
  */
-export function ChivitoAve({ mockup = 'b', size = 120, flap = true, className = '', ariaLabel }) {
+export function ChivitoAve({ size = 120, flap = true, className = '', ariaLabel }) {
   const id = useUid('chiv');
-  const isB = mockup === 'b';
   return (
     <span
-      className={`chivito ${isB ? 'chiv-b' : 'chiv-a'} ${flap ? 'is-flap' : ''} ${className}`.trim()}
+      className={`chivito ${flap ? 'is-flap' : ''} ${className}`.trim()}
       style={{ width: size }}
       role={ariaLabel ? 'img' : undefined}
       aria-label={ariaLabel || undefined}
       aria-hidden={ariaLabel ? undefined : 'true'}
     >
-      {isB ? <ChivitoSVG_B id={id} /> : <ChivitoSVG_A />}
+      <ChivitoSVG id={id} />
     </span>
   );
 }
@@ -280,24 +206,21 @@ export function ChivitoAve({ mockup = 'b', size = 120, flap = true, className = 
  *  FRAILEJÓN — roseta plateada afelpada (Espeletia) + racimo de flores
  *  amarillas. La simbiosis real del páramo: el chivito liba esta flor.
  * ════════════════════════════════════════════════════════════════════════ */
-function FrailejonSVG({ mockup, id }) {
-  const isB = mockup === 'b';
+function FrailejonSVG({ id }) {
   const g = (s) => `${id}-${s}`;
   return (
     <svg viewBox="0 0 150 150" className="chiv-frailejon-svg" aria-hidden="true" width="100%">
-      {isB && (
-        <defs>
-          <linearGradient id={g('hoja')} x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0" stopColor="#c8d2b4" />
-            <stop offset="100%" stopColor="#8ea07a" />
-          </linearGradient>
-          <radialGradient id={g('flor')} cx="42%" cy="38%" r="62%">
-            <stop offset="0" stopColor="#ffe17a" />
-            <stop offset="70%" stopColor="#f4c430" />
-            <stop offset="100%" stopColor="#d59f18" />
-          </radialGradient>
-        </defs>
-      )}
+      <defs>
+        <linearGradient id={g('hoja')} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#c8d2b4" />
+          <stop offset="100%" stopColor="#8ea07a" />
+        </linearGradient>
+        <radialGradient id={g('flor')} cx="42%" cy="38%" r="62%">
+          <stop offset="0" stopColor="#ffe17a" />
+          <stop offset="70%" stopColor="#f4c430" />
+          <stop offset="100%" stopColor="#d59f18" />
+        </radialGradient>
+      </defs>
 
       {/* ROSETA de hojas plateadas afelpadas, radiando desde el centro-abajo */}
       <g>
@@ -308,37 +231,30 @@ function FrailejonSVG({ mockup, id }) {
           <g key={i} transform={`translate(75 128) rotate(${leaf.r}) scale(${leaf.s})`}>
             <path
               d="M0 0 Q-11 -46 0 -92 Q11 -46 0 0 Z"
-              fill={isB ? `url(#${g('hoja')})` : '#a9b790'}
-              stroke={isB ? '#7d8e68' : '#8ea077'}
+              fill={`url(#${g('hoja')})`}
+              stroke="#7d8e68"
               strokeWidth="1"
             />
-            {isB && (
-              <>
-                {/* nervadura central */}
-                <path d="M0 -4 L0 -86" stroke="#7d8e68" strokeWidth="0.8" opacity="0.6" fill="none" />
-                {/* pelusa afelpada (líneas finas) */}
-                <g stroke="#e4ecd6" strokeWidth="0.5" opacity="0.55" fill="none">
-                  <path d="M0 -20 L-5 -30" /><path d="M0 -40 L-5 -50" /><path d="M0 -60 L-5 -68" />
-                  <path d="M0 -30 L5 -40" /><path d="M0 -50 L5 -58" />
-                </g>
-              </>
-            )}
+            {/* nervadura central */}
+            <path d="M0 -4 L0 -86" stroke="#7d8e68" strokeWidth="0.8" opacity="0.6" fill="none" />
+            {/* pelusa afelpada (líneas finas) */}
+            <g stroke="#e4ecd6" strokeWidth="0.5" opacity="0.55" fill="none">
+              <path d="M0 -20 L-5 -30" /><path d="M0 -40 L-5 -50" /><path d="M0 -60 L-5 -68" />
+              <path d="M0 -30 L5 -40" /><path d="M0 -50 L5 -58" />
+            </g>
           </g>
         ))}
       </g>
 
       {/* tallo floral que se alza de la roseta */}
-      <path d="M75 60 Q78 40 88 30" fill="none" stroke={isB ? '#8a9a6f' : '#93a377'} strokeWidth="3" strokeLinecap="round" />
+      <path d="M75 60 Q78 40 88 30" fill="none" stroke="#8a9a6f" strokeWidth="3" strokeLinecap="round" />
 
       {/* RACIMO de flores amarillas del frailejón (varios capítulos) */}
       <g>
-        {(isB
-          ? [[88, 28, 11], [74, 34, 9], [100, 36, 8.5], [86, 44, 7.5], [96, 24, 7]]
-          : [[88, 28, 10], [74, 34, 8], [100, 36, 8], [88, 44, 7]]
-        ).map(([cx, cy, r], i) => (
+        {[[88, 28, 11], [74, 34, 9], [100, 36, 8.5], [86, 44, 7.5], [96, 24, 7]].map(([cx, cy, r], i) => (
           <g key={i}>
             {/* pétalos radiales (rayos del capítulo) */}
-            {isB && Array.from({ length: 12 }).map((_, k) => {
+            {Array.from({ length: 12 }).map((_, k) => {
               const a = (k / 12) * Math.PI * 2;
               return (
                 <line
@@ -349,9 +265,9 @@ function FrailejonSVG({ mockup, id }) {
                 />
               );
             })}
-            <circle cx={cx} cy={cy} r={r} fill={isB ? `url(#${g('flor')})` : '#f4c430'} />
+            <circle cx={cx} cy={cy} r={r} fill={`url(#${g('flor')})`} />
             {/* disco central */}
-            <circle cx={cx} cy={cy} r={r * 0.5} fill={isB ? '#c98f14' : '#d59f18'} opacity="0.9" />
+            <circle cx={cx} cy={cy} r={r * 0.5} fill="#c98f14" opacity="0.9" />
           </g>
         ))}
       </g>
@@ -362,10 +278,15 @@ function FrailejonSVG({ mockup, id }) {
 /**
  * ChivitoEscena — HERO del home: el chivito tomando néctar de la flor amarilla
  * del frailejón (roseta plateada + flores amarillas). La simbiosis real del
- * páramo. Animado sutil (el ave se acerca/retira de la flor, aletea), respeta
- * prefers-reduced-motion. `mockup` = 'a' | 'b'.
+ * páramo.
+ *
+ * Composición: el ave ocupa el 55% del ancho de la escena (integrada, ni
+ * gigante ni perdida) y va posicionada (CSS `.chiv-ave-wrap`) de modo que la
+ * punta del pico quede sobre el racimo de flores. El vuelo estacionario
+ * (`chiv-sip`) la acerca y retira de la flor con una pausa al libar. Respeta
+ * prefers-reduced-motion.
  */
-export function ChivitoEscena({ mockup = 'b', size = 200, ariaLabel = 'Chivito de páramo tomando néctar de la flor del frailejón' }) {
+export function ChivitoEscena({ size = 200, ariaLabel = 'Chivito de páramo tomando néctar de la flor del frailejón' }) {
   const id = useUid('chiv-esc');
   return (
     <span
@@ -375,10 +296,10 @@ export function ChivitoEscena({ mockup = 'b', size = 200, ariaLabel = 'Chivito d
       aria-label={ariaLabel}
     >
       <span className="chiv-frailejon-wrap" style={{ width: size, height: size, display: 'block' }}>
-        <FrailejonSVG mockup={mockup} id={id} />
+        <FrailejonSVG id={id} />
       </span>
       <span className="chiv-ave-wrap">
-        <ChivitoAve mockup={mockup} size={size * 0.62} flap ariaLabel={undefined} />
+        <ChivitoAve size={Math.round(size * 0.55)} flap ariaLabel={undefined} />
       </span>
     </span>
   );
@@ -387,13 +308,13 @@ export function ChivitoEscena({ mockup = 'b', size = 200, ariaLabel = 'Chivito d
 /**
  * ChivitoBoton — el chivito ES el icono del botón enviar/hablar del agente.
  * Encuadre compacto (cabeza + barba + cuerpo) centrado en el botón circular.
- * `state` 'thinking'|'speaking' inclina al ave como para libar. `mockup`='a'|'b'.
+ * `state` 'thinking'|'speaking' inclina al ave como para libar.
  */
-export function ChivitoBoton({ mockup = 'b', size = 38, state = 'idle', ariaLabel = 'Enviar al agente' }) {
+export function ChivitoBoton({ size = 38, state = 'idle', ariaLabel = 'Enviar al agente' }) {
   const active = state === 'thinking' || state === 'speaking';
   return (
     <span className={`chiv-boton ${active ? 'is-active' : ''}`} role="img" aria-label={ariaLabel}>
-      <ChivitoAve mockup={mockup} size={size} flap ariaLabel={undefined} />
+      <ChivitoAve size={size} flap ariaLabel={undefined} />
     </span>
   );
 }
@@ -401,13 +322,12 @@ export function ChivitoBoton({ mockup = 'b', size = 38, state = 'idle', ariaLabe
 /**
  * ChivitoCruza — TRANSICIÓN home→agente: el chivito cruza aleteando en arco,
  * UNA pasada. Respeta reduced-motion (sin cruce; el padre acorta la transición).
- * `mockup` = 'a' | 'b'.
  */
-export function ChivitoCruza({ mockup = 'b', size = 170, className = '' }) {
+export function ChivitoCruza({ size = 170, className = '' }) {
   const [reduce] = useState(() => prefersReducedMotion());
   return (
     <span className={`chiv-cruza ${className}`.trim()} style={{ width: size }} aria-hidden="true">
-      <ChivitoAve mockup={mockup} size={size} flap={!reduce} ariaLabel={undefined} />
+      <ChivitoAve size={size} flap={!reduce} ariaLabel={undefined} />
     </span>
   );
 }

--- a/src/components/chivito/__tests__/Chivito.smoke.test.jsx
+++ b/src/components/chivito/__tests__/Chivito.smoke.test.jsx
@@ -1,47 +1,46 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { ChivitoAve, ChivitoEscena, ChivitoBoton, ChivitoCruza } from '../Chivito';
-import { chivitoMockup } from '../../../config/chivitoFlag';
+import { chivitoActivo } from '../../../config/chivitoFlag';
 
 describe('chivitoFlag', () => {
   const orig = import.meta.env.VITE_CHIVITO;
   beforeEach(() => { import.meta.env.VITE_CHIVITO = orig; });
 
-  it('null cuando la flag está apagada o con valor no reconocido', () => {
+  it('false cuando la flag está apagada o con valor no reconocido', () => {
     import.meta.env.VITE_CHIVITO = undefined;
-    expect(chivitoMockup()).toBeNull();
+    expect(chivitoActivo()).toBe(false);
     import.meta.env.VITE_CHIVITO = 'nope';
-    expect(chivitoMockup()).toBeNull();
+    expect(chivitoActivo()).toBe(false);
+    import.meta.env.VITE_CHIVITO = 'false';
+    expect(chivitoActivo()).toBe(false);
   });
 
-  it('mapea a/b/ab y true/1 → ab', () => {
-    import.meta.env.VITE_CHIVITO = 'a';
-    expect(chivitoMockup()).toBe('a');
-    import.meta.env.VITE_CHIVITO = 'B';
-    expect(chivitoMockup()).toBe('b');
-    import.meta.env.VITE_CHIVITO = ' AB ';
-    expect(chivitoMockup()).toBe('ab');
-    import.meta.env.VITE_CHIVITO = '1';
-    expect(chivitoMockup()).toBe('ab');
+  it('true con true/1 y con los valores legados del A/B (a/b/ab)', () => {
     import.meta.env.VITE_CHIVITO = 'true';
-    expect(chivitoMockup()).toBe('ab');
+    expect(chivitoActivo()).toBe(true);
+    import.meta.env.VITE_CHIVITO = ' 1 ';
+    expect(chivitoActivo()).toBe(true);
+    import.meta.env.VITE_CHIVITO = 'a';
+    expect(chivitoActivo()).toBe(true);
+    import.meta.env.VITE_CHIVITO = 'B';
+    expect(chivitoActivo()).toBe(true);
+    import.meta.env.VITE_CHIVITO = ' AB ';
+    expect(chivitoActivo()).toBe(true);
   });
 });
 
 describe('Chivito piezas SVG', () => {
-  it('ChivitoAve dibuja SVG en ambos mockups (cero assets/red)', () => {
-    const { container: a } = render(<ChivitoAve mockup="a" size={100} />);
-    const { container: b } = render(<ChivitoAve mockup="b" size={100} />);
-    expect(a.querySelector('svg')).toBeTruthy();
-    expect(b.querySelector('svg')).toBeTruthy();
+  it('ChivitoAve dibuja SVG (cero assets/red)', () => {
+    const { container } = render(<ChivitoAve size={100} />);
+    expect(container.querySelector('svg')).toBeTruthy();
     // sin <img> ni <video> — es puro vectorial, offline-first.
-    expect(a.querySelector('img,video')).toBeNull();
-    expect(b.querySelector('img,video')).toBeNull();
+    expect(container.querySelector('img,video')).toBeNull();
   });
 
-  it('ChivitoAve B tiene la barba iridiscente (verde→violeta) y el brillo animado', () => {
-    const { container } = render(<ChivitoAve mockup="b" size={120} />);
-    expect(container.querySelector('.chiv-b')).toBeTruthy();
+  it('ChivitoAve tiene la barba iridiscente (verde→violeta) y el brillo animado', () => {
+    const { container } = render(<ChivitoAve size={120} />);
+    expect(container.querySelector('.chivito')).toBeTruthy();
     expect(container.querySelector('.chiv-barba-brillo')).toBeTruthy();
     // gradiente de la barba declarado en <defs>
     const grads = [...container.querySelectorAll('linearGradient')].map((g) => g.id);
@@ -49,24 +48,31 @@ describe('Chivito piezas SVG', () => {
   });
 
   it('ChivitoEscena expone el ave y la flor del frailejón con aria-label', () => {
-    const { container } = render(<ChivitoEscena mockup="b" size={180} />);
+    const { container } = render(<ChivitoEscena size={180} />);
     expect(container.querySelector('.chiv-escena')).toBeTruthy();
     expect(container.querySelector('.chiv-frailejon-svg')).toBeTruthy();
     expect(container.querySelector('.chiv-ave-wrap')).toBeTruthy();
     expect(container.querySelector('[aria-label*="frailejón"]')).toBeTruthy();
   });
 
+  it('ChivitoEscena integra el ave al 55% del ancho de la escena', () => {
+    const { container } = render(<ChivitoEscena size={200} />);
+    const ave = container.querySelector('.chiv-ave-wrap .chivito');
+    expect(ave).toBeTruthy();
+    expect(ave.style.width).toBe('110px'); // 200 * 0.55
+  });
+
   it('ChivitoBoton marca is-active en thinking/speaking y expone aria-label', () => {
-    const { container, rerender } = render(<ChivitoBoton mockup="a" state="idle" ariaLabel="Enviar al agente" />);
+    const { container, rerender } = render(<ChivitoBoton state="idle" ariaLabel="Enviar al agente" />);
     expect(container.querySelector('.chiv-boton.is-active')).toBeNull();
     expect(container.querySelector('[aria-label="Enviar al agente"]')).toBeTruthy();
-    rerender(<ChivitoBoton mockup="a" state="thinking" ariaLabel="Enviar al agente" />);
+    rerender(<ChivitoBoton state="thinking" ariaLabel="Enviar al agente" />);
     expect(container.querySelector('.chiv-boton.is-active')).toBeTruthy();
   });
 
   it('ChivitoCruza sin animación cuando prefers-reduced-motion', () => {
     const spy = vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: true });
-    const { container } = render(<ChivitoCruza mockup="b" />);
+    const { container } = render(<ChivitoCruza />);
     // el ave no lleva la clase de aleteo cuando se reduce el movimiento
     expect(container.querySelector('.chivito.is-flap')).toBeNull();
     spy.mockRestore();

--- a/src/components/chivito/chivito.css
+++ b/src/components/chivito/chivito.css
@@ -1,13 +1,17 @@
 /*
  * chivito.css — el CHIVITO DE PÁRAMO vivo (Oxypogon guerinii, "barbudito
  * paramuno") dibujado 100% en SVG/CSS. Cero assets, cero red, offline-first,
- * gama baja. Reemplaza al colibrí del A/B en las tres piezas del ave insignia
- * (home, botón del agente, transición).
+ * gama baja. Diseño DEFINITIVO (el operador eligió el mockup detallado en el
+ * A/B): gradientes, barba iridiscente verde→violeta con destello animado,
+ * plumas, sombras.
  *
- * Dos mockups, dos niveles de detalle:
- *   - Mockup A (`.chiv-a`) → simple / estilizado, colores planos.
- *   - Mockup B (`.chiv-b`) → detallado / rico, gradientes, barba iridiscente
- *     verde→violeta con brillo animado, plumas, sombras.
+ * MOVIMIENTO — criterio: vivo pero ELEGANTE, nunca mecánico ni distractor.
+ *   - Aleteo rápido (colibrí de altura) pero de amplitud contenida.
+ *   - Vuelo estacionario con deriva vertical suave (hover).
+ *   - En la escena del home, el ave se acerca a la flor, PAUSA al libar y se
+ *     retira — un ciclo largo y asimétrico para que no se lea como loop.
+ *   - El destello de la barba es un brillo OCASIONAL (una pasada por ciclo
+ *     largo), no un parpadeo constante.
  *
  * Todo el movimiento se apaga con prefers-reduced-motion (gama baja + a11y).
  * Español colombiano (usted), NUNCA voseo.
@@ -20,37 +24,48 @@
 }
 .chivito svg { display: block; overflow: visible; }
 
-/* aleteo de las alas — rápido, en contrafase, como un colibrí de altura */
+/* vuelo estacionario: deriva vertical mínima de todo el cuerpo (hover de
+   colibrí). Va en el <svg> interno para no pelear con los transforms que los
+   padres (escena, botón, cruce) aplican al contenedor. */
+.chivito.is-flap svg { animation: chiv-hover 2.8s ease-in-out infinite; }
+@keyframes chiv-hover {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-2px); }
+}
+
+/* aleteo de las alas — rápido, en contrafase, como un colibrí de altura.
+   Amplitud contenida (±12–15°) para que se sienta zumbido, no sacudida. */
 .chivito .chiv-ala-fron { transform-box: fill-box; transform-origin: 78% 30%; }
 .chivito .chiv-ala-tras { transform-box: fill-box; transform-origin: 82% 26%; }
-.chivito.is-flap .chiv-ala-fron { animation: chiv-flap 0.16s ease-in-out infinite; }
-.chivito.is-flap .chiv-ala-tras { animation: chiv-flap-back 0.16s ease-in-out infinite; }
+.chivito.is-flap .chiv-ala-fron { animation: chiv-flap 0.2s ease-in-out infinite; }
+.chivito.is-flap .chiv-ala-tras { animation: chiv-flap-back 0.2s ease-in-out infinite; }
 @keyframes chiv-flap {
-  0%, 100% { transform: rotate(-16deg) scaleY(0.94); }
-  50%      { transform: rotate(20deg) scaleY(1); }
+  0%, 100% { transform: rotate(-12deg) scaleY(0.96); }
+  50%      { transform: rotate(15deg) scaleY(1); }
 }
 @keyframes chiv-flap-back {
-  0%, 100% { transform: rotate(14deg); }
-  50%      { transform: rotate(-18deg); }
+  0%, 100% { transform: rotate(11deg); }
+  50%      { transform: rotate(-14deg); }
 }
 
-/* cresta puntiaguda — leve tremor de las plumas, muy sutil */
+/* cresta puntiaguda — tremor apenas perceptible, lento */
 .chivito .chiv-cresta { transform-box: fill-box; transform-origin: 50% 100%; }
-.chivito.is-flap .chiv-cresta { animation: chiv-cresta 2.4s ease-in-out infinite; }
+.chivito.is-flap .chiv-cresta { animation: chiv-cresta 3.4s ease-in-out infinite; }
 @keyframes chiv-cresta {
   0%, 100% { transform: rotate(0deg); }
-  50%      { transform: rotate(-3deg); }
+  50%      { transform: rotate(-2.5deg); }
 }
 
-/* barba iridiscente (Mockup B) — franja de brillo que baja por la barba
-   pasando de verde a violeta, dando el destello metálico del gorget real */
+/* barba iridiscente — destello metálico OCASIONAL: una franja de brillo baja
+   por la barba una vez por ciclo (verde→violeta) y el resto del tiempo
+   descansa. Elegante, no intermitente. */
 .chivito .chiv-barba-brillo { opacity: 0; }
-.chivito.is-flap.chiv-b .chiv-barba-brillo { animation: chiv-barba-brillo 2.8s ease-in-out infinite; }
+.chivito.is-flap .chiv-barba-brillo { animation: chiv-barba-brillo 5.2s ease-in-out infinite; }
 @keyframes chiv-barba-brillo {
-  0%, 100% { opacity: 0; transform: translateY(-3px); }
-  45%      { opacity: 0.85; }
-  55%      { opacity: 0.85; }
-  100%     { opacity: 0; transform: translateY(4px); }
+  0%, 52%   { opacity: 0; transform: translateY(-3px); }
+  62%       { opacity: 0.8; }
+  70%       { opacity: 0.8; }
+  78%, 100% { opacity: 0; transform: translateY(4px); }
 }
 
 /* ── ESCENA DEL HOME — el chivito libando la flor del frailejón ───────────── */
@@ -59,20 +74,25 @@
   display: inline-block;
   line-height: 0;
 }
+/* El ave ocupa el 55% del ancho de la escena, ubicada para que la punta del
+   pico quede sobre el racimo de flores amarillas (ver ChivitoEscena). */
 .chiv-escena .chiv-ave-wrap {
   position: absolute;
-  left: 2%;
-  top: 4%;
-  width: 62%;
+  left: 8%;
+  top: 1%;
+  width: 55%;
   z-index: 3;
-  /* vuelo estacionario: el ave se acerca y retira de la flor (sip) */
-  animation: chiv-sip 5.6s ease-in-out infinite;
+  /* vuelo estacionario: se acerca a la flor, PAUSA al libar, se retira.
+     Ciclo largo (7s) y asimétrico para que no se lea como péndulo. */
+  animation: chiv-sip 7s ease-in-out infinite;
 }
 @keyframes chiv-sip {
-  0%   { transform: translate(0, 0) rotate(-1deg); }
-  35%  { transform: translate(10px, -5px) rotate(1.5deg); }
-  60%  { transform: translate(6px, -2px) rotate(0.5deg); }
-  100% { transform: translate(0, 0) rotate(-1deg); }
+  0%   { transform: translate(0, 0) rotate(-0.6deg); }
+  30%  { transform: translate(8px, -4px) rotate(0.8deg); }
+  46%  { transform: translate(9px, -5px) rotate(0.4deg); }
+  58%  { transform: translate(8px, -4px) rotate(0.4deg); }
+  78%  { transform: translate(2px, -1px) rotate(-0.3deg); }
+  100% { transform: translate(0, 0) rotate(-0.6deg); }
 }
 /* el frailejón (roseta plateada + flores amarillas) al fondo-derecha */
 .chiv-escena .chiv-frailejon-wrap {
@@ -89,10 +109,10 @@
 }
 .chiv-boton .chivito { filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35)); }
 /* estado "thinking/speaking" del botón: el ave se inclina como para libar */
-.chiv-boton.is-active .chivito { animation: chiv-boton-lean 0.9s ease-in-out infinite; }
+.chiv-boton.is-active .chivito { animation: chiv-boton-lean 1.1s ease-in-out infinite; }
 @keyframes chiv-boton-lean {
   0%, 100% { transform: translateX(0) rotate(0deg); }
-  50%      { transform: translateX(1.5px) rotate(3deg); }
+  50%      { transform: translateX(1.5px) rotate(2.5deg); }
 }
 
 /* ── TRANSICIÓN — el chivito cruza aleteando ─────────────────────────────── */
@@ -109,31 +129,18 @@
   100% { transform: translate3d(34vw, 3vh, 0) scale(0.78) rotate(-3deg); opacity: 0; }
 }
 
-/* ── A/B del chivito en el home (flag VITE_CHIVITO=ab) ────────────────────── */
-.chiv-ab {
+/* ── el chivito montado en el hero del home (FincaVivaHero) ───────────────── */
+/* anula la animación flotante heredada de .fvh-bicho: la escena trae su propio
+   vuelo estacionario (chiv-sip) y necesita conservar su transform inline de
+   centrado. */
+.chiv-hero {
   animation: none !important;
   z-index: 8;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-}
-.chiv-ab-tag {
-  font: 600 9px/1 var(--fvh-body, system-ui, sans-serif);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: #fff;
-  background: rgba(20, 30, 18, 0.6);
-  border: 1px solid rgba(190, 242, 100, 0.4);
-  border-radius: 999px;
-  padding: 2px 7px;
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
-  white-space: nowrap;
 }
 
 /* ── prefers-reduced-motion: nada se mueve (gama baja + a11y) ─────────────── */
 @media (prefers-reduced-motion: reduce) {
+  .chivito svg,
   .chivito .chiv-ala-fron,
   .chivito .chiv-ala-tras,
   .chivito .chiv-cresta,

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -18,7 +18,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { iconForTheme } from './themeIcon';
 import { colibriRealActivo } from '../../config/colibriFlag';
 import { BarbuditoIlustrado, BarbuditoRealLoop } from '../colibri/Barbudito';
-import { chivitoMockup } from '../../config/chivitoFlag';
+import { chivitoActivo } from '../../config/chivitoFlag';
 import { ChivitoEscena, ChivitoBoton } from '../chivito/Chivito';
 import './finca-viva-hero.css';
 
@@ -35,9 +35,9 @@ const COLIBRI_REAL = colibriRealActivo();
 
 // ¿Modo CHIVITO DE PÁRAMO? Gateado por VITE_CHIVITO (chivitoFlag.js), dev-only.
 // Reemplaza al colibrí del A/B por el chivito vivo (Oxypogon) libando la flor
-// del frailejón, dibujado 100% SVG/CSS. 'ab' = A y B lado a lado; 'a'/'b' = un
-// solo mockup. Tiene precedencia sobre VITE_COLIBRI (es su reemplazo).
-const CHIVITO = chivitoMockup();
+// del frailejón, dibujado 100% SVG/CSS (diseño definitivo, ya elegido). Tiene
+// precedencia sobre VITE_COLIBRI (es su reemplazo).
+const CHIVITO = chivitoActivo();
 
 /**
  * FincaVivaHero — el HOME INMERSIVO "Finca Viva" (refinado del mockup F2 v2
@@ -394,24 +394,10 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
                         SVG 2D `ColibriVuela` de siempre. */}
                     {CHIVITO ? (
                       // CHIVITO DE PÁRAMO libando la flor del frailejón (SVG/CSS
-                      // vivo). 'ab' = los dos mockups lado a lado con etiqueta,
-                      // para que el operador elija; 'a'/'b' = uno solo, centrado.
-                      CHIVITO === 'ab' ? (
-                        <>
-                          <span className="fvh-bicho chiv-ab" style={{ left: '2%', top: '6%' }}>
-                            <ChivitoEscena mockup="a" size={150} />
-                            <span className="chiv-ab-tag">mockup A · simple</span>
-                          </span>
-                          <span className="fvh-bicho chiv-ab" style={{ right: '2%', top: '6%' }}>
-                            <ChivitoEscena mockup="b" size={150} />
-                            <span className="chiv-ab-tag">mockup B · detalle</span>
-                          </span>
-                        </>
-                      ) : (
-                        <span className="fvh-bicho chiv-ab" style={{ left: '50%', top: '6%', transform: 'translateX(-50%)' }}>
-                          <ChivitoEscena mockup={CHIVITO} size={172} />
-                        </span>
-                      )
+                      // vivo, diseño definitivo), centrado sobre la escena.
+                      <span className="fvh-bicho chiv-hero" style={{ left: '50%', top: '6%', transform: 'translateX(-50%)' }}>
+                        <ChivitoEscena size={172} />
+                      </span>
                     ) : COLIBRI_REAL ? (
                       <>
                         <span className="fvh-bicho fvh-colibri-ab fvh-colibri-ab-izq" style={{ left: '4%', top: '12%' }}>
@@ -455,9 +441,8 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
               >
                 <span className="av" aria-hidden="true">
                   {CHIVITO ? (
-                    // El chivito ES el icono del acceso al agente (Mockup A si es
-                    // A/B, para leer limpio a tamaño chico; si no, el elegido).
-                    <ChivitoBoton mockup={CHIVITO === 'ab' ? 'a' : CHIVITO} size={34} ariaLabel="Pregúntele a Chagra" />
+                    // El chivito ES el icono del acceso al agente.
+                    <ChivitoBoton size={34} ariaLabel="Pregúntele a Chagra" />
                   ) : (
                     <ColibriAvatar />
                   )}

--- a/src/config/chivitoFlag.js
+++ b/src/config/chivitoFlag.js
@@ -11,24 +11,18 @@
  *      (`ChivitoBoton`, en el compositor del home, en AgentScreen y en el FAB).
  *   3. TRANSICIÓN home→agente → el chivito cruza aleteando (`ChivitoCruza`).
  *
- * DOS MOCKUPS (dos niveles de detalle) para decidir en chagra-dev:
- *   - Mockup A → simple / estilizado: vectorial limpio, colores planos, al
- *     estilo ilustrado de la escena Finca Viva.
- *   - Mockup B → detallado / rico: gradientes, barba iridiscente verde→violeta
- *     con brillo animado, plumas, texturas del frailejón, sombras.
+ * El A/B de mockups ya se decidió (el operador eligió el detallado, hoy EL
+ * chivito), así que la flag quedó como simple ON/OFF.
  *
- * CÓMO ACTIVARLO (dev): en el `.env` (o `.env.local`) del frontend:
+ * CÓMO ACTIVARLO: en el `.env` (o `.env.local`) del frontend:
  *
- *     VITE_CHIVITO=ab     → A/B lado a lado en el home (A izq, B der, con
- *                           etiquetas). Botón del home = A; botones del agente
- *                           y FAB = B; transición = A y B cruzando en paralelo.
- *     VITE_CHIVITO=a      → mockup A coherente en las 3 piezas.
- *     VITE_CHIVITO=b      → mockup B coherente en las 3 piezas.
+ *     VITE_CHIVITO=true    → chivito ON en las 3 piezas.
  *
- * También acepta 'true' / '1' (= 'ab'). Con la flag APAGADA (default, prod)
- * cada sitio conserva su presentación actual (colibrí SVG / avatar / video),
- * igual que con VITE_COLIBRI apagada. Si ambas flags están prendidas, el
- * chivito tiene precedencia (es el reemplazo del A/B del colibrí).
+ * También acepta '1' y, por compatibilidad con configs previas del A/B,
+ * 'a' / 'b' / 'ab' (todas = ON). Con la flag APAGADA (default, prod) cada
+ * sitio conserva su presentación actual (colibrí SVG / avatar / video). Si
+ * ambas flags están prendidas, el chivito tiene precedencia sobre
+ * VITE_COLIBRI.
  *
  * Mismo criterio de parseo que `colibriRealActivo()` (colibriFlag.js) para
  * mantener la convención del repo. Español colombiano (usted), NUNCA voseo.
@@ -39,21 +33,19 @@
 const FLAG_KEY = 'VITE_CHIVITO';
 
 /**
- * ¿Qué mockup del chivito está activo?
+ * ¿Está activo el chivito de páramo?
  *
- * @returns {'a'|'b'|'ab'|null} 'a' | 'b' | 'ab' según la flag; null (default)
- *   si está apagada, con valor no reconocido o si import.meta.env falla.
+ * @returns {boolean} true si la flag está prendida; false (default) si está
+ *   apagada, con valor no reconocido o si import.meta.env falla.
  */
-export function chivitoMockup() {
+export function chivitoActivo() {
   try {
     const raw = import.meta.env?.[FLAG_KEY];
-    if (raw === true) return 'ab';
-    if (typeof raw !== 'string') return null;
+    if (raw === true) return true;
+    if (typeof raw !== 'string') return false;
     const v = raw.trim().toLowerCase();
-    if (v === 'a' || v === 'b' || v === 'ab') return v;
-    if (v === 'true' || v === '1') return 'ab';
-    return null;
+    return v === 'true' || v === '1' || v === 'a' || v === 'b' || v === 'ab';
   } catch (_) {
-    return null;
+    return false;
   }
 }


### PR DESCRIPTION
## Resumen

El operador eligió el **mockup B** (detallado: gradientes, barba iridiscente verde→violeta, plumas, moteado) en el A/B de chagra-dev. Este PR lo deja como **EL chivito definitivo** y retira el andamiaje de comparación, además de integrarlo más limpio en **tamaño** y **movimiento** dentro de la escena del home.

### B definitivo (sin A/B)
- `Chivito.jsx`: se elimina el mockup A (SVG plano) y la prop `mockup` de las 4 piezas (`ChivitoAve`, `ChivitoEscena`, `ChivitoBoton`, `ChivitoCruza`). El frailejón queda siempre en su versión rica.
- `chivitoFlag.js`: `chivitoMockup()` (`'a'|'b'|'ab'`) → `chivitoActivo()` (boolean ON/OFF). Acepta los valores legados `a`/`b`/`ab` por compatibilidad con configs previas.
- Consumidores (`FincaVivaHero`, `ColibriTransition`, `AgentFab`, `AgentScreen`): sin ramas A/B, sin etiquetas de mockup, sin `ChivitoCruza` doble en la transición.
- CSS: retirados `.chiv-ab` / `.chiv-ab-tag` / `.chiv-a` / `.chiv-b`; nuevo `.chiv-hero` (anula la animación heredada de `.fvh-bicho` y conserva el centrado).
- `dev-deploy.yml`: `VITE_CHIVITO: "ab"` → `"true"`.

### Tamaño (integración en la escena)
- El ave pasa de **62% → 55%** del ancho de la escena y se reposiciona (`left 8%, top 1%`) para que **la punta del pico quede sobre el racimo de flores amarillas** del frailejón — antes quedaba por debajo, apuntando al tallo. Ni gigante ni perdida, coherente con la composición del home.

### Movimiento (vivo pero elegante)
- **Aleteo**: 0.16s ±16–20° → **0.2s ±12–15°** — zumbido de colibrí, no sacudida.
- **Hover nuevo**: deriva vertical suave de todo el cuerpo (2px, 2.8s) — vuelo estacionario creíble en las 4 piezas.
- **Libar (`chiv-sip`)**: 5.6s → **7s con pausa al libar** y retorno asimétrico, para que no se lea como péndulo mecánico.
- **Destello de la barba**: de parpadeo constante (cada 2.8s) a **brillo ocasional** — una pasada por ciclo de 5.2s; también se corrigió el keyframe 100% duplicado.
- **Cresta**: tremor más lento y sutil (2.4s → 3.4s, ±2.5°).
- `prefers-reduced-motion`: todo apagado, incluido el hover nuevo.

## Plan de pruebas
- [x] `npx vitest run src/components/chivito` → 8/8 en verde (incluye test nuevo de proporción 55%).
- [x] `npm run build` → "built in 1m 8s".
- [ ] Revisión visual en chagra-dev (deploy con `VITE_CHIVITO=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)