### PR TITLE
feat(onboarding): camino ilustrado del primer cultivo en el home F2

### DIFF
--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -29,6 +29,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
+import CaminoPrimerCultivo from '../onboarding/CaminoPrimerCultivo';
 import {
     getProfile,
     getModuleVisibility,
@@ -691,6 +692,21 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                BAJADO. Solo activo con la flag ON; el legacy (else) queda intacto.
                ════════════════════════════════════════════════════════════════ */
             <>
+                {/* ── BLOQUE 0 · "El camino de su primer cultivo" ─────────────
+                    Onboarding ilustrado del productor NUEVO (0 siembras): qué
+                    es Chagra + sendero de 3 pasos (ubicar finca → primera
+                    siembra → conocer al asistente) sobre los flujos que YA
+                    existen. Omitible y persistido en el dispositivo. Es lo
+                    PRIMERO de la hoja: para quien empieza, orienta más que la
+                    telemetría del día. Con siembras registradas desaparece. */}
+                {plantsCount === 0 && (
+                    <CaminoPrimerCultivo
+                        onNavigate={onNavigate}
+                        plantsCount={plantsCount}
+                        rutaSiembra={registroUnifFlag ? 'registro_unificado' : 'sembrar'}
+                    />
+                )}
+
                 {/* ── BLOQUE 1 · "Cómo va su finca hoy" ───────────────────────
                     FUNDE lo que antes eran cuatro superficies solapadas (audit
                     §3.7/§3.8): el día (HoyEnFincaStrip — UNA sola vez; el tile

--- a/src/components/onboarding/CaminoPrimerCultivo.jsx
+++ b/src/components/onboarding/CaminoPrimerCultivo.jsx
@@ -1,0 +1,288 @@
+import React, { useState } from 'react';
+import { Check, ChevronRight } from 'lucide-react';
+import { getProfile } from '../../services/userProfileService';
+import { getPisoTermicoInfo } from '../../services/locationService';
+import { MSG } from '../../config/messages.js';
+import './camino-primer-cultivo.css';
+
+/**
+ * CaminoPrimerCultivo — onboarding ilustrado "el camino del primer cultivo".
+ *
+ * Es la BIENVENIDA del productor nuevo (0 siembras) en el home F2 "Finca
+ * Viva": qué es Chagra en dos líneas y un sendero de TRES pasos ilustrados
+ * que conecta con los flujos que YA existen (no crea lógica nueva):
+ *
+ *   1. Ubicar su finca      → ruta 'ubicacion-detectada' (piso térmico,
+ *                             el filtro maestro de todos los módulos).
+ *   2. Primera siembra      → ruta 'sembrar' (o 'registro_unificado' con la
+ *                             flag #23) — el mismo flujo del EmptyState de
+ *                             "Mis Plantas" ("Registrar mi primera siembra").
+ *   3. Conocer al asistente → ruta 'agente'.
+ *
+ * Señales de avance (solo LECTURA de estado existente):
+ *   - Paso 1: perfil con altitud finita + piso_confirmado === '1'
+ *             (mismo criterio que OnboardingHero).
+ *   - Paso 2: plantsCount > 0 (lo pasa el caller desde useAssetStore).
+ *   - Paso 3: marca local al tocar el paso (localStorage, offline-first).
+ *
+ * El SENDERO es el progreso: cada tramo de camino de tierra (punteado) se
+ * pinta de verde sólido al completar el paso anterior. Nada es un muro:
+ * los 3 pasos son tocables siempre, y "Omitir por ahora" lo oculta
+ * (persistido en el dispositivo, sin red).
+ *
+ * Visual: piel clara "finca viva" (crema/tinta verde, Baloo 2/Nunito) y
+ * viñetas vectoriales dibujadas a mano en el lenguaje de los place-svg de
+ * los 4 portales (FincaVivaHero). Sin <text> con emoji dentro del SVG
+ * (Android/iOS viejos los renderizan monocromos o vacíos).
+ *
+ * Accesibilidad: <section> etiquetada, pasos en <ol>, estado "listo" en el
+ * aria-label de cada botón, decoración aria-hidden, animaciones bajo
+ * prefers-reduced-motion. Tono usted colombiano, sin voseo, sin jerga.
+ */
+
+const STORAGE_KEY = 'chagra:camino-primer-cultivo:v1';
+
+/** Lee las marcas locales del camino (omitido / asistente conocido). */
+function readCaminoPrefs() {
+  const base = { omitido: false, agenteVisto: false };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return base;
+    const parsed = JSON.parse(raw);
+    return { ...base, ...(parsed && typeof parsed === 'object' ? parsed : {}) };
+  } catch (_) {
+    return base;
+  }
+}
+
+/** Persiste las marcas locales (sincrónico, offline-first, fail-silent). */
+function writeCaminoPrefs(prefs) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch (_) { /* sin storage no persistimos, pero la sesión sigue */ }
+}
+
+/* ── Viñetas vectoriales (lenguaje place-svg de FincaVivaHero) ─────────── */
+
+/** Loma con sol y el pin de ubicación clavado en la tierra. */
+function VinetaUbicar() {
+  return (
+    <svg className="cpc-svg" viewBox="0 0 80 64" aria-hidden="true">
+      <circle cx="62" cy="14" r="9" fill="#ffe08a" opacity=".6" />
+      <circle cx="62" cy="14" r="5" fill="#ffedb3" opacity=".9" />
+      <path d="M-2 46 Q22 26 44 40 T82 38 V66 H-2 Z" fill="#356b42" opacity=".5" />
+      <path d="M-2 52 Q28 38 54 48 T82 46 V66 H-2 Z" fill="#3f8f4e" />
+      {/* pin de ubicación clavado en la loma */}
+      <g className="cpc-anim-pin">
+        <path d="M36 18 q-9 0 -9 9 q0 7 9 15 q9 -8 9 -15 q0 -9 -9 -9 Z" fill="#c2562f" />
+        <circle cx="36" cy="27" r="3.6" fill="#fdf8ea" />
+      </g>
+      <ellipse cx="36" cy="45" rx="7" ry="2" fill="#26331f" opacity=".18" />
+    </svg>
+  );
+}
+
+/** Parcela isométrica con surcos y una mata recién brotada. */
+function VinetaSiembra() {
+  return (
+    <svg className="cpc-svg" viewBox="0 0 80 64" aria-hidden="true">
+      <circle cx="16" cy="12" r="7" fill="#ffe08a" opacity=".55" />
+      <polygon points="40,18 72,36 40,54 8,36" fill="#3f7a4e" />
+      <polygon points="40,18 72,36 40,37 8,36" fill="#4f9460" opacity=".7" />
+      <g stroke="#2f6b3a" strokeWidth="2.2" strokeLinecap="round" fill="none" opacity=".7">
+        <path d="M22 38 L40 48" /><path d="M30 32 L50 43" /><path d="M38 26 L58 37" />
+      </g>
+      {/* brote: tallo + dos hojas tiernas + semilla asomada */}
+      <g className="cpc-anim-brote">
+        <path d="M40 40 v-11" stroke="#2f6b3a" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        <path d="M40 32 q-7 -2 -8 -8 q7 0 8 8 Z" fill="#7fc06f" />
+        <path d="M40 30 q7 -3 9 -9 q-8 0 -9 9 Z" fill="#a7e17a" />
+      </g>
+      <ellipse cx="40" cy="41" rx="5.5" ry="1.8" fill="#26331f" opacity=".18" />
+    </svg>
+  );
+}
+
+/** El claro del asistente: pajarito de páramo con bocadillo de conversa. */
+function VinetaAgente() {
+  return (
+    <svg className="cpc-svg" viewBox="0 0 80 64" aria-hidden="true">
+      <path d="M-2 50 Q30 38 56 46 T82 44 V66 H-2 Z" fill="#356b42" opacity=".45" />
+      {/* bocadillo de conversación */}
+      <g>
+        <rect x="38" y="8" width="34" height="20" rx="9" fill="#fdf8ea" stroke="#caa066" strokeWidth="1.4" />
+        <path d="M46 27 l-4 7 l10 -6 Z" fill="#fdf8ea" />
+        <circle cx="49" cy="18" r="2.2" fill="#3f8f4e" />
+        <circle cx="56" cy="18" r="2.2" fill="#3f8f4e" opacity=".7" />
+        <circle cx="63" cy="18" r="2.2" fill="#3f8f4e" opacity=".45" />
+      </g>
+      {/* pajarito (cuerpo, ala, cabeza, pico hacia el bocadillo) */}
+      <g className="cpc-anim-ave">
+        <ellipse cx="24" cy="38" rx="11" ry="8" fill="#4f9460" />
+        <path d="M20 36 q-9 -1 -12 -8 q10 -2 14 5 Z" fill="#7fc06f" />
+        <circle cx="33" cy="32" r="5.5" fill="#4f9460" />
+        <circle cx="35" cy="31" r="1.3" fill="#26331f" />
+        <path d="M38 32 l7 -2" stroke="#c2562f" strokeWidth="2" strokeLinecap="round" />
+        <path d="M15 44 q-4 3 -8 3 q2 -5 8 -6 Z" fill="#356b42" />
+      </g>
+      <ellipse cx="25" cy="49" rx="9" ry="2" fill="#26331f" opacity=".18" />
+    </svg>
+  );
+}
+
+/**
+ * @param {object}   props
+ * @param {Function} props.onNavigate  - router del shell (misma firma que el resto del home).
+ * @param {number}  [props.plantsCount] - siembras registradas (paso 2 listo si > 0).
+ * @param {string}  [props.rutaSiembra] - destino del paso 2 ('sembrar' o
+ *   'registro_unificado' cuando la flag #23 está activa — lo decide el caller).
+ */
+export default function CaminoPrimerCultivo({
+  onNavigate,
+  plantsCount = 0,
+  rutaSiembra = 'sembrar',
+}) {
+  const [prefs, setPrefs] = useState(readCaminoPrefs);
+
+  // Piso térmico: mismo criterio de "listo" que OnboardingHero (lectura pura).
+  const [piso] = useState(() => {
+    try {
+      const p = getProfile();
+      const alt = Number(p.finca_altitud);
+      const tieneAltitud = p.finca_altitud !== '' && p.finca_altitud != null && Number.isFinite(alt);
+      const info = tieneAltitud ? getPisoTermicoInfo(alt) : null;
+      return { done: !!info && p.piso_confirmado === '1', info, altitud: alt };
+    } catch (_) {
+      return { done: false, info: null, altitud: NaN };
+    }
+  });
+
+  const marcarAgente = () => {
+    const next = { ...prefs, agenteVisto: true };
+    setPrefs(next);
+    writeCaminoPrefs(next);
+    onNavigate?.('agente');
+  };
+
+  const omitir = () => {
+    const next = { ...prefs, omitido: true };
+    setPrefs(next);
+    writeCaminoPrefs(next);
+  };
+
+  const pasos = [
+    {
+      id: 'ubicar',
+      done: piso.done,
+      titulo: 'Ubique su finca',
+      desc: 'Con la altura de su tierra, los consejos le salen acertados para su clima.',
+      hecho: piso.info
+        ? `Clima ${piso.info.label.toLowerCase()}, a unos ${Math.round(piso.altitud)} m de altura.`
+        : 'Su finca ya está ubicada.',
+      Vineta: VinetaUbicar,
+      accion: () => onNavigate?.('ubicacion-detectada'),
+    },
+    {
+      id: 'sembrar',
+      done: plantsCount > 0,
+      titulo: 'Registre su primera siembra',
+      desc: 'Una sola mata basta para estrenar su cuaderno: por foto, por voz o escribiendo.',
+      hecho: 'Su cuaderno ya tiene su primera mata.',
+      Vineta: VinetaSiembra,
+      accion: () => onNavigate?.(rutaSiembra),
+    },
+    {
+      id: 'agente',
+      done: prefs.agenteVisto,
+      titulo: 'Conozca a su asistente',
+      desc: 'Pregúntele lo que sea de su finca: le responde con voz y le muestra sus fuentes.',
+      hecho: 'Ya se conocieron. Pregúntele cuando quiera.',
+      Vineta: VinetaAgente,
+      accion: marcarAgente,
+    },
+  ];
+
+  const hechos = pasos.filter((p) => p.done).length;
+
+  // Omitido o camino completo: no ocupar el home (el productor ya arrancó).
+  if (prefs.omitido || hechos === pasos.length) return null;
+
+  const actualIdx = pasos.findIndex((p) => !p.done);
+
+  return (
+    <section
+      className="cpc px-4 pt-3 fvh-resto-block"
+      aria-label="El camino de su primer cultivo"
+      data-testid="camino-primer-cultivo"
+    >
+      <div className="cpc-card">
+        <header className="cpc-head">
+          <div className="cpc-head-txt">
+            <p className="cpc-eyebrow">El camino de su primer cultivo</p>
+            <h2 className="cpc-tit">{MSG.onboarding.bienvenido}</h2>
+            <p className="cpc-sub">
+              Este es el cuaderno de campo vivo de su finca: usted registra lo
+              que siembra y Chagra le acompaña con el calendario, los consejos
+              y la historia de cada mata.
+            </p>
+          </div>
+          {/* Letrero de madera con el paso en curso (como el de la parcela). */}
+          <span className="cpc-letrero" data-testid="cpc-paso-actual">
+            Paso {actualIdx + 1} de {pasos.length}
+          </span>
+        </header>
+
+        <ol className="cpc-sendero">
+          {pasos.map((paso, i) => {
+            const actual = i === actualIdx;
+            return (
+              <li
+                key={paso.id}
+                className={`cpc-paso${paso.done ? ' cpc-paso-hecho' : ''}${actual ? ' cpc-paso-actual' : ''}`}
+              >
+                <button
+                  type="button"
+                  onClick={paso.accion}
+                  className="cpc-paso-btn"
+                  aria-label={`Paso ${i + 1}: ${paso.titulo}${paso.done ? ' (listo)' : ''}`}
+                  data-testid={`cpc-paso-${paso.id}`}
+                >
+                  <span className="cpc-vineta" aria-hidden="true">
+                    <paso.Vineta />
+                    {paso.done && (
+                      <span className="cpc-vineta-check">
+                        <Check size={13} strokeWidth={3.2} />
+                      </span>
+                    )}
+                  </span>
+                  <span className="cpc-paso-txt">
+                    <span className="cpc-paso-tit">{paso.titulo}</span>
+                    <span className="cpc-paso-desc">
+                      {paso.done ? paso.hecho : paso.desc}
+                    </span>
+                  </span>
+                  <ChevronRight size={18} className="cpc-paso-flecha" aria-hidden="true" />
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+
+        <footer className="cpc-pie">
+          <p className="cpc-pie-nota">
+            Vaya a su ritmo: su avance queda guardado en este dispositivo, con
+            o sin señal.
+          </p>
+          <button
+            type="button"
+            onClick={omitir}
+            className="cpc-omitir"
+            data-testid="cpc-omitir"
+          >
+            Omitir por ahora
+          </button>
+        </footer>
+      </div>
+    </section>
+  );
+}

--- a/src/components/onboarding/__tests__/CaminoPrimerCultivo.test.jsx
+++ b/src/components/onboarding/__tests__/CaminoPrimerCultivo.test.jsx
@@ -1,0 +1,114 @@
+/**
+ * CaminoPrimerCultivo.test.jsx — onboarding ilustrado "el camino del primer
+ * cultivo" (home F2, productor con 0 siembras).
+ *
+ * Contrato visual: bienvenida en usted, 3 pasos tocables (nunca un muro),
+ * el paso en curso visible ("Paso X de 3"), pasos hechos marcados, CTA de
+ * cada paso conectado al router del caller (sin lógica de datos propia),
+ * "Omitir por ahora" persistido en el dispositivo (offline-first).
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Lecturas puras de estado existente (perfil + piso térmico): mockeadas para
+// controlar el avance sin tocar localStorage del perfil real.
+vi.mock('../../../services/userProfileService', () => ({
+  getProfile: vi.fn(() => ({ finca_altitud: '', piso_confirmado: '' })),
+}));
+vi.mock('../../../services/locationService', () => ({
+  getPisoTermicoInfo: vi.fn(() => ({ slug: 'frío', label: 'Frío', emoji: '⛅' })),
+}));
+
+import CaminoPrimerCultivo from '../CaminoPrimerCultivo';
+import { getProfile } from '../../../services/userProfileService';
+
+const STORAGE_KEY = 'chagra:camino-primer-cultivo:v1';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.mocked(getProfile).mockReturnValue({ finca_altitud: '', piso_confirmado: '' });
+});
+
+describe('CaminoPrimerCultivo', () => {
+  test('productor nuevo: bienvenida, Paso 1 de 3 y los 3 pasos tocables', () => {
+    const onNavigate = vi.fn();
+    render(<CaminoPrimerCultivo onNavigate={onNavigate} plantsCount={0} />);
+
+    expect(screen.getByText('Bienvenido a Chagra')).toBeInTheDocument();
+    expect(screen.getByTestId('cpc-paso-actual')).toHaveTextContent('Paso 1 de 3');
+
+    // Los 3 pasos existen y son botones (ningún paso es un muro).
+    expect(screen.getByTestId('cpc-paso-ubicar')).toBeEnabled();
+    expect(screen.getByTestId('cpc-paso-sembrar')).toBeEnabled();
+    expect(screen.getByTestId('cpc-paso-agente')).toBeEnabled();
+
+    // Paso 1 navega al detector de ubicación (flujo existente).
+    fireEvent.click(screen.getByTestId('cpc-paso-ubicar'));
+    expect(onNavigate).toHaveBeenCalledWith('ubicacion-detectada');
+  });
+
+  test('con el piso confirmado: paso 1 listo, en curso Paso 2, y siembra usa rutaSiembra', () => {
+    vi.mocked(getProfile).mockReturnValue({ finca_altitud: '2600', piso_confirmado: '1' });
+    const onNavigate = vi.fn();
+    render(
+      <CaminoPrimerCultivo onNavigate={onNavigate} plantsCount={0} rutaSiembra="registro_unificado" />
+    );
+
+    expect(screen.getByTestId('cpc-paso-actual')).toHaveTextContent('Paso 2 de 3');
+    // El paso hecho lo dice en su nombre accesible y muestra el resumen del piso.
+    expect(
+      screen.getByRole('button', { name: /Paso 1: Ubique su finca \(listo\)/ })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Clima frío, a unos 2600 m/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('cpc-paso-sembrar'));
+    expect(onNavigate).toHaveBeenCalledWith('registro_unificado');
+  });
+
+  test('conocer al asistente navega a agente y queda marcado (persistido)', () => {
+    const onNavigate = vi.fn();
+    render(<CaminoPrimerCultivo onNavigate={onNavigate} plantsCount={0} />);
+
+    fireEvent.click(screen.getByTestId('cpc-paso-agente'));
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)).agenteVisto).toBe(true);
+    // Al volver al home, el paso 3 aparece como listo.
+    expect(
+      screen.getByRole('button', { name: /Paso 3: Conozca a su asistente \(listo\)/ })
+    ).toBeInTheDocument();
+  });
+
+  test('"Omitir por ahora" lo oculta y persiste entre montajes', () => {
+    const { unmount } = render(<CaminoPrimerCultivo onNavigate={vi.fn()} plantsCount={0} />);
+    fireEvent.click(screen.getByTestId('cpc-omitir'));
+    expect(screen.queryByTestId('camino-primer-cultivo')).not.toBeInTheDocument();
+
+    unmount();
+    render(<CaminoPrimerCultivo onNavigate={vi.fn()} plantsCount={0} />);
+    expect(screen.queryByTestId('camino-primer-cultivo')).not.toBeInTheDocument();
+  });
+
+  test('camino completo (3 de 3): no ocupa el home', () => {
+    vi.mocked(getProfile).mockReturnValue({ finca_altitud: '2600', piso_confirmado: '1' });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ omitido: false, agenteVisto: true }));
+    render(<CaminoPrimerCultivo onNavigate={vi.fn()} plantsCount={3} />);
+    expect(screen.queryByTestId('camino-primer-cultivo')).not.toBeInTheDocument();
+  });
+
+  test('storage corrupto no rompe: arranca el camino desde cero', () => {
+    localStorage.setItem(STORAGE_KEY, '{no-es-json');
+    render(<CaminoPrimerCultivo onNavigate={vi.fn()} plantsCount={0} />);
+    expect(screen.getByTestId('camino-primer-cultivo')).toBeInTheDocument();
+    expect(screen.getByTestId('cpc-paso-actual')).toHaveTextContent('Paso 1 de 3');
+  });
+
+  test('accesibilidad: sección etiquetada y pasos en lista ordenada', () => {
+    render(<CaminoPrimerCultivo onNavigate={vi.fn()} plantsCount={0} />);
+    expect(
+      screen.getByRole('region', { name: 'El camino de su primer cultivo' })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+});

--- a/src/components/onboarding/camino-primer-cultivo.css
+++ b/src/components/onboarding/camino-primer-cultivo.css
@@ -1,0 +1,303 @@
+/* ============================================================================
+   camino-primer-cultivo.css — onboarding ilustrado "el camino del primer
+   cultivo" (CaminoPrimerCultivo.jsx), dentro de la hoja clara del home F2.
+
+   El SENDERO es el progreso: los tres pasos son "claros" redondos sobre un
+   camino de tierra punteado que se pinta de VERDE sólido tramo a tramo al
+   completarlos. Piel "finca viva": crema/tinta verde (tokens --fvh-* de
+   finca-viva-resto.css con fallback), Baloo 2 para el título y Nunito para
+   el cuerpo (self-host, declaradas en finca-viva-hero.css).
+
+   Scope: TODO vive bajo `.cpc` (solo se monta en el home F2 con 0 siembras).
+   Animaciones gateadas por prefers-reduced-motion. ES-CO (usted), sin voseo.
+   ========================================================================== */
+
+.cpc {
+  --cpc-tinta: var(--fvh-tinta, #26331f);
+  --cpc-tinta-suave: var(--fvh-tinta-suave, #4e5c42);
+  --cpc-verde: var(--fvh-verde-1, #3f8f4e);
+  --cpc-crema: #fffdf5;
+  --cpc-tierra: #a97b46;
+  --cpc-madera: #caa066;
+  --cpc-sol: #ffe08a;
+
+  font-family: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  color: var(--cpc-tinta);
+}
+
+/* Tarjeta: un pliego claro sobre la hoja crema, sin corte duro. */
+.cpc-card {
+  background: linear-gradient(180deg, var(--cpc-crema) 0%, #fbf4e3 100%);
+  border: 1.5px solid rgba(63, 143, 78, 0.28);
+  border-radius: 20px;
+  padding: 16px 16px 12px;
+  box-shadow: 0 6px 18px rgba(38, 51, 31, 0.08);
+}
+
+/* ── Encabezado: bienvenida + letrero de madera del paso en curso ────────── */
+.cpc-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+.cpc-head-txt { flex: 1; min-width: 0; }
+
+.cpc-eyebrow {
+  margin: 0 0 2px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cpc-verde);
+}
+
+.cpc-tit {
+  margin: 0;
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-weight: 800;
+  font-size: 21px;
+  line-height: 1.15;
+  color: var(--cpc-tinta);
+}
+
+.cpc-sub {
+  margin: 5px 0 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--cpc-tinta-suave);
+  max-width: 34rem;
+}
+
+/* Letrero de madera (como el de la parcela del portal "Mi finca"). */
+.cpc-letrero {
+  flex-shrink: 0;
+  align-self: flex-start;
+  padding: 5px 10px 6px;
+  border-radius: 7px;
+  background: linear-gradient(180deg, var(--cpc-madera) 0%, #b8874f 100%);
+  border-bottom: 3px solid #8a6038;
+  color: #3d2a17;
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-weight: 800;
+  font-size: 12px;
+  white-space: nowrap;
+  box-shadow: 0 2px 4px rgba(38, 51, 31, 0.18);
+}
+
+/* ── El sendero: lista vertical con camino de tierra entre viñetas ───────── */
+.cpc-sendero {
+  list-style: none;
+  margin: 14px 0 0;
+  padding: 0;
+}
+
+.cpc-paso { position: relative; }
+
+/* Tramo de camino bajo cada viñeta (huellas punteadas de tierra). El tramo
+   de un paso HECHO se vuelve verde sólido: el sendero ES la barra de
+   progreso. El último paso no dibuja tramo. */
+.cpc-paso:not(:last-child)::before {
+  content: '';
+  position: absolute;
+  left: 31px; /* centro de la viñeta (64px de ancho / 2 - 1.5px) */
+  top: 60px;
+  bottom: -14px;
+  width: 3px;
+  border-radius: 999px;
+  background-image: repeating-linear-gradient(
+    180deg,
+    rgba(169, 123, 70, 0.55) 0 5px,
+    transparent 5px 11px
+  );
+}
+.cpc-paso-hecho:not(:last-child)::before {
+  background-image: none;
+  background-color: var(--cpc-verde);
+}
+
+/* ── Cada paso: botón de fila (viñeta + texto + flecha) ──────────────────── */
+.cpc-paso-btn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 6px;
+  margin: 0 0 8px;
+  border: 0;
+  border-radius: 16px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background-color 0.15s ease, transform 0.12s ease;
+}
+.cpc-paso-btn:active {
+  background: rgba(63, 143, 78, 0.10);
+  transform: translateY(1px);
+}
+.cpc-paso-btn:focus-visible {
+  outline: 3px solid var(--cpc-verde);
+  outline-offset: 2px;
+}
+
+/* Viñeta: el "claro" redondo del sendero, con la ilustración adentro. */
+.cpc-vineta {
+  position: relative;
+  flex-shrink: 0;
+  width: 62px;
+  height: 62px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #dff0fa 0%, #eef7e8 60%, #dcedd2 100%);
+  border: 2px solid rgba(63, 143, 78, 0.35);
+  box-shadow: inset 0 -4px 8px rgba(38, 51, 31, 0.08);
+}
+.cpc-svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* Paso hecho: aro verde pleno + chulo cosechado. */
+.cpc-paso-hecho .cpc-vineta {
+  border-color: var(--cpc-verde);
+}
+.cpc-vineta-check {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  width: 19px;
+  height: 19px;
+  border-radius: 999px;
+  background: var(--cpc-verde);
+  color: #fdf8ea;
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--cpc-crema);
+}
+
+/* Paso actual: el claro amanece (halo de sol suave, sin gritar). */
+.cpc-paso-actual .cpc-vineta {
+  border-color: var(--cpc-verde);
+  box-shadow:
+    0 0 0 4px rgba(255, 224, 138, 0.55),
+    inset 0 -4px 8px rgba(38, 51, 31, 0.08);
+}
+
+/* Texto del paso. */
+.cpc-paso-txt {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.cpc-paso-tit {
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-weight: 800;
+  font-size: 15px;
+  line-height: 1.2;
+  color: var(--cpc-tinta);
+}
+.cpc-paso-desc {
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--cpc-tinta-suave);
+}
+.cpc-paso-hecho .cpc-paso-tit {
+  color: var(--cpc-verde);
+}
+.cpc-paso-hecho .cpc-paso-desc {
+  color: var(--cpc-tinta-suave);
+  opacity: 0.85;
+}
+
+.cpc-paso-flecha {
+  flex-shrink: 0;
+  color: rgba(78, 92, 66, 0.6);
+}
+.cpc-paso-actual .cpc-paso-flecha {
+  color: var(--cpc-verde);
+}
+
+/* ── Pie: nota offline-first + omitir (opcional, nunca un muro) ──────────── */
+.cpc-pie {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px dashed rgba(169, 123, 70, 0.35);
+}
+.cpc-pie-nota {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--cpc-tinta-suave);
+  opacity: 0.9;
+}
+.cpc-omitir {
+  flex-shrink: 0;
+  border: 0;
+  background: transparent;
+  padding: 8px 10px;
+  min-height: 40px;
+  border-radius: 10px;
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 800;
+  color: var(--cpc-verde);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1.5px;
+}
+.cpc-omitir:active { background: rgba(63, 143, 78, 0.10); }
+.cpc-omitir:focus-visible {
+  outline: 3px solid var(--cpc-verde);
+  outline-offset: 2px;
+}
+
+/* ── Movimiento (solo si el usuario no pidió calma) ──────────────────────── */
+@media (prefers-reduced-motion: no-preference) {
+  /* El halo del paso actual respira despacio, como el amanecer. */
+  .cpc-paso-actual .cpc-vineta {
+    animation: cpc-amanecer 3.2s ease-in-out infinite;
+  }
+  /* El pin se asienta, el brote se mece, el ave aletea apenas. */
+  .cpc-paso-actual .cpc-anim-pin {
+    animation: cpc-asentar 3.2s ease-in-out infinite;
+    transform-origin: 36px 42px;
+  }
+  .cpc-paso-actual .cpc-anim-brote {
+    animation: cpc-mecer 3.6s ease-in-out infinite;
+    transform-origin: 40px 40px;
+  }
+  .cpc-paso-actual .cpc-anim-ave {
+    animation: cpc-aletear 2.8s ease-in-out infinite;
+  }
+}
+
+@keyframes cpc-amanecer {
+  0%, 100% { box-shadow: 0 0 0 4px rgba(255, 224, 138, 0.55), inset 0 -4px 8px rgba(38, 51, 31, 0.08); }
+  50% { box-shadow: 0 0 0 7px rgba(255, 224, 138, 0.30), inset 0 -4px 8px rgba(38, 51, 31, 0.08); }
+}
+@keyframes cpc-asentar {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-2.5px); }
+}
+@keyframes cpc-mecer {
+  0%, 100% { transform: rotate(-2.5deg); }
+  50% { transform: rotate(2.5deg); }
+}
+@keyframes cpc-aletear {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-2px); }
+}
+
+/* ── Desktop: la tarjeta no se estira infinita dentro de la hoja ─────────── */
+@media (min-width: 720px) {
+  .cpc-card { padding: 20px 22px 14px; }
+  .cpc-tit { font-size: 24px; }
+}


### PR DESCRIPTION
## Qué hace

Onboarding ilustrado **"el camino del primer cultivo"** para el productor nuevo (0 siembras) en el home F2 "Finca Viva". Conecta con el EmptyState de Mis Plantas recién mergeado (#1986): el CTA "Registrar mi primera siembra" es el mismo flujo al que apunta el paso 2 del camino.

- **Bienvenida clara y cálida**: qué es Chagra (el cuaderno de campo vivo de su finca + el asistente) en dos líneas, tono usted colombiano, sin jerga.
- **Sendero de 3 pasos ilustrados** sobre flujos que YA existen (cero lógica de datos/auth nueva):
  1. Ubicar su finca → `ubicacion-detectada` (piso térmico; mismo criterio de "listo" que OnboardingHero)
  2. Registrar la primera siembra → `sembrar` (o `registro_unificado` con la flag #23)
  3. Conocer al asistente → `agente` (marca local al tocar)
- **El sendero ES el progreso**: los tramos de camino de tierra punteado se pintan de verde sólido al completar cada paso; letrero de madera "Paso X de 3" (como el letrero de la parcela del portal Mi finca).
- **Corto y opcional, nunca un muro**: los 3 pasos son tocables siempre; "Omitir por ahora" lo oculta (persistido en el dispositivo, offline-first); con la primera siembra hecha o el camino completo, desaparece solo.
- **Coherente con el sistema visual del home**: viñetas vectoriales a mano en el lenguaje place-svg de los 4 portales (loma+pin · parcela+brote · ave de páramo+bocadillo), piel crema/tinta verde con tokens `--fvh-*`, Baloo 2/Nunito. Sin `<text>` con emoji dentro de los SVG (Android/iOS viejos los pintan monocromos).
- **Accesible**: sección etiquetada, pasos en `<ol>`, estado "(listo)" en el aria-label, animaciones (halo que respira, brote que se mece, ave que aletea) solo bajo `prefers-reduced-motion: no-preference`.

## Dónde se monta

`DashboardLive` → rama F2 (flag `VITE_FINCA_VIVA_HOME_PERFIL` ON, la de dev-deploy), como **BLOQUE 0** de la hoja clara, solo con `plantsCount === 0`. El layout legacy (flag OFF, prod) queda intacto con su OnboardingHero.

## Verificación

- `npm run build` ✅ ("built in 2m 18s")
- `npx vitest run src/components/onboarding/__tests__/CaminoPrimerCultivo.test.jsx` ✅ 7/7
- Suites existentes de DashboardLive (homeGating / asociaciones / glaciarBanner) ✅ 8/8
- ESLint limpio en archivos tocados (incl. regla i18n ADR-050: título vía `MSG.onboarding.bienvenido`)

## Archivos

- `src/components/onboarding/CaminoPrimerCultivo.jsx` (nuevo)
- `src/components/onboarding/camino-primer-cultivo.css` (nuevo)
- `src/components/onboarding/__tests__/CaminoPrimerCultivo.test.jsx` (nuevo, 7 tests)
- `src/components/dashboard/DashboardLive.jsx` (mount BLOQUE 0 en rama F2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)