### PR TITLE
feat(tokens): capa global de tokens no-color + unificacion conservadora

### DIFF
--- a/src/components/common/screen-shell-f2.css
+++ b/src/components/common/screen-shell-f2.css
@@ -96,7 +96,7 @@ html[data-luz="noche"][data-theme="minimalista"] .screen-shell-f2 {
   width: 38px;
   height: 38px;
   flex: 0 0 auto;
-  border-radius: 12px;
+  border-radius: var(--r-sm, 12px);
   display: grid;
   place-items: center;
   padding: 6px;
@@ -106,17 +106,17 @@ html[data-luz="noche"][data-theme="minimalista"] .screen-shell-f2 {
 
 /* Pastillas de chrome (back/home): redondas, del tema (no slate fijo). */
 .screen-shell-f2-pill {
-  min-height: 44px;
-  min-width: 44px;
+  min-height: var(--tap-min, 44px);
+  min-width: var(--tap-min, 44px);
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: var(--r-pill, 999px);
   border: 1px solid var(--ssf2-topbar-border);
   background: var(--ssf2-pill-bg);
   color: var(--ssf2-pill-tinta);
   cursor: pointer;
-  transition: background 0.18s ease, color 0.18s ease, transform 0.1s ease;
+  transition: background var(--dur-estado, 0.18s) ease, color var(--dur-estado, 0.18s) ease, transform 0.1s ease;
 }
 .screen-shell-f2-pill:hover { background: var(--ssf2-pill-bg-hover); }
 .screen-shell-f2-pill:active { transform: scale(0.94); }
@@ -124,7 +124,7 @@ html[data-luz="noche"][data-theme="minimalista"] .screen-shell-f2 {
 
 /* Título: tinta del tema + ícono en el acento del tema. */
 .screen-shell-f2-title {
-  font-size: 1.18rem;
+  font-size: var(--fs-titulo, 1.18rem);
   font-weight: 800;
   line-height: 1.1;
   display: flex;
@@ -144,12 +144,12 @@ html[data-luz="noche"][data-theme="minimalista"] .screen-shell-f2 {
 
 /* Botón de ayuda: ámbar del tema (la indirección lo lleva al ámbar correcto). */
 .screen-shell-f2-help {
-  min-height: 44px;
-  min-width: 44px;
+  min-height: var(--tap-min, 44px);
+  min-width: var(--tap-min, 44px);
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 12px;
+  border-radius: var(--r-sm, 12px);
   border: 1px solid rgb(var(--c-amber-500, 245 158 11) / 0.42);
   background: rgb(var(--c-amber-500, 245 158 11) / 0.18);
   color: rgb(var(--c-amber-300, 252 211 77));

--- a/src/components/dashboard/finca-viva-resto.css
+++ b/src/components/dashboard/finca-viva-resto.css
@@ -47,7 +47,7 @@
 .fvh-resto-grip {
   width: 44px;
   height: 5px;
-  border-radius: 999px;
+  border-radius: var(--r-pill, 999px);
   background: rgba(63, 143, 78, 0.30);
   margin: 8px auto 14px;
 }
@@ -67,7 +67,7 @@
   content: '';
   width: 6px;
   height: 18px;
-  border-radius: 999px;
+  border-radius: var(--r-pill, 999px);
   background: linear-gradient(180deg, #4ade80, #2f6b3a);
 }
 .fvh-resto-sub {

--- a/src/components/registro/registro-shell.css
+++ b/src/components/registro/registro-shell.css
@@ -102,7 +102,7 @@
   letter-spacing: 0.01em;
 }
 .registro-field__hint {
-  font-size: 0.78rem;
+  font-size: var(--fs-nota, 0.78rem);
   color: rgb(var(--c-slate-500));
   font-weight: 500;
 }
@@ -113,8 +113,8 @@
   width: 100%;
   min-height: 60px;
   padding: 0.9rem 1rem;
-  font-size: 1.15rem;
-  border-radius: 1rem;
+  font-size: var(--fs-cuerpo-lg, 1.15rem);
+  border-radius: var(--r-md, 1rem);
   background: rgb(var(--c-surface-card));
   border: 1.5px solid rgb(var(--c-surface-border));
   color: rgb(var(--c-slate-100));
@@ -190,12 +190,12 @@
 
 /* Tarjeta de "consejo / contexto" — microcopy campesino con identidad. */
 .registro-tip {
-  border-radius: 1rem;
+  border-radius: var(--r-md, 1rem);
   padding: 0.85rem 1rem;
   background: rgb(var(--t-accent-rgb) / 0.10);
   border: 1px solid rgb(var(--t-accent-rgb) / 0.28);
   color: rgb(var(--c-slate-200));
-  font-size: 0.9rem;
+  font-size: var(--fs-cuerpo-sm, 0.9rem);
   line-height: 1.45;
   display: flex;
   gap: 0.6rem;
@@ -213,13 +213,13 @@
   align-items: center;
   gap: 0.4rem;
   padding: 0.55rem 0.9rem;
-  border-radius: 999px;
+  border-radius: var(--r-pill, 999px);
   font-size: 0.92rem;
   font-weight: 700;
   background: rgb(var(--c-surface-raised));
   border: 1.5px solid rgb(var(--c-surface-border));
   color: rgb(var(--c-slate-300));
-  transition: all 0.12s ease;
+  transition: all var(--dur-tap, 0.12s) ease;
 }
 .registro-chip--active {
   background: rgb(var(--t-accent-rgb) / 0.16);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import './config/env'; // Validación de env vars al startup
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import './styles/tokens.css' // tokens globales de diseño (radios/sombras/tipo/movimiento) — primero
 import './index.css'
 import './styles/themes.css'
 import './styles/temas-fase2.css'

--- a/src/styles/__tests__/tokens.test.js
+++ b/src/styles/__tests__/tokens.test.js
@@ -1,0 +1,90 @@
+/**
+ * Tokens globales de diseño (styles/tokens.css) — contrato de la capa NO-COLOR.
+ *
+ * Verifica que:
+ *   (a) tokens.css define en :root las escalas de radio, elevación, tipografía,
+ *       espaciado, movimiento y tacto (nombres estables: los consumidores usan
+ *       var(--token, fallback)).
+ *   (b) main.jsx importa tokens.css ANTES de index.css (capa base).
+ *   (c) los consumidores unificados apuntan a los tokens con fallback
+ *       byte-idéntico al valor previo (riesgo visual cero):
+ *       juego-pulido (--jp-sombra-* → --sombra-*), screen-shell-f2 y
+ *       registro-shell (radios/duración/tacto).
+ *   (d) la escalera de elevación global conserva la receta theme-aware
+ *       (--scrim-bg) que ya estaba validada en el juego.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (...p) => readFileSync(join(__dirname, ...p), 'utf8');
+
+const tokensCss = read('..', 'tokens.css');
+const mainJsx = read('..', '..', 'main.jsx');
+const juegoCss = read('..', 'juego-pulido.css');
+const shellCss = read('..', '..', 'components', 'common', 'screen-shell-f2.css');
+const registroCss = read('..', '..', 'components', 'registro', 'registro-shell.css');
+
+describe('tokens.css — capa global no-color', () => {
+  it('define la escala de radios', () => {
+    for (const [name, value] of [
+      ['--r-xs', '8px'],
+      ['--r-sm', '12px'],
+      ['--r-md', '16px'],
+      ['--r-lg', '20px'],
+      ['--r-xl', '24px'],
+      ['--r-pill', '999px'],
+    ]) {
+      expect(tokensCss).toMatch(new RegExp(`${name}:\\s*${value};`));
+    }
+  });
+
+  it('define la escalera de elevación theme-aware (sale de --scrim-bg)', () => {
+    expect(tokensCss).toMatch(/--sombra-1:.*var\(--scrim-bg/);
+    expect(tokensCss).toMatch(/--sombra-2:.*var\(--scrim-bg/);
+    expect(tokensCss).toMatch(/--sombra-3:.*var\(--scrim-bg/);
+  });
+
+  it('define tipografía, movimiento y tacto', () => {
+    expect(tokensCss).toMatch(/--fs-nota:\s*0\.78rem;/);
+    expect(tokensCss).toMatch(/--fs-cuerpo-lg:\s*1\.15rem;/);
+    expect(tokensCss).toMatch(/--fs-titulo:\s*1\.18rem;/);
+    expect(tokensCss).toMatch(/--dur-tap:\s*0\.12s;/);
+    expect(tokensCss).toMatch(/--dur-estado:\s*0\.18s;/);
+    expect(tokensCss).toMatch(/--tap-min:\s*44px;/);
+  });
+
+  it('main.jsx la importa antes de index.css', () => {
+    const iTokens = mainJsx.indexOf("./styles/tokens.css");
+    const iIndex = mainJsx.indexOf("./index.css");
+    expect(iTokens).toBeGreaterThan(-1);
+    expect(iIndex).toBeGreaterThan(-1);
+    expect(iTokens).toBeLessThan(iIndex);
+  });
+});
+
+describe('consumidores unificados (con fallback idéntico al valor previo)', () => {
+  it('juego-pulido bebe de la escalera global de sombras', () => {
+    expect(juegoCss).toMatch(/--jp-sombra-1:\s*var\(--sombra-1,/);
+    expect(juegoCss).toMatch(/--jp-sombra-2:\s*var\(--sombra-2,/);
+    expect(juegoCss).toMatch(/--jp-sombra-3:\s*var\(--sombra-3,/);
+  });
+
+  it('screen-shell-f2 usa radios, tacto y duración por token', () => {
+    expect(shellCss).toMatch(/var\(--r-pill, 999px\)/);
+    expect(shellCss).toMatch(/var\(--r-sm, 12px\)/);
+    expect(shellCss).toMatch(/var\(--tap-min, 44px\)/);
+    expect(shellCss).toMatch(/var\(--dur-estado, 0\.18s\)/);
+    expect(shellCss).toMatch(/var\(--fs-titulo, 1\.18rem\)/);
+  });
+
+  it('registro-shell usa radios, tipografía y duración por token', () => {
+    expect(registroCss).toMatch(/var\(--r-md, 1rem\)/);
+    expect(registroCss).toMatch(/var\(--r-pill, 999px\)/);
+    expect(registroCss).toMatch(/var\(--fs-cuerpo-lg, 1\.15rem\)/);
+    expect(registroCss).toMatch(/var\(--fs-nota, 0\.78rem\)/);
+    expect(registroCss).toMatch(/var\(--dur-tap, 0\.12s\)/);
+  });
+});

--- a/src/styles/juego-pulido.css
+++ b/src/styles/juego-pulido.css
@@ -45,10 +45,12 @@
   --jp-vida-texto: rgb(var(--c-emerald-300, 110 231 183));
   --jp-vida-suave: rgb(var(--c-emerald-500, 16 185 129) / 0.14);
   --jp-velo: rgb(var(--scrim-bg, 8 30 22));
-  /* Sombras consistentes (escalera de elevación) para todo el juego. */
-  --jp-sombra-1: 0 1px 2px rgb(var(--scrim-bg, 8 30 22) / 0.18);
-  --jp-sombra-2: 0 6px 18px rgb(var(--scrim-bg, 8 30 22) / 0.22);
-  --jp-sombra-3: 0 16px 44px rgb(var(--scrim-bg, 8 30 22) / 0.30);
+  /* Sombras consistentes (escalera de elevación) para todo el juego.
+     Unificadas con la escalera GLOBAL (styles/tokens.css §ELEVACIÓN); el
+     fallback conserva la receta original byte-idéntica. */
+  --jp-sombra-1: var(--sombra-1, 0 1px 2px rgb(var(--scrim-bg, 8 30 22) / 0.18));
+  --jp-sombra-2: var(--sombra-2, 0 6px 18px rgb(var(--scrim-bg, 8 30 22) / 0.22));
+  --jp-sombra-3: var(--sombra-3, 0 16px 44px rgb(var(--scrim-bg, 8 30 22) / 0.30));
 }
 
 /* ── DETALLE DE IDENTIDAD: ambiente radial de "la mano de Chagra" + sol ───────

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -109,7 +109,7 @@
   gap: 12px;
   width: 100%;
   padding: 16px;
-  border-radius: 16px;
+  border-radius: var(--r-md, 16px);
   background:
     linear-gradient(135deg, rgba(var(--t-accent-rgb), 0.14), rgb(var(--c-surface-card) / 0.96) 42%),
     rgb(var(--c-surface-card));

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -8,7 +8,7 @@
  * fallback byte-idéntico al valor que había antes → riesgo visual cero.
  *
  * ── MAPA DEL SISTEMA DE DISEÑO (auditoría 2026-07-02) ──────────────────────
- * El COLOR ya está unificado y NO vive acá (no duplicar):
+ * El COLOR ya está unificado y NO vive aquí (no duplicar):
  *
  *   --c-*             index.css      Rampas slate/emerald/amber + superficies
  *                                    (surface/card/raised/border) + acentos

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,82 @@
+/* src/styles/tokens.css
+ * ============================================================================
+ * TOKENS GLOBALES DE DISEÑO (capa NO-COLOR) — fuente única de verdad para
+ * radios, sombras/elevación, tipografía, espaciado, movimiento y tacto.
+ *
+ * Se importa PRIMERO en main.jsx. Solo define variables nuevas en :root, no
+ * pisa nada: cada uso aguas abajo lleva `var(--token, <valor actual>)` con el
+ * fallback byte-idéntico al valor que había antes → riesgo visual cero.
+ *
+ * ── MAPA DEL SISTEMA DE DISEÑO (auditoría 2026-07-02) ──────────────────────
+ * El COLOR ya está unificado y NO vive acá (no duplicar):
+ *
+ *   --c-*             index.css      Rampas slate/emerald/amber + superficies
+ *                                    (surface/card/raised/border) + acentos
+ *                                    (muzo/morpho/orchid/frog). RGB triple por
+ *                                    TEMA (:root = biopunk; [data-theme=
+ *                                    "minimalista"|"nature"|"verde-vivo"]).
+ *                                    Tailwind los mapea con <alpha-value>.
+ *   --t-accent-*      themes.css     Acento de marca por tema (base/strong/
+ *                                    deep) + --t-bg-rgb.
+ *   --fx-* / --scrim- index.css      Efectos gateados por tema (partículas,
+ *                                    glow, patrón) y velo de fondo por tema.
+ *
+ * Capas-puente POR FEATURE (prefijo propio, beben de --c-*; se quedan):
+ *   --fvh-*   finca-viva-hero.css    Escena del home F2 (cielo/sol/tinta).
+ *   --ssf2-*  screen-shell-f2.css    Shell de pantallas secundarias F2.
+ *   --jp-*    juego-pulido.css       Pulido de los tableros del juego.
+ *   --cpc-*   camino-primer-cultivo.css  Onboarding (fallbacks a --fvh-*).
+ *
+ * EXCEPCIONES DELIBERADAS (no tokenizar):
+ *   --cv-*    cicloVivo.css          Piel "cuaderno de campo" en papel crema:
+ *                                    identidad propia INTENCIONAL, no un tema.
+ *   chivito.css                      Coreografía de animación del barbudito;
+ *                                    sus tiempos/amplitudes son ajuste fino.
+ * ============================================================================ */
+
+:root {
+  /* ── RADIOS — escala única. Uso: border-radius: var(--r-md, 16px). ────────
+     Referencia adoptada de lo ya mergeado: pastillas/chips = pill; botones y
+     campos = md; tarjetas grandes del hero = --fvh-r (24px) ≈ xl. */
+  --r-xs: 8px;    /* detalles pequeños, badges cuadrados */
+  --r-sm: 12px;   /* botones de chrome, iconos de marca */
+  --r-md: 16px;   /* inputs, cards estándar, tips (= 1rem) */
+  --r-lg: 20px;   /* cards destacadas */
+  --r-xl: 24px;   /* tarjetas del hero (= --fvh-r) */
+  --r-pill: 999px; /* chips, pastillas, CTAs redondos */
+
+  /* ── ELEVACIÓN — escalera de sombras THEME-AWARE. La sombra sale del velo
+     del tema (--scrim-bg): navy en biopunk, crema/papel sutil en claros.
+     Receta = la escalera ya validada del juego (--jp-sombra-*), promovida a
+     global para que cards/calendario/directorio compartan la misma luz. ──── */
+  --sombra-1: 0 1px 2px rgb(var(--scrim-bg, 8 30 22) / 0.18);   /* reposo */
+  --sombra-2: 0 6px 18px rgb(var(--scrim-bg, 8 30 22) / 0.22);  /* raised */
+  --sombra-3: 0 16px 44px rgb(var(--scrim-bg, 8 30 22) / 0.30); /* modal/float */
+
+  /* ── TIPOGRAFÍA — escala corta en rem (base Inter, index.css). Los tamaños
+     px finos de escenas dibujadas (hero, cuaderno) NO entran en la escala. ── */
+  --fs-nota: 0.78rem;      /* hints, metadatos, microcopy secundario */
+  --fs-cuerpo-sm: 0.9rem;  /* texto de apoyo, tips */
+  --fs-cuerpo: 1rem;       /* cuerpo por defecto */
+  --fs-cuerpo-lg: 1.15rem; /* inputs táctiles de campo (legibles al sol) */
+  --fs-titulo: 1.18rem;    /* títulos de pantalla (topbar) */
+  --fs-display: 1.6rem;    /* saludos/display del home */
+
+  /* ── ESPACIADO — escala base 4px para CSS propio (el JSX usa Tailwind). ── */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 20px;
+  --sp-6: 24px;
+  --sp-8: 32px;
+
+  /* ── MOVIMIENTO — duraciones/curvas de interacción de UI (NO de escenas
+     animadas). Todo movimiento respeta prefers-reduced-motion (index.css). ── */
+  --dur-tap: 0.12s;    /* press/active de chips y botones */
+  --dur-estado: 0.18s; /* hover / cambio de estado */
+  --ease-suave: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ── TACTO — mínimo táctil WCAG/campo (dedos con tierra, sol directo). ─── */
+  --tap-min: 44px;
+}


### PR DESCRIPTION
Auditoría del sistema de diseño: el COLOR ya estaba unificado (--c-* por
tema en index.css, --t-accent-* en themes.css, --fx-*/--scrim-*, y capas
puente por feature --fvh-/--ssf2-/--jp-/--cpc-). Lo que faltaba era la capa
global NO-COLOR: radios, sombras/elevación, tipografía, espaciado,
movimiento y tacto estaban hardcodeados e inconsistentes entre features.

- styles/tokens.css (nuevo): fuente única para --r-* (radios), --sombra-1/2/3
  (elevación theme-aware vía --scrim-bg, receta promovida de --jp-sombra-*),
  --fs-* (escala tipográfica corta), --sp-* (espaciado base 4px), --dur-*/
  --ease-suave (movimiento) y --tap-min (44px táctil). Incluye el mapa
  documentado de TODAS las capas de tokens existentes y sus excepciones
  deliberadas (cuaderno --cv-*, coreografía del chivito).
- main.jsx: importa tokens.css primero (capa base).
- Unificación quirúrgica con fallback byte-idéntico al valor previo
  (riesgo visual cero): juego-pulido (--jp-sombra-* → --sombra-*),
  screen-shell-f2, registro-shell, finca-viva-resto y themes.css
  (radios/pastillas, tacto 44px, duraciones, tamaños de texto).
- Test de contrato styles/__tests__/tokens.test.js (nombres estables,
  orden de import, consumidores con fallback idéntico).

Sin cambios de paleta ni de layout: no se tocan index.css (rampas --c-*),
finca-viva-hero.css (coreografía de escena), cicloVivo (piel cuaderno
intencional) ni chivito.css. Build y tests de temas en verde.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
