### PR TITLE
feat(directorio): jerarquía visual de la ficha de especie con emoji, ciclo e identidad de tokens

### DIFF
--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { ChevronLeft, Search, Sprout, Leaf, X } from 'lucide-react';
 import { searchSpecies, buildSpeciesFicha, listSpeciesForBrowse } from '../../services/directorioEspecies.js';
-import SpeciesFicha from './SpeciesFicha.jsx';
+import SpeciesFicha, { SpeciesFichaSkeleton } from './SpeciesFicha.jsx';
 import EmptyState from '../common/EmptyState.jsx';
 import SkeletonList from '../common/SkeletonList.jsx';
 import { fvhSkinClass } from '../../config/fvhSkin.js';
@@ -363,14 +363,12 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
 
       {/* Resultados / estados */}
       <div className="px-4 pt-3 pb-10">
-        {/* Abriendo una ficha: skeleton con la silueta de la ficha que viene. */}
+        {/* Abriendo una ficha: skeleton con la silueta REAL de la ficha que
+            viene (foto + identidad + secciones) — sin salto de layout. */}
         {loadingFicha && (
-          <SkeletonList
-            count={4}
-            variant="row"
-            ariaLabel="Abriendo la ficha…"
-            data-testid="directorio-loading-ficha"
-          />
+          <div data-testid="directorio-loading-ficha" className="-mx-4">
+            <SpeciesFichaSkeleton />
+          </div>
         )}
 
         {/* Buscando: skeleton de filas (percepción de rapidez, sin salto). */}

--- a/src/components/DirectorioEspecies/SpeciesFicha.jsx
+++ b/src/components/DirectorioEspecies/SpeciesFicha.jsx
@@ -9,10 +9,13 @@ import {
   ShieldAlert,
   BookOpen,
   Mountain,
-  Sparkles,
+  CalendarRange,
   ImageOff,
 } from 'lucide-react';
 import PisoTermicoBand from './PisoTermicoBand.jsx';
+import Skeleton from '../common/Skeleton.jsx';
+import { getSpeciesVisual, SPECIES_TONE_CLASSES } from '../../utils/speciesVisual.js';
+import { ETAPA_CODE_ICONS } from '../icons/etapaCicloIcons.js';
 
 /**
  * SpeciesFicha — ficha visual completa y grounded de una especie del Directorio.
@@ -20,7 +23,14 @@ import PisoTermicoBand from './PisoTermicoBand.jsx';
  * Identidad Chagra, mobile-first. Cada sección se autocontiene y muestra
  * deflección honesta ("sin datos de X todavía") cuando la fuente no tiene el
  * dato. NUNCA inventa. Recibe la ficha ya construida por
- * `buildSpeciesFicha(speciesId)`.
+ * `buildSpeciesFicha(speciesId)` — este componente es SOLO capa visual.
+ *
+ * Sistema visual:
+ *   - Emoji por especie (utils/speciesVisual) = contenido; iconos lucide =
+ *     chrome de UI y etapas de ciclo (components/icons/etapaCicloIcons).
+ *   - Radios/sombras/táctil desde los tokens globales (styles/tokens.css)
+ *     vía valores arbitrarios de Tailwind con fallback byte-idéntico.
+ *   - Todo movimiento va tras `motion-safe:` (prefers-reduced-motion).
  *
  * @param {object} props
  * @param {object} props.ficha — salida de buildSpeciesFicha.
@@ -35,25 +45,52 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
     fenologia, fuentes = [],
   } = ficha;
 
+  // El catálogo lista variantes de nombre común con "/" ("Mora andina / Mora
+  // de Castilla"): el primero manda la jerarquía, el resto baja a chips junto
+  // a los nombres regionales. Presentación pura — el dato no se toca.
+  const nombreParts = String(comun || '').split('/').map((s) => s.trim()).filter(Boolean);
+  const nombrePrincipal = nombreParts[0] || comun;
+  const otrosNombres = [...nombreParts.slice(1), ...nombresRegionales];
+
+  const nCompatibles = asociaciones?.compatibles?.length || 0;
+  const nAntagonistas = asociaciones?.antagonistas?.length || 0;
+
   return (
     <article className="max-w-2xl mx-auto pb-10" data-testid="species-ficha">
-      {/* FOTO / fallback ilustrado */}
-      <SpeciesPhoto imagen={imagen} comun={comun} />
+      {/* FOTO / fallback ilustrado con el emoji de la especie */}
+      <SpeciesPhoto imagen={imagen} comun={comun} ficha={ficha} />
 
-      {/* Identidad */}
+      {/* Identidad — emoji por especie + nombre como jerarquía principal */}
       <header className="px-4 pt-4">
-        <h2 className="text-2xl font-black text-emerald-100 leading-tight">{comun}</h2>
-        {cientifico && (
-          <p className="text-sm italic text-emerald-300/80">{cientifico}</p>
-        )}
-        <div className="flex flex-wrap gap-1.5 mt-2">
+        <div className="flex items-start gap-3">
+          <SpeciesEmojiBadge ficha={ficha} />
+          <div className="min-w-0 flex-1">
+            <h2 className="text-2xl font-black text-emerald-100 leading-tight">{nombrePrincipal}</h2>
+            {cientifico && (
+              <p className="text-sm italic text-emerald-300/80 mt-0.5">{cientifico}</p>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-1.5 mt-3">
           {familia && <Pill icon={Leaf} tone="emerald">{familia}</Pill>}
           {estrato && <Pill icon={Mountain} tone="slate">Estrato {estrato}</Pill>}
         </div>
-        {nombresRegionales.length > 0 && (
-          <p className="text-xs text-slate-400 mt-2">
-            También: {nombresRegionales.join(' · ')}
-          </p>
+        {otrosNombres.length > 0 && (
+          <div className="mt-3" data-testid="ficha-nombres-regionales">
+            <p className="text-[length:var(--fs-nota,0.78rem)] font-bold text-slate-400 mb-1.5">
+              También conocida como
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {otrosNombres.map((n) => (
+                <span
+                  key={n}
+                  className="px-2.5 py-1 rounded-[var(--r-pill,999px)] border border-slate-700/60 bg-slate-800/50 text-[11px] font-semibold text-slate-300 leading-tight"
+                >
+                  {n}
+                </span>
+              ))}
+            </div>
+          </div>
         )}
       </header>
 
@@ -62,8 +99,18 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
         <PisoTermicoBand pisoTermico={pisoTermico} />
       </Section>
 
+      {/* CICLO DE VIDA — iconos de etapa del set común (etapaCicloIcons) */}
+      <Section icon={CalendarRange} title="Ciclo de vida" accent="lime">
+        <CicloStats fenologia={fenologia} />
+      </Section>
+
       {/* ASOCIACIONES */}
-      <Section icon={Sprout} title="Asociaciones de cultivo" accent="emerald">
+      <Section
+        icon={Sprout}
+        title="Asociaciones de cultivo"
+        accent="emerald"
+        count={nCompatibles + nAntagonistas || null}
+      >
         <div className="space-y-3">
           <AssocGroup
             label="Asociar (favorables)"
@@ -85,7 +132,12 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
       </Section>
 
       {/* BIOPREPARADOS */}
-      <Section icon={FlaskConical} title="Biopreparados asociados" accent="teal">
+      <Section
+        icon={FlaskConical}
+        title="Biopreparados asociados"
+        accent="teal"
+        count={biopreparados.length || null}
+      >
         {biopreparados.length === 0 ? (
           <Empty>Sin biopreparados asociados en el grafo todavía.</Empty>
         ) : (
@@ -93,23 +145,39 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
             {biopreparados.map((b) => (
               <li
                 key={b.id || b.nombre}
-                className="rounded-lg border border-teal-700/40 bg-teal-950/30 p-2.5"
+                className="rounded-[var(--r-md,16px)] border border-teal-700/40 bg-teal-950/30 p-3 shadow-[var(--sombra-1,0_1px_2px_rgb(8_30_22/0.18))]"
               >
-                <p className="text-sm font-bold text-teal-100 leading-tight flex items-center gap-1.5">
-                  <FlaskConical size={14} className="text-teal-300 shrink-0" aria-hidden="true" />
-                  {b.nombre}
-                </p>
-                {b.tipo && (
-                  <span className="text-[10px] uppercase tracking-wide text-teal-400/80">{b.tipo}</span>
-                )}
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-bold text-teal-100 leading-tight flex items-center gap-1.5 min-w-0">
+                    <FlaskConical size={14} className="text-teal-300 shrink-0" aria-hidden="true" />
+                    {b.nombre}
+                  </p>
+                  {b.tipo && (
+                    <span className="shrink-0 px-2 py-0.5 rounded-[var(--r-pill,999px)] border border-teal-600/40 bg-teal-900/40 text-[10px] uppercase tracking-wide font-bold text-teal-300">
+                      {b.tipo}
+                    </span>
+                  )}
+                </div>
                 {b.dosis && (
-                  <p className="text-xs text-slate-300 mt-1"><span className="font-semibold text-slate-200">Dosis:</span> {b.dosis}</p>
+                  <p className="text-xs text-slate-300 mt-1.5"><span className="font-semibold text-slate-200">Dosis:</span> {b.dosis}</p>
                 )}
                 {b.uso && (
                   <p className="text-xs text-slate-400 mt-0.5">{b.uso}</p>
                 )}
+                {Array.isArray(b.ingredientes) && b.ingredientes.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-1.5">
+                    {b.ingredientes.map((ing) => (
+                      <span
+                        key={ing}
+                        className="px-1.5 py-0.5 rounded-[var(--r-xs,8px)] bg-slate-800/70 border border-slate-700/50 text-[10px] text-slate-300 leading-tight"
+                      >
+                        {ing}
+                      </span>
+                    ))}
+                  </div>
+                )}
                 {!b.enCatalogo && (
-                  <p className="text-[10px] text-slate-500 italic mt-0.5">Receta detallada no curada en el catálogo todavía.</p>
+                  <p className="text-[10px] text-slate-500 italic mt-1">Receta detallada no curada en el catálogo todavía.</p>
                 )}
               </li>
             ))}
@@ -118,7 +186,12 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
       </Section>
 
       {/* PLAGAS / ENFERMEDADES + CONTROLADORES */}
-      <Section icon={Bug} title="Plagas, enfermedades y control biológico" accent="rose">
+      <Section
+        icon={Bug}
+        title="Plagas, enfermedades y control biológico"
+        accent="rose"
+        count={amenazas.length || null}
+      >
         {amenazas.length === 0 ? (
           <Empty>Sin plagas o enfermedades registradas todavía.</Empty>
         ) : (
@@ -126,22 +199,37 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
             {amenazas.map((a) => (
               <li
                 key={`${a.tipo}-${a.nombre}`}
-                className="rounded-lg border border-rose-800/40 bg-rose-950/20 p-2.5"
+                className="rounded-[var(--r-md,16px)] border border-rose-800/40 bg-rose-950/20 p-3 shadow-[var(--sombra-1,0_1px_2px_rgb(8_30_22/0.18))]"
               >
-                <p className="text-sm font-bold text-rose-100 leading-tight flex items-center gap-1.5">
-                  {a.tipo === 'enfermedad'
-                    ? <ShieldAlert size={14} className="text-rose-300 shrink-0" aria-hidden="true" />
-                    : <Bug size={14} className="text-rose-300 shrink-0" aria-hidden="true" />}
-                  {a.nombre}
-                  <span className="text-[10px] uppercase tracking-wide text-rose-400/70">{a.tipo}</span>
-                </p>
-                {a.controladores && a.controladores.length > 0 ? (
-                  <p className="text-xs text-emerald-200/90 mt-1">
-                    <ShieldCheck size={12} className="inline -mt-0.5 mr-1 text-emerald-300" aria-hidden="true" />
-                    Control: {a.controladores.join(' · ')}
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-bold text-rose-100 leading-tight flex items-center gap-1.5 min-w-0">
+                    {a.tipo === 'enfermedad'
+                      ? <ShieldAlert size={14} className="text-rose-300 shrink-0" aria-hidden="true" />
+                      : <Bug size={14} className="text-rose-300 shrink-0" aria-hidden="true" />}
+                    {a.nombre}
                   </p>
+                  <span className="shrink-0 px-2 py-0.5 rounded-[var(--r-pill,999px)] border border-rose-700/40 bg-rose-900/40 text-[10px] uppercase tracking-wide font-bold text-rose-300">
+                    {a.tipo}
+                  </span>
+                </div>
+                {a.controladores && a.controladores.length > 0 ? (
+                  <div className="mt-2">
+                    <p className="text-[10px] font-bold uppercase tracking-wide text-emerald-400/80 mb-1 flex items-center gap-1">
+                      <ShieldCheck size={11} aria-hidden="true" /> Control biológico
+                    </p>
+                    <div className="flex flex-wrap gap-1">
+                      {a.controladores.map((c) => (
+                        <span
+                          key={c}
+                          className="px-2 py-0.5 rounded-[var(--r-pill,999px)] border border-emerald-700/40 bg-emerald-950/40 text-[11px] font-semibold text-emerald-200 leading-tight"
+                        >
+                          {c}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
                 ) : (
-                  <p className="text-[11px] text-slate-500 italic mt-1">Sin controlador biológico registrado todavía.</p>
+                  <p className="text-[11px] text-slate-500 italic mt-1.5">Sin controlador biológico registrado todavía.</p>
                 )}
               </li>
             ))}
@@ -158,17 +246,29 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
         </Section>
       )}
 
-      {/* FUENTES */}
+      {/* FUENTES — pie de página del dato, no una sección más */}
       {fuentes.length > 0 && (
-        <div className="px-4 pt-5">
-          <p className="text-[11px] text-slate-500 flex items-start gap-1.5">
-            <Sparkles size={12} className="text-slate-500 mt-0.5 shrink-0" aria-hidden="true" />
-            <span>
-              Fuentes: {fuentes.map((f) => f.title).join(' · ')}. Datos del catálogo y
-              del grafo de conocimiento de Chagra; sin datos no se inventa nada.
-            </span>
-          </p>
-        </div>
+        <footer className="px-4 pt-6" data-testid="ficha-fuentes">
+          <div className="rounded-[var(--r-md,16px)] border border-slate-800/70 bg-slate-900/50 p-3">
+            <p className="text-[10px] font-bold uppercase tracking-wide text-slate-500 mb-1.5 flex items-center gap-1.5">
+              <BookOpen size={12} aria-hidden="true" /> Fuentes
+            </p>
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              {fuentes.map((f) => (
+                <span
+                  key={f.id || f.title}
+                  className="px-2 py-0.5 rounded-[var(--r-xs,8px)] border border-slate-700/50 bg-slate-800/60 text-[11px] font-semibold text-slate-300 leading-tight"
+                >
+                  {f.title}
+                </span>
+              ))}
+            </div>
+            <p className="text-[length:var(--fs-nota,0.78rem)] text-slate-500 leading-relaxed">
+              Datos del catálogo y del grafo de conocimiento de Chagra; sin datos
+              no se inventa nada.
+            </p>
+          </div>
+        </footer>
       )}
     </article>
   );
@@ -176,7 +276,90 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
 
 /* ---------------------------------------------------------------- subcomp. */
 
-function SpeciesPhoto({ imagen, comun }) {
+/** Badge grande del emoji por especie (mismo set que el Directorio). */
+function SpeciesEmojiBadge({ ficha }) {
+  const { emoji, tone } = getSpeciesVisual(ficha);
+  const toneCls = SPECIES_TONE_CLASSES[tone] || SPECIES_TONE_CLASSES.emerald;
+  return (
+    <span
+      className={`w-14 h-14 rounded-[var(--r-md,16px)] border grid place-items-center shrink-0 text-3xl leading-none shadow-[var(--sombra-1,0_1px_2px_rgb(8_30_22/0.18))] ${toneCls}`}
+      aria-hidden="true"
+      data-testid="ficha-species-emoji"
+    >
+      {emoji}
+    </span>
+  );
+}
+
+/** Capitaliza un valor plano del catálogo para mostrarlo ("semilla" → "Semilla"). */
+function cap(v) {
+  const s = String(v || '').trim();
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
+}
+
+/**
+ * CicloStats — duración de ciclo, propagación y tipo de cosecha como filas de
+ * dato con los MISMOS iconos de etapa del set común (siembra = Bean, cosecha =
+ * canasta). Solo pinta lo que la ficha trae; sin dato → deflección honesta.
+ */
+function CicloStats({ fenologia }) {
+  const cycleMonths = typeof fenologia?.cycleMonths === 'number' && Number.isFinite(fenologia.cycleMonths)
+    ? fenologia.cycleMonths
+    : null;
+  const propagation = typeof fenologia?.propagation === 'string' && fenologia.propagation.trim()
+    ? fenologia.propagation
+    : null;
+  const harvestType = typeof fenologia?.harvestType === 'string' && fenologia.harvestType.trim()
+    ? fenologia.harvestType
+    : null;
+
+  const SiembraIcon = ETAPA_CODE_ICONS.sowing;
+  const CosechaIcon = ETAPA_CODE_ICONS.harvest_window;
+
+  const stats = [
+    cycleMonths !== null && {
+      key: 'ciclo',
+      Icon: CalendarRange,
+      label: 'Duración del ciclo',
+      value: cycleMonths === 1 ? '≈ 1 mes' : `≈ ${cycleMonths} meses`,
+    },
+    propagation && {
+      key: 'propagacion',
+      Icon: SiembraIcon,
+      label: 'Propagación',
+      value: cap(propagation),
+    },
+    harvestType && {
+      key: 'cosecha',
+      Icon: CosechaIcon,
+      label: 'Cosecha',
+      value: cap(harvestType),
+    },
+  ].filter(Boolean);
+
+  if (stats.length === 0) {
+    return <Empty>Sin datos de ciclo registrados para esta especie todavía.</Empty>;
+  }
+
+  return (
+    <div className="grid grid-cols-1 min-[420px]:grid-cols-2 sm:grid-cols-3 gap-2" data-testid="ficha-ciclo">
+      {stats.map((stat) => (
+        <div
+          key={stat.key}
+          className="flex items-center gap-2.5 min-h-[var(--tap-min,44px)] rounded-[var(--r-md,16px)] border border-lime-800/40 bg-lime-950/20 px-3 py-2"
+        >
+          <stat.Icon size={18} className="text-lime-300 shrink-0" aria-hidden="true" />
+          <div className="min-w-0 leading-tight">
+            <p className="text-[10px] uppercase tracking-wide font-bold text-lime-400/80">{stat.label}</p>
+            <p className="text-sm font-bold text-slate-100 truncate">{stat.value}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SpeciesPhoto({ imagen, comun, ficha }) {
   if (imagen?.url) {
     return (
       <figure className="relative w-full aspect-[16/10] sm:aspect-[2/1] bg-slate-900 overflow-hidden">
@@ -192,49 +375,45 @@ function SpeciesPhoto({ imagen, comun }) {
       </figure>
     );
   }
-  // Fallback ilustrado elegante (SVG inline) — nunca imagen rota.
+  // Fallback ilustrado: el EMOJI de la especie (no un glifo genérico) sobre el
+  // degradado de identidad — nunca imagen rota y cada especie se distingue.
+  const { emoji } = getSpeciesVisual(ficha || { comun });
   return (
     <div
-      className="relative w-full aspect-[16/10] sm:aspect-[2/1] flex flex-col items-center justify-center bg-gradient-to-br from-emerald-950 via-slate-900 to-teal-950 overflow-hidden"
+      className="relative w-full aspect-[16/10] sm:aspect-[2/1] flex flex-col items-center justify-center gap-1 bg-gradient-to-br from-emerald-950 via-slate-900 to-teal-950 overflow-hidden"
       data-testid="species-photo-fallback"
       role="img"
       aria-label={`Sin foto de ${comun}; ilustración`}
     >
-      <svg viewBox="0 0 120 120" className="w-24 h-24 opacity-80" aria-hidden="true">
-        <defs>
-          <linearGradient id="leafGrad" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%" stopColor="#34d399" />
-            <stop offset="100%" stopColor="#0d9488" />
-          </linearGradient>
-        </defs>
-        <path
-          d="M60 105 C60 70 42 58 30 40 C58 44 70 60 70 80 C84 60 86 40 90 22 C96 52 84 78 64 92 Z"
-          fill="url(#leafGrad)"
-        />
-        <path d="M60 105 L60 70" stroke="#065f46" strokeWidth="3" strokeLinecap="round" />
-      </svg>
-      <p className="mt-1 flex items-center gap-1.5 text-[11px] text-emerald-200/70">
+      <span className="text-6xl leading-none drop-shadow-lg" aria-hidden="true">{emoji}</span>
+      <p className="mt-2 flex items-center gap-1.5 text-[11px] text-emerald-200/70">
         <ImageOff size={12} aria-hidden="true" /> Sin foto en el catálogo todavía
       </p>
     </div>
   );
 }
 
-function Section({ icon, title, accent, children }) {
+function Section({ icon, title, accent, count = null, children }) {
   const Icon = icon;
   const ACC = {
     amber: 'from-amber-400 to-orange-400',
+    lime: 'from-lime-400 to-emerald-400',
     emerald: 'from-emerald-400 to-teal-400',
     teal: 'from-teal-400 to-cyan-400',
     rose: 'from-rose-400 to-pink-400',
     indigo: 'from-indigo-400 to-violet-400',
   }[accent] || 'from-slate-400 to-slate-500';
   return (
-    <section className="px-4 pt-5">
+    <section className="px-4 pt-6">
       <h3 className="flex items-center gap-2 text-xs font-black text-slate-300 uppercase tracking-wider mb-2.5">
         <span aria-hidden="true" className={`h-3.5 w-1 rounded-full bg-gradient-to-b ${ACC}`} />
         <Icon size={15} className="text-slate-400" aria-hidden="true" />
-        {title}
+        <span>{title}</span>
+        {typeof count === 'number' && count > 0 && (
+          <span className="px-1.5 py-0.5 rounded-full bg-slate-800 border border-slate-700/60 text-[10px] font-bold text-slate-400 leading-none">
+            {count}
+          </span>
+        )}
       </h3>
       {children}
     </section>
@@ -259,10 +438,12 @@ function AssocGroup({ label, icon, tone, items, emptyText, onSelectSpecies }) {
         <div className="flex flex-wrap gap-1.5">
           {list.map((s) => {
             const clickable = s.enCatalogo && typeof onSelectSpecies === 'function';
+            const { emoji } = getSpeciesVisual(s);
             const content = (
               <>
+                <span aria-hidden="true" className="text-sm leading-none">{emoji}</span>
                 <span className="font-bold">{s.comun || s.id}</span>
-                {s.cientifico && <span className="italic text-[10px] text-slate-400 ml-1">{s.cientifico}</span>}
+                {s.cientifico && <span className="italic text-[10px] text-slate-400">{s.cientifico}</span>}
               </>
             );
             return clickable ? (
@@ -270,12 +451,15 @@ function AssocGroup({ label, icon, tone, items, emptyText, onSelectSpecies }) {
                 key={s.id}
                 type="button"
                 onClick={() => onSelectSpecies(s.id)}
-                className={`px-2 py-1 rounded-md border text-[11px] leading-tight ${TONE} hover:brightness-125 transition`}
+                className={`inline-flex items-center gap-1.5 min-h-[36px] px-2.5 py-1 rounded-[var(--r-pill,999px)] border text-[11px] leading-tight ${TONE} hover:brightness-125 motion-safe:transition focus:outline-none focus:ring-2 focus:ring-emerald-400/60`}
               >
                 {content}
               </button>
             ) : (
-              <span key={s.id} className={`px-2 py-1 rounded-md border text-[11px] leading-tight ${TONE} opacity-90`}>
+              <span
+                key={s.id}
+                className={`inline-flex items-center gap-1.5 min-h-[36px] px-2.5 py-1 rounded-[var(--r-pill,999px)] border text-[11px] leading-tight ${TONE} opacity-90`}
+              >
                 {content}
               </span>
             );
@@ -293,7 +477,7 @@ function Pill({ icon, tone, children }) {
     slate: 'bg-slate-700/40 text-slate-300 border-slate-600/40',
   }[tone] || 'bg-slate-700/40 text-slate-300 border-slate-600/40';
   return (
-    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md border text-[11px] font-bold ${TONE}`}>
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-[var(--r-xs,8px)] border text-[11px] font-bold ${TONE}`}>
       {Icon && <Icon size={11} aria-hidden="true" />}
       {children}
     </span>
@@ -302,4 +486,39 @@ function Pill({ icon, tone, children }) {
 
 function Empty({ children }) {
   return <p className="text-xs text-slate-500 italic">{children}</p>;
+}
+
+/**
+ * SpeciesFichaSkeleton — placeholder de carga con la SILUETA real de la ficha
+ * (foto, identidad, secciones), construido con el Skeleton común. Reemplaza
+ * las filas genéricas mientras `buildSpeciesFicha` lee el catálogo offline:
+ * el ojo ya sabe qué viene y no hay salto de layout. El shimmer respeta
+ * prefers-reduced-motion (motion-safe en Skeleton).
+ */
+export function SpeciesFichaSkeleton() {
+  return (
+    <div className="max-w-2xl mx-auto pb-10" data-testid="species-ficha-skeleton">
+      {/* Foto */}
+      <Skeleton variant="rect" width="100%" height={190} rounded="none" className="w-full" ariaLabel="Abriendo la ficha…" />
+      {/* Identidad */}
+      <div className="px-4 pt-4 flex items-start gap-3">
+        <Skeleton variant="rect" width={56} height={56} rounded="xl" />
+        <div className="flex-1 space-y-2 pt-1">
+          <Skeleton width="70%" height={20} />
+          <Skeleton width="45%" height={12} />
+        </div>
+      </div>
+      <div className="px-4 pt-3 flex gap-1.5">
+        <Skeleton width={90} height={22} rounded="lg" />
+        <Skeleton width={110} height={22} rounded="lg" />
+      </div>
+      {/* Secciones */}
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="px-4 pt-6 space-y-2">
+          <Skeleton width="55%" height={12} />
+          <Skeleton variant="rect" width="100%" height={72} rounded="xl" />
+        </div>
+      ))}
+    </div>
+  );
 }


### PR DESCRIPTION
## Qué cambia (solo capa visual — cero lógica de datos)

Mejora visual de la **ficha de especie** del Directorio (`SpeciesFicha.jsx`):

- **Identidad**: badge grande del emoji por especie (`utils/speciesVisual`, mismo set del Directorio) junto al nombre; variantes del nombre común ("A / B") y nombres regionales como chips "También conocida como".
- **Fallback de foto**: el emoji de la especie sobre el degradado de identidad — cada especie se distingue, nunca imagen rota. Mismo testid y aria-label.
- **Nueva sección "Ciclo de vida"**: duración (≈ meses), propagación y cosecha — datos que `buildSpeciesFicha` ya entregaba y la UI no pintaba — con los iconos de etapa del set común (`etapaCicloIcons`). Sin dato → deflección honesta.
- **Chips**: controladores biológicos e ingredientes de biopreparados pasan de texto corrido a chips; tipo de amenaza/biopreparado como pastilla; asociaciones con emoji por especie y alto táctil.
- **Encabezados de sección con contador** (asociaciones, biopreparados, amenazas).
- **Pie de fuentes** como footer propio (caja con chips por fuente).
- **Tokens globales** (`styles/tokens.css`): `--r-md/--r-xs/--r-pill`, `--sombra-1`, `--tap-min`, `--fs-nota` vía valores arbitrarios con fallback byte-idéntico.
- **`SpeciesFichaSkeleton`**: silueta real de la ficha (foto + identidad + secciones) con el `Skeleton` común; reemplaza las filas genéricas al abrir una ficha en `DirectorioEspeciesScreen` (mismo testid). Shimmer/transiciones tras `motion-safe` (prefers-reduced-motion).

## Verificación

- `npx vitest run src/components/DirectorioEspecies/` → 15/15 verdes (testids y textos de deflección intactos).
- `npx eslint src/components/DirectorioEspecies/` → limpio.
- `npm run build` → ✓ built.
- `tsc:check` → mismo conteo que el baseline de dev (2162; 0 errores en los archivos fuente tocados).

Tono usted, offline-first, sin dependencias nuevas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)