### PR TITLE
feat(aprender): pasada visual del hub de lecciones — ilustración por lección + progreso visible

### DIFF
--- a/src/components/Aprende/AprenderConAgente.jsx
+++ b/src/components/Aprende/AprenderConAgente.jsx
@@ -14,11 +14,13 @@
  *   - Lenguaje colombiano (tú/usted, sin voseo argentino).
  *   - Accesible: aria-labels, navegación por teclado.
  */
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import {
   BookOpen,
+  CheckCircle2,
   ChevronRight,
   ChevronLeft,
+  ScrollText,
   Sprout,
   Leaf,
   FlaskConical,
@@ -30,9 +32,11 @@ import {
 import lecciones from '../../data/agro-lecciones.json';
 import todasLasCards from '../../data/agro-insight-cards.json';
 import InsightCard from './InsightCard.jsx';
+import LeccionIlustracion from './LeccionIlustracion.jsx';
 import ManoChagraGlyph from '../dashboard/ManoChagraGlyph.jsx';
 import LessonInfographic from '../LessonInfographic.jsx';
 import { aprenderInfografiaActivo } from '../../config/aprenderInfografiaFlag.js';
+import './aprender-hub.css';
 
 // Infográfico por lección (PoC del audit triple: "cero gráficos"). Gateado
 // dev-only por VITE_APRENDER_INFOGRAFIA; se evalúa una sola vez (flag de build).
@@ -91,6 +95,66 @@ const LECCION_COLORS = {
   },
 };
 
+/* ── Progreso local por lección (solo capa visual, offline-first) ──────────
+   Guarda hasta dónde llegó el usuario en cada lección para que el hub muestre
+   progreso visible (audit: "progreso visible"). localStorage con try/catch:
+   si el almacenamiento falla (modo privado, cuota), el hub degrada limpio
+   a "sin progreso" y la lección funciona igual. */
+const PROGRESO_KEY = 'chagra.aprender.progreso.v1';
+
+function leerProgresoLecciones() {
+  try {
+    const raw = window.localStorage.getItem(PROGRESO_KEY);
+    const data = raw ? JSON.parse(raw) : {};
+    return data && typeof data === 'object' && !Array.isArray(data) ? data : {};
+  } catch {
+    return {};
+  }
+}
+
+function guardarProgresoLeccion(slug, patch) {
+  try {
+    const data = leerProgresoLecciones();
+    data[slug] = { ...(data[slug] || {}), ...patch };
+    window.localStorage.setItem(PROGRESO_KEY, JSON.stringify(data));
+  } catch {
+    /* sin almacenamiento: el progreso simplemente no persiste */
+  }
+}
+
+/* ── Fuente con DOI destacado ──────────────────────────────────────────────
+   Si la fuente trae un DOI, lo separa a un chip monoespaciado propio para que
+   la trazabilidad científica sea visible de un vistazo (audit: pie de
+   fuente/DOI donde aplique). Si no hay DOI, muestra la fuente tal cual. */
+function extraerDoi(fuente) {
+  if (typeof fuente !== 'string') return { texto: fuente || '', doi: null };
+  const match = /,?\s*DOI[:\s]+(\S+)/i.exec(fuente);
+  if (!match) return { texto: fuente, doi: null };
+  return {
+    texto: fuente.slice(0, match.index).trim().replace(/[,;]$/, ''),
+    doi: match[1],
+  };
+}
+
+function FuentePie({ etiqueta = 'Fuente base', fuente }) {
+  const { texto, doi } = extraerDoi(fuente);
+  if (!texto && !doi) return null;
+  return (
+    <div className="flex items-start gap-2 pt-2 border-t border-slate-800/40">
+      <ScrollText size={12} className="text-slate-600 shrink-0 mt-0.5" aria-hidden="true" />
+      <p className="text-[11px] text-slate-500 leading-relaxed min-w-0">
+        <strong className="text-slate-500">{etiqueta}:</strong> {texto}
+        {doi && (
+          <>
+            {' '}
+            <span className="aprh-doi inline-block text-slate-400 mt-0.5">DOI {doi}</span>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}
+
 /**
  * Bloque de contenido individual de una lección.
  */
@@ -105,11 +169,22 @@ function BloqueContenido({ bloque }) {
           Dato verificado
         </p>
         <p className="text-sm text-emerald-100 leading-relaxed">{bloque.texto}</p>
-        {bloque.fuente && (
-          <p className="text-[11px] text-emerald-300/60 mt-2 leading-relaxed">
-            Fuente: {bloque.fuente}
-          </p>
-        )}
+        {bloque.fuente && (() => {
+          const { texto, doi } = extraerDoi(bloque.fuente);
+          return (
+            <p className="text-[11px] text-emerald-300/60 mt-2 leading-relaxed">
+              Fuente: {texto}
+              {doi && (
+                <>
+                  {' '}
+                  <span className="aprh-doi inline-block text-emerald-300/70 mt-0.5">
+                    DOI {doi}
+                  </span>
+                </>
+              )}
+            </p>
+          );
+        })()}
       </div>
     );
   }
@@ -140,7 +215,7 @@ function BloqueContenido({ bloque }) {
 }
 
 /**
- * Botón "Pregúntale al agente" — conecta Aprender → Agente. Abre el chat del
+ * Botón "Pregúntele al agente" — conecta Aprender → Agente. Abre el chat del
  * agente con la pregunta de la lección pre-cargada en el compositor (el usuario
  * la revisa y envía; sin auto-submit). Identidad de marca: glifo de la mano de
  * Chagra + acento del tema (--t-accent-rgb), nada de estética genérica de IA.
@@ -170,7 +245,7 @@ function PreguntaleAlAgenteButton({ pregunta, onAskAgent }) {
       </span>
       <span className="min-w-0 flex-1">
         <span className="block text-sm font-bold text-slate-100 leading-tight">
-          Pregúntale al agente
+          Pregúntele al agente
         </span>
         <span className="block text-xs text-slate-300/80 leading-snug mt-0.5 truncate">
           “{pregunta}”
@@ -198,7 +273,7 @@ function LeccionView({ leccion, onBack, onAskAgent }) {
   // una pregunta honesta derivada del título.
   const preguntaLeccion =
     (typeof leccion.pregunta_agente === 'string' && leccion.pregunta_agente.trim())
-      || `Cuéntame más sobre ${(leccion.titulo || leccion.slug || '').toLowerCase()}.`;
+      || `Cuénteme más sobre ${(leccion.titulo || leccion.slug || '').toLowerCase()}.`;
   const puedePreguntar = typeof onAskAgent === 'function';
 
   const bloques = leccion.contenido_bloques;
@@ -206,6 +281,20 @@ function LeccionView({ leccion, onBack, onAskAgent }) {
     () => todasLasCards.filter((c) => c.leccion_base === leccion.slug),
     [leccion.slug]
   );
+
+  // Posición en el currículo ("Lección N de M") para orientar la navegación.
+  const numeroLeccion = lecciones.findIndex((l) => l.slug === leccion.slug) + 1;
+
+  // Progreso visible (hub): persistir hasta dónde llegó en esta lección.
+  // Al llegar a los datos verificados, la lección cuenta como completada.
+  useEffect(() => {
+    const previo = leerProgresoLecciones()[leccion.slug] || {};
+    guardarProgresoLeccion(leccion.slug, {
+      visto: Math.max(previo.visto || 0, bloqueIdx + 1),
+      total: bloques.length,
+      ...(mostrandoInsights ? { completada: true } : {}),
+    });
+  }, [leccion.slug, bloqueIdx, mostrandoInsights, bloques.length]);
 
   const esUltimoBloque = bloqueIdx >= bloques.length - 1;
   const colors = LECCION_COLORS[leccion.slug] || LECCION_COLORS.suelo;
@@ -228,12 +317,35 @@ function LeccionView({ leccion, onBack, onAskAgent }) {
           <ChevronLeft size={20} className="text-sky-400" />
         </button>
         <Icon size={16} className={colors.iconColor} aria-hidden="true" />
-        <p className="text-sm font-bold text-slate-200 truncate">{leccion.titulo}</p>
+        <p className="text-sm font-bold text-slate-200 truncate flex-1 min-w-0">
+          {leccion.titulo}
+        </p>
+        {numeroLeccion > 0 && (
+          <span className="shrink-0 text-[11px] text-slate-500 font-semibold tabular-nums">
+            Lección {numeroLeccion} de {lecciones.length}
+          </span>
+        )}
       </div>
 
       <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
         {!mostrandoInsights ? (
           <>
+            {/* Portada de la lección: SU ilustración (audit: "una ilustración
+                por lección") + descripción. Solo en el primer bloque, para
+                abrir el tema de un vistazo sin repetirse en cada paso. */}
+            {bloqueIdx === 0 && (
+              <div
+                className={`aprh-card flex items-center gap-4 p-4 bg-gradient-to-br ${colors.accent} border ${colors.border.split(' ')[0]}`}
+              >
+                <span className="aprh-illo shrink-0 inline-flex items-center justify-center w-20 h-20 p-1.5">
+                  <LeccionIlustracion slug={leccion.slug} size={68} />
+                </span>
+                <p className={`text-xs leading-relaxed min-w-0 ${colors.subColor}`}>
+                  {leccion.descripcion}
+                </p>
+              </div>
+            )}
+
             {/* Infográfico de apertura (PoC audit triple: "cero gráficos").
                 Solo en el primer bloque, para introducir la lección de un
                 vistazo. Gateado dev-only (VITE_APRENDER_INFOGRAFIA); si la
@@ -250,20 +362,28 @@ function LeccionView({ leccion, onBack, onAskAgent }) {
               <BloqueContenido bloque={bloques[bloqueIdx]} />
             </div>
 
-            {/* Indicador de progreso */}
-            <div className="flex items-center gap-1" aria-label={`Paso ${bloqueIdx + 1} de ${bloques.length}`}>
-              {bloques.map((_, i) => (
-                <div
-                  key={i}
-                  className={`h-1.5 rounded-full flex-1 transition-colors ${
-                    i === bloqueIdx
-                      ? 'bg-emerald-400'
-                      : i < bloqueIdx
-                      ? 'bg-emerald-700'
-                      : 'bg-slate-700'
-                  }`}
-                />
-              ))}
+            {/* Indicador de progreso (dots + texto visible del paso) */}
+            <div aria-label={`Paso ${bloqueIdx + 1} de ${bloques.length}`}>
+              <div className="flex items-center gap-1">
+                {bloques.map((_, i) => (
+                  <div
+                    key={i}
+                    className={`h-1.5 rounded-full flex-1 transition-colors motion-reduce:transition-none ${
+                      i === bloqueIdx
+                        ? 'bg-emerald-400'
+                        : i < bloqueIdx
+                        ? 'bg-emerald-700'
+                        : 'bg-slate-700'
+                    }`}
+                  />
+                ))}
+              </div>
+              <p
+                className="text-[11px] text-slate-500 mt-1.5 text-center tabular-nums"
+                aria-hidden="true"
+              >
+                Paso {bloqueIdx + 1} de {bloques.length}
+              </p>
             </div>
 
             {/* Navegación */}
@@ -311,11 +431,8 @@ function LeccionView({ leccion, onBack, onAskAgent }) {
               />
             )}
 
-            {/* Fuente de la lección */}
-            <p className="text-[11px] text-slate-600 leading-relaxed pt-2 border-t border-slate-800/40">
-              <strong className="text-slate-500">Fuente base:</strong>{' '}
-              {leccion.fuente}
-            </p>
+            {/* Pie de fuente de la lección (con DOI destacado si aplica) */}
+            <FuentePie fuente={leccion.fuente} />
           </>
         ) : (
           /* Vista de insights */
@@ -373,7 +490,7 @@ export function AprenderEntryCard({ onNavigate }) {
       type="button"
       data-testid="aprende-entry-card"
       onClick={() => onNavigate('aprende')}
-      className="rounded-2xl bg-gradient-to-br from-emerald-900/60 to-teal-950/80 border border-emerald-600/50 hover:border-emerald-400/70 active:scale-[0.99] transition-all p-5 text-left flex items-start gap-4 min-h-[112px] shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 w-full"
+      className="aprh-card bg-gradient-to-br from-emerald-900/60 to-teal-950/80 border border-emerald-600/50 hover:border-emerald-400/70 p-5 text-left flex items-start gap-4 min-h-[112px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 w-full"
     >
       <span className="shrink-0 inline-flex items-center justify-center w-14 h-14 rounded-xl bg-emerald-700/40 border border-emerald-500/50">
         <BookOpen size={28} className="text-emerald-300" />
@@ -401,6 +518,14 @@ export function AprenderEntryCard({ onNavigate }) {
  */
 export default function AprenderConAgente({ onBack, onAskAgent }) {
   const [leccionActual, setLeccionActual] = useState(null);
+
+  // Progreso persistido por lección; se relee al volver de una lección
+  // (leccionActual → null) para que las barras del hub queden al día.
+  const progreso = useMemo(
+    () => (leccionActual ? {} : leerProgresoLecciones()),
+    [leccionActual]
+  );
+  const completadas = lecciones.filter((l) => progreso[l.slug]?.completada).length;
 
   if (leccionActual) {
     return (
@@ -434,16 +559,31 @@ export default function AprenderConAgente({ onBack, onAskAgent }) {
       </div>
 
       <main className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
-        <p className="text-xs text-slate-400 leading-relaxed">
-          Elige un tema. Cada lección tiene datos verificados con fuente real: nada inventado.
-        </p>
+        <div className="flex items-end justify-between gap-3">
+          <p className="text-xs text-slate-400 leading-relaxed min-w-0">
+            Elija un tema. Cada lección tiene datos verificados con fuente real: nada inventado.
+          </p>
+          {completadas > 0 && (
+            <span
+              data-testid="aprende-progreso-global"
+              className="shrink-0 text-[11px] font-bold text-emerald-300 tabular-nums inline-flex items-center gap-1"
+            >
+              <CheckCircle2 size={12} aria-hidden="true" />
+              {completadas} de {lecciones.length}
+            </span>
+          )}
+        </div>
 
-        {lecciones.map((leccion) => {
+        {lecciones.map((leccion, idx) => {
           const colors = LECCION_COLORS[leccion.slug] || LECCION_COLORS.suelo;
-          const Icon = LECCION_ICONS[leccion.slug] || BookOpen;
           const insightsCount = todasLasCards.filter(
             (c) => c.leccion_base === leccion.slug
           ).length;
+          const totalBloques = leccion.contenido_bloques.length;
+          const avance = progreso[leccion.slug] || {};
+          const vistos = Math.min(avance.visto || 0, totalBloques);
+          const completada = Boolean(avance.completada);
+          const pct = completada ? 100 : Math.round((vistos / totalBloques) * 100);
 
           return (
             <button
@@ -451,13 +591,27 @@ export default function AprenderConAgente({ onBack, onAskAgent }) {
               type="button"
               data-testid={`leccion-card-${leccion.slug}`}
               onClick={() => setLeccionActual(leccion)}
-              className={`w-full rounded-2xl bg-gradient-to-br ${colors.accent} border ${colors.border} active:scale-[0.99] transition-all p-4 text-left flex items-start gap-3 min-h-[88px] shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60`}
+              aria-label={`Lección ${idx + 1} de ${lecciones.length}: ${leccion.titulo}${
+                completada ? '. Completada' : vistos > 0 ? '. En progreso' : ''
+              }`}
+              className={`aprh-card w-full bg-gradient-to-br ${colors.accent} border ${colors.border} p-4 text-left flex items-start gap-3.5 min-h-[88px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60`}
             >
-              <span className={`shrink-0 inline-flex items-center justify-center w-12 h-12 rounded-xl border ${colors.iconBg}`}>
-                <Icon size={24} className={colors.iconColor} />
+              {/* Ilustración propia de la lección (audit: una por lección) */}
+              <span className={`aprh-illo shrink-0 inline-flex items-center justify-center w-[68px] h-[68px] p-1 border ${colors.iconBg.split(' ').pop()}`}>
+                <LeccionIlustracion slug={leccion.slug} size={60} />
               </span>
+
               <div className="min-w-0 flex-1">
-                <p className={`text-base font-black leading-tight ${colors.titleColor}`}>
+                <p className={`text-[10px] font-bold uppercase tracking-wider ${colors.subColor} opacity-90 flex items-center gap-1.5`}>
+                  Lección {idx + 1}
+                  {completada && (
+                    <span className="inline-flex items-center gap-0.5 text-emerald-300 normal-case tracking-normal">
+                      <CheckCircle2 size={11} aria-hidden="true" />
+                      Completada
+                    </span>
+                  )}
+                </p>
+                <p className={`text-base font-black leading-tight mt-0.5 ${colors.titleColor}`}>
                   {leccion.titulo}
                 </p>
                 <p className={`text-xs mt-1 leading-relaxed ${colors.subColor}`}>
@@ -467,6 +621,19 @@ export default function AprenderConAgente({ onBack, onAskAgent }) {
                   <p className={`text-[11px] mt-1.5 ${colors.subColor} opacity-80`}>
                     {insightsCount} dato{insightsCount !== 1 ? 's' : ''} verificado{insightsCount !== 1 ? 's' : ''}
                   </p>
+                )}
+                {/* Progreso visible por lección (solo si ya la empezó) */}
+                {vistos > 0 && !completada && (
+                  <div
+                    className="aprh-progress-track mt-2"
+                    role="progressbar"
+                    aria-valuenow={pct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label={`Progreso de la lección: ${pct} %`}
+                  >
+                    <div className="aprh-progress-fill" style={{ width: `${pct}%` }} />
+                  </div>
                 )}
               </div>
               <ChevronRight size={18} className="shrink-0 text-slate-400 self-center" aria-hidden="true" />

--- a/src/components/Aprende/LeccionIlustracion.jsx
+++ b/src/components/Aprende/LeccionIlustracion.jsx
@@ -1,0 +1,188 @@
+/**
+ * LeccionIlustracion — una ilustración propia por lección del hub "Aprender"
+ * (pedido explícito del audit: "una ilustración por lección", que las tarjetas
+ * no sean todas iguales).
+ *
+ * Cinco escenas SVG inline dibujadas a mano, una por slug:
+ *   - suelo:         corte de suelo vivo (brote, raíces, lombriz).
+ *   - asociaciones:  maíz con fríjol enredado (las "tres hermanas").
+ *   - biopreparados: frasco fermentando con burbujas y hoja.
+ *   - mip:           hoja mordida con mariquita (control biológico).
+ *   - fenologia:     arco semilla → brote → flor → fruto bajo el sol.
+ *
+ * Principios:
+ *   - Decorativas: `aria-hidden` + `focusable="false"`; el texto de la tarjeta
+ *     es el contenido real. Cero texto dentro del SVG.
+ *   - Offline-first: SVG inline, sin assets remotos ni dependencias nuevas.
+ *   - Sin animación (no hay nada que gatear por prefers-reduced-motion).
+ *   - Paleta anclada a los tonos que ya usa cada lección en el hub
+ *     (amber/green/violet/rose/sky de Tailwind), trazos round-cap como el
+ *     resto del lenguaje visual de la marca (ManoChagraGlyph).
+ *
+ * Props:
+ *   @param {string} slug       — slug de la lección (suelo|asociaciones|...).
+ *   @param {number} [size]     — lado en px (default 56).
+ *   @param {string} [className]
+ */
+import React from 'react';
+
+const TRAZO = {
+  fill: 'none',
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+};
+
+/* Corte de suelo vivo: brote arriba, horizonte, raíces y lombriz abajo. */
+function EscenaSuelo() {
+  return (
+    <g {...TRAZO}>
+      {/* Cielo sutil */}
+      <circle cx="56" cy="14" r="6" stroke="#fcd34d" strokeWidth="2" opacity="0.65" />
+      {/* Banda de suelo (dos capas) */}
+      <path d="M6 34 H66" stroke="#b45309" strokeWidth="2.4" />
+      <rect x="6" y="34" width="60" height="30" rx="6" fill="#78350f" opacity="0.28" />
+      <path d="M8 47 Q20 44 32 47 T56 47 T66 46" stroke="#92400e" strokeWidth="1.6" opacity="0.7" />
+      {/* Brote */}
+      <path d="M30 34 V22" stroke="#4ade80" strokeWidth="2.6" />
+      <path d="M30 26 Q23 24 21 17 Q29 17 30 25" stroke="#4ade80" strokeWidth="2" fill="#4ade80" fillOpacity="0.25" />
+      <path d="M30 24 Q37 22 39 15 Q31 15 30 23" stroke="#86efac" strokeWidth="2" fill="#86efac" fillOpacity="0.25" />
+      {/* Raíces */}
+      <path d="M30 34 Q29 42 24 47 M30 34 Q31 43 36 48 M30 40 Q34 43 35 45" stroke="#fbbf24" strokeWidth="1.8" opacity="0.9" />
+      {/* Lombriz */}
+      <path d="M42 58 Q46 52 51 56 Q56 60 60 55" stroke="#fb923c" strokeWidth="3.2" />
+      <circle cx="60.5" cy="54.5" r="1.1" fill="#431407" stroke="none" />
+      {/* Poros / vida microbiana */}
+      <circle cx="16" cy="55" r="1.4" fill="#fcd34d" stroke="none" opacity="0.8" />
+      <circle cx="47" cy="41" r="1.2" fill="#fcd34d" stroke="none" opacity="0.6" />
+      <circle cx="13" cy="41" r="1.2" fill="#fdba74" stroke="none" opacity="0.7" />
+    </g>
+  );
+}
+
+/* Maíz con fríjol enredado: dos plantas que se ayudan. */
+function EscenaAsociaciones() {
+  return (
+    <g {...TRAZO}>
+      {/* Piso */}
+      <path d="M10 60 H62" stroke="#166534" strokeWidth="2.2" opacity="0.8" />
+      {/* Tallo de maíz */}
+      <path d="M30 60 V14" stroke="#4ade80" strokeWidth="2.8" />
+      {/* Hojas de maíz */}
+      <path d="M30 44 Q19 42 14 33 Q26 33 30 42" stroke="#4ade80" strokeWidth="2" fill="#4ade80" fillOpacity="0.2" />
+      <path d="M30 32 Q41 30 46 21 Q34 21 30 30" stroke="#4ade80" strokeWidth="2" fill="#4ade80" fillOpacity="0.2" />
+      {/* Mazorca */}
+      <ellipse cx="34.5" cy="17" rx="3.4" ry="6" transform="rotate(24 34.5 17)" stroke="#facc15" strokeWidth="2" fill="#fde047" fillOpacity="0.35" />
+      {/* Guía de fríjol enroscada al tallo */}
+      <path d="M44 60 Q34 54 30 50 Q24 45 30 40 Q36 36 30 30 Q25 26 30 22" stroke="#a3e635" strokeWidth="2.4" />
+      {/* Hojas de fríjol (corazón) */}
+      <path d="M42 52 q-2 -6 4 -6 q6 0 3 6 q-2 4 -3.5 4 q-1.5 0 -3.5 -4z" stroke="#a3e635" strokeWidth="1.8" fill="#a3e635" fillOpacity="0.25" />
+      <path d="M21 34 q-5 -3 -1.5 -7 q4 -3 6 2 q1.5 4 -0.5 5 q-1.6 1 -4 0z" stroke="#bef264" strokeWidth="1.8" fill="#bef264" fillOpacity="0.25" />
+      {/* Florecita del fríjol */}
+      <circle cx="30" cy="21" r="2.2" fill="#f0abfc" stroke="#e879f9" strokeWidth="1.4" />
+    </g>
+  );
+}
+
+/* Frasco de biopreparado fermentando: burbujas y hoja de ortiga. */
+function EscenaBiopreparados() {
+  return (
+    <g {...TRAZO}>
+      {/* Frasco */}
+      <path d="M26 20 H46 M28 20 V26 Q22 30 22 36 V54 Q22 60 28 60 H44 Q50 60 50 54 V36 Q50 30 44 26 V20" stroke="#c4b5fd" strokeWidth="2.4" />
+      {/* Tapa de tela (fermento aeróbico) */}
+      <path d="M25 17 Q36 13 47 17" stroke="#a78bfa" strokeWidth="2.2" />
+      {/* Líquido */}
+      <path d="M23.5 40 Q30 37.5 36 40 T48.5 40 V53.5 Q48.5 58.5 44 58.5 H28 Q23.5 58.5 23.5 53.5 Z" fill="#8b5cf6" fillOpacity="0.35" stroke="#8b5cf6" strokeWidth="1.6" />
+      {/* Burbujas subiendo */}
+      <circle cx="31" cy="47" r="1.8" stroke="#ddd6fe" strokeWidth="1.5" />
+      <circle cx="38" cy="51" r="1.3" stroke="#ddd6fe" strokeWidth="1.4" />
+      <circle cx="41" cy="44" r="2.2" stroke="#ddd6fe" strokeWidth="1.5" />
+      <circle cx="35" cy="34" r="1.4" stroke="#c4b5fd" strokeWidth="1.4" opacity="0.9" />
+      <circle cx="39" cy="29" r="1.1" stroke="#c4b5fd" strokeWidth="1.3" opacity="0.7" />
+      {/* Hoja al lado (materia verde) */}
+      <path d="M12 56 Q10 44 19 39 Q22 50 14 56z" stroke="#4ade80" strokeWidth="1.8" fill="#4ade80" fillOpacity="0.25" />
+      <path d="M15.5 52 Q16 47 18 43" stroke="#4ade80" strokeWidth="1.3" />
+    </g>
+  );
+}
+
+/* Hoja mordida con mariquita: manejo integrado de plagas. */
+function EscenaMip() {
+  return (
+    <g {...TRAZO}>
+      {/* Hoja grande */}
+      <path d="M14 54 Q10 26 34 14 Q58 22 54 46 Q44 60 26 58 Q18 57 14 54z" stroke="#4ade80" strokeWidth="2.4" fill="#4ade80" fillOpacity="0.16" />
+      {/* Nervadura */}
+      <path d="M18 52 Q30 40 44 24 M28 44 Q34 44 40 40 M24 48 Q28 50 34 50" stroke="#4ade80" strokeWidth="1.5" opacity="0.85" />
+      {/* Mordisco de plaga (muescas) */}
+      <path d="M50 30 q4 3 1.5 7 q-4 2 -6 -2 q-1.5 -3.5 4.5 -5z" fill="#0f1714" stroke="#166534" strokeWidth="1.4" />
+      <circle cx="44" cy="52" r="2.6" fill="#0f1714" stroke="#166534" strokeWidth="1.2" />
+      {/* Mariquita (control biológico) */}
+      <g transform="rotate(-18 26 28)">
+        <ellipse cx="26" cy="28" rx="7" ry="6" fill="#fb7185" stroke="#e11d48" strokeWidth="1.6" />
+        <path d="M26 22.5 V33.5" stroke="#7f1d1d" strokeWidth="1.4" />
+        <circle cx="26" cy="21.5" r="2.6" fill="#7f1d1d" stroke="none" />
+        <circle cx="22.6" cy="26.5" r="1.2" fill="#7f1d1d" stroke="none" />
+        <circle cx="29.4" cy="27.5" r="1.2" fill="#7f1d1d" stroke="none" />
+        <circle cx="24" cy="30.6" r="1" fill="#7f1d1d" stroke="none" />
+      </g>
+    </g>
+  );
+}
+
+/* Ciclo fenológico: semilla → brote → flor → fruto bajo el sol. */
+function EscenaFenologia() {
+  return (
+    <g {...TRAZO}>
+      {/* Sol */}
+      <circle cx="36" cy="16" r="5" stroke="#fcd34d" strokeWidth="2" fill="#fde047" fillOpacity="0.3" />
+      <path d="M36 7 V4 M45 12 L47 10 M27 12 L25 10" stroke="#fcd34d" strokeWidth="1.8" />
+      {/* Arco del ciclo (punteado) */}
+      <path d="M10 54 Q14 30 36 28 Q58 30 62 54" stroke="#7dd3fc" strokeWidth="1.8" strokeDasharray="1 5" />
+      {/* Piso */}
+      <path d="M8 58 H64" stroke="#0c4a6e" strokeWidth="2" opacity="0.8" />
+      {/* 1. Semilla */}
+      <ellipse cx="11" cy="53" rx="2.6" ry="3.4" transform="rotate(-20 11 53)" fill="#fbbf24" stroke="#d97706" strokeWidth="1.4" />
+      {/* 2. Brote */}
+      <path d="M26 58 V47 M26 50 Q21 49 20 44 Q25 44 26 49 M26 48 Q31 47 32 42 Q27 42 26 47" stroke="#4ade80" strokeWidth="2" />
+      {/* 3. Flor */}
+      <path d="M44 58 V44" stroke="#4ade80" strokeWidth="2" />
+      <circle cx="44" cy="40" r="2.2" fill="#fde047" stroke="none" />
+      <circle cx="44" cy="35.4" r="2.4" fill="#f9a8d4" stroke="#ec4899" strokeWidth="1" />
+      <circle cx="48.4" cy="39" r="2.4" fill="#f9a8d4" stroke="#ec4899" strokeWidth="1" />
+      <circle cx="46.8" cy="44" r="2.4" fill="#f9a8d4" stroke="#ec4899" strokeWidth="1" />
+      <circle cx="41.2" cy="44" r="2.4" fill="#f9a8d4" stroke="#ec4899" strokeWidth="1" />
+      <circle cx="39.6" cy="39" r="2.4" fill="#f9a8d4" stroke="#ec4899" strokeWidth="1" />
+      {/* 4. Fruto */}
+      <path d="M60 58 V48" stroke="#4ade80" strokeWidth="2" />
+      <circle cx="60" cy="45" r="4.6" fill="#fb923c" fillOpacity="0.75" stroke="#ea580c" strokeWidth="1.6" />
+      <path d="M60 40.5 Q62 38.5 64 39" stroke="#4ade80" strokeWidth="1.6" />
+    </g>
+  );
+}
+
+const ESCENAS = {
+  suelo: EscenaSuelo,
+  asociaciones: EscenaAsociaciones,
+  biopreparados: EscenaBiopreparados,
+  mip: EscenaMip,
+  fenologia: EscenaFenologia,
+};
+
+export default function LeccionIlustracion({ slug, size = 56, className = '' }) {
+  const Escena = ESCENAS[slug];
+  if (!Escena) return null;
+  return (
+    <svg
+      data-testid={`leccion-ilustracion-${slug}`}
+      viewBox="0 0 72 72"
+      width={size}
+      height={size}
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <Escena />
+    </svg>
+  );
+}

--- a/src/components/Aprende/aprender-hub.css
+++ b/src/components/Aprende/aprender-hub.css
@@ -1,0 +1,68 @@
+/* src/components/Aprende/aprender-hub.css
+ * ----------------------------------------------------------------------------
+ * Capa-puente del hub "Aprender" (prefijo --aprh- implícito en clases .aprh-*).
+ * Bebe de los tokens globales de src/styles/tokens.css (radios, sombras,
+ * movimiento, tacto) y del acento de tema (--t-accent-rgb, themes.css).
+ * Todo movimiento respeta prefers-reduced-motion.
+ * ---------------------------------------------------------------------------- */
+
+/* Tarjeta de lección del hub: radio y sombra de la escalera global,
+   press-feedback corto (--dur-tap) y mínimo táctil de campo. */
+.aprh-card {
+  border-radius: var(--r-xl, 24px);
+  box-shadow: var(--sombra-2, 0 6px 18px rgb(8 30 22 / 0.22));
+  min-height: var(--tap-min, 44px);
+  transition:
+    transform var(--dur-tap, 0.12s) var(--ease-suave, cubic-bezier(0.4, 0, 0.2, 1)),
+    border-color var(--dur-estado, 0.18s) var(--ease-suave, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.aprh-card:active {
+  transform: scale(0.99);
+}
+
+/* Marco de la ilustración de la lección: baldosa suave que deja respirar
+   la escena SVG sin encerrarla en un cuadrado duro. */
+.aprh-illo {
+  border-radius: var(--r-lg, 20px);
+  background:
+    radial-gradient(120% 120% at 30% 20%, rgb(255 255 255 / 0.06), transparent 60%),
+    rgb(2 6 12 / 0.35);
+}
+
+/* Barra de progreso por lección (visible en la tarjeta del hub). */
+.aprh-progress-track {
+  height: 4px;
+  border-radius: var(--r-pill, 999px);
+  background: rgb(148 163 184 / 0.22);
+  overflow: hidden;
+}
+
+.aprh-progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: rgb(var(--t-accent-rgb, 52 211 153));
+  transition: width var(--dur-estado, 0.18s) var(--ease-suave, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+/* Chip DOI del pie de fuente: monoespaciado, tinta baja, no compite. */
+.aprh-doi {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  letter-spacing: 0.01em;
+  border-radius: var(--r-xs, 8px);
+  padding: 1px 6px;
+  border: 1px solid rgb(148 163 184 / 0.25);
+  background: rgb(148 163 184 / 0.08);
+  word-break: break-all;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aprh-card,
+  .aprh-progress-fill {
+    transition: none;
+  }
+  .aprh-card:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Qué cambia (solo capa visual del hub Aprender)

Responde al audit del hub educativo: **una ilustración por lección** + botón **"pregúntele al agente"** integrado, navegación clara del currículo, progreso visible y pie de fuente/DOI.

- **`LeccionIlustracion.jsx` (nuevo)**: cinco escenas SVG inline dibujadas a mano, una por lección — suelo vivo (brote/raíces/lombriz), maíz+fríjol enredado, frasco de biopreparado fermentando, hoja mordida con mariquita (MIP) y arco fenológico semilla→fruto. Decorativas (`aria-hidden`), offline-first, cero dependencias nuevas, paleta anclada a los tonos existentes de cada lección.
- **Tarjetas del hub**: ilustración propia (ya no todas iguales), numeración del currículo ("Lección N"), barra de progreso por lección, chip "Completada" y contador global "N de 5" en el encabezado. Progreso persistido en `localStorage` con degradación limpia.
- **Vista de lección**: portada con la ilustración + descripción en el primer bloque, "Lección N de M" en el sub-header y "Paso X de Y" visible bajo los dots de progreso.
- **Fuente/DOI**: pie de fuente con el DOI separado en chip monoespaciado (`FuentePie`), también en los bloques `dato_clave`.
- **Tono usted**: "Pregúntele al agente", "Cuénteme más sobre…", "Elija un tema".
- **`aprender-hub.css` (nuevo)**: capa-puente `.aprh-*` sobre los tokens globales (`--r-*`, `--sombra-2`, `--dur-*`, `--tap-min`, `--t-accent-rgb`) con `prefers-reduced-motion`.

**Sin cambios de lógica de contenido/datos** (agro-lecciones.json intacto; el botón sigue llamando `onAskAgent(pregunta_agente)`).

## Verificación
- `npx vitest run src/components/Aprende/AprenderConAgente.test.jsx` → 29/29 ✅
- `npx eslint` sobre los archivos tocados → limpio ✅
- `npm run build` → `✓ built in 8.98s` ✅
- Las 5 escenas SVG renderizadas y revisadas visualmente en chromium headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)