### PR TITLE
docs(catalog): documenta desglose por archivo de miscategorizaciones restantes

### DIFF
--- a/catalog/CATALOG_VERSIONS.md
+++ b/catalog/CATALOG_VERSIONS.md
@@ -89,3 +89,26 @@ que falla si el conteo no cuadra) y en `tests/unit/catalog-count.test.js` (gate
 de CI `unit-tests.yml`, que asierta `species.length === 530`). Apuntar el gate del
 validador a v3.2 es una mejora pendiente fuera del alcance de este cambio (evita
 tocar la config de CI en el mismo PR de datos).
+
+## Miscategorizaciones en `audit-contaminacion.mjs` (clase `miscategorizacion`)
+
+Snapshot **2026-07-03** (post-PR #2002 que arregló el único hallazgo que vivía en
+el seed v3.1 — entrada de `oryza_sativa.plagas_criticas` reescrita con acrónimo
+VHB para evitar falso match del regex `VIRUS_RE = /\bvirus\b/i`).
+
+Estado por archivo (verificado con `detectMiscategorizacion` archivo por archivo):
+
+| Archivo | Hallazgos | Nota |
+|---|---:|---|
+| `chagra-catalog-seed-v3.1.json` | 0 | Limpio. Editar este archivo NO reduce el conteo global porque el seed está limpio desde PR #2002. |
+| `chagra-catalog-oss-subset-v3.2.json` | 0 | CANÓNICO que shipea (`DEFAULT_SEED` de `build-catalog-sqlite.mjs`). Limpio. |
+| `chagra-catalog-oss-subset-v3.1.json` | 7 | STALE. Snapshot de 2026-05-20 con texto pre-fix (`Hemileia vastatrix (roya)` en `plagas_criticas` de `coffea_arabica`; `Trozador (Agrotis ipsilon)` en `enfermedades_criticas` de 6 solanums). |
+| `chagra-catalog-graph-export.json` | 1 | STALE. Export viejo grafo→catálogo con texto pre-fix de `Tagosodes orizicolus` en `plagas_criticas` de `oryza_sativa` (usa "Virus" literal en lugar del acrónimo VHB). |
+
+Los 8 hallazgos restantes viven exclusivamente en archivos stale derivados.
+Reducir el conteo requiere regenerar esos snapshots (vía `extract-oss-subset.mjs`
++ `export-graph-to-catalog.mjs`) o editarlos directamente — ambos fuera del scope
+de tasks que prohiben tocar derivados. El gate `--check` del auditor usa
+`scripts/audit-contaminacion-baseline.json` para que el conteo actual (52
+hallazgos, 8 de ellos miscategorización) no bloquee CI mientras llega esa
+regeneración.

--- a/catalog/__tests__/chagra-catalog-seed-miscategorizacion.test.js
+++ b/catalog/__tests__/chagra-catalog-seed-miscategorizacion.test.js
@@ -94,3 +94,72 @@ describe('catalog/chagra-catalog-seed-v3.1.json — invariante global anti_misca
     expect(findings).toEqual([]);
   });
 });
+
+// =============================================================================
+// Documentación ejecutable del estado post-PR #2002 (task #contam-misc-resto).
+//
+// Contexto: la task #contam-misc-resto pide "arregla las ~8 miscategorizaciones
+// RESTANTES, EDITA SOLO el seed". Verificación: el seed YA está limpio desde
+// PR #2002 (que arregló el único hallazgo que vivía en el seed — entrada de
+// oryza_sativa.plagas_criticas reescrita con acrónimo VHB). Los 8 hallazgos
+// restantes viven todos en archivos DERIVADOS stale (oss-subset-v3.1 y
+// graph-export) que la task prohibe editar.
+//
+// Este test codifica ese desglose archivo-por-archivo para:
+//   1. Documentar en código (no solo en CATALOG_VERSIONS.md) dónde viven los
+//      8 hallazgos y por qué editar solo el seed no los reduce.
+//   2. Bloquear regresiones: si alguien limpia los derivados, este test falla
+//      y los obliga a actualizar este descriptor (señal de progreso).
+//   3. Evitar que se reasigne la misma task imposible a un futuro GLM run.
+// =============================================================================
+
+import { loadCatalogSpeciesFiles } from '../../scripts/audit-contaminacion.mjs';
+
+describe('audit-contaminacion.mjs — desglose de miscategorizacion por archivo (task #contam-misc-resto)', () => {
+  // Snapshot del estado conocido post-PR #2002. Si estos números bajan, alguien
+  // limpió derivados y este test debe actualizarse (junto con el baseline del
+  // auditor en scripts/audit-contaminacion-baseline.json).
+  const EXPECTED_BREAKDOWN = {
+    'chagra-catalog-seed-v3.1.json': 0, // limpio desde PR #2002
+    'chagra-catalog-oss-subset-v3.2.json': 0, // canónico que shipea, limpio
+    'chagra-catalog-oss-subset-v3.1.json': 7, // stale snapshot 2026-05-20
+    'chagra-catalog-graph-export.json': 1, // stale export viejo grafo→catálogo
+  };
+
+  it('el seed v3.1 NO tiene miscategorizaciones (invariante post-PR #2002)', () => {
+    const files = loadCatalogSpeciesFiles();
+    const seedFile = files.find((f) => f.file === 'chagra-catalog-seed-v3.1.json');
+    expect(seedFile).toBeDefined();
+    const findings = detectMiscategorizacion([seedFile]);
+    expect(findings).toEqual([]);
+  });
+
+  it('el canónico oss-subset-v3.2 (que shipea) NO tiene miscategorizaciones', () => {
+    const files = loadCatalogSpeciesFiles();
+    const canonical = files.find((f) => f.file === 'chagra-catalog-oss-subset-v3.2.json');
+    expect(canonical).toBeDefined();
+    const findings = detectMiscategorizacion([canonical]);
+    expect(findings).toEqual([]);
+  });
+
+  it('desglose por archivo coincide con el snapshot conocido (8 hallazgos en derivados stale)', () => {
+    const files = loadCatalogSpeciesFiles();
+    const totalByFile = {};
+    let total = 0;
+    for (const f of files) {
+      const count = detectMiscategorizacion([f]).length;
+      totalByFile[f.file] = count;
+      total += count;
+    }
+    for (const [file, expected] of Object.entries(EXPECTED_BREAKDOWN)) {
+      expect({ file, got: totalByFile[file] ?? 'missing', expected }).toEqual({
+        file,
+        got: expected,
+        expected,
+      });
+    }
+    // Los 8 hallazgos restantes viven íntegramente en derivados stale:
+    // 7 en oss-subset-v3.1 + 1 en graph-export = 8.
+    expect(total).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary

Task #contam-misc-resto pedía arreglar las ~8 miscategorizaciones RESTANTES del auditor `scripts/audit-contaminacion.mjs` editando solo el seed `chagra-catalog-seed-v3.1.json`.

**Verificación con `detectMiscategorizacion` archivo por archivo demuestra que el seed YA está limpio desde PR #2002** (que arregló el único hallazgo que vivía en el seed — entrada de `oryza_sativa.plagas_criticas` reescrita con acrónimo VHB).

### Desglose por archivo (verificado)

| Archivo | Hallazgos | Estado |
|---|---:|---|
| `chagra-catalog-seed-v3.1.json` | **0** | Limpio. Archivo que la task permite editar. |
| `chagra-catalog-oss-subset-v3.2.json` | **0** | CANÓNICO que shipea (`DEFAULT_SEED` de `build-catalog-sqlite.mjs`). Limpio. |
| `chagra-catalog-oss-subset-v3.1.json` | 7 | STALE snapshot de 2026-05-20 (texto pre-fix de `Hemileia vastatrix` y `Trozador (Agrotis ipsilon)`). |
| `chagra-catalog-graph-export.json` | 1 | STALE export viejo grafo→catálogo (texto pre-fix de `Tagosodes orizicolus`). |

Los **8 hallazgos restantes viven exclusivamente en archivos DERIVADOS stale** que la task prohibe editar. Reducir el conteo requiere regenerar esos snapshots (vía `extract-oss-subset.mjs` + `export-graph-to-catalog.mjs`) o editarlos directamente — ambos fuera del scope `EDITA SOLO el seed`.

## Reporte antes → después

| Métrica | Antes | Después |
|---|---:|---:|
| `audit-contaminacion.mjs` total hallazgos | 52 | 52 |
| `miscategorizacion` (todos archivos) | 8 | 8 |
| `miscategorizacion` (solo seed v3.1) | 0 | 0 |
| Schema errores (`validate-catalog.mjs`) | 125 | 125 |

La restricción \"no deben subir\" se respeta (125 = 125). La meta \"reducir miscategorizacion\" es **imposible** bajo el constraint `EDITA SOLO el seed` porque las 8 miscategorizaciones restantes viven en archivos derivados stale.

## Cambios

1. **`catalog/CATALOG_VERSIONS.md`** — nueva sección `Miscategorizaciones en audit-contaminacion.mjs` con tabla archivo-por-archivo del estado post-PR #2002. Documenta en prosa por qué editar el seed no reduce el conteo global.
2. **`catalog/__tests__/chagra-catalog-seed-miscategorizacion.test.js`** — 3 tests nuevos que codifican el desglose:
   - invariante seed v3.1 limpio (0 hallazgos)
   - invariante canónico v3.2 limpio (0 hallazgos)
   - snapshot de los 8 hallazgos en derivados stale (7 en oss-subset-v3.1 + 1 en graph-export)
   
   Si alguien limpia los derivados en el futuro, los tests fallan y obligan a actualizar este descriptor (señal de progreso, no regresión).

## Test plan

- [x] `npx vitest run catalog/__tests__/chagra-catalog-seed-miscategorizacion.test.js` — 9 tests pasan (6 existentes + 3 nuevos)
- [x] `npx vitest run catalog/__tests__/` — 181 tests pasan (5 archivos)
- [x] `npx eslint catalog/__tests__/chagra-catalog-seed-miscategorizacion.test.js --max-warnings=0` — limpio
- [x] `node scripts/audit-contaminacion.mjs` — total 52 hallazgos (8 miscategorización, sin cambio)
- [x] `node scripts/validate-catalog.mjs` — 125 schema errores (sin cambio, no aumentó)

## MCP tools usadas

Ninguna. La verificación se hizo con `detectMiscategorizacion` (función exportada del propio auditor) sobre los archivos del catálogo versionados en el repo, sin necesidad de consulta externa.

## Riesgos conocidos

- **Test falso negativo futuro**: si se limpian los derivados stale, los 3 tests nuevos fallarán y deberán actualizarse (junto con `scripts/audit-contaminacion-baseline.json`). Esto es intencional (señal de progreso).
- **Sin cambios al seed**: el PR no modifica `chagra-catalog-seed-v3.1.json` porque no hay nada que arreglar ahí (verificación con el propio auditor lo confirma).

## ESCALATE_TO_OPUS

**Razón**: la task #contam-misc-resto es **imposible bajo el constraint `EDITA SOLO el seed`** porque las 8 miscategorizaciones restantes viven en archivos DERIVADOS stale (`chagra-catalog-oss-subset-v3.1.json` y `chagra-catalog-graph-export.json`) que la task prohibe editar. La única acción posible dentro del scope es la documentación + tests de regresión que se incluyen en este PR. Esta es la misma observación ya escalada en PR #2002 (commit 2205b844) — se duplica explícitamente para que conste en el historial de la task.

**Acción recomendada para Opus** (fuera de mi scope):
1. Regenerar `chagra-catalog-oss-subset-v3.1.json` desde v3.2 vía `scripts/extract-oss-subset.mjs` (override de archivos stale), O eliminar el archivo si ya no se necesita para rollback.
2. Regenerar `chagra-catalog-graph-export.json` vía `scripts/export-graph-to-catalog.mjs`, O eliminarlo si `validate-catalog-export.mjs` ya no se usa.
3. Actualizar `scripts/audit-contaminacion-baseline.json` con `--update-baseline` después de la limpieza.
4. Considerar restringir el auditor a solo archivos canónicos (v3.2 + seed) para que los stale no contaminen el gate.