### PR TITLE
feat(ciclo): pasada visual de la fenología — arco de etapas + etapa actual destacada + duración por ventana

### DIFF
--- a/src/components/CicloDetalle.jsx
+++ b/src/components/CicloDetalle.jsx
@@ -220,21 +220,28 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
         </div>
         {pickStage && (
           <div className="mt-2.5 flex flex-wrap gap-1.5">
-            {speciesStageOrder.map((s) => (
-              <button
-                key={s}
-                type="button"
-                disabled={busy}
-                onClick={() => handleStage(s)}
-                aria-label={`Confirmar etapa ${speciesStageLabel(s)}`}
-                className="text-xs px-2.5 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-200 disabled:opacity-50 inline-flex items-center gap-1.5"
-              >
-                {/* Glifo por etapa (set compartido): el selector se escanea
-                    por icono, no solo leyendo cada chip. */}
-                <EtapaCicloIcon code={s} nombre={speciesStageLabel(s)} size={13} className="text-emerald-400/90" />
-                {speciesStageLabel(s)}
-              </button>
-            ))}
+            {speciesStageOrder.map((s) => {
+              // Chip de la etapa ACTUAL resaltado: el selector muestra dónde
+              // está el ciclo sin tener que leer arriba (coherente con el
+              // arco de PhenologyTimeline).
+              const isCurrent = s === baseStage(displayStage);
+              return (
+                <button
+                  key={s}
+                  type="button"
+                  disabled={busy}
+                  onClick={() => handleStage(s)}
+                  aria-label={`Confirmar etapa ${speciesStageLabel(s)}`}
+                  aria-pressed={isCurrent}
+                  className={`text-xs px-2.5 py-1.5 rounded-lg disabled:opacity-50 inline-flex items-center gap-1.5 transition-colors duration-[var(--dur-estado,0.18s)] ${isCurrent ? 'bg-emerald-900/50 border border-emerald-600/60 text-emerald-200 font-bold' : 'bg-slate-800 hover:bg-slate-700 border border-transparent text-slate-200'}`}
+                >
+                  {/* Glifo por etapa (set compartido): el selector se escanea
+                      por icono, no solo leyendo cada chip. */}
+                  <EtapaCicloIcon code={s} nombre={speciesStageLabel(s)} size={13} className={isCurrent ? 'text-emerald-300' : 'text-emerald-400/90'} />
+                  {speciesStageLabel(s)}
+                </button>
+              );
+            })}
           </div>
         )}
       </section>

--- a/src/components/PhenologyTimeline.jsx
+++ b/src/components/PhenologyTimeline.jsx
@@ -31,6 +31,19 @@ const stageColor = (code) => {
   return map[code] || 'bg-slate-700 border-slate-500 text-slate-200';
 };
 
+// Ancho de la ventana estimada de una etapa, en días. Es solo FORMATO de las
+// ventanas ya calculadas (windowEnd − windowStart), no un cálculo nuevo:
+// la fuente de verdad sigue siendo phenologyCalculator.
+const stageWindowDays = (w) => {
+  if (!w || !w.windowStart || !w.windowEnd) return null;
+  const days = Math.round((w.windowEnd - w.windowStart) / 86400000);
+  return days > 0 ? days : null;
+};
+
+// Tokens de superficie compartidos (tokens.css): radio + sombra de card en
+// reposo, mismos que las cards ya unificadas (directorio, calendario).
+const CARD_SURFACE = 'bg-slate-900 border border-slate-800 rounded-[var(--r-md,16px)] shadow-[var(--sombra-1,0_1px_2px_rgb(8_30_22/0.18))]';
+
 /**
  * PhenologyTimeline — timeline fenológica básica (Task 20).
  *
@@ -73,9 +86,21 @@ export default function PhenologyTimeline({
     return m;
   }, [observedStages]);
 
+  // Índice de la etapa ACTUAL para el arco y el resaltado: lo observado por el
+  // campesino manda sobre lo estimado por calendario (misma prioridad que ya
+  // tenía la lista). Solo agrega la vista de "dónde va el ciclo", sin tocar
+  // el cálculo de ventanas.
+  const currentIdx = useMemo(() => {
+    let idx = -1;
+    windows.forEach((w, i) => { if (observedMap[w.code]) idx = Math.max(idx, i); });
+    if (idx >= 0) return idx;
+    if (estimatedCurrent) return estimatedCurrent.stageIndex;
+    return -1;
+  }, [windows, observedMap, estimatedCurrent]);
+
   if (!speciesSlug || !sowingDate) {
     return (
-      <div className="bg-slate-900 border border-slate-800 rounded-xl p-4 text-center">
+      <div className={`${CARD_SURFACE} p-4 text-center`}>
         <HelpCircle size={24} className="text-slate-500 mx-auto mb-2" />
         <p className="text-xs text-slate-500">Datos insuficientes para estimar ventanas fenológicas.</p>
       </div>
@@ -84,7 +109,7 @@ export default function PhenologyTimeline({
 
   if (windows.length === 1 && windows[0].status !== 'computed') {
     return (
-      <div className="bg-slate-900 border border-slate-800 rounded-xl p-4 text-center">
+      <div className={`${CARD_SURFACE} p-4 text-center`}>
         <AlertTriangle size={24} className="text-amber-400 mx-auto mb-2" />
         <p className="text-xs text-slate-400">{formatWindow(windows[0])}</p>
       </div>
@@ -92,12 +117,55 @@ export default function PhenologyTimeline({
   }
 
   return (
-    <div className="bg-slate-900 border border-slate-800 rounded-xl p-4">
-      <h3 className="text-2xs font-bold text-slate-400 uppercase flex items-center gap-1.5 mb-4">
+    <div className={`${CARD_SURFACE} p-4`}>
+      <h3 className="text-2xs font-bold text-slate-400 uppercase flex items-center gap-1.5 mb-3">
         <Sprout size={13} className="text-emerald-400" />
         Timeline fenológica
         {altitudeM && <span className="text-slate-600 font-normal normal-case"> · {altitudeM} msnm</span>}
       </h3>
+
+      {/* Arco del ciclo (siembra → cosecha) de un vistazo: cada nodo es el
+          glifo de su etapa (set EtapaCicloIcon); lo recorrido va en verde, la
+          etapa actual crece con anillo, lo que falta queda apagado. Es un
+          resumen decorativo de la lista de abajo (aria-hidden: la info
+          accesible completa vive en la lista). */}
+      {windows.length > 1 && (
+        <div className="flex items-center mb-1 px-0.5" aria-hidden="true">
+          {windows.map((win, i) => {
+            const isCurrent = i === currentIdx;
+            const isPastStage = currentIdx >= 0 && i < currentIdx;
+            const isFuture = currentIdx >= 0 && i > currentIdx;
+            return (
+              <React.Fragment key={win.code}>
+                {i > 0 && (
+                  <div className={`flex-1 h-0.5 min-w-1 rounded-full ${i <= currentIdx ? 'bg-emerald-500/70' : 'bg-slate-700'}`} />
+                )}
+                <div
+                  title={win.label}
+                  className={`grid place-items-center rounded-full border shrink-0 transition-[transform,box-shadow] duration-[var(--dur-estado,0.18s)] ${
+                    isCurrent
+                      ? `w-8 h-8 ${stageColor(win.code)} ring-2 ring-emerald-400/60 shadow-[var(--sombra-2,0_6px_18px_rgb(8_30_22/0.22))]`
+                      : isFuture
+                        ? 'w-6 h-6 bg-slate-800/80 border-slate-700 text-slate-500'
+                        : `w-6 h-6 ${stageColor(win.code)} ${isPastStage ? 'opacity-70' : ''}`
+                  }`}
+                >
+                  <EtapaCicloIcon code={win.code} nombre={win.label} size={isCurrent ? 15 : 12} strokeWidth={2.25} />
+                </div>
+              </React.Fragment>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Contador de días del ciclo: dato que ya calcula getCurrentStage,
+          antes escondido en un tooltip. */}
+      {estimatedCurrent && estimatedCurrent.daysElapsed >= 0 && (
+        <p className="text-2xs text-slate-500 mb-3 flex items-center gap-1">
+          <Timer size={10} className="text-morpho shrink-0" />
+          Día {estimatedCurrent.daysElapsed} desde la siembra
+        </p>
+      )}
 
       {isGenericEstimate && !compact && (
         <div className="flex items-start gap-1.5 bg-amber-900/20 border border-amber-800/40 rounded-lg px-2.5 py-2 mb-3">
@@ -109,15 +177,20 @@ export default function PhenologyTimeline({
         </div>
       )}
 
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1">
         {windows.map((win, i) => {
           const obs = observedMap[win.code];
           const isObservedCurrent = obs && obs.code === win.code;
           const isEstimatedCurrent = estimatedCurrent && estimatedCurrent.stage.code === win.code && !isObservedCurrent;
           const isPast = obs && windows.findIndex((w) => w.code === obs.code) > i;
+          const isNow = i === currentIdx;
+          const windowDays = stageWindowDays(win);
 
           return (
-            <div key={win.code} className={`flex gap-2 ${compact ? 'items-center' : ''}`}>
+            <div
+              key={win.code}
+              className={`flex gap-2 px-1.5 py-1 rounded-[var(--r-sm,12px)] transition-colors duration-[var(--dur-estado,0.18s)] ${compact ? 'items-center' : ''} ${isNow ? 'bg-emerald-500/[0.08] border border-emerald-700/40' : 'border border-transparent'}`}
+            >
               {/* Indicador de etapa: badge con GLIFO de la etapa (set
                   compartido EtapaCicloIcon). Conserva los estados visuales:
                   observado (ring emerald), estimado (ring morpho + borde
@@ -126,15 +199,22 @@ export default function PhenologyTimeline({
                 <div className={`w-5 h-5 rounded-full border grid place-items-center ${stageColor(win.code)} ${isObservedCurrent ? 'ring-2 ring-emerald-400/50' : ''} ${isEstimatedCurrent ? 'ring-2 ring-morpho/40 border-dashed' : ''} ${isPast ? 'opacity-50' : ''}`}>
                   <EtapaCicloIcon code={win.code} nombre={win.label} size={11} strokeWidth={2.25} />
                 </div>
-                {i < windows.length - 1 && <div className="w-px h-3 bg-slate-700" />}
+                {i < windows.length - 1 && (
+                  <div className={`w-px h-3 ${currentIdx >= 0 && i < currentIdx ? 'bg-emerald-600/60' : 'bg-slate-700'}`} />
+                )}
               </div>
 
               {/* Contenido */}
               <div className={`flex-1 min-w-0 ${compact ? 'flex items-center gap-2' : ''}`}>
                 <div className={`flex items-center gap-1.5 ${isPast ? 'opacity-50' : ''}`}>
-                  <span className={`text-sm font-medium ${isObservedCurrent ? 'text-emerald-300' : 'text-slate-200'}`}>
+                  <span className={`text-sm font-medium ${isObservedCurrent ? 'text-emerald-300' : isNow ? 'text-emerald-200' : 'text-slate-200'}`}>
                     {win.label}
                   </span>
+                  {isNow && (
+                    <span className="text-3xs font-bold uppercase tracking-wide text-emerald-300 bg-emerald-900/50 border border-emerald-700/50 rounded-[var(--r-pill,999px)] px-1.5 py-px">
+                      Ahora
+                    </span>
+                  )}
                   {obs && (
                     <span className="inline-flex items-center gap-0.5 text-2xs text-emerald-400" title="Observado">
                       <Eye size={10} />
@@ -154,6 +234,15 @@ export default function PhenologyTimeline({
                       <Clock size={9} />
                       est: {formatWindow(win)}
                     </span>
+
+                    {/* Ancho de la ventana en días: formato de windowStart/
+                        windowEnd ya calculados, para dimensionar cada etapa
+                        sin hacer cuentas con el calendario. */}
+                    {windowDays !== null && (
+                      <span className="text-3xs text-slate-500 bg-slate-800/80 border border-slate-700/60 rounded-[var(--r-pill,999px)] px-1.5 py-px shrink-0">
+                        ~{windowDays} días
+                      </span>
+                    )}
 
                     {obs && (
                       <span className="text-2xs text-emerald-400/80 flex items-center gap-0.5">


### PR DESCRIPTION
- PhenologyTimeline: arco horizontal siembra→cosecha con los glifos del set
  EtapaCicloIcon; lo recorrido en verde, la etapa actual con anillo y nodo
  mayor, lo pendiente atenuado (resumen decorativo, aria-hidden; la info
  accesible sigue en la lista).
- Etapa actual destacada en la lista: fila con fondo/borde emerald + chip
  "Ahora"; conectores verticales recorridos en verde.
- Duración por etapa: chip "~N días" formateando windowStart/windowEnd ya
  calculados (cero lógica nueva de fechas) + contador "Día N desde la
  siembra" que antes vivía escondido en un tooltip.
- Tokens unificados (tokens.css): --r-md/--r-sm/--r-pill, --sombra-1/2,
  --dur-estado, coherente con las cards del directorio/calendario.
- CicloDetalle: chip de la etapa actual resaltado en el selector
  "¿Cambió de etapa?" (aria-pressed), coherente con el arco.

Sin cambios de lógica de datos/fechas: phenologyCalculator intacto.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
