### PR TITLE
feat(animales): pasada visual del módulo animal — ficha por animal, secciones con identidad y chequeo con avance

### DIFF
--- a/src/components/AbejasScreen.jsx
+++ b/src/components/AbejasScreen.jsx
@@ -5,6 +5,7 @@ import {
 import { ScreenShell } from './common/ScreenShell';
 import FuentesAnimal from './common/FuentesAnimal';
 import ChecklistManejo from './common/ChecklistManejo';
+import { SeccionAnimal, FichaAnimalHero } from './common/SeccionAnimal';
 
 /**
  * AbejasScreen — vertical de abejas y apicultura del módulo Animales.
@@ -21,19 +22,8 @@ import ChecklistManejo from './common/ChecklistManejo';
  * separación entre apiarios y meliponarios.
  */
 
-function SeccionCard({ Icon, color, titulo, children }) {
-  return (
-    <section className={`rounded-2xl border ${color.border} ${color.bg} p-4`}>
-      <h2 className={`flex items-center gap-2 text-base font-bold ${color.text}`}>
-        {Icon && <Icon size={18} aria-hidden="true" />}
-        {titulo}
-      </h2>
-      <div className="mt-2 text-sm text-slate-200/90 leading-relaxed space-y-2">
-        {children}
-      </div>
-    </section>
-  );
-}
+// Capa visual compartida del módulo Animales (cinta + disco tonal + tokens).
+const SeccionCard = SeccionAnimal;
 
 // Tipos de abeja manejados en Colombia (FEDEABEJA, ICA).
 const TIPOS = [
@@ -46,16 +36,30 @@ export default function AbejasScreen({ onBack, onHome }) {
   return (
     <ScreenShell title="Abejas y apicultura" icon={Hexagon} onBack={onBack} onHome={onHome}>
       <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
-        <p className="text-sm text-slate-300 leading-relaxed">
-          Las abejas te dan miel y cera, pero su mayor aporte es invisible:
-          polinizan tus cultivos y mejoran el cuaje y la cosecha. Cuidarlas es
-          cuidar tu finca entera.
-        </p>
+        {/* Ficha de identidad del animal — emoji + produce + aporte, de un vistazo. */}
+        <FichaAnimalHero
+          emoji="🐝"
+          titulo="Abejas y apicultura"
+          descripcion="Las abejas te dan miel y cera, pero su mayor aporte es invisible: polinizan tus cultivos y mejoran el cuaje y la cosecha. Cuidarlas es cuidar tu finca entera."
+          produce={[
+            { emoji: '🍯', label: 'Miel' },
+            { emoji: '🕯️', label: 'Cera' },
+            { emoji: '🌸', label: 'Polinización' },
+          ]}
+          aporte="Aporte al ciclo: polinizan tus cultivos — más cuaje y más cosecha"
+          tone={{
+            border: 'border-yellow-600/40',
+            bg: 'bg-gradient-to-br from-yellow-500/25 to-amber-400/10',
+            halo: 'bg-yellow-400/20',
+            chip: 'border-yellow-500/40 bg-yellow-500/15 text-yellow-100',
+            aporte: 'text-yellow-300',
+          }}
+        />
 
         {/* 1. Colmenas */}
         <SeccionCard
           Icon={Info}
-          color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200' }}
+          color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200', bar: 'from-sky-400 to-cyan-300', disc: 'bg-sky-400/15' }}
           titulo="Tus colmenas"
         >
           <p>Anota lo básico de tu apiario:</p>
@@ -67,9 +71,9 @@ export default function AbejasScreen({ onBack, onHome }) {
           </ul>
           <div className="mt-2 space-y-1.5">
             {TIPOS.map((t) => (
-              <div key={t.nombre} className="rounded-lg bg-black/20 border border-slate-700/50 p-2">
-                <p className="text-sm font-bold text-slate-100">{t.nombre}</p>
-                <p className="text-xs text-slate-300/90">{t.nota}</p>
+              <div key={t.nombre} className="rounded-[var(--r-sm,12px)] bg-black/20 border border-slate-700/50 p-2.5">
+                <p className="text-sm font-bold text-slate-100 leading-tight">{t.nombre}</p>
+                <p className="mt-1 text-xs text-slate-300/90 leading-snug">{t.nota}</p>
               </div>
             ))}
           </div>
@@ -78,7 +82,7 @@ export default function AbejasScreen({ onBack, onHome }) {
         {/* 2. Polinización */}
         <SeccionCard
           Icon={Flower2}
-          color={{ border: 'border-fuchsia-700/40', bg: 'bg-fuchsia-900/20', text: 'text-fuchsia-200' }}
+          color={{ border: 'border-fuchsia-700/40', bg: 'bg-fuchsia-900/20', text: 'text-fuchsia-200', bar: 'from-fuchsia-400 to-pink-300', disc: 'bg-fuchsia-400/15' }}
           titulo="Polinización de tus cultivos"
         >
           <p>
@@ -96,7 +100,7 @@ export default function AbejasScreen({ onBack, onHome }) {
         {/* 3. Productos */}
         <SeccionCard
           Icon={Droplets}
-          color={{ border: 'border-amber-700/40', bg: 'bg-amber-900/20', text: 'text-amber-200' }}
+          color={{ border: 'border-amber-700/40', bg: 'bg-amber-900/20', text: 'text-amber-200', bar: 'from-amber-400 to-yellow-300', disc: 'bg-amber-400/15' }}
           titulo="Miel y cera"
         >
           <ul className="space-y-1.5">
@@ -116,7 +120,7 @@ export default function AbejasScreen({ onBack, onHome }) {
         {/* 4. Sanidad real */}
         <SeccionCard
           Icon={HeartPulse}
-          color={{ border: 'border-rose-700/40', bg: 'bg-rose-900/20', text: 'text-rose-200' }}
+          color={{ border: 'border-rose-700/40', bg: 'bg-rose-900/20', text: 'text-rose-200', bar: 'from-rose-400 to-pink-300', disc: 'bg-rose-400/15' }}
           titulo="Sanidad"
         >
           <p>
@@ -151,7 +155,7 @@ export default function AbejasScreen({ onBack, onHome }) {
         {/* 5. Aporte a tu finca — CICLO (polinización, NO abono) */}
         <SeccionCard
           Icon={Recycle}
-          color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200' }}
+          color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200', bar: 'from-lime-400 to-emerald-300', disc: 'bg-lime-400/15' }}
           titulo="Aporte a tu finca"
         >
           <p>

--- a/src/components/AnimalesScreen.jsx
+++ b/src/components/AnimalesScreen.jsx
@@ -91,21 +91,21 @@ function VerticalCard({ v, onNavigate }) {
       type="button"
       onClick={() => onNavigate(v.route)}
       aria-label={`${v.titulo} — ${v.subtitulo}`}
-      className={`group relative w-full text-left rounded-2xl overflow-hidden bg-gradient-to-br ${v.accent} backdrop-blur-xl border ${v.border} p-4 ring-2 ring-white/0 hover:ring-white/30 shadow-lg shadow-black/20 transition-all duration-200 ease-out active:scale-[0.98] hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70`}
+      className={`group relative w-full text-left rounded-[var(--r-lg,20px)] overflow-hidden bg-gradient-to-br ${v.accent} backdrop-blur-xl border ${v.border} p-4 ring-2 ring-white/0 hover:ring-white/30 shadow-[var(--sombra-2,0_6px_18px_rgb(8_30_22/0.22))] motion-safe:transition-all motion-safe:duration-200 ease-out motion-safe:active:scale-[0.98] motion-safe:hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70`}
     >
       {/* Cinta de acento superior: identidad de color del vertical. */}
       <span
         aria-hidden="true"
-        className={`pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${v.bar} opacity-70 group-hover:opacity-100 transition-opacity`}
+        className={`pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${v.bar} opacity-70 group-hover:opacity-100 motion-safe:transition-opacity`}
       />
       <div className="flex items-center gap-3">
         {/* Icono grande sobre disco de halo tonal (mismo patrón que FincaCards). */}
         <span className="relative grid place-items-center shrink-0">
           <span
             aria-hidden="true"
-            className={`absolute inset-0 -m-1 rounded-full ${v.halo} blur-md scale-110 group-hover:scale-125 transition-transform`}
+            className={`absolute inset-0 -m-1 rounded-full ${v.halo} blur-md scale-110 motion-safe:group-hover:scale-125 motion-safe:transition-transform`}
           />
-          <span className="relative w-12 h-12 rounded-xl bg-black/30 flex items-center justify-center text-3xl select-none">
+          <span className="relative w-12 h-12 rounded-[var(--r-sm,12px)] bg-black/30 flex items-center justify-center text-3xl select-none">
             {v.emoji}
           </span>
         </span>
@@ -117,7 +117,7 @@ function VerticalCard({ v, onNavigate }) {
             {v.aporte}
           </p>
         </div>
-        <ChevronRight size={20} className="shrink-0 text-slate-400 group-hover:text-slate-200 transition-colors" aria-hidden="true" />
+        <ChevronRight size={20} className="shrink-0 text-slate-400 group-hover:text-slate-200 motion-safe:transition-colors" aria-hidden="true" />
       </div>
     </button>
   );
@@ -144,7 +144,7 @@ export default function AnimalesScreen({ onBack, onHome, onNavigate }) {
 
         {/* Explicación del CICLO CERRADO: animal → estiércol → biopreparado →
             suelo → planta. Groundeado en biopreparados-seed.json. */}
-        <section className="mt-6 rounded-2xl border border-emerald-700/40 bg-emerald-900/20 p-4">
+        <section className="mt-6 rounded-[var(--r-lg,20px)] border border-emerald-700/40 bg-emerald-900/20 p-4 shadow-[var(--sombra-1,0_1px_2px_rgb(8_30_22/0.18))]">
           <h2 className="flex items-center gap-2 text-base font-bold text-emerald-200">
             <Recycle size={18} aria-hidden="true" />
             El ciclo cerrado de tu finca
@@ -173,7 +173,7 @@ export default function AnimalesScreen({ onBack, onHome, onNavigate }) {
           <button
             type="button"
             onClick={() => go('ciclo_nutrientes')}
-            className="mt-4 w-full min-h-[48px] rounded-xl font-bold text-sm bg-emerald-700 hover:bg-emerald-600 text-white flex items-center justify-center gap-2"
+            className="mt-4 w-full min-h-[48px] rounded-[var(--r-md,16px)] font-bold text-sm bg-emerald-700 hover:bg-emerald-600 active:brightness-90 text-white flex items-center justify-center gap-2 motion-safe:transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70"
           >
             <Recycle size={16} aria-hidden="true" /> Ver ciclo de nutrientes
             <ChevronRight size={16} aria-hidden="true" />

--- a/src/components/GallinasScreen.jsx
+++ b/src/components/GallinasScreen.jsx
@@ -5,6 +5,7 @@ import {
 import { ScreenShell } from './common/ScreenShell';
 import FuentesAnimal from './common/FuentesAnimal';
 import ChecklistManejo from './common/ChecklistManejo';
+import { SeccionAnimal, FichaAnimalHero } from './common/SeccionAnimal';
 
 /**
  * GallinasScreen — vertical de gallinas y aves de corral del módulo Animales.
@@ -23,19 +24,8 @@ import ChecklistManejo from './common/ChecklistManejo';
  * catalog/biopreparados-seed.json (bocashi incluye gallinaza).
  */
 
-function SeccionCard({ Icon, color, titulo, children }) {
-  return (
-    <section className={`rounded-2xl border ${color.border} ${color.bg} p-4`}>
-      <h2 className={`flex items-center gap-2 text-base font-bold ${color.text}`}>
-        {Icon && <Icon size={18} aria-hidden="true" />}
-        {titulo}
-      </h2>
-      <div className="mt-2 text-sm text-slate-200/90 leading-relaxed space-y-2">
-        {children}
-      </div>
-    </section>
-  );
-}
+// Capa visual compartida del módulo Animales (cinta + disco tonal + tokens).
+const SeccionCard = SeccionAnimal;
 
 // Razas reales colombianas / comunes, con propósito (Fenavi, AGROSAVIA).
 const RAZAS = [
@@ -49,16 +39,30 @@ export default function GallinasScreen({ onBack, onHome }) {
   return (
     <ScreenShell title="Gallinas y aves" icon={Bird} onBack={onBack} onHome={onHome}>
       <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
-        <p className="text-sm text-slate-300 leading-relaxed">
-          Las gallinas te dan huevos, carne y un abono de primera (la gallinaza).
-          Bien manejadas, controlan plagas del suelo y cierran el ciclo de
-          nutrientes de tu finca.
-        </p>
+        {/* Ficha de identidad del animal — emoji + produce + aporte, de un vistazo. */}
+        <FichaAnimalHero
+          emoji="🐔"
+          titulo="Gallinas y aves de corral"
+          descripcion="Las gallinas te dan huevos, carne y un abono de primera (la gallinaza). Bien manejadas, controlan plagas del suelo y cierran el ciclo de nutrientes de tu finca."
+          produce={[
+            { emoji: '🥚', label: 'Huevos' },
+            { emoji: '🍗', label: 'Carne' },
+            { emoji: '🌱', label: 'Gallinaza (abono)' },
+          ]}
+          aporte="Aporte al ciclo: la gallinaza es ingrediente del bocashi"
+          tone={{
+            border: 'border-amber-600/40',
+            bg: 'bg-gradient-to-br from-amber-600/25 to-yellow-500/10',
+            halo: 'bg-amber-400/20',
+            chip: 'border-amber-500/40 bg-amber-500/15 text-amber-100',
+            aporte: 'text-amber-300',
+          }}
+        />
 
         {/* 1. Registro básico */}
         <SeccionCard
           Icon={Info}
-          color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200' }}
+          color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200', bar: 'from-sky-400 to-cyan-300', disc: 'bg-sky-400/15' }}
           titulo="Registro básico"
         >
           <p>Anota lo esencial de tu lote para hacerle seguimiento:</p>
@@ -68,32 +72,27 @@ export default function GallinasScreen({ onBack, onHome }) {
             <li>• <span className="font-bold">Propósito:</span> ponedoras (huevo) o engorde (carne).</li>
             <li>• <span className="font-bold">Edad</span> y fecha de entrada del lote.</li>
           </ul>
-          <div className="mt-2 overflow-x-auto">
-            <table className="w-full text-xs border-collapse">
-              <thead>
-                <tr className="text-left text-slate-400 border-b border-slate-700">
-                  <th className="py-1.5 pr-2 font-bold">Raza / línea</th>
-                  <th className="py-1.5 pr-2 font-bold">Propósito</th>
-                  <th className="py-1.5 font-bold">Nota</th>
-                </tr>
-              </thead>
-              <tbody>
-                {RAZAS.map((r) => (
-                  <tr key={r.nombre} className="border-b border-slate-800/60 align-top">
-                    <td className="py-1.5 pr-2 font-bold text-slate-100">{r.nombre}</td>
-                    <td className="py-1.5 pr-2 text-amber-200">{r.proposito}</td>
-                    <td className="py-1.5 text-slate-300/90">{r.nota}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          {/* Razas como mini-fichas apiladas (más legibles en pantalla angosta
+              que una tabla de 3 columnas). Propósito como chip pastilla. */}
+          <div className="mt-2 space-y-1.5">
+            {RAZAS.map((r) => (
+              <div key={r.nombre} className="rounded-[var(--r-sm,12px)] bg-black/20 border border-slate-700/50 p-2.5">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-bold text-slate-100 leading-tight">{r.nombre}</p>
+                  <span className="shrink-0 px-2 py-0.5 rounded-[var(--r-pill,999px)] border border-amber-500/40 bg-amber-500/15 text-[10px] font-bold text-amber-200 leading-tight">
+                    {r.proposito}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-slate-300/90 leading-snug">{r.nota}</p>
+              </div>
+            ))}
           </div>
         </SeccionCard>
 
         {/* 2. Sanidad real */}
         <SeccionCard
           Icon={HeartPulse}
-          color={{ border: 'border-rose-700/40', bg: 'bg-rose-900/20', text: 'text-rose-200' }}
+          color={{ border: 'border-rose-700/40', bg: 'bg-rose-900/20', text: 'text-rose-200', bar: 'from-rose-400 to-pink-300', disc: 'bg-rose-400/15' }}
           titulo="Sanidad"
         >
           <p>
@@ -133,7 +132,7 @@ export default function GallinasScreen({ onBack, onHome }) {
         {/* 3. Manejo */}
         <SeccionCard
           Icon={Sprout}
-          color={{ border: 'border-emerald-700/40', bg: 'bg-emerald-900/20', text: 'text-emerald-200' }}
+          color={{ border: 'border-emerald-700/40', bg: 'bg-emerald-900/20', text: 'text-emerald-200', bar: 'from-emerald-400 to-teal-300', disc: 'bg-emerald-400/15' }}
           titulo="Manejo agroecológico"
         >
           <ul className="space-y-2">
@@ -159,7 +158,7 @@ export default function GallinasScreen({ onBack, onHome }) {
         {/* 4. Producción */}
         <SeccionCard
           Icon={Egg}
-          color={{ border: 'border-amber-700/40', bg: 'bg-amber-900/20', text: 'text-amber-200' }}
+          color={{ border: 'border-amber-700/40', bg: 'bg-amber-900/20', text: 'text-amber-200', bar: 'from-amber-400 to-yellow-300', disc: 'bg-amber-400/15' }}
           titulo="Producción"
         >
           <ul className="space-y-1.5">
@@ -180,7 +179,7 @@ export default function GallinasScreen({ onBack, onHome }) {
         {/* 5. Aporte a tu finca — CICLO CERRADO */}
         <SeccionCard
           Icon={Recycle}
-          color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200' }}
+          color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200', bar: 'from-lime-400 to-emerald-300', disc: 'bg-lime-400/15' }}
           titulo="Aporte a tu finca"
         >
           <p>

--- a/src/components/VacasScreen.jsx
+++ b/src/components/VacasScreen.jsx
@@ -5,6 +5,7 @@ import {
 import { ScreenShell } from './common/ScreenShell';
 import FuentesAnimal from './common/FuentesAnimal';
 import ChecklistManejo from './common/ChecklistManejo';
+import { SeccionAnimal, FichaAnimalHero } from './common/SeccionAnimal';
 
 /**
  * VacasScreen — vertical de ganado bovino del módulo Animales.
@@ -27,19 +28,8 @@ import ChecklistManejo from './common/ChecklistManejo';
  * (ambos atribuidos a Restrepo Rivera).
  */
 
-function SeccionCard({ Icon, color, titulo, children }) {
-  return (
-    <section className={`rounded-2xl border ${color.border} ${color.bg} p-4`}>
-      <h2 className={`flex items-center gap-2 text-base font-bold ${color.text}`}>
-        {Icon && <Icon size={18} aria-hidden="true" />}
-        {titulo}
-      </h2>
-      <div className="mt-2 text-sm text-slate-200/90 leading-relaxed space-y-2">
-        {children}
-      </div>
-    </section>
-  );
-}
+// Capa visual compartida del módulo Animales (cinta + disco tonal + tokens).
+const SeccionCard = SeccionAnimal;
 
 // Razas reales manejadas en Colombia, con propósito (AGROSAVIA, FEDEGAN).
 const RAZAS = [
@@ -55,16 +45,30 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
   return (
     <ScreenShell title="Vacas y ganado" icon={Beef} onBack={onBack} onHome={onHome}>
       <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
-        <p className="text-sm text-slate-300 leading-relaxed">
-          Las vacas te dan leche y carne, y además la boñiga (bovinaza) es uno de
-          los mejores abonos de la finca. Bien manejadas, con árboles y pasto, el
-          ganado cuida el suelo en vez de dañarlo.
-        </p>
+        {/* Ficha de identidad del animal — emoji + produce + aporte, de un vistazo. */}
+        <FichaAnimalHero
+          emoji="🐄"
+          titulo="Vacas y ganado"
+          descripcion="Las vacas te dan leche y carne, y además la boñiga (bovinaza) es uno de los mejores abonos de la finca. Bien manejadas, con árboles y pasto, el ganado cuida el suelo en vez de dañarlo."
+          produce={[
+            { emoji: '🥛', label: 'Leche' },
+            { emoji: '🥩', label: 'Carne' },
+            { emoji: '🌱', label: 'Boñiga (abono)' },
+          ]}
+          aporte="Aporte al ciclo: la boñiga es la base del biol y entra al bocashi"
+          tone={{
+            border: 'border-orange-600/40',
+            bg: 'bg-gradient-to-br from-orange-600/25 to-amber-500/10',
+            halo: 'bg-orange-400/20',
+            chip: 'border-orange-500/40 bg-orange-500/15 text-orange-100',
+            aporte: 'text-orange-300',
+          }}
+        />
 
         {/* 1. Registro básico */}
         <SeccionCard
           Icon={Info}
-          color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200' }}
+          color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200', bar: 'from-sky-400 to-cyan-300', disc: 'bg-sky-400/15' }}
           titulo="Registro básico"
         >
           <p>Anota lo esencial de tu ganado para hacerle seguimiento:</p>
@@ -74,32 +78,27 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
             <li>• <span className="font-bold">Propósito:</span> leche, carne o doble propósito.</li>
             <li>• <span className="font-bold">Edad y estado:</span> ternero, levante, vaca de cría, vaca en producción.</li>
           </ul>
-          <div className="mt-2 overflow-x-auto">
-            <table className="w-full text-xs border-collapse">
-              <thead>
-                <tr className="text-left text-slate-400 border-b border-slate-700">
-                  <th className="py-1.5 pr-2 font-bold">Raza / cruce</th>
-                  <th className="py-1.5 pr-2 font-bold">Propósito</th>
-                  <th className="py-1.5 font-bold">Nota</th>
-                </tr>
-              </thead>
-              <tbody>
-                {RAZAS.map((r) => (
-                  <tr key={r.nombre} className="border-b border-slate-800/60 align-top">
-                    <td className="py-1.5 pr-2 font-bold text-slate-100">{r.nombre}</td>
-                    <td className="py-1.5 pr-2 text-amber-200">{r.proposito}</td>
-                    <td className="py-1.5 text-slate-300/90">{r.nota}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          {/* Razas como mini-fichas apiladas (más legibles en pantalla angosta
+              que una tabla de 3 columnas). Propósito como chip pastilla. */}
+          <div className="mt-2 space-y-1.5">
+            {RAZAS.map((r) => (
+              <div key={r.nombre} className="rounded-[var(--r-sm,12px)] bg-black/20 border border-slate-700/50 p-2.5">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-bold text-slate-100 leading-tight">{r.nombre}</p>
+                  <span className="shrink-0 px-2 py-0.5 rounded-[var(--r-pill,999px)] border border-amber-500/40 bg-amber-500/15 text-[10px] font-bold text-amber-200 leading-tight">
+                    {r.proposito}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-slate-300/90 leading-snug">{r.nota}</p>
+              </div>
+            ))}
           </div>
         </SeccionCard>
 
         {/* 2. Sanidad real */}
         <SeccionCard
           Icon={HeartPulse}
-          color={{ border: 'border-rose-700/40', bg: 'bg-rose-900/20', text: 'text-rose-200' }}
+          color={{ border: 'border-rose-700/40', bg: 'bg-rose-900/20', text: 'text-rose-200', bar: 'from-rose-400 to-pink-300', disc: 'bg-rose-400/15' }}
           titulo="Sanidad"
         >
           <p>
@@ -142,7 +141,7 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
         {/* 3. Manejo — pastoreo rotacional + SILVOPASTOREO (enlaza al proceso) */}
         <SeccionCard
           Icon={Sprout}
-          color={{ border: 'border-emerald-700/40', bg: 'bg-emerald-900/20', text: 'text-emerald-200' }}
+          color={{ border: 'border-emerald-700/40', bg: 'bg-emerald-900/20', text: 'text-emerald-200', bar: 'from-emerald-400 to-teal-300', disc: 'bg-emerald-400/15' }}
           titulo="Manejo agroecológico"
         >
           <ul className="space-y-2">
@@ -164,7 +163,7 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
           <button
             type="button"
             onClick={() => go('seguimiento_silvopastoreo')}
-            className="mt-1 w-full rounded-xl border border-emerald-600/50 bg-emerald-950/40 p-3 flex items-center gap-2.5 text-left hover:border-emerald-500 transition-colors"
+            className="mt-1 w-full min-h-[var(--tap-min,44px)] rounded-[var(--r-md,16px)] border border-emerald-600/50 bg-emerald-950/40 p-3 flex items-center gap-2.5 text-left hover:border-emerald-500 motion-safe:transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70"
           >
             <Trees size={20} className="shrink-0 text-emerald-300" aria-hidden="true" />
             <span className="text-sm text-emerald-100 flex-1">
@@ -177,7 +176,7 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
         {/* 4. Producción */}
         <SeccionCard
           Icon={Milk}
-          color={{ border: 'border-amber-700/40', bg: 'bg-amber-900/20', text: 'text-amber-200' }}
+          color={{ border: 'border-amber-700/40', bg: 'bg-amber-900/20', text: 'text-amber-200', bar: 'from-amber-400 to-yellow-300', disc: 'bg-amber-400/15' }}
           titulo="Producción"
         >
           <ul className="space-y-1.5">
@@ -199,7 +198,7 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
         {/* 5. Aporte a tu finca — CICLO CERRADO (boñiga → biol → suelo → planta) */}
         <SeccionCard
           Icon={Recycle}
-          color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200' }}
+          color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200', bar: 'from-lime-400 to-emerald-300', disc: 'bg-lime-400/15' }}
           titulo="Aporte a tu finca"
         >
           <p>

--- a/src/components/common/ChecklistManejo.jsx
+++ b/src/components/common/ChecklistManejo.jsx
@@ -29,16 +29,37 @@ export default function ChecklistManejo({ titulo = 'Lista de chequeo', items = [
 
   if (total === 0) return null;
 
+  const completo = hechos === total;
+
   return (
-    <section className={`rounded-2xl border ${c.border} ${c.bg} p-4`}>
+    <section className={`rounded-[var(--r-lg,20px)] border ${c.border} ${c.bg} p-4 shadow-[var(--sombra-1,0_1px_2px_rgb(8_30_22/0.18))]`}>
       <div className="flex items-center justify-between gap-2">
         <h2 className={`flex items-center gap-2 text-base font-bold ${c.text}`}>
           <ListChecks size={18} aria-hidden="true" />
           {titulo}
         </h2>
-        <span className="text-xs font-bold text-slate-300/80 tabular-nums" aria-live="polite">
-          {hechos}/{total}
+        <span
+          className={`text-xs font-bold tabular-nums ${completo ? 'text-emerald-300' : 'text-slate-300/80'}`}
+          aria-live="polite"
+        >
+          {completo ? `✓ ${hechos}/${total}` : `${hechos}/${total}`}
         </span>
+      </div>
+      {/* Barra de avance del chequeo — el estado del manejo, de un vistazo. */}
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={hechos}
+        aria-label={`Avance: ${hechos} de ${total} prácticas`}
+        className="mt-2.5 h-1.5 rounded-[var(--r-pill,999px)] bg-black/30 overflow-hidden"
+      >
+        <div
+          className={`h-full rounded-[var(--r-pill,999px)] motion-safe:transition-[width] motion-safe:duration-300 ${
+            completo ? 'bg-emerald-400' : 'bg-emerald-500/70'
+          }`}
+          style={{ width: `${total ? Math.round((hechos / total) * 100) : 0}%` }}
+        />
       </div>
       <ul className="mt-3 space-y-1.5">
         {items.map((item, i) => {
@@ -49,7 +70,11 @@ export default function ChecklistManejo({ titulo = 'Lista de chequeo', items = [
                 type="button"
                 onClick={() => toggle(i)}
                 aria-pressed={on}
-                className="group w-full flex items-start gap-2.5 text-left rounded-xl border border-slate-700/50 bg-black/20 p-2.5 hover:border-slate-500/70 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                className={`group w-full min-h-[var(--tap-min,44px)] flex items-start gap-2.5 text-left rounded-[var(--r-sm,12px)] border p-2.5 motion-safe:transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 ${
+                  on
+                    ? 'border-emerald-700/40 bg-emerald-950/30'
+                    : 'border-slate-700/50 bg-black/20 hover:border-slate-500/70'
+                }`}
               >
                 {on ? (
                   <CheckSquare size={18} className="mt-0.5 shrink-0 text-emerald-300" aria-hidden="true" />

--- a/src/components/common/FuentesAnimal.jsx
+++ b/src/components/common/FuentesAnimal.jsx
@@ -22,7 +22,7 @@ export default function FuentesAnimal({ claves = [], nota }) {
   if (items.length === 0) return null;
 
   return (
-    <section className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4">
+    <section className="rounded-[var(--r-lg,20px)] border border-slate-700/60 bg-slate-900/50 p-4 shadow-[var(--sombra-1,0_1px_2px_rgb(8_30_22/0.18))]">
       <h2 className="flex items-center gap-2 text-base font-bold text-slate-100">
         <BookOpen size={18} aria-hidden="true" />
         Fuentes y saber más
@@ -38,7 +38,7 @@ export default function FuentesAnimal({ claves = [], nota }) {
               href={f.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="group flex items-start gap-2.5 rounded-xl border border-slate-700/60 bg-slate-950/40 p-3 hover:border-sky-500/60 hover:bg-slate-900/70 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70"
+              className="group flex items-start gap-2.5 min-h-[var(--tap-min,44px)] rounded-[var(--r-sm,12px)] border border-slate-700/60 bg-slate-950/40 p-3 hover:border-sky-500/60 hover:bg-slate-900/70 motion-safe:transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70"
             >
               <ExternalLink size={16} className="mt-0.5 shrink-0 text-sky-300 group-hover:text-sky-200" aria-hidden="true" />
               <span className="flex-1 min-w-0">

--- a/src/components/common/SeccionAnimal.jsx
+++ b/src/components/common/SeccionAnimal.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { Recycle } from 'lucide-react';
+
+/**
+ * SeccionAnimal + FichaAnimalHero — capa VISUAL compartida del módulo Animales
+ * (GallinasScreen, VacasScreen, AbejasScreen). Solo presentación: no toca
+ * datos ni lógica. Deduplica el SeccionCard que vivía copiado en las 3
+ * pantallas y le da la misma identidad de las cards ya mergeadas
+ * (SpeciesFicha / FincaCards): tokens globales de radio/sombra (tokens.css),
+ * cinta de acento superior, icono sobre disco tonal y chips pastilla.
+ *
+ * Movimiento gateado con `motion-safe:` (respeta prefers-reduced-motion).
+ */
+
+/**
+ * Tarjeta de sección con cinta de acento e icono en disco tonal.
+ *
+ * @param {{
+ *   Icon?: React.ComponentType,
+ *   color: { border: string, bg: string, text: string, bar?: string, disc?: string },
+ *   titulo: string,
+ *   children: React.ReactNode,
+ * }} props
+ *  - color.bar  (opcional): gradiente tailwind de la cinta superior.
+ *  - color.disc (opcional): fondo tonal del disco del icono.
+ */
+export function SeccionAnimal({ Icon, color, titulo, children }) {
+  return (
+    <section
+      className={`relative overflow-hidden rounded-[var(--r-lg,20px)] border ${color.border} ${color.bg} p-4 shadow-[var(--sombra-1,0_1px_2px_rgb(8_30_22/0.18))]`}
+    >
+      {/* Cinta de acento superior — misma identidad que las cards del hub. */}
+      {color.bar && (
+        <span
+          aria-hidden="true"
+          className={`pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${color.bar} opacity-70`}
+        />
+      )}
+      <h2 className={`flex items-center gap-2.5 text-base font-bold ${color.text}`}>
+        {Icon && (
+          <span
+            aria-hidden="true"
+            className={`grid place-items-center w-8 h-8 shrink-0 rounded-[var(--r-sm,12px)] ${color.disc || 'bg-black/25'}`}
+          >
+            <Icon size={17} />
+          </span>
+        )}
+        {titulo}
+      </h2>
+      <div className="mt-2.5 text-sm text-slate-200/90 leading-relaxed space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * FichaAnimalHero — cabecera de identidad del vertical animal: emoji grande
+ * sobre disco tonal (mismo patrón que la ficha de especie del Directorio),
+ * nombre, descripción corta, chips de lo que PRODUCE y línea del APORTE al
+ * ciclo de la finca. Datos 100% estáticos que ya vivían en el copy.
+ *
+ * @param {{
+ *   emoji: string,
+ *   titulo: string,
+ *   descripcion: string,
+ *   produce: { emoji: string, label: string }[],
+ *   aporte: string,
+ *   tone: { border: string, bg: string, halo: string, chip: string, aporte: string },
+ * }} props
+ */
+export function FichaAnimalHero({ emoji, titulo, descripcion, produce = [], aporte, tone }) {
+  return (
+    <header
+      data-testid="ficha-animal-hero"
+      className={`relative overflow-hidden rounded-[var(--r-xl,24px)] border ${tone.border} ${tone.bg} p-4 shadow-[var(--sombra-2,0_6px_18px_rgb(8_30_22/0.22))]`}
+    >
+      <div className="flex items-start gap-3">
+        {/* Emoji de identidad sobre halo tonal (patrón SpeciesFicha). */}
+        <span className="relative grid place-items-center shrink-0" aria-hidden="true">
+          <span className={`absolute inset-0 -m-1 rounded-full ${tone.halo} blur-md scale-110`} />
+          <span className="relative w-14 h-14 rounded-[var(--r-md,16px)] bg-black/30 border border-white/10 grid place-items-center text-4xl leading-none select-none">
+            {emoji}
+          </span>
+        </span>
+        <div className="flex-1 min-w-0">
+          <h2 className="text-lg font-bold text-white leading-tight">{titulo}</h2>
+          <p className="mt-1 text-sm text-slate-300 leading-relaxed">{descripcion}</p>
+        </div>
+      </div>
+
+      {/* Qué produce — chips pastilla legibles de un vistazo. */}
+      {produce.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-1.5" data-testid="ficha-animal-produce">
+          <span className="text-[10px] uppercase tracking-wide font-bold text-slate-400 mr-0.5">
+            Produce
+          </span>
+          {produce.map((p) => (
+            <span
+              key={p.label}
+              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-[var(--r-pill,999px)] border text-[11px] font-bold leading-tight ${tone.chip}`}
+            >
+              <span aria-hidden="true">{p.emoji}</span>
+              {p.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Aporte al ciclo cerrado de la finca. */}
+      {aporte && (
+        <p className={`mt-2.5 flex items-start gap-1.5 text-xs font-bold ${tone.aporte}`}>
+          <Recycle size={14} className="mt-0.5 shrink-0" aria-hidden="true" />
+          {aporte}
+        </p>
+      )}
+    </header>
+  );
+}
+
+export default SeccionAnimal;

--- a/src/components/common/__tests__/SeccionAnimal.test.jsx
+++ b/src/components/common/__tests__/SeccionAnimal.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Info } from 'lucide-react';
+import { SeccionAnimal, FichaAnimalHero } from '../SeccionAnimal';
+
+const TONE = {
+  border: 'border-amber-600/40',
+  bg: 'bg-gradient-to-br from-amber-600/25 to-yellow-500/10',
+  halo: 'bg-amber-400/20',
+  chip: 'border-amber-500/40 bg-amber-500/15 text-amber-100',
+  aporte: 'text-amber-300',
+};
+
+describe('SeccionAnimal', () => {
+  it('renderiza título y contenido', () => {
+    render(
+      <SeccionAnimal
+        Icon={Info}
+        color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200', bar: 'from-sky-400 to-cyan-300' }}
+        titulo="Registro básico"
+      >
+        <p>Contenido de la sección</p>
+      </SeccionAnimal>,
+    );
+    expect(screen.getByRole('heading', { name: /registro básico/i })).toBeInTheDocument();
+    expect(screen.getByText('Contenido de la sección')).toBeInTheDocument();
+  });
+
+  it('no rompe sin cinta de acento (color.bar opcional)', () => {
+    render(
+      <SeccionAnimal
+        color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200' }}
+        titulo="Sin cinta"
+      >
+        <p>ok</p>
+      </SeccionAnimal>,
+    );
+    expect(screen.getByRole('heading', { name: /sin cinta/i })).toBeInTheDocument();
+  });
+});
+
+describe('FichaAnimalHero', () => {
+  it('renderiza emoji, título, chips de produce y aporte', () => {
+    render(
+      <FichaAnimalHero
+        emoji="🐔"
+        titulo="Gallinas y aves de corral"
+        descripcion="Huevos, carne y gallinaza para su finca."
+        produce={[
+          { emoji: '🥚', label: 'Huevos' },
+          { emoji: '🌱', label: 'Gallinaza (abono)' },
+        ]}
+        aporte="Aporte al ciclo: la gallinaza es ingrediente del bocashi"
+        tone={TONE}
+      />,
+    );
+    expect(screen.getByTestId('ficha-animal-hero')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /gallinas y aves de corral/i })).toBeInTheDocument();
+    expect(screen.getByTestId('ficha-animal-produce')).toHaveTextContent('Huevos');
+    expect(screen.getByTestId('ficha-animal-produce')).toHaveTextContent('Gallinaza (abono)');
+    expect(screen.getByText(/ingrediente del bocashi/i)).toBeInTheDocument();
+  });
+
+  it('omite la fila de produce cuando viene vacía', () => {
+    render(
+      <FichaAnimalHero
+        emoji="🐝"
+        titulo="Abejas"
+        descripcion="Polinización."
+        produce={[]}
+        aporte=""
+        tone={TONE}
+      />,
+    );
+    expect(screen.queryByTestId('ficha-animal-produce')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Qué cambia (solo capa visual)

Pasada visual del vertical animal (hub Animales + Gallinas + Vacas + Abejas). **Cero cambios de datos o lógica** — el contenido sanitario/de manejo queda byte-idéntico.

- **`common/SeccionAnimal.jsx` (nuevo):** deduplica el `SeccionCard` que vivía copiado en las 3 pantallas y lo alinea con las cards ya mergeadas: tokens globales (`--r-lg`, `--sombra-1/2`), cinta de acento superior e icono sobre disco tonal.
- **`FichaAnimalHero`:** cabecera de identidad por animal — emoji propio (🐔 / 🐄 / 🐝) sobre halo tonal (mismo patrón que la ficha de especie del Directorio), chips pastilla de lo que **produce** (huevos, carne, leche, miel, cera, abono, polinización) y línea del **aporte al ciclo cerrado**. Datos 100% estáticos que ya vivían en el copy.
- **Razas legibles:** la tabla de 3 columnas pasa a mini-fichas apiladas con el propósito como chip — mejor en pantalla angosta y con sol directo.
- **`ChecklistManejo`:** barra de avance visible (estado del chequeo de un vistazo), contador con ✓ al completar, filas marcadas con acento esmeralda y `min-h` táctil de 44px.
- **Hub Animales + `FuentesAnimal`:** radios/sombras desde `tokens.css` y todo el movimiento gateado con `motion-safe:` (respeta `prefers-reduced-motion`).
- **Tests:** 4 casos de render del componente compartido nuevo (`npx vitest run src/components/common/__tests__/SeccionAnimal.test.jsx` ✅).

## Verificación
- `npm run build` → ✓ built in 7.70s
- ESLint limpio en los archivos tocados
- `tsc:check`: mismo conteo de diagnósticos que la base (no agrega errores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)