### PR TITLE
feat(fotos): pulir comparador antes/después — fechas por foto, chip de días y slider accesible

### DIFF
--- a/src/components/AssetTimeline.jsx
+++ b/src/components/AssetTimeline.jsx
@@ -173,7 +173,7 @@ const PhotoAttachmentThumb = ({ photoId, timestamp, pending }) => {
 // tener que ir foto por foto. Solo se muestra si hay al menos 2 fotos distintas
 // Y ambas URLs resuelven (usePhotoUrl); si falta alguna, no se renderiza nada
 // (degrada limpio, no deja un hueco roto).
-const PhotoEvolutionSection = ({ oldest, newest }) => {
+const PhotoEvolutionSection = ({ oldest, newest, photoCount = 2 }) => {
   const beforePhoto = usePhotoUrl({ photoId: oldest.photoId });
   const afterPhoto = usePhotoUrl({ photoId: newest.photoId });
 
@@ -182,9 +182,16 @@ const PhotoEvolutionSection = ({ oldest, newest }) => {
 
   return (
     <div className="mb-4 shrink-0" data-testid="asset-timeline-before-after">
-      <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 flex items-center gap-1.5">
-        <Camera size={12} /> Evolución de la planta
-      </h4>
+      <div className="flex items-center justify-between mb-2">
+        <h4 className="text-xs font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1.5">
+          <Camera size={12} className="text-emerald-400" /> Evolución de la planta
+        </h4>
+        {/* Contexto: cuántas fotos tiene la hoja de vida (el slider compara
+            la primera y la última). Solo presentación. */}
+        <span className="text-[10px] font-bold text-slate-400 bg-slate-800/80 border border-slate-700/60 px-2 py-0.5 rounded-[var(--r-pill,999px)] tabular-nums whitespace-nowrap">
+          {photoCount === 2 ? '2 fotos' : `${photoCount} fotos · primera vs última`}
+        </span>
+      </div>
       <BeforeAfterPhoto
         before={{ url: beforePhoto.url, taken_at: oldest.timestamp ? oldest.timestamp * 1000 : null }}
         after={{ url: afterPhoto.url, taken_at: newest.timestamp ? newest.timestamp * 1000 : null }}
@@ -507,7 +514,11 @@ export default function AssetTimeline({ assetId }) {
       </div>
 
       {showPhotoEvolution && (
-        <PhotoEvolutionSection oldest={oldestPhoto} newest={newestPhoto} />
+        <PhotoEvolutionSection
+          oldest={oldestPhoto}
+          newest={newestPhoto}
+          photoCount={photoAttachments.length}
+        />
       )}
 
       {logs.length === 0 ? (

--- a/src/components/BeforeAfterPhoto.jsx
+++ b/src/components/BeforeAfterPhoto.jsx
@@ -14,8 +14,12 @@ import React, { useState, useRef, useCallback, useEffect } from 'react';
  *   - Imagen `after` (más nueva) está clip-path inset desde la derecha,
  *     controlado por `splitPct` (0..100). Default 50.
  *   - Handle vertical en `splitPct%` con icono ↔ centrado, drag horizontal.
- *   - Captions de timestamp legible en cada esquina ("Hace 3 sem" / "Hoy").
- *   - Touch (50px hitbox), keyboard (←→ con focus), mouse (drag).
+ *   - Captions en cada esquina: etiqueta Antes/Ahora + fecha relativa
+ *     ("hace 3 sem") + fecha absoluta es-CO ("12 mar"). Chip superior con los
+ *     días transcurridos entre ambas fotos.
+ *   - Touch (48px hitbox ≥ --tap-min), keyboard (←→/Home/End con focus),
+ *     mouse (drag). Handle con role="slider". Movimiento gateado por
+ *     prefers-reduced-motion (motion-safe) y tokens de tokens.css.
  *
  * Props:
  *   - before: { url, taken_at?, caption? } — foto vieja
@@ -23,10 +27,36 @@ import React, { useState, useRef, useCallback, useEffect } from 'react';
  *   - className: extra clases para wrapper
  */
 
-function formatRelativeTime(isoOrEpoch) {
+function toMs(isoOrEpoch) {
     if (!isoOrEpoch) return null;
     const ts = typeof isoOrEpoch === 'string' ? new Date(isoOrEpoch).getTime() : Number(isoOrEpoch);
-    if (!isFinite(ts)) return null;
+    return isFinite(ts) ? ts : null;
+}
+
+// Fecha absoluta corta es-CO ("12 mar" / "12 mar 2024" si es otro año) — el
+// productor necesita la fecha real de cada foto, no solo "hace 3 sem".
+function formatAbsoluteDate(isoOrEpoch) {
+    const ts = toMs(isoOrEpoch);
+    if (ts == null) return null;
+    const d = new Date(ts);
+    const opts = { day: '2-digit', month: 'short' };
+    if (d.getFullYear() !== new Date().getFullYear()) opts.year = 'numeric';
+    return d.toLocaleDateString('es-CO', opts);
+}
+
+// Días transcurridos entre las dos fotos — enmarca el progreso ("34 días de
+// diferencia") sin que el productor tenga que restar fechas mentalmente.
+function daysBetween(a, b) {
+    const tsA = toMs(a);
+    const tsB = toMs(b);
+    if (tsA == null || tsB == null) return null;
+    const days = Math.round(Math.abs(tsB - tsA) / (24 * 60 * 60 * 1000));
+    return days >= 1 ? days : null;
+}
+
+function formatRelativeTime(isoOrEpoch) {
+    const ts = toMs(isoOrEpoch);
+    if (ts == null) return null;
     const diffMs = Date.now() - ts;
     if (diffMs < 0) return 'hoy';
     const days = Math.floor(diffMs / (24 * 60 * 60 * 1000));
@@ -47,6 +77,9 @@ function formatRelativeTime(isoOrEpoch) {
 
 export default function BeforeAfterPhoto({ before, after, className = '' }) {
     const [splitPct, setSplitPct] = useState(50);
+    // Tras la primera interacción (drag/teclado) el hint "Deslice para
+    // comparar" se desvanece — ya cumplió su función de enseñar el gesto.
+    const [hasInteracted, setHasInteracted] = useState(false);
     const containerRef = useRef(null);
     const draggingRef = useRef(false);
 
@@ -61,6 +94,7 @@ export default function BeforeAfterPhoto({ before, after, className = '' }) {
 
     const onPointerDown = useCallback((e) => {
         draggingRef.current = true;
+        setHasInteracted(true);
         e.currentTarget.setPointerCapture?.(e.pointerId);
         updateFromPointer(e.clientX);
     }, [updateFromPointer]);
@@ -76,11 +110,20 @@ export default function BeforeAfterPhoto({ before, after, className = '' }) {
     }, []);
 
     const onKey = useCallback((e) => {
+        if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) {
+            setHasInteracted(true);
+        }
         if (e.key === 'ArrowLeft') {
             setSplitPct((p) => Math.max(0, p - 5));
             e.preventDefault();
         } else if (e.key === 'ArrowRight') {
             setSplitPct((p) => Math.min(100, p + 5));
+            e.preventDefault();
+        } else if (e.key === 'Home') {
+            setSplitPct(0);
+            e.preventDefault();
+        } else if (e.key === 'End') {
+            setSplitPct(100);
             e.preventDefault();
         }
     }, []);
@@ -94,11 +137,14 @@ export default function BeforeAfterPhoto({ before, after, className = '' }) {
 
     const beforeLabel = before.caption || formatRelativeTime(before.taken_at) || 'antes';
     const afterLabel = after.caption || formatRelativeTime(after.taken_at) || 'ahora';
+    const beforeDate = formatAbsoluteDate(before.taken_at);
+    const afterDate = formatAbsoluteDate(after.taken_at);
+    const elapsedDays = daysBetween(before.taken_at, after.taken_at);
 
     return (
         <div
             ref={containerRef}
-            className={`relative w-full aspect-[4/3] overflow-hidden rounded-2xl border border-slate-700/60 bg-slate-900 select-none touch-none ${className}`}
+            className={`relative w-full aspect-[4/3] overflow-hidden rounded-[var(--r-lg,20px)] border border-slate-700/60 bg-slate-900 shadow-[var(--sombra-1,0_1px_2px_rgb(8_30_22/0.18))] select-none touch-none ${className}`}
             onPointerDown={onPointerDown}
             onPointerMove={onPointerMove}
             onPointerUp={onPointerUp}
@@ -120,20 +166,40 @@ export default function BeforeAfterPhoto({ before, after, className = '' }) {
                 style={{ clipPath: `inset(0 0 0 ${splitPct}%)` }}
             />
 
-            {/* Caption BEFORE — esquina inferior izquierda */}
+            {/* Caption BEFORE — esquina inferior izquierda: etiqueta + fecha
+                relativa + fecha absoluta (el productor necesita saber CUÁNDO
+                fue cada foto, no solo "hace 3 sem"). */}
             <div
-                className="absolute bottom-2 left-2 px-2 py-0.5 rounded-md bg-black/60 backdrop-blur text-[10px] font-medium text-amber-200 uppercase tracking-wide pointer-events-none transition-opacity"
+                className="absolute bottom-2 left-2 px-2 py-1 rounded-[var(--r-xs,8px)] bg-black/60 backdrop-blur pointer-events-none motion-safe:transition-opacity motion-safe:duration-[var(--dur-estado,0.18s)]"
                 style={{ opacity: splitPct > 8 ? 1 : 0 }}
             >
-                {beforeLabel}
+                <span className="block text-[9px] font-black text-amber-300 uppercase tracking-widest leading-tight">
+                    Antes
+                </span>
+                <span className="block text-[10px] font-medium text-slate-100 leading-tight">
+                    {beforeLabel}{beforeDate && beforeLabel !== beforeDate ? ` · ${beforeDate}` : ''}
+                </span>
             </div>
             {/* Caption AFTER — esquina inferior derecha */}
             <div
-                className="absolute bottom-2 right-2 px-2 py-0.5 rounded-md bg-black/60 backdrop-blur text-[10px] font-medium text-emerald-200 uppercase tracking-wide pointer-events-none transition-opacity"
+                className="absolute bottom-2 right-2 px-2 py-1 rounded-[var(--r-xs,8px)] bg-black/60 backdrop-blur text-right pointer-events-none motion-safe:transition-opacity motion-safe:duration-[var(--dur-estado,0.18s)]"
                 style={{ opacity: splitPct < 92 ? 1 : 0 }}
             >
-                {afterLabel}
+                <span className="block text-[9px] font-black text-emerald-300 uppercase tracking-widest leading-tight">
+                    Ahora
+                </span>
+                <span className="block text-[10px] font-medium text-slate-100 leading-tight">
+                    {afterLabel}{afterDate && afterLabel !== afterDate ? ` · ${afterDate}` : ''}
+                </span>
             </div>
+
+            {/* Chip de días transcurridos — enmarca el progreso entre las dos
+                fotos sin obligar a restar fechas. */}
+            {elapsedDays != null && (
+                <span className="absolute top-2 left-1/2 -translate-x-1/2 px-2.5 py-0.5 rounded-[var(--r-pill,999px)] bg-emerald-900/70 border border-emerald-600/50 backdrop-blur text-[10px] font-bold text-emerald-200 tabular-nums pointer-events-none whitespace-nowrap">
+                    {elapsedDays === 1 ? '1 día después' : `${elapsedDays} días después`}
+                </span>
+            )}
 
             {/* Línea vertical en la posición del split */}
             <div
@@ -141,15 +207,18 @@ export default function BeforeAfterPhoto({ before, after, className = '' }) {
                 style={{ left: `${splitPct}%` }}
             />
 
-            {/* Handle visible — circular con icono ↔. 50px touch hitbox */}
+            {/* Handle visible — circular con icono ↔. 48px touch hitbox (≥ --tap-min) */}
             <button
                 type="button"
+                role="slider"
                 aria-label="Mover comparación antes/después"
+                aria-orientation="horizontal"
                 aria-valuemin={0}
                 aria-valuemax={100}
                 aria-valuenow={Math.round(splitPct)}
+                aria-valuetext={`${Math.round(splitPct)} % de la foto de antes visible`}
                 onKeyDown={onKey}
-                className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 w-12 h-12 rounded-full bg-white/95 shadow-xl flex items-center justify-center cursor-ew-resize text-slate-900 hover:scale-110 focus:scale-110 focus:outline-none focus:ring-2 focus:ring-emerald-400 transition-transform"
+                className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 w-12 h-12 min-w-[var(--tap-min,44px)] min-h-[var(--tap-min,44px)] rounded-full bg-white/95 shadow-[var(--sombra-2,0_6px_18px_rgb(8_30_22/0.22))] flex items-center justify-center cursor-ew-resize text-slate-900 motion-safe:hover:scale-110 motion-safe:focus:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 motion-safe:transition-transform motion-safe:duration-[var(--dur-tap,0.12s)]"
                 style={{ left: `${splitPct}%` }}
             >
                 <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -158,9 +227,14 @@ export default function BeforeAfterPhoto({ before, after, className = '' }) {
                 </svg>
             </button>
 
-            {/* Hint inferior — visible primer use */}
-            <p className="absolute top-2 left-1/2 -translate-x-1/2 px-2 py-0.5 rounded-md bg-black/55 backdrop-blur text-[10px] font-medium text-slate-300 pointer-events-none">
-                Desliza para comparar
+            {/* Hint — tono usted; se desvanece tras la primera interacción
+                para no tapar la foto una vez el productor ya entendió el gesto. */}
+            <p
+                className="absolute bottom-10 left-1/2 -translate-x-1/2 px-2 py-0.5 rounded-[var(--r-xs,8px)] bg-black/55 backdrop-blur text-[10px] font-medium text-slate-200 pointer-events-none whitespace-nowrap motion-safe:transition-opacity motion-safe:duration-[var(--dur-estado,0.18s)]"
+                style={{ opacity: hasInteracted ? 0 : 1 }}
+                aria-hidden={hasInteracted}
+            >
+                Deslice para comparar
             </p>
         </div>
     );

--- a/src/components/__tests__/AssetTimeline.beforeAfter.test.jsx
+++ b/src/components/__tests__/AssetTimeline.beforeAfter.test.jsx
@@ -102,9 +102,11 @@ describe('AssetTimeline — comparación antes/después (BeforeAfterPhoto)', () 
 
     expect(screen.getByTestId('asset-timeline-before-after')).toBeTruthy();
     expect(screen.getByText('Evolución de la planta')).toBeTruthy();
-    // BeforeAfterPhoto renderiza el hint "Desliza para comparar" cuando ambas
-    // fotos (before/after) resuelven con URL.
-    expect(screen.getByText('Desliza para comparar')).toBeTruthy();
+    // BeforeAfterPhoto renderiza el hint "Deslice para comparar" (tono usted)
+    // cuando ambas fotos (before/after) resuelven con URL.
+    expect(screen.getByText('Deslice para comparar')).toBeTruthy();
+    // Chip de contexto con el conteo de fotos de la hoja de vida.
+    expect(screen.getByText('2 fotos')).toBeTruthy();
   });
 
   it('no renderiza la comparación si solo hay una foto adjunta', () => {

--- a/src/components/__tests__/BeforeAfterPhoto.test.jsx
+++ b/src/components/__tests__/BeforeAfterPhoto.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import BeforeAfterPhoto from '../BeforeAfterPhoto';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Fechas relativas a "hoy" para que las aserciones no dependan del reloj real.
+const beforeTs = Date.now() - 34 * DAY_MS;
+const afterTs = Date.now();
+
+const beforePhoto = { url: 'blob://foto-vieja', taken_at: beforeTs };
+const afterPhoto = { url: 'blob://foto-nueva', taken_at: afterTs };
+
+describe('BeforeAfterPhoto — comparador visual antes/ahora', () => {
+  it('renderiza etiquetas Antes/Ahora con fecha y el chip de días transcurridos', () => {
+    render(<BeforeAfterPhoto before={beforePhoto} after={afterPhoto} />);
+
+    expect(screen.getByText('Antes')).toBeTruthy();
+    expect(screen.getByText('Ahora')).toBeTruthy();
+    // Fecha relativa de la foto vieja (34 días → "hace 1 mes") + absoluta es-CO.
+    expect(screen.getByText(/hace 1 mes/)).toBeTruthy();
+    // Chip de progreso entre ambas fotos.
+    expect(screen.getByText('34 días después')).toBeTruthy();
+    // Hint en tono usted.
+    expect(screen.getByText('Deslice para comparar')).toBeTruthy();
+  });
+
+  it('expone el handle como slider accesible y responde a teclado (←/→/Home/End)', () => {
+    render(<BeforeAfterPhoto before={beforePhoto} after={afterPhoto} />);
+
+    const handle = screen.getByRole('slider', { name: 'Mover comparación antes/después' });
+    expect(handle.getAttribute('aria-valuenow')).toBe('50');
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    expect(handle.getAttribute('aria-valuenow')).toBe('55');
+
+    fireEvent.keyDown(handle, { key: 'Home' });
+    expect(handle.getAttribute('aria-valuenow')).toBe('0');
+
+    fireEvent.keyDown(handle, { key: 'End' });
+    expect(handle.getAttribute('aria-valuenow')).toBe('100');
+  });
+
+  it('desvanece el hint tras la primera interacción de teclado', () => {
+    render(<BeforeAfterPhoto before={beforePhoto} after={afterPhoto} />);
+
+    const hint = screen.getByText('Deslice para comparar');
+    expect(hint.style.opacity).toBe('1');
+
+    const handle = screen.getByRole('slider', { name: 'Mover comparación antes/después' });
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    expect(hint.style.opacity).toBe('0');
+  });
+
+  it('no renderiza nada si falta la URL de alguna de las dos fotos', () => {
+    const { container } = render(
+      <BeforeAfterPhoto before={{ url: null }} after={afterPhoto} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Qué hace

Pasada VISUAL del comparador antes/después de fotos (`BeforeAfterPhoto`), ya cableado en la hoja de vida de la mata (`AssetDetailView` → `AssetTimeline` → `PhotoEvolutionSection`). Solo presentación — sin cambios en la lógica de datos/fotos.

## Cambios

- **Fechas por foto**: captions con etiqueta *Antes/Ahora* + fecha relativa ("hace 3 sem") + fecha absoluta es-CO ("12 mar"), y chip superior con los **días transcurridos** entre las dos fotos.
- **Accesibilidad**: handle con `role=slider` + `aria-valuetext`, teclas ←/→/Home/End, hitbox ≥ `--tap-min`. Hint en tono usted ("Deslice para comparar") que se desvanece tras la primera interacción.
- **Tokens unificados** (`tokens.css`): `--r-*`, `--sombra-*`, `--dur-*`, `--tap-min`; transiciones gateadas con `motion-safe` (prefers-reduced-motion).
- **Exposición en la ficha**: encabezado de *Evolución de la planta* con chip de conteo ("N fotos · primera vs última").

## Verificación

- `npm run build` ✅
- `npx vitest run` sobre `BeforeAfterPhoto.test.jsx` (nuevo) + `AssetTimeline.beforeAfter.test.jsx` → 6/6 ✅
- ESLint limpio en los 4 archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)