### PR TITLE
feat(mapa): piel Chagra para el mapa de la finca — leyenda, chips de zonas y EmptyState

### DIFF
--- a/src/components/FarmMap.jsx
+++ b/src/components/FarmMap.jsx
@@ -1,9 +1,12 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import { MapPin, Maximize2 } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { wktToGeoJson } from '../utils/geo';
 import { logCache } from '../db/logCache';
+import EmptyState from './common/EmptyState';
+import '../styles/farm-map.css';
 
 /**
  * FarmMap, Vista maestra de activos geolocalizados (Fase 17.2).
@@ -12,6 +15,11 @@ import { logCache } from '../db/logCache';
  * el store, los parsea con `wktToGeoJson` y los dibuja como capas de Leaflet
  * tipadas por `asset_type`. Usa `L.featureGroup` para permitir encuadre
  * automático (fitBounds) tanto global como por zona filtrada.
+ *
+ * Capa visual (pasada 2026-07): chrome de Leaflet con la piel Chagra
+ * (farm-map.css, theme-aware), leyenda de campo, chips de navegación por
+ * zona (solo viewport, no toca datos) y EmptyState estándar. Todo movimiento
+ * de cámara respeta prefers-reduced-motion.
  *
  * Props:
  *   - focusZoneId: UUID de asset--land para filtrar y hacer zoom (drill-down espacial).
@@ -55,6 +63,19 @@ const STYLES = {
   },
 };
 
+// Leyenda de campo: qué significa cada color del mapa. Espeja STYLES /
+// TASK_STYLES — si cambia un color arriba, cambia acá.
+const LEGEND_ASSETS = [
+  { label: 'Zona', color: STYLES.land.color, outline: true },
+  { label: 'Estructura', color: STYLES.structure.color },
+  { label: 'Cultivo', color: STYLES.plant.fillColor },
+];
+
+// Movimiento de cámara accesible: sin animación si el sistema pide calma.
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  !!window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
+
 // Extrae el WKT desde el shape JSON:API de FarmOS.
 const getWkt = (asset) => {
   const geo = asset.attributes?.intrinsic_geometry;
@@ -63,18 +84,33 @@ const getWkt = (asset) => {
   return geo.value || null;
 };
 
+// Id del parent (zona) de un asset, shape JSON:API.
+const getParentId = (asset) => {
+  const rel = asset.relationships?.parent?.data || asset.relationships?.location?.data;
+  return Array.isArray(rel) ? rel[0]?.id : rel?.id;
+};
+
+// Escape mínimo para strings que van dentro del HTML del popup.
+const esc = (s) =>
+  String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
 // Construye el popup HTML (Leaflet acepta string o HTMLElement).
+// Estilos en farm-map.css (.chagra-popup-*), theme-aware.
 const buildPopup = (asset, assetType) => {
   const name = asset.attributes?.name || asset.name || 'Sin nombre';
   const subType = asset.attributes?.land_type || asset.attributes?.sub_type || assetType;
   const notes = asset.attributes?.notes;
   const notesText = typeof notes === 'object' ? notes?.value : notes;
   return `
-    <div style="min-width:180px;font-family:system-ui;">
-      <div style="font-size:10px;text-transform:uppercase;color:#64748b;letter-spacing:0.05em;margin-bottom:2px;">${subType}</div>
-      <div style="font-size:14px;font-weight:700;color:#0f172a;">${name}</div>
-      ${notesText ? `<div style="font-size:11px;color:#475569;margin-top:4px;">${notesText.slice(0, 80)}${notesText.length > 80 ? '…' : ''}</div>` : ''}
-      <button data-asset-id="${asset.id}" class="chagra-popup-logs" style="margin-top:8px;padding:4px 10px;background:#0f172a;color:white;border:none;border-radius:4px;font-size:11px;font-weight:700;cursor:pointer;">Ver logs →</button>
+    <div class="chagra-popup">
+      <div class="chagra-popup-tipo">${esc(subType)}</div>
+      <div class="chagra-popup-nombre">${esc(name)}</div>
+      ${notesText ? `<div class="chagra-popup-notas">${esc(notesText.slice(0, 80))}${notesText.length > 80 ? '…' : ''}</div>` : ''}
+      <button data-asset-id="${esc(asset.id)}" class="chagra-popup-logs chagra-popup-btn">Ver historial →</button>
     </div>
   `;
 };
@@ -92,12 +128,28 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
   const containerRef = useRef(null);
   const mapRef = useRef(null);
   const featureGroupRef = useRef(null);
+  // Capa Leaflet de cada zona, para navegar desde los chips (solo viewport).
+  const landLayersRef = useRef(new Map());
 
   const plants = useAssetStore((s) => s.plants);
   const structures = useAssetStore((s) => s.structures);
   const lands = useAssetStore((s) => s.lands);
 
   const [pendingTasks, setPendingTasks] = useState([]);
+  // Chip activo (id de zona o null = toda la finca). Solo estado visual.
+  const [activeZoneChip, setActiveZoneChip] = useState(null);
+
+  // Chips de navegación: zonas con geometría + conteo de cultivos por zona.
+  // Lectura pura del store (misma relación parent que el filtro del mapa).
+  const zoneChips = useMemo(() => {
+    return lands
+      .filter((land) => getWkt(land))
+      .map((land) => ({
+        id: land.id,
+        name: land.attributes?.name || land.name || 'Sin nombre',
+        plantCount: plants.filter((p) => getParentId(p) === land.id).length,
+      }));
+  }, [lands, plants]);
 
   // Inicialización única del mapa
   useEffect(() => {
@@ -122,6 +174,9 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
       zoom: savedZoom,
       zoomControl: true,
       attributionControl: false,
+      // prefers-reduced-motion: cámara sin animaciones (zoom/fade vía CSS).
+      zoomAnimation: !prefersReducedMotion(),
+      fadeAnimation: !prefersReducedMotion(),
     });
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -146,7 +201,7 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
     map.on('moveend', saveViewport);
     map.on('zoomend', saveViewport);
 
-    // Delegación de click para botones "Ver logs →" dentro de popups
+    // Delegación de click para botones "Ver historial →" dentro de popups
     if (onAssetClick) {
       map.on('popupopen', (e) => {
         const btn = e.popup.getElement()?.querySelector('.chagra-popup-logs');
@@ -163,6 +218,7 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
       map.remove();
       mapRef.current = null;
       featureGroupRef.current = null;
+      landLayersRef.current = new Map();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -192,6 +248,7 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
     if (!map || !fg) return;
 
     fg.clearLayers();
+    landLayersRef.current = new Map();
 
     // Determinar qué assets dibujar según focusZoneId
     let landsToRender = lands;
@@ -200,11 +257,7 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
 
     if (focusZoneId) {
       // Filtrar plants y structures cuyo parent apunte a la zona enfocada
-      const filterByParent = (asset) => {
-        const rel = asset.relationships?.parent?.data || asset.relationships?.location?.data;
-        const parentId = Array.isArray(rel) ? rel[0]?.id : rel?.id;
-        return parentId === focusZoneId;
-      };
+      const filterByParent = (asset) => getParentId(asset) === focusZoneId;
       landsToRender = lands.filter((l) => l.id === focusZoneId);
       structuresToRender = structures.filter(filterByParent);
       plantsToRender = plants.filter(filterByParent);
@@ -227,6 +280,7 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
       if (layer) {
         layer.bindPopup(buildPopup(land, 'Zona'));
         fg.addLayer(layer);
+        landLayersRef.current.set(land.id, layer);
       }
     }
 
@@ -293,11 +347,11 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
         });
 
         const popupHtml = `
-          <div style="min-width:180px;font-family:system-ui;">
-            <div style="font-size:10px;text-transform:uppercase;color:${style.color};font-weight:700;margin-bottom:2px;">${style.label}</div>
-            <div style="font-size:14px;font-weight:700;color:#0f172a;">${taskName}</div>
-            ${notesText ? `<div style="font-size:11px;color:#475569;margin-top:4px;">${notesText.slice(0, 100)}</div>` : ''}
-            <button data-task-id="${task.id}" class="chagra-popup-complete" style="margin-top:8px;padding:6px 12px;background:${style.color};color:white;border:none;border-radius:6px;font-size:12px;font-weight:700;cursor:pointer;width:100%;">Completar ahora ✓</button>
+          <div class="chagra-popup" style="--tarea-color:${style.color}">
+            <div class="chagra-popup-tipo chagra-popup-tipo--tarea">${esc(style.label)}</div>
+            <div class="chagra-popup-nombre">${esc(taskName)}</div>
+            ${notesText ? `<div class="chagra-popup-notas">${esc(notesText.slice(0, 100))}</div>` : ''}
+            <button data-task-id="${esc(task.id)}" class="chagra-popup-complete chagra-popup-btn">Completar ahora ✓</button>
           </div>
         `;
         marker.bindPopup(popupHtml);
@@ -317,20 +371,129 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
     // Encuadre automático: fitBounds si hay capas con geometría
     if (fg.getLayers().length > 0) {
       try {
-        map.fitBounds(fg.getBounds(), { padding: [30, 30], maxZoom: 18 });
+        map.fitBounds(fg.getBounds(), {
+          padding: [30, 30],
+          maxZoom: 18,
+          animate: !prefersReducedMotion(),
+        });
       } catch (err) {
         console.warn('[FarmMap] fitBounds falló:', err.message);
       }
     }
   }, [plants, structures, lands, focusZoneId, showTasks, pendingTasks, onTaskComplete]);
 
+  // Navegación por chip: encuadra la zona y abre su popup. Solo mueve la
+  // cámara — no filtra datos ni toca el store.
+  const goToZone = (zoneId) => {
+    const map = mapRef.current;
+    const layer = landLayersRef.current.get(zoneId);
+    if (!map || !layer) return;
+    setActiveZoneChip(zoneId);
+    const animate = !prefersReducedMotion();
+    if (typeof layer.getBounds === 'function') {
+      map.fitBounds(layer.getBounds(), { padding: [40, 40], maxZoom: 18, animate });
+    } else if (typeof layer.getLatLng === 'function') {
+      map.setView(layer.getLatLng(), 17, { animate });
+    }
+    if (typeof layer.openPopup === 'function') layer.openPopup();
+  };
+
+  // "Toda la finca": vuelve al encuadre global de todo lo dibujado.
+  const goToAll = () => {
+    const map = mapRef.current;
+    const fg = featureGroupRef.current;
+    setActiveZoneChip(null);
+    if (!map || !fg || fg.getLayers().length === 0) return;
+    try {
+      map.fitBounds(fg.getBounds(), {
+        padding: [30, 30],
+        maxZoom: 18,
+        animate: !prefersReducedMotion(),
+      });
+    } catch (_e) { /* noop */ }
+  };
+
+  const isEmpty = plants.length === 0 && structures.length === 0 && lands.length === 0;
+  const showZoneChips = !focusZoneId && zoneChips.length > 0;
+
   return (
-    <div className="relative w-full h-full">
+    <div className="chagra-farm-map relative w-full h-full">
       <div ref={containerRef} className="absolute inset-0 bg-slate-950" />
-      {plants.length === 0 && structures.length === 0 && lands.length === 0 && (
-        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-          <div className="bg-slate-900/90 border border-slate-700 rounded-xl px-6 py-4 text-slate-300 text-sm">
-            Sin activos georreferenciados aún.
+
+      {/* Chips de lugares: navegación entre zonas sin salir del mapa */}
+      {showZoneChips && (
+        <nav className="chagra-map-zonas" aria-label="Ir a un lugar de la finca">
+          <button
+            type="button"
+            className="chagra-map-chip"
+            aria-pressed={activeZoneChip === null}
+            onClick={goToAll}
+            data-testid="farm-map-chip-all"
+          >
+            <Maximize2 size={12} aria-hidden="true" />
+            <span>Toda la finca</span>
+          </button>
+          {zoneChips.map((zone) => (
+            <button
+              key={zone.id}
+              type="button"
+              className="chagra-map-chip"
+              aria-pressed={activeZoneChip === zone.id}
+              onClick={() => goToZone(zone.id)}
+              data-testid={`farm-map-chip-${zone.id}`}
+            >
+              <MapPin size={12} aria-hidden="true" />
+              <span>{zone.name}</span>
+              {zone.plantCount > 0 && (
+                <span
+                  className="chagra-map-chip-num"
+                  aria-label={`${zone.plantCount} cultivos`}
+                >
+                  {zone.plantCount}
+                </span>
+              )}
+            </button>
+          ))}
+        </nav>
+      )}
+
+      {/* Leyenda de campo: qué significa cada color */}
+      {!isEmpty && (
+        <div className="chagra-map-leyenda" data-testid="farm-map-legend">
+          {LEGEND_ASSETS.map((item) => (
+            <span key={item.label} className="chagra-map-leyenda-item">
+              <span
+                aria-hidden="true"
+                className={`chagra-map-leyenda-swatch${item.outline ? ' chagra-map-leyenda-swatch--contorno' : ''}`}
+                style={item.outline ? { color: item.color } : { background: item.color }}
+              />
+              {item.label}
+            </span>
+          ))}
+          {showTasks && Object.entries(TASK_STYLES).map(([type, style]) => (
+            <span key={type} className="chagra-map-leyenda-item">
+              <span
+                aria-hidden="true"
+                className="chagra-map-leyenda-swatch"
+                style={{ background: style.color }}
+              />
+              {style.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Estado vacío honesto: el mapa sigue detrás (navegable), la card invita */}
+      {isEmpty && (
+        <div className="absolute inset-0 z-[500] flex items-center justify-center p-6 pointer-events-none">
+          <div className="chagra-map-empty-card">
+            <EmptyState
+              size="compact"
+              icon={MapPin}
+              title="Sin lugares en el mapa todavía"
+              description="Cuando registre sus zonas y siembras con ubicación, aquí las verá dibujadas sobre su finca."
+              data-testid="farm-map-empty"
+            />
           </div>
         </div>
       )}

--- a/src/components/__tests__/FarmMap.visual.test.jsx
+++ b/src/components/__tests__/FarmMap.visual.test.jsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * FarmMap — capa visual (leyenda de campo, chips de zonas, EmptyState).
+ *
+ * Leaflet es pesado (canvas/tiles) y no es lo que probamos acá: lo
+ * stubbeamos con un doble mínimo. Lo que sí se ejercita de verdad es el
+ * componente React: overlays, estados y navegación por chips (viewport).
+ */
+
+const { mapStub, fgLayers, leafletStub, storeState } = vi.hoisted(() => {
+  const fgLayers = [];
+  const mapStub = {
+    on: vi.fn(),
+    off: vi.fn(),
+    remove: vi.fn(),
+    getCenter: vi.fn(() => ({ lat: 4.53, lng: -73.92 })),
+    getZoom: vi.fn(() => 15),
+    fitBounds: vi.fn(),
+    setView: vi.fn(),
+  };
+  const makeLayer = () => ({
+    bindPopup: vi.fn(),
+    openPopup: vi.fn(),
+    getBounds: vi.fn(() => 'layer-bounds'),
+    getLatLng: vi.fn(() => ({ lat: 0, lng: 0 })),
+  });
+  const fgStub = {
+    addTo: vi.fn(() => fgStub),
+    clearLayers: vi.fn(() => { fgLayers.length = 0; }),
+    addLayer: vi.fn((l) => fgLayers.push(l)),
+    getLayers: vi.fn(() => fgLayers),
+    getBounds: vi.fn(() => 'fg-bounds'),
+  };
+  const leafletStub = {
+    map: vi.fn(() => mapStub),
+    tileLayer: vi.fn(() => ({ addTo: vi.fn() })),
+    featureGroup: vi.fn(() => fgStub),
+    polygon: vi.fn(() => makeLayer()),
+    circleMarker: vi.fn(() => makeLayer()),
+  };
+  const storeState = { current: { plants: [], structures: [], lands: [] } };
+  return { mapStub, fgLayers, leafletStub, storeState };
+});
+
+vi.mock('leaflet', () => ({ default: leafletStub }));
+vi.mock('leaflet/dist/leaflet.css', () => ({}));
+
+// Store: selector-style zustand double, estado por test.
+vi.mock('../../store/useAssetStore', () => ({
+  default: (selector) => selector(storeState.current),
+}));
+
+// logCache toca IndexedDB: doble vacío (solo se usa con showTasks).
+vi.mock('../../db/logCache', () => ({
+  logCache: { getAll: vi.fn(async () => []) },
+}));
+
+import FarmMap from '../FarmMap';
+
+const POLY = 'POLYGON ((-73.92 4.53, -73.91 4.53, -73.91 4.54, -73.92 4.53))';
+
+const makeLand = (id, name) => ({
+  id,
+  type: 'asset--land',
+  attributes: { name, intrinsic_geometry: { value: POLY }, land_type: 'field' },
+});
+
+const makePlant = (id, parentId) => ({
+  id,
+  type: 'asset--plant',
+  attributes: { name: `Planta ${id}` },
+  relationships: { parent: { data: [{ id: parentId, type: 'asset--land' }] } },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fgLayers.length = 0;
+  storeState.current = { plants: [], structures: [], lands: [] };
+  localStorage.clear();
+});
+
+describe('FarmMap — capa visual', () => {
+  test('sin activos: muestra EmptyState honesto y oculta leyenda y chips', () => {
+    render(<FarmMap />);
+
+    expect(screen.getByTestId('farm-map-empty')).toBeInTheDocument();
+    expect(screen.getByText('Sin lugares en el mapa todavía')).toBeInTheDocument();
+    expect(screen.queryByTestId('farm-map-legend')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('farm-map-chip-all')).not.toBeInTheDocument();
+  });
+
+  test('con zonas: chips de navegación con nombre + conteo de cultivos, y leyenda', () => {
+    storeState.current = {
+      lands: [makeLand('z1', 'Era de aromáticas'), makeLand('z2', 'Invernadero')],
+      plants: [makePlant('p1', 'z1'), makePlant('p2', 'z1'), makePlant('p3', 'z2')],
+      structures: [],
+    };
+    render(<FarmMap />);
+
+    // Chips: "Toda la finca" + una por zona con geometría
+    expect(screen.getByTestId('farm-map-chip-all')).toBeInTheDocument();
+    expect(screen.getByText('Era de aromáticas')).toBeInTheDocument();
+    expect(screen.getByText('Invernadero')).toBeInTheDocument();
+    expect(screen.getByLabelText('2 cultivos')).toBeInTheDocument();
+    expect(screen.getByLabelText('1 cultivos')).toBeInTheDocument();
+
+    // Leyenda de campo con los tres tipos base
+    const legend = screen.getByTestId('farm-map-legend');
+    expect(legend).toHaveTextContent('Zona');
+    expect(legend).toHaveTextContent('Estructura');
+    expect(legend).toHaveTextContent('Cultivo');
+
+    // Sin EmptyState cuando hay datos
+    expect(screen.queryByTestId('farm-map-empty')).not.toBeInTheDocument();
+  });
+
+  test('tocar un chip encuadra la zona (fitBounds) y lo marca activo', async () => {
+    storeState.current = {
+      lands: [makeLand('z1', 'Era de aromáticas')],
+      plants: [],
+      structures: [],
+    };
+    render(<FarmMap />);
+
+    const chip = screen.getByTestId('farm-map-chip-z1');
+    const chipAll = screen.getByTestId('farm-map-chip-all');
+    expect(chipAll).toHaveAttribute('aria-pressed', 'true');
+    expect(chip).toHaveAttribute('aria-pressed', 'false');
+
+    mapStub.fitBounds.mockClear();
+    fireEvent.click(chip);
+
+    await waitFor(() => expect(chip).toHaveAttribute('aria-pressed', 'true'));
+    expect(chipAll).toHaveAttribute('aria-pressed', 'false');
+    expect(mapStub.fitBounds).toHaveBeenCalledWith(
+      'layer-bounds',
+      expect.objectContaining({ maxZoom: 18 }),
+    );
+
+    // "Toda la finca" vuelve al encuadre global
+    fireEvent.click(chipAll);
+    await waitFor(() => expect(chipAll).toHaveAttribute('aria-pressed', 'true'));
+    expect(mapStub.fitBounds).toHaveBeenLastCalledWith(
+      'fg-bounds',
+      expect.objectContaining({ maxZoom: 18 }),
+    );
+  });
+
+  test('focusZoneId oculta los chips (drill-down externo manda)', () => {
+    storeState.current = {
+      lands: [makeLand('z1', 'Era de aromáticas')],
+      plants: [],
+      structures: [],
+    };
+    render(<FarmMap focusZoneId="z1" />);
+
+    expect(screen.queryByTestId('farm-map-chip-all')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('farm-map-chip-z1')).not.toBeInTheDocument();
+  });
+
+  test('showTasks agrega los tipos de tarea a la leyenda', () => {
+    storeState.current = {
+      lands: [makeLand('z1', 'Era de aromáticas')],
+      plants: [],
+      structures: [],
+    };
+    render(<FarmMap showTasks />);
+
+    const legend = screen.getByTestId('farm-map-legend');
+    expect(legend).toHaveTextContent('Observación');
+    expect(legend).toHaveTextContent('Cosecha');
+    expect(legend).toHaveTextContent('Mantenimiento');
+  });
+});

--- a/src/styles/farm-map.css
+++ b/src/styles/farm-map.css
@@ -1,0 +1,251 @@
+/* src/styles/farm-map.css
+ * ============================================================================
+ * MAPA DE LA FINCA — piel Chagra para el chrome de Leaflet + overlays propios
+ * (leyenda de campo, chips de lugares). Capa-puente por feature (prefijo
+ * chagra-map-*), bebe de los tokens globales:
+ *   - color: rampas theme-aware --c-slate-* / --c-emerald-* (index.css)
+ *   - radios/sombras/tipo/tacto: --r-* / --sombra-* / --fs-* / --tap-min
+ *     (tokens.css), siempre con fallback byte-idéntico al valor previo.
+ *
+ * Por qué existe: Leaflet trae popups blancos y controles grises que se ven
+ * como un widget ajeno dentro de la app. Acá el mapa habla el mismo idioma
+ * visual que el resto (cards slate, acento esmeralda, pills), y sigue
+ * funcionando en los temas claros porque todo sale de las rampas por tema.
+ * Todo scoped bajo .chagra-farm-map: cero fugas a otros usos de Leaflet.
+ * ============================================================================ */
+
+/* ── Popups: de "widget blanco ajeno" a card Chagra ──────────────────────── */
+.chagra-farm-map .leaflet-popup-content-wrapper {
+  background: rgb(var(--c-slate-900, 15 23 42));
+  color: rgb(var(--c-slate-100, 241 245 249));
+  border: 1px solid rgb(var(--c-slate-700, 51 65 85));
+  border-radius: var(--r-md, 16px);
+  box-shadow: var(--sombra-3, 0 16px 44px rgb(2 6 23 / 0.3));
+}
+
+.chagra-farm-map .leaflet-popup-content {
+  margin: 12px 14px;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.chagra-farm-map .leaflet-popup-tip {
+  background: rgb(var(--c-slate-900, 15 23 42));
+  border: 1px solid rgb(var(--c-slate-700, 51 65 85));
+  box-shadow: none;
+}
+
+.chagra-farm-map .leaflet-popup-close-button {
+  color: rgb(var(--c-slate-400, 148 163 184));
+  font-size: 18px;
+  padding: 6px 8px 0 0;
+}
+
+.chagra-farm-map .leaflet-popup-close-button:hover {
+  color: rgb(var(--c-slate-100, 241 245 249));
+}
+
+/* Contenido del popup (clases inyectadas desde buildPopup) */
+.chagra-popup { min-width: 180px; }
+
+.chagra-popup-tipo {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+  color: rgb(var(--c-slate-400, 148 163 184));
+  margin-bottom: 2px;
+}
+
+.chagra-popup-tipo--tarea { color: var(--tarea-color, rgb(var(--c-morpho, 6 182 212))); }
+
+.chagra-popup-nombre {
+  font-size: 14px;
+  font-weight: 700;
+  color: rgb(var(--c-slate-100, 241 245 249));
+}
+
+.chagra-popup-notas {
+  font-size: 11px;
+  color: rgb(var(--c-slate-400, 148 163 184));
+  margin-top: 4px;
+}
+
+.chagra-popup-btn {
+  margin-top: 8px;
+  padding: 8px 12px;
+  border: none;
+  border-radius: var(--r-sm, 12px);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  width: 100%;
+  transition: filter var(--dur-tap, 0.12s) var(--ease-suave, ease);
+}
+
+.chagra-popup-btn:active { filter: brightness(0.9); }
+
+.chagra-popup-logs {
+  background: rgb(var(--c-emerald-600, 5 150 105));
+  color: #fff;
+}
+
+.chagra-popup-complete {
+  background: var(--tarea-color, rgb(var(--c-emerald-600, 5 150 105)));
+  color: #fff;
+}
+
+/* ── Controles de zoom: mismo chrome que los botones de la app ───────────── */
+.chagra-farm-map .leaflet-control-zoom {
+  border: 1px solid rgb(var(--c-slate-700, 51 65 85));
+  border-radius: var(--r-sm, 12px);
+  box-shadow: var(--sombra-2, 0 6px 18px rgb(2 6 23 / 0.22));
+  overflow: hidden;
+}
+
+.chagra-farm-map .leaflet-control-zoom a {
+  background: rgb(var(--c-slate-900, 15 23 42));
+  color: rgb(var(--c-slate-100, 241 245 249));
+  border-bottom-color: rgb(var(--c-slate-700, 51 65 85));
+  width: 40px;   /* tacto de campo: dedos con tierra, sol directo */
+  height: 40px;
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.chagra-farm-map .leaflet-control-zoom a:hover,
+.chagra-farm-map .leaflet-control-zoom a:focus {
+  background: rgb(var(--c-slate-800, 30 41 59));
+  color: rgb(var(--c-slate-100, 241 245 249));
+}
+
+.chagra-farm-map .leaflet-control-zoom a.leaflet-disabled {
+  background: rgb(var(--c-slate-900, 15 23 42));
+  color: rgb(var(--c-slate-600, 71 85 105));
+}
+
+/* ── Chips de lugares (navegación entre zonas, arriba del mapa) ──────────── */
+.chagra-map-zonas {
+  position: absolute;
+  top: 8px;
+  left: 56px;              /* deja libre el control de zoom (topleft) */
+  right: 8px;
+  z-index: 500;            /* sobre tiles/overlays (400), bajo popups (700) */
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 4px;     /* aire para la sombra al hacer scroll */
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.chagra-map-zonas::-webkit-scrollbar { display: none; }
+
+.chagra-map-chip {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 36px;
+  padding: 6px 12px;
+  border-radius: var(--r-pill, 999px);
+  border: 1px solid rgb(var(--c-slate-700, 51 65 85));
+  background: rgb(var(--c-slate-900, 15 23 42) / 0.92);
+  color: rgb(var(--c-slate-200, 226 232 240));
+  font-size: var(--fs-nota, 0.78rem);
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+  box-shadow: var(--sombra-1, 0 1px 2px rgb(2 6 23 / 0.18));
+  transition:
+    background var(--dur-estado, 0.18s) var(--ease-suave, ease),
+    border-color var(--dur-estado, 0.18s) var(--ease-suave, ease);
+}
+
+.chagra-map-chip:active { filter: brightness(0.9); }
+
+.chagra-map-chip[aria-pressed="true"] {
+  background: rgb(var(--c-emerald-900, 6 78 59) / 0.9);
+  border-color: rgb(var(--c-emerald-600, 5 150 105));
+  color: rgb(var(--c-emerald-300, 110 231 183));
+}
+
+/* Conteo de cultivos dentro del chip: dato, no decoración */
+.chagra-map-chip-num {
+  font-variant-numeric: tabular-nums;
+  font-weight: 900;
+  color: rgb(var(--c-emerald-400, 52 211 153));
+}
+
+.chagra-map-chip[aria-pressed="true"] .chagra-map-chip-num {
+  color: rgb(var(--c-emerald-300, 110 231 183));
+}
+
+/* ── Leyenda de campo (abajo-izquierda): qué significa cada color ────────── */
+.chagra-map-leyenda {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  z-index: 500;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 10px;
+  max-width: calc(100% - 20px);
+  padding: 6px 10px;
+  border-radius: var(--r-sm, 12px);
+  border: 1px solid rgb(var(--c-slate-700, 51 65 85));
+  background: rgb(var(--c-slate-900, 15 23 42) / 0.88);
+  backdrop-filter: blur(4px);
+  box-shadow: var(--sombra-1, 0 1px 2px rgb(2 6 23 / 0.18));
+}
+
+.chagra-map-leyenda-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgb(var(--c-slate-300, 203 213 225));
+}
+
+.chagra-map-leyenda-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+/* Zona = contorno (así se dibuja en el mapa); resto = relleno */
+.chagra-map-leyenda-swatch--contorno {
+  background: transparent;
+  border: 2px solid currentColor;
+  border-radius: 3px;
+}
+
+/* ── Estado vacío: card sobre el mapa (el mapa sigue navegable detrás) ───── */
+.chagra-map-empty-card {
+  pointer-events: none;
+  max-width: 300px;
+  border-radius: var(--r-lg, 20px);
+  border: 1px solid rgb(var(--c-slate-700, 51 65 85));
+  background: rgb(var(--c-slate-900, 15 23 42) / 0.92);
+  backdrop-filter: blur(4px);
+  box-shadow: var(--sombra-2, 0 6px 18px rgb(2 6 23 / 0.22));
+}
+
+/* ── Movimiento: el mapa respeta prefers-reduced-motion ──────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .chagra-farm-map .leaflet-zoom-animated,
+  .chagra-farm-map .leaflet-fade-anim .leaflet-tile,
+  .chagra-farm-map .leaflet-pan-anim .leaflet-map-pane {
+    transition: none !important;
+  }
+
+  .chagra-map-chip,
+  .chagra-popup-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Qué cambia

Pasada **solo visual** sobre `FarmMap` (la vista espacial de los lugares de la finca). La carga de assets, el filtrado por `focusZoneId` y los callbacks (`onAssetClick`/`onTaskComplete`) quedan intactos.

- **`src/styles/farm-map.css` (nueva)** — chrome de Leaflet con la piel de la app: popups y controles de zoom theme-aware (rampas `--c-slate-*` + tokens `--r-*`/`--sombra-*` de `tokens.css`), en vez del widget blanco por defecto. Todo scoped bajo `.chagra-farm-map`, cero fugas a otros usos de Leaflet.
- **Leyenda de campo** (abajo-izquierda): qué significa cada color del mapa — zona/estructura/cultivo, más los tipos de tarea cuando `showTasks` (WorkerDashboard).
- **Chips de lugares** (arriba): navegación entre zonas sin salir del mapa — tocar un chip encuadra la zona, abre su popup y muestra el conteo de cultivos del lugar. Solo mueve la cámara, no filtra datos. Ocultos cuando el drill-down externo manda (`focusZoneId`).
- **Estado vacío** con el `EmptyState` estándar (card sobre el mapa, que sigue navegable detrás). Copy en usted, invitación en vez de aviso frío.
- **Popups** con clases CSS (+ escape HTML de nombre/notas al inyectar) y botón "Ver historial" con acento esmeralda.
- **prefers-reduced-motion**: `fitBounds`/`setView` sin animación, `zoomAnimation`/`fadeAnimation` de Leaflet desactivadas, transiciones de chips/botones en reposo.

## Verificación

- `npm run build` ✅ (artefactos de prebuild restaurados, no van en el commit)
- `npx vitest run src/components/__tests__/FarmMap.visual.test.jsx` ✅ 5/5 (vacío, chips+conteos+leyenda, navegación por chip, focusZoneId, leyenda de tareas)
- Tests existentes de consumidores (`AssetsDashboard.mount/zonaYfinca/virtualizedList`) ✅ 16/16
- ESLint: los 3 hallazgos en `FarmMap.jsx` (2 warnings i18n en `TASK_STYLES`, 1 error `set-state-in-effect`) son **pre-existentes** — verificado linteando la versión original (mismos 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)