### PR TITLE
feat(grafo): detectar self-loops y aristas duplicadas en check-age-integrity

### DIFF
--- a/scripts/__tests__/check-age-integrity.test.mjs
+++ b/scripts/__tests__/check-age-integrity.test.mjs
@@ -65,8 +65,100 @@ describe('checkAgeIntegrity catalog mode', function () {
   });
 });
 
+describe('checkAgeIntegrity self-loops', function () {
+  it('detects self-loop edge (source === target)', function () {
+    var dump = {
+      nodes: [
+        mkNode('a', ['Species'], { origin_layer: 'Co' }),
+        mkNode('b', ['Species'], { origin_layer: 'NON-Co' }),
+      ],
+      edges: [mkEdge('a', 'a'), mkEdge('a', 'b')],
+    };
+    var r = checkAgeIntegrity(dump);
+    expect(r.stats.selfLoops).toBe(1);
+    expect(
+      r.errors.filter(function (e) { return e.indexOf('Self-loop') >= 0; }).length
+    ).toBe(1);
+  });
+  it('does not flag normal edges as self-loops', function () {
+    var dump = {
+      nodes: [
+        mkNode('a', ['Species'], { origin_layer: 'Co' }),
+        mkNode('b', ['Species'], { origin_layer: 'NON-Co' }),
+      ],
+      edges: [mkEdge('a', 'b')],
+    };
+    expect(checkAgeIntegrity(dump).stats.selfLoops).toBe(0);
+  });
+  it('reports multiple self-loops independently', function () {
+    var dump = {
+      nodes: [
+        mkNode('a', ['Species'], { origin_layer: 'Co' }),
+        mkNode('b', ['Species'], { origin_layer: 'NON-Co' }),
+      ],
+      edges: [mkEdge('a', 'a'), mkEdge('b', 'b')],
+    };
+    expect(checkAgeIntegrity(dump).stats.selfLoops).toBe(2);
+  });
+});
+
+describe('checkAgeIntegrity duplicate edges', function () {
+  it('detects duplicate edge (same source+target+label)', function () {
+    var dump = {
+      nodes: [
+        mkNode('a', ['Species'], { origin_layer: 'Co' }),
+        mkNode('b', ['Species'], { origin_layer: 'NON-Co' }),
+      ],
+      edges: [mkEdge('a', 'b'), mkEdge('a', 'b')],
+    };
+    var r = checkAgeIntegrity(dump);
+    expect(r.stats.duplicateEdges).toBe(1);
+    expect(
+      r.errors.filter(function (e) { return e.indexOf('Duplicate') >= 0; }).length
+    ).toBe(1);
+  });
+  it('same source+target but different label is NOT duplicate', function () {
+    var dump = {
+      nodes: [
+        mkNode('a', ['Species'], { origin_layer: 'Co' }),
+        mkNode('b', ['Species'], { origin_layer: 'NON-Co' }),
+      ],
+      edges: [
+        mkEdge('a', 'b', 'COMPATIBLE_WITH'),
+        mkEdge('a', 'b', 'ANTAGONIST_OF'),
+      ],
+    };
+    expect(checkAgeIntegrity(dump).stats.duplicateEdges).toBe(0);
+  });
+  it('reversed direction is NOT duplicate', function () {
+    var dump = {
+      nodes: [
+        mkNode('a', ['Species'], { origin_layer: 'Co' }),
+        mkNode('b', ['Species'], { origin_layer: 'NON-Co' }),
+      ],
+      edges: [mkEdge('a', 'b'), mkEdge('b', 'a')],
+    };
+    expect(checkAgeIntegrity(dump).stats.duplicateEdges).toBe(0);
+  });
+  it('does not flag a single edge as duplicate', function () {
+    var dump = {
+      nodes: [
+        mkNode('a', ['Species'], { origin_layer: 'Co' }),
+        mkNode('b', ['Species'], { origin_layer: 'NON-Co' }),
+      ],
+      edges: [mkEdge('a', 'b')],
+    };
+    expect(checkAgeIntegrity(dump).stats.duplicateEdges).toBe(0);
+  });
+});
+
 describe('checkAgeIntegrity empty', function () {
   it('empty graph is valid', function () {
     expect(checkAgeIntegrity({ nodes: [], edges: [] }).errors).toEqual([]);
+  });
+  it('empty graph reports zero selfLoops and duplicateEdges', function () {
+    var r = checkAgeIntegrity({ nodes: [], edges: [] });
+    expect(r.stats.selfLoops).toBe(0);
+    expect(r.stats.duplicateEdges).toBe(0);
   });
 });

--- a/scripts/check-age-integrity.mjs
+++ b/scripts/check-age-integrity.mjs
@@ -17,7 +17,15 @@ export function isValidOriginLayer(layer) {
 export function checkAgeIntegrity(data, opts) {
   opts = opts || {};
   const errors = [];
-  const stats = { nodes: 0, edges: 0, orphans: 0, invalidEdges: 0, invalidOriginLayer: 0 };
+  const stats = {
+    nodes: 0,
+    edges: 0,
+    orphans: 0,
+    invalidEdges: 0,
+    invalidOriginLayer: 0,
+    selfLoops: 0,
+    duplicateEdges: 0,
+  };
 
   let nodes;
   let edges;
@@ -50,7 +58,27 @@ export function checkAgeIntegrity(data, opts) {
     }
   }
 
+  const seenEdgeKeys = new Set();
   for (const edge of edges) {
+    if (edge.source === edge.target) {
+      errors.push(
+        'Self-loop edge: ' + edge.source + ' -> ' + edge.target +
+        ' (' + (edge.label || 'UNKNOWN') + ')'
+      );
+      stats.selfLoops++;
+    }
+
+    const edgeKey = edge.source + '|' + edge.target + '|' + (edge.label || '');
+    if (seenEdgeKeys.has(edgeKey)) {
+      errors.push(
+        'Duplicate edge: ' + edge.source + ' -> ' + edge.target +
+        ' (' + (edge.label || 'UNKNOWN') + ')'
+      );
+      stats.duplicateEdges++;
+    } else {
+      seenEdgeKeys.add(edgeKey);
+    }
+
     if (!nodeIds.has(edge.source)) {
       errors.push('Invalid edge source: ' + edge.source);
       stats.invalidEdges++;


### PR DESCRIPTION
## Summary
Adds two **additive** checks to `checkAgeIntegrity` in `scripts/check-age-integrity.mjs`:
- **Self-loops**: `edge.source === edge.target` → pushes an error and increments `stats.selfLoops`.
- **Duplicate edges**: same `source + target + label` → pushes an error and increments `stats.duplicateEdges`.

The existing logic for `orphans`, `invalidEdges` and `invalidOriginLayer` is untouched. The duplicate-edge key is built with a `|` separator to avoid spurious collisions (e.g. `a|b|c` vs `ab||c`).

## Files changed
- `scripts/check-age-integrity.mjs` (+30/−1): new stat fields, self-loop and duplicate detection in the existing edges loop.
- `scripts/__tests__/check-age-integrity.test.mjs` (+92): 8 new tests covering self-loops, duplicates, label-sensitivity, direction-sensitivity, and empty-graph stats.

## Test plan
- [`npx vitest run scripts/__tests__/check-age-integrity.test.mjs`](.) → **22/22 pass** (14 existing + 8 new).
- `npx eslint scripts/check-age-integrity.mjs scripts/__tests__/check-age-integrity.test.mjs --max-warnings=0` → clean (exit 0).
- `npm run tsc:check` → exit 0 (`scripts/` is not in `jsconfig.json` include paths, so the checker file is not type-checked; baseline src/ errors are pre-existing and unrelated).

## Risks
- New errors will surface in any pre-existing dump that happens to contain self-loops or duplicate edges. This is the intended behavior (the checker is now stricter), but flagging in case CI on other branches consumes dumps that legitimately contained such edges.
- No public API change beyond two additive stat fields.

## MCP tools used
None required for this task (pure-script checker, no species/plagas/ADRs involved).

Generado por lane glm (GLM-4.6).