### PR TITLE
feat(agente): pulido visual del chat voice-first (burbujas, estados de voz, mic, fuente)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3380,9 +3380,14 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           {/* Fila 1: textarea o waveform de grabación */}
           {state === STATE_RECORDING ? (
             <div className="flex items-center gap-3 px-3 py-3 min-h-[52px]">
-              <span className="relative flex h-3 w-3 shrink-0">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-rose-400 opacity-75" />
-                <span className="relative inline-flex rounded-full h-3 w-3 bg-rose-500" />
+              {/* Onda de voz animada (pulido voice-first 2026-07): reemplaza al
+                  punto rojo estático. Barras que laten en rose — el operador VE
+                  que lo estamos oyendo. CSS en AGENT_COMPOSITOR_CSS (.as-rec-*),
+                  con fallback quieto bajo prefers-reduced-motion. */}
+              <span className="as-rec-wave text-rose-400 shrink-0" aria-hidden="true">
+                {[0, 1, 2, 3, 4].map((i) => (
+                  <span key={i} className="as-rec-bar" style={{ animationDelay: `${i * 0.13}s` }} />
+                ))}
               </span>
               <span className="flex-1 text-sm text-rose-400 font-medium tabular-nums">
                 Grabando… {Math.floor(durationMs / 1000)}s

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -278,6 +278,16 @@ function ConfianzaBadge({ metadata }) {
 export default function ChatBubble({ message, isStreaming = false, promptText, onConsentNeeded, onRetryOrphan }) {
   const isUser = message.role === 'user';
   const showSourceBadges = usePrefsStore((s) => s.showSourceBadges);
+  // Indicador SUTIL de grounding (pulido voice-first 2026-07): además de los
+  // badges detallados (que dependen del pref showSourceBadges), una respuesta
+  // groundeada lleva SIEMPRE un filo esmeralda a la izquierda + un check junto
+  // a la hora. Señal barata de "esto viene respaldado" que el campesino capta
+  // sin leer. Solo lee metadata YA existente en el turno — cero backend nuevo.
+  const isGrounded =
+    !isUser &&
+    !isStreaming &&
+    !message._orphan_recovery &&
+    message?.metadata?.grounded === true;
   // Badge "fuente" solo aplica a respuestas del agente, no del usuario, y
   // no durante streaming (se muestra cuando el turn está estabilizado).
   // Mensajes _orphan_recovery (recuperación de pregunta sin respuesta) no
@@ -323,10 +333,10 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
   };
 
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3`}>
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3.5`}>
       <div className={`flex gap-2 max-w-[85%] ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
         {isUser ? (
-          <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-emerald-600">
+          <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-emerald-600 ring-1 ring-emerald-400/40 shadow-sm shadow-emerald-950/30">
             <User size={16} className="text-white" />
           </div>
         ) : (
@@ -340,11 +350,14 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
         )}
 
         <div
-          className={`rounded-2xl px-4 py-2.5 ${
+          className={`rounded-2xl px-4 py-3 shadow-md ${
             isUser
-              ? 'bg-emerald-700/60 text-white rounded-tr-sm'
-              : 'bg-slate-800/80 text-slate-100 rounded-tl-sm cursor-pointer'
+              ? 'bg-emerald-700/70 text-white rounded-tr-md border border-emerald-500/25 shadow-emerald-950/25'
+              : `bg-slate-800/90 text-slate-100 rounded-tl-md border border-slate-700/60 shadow-slate-950/30 cursor-pointer${
+                  isGrounded ? ' border-l-2 border-l-emerald-400/70' : ''
+                }`
           }`}
+          data-grounded={isGrounded ? 'true' : undefined}
           onDoubleClick={handleBubbleDoubleClick}
           title={!isUser && !isStreaming ? 'Doble click reproduce o silencia esta respuesta' : undefined}
         >
@@ -379,7 +392,7 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
               una respuesta "fantasma". Para el usuario sí mostramos su texto
               tal cual (puede ser vacío sólo si tipeó vacío, que el submit ya
               previene). Cero hype, español colombiano. */}
-          <p className="text-sm leading-relaxed whitespace-pre-wrap">
+          <p className="text-[15px] leading-relaxed whitespace-pre-wrap">
             {!isUser && (typeof message.content !== 'string' || message.content.trim().length === 0)
               ? <span className="italic text-slate-400">No recibí respuesta del asistente. Intenta de nuevo.</span>
               : message.content}
@@ -406,12 +419,29 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
             </div>
           )}
           {message.timestamp && (
-            <p className={`text-[10px] mt-1 ${isUser ? 'text-emerald-300/60' : 'text-slate-500'}`}>
-              {formatTime(message.timestamp)}
-            </p>
+            <div className={`flex items-center gap-1 mt-1.5 ${isUser ? 'justify-end' : ''}`}>
+              {/* Check sutil de grounding: siempre visible en respuestas
+                  respaldadas por el catálogo, aunque los badges detallados
+                  estén apagados en preferencias. Solo lectura de metadata. */}
+              {isGrounded && (
+                <span
+                  className="inline-flex shrink-0 text-emerald-400/80"
+                  title="Respuesta con respaldo del catálogo Chagra"
+                  data-testid="grounded-tick"
+                >
+                  <BadgeCheck size={11} aria-hidden="true" />
+                </span>
+              )}
+              <p className={`text-[10px] ${isUser ? 'text-emerald-200/70' : 'text-slate-500'}`}>
+                {formatTime(message.timestamp)}
+              </p>
+            </div>
           )}
           {isStreaming && (
-            <span className="inline-block w-2 h-2 bg-violet-400 rounded-full ml-1 animate-pulse" />
+            <span
+              className="inline-block w-[3px] h-3.5 ml-1 rounded-full bg-emerald-300/90 animate-pulse align-middle"
+              aria-hidden="true"
+            />
           )}
           {/* Task #194: Botones de feedback 👍/👎 para respuestas del agente */}
           {!isUser && !isStreaming && !message._orphan_recovery && (

--- a/src/components/AgentScreen/VoiceStatusStrip.jsx
+++ b/src/components/AgentScreen/VoiceStatusStrip.jsx
@@ -42,8 +42,22 @@ const STRIP_CSS = `
   display: inline-block; width: 8px; height: 8px; border-radius: 9999px;
   background: currentColor; animation: vsb-dot 1.2s ease-in-out infinite;
 }
+@keyframes vsb-ring {
+  0%   { transform: scale(0.72); opacity: 0.85; }
+  100% { transform: scale(1.65); opacity: 0; }
+}
+.vsb-ring {
+  position: absolute; inset: 0; border-radius: 9999px;
+  border: 2px solid currentColor; pointer-events: none;
+  animation: vsb-ring 1.5s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
+}
+.vsb-ring--late { animation-delay: 0.75s; }
 @media (prefers-reduced-motion: reduce) {
   .vsb-eq-bar, .vsb-dot { animation: none !important; }
+  /* Sin movimiento: las ondas del mic se congelan como un anillo estático
+     tenue — sigue comunicando "escuchando" sin animar. */
+  .vsb-ring { animation: none !important; opacity: 0.35; transform: scale(1.15); }
+  .vsb-ring--late { display: none; }
 }
 `;
 
@@ -100,8 +114,17 @@ export default function VoiceStatusStrip({
                 : 'bg-emerald-900/30 border-emerald-700/50 text-emerald-300'
           }`}
         >
-          <span className="shrink-0 flex items-center justify-center w-9 h-9 rounded-full bg-slate-900/60">
-            {isListening && <Mic size={20} className="animate-pulse" aria-hidden="true" />}
+          <span className="relative shrink-0 flex items-center justify-center w-9 h-9 rounded-full bg-slate-900/60">
+            {/* Escuchando: ondas tipo sonar que emanan del mic (currentColor
+                → hereda el rose del estado). Bajo prefers-reduced-motion se
+                congelan en un anillo estático tenue (CSS de arriba). */}
+            {isListening && (
+              <>
+                <span className="vsb-ring" aria-hidden="true" />
+                <span className="vsb-ring vsb-ring--late" aria-hidden="true" />
+                <Mic size={20} className="animate-pulse" aria-hidden="true" />
+              </>
+            )}
             {isThinking && <ThinkingDots />}
             {isSpeaking && <Equalizer />}
           </span>

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -90,6 +90,37 @@ export const AGENT_COMPOSITOR_CSS = `
   .as-mic-on {
     background: rgb(244,63,94) !important; border-color: rgb(244,63,94) !important;
     color: #fff !important; box-shadow: 0 4px 14px -4px rgba(244,63,94,0.5);
+    /* Pulido voice-first 2026-07: en grabación el mic LATE (pulso de sombra,
+       sin transform — no pelea con el scale(0.9) del :active) y emite ondas
+       concéntricas via pseudo-elementos. Feedback táctil visual inequívoco. */
+    animation: as-mic-rec 1.2s ease-in-out infinite;
+  }
+  @keyframes as-mic-rec {
+    0%, 100% { box-shadow: 0 4px 14px -4px rgba(244,63,94,0.5), 0 0 0 0 rgba(244,63,94,0.40); }
+    50%      { box-shadow: 0 4px 18px -4px rgba(244,63,94,0.65), 0 0 0 9px rgba(244,63,94,0); }
+  }
+  .as-mic-on::before, .as-mic-on::after {
+    content: ''; position: absolute; inset: -3px; border-radius: 50%;
+    border: 2px solid rgba(244,63,94,0.55); pointer-events: none;
+    animation: as-mic-ripple 1.6s cubic-bezier(0.22,0.61,0.36,1) infinite;
+  }
+  .as-mic-on::after { animation-delay: 0.8s; }
+  @keyframes as-mic-ripple {
+    0%   { transform: scale(0.85); opacity: 0.85; }
+    100% { transform: scale(1.45); opacity: 0; }
+  }
+  /* Onda de voz en la fila del compositor mientras graba: barras que suben y
+     bajan con currentColor (rose). Reemplaza al punto rojo estático — el
+     campesino VE que el aparato lo está oyendo. */
+  .as-rec-wave { display: inline-flex; align-items: center; gap: 3px; height: 20px; }
+  .as-rec-bar {
+    width: 3px; height: 100%; border-radius: 2px; background: currentColor;
+    transform-origin: 50% 50%;
+    animation: as-rec-bar 1.05s ease-in-out infinite;
+  }
+  @keyframes as-rec-bar {
+    0%, 100% { transform: scaleY(0.3); opacity: 0.7; }
+    50%      { transform: scaleY(1); opacity: 1; }
   }
   /* TIER 2 #5 (voz punta-a-punta): mic GRANDE — el camino principal para
      baja alfabetización es hablar. 54px + anillo de acento del TEMA
@@ -138,6 +169,13 @@ export const AGENT_COMPOSITOR_CSS = `
     .as-shimmer::after, .as-sending { animation: none !important; }
     .as-tool { animation: none !important; }
     .as-mic-big { animation: none !important; }
+    /* Grabación sin movimiento: cae a un anillo estático (::before congelado
+       a opacidad tenue) + barras quietas a media altura. La señal de estado
+       persiste sin animar. */
+    .as-mic-on { animation: none !important; }
+    .as-mic-on::before { animation: none !important; opacity: 0.5; transform: scale(1.08); }
+    .as-mic-on::after { display: none; }
+    .as-rec-bar { animation: none !important; transform: scaleY(0.55); }
   }
 `;
 


### PR DESCRIPTION
- Burbujas: usuario (esmeralda con borde/sombra, avatar con anillo) vs
  agente (slate con borde) mejor diferenciadas; texto 15px, mas aire y
  esquina asimetrica mas marcada; caret de streaming esmeralda fino.
- Grounding sutil: filo esmeralda a la izquierda + check junto a la hora
  cuando metadata.grounded === true (solo lee estado existente).
- Estados de voz: ondas sonar alrededor del mic en 'escuchando' del
  VoiceStatusStrip (currentColor, congeladas bajo reduced-motion).
- Microfono: en grabacion el boton late (pulso de sombra) y emite ondas
  concentricas; la fila del compositor muestra onda de voz animada en vez
  del punto rojo estatico.
- Cero cambios de logica/props: solo capa visual, testids y aria intactos.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
