### PR TITLE
feat(a11y): mejorar contraste y tamanos tactiles de campo (pantallas de alto trafico)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3259,10 +3259,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           <button
             type="button"
             onClick={() => setAlertContextBanner(null)}
-            className="shrink-0 p-1 rounded-md hover:bg-white/10 text-slate-400"
+            className="tap-target shrink-0 p-1.5 rounded-md hover:bg-white/10 text-slate-400"
             aria-label="Cerrar contexto de alerta"
           >
-            <X size={14} />
+            <X size={16} />
           </button>
         </div>
       )}
@@ -3307,10 +3307,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             <button
               type="button"
               onClick={clearAgentAttachment}
-              className="p-1.5 rounded-full bg-slate-700 hover:bg-slate-600 text-slate-300"
+              className="tap-target p-2 rounded-full bg-slate-700 hover:bg-slate-600 text-slate-300"
               aria-label="Quitar foto"
             >
-              <X size={13} />
+              <X size={15} />
             </button>
           </div>
         )}

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -160,7 +160,7 @@ function FuenteBadge({ metadata }) {
         data-testid="fuente-badge"
         data-source="verifiable-source"
         title={`Esta respuesta cita una fuente verificable (${label}). Abre el recurso citado en una pestaña nueva.`}
-        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-sky-600/20 text-sky-300 border border-sky-700 hover:bg-sky-600/30 underline-offset-2 hover:underline"
+        className="tap-target text-xs px-2.5 py-1.5 rounded-md inline-flex items-center gap-1 mt-1 bg-sky-600/20 text-sky-300 border border-sky-700 hover:bg-sky-600/30 underline-offset-2 hover:underline"
       >
         <ShieldCheck size={12} aria-hidden="true" />
         <span>Fuente verificable: {label}</span>

--- a/src/components/AgentScreen/SuggestedActions.jsx
+++ b/src/components/AgentScreen/SuggestedActions.jsx
@@ -14,7 +14,7 @@ export default function SuggestedActions({ onSelect }) {
             key={idx}
             type="button"
             onClick={() => onSelect(s.text)}
-            className="agent-chip flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium transition-colors"
+            className="agent-chip flex items-center gap-1.5 min-h-[38px] px-3.5 py-2 rounded-full border text-xs font-medium transition-colors"
           >
             <span>{s.icon}</span>
             <span>{s.text}</span>

--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -93,7 +93,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
             type="button"
             onClick={backToSearch}
             aria-label="Volver a la búsqueda"
-            className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
+            className="w-11 h-11 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
           >
             <ChevronLeft size={20} />
           </button>
@@ -119,7 +119,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
             type="button"
             onClick={onBack}
             aria-label="Volver"
-            className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
+            className="w-11 h-11 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
           >
             <ChevronLeft size={20} />
           </button>
@@ -152,7 +152,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
               type="button"
               onClick={() => { setQuery(''); setResults([]); }}
               aria-label="Limpiar búsqueda"
-              className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full hover:bg-slate-800 flex items-center justify-center text-slate-400"
+              className="tap-target absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full hover:bg-slate-800 flex items-center justify-center text-slate-400"
             >
               <X size={16} />
             </button>
@@ -204,7 +204,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
                         <span className="jp-tinta-suave block text-xs italic text-slate-400 leading-tight truncate">{r.cientifico}</span>
                       )}
                       {r.familia && (
-                        <span className="jp-tinta-suave block text-[10px] text-slate-500 leading-tight">{r.familia}</span>
+                        <span className="jp-tinta-suave block text-[11px] text-slate-400 leading-tight">{r.familia}</span>
                       )}
                     </span>
                   </button>

--- a/src/components/DirectorioEspecies/PisoTermicoBand.jsx
+++ b/src/components/DirectorioEspecies/PisoTermicoBand.jsx
@@ -64,7 +64,7 @@ export default function PisoTermicoBand({ pisoTermico }) {
                   title={`${p.label} · ${p.minM}–${p.maxM} msnm`}
                 >
                   {active && (
-                    <span className="absolute inset-0 flex items-center justify-center text-[9px] font-black text-white/90 tracking-tight uppercase">
+                    <span className="piso-band-label absolute inset-0 flex items-center justify-center text-[10px] font-black tracking-tight uppercase">
                       {p.label}
                     </span>
                   )}
@@ -139,7 +139,7 @@ export default function PisoTermicoBand({ pisoTermico }) {
             return (
               <span
                 key={z}
-                className={`px-2 py-0.5 rounded-md border text-[11px] font-bold ${tone.chip}`}
+                className={`px-2.5 py-1 rounded-md border text-xs font-bold ${tone.chip}`}
               >
                 {ZONE_LABEL[z] || z}
               </span>

--- a/src/components/DirectorioEspecies/SpeciesFicha.jsx
+++ b/src/components/DirectorioEspecies/SpeciesFicha.jsx
@@ -100,7 +100,7 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
                   {b.nombre}
                 </p>
                 {b.tipo && (
-                  <span className="text-[10px] uppercase tracking-wide text-teal-400/80">{b.tipo}</span>
+                  <span className="text-[11px] font-semibold uppercase tracking-wide text-teal-300">{b.tipo}</span>
                 )}
                 {b.dosis && (
                   <p className="text-xs text-slate-300 mt-1"><span className="font-semibold text-slate-200">Dosis:</span> {b.dosis}</p>
@@ -109,7 +109,7 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
                   <p className="text-xs text-slate-400 mt-0.5">{b.uso}</p>
                 )}
                 {!b.enCatalogo && (
-                  <p className="text-[10px] text-slate-500 italic mt-0.5">Receta detallada no curada en el catálogo todavía.</p>
+                  <p className="text-[11px] text-slate-400 italic mt-0.5">Receta detallada no curada en el catálogo todavía.</p>
                 )}
               </li>
             ))}
@@ -133,7 +133,7 @@ export default function SpeciesFicha({ ficha, onSelectSpecies }) {
                     ? <ShieldAlert size={14} className="text-rose-300 shrink-0" aria-hidden="true" />
                     : <Bug size={14} className="text-rose-300 shrink-0" aria-hidden="true" />}
                   {a.nombre}
-                  <span className="text-[10px] uppercase tracking-wide text-rose-400/70">{a.tipo}</span>
+                  <span className="text-[11px] font-semibold uppercase tracking-wide text-rose-300">{a.tipo}</span>
                 </p>
                 {a.controladores && a.controladores.length > 0 ? (
                   <p className="text-xs text-emerald-200/90 mt-1">
@@ -213,7 +213,7 @@ function SpeciesPhoto({ imagen, comun }) {
         />
         <path d="M60 105 L60 70" stroke="#065f46" strokeWidth="3" strokeLinecap="round" />
       </svg>
-      <p className="mt-1 flex items-center gap-1.5 text-[11px] text-emerald-200/70">
+      <p className="mt-1 flex items-center gap-1.5 text-xs text-emerald-200/70">
         <ImageOff size={12} aria-hidden="true" /> Sin foto en el catálogo todavía
       </p>
     </div>
@@ -256,7 +256,7 @@ function AssocGroup({ label, icon, tone, items, emptyText, onSelectSpecies }) {
       {list.length === 0 ? (
         <Empty>{emptyText}</Empty>
       ) : (
-        <div className="flex flex-wrap gap-1.5">
+        <div className="flex flex-wrap gap-2">
           {list.map((s) => {
             const clickable = s.enCatalogo && typeof onSelectSpecies === 'function';
             const content = (
@@ -270,12 +270,12 @@ function AssocGroup({ label, icon, tone, items, emptyText, onSelectSpecies }) {
                 key={s.id}
                 type="button"
                 onClick={() => onSelectSpecies(s.id)}
-                className={`px-2 py-1 rounded-md border text-[11px] leading-tight ${TONE} hover:brightness-125 transition`}
+                className={`min-h-[38px] px-3 py-1.5 rounded-lg border text-xs leading-tight ${TONE} hover:brightness-125 transition`}
               >
                 {content}
               </button>
             ) : (
-              <span key={s.id} className={`px-2 py-1 rounded-md border text-[11px] leading-tight ${TONE} opacity-90`}>
+              <span key={s.id} className={`inline-flex items-center px-3 py-1.5 rounded-lg border text-xs leading-tight ${TONE} opacity-90`}>
                 {content}
               </span>
             );

--- a/src/index.css
+++ b/src/index.css
@@ -491,6 +491,35 @@
     -webkit-backdrop-filter: blur(12px);
     backdrop-filter: blur(12px);
   }
+
+  /* ---------------------------------------------------------------------------
+   * TOUCH TARGET DE CAMPO (a11y 2026-07-03 — dedos grandes, sol, guantes).
+   * Área táctil mínima 44×44px (WCAG 2.5.5 / guías iOS-Android) SIN cambiar el
+   * tamaño visual ni el layout: un pseudo-elemento absoluto centrado extiende
+   * el hit-area del control. Aditivo y reutilizable: aplicá `.tap-target` a
+   * cualquier botón/enlace chico (chips, "x" de limpiar, links de badge).
+   * No usar en contenedores con hijos interactivos propios (taparía sus taps).
+   * ------------------------------------------------------------------------- */
+  .tap-target {
+    position: relative;
+  }
+  /* Si el elemento YA está posicionado (chips absolutos como la "x" del
+   * buscador), conservar su posicionamiento — el ::after funciona igual. */
+  .tap-target.absolute {
+    position: absolute;
+  }
+  .tap-target.fixed {
+    position: fixed;
+  }
+  .tap-target::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: max(100%, 44px);
+    height: max(100%, 44px);
+    transform: translate(-50%, -50%);
+  }
 }
 
 /* ===========================================================================

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -678,6 +678,125 @@
 [data-theme="minimalista"] .bg-amber-400\/10,
 [data-theme="verde-vivo"] .bg-amber-400\/10{ background-color: rgb(245 158 11 / 0.16) !important; }
 
+/* ───────────────────────────────────────────────────────────────────────────
+ * §3d. FAMILIAS ESTÁTICAS RESTANTES en temas claros (a11y campo 2026-07-03).
+ * Pantallas de alto tráfico auditadas con sonda WCAG: Directorio de especies
+ * (SpeciesFicha/PisoTermicoBand: teal/rose/orange/indigo), Agente (badges de
+ * fuente de ChatBubble: green/red/sky ya cubierto), Home/Dashboard
+ * (AIStatusFooter/SensorInsightCard/FincaCards: cyan/blue/pink/indigo/teal).
+ * Esas familias NO están en la indirección --c-* (solo slate/emerald/amber),
+ * así que texto -100/-200/-300 claro + tinte bg-*-950/xx o bg-*-500/20 quedaba
+ * claro-sobre-claro (medido 1.0–1.7:1) en los 3 temas claros. Mismo patrón que
+ * el bloque de chips de arriba: texto al tono -800 del MISMO color (conserva
+ * la semántica; 4.8–7.4:1 medido sobre crema/tinte) y tintes oscuros -950/xx
+ * aligerados a un velo claro. Biopunk (oscuro, sin data-theme) NO se toca. */
+
+/* Texto claro → tono -800/-700 de su propia familia (AA sobre crema/papel). */
+[data-theme="nature"] .text-teal-100,
+[data-theme="minimalista"] .text-teal-100,
+[data-theme="verde-vivo"] .text-teal-100,
+[data-theme="nature"] .text-teal-300,
+[data-theme="minimalista"] .text-teal-300,
+[data-theme="verde-vivo"] .text-teal-300{ color: rgb(17 94 89) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-teal-400\/80,
+[data-theme="minimalista"] .text-teal-400\/80,
+[data-theme="verde-vivo"] .text-teal-400\/80{ color: rgb(15 118 110) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-rose-100,
+[data-theme="minimalista"] .text-rose-100,
+[data-theme="verde-vivo"] .text-rose-100,
+[data-theme="nature"] .text-rose-300,
+[data-theme="minimalista"] .text-rose-300,
+[data-theme="verde-vivo"] .text-rose-300,
+[data-theme="nature"] .text-rose-400\/70,
+[data-theme="minimalista"] .text-rose-400\/70,
+[data-theme="verde-vivo"] .text-rose-400\/70{ color: rgb(159 18 57) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-orange-200,
+[data-theme="minimalista"] .text-orange-200,
+[data-theme="verde-vivo"] .text-orange-200{ color: rgb(154 52 18) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-indigo-200,
+[data-theme="minimalista"] .text-indigo-200,
+[data-theme="verde-vivo"] .text-indigo-200,
+[data-theme="nature"] .text-indigo-300,
+[data-theme="minimalista"] .text-indigo-300,
+[data-theme="verde-vivo"] .text-indigo-300{ color: rgb(55 48 163) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-cyan-200,
+[data-theme="minimalista"] .text-cyan-200,
+[data-theme="verde-vivo"] .text-cyan-200{ color: rgb(21 94 117) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-green-300,
+[data-theme="minimalista"] .text-green-300,
+[data-theme="verde-vivo"] .text-green-300{ color: rgb(22 101 52) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-red-200,
+[data-theme="minimalista"] .text-red-200,
+[data-theme="verde-vivo"] .text-red-200{ color: rgb(153 27 27) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-blue-300,
+[data-theme="minimalista"] .text-blue-300,
+[data-theme="verde-vivo"] .text-blue-300{ color: rgb(30 64 175) !important; text-shadow: none !important; }
+[data-theme="nature"] .text-pink-300,
+[data-theme="minimalista"] .text-pink-300,
+[data-theme="verde-vivo"] .text-pink-300{ color: rgb(157 23 77) !important; text-shadow: none !important; }
+
+/* emerald -100 y variantes con alpha: los tokens claros de emerald-100/200 son
+ * VERDES PÁLIDOS (pensados como fill), como texto sobre crema no contrastan
+ * (medido 1.07–1.65). Al verde profundo del tema (AA, 7.2–10:1). */
+[data-theme="nature"] .text-emerald-100,
+[data-theme="minimalista"] .text-emerald-100,
+[data-theme="verde-vivo"] .text-emerald-100,
+[data-theme="nature"] .text-emerald-200\/90,
+[data-theme="minimalista"] .text-emerald-200\/90,
+[data-theme="verde-vivo"] .text-emerald-200\/90,
+[data-theme="nature"] .text-emerald-200\/70,
+[data-theme="minimalista"] .text-emerald-200\/70,
+[data-theme="verde-vivo"] .text-emerald-200\/70{ color: rgb(var(--c-emerald-700)) !important; text-shadow: none !important; }
+
+/* Tintes OSCUROS -950/xx (cards de biopreparados/amenazas/asociaciones de la
+ * ficha de especie): sobre crema sobrevivían como bloques oscuros Tailwind
+ * (no hay --c-*-950 para estas familias). → velo claro de la misma familia. */
+[data-theme="nature"] .bg-teal-950\/30,
+[data-theme="minimalista"] .bg-teal-950\/30,
+[data-theme="verde-vivo"] .bg-teal-950\/30{ background-color: rgb(20 184 166 / 0.12) !important; }
+[data-theme="nature"] .bg-rose-950\/20,
+[data-theme="minimalista"] .bg-rose-950\/20,
+[data-theme="verde-vivo"] .bg-rose-950\/20{ background-color: rgb(244 63 94 / 0.10) !important; }
+[data-theme="nature"] .bg-emerald-950\/30,
+[data-theme="minimalista"] .bg-emerald-950\/30,
+[data-theme="verde-vivo"] .bg-emerald-950\/30{ background-color: rgb(16 185 129 / 0.12) !important; }
+
+/* Rellenos /20 de chips en familias que faltaban (pisos térmicos, badge IA). */
+[data-theme="nature"] .bg-orange-500\/20,
+[data-theme="minimalista"] .bg-orange-500\/20,
+[data-theme="verde-vivo"] .bg-orange-500\/20{ background-color: rgb(249 115 22 / 0.14) !important; }
+[data-theme="nature"] .bg-indigo-500\/20,
+[data-theme="minimalista"] .bg-indigo-500\/20,
+[data-theme="verde-vivo"] .bg-indigo-500\/20{ background-color: rgb(99 102 241 / 0.14) !important; }
+[data-theme="nature"] .bg-cyan-500\/20,
+[data-theme="minimalista"] .bg-cyan-500\/20,
+[data-theme="verde-vivo"] .bg-cyan-500\/20{ background-color: rgb(6 182 212 / 0.14) !important; }
+
+/* Fallback "sin foto" de la ficha de especie: gradiente esmeralda-oscuro fijo
+ * → sobre los temas claros queda un bloque negro-verdoso. Anclado al testid
+ * (patrón §3c) para no arrastrar otros gradientes. */
+[data-theme="nature"] [data-testid="species-photo-fallback"],
+[data-theme="minimalista"] [data-testid="species-photo-fallback"],
+[data-theme="verde-vivo"] [data-testid="species-photo-fallback"]{
+  background-image: none !important;
+  background-color: rgb(var(--c-surface-raised)) !important;
+}
+
+/* Etiqueta de estrato del PisoTermicoBand (Directorio): texto blanco font-black
+ * sobre la franja de color del piso térmico. En biopunk la franja monta sobre
+ * fondo oscuro → blanco + sombra lee bien; en claros la franja translúcida
+ * aclara (blanco medía 1.7–2.1) → tinta oscura con halo claro. */
+.piso-band-label {
+  color: rgba(255, 255, 255, 0.95);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
+}
+[data-theme="nature"] .piso-band-label,
+[data-theme="minimalista"] .piso-band-label,
+[data-theme="verde-vivo"] .piso-band-label{
+  color: rgb(30 26 12);
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.45);
+}
+
 /* Bordes blancos (sólidos y con opacidad) → línea sutil del tema. */
 [data-theme="minimalista"] .border-white,
 [data-theme="minimalista"] [class*="border-white\/"],


### PR DESCRIPTION
## Accesibilidad + contraste de campo — rebanada: familias de color estáticas en temas claros + touch targets (directorio / agente / home)

Contexto: la app la usan campesinos al sol, con teléfonos baratos. Esta rebanada ataca los offenders `bg-*-500/20 + text-*-200` (y `bg-*-950/xx + text-*-100`) de las familias que **no** están en la indirección `--c-*` (solo slate/emerald/amber lo están), más los targets táctiles < 44px de las pantallas de alto tráfico. **Solo capa visual** — cero cambios de props, testids o lógica. Biopunk (tema oscuro base) no se toca, salvo dos mejoras que también le suben contraste.

### Pantallas / elementos tocados

**Directorio de especies** (`DirectorioEspeciesScreen`, `SpeciesFicha`, `PisoTermicoBand`)
- Cards de biopreparados (`bg-teal-950/30 text-teal-100`), amenazas (`bg-rose-950/20 text-rose-100`) y asociaciones (`bg-emerald-950/30 text-emerald-100`): en los 3 temas claros quedaban bloque oscuro/texto casi blanco.
- Chips de piso térmico (`bg-orange-500/20 text-orange-200`, `bg-indigo-500/20 text-indigo-200`): claro-sobre-claro en temas claros.
- Etiqueta de estrato de la banda (Cálido/Templado/…): 9px → 10px, nueva clase `.piso-band-label` (blanco+sombra en biopunk, tinta oscura+halo claro en claros).
- Fallback "sin foto": gradiente esmeralda-oscuro fijo → superficie del tema en claros (anclado a `data-testid`).
- Botones "Volver" 40×40 → 44×44; "x" limpiar búsqueda 32×32 → 36×36 visual + hit-area 44 (`.tap-target`).
- Labels `tipo` de biopreparado/amenaza: 10px `text-*-400/80` → 11px semibold `text-*-300` (biopunk sube de 6.8:1 a 12.8:1; claros vía override).
- Chips de asociaciones clicables: ~26px de alto → `min-h-[38px] px-3 py-1.5`, gap 6→8px; familia en resultados 10px slate-500 → 11px slate-400 (3.75:1 → 6.96:1 en biopunk).

**Agente** (`ChatBubble`, `AgentScreen`, `SuggestedActions`)
- Badges de fuente (`bg-green-600/20 text-green-300`, `bg-red-700/25 text-red-200`): ilegibles en claros → tono -800.
- Link "Fuente verificable" (sky): + `.tap-target` y padding (hit-area 44px).
- Botones "x" (cerrar contexto de alerta, quitar foto adjunta): ~22-25px → `.tap-target` + ícono/padding mayores.
- Chips de sugerencias: ~30px de alto → `min-h-[38px] py-2`.

**Home / dashboard** (vía CSS app-wide, sin tocar componentes)
- Badges IA (`bg-cyan-500/20 text-cyan-200` en AIStatusFooter/SensorInsightCard), ENSO (`text-blue-300`), íconos de tiles (`text-teal/rose/green/indigo/pink-300` en FincaCards): ilegibles en claros → tonos -800 de su misma familia.

### Antes / después de contraste (sonda WCAG, peor caso = crema nature)

| Elemento | Antes | Después |
|---|---|---|
| Ficha biopreparado: `text-teal-100` s/ tinte | 1.64 | **6.77** (teal-800) |
| Label tipo: `text-teal-400/80` s/ tinte | 1.03 | **4.89** (teal-700) |
| Amenazas: `text-rose-100` s/ tinte | 1.28 | **7.05** (rose-800) |
| Chip piso: `text-orange-200` s/ `bg-orange-500/20` | 1.02 | **5.62** (orange-800) |
| Chip piso: `text-indigo-200` s/ `bg-indigo-500/20` | 1.03 | **7.35** (indigo-800) |
| Badge IA home: `text-cyan-200` s/ `bg-cyan-500/20` | 1.08 | **5.64** (cyan-800) |
| Badge chat: `text-green-300` s/ `bg-green-600/20` | 1.00 | **5.07** (green-800) |
| Badge chat: `text-red-200` s/ `bg-red-700/25` | 1.21 | **4.76** (red-800) |
| Asociaciones: `text-emerald-100` s/ tinte | 1.65 | **7.34** (`--c-emerald-700`) |
| Banda piso térmico (label estrato, claros) | 1.7–2.1 | **~8** (tinta oscura) |
| Biopunk: familia resultado `slate-500` → `slate-400` | 3.75 | **6.96** |

Todos los tonos nuevos pasan AA (≥4.5:1) también sobre papel minimalista y crema verde-vivo (6.4–7.6:1 verificado).

### Helper reutilizable
- `.tap-target` (index.css, aditivo): hit-area mínima 44×44 vía pseudo-elemento, sin cambiar tamaño visual ni layout. No se aplica a chips adyacentes en grilla densa (las áreas expandidas se robarían taps entre vecinos) — ahí se subió el tamaño visual.

### Verificación
- `npm run build` ✅ (y las clases nuevas presentes en el bundle CSS)
- `npx vitest run src/components/DirectorioEspecies src/components/AgentScreen src/styles/__tests__` ✅ 13 files / 88 tests
- Contratos de tema (`themes.coverage.test.js`, `verdeVivo.theme.test.js`) ✅ — cambios 100% aditivos al patrón existente de `themes.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
