### PR TITLE
feat(telemetria): pasada visual de widgets de sensores y alertas

### DIFF
--- a/src/components/CriticalAlertBanner.jsx
+++ b/src/components/CriticalAlertBanner.jsx
@@ -127,12 +127,15 @@ export default function CriticalAlertBanner({ onNavigate }) {
       role="alert"
       aria-live="assertive"
       data-testid="critical-alert-banner"
-      className="fixed top-0 inset-x-0 z-[120] bg-red-950/95 border-b-2 border-red-500 backdrop-blur-sm shadow-lg shadow-red-900/40"
+      className="fixed top-0 inset-x-0 z-[120] bg-gradient-to-r from-red-950/95 via-red-900/95 to-red-950/95 border-b-2 border-red-400 backdrop-blur-sm shadow-lg shadow-red-900/50"
     >
+      {/* Fondo rojo oscuro FIJO (no theme-aware a propósito): una crítica se ve
+          igual de alarmante en biopunk y en los temas claros; el texto claro
+          sobre rojo profundo mantiene contraste AA en todos. */}
       <div className="max-w-2xl mx-auto px-3 py-2.5 flex items-start gap-3">
         <span className="relative flex h-6 w-6 shrink-0 items-center justify-center mt-0.5">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500/60" />
-          <AlertTriangle size={20} className="relative text-red-200" />
+          <span className="absolute inline-flex h-full w-full motion-safe:animate-ping rounded-full bg-red-500/60" />
+          <AlertTriangle size={20} className="relative text-red-100" />
         </span>
         <button
           type="button"
@@ -140,17 +143,17 @@ export default function CriticalAlertBanner({ onNavigate }) {
           className="flex-1 text-left min-w-0"
           aria-label={`${top.title}. ${top.cta_label || 'Ver detalle'}`}
         >
-          <p className="text-sm font-bold text-red-100 leading-tight">{top.title}</p>
+          <p className="text-sm font-black text-white leading-tight">{top.title}</p>
           {top.body && (
-            <p className="text-xs text-red-200/90 mt-0.5 line-clamp-2">{top.body}</p>
+            <p className="text-xs text-red-100/90 mt-0.5 line-clamp-2">{top.body}</p>
           )}
-          <span className="inline-flex items-center gap-1 mt-1 text-2xs font-semibold text-red-200 uppercase tracking-wide">
+          <span className="inline-flex items-center gap-1 mt-1.5 px-2.5 py-1 rounded-full bg-red-500/25 border border-red-300/40 text-2xs font-bold text-red-50 uppercase tracking-wide">
             {top.cta_label || 'Ver detalle'}
             <ChevronRight size={12} />
-            {extraCount > 0 && (
-              <span className="ml-2 normal-case opacity-80">+{extraCount} más crítica{extraCount === 1 ? '' : 's'}</span>
-            )}
           </span>
+          {extraCount > 0 && (
+            <span className="ml-2 text-2xs font-semibold text-red-200/90">+{extraCount} más crítica{extraCount === 1 ? '' : 's'}</span>
+          )}
         </button>
         <button
           type="button"

--- a/src/components/IoTSensorCard.jsx
+++ b/src/components/IoTSensorCard.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Activity } from 'lucide-react';
 import Sparkline from './common/Sparkline';
-import Badge from './common/Badge';
 
 /**
  * IoTSensorCard, card de lectura de sensor IoT en estilo HUD industrial.
@@ -12,14 +11,74 @@ import Badge from './common/Badge';
  * cyan lateral, esquinas diagonales recortadas via clip-path, tipografia
  * monoespaciada para los readouts numericos y labels tecnicos.
  *
+ * Pasada visual 2026-07 (legibilidad al sol + temas claros):
+ *   - Readouts mas grandes (text-3xl) con etiqueta de estado explicita
+ *     ("Optima" / "Critica" / "Sin dato") — el estado no depende solo del
+ *     color, se lee tambien como texto (sol directo / daltonismo).
+ *   - El contenedor de cada readout cambia con el estado (tone):
+ *     ok = borde emerald sutil, warn = sky, alert = rose + fondo tintado,
+ *     nodata = borde punteado gris. Todas las clases son del safe set
+ *     theme-aware (tokens CSS-var u overrides en themes.css).
+ *
  * Props:
  *   - title               string    encabezado descriptivo ("INVERNADERO, ZONA A").
  *   - deviceId            string    identificador tecnico en mono ("matera_cocina · zigbee").
  *   - humidity, temperature          valores crudos de Home Assistant (string|null).
  *   - humidityHistory, temperatureHistory   arrays de HA history para las sparklines.
- *   - getHumidityColor, getTemperatureColor   helpers que devuelven clase Tailwind
- *                                             de color segun el valor (critico/optimo/etc).
+ *   - getHumidityMeta, getTemperatureMeta   helpers que devuelven { tone, cls, label }
+ *                                           segun el valor (critico/optimo/etc).
  */
+
+// Estilo del contenedor de cada readout segun el estado semantico (tone).
+// alert lleva fondo tintado + borde fuerte para que la celda entera grite,
+// no solo el numero. nodata usa borde punteado = "aqui falta señal".
+const TONE_BOX = {
+  ok: 'bg-slate-950/60 border border-emerald-500/30',
+  warn: 'bg-sky-950/40 border border-sky-500/40',
+  alert: 'bg-rose-950/20 border border-rose-500/50',
+  nodata: 'bg-slate-950/40 border border-dashed border-slate-600',
+};
+
+// Punto de estado junto a la etiqueta — refuerza el semaforo del readout.
+const TONE_DOT = {
+  ok: 'bg-emerald-400',
+  warn: 'bg-sky-400',
+  alert: 'bg-rose-400 motion-safe:animate-pulse',
+  nodata: 'bg-slate-600',
+};
+
+function SensorReadout({ label, value, unit, meta }) {
+  const { tone = 'nodata', cls = 'text-slate-400', label: stateLabel = '' } = meta || {};
+  const offline = tone === 'nodata';
+  return (
+    <div className={`rounded px-2.5 py-2 min-h-[64px] ${TONE_BOX[tone] || TONE_BOX.nodata}`}>
+      <span className="block text-[9px] text-slate-400 font-mono tracking-widest uppercase mb-0.5">
+        {label}
+      </span>
+      {offline ? (
+        <div className="flex items-baseline gap-1">
+          <span className="text-3xl font-black font-mono leading-none text-slate-600" aria-hidden="true">
+            --
+          </span>
+        </div>
+      ) : (
+        <div className="flex items-baseline gap-1">
+          <span className={`text-3xl font-black font-mono tabular-nums leading-none ${cls}`}>
+            {value}
+          </span>
+          <span className="text-sm text-slate-400 font-mono">{unit}</span>
+        </div>
+      )}
+      <span className="mt-1.5 flex items-center gap-1.5">
+        <span aria-hidden="true" className={`inline-block w-1.5 h-1.5 rounded-full shrink-0 ${TONE_DOT[tone] || TONE_DOT.nodata}`} />
+        <span className={`text-[9px] font-mono font-bold uppercase tracking-widest ${offline ? 'text-slate-500' : cls}`}>
+          {stateLabel}
+        </span>
+      </span>
+    </div>
+  );
+}
+
 export default function IoTSensorCard({
   title,
   deviceId,
@@ -27,13 +86,17 @@ export default function IoTSensorCard({
   temperature,
   humidityHistory,
   temperatureHistory,
-  getHumidityColor,
-  getTemperatureColor,
+  getHumidityMeta,
+  getTemperatureMeta,
 }) {
   const isMissing = (v) => v === null || v === undefined || v === 'unavailable' || v === 'unknown';
-  const humOffline = isMissing(humidity);
-  const tempOffline = isMissing(temperature);
-  const online = !humOffline;
+  const humMeta = isMissing(humidity)
+    ? { tone: 'nodata', cls: 'text-slate-400', label: 'Sin dato' }
+    : getHumidityMeta(humidity);
+  const tempMeta = isMissing(temperature)
+    ? { tone: 'nodata', cls: 'text-slate-400', label: 'Sin dato' }
+    : getTemperatureMeta(temperature);
+  const online = humMeta.tone !== 'nodata' || tempMeta.tone !== 'nodata';
   // Clip-path recorta la esquina superior-derecha en diagonal (~14px),
   // estetica HUD de pantalla de control industrial.
   const hudClip = {
@@ -67,7 +130,7 @@ export default function IoTSensorCard({
                   online ? 'bg-morpho motion-safe:animate-pulse' : 'bg-slate-600'
                 }`}
               />
-              <span className="text-morpho/90 text-2xs font-bold tracking-[0.2em] uppercase">
+              <span className="text-morpho text-2xs font-bold tracking-[0.2em] uppercase">
                 {title}
               </span>
             </div>
@@ -75,55 +138,20 @@ export default function IoTSensorCard({
               {deviceId}
             </span>
           </div>
-          <span className="text-[9px] text-morpho/60 font-mono uppercase tracking-widest shrink-0">
+          <span className="text-[9px] text-morpho/70 font-mono uppercase tracking-widest shrink-0">
             <Activity size={10} className="inline mb-0.5 mr-0.5" />
             IoT
           </span>
         </div>
 
-        {/* Readouts numericos grandes en mono. Si el sensor no reporta
-            (null/undefined/unavailable/unknown) se muestra un Badge OFFLINE
-            en lugar del numero+unidad, evita concatenaciones sin sentido
-            tipo "---%" o "null°C". */}
+        {/* Readouts numericos grandes en mono. El estado (optimo/critico/
+            saturado/sin dato) se comunica por COLOR + ETIQUETA + contenedor
+            tintado — nunca solo por el color del numero. Si el sensor no
+            reporta (null/undefined/unavailable/unknown) se muestra "--" con
+            borde punteado y etiqueta "Sin dato". */}
         <div className="grid grid-cols-2 gap-3 mb-3">
-          <div className="bg-slate-950/60 border border-slate-800 rounded px-2.5 py-1.5 min-h-[56px]">
-            <span className="block text-[9px] text-slate-500 font-mono tracking-widest uppercase mb-0.5">
-              Humedad
-            </span>
-            {humOffline ? (
-              <Badge variant="outline" className="text-slate-500 border-slate-700">
-                OFFLINE
-              </Badge>
-            ) : (
-              <div className="flex items-baseline gap-1">
-                <span
-                  className={`text-2xl font-black font-mono tabular-nums leading-none ${getHumidityColor(humidity)}`}
-                >
-                  {humidity}
-                </span>
-                <span className="text-xs text-slate-500 font-mono">%</span>
-              </div>
-            )}
-          </div>
-          <div className="bg-slate-950/60 border border-slate-800 rounded px-2.5 py-1.5 min-h-[56px]">
-            <span className="block text-[9px] text-slate-500 font-mono tracking-widest uppercase mb-0.5">
-              Temperatura
-            </span>
-            {tempOffline ? (
-              <Badge variant="outline" className="text-slate-500 border-slate-700">
-                OFFLINE
-              </Badge>
-            ) : (
-              <div className="flex items-baseline gap-1">
-                <span
-                  className={`text-2xl font-black font-mono tabular-nums leading-none ${getTemperatureColor(temperature)}`}
-                >
-                  {temperature}
-                </span>
-                <span className="text-xs text-slate-500 font-mono">°C</span>
-              </div>
-            )}
-          </div>
+          <SensorReadout label="Humedad" value={humidity} unit="%" meta={humMeta} />
+          <SensorReadout label="Temperatura" value={temperature} unit="°C" meta={tempMeta} />
         </div>
 
         {/* Sparklines de 24h: en mobile apilados (grid-cols-1), en desktop

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -44,23 +44,30 @@ const OLLAMA_URL = '/api/ollama';
 // Cooldown de idempotencia persistente (delegado a sync_meta vía assetCache)
 const COOLDOWN_MS = 5 * 60 * 1000; // 5 minutos
 
-// Utilidades de formateo condicional
-const getHumidityColor = (humidity) => {
+// Utilidades de formateo condicional (SOLO presentación — mismos umbrales).
+// Devuelven meta visual { tone, cls, label } por lectura:
+//   tone  → estado semántico (ok | warn | alert | nodata) que IoTSensorCard
+//           usa para diferenciar el contenedor del readout (borde/fondo).
+//   cls   → clase de color del número. Se eligen clases del "safe set"
+//           theme-aware: emerald-* va por tokens CSS-var y rose-300/sky-300
+//           tienen override global en themes.css para los temas claros.
+//   label → etiqueta corta de estado, legible al sol (no solo color).
+const getHumidityMeta = (humidity) => {
   const value = parseFloat(humidity);
-  if (isNaN(value)) return 'text-slate-400';
+  if (isNaN(value)) return { tone: 'nodata', cls: 'text-slate-400', label: 'Sin dato' };
 
-  if (value < 40) return 'text-red-500'; // Humedad crítica
-  if (value <= 70) return 'text-green-500'; // Humedad óptima
-  return 'text-blue-500'; // Humedad saturada
+  if (value < 40) return { tone: 'alert', cls: 'text-rose-300', label: 'Crítica' }; // Humedad crítica
+  if (value <= 70) return { tone: 'ok', cls: 'text-emerald-300', label: 'Óptima' }; // Humedad óptima
+  return { tone: 'warn', cls: 'text-sky-300', label: 'Saturada' }; // Humedad saturada
 };
 
-const getTemperatureColor = (temperature) => {
+const getTemperatureMeta = (temperature) => {
   const value = parseFloat(temperature);
-  if (isNaN(value)) return 'text-slate-400';
+  if (isNaN(value)) return { tone: 'nodata', cls: 'text-slate-400', label: 'Sin dato' };
 
-  if (value < 12) return 'text-blue-400'; // Frío
-  if (value <= 28) return 'text-green-500'; // Óptimo
-  return 'text-red-500'; // Calor crítico
+  if (value < 12) return { tone: 'warn', cls: 'text-sky-300', label: 'Fría' }; // Frío
+  if (value <= 28) return { tone: 'ok', cls: 'text-emerald-300', label: 'Óptima' }; // Óptimo
+  return { tone: 'alert', cls: 'text-rose-300', label: 'Calor crítico' }; // Calor crítico
 };
 
 export default function TelemetryAlerts() {
@@ -731,7 +738,7 @@ export default function TelemetryAlerts() {
             </div>
           </>
         ) : (
-          <div className="motion-safe:animate-glitch-in">
+          <div className="motion-safe:animate-glitch-in space-y-3">
             {wateringEffect && (
               <div className="mb-3 p-3 rounded-xl bg-cyan-950/40 border border-cyan-700/50 text-cyan-200 text-xs flex items-center gap-2 motion-safe:animate-pulse">
                 <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -754,8 +761,8 @@ export default function TelemetryAlerts() {
                 : sensors.invernaderoTemperature}
               humidityHistory={sensorHistory['sensor.matera_cocina_humidity']}
               temperatureHistory={sensorHistory['sensor.matera_cocina_temperature']}
-              getHumidityColor={getHumidityColor}
-              getTemperatureColor={getTemperatureColor}
+              getHumidityMeta={getHumidityMeta}
+              getTemperatureMeta={getTemperatureMeta}
             />
             <IoTSensorCard
               title="MATERA TABACO"
@@ -768,8 +775,8 @@ export default function TelemetryAlerts() {
                 : sensors.tabacoTemperature}
               humidityHistory={sensorHistory['sensor.hobeian_zg_303z_humidity']}
               temperatureHistory={sensorHistory['sensor.hobeian_zg_303z_temperature']}
-              getHumidityColor={getHumidityColor}
-              getTemperatureColor={getTemperatureColor}
+              getHumidityMeta={getHumidityMeta}
+              getTemperatureMeta={getTemperatureMeta}
             />
           </div>
         )}
@@ -859,23 +866,32 @@ export default function TelemetryAlerts() {
                       </div>
                     );
                   }
+                  // Severidad visual por tipo de alerta (SOLO presentación):
+                  //   🚨/🔥 crítico  → rose (acción inmediata)
+                  //   💧/❄️ ambiental → sky (agua/frío)
+                  //   ⚠️ operativo    → amber (revisar)
+                  // Clases del safe set theme-aware (override en themes.css
+                  // para temas claros) + borde izquierdo grueso para que la
+                  // jerarquía se lea también al sol, no solo por el tinte.
+                  const severityCls = (line) => {
+                    if (/^(🚨|🔥)/.test(line))
+                      return 'bg-rose-950/20 border border-rose-500/40 border-l-4 border-l-rose-500 text-rose-200 font-semibold';
+                    if (/^(💧|❄️)/.test(line))
+                      return 'bg-sky-950/40 border border-sky-500/40 border-l-4 border-l-sky-400 text-sky-200 font-medium';
+                    if (/^⚠️/.test(line))
+                      return 'bg-amber-500/10 border border-amber-500/40 border-l-4 border-l-amber-400 text-amber-200 font-medium';
+                    return 'text-slate-300';
+                  };
                   return (
                     <ul className="space-y-1.5">
-                      {lines.map((line, idx) => {
-                        const isAlert = /^(🚨|💧|🔥|❄️|⚠️)/.test(line);
-                        return (
-                          <li
-                            key={idx}
-                            className={`flex items-start gap-2 text-sm leading-relaxed rounded-lg px-3 py-2 ${
-                              isAlert
-                                ? 'bg-amber-950/30 border border-amber-800/50 text-amber-200'
-                                : 'text-slate-300'
-                            }`}
-                          >
-                            <span className="leading-snug">{line}</span>
-                          </li>
-                        );
-                      })}
+                      {lines.map((line, idx) => (
+                        <li
+                          key={idx}
+                          className={`flex items-start gap-2 text-sm leading-relaxed rounded-lg px-3 py-2 ${severityCls(line)}`}
+                        >
+                          <span className="leading-snug">{line}</span>
+                        </li>
+                      ))}
                     </ul>
                   );
                 })()}

--- a/src/components/dashboard/AIStatusFooter.jsx
+++ b/src/components/dashboard/AIStatusFooter.jsx
@@ -63,9 +63,12 @@ function getSensorChip(sensors) {
     if (!label) label = `${sensors.length} sensor${sensors.length === 1 ? '' : 'es'}`;
 
     const sub = stale > 0 ? `${stale} sin update` : 'al día';
+    // Semáforo del chip: todo caído = rose, parcial/extremos = amber, sano =
+    // emerald. Bordes /50 + fondos /15 para que el estado se distinga también
+    // con brillo de sol directo (antes /40 y /10 se lavaban).
     const color = stale === sensors.length ? 'text-rose-300' : (stale > 0 ? 'text-amber-300' : 'text-emerald-300');
-    const bg = stale === sensors.length ? 'bg-rose-500/10' : (stale > 0 ? 'bg-amber-500/10' : 'bg-emerald-500/10');
-    const border = stale === sensors.length ? 'border-rose-600/40' : (stale > 0 ? 'border-amber-600/40' : 'border-emerald-600/40');
+    const bg = stale === sensors.length ? 'bg-rose-500/15' : (stale > 0 ? 'bg-amber-500/15' : 'bg-emerald-500/15');
+    const border = stale === sensors.length ? 'border-rose-500/50' : (stale > 0 ? 'border-amber-500/50' : 'border-emerald-500/50');
     return {
         Icon: stale === sensors.length ? WifiOff : ThermometerSun,
         label,
@@ -88,12 +91,16 @@ function getClimaChip(snapshot) {
         };
     }
     const enso = snapshot.enso_status || 'neutral';
+    // Escala ENSO como rampa de riesgo: neutral (morpho, token theme-aware)
+    // → Niña (sky, húmedo) → Niño débil (amber) → moderado (orange) → fuerte
+    // (rose). Textos -300 del safe set (override en themes.css para claros);
+    // bordes /50 y fondos /15 para legibilidad exterior.
     const ensoColors = {
-        neutral: { color: 'text-cyan-300', bg: 'bg-cyan-500/10', border: 'border-cyan-600/40' },
-        nina: { color: 'text-blue-300', bg: 'bg-blue-500/10', border: 'border-blue-600/40' },
-        nino_debil: { color: 'text-amber-300', bg: 'bg-amber-500/10', border: 'border-amber-600/40' },
-        nino_moderado: { color: 'text-orange-300', bg: 'bg-orange-500/10', border: 'border-orange-600/40' },
-        nino_fuerte: { color: 'text-rose-300', bg: 'bg-rose-500/10', border: 'border-rose-600/40' },
+        neutral: { color: 'text-morpho-glow', bg: 'bg-morpho/10', border: 'border-morpho/50' },
+        nina: { color: 'text-sky-300', bg: 'bg-sky-500/15', border: 'border-sky-500/50' },
+        nino_debil: { color: 'text-amber-300', bg: 'bg-amber-500/15', border: 'border-amber-500/50' },
+        nino_moderado: { color: 'text-orange-300', bg: 'bg-orange-500/15', border: 'border-orange-500/50' },
+        nino_fuerte: { color: 'text-rose-300', bg: 'bg-rose-500/15', border: 'border-rose-500/50' },
     };
     const c = ensoColors[enso] || ensoColors.neutral;
     const labelByEnso = {
@@ -123,17 +130,19 @@ function getAgentChip(hint) {
             label: 'Agente listo',
             sub: 'Pregúntame algo',
             color: 'text-emerald-300',
-            bg: 'bg-emerald-500/10',
-            border: 'border-emerald-600/40',
+            bg: 'bg-emerald-500/15',
+            border: 'border-emerald-500/50',
         };
     }
+    // orchid = token IA generativa del design system (magenta en biopunk,
+    // terracota/ocre en los temas claros) — coherente con AIStreamPanel.
     return {
         Icon: Sparkles,
         label: 'Sugerencia',
         sub: hint.length > 30 ? hint.slice(0, 30) + '…' : hint,
-        color: 'text-violet-300',
-        bg: 'bg-violet-500/10',
-        border: 'border-violet-600/40',
+        color: 'text-orchid-glow',
+        bg: 'bg-orchid/10',
+        border: 'border-orchid/50',
     };
 }
 
@@ -147,8 +156,8 @@ function Chip({ Icon, label, sub, color, bg, border, onClick, ariaLabel }) {
         >
             <Icon size={18} className={`shrink-0 ${color}`} />
             <div className="flex flex-col items-start min-w-0">
-                <span className={`text-xs font-bold truncate w-full text-left ${color}`}>{label}</span>
-                <span className="text-[10px] text-slate-400 truncate w-full text-left">{sub}</span>
+                <span className={`text-xs font-black tracking-wide truncate w-full text-left ${color}`}>{label}</span>
+                <span className="text-[10px] font-medium text-slate-400 truncate w-full text-left">{sub}</span>
             </div>
         </button>
     );
@@ -175,15 +184,17 @@ export default function AIStatusFooter({ sensors = [], climaSnapshot = null, age
                 transition: 'opacity 700ms ease-out, transform 700ms ease-out',
             }}
         >
+            {/* Header con tokens morpho (theme-aware: cyan neón en biopunk,
+                salvia/verde en los temas claros) en vez de cyan-* crudo. */}
             <div className="flex items-center gap-2 mb-2 px-1">
-                <Activity size={14} className="text-cyan-400 animate-pulse" />
-                <span className="text-[10px] font-bold text-cyan-300 uppercase tracking-[0.18em]">
+                <Activity size={14} className="text-morpho motion-safe:animate-pulse" />
+                <span className="text-[10px] font-bold text-morpho-glow uppercase tracking-[0.18em]">
                     Status proactivo IA
                 </span>
-                <span className="px-1.5 py-0.5 rounded text-[9px] font-black bg-cyan-500/20 text-cyan-200 uppercase tracking-wider">
+                <span className="px-1.5 py-0.5 rounded text-[9px] font-black bg-morpho/20 text-morpho-glow uppercase tracking-wider">
                     Live
                 </span>
-                <div className="flex-1 h-px bg-gradient-to-r from-cyan-700/40 to-transparent" />
+                <div className="flex-1 h-px bg-gradient-to-r from-morpho/40 to-transparent" />
             </div>
             <div className="flex gap-2">
                 <Chip
@@ -202,7 +213,7 @@ export default function AIStatusFooter({ sensors = [], climaSnapshot = null, age
                     ariaLabel={`Agente: ${agentChip.label}, ${agentChip.sub}`}
                 />
             </div>
-            <p className="text-[9px] text-slate-600 text-center mt-2 italic">
+            <p className="text-[9px] text-slate-500 text-center mt-2 italic">
                 Toca cualquier chip para profundizar
             </p>
         </div>

--- a/src/components/dashboard/SensorInsightCard.jsx
+++ b/src/components/dashboard/SensorInsightCard.jsx
@@ -96,34 +96,36 @@ export default function SensorInsightCard({ sensors = [], onNavigate }) {
         <button
             type="button"
             onClick={() => onNavigate?.('mapa')}
-            className="group relative w-full text-left rounded-2xl bg-gradient-to-br from-cyan-500/10 via-emerald-500/8 to-violet-500/10 backdrop-blur-xl border border-cyan-700/30 p-4 transition-all active:scale-[0.98] hover:border-cyan-500/50 mt-3"
+            className="group relative w-full text-left rounded-2xl bg-gradient-to-br from-morpho/10 via-emerald-500/8 to-orchid/10 backdrop-blur-xl border border-morpho/30 p-4 transition-all active:scale-[0.98] hover:border-morpho/60 mt-3"
             style={{
                 opacity: animateIn ? 1 : 0,
                 transform: animateIn ? 'translateY(0)' : 'translateY(8px)',
                 transition: 'opacity 600ms ease-out, transform 600ms ease-out',
             }}
         >
+            {/* Tokens morpho/orchid (theme-aware) en vez de cyan/violet crudo:
+                neón en biopunk, salvia/terracota legibles en los temas claros. */}
             <div className="flex items-center gap-3">
-                <div className="shrink-0 w-11 h-11 rounded-xl bg-black/35 flex items-center justify-center relative">
-                    <Activity size={20} className="text-cyan-300" />
+                <div className="shrink-0 w-11 h-11 rounded-xl bg-slate-950/50 border border-morpho/20 flex items-center justify-center relative">
+                    <Activity size={20} className="text-morpho-glow" />
                     {/* Pulse indicator */}
-                    <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-cyan-400 animate-pulse" />
+                    <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-morpho motion-safe:animate-pulse" />
                 </div>
                 <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
                         <Icon size={14} className={color} />
-                        <h3 className="text-xs font-bold text-cyan-200 uppercase tracking-wider">
+                        <h3 className="text-xs font-bold text-morpho-glow uppercase tracking-wider">
                             {title}
                         </h3>
-                        <span className="px-1.5 py-0.5 rounded text-[9px] font-black bg-cyan-500/20 text-cyan-200 uppercase tracking-wider">
+                        <span className="px-1.5 py-0.5 rounded text-[9px] font-black bg-morpho/20 text-morpho-glow uppercase tracking-wider">
                             IA
                         </span>
                     </div>
-                    <p className={`text-sm font-medium mt-1 leading-snug ${color}`}>
+                    <p className={`text-sm font-semibold mt-1 leading-snug ${color}`}>
                         {line}
                     </p>
                 </div>
-                <span className="shrink-0 text-xs text-slate-400 group-hover:text-cyan-300 transition-colors">
+                <span className="shrink-0 text-xs font-bold text-slate-400 group-hover:text-morpho-glow transition-colors">
                     {cta} →
                 </span>
             </div>


### PR DESCRIPTION
Pasada SOLO de presentacion sobre los widgets de telemetria IoT y alertas
(sin tocar fuentes de datos, umbrales ni logica de despacho):

- IoTSensorCard: readouts mas grandes (text-3xl) con etiqueta de estado
  explicita (Optima/Critica/Saturada/Fria/Sin dato) y contenedor tintado
  por estado (emerald/sky/rose/punteado) — el estado ya no depende solo
  del color del numero (legibilidad al sol + daltonismo). Estado sin dato
  pasa de badge OFFLINE a "--" con borde punteado.
- TelemetryAlerts: helpers de color → helpers de meta visual {tone, cls,
  label} con los MISMOS umbrales; lista de alertas deterministas con
  severidad diferenciada (rose critico / sky ambiental / amber operativo)
  y borde izquierdo grueso; separacion entre cards de sensores.
- AIStatusFooter: cyan/violet crudos → tokens morpho/orchid theme-aware
  (neon en biopunk, salvia/terracota en temas claros); rampa ENSO como
  escala de riesgo (morpho→sky→amber→orange→rose); bordes /50 y fondos
  /15 para que los estados se distingan a pleno sol.
- SensorInsightCard: mismos tokens morpho/orchid en vez de cyan/violet.
- CriticalAlertBanner: gradiente rojo mas profundo, titulo blanco font-
  black, CTA como pill con borde — mas urgencia y contraste en cualquier
  tema (fondo rojo fijo a proposito).

Clases elegidas del safe set theme-aware (tokens CSS-var o overrides
globales de themes.css) para no romper minimalista/nature/verde-vivo.

Build verde; tests de componentes tocados verdes (fallo preexistente en
SeguimientoProcesoScreen reproducido tambien en main, no relacionado).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
