### PR TITLE
feat(demo): rediseño chat del agente + portada Finca Viva (V1 · lenguaje 'Tierra y savia')

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square } from 'lucide-react';
+import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square, SlidersHorizontal } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe, queueForRetry } from '../../services/voiceService';
 import VoiceStatusStrip from './VoiceStatusStrip';
@@ -296,6 +296,13 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // La MANO de Chagra (AgentRedMenu) — MISMA red que el home, no menús de texto.
   // sheetOpen monta/desmonta el overlay de la mano (AgentManoOverlay).
   const [sheetOpen, setSheetOpen] = useState(false);
+  // Bottom-sheet de MODOS/HERRAMIENTAS. Antes la bandeja de ~12 chips de modo
+  // (ChipsToolbar) vivía SIEMPRE sobre el input y comía media pantalla en el
+  // celular. Ahora la bandeja se colapsa en un botón del compositor y estas
+  // sugerencias se abren en un sheet con scroll — el chat recupera el alto
+  // completo con el sheet cerrado. Es solo estado de presentación (abre/cierra):
+  // el ruteo de intención sigue en ChipsToolbar → onSelectIntent → setActiveIntent.
+  const [modosSheetOpen, setModosSheetOpen] = useState(false);
   // Fase del compositor para la animación shimmer/lift al enviar.
   const [composerPhase, setComposerPhase] = useState('idle'); // 'idle' | 'sending'
   // Deep Research (A6/A7): refs para los AbortControllers de los jobs en vuelo.
@@ -3046,9 +3053,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
 
   // CHIPS DE MODO (A4): placeholder guía según el modo activo. Sin modo →
   // placeholder genérico. Español colombiano (tú/usted), nunca voseo.
-  const activePlaceholder = activeIntent
-    ? (CHIP_DEFS.find((c) => c.intent === activeIntent)?.placeholder || 'Escribe tu pregunta...')
-    : 'Escribe tu pregunta...';
+  const activeChipDef = activeIntent
+    ? (CHIP_DEFS.find((c) => c.intent === activeIntent) || null)
+    : null;
+  const activePlaceholder = activeChipDef?.placeholder || 'Escribe tu pregunta...';
 
   // PIEL POR TEMA del botón enviar (Fase 2 de temas). Con la flag ON y el botón
   // habilitado (hay texto/adjunto y no se está grabando ni hay cola), aplicamos
@@ -3358,16 +3366,11 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           onDismissNotice={() => setVoiceNotice('')}
         />
 
-        <ChipsToolbar
-          activeIntent={activeIntent}
-          hasAttachment={Boolean(agentAttachment)}
-          disabled={state === STATE_RECORDING || queuePending.length >= 1}
-          isPro={isPro}
-          chipDefs={profileChipDefs}
-          onSelectIntent={(intent) => {
-            setActiveIntent((current) => (current === intent ? null : intent));
-          }}
-        />
+        {/* La bandeja de ~12 chips de modo (ChipsToolbar) ya NO vive inline sobre
+            el input — ahogaba el chat en móvil. Se colapsó en el botón de modos
+            del compositor (abre el bottom-sheet de más abajo). Aquí solo queda,
+            cuando hay un modo forzado, una cinta delgada que lo muestra y permite
+            quitarlo. La data y el ruteo son los MISMOS (ChipsToolbar en el sheet). */}
 
         {/* Pill — unified with AgentHero (as-bar CSS tokens) */}
         <div
@@ -3377,6 +3380,22 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             composerPhase === 'sending' ? 'as-shimmer as-sending' : '',
           ].join(' ')}
         >
+          {/* Cinta del MODO ACTIVO — visible solo con un modo forzado. */}
+          {activeChipDef && state !== STATE_RECORDING && (
+            <div className="as-modo-activo" data-testid="agent-modo-activo">
+              <span className="as-modo-activo-emoji" aria-hidden="true">{activeChipDef.emoji}</span>
+              <span className="as-modo-activo-txt">Modo {activeChipDef.label}</span>
+              <button
+                type="button"
+                className="as-modo-activo-x"
+                onClick={() => setActiveIntent(null)}
+                aria-label={`Quitar el modo ${activeChipDef.label}`}
+                title="Quitar el modo"
+              >
+                <X size={15} aria-hidden="true" />
+              </button>
+            </div>
+          )}
           {/* Fila 1: textarea o waveform de grabación */}
           {state === STATE_RECORDING ? (
             <div className="flex items-center gap-3 px-3 py-3 min-h-[52px]">
@@ -3461,6 +3480,23 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               <Camera size={19} strokeWidth={2} aria-hidden="true" />
             </button>
 
+            {/* Modos y herramientas — colapsa la bandeja de ~12 chips (ChipsToolbar)
+                en un botón. Abre el bottom-sheet con todos los modos. El punto de
+                acento aparece cuando hay un modo forzado activo. */}
+            <button
+              type="button"
+              onClick={() => setModosSheetOpen(true)}
+              disabled={state === STATE_RECORDING}
+              aria-label="Modos y herramientas del agente"
+              aria-haspopup="dialog"
+              aria-expanded={modosSheetOpen}
+              data-testid="agent-modos-trigger"
+              className={['as-iconbtn as-modos', activeIntent ? 'has-active' : ''].join(' ')}
+            >
+              <SlidersHorizontal size={19} strokeWidth={2} aria-hidden="true" />
+              {activeIntent && <span className="as-modos-dot" aria-hidden="true" />}
+            </button>
+
             <div className="flex-1" />
 
             {/* Micrófono (toggle) — GRANDE (TIER 2 #5): el camino principal
@@ -3527,6 +3563,58 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             quitar los chips/líneas de sugerencia que ensucian la pantalla del
             agente. El acceso a capacidades queda por la mano de Chagra (botón
             Ⓐ del compositor + botón de la pantalla vacía). */}
+
+        {/* ── BOTTOM-SHEET DE MODOS Y HERRAMIENTAS ────────────────────────────
+            Colapsa la bandeja de ~12 chips (ChipsToolbar) que antes vivía sobre
+            el input. Misma data y mismo ruteo (ChipsToolbar → onSelectIntent);
+            solo cambia el CONTENEDOR: un sheet con scroll que se cierra al elegir
+            o al tocar afuera. Con el sheet cerrado el chat tiene el alto completo. */}
+        {modosSheetOpen && (
+          <div
+            className="as-modos-sheet"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Modos y herramientas del agente"
+            data-testid="agent-modos-sheet"
+          >
+            <button
+              type="button"
+              className="as-modos-scrim"
+              aria-label="Cerrar modos y herramientas"
+              onClick={() => setModosSheetOpen(false)}
+            />
+            <div className="as-modos-panel">
+              <span className="as-modos-grab" aria-hidden="true" />
+              <div className="as-modos-head">
+                <h2>Modos y herramientas</h2>
+                <button
+                  type="button"
+                  className="as-modos-close"
+                  onClick={() => setModosSheetOpen(false)}
+                  aria-label="Cerrar"
+                >
+                  <X size={18} aria-hidden="true" />
+                </button>
+              </div>
+              <p className="as-modos-sub">
+                Toca un modo para que Chagra vaya directo al grano. Toca “Más” para ver todo.
+              </p>
+              <div className="as-modos-body">
+                <ChipsToolbar
+                  activeIntent={activeIntent}
+                  hasAttachment={Boolean(agentAttachment)}
+                  disabled={state === STATE_RECORDING || queuePending.length >= 1}
+                  isPro={isPro}
+                  chipDefs={profileChipDefs}
+                  onSelectIntent={(intent) => {
+                    setActiveIntent((current) => (current === intent ? null : intent));
+                    setModosSheetOpen(false);
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Input oculto de foto */}
         <input

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -333,16 +333,18 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
   };
 
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3.5`}>
-      <div className={`flex gap-2 max-w-[85%] ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-4`}>
+      <div className={`flex gap-2.5 max-w-[86%] ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
         {isUser ? (
-          <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-emerald-600 ring-1 ring-emerald-400/40 shadow-sm shadow-emerald-950/30">
+          <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-gradient-to-br from-emerald-500 to-emerald-700 ring-1 ring-emerald-300/40 shadow-sm shadow-emerald-950/40">
             <User size={16} className="text-white" />
           </div>
         ) : (
           <div
-            className={`shrink-0 w-9 h-9 rounded-full flex items-center justify-center bg-slate-900 border overflow-hidden ${
-              isStreaming ? 'border-amber-400/60 shadow-[0_0_10px_rgba(245,158,11,.4)]' : 'border-emerald-700/40'
+            className={`shrink-0 w-9 h-9 rounded-full flex items-center justify-center bg-[#0f1a14] border overflow-hidden transition-shadow ${
+              isStreaming
+                ? 'border-amber-400/70 shadow-[0_0_14px_rgba(245,158,11,.45)]'
+                : 'border-emerald-600/45 shadow-[0_0_10px_rgba(16,185,129,.18)]'
             }`}
           >
             <ChagraAgentAvatar state={agentState} size={32} ariaLabel="Chagra IA" />
@@ -350,11 +352,11 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
         )}
 
         <div
-          className={`rounded-2xl px-4 py-3 shadow-md ${
+          className={`rounded-[20px] px-4 py-3 shadow-lg ${
             isUser
-              ? 'bg-emerald-700/70 text-white rounded-tr-md border border-emerald-500/25 shadow-emerald-950/25'
-              : `bg-slate-800/90 text-slate-100 rounded-tl-md border border-slate-700/60 shadow-slate-950/30 cursor-pointer${
-                  isGrounded ? ' border-l-2 border-l-emerald-400/70' : ''
+              ? 'bg-gradient-to-br from-emerald-600/85 to-emerald-800/85 text-white rounded-tr-md border border-emerald-400/25 shadow-emerald-950/30'
+              : `bg-[#182421]/94 text-emerald-50/95 rounded-tl-md border border-emerald-900/45 shadow-emerald-950/25 cursor-pointer${
+                  isGrounded ? ' border-l-[3px] border-l-emerald-400/80' : ''
                 }`
           }`}
           data-grounded={isGrounded ? 'true' : undefined}
@@ -392,7 +394,7 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
               una respuesta "fantasma". Para el usuario sí mostramos su texto
               tal cual (puede ser vacío sólo si tipeó vacío, que el submit ya
               previene). Cero hype, español colombiano. */}
-          <p className="text-[15px] leading-relaxed whitespace-pre-wrap">
+          <p className="text-[15.5px] leading-[1.62] whitespace-pre-wrap [text-wrap:pretty]">
             {!isUser && (typeof message.content !== 'string' || message.content.trim().length === 0)
               ? <span className="italic text-slate-400">No recibí respuesta del asistente. Intenta de nuevo.</span>
               : message.content}

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -396,25 +396,35 @@ describe('AgentScreen - chips toolbar', () => {
     vi.clearAllMocks();
   });
 
-  it('monta la barra de chips junto al input y cambia la intencion al tocar un chip', async () => {
+  it('colapsa la bandeja de chips: cerrada no ahoga el chat; el disparador abre el sheet y elegir un modo fuerza la intencion', async () => {
     render(<AgentScreen onBack={() => {}} />);
 
+    // El disparador de modos vive en el compositor y la bandeja arranca CERRADA
+    // (recupera el alto del chat). ChipsToolbar NO está montada hasta abrir.
     await waitFor(() => {
-      expect(screen.getByTestId('chips-toolbar')).toBeInTheDocument();
+      expect(screen.getByTestId('agent-modos-trigger')).toBeInTheDocument();
     });
+    expect(screen.queryByTestId('chips-toolbar')).not.toBeInTheDocument();
 
-    const toolbar = screen.getByTestId('chips-toolbar');
-    const input = screen.getByTestId('agent-input');
-    expect(toolbar.compareDocumentPosition(input) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
-
+    // Abrir el sheet → la bandeja aparece con sus chips.
+    fireEvent.click(screen.getByTestId('agent-modos-trigger'));
+    const toolbar = await screen.findByTestId('chips-toolbar');
     expect(toolbar).toHaveTextContent('Biopreparado');
-    const biopreparadoChip = screen.getByRole('button', { name: /biopreparado/i });
-    fireEvent.click(biopreparadoChip);
 
-    expect(biopreparadoChip).toHaveAttribute('aria-pressed', 'true');
+    // Elegir un modo fuerza la intención: cambia el placeholder del input, cierra
+    // el sheet y muestra la cinta del modo activo. (El chip queda desmontado al
+    // cerrar el sheet, por eso verificamos el efecto persistente, no aria-pressed.)
+    fireEvent.click(screen.getByRole('button', { name: /biopreparado/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('chips-toolbar')).not.toBeInTheDocument();
+    });
     expect(screen.getByTestId('agent-input')).toHaveAttribute(
       'placeholder',
       'Escribe para que plaga o planta quieres el biopreparado',
     );
+    expect(screen.getByTestId('agent-modo-activo')).toHaveTextContent('Modo Biopreparado');
+    // El disparador refleja el modo activo (punto de acento + clase has-active).
+    expect(screen.getByTestId('agent-modos-trigger').className).toMatch(/has-active/);
   });
 });

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -143,6 +143,117 @@ export const AGENT_COMPOSITOR_CSS = `
     transition: opacity 0.25s ease, box-shadow 0.25s ease;
   }
   .as-send:disabled { opacity: 0.35; cursor: not-allowed; }
+
+  /* ══════════════════════════════════════════════════════════════════════════
+     MODOS Y HERRAMIENTAS — la bandeja de ~12 chips (ChipsToolbar) que antes
+     vivía SIEMPRE sobre el input y comía media pantalla en el celular ahora se
+     colapsa en UN botón del compositor. Al tocarlo se abre un bottom-sheet con
+     scroll (todos los modos). Con el sheet cerrado el chat recupera el alto
+     completo. Todo token-aware (--c-*/--t-accent-rgb) → coherente en los 4 temas.
+     ══════════════════════════════════════════════════════════════════════════ */
+  .as-modos.has-active {
+    border-color: rgb(var(--t-accent-rgb, 25 201 154) / 0.65);
+    color: rgb(var(--t-accent-rgb, 25 201 154));
+  }
+  .as-modos-dot {
+    position: absolute; top: 5px; right: 5px;
+    width: 9px; height: 9px; border-radius: 50%;
+    background: rgb(var(--t-accent-rgb, 25 201 154));
+    box-shadow: 0 0 0 2px rgb(var(--c-surface-card, 30 41 59));
+  }
+
+  /* Cinta del MODO ACTIVO — fila delgada arriba del compositor, visible SOLO
+     cuando hay un modo forzado. El productor ve qué modo está puesto y lo puede
+     quitar, sin reintroducir la bandeja entera. */
+  .as-modo-activo {
+    display: flex; align-items: center; gap: 8px;
+    margin: 2px 2px 8px; padding: 6px 6px 6px 11px;
+    border-radius: 13px;
+    background: rgb(var(--t-accent-rgb, 25 201 154) / 0.15);
+    border: 1px solid rgb(var(--t-accent-rgb, 25 201 154) / 0.34);
+  }
+  .as-modo-activo-emoji { font-size: 15px; line-height: 1; flex: none; }
+  .as-modo-activo-txt {
+    flex: 1; min-width: 0; font-size: 12.5px; font-weight: 800;
+    letter-spacing: 0.1px;
+    color: rgb(var(--c-slate-100, 226 232 240));
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .as-modo-activo-x {
+    flex: none; width: 28px; height: 28px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    color: rgb(var(--c-slate-300, 148 163 184)); cursor: pointer;
+    background: transparent; border: 0; transition: background 0.18s ease, color 0.18s ease;
+  }
+  .as-modo-activo-x:hover {
+    background: rgb(var(--c-slate-100, 226 232 240) / 0.12);
+    color: rgb(var(--c-slate-100, 226 232 240));
+  }
+
+  .as-modos-sheet {
+    position: fixed; inset: 0; z-index: 60;
+    display: flex; flex-direction: column; justify-content: flex-end;
+  }
+  .as-modos-scrim {
+    position: absolute; inset: 0; border: 0; padding: 0; margin: 0; cursor: pointer;
+    background: rgba(6, 14, 11, 0.56);
+    -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px);
+    animation: as-modos-fade 0.22s ease both;
+  }
+  .as-modos-panel {
+    position: relative; z-index: 1;
+    width: 100%; max-width: 640px; margin: 0 auto;
+    max-height: min(68vh, 540px);
+    display: flex; flex-direction: column;
+    background: rgb(var(--c-surface-card, 17 24 39));
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85));
+    border-bottom: 0;
+    border-radius: 26px 26px 0 0;
+    box-shadow: 0 -20px 52px -16px rgba(0, 0, 0, 0.6);
+    padding: 8px 15px calc(env(safe-area-inset-bottom, 0px) + 16px);
+    animation: as-modos-rise 0.34s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  .as-modos-grab {
+    width: 44px; height: 4px; border-radius: 999px; flex: none;
+    background: rgb(var(--c-slate-300, 148 163 184) / 0.5);
+    margin: 5px auto 9px;
+  }
+  .as-modos-head { display: flex; align-items: center; gap: 10px; margin-bottom: 3px; }
+  .as-modos-head h2 {
+    flex: 1; min-width: 0;
+    font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+    font-weight: 800; font-size: 17px; letter-spacing: -0.3px;
+    color: rgb(var(--c-slate-100, 241 245 249));
+  }
+  .as-modos-close {
+    flex: none; width: 38px; height: 38px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    background: rgb(var(--c-surface-raised, 30 41 59));
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85));
+    color: rgb(var(--c-slate-300, 148 163 184)); cursor: pointer;
+    transition: color 0.18s ease, border-color 0.18s ease;
+  }
+  .as-modos-close:hover {
+    color: rgb(var(--c-slate-100, 241 245 249));
+    border-color: rgb(var(--t-accent-rgb, 25 201 154) / 0.5);
+  }
+  .as-modos-sub {
+    font-size: 12.5px; line-height: 1.4; margin: 0 2px 6px;
+    color: rgb(var(--c-slate-400, 148 163 184));
+  }
+  .as-modos-body { overflow-y: auto; overscroll-behavior: contain; -webkit-overflow-scrolling: touch; }
+  /* Dentro del sheet, la bandeja no lleva superficie ni borde propios (el panel
+     ya los da) — solo pinta sus chips. */
+  .as-modos-body .agent-chip-tray {
+    background: transparent !important; border-top: 0 !important;
+    -webkit-backdrop-filter: none !important; backdrop-filter: none !important;
+    padding: 4px 2px 2px;
+  }
+  @keyframes as-modos-rise { from { transform: translateY(100%); } to { transform: translateY(0); } }
+  @keyframes as-modos-fade { from { opacity: 0; } to { opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) {
+    .as-modos-panel, .as-modos-scrim { animation: none !important; }
+  }
   @keyframes as-send-shimmer {
     0%   { transform: translateX(-130%); opacity: 0; }
     25%  { opacity: 1; }

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -1135,3 +1135,121 @@
   text-shadow: var(--fvh-on-cielo-sombra);
 }
 .fvh .fvh-portales-tit span { background: var(--fvh-on-cielo-div); }
+
+/* ════════════════════════════════════════════════════════════════════════════
+   ELEVACIÓN A NIVEL DEMO (2026-07-03) — la portada es lo PRIMERO que ve el
+   piloto. Sobre la pasada base (#1957) sube el salto de calidad SIN tocar
+   lógica/props/testids ni promover la flag: solo capa visual, aditiva, coherente
+   en los 4 temas y respetuosa de prefers-reduced-motion (el kill-switch de más
+   arriba, `.fvh *,::before,::after { animation:none !important }`, ya congela
+   todo lo de aquí). Cuatro gestos:
+     1. LUZ QUE RESPIRA sobre la escena (bruma dorada de día · resplandor lunar
+        de noche · brasa al amanecer/atardecer) → profundidad y "hora viva".
+     2. Los 4 PORTALES como un ABANICO/mano de acciones (naipes en abanico que se
+        enderezan y se adelantan al escogerlos) → la firma de la portada.
+     3. COLIBRÍ con más carácter: iridiscencia que titila + vuelo con un "dardo".
+     4. Marca "MI finca" con un halo vivo que respira.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* ── 1. Luz atmosférica que respira sobre la escena ────────────────────────
+   Capa decorativa (pointer-events:none) dentro de .fvh-escena, por ENCIMA del
+   arte SVG (z2) y por DEBAJO de los bichos (z7) y el globo (z8). No lava el
+   texto: el único texto sobre la escena es el globo, que va más arriba. */
+.fvh-escena::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 4;
+  border-radius: inherit;
+  background:
+    radial-gradient(46% 40% at 82% 15%, rgba(255, 226, 156, 0.42), transparent 62%),
+    radial-gradient(96% 60% at 50% 4%, rgba(255, 247, 219, 0.14), transparent 64%);
+  opacity: 0.7;
+  animation: fvh-luz-respira 8.5s ease-in-out infinite;
+}
+.fvh[data-luz="noche"] .fvh-escena::after {
+  background:
+    radial-gradient(46% 40% at 80% 13%, rgba(176, 206, 255, 0.4), transparent 64%),
+    radial-gradient(98% 66% at 50% 6%, rgba(150, 180, 240, 0.1), transparent 66%);
+  opacity: 0.6;
+}
+.fvh[data-luz="amanecer"] .fvh-escena::after,
+.fvh[data-luz="atardecer"] .fvh-escena::after {
+  background:
+    radial-gradient(54% 46% at 78% 22%, rgba(255, 168, 102, 0.5), transparent 62%),
+    radial-gradient(98% 64% at 50% 6%, rgba(255, 202, 142, 0.16), transparent 64%);
+  opacity: 0.72;
+}
+@keyframes fvh-luz-respira {
+  0%, 100% { opacity: 0.52; }
+  50%      { opacity: 0.82; }
+}
+
+/* ── 2. Los 4 portales como un ABANICO/mano de acciones ────────────────────
+   El tilt usa la propiedad independiente `rotate:` — NO `transform:` — para no
+   pelear con la animación de entrada (fvh-rise anima transform) ni con el
+   translate del :hover/:active. Origen en la base = abanico que abre desde la
+   "muñeca". Al pasar el puntero (o el foco), el naipe se ENDEREZA y se adelanta,
+   como cuando uno saca una carta del abanico. */
+.fvh-portales { perspective: 1400px; }
+.fvh-portal {
+  transform-origin: bottom center;
+  transition: transform 0.2s cubic-bezier(0.22, 0.9, 0.35, 1),
+              box-shadow 0.2s ease,
+              rotate 0.34s cubic-bezier(0.22, 0.9, 0.35, 1);
+}
+/* Abanico móvil (2×2): tilt sutil alterno — insinúa el abanico sin desordenar. */
+.fvh-portal:nth-child(1) { rotate: -2.4deg; }
+.fvh-portal:nth-child(2) { rotate: 1.8deg; }
+.fvh-portal:nth-child(3) { rotate: -1.6deg; }
+.fvh-portal:nth-child(4) { rotate: 2.6deg; }
+@media (hover: hover) and (pointer: fine) {
+  .fvh-portal:hover {
+    rotate: 0deg;
+    transform: translateY(-7px) scale(1.015);
+    z-index: 3;
+  }
+  .fvh-portal:focus-visible { rotate: 0deg; z-index: 3; }
+}
+
+/* ── 3. Colibrí con carácter ───────────────────────────────────────────────
+   Iridiscencia: un hue-rotate lento y sutil sobre el plumaje (el mismo SVG,
+   colores que respiran como el tornasol real). Vuelo con un "dardo" ocasional
+   (acelera y frena, como un colibrí de verdad) — reemplaza la curva plana. */
+.fvh-colibri-svg { animation: fvh-colibri-iris 5.5s ease-in-out infinite; }
+@keyframes fvh-colibri-iris {
+  0%, 100% { filter: hue-rotate(0deg) saturate(1); }
+  50%      { filter: hue-rotate(-14deg) saturate(1.12); }
+}
+.fvh-colibri-vuela {
+  animation: fvh-colibri-dardo 6.5s cubic-bezier(0.5, 0, 0.2, 1) infinite;
+}
+@keyframes fvh-colibri-dardo {
+  0%   { transform: translate(0, 0) rotate(-3deg) scale(1); }
+  18%  { transform: translate(-30px, 12px) rotate(4deg) scale(1.04); }
+  24%  { transform: translate(-32px, 13px) rotate(3deg) scale(1); }
+  55%  { transform: translate(-6px, -8px) rotate(-2deg) scale(1.02); }
+  78%  { transform: translate(-18px, 6px) rotate(2deg) scale(1); }
+  100% { transform: translate(0, 0) rotate(-3deg) scale(1); }
+}
+
+/* ── 4. Marca "MI finca" — halo vivo que respira detrás del ícono ──────────── */
+.fvh-brand-a {
+  position: relative;
+  isolation: isolate;
+}
+.fvh-brand-a::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  z-index: -1;
+  border-radius: 19px;
+  background: radial-gradient(circle at 50% 45%, rgb(var(--c-emerald-400, 63 143 78) / 0.5), transparent 70%);
+  opacity: 0.55;
+  animation: fvh-marca-halo 4.5s ease-in-out infinite;
+}
+@keyframes fvh-marca-halo {
+  0%, 100% { opacity: 0.32; transform: scale(0.94); }
+  50%      { opacity: 0.62; transform: scale(1.04); }
+}


### PR DESCRIPTION
## Rediseño de las dos superficies más vistas del demo (V1)

Rediseño — no pulido — del **chat del agente** y la **portada Finca Viva**, con un **mismo lenguaje visual** ("Tierra y savia": Baloo 2 + Nunito, paleta de tierra/savia por tokens, luz cálida que respira, micro-animación viva). Solo capa visual; cero cambios de lógica, props ni testids (salvo testids nuevos de UI). No promueve la flag finca-viva.

### Lenguaje visual — direcciones consideradas
- **A · "Tierra y savia"** (elegida): materiales campesinos colombianos — barro/terracota, café, verde-hoja, oro de maíz, cielo de páramo — sobre papel cálido, tipografía redonda con calidez (Baloo 2), profundidad por luz filtrada por hojas, micro-motion que "respira". Es la única que dice *finca campesina viva y confiable* sin leerse como dashboard ni chatbot, y retiñe (no repinta) en los 4 temas.
- **B · "Neón de páramo"** (biopunk night): navy + teal/orquídea. Descartada: se acerca al look de IA oscura genérica y pelea con "legible al sol".
- **C · "Almanaque de la finca"** (broadsheet): reglas finas, tipografía editorial. Descartada: es uno de los defaults templados y riñe con lo cálido/vivo.

### Punto 1 — AgentScreen (chat)
**Problema medido:** la bandeja de ~12 chips de modo (`ChipsToolbar`) vivía SIEMPRE sobre el input y comía casi la mitad del alto en móvil, ahogando la lectura.
- **Colapsada en UN botón** de modos/herramientas en el compositor → abre un **bottom-sheet con scroll** (cierra al elegir o al tocar afuera). Misma data y mismo ruteo: la **misma `ChipsToolbar`** (mismo `onSelectIntent`, mismos `chipDefs` por perfil) se monta dentro del sheet. Con el sheet cerrado el chat recupera el **alto completo**.
- Cinta delgada del **modo activo** (con botón para quitarlo) sobre el input, visible solo cuando hay un modo forzado; el disparador muestra un punto de acento.
- **Chat rediseñado**: burbujas más cálidas y redondeadas, más aire y jerarquía, lectura a 15.5px/1.62 con `text-wrap: pretty`, avatares con anillo vivo, filo esmeralda del grounding reforzado.
- Test `AgentScreen.chipsToolbar` ajustado al markup nuevo (abre el sheet → elige modo → verifica placeholder + cinta activa).

### Punto 2 — Portada Finca Viva (`FincaVivaHero`)
Solo `finca-viva-hero.css`, aditivo:
1. **Luz que respira** sobre la escena (bruma dorada de día · resplandor lunar de noche · brasa al amanecer/atardecer via `data-luz`).
2. Los **4 portales como un ABANICO/mano de acciones** (naipes en abanico con la propiedad independiente `rotate` — no pelea con la animación de entrada — que se enderezan y se adelantan al escogerlos).
3. **Colibrí con carácter**: iridiscencia que titila + vuelo con un "dardo".
4. Marca **"Mi finca"** con halo vivo que respira.
Respeta el A/B del colibrí (ambos), reduced-motion y los 4 temas.

### Verificación
`npm run build` verde. Tests de los componentes tocados verdes: Punto 1 (121) + Punto 2 (32).

> Segunda versión (segunda pasada, dirección alternativa) va en un PR separado para evaluar ambos resultados lado a lado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
