### PR TITLE
feat(demo): rediseño chat + portada Finca Viva (V2 · 'theme-native / cine de finca') — 2ª pasada

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square } from 'lucide-react';
+import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square, Wrench } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe, queueForRetry } from '../../services/voiceService';
 import VoiceStatusStrip from './VoiceStatusStrip';
@@ -296,6 +296,12 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // La MANO de Chagra (AgentRedMenu) — MISMA red que el home, no menús de texto.
   // sheetOpen monta/desmonta el overlay de la mano (AgentManoOverlay).
   const [sheetOpen, setSheetOpen] = useState(false);
+  // V2 — Gaveta de MODOS/HERRAMIENTAS. La bandeja de ~12 chips (ChipsToolbar) ya
+  // no vive sobre el input; se colapsa en un disparador ETIQUETADO del compositor
+  // que también MUESTRA el modo activo, y las sugerencias se abren en una gaveta
+  // (bottom-sheet) con scroll. Solo estado de presentación; el ruteo sigue en
+  // ChipsToolbar → onSelectIntent → setActiveIntent.
+  const [modosSheetOpen, setModosSheetOpen] = useState(false);
   // Fase del compositor para la animación shimmer/lift al enviar.
   const [composerPhase, setComposerPhase] = useState('idle'); // 'idle' | 'sending'
   // Deep Research (A6/A7): refs para los AbortControllers de los jobs en vuelo.
@@ -3046,9 +3052,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
 
   // CHIPS DE MODO (A4): placeholder guía según el modo activo. Sin modo →
   // placeholder genérico. Español colombiano (tú/usted), nunca voseo.
-  const activePlaceholder = activeIntent
-    ? (CHIP_DEFS.find((c) => c.intent === activeIntent)?.placeholder || 'Escribe tu pregunta...')
-    : 'Escribe tu pregunta...';
+  const activeChipDef = activeIntent
+    ? (CHIP_DEFS.find((c) => c.intent === activeIntent) || null)
+    : null;
+  const activePlaceholder = activeChipDef?.placeholder || 'Escribe tu pregunta...';
 
   // PIEL POR TEMA del botón enviar (Fase 2 de temas). Con la flag ON y el botón
   // habilitado (hay texto/adjunto y no se está grabando ni hay cola), aplicamos
@@ -3358,16 +3365,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           onDismissNotice={() => setVoiceNotice('')}
         />
 
-        <ChipsToolbar
-          activeIntent={activeIntent}
-          hasAttachment={Boolean(agentAttachment)}
-          disabled={state === STATE_RECORDING || queuePending.length >= 1}
-          isPro={isPro}
-          chipDefs={profileChipDefs}
-          onSelectIntent={(intent) => {
-            setActiveIntent((current) => (current === intent ? null : intent));
-          }}
-        />
+        {/* V2: la bandeja de ~12 chips (ChipsToolbar) ya NO vive inline sobre el
+            input — ahogaba el chat. Se colapsó en el disparador etiquetado de la
+            gaveta (fila del compositor de abajo), que además muestra el modo
+            activo. Misma data y ruteo (ChipsToolbar en la gaveta). */}
 
         {/* Pill — unified with AgentHero (as-bar CSS tokens) */}
         <div
@@ -3461,6 +3462,26 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               <Camera size={19} strokeWidth={2} aria-hidden="true" />
             </button>
 
+            {/* V2 — Disparador ETIQUETADO de la gaveta de modos. Colapsa la
+                bandeja de ~12 chips y DOBLA como indicador del modo activo: sin
+                modo dice "Modos"; con un modo muestra su emoji + etiqueta. Abre
+                la gaveta (bottom-sheet) de más abajo. */}
+            <button
+              type="button"
+              onClick={() => setModosSheetOpen(true)}
+              disabled={state === STATE_RECORDING}
+              aria-label={activeChipDef ? `Modo activo: ${activeChipDef.label}. Abrir modos y herramientas` : 'Modos y herramientas del agente'}
+              aria-haspopup="dialog"
+              aria-expanded={modosSheetOpen}
+              data-testid="agent-modos-trigger"
+              className={['as-modos-pill', activeChipDef ? 'is-active' : ''].join(' ')}
+            >
+              {activeChipDef
+                ? <span className="as-modos-pill-emoji" aria-hidden="true">{activeChipDef.emoji}</span>
+                : <Wrench size={16} strokeWidth={2.2} aria-hidden="true" />}
+              <span className="as-modos-pill-txt">{activeChipDef ? activeChipDef.label : 'Modos'}</span>
+            </button>
+
             <div className="flex-1" />
 
             {/* Micrófono (toggle) — GRANDE (TIER 2 #5): el camino principal
@@ -3527,6 +3548,59 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             quitar los chips/líneas de sugerencia que ensucian la pantalla del
             agente. El acceso a capacidades queda por la mano de Chagra (botón
             Ⓐ del compositor + botón de la pantalla vacía). */}
+
+        {/* ── V2 · GAVETA DE MODOS Y HERRAMIENTAS ─────────────────────────────
+            Colapsa la bandeja de ~12 chips (ChipsToolbar) que ahogaba el chat.
+            Misma data y ruteo; solo cambia el contenedor: una gaveta con scroll
+            que se cierra al elegir o al tocar afuera. Con la gaveta cerrada el
+            chat tiene el alto completo. */}
+        {modosSheetOpen && (
+          <div
+            className="as-gaveta"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Modos y herramientas del agente"
+            data-testid="agent-modos-sheet"
+          >
+            <button
+              type="button"
+              className="as-gaveta-scrim"
+              aria-label="Cerrar modos y herramientas"
+              onClick={() => setModosSheetOpen(false)}
+            />
+            <div className="as-gaveta-panel">
+              <span className="as-gaveta-grab" aria-hidden="true" />
+              <div className="as-gaveta-head">
+                <span className="as-gaveta-ico" aria-hidden="true"><Wrench size={17} strokeWidth={2.2} /></span>
+                <div className="as-gaveta-titwrap">
+                  <h2>Modos y herramientas</h2>
+                  <p>Toca un modo y Chagra va directo al grano.</p>
+                </div>
+                <button
+                  type="button"
+                  className="as-gaveta-close"
+                  onClick={() => setModosSheetOpen(false)}
+                  aria-label="Cerrar"
+                >
+                  <X size={18} aria-hidden="true" />
+                </button>
+              </div>
+              <div className="as-gaveta-body">
+                <ChipsToolbar
+                  activeIntent={activeIntent}
+                  hasAttachment={Boolean(agentAttachment)}
+                  disabled={state === STATE_RECORDING || queuePending.length >= 1}
+                  isPro={isPro}
+                  chipDefs={profileChipDefs}
+                  onSelectIntent={(intent) => {
+                    setActiveIntent((current) => (current === intent ? null : intent));
+                    setModosSheetOpen(false);
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Input oculto de foto */}
         <input

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -333,8 +333,8 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
   };
 
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3.5`}>
-      <div className={`flex gap-2 max-w-[85%] ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-4`}>
+      <div className={`flex gap-2.5 max-w-[86%] ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
         {isUser ? (
           <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-emerald-600 ring-1 ring-emerald-400/40 shadow-sm shadow-emerald-950/30">
             <User size={16} className="text-white" />
@@ -342,20 +342,20 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
         ) : (
           <div
             className={`shrink-0 w-9 h-9 rounded-full flex items-center justify-center bg-slate-900 border overflow-hidden ${
-              isStreaming ? 'border-amber-400/60 shadow-[0_0_10px_rgba(245,158,11,.4)]' : 'border-emerald-700/40'
+              isStreaming ? 'border-amber-400/60 shadow-[0_0_12px_rgba(245,158,11,.42)]' : 'border-emerald-600/45'
             }`}
           >
             <ChagraAgentAvatar state={agentState} size={32} ariaLabel="Chagra IA" />
           </div>
         )}
 
+        {/* V2: burbuja THEME-NATIVE (papel en temas claros, vidrio en biopunk)
+            via .chatb-agent/.chatb-user (index.css, tokens). */}
         <div
-          className={`rounded-2xl px-4 py-3 shadow-md ${
+          className={`rounded-[20px] px-4 py-3 ${
             isUser
-              ? 'bg-emerald-700/70 text-white rounded-tr-md border border-emerald-500/25 shadow-emerald-950/25'
-              : `bg-slate-800/90 text-slate-100 rounded-tl-md border border-slate-700/60 shadow-slate-950/30 cursor-pointer${
-                  isGrounded ? ' border-l-2 border-l-emerald-400/70' : ''
-                }`
+              ? 'chatb-user rounded-tr-md'
+              : `chatb-agent rounded-tl-md cursor-pointer`
           }`}
           data-grounded={isGrounded ? 'true' : undefined}
           onDoubleClick={handleBubbleDoubleClick}

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -396,25 +396,33 @@ describe('AgentScreen - chips toolbar', () => {
     vi.clearAllMocks();
   });
 
-  it('monta la barra de chips junto al input y cambia la intencion al tocar un chip', async () => {
+  it('V2: colapsa la bandeja en la gaveta; el disparador etiquetado la abre y elegir un modo lo fuerza y lo muestra', async () => {
     render(<AgentScreen onBack={() => {}} />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('chips-toolbar')).toBeInTheDocument();
-    });
+    // El disparador etiquetado vive en el compositor; la gaveta arranca CERRADA
+    // (el chat recupera el alto). ChipsToolbar NO está montada hasta abrirla.
+    const trigger = await screen.findByTestId('agent-modos-trigger');
+    expect(trigger).toHaveTextContent('Modos');
+    expect(screen.queryByTestId('chips-toolbar')).not.toBeInTheDocument();
 
-    const toolbar = screen.getByTestId('chips-toolbar');
-    const input = screen.getByTestId('agent-input');
-    expect(toolbar.compareDocumentPosition(input) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
-
+    // Abrir la gaveta → la bandeja aparece con sus chips.
+    fireEvent.click(trigger);
+    const toolbar = await screen.findByTestId('chips-toolbar');
     expect(toolbar).toHaveTextContent('Biopreparado');
-    const biopreparadoChip = screen.getByRole('button', { name: /biopreparado/i });
-    fireEvent.click(biopreparadoChip);
 
-    expect(biopreparadoChip).toHaveAttribute('aria-pressed', 'true');
+    // Elegir un modo lo fuerza: cambia el placeholder del input, cierra la gaveta
+    // y el disparador pasa a MOSTRAR el modo activo (el chip queda desmontado al
+    // cerrar, por eso verificamos el efecto persistente, no aria-pressed).
+    fireEvent.click(screen.getByRole('button', { name: /biopreparado/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('chips-toolbar')).not.toBeInTheDocument();
+    });
     expect(screen.getByTestId('agent-input')).toHaveAttribute(
       'placeholder',
       'Escribe para que plaga o planta quieres el biopreparado',
     );
+    expect(screen.getByTestId('agent-modos-trigger')).toHaveTextContent('Biopreparado');
+    expect(screen.getByTestId('agent-modos-trigger').className).toMatch(/is-active/);
   });
 });

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -143,6 +143,108 @@ export const AGENT_COMPOSITOR_CSS = `
     transition: opacity 0.25s ease, box-shadow 0.25s ease;
   }
   .as-send:disabled { opacity: 0.35; cursor: not-allowed; }
+
+  /* ══════════════════════════════════════════════════════════════════════════
+     V2 · MODOS Y HERRAMIENTAS — la bandeja de ~12 chips (ChipsToolbar) que antes
+     vivía SIEMPRE sobre el input y comía media pantalla en el celular se colapsa
+     en un DISPARADOR ETIQUETADO del compositor que TAMBIÉN muestra el modo
+     activo, y las sugerencias se abren en una GAVETA con scroll. Token-aware
+     (--c-*/--t-accent-rgb) → coherente en los 4 temas.
+     ══════════════════════════════════════════════════════════════════════════ */
+  .as-modos-pill {
+    flex: 0 1 auto; min-width: 0; height: 44px; max-width: 148px;
+    display: inline-flex; align-items: center; gap: 7px;
+    padding: 0 13px; border-radius: 22px;
+    background: rgb(var(--c-surface-raised, 30 41 59) / 0.9);
+    border: 1px solid rgb(var(--c-surface-border, 100 116 139) / 0.55);
+    color: rgb(var(--c-slate-300, 148 163 184)); cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  }
+  .as-modos-pill:hover {
+    color: rgb(var(--c-slate-100, 226 232 240));
+    border-color: rgb(var(--t-accent-rgb, 25 201 154) / 0.5);
+  }
+  .as-modos-pill:disabled { opacity: 0.4; cursor: not-allowed; }
+  .as-modos-pill.is-active {
+    background: rgb(var(--t-accent-rgb, 25 201 154) / 0.16);
+    border-color: rgb(var(--t-accent-rgb, 25 201 154) / 0.6);
+    color: rgb(var(--t-accent-rgb, 25 201 154));
+  }
+  .as-modos-pill-emoji { font-size: 16px; line-height: 1; flex: none; }
+  .as-modos-pill-txt {
+    min-width: 0; font-size: 13px; font-weight: 800; letter-spacing: 0.1px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+
+  .as-gaveta {
+    position: fixed; inset: 0; z-index: 60;
+    display: flex; flex-direction: column; justify-content: flex-end;
+  }
+  .as-gaveta-scrim {
+    position: absolute; inset: 0; border: 0; padding: 0; margin: 0; cursor: pointer;
+    background: rgba(6, 14, 11, 0.56);
+    -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px);
+    animation: as-gaveta-fade 0.22s ease both;
+  }
+  .as-gaveta-panel {
+    position: relative; z-index: 1;
+    width: 100%; max-width: 640px; margin: 0 auto;
+    max-height: min(68vh, 540px);
+    display: flex; flex-direction: column;
+    background: rgb(var(--c-surface-card, 17 24 39));
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85));
+    border-bottom: 0; border-radius: 26px 26px 0 0;
+    box-shadow: 0 -20px 52px -16px rgba(0, 0, 0, 0.6);
+    padding: 8px 15px calc(env(safe-area-inset-bottom, 0px) + 16px);
+    animation: as-gaveta-rise 0.34s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  .as-gaveta-grab {
+    width: 44px; height: 4px; border-radius: 999px; flex: none;
+    background: rgb(var(--c-slate-300, 148 163 184) / 0.5);
+    margin: 5px auto 10px;
+  }
+  .as-gaveta-head { display: flex; align-items: center; gap: 11px; margin-bottom: 6px; }
+  .as-gaveta-ico {
+    flex: none; width: 40px; height: 40px; border-radius: 13px;
+    display: flex; align-items: center; justify-content: center;
+    background: rgb(var(--t-accent-rgb, 25 201 154) / 0.16);
+    color: rgb(var(--t-accent-rgb, 25 201 154));
+    border: 1px solid rgb(var(--t-accent-rgb, 25 201 154) / 0.3);
+  }
+  .as-gaveta-titwrap { flex: 1; min-width: 0; }
+  .as-gaveta-titwrap h2 {
+    font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+    font-weight: 800; font-size: 17px; letter-spacing: -0.3px; line-height: 1.1;
+    color: rgb(var(--c-slate-100, 241 245 249));
+  }
+  .as-gaveta-titwrap p {
+    font-size: 12px; line-height: 1.3; margin-top: 2px;
+    color: rgb(var(--c-slate-400, 148 163 184));
+  }
+  .as-gaveta-close {
+    flex: none; width: 38px; height: 38px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    background: rgb(var(--c-surface-raised, 30 41 59));
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85));
+    color: rgb(var(--c-slate-300, 148 163 184)); cursor: pointer;
+    transition: color 0.18s ease, border-color 0.18s ease;
+  }
+  .as-gaveta-close:hover {
+    color: rgb(var(--c-slate-100, 241 245 249));
+    border-color: rgb(var(--t-accent-rgb, 25 201 154) / 0.5);
+  }
+  .as-gaveta-body { overflow-y: auto; overscroll-behavior: contain; -webkit-overflow-scrolling: touch; }
+  .as-gaveta-body .agent-chip-tray {
+    background: transparent !important; border-top: 0 !important;
+    -webkit-backdrop-filter: none !important; backdrop-filter: none !important;
+    padding: 2px 2px;
+  }
+  @keyframes as-gaveta-rise { from { transform: translateY(100%); } to { transform: translateY(0); } }
+  @keyframes as-gaveta-fade { from { opacity: 0; } to { opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) {
+    .as-gaveta-panel, .as-gaveta-scrim { animation: none !important; }
+    .as-modos-pill { transition: none; }
+  }
   @keyframes as-send-shimmer {
     0%   { transform: translateX(-130%); opacity: 0; }
     25%  { opacity: 1; }

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -1135,3 +1135,107 @@
   text-shadow: var(--fvh-on-cielo-sombra);
 }
 .fvh .fvh-portales-tit span { background: var(--fvh-on-cielo-div); }
+
+/* ════════════════════════════════════════════════════════════════════════════
+   V2 · ELEVACIÓN A NIVEL DEMO — dirección "CINE DE FINCA" (2026-07-03).
+   Distinta de V1 (abanico + bruma que respira): aquí la portada se trata como un
+   PLANO cinematográfico — rayos de luz volumétricos que bajan del sol, una viñeta
+   que enfoca la finca, y los 4 portales como TECLAS FÍSICAS que se hunden al
+   pulsarlas. Solo capa visual, aditiva, coherente en los 4 temas y respetuosa de
+   reduced-motion (el kill-switch de arriba congela todo lo animado). No promueve
+   la flag ni toca lógica/props/testids. Respeta el A/B del colibrí (ambos).
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* ── Viñeta cinematográfica: enfoca la mirada en la finca (esquinas al fondo,
+     brillo de aire arriba). z3: sobre el arte SVG, bajo los bichos/globo. */
+.fvh-escena::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+  border-radius: inherit;
+  background:
+    radial-gradient(130% 78% at 50% 8%, rgba(255, 255, 255, 0.08), transparent 42%),
+    radial-gradient(120% 100% at 50% 108%, rgba(10, 18, 10, 0.34), transparent 60%);
+}
+
+/* ── Rayos de luz volumétricos que bajan del sol (arriba-derecha en la finca).
+     Haz de bandas cálidas, enmascarado para concentrarse cerca del sol y
+     desvanecerse hacia abajo; deriva y respira muy lento. z4: sobre el arte,
+     bajo los bichos (z7)/globo (z8). */
+.fvh-escena::after {
+  content: "";
+  position: absolute;
+  inset: -10% -10% 0 -10%;
+  pointer-events: none;
+  z-index: 4;
+  background: repeating-linear-gradient(
+    106deg,
+    transparent 0 26px,
+    rgba(255, 240, 194, 0.09) 26px 34px,
+    transparent 34px 72px
+  );
+  -webkit-mask-image: radial-gradient(58% 66% at 84% 4%, #000 0, rgba(0,0,0,0.45) 42%, transparent 72%);
+  mask-image: radial-gradient(58% 66% at 84% 4%, #000 0, rgba(0,0,0,0.45) 42%, transparent 72%);
+  opacity: 0.75;
+  animation: fvh-rayos 11s ease-in-out infinite;
+}
+.fvh[data-luz="noche"] .fvh-escena::after {
+  background: repeating-linear-gradient(
+    106deg,
+    transparent 0 26px,
+    rgba(190, 214, 255, 0.07) 26px 34px,
+    transparent 34px 72px
+  );
+  opacity: 0.55;
+}
+.fvh[data-luz="amanecer"] .fvh-escena::after,
+.fvh[data-luz="atardecer"] .fvh-escena::after {
+  background: repeating-linear-gradient(
+    106deg,
+    transparent 0 24px,
+    rgba(255, 186, 120, 0.12) 24px 33px,
+    transparent 33px 70px
+  );
+  opacity: 0.85;
+}
+@keyframes fvh-rayos {
+  0%, 100% { transform: translateX(0); opacity: 0.55; }
+  50%      { transform: translateX(-14px); opacity: 0.85; }
+}
+
+/* ── Los 4 portales como TECLAS FÍSICAS: repisa inferior + filo de luz superior
+     (relieve), y se HUNDEN al pulsarlas (la tecla baja y la sombra se recoge).
+     Sin abanico — otra firma que la de V1. */
+.fvh-portal {
+  box-shadow:
+    0 16px 30px var(--fvh-sombra-iso),
+    0 2px 0 rgba(255, 255, 255, 0.30) inset,
+    0 -8px 14px -8px rgba(10, 18, 10, 0.5) inset;
+  transition: transform 0.14s cubic-bezier(0.34, 1.2, 0.64, 1), box-shadow 0.14s ease;
+}
+.fvh-portal:active {
+  transform: translateY(4px) scale(0.99);
+  box-shadow:
+    0 6px 14px var(--fvh-sombra-iso),
+    0 1px 0 rgba(255, 255, 255, 0.22) inset,
+    0 -5px 10px -8px rgba(10, 18, 10, 0.5) inset;
+}
+@media (hover: hover) and (pointer: fine) {
+  .fvh-portal:hover {
+    transform: translateY(-5px);
+    box-shadow:
+      0 24px 44px rgb(var(--p-glow) / 0.5),
+      0 2px 0 rgba(255, 255, 255, 0.38) inset,
+      0 -8px 14px -8px rgba(10, 18, 10, 0.5) inset;
+  }
+}
+
+/* ── Colibrí: un DESTELLO en el plumaje (brillo que sube y baja) — distinto del
+     tornasol por hue-rotate de V1. */
+.fvh-colibri-svg { animation: fvh-colibri-destello 4.6s ease-in-out infinite; }
+@keyframes fvh-colibri-destello {
+  0%, 100% { filter: brightness(1) saturate(1); }
+  50%      { filter: brightness(1.14) saturate(1.1); }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -492,6 +492,30 @@
     backdrop-filter: blur(12px);
   }
 
+  /* ─────────────────────────────────────────────────────────────────────────
+   * V2 · BURBUJAS DE CHAT THEME-NATIVE. En vez de un slate oscuro fijo, la
+   * burbuja toma la PIEL del tema: papel cálido en nature/minimalista/verde-vivo,
+   * vidrio oscuro en biopunk. Así el chat se lee como "cuaderno de campo" al sol
+   * y como panel nocturno en biopunk — coherente en los 4 temas, legible siempre.
+   * ------------------------------------------------------------------------- */
+  .chatb-agent {
+    background-color: rgb(var(--c-surface-card));
+    color: rgb(var(--c-slate-100));
+    border: 1px solid rgb(var(--c-surface-border));
+    box-shadow: 0 6px 18px -10px rgba(0, 0, 0, 0.45);
+  }
+  /* Filo de "renglón" del cuaderno + realce de grounding cuando la respuesta
+   * viene del catálogo. */
+  .chatb-agent[data-grounded="true"] {
+    border-left: 3px solid rgb(var(--c-emerald-500) / 0.9);
+  }
+  .chatb-user {
+    background-color: rgb(var(--c-emerald-600));
+    color: #fff;
+    border: 1px solid rgb(var(--c-emerald-500) / 0.45);
+    box-shadow: 0 6px 18px -10px rgb(var(--c-emerald-700) / 0.6);
+  }
+
   /* ---------------------------------------------------------------------------
    * TOUCH TARGET DE CAMPO (a11y 2026-07-03 — dedos grandes, sol, guantes).
    * Área táctil mínima 44×44px (WCAG 2.5.5 / guías iOS-Android) SIN cambiar el


### PR DESCRIPTION
## Segunda versión (V2) — segunda pasada, dirección alternativa

**Nota de intencionalidad.** Este PR es la **segunda pasada** del mismo encargo (rediseño del chat del agente + portada Finca Viva), hecha DESPUÉS de la V1 y a partir de lo aprendido, para **evaluar dos resultados lado a lado** en PRs separados. Mismo lenguaje base ("Tierra y savia"), pero **énfasis intencional distinto**: V1 apuesta por lo *cálido, lúdico y cozy*; **V2 apuesta por lo *theme-native, sereno y cinematográfico*.** Ambas cumplen el requisito duro (colapsar la bandeja de chips, recuperar el alto del chat, coherencia en 4 temas, cero cambios de lógica).

Comparte rama con nadie: parte **fresca de `main`** (independiente de la V1).

### En qué difiere V2 de V1 (para el evaluador)

| | **V1** (PR #2026) | **V2** (este PR) |
|---|---|---|
| Disparador de modos | Botón de **ícono** en el compositor + **cinta de modo activo** aparte | **Un solo control etiquetado** que *es* el disparador **y** el indicador de modo ("Modos" → "🐛 Plaga") |
| Gaveta | Bottom-sheet simple | **Gaveta titulada** (ícono + título + subtítulo) |
| Burbujas de chat | Charcoal-verde **fijo** (cozy oscuro en todos los temas) | **Theme-native**: papel cálido en temas claros, vidrio oscuro en biopunk (`.chatb-agent/.chatb-user` con tokens) |
| Firma del hero | **Abanico**: los 4 portales como naipes en abanico + **bruma que respira** | **Cine de finca**: **rayos de luz** volumétricos + **viñeta** + portales como **teclas físicas** que se hunden |
| Colibrí | Iridiscencia por **hue-rotate** + vuelo con dardo | **Destello** de plumaje (brillo) |

### Punto 1 — AgentScreen (chat)
- Bandeja de ~12 chips (`ChipsToolbar`) colapsada en un **disparador etiquetado** del compositor que también muestra el modo activo; abre una **gaveta** con scroll (cierra al elegir o al tocar afuera). Misma data y ruteo: la **misma `ChipsToolbar`** dentro de la gaveta. Con la gaveta cerrada, el chat recupera el **alto completo**.
- **Chat theme-native**: burbujas que toman la piel del tema (papel/vidrio) → se lee como cuaderno de campo al sol y panel nocturno en biopunk.
- Test `AgentScreen.chipsToolbar` ajustado al markup nuevo.

### Punto 2 — Portada Finca Viva (`FincaVivaHero`, solo CSS)
Rayos de luz volumétricos (enmascarados hacia el sol) · viñeta cinematográfica · portales como teclas físicas con relieve que se hunden al pulsar · colibrí con destello de plumaje. Respeta A/B del colibrí, reduced-motion y los 4 temas.

### Verificación
`npm run build` verde. Tests de componentes tocados verdes (135).

> **Cómo evaluar:** abrir #2026 (V1) y este (V2) en el demo con la flag finca-viva ON; comparar el chat (dark cozy vs papel theme-native) y la portada (abanico+bruma vs rayos+teclas). Elegir una, o combinar (p.ej. gaveta+burbujas theme-native de V2 con el abanico de V1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
