### PR TITLE
feat(iconos): refinar iconos por especie y etapa de ciclo

### DIFF
--- a/src/components/PhenologyTimeline.jsx
+++ b/src/components/PhenologyTimeline.jsx
@@ -1,6 +1,37 @@
 import React, { useMemo } from 'react';
 import { Clock, Eye, HelpCircle, AlertTriangle, CheckCircle, Sprout, Timer } from 'lucide-react';
 import { calculateWindows, formatWindow, getCurrentStage } from '../services/phenologyCalculator';
+import { GLYPHS } from './CicloVivo/cicloVivoArte';
+
+// Glifo campesino por etapa fenológica. Reusa la familia de arte aprobada de
+// "El Ciclo Vivo" (cicloVivoArte) para que la línea de tiempo y la rueda hablen
+// el MISMO idioma visual: cada etapa se reconoce por su ilustración, no solo por
+// un punto de color. El color es la paleta canónica de fase (semilla parda →
+// cosecha dorada). Solo presentación; el código de etapa no cambia.
+const STAGE_GLYPH = {
+  sowing: { key: 'semilla', color: '#A9793F' },
+  emergence: { key: 'germinacion', color: '#7CA46B' },
+  vegetative: { key: 'crecimiento', color: '#5B9146' },
+  flowering: { key: 'floracion', color: '#E8879C' },
+  fruiting: { key: 'fructificacion', color: '#DA6236' },
+  harvest_window: { key: 'cosecha', color: '#D49A46' },
+  closed: { key: 'poscosecha', color: '#C9A227' },
+};
+
+/** Glifo de etapa (silueta campesina de la fase, coloreada por su paleta). */
+function StageGlyph({ code, size }) {
+  const g = STAGE_GLYPH[code];
+  if (!g || typeof GLYPHS[g.key] !== 'function') return null;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="-12 -12 24 24"
+      aria-hidden="true"
+      dangerouslySetInnerHTML={{ __html: GLYPHS[g.key](g.color) }}
+    />
+  );
+}
 
 // Colores theme-aware: la rampa slate/emerald/amber y los acentos custom
 // (orchid/morpho) se remapean por tema (themes.css / tailwind.config.js), así el
@@ -11,19 +42,6 @@ const confidenceColor = (c) => {
   if (c >= 0.6) return 'text-emerald-300';
   if (c >= 0.4) return 'text-amber-400';
   return 'text-slate-500';
-};
-
-const stageColor = (code) => {
-  const map = {
-    sowing: 'bg-emerald-800 border-emerald-600',
-    emergence: 'bg-emerald-700 border-emerald-500',
-    vegetative: 'bg-emerald-600 border-emerald-400',
-    flowering: 'bg-orchid border-orchid',
-    fruiting: 'bg-amber-700 border-amber-500',
-    harvest_window: 'bg-amber-600 border-amber-400',
-    closed: 'bg-slate-700 border-slate-500',
-  };
-  return map[code] || 'bg-slate-700 border-slate-500';
 };
 
 /**
@@ -125,10 +143,25 @@ export default function PhenologyTimeline({
                   : ''
               }`}
             >
-              {/* Indicador de etapa */}
+              {/* Indicador de etapa: medallón con el glifo campesino de la fase.
+                  La identidad de color viaja en el propio glifo (paleta de fase);
+                  el disco es un fondo neutro que deja leer la ilustración y porta
+                  los estados (observada / estimada / pasada). */}
               <div className="flex flex-col items-center gap-0.5 shrink-0">
-                <div className={`rounded-full border ${isCurrent ? 'w-3.5 h-3.5' : 'w-3 h-3'} ${stageColor(win.code)} ${isObservedCurrent ? 'ring-2 ring-emerald-400/50' : ''} ${isEstimatedCurrent ? 'ring-2 ring-morpho/40 border-dashed' : ''} ${isPast ? 'opacity-50' : ''}`} />
-                {i < windows.length - 1 && <div className="w-px h-4 bg-slate-700" />}
+                <div
+                  className={`grid place-items-center rounded-full border shrink-0 transition-colors ${
+                    isCurrent ? 'w-7 h-7' : 'w-6 h-6'
+                  } ${
+                    isObservedCurrent
+                      ? 'bg-emerald-500/15 border-emerald-500/50 ring-2 ring-emerald-400/40'
+                      : isEstimatedCurrent
+                        ? 'bg-morpho/10 border-dashed border-morpho/45 ring-2 ring-morpho/30'
+                        : 'bg-slate-800/70 border-slate-700'
+                  } ${isPast ? 'opacity-50' : ''}`}
+                >
+                  <StageGlyph code={win.code} size={isCurrent ? 18 : 15} />
+                </div>
+                {i < windows.length - 1 && <div className="w-px h-4 bg-slate-700/70" />}
               </div>
 
               {/* Contenido */}

--- a/src/components/SpeciesImage.jsx
+++ b/src/components/SpeciesImage.jsx
@@ -3,7 +3,7 @@
  * nombre cientifico. Ese estado async no pertenece al render sincrono.
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Bug, ImageOff, Leaf, Microscope } from 'lucide-react';
+import { Bug, ImageOff, Leaf, Microscope, Sprout } from 'lucide-react';
 import { getSpeciesImage, parseCatalogImage } from '../services/speciesImageService';
 
 // Bug #61 (ficha de especie, foto no carga): en senal movil rural el
@@ -26,17 +26,23 @@ function classifySpecies({ category, commonName, scientificName }) {
 function FallbackIcon({ kind, size = 28 }) {
   if (kind === 'microorganismo') return <Microscope size={size} aria-hidden="true" />;
   if (kind === 'patogeno') return <Bug size={size} aria-hidden="true" />;
+  // Maleza / invasora / pasto / helecho: es un ser vivo, no un "sin imagen".
+  // Un brote lo dice mejor que el icono roto de ImageOff.
+  if (kind === 'organismo') return <Sprout size={size} aria-hidden="true" />;
   if (kind === 'planta') return <Leaf size={size} aria-hidden="true" />;
   return <ImageOff size={size} aria-hidden="true" />;
 }
 
 // Emoji grande de categoria - la cara visible del fallback cuando NO hay
-// foto. Contexto inmediato (campesino/nino) sin depender de la red.
+// foto. Contexto inmediato (campesino/nino) sin depender de la red. Un set
+// legible a tamano chico y con las cuatro categorias claramente distintas:
+// cultivo (brote), plaga (insecto), microorganismo (lupa) y maleza/pasto
+// (espiga), sin dos verdes que se confundan de lejos.
 const FALLBACK_EMOJI = {
-  planta: '\u{1F331}',
-  patogeno: '\u{1F41B}',
-  microorganismo: '\u{1F52C}',
-  organismo: '\u{1F33F}',
+  planta: '\u{1F331}', // brote
+  patogeno: '\u{1F41B}', // insecto
+  microorganismo: '\u{1F52C}', // microscopio
+  organismo: '\u{1F33E}', // espiga de pasto/maleza
 };
 
 // Fondo suave por categoria - el fallback NUNCA es un hueco vacio.
@@ -199,10 +205,12 @@ export default function SpeciesImage({
       return (
         <div
           data-testid="species-image-fallback"
-          className={`flex h-20 items-center gap-2 rounded-lg border bg-gradient-to-br px-3 ${bg} ${className}`}
+          className={`flex h-20 items-center gap-2.5 rounded-lg border bg-gradient-to-br px-3 ${bg} ${className}`}
           title={`Sin foto de referencia para ${displayName}`}
         >
-          <span className="text-2xl leading-none" aria-hidden="true">{emoji}</span>
+          <span className="grid h-11 w-11 shrink-0 place-items-center rounded-lg bg-slate-950/40 ring-1 ring-white/10">
+            <span className="text-2xl leading-none" aria-hidden="true">{emoji}</span>
+          </span>
           <span className="min-w-0 truncate text-xs font-semibold text-slate-200">{displayName}</span>
         </div>
       );


### PR DESCRIPTION
Unifica el idioma visual de los iconos de catalogo/directorio/cards con
la familia de arte campesina ya aprobada de "El Ciclo Vivo".

- PhenologyTimeline: cada etapa fenologica se marca con el glifo campesino
  de su fase (semilla/germinacion/.../poscosecha) reusando GLYPHS de
  cicloVivoArte, coloreado con la paleta canonica de fase. Se reconoce la
  etapa por su ilustracion, no solo por un punto de color; los estados
  (observada/estimada/pasada) viajan en el medallon. Se elimina stageColor
  (ya sin uso).
- SpeciesImage (fallback sin foto): set de 4 categorias mas distinto y
  legible a tamano chico (cultivo/plaga/microorganismo/maleza), la maleza
  deja de usar el icono roto ImageOff por un brote (Sprout), y el fallback
  compacto ahora lleva el mismo medallon que el completo para coherencia.

Solo capa visual: sin cambios de logica, props ni testids.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
