### PR TITLE
feat(ux): estados vacíos y de carga con ilustración

### DIFF
--- a/src/components/AssetTimeline.jsx
+++ b/src/components/AssetTimeline.jsx
@@ -7,6 +7,7 @@ import { savePayload } from '../services/payloadService';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import { usePhotoUrl } from '../hooks/usePhotoUrl';
 import BeforeAfterPhoto from './BeforeAfterPhoto';
+import EmptyStateCampo from './common/EmptyStateCampo.jsx';
 
 /**
  * AssetTimeline, Línea de tiempo agroecológica de un activo (plant).
@@ -470,12 +471,12 @@ export default function AssetTimeline({ assetId }) {
       )}
 
       {logs.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-center text-slate-500 min-h-[300px]">
-          <Leaf size={32} className="mx-auto mb-2 opacity-40" />
-          <p className="text-sm">Sin eventos registrados en los últimos 30 días.</p>
-          <p className="text-xs mt-1 opacity-70">
-            Los registros de siembra, insumos y cosecha aparecerán aquí.
-          </p>
+        <div className="flex-1 flex flex-col items-center justify-center min-h-[300px]">
+          <EmptyStateCampo
+            variant="bitacora"
+            title="Sin eventos registrados en los últimos 30 días."
+            hint="La bitácora de esta planta está por escribirse: cada siembra, aplicación y cosecha que registres se anota aquí."
+          />
         </div>
       ) : (
         <div className="flex-1 min-h-0 border-l-2 border-slate-800 ml-2">

--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { ChevronLeft, Search, Sprout, Leaf, X, BookOpen } from 'lucide-react';
+import { ChevronLeft, Search, Sprout, Leaf, X } from 'lucide-react';
 import { searchSpecies, buildSpeciesFicha } from '../../services/directorioEspecies.js';
 import SpeciesFicha from './SpeciesFicha.jsx';
+import EmptyStateCampo from '../common/EmptyStateCampo.jsx';
+import SkeletonCampo from '../common/SkeletonCampo.jsx';
+import ChagraGrowLoader from '../ChagraGrowLoader.jsx';
 import { fvhSkinClass } from '../../config/fvhSkin.js';
 
 /**
@@ -163,22 +166,30 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
       {/* Resultados / estados */}
       <div className="px-4 pt-4">
         {loadingFicha && (
-          <p className="jp-tinta-suave text-sm text-slate-400" data-testid="directorio-loading-ficha">Abriendo la ficha…</p>
+          <div data-testid="directorio-loading-ficha">
+            <p className="jp-tinta-suave flex items-center gap-2 text-sm text-slate-400 mb-3">
+              <ChagraGrowLoader size={26} aria-hidden="true" />
+              Abriendo la ficha…
+            </p>
+            <SkeletonCampo variant="ficha" />
+          </div>
         )}
 
         {!loadingFicha && searching && (
-          <p className="jp-tinta-suave text-sm text-slate-400">Buscando…</p>
+          <SkeletonCampo
+            variant="lista"
+            count={3}
+            label={<span className="jp-tinta-suave">Buscando en el catálogo…</span>}
+          />
         )}
 
         {!loadingFicha && !searching && touched && query.trim().length >= 2 && results.length === 0 && (
-          <div className="text-center py-10" data-testid="directorio-empty">
-            <Leaf size={32} className="mx-auto text-slate-700 mb-2" aria-hidden="true" />
-            <p className="jp-tinta text-sm text-slate-400">
-              No encontramos “{query.trim()}” en el catálogo todavía.
-            </p>
-            <p className="jp-tinta-suave text-xs text-slate-500 mt-1">
-              Prueba con otro nombre común o el nombre científico.
-            </p>
+          <div className="py-8" data-testid="directorio-empty">
+            <EmptyStateCampo
+              variant="busqueda"
+              title={<span className="jp-tinta">No encontramos “{query.trim()}” en el catálogo todavía.</span>}
+              hint={<span className="jp-tinta-suave">Prueba con otro nombre común o el nombre científico: la misma planta cambia de nombre de vereda en vereda.</span>}
+            />
           </div>
         )}
 
@@ -216,12 +227,17 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
 
         {/* Estado inicial vacío — guía */}
         {!loadingFicha && !searching && !touched && results.length === 0 && (
-          <div className="text-center py-12" data-testid="directorio-hint">
-            <BookOpen size={34} className="mx-auto text-slate-700 mb-3" aria-hidden="true" />
-            <p className="jp-tinta-suave text-sm text-slate-400 max-w-xs mx-auto leading-relaxed">
-              Busca cualquier especie del catálogo y mira su piso térmico, con qué
-              se asocia, qué biopreparados le sirven y qué plagas la afectan.
-            </p>
+          <div className="py-10" data-testid="directorio-hint">
+            <EmptyStateCampo
+              variant="directorio"
+              title={<span className="jp-tinta">El cuaderno de especies de tu chagra.</span>}
+              hint={
+                <span className="jp-tinta-suave">
+                  Busca cualquier especie del catálogo y mira su piso térmico, con qué
+                  se asocia, qué biopreparados le sirven y qué plagas la afectan.
+                </span>
+              }
+            />
           </div>
         )}
       </div>

--- a/src/components/InventoryDashboard.jsx
+++ b/src/components/InventoryDashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { Package, AlertTriangle, Plus, X, Download } from 'lucide-react';
+import EmptyStateCampo from './common/EmptyStateCampo.jsx';
 import useAssetStore from '../store/useAssetStore';
 import { UNIT_OPTIONS } from '../config/materials';
 import { useConsumptionMetrics } from '../hooks/useConsumptionMetrics';
@@ -339,12 +340,12 @@ export const InventoryDashboard = () => {
       </div>
 
       {materials.length === 0 ? (
-        <div className="py-12 text-center text-slate-500">
-          <Package size={40} className="mx-auto mb-3 opacity-40" />
-          <p className="text-sm">No hay insumos registrados en bodega.</p>
-          <p className="text-xs mt-1 opacity-70">
-            Agrega un material desde el panel de Activos para comenzar a trackear el inventario.
-          </p>
+        <div className="py-10">
+          <EmptyStateCampo
+            variant="bodega"
+            title="No hay insumos registrados en bodega."
+            hint="Los estantes esperan tu primer biopreparado. Agrega un material desde el panel de Activos y aquí llevamos la cuenta de cada litro y cada kilo."
+          />
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/components/InventoryEventTimeline.jsx
+++ b/src/components/InventoryEventTimeline.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { GroupedVirtuoso } from 'react-virtuoso';
 import { Clock, Filter, CheckCircle, Package, ArrowRightLeft, History } from 'lucide-react';
 import { openDB, STORES } from '../db/dbCore';
+import EmptyStateCampo from './common/EmptyStateCampo.jsx';
+import SkeletonCampo from './common/SkeletonCampo.jsx';
 
 const TYPE_CONFIG = {
     input: { icon: ArrowRightLeft, color: 'text-blue-400', label: 'Consumo' },
@@ -134,9 +136,12 @@ export default function InventoryEventTimeline({ itemId }) {
 
     if (loading) {
         return (
-            <div className="p-12 text-center text-slate-500 animate-pulse bg-slate-900/20 rounded-2xl border border-slate-800/50">
-                <History size={32} className="mx-auto mb-3 opacity-20 animate-spin-slow" />
-                <span className="text-xs font-black tracking-widest uppercase">Consultando Inventario…</span>
+            <div className="p-6 bg-slate-900/20 rounded-2xl border border-slate-800/50">
+                <SkeletonCampo
+                    variant="timeline"
+                    count={3}
+                    label="Consultando inventario…"
+                />
             </div>
         );
     }
@@ -168,12 +173,12 @@ export default function InventoryEventTimeline({ itemId }) {
 
             <div className="flex-1 min-h-0 border-l-2 border-slate-800/50 ml-6 my-4 relative">
                 {flatEvents.length === 0 ? (
-                    <div className="absolute inset-0 flex flex-col items-center justify-center text-slate-600 px-8 text-center">
-                        <div className="w-16 h-16 rounded-full bg-slate-900 flex items-center justify-center mb-4 border border-slate-800">
-                            <History size={32} className="opacity-20" />
-                        </div>
-                        <p className="text-xs font-bold uppercase tracking-widest">Sin actividad registrada</p>
-                        <p className="text-[10px] mt-1 opacity-50">Los movimientos de este ítem aparecerán aquí.</p>
+                    <div className="absolute inset-0 flex flex-col items-center justify-center px-8">
+                        <EmptyStateCampo
+                            variant="bitacora"
+                            title="Sin actividad registrada"
+                            hint="Cada consumo, abastecimiento o auditoría de este ítem queda anotado aquí, como en el cuaderno de la finca."
+                        />
                     </div>
                 ) : (
                     <GroupedVirtuoso

--- a/src/components/common/EmptyStateCampo.jsx
+++ b/src/components/common/EmptyStateCampo.jsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import './campo-states.css';
+
+/**
+ * EmptyStateCampo — estado vacío con identidad de cuaderno de campo.
+ *
+ * Cada variante es una viñeta SVG dibujada "a tinta" (trazo redondeado, gris
+ * cálido) sobre la misma línea de suelo del ChagraGrowLoader, con UN solo
+ * elemento vivo por escena (brote esmeralda o fermento ámbar) que respira
+ * lentamente. Nada de iconos genéricos apagados: un vacío en Chagra es una
+ * chagra que espera siembra, no un error.
+ *
+ * Componente PURAMENTE presentacional: sin estado, sin efectos, sin fetch.
+ *
+ * @param {object} props
+ * @param {'directorio'|'busqueda'|'bodega'|'bitacora'} [props.variant]
+ * @param {React.ReactNode} [props.title]   - frase principal (mantener negación explícita: "Sin…", "No hay…").
+ * @param {React.ReactNode} [props.hint]    - guía de qué hacer para llenar este espacio.
+ * @param {string} [props.className]
+ * @param {React.ReactNode} [props.children] - contenido extra (ej. CTA) debajo del hint.
+ */
+
+// Paleta de la viñeta (sobre slate-900/950):
+const INK = '#94a3b8'; // trazo principal (slate-400)
+const INK_SOFT = '#64748b'; // trazo secundario (slate-500)
+const TIERRA = '#8b7d6b'; // suelo y surcos, gris cálido
+const MIMBRE = '#b08954'; // canasto / madera
+const PAGINA = '#1e293b'; // relleno de páginas del cuaderno
+const BROTE = '#34d399'; // el elemento vivo (emerald-400)
+const BROTE_CLARO = '#6ee7b7';
+const SOL = '#fbbf24'; // amber-400
+
+/** Línea de suelo compartida por todas las escenas. */
+const Suelo = () => (
+  <line x1="18" y1="88" x2="142" y2="88" stroke={TIERRA} strokeWidth="1.5" strokeLinecap="round" opacity="0.55" />
+);
+
+/** Sol pequeño con rayos cortos; es el punto cálido de la escena. */
+const Sol = ({ cx = 128, cy = 20 }) => (
+  <g className="esc-vivo" stroke={SOL} strokeWidth="1.4" strokeLinecap="round" fill="none">
+    <circle cx={cx} cy={cy} r="6" />
+    <line x1={cx - 11} y1={cy} x2={cx - 9} y2={cy} />
+    <line x1={cx + 9} y1={cy} x2={cx + 11} y2={cy} />
+    <line x1={cx} y1={cy - 11} x2={cx} y2={cy - 9} />
+    <line x1={cx - 7.5} y1={cy - 7.5} x2={cx - 6} y2={cy - 6} />
+    <line x1={cx + 6} y1={cy - 6} x2={cx + 7.5} y2={cy - 7.5} />
+  </g>
+);
+
+/** Cerro andino al fondo, un trazo suave. */
+const Cerro = () => (
+  <path
+    d="M18,60 Q46,32 70,54 Q88,68 108,56 Q126,46 142,58"
+    fill="none"
+    stroke={INK_SOFT}
+    strokeWidth="1.2"
+    strokeLinecap="round"
+    opacity="0.4"
+  />
+);
+
+/* ── Viñetas ──────────────────────────────────────────────────────────── */
+
+// Directorio (primera vez): cuaderno de campo abierto con una hoja prensada.
+const VignetteDirectorio = () => (
+  <>
+    <Cerro />
+    <Sol />
+    <Suelo />
+    {/* Páginas abiertas */}
+    <path d="M30,54 Q54,47 78,54 L78,86 Q54,79 30,86 Z" fill={PAGINA} stroke={INK} strokeWidth="1.4" strokeLinejoin="round" />
+    <path d="M126,54 Q102,47 78,54 L78,86 Q102,79 126,86 Z" fill={PAGINA} stroke={INK} strokeWidth="1.4" strokeLinejoin="round" />
+    <line x1="78" y1="54" x2="78" y2="86" stroke={INK} strokeWidth="1.2" />
+    {/* Apuntes en la página izquierda */}
+    <g stroke={INK_SOFT} strokeWidth="1.2" strokeLinecap="round" fill="none" opacity="0.7">
+      <path d="M38,62 Q54,57 70,62" />
+      <path d="M38,69 Q54,64 70,69" />
+      <path d="M38,76 Q50,72 60,75" />
+    </g>
+    {/* Hoja prensada en la página derecha: lo único vivo */}
+    <g className="esc-vivo">
+      <path d="M94,60 Q108,60 112,74 Q98,76 92,66 Z" fill={BROTE} opacity="0.9" />
+      <path d="M95,62 Q102,66 109,72" fill="none" stroke="#065f46" strokeWidth="1" strokeLinecap="round" />
+    </g>
+  </>
+);
+
+// Búsqueda sin resultados: lupa sobre los surcos, con un brote adentro.
+const VignetteBusqueda = () => (
+  <>
+    <Cerro />
+    {/* Surcos en perspectiva */}
+    <g fill="none" stroke={TIERRA} strokeWidth="1.3" strokeLinecap="round">
+      <path d="M24,88 Q80,74 136,88" opacity="0.5" />
+      <path d="M32,80 Q80,68 128,80" opacity="0.4" />
+      <path d="M40,72 Q80,63 120,72" opacity="0.3" />
+    </g>
+    {/* Brote dentro del lente: lo que todavía no está sembrado */}
+    <g className="esc-vivo">
+      <line x1="72" y1="60" x2="72" y2="48" stroke={BROTE} strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M72,53 Q65,48 60,50 Q66,55 72,56 Z" fill={BROTE} />
+      <path d="M72,50 Q79,45 84,47 Q78,52 72,53 Z" fill={BROTE_CLARO} />
+    </g>
+    {/* Lupa */}
+    <circle cx="72" cy="52" r="17" fill="none" stroke={INK} strokeWidth="2" />
+    <path d="M59,45 A15,15 0 0 1 66,38" fill="none" stroke="#cbd5e1" strokeWidth="1.4" strokeLinecap="round" opacity="0.5" />
+    <line x1="84.5" y1="64.5" x2="100" y2="82" stroke={INK} strokeWidth="3.5" strokeLinecap="round" />
+    <Suelo />
+  </>
+);
+
+// Bodega vacía: estante con frascos (un fermento vivo) y canasto con hojas.
+const VignetteBodega = () => (
+  <>
+    {/* Estante */}
+    <line x1="26" y1="46" x2="134" y2="46" stroke={MIMBRE} strokeWidth="2" strokeLinecap="round" />
+    <line x1="34" y1="46" x2="30" y2="54" stroke={MIMBRE} strokeWidth="1.4" strokeLinecap="round" opacity="0.5" />
+    <line x1="126" y1="46" x2="130" y2="54" stroke={MIMBRE} strokeWidth="1.4" strokeLinecap="round" opacity="0.5" />
+    {/* Frasco 1 */}
+    <g stroke={INK} strokeWidth="1.4" fill="none">
+      <rect x="38" y="24" width="20" height="22" rx="3" />
+      <rect x="41" y="19" width="14" height="5" rx="2" />
+      <path d="M40,35 Q48,32 56,35" stroke={INK_SOFT} opacity="0.6" />
+    </g>
+    {/* Frasco 2: fermento vivo, burbujeando en ámbar */}
+    <g className="esc-vivo">
+      <rect x="70" y="20" width="20" height="26" rx="3" fill="rgba(251,191,36,0.08)" stroke={SOL} strokeWidth="1.4" />
+      <rect x="73" y="15" width="14" height="5" rx="2" fill="none" stroke={SOL} strokeWidth="1.4" />
+      <circle cx="76" cy="39" r="1.5" fill={SOL} opacity="0.7" />
+      <circle cx="83" cy="33" r="2" fill={SOL} opacity="0.7" />
+      <circle cx="79" cy="27" r="1.2" fill={SOL} opacity="0.7" />
+    </g>
+    {/* Frasco 3, más pequeño */}
+    <g stroke={INK} strokeWidth="1.4" fill="none">
+      <rect x="102" y="29" width="16" height="17" rx="3" />
+      <rect x="104" y="25" width="12" height="4" rx="2" />
+    </g>
+    {/* Hojas frescas asomando del canasto */}
+    <g className="esc-sway">
+      <path d="M70,64 Q64,53 55,51 Q59,62 68,66 Z" fill={BROTE} opacity="0.9" />
+      <path d="M88,63 Q94,53 103,52 Q98,62 90,66 Z" fill={BROTE_CLARO} opacity="0.9" />
+    </g>
+    {/* Canasto tejido */}
+    <path d="M52,66 Q80,60 108,66 L102,85 Q80,89 58,85 Z" fill="rgba(176,137,84,0.12)" stroke={MIMBRE} strokeWidth="1.5" strokeLinejoin="round" />
+    <g stroke={MIMBRE} strokeWidth="1" strokeLinecap="round" opacity="0.5">
+      <line x1="63" y1="65" x2="65" y2="85" />
+      <line x1="74" y1="63" x2="75" y2="87" />
+      <line x1="86" y1="63" x2="86" y2="87" />
+      <line x1="97" y1="65" x2="95" y2="85" />
+    </g>
+    <Suelo />
+  </>
+);
+
+// Bitácora sin eventos: cuaderno con lápiz listo, la historia por escribir.
+const VignetteBitacora = () => (
+  <>
+    <Sol cx={30} cy={20} />
+    <Suelo />
+    {/* Páginas abiertas */}
+    <path d="M30,54 Q54,47 78,54 L78,86 Q54,79 30,86 Z" fill={PAGINA} stroke={INK} strokeWidth="1.4" strokeLinejoin="round" />
+    <path d="M126,54 Q102,47 78,54 L78,86 Q102,79 126,86 Z" fill={PAGINA} stroke={INK} strokeWidth="1.4" strokeLinejoin="round" />
+    <line x1="78" y1="54" x2="78" y2="86" stroke={INK} strokeWidth="1.2" />
+    {/* Lo ya escrito, desvaneciéndose hacia hoy */}
+    <g stroke={INK_SOFT} strokeWidth="1.2" strokeLinecap="round" fill="none">
+      <path d="M38,62 Q54,57 70,62" opacity="0.7" />
+      <path d="M38,69 Q54,64 70,69" opacity="0.45" />
+      <path d="M38,76 Q50,72 58,75" opacity="0.25" />
+    </g>
+    {/* Renglón que espera, punteado */}
+    <path d="M90,64 Q100,61 112,63" fill="none" stroke={INK_SOFT} strokeWidth="1.2" strokeLinecap="round" strokeDasharray="2 4" opacity="0.6" />
+    {/* Lápiz recostado sobre la página derecha */}
+    <g className="esc-vivo">
+      <line x1="130" y1="42" x2="110" y2="66" stroke={MIMBRE} strokeWidth="4.5" strokeLinecap="round" />
+      <line x1="131.5" y1="40" x2="134" y2="37" stroke={INK} strokeWidth="4.5" strokeLinecap="round" />
+      <path d="M110,66 L103,75 L113,70 Z" fill="#d6c9a8" />
+      <circle cx="103.8" cy="74" r="1.4" fill={BROTE} />
+    </g>
+  </>
+);
+
+const VIGNETTES = {
+  directorio: VignetteDirectorio,
+  busqueda: VignetteBusqueda,
+  bodega: VignetteBodega,
+  bitacora: VignetteBitacora,
+};
+
+export default function EmptyStateCampo({
+  variant = 'directorio',
+  title = null,
+  hint = null,
+  className = '',
+  children = null,
+}) {
+  const Vignette = VIGNETTES[variant] || VignetteDirectorio;
+  return (
+    <div className={`flex flex-col items-center text-center px-6 ${className}`}>
+      <svg
+        className="esc-scene mb-3"
+        viewBox="0 0 160 100"
+        width="176"
+        height="110"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <Vignette />
+      </svg>
+      {title && <p className="text-sm font-bold text-slate-200 leading-snug max-w-xs mx-auto">{title}</p>}
+      {hint && <p className="text-xs text-slate-400 mt-1.5 leading-relaxed max-w-xs mx-auto">{hint}</p>}
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/SkeletonCampo.jsx
+++ b/src/components/common/SkeletonCampo.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import './campo-states.css';
+
+/**
+ * SkeletonCampo — composiciones de carga con la forma real del contenido.
+ *
+ * Complementa al primitivo `Skeleton` (línea/rect/círculo): aquí los huesos
+ * ya vienen armados con la silueta de las tarjetas que van a reemplazar
+ * (resultados de búsqueda, ficha de especie, línea de tiempo), con shimmer
+ * cálido y entrada escalonada para que la espera se sienta viva, no técnica.
+ *
+ * Componente PURAMENTE presentacional.
+ *
+ * @param {object} props
+ * @param {'lista'|'ficha'|'timeline'} [props.variant]
+ * @param {number} [props.count]   - filas a dibujar (lista/timeline).
+ * @param {React.ReactNode} [props.label] - texto visible junto al punto vivo.
+ * @param {string} [props.className]
+ */
+
+const Bone = ({ className = '', style = undefined }) => (
+  <div className={`esc-bone ${className}`} style={style} aria-hidden="true" />
+);
+
+/** Punto esmeralda que respira: la señal de "esto está germinando". */
+const Label = ({ children }) => (
+  <p className="flex items-center gap-2 text-xs text-slate-400 mb-3">
+    <span className="esc-vivo inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" aria-hidden="true" />
+    {children}
+  </p>
+);
+
+const delay = (i) => ({ animationDelay: `${i * 140}ms` });
+
+const RowsLista = ({ count }) => (
+  <ul className="space-y-2">
+    {Array.from({ length: count }).map((_, i) => (
+      <li key={i} className="flex items-center gap-3 rounded-xl border border-slate-800/70 bg-slate-900/60 p-3">
+        <Bone className="w-5 h-5 rounded-full shrink-0" style={delay(i)} />
+        <div className="flex-1 space-y-2">
+          <Bone className="h-3 w-1/2" style={delay(i)} />
+          <Bone className="h-2.5 w-1/3" style={delay(i)} />
+        </div>
+      </li>
+    ))}
+  </ul>
+);
+
+const RowsFicha = () => (
+  <div className="space-y-3">
+    <Bone className="h-36 w-full rounded-2xl" />
+    <Bone className="h-4 w-2/3" style={delay(1)} />
+    <Bone className="h-3 w-1/2" style={delay(1)} />
+    <div className="grid grid-cols-2 gap-3 pt-1">
+      <Bone className="h-20 rounded-xl" style={delay(2)} />
+      <Bone className="h-20 rounded-xl" style={delay(2)} />
+    </div>
+  </div>
+);
+
+const RowsTimeline = ({ count }) => (
+  <div className="space-y-3 border-l-2 border-slate-800/60 ml-2 pl-5">
+    {Array.from({ length: count }).map((_, i) => (
+      <div key={i} className="relative">
+        <span className="absolute -left-[27px] top-4 w-3 h-3 rounded-full bg-slate-800 border-2 border-slate-700" aria-hidden="true" />
+        <div className="rounded-xl border border-slate-800/70 bg-slate-900/50 p-3 space-y-2">
+          <div className="flex items-center gap-2">
+            <Bone className="h-3.5 w-16 rounded-full" style={delay(i)} />
+            <Bone className="h-2.5 w-10" style={delay(i)} />
+          </div>
+          <Bone className="h-3 w-3/5" style={delay(i)} />
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+export default function SkeletonCampo({
+  variant = 'lista',
+  count = 3,
+  label = null,
+  className = '',
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      className={className}
+    >
+      {label && <Label>{label}</Label>}
+      {variant === 'ficha' && <RowsFicha />}
+      {variant === 'timeline' && <RowsTimeline count={count} />}
+      {variant === 'lista' && <RowsLista count={count} />}
+    </div>
+  );
+}

--- a/src/components/common/campo-states.css
+++ b/src/components/common/campo-states.css
@@ -1,0 +1,74 @@
+/**
+ * campo-states.css — lenguaje visual compartido de estados vacíos y de carga.
+ *
+ * Una sola gramática: viñetas "tinta de cuaderno de campo" (EmptyStateCampo)
+ * y huesos de carga con shimmer cálido (SkeletonCampo). El único movimiento
+ * permitido es la respiración lenta del elemento vivo de cada escena y el
+ * barrido del shimmer; todo se apaga bajo prefers-reduced-motion.
+ */
+
+/* ── Elemento vivo de la viñeta: respira, no parpadea ───────────────────── */
+@keyframes esc-breathe {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+.esc-vivo {
+  animation: esc-breathe 3.8s ease-in-out infinite;
+}
+
+/* Hoja/brote que se mece apenas, como con brisa de tarde. */
+@keyframes esc-sway {
+  0%, 100% { transform: rotate(-2.5deg); }
+  50% { transform: rotate(2.5deg); }
+}
+
+.esc-sway {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: esc-sway 5.5s ease-in-out infinite;
+}
+
+/* La viñeta entra suave (una sola vez), sin teatralidad. */
+@keyframes esc-settle {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.esc-scene {
+  animation: esc-settle 0.45s ease-out both;
+}
+
+/* ── Huesos de carga: shimmer cálido (destello ámbar tenue) ─────────────── */
+@keyframes esc-shimmer {
+  0% { background-position: 130% 0; }
+  100% { background-position: -90% 0; }
+}
+
+.esc-bone {
+  background-color: rgba(51, 65, 85, 0.45); /* slate-700/45 */
+  background-image: linear-gradient(
+    100deg,
+    transparent 32%,
+    rgba(203, 213, 225, 0.09) 46%,
+    rgba(251, 191, 36, 0.07) 52%,
+    transparent 68%
+  );
+  background-size: 220% 100%;
+  background-repeat: no-repeat;
+  border-radius: 0.5rem;
+  animation: esc-shimmer 1.9s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .esc-vivo,
+  .esc-sway,
+  .esc-scene {
+    animation: none;
+  }
+
+  .esc-bone {
+    animation: none;
+    background-image: none;
+  }
+}


### PR DESCRIPTION
Rebanada directorio + bodega + registro: viñetas SVG estilo tinta de
cuaderno de campo (EmptyStateCampo: directorio/búsqueda/bodega/bitácora,
un solo elemento vivo por escena que respira) y skeletons con la silueta
real del contenido y shimmer cálido (SkeletonCampo: lista/ficha/timeline).

- DirectorioEspeciesScreen: primera vez, sin resultados, buscando (skeleton
  de resultados) y abriendo ficha (ChagraGrowLoader + skeleton de ficha).
- InventoryDashboard: bodega vacía con estante de frascos y canasto.
- InventoryEventTimeline: carga con skeleton de línea de tiempo + vacío.
- AssetTimeline: bitácora por escribir.

Solo capa visual: testids y copy load-bearing intactos; motion respeta
prefers-reduced-motion.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
