### PR TITLE
fix(rag): tier-gate falla-CERRADO cuando el catálogo no está disponible

### DIFF
--- a/src/services/__tests__/ragRetriever.test.js
+++ b/src/services/__tests__/ragRetriever.test.js
@@ -95,9 +95,23 @@ function setupFetchMock() {
   });
 }
 
+// Catálogo OSS que cubre los slugs sintéticos del manifest de estos describes.
+// Tras el fix FAIL-CLOSED (P0-1), el tier-gate ya NO carga el manifest completo
+// cuando el catálogo no está disponible; hay que proveer un catálogo que
+// contenga los slugs de prueba para ejercitar la mecánica del corpus por el
+// camino sano (catálogo presente), no por el agujero fail-open que se cerró.
+const EXTENDED_CATALOG = [
+  { id: 'fragaria_test' },
+  { id: 'coffea_test' },
+  { id: 'lechuga_test' },
+];
+
 describe('ragRetriever — corpus extendido v2', () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockResolvedValue(EXTENDED_CATALOG),
+    }));
     setupFetchMock();
   });
 
@@ -191,6 +205,9 @@ describe('ragRetriever — corpus extendido v2', () => {
 describe('ragRetriever — pre-tokenize perf fix', () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockResolvedValue(EXTENDED_CATALOG),
+    }));
     setupFetchMock();
   });
 
@@ -327,6 +344,14 @@ describe('ragRetriever — loadCorpus paralelo-acotado (hotfix prod-down 2026-06
 
   beforeEach(() => {
     vi.resetModules();
+    // FAIL-CLOSED (P0-1): estos tests usan slugs sp_N; sin catálogo el tier-gate
+    // ya no los carga. Proveemos un catálogo amplio que los cubra para probar la
+    // mecánica de concurrencia por el camino sano.
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockResolvedValue(
+        Array.from({ length: 120 }, (_, i) => ({ id: `sp_${i}` })),
+      ),
+    }));
   });
 
   afterEach(() => {
@@ -402,7 +427,7 @@ describe('ragRetriever — tier-gate del catalogo (SEC-002 / UXC-004)', () => {
     // pro_only_1 y pro_only_2 NO estan en el catalogo OSS
   ];
 
-  function setupGatedFetchMock() {
+  function setupGatedFetchMock(manifest = MANIFEST_GATED) {
     const tracker = { docFetches: new Set() };
     globalThis.fetch = vi.fn((url) => {
       const u = String(url);
@@ -410,7 +435,7 @@ describe('ragRetriever — tier-gate del catalogo (SEC-002 / UXC-004)', () => {
         return Promise.resolve({
           ok: true, status: 200,
           headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
-          json: () => Promise.resolve(MANIFEST_GATED),
+          json: () => Promise.resolve(manifest),
         });
       }
       const match = u.match(/\/cycle-content\/([^.]+)\.json/);
@@ -478,33 +503,66 @@ describe('ragRetriever — tier-gate del catalogo (SEC-002 / UXC-004)', () => {
     expect(stats.totalDocs).toBe(3);
   });
 
-  it('SEC-002 — si el catalogo falla, carga todos los slugs (degradacion segura)', async () => {
+  it('P0-1 FAIL-CLOSED — si el catalogo falla, NO carga slugs fuera del subconjunto seguro', async () => {
     vi.doMock('../../db/catalogDB', () => ({
       getAllSpecies: vi.fn().mockRejectedValue(new Error('SQLite no disponible')),
     }));
 
     const tracker = setupGatedFetchMock();
-    const { retrieve, getCorpusStats } = await import('../ragRetriever.js');
+    const { retrieve, getCorpusStats, getTierGateBlockCount } = await import('../ragRetriever.js');
 
     await retrieve('ficha pedagógica', 5);
 
     const stats = await getCorpusStats();
-    // Degradacion: sin catalogo, carga los 5 slugs completos
-    expect(stats.totalDocs).toBe(5);
-    expect(tracker.docFetches.size).toBe(5);
+    // FAIL-CLOSED: los slugs del MANIFEST_GATED (*_test / pro_only) NO están en
+    // CROP_TAXONOMY, así que el subconjunto seguro es vacío. No se sirve corpus
+    // amplio: NADA se fetchea, 0 docs. Antes (fail-open) cargaba los 5.
+    expect(stats.totalDocs).toBe(0);
+    expect(tracker.docFetches.size).toBe(0);
+    // La degradación se contabiliza como métrica de bloqueo observable.
+    expect(getTierGateBlockCount()).toBe(1);
   });
 
-  it('SEC-002 — catalogo vacio (sin especies) carga todos los slugs', async () => {
+  it('P0-1 FAIL-CLOSED — catalogo vacio (sin especies) tampoco carga corpus amplio', async () => {
     vi.doMock('../../db/catalogDB', () => ({
       getAllSpecies: vi.fn().mockResolvedValue([]),
     }));
 
     const tracker = setupGatedFetchMock();
-    const { retrieve } = await import('../ragRetriever.js');
+    const { retrieve, getTierGateBlockCount } = await import('../ragRetriever.js');
 
     await retrieve('ficha pedagógica', 5);
 
-    expect(tracker.docFetches.size).toBe(5);
+    // Catálogo vacío = tier indeterminado → fail-closed al subconjunto seguro
+    // (vacío para estos slugs de prueba). No se filtra corpus Pro por defecto.
+    expect(tracker.docFetches.size).toBe(0);
+    expect(getTierGateBlockCount()).toBe(1);
+  });
+
+  it('P0-1 FAIL-CLOSED — sin catalogo sirve SOLO el subconjunto seguro (CROP_TAXONOMY), nunca Pro', async () => {
+    // Manifest mixto: 3 slugs OSS reales (presentes en CROP_TAXONOMY) + 2 Pro.
+    // Reutilizamos setupGatedFetchMock (parametrizado) para no introducir otro
+    // sitio de asignación a globalThis.fetch.
+    const MANIFEST_MIX = {
+      generated_at: '2026-07-03T00:00:00Z',
+      slugs: ['coffea_arabica', 'lactuca_sativa', 'solanum_tuberosum', 'pro_secret_1', 'pro_secret_2'],
+    };
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockRejectedValue(new Error('catálogo caído')),
+    }));
+
+    const tracker = setupGatedFetchMock(MANIFEST_MIX);
+    const { retrieve, getCorpusStats } = await import('../ragRetriever.js');
+    await retrieve('ficha pedagógica', 5);
+
+    // Los 3 OSS de CROP_TAXONOMY SÍ entran; los Pro NUNCA se fetchean.
+    expect(tracker.docFetches.has('coffea_arabica')).toBe(true);
+    expect(tracker.docFetches.has('lactuca_sativa')).toBe(true);
+    expect(tracker.docFetches.has('solanum_tuberosum')).toBe(true);
+    expect(tracker.docFetches.has('pro_secret_1')).toBe(false);
+    expect(tracker.docFetches.has('pro_secret_2')).toBe(false);
+    const stats = await getCorpusStats();
+    expect(stats.totalDocs).toBe(3);
   });
 
   it('SEC-002 — retrieve solo devuelve docs dentro del tier', async () => {

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -46,6 +46,39 @@ let corpusLoadPromise = null;
 // (flattenDoc + pre-tokenize) se conserva idéntica; solo cambia serial→batch.
 const CORPUS_FETCH_CONCURRENCY = 12;
 
+// Métrica de bloqueo del tier-gate (audit P0-1, 2026-07-03). Cuenta cuántas
+// veces buildCorpus tuvo que degradar FAIL-CLOSED por no poder confiar en el
+// catálogo activo (throw o vacío). Un valor creciente es la señal observable de
+// que el RAG está sirviendo solo el subconjunto seguro, no el corpus completo.
+let tierGateBlockCount = 0;
+
+/**
+ * @returns {number} nº de veces que el tier-gate degradó FAIL-CLOSED por
+ *   catálogo no disponible. Para health-checks / telemetría.
+ */
+export function getTierGateBlockCount() {
+  return tierGateBlockCount;
+}
+
+// Sentinel numérico para el `tier` cuando degradamos FAIL-CLOSED. -1 nunca es
+// un tamaño real de catálogo (que es > 0), así el índice persistido de un build
+// seguro NO se sirve a una sesión con catálogo sano ni viceversa
+// (corpusIndexCache invalida cuando `tier` cambia). Se mantiene numérico para
+// no cambiar el tipo de `tier` (number | null) en las llamadas al cache.
+const FAIL_CLOSED_TIER = -1;
+
+/**
+ * Universo de slugs OSS-seguro hardcodeado: los ids de CROP_TAXONOMY, que
+ * viajan en el repo público y NO contienen contenido Pro/privado. Es el
+ * fallback FAIL-CLOSED del tier-gate cuando el catálogo activo no está
+ * disponible: nunca deja groundear un slug fuera de esta taxonomía baked-in.
+ */
+function safeSubsetIds() {
+  return new Set(
+    Object.values(CROP_TAXONOMY).flatMap((group) => group.species.map((sp) => sp.id)),
+  );
+}
+
 function tokenize(text) {
   if (!text || typeof text !== 'string') return [];
   return text
@@ -232,12 +265,20 @@ async function buildCorpus() {
   // Tier gate (SEC-002 / UXC-004): filtrar slugs contra el catalogo activo.
   // En OSS el catalogo tiene ~263 especies; el manifest ~491. Los ~296 slugs
   // sin entrada en el catalogo NO deben groundearse para evitar leak de
-  // contenido Pro a usuarios OSS. Degradacion: si el catalogo falla, se
-  // cargan todos los slugs (mejor grounding completo que ninguno).
+  // contenido Pro a usuarios OSS.
+  //
+  // FAIL-CLOSED (audit P0-1, 2026-07-03): si el catálogo NO está disponible
+  // (getAllSpecies lanza) o viene vacío, NO cargamos el manifest completo —
+  // eso serviría corpus fuera de tier (contenido Pro/privado) justo cuando el
+  // gate debía impedirlo. En su lugar degradamos a un SUBCONJUNTO SEGURO
+  // hardcodeado (CROP_TAXONOMY ∩ manifest, ver safeSubsetIds), contamos el
+  // bloqueo y NUNCA servimos RAG "amplio" por defecto.
   let tier = null;
+  let catalogTrusted = false;
   try {
     const catalogSpecies = await getAllSpecies();
     if (catalogSpecies && catalogSpecies.length > 0) {
+      catalogTrusted = true;
       tier = catalogSpecies.length;
       const allowedIds = new Set(catalogSpecies.map((s) => s.id));
       const before = species.length;
@@ -245,9 +286,24 @@ async function buildCorpus() {
       if (before !== species.length) {
         console.info(`[RAG] Tier gate: ${before} slugs en manifest, ${species.length} dentro del catalogo (${before - species.length} excluidos).`);
       }
+    } else {
+      console.warn('[RAG] Tier gate: catálogo vacío — degradando FAIL-CLOSED al subconjunto seguro.');
     }
   } catch (err) {
-    console.warn('[RAG] No se pudo cargar el catalogo para tier-gate — cargando todos los slugs:', err?.message);
+    console.warn('[RAG] No se pudo cargar el catálogo para tier-gate — degradando FAIL-CLOSED al subconjunto seguro:', err?.message);
+  }
+
+  if (!catalogTrusted) {
+    // FAIL-CLOSED: sin un catálogo confiable no podemos determinar el tier, así
+    // que restringimos al subconjunto seguro OSS en vez de servir el manifest
+    // completo. Nunca contenido fuera de CROP_TAXONOMY. Si el manifest era null,
+    // `species` ya era CROP_TAXONOMY (este filtro es un no-op y es correcto).
+    const safeIds = safeSubsetIds();
+    const before = species.length;
+    species = species.filter((slug) => safeIds.has(slug));
+    tier = FAIL_CLOSED_TIER;
+    tierGateBlockCount += 1;
+    console.warn(`[RAG] Tier gate FAIL-CLOSED (#${tierGateBlockCount}): ${before} slugs → ${species.length} del subconjunto seguro (CROP_TAXONOMY). Sin catálogo confiable no se sirve RAG amplio.`);
   }
 
   // OFFLINE-FIRST: intentar hidratar el índice YA construido desde IndexedDB
@@ -691,4 +747,5 @@ export const RAG_SERVICE = {
   retrieve,
   getCorpusStats,
   prewarmCorpus,
+  getTierGateBlockCount,
 };


### PR DESCRIPTION
Antes, si getAllSpecies() lanzaba (o devolvía vacío) el tier-gate del RAG
degradaba a cargar TODOS los slugs del manifest ("mejor grounding completo
que ninguno"). Eso invierte el propósito del gate: una indisponibilidad del
catálogo cambiaba el perímetro de datos groundeables y podía servir corpus
fuera de tier (contenido Pro/privado) a usuarios OSS (audit P0-1).

Ahora falla CERRADO: sin un catálogo confiable se restringe a un subconjunto
seguro hardcodeado (CROP_TAXONOMY ∩ manifest, que viaja en el repo público y
no contiene contenido Pro), nunca al manifest completo. Se añade una métrica
de bloqueo observable (getTierGateBlockCount) y un `tier` sentinel distinto
para que el índice persistido de un build seguro no se sirva a una sesión con
catálogo sano ni viceversa.

Tests: nuevo caso positivo (subconjunto seguro sirve solo slugs OSS, nunca
Pro) + los dos casos de degradación ahora asertan fail-closed. Los describes
que probaban la mecánica del corpus por el agujero fail-open ahora mockean un
catálogo real.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
