### PR TITLE
feat(agente): V3 rediseño del chat en fable + colapsar bandeja de modos en botón

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square } from 'lucide-react';
+import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square, Sprout } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe, queueForRetry } from '../../services/voiceService';
 import VoiceStatusStrip from './VoiceStatusStrip';
@@ -15,7 +15,7 @@ import { analyzeFoliage } from '../../services/aiService';
 import { captureAndCompress } from '../../services/photoService';
 import { processPhotoItem, buildPhotoUserMessage } from '../../services/agentOutboxPhoto';
 import { isAnalyzableImageAttachment, buildAttachmentRejection } from '../../services/agentOutboxAttachment';
-import { AGENT_ENTRANCE_CSS, AGENT_COMPOSITOR_CSS, agentEntranceClass } from './agentEntrance';
+import { AGENT_ENTRANCE_CSS, AGENT_COMPOSITOR_CSS, AGENT_V3_CSS, agentEntranceClass } from './agentEntrance';
 import {
   addTurn,
   getFullHistory,
@@ -296,6 +296,13 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // La MANO de Chagra (AgentRedMenu) — MISMA red que el home, no menús de texto.
   // sheetOpen monta/desmonta el overlay de la mano (AgentManoOverlay).
   const [sheetOpen, setSheetOpen] = useState(false);
+  // V3 (fable) — LA MOCHILA de modos. La bandeja de ~11-13 chips (ChipsToolbar)
+  // ya NO vive inline sobre el input (se comía media pantalla en móvil y
+  // ahorcaba el chat — el operador la rechazó 3 veces): se colapsa en UN
+  // disparador del compositor que abre un bottom-sheet con scroll. Solo estado
+  // de presentación; el ruteo sigue intacto (ChipsToolbar → onSelectIntent →
+  // setActiveIntent).
+  const [mochilaOpen, setMochilaOpen] = useState(false);
   // Fase del compositor para la animación shimmer/lift al enviar.
   const [composerPhase, setComposerPhase] = useState('idle'); // 'idle' | 'sending'
   // Deep Research (A6/A7): refs para los AbortControllers de los jobs en vuelo.
@@ -3046,9 +3053,12 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
 
   // CHIPS DE MODO (A4): placeholder guía según el modo activo. Sin modo →
   // placeholder genérico. Español colombiano (tú/usted), nunca voseo.
-  const activePlaceholder = activeIntent
-    ? (CHIP_DEFS.find((c) => c.intent === activeIntent)?.placeholder || 'Escribe tu pregunta...')
-    : 'Escribe tu pregunta...';
+  // V3: la def completa alimenta también el disparador de la mochila (que
+  // muestra emoji + etiqueta del modo activo).
+  const activeChipDef = activeIntent
+    ? (CHIP_DEFS.find((c) => c.intent === activeIntent) || null)
+    : null;
+  const activePlaceholder = activeChipDef?.placeholder || 'Escribe tu pregunta...';
 
   // PIEL POR TEMA del botón enviar (Fase 2 de temas). Con la flag ON y el botón
   // habilitado (hay texto/adjunto y no se está grabando ni hay cola), aplicamos
@@ -3068,7 +3078,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           (fix legibilidad 2026-06-15). */}
       <div className="absolute inset-0 agent-scrim backdrop-blur-[2px] pointer-events-none" aria-hidden="true" />
       {/* B1: animación de entrada (fade+rise). Respeta prefers-reduced-motion. */}
-      <style>{AGENT_ENTRANCE_CSS}{AGENT_COMPOSITOR_CSS}</style>
+      <style>{AGENT_ENTRANCE_CSS}{AGENT_COMPOSITOR_CSS}{AGENT_V3_CSS}</style>
 
       {/* ── Header estilo ScreenShell (2026-06-08): superficie OPACA por token
           (.agent-bar-surface) + acciones globales. Antes bg-slate-900/50 dejaba
@@ -3358,16 +3368,11 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           onDismissNotice={() => setVoiceNotice('')}
         />
 
-        <ChipsToolbar
-          activeIntent={activeIntent}
-          hasAttachment={Boolean(agentAttachment)}
-          disabled={state === STATE_RECORDING || queuePending.length >= 1}
-          isPro={isPro}
-          chipDefs={profileChipDefs}
-          onSelectIntent={(intent) => {
-            setActiveIntent((current) => (current === intent ? null : intent));
-          }}
-        />
+        {/* V3: la bandeja de ~11-13 chips (ChipsToolbar) ya NO se pinta inline
+            aquí — ahogaba el chat en móvil. Vive dentro de LA MOCHILA
+            (bottom-sheet de más abajo) y se abre desde el disparador "Temas"
+            del compositor. Con la mochila cerrada el chat tiene el alto
+            completo. Misma data y ruteo — cero cambios de lógica. */}
 
         {/* Pill — unified with AgentHero (as-bar CSS tokens) */}
         <div
@@ -3377,6 +3382,34 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             composerPhase === 'sending' ? 'as-shimmer as-sending' : '',
           ].join(' ')}
         >
+          {/* V3 — Etiqueta del MODO ACTIVO sobre el input (ancho completo, no
+              se trunca): dice de qué tema va a responder Chagra. Tocarla
+              reabre la mochila; la "x" limpia el modo con un toque (mismo
+              setActiveIntent — cero mecanismo nuevo). */}
+          {activeChipDef && state !== STATE_RECORDING && (
+            <div className="v3-modo-tagrow">
+              <button
+                type="button"
+                onClick={() => setMochilaOpen(true)}
+                aria-label={`Modo activo: ${activeChipDef.label}. Cambiar tema`}
+                data-testid="agent-modo-tag"
+                className="v3-modo-tag"
+              >
+                <span aria-hidden="true">{activeChipDef.emoji}</span>
+                <span className="v3-modo-tag-txt">{activeChipDef.label}</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveIntent(null)}
+                aria-label={`Quitar el modo ${activeChipDef.label}`}
+                data-testid="agent-modo-clear"
+                className="v3-modo-clear"
+              >
+                <X size={14} aria-hidden="true" />
+              </button>
+            </div>
+          )}
+
           {/* Fila 1: textarea o waveform de grabación */}
           {state === STATE_RECORDING ? (
             <div className="flex items-center gap-3 px-3 py-3 min-h-[52px]">
@@ -3461,6 +3494,27 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               <Camera size={19} strokeWidth={2} aria-hidden="true" />
             </button>
 
+            {/* V3 — Disparador de LA MOCHILA de temas. Colapsa la bandeja de
+                ~11-13 chips en un solo control (mandato del operador tras
+                rechazarla 3 veces). Etiqueta constante "Temas" (el modo activo
+                se muestra COMPLETO en la etiqueta sobre el input — aquí solo
+                se tiñe con el acento para no truncarse en la fila angosta). */}
+            <button
+              type="button"
+              onClick={() => setMochilaOpen(true)}
+              disabled={state === STATE_RECORDING}
+              aria-label={activeChipDef
+                ? `Modo activo: ${activeChipDef.label}. Abrir los temas del agente`
+                : 'Temas del agente'}
+              aria-haspopup="dialog"
+              aria-expanded={mochilaOpen}
+              data-testid="agent-modos-trigger"
+              className={['v3-modo', activeChipDef ? 'is-active' : ''].join(' ')}
+            >
+              <Sprout size={17} strokeWidth={2.2} aria-hidden="true" />
+              <span className="v3-modo-txt">Temas</span>
+            </button>
+
             <div className="flex-1" />
 
             {/* Micrófono (toggle) — GRANDE (TIER 2 #5): el camino principal
@@ -3527,6 +3581,66 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             quitar los chips/líneas de sugerencia que ensucian la pantalla del
             agente. El acceso a capacidades queda por la mano de Chagra (botón
             Ⓐ del compositor + botón de la pantalla vacía). */}
+
+        {/* ── V3 · LA MOCHILA DE TEMAS ────────────────────────────────────────
+            Colapsa la bandeja de ~11-13 chips de modo (ChipsToolbar) que
+            ahogaba el chat. Misma data y ruteo; solo cambia el contenedor: un
+            bottom-sheet con scroll que se cierra al elegir un modo, al tocar
+            afuera o con Escape. El dobladillo lleva LA COSTURA — la misma
+            puntada que firma las respuestas respaldadas por el catálogo. */}
+        {mochilaOpen && (
+          <div
+            className="v3-mochila"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Temas del agente"
+            data-testid="agent-modos-sheet"
+            onKeyDown={(e) => { if (e.key === 'Escape') setMochilaOpen(false); }}
+          >
+            <button
+              type="button"
+              className="v3-mochila-scrim"
+              aria-label="Cerrar los temas del agente"
+              onClick={() => setMochilaOpen(false)}
+            />
+            <div className="v3-mochila-panel">
+              <div className="v3-mochila-hem" aria-hidden="true">
+                <span className="v3-mochila-grab" />
+                <span className="v3-mochila-stitch" />
+              </div>
+              <div className="v3-mochila-head">
+                <div className="v3-mochila-titwrap">
+                  <h2>¿Sobre qué hablamos?</h2>
+                  <p>Toca un tema y Chagra va directo al grano, sin rodeos.</p>
+                </div>
+                <button
+                  type="button"
+                  className="v3-mochila-close"
+                  onClick={() => setMochilaOpen(false)}
+                  aria-label="Cerrar"
+                  /* Al abrir, el foco entra al diálogo (cerrar) → Escape y
+                     lectores de pantalla operan DENTRO de la mochila. */
+                  autoFocus
+                >
+                  <X size={18} aria-hidden="true" />
+                </button>
+              </div>
+              <div className="v3-mochila-body">
+                <ChipsToolbar
+                  activeIntent={activeIntent}
+                  hasAttachment={Boolean(agentAttachment)}
+                  disabled={state === STATE_RECORDING || queuePending.length >= 1}
+                  isPro={isPro}
+                  chipDefs={profileChipDefs}
+                  onSelectIntent={(intent) => {
+                    setActiveIntent((current) => (current === intent ? null : intent));
+                    setMochilaOpen(false);
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Input oculto de foto */}
         <input

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { User, BadgeCheck, Info, Sparkles, AlertTriangle, ExternalLink, ShieldCheck } from 'lucide-react';
+import { BadgeCheck, Info, Sparkles, AlertTriangle, ExternalLink, ShieldCheck } from 'lucide-react';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import { speak, speakKokoro, stop, isSpeaking, isKokoroAvailable } from '../../services/ttsService';
 import { agentSounds } from '../../services/agentSoundService';
@@ -332,35 +332,32 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
     }
   };
 
+  // V3 "cuaderno de campo cosido": los turnos ya no son la pareja genérica
+  // avatar-circulito + burbuja slate de chatbot. El turno del AGENTE es una
+  // ENTRADA de cuaderno: byline chiquito (colibrí 22px + "Chagra" en Baloo 2)
+  // y debajo la tarjeta-papel del tema (.v3-card), con LA COSTURA de hilo
+  // esmeralda en el borde izquierdo cuando la respuesta viene respaldada por
+  // el catálogo (data-grounded — el CSS pinta la puntada). El turno del
+  // USUARIO es una nota compacta con el verde del tema (.v3-bubble-user), sin
+  // ícono de personita: la alineación derecha ya dice quién habla y el chat
+  // recupera ese ancho en el celular. CSS en AGENT_V3_CSS (agentEntrance.js).
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3.5`}>
-      <div className={`flex gap-2 max-w-[85%] ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
-        {isUser ? (
-          <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-emerald-600 ring-1 ring-emerald-400/40 shadow-sm shadow-emerald-950/30">
-            <User size={16} className="text-white" />
-          </div>
-        ) : (
-          <div
-            className={`shrink-0 w-9 h-9 rounded-full flex items-center justify-center bg-slate-900 border overflow-hidden ${
-              isStreaming ? 'border-amber-400/60 shadow-[0_0_10px_rgba(245,158,11,.4)]' : 'border-emerald-700/40'
-            }`}
-          >
-            <ChagraAgentAvatar state={agentState} size={32} ariaLabel="Chagra IA" />
-          </div>
-        )}
+    <div className={`v3-turn ${isUser ? 'v3-turn-user' : 'v3-turn-agent'}`}>
+      {!isUser && (
+        <div className="v3-byline" aria-hidden="true">
+          <span className={`v3-byline-avatar${isStreaming ? ' is-streaming' : ''}`}>
+            <ChagraAgentAvatar state={agentState} size={22} ariaLabel="Chagra IA" />
+          </span>
+          <span>Chagra</span>
+        </div>
+      )}
 
-        <div
-          className={`rounded-2xl px-4 py-3 shadow-md ${
-            isUser
-              ? 'bg-emerald-700/70 text-white rounded-tr-md border border-emerald-500/25 shadow-emerald-950/25'
-              : `bg-slate-800/90 text-slate-100 rounded-tl-md border border-slate-700/60 shadow-slate-950/30 cursor-pointer${
-                  isGrounded ? ' border-l-2 border-l-emerald-400/70' : ''
-                }`
-          }`}
-          data-grounded={isGrounded ? 'true' : undefined}
-          onDoubleClick={handleBubbleDoubleClick}
-          title={!isUser && !isStreaming ? 'Doble click reproduce o silencia esta respuesta' : undefined}
-        >
+      <div
+        className={isUser ? 'v3-bubble-user' : 'v3-card cursor-pointer'}
+        data-grounded={isGrounded ? 'true' : undefined}
+        onDoubleClick={handleBubbleDoubleClick}
+        title={!isUser && !isStreaming ? 'Doble click reproduce o silencia esta respuesta' : undefined}
+      >
           {/* Bug 2026-05-31: la foto del compositor del home NO llegaba al chat,
               solo el texto. Si el mensaje trae `imageUrl` (foto adjuntada en
               AgentHero → outbox → AgentScreen), la pintamos como miniatura
@@ -476,7 +473,6 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
               </p>
             </div>
           )}
-        </div>
       </div>
     </div>
   );

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -99,7 +99,14 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
             <ProactiveGreeting greeting={proactiveGreeting} />
           ) : (
             <>
-              <p className="text-slate-200 text-base mb-2 font-medium">¡Hola! Soy tu asistente agroecológico.</p>
+              {/* V3: saludo en Baloo 2 (display de la casa) — el mismo trazo
+                  redondo del home Finca Viva, no la sans genérica. */}
+              <p
+                className="text-slate-200 text-xl mb-2"
+                style={{ fontFamily: "'Baloo 2', 'Nunito', system-ui, sans-serif", fontWeight: 700, letterSpacing: '-0.3px' }}
+              >
+                ¡Hola! Soy tu asistente agroecológico.
+              </p>
               <p className="text-slate-500 text-xs">Puedes hablarme o escribirme sobre tus plantas.</p>
             </>
           )}
@@ -216,14 +223,21 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
           desapercibido porque el ojo del operador está en la ventana de
           diálogo. Acá el colibrí late en thinking + texto "Pensando…". */}
       {showThinkingAvatar && (
-        <div className="flex items-end gap-3 mb-4 animate-fadeIn">
-          <ChagraAgentAvatar
-            state="thinking"
-            size={96}
-            className="shrink-0 mb-1"
-            ariaLabel={MSG.agente.pensandoAria}
-          />
-          <div className="rounded-2xl rounded-bl-sm bg-slate-800/80 border border-slate-700/60 px-4 py-3 text-slate-300 text-sm italic shadow-lg">
+        // V3: la espera del primer token es una ENTRADA más del cuaderno —
+        // byline "Chagra" + tarjeta-papel, coherente con las respuestas. El
+        // colibrí late en thinking (alas en blur + sip rápido) en el byline.
+        <div className="v3-turn animate-fadeIn">
+          <div className="v3-byline">
+            <span className="v3-byline-avatar is-streaming">
+              <ChagraAgentAvatar
+                state="thinking"
+                size={22}
+                ariaLabel={MSG.agente.pensandoAria}
+              />
+            </span>
+            <span>Chagra</span>
+          </div>
+          <div className="v3-card text-sm italic text-slate-300">
             {MSG.agente.pensandoTexto}
             <span className="inline-block ml-1 animate-thinkingDot">·</span>
             <span className="inline-block ml-0.5 animate-thinkingDot [animation-delay:200ms]">·</span>
@@ -278,7 +292,11 @@ function ProactiveGreeting({ greeting }) {
   const isPending = state === 'pending';
   return (
     <div data-testid="proactive-greeting" data-greeting-state={state}>
-      <p className="text-slate-200 text-base mb-1.5 font-medium">
+      {/* V3: saludo en Baloo 2 — misma voz tipográfica que el resto del agente. */}
+      <p
+        className="text-slate-200 text-xl mb-1.5"
+        style={{ fontFamily: "'Baloo 2', 'Nunito', system-ui, sans-serif", fontWeight: 700, letterSpacing: '-0.3px' }}
+      >
         {hi}. Soy <span className="text-emerald-300">Chagra</span>.
       </p>
       <p

--- a/src/components/AgentScreen/VoiceStatusStrip.jsx
+++ b/src/components/AgentScreen/VoiceStatusStrip.jsx
@@ -129,9 +129,12 @@ export default function VoiceStatusStrip({
             {isSpeaking && <Equalizer />}
           </span>
           <p
-            className="flex-1 text-base font-bold leading-tight"
+            className="flex-1 text-base leading-tight"
             data-testid="voice-state-label"
             aria-live="polite"
+            /* V3: la voz de estado habla en Baloo 2 — la misma letra redonda y
+               amable del resto del agente (byline, mochila), no la sans dura. */
+            style={{ fontFamily: "'Baloo 2', 'Nunito', system-ui, sans-serif", fontWeight: 700, letterSpacing: '0.1px' }}
           >
             {isListening && 'Chagra te escucha'}
             {isThinking && 'Chagra está pensando'}

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -396,25 +396,44 @@ describe('AgentScreen - chips toolbar', () => {
     vi.clearAllMocks();
   });
 
-  it('monta la barra de chips junto al input y cambia la intencion al tocar un chip', async () => {
+  it('V3: colapsa la bandeja en la mochila; el disparador la abre y elegir un modo lo fuerza, la cierra y lo muestra', async () => {
     render(<AgentScreen onBack={() => {}} />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('chips-toolbar')).toBeInTheDocument();
-    });
+    // El disparador vive en el compositor; la mochila arranca CERRADA (el
+    // chat recupera el alto completo). ChipsToolbar NO está montada aún y no
+    // hay etiqueta de modo activo.
+    const trigger = await screen.findByTestId('agent-modos-trigger');
+    expect(trigger).toHaveTextContent('Temas');
+    expect(screen.queryByTestId('chips-toolbar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('agent-modo-tag')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('agent-modo-clear')).not.toBeInTheDocument();
 
-    const toolbar = screen.getByTestId('chips-toolbar');
-    const input = screen.getByTestId('agent-input');
-    expect(toolbar.compareDocumentPosition(input) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
-
+    // Abrir la mochila → la bandeja aparece con sus modos.
+    fireEvent.click(trigger);
+    const toolbar = await screen.findByTestId('chips-toolbar');
+    expect(screen.getByTestId('agent-modos-sheet')).toBeInTheDocument();
     expect(toolbar).toHaveTextContent('Biopreparado');
-    const biopreparadoChip = screen.getByRole('button', { name: /biopreparado/i });
-    fireEvent.click(biopreparadoChip);
 
-    expect(biopreparadoChip).toHaveAttribute('aria-pressed', 'true');
+    // Elegir un modo lo fuerza: cambia el placeholder del input, cierra la
+    // mochila, tiñe el disparador y muestra la ETIQUETA del modo activo sobre
+    // el input (el chip queda desmontado al cerrar, por eso verificamos el
+    // efecto persistente, no aria-pressed).
+    fireEvent.click(screen.getByRole('button', { name: /biopreparado/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('chips-toolbar')).not.toBeInTheDocument();
+    });
     expect(screen.getByTestId('agent-input')).toHaveAttribute(
       'placeholder',
       'Escribe para que plaga o planta quieres el biopreparado',
     );
+    expect(screen.getByTestId('agent-modo-tag')).toHaveTextContent('Biopreparado');
+    expect(screen.getByTestId('agent-modos-trigger').className).toMatch(/is-active/);
+
+    // Salida rápida del modo: la "x" junto a la etiqueta lo limpia sin
+    // reabrir la mochila.
+    fireEvent.click(screen.getByTestId('agent-modo-clear'));
+    expect(screen.queryByTestId('agent-modo-tag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('agent-input')).toHaveAttribute('placeholder', 'Escribe tu pregunta...');
   });
 });

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -179,6 +179,307 @@ export const AGENT_COMPOSITOR_CSS = `
   }
 `;
 
+/**
+ * V3 (fable) — "CUADERNO DE CAMPO COSIDO". CSS de la capa visual nueva del chat
+ * del agente:
+ *
+ *   1. LA MOCHILA (.v3-mochila*): la bandeja de ~11-13 chips de modo que vivía
+ *      SIEMPRE sobre el input (y se comía media pantalla en el celular — el
+ *      operador la rechazó 3 veces) se colapsa en UN disparador del compositor
+ *      (.v3-modo) que abre un bottom-sheet con scroll. Cerrada, el chat tiene
+ *      el ALTO COMPLETO.
+ *   2. TARJETAS-SEMILLA (.v3-chipcard): dentro de la mochila los modos son
+ *      tarjetas grandes en grilla (emoji 22px + etiqueta Nunito) — legibles al
+ *      sol y tocables con guantes, no píldoras miniatura.
+ *   3. EL CUADERNO (.v3-turn/.v3-card): los turnos del agente son ENTRADAS de
+ *      cuaderno de campo — byline "Chagra" en Baloo 2 + tarjeta papel del tema.
+ *      La firma de la marca es LA COSTURA: una puntada de hilo esmeralda en el
+ *      borde izquierdo de las respuestas respaldadas por el catálogo
+ *      ([data-grounded="true"]) — "cosida al catálogo", como la costura de un
+ *      costal de fique. Las respuestas solo-generativas NO llevan costura.
+ *
+ * Todo por TOKENS de tema (--c-* espacio-separado, --t-accent-rgb coma-
+ * separado) → coherente en los 4 temas y legible al sol (superficies opacas).
+ * Tipografía: Baloo 2 (display) + Nunito (cuerpo), ya self-host en /fonts —
+ * los @font-face duplican los de finca-viva-hero.css a propósito (el navegador
+ * los dedupe) para que el agente no dependa de que el home los haya cargado.
+ * Respeta prefers-reduced-motion (bloque final).
+ */
+export const AGENT_V3_CSS = `
+  @font-face {
+    font-family: 'Baloo 2'; font-style: normal; font-weight: 400 800;
+    font-display: swap; src: url('/fonts/baloo2-latin.woff2') format('woff2');
+  }
+  @font-face {
+    font-family: 'Nunito'; font-style: normal; font-weight: 400 800;
+    font-display: swap; src: url('/fonts/nunito-latin.woff2') format('woff2');
+  }
+
+  /* ── Disparador de modos en el compositor (colapsa la bandeja) ─────────── */
+  .v3-modo {
+    flex: 0 1 auto; min-width: 0; max-width: 160px; height: 44px;
+    display: inline-flex; align-items: center; gap: 7px;
+    padding: 0 13px;
+    /* Forma de SEMILLA: radio asimétrico — sello de la V3, no píldora genérica. */
+    border-radius: 22px 22px 22px 8px;
+    background: rgb(var(--c-surface-raised, 30 41 59) / 0.92);
+    border: 1px solid rgb(var(--c-surface-border, 100 116 139) / 0.6);
+    color: rgb(var(--c-slate-300, 203 213 225)); cursor: pointer;
+    font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+                transform 0.16s cubic-bezier(0.22, 0.61, 0.36, 1);
+  }
+  .v3-modo:hover { border-color: rgba(var(--t-accent-rgb, 25, 201, 154), 0.55); }
+  .v3-modo:active { transform: scale(0.95); }
+  .v3-modo:disabled { opacity: 0.4; cursor: not-allowed; }
+  .v3-modo.is-active {
+    background: rgba(var(--t-accent-rgb, 25, 201, 154), 0.16);
+    border-color: rgba(var(--t-accent-rgb, 25, 201, 154), 0.65);
+    color: rgb(var(--t-accent-rgb, 25, 201, 154));
+  }
+  .v3-modo-txt {
+    min-width: 0; font-size: 13.5px; font-weight: 700; letter-spacing: 0.1px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  /* Etiqueta del MODO ACTIVO sobre el input (fila propia dentro del pill —
+     ancho completo, nunca se trunca como en la fila de íconos). */
+  .v3-modo-tagrow {
+    display: flex; align-items: center; gap: 6px;
+    padding: 7px 8px 0;
+  }
+  .v3-modo-tag {
+    min-width: 0; max-width: 100%; height: 30px;
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 0 11px; border-radius: 15px 15px 15px 6px;
+    background: rgba(var(--t-accent-rgb, 25, 201, 154), 0.15);
+    border: 1px solid rgba(var(--t-accent-rgb, 25, 201, 154), 0.55);
+    color: rgb(var(--t-accent-rgb, 25, 201, 154)); cursor: pointer;
+    font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+    animation: v3-pop 0.22s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  .v3-modo-tag-txt {
+    min-width: 0; font-size: 12.5px; font-weight: 700; letter-spacing: 0.1px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  /* Salida rápida del modo activo (un toque, sin reabrir la mochila). */
+  .v3-modo-clear {
+    flex: none; width: 30px; height: 30px; border-radius: 50%;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: rgb(var(--c-surface-raised, 30 41 59) / 0.9);
+    border: 1px solid rgb(var(--c-surface-border, 100 116 139) / 0.55);
+    color: rgb(var(--c-slate-400, 148 163 184)); cursor: pointer;
+    transition: color 0.18s ease, border-color 0.18s ease, transform 0.16s ease;
+  }
+  .v3-modo-clear:hover { color: rgb(var(--c-slate-100, 241 245 249)); }
+  .v3-modo-clear:active { transform: scale(0.9); }
+
+  /* ── LA MOCHILA — bottom-sheet de modos con scroll ─────────────────────── */
+  .v3-mochila {
+    position: fixed; inset: 0; z-index: 70;
+    display: flex; flex-direction: column; justify-content: flex-end;
+  }
+  .v3-mochila-scrim {
+    position: absolute; inset: 0; border: 0; padding: 0; margin: 0; cursor: pointer;
+    background: rgba(5, 12, 9, 0.58);
+    -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px);
+    animation: v3-fade 0.2s ease both;
+  }
+  .v3-mochila-panel {
+    position: relative; z-index: 1; width: 100%; max-width: 680px; margin: 0 auto;
+    max-height: min(72dvh, 560px);
+    display: flex; flex-direction: column;
+    background: rgb(var(--c-surface-card, 15 23 42));
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85));
+    border-bottom: 0; border-radius: 24px 24px 0 0;
+    box-shadow: 0 -22px 56px -18px rgba(0, 0, 0, 0.65);
+    padding: 0 14px calc(env(safe-area-inset-bottom, 0px) + 14px);
+    animation: v3-rise 0.32s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  /* Dobladillo COSIDO: agarradera + puntada de hilo del acento — misma costura
+     que firma las respuestas respaldadas. */
+  .v3-mochila-hem { padding: 9px 0 8px; flex: none; }
+  .v3-mochila-grab {
+    display: block; width: 44px; height: 4px; border-radius: 999px;
+    background: rgb(var(--c-slate-400, 148 163 184) / 0.55);
+    margin: 0 auto 9px;
+  }
+  .v3-mochila-stitch {
+    display: block; height: 2px; border-radius: 2px; margin: 0 6px;
+    background-image: repeating-linear-gradient(
+      90deg,
+      rgba(var(--t-accent-rgb, 25, 201, 154), 0.75) 0 8px,
+      transparent 8px 15px
+    );
+  }
+  .v3-mochila-head {
+    display: flex; align-items: flex-start; gap: 10px;
+    padding: 4px 4px 10px; flex: none;
+  }
+  .v3-mochila-titwrap { flex: 1; min-width: 0; }
+  .v3-mochila-titwrap h2 {
+    font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+    font-weight: 800; font-size: 19px; letter-spacing: -0.3px; line-height: 1.15;
+    color: rgb(var(--c-slate-100, 241 245 249));
+  }
+  .v3-mochila-titwrap p {
+    font-family: 'Nunito', system-ui, sans-serif;
+    font-size: 12.5px; line-height: 1.35; margin-top: 2px;
+    color: rgb(var(--c-slate-400, 148 163 184));
+  }
+  .v3-mochila-close {
+    flex: none; width: 38px; height: 38px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    background: rgb(var(--c-surface-raised, 30 41 59));
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85));
+    color: rgb(var(--c-slate-300, 203 213 225)); cursor: pointer;
+    transition: color 0.18s ease, border-color 0.18s ease;
+  }
+  .v3-mochila-close:hover {
+    color: rgb(var(--c-slate-100, 241 245 249));
+    border-color: rgba(var(--t-accent-rgb, 25, 201, 154), 0.55);
+  }
+  .v3-mochila-body {
+    overflow-y: auto; overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch; padding: 2px 2px 6px;
+  }
+
+  /* ── Tarjetas-semilla de modo (grilla dentro de la mochila) ────────────── */
+  .v3-chipgrid {
+    display: grid; gap: 9px;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
+  .v3-chipcard {
+    display: flex; align-items: center; gap: 10px; text-align: left;
+    min-height: 58px; padding: 9px 11px;
+    border-radius: 16px 16px 16px 6px;
+    background: rgb(var(--c-surface-raised, 30 41 59) / 0.85);
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85) / 0.9);
+    color: rgb(var(--c-slate-100, 241 245 249)); cursor: pointer;
+    animation: v3-pop 0.26s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+    animation-delay: calc(var(--i, 0) * 22ms);
+    transition: border-color 0.18s ease, background 0.18s ease,
+                transform 0.14s cubic-bezier(0.22, 0.61, 0.36, 1);
+  }
+  .v3-chipcard:hover { border-color: rgba(var(--t-accent-rgb, 25, 201, 154), 0.55); }
+  .v3-chipcard:active { transform: scale(0.96); }
+  .v3-chipcard:disabled { opacity: 0.45; cursor: not-allowed; }
+  .v3-chipcard[aria-pressed="true"] {
+    background: rgba(var(--t-accent-rgb, 25, 201, 154), 0.16);
+    border-color: rgba(var(--t-accent-rgb, 25, 201, 154), 0.7);
+  }
+  .v3-chipcard.is-locked {
+    opacity: 0.55; cursor: not-allowed;
+    background: rgb(var(--c-surface-raised, 30 41 59) / 0.5);
+  }
+  .v3-chipcard-emoji {
+    flex: none; width: 36px; height: 36px; border-radius: 12px 12px 12px 5px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 21px; line-height: 1;
+    background: rgb(var(--c-surface-card, 15 23 42));
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85) / 0.7);
+  }
+  .v3-chipcard-label {
+    min-width: 0; font-family: 'Nunito', system-ui, sans-serif;
+    font-size: 13.5px; font-weight: 700; line-height: 1.25;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  /* Fila "Más consultas" — ocupa todo el ancho de la grilla, borde punteado
+     (misma familia visual que la costura). */
+  .v3-more-row {
+    grid-column: 1 / -1; min-height: 46px; margin-top: 2px;
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+    border-radius: 14px; border: 1.5px dashed rgb(var(--c-surface-border, 51 65 85));
+    background: transparent; color: rgb(var(--c-slate-400, 148 163 184));
+    font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+    font-size: 13.5px; font-weight: 700; cursor: pointer;
+    transition: color 0.18s ease, border-color 0.18s ease;
+  }
+  .v3-more-row:hover {
+    color: rgb(var(--c-slate-100, 241 245 249));
+    border-color: rgba(var(--t-accent-rgb, 25, 201, 154), 0.5);
+  }
+  .v3-more-row[aria-expanded="true"] {
+    color: rgb(var(--t-accent-rgb, 25, 201, 154));
+    border-color: rgba(var(--t-accent-rgb, 25, 201, 154), 0.55);
+  }
+  .v3-chipgrid-more { margin-top: 9px; }
+
+  /* ── EL CUADERNO — turnos del chat como entradas de campo ──────────────── */
+  .v3-turn {
+    margin-bottom: 15px;
+    animation: v3-entry 0.26s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  .v3-turn-user { display: flex; justify-content: flex-end; }
+  .v3-byline {
+    display: flex; align-items: center; gap: 6px; margin: 0 0 4px 2px;
+    font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+    font-size: 12.5px; font-weight: 700; letter-spacing: 0.2px;
+    color: rgb(var(--c-slate-400, 148 163 184));
+  }
+  .v3-byline-avatar {
+    flex: none; width: 26px; height: 26px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center; overflow: hidden;
+    background: rgb(var(--c-surface-card, 15 23 42));
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85));
+  }
+  .v3-byline-avatar.is-streaming {
+    border-color: rgba(var(--t-accent-rgb, 25, 201, 154), 0.7);
+    box-shadow: 0 0 10px rgba(var(--t-accent-rgb, 25, 201, 154), 0.35);
+  }
+  /* Tarjeta-papel del agente. Lomo plano arriba-izquierda (bajo el byline),
+     tipografía Nunito de cuaderno, superficie del TEMA (papel en claros,
+     panel nocturno en biopunk). */
+  .v3-card {
+    position: relative; max-width: 88%;
+    padding: 11px 14px; border-radius: 5px 18px 18px 18px;
+    background: rgb(var(--c-surface-card, 15 23 42) / 0.97);
+    border: 1px solid rgb(var(--c-surface-border, 51 65 85) / 0.9);
+    box-shadow: 0 8px 22px -14px rgba(0, 0, 0, 0.55);
+    color: rgb(var(--c-slate-100, 241 245 249));
+    font-family: 'Nunito', system-ui, sans-serif;
+  }
+  /* LA COSTURA (firma V3): respuesta respaldada por el catálogo = puntada de
+     hilo esmeralda en el borde izquierdo, como la costura de un costal. Las
+     respuestas solo-generativas no llevan hilo. */
+  .v3-card[data-grounded="true"] { padding-left: 22px; }
+  .v3-card[data-grounded="true"]::before {
+    content: ''; position: absolute; left: 9px; top: 12px; bottom: 12px;
+    width: 2.5px; border-radius: 2px;
+    background-image: repeating-linear-gradient(
+      180deg,
+      rgb(var(--c-emerald-500, 16 185 129)) 0 7px,
+      transparent 7px 13px
+    );
+  }
+  .v3-bubble-user {
+    max-width: 82%; padding: 10px 14px;
+    border-radius: 18px 18px 5px 18px;
+    background: rgb(var(--c-emerald-700, 4 120 87));
+    border: 1px solid rgb(var(--c-emerald-500, 16 185 129) / 0.35);
+    box-shadow: 0 8px 22px -14px rgb(var(--c-emerald-700, 4 120 87) / 0.8);
+    color: #fff; font-family: 'Nunito', system-ui, sans-serif;
+  }
+
+  @keyframes v3-rise { from { transform: translateY(100%); } to { transform: translateY(0); } }
+  @keyframes v3-fade { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes v3-pop {
+    from { opacity: 0; transform: translateY(8px) scale(0.97); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+  }
+  @keyframes v3-entry {
+    from { opacity: 0; transform: translateY(7px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .v3-mochila-panel, .v3-mochila-scrim, .v3-chipcard, .v3-turn,
+    .v3-modo-tag {
+      animation: none !important;
+    }
+    .v3-modo, .v3-modo-clear, .v3-chipcard { transition: none; }
+  }
+`;
+
 
 /**
  * ¿El usuario pidió reducir el movimiento? Tolerante a entornos sin matchMedia

--- a/src/components/ChipsToolbar.jsx
+++ b/src/components/ChipsToolbar.jsx
@@ -3,20 +3,29 @@ import { CHIP_DEFS, CHIP_INTENTS } from '../services/chipIntentRouter';
 import { isDeepResearchEnabled } from '../services/deepResearchClient';
 
 /**
- * ChipsToolbar — "caja de herramientas" del agente como CHIPS DE MODO
- * (estilo Gemini). Fila horizontal scrollable que vive JUSTO sobre el input
- * del chat (A4/B4). Al tocar un chip, la intención queda forzada y rutea
- * DIRECTO a la capacidad determinística, SALTANDO el NLU (A3) — el routing
- * vive en `chipIntentRouter.planForcedIntent` y lo ejecuta AgentScreen.
+ * ChipsToolbar — "caja de herramientas" del agente como MODOS de consulta.
+ * Al tocar un modo, la intención queda forzada y rutea DIRECTO a la capacidad
+ * determinística, SALTANDO el NLU (A3) — el routing vive en
+ * `chipIntentRouter.planForcedIntent` y lo ejecuta AgentScreen.
+ *
+ * V3 (fable, "cuaderno de campo cosido"): este componente YA NO vive inline
+ * sobre el input del chat — la bandeja de ~11-13 píldoras en flex-wrap se comía
+ * media pantalla en el celular y ahorcaba el chat (el operador la rechazó 3
+ * veces). Ahora vive DENTRO de la "mochila" (bottom-sheet del AgentScreen) y
+ * cada modo se pinta como TARJETA-SEMILLA grande en grilla (emoji 21px +
+ * etiqueta Nunito, ≥58px de alto): legible al sol, tocable con guantes, apto
+ * para baja alfabetización. CSS en AGENT_V3_CSS (agentEntrance.js), 100% por
+ * tokens de tema.
+ *
+ * SOLO cambió la capa visual: misma data (CHIP_DEFS / chipDefs por perfil),
+ * mismo mecanismo (onSelectIntent(intent)), mismos testids/roles/aria
+ * (mode-chip, mode-chip-foto, mode-chip-more, chips-toolbar,
+ * chips-toolbar-more, aria-pressed/expanded/controls) — cero cambios de
+ * lógica ni de contrato de tests.
  *
  * Diferencia frente a `QuickChipsBar`: aquél es un atajo de pantalla-nueva
- * que inyecta texto y pasa por el NLU normal. ChipsToolbar es una barra
- * PERSISTENTE de modos que se queda visible durante toda la conversación y
- * fuerza la intención sin inferencia.
- *
- * Diseño: píldoras táctiles, alto contraste (legible al sol, campesino), área
- * de toque cómoda (min 44px alto efectivo), scroll horizontal sin barra
- * visible. Cada chip es un <button> con aria-pressed para el estado activo.
+ * que inyecta texto y pasa por el NLU normal. ChipsToolbar fuerza la
+ * intención sin inferencia.
  *
  * El chip 📷 foto solo se muestra cuando hay una imagen adjunta lista
  * (`hasAttachment`). Coordina con el flujo de adjuntos del compositor.
@@ -49,15 +58,14 @@ import { isDeepResearchEnabled } from '../services/deepResearchClient';
  *                     omite (null/undefined), se muestran TODOS los chips
  *                     (CHIP_DEFS) — comportamiento histórico, sin breaking
  *                     change. Este componente NO decide la selección: solo
- *                     pinta lo que recibe con su CSS actual (la legibilidad/
- *                     estilo la lleva otro stream).
+ *                     pinta lo que recibe. La legibilidad/estilo va por CSS.
  *
  * Grupo "Más" (grounding oscuro, 2026-07-01): algunos chips del manifiesto
  * (toxicidad, saberes tradicionales, alerta normativa páramo, variedades,
  * polinización, fenología — `moreGroup:true` en CHIP_DEFS, derivado de
  * `chipMore` en agentCapabilities.js) son consultas puntuales del grafo, NO el
- * núcleo diario. Para no saturar la barra principal se agrupan detrás de un
- * chip toggle "Más" (`data-testid="mode-chip-more"`): al tocarlo se despliega
+ * núcleo diario. Para no saturar la grilla principal se agrupan detrás de una
+ * fila toggle "Más" (`data-testid="mode-chip-more"`): al tocarla se despliega
  * un SEGUNDO `role="toolbar"` con esos chips, pintados con el MISMO patrón
  * (mismo `onSelectIntent`, mismo `data-testid="mode-chip"`, mismo
  * aria-pressed/disabled) — cero mecanismo nuevo, solo una repisa aparte.
@@ -93,31 +101,17 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
 
   // Grupo "Más": chips de grounding puntual (toxicidad, saberes tradicionales,
   // alerta páramo, variedades, polinización, fenología) que NO se pintan en la
-  // fila principal — se agrupan detrás del toggle para no saturar la barra
-  // con el núcleo diario. `coreChipDefs` conserva EXACTAMENTE el comportamiento
+  // grilla principal — se agrupan detrás del toggle para no saturar con el
+  // núcleo diario. `coreChipDefs` conserva EXACTAMENTE el comportamiento
   // histórico (mismo orden, mismo contenido) para no romper nada existente.
   const coreChipDefs = visibleChipDefs.filter((def) => !def.moreGroup);
   const moreChipDefs = visibleChipDefs.filter((def) => def.moreGroup);
 
-  const baseChip =
-    'shrink-0 inline-flex items-center gap-1.5 px-3.5 py-2 rounded-full border ' +
-    'text-sm font-semibold whitespace-nowrap transition-all active:scale-95 ' +
-    'focus:outline-none focus:ring-2 focus:ring-emerald-400/60 ' +
-    'disabled:opacity-40 disabled:cursor-not-allowed';
-  // Alto contraste: activo = verde sólido sobre texto blanco; inactivo =
-  // superficie OPACA por token (.agent-chip — paridad con el home, legible sobre
-  // la foto de fondo). Toque ≥44px efectivo por padding.
-  const inactiveChip = 'agent-chip';
-  const activeChip =
-    'bg-emerald-600 border-emerald-300 text-white shadow-md';
-  // Chip Pro bloqueado: apariencia visualmente diferenciada para free users.
-  const proLockedChip =
-    'bg-slate-800 border-slate-700 text-slate-500 cursor-not-allowed';
-
-  // Render de UN chip de modo — compartido entre la fila principal y el
-  // grupo "Más" (mismo mecanismo: onSelectIntent(def.intent), mismo testid,
-  // mismo aria-pressed/disabled). Evita duplicar el markup entre las dos filas.
-  const renderChip = (def) => {
+  // Render de UN modo como tarjeta-semilla — compartido entre la grilla
+  // principal y el grupo "Más" (mismo mecanismo: onSelectIntent(def.intent),
+  // mismo testid, mismo aria-pressed/disabled). `index` alimenta --i para la
+  // entrada escalonada (solo presentación; reduced-motion la apaga por CSS).
+  const renderChip = (def, index) => {
     const isActive = activeIntent === def.intent;
     // El chip 🔬 Deep Research es Pro-only. Para usuarios free: deshabilitado
     // con copy claro "función Pro" y title explicativo. NO se oculta — el
@@ -125,11 +119,6 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
     const isDeepChip = def.intent === CHIP_INTENTS.deep;
     const isProLocked = isDeepChip && !isPro;
     const chipDisabled = disabled || isProLocked;
-    const chipClass = isProLocked
-      ? proLockedChip
-      : isActive
-        ? activeChip
-        : inactiveChip;
     const chipTitle = isProLocked
       ? 'Función Pro — disponible para usuarios con acceso avanzado'
       : def.placeholder;
@@ -146,23 +135,21 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
         aria-pressed={isActive}
         aria-label={isProLocked ? `${def.label} — función Pro` : def.label}
         title={chipTitle}
-        className={`${baseChip} ${chipClass}`}
+        className={`v3-chipcard${isProLocked ? ' is-locked' : ''}`}
+        style={{ '--i': index }}
       >
-        <span aria-hidden="true">{def.emoji}</span>
-        <span>{isProLocked ? `${def.label} (Pro)` : def.label}</span>
+        <span className="v3-chipcard-emoji" aria-hidden="true">{def.emoji}</span>
+        <span className="v3-chipcard-label">{isProLocked ? `${def.label} (Pro)` : def.label}</span>
       </button>
     );
   };
 
   return (
-    <div
-      data-testid="chips-toolbar"
-      className="agent-chip-tray px-3 py-2"
-    >
+    <div data-testid="chips-toolbar">
       <div
         role="toolbar"
         aria-label="Modos del asistente"
-        className="flex flex-wrap gap-2 pb-1 -mb-1"
+        className="v3-chipgrid"
       >
         {/* Chip 📷 foto: primero y SOLO si hay imagen adjunta. */}
         {hasAttachment && (
@@ -172,10 +159,11 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
             onClick={() => onSelectIntent('foto')}
             disabled={disabled}
             aria-pressed={activeIntent === 'foto'}
-            className={`${baseChip} ${activeIntent === 'foto' ? activeChip : inactiveChip}`}
+            className="v3-chipcard"
+            style={{ '--i': 0 }}
           >
-            <span aria-hidden="true">📷</span>
-            <span>Foto</span>
+            <span className="v3-chipcard-emoji" aria-hidden="true">📷</span>
+            <span className="v3-chipcard-label">Foto</span>
           </button>
         )}
 
@@ -193,10 +181,10 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
             aria-controls="chips-toolbar-more"
             aria-label={showMore ? 'Ocultar más consultas del agente' : 'Más consultas del agente'}
             title="Más consultas: toxicidad, saberes tradicionales, variedades, polinización, fenología y normativa de páramo"
-            className={`${baseChip} ${showMore ? activeChip : inactiveChip}`}
+            className="v3-more-row"
           >
             <span aria-hidden="true">{showMore ? '➖' : '➕'}</span>
-            <span>Más</span>
+            <span>{showMore ? 'Menos consultas' : 'Más consultas del catálogo'}</span>
           </button>
         )}
       </div>
@@ -206,7 +194,7 @@ const ChipsToolbar = React.memo(function ChipsToolbar({
           id="chips-toolbar-more"
           role="toolbar"
           aria-label="Más consultas del agente"
-          className="flex flex-wrap gap-2 pt-2 mt-2 border-t border-white/10"
+          className="v3-chipgrid v3-chipgrid-more"
         >
           {moreChipDefs.map(renderChip)}
         </div>

--- a/src/components/__tests__/agentUserFlow.smoke.test.jsx
+++ b/src/components/__tests__/agentUserFlow.smoke.test.jsx
@@ -77,7 +77,9 @@ describe('flujo usuario nuevo — estado activo del modo claro', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} activeIntent="clima" />);
     const climaChip = screen.getByRole('button', { name: /clima/i });
     expect(climaChip).toHaveAttribute('aria-pressed', 'true');
-    expect(climaChip).toHaveClass(/emerald/); // verde = activo
+    // V3: el estado activo ya no va por clase Tailwind emerald — lo pinta el
+    // CSS por atributo (.v3-chipcard[aria-pressed="true"] → acento del tema).
+    expect(climaChip).toHaveClass('v3-chipcard');
   });
 
   it('chip inactivo no tiene aria-pressed=true', () => {


### PR DESCRIPTION
## V3 (fable) — rediseño del chat del agente: "Cuaderno de campo cosido"

Tercera iteración del rediseño del chat (V1 #2026, V2 #2028 corrieron en Opus). Esta es la versión de fable, con dirección de diseño propia. **Solo capa visual** — cero cambios de lógica (streaming, tool-calls, captura, memoria), props ni contratos de datos.

### 1. FIX obligatorio: la bandeja de ~11-13 chips → LA MOCHILA
La bandeja `ChipsToolbar` en `flex-wrap` que vivía SIEMPRE sobre el input se comía ~mitad del alto en móvil (rechazada 3× por el operador). Ahora:

- **Un solo control** en la fila de íconos del compositor: pill "Temas" (forma de semilla, Baloo 2). Cero alto extra.
- Abre **LA MOCHILA**: bottom-sheet con scroll (`max-height 72dvh`), cierra al elegir, al tocar afuera, con la ✕ o con Escape (el foco entra al diálogo al abrir).
- Adentro, los modos son **tarjetas-semilla en grilla 2-col** (emoji 21px + etiqueta Nunito, ≥58px de alto): legibles al sol, tocables con guantes — no píldoras miniatura. Entrada escalonada (22ms/tarjeta).
- El grupo "Más" conserva su toggle (mismos testids/aria) como fila punteada "Más consultas del catálogo".
- **Modo activo** = etiqueta de ancho completo sobre el input (`🐛 Plaga ✕`): nunca se trunca, un toque en la ✕ lo quita, tocarla reabre la mochila. El pill "Temas" se tiñe de acento como señal secundaria.
- **Con la mochila cerrada el chat recupera el ALTO COMPLETO.** Misma data (`CHIP_DEFS`/`profileChipDefs`) y mismo `onSelectIntent` — cero mecanismo nuevo.

### 2. Rediseño BOLD del chat: el cuaderno + LA COSTURA
- **Turnos del agente = entradas de cuaderno de campo**: byline "Chagra" (colibrí 22px + Baloo 2) y tarjeta-papel del tema (lomo plano arriba-izquierda, Nunito 15px/1.65). Ya no es la pareja genérica avatar-circulito + burbuja slate de chatbot.
- **Firma de la marca — LA COSTURA**: las respuestas respaldadas por el catálogo (`data-grounded`) llevan una **puntada de hilo esmeralda** en el borde izquierdo, como la costura de un costal de fique. Generativa = sin hilo. El mismo hilo cose el dobladillo de la mochila.
- **Turnos del usuario**: nota compacta `--c-emerald-700` + blanco (AA en los 4 temas), sin ícono de personita — se recupera ese ancho en móvil.
- **Tipografía**: Baloo 2 (display: saludos, byline, mochila, estados de voz) + Nunito (cuerpo) — las fuentes self-host del home Finca Viva, nada de Inter/Roboto en la cara del chat.
- "Pensando…" pre-stream ahora es una entrada más del cuaderno (byline con colibrí en thinking + tarjeta-papel).
- Micro-animaciones: entrada de turnos (260ms rise), sheet rise, stagger de tarjetas — todo apagado bajo `prefers-reduced-motion`.
- 100% tokens de tema (`--c-*`, `--t-accent-rgb`) → coherente en los 4 temas, superficies opacas legibles al sol. Verificado con screenshots reales en biopunk + nature + minimalista + verde-vivo.

### Alcance/seguridad
- `AgentScreen.jsx` (monolito): solo se tocó la capa de render del compositor/sheet — el ruteo `onSelectIntent → setActiveIntent` quedó idéntico.
- `ChipsToolbar` conserva TODOS los contratos: `mode-chip`, `mode-chip-foto`, `mode-chip-more`, `chips-toolbar(-more)`, roles toolbar, `aria-pressed/expanded/controls`, gating deep/Pro, disabled.
- NO se tocó `FincaVivaHero.jsx` ni `finca-viva-hero.css` (los `@font-face` se duplican adrede en el CSS del agente — el navegador los dedupe — para no depender del home).
- Tests: 157 pass (13 archivos: ChipsToolbar smoke/grounding, ChatBubble, VoiceStatusStrip, ChatHistory, queue, photoPipeline, entrance, userFlow). Se ajustaron 2 asserts de capa visual: `AgentScreen.chipsToolbar` (nuevo flujo mochila) y un `toHaveClass(/emerald/)` de `agentUserFlow` (el activo ahora se pinta por `[aria-pressed]` + acento del tema).
- `npm run build` VERDE. Smoke visual real (Playwright + chromium contra `dist/`): monta sin pageerrors, mochila abre/cierra, modo se fuerza y limpia, chat con turnos nuevos en los 4 temas.

### Para captura (antes/después obvio)
1. `#agente` en móvil: el chat ocupa TODO el alto — ya no hay bandeja de píldoras sobre el input.
2. Tocar **Temas** → la mochila sube con la puntada en el dobladillo y la grilla de tarjetas.
3. Elegir **Plaga** → etiqueta `🐛 Plaga ✕` sobre el input + placeholder guiado.
4. Mandar una pregunta → entrada de cuaderno con byline "Chagra"; si la respuesta viene del catálogo, la costura esmeralda al borde izquierdo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
