### PR TITLE
feat(agua): modulo de manejo del agua (cosecha lluvia, riego, calidad)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,6 +104,10 @@ const CicloNutrientesScreen = lazy(() => import('./components/CicloNutrientesScr
 const CalendarioFincaScreen = lazy(() => import('./components/CalendarioFincaScreen'));
 const SeguimientoProcesoScreen = lazy(() => import('./components/SeguimientoProcesoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
+// Módulo "Agua de la finca": cosecha de lluvia (calculadora determinista),
+// riego con medida (ETc; Kc/ETo = slots grounded-pendiente) y cuidar el agua
+// (calidad + nacimiento, caso "se me seca el nacimiento en verano").
+const AguaScreen = lazy(() => import('./components/agua/AguaScreen'));
 const CromatografiaScreen = lazy(() => import('./components/CromatografiaScreen'));
 const CicloVivoFullView = lazy(() => import('./components/CicloVivo/CicloVivoFullView'));
 const ToxicologiaScreen = lazy(() => import('./components/ToxicologiaScreen'));
@@ -192,6 +196,8 @@ const HASH_VIEW_ROUTES = {
   'mundo-subsuelo': 'subsuelo',
   toxicologia: 'toxicologia',
   suelo: 'suelo',
+  agua: 'agua',
+  'manejo-agua': 'agua',
   aprende: 'aprende',
   directorio: 'directorio',
   'directorio-especies': 'directorio',
@@ -209,7 +215,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
+  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
   'usage_stats', 'mercado', 'auditoria_inventario',
@@ -1239,6 +1245,17 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Cromatografia de Suelo">
               <CromatografiaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'agua':
+        // Módulo "Agua de la finca" (3 pilares: cosechar lluvia / regar con
+        // medida / cuidar el agua + nacimiento). Cifras duras pendientes de
+        // grounding se muestran como "dato en camino" (src/data/aguaFinca.js).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Agua de la finca">
+              <AguaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/agua/AguaScreen.jsx
+++ b/src/components/agua/AguaScreen.jsx
@@ -1,0 +1,537 @@
+import React, { useMemo, useState } from 'react';
+import {
+  CloudRain, Droplets, Sprout, Calculator, TriangleAlert, Sun,
+  ShieldCheck, Users, Hourglass, Milk, ChevronRight,
+} from 'lucide-react';
+import { ScreenShell } from '../common/ScreenShell';
+import CaminoDelAgua from './CaminoDelAgua';
+import {
+  litrosLluviaCaptables,
+  canecasEquivalentes,
+  porcentajeTanque,
+  etcDiaria,
+  litrosRiegoDia,
+  COEF_ESCORRENTIA_TECHO_DEFAULT,
+  LITROS_POR_CANECA_55GAL,
+} from '../../services/aguaCalculos';
+import {
+  PILARES_AGUA,
+  PASOS_COSECHA,
+  KC_CULTIVOS,
+  SISTEMAS_RIEGO,
+  PRACTICAS_AHORRO,
+  USOS_DEL_AGUA,
+  SENALES_ALERTA_AGUA,
+  DOSIS_POTABILIZACION,
+  RONDA_PROTECCION,
+  CASO_NACIMIENTO,
+} from '../../data/aguaFinca';
+import { getEnsoPhase, getEnsoLabel } from '../../services/ensoService';
+import './agua.css';
+
+/**
+ * AguaScreen — módulo "Agua de la finca": manejo del agua para el campesino.
+ *
+ * Tres pilares (cuaderno de campo, un solo camino visual):
+ *   1. Cosechar la lluvia — calculadora determinista techo × lluvia → litros.
+ *   2. Regar con medida  — ETc = ETo × Kc (fórmula FAO); Kc/ETo reales son
+ *      slots grounded-pendiente (src/data/aguaFinca.js), NO se inventan.
+ *   3. Cuidar el agua    — calidad/potabilidad + proteger el nacimiento, con
+ *      el caso insignia "se me seca el nacimiento en verano". Se conecta con
+ *      el ciclo ENSO que Chagra ya sigue (ensoService) — no se re-implementa.
+ *
+ * Toda cifra dura pendiente de grounding se pinta como "dato en camino"
+ * (SlotPendiente), nunca como número inventado.
+ */
+
+const fmt = (n) => Number(n).toLocaleString('es-CO');
+
+/** Chip honesto para cifras aún sin grounding: promete el dato, no lo inventa. */
+function SlotPendiente({ children }) {
+  return (
+    <span
+      data-testid="slot-grounded-pendiente"
+      className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] font-bold text-amber-300"
+    >
+      <Hourglass size={11} aria-hidden="true" />
+      {children || 'Dato en camino'}
+    </span>
+  );
+}
+
+/** Campo numérico grande, legible al sol, con etiqueta arriba y unidad al lado. */
+function CampoNumero({ id, label, unidad, value, onChange, placeholder, hint }) {
+  return (
+    <label htmlFor={id} className="block">
+      <span className="block text-xs font-bold uppercase tracking-wide text-slate-300 mb-1">{label}</span>
+      <span className="flex items-center gap-2 rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 focus-within:border-cyan-500">
+        <input
+          id={id}
+          data-testid={id}
+          type="number"
+          inputMode="decimal"
+          min="0"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="w-full bg-transparent text-lg font-black text-white outline-none placeholder:text-slate-600"
+        />
+        <span className="shrink-0 text-sm font-bold text-slate-400">{unidad}</span>
+      </span>
+      {hint && <span className="block mt-1 text-[11px] leading-snug text-slate-400">{hint}</span>}
+    </label>
+  );
+}
+
+/* ── PILAR 1 · Cosechar la lluvia ─────────────────────────────────────── */
+function PilarLluvia() {
+  const [areaTecho, setAreaTecho] = useState('');
+  const [lluviaMes, setLluviaMes] = useState('');
+  const [capacidad, setCapacidad] = useState('1000');
+
+  const litros = useMemo(
+    () => litrosLluviaCaptables({ areaTechoM2: areaTecho, lluviaMm: lluviaMes }),
+    [areaTecho, lluviaMes],
+  );
+  const canecas = litros != null ? canecasEquivalentes(litros) : null;
+  const nivel = litros != null ? porcentajeTanque({ litros, capacidadL: capacidad }) : null;
+
+  return (
+    <section className="agua-seccion space-y-4" data-testid="pilar-lluvia">
+      <p className="text-sm leading-relaxed text-slate-200">
+        Cada aguacero que cae sobre su techo es agua que ya pagó el cielo. Con un
+        canal y un tanque, ese techo se vuelve la primera fuente de agua de la
+        finca — y cada caneca guardada es agua que en verano no se le saca al
+        nacimiento.
+      </p>
+
+      {/* Calculadora determinista: área × lluvia × 0.8 */}
+      <div className="rounded-2xl border border-cyan-700/40 bg-slate-900/60 p-4 space-y-3">
+        <p className="flex items-center gap-2 text-sm font-black text-cyan-300 uppercase tracking-wide">
+          <Calculator size={16} aria-hidden="true" /> Cuánta agua le cae al techo
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <CampoNumero
+            id="agua-area-techo"
+            label="Techo"
+            unidad="m²"
+            value={areaTecho}
+            onChange={setAreaTecho}
+            placeholder="60"
+            hint="Largo × ancho del piso que cubre el techo."
+          />
+          <CampoNumero
+            id="agua-lluvia-mes"
+            label="Lluvia del mes"
+            unidad="mm"
+            value={lluviaMes}
+            onChange={setLluviaMes}
+            placeholder="120"
+            hint="De su pluviómetro o del módulo de clima."
+          />
+        </div>
+        <p className="text-[11px] leading-snug text-slate-400">
+          El dato de lluvia típica de su municipio llegará solo al módulo{' '}
+          <SlotPendiente>lluvia por zona en camino (IDEAM)</SlotPendiente>. Mientras
+          tanto, digite el suyo.
+        </p>
+
+        {litros != null ? (
+          <div className="flex items-center gap-4 rounded-xl border border-cyan-600/40 bg-cyan-950/40 p-3" data-testid="calc-lluvia-resultado">
+            {/* tanque con nivel animado (scaleY) */}
+            <svg viewBox="0 0 44 56" className="w-12 h-16 shrink-0" aria-hidden="true">
+              <rect x="4" y="4" width="36" height="48" rx="6" fill="none" stroke="currentColor" strokeWidth="3" className="text-slate-400" />
+              <g>
+                <rect
+                  x="8" y="8" width="28" height="40" rx="3"
+                  fill="currentColor"
+                  className="text-cyan-400/80 agua-nivel"
+                  style={{ transform: `scaleY(${Math.max(nivel ?? 0, 4) / 100})` }}
+                />
+              </g>
+            </svg>
+            <div className="min-w-0">
+              <p className="text-2xl font-black text-white leading-none">
+                {fmt(litros)} <span className="text-base font-bold text-cyan-300">litros al mes</span>
+              </p>
+              <p className="mt-1 text-xs text-slate-300">
+                ≈ {fmt(canecas)} canecas de 55 galones ({LITROS_POR_CANECA_55GAL} L).
+                {nivel != null && Number(capacidad) > 0 && (
+                  <> Su tanque de {fmt(capacidad)} L quedaría al <strong className="text-cyan-200">{nivel}%</strong>{nivel >= 100 ? ' — ¡y sobra!' : '.'}</>
+                )}
+              </p>
+              <p className="mt-1 text-[10px] text-slate-500">
+                Cuenta hecha con el {Math.round(COEF_ESCORRENTIA_TECHO_DEFAULT * 100)}% de la lluvia: una parte siempre se pierde en salpique y primeras lavadas.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <p className="text-xs italic text-slate-500" data-testid="calc-lluvia-vacia">
+            Digite el techo y la lluvia para ver los litros.
+          </p>
+        )}
+
+        <CampoNumero
+          id="agua-capacidad-tanque"
+          label="¿De cuánto es su tanque? (opcional)"
+          unidad="L"
+          value={capacidad}
+          onChange={setCapacidad}
+          placeholder="1000"
+        />
+      </div>
+
+      {/* Pasos del sistema — es una secuencia real de construcción */}
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4">
+        <p className="text-sm font-black text-slate-100 uppercase tracking-wide mb-3">Del techo al tanque, en orden</p>
+        <ol className="space-y-3">
+          {PASOS_COSECHA.map((paso, i) => (
+            <li key={paso.id} className="flex gap-3">
+              <span aria-hidden="true" className="shrink-0 w-6 h-6 rounded-full bg-cyan-500/20 border border-cyan-500/40 text-cyan-300 text-xs font-black grid place-items-center">
+                {i + 1}
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-bold text-slate-100 leading-tight">{paso.titulo}</p>
+                <p className="text-xs leading-snug text-slate-300 mt-0.5">{paso.detalle}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+/* ── PILAR 2 · Regar con medida ───────────────────────────────────────── */
+function PilarRiego() {
+  const [eto, setEto] = useState('');
+  const [kc, setKc] = useState('');
+  const [area, setArea] = useState('');
+
+  const etc = useMemo(() => etcDiaria({ etoMmDia: eto, kc }), [eto, kc]);
+  const litrosDia = useMemo(
+    () => (etc != null ? litrosRiegoDia({ etcMmDia: etc, areaM2: area }) : null),
+    [etc, area],
+  );
+
+  return (
+    <section className="agua-seccion space-y-4" data-testid="pilar-riego">
+      <p className="text-sm leading-relaxed text-slate-200">
+        Regar no es empapar: es darle a la mata lo que ese día transpiró y ni una
+        gota más. Esa cuenta tiene nombre — <strong className="text-teal-300">ETc</strong>,
+        el consumo diario del cultivo — y se saca multiplicando el clima de su zona
+        (ETo) por el apetito de agua de cada cultivo (Kc).
+      </p>
+
+      <div className="rounded-2xl border border-teal-700/40 bg-slate-900/60 p-4 space-y-3">
+        <p className="flex items-center gap-2 text-sm font-black text-teal-300 uppercase tracking-wide">
+          <Calculator size={16} aria-hidden="true" /> La cuenta del riego
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <CampoNumero
+            id="agua-eto"
+            label="ETo de su zona"
+            unidad="mm/día"
+            value={eto}
+            onChange={setEto}
+            placeholder="—"
+            hint="Cuánta agua 'pide' el clima al día."
+          />
+          <CampoNumero
+            id="agua-kc"
+            label="Kc del cultivo"
+            unidad=""
+            value={kc}
+            onChange={setKc}
+            placeholder="—"
+            hint="El apetito del cultivo (entre 0.2 y 1.3)."
+          />
+        </div>
+        <CampoNumero
+          id="agua-area-riego"
+          label="Área sembrada"
+          unidad="m²"
+          value={area}
+          onChange={setArea}
+          placeholder="100"
+        />
+        <p className="text-[11px] leading-snug text-slate-400">
+          La ETo por piso térmico y el Kc de cada cultivo del directorio llegarán
+          con fuente citada <SlotPendiente>ETo y Kc en camino (FAO-56 / IDEAM)</SlotPendiente>.
+          Si ya los conoce, la cuenta le sirve desde hoy.
+        </p>
+
+        {litrosDia != null ? (
+          <div className="rounded-xl border border-teal-600/40 bg-teal-950/40 p-3" data-testid="calc-riego-resultado">
+            <p className="text-2xl font-black text-white leading-none">
+              {fmt(litrosDia)} <span className="text-base font-bold text-teal-300">litros al día</span>
+            </p>
+            <p className="mt-1 text-xs text-slate-300">
+              Consumo del cultivo: <strong className="text-teal-200">{etc} mm/día</strong> (ETo × Kc) sobre {fmt(area)} m².
+              Es la necesidad de la planta: según el sistema de riego, una parte se pierde por el camino.
+            </p>
+          </div>
+        ) : (
+          <p className="text-xs italic text-slate-500" data-testid="calc-riego-vacia">
+            Digite ETo, Kc y área para ver los litros diarios.
+          </p>
+        )}
+
+        {/* Kc por cultivo: slots honestos, se llenan por grounding */}
+        <div>
+          <p className="text-xs font-bold uppercase tracking-wide text-slate-300 mb-1.5">Kc por cultivo</p>
+          <div className="flex flex-wrap gap-1.5">
+            {KC_CULTIVOS.map((c) => (
+              <span key={c.slug} className="inline-flex items-center gap-1.5 rounded-full border border-slate-700 bg-slate-950/50 px-2.5 py-1 text-xs font-bold text-slate-200">
+                {c.nombre}
+                {c.kc == null ? <SlotPendiente /> : <span className="text-teal-300">{c.kc}</span>}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Sistemas de riego: comparación cualitativa, sin cifras inventadas */}
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 space-y-3">
+        <p className="text-sm font-black text-slate-100 uppercase tracking-wide">Con qué riega, cuánto pierde</p>
+        {SISTEMAS_RIEGO.map((s) => (
+          <div key={s.id} className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3">
+            <p className="flex flex-wrap items-center gap-2 text-sm font-bold text-slate-100 leading-tight">
+              {s.nombre}
+              <span className="rounded-full bg-slate-700/50 px-2 py-0.5 text-[11px] font-bold text-slate-300">{s.pierde}</span>
+            </p>
+            <p className="text-xs leading-snug text-slate-300 mt-1">{s.detalle}</p>
+          </div>
+        ))}
+        <p className="text-[11px] leading-snug text-slate-400">
+          El porcentaje exacto de eficiencia de cada sistema{' '}
+          <SlotPendiente>eficiencias en camino (FAO)</SlotPendiente> — el orden, eso sí,
+          no cambia: goteo rinde más que aspersión, y aspersión más que el surco.
+        </p>
+      </div>
+
+      {/* Prácticas de ahorro */}
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4">
+        <p className="text-sm font-black text-slate-100 uppercase tracking-wide mb-3">Menos sed con el mismo cielo</p>
+        <ul className="space-y-3">
+          {PRACTICAS_AHORRO.map((p) => (
+            <li key={p.id} className="flex gap-3">
+              <Sprout size={18} aria-hidden="true" className="shrink-0 text-lime-400 mt-0.5" />
+              <div className="min-w-0">
+                <p className="text-sm font-bold text-slate-100 leading-tight">{p.titulo}</p>
+                <p className="text-xs leading-snug text-slate-300 mt-0.5">{p.detalle}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+/* ── PILAR 3 · Cuidar el agua ─────────────────────────────────────────── */
+function PilarCuidar() {
+  // Fase ENSO viva desde el servicio que Chagra ya tiene (no se re-implementa
+  // clima aquí; solo se lee para aterrizar el consejo del caso insignia).
+  const fase = getEnsoPhase();
+  const faseLabel = getEnsoLabel();
+  const consejoEnso = {
+    el_nino: 'Fase actual: El Niño — se espera menos lluvia de lo normal. Guarde desde ya y racione temprano: este es el verano que seca nacimientos.',
+    la_nina: 'Fase actual: La Niña — se espera más lluvia de lo normal. Aproveche: llene tanques, siembre la protección del nacimiento y revise canales.',
+    neutral: 'Fase actual: Neutral — el año viene sin Niño ni Niña encima, pero el verano llega igual: la protección se siembra en invierno.',
+  }[fase] || '';
+
+  return (
+    <section className="agua-seccion space-y-4" data-testid="pilar-cuidar">
+      <p className="text-sm leading-relaxed text-slate-200">
+        El agua de la finca son dos cuidados en uno: que la que entra a la casa no
+        enferme a nadie, y que el nacimiento que la da no se quede solo.
+      </p>
+
+      {/* Escalera de usos */}
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 space-y-3">
+        <p className="text-sm font-black text-slate-100 uppercase tracking-wide">Cada agua para lo suyo</p>
+        {USOS_DEL_AGUA.map((u) => (
+          <div key={u.id} className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3">
+            <p className="text-sm font-bold text-slate-100 leading-tight">{u.agua}</p>
+            <p className="text-xs text-slate-300 mt-1"><strong className="text-emerald-300">Sirve para:</strong> {u.sirve}</p>
+            <p className="text-xs text-amber-200/90 mt-0.5"><strong>Ojo:</strong> {u.ojo}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Potabilidad — cualitativo seguro + dosis pendientes */}
+      <div className="rounded-2xl border border-sky-700/40 bg-slate-900/60 p-4 space-y-2">
+        <p className="flex items-center gap-2 text-sm font-black text-sky-300 uppercase tracking-wide">
+          <Milk size={16} aria-hidden="true" /> Para tomar: trátela siempre
+        </p>
+        <p className="text-xs leading-snug text-slate-200">
+          Deje asentar el agua turbia y pásela por tela limpia. Para consumo, lo más
+          seguro de la finca es <strong className="text-sky-200">hervirla hasta que suelte borbotones</strong> y
+          guardarla tapada. También sirve desinfectar con cloro de uso doméstico —
+          pero la dosis exacta por litro solo se la vamos a dar con fuente sanitaria:
+        </p>
+        <p>
+          <SlotPendiente>dosis de cloro y tiempos en camino (OMS / MinSalud)</SlotPendiente>
+        </p>
+        {DOSIS_POTABILIZACION.cloroGotasPorLitro == null && (
+          <p className="text-[11px] leading-snug text-slate-400">
+            Mientras el dato llega, no adivine gotas: hierva. Y si el agua huele a
+            químico o viene de potrero fumigado, ni hervida — consígala de otra fuente.
+          </p>
+        )}
+        <div className="rounded-xl border border-rose-700/40 bg-rose-950/30 p-3">
+          <p className="flex items-center gap-2 text-xs font-black text-rose-300 uppercase tracking-wide mb-1.5">
+            <TriangleAlert size={14} aria-hidden="true" /> No la use si ve esto
+          </p>
+          <ul className="space-y-1">
+            {SENALES_ALERTA_AGUA.map((s) => (
+              <li key={s} className="text-xs leading-snug text-slate-200 flex gap-1.5">
+                <span aria-hidden="true" className="text-rose-400">•</span>{s}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {/* CASO INSIGNIA */}
+      <div className="rounded-2xl border border-emerald-700/50 bg-emerald-950/30 p-4 space-y-3" data-testid="caso-nacimiento">
+        <p className="flex items-center gap-2 text-base font-black text-emerald-200 leading-tight">
+          <Droplets size={18} aria-hidden="true" className="shrink-0 text-cyan-300" />
+          «{CASO_NACIMIENTO.titulo}»
+        </p>
+        <p className="text-xs leading-snug text-slate-200">{CASO_NACIMIENTO.resumen}</p>
+
+        <div>
+          <p className="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-amber-300 mb-2">
+            <Sun size={14} aria-hidden="true" /> En pleno verano (auxilio)
+          </p>
+          <ul className="space-y-2">
+            {CASO_NACIMIENTO.enVerano.map((p) => (
+              <li key={p.id} className="text-xs leading-snug text-slate-200">
+                <strong className="text-slate-100">{p.titulo}.</strong> {p.detalle}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <p className="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-emerald-300 mb-2">
+            <CloudRain size={14} aria-hidden="true" /> En invierno se siembra la solución
+          </p>
+          <ul className="space-y-2">
+            {CASO_NACIMIENTO.enInvierno.map((p) => (
+              <li key={p.id} className="text-xs leading-snug text-slate-200">
+                <strong className="text-slate-100">{p.titulo}.</strong> {p.detalle}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <p className="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-sky-300 mb-2">
+            <Users size={14} aria-hidden="true" /> Con los vecinos y con el clima
+          </p>
+          <ul className="space-y-2">
+            {CASO_NACIMIENTO.comunidad.map((p) => (
+              <li key={p.id} className="text-xs leading-snug text-slate-200">
+                <strong className="text-slate-100">{p.titulo}.</strong> {p.detalle}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Conexión viva con el ENSO que Chagra ya sigue */}
+        <div className="rounded-xl border border-cyan-700/40 bg-slate-950/50 p-3" data-testid="enso-conexion">
+          <p className="text-xs font-black uppercase tracking-wide text-cyan-300 mb-1">
+            El clima que viene · {faseLabel}
+          </p>
+          <p className="text-xs leading-snug text-slate-200">{consejoEnso}</p>
+        </div>
+
+        {/* Franja legal: slot honesto */}
+        <div className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3">
+          <p className="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-slate-200 mb-1">
+            <ShieldCheck size={14} aria-hidden="true" /> La ley también lo protege
+          </p>
+          <p className="text-xs leading-snug text-slate-300">
+            La norma colombiana ordena conservar una franja de monte alrededor de los
+            nacimientos y a la orilla de los cauces. Los metros exactos se los daremos
+            con la norma citada{' '}
+            {RONDA_PROTECCION.metrosNacimiento == null && (
+              <SlotPendiente>metros de ronda en camino (norma verificada)</SlotPendiente>
+            )}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ── Pantalla principal ───────────────────────────────────────────────── */
+export default function AguaScreen({ onBack, onNavigate }) {
+  const [pilar, setPilar] = useState('lluvia');
+
+  return (
+    <ScreenShell title="Agua de la finca" icon={CloudRain} onBack={onBack}>
+      <div className="max-w-2xl mx-auto p-4 space-y-4" data-testid="agua-screen">
+        {/* Portada: el camino del agua + la nota de cuaderno */}
+        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4">
+          <CaminoDelAgua activo={pilar} />
+          <p className="mt-2 text-xs italic leading-snug text-slate-400 text-center">
+            El agua hace un solo camino en la finca: cae al techo, riega el surco y
+            nace en la loma. Cuidarlo completo es lo que la mantiene corriendo.
+          </p>
+        </div>
+
+        {/* Navegación entre pilares */}
+        <div className="grid grid-cols-3 gap-2" role="tablist" aria-label="Pilares del agua">
+          {PILARES_AGUA.map((p) => {
+            const activo = pilar === p.id;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                role="tab"
+                aria-selected={activo}
+                data-testid={`pilar-tab-${p.id}`}
+                onClick={() => setPilar(p.id)}
+                className={`rounded-xl border px-2 py-2.5 text-center transition-colors min-h-[56px] ${
+                  activo
+                    ? 'agua-estacion-activa border-cyan-500/70 bg-cyan-500/15 text-cyan-200'
+                    : 'border-slate-700 bg-slate-900/50 text-slate-300 active:bg-slate-800/70'
+                }`}
+              >
+                <span className="block text-sm font-black leading-tight">{p.titulo}</span>
+                <span className={`block text-[10px] leading-tight mt-0.5 ${activo ? 'text-cyan-300/90' : 'text-slate-500'}`}>
+                  {p.descripcion}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {pilar === 'lluvia' && <PilarLluvia />}
+        {pilar === 'riego' && <PilarRiego />}
+        {pilar === 'cuidar' && <PilarCuidar />}
+
+        {/* Puente al agente para lo que el módulo no alcanza */}
+        {typeof onNavigate === 'function' && (
+          <button
+            type="button"
+            data-testid="agua-preguntar-agente"
+            onClick={() => onNavigate('agente', { prefilledPrompt: '¿Cómo cuido el agua de mi finca en la época seca?' })}
+            className="w-full flex items-center gap-3 rounded-2xl border border-slate-700/60 bg-slate-900/40 p-3.5 text-left active:bg-slate-800/60 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-10 h-10 rounded-xl bg-cyan-500/15 grid place-items-center">
+              <Droplets size={20} className="text-cyan-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">¿Su caso es distinto?</span>
+              <span className="block text-xs text-slate-400 leading-tight mt-0.5">Cuénteselo al agente: él conoce su finca y su clima.</span>
+            </span>
+            <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/agua/AguaScreen.test.jsx
+++ b/src/components/agua/AguaScreen.test.jsx
@@ -1,0 +1,108 @@
+/**
+ * AguaScreen.test.jsx — módulo "Agua de la finca".
+ *
+ * Cubre:
+ *   1. Render base: camino del agua + los 3 pilares navegables.
+ *   2. Calculadora de lluvia: 100 m² × 100 mm → 8.000 L (determinista).
+ *   3. Cambio de pilar: riego (calculadora ETc) y cuidar (caso nacimiento).
+ *   4. Honestidad grounded: los slots pendientes se pintan como "dato en
+ *      camino", nunca como cifra.
+ *   5. Puente al agente (onNavigate).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AguaScreen from './AguaScreen.jsx';
+
+describe('AguaScreen — render base', () => {
+  it('monta la pantalla con el camino del agua y los 3 pilares', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    expect(screen.getByTestId('agua-screen')).toBeInTheDocument();
+    expect(screen.getByTestId('camino-del-agua')).toBeInTheDocument();
+    expect(screen.getByTestId('pilar-tab-lluvia')).toBeInTheDocument();
+    expect(screen.getByTestId('pilar-tab-riego')).toBeInTheDocument();
+    expect(screen.getByTestId('pilar-tab-cuidar')).toBeInTheDocument();
+    // Arranca en el pilar de lluvia
+    expect(screen.getByTestId('pilar-lluvia')).toBeInTheDocument();
+  });
+});
+
+describe('AguaScreen — calculadora de cosecha de lluvia', () => {
+  it('calcula litros al mes: 100 m² × 100 mm × 0.8 = 8.000 L', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    expect(screen.getByTestId('calc-lluvia-vacia')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('agua-area-techo'), { target: { value: '100' } });
+    fireEvent.change(screen.getByTestId('agua-lluvia-mes'), { target: { value: '100' } });
+
+    const resultado = screen.getByTestId('calc-lluvia-resultado');
+    expect(resultado).toHaveTextContent('8.000');
+    expect(resultado).toHaveTextContent('litros al mes');
+    // Con el tanque default de 1.000 L queda lleno (100%)
+    expect(resultado).toHaveTextContent('100%');
+  });
+
+  it('no muestra resultado con entradas incompletas', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.change(screen.getByTestId('agua-area-techo'), { target: { value: '100' } });
+    expect(screen.queryByTestId('calc-lluvia-resultado')).toBeNull();
+  });
+});
+
+describe('AguaScreen — pilar riego', () => {
+  it('calcula ETc y litros/día con valores digitados', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-riego'));
+    expect(screen.getByTestId('pilar-riego')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('agua-eto'), { target: { value: '4' } });
+    fireEvent.change(screen.getByTestId('agua-kc'), { target: { value: '1.15' } });
+    fireEvent.change(screen.getByTestId('agua-area-riego'), { target: { value: '100' } });
+
+    const resultado = screen.getByTestId('calc-riego-resultado');
+    expect(resultado).toHaveTextContent('460');
+    expect(resultado).toHaveTextContent('litros al día');
+    expect(resultado).toHaveTextContent('4.6 mm/día');
+  });
+
+  it('muestra los Kc de cultivos como slots grounded-pendiente (sin cifras inventadas)', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-riego'));
+    // Todos los Kc del seed están en null → cada chip de cultivo lleva su slot
+    const slots = screen.getAllByTestId('slot-grounded-pendiente');
+    expect(slots.length).toBeGreaterThanOrEqual(6);
+    expect(screen.getByText('Maíz')).toBeInTheDocument();
+  });
+});
+
+describe('AguaScreen — pilar cuidar (caso nacimiento + ENSO)', () => {
+  it('muestra el caso insignia y la conexión con el clima ENSO', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    expect(screen.getByTestId('pilar-cuidar')).toBeInTheDocument();
+
+    const caso = screen.getByTestId('caso-nacimiento');
+    expect(caso).toHaveTextContent('Se me seca el nacimiento en verano');
+    // Conexión viva con ensoService (fase default en test: Neutral)
+    expect(screen.getByTestId('enso-conexion')).toHaveTextContent(/Neutral|Niño|Niña/);
+  });
+
+  it('las dosis de potabilización y la ronda legal quedan como dato en camino', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    const slots = screen.getAllByTestId('slot-grounded-pendiente');
+    // dosis de cloro + metros de ronda, al menos
+    expect(slots.length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/hervirla hasta que suelte borbotones/i)).toBeInTheDocument();
+  });
+});
+
+describe('AguaScreen — puente al agente', () => {
+  it('navega al agente con la pregunta prellenada', () => {
+    const onNavigate = vi.fn();
+    render(<AguaScreen onBack={() => {}} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('agua-preguntar-agente'));
+    expect(onNavigate).toHaveBeenCalledWith('agente', expect.objectContaining({
+      prefilledPrompt: expect.stringMatching(/agua/i),
+    }));
+  });
+});

--- a/src/components/agua/CaminoDelAgua.jsx
+++ b/src/components/agua/CaminoDelAgua.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+
+/**
+ * CaminoDelAgua — la ilustración insignia del módulo "Agua de la finca".
+ *
+ * SVG propio (nada de librerías de stock): el recorrido del agua en una finca
+ * campesina, de izquierda a derecha —
+ *
+ *   NUBE con lluvia → TECHO de la casa → canal → TANQUE   (pilar: lluvia)
+ *   SURCO con la mata regada gota a gota                  (pilar: riego)
+ *   LOMA con monte nativo y el NACIMIENTO                 (pilar: cuidar)
+ *
+ * Es DECORATIVA (aria-hidden): la navegación real entre pilares son los
+ * botones que la acompañan en AguaScreen. La estación del pilar activo se
+ * resalta subiendo la opacidad de su grupo y bajando la de los demás — así
+ * el dibujo "responde" a la pestaña sin ser él mismo un control.
+ *
+ * Trazo: línea redondeada, formas simples de cuaderno de campo. Colores en
+ * clases Tailwind (currentColor por grupo) para que respiren con los temas.
+ */
+export default function CaminoDelAgua({ activo = 'lluvia' }) {
+  const dim = (id) => (activo === id ? 'opacity-100' : 'opacity-40');
+  return (
+    <svg
+      viewBox="0 0 360 132"
+      role="img"
+      aria-hidden="true"
+      className="w-full h-auto select-none"
+      data-testid="camino-del-agua"
+    >
+      {/* línea de tierra que une todo el camino */}
+      <path
+        d="M6 112 Q 90 106 180 112 T 354 110"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        className="text-amber-700/60"
+      />
+
+      {/* ── ESTACIÓN 1 · lluvia: nube → techo → tanque ── */}
+      <g className={`transition-opacity duration-300 ${dim('lluvia')}`}>
+        {/* nube */}
+        <g className="text-sky-300">
+          <path
+            d="M28 34 q -8 0 -8 -8 q 0 -9 9 -9 q 2 -8 11 -8 q 8 0 10 7 q 9 -1 10 8 q 0 10 -10 10 z"
+            fill="currentColor"
+            opacity="0.85"
+          />
+          {/* gotas animadas (agua.css) */}
+          <g stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
+            <line x1="24" y1="40" x2="24" y2="46" className="agua-gota" />
+            <line x1="38" y1="40" x2="38" y2="46" className="agua-gota agua-gota--2" />
+            <line x1="52" y1="40" x2="52" y2="46" className="agua-gota agua-gota--3" />
+          </g>
+        </g>
+        {/* casa campesina: muro + techo a dos aguas */}
+        <g>
+          <rect x="18" y="86" width="44" height="26" rx="2" fill="currentColor" className="text-amber-200/70" />
+          <path d="M12 88 L40 66 L68 88 Z" fill="currentColor" className="text-rose-400/80" />
+          <rect x="34" y="96" width="12" height="16" rx="1.5" fill="currentColor" className="text-amber-900/70" />
+        </g>
+        {/* canal del alero al tanque */}
+        <path
+          d="M66 88 q 14 2 18 10"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          className="text-slate-400"
+        />
+        {/* tanque con nivel de agua */}
+        <g>
+          <rect x="80" y="96" width="22" height="18" rx="3" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-slate-300" />
+          <rect x="83" y="103" width="16" height="8" rx="1.5" fill="currentColor" className="text-cyan-400/80 agua-hilo" />
+        </g>
+      </g>
+
+      {/* ── ESTACIÓN 2 · riego: surco + mata + goteo ── */}
+      <g className={`transition-opacity duration-300 ${dim('riego')}`}>
+        {/* surcos */}
+        <g stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" className="text-amber-600/70">
+          <path d="M138 112 q 12 -6 24 0" fill="none" />
+          <path d="M168 112 q 12 -6 24 0" fill="none" />
+          <path d="M198 112 q 12 -6 24 0" fill="none" />
+        </g>
+        {/* mata de maíz estilizada en el surco del medio */}
+        <g stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" fill="none" className="text-lime-400">
+          <line x1="180" y1="108" x2="180" y2="78" />
+          <path d="M180 98 q -10 -3 -14 -12" />
+          <path d="M180 92 q 10 -3 14 -12" />
+          <path d="M180 84 q -8 -2 -11 -10" />
+        </g>
+        {/* manguera de goteo con su gota */}
+        <path d="M120 100 q 40 -14 54 -8" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeDasharray="1 6" className="text-cyan-300" />
+        <g className="text-cyan-300">
+          <line x1="174" y1="96" x2="174" y2="102" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" className="agua-gota agua-gota--2" />
+        </g>
+      </g>
+
+      {/* ── ESTACIÓN 3 · cuidar: loma, monte nativo y nacimiento ── */}
+      <g className={`transition-opacity duration-300 ${dim('cuidar')}`}>
+        {/* loma */}
+        <path
+          d="M240 112 Q 292 58 352 108"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          className="text-emerald-600/80"
+        />
+        {/* árboles nativos (copas redondas de trazo) */}
+        <g className="text-emerald-400">
+          <line x1="284" y1="84" x2="284" y2="70" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+          <circle cx="284" cy="62" r="9" fill="currentColor" opacity="0.85" />
+          <line x1="304" y1="80" x2="304" y2="68" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+          <circle cx="304" cy="61" r="7" fill="currentColor" opacity="0.7" />
+          <line x1="266" y1="92" x2="266" y2="82" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+          <circle cx="266" cy="76" r="6" fill="currentColor" opacity="0.7" />
+        </g>
+        {/* ojo de agua + hilo que baja de la loma */}
+        <g className="text-cyan-300">
+          <circle cx="288" cy="94" r="4.5" fill="currentColor" className="agua-hilo" />
+          <path
+            d="M288 98 q -4 8 2 14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            className="agua-hilo"
+          />
+        </g>
+        {/* cerca de protección (dos postes con cuerda) */}
+        <g stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="text-amber-500/80">
+          <line x1="258" y1="112" x2="258" y2="100" />
+          <line x1="318" y1="112" x2="318" y2="100" />
+          <path d="M258 103 q 30 -6 60 0" fill="none" strokeDasharray="4 4" />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/components/agua/agua.css
+++ b/src/components/agua/agua.css
@@ -1,0 +1,73 @@
+/*
+ * agua.css — micro-animaciones del módulo "Agua de la finca".
+ *
+ * Principios:
+ *   · Sutiles y de bajo costo (solo transform/opacity, nada de layout).
+ *   · prefers-reduced-motion las apaga TODAS.
+ *   · Los colores del módulo salen de las clases Tailwind del componente
+ *     (paleta slate + acentos cyan/sky/teal), que ya reaccionan a los temas
+ *     de la app vía data-theme (themes.css) — aquí no se fija ningún color
+ *     de tema, solo movimiento.
+ */
+
+/* Gotas de lluvia del "camino del agua": caen en loop, escalonadas. */
+@keyframes agua-gota-cae {
+  0% { transform: translateY(0); opacity: 0; }
+  15% { opacity: 0.9; }
+  85% { opacity: 0.9; }
+  100% { transform: translateY(26px); opacity: 0; }
+}
+
+.agua-gota {
+  animation: agua-gota-cae 1.6s linear infinite;
+}
+.agua-gota--2 { animation-delay: 0.5s; }
+.agua-gota--3 { animation-delay: 1s; }
+
+/* El hilo del nacimiento "respira" (opacity), como agua corriendo. */
+@keyframes agua-hilo-respira {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+.agua-hilo {
+  animation: agua-hilo-respira 2.8s ease-in-out infinite;
+}
+
+/* Nivel del tanque en la calculadora: sube suave cuando cambia el resultado.
+   Se anima con transform scaleY (transform-origin bottom) — sin reflow. */
+.agua-nivel {
+  transform-origin: center bottom;
+  transition: transform 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Estación activa del camino: aro que pulsa una sola vez al seleccionar. */
+@keyframes agua-estacion-pulso {
+  0% { transform: scale(0.92); opacity: 0.4; }
+  60% { transform: scale(1.06); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+.agua-estacion-activa {
+  animation: agua-estacion-pulso 0.45s ease-out;
+}
+
+/* Entrada suave del contenido del pilar al cambiar de pestaña. */
+@keyframes agua-seccion-entra {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.agua-seccion {
+  animation: agua-seccion-entra 0.3s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agua-gota,
+  .agua-hilo,
+  .agua-estacion-activa,
+  .agua-seccion {
+    animation: none;
+  }
+  .agua-gota { opacity: 0.9; }
+  .agua-nivel {
+    transition: none;
+  }
+}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic, CloudRain } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -180,6 +180,9 @@ const APRENDER_TILES = [
     { view: 'ciclo_nutrientes', label: 'Ciclo de nutrientes', icon: Recycle, desc: 'Del animal al suelo y la planta', accent: 'text-emerald-400 border-l-emerald-500' },
     { view: 'biopreparados', label: 'Biopreparados', icon: FlaskConical, desc: 'Recetas caseras paso a paso', accent: 'text-lime-400 border-l-lime-500', data: { back: 'dashboard' } },
     { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Salud del suelo y micorrizas', descF2: 'Cómo está su tierra y cómo cuidarla', accent: 'text-amber-400 border-l-amber-500' },
+    // Módulo "Agua de la finca" (cosecha de lluvia + riego con medida +
+    // cuidar el nacimiento). Ruta real: App.jsx case 'agua' / #agua.
+    { view: 'agua', label: 'Agua', labelF2: 'El agua de su finca', icon: CloudRain, desc: 'Cosechar lluvia, regar con medida y cuidar el nacimiento', descF2: 'Coseche la lluvia, riegue con medida y cuide su nacimiento', accent: 'text-cyan-400 border-l-cyan-500' },
     { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo', descF2: 'Qué es peligroso y cómo cuidarse', accent: 'text-rose-400 border-l-rose-500' },
     { view: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle, desc: 'Cómo funciona Chagra', accent: 'text-violet-400 border-l-violet-500' },
 ];

--- a/src/data/aguaFinca.js
+++ b/src/data/aguaFinca.js
@@ -1,0 +1,209 @@
+/**
+ * aguaFinca.js — CONTENIDO del módulo "Agua de la finca" (3 pilares).
+ *
+ * REGLA ANTI-ALUCINACIÓN del módulo: todo lo CUALITATIVO (prácticas, pasos,
+ * señales) vive aquí como copy; toda CIFRA DURA (mm de lluvia por zona, Kc por
+ * cultivo, ETo por piso térmico, dosis de potabilización, metros legales de
+ * ronda) es un SLOT con `valor: null` + `estado: 'grounded_pendiente'` que el
+ * pipeline de grounding (DR con fuente → catálogo/AGE) llenará. La UI pinta
+ * "dato en camino" cuando el valor es null — NUNCA muestra un número
+ * inventado.
+ *
+ * Convención del slot:
+ *   { estado: 'grounded_pendiente', valor: null, fuentePrevista: '<de dónde saldrá>' }
+ */
+
+export const ESTADO_GROUNDED_PENDIENTE = 'grounded_pendiente';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * PILAR 1 · COSECHAR LA LLUVIA
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Lluvia mensual típica por zona/municipio (mm/mes).
+ * TODO GROUNDED-PENDIENTE: llega aparte por el pipeline de clima (dato
+ * IDEAM/estación por municipio, DR en curso). Mientras tanto la calculadora
+ * usa el mm que la persona digita (por ejemplo, del pluviómetro casero o de
+ * lo que informa el módulo de clima de Chagra).
+ */
+export const LLUVIA_MENSUAL_ZONA = {
+  estado: ESTADO_GROUNDED_PENDIENTE,
+  valor: null,
+  fuentePrevista: 'IDEAM — promedios mensuales de precipitación por municipio (pipeline clima Chagra)',
+};
+
+/** Pasos del sistema techo→tanque, en orden real de construcción. Cualitativo. */
+export const PASOS_COSECHA = [
+  {
+    id: 'techo',
+    titulo: 'El techo que ya tiene',
+    detalle: 'Cualquier techo con caída sirve: casa, cocina, marranera, gallinero. Mida el piso que cubre el techo (largo × ancho): esa es el área que cosecha.',
+  },
+  {
+    id: 'canal',
+    titulo: 'Canal y bajante',
+    detalle: 'Una canaleta con buena pendiente hacia el tanque, sin hojas acumuladas. Revísela antes de las temporadas de lluvia: canal tapada es cosecha perdida.',
+  },
+  {
+    id: 'primeras-aguas',
+    titulo: 'Deje ir la primera lavada',
+    detalle: 'La primera lluvia después de días secos baja lavando el techo (polvo, hollín, excremento de aves). Desvíela o deséchela: al tanque solo debe entrar agua de techo ya lavado.',
+  },
+  {
+    id: 'tanque',
+    titulo: 'Tanque tapado y oscuro',
+    detalle: 'Tanque con tapa y sin luz por dentro: la luz cría algas y el tanque destapado cría zancudos. Con malla en la entrada del agua no entran hojas ni animales.',
+  },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * PILAR 2 · REGAR CON MEDIDA
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * ETo de referencia por piso térmico (mm/día).
+ * TODO GROUNDED-PENDIENTE: valores por piso térmico colombiano con fuente
+ * (FAO-56 + estaciones IDEAM; DR de riego). La calculadora acepta el valor
+ * digitado mientras llega el dato por zona.
+ */
+export const ETO_POR_PISO_TERMICO = [
+  { piso: 'cálido', etoMmDia: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { piso: 'templado', etoMmDia: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { piso: 'frío', etoMmDia: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { piso: 'páramo', etoMmDia: null, estado: ESTADO_GROUNDED_PENDIENTE },
+];
+
+/**
+ * Kc (coeficiente de cultivo) por especie y etapa.
+ * TODO GROUNDED-PENDIENTE: Kc reales FAO-56 / literatura citada, por cultivo
+ * y etapa fenológica, vía DR + catálogo (se conectará con el slug de especie
+ * del directorio). `kc: null` = la UI muestra "dato en camino".
+ */
+export const KC_CULTIVOS = [
+  { slug: 'maiz', nombre: 'Maíz', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'frijol', nombre: 'Fríjol', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'cafe', nombre: 'Café', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'platano', nombre: 'Plátano', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'tomate', nombre: 'Tomate', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'papa', nombre: 'Papa', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+];
+
+/**
+ * Eficiencia por sistema de riego (fracción del agua que sí llega a la raíz).
+ * TODO GROUNDED-PENDIENTE: coeficientes con fuente (FAO). Mientras tanto la
+ * comparación es solo CUALITATIVA (orden goteo > aspersión > gravedad), sin
+ * números inventados.
+ */
+export const SISTEMAS_RIEGO = [
+  {
+    id: 'goteo',
+    nombre: 'Goteo (o botella gota a gota)',
+    pierde: 'Pierde poquito',
+    coef: null,
+    estado: ESTADO_GROUNDED_PENDIENTE,
+    detalle: 'El agua cae despacio al pie de la mata. Se puede armar casero con manguera perforada o botellas. El que más rinde cuando el agua está contada.',
+  },
+  {
+    id: 'aspersion',
+    nombre: 'Aspersión (rociador)',
+    pierde: 'Pierde algo al viento y al sol',
+    coef: null,
+    estado: ESTADO_GROUNDED_PENDIENTE,
+    detalle: 'Moja también donde no hay raíz, y con sol fuerte parte se evapora antes de caer. Riegue de madrugada o al caer la tarde.',
+  },
+  {
+    id: 'gravedad',
+    nombre: 'Por surco o manguera suelta',
+    pierde: 'Pierde harto por el camino',
+    coef: null,
+    estado: ESTADO_GROUNDED_PENDIENTE,
+    detalle: 'Mucha agua se infiltra o se escurre antes de llegar a la mata. Si es lo que hay, riegue por tandas cortas y con el surco bien trazado.',
+  },
+];
+
+/** Prácticas que bajan la sed del cultivo. Cualitativas, agroecología clásica. */
+export const PRACTICAS_AHORRO = [
+  { id: 'cobertura', titulo: 'Tape el suelo', detalle: 'Hojarasca, pasto de corte o tamo sobre el suelo: la tierra tapada guarda la humedad y no se agrieta al sol.' },
+  { id: 'materia-organica', titulo: 'Suelo con materia orgánica', detalle: 'Un suelo con compost y bocashi funciona como esponja: recibe el aguacero y lo suelta despacio.' },
+  { id: 'hora', titulo: 'Riegue cuando no hay sol bravo', detalle: 'De madrugada o al atardecer el agua entra a la tierra en vez de evaporarse.' },
+  { id: 'observar', titulo: 'Riegue por la planta, no por costumbre', detalle: 'Meta el dedo a la tierra: si a un jeme de hondo está húmeda, todavía no toca. La mata avisa primero con las hojas.' },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * PILAR 3 · CUIDAR EL AGUA (calidad + nacimiento)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Dosis de potabilización casera (cloro por litro, minutos de hervor, horas
+ * de SODIS al sol).
+ * TODO GROUNDED-PENDIENTE: dosis exactas con fuente sanitaria (OMS/MinSalud)
+ * vía DR. El copy queda cualitativo y seguro mientras tanto.
+ */
+export const DOSIS_POTABILIZACION = {
+  estado: ESTADO_GROUNDED_PENDIENTE,
+  cloroGotasPorLitro: null,
+  hervorMinutos: null,
+  sodisHorasSol: null,
+  fuentePrevista: 'OMS / MinSalud — guías de tratamiento casero de agua para consumo',
+};
+
+/** Escalera de calidad: para qué sirve cada agua de la finca. Cualitativo. */
+export const USOS_DEL_AGUA = [
+  { id: 'lluvia-directa', agua: 'Lluvia recién cosechada (tanque tapado)', sirve: 'Riego, animales, lavar, aseo de la casa', ojo: 'Para tomar o cocinar, trátela primero (hierva o desinfecte).' },
+  { id: 'quebrada', agua: 'Quebrada o acequia', sirve: 'Riego', ojo: 'Aguas abajo de potreros o viviendas puede traer microbios: no la tome sin tratar.' },
+  { id: 'nacimiento', agua: 'Nacimiento protegido', sirve: 'La reserva más valiosa de la finca', ojo: 'Aun así, para consumo humano lo seguro es hervir o desinfectar.' },
+];
+
+/** Señales de alarma en el agua — cuándo NO usarla ni para riego de hortaliza. */
+export const SENALES_ALERTA_AGUA = [
+  'Cambia de color o huele a podrido después de un aguacero.',
+  'Espuma que no se deshace (jabones o agroquímicos aguas arriba).',
+  'Peces o renacuajos muertos en el cauce.',
+  'Nata aceitosa en la superficie.',
+];
+
+/**
+ * Franja legal de protección alrededor de nacimientos y cauces (metros).
+ * TODO GROUNDED-PENDIENTE: metros exactos con la norma citada y vigente
+ * (normativa forestal protectora de nacederos y rondas hídricas, DR legal).
+ * No se muestra número hasta que esté verificado.
+ */
+export const RONDA_PROTECCION = {
+  estado: ESTADO_GROUNDED_PENDIENTE,
+  metrosNacimiento: null,
+  metrosCauce: null,
+  fuentePrevista: 'Normativa colombiana de rondas hídricas y áreas forestales protectoras (verificación legal en curso)',
+};
+
+/**
+ * CASO INSIGNIA · "Se me seca el nacimiento en verano".
+ * Plan cualitativo por tiempos: qué hacer YA en verano, qué sembrar/cercar en
+ * invierno, y cómo leer el clima que viene (conecta con el módulo de clima y
+ * el ciclo ENSO que Chagra ya sigue — no se re-implementa aquí).
+ */
+export const CASO_NACIMIENTO = {
+  id: 'nacimiento-seco-verano',
+  titulo: 'Se me seca el nacimiento en verano',
+  resumen: 'Un nacimiento no se seca de un día para otro: se va quedando solo. Casi siempre es la suma de potrero hasta el borde, árboles tumbados arriba y todo el mundo sacando agua a la vez en la época seca.',
+  enVerano: [
+    { id: 'no-secar-del-todo', titulo: 'No lo ordeñe hasta el fondo', detalle: 'Si entre todos sacan hasta la última gota, el ojo de agua pierde su hilo y tarda más en volver. Racionen por horas y dejen siempre un remanente corriendo.' },
+    { id: 'lluvia-alivia', titulo: 'Use la lluvia guardada primero', detalle: 'Cada caneca de lluvia cosechada en invierno es agua que en verano NO se le saca al nacimiento. Por eso este módulo empieza por el techo.' },
+    { id: 'sombra-de-emergencia', titulo: 'No despeje más monte alrededor', detalle: 'En plena sequía ni socole ni queme cerca del ojo de agua: esa sombra es lo que le queda de humedad.' },
+  ],
+  enInvierno: [
+    { id: 'cercar', titulo: 'Cierre el paso del ganado', detalle: 'Una cerca sencilla alrededor del nacimiento evita el pisoteo que compacta el suelo y ensucia el agua. Deje un bebedero afuera para los animales.' },
+    { id: 'sembrar-nativas', titulo: 'Siembre monte nativo alrededor', detalle: 'Árboles y matorral nativo de su piso térmico alrededor del ojo de agua y aguas arriba: sus raíces son las que guardan el agua del invierno para soltarla en verano.' },
+    { id: 'zanjas', titulo: 'Ayude a que el aguacero entre a la tierra', detalle: 'Zanjas de infiltración a nivel, terrazas y suelo tapado ladera arriba: el agua que corre se pierde; la que se infiltra es la que el nacimiento le devuelve en verano.' },
+  ],
+  comunidad: [
+    { id: 'vecinos', titulo: 'El agua es de la vereda', detalle: 'Si el nacimiento abastece a varios, siéntense a acordar turnos y a cuidar juntos la parte alta. Un solo vecino cuidando no alcanza.' },
+    { id: 'clima', titulo: 'Léale el paso al clima', detalle: 'Chagra ya sigue el ciclo del Niño y la Niña en su módulo de clima: cuando viene un Niño (más seco), guarde más lluvia desde antes y raciónese temprano.' },
+  ],
+};
+
+/** Los 3 pilares del módulo — estructura de navegación. */
+export const PILARES_AGUA = [
+  { id: 'lluvia', titulo: 'Cosechar la lluvia', corto: 'Lluvia', descripcion: 'Del techo al tanque: cuánta agua le cae gratis y cómo guardarla.' },
+  { id: 'riego', titulo: 'Regar con medida', corto: 'Riego', descripcion: 'Cuánta agua necesita de verdad su cultivo y cómo no botarla.' },
+  { id: 'cuidar', titulo: 'Cuidar el agua', corto: 'Cuidar', descripcion: 'Agua sana para la casa y un nacimiento que no se seque.' },
+];

--- a/src/services/__tests__/aguaCalculos.test.js
+++ b/src/services/__tests__/aguaCalculos.test.js
@@ -1,0 +1,99 @@
+/**
+ * aguaCalculos.test.js — la lógica determinista del módulo "Agua de la finca".
+ * Solo matemática de unidades: aquí no hay datos duros que validar (esos son
+ * slots grounded-pendiente en src/data/aguaFinca.js).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  litrosLluviaCaptables,
+  canecasEquivalentes,
+  porcentajeTanque,
+  etcDiaria,
+  litrosRiegoDia,
+  diasDeReserva,
+  COEF_ESCORRENTIA_TECHO_DEFAULT,
+  LITROS_POR_CANECA_55GAL,
+} from '../aguaCalculos';
+
+describe('litrosLluviaCaptables', () => {
+  it('aplica la identidad 1 mm × 1 m² = 1 L con el coeficiente default 0.8', () => {
+    // 100 m² × 100 mm × 0.8 = 8000 L
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: 100 })).toBe(8000);
+    expect(COEF_ESCORRENTIA_TECHO_DEFAULT).toBe(0.8);
+  });
+
+  it('acepta strings numéricos (inputs de formulario)', () => {
+    expect(litrosLluviaCaptables({ areaTechoM2: '60', lluviaMm: '120' })).toBe(Math.round(60 * 120 * 0.8));
+  });
+
+  it('respeta un coeficiente explícito', () => {
+    expect(litrosLluviaCaptables({ areaTechoM2: 50, lluviaMm: 100, coefEscorrentia: 1 })).toBe(5000);
+  });
+
+  it('devuelve null con entradas inválidas', () => {
+    expect(litrosLluviaCaptables({ areaTechoM2: 0, lluviaMm: 100 })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: -5, lluviaMm: 100 })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: -1 })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: '', lluviaMm: '' })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: 100, coefEscorrentia: 1.5 })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: 100, coefEscorrentia: 0 })).toBeNull();
+  });
+
+  it('con lluvia 0 devuelve 0 litros (mes seco válido)', () => {
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: 0 })).toBe(0);
+  });
+});
+
+describe('canecasEquivalentes', () => {
+  it('convierte litros a canecas de 55 galones (208 L)', () => {
+    expect(LITROS_POR_CANECA_55GAL).toBe(208);
+    expect(canecasEquivalentes(208)).toBe(1);
+    expect(canecasEquivalentes(8000)).toBe(38.5);
+  });
+  it('devuelve null con entrada inválida', () => {
+    expect(canecasEquivalentes(-1)).toBeNull();
+    expect(canecasEquivalentes('x')).toBeNull();
+  });
+});
+
+describe('porcentajeTanque', () => {
+  it('calcula el porcentaje con tope 100', () => {
+    expect(porcentajeTanque({ litros: 500, capacidadL: 1000 })).toBe(50);
+    expect(porcentajeTanque({ litros: 2500, capacidadL: 1000 })).toBe(100);
+  });
+  it('devuelve null si el tanque no tiene capacidad válida', () => {
+    expect(porcentajeTanque({ litros: 500, capacidadL: 0 })).toBeNull();
+    expect(porcentajeTanque({ litros: 500, capacidadL: '' })).toBeNull();
+  });
+});
+
+describe('etcDiaria (ETc = ETo × Kc, FAO)', () => {
+  it('multiplica ETo por Kc con 2 decimales', () => {
+    expect(etcDiaria({ etoMmDia: 4, kc: 1.15 })).toBe(4.6);
+    expect(etcDiaria({ etoMmDia: '3.5', kc: '0.8' })).toBe(2.8);
+  });
+  it('rechaza Kc fuera de rango físico (0–2]', () => {
+    expect(etcDiaria({ etoMmDia: 4, kc: 0 })).toBeNull();
+    expect(etcDiaria({ etoMmDia: 4, kc: 2.5 })).toBeNull();
+    expect(etcDiaria({ etoMmDia: 0, kc: 1 })).toBeNull();
+  });
+});
+
+describe('litrosRiegoDia', () => {
+  it('convierte mm/día × m² a litros/día (1 mm = 1 L/m²)', () => {
+    expect(litrosRiegoDia({ etcMmDia: 4.6, areaM2: 100 })).toBe(460);
+  });
+  it('devuelve null con área o ETc inválidos', () => {
+    expect(litrosRiegoDia({ etcMmDia: 0, areaM2: 100 })).toBeNull();
+    expect(litrosRiegoDia({ etcMmDia: 4, areaM2: '' })).toBeNull();
+  });
+});
+
+describe('diasDeReserva', () => {
+  it('divide reserva entre consumo, al piso', () => {
+    expect(diasDeReserva({ litrosGuardados: 1000, consumoLitrosDia: 300 })).toBe(3);
+  });
+  it('devuelve null sin consumo válido', () => {
+    expect(diasDeReserva({ litrosGuardados: 1000, consumoLitrosDia: 0 })).toBeNull();
+  });
+});

--- a/src/services/aguaCalculos.js
+++ b/src/services/aguaCalculos.js
@@ -1,0 +1,138 @@
+/**
+ * aguaCalculos.js — lógica DETERMINISTA del módulo "Agua de la finca".
+ *
+ * Solo matemática de unidades y fórmulas clásicas de manejo de agua. AQUÍ NO
+ * VIVEN DATOS DUROS (lluvia por zona, Kc por cultivo, ETo por piso térmico):
+ * esos son slots grounded-pendiente en src/data/aguaFinca.js y llegan por el
+ * pipeline de grounding (DR → catálogo/AGE), nunca inventados en código.
+ *
+ * Identidad de unidades que sostiene todo el módulo:
+ *   1 mm de lluvia sobre 1 m² = 1 litro. (No es un dato: es la definición
+ *   del milímetro de precipitación.)
+ */
+
+/**
+ * Coeficiente de escorrentía del techo: fracción de la lluvia que de verdad
+ * llega al tanque (el resto se pierde en salpique, evaporación y primeras
+ * lavadas del techo). 0.8 es un valor CONSERVADOR de diseño, usado como
+ * default editable por la persona.
+ *
+ * TODO GROUNDED-PENDIENTE: coeficiente por material de techo (zinc/teja de
+ * barro/fibrocemento/paja) con fuente técnica citada (DR cosecha de agua
+ * lluvia). Cuando llegue, este default pasa a ser el fallback.
+ */
+export const COEF_ESCORRENTIA_TECHO_DEFAULT = 0.8;
+
+/** Una caneca azul estándar de 55 galones (EE. UU.) ≈ 208 litros. Conversión de unidades, no dato de campo. */
+export const LITROS_POR_CANECA_55GAL = 208;
+
+/**
+ * Parseo estricto para inputs de formulario: '' / null / undefined → NaN
+ * (Number('') sería 0 y un campo vacío se volvería "0 mm de lluvia" — falso).
+ * @param {number|string|null|undefined} v
+ * @returns {number}
+ */
+function num(v) {
+  if (v == null || (typeof v === 'string' && v.trim() === '')) return NaN;
+  return Number(v);
+}
+
+/**
+ * Litros de lluvia captables en un periodo.
+ * litros = área de techo (m²) × lluvia (mm) × coeficiente de escorrentía.
+ *
+ * @param {Object} p
+ * @param {number|string} p.areaTechoM2 - área de techo que drena a canal (m²)
+ * @param {number|string} p.lluviaMm - lámina de lluvia del periodo (mm)
+ * @param {number|string} [p.coefEscorrentia] - fracción 0–1 que llega al tanque
+ * @returns {number|null} litros (redondeados), o null si la entrada no sirve
+ */
+export function litrosLluviaCaptables({ areaTechoM2, lluviaMm, coefEscorrentia = COEF_ESCORRENTIA_TECHO_DEFAULT }) {
+  const area = num(areaTechoM2);
+  const mm = num(lluviaMm);
+  const coef = num(coefEscorrentia);
+  if (!Number.isFinite(area) || area <= 0) return null;
+  if (!Number.isFinite(mm) || mm < 0) return null;
+  if (!Number.isFinite(coef) || coef <= 0 || coef > 1) return null;
+  return Math.round(area * mm * coef);
+}
+
+/**
+ * Cuántas canecas de 55 galones equivalen a unos litros. Para que el número
+ * grande se pueda "ver" en objetos de finca.
+ * @param {number} litros
+ * @returns {number|null} canecas (1 decimal)
+ */
+export function canecasEquivalentes(litros) {
+  const l = num(litros);
+  if (!Number.isFinite(l) || l < 0) return null;
+  return Math.round((l / LITROS_POR_CANECA_55GAL) * 10) / 10;
+}
+
+/**
+ * Porcentaje de llenado de un tanque (tope 100).
+ * @param {Object} p
+ * @param {number|string} p.litros - litros captados
+ * @param {number|string} p.capacidadL - capacidad del tanque en litros
+ * @returns {number|null} 0–100
+ */
+export function porcentajeTanque({ litros, capacidadL }) {
+  const l = num(litros);
+  const cap = num(capacidadL);
+  if (!Number.isFinite(l) || l < 0) return null;
+  if (!Number.isFinite(cap) || cap <= 0) return null;
+  return Math.min(100, Math.round((l / cap) * 100));
+}
+
+/**
+ * ETc (consumo diario del cultivo) = ETo × Kc. Fórmula FAO clásica; los
+ * VALORES de ETo (por piso térmico) y Kc (por cultivo y etapa) son slots
+ * grounded-pendiente en src/data/aguaFinca.js — aquí solo se multiplica lo
+ * que la persona (o el catálogo, cuando llegue) ponga.
+ *
+ * @param {Object} p
+ * @param {number|string} p.etoMmDia - evapotranspiración de referencia (mm/día)
+ * @param {number|string} p.kc - coeficiente del cultivo (típico 0.2–1.3)
+ * @returns {number|null} ETc en mm/día (2 decimales)
+ */
+export function etcDiaria({ etoMmDia, kc }) {
+  const eto = num(etoMmDia);
+  const k = num(kc);
+  if (!Number.isFinite(eto) || eto <= 0) return null;
+  if (!Number.isFinite(k) || k <= 0 || k > 2) return null;
+  return Math.round(eto * k * 100) / 100;
+}
+
+/**
+ * Litros de riego por día para un área: ETc (mm/día) × área (m²).
+ * (1 mm = 1 L/m², identidad de unidades.) Es la necesidad NETA de la planta;
+ * el sistema de riego pierde una parte según su eficiencia (ese coeficiente
+ * es slot grounded-pendiente, no se aplica aquí).
+ *
+ * @param {Object} p
+ * @param {number|string} p.etcMmDia - consumo del cultivo (mm/día)
+ * @param {number|string} p.areaM2 - área sembrada (m²)
+ * @returns {number|null} litros por día (redondeados)
+ */
+export function litrosRiegoDia({ etcMmDia, areaM2 }) {
+  const etc = num(etcMmDia);
+  const area = num(areaM2);
+  if (!Number.isFinite(etc) || etc <= 0) return null;
+  if (!Number.isFinite(area) || area <= 0) return null;
+  return Math.round(etc * area);
+}
+
+/**
+ * Cuántos días alcanza el agua guardada para un consumo diario dado.
+ * @param {Object} p
+ * @param {number|string} p.litrosGuardados
+ * @param {number|string} p.consumoLitrosDia
+ * @returns {number|null} días enteros (piso)
+ */
+export function diasDeReserva({ litrosGuardados, consumoLitrosDia }) {
+  const l = num(litrosGuardados);
+  const c = num(consumoLitrosDia);
+  if (!Number.isFinite(l) || l < 0) return null;
+  if (!Number.isFinite(c) || c <= 0) return null;
+  return Math.floor(l / c);
+}


### PR DESCRIPTION
Mini-app "Agua de la finca" con chip en el home (bloque Consultar y
aprender, ambos layouts) y ruta #agua / #manejo-agua.

Tres pilares con la ilustracion insignia "el camino del agua" (SVG
propio, lluvia animada, reduced-motion respetado):

1. Cosechar la lluvia — calculadora determinista techo (m2) x lluvia
   (mm) x 0.8 -> litros/mes, canecas equivalentes y nivel de tanque
   animado. Dato de lluvia por municipio = slot grounded-pendiente
   (IDEAM, pipeline clima).
2. Regar con medida — ETc = ETo x Kc (FAO) con litros/dia por area;
   Kc por cultivo, ETo por piso termico y eficiencias de riego = slots
   grounded-pendiente (sin cifras inventadas), comparacion cualitativa
   de sistemas + practicas de ahorro.
3. Cuidar el agua — escalera de usos, potabilidad (dosis = slot
   grounded-pendiente OMS/MinSalud), senales de alarma, ronda legal
   (metros = slot pendiente de verificacion) y el caso insignia
   "se me seca el nacimiento en verano" conectado al ciclo ENSO que
   Chagra ya sigue (ensoService, sin re-implementar clima).

Logica determinista pura en src/services/aguaCalculos.js (23 tests);
slots y copy en src/data/aguaFinca.js; UI en src/components/agua/.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
