### PR TITLE
feat(estiercol): módulo de aprovechamiento de estiércol (biodigestor, olores, abonos)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -90,6 +90,7 @@ const AnimalesScreen = lazy(() => import('./components/AnimalesScreen'));
 const GallinasScreen = lazy(() => import('./components/GallinasScreen'));
 const AbejasScreen = lazy(() => import('./components/AbejasScreen'));
 const VacasScreen = lazy(() => import('./components/VacasScreen'));
+const EstiercolScreen = lazy(() => import('./components/EstiercolScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
@@ -187,6 +188,10 @@ const HASH_VIEW_ROUTES = {
   'animales-gallinas': 'animales_gallinas',
   'animales-abejas': 'animales_abejas',
   'animales-vacas': 'animales_vacas',
+  estiercol: 'estiercol',
+  'del-corral-al-abono': 'estiercol',
+  abono: 'estiercol',
+  biodigestor: 'estiercol',
   'doom-finca': 'doom_finca',
   subsuelo: 'subsuelo',
   'mundo-subsuelo': 'subsuelo',
@@ -206,7 +211,7 @@ const HASH_VIEW_ROUTES = {
 const MODULE_VIEWS = new Set([
   'activos', 'mapa', 'javier', 'bodega', 'task_log', 'historial', 'bitacora',
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
-  'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
+  'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'estiercol',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
@@ -1110,6 +1115,20 @@ export default function App() {
               {/* onNavigate: VacasScreen enlaza al proceso de seguimiento de
                   silvopastoreo existente ('seguimiento_silvopastoreo'). */}
               <VacasScreen onBack={() => navigate('animales')} onHome={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'estiercol':
+        // Módulo "Del corral al abono": aprovechamiento del estiércol
+        // (olores/gallinaza, biodigestor con calculadora de dimensionamiento y
+        // abonos: gallinaza/porquinaza/bovinaza/biol/biosol/compost/
+        // lombricompost). Calculadora determinista (biodigestorCalculator.js);
+        // dosis/rendimientos exactos quedan en slots grounded-pendiente hasta la
+        // investigación (nacional + internacional). Ruta #estiercol / #biodigestor.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Del corral al abono">
+              <EstiercolScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/__tests__/App.estiercol-route.test.jsx
+++ b/src/__tests__/App.estiercol-route.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Test de RUTA: verifica que App rutea 'estiercol' → EstiercolScreen ("Del
+// corral al abono"). El tile del home (DashboardLive APRENDER_TILES) llama
+// onNavigate('estiercol') y #estiercol / #biodigestor también lo disparan; sin
+// el case en el switch de App esa navegación caería en "Vista no disponible"
+// (feature huérfana). Acá montamos App con #estiercol + sesión autenticada y
+// comprobamos que la pantalla monta.
+//
+// Los efectos pesados de boot se mockean para que App arranque limpio en jsdom.
+
+vi.mock('../services/authService', () => ({
+  isAuthenticated: () => Promise.resolve(true),
+  logoutUser: () => Promise.resolve(),
+}));
+vi.mock('../db/catalogDB', () => ({ initCatalog: () => Promise.resolve() }));
+vi.mock('../services/ragRetriever', () => ({
+  prewarmCorpus: () => {},
+  retrieve: () => Promise.resolve([]),
+}));
+vi.mock('../services/alertEngine', () => ({ alertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/cropAlertEngine', () => ({ cropAlertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/apiService', () => ({
+  fetchFromFarmOS: () => Promise.resolve(null),
+  fetchWithAuthRetry: () => Promise.resolve({ ok: true }),
+}));
+
+// La pantalla destino: stub liviano que delata que se montó. Probamos el WIRING
+// de la ruta, no el render interno del módulo (cubierto en su propio test).
+vi.mock('../components/EstiercolScreen', () => ({
+  default: () => <div data-testid="estiercol-screen">del corral al abono stub</div>,
+}));
+
+vi.mock('../db/farmProcessCache', () => ({ listFarmProcesses: () => Promise.resolve([]) }));
+
+import App from '../App';
+
+describe('App — ruta "estiercol"', () => {
+  beforeEach(() => {
+    window.location.hash = '#estiercol';
+    localStorage.clear();
+  });
+  afterEach(() => {
+    window.location.hash = '';
+    vi.clearAllMocks();
+  });
+
+  it('con sesión autenticada y #estiercol monta EstiercolScreen (no "Vista no disponible")', async () => {
+    render(<App />);
+    await waitFor(
+      () => expect(screen.getByTestId('estiercol-screen')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+    expect(screen.queryByText('Vista no disponible')).toBeNull();
+  });
+});

--- a/src/components/EstiercolScreen.jsx
+++ b/src/components/EstiercolScreen.jsx
@@ -1,0 +1,532 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Recycle, Wind, Flame, Sprout, Droplets, Layers, Calculator, Info,
+  ChevronRight, AlertTriangle, CheckCircle2, Container, ShieldCheck,
+  ArrowRight, Sun, Minus, Plus, FlaskConical,
+} from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+import {
+  BiodigestorIlustracion, CicloCorralAbono, AbonoGlifo,
+} from './estiercol/EstiercolIlustraciones';
+import { estimarBiodigestor, ANIMALES_BIODIGESTOR } from '../services/biodigestorCalculator';
+import './estiercol/estiercol.css';
+
+/**
+ * EstiercolScreen — "Del corral al abono".
+ *
+ * Mini-app de aprovechamiento del estiércol para el campesino colombiano.
+ * Lenguaje "cuaderno de campo / Ciclo Vivo": nada sobra en la finca; el
+ * estiércol se vuelve abono, gas y suelo vivo. Tres pilares:
+ *
+ *   1. Olores      — resuelve el caso real "la gallinaza huele y los vecinos
+ *                    se quejan": causas + soluciones (secar, cubrir, airear,
+ *                    biofiltro, compostar).
+ *   2. Biodigestor — bases + beneficios + calculadora de dimensionamiento
+ *                    (caso insignia: 300 cerdos). Fórmula determinista en
+ *                    services/biodigestorCalculator.js.
+ *   3. Abonos      — gallinaza, porquinaza, bovinaza, biol, biosol, compost,
+ *                    lombricompost: cómo se hacen + dónde va la dosis.
+ *
+ * ⚠️  GROUNDING: NINGUNA cifra dura de dosis/rendimiento está inventada como
+ * dato citado. Las dosis exactas y los rendimientos van en slots marcados
+ * <GroundedSlot> ("pendiente de la investigación"); la calculadora usa
+ * coeficientes de referencia rotulados "estimado" (ver biodigestorCalculator.js,
+ * tag GROUNDED-PENDIENTE). Las 2 investigaciones (nacional + internacional)
+ * reemplazan esos slots después.
+ */
+
+const PILARES = [
+  { id: 'inicio', label: 'Inicio', Icon: Recycle },
+  { id: 'olores', label: 'Olores', Icon: Wind },
+  { id: 'biodigestor', label: 'Biodigestor', Icon: Flame },
+  { id: 'abonos', label: 'Abonos', Icon: Sprout },
+];
+
+/* ── Piezas de UI reutilizables ─────────────────────────────────────────── */
+
+/** Card de sección con encabezado a color (patrón de las pantallas de Chagra). */
+function SeccionCard({ Icon, tono, titulo, children, className = '' }) {
+  return (
+    <section className={`rounded-2xl border ${tono.border} ${tono.bg} p-4 ${className}`}>
+      {titulo && (
+        <h2 className={`flex items-center gap-2 text-base font-black ${tono.text}`}>
+          {Icon && <Icon size={18} aria-hidden="true" />}
+          {titulo}
+        </h2>
+      )}
+      <div className="mt-2 text-sm text-slate-200/90 leading-relaxed space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+/** Paso numerado (tipo receta del cuaderno). */
+function Paso({ n, titulo, children, tono }) {
+  return (
+    <div className="flex gap-3">
+      <span className={`shrink-0 w-7 h-7 rounded-full grid place-items-center text-sm font-black ${tono.chip}`}>
+        {n}
+      </span>
+      <div className="min-w-0">
+        <p className="font-bold text-slate-100 leading-tight">{titulo}</p>
+        {children && <p className="text-sm text-slate-300/90 leading-snug mt-0.5">{children}</p>}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Slot de dato GROUNDED-PENDIENTE. Marca en la UI —con honestidad— dónde va una
+ * cifra citada (dosis exacta, rendimiento) que aún NO está groundeada. NO se
+ * inventa un número: se anuncia el hueco. La investigación lo llena luego.
+ */
+function GroundedSlot({ children = 'Dosis exacta y frecuencia' }) {
+  return (
+    <p
+      data-testid="grounded-slot"
+      className="mt-2 flex items-start gap-2 rounded-lg border border-dashed border-amber-500/50 bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-200/90"
+    >
+      <Info size={14} className="mt-0.5 shrink-0 text-amber-300" aria-hidden="true" />
+      <span>
+        <span className="font-bold">{children}:</span>{' '}
+        pendiente de la investigación agronómica. No damos un número al azar.
+      </span>
+    </p>
+  );
+}
+
+/* ── PILAR 1 · OLORES ───────────────────────────────────────────────────── */
+
+const OLOR_CAUSAS = [
+  { Icon: Droplets, t: 'Está fresca y húmeda', d: 'El nitrógeno se escapa como amoníaco: ese olor picante que se siente de lejos.' },
+  { Icon: Wind, t: 'Amontonada sin aire', d: 'Sin oxígeno se pudre (fermentación anaerobia) y suelta gases de mal olor.' },
+  { Icon: Layers, t: 'Sin material seco encima', d: 'Nada absorbe la humedad ni tapa el olor; la pila queda destapada.' },
+  { Icon: Sun, t: 'Mojada por lluvia o lavados', d: 'El agua la escurre y la hace fermentar mal; los lixiviados apestan.' },
+];
+
+const OLOR_SOLUCIONES = [
+  { t: 'Secar', d: 'Tiéndala en capa delgada bajo techo. La gallinaza seca casi no huele y pesa menos para mover.' },
+  { t: 'Cubrir con material seco', d: 'Cascarilla de arroz, aserrín, hoja seca o tamo encima. Tapa el olor y equilibra la mezcla (carbono).' },
+  { t: 'Airear y voltear', d: 'Déle vuelta cada pocos días. Con oxígeno la pila trabaja sin pudrirse ni apestar.' },
+  { t: 'Compostar bien', d: 'Mezcle 2 a 3 partes de material seco por 1 de estiércol. Un compost bien hecho huele a tierra de monte, no a amoníaco.' },
+  { t: 'Biofiltro en el galpón', d: 'Una cama de viruta, carbón y compost por donde pase el aire del corral atrapa el olor antes de que llegue al vecino.' },
+];
+
+function PilarOlores() {
+  const tono = { border: 'border-teal-600/40', bg: 'bg-teal-900/20', text: 'text-teal-200', chip: 'bg-teal-500/20 text-teal-100 border border-teal-400/40' };
+  return (
+    <div className="space-y-4 estiercol-enter">
+      {/* El caso real, en voz del campo */}
+      <div className="rounded-2xl border border-rose-600/40 bg-rose-900/20 p-4">
+        <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-rose-300">
+          <AlertTriangle size={14} aria-hidden="true" /> El caso
+        </p>
+        <p className="mt-1 text-lg font-black text-slate-100 leading-snug">
+          «La gallinaza huele muy feo y los vecinos se quejan.»
+        </p>
+        <p className="mt-1 text-sm text-slate-300/90">
+          Pasa en toda finca con animales. El olor no es mala suerte: es estiércol
+          fresco perdiendo nitrógeno al aire. Se arregla, y de paso usted gana abono.
+        </p>
+      </div>
+
+      <SeccionCard Icon={Info} tono={{ border: 'border-amber-600/40', bg: 'bg-amber-900/20', text: 'text-amber-200' }} titulo="Por qué huele">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
+          {OLOR_CAUSAS.map((c) => (
+            <div key={c.t} className="rounded-xl bg-black/20 border border-slate-700/50 p-3">
+              <p className="flex items-center gap-2 font-bold text-slate-100">
+                <c.Icon size={16} className="text-amber-300 shrink-0" aria-hidden="true" />
+                {c.t}
+              </p>
+              <p className="text-xs text-slate-300/90 mt-1 leading-snug">{c.d}</p>
+            </div>
+          ))}
+        </div>
+      </SeccionCard>
+
+      {/* De esto → a esto (antes/después) */}
+      <div className="rounded-2xl border border-slate-700/50 bg-slate-900/30 p-3.5 flex items-center gap-3">
+        <div className="flex-1 text-center">
+          <p className="text-2xl" aria-hidden="true">💩</p>
+          <p className="text-xs font-bold text-rose-300 mt-1">Pila húmeda y tapada</p>
+          <p className="text-2xs text-slate-400">huele a amoníaco</p>
+        </div>
+        <ArrowRight size={22} className="text-emerald-400 shrink-0" aria-hidden="true" />
+        <div className="flex-1 text-center">
+          <p className="text-2xl" aria-hidden="true">🌱</p>
+          <p className="text-xs font-bold text-emerald-300 mt-1">Compost aireado</p>
+          <p className="text-2xs text-slate-400">huele a tierra</p>
+        </div>
+      </div>
+
+      <SeccionCard Icon={CheckCircle2} tono={tono} titulo="Cómo quitarle el olor">
+        <div className="space-y-3 mt-1">
+          {OLOR_SOLUCIONES.map((s, i) => (
+            <Paso key={s.t} n={i + 1} titulo={s.t} tono={tono}>{s.d}</Paso>
+          ))}
+        </div>
+        <div className="mt-3 rounded-lg bg-emerald-500/10 border border-emerald-500/30 px-3 py-2 text-xs text-emerald-100/90">
+          <span className="font-bold">Regla de oro:</span> seco y con aire no huele; mojado y tapado apesta.
+        </div>
+      </SeccionCard>
+    </div>
+  );
+}
+
+/* ── PILAR 2 · BIODIGESTOR ──────────────────────────────────────────────── */
+
+const BIODIGESTOR_BENEFICIOS = [
+  { Icon: Flame, t: 'Gas para cocinar', d: 'Menos leña y menos humo en la cocina.', tono: 'text-amber-300' },
+  { Icon: Droplets, t: 'Biol fertilizante', d: 'Abono líquido listo para las matas.', tono: 'text-lime-300' },
+  { Icon: Wind, t: 'Menos olor y moscas', d: 'El estiércol va cerrado, no en pila abierta.', tono: 'text-teal-300' },
+  { Icon: ShieldCheck, t: 'Saneamiento', d: 'Cuida el agua, la salud y el corral.', tono: 'text-sky-300' },
+];
+
+function PilarBiodigestor() {
+  const [tipoAnimal, setTipoAnimal] = useState('cerdo');
+  const [numAnimales, setNumAnimales] = useState(300); // caso insignia
+
+  const est = useMemo(
+    () => estimarBiodigestor({ tipoAnimal, numAnimales }),
+    [tipoAnimal, numAnimales],
+  );
+  // Mapa biogás → llenado visual de la cúpula (0.12..1).
+  const llenado = Math.min(1, 0.12 + est.biogasM3Dia / 100);
+
+  const setNum = (v) => setNumAnimales(Math.max(0, Math.min(100000, Math.floor(v) || 0)));
+
+  const tono = { border: 'border-amber-600/40', bg: 'bg-amber-900/20', text: 'text-amber-200', chip: 'bg-amber-500/20 text-amber-100 border border-amber-400/40' };
+
+  return (
+    <div className="space-y-4 estiercol-enter">
+      <SeccionCard Icon={Info} tono={{ border: 'border-slate-700/50', bg: 'bg-slate-900/30', text: 'text-slate-100' }} titulo="Qué es un biodigestor">
+        <p>
+          Una bolsa o tanque cerrado donde el estiércol se descompone <b>sin aire</b>.
+          De ahí salen dos cosas: <b className="text-amber-200">biogás</b> para cocinar
+          y <b className="text-lime-200">biol</b>, un abono líquido. El mismo estiércol
+          que le daba problemas le da energía y fertilizante.
+        </p>
+      </SeccionCard>
+
+      {/* Ilustración del tubular en corte */}
+      <div className="rounded-2xl border border-amber-700/40 bg-gradient-to-b from-amber-900/10 to-transparent p-3">
+        <BiodigestorIlustracion llenado={llenado} />
+        <p className="text-center text-xs text-slate-400 mt-1">
+          Biodigestor tubular en corte: entra la mezcla, se llena de biogás arriba y sale el biol.
+        </p>
+      </div>
+
+      <SeccionCard Icon={CheckCircle2} tono={tono} titulo="Para qué sirve">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
+          {BIODIGESTOR_BENEFICIOS.map((b) => (
+            <div key={b.t} className="rounded-xl bg-black/20 border border-slate-700/50 p-3">
+              <p className="flex items-center gap-2 font-bold text-slate-100">
+                <b.Icon size={16} className={`${b.tono} shrink-0`} aria-hidden="true" />
+                {b.t}
+              </p>
+              <p className="text-xs text-slate-300/90 mt-1 leading-snug">{b.d}</p>
+            </div>
+          ))}
+        </div>
+      </SeccionCard>
+
+      {/* Calculadora de dimensionamiento */}
+      <SeccionCard Icon={Calculator} tono={{ border: 'border-lime-600/40', bg: 'bg-lime-900/20', text: 'text-lime-200' }} titulo="Calculadora: ¿de qué tamaño?">
+        <p className="text-sm text-slate-300/90">
+          Ponga su hato y vea el tamaño del digestor y cuánto biogás y biol daría.
+        </p>
+
+        {/* Tipo de animal */}
+        <div className="mt-3">
+          <p className="text-xs font-bold text-slate-300 mb-1.5">Animal</p>
+          <div className="grid grid-cols-3 gap-2" role="group" aria-label="Tipo de animal">
+            {Object.values(ANIMALES_BIODIGESTOR).map((a) => {
+              const activo = a.id === tipoAnimal;
+              return (
+                <button
+                  key={a.id}
+                  type="button"
+                  onClick={() => setTipoAnimal(a.id)}
+                  aria-pressed={activo}
+                  className={`estiercol-pilar-btn rounded-xl border px-2 py-2.5 text-center ${activo
+                    ? 'border-lime-400/70 bg-lime-500/20 text-lime-100'
+                    : 'border-slate-700/60 bg-black/20 text-slate-300'}`}
+                >
+                  <span className="text-xl block" aria-hidden="true">{a.emoji}</span>
+                  <span className="text-xs font-bold block mt-0.5">{a.nombre}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Número de animales */}
+        <div className="mt-3">
+          <label htmlFor="num-animales" className="text-xs font-bold text-slate-300 mb-1.5 block">
+            ¿Cuántos {ANIMALES_BIODIGESTOR[tipoAnimal].nombre.toLowerCase()}?
+          </label>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setNum(numAnimales - 10)}
+              aria-label="Quitar 10"
+              className="estiercol-pilar-btn shrink-0 w-11 h-11 rounded-xl border border-slate-700/60 bg-black/20 text-slate-200 grid place-items-center"
+            >
+              <Minus size={18} aria-hidden="true" />
+            </button>
+            <input
+              id="num-animales"
+              type="number"
+              inputMode="numeric"
+              min="0"
+              value={numAnimales}
+              onChange={(e) => setNum(Number(e.target.value))}
+              className="flex-1 min-w-0 text-center text-2xl font-black bg-black/25 border border-slate-700/60 rounded-xl py-2 text-lime-100 focus:outline-none focus:border-lime-400/70"
+            />
+            <button
+              type="button"
+              onClick={() => setNum(numAnimales + 10)}
+              aria-label="Sumar 10"
+              className="estiercol-pilar-btn shrink-0 w-11 h-11 rounded-xl border border-slate-700/60 bg-black/20 text-slate-200 grid place-items-center"
+            >
+              <Plus size={18} aria-hidden="true" />
+            </button>
+          </div>
+          {/* Atajos, con el caso insignia bien a la vista */}
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {[10, 50, 100, 300].map((p) => (
+              <button
+                key={p}
+                type="button"
+                onClick={() => setNum(p)}
+                className={`estiercol-pilar-btn text-xs font-bold rounded-full px-3 py-1 border ${numAnimales === p
+                  ? 'border-lime-400/70 bg-lime-500/20 text-lime-100'
+                  : 'border-slate-700/60 bg-black/20 text-slate-300'}`}
+              >
+                {p}{p === 300 ? ' 🐖' : ''}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Resultados */}
+        <div className="grid grid-cols-2 gap-2.5 mt-4" data-testid="biodigestor-resultados">
+          <ResultCard Icon={Container} valor={est.volumenDigestorM3} unidad="m³" etiqueta="Tamaño del digestor" tono="text-sky-200" />
+          <ResultCard Icon={Flame} valor={est.biogasM3Dia} unidad="m³/día" etiqueta="Biogás" tono="text-amber-200" />
+          <ResultCard Icon={Droplets} valor={est.biolLitrosDia} unidad="L/día" etiqueta="Biol (abono líquido)" tono="text-lime-200" />
+          <ResultCard Icon={Flame} valor={est.horasFogonDia} unidad="h/día" etiqueta="Fogón encendido" tono="text-orange-200" />
+        </div>
+
+        <div className="mt-3 rounded-lg border border-dashed border-slate-500/50 bg-slate-500/10 px-3 py-2 text-xs text-slate-300/90">
+          <span className="font-bold text-slate-200">Cifras estimadas.</span>{' '}
+          Son un orden de magnitud con relaciones estándar. Los rendimientos
+          exactos por región, raza y dieta se afinan con la investigación
+          (nacional + internacional) que está en curso.
+        </div>
+      </SeccionCard>
+    </div>
+  );
+}
+
+function ResultCard({ Icon, valor, unidad, etiqueta, tono }) {
+  const texto = Number.isFinite(valor)
+    ? valor.toLocaleString('es-CO', { maximumFractionDigits: 1 })
+    : '—';
+  return (
+    <div className="rounded-xl bg-black/25 border border-slate-700/50 p-3">
+      {Icon && <Icon size={18} className={`${tono} mb-1`} aria-hidden="true" />}
+      <p className="leading-none">
+        <span className={`text-2xl font-black ${tono}`}>{texto}</span>{' '}
+        <span className="text-xs text-slate-400 font-bold">{unidad}</span>
+      </p>
+      <p className="text-2xs text-slate-400 mt-1 leading-tight">{etiqueta}</p>
+    </div>
+  );
+}
+
+/* ── PILAR 3 · ABONOS ───────────────────────────────────────────────────── */
+
+const ABONOS = [
+  {
+    tipo: 'gallinaza', nombre: 'Gallinaza', de: 'De las gallinas',
+    que: 'Estiércol de gallina con la cama (cascarilla, viruta). Muy rica en nitrógeno; fresca quema las matas.',
+    pasos: ['Recójala seca de la cama profunda.', 'Madúrela o compóstela 4–8 semanas antes de usar.', 'Aplíquela al suelo, nunca sobre la hoja.'],
+    tono: { border: 'border-amber-600/40', bg: 'bg-amber-900/20', text: 'text-amber-200' },
+  },
+  {
+    tipo: 'porquinaza', nombre: 'Porquinaza', de: 'De los cerdos',
+    que: 'Estiércol de cerdo, casi siempre líquido. Muy fuerte: va al biodigestor o bien compostado.',
+    pasos: ['Sepárela del agua de lavado.', 'Llévela al biodigestor o a una pila con material seco.', 'Use el biol/compost resultante, no la porquinaza cruda.'],
+    tono: { border: 'border-pink-600/40', bg: 'bg-pink-900/20', text: 'text-pink-200' },
+  },
+  {
+    tipo: 'bovinaza', nombre: 'Bovinaza (boñiga)', de: 'De las vacas',
+    que: 'La boñiga clásica del biol. Equilibrada y noble; base de muchos preparados.',
+    pasos: ['Recójala del establo o el potrero.', 'Madúrela o llévela al biol/compost.', 'Aplíquela madura al pie de la planta.'],
+    tono: { border: 'border-orange-600/40', bg: 'bg-orange-900/20', text: 'text-orange-200' },
+  },
+  {
+    tipo: 'biol', nombre: 'Biol', de: 'Líquido — foliar o al pie',
+    que: 'El líquido que sale del biodigestor o de un tanque tapado. Fertilizante y bioestimulante.',
+    pasos: ['Deje fermentar el estiércol con agua, tapado y sin aire.', 'Cuele el líquido.', 'Diluya en agua y aplique foliar o al pie.'],
+    tono: { border: 'border-lime-600/40', bg: 'bg-lime-900/20', text: 'text-lime-200' },
+  },
+  {
+    tipo: 'biosol', nombre: 'Biosol', de: 'Sólido del biodigestor',
+    que: 'La parte sólida que queda tras sacar el biol. Abono estable para el suelo.',
+    pasos: ['Retire el sólido del fondo/salida del digestor.', 'Séquelo a la sombra.', 'Incorpórelo al suelo como abono de fondo.'],
+    tono: { border: 'border-yellow-600/40', bg: 'bg-yellow-900/20', text: 'text-yellow-200' },
+  },
+  {
+    tipo: 'compost', nombre: 'Compost', de: 'Pila aireada',
+    que: 'Estiércol + material seco, volteado con aire hasta que huele a tierra. El abono más versátil.',
+    pasos: ['Mezcle estiércol con material seco (2–3 : 1).', 'Voltee cada pocos días y mantenga húmedo como esponja escurrida.', 'Listo cuando huele a tierra y no se reconoce el material.'],
+    tono: { border: 'border-emerald-600/40', bg: 'bg-emerald-900/20', text: 'text-emerald-200' },
+  },
+  {
+    tipo: 'lombricompost', nombre: 'Lombricompost', de: 'Con lombriz roja',
+    que: 'Estiércol digerido por lombriz roja californiana. El humus más fino y de mejor calidad.',
+    pasos: ['Prepare camas con estiércol ya pre-compostado (frío).', 'Siembre la lombriz y manténgala húmeda y a la sombra.', 'Cose­che el humus del lecho cada pocos meses.'],
+    tono: { border: 'border-teal-600/40', bg: 'bg-teal-900/20', text: 'text-teal-200' },
+  },
+];
+
+function AbonoCard({ abono }) {
+  const [abierto, setAbierto] = useState(false);
+  return (
+    <div className={`rounded-2xl border ${abono.tono.border} ${abono.tono.bg} overflow-hidden`}>
+      <button
+        type="button"
+        onClick={() => setAbierto((v) => !v)}
+        aria-expanded={abierto}
+        className="w-full flex items-center gap-3 p-3.5 text-left"
+      >
+        <span className="shrink-0 w-11 h-11 rounded-xl bg-black/25 border border-slate-700/50 grid place-items-center">
+          <AbonoGlifo tipo={abono.tipo} size={34} />
+        </span>
+        <span className="flex-1 min-w-0">
+          <span className={`block font-black leading-tight ${abono.tono.text}`}>{abono.nombre}</span>
+          <span className="block text-2xs text-slate-400">{abono.de}</span>
+        </span>
+        <ChevronRight size={18} className={`shrink-0 text-slate-500 transition-transform ${abierto ? 'rotate-90' : ''}`} aria-hidden="true" />
+      </button>
+      {abierto && (
+        <div className="px-3.5 pb-3.5 -mt-1 space-y-2 estiercol-enter">
+          <p className="text-sm text-slate-300/90 leading-snug">{abono.que}</p>
+          <div>
+            <p className="text-xs font-bold text-slate-300 mb-1">Cómo se hace</p>
+            <ol className="space-y-1">
+              {abono.pasos.map((p, i) => (
+                <li key={i} className="flex gap-2 text-sm text-slate-300/90">
+                  <span className={`shrink-0 font-black ${abono.tono.text}`}>{i + 1}.</span>
+                  <span>{p}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+          <GroundedSlot />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PilarAbonos() {
+  return (
+    <div className="space-y-3 estiercol-enter">
+      <SeccionCard Icon={FlaskConical} tono={{ border: 'border-slate-700/50', bg: 'bg-slate-900/30', text: 'text-slate-100' }} titulo="Cada estiércol tiene su abono">
+        <p>
+          No todo estiércol se usa igual. Toque cada uno para ver qué es, cómo se
+          hace y —cuando la investigación lo confirme— cuánto aplicar.
+        </p>
+      </SeccionCard>
+      <div className="space-y-2.5">
+        {ABONOS.map((a) => <AbonoCard key={a.tipo} abono={a} />)}
+      </div>
+    </div>
+  );
+}
+
+/* ── INICIO (landing del módulo) ────────────────────────────────────────── */
+
+function PilarInicio({ onIr }) {
+  const cards = [
+    { id: 'olores', Icon: Wind, t: 'Quitar el olor', d: 'La gallinaza huele y el vecino se queja. Solución.', tono: 'border-l-teal-500 text-teal-300' },
+    { id: 'biodigestor', Icon: Flame, t: 'Sacar biogás', d: 'Gas para cocinar y biol. Calcule su biodigestor.', tono: 'border-l-amber-500 text-amber-300' },
+    { id: 'abonos', Icon: Sprout, t: 'Hacer abono', d: 'Gallinaza, biol, compost, lombricompost y más.', tono: 'border-l-lime-500 text-lime-300' },
+  ];
+  return (
+    <div className="space-y-4 estiercol-enter">
+      <div className="rounded-2xl border border-emerald-700/40 bg-gradient-to-b from-emerald-900/20 to-transparent p-4">
+        <p className="text-sm text-slate-200/95 leading-relaxed">
+          En la finca <b>nada sobra</b>. El estiércol del corral, bien manejado, se
+          vuelve <b className="text-lime-200">abono</b>, <b className="text-amber-200">gas para cocinar</b> y
+          suelo vivo. Aquí aprende a aprovecharlo sin malos olores.
+        </p>
+        <div className="mt-2 max-w-[240px] mx-auto">
+          <CicloCorralAbono />
+        </div>
+      </div>
+      <div className="space-y-2.5">
+        {cards.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => onIr(c.id)}
+            className={`estiercol-pilar-btn w-full flex items-center gap-3 rounded-2xl border border-slate-800 border-l-4 ${c.tono.split(' ')[0]} bg-slate-900/40 p-4 text-left`}
+          >
+            <c.Icon size={26} className={`shrink-0 ${c.tono.split(' ')[1]}`} aria-hidden="true" />
+            <span className="flex-1 min-w-0">
+              <span className={`block font-black ${c.tono.split(' ')[1]}`}>{c.t}</span>
+              <span className="block text-xs text-slate-400 mt-0.5">{c.d}</span>
+            </span>
+            <ChevronRight size={20} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── Pantalla ───────────────────────────────────────────────────────────── */
+
+export default function EstiercolScreen({ onBack, onHome }) {
+  const [pilar, setPilar] = useState('inicio');
+
+  return (
+    <ScreenShell title="Del corral al abono" icon={Recycle} onBack={onBack} onHome={onHome}>
+      <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto">
+        {/* Navegación por pilares (segmentada, siempre visible) */}
+        <nav
+          className="flex gap-1.5 mb-4 overflow-x-auto -mx-1 px-1 pb-1"
+          aria-label="Secciones del módulo"
+          data-testid="estiercol-pilares"
+        >
+          {PILARES.map((p) => {
+            const activo = p.id === pilar;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setPilar(p.id)}
+                aria-current={activo ? 'page' : undefined}
+                className={`estiercol-pilar-btn shrink-0 flex items-center gap-1.5 rounded-full px-3.5 py-2 text-sm font-bold border ${activo
+                  ? 'border-emerald-400/70 bg-emerald-500/20 text-emerald-100 shadow-[0_0_0_1px_rgba(52,211,153,0.25)]'
+                  : 'border-slate-700/60 bg-slate-900/40 text-slate-300'}`}
+              >
+                <p.Icon size={16} aria-hidden="true" />
+                {p.label}
+              </button>
+            );
+          })}
+        </nav>
+
+        {pilar === 'inicio' && <PilarInicio onIr={setPilar} />}
+        {pilar === 'olores' && <PilarOlores />}
+        {pilar === 'biodigestor' && <PilarBiodigestor />}
+        {pilar === 'abonos' && <PilarAbonos />}
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/__tests__/EstiercolScreen.test.jsx
+++ b/src/components/__tests__/EstiercolScreen.test.jsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+import EstiercolScreen from '../EstiercolScreen';
+
+// ScreenShell trae NotificationsBell (fetch clima, IDB, useTheme…) —
+// passthrough simple para probar el CONTENIDO del módulo.
+vi.mock('../common/ScreenShell', () => ({
+  ScreenShell: ({ title, children }) => (
+    <div><h1>{title}</h1>{children}</div>
+  ),
+}));
+
+describe('EstiercolScreen — "Del corral al abono"', () => {
+  it('abre en el inicio con el título y los tres accesos', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    expect(screen.getByRole('heading', { name: /Del corral al abono/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Quitar el olor/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Sacar biogás/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Hacer abono/i })).toBeTruthy();
+  });
+
+  it('Olores muestra el caso real de la gallinaza', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    fireEvent.click(within(screen.getByTestId('estiercol-pilares')).getByText('Olores'));
+    expect(screen.getByText(/huele muy feo y los vecinos se quejan/i)).toBeTruthy();
+    expect(screen.getByText(/Por qué huele/i)).toBeTruthy();
+    expect(screen.getByText(/Cómo quitarle el olor/i)).toBeTruthy();
+  });
+
+  it('la calculadora del biodigestor arranca en el caso insignia (300 cerdos)', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    fireEvent.click(within(screen.getByTestId('estiercol-pilares')).getByText('Biodigestor'));
+    const input = screen.getByLabelText(/Cuántos cerdos/i);
+    expect(input.value).toBe('300');
+    // Resultados coherentes con la fórmula (72 m³/día de biogás para 300 cerdos).
+    const res = screen.getByTestId('biodigestor-resultados');
+    expect(within(res).getByText('72')).toBeTruthy();
+  });
+
+  it('la calculadora recalcula al cambiar el número de animales', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    fireEvent.click(within(screen.getByTestId('estiercol-pilares')).getByText('Biodigestor'));
+    const input = screen.getByLabelText(/Cuántos cerdos/i);
+    fireEvent.change(input, { target: { value: '100' } });
+    // 100 cerdos → 24 m³/día de biogás.
+    const res = screen.getByTestId('biodigestor-resultados');
+    expect(within(res).getByText('24')).toBeTruthy();
+  });
+
+  it('Abonos lista los siete abonos y marca el slot grounded-pendiente al abrir', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    fireEvent.click(within(screen.getByTestId('estiercol-pilares')).getByText('Abonos'));
+    for (const nombre of ['Gallinaza', 'Porquinaza', 'Bovinaza (boñiga)', 'Biol', 'Biosol', 'Compost', 'Lombricompost']) {
+      expect(screen.getByText(nombre)).toBeTruthy();
+    }
+    // Sin abrir ninguna tarjeta, no hay slots visibles.
+    expect(screen.queryAllByTestId('grounded-slot').length).toBe(0);
+    fireEvent.click(screen.getByText('Gallinaza'));
+    expect(screen.getAllByTestId('grounded-slot').length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic, Leaf } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -178,6 +178,10 @@ const APRENDER_TILES = [
     { view: 'aprende', label: 'Aprender', icon: BookOpen, desc: 'Lecciones agroecológicas con fuente', accent: 'text-emerald-400 border-l-emerald-500' },
     { view: 'casos', label: 'Casos de estudio', labelF2: 'Casos reales', icon: ClipboardList, desc: 'Problemas reales y su tratamiento', descF2: 'Problemas de otras fincas y cómo los resolvieron', accent: 'text-amber-400 border-l-amber-500' },
     { view: 'ciclo_nutrientes', label: 'Ciclo de nutrientes', icon: Recycle, desc: 'Del animal al suelo y la planta', accent: 'text-emerald-400 border-l-emerald-500' },
+    // "Del corral al abono" — mini-app de aprovechamiento del estiércol
+    // (olores/gallinaza · biodigestor con calculadora · abonos). Ruta App.jsx
+    // 'estiercol'. Vecino natural del ciclo de nutrientes: lo hace accionable.
+    { view: 'estiercol', label: 'Del corral al abono', labelF2: 'Del corral al abono', icon: Leaf, desc: 'Aproveche el estiércol: sin olores, biogás y abono', descF2: 'Quítele el olor al estiércol y sáquele abono y gas', accent: 'text-lime-400 border-l-lime-500' },
     { view: 'biopreparados', label: 'Biopreparados', icon: FlaskConical, desc: 'Recetas caseras paso a paso', accent: 'text-lime-400 border-l-lime-500', data: { back: 'dashboard' } },
     { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Salud del suelo y micorrizas', descF2: 'Cómo está su tierra y cómo cuidarla', accent: 'text-amber-400 border-l-amber-500' },
     { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo', descF2: 'Qué es peligroso y cómo cuidarse', accent: 'text-rose-400 border-l-rose-500' },

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -162,7 +162,7 @@ describe('Home F2 — reorganización en 5 bloques (audit 2026-06-26)', () => {
     const labels = within(aprender).getAllByRole('button').map(labelOf);
     expect(labels).not.toContain('Aprender');
     expect(labels).toEqual([
-      'Casos reales', 'Ciclo de nutrientes', 'Biopreparados', 'Suelo', 'Seguridad', 'Preguntas frecuentes', 'Sacar reportes',
+      'Casos reales', 'Ciclo de nutrientes', 'Del corral al abono', 'Biopreparados', 'Suelo', 'Seguridad', 'Preguntas frecuentes', 'Sacar reportes',
     ]);
   });
 

--- a/src/components/estiercol/EstiercolIlustraciones.jsx
+++ b/src/components/estiercol/EstiercolIlustraciones.jsx
@@ -1,0 +1,275 @@
+import React from 'react';
+
+/**
+ * Ilustraciones propias del módulo "Del corral al abono".
+ * SVG a mano (tipo cuaderno de campo): trazo redondo, tierra colorada, gas
+ * ámbar, biol/planta verde. Colores fijos de ILUSTRACIÓN (no de tema) porque
+ * viven dentro de cards que ya ponen su propio fondo; se eligieron con contraste
+ * alto para leerse al sol en los 4 temas.
+ */
+
+/* Paleta de la ilustración (tierra / gas / agua / planta). */
+const C = {
+  tierra: '#7c4a24',
+  tierraOsc: '#5a3418',
+  gas: '#f5b53d',
+  gasClaro: '#ffd982',
+  biol: '#4a9b6e',
+  biolClaro: '#7fd0a3',
+  agua: '#3f9fd4',
+  trazo: '#2c1c0f',
+  cielo: '#cfe8d6',
+};
+
+/**
+ * Biodigestor tubular en corte. `llenado` (0..1) infla la cúpula de gas y activa
+ * las burbujas + la llama del fogón. `animated` controla las micro-animaciones.
+ *
+ * @param {{ llenado?: number, animated?: boolean, className?: string }} props
+ */
+export function BiodigestorIlustracion({ llenado = 0.6, animated = true, className = '' }) {
+  const f = Math.max(0, Math.min(1, llenado));
+  // La cúpula crece de una tira fina (vacío) a una campana gruesa (lleno).
+  const domoAltura = 10 + f * 40; // px
+  const domoTop = 96 - domoAltura;
+  const hayGas = f > 0.02;
+
+  return (
+    <svg
+      viewBox="0 0 320 200"
+      className={className}
+      role="img"
+      aria-label="Corte de un biodigestor tubular: entra la mezcla de estiércol y agua, se llena de biogás en la parte de arriba y sale el biol líquido por el otro lado."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      {/* Cielo/aire */}
+      <rect x="0" y="0" width="320" height="118" fill={C.cielo} opacity="0.35" />
+      {/* Suelo */}
+      <path d="M0 118 H320 V200 H0 Z" fill={C.tierra} opacity="0.9" />
+      <path d="M0 118 H320" stroke={C.tierraOsc} strokeWidth="3" strokeLinecap="round" />
+      {/* Textura de tierra (puntitos) */}
+      {[[28, 150], [70, 176], [150, 188], [212, 158], [268, 182], [300, 150]].map(([x, y], i) => (
+        <circle key={i} cx={x} cy={y} r="2.4" fill={C.tierraOsc} opacity="0.5" />
+      ))}
+
+      {/* Zanja + bolsa tubular (cuerpo del digestor), medio enterrada */}
+      <g>
+        {/* Cámara líquida (la mezcla en digestión) */}
+        <path
+          d="M60 96 Q60 132 96 132 H224 Q260 132 260 96 Z"
+          fill={C.tierraOsc}
+          opacity="0.55"
+        />
+        <path
+          d="M64 98 Q66 126 98 126 H222 Q254 126 256 98 Z"
+          fill={C.agua}
+          opacity="0.45"
+        />
+
+        {/* Cúpula de gas (se infla con `llenado`) */}
+        <g className={animated && hayGas ? 'estiercol-cupula' : undefined}>
+          <path
+            d={`M60 96 Q60 ${domoTop} 160 ${domoTop} Q260 ${domoTop} 260 96 Z`}
+            fill={hayGas ? C.gas : '#e7e2d8'}
+            opacity={hayGas ? 0.85 : 0.4}
+          />
+          <path
+            d={`M60 96 Q60 ${domoTop} 160 ${domoTop} Q260 ${domoTop} 260 96`}
+            fill="none"
+            stroke={C.trazo}
+            strokeWidth="2.5"
+            strokeLinecap="round"
+          />
+          {hayGas && (
+            <text x="160" y={domoTop + domoAltura / 2 + 4} textAnchor="middle"
+              fontSize="11" fontWeight="700" fill={C.trazo} opacity="0.8">
+              biogás
+            </text>
+          )}
+        </g>
+
+        {/* Contorno del cuerpo */}
+        <path
+          d="M60 96 Q60 132 96 132 H224 Q260 132 260 96"
+          fill="none"
+          stroke={C.trazo}
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+
+        {/* Burbujas subiendo */}
+        {animated && hayGas && (
+          <g fill={C.gasClaro} stroke={C.gas} strokeWidth="1">
+            <circle className="estiercol-burbuja" cx="120" cy="120" r="3" />
+            <circle className="estiercol-burbuja estiercol-burbuja--b" cx="160" cy="122" r="2.4" />
+            <circle className="estiercol-burbuja estiercol-burbuja--c" cx="196" cy="120" r="3.4" />
+            <circle className="estiercol-burbuja estiercol-burbuja--d" cx="142" cy="122" r="2" />
+          </g>
+        )}
+      </g>
+
+      {/* Entrada: tubo de carga (mezcla estiércol + agua) */}
+      <g>
+        <path d="M22 74 L58 100" stroke={C.trazo} strokeWidth="9" strokeLinecap="round" />
+        <path d="M22 74 L58 100" stroke={C.tierra} strokeWidth="5" strokeLinecap="round" />
+        <circle cx="20" cy="72" r="12" fill={C.tierraOsc} stroke={C.trazo} strokeWidth="2" />
+        <text x="20" y="52" textAnchor="middle" fontSize="10" fontWeight="700" fill={C.trazo}>entra</text>
+        <text x="20" y="42" textAnchor="middle" fontSize="10" fontWeight="700" fill={C.trazo}>mezcla</text>
+      </g>
+
+      {/* Salida: biol (efluente fertilizante) a un tanque */}
+      <g>
+        <path d="M260 100 L296 104" stroke={C.trazo} strokeWidth="9" strokeLinecap="round" />
+        <path d="M260 100 L296 104" stroke={C.biol} strokeWidth="5" strokeLinecap="round" />
+        <path d="M286 104 h26 v34 a4 4 0 0 1 -4 4 h-18 a4 4 0 0 1 -4 -4 Z"
+          fill={C.biol} opacity="0.35" stroke={C.trazo} strokeWidth="2" />
+        <text x="299" y="60" textAnchor="middle" fontSize="10" fontWeight="700" fill={C.trazo}>biol</text>
+        <path d="M299 66 V96" stroke={C.biol} strokeWidth="2" strokeLinecap="round"
+          className={animated ? 'estiercol-flujo' : undefined} />
+      </g>
+
+      {/* Línea de gas + fogón */}
+      <g>
+        <path d="M160 34 V52" stroke={C.trazo} strokeWidth="3" strokeLinecap="round" />
+        <path
+          d="M160 34 Q160 12 196 12 H236"
+          fill="none"
+          stroke={C.trazo}
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeDasharray={hayGas ? undefined : '4 5'}
+        />
+        {/* Fogón */}
+        <rect x="232" y="12" width="30" height="8" rx="3" fill={C.tierraOsc} stroke={C.trazo} strokeWidth="1.6" />
+        {hayGas && (
+          <path
+            className={animated ? 'estiercol-llama' : undefined}
+            d="M247 12 q-6 -8 0 -14 q6 6 0 14 Z"
+            fill={C.gas}
+            stroke={C.gasClaro}
+            strokeWidth="1"
+          />
+        )}
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * El ciclo cerrado en una sola imagen: CORRAL → PILA/DIGESTOR → BIOL+BIOGÁS →
+ * SUELO/PLANTA, con flechas que fluyen. Es el emblema del módulo.
+ *
+ * @param {{ animated?: boolean, className?: string }} props
+ */
+export function CicloCorralAbono({ animated = true, className = '' }) {
+  const nodo = (x, y, fill) => (
+    <circle cx={x} cy={y} r="30" fill={fill} opacity="0.16" stroke={fill} strokeWidth="2" />
+  );
+  const flecha = (d) => (
+    <path d={d} fill="none" stroke={C.trazo} strokeWidth="2.4" strokeLinecap="round"
+      opacity="0.75" className={animated ? 'estiercol-flujo' : undefined} />
+  );
+  return (
+    <svg
+      viewBox="0 0 300 300"
+      className={className}
+      role="img"
+      aria-label="El ciclo: del corral sale el estiércol, se procesa en pila o biodigestor, produce biol y biogás, y el abono vuelve al suelo y la planta."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      {/* Nodos */}
+      {nodo(150, 52, C.tierra)}
+      <text x="150" y="49" textAnchor="middle" fontSize="26">🐖</text>
+      <text x="150" y="92" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Corral</text>
+
+      {nodo(248, 150, C.gas)}
+      <text x="248" y="147" textAnchor="middle" fontSize="24">🛢️</text>
+      <text x="248" y="190" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Procesa</text>
+
+      {nodo(150, 248, C.biol)}
+      <text x="150" y="245" textAnchor="middle" fontSize="24">💧</text>
+      <text x="150" y="220" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Biol y biogás</text>
+
+      {nodo(52, 150, C.biolClaro)}
+      <text x="52" y="147" textAnchor="middle" fontSize="24">🌱</text>
+      <text x="52" y="190" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Suelo</text>
+
+      {/* Flechas del ciclo (sentido horario) */}
+      {flecha('M182 66 Q222 84 236 122')}
+      {flecha('M236 178 Q222 216 182 234')}
+      {flecha('M118 234 Q78 216 64 178')}
+      {flecha('M64 122 Q78 84 118 66')}
+    </svg>
+  );
+}
+
+/**
+ * Glifo pequeño y propio para cada abono (tarjetas de "Abonos de estiércol").
+ * `tipo`: gallinaza | porquinaza | bovinaza | biol | biosol | compost |
+ * lombricompost. Devuelve un SVG compacto de 44×44.
+ *
+ * @param {{ tipo: string, size?: number, className?: string }} props
+ */
+export function AbonoGlifo({ tipo, size = 44, className = '' }) {
+  const base = (children) => (
+    <svg viewBox="0 0 44 44" width={size} height={size} className={className}
+      role="img" aria-hidden="true" style={{ display: 'block' }}>
+      {children}
+    </svg>
+  );
+  const sacoTierra = (fill, stroke) => (
+    <>
+      <path d="M12 16 q10 -8 20 0 l3 22 a3 3 0 0 1 -3 3 H12 a3 3 0 0 1 -3 -3 Z"
+        fill={fill} opacity="0.85" stroke={stroke} strokeWidth="1.6" />
+      <path d="M13 16 q9 -6 18 0" fill="none" stroke={stroke} strokeWidth="1.6" strokeLinecap="round" />
+    </>
+  );
+  const gota = (fill, stroke) => (
+    <path d="M22 8 C30 20 32 26 32 30 a10 10 0 0 1 -20 0 c0 -4 2 -10 10 -22 Z"
+      fill={fill} opacity="0.85" stroke={stroke} strokeWidth="1.6" />
+  );
+  switch (tipo) {
+    case 'gallinaza':
+      return base(<>
+        {sacoTierra('#e8b84b', C.trazo)}
+        <circle cx="18" cy="27" r="1.8" fill={C.trazo} />
+        <circle cx="26" cy="30" r="1.8" fill={C.trazo} />
+        <circle cx="22" cy="34" r="1.8" fill={C.trazo} />
+      </>);
+    case 'porquinaza':
+      return base(<>
+        {sacoTierra('#e59aa6', C.trazo)}
+        <circle cx="18" cy="28" r="1.8" fill={C.trazo} />
+        <circle cx="26" cy="28" r="1.8" fill={C.trazo} />
+      </>);
+    case 'bovinaza':
+      return base(<>
+        {sacoTierra('#c88a52', C.trazo)}
+        <path d="M15 30 h14 M17 34 h10" stroke={C.trazo} strokeWidth="1.6" strokeLinecap="round" />
+      </>);
+    case 'biol':
+      return base(<>
+        {gota(C.biol, C.trazo)}
+        <path d="M17 27 h10 M18 31 h8" stroke="#fff" strokeWidth="1.6" strokeLinecap="round" opacity="0.8" />
+      </>);
+    case 'biosol':
+      return base(<>
+        <rect x="11" y="18" width="22" height="20" rx="3" fill="#b98a4e" opacity="0.85" stroke={C.trazo} strokeWidth="1.6" />
+        <path d="M22 8 v8 M14 12 l4 4 M30 12 l-4 4" stroke={C.gas} strokeWidth="2" strokeLinecap="round" />
+      </>);
+    case 'compost':
+      return base(<>
+        <path d="M8 34 q14 -12 28 0 Z" fill="#7c5a34" opacity="0.85" stroke={C.trazo} strokeWidth="1.6" />
+        <path d="M16 30 q2 -6 6 -6 M24 32 q2 -5 5 -5" stroke={C.biol} strokeWidth="1.8" strokeLinecap="round" fill="none" />
+      </>);
+    case 'lombricompost':
+      return base(<>
+        <path d="M8 34 q14 -12 28 0 Z" fill="#4a3218" opacity="0.9" stroke={C.trazo} strokeWidth="1.6" />
+        <path d="M14 30 q3 -3 6 0 q3 3 6 0" fill="none" stroke="#e59aa6" strokeWidth="2.4" strokeLinecap="round" />
+      </>);
+    default:
+      return base(<circle cx="22" cy="22" r="12" fill={C.tierra} opacity="0.6" />);
+  }
+}
+
+export default BiodigestorIlustracion;

--- a/src/components/estiercol/estiercol.css
+++ b/src/components/estiercol/estiercol.css
@@ -1,0 +1,78 @@
+/* ───────────────────────────────────────────────────────────────────────────
+   Micro-animaciones del módulo "Del corral al abono".
+   Sutiles, cálidas, tipo cuaderno de campo. Todas se apagan con
+   prefers-reduced-motion. No hardcodean color de tema (usan currentColor /
+   opacidad) para vivir bien en los 4 temas y ser legibles al sol.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+/* Entrada suave de cada sección al cambiar de pilar. */
+@keyframes estiercol-fade-up {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.estiercol-enter {
+  animation: estiercol-fade-up 0.34s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* Burbujas de gas subiendo dentro del biodigestor (SVG). */
+@keyframes estiercol-burbuja {
+  0%   { transform: translateY(0)   scale(0.8); opacity: 0; }
+  15%  { opacity: 0.85; }
+  85%  { opacity: 0.85; }
+  100% { transform: translateY(-46px) scale(1.15); opacity: 0; }
+}
+.estiercol-burbuja {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: estiercol-burbuja 3.2s ease-in-out infinite;
+}
+.estiercol-burbuja--b { animation-delay: 0.9s;  animation-duration: 3.8s; }
+.estiercol-burbuja--c { animation-delay: 1.7s;  animation-duration: 2.9s; }
+.estiercol-burbuja--d { animation-delay: 2.4s;  animation-duration: 3.5s; }
+
+/* La cúpula de gas "respira" muy leve cuando hay biogás. */
+@keyframes estiercol-respira {
+  0%, 100% { transform: scaleY(1);    }
+  50%      { transform: scaleY(1.035); }
+}
+.estiercol-cupula {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  animation: estiercol-respira 4.5s ease-in-out infinite;
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Llama del fogón — parpadeo cálido. */
+@keyframes estiercol-llama {
+  0%, 100% { transform: scaleY(1)    translateY(0);    opacity: 0.95; }
+  50%      { transform: scaleY(1.18) translateY(-1px); opacity: 1; }
+}
+.estiercol-llama {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  animation: estiercol-llama 0.9s ease-in-out infinite;
+}
+
+/* Flecha del ciclo — recorrido punteado que fluye. */
+@keyframes estiercol-flujo {
+  to { stroke-dashoffset: -24; }
+}
+.estiercol-flujo {
+  stroke-dasharray: 5 5;
+  animation: estiercol-flujo 1.1s linear infinite;
+}
+
+/* Chip/pastilla del pilar activo — sutil elevación. */
+.estiercol-pilar-btn {
+  transition: transform 0.16s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+.estiercol-pilar-btn:active { transform: scale(0.97); }
+
+@media (prefers-reduced-motion: reduce) {
+  .estiercol-enter,
+  .estiercol-burbuja,
+  .estiercol-cupula,
+  .estiercol-llama,
+  .estiercol-flujo { animation: none; }
+  .estiercol-cupula { transition: none; }
+}

--- a/src/services/__tests__/biodigestorCalculator.test.js
+++ b/src/services/__tests__/biodigestorCalculator.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  estimarBiodigestor,
+  ANIMALES_BIODIGESTOR,
+  PARAMS_PROCESO,
+} from '../biodigestorCalculator';
+
+describe('biodigestorCalculator — estimarBiodigestor', () => {
+  it('el caso insignia (300 cerdos) da un orden de magnitud coherente', () => {
+    const r = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 300 });
+    // 300 × 4 kg = 1200 kg/día de estiércol fresco.
+    expect(r.estiercolKgDia).toBe(1200);
+    // Mezcla 1:3 → 1200 L estiércol + 3600 L agua = 4800 L/día.
+    expect(r.mezclaLitrosDia).toBe(4800);
+    // Volumen = 4.8 m³ × 30 días × 1.15 = 165.6 m³.
+    expect(r.volumenDigestorM3).toBeCloseTo(165.6, 1);
+    // Biogás = 1200 × 0.06 = 72 m³/día.
+    expect(r.biogasM3Dia).toBe(72);
+    // Biol = 4800 × 0.9 = 4320 L/día.
+    expect(r.biolLitrosDia).toBe(4320);
+    expect(r.groundedPendiente).toBe(true);
+  });
+
+  it('escala linealmente con el número de animales', () => {
+    const a = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 100 });
+    const b = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 200 });
+    expect(b.biogasM3Dia).toBeCloseTo(a.biogasM3Dia * 2, 5);
+    expect(b.volumenDigestorM3).toBeCloseTo(a.volumenDigestorM3 * 2, 5);
+  });
+
+  it('con 0 animales todo es 0 (sin NaN ni negativos)', () => {
+    const r = estimarBiodigestor({ tipoAnimal: 'bovino', numAnimales: 0 });
+    for (const v of [r.estiercolKgDia, r.mezclaLitrosDia, r.volumenDigestorM3, r.biogasM3Dia, r.biolLitrosDia]) {
+      expect(v).toBe(0);
+      expect(Number.isNaN(v)).toBe(false);
+    }
+  });
+
+  it('cada especie usa su propio coeficiente de estiércol', () => {
+    const cerdo = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 10 });
+    const gallina = estimarBiodigestor({ tipoAnimal: 'gallina', numAnimales: 10 });
+    expect(cerdo.estiercolKgDia).toBe(10 * ANIMALES_BIODIGESTOR.cerdo.estiercolKgDia);
+    expect(gallina.estiercolKgDia).toBeCloseTo(10 * ANIMALES_BIODIGESTOR.gallina.estiercolKgDia, 5);
+    expect(cerdo.estiercolKgDia).toBeGreaterThan(gallina.estiercolKgDia);
+  });
+
+  it('es determinista: misma entrada → misma salida', () => {
+    const a = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 42 });
+    const b = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 42 });
+    expect(a).toEqual(b);
+  });
+
+  it('entradas inválidas caen a defaults seguros (cerdo, 0)', () => {
+    const r = estimarBiodigestor({ tipoAnimal: 'unicornio', numAnimales: -5 });
+    expect(r.tipoAnimal).toBe('cerdo');
+    expect(r.numAnimales).toBe(0);
+    expect(r.biogasM3Dia).toBe(0);
+  });
+
+  it('trunca fracciones de animal (no hay medio cerdo)', () => {
+    const r = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 2.9 });
+    expect(r.numAnimales).toBe(2);
+  });
+
+  it('los parámetros de proceso quedan expuestos para el grounding posterior', () => {
+    expect(PARAMS_PROCESO.TRH_DIAS).toBeGreaterThan(0);
+    expect(PARAMS_PROCESO.BIOGAS_M3_POR_KG).toBeGreaterThan(0);
+  });
+});

--- a/src/services/biodigestorCalculator.js
+++ b/src/services/biodigestorCalculator.js
@@ -1,0 +1,141 @@
+/**
+ * biodigestorCalculator — dimensionamiento SIMPLE y determinista de un
+ * biodigestor tubular a partir del hato de la finca.
+ *
+ * El campesino ingresa TIPO de animal y NÚMERO de cabezas; la función estima:
+ *   · estiércol fresco por día (kg)
+ *   · mezcla a cargar por día (estiércol + agua, litros)
+ *   · volumen del digestor (m³)
+ *   · biogás por día (m³)
+ *   · biol por día (litros)  ← el efluente, fertilizante líquido
+ *   · equivalencia tangible (horas de fogón)
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * ⚠️  GROUNDED-PENDIENTE — LEER ANTES DE TOMAR ESTAS CIFRAS COMO DATO DURO
+ * ─────────────────────────────────────────────────────────────────────────
+ * Los coeficientes de abajo (PARAMS_ANIMAL + PARAMS_PROCESO) son RANGOS DE
+ * REFERENCIA de ingeniería agrícola, NO datos groundeados del catálogo/DR.
+ * Sirven para que la calculadora dé un orden de magnitud razonable y
+ * pedagógico. Las DOS investigaciones (nacional Colombia + internacional) que
+ * llegan aparte deben REEMPLAZAR cada constante marcada `@grounded-pendiente`
+ * por su valor citado, afinado por región térmica, raza y dieta.
+ *
+ * Puntos exactos a groundear (buscar el tag GROUNDED-PENDIENTE):
+ *   1. estiercolKgDia por especie (producción de estiércol fresco/animal/día).
+ *   2. BIOGAS_M3_POR_KG (rendimiento de biogás por kg de estiércol fresco).
+ *   3. TRH_DIAS (tiempo de retención hidráulica según clima/piso térmico).
+ *   4. DILUCION_AGUA (relación estiércol:agua de carga).
+ *   5. BIOGAS_M3_POR_HORA_FOGON (consumo de un fogón doméstico).
+ * Nada aquí se presenta al usuario como cifra citada mientras siga siendo
+ * placeholder: la UI rotula estos resultados como "estimado" (ver
+ * EstiercolScreen).
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+/**
+ * Parámetros por especie. `estiercolKgDia` = kg de estiércol FRESCO que produce
+ * un animal por día (excreta recolectable).
+ *
+ * GROUNDED-PENDIENTE #1 — valores de referencia; afinar por raza/peso/dieta.
+ * @type {Record<string, {id:string, nombre:string, emoji:string, estiercolKgDia:number, nota:string}>}
+ */
+export const ANIMALES_BIODIGESTOR = {
+  cerdo: {
+    id: 'cerdo',
+    nombre: 'Cerdos',
+    emoji: '🐖',
+    estiercolKgDia: 4.0, // @grounded-pendiente
+    nota: 'Cerdo de engorde (~60 kg vivo)',
+  },
+  bovino: {
+    id: 'bovino',
+    nombre: 'Vacas',
+    emoji: '🐄',
+    estiercolKgDia: 10.0, // @grounded-pendiente
+    nota: 'Bovino adulto (estabulado o con recolección)',
+  },
+  gallina: {
+    id: 'gallina',
+    nombre: 'Gallinas',
+    emoji: '🐔',
+    estiercolKgDia: 0.12, // @grounded-pendiente
+    nota: 'Ponedora en piso (gallinaza recogida)',
+  },
+};
+
+/**
+ * Parámetros del proceso de biodigestión anaerobia (régimen mesofílico tibio).
+ * GROUNDED-PENDIENTE #2–#5.
+ */
+export const PARAMS_PROCESO = {
+  /** Partes de agua por parte de estiércol en la carga (mezcla 1:3). @grounded-pendiente #4 */
+  DILUCION_AGUA: 3,
+  /** Tiempo de retención hidráulica en días (clima templado). @grounded-pendiente #3 */
+  TRH_DIAS: 30,
+  /** m³ de biogás por kg de estiércol fresco. @grounded-pendiente #2 */
+  BIOGAS_M3_POR_KG: 0.06,
+  /** Fracción de la mezcla que sale como biol (efluente). */
+  BIOL_FRACCION: 0.9,
+  /** Holgura de diseño sobre el volumen líquido (cámara de gas + seguridad). */
+  FACTOR_SEGURIDAD: 1.15,
+  /** Densidad aprox. del estiércol/mezcla (kg/L) para pasar masa↔volumen. */
+  DENSIDAD_KG_L: 1.0,
+  /** Consumo de un fogón doméstico de biogás (m³/hora). @grounded-pendiente #5 */
+  BIOGAS_M3_POR_HORA_FOGON: 0.35,
+};
+
+/** Redondea a `dec` decimales devolviendo Number (evita el "-0"). */
+function round(n, dec = 1) {
+  const f = 10 ** dec;
+  return Math.round((n + Number.EPSILON) * f) / f || 0;
+}
+
+/**
+ * @typedef {Object} EstimacionBiodigestor
+ * @property {string}  tipoAnimal
+ * @property {number}  numAnimales
+ * @property {number}  estiercolKgDia     Estiércol fresco total por día (kg).
+ * @property {number}  aguaLitrosDia      Agua de dilución por día (L).
+ * @property {number}  mezclaLitrosDia    Mezcla a cargar por día (L).
+ * @property {number}  volumenDigestorM3  Volumen recomendado del digestor (m³).
+ * @property {number}  biogasM3Dia        Biogás estimado por día (m³).
+ * @property {number}  biolLitrosDia      Biol (efluente fertilizante) por día (L).
+ * @property {number}  horasFogonDia      Equivalencia: horas de fogón por día.
+ * @property {boolean} groundedPendiente  Siempre true: cifras estimadas, sin citar.
+ */
+
+/**
+ * Estima el dimensionamiento del biodigestor. Función PURA y determinista.
+ *
+ * @param {{ tipoAnimal?: string, numAnimales?: number }} params
+ * @returns {EstimacionBiodigestor}
+ */
+export function estimarBiodigestor({ tipoAnimal = 'cerdo', numAnimales = 0 } = {}) {
+  const animal = ANIMALES_BIODIGESTOR[tipoAnimal] || ANIMALES_BIODIGESTOR.cerdo;
+  const n = Math.max(0, Math.floor(Number(numAnimales) || 0));
+  const P = PARAMS_PROCESO;
+
+  const estiercolKgDia = n * animal.estiercolKgDia;
+  const estiercolLitrosDia = estiercolKgDia / P.DENSIDAD_KG_L;
+  const aguaLitrosDia = estiercolLitrosDia * P.DILUCION_AGUA;
+  const mezclaLitrosDia = estiercolLitrosDia + aguaLitrosDia;
+  const mezclaM3Dia = mezclaLitrosDia / 1000;
+
+  const volumenDigestorM3 = mezclaM3Dia * P.TRH_DIAS * P.FACTOR_SEGURIDAD;
+  const biogasM3Dia = estiercolKgDia * P.BIOGAS_M3_POR_KG;
+  const biolLitrosDia = mezclaLitrosDia * P.BIOL_FRACCION;
+  const horasFogonDia = biogasM3Dia / P.BIOGAS_M3_POR_HORA_FOGON;
+
+  return {
+    tipoAnimal: animal.id,
+    numAnimales: n,
+    estiercolKgDia: round(estiercolKgDia, 1),
+    aguaLitrosDia: round(aguaLitrosDia, 0),
+    mezclaLitrosDia: round(mezclaLitrosDia, 0),
+    volumenDigestorM3: round(volumenDigestorM3, 1),
+    biogasM3Dia: round(biogasM3Dia, 1),
+    biolLitrosDia: round(biolLitrosDia, 0),
+    horasFogonDia: round(horasFogonDia, 1),
+    groundedPendiente: true,
+  };
+}


### PR DESCRIPTION
## Del corral al abono — mini-app de aprovechamiento del estiércol

Feature insignia para el campesino colombiano: desde un chip en el home hasta una mini-app completa, con lenguaje "cuaderno de campo / Ciclo Vivo".

### Entrada (home)
Tile **"Del corral al abono"** (ícono `Leaf`, acento lima) en `APRENDER_TILES`, junto a "Ciclo de nutrientes". Se renderiza en **ambos layouts** (F2 y legacy). Ruta `estiercol` cableada en `App.jsx` (import lazy + `case` + `MODULE_VIEWS` + hash `#estiercol` / `#biodigestor` / `#del-corral-al-abono` / `#abono`).

### Tres pilares
1. **Olores** — resuelve el caso real *"la gallinaza huele muy feo y los vecinos se quejan"*: causas (fresca/húmeda, sin aire, sin cobertura, mojada) + soluciones en pasos (secar, cubrir con carbono, airear, compostar, biofiltro) + regla de oro.
2. **Biodigestor** — qué es + para qué sirve + **calculadora de dimensionamiento determinista** (caso insignia **300 cerdos** por defecto): estima tamaño del digestor (m³), biogás (m³/día), biol (L/día) y horas de fogón. Ilustración del **biodigestor tubular en corte** que se llena de biogás según el resultado (burbujas + llama, reduce-motion aware).
3. **Abonos** — gallinaza, porquinaza, bovinaza, biol, biosol, compost, lombricompost: tarjetas expandibles con **glifo SVG propio**, "cómo se hace" en pasos y slot de dosis.

### Grounding honesto (dónde va la investigación)
Ninguna cifra dura de dosis/rendimiento está inventada como dato citado:
- `src/services/biodigestorCalculator.js` — función pura; coeficientes de referencia rotulados con el tag **`GROUNDED-PENDIENTE`** (5 puntos: estiércol/animal, biogás/kg, TRH, dilución, consumo de fogón). La UI los rotula "cifras estimadas".
- Componente **`<GroundedSlot>`** — marca en la UI cada dosis exacta pendiente ("pendiente de la investigación agronómica. No damos un número al azar").

Las 2 investigaciones (nacional + internacional) reemplazan esos slots después.

### Identidad / temas
Ilustraciones SVG propias (`EstiercolIlustraciones.jsx`), micro-animaciones sutiles (`estiercol.css`, `prefers-reduced-motion` respetado), y `ScreenShell` para coherencia con los 4 temas y legibilidad al sol.

### Verificación
- `npm run build` ✅ (exit 0)
- Tests ✅ — calculadora (8) · pantalla (6) · ruta (1) · dashboard redistribución actualizado. 164/164 en la corrida ampliada.
- ESLint limpio en los archivos nuevos.
- Chip verificado importado + ruteado + visible (test de ruta + aserción de `aprender-tiles`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)