### PR TITLE
feat(home): reestructuracion 2.0 - mundos de mi finca (V4)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,6 +110,9 @@ const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScree
 // (calidad + nacimiento, caso "se me seca el nacimiento en verano").
 const AguaScreen = lazy(() => import('./components/agua/AguaScreen'));
 const SaludSueloScreen = lazy(() => import('./components/SaludSueloScreen'));
+// LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home): un mundo por dentro —
+// las funciones existentes agrupadas por lugar. Re-rutea, no reimplementa.
+const MundoScreen = lazy(() => import('./components/MundoScreen'));
 const CromatografiaScreen = lazy(() => import('./components/CromatografiaScreen'));
 const CicloVivoFullView = lazy(() => import('./components/CicloVivo/CicloVivoFullView'));
 const ToxicologiaScreen = lazy(() => import('./components/ToxicologiaScreen'));
@@ -227,7 +230,7 @@ const MODULE_VIEWS = new Set([
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'salud_suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
-  'usage_stats', 'mercado', 'auditoria_inventario',
+  'usage_stats', 'mercado', 'auditoria_inventario', 'mundo',
 ]);
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -1287,6 +1290,22 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Agua de la finca">
               <AguaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mundo':
+        // LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home, V4): la
+        // pantalla de un mundo agrupa sus funciones y RE-RUTEA a las vistas
+        // reales existentes. data = { mundo: id } (mundosFinca.js); sin data o
+        // con id desconocido muestra el índice de mundos (fallback honesto).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mundos de la finca">
+              <MundoScreen
+                mundoId={currentViewData?.mundo}
+                onBack={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,6 +104,10 @@ const CicloNutrientesScreen = lazy(() => import('./components/CicloNutrientesScr
 const CalendarioFincaScreen = lazy(() => import('./components/CalendarioFincaScreen'));
 const SeguimientoProcesoScreen = lazy(() => import('./components/SeguimientoProcesoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
+// Módulo "Agua de la finca": cosecha de lluvia (calculadora determinista),
+// riego con medida (ETc; Kc/ETo = slots grounded-pendiente) y cuidar el agua
+// (calidad + nacimiento, caso "se me seca el nacimiento en verano").
+const AguaScreen = lazy(() => import('./components/agua/AguaScreen'));
 const CromatografiaScreen = lazy(() => import('./components/CromatografiaScreen'));
 const CicloVivoFullView = lazy(() => import('./components/CicloVivo/CicloVivoFullView'));
 const ToxicologiaScreen = lazy(() => import('./components/ToxicologiaScreen'));
@@ -192,6 +196,8 @@ const HASH_VIEW_ROUTES = {
   'mundo-subsuelo': 'subsuelo',
   toxicologia: 'toxicologia',
   suelo: 'suelo',
+  agua: 'agua',
+  'manejo-agua': 'agua',
   aprende: 'aprende',
   directorio: 'directorio',
   'directorio-especies': 'directorio',
@@ -209,7 +215,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
+  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
   'usage_stats', 'mercado', 'auditoria_inventario',
@@ -1239,6 +1245,17 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Cromatografia de Suelo">
               <CromatografiaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'agua':
+        // Módulo "Agua de la finca" (3 pilares: cosechar lluvia / regar con
+        // medida / cuidar el agua + nacimiento). Cifras duras pendientes de
+        // grounding se muestran como "dato en camino" (src/data/aguaFinca.js).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Agua de la finca">
+              <AguaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -118,6 +118,11 @@ const PoscosechaScreen = lazy(() => import('./components/PoscosechaScreen'));
 // LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home): un mundo por dentro —
 // las funciones existentes agrupadas por lugar. Re-rutea, no reimplementa.
 const MundoScreen = lazy(() => import('./components/MundoScreen'));
+// Portada a medida del mundo 🌱 CULTIVOS Y SEMILLAS: hub que orienta por
+// región/clima, agrupa las funciones existentes (directorio, ciclo, germinación,
+// calendario, siembra, cosecha) y suma una calculadora de grados-día. Re-rutea,
+// no reimplementa.
+const MundoCultivosHub = lazy(() => import('./components/cultivos/MundoCultivosHub'));
 const CromatografiaScreen = lazy(() => import('./components/CromatografiaScreen'));
 const CicloVivoFullView = lazy(() => import('./components/CicloVivo/CicloVivoFullView'));
 const ToxicologiaScreen = lazy(() => import('./components/ToxicologiaScreen'));
@@ -1323,6 +1328,20 @@ export default function App() {
             <ErrorFallback moduleName="Mundos de la finca">
               <MundoScreen
                 mundoId={currentViewData?.mundo}
+                onBack={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mundo_cultivos':
+        // Portada a medida del mundo CULTIVOS Y SEMILLAS (hub): orienta por
+        // región/clima, agrupa las funciones existentes y suma la calculadora
+        // de grados-día. Cada lámina RE-RUTEA a su pantalla real vía navigate.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Cultivos y semillas">
+              <MundoCultivosHub
                 onBack={() => navigate('dashboard')}
                 onNavigate={navigate}
               />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,6 +110,11 @@ const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScree
 // (calidad + nacimiento, caso "se me seca el nacimiento en verano").
 const AguaScreen = lazy(() => import('./components/agua/AguaScreen'));
 const SaludSueloScreen = lazy(() => import('./components/SaludSueloScreen'));
+// Módulo "Poscosecha y Despensa" (mundo Mercado y despensa): cosechar en punto
+// (índices de madurez), guardar bien (curado + calculadora determinista de
+// secado de grano a humedad segura) y transformar el excedente con su punto
+// crítico de inocuidad. Cifras grounded al DR nacional/internacional.
+const PoscosechaScreen = lazy(() => import('./components/PoscosechaScreen'));
 // LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home): un mundo por dentro —
 // las funciones existentes agrupadas por lugar. Re-rutea, no reimplementa.
 const MundoScreen = lazy(() => import('./components/MundoScreen'));
@@ -218,6 +223,9 @@ const HASH_VIEW_ROUTES = {
   mercado: 'mercado',
   mercados: 'mercado',
   vender: 'mercado',
+  poscosecha: 'poscosecha',
+  despensa: 'poscosecha',
+  'poscosecha-despensa': 'poscosecha',
 };
 
 // Vistas que cuentan como "módulo" para telemetría de piloto.
@@ -227,7 +235,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'estiercol',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'salud_suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
+  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'salud_suelo', 'poscosecha', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
   'usage_stats', 'mercado', 'auditoria_inventario', 'mundo',
@@ -1271,6 +1279,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Salud del Suelo">
               <SaludSueloScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'poscosecha':
+        // Módulo "Poscosecha y Despensa" (mundo Mercado y despensa): 3 pilares
+        // (cosechar en punto / guardar bien / transformar) + calculadora
+        // determinista de secado de grano. Cifras grounded al DR; slots no
+        // cerrados marcados grounded-pendiente en poscosechaCalculator.js.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Poscosecha y Despensa">
+              <PoscosechaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,6 +104,7 @@ const CicloNutrientesScreen = lazy(() => import('./components/CicloNutrientesScr
 const CalendarioFincaScreen = lazy(() => import('./components/CalendarioFincaScreen'));
 const SeguimientoProcesoScreen = lazy(() => import('./components/SeguimientoProcesoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
+const SaludSueloScreen = lazy(() => import('./components/SaludSueloScreen'));
 const CromatografiaScreen = lazy(() => import('./components/CromatografiaScreen'));
 const CicloVivoFullView = lazy(() => import('./components/CicloVivo/CicloVivoFullView'));
 const ToxicologiaScreen = lazy(() => import('./components/ToxicologiaScreen'));
@@ -192,6 +193,9 @@ const HASH_VIEW_ROUTES = {
   'mundo-subsuelo': 'subsuelo',
   toxicologia: 'toxicologia',
   suelo: 'suelo',
+  'salud-suelo': 'salud_suelo',
+  'cuaderno-suelo': 'salud_suelo',
+  encalado: 'salud_suelo',
   aprende: 'aprende',
   directorio: 'directorio',
   'directorio-especies': 'directorio',
@@ -209,7 +213,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
+  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'salud_suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
   'usage_stats', 'mercado', 'auditoria_inventario',
@@ -1231,6 +1235,14 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Diagnostico de Suelo">
               <SoilDiagnosticScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'salud_suelo':
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Salud del Suelo">
+              <SaludSueloScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -90,6 +90,7 @@ const AnimalesScreen = lazy(() => import('./components/AnimalesScreen'));
 const GallinasScreen = lazy(() => import('./components/GallinasScreen'));
 const AbejasScreen = lazy(() => import('./components/AbejasScreen'));
 const VacasScreen = lazy(() => import('./components/VacasScreen'));
+const EstiercolScreen = lazy(() => import('./components/EstiercolScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
@@ -187,6 +188,10 @@ const HASH_VIEW_ROUTES = {
   'animales-gallinas': 'animales_gallinas',
   'animales-abejas': 'animales_abejas',
   'animales-vacas': 'animales_vacas',
+  estiercol: 'estiercol',
+  'del-corral-al-abono': 'estiercol',
+  abono: 'estiercol',
+  biodigestor: 'estiercol',
   'doom-finca': 'doom_finca',
   subsuelo: 'subsuelo',
   'mundo-subsuelo': 'subsuelo',
@@ -206,7 +211,7 @@ const HASH_VIEW_ROUTES = {
 const MODULE_VIEWS = new Set([
   'activos', 'mapa', 'javier', 'bodega', 'task_log', 'historial', 'bitacora',
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
-  'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
+  'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'estiercol',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
@@ -1110,6 +1115,20 @@ export default function App() {
               {/* onNavigate: VacasScreen enlaza al proceso de seguimiento de
                   silvopastoreo existente ('seguimiento_silvopastoreo'). */}
               <VacasScreen onBack={() => navigate('animales')} onHome={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'estiercol':
+        // Módulo "Del corral al abono": aprovechamiento del estiércol
+        // (olores/gallinaza, biodigestor con calculadora de dimensionamiento y
+        // abonos: gallinaza/porquinaza/bovinaza/biol/biosol/compost/
+        // lombricompost). Calculadora determinista (biodigestorCalculator.js);
+        // dosis/rendimientos exactos quedan en slots grounded-pendiente hasta la
+        // investigación (nacional + internacional). Ruta #estiercol / #biodigestor.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Del corral al abono">
+              <EstiercolScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/__tests__/App.estiercol-route.test.jsx
+++ b/src/__tests__/App.estiercol-route.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Test de RUTA: verifica que App rutea 'estiercol' → EstiercolScreen ("Del
+// corral al abono"). El tile del home (DashboardLive APRENDER_TILES) llama
+// onNavigate('estiercol') y #estiercol / #biodigestor también lo disparan; sin
+// el case en el switch de App esa navegación caería en "Vista no disponible"
+// (feature huérfana). Acá montamos App con #estiercol + sesión autenticada y
+// comprobamos que la pantalla monta.
+//
+// Los efectos pesados de boot se mockean para que App arranque limpio en jsdom.
+
+vi.mock('../services/authService', () => ({
+  isAuthenticated: () => Promise.resolve(true),
+  logoutUser: () => Promise.resolve(),
+}));
+vi.mock('../db/catalogDB', () => ({ initCatalog: () => Promise.resolve() }));
+vi.mock('../services/ragRetriever', () => ({
+  prewarmCorpus: () => {},
+  retrieve: () => Promise.resolve([]),
+}));
+vi.mock('../services/alertEngine', () => ({ alertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/cropAlertEngine', () => ({ cropAlertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/apiService', () => ({
+  fetchFromFarmOS: () => Promise.resolve(null),
+  fetchWithAuthRetry: () => Promise.resolve({ ok: true }),
+}));
+
+// La pantalla destino: stub liviano que delata que se montó. Probamos el WIRING
+// de la ruta, no el render interno del módulo (cubierto en su propio test).
+vi.mock('../components/EstiercolScreen', () => ({
+  default: () => <div data-testid="estiercol-screen">del corral al abono stub</div>,
+}));
+
+vi.mock('../db/farmProcessCache', () => ({ listFarmProcesses: () => Promise.resolve([]) }));
+
+import App from '../App';
+
+describe('App — ruta "estiercol"', () => {
+  beforeEach(() => {
+    window.location.hash = '#estiercol';
+    localStorage.clear();
+  });
+  afterEach(() => {
+    window.location.hash = '';
+    vi.clearAllMocks();
+  });
+
+  it('con sesión autenticada y #estiercol monta EstiercolScreen (no "Vista no disponible")', async () => {
+    render(<App />);
+    await waitFor(
+      () => expect(screen.getByTestId('estiercol-screen')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+    expect(screen.queryByText('Vista no disponible')).toBeNull();
+  });
+});

--- a/src/components/EstiercolScreen.jsx
+++ b/src/components/EstiercolScreen.jsx
@@ -1,0 +1,532 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Recycle, Wind, Flame, Sprout, Droplets, Layers, Calculator, Info,
+  ChevronRight, AlertTriangle, CheckCircle2, Container, ShieldCheck,
+  ArrowRight, Sun, Minus, Plus, FlaskConical,
+} from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+import {
+  BiodigestorIlustracion, CicloCorralAbono, AbonoGlifo,
+} from './estiercol/EstiercolIlustraciones';
+import { estimarBiodigestor, ANIMALES_BIODIGESTOR } from '../services/biodigestorCalculator';
+import './estiercol/estiercol.css';
+
+/**
+ * EstiercolScreen — "Del corral al abono".
+ *
+ * Mini-app de aprovechamiento del estiércol para el campesino colombiano.
+ * Lenguaje "cuaderno de campo / Ciclo Vivo": nada sobra en la finca; el
+ * estiércol se vuelve abono, gas y suelo vivo. Tres pilares:
+ *
+ *   1. Olores      — resuelve el caso real "la gallinaza huele y los vecinos
+ *                    se quejan": causas + soluciones (secar, cubrir, airear,
+ *                    biofiltro, compostar).
+ *   2. Biodigestor — bases + beneficios + calculadora de dimensionamiento
+ *                    (caso insignia: 300 cerdos). Fórmula determinista en
+ *                    services/biodigestorCalculator.js.
+ *   3. Abonos      — gallinaza, porquinaza, bovinaza, biol, biosol, compost,
+ *                    lombricompost: cómo se hacen + dónde va la dosis.
+ *
+ * ⚠️  GROUNDING: NINGUNA cifra dura de dosis/rendimiento está inventada como
+ * dato citado. Las dosis exactas y los rendimientos van en slots marcados
+ * <GroundedSlot> ("pendiente de la investigación"); la calculadora usa
+ * coeficientes de referencia rotulados "estimado" (ver biodigestorCalculator.js,
+ * tag GROUNDED-PENDIENTE). Las 2 investigaciones (nacional + internacional)
+ * reemplazan esos slots después.
+ */
+
+const PILARES = [
+  { id: 'inicio', label: 'Inicio', Icon: Recycle },
+  { id: 'olores', label: 'Olores', Icon: Wind },
+  { id: 'biodigestor', label: 'Biodigestor', Icon: Flame },
+  { id: 'abonos', label: 'Abonos', Icon: Sprout },
+];
+
+/* ── Piezas de UI reutilizables ─────────────────────────────────────────── */
+
+/** Card de sección con encabezado a color (patrón de las pantallas de Chagra). */
+function SeccionCard({ Icon, tono, titulo, children, className = '' }) {
+  return (
+    <section className={`rounded-2xl border ${tono.border} ${tono.bg} p-4 ${className}`}>
+      {titulo && (
+        <h2 className={`flex items-center gap-2 text-base font-black ${tono.text}`}>
+          {Icon && <Icon size={18} aria-hidden="true" />}
+          {titulo}
+        </h2>
+      )}
+      <div className="mt-2 text-sm text-slate-200/90 leading-relaxed space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+/** Paso numerado (tipo receta del cuaderno). */
+function Paso({ n, titulo, children, tono }) {
+  return (
+    <div className="flex gap-3">
+      <span className={`shrink-0 w-7 h-7 rounded-full grid place-items-center text-sm font-black ${tono.chip}`}>
+        {n}
+      </span>
+      <div className="min-w-0">
+        <p className="font-bold text-slate-100 leading-tight">{titulo}</p>
+        {children && <p className="text-sm text-slate-300/90 leading-snug mt-0.5">{children}</p>}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Slot de dato GROUNDED-PENDIENTE. Marca en la UI —con honestidad— dónde va una
+ * cifra citada (dosis exacta, rendimiento) que aún NO está groundeada. NO se
+ * inventa un número: se anuncia el hueco. La investigación lo llena luego.
+ */
+function GroundedSlot({ children = 'Dosis exacta y frecuencia' }) {
+  return (
+    <p
+      data-testid="grounded-slot"
+      className="mt-2 flex items-start gap-2 rounded-lg border border-dashed border-amber-500/50 bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-200/90"
+    >
+      <Info size={14} className="mt-0.5 shrink-0 text-amber-300" aria-hidden="true" />
+      <span>
+        <span className="font-bold">{children}:</span>{' '}
+        pendiente de la investigación agronómica. No damos un número al azar.
+      </span>
+    </p>
+  );
+}
+
+/* ── PILAR 1 · OLORES ───────────────────────────────────────────────────── */
+
+const OLOR_CAUSAS = [
+  { Icon: Droplets, t: 'Está fresca y húmeda', d: 'El nitrógeno se escapa como amoníaco: ese olor picante que se siente de lejos.' },
+  { Icon: Wind, t: 'Amontonada sin aire', d: 'Sin oxígeno se pudre (fermentación anaerobia) y suelta gases de mal olor.' },
+  { Icon: Layers, t: 'Sin material seco encima', d: 'Nada absorbe la humedad ni tapa el olor; la pila queda destapada.' },
+  { Icon: Sun, t: 'Mojada por lluvia o lavados', d: 'El agua la escurre y la hace fermentar mal; los lixiviados apestan.' },
+];
+
+const OLOR_SOLUCIONES = [
+  { t: 'Secar', d: 'Tiéndala en capa delgada bajo techo. La gallinaza seca casi no huele y pesa menos para mover.' },
+  { t: 'Cubrir con material seco', d: 'Cascarilla de arroz, aserrín, hoja seca o tamo encima. Tapa el olor y equilibra la mezcla (carbono).' },
+  { t: 'Airear y voltear', d: 'Déle vuelta cada pocos días. Con oxígeno la pila trabaja sin pudrirse ni apestar.' },
+  { t: 'Compostar bien', d: 'Mezcle 2 a 3 partes de material seco por 1 de estiércol. Un compost bien hecho huele a tierra de monte, no a amoníaco.' },
+  { t: 'Biofiltro en el galpón', d: 'Una cama de viruta, carbón y compost por donde pase el aire del corral atrapa el olor antes de que llegue al vecino.' },
+];
+
+function PilarOlores() {
+  const tono = { border: 'border-teal-600/40', bg: 'bg-teal-900/20', text: 'text-teal-200', chip: 'bg-teal-500/20 text-teal-100 border border-teal-400/40' };
+  return (
+    <div className="space-y-4 estiercol-enter">
+      {/* El caso real, en voz del campo */}
+      <div className="rounded-2xl border border-rose-600/40 bg-rose-900/20 p-4">
+        <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-rose-300">
+          <AlertTriangle size={14} aria-hidden="true" /> El caso
+        </p>
+        <p className="mt-1 text-lg font-black text-slate-100 leading-snug">
+          «La gallinaza huele muy feo y los vecinos se quejan.»
+        </p>
+        <p className="mt-1 text-sm text-slate-300/90">
+          Pasa en toda finca con animales. El olor no es mala suerte: es estiércol
+          fresco perdiendo nitrógeno al aire. Se arregla, y de paso usted gana abono.
+        </p>
+      </div>
+
+      <SeccionCard Icon={Info} tono={{ border: 'border-amber-600/40', bg: 'bg-amber-900/20', text: 'text-amber-200' }} titulo="Por qué huele">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
+          {OLOR_CAUSAS.map((c) => (
+            <div key={c.t} className="rounded-xl bg-black/20 border border-slate-700/50 p-3">
+              <p className="flex items-center gap-2 font-bold text-slate-100">
+                <c.Icon size={16} className="text-amber-300 shrink-0" aria-hidden="true" />
+                {c.t}
+              </p>
+              <p className="text-xs text-slate-300/90 mt-1 leading-snug">{c.d}</p>
+            </div>
+          ))}
+        </div>
+      </SeccionCard>
+
+      {/* De esto → a esto (antes/después) */}
+      <div className="rounded-2xl border border-slate-700/50 bg-slate-900/30 p-3.5 flex items-center gap-3">
+        <div className="flex-1 text-center">
+          <p className="text-2xl" aria-hidden="true">💩</p>
+          <p className="text-xs font-bold text-rose-300 mt-1">Pila húmeda y tapada</p>
+          <p className="text-2xs text-slate-400">huele a amoníaco</p>
+        </div>
+        <ArrowRight size={22} className="text-emerald-400 shrink-0" aria-hidden="true" />
+        <div className="flex-1 text-center">
+          <p className="text-2xl" aria-hidden="true">🌱</p>
+          <p className="text-xs font-bold text-emerald-300 mt-1">Compost aireado</p>
+          <p className="text-2xs text-slate-400">huele a tierra</p>
+        </div>
+      </div>
+
+      <SeccionCard Icon={CheckCircle2} tono={tono} titulo="Cómo quitarle el olor">
+        <div className="space-y-3 mt-1">
+          {OLOR_SOLUCIONES.map((s, i) => (
+            <Paso key={s.t} n={i + 1} titulo={s.t} tono={tono}>{s.d}</Paso>
+          ))}
+        </div>
+        <div className="mt-3 rounded-lg bg-emerald-500/10 border border-emerald-500/30 px-3 py-2 text-xs text-emerald-100/90">
+          <span className="font-bold">Regla de oro:</span> seco y con aire no huele; mojado y tapado apesta.
+        </div>
+      </SeccionCard>
+    </div>
+  );
+}
+
+/* ── PILAR 2 · BIODIGESTOR ──────────────────────────────────────────────── */
+
+const BIODIGESTOR_BENEFICIOS = [
+  { Icon: Flame, t: 'Gas para cocinar', d: 'Menos leña y menos humo en la cocina.', tono: 'text-amber-300' },
+  { Icon: Droplets, t: 'Biol fertilizante', d: 'Abono líquido listo para las matas.', tono: 'text-lime-300' },
+  { Icon: Wind, t: 'Menos olor y moscas', d: 'El estiércol va cerrado, no en pila abierta.', tono: 'text-teal-300' },
+  { Icon: ShieldCheck, t: 'Saneamiento', d: 'Cuida el agua, la salud y el corral.', tono: 'text-sky-300' },
+];
+
+function PilarBiodigestor() {
+  const [tipoAnimal, setTipoAnimal] = useState('cerdo');
+  const [numAnimales, setNumAnimales] = useState(300); // caso insignia
+
+  const est = useMemo(
+    () => estimarBiodigestor({ tipoAnimal, numAnimales }),
+    [tipoAnimal, numAnimales],
+  );
+  // Mapa biogás → llenado visual de la cúpula (0.12..1).
+  const llenado = Math.min(1, 0.12 + est.biogasM3Dia / 100);
+
+  const setNum = (v) => setNumAnimales(Math.max(0, Math.min(100000, Math.floor(v) || 0)));
+
+  const tono = { border: 'border-amber-600/40', bg: 'bg-amber-900/20', text: 'text-amber-200', chip: 'bg-amber-500/20 text-amber-100 border border-amber-400/40' };
+
+  return (
+    <div className="space-y-4 estiercol-enter">
+      <SeccionCard Icon={Info} tono={{ border: 'border-slate-700/50', bg: 'bg-slate-900/30', text: 'text-slate-100' }} titulo="Qué es un biodigestor">
+        <p>
+          Una bolsa o tanque cerrado donde el estiércol se descompone <b>sin aire</b>.
+          De ahí salen dos cosas: <b className="text-amber-200">biogás</b> para cocinar
+          y <b className="text-lime-200">biol</b>, un abono líquido. El mismo estiércol
+          que le daba problemas le da energía y fertilizante.
+        </p>
+      </SeccionCard>
+
+      {/* Ilustración del tubular en corte */}
+      <div className="rounded-2xl border border-amber-700/40 bg-gradient-to-b from-amber-900/10 to-transparent p-3">
+        <BiodigestorIlustracion llenado={llenado} />
+        <p className="text-center text-xs text-slate-400 mt-1">
+          Biodigestor tubular en corte: entra la mezcla, se llena de biogás arriba y sale el biol.
+        </p>
+      </div>
+
+      <SeccionCard Icon={CheckCircle2} tono={tono} titulo="Para qué sirve">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
+          {BIODIGESTOR_BENEFICIOS.map((b) => (
+            <div key={b.t} className="rounded-xl bg-black/20 border border-slate-700/50 p-3">
+              <p className="flex items-center gap-2 font-bold text-slate-100">
+                <b.Icon size={16} className={`${b.tono} shrink-0`} aria-hidden="true" />
+                {b.t}
+              </p>
+              <p className="text-xs text-slate-300/90 mt-1 leading-snug">{b.d}</p>
+            </div>
+          ))}
+        </div>
+      </SeccionCard>
+
+      {/* Calculadora de dimensionamiento */}
+      <SeccionCard Icon={Calculator} tono={{ border: 'border-lime-600/40', bg: 'bg-lime-900/20', text: 'text-lime-200' }} titulo="Calculadora: ¿de qué tamaño?">
+        <p className="text-sm text-slate-300/90">
+          Ponga su hato y vea el tamaño del digestor y cuánto biogás y biol daría.
+        </p>
+
+        {/* Tipo de animal */}
+        <div className="mt-3">
+          <p className="text-xs font-bold text-slate-300 mb-1.5">Animal</p>
+          <div className="grid grid-cols-3 gap-2" role="group" aria-label="Tipo de animal">
+            {Object.values(ANIMALES_BIODIGESTOR).map((a) => {
+              const activo = a.id === tipoAnimal;
+              return (
+                <button
+                  key={a.id}
+                  type="button"
+                  onClick={() => setTipoAnimal(a.id)}
+                  aria-pressed={activo}
+                  className={`estiercol-pilar-btn rounded-xl border px-2 py-2.5 text-center ${activo
+                    ? 'border-lime-400/70 bg-lime-500/20 text-lime-100'
+                    : 'border-slate-700/60 bg-black/20 text-slate-300'}`}
+                >
+                  <span className="text-xl block" aria-hidden="true">{a.emoji}</span>
+                  <span className="text-xs font-bold block mt-0.5">{a.nombre}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Número de animales */}
+        <div className="mt-3">
+          <label htmlFor="num-animales" className="text-xs font-bold text-slate-300 mb-1.5 block">
+            ¿Cuántos {ANIMALES_BIODIGESTOR[tipoAnimal].nombre.toLowerCase()}?
+          </label>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setNum(numAnimales - 10)}
+              aria-label="Quitar 10"
+              className="estiercol-pilar-btn shrink-0 w-11 h-11 rounded-xl border border-slate-700/60 bg-black/20 text-slate-200 grid place-items-center"
+            >
+              <Minus size={18} aria-hidden="true" />
+            </button>
+            <input
+              id="num-animales"
+              type="number"
+              inputMode="numeric"
+              min="0"
+              value={numAnimales}
+              onChange={(e) => setNum(Number(e.target.value))}
+              className="flex-1 min-w-0 text-center text-2xl font-black bg-black/25 border border-slate-700/60 rounded-xl py-2 text-lime-100 focus:outline-none focus:border-lime-400/70"
+            />
+            <button
+              type="button"
+              onClick={() => setNum(numAnimales + 10)}
+              aria-label="Sumar 10"
+              className="estiercol-pilar-btn shrink-0 w-11 h-11 rounded-xl border border-slate-700/60 bg-black/20 text-slate-200 grid place-items-center"
+            >
+              <Plus size={18} aria-hidden="true" />
+            </button>
+          </div>
+          {/* Atajos, con el caso insignia bien a la vista */}
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {[10, 50, 100, 300].map((p) => (
+              <button
+                key={p}
+                type="button"
+                onClick={() => setNum(p)}
+                className={`estiercol-pilar-btn text-xs font-bold rounded-full px-3 py-1 border ${numAnimales === p
+                  ? 'border-lime-400/70 bg-lime-500/20 text-lime-100'
+                  : 'border-slate-700/60 bg-black/20 text-slate-300'}`}
+              >
+                {p}{p === 300 ? ' 🐖' : ''}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Resultados */}
+        <div className="grid grid-cols-2 gap-2.5 mt-4" data-testid="biodigestor-resultados">
+          <ResultCard Icon={Container} valor={est.volumenDigestorM3} unidad="m³" etiqueta="Tamaño del digestor" tono="text-sky-200" />
+          <ResultCard Icon={Flame} valor={est.biogasM3Dia} unidad="m³/día" etiqueta="Biogás" tono="text-amber-200" />
+          <ResultCard Icon={Droplets} valor={est.biolLitrosDia} unidad="L/día" etiqueta="Biol (abono líquido)" tono="text-lime-200" />
+          <ResultCard Icon={Flame} valor={est.horasFogonDia} unidad="h/día" etiqueta="Fogón encendido" tono="text-orange-200" />
+        </div>
+
+        <div className="mt-3 rounded-lg border border-dashed border-slate-500/50 bg-slate-500/10 px-3 py-2 text-xs text-slate-300/90">
+          <span className="font-bold text-slate-200">Cifras estimadas.</span>{' '}
+          Son un orden de magnitud con relaciones estándar. Los rendimientos
+          exactos por región, raza y dieta se afinan con la investigación
+          (nacional + internacional) que está en curso.
+        </div>
+      </SeccionCard>
+    </div>
+  );
+}
+
+function ResultCard({ Icon, valor, unidad, etiqueta, tono }) {
+  const texto = Number.isFinite(valor)
+    ? valor.toLocaleString('es-CO', { maximumFractionDigits: 1 })
+    : '—';
+  return (
+    <div className="rounded-xl bg-black/25 border border-slate-700/50 p-3">
+      {Icon && <Icon size={18} className={`${tono} mb-1`} aria-hidden="true" />}
+      <p className="leading-none">
+        <span className={`text-2xl font-black ${tono}`}>{texto}</span>{' '}
+        <span className="text-xs text-slate-400 font-bold">{unidad}</span>
+      </p>
+      <p className="text-2xs text-slate-400 mt-1 leading-tight">{etiqueta}</p>
+    </div>
+  );
+}
+
+/* ── PILAR 3 · ABONOS ───────────────────────────────────────────────────── */
+
+const ABONOS = [
+  {
+    tipo: 'gallinaza', nombre: 'Gallinaza', de: 'De las gallinas',
+    que: 'Estiércol de gallina con la cama (cascarilla, viruta). Muy rica en nitrógeno; fresca quema las matas.',
+    pasos: ['Recójala seca de la cama profunda.', 'Madúrela o compóstela 4–8 semanas antes de usar.', 'Aplíquela al suelo, nunca sobre la hoja.'],
+    tono: { border: 'border-amber-600/40', bg: 'bg-amber-900/20', text: 'text-amber-200' },
+  },
+  {
+    tipo: 'porquinaza', nombre: 'Porquinaza', de: 'De los cerdos',
+    que: 'Estiércol de cerdo, casi siempre líquido. Muy fuerte: va al biodigestor o bien compostado.',
+    pasos: ['Sepárela del agua de lavado.', 'Llévela al biodigestor o a una pila con material seco.', 'Use el biol/compost resultante, no la porquinaza cruda.'],
+    tono: { border: 'border-pink-600/40', bg: 'bg-pink-900/20', text: 'text-pink-200' },
+  },
+  {
+    tipo: 'bovinaza', nombre: 'Bovinaza (boñiga)', de: 'De las vacas',
+    que: 'La boñiga clásica del biol. Equilibrada y noble; base de muchos preparados.',
+    pasos: ['Recójala del establo o el potrero.', 'Madúrela o llévela al biol/compost.', 'Aplíquela madura al pie de la planta.'],
+    tono: { border: 'border-orange-600/40', bg: 'bg-orange-900/20', text: 'text-orange-200' },
+  },
+  {
+    tipo: 'biol', nombre: 'Biol', de: 'Líquido — foliar o al pie',
+    que: 'El líquido que sale del biodigestor o de un tanque tapado. Fertilizante y bioestimulante.',
+    pasos: ['Deje fermentar el estiércol con agua, tapado y sin aire.', 'Cuele el líquido.', 'Diluya en agua y aplique foliar o al pie.'],
+    tono: { border: 'border-lime-600/40', bg: 'bg-lime-900/20', text: 'text-lime-200' },
+  },
+  {
+    tipo: 'biosol', nombre: 'Biosol', de: 'Sólido del biodigestor',
+    que: 'La parte sólida que queda tras sacar el biol. Abono estable para el suelo.',
+    pasos: ['Retire el sólido del fondo/salida del digestor.', 'Séquelo a la sombra.', 'Incorpórelo al suelo como abono de fondo.'],
+    tono: { border: 'border-yellow-600/40', bg: 'bg-yellow-900/20', text: 'text-yellow-200' },
+  },
+  {
+    tipo: 'compost', nombre: 'Compost', de: 'Pila aireada',
+    que: 'Estiércol + material seco, volteado con aire hasta que huele a tierra. El abono más versátil.',
+    pasos: ['Mezcle estiércol con material seco (2–3 : 1).', 'Voltee cada pocos días y mantenga húmedo como esponja escurrida.', 'Listo cuando huele a tierra y no se reconoce el material.'],
+    tono: { border: 'border-emerald-600/40', bg: 'bg-emerald-900/20', text: 'text-emerald-200' },
+  },
+  {
+    tipo: 'lombricompost', nombre: 'Lombricompost', de: 'Con lombriz roja',
+    que: 'Estiércol digerido por lombriz roja californiana. El humus más fino y de mejor calidad.',
+    pasos: ['Prepare camas con estiércol ya pre-compostado (frío).', 'Siembre la lombriz y manténgala húmeda y a la sombra.', 'Cose­che el humus del lecho cada pocos meses.'],
+    tono: { border: 'border-teal-600/40', bg: 'bg-teal-900/20', text: 'text-teal-200' },
+  },
+];
+
+function AbonoCard({ abono }) {
+  const [abierto, setAbierto] = useState(false);
+  return (
+    <div className={`rounded-2xl border ${abono.tono.border} ${abono.tono.bg} overflow-hidden`}>
+      <button
+        type="button"
+        onClick={() => setAbierto((v) => !v)}
+        aria-expanded={abierto}
+        className="w-full flex items-center gap-3 p-3.5 text-left"
+      >
+        <span className="shrink-0 w-11 h-11 rounded-xl bg-black/25 border border-slate-700/50 grid place-items-center">
+          <AbonoGlifo tipo={abono.tipo} size={34} />
+        </span>
+        <span className="flex-1 min-w-0">
+          <span className={`block font-black leading-tight ${abono.tono.text}`}>{abono.nombre}</span>
+          <span className="block text-2xs text-slate-400">{abono.de}</span>
+        </span>
+        <ChevronRight size={18} className={`shrink-0 text-slate-500 transition-transform ${abierto ? 'rotate-90' : ''}`} aria-hidden="true" />
+      </button>
+      {abierto && (
+        <div className="px-3.5 pb-3.5 -mt-1 space-y-2 estiercol-enter">
+          <p className="text-sm text-slate-300/90 leading-snug">{abono.que}</p>
+          <div>
+            <p className="text-xs font-bold text-slate-300 mb-1">Cómo se hace</p>
+            <ol className="space-y-1">
+              {abono.pasos.map((p, i) => (
+                <li key={i} className="flex gap-2 text-sm text-slate-300/90">
+                  <span className={`shrink-0 font-black ${abono.tono.text}`}>{i + 1}.</span>
+                  <span>{p}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+          <GroundedSlot />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PilarAbonos() {
+  return (
+    <div className="space-y-3 estiercol-enter">
+      <SeccionCard Icon={FlaskConical} tono={{ border: 'border-slate-700/50', bg: 'bg-slate-900/30', text: 'text-slate-100' }} titulo="Cada estiércol tiene su abono">
+        <p>
+          No todo estiércol se usa igual. Toque cada uno para ver qué es, cómo se
+          hace y —cuando la investigación lo confirme— cuánto aplicar.
+        </p>
+      </SeccionCard>
+      <div className="space-y-2.5">
+        {ABONOS.map((a) => <AbonoCard key={a.tipo} abono={a} />)}
+      </div>
+    </div>
+  );
+}
+
+/* ── INICIO (landing del módulo) ────────────────────────────────────────── */
+
+function PilarInicio({ onIr }) {
+  const cards = [
+    { id: 'olores', Icon: Wind, t: 'Quitar el olor', d: 'La gallinaza huele y el vecino se queja. Solución.', tono: 'border-l-teal-500 text-teal-300' },
+    { id: 'biodigestor', Icon: Flame, t: 'Sacar biogás', d: 'Gas para cocinar y biol. Calcule su biodigestor.', tono: 'border-l-amber-500 text-amber-300' },
+    { id: 'abonos', Icon: Sprout, t: 'Hacer abono', d: 'Gallinaza, biol, compost, lombricompost y más.', tono: 'border-l-lime-500 text-lime-300' },
+  ];
+  return (
+    <div className="space-y-4 estiercol-enter">
+      <div className="rounded-2xl border border-emerald-700/40 bg-gradient-to-b from-emerald-900/20 to-transparent p-4">
+        <p className="text-sm text-slate-200/95 leading-relaxed">
+          En la finca <b>nada sobra</b>. El estiércol del corral, bien manejado, se
+          vuelve <b className="text-lime-200">abono</b>, <b className="text-amber-200">gas para cocinar</b> y
+          suelo vivo. Aquí aprende a aprovecharlo sin malos olores.
+        </p>
+        <div className="mt-2 max-w-[240px] mx-auto">
+          <CicloCorralAbono />
+        </div>
+      </div>
+      <div className="space-y-2.5">
+        {cards.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => onIr(c.id)}
+            className={`estiercol-pilar-btn w-full flex items-center gap-3 rounded-2xl border border-slate-800 border-l-4 ${c.tono.split(' ')[0]} bg-slate-900/40 p-4 text-left`}
+          >
+            <c.Icon size={26} className={`shrink-0 ${c.tono.split(' ')[1]}`} aria-hidden="true" />
+            <span className="flex-1 min-w-0">
+              <span className={`block font-black ${c.tono.split(' ')[1]}`}>{c.t}</span>
+              <span className="block text-xs text-slate-400 mt-0.5">{c.d}</span>
+            </span>
+            <ChevronRight size={20} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── Pantalla ───────────────────────────────────────────────────────────── */
+
+export default function EstiercolScreen({ onBack, onHome }) {
+  const [pilar, setPilar] = useState('inicio');
+
+  return (
+    <ScreenShell title="Del corral al abono" icon={Recycle} onBack={onBack} onHome={onHome}>
+      <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto">
+        {/* Navegación por pilares (segmentada, siempre visible) */}
+        <nav
+          className="flex gap-1.5 mb-4 overflow-x-auto -mx-1 px-1 pb-1"
+          aria-label="Secciones del módulo"
+          data-testid="estiercol-pilares"
+        >
+          {PILARES.map((p) => {
+            const activo = p.id === pilar;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setPilar(p.id)}
+                aria-current={activo ? 'page' : undefined}
+                className={`estiercol-pilar-btn shrink-0 flex items-center gap-1.5 rounded-full px-3.5 py-2 text-sm font-bold border ${activo
+                  ? 'border-emerald-400/70 bg-emerald-500/20 text-emerald-100 shadow-[0_0_0_1px_rgba(52,211,153,0.25)]'
+                  : 'border-slate-700/60 bg-slate-900/40 text-slate-300'}`}
+              >
+                <p.Icon size={16} aria-hidden="true" />
+                {p.label}
+              </button>
+            );
+          })}
+        </nav>
+
+        {pilar === 'inicio' && <PilarInicio onIr={setPilar} />}
+        {pilar === 'olores' && <PilarOlores />}
+        {pilar === 'biodigestor' && <PilarBiodigestor />}
+        {pilar === 'abonos' && <PilarAbonos />}
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/MundoScreen.jsx
+++ b/src/components/MundoScreen.jsx
@@ -46,9 +46,11 @@ export default function MundoScreen({ mundoId, onBack, onNavigate }) {
                                 type="button"
                                 className="mf-indice-item"
                                 style={{ '--mf-a': m.tinte[0], '--mf-b': m.tinte[1] }}
-                                onClick={() => (m.directo
-                                    ? onNavigate?.(m.directo.view, m.directo.data)
-                                    : onNavigate?.('mundo', { mundo: m.id }))}
+                                onClick={() => {
+                                    if (m.portada) onNavigate?.(m.portada);
+                                    else if (m.directo) onNavigate?.(m.directo.view, m.directo.data);
+                                    else onNavigate?.('mundo', { mundo: m.id });
+                                }}
                                 aria-label={`${m.titulo}: ${m.lema}`}
                             >
                                 <span aria-hidden="true" className="mf-indice-emoji">{m.emoji}</span>

--- a/src/components/MundoScreen.jsx
+++ b/src/components/MundoScreen.jsx
@@ -1,0 +1,121 @@
+/*
+ * i18n (ADR-050): copy de navegación en español Colombia, pendiente de migrar a
+ * src/config/messages.js — mismo criterio que DashboardLive.jsx.
+ */
+import { Globe2 } from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+import { MUNDOS_FINCA, getMundo } from './dashboard/mundosFinca';
+import MundoVineta from './dashboard/MundoVinetas';
+import './dashboard/mundos-finca.css';
+
+/**
+ * MundoScreen — un MUNDO de la finca por dentro (ruta 'mundo', data { mundo }).
+ *
+ * La pantalla que agrupa las funciones de un mundo (reestructuración 2.0 del
+ * home): cabecera con la viñeta ilustrada del lugar + su lema, y debajo las
+ * entradas como filas generosas (una por función real de App.jsx). NO
+ * reimplementa ninguna pantalla: cada fila RE-RUTEA a la vista existente.
+ *
+ * El agente queda siempre a la mano: el pie ofrece "Pregúntele a Chagra"
+ * con el contexto del mundo.
+ *
+ * Fallback honesto: si llega un id desconocido (deep-link viejo, recarga sin
+ * data), muestra el índice de TODOS los mundos en vez de un error.
+ *
+ * @param {Object} props
+ * @param {string} [props.mundoId]  id del mundo (mundosFinca.js).
+ * @param {Function} props.onBack   volver al home.
+ * @param {(view: string, data?: any) => void} props.onNavigate
+ */
+export default function MundoScreen({ mundoId, onBack, onNavigate }) {
+    const mundo = getMundo(mundoId);
+
+    if (!mundo) {
+        // Índice de mundos: recarga o enlace sin data → se ofrece el mapa
+        // completo, nunca una pantalla rota.
+        return (
+            <ScreenShell title="Los mundos de su finca" icon={Globe2} onBack={onBack}>
+                <div className="max-w-2xl mx-auto p-4" data-testid="mundo-indice">
+                    <p className="mf-indice-intro">
+                        Elija un mundo para ver sus herramientas.
+                    </p>
+                    <div className="mf-indice">
+                        {MUNDOS_FINCA.map((m) => (
+                            <button
+                                key={m.id}
+                                type="button"
+                                className="mf-indice-item"
+                                style={{ '--mf-a': m.tinte[0], '--mf-b': m.tinte[1] }}
+                                onClick={() => (m.directo
+                                    ? onNavigate?.(m.directo.view, m.directo.data)
+                                    : onNavigate?.('mundo', { mundo: m.id }))}
+                                aria-label={`${m.titulo}: ${m.lema}`}
+                            >
+                                <span aria-hidden="true" className="mf-indice-emoji">{m.emoji}</span>
+                                <span className="mf-indice-txt">
+                                    <b>{m.titulo}</b>
+                                    <small>{m.lema}</small>
+                                </span>
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            </ScreenShell>
+        );
+    }
+
+    const entradas = mundo.entradas || [];
+
+    return (
+        <ScreenShell title={mundo.titulo} onBack={onBack}>
+            <div
+                className="max-w-2xl mx-auto p-4 mf-mundo"
+                style={{ '--mf-a': mundo.tinte[0], '--mf-b': mundo.tinte[1] }}
+                data-testid={`mundo-screen-${mundo.id}`}
+            >
+                {/* Portada del mundo: la misma viñeta de la tarjeta, en grande. */}
+                <div className="mf-mundo-hero" aria-hidden="true">
+                    <MundoVineta mundoId={mundo.id} />
+                    <span className="mf-mundo-emoji">{mundo.emoji}</span>
+                </div>
+                <p className="mf-mundo-lema">{mundo.lema}</p>
+
+                {/* Las funciones del mundo — cada una re-rutea a su pantalla real. */}
+                <nav className="mf-entradas" aria-label={`Herramientas de ${mundo.titulo}`}>
+                    {entradas.map((e) => (
+                        <button
+                            key={e.view}
+                            type="button"
+                            className="mf-entrada"
+                            data-testid={`entrada-${e.view}`}
+                            onClick={() => onNavigate?.(e.view, e.data)}
+                            aria-label={`${e.label}: ${e.desc}`}
+                        >
+                            <span className="mf-entrada-icono" aria-hidden="true">{e.emoji}</span>
+                            <span className="mf-entrada-txt">
+                                <b>{e.label}</b>
+                                <small>{e.desc}</small>
+                            </span>
+                            <span className="mf-entrada-ir" aria-hidden="true">→</span>
+                        </button>
+                    ))}
+                </nav>
+
+                {/* El agente siempre presente, con el contexto del mundo. */}
+                <button
+                    type="button"
+                    className="mf-agente"
+                    data-testid="mundo-agente"
+                    onClick={() => onNavigate?.('agente')}
+                    aria-label={`Pregúntele a Chagra sobre ${mundo.titulo.toLowerCase()}`}
+                >
+                    <span aria-hidden="true">💬</span>
+                    <span>
+                        <b>Pregúntele a Chagra</b>
+                        <small>Cualquier duda sobre {mundo.titulo.toLowerCase()}, con su fuente.</small>
+                    </span>
+                </button>
+            </div>
+        </ScreenShell>
+    );
+}

--- a/src/components/PoscosechaScreen.jsx
+++ b/src/components/PoscosechaScreen.jsx
@@ -1,0 +1,601 @@
+/* i18n (ADR-050): etiquetas user-facing en español Colombia pendientes de
+ * migrar a src/config/messages.js. Misma deuda preexistente que SaludSueloScreen
+ * y App.jsx; se desactiva la regla soft a nivel de archivo. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useMemo, useState } from 'react';
+import {
+  ChevronLeft, ChevronRight, ArrowRight, Info, AlertTriangle, CheckCircle2,
+  Scissors, Warehouse, FlaskConical, Sun, Snowflake, Droplets, Wind,
+  Sprout, Wheat, ShieldCheck,
+} from 'lucide-react';
+import {
+  GRANOS,
+  calcularSecadoGrano,
+  evaluarMateriaSecaAguacate,
+  AGUACATE_MS_MINIMO_NORMA,
+  CURADO,
+  DANIO_POR_FRIO,
+  TRANSFORMACIONES,
+  PERDIDA_PAIS,
+} from '../services/poscosechaCalculator';
+
+/**
+ * PoscosechaScreen — mini-app "Poscosecha y Despensa" (mundo Mercado y despensa).
+ *
+ * Identidad: cuaderno de campo / Ciclo Vivo. Cálida, campesina, legible al sol.
+ *
+ * Gancho: el país pierde ~1 de cada 3 productos entre la mata y la venta, y la
+ * mayor parte se evita SIN plata. Tres pilares:
+ *   1. Cosechar en punto — índices de madurez (aguacate Hass por materia seca).
+ *   2. Guardar bien        — curado (2 recetas OPUESTAS), daño por frío, y la
+ *      CALCULADORA de secado de grano a humedad segura (determinista).
+ *   3. Transformar          — deshidratados, mermeladas, harinas, panela, queso,
+ *      café — cada uno con su punto crítico de inocuidad.
+ *
+ * CERO invención: las cifras salen de poscosechaCalculator.js (grounded al DR
+ * nacional/internacional); los slots no cerrados se marcan grounded-pendiente.
+ * La matemática del secado es balance de masa exacto.
+ */
+
+/* ── Ilustración SVG propia: canasta con sol, gotas de agua que se van y grano ── */
+function DespensaIlustracion() {
+  return (
+    <svg
+      viewBox="0 0 240 150"
+      role="img"
+      aria-label="Ilustración de una canasta de cosecha bajo el sol, con la humedad saliendo del grano"
+      className="w-full h-auto"
+    >
+      {/* Fondo cálido */}
+      <rect x="0" y="0" width="240" height="150" rx="6" fill="rgb(var(--t-accent-rgb) / 0.08)" />
+      {/* Sol que "respira" */}
+      <circle cx="204" cy="26" r="12" fill="#f4b83c" className="pc-sun" />
+      <g stroke="#f4b83c" strokeWidth="2" strokeLinecap="round" className="pc-sun">
+        <path d="M204 6 V0" /><path d="M226 26 H232" /><path d="M219 11 L223 7" />
+      </g>
+      {/* Repisa / mesa */}
+      <rect x="16" y="118" width="208" height="7" rx="3" fill="#7a5a3c" />
+      {/* Canasta */}
+      <path d="M54 92 H150 L140 120 H64 Z" fill="#b9822f" />
+      <path d="M54 92 H150" stroke="#8a5f22" strokeWidth="3" />
+      <g stroke="#8a5f22" strokeWidth="1.6" opacity="0.6">
+        <path d="M74 92 L70 120" /><path d="M96 92 L94 120" /><path d="M118 92 L118 120" /><path d="M138 92 L142 120" />
+      </g>
+      {/* Frutos en la canasta */}
+      <circle cx="78" cy="88" r="10" fill="#5a9e4a" />
+      <circle cx="100" cy="86" r="11" fill="#d06a3a" />
+      <circle cx="122" cy="88" r="10" fill="#e0b03a" />
+      {/* Gotas de humedad que se van (secado) */}
+      <g fill="rgb(70 130 180 / 0.85)" className="pc-drops">
+        <path d="M40 70 q-4 6 0 9 q4 -3 0 -9 Z" />
+        <path d="M168 62 q-4 6 0 9 q4 -3 0 -9 Z" />
+        <path d="M150 78 q-3 5 0 7 q3 -2 0 -7 Z" />
+      </g>
+      {/* Granos secos guardados abajo */}
+      <g fill="#c9a04a">
+        <ellipse cx="182" cy="112" rx="4" ry="3" />
+        <ellipse cx="192" cy="114" rx="4" ry="3" />
+        <ellipse cx="187" cy="108" rx="4" ry="3" />
+      </g>
+    </svg>
+  );
+}
+
+const COLOR_MAP = {
+  emerald: { text: 'text-emerald-300', border: 'border-emerald-700/50', bg: 'bg-emerald-950/30', dot: 'bg-emerald-400' },
+  lime: { text: 'text-lime-300', border: 'border-lime-700/50', bg: 'bg-lime-950/30', dot: 'bg-lime-400' },
+  amber: { text: 'text-amber-300', border: 'border-amber-700/50', bg: 'bg-amber-950/30', dot: 'bg-amber-400' },
+  rose: { text: 'text-rose-300', border: 'border-rose-700/50', bg: 'bg-rose-950/30', dot: 'bg-rose-400' },
+  slate: { text: 'text-slate-300', border: 'border-slate-700/50', bg: 'bg-slate-900/50', dot: 'bg-slate-500' },
+};
+
+/* ═══════════════════════════════ Componente ═══════════════════════════════ */
+/**
+ * @param {Object} props
+ * @param {() => void} props.onBack
+ * @param {(view: string, data?: any) => void} [props.onNavigate]
+ */
+export default function PoscosechaScreen({ onBack, onNavigate }) {
+  const [pilar, setPilar] = useState('hub'); // hub | cosecha | guardar | transformar
+
+  const volver = () => {
+    if (pilar === 'hub') { onBack?.(); return; }
+    setPilar('hub');
+  };
+
+  const subtitulo = pilar === 'hub' ? 'Cosechar en punto, guardar bien y transformar.'
+    : pilar === 'cosecha' ? 'Cosechar en el punto'
+    : pilar === 'guardar' ? 'Guardar sin que se dañe'
+    : 'Transformar el excedente';
+
+  return (
+    <div className="min-h-[100dvh] text-white">
+      <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
+        <button
+          type="button"
+          onClick={volver}
+          aria-label="Volver"
+          className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
+        >
+          <ChevronLeft size={20} />
+        </button>
+        <div>
+          <h1 className="text-lg font-bold leading-tight text-white">Poscosecha y Despensa</h1>
+          <p className="text-xs text-slate-400 leading-tight">{subtitulo}</p>
+        </div>
+      </header>
+
+      <div className="px-4 pb-10">
+        {pilar === 'hub' && <Hub onIr={setPilar} onNavigate={onNavigate} />}
+        {pilar === 'cosecha' && <PilarCosecha />}
+        {pilar === 'guardar' && <PilarGuardar />}
+        {pilar === 'transformar' && <PilarTransformar onNavigate={onNavigate} />}
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────── Hub ─────────────────────────────────── */
+function Hub({ onIr, onNavigate }) {
+  const pilares = [
+    { key: 'cosecha', icon: Scissors, titulo: 'Cosechar en punto', desc: 'Cada cultivo tiene su seña. El aguacate se cosecha por materia seca, no en la mata.', accent: 'emerald' },
+    { key: 'guardar', icon: Warehouse, titulo: 'Guardar bien', desc: 'Curado, frío casero y la calculadora de secado de grano a humedad segura.', accent: 'amber' },
+    { key: 'transformar', icon: FlaskConical, titulo: 'Transformar', desc: 'Deshidratados, mermeladas, harinas, panela, queso y café — con su punto crítico.', accent: 'lime' },
+  ];
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Gancho — la magnitud del problema */}
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 overflow-hidden">
+        <div className="p-4 pb-3">
+          <DespensaIlustracion />
+        </div>
+        <div className="px-4 pb-4">
+          <p className="text-[13px] uppercase tracking-wide font-bold text-slate-400">El problema</p>
+          <p className="mt-1 text-[15px] text-slate-100 leading-snug">
+            <span className="font-bold">Colombia pierde cerca de 1 de cada 3 productos</span> entre la mata y la venta.
+          </p>
+          <p className="mt-2 text-sm text-slate-300 leading-relaxed">
+            Son <span className="font-semibold text-slate-100">{PERDIDA_PAIS.toneladasMt} millones de toneladas al año</span>{' '}
+            ({PERDIDA_PAIS.porcentajeOferta} % de la comida del país). La mayor parte se evita{' '}
+            <span className="font-semibold text-slate-100">con manejo, no con plata</span>: sombra, suavidad, limpieza y buen guardado.
+          </p>
+          <p className="mt-2 text-[11px] text-slate-500">Fuente: {PERDIDA_PAIS.fuente} · confianza {PERDIDA_PAIS.confianza}.</p>
+        </div>
+      </section>
+
+      {/* Tres pilares */}
+      <div className="flex flex-col gap-3">
+        {pilares.map((p, i) => {
+          const c = COLOR_MAP[p.accent];
+          const Icono = p.icon;
+          return (
+            <button
+              key={p.key}
+              type="button"
+              onClick={() => onIr(p.key)}
+              className={`text-left rounded-2xl border ${c.border} ${c.bg} p-4 flex items-start gap-3 hover:border-opacity-100 transition-colors motion-reduce:transition-none active:scale-[0.99]`}
+            >
+              <span
+                className="w-11 h-11 rounded-xl flex items-center justify-center shrink-0"
+                style={{ backgroundColor: 'rgb(var(--t-accent-rgb) / 0.20)' }}
+              >
+                <Icono size={22} className={c.text} />
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="text-[11px] font-bold text-slate-500">Paso {i + 1}</span>
+                <span className="block text-[15px] font-bold text-white leading-tight">{p.titulo}</span>
+                <span className="block text-sm text-slate-300 mt-0.5 leading-snug">{p.desc}</span>
+              </span>
+              <ChevronRight size={20} className="text-slate-500 shrink-0 mt-2" />
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Puente honesto a herramientas existentes del mismo mundo */}
+      {onNavigate ? (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-3">
+          <p className="text-xs uppercase tracking-wide font-bold text-slate-400 mb-2">También en Chagra</p>
+          <div className="flex flex-col gap-2">
+            <PuenteBoton
+              icon={Warehouse}
+              titulo="Bodega de insumos"
+              sub="Lo que tiene guardado y lo que se le está acabando."
+              onClick={() => onNavigate('bodega')}
+            />
+            <PuenteBoton
+              icon={Sprout}
+              titulo="Pregúntele al agente"
+              sub="Índice de cosecha, curado o inocuidad para su cultivo."
+              onClick={() => onNavigate('agente', { prompt: '¿Cuándo cosecho y cómo guardo para que no se me dañe?' })}
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function PuenteBoton({ icon, titulo, sub, onClick }) {
+  const Icon = icon;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full text-left rounded-xl border border-slate-700/60 bg-slate-800/40 p-3 flex items-center gap-3 hover:border-slate-600 transition-colors motion-reduce:transition-none"
+    >
+      <Icon size={20} className="shrink-0" style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm font-bold text-slate-100 leading-tight">{titulo}</span>
+        <span className="block text-xs text-slate-400 leading-snug">{sub}</span>
+      </span>
+      <ChevronRight size={18} className="text-slate-500 shrink-0" />
+    </button>
+  );
+}
+
+/* ─────────────────── Pilar 1 — Cosechar en punto ─────────────────── */
+function PilarCosecha() {
+  const [ms, setMs] = useState('');
+  const setMsClean = (raw) => setMs(raw.replace(',', '.').replace(/[^0-9.]/g, ''));
+  const res = useMemo(() => (ms === '' ? null : evaluarMateriaSecaAguacate(ms)), [ms]);
+  const c = res ? COLOR_MAP[res.color] : COLOR_MAP.slate;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-slate-300 leading-relaxed">
+        El punto de cosecha se lee con los ojos (color), la mano (firmeza) y el calendario
+        (días desde la flor). Cosechar en el punto es la <span className="font-semibold text-slate-100">primera defensa</span> contra la pérdida.
+      </p>
+
+      {/* Aguacate Hass — índice por materia seca (calculadora insignia) */}
+      <section className="rounded-2xl border border-emerald-800/40 bg-emerald-950/20 p-4">
+        <div className="flex items-center gap-2">
+          <Sprout size={20} className="text-emerald-300 shrink-0" />
+          <h3 className="text-[15px] font-bold text-emerald-200">Aguacate Hass: por materia seca</h3>
+        </div>
+        <p className="text-sm text-emerald-100/90 mt-2 leading-relaxed">
+          El aguacate <span className="font-semibold">no madura en la planta</span>: se cosecha fisiológicamente maduro
+          y ablanda después. La seña no es el color, es el <span className="font-semibold">contenido de materia seca</span>.
+        </p>
+        <label htmlFor="pc-ms" className="mt-3 block text-xs uppercase tracking-wide font-bold text-emerald-200/80">
+          Materia seca medida (%)
+        </label>
+        <div className="mt-1.5 flex items-center gap-2">
+          <input
+            id="pc-ms"
+            type="text"
+            inputMode="decimal"
+            value={ms}
+            onChange={(e) => setMsClean(e.target.value)}
+            placeholder="ej. 22"
+            aria-label="Materia seca del aguacate en porcentaje"
+            className="flex-1 min-w-0 rounded-lg bg-slate-800 border border-slate-700 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+          />
+          <span className="text-xs text-slate-400 shrink-0">%</span>
+        </div>
+        {res ? (
+          <div className={`mt-3 rounded-xl border ${c.border} ${c.bg} p-3 flex items-start gap-2`}>
+            <span className={`w-2 h-2 rounded-full ${c.dot} mt-1.5 shrink-0`} aria-hidden="true" />
+            <p className={`text-sm ${c.text} leading-snug`}>{res.label}</p>
+          </div>
+        ) : (
+          <p className="mt-3 text-xs text-emerald-200/70 leading-snug">
+            Norma internacional: ≥ {AGUACATE_MS_MINIMO_NORMA} %. Para Colombia se propone 23–24 % como punto de cosecha.
+          </p>
+        )}
+        <p className="mt-2 text-[11px] text-slate-500">Fuente: AGROSAVIA; norma de exportación · confianza alta.</p>
+      </section>
+
+      {/* Otros cultivos — reglas cualitativas honestas */}
+      <div className="flex flex-col gap-3">
+        <RegistroCosecha
+          titulo="Uchuva"
+          texto="El punto se lee por el color del capacho (cáliz) y del fruto. La variedad andina llega a ~14,5 °Brix, buenos para consumo y guardado."
+          fuente="AGROSAVIA · confianza media-alta"
+        />
+        <RegistroCosecha
+          titulo="Climatéricos (banano, plátano, mango, tomate, papaya)"
+          texto="Se cosechan fisiológicamente maduros pero FIRMES y maduran después. Para consumo local puede esperar más color; para transporte largo, coséchelos más verdes."
+          fuente="FAO · confianza alta"
+        />
+      </div>
+
+      <p className="text-xs text-slate-500 leading-relaxed">
+        <Info size={13} className="inline mr-1 -mt-0.5" />
+        Los índices por cultivo (color exacto, Brix, días desde floración) están pendientes de anclar a la ficha
+        primaria de cada especie (dato en camino). Para su cultivo, consulte al agente o a su técnico.
+      </p>
+    </div>
+  );
+}
+
+function RegistroCosecha({ titulo, texto, fuente }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+      <h3 className="text-sm font-bold text-slate-100 flex items-center gap-2">
+        <Wheat size={16} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+        {titulo}
+      </h3>
+      <p className="text-sm text-slate-300 mt-1 leading-snug">{texto}</p>
+      <p className="mt-1.5 text-[11px] text-slate-500">Fuente: {fuente}.</p>
+    </div>
+  );
+}
+
+/* ─────────────────── Pilar 2 — Guardar bien ─────────────────── */
+function PilarGuardar() {
+  return (
+    <div className="flex flex-col gap-5">
+      {/* 2a. Calculadora de secado de grano (determinista) */}
+      <CalculadoraSecado />
+
+      {/* 2b. Curado — dos recetas OPUESTAS */}
+      <section>
+        <h2 className="text-sm uppercase tracking-wide font-bold text-slate-400 mb-2 flex items-center gap-2">
+          <Droplets size={15} /> Curado: dos recetas opuestas
+        </h2>
+        <p className="text-sm text-slate-300 leading-relaxed mb-3">
+          Curar es dejar que la cosecha <span className="font-semibold text-slate-100">cicatrice las heridas</span> antes de
+          guardarla. Pero la receta es <span className="font-semibold text-slate-100">opuesta</span> según el producto: no las confunda.
+        </p>
+        <div className="grid grid-cols-1 gap-3">
+          <CuradoCard data={CURADO.raices} icon={Droplets} accent="emerald" />
+          <CuradoCard data={CURADO.bulbos} icon={Wind} accent="amber" />
+        </div>
+      </section>
+
+      {/* 2c. Daño por frío */}
+      <section className="rounded-2xl border border-sky-800/40 bg-sky-950/20 p-4">
+        <div className="flex items-center gap-2">
+          <Snowflake size={18} className="text-sky-300 shrink-0" />
+          <h3 className="text-[15px] font-bold text-sky-200">Ojo con el frío en los tropicales</h3>
+        </div>
+        <p className="text-sm text-sky-100/90 mt-2 leading-relaxed">
+          Muchos productos tropicales se dañan por frío por debajo de 10–13 °C: se manchan y no maduran.
+          <span className="font-semibold"> No los meta a la nevera.</span>
+        </p>
+        <ul className="mt-3 flex flex-col gap-2">
+          {DANIO_POR_FRIO.map((d) => (
+            <li key={d.producto} className="flex items-start gap-2 text-sm text-sky-100/90">
+              <span className="text-sky-400 shrink-0 mt-0.5" aria-hidden="true">•</span>
+              <span className="leading-snug"><span className="font-semibold">{d.producto}:</span> {d.nota}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* 2d. Grano hermético — sin química */}
+      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+        <h3 className="text-sm font-bold text-slate-100 flex items-center gap-2">
+          <ShieldCheck size={16} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+          El silo hermético mata el gorgojo sin veneno
+        </h3>
+        <p className="text-sm text-slate-300 mt-1 leading-snug">
+          Grano seco (12–13 %) en recipiente limpio y BIEN tapado: el aire se acaba y las plagas mueren sin químico.
+          En bodega abierta se pierde más del 5 % al año; con silo hermético, casi nada.
+        </p>
+        <p className="mt-1.5 text-[11px] text-slate-500">Fuente: FAO / SciELO · confianza media-alta.</p>
+      </section>
+    </div>
+  );
+}
+
+function CuradoCard({ data, icon, accent }) {
+  const Icon = icon;
+  const c = COLOR_MAP[accent];
+  return (
+    <div className={`rounded-2xl border ${c.border} ${c.bg} p-4`}>
+      <div className="flex items-center gap-2">
+        <Icon size={18} className={`${c.text} shrink-0`} />
+        <h3 className={`text-[15px] font-bold ${c.text}`}>{data.label}</h3>
+      </div>
+      <p className="text-xs text-slate-400 mt-0.5">{data.ejemplos}</p>
+      <p className="mt-2 text-sm text-slate-100">
+        Receta: <span className="font-bold">{data.receta}</span>
+      </p>
+      <p className="text-sm text-slate-300 mt-1 leading-snug">{data.porque}</p>
+      <ul className="mt-3 flex flex-col gap-2">
+        {data.detalle.map((d) => (
+          <li key={d.cultivo} className="rounded-lg border border-slate-700/50 bg-slate-900/40 p-2.5">
+            <p className="text-sm font-bold text-slate-100">{d.cultivo}</p>
+            <p className="text-sm text-slate-300 leading-snug">{d.cond}</p>
+            <p className="text-xs text-slate-400 mt-1 leading-snug">{d.ojo}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function CalculadoraSecado() {
+  const [grano, setGrano] = useState('maiz');
+  const [peso, setPeso] = useState('');
+  const [humedad, setHumedad] = useState('');
+
+  const info = GRANOS[grano];
+  const objetivo = info.humedadSegura;
+
+  const clean = (raw) => raw.replace(',', '.').replace(/[^0-9.]/g, '');
+
+  const res = useMemo(
+    () => calcularSecadoGrano({ pesoInicial: peso, humedadInicial: humedad, humedadObjetivo: objetivo }),
+    [peso, humedad, objetivo],
+  );
+
+  const humedadNum = humedad === '' ? null : Number.parseFloat(humedad.replace(',', '.'));
+  const yaSeco = humedadNum != null && Number.isFinite(humedadNum) && humedadNum > 0 && humedadNum <= objetivo;
+
+  return (
+    <section className="rounded-2xl border border-amber-800/40 bg-amber-950/20 p-4">
+      <div className="flex items-center gap-2">
+        <Sun size={20} className="text-amber-300 shrink-0" />
+        <h3 className="text-[15px] font-bold text-amber-200">Calculadora de secado de grano</h3>
+      </div>
+      <p className="text-sm text-amber-100/90 mt-2 leading-relaxed">
+        Grano que se guarda húmedo se pierde por moho. Le decimos cuánta agua debe sacar para llegar a la humedad segura
+        y cuánto le va a quedar.
+      </p>
+
+      {/* Selector de grano */}
+      <p className="mt-3 text-xs uppercase tracking-wide font-bold text-amber-200/80 mb-1.5">¿Qué grano?</p>
+      <div className="flex flex-wrap gap-2">
+        {Object.entries(GRANOS).map(([key, g]) => {
+          const activo = grano === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setGrano(key)}
+              aria-pressed={activo}
+              className={`min-h-[40px] px-3 rounded-full border text-sm font-semibold transition-colors motion-reduce:transition-none ${
+                activo ? 'border-transparent text-white' : 'bg-slate-800 border-slate-700 text-slate-200 hover:border-slate-500'
+              }`}
+              style={activo ? { backgroundColor: 'rgb(var(--t-accent-rgb) / 0.25)', boxShadow: 'inset 0 0 0 2px rgb(var(--t-accent-rgb))' } : undefined}
+            >
+              {g.label}
+            </button>
+          );
+        })}
+      </div>
+      <p className="mt-2 text-xs text-amber-100/80 leading-snug">
+        Humedad segura del {info.label.toLowerCase()}: <span className="font-bold">{info.humedadSeguraRango[0]}–{info.humedadSeguraRango[1]} %</span>.
+        {' '}{info.nota}
+      </p>
+
+      {/* Entradas */}
+      <div className="grid grid-cols-2 gap-3 mt-3">
+        <div>
+          <label htmlFor="pc-peso" className="block text-xs uppercase tracking-wide font-bold text-amber-200/80 mb-1">
+            Peso mojado
+          </label>
+          <input
+            id="pc-peso"
+            type="text"
+            inputMode="decimal"
+            value={peso}
+            onChange={(e) => setPeso(clean(e.target.value))}
+            placeholder="ej. 100"
+            aria-label="Peso mojado del grano"
+            className="w-full rounded-lg bg-slate-800 border border-slate-700 px-2.5 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+          />
+          <p className="mt-1 text-[10px] text-slate-500">kg, arrobas o bultos</p>
+        </div>
+        <div>
+          <label htmlFor="pc-hum" className="block text-xs uppercase tracking-wide font-bold text-amber-200/80 mb-1">
+            Humedad actual (%)
+          </label>
+          <input
+            id="pc-hum"
+            type="text"
+            inputMode="decimal"
+            value={humedad}
+            onChange={(e) => setHumedad(clean(e.target.value))}
+            placeholder="ej. 22"
+            aria-label="Humedad actual del grano en porcentaje"
+            className="w-full rounded-lg bg-slate-800 border border-slate-700 px-2.5 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+          />
+          <p className="mt-1 text-[10px] text-slate-500">objetivo: {objetivo} %</p>
+        </div>
+      </div>
+
+      {/* Resultado */}
+      {res ? (
+        <div className="mt-3 rounded-xl border border-emerald-700/50 bg-emerald-950/30 p-4">
+          <div className="flex items-center gap-2">
+            <CheckCircle2 size={18} className="text-emerald-300 shrink-0" />
+            <p className="text-sm font-bold text-emerald-200">Para guardar sin moho</p>
+          </div>
+          <p className="text-4xl font-black text-white mt-2 leading-none">
+            {res.aguaEliminada}
+            <span className="text-lg font-bold text-slate-300"> de agua a sacar</span>
+          </p>
+          <p className="text-sm text-emerald-200/90 mt-1.5">
+            Le quedan <span className="font-bold">{res.pesoFinal}</span> de grano seco al {objetivo} %
+            {' '}(merma de {res.mermaPorc} % en peso; la materia seca no cambia).
+          </p>
+        </div>
+      ) : yaSeco ? (
+        <div className="mt-3 rounded-xl border border-emerald-700/50 bg-emerald-950/30 p-3 flex items-start gap-2.5">
+          <CheckCircle2 size={20} className="text-emerald-300 shrink-0 mt-0.5" />
+          <p className="text-sm text-emerald-100">
+            <span className="font-bold">Ya está en punto.</span> Ese grano está igual o más seco que la humedad segura;
+            puede guardarlo hermético. No lo seque de más.
+          </p>
+        </div>
+      ) : (
+        <p className="mt-3 text-sm text-amber-100/70 text-center py-2">
+          Escriba el peso y la humedad actual (mayor que el objetivo) para calcular.
+        </p>
+      )}
+
+      <details className="mt-3 rounded-lg border border-amber-800/30 bg-amber-950/10 p-2.5">
+        <summary className="text-xs font-bold text-amber-200/90 cursor-pointer">Cómo se calcula</summary>
+        <p className="mt-1.5 text-xs text-amber-100/70 leading-relaxed">
+          Balance de masa exacto: la materia seca no cambia al secar, solo se va agua.
+          Peso final = peso × (100 − humedad actual) ÷ (100 − humedad objetivo). Las humedades seguras vienen del
+          deep research (FAO / Cenicafé), confianza alta.
+        </p>
+      </details>
+    </section>
+  );
+}
+
+/* ─────────────────── Pilar 3 — Transformar ─────────────────── */
+function PilarTransformar({ onNavigate }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-slate-300 leading-relaxed">
+        El excedente que se iba a perder puede volverse producto vendible que dura meses. Cada línea tiene
+        <span className="font-semibold text-slate-100"> un punto crítico de inocuidad</span> — casi siempre calor, limpieza y empaque sellado.
+      </p>
+
+      <div className="flex flex-col gap-3">
+        {TRANSFORMACIONES.map((t) => (
+          <article
+            key={t.id}
+            className={`rounded-2xl border p-4 ${t.critico ? 'border-rose-700/50 bg-rose-950/20' : 'border-slate-800 bg-slate-900/60'}`}
+          >
+            <h3 className={`text-[15px] font-bold ${t.critico ? 'text-rose-200' : 'text-slate-100'}`}>{t.titulo}</h3>
+            <p className="text-sm text-slate-300 mt-1 leading-snug">{t.resumen}</p>
+            <div className={`mt-2 rounded-lg p-2.5 flex items-start gap-2 ${t.critico ? 'bg-rose-950/40 border border-rose-800/40' : 'bg-slate-800/40 border border-slate-700/50'}`}>
+              <AlertTriangle size={16} className={`shrink-0 mt-0.5 ${t.critico ? 'text-rose-400' : 'text-amber-400'}`} />
+              <p className={`text-sm leading-snug ${t.critico ? 'text-rose-100 font-semibold' : 'text-slate-200'}`}>
+                <span className="font-bold">Punto crítico:</span> {t.puntoCritico}
+              </p>
+            </div>
+            <p className="text-xs text-slate-400 mt-2 leading-snug">{t.dato}</p>
+            <p className="mt-1.5 text-[11px] text-slate-500">Fuente: {t.fuente} · confianza {t.confianza}.</p>
+          </article>
+        ))}
+      </div>
+
+      {/* Inocuidad: dos capas */}
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+        <div className="flex items-center gap-2">
+          <ShieldCheck size={18} style={{ color: 'rgb(var(--t-accent-rgb))' }} className="shrink-0" />
+          <h3 className="text-[15px] font-bold text-slate-100">Inocuidad: lo gratis primero</h3>
+        </div>
+        <p className="text-sm text-slate-300 mt-2 leading-relaxed">
+          <span className="font-semibold text-slate-100">Básico y gratis (para todos):</span> agua limpia, manos limpias,
+          superficies limpias, calor donde toca y empaque sellado.
+        </p>
+        <p className="text-sm text-slate-300 mt-1.5 leading-relaxed">
+          <span className="font-semibold text-slate-100">Formal (para vender fuera de la finca):</span> BPM
+          (Resolución 2674 de 2013, INVIMA) y certificado de manipulación de alimentos. No se asuste: la inocuidad
+          empieza con lo básico.
+        </p>
+        <p className="mt-2 text-[11px] text-slate-500">Fuente: INVIMA / MinSalud · confianza alta.</p>
+      </section>
+
+      {onNavigate ? (
+        <PuenteBoton
+          icon={Sprout}
+          titulo="Pregúntele al agente"
+          sub="Receta, dosis de azúcar o pasos de inocuidad para su producto."
+          onClick={() => onNavigate('agente', { prompt: '¿Cómo transformo mi excedente sin que se dañe?' })}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/SaludSueloScreen.jsx
+++ b/src/components/SaludSueloScreen.jsx
@@ -1,0 +1,671 @@
+/* i18n (ADR-050): etiquetas user-facing en español Colombia pendientes de
+ * migrar a src/config/messages.js. Misma deuda preexistente que SoilDiagnosticScreen
+ * y App.jsx; se desactiva la regla soft a nivel de archivo. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useMemo, useState } from 'react';
+import {
+  ChevronLeft, ChevronRight, Sprout, Layers, Recycle, Calculator,
+  FlaskConical, AlertTriangle, CheckCircle2, Info, Leaf, Worm, Gauge,
+  Beaker, ArrowRight, Wheat,
+} from 'lucide-react';
+import {
+  calcularCICE,
+  calcularSaturacionAluminio,
+  interpretarSaturacionAl,
+  calcularDosisCal,
+  guardasEncalado,
+  FUENTES_CAL,
+  SATURACION_AL_OBJETIVO_DEFAULT,
+} from '../services/encaladoCalculator';
+
+/**
+ * SaludSueloScreen — mini-app "Cuaderno del Suelo" (módulo Salud del Suelo).
+ *
+ * Identidad: cuaderno de campo / Ciclo Vivo. Cálida, campesina, legible al sol.
+ *
+ * Tres pilares + caso insignia ("mi tierra está cansada / ácida"):
+ *   1. ¿Cómo está mi suelo?  — leer/interpretar un análisis (pH, MO, N-P-K, Al)
+ *      + PUENTE a la cromatografía existente (route 'cromatografia') y al
+ *      diagnóstico sin laboratorio (route 'suelo').
+ *   2. Corregir la acidez    — calculadora de encalado DETERMINISTA
+ *      (saturación de Al → dosis de cal; factores exactos = grounded-pendiente).
+ *   3. Mejorar el suelo       — materia orgánica, coberturas, abonos verdes,
+ *      micorrizas (PUENTE al grafo vía Mundo Subsuelo / agente / directorio).
+ *
+ * Coherencia (NO duplica): la cromatografía y el diagnóstico folk YA existen;
+ * esta pantalla los ENLAZA, no los reimplementa. Las micorrizas viven en el
+ * grafo (AGE) y se exponen por Mundo Subsuelo / agente; aquí se enlazan.
+ *
+ * CERO invención: el copy es estructura; las cifras finas de dosis salen de la
+ * calculadora determinista, y sus factores de zona están marcados como
+ * GROUNDED-PENDIENTE en encaladoCalculator.js.
+ */
+
+/* ── Ilustración SVG propia: perfil de suelo vivo (raíz + horizontes + fauna) ── */
+function PerfilSueloIlustracion() {
+  return (
+    <svg
+      viewBox="0 0 240 150"
+      role="img"
+      aria-label="Ilustración de un perfil de suelo vivo con raíz, lombriz y hongos"
+      className="w-full h-auto"
+    >
+      {/* Cielo / aire */}
+      <rect x="0" y="0" width="240" height="34" rx="6" fill="rgb(var(--t-accent-rgb) / 0.10)" />
+      {/* Horizonte A — materia orgánica (oscuro) */}
+      <path d="M0 34 H240 V70 Q120 62 0 70 Z" fill="#4b3a2a" />
+      {/* Horizonte B — mineral (más claro) */}
+      <path d="M0 70 Q120 62 240 70 V112 Q120 106 0 112 Z" fill="#7a5a3c" />
+      {/* Horizonte C — roca madre */}
+      <path d="M0 112 Q120 106 240 112 V150 H0 Z" fill="#8a6f52" />
+      {/* Planta */}
+      <g stroke="#3f7d3f" strokeWidth="2.4" strokeLinecap="round" fill="none">
+        <path d="M120 34 V14" />
+        <path d="M120 22 Q110 14 102 18" />
+        <path d="M120 26 Q130 18 138 22" />
+      </g>
+      {/* Raíz principal + laterales (con leve animación de crecimiento) */}
+      <g stroke="#d9b98a" strokeWidth="2" strokeLinecap="round" fill="none" className="ss-root">
+        <path d="M120 34 V120" />
+        <path d="M120 58 Q100 66 88 82" />
+        <path d="M120 74 Q140 82 152 96" />
+        <path d="M120 96 Q104 102 96 116" />
+      </g>
+      {/* Red de micorrizas (puntos difusos alrededor de la raíz) */}
+      <g fill="rgb(var(--t-accent-rgb) / 0.85)" className="ss-myco">
+        <circle cx="96" cy="80" r="2" />
+        <circle cx="150" cy="94" r="2" />
+        <circle cx="100" cy="112" r="2" />
+        <circle cx="134" cy="70" r="1.6" />
+        <circle cx="84" cy="96" r="1.6" />
+      </g>
+      {/* Lombriz */}
+      <path d="M40 92 q8 -8 16 0 q8 8 16 0" fill="none" stroke="#c56b6b" strokeWidth="3.4" strokeLinecap="round" />
+      {/* Sol */}
+      <circle cx="210" cy="18" r="9" fill="#f4c14b" className="ss-sun" />
+    </svg>
+  );
+}
+
+/* ── Indicadores del análisis (pilar 1). Umbrales = referencia general;
+ *    los cortes finos por cultivo/región son GROUNDED-PENDIENTE. ── */
+const INDICADORES_ANALISIS = [
+  {
+    key: 'ph', label: 'pH (acidez)', icon: Gauge, unidad: '', ejemplo: '5.4',
+    ayuda: 'Menos de 5.5 = tierra ácida (muchos cultivos sufren). 6.0–6.8 es lo ideal para la mayoría.',
+    // GROUNDED-PENDIENTE: rango óptimo exacto por cultivo (café/papa/aguacate…).
+    interpreta: (v) => v == null ? null
+      : v < 5.5 ? { txt: 'Ácida — conviene revisar encalado', color: 'amber' }
+      : v <= 6.8 ? { txt: 'En buen rango', color: 'emerald' }
+      : { txt: 'Alcalina — puede trabar hierro y zinc', color: 'lime' },
+  },
+  {
+    key: 'mo', label: 'Materia orgánica', icon: Leaf, unidad: '%', ejemplo: '3.2',
+    ayuda: 'Es la "comida" de la vida del suelo. Más materia orgánica = tierra más viva, más esponja, más retención.',
+    // GROUNDED-PENDIENTE: umbral de MO adecuada varía por clima (andino alto vs cálido).
+    interpreta: (v) => v == null ? null
+      : v < 2 ? { txt: 'Baja — la tierra puede estar cansada', color: 'amber' }
+      : v <= 5 ? { txt: 'Aceptable', color: 'emerald' }
+      : { txt: 'Alta — suelo con buena reserva', color: 'emerald' },
+  },
+  {
+    key: 'p', label: 'Fósforo (P)', icon: Sprout, unidad: 'ppm', ejemplo: '12',
+    ayuda: 'Clave para raíces y floración. En suelos ácidos el aluminio y el hierro lo "traban": ahí las micorrizas ayudan mucho.',
+    // GROUNDED-PENDIENTE: nivel crítico de P depende del método (Bray/Olsen) y suelo.
+    interpreta: (v) => v == null ? null
+      : v < 10 ? { txt: 'Bajo', color: 'amber' } : { txt: 'Suficiente o alto', color: 'emerald' },
+  },
+  {
+    key: 'k', label: 'Potasio (K)', icon: Wheat, unidad: 'cmol/kg', ejemplo: '0.3',
+    ayuda: 'Da vigor, resistencia y calidad al fruto. Se pierde fácil en tierras arenosas.',
+    // GROUNDED-PENDIENTE: nivel crítico de K por cultivo.
+    interpreta: (v) => v == null ? null
+      : v < 0.2 ? { txt: 'Bajo', color: 'amber' } : { txt: 'Adecuado', color: 'emerald' },
+  },
+  {
+    key: 'al_sat', label: 'Saturación de aluminio', icon: AlertTriangle, unidad: '%', ejemplo: '35',
+    ayuda: 'El aluminio libre quema las raíces. Este número decide si hace falta cal. Se calcula solo en la pestaña "Corregir la acidez".',
+    interpreta: (v) => {
+      const info = interpretarSaturacionAl(v == null ? null : v);
+      return v == null ? null : { txt: info.label, color: info.color };
+    },
+  },
+];
+
+const COLOR_MAP = {
+  emerald: { text: 'text-emerald-300', border: 'border-emerald-700/50', bg: 'bg-emerald-950/30', dot: 'bg-emerald-400' },
+  lime: { text: 'text-lime-300', border: 'border-lime-700/50', bg: 'bg-lime-950/30', dot: 'bg-lime-400' },
+  amber: { text: 'text-amber-300', border: 'border-amber-700/50', bg: 'bg-amber-950/30', dot: 'bg-amber-400' },
+  rose: { text: 'text-rose-300', border: 'border-rose-700/50', bg: 'bg-rose-950/30', dot: 'bg-rose-400' },
+  slate: { text: 'text-slate-300', border: 'border-slate-700/50', bg: 'bg-slate-900/50', dot: 'bg-slate-500' },
+};
+
+/* ── Prácticas para mejorar el suelo (pilar 3). Estructura + copy; las dosis
+ *    finas se remiten al agente/directorio (grounded). ── */
+const PRACTICAS_MEJORA = [
+  {
+    icon: Leaf, titulo: 'Subir la materia orgánica',
+    texto: 'Compost, bocashi, humus de lombriz y dejar los residuos de la cosecha. Es la base: alimenta la vida y hace la tierra más esponja.',
+  },
+  {
+    icon: Recycle, titulo: 'Coberturas vivas y muertas',
+    texto: 'Tapar el suelo con hojarasca o plantas de cobertura. Protege de la lluvia y el sol, guarda humedad y frena la erosión.',
+  },
+  {
+    icon: Sprout, titulo: 'Abonos verdes / leguminosas',
+    texto: 'Fríjol de abono, crotalaria, canavalia. Las leguminosas fijan nitrógeno del aire con sus bacterias: abonan sin bolsa.',
+  },
+  {
+    icon: Worm, titulo: 'Cuidar la vida del suelo',
+    texto: 'Menos remoción, menos veneno. Lombrices, hongos y bacterias son los que trabajan la tierra por usted.',
+  },
+];
+
+/* ═══════════════════════════════ Componente ═══════════════════════════════ */
+/**
+ * @param {Object} props
+ * @param {() => void} props.onBack
+ * @param {(view: string, data?: any) => void} [props.onNavigate]
+ */
+export default function SaludSueloScreen({ onBack, onNavigate }) {
+  const [pilar, setPilar] = useState('hub'); // hub | analisis | acidez | mejorar
+
+  const volver = () => {
+    if (pilar === 'hub') { onBack?.(); return; }
+    setPilar('hub');
+  };
+
+  const Header = (
+    <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
+      <button
+        type="button"
+        onClick={volver}
+        aria-label="Volver"
+        className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
+      >
+        <ChevronLeft size={20} />
+      </button>
+      <div>
+        <h1 className="text-lg font-bold leading-tight text-white">Cuaderno del Suelo</h1>
+        <p className="text-xs text-slate-400 leading-tight">
+          {pilar === 'hub' ? 'La salud de su tierra, paso a paso.'
+            : pilar === 'analisis' ? '¿Cómo está mi suelo?'
+            : pilar === 'acidez' ? 'Corregir la acidez'
+            : 'Mejorar el suelo'}
+        </p>
+      </div>
+    </header>
+  );
+
+  return (
+    <div className="min-h-[100dvh] text-white">
+      {Header}
+      <div className="px-4 pb-10">
+        {pilar === 'hub' && <Hub onIr={setPilar} onNavigate={onNavigate} />}
+        {pilar === 'analisis' && <PilarAnalisis onNavigate={onNavigate} onIr={setPilar} />}
+        {pilar === 'acidez' && <PilarAcidez />}
+        {pilar === 'mejorar' && <PilarMejora onNavigate={onNavigate} />}
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────── Hub ─────────────────────────────────── */
+function Hub({ onIr, onNavigate }) {
+  const pilares = [
+    { key: 'analisis', icon: Gauge, titulo: '¿Cómo está mi suelo?', desc: 'Lea su análisis: pH, materia orgánica, N-P-K y aluminio, en palabras claras.', accent: 'emerald' },
+    { key: 'acidez', icon: Calculator, titulo: 'Corregir la acidez', desc: 'Calculadora de cal: de la saturación de aluminio a los bultos por hectárea.', accent: 'amber' },
+    { key: 'mejorar', icon: Leaf, titulo: 'Mejorar el suelo', desc: 'Materia orgánica, coberturas, abonos verdes y micorrizas para una tierra viva.', accent: 'lime' },
+  ];
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Caso insignia — el léxico campesino como entrada */}
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 overflow-hidden">
+        <div className="p-4 pb-3">
+          <PerfilSueloIlustracion />
+        </div>
+        <div className="px-4 pb-4">
+          <p className="text-[13px] uppercase tracking-wide font-bold text-slate-400">Caso frecuente</p>
+          <p className="mt-1 text-[15px] text-slate-100 leading-snug">
+            <span className="font-bold">"Mi tierra está cansada y ácida, ya no da como antes."</span>
+          </p>
+          <p className="mt-2 text-sm text-slate-300 leading-relaxed">
+            Vamos por partes: primero <span className="font-semibold text-slate-100">leemos cómo está</span>,
+            luego <span className="font-semibold text-slate-100">corregimos la acidez</span> si hace falta,
+            y por último <span className="font-semibold text-slate-100">la volvemos a llenar de vida</span>.
+          </p>
+        </div>
+      </section>
+
+      {/* Tres pilares */}
+      <div className="flex flex-col gap-3">
+        {pilares.map((p, i) => {
+          const c = COLOR_MAP[p.accent];
+          const Icono = p.icon;
+          return (
+            <button
+              key={p.key}
+              type="button"
+              onClick={() => onIr(p.key)}
+              className={`text-left rounded-2xl border ${c.border} ${c.bg} p-4 flex items-start gap-3 hover:border-opacity-100 transition-colors motion-reduce:transition-none active:scale-[0.99]`}
+            >
+              <span
+                className="w-11 h-11 rounded-xl flex items-center justify-center shrink-0"
+                style={{ backgroundColor: 'rgb(var(--t-accent-rgb) / 0.20)' }}
+              >
+                <Icono size={22} className={c.text} />
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="flex items-center gap-2">
+                  <span className="text-[11px] font-bold text-slate-500">Paso {i + 1}</span>
+                </span>
+                <span className="block text-[15px] font-bold text-white leading-tight">{p.titulo}</span>
+                <span className="block text-sm text-slate-300 mt-0.5 leading-snug">{p.desc}</span>
+              </span>
+              <ChevronRight size={20} className="text-slate-500 shrink-0 mt-2" />
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Puente honesto a herramientas existentes (NO duplicar) */}
+      {onNavigate ? (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-3">
+          <p className="text-xs uppercase tracking-wide font-bold text-slate-400 mb-2">También en Chagra</p>
+          <div className="flex flex-col gap-2">
+            <PuenteBoton
+              icon={FlaskConical}
+              titulo="Cromatografía de suelo"
+              sub="Vea la vida y los minerales de su tierra en colores."
+              onClick={() => onNavigate('cromatografia')}
+            />
+            <PuenteBoton
+              icon={Sprout}
+              titulo="Diagnóstico sin laboratorio"
+              sub="Pruebas caseras honestas si aún no tiene análisis."
+              onClick={() => onNavigate('suelo')}
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function PuenteBoton({ icon, titulo, sub, onClick }) {
+  const Icon = icon;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full text-left rounded-xl border border-slate-700/60 bg-slate-800/40 p-3 flex items-center gap-3 hover:border-slate-600 transition-colors motion-reduce:transition-none"
+    >
+      <Icon size={20} className="shrink-0" style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm font-bold text-slate-100 leading-tight">{titulo}</span>
+        <span className="block text-xs text-slate-400 leading-snug">{sub}</span>
+      </span>
+      <ChevronRight size={18} className="text-slate-500 shrink-0" />
+    </button>
+  );
+}
+
+/* ───────────────────── Pilar 1 — ¿Cómo está mi suelo? ─────────────────────── */
+function PilarAnalisis({ onNavigate, onIr }) {
+  const [valores, setValores] = useState({ ph: '', mo: '', p: '', k: '', al_sat: '' });
+
+  const setV = (key, raw) => {
+    // Acepta coma decimal (uso local) y solo números.
+    const limpio = raw.replace(',', '.').replace(/[^0-9.]/g, '');
+    setValores((prev) => ({ ...prev, [key]: limpio }));
+  };
+
+  const num = (s) => (s === '' || s == null ? null : Number.parseFloat(s));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-slate-300 leading-relaxed">
+        Escriba lo que dice su análisis de suelo (el papel del laboratorio). Solo lo que tenga a mano;
+        lo que no sepa, déjelo vacío. Le traducimos cada número a palabras claras.
+      </p>
+
+      <div className="flex flex-col gap-3">
+        {INDICADORES_ANALISIS.map((ind) => {
+          const Icono = ind.icon;
+          const v = num(valores[ind.key]);
+          const res = ind.interpreta(v);
+          const c = res ? COLOR_MAP[res.color] : COLOR_MAP.slate;
+          const bloqueado = ind.key === 'al_sat';
+          return (
+            <div key={ind.key} className={`rounded-xl border ${res ? c.border : 'border-slate-800'} bg-slate-900/60 p-3`}>
+              <label className="flex items-center gap-2 text-sm font-bold text-slate-100">
+                <Icono size={18} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+                {ind.label}
+              </label>
+              <div className="mt-2 flex items-center gap-2">
+                <input
+                  type="text"
+                  inputMode="decimal"
+                  value={valores[ind.key]}
+                  onChange={(e) => setV(ind.key, e.target.value)}
+                  disabled={bloqueado}
+                  placeholder={bloqueado ? 'Se calcula en "Corregir la acidez"' : `ej. ${ind.ejemplo}`}
+                  aria-label={ind.label}
+                  className="flex-1 min-w-0 rounded-lg bg-slate-800 border border-slate-700 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500 disabled:opacity-50"
+                />
+                {ind.unidad ? <span className="text-xs text-slate-400 shrink-0">{ind.unidad}</span> : null}
+              </div>
+              {res ? (
+                <div className={`mt-2 flex items-center gap-2 text-sm ${c.text}`}>
+                  <span className={`w-2 h-2 rounded-full ${c.dot}`} aria-hidden="true" />
+                  <span className="font-semibold">{res.txt}</span>
+                </div>
+              ) : (
+                <p className="mt-2 text-xs text-slate-400 leading-snug">{ind.ayuda}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Puente a la acidez si el pH salió ácido */}
+      {num(valores.ph) != null && num(valores.ph) < 5.5 ? (
+        <button
+          type="button"
+          onClick={() => onIr('acidez')}
+          className="rounded-xl border border-amber-700/50 bg-amber-950/30 p-3 flex items-center gap-2.5 text-left hover:border-amber-600 transition-colors"
+        >
+          <Calculator size={20} className="shrink-0 text-amber-400" />
+          <span className="text-sm text-amber-100 flex-1">
+            <span className="font-bold">Su tierra salió ácida.</span> Calcule cuánta cal necesita.
+          </span>
+          <ArrowRight size={18} className="shrink-0 text-amber-400" />
+        </button>
+      ) : null}
+
+      {/* Enlace a la cromatografía como lectura complementaria */}
+      {onNavigate ? (
+        <PuenteBoton
+          icon={FlaskConical}
+          titulo="Contrástelo con una cromatografía"
+          sub="La foto de colores muestra la vida del suelo que los números no ven."
+          onClick={() => onNavigate('cromatografia')}
+        />
+      ) : null}
+
+      <p className="text-xs text-slate-500 leading-relaxed">
+        <Info size={13} className="inline mr-1 -mt-0.5" />
+        Los rangos son una guía general. El nivel exacto ideal cambia según su cultivo y su región
+        (dato pendiente de anclar por zona). Para una recomendación fina, consulte a su técnico o al agente.
+      </p>
+    </div>
+  );
+}
+
+/* ────────────────────── Pilar 2 — Corregir la acidez ──────────────────────── */
+function PilarAcidez() {
+  const [bases, setBases] = useState({ al: '', ca: '', mg: '', k: '' });
+  const [fuente, setFuente] = useState('cal_dolomita');
+  const [objetivo, setObjetivo] = useState(String(SATURACION_AL_OBJETIVO_DEFAULT));
+  const [hectareas, setHectareas] = useState('1');
+
+  const setB = (key, raw) => {
+    const limpio = raw.replace(',', '.').replace(/[^0-9.]/g, '');
+    setBases((prev) => ({ ...prev, [key]: limpio }));
+  };
+
+  const numBases = useMemo(() => ({
+    al: parseNum(bases.al), ca: parseNum(bases.ca), mg: parseNum(bases.mg), k: parseNum(bases.k),
+  }), [bases]);
+
+  const tieneMinimo = numBases.al > 0 && (numBases.ca > 0 || numBases.mg > 0);
+
+  const resultado = useMemo(() => {
+    if (!tieneMinimo) return null;
+    const cice = calcularCICE(numBases);
+    const satAl = calcularSaturacionAluminio(numBases);
+    const obj = parseNum(objetivo) || SATURACION_AL_OBJETIVO_DEFAULT;
+    const dosis = calcularDosisCal(numBases, { saturacionObjetivo: obj, fuente });
+    const avisos = guardasEncalado(numBases, satAl);
+    return { cice, satAl, dosis, avisos };
+  }, [numBases, tieneMinimo, objetivo, fuente]);
+
+  const ha = parseNum(hectareas) || 1;
+  const interpretSat = resultado ? interpretarSaturacionAl(resultado.satAl) : null;
+  const satColor = interpretSat ? COLOR_MAP[interpretSat.color] : COLOR_MAP.slate;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+        <div className="flex items-start gap-2.5">
+          <Beaker size={20} className="shrink-0 mt-0.5" style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+          <p className="text-sm text-slate-300 leading-relaxed">
+            Copie del análisis los cationes intercambiables en <span className="font-semibold text-slate-100">cmol(+)/kg</span> (a
+            veces los llaman "meq/100 g", es lo mismo). Con eso calculamos la saturación de aluminio y la cal que necesita.
+          </p>
+        </div>
+      </div>
+
+      {/* Entradas de bases */}
+      <div className="grid grid-cols-2 gap-3">
+        {[
+          { key: 'al', label: 'Aluminio (Al)', ej: '1.8' },
+          { key: 'ca', label: 'Calcio (Ca)', ej: '2.5' },
+          { key: 'mg', label: 'Magnesio (Mg)', ej: '0.8' },
+          { key: 'k', label: 'Potasio (K)', ej: '0.3' },
+        ].map((f) => (
+          <div key={f.key} className="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+            <label className="block text-sm font-bold text-slate-100 leading-tight">{f.label}</label>
+            <div className="mt-1.5 flex items-center gap-1.5">
+              <input
+                type="text"
+                inputMode="decimal"
+                value={bases[f.key]}
+                onChange={(e) => setB(f.key, e.target.value)}
+                placeholder={`ej. ${f.ej}`}
+                aria-label={f.label}
+                className="w-full min-w-0 rounded-lg bg-slate-800 border border-slate-700 px-2.5 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+              />
+            </div>
+            <p className="mt-1 text-[10px] text-slate-500">cmol(+)/kg</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Fuente de cal + objetivo + hectáreas */}
+      <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-3 flex flex-col gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-wide font-bold text-slate-400 mb-1.5">¿Qué cal va a usar?</p>
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(FUENTES_CAL).map(([key, info]) => {
+              const activo = fuente === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setFuente(key)}
+                  aria-pressed={activo}
+                  className={`min-h-[40px] px-3 rounded-full border text-sm font-semibold transition-colors ${
+                    activo ? 'border-transparent text-white' : 'bg-slate-800 border-slate-700 text-slate-200 hover:border-slate-500'
+                  }`}
+                  style={activo ? { backgroundColor: 'rgb(var(--t-accent-rgb) / 0.25)', boxShadow: 'inset 0 0 0 2px rgb(var(--t-accent-rgb))' } : undefined}
+                >
+                  {info.label}
+                </button>
+              );
+            })}
+          </div>
+          <p className="mt-1.5 text-xs text-slate-400">{FUENTES_CAL[fuente].nota} (PRNT ~{FUENTES_CAL[fuente].prnt}%)</p>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs uppercase tracking-wide font-bold text-slate-400 mb-1">Al objetivo (%)</label>
+            <input
+              type="text" inputMode="decimal" value={objetivo}
+              onChange={(e) => setObjetivo(e.target.value.replace(',', '.').replace(/[^0-9.]/g, ''))}
+              aria-label="Saturación de aluminio objetivo"
+              className="w-full rounded-lg bg-slate-800 border border-slate-700 px-2.5 py-2 text-sm text-white focus:outline-none focus:border-slate-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs uppercase tracking-wide font-bold text-slate-400 mb-1">Hectáreas</label>
+            <input
+              type="text" inputMode="decimal" value={hectareas}
+              onChange={(e) => setHectareas(e.target.value.replace(',', '.').replace(/[^0-9.]/g, ''))}
+              aria-label="Número de hectáreas"
+              className="w-full rounded-lg bg-slate-800 border border-slate-700 px-2.5 py-2 text-sm text-white focus:outline-none focus:border-slate-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Resultado */}
+      {!tieneMinimo ? (
+        <p className="text-sm text-slate-400 text-center py-4">
+          Escriba al menos el aluminio y el calcio (o magnesio) para calcular.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {/* Saturación de Al */}
+          <div className={`rounded-xl border ${satColor.border} ${satColor.bg} p-3`}>
+            <p className="text-xs uppercase tracking-wide font-bold text-slate-400">Saturación de aluminio</p>
+            <p className={`text-3xl font-black mt-0.5 ${satColor.text}`}>
+              {resultado.satAl != null ? `${resultado.satAl.toFixed(0)}%` : '—'}
+            </p>
+            <p className={`text-sm font-semibold ${satColor.text}`}>{interpretSat?.label}</p>
+          </div>
+
+          {/* Dosis */}
+          {resultado.dosis.necesitaCal ? (
+            <div className="rounded-xl border border-emerald-700/50 bg-emerald-950/30 p-4">
+              <div className="flex items-center gap-2">
+                <CheckCircle2 size={18} className="text-emerald-300 shrink-0" />
+                <p className="text-sm font-bold text-emerald-200">Dosis estimada de {resultado.dosis.fuente}</p>
+              </div>
+              <p className="text-4xl font-black text-white mt-2 leading-none">
+                {resultado.dosis.dosisRealTha.toFixed(1)}
+                <span className="text-lg font-bold text-slate-300"> t/ha</span>
+              </p>
+              <p className="text-sm text-emerald-200/90 mt-1">
+                ≈ {(resultado.dosis.dosisRealTha * 20).toFixed(0)} bultos de 50 kg por hectárea
+                {ha !== 1 ? ` · ${(resultado.dosis.dosisRealTha * ha).toFixed(1)} t para sus ${ha} ha` : ''}
+              </p>
+              <div className="mt-3 pt-3 border-t border-emerald-800/40 text-xs text-emerald-200/70 leading-relaxed">
+                Equivale a {resultado.dosis.requerimientoCmol} cmol(+)/kg de CaCO₃
+                ({resultado.dosis.dosisCaCO3Tha.toFixed(1)} t/ha puro, ajustado a PRNT {resultado.dosis.prnt}%).
+                Fórmula de Cochrane, Salinas &amp; Sánchez (1980).
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-xl border border-emerald-700/50 bg-emerald-950/30 p-4 flex items-start gap-2.5">
+              <CheckCircle2 size={20} className="text-emerald-300 shrink-0 mt-0.5" />
+              <p className="text-sm text-emerald-100">
+                <span className="font-bold">No necesita encalar.</span> La saturación de aluminio ya está
+                por debajo de su objetivo. Encalar de más bloquea fósforo, zinc y boro.
+              </p>
+            </div>
+          )}
+
+          {/* Guardas de seguridad */}
+          <div className="rounded-xl border border-amber-800/50 bg-amber-950/20 overflow-hidden">
+            <div className="flex items-center gap-2 p-3 border-b border-amber-800/30">
+              <AlertTriangle size={18} className="text-amber-400 shrink-0" />
+              <h3 className="text-sm font-bold text-amber-300">Antes de aplicar</h3>
+            </div>
+            <ul className="p-3 flex flex-col gap-2">
+              {resultado.avisos.map((a, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-amber-100/90">
+                  <span className="text-amber-400 shrink-0 mt-0.5" aria-hidden="true">•</span>
+                  <span className="leading-snug">{a}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {/* Transparencia de supuestos — honestidad grounded-pendiente */}
+      <details className="rounded-xl border border-slate-800 bg-slate-900/50 p-3">
+        <summary className="text-sm font-bold text-slate-200 cursor-pointer">Cómo se calcula (supuestos)</summary>
+        <div className="mt-2 text-xs text-slate-400 leading-relaxed flex flex-col gap-1.5">
+          <p>Saturación de Al = Al ÷ (Al + Ca + Mg + K) × 100. Es matemática exacta.</p>
+          <p>Requerimiento (cmol/kg) = 1.5 × [Al − (objetivo/100) × CICE], método de Cochrane, Salinas &amp; Sánchez (1980).</p>
+          <p>
+            <span className="font-bold text-slate-300">Pendiente de anclar por zona</span>: la conversión a
+            toneladas por hectárea usa densidad aparente y profundidad de referencia (20 cm), y el PRNT
+            típico de cada cal. Los valores exactos de <em>su</em> suelo y <em>su</em> producto cambian el
+            número. Trátelo como una estimación orientadora, no como receta cerrada.
+          </p>
+        </div>
+      </details>
+    </div>
+  );
+}
+
+/* ───────────────────────── Pilar 3 — Mejorar el suelo ─────────────────────── */
+function PilarMejora({ onNavigate }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-slate-300 leading-relaxed">
+        Corregir la acidez es el arranque. Lo que de verdad recupera una tierra cansada es
+        <span className="font-semibold text-slate-100"> devolverle vida</span>: materia orgánica, raíces
+        vivas todo el año y los aliados invisibles del suelo.
+      </p>
+
+      <div className="flex flex-col gap-3">
+        {PRACTICAS_MEJORA.map((p) => {
+          const Icono = p.icon;
+          return (
+            <div key={p.titulo} className="rounded-xl border border-slate-800 bg-slate-900/60 p-3 flex items-start gap-3">
+              <span
+                className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                style={{ backgroundColor: 'rgb(var(--t-accent-rgb) / 0.18)' }}
+              >
+                <Icono size={20} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+              </span>
+              <div>
+                <h3 className="text-sm font-bold text-slate-100">{p.titulo}</h3>
+                <p className="text-sm text-slate-300 mt-0.5 leading-snug">{p.texto}</p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Bloque micorrizas — enlaza al grafo (Mundo Subsuelo / agente), NO reimplementa */}
+      <section className="rounded-2xl border border-lime-800/40 bg-lime-950/20 p-4">
+        <div className="flex items-center gap-2">
+          <Layers size={20} className="text-lime-300 shrink-0" />
+          <h3 className="text-[15px] font-bold text-lime-200">Micorrizas: el internet del suelo</h3>
+        </div>
+        <p className="text-sm text-lime-100/90 mt-2 leading-relaxed">
+          Son hongos que se unen a las raíces y les extienden el alcance para buscar agua y fósforo,
+          justo el que la tierra ácida traba. Cuidarlas (menos veneno, menos arado) vale más que muchas bolsas de abono.
+        </p>
+        {onNavigate ? (
+          <div className="mt-3 flex flex-col gap-2">
+            <PuenteBoton
+              icon={Worm}
+              titulo="Mundo Subsuelo"
+              sub="Vea cómo trabajan las micorrizas y la vida del suelo, paso a paso."
+              onClick={() => onNavigate('subsuelo')}
+            />
+            <PuenteBoton
+              icon={Sprout}
+              titulo="Pregúntele al agente"
+              sub="Qué especies asociar, con qué inocular y cómo cuidar sus micorrizas."
+              onClick={() => onNavigate('agente', { prompt: '¿Cómo cuido las micorrizas de mi suelo?' })}
+            />
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
+/* util local */
+function parseNum(s) {
+  if (s === '' || s == null) return 0;
+  const n = Number.parseFloat(String(s).replace(',', '.'));
+  return Number.isFinite(n) ? n : 0;
+}

--- a/src/components/__tests__/EstiercolScreen.test.jsx
+++ b/src/components/__tests__/EstiercolScreen.test.jsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+import EstiercolScreen from '../EstiercolScreen';
+
+// ScreenShell trae NotificationsBell (fetch clima, IDB, useTheme…) —
+// passthrough simple para probar el CONTENIDO del módulo.
+vi.mock('../common/ScreenShell', () => ({
+  ScreenShell: ({ title, children }) => (
+    <div><h1>{title}</h1>{children}</div>
+  ),
+}));
+
+describe('EstiercolScreen — "Del corral al abono"', () => {
+  it('abre en el inicio con el título y los tres accesos', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    expect(screen.getByRole('heading', { name: /Del corral al abono/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Quitar el olor/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Sacar biogás/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Hacer abono/i })).toBeTruthy();
+  });
+
+  it('Olores muestra el caso real de la gallinaza', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    fireEvent.click(within(screen.getByTestId('estiercol-pilares')).getByText('Olores'));
+    expect(screen.getByText(/huele muy feo y los vecinos se quejan/i)).toBeTruthy();
+    expect(screen.getByText(/Por qué huele/i)).toBeTruthy();
+    expect(screen.getByText(/Cómo quitarle el olor/i)).toBeTruthy();
+  });
+
+  it('la calculadora del biodigestor arranca en el caso insignia (300 cerdos)', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    fireEvent.click(within(screen.getByTestId('estiercol-pilares')).getByText('Biodigestor'));
+    const input = screen.getByLabelText(/Cuántos cerdos/i);
+    expect(input.value).toBe('300');
+    // Resultados coherentes con la fórmula (72 m³/día de biogás para 300 cerdos).
+    const res = screen.getByTestId('biodigestor-resultados');
+    expect(within(res).getByText('72')).toBeTruthy();
+  });
+
+  it('la calculadora recalcula al cambiar el número de animales', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    fireEvent.click(within(screen.getByTestId('estiercol-pilares')).getByText('Biodigestor'));
+    const input = screen.getByLabelText(/Cuántos cerdos/i);
+    fireEvent.change(input, { target: { value: '100' } });
+    // 100 cerdos → 24 m³/día de biogás.
+    const res = screen.getByTestId('biodigestor-resultados');
+    expect(within(res).getByText('24')).toBeTruthy();
+  });
+
+  it('Abonos lista los siete abonos y marca el slot grounded-pendiente al abrir', () => {
+    render(<EstiercolScreen onBack={() => {}} onHome={() => {}} />);
+    fireEvent.click(within(screen.getByTestId('estiercol-pilares')).getByText('Abonos'));
+    for (const nombre of ['Gallinaza', 'Porquinaza', 'Bovinaza (boñiga)', 'Biol', 'Biosol', 'Compost', 'Lombricompost']) {
+      expect(screen.getByText(nombre)).toBeTruthy();
+    }
+    // Sin abrir ninguna tarjeta, no hay slots visibles.
+    expect(screen.queryAllByTestId('grounded-slot').length).toBe(0);
+    fireEvent.click(screen.getByText('Gallinaza'));
+    expect(screen.getAllByTestId('grounded-slot').length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/__tests__/PoscosechaScreen.test.jsx
+++ b/src/components/__tests__/PoscosechaScreen.test.jsx
@@ -1,0 +1,103 @@
+/**
+ * PoscosechaScreen — mini-app "Poscosecha y Despensa" (mundo Mercado y despensa).
+ *
+ * Contrato cubierto:
+ *   - Hub: gancho (pérdida país) + los tres pilares navegables.
+ *   - Pilar 1: la materia seca del aguacate se evalúa contra el umbral.
+ *   - Pilar 2: la calculadora de secado produce el agua a sacar (balance de masa)
+ *     y las dos recetas OPUESTAS de curado aparecen.
+ *   - Pilar 3: el queso está marcado como punto crítico (pasteurizar).
+ *   - Puentes: enlaza a la bodega existente sin reimplementarla.
+ *   - onBack desde el hub; volver desde un pilar regresa al hub.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import PoscosechaScreen from '../PoscosechaScreen';
+
+afterEach(() => cleanup());
+
+const irA = (nombre) => fireEvent.click(screen.getByRole('button', { name: nombre }));
+
+describe('PoscosechaScreen — hub', () => {
+  it('muestra el gancho y los tres pilares', () => {
+    render(<PoscosechaScreen onBack={() => {}} onNavigate={() => {}} />);
+    expect(screen.getByText(/1 de cada 3 productos/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Cosechar en punto/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Guardar bien/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Transformar/i })).toBeTruthy();
+  });
+
+  it('botón volver llama onBack desde el hub', () => {
+    const onBack = vi.fn();
+    render(<PoscosechaScreen onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: /Volver/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('enlaza a la bodega existente (no la reimplementa)', () => {
+    const onNavigate = vi.fn();
+    render(<PoscosechaScreen onBack={() => {}} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByRole('button', { name: /Bodega de insumos/i }));
+    expect(onNavigate).toHaveBeenCalledWith('bodega');
+  });
+});
+
+describe('PoscosechaScreen — pilar 1: cosechar en punto', () => {
+  it('evalúa la materia seca del aguacate contra el umbral', () => {
+    render(<PoscosechaScreen onBack={() => {}} />);
+    irA(/Cosechar en punto/i);
+    const input = screen.getByLabelText(/Materia seca del aguacate/i);
+    fireEvent.change(input, { target: { value: '19' } });
+    expect(screen.getByText(/Aún verde/i)).toBeTruthy();
+    fireEvent.change(input, { target: { value: '24' } });
+    expect(screen.getByText(/punto óptimo/i)).toBeTruthy();
+  });
+});
+
+describe('PoscosechaScreen — pilar 2: guardar bien', () => {
+  it('la calculadora de secado produce el agua a sacar', () => {
+    render(<PoscosechaScreen onBack={() => {}} />);
+    irA(/Guardar bien/i);
+    fireEvent.change(screen.getByLabelText(/Peso mojado del grano/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Humedad actual del grano/i), { target: { value: '22' } });
+    expect(screen.getByText(/de agua a sacar/i)).toBeTruthy();
+    expect(screen.getByText(/de grano seco/i)).toBeTruthy();
+  });
+
+  it('avisa cuando el grano ya está en punto', () => {
+    render(<PoscosechaScreen onBack={() => {}} />);
+    irA(/Guardar bien/i);
+    fireEvent.change(screen.getByLabelText(/Peso mojado del grano/i), { target: { value: '100' } });
+    // 12 % ya está por debajo del objetivo del maíz (13 %)
+    fireEvent.change(screen.getByLabelText(/Humedad actual del grano/i), { target: { value: '12' } });
+    expect(screen.getByText(/Ya está en punto/i)).toBeTruthy();
+  });
+
+  it('muestra las dos recetas OPUESTAS de curado', () => {
+    render(<PoscosechaScreen onBack={() => {}} />);
+    irA(/Guardar bien/i);
+    expect(screen.getByText(/Raíces y tubérculos/i)).toBeTruthy();
+    expect(screen.getByText(/Cebolla y ajo/i)).toBeTruthy();
+    // receta húmeda vs seca
+    expect(screen.getAllByText(/húmedo/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/seco/i).length).toBeGreaterThan(0);
+  });
+});
+
+describe('PoscosechaScreen — pilar 3: transformar', () => {
+  it('el queso lleva el punto crítico de pasteurizar', () => {
+    render(<PoscosechaScreen onBack={() => {}} />);
+    irA(/Transformar/i);
+    expect(screen.getByText(/^Quesos$/i)).toBeTruthy();
+    expect(screen.getByText(/PASTEURICE/i)).toBeTruthy();
+  });
+
+  it('vuelve al hub con el botón volver desde un pilar', () => {
+    const onBack = vi.fn();
+    render(<PoscosechaScreen onBack={onBack} />);
+    irA(/Transformar/i);
+    fireEvent.click(screen.getByRole('button', { name: /Volver/i }));
+    expect(within(document.body).getByText(/1 de cada 3 productos/i)).toBeTruthy();
+    expect(onBack).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/SaludSueloScreen.test.jsx
+++ b/src/components/__tests__/SaludSueloScreen.test.jsx
@@ -1,0 +1,117 @@
+/**
+ * SaludSueloScreen — mini-app "Cuaderno del Suelo" (módulo Salud del Suelo).
+ *
+ * Contrato cubierto:
+ *   - Hub: caso insignia + los tres pilares navegables.
+ *   - Pilar 1: interpreta valores del análisis (pH ácido → aviso).
+ *   - Pilar 2: la calculadora de encalado produce una dosis con la fórmula.
+ *   - Pilar 3: enlaza a micorrizas (Mundo Subsuelo) sin reimplementarlas.
+ *   - Puentes: enlaza a la cromatografía y al diagnóstico folk existentes.
+ *   - onBack desde el hub.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import SaludSueloScreen from '../SaludSueloScreen';
+
+afterEach(() => cleanup());
+
+const irA = (nombre) => fireEvent.click(screen.getByRole('button', { name: nombre }));
+
+describe('SaludSueloScreen — hub', () => {
+  it('muestra el caso insignia y los tres pilares', () => {
+    render(<SaludSueloScreen onBack={() => {}} onNavigate={() => {}} />);
+    expect(screen.getByText(/está cansada y ácida/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /¿Cómo está mi suelo\?/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Corregir la acidez/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Mejorar el suelo/i })).toBeTruthy();
+  });
+
+  it('botón volver llama onBack desde el hub', () => {
+    const onBack = vi.fn();
+    render(<SaludSueloScreen onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: /Volver/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('enlaza a la cromatografía existente (no la reimplementa)', () => {
+    const onNavigate = vi.fn();
+    render(<SaludSueloScreen onBack={() => {}} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByRole('button', { name: /Cromatografía de suelo/i }));
+    expect(onNavigate).toHaveBeenCalledWith('cromatografia');
+  });
+
+  it('enlaza al diagnóstico sin laboratorio existente', () => {
+    const onNavigate = vi.fn();
+    render(<SaludSueloScreen onBack={() => {}} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByRole('button', { name: /Diagnóstico sin laboratorio/i }));
+    expect(onNavigate).toHaveBeenCalledWith('suelo');
+  });
+});
+
+describe('SaludSueloScreen — pilar 1: ¿cómo está mi suelo?', () => {
+  it('interpreta un pH ácido y ofrece pasar a la calculadora', () => {
+    render(<SaludSueloScreen onBack={() => {}} onNavigate={() => {}} />);
+    irA(/¿Cómo está mi suelo\?/i);
+    const phInput = screen.getByLabelText(/pH \(acidez\)/i);
+    fireEvent.change(phInput, { target: { value: '5.1' } });
+    expect(screen.getAllByText(/Ácida/i).length).toBeGreaterThan(0);
+    // aparece el puente a la calculadora de acidez
+    expect(screen.getByText(/salió ácida/i)).toBeTruthy();
+  });
+
+  it('acepta coma decimal en las entradas', () => {
+    render(<SaludSueloScreen onBack={() => {}} />);
+    irA(/¿Cómo está mi suelo\?/i);
+    const moInput = screen.getByLabelText(/Materia orgánica/i);
+    fireEvent.change(moInput, { target: { value: '1,2' } });
+    expect(moInput.value).toBe('1.2');
+    expect(screen.getByText(/Baja/i)).toBeTruthy();
+  });
+});
+
+describe('SaludSueloScreen — pilar 2: calculadora de encalado', () => {
+  it('calcula la saturación de aluminio y una dosis de cal', () => {
+    render(<SaludSueloScreen onBack={() => {}} />);
+    irA(/Corregir la acidez/i);
+    fireEvent.change(screen.getByLabelText(/Aluminio \(Al\)/i), { target: { value: '1.8' } });
+    fireEvent.change(screen.getByLabelText(/Calcio \(Ca\)/i), { target: { value: '2.5' } });
+    fireEvent.change(screen.getByLabelText(/Magnesio \(Mg\)/i), { target: { value: '0.8' } });
+    fireEvent.change(screen.getByLabelText(/Potasio \(K\)/i), { target: { value: '0.3' } });
+    // saturación ~33%
+    expect(screen.getByText(/33%/)).toBeTruthy();
+    // muestra una dosis en t/ha
+    expect(screen.getAllByText(/t\/ha/i).length).toBeGreaterThan(0);
+    // referencia honesta a la fórmula
+    expect(screen.getAllByText(/Cochrane/i).length).toBeGreaterThan(0);
+  });
+
+  it('con aluminio bajo no recomienda encalar', () => {
+    render(<SaludSueloScreen onBack={() => {}} />);
+    irA(/Corregir la acidez/i);
+    fireEvent.change(screen.getByLabelText(/Aluminio \(Al\)/i), { target: { value: '0.2' } });
+    fireEvent.change(screen.getByLabelText(/Calcio \(Ca\)/i), { target: { value: '4' } });
+    fireEvent.change(screen.getByLabelText(/Magnesio \(Mg\)/i), { target: { value: '1.5' } });
+    expect(screen.getByText(/No necesita encalar/i)).toBeTruthy();
+  });
+});
+
+describe('SaludSueloScreen — pilar 3: mejorar el suelo / micorrizas', () => {
+  it('enlaza a Mundo Subsuelo para las micorrizas (grafo)', () => {
+    const onNavigate = vi.fn();
+    render(<SaludSueloScreen onBack={() => {}} onNavigate={onNavigate} />);
+    irA(/Mejorar el suelo/i);
+    expect(screen.getByText(/el internet del suelo/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Mundo Subsuelo/i }));
+    expect(onNavigate).toHaveBeenCalledWith('subsuelo');
+  });
+
+  it('vuelve al hub con el botón volver desde un pilar', () => {
+    const onBack = vi.fn();
+    render(<SaludSueloScreen onBack={onBack} />);
+    irA(/Mejorar el suelo/i);
+    fireEvent.click(screen.getByRole('button', { name: /Volver/i }));
+    // de vuelta en el hub: se ve el caso insignia; onBack NO se llamó aún
+    expect(within(document.body).getByText(/está cansada y ácida/i)).toBeTruthy();
+    expect(onBack).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/agua/AguaScreen.jsx
+++ b/src/components/agua/AguaScreen.jsx
@@ -1,0 +1,537 @@
+import React, { useMemo, useState } from 'react';
+import {
+  CloudRain, Droplets, Sprout, Calculator, TriangleAlert, Sun,
+  ShieldCheck, Users, Hourglass, Milk, ChevronRight,
+} from 'lucide-react';
+import { ScreenShell } from '../common/ScreenShell';
+import CaminoDelAgua from './CaminoDelAgua';
+import {
+  litrosLluviaCaptables,
+  canecasEquivalentes,
+  porcentajeTanque,
+  etcDiaria,
+  litrosRiegoDia,
+  COEF_ESCORRENTIA_TECHO_DEFAULT,
+  LITROS_POR_CANECA_55GAL,
+} from '../../services/aguaCalculos';
+import {
+  PILARES_AGUA,
+  PASOS_COSECHA,
+  KC_CULTIVOS,
+  SISTEMAS_RIEGO,
+  PRACTICAS_AHORRO,
+  USOS_DEL_AGUA,
+  SENALES_ALERTA_AGUA,
+  DOSIS_POTABILIZACION,
+  RONDA_PROTECCION,
+  CASO_NACIMIENTO,
+} from '../../data/aguaFinca';
+import { getEnsoPhase, getEnsoLabel } from '../../services/ensoService';
+import './agua.css';
+
+/**
+ * AguaScreen — módulo "Agua de la finca": manejo del agua para el campesino.
+ *
+ * Tres pilares (cuaderno de campo, un solo camino visual):
+ *   1. Cosechar la lluvia — calculadora determinista techo × lluvia → litros.
+ *   2. Regar con medida  — ETc = ETo × Kc (fórmula FAO); Kc/ETo reales son
+ *      slots grounded-pendiente (src/data/aguaFinca.js), NO se inventan.
+ *   3. Cuidar el agua    — calidad/potabilidad + proteger el nacimiento, con
+ *      el caso insignia "se me seca el nacimiento en verano". Se conecta con
+ *      el ciclo ENSO que Chagra ya sigue (ensoService) — no se re-implementa.
+ *
+ * Toda cifra dura pendiente de grounding se pinta como "dato en camino"
+ * (SlotPendiente), nunca como número inventado.
+ */
+
+const fmt = (n) => Number(n).toLocaleString('es-CO');
+
+/** Chip honesto para cifras aún sin grounding: promete el dato, no lo inventa. */
+function SlotPendiente({ children }) {
+  return (
+    <span
+      data-testid="slot-grounded-pendiente"
+      className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] font-bold text-amber-300"
+    >
+      <Hourglass size={11} aria-hidden="true" />
+      {children || 'Dato en camino'}
+    </span>
+  );
+}
+
+/** Campo numérico grande, legible al sol, con etiqueta arriba y unidad al lado. */
+function CampoNumero({ id, label, unidad, value, onChange, placeholder, hint }) {
+  return (
+    <label htmlFor={id} className="block">
+      <span className="block text-xs font-bold uppercase tracking-wide text-slate-300 mb-1">{label}</span>
+      <span className="flex items-center gap-2 rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 focus-within:border-cyan-500">
+        <input
+          id={id}
+          data-testid={id}
+          type="number"
+          inputMode="decimal"
+          min="0"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="w-full bg-transparent text-lg font-black text-white outline-none placeholder:text-slate-600"
+        />
+        <span className="shrink-0 text-sm font-bold text-slate-400">{unidad}</span>
+      </span>
+      {hint && <span className="block mt-1 text-[11px] leading-snug text-slate-400">{hint}</span>}
+    </label>
+  );
+}
+
+/* ── PILAR 1 · Cosechar la lluvia ─────────────────────────────────────── */
+function PilarLluvia() {
+  const [areaTecho, setAreaTecho] = useState('');
+  const [lluviaMes, setLluviaMes] = useState('');
+  const [capacidad, setCapacidad] = useState('1000');
+
+  const litros = useMemo(
+    () => litrosLluviaCaptables({ areaTechoM2: areaTecho, lluviaMm: lluviaMes }),
+    [areaTecho, lluviaMes],
+  );
+  const canecas = litros != null ? canecasEquivalentes(litros) : null;
+  const nivel = litros != null ? porcentajeTanque({ litros, capacidadL: capacidad }) : null;
+
+  return (
+    <section className="agua-seccion space-y-4" data-testid="pilar-lluvia">
+      <p className="text-sm leading-relaxed text-slate-200">
+        Cada aguacero que cae sobre su techo es agua que ya pagó el cielo. Con un
+        canal y un tanque, ese techo se vuelve la primera fuente de agua de la
+        finca — y cada caneca guardada es agua que en verano no se le saca al
+        nacimiento.
+      </p>
+
+      {/* Calculadora determinista: área × lluvia × 0.8 */}
+      <div className="rounded-2xl border border-cyan-700/40 bg-slate-900/60 p-4 space-y-3">
+        <p className="flex items-center gap-2 text-sm font-black text-cyan-300 uppercase tracking-wide">
+          <Calculator size={16} aria-hidden="true" /> Cuánta agua le cae al techo
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <CampoNumero
+            id="agua-area-techo"
+            label="Techo"
+            unidad="m²"
+            value={areaTecho}
+            onChange={setAreaTecho}
+            placeholder="60"
+            hint="Largo × ancho del piso que cubre el techo."
+          />
+          <CampoNumero
+            id="agua-lluvia-mes"
+            label="Lluvia del mes"
+            unidad="mm"
+            value={lluviaMes}
+            onChange={setLluviaMes}
+            placeholder="120"
+            hint="De su pluviómetro o del módulo de clima."
+          />
+        </div>
+        <p className="text-[11px] leading-snug text-slate-400">
+          El dato de lluvia típica de su municipio llegará solo al módulo{' '}
+          <SlotPendiente>lluvia por zona en camino (IDEAM)</SlotPendiente>. Mientras
+          tanto, digite el suyo.
+        </p>
+
+        {litros != null ? (
+          <div className="flex items-center gap-4 rounded-xl border border-cyan-600/40 bg-cyan-950/40 p-3" data-testid="calc-lluvia-resultado">
+            {/* tanque con nivel animado (scaleY) */}
+            <svg viewBox="0 0 44 56" className="w-12 h-16 shrink-0" aria-hidden="true">
+              <rect x="4" y="4" width="36" height="48" rx="6" fill="none" stroke="currentColor" strokeWidth="3" className="text-slate-400" />
+              <g>
+                <rect
+                  x="8" y="8" width="28" height="40" rx="3"
+                  fill="currentColor"
+                  className="text-cyan-400/80 agua-nivel"
+                  style={{ transform: `scaleY(${Math.max(nivel ?? 0, 4) / 100})` }}
+                />
+              </g>
+            </svg>
+            <div className="min-w-0">
+              <p className="text-2xl font-black text-white leading-none">
+                {fmt(litros)} <span className="text-base font-bold text-cyan-300">litros al mes</span>
+              </p>
+              <p className="mt-1 text-xs text-slate-300">
+                ≈ {fmt(canecas)} canecas de 55 galones ({LITROS_POR_CANECA_55GAL} L).
+                {nivel != null && Number(capacidad) > 0 && (
+                  <> Su tanque de {fmt(capacidad)} L quedaría al <strong className="text-cyan-200">{nivel}%</strong>{nivel >= 100 ? ' — ¡y sobra!' : '.'}</>
+                )}
+              </p>
+              <p className="mt-1 text-[10px] text-slate-500">
+                Cuenta hecha con el {Math.round(COEF_ESCORRENTIA_TECHO_DEFAULT * 100)}% de la lluvia: una parte siempre se pierde en salpique y primeras lavadas.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <p className="text-xs italic text-slate-500" data-testid="calc-lluvia-vacia">
+            Digite el techo y la lluvia para ver los litros.
+          </p>
+        )}
+
+        <CampoNumero
+          id="agua-capacidad-tanque"
+          label="¿De cuánto es su tanque? (opcional)"
+          unidad="L"
+          value={capacidad}
+          onChange={setCapacidad}
+          placeholder="1000"
+        />
+      </div>
+
+      {/* Pasos del sistema — es una secuencia real de construcción */}
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4">
+        <p className="text-sm font-black text-slate-100 uppercase tracking-wide mb-3">Del techo al tanque, en orden</p>
+        <ol className="space-y-3">
+          {PASOS_COSECHA.map((paso, i) => (
+            <li key={paso.id} className="flex gap-3">
+              <span aria-hidden="true" className="shrink-0 w-6 h-6 rounded-full bg-cyan-500/20 border border-cyan-500/40 text-cyan-300 text-xs font-black grid place-items-center">
+                {i + 1}
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-bold text-slate-100 leading-tight">{paso.titulo}</p>
+                <p className="text-xs leading-snug text-slate-300 mt-0.5">{paso.detalle}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+/* ── PILAR 2 · Regar con medida ───────────────────────────────────────── */
+function PilarRiego() {
+  const [eto, setEto] = useState('');
+  const [kc, setKc] = useState('');
+  const [area, setArea] = useState('');
+
+  const etc = useMemo(() => etcDiaria({ etoMmDia: eto, kc }), [eto, kc]);
+  const litrosDia = useMemo(
+    () => (etc != null ? litrosRiegoDia({ etcMmDia: etc, areaM2: area }) : null),
+    [etc, area],
+  );
+
+  return (
+    <section className="agua-seccion space-y-4" data-testid="pilar-riego">
+      <p className="text-sm leading-relaxed text-slate-200">
+        Regar no es empapar: es darle a la mata lo que ese día transpiró y ni una
+        gota más. Esa cuenta tiene nombre — <strong className="text-teal-300">ETc</strong>,
+        el consumo diario del cultivo — y se saca multiplicando el clima de su zona
+        (ETo) por el apetito de agua de cada cultivo (Kc).
+      </p>
+
+      <div className="rounded-2xl border border-teal-700/40 bg-slate-900/60 p-4 space-y-3">
+        <p className="flex items-center gap-2 text-sm font-black text-teal-300 uppercase tracking-wide">
+          <Calculator size={16} aria-hidden="true" /> La cuenta del riego
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <CampoNumero
+            id="agua-eto"
+            label="ETo de su zona"
+            unidad="mm/día"
+            value={eto}
+            onChange={setEto}
+            placeholder="—"
+            hint="Cuánta agua 'pide' el clima al día."
+          />
+          <CampoNumero
+            id="agua-kc"
+            label="Kc del cultivo"
+            unidad=""
+            value={kc}
+            onChange={setKc}
+            placeholder="—"
+            hint="El apetito del cultivo (entre 0.2 y 1.3)."
+          />
+        </div>
+        <CampoNumero
+          id="agua-area-riego"
+          label="Área sembrada"
+          unidad="m²"
+          value={area}
+          onChange={setArea}
+          placeholder="100"
+        />
+        <p className="text-[11px] leading-snug text-slate-400">
+          La ETo por piso térmico y el Kc de cada cultivo del directorio llegarán
+          con fuente citada <SlotPendiente>ETo y Kc en camino (FAO-56 / IDEAM)</SlotPendiente>.
+          Si ya los conoce, la cuenta le sirve desde hoy.
+        </p>
+
+        {litrosDia != null ? (
+          <div className="rounded-xl border border-teal-600/40 bg-teal-950/40 p-3" data-testid="calc-riego-resultado">
+            <p className="text-2xl font-black text-white leading-none">
+              {fmt(litrosDia)} <span className="text-base font-bold text-teal-300">litros al día</span>
+            </p>
+            <p className="mt-1 text-xs text-slate-300">
+              Consumo del cultivo: <strong className="text-teal-200">{etc} mm/día</strong> (ETo × Kc) sobre {fmt(area)} m².
+              Es la necesidad de la planta: según el sistema de riego, una parte se pierde por el camino.
+            </p>
+          </div>
+        ) : (
+          <p className="text-xs italic text-slate-500" data-testid="calc-riego-vacia">
+            Digite ETo, Kc y área para ver los litros diarios.
+          </p>
+        )}
+
+        {/* Kc por cultivo: slots honestos, se llenan por grounding */}
+        <div>
+          <p className="text-xs font-bold uppercase tracking-wide text-slate-300 mb-1.5">Kc por cultivo</p>
+          <div className="flex flex-wrap gap-1.5">
+            {KC_CULTIVOS.map((c) => (
+              <span key={c.slug} className="inline-flex items-center gap-1.5 rounded-full border border-slate-700 bg-slate-950/50 px-2.5 py-1 text-xs font-bold text-slate-200">
+                {c.nombre}
+                {c.kc == null ? <SlotPendiente /> : <span className="text-teal-300">{c.kc}</span>}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Sistemas de riego: comparación cualitativa, sin cifras inventadas */}
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 space-y-3">
+        <p className="text-sm font-black text-slate-100 uppercase tracking-wide">Con qué riega, cuánto pierde</p>
+        {SISTEMAS_RIEGO.map((s) => (
+          <div key={s.id} className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3">
+            <p className="flex flex-wrap items-center gap-2 text-sm font-bold text-slate-100 leading-tight">
+              {s.nombre}
+              <span className="rounded-full bg-slate-700/50 px-2 py-0.5 text-[11px] font-bold text-slate-300">{s.pierde}</span>
+            </p>
+            <p className="text-xs leading-snug text-slate-300 mt-1">{s.detalle}</p>
+          </div>
+        ))}
+        <p className="text-[11px] leading-snug text-slate-400">
+          El porcentaje exacto de eficiencia de cada sistema{' '}
+          <SlotPendiente>eficiencias en camino (FAO)</SlotPendiente> — el orden, eso sí,
+          no cambia: goteo rinde más que aspersión, y aspersión más que el surco.
+        </p>
+      </div>
+
+      {/* Prácticas de ahorro */}
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4">
+        <p className="text-sm font-black text-slate-100 uppercase tracking-wide mb-3">Menos sed con el mismo cielo</p>
+        <ul className="space-y-3">
+          {PRACTICAS_AHORRO.map((p) => (
+            <li key={p.id} className="flex gap-3">
+              <Sprout size={18} aria-hidden="true" className="shrink-0 text-lime-400 mt-0.5" />
+              <div className="min-w-0">
+                <p className="text-sm font-bold text-slate-100 leading-tight">{p.titulo}</p>
+                <p className="text-xs leading-snug text-slate-300 mt-0.5">{p.detalle}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+/* ── PILAR 3 · Cuidar el agua ─────────────────────────────────────────── */
+function PilarCuidar() {
+  // Fase ENSO viva desde el servicio que Chagra ya tiene (no se re-implementa
+  // clima aquí; solo se lee para aterrizar el consejo del caso insignia).
+  const fase = getEnsoPhase();
+  const faseLabel = getEnsoLabel();
+  const consejoEnso = {
+    el_nino: 'Fase actual: El Niño — se espera menos lluvia de lo normal. Guarde desde ya y racione temprano: este es el verano que seca nacimientos.',
+    la_nina: 'Fase actual: La Niña — se espera más lluvia de lo normal. Aproveche: llene tanques, siembre la protección del nacimiento y revise canales.',
+    neutral: 'Fase actual: Neutral — el año viene sin Niño ni Niña encima, pero el verano llega igual: la protección se siembra en invierno.',
+  }[fase] || '';
+
+  return (
+    <section className="agua-seccion space-y-4" data-testid="pilar-cuidar">
+      <p className="text-sm leading-relaxed text-slate-200">
+        El agua de la finca son dos cuidados en uno: que la que entra a la casa no
+        enferme a nadie, y que el nacimiento que la da no se quede solo.
+      </p>
+
+      {/* Escalera de usos */}
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 space-y-3">
+        <p className="text-sm font-black text-slate-100 uppercase tracking-wide">Cada agua para lo suyo</p>
+        {USOS_DEL_AGUA.map((u) => (
+          <div key={u.id} className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3">
+            <p className="text-sm font-bold text-slate-100 leading-tight">{u.agua}</p>
+            <p className="text-xs text-slate-300 mt-1"><strong className="text-emerald-300">Sirve para:</strong> {u.sirve}</p>
+            <p className="text-xs text-amber-200/90 mt-0.5"><strong>Ojo:</strong> {u.ojo}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Potabilidad — cualitativo seguro + dosis pendientes */}
+      <div className="rounded-2xl border border-sky-700/40 bg-slate-900/60 p-4 space-y-2">
+        <p className="flex items-center gap-2 text-sm font-black text-sky-300 uppercase tracking-wide">
+          <Milk size={16} aria-hidden="true" /> Para tomar: trátela siempre
+        </p>
+        <p className="text-xs leading-snug text-slate-200">
+          Deje asentar el agua turbia y pásela por tela limpia. Para consumo, lo más
+          seguro de la finca es <strong className="text-sky-200">hervirla hasta que suelte borbotones</strong> y
+          guardarla tapada. También sirve desinfectar con cloro de uso doméstico —
+          pero la dosis exacta por litro solo se la vamos a dar con fuente sanitaria:
+        </p>
+        <p>
+          <SlotPendiente>dosis de cloro y tiempos en camino (OMS / MinSalud)</SlotPendiente>
+        </p>
+        {DOSIS_POTABILIZACION.cloroGotasPorLitro == null && (
+          <p className="text-[11px] leading-snug text-slate-400">
+            Mientras el dato llega, no adivine gotas: hierva. Y si el agua huele a
+            químico o viene de potrero fumigado, ni hervida — consígala de otra fuente.
+          </p>
+        )}
+        <div className="rounded-xl border border-rose-700/40 bg-rose-950/30 p-3">
+          <p className="flex items-center gap-2 text-xs font-black text-rose-300 uppercase tracking-wide mb-1.5">
+            <TriangleAlert size={14} aria-hidden="true" /> No la use si ve esto
+          </p>
+          <ul className="space-y-1">
+            {SENALES_ALERTA_AGUA.map((s) => (
+              <li key={s} className="text-xs leading-snug text-slate-200 flex gap-1.5">
+                <span aria-hidden="true" className="text-rose-400">•</span>{s}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {/* CASO INSIGNIA */}
+      <div className="rounded-2xl border border-emerald-700/50 bg-emerald-950/30 p-4 space-y-3" data-testid="caso-nacimiento">
+        <p className="flex items-center gap-2 text-base font-black text-emerald-200 leading-tight">
+          <Droplets size={18} aria-hidden="true" className="shrink-0 text-cyan-300" />
+          «{CASO_NACIMIENTO.titulo}»
+        </p>
+        <p className="text-xs leading-snug text-slate-200">{CASO_NACIMIENTO.resumen}</p>
+
+        <div>
+          <p className="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-amber-300 mb-2">
+            <Sun size={14} aria-hidden="true" /> En pleno verano (auxilio)
+          </p>
+          <ul className="space-y-2">
+            {CASO_NACIMIENTO.enVerano.map((p) => (
+              <li key={p.id} className="text-xs leading-snug text-slate-200">
+                <strong className="text-slate-100">{p.titulo}.</strong> {p.detalle}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <p className="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-emerald-300 mb-2">
+            <CloudRain size={14} aria-hidden="true" /> En invierno se siembra la solución
+          </p>
+          <ul className="space-y-2">
+            {CASO_NACIMIENTO.enInvierno.map((p) => (
+              <li key={p.id} className="text-xs leading-snug text-slate-200">
+                <strong className="text-slate-100">{p.titulo}.</strong> {p.detalle}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <p className="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-sky-300 mb-2">
+            <Users size={14} aria-hidden="true" /> Con los vecinos y con el clima
+          </p>
+          <ul className="space-y-2">
+            {CASO_NACIMIENTO.comunidad.map((p) => (
+              <li key={p.id} className="text-xs leading-snug text-slate-200">
+                <strong className="text-slate-100">{p.titulo}.</strong> {p.detalle}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Conexión viva con el ENSO que Chagra ya sigue */}
+        <div className="rounded-xl border border-cyan-700/40 bg-slate-950/50 p-3" data-testid="enso-conexion">
+          <p className="text-xs font-black uppercase tracking-wide text-cyan-300 mb-1">
+            El clima que viene · {faseLabel}
+          </p>
+          <p className="text-xs leading-snug text-slate-200">{consejoEnso}</p>
+        </div>
+
+        {/* Franja legal: slot honesto */}
+        <div className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3">
+          <p className="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-slate-200 mb-1">
+            <ShieldCheck size={14} aria-hidden="true" /> La ley también lo protege
+          </p>
+          <p className="text-xs leading-snug text-slate-300">
+            La norma colombiana ordena conservar una franja de monte alrededor de los
+            nacimientos y a la orilla de los cauces. Los metros exactos se los daremos
+            con la norma citada{' '}
+            {RONDA_PROTECCION.metrosNacimiento == null && (
+              <SlotPendiente>metros de ronda en camino (norma verificada)</SlotPendiente>
+            )}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ── Pantalla principal ───────────────────────────────────────────────── */
+export default function AguaScreen({ onBack, onNavigate }) {
+  const [pilar, setPilar] = useState('lluvia');
+
+  return (
+    <ScreenShell title="Agua de la finca" icon={CloudRain} onBack={onBack}>
+      <div className="max-w-2xl mx-auto p-4 space-y-4" data-testid="agua-screen">
+        {/* Portada: el camino del agua + la nota de cuaderno */}
+        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4">
+          <CaminoDelAgua activo={pilar} />
+          <p className="mt-2 text-xs italic leading-snug text-slate-400 text-center">
+            El agua hace un solo camino en la finca: cae al techo, riega el surco y
+            nace en la loma. Cuidarlo completo es lo que la mantiene corriendo.
+          </p>
+        </div>
+
+        {/* Navegación entre pilares */}
+        <div className="grid grid-cols-3 gap-2" role="tablist" aria-label="Pilares del agua">
+          {PILARES_AGUA.map((p) => {
+            const activo = pilar === p.id;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                role="tab"
+                aria-selected={activo}
+                data-testid={`pilar-tab-${p.id}`}
+                onClick={() => setPilar(p.id)}
+                className={`rounded-xl border px-2 py-2.5 text-center transition-colors min-h-[56px] ${
+                  activo
+                    ? 'agua-estacion-activa border-cyan-500/70 bg-cyan-500/15 text-cyan-200'
+                    : 'border-slate-700 bg-slate-900/50 text-slate-300 active:bg-slate-800/70'
+                }`}
+              >
+                <span className="block text-sm font-black leading-tight">{p.titulo}</span>
+                <span className={`block text-[10px] leading-tight mt-0.5 ${activo ? 'text-cyan-300/90' : 'text-slate-500'}`}>
+                  {p.descripcion}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {pilar === 'lluvia' && <PilarLluvia />}
+        {pilar === 'riego' && <PilarRiego />}
+        {pilar === 'cuidar' && <PilarCuidar />}
+
+        {/* Puente al agente para lo que el módulo no alcanza */}
+        {typeof onNavigate === 'function' && (
+          <button
+            type="button"
+            data-testid="agua-preguntar-agente"
+            onClick={() => onNavigate('agente', { prefilledPrompt: '¿Cómo cuido el agua de mi finca en la época seca?' })}
+            className="w-full flex items-center gap-3 rounded-2xl border border-slate-700/60 bg-slate-900/40 p-3.5 text-left active:bg-slate-800/60 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-10 h-10 rounded-xl bg-cyan-500/15 grid place-items-center">
+              <Droplets size={20} className="text-cyan-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">¿Su caso es distinto?</span>
+              <span className="block text-xs text-slate-400 leading-tight mt-0.5">Cuénteselo al agente: él conoce su finca y su clima.</span>
+            </span>
+            <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/agua/AguaScreen.test.jsx
+++ b/src/components/agua/AguaScreen.test.jsx
@@ -1,0 +1,108 @@
+/**
+ * AguaScreen.test.jsx — módulo "Agua de la finca".
+ *
+ * Cubre:
+ *   1. Render base: camino del agua + los 3 pilares navegables.
+ *   2. Calculadora de lluvia: 100 m² × 100 mm → 8.000 L (determinista).
+ *   3. Cambio de pilar: riego (calculadora ETc) y cuidar (caso nacimiento).
+ *   4. Honestidad grounded: los slots pendientes se pintan como "dato en
+ *      camino", nunca como cifra.
+ *   5. Puente al agente (onNavigate).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AguaScreen from './AguaScreen.jsx';
+
+describe('AguaScreen — render base', () => {
+  it('monta la pantalla con el camino del agua y los 3 pilares', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    expect(screen.getByTestId('agua-screen')).toBeInTheDocument();
+    expect(screen.getByTestId('camino-del-agua')).toBeInTheDocument();
+    expect(screen.getByTestId('pilar-tab-lluvia')).toBeInTheDocument();
+    expect(screen.getByTestId('pilar-tab-riego')).toBeInTheDocument();
+    expect(screen.getByTestId('pilar-tab-cuidar')).toBeInTheDocument();
+    // Arranca en el pilar de lluvia
+    expect(screen.getByTestId('pilar-lluvia')).toBeInTheDocument();
+  });
+});
+
+describe('AguaScreen — calculadora de cosecha de lluvia', () => {
+  it('calcula litros al mes: 100 m² × 100 mm × 0.8 = 8.000 L', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    expect(screen.getByTestId('calc-lluvia-vacia')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('agua-area-techo'), { target: { value: '100' } });
+    fireEvent.change(screen.getByTestId('agua-lluvia-mes'), { target: { value: '100' } });
+
+    const resultado = screen.getByTestId('calc-lluvia-resultado');
+    expect(resultado).toHaveTextContent('8.000');
+    expect(resultado).toHaveTextContent('litros al mes');
+    // Con el tanque default de 1.000 L queda lleno (100%)
+    expect(resultado).toHaveTextContent('100%');
+  });
+
+  it('no muestra resultado con entradas incompletas', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.change(screen.getByTestId('agua-area-techo'), { target: { value: '100' } });
+    expect(screen.queryByTestId('calc-lluvia-resultado')).toBeNull();
+  });
+});
+
+describe('AguaScreen — pilar riego', () => {
+  it('calcula ETc y litros/día con valores digitados', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-riego'));
+    expect(screen.getByTestId('pilar-riego')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('agua-eto'), { target: { value: '4' } });
+    fireEvent.change(screen.getByTestId('agua-kc'), { target: { value: '1.15' } });
+    fireEvent.change(screen.getByTestId('agua-area-riego'), { target: { value: '100' } });
+
+    const resultado = screen.getByTestId('calc-riego-resultado');
+    expect(resultado).toHaveTextContent('460');
+    expect(resultado).toHaveTextContent('litros al día');
+    expect(resultado).toHaveTextContent('4.6 mm/día');
+  });
+
+  it('muestra los Kc de cultivos como slots grounded-pendiente (sin cifras inventadas)', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-riego'));
+    // Todos los Kc del seed están en null → cada chip de cultivo lleva su slot
+    const slots = screen.getAllByTestId('slot-grounded-pendiente');
+    expect(slots.length).toBeGreaterThanOrEqual(6);
+    expect(screen.getByText('Maíz')).toBeInTheDocument();
+  });
+});
+
+describe('AguaScreen — pilar cuidar (caso nacimiento + ENSO)', () => {
+  it('muestra el caso insignia y la conexión con el clima ENSO', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    expect(screen.getByTestId('pilar-cuidar')).toBeInTheDocument();
+
+    const caso = screen.getByTestId('caso-nacimiento');
+    expect(caso).toHaveTextContent('Se me seca el nacimiento en verano');
+    // Conexión viva con ensoService (fase default en test: Neutral)
+    expect(screen.getByTestId('enso-conexion')).toHaveTextContent(/Neutral|Niño|Niña/);
+  });
+
+  it('las dosis de potabilización y la ronda legal quedan como dato en camino', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    const slots = screen.getAllByTestId('slot-grounded-pendiente');
+    // dosis de cloro + metros de ronda, al menos
+    expect(slots.length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/hervirla hasta que suelte borbotones/i)).toBeInTheDocument();
+  });
+});
+
+describe('AguaScreen — puente al agente', () => {
+  it('navega al agente con la pregunta prellenada', () => {
+    const onNavigate = vi.fn();
+    render(<AguaScreen onBack={() => {}} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('agua-preguntar-agente'));
+    expect(onNavigate).toHaveBeenCalledWith('agente', expect.objectContaining({
+      prefilledPrompt: expect.stringMatching(/agua/i),
+    }));
+  });
+});

--- a/src/components/agua/CaminoDelAgua.jsx
+++ b/src/components/agua/CaminoDelAgua.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+
+/**
+ * CaminoDelAgua — la ilustración insignia del módulo "Agua de la finca".
+ *
+ * SVG propio (nada de librerías de stock): el recorrido del agua en una finca
+ * campesina, de izquierda a derecha —
+ *
+ *   NUBE con lluvia → TECHO de la casa → canal → TANQUE   (pilar: lluvia)
+ *   SURCO con la mata regada gota a gota                  (pilar: riego)
+ *   LOMA con monte nativo y el NACIMIENTO                 (pilar: cuidar)
+ *
+ * Es DECORATIVA (aria-hidden): la navegación real entre pilares son los
+ * botones que la acompañan en AguaScreen. La estación del pilar activo se
+ * resalta subiendo la opacidad de su grupo y bajando la de los demás — así
+ * el dibujo "responde" a la pestaña sin ser él mismo un control.
+ *
+ * Trazo: línea redondeada, formas simples de cuaderno de campo. Colores en
+ * clases Tailwind (currentColor por grupo) para que respiren con los temas.
+ */
+export default function CaminoDelAgua({ activo = 'lluvia' }) {
+  const dim = (id) => (activo === id ? 'opacity-100' : 'opacity-40');
+  return (
+    <svg
+      viewBox="0 0 360 132"
+      role="img"
+      aria-hidden="true"
+      className="w-full h-auto select-none"
+      data-testid="camino-del-agua"
+    >
+      {/* línea de tierra que une todo el camino */}
+      <path
+        d="M6 112 Q 90 106 180 112 T 354 110"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        className="text-amber-700/60"
+      />
+
+      {/* ── ESTACIÓN 1 · lluvia: nube → techo → tanque ── */}
+      <g className={`transition-opacity duration-300 ${dim('lluvia')}`}>
+        {/* nube */}
+        <g className="text-sky-300">
+          <path
+            d="M28 34 q -8 0 -8 -8 q 0 -9 9 -9 q 2 -8 11 -8 q 8 0 10 7 q 9 -1 10 8 q 0 10 -10 10 z"
+            fill="currentColor"
+            opacity="0.85"
+          />
+          {/* gotas animadas (agua.css) */}
+          <g stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
+            <line x1="24" y1="40" x2="24" y2="46" className="agua-gota" />
+            <line x1="38" y1="40" x2="38" y2="46" className="agua-gota agua-gota--2" />
+            <line x1="52" y1="40" x2="52" y2="46" className="agua-gota agua-gota--3" />
+          </g>
+        </g>
+        {/* casa campesina: muro + techo a dos aguas */}
+        <g>
+          <rect x="18" y="86" width="44" height="26" rx="2" fill="currentColor" className="text-amber-200/70" />
+          <path d="M12 88 L40 66 L68 88 Z" fill="currentColor" className="text-rose-400/80" />
+          <rect x="34" y="96" width="12" height="16" rx="1.5" fill="currentColor" className="text-amber-900/70" />
+        </g>
+        {/* canal del alero al tanque */}
+        <path
+          d="M66 88 q 14 2 18 10"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          className="text-slate-400"
+        />
+        {/* tanque con nivel de agua */}
+        <g>
+          <rect x="80" y="96" width="22" height="18" rx="3" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-slate-300" />
+          <rect x="83" y="103" width="16" height="8" rx="1.5" fill="currentColor" className="text-cyan-400/80 agua-hilo" />
+        </g>
+      </g>
+
+      {/* ── ESTACIÓN 2 · riego: surco + mata + goteo ── */}
+      <g className={`transition-opacity duration-300 ${dim('riego')}`}>
+        {/* surcos */}
+        <g stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" className="text-amber-600/70">
+          <path d="M138 112 q 12 -6 24 0" fill="none" />
+          <path d="M168 112 q 12 -6 24 0" fill="none" />
+          <path d="M198 112 q 12 -6 24 0" fill="none" />
+        </g>
+        {/* mata de maíz estilizada en el surco del medio */}
+        <g stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" fill="none" className="text-lime-400">
+          <line x1="180" y1="108" x2="180" y2="78" />
+          <path d="M180 98 q -10 -3 -14 -12" />
+          <path d="M180 92 q 10 -3 14 -12" />
+          <path d="M180 84 q -8 -2 -11 -10" />
+        </g>
+        {/* manguera de goteo con su gota */}
+        <path d="M120 100 q 40 -14 54 -8" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeDasharray="1 6" className="text-cyan-300" />
+        <g className="text-cyan-300">
+          <line x1="174" y1="96" x2="174" y2="102" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" className="agua-gota agua-gota--2" />
+        </g>
+      </g>
+
+      {/* ── ESTACIÓN 3 · cuidar: loma, monte nativo y nacimiento ── */}
+      <g className={`transition-opacity duration-300 ${dim('cuidar')}`}>
+        {/* loma */}
+        <path
+          d="M240 112 Q 292 58 352 108"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          className="text-emerald-600/80"
+        />
+        {/* árboles nativos (copas redondas de trazo) */}
+        <g className="text-emerald-400">
+          <line x1="284" y1="84" x2="284" y2="70" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+          <circle cx="284" cy="62" r="9" fill="currentColor" opacity="0.85" />
+          <line x1="304" y1="80" x2="304" y2="68" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+          <circle cx="304" cy="61" r="7" fill="currentColor" opacity="0.7" />
+          <line x1="266" y1="92" x2="266" y2="82" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+          <circle cx="266" cy="76" r="6" fill="currentColor" opacity="0.7" />
+        </g>
+        {/* ojo de agua + hilo que baja de la loma */}
+        <g className="text-cyan-300">
+          <circle cx="288" cy="94" r="4.5" fill="currentColor" className="agua-hilo" />
+          <path
+            d="M288 98 q -4 8 2 14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            className="agua-hilo"
+          />
+        </g>
+        {/* cerca de protección (dos postes con cuerda) */}
+        <g stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="text-amber-500/80">
+          <line x1="258" y1="112" x2="258" y2="100" />
+          <line x1="318" y1="112" x2="318" y2="100" />
+          <path d="M258 103 q 30 -6 60 0" fill="none" strokeDasharray="4 4" />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/components/agua/agua.css
+++ b/src/components/agua/agua.css
@@ -1,0 +1,73 @@
+/*
+ * agua.css — micro-animaciones del módulo "Agua de la finca".
+ *
+ * Principios:
+ *   · Sutiles y de bajo costo (solo transform/opacity, nada de layout).
+ *   · prefers-reduced-motion las apaga TODAS.
+ *   · Los colores del módulo salen de las clases Tailwind del componente
+ *     (paleta slate + acentos cyan/sky/teal), que ya reaccionan a los temas
+ *     de la app vía data-theme (themes.css) — aquí no se fija ningún color
+ *     de tema, solo movimiento.
+ */
+
+/* Gotas de lluvia del "camino del agua": caen en loop, escalonadas. */
+@keyframes agua-gota-cae {
+  0% { transform: translateY(0); opacity: 0; }
+  15% { opacity: 0.9; }
+  85% { opacity: 0.9; }
+  100% { transform: translateY(26px); opacity: 0; }
+}
+
+.agua-gota {
+  animation: agua-gota-cae 1.6s linear infinite;
+}
+.agua-gota--2 { animation-delay: 0.5s; }
+.agua-gota--3 { animation-delay: 1s; }
+
+/* El hilo del nacimiento "respira" (opacity), como agua corriendo. */
+@keyframes agua-hilo-respira {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+.agua-hilo {
+  animation: agua-hilo-respira 2.8s ease-in-out infinite;
+}
+
+/* Nivel del tanque en la calculadora: sube suave cuando cambia el resultado.
+   Se anima con transform scaleY (transform-origin bottom) — sin reflow. */
+.agua-nivel {
+  transform-origin: center bottom;
+  transition: transform 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Estación activa del camino: aro que pulsa una sola vez al seleccionar. */
+@keyframes agua-estacion-pulso {
+  0% { transform: scale(0.92); opacity: 0.4; }
+  60% { transform: scale(1.06); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+.agua-estacion-activa {
+  animation: agua-estacion-pulso 0.45s ease-out;
+}
+
+/* Entrada suave del contenido del pilar al cambiar de pestaña. */
+@keyframes agua-seccion-entra {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.agua-seccion {
+  animation: agua-seccion-entra 0.3s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agua-gota,
+  .agua-hilo,
+  .agua-estacion-activa,
+  .agua-seccion {
+    animation: none;
+  }
+  .agua-gota { opacity: 0.9; }
+  .agua-nivel {
+    transition: none;
+  }
+}

--- a/src/components/cultivos/CalculadoraGradosDia.jsx
+++ b/src/components/cultivos/CalculadoraGradosDia.jsx
@@ -1,0 +1,247 @@
+/*
+ * i18n (ADR-050): copy campesino en español Colombia, pendiente de migrar a
+ * src/config/messages.js — mismo criterio que DashboardLive.jsx.
+ */
+import { useMemo, useState } from 'react';
+import {
+    CULTIVOS_GDD,
+    CULTIVO_GDD_BY_ID,
+    PISOS_TERMICOS,
+    gddDia,
+    gddAcumulado,
+    diasTranscurridos,
+    estimarEtapa,
+    compararRitmo,
+} from '../../services/gradosDiaCalculator';
+
+/**
+ * CalculadoraGradosDia — el "reloj térmico" del cultivo, determinista.
+ *
+ * Deja al campesino ver POR QUÉ la misma mata tarda más en tierra fría: cuenta
+ * el calor (grados-día) que acumula por encima de su temperatura base, no los
+ * días del calendario. Todo el cálculo vive en gradosDiaCalculator.js (funciones
+ * puras, groundeadas). Esta pantalla solo arma los controles y muestra números.
+ *
+ * Honestidad: los umbrales de etapa por GDD están grounded-pendiente; la etapa
+ * se estima por la fenología en DÍAS que sí está groundeada (AGROSAVIA/ICA). Los
+ * presets de piso térmico son referencia editable.
+ *
+ * @param {Object} props
+ * @param {string} [props.className]
+ */
+export default function CalculadoraGradosDia({ className = '' }) {
+    const [cultivoId, setCultivoId] = useState('maiz');
+    const [pisoId, setPisoId] = useState('frio');
+    const [tmin, setTmin] = useState(7);
+    const [tmax, setTmax] = useState(19);
+    const [tbManual, setTbManual] = useState(10);
+    const [fecha, setFecha] = useState('');
+
+    const cultivo = CULTIVO_GDD_BY_ID[cultivoId] || CULTIVOS_GDD[0];
+    const tb = cultivoId === 'manual' ? Number(tbManual) : cultivo.tb;
+    const to = cultivoId === 'manual' ? null : cultivo.to;
+
+    // Aplica un preset de piso térmico (referencia editable).
+    const aplicarPiso = (id) => {
+        const p = PISOS_TERMICOS.find((x) => x.id === id);
+        if (!p) return;
+        setPisoId(id);
+        setTmin(p.tmin);
+        setTmax(p.tmax);
+    };
+
+    const nTmin = Number(tmin);
+    const nTmax = Number(tmax);
+
+    const porDia = useMemo(
+        () => Math.round(gddDia(nTmin, nTmax, tb, to) * 10) / 10,
+        [nTmin, nTmax, tb, to],
+    );
+
+    // Días desde la siembra (si dieron fecha) y GDD acumulados a hoy.
+    const dds = useMemo(() => (fecha ? diasTranscurridos(fecha) : null), [fecha]);
+    const acumulado = useMemo(
+        () => (dds != null ? gddAcumulado(nTmin, nTmax, tb, to, dds) : null),
+        [dds, nTmin, nTmax, tb, to],
+    );
+    const etapa = useMemo(
+        () => (dds != null ? estimarEtapa(cultivoId, dds) : null),
+        [cultivoId, dds],
+    );
+
+    // Comparación tierra fría vs templada (evidencia del "tarda más").
+    const ritmo = useMemo(() => compararRitmo(cultivoId, 'templado', 'frio'), [cultivoId]);
+
+    const tempsInvalidas = !(Number.isFinite(nTmin) && Number.isFinite(nTmax)) || nTmax < nTmin;
+
+    return (
+        <div className={`mch-calc ${className}`} data-testid="calc-grados-dia">
+            <p className="mch-calc-intro">
+                Los <b>grados-día</b> cuentan el calor que junta la mata, no los días del
+                almanaque. En tierra fría junta menos calor por día — por eso tarda más.
+            </p>
+
+            {/* 1 · Cultivo */}
+            <fieldset className="mch-calc-grupo">
+                <legend>1 · ¿Qué sembró?</legend>
+                <div className="mch-calc-chips" role="radiogroup" aria-label="Cultivo">
+                    {CULTIVOS_GDD.map((c) => (
+                        <button
+                            key={c.id}
+                            type="button"
+                            role="radio"
+                            aria-checked={cultivoId === c.id}
+                            className={`mch-chip ${cultivoId === c.id ? 'is-on' : ''}`}
+                            onClick={() => setCultivoId(c.id)}
+                            data-testid={`calc-cultivo-${c.id}`}
+                        >
+                            <span aria-hidden="true">{c.emoji}</span> {c.nombre}
+                        </button>
+                    ))}
+                </div>
+                {cultivoId === 'manual' ? (
+                    <label className="mch-calc-campo">
+                        Temperatura base (°C)
+                        <input
+                            type="number"
+                            inputMode="decimal"
+                            value={tbManual}
+                            min={0}
+                            max={20}
+                            step={0.5}
+                            onChange={(e) => setTbManual(e.target.value)}
+                            data-testid="calc-tb-manual"
+                        />
+                    </label>
+                ) : (
+                    <p className="mch-calc-nota">
+                        Base <b>{tb} °C</b>{to != null ? `, tope ${to} °C` : ''}. {cultivo.tbNota}{' '}
+                        <span className="mch-fuente">({cultivo.fuente})</span>
+                    </p>
+                )}
+            </fieldset>
+
+            {/* 2 · Clima del lugar */}
+            <fieldset className="mch-calc-grupo">
+                <legend>2 · ¿Cómo es el clima de su finca?</legend>
+                <div className="mch-calc-chips" role="radiogroup" aria-label="Piso térmico">
+                    {PISOS_TERMICOS.map((p) => (
+                        <button
+                            key={p.id}
+                            type="button"
+                            role="radio"
+                            aria-checked={pisoId === p.id}
+                            className={`mch-chip ${pisoId === p.id ? 'is-on' : ''}`}
+                            onClick={() => aplicarPiso(p.id)}
+                            data-testid={`calc-piso-${p.id}`}
+                        >
+                            {p.nombre}
+                            <small>{p.rango}</small>
+                        </button>
+                    ))}
+                </div>
+                <div className="mch-calc-temps">
+                    <label className="mch-calc-campo">
+                        Mínima de la noche (°C)
+                        <input
+                            type="number"
+                            inputMode="decimal"
+                            value={tmin}
+                            step={0.5}
+                            onChange={(e) => { setTmin(e.target.value); setPisoId(''); }}
+                            data-testid="calc-tmin"
+                        />
+                    </label>
+                    <label className="mch-calc-campo">
+                        Máxima del día (°C)
+                        <input
+                            type="number"
+                            inputMode="decimal"
+                            value={tmax}
+                            step={0.5}
+                            onChange={(e) => { setTmax(e.target.value); setPisoId(''); }}
+                            data-testid="calc-tmax"
+                        />
+                    </label>
+                </div>
+                <p className="mch-calc-nota">
+                    Valores de referencia por piso térmico — <b>ajústelos a su finca</b>.
+                </p>
+            </fieldset>
+
+            {/* Resultado por día */}
+            {tempsInvalidas ? (
+                <p className="mch-calc-aviso" role="status">
+                    Revise las temperaturas: la máxima del día no puede ser menor que la
+                    mínima de la noche.
+                </p>
+            ) : (
+                <div className="mch-calc-resultado" role="status" aria-live="polite">
+                    <div className="mch-calc-big">
+                        <b data-testid="calc-por-dia">{porDia}</b>
+                        <span>grados-día por día</span>
+                    </div>
+                    {ritmo && Number.isFinite(ritmo.factor) && ritmo.factor > 1 && (
+                        <p className="mch-calc-porque">
+                            En tierra templada esta mata juntaría <b>{ritmo.calido}</b> °D/día
+                            y en tierra fría <b>{ritmo.frio}</b> °D/día: por eso en lo frío va{' '}
+                            <b>~{ritmo.factor}×</b> más despacio.
+                        </p>
+                    )}
+                </div>
+            )}
+
+            {/* 3 · Fecha de siembra → etapa y acumulado */}
+            <fieldset className="mch-calc-grupo">
+                <legend>3 · ¿Cuándo sembró? <small>(opcional)</small></legend>
+                <label className="mch-calc-campo">
+                    Fecha de siembra
+                    <input
+                        type="date"
+                        value={fecha}
+                        max={new Date().toISOString().slice(0, 10)}
+                        onChange={(e) => setFecha(e.target.value)}
+                        data-testid="calc-fecha"
+                    />
+                </label>
+                {dds != null && !tempsInvalidas && (
+                    <div className="mch-calc-etapa" data-testid="calc-etapa">
+                        <p>
+                            Van <b>{dds}</b> días desde la siembra ·{' '}
+                            <b>{acumulado}</b> grados-día acumulados.
+                        </p>
+                        {etapa ? (
+                            <>
+                                <p className="mch-calc-etapa-actual">
+                                    <span aria-hidden="true">📍</span> Según la fenología, va en{' '}
+                                    <b>{etapa.actual.label}</b> — {etapa.actual.desc}.
+                                </p>
+                                {etapa.proxima && (
+                                    <p className="mch-calc-etapa-prox">
+                                        Sigue <b>{etapa.proxima.label}</b> en ~{etapa.diasParaProxima}{' '}
+                                        días.
+                                    </p>
+                                )}
+                                <p className="mch-calc-nota">
+                                    Etapa por días de fenología{' '}
+                                    <span className="mch-fuente">({cultivo.fenologiaFuente})</span>. Los
+                                    umbrales de etapa por grados-día están en camino.
+                                </p>
+                            </>
+                        ) : (
+                            <p className="mch-calc-nota">
+                                Para este cultivo aún no cargamos la fenología en días — el dato
+                                está en camino. El acumulado de grados-día sí es exacto.
+                            </p>
+                        )}
+                    </div>
+                )}
+            </fieldset>
+
+            <p className="mch-calc-pie">
+                Los rangos son envolventes de adaptación, no reglas duras: varían por
+                variedad, microclima y manejo. Cálculo determinista; sin conexión.
+            </p>
+        </div>
+    );
+}

--- a/src/components/cultivos/MundoCultivosHub.jsx
+++ b/src/components/cultivos/MundoCultivosHub.jsx
@@ -1,0 +1,244 @@
+/*
+ * i18n (ADR-050): copy de navegación campesino en español Colombia, pendiente de
+ * migrar a src/config/messages.js — mismo criterio que DashboardLive.jsx.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useState } from 'react';
+import { ScreenShell } from '../common/ScreenShell';
+import { REGIMENES_LLUVIA } from '../../services/gradosDiaCalculator';
+import CalculadoraGradosDia from './CalculadoraGradosDia';
+import './mundo-cultivos-hub.css';
+
+/**
+ * MundoCultivosHub — la PORTADA del mundo 🌱 CULTIVOS Y SEMILLAS.
+ *
+ * Reúne y da entrada elegante a las funciones que YA existen (directorio de
+ * especies, ciclo de cultivo, germinación, calendario, fenología, siembra y
+ * cosecha) SIN reimplementarlas: cada lámina RE-RUTEA vía onNavigate a su
+ * pantalla real de App.jsx. Suma una calculadora determinista de grados-día.
+ *
+ * Orientación primero (grounding 2026-07-04): el calendario campesino no es una
+ * fecha universal — depende del RÉGIMEN de lluvia (bimodal andino = dos siembras;
+ * unimodal = una) y del PISO TÉRMICO. Por eso el hub abre orientando por región.
+ *
+ * Identidad: cuaderno de campo (papel crema, tinta verde, Baloo 2 / Nunito),
+ * SVG propios, funciona sobre los 4 temas (láminas de papel), reduced-motion.
+ *
+ * @param {Object} props
+ * @param {Function} props.onBack   volver al home.
+ * @param {(view: string, data?: any) => void} props.onNavigate
+ */
+export default function MundoCultivosHub({ onBack, onNavigate }) {
+    const [regimenId, setRegimenId] = useState('bimodal');
+    const [calcAbierta, setCalcAbierta] = useState(false);
+    const regimen = REGIMENES_LLUVIA.find((r) => r.id === regimenId) || REGIMENES_LLUVIA[0];
+
+    // Las funciones del mundo, agrupadas editorialmente. `view` SIEMPRE es un
+    // case real de App.jsx (y vive también en las entradas del mundo cultivos en
+    // mundosFinca.js, que congela la reachability).
+    const grupos = [
+        {
+            titulo: 'Saber qué y cuándo sembrar',
+            desc: 'El conocimiento antes de meter la semilla',
+            items: [
+                { view: 'directorio', emoji: '🌱', label: 'Qué puedo sembrar', desc: 'Especies para su clima, con qué se llevan y sus plagas' },
+                { view: 'calendario_finca', emoji: '🗓️', label: 'Calendario de la finca', desc: 'Cuándo sembrar, abonar y cosechar, todo junto' },
+                { view: 'ciclo', emoji: '🔄', label: 'Ciclo de cultivo', desc: 'La vida de la mata etapa por etapa (fenología)' },
+            ],
+        },
+        {
+            titulo: 'Sembrar y hacer seguimiento',
+            desc: 'De la semilla a la cosecha',
+            items: [
+                { view: 'germinacion', emoji: '🫘', label: 'Semilleros', desc: 'Pruebe sus semillas y vea cuáles nacen' },
+                { view: 'sembrar', emoji: '🌽', label: 'Registrar una siembra', desc: 'Anote lo que sembró y arranca su ciclo' },
+                { view: 'activos', emoji: '🪴', label: 'Mis matas', desc: 'Las plantas que tiene sembradas y cómo van' },
+                { view: 'cosechar', emoji: '🧺', label: 'Cosechar', desc: 'Anote lo que recogió' },
+            ],
+        },
+    ];
+
+    return (
+        <ScreenShell title="Cultivos y semillas" onBack={onBack}>
+            <div className="mch" data-testid="mundo-cultivos-hub">
+                {/* Portada ilustrada del mundo (SVG propio, rsvg-safe). */}
+                <header className="mch-hero">
+                    <HeroCultivos />
+                    <div className="mch-hero-txt">
+                        <h1 className="mch-hero-tit">
+                            <span aria-hidden="true">🌱</span> Cultivos y semillas
+                        </h1>
+                        <p className="mch-hero-lema">
+                            Qué sembrar, cuándo, y cómo van sus matas. Empiece por su región.
+                        </p>
+                    </div>
+                </header>
+
+                {/* Orientación: régimen de lluvia → ventanas de siembra (grounded). */}
+                <section className="mch-orienta" aria-labelledby="mch-orienta-tit">
+                    <h2 id="mch-orienta-tit" className="mch-h2">
+                        <span aria-hidden="true">🌧️</span> ¿Cuándo se siembra en su tierra?
+                    </h2>
+                    <p className="mch-sub">
+                        No hay una fecha para toda Colombia: se siembra al empezar las lluvias.
+                        Elija su región.
+                    </p>
+                    <div className="mch-seg" role="radiogroup" aria-label="Régimen de lluvia">
+                        {REGIMENES_LLUVIA.map((r) => (
+                            <button
+                                key={r.id}
+                                type="button"
+                                role="radio"
+                                aria-checked={regimenId === r.id}
+                                className={`mch-seg-btn ${regimenId === r.id ? 'is-on' : ''}`}
+                                onClick={() => setRegimenId(r.id)}
+                                data-testid={`regimen-${r.id}`}
+                            >
+                                {r.nombre}
+                            </button>
+                        ))}
+                    </div>
+                    <div className="mch-ventanas" data-testid="ventanas-siembra">
+                        <p className="mch-ventanas-desc">{regimen.desc}</p>
+                        <div className="mch-ventanas-grid">
+                            {regimen.ventanas.map((v) => (
+                                <div key={v.label} className="mch-ventana">
+                                    <b>{v.label}</b>
+                                    <span><i>Siembra:</i> {v.siembra}</span>
+                                    <span><i>Cosecha:</i> {v.cosecha}</span>
+                                </div>
+                            ))}
+                        </div>
+                        <p className="mch-nota">
+                            {regimen.nota} <span className="mch-fuente">({regimen.fuente})</span>
+                        </p>
+                    </div>
+                </section>
+
+                {/* Las funciones existentes, agrupadas — cada una re-rutea. */}
+                {grupos.map((g) => (
+                    <section key={g.titulo} className="mch-grupo" aria-label={g.titulo}>
+                        <h2 className="mch-h2">{g.titulo}</h2>
+                        <p className="mch-sub">{g.desc}</p>
+                        <nav className="mch-laminas">
+                            {g.items.map((it) => (
+                                <button
+                                    key={it.view}
+                                    type="button"
+                                    className="mch-lamina"
+                                    data-testid={`lamina-${it.view}`}
+                                    onClick={() => onNavigate?.(it.view)}
+                                    aria-label={`${it.label}: ${it.desc}`}
+                                >
+                                    <span className="mch-lamina-ic" aria-hidden="true">{it.emoji}</span>
+                                    <span className="mch-lamina-txt">
+                                        <b>{it.label}</b>
+                                        <small>{it.desc}</small>
+                                    </span>
+                                    <span className="mch-lamina-ir" aria-hidden="true">→</span>
+                                </button>
+                            ))}
+                        </nav>
+                    </section>
+                ))}
+
+                {/* Calculadora de grados-día — el reloj térmico, determinista. */}
+                <section className="mch-grupo" aria-labelledby="mch-calc-tit">
+                    <button
+                        type="button"
+                        className={`mch-calc-toggle ${calcAbierta ? 'is-open' : ''}`}
+                        aria-expanded={calcAbierta}
+                        aria-controls="mch-calc-panel"
+                        onClick={() => setCalcAbierta((v) => !v)}
+                        data-testid="calc-toggle"
+                    >
+                        <span className="mch-lamina-ic" aria-hidden="true">🌡️</span>
+                        <span className="mch-lamina-txt">
+                            <b id="mch-calc-tit">Calculadora de grados-día</b>
+                            <small>Por qué en tierra fría la misma mata tarda más</small>
+                        </span>
+                        <span className="mch-lamina-ir" aria-hidden="true">{calcAbierta ? '▲' : '▼'}</span>
+                    </button>
+                    {calcAbierta && (
+                        <div id="mch-calc-panel">
+                            <CalculadoraGradosDia />
+                        </div>
+                    )}
+                </section>
+
+                {/* Saber cultural: calendario lunar, con respeto (no agronomía dura). */}
+                <section className="mch-luna" aria-label="Calendario lunar">
+                    <span className="mch-luna-ic" aria-hidden="true">🌙</span>
+                    <p>
+                        <b>El calendario lunar</b> es saber campesino que vale para organizar las
+                        labores (creciente para lo de porte alto; menguante para raíces como la
+                        papa). No promete más cosecha: es cultura, no receta.{' '}
+                        <span className="mch-fuente">(R43, R44)</span>
+                    </p>
+                </section>
+
+                {/* El agente, siempre a la mano, con el contexto del mundo. */}
+                <button
+                    type="button"
+                    className="mch-agente"
+                    data-testid="mch-agente"
+                    onClick={() => onNavigate?.('agente')}
+                    aria-label="Pregúntele a Chagra sobre cultivos y semillas"
+                >
+                    <span aria-hidden="true">💬</span>
+                    <span>
+                        <b>Pregúntele a Chagra</b>
+                        <small>Cualquier duda sobre qué y cuándo sembrar, con su fuente.</small>
+                    </span>
+                </button>
+            </div>
+        </ScreenShell>
+    );
+}
+
+/**
+ * HeroCultivos — ilustración propia de la portada (mismo lenguaje vector que las
+ * viñetas de mundo: horizonte + tierra + foco). rsvg-safe: sin filtros, sin
+ * foreignObject, sin <text> con emoji. El movimiento (si acaso) lo pone el CSS y
+ * respeta reduced-motion.
+ */
+function HeroCultivos() {
+    return (
+        <svg
+            className="mch-hero-svg"
+            viewBox="0 0 320 120"
+            preserveAspectRatio="xMidYMid slice"
+            aria-hidden="true"
+        >
+            {/* cielo de mañana */}
+            <rect width="320" height="120" fill="#eaf3da" />
+            <circle cx="268" cy="30" r="16" fill="#ffe08a" />
+            <circle cx="268" cy="30" r="9" fill="#fff3c4" />
+            {/* cordillera (pisos térmicos: el fondo azulado del frío) */}
+            <path d="M-4 58 L46 30 L96 52 L150 26 L210 50 L272 28 L324 48 V120 H-4 Z" fill="#bcd6a6" />
+            {/* laderas de cultivo en verde escalonado */}
+            <path d="M-4 64 Q70 46 150 62 T324 56 V120 H-4 Z" fill="#9bc172" />
+            <path d="M-4 82 Q90 66 180 80 T324 76 V120 H-4 Z" fill="#6fa356" />
+            {/* surcos en perspectiva */}
+            <g stroke="#4c7a3d" strokeWidth="3" strokeLinecap="round" fill="none" opacity=".5">
+                <path d="M40 120 L86 84" />
+                <path d="M96 120 L120 84" />
+                <path d="M164 120 L166 84" />
+                <path d="M236 120 L214 84" />
+                <path d="M300 120 L266 84" />
+            </g>
+            {/* matas de maíz jóvenes */}
+            <g stroke="#2f6b3a" strokeWidth="2.8" strokeLinecap="round" fill="none">
+                <g><path d="M118 100 v-20" /><path d="M118 90 q-9 -4 -13 -12" /><path d="M118 85 q9 -4 13 -12" /></g>
+                <g><path d="M196 96 v-18" /><path d="M196 88 q-8 -4 -12 -11" /><path d="M196 83 q8 -4 12 -11" /></g>
+            </g>
+            {/* semilla germinando, primer plano */}
+            <g transform="translate(58 92)">
+                <ellipse cx="0" cy="10" rx="9" ry="6" fill="#8a5a38" />
+                <path d="M0 8 v-11" stroke="#5a9e4b" strokeWidth="3" strokeLinecap="round" fill="none" />
+                <path d="M0 -3 q-7 -2 -9 -9" stroke="#5a9e4b" strokeWidth="3" strokeLinecap="round" fill="none" />
+                <path d="M0 -3 q7 -2 9 -9" stroke="#5a9e4b" strokeWidth="3" strokeLinecap="round" fill="none" />
+            </g>
+        </svg>
+    );
+}

--- a/src/components/cultivos/__tests__/MundoCultivosHub.test.jsx
+++ b/src/components/cultivos/__tests__/MundoCultivosHub.test.jsx
@@ -1,0 +1,97 @@
+/**
+ * MundoCultivosHub — la PORTADA del mundo cultivos. Contrato:
+ *   1. Orienta por región (régimen de lluvia) antes de sembrar.
+ *   2. Cada lámina RE-RUTEA a su pantalla real (onNavigate), no reimplementa.
+ *   3. La calculadora de grados-día calcula determinista (maíz frío = 4.5 °D/día).
+ *   4. El agente queda a la mano.
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+import MundoCultivosHub from '../MundoCultivosHub';
+import CalculadoraGradosDia from '../CalculadoraGradosDia';
+
+afterEach(() => cleanup());
+
+describe('MundoCultivosHub — portada del mundo cultivos', () => {
+    test('renderiza el hub con hero y orientación por región', () => {
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={vi.fn()} />);
+        expect(screen.getByTestId('mundo-cultivos-hub')).toBeInTheDocument();
+        expect(screen.getByTestId('regimen-bimodal')).toBeInTheDocument();
+        expect(screen.getByTestId('regimen-unimodal')).toBeInTheDocument();
+        // Por defecto abre en bimodal (Andes) → dos semestres de siembra.
+        const ventanas = screen.getByTestId('ventanas-siembra');
+        expect(within(ventanas).getByText(/Semestre A/)).toBeInTheDocument();
+        expect(within(ventanas).getByText(/Semestre B/)).toBeInTheDocument();
+    });
+
+    test('el régimen unimodal muestra una sola ventana de siembra', () => {
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={vi.fn()} />);
+        fireEvent.click(screen.getByTestId('regimen-unimodal'));
+        const ventanas = screen.getByTestId('ventanas-siembra');
+        expect(within(ventanas).getByText(/Única/)).toBeInTheDocument();
+        expect(within(ventanas).queryByText(/Semestre B/)).toBeNull();
+    });
+
+    test('cada lámina re-rutea a su vista real existente', () => {
+        const onNavigate = vi.fn();
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={onNavigate} />);
+        const esperadas = ['directorio', 'calendario_finca', 'ciclo', 'germinacion', 'sembrar', 'activos', 'cosechar'];
+        for (const view of esperadas) {
+            fireEvent.click(screen.getByTestId(`lamina-${view}`));
+            expect(onNavigate).toHaveBeenCalledWith(view);
+        }
+    });
+
+    test('la calculadora de grados-día se despliega y calcula (maíz frío = 4.5)', () => {
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={vi.fn()} />);
+        // Cerrada por defecto: la portada se lee primero.
+        expect(screen.queryByTestId('calc-grados-dia')).toBeNull();
+        fireEvent.click(screen.getByTestId('calc-toggle'));
+        expect(screen.getByTestId('calc-grados-dia')).toBeInTheDocument();
+        expect(screen.getByTestId('calc-por-dia')).toHaveTextContent('4.5');
+    });
+
+    test('el agente queda a la mano al pie', () => {
+        const onNavigate = vi.fn();
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={onNavigate} />);
+        fireEvent.click(screen.getByTestId('mch-agente'));
+        expect(onNavigate).toHaveBeenCalledWith('agente');
+    });
+});
+
+describe('CalculadoraGradosDia — determinista y honesta', () => {
+    test('cambiar de piso térmico recalcula los grados-día por día', () => {
+        render(<CalculadoraGradosDia />);
+        // Arranca en tierra fría → maíz 4.5 °D/día.
+        expect(screen.getByTestId('calc-por-dia')).toHaveTextContent('4.5');
+        // Tierra templada → 10.5 °D/día.
+        fireEvent.click(screen.getByTestId('calc-piso-templado'));
+        expect(screen.getByTestId('calc-por-dia')).toHaveTextContent('10.5');
+    });
+
+    test('cultivo manual muestra el campo de temperatura base', () => {
+        render(<CalculadoraGradosDia />);
+        expect(screen.queryByTestId('calc-tb-manual')).toBeNull();
+        fireEvent.click(screen.getByTestId('calc-cultivo-manual'));
+        expect(screen.getByTestId('calc-tb-manual')).toBeInTheDocument();
+    });
+
+    test('con fecha de siembra estima la etapa por fenología', () => {
+        render(<CalculadoraGradosDia />);
+        fireEvent.change(screen.getByTestId('calc-fecha'), { target: { value: '2020-01-01' } });
+        const etapa = screen.getByTestId('calc-etapa');
+        // Fecha muy pasada → maíz ya en grano seco (último hito), sin próxima.
+        expect(within(etapa).getByText(/Grano seco/)).toBeInTheDocument();
+        expect(within(etapa).getByText(/grados-día acumulados/)).toBeInTheDocument();
+    });
+
+    test('temperaturas invertidas muestran aviso, no un número falso', () => {
+        render(<CalculadoraGradosDia />);
+        fireEvent.change(screen.getByTestId('calc-tmax'), { target: { value: '3' } });
+        expect(screen.queryByTestId('calc-por-dia')).toBeNull();
+        expect(screen.getByText(/no puede ser menor/)).toBeInTheDocument();
+    });
+});

--- a/src/components/cultivos/mundo-cultivos-hub.css
+++ b/src/components/cultivos/mundo-cultivos-hub.css
@@ -1,0 +1,496 @@
+/* ============================================================================
+   mundo-cultivos-hub.css — PORTADA del mundo 🌱 CULTIVOS Y SEMILLAS.
+
+   Identidad: CUADERNO DE CAMPO. Todo son láminas de papel crema con tinta verde
+   (Baloo 2 en títulos, Nunito en cuerpo). Al ser "papel", el hub se lee bien
+   sobre los 4 temas (biopunk oscuro, nature, minimalista, verde-vivo) sin
+   depender de las variables --c-* del tema: es una hoja pegada encima.
+
+   Namespace propio `.mch-` para no colisionar con las portadas hermanas de los
+   otros mundos (cada agente trae su prefijo). Legible al sol: tinta oscura,
+   labels en negrita, jerarquía sin depender del color. rsvg-safe en los SVG.
+   prefers-reduced-motion: sin animaciones ni lifts.
+   ========================================================================== */
+
+.mch {
+  --mch-papel: #fffdf6;
+  --mch-papel-2: #f4f6ea;
+  --mch-tinta: #26331f;
+  --mch-tinta-suave: #4e5c42;
+  --mch-verde: #3f8f4e;
+  --mch-verde-hondo: #2f6b3a;
+  --mch-ocre: #b98a2f;
+  --mch-display: 'Baloo 2', 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --mch-body: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 12px 14px 28px;
+  font-family: var(--mch-body);
+  color: var(--mch-tinta);
+}
+
+/* ── Portada ilustrada ─────────────────────────────────────────────────────── */
+.mch-hero {
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-bottom: 4px solid var(--mch-verde);
+  box-shadow: 0 3px 14px rgba(38, 51, 31, 0.12);
+  background: #eaf3da;
+}
+.mch-hero-svg {
+  display: block;
+  width: 100%;
+  height: 128px;
+}
+.mch-hero-txt {
+  padding: 12px 14px 14px;
+  background: var(--mch-papel);
+  border-top: 1px solid rgba(38, 51, 31, 0.1);
+}
+.mch-hero-tit {
+  margin: 0;
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 22px;
+  line-height: 1.15;
+  color: var(--mch-tinta);
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.mch-hero-lema {
+  margin: 5px 0 0;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 600;
+  color: var(--mch-tinta-suave);
+}
+
+/* ── Secciones y encabezados ───────────────────────────────────────────────── */
+.mch-orienta,
+.mch-grupo {
+  margin-top: 20px;
+}
+.mch-h2 {
+  margin: 0;
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 17px;
+  line-height: 1.2;
+  color: var(--mch-tinta);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+/* hilo cosido del cuaderno bajo cada título de sección */
+.mch-h2::after {
+  content: '';
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: repeating-linear-gradient(90deg,
+    color-mix(in srgb, var(--mch-verde) 55%, transparent) 0 5px,
+    transparent 5px 9px);
+  opacity: 0.6;
+}
+.mch-sub {
+  margin: 4px 0 10px;
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--mch-tinta-suave);
+  max-width: 52ch;
+}
+
+/* ── Orientación por régimen de lluvia ─────────────────────────────────────── */
+.mch-seg {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.mch-seg-btn {
+  flex: 1 1 auto;
+  min-height: 46px;
+  padding: 8px 12px;
+  border-radius: 13px;
+  border: 1.5px solid rgba(38, 51, 31, 0.16);
+  background: var(--mch-papel);
+  color: var(--mch-tinta);
+  font-family: var(--mch-body);
+  font-weight: 700;
+  font-size: 12.5px;
+  line-height: 1.25;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.mch-seg-btn.is-on {
+  border-color: var(--mch-verde);
+  background: color-mix(in srgb, var(--mch-verde) 12%, var(--mch-papel));
+  box-shadow: inset 0 0 0 1px var(--mch-verde);
+}
+.mch-seg-btn:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 2px;
+}
+
+.mch-ventanas {
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-left: 4px solid var(--mch-ocre);
+  border-radius: 12px;
+  background: var(--mch-papel);
+  padding: 11px 13px;
+  box-shadow: 0 1px 6px rgba(38, 51, 31, 0.07);
+}
+.mch-ventanas-desc {
+  margin: 0 0 9px;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--mch-tinta);
+}
+.mch-ventanas-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 9px;
+}
+.mch-ventana {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 9px 11px;
+  border-radius: 10px;
+  background: var(--mch-papel-2);
+  border: 1px solid rgba(38, 51, 31, 0.1);
+}
+.mch-ventana b {
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 13px;
+  color: var(--mch-verde-hondo);
+}
+.mch-ventana span {
+  font-size: 11.5px;
+  line-height: 1.35;
+  color: var(--mch-tinta);
+}
+.mch-ventana i {
+  font-style: normal;
+  font-weight: 700;
+  color: var(--mch-tinta-suave);
+}
+.mch-nota {
+  margin: 9px 0 0;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--mch-tinta-suave);
+}
+.mch-fuente {
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--mch-ocre);
+  white-space: nowrap;
+}
+
+/* ── Láminas de función (re-rutean a pantallas existentes) ─────────────────── */
+.mch-laminas {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.mch-lamina,
+.mch-calc-toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 60px;
+  padding: 10px 12px;
+  border-radius: 15px;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  background: var(--mch-papel);
+  color: var(--mch-tinta);
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 1px 6px rgba(38, 51, 31, 0.07);
+  transition: transform 140ms ease, box-shadow 140ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.mch-lamina:active,
+.mch-calc-toggle:active { transform: scale(0.988); }
+@media (hover: hover) {
+  .mch-lamina:hover,
+  .mch-calc-toggle:hover { box-shadow: 0 4px 14px rgba(38, 51, 31, 0.13); }
+}
+.mch-lamina:focus-visible,
+.mch-calc-toggle:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 2px;
+}
+.mch-lamina-ic {
+  flex: 0 0 auto;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  font-size: 22px;
+  border-radius: 12px;
+  background: var(--mch-papel-2);
+  border: 1px solid color-mix(in srgb, var(--mch-verde) 40%, transparent);
+}
+.mch-lamina-txt {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.mch-lamina-txt b {
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 14.5px;
+  line-height: 1.2;
+}
+.mch-lamina-txt small {
+  font-size: 11.5px;
+  line-height: 1.3;
+  color: var(--mch-tinta-suave);
+}
+.mch-lamina-ir {
+  flex: 0 0 auto;
+  font-weight: 800;
+  color: var(--mch-verde);
+  opacity: 0.85;
+}
+.mch-calc-toggle.is-open { border-color: var(--mch-verde); }
+
+/* ── Calculadora de grados-día ─────────────────────────────────────────────── */
+.mch-calc {
+  margin-top: 10px;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-radius: 16px;
+  background: var(--mch-papel);
+  padding: 13px 14px 14px;
+  box-shadow: 0 1px 6px rgba(38, 51, 31, 0.07);
+}
+.mch-calc-intro {
+  margin: 0 0 12px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--mch-tinta);
+}
+.mch-calc-grupo {
+  border: 0;
+  border-top: 1px dashed rgba(38, 51, 31, 0.18);
+  margin: 0;
+  padding: 12px 0 4px;
+}
+.mch-calc-grupo:first-of-type { border-top: 0; padding-top: 0; }
+.mch-calc-grupo legend {
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 13.5px;
+  color: var(--mch-verde-hondo);
+  padding: 0;
+  margin-bottom: 8px;
+}
+.mch-calc-grupo legend small {
+  font-weight: 600;
+  color: var(--mch-tinta-suave);
+}
+.mch-calc-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 9px;
+}
+.mch-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-height: 40px;
+  padding: 6px 11px;
+  border-radius: 11px;
+  border: 1.5px solid rgba(38, 51, 31, 0.16);
+  background: var(--mch-papel-2);
+  color: var(--mch-tinta);
+  font-family: var(--mch-body);
+  font-weight: 700;
+  font-size: 12.5px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: border-color 140ms ease, background 140ms ease;
+}
+.mch-chip small {
+  font-weight: 600;
+  font-size: 10px;
+  color: var(--mch-tinta-suave);
+}
+.mch-chip.is-on {
+  border-color: var(--mch-verde);
+  background: color-mix(in srgb, var(--mch-verde) 14%, var(--mch-papel));
+  box-shadow: inset 0 0 0 1px var(--mch-verde);
+}
+.mch-chip:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 2px;
+}
+.mch-calc-temps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+}
+.mch-calc-campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--mch-tinta-suave);
+}
+.mch-calc-campo input {
+  min-height: 44px;
+  padding: 8px 11px;
+  border-radius: 11px;
+  border: 1.5px solid rgba(38, 51, 31, 0.2);
+  background: #fff;
+  color: var(--mch-tinta);
+  font-family: var(--mch-body);
+  font-size: 15px;
+  font-weight: 700;
+}
+.mch-calc-campo input:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 1px;
+  border-color: var(--mch-verde);
+}
+.mch-calc-nota {
+  margin: 8px 0 0;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--mch-tinta-suave);
+}
+.mch-calc-aviso {
+  margin: 12px 0;
+  padding: 10px 12px;
+  border-radius: 11px;
+  background: #fbeecf;
+  border: 1px solid var(--mch-ocre);
+  color: #6b4e12;
+  font-size: 12px;
+  font-weight: 700;
+}
+.mch-calc-resultado {
+  margin: 12px 0;
+  padding: 12px 14px;
+  border-radius: 13px;
+  background: color-mix(in srgb, var(--mch-verde) 10%, var(--mch-papel));
+  border: 1px solid color-mix(in srgb, var(--mch-verde) 35%, transparent);
+}
+.mch-calc-big {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+}
+.mch-calc-big b {
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 30px;
+  line-height: 1;
+  color: var(--mch-verde-hondo);
+}
+.mch-calc-big span {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--mch-tinta-suave);
+}
+.mch-calc-porque {
+  margin: 9px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--mch-tinta);
+}
+.mch-calc-etapa {
+  margin-top: 10px;
+  padding: 11px 13px;
+  border-radius: 12px;
+  background: var(--mch-papel-2);
+  border: 1px solid rgba(38, 51, 31, 0.12);
+}
+.mch-calc-etapa p { margin: 0 0 6px; font-size: 12.5px; line-height: 1.4; }
+.mch-calc-etapa p:last-child { margin-bottom: 0; }
+.mch-calc-etapa-actual b { color: var(--mch-verde-hondo); }
+.mch-calc-etapa-prox { color: var(--mch-tinta-suave); }
+.mch-calc-pie {
+  margin: 12px 0 0;
+  font-size: 10.5px;
+  line-height: 1.4;
+  color: var(--mch-tinta-suave);
+  font-style: italic;
+}
+
+/* ── Saber cultural: calendario lunar ──────────────────────────────────────── */
+.mch-luna {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  margin-top: 20px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: color-mix(in srgb, #3a4a7a 8%, var(--mch-papel));
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-left: 4px solid #5b6ea8;
+}
+.mch-luna-ic { font-size: 22px; line-height: 1.2; flex: 0 0 auto; }
+.mch-luna p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--mch-tinta);
+}
+
+/* ── El agente al pie ──────────────────────────────────────────────────────── */
+.mch-agente {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 20px;
+  min-height: 58px;
+  padding: 10px 14px;
+  border-radius: 15px;
+  border: 1.5px dashed var(--mch-verde);
+  background: color-mix(in srgb, var(--mch-papel-2) 60%, var(--mch-papel));
+  color: var(--mch-tinta);
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.mch-agente > span:first-child { font-size: 22px; }
+.mch-agente b {
+  display: block;
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 14.5px;
+}
+.mch-agente small {
+  display: block;
+  font-size: 11.5px;
+  color: var(--mch-tinta-suave);
+}
+.mch-agente:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 2px;
+}
+
+/* ── Accesibilidad de movimiento ───────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .mch-lamina,
+  .mch-calc-toggle,
+  .mch-seg-btn,
+  .mch-chip { transition: none; }
+  .mch-lamina:active,
+  .mch-calc-toggle:active { transform: none; }
+}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic, Gauge } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -180,6 +180,11 @@ const APRENDER_TILES = [
     { view: 'ciclo_nutrientes', label: 'Ciclo de nutrientes', icon: Recycle, desc: 'Del animal al suelo y la planta', accent: 'text-emerald-400 border-l-emerald-500' },
     { view: 'biopreparados', label: 'Biopreparados', icon: FlaskConical, desc: 'Recetas caseras paso a paso', accent: 'text-lime-400 border-l-lime-500', data: { back: 'dashboard' } },
     { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Salud del suelo y micorrizas', descF2: 'Cómo está su tierra y cómo cuidarla', accent: 'text-amber-400 border-l-amber-500' },
+    // Cuaderno del Suelo (módulo Salud del Suelo): leer el análisis de laboratorio
+    // (pH, MO, N-P-K, aluminio), calculadora de encalado determinista y mejora del
+    // suelo. Complementa la ruta 'suelo' (diagnóstico folk sin laboratorio) y
+    // enlaza a la cromatografía + micorrizas del grafo, sin reimplementarlas.
+    { view: 'salud_suelo', label: 'Cuaderno del Suelo', icon: Gauge, desc: 'Leer el análisis, encalar y mejorar la tierra', descF2: 'Cómo está su tierra, corregir la acidez y mejorarla', accent: 'text-emerald-400 border-l-emerald-500' },
     { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo', descF2: 'Qué es peligroso y cómo cuidarse', accent: 'text-rose-400 border-l-rose-500' },
     { view: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle, desc: 'Cómo funciona Chagra', accent: 'text-violet-400 border-l-violet-500' },
 ];

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -656,17 +656,21 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
             {/* ════════════════════════════════════════════════════════════════
                 "EL RESTO DE SU FINCA" — la hoja cohesiva bajo el hero.
                 ────────────────────────────────────────────────────────────────
-                Con la flag F2 ON (y finca PROPIA, no la red institucional del
-                extensionista), TODO lo que sigue se consolida en UNA hoja clara
-                (.fvh-resto) que sube desde el hero — sin un segundo AgentHero,
-                sin un segundo set de portales (los 4 viven en el hero), sin un
-                segundo saludo. Sólo el INVENTARIO de un vistazo + herramientas +
-                casos + seguimiento + animales. Con la flag OFF, el wrapper es
-                pass-through (clase vacía): el dashboard legacy queda intacto.
+                Con la flag F2 ON, TODO lo que sigue se consolida en UNA hoja
+                clara (.fvh-resto) que sube desde el hero — sin un segundo
+                AgentHero, sin un segundo set de portales (los 4 viven en el
+                hero), sin un segundo saludo. Sólo el INVENTARIO de un vistazo +
+                herramientas + casos + seguimiento + animales. Con la flag OFF,
+                el wrapper es pass-through (clase vacía): el dashboard legacy
+                queda intacto.
 
-                El extensionista (red institucional) NO lleva hoja: su red ocupa
-                el hero completo. ════════════════════════════════════════════ */}
-            {fincaVivaFlag && esExtensionista ? null : (
+                El extensionista/operador ve la RED institucional como PORTADA
+                del hero y, DEBAJO, esta MISMA hoja (aditiva) con "Los mundos de
+                mi finca": la red no reemplaza ni oculta el home — se suma. Antes
+                un gate `esExtensionista ? null` borraba la hoja completa y el
+                operador (que es extensionista por bypass) se quedaba SIN los
+                mundos; ahora la hoja se renderiza para todos los perfiles.
+                ════════════════════════════════════════════════════════════ */}
             <div className={fincaVivaFlag ? 'fvh-resto' : 'contents'} data-testid={fincaVivaFlag ? 'fvh-resto' : undefined}>
             <div className={fincaVivaFlag ? 'fvh-resto-shell' : 'contents'}>
 
@@ -948,7 +952,6 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
             {/* /fvh-resto-shell + /fvh-resto (o /contents con flag OFF) */}
             </div>
             </div>
-            )}
         </div>
     );
 }

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic, CloudRain, Leaf, Gauge } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, Mic, CloudRain, Leaf, Gauge } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -58,6 +58,10 @@ import './dashboard-resto-redistribucion.css';
 // CAPABILITIES_STATUS.md §2.
 import CaseStudyTopWidget from '../CaseStudyTopWidget';
 import CicloVivoWidget from '../CicloVivo/CicloVivoWidget';
+// LOS MUNDOS DE MI FINCA (reestructuración 2.0, V4): el contenedor que agrupa
+// las funciones dispersas del home F2 en 9 mundos coherentes (mundosFinca.js).
+// Solo se monta con la flag F2 ON; el legacy conserva sus tiles.
+import MundosDeMiFinca from './MundosDeMiFinca';
 import ClimaStrip from './ClimaStrip';
 import HoyEnFincaStrip from './HoyEnFincaStrip';
 import AIStatusFooter from './AIStatusFooter';
@@ -196,11 +200,9 @@ const APRENDER_TILES = [
     { view: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle, desc: 'Cómo funciona Chagra', accent: 'text-violet-400 border-l-violet-500' },
 ];
 
-// Reportes para imprimir/llevar a la cooperativa. Antes vivía solo como tarjeta
-// "Informes/CSV" en el grid del vistazo (audit: jerga); en F2 se trae al bloque
-// "Consultar y aprender" con copy campesino ("Sacar reportes"). `informes` es la
-// ruta real (App.jsx). Solo se ofrece como tile en la home F2.
-const REPORTES_TILE_F2 = { view: 'informes', label: 'Sacar reportes', icon: FileText, desc: 'Para imprimir o llevar al banco o la cooperativa', accent: 'text-slate-300 border-l-slate-500' };
+// Reportes ("Sacar reportes", ruta 'informes'): con la reestructuración 2.0
+// vive DENTRO del mundo "Mercado y despensa" (mundosFinca.js) — ya no es un
+// tile suelto del home F2. El legacy (flag OFF) lo conserva vía InformesCard.
 
 // 3) GESTIÓN — "Mi finca": registros y acciones de manejo, sin launcher directo
 //    antes (huérfanas o solo por la mano). Semilleros entra aquí (es gestión de
@@ -697,10 +699,14 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
 
             {fincaVivaFlag ? (
             /* ════════════════════════════════════════════════════════════════
-               HOME F2 EN 5 BLOQUES (audit botones/distribución 2026-06-26).
-               Orden = flujo mental del campesino: estado → tengo → hago →
-               consulto → vendo. Copy campesino. Bloque condicional de proyectos
-               BAJADO. Solo activo con la flag ON; el legacy (else) queda intacto.
+               HOME F2 — REESTRUCTURACIÓN 2.0 "LOS MUNDOS DE MI FINCA" (V4).
+               Flujo: cómo va la finca (estado) → registrar (la acción diaria,
+               voz-primero, ancla del portal "Mi finca") → LOS MUNDOS (todas las
+               herramientas agrupadas en 9 lugares coherentes, mundosFinca.js)
+               → ciclo vivo + casos → pie (FAQ/Ayuda). Reemplaza los 5 bloques
+               del audit 2026-06-26 (las tiles de consultar/aprender, mercado,
+               inventario suelto y seguimiento viven ahora DENTRO de sus
+               mundos). Solo activo con la flag ON; el legacy (else) intacto.
                ════════════════════════════════════════════════════════════════ */
             <>
                 {/* ── BLOQUE 1 · "Cómo va su finca hoy" ───────────────────────
@@ -721,42 +727,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     </div>
                 </div>
 
-                {/* El Ciclo Vivo: portal a la rueda de las 7 fases. Estado real
-                    por función desde chagra-stats.json (se enciende solo). */}
-                <div className="px-4 pt-3 fvh-resto-block">
-                    {blockLabel('El ciclo de su cultivo', 'from-amber-400 to-lime-400')}
-                    <CicloVivoWidget onNavigate={onNavigate} />
-                </div>
-
-                {/* Top problemas activos (casos de estudio, DR-044). Se auto-oculta
-                    si no hay casos → zero footprint. Va tras el estado del día. */}
-                <div className="px-4 pt-3 fvh-resto-block">
-                    <CaseStudyTopWidget onNavigate={onNavigate} maxItems={3} />
-                </div>
-
-                {/* ── BLOQUE 2 · "Sus plantas y animales" ─────────────────────
-                    Agrupa las cinco superficies de plantas que antes estaban
-                    revueltas entre el grid del vistazo y el bloque destacado
-                    (audit §3.4): mis matas (plantas), zonas, plagas, asociaciones
-                    y flora/fauna — más los animales. Así se entiende cuál abrir
-                    para "ver mis matas". */}
-                <div className="px-4 pt-3 fvh-resto-block" data-testid="bloque-plantas-animales">
-                    {blockLabel('Sus plantas y animales', 'from-lime-400 to-emerald-400')}
-                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-                        <PlantasCard onNavigate={onNavigate} variant="grid" />
-                        <ZonasCard onNavigate={onNavigate} variant="grid" />
-                        <PlagasCard onNavigate={onNavigate} variant="grid" />
-                        <AsociacionesCard onNavigate={onNavigate} variant="grid" />
-                        <BiodiversidadCard onNavigate={onNavigate} variant="grid" />
-                    </div>
-                    {mostrarAnimales && (
-                        <div className="mt-3">
-                            <AnimalesCard onNavigate={onNavigate} variant="list" />
-                        </div>
-                    )}
-                </div>
-
-                {/* ── BLOQUE 3 · "Registrar en la finca" ──────────────────────
+                {/* ── BLOQUE 2 · "Registrar en la finca" ──────────────────────
                     El bloque de ACCIÓN: semilleros, cosechar, abonos e insumos
                     (UNIFICA los dos insumos que se solapaban, audit §3.1), labores
                     y la bitácora. Conserva el ancla #finca-gestion: el portal "Mi
@@ -810,43 +781,57 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     </div>
                 </div>
 
-                {/* ── BLOQUE 4 · "Consultar y aprender" ───────────────────────
-                    Lo de consulta ocasional, no del primer scroll (audit §4):
-                    catálogo de plantas + calendario (lo fuerte y grounded, en
-                    tiles grandes), las superficies de contenido (casos,
-                    biopreparados, suelo, seguridad, faq) y "Sacar reportes". El
-                    portal "Aprender" del hero ya entra al hub `aprende`, así que
-                    aquí se filtra ese tile para no duplicar el nombre (audit
-                    §3.5). Colapsable: <details> abierto por defecto. */}
-                <div className="px-4 pt-3 fvh-resto-block" data-testid="bloque-consultar">
-                    <details open className="fvh-consultar">
-                        <summary className="list-none cursor-pointer">
-                            {blockLabel('Consultar y aprender', 'from-violet-400 to-emerald-400')}
-                        </summary>
-                        <div className="grid grid-cols-2 gap-3" data-testid="destacado-tiles">
-                            {DESTACADO_TILES.map((tile) => renderTile(tile, { large: true }))}
-                        </div>
-                        <div className="grid grid-cols-3 gap-3 mt-3" data-testid="aprender-tiles">
-                            {APRENDER_TILES
-                                .filter((tile) => tile.view !== 'aprende')
-                                .map((tile) => renderTile(tile))}
-                            {renderTile(REPORTES_TILE_F2)}
-                        </div>
-                    </details>
+                {/* ── BLOQUE 3 · LOS MUNDOS DE SU FINCA (reestructuración 2.0) ─
+                    EL contenedor: reemplaza la caja de herramientas regada de
+                    antes (tiles de consultar/aprender + inventario suelto +
+                    mercado + seguimiento) por 9 mundos coherentes. Cada función
+                    vieja vive DENTRO de su mundo (mundosFinca.js es la fuente
+                    única; el test de reachability congela el contrato). El gate
+                    de Animales por perfil se conserva (mostrarAnimales). */}
+                <div className="px-4 pt-4 fvh-resto-block" data-testid="bloque-mundos">
+                    <MundosDeMiFinca
+                        onNavigate={onNavigate}
+                        mostrarAnimales={mostrarAnimales}
+                        plantsCount={plantsCount}
+                    />
                 </div>
 
-                {/* ── BLOQUE 5 · "Vender y comprar" ───────────────────────────
-                    Mercado, ya está bien; va al fondo de lo cotidiano. */}
-                {renderMercado()}
+                {/* El Ciclo Vivo: portal a la rueda de las 7 fases. Estado real
+                    por función desde chagra-stats.json (se enciende solo). */}
+                <div className="px-4 pt-3 fvh-resto-block">
+                    {blockLabel('El ciclo de su cultivo', 'from-amber-400 to-lime-400')}
+                    <CicloVivoWidget onNavigate={onNavigate} />
+                </div>
 
-                {/* ── CONDICIONAL · "Sus proyectos de finca" (BAJADO) ─────────
-                    Reforestación · Silvopastoreo · Páramo · Cerdos. Es de nicho
-                    (audit §4): gateado por perfil y BAJADO bajo lo cotidiano para
-                    no robarle el primer scroll a "mis plantas/hoy". */}
-                {renderSeguimiento({ f2: true })}
+                {/* Top problemas activos (casos de estudio, DR-044). Se auto-oculta
+                    si no hay casos → zero footprint. */}
+                <div className="px-4 pt-3 fvh-resto-block">
+                    <CaseStudyTopWidget onNavigate={onNavigate} maxItems={3} />
+                </div>
 
                 {/* "Campo, Javier" (gateado al operador), al fondo. */}
                 {renderJavier()}
+
+                {/* Pie del cuaderno: ayuda y preguntas frecuentes, discretas
+                    pero siempre alcanzables (antes "Preguntas frecuentes" era
+                    un tile de Consultar; el mundo no las necesita). */}
+                <div className="px-4 pt-4 pb-2 flex items-center justify-center gap-2 fvh-resto-block" data-testid="footer-ayuda">
+                    <button
+                        type="button"
+                        onClick={() => onNavigate('faq')}
+                        className="text-xs font-bold underline underline-offset-2 fvh-block-label"
+                    >
+                        Preguntas frecuentes
+                    </button>
+                    <span aria-hidden="true" className="fvh-block-label">·</span>
+                    <button
+                        type="button"
+                        onClick={() => onNavigate('ayuda')}
+                        className="text-xs font-bold underline underline-offset-2 fvh-block-label"
+                    >
+                        Ayuda
+                    </button>
+                </div>
             </>
             ) : (
             /* ════════════════════════════════════════════════════════════════

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic, Leaf } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -178,6 +178,10 @@ const APRENDER_TILES = [
     { view: 'aprende', label: 'Aprender', icon: BookOpen, desc: 'Lecciones agroecológicas con fuente', accent: 'text-emerald-400 border-l-emerald-500' },
     { view: 'casos', label: 'Casos de estudio', labelF2: 'Casos reales', icon: ClipboardList, desc: 'Problemas reales y su tratamiento', descF2: 'Problemas de otras fincas y cómo los resolvieron', accent: 'text-amber-400 border-l-amber-500' },
     { view: 'ciclo_nutrientes', label: 'Ciclo de nutrientes', icon: Recycle, desc: 'Del animal al suelo y la planta', accent: 'text-emerald-400 border-l-emerald-500' },
+    // "Del corral al abono" — mini-app de aprovechamiento del estiércol
+    // (olores/gallinaza · biodigestor con calculadora · abonos). Ruta App.jsx
+    // 'estiercol'. Vecino natural del ciclo de nutrientes: lo hace accionable.
+    { view: 'estiercol', label: 'Del corral al abono', labelF2: 'Del corral al abono', icon: Leaf, desc: 'Aproveche el estiércol: sin olores, biogás y abono', descF2: 'Quítele el olor al estiércol y sáquele abono y gas', accent: 'text-lime-400 border-l-lime-500' },
     { view: 'biopreparados', label: 'Biopreparados', icon: FlaskConical, desc: 'Recetas caseras paso a paso', accent: 'text-lime-400 border-l-lime-500', data: { back: 'dashboard' } },
     { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Salud del suelo y micorrizas', descF2: 'Cómo está su tierra y cómo cuidarla', accent: 'text-amber-400 border-l-amber-500' },
     { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo', descF2: 'Qué es peligroso y cómo cuidarse', accent: 'text-rose-400 border-l-rose-500' },

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, FileText, Mic, CloudRain } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import {
@@ -180,6 +180,9 @@ const APRENDER_TILES = [
     { view: 'ciclo_nutrientes', label: 'Ciclo de nutrientes', icon: Recycle, desc: 'Del animal al suelo y la planta', accent: 'text-emerald-400 border-l-emerald-500' },
     { view: 'biopreparados', label: 'Biopreparados', icon: FlaskConical, desc: 'Recetas caseras paso a paso', accent: 'text-lime-400 border-l-lime-500', data: { back: 'dashboard' } },
     { view: 'suelo', label: 'Suelo', icon: Layers, desc: 'Salud del suelo y micorrizas', descF2: 'Cómo está su tierra y cómo cuidarla', accent: 'text-amber-400 border-l-amber-500' },
+    // Módulo "Agua de la finca" (cosecha de lluvia + riego con medida +
+    // cuidar el nacimiento). Ruta real: App.jsx case 'agua' / #agua.
+    { view: 'agua', label: 'Agua', labelF2: 'El agua de su finca', icon: CloudRain, desc: 'Cosechar lluvia, regar con medida y cuidar el nacimiento', descF2: 'Coseche la lluvia, riegue con medida y cuide su nacimiento', accent: 'text-cyan-400 border-l-cyan-500' },
     { view: 'toxicologia', label: 'Seguridad', icon: ShieldAlert, desc: 'Toxicidad de insumos y riesgo', descF2: 'Qué es peligroso y cómo cuidarse', accent: 'text-rose-400 border-l-rose-500' },
     { view: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle, desc: 'Cómo funciona Chagra', accent: 'text-violet-400 border-l-violet-500' },
 ];

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -162,6 +162,13 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
 
   // ── Cielo real: hora + clima (REUSA atmosphereService, no inventa motor) ──
   const atmosfera = useAtmosferaEscena();
+  // La atmósfera + el TEMA activo: las escenas pintan su cielo interno con la
+  // piel del tema (CIELOS_TEMA) además de la hora/clima reales. Un solo objeto
+  // para no cambiar la firma de las 3 escenas.
+  const atmosferaTema = useMemo(
+    () => ({ ...atmosfera, tema: theme }),
+    [atmosfera, theme],
+  );
 
   // Variante de escena por PERFIL (override duro urbano, invernadero, finca…).
   const variant = useMemo(() => {
@@ -354,12 +361,12 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
 
               {tieneFincaPropia ? (
                 <>
-                  {escala === 'balcon' && <SceneBalcon poblada={poblada} cielo={atmosfera} />}
-                  {escala === 'invernadero' && <SceneInvernadero poblada={poblada} cielo={atmosfera} />}
+                  {escala === 'balcon' && <SceneBalcon poblada={poblada} cielo={atmosferaTema} />}
+                  {escala === 'invernadero' && <SceneInvernadero poblada={poblada} cielo={atmosferaTema} />}
                   {escala === 'finca' && (
                     <SceneFinca
                       poblada={poblada}
-                      cielo={atmosfera}
+                      cielo={atmosferaTema}
                       estructura={estructuraFinca}
                       escalaFinca={variant?.escala}
                     />
@@ -656,9 +663,53 @@ const CIELOS_ESCENA = {
     noche: ['#1d2b4a', '#465a64'],
   },
 };
+/**
+ * CIELOS POR TEMA — la piel del tema DENTRO de la escena (V4, req. "profundizar
+ * el tema en la escena"). Antes los 4 temas casi solo cambiaban la barra y el
+ * degradado del shell: la banda central isométrica seguía con el mismo cielo.
+ * Ahora cada tema fija el cielo INTERNO de la escena por tono de luz:
+ *   · biopunk (base) — navy/teal nocturno-neón incluso de día (coherente con el
+ *     velo neón y el boceto aprobado; adiós al "mediodía suelto").
+ *   · verde-vivo — turquesa fresco + crema frondosa (el look vivo original).
+ *   · nature — cielos de tierra: crema dorada de día, ocres al sol bajo.
+ *   · minimalista — papel: salvia pálida, tonos apagados, noche gris-azul.
+ * Se aplica ANTES que la tabla por escena (que queda como fallback sin tema).
+ * El grade/textura por tema del CSS (.fvh-escena > svg) completa la piel.
+ */
+const CIELOS_TEMA = {
+  biopunk: {
+    dia: ['#16324f', '#2b5a63'],
+    amanecer: ['#3b2f5e', '#b06a55'],
+    atardecer: ['#3a2440', '#c25c4a'],
+    noche: ['#0c1830', '#26404d'],
+  },
+  'verde-vivo': {
+    dia: ['#79c9b7', '#e2f0cf'],
+    amanecer: ['#ecb27a', '#f6ecc4'],
+    atardecer: ['#dd8455', '#f3d99b'],
+    noche: ['#183253', '#3e5a63'],
+  },
+  nature: {
+    dia: ['#d9c493', '#f2e8cd'],
+    amanecer: ['#e0a066', '#f7e6c0'],
+    atardecer: ['#c97a45', '#efd6a0'],
+    noche: ['#26243d', '#5a4a58'],
+  },
+  minimalista: {
+    dia: ['#cfdcd2', '#f3f1e8'],
+    amanecer: ['#e3c3a3', '#f5eddd'],
+    atardecer: ['#d8a887', '#f0e2c8'],
+    noche: ['#31394a', '#5d6672'],
+  },
+};
+
 function cieloEscena(cielo, escena) {
+  const tono = tonoLuz(cielo);
+  // Piel por tema primero (cielo.tema lo inyecta el hero desde useTheme).
+  const porTema = CIELOS_TEMA[cielo?.tema]?.[tono];
+  if (porTema) return porTema;
   const mapa = CIELOS_ESCENA[escena] || CIELOS_ESCENA.finca;
-  return mapa[tonoLuz(cielo)] || mapa.dia;
+  return mapa[tono] || mapa.dia;
 }
 
 /**

--- a/src/components/dashboard/MundoVinetas.jsx
+++ b/src/components/dashboard/MundoVinetas.jsx
@@ -1,0 +1,332 @@
+/**
+ * MundoVinetas — la ilustración propia de cada MUNDO de la finca.
+ *
+ * Cada viñeta es un LUGAR dibujado a mano en vector (mismo lenguaje que los
+ * place-svg de los 4 portales del hero): horizonte + tierra + UN foco propio.
+ * Sin <text> con emoji dentro del SVG (Android/iOS viejos los renderizan
+ * monocromos o vacíos), sin filtros ni foreignObject (rsvg-safe), sin motor
+ * de animación — el movimiento lo pone el CSS (y respeta reduced-motion).
+ *
+ * Todas comparten viewBox 180×90 y `preserveAspectRatio="xMidYMid slice"` para
+ * comportarse como banda de tarjeta y como cabecera de la pantalla de mundo.
+ */
+
+const SVG_PROPS = {
+    className: 'mf-vineta-svg',
+    viewBox: '0 0 180 90',
+    preserveAspectRatio: 'xMidYMid slice',
+    'aria-hidden': true,
+};
+
+/** 🌾 Cultivos y semillas — surcos con milpa joven, sol de mañana. */
+function VinetaCultivos() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#dcedc9" />
+            <circle cx="150" cy="18" r="11" fill="#ffe08a" />
+            <circle cx="150" cy="18" r="6.5" fill="#fff3c4" />
+            <path d="M-4 44 Q46 26 92 40 T184 36 V90 H-4 Z" fill="#9bc172" />
+            <path d="M-4 58 Q60 44 120 56 T184 52 V90 H-4 Z" fill="#6fa356" />
+            {/* surcos en perspectiva */}
+            <g stroke="#4c7a3d" strokeWidth="3" strokeLinecap="round" fill="none" opacity=".55">
+                <path d="M18 90 L52 60" /><path d="M56 90 L78 60" />
+                <path d="M96 90 L104 60" /><path d="M136 90 L130 60" /><path d="M170 90 L154 60" />
+            </g>
+            {/* matas de maíz jóvenes */}
+            <g stroke="#2f6b3a" strokeWidth="2.6" strokeLinecap="round" fill="none">
+                <g><path d="M64 74 v-16" /><path d="M64 66 q-7 -3 -10 -9" /><path d="M64 62 q7 -3 10 -9" /></g>
+                <g><path d="M112 70 v-14" /><path d="M112 64 q-6 -3 -9 -8" /><path d="M112 60 q6 -3 9 -8" /></g>
+            </g>
+            {/* semilla germinando en primer plano */}
+            <g transform="translate(30 68)">
+                <ellipse cx="0" cy="8" rx="7" ry="4.6" fill="#8a5a38" />
+                <path d="M0 6 v-8" stroke="#5a9e4b" strokeWidth="2.4" strokeLinecap="round" fill="none" />
+                <path d="M0 -2 q-5 -2 -6 -7" stroke="#5a9e4b" strokeWidth="2.4" strokeLinecap="round" fill="none" />
+                <path d="M0 -2 q5 -2 6 -7" stroke="#5a9e4b" strokeWidth="2.4" strokeLinecap="round" fill="none" />
+            </g>
+        </svg>
+    );
+}
+
+/** 🌱 El suelo vivo — corte de tierra en capas con raíces y lombriz. */
+function VinetaSuelo() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#f0e2c8" />
+            {/* mata arriba del corte */}
+            <g stroke="#3f8f4e" strokeWidth="2.6" strokeLinecap="round" fill="none">
+                <path d="M92 26 v-12" /><path d="M92 20 q-8 -2 -11 -9" /><path d="M92 17 q8 -2 11 -9" />
+            </g>
+            {/* capas del suelo */}
+            <path d="M0 26 H180 V44 H0 Z" fill="#7a5230" />
+            <path d="M0 44 H180 V64 H0 Z" fill="#8a5a38" />
+            <path d="M0 64 H180 V90 H0 Z" fill="#a0764a" />
+            <path d="M0 26 H180 V30 H0 Z" fill="#4c7a3d" />
+            {/* raíces que bajan */}
+            <g stroke="#e8d3ae" strokeWidth="2" strokeLinecap="round" fill="none" opacity=".85">
+                <path d="M92 28 q-3 10 -10 16 q-5 5 -6 12" />
+                <path d="M92 28 q2 12 9 18 q5 5 5 11" />
+                <path d="M92 28 q0 14 -2 24" />
+            </g>
+            {/* piedras y poros */}
+            <g fill="#6b4626" opacity=".8">
+                <ellipse cx="30" cy="52" rx="4" ry="2.6" /><ellipse cx="150" cy="38" rx="3.4" ry="2.2" />
+                <ellipse cx="52" cy="76" rx="4.6" ry="3" /><ellipse cx="128" cy="72" rx="3.6" ry="2.4" />
+            </g>
+            {/* lombriz feliz (suelo vivo) */}
+            <path d="M20 68 q6 -6 12 0 t12 0 t12 0" stroke="#d98a7a" strokeWidth="4.6" strokeLinecap="round" fill="none" />
+            <circle cx="57.5" cy="67" r="1.2" fill="#5a2e22" />
+        </svg>
+    );
+}
+
+/** 💧 El agua — quebrada, tanque de cosecha de lluvia y gotas. */
+function VinetaAgua() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#d7ecf3" />
+            <path d="M-4 40 Q50 24 100 36 T184 32 V90 H-4 Z" fill="#8fbf80" />
+            {/* quebrada que baja en curvas */}
+            <path d="M96 30 Q78 46 96 58 T88 90 L118 90 Q104 70 120 58 T112 30 Z" fill="#5ab8d8" />
+            <path d="M100 36 Q88 48 100 58 T96 82" stroke="#9fe3ee" strokeWidth="3" strokeLinecap="round" fill="none" opacity=".8" />
+            {/* tanque de lluvia con canaleta */}
+            <g transform="translate(24 40)">
+                <rect x="0" y="10" width="26" height="26" rx="4" fill="#3d7f9e" />
+                <rect x="0" y="10" width="26" height="6" rx="3" fill="#2f6b86" />
+                <path d="M-8 2 L30 -6" stroke="#8a5a38" strokeWidth="3.4" strokeLinecap="round" />
+                <path d="M4 4 q-2 5 2 6" stroke="#9fe3ee" strokeWidth="2.6" strokeLinecap="round" fill="none" />
+            </g>
+            {/* gotas de lluvia */}
+            <g fill="#4e9dc0">
+                <path d="M142 16 q4 6 0 9 q-4 -3 0 -9" /><path d="M158 28 q4 6 0 9 q-4 -3 0 -9" />
+                <path d="M148 44 q4 6 0 9 q-4 -3 0 -9" />
+            </g>
+        </svg>
+    );
+}
+
+/** 🐄 Del corral al abono — montón de compost humeante y carretilla. */
+function VinetaAbono() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#e9ecc9" />
+            <path d="M-4 52 Q60 40 120 50 T184 48 V90 H-4 Z" fill="#9bb45a" />
+            {/* cerca del corral */}
+            <g stroke="#8a5a38" strokeWidth="3" strokeLinecap="round">
+                <path d="M18 40 V58" /><path d="M42 38 V56" /><path d="M66 40 V58" />
+                <path d="M12 46 H72" /><path d="M12 53 H72" />
+            </g>
+            {/* montón de compost con vapor */}
+            <g transform="translate(112 30)">
+                <path d="M-22 34 Q-16 8 4 6 Q26 8 30 34 Z" fill="#6b4626" />
+                <path d="M-14 34 Q-8 16 4 14 Q18 16 22 34 Z" fill="#8a5a38" />
+                <path d="M-4 10 q-3 -6 1 -9 q4 -3 1 -8" stroke="#f6f2e4" strokeWidth="2.4" strokeLinecap="round" fill="none" opacity=".85" />
+                <path d="M10 12 q-3 -5 1 -8" stroke="#f6f2e4" strokeWidth="2.2" strokeLinecap="round" fill="none" opacity=".7" />
+                {/* brote que nace del abono */}
+                <path d="M26 30 v-7 m0 0 q-4 -1 -5 -6 m5 6 q4 -1 5 -6" stroke="#3f8f4e" strokeWidth="2.2" strokeLinecap="round" fill="none" />
+            </g>
+            {/* carretilla */}
+            <g transform="translate(42 64)">
+                <path d="M0 0 L26 0 L21 10 L5 10 Z" fill="#c2562f" />
+                <circle cx="13" cy="15" r="4.6" fill="#4a3527" />
+                <circle cx="13" cy="15" r="1.8" fill="#e9ecc9" />
+                <path d="M26 0 L34 -4" stroke="#7a5230" strokeWidth="2.8" strokeLinecap="round" />
+                <ellipse cx="13" cy="-2" rx="9" ry="3.4" fill="#8a5a38" />
+            </g>
+        </svg>
+    );
+}
+
+/** 🐞 Sanidad de la mata — hoja mordida, mariquita aliada y frasco de biopreparado. */
+function VinetaSanidad() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#f6ded1" />
+            <path d="M-4 58 Q60 46 120 56 T184 52 V90 H-4 Z" fill="#8fae5f" />
+            {/* mata con hoja mordida */}
+            <g transform="translate(58 20)">
+                <path d="M0 52 V16" stroke="#2f6b3a" strokeWidth="3" strokeLinecap="round" fill="none" />
+                <path d="M0 30 Q-16 26 -20 12 Q-4 12 0 24 Z" fill="#5a9e4b" />
+                {/* hoja mordida: borde con mordiscos */}
+                <path d="M0 22 Q16 18 22 5 Q14 6 12 9 Q11 5 8 7 Q7 3 4 6 Q2 10 0 16 Z" fill="#5a9e4b" />
+                <circle cx="16" cy="9" r="2" fill="#f6ded1" />
+            </g>
+            {/* mariquita (control biológico, la aliada) */}
+            <g transform="translate(84 30)">
+                <circle cx="0" cy="0" r="6.4" fill="#d94f30" />
+                <path d="M0 -6.4 V6.4" stroke="#3a2418" strokeWidth="1.6" />
+                <circle cx="0" cy="-6" r="2.6" fill="#3a2418" />
+                <circle cx="-2.8" cy="-1" r="1.3" fill="#3a2418" /><circle cx="2.8" cy="1.6" r="1.3" fill="#3a2418" />
+            </g>
+            {/* frasco de biopreparado con atomizador */}
+            <g transform="translate(126 44)">
+                <rect x="0" y="8" width="20" height="26" rx="5" fill="#7fb069" />
+                <rect x="3" y="14" width="14" height="14" rx="2.5" fill="#f6f2e4" />
+                <path d="M6 20 h8 M6 24 h6" stroke="#7a5230" strokeWidth="1.8" strokeLinecap="round" />
+                <rect x="4" y="0" width="9" height="8" rx="2" fill="#4c7a3d" />
+                <path d="M13 3 h6" stroke="#4c7a3d" strokeWidth="3" strokeLinecap="round" />
+                <g stroke="#6fb6d6" strokeWidth="2" strokeLinecap="round" opacity=".9">
+                    <path d="M24 1 l4 -2" /><path d="M24 4 l5 0" /><path d="M24 7 l4 2" />
+                </g>
+            </g>
+        </svg>
+    );
+}
+
+/** ⛅ El clima — loma con nube de lluvia a un lado y sol al otro. */
+function VinetaClima() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#dce9f2" />
+            <path d="M-4 60 Q56 40 116 56 T184 50 V90 H-4 Z" fill="#7fa968" />
+            {/* sol despejado a la derecha */}
+            <circle cx="140" cy="24" r="12" fill="#ffe08a" />
+            <circle cx="140" cy="24" r="7" fill="#fff3c4" />
+            <g stroke="#ffd24d" strokeWidth="2.6" strokeLinecap="round">
+                <path d="M140 6 v-4" /><path d="M158 24 h4" /><path d="M153 11 l3 -3" /><path d="M153 37 l3 3" />
+            </g>
+            {/* nube con lluvia a la izquierda */}
+            <g>
+                <ellipse cx="44" cy="26" rx="20" ry="11" fill="#f3f6f4" />
+                <ellipse cx="62" cy="30" rx="14" ry="9" fill="#e3ebe9" />
+                <ellipse cx="30" cy="31" rx="12" ry="8" fill="#e3ebe9" />
+                <g stroke="#4e7d9a" strokeWidth="2.4" strokeLinecap="round">
+                    <path d="M32 44 l-3 9" /><path d="M46 46 l-3 9" /><path d="M60 44 l-3 9" />
+                </g>
+            </g>
+            {/* veleta en la loma */}
+            <g transform="translate(94 48)" stroke="#7a5230" strokeWidth="2.6" strokeLinecap="round">
+                <path d="M0 22 V0" />
+                <path d="M0 2 L12 6 L0 10 Z" fill="#c2562f" stroke="none" />
+            </g>
+        </svg>
+    );
+}
+
+/** 🐔 Los animales — gallina en primer plano, vaca al fondo, cerca. */
+function VinetaAnimales() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#f3e3cf" />
+            <path d="M-4 52 Q60 40 120 50 T184 46 V90 H-4 Z" fill="#9bb45a" />
+            {/* cerca */}
+            <g stroke="#8a5a38" strokeWidth="2.8" strokeLinecap="round">
+                <path d="M112 38 V58" /><path d="M136 36 V56" /><path d="M162 38 V58" />
+                <path d="M106 44 H168" /><path d="M106 51 H168" />
+            </g>
+            {/* vaca al fondo (silueta simple con manchas) */}
+            <g transform="translate(126 58)">
+                <ellipse cx="0" cy="0" rx="14" ry="8" fill="#f6f2e4" />
+                <circle cx="12" cy="-4" r="4.6" fill="#f6f2e4" />
+                <ellipse cx="-4" cy="-1" rx="4.6" ry="3.4" fill="#4a3527" />
+                <ellipse cx="5" cy="3" rx="3.4" ry="2.4" fill="#4a3527" />
+                <g stroke="#e0d6c2" strokeWidth="2.6" strokeLinecap="round">
+                    <path d="M-8 7 V14" /><path d="M6 7 V14" />
+                </g>
+            </g>
+            {/* gallina protagonista */}
+            <g transform="translate(48 56)">
+                <ellipse cx="0" cy="0" rx="15" ry="11" fill="#c2562f" />
+                <path d="M-14 -3 Q-22 -1 -24 5 Q-16 7 -11 3 Z" fill="#a8431f" />
+                <circle cx="13" cy="-8" r="6.4" fill="#c2562f" />
+                <path d="M13 -16 q1.6 -3.4 4 -1.6 q-1 2.4 -4 1.6" fill="#d94f30" />
+                <path d="M19 -8 l5 2 l-5 2 Z" fill="#ffd24d" />
+                <circle cx="14.5" cy="-9.5" r="1.4" fill="#2c1c12" />
+                <g stroke="#ffd24d" strokeWidth="2.4" strokeLinecap="round">
+                    <path d="M-4 10 V17" /><path d="M5 10 V17" />
+                </g>
+                {/* pollito */}
+                <circle cx="26" cy="12" r="4.6" fill="#ffd24d" />
+                <circle cx="29" cy="9" r="3" fill="#ffd24d" />
+                <circle cx="30" cy="8.4" r=".9" fill="#2c1c12" />
+            </g>
+        </svg>
+    );
+}
+
+/** 🧺 Mercado y despensa — toldo de plaza, canasta y balanza. */
+function VinetaMercado() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#f7ecd2" />
+            <path d="M-4 62 Q60 52 120 60 T184 56 V90 H-4 Z" fill="#c9b06a" opacity=".6" />
+            {/* puesto con toldo */}
+            <g transform="translate(96 8)">
+                <path d="M-8 14 Q26 2 60 14 L56 26 Q26 16 -4 26 Z" fill="#c2562f" />
+                <g fill="#f6f2e4">
+                    <path d="M2 24 Q6 15 10 13 L14 12 Q10 16 8 25 Z" />
+                    <path d="M22 20 Q26 12 30 11 L34 11 Q30 14 28 21 Z" />
+                    <path d="M42 21 Q46 13 50 13 L54 14 Q50 17 48 24 Z" />
+                </g>
+                <rect x="0" y="26" width="4" height="38" fill="#8a5a38" />
+                <rect x="48" y="26" width="4" height="38" fill="#8a5a38" />
+                <rect x="-4" y="48" width="60" height="10" rx="3" fill="#a0764a" />
+                {/* productos sobre la mesa */}
+                <circle cx="10" cy="44" r="5" fill="#d94f30" />
+                <circle cx="22" cy="44" r="5" fill="#ffd24d" />
+                <path d="M34 48 q0 -9 6 -9 q6 0 6 9 Z" fill="#5a9e4b" />
+            </g>
+            {/* canasta en primer plano */}
+            <g transform="translate(30 52)">
+                <path d="M-16 0 Q0 -8 16 0 L12 18 Q0 22 -12 18 Z" fill="#caa066" />
+                <path d="M-12 4 H12 M-11 10 H11" stroke="#8a5a38" strokeWidth="1.8" strokeLinecap="round" />
+                <path d="M-8 -2 Q0 -14 8 -2" stroke="#8a5a38" strokeWidth="2.6" fill="none" strokeLinecap="round" />
+                <circle cx="-4" cy="-3" r="4" fill="#d94f30" />
+                <circle cx="5" cy="-4" r="4" fill="#5a9e4b" />
+            </g>
+        </svg>
+    );
+}
+
+/** 🌳 Diseño de la finca — colinas con árboles en curvas de nivel y casita. */
+function VinetaDisenio() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#d8e9d2" />
+            <path d="M-4 46 Q50 22 110 40 T184 34 V90 H-4 Z" fill="#79a35e" />
+            <path d="M-4 64 Q70 50 184 60 V90 H-4 Z" fill="#5d8c49" />
+            {/* curvas de nivel */}
+            <g stroke="#4c7a3d" strokeWidth="2" strokeLinecap="round" fill="none" opacity=".5">
+                <path d="M8 56 Q60 44 120 52 T176 48" />
+                <path d="M4 72 Q70 60 176 68" />
+            </g>
+            {/* árboles en línea (cerca viva) */}
+            <g>
+                <g transform="translate(34 40)"><path d="M0 12 V4" stroke="#7a5230" strokeWidth="2.6" strokeLinecap="round" /><circle cx="0" cy="-2" r="7" fill="#3f8f4e" /><circle cx="-3" cy="-4" r="3" fill="#5a9e4b" /></g>
+                <g transform="translate(66 34)"><path d="M0 12 V4" stroke="#7a5230" strokeWidth="2.6" strokeLinecap="round" /><circle cx="0" cy="-2" r="8" fill="#2f6b3a" /><circle cx="-3" cy="-4" r="3.4" fill="#4c8a4a" /></g>
+                <g transform="translate(100 38)"><path d="M0 12 V4" stroke="#7a5230" strokeWidth="2.6" strokeLinecap="round" /><circle cx="0" cy="-2" r="7" fill="#3f8f4e" /><circle cx="-3" cy="-4" r="3" fill="#5a9e4b" /></g>
+            </g>
+            {/* casita entre lo verde */}
+            <g transform="translate(134 44)">
+                <polygon points="0,0 12,-9 24,0" fill="#c2562f" />
+                <rect x="2" y="0" width="20" height="14" fill="#f6efe0" />
+                <rect x="9" y="5" width="6" height="9" fill="#7a5230" />
+            </g>
+            {/* pájaro del monte */}
+            <path d="M52 16 q4 -4 8 0 q4 -4 8 0" stroke="#4a3527" strokeWidth="2" strokeLinecap="round" fill="none" />
+        </svg>
+    );
+}
+
+/** Viñeta por id de mundo (fuente única para tarjeta + pantalla de mundo). */
+const VINETAS = {
+    cultivos: VinetaCultivos,
+    suelo: VinetaSuelo,
+    agua: VinetaAgua,
+    abono: VinetaAbono,
+    sanidad: VinetaSanidad,
+    clima: VinetaClima,
+    animales: VinetaAnimales,
+    mercado: VinetaMercado,
+    disenio: VinetaDisenio,
+};
+
+/**
+ * La viñeta ilustrada de un mundo.
+ * @param {{ mundoId: string }} props
+ */
+export default function MundoVineta({ mundoId }) {
+    const Vineta = VINETAS[mundoId];
+    if (!Vineta) return null;
+    return <Vineta />;
+}

--- a/src/components/dashboard/MundosDeMiFinca.jsx
+++ b/src/components/dashboard/MundosDeMiFinca.jsx
@@ -30,7 +30,8 @@ export default function MundosDeMiFinca({ onNavigate, mostrarAnimales = true, pl
     const mundos = MUNDOS_FINCA.filter((m) => m.gate !== 'animales' || mostrarAnimales);
 
     const abrir = (m) => {
-        if (m.directo) onNavigate?.(m.directo.view, m.directo.data);
+        if (m.portada) onNavigate?.(m.portada);
+        else if (m.directo) onNavigate?.(m.directo.view, m.directo.data);
         else onNavigate?.('mundo', { mundo: m.id });
     };
 

--- a/src/components/dashboard/MundosDeMiFinca.jsx
+++ b/src/components/dashboard/MundosDeMiFinca.jsx
@@ -1,0 +1,103 @@
+/*
+ * i18n (ADR-050): copy de navegación del home en español Colombia, pendiente de
+ * migrar a src/config/messages.js — mismo criterio que DashboardLive.jsx.
+ */
+import { MUNDOS_FINCA } from './mundosFinca';
+import MundoVineta from './MundoVinetas';
+import './mundos-finca.css';
+
+/**
+ * MundosDeMiFinca — la grilla de LOS MUNDOS DE MI FINCA en el home F2.
+ *
+ * El contenedor que reemplaza la caja de herramientas regada (~15 tiles planas
+ * + inventario + mercado + seguimiento) por 9 LUGARES coherentes: cada tarjeta
+ * es un mundo ilustrado con su paleta de tierra propia; al entrar, sus
+ * funciones agrupadas (MundoScreen, ruta 'mundo'). Los mundos de UNA sola
+ * pantalla (Agua, Del corral al abono, Clima) navegan directo, sin pantalla
+ * intermedia vacía.
+ *
+ * La fuente única del mapa mundo→funciones es mundosFinca.js. El agente y el
+ * registro por voz NO viven aquí: quedan siempre presentes en el hero y en el
+ * bloque "Registrar en la finca".
+ *
+ * @param {Object} props
+ * @param {(view: string, data?: any) => void} props.onNavigate
+ * @param {boolean} [props.mostrarAnimales]  gate por perfil del mundo Animales
+ *   (mismo criterio que la tarjeta Animales del home: un urbano no lo ve).
+ * @param {number} [props.plantsCount]  matas sembradas (sello vivo en Cultivos).
+ */
+export default function MundosDeMiFinca({ onNavigate, mostrarAnimales = true, plantsCount = 0 }) {
+    const mundos = MUNDOS_FINCA.filter((m) => m.gate !== 'animales' || mostrarAnimales);
+
+    const abrir = (m) => {
+        if (m.directo) onNavigate?.(m.directo.view, m.directo.data);
+        else onNavigate?.('mundo', { mundo: m.id });
+    };
+
+    // Sello vivo por mundo (dato real, nunca inventado): hoy solo Cultivos
+    // lleva el conteo de matas sembradas del store.
+    const sello = (m) => {
+        if (m.id === 'cultivos' && plantsCount > 0) {
+            return plantsCount === 1 ? '1 mata sembrada' : `${plantsCount} matas sembradas`;
+        }
+        return null;
+    };
+
+    return (
+        <section className="mf" aria-label="Los mundos de su finca" data-testid="mundos-finca">
+            <header className="mf-head">
+                <h2 className="mf-tit">Los mundos de su finca</h2>
+                <p className="mf-sub">
+                    Cada mundo es un lugar de su finca: entre y adentro están todas sus herramientas.
+                </p>
+            </header>
+
+            <div className="mf-grid">
+                {mundos.map((m, i) => {
+                    const entradas = m.entradas || [];
+                    const visibles = entradas.slice(0, 3);
+                    const resto = entradas.length - visibles.length;
+                    const selloTxt = sello(m);
+                    const aria = m.directo
+                        ? `${m.titulo}: ${m.lema}`
+                        : `${m.titulo}: ${m.lema}. Adentro: ${entradas.map((e) => e.label).join(', ')}.`;
+                    return (
+                        <button
+                            key={m.id}
+                            type="button"
+                            className={`mf-card ${m.featured ? 'mf-card--featured' : ''}`}
+                            style={{ '--mf-a': m.tinte[0], '--mf-b': m.tinte[1], '--mf-i': i }}
+                            data-testid={`mundo-${m.id}`}
+                            onClick={() => abrir(m)}
+                            aria-label={aria}
+                        >
+                            <span className="mf-vineta" aria-hidden="true">
+                                <MundoVineta mundoId={m.id} />
+                                {selloTxt && <span className="mf-sello">{selloTxt}</span>}
+                            </span>
+                            <span className="mf-body">
+                                <span className="mf-nombre">
+                                    <span className="mf-emoji" aria-hidden="true">{m.emoji}</span>
+                                    <b>{m.titulo}</b>
+                                </span>
+                                <span className="mf-lema">{m.lema}</span>
+                                {entradas.length > 0 ? (
+                                    <span className="mf-adentro" aria-hidden="true">
+                                        {visibles.map((e) => (
+                                            <span key={e.view} className="mf-chip">{e.label}</span>
+                                        ))}
+                                        {resto > 0 && <span className="mf-chip mf-chip--mas">+{resto} más</span>}
+                                    </span>
+                                ) : (
+                                    <span className="mf-adentro" aria-hidden="true">
+                                        <span className="mf-chip mf-chip--entrar">Entrar →</span>
+                                    </span>
+                                )}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+        </section>
+    );
+}

--- a/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen, cleanup, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * DashboardLive.extensionistaMundos.test.jsx — REGRESIÓN del gate del home V4.
+ *
+ * Bug: en el home finca-viva (flag F2 ON), el OPERADOR es extensionista por
+ * bypass (operator_override → esOperador → esExtensionista). Un gate
+ * `esExtensionista ? null` borraba la hoja `.fvh-resto` COMPLETA, así que el
+ * operador/extensionista se quedaba SIN "Los mundos de mi finca" (mundos-finca)
+ * mientras un campesino normal SÍ los veía.
+ *
+ * Fix: la red institucional sigue siendo la PORTADA del hero, pero la hoja
+ * .fvh-resto (con los mundos) se renderiza ADITIVAMENTE debajo para TODOS los
+ * perfiles. Este test congela ese contrato: extensionista/operador ve la RED
+ * arriba Y la grilla de mundos abajo.
+ */
+
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => true, // el operador ve todo (renderJavier, etc.)
+}));
+
+vi.mock('../../../config/fincaVivaHomeFlag', () => ({
+  fincaVivaHomePerfilActivo: () => true, // home F2 ON
+}));
+
+// El operador/extensionista: modo supervisor multi-finca activo.
+vi.mock('../../../config/extensionistaAccess', () => ({
+  esExtensionistaActual: () => true,
+}));
+
+// El hero real es pesado: lo stubeamos pero RENDERIZAMOS sus children para que
+// la red institucional (que va como child cuando esExtensionista) sea visible.
+vi.mock('../FincaVivaHero', () => ({
+  default: (props) => (
+    <div data-testid="finca-viva-hero" data-titulo={props.titulo}>
+      {props.children}
+    </div>
+  ),
+}));
+vi.mock('../FincaRedInstitucional', () => ({
+  default: () => <div data-testid="red-institucional" />,
+}));
+
+vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
+vi.mock('../../OnboardingHero', () => ({ default: () => <div /> }));
+vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
+vi.mock('../MiFincaVivaHomeCard', () => ({ default: () => <div /> }));
+vi.mock('../../CaseStudyTopWidget', () => ({ default: () => null }));
+vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
+vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));
+vi.mock('../AIStatusFooter', () => ({ default: () => <div /> }));
+vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div /> }));
+
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({
+    plants: [{ id: 'p1' }], lands: [], materials: [], isHydrated: true, iotAlerts: [],
+  }),
+}));
+vi.mock('../../../db/farmProcessCache', () => ({ listFarmProcesses: vi.fn(async () => []) }));
+
+let mockProfile = { rol: 'campesino', piso_confirmado: '1', finca_altitud: '1800' };
+vi.mock('../../../services/userProfileService', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getProfile: vi.fn(() => mockProfile),
+    hasManualModuleVisibility: vi.fn(() => true),
+  };
+});
+
+globalThis.ResizeObserver = globalThis.ResizeObserver || class { observe() {} unobserve() {} disconnect() {} };
+
+import DashboardLive from '../DashboardLive';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  localStorage.setItem('chagra:operator_override', '1');
+  mockProfile = { rol: 'campesino', piso_confirmado: '1', finca_altitud: '1800' };
+});
+afterEach(() => cleanup());
+
+describe('DashboardLive — operador/extensionista ve los mundos (aditivo, no reemplazo)', () => {
+  test('la RED institucional es la portada Y "Los mundos de mi finca" se ven debajo', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+
+    // La red institucional ocupa el hero (portada del supervisor).
+    await waitFor(() => expect(screen.getByTestId('red-institucional')).toBeInTheDocument());
+    expect(screen.getByTestId('finca-viva-hero').getAttribute('data-titulo'))
+      .toBe('Red de fincas que acompaño');
+
+    // Y la hoja .fvh-resto NO se oculta: la grilla de mundos está presente.
+    const bloque = screen.getByTestId('bloque-mundos');
+    expect(within(bloque).getByTestId('mundos-finca')).toBeInTheDocument();
+    // La hoja completa se renderiza (antes era null para el extensionista).
+    expect(screen.getByTestId('fvh-resto')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -152,9 +152,10 @@ describe('Home F2 — reestructuración 2.0 "Los mundos de mi finca" (V4)', () =
     render(<DashboardLive onNavigate={onNavigate} />);
     await screen.findByTestId('bloque-mundos');
 
-    // Mundo con entradas → pantalla de mundo.
+    // Cultivos tiene PORTADA a medida (hub) → navega a su vista propia.
     fireEvent.click(screen.getByTestId('mundo-cultivos'));
-    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'cultivos' });
+    expect(onNavigate).toHaveBeenCalledWith('mundo_cultivos');
+    // Mundo con entradas y sin portada → pantalla de mundo genérica.
     fireEvent.click(screen.getByTestId('mundo-mercado'));
     expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'mercado' });
 

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -162,7 +162,7 @@ describe('Home F2 — reorganización en 5 bloques (audit 2026-06-26)', () => {
     const labels = within(aprender).getAllByRole('button').map(labelOf);
     expect(labels).not.toContain('Aprender');
     expect(labels).toEqual([
-      'Casos reales', 'Ciclo de nutrientes', 'Biopreparados', 'Suelo', 'Seguridad', 'Preguntas frecuentes', 'Sacar reportes',
+      'Casos reales', 'Ciclo de nutrientes', 'Del corral al abono', 'Biopreparados', 'Suelo', 'Seguridad', 'Preguntas frecuentes', 'Sacar reportes',
     ]);
   });
 

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -83,18 +83,16 @@ const labelOf = (el) => el.getAttribute('aria-label')?.split(':')[0];
 const indexInDom = (node) =>
   Array.prototype.indexOf.call(document.querySelectorAll('[data-testid]'), node);
 
-describe('Home F2 — reorganización en 5 bloques (audit 2026-06-26)', () => {
-  test('los 5 bloques existen en el orden del flujo del campesino', async () => {
+describe('Home F2 — reestructuración 2.0 "Los mundos de mi finca" (V4)', () => {
+  test('el flujo: estado → registrar → LOS MUNDOS → pie de ayuda, en orden', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('bloque-finca-hoy')).toBeInTheDocument());
 
-    // estado → tengo → hago → consulto → vendo.
     const blocks = [
-      'bloque-finca-hoy',        // 1. Cómo va su finca hoy
-      'bloque-plantas-animales', // 2. Sus plantas y animales
-      'bloque-registrar',        // 3. Registrar en la finca
-      'bloque-consultar',        // 4. Consultar y aprender
-      'mercado-tiles',           // 5. Vender y comprar
+      'bloque-finca-hoy',  // 1. Cómo va su finca hoy
+      'bloque-registrar',  // 2. Registrar en la finca (voz-primero, ancla)
+      'bloque-mundos',     // 3. LOS MUNDOS DE SU FINCA
+      'footer-ayuda',      // pie: FAQ · Ayuda
     ];
     for (const b of blocks) expect(screen.getByTestId(b)).toBeInTheDocument();
 
@@ -119,17 +117,7 @@ describe('Home F2 — reorganización en 5 bloques (audit 2026-06-26)', () => {
     expect(screen.getAllByTestId('hoy-strip')).toHaveLength(1);
   });
 
-  test('BLOQUE 2 agrupa plantas, zonas, plagas, asociaciones y flora/fauna', async () => {
-    render(<DashboardLive onNavigate={vi.fn()} />);
-    const block = await screen.findByTestId('bloque-plantas-animales');
-    const txt = block.textContent;
-    expect(block).toHaveTextContent('Sus plantas y animales');
-    for (const t of ['Mis plantas', 'Mis zonas', 'Plagas', 'Asociaciones', 'Plantas y animales del monte']) {
-      expect(txt).toContain(t);
-    }
-  });
-
-  test('BLOQUE 3 "Registrar" unifica abonos e insumos y usa copy campesino', async () => {
+  test('"Registrar" unifica abonos e insumos y usa copy campesino', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
     const block = await screen.findByTestId('bloque-registrar');
     const gestion = within(block).getByTestId('gestion-tiles');
@@ -139,7 +127,7 @@ describe('Home F2 — reorganización en 5 bloques (audit 2026-06-26)', () => {
     expect(block).toHaveTextContent('Bitácora');
   });
 
-  test('BLOQUE 3 conserva el ancla #finca-gestion (destino del portal Mi finca)', async () => {
+  test('"Registrar" conserva el ancla #finca-gestion (destino del portal Mi finca)', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
     const block = await screen.findByTestId('bloque-registrar');
     const ancla = document.getElementById('finca-gestion');
@@ -147,61 +135,58 @@ describe('Home F2 — reorganización en 5 bloques (audit 2026-06-26)', () => {
     expect(ancla).toBe(block);
   });
 
-  test('BLOQUE 4 "Consultar y aprender" con catálogo, calendario, contenido y reportes', async () => {
+  test('LOS MUNDOS: la grilla monta los 9 mundos con su copy', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const block = await screen.findByTestId('bloque-consultar');
-
-    // Lo fuerte y grounded, con copy campesino.
-    const destacado = within(block).getByTestId('destacado-tiles');
-    expect(within(destacado).getAllByRole('button').map(labelOf))
-      .toEqual(['Qué puedo sembrar', 'Calendario de la finca']);
-
-    // El contenido consolidado + "Sacar reportes"; NO duplica el hub "Aprender"
-    // (ese es el portal del hero en F2).
-    const aprender = within(block).getByTestId('aprender-tiles');
-    const labels = within(aprender).getAllByRole('button').map(labelOf);
-    expect(labels).not.toContain('Aprender');
-    expect(labels).toEqual([
-      'Casos reales', 'Ciclo de nutrientes', 'Del corral al abono', 'Biopreparados', 'Suelo', 'El agua de su finca', 'Cuaderno del Suelo', 'Seguridad', 'Preguntas frecuentes', 'Sacar reportes',
-    ]);
+    const block = await screen.findByTestId('bloque-mundos');
+    expect(within(block).getByTestId('mundos-finca')).toBeInTheDocument();
+    for (const id of ['cultivos', 'suelo', 'agua', 'abono', 'sanidad', 'clima', 'animales', 'mercado', 'disenio']) {
+      expect(within(block).getByTestId(`mundo-${id}`)).toBeInTheDocument();
+    }
+    expect(block).toHaveTextContent('Los mundos de su finca');
+    expect(block).toHaveTextContent('Cultivos y semillas');
+    expect(block).toHaveTextContent('Sanidad de la mata');
   });
 
-  test('BLOQUE 5 Mercado al fondo y navega a la ruta mercado', async () => {
+  test('mundos con pantalla propia navegan a la ruta mundo; los directos a su vista', async () => {
     const onNavigate = vi.fn();
     render(<DashboardLive onNavigate={onNavigate} />);
-    const block = await screen.findByTestId('mercado-tiles');
-    fireEvent.click(within(block).getByRole('button', { name: /Mercado/ }));
-    expect(onNavigate).toHaveBeenCalledWith('mercado', undefined);
+    await screen.findByTestId('bloque-mundos');
+
+    // Mundo con entradas → pantalla de mundo.
+    fireEvent.click(screen.getByTestId('mundo-cultivos'));
+    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'cultivos' });
+    fireEvent.click(screen.getByTestId('mundo-mercado'));
+    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'mercado' });
+
+    // Mundos de UNA pantalla → directo, sin intermedia vacía.
+    fireEvent.click(screen.getByTestId('mundo-agua'));
+    expect(onNavigate).toHaveBeenCalledWith('agua', undefined);
+    fireEvent.click(screen.getByTestId('mundo-abono'));
+    expect(onNavigate).toHaveBeenCalledWith('estiercol', undefined);
+    fireEvent.click(screen.getByTestId('mundo-clima'));
+    expect(onNavigate).toHaveBeenCalledWith('hoy_finca', undefined);
   });
 
-  test('"Sus proyectos de finca" va MÁS ABAJO que lo cotidiano (estado/registrar)', async () => {
+  test('las tiles sueltas viejas ya NO existen en F2 (viven dentro de sus mundos)', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    await screen.findByTestId('seguimiento-cards');
-    const seguimiento = screen.getByTestId('seguimiento-cards');
-    const registrar = screen.getByTestId('bloque-registrar');
-    const hoy = screen.getByTestId('bloque-finca-hoy');
-    // El bloque condicional de proyectos queda debajo de lo cotidiano.
-    expect(indexInDom(seguimiento)).toBeGreaterThan(indexInDom(registrar));
-    expect(indexInDom(seguimiento)).toBeGreaterThan(indexInDom(hoy));
-    // Y lleva su rótulo campesino renombrado.
-    expect(seguimiento.closest('[class*="px-4"]')).toHaveTextContent('Sus proyectos de finca');
+    await screen.findByTestId('bloque-mundos');
+    // Los bloques desmontados por la reestructuración.
+    expect(screen.queryByTestId('bloque-plantas-animales')).toBeNull();
+    expect(screen.queryByTestId('bloque-consultar')).toBeNull();
+    expect(screen.queryByTestId('destacado-tiles')).toBeNull();
+    expect(screen.queryByTestId('aprender-tiles')).toBeNull();
+    expect(screen.queryByTestId('mercado-tiles')).toBeNull();
+    expect(screen.queryByTestId('seguimiento-cards')).toBeNull();
   });
 
-  test('los tiles navegan a sus rutas reales (directorio, calendario, casos, biopreparados con back, reportes)', async () => {
+  test('el pie mantiene FAQ y Ayuda alcanzables', async () => {
     const onNavigate = vi.fn();
     render(<DashboardLive onNavigate={onNavigate} />);
-    await screen.findByTestId('bloque-consultar');
-
-    fireEvent.click(screen.getByRole('button', { name: /^Qué puedo sembrar/ }));
-    expect(onNavigate).toHaveBeenCalledWith('directorio', undefined);
-    fireEvent.click(screen.getByRole('button', { name: /^Calendario de la finca/ }));
-    expect(onNavigate).toHaveBeenCalledWith('calendario_finca', undefined);
-    fireEvent.click(screen.getByRole('button', { name: /^Casos reales/ }));
-    expect(onNavigate).toHaveBeenCalledWith('casos', undefined);
-    fireEvent.click(screen.getByRole('button', { name: /^Biopreparados/ }));
-    expect(onNavigate).toHaveBeenCalledWith('biopreparados', { back: 'dashboard' });
-    fireEvent.click(screen.getByRole('button', { name: /^Sacar reportes/ }));
-    expect(onNavigate).toHaveBeenCalledWith('informes', undefined);
+    const pie = await screen.findByTestId('footer-ayuda');
+    fireEvent.click(within(pie).getByRole('button', { name: /Preguntas frecuentes/ }));
+    expect(onNavigate).toHaveBeenCalledWith('faq');
+    fireEvent.click(within(pie).getByRole('button', { name: /^Ayuda$/ }));
+    expect(onNavigate).toHaveBeenCalledWith('ayuda');
   });
 
   test('el hero recibe onGestionar y, al invocarlo, hace scroll al ancla de gestión (no navega al juego)', async () => {

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -162,7 +162,7 @@ describe('Home F2 — reorganización en 5 bloques (audit 2026-06-26)', () => {
     const labels = within(aprender).getAllByRole('button').map(labelOf);
     expect(labels).not.toContain('Aprender');
     expect(labels).toEqual([
-      'Casos reales', 'Ciclo de nutrientes', 'Biopreparados', 'Suelo', 'Seguridad', 'Preguntas frecuentes', 'Sacar reportes',
+      'Casos reales', 'Ciclo de nutrientes', 'Biopreparados', 'Suelo', 'Cuaderno del Suelo', 'Seguridad', 'Preguntas frecuentes', 'Sacar reportes',
     ]);
   });
 

--- a/src/components/dashboard/__tests__/MundosDeMiFinca.reachability.test.jsx
+++ b/src/components/dashboard/__tests__/MundosDeMiFinca.reachability.test.jsx
@@ -1,0 +1,122 @@
+/**
+ * LOS MUNDOS DE MI FINCA — contrato de ALCANZABILIDAD (reestructuración 2.0).
+ *
+ * La reestructuración quitó del home F2 las tiles sueltas (consultar/aprender,
+ * inventario, mercado, seguimiento). Este test CONGELA el contrato de que nada
+ * quedó huérfano:
+ *   1. Toda función que el home F2 exponía sigue alcanzable vía mundos.
+ *   2. Toda vista referida por el manifiesto EXISTE en el router real
+ *      (case '<view>' en App.jsx, o la familia seguimiento_*).
+ *   3. La pantalla de mundo re-rutea de verdad (click → onNavigate) y su
+ *      fallback sin id muestra el índice, nunca una pantalla rota.
+ */
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+import { MUNDOS_FINCA, mundosViews, getMundo } from '../mundosFinca';
+import MundosDeMiFinca from '../MundosDeMiFinca';
+import MundoScreen from '../../MundoScreen';
+
+afterEach(() => cleanup());
+
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+const appSrc = fs.readFileSync(path.resolve(__dir, '../../../App.jsx'), 'utf8');
+
+describe('Mundos — el mapa cubre todo lo que el home F2 exponía (sin huérfanos)', () => {
+  // Las vistas que ANTES eran tiles/tarjetas sueltas del home F2 y ahora deben
+  // vivir dentro de un mundo. Si alguien quita una entrada del manifiesto sin
+  // reubicarla, este test truena.
+  const VIEWS_QUE_NO_PUEDEN_QUEDAR_HUERFANAS = [
+    // Consultar y aprender (ex bloque 4)
+    'directorio', 'calendario_finca', 'casos', 'ciclo_nutrientes', 'estiercol',
+    'biopreparados', 'suelo', 'agua', 'salud_suelo', 'toxicologia', 'informes',
+    // Inventario/plantas y animales (ex bloque 2)
+    'activos', 'mapa', 'reportar_invasora', 'asociaciones', 'biodiversidad', 'animales',
+    // Mercado (ex bloque 5)
+    'mercado',
+    // Seguimiento de procesos (ex tarjetas condicionales)
+    'seguimiento_reforestacion', 'seguimiento_silvopastoreo', 'seguimiento_paramo', 'seguimiento_cerdos',
+  ];
+
+  test('toda vista del home viejo sigue alcanzable vía mundos', () => {
+    const views = new Set(mundosViews());
+    for (const v of VIEWS_QUE_NO_PUEDEN_QUEDAR_HUERFANAS) {
+      expect(views.has(v), `vista huérfana: ${v} no está en ningún mundo`).toBe(true);
+    }
+  });
+
+  test('toda vista del manifiesto existe en el router real (App.jsx)', () => {
+    for (const v of mundosViews()) {
+      const enRouter = appSrc.includes(`case '${v}':`)
+        // La familia seguimiento_<key> se resuelve por parseSeguimientoView.
+        || (/^seguimiento_/.test(v) && appSrc.includes('parseSeguimientoView'));
+      expect(enRouter, `la vista '${v}' del manifiesto no existe en App.jsx`).toBe(true);
+    }
+    // Y la propia ruta de mundo existe.
+    expect(appSrc).toContain("case 'mundo':");
+  });
+
+  test('el manifiesto es sano: ids únicos, tinte, y directo XOR entradas', () => {
+    const ids = MUNDOS_FINCA.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const m of MUNDOS_FINCA) {
+      expect(Array.isArray(m.tinte) && m.tinte.length === 2, `tinte de ${m.id}`).toBe(true);
+      const tieneDirecto = !!m.directo;
+      const tieneEntradas = (m.entradas || []).length > 0;
+      expect(tieneDirecto !== tieneEntradas, `${m.id} debe ser directo O tener entradas`).toBe(true);
+    }
+  });
+});
+
+describe('MundosDeMiFinca — grilla del home', () => {
+  test('el gate de Animales por perfil oculta SOLO ese mundo', () => {
+    render(<MundosDeMiFinca onNavigate={vi.fn()} mostrarAnimales={false} />);
+    expect(screen.queryByTestId('mundo-animales')).toBeNull();
+    expect(screen.getByTestId('mundo-cultivos')).toBeInTheDocument();
+    expect(screen.getByTestId('mundo-sanidad')).toBeInTheDocument();
+  });
+
+  test('el sello vivo de Cultivos usa el conteo real de matas', () => {
+    render(<MundosDeMiFinca onNavigate={vi.fn()} plantsCount={7} />);
+    expect(screen.getByTestId('mundo-cultivos')).toHaveTextContent('7 matas sembradas');
+  });
+});
+
+describe('MundoScreen — el mundo por dentro re-rutea a las vistas reales', () => {
+  test('cada entrada navega a su vista (con su data)', () => {
+    const onNavigate = vi.fn();
+    render(<MundoScreen mundoId="sanidad" onBack={vi.fn()} onNavigate={onNavigate} />);
+    const mundo = getMundo('sanidad');
+    for (const e of mundo.entradas) {
+      fireEvent.click(screen.getByTestId(`entrada-${e.view}`));
+      expect(onNavigate).toHaveBeenCalledWith(e.view, e.data);
+    }
+    // Biopreparados conserva su back al dashboard (fix del onBack huérfano).
+    expect(onNavigate).toHaveBeenCalledWith('biopreparados', { back: 'dashboard' });
+  });
+
+  test('el agente queda siempre presente en el pie del mundo', () => {
+    const onNavigate = vi.fn();
+    render(<MundoScreen mundoId="suelo" onBack={vi.fn()} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('mundo-agente'));
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+  });
+
+  test('sin id (recarga/enlace viejo) muestra el índice de mundos, no un error', () => {
+    const onNavigate = vi.fn();
+    render(<MundoScreen mundoId={undefined} onBack={vi.fn()} onNavigate={onNavigate} />);
+    const indice = screen.getByTestId('mundo-indice');
+    // Todos los mundos listados y navegables.
+    const botones = within(indice).getAllByRole('button');
+    expect(botones.length).toBe(MUNDOS_FINCA.length);
+    fireEvent.click(within(indice).getByRole('button', { name: /El suelo vivo/ }));
+    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'suelo' });
+    fireEvent.click(within(indice).getByRole('button', { name: /^El agua/ }));
+    expect(onNavigate).toHaveBeenCalledWith('agua', undefined);
+  });
+});

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -203,6 +203,51 @@
 [data-theme="nature"] .fvh,
 [data-theme="minimalista"] .fvh { --fvh-neon-velo: 0; }
 
+/* ── PROFUNDIZAR EL TEMA EN LA ESCENA (V4) ──────────────────────────────────
+   Antes los temas retiñían el shell pero la BANDA CENTRAL isométrica quedaba
+   casi igual (mismos verdes/tierras del SVG). Dos capas nuevas, sin tocar los
+   SVG ni la disposición:
+
+   1) GRADE de color por tema sobre el SVG de la escena (.fvh-escena > svg —
+      SOLO la escena; el globo del agente y la fauna quedan fuera): biopunk
+      enfría y apaga hacia su clave nocturna; nature calienta a tierra; el
+      minimalista desatura a papel; verde-vivo sube la savia. Es la misma
+      escena con otra LUZ, como los bocetos por tema aprobados.
+
+   2) VELADURA/TEXTURA por tema (reusa el ::after del velo, que biopunk ya
+      ocupaba con su neón): sol de mañana en verde-vivo, veladura dorada +
+      grano de papel kraft en nature, trama fina de papel en minimalista. */
+.fvh-escena > svg {
+  filter: saturate(0.86) hue-rotate(-8deg) brightness(0.93); /* biopunk base */
+  transition: filter 0.6s ease;
+}
+[data-theme="verde-vivo"] .fvh-escena > svg { filter: saturate(1.14) brightness(1.02); }
+[data-theme="nature"] .fvh-escena > svg { filter: sepia(0.22) saturate(0.95) brightness(1.02); }
+[data-theme="minimalista"] .fvh-escena > svg { filter: saturate(0.62) contrast(0.97) brightness(1.05); }
+
+/* verde-vivo: sol de mañana que entra por la esquina alta izquierda. */
+[data-theme="verde-vivo"] .fvh-escena-wrap::after {
+  opacity: 1;
+  background: radial-gradient(110% 80% at 22% 8%, rgba(255, 240, 180, 0.20), transparent 52%);
+}
+/* nature: veladura dorada de tierra + grano horizontal de papel kraft. */
+[data-theme="nature"] .fvh-escena-wrap::after {
+  opacity: 1;
+  background:
+    radial-gradient(120% 90% at 50% 0%, rgba(255, 214, 150, 0.16), transparent 55%),
+    repeating-linear-gradient(0deg, rgba(122, 82, 48, 0.05) 0 2px, transparent 2px 6px);
+}
+/* minimalista: luz pareja de estudio + trama vertical finísima de papel. */
+[data-theme="minimalista"] .fvh-escena-wrap::after {
+  opacity: 1;
+  background:
+    linear-gradient(180deg, rgba(246, 243, 236, 0.20) 0%, transparent 40%),
+    repeating-linear-gradient(90deg, rgba(60, 70, 60, 0.035) 0 1px, transparent 1px 8px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .fvh-escena > svg { transition: none; }
+}
+
 /* VIÑETA DE PROFUNDIDAD de la escena (todos los temas): un brillo apenas
    perceptible arriba (aire) + una caída suave abajo que asienta la escena
    contra el compositor. z5: sobre la escena (z2), bajo el velo neón (z6). */

--- a/src/components/dashboard/mundos-finca.css
+++ b/src/components/dashboard/mundos-finca.css
@@ -1,0 +1,395 @@
+/* ============================================================================
+   mundos-finca.css — LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home).
+
+   Identidad: CUADERNO DE CAMPO. Cada mundo es una lámina de papel pegada al
+   cuaderno crema del home: viñeta ilustrada arriba, nombre en Baloo 2, lema en
+   Nunito y las herramientas "adentro" como chips de tinta. La paleta de cada
+   mundo entra por dos custom properties que fija el JSX:
+     --mf-a  acento fuerte (tierra/verde/agua del mundo)
+     --mf-b  acento suave (el papel tintado del mundo)
+
+   Los mundos viven en dos superficies:
+     · La GRILLA del home (.mf, dentro de la hoja crema .fvh-resto).
+     · La PANTALLA de mundo (.mf-mundo, dentro de ScreenShell — ahí las láminas
+       de papel funcionan sobre cualquier tema, claro u oscuro: son papel).
+
+   Legible al sol: tinta oscura #26331f sobre papel, labels en negrita, sin
+   depender del color para la jerarquía. prefers-reduced-motion: sin entradas
+   animadas ni lifts. rsvg-safe: nada de filtros en las viñetas.
+   ========================================================================== */
+
+.mf {
+  --mf-papel: #fffdf6;
+  --mf-tinta: #26331f;
+  --mf-tinta-suave: #4e5c42;
+  --mf-display: 'Baloo 2', 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --mf-body: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  font-family: var(--mf-body);
+  color: var(--mf-tinta);
+}
+
+/* ── Cabecera de la sección ────────────────────────────────────────────────── */
+.mf-head { margin: 2px 2px 12px; }
+.mf-tit {
+  font-family: var(--mf-display);
+  font-weight: 800;
+  font-size: 21px;
+  line-height: 1.15;
+  color: var(--mf-tinta);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+/* La puntada del cuaderno: hilo corto cosido antes del título. */
+.mf-tit::before {
+  content: '';
+  width: 26px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background:
+    repeating-linear-gradient(90deg,
+      #3f8f4e 0 6px, transparent 6px 10px);
+}
+.mf-sub {
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--mf-tinta-suave);
+  margin: 4px 0 0;
+  max-width: 42ch;
+}
+
+/* ── Grilla de mundos ──────────────────────────────────────────────────────── */
+.mf-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+@media (min-width: 720px) {
+  .mf-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+/* ── Tarjeta de mundo: la lámina de papel ──────────────────────────────────── */
+.mf-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-radius: 18px;
+  background: var(--mf-papel, #fffdf6);
+  box-shadow: 0 2px 10px rgba(38, 51, 31, 0.08);
+  overflow: hidden;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  /* entrada escalonada de la grilla (--mf-i la fija el JSX) */
+  animation: mf-brota 420ms cubic-bezier(0.22, 0.9, 0.3, 1) both;
+  animation-delay: calc(var(--mf-i, 0) * 45ms);
+}
+.mf-card:active { transform: scale(0.985); }
+@media (hover: hover) {
+  .mf-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 18px rgba(38, 51, 31, 0.14);
+  }
+}
+.mf-card:focus-visible {
+  outline: 3px solid var(--mf-a, #3f8f4e);
+  outline-offset: 2px;
+}
+@keyframes mf-brota {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* El mundo destacado (Cultivos) ocupa la fila completa. */
+.mf-card--featured { grid-column: 1 / -1; }
+
+/* Banda de viñeta ilustrada. */
+.mf-vineta {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 84px;
+  background: var(--mf-b, #eef3e2);
+  /* línea de tierra del mundo: separa la ilustración del papel */
+  border-bottom: 3px solid var(--mf-a, #3f8f4e);
+}
+.mf-card--featured .mf-vineta { height: 116px; }
+.mf-vineta-svg { display: block; width: 100%; height: 100%; }
+
+/* Sello vivo sobre la viñeta (dato real: "N matas sembradas"). */
+.mf-sello {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: rgba(255, 253, 246, 0.92);
+  border: 1px solid var(--mf-a, #3f8f4e);
+  color: var(--mf-tinta);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+/* Cuerpo de la lámina. */
+.mf-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px 12px;
+  flex: 1;
+}
+.mf-nombre {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--mf-display);
+  font-weight: 800;
+  font-size: 15.5px;
+  line-height: 1.15;
+  color: var(--mf-tinta);
+}
+.mf-card--featured .mf-nombre { font-size: 18px; }
+.mf-emoji { font-size: 18px; line-height: 1; }
+.mf-lema {
+  font-size: 11.5px;
+  line-height: 1.35;
+  color: var(--mf-tinta-suave);
+}
+.mf-card--featured .mf-lema { font-size: 12.5px; }
+
+/* "Adentro": chips de las herramientas del mundo. */
+.mf-adentro {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+.mf-chip {
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 4px 7px;
+  border-radius: 999px;
+  background: var(--mf-b, #eef3e2);
+  border: 1px solid color-mix(in srgb, var(--mf-a, #3f8f4e) 35%, transparent);
+  color: var(--mf-tinta);
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mf-chip--mas,
+.mf-chip--entrar {
+  background: transparent;
+  border-style: dashed;
+  color: var(--mf-tinta-suave);
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   PANTALLA DE MUNDO (MundoScreen) — el mundo por dentro.
+   ══════════════════════════════════════════════════════════════════════════ */
+.mf-mundo {
+  --mf-papel: #fffdf6;
+  --mf-tinta: #26331f;
+  --mf-tinta-suave: #4e5c42;
+  font-family: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+/* Portada: la viñeta en grande con el emoji del mundo sellado encima. */
+.mf-mundo-hero {
+  position: relative;
+  height: 132px;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-bottom: 4px solid var(--mf-a, #3f8f4e);
+  background: var(--mf-b, #eef3e2);
+  box-shadow: 0 3px 12px rgba(38, 51, 31, 0.10);
+}
+.mf-mundo-hero .mf-vineta-svg { width: 100%; height: 100%; display: block; }
+.mf-mundo-emoji {
+  position: absolute;
+  right: 10px;
+  bottom: 8px;
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  font-size: 24px;
+  border-radius: 14px;
+  background: rgba(255, 253, 246, 0.92);
+  border: 1.5px solid var(--mf-a, #3f8f4e);
+  box-shadow: 0 2px 8px rgba(38, 51, 31, 0.14);
+}
+.mf-mundo-lema {
+  margin: 10px 4px 14px;
+  font-size: 13.5px;
+  line-height: 1.4;
+  font-weight: 700;
+  color: var(--mf-tinta);
+  background: var(--mf-papel);
+  border-left: 4px solid var(--mf-a, #3f8f4e);
+  border-radius: 10px;
+  padding: 9px 12px;
+  box-shadow: 0 1px 6px rgba(38, 51, 31, 0.08);
+}
+
+/* Las herramientas del mundo: filas de papel generosas (área táctil ≥56px). */
+.mf-entradas {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.mf-entrada {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 60px;
+  padding: 10px 12px;
+  border-radius: 15px;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  background: var(--mf-papel);
+  color: var(--mf-tinta);
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 1px 6px rgba(38, 51, 31, 0.07);
+  transition: transform 140ms ease, box-shadow 140ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.mf-entrada:active { transform: scale(0.988); }
+@media (hover: hover) {
+  .mf-entrada:hover { box-shadow: 0 4px 14px rgba(38, 51, 31, 0.13); }
+}
+.mf-entrada:focus-visible {
+  outline: 3px solid var(--mf-a, #3f8f4e);
+  outline-offset: 2px;
+}
+.mf-entrada-icono {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  font-size: 21px;
+  border-radius: 12px;
+  background: var(--mf-b, #eef3e2);
+  border: 1px solid color-mix(in srgb, var(--mf-a, #3f8f4e) 40%, transparent);
+}
+.mf-entrada-txt {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.mf-entrada-txt b {
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-weight: 800;
+  font-size: 14.5px;
+  line-height: 1.2;
+}
+.mf-entrada-txt small {
+  font-size: 11.5px;
+  line-height: 1.3;
+  color: var(--mf-tinta-suave);
+}
+.mf-entrada-ir {
+  flex: 0 0 auto;
+  font-weight: 800;
+  color: var(--mf-a, #3f8f4e);
+  opacity: 0.85;
+}
+
+/* El agente, siempre a la mano al pie del mundo. */
+.mf-agente {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 14px;
+  min-height: 58px;
+  padding: 10px 14px;
+  border-radius: 15px;
+  border: 1.5px dashed var(--mf-a, #3f8f4e);
+  background: color-mix(in srgb, var(--mf-b, #eef3e2) 55%, var(--mf-papel));
+  color: var(--mf-tinta);
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.mf-agente > span:first-child { font-size: 22px; }
+.mf-agente b {
+  display: block;
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-weight: 800;
+  font-size: 14.5px;
+}
+.mf-agente small {
+  display: block;
+  font-size: 11.5px;
+  color: var(--mf-tinta-suave);
+}
+.mf-agente:focus-visible {
+  outline: 3px solid var(--mf-a, #3f8f4e);
+  outline-offset: 2px;
+}
+
+/* Índice de mundos (fallback sin id): lista sencilla de láminas. */
+.mf-indice-intro {
+  font-size: 13px;
+  color: #4e5c42;
+  margin: 0 2px 10px;
+}
+.mf-indice { display: flex; flex-direction: column; gap: 9px; }
+.mf-indice-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 56px;
+  padding: 9px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-left: 5px solid var(--mf-a, #3f8f4e);
+  background: #fffdf6;
+  color: #26331f;
+  text-align: left;
+  cursor: pointer;
+}
+.mf-indice-emoji { font-size: 22px; }
+.mf-indice-txt b {
+  display: block;
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-weight: 800;
+  font-size: 14.5px;
+}
+.mf-indice-txt small {
+  display: block;
+  font-size: 11.5px;
+  color: #4e5c42;
+}
+.mf-indice-item:focus-visible {
+  outline: 3px solid var(--mf-a, #3f8f4e);
+  outline-offset: 2px;
+}
+
+/* ── Accesibilidad de movimiento ──────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .mf-card {
+    animation: none;
+    transition: none;
+  }
+  .mf-card:active,
+  .mf-entrada:active { transform: none; }
+  .mf-entrada { transition: none; }
+  @media (hover: hover) {
+    .mf-card:hover { transform: none; }
+  }
+}

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -1,0 +1,170 @@
+/*
+ * i18n (ADR-050): igual que DashboardLive.jsx, este manifiesto contiene el copy
+ * de navegación del home en español Colombia, pendiente de migrar a
+ * src/config/messages.js. La regla chagra-i18n es soft (warn); se desactiva a
+ * nivel de archivo para no bloquear el pre-commit con deuda preexistente.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+/**
+ * mundosFinca — LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home, V4).
+ *
+ * ANTES: el home F2 era ~15 tiles planas + 5 tarjetas de inventario + mercado +
+ * seguimiento — una caja de herramientas regada. AHORA: las mismas funciones,
+ * agrupadas en 9 MUNDOS coherentes y aprendibles, cada uno un LUGAR de la finca
+ * con su ilustración, su color de tierra y sus funciones adentro.
+ *
+ * FUENTE ÚNICA: la grilla del home (MundosDeMiFinca), la pantalla de mundo
+ * (MundoScreen) y el test de alcanzabilidad leen de aquí. NO duplicar rutas.
+ *
+ * REGLA DE ORO (reachability): TODO lo que era alcanzable desde el home F2
+ * sigue siéndolo — cada tile vieja vive ahora DENTRO de su mundo. El test
+ * MundosDeMiFinca.reachability.test.jsx congela ese contrato.
+ *
+ * Esquema de cada mundo:
+ *   id       — clave estable (ruta 'mundo' + data { mundo: id }).
+ *   titulo   — nombre campesino del mundo (Baloo 2 en la tarjeta).
+ *   emoji    — glifo del mundo (acompaña a la viñeta SVG, no la reemplaza).
+ *   lema     — una línea: qué se hace en este mundo (voz activa, concreta).
+ *   tinte    — [acento fuerte, acento suave] (hex) — la paleta de tierra propia.
+ *   featured — true = tarjeta grande (ancho completo) en la grilla.
+ *   directo  — {view, data}: el mundo ES una sola pantalla → la tarjeta navega
+ *              directo (sin pantalla intermedia de mundo).
+ *   entradas — funciones del mundo: {view, label, desc, emoji, data?}.
+ *              `view` SIEMPRE es un case real de App.jsx.
+ */
+
+export const MUNDOS_FINCA = [
+    {
+        id: 'cultivos',
+        titulo: 'Cultivos y semillas',
+        emoji: '🌾',
+        lema: 'Qué sembrar, cuándo, y cómo van sus matas',
+        tinte: ['#3f8f4e', '#dcedc9'],
+        featured: true,
+        entradas: [
+            { view: 'directorio', label: 'Qué puedo sembrar', desc: 'Especies para su clima, con qué se llevan y sus plagas', emoji: '🌱' },
+            { view: 'calendario_finca', label: 'Calendario de la finca', desc: 'Cuándo sembrar, abonar y cosechar, todo junto', emoji: '🗓️' },
+            { view: 'activos', label: 'Mis matas', desc: 'Las plantas que tiene sembradas y cómo van', emoji: '🪴' },
+            { view: 'mapa', label: 'Zonas de la finca', desc: 'Sus lotes, eras y potreros en el mapa', emoji: '🗺️' },
+            { view: 'germinacion', label: 'Semilleros', desc: 'Pruebe sus semillas y vea cuáles nacen', emoji: '🫘' },
+            { view: 'sembrar', label: 'Registrar una siembra', desc: 'Anote lo que sembró y arranca su ciclo', emoji: '🌽' },
+            { view: 'cosechar', label: 'Cosechar', desc: 'Anote lo que recogió', emoji: '🧺' },
+            { view: 'ciclo', label: 'Ciclo de cultivo', desc: 'La vida de la mata etapa por etapa', emoji: '🔄' },
+        ],
+    },
+    {
+        id: 'suelo',
+        titulo: 'El suelo vivo',
+        emoji: '🌱',
+        lema: 'Conozca su tierra, corríjala y aliméntela',
+        tinte: ['#8a5a38', '#f0e2c8'],
+        entradas: [
+            { view: 'salud_suelo', label: 'Cuaderno del suelo', desc: 'Lea su análisis, corrija la acidez y mejore la tierra', emoji: '📓' },
+            { view: 'suelo', label: 'Cómo está mi tierra', desc: 'Diagnóstico sin laboratorio: color, olor y tacto', emoji: '🤲' },
+            { view: 'cromatografia', label: 'Cromatografía', desc: 'El retrato del suelo en un papel de filtro', emoji: '🎯' },
+            { view: 'ciclo_nutrientes', label: 'Ciclo de nutrientes', desc: 'Del animal al suelo y de vuelta a la planta', emoji: '♻️' },
+        ],
+    },
+    {
+        id: 'agua',
+        titulo: 'El agua',
+        emoji: '💧',
+        lema: 'Coseche la lluvia, riegue con medida y cuide su nacimiento',
+        tinte: ['#2f7fa3', '#d7ecf3'],
+        directo: { view: 'agua' },
+    },
+    {
+        id: 'abono',
+        titulo: 'Del corral al abono',
+        emoji: '🐄',
+        lema: 'Quítele el olor al estiércol y sáquele abono y gas',
+        tinte: ['#6d7a2e', '#e9ecc9'],
+        directo: { view: 'estiercol' },
+    },
+    {
+        id: 'sanidad',
+        titulo: 'Sanidad de la mata',
+        emoji: '🐞',
+        lema: 'Plagas, remedios caseros y los bichos que lo ayudan',
+        tinte: ['#b0532f', '#f6ded1'],
+        entradas: [
+            { view: 'biopreparados', label: 'Biopreparados', desc: 'Recetas caseras paso a paso para proteger la mata', emoji: '🧪', data: { back: 'dashboard' } },
+            { view: 'reportar_invasora', label: 'Reportar una plaga', desc: 'Vio algo raro en una mata: repórtelo con foto', emoji: '🔍' },
+            { view: 'casos', label: 'Casos reales', desc: 'Problemas de otras fincas y cómo los resolvieron', emoji: '📋' },
+            { view: 'defensores', label: 'Defensores de la finca', desc: 'Conozca jugando los bichos buenos que controlan plagas', emoji: '🐞' },
+            { view: 'toxicologia', label: 'Seguridad con insumos', desc: 'Qué es peligroso y cómo cuidarse', emoji: '⚠️' },
+        ],
+    },
+    {
+        id: 'clima',
+        titulo: 'El clima',
+        emoji: '⛅',
+        lema: 'Su día en la finca: lluvia, heladas y avisos',
+        tinte: ['#4c7fa0', '#dce9f2'],
+        directo: { view: 'hoy_finca' },
+    },
+    {
+        id: 'animales',
+        titulo: 'Los animales',
+        emoji: '🐔',
+        lema: 'Gallinas, vacas, abejas y cerdos: sanidad y manejo',
+        tinte: ['#a86a3a', '#f3e3cf'],
+        // Gate por perfil: un urbano de balcón no ve este mundo (mismo criterio
+        // `mostrarAnimales` del home). El filtro lo aplica MundosDeMiFinca.
+        gate: 'animales',
+        entradas: [
+            { view: 'animales', label: 'Todos los animales', desc: 'Su corral completo y el ciclo cerrado', emoji: '🐮' },
+            { view: 'animales_gallinas', label: 'Gallinas', desc: 'Postura, sanidad y gallinaza', emoji: '🐔' },
+            { view: 'animales_vacas', label: 'Vacas', desc: 'Manejo, pastoreo y ordeño', emoji: '🐄' },
+            { view: 'animales_abejas', label: 'Abejas', desc: 'Colmenas y polinización de sus cultivos', emoji: '🐝' },
+            { view: 'seguimiento_cerdos', label: 'Cerdos', desc: 'Ciclo de manejo porcino y cama profunda', emoji: '🐖' },
+        ],
+    },
+    {
+        id: 'mercado',
+        titulo: 'Mercado y despensa',
+        emoji: '🧺',
+        lema: 'Venda directo, saque cuentas y transforme su cosecha',
+        tinte: ['#b98a2f', '#f7ecd2'],
+        entradas: [
+            { view: 'mercado', label: 'Vender y comprar', desc: 'Directo entre fincas, sin intermediarios', emoji: '🤝' },
+            { view: 'bodega', label: 'Bodega de insumos', desc: 'Lo que tiene guardado y lo que se acaba', emoji: '🏚️' },
+            { view: 'informes', label: 'Sacar reportes', desc: 'Para imprimir o llevar al banco o la cooperativa', emoji: '🖨️' },
+            { view: 'fermentos', label: 'Fermentos de la cocina', desc: 'Masato, chicha y kéfir con sus vetos de seguridad', emoji: '🫙' },
+        ],
+    },
+    {
+        id: 'disenio',
+        titulo: 'Diseño de la finca',
+        emoji: '🌳',
+        lema: 'Buenas vecinas, monte vivo y proyectos de restauración',
+        tinte: ['#2f6b3a', '#d8e9d2'],
+        entradas: [
+            { view: 'asociaciones', label: 'Buenas vecinas', desc: 'Qué cultivos se ayudan sembrados juntos', emoji: '🌻' },
+            { view: 'biodiversidad', label: 'El monte de la finca', desc: 'Plantas y animales silvestres que la acompañan', emoji: '🦜' },
+            { view: 'seguimiento_reforestacion', label: 'Reforestación', desc: 'Restauración con árboles nativos', emoji: '🌳' },
+            { view: 'seguimiento_silvopastoreo', label: 'Silvopastoreo', desc: 'Árboles + pasto + ganado en el mismo lote', emoji: '🐂' },
+            { view: 'seguimiento_paramo', label: 'Páramo', desc: 'Conservación del páramo y su agua', emoji: '🏔️' },
+        ],
+    },
+];
+
+/** Mapa id → mundo, para resolver desde la ruta 'mundo'. */
+export const MUNDO_BY_ID = Object.fromEntries(MUNDOS_FINCA.map((m) => [m.id, m]));
+
+/** Resuelve un mundo desde su id (null si no existe). */
+export const getMundo = (id) => MUNDO_BY_ID[id] || null;
+
+/**
+ * TODAS las vistas alcanzables vía mundos (directas + entradas), para el test
+ * de reachability y auditorías de huérfanos.
+ * @returns {string[]} views únicas.
+ */
+export function mundosViews() {
+    const out = new Set();
+    for (const m of MUNDOS_FINCA) {
+        if (m.directo) out.add(m.directo.view);
+        for (const e of m.entradas || []) out.add(e.view);
+    }
+    return [...out];
+}

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -29,6 +29,10 @@
  *   featured — true = tarjeta grande (ancho completo) en la grilla.
  *   directo  — {view, data}: el mundo ES una sola pantalla → la tarjeta navega
  *              directo (sin pantalla intermedia de mundo).
+ *   portada  — view de una PORTADA de mundo a medida (hub ilustrado) que
+ *              reemplaza a la MundoScreen genérica: la tarjeta y el índice
+ *              navegan ahí. Convive con `entradas` (que siguen congelando la
+ *              reachability y sirven de fallback genérico si hiciera falta).
  *   entradas — funciones del mundo: {view, label, desc, emoji, data?}.
  *              `view` SIEMPRE es un case real de App.jsx.
  */
@@ -41,6 +45,9 @@ export const MUNDOS_FINCA = [
         lema: 'Qué sembrar, cuándo, y cómo van sus matas',
         tinte: ['#3f8f4e', '#dcedc9'],
         featured: true,
+        // Portada a medida (hub del mundo cultivos): orienta por región/clima,
+        // agrupa las funciones existentes y suma la calculadora de grados-día.
+        portada: 'mundo_cultivos',
         entradas: [
             { view: 'directorio', label: 'Qué puedo sembrar', desc: 'Especies para su clima, con qué se llevan y sus plagas', emoji: '🌱' },
             { view: 'calendario_finca', label: 'Calendario de la finca', desc: 'Cuándo sembrar, abonar y cosechar, todo junto', emoji: '🗓️' },

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -128,6 +128,7 @@ export const MUNDOS_FINCA = [
         tinte: ['#b98a2f', '#f7ecd2'],
         entradas: [
             { view: 'mercado', label: 'Vender y comprar', desc: 'Directo entre fincas, sin intermediarios', emoji: '🤝' },
+            { view: 'poscosecha', label: 'Poscosecha y despensa', desc: 'Cosechar en punto, guardar sin que se dañe y transformar', emoji: '🥕' },
             { view: 'bodega', label: 'Bodega de insumos', desc: 'Lo que tiene guardado y lo que se acaba', emoji: '🏚️' },
             { view: 'informes', label: 'Sacar reportes', desc: 'Para imprimir o llevar al banco o la cooperativa', emoji: '🖨️' },
             { view: 'fermentos', label: 'Fermentos de la cocina', desc: 'Masato, chicha y kéfir con sus vetos de seguridad', emoji: '🫙' },

--- a/src/components/estiercol/EstiercolIlustraciones.jsx
+++ b/src/components/estiercol/EstiercolIlustraciones.jsx
@@ -1,0 +1,275 @@
+import React from 'react';
+
+/**
+ * Ilustraciones propias del módulo "Del corral al abono".
+ * SVG a mano (tipo cuaderno de campo): trazo redondo, tierra colorada, gas
+ * ámbar, biol/planta verde. Colores fijos de ILUSTRACIÓN (no de tema) porque
+ * viven dentro de cards que ya ponen su propio fondo; se eligieron con contraste
+ * alto para leerse al sol en los 4 temas.
+ */
+
+/* Paleta de la ilustración (tierra / gas / agua / planta). */
+const C = {
+  tierra: '#7c4a24',
+  tierraOsc: '#5a3418',
+  gas: '#f5b53d',
+  gasClaro: '#ffd982',
+  biol: '#4a9b6e',
+  biolClaro: '#7fd0a3',
+  agua: '#3f9fd4',
+  trazo: '#2c1c0f',
+  cielo: '#cfe8d6',
+};
+
+/**
+ * Biodigestor tubular en corte. `llenado` (0..1) infla la cúpula de gas y activa
+ * las burbujas + la llama del fogón. `animated` controla las micro-animaciones.
+ *
+ * @param {{ llenado?: number, animated?: boolean, className?: string }} props
+ */
+export function BiodigestorIlustracion({ llenado = 0.6, animated = true, className = '' }) {
+  const f = Math.max(0, Math.min(1, llenado));
+  // La cúpula crece de una tira fina (vacío) a una campana gruesa (lleno).
+  const domoAltura = 10 + f * 40; // px
+  const domoTop = 96 - domoAltura;
+  const hayGas = f > 0.02;
+
+  return (
+    <svg
+      viewBox="0 0 320 200"
+      className={className}
+      role="img"
+      aria-label="Corte de un biodigestor tubular: entra la mezcla de estiércol y agua, se llena de biogás en la parte de arriba y sale el biol líquido por el otro lado."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      {/* Cielo/aire */}
+      <rect x="0" y="0" width="320" height="118" fill={C.cielo} opacity="0.35" />
+      {/* Suelo */}
+      <path d="M0 118 H320 V200 H0 Z" fill={C.tierra} opacity="0.9" />
+      <path d="M0 118 H320" stroke={C.tierraOsc} strokeWidth="3" strokeLinecap="round" />
+      {/* Textura de tierra (puntitos) */}
+      {[[28, 150], [70, 176], [150, 188], [212, 158], [268, 182], [300, 150]].map(([x, y], i) => (
+        <circle key={i} cx={x} cy={y} r="2.4" fill={C.tierraOsc} opacity="0.5" />
+      ))}
+
+      {/* Zanja + bolsa tubular (cuerpo del digestor), medio enterrada */}
+      <g>
+        {/* Cámara líquida (la mezcla en digestión) */}
+        <path
+          d="M60 96 Q60 132 96 132 H224 Q260 132 260 96 Z"
+          fill={C.tierraOsc}
+          opacity="0.55"
+        />
+        <path
+          d="M64 98 Q66 126 98 126 H222 Q254 126 256 98 Z"
+          fill={C.agua}
+          opacity="0.45"
+        />
+
+        {/* Cúpula de gas (se infla con `llenado`) */}
+        <g className={animated && hayGas ? 'estiercol-cupula' : undefined}>
+          <path
+            d={`M60 96 Q60 ${domoTop} 160 ${domoTop} Q260 ${domoTop} 260 96 Z`}
+            fill={hayGas ? C.gas : '#e7e2d8'}
+            opacity={hayGas ? 0.85 : 0.4}
+          />
+          <path
+            d={`M60 96 Q60 ${domoTop} 160 ${domoTop} Q260 ${domoTop} 260 96`}
+            fill="none"
+            stroke={C.trazo}
+            strokeWidth="2.5"
+            strokeLinecap="round"
+          />
+          {hayGas && (
+            <text x="160" y={domoTop + domoAltura / 2 + 4} textAnchor="middle"
+              fontSize="11" fontWeight="700" fill={C.trazo} opacity="0.8">
+              biogás
+            </text>
+          )}
+        </g>
+
+        {/* Contorno del cuerpo */}
+        <path
+          d="M60 96 Q60 132 96 132 H224 Q260 132 260 96"
+          fill="none"
+          stroke={C.trazo}
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+
+        {/* Burbujas subiendo */}
+        {animated && hayGas && (
+          <g fill={C.gasClaro} stroke={C.gas} strokeWidth="1">
+            <circle className="estiercol-burbuja" cx="120" cy="120" r="3" />
+            <circle className="estiercol-burbuja estiercol-burbuja--b" cx="160" cy="122" r="2.4" />
+            <circle className="estiercol-burbuja estiercol-burbuja--c" cx="196" cy="120" r="3.4" />
+            <circle className="estiercol-burbuja estiercol-burbuja--d" cx="142" cy="122" r="2" />
+          </g>
+        )}
+      </g>
+
+      {/* Entrada: tubo de carga (mezcla estiércol + agua) */}
+      <g>
+        <path d="M22 74 L58 100" stroke={C.trazo} strokeWidth="9" strokeLinecap="round" />
+        <path d="M22 74 L58 100" stroke={C.tierra} strokeWidth="5" strokeLinecap="round" />
+        <circle cx="20" cy="72" r="12" fill={C.tierraOsc} stroke={C.trazo} strokeWidth="2" />
+        <text x="20" y="52" textAnchor="middle" fontSize="10" fontWeight="700" fill={C.trazo}>entra</text>
+        <text x="20" y="42" textAnchor="middle" fontSize="10" fontWeight="700" fill={C.trazo}>mezcla</text>
+      </g>
+
+      {/* Salida: biol (efluente fertilizante) a un tanque */}
+      <g>
+        <path d="M260 100 L296 104" stroke={C.trazo} strokeWidth="9" strokeLinecap="round" />
+        <path d="M260 100 L296 104" stroke={C.biol} strokeWidth="5" strokeLinecap="round" />
+        <path d="M286 104 h26 v34 a4 4 0 0 1 -4 4 h-18 a4 4 0 0 1 -4 -4 Z"
+          fill={C.biol} opacity="0.35" stroke={C.trazo} strokeWidth="2" />
+        <text x="299" y="60" textAnchor="middle" fontSize="10" fontWeight="700" fill={C.trazo}>biol</text>
+        <path d="M299 66 V96" stroke={C.biol} strokeWidth="2" strokeLinecap="round"
+          className={animated ? 'estiercol-flujo' : undefined} />
+      </g>
+
+      {/* Línea de gas + fogón */}
+      <g>
+        <path d="M160 34 V52" stroke={C.trazo} strokeWidth="3" strokeLinecap="round" />
+        <path
+          d="M160 34 Q160 12 196 12 H236"
+          fill="none"
+          stroke={C.trazo}
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeDasharray={hayGas ? undefined : '4 5'}
+        />
+        {/* Fogón */}
+        <rect x="232" y="12" width="30" height="8" rx="3" fill={C.tierraOsc} stroke={C.trazo} strokeWidth="1.6" />
+        {hayGas && (
+          <path
+            className={animated ? 'estiercol-llama' : undefined}
+            d="M247 12 q-6 -8 0 -14 q6 6 0 14 Z"
+            fill={C.gas}
+            stroke={C.gasClaro}
+            strokeWidth="1"
+          />
+        )}
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * El ciclo cerrado en una sola imagen: CORRAL → PILA/DIGESTOR → BIOL+BIOGÁS →
+ * SUELO/PLANTA, con flechas que fluyen. Es el emblema del módulo.
+ *
+ * @param {{ animated?: boolean, className?: string }} props
+ */
+export function CicloCorralAbono({ animated = true, className = '' }) {
+  const nodo = (x, y, fill) => (
+    <circle cx={x} cy={y} r="30" fill={fill} opacity="0.16" stroke={fill} strokeWidth="2" />
+  );
+  const flecha = (d) => (
+    <path d={d} fill="none" stroke={C.trazo} strokeWidth="2.4" strokeLinecap="round"
+      opacity="0.75" className={animated ? 'estiercol-flujo' : undefined} />
+  );
+  return (
+    <svg
+      viewBox="0 0 300 300"
+      className={className}
+      role="img"
+      aria-label="El ciclo: del corral sale el estiércol, se procesa en pila o biodigestor, produce biol y biogás, y el abono vuelve al suelo y la planta."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      {/* Nodos */}
+      {nodo(150, 52, C.tierra)}
+      <text x="150" y="49" textAnchor="middle" fontSize="26">🐖</text>
+      <text x="150" y="92" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Corral</text>
+
+      {nodo(248, 150, C.gas)}
+      <text x="248" y="147" textAnchor="middle" fontSize="24">🛢️</text>
+      <text x="248" y="190" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Procesa</text>
+
+      {nodo(150, 248, C.biol)}
+      <text x="150" y="245" textAnchor="middle" fontSize="24">💧</text>
+      <text x="150" y="220" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Biol y biogás</text>
+
+      {nodo(52, 150, C.biolClaro)}
+      <text x="52" y="147" textAnchor="middle" fontSize="24">🌱</text>
+      <text x="52" y="190" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Suelo</text>
+
+      {/* Flechas del ciclo (sentido horario) */}
+      {flecha('M182 66 Q222 84 236 122')}
+      {flecha('M236 178 Q222 216 182 234')}
+      {flecha('M118 234 Q78 216 64 178')}
+      {flecha('M64 122 Q78 84 118 66')}
+    </svg>
+  );
+}
+
+/**
+ * Glifo pequeño y propio para cada abono (tarjetas de "Abonos de estiércol").
+ * `tipo`: gallinaza | porquinaza | bovinaza | biol | biosol | compost |
+ * lombricompost. Devuelve un SVG compacto de 44×44.
+ *
+ * @param {{ tipo: string, size?: number, className?: string }} props
+ */
+export function AbonoGlifo({ tipo, size = 44, className = '' }) {
+  const base = (children) => (
+    <svg viewBox="0 0 44 44" width={size} height={size} className={className}
+      role="img" aria-hidden="true" style={{ display: 'block' }}>
+      {children}
+    </svg>
+  );
+  const sacoTierra = (fill, stroke) => (
+    <>
+      <path d="M12 16 q10 -8 20 0 l3 22 a3 3 0 0 1 -3 3 H12 a3 3 0 0 1 -3 -3 Z"
+        fill={fill} opacity="0.85" stroke={stroke} strokeWidth="1.6" />
+      <path d="M13 16 q9 -6 18 0" fill="none" stroke={stroke} strokeWidth="1.6" strokeLinecap="round" />
+    </>
+  );
+  const gota = (fill, stroke) => (
+    <path d="M22 8 C30 20 32 26 32 30 a10 10 0 0 1 -20 0 c0 -4 2 -10 10 -22 Z"
+      fill={fill} opacity="0.85" stroke={stroke} strokeWidth="1.6" />
+  );
+  switch (tipo) {
+    case 'gallinaza':
+      return base(<>
+        {sacoTierra('#e8b84b', C.trazo)}
+        <circle cx="18" cy="27" r="1.8" fill={C.trazo} />
+        <circle cx="26" cy="30" r="1.8" fill={C.trazo} />
+        <circle cx="22" cy="34" r="1.8" fill={C.trazo} />
+      </>);
+    case 'porquinaza':
+      return base(<>
+        {sacoTierra('#e59aa6', C.trazo)}
+        <circle cx="18" cy="28" r="1.8" fill={C.trazo} />
+        <circle cx="26" cy="28" r="1.8" fill={C.trazo} />
+      </>);
+    case 'bovinaza':
+      return base(<>
+        {sacoTierra('#c88a52', C.trazo)}
+        <path d="M15 30 h14 M17 34 h10" stroke={C.trazo} strokeWidth="1.6" strokeLinecap="round" />
+      </>);
+    case 'biol':
+      return base(<>
+        {gota(C.biol, C.trazo)}
+        <path d="M17 27 h10 M18 31 h8" stroke="#fff" strokeWidth="1.6" strokeLinecap="round" opacity="0.8" />
+      </>);
+    case 'biosol':
+      return base(<>
+        <rect x="11" y="18" width="22" height="20" rx="3" fill="#b98a4e" opacity="0.85" stroke={C.trazo} strokeWidth="1.6" />
+        <path d="M22 8 v8 M14 12 l4 4 M30 12 l-4 4" stroke={C.gas} strokeWidth="2" strokeLinecap="round" />
+      </>);
+    case 'compost':
+      return base(<>
+        <path d="M8 34 q14 -12 28 0 Z" fill="#7c5a34" opacity="0.85" stroke={C.trazo} strokeWidth="1.6" />
+        <path d="M16 30 q2 -6 6 -6 M24 32 q2 -5 5 -5" stroke={C.biol} strokeWidth="1.8" strokeLinecap="round" fill="none" />
+      </>);
+    case 'lombricompost':
+      return base(<>
+        <path d="M8 34 q14 -12 28 0 Z" fill="#4a3218" opacity="0.9" stroke={C.trazo} strokeWidth="1.6" />
+        <path d="M14 30 q3 -3 6 0 q3 3 6 0" fill="none" stroke="#e59aa6" strokeWidth="2.4" strokeLinecap="round" />
+      </>);
+    default:
+      return base(<circle cx="22" cy="22" r="12" fill={C.tierra} opacity="0.6" />);
+  }
+}
+
+export default BiodigestorIlustracion;

--- a/src/components/estiercol/estiercol.css
+++ b/src/components/estiercol/estiercol.css
@@ -1,0 +1,78 @@
+/* ───────────────────────────────────────────────────────────────────────────
+   Micro-animaciones del módulo "Del corral al abono".
+   Sutiles, cálidas, tipo cuaderno de campo. Todas se apagan con
+   prefers-reduced-motion. No hardcodean color de tema (usan currentColor /
+   opacidad) para vivir bien en los 4 temas y ser legibles al sol.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+/* Entrada suave de cada sección al cambiar de pilar. */
+@keyframes estiercol-fade-up {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.estiercol-enter {
+  animation: estiercol-fade-up 0.34s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* Burbujas de gas subiendo dentro del biodigestor (SVG). */
+@keyframes estiercol-burbuja {
+  0%   { transform: translateY(0)   scale(0.8); opacity: 0; }
+  15%  { opacity: 0.85; }
+  85%  { opacity: 0.85; }
+  100% { transform: translateY(-46px) scale(1.15); opacity: 0; }
+}
+.estiercol-burbuja {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: estiercol-burbuja 3.2s ease-in-out infinite;
+}
+.estiercol-burbuja--b { animation-delay: 0.9s;  animation-duration: 3.8s; }
+.estiercol-burbuja--c { animation-delay: 1.7s;  animation-duration: 2.9s; }
+.estiercol-burbuja--d { animation-delay: 2.4s;  animation-duration: 3.5s; }
+
+/* La cúpula de gas "respira" muy leve cuando hay biogás. */
+@keyframes estiercol-respira {
+  0%, 100% { transform: scaleY(1);    }
+  50%      { transform: scaleY(1.035); }
+}
+.estiercol-cupula {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  animation: estiercol-respira 4.5s ease-in-out infinite;
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Llama del fogón — parpadeo cálido. */
+@keyframes estiercol-llama {
+  0%, 100% { transform: scaleY(1)    translateY(0);    opacity: 0.95; }
+  50%      { transform: scaleY(1.18) translateY(-1px); opacity: 1; }
+}
+.estiercol-llama {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  animation: estiercol-llama 0.9s ease-in-out infinite;
+}
+
+/* Flecha del ciclo — recorrido punteado que fluye. */
+@keyframes estiercol-flujo {
+  to { stroke-dashoffset: -24; }
+}
+.estiercol-flujo {
+  stroke-dasharray: 5 5;
+  animation: estiercol-flujo 1.1s linear infinite;
+}
+
+/* Chip/pastilla del pilar activo — sutil elevación. */
+.estiercol-pilar-btn {
+  transition: transform 0.16s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+.estiercol-pilar-btn:active { transform: scale(0.97); }
+
+@media (prefers-reduced-motion: reduce) {
+  .estiercol-enter,
+  .estiercol-burbuja,
+  .estiercol-cupula,
+  .estiercol-llama,
+  .estiercol-flujo { animation: none; }
+  .estiercol-cupula { transition: none; }
+}

--- a/src/data/aguaFinca.js
+++ b/src/data/aguaFinca.js
@@ -1,0 +1,209 @@
+/**
+ * aguaFinca.js — CONTENIDO del módulo "Agua de la finca" (3 pilares).
+ *
+ * REGLA ANTI-ALUCINACIÓN del módulo: todo lo CUALITATIVO (prácticas, pasos,
+ * señales) vive aquí como copy; toda CIFRA DURA (mm de lluvia por zona, Kc por
+ * cultivo, ETo por piso térmico, dosis de potabilización, metros legales de
+ * ronda) es un SLOT con `valor: null` + `estado: 'grounded_pendiente'` que el
+ * pipeline de grounding (DR con fuente → catálogo/AGE) llenará. La UI pinta
+ * "dato en camino" cuando el valor es null — NUNCA muestra un número
+ * inventado.
+ *
+ * Convención del slot:
+ *   { estado: 'grounded_pendiente', valor: null, fuentePrevista: '<de dónde saldrá>' }
+ */
+
+export const ESTADO_GROUNDED_PENDIENTE = 'grounded_pendiente';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * PILAR 1 · COSECHAR LA LLUVIA
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Lluvia mensual típica por zona/municipio (mm/mes).
+ * TODO GROUNDED-PENDIENTE: llega aparte por el pipeline de clima (dato
+ * IDEAM/estación por municipio, DR en curso). Mientras tanto la calculadora
+ * usa el mm que la persona digita (por ejemplo, del pluviómetro casero o de
+ * lo que informa el módulo de clima de Chagra).
+ */
+export const LLUVIA_MENSUAL_ZONA = {
+  estado: ESTADO_GROUNDED_PENDIENTE,
+  valor: null,
+  fuentePrevista: 'IDEAM — promedios mensuales de precipitación por municipio (pipeline clima Chagra)',
+};
+
+/** Pasos del sistema techo→tanque, en orden real de construcción. Cualitativo. */
+export const PASOS_COSECHA = [
+  {
+    id: 'techo',
+    titulo: 'El techo que ya tiene',
+    detalle: 'Cualquier techo con caída sirve: casa, cocina, marranera, gallinero. Mida el piso que cubre el techo (largo × ancho): esa es el área que cosecha.',
+  },
+  {
+    id: 'canal',
+    titulo: 'Canal y bajante',
+    detalle: 'Una canaleta con buena pendiente hacia el tanque, sin hojas acumuladas. Revísela antes de las temporadas de lluvia: canal tapada es cosecha perdida.',
+  },
+  {
+    id: 'primeras-aguas',
+    titulo: 'Deje ir la primera lavada',
+    detalle: 'La primera lluvia después de días secos baja lavando el techo (polvo, hollín, excremento de aves). Desvíela o deséchela: al tanque solo debe entrar agua de techo ya lavado.',
+  },
+  {
+    id: 'tanque',
+    titulo: 'Tanque tapado y oscuro',
+    detalle: 'Tanque con tapa y sin luz por dentro: la luz cría algas y el tanque destapado cría zancudos. Con malla en la entrada del agua no entran hojas ni animales.',
+  },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * PILAR 2 · REGAR CON MEDIDA
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * ETo de referencia por piso térmico (mm/día).
+ * TODO GROUNDED-PENDIENTE: valores por piso térmico colombiano con fuente
+ * (FAO-56 + estaciones IDEAM; DR de riego). La calculadora acepta el valor
+ * digitado mientras llega el dato por zona.
+ */
+export const ETO_POR_PISO_TERMICO = [
+  { piso: 'cálido', etoMmDia: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { piso: 'templado', etoMmDia: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { piso: 'frío', etoMmDia: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { piso: 'páramo', etoMmDia: null, estado: ESTADO_GROUNDED_PENDIENTE },
+];
+
+/**
+ * Kc (coeficiente de cultivo) por especie y etapa.
+ * TODO GROUNDED-PENDIENTE: Kc reales FAO-56 / literatura citada, por cultivo
+ * y etapa fenológica, vía DR + catálogo (se conectará con el slug de especie
+ * del directorio). `kc: null` = la UI muestra "dato en camino".
+ */
+export const KC_CULTIVOS = [
+  { slug: 'maiz', nombre: 'Maíz', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'frijol', nombre: 'Fríjol', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'cafe', nombre: 'Café', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'platano', nombre: 'Plátano', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'tomate', nombre: 'Tomate', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+  { slug: 'papa', nombre: 'Papa', kc: null, estado: ESTADO_GROUNDED_PENDIENTE },
+];
+
+/**
+ * Eficiencia por sistema de riego (fracción del agua que sí llega a la raíz).
+ * TODO GROUNDED-PENDIENTE: coeficientes con fuente (FAO). Mientras tanto la
+ * comparación es solo CUALITATIVA (orden goteo > aspersión > gravedad), sin
+ * números inventados.
+ */
+export const SISTEMAS_RIEGO = [
+  {
+    id: 'goteo',
+    nombre: 'Goteo (o botella gota a gota)',
+    pierde: 'Pierde poquito',
+    coef: null,
+    estado: ESTADO_GROUNDED_PENDIENTE,
+    detalle: 'El agua cae despacio al pie de la mata. Se puede armar casero con manguera perforada o botellas. El que más rinde cuando el agua está contada.',
+  },
+  {
+    id: 'aspersion',
+    nombre: 'Aspersión (rociador)',
+    pierde: 'Pierde algo al viento y al sol',
+    coef: null,
+    estado: ESTADO_GROUNDED_PENDIENTE,
+    detalle: 'Moja también donde no hay raíz, y con sol fuerte parte se evapora antes de caer. Riegue de madrugada o al caer la tarde.',
+  },
+  {
+    id: 'gravedad',
+    nombre: 'Por surco o manguera suelta',
+    pierde: 'Pierde harto por el camino',
+    coef: null,
+    estado: ESTADO_GROUNDED_PENDIENTE,
+    detalle: 'Mucha agua se infiltra o se escurre antes de llegar a la mata. Si es lo que hay, riegue por tandas cortas y con el surco bien trazado.',
+  },
+];
+
+/** Prácticas que bajan la sed del cultivo. Cualitativas, agroecología clásica. */
+export const PRACTICAS_AHORRO = [
+  { id: 'cobertura', titulo: 'Tape el suelo', detalle: 'Hojarasca, pasto de corte o tamo sobre el suelo: la tierra tapada guarda la humedad y no se agrieta al sol.' },
+  { id: 'materia-organica', titulo: 'Suelo con materia orgánica', detalle: 'Un suelo con compost y bocashi funciona como esponja: recibe el aguacero y lo suelta despacio.' },
+  { id: 'hora', titulo: 'Riegue cuando no hay sol bravo', detalle: 'De madrugada o al atardecer el agua entra a la tierra en vez de evaporarse.' },
+  { id: 'observar', titulo: 'Riegue por la planta, no por costumbre', detalle: 'Meta el dedo a la tierra: si a un jeme de hondo está húmeda, todavía no toca. La mata avisa primero con las hojas.' },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * PILAR 3 · CUIDAR EL AGUA (calidad + nacimiento)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Dosis de potabilización casera (cloro por litro, minutos de hervor, horas
+ * de SODIS al sol).
+ * TODO GROUNDED-PENDIENTE: dosis exactas con fuente sanitaria (OMS/MinSalud)
+ * vía DR. El copy queda cualitativo y seguro mientras tanto.
+ */
+export const DOSIS_POTABILIZACION = {
+  estado: ESTADO_GROUNDED_PENDIENTE,
+  cloroGotasPorLitro: null,
+  hervorMinutos: null,
+  sodisHorasSol: null,
+  fuentePrevista: 'OMS / MinSalud — guías de tratamiento casero de agua para consumo',
+};
+
+/** Escalera de calidad: para qué sirve cada agua de la finca. Cualitativo. */
+export const USOS_DEL_AGUA = [
+  { id: 'lluvia-directa', agua: 'Lluvia recién cosechada (tanque tapado)', sirve: 'Riego, animales, lavar, aseo de la casa', ojo: 'Para tomar o cocinar, trátela primero (hierva o desinfecte).' },
+  { id: 'quebrada', agua: 'Quebrada o acequia', sirve: 'Riego', ojo: 'Aguas abajo de potreros o viviendas puede traer microbios: no la tome sin tratar.' },
+  { id: 'nacimiento', agua: 'Nacimiento protegido', sirve: 'La reserva más valiosa de la finca', ojo: 'Aun así, para consumo humano lo seguro es hervir o desinfectar.' },
+];
+
+/** Señales de alarma en el agua — cuándo NO usarla ni para riego de hortaliza. */
+export const SENALES_ALERTA_AGUA = [
+  'Cambia de color o huele a podrido después de un aguacero.',
+  'Espuma que no se deshace (jabones o agroquímicos aguas arriba).',
+  'Peces o renacuajos muertos en el cauce.',
+  'Nata aceitosa en la superficie.',
+];
+
+/**
+ * Franja legal de protección alrededor de nacimientos y cauces (metros).
+ * TODO GROUNDED-PENDIENTE: metros exactos con la norma citada y vigente
+ * (normativa forestal protectora de nacederos y rondas hídricas, DR legal).
+ * No se muestra número hasta que esté verificado.
+ */
+export const RONDA_PROTECCION = {
+  estado: ESTADO_GROUNDED_PENDIENTE,
+  metrosNacimiento: null,
+  metrosCauce: null,
+  fuentePrevista: 'Normativa colombiana de rondas hídricas y áreas forestales protectoras (verificación legal en curso)',
+};
+
+/**
+ * CASO INSIGNIA · "Se me seca el nacimiento en verano".
+ * Plan cualitativo por tiempos: qué hacer YA en verano, qué sembrar/cercar en
+ * invierno, y cómo leer el clima que viene (conecta con el módulo de clima y
+ * el ciclo ENSO que Chagra ya sigue — no se re-implementa aquí).
+ */
+export const CASO_NACIMIENTO = {
+  id: 'nacimiento-seco-verano',
+  titulo: 'Se me seca el nacimiento en verano',
+  resumen: 'Un nacimiento no se seca de un día para otro: se va quedando solo. Casi siempre es la suma de potrero hasta el borde, árboles tumbados arriba y todo el mundo sacando agua a la vez en la época seca.',
+  enVerano: [
+    { id: 'no-secar-del-todo', titulo: 'No lo ordeñe hasta el fondo', detalle: 'Si entre todos sacan hasta la última gota, el ojo de agua pierde su hilo y tarda más en volver. Racionen por horas y dejen siempre un remanente corriendo.' },
+    { id: 'lluvia-alivia', titulo: 'Use la lluvia guardada primero', detalle: 'Cada caneca de lluvia cosechada en invierno es agua que en verano NO se le saca al nacimiento. Por eso este módulo empieza por el techo.' },
+    { id: 'sombra-de-emergencia', titulo: 'No despeje más monte alrededor', detalle: 'En plena sequía ni socole ni queme cerca del ojo de agua: esa sombra es lo que le queda de humedad.' },
+  ],
+  enInvierno: [
+    { id: 'cercar', titulo: 'Cierre el paso del ganado', detalle: 'Una cerca sencilla alrededor del nacimiento evita el pisoteo que compacta el suelo y ensucia el agua. Deje un bebedero afuera para los animales.' },
+    { id: 'sembrar-nativas', titulo: 'Siembre monte nativo alrededor', detalle: 'Árboles y matorral nativo de su piso térmico alrededor del ojo de agua y aguas arriba: sus raíces son las que guardan el agua del invierno para soltarla en verano.' },
+    { id: 'zanjas', titulo: 'Ayude a que el aguacero entre a la tierra', detalle: 'Zanjas de infiltración a nivel, terrazas y suelo tapado ladera arriba: el agua que corre se pierde; la que se infiltra es la que el nacimiento le devuelve en verano.' },
+  ],
+  comunidad: [
+    { id: 'vecinos', titulo: 'El agua es de la vereda', detalle: 'Si el nacimiento abastece a varios, siéntense a acordar turnos y a cuidar juntos la parte alta. Un solo vecino cuidando no alcanza.' },
+    { id: 'clima', titulo: 'Léale el paso al clima', detalle: 'Chagra ya sigue el ciclo del Niño y la Niña en su módulo de clima: cuando viene un Niño (más seco), guarde más lluvia desde antes y raciónese temprano.' },
+  ],
+};
+
+/** Los 3 pilares del módulo — estructura de navegación. */
+export const PILARES_AGUA = [
+  { id: 'lluvia', titulo: 'Cosechar la lluvia', corto: 'Lluvia', descripcion: 'Del techo al tanque: cuánta agua le cae gratis y cómo guardarla.' },
+  { id: 'riego', titulo: 'Regar con medida', corto: 'Riego', descripcion: 'Cuánta agua necesita de verdad su cultivo y cómo no botarla.' },
+  { id: 'cuidar', titulo: 'Cuidar el agua', corto: 'Cuidar', descripcion: 'Agua sana para la casa y un nacimiento que no se seque.' },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -552,6 +552,36 @@
 }
 
 /* ===========================================================================
+ * SALUD DEL SUELO — micro-animaciones sutiles del perfil de suelo vivo
+ * (SaludSueloScreen). La raíz "crece", las micorrizas titilan y el sol respira.
+ * Sutil e infinito muy lento; se apaga con prefers-reduced-motion.
+ * =========================================================================== */
+.ss-root {
+  stroke-dasharray: 260;
+  stroke-dashoffset: 260;
+  animation: ss-grow 1.6s ease-out 0.2s forwards;
+}
+.ss-myco circle {
+  animation: ss-pulse 3.2s ease-in-out infinite;
+}
+.ss-myco circle:nth-child(2) { animation-delay: 0.6s; }
+.ss-myco circle:nth-child(3) { animation-delay: 1.2s; }
+.ss-myco circle:nth-child(4) { animation-delay: 1.8s; }
+.ss-myco circle:nth-child(5) { animation-delay: 2.4s; }
+.ss-sun {
+  transform-origin: 210px 18px;
+  animation: ss-breathe 4s ease-in-out infinite;
+}
+@keyframes ss-grow { to { stroke-dashoffset: 0; } }
+@keyframes ss-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 1; } }
+@keyframes ss-breathe { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.08); } }
+@media (prefers-reduced-motion: reduce) {
+  .ss-root { stroke-dashoffset: 0; animation: none; }
+  .ss-myco circle { animation: none; opacity: 0.85; }
+  .ss-sun { animation: none; }
+}
+
+/* ===========================================================================
  * LOADING SKELETON DARK — fondo oscuro unificado para estados de carga.
  *
  * Tarea 81: .loading-skeleton-dark evita flash blanco en dark theme

--- a/src/index.css
+++ b/src/index.css
@@ -582,6 +582,31 @@
 }
 
 /* ===========================================================================
+ * POSCOSECHA Y DESPENSA — micro-animaciones sutiles de la despensa
+ * (PoscosechaScreen). El sol respira y las gotas de humedad se van (secado).
+ * Sutil e infinito muy lento; se apaga con prefers-reduced-motion.
+ * =========================================================================== */
+.pc-sun {
+  transform-origin: 204px 26px;
+  animation: pc-breathe 4s ease-in-out infinite;
+}
+.pc-drops path {
+  animation: pc-evap 3.4s ease-in-out infinite;
+}
+.pc-drops path:nth-child(2) { animation-delay: 0.8s; }
+.pc-drops path:nth-child(3) { animation-delay: 1.6s; }
+@keyframes pc-breathe { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.08); } }
+@keyframes pc-evap {
+  0% { opacity: 0.85; transform: translateY(0); }
+  70% { opacity: 0; transform: translateY(-10px); }
+  100% { opacity: 0; transform: translateY(-10px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .pc-sun { animation: none; }
+  .pc-drops path { animation: none; opacity: 0.6; }
+}
+
+/* ===========================================================================
  * LOADING SKELETON DARK — fondo oscuro unificado para estados de carga.
  *
  * Tarea 81: .loading-skeleton-dark evita flash blanco en dark theme

--- a/src/services/__tests__/aguaCalculos.test.js
+++ b/src/services/__tests__/aguaCalculos.test.js
@@ -1,0 +1,99 @@
+/**
+ * aguaCalculos.test.js — la lógica determinista del módulo "Agua de la finca".
+ * Solo matemática de unidades: aquí no hay datos duros que validar (esos son
+ * slots grounded-pendiente en src/data/aguaFinca.js).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  litrosLluviaCaptables,
+  canecasEquivalentes,
+  porcentajeTanque,
+  etcDiaria,
+  litrosRiegoDia,
+  diasDeReserva,
+  COEF_ESCORRENTIA_TECHO_DEFAULT,
+  LITROS_POR_CANECA_55GAL,
+} from '../aguaCalculos';
+
+describe('litrosLluviaCaptables', () => {
+  it('aplica la identidad 1 mm × 1 m² = 1 L con el coeficiente default 0.8', () => {
+    // 100 m² × 100 mm × 0.8 = 8000 L
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: 100 })).toBe(8000);
+    expect(COEF_ESCORRENTIA_TECHO_DEFAULT).toBe(0.8);
+  });
+
+  it('acepta strings numéricos (inputs de formulario)', () => {
+    expect(litrosLluviaCaptables({ areaTechoM2: '60', lluviaMm: '120' })).toBe(Math.round(60 * 120 * 0.8));
+  });
+
+  it('respeta un coeficiente explícito', () => {
+    expect(litrosLluviaCaptables({ areaTechoM2: 50, lluviaMm: 100, coefEscorrentia: 1 })).toBe(5000);
+  });
+
+  it('devuelve null con entradas inválidas', () => {
+    expect(litrosLluviaCaptables({ areaTechoM2: 0, lluviaMm: 100 })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: -5, lluviaMm: 100 })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: -1 })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: '', lluviaMm: '' })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: 100, coefEscorrentia: 1.5 })).toBeNull();
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: 100, coefEscorrentia: 0 })).toBeNull();
+  });
+
+  it('con lluvia 0 devuelve 0 litros (mes seco válido)', () => {
+    expect(litrosLluviaCaptables({ areaTechoM2: 100, lluviaMm: 0 })).toBe(0);
+  });
+});
+
+describe('canecasEquivalentes', () => {
+  it('convierte litros a canecas de 55 galones (208 L)', () => {
+    expect(LITROS_POR_CANECA_55GAL).toBe(208);
+    expect(canecasEquivalentes(208)).toBe(1);
+    expect(canecasEquivalentes(8000)).toBe(38.5);
+  });
+  it('devuelve null con entrada inválida', () => {
+    expect(canecasEquivalentes(-1)).toBeNull();
+    expect(canecasEquivalentes('x')).toBeNull();
+  });
+});
+
+describe('porcentajeTanque', () => {
+  it('calcula el porcentaje con tope 100', () => {
+    expect(porcentajeTanque({ litros: 500, capacidadL: 1000 })).toBe(50);
+    expect(porcentajeTanque({ litros: 2500, capacidadL: 1000 })).toBe(100);
+  });
+  it('devuelve null si el tanque no tiene capacidad válida', () => {
+    expect(porcentajeTanque({ litros: 500, capacidadL: 0 })).toBeNull();
+    expect(porcentajeTanque({ litros: 500, capacidadL: '' })).toBeNull();
+  });
+});
+
+describe('etcDiaria (ETc = ETo × Kc, FAO)', () => {
+  it('multiplica ETo por Kc con 2 decimales', () => {
+    expect(etcDiaria({ etoMmDia: 4, kc: 1.15 })).toBe(4.6);
+    expect(etcDiaria({ etoMmDia: '3.5', kc: '0.8' })).toBe(2.8);
+  });
+  it('rechaza Kc fuera de rango físico (0–2]', () => {
+    expect(etcDiaria({ etoMmDia: 4, kc: 0 })).toBeNull();
+    expect(etcDiaria({ etoMmDia: 4, kc: 2.5 })).toBeNull();
+    expect(etcDiaria({ etoMmDia: 0, kc: 1 })).toBeNull();
+  });
+});
+
+describe('litrosRiegoDia', () => {
+  it('convierte mm/día × m² a litros/día (1 mm = 1 L/m²)', () => {
+    expect(litrosRiegoDia({ etcMmDia: 4.6, areaM2: 100 })).toBe(460);
+  });
+  it('devuelve null con área o ETc inválidos', () => {
+    expect(litrosRiegoDia({ etcMmDia: 0, areaM2: 100 })).toBeNull();
+    expect(litrosRiegoDia({ etcMmDia: 4, areaM2: '' })).toBeNull();
+  });
+});
+
+describe('diasDeReserva', () => {
+  it('divide reserva entre consumo, al piso', () => {
+    expect(diasDeReserva({ litrosGuardados: 1000, consumoLitrosDia: 300 })).toBe(3);
+  });
+  it('devuelve null sin consumo válido', () => {
+    expect(diasDeReserva({ litrosGuardados: 1000, consumoLitrosDia: 0 })).toBeNull();
+  });
+});

--- a/src/services/__tests__/biodigestorCalculator.test.js
+++ b/src/services/__tests__/biodigestorCalculator.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  estimarBiodigestor,
+  ANIMALES_BIODIGESTOR,
+  PARAMS_PROCESO,
+} from '../biodigestorCalculator';
+
+describe('biodigestorCalculator — estimarBiodigestor', () => {
+  it('el caso insignia (300 cerdos) da un orden de magnitud coherente', () => {
+    const r = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 300 });
+    // 300 × 4 kg = 1200 kg/día de estiércol fresco.
+    expect(r.estiercolKgDia).toBe(1200);
+    // Mezcla 1:3 → 1200 L estiércol + 3600 L agua = 4800 L/día.
+    expect(r.mezclaLitrosDia).toBe(4800);
+    // Volumen = 4.8 m³ × 30 días × 1.15 = 165.6 m³.
+    expect(r.volumenDigestorM3).toBeCloseTo(165.6, 1);
+    // Biogás = 1200 × 0.06 = 72 m³/día.
+    expect(r.biogasM3Dia).toBe(72);
+    // Biol = 4800 × 0.9 = 4320 L/día.
+    expect(r.biolLitrosDia).toBe(4320);
+    expect(r.groundedPendiente).toBe(true);
+  });
+
+  it('escala linealmente con el número de animales', () => {
+    const a = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 100 });
+    const b = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 200 });
+    expect(b.biogasM3Dia).toBeCloseTo(a.biogasM3Dia * 2, 5);
+    expect(b.volumenDigestorM3).toBeCloseTo(a.volumenDigestorM3 * 2, 5);
+  });
+
+  it('con 0 animales todo es 0 (sin NaN ni negativos)', () => {
+    const r = estimarBiodigestor({ tipoAnimal: 'bovino', numAnimales: 0 });
+    for (const v of [r.estiercolKgDia, r.mezclaLitrosDia, r.volumenDigestorM3, r.biogasM3Dia, r.biolLitrosDia]) {
+      expect(v).toBe(0);
+      expect(Number.isNaN(v)).toBe(false);
+    }
+  });
+
+  it('cada especie usa su propio coeficiente de estiércol', () => {
+    const cerdo = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 10 });
+    const gallina = estimarBiodigestor({ tipoAnimal: 'gallina', numAnimales: 10 });
+    expect(cerdo.estiercolKgDia).toBe(10 * ANIMALES_BIODIGESTOR.cerdo.estiercolKgDia);
+    expect(gallina.estiercolKgDia).toBeCloseTo(10 * ANIMALES_BIODIGESTOR.gallina.estiercolKgDia, 5);
+    expect(cerdo.estiercolKgDia).toBeGreaterThan(gallina.estiercolKgDia);
+  });
+
+  it('es determinista: misma entrada → misma salida', () => {
+    const a = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 42 });
+    const b = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 42 });
+    expect(a).toEqual(b);
+  });
+
+  it('entradas inválidas caen a defaults seguros (cerdo, 0)', () => {
+    const r = estimarBiodigestor({ tipoAnimal: 'unicornio', numAnimales: -5 });
+    expect(r.tipoAnimal).toBe('cerdo');
+    expect(r.numAnimales).toBe(0);
+    expect(r.biogasM3Dia).toBe(0);
+  });
+
+  it('trunca fracciones de animal (no hay medio cerdo)', () => {
+    const r = estimarBiodigestor({ tipoAnimal: 'cerdo', numAnimales: 2.9 });
+    expect(r.numAnimales).toBe(2);
+  });
+
+  it('los parámetros de proceso quedan expuestos para el grounding posterior', () => {
+    expect(PARAMS_PROCESO.TRH_DIAS).toBeGreaterThan(0);
+    expect(PARAMS_PROCESO.BIOGAS_M3_POR_KG).toBeGreaterThan(0);
+  });
+});

--- a/src/services/__tests__/encaladoCalculator.test.js
+++ b/src/services/__tests__/encaladoCalculator.test.js
@@ -1,0 +1,109 @@
+/**
+ * encaladoCalculator — cobertura de la matemática DETERMINISTA de encalado.
+ *
+ * Verifica que:
+ *   - CICE y saturación de aluminio son aritmética pura y correcta.
+ *   - La fórmula de Cochrane (1980) produce el requerimiento esperado.
+ *   - Si el aluminio no justifica cal, la dosis es 0 (no se sobre-encala).
+ *   - El PRNT de la fuente sube el producto físico requerido.
+ *   - Las guardas de seguridad se activan en los casos de riesgo.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  calcularCICE,
+  calcularSaturacionAluminio,
+  interpretarSaturacionAl,
+  calcularDosisCal,
+  guardasEncalado,
+  FUENTES_CAL,
+  COEF_COCHRANE_DEFAULT,
+  FACTOR_THA_POR_CMOL_20CM_DEFAULT,
+} from '../encaladoCalculator';
+
+describe('CICE y saturación de aluminio (aritmética pura)', () => {
+  it('CICE suma Al + Ca + Mg + K', () => {
+    expect(calcularCICE({ al: 1.8, ca: 2.5, mg: 0.8, k: 0.3 })).toBeCloseTo(5.4, 6);
+  });
+
+  it('CICE con K ausente lo trata como 0', () => {
+    expect(calcularCICE({ al: 1, ca: 2, mg: 1 })).toBeCloseTo(4, 6);
+  });
+
+  it('saturación de Al = Al / CICE × 100', () => {
+    // 1.8 / 5.4 = 33.33%
+    expect(calcularSaturacionAluminio({ al: 1.8, ca: 2.5, mg: 0.8, k: 0.3 })).toBeCloseTo(33.333, 2);
+  });
+
+  it('CICE = 0 → saturación null (sin división por cero)', () => {
+    expect(calcularSaturacionAluminio({ al: 0, ca: 0, mg: 0, k: 0 })).toBeNull();
+  });
+});
+
+describe('interpretarSaturacionAl — niveles cualitativos', () => {
+  it('clasifica por umbrales', () => {
+    expect(interpretarSaturacionAl(5).nivel).toBe('bajo');
+    expect(interpretarSaturacionAl(20).nivel).toBe('moderado');
+    expect(interpretarSaturacionAl(40).nivel).toBe('alto');
+    expect(interpretarSaturacionAl(70).nivel).toBe('muy_alto');
+    expect(interpretarSaturacionAl(null).nivel).toBe('sin_datos');
+  });
+});
+
+describe('calcularDosisCal — fórmula de Cochrane (1980)', () => {
+  it('calcula el requerimiento con el coeficiente y factor por defecto', () => {
+    const bases = { al: 1.8, ca: 2.5, mg: 0.8, k: 0.3 }; // CICE 5.4, satAl 33.3%
+    const r = calcularDosisCal(bases, { saturacionObjetivo: 25, fuente: 'cal_dolomita' });
+    // exceso = 1.8 - 0.25*5.4 = 1.8 - 1.35 = 0.45
+    // req = 1.5 * 0.45 = 0.675 cmol/kg
+    expect(r.requerimientoCmol).toBeCloseTo(0.68, 1);
+    expect(COEF_COCHRANE_DEFAULT).toBe(1.5);
+    // CaCO3 puro = 0.675 * 1.2 = 0.81 t/ha
+    expect(r.dosisCaCO3Tha).toBeCloseTo(0.81, 1);
+    // ajuste PRNT 95% → 0.81 / 0.95 ≈ 0.85 t/ha
+    expect(r.dosisRealTha).toBeCloseTo(0.85, 1);
+    expect(r.necesitaCal).toBe(true);
+    expect(FACTOR_THA_POR_CMOL_20CM_DEFAULT).toBe(1.2);
+  });
+
+  it('no requiere cal si la saturación de Al ya está bajo el objetivo', () => {
+    const bases = { al: 0.2, ca: 4, mg: 1.5, k: 0.4 }; // satAl ~3.3%
+    const r = calcularDosisCal(bases, { saturacionObjetivo: 25 });
+    expect(r.necesitaCal).toBe(false);
+    expect(r.requerimientoCmol).toBe(0);
+    expect(r.dosisRealTha).toBe(0);
+  });
+
+  it('la cal de menor PRNT exige más producto físico', () => {
+    const bases = { al: 2, ca: 1, mg: 0.5, k: 0.2 };
+    const dolomita = calcularDosisCal(bases, { fuente: 'cal_dolomita' }); // PRNT 95
+    const viva = calcularDosisCal(bases, { fuente: 'cal_viva' }); // PRNT 130
+    // Más PRNT → menos producto. La cal viva (130) exige menos que la dolomita (95).
+    expect(viva.dosisRealTha).toBeLessThan(dolomita.dosisRealTha);
+    // Ambas parten del mismo CaCO3 puro.
+    expect(viva.dosisCaCO3Tha).toBeCloseTo(dolomita.dosisCaCO3Tha, 6);
+  });
+
+  it('expone los supuestos grounded-pendiente para transparencia', () => {
+    const r = calcularDosisCal({ al: 2, ca: 1, mg: 1 });
+    expect(r.supuestos.groundedPendiente.length).toBeGreaterThanOrEqual(4);
+    expect(r.supuestos.profundidadCm).toBe(20);
+    expect(FUENTES_CAL.cal_dolomita.prnt).toBeGreaterThan(0);
+  });
+});
+
+describe('guardasEncalado — seguridad', () => {
+  it('avisa si la saturación de Al es baja (no sobre-encalar)', () => {
+    const avisos = guardasEncalado({ al: 0.2, ca: 4, mg: 1 }, 5);
+    expect(avisos.some((a) => /baja/i.test(a))).toBe(true);
+  });
+
+  it('sugiere dolomita si el calcio supera mucho al magnesio', () => {
+    const avisos = guardasEncalado({ al: 2, ca: 6, mg: 0.5 }, 40);
+    expect(avisos.some((a) => /dolomita/i.test(a))).toBe(true);
+  });
+
+  it('siempre advierte no mezclar con urea/estiércol fresco', () => {
+    const avisos = guardasEncalado({ al: 2, ca: 2, mg: 1 }, 30);
+    expect(avisos.some((a) => /urea|estiércol/i.test(a))).toBe(true);
+  });
+});

--- a/src/services/__tests__/gradosDiaCalculator.test.js
+++ b/src/services/__tests__/gradosDiaCalculator.test.js
@@ -1,0 +1,136 @@
+/**
+ * gradosDiaCalculator — cálculo DETERMINISTA de grados-día. El contrato: los
+ * números salen del método modificado del promedio (grounding R30) y la etapa
+ * de la fenología en DÍAS (grounded), nunca inventados.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+    CULTIVOS_GDD,
+    CULTIVO_GDD_BY_ID,
+    PISOS_TERMICOS,
+    REGIMENES_LLUVIA,
+    gddDia,
+    gddAcumulado,
+    diasTranscurridos,
+    estimarEtapa,
+    compararRitmo,
+} from '../gradosDiaCalculator';
+
+describe('gddDia — método modificado del promedio', () => {
+    test('maíz en tierra fría (Tb=10): clampa la mínima a 10', () => {
+        // tmin 7 < Tb 10 → 10; (10+19)/2 - 10 = 4.5
+        expect(gddDia(7, 19, 10, 30)).toBe(4.5);
+    });
+
+    test('maíz en tierra templada acumula más calor por día', () => {
+        // (15+26)/2 - 10 = 10.5
+        expect(gddDia(15, 26, 10, 30)).toBe(10.5);
+    });
+
+    test('clampa la máxima a la temperatura tope To', () => {
+        // tmax 35 > To 30 → 30; (20+30)/2 - 10 = 15
+        expect(gddDia(20, 35, 10, 30)).toBe(15);
+    });
+
+    test('día por debajo de la base → 0 grados-día (nunca negativo)', () => {
+        expect(gddDia(2, 8, 10, 30)).toBe(0);
+    });
+
+    test('sin To (null) no aplica tope superior', () => {
+        // papa Tb=5, sin cap: (7+25)/2 - 5 = 11
+        expect(gddDia(7, 25, 5, null)).toBe(11);
+    });
+
+    test('entradas no numéricas → 0 (robustez)', () => {
+        expect(gddDia(NaN, 20, 10, 30)).toBe(0);
+        expect(gddDia(10, undefined, 10, 30)).toBe(0);
+    });
+});
+
+describe('gddAcumulado — acumulación por N días a ritmo constante', () => {
+    test('maíz frío por 10 días = 45 °D', () => {
+        expect(gddAcumulado(7, 19, 10, 30, 10)).toBe(45);
+    });
+    test('días negativos o cero → 0', () => {
+        expect(gddAcumulado(15, 26, 10, 30, 0)).toBe(0);
+        expect(gddAcumulado(15, 26, 10, 30, -5)).toBe(0);
+    });
+    test('trunca días fraccionarios', () => {
+        expect(gddAcumulado(15, 26, 10, 30, 3.9)).toBe(31.5); // 10.5*3
+    });
+});
+
+describe('diasTranscurridos', () => {
+    test('cuenta días enteros entre dos fechas', () => {
+        expect(diasTranscurridos('2026-01-01', '2026-01-11')).toBe(10);
+    });
+    test('futuro o fecha inválida → 0', () => {
+        expect(diasTranscurridos('2026-02-01', '2026-01-01')).toBe(0);
+        expect(diasTranscurridos('no-es-fecha', '2026-01-01')).toBe(0);
+    });
+});
+
+describe('estimarEtapa — por fenología en días (grounded)', () => {
+    test('maíz recién sembrado: siembra → próxima emergencia', () => {
+        const e = estimarEtapa('maiz', 0);
+        expect(e.actual.id).toBe('siembra');
+        expect(e.proxima.id).toBe('emergencia');
+        expect(e.diasParaProxima).toBe(8);
+    });
+
+    test('maíz a los 50 días va en crecimiento, sigue floración', () => {
+        const e = estimarEtapa('maiz', 50);
+        expect(e.actual.id).toBe('vegetativo');
+        expect(e.proxima.id).toBe('floracion');
+        expect(e.diasParaProxima).toBe(10);
+    });
+
+    test('pasado el último hito no hay próxima etapa', () => {
+        const e = estimarEtapa('maiz', 200);
+        expect(e.actual.id).toBe('grano_seco');
+        expect(e.proxima).toBeNull();
+        expect(e.diasParaProxima).toBeNull();
+    });
+
+    test('papa a los 90 días va en tuberización', () => {
+        const e = estimarEtapa('papa', 90);
+        expect(e.actual.id).toBe('tuberizacion');
+    });
+
+    test('cultivo manual (sin fenología) → null honesto', () => {
+        expect(estimarEtapa('manual', 30)).toBeNull();
+    });
+});
+
+describe('compararRitmo — evidencia de "tarda más en tierra fría"', () => {
+    test('maíz: templado junta más °D/día que frío (factor > 1)', () => {
+        const r = compararRitmo('maiz', 'templado', 'frio');
+        expect(r.calido).toBe(10.5);
+        expect(r.frio).toBe(4.5);
+        expect(r.factor).toBeGreaterThan(1);
+    });
+    test('ids desconocidos → null', () => {
+        expect(compararRitmo('maiz', 'x', 'frio')).toBeNull();
+    });
+});
+
+describe('datos groundeados — integridad del set', () => {
+    test('maíz y papa traen Tb y fuente citada', () => {
+        expect(CULTIVO_GDD_BY_ID.maiz.tb).toBe(10);
+        expect(CULTIVO_GDD_BY_ID.maiz.to).toBe(30);
+        expect(CULTIVO_GDD_BY_ID.maiz.fuente).toMatch(/R30/);
+        expect(CULTIVO_GDD_BY_ID.papa.tb).toBe(5);
+        expect(CULTIVO_GDD_BY_ID.papa.fuente).toMatch(/R31/);
+    });
+    test('todo cultivo tiene id, nombre y Tb numérica', () => {
+        for (const c of CULTIVOS_GDD) {
+            expect(typeof c.id).toBe('string');
+            expect(typeof c.nombre).toBe('string');
+            expect(Number.isFinite(c.tb)).toBe(true);
+        }
+    });
+    test('los pisos térmicos y regímenes existen para la orientación', () => {
+        expect(PISOS_TERMICOS.length).toBeGreaterThanOrEqual(4);
+        expect(REGIMENES_LLUVIA.map((r) => r.id)).toEqual(['bimodal', 'unimodal']);
+    });
+});

--- a/src/services/__tests__/poscosechaCalculator.test.js
+++ b/src/services/__tests__/poscosechaCalculator.test.js
@@ -1,0 +1,122 @@
+/**
+ * poscosechaCalculator — cobertura de la lógica DETERMINISTA de poscosecha.
+ *
+ * Verifica que:
+ *   - El secado de grano es un balance de masa EXACTO (la materia seca no cambia).
+ *   - Las guardas rechazan datos inválidos (secar "hacia arriba", humedad ≥ 100).
+ *   - La evaluación de materia seca del aguacate respeta los umbrales de norma.
+ *   - Los catálogos grounded (granos, curado, transformaciones) están completos.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  GRANOS,
+  calcularSecadoGrano,
+  evaluarMateriaSecaAguacate,
+  AGUACATE_MS_MINIMO_NORMA,
+  CURADO,
+  DANIO_POR_FRIO,
+  TRANSFORMACIONES,
+  PERDIDA_PAIS,
+} from '../poscosechaCalculator';
+
+describe('secado de grano — balance de masa exacto', () => {
+  it('la materia seca se conserva al secar', () => {
+    // 100 kg al 22 % → materia seca = 78 kg (constante).
+    const r = calcularSecadoGrano({ pesoInicial: 100, humedadInicial: 22, humedadObjetivo: 13 });
+    expect(r).not.toBeNull();
+    expect(r.materiaSeca).toBeCloseTo(78, 2);
+    // peso final = 78 / (1 - 0.13) = 89.655...
+    expect(r.pesoFinal).toBeCloseTo(89.66, 1);
+    // agua a sacar = 100 - 89.66 = 10.34
+    expect(r.aguaEliminada).toBeCloseTo(10.34, 1);
+  });
+
+  it('agua eliminada + peso final = peso inicial (conservación)', () => {
+    const r = calcularSecadoGrano({ pesoInicial: 50, humedadInicial: 18, humedadObjetivo: 13 });
+    expect(r.pesoFinal + r.aguaEliminada).toBeCloseTo(50, 1);
+  });
+
+  it('acepta coma decimal en las entradas', () => {
+    const r = calcularSecadoGrano({ pesoInicial: '100', humedadInicial: '22,5', humedadObjetivo: 13 });
+    expect(r).not.toBeNull();
+    expect(r.aguaEliminada).toBeGreaterThan(0);
+  });
+
+  it('rechaza secar hacia arriba (humedad objetivo ≥ actual)', () => {
+    expect(calcularSecadoGrano({ pesoInicial: 100, humedadInicial: 12, humedadObjetivo: 13 })).toBeNull();
+    expect(calcularSecadoGrano({ pesoInicial: 100, humedadInicial: 13, humedadObjetivo: 13 })).toBeNull();
+  });
+
+  it('rechaza datos inválidos (peso ≤ 0, humedad fuera de 0–100)', () => {
+    expect(calcularSecadoGrano({ pesoInicial: 0, humedadInicial: 22, humedadObjetivo: 13 })).toBeNull();
+    expect(calcularSecadoGrano({ pesoInicial: 100, humedadInicial: 120, humedadObjetivo: 13 })).toBeNull();
+    expect(calcularSecadoGrano({ pesoInicial: 100, humedadInicial: '', humedadObjetivo: 13 })).toBeNull();
+  });
+});
+
+describe('índice de cosecha — aguacate Hass por materia seca', () => {
+  it('por debajo del 21 % está verde', () => {
+    const r = evaluarMateriaSecaAguacate(19);
+    expect(r.nivel).toBe('verde');
+    expect(r.color).toBe('amber');
+  });
+
+  it('entre 21 y 23 % está en punto de norma', () => {
+    expect(evaluarMateriaSecaAguacate(AGUACATE_MS_MINIMO_NORMA).nivel).toBe('norma');
+    expect(evaluarMateriaSecaAguacate(22).nivel).toBe('norma');
+  });
+
+  it('desde 23 % está en punto óptimo', () => {
+    expect(evaluarMateriaSecaAguacate(24).nivel).toBe('optimo');
+    expect(evaluarMateriaSecaAguacate(24).color).toBe('emerald');
+  });
+
+  it('sin dato devuelve null', () => {
+    expect(evaluarMateriaSecaAguacate('')).toBeNull();
+    expect(evaluarMateriaSecaAguacate(null)).toBeNull();
+  });
+});
+
+describe('catálogos grounded', () => {
+  it('las dos recetas de curado son OPUESTAS (húmedo vs seco)', () => {
+    expect(CURADO.raices.receta).toMatch(/húmedo/i);
+    expect(CURADO.bulbos.receta).toMatch(/seco/i);
+    expect(CURADO.raices.detalle.length).toBeGreaterThan(0);
+    expect(CURADO.bulbos.detalle.length).toBeGreaterThan(0);
+  });
+
+  it('cada grano trae humedad segura, rango y fuente', () => {
+    for (const g of Object.values(GRANOS)) {
+      expect(g.humedadSegura).toBeGreaterThan(0);
+      expect(g.humedadSeguraRango).toHaveLength(2);
+      expect(g.fuente).toBeTruthy();
+    }
+    // El maíz debe estar en su rango seguro conocido (13–14 %).
+    expect(GRANOS.maiz.humedadSeguraRango).toEqual([13, 14]);
+  });
+
+  it('el queso está marcado como punto crítico (pasteurizar)', () => {
+    const queso = TRANSFORMACIONES.find((t) => t.id === 'queso');
+    expect(queso.critico).toBe(true);
+    expect(queso.puntoCritico).toMatch(/pasteuri/i);
+  });
+
+  it('cada transformación tiene punto crítico y fuente', () => {
+    for (const t of TRANSFORMACIONES) {
+      expect(t.puntoCritico).toBeTruthy();
+      expect(t.fuente).toBeTruthy();
+    }
+  });
+
+  it('el daño por frío lista tropicales con su umbral', () => {
+    expect(DANIO_POR_FRIO.length).toBeGreaterThan(0);
+    for (const d of DANIO_POR_FRIO) {
+      expect(d.minC).toBeGreaterThan(0);
+    }
+  });
+
+  it('la cifra de pérdida país está anclada a fuente', () => {
+    expect(PERDIDA_PAIS.porcentajeOferta).toBe(34);
+    expect(PERDIDA_PAIS.fuente).toMatch(/DNP/);
+  });
+});

--- a/src/services/aguaCalculos.js
+++ b/src/services/aguaCalculos.js
@@ -1,0 +1,138 @@
+/**
+ * aguaCalculos.js — lógica DETERMINISTA del módulo "Agua de la finca".
+ *
+ * Solo matemática de unidades y fórmulas clásicas de manejo de agua. AQUÍ NO
+ * VIVEN DATOS DUROS (lluvia por zona, Kc por cultivo, ETo por piso térmico):
+ * esos son slots grounded-pendiente en src/data/aguaFinca.js y llegan por el
+ * pipeline de grounding (DR → catálogo/AGE), nunca inventados en código.
+ *
+ * Identidad de unidades que sostiene todo el módulo:
+ *   1 mm de lluvia sobre 1 m² = 1 litro. (No es un dato: es la definición
+ *   del milímetro de precipitación.)
+ */
+
+/**
+ * Coeficiente de escorrentía del techo: fracción de la lluvia que de verdad
+ * llega al tanque (el resto se pierde en salpique, evaporación y primeras
+ * lavadas del techo). 0.8 es un valor CONSERVADOR de diseño, usado como
+ * default editable por la persona.
+ *
+ * TODO GROUNDED-PENDIENTE: coeficiente por material de techo (zinc/teja de
+ * barro/fibrocemento/paja) con fuente técnica citada (DR cosecha de agua
+ * lluvia). Cuando llegue, este default pasa a ser el fallback.
+ */
+export const COEF_ESCORRENTIA_TECHO_DEFAULT = 0.8;
+
+/** Una caneca azul estándar de 55 galones (EE. UU.) ≈ 208 litros. Conversión de unidades, no dato de campo. */
+export const LITROS_POR_CANECA_55GAL = 208;
+
+/**
+ * Parseo estricto para inputs de formulario: '' / null / undefined → NaN
+ * (Number('') sería 0 y un campo vacío se volvería "0 mm de lluvia" — falso).
+ * @param {number|string|null|undefined} v
+ * @returns {number}
+ */
+function num(v) {
+  if (v == null || (typeof v === 'string' && v.trim() === '')) return NaN;
+  return Number(v);
+}
+
+/**
+ * Litros de lluvia captables en un periodo.
+ * litros = área de techo (m²) × lluvia (mm) × coeficiente de escorrentía.
+ *
+ * @param {Object} p
+ * @param {number|string} p.areaTechoM2 - área de techo que drena a canal (m²)
+ * @param {number|string} p.lluviaMm - lámina de lluvia del periodo (mm)
+ * @param {number|string} [p.coefEscorrentia] - fracción 0–1 que llega al tanque
+ * @returns {number|null} litros (redondeados), o null si la entrada no sirve
+ */
+export function litrosLluviaCaptables({ areaTechoM2, lluviaMm, coefEscorrentia = COEF_ESCORRENTIA_TECHO_DEFAULT }) {
+  const area = num(areaTechoM2);
+  const mm = num(lluviaMm);
+  const coef = num(coefEscorrentia);
+  if (!Number.isFinite(area) || area <= 0) return null;
+  if (!Number.isFinite(mm) || mm < 0) return null;
+  if (!Number.isFinite(coef) || coef <= 0 || coef > 1) return null;
+  return Math.round(area * mm * coef);
+}
+
+/**
+ * Cuántas canecas de 55 galones equivalen a unos litros. Para que el número
+ * grande se pueda "ver" en objetos de finca.
+ * @param {number} litros
+ * @returns {number|null} canecas (1 decimal)
+ */
+export function canecasEquivalentes(litros) {
+  const l = num(litros);
+  if (!Number.isFinite(l) || l < 0) return null;
+  return Math.round((l / LITROS_POR_CANECA_55GAL) * 10) / 10;
+}
+
+/**
+ * Porcentaje de llenado de un tanque (tope 100).
+ * @param {Object} p
+ * @param {number|string} p.litros - litros captados
+ * @param {number|string} p.capacidadL - capacidad del tanque en litros
+ * @returns {number|null} 0–100
+ */
+export function porcentajeTanque({ litros, capacidadL }) {
+  const l = num(litros);
+  const cap = num(capacidadL);
+  if (!Number.isFinite(l) || l < 0) return null;
+  if (!Number.isFinite(cap) || cap <= 0) return null;
+  return Math.min(100, Math.round((l / cap) * 100));
+}
+
+/**
+ * ETc (consumo diario del cultivo) = ETo × Kc. Fórmula FAO clásica; los
+ * VALORES de ETo (por piso térmico) y Kc (por cultivo y etapa) son slots
+ * grounded-pendiente en src/data/aguaFinca.js — aquí solo se multiplica lo
+ * que la persona (o el catálogo, cuando llegue) ponga.
+ *
+ * @param {Object} p
+ * @param {number|string} p.etoMmDia - evapotranspiración de referencia (mm/día)
+ * @param {number|string} p.kc - coeficiente del cultivo (típico 0.2–1.3)
+ * @returns {number|null} ETc en mm/día (2 decimales)
+ */
+export function etcDiaria({ etoMmDia, kc }) {
+  const eto = num(etoMmDia);
+  const k = num(kc);
+  if (!Number.isFinite(eto) || eto <= 0) return null;
+  if (!Number.isFinite(k) || k <= 0 || k > 2) return null;
+  return Math.round(eto * k * 100) / 100;
+}
+
+/**
+ * Litros de riego por día para un área: ETc (mm/día) × área (m²).
+ * (1 mm = 1 L/m², identidad de unidades.) Es la necesidad NETA de la planta;
+ * el sistema de riego pierde una parte según su eficiencia (ese coeficiente
+ * es slot grounded-pendiente, no se aplica aquí).
+ *
+ * @param {Object} p
+ * @param {number|string} p.etcMmDia - consumo del cultivo (mm/día)
+ * @param {number|string} p.areaM2 - área sembrada (m²)
+ * @returns {number|null} litros por día (redondeados)
+ */
+export function litrosRiegoDia({ etcMmDia, areaM2 }) {
+  const etc = num(etcMmDia);
+  const area = num(areaM2);
+  if (!Number.isFinite(etc) || etc <= 0) return null;
+  if (!Number.isFinite(area) || area <= 0) return null;
+  return Math.round(etc * area);
+}
+
+/**
+ * Cuántos días alcanza el agua guardada para un consumo diario dado.
+ * @param {Object} p
+ * @param {number|string} p.litrosGuardados
+ * @param {number|string} p.consumoLitrosDia
+ * @returns {number|null} días enteros (piso)
+ */
+export function diasDeReserva({ litrosGuardados, consumoLitrosDia }) {
+  const l = num(litrosGuardados);
+  const c = num(consumoLitrosDia);
+  if (!Number.isFinite(l) || l < 0) return null;
+  if (!Number.isFinite(c) || c <= 0) return null;
+  return Math.floor(l / c);
+}

--- a/src/services/biodigestorCalculator.js
+++ b/src/services/biodigestorCalculator.js
@@ -1,0 +1,141 @@
+/**
+ * biodigestorCalculator — dimensionamiento SIMPLE y determinista de un
+ * biodigestor tubular a partir del hato de la finca.
+ *
+ * El campesino ingresa TIPO de animal y NÚMERO de cabezas; la función estima:
+ *   · estiércol fresco por día (kg)
+ *   · mezcla a cargar por día (estiércol + agua, litros)
+ *   · volumen del digestor (m³)
+ *   · biogás por día (m³)
+ *   · biol por día (litros)  ← el efluente, fertilizante líquido
+ *   · equivalencia tangible (horas de fogón)
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * ⚠️  GROUNDED-PENDIENTE — LEER ANTES DE TOMAR ESTAS CIFRAS COMO DATO DURO
+ * ─────────────────────────────────────────────────────────────────────────
+ * Los coeficientes de abajo (PARAMS_ANIMAL + PARAMS_PROCESO) son RANGOS DE
+ * REFERENCIA de ingeniería agrícola, NO datos groundeados del catálogo/DR.
+ * Sirven para que la calculadora dé un orden de magnitud razonable y
+ * pedagógico. Las DOS investigaciones (nacional Colombia + internacional) que
+ * llegan aparte deben REEMPLAZAR cada constante marcada `@grounded-pendiente`
+ * por su valor citado, afinado por región térmica, raza y dieta.
+ *
+ * Puntos exactos a groundear (buscar el tag GROUNDED-PENDIENTE):
+ *   1. estiercolKgDia por especie (producción de estiércol fresco/animal/día).
+ *   2. BIOGAS_M3_POR_KG (rendimiento de biogás por kg de estiércol fresco).
+ *   3. TRH_DIAS (tiempo de retención hidráulica según clima/piso térmico).
+ *   4. DILUCION_AGUA (relación estiércol:agua de carga).
+ *   5. BIOGAS_M3_POR_HORA_FOGON (consumo de un fogón doméstico).
+ * Nada aquí se presenta al usuario como cifra citada mientras siga siendo
+ * placeholder: la UI rotula estos resultados como "estimado" (ver
+ * EstiercolScreen).
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+/**
+ * Parámetros por especie. `estiercolKgDia` = kg de estiércol FRESCO que produce
+ * un animal por día (excreta recolectable).
+ *
+ * GROUNDED-PENDIENTE #1 — valores de referencia; afinar por raza/peso/dieta.
+ * @type {Record<string, {id:string, nombre:string, emoji:string, estiercolKgDia:number, nota:string}>}
+ */
+export const ANIMALES_BIODIGESTOR = {
+  cerdo: {
+    id: 'cerdo',
+    nombre: 'Cerdos',
+    emoji: '🐖',
+    estiercolKgDia: 4.0, // @grounded-pendiente
+    nota: 'Cerdo de engorde (~60 kg vivo)',
+  },
+  bovino: {
+    id: 'bovino',
+    nombre: 'Vacas',
+    emoji: '🐄',
+    estiercolKgDia: 10.0, // @grounded-pendiente
+    nota: 'Bovino adulto (estabulado o con recolección)',
+  },
+  gallina: {
+    id: 'gallina',
+    nombre: 'Gallinas',
+    emoji: '🐔',
+    estiercolKgDia: 0.12, // @grounded-pendiente
+    nota: 'Ponedora en piso (gallinaza recogida)',
+  },
+};
+
+/**
+ * Parámetros del proceso de biodigestión anaerobia (régimen mesofílico tibio).
+ * GROUNDED-PENDIENTE #2–#5.
+ */
+export const PARAMS_PROCESO = {
+  /** Partes de agua por parte de estiércol en la carga (mezcla 1:3). @grounded-pendiente #4 */
+  DILUCION_AGUA: 3,
+  /** Tiempo de retención hidráulica en días (clima templado). @grounded-pendiente #3 */
+  TRH_DIAS: 30,
+  /** m³ de biogás por kg de estiércol fresco. @grounded-pendiente #2 */
+  BIOGAS_M3_POR_KG: 0.06,
+  /** Fracción de la mezcla que sale como biol (efluente). */
+  BIOL_FRACCION: 0.9,
+  /** Holgura de diseño sobre el volumen líquido (cámara de gas + seguridad). */
+  FACTOR_SEGURIDAD: 1.15,
+  /** Densidad aprox. del estiércol/mezcla (kg/L) para pasar masa↔volumen. */
+  DENSIDAD_KG_L: 1.0,
+  /** Consumo de un fogón doméstico de biogás (m³/hora). @grounded-pendiente #5 */
+  BIOGAS_M3_POR_HORA_FOGON: 0.35,
+};
+
+/** Redondea a `dec` decimales devolviendo Number (evita el "-0"). */
+function round(n, dec = 1) {
+  const f = 10 ** dec;
+  return Math.round((n + Number.EPSILON) * f) / f || 0;
+}
+
+/**
+ * @typedef {Object} EstimacionBiodigestor
+ * @property {string}  tipoAnimal
+ * @property {number}  numAnimales
+ * @property {number}  estiercolKgDia     Estiércol fresco total por día (kg).
+ * @property {number}  aguaLitrosDia      Agua de dilución por día (L).
+ * @property {number}  mezclaLitrosDia    Mezcla a cargar por día (L).
+ * @property {number}  volumenDigestorM3  Volumen recomendado del digestor (m³).
+ * @property {number}  biogasM3Dia        Biogás estimado por día (m³).
+ * @property {number}  biolLitrosDia      Biol (efluente fertilizante) por día (L).
+ * @property {number}  horasFogonDia      Equivalencia: horas de fogón por día.
+ * @property {boolean} groundedPendiente  Siempre true: cifras estimadas, sin citar.
+ */
+
+/**
+ * Estima el dimensionamiento del biodigestor. Función PURA y determinista.
+ *
+ * @param {{ tipoAnimal?: string, numAnimales?: number }} params
+ * @returns {EstimacionBiodigestor}
+ */
+export function estimarBiodigestor({ tipoAnimal = 'cerdo', numAnimales = 0 } = {}) {
+  const animal = ANIMALES_BIODIGESTOR[tipoAnimal] || ANIMALES_BIODIGESTOR.cerdo;
+  const n = Math.max(0, Math.floor(Number(numAnimales) || 0));
+  const P = PARAMS_PROCESO;
+
+  const estiercolKgDia = n * animal.estiercolKgDia;
+  const estiercolLitrosDia = estiercolKgDia / P.DENSIDAD_KG_L;
+  const aguaLitrosDia = estiercolLitrosDia * P.DILUCION_AGUA;
+  const mezclaLitrosDia = estiercolLitrosDia + aguaLitrosDia;
+  const mezclaM3Dia = mezclaLitrosDia / 1000;
+
+  const volumenDigestorM3 = mezclaM3Dia * P.TRH_DIAS * P.FACTOR_SEGURIDAD;
+  const biogasM3Dia = estiercolKgDia * P.BIOGAS_M3_POR_KG;
+  const biolLitrosDia = mezclaLitrosDia * P.BIOL_FRACCION;
+  const horasFogonDia = biogasM3Dia / P.BIOGAS_M3_POR_HORA_FOGON;
+
+  return {
+    tipoAnimal: animal.id,
+    numAnimales: n,
+    estiercolKgDia: round(estiercolKgDia, 1),
+    aguaLitrosDia: round(aguaLitrosDia, 0),
+    mezclaLitrosDia: round(mezclaLitrosDia, 0),
+    volumenDigestorM3: round(volumenDigestorM3, 1),
+    biogasM3Dia: round(biogasM3Dia, 1),
+    biolLitrosDia: round(biolLitrosDia, 0),
+    horasFogonDia: round(horasFogonDia, 1),
+    groundedPendiente: true,
+  };
+}

--- a/src/services/encaladoCalculator.js
+++ b/src/services/encaladoCalculator.js
@@ -1,0 +1,199 @@
+/**
+ * encaladoCalculator — calculadora DETERMINISTA de encalado a partir de la
+ * saturación de aluminio, para el módulo "Salud del Suelo" (Cuaderno del Suelo).
+ *
+ * Filosofía (inviolable, alineada con soilDiagnostic.js):
+ *   - La MATEMÁTICA es determinista y estándar (Cochrane/Salinas/Sánchez 1980;
+ *     Kamprath 1970). Se calcula, no se inventa.
+ *   - Los FACTORES exactos que dependen de la zona/suelo/producto (densidad
+ *     aparente, profundidad, PRNT de la cal, saturación objetivo) NO se
+ *     inventan: son SLOTS GROUNDED-PENDIENTE con un valor por defecto documentado
+ *     y una fuente pendiente de anclar por región (DR-SUELOS-ENCALADO).
+ *   - Nunca se recomienda encalar si la saturación de Al no lo justifica.
+ *
+ * NO reemplaza un análisis de laboratorio ni la recomendación de un ingeniero
+ * agrónomo: es una estimación orientadora para el cuaderno de campo.
+ */
+
+/* ─────────────────────────── SLOTS GROUNDED-PENDIENTE ───────────────────────
+ * Estos factores tienen valor por defecto estándar de literatura, PERO el valor
+ * exacto por REGIÓN/PRODUCTO debe anclarse a fuente (DR-SUELOS-ENCALADO). No se
+ * "inventan" cifras finas; se usa el estándar y se marca la incertidumbre.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Coeficiente de la fórmula de Cochrane, Salinas & Sánchez (1980).
+ * Rango de literatura 1.5–2.0 según el poder tampón (buffer) del suelo.
+ * GROUNDED-PENDIENTE: el valor exacto por tipo de suelo (andisol vs oxisol vs
+ * suelo de ladera cafetera) debe anclarse a fuente regional.
+ */
+export const COEF_COCHRANE_DEFAULT = 1.5;
+
+/**
+ * Saturación de aluminio OBJETIVO (%) tras el encalado. Se baja el Al hasta un
+ * nivel tolerable por el cultivo, NO a cero (encalar de más bloquea P, Zn, B).
+ * GROUNDED-PENDIENTE: umbral crítico por cultivo (café, papa, aguacate, maíz…)
+ * debe anclarse a fuente. 25 % es un valor conservador de referencia general.
+ */
+export const SATURACION_AL_OBJETIVO_DEFAULT = 25;
+
+/**
+ * Factor de conversión de cmol(+)/kg de requerimiento a toneladas/ha de CaCO₃
+ * PURO, para una capa de 20 cm. Se deriva de: 1 cmol(+)/kg = 0.5 g CaCO₃/kg de
+ * suelo, y una masa de suelo de ~2.4×10⁶ kg/ha (20 cm, densidad aparente
+ * 1.2 g/cm³) ⇒ ~1.2 t/ha por cada cmol(+)/kg.
+ * GROUNDED-PENDIENTE: la densidad aparente y la profundidad efectiva REALES de
+ * la zona cambian este factor; anclar por región (andisoles ~0.9 g/cm³ dan un
+ * factor menor). Rango típico 1.0–1.5.
+ */
+export const FACTOR_THA_POR_CMOL_20CM_DEFAULT = 1.2;
+
+/**
+ * Catálogo de fuentes de cal con su PRNT (Poder Relativo de Neutralización
+ * Total, % equivalente a CaCO₃ puro). Baja el requerimiento efectivo: si la cal
+ * neutraliza menos, hay que aplicar más.
+ * GROUNDED-PENDIENTE: el PRNT REAL depende del proveedor y del lote; el usuario
+ * debe leerlo en la ficha del producto. Estos son valores de referencia típicos.
+ */
+export const FUENTES_CAL = {
+  cal_dolomita: { label: 'Cal dolomita', prnt: 95, aporta: 'Ca + Mg', nota: 'Aporta magnesio; buena si el Mg está bajo.' },
+  cal_agricola: { label: 'Cal agrícola (calcítica)', prnt: 90, aporta: 'Ca', nota: 'Solo calcio; no corrige déficit de magnesio.' },
+  cal_viva:     { label: 'Cal viva (óxido)', prnt: 130, aporta: 'Ca', nota: 'Reacción fuerte y rápida; manéjela con cuidado (cáustica).' },
+};
+
+/* ────────────────────────────── DETERMINISTA ─────────────────────────────── */
+
+/**
+ * @typedef {Object} BasesSuelo
+ * @property {number} al  Aluminio intercambiable (cmol(+)/kg).
+ * @property {number} ca  Calcio intercambiable (cmol(+)/kg).
+ * @property {number} mg  Magnesio intercambiable (cmol(+)/kg).
+ * @property {number} [k] Potasio intercambiable (cmol(+)/kg). Opcional.
+ */
+
+/**
+ * Capacidad de Intercambio Catiónico Efectiva (CICE) = Al + Ca + Mg + K.
+ * Arithmética pura, sin factores inventados.
+ * @param {BasesSuelo} b
+ * @returns {number} cmol(+)/kg
+ */
+export function calcularCICE({ al = 0, ca = 0, mg = 0, k = 0 }) {
+  return al + ca + mg + k;
+}
+
+/**
+ * Saturación de aluminio (%) = Al / CICE × 100. Es el indicador clave de acidez
+ * intercambiable. Arithmética pura.
+ * @param {BasesSuelo} b
+ * @returns {number|null} porcentaje 0–100, o null si CICE = 0
+ */
+export function calcularSaturacionAluminio(b) {
+  const cice = calcularCICE(b);
+  if (cice <= 0) return null;
+  return (b.al / cice) * 100;
+}
+
+/**
+ * Interpreta la saturación de Al en un nivel cualitativo honesto.
+ * Umbrales de referencia general (no específicos de cultivo).
+ * @param {number|null} satAl
+ */
+export function interpretarSaturacionAl(satAl) {
+  if (satAl == null) return { nivel: 'sin_datos', label: 'Sin datos suficientes', color: 'slate' };
+  if (satAl < 10) return { nivel: 'bajo', label: 'Acidez baja — la mayoría de cultivos crecen bien', color: 'emerald' };
+  if (satAl < 30) return { nivel: 'moderado', label: 'Acidez moderada — algunos cultivos se afectan', color: 'lime' };
+  if (satAl < 60) return { nivel: 'alto', label: 'Acidez alta — conviene corregir', color: 'amber' };
+  return { nivel: 'muy_alto', label: 'Acidez muy alta — toxicidad de aluminio probable', color: 'rose' };
+}
+
+/**
+ * Calcula la dosis de cal por el método de Cochrane, Salinas & Sánchez (1980):
+ *
+ *   Requerimiento (cmol/kg) = coef × [ Al − (RAS/100) × CICE ]
+ *
+ * donde RAS = saturación de Al objetivo. Si el corchete ≤ 0, no se requiere cal.
+ * Luego convierte a t/ha de CaCO₃ puro y ajusta por el PRNT de la fuente elegida.
+ *
+ * @param {BasesSuelo} bases
+ * @param {Object} [opts]
+ * @param {number} [opts.coef]              Coeficiente de Cochrane (GROUNDED-PENDIENTE).
+ * @param {number} [opts.saturacionObjetivo] % de Al objetivo (GROUNDED-PENDIENTE).
+ * @param {number} [opts.factorTha]         t/ha por cmol/kg (GROUNDED-PENDIENTE, densidad/prof).
+ * @param {keyof typeof FUENTES_CAL} [opts.fuente] Fuente de cal (define el PRNT).
+ * @returns {{
+ *   requerimientoCmol: number,
+ *   dosisCaCO3Tha: number,
+ *   dosisRealTha: number,
+ *   fuente: string,
+ *   prnt: number,
+ *   necesitaCal: boolean,
+ *   supuestos: Object,
+ * }}
+ */
+export function calcularDosisCal(bases, opts = {}) {
+  const {
+    coef = COEF_COCHRANE_DEFAULT,
+    saturacionObjetivo = SATURACION_AL_OBJETIVO_DEFAULT,
+    factorTha = FACTOR_THA_POR_CMOL_20CM_DEFAULT,
+    fuente = 'cal_dolomita',
+  } = opts;
+
+  const cice = calcularCICE(bases);
+  const fuenteInfo = FUENTES_CAL[fuente] || FUENTES_CAL.cal_dolomita;
+  const prnt = fuenteInfo.prnt;
+
+  // Corchete de Cochrane: exceso de Al sobre el objetivo tolerable.
+  const excesoAl = bases.al - (saturacionObjetivo / 100) * cice;
+  const requerimientoCmol = Math.max(0, coef * excesoAl);
+
+  const dosisCaCO3Tha = requerimientoCmol * factorTha;
+  // Ajuste por calidad de la cal: menos PRNT ⇒ más producto físico.
+  const dosisRealTha = prnt > 0 ? dosisCaCO3Tha / (prnt / 100) : dosisCaCO3Tha;
+
+  return {
+    requerimientoCmol: redondear(requerimientoCmol, 2),
+    dosisCaCO3Tha: redondear(dosisCaCO3Tha, 2),
+    dosisRealTha: redondear(dosisRealTha, 2),
+    fuente: fuenteInfo.label,
+    prnt,
+    necesitaCal: requerimientoCmol > 0,
+    supuestos: {
+      coef,
+      saturacionObjetivo,
+      factorTha,
+      profundidadCm: 20,
+      groundedPendiente: [
+        'coef (poder tampón por tipo de suelo)',
+        'saturacionObjetivo (umbral crítico por cultivo)',
+        'factorTha (densidad aparente y profundidad reales de la zona)',
+        'prnt (poder de neutralización real del producto/lote)',
+      ],
+    },
+  };
+}
+
+/** Redondeo estable a n decimales. */
+function redondear(x, n) {
+  const f = 10 ** n;
+  return Math.round(x * f) / f;
+}
+
+/**
+ * Guardas de seguridad para la recomendación de encalado (alineadas con las de
+ * soilDiagnostic.js). Devuelve advertencias según el contexto.
+ * @param {BasesSuelo} bases
+ * @param {number|null} satAl
+ * @returns {string[]}
+ */
+export function guardasEncalado(bases, satAl) {
+  const avisos = [];
+  if (satAl != null && satAl < 10) {
+    avisos.push('La saturación de aluminio es baja: encalar aquí puede hacer más mal que bien (bloquea fósforo, zinc y boro). Confirme con un análisis antes de aplicar cal.');
+  }
+  if (bases.mg != null && bases.ca != null && bases.mg > 0 && bases.ca / bases.mg > 5) {
+    avisos.push('El calcio está muy por encima del magnesio: prefiera cal dolomita para no desbalancear aún más el magnesio.');
+  }
+  avisos.push('No mezcle la cal con urea ni estiércol fresco en la misma aplicación: se pierde nitrógeno como amoníaco. Deje pasar 2–4 semanas.');
+  avisos.push('Aplique en dos pasadas si la dosis es alta (> 2 t/ha) e incorpore bien: la cal se mueve muy poco en el suelo.');
+  return avisos;
+}

--- a/src/services/gradosDiaCalculator.js
+++ b/src/services/gradosDiaCalculator.js
@@ -1,0 +1,246 @@
+/**
+ * gradosDiaCalculator — el "reloj térmico" del cultivo (grados-día de desarrollo).
+ * ============================================================================
+ * Calculadora DETERMINISTA de grados-día acumulados (GDD): en vez de contar días
+ * calendario, cuenta el CALOR que la mata acumula por encima de su temperatura
+ * base (Tb). Explica por qué el mismo cultivo tarda más en tierra fría — "acumula
+ * menos calor por día" — la intuición campesina detrás de los GDD.
+ *
+ * GROUNDING (deepresearch 2026-07-04-cultivos-clima-nacional-CO.md):
+ *   · Maíz: Tb = 10 °C, To = 30 °C (método modificado: si Tmín<10 se usa 10; si
+ *     Tmáx>30 se usa 30). Fuente R30 (SciELO/Rev. Chapingo) — confianza alta.
+ *   · Papa: Tb típica 4–7 °C según el modelo. Fuente R31 (SciELO) — media-alta.
+ *     El valor único usado por AGROSAVIA para papa colombiana está PENDIENTE de
+ *     cierre (grounded-pendiente); usamos 5 °C como representativo del rango.
+ *   · Fenología en días (para estimar etapa) — grounded:
+ *       Papa (altiplano cundiboyacense, AGROSAVIA R10): emergencia 30–35 dds,
+ *       floración ~40–50 dds, tuberización 80–90 dds, madurez ~165–170 dds.
+ *       Maíz ICA V-305 (R18): ~100 días a choclo, ~170 a grano seco.
+ *       Maíz ICA V-109 (R18): ~70–80 días a choclo, ~120 a grano seco.
+ *
+ * REGLA DE INTEGRIDAD: no se inventan umbrales. Los umbrales de etapa por GDD
+ * (cuántos °D hasta floración/cosecha) NO están en el grounding → se marcan
+ * grounded-pendiente y la ETAPA se estima por fenología en DÍAS (que sí está
+ * groundeada), no por GDD. La calculadora entrega los GDD como el "porqué" del
+ * ritmo, y los días como el "qué etapa".
+ *
+ * Todo son funciones puras (sin estado, sin red) → fáciles de testear y de
+ * confiar. Los presets de piso térmico son REFERENCIA EDITABLE (confianza media):
+ * el campesino ajusta Tmín/Tmáx a su finca; el cálculo usa lo que él confirme.
+ */
+
+/**
+ * @typedef {Object} CultivoGDD
+ * @property {string} id            clave estable
+ * @property {string} nombre        nombre campesino
+ * @property {string} emoji
+ * @property {number} tb            temperatura base (°C)
+ * @property {number|null} to       temperatura tope (°C) o null si no se aplica cap
+ * @property {string} tbNota        procedencia/confianza de la Tb
+ * @property {string} fuente        referencia del grounding
+ * @property {Array<{id:string,label:string,desc:string,dds:number}>} [fenologia]
+ *   hitos fenológicos en días-después-de-siembra (dds), en orden ascendente.
+ * @property {string} [fenologiaFuente]
+ */
+
+/** Cultivos con Tb groundeada. `manual` deja al usuario fijar su propia Tb. */
+export const CULTIVOS_GDD = /** @type {CultivoGDD[]} */ ([
+    {
+        id: 'maiz',
+        nombre: 'Maíz',
+        emoji: '🌽',
+        tb: 10,
+        to: 30,
+        tbNota: 'Tb 10 °C, tope 30 °C (método modificado). Confianza alta.',
+        fuente: 'R30 — Rev. Chapingo / SciELO',
+        fenologia: [
+            { id: 'siembra', label: 'Siembra', desc: 'Semilla en el surco', dds: 0 },
+            { id: 'emergencia', label: 'Emergencia', desc: 'Asoma la matica', dds: 8 },
+            { id: 'vegetativo', label: 'Crecimiento', desc: 'Hoja y tallo', dds: 35 },
+            { id: 'floracion', label: 'Floración', desc: 'Espiga y jilote', dds: 60 },
+            { id: 'choclo', label: 'Choclo', desc: 'Mazorca tierna (V-305)', dds: 100 },
+            { id: 'grano_seco', label: 'Grano seco', desc: 'Madurez de cosecha (V-305)', dds: 170 },
+        ],
+        fenologiaFuente: 'R18 — ICA V-305 (V-109: choclo 70–80 d / grano 120 d)',
+    },
+    {
+        id: 'papa',
+        nombre: 'Papa',
+        emoji: '🥔',
+        tb: 5,
+        to: null,
+        tbNota: 'Tb 4–7 °C según modelo; usamos 5 °C. Valor AGROSAVIA exacto: pendiente.',
+        fuente: 'R31 — SciELO (tiempo térmico papa)',
+        fenologia: [
+            { id: 'siembra', label: 'Siembra', desc: 'Tubérculo-semilla enterrado', dds: 0 },
+            { id: 'emergencia', label: 'Emergencia', desc: 'Brota la planta', dds: 32 },
+            { id: 'floracion', label: 'Floración', desc: 'Flor de la papa', dds: 45 },
+            { id: 'tuberizacion', label: 'Tuberización', desc: 'Cuaja el tubérculo', dds: 85 },
+            { id: 'madurez', label: 'Madurez', desc: 'Lista para arrancar', dds: 167 },
+        ],
+        fenologiaFuente: 'R10 — AGROSAVIA, altiplano cundiboyacense',
+    },
+    {
+        id: 'manual',
+        nombre: 'Otro cultivo (Tb a mano)',
+        emoji: '🌱',
+        tb: 10,
+        to: null,
+        tbNota: 'Fije la temperatura base de su cultivo. Confírmela con su técnico.',
+        fuente: 'grounded-pendiente',
+    },
+]);
+
+/** Mapa id → cultivo. */
+export const CULTIVO_GDD_BY_ID = Object.fromEntries(CULTIVOS_GDD.map((c) => [c.id, c]));
+
+/**
+ * Presets de piso térmico: Tmín/Tmáx TÍPICOS de un día, coherentes con las
+ * temperaturas medias del grounding (cálido ~24+, templado ~17–24, frío ~12–17,
+ * páramo <10). Son REFERENCIA EDITABLE (confianza media): el amplitud diurna es
+ * una aproximación; el usuario ajusta a su finca. No son norma dura.
+ */
+export const PISOS_TERMICOS = [
+    { id: 'calido', nombre: 'Tierra caliente', rango: '0–1000 m', tmin: 20, tmax: 30, media: '~24 °C+' },
+    { id: 'templado', nombre: 'Tierra templada (café)', rango: '1000–2000 m', tmin: 15, tmax: 26, media: '~17–24 °C' },
+    { id: 'frio', nombre: 'Tierra fría (papa)', rango: '2000–3000 m', tmin: 7, tmax: 19, media: '~12–17 °C' },
+    { id: 'paramo', nombre: 'Páramo', rango: '>3000 m', tmin: 3, tmax: 13, media: '<10 °C' },
+];
+
+/**
+ * Régimen de lluvias → ventanas de siembra (grounding R16/R17). El calendario
+ * campesino se ancla al INICIO de las lluvias, no a un mes fijo.
+ */
+export const REGIMENES_LLUVIA = [
+    {
+        id: 'bimodal',
+        nombre: 'Región Andina (bimodal)',
+        desc: 'Dos temporadas de lluvia → dos siembras al año.',
+        ventanas: [
+            { label: 'Semestre A', siembra: 'marzo–mayo', cosecha: 'julio–agosto' },
+            { label: 'Semestre B', siembra: 'septiembre–noviembre', cosecha: 'diciembre–enero' },
+        ],
+        nota: 'Siembre apenas se estabilicen las primeras lluvias. "Mitaca" = la segunda cosecha del año.',
+        fuente: 'R16, R17',
+    },
+    {
+        id: 'unimodal',
+        nombre: 'Llanos, Caribe, Amazonía, Pacífico (unimodal)',
+        desc: 'Una sola temporada de lluvia → una siembra al año.',
+        ventanas: [
+            { label: 'Única', siembra: 'al arrancar las lluvias (mitad de año)', cosecha: 'según el ciclo del cultivo' },
+        ],
+        nota: 'La seca va aproximadamente de diciembre a marzo.',
+        fuente: 'R16',
+    },
+];
+
+/**
+ * Grados-día de UN día por el método modificado del promedio.
+ * Regla del grounding: clampa Tmín y Tmáx al rango [Tb, To] antes de promediar
+ * ("si Tmín<10 se usa 10; si Tmáx>30 se usa 30"). Nunca negativo.
+ *
+ * @param {number} tmin  temperatura mínima del día (°C)
+ * @param {number} tmax  temperatura máxima del día (°C)
+ * @param {number} tb    temperatura base del cultivo (°C)
+ * @param {number|null} [to]  temperatura tope (°C) o null/undefined = sin cap
+ * @returns {number} grados-día del día (≥ 0)
+ */
+export function gddDia(tmin, tmax, tb, to = null) {
+    if (![tmin, tmax, tb].every((v) => Number.isFinite(v))) return 0;
+    let lo = tmin;
+    let hi = tmax;
+    if (Number.isFinite(to)) {
+        if (hi > to) hi = to;
+        if (lo > to) lo = to;
+    }
+    if (lo < tb) lo = tb;
+    if (hi < tb) hi = tb;
+    const media = (lo + hi) / 2;
+    const gdd = media - tb;
+    return gdd > 0 ? gdd : 0;
+}
+
+/**
+ * GDD acumulados sobre N días a un ritmo térmico constante (Tmín/Tmáx típicos).
+ * Determinista: N × gddDia. Redondeado a 1 decimal para lectura.
+ *
+ * @param {number} tmin
+ * @param {number} tmax
+ * @param {number} tb
+ * @param {number|null} to
+ * @param {number} dias  número de días (se trunca a entero ≥ 0)
+ * @returns {number} GDD acumulados
+ */
+export function gddAcumulado(tmin, tmax, tb, to, dias) {
+    const n = Math.max(0, Math.trunc(dias || 0));
+    const porDia = gddDia(tmin, tmax, tb, to);
+    return Math.round(porDia * n * 10) / 10;
+}
+
+/**
+ * Días transcurridos entre dos fechas (YYYY-MM-DD o Date), ≥ 0.
+ * @param {string|Date} desde
+ * @param {string|Date} [hasta] por defecto hoy
+ * @returns {number} días enteros
+ */
+export function diasTranscurridos(desde, hasta = new Date()) {
+    const a = desde instanceof Date ? desde : new Date(`${desde}T00:00:00`);
+    const b = hasta instanceof Date ? hasta : new Date(`${hasta}T00:00:00`);
+    if (Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return 0;
+    const ms = b.getTime() - a.getTime();
+    return Math.max(0, Math.floor(ms / 86400000));
+}
+
+/**
+ * Estima la ETAPA fenológica por días-después-de-siembra usando la fenología
+ * GROUNDED en días (no por GDD, cuyos umbrales están pendientes). Devuelve el
+ * hito actual y el próximo, con los días que faltan.
+ *
+ * @param {string} cultivoId
+ * @param {number} dds  días desde la siembra
+ * @returns {null | {actual: object, proxima: object|null, diasParaProxima: number|null}}
+ */
+export function estimarEtapa(cultivoId, dds) {
+    const cultivo = CULTIVO_GDD_BY_ID[cultivoId];
+    if (!cultivo || !Array.isArray(cultivo.fenologia) || cultivo.fenologia.length === 0) {
+        return null;
+    }
+    const hitos = cultivo.fenologia;
+    const d = Math.max(0, Math.trunc(dds || 0));
+    let actual = hitos[0];
+    let proxima = null;
+    for (let i = 0; i < hitos.length; i += 1) {
+        if (d >= hitos[i].dds) {
+            actual = hitos[i];
+            proxima = hitos[i + 1] || null;
+        } else {
+            proxima = proxima || hitos[i];
+            break;
+        }
+    }
+    // Si ya pasó el último hito, no hay próxima.
+    if (d >= hitos[hitos.length - 1].dds) proxima = null;
+    const diasParaProxima = proxima ? proxima.dds - d : null;
+    return { actual, proxima, diasParaProxima };
+}
+
+/**
+ * Compara el ritmo térmico (GDD/día) de dos pisos térmicos para el mismo
+ * cultivo — la evidencia visible de "en tierra fría tarda más". Determinista.
+ *
+ * @param {string} cultivoId
+ * @param {string} pisoCalidoId  piso más cálido (referencia)
+ * @param {string} pisoFrioId    piso más frío (comparación)
+ * @returns {null | {calido:number, frio:number, factor:number}}
+ */
+export function compararRitmo(cultivoId, pisoCalidoId, pisoFrioId) {
+    const cultivo = CULTIVO_GDD_BY_ID[cultivoId];
+    const pc = PISOS_TERMICOS.find((p) => p.id === pisoCalidoId);
+    const pf = PISOS_TERMICOS.find((p) => p.id === pisoFrioId);
+    if (!cultivo || !pc || !pf) return null;
+    const calido = gddDia(pc.tmin, pc.tmax, cultivo.tb, cultivo.to);
+    const frio = gddDia(pf.tmin, pf.tmax, cultivo.tb, cultivo.to);
+    const factor = frio > 0 ? Math.round((calido / frio) * 10) / 10 : Infinity;
+    return { calido: Math.round(calido * 10) / 10, frio: Math.round(frio * 10) / 10, factor };
+}

--- a/src/services/poscosechaCalculator.js
+++ b/src/services/poscosechaCalculator.js
@@ -1,0 +1,277 @@
+/* i18n (ADR-050): este servicio incluye copy user-facing (notas y puntos
+ * críticos) en español Colombia, pendiente de migrar a src/config/messages.js.
+ * Misma deuda que PoscosechaScreen; se desactiva la regla soft a nivel de archivo. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+/**
+ * poscosechaCalculator — lógica DETERMINISTA para la mini-app "Poscosecha y
+ * Despensa" (mundo Mercado y despensa).
+ *
+ * Filosofía (inviolable, alineada con encaladoCalculator.js / soilDiagnostic.js):
+ *   - La MATEMÁTICA es determinista y estándar (balance de masa de agua). Se
+ *     calcula, no se inventa.
+ *   - Los PARÁMETROS de referencia (humedad segura por grano, materia seca de
+ *     cosecha, temperaturas/HR de curado y daño por frío) salen del deep research
+ *     nacional/internacional con su fuente y nivel de confianza. Los que no están
+ *     cerrados se marcan GROUNDED-PENDIENTE.
+ *   - Nunca se afirma un número que no esté anclado a fuente.
+ *
+ * Grounding:
+ *   - deepresearch/2026-07-04-poscosecha-conservacion-nacional-CO.md
+ *   - deepresearch/2026-07-04-postharvest-storage-international.md
+ */
+
+/* ═══════════════════ 1. SECADO DE GRANO — balance de masa ═══════════════════
+ * El campesino conoce el peso mojado del bulto y la humedad (por sensor, por el
+ * comprador o por la tabla). Para guardar sin moho hay que bajar a la humedad
+ * segura. La materia seca NO cambia al secar: solo se va agua. De ahí:
+ *
+ *   materia_seca = peso_inicial × (1 − humedad_inicial/100)   [constante]
+ *   peso_final   = materia_seca / (1 − humedad_objetivo/100)
+ *                = peso_inicial × (100 − humedad_inicial) / (100 − humedad_objetivo)
+ *   agua_a_quitar = peso_inicial − peso_final
+ *
+ * Es aritmética exacta (conservación de masa), no una estimación.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Humedad segura de almacenamiento por grano (% base húmeda). Debajo de este
+ * nivel el moho (incl. micotoxinas/aflatoxina) e insectos no prosperan.
+ * Confianza ALTA — múltiples fuentes FAO/Cenicafé concuerdan.
+ */
+export const GRANOS = {
+  maiz: {
+    label: 'Maíz',
+    humedadSegura: 13,
+    humedadSeguraRango: [13, 14],
+    // FAO x5036e: humedad de moho despreciable < 13 %; 13.5 % ≈ 70 % HR a 27 °C.
+    nota: 'Debajo de 13 % el moho casi no crece. Guárdelo seco y hermético.',
+    fuente: 'FAO x5036e; DR nacional §4',
+    confianza: 'alta',
+  },
+  frijol: {
+    label: 'Fríjol',
+    humedadSegura: 13,
+    humedadSeguraRango: [12, 14],
+    nota: 'A 12–14 % se limita el gorgojo y se conserva el poder de germinar.',
+    fuente: 'PICS/Purdue; DR internacional §4.1',
+    confianza: 'alta',
+  },
+  arroz: {
+    label: 'Arroz',
+    humedadSegura: 13,
+    humedadSeguraRango: [12, 13],
+    nota: 'Séquelo a 12–13 % para guardar sin que se caliente ni amarille.',
+    fuente: 'DR nacional §4',
+    confianza: 'media-alta',
+  },
+  cafe_pergamino: {
+    label: 'Café pergamino',
+    humedadSegura: 11,
+    humedadSeguraRango: [10, 12],
+    // Cenicafé: 10–12 %, SIN bajar de ~11 %; evita el hongo de la Ocratoxina A.
+    nota: 'Séquelo a 10–12 %, sin pasarse de seco (no baje de ~11 %). Voltéelo al sol para evitar el hongo de la Ocratoxina A.',
+    fuente: 'Cenicafé avt0461; DR nacional §5.6',
+    confianza: 'media-alta',
+  },
+};
+
+/**
+ * Balance de masa del secado de grano. Todo en la misma unidad de peso (kg,
+ * arrobas, bultos — el resultado sale en la misma unidad de entrada).
+ *
+ * @param {Object} p
+ * @param {number} p.pesoInicial      Peso mojado del lote (misma unidad de salida).
+ * @param {number} p.humedadInicial   Humedad actual del grano (% base húmeda).
+ * @param {number} p.humedadObjetivo  Humedad segura de guardado (% base húmeda).
+ * @returns {null | {
+ *   pesoInicial: number,
+ *   pesoFinal: number,
+ *   aguaEliminada: number,
+ *   materiaSeca: number,
+ *   mermaPorc: number,
+ * }}  null si los datos no permiten un cálculo válido.
+ */
+export function calcularSecadoGrano({ pesoInicial, humedadInicial, humedadObjetivo }) {
+  const w = num(pesoInicial);
+  const hi = num(humedadInicial);
+  const hf = num(humedadObjetivo);
+
+  // Guardas: pesos y humedades válidas (0–100), y no "secar" hacia arriba.
+  if (w == null || hi == null || hf == null) return null;
+  if (w <= 0) return null;
+  if (hi <= 0 || hi >= 100) return null;
+  if (hf < 0 || hf >= 100) return null;
+  if (hf >= hi) return null; // ya está igual o más seco que el objetivo
+
+  const materiaSeca = w * (1 - hi / 100);
+  const pesoFinal = materiaSeca / (1 - hf / 100);
+  const aguaEliminada = w - pesoFinal;
+  const mermaPorc = (aguaEliminada / w) * 100;
+
+  return {
+    pesoInicial: redondear(w, 2),
+    pesoFinal: redondear(pesoFinal, 2),
+    aguaEliminada: redondear(aguaEliminada, 2),
+    materiaSeca: redondear(materiaSeca, 2),
+    mermaPorc: redondear(mermaPorc, 1),
+  };
+}
+
+/* ═══════════════════ 2. ÍNDICE DE COSECHA — materia seca ═══════════════════
+ * El aguacate Hass NO madura en la planta: se cosecha por contenido de materia
+ * seca. Norma internacional ≥ 21 %; para Colombia se propone 23–24 %.
+ * Confianza ALTA (AGROSAVIA, norma de exportación).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Umbral de materia seca del aguacate Hass (%). */
+export const AGUACATE_MS_MINIMO_NORMA = 21; // norma internacional de cosecha
+export const AGUACATE_MS_MINIMO_COLOMBIA = 23; // propuesto Colombia (23–24 %)
+
+/**
+ * Evalúa si un aguacate Hass está en punto de cosecha por su materia seca.
+ * @param {number|null} materiaSecaPorc  % de materia seca medido.
+ * @returns {{ nivel: string, label: string, color: string } | null}
+ */
+export function evaluarMateriaSecaAguacate(materiaSecaPorc) {
+  const v = num(materiaSecaPorc);
+  if (v == null) return null;
+  if (v < AGUACATE_MS_MINIMO_NORMA) {
+    return { nivel: 'verde', label: 'Aún verde: por debajo del 21 %. Si lo corta ahora, no ablanda bien y queda insípido.', color: 'amber' };
+  }
+  if (v < AGUACATE_MS_MINIMO_COLOMBIA) {
+    return { nivel: 'norma', label: 'En punto de norma (≥ 21 %). Apto para cosechar; para exportación se prefiere 23–24 %.', color: 'lime' };
+  }
+  return { nivel: 'optimo', label: 'En punto óptimo (≥ 23 %). Buen sabor y aceite; coséchelo firme, ablanda después.', color: 'emerald' };
+}
+
+/* ═══════════════════ 3. CURADO — dos recetas OPUESTAS ═══════════════════════
+ * El error frecuente: curar todo igual. Raíces/tubérculos = cálido + HÚMEDO;
+ * cebolla/ajo = cálido + SECO. Confundirlas pudre la cosecha.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const CURADO = {
+  raices: {
+    label: 'Raíces y tubérculos',
+    ejemplos: 'yuca, papa, batata, ñame',
+    receta: 'cálido y HÚMEDO',
+    detalle: [
+      { cultivo: 'Yuca', cond: '4–7 días a ~30–35 °C, 80–85 % de humedad', ojo: 'Se "raya" (deterioro fisiológico) en 2–3 días si no se cura, parafina o congela.', fuente: 'DR nacional §3.5', confianza: 'media-alta' },
+      { cultivo: 'Papa', cond: '15–20 °C, 85–90 % HR, 5–10 días', ojo: 'Después: bodega fresca, oscura y ventilada.', fuente: 'DR nacional §3.5', confianza: 'media' },
+      { cultivo: 'Batata/camote', cond: 'periodo corto cálido y húmedo', ojo: 'Cicatriza, endurece la piel y la vuelve más dulce (almidón → azúcar). No la enfríe por debajo de ~12,5 °C.', fuente: 'DR internacional §3.2', confianza: 'alta' },
+    ],
+    porque: 'La humedad y el calor hacen cicatrizar las heridas y engrosar la piel; así la raíz aguanta semanas en vez de días.',
+  },
+  bulbos: {
+    label: 'Cebolla y ajo',
+    ejemplos: 'cebolla de bulbo, ajo',
+    receta: 'cálido y SECO',
+    detalle: [
+      { cultivo: 'Ajo', cond: '10–14 días con calor, buena ventilación y HR baja', ojo: 'Listo cuando la piel está apergaminada y el cuello duro. Luego guárdelo fresco y seco.', fuente: 'DR internacional §3.2', confianza: 'alta' },
+      { cultivo: 'Cebolla', cond: 'secar cuello y capas externas con calor y aire seco', ojo: 'Guárdela con HR baja (~65–70 %); la humedad la pudre.', fuente: 'DR internacional §3.2', confianza: 'alta' },
+    ],
+    porque: 'Aquí el objetivo es lo contrario: SECAR el cuello y las capas de afuera. Si las cura húmedas, se pudren.',
+  },
+};
+
+/**
+ * Daño por frío en tropicales: NO refrigerar por debajo de su umbral o se
+ * manchan y no maduran. Confianza ALTA/MEDIA (FAO/WFLO).
+ */
+export const DANIO_POR_FRIO = [
+  { producto: 'Plátano verde', minC: 12, nota: 'Por debajo de ~12–13 °C se mancha y no madura.' },
+  { producto: 'Mango', minC: 10, nota: 'Guárdelo a 7–12 °C, no más frío.' },
+  { producto: 'Aguacate', minC: 7, nota: 'Rango 7–12 °C; el frío extremo lo daña.' },
+  { producto: 'Batata/camote', minC: 12.5, nota: 'No la meta a la nevera: se daña por frío.' },
+];
+
+/* ═══════════════════ 4. TRANSFORMACIÓN — punto crítico de inocuidad ═════════
+ * Cada línea conserva el excedente, pero cada una tiene UN punto crítico que
+ * casi siempre es calor + limpieza + empaque sellado.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const TRANSFORMACIONES = [
+  {
+    id: 'deshidratados',
+    titulo: 'Deshidratados / secado solar',
+    resumen: 'Quitar el agua frena hongos y bacterias. Vida de anaquel de meses a temperatura ambiente.',
+    puntoCritico: 'Secar bien (humedad residual baja) y empacar sellado. El secador solar tapa del polvo y los insectos.',
+    dato: 'En un estudio colombiano de secado solar: tomate ~106 días, mango ~109 días, zanahoria ~174 días de vida útil.',
+    fuente: 'DR nacional §5.1',
+    confianza: 'media',
+  },
+  {
+    id: 'mermeladas',
+    titulo: 'Mermeladas y conservas',
+    resumen: 'Azúcar + acidez + cocción + envase esterilizado conservan la fruta por meses.',
+    puntoCritico: 'Envase y tapa esterilizados, sellado en caliente y buena acidez. Frasco mal sellado = riesgo.',
+    dato: 'Ruta accesible para el excedente frutícola y negocio rural viable.',
+    fuente: 'DR nacional §5.2; FAO x5029s',
+    confianza: 'media',
+  },
+  {
+    id: 'harinas',
+    titulo: 'Harinas (yuca, plátano, maíz)',
+    resumen: 'Deshidratar y moler rescata raíces que se perderían en 2–3 días y les da larga vida.',
+    puntoCritico: 'Secado completo antes de moler y empaque seco y sellado; si queda humedad, se enmohece.',
+    dato: 'Producto de larga vida y mayor valor que la raíz fresca.',
+    fuente: 'DR nacional §5.3',
+    confianza: 'media',
+  },
+  {
+    id: 'panela',
+    titulo: 'Panela',
+    resumen: 'Producto insignia campesino andino. Hornillas ecoeficientes tipo CIMPA mejoran combustión y calidad.',
+    puntoCritico: 'Agua potable en el trapiche, tanque tapado y limpio, buenas prácticas. Ley 2005 de 2019 prohíbe adulterantes.',
+    dato: 'Tecnología propia de AGROSAVIA (CIMPA).',
+    fuente: 'DR nacional §5.4',
+    confianza: 'media-alta',
+  },
+  {
+    id: 'queso',
+    titulo: 'Quesos',
+    resumen: 'Valor agregado alto, pero SENSIBLE en inocuidad. El queso de leche cruda es de alto riesgo.',
+    // Único mensaje en tono firme, no opcional (DR §5.5 / hallazgo 9).
+    puntoCritico: 'PASTEURICE la leche sí o sí: 63 °C por 30 minutos (o 72 °C por 15 segundos). Manos, utensilios y agua limpios.',
+    dato: 'Reduce E. coli y otros patógenos. Decreto 616 de 2006.',
+    fuente: 'DR nacional §5.5',
+    confianza: 'alta',
+    critico: true,
+  },
+  {
+    id: 'cafe',
+    titulo: 'Café',
+    resumen: 'Antes de tostar, el secado del pergamino manda: 10–12 % de humedad, sin pasarse de seco.',
+    puntoCritico: 'Voltear al sol para evitar el hongo de la Ocratoxina A. Guardar < 20 °C, HR < 75 %, protegido de la luz.',
+    dato: 'Así conserva calidad hasta ~10 meses.',
+    fuente: 'DR nacional §5.6',
+    confianza: 'media-alta',
+  },
+];
+
+/* ═══════════════════ 5. MAGNITUD DEL PROBLEMA (gancho) ══════════════════════ */
+
+/** Cifras de pérdida país (DNP, año base 2016). Confianza ALTA por triangulación. */
+export const PERDIDA_PAIS = {
+  toneladasMt: 9.76,
+  porcentajeOferta: 34,
+  porcentajePoscosecha: 19.8, // eslabón poscosecha y almacenamiento
+  frutasHortalizasPorc: 62,
+  raicesTuberculosPorc: 25,
+  fuente: 'DNP (año base 2016); DR nacional §1',
+  confianza: 'alta',
+};
+
+/* ────────────────────────────── utilidades ──────────────────────────────── */
+
+/** Convierte a número aceptando coma decimal; null si no es finito. */
+function num(s) {
+  if (s === '' || s == null) return null;
+  const n = Number.parseFloat(String(s).replace(',', '.'));
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Redondeo estable a n decimales. */
+function redondear(x, n) {
+  const f = 10 ** n;
+  return Math.round(x * f) / f;
+}


### PR DESCRIPTION
## V4 — Reestructuración 2.0 del home: "Los mundos de mi finca"

El home F2 era una caja de herramientas regada: ~15 tiles planas + 5 tarjetas de inventario + mercado + seguimiento. Esta PR agrupa TODO en **9 mundos coherentes y aprendibles**, cada uno un lugar ilustrado de la finca con su paleta de tierra propia.

### Mapa mundos → funciones
| Mundo | Funciones (rutas reales) |
|---|---|
| 🌾 **Cultivos y semillas** (destacado) | directorio · calendario_finca · activos (Mis matas) · mapa (Zonas) · germinacion · sembrar · cosechar · ciclo |
| 🌱 **El suelo vivo** | salud_suelo · suelo · cromatografia · ciclo_nutrientes |
| 💧 **El agua** | → agua (directo, mini-app) |
| 🐄 **Del corral al abono** | → estiercol (directo, mini-app) |
| 🐞 **Sanidad de la mata** | biopreparados · reportar_invasora · casos · defensores (juego) · toxicologia |
| ⛅ **El clima** | → hoy_finca (directo: día + clima + alertas) |
| 🐔 **Los animales** (gate perfil) | animales · gallinas · vacas · abejas · seguimiento_cerdos |
| 🧺 **Mercado y despensa** | mercado · bodega · informes · fermentos |
| 🌳 **Diseño de la finca** | asociaciones · biodiversidad · seguimiento_reforestacion · seguimiento_silvopastoreo · seguimiento_paramo |

Siempre presentes fuera de los mundos: **agente** (hero + compositor + pie de cada mundo), **registro por voz** (bloque "Registrar en la finca", ancla del portal "Mi finca"), estado del día, Ciclo Vivo, FAQ/Ayuda (pie).

### Qué se agregó
- `mundosFinca.js` — manifiesto fuente única (mundos, entradas, tintes, gates).
- `MundoVinetas.jsx` — 9 viñetas SVG dibujadas a mano (rsvg-safe, sin filtros).
- `MundosDeMiFinca.jsx` + `mundos-finca.css` — la grilla "cuaderno de campo" (tarjeta destacada, chips "adentro", sello vivo con matas reales, entrada escalonada con reduced-motion).
- `MundoScreen.jsx` — el mundo por dentro (ruta nueva `mundo`): viñeta grande + filas generosas → re-rutea a pantallas existentes; fallback índice si llega sin id.
- Reachability CONGELADA por test: `MundosDeMiFinca.reachability.test.jsx` verifica (1) que ninguna vista del home viejo quedó huérfana y (2) que toda vista del manifiesto existe como `case` real en App.jsx.

### Tema profundizado en la ESCENA (req. 3)
- `CIELOS_TEMA` (FincaVivaHero): cada tema fija el **cielo interno** de la escena por tono de luz (biopunk navy-neón incluso de día; nature crema/tierra; minimalista papel; verde-vivo turquesa).
- CSS: **grade de color por tema** sobre el SVG de la escena (`.fvh-escena > svg` con filter — biopunk enfría, nature sepia cálido, minimalista desatura, verde-vivo sube savia) + **veladura/textura por tema** (sol de mañana en verde-vivo, grano kraft en nature, trama papel en minimalista) reusando la capa del velo neón.

### Seguridad
- TODO gated por `VITE_FINCA_VIVA_HOME_PERFIL` (flag OFF = prod intacto; layout legacy no tocado, sus tests siguen tal cual).
- Ninguna lógica de negocio/motor del agente tocada; solo re-ruteo + capa visual. Mini-apps agua/estiércol/suelo intactas, integradas como sus mundos.

### Verificación
- `npm run build` ✅ · vitest dashboard 157/157 ✅ + suite completa ✅
- Smoke visual con Playwright (móvil 412px + desktop 1280px, 4 temas, dev flag ON): grilla, MundoScreen (suelo/sanidad), heros por tema.

### Pantallas para verificar reachability (QA manual)
Desde el home F2: directorio, calendario_finca, activos, mapa, germinacion, sembrar, cosechar, ciclo, salud_suelo, suelo, cromatografia, ciclo_nutrientes, agua, estiercol, biopreparados (con back a home), reportar_invasora, casos, defensores, toxicologia, hoy_finca, animales (+gallinas/vacas/abejas/cerdos), mercado, bodega, informes, fermentos, asociaciones, biodiversidad, reforestación/silvopastoreo/páramo, registro_unificado, bitácora, faq, ayuda, agente, aprende/juego (portales del hero), glaciar (whitelist), javier (operador).

### Follow-up sugerido (no bloqueante)
- La tarjeta Bitácora (FincaCards) se ve lavada sobre la hoja crema F2 (contraste pre-existente, no introducido aquí).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
