### PR TITLE
feat(semilla): mini-app soberania de semilla (seleccion, guardado, germinacion)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,6 +110,11 @@ const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScree
 // (calidad + nacimiento, caso "se me seca el nacimiento en verano").
 const AguaScreen = lazy(() => import('./components/agua/AguaScreen'));
 const SaludSueloScreen = lazy(() => import('./components/SaludSueloScreen'));
+// Mini-app "Semilla" (soberanía de semilla): seleccionar (plantas madre),
+// guardar (rama ortodoxa vs recalcitrante + Harrington) y probar germinación
+// (rag-doll + ajuste de densidad). Calculadoras deterministas en
+// src/services/semillaCalculator.js.
+const SemillaScreen = lazy(() => import('./components/semilla/SemillaScreen'));
 // LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home): un mundo por dentro —
 // las funciones existentes agrupadas por lugar. Re-rutea, no reimplementa.
 const MundoScreen = lazy(() => import('./components/MundoScreen'));
@@ -210,6 +215,9 @@ const HASH_VIEW_ROUTES = {
   'salud-suelo': 'salud_suelo',
   'cuaderno-suelo': 'salud_suelo',
   encalado: 'salud_suelo',
+  semilla: 'semilla',
+  semillas: 'semilla',
+  'soberania-semilla': 'semilla',
   aprende: 'aprende',
   directorio: 'directorio',
   'directorio-especies': 'directorio',
@@ -227,7 +235,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'estiercol',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'salud_suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
+  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'salud_suelo', 'semilla', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
   'usage_stats', 'mercado', 'auditoria_inventario', 'mundo',
@@ -1271,6 +1279,17 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Salud del Suelo">
               <SaludSueloScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'semilla':
+        // Mini-app "Semilla" (soberanía de semilla): seleccionar / guardar /
+        // germinar, con calculadoras deterministas (semillaCalculator.js).
+        // Ruta #semilla / #soberania-semilla. Vive en el mundo Cultivos.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Semilla">
+              <SemillaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -46,6 +46,7 @@ export const MUNDOS_FINCA = [
             { view: 'calendario_finca', label: 'Calendario de la finca', desc: 'Cuándo sembrar, abonar y cosechar, todo junto', emoji: '🗓️' },
             { view: 'activos', label: 'Mis matas', desc: 'Las plantas que tiene sembradas y cómo van', emoji: '🪴' },
             { view: 'mapa', label: 'Zonas de la finca', desc: 'Sus lotes, eras y potreros en el mapa', emoji: '🗺️' },
+            { view: 'semilla', label: 'Semilla propia', desc: 'Seleccione, guarde y pruebe su semilla criolla', emoji: '🌾' },
             { view: 'germinacion', label: 'Semilleros', desc: 'Pruebe sus semillas y vea cuáles nacen', emoji: '🫘' },
             { view: 'sembrar', label: 'Registrar una siembra', desc: 'Anote lo que sembró y arranca su ciclo', emoji: '🌽' },
             { view: 'cosechar', label: 'Cosechar', desc: 'Anote lo que recogió', emoji: '🧺' },

--- a/src/components/semilla/SemillaScreen.jsx
+++ b/src/components/semilla/SemillaScreen.jsx
@@ -1,0 +1,698 @@
+/* i18n (ADR-050): etiquetas user-facing en español Colombia pendientes de
+ * migrar a src/config/messages.js. Misma deuda preexistente que SaludSueloScreen
+ * y App.jsx; se desactiva la regla soft a nivel de archivo. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useMemo, useState } from 'react';
+import {
+  ChevronLeft, ChevronRight, ArrowRight, Sprout, Wheat, Snowflake,
+  Archive, FlaskConical, Bug, Calculator, CheckCircle2, AlertTriangle,
+  Info, Percent, Users, Sun, Droplets, ShieldCheck,
+} from 'lucide-react';
+import {
+  CULTIVOS_SEMILLA, SISTEMAS_REPRODUCTIVOS, evaluarSeleccion, ROGUING_PCT,
+  clasificarConservacion, RECALCITRANTES, factorVidaHarrington,
+  reglaSumaHarrington, aceiteAntigorgojo, porcentajeGerminacion,
+  interpretarGerminacion, ajusteDensidad, UMBRAL_GERMINACION,
+} from '../../services/semillaCalculator';
+
+/**
+ * SemillaScreen — mini-app "Semilla" (soberanía de semilla), mundo Cultivos.
+ *
+ * Identidad: cuaderno de campo. Cálida, campesina, legible al sol. 4 temas vía
+ * variables de tema (rgb(var(--t-accent-rgb))), micro-animaciones que respetan
+ * prefers-reduced-motion. Solo visual + calculadoras DETERMINISTAS.
+ *
+ * Tres pilares (grounding DR-SEMILLA 2026-07-04):
+ *   1. SELECCIONAR — de plantas sanas/típicas, roguing antes de floración;
+ *      calculadora de nº mínimo de plantas madre por sistema reproductivo.
+ *   2. GUARDAR — la rama decisiva ORTODOXA vs RECALCITRANTE (nunca "seca y
+ *      guarda" a cacao/café/aguacate) + reglas de Harrington + anti-gorgojo.
+ *   3. GERMINAR — prueba casera (rag-doll) + calculadora de ajuste de densidad
+ *      de siembra por % de viabilidad.
+ *
+ * CERO invención: el copy es estructura; las cifras finas salen del grounding
+ * verificado y de las calculadoras deterministas de semillaCalculator.js. Lo que
+ * depende de zona/cultivo y no está anclado se marca grounded-pendiente.
+ */
+
+const COLOR_MAP = {
+  emerald: { text: 'text-emerald-300', border: 'border-emerald-700/50', bg: 'bg-emerald-950/30', dot: 'bg-emerald-400' },
+  lime: { text: 'text-lime-300', border: 'border-lime-700/50', bg: 'bg-lime-950/30', dot: 'bg-lime-400' },
+  amber: { text: 'text-amber-300', border: 'border-amber-700/50', bg: 'bg-amber-950/30', dot: 'bg-amber-400' },
+  rose: { text: 'text-rose-300', border: 'border-rose-700/50', bg: 'bg-rose-950/30', dot: 'bg-rose-400' },
+  slate: { text: 'text-slate-300', border: 'border-slate-700/50', bg: 'bg-slate-900/50', dot: 'bg-slate-500' },
+};
+
+/* ── Ilustración SVG propia: "de la semilla a la mata" sobre papel de cuaderno ── */
+function SemillaIlustracion() {
+  return (
+    <svg
+      viewBox="0 0 240 150"
+      role="img"
+      aria-label="Ilustración de una semilla germinando: raíz, brote y hojas, con semillas guardadas"
+      className="w-full h-auto"
+    >
+      {/* Papel de cuaderno */}
+      <rect x="0" y="0" width="240" height="150" rx="8" fill="rgb(var(--t-accent-rgb) / 0.06)" />
+      <g stroke="rgb(var(--t-accent-rgb) / 0.18)" strokeWidth="1">
+        <line x1="0" y1="46" x2="240" y2="46" />
+        <line x1="0" y1="78" x2="240" y2="78" />
+        <line x1="0" y1="110" x2="240" y2="110" />
+      </g>
+      {/* Tierra */}
+      <path d="M0 110 H240 V150 H0 Z" fill="#5a4327" />
+      <path d="M0 110 H240 V120 Q120 114 0 120 Z" fill="#6b4f2e" />
+      {/* Sol */}
+      <circle cx="212" cy="26" r="10" fill="#f4c14b" className="sm-sun" />
+      {/* Semilla que germina en el centro: raíz baja, brote sube */}
+      <g className="sm-sprout">
+        {/* Raíz principal + laterales */}
+        <g stroke="#d9b98a" strokeWidth="2.2" strokeLinecap="round" fill="none">
+          <path d="M96 116 V138" />
+          <path d="M96 124 Q84 128 78 138" />
+          <path d="M96 128 Q108 132 114 140" />
+        </g>
+        {/* Tallo */}
+        <path d="M96 116 V70" stroke="#3f7d3f" strokeWidth="2.6" strokeLinecap="round" fill="none" />
+        {/* Cotiledones / hojas */}
+        <path d="M96 84 Q78 76 70 86 Q82 92 96 88 Z" fill="#4e9a4e" />
+        <path d="M96 78 Q114 68 124 78 Q112 86 96 82 Z" fill="#3f7d3f" />
+        {/* Cascarilla de la semilla en la base */}
+        <ellipse cx="96" cy="114" rx="7" ry="4.5" fill="#c9a06a" transform="rotate(-18 96 114)" />
+      </g>
+      {/* Semillas guardadas (frasco a la izquierda) */}
+      <g className="sm-seeds">
+        <ellipse cx="34" cy="96" rx="4.5" ry="3" fill="#caa26a" />
+        <ellipse cx="46" cy="100" rx="4.5" ry="3" fill="#b98a4f" />
+        <ellipse cx="30" cy="103" rx="4.5" ry="3" fill="#d8b57e" />
+        <ellipse cx="42" cy="90" rx="4" ry="2.6" fill="#c9a06a" />
+      </g>
+    </svg>
+  );
+}
+
+/* ═══════════════════════════════ Componente ═══════════════════════════════ */
+/**
+ * @param {Object} props
+ * @param {() => void} props.onBack
+ * @param {(view: string, data?: any) => void} [props.onNavigate]
+ */
+export default function SemillaScreen({ onBack, onNavigate }) {
+  const [pilar, setPilar] = useState('hub'); // hub | seleccionar | guardar | germinar
+
+  const volver = () => {
+    if (pilar === 'hub') { onBack?.(); return; }
+    setPilar('hub');
+  };
+
+  const subtitulo =
+    pilar === 'hub' ? 'Su semilla, su autonomía. De la selección al guardado.'
+    : pilar === 'seleccionar' ? 'Seleccionar la semilla'
+    : pilar === 'guardar' ? 'Guardar la semilla'
+    : 'Probar la germinación';
+
+  return (
+    <div className="min-h-[100dvh] text-white">
+      <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
+        <button
+          type="button"
+          onClick={volver}
+          aria-label="Volver"
+          className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
+        >
+          <ChevronLeft size={20} />
+        </button>
+        <div>
+          <h1 className="text-lg font-bold leading-tight text-white">Semilla</h1>
+          <p className="text-xs text-slate-400 leading-tight">{subtitulo}</p>
+        </div>
+      </header>
+
+      <div className="px-4 pb-10">
+        {pilar === 'hub' && <Hub onIr={setPilar} onNavigate={onNavigate} />}
+        {pilar === 'seleccionar' && <PilarSeleccionar />}
+        {pilar === 'guardar' && <PilarGuardar />}
+        {pilar === 'germinar' && <PilarGerminar onNavigate={onNavigate} />}
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────── Hub ─────────────────────────────────── */
+function Hub({ onIr, onNavigate }) {
+  const pilares = [
+    { key: 'seleccionar', icon: Sprout, titulo: 'Seleccionar', desc: 'De cuáles plantas sacar semilla y cuántas plantas madre necesita.', accent: 'emerald' },
+    { key: 'guardar', icon: Archive, titulo: 'Guardar', desc: '¿Se seca y se guarda, o se siembra fresca? Cómo darle el doble de vida.', accent: 'amber' },
+    { key: 'germinar', icon: Percent, titulo: 'Probar germinación', desc: 'La prueba casera y cuánta semilla poner según cuántas nacen.', accent: 'lime' },
+  ];
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Marco: soberanía de semilla */}
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 overflow-hidden">
+        <div className="p-4 pb-3">
+          <SemillaIlustracion />
+        </div>
+        <div className="px-4 pb-4">
+          <p className="text-[13px] uppercase tracking-wide font-bold text-slate-400">Soberanía de semilla</p>
+          <p className="mt-1 text-[15px] text-slate-100 leading-snug">
+            <span className="font-bold">"Quien guarda su semilla, guarda su autonomía."</span>
+          </p>
+          <p className="mt-2 text-sm text-slate-300 leading-relaxed">
+            Guardar semilla criolla es un derecho campesino y el corazón del fitomejoramiento propio.
+            Aquí lo hacemos bien: <span className="font-semibold text-slate-100">seleccionar</span> de las
+            mejores plantas, <span className="font-semibold text-slate-100">guardar</span> según la especie
+            y <span className="font-semibold text-slate-100">probar</span> que la semilla nazca.
+          </p>
+        </div>
+      </section>
+
+      <div className="flex flex-col gap-3">
+        {pilares.map((p, i) => {
+          const c = COLOR_MAP[p.accent];
+          const Icono = p.icon;
+          return (
+            <button
+              key={p.key}
+              type="button"
+              onClick={() => onIr(p.key)}
+              className={`text-left rounded-2xl border ${c.border} ${c.bg} p-4 flex items-start gap-3 hover:border-opacity-100 transition-colors motion-reduce:transition-none active:scale-[0.99]`}
+            >
+              <span
+                className="w-11 h-11 rounded-xl flex items-center justify-center shrink-0"
+                style={{ backgroundColor: 'rgb(var(--t-accent-rgb) / 0.20)' }}
+              >
+                <Icono size={22} className={c.text} />
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="text-[11px] font-bold text-slate-500">Paso {i + 1}</span>
+                <span className="block text-[15px] font-bold text-white leading-tight">{p.titulo}</span>
+                <span className="block text-sm text-slate-300 mt-0.5 leading-snug">{p.desc}</span>
+              </span>
+              <ChevronRight size={20} className="text-slate-500 shrink-0 mt-2" />
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Nota de soberanía / derecho a guardar (grounding legal DR) */}
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-3">
+        <div className="flex items-start gap-2.5">
+          <ShieldCheck size={18} className="shrink-0 mt-0.5" style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+          <p className="text-xs text-slate-400 leading-relaxed">
+            Guardar, usar e intercambiar semilla propia es un derecho reconocido (Tratado de Semillas de la
+            FAO, art. 9; Sentencia T-247 de 2023 sobre maíz nativo). La norma del ICA (Res. 15141 de 2024)
+            regula solo la semilla <em>certificada de mejoramiento</em>, no la criolla ni el grano de consumo.
+            {onNavigate ? ' Pregúntele al agente por su caso.' : ''}
+          </p>
+        </div>
+        {onNavigate ? (
+          <button
+            type="button"
+            onClick={() => onNavigate('agente', { prompt: '¿Puedo guardar e intercambiar mi propia semilla criolla?' })}
+            className="mt-2.5 w-full text-left rounded-xl border border-slate-700/60 bg-slate-800/40 p-3 flex items-center gap-3 hover:border-slate-600 transition-colors motion-reduce:transition-none"
+          >
+            <Users size={18} className="shrink-0" style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+            <span className="flex-1 text-sm font-bold text-slate-100 leading-tight">Custodios, casas de semilla y su derecho</span>
+            <ChevronRight size={18} className="text-slate-500 shrink-0" />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/* ───────────────────── Pilar 1 — Seleccionar la semilla ───────────────────── */
+const REGLAS_SELECCION = [
+  { icon: Sprout, titulo: 'Plantas sanas, vigorosas y típicas', texto: 'Escoja las que se ven sanas, fuertes y con las características propias de la variedad. Buena producción, sin plagas ni enfermedades.' },
+  { icon: CheckCircle2, titulo: 'Marque en pie, antes de cosechar', texto: 'A la madurez fisiológica se ve la sanidad de toda la planta. Marque las escogidas con cinta, cabuya o pintura de color.' },
+  { icon: ArrowRight, titulo: 'Del centro del lote, no de los bordes', texto: 'En el centro la planta compite de verdad y hay menos cruce con el cultivo del vecino.' },
+  { icon: AlertTriangle, titulo: 'Depure las atípicas ANTES de la floración', texto: 'Saque las plantas "fuera de tipo", débiles o enfermas antes de que suelten polen: así no pasan sus genes. Se llama roguing.' },
+];
+
+function PilarSeleccionar() {
+  const [cultivoId, setCultivoId] = useState('maiz');
+  const [plantas, setPlantas] = useState('');
+
+  const disp = plantas === '' ? null : Math.max(0, Number.parseInt(plantas, 10) || 0);
+  const cultivo = CULTIVOS_SEMILLA.find((c) => c.id === cultivoId);
+  const resultado = useMemo(
+    () => (disp == null ? null : evaluarSeleccion(cultivoId, disp)),
+    [cultivoId, disp],
+  );
+  const nivelColor = resultado
+    ? (resultado.nivel === 'ok' ? COLOR_MAP.emerald : resultado.nivel === 'justo' ? COLOR_MAP.amber : COLOR_MAP.rose)
+    : COLOR_MAP.slate;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-slate-300 leading-relaxed">
+        La selección es el corazón de la semilla propia: de qué plantas sacarla decide si la variedad
+        se conserva —o mejora— año tras año.
+      </p>
+
+      {/* Reglas de oro */}
+      <div className="flex flex-col gap-3">
+        {REGLAS_SELECCION.map((r) => {
+          const Icono = r.icon;
+          return (
+            <div key={r.titulo} className="rounded-xl border border-slate-800 bg-slate-900/60 p-3 flex items-start gap-3">
+              <span className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ backgroundColor: 'rgb(var(--t-accent-rgb) / 0.18)' }}>
+                <Icono size={20} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+              </span>
+              <div>
+                <h3 className="text-sm font-bold text-slate-100">{r.titulo}</h3>
+                <p className="text-sm text-slate-300 mt-0.5 leading-snug">{r.texto}</p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Calculadora: nº mínimo de plantas madre */}
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <Calculator size={18} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+          <h3 className="text-[15px] font-bold text-white">¿Cuántas plantas madre necesita?</h3>
+        </div>
+        <p className="text-sm text-slate-300 leading-snug">
+          Con pocas plantas la variedad pierde vigor por endogamia. El mínimo depende de si el cultivo
+          se cruza (necesita muchas) o se autopoliniza (le bastan pocas).
+        </p>
+
+        {/* Selección de cultivo */}
+        <div className="flex flex-wrap gap-2">
+          {CULTIVOS_SEMILLA.map((c) => {
+            const activo = c.id === cultivoId;
+            return (
+              <button
+                key={c.id}
+                type="button"
+                onClick={() => setCultivoId(c.id)}
+                aria-pressed={activo}
+                className={`min-h-[40px] px-3 rounded-full border text-sm font-semibold transition-colors ${activo ? 'border-transparent text-white' : 'bg-slate-800 border-slate-700 text-slate-200 hover:border-slate-500'}`}
+                style={activo ? { backgroundColor: 'rgb(var(--t-accent-rgb) / 0.25)', boxShadow: 'inset 0 0 0 2px rgb(var(--t-accent-rgb))' } : undefined}
+              >
+                {c.nombre}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Sistema del cultivo elegido */}
+        {cultivo ? (
+          <p className="text-xs text-slate-400">
+            <span className="font-semibold text-slate-300">{SISTEMAS_REPRODUCTIVOS[cultivo.sistema].label}.</span>{' '}
+            {SISTEMAS_REPRODUCTIVOS[cultivo.sistema].resumen}
+            {cultivo.nota ? ` (${cultivo.nota})` : ''}
+          </p>
+        ) : null}
+
+        {/* Entrada de plantas disponibles */}
+        <div>
+          <label className="block text-xs uppercase tracking-wide font-bold text-slate-400 mb-1">¿Cuántas plantas buenas tiene en el lote?</label>
+          <input
+            type="text"
+            inputMode="numeric"
+            value={plantas}
+            onChange={(e) => setPlantas(e.target.value.replace(/[^0-9]/g, ''))}
+            placeholder="ej. 120"
+            aria-label="Plantas buenas disponibles en el lote"
+            className="w-full rounded-lg bg-slate-800 border border-slate-700 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+          />
+        </div>
+
+        {/* Resultado */}
+        {resultado ? (
+          <div className={`rounded-xl border ${nivelColor.border} ${nivelColor.bg} p-3`}>
+            <div className="flex items-center gap-2">
+              <span className={`w-2 h-2 rounded-full ${nivelColor.dot}`} aria-hidden="true" />
+              <p className={`text-sm font-bold ${nivelColor.text}`}>
+                {resultado.nivel === 'ok' ? 'Alcanza de sobra' : resultado.nivel === 'justo' ? 'Alcanza, pero justo' : 'No alcanza'}
+              </p>
+            </div>
+            <p className="mt-2 text-sm text-slate-200 leading-relaxed">
+              Para <span className="font-semibold">{resultado.cultivo.nombre}</span> guarde semilla de al menos{' '}
+              <span className="font-black text-white">{resultado.min}</span> plantas
+              {resultado.optimo > resultado.min ? <> (lo óptimo son <span className="font-bold text-white">{resultado.optimo}</span>)</> : null}.
+            </p>
+            <p className="mt-1.5 text-sm text-slate-300 leading-relaxed">
+              Antes de la floración, depure de <span className="font-semibold text-slate-100">{resultado.roguing.min} a {resultado.roguing.max}</span> plantas
+              atípicas ({ROGUING_PCT.min}–{ROGUING_PCT.max} %). Le quedarían{' '}
+              <span className="font-bold text-white">{resultado.disponiblesTrasRoguing}</span> para semilla.
+            </p>
+            {!resultado.suficiente ? (
+              <p className="mt-1.5 text-sm text-rose-200 leading-relaxed">
+                Le faltan <span className="font-bold">{resultado.faltan}</span> plantas. Siembre más el próximo ciclo,
+                o guarde semilla de varios años e intercambie con otros custodios para no perder diversidad.
+              </p>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-sm text-slate-400 text-center py-2">Escriba cuántas plantas tiene para ver si alcanzan.</p>
+        )}
+      </section>
+
+      <p className="text-xs text-slate-500 leading-relaxed">
+        <Info size={13} className="inline mr-1 -mt-0.5" />
+        Cifras de Grupo Semillas, SwissAid y AGROSAVIA. Los mínimos por cultivo y la distancia de
+        aislamiento fina para no cruzar variedades cambian por región y viento (dato pendiente de anclar por zona).
+      </p>
+    </div>
+  );
+}
+
+/* Campo numérico reutilizable (a nivel de módulo: identidad estable, sin
+ * remontar el input ni perder el foco al escribir). */
+function CampoNum({ label, value, set, sufijo }) {
+  return (
+    <div>
+      <label className="block text-[11px] uppercase tracking-wide font-bold text-slate-400 mb-1">{label}</label>
+      <div className="flex items-center gap-1">
+        <input
+          type="text" inputMode="decimal" value={value}
+          onChange={(e) => set(e.target.value.replace(',', '.').replace(/[^0-9.]/g, ''))}
+          aria-label={label}
+          className="w-full min-w-0 rounded-lg bg-slate-800 border border-slate-700 px-2.5 py-2 text-sm text-white focus:outline-none focus:border-slate-500"
+        />
+        <span className="text-xs text-slate-400 shrink-0">{sufijo}</span>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────── Pilar 2 — Guardar la semilla ─────────────────────── */
+function PilarGuardar() {
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-slate-300 leading-relaxed">
+        Antes de guardar, la pregunta que lo decide todo: <span className="font-semibold text-slate-100">¿esta semilla
+        se puede secar y guardar, o hay que sembrarla fresca?</span> Equivocarse aquí mata la semilla.
+      </p>
+
+      <RamaConservacion />
+      <HarringtonCalc />
+      <AntigorgojoCalc />
+
+      <p className="text-xs text-slate-500 leading-relaxed">
+        <Info size={13} className="inline mr-1 -mt-0.5" />
+        Guías de FAO (humedad, reglas de Harrington, control de gorgojo), Red de Semillas Libres y AGROSAVIA.
+        El comportamiento exacto de cada especie tropical se marca grounded-pendiente por especie.
+      </p>
+    </div>
+  );
+}
+
+/* Rama decisiva: ortodoxa vs recalcitrante */
+function RamaConservacion() {
+  const [nombre, setNombre] = useState('');
+  const clas = useMemo(() => (nombre.trim() ? clasificarConservacion(nombre) : null), [nombre]);
+
+  return (
+    <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <FlaskConical size={18} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+        <h3 className="text-[15px] font-bold text-white">¿Se seca o se siembra fresca?</h3>
+      </div>
+
+      <input
+        type="text"
+        value={nombre}
+        onChange={(e) => setNombre(e.target.value)}
+        placeholder="Escriba la semilla: fríjol, cacao, tomate…"
+        aria-label="Nombre de la semilla a clasificar"
+        className="w-full rounded-lg bg-slate-800 border border-slate-700 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+      />
+
+      {/* Atajo con las recalcitrantes conocidas */}
+      <div className="flex flex-wrap gap-1.5">
+        {RECALCITRANTES.slice(0, 6).map((r) => (
+          <button
+            key={r.nombre}
+            type="button"
+            onClick={() => setNombre(r.nombre)}
+            className="min-h-[34px] px-2.5 rounded-full border border-slate-700 bg-slate-800 text-xs font-semibold text-slate-200 hover:border-slate-500 transition-colors"
+          >
+            {r.nombre}
+          </button>
+        ))}
+      </div>
+
+      {clas ? (
+        clas.tipo === 'recalcitrante' ? (
+          <div className="rounded-xl border border-rose-700/60 bg-rose-950/30 p-3">
+            <div className="flex items-center gap-2">
+              <AlertTriangle size={18} className="text-rose-300 shrink-0" />
+              <p className="text-sm font-bold text-rose-200">Recalcitrante — NO la seque</p>
+            </div>
+            <p className="mt-2 text-sm text-rose-100/90 leading-relaxed">
+              {clas.nombre} muere si se seca como el fríjol. Vive solo días o semanas: <span className="font-semibold">siémbrela
+              fresca</span>, apenas la saque del fruto, o manténgala como planta viva. No la guarde en frasco ni en la nevera.
+              {clas.nota ? <span className="block mt-1 text-rose-200/70 text-xs">Ojo: {clas.nota}.</span> : null}
+            </p>
+          </div>
+        ) : clas.tipo === 'ortodoxa' ? (
+          <div className="rounded-xl border border-emerald-700/50 bg-emerald-950/30 p-3">
+            <div className="flex items-center gap-2">
+              <CheckCircle2 size={18} className="text-emerald-300 shrink-0" />
+              <p className="text-sm font-bold text-emerald-200">Ortodoxa — se seca y se guarda</p>
+            </div>
+            <p className="mt-2 text-sm text-emerald-100/90 leading-relaxed">
+              {clas.nombre} tolera secarse. Séquela <span className="font-semibold">a la sombra</span> (nunca al sol
+              directo ni sobre cemento), de ~15 % a ~5 % de humedad, en 2–3 semanas. Guárdela bien seca (4–8 % de humedad)
+              en frasco de vidrio, vasija de barro o envase hermético, en sitio fresco y oscuro.
+            </p>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-slate-700/60 bg-slate-800/40 p-3">
+            <p className="text-sm text-slate-200 leading-relaxed">
+              No tengo esta semilla clasificada. Regla honesta: granos, legumbres y la mayoría de hortalizas son
+              <span className="font-semibold text-slate-100"> ortodoxas</span> (se secan). Muchos árboles y frutales
+              tropicales (cacao, café, aguacate, guanábana) son <span className="font-semibold text-slate-100">recalcitrantes</span>
+              {' '}(se siembran frescos). Ante la duda, siembre una parte fresca y guarde otra seca para comparar, o pregunte al agente.
+            </p>
+          </div>
+        )
+      ) : (
+        <p className="text-sm text-slate-400 text-center py-1">Escriba una semilla para saber cómo tratarla.</p>
+      )}
+    </section>
+  );
+}
+
+/* Calculadora de Harrington: el doble de vida */
+function HarringtonCalc() {
+  const [hDesde, setHDesde] = useState('12');
+  const [hHasta, setHHasta] = useState('8');
+  const [tDesde, setTDesde] = useState('25');
+  const [tHasta, setTHasta] = useState('10');
+
+  const num = (s) => Number.parseFloat(String(s).replace(',', '.'));
+  const listo = [hDesde, hHasta, tDesde, tHasta].every((s) => s !== '' && Number.isFinite(num(s)));
+  const r = useMemo(
+    () => (listo ? factorVidaHarrington({ humedadDesde: num(hDesde), humedadHasta: num(hHasta), tempDesde: num(tDesde), tempHasta: num(tHasta) }) : null),
+    [hDesde, hHasta, tDesde, tHasta, listo],
+  );
+  const suma = useMemo(
+    () => (tHasta !== '' && hHasta !== '' && Number.isFinite(num(tHasta)) ? reglaSumaHarrington(num(tHasta), num(hHasta)) : null),
+    [tHasta, hHasta],
+  );
+
+  return (
+    <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <Snowflake size={18} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+        <h3 className="text-[15px] font-bold text-white">El doble de vida: más seca y más fría</h3>
+      </div>
+      <p className="text-sm text-slate-300 leading-snug">
+        Regla de Harrington: la semilla vive el <span className="font-semibold text-slate-100">doble</span> por cada
+        1 % menos de humedad, y otro tanto por cada 5 °C menos. Compare cómo la guarda hoy con cómo podría guardarla.
+      </p>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-2.5 flex flex-col gap-2">
+          <p className="text-xs font-bold text-slate-400">Como la guarda hoy</p>
+          <CampoNum label="Humedad (hoy)" value={hDesde} set={setHDesde} sufijo="%" />
+          <CampoNum label="Temperatura (hoy)" value={tDesde} set={setTDesde} sufijo="°C" />
+        </div>
+        <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-2.5 flex flex-col gap-2">
+          <p className="text-xs font-bold text-slate-400">Cómo podría guardarla</p>
+          <CampoNum label="Humedad (mejor)" value={hHasta} set={setHHasta} sufijo="%" />
+          <CampoNum label="Temperatura (mejor)" value={tHasta} set={setTHasta} sufijo="°C" />
+        </div>
+      </div>
+
+      {r ? (
+        <div className="rounded-xl border border-emerald-700/50 bg-emerald-950/30 p-3">
+          <p className="text-xs uppercase tracking-wide font-bold text-slate-400">Le rinde</p>
+          <p className="text-3xl font-black text-white mt-0.5 leading-none">
+            × {r.factor}
+            <span className="text-sm font-bold text-slate-300"> más tiempo</span>
+          </p>
+          <p className="text-xs text-emerald-200/80 mt-1">
+            × {r.factorHumedad} por secarla + × {r.factorTemp} por enfriarla (se multiplican).
+          </p>
+          {suma ? (
+            <p className={`mt-2 text-xs ${suma.cumple ? 'text-emerald-200/80' : 'text-amber-200/90'}`}>
+              Regla del 100: {suma.tempF} °F + humedad relativa = {suma.suma}.{' '}
+              {suma.cumple ? 'Por debajo de 100: buen sitio.' : 'Pasa de 100: busque un sitio más seco o fresco.'}
+            </p>
+          ) : null}
+          {r.avisos.map((a) => (
+            <p key={a} className="mt-2 text-xs text-amber-200/90 leading-snug">
+              <AlertTriangle size={12} className="inline mr-1 -mt-0.5" />{a}
+            </p>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-slate-400 text-center py-1">Complete las cuatro casillas para ver cuánto le rinde.</p>
+      )}
+    </section>
+  );
+}
+
+/* Calculadora anti-gorgojo con aceite */
+function AntigorgojoCalc() {
+  const [kg, setKg] = useState('');
+  const dosis = kg === '' ? null : aceiteAntigorgojo(Number.parseFloat(kg.replace(',', '.')) || 0);
+
+  return (
+    <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <Bug size={18} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+        <h3 className="text-[15px] font-bold text-white">Que no le entre el gorgojo</h3>
+      </div>
+      <p className="text-sm text-slate-300 leading-snug">
+        Sin químicos: un poquito de aceite vegetal cubre el grano y asfixia al gorgojo. También sirven
+        ceniza o arena (1 parte por 4 de grano) y congelar la semilla 3–5 días para matar huevos.
+      </p>
+      <div>
+        <label className="block text-xs uppercase tracking-wide font-bold text-slate-400 mb-1">¿Cuántos kilos de grano va a guardar?</label>
+        <div className="flex items-center gap-1.5">
+          <input
+            type="text" inputMode="decimal" value={kg}
+            onChange={(e) => setKg(e.target.value.replace(',', '.').replace(/[^0-9.]/g, ''))}
+            placeholder="ej. 10"
+            aria-label="Kilos de grano a guardar"
+            className="w-full min-w-0 rounded-lg bg-slate-800 border border-slate-700 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+          />
+          <span className="text-xs text-slate-400 shrink-0">kg</span>
+        </div>
+      </div>
+      {dosis ? (
+        <div className="rounded-xl border border-emerald-700/50 bg-emerald-950/30 p-3">
+          <p className="text-sm text-emerald-100">
+            Use entre <span className="font-black text-white">{dosis.min}</span> y{' '}
+            <span className="font-black text-white">{dosis.max}</span> ml de aceite (2–7 ml por kg).
+            Revuelva bien. Protege {dosis.meses} meses.
+          </p>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+/* ─────────────────────── Pilar 3 — Probar germinación ─────────────────────── */
+function PilarGerminar({ onNavigate }) {
+  const [germinadas, setGerminadas] = useState('');
+  const [total, setTotal] = useState('100');
+
+  const g = germinadas === '' ? null : Math.max(0, Number.parseInt(germinadas, 10) || 0);
+  const t = total === '' ? null : Math.max(0, Number.parseInt(total, 10) || 0);
+  const pct = g != null && t != null ? porcentajeGerminacion(g, t) : null;
+  const interp = pct != null ? interpretarGerminacion(pct) : null;
+  const c = interp ? COLOR_MAP[interp.color] : COLOR_MAP.slate;
+  const densidad = pct != null && pct > 0 && pct < UMBRAL_GERMINACION.buena ? ajusteDensidad(pct) : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-slate-300 leading-relaxed">
+        Antes de sembrar todo un lote, pruebe si su semilla nace. Es la prueba casera de germinación
+        (la "rag-doll"), la misma que enseñan AGROSAVIA y el SENA.
+      </p>
+
+      {/* Guía de la prueba */}
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+        <h3 className="text-[15px] font-bold text-white mb-2">Cómo se hace</h3>
+        <ol className="flex flex-col gap-2 text-sm text-slate-300">
+          {[
+            'Cuente 100 semillas al azar del lote (en 10 hileras de a 10).',
+            'Póngalas sobre papel o periódico húmedo y enróllelo.',
+            'Meta el rollo en una bolsa plástica, en sitio cálido y a la sombra.',
+            'Revise que siga húmedo y cuente las que nacen entre 3 y 10 días.',
+          ].map((paso, i) => (
+            <li key={i} className="flex items-start gap-2.5">
+              <span className="w-5 h-5 rounded-full flex items-center justify-center shrink-0 text-[11px] font-black text-white" style={{ backgroundColor: 'rgb(var(--t-accent-rgb) / 0.30)' }}>{i + 1}</span>
+              <span className="leading-snug">{paso}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Calculadora */}
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <Percent size={18} style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+          <h3 className="text-[15px] font-bold text-white">Saque el porcentaje</h3>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs uppercase tracking-wide font-bold text-slate-400 mb-1">Nacieron</label>
+            <input
+              type="text" inputMode="numeric" value={germinadas}
+              onChange={(e) => setGerminadas(e.target.value.replace(/[^0-9]/g, ''))}
+              placeholder="ej. 78"
+              aria-label="Semillas que nacieron"
+              className="w-full rounded-lg bg-slate-800 border border-slate-700 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs uppercase tracking-wide font-bold text-slate-400 mb-1">De un total de</label>
+            <input
+              type="text" inputMode="numeric" value={total}
+              onChange={(e) => setTotal(e.target.value.replace(/[^0-9]/g, ''))}
+              placeholder="100"
+              aria-label="Total de semillas puestas a prueba"
+              className="w-full rounded-lg bg-slate-800 border border-slate-700 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+            />
+          </div>
+        </div>
+
+        {pct != null && interp ? (
+          <div className={`rounded-xl border ${c.border} ${c.bg} p-3`}>
+            <p className="text-4xl font-black text-white leading-none">{pct}<span className="text-lg text-slate-300">%</span></p>
+            <p className={`mt-1 text-sm font-bold ${c.text}`}>{interp.label}</p>
+            <p className="mt-1 text-sm text-slate-200 leading-snug">{interp.accion}</p>
+            {densidad ? (
+              <div className="mt-2 pt-2 border-t border-slate-700/50 text-sm text-slate-200 leading-relaxed">
+                Para compensar, siembre <span className="font-black text-white">× {densidad.factor}</span> la semilla de costumbre.
+                <span className="block text-xs text-slate-400 mt-0.5">Valor cultural = pureza × germinación / 100 = {densidad.valorCultural} (pureza asumida 100 %).</span>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-sm text-slate-400 text-center py-1">Escriba cuántas nacieron para ver el resultado.</p>
+        )}
+
+        <p className="text-xs text-slate-500 leading-snug">
+          Guía: ≥ {UMBRAL_GERMINACION.buena} % buena · {UMBRAL_GERMINACION.descartar}–{UMBRAL_GERMINACION.buena - 1} % siembre más tupido · &lt; {UMBRAL_GERMINACION.descartar} % descarte el lote.
+        </p>
+      </section>
+
+      {/* Puente al módulo Semilleros existente (no lo reimplementa) */}
+      {onNavigate ? (
+        <button
+          type="button"
+          onClick={() => onNavigate('germinacion')}
+          className="w-full text-left rounded-xl border border-slate-700/60 bg-slate-800/40 p-3 flex items-center gap-3 hover:border-slate-600 transition-colors motion-reduce:transition-none"
+        >
+          <Sprout size={20} className="shrink-0" style={{ color: 'rgb(var(--t-accent-rgb))' }} />
+          <span className="flex-1 min-w-0">
+            <span className="block text-sm font-bold text-slate-100 leading-tight">Registrar la prueba en Semilleros</span>
+            <span className="block text-xs text-slate-400 leading-snug">Guarde el resultado y compárelo con otras pruebas.</span>
+          </span>
+          <ChevronRight size={18} className="text-slate-500 shrink-0" />
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/semilla/__tests__/SemillaScreen.test.jsx
+++ b/src/components/semilla/__tests__/SemillaScreen.test.jsx
@@ -1,0 +1,101 @@
+/**
+ * SemillaScreen — mini-app "Semilla" (soberanía de semilla).
+ *
+ * Contrato cubierto:
+ *   - Hub: marco de soberanía + los tres pilares navegables + volver.
+ *   - Pilar Seleccionar: la calculadora de plantas madre responde.
+ *   - Pilar Guardar: la rama decisiva advierte que un recalcitrante NO se seca.
+ *   - Pilar Germinar: la prueba casera calcula el % e interpreta el resultado.
+ *   - Puente honesto al módulo Semilleros existente (no lo reimplementa).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import SemillaScreen from '../SemillaScreen';
+
+afterEach(() => cleanup());
+
+const irA = (nombre) => fireEvent.click(screen.getByRole('button', { name: nombre }));
+
+describe('SemillaScreen — hub', () => {
+  it('muestra el marco de soberanía y los tres pilares', () => {
+    render(<SemillaScreen onBack={() => {}} onNavigate={() => {}} />);
+    expect(screen.getByText(/guarda su autonomía/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Seleccionar/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Guardar/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Probar germinación/i })).toBeTruthy();
+  });
+
+  it('botón volver llama onBack desde el hub', () => {
+    const onBack = vi.fn();
+    render(<SemillaScreen onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: /Volver/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});
+
+describe('SemillaScreen — pilar Seleccionar', () => {
+  it('la calculadora avisa cuando no alcanzan las plantas madre de maíz', () => {
+    render(<SemillaScreen onBack={() => {}} />);
+    irA(/Seleccionar/i);
+    const input = screen.getByLabelText(/Plantas buenas disponibles/i);
+    fireEvent.change(input, { target: { value: '90' } });
+    // 90 → tras roguing 76 < 100 mínimo del maíz.
+    expect(screen.getByText(/No alcanza/i)).toBeTruthy();
+    expect(screen.getAllByText(/100/).length).toBeGreaterThan(0);
+  });
+
+  it('cambiar a fríjol usa su mínimo bajo (autógama)', () => {
+    render(<SemillaScreen onBack={() => {}} />);
+    irA(/Seleccionar/i);
+    fireEvent.click(screen.getByRole('button', { name: /^Fríjol$/i }));
+    const input = screen.getByLabelText(/Plantas buenas disponibles/i);
+    fireEvent.change(input, { target: { value: '30' } });
+    expect(screen.getByText(/Alcanza/i)).toBeTruthy();
+  });
+});
+
+describe('SemillaScreen — pilar Guardar (rama decisiva)', () => {
+  it('advierte que el cacao es recalcitrante y NO se seca', () => {
+    render(<SemillaScreen onBack={() => {}} />);
+    irA(/Guardar/i);
+    const input = screen.getByLabelText(/Nombre de la semilla a clasificar/i);
+    fireEvent.change(input, { target: { value: 'cacao' } });
+    expect(screen.getByText(/Recalcitrante/i)).toBeTruthy();
+    expect(screen.getByText(/siémbrela\s+fresca/i)).toBeTruthy();
+  });
+
+  it('el fríjol sale ortodoxo (se seca y se guarda)', () => {
+    render(<SemillaScreen onBack={() => {}} />);
+    irA(/Guardar/i);
+    const input = screen.getByLabelText(/Nombre de la semilla a clasificar/i);
+    fireEvent.change(input, { target: { value: 'fríjol' } });
+    expect(screen.getByText(/Ortodoxa/i)).toBeTruthy();
+  });
+
+  it('la calculadora de Harrington muestra el factor de vida por defecto', () => {
+    render(<SemillaScreen onBack={() => {}} />);
+    irA(/Guardar/i);
+    // Valores por defecto: 12→8 % y 25→10 °C = ×128.
+    expect(screen.getByText(/× 128/)).toBeTruthy();
+  });
+});
+
+describe('SemillaScreen — pilar Germinar', () => {
+  it('calcula el % y ofrece el ajuste de densidad cuando es baja', () => {
+    render(<SemillaScreen onBack={() => {}} />);
+    irA(/Probar germinación/i);
+    const nacieron = screen.getByLabelText(/Semillas que nacieron/i);
+    fireEvent.change(nacieron, { target: { value: '40' } });
+    // 40/100 = 40 % → descartar, ajuste ×2.5.
+    expect(screen.getByText(/Muy baja/i)).toBeTruthy();
+    expect(screen.getByText(/× 2\.5/)).toBeTruthy();
+  });
+
+  it('enlaza al módulo Semilleros existente (no lo reimplementa)', () => {
+    const onNavigate = vi.fn();
+    render(<SemillaScreen onBack={() => {}} onNavigate={onNavigate} />);
+    irA(/Probar germinación/i);
+    fireEvent.click(screen.getByRole('button', { name: /Registrar la prueba en Semilleros/i }));
+    expect(onNavigate).toHaveBeenCalledWith('germinacion');
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -582,6 +582,37 @@
 }
 
 /* ===========================================================================
+ * SEMILLA — micro-animaciones de la ilustración "de la semilla a la mata"
+ * (SemillaScreen). El brote "crece", las semillas guardadas titilan y el sol
+ * respira. Sutil e infinito muy lento; se apaga con prefers-reduced-motion.
+ * =========================================================================== */
+.sm-sprout {
+  transform-origin: 96px 116px;
+  animation: sm-grow 1.4s ease-out 0.15s both;
+}
+.sm-seeds ellipse {
+  animation: sm-twinkle 3.4s ease-in-out infinite;
+}
+.sm-seeds ellipse:nth-child(2) { animation-delay: 0.7s; }
+.sm-seeds ellipse:nth-child(3) { animation-delay: 1.4s; }
+.sm-seeds ellipse:nth-child(4) { animation-delay: 2.1s; }
+.sm-sun {
+  transform-origin: 212px 26px;
+  animation: sm-breathe 4.2s ease-in-out infinite;
+}
+@keyframes sm-grow {
+  from { transform: scaleY(0.6); opacity: 0; }
+  to { transform: scaleY(1); opacity: 1; }
+}
+@keyframes sm-twinkle { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
+@keyframes sm-breathe { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.08); } }
+@media (prefers-reduced-motion: reduce) {
+  .sm-sprout { transform: none; opacity: 1; animation: none; }
+  .sm-seeds ellipse { animation: none; opacity: 0.9; }
+  .sm-sun { animation: none; }
+}
+
+/* ===========================================================================
  * LOADING SKELETON DARK — fondo oscuro unificado para estados de carga.
  *
  * Tarea 81: .loading-skeleton-dark evita flash blanco en dark theme

--- a/src/services/__tests__/semillaCalculator.test.js
+++ b/src/services/__tests__/semillaCalculator.test.js
@@ -1,0 +1,162 @@
+/**
+ * semillaCalculator — cobertura de las calculadoras DETERMINISTAS de semilla.
+ *
+ * Verifica que la matemática es exacta y anclada al grounding (DR-SEMILLA):
+ *   - Selección: mínimos de plantas madre y roguing 10–15 %.
+ *   - Guardado: rama ortodoxa vs recalcitrante; Harrington (×2 por −1 % / −5 °C);
+ *     regla del 100; dosis de aceite anti-gorgojo.
+ *   - Germinación: %, umbrales (≥70/50/<50) y ajuste de densidad (20 % → ×5).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  CULTIVOS_SEMILLA, evaluarSeleccion, roguingRango, ROGUING_PCT, getCultivoSemilla,
+  clasificarConservacion, factorVidaHarrington, reglaSumaHarrington, aceiteAntigorgojo,
+  porcentajeGerminacion, interpretarGerminacion, ajusteDensidad, UMBRAL_GERMINACION,
+} from '../semillaCalculator';
+
+describe('Selección — plantas madre y roguing', () => {
+  it('el catálogo tiene el maíz alógamo (≥100, óptimo 200) y el fríjol autógamo (≥10)', () => {
+    const maiz = getCultivoSemilla('maiz');
+    const frijol = getCultivoSemilla('frijol');
+    expect(maiz.sistema).toBe('cruzada');
+    expect(maiz.min).toBe(100);
+    expect(maiz.optimo).toBe(200);
+    expect(frijol.sistema).toBe('auto');
+    expect(frijol.min).toBe(10);
+  });
+
+  it('roguing depura 10–15 % de la población (redondeo hacia arriba)', () => {
+    expect(ROGUING_PCT).toEqual({ min: 10, max: 15 });
+    expect(roguingRango(200)).toEqual({ min: 20, max: 30 });
+    expect(roguingRango(90)).toEqual({ min: 9, max: 14 }); // ceil(9), ceil(13.5)
+    expect(roguingRango(0)).toEqual({ min: 0, max: 0 });
+  });
+
+  it('evaluarSeleccion marca insuficiente cuando tras depurar no llega al mínimo', () => {
+    // maíz min 100; con 90 plantas, tras quitar hasta 14 quedan 76 < 100.
+    const r = evaluarSeleccion('maiz', 90);
+    expect(r.suficiente).toBe(false);
+    expect(r.disponiblesTrasRoguing).toBe(76);
+    expect(r.faltan).toBe(24);
+    expect(r.nivel).toBe('insuficiente');
+  });
+
+  it('evaluarSeleccion marca ok cuando supera el óptimo tras depurar', () => {
+    // maíz óptimo 200; con 250 quedan 250-38=212 ≥ 200.
+    const r = evaluarSeleccion('maiz', 250);
+    expect(r.suficiente).toBe(true);
+    expect(r.nivel).toBe('ok');
+    expect(r.faltan).toBe(0);
+  });
+
+  it('fríjol con 15 plantas alcanza el mínimo (justo)', () => {
+    // min 10, óptimo 20; con 15 quedan 15-ceil(2.25)=15-3=12 → ≥10 pero <20.
+    const r = evaluarSeleccion('frijol', 15);
+    expect(r.suficiente).toBe(true);
+    expect(r.nivel).toBe('justo');
+  });
+
+  it('cultivo inexistente devuelve null', () => {
+    expect(evaluarSeleccion('marte', 10)).toBeNull();
+  });
+});
+
+describe('Guardado — rama ortodoxa vs recalcitrante (la decisiva)', () => {
+  it('cacao, café y aguacate son RECALCITRANTES (no se secan)', () => {
+    expect(clasificarConservacion('cacao').tipo).toBe('recalcitrante');
+    expect(clasificarConservacion('Café castillo').tipo).toBe('recalcitrante');
+    expect(clasificarConservacion('aguacate hass').tipo).toBe('recalcitrante');
+  });
+
+  it('fríjol, maíz y tomate son ORTODOXAS (se secan y guardan)', () => {
+    expect(clasificarConservacion('Fríjol cargamanto').tipo).toBe('ortodoxa');
+    expect(clasificarConservacion('MAIZ').tipo).toBe('ortodoxa');
+    expect(clasificarConservacion('tomate chonto').tipo).toBe('ortodoxa');
+  });
+
+  it('una especie no catalogada devuelve desconocida (honesto, no inventa)', () => {
+    expect(clasificarConservacion('quinua').tipo).toBe('desconocida');
+    expect(clasificarConservacion('').tipo).toBe('desconocida');
+  });
+});
+
+describe('Guardado — reglas de Harrington', () => {
+  it('la vida se duplica por cada −1 % de humedad y por cada −5 °C (se multiplican)', () => {
+    // 12→8 % = 4 % menos = 2^4 = 16×; 25→10 °C = 15 °C menos = 2^3 = 8×; total 128×.
+    const r = factorVidaHarrington({ humedadDesde: 12, humedadHasta: 8, tempDesde: 25, tempHasta: 10 });
+    expect(r.factorHumedad).toBe(16);
+    expect(r.factorTemp).toBe(8);
+    expect(r.factor).toBe(128);
+    expect(r.enRango).toBe(true);
+    expect(r.avisos).toHaveLength(0);
+  });
+
+  it('avisa si se sobre-seca por debajo de ~5 % (la regla deja de valer)', () => {
+    const r = factorVidaHarrington({ humedadDesde: 8, humedadHasta: 3, tempDesde: 20, tempHasta: 20 });
+    expect(r.enRango).toBe(false);
+    expect(r.avisos.length).toBeGreaterThan(0);
+  });
+
+  it('regla del 100: °F + %HR debe quedar por debajo de 100', () => {
+    // 10 °C = 50 °F; con 40 % HR → 90 < 100 cumple.
+    const ok = reglaSumaHarrington(10, 40);
+    expect(ok.tempF).toBe(50);
+    expect(ok.suma).toBe(90);
+    expect(ok.cumple).toBe(true);
+    // 25 °C = 77 °F; con 60 % → 137 no cumple.
+    expect(reglaSumaHarrington(25, 60).cumple).toBe(false);
+  });
+
+  it('dosis de aceite anti-gorgojo: 2–7 ml por kg de grano', () => {
+    expect(aceiteAntigorgojo(10)).toMatchObject({ min: 20, max: 70 });
+    expect(aceiteAntigorgojo(0)).toMatchObject({ min: 0, max: 0 });
+  });
+});
+
+describe('Germinación — prueba casera y ajuste de densidad', () => {
+  it('calcula el % (germinadas / total × 100) y nunca pasa de 100', () => {
+    expect(porcentajeGerminacion(78, 100)).toBe(78);
+    expect(porcentajeGerminacion(7, 10)).toBe(70);
+    expect(porcentajeGerminacion(120, 100)).toBe(100); // clamp
+    expect(porcentajeGerminacion(5, 0)).toBeNull();
+  });
+
+  it('interpreta ≥70 buena · 50–69 más tupido · <50 descartar', () => {
+    expect(UMBRAL_GERMINACION).toEqual({ buena: 70, descartar: 50 });
+    expect(interpretarGerminacion(85).nivel).toBe('buena');
+    expect(interpretarGerminacion(70).nivel).toBe('buena');
+    expect(interpretarGerminacion(60).nivel).toBe('tupido');
+    expect(interpretarGerminacion(49).nivel).toBe('descartar');
+    expect(interpretarGerminacion(null).nivel).toBe('sin_datos');
+  });
+
+  it('ajuste de densidad: 20 % de germinación exige ×5 la semilla', () => {
+    // valor cultural = 100 × 20 / 100 = 20; factor = 100/20 = 5.
+    const r = ajusteDensidad(20);
+    expect(r.valorCultural).toBe(20);
+    expect(r.factor).toBe(5);
+  });
+
+  it('el ajuste considera la pureza física del lote', () => {
+    // germinación 80 %, pureza 90 % → valor cultural 72; factor ≈ 1.39.
+    const r = ajusteDensidad(80, 90);
+    expect(r.valorCultural).toBe(72);
+    expect(r.factor).toBeCloseTo(1.39, 2);
+  });
+
+  it('germinación 0 o pureza 0 no produce factor (evita división por cero)', () => {
+    expect(ajusteDensidad(0)).toBeNull();
+    expect(ajusteDensidad(50, 0)).toBeNull();
+  });
+});
+
+describe('catálogo — sanidad', () => {
+  it('todos los cultivos tienen id, sistema válido y min≤optimo', () => {
+    for (const c of CULTIVOS_SEMILLA) {
+      expect(c.id).toBeTruthy();
+      expect(['cruzada', 'auto']).toContain(c.sistema);
+      expect(c.min).toBeGreaterThan(0);
+      expect(c.optimo).toBeGreaterThanOrEqual(c.min);
+    }
+  });
+});

--- a/src/services/semillaCalculator.js
+++ b/src/services/semillaCalculator.js
@@ -1,0 +1,338 @@
+/**
+ * semillaCalculator — calculadoras DETERMINISTAS de soberanía de semilla, para
+ * la mini-app "Semilla" (mundo Cultivos y semillas). Tres pilares:
+ *
+ *   1. SELECCIONAR — nº mínimo de plantas madre por sistema reproductivo
+ *      (maíz alógamo ≥100/óptimo 200; fríjol autógamo ≥10) + depuración de
+ *      atípicas (roguing, 10–15 %).
+ *   2. GUARDAR — la rama decisiva ORTODOXA vs RECALCITRANTE (nunca "seca y
+ *      guarda" a cacao/café/aguacate) + reglas de Harrington (−1 % humedad o
+ *      −5 °C ⇒ el DOBLE de vida; °F + %HR < 100) + dosis anti-gorgojo.
+ *   3. GERMINAR — % de la prueba casera (rag-doll) y ajuste de densidad de
+ *      siembra por viabilidad (a menos germinación, más semilla).
+ *
+ * Filosofía (inviolable, igual que encaladoCalculator.js / aguaCalculos.js):
+ *   - La MATEMÁTICA es determinista y estándar. Se calcula, no se inventa.
+ *   - Las cifras de campo salen del grounding (DR-SEMILLA 2026-07-04: Grupo
+ *     Semillas / Red de Semillas Libres / SwissAid / AGROSAVIA / FAO / Seed
+ *     Savers Exchange). Lo que depende de cultivo/región y aún no está anclado
+ *     se marca SLOT GROUNDED-PENDIENTE, con un valor de referencia documentado.
+ *   - Nada de esto reemplaza el criterio de un custodio de semillas ni un
+ *     análisis ISTA: es una guía orientadora para el cuaderno de campo.
+ */
+
+/* ═══════════════════════════ 1. SELECCIONAR ═══════════════════════════════ */
+
+/**
+ * Sistema reproductivo → sensibilidad a la endogamia y regla general de
+ * población mínima. Confianza alta (Grupo Semillas; Learn Seed Saving; SSE).
+ */
+export const SISTEMAS_REPRODUCTIVOS = {
+  cruzada: {
+    label: 'Polinización cruzada (alógama)',
+    resumen: 'Se cruza con otras plantas (viento o insectos). Necesita MUCHAS plantas madre para no perder vigor por endogamia.',
+    reglaGeneral: '≥ 100 plantas (maíz, el caso extremo, ≥ 200)',
+  },
+  auto: {
+    label: 'Autopolinización (autógama)',
+    resumen: 'Se poliniza dentro de su propia flor. Tolera la endogamia y se mantiene con pocas plantas.',
+    reglaGeneral: '≥ 10 para mantener; ≥ 20 para preservar diversidad',
+  },
+};
+
+/**
+ * Catálogo de cultivos con su sistema reproductivo y el nº mínimo/óptimo de
+ * plantas madre. Cifras del grounding (Grupo Semillas cartilla; SSE), confianza
+ * alta. `min` = piso para no degradar la variedad; `optimo` = meta recomendada.
+ * Nota honesta: el pepino/melón se CRUZAN, pero la cartilla colombiana los lista
+ * con un mínimo de 20; se conserva esa cifra y se marca el matiz.
+ */
+export const CULTIVOS_SEMILLA = [
+  { id: 'maiz', nombre: 'Maíz', sistema: 'cruzada', min: 100, optimo: 200, fuente: 'Grupo Semillas; Seed Savers Exchange' },
+  { id: 'frijol', nombre: 'Fríjol', sistema: 'auto', min: 10, optimo: 20, fuente: 'Grupo Semillas; Learn Seed Saving' },
+  { id: 'tomate', nombre: 'Tomate', sistema: 'auto', min: 20, optimo: 20, fuente: 'Grupo Semillas' },
+  { id: 'pepino', nombre: 'Pepino / melón', sistema: 'cruzada', min: 20, optimo: 20, fuente: 'Grupo Semillas', nota: 'se cruza; la cartilla lista mínimo 20' },
+  { id: 'zanahoria', nombre: 'Zanahoria', sistema: 'cruzada', min: 100, optimo: 100, fuente: 'Grupo Semillas' },
+  { id: 'cebolla', nombre: 'Cebolla', sistema: 'cruzada', min: 50, optimo: 50, fuente: 'Grupo Semillas' },
+  { id: 'cilantro', nombre: 'Cilantro', sistema: 'cruzada', min: 50, optimo: 50, fuente: 'Grupo Semillas' },
+  { id: 'coles', nombre: 'Brócoli / repollo', sistema: 'cruzada', min: 50, optimo: 50, fuente: 'Grupo Semillas', nota: 'todas las coles se cruzan entre sí' },
+];
+
+/** Mapa id → cultivo. */
+const CULTIVO_BY_ID = Object.fromEntries(CULTIVOS_SEMILLA.map((c) => [c.id, c]));
+
+/** Resuelve un cultivo del catálogo por id (null si no existe). */
+export function getCultivoSemilla(id) {
+  return CULTIVO_BY_ID[id] || null;
+}
+
+/**
+ * Rango de depuración de atípicas (roguing / selección negativa): quitar del
+ * lote las plantas "fuera de tipo", enfermas o débiles ANTES de la floración.
+ * GROUNDED: 10–15 % (AGROSAVIA maíz Simijaca). No inventado.
+ */
+export const ROGUING_PCT = { min: 10, max: 15 };
+
+/**
+ * Nº de plantas a depurar por roguing en una población dada.
+ * @param {number} poblacion  plantas del lote candidatas a semilla
+ * @returns {{ min: number, max: number }} plantas a eliminar (redondeo hacia arriba)
+ */
+export function roguingRango(poblacion) {
+  const p = Math.max(0, Number(poblacion) || 0);
+  return {
+    min: Math.ceil((p * ROGUING_PCT.min) / 100),
+    max: Math.ceil((p * ROGUING_PCT.max) / 100),
+  };
+}
+
+/**
+ * Evalúa la selección: dado el cultivo y las plantas disponibles, dice si
+ * alcanzan para conservar la variedad tras depurar las atípicas.
+ *
+ * @param {string} cultivoId
+ * @param {number} plantasDisponibles
+ * @returns {null | {
+ *   cultivo: object,
+ *   min: number, optimo: number,
+ *   roguing: { min: number, max: number },
+ *   disponiblesTrasRoguing: number,
+ *   suficiente: boolean,
+ *   faltan: number,
+ *   nivel: 'ok'|'justo'|'insuficiente',
+ * }}
+ */
+export function evaluarSeleccion(cultivoId, plantasDisponibles) {
+  const cultivo = getCultivoSemilla(cultivoId);
+  if (!cultivo) return null;
+  const disp = Math.max(0, Number(plantasDisponibles) || 0);
+  const roguing = roguingRango(disp);
+  const disponiblesTrasRoguing = Math.max(0, disp - roguing.max);
+  const suficiente = disponiblesTrasRoguing >= cultivo.min;
+  const alcanzaOptimo = disponiblesTrasRoguing >= cultivo.optimo;
+  const faltan = suficiente ? 0 : cultivo.min - disponiblesTrasRoguing;
+  const nivel = alcanzaOptimo ? 'ok' : suficiente ? 'justo' : 'insuficiente';
+  return {
+    cultivo,
+    min: cultivo.min,
+    optimo: cultivo.optimo,
+    roguing,
+    disponiblesTrasRoguing,
+    suficiente,
+    faltan,
+    nivel,
+  };
+}
+
+/* ═══════════════════════════ 2. GUARDAR ═══════════════════════════════════ */
+
+/**
+ * Especies RECALCITRANTES relevantes para el trópico colombiano: NO toleran el
+ * secado bajo ~20–50 % de humedad; mueren si se guardan como el fríjol. Se
+ * siembran frescas. GROUNDED alta (FAO cap.7; UCR Morera et al.).
+ */
+export const RECALCITRANTES = [
+  { nombre: 'Cacao', claves: ['cacao'] },
+  { nombre: 'Café', claves: ['café', 'cafe'] },
+  { nombre: 'Aguacate', claves: ['aguacate', 'palta'] },
+  { nombre: 'Chontaduro', claves: ['chontaduro', 'pejibaye', 'pejiballe'] },
+  { nombre: 'Guanábana', claves: ['guanábana', 'guanabana'] },
+  { nombre: 'Guayaba', claves: ['guayaba'] },
+  { nombre: 'Cítricos', claves: ['cítrico', 'citrico', 'naranja', 'limón', 'limon', 'mandarina', 'lima'], nota: 'algunas semillas de cítricos sí son ortodoxas' },
+  { nombre: 'Mango', claves: ['mango'] },
+];
+
+/**
+ * Especies ORTODOXAS comunes: toleran secarse a ~5 % y guardarse en frío. Se
+ * pueden banquear por años. GROUNDED alta (FAO; CPC).
+ */
+export const ORTODOXAS = [
+  { nombre: 'Maíz', claves: ['maíz', 'maiz'] },
+  { nombre: 'Fríjol', claves: ['fríjol', 'frijol', 'frijoles'] },
+  { nombre: 'Arroz', claves: ['arroz'] },
+  { nombre: 'Tomate', claves: ['tomate'] },
+  { nombre: 'Ají / pimentón', claves: ['ají', 'aji', 'pimentón', 'pimenton', 'chile'] },
+  { nombre: 'Zapallo / calabaza', claves: ['zapallo', 'calabaza', 'ahuyama', 'auyama'] },
+  { nombre: 'Cebolla', claves: ['cebolla'] },
+  { nombre: 'Zanahoria', claves: ['zanahoria'] },
+  { nombre: 'Lechuga', claves: ['lechuga'] },
+  { nombre: 'Coles', claves: ['brócoli', 'brocoli', 'repollo', 'coliflor', 'col'] },
+  { nombre: 'Cilantro', claves: ['cilantro'] },
+  { nombre: 'Arveja', claves: ['arveja', 'chícharo', 'chicharo'] },
+];
+
+/** Normaliza para comparar sin tildes ni mayúsculas. */
+function normalizar(s) {
+  return String(s || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim();
+}
+
+/**
+ * Clasifica el comportamiento de conservación de una semilla por su nombre.
+ * La RAMA DECISIVA del guardado: al recalcitrante NO se le dice "seca y guarda".
+ *
+ * @param {string} nombre  nombre común de la especie
+ * @returns {{ tipo: 'recalcitrante'|'ortodoxa'|'desconocida', nombre: string|null, nota?: string }}
+ */
+export function clasificarConservacion(nombre) {
+  const q = normalizar(nombre);
+  if (!q) return { tipo: 'desconocida', nombre: null };
+  for (const r of RECALCITRANTES) {
+    if (r.claves.some((k) => q.includes(normalizar(k)))) {
+      return { tipo: 'recalcitrante', nombre: r.nombre, nota: r.nota };
+    }
+  }
+  for (const o of ORTODOXAS) {
+    if (o.claves.some((k) => q.includes(normalizar(k)))) {
+      return { tipo: 'ortodoxa', nombre: o.nombre };
+    }
+  }
+  return { tipo: 'desconocida', nombre: null };
+}
+
+/**
+ * Rango válido de las reglas de duplicación de Harrington. Fuera de aquí la
+ * regla deja de cumplirse (sobre-secar < ~4–5 % daña la semilla). FAO cap.7.
+ */
+export const HARRINGTON_RANGO = {
+  humedad: { min: 5, max: 14 }, // % contenido de humedad
+  temp: { min: 0, max: 50 }, // °C
+};
+
+/**
+ * Factor de longevidad de Harrington entre dos condiciones de almacenamiento:
+ * la vida se DUPLICA por cada −1 % de humedad y por cada −5 °C. Los efectos son
+ * independientes y se multiplican. GROUNDED alta (FAO cap.7; Roberts).
+ *
+ * @param {Object} p
+ * @param {number} p.humedadDesde  % humedad de la condición de partida
+ * @param {number} p.humedadHasta  % humedad de la condición mejorada
+ * @param {number} p.tempDesde     °C de la condición de partida
+ * @param {number} p.tempHasta     °C de la condición mejorada
+ * @returns {{ factor: number, factorHumedad: number, factorTemp: number, enRango: boolean, avisos: string[] }}
+ */
+export function factorVidaHarrington({ humedadDesde, humedadHasta, tempDesde, tempHasta }) {
+  const hD = Number(humedadDesde);
+  const hH = Number(humedadHasta);
+  const tD = Number(tempDesde);
+  const tH = Number(tempHasta);
+  const factorHumedad = 2 ** (hD - hH);
+  const factorTemp = 2 ** ((tD - tH) / 5);
+  const factor = factorHumedad * factorTemp;
+
+  const avisos = [];
+  const dentro = (v, r) => v >= r.min && v <= r.max;
+  const enRango =
+    dentro(hD, HARRINGTON_RANGO.humedad) && dentro(hH, HARRINGTON_RANGO.humedad) &&
+    dentro(tD, HARRINGTON_RANGO.temp) && dentro(tH, HARRINGTON_RANGO.temp);
+  if (hH < HARRINGTON_RANGO.humedad.min || hD < HARRINGTON_RANGO.humedad.min) {
+    avisos.push('Cuidado con sobre-secar por debajo de ~5 % de humedad: la regla deja de cumplirse y la semilla se puede dañar.');
+  }
+  if (!enRango) {
+    avisos.push('Alguna condición está fuera del rango donde la regla es válida (humedad 5–14 %, temperatura 0–50 °C). Tome el resultado solo como orientación.');
+  }
+  return {
+    factor: redondear(factor, 2),
+    factorHumedad: redondear(factorHumedad, 2),
+    factorTemp: redondear(factorTemp, 2),
+    enRango,
+    avisos,
+  };
+}
+
+/**
+ * Regla clásica de Harrington: la suma de temperatura (°F) + humedad relativa
+ * (%) del sitio de guardado no debe pasar de 100. GROUNDED alta (FAO cap.7).
+ *
+ * @param {number} tempC  temperatura del sitio, °C
+ * @param {number} humedadRelativa  % humedad relativa del sitio
+ * @returns {{ tempF: number, suma: number, cumple: boolean }}
+ */
+export function reglaSumaHarrington(tempC, humedadRelativa) {
+  const tempF = Number(tempC) * (9 / 5) + 32;
+  const suma = tempF + Number(humedadRelativa);
+  return { tempF: redondear(tempF, 1), suma: redondear(suma, 1), cumple: suma < 100 };
+}
+
+/**
+ * Dosis de aceite vegetal para proteger grano guardado del gorgojo, sin
+ * químicos. GROUNDED alta (FAO poscosecha): 2–7 ml por kg de grano; protege
+ * 4–5 meses.
+ * @param {number} kgGrano
+ * @returns {{ min: number, max: number, meses: string }} ml de aceite
+ */
+export function aceiteAntigorgojo(kgGrano) {
+  const kg = Math.max(0, Number(kgGrano) || 0);
+  return { min: redondear(kg * 2, 1), max: redondear(kg * 7, 1), meses: '4–5' };
+}
+
+/* ═══════════════════════════ 3. GERMINAR ══════════════════════════════════ */
+
+/**
+ * Umbrales de la prueba de germinación casera (rag-doll). GROUNDED alta
+ * (Grupo Semillas pág.30 ≥70 % bueno; AGROSAVIA/FAO calidad; COMO Seed Library).
+ */
+export const UMBRAL_GERMINACION = { buena: 70, descartar: 50 };
+
+/**
+ * % de germinación de la prueba casera.
+ * @param {number} germinadas  semillas que germinaron
+ * @param {number} total  semillas puestas a prueba (típico 100 ó 10)
+ * @returns {number|null} porcentaje 0–100, o null si total ≤ 0
+ */
+export function porcentajeGerminacion(germinadas, total) {
+  const g = Math.max(0, Number(germinadas) || 0);
+  const t = Number(total) || 0;
+  if (t <= 0) return null;
+  return redondear(Math.min(g, t) / t * 100, 0);
+}
+
+/**
+ * Interpreta el % de germinación en una decisión de campo honesta.
+ * ≥70 % buena (siembra normal) · 50–<70 % usar más semilla · <50 % descartar.
+ * @param {number|null} pct
+ * @returns {{ nivel: 'buena'|'tupido'|'descartar'|'sin_datos', label: string, accion: string, color: string }}
+ */
+export function interpretarGerminacion(pct) {
+  if (pct == null || Number.isNaN(pct)) {
+    return { nivel: 'sin_datos', label: 'Sin datos', accion: 'Haga la prueba con 100 semillas.', color: 'slate' };
+  }
+  if (pct >= UMBRAL_GERMINACION.buena) {
+    return { nivel: 'buena', label: 'Semilla buena', accion: 'Siembre con su densidad normal.', color: 'emerald' };
+  }
+  if (pct >= UMBRAL_GERMINACION.descartar) {
+    return { nivel: 'tupido', label: 'Sirve, pero floja', accion: 'Siembre más tupido para compensar las que no nacen.', color: 'amber' };
+  }
+  return { nivel: 'descartar', label: 'Muy baja', accion: 'Descarte el lote o consiga semilla nueva: no rinde.', color: 'rose' };
+}
+
+/**
+ * Ajuste de densidad de siembra por viabilidad (relación INVERSA: a menos
+ * germinación, más semilla). Basado en el "valor cultural" = pureza × poder
+ * germinativo / 100 (infoagro; FAO x8234s). El factor multiplica la densidad
+ * de referencia para compensar la semilla que no nace.
+ *
+ * @param {number} germinacionPct  % de germinación (0–100)
+ * @param {number} [purezaPct=100]  % de pureza física del lote
+ * @returns {null | { valorCultural: number, factor: number }}
+ */
+export function ajusteDensidad(germinacionPct, purezaPct = 100) {
+  const g = Number(germinacionPct);
+  const p = Number(purezaPct);
+  if (!(g > 0) || !(p > 0)) return null;
+  const valorCultural = (p * g) / 100;
+  if (valorCultural <= 0) return null;
+  const factor = 100 / valorCultural;
+  return { valorCultural: redondear(valorCultural, 1), factor: redondear(factor, 2) };
+}
+
+/* ─────────────────────────────── util ────────────────────────────────────── */
+
+/** Redondeo estable a n decimales. */
+function redondear(x, n) {
+  const f = 10 ** n;
+  return Math.round(x * f) / f;
+}


### PR DESCRIPTION
## 🌾 Mini-app Semilla — soberanía de semilla

Nueva mini-app dentro del **mundo Cultivos y semillas**, con identidad de cuaderno de campo, SVG propio, 4 temas y `prefers-reduced-motion`. Solo visual + calculadoras **deterministas**. Grounded al DR `2026-07-04-semilla-soberania-nacional-CO.md` + `...seed-saving-international.md`.

### Tres pilares + calculadoras
1. **Seleccionar** — de plantas sanas/vigorosas/típicas; marcar en pie; roguing (10–15 %) **antes de la floración**. Calculadora de nº mínimo de plantas madre por sistema reproductivo (maíz alógamo ≥100/óptimo 200; fríjol autógamo ≥10) → dice si alcanzan tras depurar.
2. **Guardar** — **la rama decisiva ortodoxa vs recalcitrante**: a cacao, café, aguacate, chontaduro, guanábana y cítricos NO se les dice "seca y guarda" (se siembran frescos). Reglas de Harrington (×2 de vida por cada −1 % humedad o −5 °C; suma °F+%HR<100) + dosis de aceite anti-gorgojo.
3. **Germinación** — prueba casera rag-doll (100 semillas): ≥70 % buena / 50–69 % sembrar más tupido / <50 % descartar → calculadora de **ajuste de densidad por viabilidad** (20 % → ×5).

### Corrección legal aplicada
Res. ICA 3168/2015 **derogada** por la 15141/2024; **UPOV 91 no rige** (Sentencia C-1051/2012). La nota de soberanía usa lo vigente (TIRFAA art. 9, T-247/2023).

### Cableado (no huérfana)
Entrada `semilla` en el mundo Cultivos (`mundosFinca.js`) + ruta en `App.jsx` (import lazy + `case 'semilla'` + hash `#semilla`/`#soberania-semilla` + `MODULE_VIEWS`). Lógica en `src/services/semillaCalculator.js`.

### grounded-pendiente (sin inventar cifras)
- Mínimos de plantas madre finos y **distancia de aislamiento** por cultivo/región/viento.
- Comportamiento ortodoxo/recalcitrante exacto por especie tropical.
- Umbrales de humedad/temperatura por clima local.

### Verificación
- ✅ Tests: `semillaCalculator` (19) + `SemillaScreen` (9) + reachability (8) verdes.
- ✅ `vite build` verde. ✅ ESLint limpio (incl. no-undef).

🤖 Generated with [Claude Code](https://claude.com/claude-code)