### PR TITLE
feat(clima): mini-app ⛅ traductor de boletines IDEAM/ENSO

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -109,6 +109,10 @@ const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScree
 // riego con medida (ETc; Kc/ETo = slots grounded-pendiente) y cuidar el agua
 // (calidad + nacimiento, caso "se me seca el nacimiento en verano").
 const AguaScreen = lazy(() => import('./components/agua/AguaScreen'));
+// "El clima que viene": traductor campesino de los boletines IDEAM/ENSO. Lee la
+// fase ENSO en vivo (ensoService) y remite a la Mesa Técnica Agroclimática — no
+// reimplementa el motor de clima ni pronostica.
+const ClimaBoletinScreen = lazy(() => import('./components/clima/ClimaBoletinScreen'));
 const SaludSueloScreen = lazy(() => import('./components/SaludSueloScreen'));
 // LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home): un mundo por dentro —
 // las funciones existentes agrupadas por lugar. Re-rutea, no reimplementa.
@@ -227,7 +231,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'estiercol',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'salud_suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
+  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
   'usage_stats', 'mercado', 'auditoria_inventario', 'mundo',
@@ -1290,6 +1294,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Agua de la finca">
               <AguaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'clima_boletin':
+        // "El clima que viene" (mundo Clima): TRADUCTOR de los boletines
+        // IDEAM/ENSO. 3 pilares — qué viene (fase ENSO viva de ensoService) /
+        // qué hacer (regla accionable por fase) / dónde mirar (MTA + Fenalce).
+        // No pronostica: lee la fase real y remite al boletín vigente.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El clima que viene">
+              <ClimaBoletinScreen onBack={() => navigate('mundo', { mundo: 'clima' })} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/clima/CieloENSO.jsx
+++ b/src/components/clima/CieloENSO.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+
+/**
+ * CieloENSO — ilustración SVG propia del cielo de la finca, dibujada según la
+ * FAMILIA ENSO en vivo. Es la "portada" del módulo El clima que viene:
+ *
+ *   nino    → sol grande con rayos y suelo reseco (poca lluvia, más calor).
+ *   nina    → nubes cargadas con lluvia cayendo (exceso de agua).
+ *   neutral → sol asomando entre nubes (patrón normal).
+ *
+ * Cuaderno de campo: trazo simple, colores del tema vía currentText/clases
+ * Tailwind (no fija color de tema, reacciona a data-theme como el resto). Las
+ * animaciones viven en clima.css y se apagan con prefers-reduced-motion.
+ *
+ * @param {{ family?: 'nino'|'nina'|'neutral' }} props
+ */
+export default function CieloENSO({ family = 'neutral' }) {
+  return (
+    <svg
+      viewBox="0 0 220 120"
+      className="w-full h-auto max-h-40"
+      role="img"
+      aria-label={
+        family === 'nino'
+          ? 'Cielo despejado y soleado: fase El Niño'
+          : family === 'nina'
+            ? 'Nubes con lluvia: fase La Niña'
+            : 'Sol entre nubes: fase neutral'
+      }
+      data-testid="cielo-enso"
+      data-family={family}
+    >
+      {/* Suelo / horizonte: reseco en Niño, húmedo en Niña */}
+      <rect
+        x="0" y="98" width="220" height="22"
+        className={
+          family === 'nino'
+            ? 'text-amber-700/40'
+            : family === 'nina'
+              ? 'text-emerald-800/50'
+              : 'text-emerald-700/30'
+        }
+        fill="currentColor"
+      />
+
+      {family === 'nino' && (
+        <g data-testid="cielo-sol">
+          {/* Rayos del sol (pulsan) */}
+          <g className="clima-sol-rayos text-amber-400" stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+            {Array.from({ length: 12 }).map((_, i) => {
+              const a = (i * Math.PI) / 6;
+              const cx = 110; const cy = 52;
+              return (
+                <line
+                  key={i}
+                  x1={cx + Math.cos(a) * 26}
+                  y1={cy + Math.sin(a) * 26}
+                  x2={cx + Math.cos(a) * 36}
+                  y2={cy + Math.sin(a) * 36}
+                />
+              );
+            })}
+          </g>
+          <circle cx="110" cy="52" r="20" className="text-amber-300" fill="currentColor" />
+          {/* Grietas de tierra seca */}
+          <g className="text-amber-800/60" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+            <path d="M30 108 l14 4 M70 106 l10 6 M150 108 l14 3 M190 105 l-10 7" fill="none" />
+          </g>
+        </g>
+      )}
+
+      {family === 'nina' && (
+        <g data-testid="cielo-lluvia">
+          {/* Nube cargada */}
+          <g className="clima-nube-deriva text-slate-400" fill="currentColor">
+            <ellipse cx="90" cy="48" rx="34" ry="20" />
+            <ellipse cx="120" cy="42" rx="26" ry="18" />
+            <ellipse cx="140" cy="52" rx="22" ry="15" />
+            <rect x="60" y="48" width="88" height="16" rx="8" />
+          </g>
+          {/* Lluvia */}
+          <g className="text-sky-400" stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+            {[70, 90, 110, 130, 150].map((x, i) => (
+              <line
+                key={x}
+                x1={x} y1="70" x2={x - 4} y2="86"
+                className={`clima-gota clima-gota--${(i % 3) + 1}`}
+              />
+            ))}
+          </g>
+        </g>
+      )}
+
+      {family === 'neutral' && (
+        <g data-testid="cielo-mixto">
+          {/* Sol asomando */}
+          <circle cx="72" cy="46" r="17" className="text-amber-300/90" fill="currentColor" />
+          <g className="clima-sol-rayos text-amber-400/80" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+            {Array.from({ length: 8 }).map((_, i) => {
+              const a = (i * Math.PI) / 4;
+              return (
+                <line
+                  key={i}
+                  x1={72 + Math.cos(a) * 22}
+                  y1={46 + Math.sin(a) * 22}
+                  x2={72 + Math.cos(a) * 29}
+                  y2={46 + Math.sin(a) * 29}
+                />
+              );
+            })}
+          </g>
+          {/* Nube que deriva, tapando parte del sol */}
+          <g className="clima-nube-deriva text-slate-300" fill="currentColor">
+            <ellipse cx="130" cy="52" rx="32" ry="18" />
+            <ellipse cx="158" cy="46" rx="22" ry="15" />
+            <rect x="104" y="52" width="72" height="14" rx="7" />
+          </g>
+        </g>
+      )}
+    </svg>
+  );
+}

--- a/src/components/clima/ClimaBoletinScreen.jsx
+++ b/src/components/clima/ClimaBoletinScreen.jsx
@@ -1,0 +1,356 @@
+import React, { useMemo, useState } from 'react';
+import {
+  CloudSun, Compass, ListChecks, BookOpenText, MapPin, ExternalLink,
+  Hourglass, Radio, ChevronRight, Sun, CloudRain, Cloud,
+} from 'lucide-react';
+import { ScreenShell } from '../common/ScreenShell';
+import CieloENSO from './CieloENSO';
+import { getEnsoPhase, getEnsoLabel, getEnsoPhaseSource } from '../../services/ensoService';
+import { ensoFamily, regionFromProfile, ensoRegionalLine, ENSO_WATCH_2026 } from '../../services/ensoContext';
+import { getProfile } from '../../services/userProfileService';
+import {
+  PILARES_CLIMA,
+  LECTURA_ENSO,
+  ACCIONES_ENSO,
+  REGLA_INSIGNIA,
+  BOLETINES_IDEAM,
+  MTA_INFO,
+  MTA_POR_REGION,
+  FENALCE_INFO,
+} from '../../data/climaBoletines';
+import './clima.css';
+
+/**
+ * ClimaBoletinScreen — módulo "El clima que viene": el TRADUCTOR CAMPESINO de
+ * los boletines agroclimáticos del IDEAM.
+ *
+ * Chagra NO pronostica ni reemplaza al IDEAM. Este módulo:
+ *   1. ¿Qué viene?  — lee la FASE ENSO en vivo (ensoService, alimentado por el
+ *      sidecar NOAA/IDEAM) y la explica en palabras de finca. No fabrica fase.
+ *   2. Qué hacer    — la regla accionable por fase (El Niño → material precoz y
+ *      de menor demanda hídrica; La Niña → drenaje/exceso de agua), con la
+ *      lectura regional de ensoContext según el perfil.
+ *   3. Dónde mirar  — remite al Boletín Agroclimático de la Mesa Técnica del
+ *      departamento, al boletín ENSO del IDEAM y a Fenalce.
+ *
+ * Todo lo coyuntural (probabilidades, mm por municipio) es un SLOT que se remite
+ * a la fuente vigente — nunca un número inventado (las cifras ENSO caducan).
+ */
+
+const FASE_ICON = { nino: Sun, nina: CloudRain, neutral: Cloud };
+const FASE_ACENTO = {
+  nino: { text: 'text-amber-300', border: 'border-amber-500/50', bg: 'bg-amber-500/10', chip: 'bg-amber-500/15 text-amber-200' },
+  nina: { text: 'text-sky-300', border: 'border-sky-500/50', bg: 'bg-sky-500/10', chip: 'bg-sky-500/15 text-sky-200' },
+  neutral: { text: 'text-slate-200', border: 'border-slate-600/60', bg: 'bg-slate-500/10', chip: 'bg-slate-500/15 text-slate-200' },
+};
+
+/** Chip honesto para cifras que caducan / aún sin grounding: promete, no inventa. */
+function SlotPendiente({ children }) {
+  return (
+    <span
+      data-testid="slot-grounded-pendiente"
+      className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] font-bold text-amber-300"
+    >
+      <Hourglass size={11} aria-hidden="true" />
+      {children || 'Dato en camino'}
+    </span>
+  );
+}
+
+/** De dónde salió la fase: viva (sidecar), fijada a mano, o base sin conexión. */
+function FuenteFase({ source }) {
+  const map = {
+    live: { icon: Radio, label: 'En vivo (IDEAM/NOAA)', cls: 'text-emerald-300 border-emerald-500/40 bg-emerald-500/10' },
+    manual: { icon: MapPin, label: 'Fijada a mano', cls: 'text-amber-300 border-amber-500/40 bg-amber-500/10' },
+    // eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- copy UI es-CO, deuda ADR-050 (messages.js) pendiente igual que el resto del módulo
+    default: { icon: Hourglass, label: 'Sin conexión — valor base', cls: 'text-slate-400 border-slate-600/50 bg-slate-700/20' },
+  };
+  const m = map[source] || map.default;
+  const Icon = m.icon;
+  return (
+    <span
+      data-testid="clima-fuente-fase"
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-bold ${m.cls}`}
+    >
+      <Icon size={11} aria-hidden="true" />
+      {m.label}
+    </span>
+  );
+}
+
+/* ── PILAR 1 · ¿Qué viene? ─────────────────────────────────────────────── */
+function PilarQueViene({ family, faseLabel, source, regionLine }) {
+  const lectura = LECTURA_ENSO[family] || LECTURA_ENSO.neutral;
+  const acento = FASE_ACENTO[family] || FASE_ACENTO.neutral;
+  const FaseIcon = FASE_ICON[family] || Cloud;
+
+  return (
+    <section className="clima-seccion space-y-4" data-testid="pilar-que-viene">
+      <div className={`rounded-2xl border p-4 ${acento.border} ${acento.bg}`}>
+        <div className="flex items-center gap-3">
+          <span aria-hidden="true" className={`shrink-0 w-11 h-11 rounded-xl grid place-items-center ${acento.chip}`}>
+            <FaseIcon size={24} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] font-bold uppercase tracking-wide text-slate-400">Fase del clima ahora</p>
+            <p className={`text-xl font-black leading-tight ${acento.text}`} data-testid="clima-fase-label">
+              {faseLabel}
+            </p>
+          </div>
+        </div>
+        <div className="mt-2">
+          <FuenteFase source={source} />
+        </div>
+        <p className="mt-3 text-sm font-bold text-slate-100">{lectura.titulo}</p>
+        <p className="mt-1 text-sm leading-relaxed text-slate-200">{lectura.resumen}</p>
+      </div>
+
+      {/* Señales que se ven en la finca */}
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4">
+        <p className="text-sm font-black text-slate-100 uppercase tracking-wide mb-3">Qué se ve en la finca</p>
+        <ul className="space-y-2">
+          {lectura.senales.map((s) => (
+            <li key={s} className="flex gap-2 text-sm leading-snug text-slate-200">
+              <span aria-hidden="true" className={`mt-1.5 shrink-0 w-1.5 h-1.5 rounded-full ${acento.chip}`} />
+              <span>{s}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Lectura regional (de ensoContext, según el perfil) */}
+      {regionLine && (
+        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/40 p-4" data-testid="clima-region-linea">
+          <p className="flex items-center gap-2 text-sm font-black text-slate-100 uppercase tracking-wide mb-2">
+            <MapPin size={15} aria-hidden="true" /> En su región
+          </p>
+          <p className="text-sm leading-relaxed text-slate-200">{regionLine}</p>
+        </div>
+      )}
+
+      {/* Vigilancia: probabilidad de transición — CADUCA, se remite */}
+      {family === 'neutral' && (
+        <p className="text-xs leading-snug text-slate-400">
+          El IDEAM vigila una posible transición de fase (probabilidades por trimestre){' '}
+          <SlotPendiente>la cifra vigente cambia — se lee del boletín ENSO</SlotPendiente>. El respaldo sin
+          conexión es del boletín NOAA/IDEAM de referencia, no un pronóstico propio.
+        </p>
+      )}
+
+      <p className="text-[11px] italic text-slate-500">
+        La fase la fija el IDEAM (boletín ENSO). Chagra solo la lee y la traduce — no inventa el clima.
+      </p>
+    </section>
+  );
+}
+
+/* ── PILAR 2 · Qué hacer ───────────────────────────────────────────────── */
+function PilarQueHacer({ family, regionLine, onNavigate }) {
+  const acciones = ACCIONES_ENSO[family] || ACCIONES_ENSO.neutral;
+  const acento = FASE_ACENTO[family] || FASE_ACENTO.neutral;
+
+  return (
+    <section className="clima-seccion space-y-4" data-testid="pilar-que-hacer">
+      {/* La regla insignia del grounding */}
+      <div className={`rounded-2xl border p-4 ${acento.border} ${acento.bg}`}>
+        <p className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-wide text-slate-400">
+          <ListChecks size={14} aria-hidden="true" /> La regla del momento
+        </p>
+        <p className={`mt-1 text-base font-black leading-snug ${acento.text}`} data-testid="clima-regla-insignia">
+          {REGLA_INSIGNIA[family] || REGLA_INSIGNIA.neutral}
+        </p>
+      </div>
+
+      {/* Acciones concretas */}
+      <div className="grid gap-2.5">
+        {acciones.map((a) => (
+          <div key={a.titulo} className="flex gap-3 rounded-2xl border border-slate-700/60 bg-slate-900/50 p-3.5">
+            <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-xl bg-slate-800/70 grid place-items-center text-lg">
+              {a.emoji}
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-bold text-slate-100 leading-tight">{a.titulo}</p>
+              <p className="text-xs leading-snug text-slate-300 mt-0.5">{a.detalle}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {regionLine && (
+        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/40 p-4" data-testid="clima-region-accion">
+          <p className="flex items-center gap-2 text-sm font-black text-slate-100 uppercase tracking-wide mb-2">
+            <MapPin size={15} aria-hidden="true" /> Ajuste para su región
+          </p>
+          <p className="text-sm leading-relaxed text-slate-200">{regionLine}</p>
+        </div>
+      )}
+
+      {typeof onNavigate === 'function' && (
+        <button
+          type="button"
+          data-testid="clima-preguntar-agente"
+          onClick={() => onNavigate('agente', { prefilledPrompt: '¿Qué debo sembrar según la fase del clima que viene?' })}
+          className="w-full flex items-center gap-3 rounded-2xl border border-slate-700/60 bg-slate-900/40 p-3.5 text-left active:bg-slate-800/60 transition-colors"
+        >
+          <span aria-hidden="true" className="shrink-0 w-10 h-10 rounded-xl bg-sky-500/15 grid place-items-center">
+            <CloudSun size={20} className="text-sky-300" />
+          </span>
+          <span className="flex-1 min-w-0">
+            <span className="block text-sm font-bold text-slate-100 leading-tight">¿Y en su finca?</span>
+            <span className="block text-xs text-slate-400 leading-tight mt-0.5">Pregúntele al agente qué variedad y fecha le conviene con esta fase.</span>
+          </span>
+          <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+        </button>
+      )}
+    </section>
+  );
+}
+
+/* ── PILAR 3 · Dónde mirar ─────────────────────────────────────────────── */
+function PilarDondeMirar({ mtaRegional }) {
+  return (
+    <section className="clima-seccion space-y-4" data-testid="pilar-donde-mirar">
+      <p className="text-sm leading-relaxed text-slate-200">
+        Chagra le traduce el clima, pero la palabra oficial la tiene el IDEAM. Estos boletines los publican
+        gratis y son la fuente de verdad de lo que viene:
+      </p>
+
+      {/* Boletines IDEAM */}
+      <div className="grid gap-2.5">
+        {BOLETINES_IDEAM.map((b) => (
+          <a
+            key={b.id}
+            href={b.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid={`boletin-${b.id}`}
+            className="flex gap-3 rounded-2xl border border-slate-700/60 bg-slate-900/50 p-3.5 active:bg-slate-800/60 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-xl bg-sky-500/15 grid place-items-center">
+              <BookOpenText size={18} className="text-sky-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="flex items-center gap-2">
+                <span className="text-sm font-bold text-slate-100 leading-tight">{b.nombre}</span>
+                <span className="shrink-0 rounded-full bg-slate-800/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-400">
+                  {b.frecuencia}
+                </span>
+              </span>
+              <span className="block text-xs leading-snug text-slate-300 mt-0.5">{b.para}</span>
+              <span className="block text-[10px] text-slate-500 mt-1">{b.emisor}</span>
+            </span>
+            <ExternalLink size={16} className="shrink-0 text-slate-500 mt-0.5" aria-hidden="true" />
+          </a>
+        ))}
+      </div>
+
+      {/* Mesa Técnica Agroclimática — remite a la del departamento */}
+      <div className="rounded-2xl border border-emerald-700/40 bg-emerald-950/20 p-4" data-testid="clima-mta">
+        <p className="flex items-center gap-2 text-sm font-black text-emerald-200 uppercase tracking-wide mb-2">
+          <Compass size={15} aria-hidden="true" /> {MTA_INFO.titulo}
+        </p>
+        <p className="text-sm leading-relaxed text-slate-200">{MTA_INFO.descripcion}</p>
+        {mtaRegional && (
+          <p className="mt-2 text-sm text-emerald-200" data-testid="clima-mta-regional">
+            Busque el <strong>Boletín Agroclimático</strong> de la{' '}
+            <strong>{mtaRegional}</strong>: ahí está la ventana de siembra para su zona.
+          </p>
+        )}
+        <p className="mt-2 text-[11px] text-slate-500">{MTA_INFO.coordinacion}</p>
+      </div>
+
+      {/* Fenalce */}
+      <a
+        href={FENALCE_INFO.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="clima-fenalce"
+        className="flex gap-3 rounded-2xl border border-slate-700/60 bg-slate-900/50 p-3.5 active:bg-slate-800/60 transition-colors"
+      >
+        <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-xl bg-amber-500/15 grid place-items-center text-lg">🌽</span>
+        <span className="flex-1 min-w-0">
+          <span className="text-sm font-bold text-slate-100 leading-tight">{FENALCE_INFO.titulo}</span>
+          <span className="block text-xs leading-snug text-slate-300 mt-0.5">{FENALCE_INFO.descripcion}</span>
+        </span>
+        <ExternalLink size={16} className="shrink-0 text-slate-500 mt-0.5" aria-hidden="true" />
+      </a>
+
+      <p className="text-[11px] italic text-slate-500">
+        Los pronósticos concretos y las probabilidades cambian cada mes: léalos en el boletín vigente, no de memoria.
+      </p>
+    </section>
+  );
+}
+
+/* ── Pantalla principal ───────────────────────────────────────────────── */
+export default function ClimaBoletinScreen({ onBack, onNavigate }) {
+  const [pilar, setPilar] = useState('que_viene');
+
+  // Fase ENSO EN VIVO (ensoService) — fuente única para toda la app. No se
+  // fabrica aquí: viene del sidecar NOAA/IDEAM (o del override manual/base).
+  const phase = getEnsoPhase();
+  const faseLabel = getEnsoLabel();
+  const source = getEnsoPhaseSource();
+  // ensoService devuelve coarse ('el_nino'/'la_nina'/'neutral'); ensoContext
+  // trabaja en familias por prefijo de slug ('nino'/'nina'/'neutral'). El coarse
+  // 'el_nino' NO empieza por 'nino', así que hay que normalizar el prefijo ANTES
+  // de pasarlo a ensoFamily/ensoRegionalLine — si no, El Niño caería a neutral.
+  const family = ensoFamily(
+    phase === 'el_nino' ? 'nino' : phase === 'la_nina' ? 'nina' : phase,
+  );
+
+  // Lectura regional según el perfil (ensoContext). Vacío si no hay región.
+  const region = useMemo(() => regionFromProfile(getProfile()), []);
+  const regionLine = useMemo(() => ensoRegionalLine(family, region), [family, region]);
+  const mtaRegional = region ? MTA_POR_REGION[region] : null;
+
+  return (
+    <ScreenShell title="El clima que viene" icon={CloudSun} onBack={onBack}>
+      <div className="max-w-2xl mx-auto p-4 space-y-4" data-testid="clima-boletin-screen">
+        {/* Portada: el cielo de la fase actual + nota de cuaderno */}
+        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4">
+          <CieloENSO family={family} />
+          <p className="mt-2 text-xs italic leading-snug text-slate-400 text-center">
+            Chagra le lee los boletines del IDEAM en palabras de finca: qué viene, qué hacer, y dónde
+            confirmarlo. No adivina el clima — lo traduce.
+          </p>
+        </div>
+
+        {/* Navegación entre pilares */}
+        <div className="grid grid-cols-3 gap-2" role="tablist" aria-label="Pilares del clima">
+          {PILARES_CLIMA.map((p) => {
+            const activo = pilar === p.id;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                role="tab"
+                aria-selected={activo}
+                data-testid={`pilar-tab-${p.id}`}
+                onClick={() => setPilar(p.id)}
+                className={`rounded-xl border px-2 py-2.5 text-center transition-colors min-h-[56px] ${
+                  activo
+                    ? 'clima-tab-activo border-sky-500/70 bg-sky-500/15 text-sky-200'
+                    : 'border-slate-700 bg-slate-900/50 text-slate-300 active:bg-slate-800/70'
+                }`}
+              >
+                <span className="block text-sm font-black leading-tight">{p.titulo}</span>
+                <span className={`block text-[10px] leading-tight mt-0.5 ${activo ? 'text-sky-300/90' : 'text-slate-500'}`}>
+                  {p.descripcion}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {pilar === 'que_viene' && (
+          <PilarQueViene family={family} faseLabel={faseLabel} source={source} regionLine={regionLine} />
+        )}
+        {pilar === 'que_hacer' && (
+          <PilarQueHacer family={family} regionLine={regionLine} onNavigate={onNavigate} />
+        )}
+        {pilar === 'donde_mirar' && <PilarDondeMirar mtaRegional={mtaRegional} />}
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/clima/ClimaBoletinScreen.test.jsx
+++ b/src/components/clima/ClimaBoletinScreen.test.jsx
@@ -1,0 +1,126 @@
+/**
+ * ClimaBoletinScreen.test.jsx — módulo "El clima que viene" (traductor IDEAM/ENSO).
+ *
+ * Cubre:
+ *   1. Render base: cielo ENSO + los 3 pilares navegables.
+ *   2. ¿Qué viene?: muestra la fase ENVIVO de ensoService (default: Neutral) y
+ *      la marca honesta de la fuente (sin conexión → valor base).
+ *   3. Enlace real con ensoService: al fijar El Niño con setEnsoPhase, el módulo
+ *      lo refleja (no reimplementa el motor).
+ *   4. Qué hacer: la regla insignia por fase (El Niño → material precoz).
+ *   5. Dónde mirar: remite a los boletines IDEAM + MTA + Fenalce.
+ *   6. Honestidad grounded: la probabilidad que caduca queda como "dato en camino".
+ *   7. Puente al agente (onNavigate).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import ClimaBoletinScreen from './ClimaBoletinScreen.jsx';
+import { setEnsoPhase, clearEnsoPhase } from '../../services/ensoService.js';
+
+// Perfil con departamento andino → región 'andina' (ensoContext.regionFromProfile),
+// para verificar que la lectura regional usa la FAMILIA correcta y no cae a
+// neutral con el coarse 'el_nino'. Conservamos el resto del módulo real
+// (climaService y otros dependen de sus otras exportaciones).
+vi.mock('../../services/userProfileService', async (importActual) => {
+  const actual = await importActual();
+  return { ...actual, getProfile: () => ({ departamento: 'boyacá' }) };
+});
+
+beforeEach(() => {
+  cleanup();
+  clearEnsoPhase();
+  try { localStorage.clear(); } catch { /* jsdom */ }
+});
+
+describe('ClimaBoletinScreen — render base', () => {
+  it('monta la pantalla con el cielo ENSO y los 3 pilares', () => {
+    render(<ClimaBoletinScreen onBack={() => {}} />);
+    expect(screen.getByTestId('clima-boletin-screen')).toBeInTheDocument();
+    expect(screen.getByTestId('cielo-enso')).toBeInTheDocument();
+    expect(screen.getByTestId('pilar-tab-que_viene')).toBeInTheDocument();
+    expect(screen.getByTestId('pilar-tab-que_hacer')).toBeInTheDocument();
+    expect(screen.getByTestId('pilar-tab-donde_mirar')).toBeInTheDocument();
+    // Arranca en "¿Qué viene?"
+    expect(screen.getByTestId('pilar-que-viene')).toBeInTheDocument();
+  });
+});
+
+describe('ClimaBoletinScreen — ¿Qué viene? lee la fase ENSO en vivo', () => {
+  it('sin override muestra fase Neutral y la fuente honesta (valor base)', () => {
+    render(<ClimaBoletinScreen onBack={() => {}} />);
+    expect(screen.getByTestId('clima-fase-label')).toHaveTextContent('Neutral');
+    // Sin sidecar ni override → fuente "sin conexión / valor base".
+    expect(screen.getByTestId('clima-fuente-fase')).toHaveTextContent(/base|conexión/i);
+    // El cielo neutral dibuja sol entre nubes.
+    expect(screen.getByTestId('cielo-enso')).toHaveAttribute('data-family', 'neutral');
+  });
+
+  it('refleja la fase de ensoService cuando el operador fija El Niño (no la inventa)', () => {
+    setEnsoPhase('el_nino');
+    render(<ClimaBoletinScreen onBack={() => {}} />);
+    expect(screen.getByTestId('clima-fase-label')).toHaveTextContent('El Niño');
+    expect(screen.getByTestId('clima-fuente-fase')).toHaveTextContent(/mano/i);
+    expect(screen.getByTestId('cielo-enso')).toHaveAttribute('data-family', 'nino');
+  });
+
+  it('en neutral la probabilidad que caduca se pinta como dato en camino', () => {
+    render(<ClimaBoletinScreen onBack={() => {}} />);
+    expect(screen.getAllByTestId('slot-grounded-pendiente').length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('ClimaBoletinScreen — Qué hacer (regla accionable por fase)', () => {
+  it('con El Niño da la regla insignia: material precoz y de menor demanda hídrica', () => {
+    setEnsoPhase('el_nino');
+    render(<ClimaBoletinScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-que_hacer'));
+    expect(screen.getByTestId('clima-regla-insignia')).toHaveTextContent(/PRECOZ/i);
+  });
+
+  it('con La Niña la regla apunta al manejo del exceso de agua', () => {
+    setEnsoPhase('la_nina');
+    render(<ClimaBoletinScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-que_hacer'));
+    expect(screen.getByTestId('clima-regla-insignia')).toHaveTextContent(/EXCESO de agua/i);
+  });
+});
+
+describe('ClimaBoletinScreen — lectura regional (familia ENSO correcta)', () => {
+  it('bajo El Niño y perfil andino muestra el impacto regional del Niño, no la vigilancia neutral', () => {
+    setEnsoPhase('el_nino');
+    render(<ClimaBoletinScreen onBack={() => {}} />);
+    const linea = screen.getByTestId('clima-region-linea');
+    // La línea andina.nino de ensoContext ("El Niño en los Andes trae menos lluvia...").
+    expect(linea).toHaveTextContent(/El Niño en los Andes/i);
+  });
+
+  it('remite a la Mesa Técnica Agroclimática de la región del perfil', () => {
+    render(<ClimaBoletinScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-donde_mirar'));
+    expect(screen.getByTestId('clima-mta-regional')).toHaveTextContent(/Andina/i);
+  });
+});
+
+describe('ClimaBoletinScreen — Dónde mirar (remite, no reemplaza)', () => {
+  it('lista los boletines IDEAM, la MTA y Fenalce', () => {
+    render(<ClimaBoletinScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-donde_mirar'));
+    expect(screen.getByTestId('boletin-agrometeorologico')).toBeInTheDocument();
+    expect(screen.getByTestId('boletin-agroclimatico')).toBeInTheDocument();
+    expect(screen.getByTestId('boletin-enso')).toBeInTheDocument();
+    expect(screen.getByTestId('clima-mta')).toBeInTheDocument();
+    expect(screen.getByTestId('clima-fenalce')).toBeInTheDocument();
+  });
+});
+
+describe('ClimaBoletinScreen — puente al agente', () => {
+  it('navega al agente con la pregunta prellenada', () => {
+    const onNavigate = vi.fn();
+    render(<ClimaBoletinScreen onBack={() => {}} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-que_hacer'));
+    fireEvent.click(screen.getByTestId('clima-preguntar-agente'));
+    expect(onNavigate).toHaveBeenCalledWith('agente', expect.objectContaining({
+      prefilledPrompt: expect.stringMatching(/sembrar|clima/i),
+    }));
+  });
+});

--- a/src/components/clima/clima.css
+++ b/src/components/clima/clima.css
@@ -1,0 +1,74 @@
+/*
+ * clima.css — micro-animaciones del módulo "El clima que viene".
+ *
+ * Principios (iguales al módulo de agua):
+ *   · Sutiles y de bajo costo (solo transform/opacity, nada de layout).
+ *   · prefers-reduced-motion las apaga TODAS.
+ *   · No fija ningún color de tema: el color sale de las clases Tailwind del
+ *     componente (paleta slate + acentos cielo/ámbar), que ya reaccionan a los
+ *     temas de la app vía data-theme (themes.css). Aquí solo hay movimiento.
+ */
+
+/* Los rayos del sol laten suave (opacity + escala mínima desde el centro). */
+@keyframes clima-sol-late {
+  0%, 100% { opacity: 0.7; transform: scale(0.98); }
+  50% { opacity: 1; transform: scale(1.03); }
+}
+.clima-sol-rayos {
+  transform-origin: center;
+  transform-box: fill-box;
+  animation: clima-sol-late 3.4s ease-in-out infinite;
+}
+
+/* La nube deriva de lado a lado, lentísima (como cielo real). */
+@keyframes clima-nube-va {
+  0%, 100% { transform: translateX(-4px); }
+  50% { transform: translateX(4px); }
+}
+.clima-nube-deriva {
+  animation: clima-nube-va 7s ease-in-out infinite;
+}
+
+/* Gotas de lluvia: caen en loop, escalonadas. */
+@keyframes clima-gota-cae {
+  0% { transform: translateY(0); opacity: 0; }
+  20% { opacity: 0.95; }
+  80% { opacity: 0.95; }
+  100% { transform: translateY(20px); opacity: 0; }
+}
+.clima-gota {
+  animation: clima-gota-cae 1.5s linear infinite;
+}
+.clima-gota--2 { animation-delay: 0.4s; }
+.clima-gota--3 { animation-delay: 0.8s; }
+
+/* Entrada suave del contenido del pilar al cambiar de pestaña. */
+@keyframes clima-seccion-entra {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.clima-seccion {
+  animation: clima-seccion-entra 0.3s ease-out;
+}
+
+/* Pulso único del tab activo al seleccionarlo. */
+@keyframes clima-tab-pulso {
+  0% { transform: scale(0.94); }
+  60% { transform: scale(1.04); }
+  100% { transform: scale(1); }
+}
+.clima-tab-activo {
+  animation: clima-tab-pulso 0.4s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .clima-sol-rayos,
+  .clima-nube-deriva,
+  .clima-gota,
+  .clima-seccion,
+  .clima-tab-activo {
+    animation: none;
+  }
+  .clima-sol-rayos { opacity: 1; }
+  .clima-gota { opacity: 0.95; }
+}

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -99,9 +99,12 @@ export const MUNDOS_FINCA = [
         id: 'clima',
         titulo: 'El clima',
         emoji: '⛅',
-        lema: 'Su día en la finca: lluvia, heladas y avisos',
+        lema: 'Lo que viene y qué hacer: los boletines del IDEAM en campesino',
         tinte: ['#4c7fa0', '#dce9f2'],
-        directo: { view: 'hoy_finca' },
+        entradas: [
+            { view: 'hoy_finca', label: 'Su día en la finca', desc: 'Lluvia, heladas y avisos para hoy', emoji: '🌤️' },
+            { view: 'clima_boletin', label: 'El clima que viene', desc: 'Qué trae El Niño o La Niña y qué hacer, leído del IDEAM', emoji: '⛅' },
+        ],
     },
     {
         id: 'animales',

--- a/src/data/climaBoletines.js
+++ b/src/data/climaBoletines.js
@@ -1,0 +1,205 @@
+/**
+ * climaBoletines.js — CONTENIDO del módulo "El clima que viene" (traductor de
+ * boletines IDEAM/ENSO).
+ *
+ * POSICIONAMIENTO (grounding 2026-07-04, Parte B): Chagra NO reemplaza al IDEAM
+ * ni pronostica el clima. Es el TRADUCTOR CAMPESINO de los boletines oficiales:
+ * lee la FASE ENSO en vivo (ensoService, alimentado por el sidecar NOAA/IDEAM),
+ * la explica en palabras de finca y REMITE al boletín de la Mesa Técnica
+ * Agroclimática (MTA) departamental y a Fenalce para la ventana de siembra.
+ *
+ * REGLA ANTI-ALUCINACIÓN: este archivo solo contiene conocimiento DURABLE y
+ * citado (qué significa cada fase ENSO, la regla agronómica institucional, el
+ * catálogo de boletines oficiales). NADA de pronósticos concretos: esos CADUCAN
+ * y se leen del boletín vigente. Las cifras coyunturales (probabilidades, mm por
+ * municipio) son SLOTS grounded-pendiente que se remiten a la fuente, no se
+ * inventan aquí.
+ *
+ * Fuentes (ver deepresearch/2026-07-04-cultivos-clima-nacional-CO.md, Parte B):
+ *   IDEAM [R32-R37], FAO/MADR Mesas Técnicas Agroclimáticas [R38-R40],
+ *   Fenalce agroclimatología [R41-R42], impactos ENSO [R32-R35].
+ */
+
+export const ESTADO_GROUNDED_PENDIENTE = 'grounded_pendiente';
+
+/* ── Pilares del módulo (pestañas) ────────────────────────────────────── */
+export const PILARES_CLIMA = [
+  { id: 'que_viene', titulo: '¿Qué viene?', descripcion: 'El estado del clima ahora' },
+  { id: 'que_hacer', titulo: 'Qué hacer', descripcion: 'Según la fase' },
+  { id: 'donde_mirar', titulo: 'Dónde mirar', descripcion: 'Los boletines' },
+];
+
+/* ── PILAR 1 · ¿Qué viene? — lectura de cada fase ENSO ─────────────────── */
+/**
+ * Qué significa cada fase del ciclo ENSO para la finca. Conocimiento durable y
+ * citado (IDEAM, Fenalce). Se cruza con la fase EN VIVO de ensoService — aquí
+ * NO se decide qué fase es, solo qué implica.
+ * Clave = familia ENSO de ensoContext.ensoFamily: 'nino' | 'nina' | 'neutral'.
+ */
+export const LECTURA_ENSO = Object.freeze({
+  nino: {
+    titulo: 'El Niño: más sol, menos lluvia',
+    resumen:
+      'En fase El Niño el país tiende a llover menos y calentar más. Sube el riesgo de sequía, de incendio y de que el agua no alcance para el riego.',
+    senales: [
+      'Aguaceros más tardíos o más flojos de lo normal.',
+      'Días más calurosos y quebradas con menos caudal.',
+      'En el altiplano frío, cielo despejado de noche = más riesgo de helada.',
+    ],
+    regla:
+      'Siembre material PRECOZ y de MENOR necesidad de agua. Guarde agua desde ya y refuerce el riego.',
+    fuente: 'IDEAM · Fenalce (boletín ENSO)',
+  },
+  nina: {
+    titulo: 'La Niña: más lluvia',
+    resumen:
+      'En fase La Niña llueve más de lo normal. El problema pasa a ser el EXCESO de agua: encharcamiento, hongos y enfermedades en la mata.',
+    senales: [
+      'Lluvias más largas y fuertes; suelos que no alcanzan a secar.',
+      'Más gota, mildiu y hongos en papa, café y hortalizas.',
+      'Riesgo de deslizamiento en ladera y de anegar el lote.',
+    ],
+    regla:
+      'Prepare el DRENAJE y las camas altas. Vigile hongos y cuide maíz, fríjol y soya, que sufren con el agua parada.',
+    fuente: 'IDEAM · Fenalce (boletín ENSO)',
+  },
+  neutral: {
+    titulo: 'Neutral: ni Niño ni Niña marcados',
+    resumen:
+      'El ciclo ENSO está en fase neutral: el clima sigue el patrón normal de su región (dos temporadas de lluvia en los Andes, una en llanos y Caribe). Es el momento de planear con calma.',
+    senales: [
+      'Lluvias dentro de lo esperado para la época.',
+      'Buen momento para revisar el calendario de siembra por región.',
+      'Conviene mirar si el IDEAM anuncia vigilancia de Niño o de Niña.',
+    ],
+    regla:
+      'Siembre al ritmo normal de su región, apenas se estabilicen las primeras lluvias. Mantenga el ojo en el boletín por si cambia la fase.',
+    fuente: 'IDEAM (boletín de seguimiento ENSO)',
+  },
+});
+
+/* ── PILAR 2 · Qué hacer — acciones por fase ENSO ─────────────────────── */
+/**
+ * Medidas accionables por fase. Regla institucional del grounding [R34][R42]:
+ *   El Niño → materiales precoces y de menor demanda hídrica; reforzar agua.
+ *   La Niña → manejo de exceso de agua, drenaje y enfermedades.
+ */
+export const ACCIONES_ENSO = Object.freeze({
+  nino: [
+    { emoji: '🌱', titulo: 'Variedad precoz', detalle: 'Elija material que madure rápido y aguante seco: menos días en el lote, menos exposición a la sequía.' },
+    { emoji: '💧', titulo: 'Guarde agua desde ya', detalle: 'Coseche lluvia mientras todavía cae y cuide el nacimiento. En verano cada caneca cuenta.' },
+    { emoji: '🌾', titulo: 'Mulch y sombrío', detalle: 'Cubra el suelo con hojarasca o pasto seco para que no se le vaya la humedad. En café/cacao, sombrío.' },
+    { emoji: '🔥', titulo: 'Ojo con el fuego', detalle: 'Con todo seco, una quema se sale de control fácil. Haga rondas cortafuego y evite quemar.' },
+  ],
+  nina: [
+    { emoji: '🚰', titulo: 'Drenaje al día', detalle: 'Destape zanjas y canales antes del aguacero. Agua parada pudre la raíz.' },
+    { emoji: '🛏️', titulo: 'Camas altas', detalle: 'Siembre en eras levantadas para que la mata no quede con los pies en el barro.' },
+    { emoji: '🍄', titulo: 'Vigile hongos', detalle: 'Con humedad se disparan gota, mildiu y roya. Revise seguido y actúe temprano.' },
+    { emoji: '⛰️', titulo: 'Cuide la ladera', detalle: 'En pendiente, barreras vivas y coberturas para que la lluvia no le lave el suelo.' },
+  ],
+  neutral: [
+    { emoji: '🗓️', titulo: 'Siembre a tiempo', detalle: 'Arranque apenas se estabilicen las primeras lluvias de su región; no adelante ni atrase por costumbre.' },
+    { emoji: '📻', titulo: 'Siga el boletín', detalle: 'Revise el boletín ENSO del IDEAM: si empieza vigilancia de Niño o de Niña, ajuste el plan.' },
+    { emoji: '🌱', titulo: 'Diversifique', detalle: 'Mezclar variedades y ciclos reparte el riesgo si el clima cambia a mitad de temporada.' },
+    { emoji: '💧', titulo: 'Deje lista el agua', detalle: 'Tenga el sistema de riego y de cosecha de lluvia a punto para cualquiera de los dos escenarios.' },
+  ],
+});
+
+/**
+ * La regla accionable insignia del grounding, resumida en una línea por fase.
+ * La usa el encabezado del pilar "Qué hacer".
+ */
+export const REGLA_INSIGNIA = Object.freeze({
+  nino: 'El Niño → material PRECOZ y de MENOR necesidad de agua.',
+  nina: 'La Niña → manejo del EXCESO de agua: drenaje y enfermedades.',
+  neutral: 'Neutral → siembre al ritmo normal de su región y siga el boletín.',
+});
+
+/* ── PILAR 3 · Dónde mirar — catálogo de boletines oficiales ──────────── */
+/**
+ * Los productos oficiales que Chagra ayuda a leer (no reemplaza). Cada uno con
+ * su frecuencia, para qué sirve y dónde consultarlo. URLs de fuentes públicas
+ * institucionales (IDEAM / MADR-FAO / Fenalce).
+ */
+export const BOLETINES_IDEAM = Object.freeze([
+  {
+    id: 'agrometeorologico',
+    nombre: 'Boletín Agrometeorológico',
+    frecuencia: 'semanal',
+    para: 'El tiempo de los próximos 7 días por departamento: para decidir labores, riego y qué día no llueve.',
+    emisor: 'IDEAM',
+    url: 'https://www.pronosticosyalertas.gov.co',
+  },
+  {
+    id: 'agroclimatico',
+    nombre: 'Boletín Agroclimático Nacional',
+    frecuencia: 'mensual',
+    para: 'Predicción del trimestre que viene con recomendaciones por cultivo. Lo hace la Mesa Técnica Agroclimática (MADR + FAO + IDEAM).',
+    emisor: 'IDEAM · MADR · FAO',
+    url: 'https://www.pronosticosyalertas.gov.co',
+  },
+  {
+    id: 'enso',
+    nombre: 'Boletín de seguimiento del ciclo ENSO',
+    frecuencia: 'mensual',
+    para: 'La fase oficial El Niño / La Niña / Neutral vigente. Es la fuente de verdad de "qué viene".',
+    emisor: 'IDEAM',
+    url: 'https://www.ideam.gov.co',
+  },
+]);
+
+/**
+ * Mesas Técnicas Agroclimáticas (MTA): infraestructura institucional existente
+ * (8 mesas, 36 cultivos, ~631.000 productores) [R38]. Chagra REMITE a la MTA
+ * del departamento del usuario para la ventana de siembra local.
+ */
+export const MTA_INFO = Object.freeze({
+  titulo: 'Mesa Técnica Agroclimática (MTA)',
+  descripcion:
+    'Reunión trimestral donde científicos, técnicos y campesinos leen juntos el pronóstico y sacan las medidas por cultivo para cada departamento. De ahí sale el Boletín Agroclimático de su región.',
+  coordinacion: 'MADR + FAO + IDEAM, con ICA, AGROSAVIA, Cenicafé y los gremios.',
+  fuente: 'FAO Colombia · MADR (Mesas Técnicas Agroclimáticas)',
+});
+
+/**
+ * Nombre humano de la mesa/boletín por región natural (para remitir según el
+ * perfil). La región se infiere con ensoContext.regionFromProfile.
+ */
+export const MTA_POR_REGION = Object.freeze({
+  andina: 'Mesa Técnica Agroclimática de la región Andina',
+  caribe: 'Mesa Técnica Agroclimática del Caribe',
+  pacifico: 'Mesa Técnica Agroclimática del Pacífico',
+  orinoquia: 'Mesa Técnica Agroclimática de la Orinoquía',
+  amazonia: 'Mesa Técnica Agroclimática de la Amazonía',
+});
+
+/** Fenalce: pronóstico a 3 meses para cereales y leguminosas [R41][R42]. */
+export const FENALCE_INFO = Object.freeze({
+  titulo: 'Fenalce — agroclimatología',
+  descripcion:
+    'Si siembra maíz, fríjol, soya, sorgo o arveja, Fenalce anticipa el clima a 3 meses por región y recomienda semilla, fecha de siembra y manejo del agua.',
+  url: 'https://www.fenalce.co/areas-estrategicas/agroclimatologia-y-agrometereologia/',
+  fuente: 'Fenalce (área de agroclimatología y agrometeorología)',
+});
+
+/**
+ * Lluvia mensual por municipio (mm) — SLOT grounded-pendiente. Igual que el
+ * módulo de agua: llega por el pipeline de clima (IDEAM por estación/municipio).
+ * Mientras tanto, el módulo REMITE al boletín, no inventa el número.
+ */
+export const LLUVIA_MENSUAL_ZONA = Object.freeze({
+  estado: ESTADO_GROUNDED_PENDIENTE,
+  valor: null,
+  fuentePrevista: 'IDEAM — promedios mensuales de precipitación por municipio (pipeline clima Chagra)',
+});
+
+/**
+ * Probabilidad de transición de fase (%) por trimestre — SLOT grounded-pendiente
+ * en producción: CADUCA. El respaldo estático vive en ensoContext.ENSO_WATCH_2026;
+ * el número vigente se lee del boletín ENSO, no se cachea aquí.
+ */
+export const PROBABILIDAD_TRANSICION = Object.freeze({
+  estado: ESTADO_GROUNDED_PENDIENTE,
+  valor: null,
+  fuentePrevista: 'IDEAM / NOAA CPC — boletín ENSO vigente (las probabilidades caducan)',
+});


### PR DESCRIPTION
## ⛅ El clima que viene — traductor campesino de boletines IDEAM/ENSO

Mini-app del **mundo Clima**. Posiciona a Chagra como **TRADUCTOR** de los boletines agroclimáticos oficiales (IDEAM / Mesa Técnica Agroclimática / Fenalce), **no como reemplazo**. Solo visual + lógica determinista; **no pronostica**.

### Tres pilares
1. **¿Qué viene?** — lee la **fase ENSO EN VIVO** de `ensoService` (alimentado por el sidecar NOAA/IDEAM). No fabrica la fase: la muestra con marca honesta de la fuente (`en vivo` / `fijada a mano` / `sin conexión — valor base`) y añade la **lectura regional** de `ensoContext` según el perfil.
2. **Qué hacer** — la regla accionable por fase del grounding:
   - **El Niño → material precoz y de menor demanda hídrica** (+ guardar agua, mulch, ojo con el fuego).
   - **La Niña → manejo del exceso de agua**: drenaje, camas altas, vigilar hongos.
3. **Dónde mirar** — remite al **Boletín Agroclimático de la Mesa Técnica Agroclimática** del departamento, al **boletín ENSO del IDEAM** y a **Fenalce**.

### Cómo enlaza lo existente (no reimplementa)
- `services/ensoService.js` → `getEnsoPhase` / `getEnsoLabel` / `getEnsoPhaseSource` (fuente única de la fase).
- `services/ensoContext.js` → `ensoFamily` / `regionFromProfile` / `ensoRegionalLine` (lectura regional citada a DR-MISSION).
- Fix de correctitud: `ensoService` devuelve coarse (`el_nino`), pero `ensoContext.ensoFamily` trabaja por prefijo de slug (`nino`); se normaliza antes de pasarlo, para que El Niño no caiga a la línea neutral.

### Identidad + accesibilidad
- SVG propio del cielo por fase (`CieloENSO.jsx`): sol con rayos / nubes con lluvia / sol entre nubes.
- Cuaderno de campo, 4 temas vía clases slate + `data-theme`; animaciones en `clima.css` **apagadas con `prefers-reduced-motion`**.

### Cableado (no huérfana)
- Ruta `clima_boletin` en `App.jsx` (lazy + case + telemetría).
- `mundosFinca.js`: el mundo `clima` pasa de `directo` a `entradas` — conserva **hoy_finca** ("Su día en la finca") y agrega **El clima que viene**.

### Anti-alucinación — slots grounded-pendiente
Las cifras que **caducan** o aún sin grounding se remiten a la fuente, nunca se inventan:
- Probabilidad de transición ENSO por trimestre (caduca) → se lee del boletín ENSO vigente.
- Lluvia mensual por municipio (mm) → pipeline clima IDEAM por estación/municipio.

### Grounding
`Chagra-strategy/deepresearch/2026-07-04-cultivos-clima-nacional-CO.md` (Parte B: ENSO, boletines IDEAM, MTA, Fenalce).

### Verificación
- Tests nuevos: **10/10** (`ClimaBoletinScreen.test.jsx`) — render, fase viva, override El Niño/La Niña, regla insignia, lectura regional (familia correcta), boletines/MTA/Fenalce, puente al agente.
- Reachability: **8/8** (contrato de mundos sin huérfanos).
- Lint clima files: `eslint --max-warnings=0` limpio · Build: `✓ built in 4m 16s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)