### PR TITLE
feat(cultivos): hub del mundo cultivos + calculadora grados-dia

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -113,6 +113,11 @@ const SaludSueloScreen = lazy(() => import('./components/SaludSueloScreen'));
 // LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home): un mundo por dentro —
 // las funciones existentes agrupadas por lugar. Re-rutea, no reimplementa.
 const MundoScreen = lazy(() => import('./components/MundoScreen'));
+// Portada a medida del mundo 🌱 CULTIVOS Y SEMILLAS: hub que orienta por
+// región/clima, agrupa las funciones existentes (directorio, ciclo, germinación,
+// calendario, siembra, cosecha) y suma una calculadora de grados-día. Re-rutea,
+// no reimplementa.
+const MundoCultivosHub = lazy(() => import('./components/cultivos/MundoCultivosHub'));
 const CromatografiaScreen = lazy(() => import('./components/CromatografiaScreen'));
 const CicloVivoFullView = lazy(() => import('./components/CicloVivo/CicloVivoFullView'));
 const ToxicologiaScreen = lazy(() => import('./components/ToxicologiaScreen'));
@@ -1303,6 +1308,20 @@ export default function App() {
             <ErrorFallback moduleName="Mundos de la finca">
               <MundoScreen
                 mundoId={currentViewData?.mundo}
+                onBack={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mundo_cultivos':
+        // Portada a medida del mundo CULTIVOS Y SEMILLAS (hub): orienta por
+        // región/clima, agrupa las funciones existentes y suma la calculadora
+        // de grados-día. Cada lámina RE-RUTEA a su pantalla real vía navigate.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Cultivos y semillas">
+              <MundoCultivosHub
                 onBack={() => navigate('dashboard')}
                 onNavigate={navigate}
               />

--- a/src/components/MundoScreen.jsx
+++ b/src/components/MundoScreen.jsx
@@ -46,9 +46,11 @@ export default function MundoScreen({ mundoId, onBack, onNavigate }) {
                                 type="button"
                                 className="mf-indice-item"
                                 style={{ '--mf-a': m.tinte[0], '--mf-b': m.tinte[1] }}
-                                onClick={() => (m.directo
-                                    ? onNavigate?.(m.directo.view, m.directo.data)
-                                    : onNavigate?.('mundo', { mundo: m.id }))}
+                                onClick={() => {
+                                    if (m.portada) onNavigate?.(m.portada);
+                                    else if (m.directo) onNavigate?.(m.directo.view, m.directo.data);
+                                    else onNavigate?.('mundo', { mundo: m.id });
+                                }}
                                 aria-label={`${m.titulo}: ${m.lema}`}
                             >
                                 <span aria-hidden="true" className="mf-indice-emoji">{m.emoji}</span>

--- a/src/components/cultivos/CalculadoraGradosDia.jsx
+++ b/src/components/cultivos/CalculadoraGradosDia.jsx
@@ -1,0 +1,247 @@
+/*
+ * i18n (ADR-050): copy campesino en español Colombia, pendiente de migrar a
+ * src/config/messages.js — mismo criterio que DashboardLive.jsx.
+ */
+import { useMemo, useState } from 'react';
+import {
+    CULTIVOS_GDD,
+    CULTIVO_GDD_BY_ID,
+    PISOS_TERMICOS,
+    gddDia,
+    gddAcumulado,
+    diasTranscurridos,
+    estimarEtapa,
+    compararRitmo,
+} from '../../services/gradosDiaCalculator';
+
+/**
+ * CalculadoraGradosDia — el "reloj térmico" del cultivo, determinista.
+ *
+ * Deja al campesino ver POR QUÉ la misma mata tarda más en tierra fría: cuenta
+ * el calor (grados-día) que acumula por encima de su temperatura base, no los
+ * días del calendario. Todo el cálculo vive en gradosDiaCalculator.js (funciones
+ * puras, groundeadas). Esta pantalla solo arma los controles y muestra números.
+ *
+ * Honestidad: los umbrales de etapa por GDD están grounded-pendiente; la etapa
+ * se estima por la fenología en DÍAS que sí está groundeada (AGROSAVIA/ICA). Los
+ * presets de piso térmico son referencia editable.
+ *
+ * @param {Object} props
+ * @param {string} [props.className]
+ */
+export default function CalculadoraGradosDia({ className = '' }) {
+    const [cultivoId, setCultivoId] = useState('maiz');
+    const [pisoId, setPisoId] = useState('frio');
+    const [tmin, setTmin] = useState(7);
+    const [tmax, setTmax] = useState(19);
+    const [tbManual, setTbManual] = useState(10);
+    const [fecha, setFecha] = useState('');
+
+    const cultivo = CULTIVO_GDD_BY_ID[cultivoId] || CULTIVOS_GDD[0];
+    const tb = cultivoId === 'manual' ? Number(tbManual) : cultivo.tb;
+    const to = cultivoId === 'manual' ? null : cultivo.to;
+
+    // Aplica un preset de piso térmico (referencia editable).
+    const aplicarPiso = (id) => {
+        const p = PISOS_TERMICOS.find((x) => x.id === id);
+        if (!p) return;
+        setPisoId(id);
+        setTmin(p.tmin);
+        setTmax(p.tmax);
+    };
+
+    const nTmin = Number(tmin);
+    const nTmax = Number(tmax);
+
+    const porDia = useMemo(
+        () => Math.round(gddDia(nTmin, nTmax, tb, to) * 10) / 10,
+        [nTmin, nTmax, tb, to],
+    );
+
+    // Días desde la siembra (si dieron fecha) y GDD acumulados a hoy.
+    const dds = useMemo(() => (fecha ? diasTranscurridos(fecha) : null), [fecha]);
+    const acumulado = useMemo(
+        () => (dds != null ? gddAcumulado(nTmin, nTmax, tb, to, dds) : null),
+        [dds, nTmin, nTmax, tb, to],
+    );
+    const etapa = useMemo(
+        () => (dds != null ? estimarEtapa(cultivoId, dds) : null),
+        [cultivoId, dds],
+    );
+
+    // Comparación tierra fría vs templada (evidencia del "tarda más").
+    const ritmo = useMemo(() => compararRitmo(cultivoId, 'templado', 'frio'), [cultivoId]);
+
+    const tempsInvalidas = !(Number.isFinite(nTmin) && Number.isFinite(nTmax)) || nTmax < nTmin;
+
+    return (
+        <div className={`mch-calc ${className}`} data-testid="calc-grados-dia">
+            <p className="mch-calc-intro">
+                Los <b>grados-día</b> cuentan el calor que junta la mata, no los días del
+                almanaque. En tierra fría junta menos calor por día — por eso tarda más.
+            </p>
+
+            {/* 1 · Cultivo */}
+            <fieldset className="mch-calc-grupo">
+                <legend>1 · ¿Qué sembró?</legend>
+                <div className="mch-calc-chips" role="radiogroup" aria-label="Cultivo">
+                    {CULTIVOS_GDD.map((c) => (
+                        <button
+                            key={c.id}
+                            type="button"
+                            role="radio"
+                            aria-checked={cultivoId === c.id}
+                            className={`mch-chip ${cultivoId === c.id ? 'is-on' : ''}`}
+                            onClick={() => setCultivoId(c.id)}
+                            data-testid={`calc-cultivo-${c.id}`}
+                        >
+                            <span aria-hidden="true">{c.emoji}</span> {c.nombre}
+                        </button>
+                    ))}
+                </div>
+                {cultivoId === 'manual' ? (
+                    <label className="mch-calc-campo">
+                        Temperatura base (°C)
+                        <input
+                            type="number"
+                            inputMode="decimal"
+                            value={tbManual}
+                            min={0}
+                            max={20}
+                            step={0.5}
+                            onChange={(e) => setTbManual(e.target.value)}
+                            data-testid="calc-tb-manual"
+                        />
+                    </label>
+                ) : (
+                    <p className="mch-calc-nota">
+                        Base <b>{tb} °C</b>{to != null ? `, tope ${to} °C` : ''}. {cultivo.tbNota}{' '}
+                        <span className="mch-fuente">({cultivo.fuente})</span>
+                    </p>
+                )}
+            </fieldset>
+
+            {/* 2 · Clima del lugar */}
+            <fieldset className="mch-calc-grupo">
+                <legend>2 · ¿Cómo es el clima de su finca?</legend>
+                <div className="mch-calc-chips" role="radiogroup" aria-label="Piso térmico">
+                    {PISOS_TERMICOS.map((p) => (
+                        <button
+                            key={p.id}
+                            type="button"
+                            role="radio"
+                            aria-checked={pisoId === p.id}
+                            className={`mch-chip ${pisoId === p.id ? 'is-on' : ''}`}
+                            onClick={() => aplicarPiso(p.id)}
+                            data-testid={`calc-piso-${p.id}`}
+                        >
+                            {p.nombre}
+                            <small>{p.rango}</small>
+                        </button>
+                    ))}
+                </div>
+                <div className="mch-calc-temps">
+                    <label className="mch-calc-campo">
+                        Mínima de la noche (°C)
+                        <input
+                            type="number"
+                            inputMode="decimal"
+                            value={tmin}
+                            step={0.5}
+                            onChange={(e) => { setTmin(e.target.value); setPisoId(''); }}
+                            data-testid="calc-tmin"
+                        />
+                    </label>
+                    <label className="mch-calc-campo">
+                        Máxima del día (°C)
+                        <input
+                            type="number"
+                            inputMode="decimal"
+                            value={tmax}
+                            step={0.5}
+                            onChange={(e) => { setTmax(e.target.value); setPisoId(''); }}
+                            data-testid="calc-tmax"
+                        />
+                    </label>
+                </div>
+                <p className="mch-calc-nota">
+                    Valores de referencia por piso térmico — <b>ajústelos a su finca</b>.
+                </p>
+            </fieldset>
+
+            {/* Resultado por día */}
+            {tempsInvalidas ? (
+                <p className="mch-calc-aviso" role="status">
+                    Revise las temperaturas: la máxima del día no puede ser menor que la
+                    mínima de la noche.
+                </p>
+            ) : (
+                <div className="mch-calc-resultado" role="status" aria-live="polite">
+                    <div className="mch-calc-big">
+                        <b data-testid="calc-por-dia">{porDia}</b>
+                        <span>grados-día por día</span>
+                    </div>
+                    {ritmo && Number.isFinite(ritmo.factor) && ritmo.factor > 1 && (
+                        <p className="mch-calc-porque">
+                            En tierra templada esta mata juntaría <b>{ritmo.calido}</b> °D/día
+                            y en tierra fría <b>{ritmo.frio}</b> °D/día: por eso en lo frío va{' '}
+                            <b>~{ritmo.factor}×</b> más despacio.
+                        </p>
+                    )}
+                </div>
+            )}
+
+            {/* 3 · Fecha de siembra → etapa y acumulado */}
+            <fieldset className="mch-calc-grupo">
+                <legend>3 · ¿Cuándo sembró? <small>(opcional)</small></legend>
+                <label className="mch-calc-campo">
+                    Fecha de siembra
+                    <input
+                        type="date"
+                        value={fecha}
+                        max={new Date().toISOString().slice(0, 10)}
+                        onChange={(e) => setFecha(e.target.value)}
+                        data-testid="calc-fecha"
+                    />
+                </label>
+                {dds != null && !tempsInvalidas && (
+                    <div className="mch-calc-etapa" data-testid="calc-etapa">
+                        <p>
+                            Van <b>{dds}</b> días desde la siembra ·{' '}
+                            <b>{acumulado}</b> grados-día acumulados.
+                        </p>
+                        {etapa ? (
+                            <>
+                                <p className="mch-calc-etapa-actual">
+                                    <span aria-hidden="true">📍</span> Según la fenología, va en{' '}
+                                    <b>{etapa.actual.label}</b> — {etapa.actual.desc}.
+                                </p>
+                                {etapa.proxima && (
+                                    <p className="mch-calc-etapa-prox">
+                                        Sigue <b>{etapa.proxima.label}</b> en ~{etapa.diasParaProxima}{' '}
+                                        días.
+                                    </p>
+                                )}
+                                <p className="mch-calc-nota">
+                                    Etapa por días de fenología{' '}
+                                    <span className="mch-fuente">({cultivo.fenologiaFuente})</span>. Los
+                                    umbrales de etapa por grados-día están en camino.
+                                </p>
+                            </>
+                        ) : (
+                            <p className="mch-calc-nota">
+                                Para este cultivo aún no cargamos la fenología en días — el dato
+                                está en camino. El acumulado de grados-día sí es exacto.
+                            </p>
+                        )}
+                    </div>
+                )}
+            </fieldset>
+
+            <p className="mch-calc-pie">
+                Los rangos son envolventes de adaptación, no reglas duras: varían por
+                variedad, microclima y manejo. Cálculo determinista; sin conexión.
+            </p>
+        </div>
+    );
+}

--- a/src/components/cultivos/MundoCultivosHub.jsx
+++ b/src/components/cultivos/MundoCultivosHub.jsx
@@ -1,0 +1,244 @@
+/*
+ * i18n (ADR-050): copy de navegación campesino en español Colombia, pendiente de
+ * migrar a src/config/messages.js — mismo criterio que DashboardLive.jsx.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useState } from 'react';
+import { ScreenShell } from '../common/ScreenShell';
+import { REGIMENES_LLUVIA } from '../../services/gradosDiaCalculator';
+import CalculadoraGradosDia from './CalculadoraGradosDia';
+import './mundo-cultivos-hub.css';
+
+/**
+ * MundoCultivosHub — la PORTADA del mundo 🌱 CULTIVOS Y SEMILLAS.
+ *
+ * Reúne y da entrada elegante a las funciones que YA existen (directorio de
+ * especies, ciclo de cultivo, germinación, calendario, fenología, siembra y
+ * cosecha) SIN reimplementarlas: cada lámina RE-RUTEA vía onNavigate a su
+ * pantalla real de App.jsx. Suma una calculadora determinista de grados-día.
+ *
+ * Orientación primero (grounding 2026-07-04): el calendario campesino no es una
+ * fecha universal — depende del RÉGIMEN de lluvia (bimodal andino = dos siembras;
+ * unimodal = una) y del PISO TÉRMICO. Por eso el hub abre orientando por región.
+ *
+ * Identidad: cuaderno de campo (papel crema, tinta verde, Baloo 2 / Nunito),
+ * SVG propios, funciona sobre los 4 temas (láminas de papel), reduced-motion.
+ *
+ * @param {Object} props
+ * @param {Function} props.onBack   volver al home.
+ * @param {(view: string, data?: any) => void} props.onNavigate
+ */
+export default function MundoCultivosHub({ onBack, onNavigate }) {
+    const [regimenId, setRegimenId] = useState('bimodal');
+    const [calcAbierta, setCalcAbierta] = useState(false);
+    const regimen = REGIMENES_LLUVIA.find((r) => r.id === regimenId) || REGIMENES_LLUVIA[0];
+
+    // Las funciones del mundo, agrupadas editorialmente. `view` SIEMPRE es un
+    // case real de App.jsx (y vive también en las entradas del mundo cultivos en
+    // mundosFinca.js, que congela la reachability).
+    const grupos = [
+        {
+            titulo: 'Saber qué y cuándo sembrar',
+            desc: 'El conocimiento antes de meter la semilla',
+            items: [
+                { view: 'directorio', emoji: '🌱', label: 'Qué puedo sembrar', desc: 'Especies para su clima, con qué se llevan y sus plagas' },
+                { view: 'calendario_finca', emoji: '🗓️', label: 'Calendario de la finca', desc: 'Cuándo sembrar, abonar y cosechar, todo junto' },
+                { view: 'ciclo', emoji: '🔄', label: 'Ciclo de cultivo', desc: 'La vida de la mata etapa por etapa (fenología)' },
+            ],
+        },
+        {
+            titulo: 'Sembrar y hacer seguimiento',
+            desc: 'De la semilla a la cosecha',
+            items: [
+                { view: 'germinacion', emoji: '🫘', label: 'Semilleros', desc: 'Pruebe sus semillas y vea cuáles nacen' },
+                { view: 'sembrar', emoji: '🌽', label: 'Registrar una siembra', desc: 'Anote lo que sembró y arranca su ciclo' },
+                { view: 'activos', emoji: '🪴', label: 'Mis matas', desc: 'Las plantas que tiene sembradas y cómo van' },
+                { view: 'cosechar', emoji: '🧺', label: 'Cosechar', desc: 'Anote lo que recogió' },
+            ],
+        },
+    ];
+
+    return (
+        <ScreenShell title="Cultivos y semillas" onBack={onBack}>
+            <div className="mch" data-testid="mundo-cultivos-hub">
+                {/* Portada ilustrada del mundo (SVG propio, rsvg-safe). */}
+                <header className="mch-hero">
+                    <HeroCultivos />
+                    <div className="mch-hero-txt">
+                        <h1 className="mch-hero-tit">
+                            <span aria-hidden="true">🌱</span> Cultivos y semillas
+                        </h1>
+                        <p className="mch-hero-lema">
+                            Qué sembrar, cuándo, y cómo van sus matas. Empiece por su región.
+                        </p>
+                    </div>
+                </header>
+
+                {/* Orientación: régimen de lluvia → ventanas de siembra (grounded). */}
+                <section className="mch-orienta" aria-labelledby="mch-orienta-tit">
+                    <h2 id="mch-orienta-tit" className="mch-h2">
+                        <span aria-hidden="true">🌧️</span> ¿Cuándo se siembra en su tierra?
+                    </h2>
+                    <p className="mch-sub">
+                        No hay una fecha para toda Colombia: se siembra al empezar las lluvias.
+                        Elija su región.
+                    </p>
+                    <div className="mch-seg" role="radiogroup" aria-label="Régimen de lluvia">
+                        {REGIMENES_LLUVIA.map((r) => (
+                            <button
+                                key={r.id}
+                                type="button"
+                                role="radio"
+                                aria-checked={regimenId === r.id}
+                                className={`mch-seg-btn ${regimenId === r.id ? 'is-on' : ''}`}
+                                onClick={() => setRegimenId(r.id)}
+                                data-testid={`regimen-${r.id}`}
+                            >
+                                {r.nombre}
+                            </button>
+                        ))}
+                    </div>
+                    <div className="mch-ventanas" data-testid="ventanas-siembra">
+                        <p className="mch-ventanas-desc">{regimen.desc}</p>
+                        <div className="mch-ventanas-grid">
+                            {regimen.ventanas.map((v) => (
+                                <div key={v.label} className="mch-ventana">
+                                    <b>{v.label}</b>
+                                    <span><i>Siembra:</i> {v.siembra}</span>
+                                    <span><i>Cosecha:</i> {v.cosecha}</span>
+                                </div>
+                            ))}
+                        </div>
+                        <p className="mch-nota">
+                            {regimen.nota} <span className="mch-fuente">({regimen.fuente})</span>
+                        </p>
+                    </div>
+                </section>
+
+                {/* Las funciones existentes, agrupadas — cada una re-rutea. */}
+                {grupos.map((g) => (
+                    <section key={g.titulo} className="mch-grupo" aria-label={g.titulo}>
+                        <h2 className="mch-h2">{g.titulo}</h2>
+                        <p className="mch-sub">{g.desc}</p>
+                        <nav className="mch-laminas">
+                            {g.items.map((it) => (
+                                <button
+                                    key={it.view}
+                                    type="button"
+                                    className="mch-lamina"
+                                    data-testid={`lamina-${it.view}`}
+                                    onClick={() => onNavigate?.(it.view)}
+                                    aria-label={`${it.label}: ${it.desc}`}
+                                >
+                                    <span className="mch-lamina-ic" aria-hidden="true">{it.emoji}</span>
+                                    <span className="mch-lamina-txt">
+                                        <b>{it.label}</b>
+                                        <small>{it.desc}</small>
+                                    </span>
+                                    <span className="mch-lamina-ir" aria-hidden="true">→</span>
+                                </button>
+                            ))}
+                        </nav>
+                    </section>
+                ))}
+
+                {/* Calculadora de grados-día — el reloj térmico, determinista. */}
+                <section className="mch-grupo" aria-labelledby="mch-calc-tit">
+                    <button
+                        type="button"
+                        className={`mch-calc-toggle ${calcAbierta ? 'is-open' : ''}`}
+                        aria-expanded={calcAbierta}
+                        aria-controls="mch-calc-panel"
+                        onClick={() => setCalcAbierta((v) => !v)}
+                        data-testid="calc-toggle"
+                    >
+                        <span className="mch-lamina-ic" aria-hidden="true">🌡️</span>
+                        <span className="mch-lamina-txt">
+                            <b id="mch-calc-tit">Calculadora de grados-día</b>
+                            <small>Por qué en tierra fría la misma mata tarda más</small>
+                        </span>
+                        <span className="mch-lamina-ir" aria-hidden="true">{calcAbierta ? '▲' : '▼'}</span>
+                    </button>
+                    {calcAbierta && (
+                        <div id="mch-calc-panel">
+                            <CalculadoraGradosDia />
+                        </div>
+                    )}
+                </section>
+
+                {/* Saber cultural: calendario lunar, con respeto (no agronomía dura). */}
+                <section className="mch-luna" aria-label="Calendario lunar">
+                    <span className="mch-luna-ic" aria-hidden="true">🌙</span>
+                    <p>
+                        <b>El calendario lunar</b> es saber campesino que vale para organizar las
+                        labores (creciente para lo de porte alto; menguante para raíces como la
+                        papa). No promete más cosecha: es cultura, no receta.{' '}
+                        <span className="mch-fuente">(R43, R44)</span>
+                    </p>
+                </section>
+
+                {/* El agente, siempre a la mano, con el contexto del mundo. */}
+                <button
+                    type="button"
+                    className="mch-agente"
+                    data-testid="mch-agente"
+                    onClick={() => onNavigate?.('agente')}
+                    aria-label="Pregúntele a Chagra sobre cultivos y semillas"
+                >
+                    <span aria-hidden="true">💬</span>
+                    <span>
+                        <b>Pregúntele a Chagra</b>
+                        <small>Cualquier duda sobre qué y cuándo sembrar, con su fuente.</small>
+                    </span>
+                </button>
+            </div>
+        </ScreenShell>
+    );
+}
+
+/**
+ * HeroCultivos — ilustración propia de la portada (mismo lenguaje vector que las
+ * viñetas de mundo: horizonte + tierra + foco). rsvg-safe: sin filtros, sin
+ * foreignObject, sin <text> con emoji. El movimiento (si acaso) lo pone el CSS y
+ * respeta reduced-motion.
+ */
+function HeroCultivos() {
+    return (
+        <svg
+            className="mch-hero-svg"
+            viewBox="0 0 320 120"
+            preserveAspectRatio="xMidYMid slice"
+            aria-hidden="true"
+        >
+            {/* cielo de mañana */}
+            <rect width="320" height="120" fill="#eaf3da" />
+            <circle cx="268" cy="30" r="16" fill="#ffe08a" />
+            <circle cx="268" cy="30" r="9" fill="#fff3c4" />
+            {/* cordillera (pisos térmicos: el fondo azulado del frío) */}
+            <path d="M-4 58 L46 30 L96 52 L150 26 L210 50 L272 28 L324 48 V120 H-4 Z" fill="#bcd6a6" />
+            {/* laderas de cultivo en verde escalonado */}
+            <path d="M-4 64 Q70 46 150 62 T324 56 V120 H-4 Z" fill="#9bc172" />
+            <path d="M-4 82 Q90 66 180 80 T324 76 V120 H-4 Z" fill="#6fa356" />
+            {/* surcos en perspectiva */}
+            <g stroke="#4c7a3d" strokeWidth="3" strokeLinecap="round" fill="none" opacity=".5">
+                <path d="M40 120 L86 84" />
+                <path d="M96 120 L120 84" />
+                <path d="M164 120 L166 84" />
+                <path d="M236 120 L214 84" />
+                <path d="M300 120 L266 84" />
+            </g>
+            {/* matas de maíz jóvenes */}
+            <g stroke="#2f6b3a" strokeWidth="2.8" strokeLinecap="round" fill="none">
+                <g><path d="M118 100 v-20" /><path d="M118 90 q-9 -4 -13 -12" /><path d="M118 85 q9 -4 13 -12" /></g>
+                <g><path d="M196 96 v-18" /><path d="M196 88 q-8 -4 -12 -11" /><path d="M196 83 q8 -4 12 -11" /></g>
+            </g>
+            {/* semilla germinando, primer plano */}
+            <g transform="translate(58 92)">
+                <ellipse cx="0" cy="10" rx="9" ry="6" fill="#8a5a38" />
+                <path d="M0 8 v-11" stroke="#5a9e4b" strokeWidth="3" strokeLinecap="round" fill="none" />
+                <path d="M0 -3 q-7 -2 -9 -9" stroke="#5a9e4b" strokeWidth="3" strokeLinecap="round" fill="none" />
+                <path d="M0 -3 q7 -2 9 -9" stroke="#5a9e4b" strokeWidth="3" strokeLinecap="round" fill="none" />
+            </g>
+        </svg>
+    );
+}

--- a/src/components/cultivos/__tests__/MundoCultivosHub.test.jsx
+++ b/src/components/cultivos/__tests__/MundoCultivosHub.test.jsx
@@ -1,0 +1,97 @@
+/**
+ * MundoCultivosHub — la PORTADA del mundo cultivos. Contrato:
+ *   1. Orienta por región (régimen de lluvia) antes de sembrar.
+ *   2. Cada lámina RE-RUTEA a su pantalla real (onNavigate), no reimplementa.
+ *   3. La calculadora de grados-día calcula determinista (maíz frío = 4.5 °D/día).
+ *   4. El agente queda a la mano.
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+import MundoCultivosHub from '../MundoCultivosHub';
+import CalculadoraGradosDia from '../CalculadoraGradosDia';
+
+afterEach(() => cleanup());
+
+describe('MundoCultivosHub — portada del mundo cultivos', () => {
+    test('renderiza el hub con hero y orientación por región', () => {
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={vi.fn()} />);
+        expect(screen.getByTestId('mundo-cultivos-hub')).toBeInTheDocument();
+        expect(screen.getByTestId('regimen-bimodal')).toBeInTheDocument();
+        expect(screen.getByTestId('regimen-unimodal')).toBeInTheDocument();
+        // Por defecto abre en bimodal (Andes) → dos semestres de siembra.
+        const ventanas = screen.getByTestId('ventanas-siembra');
+        expect(within(ventanas).getByText(/Semestre A/)).toBeInTheDocument();
+        expect(within(ventanas).getByText(/Semestre B/)).toBeInTheDocument();
+    });
+
+    test('el régimen unimodal muestra una sola ventana de siembra', () => {
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={vi.fn()} />);
+        fireEvent.click(screen.getByTestId('regimen-unimodal'));
+        const ventanas = screen.getByTestId('ventanas-siembra');
+        expect(within(ventanas).getByText(/Única/)).toBeInTheDocument();
+        expect(within(ventanas).queryByText(/Semestre B/)).toBeNull();
+    });
+
+    test('cada lámina re-rutea a su vista real existente', () => {
+        const onNavigate = vi.fn();
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={onNavigate} />);
+        const esperadas = ['directorio', 'calendario_finca', 'ciclo', 'germinacion', 'sembrar', 'activos', 'cosechar'];
+        for (const view of esperadas) {
+            fireEvent.click(screen.getByTestId(`lamina-${view}`));
+            expect(onNavigate).toHaveBeenCalledWith(view);
+        }
+    });
+
+    test('la calculadora de grados-día se despliega y calcula (maíz frío = 4.5)', () => {
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={vi.fn()} />);
+        // Cerrada por defecto: la portada se lee primero.
+        expect(screen.queryByTestId('calc-grados-dia')).toBeNull();
+        fireEvent.click(screen.getByTestId('calc-toggle'));
+        expect(screen.getByTestId('calc-grados-dia')).toBeInTheDocument();
+        expect(screen.getByTestId('calc-por-dia')).toHaveTextContent('4.5');
+    });
+
+    test('el agente queda a la mano al pie', () => {
+        const onNavigate = vi.fn();
+        render(<MundoCultivosHub onBack={vi.fn()} onNavigate={onNavigate} />);
+        fireEvent.click(screen.getByTestId('mch-agente'));
+        expect(onNavigate).toHaveBeenCalledWith('agente');
+    });
+});
+
+describe('CalculadoraGradosDia — determinista y honesta', () => {
+    test('cambiar de piso térmico recalcula los grados-día por día', () => {
+        render(<CalculadoraGradosDia />);
+        // Arranca en tierra fría → maíz 4.5 °D/día.
+        expect(screen.getByTestId('calc-por-dia')).toHaveTextContent('4.5');
+        // Tierra templada → 10.5 °D/día.
+        fireEvent.click(screen.getByTestId('calc-piso-templado'));
+        expect(screen.getByTestId('calc-por-dia')).toHaveTextContent('10.5');
+    });
+
+    test('cultivo manual muestra el campo de temperatura base', () => {
+        render(<CalculadoraGradosDia />);
+        expect(screen.queryByTestId('calc-tb-manual')).toBeNull();
+        fireEvent.click(screen.getByTestId('calc-cultivo-manual'));
+        expect(screen.getByTestId('calc-tb-manual')).toBeInTheDocument();
+    });
+
+    test('con fecha de siembra estima la etapa por fenología', () => {
+        render(<CalculadoraGradosDia />);
+        fireEvent.change(screen.getByTestId('calc-fecha'), { target: { value: '2020-01-01' } });
+        const etapa = screen.getByTestId('calc-etapa');
+        // Fecha muy pasada → maíz ya en grano seco (último hito), sin próxima.
+        expect(within(etapa).getByText(/Grano seco/)).toBeInTheDocument();
+        expect(within(etapa).getByText(/grados-día acumulados/)).toBeInTheDocument();
+    });
+
+    test('temperaturas invertidas muestran aviso, no un número falso', () => {
+        render(<CalculadoraGradosDia />);
+        fireEvent.change(screen.getByTestId('calc-tmax'), { target: { value: '3' } });
+        expect(screen.queryByTestId('calc-por-dia')).toBeNull();
+        expect(screen.getByText(/no puede ser menor/)).toBeInTheDocument();
+    });
+});

--- a/src/components/cultivos/mundo-cultivos-hub.css
+++ b/src/components/cultivos/mundo-cultivos-hub.css
@@ -1,0 +1,496 @@
+/* ============================================================================
+   mundo-cultivos-hub.css — PORTADA del mundo 🌱 CULTIVOS Y SEMILLAS.
+
+   Identidad: CUADERNO DE CAMPO. Todo son láminas de papel crema con tinta verde
+   (Baloo 2 en títulos, Nunito en cuerpo). Al ser "papel", el hub se lee bien
+   sobre los 4 temas (biopunk oscuro, nature, minimalista, verde-vivo) sin
+   depender de las variables --c-* del tema: es una hoja pegada encima.
+
+   Namespace propio `.mch-` para no colisionar con las portadas hermanas de los
+   otros mundos (cada agente trae su prefijo). Legible al sol: tinta oscura,
+   labels en negrita, jerarquía sin depender del color. rsvg-safe en los SVG.
+   prefers-reduced-motion: sin animaciones ni lifts.
+   ========================================================================== */
+
+.mch {
+  --mch-papel: #fffdf6;
+  --mch-papel-2: #f4f6ea;
+  --mch-tinta: #26331f;
+  --mch-tinta-suave: #4e5c42;
+  --mch-verde: #3f8f4e;
+  --mch-verde-hondo: #2f6b3a;
+  --mch-ocre: #b98a2f;
+  --mch-display: 'Baloo 2', 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --mch-body: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 12px 14px 28px;
+  font-family: var(--mch-body);
+  color: var(--mch-tinta);
+}
+
+/* ── Portada ilustrada ─────────────────────────────────────────────────────── */
+.mch-hero {
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-bottom: 4px solid var(--mch-verde);
+  box-shadow: 0 3px 14px rgba(38, 51, 31, 0.12);
+  background: #eaf3da;
+}
+.mch-hero-svg {
+  display: block;
+  width: 100%;
+  height: 128px;
+}
+.mch-hero-txt {
+  padding: 12px 14px 14px;
+  background: var(--mch-papel);
+  border-top: 1px solid rgba(38, 51, 31, 0.1);
+}
+.mch-hero-tit {
+  margin: 0;
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 22px;
+  line-height: 1.15;
+  color: var(--mch-tinta);
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.mch-hero-lema {
+  margin: 5px 0 0;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 600;
+  color: var(--mch-tinta-suave);
+}
+
+/* ── Secciones y encabezados ───────────────────────────────────────────────── */
+.mch-orienta,
+.mch-grupo {
+  margin-top: 20px;
+}
+.mch-h2 {
+  margin: 0;
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 17px;
+  line-height: 1.2;
+  color: var(--mch-tinta);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+/* hilo cosido del cuaderno bajo cada título de sección */
+.mch-h2::after {
+  content: '';
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: repeating-linear-gradient(90deg,
+    color-mix(in srgb, var(--mch-verde) 55%, transparent) 0 5px,
+    transparent 5px 9px);
+  opacity: 0.6;
+}
+.mch-sub {
+  margin: 4px 0 10px;
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--mch-tinta-suave);
+  max-width: 52ch;
+}
+
+/* ── Orientación por régimen de lluvia ─────────────────────────────────────── */
+.mch-seg {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.mch-seg-btn {
+  flex: 1 1 auto;
+  min-height: 46px;
+  padding: 8px 12px;
+  border-radius: 13px;
+  border: 1.5px solid rgba(38, 51, 31, 0.16);
+  background: var(--mch-papel);
+  color: var(--mch-tinta);
+  font-family: var(--mch-body);
+  font-weight: 700;
+  font-size: 12.5px;
+  line-height: 1.25;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.mch-seg-btn.is-on {
+  border-color: var(--mch-verde);
+  background: color-mix(in srgb, var(--mch-verde) 12%, var(--mch-papel));
+  box-shadow: inset 0 0 0 1px var(--mch-verde);
+}
+.mch-seg-btn:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 2px;
+}
+
+.mch-ventanas {
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-left: 4px solid var(--mch-ocre);
+  border-radius: 12px;
+  background: var(--mch-papel);
+  padding: 11px 13px;
+  box-shadow: 0 1px 6px rgba(38, 51, 31, 0.07);
+}
+.mch-ventanas-desc {
+  margin: 0 0 9px;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--mch-tinta);
+}
+.mch-ventanas-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 9px;
+}
+.mch-ventana {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 9px 11px;
+  border-radius: 10px;
+  background: var(--mch-papel-2);
+  border: 1px solid rgba(38, 51, 31, 0.1);
+}
+.mch-ventana b {
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 13px;
+  color: var(--mch-verde-hondo);
+}
+.mch-ventana span {
+  font-size: 11.5px;
+  line-height: 1.35;
+  color: var(--mch-tinta);
+}
+.mch-ventana i {
+  font-style: normal;
+  font-weight: 700;
+  color: var(--mch-tinta-suave);
+}
+.mch-nota {
+  margin: 9px 0 0;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--mch-tinta-suave);
+}
+.mch-fuente {
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--mch-ocre);
+  white-space: nowrap;
+}
+
+/* ── Láminas de función (re-rutean a pantallas existentes) ─────────────────── */
+.mch-laminas {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.mch-lamina,
+.mch-calc-toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 60px;
+  padding: 10px 12px;
+  border-radius: 15px;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  background: var(--mch-papel);
+  color: var(--mch-tinta);
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 1px 6px rgba(38, 51, 31, 0.07);
+  transition: transform 140ms ease, box-shadow 140ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.mch-lamina:active,
+.mch-calc-toggle:active { transform: scale(0.988); }
+@media (hover: hover) {
+  .mch-lamina:hover,
+  .mch-calc-toggle:hover { box-shadow: 0 4px 14px rgba(38, 51, 31, 0.13); }
+}
+.mch-lamina:focus-visible,
+.mch-calc-toggle:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 2px;
+}
+.mch-lamina-ic {
+  flex: 0 0 auto;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  font-size: 22px;
+  border-radius: 12px;
+  background: var(--mch-papel-2);
+  border: 1px solid color-mix(in srgb, var(--mch-verde) 40%, transparent);
+}
+.mch-lamina-txt {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.mch-lamina-txt b {
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 14.5px;
+  line-height: 1.2;
+}
+.mch-lamina-txt small {
+  font-size: 11.5px;
+  line-height: 1.3;
+  color: var(--mch-tinta-suave);
+}
+.mch-lamina-ir {
+  flex: 0 0 auto;
+  font-weight: 800;
+  color: var(--mch-verde);
+  opacity: 0.85;
+}
+.mch-calc-toggle.is-open { border-color: var(--mch-verde); }
+
+/* ── Calculadora de grados-día ─────────────────────────────────────────────── */
+.mch-calc {
+  margin-top: 10px;
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-radius: 16px;
+  background: var(--mch-papel);
+  padding: 13px 14px 14px;
+  box-shadow: 0 1px 6px rgba(38, 51, 31, 0.07);
+}
+.mch-calc-intro {
+  margin: 0 0 12px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--mch-tinta);
+}
+.mch-calc-grupo {
+  border: 0;
+  border-top: 1px dashed rgba(38, 51, 31, 0.18);
+  margin: 0;
+  padding: 12px 0 4px;
+}
+.mch-calc-grupo:first-of-type { border-top: 0; padding-top: 0; }
+.mch-calc-grupo legend {
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 13.5px;
+  color: var(--mch-verde-hondo);
+  padding: 0;
+  margin-bottom: 8px;
+}
+.mch-calc-grupo legend small {
+  font-weight: 600;
+  color: var(--mch-tinta-suave);
+}
+.mch-calc-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 9px;
+}
+.mch-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-height: 40px;
+  padding: 6px 11px;
+  border-radius: 11px;
+  border: 1.5px solid rgba(38, 51, 31, 0.16);
+  background: var(--mch-papel-2);
+  color: var(--mch-tinta);
+  font-family: var(--mch-body);
+  font-weight: 700;
+  font-size: 12.5px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: border-color 140ms ease, background 140ms ease;
+}
+.mch-chip small {
+  font-weight: 600;
+  font-size: 10px;
+  color: var(--mch-tinta-suave);
+}
+.mch-chip.is-on {
+  border-color: var(--mch-verde);
+  background: color-mix(in srgb, var(--mch-verde) 14%, var(--mch-papel));
+  box-shadow: inset 0 0 0 1px var(--mch-verde);
+}
+.mch-chip:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 2px;
+}
+.mch-calc-temps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+}
+.mch-calc-campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--mch-tinta-suave);
+}
+.mch-calc-campo input {
+  min-height: 44px;
+  padding: 8px 11px;
+  border-radius: 11px;
+  border: 1.5px solid rgba(38, 51, 31, 0.2);
+  background: #fff;
+  color: var(--mch-tinta);
+  font-family: var(--mch-body);
+  font-size: 15px;
+  font-weight: 700;
+}
+.mch-calc-campo input:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 1px;
+  border-color: var(--mch-verde);
+}
+.mch-calc-nota {
+  margin: 8px 0 0;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--mch-tinta-suave);
+}
+.mch-calc-aviso {
+  margin: 12px 0;
+  padding: 10px 12px;
+  border-radius: 11px;
+  background: #fbeecf;
+  border: 1px solid var(--mch-ocre);
+  color: #6b4e12;
+  font-size: 12px;
+  font-weight: 700;
+}
+.mch-calc-resultado {
+  margin: 12px 0;
+  padding: 12px 14px;
+  border-radius: 13px;
+  background: color-mix(in srgb, var(--mch-verde) 10%, var(--mch-papel));
+  border: 1px solid color-mix(in srgb, var(--mch-verde) 35%, transparent);
+}
+.mch-calc-big {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+}
+.mch-calc-big b {
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 30px;
+  line-height: 1;
+  color: var(--mch-verde-hondo);
+}
+.mch-calc-big span {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--mch-tinta-suave);
+}
+.mch-calc-porque {
+  margin: 9px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--mch-tinta);
+}
+.mch-calc-etapa {
+  margin-top: 10px;
+  padding: 11px 13px;
+  border-radius: 12px;
+  background: var(--mch-papel-2);
+  border: 1px solid rgba(38, 51, 31, 0.12);
+}
+.mch-calc-etapa p { margin: 0 0 6px; font-size: 12.5px; line-height: 1.4; }
+.mch-calc-etapa p:last-child { margin-bottom: 0; }
+.mch-calc-etapa-actual b { color: var(--mch-verde-hondo); }
+.mch-calc-etapa-prox { color: var(--mch-tinta-suave); }
+.mch-calc-pie {
+  margin: 12px 0 0;
+  font-size: 10.5px;
+  line-height: 1.4;
+  color: var(--mch-tinta-suave);
+  font-style: italic;
+}
+
+/* ── Saber cultural: calendario lunar ──────────────────────────────────────── */
+.mch-luna {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  margin-top: 20px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: color-mix(in srgb, #3a4a7a 8%, var(--mch-papel));
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-left: 4px solid #5b6ea8;
+}
+.mch-luna-ic { font-size: 22px; line-height: 1.2; flex: 0 0 auto; }
+.mch-luna p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--mch-tinta);
+}
+
+/* ── El agente al pie ──────────────────────────────────────────────────────── */
+.mch-agente {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 20px;
+  min-height: 58px;
+  padding: 10px 14px;
+  border-radius: 15px;
+  border: 1.5px dashed var(--mch-verde);
+  background: color-mix(in srgb, var(--mch-papel-2) 60%, var(--mch-papel));
+  color: var(--mch-tinta);
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.mch-agente > span:first-child { font-size: 22px; }
+.mch-agente b {
+  display: block;
+  font-family: var(--mch-display);
+  font-weight: 800;
+  font-size: 14.5px;
+}
+.mch-agente small {
+  display: block;
+  font-size: 11.5px;
+  color: var(--mch-tinta-suave);
+}
+.mch-agente:focus-visible {
+  outline: 3px solid var(--mch-verde);
+  outline-offset: 2px;
+}
+
+/* ── Accesibilidad de movimiento ───────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .mch-lamina,
+  .mch-calc-toggle,
+  .mch-seg-btn,
+  .mch-chip { transition: none; }
+  .mch-lamina:active,
+  .mch-calc-toggle:active { transform: none; }
+}

--- a/src/components/dashboard/MundosDeMiFinca.jsx
+++ b/src/components/dashboard/MundosDeMiFinca.jsx
@@ -30,7 +30,8 @@ export default function MundosDeMiFinca({ onNavigate, mostrarAnimales = true, pl
     const mundos = MUNDOS_FINCA.filter((m) => m.gate !== 'animales' || mostrarAnimales);
 
     const abrir = (m) => {
-        if (m.directo) onNavigate?.(m.directo.view, m.directo.data);
+        if (m.portada) onNavigate?.(m.portada);
+        else if (m.directo) onNavigate?.(m.directo.view, m.directo.data);
         else onNavigate?.('mundo', { mundo: m.id });
     };
 

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -152,9 +152,10 @@ describe('Home F2 — reestructuración 2.0 "Los mundos de mi finca" (V4)', () =
     render(<DashboardLive onNavigate={onNavigate} />);
     await screen.findByTestId('bloque-mundos');
 
-    // Mundo con entradas → pantalla de mundo.
+    // Cultivos tiene PORTADA a medida (hub) → navega a su vista propia.
     fireEvent.click(screen.getByTestId('mundo-cultivos'));
-    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'cultivos' });
+    expect(onNavigate).toHaveBeenCalledWith('mundo_cultivos');
+    // Mundo con entradas y sin portada → pantalla de mundo genérica.
     fireEvent.click(screen.getByTestId('mundo-mercado'));
     expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'mercado' });
 

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -29,6 +29,10 @@
  *   featured — true = tarjeta grande (ancho completo) en la grilla.
  *   directo  — {view, data}: el mundo ES una sola pantalla → la tarjeta navega
  *              directo (sin pantalla intermedia de mundo).
+ *   portada  — view de una PORTADA de mundo a medida (hub ilustrado) que
+ *              reemplaza a la MundoScreen genérica: la tarjeta y el índice
+ *              navegan ahí. Convive con `entradas` (que siguen congelando la
+ *              reachability y sirven de fallback genérico si hiciera falta).
  *   entradas — funciones del mundo: {view, label, desc, emoji, data?}.
  *              `view` SIEMPRE es un case real de App.jsx.
  */
@@ -41,6 +45,9 @@ export const MUNDOS_FINCA = [
         lema: 'Qué sembrar, cuándo, y cómo van sus matas',
         tinte: ['#3f8f4e', '#dcedc9'],
         featured: true,
+        // Portada a medida (hub del mundo cultivos): orienta por región/clima,
+        // agrupa las funciones existentes y suma la calculadora de grados-día.
+        portada: 'mundo_cultivos',
         entradas: [
             { view: 'directorio', label: 'Qué puedo sembrar', desc: 'Especies para su clima, con qué se llevan y sus plagas', emoji: '🌱' },
             { view: 'calendario_finca', label: 'Calendario de la finca', desc: 'Cuándo sembrar, abonar y cosechar, todo junto', emoji: '🗓️' },

--- a/src/services/__tests__/gradosDiaCalculator.test.js
+++ b/src/services/__tests__/gradosDiaCalculator.test.js
@@ -1,0 +1,136 @@
+/**
+ * gradosDiaCalculator — cálculo DETERMINISTA de grados-día. El contrato: los
+ * números salen del método modificado del promedio (grounding R30) y la etapa
+ * de la fenología en DÍAS (grounded), nunca inventados.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+    CULTIVOS_GDD,
+    CULTIVO_GDD_BY_ID,
+    PISOS_TERMICOS,
+    REGIMENES_LLUVIA,
+    gddDia,
+    gddAcumulado,
+    diasTranscurridos,
+    estimarEtapa,
+    compararRitmo,
+} from '../gradosDiaCalculator';
+
+describe('gddDia — método modificado del promedio', () => {
+    test('maíz en tierra fría (Tb=10): clampa la mínima a 10', () => {
+        // tmin 7 < Tb 10 → 10; (10+19)/2 - 10 = 4.5
+        expect(gddDia(7, 19, 10, 30)).toBe(4.5);
+    });
+
+    test('maíz en tierra templada acumula más calor por día', () => {
+        // (15+26)/2 - 10 = 10.5
+        expect(gddDia(15, 26, 10, 30)).toBe(10.5);
+    });
+
+    test('clampa la máxima a la temperatura tope To', () => {
+        // tmax 35 > To 30 → 30; (20+30)/2 - 10 = 15
+        expect(gddDia(20, 35, 10, 30)).toBe(15);
+    });
+
+    test('día por debajo de la base → 0 grados-día (nunca negativo)', () => {
+        expect(gddDia(2, 8, 10, 30)).toBe(0);
+    });
+
+    test('sin To (null) no aplica tope superior', () => {
+        // papa Tb=5, sin cap: (7+25)/2 - 5 = 11
+        expect(gddDia(7, 25, 5, null)).toBe(11);
+    });
+
+    test('entradas no numéricas → 0 (robustez)', () => {
+        expect(gddDia(NaN, 20, 10, 30)).toBe(0);
+        expect(gddDia(10, undefined, 10, 30)).toBe(0);
+    });
+});
+
+describe('gddAcumulado — acumulación por N días a ritmo constante', () => {
+    test('maíz frío por 10 días = 45 °D', () => {
+        expect(gddAcumulado(7, 19, 10, 30, 10)).toBe(45);
+    });
+    test('días negativos o cero → 0', () => {
+        expect(gddAcumulado(15, 26, 10, 30, 0)).toBe(0);
+        expect(gddAcumulado(15, 26, 10, 30, -5)).toBe(0);
+    });
+    test('trunca días fraccionarios', () => {
+        expect(gddAcumulado(15, 26, 10, 30, 3.9)).toBe(31.5); // 10.5*3
+    });
+});
+
+describe('diasTranscurridos', () => {
+    test('cuenta días enteros entre dos fechas', () => {
+        expect(diasTranscurridos('2026-01-01', '2026-01-11')).toBe(10);
+    });
+    test('futuro o fecha inválida → 0', () => {
+        expect(diasTranscurridos('2026-02-01', '2026-01-01')).toBe(0);
+        expect(diasTranscurridos('no-es-fecha', '2026-01-01')).toBe(0);
+    });
+});
+
+describe('estimarEtapa — por fenología en días (grounded)', () => {
+    test('maíz recién sembrado: siembra → próxima emergencia', () => {
+        const e = estimarEtapa('maiz', 0);
+        expect(e.actual.id).toBe('siembra');
+        expect(e.proxima.id).toBe('emergencia');
+        expect(e.diasParaProxima).toBe(8);
+    });
+
+    test('maíz a los 50 días va en crecimiento, sigue floración', () => {
+        const e = estimarEtapa('maiz', 50);
+        expect(e.actual.id).toBe('vegetativo');
+        expect(e.proxima.id).toBe('floracion');
+        expect(e.diasParaProxima).toBe(10);
+    });
+
+    test('pasado el último hito no hay próxima etapa', () => {
+        const e = estimarEtapa('maiz', 200);
+        expect(e.actual.id).toBe('grano_seco');
+        expect(e.proxima).toBeNull();
+        expect(e.diasParaProxima).toBeNull();
+    });
+
+    test('papa a los 90 días va en tuberización', () => {
+        const e = estimarEtapa('papa', 90);
+        expect(e.actual.id).toBe('tuberizacion');
+    });
+
+    test('cultivo manual (sin fenología) → null honesto', () => {
+        expect(estimarEtapa('manual', 30)).toBeNull();
+    });
+});
+
+describe('compararRitmo — evidencia de "tarda más en tierra fría"', () => {
+    test('maíz: templado junta más °D/día que frío (factor > 1)', () => {
+        const r = compararRitmo('maiz', 'templado', 'frio');
+        expect(r.calido).toBe(10.5);
+        expect(r.frio).toBe(4.5);
+        expect(r.factor).toBeGreaterThan(1);
+    });
+    test('ids desconocidos → null', () => {
+        expect(compararRitmo('maiz', 'x', 'frio')).toBeNull();
+    });
+});
+
+describe('datos groundeados — integridad del set', () => {
+    test('maíz y papa traen Tb y fuente citada', () => {
+        expect(CULTIVO_GDD_BY_ID.maiz.tb).toBe(10);
+        expect(CULTIVO_GDD_BY_ID.maiz.to).toBe(30);
+        expect(CULTIVO_GDD_BY_ID.maiz.fuente).toMatch(/R30/);
+        expect(CULTIVO_GDD_BY_ID.papa.tb).toBe(5);
+        expect(CULTIVO_GDD_BY_ID.papa.fuente).toMatch(/R31/);
+    });
+    test('todo cultivo tiene id, nombre y Tb numérica', () => {
+        for (const c of CULTIVOS_GDD) {
+            expect(typeof c.id).toBe('string');
+            expect(typeof c.nombre).toBe('string');
+            expect(Number.isFinite(c.tb)).toBe(true);
+        }
+    });
+    test('los pisos térmicos y regímenes existen para la orientación', () => {
+        expect(PISOS_TERMICOS.length).toBeGreaterThanOrEqual(4);
+        expect(REGIMENES_LLUVIA.map((r) => r.id)).toEqual(['bimodal', 'unimodal']);
+    });
+});

--- a/src/services/gradosDiaCalculator.js
+++ b/src/services/gradosDiaCalculator.js
@@ -1,0 +1,246 @@
+/**
+ * gradosDiaCalculator — el "reloj térmico" del cultivo (grados-día de desarrollo).
+ * ============================================================================
+ * Calculadora DETERMINISTA de grados-día acumulados (GDD): en vez de contar días
+ * calendario, cuenta el CALOR que la mata acumula por encima de su temperatura
+ * base (Tb). Explica por qué el mismo cultivo tarda más en tierra fría — "acumula
+ * menos calor por día" — la intuición campesina detrás de los GDD.
+ *
+ * GROUNDING (deepresearch 2026-07-04-cultivos-clima-nacional-CO.md):
+ *   · Maíz: Tb = 10 °C, To = 30 °C (método modificado: si Tmín<10 se usa 10; si
+ *     Tmáx>30 se usa 30). Fuente R30 (SciELO/Rev. Chapingo) — confianza alta.
+ *   · Papa: Tb típica 4–7 °C según el modelo. Fuente R31 (SciELO) — media-alta.
+ *     El valor único usado por AGROSAVIA para papa colombiana está PENDIENTE de
+ *     cierre (grounded-pendiente); usamos 5 °C como representativo del rango.
+ *   · Fenología en días (para estimar etapa) — grounded:
+ *       Papa (altiplano cundiboyacense, AGROSAVIA R10): emergencia 30–35 dds,
+ *       floración ~40–50 dds, tuberización 80–90 dds, madurez ~165–170 dds.
+ *       Maíz ICA V-305 (R18): ~100 días a choclo, ~170 a grano seco.
+ *       Maíz ICA V-109 (R18): ~70–80 días a choclo, ~120 a grano seco.
+ *
+ * REGLA DE INTEGRIDAD: no se inventan umbrales. Los umbrales de etapa por GDD
+ * (cuántos °D hasta floración/cosecha) NO están en el grounding → se marcan
+ * grounded-pendiente y la ETAPA se estima por fenología en DÍAS (que sí está
+ * groundeada), no por GDD. La calculadora entrega los GDD como el "porqué" del
+ * ritmo, y los días como el "qué etapa".
+ *
+ * Todo son funciones puras (sin estado, sin red) → fáciles de testear y de
+ * confiar. Los presets de piso térmico son REFERENCIA EDITABLE (confianza media):
+ * el campesino ajusta Tmín/Tmáx a su finca; el cálculo usa lo que él confirme.
+ */
+
+/**
+ * @typedef {Object} CultivoGDD
+ * @property {string} id            clave estable
+ * @property {string} nombre        nombre campesino
+ * @property {string} emoji
+ * @property {number} tb            temperatura base (°C)
+ * @property {number|null} to       temperatura tope (°C) o null si no se aplica cap
+ * @property {string} tbNota        procedencia/confianza de la Tb
+ * @property {string} fuente        referencia del grounding
+ * @property {Array<{id:string,label:string,desc:string,dds:number}>} [fenologia]
+ *   hitos fenológicos en días-después-de-siembra (dds), en orden ascendente.
+ * @property {string} [fenologiaFuente]
+ */
+
+/** Cultivos con Tb groundeada. `manual` deja al usuario fijar su propia Tb. */
+export const CULTIVOS_GDD = /** @type {CultivoGDD[]} */ ([
+    {
+        id: 'maiz',
+        nombre: 'Maíz',
+        emoji: '🌽',
+        tb: 10,
+        to: 30,
+        tbNota: 'Tb 10 °C, tope 30 °C (método modificado). Confianza alta.',
+        fuente: 'R30 — Rev. Chapingo / SciELO',
+        fenologia: [
+            { id: 'siembra', label: 'Siembra', desc: 'Semilla en el surco', dds: 0 },
+            { id: 'emergencia', label: 'Emergencia', desc: 'Asoma la matica', dds: 8 },
+            { id: 'vegetativo', label: 'Crecimiento', desc: 'Hoja y tallo', dds: 35 },
+            { id: 'floracion', label: 'Floración', desc: 'Espiga y jilote', dds: 60 },
+            { id: 'choclo', label: 'Choclo', desc: 'Mazorca tierna (V-305)', dds: 100 },
+            { id: 'grano_seco', label: 'Grano seco', desc: 'Madurez de cosecha (V-305)', dds: 170 },
+        ],
+        fenologiaFuente: 'R18 — ICA V-305 (V-109: choclo 70–80 d / grano 120 d)',
+    },
+    {
+        id: 'papa',
+        nombre: 'Papa',
+        emoji: '🥔',
+        tb: 5,
+        to: null,
+        tbNota: 'Tb 4–7 °C según modelo; usamos 5 °C. Valor AGROSAVIA exacto: pendiente.',
+        fuente: 'R31 — SciELO (tiempo térmico papa)',
+        fenologia: [
+            { id: 'siembra', label: 'Siembra', desc: 'Tubérculo-semilla enterrado', dds: 0 },
+            { id: 'emergencia', label: 'Emergencia', desc: 'Brota la planta', dds: 32 },
+            { id: 'floracion', label: 'Floración', desc: 'Flor de la papa', dds: 45 },
+            { id: 'tuberizacion', label: 'Tuberización', desc: 'Cuaja el tubérculo', dds: 85 },
+            { id: 'madurez', label: 'Madurez', desc: 'Lista para arrancar', dds: 167 },
+        ],
+        fenologiaFuente: 'R10 — AGROSAVIA, altiplano cundiboyacense',
+    },
+    {
+        id: 'manual',
+        nombre: 'Otro cultivo (Tb a mano)',
+        emoji: '🌱',
+        tb: 10,
+        to: null,
+        tbNota: 'Fije la temperatura base de su cultivo. Confírmela con su técnico.',
+        fuente: 'grounded-pendiente',
+    },
+]);
+
+/** Mapa id → cultivo. */
+export const CULTIVO_GDD_BY_ID = Object.fromEntries(CULTIVOS_GDD.map((c) => [c.id, c]));
+
+/**
+ * Presets de piso térmico: Tmín/Tmáx TÍPICOS de un día, coherentes con las
+ * temperaturas medias del grounding (cálido ~24+, templado ~17–24, frío ~12–17,
+ * páramo <10). Son REFERENCIA EDITABLE (confianza media): el amplitud diurna es
+ * una aproximación; el usuario ajusta a su finca. No son norma dura.
+ */
+export const PISOS_TERMICOS = [
+    { id: 'calido', nombre: 'Tierra caliente', rango: '0–1000 m', tmin: 20, tmax: 30, media: '~24 °C+' },
+    { id: 'templado', nombre: 'Tierra templada (café)', rango: '1000–2000 m', tmin: 15, tmax: 26, media: '~17–24 °C' },
+    { id: 'frio', nombre: 'Tierra fría (papa)', rango: '2000–3000 m', tmin: 7, tmax: 19, media: '~12–17 °C' },
+    { id: 'paramo', nombre: 'Páramo', rango: '>3000 m', tmin: 3, tmax: 13, media: '<10 °C' },
+];
+
+/**
+ * Régimen de lluvias → ventanas de siembra (grounding R16/R17). El calendario
+ * campesino se ancla al INICIO de las lluvias, no a un mes fijo.
+ */
+export const REGIMENES_LLUVIA = [
+    {
+        id: 'bimodal',
+        nombre: 'Región Andina (bimodal)',
+        desc: 'Dos temporadas de lluvia → dos siembras al año.',
+        ventanas: [
+            { label: 'Semestre A', siembra: 'marzo–mayo', cosecha: 'julio–agosto' },
+            { label: 'Semestre B', siembra: 'septiembre–noviembre', cosecha: 'diciembre–enero' },
+        ],
+        nota: 'Siembre apenas se estabilicen las primeras lluvias. "Mitaca" = la segunda cosecha del año.',
+        fuente: 'R16, R17',
+    },
+    {
+        id: 'unimodal',
+        nombre: 'Llanos, Caribe, Amazonía, Pacífico (unimodal)',
+        desc: 'Una sola temporada de lluvia → una siembra al año.',
+        ventanas: [
+            { label: 'Única', siembra: 'al arrancar las lluvias (mitad de año)', cosecha: 'según el ciclo del cultivo' },
+        ],
+        nota: 'La seca va aproximadamente de diciembre a marzo.',
+        fuente: 'R16',
+    },
+];
+
+/**
+ * Grados-día de UN día por el método modificado del promedio.
+ * Regla del grounding: clampa Tmín y Tmáx al rango [Tb, To] antes de promediar
+ * ("si Tmín<10 se usa 10; si Tmáx>30 se usa 30"). Nunca negativo.
+ *
+ * @param {number} tmin  temperatura mínima del día (°C)
+ * @param {number} tmax  temperatura máxima del día (°C)
+ * @param {number} tb    temperatura base del cultivo (°C)
+ * @param {number|null} [to]  temperatura tope (°C) o null/undefined = sin cap
+ * @returns {number} grados-día del día (≥ 0)
+ */
+export function gddDia(tmin, tmax, tb, to = null) {
+    if (![tmin, tmax, tb].every((v) => Number.isFinite(v))) return 0;
+    let lo = tmin;
+    let hi = tmax;
+    if (Number.isFinite(to)) {
+        if (hi > to) hi = to;
+        if (lo > to) lo = to;
+    }
+    if (lo < tb) lo = tb;
+    if (hi < tb) hi = tb;
+    const media = (lo + hi) / 2;
+    const gdd = media - tb;
+    return gdd > 0 ? gdd : 0;
+}
+
+/**
+ * GDD acumulados sobre N días a un ritmo térmico constante (Tmín/Tmáx típicos).
+ * Determinista: N × gddDia. Redondeado a 1 decimal para lectura.
+ *
+ * @param {number} tmin
+ * @param {number} tmax
+ * @param {number} tb
+ * @param {number|null} to
+ * @param {number} dias  número de días (se trunca a entero ≥ 0)
+ * @returns {number} GDD acumulados
+ */
+export function gddAcumulado(tmin, tmax, tb, to, dias) {
+    const n = Math.max(0, Math.trunc(dias || 0));
+    const porDia = gddDia(tmin, tmax, tb, to);
+    return Math.round(porDia * n * 10) / 10;
+}
+
+/**
+ * Días transcurridos entre dos fechas (YYYY-MM-DD o Date), ≥ 0.
+ * @param {string|Date} desde
+ * @param {string|Date} [hasta] por defecto hoy
+ * @returns {number} días enteros
+ */
+export function diasTranscurridos(desde, hasta = new Date()) {
+    const a = desde instanceof Date ? desde : new Date(`${desde}T00:00:00`);
+    const b = hasta instanceof Date ? hasta : new Date(`${hasta}T00:00:00`);
+    if (Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return 0;
+    const ms = b.getTime() - a.getTime();
+    return Math.max(0, Math.floor(ms / 86400000));
+}
+
+/**
+ * Estima la ETAPA fenológica por días-después-de-siembra usando la fenología
+ * GROUNDED en días (no por GDD, cuyos umbrales están pendientes). Devuelve el
+ * hito actual y el próximo, con los días que faltan.
+ *
+ * @param {string} cultivoId
+ * @param {number} dds  días desde la siembra
+ * @returns {null | {actual: object, proxima: object|null, diasParaProxima: number|null}}
+ */
+export function estimarEtapa(cultivoId, dds) {
+    const cultivo = CULTIVO_GDD_BY_ID[cultivoId];
+    if (!cultivo || !Array.isArray(cultivo.fenologia) || cultivo.fenologia.length === 0) {
+        return null;
+    }
+    const hitos = cultivo.fenologia;
+    const d = Math.max(0, Math.trunc(dds || 0));
+    let actual = hitos[0];
+    let proxima = null;
+    for (let i = 0; i < hitos.length; i += 1) {
+        if (d >= hitos[i].dds) {
+            actual = hitos[i];
+            proxima = hitos[i + 1] || null;
+        } else {
+            proxima = proxima || hitos[i];
+            break;
+        }
+    }
+    // Si ya pasó el último hito, no hay próxima.
+    if (d >= hitos[hitos.length - 1].dds) proxima = null;
+    const diasParaProxima = proxima ? proxima.dds - d : null;
+    return { actual, proxima, diasParaProxima };
+}
+
+/**
+ * Compara el ritmo térmico (GDD/día) de dos pisos térmicos para el mismo
+ * cultivo — la evidencia visible de "en tierra fría tarda más". Determinista.
+ *
+ * @param {string} cultivoId
+ * @param {string} pisoCalidoId  piso más cálido (referencia)
+ * @param {string} pisoFrioId    piso más frío (comparación)
+ * @returns {null | {calido:number, frio:number, factor:number}}
+ */
+export function compararRitmo(cultivoId, pisoCalidoId, pisoFrioId) {
+    const cultivo = CULTIVO_GDD_BY_ID[cultivoId];
+    const pc = PISOS_TERMICOS.find((p) => p.id === pisoCalidoId);
+    const pf = PISOS_TERMICOS.find((p) => p.id === pisoFrioId);
+    if (!cultivo || !pc || !pf) return null;
+    const calido = gddDia(pc.tmin, pc.tmax, cultivo.tb, cultivo.to);
+    const frio = gddDia(pf.tmin, pf.tmax, cultivo.tb, cultivo.to);
+    const factor = frio > 0 ? Math.round((calido / frio) * 10) / 10 : Infinity;
+    return { calido: Math.round(calido * 10) / 10, frio: Math.round(frio * 10) / 10, factor };
+}


### PR DESCRIPTION
## 🌱 Hub del mundo CULTIVOS Y SEMILLAS + calculadora de grados-día

Portada a medida del mundo **cultivos** (V4 reestructuración de mundos): una **portada bonita que unifica y da entrada elegante a las funciones que YA existen** — no reimplementa ninguna. Cada lámina **re-rutea** (`onNavigate`) a su pantalla real de `App.jsx`.

### Qué enlaza (pantallas existentes, sin tocarlas)
- **Qué puedo sembrar** → `directorio` (directorio de especies)
- **Calendario de la finca** → `calendario_finca`
- **Ciclo de cultivo (fenología)** → `ciclo`
- **Semilleros** → `germinacion`
- **Registrar una siembra** → `sembrar`
- **Mis matas** → `activos`
- **Cosechar** → `cosechar`
- **Pregúntele a Chagra** → `agente`

### Lo nuevo (solo visual + cálculo determinista)
- **Orientación por región**: selector régimen **bimodal andino** (semestre A mar–may / B sep–nov) vs **unimodal** (una siembra) — el calendario campesino no es una fecha universal.
- **Calculadora de grados-día** determinista: método modificado del promedio, Tb por cultivo; muestra por qué en tierra fría la misma mata tarda más y estima la etapa por fenología en días.
- Identidad **cuaderno de campo**, **SVG propio** rsvg-safe, **4 temas** (láminas de papel), **reduced-motion**. Sin red.

### Grounding (`2026-07-04-cultivos-clima-nacional-CO.md`)
- Maíz **Tb=10 / To=30** (R30); papa **Tb 4–7 → 5** (R31).
- Fenología en días: papa R10 (AGROSAVIA), maíz ICA V-305/V-109 R18.
- Ventanas de siembra R16/R17. Calendario lunar presentado como **saber cultural, no agronomía dura** (R43/R44).

### Slots grounded-pendiente
- **Tb exacta de papa** usada por AGROSAVIA (usamos 5 °C del rango 4–7).
- **To (tope)** de papa y del cultivo manual (sin cap superior por ahora).
- **Umbrales de etapa por grados-día** (la etapa se estima por fenología en días, que sí está groundeada).
- **Kc / variedades exactas** por cultivo.
- Presets de piso térmico Tmín/Tmáx = **referencia editable** (confianza media), ajustables por el usuario.

### Cableado limpio (colisión con mundos hermanos)
`mundosFinca.js` gana el campo **`portada`** (convive con `entradas` → reachability intacta); `MundosDeMiFinca` y `MundoScreen` lo respetan; `App.jsx` enruta `case 'mundo_cultivos'`.

### Verificación
- Build verde (`vite build` ✓).
- Tests: `gradosDiaCalculator` (21) · `MundoCultivosHub` (9) · reachability (8) · `DashboardLive.redistribucion` actualizado (11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)