### PR TITLE
feat(agente): «Chagra enseña a usar Chagra» — ayuda groundeada + deep-link

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -52,6 +52,12 @@ import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities,
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
 // el chip cuyo backend aún no existe (deep).
 import { planForcedIntent, isStubIntent, isDeepResearchIntent, CHIP_DEFS } from '../../services/chipIntentRouter';
+// «Chagra enseña a usar Chagra» (ayuda groundeada): detecta preguntas META
+// («¿cómo uso X?», «¿qué puede hacer Chagra?», «¿dónde veo los precios?») y
+// responde DESDE el manifiesto (ayudaFunciones) — sin LLM, nunca inventa una
+// función que no existe, y evita el misroute meta→get_species.
+import { detectMetaAyudaIntent } from '../../services/metaAyudaIntent';
+import { buildAyudaResponse } from '../../services/ayudaAgentResponder';
 // #349 — router heurístico de GROUNDING para el path de FALLO del NLU. Cuando
 // `planNlu` devuelve null (timeout/fail del sidecar bajo contención de GPU), el
 // turno NO debe saltarse el grounding: este router PURO deriva el tool obvio
@@ -2586,6 +2592,37 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
     // chip activo → rutean por el NLU normal.
     let firstForcedIntent = forcedIntent;
 
+    // «CHAGRA ENSEÑA A USAR CHAGRA» (ayuda groundeada) — solo texto libre (sin
+    // chip, sin foto). Si el usuario pregunta CÓMO usar una función, QUÉ puede
+    // hacer Chagra o DÓNDE ve algo, respondemos DESDE el manifiesto de ayuda
+    // (determinístico, sin LLM): nunca inventa una función que no existe y de
+    // paso evita el misroute meta→get_species → «el catálogo no tiene esa
+    // especie». Adjuntamos la acción de deep-link para el botón «Abrir …».
+    if (!forcedIntent && !visionContext && !suppressUserBubble) {
+      const meta = detectMetaAyudaIntent(trimmed);
+      if (meta.isMeta) {
+        const resp = buildAyudaResponse(meta);
+        if (resp && resp.content) {
+          const userMessage = { role: 'user', content: trimmed, timestamp: Date.now() };
+          const assistantMessage = {
+            role: 'assistant',
+            content: resp.content,
+            timestamp: Date.now(),
+            ...(resp.ayudaAction ? { _ayudaAction: resp.ayudaAction } : {}),
+          };
+          setMessages((prev) => [...prev, userMessage, assistantMessage]);
+          try {
+            await addTurn(operatorId, { role: 'user', content: trimmed });
+            await addTurn(operatorId, { role: 'assistant', content: resp.content });
+          } catch (e) {
+            console.warn('[Agent] ayuda addTurn failed (continuo):', e?.message);
+          }
+          setActiveIntent(null);
+          return;
+        }
+      }
+    }
+
     const route = selectChatRoute(trimmed);
     const result = useAgentQueueStore.getState().enqueue(trimmed, route);
 
@@ -2757,6 +2794,19 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
     });
     // Tras cualquier acción (o no-op de capacidad por lanzar) cerramos la mano.
     if (acted) setSheetOpen(false);
+  };
+
+  // Deep-link de una tarjeta de AYUDA («Abrir …» / «Preguntar: …»): navega a la
+  // vista con el MISMO mecanismo de la mano (onNavigate → HASH_VIEW_ROUTES) o,
+  // para capacidades tipo `ask`, siembra la pregunta insignia en el chat.
+  const handleAyudaAction = (action) => {
+    if (!action) return;
+    if (action.tipo === 'nav' && action.view) {
+      try { agentSounds.start(); } catch { /* sonido opcional */ }
+      if (onNavigate) onNavigate(action.view);
+    } else if (action.tipo === 'ask' && action.prompt) {
+      handleSubmit(action.prompt);
+    }
   };
 
   // ── Foto inline desde el compositor del AgentScreen ───────────────────────
@@ -3214,6 +3264,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         onRetryOrphan={handleRetryOrphan}
         onCancelDeepResearch={handleCancelDeepResearch}
         onDismissInsight={handleDismissInsight}
+        onAyudaAction={handleAyudaAction}
         proactiveGreeting={proactiveGreeting}
         onBack={onBack}
       />

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -29,7 +29,7 @@ const FLOATING_BACK_THRESHOLD_PX = 160;
  * @param {Object|null} [props.proactiveGreeting=null] - Datos del saludo proactivo dinámico.
  * @param {Function} props.onBack - Callback para volver a la pantalla anterior.
  */
-export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, onDismissInsight, proactiveGreeting = null, onBack }) {
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, onDismissInsight, onAyudaAction, proactiveGreeting = null, onBack }) {
   const bottomRef = useRef(null);
   const scrollRef = useRef(null);
   // (B) Botón "Volver" flotante: visible solo cuando el operador se alejó del
@@ -212,6 +212,22 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
                     : undefined
                 }
               />
+            )}
+            {/* AYUDA GROUNDED («Chagra enseña a usar Chagra»): deep-link a la
+                función que el agente acaba de explicar. Navega con el mismo
+                mecanismo de la mano (onNavigate) o siembra la pregunta insignia. */}
+            {msg._ayudaAction && typeof onAyudaAction === 'function' && (
+              <div className="mb-4 ml-12 -mt-2">
+                <button
+                  type="button"
+                  onClick={() => onAyudaAction(msg._ayudaAction)}
+                  data-testid="ayuda-deeplink"
+                  className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-full bg-emerald-600/90 hover:bg-emerald-500 text-white text-sm font-semibold shadow-lg active:scale-95 transition"
+                >
+                  <span aria-hidden>↗</span>
+                  <span>{msg._ayudaAction.label}</span>
+                </button>
+              </div>
             )}
           </React.Fragment>
         );

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -26,6 +26,7 @@ const FLOATING_BACK_THRESHOLD_PX = 160;
  * @param {Function} props.onConsentNeeded - Callback cuando se requiere consentimiento del usuario.
  * @param {Function} props.onRetryOrphan - Callback para reintentar un mensaje huérfano (sin respuesta).
  * @param {Function} props.onCancelDeepResearch - Callback para cancelar una investigación profunda en curso.
+ * @param {Function} [props.onAyudaAction] - Callback del deep-link «Abrir …» de la ayuda groundeada (AYUDA_FUNCIONES).
  * @param {Object|null} [props.proactiveGreeting=null] - Datos del saludo proactivo dinámico.
  * @param {Function} props.onBack - Callback para volver a la pantalla anterior.
  */

--- a/src/data/__tests__/ayudaFunciones.test.js
+++ b/src/data/__tests__/ayudaFunciones.test.js
@@ -36,13 +36,13 @@ describe('AYUDA_FUNCIONES — manifiesto derivado de CAPABILITY_MANIFEST', () =>
 describe('matchAyudaFuncion — match grounded', () => {
   it('«¿cómo registro una siembra?» → Registrar hablando (función real)', () => {
     const r = matchAyudaFuncion('como registro una siembra');
-    expect(r.found).toBe(true);
+    if (!r.found) throw new Error('se esperaba found:true');
     expect(r.funcion.id).toBe('procesos');
   });
 
   it('«dónde veo mis plantas» → Mis plantas, con vista de navegación', () => {
     const r = matchAyudaFuncion('donde veo mis plantas');
-    expect(r.found).toBe(true);
+    if (!r.found) throw new Error('se esperaba found:true');
     expect(r.funcion.id).toBe('plantas');
     expect(r.funcion.accion.tipo).toBe('nav');
     expect(r.funcion.accion.view).toBe('activos');
@@ -50,17 +50,22 @@ describe('matchAyudaFuncion — match grounded', () => {
 
   it('«el mapa de la finca» → mapa', () => {
     const r = matchAyudaFuncion('el mapa de la finca');
-    expect(r.found).toBe(true);
+    if (!r.found) throw new Error('se esperaba found:true');
     expect(r.funcion.id).toBe('mapa');
   });
 
   it('ANTI-ALUCINACIÓN: función inexistente → found:false + sugerencias reales', () => {
     const r = matchAyudaFuncion('como pido un dron con inteligencia artificial cuantica');
-    expect(r.found).toBe(false);
-    expect(Array.isArray(r.sugerencias)).toBe(true);
-    expect(r.sugerencias.length).toBeGreaterThan(0);
+    if (r.found) throw new Error('se esperaba found:false');
+    // tsc corre con strict:false (jsconfig.json): el narrowing de CFA no reduce
+    // el branch `found:false` de una unión discriminada por booleano tras un
+    // `throw` (limitación conocida sin strictNullChecks). Cast explícito,
+    // documentado, ya validado arriba por el `if`.
+    const { sugerencias } = /** @type {{ found: false, sugerencias: import('../ayudaFunciones.js').AyudaFuncion[] }} */ (r);
+    expect(Array.isArray(sugerencias)).toBe(true);
+    expect(sugerencias.length).toBeGreaterThan(0);
     // Todas las sugerencias son funciones REALES del manifiesto.
-    for (const s of r.sugerencias) {
+    for (const s of sugerencias) {
       expect(getAyudaFuncion(s.id)).not.toBeNull();
     }
   });

--- a/src/data/__tests__/ayudaFunciones.test.js
+++ b/src/data/__tests__/ayudaFunciones.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AYUDA_FUNCIONES,
+  matchAyudaFuncion,
+  listAyudaFunciones,
+  getAyudaFuncion,
+} from '../ayudaFunciones.js';
+import { buildAyudaResponse } from '../../services/ayudaAgentResponder.js';
+
+/**
+ * Tests del manifiesto de AYUDA groundeado («Chagra enseña a usar Chagra»).
+ * Contrato crítico: anti-alucinación (nunca inventa una función que no existe)
+ * + deep-link a la función real.
+ */
+describe('AYUDA_FUNCIONES — manifiesto derivado de CAPABILITY_MANIFEST', () => {
+  it('no está vacío y toda entrada tiene forma canónica', () => {
+    expect(AYUDA_FUNCIONES.length).toBeGreaterThan(10);
+    for (const f of AYUDA_FUNCIONES) {
+      expect(typeof f.id).toBe('string');
+      expect(f.nombre).toBeTruthy();
+      expect(typeof f.que_hace).toBe('string');
+      expect(Array.isArray(f.como_se_usa)).toBe(true);
+      expect(f.como_se_usa.length).toBeGreaterThan(0);
+      expect(f.accion && typeof f.accion.tipo).toBe('string');
+      expect(Array.isArray(f.keywords)).toBe(true);
+    }
+  });
+
+  it('las funciones de navegación tienen una vista destino (deep-link)', () => {
+    const navs = AYUDA_FUNCIONES.filter((f) => f.accion.tipo === 'nav');
+    expect(navs.length).toBeGreaterThan(3);
+    for (const f of navs) expect(f.accion.view).toBeTruthy();
+  });
+});
+
+describe('matchAyudaFuncion — match grounded', () => {
+  it('«¿cómo registro una siembra?» → Registrar hablando (función real)', () => {
+    const r = matchAyudaFuncion('como registro una siembra');
+    expect(r.found).toBe(true);
+    expect(r.funcion.id).toBe('procesos');
+  });
+
+  it('«dónde veo mis plantas» → Mis plantas, con vista de navegación', () => {
+    const r = matchAyudaFuncion('donde veo mis plantas');
+    expect(r.found).toBe(true);
+    expect(r.funcion.id).toBe('plantas');
+    expect(r.funcion.accion.tipo).toBe('nav');
+    expect(r.funcion.accion.view).toBe('activos');
+  });
+
+  it('«el mapa de la finca» → mapa', () => {
+    const r = matchAyudaFuncion('el mapa de la finca');
+    expect(r.found).toBe(true);
+    expect(r.funcion.id).toBe('mapa');
+  });
+
+  it('ANTI-ALUCINACIÓN: función inexistente → found:false + sugerencias reales', () => {
+    const r = matchAyudaFuncion('como pido un dron con inteligencia artificial cuantica');
+    expect(r.found).toBe(false);
+    expect(Array.isArray(r.sugerencias)).toBe(true);
+    expect(r.sugerencias.length).toBeGreaterThan(0);
+    // Todas las sugerencias son funciones REALES del manifiesto.
+    for (const s of r.sugerencias) {
+      expect(getAyudaFuncion(s.id)).not.toBeNull();
+    }
+  });
+});
+
+describe('listAyudaFunciones — catálogo', () => {
+  it('devuelve total y grupos no vacíos', () => {
+    const { total, grupos } = listAyudaFunciones();
+    expect(total).toBe(AYUDA_FUNCIONES.length);
+    expect(Object.keys(grupos).length).toBeGreaterThan(1);
+  });
+});
+
+describe('buildAyudaResponse — respuesta groundeada + deep-link', () => {
+  it('how-to con match → texto de la función + acción nav', () => {
+    const resp = buildAyudaResponse({ isMeta: true, kind: 'howto', consulta: 'donde veo mis plantas' });
+    expect(resp).not.toBeNull();
+    expect(resp.content).toContain('Mis plantas');
+    expect(resp.ayudaAction).toMatchObject({ tipo: 'nav', view: 'activos' });
+  });
+
+  it('capabilities → catálogo, sin acción única', () => {
+    const resp = buildAyudaResponse({ isMeta: true, kind: 'capabilities', consulta: 'que puede hacer chagra' });
+    expect(resp.content).toMatch(/funciones/i);
+    expect(resp.ayudaAction).toBeNull();
+  });
+
+  it('how-to SIN match → mensaje honesto (no inventa función)', () => {
+    const resp = buildAyudaResponse({ isMeta: true, kind: 'howto', consulta: 'quiero un tractor volador teletransportador' });
+    expect(resp.content).toMatch(/todav[ií]a no tengo esa funci[oó]n/i);
+    expect(resp.ayudaAction).toBeNull();
+  });
+
+  it('no-meta → null (sigue el flujo normal)', () => {
+    expect(buildAyudaResponse({ isMeta: false })).toBeNull();
+  });
+});

--- a/src/data/ayudaFunciones.js
+++ b/src/data/ayudaFunciones.js
@@ -1,0 +1,354 @@
+/*
+ * i18n (ADR-050): ayudaFunciones.js contiene copy user-facing en español
+ * Colombia (nombres de función, pasos de uso, "cuándo sirve") pendiente de
+ * migrar a src/config/messages.js. Se desactiva la regla a nivel de archivo,
+ * mismo criterio que agentCapabilities.js (de donde se DERIVA este manifiesto).
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+/**
+ * ayudaFunciones.js — MANIFIESTO DE AYUDA GROUNDED («Chagra enseña a usar Chagra»).
+ *
+ * FUENTE DE VERDAD para responder «¿cómo uso X?», «¿qué puede hacer Chagra?»,
+ * «¿dónde veo los precios?». Si una función NO está aquí, el agente NO la puede
+ * afirmar (anti-alucinación: nunca inventa funciones que no existen).
+ *
+ * NO se re-declaran capacidades: este archivo se DERIVA de la fuente única
+ * `agentCapabilities.js` (CAPABILITY_MANIFEST — «la mano de Chagra»). Aquí solo
+ * se ENRIQUECE cada capacidad LIVE con lo que necesita una respuesta de ayuda:
+ *   - nombre        → label del manifiesto
+ *   - que_hace      → desc del manifiesto
+ *   - como_se_usa   → pasos concretos (derivados del tipo de acción + overrides)
+ *   - cuando_sirve  → cuándo le sirve al campesino (curado, con fallback a desc)
+ *   - accion        → cómo se abre: nav (vista), ask (pregunta al agente), photo
+ *   - keywords      → sinónimos campesinos para el match de la consulta
+ *
+ * El deep-link usa el MISMO mecanismo de navegación de la app (`onNavigate(view)`
+ * / HASH_VIEW_ROUTES). Para capacidades `nav`, `accion.view` es la vista destino.
+ *
+ * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+
+import { CAPABILITY_MANIFEST } from '../services/agentCapabilities.js';
+
+/**
+ * Sinónimos/keywords campesinos por id de capacidad. Refuerzan el match de la
+ * consulta más allá del label. Todo en minúsculas y sin tildes (el matcher
+ * normaliza igual). NO inventan capacidades: solo son formas de nombrar las que
+ * ya existen en el manifiesto.
+ * @type {Record<string, string[]>}
+ */
+const KEYWORDS_EXTRA = Object.freeze({
+  plantas: ['mis plantas', 'mis cultivos', 'mis siembras', 'lo que tengo sembrado', 'inventario', 'activos', 'que tengo en la finca'],
+  procesos: ['registrar', 'anotar', 'registro', 'guardar lo que hago', 'apuntar', 'registrar hablando', 'registrar por voz', 'crear registro', 'anotar labor', 'como registro', 'como anoto'],
+  observaciones: ['anotar lo que veo', 'observacion', 'apunte', 'nota de campo', 'registrar observacion', 'anotar lo que vi'],
+  tareas: ['tareas', 'labores', 'pendientes', 'trabajos', 'que tengo que hacer', 'tareas de hoy', 'agenda'],
+  mapa: ['mapa', 'ubicacion', 'donde estan mis cultivos', 'croquis', 'plano de la finca'],
+  historial: ['cuaderno', 'cuaderno de campo', 'bitacora', 'historial', 'lo que anote', 'registros pasados', 'lo que hice'],
+  biodiversidad: ['biodiversidad', 'la vida de la finca', 'fauna', 'insectos', 'bichos beneficos'],
+  ciclo: ['ciclo del cultivo', 'etapas del cultivo', 'desarrollo del cultivo'],
+  germinacion: ['germinacion', 'prueba de semilla', 'sirve mi semilla', 'semilla viva', 'probar semilla'],
+  suelo: ['suelo', 'tierra', 'mi suelo', 'analisis de suelo', 'prueba de tierra', 'diagnostico de suelo'],
+  mercado: ['mercado', 'vender', 'marketplace', 'ofertas', 'publicar cosecha', 'vender la cosecha', 'mercado de la finca'],
+  precio: ['precio', 'precios', 'cuanto vale', 'a como esta', 'mercado mayorista', 'valor', 'donde veo los precios'],
+  aprender_hub: ['aprender', 'lecciones', 'aprende', 'ensename', 'curso', 'educacion'],
+  foto: ['foto', 'camara', 'tomar foto', 'identificar con foto', 'reconocer planta', 'foto de la mata', 'foto de la hoja'],
+  voz: ['agregar planta por voz', 'planta por voz', 'dictar planta'],
+  siembro: ['que siembro', 'que sembrar', 'sembrar', 'siembra'],
+  plaga: ['plaga', 'control de plagas', 'controlar plaga', 'bichos'],
+  biopreparado: ['biopreparado', 'caldo', 'purin', 'receta casera'],
+  clima: ['clima', 'tiempo', 'lluvia', 'pronostico'],
+  calendario: ['calendario', 'cuando sembrar', 'cuando cosechar', 'epoca de siembra'],
+  restauracion: ['restaurar', 'sembrar monte', 'nativas', 'reforestar', 'recuperar terreno'],
+  silvopastoreo: ['silvopastoreo', 'arboles para ganado', 'forraje'],
+  paramo: ['paramo', 'restaurar paramo'],
+  incendio: ['riesgo de incendio', 'incendio', 'quema'],
+  toxicidad: ['toxica', 'venenosa', 'comestible', 'se puede comer'],
+  saberes_tradicionales: ['saberes', 'glosario', 'saberes tradicionales'],
+  variedades: ['variedades', 'cultivares', 'que variedad'],
+  polinizacion: ['polinizacion', 'poliniza', 'colmenas', 'abejas'],
+  fenologia: ['fenologia', 'etapas de la planta', 'bbch'],
+  alerta_paramo: ['normativa paramo', 'ley 1930', 'se puede sembrar en el paramo'],
+  'alertas-cultivo': ['alertas', 'avisos', 'alertas del cultivo'],
+  'vender-mercados': ['vender mejor', 'a donde llevar la cosecha'],
+});
+
+/**
+ * «Cuándo le sirve» curado por id (opcional). Si no hay, se cae a `que_hace`.
+ * @type {Record<string, string>}
+ */
+const CUANDO_SIRVE = Object.freeze({
+  plantas: 'Cuando quieres ver, editar o revisar lo que tienes sembrado en la finca.',
+  procesos: 'Cuando hiciste o viste algo (siembra, cosecha, insumo, mantenimiento, observación o plaga) y quieres guardarlo hablando.',
+  observaciones: 'Cuando notas algo en el campo y quieres dejarlo anotado.',
+  tareas: 'Cuando quieres ver, crear o marcar como hechos los trabajos de la finca.',
+  mapa: 'Cuando quieres ubicar en un plano tus cultivos, tareas y hallazgos.',
+  historial: 'Cuando quieres consultar lo que ya registraste o realizaste.',
+  suelo: 'Cuando quieres diagnosticar tu tierra con pruebas caseras honestas.',
+  germinacion: 'Cuando dudas si tu semilla está viva antes de sembrarla.',
+  mercado: 'Cuando quieres publicar lo que vendes o ver ofertas de fincas vecinas.',
+  precio: 'Cuando quieres una referencia de precio mayorista del día.',
+  foto: 'Cuando no sabes qué planta es o si tiene plaga o enfermedad.',
+  siembro: 'Cuando quieres saber qué sembrar según tu clima y tu altura.',
+  plaga: 'Cuando tienes una plaga y quieres controlarla sin veneno.',
+  clima: 'Cuando quieres el clima de tu zona esta semana.',
+  calendario: 'Cuando quieres saber en qué mes sembrar o cosechar.',
+});
+
+/**
+ * Overrides de pasos concretos por id (opcional). Si no hay, se usan los pasos
+ * genéricos derivados del tipo de acción.
+ * @type {Record<string, string[]>}
+ */
+const PASOS_OVERRIDE = Object.freeze({
+  procesos: [
+    'Toca el botón Ⓐ (la mano de Chagra) y elige «Registrar hablando».',
+    'Cuéntale qué hiciste o viste; Chagra clasifica (siembra, cosecha, insumo, mantenimiento, observación o plaga) y lo guarda.',
+  ],
+  foto: [
+    'Toca el botón de cámara 📷 en el chat.',
+    'Tómale la foto a la mata: Chagra te dice qué es y si tiene plaga o enfermedad.',
+  ],
+  germinacion: [
+    'Abre «¿Sirve mi semilla?» desde la mano de Chagra (botón Ⓐ) o con el botón de abajo.',
+    'Sigue la prueba casera de germinación para saber si la semilla está viva.',
+  ],
+  suelo: [
+    'Abre «Mi suelo» desde la mano de Chagra (botón Ⓐ) o con el botón de abajo.',
+    'Haz las pruebas caseras que te indica para diagnosticar tu tierra.',
+  ],
+});
+
+/**
+ * Palabras vacías (stopwords) que NO deben derivarse como keyword de una función
+ * (evita que «con» de «Aprender con el agente» matchee cualquier consulta).
+ * @type {Set<string>}
+ */
+const STOPWORDS = new Set([
+  'con', 'del', 'los', 'las', 'una', 'uno', 'para', 'que', 'por', 'mis', 'tus',
+  'sus', 'esta', 'este', 'mata', 'agente', 'finca', 'como', 'ver',
+]);
+
+/**
+ * Normaliza texto para el match: minúsculas + sin tildes.
+ * @param {string} text
+ * @returns {string}
+ */
+export function normalizeAyuda(text) {
+  return String(text || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim();
+}
+
+/**
+ * Deriva la acción de apertura (deep-link) desde el `heroRoute` del manifiesto.
+ * @param {object} cap - entrada del CAPABILITY_MANIFEST.
+ * @returns {{ tipo: 'nav'|'ask'|'photo'|'chip', view?: string, prompt?: string, intent?: string }}
+ */
+function deriveAccion(cap) {
+  const hr = cap.heroRoute || {};
+  if (hr.kind === 'nav' && hr.view) return { tipo: 'nav', view: hr.view };
+  if (hr.kind === 'photo') return { tipo: 'photo' };
+  if (hr.kind === 'ask' && hr.prompt) {
+    return { tipo: 'ask', prompt: hr.prompt, ...(cap.intent ? { intent: cap.intent } : {}) };
+  }
+  // Sin heroRoute utilizable pero con chip → la abre el chip del ChipsToolbar.
+  if (cap.intent) return { tipo: 'chip', intent: cap.intent };
+  // Fallback honesto: sin ruta de apertura conocida → se describe, sin botón.
+  return { tipo: 'chip', intent: cap.id };
+}
+
+/**
+ * Pasos genéricos según el tipo de acción. Grounded: describen la navegación
+ * REAL de la app (mano de Chagra / chips / cámara).
+ * @param {string} nombre
+ * @param {{tipo:string, prompt?:string}} accion
+ * @returns {string[]}
+ */
+function pasosGenericos(nombre, accion) {
+  switch (accion.tipo) {
+    case 'nav':
+      return [
+        `Toca el botón Ⓐ (la mano de Chagra) y elige «${nombre}».`,
+        `O usa el botón «Abrir ${nombre}» aquí abajo.`,
+      ];
+    case 'photo':
+      return [
+        'Toca el botón de cámara 📷 en el chat.',
+        'Tómale la foto a tu planta para que Chagra la analice.',
+      ];
+    case 'ask':
+      return [
+        `Toca el chip «${nombre}» arriba del chat y escribe tu caso.`,
+        accion.prompt ? `También puedes preguntarme directo, por ejemplo: «${accion.prompt}».` : 'También puedes preguntarme directo por el chat.',
+      ];
+    case 'chip':
+    default:
+      return [
+        `Toca el chip «${nombre}» en la barra de herramientas del chat.`,
+        'Escribe tu consulta y Chagra te responde con datos del catálogo.',
+      ];
+  }
+}
+
+/**
+ * AYUDA_FUNCIONES — el manifiesto de ayuda, derivado de CAPABILITY_MANIFEST.
+ * Solo capacidades `status:'live'` (las que el campesino puede usar de verdad).
+ * Cada entrada es la forma canónica que consume el agente y la tarjeta de ayuda.
+ *
+ * @typedef {Object} AyudaFuncion
+ * @property {string} id
+ * @property {string} nombre
+ * @property {string} que_hace
+ * @property {string} cuando_sirve
+ * @property {string[]} como_se_usa
+ * @property {{tipo:string, view?:string, prompt?:string, intent?:string}} accion
+ * @property {string[]} keywords
+ * @property {string} grupo
+ *
+ * @type {ReadonlyArray<AyudaFuncion>}
+ */
+export const AYUDA_FUNCIONES = Object.freeze(
+  CAPABILITY_MANIFEST.filter((cap) => cap.status === 'live').map((cap) => {
+    const nombre = cap.label;
+    const accion = deriveAccion(cap);
+    const keywords = Array.from(
+      new Set([
+        // Tokens del nombre: solo palabras "de contenido" (≥4 chars, no stopword)
+        // para no derivar ruido como "con"/"del".
+        ...normalizeAyuda(nombre)
+          .split(/\s+/)
+          .filter((w) => w.length >= 4 && !STOPWORDS.has(w)),
+        ...(cap.group ? [normalizeAyuda(cap.group)] : []),
+        ...(KEYWORDS_EXTRA[cap.id] || []).map(normalizeAyuda),
+      ]),
+    );
+    return Object.freeze({
+      id: cap.id,
+      nombre,
+      que_hace: cap.desc || '',
+      cuando_sirve: CUANDO_SIRVE[cap.id] || cap.desc || '',
+      como_se_usa: PASOS_OVERRIDE[cap.id] || pasosGenericos(nombre, accion),
+      accion,
+      keywords,
+      grupo: cap.group || 'otras',
+    });
+  }),
+);
+
+/** Índice por id para acceso O(1). @type {Record<string, AyudaFuncion>} */
+const BY_ID = Object.freeze(
+  AYUDA_FUNCIONES.reduce((acc, f) => {
+    acc[f.id] = f;
+    return acc;
+  }, /** @type {Record<string, any>} */ ({})),
+);
+
+/**
+ * ¿`needle` aparece como palabra completa en `haystack`? Evita que un token
+ * corto sea tragado por una consulta larga.
+ * @param {string} haystack
+ * @param {string} needle
+ * @returns {boolean}
+ */
+function containsWord(haystack, needle) {
+  if (!needle) return false;
+  const tokens = haystack.split(/[^a-z0-9]+/).filter(Boolean);
+  return tokens.includes(needle);
+}
+
+/**
+ * Puntúa qué tan bien una función matchea la consulta. MAYOR = mejor (0 = sin
+ * match). Determinístico, sin fabricación.
+ *   100 = nombre o id exacto
+ *    70 = una keyword multi-palabra aparece como frase en la consulta
+ *    40 = una keyword de una palabra aparece como palabra en la consulta
+ *    20 = solapamiento de tokens del nombre con la consulta
+ * @param {AyudaFuncion} f
+ * @param {string} normQuery
+ * @returns {number}
+ */
+function scoreFuncion(f, normQuery) {
+  if (!normQuery) return 0;
+  const normNombre = normalizeAyuda(f.nombre);
+  if (normNombre === normQuery || f.id === normQuery) return 100;
+
+  let best = 0;
+  for (const kw of f.keywords) {
+    if (!kw) continue;
+    if (kw.includes(' ')) {
+      // keyword multi-palabra → match por frase (substring).
+      if (normQuery.includes(kw)) best = Math.max(best, 70);
+    } else if (kw.length >= 4 && !STOPWORDS.has(kw)) {
+      // keyword de una palabra: solo tokens de contenido (≥4, no stopword) para
+      // no matchear ruido. Palabra completa o substring largo.
+      if (containsWord(normQuery, kw) || normQuery.includes(kw)) best = Math.max(best, 40);
+    }
+  }
+  // Solapamiento de tokens del nombre.
+  const nombreTokens = normNombre.split(/\s+/).filter((w) => w.length >= 4);
+  for (const t of nombreTokens) {
+    if (containsWord(normQuery, t)) best = Math.max(best, 20);
+  }
+  return best;
+}
+
+/**
+ * matchAyudaFuncion — resuelve una consulta de ayuda contra el manifiesto.
+ *
+ * Diseño HONESTO (anti-alucinación): si NINGUNA función matchea, devuelve
+ * `found:false` con sugerencias reales del manifiesto — NUNCA inventa una
+ * función. La respuesta del agente debe reflejar ese `found:false` sin fabricar.
+ *
+ * @param {string} consulta - texto libre del usuario.
+ * @param {object} [opts]
+ * @param {number} [opts.limit=4] - máximo de alternativas a devolver.
+ * @returns {{ found: true, funcion: AyudaFuncion, alternativas: AyudaFuncion[] }
+ *   | { found: false, sugerencias: AyudaFuncion[] }}
+ */
+export function matchAyudaFuncion(consulta, opts = {}) {
+  const limit = Number.isInteger(opts.limit) && opts.limit > 0 ? opts.limit : 4;
+  const normQuery = normalizeAyuda(consulta);
+
+  const ranked = AYUDA_FUNCIONES
+    .map((f) => ({ f, score: scoreFuncion(f, normQuery) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score || a.f.nombre.length - b.f.nombre.length);
+
+  if (ranked.length === 0) {
+    // Sin match: sugerencias reales (las funciones más comunes), NO inventadas.
+    const sugeridas = ['plantas', 'procesos', 'tareas', 'siembro', 'plaga', 'clima']
+      .map((id) => BY_ID[id])
+      .filter(Boolean);
+    return { found: false, sugerencias: sugeridas };
+  }
+
+  return {
+    found: true,
+    funcion: ranked[0].f,
+    alternativas: ranked.slice(1, limit).map((x) => x.f),
+  };
+}
+
+/**
+ * listAyudaFunciones — todas las funciones LIVE, agrupadas por área. Para
+ * responder «¿qué puede hacer Chagra?».
+ * @returns {{ total: number, grupos: Record<string, AyudaFuncion[]> }}
+ */
+export function listAyudaFunciones() {
+  const grupos = /** @type {Record<string, any[]>} */ ({});
+  for (const f of AYUDA_FUNCIONES) {
+    (grupos[f.grupo] = grupos[f.grupo] || []).push(f);
+  }
+  return { total: AYUDA_FUNCIONES.length, grupos };
+}
+
+/**
+ * getAyudaFuncion — acceso directo por id (o null si no existe).
+ * @param {string} id
+ * @returns {AyudaFuncion|null}
+ */
+export function getAyudaFuncion(id) {
+  return BY_ID[id] || null;
+}

--- a/src/data/ayudaFunciones.js
+++ b/src/data/ayudaFunciones.js
@@ -193,10 +193,6 @@ function pasosGenericos(nombre, accion) {
 }
 
 /**
- * AYUDA_FUNCIONES — el manifiesto de ayuda, derivado de CAPABILITY_MANIFEST.
- * Solo capacidades `status:'live'` (las que el campesino puede usar de verdad).
- * Cada entrada es la forma canónica que consume el agente y la tarjeta de ayuda.
- *
  * @typedef {Object} AyudaFuncion
  * @property {string} id
  * @property {string} nombre
@@ -206,6 +202,12 @@ function pasosGenericos(nombre, accion) {
  * @property {{tipo:string, view?:string, prompt?:string, intent?:string}} accion
  * @property {string[]} keywords
  * @property {string} grupo
+ */
+
+/**
+ * AYUDA_FUNCIONES — el manifiesto de ayuda, derivado de CAPABILITY_MANIFEST.
+ * Solo capacidades `status:'live'` (las que el campesino puede usar de verdad).
+ * Cada entrada es la forma canónica que consume el agente y la tarjeta de ayuda.
  *
  * @type {ReadonlyArray<AyudaFuncion>}
  */

--- a/src/services/__tests__/metaAyudaIntent.test.js
+++ b/src/services/__tests__/metaAyudaIntent.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { detectMetaAyudaIntent } from '../metaAyudaIntent.js';
+
+/**
+ * Tests del detector de intención META/how-to («¿cómo uso Chagra?»). El
+ * contrato clave es de PRECISIÓN: NO robar consultas agronómicas. Ver
+ * metaAyudaIntent.js.
+ */
+describe('detectMetaAyudaIntent — SÍ es meta (sobre la app)', () => {
+  const metaQueries = [
+    '¿Qué puede hacer Chagra?',
+    '¿Qué funciones tiene la app?',
+    '¿Qué sabes hacer?',
+    '¿En qué me ayudas?',
+    '¿Cómo registro una cosecha?',
+    '¿Cómo anoto lo que vi hoy?',
+    '¿Cómo agrego una planta?',
+    '¿Cómo uso la app?',
+    '¿Dónde veo los precios?',
+    '¿Dónde está el mapa de la finca?',
+    '¿Cómo abro el cuaderno de campo?',
+    'no sé cómo usar esto',
+  ];
+  for (const q of metaQueries) {
+    it(`meta: "${q}"`, () => {
+      const r = detectMetaAyudaIntent(q);
+      expect(r.isMeta).toBe(true);
+      expect(['capabilities', 'howto']).toContain(r.kind);
+      expect(r.consulta).toBeTruthy();
+    });
+  }
+
+  it('«qué puede hacer» → kind capabilities', () => {
+    expect(detectMetaAyudaIntent('¿qué puede hacer Chagra?').kind).toBe('capabilities');
+  });
+});
+
+describe('detectMetaAyudaIntent — NO es meta (agronómico)', () => {
+  const agroQueries = [
+    '¿Cómo siembro maíz?',
+    '¿Cómo controlo la broca del café?',
+    '¿Cómo preparo un caldo bordelés?',
+    '¿Cómo cosecho la papa?',
+    '¿Qué le echo al pulgón?',
+    '¿Cuándo siembro el frijol?',
+    '¿Dónde consigo semilla de arveja?',
+    '¿Cómo va mi chagra este año?',
+    'para qué sirve el neem',
+    '¿qué plaga tiene mi tomate?',
+  ];
+  for (const q of agroQueries) {
+    it(`NO meta: "${q}"`, () => {
+      expect(detectMetaAyudaIntent(q).isMeta).toBe(false);
+    });
+  }
+});
+
+describe('detectMetaAyudaIntent — guardas', () => {
+  it('vacío / no-string → no meta', () => {
+    expect(detectMetaAyudaIntent('').isMeta).toBe(false);
+    expect(detectMetaAyudaIntent(null).isMeta).toBe(false);
+    expect(detectMetaAyudaIntent(undefined).isMeta).toBe(false);
+  });
+});

--- a/src/services/__tests__/metaAyudaIntent.test.js
+++ b/src/services/__tests__/metaAyudaIntent.test.js
@@ -20,6 +20,9 @@ describe('detectMetaAyudaIntent — SÍ es meta (sobre la app)', () => {
     '¿Dónde está el mapa de la finca?',
     '¿Cómo abro el cuaderno de campo?',
     'no sé cómo usar esto',
+    '¿Cómo uso la cámara?',
+    'qué hace el mundo de suelo',
+    'qué hace la sección de plagas',
   ];
   for (const q of metaQueries) {
     it(`meta: "${q}"`, () => {
@@ -47,6 +50,10 @@ describe('detectMetaAyudaIntent — NO es meta (agronómico)', () => {
     '¿Cómo va mi chagra este año?',
     'para qué sirve el neem',
     '¿qué plaga tiene mi tomate?',
+    'qué hace la broca del café',
+    'qué hace el pulgón en mi tomate',
+    'cómo uso la cámara fría para guardar la cosecha',
+    'cómo uso la cámara frigorífica',
   ];
   for (const q of agroQueries) {
     it(`NO meta: "${q}"`, () => {

--- a/src/services/ayudaAgentResponder.js
+++ b/src/services/ayudaAgentResponder.js
@@ -111,16 +111,20 @@ export function buildAyudaResponse(meta) {
   }
 
   // how-to: resolver la función concreta.
-  const m = matchAyudaFuncion(consulta);
-  if (m.found) {
+  const matchHowto = matchAyudaFuncion(consulta);
+  if (matchHowto.found) {
     return {
-      content: formatFuncion(m.funcion, m.alternativas),
-      ayudaAction: buildAction(m.funcion),
+      content: formatFuncion(matchHowto.funcion, matchHowto.alternativas),
+      ayudaAction: buildAction(matchHowto.funcion),
     };
   }
 
   // HONESTO — no hay función que matchee: NO inventamos. Ofrecemos las reales.
-  const sugeridas = (m.sugerencias || []).map((s) => s.nombre).join(', ');
+  // tsc corre con strict:false (jsconfig.json): el narrowing de CFA no reduce
+  // el branch `found:false` de la unión tras el `if` de arriba (limitación
+  // conocida sin strictNullChecks). Cast explícito, ya validado por el `if`.
+  const { sugerencias } = /** @type {{ found: false, sugerencias: import('../data/ayudaFunciones.js').AyudaFuncion[] }} */ (matchHowto);
+  const sugeridas = (sugerencias || []).map((s) => s.nombre).join(', ');
   const content =
     'Todavía no tengo esa función en Chagra. ' +
     (sugeridas

--- a/src/services/ayudaAgentResponder.js
+++ b/src/services/ayudaAgentResponder.js
@@ -1,0 +1,132 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+/**
+ * ayudaAgentResponder.js — Arma la RESPUESTA GROUNDED del agente para preguntas
+ * «¿cómo uso X?» / «¿qué puede hacer Chagra?».
+ *
+ * Toma la consulta (ya detectada como META por metaAyudaIntent) y la resuelve
+ * contra el manifiesto de ayuda (ayudaFunciones). La respuesta se compone
+ * DETERMINÍSTICAMENTE desde el manifiesto — sin LLM — así que NUNCA inventa una
+ * función que no existe (anti-alucinación por construcción).
+ *
+ * Devuelve `{ content, ayudaAction }`:
+ *   - content: texto en español colombiano para la burbuja del agente.
+ *   - ayudaAction: acción de deep-link para el botón «Abrir …» (o null). El
+ *     AgentScreen la adjunta al mensaje y ChatHistory pinta el botón, que navega
+ *     con el mecanismo existente (onNavigate → HASH_VIEW_ROUTES).
+ *
+ * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+
+import { matchAyudaFuncion, listAyudaFunciones } from '../data/ayudaFunciones.js';
+
+/** Etiquetas amables por grupo del manifiesto. */
+const GRUPO_LABEL = Object.freeze({
+  cultivo: '🌿 Tus cultivos',
+  cuidar: '🐛 Cuidar y sanar',
+  planear: '📅 Planear',
+  vender: '🛒 Vender',
+  restaurar: '🌳 Restaurar',
+  aprender: '📚 Aprender',
+  observar: '🔍 Observar',
+  registrar: '📝 Registrar',
+  otras: 'Otras funciones',
+});
+
+/**
+ * Construye la acción de deep-link para una función, o null si no es navegable.
+ * @param {import('../data/ayudaFunciones.js').AyudaFuncion} f
+ * @returns {{ label: string, view?: string, prompt?: string, tipo: string }|null}
+ */
+function buildAction(f) {
+  if (!f || !f.accion) return null;
+  if (f.accion.tipo === 'nav' && f.accion.view) {
+    return { tipo: 'nav', label: `Abrir ${f.nombre}`, view: f.accion.view };
+  }
+  if (f.accion.tipo === 'ask' && f.accion.prompt) {
+    return { tipo: 'ask', label: `Preguntar: ${f.nombre}`, prompt: f.accion.prompt };
+  }
+  return null;
+}
+
+/**
+ * Texto de una función matcheada.
+ * @param {import('../data/ayudaFunciones.js').AyudaFuncion} f
+ * @param {import('../data/ayudaFunciones.js').AyudaFuncion[]} alternativas
+ * @returns {string}
+ */
+function formatFuncion(f, alternativas) {
+  const pasos = f.como_se_usa.map((p, i) => `${i + 1}. ${p}`).join('\n');
+  let out = `**${f.nombre}** — ${f.que_hace}\n\n`;
+  out += `Cómo se usa:\n${pasos}\n`;
+  if (f.cuando_sirve && f.cuando_sirve !== f.que_hace) {
+    out += `\nCuándo te sirve: ${f.cuando_sirve}\n`;
+  }
+  if (alternativas && alternativas.length > 0) {
+    const otras = alternativas.map((a) => a.nombre).join(', ');
+    out += `\nSi buscabas otra cosa, también tengo: ${otras}.`;
+  }
+  return out.trim();
+}
+
+/**
+ * Texto del catálogo completo de funciones (para «¿qué puede hacer Chagra?»).
+ * @returns {string}
+ */
+function formatCapabilities() {
+  const { total, grupos } = listAyudaFunciones();
+  let out = `Chagra te ayuda con ${total} funciones. Estas son las principales:\n`;
+  for (const [grupo, funcs] of Object.entries(grupos)) {
+    const label = GRUPO_LABEL[grupo] || grupo;
+    const items = funcs.map((f) => `- ${f.nombre}: ${f.que_hace}`).join('\n');
+    out += `\n${label}\n${items}\n`;
+  }
+  out += '\nPregúntame «¿cómo uso ...?» por cualquiera de estas para que te guíe paso a paso.';
+  return out.trim();
+}
+
+/**
+ * buildAyudaResponse — respuesta groundeada para una consulta META.
+ *
+ * @param {{ isMeta: boolean, kind?: string, consulta?: string }} meta - salida
+ *   de detectMetaAyudaIntent.
+ * @returns {{ content: string, ayudaAction: object|null } | null} null si no es
+ *   META (el caller sigue el flujo normal).
+ */
+export function buildAyudaResponse(meta) {
+  if (!meta || !meta.isMeta) return null;
+  const consulta = meta.consulta || '';
+
+  // Catálogo completo si preguntó por capacidades y NO nombró una función
+  // concreta resoluble.
+  if (meta.kind === 'capabilities') {
+    const m = matchAyudaFuncion(consulta);
+    // Si además nombró una función concreta con match fuerte, guiamos a esa;
+    // si no, damos el catálogo.
+    if (!m.found) {
+      return { content: formatCapabilities(), ayudaAction: null };
+    }
+    // "qué puede hacer con el mapa" → describe el mapa; pero el caso típico
+    // ("qué puede hacer chagra") no matchea función → catálogo.
+    return { content: formatCapabilities(), ayudaAction: null };
+  }
+
+  // how-to: resolver la función concreta.
+  const m = matchAyudaFuncion(consulta);
+  if (m.found) {
+    return {
+      content: formatFuncion(m.funcion, m.alternativas),
+      ayudaAction: buildAction(m.funcion),
+    };
+  }
+
+  // HONESTO — no hay función que matchee: NO inventamos. Ofrecemos las reales.
+  const sugeridas = (m.sugerencias || []).map((s) => s.nombre).join(', ');
+  const content =
+    'Todavía no tengo esa función en Chagra. ' +
+    (sugeridas
+      ? `Lo que sí puedo hacer, por ejemplo: ${sugeridas}. Dime cuál te sirve y te guío.`
+      : 'Escríbeme «¿qué puede hacer Chagra?» y te muestro todo lo que tengo.');
+  return { content, ayudaAction: null };
+}
+
+export default { buildAyudaResponse };

--- a/src/services/metaAyudaIntent.js
+++ b/src/services/metaAyudaIntent.js
@@ -1,0 +1,111 @@
+/**
+ * metaAyudaIntent.js — Detector de intención META/how-to («¿cómo uso Chagra?»).
+ *
+ * Distingue una pregunta SOBRE Chagra (cómo se usa una función, qué puede hacer
+ * la app, dónde se ve algo) de una pregunta AGRONÓMICA (cómo se siembra, cómo se
+ * controla una plaga). Las primeras se ruteo a la ayuda groundeada
+ * (matchAyudaFuncion) en vez de a un tool de especie.
+ *
+ * Racional (fix de bug conocido): preguntas meta/generales misruteaban a
+ * get_species → el catálogo devolvía found:false → deflección inútil «el catálogo
+ * no tiene esa especie». Este detector las intercepta ANTES del NLU/tool.
+ *
+ * Diseño de PRECISIÓN ALTA: se prefiere NO disparar (dejar el flujo agronómico
+ * normal) antes que robar una consulta agronómica. Por eso:
+ *   - Verbos INEQUÍVOCOS de operar la app (registro/anoto/agrego/abro/accedo…)
+ *     disparan solos.
+ *   - Verbos AMBIGUOS (uso/veo/funciona) disparan SOLO junto a una referencia a
+ *     la app (chagra/la app/el agente/menú/pantalla…).
+ *   - Verbos agronómicos (siembro/cosecho/controlo/preparo) NUNCA disparan.
+ *
+ * Puro y sin red — testeable en aislamiento.
+ *
+ * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+
+/**
+ * Normaliza: minúsculas + sin tildes (ñ→n). Igual que el matcher de ayuda.
+ * @param {string} text
+ * @returns {string}
+ */
+function norm(text) {
+  return String(text || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim();
+}
+
+// Referencias a la app/el agente (NO al cultivo). "chagra" cuenta como nombre de
+// la app; en la práctica "¿cómo funciona chagra?" es meta y "¿cómo va mi chagra?"
+// no trae verbo-app, así que no dispara igual.
+const RE_APP_REF = /\b(chagra|la app|esta app|la aplicacion|esta aplicacion|el agente|el asistente|la herramienta|esta herramienta|el sistema|el aplicativo|el menu|un menu|el boton|la pantalla|la seccion|una seccion|la opcion|la mano de chagra|aqui en la app|en la app|de la app)\b/;
+
+// Pregunta por CAPACIDADES de la app → responder con el catálogo de funciones.
+const RE_CAPABILITIES = [
+  /\bque (puede|puedes|podes|sabe|sabes) hacer\b/,
+  /\bque (funciones|herramientas|capacidades|cosas)\b.*\b(tiene|tienes|hay|ofrece|maneja|puede|hace)\b/,
+  /\bque (funciones|herramientas|capacidades)\b/,
+  /\bque puedo hacer (con|en|aqui)\b/,
+  /\ben que me (ayuda|ayudas|puede ayudar|puedes ayudar)\b/,
+  /\bque mas (puedes|podes|sabes) hacer\b/,
+  /\bque haces\b/,
+  /\bpara que (sirve|me sirve|es|sirves)\b/, // se exige RE_APP_REF aparte
+];
+
+// Verbos INEQUÍVOCOS de operar la app (registrar/navegar). Disparan solos.
+const RE_APP_VERB_STRONG = /\bcomo (registro|registrar|anoto|anotar|apunto|apuntar|agrego|agregar|anado|anadir|guardo|guardar|creo|crear|ingreso|ingresar|abro|abrir|accedo|acceder|activo|activar|entro a|entrar a|llego a|llegar a|navego a)\b/;
+
+// Verbos AMBIGUOS: disparan SOLO con referencia a la app.
+const RE_APP_VERB_WEAK = /\bcomo (uso|usar|utilizo|utilizar|funciona|manejo esto|manejo la app|veo|ver|consulto|consultar|encuentro|encontrar|reviso|revisar)\b/;
+
+// Preguntas de UBICACIÓN dentro de la app (navegación). Excluyen compra/consecución.
+const RE_WHERE = /\b(donde (veo|encuentro|esta|estan|queda|miro|consulto|configuro|activo|reviso|puedo ver)|en que (parte|seccion|pantalla|menu)|como llego a)\b/;
+// Frases de ubicación que NO son de la app (comercio/agronomía) — bloquean RE_WHERE.
+const RE_WHERE_BLOCK = /\bdonde (consigo|compro|vendo|siembro|planto|cultivo|encuentro semilla|venden)\b/;
+
+// Frases sueltas de "no sé usar esto / ayúdame con la app".
+const RE_HELP_APP = /\b(no se como (usar|manejar|funciona)|como se (usa|maneja) (esto|la app|chagra)|ayuda con la app|como manejo la app|como funciona esto)\b/;
+
+/**
+ * Detecta si el texto es una pregunta META (sobre cómo usar Chagra) y de qué
+ * clase. Devuelve `{ isMeta:false }` cuando NO lo es (deja el flujo agronómico).
+ *
+ * @param {string} text - texto crudo del usuario.
+ * @returns {{ isMeta: boolean, kind?: 'capabilities'|'howto', consulta?: string }}
+ */
+export function detectMetaAyudaIntent(text) {
+  if (!text || typeof text !== 'string') return { isMeta: false };
+  const n = norm(text);
+  if (!n) return { isMeta: false };
+  const hasAppRef = RE_APP_REF.test(n);
+
+  // 1) Pregunta por capacidades → catálogo de funciones.
+  const isCapabilityQ = RE_CAPABILITIES.slice(0, 7).some((re) => re.test(n));
+  const isParaQueSirveApp = RE_CAPABILITIES[7].test(n) && hasAppRef;
+  if (isCapabilityQ || isParaQueSirveApp) {
+    return { isMeta: true, kind: 'capabilities', consulta: text.trim() };
+  }
+
+  // 2) Cómo operar la app (verbo fuerte, o débil + referencia a la app).
+  if (RE_APP_VERB_STRONG.test(n)) {
+    return { isMeta: true, kind: 'howto', consulta: text.trim() };
+  }
+  if (RE_APP_VERB_WEAK.test(n) && hasAppRef) {
+    return { isMeta: true, kind: 'howto', consulta: text.trim() };
+  }
+
+  // 3) Dónde está algo dentro de la app (navegación), sin frases de comercio.
+  if (RE_WHERE.test(n) && !RE_WHERE_BLOCK.test(n)) {
+    return { isMeta: true, kind: 'howto', consulta: text.trim() };
+  }
+
+  // 4) "No sé usar esto / ayuda con la app".
+  if (RE_HELP_APP.test(n)) {
+    return { isMeta: true, kind: hasAppRef || /esto|la app|chagra/.test(n) ? 'howto' : 'howto', consulta: text.trim() };
+  }
+
+  return { isMeta: false };
+}
+
+export default { detectMetaAyudaIntent };

--- a/src/services/metaAyudaIntent.js
+++ b/src/services/metaAyudaIntent.js
@@ -67,6 +67,18 @@ const RE_WHERE_BLOCK = /\bdonde (consigo|compro|vendo|siembro|planto|cultivo|enc
 // Frases sueltas de "no sé usar esto / ayúdame con la app".
 const RE_HELP_APP = /\b(no se como (usar|manejar|funciona)|como se (usa|maneja) (esto|la app|chagra)|ayuda con la app|como manejo la app|como funciona esto)\b/;
 
+// Cámara del chat (tomar foto de la mata): pregunta insignia «¿cómo uso la
+// cámara?» que NO siempre trae una referencia explícita a la app (RE_APP_REF).
+// Excluye "cámara fría/frigorífica" (cadena de frío poscosecha — agronómico,
+// NO la cámara de fotos del chat).
+const RE_CAMARA_APP = /\bcomo (uso|utilizo|activo|manejo|abro) (la |mi )?camara\b(?! (fria|frigorifica))/;
+
+// «Qué hace el mundo/la sección/el módulo de X» (pregunta por lo que ofrece
+// una PARTE de la app, no el catálogo completo). El marcador de navegación
+// (mundo/parte/sección/módulo de) es lo que la distingue de una pregunta
+// agronómica tipo «qué hace la broca del café» (sin ese marcador, NO dispara).
+const RE_QUE_HACE_SECCION = /\bque hace\b.*\b(el |la )?(mundo|parte|seccion|modulo|area) de\b/;
+
 /**
  * Detecta si el texto es una pregunta META (sobre cómo usar Chagra) y de qué
  * clase. Devuelve `{ isMeta:false }` cuando NO lo es (deja el flujo agronómico).
@@ -87,11 +99,21 @@ export function detectMetaAyudaIntent(text) {
     return { isMeta: true, kind: 'capabilities', consulta: text.trim() };
   }
 
+  // 1b) «Qué hace el mundo/sección/módulo de X» → howto de esa parte (resuelve
+  // por keyword, no por catálogo completo).
+  if (RE_QUE_HACE_SECCION.test(n)) {
+    return { isMeta: true, kind: 'howto', consulta: text.trim() };
+  }
+
   // 2) Cómo operar la app (verbo fuerte, o débil + referencia a la app).
   if (RE_APP_VERB_STRONG.test(n)) {
     return { isMeta: true, kind: 'howto', consulta: text.trim() };
   }
   if (RE_APP_VERB_WEAK.test(n) && hasAppRef) {
+    return { isMeta: true, kind: 'howto', consulta: text.trim() };
+  }
+  // 2b) Cámara del chat: insignia sin referencia explícita a la app.
+  if (RE_CAMARA_APP.test(n)) {
     return { isMeta: true, kind: 'howto', consulta: text.trim() };
   }
 

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -356,6 +356,12 @@ const ALLOWED_TOOLS = new Set([
   'get_alerta_carbono', //        alerta defensiva bonos de carbono + PSA estatal
   'get_alerta_normativa_paramo', // alerta regulatoria de páramo (Ley 1930/2018)
   'get_alerta_clima_consejo', //  alerta de decisión por cambio climático
+  // «Chagra enseña a usar Chagra» (ayuda groundeada): cómo usar una función de
+  // la app, qué puede hacer Chagra y dónde se ve algo, con deep-link. Standalone
+  // (manifiesto de funciones), grounded — found:false si la función no existe
+  // (nunca inventa). El cliente además intercepta la mayoría de estas preguntas
+  // localmente (metaAyudaIntent), pero se expone para el ruteo del NLU en chat.
+  'get_ayuda_funcion',
 ]);
 
 /**


### PR DESCRIPTION
## Qué construye

«Chagra enseña a usar Chagra»: el agente responde CÓMO usar cualquier función de Chagra y redirige a ella con un deep-link, **grounded** (nunca inventa funciones que no existen). Capa cliente (repo público). El tool del sidecar va en un PR separado de `chagra-pro`.

### Capas
1. **Manifiesto de ayuda** — `src/data/ayudaFunciones.js`. FUENTE DE VERDAD, **derivada** de `agentCapabilities.js` (CAPABILITY_MANIFEST, «la mano de Chagra»). Consolida las 32 funciones LIVE: `nombre`, `que_hace`, `como_se_usa` (pasos), `cuando_sirve`, `accion` (deep-link) y `keywords`. Matcher determinístico `matchAyudaFuncion` + `listAyudaFunciones`. Si una función no está aquí, el agente no la puede afirmar.
2. **Detección de intención META/how-to** — `src/services/metaAyudaIntent.js`. Distingue «¿cómo registro una cosecha?» / «¿qué puede hacer Chagra?» / «¿dónde veo los precios?» (SOBRE la app) de una pregunta agronómica. Alta precisión: verbos de operar la app disparan; verbos agronómicos (siembro/cosecho/controlo/preparo) NO. **Arregla de paso el misroute conocido meta→get_species → deflección.**
3. **Respuesta con deep-link** — `ayudaAgentResponder.js` compone la respuesta DESDE el manifiesto (sin LLM → anti-alucinación por construcción). `AgentScreen` la intercepta antes del NLU/tool; `ChatHistory` pinta un botón «Abrir …» que navega con `onNavigate` (HASH_VIEW_ROUTES). `sidecarClient` agrega `get_ayuda_funcion` a la allow-list.

### Anti-alucinación (crítico)
- Función inexistente → respuesta honesta («Todavía no tengo esa función… lo que sí puedo hacer: …»), **nunca inventada** (test cubierto).
- «¿cómo registro una siembra?» → devuelve la función real de registro + su ruta.

## Verificación
- `npm run build` verde.
- Tests: **35 nuevos** (`ayudaFunciones.test.js` + `metaAyudaIntent.test.js`) + 83 verdes en la suite AgentScreen/ChatHistory tocada.
- eslint verde en los módulos nuevos.

## PR hermano
Sidecar `get_ayuda_funcion` en `chagra-pro` (tool + dataset portado + allow-list + R0-META en el NLU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)