### PR TITLE
feat(ayuda): overhaul visual + correccion de tips y boton de ayuda

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -976,6 +976,7 @@ export default function App() {
             </ScreenShell>
           </ErrorBoundary>
         );
+      case 'gestionar': // alias usado por el FAQ ("Gestionar mi finca") — sin este label caía en default "Vista no disponible"
       case 'activos':
         return (
           <ErrorBoundary>
@@ -1207,6 +1208,7 @@ export default function App() {
             </ErrorFallback>
           </ErrorBoundary>
         );
+      case 'calendario': // alias usado por Manual/FAQ (HASH_VIEW_ROUTES ya lo mapea para hash, pero navigate() no normaliza — sin este label caía en default "Vista no disponible")
       case 'calendario_finca':
         // Módulo CALENDARIO DE FINCA: UN SOLO calendario que UNIFICA por planta
         // (ciclos de la finca, o especies del catálogo si no hay finca) las
@@ -1298,6 +1300,7 @@ export default function App() {
             </ErrorFallback>
           </ErrorBoundary>
         );
+      case 'especies': // alias usado por Manual/FAQ (mismo caso que 'calendario': navigate() no pasa por HASH_VIEW_ROUTES)
       case 'directorio':
         // Directorio de especies: explorador visual del catálogo. Buscador con
         // resolución de nombre (matcher canónico del proyecto) + ficha grounded

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square, Sprout } from 'lucide-react';
+import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square, Sprout, HelpCircle } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe, queueForRetry } from '../../services/voiceService';
 import VoiceStatusStrip from './VoiceStatusStrip';
@@ -3160,6 +3160,20 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           title={ttsEnabled ? 'Silenciar voz' : 'Activar voz'}
         >
           {ttsEnabled ? <Volume2 size={15} /> : <VolumeX size={15} />}
+        </button>
+        {/* Ayuda (overhaul ayuda 2026-07): el AgentScreen es inmersivo (sin
+            TopBar), así que el "?" global no existía aquí — el campesino que
+            se pierde EN el chat no tenía puerta al Manual. Mismo mecanismo de
+            navegación global que el botón Home (chagra:nav → App.jsx). */}
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'ayuda' }))}
+          className="p-2.5 rounded-full bg-amber-500/15 hover:bg-amber-500/25 active:bg-amber-500/35 text-amber-300 min-h-[44px] min-w-[44px] flex items-center justify-center transition-all"
+          title="Manual de uso"
+          aria-label="Abrir el manual de uso"
+          data-testid="agent-help-btn"
+        >
+          <HelpCircle size={16} strokeWidth={2.5} />
         </button>
         <div className={`hidden sm:flex items-center gap-1 px-2 py-1 rounded-full text-[10px] ${
           isOnline ? 'bg-emerald-900/40 text-emerald-400' : 'bg-red-900/40 text-red-400'

--- a/src/components/HelpCicloScreen.jsx
+++ b/src/components/HelpCicloScreen.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ArrowLeft, ChevronRight, Clock } from 'lucide-react';
 import HelpCycleSection from './HelpCycleSection.jsx';
+import { IlusCiclo } from './help/HelpIllustrations.jsx';
 
 /**
  * Sub-vista del Manual: Aprende sembrando. Wrapper del HelpCycleSection
@@ -25,10 +26,16 @@ export default function HelpCicloScreen({ onBackToHome }) {
       </div>
 
       <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-4">
-        <p className="text-sm text-slate-300 leading-relaxed">
-          Punto de partida educativo para empezar desde cero. No solo cómo usar Chagra: cómo cultivar.
-          Toca cada especie para abrir su corpus consolidado y, si quieres, hazle una pregunta por voz a la IA.
-        </p>
+        {/* Hero con ilustración propia (overhaul ayuda 2026-07) */}
+        <div className="flex items-start gap-3">
+          <span className="shrink-0 inline-flex items-center justify-center w-14 h-14 rounded-[16px_16px_16px_6px] bg-pink-700/30 border border-pink-500/40">
+            <IlusCiclo size={36} className="text-pink-200" />
+          </span>
+          <p className="text-sm text-slate-300 leading-relaxed flex-1 min-w-0">
+            Punto de partida educativo para empezar desde cero. No solo cómo usar Chagra: cómo cultivar.
+            Toca cada especie para abrir su corpus consolidado y, si quieres, hazle una pregunta por voz a la IA.
+          </p>
+        </div>
 
         {/* Accordion principal por especie (PR #201) */}
         <HelpCycleSection />

--- a/src/components/HelpDatosScreen.jsx
+++ b/src/components/HelpDatosScreen.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   ArrowLeft,
   ChevronRight,
-  Notebook,
   Wifi,
   CloudUpload,
   Smartphone,
@@ -11,6 +10,7 @@ import {
   ShieldCheck,
   Bot,
 } from 'lucide-react';
+import { IlusDatos, IlusRegistro } from './help/HelpIllustrations.jsx';
 
 /**
  * HelpDatosScreen — Sub-vista del Manual: "¿Dónde se guardan mis datos?".
@@ -80,8 +80,8 @@ export default function HelpDatosScreen({ onBackToHome, onNavigate }) {
       <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-6">
         {/* Hero */}
         <div className="flex items-start gap-3">
-          <span className="shrink-0 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-teal-700/40 border border-teal-500/50">
-            <Notebook size={26} className="text-teal-300" />
+          <span className="shrink-0 inline-flex items-center justify-center w-14 h-14 rounded-[16px_16px_16px_6px] bg-teal-700/40 border border-teal-500/50">
+            <IlusDatos size={36} className="text-teal-200" />
           </span>
           <div className="min-w-0 flex-1">
             <h2 className="text-2xl font-black text-teal-100 leading-tight">
@@ -118,7 +118,7 @@ export default function HelpDatosScreen({ onBackToHome, onNavigate }) {
         {/* La metáfora del cuaderno de campo */}
         <section className="rounded-xl border border-teal-900/60 bg-teal-950/30 p-4">
           <div className="flex items-start gap-3">
-            <Notebook size={20} className="text-teal-300 shrink-0 mt-0.5" aria-hidden="true" />
+            <IlusRegistro size={34} className="text-teal-300 shrink-0 mt-0.5" />
             <div className="text-sm text-slate-200 leading-relaxed space-y-2">
               <p>
                 Piensa en Chagra como un{' '}

--- a/src/components/HelpHomeScreen.jsx
+++ b/src/components/HelpHomeScreen.jsx
@@ -1,9 +1,13 @@
 import React, { useState, useMemo } from 'react';
 import {
-  Mic, BookOpen, Sprout, ChevronRight, Library, Bot, Database, Search, X,
+  BookOpen, Sprout, ChevronRight, Library, Search, X,
   Leaf, CalendarDays, Store, HelpCircle, Gamepad2, MessageSquare,
 } from 'lucide-react';
 import HelpRegionSelector from './HelpRegionSelector.jsx';
+import ManoChagraGlyph from './dashboard/ManoChagraGlyph.jsx';
+import {
+  IlusVoz, IlusMundos, IlusCiclo, IlusDatos, IlusVerificado,
+} from './help/HelpIllustrations.jsx';
 
 /**
  * Home del Manual: botones grandes para entrar a las sub-vistas del help,
@@ -37,10 +41,29 @@ export default function HelpHomeScreen({ onSelect, onNavigate }) {
     if (typeof onNavigate === 'function') onNavigate(route);
   };
 
+  // Tarjetas de tema. `icon` acepta lucide O una ilustración propia de
+  // help/HelpIllustrations.jsx (misma interfaz size/className): las
+  // ilustraciones traen LA COSTURA del acento del tema — marca cosida.
   const cards = [
     {
+      // Overhaul 2026-07: LA pregunta número uno del campesino nuevo ("¿esto
+      // pa' qué sirve?") ahora es la PRIMERA tarjeta. Abre el mapa completo
+      // de funciones derivado del manifiesto de la mano, con deep-links.
+      key: 'funciones',
+      icon: ManoChagraGlyph,
+      title: '¿Qué puede hacer Chagra?',
+      sub: 'Todas las funciones en tarjetas que abren directo: registrar, cuidar, planear, aprender, vender.',
+      keywords: 'funciones capacidades que puede hacer todo lista mano boton abrir atajos empezar primera vez',
+      accent: 'from-emerald-900/60 to-slate-950/80',
+      border: 'border-emerald-500/50 hover:border-emerald-300/70',
+      iconBg: 'bg-emerald-700/40 border-emerald-400/60',
+      iconColor: 'text-emerald-200',
+      titleColor: 'text-emerald-50',
+      subColor: 'text-emerald-100/70',
+    },
+    {
       key: 'voz',
-      icon: Mic,
+      icon: IlusVoz,
       title: 'Cómo usar la voz',
       sub: 'Habla y deja que Chagra registre tu siembra, cosecha o lo que veas en campo.',
       keywords: 'voz hablar microfono micrófono dictar grabar audio transcribir registrar sin manos',
@@ -53,7 +76,7 @@ export default function HelpHomeScreen({ onSelect, onNavigate }) {
     },
     {
       key: 'uso',
-      icon: BookOpen,
+      icon: IlusMundos,
       title: 'Cómo usar Chagra',
       sub: 'Inicio rápido, foto, zonas, plagas, cosecha, reportes y problemas comunes.',
       keywords: 'usar inicio rapido foto camara cámara zona ubicacion gps plaga cosecha reportar problema bug ayuda offline sin internet',
@@ -66,7 +89,7 @@ export default function HelpHomeScreen({ onSelect, onNavigate }) {
     },
     {
       key: 'ciclo',
-      icon: Sprout,
+      icon: IlusCiclo,
       title: 'Aprende sembrando',
       sub: 'El ciclo de un cultivo paso a paso: germinar, crecer, florecer, cosechar. Con su fuente.',
       keywords: 'aprender sembrar cultivar ciclo lechuga fresa tomate germinar cosechar floracion fenologia biopreparado bocashi compañeros perenne',
@@ -81,7 +104,7 @@ export default function HelpHomeScreen({ onSelect, onNavigate }) {
       key: 'diccionario',
       icon: Library,
       title: 'Diccionario',
-      sub: 'Bocashi, micorriza, milpa… palabras del campo explicadas como si tu hije de 11 años te preguntara.',
+      sub: 'Bocashi, micorriza, milpa… palabras del campo explicadas como si tu hijo de 11 años te preguntara.',
       keywords: 'diccionario palabras significado bocashi micorriza milpa terminos términos definicion qué es',
       accent: 'from-violet-900/40 to-purple-950/80',
       border: 'border-violet-600/40 hover:border-violet-400/70',
@@ -94,7 +117,7 @@ export default function HelpHomeScreen({ onSelect, onNavigate }) {
       // Task #123: sección Ayuda > "Sobre el agente Chagra".
       // Cero hype, lo que SÍ y lo que NO puede el agente, auditable.
       key: 'agente',
-      icon: Bot,
+      icon: IlusVerificado,
       title: 'Sobre el agente Chagra',
       sub: 'Qué SÍ puede y qué NO puede. Sin promesas mágicas. Con fuentes.',
       keywords: 'agente ia inteligencia artificial chat puede no puede limitaciones confiar auditar fuente',
@@ -110,7 +133,7 @@ export default function HelpHomeScreen({ onSelect, onNavigate }) {
       // iniciar sesión). Responde la pregunta más confusa del piloto
       // ("¿por qué veo cosas distintas en mis aparatos?").
       key: 'datos',
-      icon: Database,
+      icon: IlusDatos,
       title: '¿Dónde se guardan mis datos?',
       sub: 'Tu cuaderno de campo en el bolsillo: todo se guarda en tu aparato, sin internet. Por qué a veces ves cosas distintas en el celular y el computador.',
       keywords: 'datos guardar guardan donde dónde almacenar privacidad sincronizar sincronización servidor nube internet sin conexion offline cuaderno celular computador aparato dispositivo perder respaldo iniciar sesion sesión usuario',
@@ -130,9 +153,12 @@ export default function HelpHomeScreen({ onSelect, onNavigate }) {
     {
       key: 'gestionar',
       icon: Sprout,
-      title: 'Gestionar',
+      // Paridad con FincaVivaHero (bug viejo replicado aquí: el portal
+      // "Gestionar" mandaba a 'juego', el mismo destino que "Jugar"). El
+      // portal del home hoy se llama "Mi finca" y abre la gestión real.
+      title: 'Mi finca (Gestionar)',
       sub: 'Registre y cuide sus siembras, zonas, animales y bitácora.',
-      route: 'juego',
+      route: 'activos',
       iconColor: 'text-emerald-300',
       ring: 'border-emerald-600/40 hover:border-emerald-400/70',
     },
@@ -351,8 +377,8 @@ export default function HelpHomeScreen({ onSelect, onNavigate }) {
               onClick={() => onSelect(c.key)}
               className={`rounded-2xl bg-gradient-to-br ${c.accent} border ${c.border} active:scale-[0.99] transition-all p-5 text-left flex items-start gap-4 min-h-[112px] shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60`}
             >
-              <span className={`shrink-0 inline-flex items-center justify-center w-14 h-14 rounded-xl border ${c.iconBg}`}>
-                <Icon size={28} className={c.iconColor} />
+              <span className={`shrink-0 inline-flex items-center justify-center w-14 h-14 rounded-[16px_16px_16px_6px] border ${c.iconBg}`}>
+                <Icon size={34} className={c.iconColor} />
               </span>
               <div className="min-w-0 flex-1">
                 <p className={`text-lg font-black leading-tight ${c.titleColor}`}>{c.title}</p>

--- a/src/components/HelpManual.jsx
+++ b/src/components/HelpManual.jsx
@@ -9,6 +9,8 @@ import HelpDictionary from './HelpDictionary.jsx';
 import HelpVoiceRegionalDemo from './HelpVoiceRegionalDemo.jsx';
 import HelpAgentSection from './HelpAgentSection.jsx';
 import HelpDatosScreen from './HelpDatosScreen.jsx';
+import HelpFuncionesScreen from './help/HelpFuncionesScreen.jsx';
+import { CosturaDivider } from './help/HelpIllustrations.jsx';
 
 /**
  * HelpManual — Manual de usuario integrado en la PWA.
@@ -45,7 +47,7 @@ import HelpDatosScreen from './HelpDatosScreen.jsx';
  *   - "Novedades mayo 2026"        → Chagra/CHANGELOG.md (root)
  */
 export default function HelpManual({ onBack, onNavigate }) {
-  // 'home' | 'voz' | 'uso' | 'ciclo' | 'diccionario' | 'agente' | 'datos' | 'voz-regional-demo'
+  // 'home' | 'funciones' | 'voz' | 'uso' | 'ciclo' | 'diccionario' | 'agente' | 'datos' | 'voz-regional-demo'
   const [section, setSection] = useState('home');
 
   // CTAs híbridas (P5): cierran el manual y navegan al flow real.
@@ -74,12 +76,20 @@ export default function HelpManual({ onBack, onNavigate }) {
         </div>
       </header>
 
+      {/* Dobladillo cosido bajo el header: LA COSTURA de la marca (misma
+          puntada del dobladillo de la mochila del agente) — el Manual es
+          contenido curado, cosido al cuaderno de campo. */}
+      <CosturaDivider className="mx-4 mt-2" />
+
       {/* Tip del día siempre visible bajo el header */}
       <HelpTipCard />
 
       {/* Sub-vistas */}
       {section === 'home' && (
         <HelpHomeScreen onSelect={setSection} onNavigate={closeAndNavigate} />
+      )}
+      {section === 'funciones' && (
+        <HelpFuncionesScreen onBackToHome={goHome} onNavigate={closeAndNavigate} />
       )}
       {section === 'voz' && (
         <HelpVozScreen onBackToHome={goHome} onNavigate={closeAndNavigate} />

--- a/src/components/HelpTipCard.jsx
+++ b/src/components/HelpTipCard.jsx
@@ -1,9 +1,28 @@
 import React, { useState, useEffect } from 'react';
-import { HELP_TIPS } from '../data/help-tips.js';
+import { RefreshCcw } from 'lucide-react';
+import { HELP_TIPS, TIP_CATEGORIES } from '../data/help-tips.js';
 
 const STORAGE_KEY = 'chagra:help_tip_history';
 const HISTORY_LIMIT = 5;
 
+/**
+ * HelpTipCard — "Tip del día" del Manual.
+ *
+ * Rediseño 2026-07 (overhaul ayuda visual):
+ *   - Antes era una tarjeta ámbar CLARA (bg-amber-50) pegada sobre el fondo
+ *     oscuro: chocaba con biopunk y con los temas (colores fijos, sin --c-*).
+ *     Ahora usa las superficies del tema (slate → variables --c-*) y funciona
+ *     en los 4 temas sin overrides.
+ *   - LA COSTURA en el borde izquierdo (misma puntada esmeralda que firma las
+ *     respuestas respaldadas del agente): estos tips son contenido CURADO con
+ *     fuente (cementerio de plantas / lecciones de especie), no relleno.
+ *   - Ícono de categoría GRANDE + título corto y negro (para quien lee poco,
+ *     el título ya es el consejo) + botón "Otro tip" con tap target ≥44px
+ *     (antes: link subrayado minúsculo "siguiente >").
+ *   - Cero animación (reduced-motion respetado por construcción).
+ *
+ * Lógica intacta: tip aleatorio sin repetir los últimos 5 (localStorage).
+ */
 export default function HelpTipCard() {
   const [currentTip, setCurrentTip] = useState(null);
 
@@ -39,31 +58,64 @@ export default function HelpTipCard() {
     return null;
   }
 
+  const cat = TIP_CATEGORIES[currentTip.category] || { label: 'Consejo', emoji: '💡' };
+  const source = currentTip.source || '';
+  const sourceLabel = source.startsWith('cemetery_reason:')
+    ? 'Aprendido de matas que se perdieron'
+    : source.startsWith('species_lesson:')
+      ? 'Lo que enseña esa especie'
+      : 'Experiencia de campo';
+
   return (
-    <div className="border rounded-xl border-amber-200 bg-amber-50 p-4 mb-6">
+    <div className="mx-4 mt-3 mb-4 relative rounded-2xl bg-slate-900/70 border border-slate-800 p-4 pl-6 shadow-lg">
+      {/* LA COSTURA: puntada de hilo esmeralda en el borde izquierdo — tip
+          curado con fuente, cosido al cuaderno (mismo lenguaje que las
+          respuestas respaldadas del agente). */}
+      <span
+        aria-hidden="true"
+        className="absolute left-2.5 top-4 bottom-4 w-[2.5px] rounded-full"
+        style={{
+          backgroundImage:
+            'repeating-linear-gradient(180deg, rgb(var(--c-emerald-500, 16 185 129)) 0 7px, transparent 7px 13px)',
+        }}
+      />
       <div className="flex items-start gap-3">
-        <div className="shrink-0">
-          <span className="text-amber-600 text-xl">💡</span>
-        </div>
-        <div className="flex-1 space-y-2">
-          <p className="font-bold text-amber-800 text-sm">Tip del día</p>
-          <p className="text-amber-700 text-sm leading-relaxed">
+        {/* Ícono de categoría grande, en tarjeta-semilla (esquina de lomo) */}
+        <span
+          aria-hidden="true"
+          className="shrink-0 inline-flex items-center justify-center w-12 h-12 text-2xl leading-none bg-slate-950/60 border border-slate-700/60 rounded-[14px_14px_14px_5px]"
+        >
+          {cat.emoji}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className="text-[10px] uppercase tracking-wider font-bold text-emerald-400">
+              Tip del día
+            </p>
+            <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-emerald-500/15 text-emerald-300 border border-emerald-700/40">
+              {cat.label}
+            </span>
+          </div>
+          {currentTip.title && (
+            <p className="text-base font-black text-slate-100 leading-snug mt-1">
+              {currentTip.title}
+            </p>
+          )}
+          <p className="text-sm text-slate-300 leading-relaxed mt-1">
             {currentTip.text}
           </p>
-          <button
-            onClick={loadRandomTip}
-            className="text-amber-600 hover:text-amber-800 text-xs font-medium underline"
-          >
-            siguiente &gt;
-          </button>
-          <p className="text-amber-500 text-xs italic">
-            {(currentTip.source || '').startsWith('cemetery_reason:')
-              ? 'Origen: lo que pasó antes de morir'
-              : (currentTip.source || '').startsWith('species_lesson:')
-                ? 'Origen: lo que enseña esa especie'
-                : 'Origen: experiencias'}
-          </p>
-</div>
+          <div className="flex items-center justify-between gap-2 mt-2.5">
+            <p className="text-[11px] text-slate-500 italic min-w-0">{sourceLabel}</p>
+            <button
+              type="button"
+              onClick={loadRandomTip}
+              className="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-emerald-500/10 hover:bg-emerald-500/20 active:bg-emerald-500/30 text-emerald-300 border border-emerald-700/40 text-xs font-bold min-h-[40px] transition-colors"
+            >
+              <RefreshCcw size={13} aria-hidden="true" />
+              Otro tip
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/HelpUsoScreen.jsx
+++ b/src/components/HelpUsoScreen.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import {
-  ArrowLeft, ChevronDown, ChevronRight, Sprout, Camera, MapPin, Bug, Apple,
-  MessageCircle, Wrench, Compass, Mic, CalendarDays, Leaf, Store,
+  ArrowLeft, ChevronDown, ChevronRight, Sprout, MapPin, Bug, Apple,
+  MessageCircle, Wrench, Mic, CalendarDays, Leaf, Store,
 } from 'lucide-react';
 import FieldFeedback from './FieldFeedback';
+import { IlusFoto, IlusMundos } from './help/HelpIllustrations.jsx';
 
 /**
  * Sub-vista del Manual: cómo usar Chagra (FAQs reorganizadas).
@@ -31,12 +32,12 @@ const Section = ({ icon: Icon, title, children, defaultOpen = false, isNew = fal
         aria-expanded={open}
         className="w-full p-3 flex items-center gap-3 hover:bg-slate-800/60 active:bg-slate-800 text-left min-h-[56px]"
       >
-        <span className={`shrink-0 inline-flex items-center justify-center ${open ? 'animate-pulse' : ''}`}>
+        <span className={`shrink-0 inline-flex items-center justify-center ${open ? 'motion-safe:animate-pulse' : ''}`}>
           <Icon size={20} className="text-emerald-400" />
         </span>
         <span className="text-base font-bold text-white flex-1">{title}</span>
         {isNew && (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[9px] font-bold bg-emerald-500/20 text-emerald-300 border border-emerald-600/40 animate-pulse">
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[9px] font-bold bg-emerald-500/20 text-emerald-300 border border-emerald-600/40 motion-safe:animate-pulse">
             ✨ NUEVO
           </span>
         )}
@@ -100,13 +101,13 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
         {/* 0. Orientación — los cuatro lugares de Chagra (home F2). Esto va
             primero porque es el mapa mental que el campesino nuevo necesita
             para no perderse. Mismos nombres que los portales del inicio. */}
-        <Section icon={Compass} title="🧭 Los cuatro lugares de Chagra" defaultOpen>
+        <Section icon={IlusMundos} title="🧭 Los cuatro lugares de Chagra" defaultOpen>
           <p>
             Al abrir Chagra ves <strong className="text-emerald-200">su finca dibujada</strong> (la pantalla de inicio). Ahí toca uno de estos cuatro lugares:
           </p>
           <ul className="mt-2 space-y-2 text-sm">
             <li>
-              <strong className="text-emerald-300">🌱 Gestionar</strong> — registrar y cuidar sus siembras, zonas, animales y la bitácora. También vender su cosecha.
+              <strong className="text-emerald-300">🌱 Mi finca (Gestionar)</strong> — registrar y cuidar sus siembras, zonas, animales y la bitácora. También vender su cosecha.
             </li>
             <li>
               <strong className="text-amber-300">📚 Aprender</strong> — lecciones de agroecología con fuente: suelo vivo, milpa, biopreparados, MIP, fenología.
@@ -126,7 +127,9 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
         {/* 1. Inicio rápido */}
         <Section icon={Sprout} title="🌱 Inicio rápido (primera vez)" action={quickAction('Crear primera planta', 'plant_asset')}>
           <ol className="list-decimal pl-5 space-y-1.5">
-            <li>Toca el botón <strong className="text-purple-400">+</strong> arriba (header) para registrar tu primera planta.</li>
+            {/* Corrección 2026-07: el botón "+" del header ya no existe
+                (UX-27 #286 lo reemplazó por el botón unificado mic+planta). */}
+            <li>Toca el botón del <strong className="text-purple-400">micrófono con la plantica</strong> arriba (header) y di lo que sembraste, o crea la planta a mano con el botón de abajo.</li>
             <li>Busca la especie escribiendo (ej. &ldquo;gulpa&rdquo; encuentra Gulupa). Chagra autocompleta estrato, gremio y producción.</li>
             <li>Si tienes foto, súbela desde la cámara o galería.</li>
             <li>Marca la ubicación: toca mapa o &ldquo;Mi ubicación&rdquo;.</li>
@@ -146,7 +149,7 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
         </Section>
 
         {/* 2. Foto + IA */}
-        <Section icon={Camera} title="📸 Foto + IA por foto" action={quickAction('Crear planta con foto', 'plant_asset')}>
+        <Section icon={IlusFoto} title="📸 Foto + IA por foto" action={quickAction('Crear planta con foto', 'plant_asset')}>
           <p><strong>Al crear planta:</strong> el botón cámara abre tu cámara o galería. La foto queda en la hoja de vida de esa planta.</p>
           <p><strong>Adjuntar a evento existente</strong>: entra al evento desde Bitácora → sección &ldquo;Adjuntar foto a este evento&rdquo;. Útil para documentar después.</p>
 
@@ -252,7 +255,9 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
         {/* 8. Vender / Mercado — pantalla nueva (#1854). */}
         <Section icon={Store} title="🛒 Vender mi cosecha (mercado)" action={quickAction('Abrir el mercado de la finca', 'mercados')} isNew>
           <p>En el <strong className="text-emerald-200">Mercado de la finca</strong> publicas lo que produces y lo vendes por <strong>circuitos cortos</strong> (de tu finca a quien come), coordinando por WhatsApp.</p>
-          <p className="text-xs text-slate-400 italic mt-2">El precio lo pones tú. Chagra todavía no te dice un precio de mercado exacto — esa parte está en construcción.</p>
+          {/* Corrección 2026-07: el chip «Precio» del chat ya consulta la
+              referencia mayorista real (SIPSA/DANE) desde 2026-07-01. */}
+          <p className="text-xs text-slate-400 italic mt-2">El precio lo pones tú. Si quieres una referencia mayorista del día (SIPSA/DANE), pregúntale al Agente con el chip «Precio»: te la cita solo si hay fuente.</p>
         </Section>
 
         {/* 9. Reportar problema / sugerir mejora — embed del FieldFeedback
@@ -355,7 +360,7 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
         </Section>
 
         <p className="text-[11px] text-slate-600 text-center mt-4 italic leading-relaxed">
-          Manual v2.1 · Actualizado 2026-06-25 · Colombia es el país de la belleza.
+          Manual v2.2 · Actualizado 2026-07-04 · Colombia es el país de la belleza.
         </p>
       </main>
     </div>

--- a/src/components/HelpVozScreen.jsx
+++ b/src/components/HelpVozScreen.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ArrowLeft, Mic, Ear, BrainCircuit, CheckCircle2, ChevronRight } from 'lucide-react';
+import { IlusVoz } from './help/HelpIllustrations.jsx';
 
 /**
  * Sub-vista del Manual: cómo usar la voz. Híbrido tutorial + CTA "Probar
@@ -13,10 +14,14 @@ export default function HelpVozScreen({ onBackToHome, onNavigate }) {
 
   const steps = [
     {
+      // Corrección 2026-07: el copy viejo decía "abajo a la izquierda,
+      // siempre visible" — desactualizado. Las entradas REALES de la voz
+      // hoy: la mano Ⓐ → "Registrar hablando" (flujo unificado) y el botón
+      // de micrófono de la barra de arriba (agregar planta por voz).
       n: 1,
       icon: Mic,
-      title: 'Toca el botón micrófono',
-      body: 'Está abajo a la izquierda, siempre visible. Lo encuentras en cualquier pantalla menos cuando ya estás dentro del módulo de voz.',
+      title: 'Abre la voz desde la mano de Chagra',
+      body: 'Toca el botón Ⓐ (la mano de Chagra) y elige "Registrar hablando". También sirve el botón de micrófono con la plantica, arriba en la barra.',
     },
     {
       n: 2,
@@ -57,8 +62,8 @@ export default function HelpVozScreen({ onBackToHome, onNavigate }) {
 
       <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-4">
         <div className="flex items-start gap-3">
-          <span className="shrink-0 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-emerald-700/40 border border-emerald-500/50">
-            <Mic size={26} className="text-emerald-300" />
+          <span className="shrink-0 inline-flex items-center justify-center w-14 h-14 rounded-[16px_16px_16px_6px] bg-emerald-700/40 border border-emerald-500/50">
+            <IlusVoz size={36} className="text-emerald-200" />
           </span>
           <div className="min-w-0 flex-1">
             <h2 className="text-2xl font-black text-emerald-100 leading-tight">Habla y registra</h2>

--- a/src/components/__tests__/HelpTipCard.smoke.test.jsx
+++ b/src/components/__tests__/HelpTipCard.smoke.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HelpTipCard from '../HelpTipCard.jsx';
+import { HELP_TIPS, TIP_CATEGORIES } from '../../data/help-tips.js';
+import { describe, test, expect, beforeEach } from 'vitest';
+
+/**
+ * Smoke test del HelpTipCard rediseñado (overhaul ayuda 2026-07).
+ *
+ * Verifica:
+ *   - Muestra un tip con su título corto (escaneable) y botón "Otro tip".
+ *   - "Otro tip" carga uno distinto sin repetir los últimos 5 (localStorage).
+ *   - Los datos: todo tip tiene title/category/source y la categoría existe
+ *     en TIP_CATEGORIES (el ícono grande nunca cae a undefined).
+ */
+describe('HelpTipCard smoke', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('Renderiza un tip con título y botón "Otro tip"', async () => {
+    render(<HelpTipCard />);
+    // El tip carga async (setTimeout 0)
+    expect(await screen.findByText(/Tip del día/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Otro tip/i })).toBeInTheDocument();
+  });
+
+  test('"Otro tip" persiste el historial en localStorage', async () => {
+    render(<HelpTipCard />);
+    const btn = await screen.findByRole('button', { name: /Otro tip/i });
+    act(() => {
+      fireEvent.click(btn);
+    });
+    const history = JSON.parse(localStorage.getItem('chagra:help_tip_history'));
+    expect(Array.isArray(history)).toBe(true);
+    expect(history.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('Todos los tips tienen título corto y categoría con metadatos', () => {
+    for (const tip of HELP_TIPS) {
+      expect(tip.title, `tip ${tip.id} sin title`).toBeTruthy();
+      expect(tip.title.length, `título muy largo en ${tip.id}`).toBeLessThanOrEqual(60);
+      expect(TIP_CATEGORIES[tip.category], `categoría desconocida en ${tip.id}`).toBeTruthy();
+      expect(tip.source, `tip ${tip.id} sin fuente`).toBeTruthy();
+    }
+  });
+
+  test('El copy de los tips no contiene voseo argentino ni jerga académica', () => {
+    const text = HELP_TIPS.map((t) => `${t.title} ${t.text}`).join(' ');
+    expect(text).not.toMatch(/\btenés\b|\bpodés\b|\belegí\b/i);
+    // Jerga que el overhaul sacó a propósito (habla campesina):
+    expect(text).not.toMatch(/edáfic|cinétic|milimétric|arquitectónic/i);
+  });
+});

--- a/src/components/help/HelpFuncionesScreen.jsx
+++ b/src/components/help/HelpFuncionesScreen.jsx
@@ -1,0 +1,245 @@
+import React, { useMemo, useState } from 'react';
+import { ArrowLeft, ChevronRight, Search, X, Camera, MessageCircle } from 'lucide-react';
+import { CAPABILITY_MANIFEST } from '../../services/agentCapabilities.js';
+import ManoChagraGlyph from '../dashboard/ManoChagraGlyph.jsx';
+import { CosturaDivider } from './HelpIllustrations.jsx';
+
+/**
+ * HelpFuncionesScreen — "¿Qué puede hacer Chagra?" (sub-vista del Manual).
+ *
+ * LA respuesta del botón "?" a la pregunta más básica del campesino nuevo:
+ * qué hace esta app y cómo llego a cada cosa. Cada tarjeta ABRE la función
+ * (deep-link real, mismas vistas de App.jsx) — no la describe y ya.
+ *
+ * GROUNDED por construcción: se DERIVA de CAPABILITY_MANIFEST
+ * (agentCapabilities.js — la fuente única de "la mano de Chagra"). Si una
+ * función no está en el manifiesto, NO aparece aquí: esta pantalla no puede
+ * prometer nada que la app no tenga. Cero re-declaración de capacidades
+ * (mismo criterio que ayudaFunciones.js de «Chagra enseña a usar Chagra»).
+ *
+ * Cómo se llega a cada función (derivado de heroRoute):
+ *   - kind 'nav'   → botón "Abrir" que navega a esa pantalla.
+ *   - kind 'ask'   → "Pregúntale" (abre el chat del agente; la función es
+ *                    una consulta con fuente).
+ *   - kind 'photo' → "Con foto" (abre el chat; ahí está el botón cámara).
+ *   - otro/chip    → "Pregúntale" (vive como chip dentro del chat).
+ *   - status 'soon' → lista honesta "En camino", sin botón (anti-promesa).
+ */
+
+/** Etiquetas campesinas + orden de los grupos del manifiesto. */
+const GRUPOS = [
+  { id: 'registrar', label: 'Guardar lo que hago' },
+  { id: 'cultivo', label: 'Cultivar' },
+  { id: 'cuidar', label: 'Cuidar' },
+  { id: 'observar', label: 'Observar la finca' },
+  { id: 'planear', label: 'Planear' },
+  { id: 'aprender', label: 'Aprender' },
+  { id: 'vender', label: 'Vender' },
+  { id: 'restaurar', label: 'Restaurar el monte' },
+];
+
+/** Deriva la acción de apertura de una capacidad (sin re-declarar nada). */
+function accionDe(cap) {
+  const hr = cap.heroRoute || {};
+  if (hr.kind === 'nav' && hr.view) return { tipo: 'abrir', view: hr.view, label: 'Abrir' };
+  if (hr.kind === 'photo') return { tipo: 'foto', view: 'agente', label: 'Con foto' };
+  return { tipo: 'preguntar', view: 'agente', label: 'Pregúntale' };
+}
+
+const normalize = (s) =>
+  (s || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '');
+
+export default function HelpFuncionesScreen({ onBackToHome, onNavigate }) {
+  const [query, setQuery] = useState('');
+
+  const go = (view) => {
+    if (typeof onNavigate === 'function') onNavigate(view);
+  };
+
+  // Capacidades visibles = live Y alcanzables: las que brotan de la mano Ⓐ
+  // (hero !== false) MÁS los chips de consulta del chat (tienen `intent`:
+  // toxicidad, saberes, variedades, polinización, fenología, alerta páramo,
+  // precio — viven bajo "Más" en la barra de chips). Quedan fuera solo las
+  // entradas retiradas por dedup (hero:false SIN intent: puertas duplicadas
+  // a la misma vista) y las 'soon' (van a "En camino", sin promesa).
+  const { vivas, enCamino } = useMemo(() => {
+    const vivas = CAPABILITY_MANIFEST.filter(
+      (c) => c.status === 'live' && (c.hero !== false || c.intent)
+    );
+    const enCamino = CAPABILITY_MANIFEST.filter((c) => c.status !== 'live');
+    return { vivas, enCamino };
+  }, []);
+
+  const visibles = useMemo(() => {
+    const q = normalize(query).trim();
+    if (!q) return vivas;
+    const terms = q.split(/\s+/);
+    return vivas.filter((c) => {
+      const hay = normalize(`${c.label} ${c.desc || ''}`);
+      return terms.every((t) => hay.includes(t));
+    });
+  }, [vivas, query]);
+
+  const porGrupo = useMemo(() => {
+    const map = new Map();
+    for (const c of visibles) {
+      if (!map.has(c.group)) map.set(c.group, []);
+      map.get(c.group).push(c);
+    }
+    return map;
+  }, [visibles]);
+
+  return (
+    <div className="h-full w-full flex flex-col">
+      {/* Sub-header con back to home del Manual */}
+      <div className="px-4 pt-3 pb-2 flex items-center gap-2 shrink-0 border-b border-slate-800/60 bg-slate-950/60">
+        <button
+          type="button"
+          onClick={onBackToHome}
+          aria-label="Volver al Manual"
+          className="p-2 -ml-2 rounded-lg active:bg-slate-800 min-h-[40px] min-w-[40px] flex items-center justify-center"
+        >
+          <ArrowLeft size={20} className="text-emerald-400" />
+        </button>
+        <p className="text-xs uppercase tracking-wider text-emerald-400/80 font-bold">Manual</p>
+        <ChevronRight size={14} className="text-slate-600" />
+        <p className="text-xs font-bold text-emerald-200">¿Qué puede hacer Chagra?</p>
+      </div>
+
+      <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-4">
+        {/* Hero: la mano de Chagra presenta sus capacidades */}
+        <div className="flex items-start gap-3">
+          <span className="shrink-0 inline-flex items-center justify-center w-14 h-14 rounded-[16px_16px_16px_6px] bg-emerald-700/30 border border-emerald-500/50 text-emerald-300">
+            <ManoChagraGlyph size={32} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-2xl font-black text-emerald-100 leading-tight">
+              Todo esto puede hacer Chagra
+            </h2>
+            <p className="text-sm text-slate-300 leading-relaxed mt-1">
+              Toca una tarjeta y te lleva directo. Estas mismas funciones brotan
+              de <strong className="text-emerald-200">la mano de Chagra</strong>{' '}
+              (el botón Ⓐ) en cualquier pantalla.
+            </p>
+          </div>
+        </div>
+
+        <CosturaDivider />
+
+        {/* Buscador simple (mismo filtro plano del Manual, sin IA) */}
+        <div className="relative">
+          <Search size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500 pointer-events-none" aria-hidden="true" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Buscar una función (ej. plaga, foto, vender)"
+            aria-label="Buscar una función"
+            className="w-full pl-10 pr-10 py-3 rounded-xl bg-slate-900/70 border border-slate-700 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/60 focus:border-emerald-600/60 min-h-[48px]"
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => setQuery('')}
+              aria-label="Borrar búsqueda"
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-full text-slate-400 hover:text-slate-200 active:bg-slate-800 min-h-[36px] min-w-[36px] flex items-center justify-center"
+            >
+              <X size={16} />
+            </button>
+          )}
+        </div>
+
+        {/* Grupos (mismo orden de ramas de la mano) */}
+        {GRUPOS.map((g) => {
+          const caps = porGrupo.get(g.id);
+          if (!caps || caps.length === 0) return null;
+          return (
+            <section key={g.id} aria-label={g.label}>
+              <p className="text-[11px] uppercase tracking-wider text-emerald-400/80 font-bold mb-2">
+                {g.label}
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {caps.map((cap) => {
+                  const accion = accionDe(cap);
+                  return (
+                    <button
+                      key={cap.id}
+                      type="button"
+                      onClick={() => go(accion.view)}
+                      data-testid={`funcion-${cap.id}`}
+                      className="rounded-[16px_16px_16px_6px] bg-slate-900/60 border border-slate-800 hover:border-emerald-600/50 active:scale-[0.99] transition-all p-3 text-left flex items-center gap-3 min-h-[64px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+                    >
+                      <span
+                        aria-hidden="true"
+                        className="shrink-0 inline-flex items-center justify-center w-11 h-11 text-[22px] leading-none bg-slate-950/60 border border-slate-700/60 rounded-[12px_12px_12px_5px]"
+                      >
+                        {cap.icon}
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-sm font-black text-slate-100 leading-tight">
+                          {cap.label}
+                        </span>
+                        {cap.desc && (
+                          <span className="block text-[11px] text-slate-400 leading-snug mt-0.5">
+                            {cap.desc}
+                          </span>
+                        )}
+                      </span>
+                      <span className="shrink-0 inline-flex items-center gap-1 text-[10px] font-bold text-emerald-300">
+                        {accion.tipo === 'foto' && <Camera size={12} aria-hidden="true" />}
+                        {accion.tipo === 'preguntar' && <MessageCircle size={12} aria-hidden="true" />}
+                        {accion.label}
+                        <ChevronRight size={13} aria-hidden="true" className="text-slate-500" />
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+
+        {query && visibles.length === 0 && (
+          <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-5 text-center">
+            <p className="text-sm text-slate-300 leading-relaxed">
+              Ninguna función se llama así.
+            </p>
+            <p className="text-xs text-slate-500 leading-relaxed mt-1.5">
+              Prueba con otra palabra (ej.{' '}
+              <strong className="text-slate-300">plaga</strong>,{' '}
+              <strong className="text-slate-300">foto</strong>,{' '}
+              <strong className="text-slate-300">vender</strong>) o pregúntale
+              al agente con tus palabras.
+            </p>
+          </div>
+        )}
+
+        {/* En camino — honesto, sin botón (anti-promesa) */}
+        {!query && enCamino.length > 0 && (
+          <section aria-label="Funciones en camino" className="mt-1">
+            <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold mb-2">
+              En camino (todavía no)
+            </p>
+            <ul className="flex flex-col gap-1.5">
+              {enCamino.map((cap) => (
+                <li
+                  key={cap.id}
+                  className="rounded-xl border border-dashed border-slate-700/70 bg-slate-900/30 px-3 py-2.5 flex items-center gap-2.5 text-sm text-slate-400"
+                >
+                  <span aria-hidden="true" className="text-base opacity-70">{cap.icon}</span>
+                  <span className="font-bold text-slate-300">{cap.label}</span>
+                  <span className="text-[11px] text-slate-500 min-w-0 truncate">{cap.desc}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <p className="text-[11px] text-slate-600 text-center mt-2 italic leading-relaxed">
+          Esta lista sale del mismo manifiesto que usa la app: si una función no
+          está aquí, Chagra todavía no la tiene. Sin promesas.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/components/help/HelpIllustrations.jsx
+++ b/src/components/help/HelpIllustrations.jsx
@@ -1,0 +1,222 @@
+/**
+ * HelpIllustrations — ilustraciones PROPIAS de la capa de ayuda de Chagra.
+ *
+ * Lenguaje visual (mismo que ManoChagraGlyph / la mochila del agente):
+ *   - Trazo grueso round-cap en `currentColor` → heredan el color del texto
+ *     y funcionan en los 4 temas (biopunk oscuro, minimalista, nature,
+ *     verde-vivo) sin overrides. Legibles al sol (alto contraste = el del
+ *     texto del tema).
+ *   - UNA capa de acento: LA COSTURA — puntada de hilo del acento del tema
+ *     (`--t-accent-rgb`, con fallback al teal biopunk). Es la firma de marca:
+ *     lo curado/verificado va "cosido" como un costal de fique. Cada
+ *     ilustración lleva su puntada.
+ *   - CERO animación: en la ayuda el movimiento distrae (y así reduced-motion
+ *     queda respetado por construcción). La vida está en el contenido.
+ *
+ * Todas aceptan { size, className } y son decorativas (aria-hidden).
+ */
+import React from 'react';
+
+/** Color del hilo de la costura: acento del tema activo. */
+const HILO = 'rgb(var(--t-accent-rgb, 25, 201, 154))';
+
+/** Wrapper común: svg 48×48 de trazo currentColor. */
+function Lienzo({ size, className, children }) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+    >
+      {children}
+    </svg>
+  );
+}
+
+/** Puntada de hilo (path con guiones) en el acento del tema. */
+function Puntada({ d, width = 2.4 }) {
+  return (
+    <path
+      d={d}
+      stroke={HILO}
+      strokeWidth={width}
+      strokeDasharray="4.5 3.5"
+      fill="none"
+    />
+  );
+}
+
+/**
+ * VOZ — micrófono del que brota una hoja; la onda de voz es la costura:
+ * hablar también queda cosido (registrado) en el cuaderno.
+ */
+export function IlusVoz({ size = 56, className = '' }) {
+  return (
+    <Lienzo size={size} className={className}>
+      {/* Cápsula del micrófono */}
+      <rect x="19" y="8" width="10" height="16" rx="5" />
+      {/* Arco del soporte + pie */}
+      <path d="M14 20a10 10 0 0 0 20 0" />
+      <path d="M24 30v6M18 40h12" />
+      {/* Hoja que brota del micrófono (la voz siembra) */}
+      <path d="M29 10c2.2-2.6 5-3.6 8-3-0.4 3-2 5.4-5.2 6.2" />
+      {/* Costura: la onda de lo hablado, cosida */}
+      <Puntada d="M6 27c3-4 5-4 8-1" />
+      <Puntada d="M34 26c3 3 5 3 8-1" />
+    </Lienzo>
+  );
+}
+
+/**
+ * FOTO — cámara con una hoja dentro del lente: "tómele foto a la mata".
+ * La correa de la cámara es la costura.
+ */
+export function IlusFoto({ size = 56, className = '' }) {
+  return (
+    <Lienzo size={size} className={className}>
+      {/* Cuerpo de la cámara */}
+      <path d="M8 16h7l3-4h12l3 4h7v22H8z" />
+      {/* Lente */}
+      <circle cx="24" cy="27" r="7.5" />
+      {/* Hoja dentro del lente (lo que la cámara ve) */}
+      <path d="M21.5 29.5c0-3.5 2-5.5 5.5-6-0.3 3.6-2.2 5.6-5.5 6z" />
+      {/* Visor */}
+      <path d="M34 21h2.5" />
+      {/* Costura: la correa colgando */}
+      <Puntada d="M8 20c-3 1-4.5 3-5 6" />
+      <Puntada d="M40 20c3 1 4.5 3 5 6" />
+    </Lienzo>
+  );
+}
+
+/**
+ * MUNDOS — la finca dibujada de la pantalla de inicio, partida en los cuatro
+ * lugares (Gestionar / Aprender / Jugar / Agente). Los linderos entre parcelas
+ * son costura: los cuatro lugares están cosidos en una sola finca.
+ */
+export function IlusMundos({ size = 56, className = '' }) {
+  return (
+    <Lienzo size={size} className={className}>
+      {/* La finca (lindero exterior redondeado, como parcela vista desde arriba) */}
+      <rect x="6" y="6" width="36" height="36" rx="9" />
+      {/* Linderos interiores = costura */}
+      <Puntada d="M24 7v34" />
+      <Puntada d="M7 24h34" />
+      {/* Gestionar: brote */}
+      <path d="M15 19v-4.5M15 14.5c-1.8 0-3-1-3.2-3 2 0 3.2.8 3.2 3zM15 14.5c1.8-.6 2.8-1.8 3-3.8" />
+      {/* Aprender: libro abierto */}
+      <path d="M29 13c1.6-1 3.2-1 4.5 0v6c-1.3-1-2.9-1-4.5 0zM33.5 13c1.6-1 3.2-1 4.5 0" />
+      {/* Jugar: rombo semilla (ficha de juego) */}
+      <path d="M15 30l3.2 3.5L15 37l-3.2-3.5z" />
+      {/* Agente: burbuja de chat con punto */}
+      <path d="M29 30h8v5h-5.5L29 37.5z" />
+    </Lienzo>
+  );
+}
+
+/**
+ * REGISTRO / CUADERNO — el cuaderno de campo abierto con su lápiz; el lomo es
+ * la costura (el cuaderno está cosido a mano, como los de vereda).
+ */
+export function IlusRegistro({ size = 56, className = '' }) {
+  return (
+    <Lienzo size={size} className={className}>
+      {/* Dos páginas abiertas */}
+      <path d="M24 10c-4-2.6-9.5-3-16-1.5V37c6.5-1.5 12-1 16 1.5" />
+      <path d="M24 10c4-2.6 9.5-3 16-1.5V37c-6.5-1.5-12-1-16 1.5" />
+      {/* Renglones de apuntes (página izquierda) */}
+      <path d="M12 17.5c3-.6 5.5-.7 8-.3M12 23c3-.6 5.5-.7 8-.3M12 28.5c2-.4 3.8-.5 5.5-.4" />
+      {/* Lápiz apoyado en la página derecha */}
+      <path d="M29 27l9.5-9.5 3 3L32 30l-4 1z" />
+      {/* Costura: el lomo cosido del cuaderno */}
+      <Puntada d="M24 11v27" />
+    </Lienzo>
+  );
+}
+
+/**
+ * VERIFICADO — el sello de "esto viene del catálogo": una etiqueta de bulto
+ * (marbete) cuyo chulo está cosido con hilo y aguja. Misma metáfora que la
+ * costura de las respuestas respaldadas del agente.
+ */
+export function IlusVerificado({ size = 56, className = '' }) {
+  return (
+    <Lienzo size={size} className={className}>
+      {/* Marbete (etiqueta de costal) con ojal */}
+      <path d="M10 12h20l8 8v16H10z" />
+      <path d="M30 12v8h8" />
+      <circle cx="15.5" cy="18" r="1.6" />
+      {/* Chulo cosido (hilo del acento) que sale del marbete como hebra */}
+      <Puntada d="M15 28l6 6 12-12" width={2.8} />
+      <Puntada d="M33 22c3-2.5 6-3 9.5-1.5" width={1.8} />
+    </Lienzo>
+  );
+}
+
+/**
+ * DATOS — el cuaderno del bolsillo (teléfono) y su copia en el archivo
+ * central; el camino entre los dos es costura: primero se guarda en tu
+ * aparato, luego se cose con el servidor cuando hay señal.
+ */
+export function IlusDatos({ size = 56, className = '' }) {
+  return (
+    <Lienzo size={size} className={className}>
+      {/* Teléfono con brote en pantalla (tu cuaderno de bolsillo) */}
+      <rect x="7" y="14" width="15" height="26" rx="3.5" />
+      <path d="M14.5 33v-5M14.5 28c-1.6 0-2.7-.9-3-2.7 1.8 0 2.9.8 3 2.7zM14.5 28c1.6-.5 2.5-1.6 2.8-3.4" />
+      {/* Nube (el archivo central) */}
+      <path d="M31 18a5.5 5.5 0 0 1 5.5-4.5c3 0 5.5 2.2 5.7 5.2 2 .6 3 2 3 4 0 2.6-2 4.3-4.7 4.3h-9.3c-2.6 0-4.2-1.7-4.2-4 0-2.6 1.7-4.6 4-5z" />
+      {/* Costura: la sincronización cosida entre aparato y nube */}
+      <Puntada d="M25 33c4.5 0 7.5-2 9.5-5.5" />
+    </Lienzo>
+  );
+}
+
+/**
+ * CICLO — sembrar es un proceso: semilla → brote → mata con fruto, todos
+ * creciendo sobre la misma costura (el hilo del tiempo / el surco).
+ */
+export function IlusCiclo({ size = 56, className = '' }) {
+  return (
+    <Lienzo size={size} className={className}>
+      {/* Sol de la mañana (rayos parejos alrededor) */}
+      <circle cx="39" cy="10" r="3.4" />
+      <path d="M39 3.2v2M39 14.8v2M32.2 10h2M43.8 10h2M34.2 5.2l1.4 1.4M42.4 13.4l1.4 1.4M43.8 5.2l-1.4 1.4M35.6 13.4l-1.4 1.4" strokeWidth="1.8" />
+      {/* Semilla en tierra */}
+      <path d="M9 34c1.8-.4 3-1.5 3.2-3.4-1.9.2-3 1.3-3.2 3.4z" />
+      {/* Brote */}
+      <path d="M22 35v-6M22 29c-1.9 0-3.1-1-3.4-3.2 2.1 0 3.3.9 3.4 3.2zM22 29c1.9-.6 3-1.9 3.2-4" />
+      {/* Mata con fruto */}
+      <path d="M36 35V22M36 27c-2.4 0-4-1.3-4.4-4 2.7 0 4.3 1.2 4.4 4zM36 24c2.4-.7 3.8-2.3 4-5" />
+      <circle cx="40.5" cy="30" r="2.2" />
+      {/* Costura: el surco donde todo va sembrado */}
+      <Puntada d="M5 38.5h38" />
+    </Lienzo>
+  );
+}
+
+/**
+ * CosturaDivider — la puntada de hilo del acento como separador de sección.
+ * Es el MISMO patrón visual del dobladillo de la mochila del agente
+ * (.v3-mochila-stitch) traído a la ayuda: cose el header con el contenido.
+ */
+export function CosturaDivider({ className = '' }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`block h-[2px] rounded-full ${className}`}
+      style={{
+        backgroundImage:
+          'repeating-linear-gradient(90deg, rgba(var(--t-accent-rgb, 25, 201, 154), 0.75) 0 8px, transparent 8px 15px)',
+      }}
+    />
+  );
+}

--- a/src/components/help/__tests__/HelpFuncionesScreen.smoke.test.jsx
+++ b/src/components/help/__tests__/HelpFuncionesScreen.smoke.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HelpFuncionesScreen from '../HelpFuncionesScreen.jsx';
+import { CAPABILITY_MANIFEST } from '../../../services/agentCapabilities.js';
+import { describe, test, expect, vi } from 'vitest';
+
+/**
+ * Smoke test de HelpFuncionesScreen — "¿Qué puede hacer Chagra?".
+ *
+ * Grounding por construcción: la pantalla se DERIVA de CAPABILITY_MANIFEST.
+ * Verifica:
+ *   - Renderiza TODAS las capacidades live visibles de la mano (hero !== false).
+ *   - Deep-link 'nav' navega a la vista del manifiesto (heroRoute.view).
+ *   - Deep-link 'ask'/chip navega al agente.
+ *   - El buscador filtra y el estado vacío no deja pantalla en blanco.
+ *   - Sin voseo argentino en el copy.
+ */
+describe('HelpFuncionesScreen smoke', () => {
+  const vivas = CAPABILITY_MANIFEST.filter(
+    (c) => c.status === 'live' && (c.hero !== false || c.intent)
+  );
+
+  test('Renderiza una tarjeta por cada capacidad live de la mano', () => {
+    render(<HelpFuncionesScreen onBackToHome={() => {}} onNavigate={() => {}} />);
+    for (const cap of vivas) {
+      expect(screen.getByTestId(`funcion-${cap.id}`)).toBeInTheDocument();
+    }
+  });
+
+  test('Capacidad nav abre su vista real del manifiesto', () => {
+    const onNavigate = vi.fn();
+    render(<HelpFuncionesScreen onBackToHome={() => {}} onNavigate={onNavigate} />);
+    const capNav = vivas.find((c) => c.heroRoute?.kind === 'nav' && c.heroRoute.view);
+    fireEvent.click(screen.getByTestId(`funcion-${capNav.id}`));
+    expect(onNavigate).toHaveBeenCalledWith(capNav.heroRoute.view);
+  });
+
+  test('Capacidad de consulta (ask/chip) abre el agente', () => {
+    const onNavigate = vi.fn();
+    render(<HelpFuncionesScreen onBackToHome={() => {}} onNavigate={onNavigate} />);
+    const capAsk = vivas.find((c) => c.heroRoute?.kind === 'ask');
+    fireEvent.click(screen.getByTestId(`funcion-${capAsk.id}`));
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+  });
+
+  test('El buscador filtra y sin coincidencias muestra mensaje', () => {
+    render(<HelpFuncionesScreen onBackToHome={() => {}} onNavigate={() => {}} />);
+    const input = screen.getByLabelText(/Buscar una función/i);
+    fireEvent.change(input, { target: { value: 'zzzzxxxx' } });
+    expect(screen.getByText(/Ninguna función se llama así/i)).toBeInTheDocument();
+  });
+
+  test('El copy no contiene voseo argentino', () => {
+    const { container } = render(
+      <HelpFuncionesScreen onBackToHome={() => {}} onNavigate={() => {}} />
+    );
+    const text = container.textContent || '';
+    expect(text).not.toMatch(/\btenés\b/i);
+    expect(text).not.toMatch(/\bpodés\b/i);
+    expect(text).not.toMatch(/\bacá\b/i);
+    expect(text).not.toMatch(/\bvos\b/i);
+  });
+});

--- a/src/data/help-tips.js
+++ b/src/data/help-tips.js
@@ -1,208 +1,257 @@
-// Tips dinámicos rotantes para HelpManual
-// Fuente: extracto de PlantCemeteryModal.jsx + ciclo contenido DR-034
-// Categoría: errores (cementerio), observacion, riego, sustrato, plagas, paciencia
+// Tips dinámicos rotantes para HelpManual (HelpTipCard).
+// Fuente: extracto de PlantCemeteryModal.jsx + ciclo contenido DR-034.
+// Categoría: errores (cementerio), observacion, riego, sustrato, plagas, paciencia.
+//
+// Overhaul 2026-07 (ayuda visual): cada tip ganó `title` (frase corta y
+// escaneable — para quien lee poco, el título ya es el consejo) y el texto se
+// pasó a HABLA CAMPESINA: fuera "humedad edáfica", "impacto cinético",
+// "manejo arquitectónico" — el dato agronómico es el mismo, dicho como se
+// dice en la vereda. Los ids/categorías/sources NO cambian (compat).
+
+/** Metadatos visuales por categoría (ícono grande + etiqueta del chip). */
+export const TIP_CATEGORIES = Object.freeze({
+  riego: { label: 'Riego', emoji: '💧' },
+  plagas: { label: 'Plagas', emoji: '🐛' },
+  sustrato: { label: 'Tierra', emoji: '🪱' },
+  observacion: { label: 'Observar', emoji: '👀' },
+  paciencia: { label: 'Paciencia', emoji: '🌱' },
+});
+
 export const HELP_TIPS = [
   {
     id: 'cemetery-overwatering',
     category: 'riego',
-    text: 'Antes de regar, meta el dedo 3 cm en el sustrato. Si está húmedo, espere. La mayoría de plantas que mueren por riego excesivo se salvan con esta regla.',
+    title: 'El dedo antes que la regadera',
+    text: 'Antes de regar, meta el dedo 3 cm en la tierra. Si sale húmedo, espere. La mayoría de matas que se mueren ahogadas se salvan con esta regla.',
     source: 'cemetery_reason:overwatering'
   },
   {
     id: 'cemetery-underwatering',
     category: 'riego',
-    text: 'Hojas secas en bordes y caída de flores son señales tempranas. Observe la planta antes de programar riego; ajuste frecuencia según piso térmico y tipo de sustrato.',
+    title: 'La mata avisa antes de secarse',
+    text: 'Bordes de hoja secos y flores que se caen son el primer aviso de sed. Mire la planta antes de regar por costumbre: en tierra caliente pide más seguido que en tierra fría.',
     source: 'cemetery_reason:underwatering'
   },
   {
     id: 'cemetery-pest-disease',
     category: 'plagas',
-    text: 'Toda plaga tiene una ventana de 3-7 días donde es controlable con biopreparados (sulfocálcico, ajo-ají, microorganismos). La observación semanal es prevención.',
+    title: 'La plaga da unos días de ventaja',
+    text: 'Toda plaga tiene una ventana de 3 a 7 días en la que todavía se controla con biopreparados (sulfocálcico, ajo-ají, microorganismos). Darle una vuelta al cultivo cada semana es la mejor prevención.',
     source: 'cemetery_reason:pest_disease'
   },
   {
     id: 'cemetery-wrong-soil',
     category: 'sustrato',
-    text: 'Cada especie tolera un rango de pH y textura. Compactación bloquea oxígeno radicular en 2 semanas. Test casero: si el agua tarda más de 30s en infiltrar, incorpore compost + rompa con horca.',
+    title: 'Tierra apretada, raíz ahogada',
+    text: 'La tierra pisada le quita el aire a la raíz en un par de semanas. Prueba casera: riegue un poco de agua; si tarda más de 30 segundos en entrar, meta compost y afloje con horca, sin voltear.',
     source: 'cemetery_reason:wrong_soil'
   },
   {
     id: 'cemetery-temperature',
     category: 'observacion',
-    text: 'Conozca el rango de temperatura de su especie y proteja con mulch + tela antihelada cuando el pronóstico lo exija. Helada nocturna mata hojas bajo 0°C.',
+    title: 'La helada no perdona',
+    text: 'Sepa qué frío aguanta su especie. Cuando anuncien helada, proteja con mulch (cobertura de hojarasca o paja) y tela antihelada: una noche bajo cero quema las hojas.',
     source: 'cemetery_reason:temperature'
   },
   {
     id: 'cemetery-light',
     category: 'observacion',
-    text: 'Las plantas de sol pleno puestas en sombra se ahílan (crecen pálidas y débiles) y se mueren. Las plantas de sombra puestas a pleno sol se queman. Respete la luz que pide cada especie desde la siembra.',
+    title: 'Cada mata pide su sol',
+    text: 'Una planta de pleno sol puesta en sombra crece pálida, larguirucha y débil. Una de sombra puesta al rayo del sol se quema. Respete la luz que pide cada especie desde la siembra.',
     source: 'cemetery_reason:light'
   },
   {
     id: 'cemetery-transplant',
     category: 'observacion',
-    text: 'Trasplante al atardecer, con sustrato húmedo, sin romper el cepellón. Riegue abundante el primer día y sombree 3 días para evitar choque de trasplante.',
+    title: 'Trasplante al caer la tarde',
+    text: 'Trasplante al atardecer, con la tierra húmeda y sin desbaratar el pan de tierra de la raíz. Riegue bien el primer día y dele sombra 3 días para que no sufra el cambio.',
     source: 'cemetery_reason:transplant_shock'
   },
   {
     id: 'cemetery-unknown',
     category: 'paciencia',
-    text: 'No saber la causa también es dato. Guarde foto del estado final y anote síntomas observados para referencia futura. La curva de aprendizaje agroecológica es de meses, no días.',
+    title: 'No saber la causa también es dato',
+    text: 'Si una mata se murió y no sabe por qué, guarde una foto de cómo quedó y anote lo que vio. Aprender a cultivar toma meses, no días — y cada pérdida anotada enseña.',
     source: 'cemetery_reason:unknown'
   },
   {
     id: 'lechuga-lesson',
     category: 'observacion',
-    text: 'Es el cultivo escuela por excelencia. Ciclo corto (60-90 días) permite observar germinación, trasplante, desarrollo, plagas y cosecha en una temporada. Enseña gestión milimétrica de humedad edáfica y velocidad de ciclo.',
+    title: 'La lechuga es el cultivo escuela',
+    text: 'En 60 a 90 días le muestra todo: germinar, trasplantar, crecer, plagas y cosecha. Enseña a manejar el agua con cuidado y a moverse al ritmo del cultivo. Ideal para empezar.',
     source: 'species_lesson:lechuga'
   },
   {
     id: 'lechuga-watering',
     category: 'riego',
-    text: 'Gestione humedad superficial fina durante germinación (nebulización) y evite impacto cinético de gotas grandes. Temperatura óptima 18-20°C.',
+    title: 'A la semilla, agua en rocío',
+    text: 'Mientras germina, riegue la lechuga con llovizna finita (rocío), no con gotas gruesas que golpean y desentierran la semilla. Le va mejor con clima fresco, de 18 a 20 °C.',
     source: 'species_lesson:lechuga'
   },
   {
     id: 'lechuga-transplant-tip',
     category: 'observacion',
-    text: 'Trasplante al atardecer. Hidrate bandeja 2h antes. Hueco profundidad equivalente al cepellón sin enterrar el cuello. Riego inmediato + sombreado parcial 48h.',
+    title: 'Lechuga: trasplante sin ahorcar el cuello',
+    text: 'Trasplante al atardecer. Moje la bandeja 2 horas antes. El hueco, del tamaño del pan de raíces, sin enterrar el cuello de la mata. Riegue de una y dele media sombra 2 días.',
     source: 'species_lesson:lechuga'
   },
   {
     id: 'lechuga-harvest',
     category: 'paciencia',
-    text: 'Corte basal limpio con cuchillo temprano en la mañana. Empaque inmediato en contenedores rígidos para evitar magulladuras. Coseche cuando diámetro comercial se alcance antes del espigado.',
+    title: 'Coseche temprano, con cuchillo limpio',
+    text: 'Corte la lechuga de raíz con cuchillo limpio, temprano en la mañana. Pásela de una a una caja dura para que no se magulle. Coseche cuando llegue al tamaño de venta, antes de que se espigue (eche tallo de flor).',
     source: 'species_lesson:lechuga'
   },
   {
     id: 'lechuga-companions',
     category: 'plagas',
-    text: 'Plante cebolla, zanahoria o rábano cerca de su lechuga. Los compuestos azufrados de la cebolla disuaden herbívoros y el rábano se cosecha antes del acogollado.',
+    title: 'Cebolla y rábano, guardianes de la lechuga',
+    text: 'Siembre cebolla, zanahoria o rábano al lado de la lechuga. El olor azufrado de la cebolla espanta a los que se la comen, y el rábano se cosecha antes de que la lechuga acogolle.',
     source: 'species_lesson:lechuga'
   },
   {
     id: 'lechuga-biolog',
     category: 'plagas',
-    text: 'Aplique biol al 5% cada 10 días desde día 10 post-trasplante para mejorar crecimiento y resistencia a plagas.',
+    title: 'Biol cada 10 días',
+    text: 'Aplique biol al 5 % (medio litro por cada 10 litros de agua) cada 10 días, desde el día 10 después del trasplante. La mata crece más pareja y aguanta mejor las plagas.',
     source: 'species_lesson:lechuga'
   },
   {
     id: 'lechuga-mulch',
     category: 'sustrato',
-    text: 'Use mulch para estabilizar humedad del sustrato y prevenir enfermedades como quemado de bordes (tip burn) y mildiu velloso.',
+    title: 'Mulch: la cobija de la tierra',
+    text: 'Cubra la tierra con hojarasca o paja (mulch): guarda la humedad pareja y previene el quemado de bordes de la hoja y el mildeo velloso.',
     source: 'species_lesson:lechuga'
   },
   {
     id: 'fresa-lesson',
     category: 'observacion',
-    text: 'Cultivo puente entre agricultura sexual (lechuga) y asexual (café/aguacate por injerto). Enseña propagación vegetativa por estolón — clonación natural visible y manejable.',
+    title: 'La fresa enseña a sacar hijos',
+    text: 'La fresa saca estolones: bejucos con matas hijas idénticas a la madre. Es la escuela para aprender a multiplicar sin semilla — el paso antes de injertar café o aguacate.',
     source: 'species_lesson:fresa'
   },
   {
     id: 'fresa-mulch-obligatorio',
     category: 'sustrato',
-    text: 'El mulch es OBLIGATORIO para fresas — aisla el fruto del suelo y previene Botrytis. Use plástico negro o vegetal como cisco de café o paja.',
+    title: 'Fresa sin mulch se pudre',
+    text: 'En fresa el mulch es OBLIGATORIO: separa el fruto del suelo y evita la pudrición del fruto (moho gris, Botrytis). Sirve plástico negro, cisco de café o paja.',
     source: 'species_lesson:fresa'
   },
   {
     id: 'fresa-propagacion',
     category: 'paciencia',
-    text: 'Renueve su cultivo de fresas cada 2 años con estolones propios. Esto mantiene vigor y productividad en su parcela.',
+    title: 'Renueve la fresa cada 2 años',
+    text: 'Cada 2 años renueve el cultivo con los estolones de sus propias matas. Así la fresera se mantiene vigorosa y productiva sin comprar planta.',
     source: 'species_lesson:fresa'
   },
   {
     id: 'fresa-riego-goteo',
     category: 'riego',
-    text: 'Riegue fresas por goteo, nunca por aspersión. La aspersión favorece el desarrollo de Botrytis cinerea en frutos y flores.',
+    title: 'A la fresa, agua al pie',
+    text: 'Riegue la fresa por goteo o al pie de la mata, nunca en lluvia por encima: mojar flores y frutos le abre la puerta al moho gris (Botrytis).',
     source: 'species_lesson:fresa'
   },
   {
     id: 'fresa-higiene',
     category: 'observacion',
-    text: 'Mantenga rigurosa higiene del microclima edáfico alrededor de sus fresas. Elimine hojas secas y frutos dañados para prevenir enfermedades.',
+    title: 'Fresera limpia, fruta sana',
+    text: 'Mantenga limpio el pie de las freseras: saque hojas secas y frutos dañados apenas los vea. Menos material podrido alrededor = menos enfermedad.',
     source: 'species_lesson:fresa'
   },
   {
     id: 'tomate-lesson',
     category: 'observacion',
-    text: 'El tomate chonto es un cultivo aprendiz de poda — enseña manejo arquitectónico de la planta: tutorado, deschuponada semanal, descopado al alcanzar 1.8m.',
+    title: 'El tomate enseña a podar',
+    text: 'El tomate chonto es la escuela de darle forma a la planta: amarrarla a un tutor, quitarle los chupones cada semana y despuntarla cuando llega a 1,80 m.',
     source: 'species_lesson:tomate_chonto'
   },
   {
     id: 'tomate-tutorado',
     category: 'observacion',
-    text: 'Inicie el tutorado de tomate chonto el día 15 post-trasplante. Use estaca de 1.8-2m con hilo en V o malla para apoyar el crecimiento vertical.',
+    title: 'Tutor al día 15',
+    text: 'A los 15 días del trasplante, párele el tutor al tomate: estaca de 1,80 a 2 m con hilo en V o malla, para que suba derecho y el fruto no toque el suelo.',
     source: 'species_lesson:tomate_chonto'
   },
   {
     id: 'tomate-deschupone',
     category: 'plagas',
-    text: 'Realice deschuponada semanal en tomate chonto: elimine los chupones que aparecen en las axilas de las hojas para dirigir energía al fruto principal.',
+    title: 'Chupones fuera, cada semana',
+    text: 'Quítele al tomate chonto los chupones (brotes que salen entre el tallo y la hoja) una vez por semana, para que la fuerza se vaya al fruto y no al monte.',
     source: 'species_lesson:tomate_chonto'
   },
   {
     id: 'tomate-copa-baja',
     category: 'observacion',
-    text: 'Mantenga una copa baja en su tomate chonto (máx 1.8m de altura). Esto facilita la cosecha, mejora la circulación de aire y reduce enfermedades fúngicas.',
+    title: 'Tomate de copa baja',
+    text: 'No deje pasar el tomate chonto de 1,80 m: despúntelo ahí. Así cosecha sin escalera, corre más aire entre las matas y hay menos hongos.',
     source: 'species_lesson:tomate_chonto'
   },
   {
     id: 'tomate-trichoderma-pre',
     category: 'plagas',
-    text: 'Antes del trasplante, inocule masivamente las camas con Trichoderma spp. Esto destruye hifas de Fusarium y Rhizoctonia que causan pudrición de raíces.',
+    title: 'Trichoderma antes de trasplantar',
+    text: 'Antes del trasplante, moje bien las camas con Trichoderma (hongo bueno). Se le adelanta a los hongos que pudren la raíz del tomate (Fusarium y Rhizoctonia).',
     source: 'species_lesson:tomate_chonto'
   },
   {
     id: 'tomate-rotacion-leguminosa',
     category: 'sustrato',
-    text: 'Practique rotación crítica con leguminosas o maíz mínimo 2 ciclos antes de retornar tomate al mismo lote. Esto reduce presión de patógenos del suelo.',
+    title: 'No repita tomate en el mismo lote',
+    text: 'Después de tomate, siembre fríjol (u otra leguminosa) o maíz al menos 2 ciclos antes de volver a meter tomate ahí. Así los males del suelo no se enseñan al lote.',
     source: 'species_lesson:tomate_chonto'
   },
   {
     id: 'tomate-espaldera-colombiana',
     category: 'observacion',
-    text: 'Use la espaldera colombiana para su tomate: poste cada 4m + alambre superior + hilo individual por planta. Esta estructura es económica y efectiva.',
+    title: 'La espaldera colombiana rinde',
+    text: 'Para el tomate: poste cada 4 metros, un alambre arriba y un hilo por mata colgando del alambre. Barata, rápida de armar y aguanta toda la cosecha.',
     source: 'species_lesson:tomate_chonto'
   },
   {
     id: 'tomate-polinizacion-abejorro',
     category: 'observacion',
-    text: 'En climas fríos, introduzca abejorros nativos Bombus atratus para polinizar su tomate chonto. Esto evita aborto floral por temperaturas <10°C nocturnas.',
+    title: 'En clima frío, cuide al abejorro',
+    text: 'En tierra fría el tomate bota la flor si la noche baja de 10 °C y nadie la poliniza. Cuide y atraiga al abejorro nativo (Bombus atratus) dejando flores silvestres cerca: es el mejor polinizador del tomate.',
     source: 'species_lesson:tomate_chonto'
   },
   {
     id: 'observacion-humedad-raices',
     category: 'observacion',
-    text: 'Aprenda a leer las señales de su planta: hojas flojas indican falta de agua; hojas amarillentas pueden indicar exceso. Observe diariamente, no solo riegue por hábito.',
+    title: 'Lea las hojas antes de regar',
+    text: 'Hoja caída y floja: falta agua. Hoja amarilla pareja: puede ser exceso. Mire sus matas todos los días un momento — regar por costumbre mata más que la sequía.',
     source: 'general:observacion'
   },
   {
     id: 'sustrato-compost-maduro',
     category: 'sustrato',
-    text: 'Siempre use compost maduro en su sustrato. El compost fresco puede quemar las raíces y competir por nitrógeno durante su descomposición.',
+    title: 'Compost maduro, nunca caliente',
+    text: 'Use siempre compost maduro (oscuro, con olor a tierra de monte). El compost fresco todavía está "caliente": quema la raíz y le roba nitrógeno a la mata mientras termina de descomponerse.',
     source: 'general:sustrato'
   },
   {
     id: 'plagas-prevencion-semanal',
     category: 'plagas',
-    text: 'La prevención es su mejor aliada contra plagas. Dedique 10 minutos cada semana a inspeccionar el envés de las hojas y tallos en busca de insectos o hongos.',
+    title: '10 minutos que valen la cosecha',
+    text: 'Una vez por semana, voltee hojas y mire el envés y los tallos buscando bichos o manchas. Agarrar la plaga chiquita es la diferencia entre un biopreparado y perder el cultivo.',
     source: 'general:plagas'
   },
   {
     id: 'paciencia-cosecha-escalonada',
     category: 'paciencia',
-    text: 'Siembre en escalonado: cada 2-3 semanas una nueva tanda de semillas. Así tendrá cosecha continua en lugar de un exceso que se pierde.',
+    title: 'Siembre por tandas',
+    text: 'Cada 2 o 3 semanas siembre una tanda nueva en vez de todo de una. Así cosecha seguido todo el tiempo, en lugar de un montón que no alcanza a comerse ni a vender.',
     source: 'general:paciencia'
   },
   {
     id: 'error-aprender-del-fracaso',
     category: 'observacion',
-    text: 'Cada planta que no prospera es un maestro. Anote qué hizo diferente esa vez y ajuste su próximo intento. El fracaso es parte del currículo agroecológico.',
+    title: 'Cada mata perdida es un maestro',
+    text: 'Cuando una planta no prospere, anote qué hizo distinto esa vez y cámbielo en el siguiente intento. Equivocarse hace parte del oficio — lo grave es no anotarlo.',
     source: 'general:mentalidad'
   }
 ];
 
 // Nota: ampliación pendiente según roadmap queue/040 fase 2.
-// Actualmente hay 27 tips cubriendo errores comunes, observación, riego,
-// sustrato, plagas y paciencia. Próximo objetivo: 30-50 tips con curaduría
+// Actualmente hay 33 tips cubriendo errores comunes, observación, riego,
+// tierra, plagas y paciencia. Próximo objetivo: 30-50 tips con curaduría
 // humana basada en Cementerio de Plantas + lecciones de especies clave.


### PR DESCRIPTION
## Qué hace

Overhaul de TODA la capa de ayuda (tips + botón "?") con carga visual propia. Capa visual + contenido; **cero cambios de lógica de negocio**.

### Nuevo
- **`help/HelpIllustrations.jsx`** — 7 ilustraciones SVG propias (voz, foto, mundos, registro/cuaderno, verificado, datos, ciclo). Trazo `currentColor` + puntada de **LA COSTURA** en el acento del tema (`--t-accent-rgb`) → coherentes en los 4 temas (incl. biopunk) sin overrides, sin animación (reduced-motion por construcción), legibles al sol. + `CosturaDivider`.
- **`help/HelpFuncionesScreen.jsx`** — "¿Qué puede hacer Chagra?": derivada de `CAPABILITY_MANIFEST` (grounded por construcción — si no está en el manifiesto, no aparece). Tarjetas por grupo con **deep-link real** (Abrir / Pregúntale / Con foto), chips de grounding del chat incluidos, sección honesta "En camino". Es la primera tarjeta del Manual. Compatible con «Chagra enseña a usar Chagra» (#2050): misma fuente única, archivos distintos.

### Correcciones (contenido roto o desactualizado)
- **App.jsx**: los deep-links `especies`, `calendario` y `gestionar` (usados por Manual, HelpUso y `faqChagra.json` — 8 destinos del FAQ) caían en `default:` **"Vista no disponible"** porque `navigate()` no normaliza por `HASH_VIEW_ROUTES`. Aliases añadidos (3 labels de case).
- **HelpHome**: el lugar "Gestionar" mandaba a `'juego'` (bug del portal replicado en la ayuda) → `'activos'` + título "Mi finca (Gestionar)" (paridad FincaVivaHero).
- **HelpVoz** paso 1: "micrófono abajo a la izquierda, siempre visible" (obsoleto) → mano Ⓐ «Registrar hablando» + botón mic del header.
- **HelpUso**: botón "+" del header ya no existe (UX-27 #286) → mic+planta; precio ya **no** "en construcción" (chip Precio consulta SIPSA/DANE desde 2026-07-01); `animate-pulse` → `motion-safe:`; "hije" → "hijo".
- **help-tips.js**: 33 tips con **título corto escaneable** + habla campesina (fuera "humedad edáfica", "impacto cinético", "manejo arquitectónico"; "introduzca abejorros" → atraer/cuidar el nativo). Ids/categorías/sources intactos.

### Visual
- **HelpTipCard** rediseñada: antes tarjeta ámbar CLARA fija (chocaba con el fondo oscuro y los temas); ahora theme-aware, con costura de verificado, ícono de categoría grande, título negro y botón "Otro tip" ≥40px.
- Ilustraciones propias en tarjetas del Manual + héroes de Voz/Datos/Ciclo; esquina-semilla `16/16/16/6` como lenguaje común con la mochila del agente.
- **AgentScreen**: botón "?" en el header inmersivo (`chagra:nav → ayuda`) — el chat no tenía puerta al Manual.

## Verificación
- `npm run build` verde.
- Tests: 5 suites de ayuda (23), AgentScreen (48), rutas App (26) — verdes. Nuevos smoke tests de HelpFuncionesScreen (derivado del manifiesto) y HelpTipCard (incluye guard anti-jerga y anti-voseo).
- Screenshots reales (HTML renderizado + CSS compilado del build) en biopunk oscuro y tema minimalista claro: ilustraciones, costura y contraste OK en ambos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)