### PR TITLE
fix/agrupar entradas repetidas

### DIFF
--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -25,6 +25,7 @@ import { useFincaActiveStore } from '../services/fincaActiveStore';
 import { savePhoto } from '../services/photoService';
 import { wktToGeoJson } from '../utils/geo';
 import { buildPlantMeta, formatPlantMetaFallbackLine, ETAPA_FENOLOGICA_OPTIONS } from '../utils/plantMeta';
+import { agruparEntradas, claveMataAgrupada, stripInstanceSuffix, formatFechaSiembra } from '../utils/agruparEntradas';
 import MultiFincaModal from './MultiFincaModal';
 
 // Note: fincaNombre constant removed. Now derived from useFincaActiveStore inside the component.
@@ -415,6 +416,19 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
   // Estado local del formulario de cosecha scoped por asset.id
   const [activeHarvestId, setActiveHarvestId] = useState(null);
   const [harvestData, setHarvestData] = useState({ yield: '', unit: 'kg', notes: '' });
+
+  // Grupos de matas expandidos (por clave). Cuando se siembran varias matas
+  // iguales (individual + qty>1 → "Fresa #01".."#20"), el listado las colapsa
+  // en UNA fila "Fresa ×20 · sembradas 4 mar · <zona>". Expandir muestra las
+  // individuales para editar/cosechar/eliminar cada una.
+  const [expandedGroups, setExpandedGroups] = useState(() => new Set());
+  const toggleGroup = (key) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
 
   const resetHarvestForm = () => {
     setActiveHarvestId(null);
@@ -856,6 +870,217 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
   const tabConfig = ASSET_TABS.find(t => t.id === activeTab);
   const currentAssets = getAssetsForTab();
   const colors = colorMap[tabConfig.color];
+
+  // Nombre legible de un lote/zona a partir de su id (para las etiquetas de grupo).
+  const landNameById = (id) => {
+    if (!id) return '';
+    const land = lands.find((l) => l.id === id);
+    return (land?.attributes?.name || land?.name || '').trim();
+  };
+
+  // Mejor fecha de siembra conocida de una mata: la fecha_germinacion que el
+  // operador escribió, o la de creación local.
+  const plantSowDate = (asset) =>
+    asset.attributes?._chagra_plant_meta?.fecha_germinacion
+    || asset._createdAt
+    || asset.attributes?.created
+    || asset.attributes?.timestamp
+    || null;
+
+  // Filas a renderizar. Solo en la tab 'plant' colapsamos matas equivalentes
+  // (misma especie + fecha de siembra + lote) en una fila agregada; el resto de
+  // tabs (zonas, infraestructura, equipo, material) van fila por fila.
+  const plantRows = activeTab === 'plant'
+    ? agruparEntradas(currentAssets, (asset) => claveMataAgrupada({
+        species: asset.attributes?._speciesSlug,
+        name: asset.attributes?.name || asset.name,
+        date: plantSowDate(asset),
+        bed: getParentLandId(asset),
+      }))
+    : currentAssets.map((asset, i) => ({
+        key: asset.id || `row-${i}`,
+        items: [asset],
+        count: 1,
+        representative: asset,
+        grouped: false,
+      }));
+
+  // Tarjeta individual de un activo (mata/zona/infra/…). Reutilizable tanto para
+  // una fila suelta como para cada mata dentro de un grupo expandido, así no se
+  // pierde ninguna funcionalidad por-mata (ver ficha, cosechar, eliminar).
+  const renderAssetCard = (asset, { nested = false } = {}) => {
+    // Bug pre-demo-institucional 2026-05-19: en tab 'structure' conviven lands +
+    // structures. Diferenciamos icono y label fallback según el `type`.
+    const rawName = (asset.attributes?.name || asset.name || '').trim();
+    const isLand = asset.type === 'asset--land';
+    const isStructure = asset.type === 'asset--structure';
+    const typeLabel = isLand ? 'zona' : isStructure ? 'infraestructura' : '';
+    const name = rawName || (typeLabel ? `(sin nombre · ${typeLabel})` : '(sin nombre)');
+    const notes = asset.attributes?.notes;
+    const notesText = typeof notes === 'object' ? notes?.value : notes;
+    const isPending = asset._pending;
+    const TabIcon = activeTab === 'structure'
+      ? (isLand ? Square : Warehouse)
+      : tabConfig.icon;
+
+    return (
+      <div
+        role="article"
+        className={`p-4 rounded-xl border transition-all ${isPending
+          ? 'bg-slate-800/50 border-dashed border-slate-600'
+          : nested
+            ? 'bg-slate-800/60 border-slate-700/70'
+            : 'bg-slate-800 border-slate-700'
+          }`}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => setSelectedAsset(asset.id)}
+            className="flex items-center gap-3 flex-1 min-w-0 text-left hover:opacity-80 transition-opacity"
+          >
+            {activeTab === 'plant' ? (
+              <PlantCardThumb asset={asset} colors={colors} FallbackIcon={TabIcon} />
+            ) : (
+              <div className={`p-2.5 rounded-lg ${colors.light} shrink-0`}>
+                <TabIcon size={20} className={colors.text} />
+              </div>
+            )}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5 flex-wrap">
+                <h4 className="font-bold text-slate-200 truncate text-base">{name}</h4>
+                <span className="text-[10px] font-bold uppercase text-emerald-300/70 border border-emerald-700/40 bg-emerald-900/20 rounded-full px-2 py-0.5 shrink-0">{fincaNombre}</span>
+                {isPending && (
+                  <span className="text-xs text-amber-400 bg-amber-900/30 px-1.5 py-0.5 rounded-full shrink-0">pendiente</span>
+                )}
+              </div>
+              {notesText && <p className="text-xs text-slate-500 truncate mt-1">{notesText}</p>}
+            </div>
+          </button>
+          <button
+            onClick={() => handleDelete(asset.id)}
+            className="p-2 rounded-lg bg-red-900/30 hover:bg-red-800/50 text-red-400 shrink-0 min-h-[40px] min-w-[40px] flex items-center justify-center"
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+
+        {/* Registro de cosecha (solo tab plant, no registros pendientes) */}
+        {activeTab === 'plant' && !isPending && (
+          <div className="mt-4 border-t border-slate-700 pt-4">
+            {activeHarvestId !== asset.id ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setActiveHarvestId(asset.id);
+                  setHarvestData({ yield: '', unit: 'kg', notes: '' });
+                }}
+                className="w-full py-2 bg-lime-700 text-white rounded-md hover:bg-lime-600 transition-colors text-sm font-medium"
+              >
+                Registrar Cosecha
+              </button>
+            ) : (
+              <div className="bg-slate-900 p-3 rounded-md border border-slate-600">
+                <h4 className="text-sm font-bold text-slate-200 mb-2">Datos de Rendimiento</h4>
+                <div className="flex gap-2 mb-2">
+                  <input
+                    type="number"
+                    placeholder="Cantidad"
+                    value={harvestData.yield}
+                    onChange={(e) => setHarvestData({ ...harvestData, yield: e.target.value })}
+                    className="w-2/3 p-2 bg-slate-800 border border-slate-700 rounded text-sm text-slate-200"
+                  />
+                  <select
+                    value={harvestData.unit}
+                    onChange={(e) => setHarvestData({ ...harvestData, unit: e.target.value })}
+                    className="w-1/3 p-2 bg-slate-800 border border-slate-700 rounded text-sm text-slate-200"
+                  >
+                    <option value="kg">kg</option>
+                    <option value="g">g</option>
+                    <option value="lb">lb</option>
+                    <option value="unidades">unds</option>
+                  </select>
+                </div>
+                <textarea
+                  placeholder="Observaciones fitosanitarias o de calidad..."
+                  value={harvestData.notes}
+                  onChange={(e) => setHarvestData({ ...harvestData, notes: e.target.value })}
+                  className="w-full p-2 bg-slate-800 border border-slate-700 rounded text-sm text-slate-200 mb-2"
+                  rows={2}
+                />
+                <div className="flex gap-2 justify-end">
+                  <button
+                    type="button"
+                    onClick={resetHarvestForm}
+                    className="px-3 py-1 text-xs text-slate-400 hover:text-white"
+                  >
+                    Cancelar
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => submitHarvest(asset)}
+                    disabled={!harvestData.yield}
+                    className="px-3 py-1 bg-lime-600 text-white text-xs rounded hover:bg-lime-500 disabled:opacity-50"
+                  >
+                    Guardar Registro
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // Tarjeta AGREGADA de un grupo de matas iguales: "🌱 Fresa ×20 · sembradas
+  // 4 mar · Cama 1", expandible a las matas individuales.
+  const renderGroupCard = (grupo) => {
+    const rep = grupo.representative;
+    const nombre = stripInstanceSuffix(rep.attributes?.name || rep.name) || '(sin nombre)';
+    const fecha = formatFechaSiembra(plantSowDate(rep));
+    const zona = landNameById(getParentLandId(rep));
+    const isOpen = expandedGroups.has(grupo.key);
+    const anyPending = grupo.items.some((a) => a._pending);
+    const detalle = [fecha ? `sembradas ${fecha}` : '', zona].filter(Boolean).join(' · ');
+    return (
+      <div className={`rounded-xl border transition-all ${anyPending ? 'bg-slate-800/50 border-dashed border-slate-600' : 'bg-slate-800 border-slate-700'}`}>
+        <button
+          type="button"
+          onClick={() => toggleGroup(grupo.key)}
+          aria-expanded={isOpen}
+          className="w-full flex items-center gap-3 p-4 text-left hover:opacity-90 transition-opacity"
+        >
+          <PlantCardThumb asset={rep} colors={colors} FallbackIcon={tabConfig.icon} />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <h4 className="font-bold text-slate-200 truncate text-base">{nombre}</h4>
+              <span className="text-xs font-bold text-lime-300 bg-lime-900/40 border border-lime-700/40 rounded-full px-2 py-0.5 shrink-0 tabular-nums">×{grupo.count}</span>
+              {anyPending && (
+                <span className="text-xs text-amber-400 bg-amber-900/30 px-1.5 py-0.5 rounded-full shrink-0">pendiente</span>
+              )}
+            </div>
+            {detalle && <p className="text-xs text-slate-500 truncate mt-1">{detalle}</p>}
+          </div>
+          <ChevronDown size={20} className={`text-slate-500 shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+        </button>
+        {isOpen && (
+          <div className="px-3 pb-3 pt-0 flex flex-col gap-2 border-t border-slate-700/60">
+            <p className="text-2xs text-slate-500 pt-2 px-1">{grupo.count} matas individuales — toca una para ver su ficha, cosechar o eliminar.</p>
+            {grupo.items.map((asset) => (
+              <div key={asset.id}>{renderAssetCard(asset, { nested: true })}</div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderRow = (grupo) => (
+    <div className="pb-2 px-1">
+      {grupo.grouped ? renderGroupCard(grupo) : renderAssetCard(grupo.representative)}
+    </div>
+  );
 
   const getPlaceholder = () => {
     if (activeTab === 'plant') return 'Ej: Café, Aguacate, Guanábana...';
@@ -1703,145 +1928,19 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
             </div>
           ) : (
             <Virtuoso
-              data={currentAssets}
+              data={plantRows}
               initialTopMostItemIndex={(() => {
                 const saved = sessionStorage.getItem(`chagra:scroll:activos:${activeTab}`);
                 return saved ? parseInt(saved, 10) : 0;
               })()}
               rangeChanged={(range) => {
-                // Throttled save? sessionStorage is fast enough for small strings, 
+                // Throttled save? sessionStorage is fast enough for small strings,
                 // but let's follow the 056-1 rule of "topmost index".
                 sessionStorage.setItem(`chagra:scroll:activos:${activeTab}`, String(range.startIndex));
               }}
               style={{ height: '100%', width: '100%' }}
               overscan={400}
-              itemContent={(index, asset) => {
-                // Bug pre-demo-institucional 2026-05-19: en tab 'structure' ahora
-                // conviven lands + structures. Diferenciamos icono y label
-                // fallback según el `type` del asset para que el operador
-                // pueda distinguir un terreno (land) de una construcción
-                // (structure) aun cuando ambos carecen de nombre.
-                const rawName = (asset.attributes?.name || asset.name || '').trim();
-                const isLand = asset.type === 'asset--land';
-                const isStructure = asset.type === 'asset--structure';
-                const typeLabel = isLand ? 'zona' : isStructure ? 'infraestructura' : '';
-                const name = rawName || (typeLabel ? `(sin nombre · ${typeLabel})` : '(sin nombre)');
-                const notes = asset.attributes?.notes;
-                const notesText = typeof notes === 'object' ? notes?.value : notes;
-                const isPending = asset._pending;
-                const TabIcon = activeTab === 'structure'
-                  ? (isLand ? Square : Warehouse)
-                  : tabConfig.icon;
-
-                return (
-                  <div className="pb-2 px-1">
-                    <div
-                      role="article"
-                      className={`p-4 rounded-xl border transition-all ${isPending
-                        ? 'bg-slate-800/50 border-dashed border-slate-600'
-                        : 'bg-slate-800 border-slate-700'
-                        }`}
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <button
-                          type="button"
-                          onClick={() => setSelectedAsset(asset.id)}
-                          className="flex items-center gap-3 flex-1 min-w-0 text-left hover:opacity-80 transition-opacity"
-                        >
-                          {activeTab === 'plant' ? (
-                            <PlantCardThumb asset={asset} colors={colors} FallbackIcon={TabIcon} />
-                          ) : (
-                            <div className={`p-2.5 rounded-lg ${colors.light} shrink-0`}>
-                              <TabIcon size={20} className={colors.text} />
-                            </div>
-                          )}
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-1.5 flex-wrap">
-                              <h4 className="font-bold text-slate-200 truncate text-base">{name}</h4>
-                              <span className="text-[10px] font-bold uppercase text-emerald-300/70 border border-emerald-700/40 bg-emerald-900/20 rounded-full px-2 py-0.5 shrink-0">{fincaNombre}</span>
-                              {isPending && (
-                                <span className="text-xs text-amber-400 bg-amber-900/30 px-1.5 py-0.5 rounded-full shrink-0">pendiente</span>
-                              )}
-                            </div>
-                            {notesText && <p className="text-xs text-slate-500 truncate mt-1">{notesText}</p>}
-                          </div>
-                        </button>
-                        <button
-                          onClick={() => handleDelete(asset.id)}
-                          className="p-2 rounded-lg bg-red-900/30 hover:bg-red-800/50 text-red-400 shrink-0 min-h-[40px] min-w-[40px] flex items-center justify-center"
-                        >
-                          <Trash2 size={16} />
-                        </button>
-                      </div>
-
-                      {/* Registro de cosecha (solo tab plant, no registros pendientes) */}
-                      {activeTab === 'plant' && !isPending && (
-                        <div className="mt-4 border-t border-slate-700 pt-4">
-                          {activeHarvestId !== asset.id ? (
-                            <button
-                              type="button"
-                              onClick={() => {
-                                setActiveHarvestId(asset.id);
-                                setHarvestData({ yield: '', unit: 'kg', notes: '' });
-                              }}
-                              className="w-full py-2 bg-lime-700 text-white rounded-md hover:bg-lime-600 transition-colors text-sm font-medium"
-                            >
-                              Registrar Cosecha
-                            </button>
-                          ) : (
-                            <div className="bg-slate-900 p-3 rounded-md border border-slate-600">
-                              <h4 className="text-sm font-bold text-slate-200 mb-2">Datos de Rendimiento</h4>
-                              <div className="flex gap-2 mb-2">
-                                <input
-                                  type="number"
-                                  placeholder="Cantidad"
-                                  value={harvestData.yield}
-                                  onChange={(e) => setHarvestData({ ...harvestData, yield: e.target.value })}
-                                  className="w-2/3 p-2 bg-slate-800 border border-slate-700 rounded text-sm text-slate-200"
-                                />
-                                <select
-                                  value={harvestData.unit}
-                                  onChange={(e) => setHarvestData({ ...harvestData, unit: e.target.value })}
-                                  className="w-1/3 p-2 bg-slate-800 border border-slate-700 rounded text-sm text-slate-200"
-                                >
-                                  <option value="kg">kg</option>
-                                  <option value="g">g</option>
-                                  <option value="lb">lb</option>
-                                  <option value="unidades">unds</option>
-                                </select>
-                              </div>
-                              <textarea
-                                placeholder="Observaciones fitosanitarias o de calidad..."
-                                value={harvestData.notes}
-                                onChange={(e) => setHarvestData({ ...harvestData, notes: e.target.value })}
-                                className="w-full p-2 bg-slate-800 border border-slate-700 rounded text-sm text-slate-200 mb-2"
-                                rows={2}
-                              />
-                              <div className="flex gap-2 justify-end">
-                                <button
-                                  type="button"
-                                  onClick={resetHarvestForm}
-                                  className="px-3 py-1 text-xs text-slate-400 hover:text-white"
-                                >
-                                  Cancelar
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => submitHarvest(asset)}
-                                  disabled={!harvestData.yield}
-                                  className="px-3 py-1 bg-lime-600 text-white text-xs rounded hover:bg-lime-500 disabled:opacity-50"
-                                >
-                                  Guardar Registro
-                                </button>
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                );
-              }}
+              itemContent={(index, grupo) => renderRow(grupo)}
             />
           )}
         </div>

--- a/src/components/CalendarioFincaScreen.jsx
+++ b/src/components/CalendarioFincaScreen.jsx
@@ -9,6 +9,7 @@ import { listFarmProcesses, hydrateCyclesFromFarmOS } from '../db/farmProcessCac
 import { getProfile } from '../services/userProfileService';
 import { getAllSpecies } from '../db/catalogDB';
 import { matchSpeciesInCatalog } from '../utils/speciesResolver';
+import { agruparEntradas, claveMataAgrupada } from '../utils/agruparEntradas';
 import { isPerennialSpecies, monthShortName } from '../data/perennialCycles';
 import { getTemplate } from '../data/phenologyTemplates';
 import {
@@ -113,11 +114,26 @@ export default function CalendarioFincaScreen({ onBack, onHome, onNavigate }) {
       let fallback = false;
 
       if (Array.isArray(cycles) && cycles.length > 0) {
-        built = cycles.map((cycle) => {
+        // Agrupar ciclos equivalentes (misma especie + fecha + lote) ANTES de
+        // armar el calendario: N matas iguales ("Fresa #01".."#20") tienen un
+        // calendario fenológico idéntico, así que se colapsan en UNA fila
+        // "Fresa ×20". Sin esto la tira anual y el detalle mensual repiten la
+        // misma información N veces y el conteo de tareas queda inflado.
+        const grupos = agruparEntradas(cycles, (cycle) => {
+          const a = cycle.attributes || {};
+          return claveMataAgrupada({
+            species: a.subject_slug,
+            name: a.subject_label,
+            date: a.created_at,
+            bed: a.location_land_asset_id,
+          });
+        });
+        built = grupos.map((grupo) => {
+          const cycle = grupo.representative;
           const a = cycle.attributes || {};
           const species = matchSpeciesInCatalog(catalog, a.subject_slug, a.subject_label);
           const speciesSlug = species?.id || species?.slug || a.subject_slug;
-          return buildPlantCalendar({
+          const plant = buildPlantCalendar({
             id: cycle.process_id || cycle.id,
             name: a.subject_label || species?.nombre_comun || speciesSlug,
             speciesSlug,
@@ -126,6 +142,9 @@ export default function CalendarioFincaScreen({ onBack, onHome, onNavigate }) {
             altitudeM,
             now,
           });
+          // Cuántas matas iguales representa esta fila (para el badge "×N").
+          plant.count = grupo.count;
+          return plant;
         });
       } else {
         // 2. Sin finca: calendario por especie del catálogo con datos honestos.
@@ -388,6 +407,9 @@ export default function CalendarioFincaScreen({ onBack, onHome, onNavigate }) {
                   >
                     <span className="flex items-center gap-2 min-w-0">
                       <span className="text-sm font-bold text-white truncate">{plant.name}</span>
+                      {plant.count > 1 && (
+                        <span className="text-2xs font-bold text-lime-300 bg-lime-900/30 border border-lime-700/40 rounded-full px-1.5 py-0.5 shrink-0 tabular-nums">×{plant.count}</span>
+                      )}
                       {plant.isGeneric && (
                         <span className="text-2xs text-amber-400 shrink-0">aprox.</span>
                       )}

--- a/src/components/CicloCultivoScreen.jsx
+++ b/src/components/CicloCultivoScreen.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ChevronLeft, Sprout, Mic, RotateCcw, AlertTriangle, Beaker } from 'lucide-react';
+import { ChevronLeft, ChevronDown, Sprout, Mic, RotateCcw, AlertTriangle, Beaker } from 'lucide-react';
 import { listFarmProcesses, hydrateCyclesFromFarmOS } from '../db/farmProcessCache';
+import { agruparEntradas, claveMataAgrupada, stripInstanceSuffix, formatFechaSiembra } from '../utils/agruparEntradas';
 import { getProfile } from '../services/userProfileService';
 import DailyTasksView from './DailyTasksView';
 import CicloDetalle from './CicloDetalle';
@@ -22,6 +23,8 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
   const [error, setError] = useState('');
   const [cycles, setCycles] = useState([]);
   const [selectedId, setSelectedId] = useState(null);
+  // Grupos expandidos (por clave) — N matas iguales se colapsan en una fila.
+  const [expandedGroups, setExpandedGroups] = useState(() => new Set());
 
   const altitudeM = useMemo(() => {
     const v = getProfile()?.finca_altitud;
@@ -70,6 +73,32 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
     () => cycles.find((c) => (c.process_id || c.id) === selectedId) || null,
     [cycles, selectedId],
   );
+
+  // Agrupar ciclos equivalentes (misma especie + fecha de siembra + lote) para
+  // no repetir N filas casi idénticas cuando se sembraron varias matas iguales
+  // ("Fresa #01".."#20"). Cada grupo se puede expandir a sus ciclos individuales
+  // (que siguen navegando a su propio detalle). Presentación pura: DailyTasksView
+  // y el detalle siguen usando `cycles` sin tocar.
+  const cycleGroups = useMemo(
+    () => agruparEntradas(cycles, (c) => {
+      const a = c.attributes || {};
+      return claveMataAgrupada({
+        species: a.subject_slug,
+        name: a.subject_label,
+        date: a.created_at,
+        bed: a.location_land_asset_id,
+      });
+    }),
+    [cycles],
+  );
+
+  const toggleGroup = useCallback((key) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  }, []);
 
   const Header = (
     <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
@@ -161,15 +190,18 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
           {/* Digest "para hoy": labores urgentes agregadas de todos los ciclos. */}
           <DailyTasksView processes={cycles} />
           <ul className="flex flex-col gap-2">
-          {cycles.map((c) => {
-            const a = c.attributes || {};
-            const id = c.process_id || c.id;
-            return (
-              <li key={id}>
+          {cycleGroups.map((grupo) => {
+            // Fila individual reutilizable (navega al detalle del ciclo).
+            const renderCycleRow = (c, { nested = false } = {}) => {
+              const a = c.attributes || {};
+              const id = c.process_id || c.id;
+              return (
                 <button
                   type="button"
                   onClick={() => setSelectedId(id)}
-                  className="w-full text-left bg-slate-900 border border-slate-800 hover:border-lime-700/50 rounded-xl p-3 flex items-center gap-3"
+                  className={`w-full text-left border rounded-xl p-3 flex items-center gap-3 ${nested
+                    ? 'bg-slate-900/60 border-slate-800/80 hover:border-lime-700/40'
+                    : 'bg-slate-900 border-slate-800 hover:border-lime-700/50'}`}
                 >
                   <span className="w-10 h-10 rounded-full bg-lime-900/40 border border-lime-800/50 flex items-center justify-center shrink-0">
                     <Sprout size={18} className="text-lime-400" />
@@ -180,6 +212,49 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
                   </span>
                   <ChevronLeft size={18} className="text-slate-600 rotate-180" />
                 </button>
+              );
+            };
+
+            // Grupo unitario o pequeño → fila normal (una sola).
+            if (!grupo.grouped) {
+              const c = grupo.representative;
+              return <li key={grupo.key}>{renderCycleRow(c)}</li>;
+            }
+
+            // Grupo colapsado: "Fresa ×20 · sembradas 4 mar" + expandir.
+            const a = grupo.representative.attributes || {};
+            const nombre = stripInstanceSuffix(a.subject_label) || a.subject_label || 'Ciclo';
+            const fecha = formatFechaSiembra(a.created_at);
+            const isOpen = expandedGroups.has(grupo.key);
+            return (
+              <li key={grupo.key}>
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(grupo.key)}
+                  aria-expanded={isOpen}
+                  className="w-full text-left bg-slate-900 border border-slate-800 hover:border-lime-700/50 rounded-xl p-3 flex items-center gap-3"
+                >
+                  <span className="w-10 h-10 rounded-full bg-lime-900/40 border border-lime-800/50 flex items-center justify-center shrink-0">
+                    <Sprout size={18} className="text-lime-400" />
+                  </span>
+                  <span className="flex-1 min-w-0">
+                    <span className="flex items-center gap-1.5 min-w-0">
+                      <span className="text-sm font-bold text-slate-100 truncate">{nombre}</span>
+                      <span className="text-2xs font-bold text-lime-300 bg-lime-900/40 border border-lime-700/40 rounded-full px-1.5 py-0.5 shrink-0 tabular-nums">×{grupo.count}</span>
+                    </span>
+                    <span className="block text-xs text-slate-400">
+                      Etapa: {a.current_stage || '—'}{fecha ? ` · sembradas ${fecha}` : ''}
+                    </span>
+                  </span>
+                  <ChevronDown size={18} className={`text-slate-500 shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+                </button>
+                {isOpen && (
+                  <ul className="mt-1.5 pl-3 border-l border-slate-800 flex flex-col gap-1.5">
+                    {grupo.items.map((c) => (
+                      <li key={c.process_id || c.id}>{renderCycleRow(c, { nested: true })}</li>
+                    ))}
+                  </ul>
+                )}
               </li>
             );
           })}

--- a/src/components/__tests__/AssetsDashboard.virtualizedList.test.jsx
+++ b/src/components/__tests__/AssetsDashboard.virtualizedList.test.jsx
@@ -160,6 +160,42 @@ describe('AssetsDashboard — lista principal virtualizada (react-virtuoso, queu
     expect(screen.getByTestId('assets-finca-switcher')).toBeTruthy();
   });
 
+  it('colapsa N matas iguales en una fila agrupada "×N" y la expande a las individuales', async () => {
+    const user = userEvent.setup();
+    // 3 fresas sembradas igual (mismo slug + misma fecha + mismo lote) → 1 fila.
+    const meta = { _chagra_plant_meta: { fecha_germinacion: '2026-03-04' } };
+    mockAssetState.plants = [
+      { id: 'fresa-1', type: 'asset--plant', attributes: { name: 'Fresa #01', _speciesSlug: 'fragaria_ananassa', ...meta } },
+      { id: 'fresa-2', type: 'asset--plant', attributes: { name: 'Fresa #02', _speciesSlug: 'fragaria_ananassa', ...meta } },
+      { id: 'fresa-3', type: 'asset--plant', attributes: { name: 'Fresa #03', _speciesSlug: 'fragaria_ananassa', ...meta } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="plant" />);
+    await user.click(screen.getByText(/Ver todos/i));
+    // Colapsado: badge "×3", nombre limpio "Fresa", y las individuales ocultas.
+    expect(screen.getByText('×3')).toBeTruthy();
+    expect(screen.getByText('Fresa')).toBeTruthy();
+    expect(screen.queryByText('Fresa #01')).toBeNull();
+    expect(screen.queryByText('Fresa #03')).toBeNull();
+    // Expandir: aparecen las 3 matas individuales.
+    await user.click(screen.getByText('Fresa'));
+    expect(screen.getByText('Fresa #01')).toBeTruthy();
+    expect(screen.getByText('Fresa #02')).toBeTruthy();
+    expect(screen.getByText('Fresa #03')).toBeTruthy();
+  });
+
+  it('deja sueltas las matas de distinta especie (no agrupa lo que no es equivalente)', async () => {
+    const user = userEvent.setup();
+    mockAssetState.plants = [
+      { id: 'plant-1', type: 'asset--plant', attributes: { name: 'Tomate cherry' } },
+      { id: 'plant-2', type: 'asset--plant', attributes: { name: 'Fríjol cargamanto' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="plant" />);
+    await user.click(screen.getByText(/Ver todos/i));
+    expect(screen.getByText('Tomate cherry')).toBeTruthy();
+    expect(screen.getByText('Fríjol cargamanto')).toBeTruthy();
+    expect(screen.queryByText(/^×/)).toBeNull(); // ningún badge de grupo
+  });
+
   it('renderiza la lista de zonas (drill-down raíz de plantas) y permite ver todos los cultivos', async () => {
     const user = userEvent.setup();
     mockAssetState.lands = [

--- a/src/utils/agruparEntradas.js
+++ b/src/utils/agruparEntradas.js
@@ -1,0 +1,154 @@
+/**
+ * agruparEntradas — capa de PRESENTACIÓN para colapsar entradas equivalentes
+ * (mismas matas/ciclos) en una sola fila agregada, sin perder las individuales.
+ *
+ * Motivación (operador, 2026-07): al sembrar N matas iguales el mismo día en el
+ * mismo lote (p. ej. 20 fresas), AssetsDashboard crea N `asset--plant` con
+ * nombres "Fresa #01", "Fresa #02"… (modo individual, ADR-030). Esos N assets
+ * se propagan a los listados (Mis matas, Ciclo del cultivo, Calendario) como N
+ * filas casi idénticas → ruido. Aquí NO se tocan los datos crudos: solo se
+ * agrupan para mostrar "🍓 Fresa ×20 · sembradas 4 mar · Cama 1" con opción de
+ * expandir a las individuales.
+ *
+ * Criterio de agrupación (consistente en todas las vistas): misma especie +
+ * misma fecha de siembra (bucket de día) + mismo lote/cama.
+ */
+
+/**
+ * Quita el sufijo de instancia " #NN" que AssetsDashboard agrega a cada mata
+ * cuando se siembran varias en modo individual.
+ *   "Fresa #01" → "Fresa"      "Tomate #007" → "Tomate"      "Fresa" → "Fresa"
+ * @param {string} [name]
+ * @returns {string}
+ */
+export function stripInstanceSuffix(name) {
+  if (!name || typeof name !== 'string') return '';
+  return name.replace(/\s*#\d+\s*$/, '').trim();
+}
+
+/**
+ * Normaliza una fecha (Date | epoch-ms | ISO string | 'YYYY-MM-DD') a un bucket
+ * de día 'YYYY-MM-DD'. Devuelve '' si no hay fecha válida.
+ *
+ * Se agrupa por DÍA (no por timestamp exacto) porque las N matas de una misma
+ * siembra reciben `_createdAt: Date.now()` en un mismo forEach y pueden diferir
+ * en milisegundos; sin el bucket no colapsarían.
+ * @param {Date|number|string|null|undefined} value
+ * @returns {string}
+ */
+export function dayBucket(value) {
+  if (value == null || value === '') return '';
+  if (typeof value === 'string') {
+    // Ya viene como 'YYYY-MM-DD…' (fecha_germinacion / ISO) → tomar el día.
+    const m = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  }
+  const d = value instanceof Date
+    ? value
+    : new Date(typeof value === 'number' ? value : Date.parse(String(value)));
+  if (Number.isNaN(d.getTime())) return '';
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, '0');
+  const da = String(d.getDate()).padStart(2, '0');
+  return `${y}-${mo}-${da}`;
+}
+
+const MESES_CORTOS = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+
+/**
+ * Formatea una fecha de siembra a "4 mar" (día + mes corto en español) para las
+ * etiquetas de los grupos. Devuelve '' si no hay fecha reconocible.
+ * @param {Date|number|string|null|undefined} value
+ * @returns {string}
+ */
+export function formatFechaSiembra(value) {
+  const day = dayBucket(value);
+  if (!day) return '';
+  const [, mo, da] = day.split('-');
+  const idx = Number(mo) - 1;
+  const mes = MESES_CORTOS[idx] || '';
+  const diaNum = Number(da);
+  return mes ? `${diaNum} ${mes}` : '';
+}
+
+/**
+ * Construye la clave de agrupación de una mata/ciclo por
+ * (especie + fecha de siembra + lote). El llamador extrae los campos de su
+ * propia forma (asset--plant vs FarmProcess vs objeto de calendario), así el
+ * helper no queda acoplado a un shape concreto.
+ *
+ * Sin especie identificable → devuelve '' (no se agrupa): nunca colapsamos
+ * cosas que no podemos afirmar que son la misma especie.
+ *
+ * @param {Object} f
+ * @param {string} [f.species]  slug o nombre canónico de la especie (preferido).
+ * @param {string} [f.name]     nombre visible (se le quita el sufijo "#NN").
+ * @param {Date|number|string} [f.date]  fecha de siembra/creación.
+ * @param {string} [f.bed]      id del lote/cama/zona.
+ * @returns {string}
+ */
+export function claveMataAgrupada({ species, name, date, bed } = {}) {
+  const sp = String(species || stripInstanceSuffix(name) || '').trim().toLowerCase();
+  if (!sp) return '';
+  const d = dayBucket(date);
+  const b = String(bed || '').trim();
+  return [sp, d, b].filter((p) => p !== '').join('|');
+}
+
+/**
+ * @template T
+ * @typedef {Object} Grupo
+ * @property {string} key           Clave de agrupación (o "__solo__N" para sueltos).
+ * @property {T[]} items            Entradas del grupo, en orden de aparición.
+ * @property {number} count         items.length.
+ * @property {T} representative     Primera entrada (para thumbnail/nombre).
+ * @property {boolean} grouped      true si conviene colapsar (count>=minGroupSize).
+ */
+
+/**
+ * Colapsa entradas equivalentes en grupos SIN perder las individuales ni
+ * reordenar más allá de juntar por clave (se preserva el orden de primera
+ * aparición). Capa pura: no muta los items.
+ *
+ * @template T
+ * @param {T[]} items
+ * @param {(item: T, index: number) => (string|null|undefined)} keyOf
+ *        Clave de grupo. null/''/undefined ⇒ la entrada queda como grupo
+ *        unitario propio (jamás colapsa con otra).
+ * @param {Object} [opts]
+ * @param {number} [opts.minGroupSize=2]  Umbral para marcar `grouped=true`.
+ * @returns {Grupo<T>[]}  Grupos en orden de primera aparición.
+ */
+export function agruparEntradas(items, keyOf, opts = {}) {
+  const minGroupSize = opts.minGroupSize ?? 2;
+  if (!Array.isArray(items)) return [];
+  /** @type {Map<string, T[]>} */
+  const map = new Map();
+  const order = [];
+  let soloSeq = 0;
+  items.forEach((item, index) => {
+    let key;
+    try {
+      key = keyOf(item, index);
+    } catch {
+      key = null;
+    }
+    const k = key ? String(key) : `__solo__${soloSeq++}`;
+    if (!map.has(k)) {
+      map.set(k, []);
+      order.push(k);
+    }
+    map.get(k).push(item);
+  });
+  return order.map((k) => {
+    const groupItems = map.get(k);
+    const isReal = !k.startsWith('__solo__');
+    return {
+      key: k,
+      items: groupItems,
+      count: groupItems.length,
+      representative: groupItems[0],
+      grouped: isReal && groupItems.length >= minGroupSize,
+    };
+  });
+}

--- a/src/utils/agruparEntradas.test.js
+++ b/src/utils/agruparEntradas.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+  stripInstanceSuffix,
+  dayBucket,
+  formatFechaSiembra,
+  claveMataAgrupada,
+  agruparEntradas,
+} from './agruparEntradas';
+
+describe('stripInstanceSuffix', () => {
+  it('quita el sufijo " #NN" de matas individuales', () => {
+    expect(stripInstanceSuffix('Fresa #01')).toBe('Fresa');
+    expect(stripInstanceSuffix('Tomate #007')).toBe('Tomate');
+    expect(stripInstanceSuffix('Maíz común #12')).toBe('Maíz común');
+  });
+  it('deja el nombre intacto si no hay sufijo', () => {
+    expect(stripInstanceSuffix('Fresa')).toBe('Fresa');
+    expect(stripInstanceSuffix('Lote #A no es índice')).toBe('Lote #A no es índice');
+  });
+  it('es robusto ante entradas no-string', () => {
+    expect(stripInstanceSuffix(undefined)).toBe('');
+    expect(stripInstanceSuffix(null)).toBe('');
+    expect(stripInstanceSuffix(42)).toBe('');
+  });
+});
+
+describe('dayBucket', () => {
+  it('extrae el día de un string ISO o YYYY-MM-DD', () => {
+    expect(dayBucket('2026-03-04')).toBe('2026-03-04');
+    expect(dayBucket('2026-03-04T15:30:00Z')).toBe('2026-03-04');
+  });
+  it('agrupa timestamps del mismo día que difieren en milisegundos', () => {
+    const base = new Date(2026, 2, 4, 10, 0, 0, 0).getTime();
+    expect(dayBucket(base)).toBe(dayBucket(base + 3)); // misma siembra, +3ms
+  });
+  it('devuelve "" para fechas ausentes o inválidas', () => {
+    expect(dayBucket(null)).toBe('');
+    expect(dayBucket(undefined)).toBe('');
+    expect(dayBucket('')).toBe('');
+    expect(dayBucket('no-es-fecha')).toBe('');
+  });
+});
+
+describe('formatFechaSiembra', () => {
+  it('formatea a "día mes" en español', () => {
+    expect(formatFechaSiembra('2026-03-04')).toBe('4 mar');
+    expect(formatFechaSiembra('2026-12-25')).toBe('25 dic');
+  });
+  it('devuelve "" sin fecha', () => {
+    expect(formatFechaSiembra(null)).toBe('');
+  });
+});
+
+describe('claveMataAgrupada', () => {
+  it('agrupa por especie + fecha + lote', () => {
+    const a = claveMataAgrupada({ species: 'fragaria_ananassa', date: '2026-03-04', bed: 'cama-1' });
+    const b = claveMataAgrupada({ species: 'fragaria_ananassa', date: '2026-03-04T09:00:00Z', bed: 'cama-1' });
+    expect(a).toBe(b);
+  });
+  it('separa especies distintas', () => {
+    const fresa = claveMataAgrupada({ species: 'fresa', date: '2026-03-04', bed: 'c1' });
+    const tomate = claveMataAgrupada({ species: 'tomate', date: '2026-03-04', bed: 'c1' });
+    expect(fresa).not.toBe(tomate);
+  });
+  it('separa distinto lote y distinta fecha', () => {
+    const c1 = claveMataAgrupada({ species: 'fresa', date: '2026-03-04', bed: 'c1' });
+    const c2 = claveMataAgrupada({ species: 'fresa', date: '2026-03-04', bed: 'c2' });
+    const d2 = claveMataAgrupada({ species: 'fresa', date: '2026-03-05', bed: 'c1' });
+    expect(new Set([c1, c2, d2]).size).toBe(3);
+  });
+  it('deriva la especie del nombre (quitando "#NN") si no hay slug', () => {
+    const k1 = claveMataAgrupada({ name: 'Fresa #01', date: '2026-03-04', bed: 'c1' });
+    const k2 = claveMataAgrupada({ name: 'Fresa #20', date: '2026-03-04', bed: 'c1' });
+    expect(k1).toBe(k2);
+  });
+  it('sin especie identificable devuelve "" (no agrupa)', () => {
+    expect(claveMataAgrupada({ date: '2026-03-04', bed: 'c1' })).toBe('');
+    expect(claveMataAgrupada({})).toBe('');
+  });
+});
+
+describe('agruparEntradas', () => {
+  const mkAsset = (i, name, slug, date, bed) => ({
+    id: `id-${i}`,
+    attributes: { name, _speciesSlug: slug, _chagra_plant_meta: { fecha_germinacion: date } },
+    _bed: bed,
+  });
+  const keyOf = (a) => claveMataAgrupada({
+    species: a.attributes._speciesSlug,
+    name: a.attributes.name,
+    date: a.attributes._chagra_plant_meta?.fecha_germinacion,
+    bed: a._bed,
+  });
+
+  it('colapsa 20 fresas idénticas en un solo grupo', () => {
+    const items = Array.from({ length: 20 }, (_, i) =>
+      mkAsset(i, `Fresa #${String(i + 1).padStart(2, '0')}`, 'fragaria_ananassa', '2026-03-04', 'cama-1'),
+    );
+    const groups = agruparEntradas(items, keyOf);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(20);
+    expect(groups[0].grouped).toBe(true);
+    expect(groups[0].representative.id).toBe('id-0');
+    expect(groups[0].items).toHaveLength(20); // no se pierde ninguna
+  });
+
+  it('no colapsa matas de distinto lote', () => {
+    const items = [
+      mkAsset(0, 'Fresa #01', 'fresa', '2026-03-04', 'cama-1'),
+      mkAsset(1, 'Fresa #02', 'fresa', '2026-03-04', 'cama-2'),
+    ];
+    const groups = agruparEntradas(items, keyOf);
+    expect(groups).toHaveLength(2);
+    expect(groups.every((g) => g.grouped === false)).toBe(true);
+  });
+
+  it('una sola mata queda como grupo no colapsado', () => {
+    const groups = agruparEntradas([mkAsset(0, 'Fresa', 'fresa', '2026-03-04', 'c1')], keyOf);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].grouped).toBe(false);
+    expect(groups[0].count).toBe(1);
+  });
+
+  it('mezcla: agrupa las repetidas y deja las únicas sueltas, preservando orden', () => {
+    const items = [
+      mkAsset(0, 'Fresa #01', 'fresa', '2026-03-04', 'c1'),
+      mkAsset(1, 'Fresa #02', 'fresa', '2026-03-04', 'c1'),
+      mkAsset(2, 'Tomate', 'tomate', '2026-03-01', 'c1'),
+      mkAsset(3, 'Fresa #03', 'fresa', '2026-03-04', 'c1'),
+    ];
+    const groups = agruparEntradas(items, keyOf);
+    // Fresa (3, primera aparición idx0) + Tomate (1, idx2)
+    expect(groups).toHaveLength(2);
+    expect(groups[0].key).toContain('fresa');
+    expect(groups[0].count).toBe(3);
+    expect(groups[0].grouped).toBe(true);
+    expect(groups[1].count).toBe(1);
+    expect(groups[1].grouped).toBe(false);
+  });
+
+  it('claves nulas nunca colapsan entre sí (grupos unitarios)', () => {
+    const items = [{ x: 1 }, { x: 2 }, { x: 3 }];
+    const groups = agruparEntradas(items, () => null);
+    expect(groups).toHaveLength(3);
+    expect(groups.every((g) => g.grouped === false && g.count === 1)).toBe(true);
+  });
+
+  it('respeta minGroupSize', () => {
+    const items = [
+      mkAsset(0, 'Fresa #01', 'fresa', '2026-03-04', 'c1'),
+      mkAsset(1, 'Fresa #02', 'fresa', '2026-03-04', 'c1'),
+    ];
+    expect(agruparEntradas(items, keyOf, { minGroupSize: 3 })[0].grouped).toBe(false);
+    expect(agruparEntradas(items, keyOf, { minGroupSize: 2 })[0].grouped).toBe(true);
+  });
+
+  it('es robusto ante entrada no-array', () => {
+    expect(agruparEntradas(null, keyOf)).toEqual([]);
+    expect(agruparEntradas(undefined, keyOf)).toEqual([]);
+  });
+
+  it('no lanza si keyOf falla en un item', () => {
+    const items = [{ ok: true }, { ok: false }];
+    const groups = agruparEntradas(items, (it) => {
+      if (!it.ok) throw new Error('boom');
+      return 'k';
+    });
+    expect(groups).toHaveLength(2); // el que falló cae a grupo unitario
+  });
+});


### PR DESCRIPTION
- **feat(iconos): refinar iconos por especie y etapa de ciclo**
- **feat(ux): estados vacíos y de carga con ilustración**
- **feat(agua): modulo de manejo del agua (cosecha lluvia, riego, calidad)**
- **feat(estiercol): modulo de aprovechamiento de estiercol (biodigestor, olores, abonos)**
- **feat(suelo): modulo de salud del suelo (analisis, encalado, materia organica)**
- **feat(home): reestructuracion 2.0 - mundos de mi finca**
- **fix(home): mostrar mundos tambien en perfil operador/extensionista**
- **feat(poscosecha): mini-app cosecha-punto, guardado y transformacion**
- **feat(semilla): mini-app soberania de semilla (seleccion, guardado, germinacion)**
- **feat(clima): mini-app traductor de boletines IDEAM/ENSO**
- **feat(cultivos): hub del mundo cultivos + calculadora grados-dia**
- **feat(sanidad): mini-app sintoma-folk -> plaga con manejo agroecologico**
- **feat(onboarding): primera vez campesina - bienvenida, capacidades estrella, ubicacion magica**
- **feat(directorio): ficha de especie a nivel referencia (identidad, fenologia, asociaciones, sanidad)**
- **test(dashboard): clima ahora abre pantalla de mundo (2 entradas) tras integrar mundo-clima (#2045)**
- **feat(tema): migrar biopunk a V4 (escena neon-organica + marca A de herramientas)**
- **feat(ux): agrupar entradas repetidas (misma especie+fecha) en listados**
