### PR TITLE
fix(tests): night audit — bench-judge wiring + AMB-31 double-count

### DIFF
--- a/scripts/__tests__/bench-judge-wiring.test.mjs
+++ b/scripts/__tests__/bench-judge-wiring.test.mjs
@@ -48,6 +48,13 @@ describe('parseFromArg — acepta --from path Y --from=path', () => {
 describe('normalizeBenchData — transforma el JSONL real del bench a items evaluables', () => {
   // Una línea del JSONL que escribe bench-agente-completo.mjs: per-model anidado,
   // sin ground_truth ni model_response plano.
+  //
+  // Desde el refactor #1947 (alinear juez/target/flattenDoc), normalizeBenchData
+  // ya NO asume un modelo objetivo por defecto: el target se resuelve en la capa
+  // superior (loadBenchData/resolveTargetDescriptor lo INFIERE del JSONL) o se
+  // pasa explícito. Estos tests unitarios llaman a normalizeBenchData de forma
+  // directa, así que pasan el target explícito del fixture (granite3.3:8b).
+  const TARGET = 'granite3.3:8b';
   const benchLine = {
     prompt_id: 1,
     category: 'species',
@@ -65,8 +72,8 @@ describe('normalizeBenchData — transforma el JSONL real del bench a items eval
     winner: 'granite3_3_8b',
   };
 
-  it('extrae la respuesta del modelo objetivo (granite por defecto) a model_response', () => {
-    const norm = normalizeBenchData([benchLine]);
+  it('extrae la respuesta del modelo objetivo (granite) a model_response', () => {
+    const norm = normalizeBenchData([benchLine], { targetModel: TARGET });
     expect(norm.results).toHaveLength(1);
     const item = norm.results[0];
     expect(item.model_response).toBe(
@@ -77,7 +84,7 @@ describe('normalizeBenchData — transforma el JSONL real del bench a items eval
   });
 
   it('deriva ground_truth de los expected_keywords cuando no hay uno explícito', () => {
-    const norm = normalizeBenchData([benchLine]);
+    const norm = normalizeBenchData([benchLine], { targetModel: TARGET });
     const item = norm.results[0];
     // El ground_truth debe mencionar los conceptos esperados (guía del juez).
     expect(item.ground_truth).toContain('drenaje');
@@ -85,7 +92,7 @@ describe('normalizeBenchData — transforma el JSONL real del bench a items eval
   });
 
   it('propaga expected_keywords y halluc_count del sidecar al item', () => {
-    const norm = normalizeBenchData([benchLine]);
+    const norm = normalizeBenchData([benchLine], { targetModel: TARGET });
     const item = norm.results[0];
     expect(item.expected_keywords).toEqual(['drenaje', 'riego', 'heladas', 'poda']);
     expect(item.sidecar_halluc_count).toBe(0);
@@ -105,7 +112,7 @@ describe('normalizeBenchData — transforma el JSONL real del bench a items eval
       ...benchLine,
       granite3_3_8b: { model: 'granite3.3:8b', response: null, error: 'Timeout' },
     };
-    const norm = normalizeBenchData([errored]);
+    const norm = normalizeBenchData([errored], { targetModel: TARGET });
     expect(norm.results).toHaveLength(0);
     expect(norm.skipped).toBe(1);
   });

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -829,23 +829,24 @@ export const PATHOGEN_KEYWORDS = [
 export function validateAmb31_crossContaminationInsectoPatogeno(catalog) {
   const errors = [];
   for (const sp of catalog.species || []) {
-    // Check insectos en enfermedades_criticas
+    // Check insectos en enfermedades_criticas.
+    // Un ítem se reporta UNA vez aunque matchee varias keywords (p. ej.
+    // "Roya del café (Hemileia vastatrix)" contiene "roya" Y "hemileia"):
+    // la contaminación es del ítem, no de cada keyword.
     for (const enf of sp.enfermedades_criticas || []) {
       const nombre = String(enf || '').toLowerCase();
-      for (const ins of INSECT_KEYWORDS) {
-        if (nombre.includes(ins)) {
-          errors.push(`AMB-31 [${sp.id}.enfermedades_criticas]: "${enf}" es un insecto (${ins}) pero está en enfermedades_criticas — debe moverse a plagas_criticas`);
-        }
+      const matched = INSECT_KEYWORDS.filter((ins) => nombre.includes(ins));
+      if (matched.length) {
+        errors.push(`AMB-31 [${sp.id}.enfermedades_criticas]: "${enf}" es un insecto (${matched.join(', ')}) pero está en enfermedades_criticas — debe moverse a plagas_criticas`);
       }
     }
 
-    // Check patógenos en plagas_criticas
+    // Check patógenos en plagas_criticas (idem: un error por ítem).
     for (const pla of sp.plagas_criticas || []) {
       const nombre = String(pla || '').toLowerCase();
-      for (const pat of PATHOGEN_KEYWORDS) {
-        if (nombre.includes(pat)) {
-          errors.push(`AMB-31 [${sp.id}.plagas_criticas]: "${pla}" es un patógeno (${pat}) pero está en plagas_criticas — debe moverse a enfermedades_criticas`);
-        }
+      const matched = PATHOGEN_KEYWORDS.filter((pat) => nombre.includes(pat));
+      if (matched.length) {
+        errors.push(`AMB-31 [${sp.id}.plagas_criticas]: "${pla}" es un patógeno (${matched.join(', ')}) pero está en plagas_criticas — debe moverse a enfermedades_criticas`);
       }
     }
   }

--- a/src/services/__tests__/agentService.especieDesconocida.test.js
+++ b/src/services/__tests__/agentService.especieDesconocida.test.js
@@ -8,7 +8,11 @@ describe('generateSourceCitationRules — guard de especie desconocida', () => {
   it('incluye la regla de NO describir especies fuera del catálogo', () => {
     const r = generateSourceCitationRules();
     expect(r).toContain('ESPECIE DESCONOCIDA');
-    expect(r).toMatch(/NO inventes su descripción/);
+    // La guarda se reformuló y se endureció: en vez del literal antiguo
+    // "NO inventes su descripción", la regla ahora enumera lo PROHIBIDO para
+    // una especie fuera del catálogo (siembra, manejo, …, descripción, usos).
+    // Verificamos la intención vigente: prohíbe dar la descripción.
+    expect(r).toMatch(/PROHIBIDO[^\n]*descripción/);
   });
 
   it('mantiene la regla previa de nombres científicos', () => {


### PR DESCRIPTION
## Auditoría nocturna de la suite de tests

Corrida de vitest bajo condiciones adversas: box saturado por varios agentes nocturnos en paralelo (load 27-45 en 8 cores) y **worktrees reclamados a mitad de corrida** (dos worktrees se borraron durante runs; artefactos de teardown como `uv_cwd`/334 "module not found" no son fallos reales). Por eso ninguna corrida llegó al 100% en una sola pasada; el set de fallos se estabilizó (sin fallos nuevos entre los archivos 58 y 154 de la última corrida).

### Arreglado — 3 causas, 6 tests (todo test-only, sin tocar producto)

**1. `scripts/__tests__/bench-judge-wiring.test.mjs` — 3 tests (test stale por refactor #1947)**
El refactor #1947 cambió el default de `normalizeBenchData` de `granite3.3:8b` a `null` (target se resuelve/infiere en `loadBenchData`). Actualizó su propio test pero dejó stale al hermano. Fix: pasar el target explícito del fixture. Producción no estaba rota.

**2. `scripts/validate-catalog.mjs` (AMB-31) — 2 tests (bug real, bajo riesgo)**
El validador de contaminación cruzada hacía `push` de un error por keyword matcheada, no por ítem. Con `'roya'` + `'hemileia'` en `PATHOGEN_KEYWORDS`, `"Roya del café (Hemileia vastatrix)"` daba 2 errores por 1 ítem. Introducido rojo en #1958. Fix: un error por ítem listando las keywords. No oculta contaminación.

**3. `src/services/__tests__/agentService.especieDesconocida.test.js` — 1 test (test stale)**
La guarda "especie desconocida" en `generateSourceCitationRules()` se reformuló/endureció; el test seguía grep-eando el literal viejo `/NO inventes su descripción/`. Fix: asertar la intención vigente (`/PROHIBIDO[^\n]*descripción/`). Guarda intacta y más fuerte.

Cada fix verificado en aislado (13/13, 41/41, 2/2).

### Documentado — NO arreglado (correcto por conservadurismo)

- **`ragRetriever.test.js` › "PROD-DOWN #1271 … NO hay fetch serial"** — flake por carga. Las aserciones estructurales (`peak>1`, `peak<=12`, `docFetches===N`) prueban el paralelismo y **pasan**; solo falla el proxy de reloj `duration<1000` (midió 1.4s bajo starvation). Pasa en máquina ociosa. No se toca.
- **`scripts/__tests__/ngsi-validate.test.mjs` › "rechaza hasAgriPest con URN con espacios"** — real y determinista, pero **ambiguo de dominio**: el validador (ajv, `validateFormats:false`, aplana Relationship a string) acepta un URN con espacios; que el schema oficial smart-data-models deba rechazarlo por `pattern`/`format` es decisión FIWARE. Fix no es de bajo riesgo (interop). **Pre-existente en main.** Requiere decisión.
- **`src/data/__tests__/dataSchema.fuente.test.js` (1/94)** — guard anti-fabricación: una entrada en una "lista citada" quedó sin `fuente`. **No se puede arreglar seguro**: inventar una `fuente` es exactamente la fabricación que el test previene; hay que aportar la fuente real (research). **Pre-existente en main.**
- **`src/components/__tests__/SeguimientoProcesoScreen.test.jsx` › "cerdos … evento sanitario"** — test de UI multi-paso frágil: selecciona `getAllByRole('combobox')[1]` (el input Raza con `<datalist>` también es combobox → índice frágil) y espera un `findByPlaceholderText` con timeout default 1000ms bajo starvation. Los otros 6 tests de cerdos pasan. Ambiguo (flake vs índice frágil). **Pre-existente en main.** Requiere investigación del owner.

### Requiere decisión — `tsc:check` gate
FALLA, pero el total de errores **BAJÓ** (1894 vs baseline 1939). Falla por-archivo: 14 archivos de features nuevas de la integración (SpeciesFicha, PoscosechaScreen, AguaScreen, ClimaBoletinScreen, CalculadoraGradosDia, dashboards de mundos…) traen errores de tipo nuevos. Deuda de tipos de la rama de integración, no introducida aquí (mis cambios son `scripts/*.mjs` + un test, fuera de `src/**`). El owner debe arreglarlos o rebaselinar (`node scripts/tsc-check-gate.mjs --update-baseline`).

### Build
`vite build` verificado **OK** (2566 módulos, 22.7s) en worktree estable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)