### PR TITLE
feat(grounding): fuentes verificadas para agro-lecciones (sin inventar)

### DIFF
--- a/src/data/agro-lecciones.json
+++ b/src/data/agro-lecciones.json
@@ -8,7 +8,8 @@
     "contenido_bloques": [
       {
         "tipo": "texto",
-        "texto": "El suelo tiene vida propia. En una cucharada de suelo sano hay más microorganismos que personas en el mundo. Esos seres vivos descomponen la materia orgánica, fijan el nitrógeno del aire y le abren camino a las raíces."
+        "texto": "El suelo tiene vida propia. En una cucharada de suelo sano hay más microorganismos que personas en el mundo. Esos seres vivos descomponen la materia orgánica, fijan el nitrógeno del aire y le abren camino a las raíces.",
+        "fuente": "FAO — Alianza Mundial por el Suelo (Global Soil Partnership): una cucharada de suelo sano alberga más organismos vivos que personas hay en la Tierra"
       },
       {
         "tipo": "dato_clave",
@@ -17,7 +18,8 @@
       },
       {
         "tipo": "texto",
-        "texto": "En suelos volcánicos (como los de la zona cafetera), el fósforo queda atrapado en las arcillas y las raíces no lo pueden alcanzar. Los hongos micorrízicos arbusculares extienden las raíces microscopicamente y liberan ese fósforo."
+        "texto": "En suelos volcánicos (como los de la zona cafetera), el fósforo queda atrapado en las arcillas y las raíces no lo pueden alcanzar. Los hongos micorrízicos arbusculares extienden las raíces microscopicamente y liberan ese fósforo.",
+        "fuente": "New Phytologist (Wang et al. 2023), DOI 10.1111/nph.18772: la vía micorrízica aporta más del 50 % del fósforo bajo P limitado; AGROSAVIA (Andisoles de ceniza volcánica fijan el fósforo)"
       },
       {
         "tipo": "dato_clave",
@@ -26,11 +28,13 @@
       },
       {
         "tipo": "texto",
-        "texto": "El compost y el bocashi mejoran el suelo: añaden materia orgánica, mejoran la estructura y activan la vida microbiana. No son insumos mágicos, pero funcionan en el largo plazo cuando se usan bien."
+        "texto": "El compost y el bocashi mejoran el suelo: añaden materia orgánica, mejoran la estructura y activan la vida microbiana. No son insumos mágicos, pero funcionan en el largo plazo cuando se usan bien.",
+        "fuente": "AGROSAVIA — Guía práctica para hacer compost y mejorar la fertilidad del suelo; FAO Global Soil Partnership (los aportes orgánicos repetidos sostienen la fertilidad en suelos tropicales)"
       },
       {
         "tipo": "advertencia",
-        "texto": "El pH del suelo no se mide con vinagre y bicarbonato. Esa prueba solo reacciona con carbonatos masivos (suelos con pH mayor que 7,5), y en los suelos andinos la acidez viene del aluminio, que no se detecta así. Usa tiras de pH o un medidor calibrado."
+        "texto": "El pH del suelo no se mide con vinagre y bicarbonato. Esa prueba solo reacciona con carbonatos masivos (suelos con pH mayor que 7,5), y en los suelos andinos la acidez viene del aluminio, que no se detecta así. Usa tiras de pH o un medidor calibrado.",
+        "fuente": "AGROSAVIA — acidez y toxicidad de aluminio: en los suelos ácidos andinos la acidez la aporta el Al³⁺, que aparece por debajo de pH 5,5 (~85 % de la superficie de Colombia es suelo ácido)"
       }
     ],
     "pregunta_agente": "¿Cómo puedo mejorar la vida de mi suelo de forma natural?"
@@ -44,7 +48,8 @@
     "contenido_bloques": [
       {
         "tipo": "texto",
-        "texto": "Las asociaciones de cultivos no son solo tradición: tienen una base científica sólida. Cuando plantas diferentes comparten el suelo, pueden usar la luz, el agua y los nutrientes de formas distintas, sin competir tanto."
+        "texto": "Las asociaciones de cultivos no son solo tradición: tienen una base científica sólida. Cuando plantas diferentes comparten el suelo, pueden usar la luz, el agua y los nutrientes de formas distintas, sin competir tanto.",
+        "fuente": "Zhang et al. (2014), Annals of Botany, DOI 10.1093/aob/mcu191 (el policultivo rinde más por unidad de tierra, LER > 1); DR-ASOCIACIONES-CULTIVO-COLOMBIA-2026-06-18"
       },
       {
         "tipo": "dato_clave",
@@ -53,7 +58,8 @@
       },
       {
         "tipo": "texto",
-        "texto": "El guamo (Inga) es el árbol de sombra más documentado en cafetales colombianos. Regula la temperatura, fija nitrógeno y aporta materia orgánica al caer las hojas. La clave es mantener la sombra entre el 30 y el 45 %: más del 50 % aumenta la roya."
+        "texto": "El guamo (Inga) es el árbol de sombra más documentado en cafetales colombianos. Regula la temperatura, fija nitrógeno y aporta materia orgánica al caer las hojas. La clave es mantener la sombra entre el 30 y el 45 %: por encima del 50 % el exceso de humedad favorece las enfermedades foliares.",
+        "fuente": "Cenicafé — Avances Técnicos 379 y 343 (manejo del sombrío 35–45 %; más del 50 % limita la producción y sube la humedad); Siles, Harmand & Vaast (2010), DOI 10.1007/s10457-009-9241-y (Inga fija nitrógeno y regula la temperatura)"
       },
       {
         "tipo": "dato_clave",
@@ -62,7 +68,8 @@
       },
       {
         "tipo": "texto",
-        "texto": "Las franjas de flores en los bordes de la finca atraen avispas, abejas y moscas benéficas que se comen las plagas. No es decoración: es infraestructura ecológica."
+        "texto": "Las franjas de flores en los bordes de la finca atraen avispas, abejas y moscas benéficas que se comen las plagas. No es decoración: es infraestructura ecológica.",
+        "fuente": "Tschumi et al. (2016), Journal of Applied Ecology, DOI 10.1111/1365-2664.12653 (las franjas florales aumentan los enemigos naturales y reducen los áfidos en los cultivos vecinos)"
       },
       {
         "tipo": "dato_clave",
@@ -81,11 +88,13 @@
     "contenido_bloques": [
       {
         "tipo": "texto",
-        "texto": "Un biopreparado es un insumo hecho con organismos vivos o materiales naturales para controlar plagas o mejorar el suelo. Los más conocidos son el bocashi, el biol, los caldos minerales y los hongos entomopatógenos."
+        "texto": "Un biopreparado es un insumo hecho con organismos vivos o materiales naturales para controlar plagas o mejorar el suelo. Los más conocidos son el bocashi, el biol, los caldos minerales y los hongos entomopatógenos.",
+        "fuente": "Biopreparados en Latinoamérica: avances y tendencias (Redalyc, 2024); marco de la Ley 2183 de 2022 (SINIA/FAIA, que prioriza bioinsumos y biopreparados)"
       },
       {
         "tipo": "texto",
-        "texto": "No todos los biopreparados son iguales. Algunos tienen evidencia sólida de campo; otros solo tienen evidencia de laboratorio; y algunos son mitos sin respaldo científico."
+        "texto": "No todos los biopreparados son iguales. Algunos tienen evidencia sólida de campo; otros solo tienen evidencia de laboratorio; y algunos son mitos sin respaldo científico.",
+        "fuente": "Criterio editorial Chagra: jerarquía de evidencia por biopreparado (campo verificado / solo laboratorio / sin respaldo científico)"
       },
       {
         "tipo": "dato_clave",
@@ -94,11 +103,13 @@
       },
       {
         "tipo": "advertencia",
-        "texto": "La dosis de un biopreparado importa. El agente Chagra no te da dosis sin fuente verificada, porque una dosis equivocada puede dañar el cultivo o desperdiciar el insumo. Si necesitas la dosis exacta, consulta la etiqueta del producto registrado ante el ICA o a un agrónomo."
+        "texto": "La dosis de un biopreparado importa. El agente Chagra no te da dosis sin fuente verificada, porque una dosis equivocada puede dañar el cultivo o desperdiciar el insumo. Si necesitas la dosis exacta, consulta la etiqueta del producto registrado ante el ICA o a un agrónomo.",
+        "fuente": "Política Chagra (dato con fuente o no va); registro de insumos agrícolas ante el ICA"
       },
       {
         "tipo": "texto",
-        "texto": "El caldo bordelés (sulfato de cobre + cal + agua) se usa como fungicida en agroecología, pero el cobre es tóxico para las abejas en dosis alta y no se aplica en floración. Es un caso especial que requiere orientación técnica."
+        "texto": "El caldo bordelés (sulfato de cobre + cal + agua) se usa como fungicida en agroecología, pero el cobre es tóxico para las abejas en dosis alta y no se aplica en floración. Es un caso especial que requiere orientación técnica.",
+        "fuente": "AGROSAVIA / DR-SANIDAD-2026-07-04 (el caldo bordelés es un fungicida cúprico preventivo); fichas de registro: no aplicar en floración por riesgo a los polinizadores y acumulación de cobre en el suelo"
       }
     ],
     "pregunta_agente": "¿Qué biopreparado casero me sirve y cómo lo preparo?"
@@ -112,11 +123,13 @@
     "contenido_bloques": [
       {
         "tipo": "texto",
-        "texto": "El MIP empieza con el monitoreo: ¿cuántos insectos hay? ¿En qué etapa del cultivo? ¿Está el daño por debajo del umbral económico? Actuar demasiado pronto puede matar a los enemigos naturales de la plaga."
+        "texto": "El MIP empieza con el monitoreo: ¿cuántos insectos hay? ¿En qué etapa del cultivo? ¿Está el daño por debajo del umbral económico? Actuar demasiado pronto puede matar a los enemigos naturales de la plaga.",
+        "fuente": "FAO — Principios y prácticas del MIP (vigilancia y umbral de acción); umbral económico según Pedigo, IPM World Textbook (Universidad de Minnesota)"
       },
       {
         "tipo": "texto",
-        "texto": "La jerarquía del MIP es: (1) prevención (variedades resistentes, rotación), (2) control cultural (recolección sanitaria, trampas), (3) control biológico (hongos, parasitoides), y solo si es necesario: (4) productos fitosanitarios de baja toxicidad."
+        "texto": "La jerarquía del MIP es: (1) prevención (variedades resistentes, rotación), (2) control cultural (recolección sanitaria, trampas), (3) control biológico (hongos, parasitoides), y solo si es necesario: (4) productos fitosanitarios de baja toxicidad.",
+        "fuente": "FAO — Principios del MIP: enfoque de ecosistema, priorizar métodos biológicos y físicos y usar plaguicidas solo como último recurso"
       },
       {
         "tipo": "dato_clave",
@@ -125,11 +138,13 @@
       },
       {
         "tipo": "texto",
-        "texto": "Algunos cultivos tienen una 'ventana crítica': el momento en que la plaga hace más daño. En papa, la gota es crítica durante la tuberización. En café, la broca ataca principalmente el fruto entre los 90 y 120 días después de la floración."
+        "texto": "Algunos cultivos tienen una 'ventana crítica': el momento en que la plaga hace más daño. En papa, la gota es crítica durante la tuberización. En café, la broca ataca principalmente el fruto entre los 90 y 120 días después de la floración.",
+        "fuente": "Cenicafé — Avances Técnicos sobre broca (Hypothenemus hampei ataca el fruto ~90–120 días tras la floración); AGROSAVIA (la gota de la papa es crítica en la tuberización, ~80–90 días tras la siembra)"
       },
       {
         "tipo": "advertencia",
-        "texto": "Chagra no recomienda agroquímicos sintéticos. Si la situación es grave y necesitas ese tipo de producto, busca orientación de un agrónomo certificado. El agente puede orientarte sobre biopreparados y control biológico documentados."
+        "texto": "Chagra no recomienda agroquímicos sintéticos. Si la situación es grave y necesitas ese tipo de producto, busca orientación de un agrónomo certificado. El agente puede orientarte sobre biopreparados y control biológico documentados.",
+        "fuente": "Política agroecológica Chagra (no recomienda agroquímicos sintéticos; deriva a un agrónomo certificado)"
       }
     ],
     "pregunta_agente": "¿Cómo manejo una plaga sin químicos paso a paso?"
@@ -143,7 +158,8 @@
     "contenido_bloques": [
       {
         "tipo": "texto",
-        "texto": "La fenología es la ciencia de los ritmos de la planta: germinación, crecimiento, floración, fructificación y cosecha. Cada etapa tiene sus necesidades y sus vulnerabilidades."
+        "texto": "La fenología es la ciencia de los ritmos de la planta: germinación, crecimiento, floración, fructificación y cosecha. Cada etapa tiene sus necesidades y sus vulnerabilidades.",
+        "fuente": "Escala BBCH (Meier, 2001) — estándar internacional de estados fenológicos, base de las guías por cultivo de AGROSAVIA y Cenicafé"
       },
       {
         "tipo": "dato_clave",
@@ -152,7 +168,8 @@
       },
       {
         "tipo": "texto",
-        "texto": "En Colombia, el fenómeno de El Niño o La Niña puede correr la fenología 2 a 4 semanas. Por eso es mejor vigilar por evento (la primera flor, el cuajado de frutos) y no solo por el calendario de días."
+        "texto": "En Colombia, el fenómeno de El Niño o La Niña puede correr la fenología varias semanas. Por eso es mejor vigilar por evento (la primera flor, el cuajado de frutos) y no solo por el calendario de días.",
+        "fuente": "IDEAM — Fenómenos El Niño y La Niña / Boletín de Seguimiento del Ciclo ENSO (fuente oficial de la fase vigente; el calendario de siembra se ajusta por semanas según la fase)"
       },
       {
         "tipo": "dato_clave",
@@ -161,7 +178,8 @@
       },
       {
         "tipo": "texto",
-        "texto": "El frijol es especialmente vulnerable al estrés hídrico en la floración (etapa R6). Mantener humedad adecuada esa semana puede salvar la cosecha."
+        "texto": "El frijol es especialmente vulnerable al estrés hídrico en la floración (etapa R6). Mantener humedad adecuada esa semana puede salvar la cosecha.",
+        "fuente": "CIAT — Etapas de desarrollo del fríjol común (Fernández, Gepts & López, 1986: R6 = floración); el déficit hídrico en floración reduce el rendimiento y el número de vainas (Cultivos Tropicales, INCA, 2021)"
       }
     ],
     "pregunta_agente": "¿En qué etapa está mi cultivo y qué debo cuidar ahora?",
@@ -199,7 +217,7 @@
       "resultado": {
         "emoji": "👀",
         "titulo": "El truco",
-        "texto": "Vigile por evento (la primera flor, el cuajado del fruto), no solo por el calendario de días. El Niño o La Niña pueden correr las etapas 2 a 4 semanas."
+        "texto": "Vigile por evento (la primera flor, el cuajado del fruto), no solo por el calendario de días. El Niño o La Niña pueden correr las etapas varias semanas."
       },
       "fuente": "DR-FENOLOGIA-RECONCILED-2026-06-18; Agrosavia / BBCH / CIP"
     }


### PR DESCRIPTION
## Qué

Los `contenido_bloques` de `src/data/agro-lecciones.json` tenían **18 bloques** (en 5 lecciones) sin `fuente`, lo que hacía fallar el guard anti-fabricación `dataSchema.fuente.test.js (c)`. Ahora **todos** traen procedencia real y verificada — sin inventar ni una cita.

## Cómo se groundeó (cada afirmación se verificó en la web / DR de dominio antes de cablear)

**14 bloques → fuente científica/institucional real:**
- FAO Alianza Mundial por el Suelo (una cucharada de suelo = más organismos que personas)
- New Phytologist (Wang 2023, DOI 10.1111/nph.18772) + AGROSAVIA (micorrizas y P en Andisoles)
- AGROSAVIA (guía de compost; acidez/aluminio en suelos andinos)
- Zhang et al. 2014 (LER); Cenicafé AT 379/343 (sombrío) + Siles et al. 2010; Tschumi et al. 2016 (franjas florales)
- Redalyc 2024 + Ley 2183/2022 (biopreparados); AGROSAVIA + DR-SANIDAD (caldo bordelés cúprico)
- FAO Principios del MIP + Pedigo (umbral económico); Cenicafé/AGROSAVIA (ventana crítica broca/gota)
- Escala BBCH (Meier 2001); IDEAM (ENSO); CIAT (fríjol R6 = floración, Fernández et al. 1986)

**4 bloques de política/editorial de Chagra → procedencia honesta** (no una cita científica falsa): definición de nivel de evidencia, política de dosis con fuente, deriva a agrónomo, marco agroecológico.

## Suavizado en vez de inventar (anti-alucinación)
- Sombra `>50 % "aumenta la roya"` → `"favorece las enfermedades foliares"` (la relación sombra↔roya no es limpia en la literatura; Cenicafé sí respalda que >50 % es excesivo y sube la humedad).
- ENSO `"2 a 4 semanas"` → `"varias semanas"` (IDEAM confirma el corrimiento del calendario, pero no pincha esa cifra exacta). Igual en la infografía para consistencia.

## Verificación
- `npm run build` ✅ verde
- `dataSchema.fuente.test.js` + `ageSchemaConsistency` + insight-cards adversarial + `AprenderConAgente` → **172 tests ✅** (el test (c) que fallaba ahora pasa)
- Cero afirmaciones con cifra sin fuente trazable. Sin tests borrados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)