### PR TITLE
feat(agente): cablear guard de piso térmico (baja cross_thermal)

### DIFF
--- a/scripts/__tests__/bench-contaminacion.test.mjs
+++ b/scripts/__tests__/bench-contaminacion.test.mjs
@@ -39,7 +39,12 @@ import {
   runOnAlpha,
   sidecarReachableLocally,
   generateMarkdownReport,
+  buildEnrichedSystemPrompt,
 } from '../bench-contaminacion.mjs';
+
+/** Stub por defecto del guard piso térmico: sin desajuste, no-op — evita que
+ * los tests que no lo ejercitan explícitamente peguen a la red real. */
+const noMismatchPisoTermicoFn = async () => ({ has_mismatch: false, system_prompt_block: '' });
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..', '..');
@@ -335,6 +340,26 @@ describe('loadCatalog', () => {
   });
 });
 
+describe('buildEnrichedSystemPrompt (guard piso térmico chagra-pro #288)', () => {
+  it('sin pisoTermicoBlock: prompt idéntico al comportamiento previo (retrocompatible)', () => {
+    const prompt = buildEnrichedSystemPrompt([{ kind: 'species', mentioned: 'x', nombre_cientifico: 'Y', nombre_comun: 'y' }]);
+    expect(prompt).not.toContain('GUARD PISO TÉRMICO');
+    expect(prompt).toContain('ENTIDADES DEL CATÁLOGO');
+  });
+
+  it('pisoTermicoBlock no vacío se agrega AL FINAL (recency máxima, mismo criterio que AgentScreen.jsx)', () => {
+    const prompt = buildEnrichedSystemPrompt([], '[GUARD PISO TÉRMICO — DESAJUSTE DETECTADO · innegociable]\nNo siembres esto acá.');
+    expect(prompt.endsWith('No siembres esto acá.')).toBe(true);
+    expect(prompt.indexOf('GUARD PISO TÉRMICO')).toBeGreaterThan(-1);
+  });
+
+  it('pisoTermicoBlock vacío/no-string es no-op', () => {
+    const base = buildEnrichedSystemPrompt([]);
+    expect(buildEnrichedSystemPrompt([], '')).toBe(base);
+    expect(buildEnrichedSystemPrompt([], undefined)).toBe(base);
+  });
+});
+
 // ── orquestación: resolveFn/callFn/validateFn INYECTADOS (sin red real) ────
 
 describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
@@ -344,11 +369,12 @@ describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
     const resolveFn = async () => ({ entities: [{ kind: 'species', mentioned: 'x' }] });
     const callFn = async () => ({ response: 'respuesta de prueba', error: null });
     const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
-    const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn });
+    const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn });
     expect(out.id).toBe('p1');
     expect(out.response).toBe('respuesta de prueba');
     expect(out.entities_grounded).toBe(1);
     expect(out.error).toBeNull();
+    expect(out.piso_termico_guard_fired).toBe(false);
   });
 
   it('si callFn devuelve error, no llama a validateFn (evita gastar red en vano)', async () => {
@@ -356,9 +382,55 @@ describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
     const resolveFn = async () => ({ entities: [] });
     const callFn = async () => ({ response: '', error: 'timeout' });
     const validateFn = async () => { validateCalled = true; return { hallucinated: [], detected_count: 0 }; };
-    const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn });
+    const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn });
     expect(out.error).toBe('timeout');
     expect(validateCalled).toBe(false);
+  });
+
+  // ── GUARD piso térmico (chagra-pro #288) — el bench debe reflejar el MISMO
+  // pipeline que producción (AgentScreen.jsx): inyecta el system_prompt_block
+  // del guard cuando hay desajuste, degrada limpio cuando no.
+  describe('wiring /piso-termico-guard (bench honesto, mismo pipeline que prod)', () => {
+    it('has_mismatch:true → el system_prompt_block del guard llega al systemPrompt que ve callFn', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      let seenSystemPrompt = null;
+      const callFn = async (_model, systemPrompt) => {
+        seenSystemPrompt = systemPrompt;
+        return { response: 'r', error: null };
+      };
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const pisoTermicoFn = async () => ({
+        has_mismatch: true,
+        system_prompt_block: '[GUARD PISO TÉRMICO — DESAJUSTE DETECTADO · innegociable]',
+      });
+      const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn });
+      expect(seenSystemPrompt).toContain('GUARD PISO TÉRMICO');
+      expect(out.piso_termico_guard_fired).toBe(true);
+    });
+
+    it('has_mismatch:false → NO inyecta nada (no-op, prompt idéntico al de antes del guard)', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      let seenSystemPrompt = null;
+      const callFn = async (_model, systemPrompt) => {
+        seenSystemPrompt = systemPrompt;
+        return { response: 'r', error: null };
+      };
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const pisoTermicoFn = async () => ({ has_mismatch: false, system_prompt_block: '' });
+      const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn });
+      expect(seenSystemPrompt).not.toContain('GUARD PISO TÉRMICO');
+      expect(out.piso_termico_guard_fired).toBe(false);
+    });
+
+    it('pisoTermicoFn caído/lanza error de red → degrada limpio, no rompe la sonda', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      const callFn = async () => ({ response: 'r', error: null });
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const pisoTermicoFn = async () => ({ has_mismatch: false, system_prompt_block: '', error: 'ECONNREFUSED' });
+      const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn });
+      expect(out.error).toBeNull();
+      expect(out.piso_termico_guard_fired).toBe(false);
+    });
   });
 });
 
@@ -372,7 +444,7 @@ describe('runAllProbes (secuencial, dependencias inyectadas)', () => {
       return { response: `resp-${userPrompt}`, error: null };
     };
     const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
-    const out = await runAllProbes(probes, { resolveFn, callFn, validateFn, sleepMs: 0 });
+    const out = await runAllProbes(probes, { resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, sleepMs: 0 });
     expect(order).toEqual(['a', 'b', 'c']);
     expect(out).toHaveLength(3);
   });
@@ -384,7 +456,7 @@ describe('runAllProbes (secuencial, dependencias inyectadas)', () => {
     const callFn = async () => ({ response: 'r', error: null });
     const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
     await runAllProbes(probes, {
-      resolveFn, callFn, validateFn, sleepMs: 0,
+      resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, sleepMs: 0,
       onProgress: (result, i, total) => calls.push([result.id, i, total]),
     });
     expect(calls).toEqual([['a', 0, 1]]);

--- a/scripts/bench-contaminacion.mjs
+++ b/scripts/bench-contaminacion.mjs
@@ -558,24 +558,78 @@ async function resolveEntities(userMessage, { sidecarUrl = SIDECAR_URL } = {}) {
   }
 }
 
-function buildEnrichedSystemPrompt(entities) {
+/**
+ * pisoTermicoGuard — llama al MISMO endpoint determinista `/piso-termico-guard`
+ * (chagra-pro #288) que consume producción (`src/services/sidecarClient.js`,
+ * cableado en `AgentScreen.jsx`). Este bench debe reflejar el pipeline REAL,
+ * no uno idealizado: si el ensamblador de prod inyecta este guard, el bench
+ * lo inyecta también — de lo contrario la sonda `cross_thermal` mediría un
+ * agente que producción ya no sirve (gaming del número, no del pipeline).
+ * FAIL-SAFE: cualquier error/timeout/non-2xx degrada a `has_mismatch:false`
+ * (no-op), nunca rompe la sonda ni fabrica un bloque.
+ * @param {string} userMessage
+ * @param {{ sidecarUrl?: string }} [opts]
+ * @returns {Promise<{ has_mismatch: boolean, system_prompt_block: string }>}
+ */
+async function pisoTermicoGuard(userMessage, { sidecarUrl = SIDECAR_URL } = {}) {
+  const token = getSidecarToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+  try {
+    const res = await fetch(`${sidecarUrl}/piso-termico-guard`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ user_message: userMessage }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return { has_mismatch: false, system_prompt_block: '' };
+    const data = await res.json();
+    return {
+      has_mismatch: data.has_mismatch === true,
+      system_prompt_block: typeof data.system_prompt_block === 'string' ? data.system_prompt_block : '',
+    };
+  } catch (err) {
+    return { has_mismatch: false, system_prompt_block: '', error: err.message };
+  }
+}
+
+/**
+ * buildEnrichedSystemPrompt — arma el system prompt que ve el modelo en la
+ * fase remote-run. `pisoTermicoBlock` (opcional) es el `system_prompt_block`
+ * YA formateado que devuelve `/piso-termico-guard` cuando detectó un
+ * desajuste (marginal/inviable) — se inyecta al FINAL (recency máxima),
+ * espejo exacto de cómo lo inyecta `AgentScreen.jsx` en producción (guarda
+ * de SUPRESIÓN-Y-REEMPLAZO, debe dominar sobre el consejo genérico). ''/
+ * ausente = no-op, el prompt queda idéntico al de antes de este guard.
+ * @param {object[]} entities
+ * @param {string} [pisoTermicoBlock]
+ */
+export function buildEnrichedSystemPrompt(entities, pisoTermicoBlock = '') {
   const basePrompt = `Eres un asistente agroecológico experto para Colombia. Responde en español claro, práctico para agricultores.
 
 Si mencionas entidades (especies, plagas, biopreparados), usa los nombres canónicos del catálogo Chagra para evitar alucinaciones. Si no tiene un dato verificado (por ejemplo, un contacto o teléfono), dígalo honestamente en vez de inventarlo.`;
 
-  if (!entities || entities.length === 0) return basePrompt;
+  const entityContext = (entities && entities.length > 0)
+    ? entities
+        .map((e) => {
+          if (e.kind === 'species') return `- ${e.mentioned} = especie: ${e.nombre_cientifico} (${e.nombre_comun})`;
+          if (e.kind === 'pest') return `- ${e.mentioned} = plaga/enfermedad del catálogo: ${e.nombre_cientifico || e.nombre_comun}`;
+          if (e.kind === 'biopreparado') return `- ${e.mentioned} = biopreparado: ${e.nombre_comun}`;
+          return null;
+        })
+        .filter(Boolean)
+        .join('\n')
+    : '';
 
-  const entityContext = entities
-    .map((e) => {
-      if (e.kind === 'species') return `- ${e.mentioned} = especie: ${e.nombre_cientifico} (${e.nombre_comun})`;
-      if (e.kind === 'pest') return `- ${e.mentioned} = plaga/enfermedad del catálogo: ${e.nombre_cientifico || e.nombre_comun}`;
-      if (e.kind === 'biopreparado') return `- ${e.mentioned} = biopreparado: ${e.nombre_comun}`;
-      return null;
-    })
-    .filter(Boolean)
-    .join('\n');
+  let prompt = entityContext
+    ? `${basePrompt}\n\nENTIDADES DEL CATÁLOGO (usa estos nombres canónicos):\n${entityContext}`
+    : basePrompt;
 
-  return `${basePrompt}\n\nENTIDADES DEL CATÁLOGO (usa estos nombres canónicos):\n${entityContext}`;
+  if (typeof pisoTermicoBlock === 'string' && pisoTermicoBlock.trim()) {
+    prompt = `${prompt}\n\n${pisoTermicoBlock}`;
+  }
+
+  return prompt;
 }
 
 async function callOllama(model, systemPrompt, userPrompt, { ollamaUrl = OLLAMA_URL, timeoutMs = CALL_TIMEOUT_MS } = {}) {
@@ -631,10 +685,16 @@ async function postValidate(userMessage, modelResponse, { sidecarUrl = SIDECAR_U
 
 /**
  * runProbeAgainstAgent — corre UNA sonda por el pipeline real. Impura (red),
- * pero cada dependencia (resolveEntities/callOllama/postValidate) es
- * inyectable para test sin red.
+ * pero cada dependencia (resolveEntities/callOllama/postValidate/
+ * pisoTermicoGuard) es inyectable para test sin red.
+ *
+ * `pisoTermicoFn` corre EN PARALELO con `resolveFn` (mismo turno, cero
+ * latencia serial añadida — espejo del `Promise.all` que hace
+ * `AgentScreen.jsx` en producción) y, si devuelve `has_mismatch:true`, su
+ * `system_prompt_block` se inyecta en `buildEnrichedSystemPrompt` — así el
+ * bench mide el MISMO pipeline que ve el usuario real, no uno sin el guard.
  * @param {object} probe
- * @param {{ model?: string, resolveFn?: Function, callFn?: Function, validateFn?: Function }} [opts]
+ * @param {{ model?: string, resolveFn?: Function, callFn?: Function, validateFn?: Function, pisoTermicoFn?: Function }} [opts]
  * @returns {Promise<object>}
  */
 export async function runProbeAgainstAgent(probe, opts = {}) {
@@ -643,10 +703,17 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     resolveFn = resolveEntities,
     callFn = callOllama,
     validateFn = postValidate,
+    pisoTermicoFn = pisoTermicoGuard,
   } = opts;
   const t0 = performance.now();
-  const { entities } = await resolveFn(probe.query);
-  const systemPrompt = buildEnrichedSystemPrompt(entities);
+  const [{ entities }, pisoTermico] = await Promise.all([
+    resolveFn(probe.query),
+    pisoTermicoFn(probe.query),
+  ]);
+  const pisoTermicoBlock = (pisoTermico && pisoTermico.has_mismatch && pisoTermico.system_prompt_block)
+    ? pisoTermico.system_prompt_block
+    : '';
+  const systemPrompt = buildEnrichedSystemPrompt(entities, pisoTermicoBlock);
   const { response, error } = await callFn(model, systemPrompt, probe.query);
   const validation = error ? { hallucinated: [], detected_count: 0 } : await validateFn(probe.query, response);
   return {
@@ -658,6 +725,7 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     response,
     error: error || null,
     entities_grounded: entities.length,
+    piso_termico_guard_fired: Boolean(pisoTermicoBlock),
     halluc_detected_count: validation.detected_count,
     latency_ms: Math.round(performance.now() - t0),
   };

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -46,7 +46,7 @@ import { createStreamDeadline } from '../../services/streamDeadline';
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, pisoTermicoGuard, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
@@ -812,7 +812,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // formatToolEvidence y analyzeQuery viven en agentPromptBase (funciones
   // puras, testeables y medibles fuera de React).
 
-  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null, fermentoBlock = '', subgrafoBloque = '', biopreparadoBlock = '') => {
+  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null, fermentoBlock = '', subgrafoBloque = '', biopreparadoBlock = '', pisoTermicoBlock = '') => {
     const analysis = analyzeQuery(query);
     // El base recibe query/historial/isEnum para inyectar SOLO los glosarios
     // y reglas condicionales que la conversación toca (re-arquitectura GR-10).
@@ -1009,6 +1009,21 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       ? `\n\n${biopreparadoBlock}`
       : '';
 
+    // GUARDA PISO TÉRMICO (chagra-pro #288, driver #1 de contaminación
+    // cross-domain, sonda `cross_thermal` de bench-contaminacion.mjs, ~86.7%
+    // medida 2026-07). El sidecar /piso-termico-guard ya cruzó el piso térmico
+    // del usuario (finca georreferenciada > perfil > texto libre) contra el
+    // rango altitudinal real de la especie (mismo motor de viabilidad AGE de
+    // /resolve-entities) y armó un bloque de SUPRESIÓN-Y-REEMPLAZO cuando hay
+    // desajuste (marginal/inviable). Va de ÚLTIMO (recency máxima, después de
+    // fermento/biopreparado) porque, igual que esas guardas, debe dominar
+    // sobre el consejo de siembra genérico. '' (no-op) cuando el piso
+    // coincide, no hubo señal de piso del usuario, o el sidecar no respondió
+    // (degradación graceful — no rompe el turno, nunca inventa un rango).
+    const pisoTermicoSafetyBlock = (typeof pisoTermicoBlock === 'string' && pisoTermicoBlock.trim())
+      ? `\n\n${pisoTermicoBlock}`
+      : '';
+
     // Re-arquitectura GR-10: ensamblado con PRESUPUESTO de tokens y prioridad
     // por relevancia (promptAssembler). El grounding (evidencia / entidades /
     // hechos curados / cadena) va al FINAL del system — donde la truncación de
@@ -1038,6 +1053,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       priceDecline: priceDeclineBlock,
       fermento: fermentoSafetyBlock,
       biopreparado: biopreparadoSafetyBlock,
+      pisoTermico: pisoTermicoSafetyBlock,
     });
 
     const messages = [
@@ -1334,6 +1350,14 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // system prompt si no hubo intención-biopreparado o el sidecar no respondió
       // (degradación graceful — FAIL-SAFE, no fabrica datos).
       let biopreparadoBlock = '';
+      // GUARDA PISO TÉRMICO (chagra-pro #288, driver #1 de contaminación
+      // cross-domain — sonda `cross_thermal` de bench-contaminacion.mjs, ~86.7%
+      // medida 2026-07). Bloque de SUPRESIÓN-Y-REEMPLAZO ya formateado por el
+      // sidecar (/piso-termico-guard) cuando la especie mencionada resulta
+      // marginal/inviable para el piso térmico del usuario. '' por default →
+      // no-op en el system prompt si el piso coincide, no hubo señal de piso
+      // del usuario, o el sidecar no respondió (degradación graceful).
+      let pisoTermicoBlock = '';
       // GraphRAG multi-hop (#1 intelligence-first): bloque "CADENA DE RELACIONES"
       // del grafo AGE para queries relacionales (plaga+cultivo). '' = no-op.
       let subgrafoBloque = '';
@@ -1348,16 +1372,25 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             try { const p = getProfile(); if (p && p.finca_altitud != null) return p.finca_altitud; } catch (_) { /* noop */ }
             return (fincaActiva && fincaActiva.altitud) || null;
           })();
+          // Piso térmico EXPLÍCITO del perfil (si el usuario lo declaró en su
+          // ficha) — segunda prioridad del guard, detrás de finca_altitud
+          // numérica. Sin esto, el guard igual funciona vía texto libre del
+          // mensaje (degradación por diseño del sidecar).
+          const rePisoTermico = (() => {
+            try { const p = getProfile(); if (p && p.piso_termico) return p.piso_termico; } catch (_) { /* noop */ }
+            return null;
+          })();
           const tRE0 = performance.now();
-          // SAFETY-CRITICAL en PARALELO: /fermento-prefilter y
-          // /biopreparado-grounding corren junto a /resolve-entities (mismo turno,
-          // antes del LLM) — CERO latencia serial añadida. Los tres wrappers son
-          // no-throw (devuelven null en error/timeout), así que Promise.all no
-          // puede rechazar por ellos.
-          const [resolved, fermento, biopreparado] = await Promise.all([
+          // SAFETY-CRITICAL en PARALELO: /fermento-prefilter,
+          // /biopreparado-grounding y /piso-termico-guard corren junto a
+          // /resolve-entities (mismo turno, antes del LLM) — CERO latencia
+          // serial añadida. Los cuatro wrappers son no-throw (devuelven null
+          // en error/timeout), así que Promise.all no puede rechazar por ellos.
+          const [resolved, fermento, biopreparado, pisoTermico] = await Promise.all([
             resolveEntities(textForLLM, { fincaAltitud: reAltitud, context: contextMemory }),
             fermentoPrefilter(textForLLM),
             biopreparadoGrounding(textForLLM),
+            pisoTermicoGuard(textForLLM, { fincaAltitud: reAltitud, pisoTermico: rePisoTermico }),
           ]);
           const tRE1 = performance.now();
           // FERMENTOS: si el sidecar marcó intención-fermento, inyectamos su
@@ -1385,6 +1418,22 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             console.debug('[sidecar] biopreparado-grounding', {
               biopreparadoId: biopreparado.biopreparado_id,
               reason: biopreparado.reason,
+            });
+          }
+          // PISO TÉRMICO: si el sidecar detectó un desajuste (especie
+          // marginal/inviable para el piso del usuario), inyectamos su bloque
+          // de SUPRESIÓN-Y-REEMPLAZO al final del system prompt (recency
+          // máxima). Si el sidecar no respondió (null) o el piso coincide,
+          // pisoTermicoBlock queda '' → no-op, el turno sigue sin romperse
+          // (degradación graceful, FAIL-SAFE — nunca inventa un rango).
+          if (pisoTermico && pisoTermico.has_mismatch && typeof pisoTermico.system_prompt_block === 'string' && pisoTermico.system_prompt_block.trim()) {
+            pisoTermicoBlock = pisoTermico.system_prompt_block;
+            console.debug('[sidecar] piso-termico-guard', {
+              speciesId: pisoTermico.species_id,
+              userPiso: pisoTermico.user_piso_termico,
+              userPisoOrigen: pisoTermico.user_piso_origen,
+              viabilidad: pisoTermico.viabilidad,
+              reason: pisoTermico.reason,
             });
           }
           if (resolved && Array.isArray(resolved.entities) && resolved.entities.length > 0) {
@@ -1912,7 +1961,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       const deterministicPrice = buildPriceAnswer({ userMessage: text, toolEvidence });
       const rawResponse = deterministicPrice != null
         ? deterministicPrice
-        : await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock, edgesTruncated, biopreparadoBlock);
+        : await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock, edgesTruncated, biopreparadoBlock, pisoTermicoBlock);
       if (deterministicPrice != null) {
         console.debug('[precio] respuesta determinista SIPSA (sin LLM)', { route: nluRoute });
       }

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -152,6 +152,7 @@ vi.mock('../../../services/sidecarClient', () => ({
   resolveEntities: vi.fn(),
   fermentoPrefilter: vi.fn(),
   biopreparadoGrounding: vi.fn(),
+  pisoTermicoGuard: vi.fn(),
   postValidate: vi.fn(),
   getClimaIdeam: vi.fn(),
   isToolAllowed: vi.fn(() => false),

--- a/src/services/__tests__/promptAssembler.test.js
+++ b/src/services/__tests__/promptAssembler.test.js
@@ -75,6 +75,19 @@ describe('assembleSystemContent — orden por prioridad', () => {
     const { content } = assembleSystemContent({ base: 'BASE', evidence: '', clima: '' });
     expect(content).toBe('BASE');
   });
+
+  it('GUARDA piso térmico (chagra-pro #288) queda AL FINAL, después de fermento/biopreparado (máxima recency)', () => {
+    const { content } = assembleSystemContent({
+      base: 'BASE',
+      evidence: 'EVIDENCIA',
+      fermento: 'GUARDA_FERMENTO',
+      biopreparado: 'GUARDA_BIOPREPARADO',
+      pisoTermico: 'GUARDA_PISO_TERMICO',
+    });
+    expect(content.indexOf('GUARDA_PISO_TERMICO')).toBeGreaterThan(content.indexOf('GUARDA_FERMENTO'));
+    expect(content.indexOf('GUARDA_PISO_TERMICO')).toBeGreaterThan(content.indexOf('GUARDA_BIOPREPARADO'));
+    expect(content.endsWith('GUARDA_PISO_TERMICO')).toBe(true);
+  });
 });
 
 describe('assembleSystemContent — presupuesto y degradación', () => {
@@ -120,14 +133,15 @@ describe('assembleSystemContent — presupuesto y degradación', () => {
         fermento: big,
         suggested: big,
         viabilidad: big,
+        pisoTermico: big,
         corpus: { variants: ['recortable', ''] },
       },
       { budget: 100 },
     );
     expect(r.overBudget).toBe(true);
     expect(warn).toHaveBeenCalled();
-    for (const name of ['base', 'evidence', 'seguridad', 'priceDecline', 'fermento', 'suggested', 'viabilidad']) {
-      expect(r.content.split(big).length - 1).toBeGreaterThanOrEqual(7);
+    for (const name of ['base', 'evidence', 'seguridad', 'priceDecline', 'fermento', 'suggested', 'viabilidad', 'pisoTermico']) {
+      expect(r.content.split(big).length - 1).toBeGreaterThanOrEqual(8);
       expect(r.breakdown.find((b) => b.name === name).degraded).toBe(false);
     }
   });

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -762,6 +762,125 @@ describe('sidecarClient — feature flag on', () => {
       expect(res).toBeNull();
     });
   });
+
+  describe('pisoTermicoGuard — GUARDA desajuste piso térmico (chagra-pro #288)', () => {
+    const MISMATCH_HIT = {
+      has_mismatch: true,
+      user_piso_termico: 'calido',
+      user_piso_origen: 'texto_mensaje',
+      species_id: 'arracacia_xanthorrhiza_amarilla',
+      species_nombre_comun: 'Arracacha amarilla',
+      species_altitud_min: 1800,
+      species_altitud_max: 2500,
+      viabilidad: 'inviable',
+      alternativas: ['Yuca', 'Plátano'],
+      system_prompt_block:
+        '[GUARD PISO TÉRMICO — DESAJUSTE DETECTADO · innegociable]\n' +
+        '"Arracacha amarilla" NO es viable en tierra caliente.',
+      reason: 'desajuste_piso_termico_inviable',
+    };
+
+    const NO_MISMATCH = {
+      has_mismatch: false,
+      user_piso_termico: null,
+      user_piso_origen: null,
+      species_id: null,
+      species_nombre_comun: null,
+      species_altitud_min: null,
+      species_altitud_max: null,
+      viabilidad: null,
+      alternativas: [],
+      system_prompt_block: '',
+      reason: 'sin_piso_termico_usuario',
+    };
+
+    it('query con DESAJUSTE de piso térmico → inyecta el system_prompt_block del sidecar', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, MISMATCH_HIT));
+      const { pisoTermicoGuard } = await importFresh();
+      const res = await pisoTermicoGuard('Tengo finca en piso térmico calido. ¿Puedo sembrar arracacha ahí?');
+      expect(res).not.toBeNull();
+      expect(res.has_mismatch).toBe(true);
+      expect(res.system_prompt_block).toContain('DESAJUSTE DETECTADO');
+      expect(res.viabilidad).toBe('inviable');
+      expect(res.alternativas).toEqual(['Yuca', 'Plátano']);
+      // POST con user_message a /piso-termico-guard (mismo contrato que /fermento-prefilter).
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/piso-termico-guard');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token-123');
+      expect(JSON.parse(opts.body)).toEqual({ user_message: 'Tengo finca en piso térmico calido. ¿Puedo sembrar arracacha ahí?' });
+    });
+
+    it('reenvía finca_altitud y piso_termico cuando se pasan por opts (prioridad finca > perfil)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, NO_MISMATCH));
+      const { pisoTermicoGuard } = await importFresh();
+      await pisoTermicoGuard('¿puedo sembrar café?', { fincaAltitud: 2600, pisoTermico: 'frio' });
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(JSON.parse(opts.body)).toEqual({
+        user_message: '¿puedo sembrar café?',
+        finca_altitud: 2600,
+        piso_termico: 'frio',
+      });
+    });
+
+    it('query SIN desajuste → has_mismatch false + bloque vacío (no se inyecta nada)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, NO_MISMATCH));
+      const { pisoTermicoGuard } = await importFresh();
+      const res = await pisoTermicoGuard('¿a cómo está la papa?');
+      expect(res).not.toBeNull();
+      expect(res.has_mismatch).toBe(false);
+      expect(res.system_prompt_block).toBe('');
+    });
+
+    it('normaliza un body parcial del sidecar a la forma contractual (defensivo)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { has_mismatch: true, system_prompt_block: 'X' }));
+      const { pisoTermicoGuard } = await importFresh();
+      const res = await pisoTermicoGuard('cómo siembro arracacha');
+      expect(res.has_mismatch).toBe(true);
+      expect(res.system_prompt_block).toBe('X');
+      expect(res.species_id).toBeNull();
+      expect(res.alternativas).toEqual([]);
+      expect(res.reason).toBe('');
+    });
+
+    it('devuelve null sin fetch cuando flag off (degradación graceful)', async () => {
+      disableFlag();
+      const { pisoTermicoGuard } = await importFresh();
+      const res = await pisoTermicoGuard('cómo siembro arracacha');
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando offline', async () => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+      const { pisoTermicoGuard } = await importFresh();
+      const res = await pisoTermicoGuard('cómo siembro arracacha');
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando userMessage vacío/no-string', async () => {
+      const { pisoTermicoGuard } = await importFresh();
+      expect(await pisoTermicoGuard('')).toBeNull();
+      expect(await pisoTermicoGuard(null)).toBeNull();
+      expect(await pisoTermicoGuard(undefined)).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('5xx → null sin throw (sidecar caído, FAIL-SAFE: no rompe el turno ni fabrica datos)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(503, { error: 'age down' }));
+      const { pisoTermicoGuard } = await importFresh();
+      const res = await pisoTermicoGuard('cómo siembro arracacha');
+      expect(res).toBeNull();
+    });
+
+    it('fetch throws → null sin throw', async () => {
+      fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const { pisoTermicoGuard } = await importFresh();
+      const res = await pisoTermicoGuard('cómo siembro arracacha');
+      expect(res).toBeNull();
+    });
+  });
 });
 
 describe('sidecarClient — getClimaSnapshot elevation (gradiente térmico)', () => {

--- a/src/services/promptAssembler.js
+++ b/src/services/promptAssembler.js
@@ -96,6 +96,7 @@ export const BLOCK_ORDER = [
   'priceDecline', // GUARDA precio sin dato (protegido)
   'fermento', // GUARDA DR-FOOD-3 (protegido, máxima recency)
   'biopreparado', // GROUNDING biopreparados chagra-pro #248 (protegido, máxima recency — anti-negación)
+  'pisoTermico', // GUARDA desajuste de piso térmico chagra-pro #288 (protegido, ÚLTIMA — cross_thermal, SUPRESIÓN-Y-REEMPLAZO)
 ];
 
 /**

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -531,6 +531,68 @@ export async function biopreparadoGrounding(userMessage) {
 }
 
 /**
+ * GUARDA de desajuste de PISO TÉRMICO (chagra-pro #288, determinista,
+ * PRE-LLM — cierra el driver #1 de contaminación cross-domain, sonda
+ * `cross_thermal` de `bench-contaminacion.mjs`, ~86.7% de contaminación
+ * medida 2026-07). Llama `POST ${BASE}/piso-termico-guard` con
+ * `{ user_message, finca_altitud?, piso_termico? }` para que el sidecar
+ * detecte el piso térmico del usuario (finca georreferenciada > piso
+ * explícito del perfil > frase en texto libre, ej. "tengo finca en piso
+ * térmico cálido") y, si la especie mencionada resulta marginal/inviable a
+ * esa altitud (motor de viabilidad de `/resolve-entities`, mismo grafo AGE),
+ * devuelva un `system_prompt_block` de SUPRESIÓN-Y-REEMPLAZO: el LLM debe
+ * advertir el desajuste PRIMERO y ofrecer solo alternativas reales del
+ * catálogo, nunca inventadas.
+ *
+ * Espejo exacto de `fermentoPrefilter`/`biopreparadoGrounding`: FAIL-SAFE,
+ * no-throw. Devuelve null si: flag off, offline, timeout, non-2xx, body
+ * inválido → el caller degrada con gracia (no inyecta bloque, no rompe el
+ * turno). Cuando `has_mismatch` es false, NO hay que inyectar nada.
+ *
+ * @param {string} userMessage — texto del operador.
+ * @param {object} [opts]
+ * @param {number|string|null} [opts.fincaAltitud] - msnm de la finca activa (prioridad 1).
+ * @param {string|null} [opts.pisoTermico] - piso térmico explícito del perfil (prioridad 2).
+ * @returns {Promise<null | {
+ *   has_mismatch: boolean,
+ *   user_piso_termico: string | null,
+ *   user_piso_origen: string | null,
+ *   species_id: string | null,
+ *   species_nombre_comun: string | null,
+ *   species_altitud_min: number | null,
+ *   species_altitud_max: number | null,
+ *   viabilidad: string | null,
+ *   alternativas: string[],
+ *   system_prompt_block: string,
+ *   reason: string,
+ * }>}
+ */
+export async function pisoTermicoGuard(userMessage, opts = {}) {
+  if (!userMessage || typeof userMessage !== 'string') return null;
+  const body = { user_message: userMessage };
+  const alt = opts && opts.fincaAltitud != null ? Number(opts.fincaAltitud) : NaN;
+  if (Number.isFinite(alt)) body.finca_altitud = alt;
+  if (opts && typeof opts.pisoTermico === 'string' && opts.pisoTermico.trim()) {
+    body.piso_termico = opts.pisoTermico.trim();
+  }
+  const raw = await postJson('/piso-termico-guard', body, NLU_TIMEOUT_MS);
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    has_mismatch: raw.has_mismatch === true,
+    user_piso_termico: typeof raw.user_piso_termico === 'string' ? raw.user_piso_termico : null,
+    user_piso_origen: typeof raw.user_piso_origen === 'string' ? raw.user_piso_origen : null,
+    species_id: typeof raw.species_id === 'string' ? raw.species_id : null,
+    species_nombre_comun: typeof raw.species_nombre_comun === 'string' ? raw.species_nombre_comun : null,
+    species_altitud_min: typeof raw.species_altitud_min === 'number' ? raw.species_altitud_min : null,
+    species_altitud_max: typeof raw.species_altitud_max === 'number' ? raw.species_altitud_max : null,
+    viabilidad: typeof raw.viabilidad === 'string' ? raw.viabilidad : null,
+    alternativas: Array.isArray(raw.alternativas) ? raw.alternativas.filter((a) => typeof a === 'string') : [],
+    system_prompt_block: typeof raw.system_prompt_block === 'string' ? raw.system_prompt_block : '',
+    reason: typeof raw.reason === 'string' ? raw.reason : '',
+  };
+}
+
+/**
  * Capa 2 anti-alucinación (cross-check de contexto). Llama
  * `POST ${BASE}/post-validate` con el TEXTO que el LLM ya generó y, opcional,
  * los `nombre_cientifico` de las entidades que la capa 1 resolvió para el turno


### PR DESCRIPTION
## Resumen

Cablea el endpoint determinista **PRE-LLM `/piso-termico-guard`** (chagra-pro #288, ya desplegado en el sidecar agro-mcp) al **ensamblador REAL del system prompt del chat** (`AgentScreen.jsx` → `promptAssembler.js`) **Y** al **bench de contaminación** (`scripts/bench-contaminacion.mjs`), para cerrar el driver #1 de contaminación cross-domain del agente (sonda `cross_thermal`, ~86.7% medida 2026-07).

Hasta ahora el endpoint existía y estaba desplegado, pero **nadie lo llamaba**. Este PR lo consume en las dos rutas que importan: producción y el bench que la mide.

## Qué cablea

### Producción (`AgentScreen.jsx`)
- Nuevo wrapper **`pisoTermicoGuard()`** en `src/services/sidecarClient.js`, espejo exacto de `fermentoPrefilter`/`biopreparadoGrounding`: FAIL-SAFE, no-throw, devuelve `null` en flag-off / offline / timeout / non-2xx. Reenvía `finca_altitud` (perfil/GPS) + `piso_termico` explícito del perfil.
- Corre **EN PARALELO** con `resolveEntities`/`fermentoPrefilter`/`biopreparadoGrounding` (mismo `Promise.all`, cero latencia serial añadida). Si `has_mismatch`, inyecta el `system_prompt_block` de **SUPRESIÓN-Y-REEMPLAZO** al final del system prompt.
- `promptAssembler.js`: nuevo bloque **protegido** `pisoTermico` de última recency (tras `fermento`/`biopreparado`), nunca sacrificable bajo presupuesto.

### Bench honesto (`bench-contaminacion.mjs`)
- `runProbeAgainstAgent` llama al **MISMO** endpoint (mismo `SIDECAR_URL` loopback) e inyecta el bloque en `buildEnrichedSystemPrompt` — así el bench mide el **pipeline REAL de producción**, no uno idealizado sin el guard (evita *gaming* del número). `pisoTermicoFn` es inyectable para test sin red.

## Degradación suave

En ambas rutas: endpoint caído / sin piso del usuario / especie sin rango altitudinal → **no-op**, nunca rompe el turno ni inventa un rango.

## Verificación en vivo (sidecar en alpha, PR chagra-pro #288 ya desplegado)

- Desajuste **inviable**: `piso térmico calido` + arracacha → `has_mismatch:true`, viabilidad `inviable`, alternativas reales (yuca, plátano...).
- Desajuste **marginal**: `piso térmico frio` + papa negra → `has_mismatch:true`, viabilidad `marginal`, matiz de riesgo.
- **Sin** falso positivo: `piso térmico calido` + plátano → `has_mismatch:false` (piso coincide, no molesta).

## Test plan
- [x] `sidecarClient.test.js` (+12 tests del wrapper: mismatch/no-mismatch/opts finca+piso/parcial/flag-off/offline/vacío/5xx/throw).
- [x] `promptAssembler.test.js` (+2: bloque al final, protegido intocable).
- [x] `bench-contaminacion.test.mjs` (+7: wiring del guard, no-op, degradación, `buildEnrichedSystemPrompt` con/sin bloque).
- [x] `AgentScreen.chipsToolbar.test.jsx` mock actualizado; suite AgentScreen (8 files, 48 tests) verde.
- [x] `npm run build` (vite) verde. `eslint --max-warnings=0` verde en los archivos tocados.

## Re-bench
`node scripts/bench-contaminacion.mjs` (ssh alpha) — la sonda `cross_thermal` en `summary.by_type.cross_thermal.rate_pct` debe bajar respecto al baseline, y los resultados ahora traen `piso_termico_guard_fired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)