### PR TITLE
feat(agua): sección de riesgos de contaminación + salud en el módulo de Agua

### DIFF
--- a/src/components/agua/AguaScreen.jsx
+++ b/src/components/agua/AguaScreen.jsx
@@ -2,9 +2,13 @@ import React, { useMemo, useState } from 'react';
 import {
   CloudRain, Droplets, Sprout, Calculator, TriangleAlert, Sun,
   ShieldCheck, Users, Hourglass, Milk, ChevronRight,
+  Skull, PiggyBank, Biohazard, FlaskConical, Fuel, Beef, Trash2,
+  Baby, Activity, ShieldAlert, Ruler, Landmark, HeartPulse,
 } from 'lucide-react';
 import { ScreenShell } from '../common/ScreenShell';
+import PedagogicalBlock from '../common/PedagogicalBlock';
 import CaminoDelAgua from './CaminoDelAgua';
+import DistanciasFinca from './DistanciasFinca';
 import {
   litrosLluviaCaptables,
   canecasEquivalentes,
@@ -26,6 +30,9 @@ import {
   DOSIS_POTABILIZACION,
   RONDA_PROTECCION,
   CASO_NACIMIENTO,
+  RIESGOS_CONTAMINACION,
+  ENFERMEDADES_AGUA,
+  DISTANCIAS_SEGURIDAD,
 } from '../../data/aguaFinca';
 import { getEnsoPhase, getEnsoLabel } from '../../services/ensoService';
 import './agua.css';
@@ -364,6 +371,214 @@ function PilarRiego() {
   );
 }
 
+/* ── PILAR 3b · Riesgos de contaminación + salud ──────────────────────── */
+
+/** Íconos de riesgo por clave de fuente contaminante (data-driven). */
+const ICONO_RIESGO = {
+  veneno: Skull,
+  cochera: PiggyBank,
+  letrina: Biohazard,
+  agroquimico: FlaskConical,
+  combustible: Fuel,
+  matadero: Beef,
+  basura: Trash2,
+};
+
+/** Íconos por enfermedad. */
+const ICONO_ENFERMEDAD = {
+  diarrea: Activity,
+  bebe: Baby,
+  intoxicacion: HeartPulse,
+};
+
+/** Semáforo de peligro: punto de color + etiqueta (alto = rojo, medio = ámbar). */
+function SemaforoPeligro({ nivel }) {
+  const alto = nivel === 'alto';
+  return (
+    <span
+      data-testid={`semaforo-${nivel}`}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-black uppercase tracking-wide ${
+        alto
+          ? 'border-rose-500/50 bg-rose-500/15 text-rose-200'
+          : 'border-amber-500/50 bg-amber-500/15 text-amber-200'
+      }`}
+    >
+      <span
+        aria-hidden="true"
+        className={`inline-block w-2 h-2 rounded-full ${alto ? 'bg-rose-400 agua-peligro-late' : 'bg-amber-400'}`}
+      />
+      Peligro {alto ? 'alto' : 'medio'}
+    </span>
+  );
+}
+
+/**
+ * RiesgosSalud — la sección nueva del pilar "Cuidar el agua":
+ *   A. Qué le echa veneno al agua (fuentes de contaminación + semáforo).
+ *   B. Y esto es lo que enferma (enfermedades, con autoridad institucional).
+ *   C. La regla de las distancias (ilustración de la finca + metros grounded).
+ * Mantiene el lenguaje visual del módulo (cuaderno de campo, acentos cyan) y
+ * NUNCA cita a una persona en lo safety-critical: solo instituciones.
+ */
+function RiesgosSalud() {
+  return (
+    <div className="space-y-4" data-testid="agua-riesgos-salud">
+      <PedagogicalBlock
+        icon={ShieldAlert}
+        tone="alerta"
+        lead="El agua no se ensucia sola: alguien, aguas arriba, le echó algo."
+        clave="Casi todo se previene con dos cosas: distancia al agua y manejo de lo que gotea (venenos, estiércol, aguas negras)."
+      >
+        <p>
+          La contaminación llega por dos caminos: la <strong className="text-rose-200">escorrentía</strong>{' '}
+          (lo que corre por encima con el aguacero) y la{' '}
+          <strong className="text-rose-200">lixiviación</strong> (lo que se filtra hacia abajo hasta el
+          agua del subsuelo). Por eso lo que pase loma arriba termina en el nacimiento y en el pozo.
+        </p>
+      </PedagogicalBlock>
+
+      {/* ── A · Qué contamina ── */}
+      <section className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 space-y-3" data-testid="agua-que-contamina">
+        <p className="flex items-center gap-2 text-sm font-black text-slate-100 uppercase tracking-wide">
+          <TriangleAlert size={16} aria-hidden="true" className="text-rose-300" /> Qué le echa veneno al agua
+        </p>
+        <ul className="space-y-2.5">
+          {RIESGOS_CONTAMINACION.map((r) => {
+            const Icono = ICONO_RIESGO[r.icono] || TriangleAlert;
+            return (
+              <li key={r.id} className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3" data-testid={`riesgo-${r.id}`}>
+                <div className="flex items-start gap-3">
+                  <span
+                    aria-hidden="true"
+                    className={`shrink-0 w-9 h-9 rounded-xl grid place-items-center ${
+                      r.nivel === 'alto' ? 'bg-rose-500/15 text-rose-300' : 'bg-amber-500/15 text-amber-300'
+                    }`}
+                  >
+                    <Icono size={18} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="flex flex-wrap items-center gap-2 text-sm font-bold text-slate-100 leading-tight">
+                      {r.fuente}
+                      <SemaforoPeligro nivel={r.nivel} />
+                    </p>
+                    <p className="mt-1 text-xs leading-snug text-slate-300">{r.aporta}</p>
+                    <p className="mt-1.5 text-[11px] leading-snug text-slate-400">
+                      <span className="inline-flex items-center gap-1 rounded bg-slate-800/70 px-1.5 py-0.5 font-bold text-slate-300">
+                        <Droplets size={10} aria-hidden="true" /> {r.via}
+                      </span>{' '}
+                      <span className="text-emerald-300 font-bold">Prevenir:</span> {r.prevenir}
+                    </p>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      {/* ── B · Qué enferma (autoridad institucional, nunca una persona) ── */}
+      <section className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 space-y-3" data-testid="agua-enfermedades">
+        <p className="flex items-center gap-2 text-sm font-black text-slate-100 uppercase tracking-wide">
+          <HeartPulse size={16} aria-hidden="true" className="text-rose-300" /> Y esto es lo que enferma
+        </p>
+        {ENFERMEDADES_AGUA.map((e) => {
+          const Icono = ICONO_ENFERMEDAD[e.icono] || Activity;
+          return (
+            <article
+              key={e.id}
+              data-testid={`enfermedad-${e.id}`}
+              className={`rounded-xl border p-3 ${
+                e.critico
+                  ? 'border-rose-600/50 bg-rose-950/30'
+                  : 'border-slate-700/50 bg-slate-950/40'
+              }`}
+            >
+              <p className="flex items-start gap-2.5 text-sm font-black leading-tight text-slate-100">
+                <Icono size={18} aria-hidden="true" className={`shrink-0 mt-0.5 ${e.critico ? 'text-rose-300' : 'text-slate-300'}`} />
+                <span>
+                  {e.nombre}
+                  {e.critico && (
+                    <span className="ml-2 rounded-full bg-rose-500/20 border border-rose-500/50 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-rose-200 align-middle">
+                      Grave
+                    </span>
+                  )}
+                </span>
+              </p>
+              <dl className="mt-2 space-y-1 text-xs leading-snug">
+                <div className="flex gap-1.5">
+                  <dt className="shrink-0 font-bold text-slate-400">De dónde:</dt>
+                  <dd className="text-slate-300">{e.causa}</dd>
+                </div>
+                <div className="flex gap-1.5">
+                  <dt className="shrink-0 font-bold text-slate-400">Cómo se ve:</dt>
+                  <dd className="text-slate-200">{e.senal}</dd>
+                </div>
+                <div className="flex gap-1.5">
+                  <dt className="shrink-0 font-bold text-slate-400">Más riesgo:</dt>
+                  <dd className="text-slate-300">{e.masRiesgo}</dd>
+                </div>
+              </dl>
+              {/* Autoridad institucional citada — el "guard": nunca una persona */}
+              <div className="mt-2 rounded-lg border border-sky-700/40 bg-sky-950/30 p-2.5">
+                <p className="flex items-start gap-1.5 text-[11px] leading-snug text-sky-100">
+                  <ShieldCheck size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-sky-300" />
+                  <span>{e.autoridad}</span>
+                </p>
+                <p className="mt-1 text-[10px] leading-snug text-slate-500">Fuente: {e.fuente}</p>
+              </div>
+            </article>
+          );
+        })}
+      </section>
+
+      {/* ── C · La regla de las distancias (ilustración + metros grounded) ── */}
+      <section className="rounded-2xl border border-emerald-700/40 bg-slate-900/60 p-4 space-y-3" data-testid="agua-distancias">
+        <p className="flex items-center gap-2 text-sm font-black text-emerald-200 uppercase tracking-wide">
+          <Ruler size={16} aria-hidden="true" /> La regla de las distancias
+        </p>
+        <p className="text-xs leading-snug text-slate-300">
+          La misma finca, en corte: el agua en el centro, y cada cosa que la puede dañar a su
+          distancia mínima. Lo verde protege; lo rojo se aleja.
+        </p>
+
+        <DistanciasFinca items={DISTANCIAS_SEGURIDAD} />
+
+        <ul className="space-y-2">
+          {DISTANCIAS_SEGURIDAD.map((d) => (
+            <li key={d.id} className="flex items-start gap-2.5" data-testid={`distancia-${d.id}`}>
+              <span
+                aria-hidden="true"
+                className={`shrink-0 mt-0.5 inline-flex items-center justify-center min-w-[52px] rounded-lg px-1.5 py-0.5 text-xs font-black ${
+                  d.tipo === 'proteger'
+                    ? 'bg-emerald-500/15 text-emerald-200 border border-emerald-500/40'
+                    : 'bg-rose-500/15 text-rose-200 border border-rose-500/40'
+                }`}
+              >
+                {d.metros} m
+              </span>
+              <span className="min-w-0">
+                <span className="block text-sm font-bold text-slate-100 leading-tight">{d.que}</span>
+                <span className="block text-xs text-slate-300 leading-snug mt-0.5">{d.detalle}</span>
+                <span className="block text-[10px] text-slate-500 leading-snug mt-0.5">
+                  {d.norma}{d.confianza === 'media' ? ' · referencia (confianza media)' : ''}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+        <p className="flex items-start gap-1.5 text-[11px] leading-snug text-slate-400">
+          <Landmark size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-slate-500" />
+          <span>
+            La distancia exacta de un corral o porqueriza al agua todavía no tiene una cifra única en
+            norma nacional{' '}<SlotPendiente>retiro de corrales en camino (ICA)</SlotPendiente>; mientras
+            tanto, la regla es sencilla: lejos y aguas abajo del pozo.
+          </span>
+        </p>
+      </section>
+    </div>
+  );
+}
+
 /* ── PILAR 3 · Cuidar el agua ─────────────────────────────────────────── */
 function PilarCuidar() {
   // Fase ENSO viva desde el servicio que Chagra ya tiene (no se re-implementa
@@ -447,6 +662,9 @@ function PilarCuidar() {
           </ul>
         </div>
       </div>
+
+      {/* RIESGOS DE CONTAMINACIÓN + SALUD (qué contamina, qué enferma, distancias) */}
+      <RiesgosSalud />
 
       {/* CASO INSIGNIA */}
       <div className="rounded-2xl border border-emerald-700/50 bg-emerald-950/30 p-4 space-y-3" data-testid="caso-nacimiento">

--- a/src/components/agua/AguaScreen.test.jsx
+++ b/src/components/agua/AguaScreen.test.jsx
@@ -106,6 +106,67 @@ describe('AguaScreen — pilar cuidar (caso nacimiento + ENSO)', () => {
   });
 });
 
+describe('AguaScreen — riesgos de contaminación + salud', () => {
+  it('muestra qué contamina el agua con el semáforo de peligro', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+
+    const bloque = screen.getByTestId('agua-que-contamina');
+    // Focos clave del pedido del operador presentes.
+    expect(bloque).toHaveTextContent(/venenos y plaguicidas/i);
+    expect(bloque).toHaveTextContent(/cocheras y corrales/i);
+    expect(bloque).toHaveTextContent(/letrinas/i);
+    // Vías de contaminación explicadas (didáctico).
+    expect(bloque).toHaveTextContent(/escorrent/i);
+    expect(bloque).toHaveTextContent(/lixiviaci/i);
+    // Semáforo: los venenos son peligro ALTO.
+    const riesgoVeneno = screen.getByTestId('riesgo-plaguicidas');
+    expect(riesgoVeneno).toHaveTextContent(/peligro alto/i);
+  });
+
+  it('la metahemoglobinemia (bebé azul) cita autoridad institucional, nunca una persona', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+
+    const meta = screen.getByTestId('enfermedad-metahemoglobinemia');
+    expect(meta).toHaveTextContent(/bebé azul/i);
+    // Safety-critical: respaldado por OMS y Resolución 2115/2007 (MinSalud).
+    expect(meta).toHaveTextContent(/OMS/);
+    expect(meta).toHaveTextContent(/Resolución 2115\/2007/);
+    // Nitratos como causa y su límite grounded.
+    expect(meta).toHaveTextContent(/nitrato/i);
+    expect(meta).toHaveTextContent(/50 mg\/L/);
+    // Marcada como grave.
+    expect(meta).toHaveTextContent(/grave/i);
+  });
+
+  it('muestra la intoxicación por plaguicidas con el ICA como autoridad', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    const intox = screen.getByTestId('enfermedad-intoxicacion');
+    expect(intox).toHaveTextContent(/intoxicaci/i);
+    expect(intox).toHaveTextContent(/ICA/);
+  });
+
+  it('muestra la regla de las distancias groundeadas + la ilustración de la finca', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+
+    // Ilustración presente (decorativa) y lista de distancias.
+    expect(screen.getByTestId('distancias-finca')).toBeInTheDocument();
+    const distancias = screen.getByTestId('agua-distancias');
+    // Cifras grounded: 10 m fumigación terrestre, 100 m nacimiento, 30 m letrina.
+    expect(screen.getByTestId('distancia-fumigacion-terrestre')).toHaveTextContent('10 m');
+    expect(screen.getByTestId('distancia-nacimiento')).toHaveTextContent('100 m');
+    expect(screen.getByTestId('distancia-septico')).toHaveTextContent('30 m');
+    // Normas citadas.
+    expect(distancias).toHaveTextContent(/Decreto 1843\/1991/);
+    expect(distancias).toHaveTextContent(/RAS/);
+    // Honestidad: el retiro exacto de corrales aún es "dato en camino".
+    expect(screen.getByTestId('agua-distancias')).toHaveTextContent(/en camino/i);
+  });
+});
+
 describe('AguaScreen — puente al agente', () => {
   it('navega al agente con la pregunta prellenada', () => {
     const onNavigate = vi.fn();

--- a/src/components/agua/DistanciasFinca.jsx
+++ b/src/components/agua/DistanciasFinca.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+
+/**
+ * DistanciasFinca — ilustración "la regla de las distancias" del módulo Agua.
+ *
+ * Un corte de la finca visto de lado (mismo trazo de cuaderno de campo que
+ * CaminoDelAgua): el AGUA en el centro-bajo del valle, la franja de MONTE que
+ * la protege (verde) y, ladera arriba, los focos de riesgo que hay que ALEJAR
+ * (rojo), cada uno con su metraje mínimo. Enseña de un vistazo la idea clave:
+ * lo verde se deja pegado al agua; lo rojo se manda lejos y aguas abajo.
+ *
+ * DECORATIVA (aria-hidden): la información autoritativa (metros + norma) va en
+ * la lista de texto que la acompaña en AguaScreen. Los metros se leen de las
+ * props para que el dibujo y la lista nunca se desincronicen.
+ *
+ * @param {{ items?: Array<{id:string, metros:number}> }} props
+ */
+export default function DistanciasFinca({ items = [] }) {
+  const m = Object.fromEntries(items.map((d) => [d.id, d.metros]));
+  const nac = m.nacimiento ?? 100;
+  const cauce = m.cauce ?? 30;
+  const sept = m.septico ?? 30;
+  const fumT = m['fumigacion-terrestre'] ?? 10;
+  const fumA = m['fumigacion-aerea'] ?? 100;
+
+  return (
+    <svg
+      viewBox="0 0 360 168"
+      role="img"
+      aria-hidden="true"
+      className="w-full h-auto select-none"
+      data-testid="distancias-finca"
+    >
+      {/* ladera: el terreno baja hacia el agua en el centro */}
+      <path
+        d="M6 150 Q 90 150 176 132 Q 184 129 192 132 Q 278 150 354 150"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        className="text-amber-700/60"
+      />
+      {/* flecha "aguas abajo" bajo la ladera derecha */}
+      <g className="text-slate-500">
+        <path d="M300 160 L336 160" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeDasharray="3 4" />
+        <path d="M330 156 L338 160 L330 164 Z" fill="currentColor" />
+      </g>
+      <text x="300" y="157" className="fill-current text-slate-500" fontSize="7" textAnchor="end">aguas abajo</text>
+
+      {/* ── AGUA en el centro (nacimiento + hilo que baja) ── */}
+      <g className="text-cyan-300">
+        <ellipse cx="184" cy="134" rx="15" ry="5.5" fill="currentColor" opacity="0.85" className="agua-hilo" />
+        <circle cx="184" cy="132" r="4.5" fill="currentColor" className="agua-hilo" />
+      </g>
+      <text x="184" y="150" className="fill-current text-cyan-200" fontSize="8" fontWeight="700" textAnchor="middle">el agua</text>
+
+      {/* ── FRANJA DE MONTE que protege (verde) — pegada al agua ── */}
+      <g className="text-emerald-400">
+        {/* copas de monte nativo a lado y lado del ojo de agua */}
+        <g>
+          <line x1="160" y1="128" x2="160" y2="116" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          <circle cx="160" cy="110" r="7" fill="currentColor" opacity="0.85" />
+          <line x1="146" y1="132" x2="146" y2="122" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          <circle cx="146" cy="117" r="5.5" fill="currentColor" opacity="0.7" />
+          <line x1="208" y1="128" x2="208" y2="116" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          <circle cx="208" cy="110" r="7" fill="currentColor" opacity="0.85" />
+          <line x1="222" y1="132" x2="222" y2="122" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          <circle cx="222" cy="117" r="5.5" fill="currentColor" opacity="0.7" />
+        </g>
+      </g>
+      {/* corchete verde de la franja protegida */}
+      <g className="text-emerald-500">
+        <path d="M132 100 L132 94 L236 94 L236 100" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+      </g>
+      <text x="184" y="88" className="fill-current text-emerald-300" fontSize="8" fontWeight="700" textAnchor="middle">
+        dejar monte: {cauce} m quebrada · {nac} m nacimiento
+      </text>
+
+      {/* ── RIESGOS que hay que ALEJAR (rojo), ladera arriba ── */}
+      {/* letrina / pozo séptico, a la derecha y aguas abajo */}
+      <g className="text-rose-400">
+        <rect x="286" y="120" width="18" height="20" rx="2" fill="none" stroke="currentColor" strokeWidth="2" />
+        <path d="M286 120 L295 112 L304 120 Z" fill="currentColor" opacity="0.85" />
+        {/* línea de retiro al agua */}
+        <path d="M200 138 L286 132" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeDasharray="2 4" />
+      </g>
+      <text x="295" y="150" className="fill-current text-rose-300" fontSize="7.5" fontWeight="700" textAnchor="middle">letrina {sept} m</text>
+
+      {/* fumigación con bomba de espalda, a la izquierda */}
+      <g className="text-rose-400">
+        {/* figura simple: persona con bomba */}
+        <circle cx="70" cy="112" r="4" fill="currentColor" opacity="0.85" />
+        <line x1="70" y1="116" x2="70" y2="128" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+        <line x1="70" y1="120" x2="80" y2="116" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        {/* rociado */}
+        <g stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" opacity="0.7">
+          <line x1="81" y1="115" x2="88" y2="112" />
+          <line x1="81" y1="117" x2="89" y2="117" />
+          <line x1="81" y1="119" x2="88" y2="122" />
+        </g>
+        <path d="M96 128 L160 134" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeDasharray="2 4" />
+      </g>
+      <text x="72" y="140" className="fill-current text-rose-300" fontSize="7.5" fontWeight="700" textAnchor="middle">fumigar +{fumT} m</text>
+
+      {/* avioneta arriba (fumigación aérea) */}
+      <g className="text-rose-400">
+        <path d="M40 34 l16 0 l6 -5 l-3 5 l10 0 l-8 4 l-21 0 z" fill="currentColor" opacity="0.8" />
+      </g>
+      <text x="52" y="52" className="fill-current text-rose-300" fontSize="7.5" fontWeight="700" textAnchor="middle">avioneta +{fumA} m</text>
+
+      {/* leyenda de color */}
+      <g fontSize="7.5" fontWeight="700">
+        <circle cx="250" cy="16" r="3.5" className="fill-current text-emerald-400" />
+        <text x="258" y="19" className="fill-current text-emerald-300">proteger (dejar monte)</text>
+        <circle cx="250" cy="30" r="3.5" className="fill-current text-rose-400" />
+        <text x="258" y="33" className="fill-current text-rose-300">alejar (retirar el riesgo)</text>
+      </g>
+    </svg>
+  );
+}

--- a/src/components/agua/agua.css
+++ b/src/components/agua/agua.css
@@ -59,11 +59,22 @@
   animation: agua-seccion-entra 0.3s ease-out;
 }
 
+/* Punto del semáforo de peligro ALTO: late suave para llamar la atención
+   sin gritar (solo opacity, bajo costo). El "medio" queda estático. */
+@keyframes agua-peligro-late {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+.agua-peligro-late {
+  animation: agua-peligro-late 1.6s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .agua-gota,
   .agua-hilo,
   .agua-estacion-activa,
-  .agua-seccion {
+  .agua-seccion,
+  .agua-peligro-late {
     animation: none;
   }
   .agua-gota { opacity: 0.9; }

--- a/src/components/common/PedagogicalBlock.jsx
+++ b/src/components/common/PedagogicalBlock.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Lightbulb } from 'lucide-react';
+
+/**
+ * PedagogicalBlock — bloque de texto DIDÁCTICO para explicar temas densos sin
+ * volverlos un muro.
+ *
+ * Patrón campesino "lee al sol": una frase-guía en grande (lo que hay que
+ * llevarse), el desarrollo en cuerpo legible, y opcionalmente una "clave"
+ * resaltada al pie. Jerarquía tipográfica clara, líneas cortas.
+ *
+ * Es puramente presentacional (sin estado ni datos de módulo): copiar-listo y
+ * reutilizable por cualquier pantalla que necesite explicar un concepto
+ * (aquí: los riesgos de contaminación del agua y la salud).
+ *
+ * NOTA: no confundir con `PedagogicalText` (mismo directorio) — ese otro
+ * componente parsea prosa cruda del catálogo (`parsePedagogicalText`) para la
+ * ficha de especie y el biopreparado; este es un bloque de layout genérico
+ * (lead/children/clave/icon) para cualquier pantalla. Nombres distintos a
+ * propósito para no pisar el componente compartido existente.
+ *
+ * @param {object} props
+ * @param {React.ReactNode} [props.lead]     frase-guía destacada (opcional).
+ * @param {React.ReactNode} [props.children] cuerpo del texto.
+ * @param {React.ReactNode} [props.clave]    cierre resaltado "lo clave" (opcional).
+ * @param {import('lucide-react').LucideIcon} [props.icon] ícono del bloque.
+ * @param {'neutral'|'alerta'} [props.tone]  acento de color.
+ * @param {string} [props.className]
+ */
+export default function PedagogicalBlock({
+  lead = null,
+  children = null,
+  clave = null,
+  icon: Icon = null,
+  tone = 'neutral',
+  className = '',
+  ...rest
+}) {
+  const accent = tone === 'alerta'
+    ? {
+      border: 'border-rose-700/40',
+      bar: 'bg-rose-500/70',
+      lead: 'text-rose-200',
+      chip: 'border-rose-500/40 bg-rose-500/10 text-rose-100',
+    }
+    : {
+      border: 'border-slate-700/60',
+      bar: 'bg-cyan-500/60',
+      lead: 'text-slate-100',
+      chip: 'border-cyan-500/40 bg-cyan-500/10 text-cyan-100',
+    };
+
+  return (
+    <div
+      className={`relative rounded-2xl border ${accent.border} bg-slate-900/50 p-4 pl-5 ${className}`}
+      {...rest}
+    >
+      {/* barra de acento a la izquierda: ancla la vista, estilo cuaderno */}
+      <span aria-hidden="true" className={`absolute left-0 top-3 bottom-3 w-1 rounded-full ${accent.bar}`} />
+
+      {(lead || Icon) && (
+        <p className={`flex items-start gap-2 text-sm font-black leading-snug ${accent.lead}`}>
+          {Icon && <Icon size={18} aria-hidden="true" className="shrink-0 mt-0.5" />}
+          {lead && <span>{lead}</span>}
+        </p>
+      )}
+
+      {children && (
+        <div className={`text-sm leading-relaxed text-slate-300 space-y-2 ${lead || Icon ? 'mt-2' : ''}`}>
+          {children}
+        </div>
+      )}
+
+      {clave && (
+        <p className={`mt-3 inline-flex items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-bold leading-snug ${accent.chip}`}>
+          <Lightbulb size={13} aria-hidden="true" className="shrink-0 mt-0.5" />
+          <span>{clave}</span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/data/aguaFinca.js
+++ b/src/data/aguaFinca.js
@@ -233,6 +233,216 @@ export const RONDA_PROTECCION = {
   confianza: 'alta',
 };
 
+/* ────────────────────────────────────────────────────────────────────────
+ * PILAR 3b · RIESGOS DE CONTAMINACIÓN + SALUD
+ * (qué le echa veneno al agua, qué enferma, y a qué distancia se previene)
+ *
+ * REGLA REFORZADA (mismo patrón que el veto de botulismo del módulo de
+ * fermentos): todo lo SAFETY-CRITICAL —nitratos que enferman a los bebés,
+ * intoxicación por plaguicidas, diarrea— se respalda con AUTORIDAD
+ * INSTITUCIONAL citada (OMS, MinSalud/INS vía Res. 2115/2007, ICA), NUNCA con
+ * la opinión de una persona. Las CIFRAS de distancia y de límite salen del DR
+ * agua nacional (2026-07-03, verificadas contra la norma). Lo que no tenga
+ * fuente firme se deja como "dato en camino" (SlotPendiente), no se inventa.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Nivel de peligro para el semáforo (alto = rojo, medio = ámbar). */
+export const NIVEL_PELIGRO = Object.freeze({ ALTO: 'alto', MEDIO: 'medio' });
+
+/**
+ * Qué contamina el agua de la finca (fuentes) y por dónde llega:
+ *   · escorrentía  = corre por encima del suelo con el aguacero,
+ *   · lixiviación  = se filtra hacia abajo hasta el agua del subsuelo.
+ * Cualitativo (agroecología + saneamiento básico). Las cifras de distancia
+ * para prevenir viven aparte, groundeadas, en DISTANCIAS_SEGURIDAD.
+ * `icono` es una clave que el componente mapea a un ícono de riesgo.
+ */
+export const RIESGOS_CONTAMINACION = [
+  {
+    id: 'plaguicidas',
+    icono: 'veneno',
+    fuente: 'Venenos y plaguicidas',
+    via: 'Escorrentía y lixiviación',
+    aporta: 'Residuos de agroquímicos que corren con el aguacero o se filtran al subsuelo hasta el nacimiento y el pozo.',
+    nivel: 'alto',
+    prevenir: 'No fumigue ni lave la bomba cerca del agua; respete la franja de seguridad (ver distancias). Los envases NO se enjuagan en la quebrada.',
+  },
+  {
+    id: 'cochera',
+    icono: 'cochera',
+    fuente: 'Cocheras y corrales mal manejados',
+    via: 'Escorrentía y lixiviación',
+    aporta: 'El estiércol sin manejo suelta coliformes y E. coli (microbios de la caca) y nitratos que bajan al agua.',
+    nivel: 'alto',
+    prevenir: 'Cochera con piso, techo y cuneta que NO drene al cauce; el estiércol va a compost o biodigestor. Siempre lejos y aguas abajo del pozo.',
+  },
+  {
+    id: 'letrina',
+    icono: 'letrina',
+    fuente: 'Letrinas y pozos sépticos mal ubicados',
+    via: 'Lixiviación',
+    aporta: 'Coliformes/E. coli y nitratos que se filtran cuando la letrina queda cerca o loma arriba del pozo de agua.',
+    nivel: 'alto',
+    prevenir: 'Letrina o pozo séptico siempre aguas abajo y a la distancia mínima del pozo de agua (ver distancias).',
+  },
+  {
+    id: 'agroquimicos',
+    icono: 'agroquimico',
+    fuente: 'Fertilizantes en exceso',
+    via: 'Lixiviación',
+    aporta: 'El sobrante de urea y abonos nitrogenados se filtra como nitratos: el mismo veneno silencioso que enferma a los bebés.',
+    nivel: 'alto',
+    prevenir: 'Abone lo que la mata necesita, no de más; un suelo tapado y con materia orgánica retiene el nitrógeno en vez de soltarlo al agua.',
+  },
+  {
+    id: 'combustibles',
+    icono: 'combustible',
+    fuente: 'Combustibles y aceites',
+    via: 'Escorrentía',
+    aporta: 'Gasolina, ACPM y aceite quemado dejan una nata de hidrocarburos que el agua no bota ni hirviendo.',
+    nivel: 'medio',
+    prevenir: 'Guarde y cambie aceites lejos del agua, sobre piso firme; el aceite usado se recoge, no se riega ni se quema al lado del cauce.',
+  },
+  {
+    id: 'matadero',
+    icono: 'matadero',
+    fuente: 'Sacrificio casero (mataderos)',
+    via: 'Escorrentía directa',
+    aporta: 'Sangre, vísceras y lavazas cargan materia orgánica y microbios directo a la quebrada si se botan ahí.',
+    nivel: 'medio',
+    prevenir: 'Sacrifique lejos del agua; los desechos van a compost o fosa, nunca al cauce.',
+  },
+  {
+    id: 'basura',
+    icono: 'basura',
+    fuente: 'Basura y botaderos',
+    via: 'Lixiviación',
+    aporta: 'La basura amontonada suelta lixiviados (el jugo negro) que bajan al suelo y al agua.',
+    nivel: 'medio',
+    prevenir: 'Nada de botaderos al lado del cauce; separe, composte lo orgánico y saque el resto de la ronda del agua.',
+  },
+];
+
+/**
+ * Distancia específica de un corral/porqueriza a la fuente de agua: no hay una
+ * cifra única citable en norma nacional (las Buenas Prácticas Porcícolas del
+ * ICA dan criterios de ubicación, no un metraje universal). Se deja honesta
+ * como "dato en camino" y en la práctica se manda "lejos y aguas abajo".
+ */
+export const DISTANCIA_CORRAL_AGUA = {
+  estado: ESTADO_GROUNDED_PENDIENTE,
+  valor: null,
+  fuentePrevista: 'ICA — Buenas Prácticas Porcícolas/Ganaderas (retiro de corrales a fuentes de agua)',
+};
+
+/**
+ * Qué ENFERMA cuando esa contaminación llega al agua que se toma.
+ *
+ * SAFETY-CRITICAL: cada enfermedad se respalda con la AUTORIDAD que fija el
+ * límite o el diagnóstico (OMS, MinSalud/INS vía Res. 2115/2007, ICA), NUNCA
+ * con una persona. La metahemoglobinemia (bebés) es la más grave y silenciosa:
+ * va marcada `critico: true`. `icono` = clave que el componente mapea.
+ */
+export const ENFERMEDADES_AGUA = [
+  {
+    id: 'diarrea',
+    icono: 'diarrea',
+    nombre: 'Diarrea e infecciones del estómago',
+    critico: false,
+    causa: 'Coliformes y E. coli de cocheras, letrinas y heces que llegan al agua.',
+    senal: 'Diarrea, vómito, cólico y deshidratación — más peligrosa en niños y ancianos.',
+    masRiesgo: 'Niños pequeños y adultos mayores.',
+    autoridad: 'El agua para tomar no admite NINGUNA E. coli (0 UFC/100 mL). En Colombia, el 37,4 % del agua rural está en riesgo ALTO.',
+    fuente: 'Resolución 2115/2007 (MinSalud/MinVivienda); INCA 2023 (MinVivienda/INS)',
+  },
+  {
+    id: 'metahemoglobinemia',
+    icono: 'bebe',
+    nombre: 'Metahemoglobinemia — el «bebé azul»',
+    critico: true,
+    causa: 'Nitratos en el agua (de estiércol, letrinas y abonos) usada para preparar el tetero.',
+    senal: 'El nitrato se vuelve nitrito en la barriga del bebé y le quita el oxígeno a la sangre: la piel se pone azulada alrededor de la boca y los ojos. Puede ser mortal.',
+    masRiesgo: 'Bebés menores de 6 meses, sobre todo con leche de fórmula preparada con esa agua.',
+    autoridad: 'La OMS fija el nitrato en máximo 50 mg/L justamente para evitar esta enfermedad en lactantes; Colombia exige máximo 10 mg/L de nitratos y 0,1 mg/L de nitritos en el agua de tomar. Si un bebé se pone azulado: al médico YA.',
+    fuente: 'OMS — Guías para la calidad del agua de consumo humano (valor guía nitrato 50 mg/L); Resolución 2115/2007 (MinSalud): nitratos 10 mg/L, nitritos 0,1 mg/L',
+  },
+  {
+    id: 'intoxicacion',
+    icono: 'intoxicacion',
+    nombre: 'Intoxicación por plaguicidas',
+    critico: true,
+    causa: 'Residuos de venenos agrícolas que la lluvia arrastra al agua, o envases lavados en el cauce.',
+    senal: 'Dolor de cabeza, náuseas, mareo, visión borrosa; en casos fuertes, urgencia médica.',
+    masRiesgo: 'Toda la familia; el veneno no se ve ni se quita hirviendo el agua.',
+    autoridad: 'El agua de tomar admite como máximo 0,1 mg/L de plaguicidas en total. El registro y control de plaguicidas es del ICA, que mantiene la lista de los prohibidos. Si el agua huele a químico o viene de potrero fumigado, NO se toma — ni hervida.',
+    fuente: 'Resolución 2115/2007 (MinSalud): plaguicidas ≤ 0,1 mg/L; ICA (registro y control de plaguicidas)',
+  },
+];
+
+/**
+ * La REGLA DE LAS DISTANCIAS: a qué retiro del agua debe quedar cada foco de
+ * contaminación y qué franja de monte hay que dejar. Cifras GROUNDED contra
+ * norma (DR agua nacional §4.1). `tipo`: 'proteger' (dejar monte) vs 'alejar'
+ * (retirar la fuente de riesgo). El componente ilustra estos metros.
+ */
+export const DISTANCIAS_SEGURIDAD = [
+  {
+    id: 'nacimiento',
+    icono: 'nacimiento',
+    que: 'Monte alrededor del nacimiento',
+    metros: 100,
+    detalle: 'Franja de bosque a la redonda del ojo de agua. Es obligación del dueño del predio.',
+    norma: 'Decreto 1449/1977 Art. 3 (hoy Decreto 1076/2015)',
+    tipo: 'proteger',
+    estado: 'grounded',
+    confianza: 'alta',
+  },
+  {
+    id: 'cauce',
+    icono: 'cauce',
+    que: 'Monte a lado y lado de ríos y quebradas',
+    metros: 30,
+    detalle: 'Franja de bosque a cada orilla del cauce, sea permanente o no.',
+    norma: 'Decreto 1449/1977 Art. 3 (hoy Decreto 1076/2015)',
+    tipo: 'proteger',
+    estado: 'grounded',
+    confianza: 'alta',
+  },
+  {
+    id: 'septico',
+    icono: 'letrina',
+    que: 'Letrina o pozo séptico, lejos y aguas abajo del pozo de agua',
+    metros: 30,
+    detalle: 'Retiro mínimo de la letrina o pozo séptico al pozo/aljibe de agua para tomar, y SIEMPRE ladera abajo de él.',
+    norma: 'RAS — Reglamento de Agua Potable y Saneamiento Básico, Título E (MinVivienda)',
+    tipo: 'alejar',
+    estado: 'grounded',
+    confianza: 'media',
+  },
+  {
+    id: 'fumigacion-terrestre',
+    icono: 'fumigar',
+    que: 'No fumigar con bomba de espalda junto al agua',
+    metros: 10,
+    detalle: 'Franja de seguridad mínima entre la fumigación terrestre y cualquier cuerpo de agua.',
+    norma: 'Decreto 1843/1991 Art. 87',
+    tipo: 'alejar',
+    estado: 'grounded',
+    confianza: 'alta',
+  },
+  {
+    id: 'fumigacion-aerea',
+    icono: 'fumigar',
+    que: 'No fumigar con avioneta sobre el agua',
+    metros: 100,
+    detalle: 'Franja de seguridad mínima para aspersión aérea sobre cuerpos de agua.',
+    norma: 'Decreto 1843/1991 Art. 87',
+    tipo: 'alejar',
+    estado: 'grounded',
+    confianza: 'alta',
+  },
+];
+
 /**
  * CASO INSIGNIA · "Se me seca el nacimiento en verano".
  * Plan cualitativo por tiempos: qué hacer YA en verano, qué sembrar/cercar en


### PR DESCRIPTION
Agrega al pilar "Cuidar el agua" una sección didáctica de RIESGOS DE
CONTAMINACIÓN + SALUD, en el mismo lenguaje visual del módulo (cuaderno de
campo, acentos cyan, animaciones sutiles):

- Qué le echa veneno al agua: 7 focos (venenos/plaguicidas, cocheras/corrales,
  letrinas/sépticos, fertilizantes, combustibles, mataderos caseros, basura)
  con ícono de riesgo, semáforo de peligro alto/medio y las vías escorrentía
  vs lixiviación explicadas.
- Y esto es lo que enferma: diarrea, metahemoglobinemia (el «bebé azul») e
  intoxicación por plaguicidas. Cada enfermedad se respalda con AUTORIDAD
  INSTITUCIONAL citada (OMS, MinSalud/INS vía Res. 2115/2007, ICA, INCA 2023),
  NUNCA una persona (mismo patrón que el veto de botulismo). La metahemo-
  globinemia va marcada como GRAVE.
- La regla de las distancias: ilustración SVG de la finca en corte
  (DistanciasFinca) + lista de metros grounded (100 m nacimiento / 30 m cauce,
  Decreto 1449/1977; 10 m terrestre / 100 m aérea al fumigar, Decreto
  1843/1991; 30 m letrina/séptico al pozo y aguas abajo, RAS Título E).

Honestidad grounded: el retiro exacto de un corral/porqueriza al agua no tiene
cifra única citable en norma nacional → se deja como "dato en camino" (ICA
Buenas Prácticas Porcícolas), no se inventa.

Reúsa un nuevo componente compartido PedagogicalText para el texto denso.
Fuentes: DR agua-manejo-nacional-CO (2026-07-03) + OMS/OPS, Res. 2115/2007,
Decreto 1843/1991, RAS Título E (MinVivienda).

Tests: 4 casos nuevos (semáforo, autoridad institucional en metahemoglobinemia,
ICA en intoxicación, distancias grounded + ilustración). 12/12 verde.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
