### PR TITLE
feat(agente): consumir el semáforo de confianza del sidecar (MODO CIENTÍFICO #17)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -818,7 +818,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // formatToolEvidence y analyzeQuery viven en agentPromptBase (funciones
   // puras, testeables y medibles fuera de React).
 
-  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null, fermentoBlock = '', subgrafoBloque = '', biopreparadoBlock = '', pisoTermicoBlock = '') => {
+  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null, fermentoBlock = '', subgrafoBloque = '', biopreparadoBlock = '', pisoTermicoBlock = '', groundingPolicyBlock = '') => {
     const analysis = analyzeQuery(query);
     // El base recibe query/historial/isEnum para inyectar SOLO los glosarios
     // y reglas condicionales que la conversación toca (re-arquitectura GR-10).
@@ -1030,6 +1030,17 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       ? `\n\n${pisoTermicoBlock}`
       : '';
 
+    // MODO CIENTÍFICO (#17) — bloque answer/hedge/abstain ya formateado por
+    // el sidecar (WIRING real de grounding-policy.ts/grounding-prompt-
+    // formatter.ts). Va DENTRO del cluster de grounding (después de la cadena
+    // relacional): cuando la política es "abstain" el LLM recibe la
+    // instrucción explícita de NO inventar; "hedge" pide matizar; "answer" no
+    // agrega instrucción (el grounding ya alcanza). '' (no-op) si el sidecar
+    // no respondió — degradación graceful.
+    const groundingPolicyContext = (typeof groundingPolicyBlock === 'string' && groundingPolicyBlock.trim())
+      ? `\n\n${groundingPolicyBlock}`
+      : '';
+
     // Re-arquitectura GR-10: ensamblado con PRESUPUESTO de tokens y prioridad
     // por relevancia (promptAssembler). El grounding (evidencia / entidades /
     // hechos curados / cadena) va al FINAL del system — donde la truncación de
@@ -1054,6 +1065,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       resolvedEntities: resolvedEntitiesBlock,
       curatedFacts: curatedFactsContext,
       relacional: relacionalContext,
+      groundingPolicy: groundingPolicyContext,
       queryAnalysis: queryAnalysisBlock,
       suggested: suggestedBlock,
       priceDecline: priceDeclineBlock,
@@ -1364,6 +1376,15 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // no-op en el system prompt si el piso coincide, no hubo señal de piso
       // del usuario, o el sidecar no respondió (degradación graceful).
       let pisoTermicoBlock = '';
+      // MODO CIENTÍFICO (#17) — WIRING real de grounding-policy.ts/grounding-
+      // prompt-formatter.ts (audit 2026-07-04-optimizacion-grounding-
+      // velocidad-inteligencia.md win #4). El sidecar decide answer/hedge/
+      // abstain sobre las entidades del turno (incluye CERO entidades →
+      // abstain) y devuelve un bloque ya formateado + el semáforo verde/
+      // ámbar/rojo. '' / null por default → no-op (degradación graceful, el
+      // turno sigue sin este gate si el sidecar no respondió).
+      let groundingPolicyBlock = '';
+      let groundingDecisionMeta = null;
       // GraphRAG multi-hop (#1 intelligence-first): bloque "CADENA DE RELACIONES"
       // del grafo AGE para queries relacionales (plaga+cultivo). '' = no-op.
       let subgrafoBloque = '';
@@ -1463,6 +1484,24 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               latencyMs: Math.round(tRE1 - tRE0),
               entities: canonical.map((e) => `${e.mentioned}→${e.canonical_id}`),
               suggestedEntities: suggested.map((e) => `${e.mentioned}→${e.canonical_id}@${e.confidence}`),
+            });
+          }
+
+          // MODO CIENTÍFICO (#17) — semáforo de confianza + política real
+          // answer/hedge/abstain. Gate INDEPENDIENTE del bloque de arriba (no
+          // anidado en `resolved.entities.length > 0`): el caso de CERO
+          // entidades es exactamente el que debe producir `abstain`/rojo. El
+          // sidecar ya corrió `decideGroundingPolicy`/`formatGroundingBlock`
+          // de verdad (grounding-wire.ts) — aquí solo consumimos el bloque
+          // pre-formateado, igual que fermento/biopreparado.
+          if (resolved && resolved.grounding && typeof resolved.grounding.block === 'string' && resolved.grounding.block.trim()) {
+            groundingPolicyBlock = resolved.grounding.block;
+            groundingDecisionMeta = resolved.grounding;
+            console.debug('[sidecar] grounding-policy', {
+              policy: resolved.grounding.policy,
+              semaphore: resolved.grounding.semaphore,
+              resolvedEntities: resolved.grounding.resolved_entities,
+              minConfidence: resolved.grounding.min_confidence,
             });
           }
 
@@ -1967,7 +2006,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       const deterministicPrice = buildPriceAnswer({ userMessage: text, toolEvidence });
       const rawResponse = deterministicPrice != null
         ? deterministicPrice
-        : await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock, edgesTruncated, biopreparadoBlock, pisoTermicoBlock);
+        : await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock, edgesTruncated, biopreparadoBlock, pisoTermicoBlock, groundingPolicyBlock);
       if (deterministicPrice != null) {
         console.debug('[precio] respuesta determinista SIPSA (sin LLM)', { route: nluRoute });
       }
@@ -2085,10 +2124,24 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       const evidenceSourceLink = groundingBadges.fuente_url
         ? {}
         : deriveEvidenceSourceLink(toolEvidence);
+      // MODO CIENTÍFICO (#17) — semáforo verde/ámbar/rojo + política real del
+      // turno (WIRING de grounding-policy.ts vía el sidecar), expuesto en la
+      // metadata del mensaje para que una futura UI (badge de confianza) lo
+      // pinte SIN volver a calcularlo — el semáforo es 1:1 con lo que el
+      // agente ya decidió. Graceful: sin decisión del sidecar → no añade nada
+      // (no contamina sourceMetadata con null).
+      const groundingSemaphoreMeta = groundingDecisionMeta
+        ? {
+            grounding_semaphore: groundingDecisionMeta.semaphore,
+            grounding_policy: groundingDecisionMeta.policy,
+            grounding_reason: groundingDecisionMeta.reason,
+          }
+        : {};
       sourceMetadata = {
         ...sourceMetadata,
         ...evidenceSourceLink,
         ...groundingBadges,
+        ...groundingSemaphoreMeta,
         auto_corrected: guarded.modified === true,
       };
 

--- a/src/services/__tests__/promptAssembler.test.js
+++ b/src/services/__tests__/promptAssembler.test.js
@@ -88,6 +88,25 @@ describe('assembleSystemContent — orden por prioridad', () => {
     expect(content.indexOf('GUARDA_PISO_TERMICO')).toBeGreaterThan(content.indexOf('GUARDA_BIOPREPARADO'));
     expect(content.endsWith('GUARDA_PISO_TERMICO')).toBe(true);
   });
+
+  // MODO CIENTÍFICO (#17): el bloque answer/hedge/abstain (grounding-policy.ts
+  // WIRING real vía el sidecar) queda DENTRO del cluster de grounding —
+  // después de la cadena relacional, antes del análisis de la query — para
+  // que domine por recency sin pisar las guardas de seguridad finales.
+  it('groundingPolicy queda DESPUÉS de relacional y ANTES de queryAnalysis', () => {
+    const { content } = assembleSystemContent({
+      base: 'BASE_PROMPT',
+      relacional: 'BLOQUE_CADENA',
+      groundingPolicy: 'BLOQUE_GROUNDING_POLICY',
+      queryAnalysis: 'BLOQUE_ANALISIS',
+    });
+    expect(content.indexOf('BLOQUE_GROUNDING_POLICY')).toBeGreaterThan(
+      content.indexOf('BLOQUE_CADENA'),
+    );
+    expect(content.indexOf('BLOQUE_ANALISIS')).toBeGreaterThan(
+      content.indexOf('BLOQUE_GROUNDING_POLICY'),
+    );
+  });
 });
 
 describe('assembleSystemContent — presupuesto y degradación', () => {
@@ -144,6 +163,23 @@ describe('assembleSystemContent — presupuesto y degradación', () => {
       expect(r.content.split(big).length - 1).toBeGreaterThanOrEqual(8);
       expect(r.breakdown.find((b) => b.name === name).degraded).toBe(false);
     }
+  });
+
+  it('groundingPolicy (MODO CIENTÍFICO #17) NUNCA se recorta bajo presión de presupuesto', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const big = 'w'.repeat(6400); // ~2000 tokens
+    const r = assembleSystemContent(
+      {
+        base: big,
+        groundingPolicy: big,
+        corpus: { variants: ['recortable', ''] },
+      },
+      { budget: 100 },
+    );
+    expect(r.overBudget).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    expect(r.breakdown.find((b) => b.name === 'groundingPolicy').degraded).toBe(false);
+    expect(r.content).toContain(big);
   });
 
   it('MEMORIA EPISÓDICA (TIER 2 #6): va ANTES del grounding y se sacrifica tras el corpus, sin tocar la evidencia', () => {

--- a/src/services/promptAssembler.js
+++ b/src/services/promptAssembler.js
@@ -91,6 +91,7 @@ export const BLOCK_ORDER = [
   'resolvedEntities', // GROUNDING entidades canónicas (protegido)
   'curatedFacts', // GROUNDING hechos curados AGE (protegido)
   'relacional', // GROUNDING cadena de relaciones GraphRAG (protegido)
+  'groundingPolicy', // MODO CIENTÍFICO #17: answer/hedge/abstain por confianza (protegido)
   'queryAnalysis', // análisis NN2/NN3 de ESTA query (protegido)
   'suggested', // GUARDA CASO B baja confianza (protegido)
   'priceDecline', // GUARDA precio sin dato (protegido)

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -425,6 +425,13 @@ const PRECIO_SIPSA_ACTIONS = new Set([
  * @param {object} [opts]
  * @param {number|string|null} [opts.fincaAltitud] - msnm de la finca activa.
  * @param {string} [opts.context] - historial de conversación (últimos N turnos).
+ * MODO CIENTÍFICO (#17): el sidecar corre `grounding-policy.ts`/`grounding-
+ * prompt-formatter.ts` (WIRING real, audit 2026-07-04-optimizacion-
+ * grounding-velocidad-inteligencia.md win #4) sobre las entidades ya
+ * resueltas y devuelve un campo `grounding` con la decisión answer/hedge/
+ * abstain + el semáforo verde/ámbar/rojo — se pasa tal cual (puede ser
+ * `null` si el sidecar no lo computó, degradación graceful).
+ *
  * @returns {Promise<null | { entities: Array<{
  *   mentioned: string,
  *   kind: 'species' | 'pest' | 'biopreparado',
@@ -438,7 +445,15 @@ const PRECIO_SIPSA_ACTIONS = new Set([
  *   viabilidad?: 'viable' | 'marginal' | 'inviable', delta_altitud?: number,
  *   companions?: Array<string|object>, antagonists?: Array<string|object>,
  *   alternativas_viables?: Array<string|object>, alternativas_cercanas?: Array<string|object>,
- * }> }>}
+ * }>, grounding: null | {
+ *   semaphore: 'verde' | 'ambar' | 'rojo',
+ *   policy: 'answer' | 'hedge' | 'abstain',
+ *   reason: string,
+ *   resolved_entities: number,
+ *   min_confidence: number,
+ *   provenance: Array<{ entity_id: string, confidence: number, source: string|null, validation_level: string|null }>,
+ *   block: string,
+ * } }>}
  */
 export async function resolveEntities(userMessage, opts = {}) {
   if (!userMessage || typeof userMessage !== 'string') return null;
@@ -458,8 +473,9 @@ export async function resolveEntities(userMessage, opts = {}) {
   if (Number.isFinite(alt)) body.finca_altitud = alt;
   const raw = await postJson('/resolve-entities', body, NLU_TIMEOUT_MS);
   if (!raw || typeof raw !== 'object') return null;
-  if (!Array.isArray(raw.entities)) return { entities: [] };
-  return { entities: raw.entities };
+  const grounding = raw.grounding && typeof raw.grounding === 'object' ? raw.grounding : null;
+  if (!Array.isArray(raw.entities)) return { entities: [], grounding };
+  return { entities: raw.entities, grounding };
 }
 
 /**


### PR DESCRIPTION
## Resumen

Lado PWA del wiring de MODO CIENTÍFICO (#17). Depende de `guatoc-ecohub/chagra-pro#294` (el sidecar corre `grounding-policy.ts`/`grounding-prompt-formatter.ts` de verdad y devuelve un campo `grounding` en `POST /resolve-entities`).

- `sidecarClient.resolveEntities()` pasa `grounding` tal cual: `{ semaphore: 'verde'|'ambar'|'rojo', policy: 'answer'|'hedge'|'abstain', reason, resolved_entities, min_confidence, provenance[], block }`. `null` si el sidecar no lo computó (degradación graceful, no rompe el turno).
- `promptAssembler`: nuevo bloque protegido `groundingPolicy` (nunca se sacrifica bajo presupuesto), justo después de `relacional` y antes de `queryAnalysis`.
- `AgentScreen.jsx`: inyecta el bloque ya formateado por el sidecar en el system prompt. El gate es **independiente** de si hubo entidades resueltas (`resolved.grounding` se lee aparte de `resolved.entities.length > 0`) — el caso de CERO entidades es exactamente el que debe producir `abstain`/rojo. También expone `grounding_semaphore`/`grounding_policy`/`grounding_reason` en la metadata del mensaje (`sourceMetadata`) para que una futura UI (fable) pinte el badge sin recalcular nada — mismo mecanismo que ya usa `ChatBubble` para el badge `confianza` (`extractGroundingBadges`).

## Qué NO hace este PR

No construye UI nueva (semáforo visual) — eso es trabajo de fable aparte, sobre los campos ya expuestos en `message.metadata.grounding_semaphore`.

## Test plan

- [x] `npx vitest run` sobre los archivos tocados + vecinos (promptAssembler, sidecarClient multiturn, AgentScreen chipsToolbar/queue/photoPipeline) — 84/84 passed.
- [x] `npm run build` — verde (solo warnings informativos preexistentes de Rollup, no relacionados).
- [x] `npm run tsc:check` — confirmado que no agrega una clase de error NUEVA (el único error que toca la línea modificada ya existía antes del cambio: `sourceMetadata` ya excedía su tipo JSDoc angosto con `auto_corrected`; mi cambio solo agrega 3 campos más al mismo literal ya no-tipado).
- [x] `eslint --max-warnings=0` sobre los 4 archivos tocados (corrido aparte del hook por la lentitud del host compartido — ver nota del commit).

🤖 Generado con [Claude Code](https://claude.com/claude-code)