### PR TITLE
fix(home): escena finca-viva VACÍA en prod (bypass operador→extensionista) + foto de perfil en topbar F2 (P0)

### DIFF
--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -44,7 +44,7 @@ import {
     esPerfilUrbano,
 } from '../../services/homeModuleSelector';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
-import { esExtensionistaActual } from '../../config/extensionistaAccess';
+import { esExtensionistaRealActual } from '../../config/extensionistaAccess';
 import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
 import { registroUnificadoActivo } from '../../config/registroUnificadoFlag';
 import SelectedBackgroundReveal from './SelectedBackgroundReveal';
@@ -398,15 +398,23 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
     // una vez al montar. Con la flag ON: (1) la escena de la finca se muestra
     // SIEMPRE — incluso con 0 plantas, que la propia escena cubre con su estado
     // "por sembrar" (fix UX: la escena por perfil orienta desde el primer uso);
-    // (2) si el usuario es extensionista (rol supervisor, con bypass de operador),
-    // se monta la RED institucional de fincas en vez de la escena de finca única.
-    // Con la flag OFF (default), el home conserva su comportamiento actual.
+    // (2) si el usuario es extensionista REAL (flag + whitelist, SIN bypass de
+    // operador), se monta la RED institucional de fincas en vez de la escena de
+    // finca única. Con la flag OFF (default), el home conserva su comportamiento
+    // actual.
     const [fincaVivaFlag] = useState(() => fincaVivaHomePerfilActivo());
     // Registro unificado (#23): con la flag ON, el bloque "Registrar en la finca"
     // muestra UNA sola puerta (→ registro_unificado) en vez de los tiles sueltos.
     const [registroUnifFlag] = useState(() => registroUnificadoActivo());
+    // HOTFIX P0 2026-07-04 (escena del home VACÍA en prod): aquí va el rol REAL
+    // (esExtensionistaRealActual), NO esExtensionistaActual. El bypass del
+    // operador de esExtensionista() convertía al operador en "extensionista" en
+    // el build de prod (VITE_OPERATOR_USERNAME baked) y su home montaba la red
+    // institucional (vacía para él) en vez de la escena de SU finca → área de
+    // escena en blanco en TODOS los temas. El bypass sigue vigente donde
+    // corresponde: la ruta #extensionista (App.jsx) y su entrada en Perfil.
     const [esExtensionista] = useState(() => {
-        try { return esExtensionistaActual(); } catch (_) { return false; }
+        try { return esExtensionistaRealActual(); } catch (_) { return false; }
     });
 
     // Escuchar cambios en visibilidad de módulos desde ProfileScreen (#7003)

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -10,6 +10,7 @@ import useAssetStore from '../../store/useAssetStore';
 import { buildFincaScene } from '../../services/fincaSceneService';
 import { selectSceneVariant, SCENE_KINDS } from '../../services/fincaSceneProfileSelector';
 import { getProfile, saveProfile, getInvernaderoEstructura } from '../../services/userProfileService';
+import { getOperatorPhoto } from '../../services/operatorPhotoService';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import { deriveAtmosphere } from '../../services/atmosphereService';
 import { resolveClimaLocation, getCachedClimaSnapshot, CLIMA_UPDATED_EVENT } from '../../services/climaService';
@@ -186,6 +187,27 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
     try { if (typeof saveProfile === 'function') saveProfile({ nivel_respuestas: next }); }
     catch (_) { /* perfil opcional: el toggle igual refleja la elección en sesión */ }
   };
+
+  // ── Foto de perfil en la píldora del topbar (hotfix P0 2026-07-04) ────────
+  // El TopBar legacy mostraba la foto fijada por el usuario (getOperatorPhoto,
+  // feature 2026-06-15); con la flag F2 ON ese TopBar NO se monta y el home se
+  // quedó con el ícono genérico de persona aunque hubiera foto. Misma mecánica
+  // de re-lectura en vivo que TopBar: 'chagra:operator-update' (same-tab, la
+  // emite operatorPhotoService al subir/cambiar/quitar) + 'storage' (cross-tab).
+  const [fotoPerfil, setFotoPerfil] = useState(() => {
+    try { return getOperatorPhoto(); } catch (_) { return ''; }
+  });
+  useEffect(() => {
+    const refresh = () => {
+      try { setFotoPerfil(getOperatorPhoto()); } catch (_) { /* storage no disponible */ }
+    };
+    window.addEventListener('chagra:operator-update', refresh);
+    window.addEventListener('storage', refresh);
+    return () => {
+      window.removeEventListener('chagra:operator-update', refresh);
+      window.removeEventListener('storage', refresh);
+    };
+  }, []);
 
   // ── Cielo real: hora + clima (REUSA atmosphereService, no inventa motor) ──
   const atmosfera = useAtmosferaEscena();
@@ -368,10 +390,21 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
               data-testid="finca-viva-perfil"
               onClick={() => onNavigate?.('perfil')}
             >
-              <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-                <circle cx="12" cy="8.4" r="4" fill="currentColor" />
-                <path d="M4.6 19.5c.7-3.7 3.8-5.8 7.4-5.8s6.7 2.1 7.4 5.8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" fill="none" />
-              </svg>
+              {/* Foto de perfil fijada por el usuario; cae al ícono genérico de
+                  persona si no hay foto (misma regla que el TopBar legacy). */}
+              {fotoPerfil ? (
+                <img
+                  src={fotoPerfil}
+                  alt=""
+                  className="fvh-pill-foto"
+                  data-testid="fvh-perfil-foto"
+                />
+              ) : (
+                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
+                  <circle cx="12" cy="8.4" r="4" fill="currentColor" />
+                  <path d="M4.6 19.5c.7-3.7 3.8-5.8 7.4-5.8s6.7 2.1 7.4 5.8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" fill="none" />
+                </svg>
+              )}
             </button>
           </div>
         </header>

--- a/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
@@ -27,9 +27,12 @@ vi.mock('../../../config/fincaVivaHomeFlag', () => ({
   fincaVivaHomePerfilActivo: () => true, // home F2 ON
 }));
 
-// El operador/extensionista: modo supervisor multi-finca activo.
+// Extensionista REAL (flag + whitelist): modo supervisor multi-finca activo.
+// (Hotfix P0 2026-07-04: la portada del home la decide esExtensionistaRealActual
+// — el bypass del operador ya NO cambia la portada, solo el acceso al panel.)
 vi.mock('../../../config/extensionistaAccess', () => ({
   esExtensionistaActual: () => true,
+  esExtensionistaRealActual: () => true,
 }));
 
 // El hero real es pesado: lo stubeamos pero RENDERIZAMOS sus children para que

--- a/src/components/dashboard/__tests__/DashboardLive.registroUnificado.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.registroUnificado.test.jsx
@@ -25,6 +25,7 @@ vi.mock('../../../config/registroUnificadoFlag', () => ({
 }));
 vi.mock('../../../config/extensionistaAccess', () => ({
   esExtensionistaActual: () => false,
+  esExtensionistaRealActual: () => false,
 }));
 vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
 vi.mock('../FincaVivaHero', () => ({

--- a/src/components/dashboard/__tests__/FincaVivaHero.fotoPerfil.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaHero.fotoPerfil.test.jsx
@@ -1,0 +1,90 @@
+/**
+ * FincaVivaHero — FOTO DE PERFIL en la píldora del topbar (hotfix P0 2026-07-04).
+ *
+ * REGRESIÓN: el TopBar legacy mostraba la foto fijada por el usuario
+ * (getOperatorPhoto, feature 2026-06-15); con la flag F2 ON ese TopBar no se
+ * monta y el home quedaba SIEMPRE con el ícono genérico de persona, aunque el
+ * usuario tuviera foto. El hero debe: (1) pintar la foto si existe, (2) caer al
+ * ícono genérico si no hay, (3) re-leer en vivo con 'chagra:operator-update'
+ * (mismo contrato que TopBar).
+ */
+import React from 'react';
+import { render, screen, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../db/farmProcessCache', () => ({ listFarmProcesses: vi.fn(async () => []) }));
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [], lands: [], materials: [], isHydrated: true }),
+}));
+vi.mock('../../../services/userProfileService', () => ({ getProfile: () => ({ rol: 'campesino' }) }));
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => false,
+}));
+vi.mock('../../NotificationsBell', () => ({
+  default: () => <button type="button" aria-label="Notificaciones" />,
+}));
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'biopunk2', setTheme: vi.fn() }),
+  resolveAutoTheme: (t) => t,
+}));
+vi.mock('../themeIcon', () => ({
+  iconForTheme: () => <svg data-testid="brand-icon" />,
+}));
+
+// Foto controlable por test: el hero la lee con getOperatorPhoto (fuente única,
+// la misma del TopBar legacy y ProfileScreen).
+let fotoActual = '';
+vi.mock('../../../services/operatorPhotoService', () => ({
+  getOperatorPhoto: () => fotoActual,
+}));
+
+import FincaVivaHero from '../FincaVivaHero';
+
+const FOTO = 'data:image/jpeg;base64,Zm90by1kZS1wcnVlYmE=';
+
+beforeEach(() => {
+  fotoActual = '';
+  vi.clearAllMocks();
+});
+afterEach(() => cleanup());
+
+describe('FincaVivaHero — foto de perfil en la píldora del topbar', () => {
+  test('con foto fijada, la píldora de perfil muestra la FOTO (no el ícono genérico)', () => {
+    fotoActual = FOTO;
+    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    const img = screen.getByTestId('fvh-perfil-foto');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', FOTO);
+    // La foto vive DENTRO del botón de perfil (sigue navegando a 'perfil').
+    expect(screen.getByTestId('finca-viva-perfil')).toContainElement(img);
+  });
+
+  test('sin foto, cae al ícono genérico de persona (sin <img>)', () => {
+    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    expect(screen.queryByTestId('fvh-perfil-foto')).not.toBeInTheDocument();
+    expect(screen.getByTestId('finca-viva-perfil')).toBeInTheDocument();
+  });
+
+  test("re-lee EN VIVO cuando el usuario sube/cambia la foto ('chagra:operator-update')", () => {
+    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    expect(screen.queryByTestId('fvh-perfil-foto')).not.toBeInTheDocument();
+    fotoActual = FOTO;
+    act(() => {
+      window.dispatchEvent(new Event('chagra:operator-update'));
+    });
+    expect(screen.getByTestId('fvh-perfil-foto')).toHaveAttribute('src', FOTO);
+  });
+
+  test("re-lee EN VIVO al quitar la foto (vuelve al ícono genérico)", () => {
+    fotoActual = FOTO;
+    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    expect(screen.getByTestId('fvh-perfil-foto')).toBeInTheDocument();
+    fotoActual = '';
+    act(() => {
+      window.dispatchEvent(new Event('chagra:operator-update'));
+    });
+    expect(screen.queryByTestId('fvh-perfil-foto')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/__tests__/FincaVivaResto.noSolapa.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaResto.noSolapa.test.jsx
@@ -63,6 +63,7 @@ vi.mock('../../../config/fincaVivaHomeFlag', () => ({
 }));
 vi.mock('../../../config/extensionistaAccess', () => ({
   esExtensionistaActual: () => false,
+  esExtensionistaRealActual: () => false,
 }));
 vi.mock('../../../config/glaciarAccess', () => ({
   tieneAccesoGlaciarActual: () => false,

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -442,6 +442,18 @@ html[data-theme="biopunk"] .fvh {
 .fvh-pill.fvh-pill-perfil {
   box-shadow: 0 4px 11px rgba(60, 40, 10, 0.18),
               0 0 0 2px rgb(var(--c-emerald-500, 47 107 58) / 0.55);
+  /* La foto de perfil (fvh-pill-foto) llena la píldora redonda sin desbordarla. */
+  overflow: hidden;
+}
+/* Foto de perfil fijada por el usuario dentro de la píldora (hotfix P0
+   2026-07-04: el home F2 mostraba SIEMPRE el ícono genérico aunque hubiera
+   foto — el TopBar legacy que la pintaba no se monta con la flag F2 ON). */
+.fvh-pill-perfil .fvh-pill-foto {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
 }
 
 /* MÓVIL ANGOSTO (regresión 2026-07-04): con 4 accesos en el header (A del

--- a/src/config/__tests__/extensionistaAccess.test.js
+++ b/src/config/__tests__/extensionistaAccess.test.js
@@ -156,3 +156,64 @@ describe('extensionistaAccess — esExtensionistaActual (lee tenant activo, offl
     expect(mod.esExtensionistaActual()).toBe(false);
   });
 });
+
+describe('extensionistaAccess — esExtensionistaReal (SIN bypass de operador; hotfix P0 2026-07-04)', () => {
+  // REGRESIÓN DE PRODUCCIÓN que motiva esta función: el home F2 (DashboardLive)
+  // decidía la portada con esExtensionista(), cuyo bypass de operador convertía
+  // al operador (VITE_OPERATOR_USERNAME baked en prod) en "extensionista" → su
+  // home montaba la RED institucional (vacía) en vez de la escena de SU finca →
+  // área de escena en blanco en TODOS los temas. La portada institucional debe
+  // gatearse por el rol REAL (flag + whitelist), nunca por el bypass.
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    localStorage.clear();
+  });
+
+  it('el OPERADOR (override local) NO es extensionista real — conserva su escena de finca', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'true');
+    localStorage.setItem('chagra:operator_override', '1');
+    const mod = await importFresh();
+    // El bypass sí aplica al panel (esExtensionista)…
+    expect(mod.esExtensionista('admin')).toBe(true);
+    // …pero NUNCA al rol real que decide la portada del home.
+    expect(mod.esExtensionistaReal('admin')).toBe(false);
+  });
+
+  it('un username de la whitelist con la flag ON SÍ es extensionista real', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'true');
+    const mod = await importFresh();
+    expect(mod.esExtensionistaReal('demo-extensionista')).toBe(true);
+    expect(mod.esExtensionistaReal('  DEMO-EXTENSIONISTA  ')).toBe(true);
+  });
+
+  it('con la flag OFF nadie es extensionista real, ni la whitelist ni el operador', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'false');
+    localStorage.setItem('chagra:operator_override', '1');
+    const mod = await importFresh();
+    expect(mod.esExtensionistaReal('demo-extensionista')).toBe(false);
+    expect(mod.esExtensionistaReal('admin')).toBe(false);
+  });
+
+  it('defensivo: null/undefined/vacío/no-string → false', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'true');
+    const mod = await importFresh();
+    expect(mod.esExtensionistaReal(null)).toBe(false);
+    expect(mod.esExtensionistaReal(undefined)).toBe(false);
+    expect(mod.esExtensionistaReal('   ')).toBe(false);
+    expect(mod.esExtensionistaReal(123)).toBe(false);
+  });
+
+  it('esExtensionistaRealActual lee el tenant activo y respeta el mismo gate', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'true');
+    const mod = await importFresh();
+    localStorage.setItem('chagra:active_tenant_id', 'demo-extensionista');
+    expect(mod.esExtensionistaRealActual()).toBe(true);
+    // El operador logueado con su propio username NO entra por acá.
+    localStorage.setItem('chagra:active_tenant_id', 'miguel-operador');
+    localStorage.setItem('chagra:operator_override', '1');
+    expect(mod.esExtensionistaRealActual()).toBe(false);
+  });
+});

--- a/src/config/__tests__/extensionistaAccess.test.js
+++ b/src/config/__tests__/extensionistaAccess.test.js
@@ -53,7 +53,7 @@ describe('extensionistaAccess — esExtensionista (función pura)', () => {
     expect(mod.esExtensionista(undefined)).toBe(false);
     expect(mod.esExtensionista('')).toBe(false);
     expect(mod.esExtensionista('   ')).toBe(false);
-    expect(mod.esExtensionista(123)).toBe(false);
+    expect(mod.esExtensionista(/** @type {any} */ (123))).toBe(false);
   });
 
   it('hace match case-insensitive y tolerante a espacios (trim)', () => {
@@ -203,7 +203,7 @@ describe('extensionistaAccess — esExtensionistaReal (SIN bypass de operador; h
     expect(mod.esExtensionistaReal(null)).toBe(false);
     expect(mod.esExtensionistaReal(undefined)).toBe(false);
     expect(mod.esExtensionistaReal('   ')).toBe(false);
-    expect(mod.esExtensionistaReal(123)).toBe(false);
+    expect(mod.esExtensionistaReal(/** @type {any} */ (123))).toBe(false);
   });
 
   it('esExtensionistaRealActual lee el tenant activo y respeta el mismo gate', async () => {

--- a/src/config/extensionistaAccess.js
+++ b/src/config/extensionistaAccess.js
@@ -121,11 +121,7 @@ export function esExtensionista(username) {
   // El operador (visión total) ve el panel extensionista aunque la flag esté
   // apagada o no esté en la whitelist — mismo criterio que glaciarAccess.
   if (esOperador(username)) return true;
-  if (!featureExtensionistaActivo()) return false;
-  if (!username || typeof username !== 'string') return false;
-  const normalized = username.trim().toLowerCase();
-  if (normalized.length === 0) return false;
-  return EXTENSIONISTA_WHITELIST.has(normalized);
+  return esExtensionistaReal(username);
 }
 
 /**
@@ -138,4 +134,46 @@ export function esExtensionista(username) {
  */
 export function esExtensionistaActual() {
   return esExtensionista(getActiveTenantId());
+}
+
+/**
+ * ¿Este username tiene el rol extensionista REAL (flag + whitelist), SIN el
+ * bypass del operador?
+ *
+ * POR QUÉ EXISTE (hotfix P0 2026-07-04, escena del home vacía en PROD):
+ *   `esExtensionista()` incluye el bypass del operador (visión total) para que
+ *   el operador pueda ENTRAR al panel #extensionista sin flag ni whitelist.
+ *   Pero DashboardLive usaba ESA misma función para decidir la PORTADA del
+ *   home F2: con `VITE_OPERATOR_USERNAME` baked en el build de prod (secret),
+ *   el operador quedaba "extensionista" y su home reemplazaba la escena de SU
+ *   finca por la RED institucional (vacía para él) → área de escena en blanco
+ *   (solo el degradado) en TODOS los temas. En dev no se reproducía porque
+ *   dev-deploy.yml NO define VITE_OPERATOR_USERNAME.
+ *
+ *   El bypass es para ACCEDER al panel (ruta #extensionista, App.jsx), no para
+ *   cambiarle la identidad de la portada: el operador tiene finca propia y su
+ *   home debe mostrar SU escena. La portada institucional es solo para el rol
+ *   REAL (featureExtensionistaActivo() + whitelist).
+ *
+ * @param {string|null|undefined} username — username farmOS del usuario.
+ * @returns {boolean} true SOLO si la flag global está encendida Y el username
+ *   está en la whitelist. El operador NO pasa por aquí (sin bypass).
+ */
+export function esExtensionistaReal(username) {
+  if (!featureExtensionistaActivo()) return false;
+  if (!username || typeof username !== 'string') return false;
+  const normalized = username.trim().toLowerCase();
+  if (normalized.length === 0) return false;
+  return EXTENSIONISTA_WHITELIST.has(normalized);
+}
+
+/**
+ * ¿El usuario actualmente logueado es extensionista REAL (sin bypass de
+ * operador)? Decide la PORTADA del home F2 (red institucional vs escena de
+ * finca propia). Offline-first, igual que `esExtensionistaActual`.
+ *
+ * @returns {boolean}
+ */
+export function esExtensionistaRealActual() {
+  return esExtensionistaReal(getActiveTenantId());
 }


### PR DESCRIPTION
## Hotfix P0 — regresión del go-live F2 vista por el operador en prod (sha 49ea5f47)

### Causa raíz 1 — escena vacía (solo degradado) en TODOS los temas
- `DashboardLive` decidía la portada del home F2 con `esExtensionistaActual()`, que incluye el **bypass del operador** (visión total).
- En el build de **prod**, `VITE_OPERATOR_USERNAME` va baked (secret) → el operador quedaba "extensionista" → `FincaVivaHero` recibía `children` (la red institucional, **vacía** para él) → `tieneFincaPropia=false` → **ninguna escena de finca se montaba**: quedaba solo el degradado del wrap, con el globo y los 4 tiles intactos.
- **Por eso solo en prod**: `dev-deploy.yml` NO define `VITE_OPERATOR_USERNAME`. Los flags `VITE_COLIBRI` / `VITE_REGISTRO_UNIFICADO` (hipótesis inicial) NO eran la causa — verificado con build de flags exactos de prod: escenas OK sin ellos.

**Fix**: nueva `esExtensionistaRealActual()` (flag `VITE_FEATURE_EXTENSIONISTA` + whitelist, **sin** bypass) gatea la portada del home. El bypass del operador queda intacto donde corresponde: ruta `#extensionista` (App.jsx), panel y entrada en Perfil.

### Causa raíz 2 — foto de perfil ausente en el topbar del home
- El home F2 no monta el TopBar legacy (quien pintaba `getOperatorPhoto()`); la píldora de perfil del hero solo dibujaba el ícono genérico — la foto fijada nunca se cableó.

**Fix**: la píldora `fvh-pill-perfil` muestra la foto fijada (fuente única `operatorPhotoService`) con re-lectura en vivo (`chagra:operator-update` + `storage`), cayendo al ícono genérico sin foto — mismo contrato que el TopBar legacy.

### Verificación (harness Playwright contra BUILD de prod, flags exactos de deploy.yml)
- **Repro confirmada** (pre-fix, como operador): escena `[]` + `.fvh-institucional` vacía en los 5 temas — el degradado pelado que reportó el operador.
- **Post-fix**: escena de autor presente y visible en los 5 temas (biopunk2/biopunk/nature/verde-vivo/minimalista), como **operador** (QA chips intactos) y como usuario normal; finca poblada (43 siembras sembradas en IDB) y vacía; foto de perfil visible en la píldora.
- Build de prod verde; `eslint` limpio; tests: 19 de `extensionistaAccess` (5 nuevos de `esExtensionistaReal`), 4 nuevos de foto de perfil, suites `dashboard/__tests__` + `config/__tests__` completas: **28 files / 213 tests verdes**.

### deploy.yml
**No necesita ningún flag nuevo**: el fix es de código. `VITE_OPERATOR_USERNAME` puede seguir baked (el operador conserva visión total y acceso al panel extensionista).

🤖 Generated with [Claude Code](https://claude.com/claude-code)