### PR TITLE
feat(agente): semáforo de confianza científica por-respuesta en ChatBubble (#2074 UI)

### DIFF
--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { BadgeCheck, Info, Sparkles, AlertTriangle, ExternalLink, ShieldCheck } from 'lucide-react';
+import React, { useState } from 'react';
+import { BadgeCheck, Info, Sparkles, AlertTriangle, ExternalLink, ShieldCheck, ChevronDown } from 'lucide-react';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import { speak, speakKokoro, stop, isSpeaking, isKokoroAvailable } from '../../services/ttsService';
 import { agentSounds } from '../../services/agentSoundService';
@@ -261,6 +261,199 @@ function ConfianzaBadge({ metadata }) {
 }
 
 /**
+ * #2074 — Semáforo de confianza científica POR-RESPUESTA. Traduce la política de
+ * grounding que el sidecar emite en `metadata.grounding_semaphore` a un chip
+ * verde/ámbar/rojo que funciona como "sello institucional": el usuario técnico
+ * lo lee de un vistazo y el campesino lo ignora sin fricción.
+ *
+ *   - 🟢 verde  → grounded ≥ umbral de confianza      → "Verificado"
+ *   - 🟡 ámbar  → una sola fuente / confianza media    → "Una fuente"
+ *   - 🔴 rojo   → disputed / sin fuente / abstain      → "Sin verificar"
+ *
+ * Al tocar el chip se despliega el `grounding_reason` (por qué el sidecar asignó
+ * ese color) + la procedencia (institución/source + DOI o enlace, si viajan en
+ * el metadata). Interacción CSP-safe: onClick de React (evento sintético, NO
+ * handler inline → no requiere 'unsafe-inline').
+ *
+ * Degradación suave: si el sidecar aún NO emite el semáforo (p.ej. antes de que
+ * #2074 llegue a producción), se DERIVA un color conservador desde las señales
+ * de grounding ya presentes en el turno (grounded / confianza / disputed). Si no
+ * hay ninguna señal reconocible (turno legacy o puramente generativo), no
+ * renderiza nada — el SourceBadge existente ya cubre ese caso.
+ */
+const _SEMAPHORE = {
+  verde: {
+    label: 'Verificado',
+    classes: 'bg-emerald-600/15 text-emerald-200 border-emerald-600/50 hover:bg-emerald-600/25',
+    dot: 'bg-emerald-400',
+    title: 'Semáforo de confianza: verde. Respuesta respaldada por el catálogo con confianza suficiente. Toca para ver por qué y la fuente.',
+    Icon: ShieldCheck,
+    fallbackReason: 'Dato respaldado por el catálogo Chagra con confianza suficiente.',
+  },
+  ambar: {
+    label: 'Una fuente',
+    classes: 'bg-amber-600/15 text-amber-200 border-amber-600/50 hover:bg-amber-600/25',
+    dot: 'bg-amber-400',
+    title: 'Semáforo de confianza: ámbar. Respaldo parcial (una sola fuente o confianza media). Toca para ver por qué y la fuente.',
+    Icon: Info,
+    fallbackReason: 'Respaldo parcial: una sola fuente o confianza media. Contrástalo antes de aplicar.',
+  },
+  rojo: {
+    label: 'Sin verificar',
+    classes: 'bg-red-700/20 text-red-200 border-red-700/60 hover:bg-red-700/30',
+    dot: 'bg-red-400',
+    title: 'Semáforo de confianza: rojo. Sin fuente verificable o dato en disputa. Toca para ver el detalle.',
+    Icon: AlertTriangle,
+    fallbackReason: 'Sin fuente verificable o dato en disputa. No lo apliques sin confirmarlo con un técnico.',
+  },
+};
+
+/**
+ * Normaliza el valor de `grounding_semaphore` (o sinónimos que pueda emitir el
+ * sidecar) a una de las claves canónicas 'verde' | 'ambar' | 'rojo'. Devuelve
+ * null si el valor no es reconocible (→ el caller intenta derivar).
+ */
+function _normSemaphore(raw) {
+  if (typeof raw !== 'string') return null;
+  const v = raw.trim().toLowerCase();
+  if (['verde', 'green', 'ok', 'grounded'].includes(v)) return 'verde';
+  if (['ambar', 'ámbar', 'amber', 'amarillo', 'yellow', 'warn', 'single', 'single_source', 'una_fuente'].includes(v)) return 'ambar';
+  if (['rojo', 'red', 'abstain', 'disputed', 'danger', 'sin_fuente'].includes(v)) return 'rojo';
+  return null;
+}
+
+/** ¿El turno trae alguna fuente citable (enlace http(s), texto o institución)? */
+function _hasVerifiableSource(md) {
+  const url = typeof md.fuente_url === 'string' ? md.fuente_url.trim() : '';
+  if (/^https?:\/\//i.test(url)) return true;
+  if (md.fuente_texto === true) return true;
+  return typeof md.fuente === 'string' && md.fuente.trim().length > 0;
+}
+
+/**
+ * Deriva un color conservador cuando el sidecar todavía no emite el semáforo.
+ * Solo se pronuncia si hay una señal firme (evita falsos alarmas en saludos):
+ *   - disputed === true                         → rojo
+ *   - grounded && (confianza alta || fuente)     → verde
+ *   - grounded (confianza media/desconocida)     → ámbar
+ *   - en cualquier otro caso                     → null (el SourceBadge ya avisa)
+ */
+function _deriveSemaphore(md) {
+  if (md.disputed === true) return 'rojo';
+  if (md.grounded === true) {
+    if (md.confianza === 'alta' || _hasVerifiableSource(md)) return 'verde';
+    return 'ambar';
+  }
+  return null;
+}
+
+/** Extrae la procedencia mostrable (institución + enlace/DOI) del metadata. */
+function _semaphoreProvenance(md) {
+  const rawUrl = typeof md.fuente_url === 'string' ? md.fuente_url.trim() : '';
+  const url = /^https?:\/\//i.test(rawUrl) ? rawUrl : '';
+  const rawDoi = typeof md.doi === 'string' ? md.doi.trim() : '';
+  // DOI puede venir como "10.xxxx/…" (bare) o ya como URL doi.org.
+  let doiLabel = '';
+  let doiUrl = '';
+  if (rawDoi) {
+    doiLabel = rawDoi.replace(/^https?:\/\/(dx\.)?doi\.org\//i, '');
+    doiUrl = /^https?:\/\//i.test(rawDoi) ? rawDoi : `https://doi.org/${rawDoi}`;
+  }
+  const inst =
+    (typeof md.institucion === 'string' && md.institucion.trim()) ||
+    (typeof md.fuente === 'string' && md.fuente.trim()) ||
+    '';
+  return { url, doiLabel, doiUrl, inst };
+}
+
+function SemaphoreBadge({ metadata }) {
+  const md = metadata || {};
+  const [expanded, setExpanded] = useState(false);
+
+  const color = _normSemaphore(md.grounding_semaphore) || _deriveSemaphore(md);
+  if (!color) return null;
+  const cfg = _SEMAPHORE[color];
+  const { Icon } = cfg;
+
+  // Origen del color: explícito del sidecar vs derivado en el cliente (útil
+  // para telemetría/QA; no cambia lo que ve el usuario).
+  const derived = !_normSemaphore(md.grounding_semaphore);
+  const reason =
+    (typeof md.grounding_reason === 'string' && md.grounding_reason.trim()) || cfg.fallbackReason;
+  const { url, doiLabel, doiUrl, inst } = _semaphoreProvenance(md);
+  const hasProvenance = Boolean(inst || url || doiLabel);
+  const detailId = 'semaphore-detail';
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls={detailId}
+        aria-label={`${cfg.title}`}
+        data-testid="semaphore-badge"
+        data-semaphore={color}
+        data-derived={derived ? 'true' : undefined}
+        title={cfg.title}
+        className={`tap-target text-xs px-2 py-1 rounded-md inline-flex items-center gap-1.5 border transition-colors ${cfg.classes}`}
+      >
+        <span className={`inline-block w-2 h-2 rounded-full ${cfg.dot}`} aria-hidden="true" />
+        <Icon size={12} aria-hidden="true" />
+        <span>{cfg.label}</span>
+        <ChevronDown
+          size={12}
+          aria-hidden="true"
+          className={`transition-transform ${expanded ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {expanded && (
+        <div
+          id={detailId}
+          data-testid="semaphore-detail"
+          className="basis-full mt-1 px-2.5 py-2 rounded-md text-xs leading-relaxed bg-slate-800/60 border border-slate-700 text-slate-200"
+        >
+          <p className="mb-1" data-testid="semaphore-reason">{reason}</p>
+          {hasProvenance && (
+            <div className="flex flex-col gap-0.5 text-slate-300" data-testid="semaphore-provenance">
+              {inst && (
+                <span className="inline-flex items-center gap-1">
+                  <ShieldCheck size={11} aria-hidden="true" />
+                  <span>Fuente: {inst}</span>
+                </span>
+              )}
+              {url && (
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sky-300 hover:underline underline-offset-2 w-fit"
+                >
+                  <ExternalLink size={11} aria-hidden="true" />
+                  <span>Abrir recurso citado</span>
+                </a>
+              )}
+              {doiLabel && (
+                <a
+                  href={doiUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sky-300 hover:underline underline-offset-2 w-fit"
+                >
+                  <ExternalLink size={11} aria-hidden="true" />
+                  <span>DOI: {doiLabel}</span>
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
  * Burbuja individual de chat para un mensaje del usuario o del agente.
  * Soporta renderizado de imágenes, badges de fuente verificable, confianza,
  * auto-corrección, nombres científicos sospechosos/alucinados, feedback,
@@ -268,7 +461,8 @@ function ConfianzaBadge({ metadata }) {
  *
  * @param {Object} props - Propiedades del componente.
  * @param {Object} props.message - Objeto mensaje con `role` ('user'|'assistant'), `content`, `timestamp`,
- *   `metadata` (fuente, confianza, tool_used, grounded), `imageUrl`, `photo`, `_orphan_recovery`,
+ *   `metadata` (fuente, confianza, tool_used, grounded, grounding_semaphore, grounding_reason, doi),
+ *   `imageUrl`, `photo`, `_orphan_recovery`,
  *   `_orphan_prompt`, `_deepResearch`, `_edges`.
  * @param {boolean} [props.isStreaming=false] - Indica si este mensaje está en streaming.
  * @param {string} [props.promptText] - Texto del prompt del usuario asociado a esta respuesta (para feedback).
@@ -406,6 +600,10 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
           )}
           {shouldShowBadge && (
             <div className="mt-1 flex flex-wrap items-center gap-1.5">
+              {/* #2074: semáforo de confianza científica por-respuesta (verde/
+                  ámbar/rojo). Chip interactivo: al tocarlo despliega el motivo
+                  del grounding + la procedencia (sello institucional). */}
+              <SemaphoreBadge metadata={message.metadata} />
               <SourceBadge metadata={message.metadata} />
               {/* #20: confianza del dato curado (alta/media/baja → verde/ámbar/gris). */}
               <ConfianzaBadge metadata={message.metadata} />

--- a/src/components/__tests__/ChatBubble.test.jsx
+++ b/src/components/__tests__/ChatBubble.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ChatBubbleRaw from '../AgentScreen/ChatBubble';
 /** @type {any} */
@@ -526,5 +526,143 @@ describe('ChatBubble — badges anti-alucinación (#18 fuente · #19 auto-correg
     expect(screen.queryByTestId('fuente-badge')).not.toBeInTheDocument();
     expect(screen.queryByTestId('confianza-badge')).not.toBeInTheDocument();
     expect(screen.queryByTestId('auto-corrected-badge')).not.toBeInTheDocument();
+  });
+});
+
+
+// #2074 — Semáforo de confianza científica por-respuesta.
+describe('ChatBubble — #2074 semáforo de confianza (verde/ámbar/rojo)', () => {
+  let storeState;
+
+  beforeEach(() => {
+    storeState = { showSourceBadges: true };
+    usePrefsStore.mockImplementation((selector) => selector(storeState));
+  });
+
+  const base = (metadata) => ({
+    role: 'assistant',
+    content: 'La gulupa se siembra sobre los 1700 msnm.',
+    timestamp: Date.now(),
+    metadata,
+  });
+
+  test('grounding_semaphore="verde" → chip verde "Verificado"', () => {
+    render(<ChatBubble message={base({ grounding_semaphore: 'verde', grounded: true })} />);
+    const badge = screen.getByTestId('semaphore-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('data-semaphore', 'verde');
+    expect(badge).toHaveTextContent(/Verificado/i);
+    // Origen explícito del sidecar (no derivado en cliente).
+    expect(badge).not.toHaveAttribute('data-derived');
+    expect(badge.className).toMatch(/emerald/);
+  });
+
+  test('grounding_semaphore="ambar" → chip ámbar "Una fuente"', () => {
+    render(<ChatBubble message={base({ grounding_semaphore: 'ambar', grounded: true })} />);
+    const badge = screen.getByTestId('semaphore-badge');
+    expect(badge).toHaveAttribute('data-semaphore', 'ambar');
+    expect(badge).toHaveTextContent(/Una fuente/i);
+    expect(badge.className).toMatch(/amber/);
+  });
+
+  test('grounding_semaphore="rojo" → chip rojo "Sin verificar"', () => {
+    render(<ChatBubble message={base({ grounding_semaphore: 'rojo', grounded: false })} />);
+    const badge = screen.getByTestId('semaphore-badge');
+    expect(badge).toHaveAttribute('data-semaphore', 'rojo');
+    expect(badge).toHaveTextContent(/Sin verificar/i);
+    expect(badge.className).toMatch(/red/);
+  });
+
+  test('normaliza sinónimos del sidecar (green/amber/red) al color canónico', () => {
+    const { rerender } = render(<ChatBubble message={base({ grounding_semaphore: 'green' })} />);
+    expect(screen.getByTestId('semaphore-badge')).toHaveAttribute('data-semaphore', 'verde');
+    rerender(<ChatBubble message={base({ grounding_semaphore: 'amber' })} />);
+    expect(screen.getByTestId('semaphore-badge')).toHaveAttribute('data-semaphore', 'ambar');
+    rerender(<ChatBubble message={base({ grounding_semaphore: 'abstain' })} />);
+    expect(screen.getByTestId('semaphore-badge')).toHaveAttribute('data-semaphore', 'rojo');
+  });
+
+  test('al tocar el chip despliega grounding_reason + procedencia (source/DOI)', () => {
+    render(
+      <ChatBubble
+        message={base({
+          grounding_semaphore: 'verde',
+          grounded: true,
+          grounding_reason: 'Dos fuentes concordantes en el catálogo curado.',
+          fuente: 'Agrosavia',
+          fuente_url: 'https://repository.agrosavia.co/doc/123',
+          doi: '10.1234/abcd',
+        })}
+      />,
+    );
+    // Colapsado: el detalle no está visible.
+    expect(screen.queryByTestId('semaphore-detail')).not.toBeInTheDocument();
+    const badge = screen.getByTestId('semaphore-badge');
+    expect(badge).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(badge);
+
+    expect(badge).toHaveAttribute('aria-expanded', 'true');
+    const detail = screen.getByTestId('semaphore-detail');
+    expect(detail).toBeInTheDocument();
+    expect(screen.getByTestId('semaphore-reason')).toHaveTextContent(
+      /Dos fuentes concordantes en el catálogo curado\./i,
+    );
+    const prov = screen.getByTestId('semaphore-provenance');
+    expect(prov).toHaveTextContent(/Fuente:\s*Agrosavia/i);
+    // DOI: enlace a doi.org construido desde el binomio bare.
+    const doiLink = screen.getByText(/DOI:\s*10\.1234\/abcd/i).closest('a');
+    expect(doiLink).toHaveAttribute('href', 'https://doi.org/10.1234/abcd');
+    expect(doiLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  test('degradación suave: sin grounding_reason usa el motivo por defecto del color', () => {
+    render(<ChatBubble message={base({ grounding_semaphore: 'rojo', grounded: false })} />);
+    fireEvent.click(screen.getByTestId('semaphore-badge'));
+    expect(screen.getByTestId('semaphore-reason')).toHaveTextContent(/Sin fuente verificable|disputa/i);
+  });
+
+  test('deriva VERDE cuando no hay semáforo explícito pero grounded + confianza alta', () => {
+    render(<ChatBubble message={base({ grounded: true, confianza: 'alta' })} />);
+    const badge = screen.getByTestId('semaphore-badge');
+    expect(badge).toHaveAttribute('data-semaphore', 'verde');
+    // Marca de derivado-en-cliente para QA/telemetría.
+    expect(badge).toHaveAttribute('data-derived', 'true');
+  });
+
+  test('deriva ROJO cuando el dato está en disputa (disputed=true)', () => {
+    render(<ChatBubble message={base({ grounded: true, disputed: true })} />);
+    expect(screen.getByTestId('semaphore-badge')).toHaveAttribute('data-semaphore', 'rojo');
+  });
+
+  test('NO renderiza semáforo en turno generativo puro sin señal (evita falsa alarma)', () => {
+    render(<ChatBubble message={base({ tool_used: null, grounded: false })} />);
+    expect(screen.queryByTestId('semaphore-badge')).not.toBeInTheDocument();
+    // El badge de fuente normal SÍ sigue apareciendo.
+    expect(screen.getByTestId('source-badge')).toBeInTheDocument();
+  });
+
+  test('respeta showSourceBadges OFF (no aparece el semáforo)', () => {
+    storeState = { showSourceBadges: false };
+    usePrefsStore.mockImplementation((selector) => selector(storeState));
+    render(<ChatBubble message={base({ grounding_semaphore: 'verde', grounded: true })} />);
+    expect(screen.queryByTestId('semaphore-badge')).not.toBeInTheDocument();
+  });
+
+  test('backward compat: metadata=null no rompe el render ni muestra semáforo', () => {
+    render(<ChatBubble message={{ role: 'assistant', content: 'Legacy.', timestamp: Date.now(), metadata: null }} />);
+    expect(screen.queryByTestId('semaphore-badge')).not.toBeInTheDocument();
+  });
+
+  test('wording sin voseo argentino ni hype', () => {
+    render(
+      <ChatBubble
+        message={base({ grounding_semaphore: 'rojo', grounded: false, grounding_reason: 'Verifica con un técnico.' })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('semaphore-badge'));
+    const detail = screen.getByTestId('semaphore-detail');
+    expect(detail.textContent).not.toMatch(/verificá|aplicá|tenés/i);
+    expect(detail.textContent).not.toMatch(/garantizado|perfecto|100%/i);
   });
 });

--- a/tests/visual/semaphore-harness.html
+++ b/tests/visual/semaphore-harness.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<!--
+  semaphore-harness.html — Harness AISLADO para el test VISUAL del #2074
+  Semáforo de confianza científica del ChatBubble. Monta el ChatBubble REAL
+  con metadata sintética en los 3 estados (verde/ámbar/rojo), SIN pasar por
+  el router/auth de la app.
+
+  Uso: navegar a /tests/visual/semaphore-harness.html en el dev server.
+-->
+<html lang="es-CO">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Semáforo de confianza — harness visual</title>
+  </head>
+  <body class="bg-slate-950 text-white">
+    <div id="harness-root"></div>
+    <script type="module" src="./semaphore-harness.jsx"></script>
+  </body>
+</html>

--- a/tests/visual/semaphore-harness.jsx
+++ b/tests/visual/semaphore-harness.jsx
@@ -1,0 +1,110 @@
+/* eslint-disable react-refresh/only-export-components --
+ * Entry point del harness visual. createRoot monta directo en el DOM; no
+ * exporta componentes y fast-refresh es irrelevante (recarga entera). */
+/**
+ * semaphore-harness.jsx — Harness AISLADO (sin router/auth) para verificar el
+ * #2074 Semáforo de confianza científica del ChatBubble en los 3 estados
+ * (verde/ámbar/rojo). Monta el ChatBubble REAL con metadata sintética.
+ *
+ * Uso: navegar a /tests/visual/semaphore-harness.html en el dev server.
+ */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import '../../src/index.css';
+import ChatBubble from '../../src/components/AgentScreen/ChatBubble.jsx';
+
+const NOW = Date.now();
+
+const CASES = [
+  {
+    id: 'verde',
+    titulo: '🟢 Verde — Verificado',
+    message: {
+      role: 'assistant',
+      content:
+        'La gulupa (Passiflora edulis f. edulis) se siembra bien sobre los 1700 msnm en clima templado, con tutorado y buen drenaje.',
+      timestamp: NOW,
+      metadata: {
+        tool_used: 'get_species',
+        grounded: true,
+        confianza: 'alta',
+        grounding_semaphore: 'verde',
+        grounding_reason:
+          'Dato concordante en dos fuentes curadas del catálogo (ficha Agrosavia + publicación revisada por pares).',
+        fuente: 'Agrosavia',
+        fuente_url: 'https://repository.agrosavia.co/handle/20.500.12324/gulupa',
+        doi: '10.1234/gulupa.2021',
+      },
+    },
+  },
+  {
+    id: 'ambar',
+    titulo: '🟡 Ámbar — Una fuente',
+    message: {
+      role: 'assistant',
+      content:
+        'El pronóstico indica lluvias intermitentes esta semana en tu vereda; evita aplicar foliares antes de un aguacero.',
+      timestamp: NOW,
+      metadata: {
+        tool_used: 'get_clima_ideam',
+        grounded: true,
+        confianza: 'media',
+        grounding_semaphore: 'ambar',
+        grounding_reason:
+          'Respaldo de una sola fuente institucional (IDEAM). Útil como referencia; contrástalo con tu observación en campo.',
+        fuente: 'IDEAM',
+        fuente_texto: true,
+      },
+    },
+  },
+  {
+    id: 'rojo',
+    titulo: '🔴 Rojo — Sin verificar',
+    message: {
+      role: 'assistant',
+      content:
+        'No tengo una fuente verificable para esa dosis exacta de biopreparado en tu cultivo. Puedo darte una guía general, pero confírmala con un técnico antes de aplicar.',
+      timestamp: NOW,
+      metadata: {
+        tool_used: null,
+        grounded: false,
+        grounding_semaphore: 'rojo',
+        grounding_reason:
+          'El catálogo Chagra no tiene una fuente verificable para este dato puntual; la respuesta es tentativa (abstención honesta).',
+      },
+    },
+  },
+];
+
+function Card({ id, titulo, message }) {
+  return (
+    <div
+      id={`card-${id}`}
+      data-state={id}
+      className="mb-8 rounded-2xl border border-slate-800 bg-slate-900/60 p-4"
+    >
+      <h2 className="text-sm font-bold text-emerald-300 mb-3 uppercase tracking-wider">
+        {titulo}
+      </h2>
+      <ChatBubble message={message} promptText="pregunta de ejemplo" />
+    </div>
+  );
+}
+
+function Harness() {
+  return (
+    <div className="max-w-[440px] mx-auto p-4 space-y-2">
+      <h1 className="text-xl font-black text-white uppercase tracking-widest text-center mb-2">
+        Semáforo de confianza #2074
+      </h1>
+      <p className="text-xs text-slate-500 text-center mb-6">
+        ChatBubble real · toca el chip para desplegar el motivo + procedencia.
+      </p>
+      {CASES.map((c) => (
+        <Card key={c.id} {...c} />
+      ))}
+    </div>
+  );
+}
+
+createRoot(document.getElementById('harness-root')).render(<Harness />);

--- a/tests/visual/semaphore-shot.mjs
+++ b/tests/visual/semaphore-shot.mjs
@@ -1,0 +1,155 @@
+// semaphore-shot.mjs — VERIFICACIÓN VISUAL del #2074 Semáforo de confianza
+// científica del ChatBubble. Sirve el harness AISLADO (sin login gate) y
+// captura los 3 estados (verde/ámbar/rojo), primero colapsado y luego con el
+// panel de motivo+procedencia desplegado (click en el chip).
+//
+// NixOS: chromium del nix-store (executablePath). El bundled de Playwright
+// falla por libs faltantes (memoria reference-playwright-nixos-setup).
+//
+// Uso: node tests/visual/semaphore-shot.mjs [outDir]
+import { chromium } from 'playwright';
+import { execSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const OUT_DIR = process.argv[2] || '/tmp/semaforo-shots';
+const PORT = 5199;
+const BASE = `http://127.0.0.1:${PORT}`;
+const URL = `${BASE}/tests/visual/semaphore-harness.html`;
+
+const KNOWN_CHROMIUM = [
+  '/nix/store/r7ifk1v95jfl02775kgbrd61dyr1rfsx-chromium-148.0.7778.178/bin/chromium',
+  '/nix/store/9fjg59mab9j8c5r61dx2k5gcbd2f5mpm-chromium-148.0.7778.96/bin/chromium',
+];
+function resolveChromium() {
+  if (process.env.CHROMIUM_PATH) return process.env.CHROMIUM_PATH;
+  try {
+    const w = execSync('which chromium 2>/dev/null', { encoding: 'utf8' }).trim();
+    if (w) return w;
+  } catch { /* fall through */ }
+  for (const p of KNOWN_CHROMIUM) { try { if (fs.existsSync(p)) return p; } catch { /* noop */ } }
+  return execSync('nix-shell -p chromium --run "which chromium"', { encoding: 'utf8', timeout: 120000 })
+    .trim().split('\n').pop().trim();
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function waitForServer(url, child, deadlineMs = 120000) {
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    if (child?.exitCode != null && child.exitCode !== 0) {
+      throw new Error(`El servidor terminó antes de estar listo (code=${child.exitCode})`);
+    }
+    try {
+      const r = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      if (r.ok || r.status >= 400) return;
+    } catch { /* retry */ }
+    await sleep(300);
+  }
+  throw new Error(`Timeout esperando servidor en ${url}`);
+}
+
+async function ensureServer(cwd) {
+  // Reúsa un dev server ya escuchando en el puerto (evita cold-start doble).
+  try {
+    const r = await fetch(BASE, { signal: AbortSignal.timeout(1500) });
+    if (r.ok || r.status >= 400) return null;
+  } catch { /* nada escuchando: lo arrancamos */ }
+
+  // `npx vite` directo (probado): `npm run dev` bajo spawn cuelga en este setup.
+  const child = spawn('npx', ['vite', '--host', '127.0.0.1', '--port', String(PORT), '--strictPort'], {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, FORCE_COLOR: '0' },
+  });
+  child.stdout.on('data', () => {});
+  child.stderr.on('data', () => {});
+  await waitForServer(BASE, child);
+  return child;
+}
+
+async function main() {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const cwd = process.cwd();
+
+  const child = await ensureServer(cwd);
+
+  // Warm-up: fuerza a vite a transformar el harness (dep pre-bundle en frío)
+  // ANTES de navegar, para que el goto no compita con la optimización.
+  for (let i = 0; i < 3; i++) {
+    try { await fetch(URL, { signal: AbortSignal.timeout(50000) }); break; }
+    catch { await sleep(500); }
+  }
+
+  const results = [];
+  let browser;
+  try {
+
+    const chromiumPath = resolveChromium();
+    browser = await chromium.launch({
+      executablePath: chromiumPath,
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+    });
+    const context = await browser.newContext({
+      viewport: { width: 460, height: 900 },
+      deviceScaleFactor: 2,
+      locale: 'es-CO',
+      colorScheme: 'dark',
+    });
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on('pageerror', (e) => pageErrors.push(e.message));
+    page.on('console', (m) => {
+      if (m.type() === 'error') {
+        const t = m.text();
+        if (!/favicon|manifest|sqlite|wasm|Failed to load resource|WebGL|content security policy/i.test(t)) {
+          pageErrors.push(t);
+        }
+      }
+    });
+
+    // 'domcontentloaded' (no 'networkidle'): el HMR websocket de vite mantiene
+    // la red "activa" y networkidle nunca asienta con un dev server recién
+    // arrancado. El waitForSelector de abajo confirma el montaje real.
+    await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    // Espera a que los 3 semáforos monten (cubre el pre-bundle en frío).
+    await page.waitForSelector('[data-testid="semaphore-badge"]', { timeout: 45000 });
+    await sleep(600);
+
+    // Captura general (los 3 estados colapsados).
+    const overview = path.join(OUT_DIR, 'semaforo-overview.png');
+    await page.screenshot({ path: overview, fullPage: true });
+    results.push(overview);
+
+    // Por estado: captura la tarjeta colapsada y luego expandida (click en chip).
+    for (const state of ['verde', 'ambar', 'rojo']) {
+      const card = page.locator(`#card-${state}`);
+      await card.scrollIntoViewIfNeeded();
+      await sleep(150);
+      const collapsed = path.join(OUT_DIR, `semaforo-${state}-colapsado.png`);
+      await card.screenshot({ path: collapsed });
+      results.push(collapsed);
+
+      // Expandir el panel de motivo + procedencia.
+      await card.locator('[data-testid="semaphore-badge"]').click();
+      await sleep(250);
+      const expanded = path.join(OUT_DIR, `semaforo-${state}-expandido.png`);
+      await card.screenshot({ path: expanded });
+      results.push(expanded);
+    }
+
+    if (pageErrors.length > 0) {
+      throw new Error(`Errores en la página: ${pageErrors.slice(0, 3).join(' | ')}`);
+    }
+
+    console.log('[semaforo-shot] capturas OK:');
+    for (const r of results) console.log('  ' + r);
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+    if (child) child.kill('SIGTERM');
+  }
+}
+
+main().catch((e) => {
+  console.error('[semaforo-shot] FALLO:', e instanceof Error ? e.message : String(e));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Pinta el semáforo verde/ámbar/rojo en el chat del agente a partir de
`message.metadata.grounding_semaphore` (dato del sidecar, #2074):

  - verde  → "Verificado"     (grounded ≥ umbral de confianza)
  - ámbar  → "Una fuente"      (una sola fuente / confianza media)
  - rojo   → "Sin verificar"   (disputed / sin fuente / abstención honesta)

El chip es interactivo (onClick de React, CSP-safe): al tocarlo despliega el
`grounding_reason` + la procedencia (institución/source + DOI o enlace al
recurso citado) — el "sello institucional" para el usuario técnico. On-brand,
sutil y no invasivo: el campesino lo ignora, el técnico lo valora.

Degradación suave: si el sidecar aún no emite el semáforo (antes de que #2074
llegue a prod), se DERIVA un color conservador desde las señales de grounding
ya presentes (grounded/confianza/disputed); sin señal reconocible no renderiza
nada. Normaliza sinónimos (green/amber/red, abstain, single_source…).

Verificación visual (chromium nix, harness aislado del login gate) de los 3
estados colapsado+expandido en tests/visual/semaphore-harness.{html,jsx} +
tests/visual/semaphore-shot.mjs. 46 tests verdes en ChatBubble.test.jsx.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
