### PR TITLE
feat(guards): wire confusion-especie + pest-vs-disease guards (promptAssembler/AgentScreen/bench) — completa el trio del bench

### DIFF
--- a/scripts/__tests__/bench-contaminacion.test.mjs
+++ b/scripts/__tests__/bench-contaminacion.test.mjs
@@ -46,6 +46,12 @@ import {
  * los tests que no lo ejercitan explícitamente peguen a la red real. */
 const noMismatchPisoTermicoFn = async () => ({ has_mismatch: false, system_prompt_block: '' });
 
+/** Stubs por defecto de los guards confusión-especie (#292) y
+ * pest-vs-disease (#293): sin disparo, no-op — mismo criterio que
+ * `noMismatchPisoTermicoFn`, evita red real en tests que no los ejercitan. */
+const noConfusionEspecieFn = async () => ({ has_confusion: false, system_prompt_block: '' });
+const noPestVsDiseaseFn = async () => ({ has_classification: false, system_prompt_block: '' });
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..', '..');
 
@@ -358,6 +364,24 @@ describe('buildEnrichedSystemPrompt (guard piso térmico chagra-pro #288)', () =
     expect(buildEnrichedSystemPrompt([], '')).toBe(base);
     expect(buildEnrichedSystemPrompt([], undefined)).toBe(base);
   });
+
+  it('confusionEspecieBlock y pestVsDiseaseBlock se agregan AL FINAL, después de pisoTermico', () => {
+    const prompt = buildEnrichedSystemPrompt(
+      [],
+      '[GUARD PISO TÉRMICO — DESAJUSTE DETECTADO · innegociable]',
+      '[GUARD CONFUSIÓN DE ESPECIE — RIESGO DE FAMILIA/TAXONOMÍA EQUIVOCADA · innegociable]',
+      '[GUARD PLAGA VS ENFERMEDAD — CLASIFICACIÓN VERIFICADA · innegociable]',
+    );
+    expect(prompt.indexOf('CONFUSIÓN DE ESPECIE')).toBeGreaterThan(prompt.indexOf('PISO TÉRMICO'));
+    expect(prompt.indexOf('PLAGA VS ENFERMEDAD')).toBeGreaterThan(prompt.indexOf('CONFUSIÓN DE ESPECIE'));
+    expect(prompt.endsWith('[GUARD PLAGA VS ENFERMEDAD — CLASIFICACIÓN VERIFICADA · innegociable]')).toBe(true);
+  });
+
+  it('confusionEspecieBlock/pestVsDiseaseBlock vacíos/no-string son no-op', () => {
+    const base = buildEnrichedSystemPrompt([]);
+    expect(buildEnrichedSystemPrompt([], '', '', '')).toBe(base);
+    expect(buildEnrichedSystemPrompt([], undefined, undefined, undefined)).toBe(base);
+  });
 });
 
 // ── orquestación: resolveFn/callFn/validateFn INYECTADOS (sin red real) ────
@@ -369,7 +393,7 @@ describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
     const resolveFn = async () => ({ entities: [{ kind: 'species', mentioned: 'x' }] });
     const callFn = async () => ({ response: 'respuesta de prueba', error: null });
     const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
-    const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn });
+    const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn });
     expect(out.id).toBe('p1');
     expect(out.response).toBe('respuesta de prueba');
     expect(out.entities_grounded).toBe(1);
@@ -382,7 +406,7 @@ describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
     const resolveFn = async () => ({ entities: [] });
     const callFn = async () => ({ response: '', error: 'timeout' });
     const validateFn = async () => { validateCalled = true; return { hallucinated: [], detected_count: 0 }; };
-    const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn });
+    const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn });
     expect(out.error).toBe('timeout');
     expect(validateCalled).toBe(false);
   });
@@ -403,7 +427,7 @@ describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
         has_mismatch: true,
         system_prompt_block: '[GUARD PISO TÉRMICO — DESAJUSTE DETECTADO · innegociable]',
       });
-      const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn });
+      const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn, confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn });
       expect(seenSystemPrompt).toContain('GUARD PISO TÉRMICO');
       expect(out.piso_termico_guard_fired).toBe(true);
     });
@@ -417,7 +441,7 @@ describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
       };
       const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
       const pisoTermicoFn = async () => ({ has_mismatch: false, system_prompt_block: '' });
-      const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn });
+      const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn, confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn });
       expect(seenSystemPrompt).not.toContain('GUARD PISO TÉRMICO');
       expect(out.piso_termico_guard_fired).toBe(false);
     });
@@ -427,9 +451,110 @@ describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
       const callFn = async () => ({ response: 'r', error: null });
       const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
       const pisoTermicoFn = async () => ({ has_mismatch: false, system_prompt_block: '', error: 'ECONNREFUSED' });
-      const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn });
+      const out = await runProbeAgainstAgent(probe, { resolveFn, callFn, validateFn, pisoTermicoFn, confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn });
       expect(out.error).toBeNull();
       expect(out.piso_termico_guard_fired).toBe(false);
+    });
+  });
+
+  // ── GUARD confusión de especie (chagra-pro #292) — mismo criterio honesto
+  // que piso térmico: el bench debe medir el pipeline REAL de prod.
+  describe('wiring /confusion-especie-guard (bench honesto, mismo pipeline que prod)', () => {
+    it('has_confusion:true → el system_prompt_block del guard llega al systemPrompt que ve callFn', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      let seenSystemPrompt = null;
+      const callFn = async (_model, systemPrompt) => {
+        seenSystemPrompt = systemPrompt;
+        return { response: 'r', error: null };
+      };
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const confusionEspecieFn = async () => ({
+        has_confusion: true,
+        system_prompt_block: '[GUARD CONFUSIÓN DE ESPECIE — RIESGO DE FAMILIA/TAXONOMÍA EQUIVOCADA · innegociable]',
+      });
+      const out = await runProbeAgainstAgent(probe, {
+        resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, confusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn,
+      });
+      expect(seenSystemPrompt).toContain('CONFUSIÓN DE ESPECIE');
+      expect(out.confusion_especie_guard_fired).toBe(true);
+    });
+
+    it('has_confusion:false → NO inyecta nada (no-op, prompt idéntico al de antes del guard)', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      let seenSystemPrompt = null;
+      const callFn = async (_model, systemPrompt) => {
+        seenSystemPrompt = systemPrompt;
+        return { response: 'r', error: null };
+      };
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const confusionEspecieFn = async () => ({ has_confusion: false, system_prompt_block: '' });
+      const out = await runProbeAgainstAgent(probe, {
+        resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, confusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn,
+      });
+      expect(seenSystemPrompt).not.toContain('CONFUSIÓN DE ESPECIE');
+      expect(out.confusion_especie_guard_fired).toBe(false);
+    });
+
+    it('confusionEspecieFn caído/lanza error de red → degrada limpio, no rompe la sonda', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      const callFn = async () => ({ response: 'r', error: null });
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const confusionEspecieFn = async () => ({ has_confusion: false, system_prompt_block: '', error: 'ECONNREFUSED' });
+      const out = await runProbeAgainstAgent(probe, {
+        resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, confusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn,
+      });
+      expect(out.error).toBeNull();
+      expect(out.confusion_especie_guard_fired).toBe(false);
+    });
+  });
+
+  // ── GUARD plaga vs enfermedad (chagra-pro #293) — mismo criterio honesto.
+  describe('wiring /pest-vs-disease-guard (bench honesto, mismo pipeline que prod)', () => {
+    it('has_classification:true → el system_prompt_block del guard llega al systemPrompt que ve callFn', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      let seenSystemPrompt = null;
+      const callFn = async (_model, systemPrompt) => {
+        seenSystemPrompt = systemPrompt;
+        return { response: 'r', error: null };
+      };
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const pestVsDiseaseFn = async () => ({
+        has_classification: true,
+        system_prompt_block: '[GUARD PLAGA VS ENFERMEDAD — CLASIFICACIÓN VERIFICADA · innegociable]',
+      });
+      const out = await runProbeAgainstAgent(probe, {
+        resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn,
+      });
+      expect(seenSystemPrompt).toContain('PLAGA VS ENFERMEDAD');
+      expect(out.pest_vs_disease_guard_fired).toBe(true);
+    });
+
+    it('has_classification:false (incluye desacuerdo catálogo↔heurística) → NO inyecta nada', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      let seenSystemPrompt = null;
+      const callFn = async (_model, systemPrompt) => {
+        seenSystemPrompt = systemPrompt;
+        return { response: 'r', error: null };
+      };
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const pestVsDiseaseFn = async () => ({ has_classification: false, system_prompt_block: '' });
+      const out = await runProbeAgainstAgent(probe, {
+        resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn,
+      });
+      expect(seenSystemPrompt).not.toContain('PLAGA VS ENFERMEDAD');
+      expect(out.pest_vs_disease_guard_fired).toBe(false);
+    });
+
+    it('pestVsDiseaseFn caído/lanza error de red → degrada limpio, no rompe la sonda', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      const callFn = async () => ({ response: 'r', error: null });
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const pestVsDiseaseFn = async () => ({ has_classification: false, system_prompt_block: '', error: 'ECONNREFUSED' });
+      const out = await runProbeAgainstAgent(probe, {
+        resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn,
+      });
+      expect(out.error).toBeNull();
+      expect(out.pest_vs_disease_guard_fired).toBe(false);
     });
   });
 });
@@ -444,7 +569,7 @@ describe('runAllProbes (secuencial, dependencias inyectadas)', () => {
       return { response: `resp-${userPrompt}`, error: null };
     };
     const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
-    const out = await runAllProbes(probes, { resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, sleepMs: 0 });
+    const out = await runAllProbes(probes, { resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn, sleepMs: 0 });
     expect(order).toEqual(['a', 'b', 'c']);
     expect(out).toHaveLength(3);
   });
@@ -456,7 +581,8 @@ describe('runAllProbes (secuencial, dependencias inyectadas)', () => {
     const callFn = async () => ({ response: 'r', error: null });
     const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
     await runAllProbes(probes, {
-      resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn, sleepMs: 0,
+      resolveFn, callFn, validateFn, pisoTermicoFn: noMismatchPisoTermicoFn,
+      confusionEspecieFn: noConfusionEspecieFn, pestVsDiseaseFn: noPestVsDiseaseFn, sleepMs: 0,
       onProgress: (result, i, total) => calls.push([result.id, i, total]),
     });
     expect(calls).toEqual([['a', 0, 1]]);

--- a/scripts/bench-contaminacion.mjs
+++ b/scripts/bench-contaminacion.mjs
@@ -594,17 +594,86 @@ async function pisoTermicoGuard(userMessage, { sidecarUrl = SIDECAR_URL } = {}) 
 }
 
 /**
+ * confusionEspecieGuard — llama al MISMO endpoint determinista
+ * `/confusion-especie-guard` (chagra-pro #292) que consume producción
+ * (`src/services/sidecarClient.js`, cableado en `AgentScreen.jsx`). Mismo
+ * criterio que `pisoTermicoGuard`: el bench mide el pipeline REAL, no uno
+ * idealizado. FAIL-SAFE: cualquier error/timeout/non-2xx degrada a
+ * `has_confusion:false` (no-op).
+ * @param {string} userMessage
+ * @param {{ sidecarUrl?: string }} [opts]
+ * @returns {Promise<{ has_confusion: boolean, system_prompt_block: string }>}
+ */
+async function confusionEspecieGuard(userMessage, { sidecarUrl = SIDECAR_URL } = {}) {
+  const token = getSidecarToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+  try {
+    const res = await fetch(`${sidecarUrl}/confusion-especie-guard`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ user_message: userMessage }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return { has_confusion: false, system_prompt_block: '' };
+    const data = await res.json();
+    return {
+      has_confusion: data.has_confusion === true,
+      system_prompt_block: typeof data.system_prompt_block === 'string' ? data.system_prompt_block : '',
+    };
+  } catch (err) {
+    return { has_confusion: false, system_prompt_block: '', error: err.message };
+  }
+}
+
+/**
+ * pestVsDiseaseGuard — llama al MISMO endpoint determinista
+ * `/pest-vs-disease-guard` (chagra-pro #293) que consume producción
+ * (`src/services/sidecarClient.js`, cableado en `AgentScreen.jsx`). Mismo
+ * criterio que `pisoTermicoGuard`/`confusionEspecieGuard`. FAIL-SAFE:
+ * cualquier error/timeout/non-2xx degrada a `has_classification:false`
+ * (no-op).
+ * @param {string} userMessage
+ * @param {{ sidecarUrl?: string }} [opts]
+ * @returns {Promise<{ has_classification: boolean, system_prompt_block: string }>}
+ */
+async function pestVsDiseaseGuard(userMessage, { sidecarUrl = SIDECAR_URL } = {}) {
+  const token = getSidecarToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+  try {
+    const res = await fetch(`${sidecarUrl}/pest-vs-disease-guard`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ user_message: userMessage }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return { has_classification: false, system_prompt_block: '' };
+    const data = await res.json();
+    return {
+      has_classification: data.has_classification === true,
+      system_prompt_block: typeof data.system_prompt_block === 'string' ? data.system_prompt_block : '',
+    };
+  } catch (err) {
+    return { has_classification: false, system_prompt_block: '', error: err.message };
+  }
+}
+
+/**
  * buildEnrichedSystemPrompt — arma el system prompt que ve el modelo en la
- * fase remote-run. `pisoTermicoBlock` (opcional) es el `system_prompt_block`
- * YA formateado que devuelve `/piso-termico-guard` cuando detectó un
- * desajuste (marginal/inviable) — se inyecta al FINAL (recency máxima),
- * espejo exacto de cómo lo inyecta `AgentScreen.jsx` en producción (guarda
- * de SUPRESIÓN-Y-REEMPLAZO, debe dominar sobre el consejo genérico). ''/
- * ausente = no-op, el prompt queda idéntico al de antes de este guard.
+ * fase remote-run. `pisoTermicoBlock`/`confusionEspecieBlock`/
+ * `pestVsDiseaseBlock` (opcionales) son los `system_prompt_block` YA
+ * formateados que devuelven sus respectivos guards cuando detectaron un
+ * problema — se inyectan al FINAL (recency máxima), espejo exacto de cómo
+ * los inyecta `AgentScreen.jsx` en producción (guardas de
+ * SUPRESIÓN-Y-REEMPLAZO, deben dominar sobre el consejo genérico). ''/
+ * ausente = no-op, el prompt queda idéntico al de antes de estos guards.
  * @param {object[]} entities
  * @param {string} [pisoTermicoBlock]
+ * @param {string} [confusionEspecieBlock]
+ * @param {string} [pestVsDiseaseBlock]
  */
-export function buildEnrichedSystemPrompt(entities, pisoTermicoBlock = '') {
+export function buildEnrichedSystemPrompt(entities, pisoTermicoBlock = '', confusionEspecieBlock = '', pestVsDiseaseBlock = '') {
   const basePrompt = `Eres un asistente agroecológico experto para Colombia. Responde en español claro, práctico para agricultores.
 
 Si mencionas entidades (especies, plagas, biopreparados), usa los nombres canónicos del catálogo Chagra para evitar alucinaciones. Si no tiene un dato verificado (por ejemplo, un contacto o teléfono), dígalo honestamente en vez de inventarlo.`;
@@ -627,6 +696,12 @@ Si mencionas entidades (especies, plagas, biopreparados), usa los nombres canón
 
   if (typeof pisoTermicoBlock === 'string' && pisoTermicoBlock.trim()) {
     prompt = `${prompt}\n\n${pisoTermicoBlock}`;
+  }
+  if (typeof confusionEspecieBlock === 'string' && confusionEspecieBlock.trim()) {
+    prompt = `${prompt}\n\n${confusionEspecieBlock}`;
+  }
+  if (typeof pestVsDiseaseBlock === 'string' && pestVsDiseaseBlock.trim()) {
+    prompt = `${prompt}\n\n${pestVsDiseaseBlock}`;
   }
 
   return prompt;
@@ -686,15 +761,17 @@ async function postValidate(userMessage, modelResponse, { sidecarUrl = SIDECAR_U
 /**
  * runProbeAgainstAgent — corre UNA sonda por el pipeline real. Impura (red),
  * pero cada dependencia (resolveEntities/callOllama/postValidate/
- * pisoTermicoGuard) es inyectable para test sin red.
+ * pisoTermicoGuard/confusionEspecieGuard/pestVsDiseaseGuard) es inyectable
+ * para test sin red.
  *
- * `pisoTermicoFn` corre EN PARALELO con `resolveFn` (mismo turno, cero
- * latencia serial añadida — espejo del `Promise.all` que hace
- * `AgentScreen.jsx` en producción) y, si devuelve `has_mismatch:true`, su
- * `system_prompt_block` se inyecta en `buildEnrichedSystemPrompt` — así el
- * bench mide el MISMO pipeline que ve el usuario real, no uno sin el guard.
+ * `pisoTermicoFn`/`confusionEspecieFn`/`pestVsDiseaseFn` corren EN PARALELO
+ * con `resolveFn` (mismo turno, cero latencia serial añadida — espejo del
+ * `Promise.all` que hace `AgentScreen.jsx` en producción) y, si alguno
+ * dispara, su `system_prompt_block` se inyecta en `buildEnrichedSystemPrompt`
+ * — así el bench mide el MISMO pipeline que ve el usuario real, no uno sin
+ * los guards.
  * @param {object} probe
- * @param {{ model?: string, resolveFn?: Function, callFn?: Function, validateFn?: Function, pisoTermicoFn?: Function }} [opts]
+ * @param {{ model?: string, resolveFn?: Function, callFn?: Function, validateFn?: Function, pisoTermicoFn?: Function, confusionEspecieFn?: Function, pestVsDiseaseFn?: Function }} [opts]
  * @returns {Promise<object>}
  */
 export async function runProbeAgainstAgent(probe, opts = {}) {
@@ -704,16 +781,26 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     callFn = callOllama,
     validateFn = postValidate,
     pisoTermicoFn = pisoTermicoGuard,
+    confusionEspecieFn = confusionEspecieGuard,
+    pestVsDiseaseFn = pestVsDiseaseGuard,
   } = opts;
   const t0 = performance.now();
-  const [{ entities }, pisoTermico] = await Promise.all([
+  const [{ entities }, pisoTermico, confusionEspecie, pestVsDisease] = await Promise.all([
     resolveFn(probe.query),
     pisoTermicoFn(probe.query),
+    confusionEspecieFn(probe.query),
+    pestVsDiseaseFn(probe.query),
   ]);
   const pisoTermicoBlock = (pisoTermico && pisoTermico.has_mismatch && pisoTermico.system_prompt_block)
     ? pisoTermico.system_prompt_block
     : '';
-  const systemPrompt = buildEnrichedSystemPrompt(entities, pisoTermicoBlock);
+  const confusionEspecieBlock = (confusionEspecie && confusionEspecie.has_confusion && confusionEspecie.system_prompt_block)
+    ? confusionEspecie.system_prompt_block
+    : '';
+  const pestVsDiseaseBlock = (pestVsDisease && pestVsDisease.has_classification && pestVsDisease.system_prompt_block)
+    ? pestVsDisease.system_prompt_block
+    : '';
+  const systemPrompt = buildEnrichedSystemPrompt(entities, pisoTermicoBlock, confusionEspecieBlock, pestVsDiseaseBlock);
   const { response, error } = await callFn(model, systemPrompt, probe.query);
   const validation = error ? { hallucinated: [], detected_count: 0 } : await validateFn(probe.query, response);
   return {
@@ -726,6 +813,8 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     error: error || null,
     entities_grounded: entities.length,
     piso_termico_guard_fired: Boolean(pisoTermicoBlock),
+    confusion_especie_guard_fired: Boolean(confusionEspecieBlock),
+    pest_vs_disease_guard_fired: Boolean(pestVsDiseaseBlock),
     halluc_detected_count: validation.detected_count,
     latency_ms: Math.round(performance.now() - t0),
   };

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -46,7 +46,7 @@ import { createStreamDeadline } from '../../services/streamDeadline';
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, pisoTermicoGuard, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, pisoTermicoGuard, confusionEspecieGuard, pestVsDiseaseGuard, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
@@ -818,7 +818,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // formatToolEvidence y analyzeQuery viven en agentPromptBase (funciones
   // puras, testeables y medibles fuera de React).
 
-  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null, fermentoBlock = '', subgrafoBloque = '', biopreparadoBlock = '', pisoTermicoBlock = '', groundingPolicyBlock = '') => {
+  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null, fermentoBlock = '', subgrafoBloque = '', biopreparadoBlock = '', pisoTermicoBlock = '', confusionEspecieBlock = '', pestVsDiseaseBlock = '', groundingPolicyBlock = '') => {
     const analysis = analyzeQuery(query);
     // El base recibe query/historial/isEnum para inyectar SOLO los glosarios
     // y reglas condicionales que la conversación toca (re-arquitectura GR-10).
@@ -1030,6 +1030,31 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       ? `\n\n${pisoTermicoBlock}`
       : '';
 
+    // GUARDA CONFUSIÓN DE ESPECIE (chagra-pro #292, segundo driver de
+    // contaminación cross-domain tras cross_thermal, sonda `confusion_especie`
+    // de bench-contaminacion.mjs, ~20% medida 2026-07). El sidecar
+    // /confusion-especie-guard ya detectó si la especie mencionada trae
+    // advertencia `_anti_confusion` curada o un look-alike de familia botánica
+    // distinta, y armó el bloque de SUPRESIÓN-Y-REEMPLAZO. Va de máxima
+    // recency (mismo criterio que fermento/biopreparado/pisoTermico). ''
+    // (no-op) cuando no hay riesgo detectado o el sidecar no respondió
+    // (degradación graceful — no rompe el turno, nunca inventa un look-alike).
+    const confusionEspecieSafetyBlock = (typeof confusionEspecieBlock === 'string' && confusionEspecieBlock.trim())
+      ? `\n\n${confusionEspecieBlock}`
+      : '';
+
+    // GUARDA PLAGA VS ENFERMEDAD (chagra-pro #293, tercer driver de
+    // contaminación cross-domain, sonda `pest_vs_disease` de
+    // bench-contaminacion.mjs). El sidecar /pest-vs-disease-guard ya cruzó el
+    // término mencionado (plaga/enfermedad) contra el catálogo Y la heurística
+    // léxica/taxonómica, y armó el bloque de SUPRESIÓN-Y-REEMPLAZO cuando
+    // ambas coinciden. '' (no-op) cuando no hubo término mencionado, hay
+    // desacuerdo catálogo↔heurística (fail-safe a propósito), o el sidecar no
+    // respondió (degradación graceful).
+    const pestVsDiseaseSafetyBlock = (typeof pestVsDiseaseBlock === 'string' && pestVsDiseaseBlock.trim())
+      ? `\n\n${pestVsDiseaseBlock}`
+      : '';
+
     // MODO CIENTÍFICO (#17) — bloque answer/hedge/abstain ya formateado por
     // el sidecar (WIRING real de grounding-policy.ts/grounding-prompt-
     // formatter.ts). Va DENTRO del cluster de grounding (después de la cadena
@@ -1072,6 +1097,8 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       fermento: fermentoSafetyBlock,
       biopreparado: biopreparadoSafetyBlock,
       pisoTermico: pisoTermicoSafetyBlock,
+      confusionEspecie: confusionEspecieSafetyBlock,
+      pestVsDisease: pestVsDiseaseSafetyBlock,
     });
 
     const messages = [
@@ -1376,6 +1403,23 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // no-op en el system prompt si el piso coincide, no hubo señal de piso
       // del usuario, o el sidecar no respondió (degradación graceful).
       let pisoTermicoBlock = '';
+      // GUARDA CONFUSIÓN DE ESPECIE (chagra-pro #292, segundo driver de
+      // contaminación cross-domain — sonda `confusion_especie` de
+      // bench-contaminacion.mjs, ~20% medida 2026-07). Bloque de
+      // SUPRESIÓN-Y-REEMPLAZO ya formateado por el sidecar
+      // (/confusion-especie-guard) cuando la especie mencionada trae
+      // advertencia curada o un look-alike de familia botánica distinta. ''
+      // por default → no-op si no hay riesgo detectado o el sidecar no
+      // respondió (degradación graceful).
+      let confusionEspecieBlock = '';
+      // GUARDA PLAGA VS ENFERMEDAD (chagra-pro #293, tercer driver de
+      // contaminación cross-domain — sonda `pest_vs_disease` de
+      // bench-contaminacion.mjs). Bloque de SUPRESIÓN-Y-REEMPLAZO ya
+      // formateado por el sidecar (/pest-vs-disease-guard) cuando el término
+      // mencionado tiene categoría confirmada (catálogo + heurística
+      // coinciden). '' por default → no-op (degradación graceful, incluye el
+      // caso de desacuerdo catálogo↔heurística — fail-safe a propósito).
+      let pestVsDiseaseBlock = '';
       // MODO CIENTÍFICO (#17) — WIRING real de grounding-policy.ts/grounding-
       // prompt-formatter.ts (audit 2026-07-04-optimizacion-grounding-
       // velocidad-inteligencia.md win #4). El sidecar decide answer/hedge/
@@ -1409,15 +1453,18 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           })();
           const tRE0 = performance.now();
           // SAFETY-CRITICAL en PARALELO: /fermento-prefilter,
-          // /biopreparado-grounding y /piso-termico-guard corren junto a
+          // /biopreparado-grounding, /piso-termico-guard,
+          // /confusion-especie-guard y /pest-vs-disease-guard corren junto a
           // /resolve-entities (mismo turno, antes del LLM) — CERO latencia
-          // serial añadida. Los cuatro wrappers son no-throw (devuelven null
-          // en error/timeout), así que Promise.all no puede rechazar por ellos.
-          const [resolved, fermento, biopreparado, pisoTermico] = await Promise.all([
+          // serial añadida. Los seis wrappers son no-throw (devuelven null en
+          // error/timeout), así que Promise.all no puede rechazar por ellos.
+          const [resolved, fermento, biopreparado, pisoTermico, confusionEspecie, pestVsDisease] = await Promise.all([
             resolveEntities(textForLLM, { fincaAltitud: reAltitud, context: contextMemory }),
             fermentoPrefilter(textForLLM),
             biopreparadoGrounding(textForLLM),
             pisoTermicoGuard(textForLLM, { fincaAltitud: reAltitud, pisoTermico: rePisoTermico }),
+            confusionEspecieGuard(textForLLM),
+            pestVsDiseaseGuard(textForLLM),
           ]);
           const tRE1 = performance.now();
           // FERMENTOS: si el sidecar marcó intención-fermento, inyectamos su
@@ -1461,6 +1508,39 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               userPisoOrigen: pisoTermico.user_piso_origen,
               viabilidad: pisoTermico.viabilidad,
               reason: pisoTermico.reason,
+            });
+          }
+          // CONFUSIÓN DE ESPECIE: si el sidecar detectó riesgo real (curado o
+          // algorítmico) de confundir la familia botánica de la especie
+          // mencionada, inyectamos su bloque de SUPRESIÓN-Y-REEMPLAZO al
+          // final del system prompt (recency máxima). Si el sidecar no
+          // respondió (null) o no hay riesgo, confusionEspecieBlock queda ''
+          // → no-op, el turno sigue sin romperse (degradación graceful).
+          if (confusionEspecie && confusionEspecie.has_confusion && typeof confusionEspecie.system_prompt_block === 'string' && confusionEspecie.system_prompt_block.trim()) {
+            confusionEspecieBlock = confusionEspecie.system_prompt_block;
+            console.debug('[sidecar] confusion-especie-guard', {
+              speciesId: confusionEspecie.species_id,
+              speciesMentioned: confusionEspecie.species_mentioned,
+              confusionSource: confusionEspecie.confusion_source,
+              lookalike: confusionEspecie.lookalike_nombre_comun,
+              reason: confusionEspecie.reason,
+            });
+          }
+          // PLAGA VS ENFERMEDAD: si el sidecar confirmó la categoría real
+          // (catálogo + heurística coinciden) del término mencionado,
+          // inyectamos su bloque de SUPRESIÓN-Y-REEMPLAZO al final del
+          // system prompt (recency máxima). Si el sidecar no respondió
+          // (null), no hubo término mencionado, o hay desacuerdo
+          // catálogo↔heurística (fail-safe a propósito), pestVsDiseaseBlock
+          // queda '' → no-op, el turno sigue sin romperse.
+          if (pestVsDisease && pestVsDisease.has_classification && typeof pestVsDisease.system_prompt_block === 'string' && pestVsDisease.system_prompt_block.trim()) {
+            pestVsDiseaseBlock = pestVsDisease.system_prompt_block;
+            console.debug('[sidecar] pest-vs-disease-guard', {
+              speciesId: pestVsDisease.species_id,
+              termMentioned: pestVsDisease.term_mentioned,
+              termCategoria: pestVsDisease.term_categoria,
+              manejoEquivocadoDetectado: pestVsDisease.manejo_equivocado_detectado,
+              reason: pestVsDisease.reason,
             });
           }
           if (resolved && Array.isArray(resolved.entities) && resolved.entities.length > 0) {
@@ -2006,7 +2086,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       const deterministicPrice = buildPriceAnswer({ userMessage: text, toolEvidence });
       const rawResponse = deterministicPrice != null
         ? deterministicPrice
-        : await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock, edgesTruncated, biopreparadoBlock, pisoTermicoBlock, groundingPolicyBlock);
+        : await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock, edgesTruncated, biopreparadoBlock, pisoTermicoBlock, confusionEspecieBlock, pestVsDiseaseBlock, groundingPolicyBlock);
       if (deterministicPrice != null) {
         console.debug('[precio] respuesta determinista SIPSA (sin LLM)', { route: nluRoute });
       }

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -153,6 +153,8 @@ vi.mock('../../../services/sidecarClient', () => ({
   fermentoPrefilter: vi.fn(),
   biopreparadoGrounding: vi.fn(),
   pisoTermicoGuard: vi.fn(),
+  confusionEspecieGuard: vi.fn(),
+  pestVsDiseaseGuard: vi.fn(),
   postValidate: vi.fn(),
   getClimaIdeam: vi.fn(),
   isToolAllowed: vi.fn(() => false),

--- a/src/services/__tests__/promptAssembler.test.js
+++ b/src/services/__tests__/promptAssembler.test.js
@@ -107,6 +107,40 @@ describe('assembleSystemContent — orden por prioridad', () => {
       content.indexOf('BLOQUE_GROUNDING_POLICY'),
     );
   });
+
+  it('GUARDAS confusión de especie (#292) y plaga vs enfermedad (#293) quedan AL FINAL, después de pisoTermico (máxima recency)', () => {
+    const { content } = assembleSystemContent({
+      base: 'BASE',
+      evidence: 'EVIDENCIA',
+      fermento: 'GUARDA_FERMENTO',
+      biopreparado: 'GUARDA_BIOPREPARADO',
+      pisoTermico: 'GUARDA_PISO_TERMICO',
+      confusionEspecie: 'GUARDA_CONFUSION_ESPECIE',
+      pestVsDisease: 'GUARDA_PEST_VS_DISEASE',
+    });
+    expect(content.indexOf('GUARDA_CONFUSION_ESPECIE')).toBeGreaterThan(content.indexOf('GUARDA_PISO_TERMICO'));
+    expect(content.indexOf('GUARDA_PEST_VS_DISEASE')).toBeGreaterThan(content.indexOf('GUARDA_CONFUSION_ESPECIE'));
+    expect(content.endsWith('GUARDA_PEST_VS_DISEASE')).toBe(true);
+  });
+
+  it('GUARDAS confusión de especie / pest_vs_disease NUNCA se recortan (no están en SACRIFICE_ORDER)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const big = 'w'.repeat(6400); // ~2000 tokens
+    const r = assembleSystemContent(
+      {
+        base: big,
+        confusionEspecie: big,
+        pestVsDisease: big,
+        corpus: { variants: ['recortable', ''] },
+      },
+      { budget: 100 },
+    );
+    expect(r.overBudget).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    expect(r.breakdown.find((b) => b.name === 'confusionEspecie').degraded).toBe(false);
+    expect(r.breakdown.find((b) => b.name === 'pestVsDisease').degraded).toBe(false);
+    expect(r.content).toContain(big);
+  });
 });
 
 describe('assembleSystemContent — presupuesto y degradación', () => {

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -881,6 +881,217 @@ describe('sidecarClient — feature flag on', () => {
       expect(res).toBeNull();
     });
   });
+
+  describe('confusionEspecieGuard — GUARDA confusión de especie/familia botánica (chagra-pro #292)', () => {
+    const CONFUSION_HIT = {
+      has_confusion: true,
+      species_mentioned: 'limoncillo',
+      species_id: 'cymbopogon_citratus',
+      species_nombre_cientifico: 'Cymbopogon citratus',
+      species_familia_botanica: 'Poaceae',
+      confusion_source: 'anti_confusion_curado',
+      lookalike_nombre_comun: null,
+      lookalike_nombre_cientifico: null,
+      lookalike_familia_botanica: null,
+      system_prompt_block:
+        '[GUARD CONFUSIÓN DE ESPECIE — RIESGO DE FAMILIA/TAXONOMÍA EQUIVOCADA · innegociable]\n' +
+        '"limoncillo" (Cymbopogon citratus) pertenece REALMENTE a la familia Poaceae.',
+      reason: 'confusion_curada_catalogo',
+    };
+
+    const NO_CONFUSION = {
+      has_confusion: false,
+      species_mentioned: null,
+      species_id: null,
+      species_nombre_cientifico: null,
+      species_familia_botanica: null,
+      confusion_source: null,
+      lookalike_nombre_comun: null,
+      lookalike_nombre_cientifico: null,
+      lookalike_familia_botanica: null,
+      system_prompt_block: '',
+      reason: 'sin_especie_mencionada',
+    };
+
+    it('mensaje con especie de riesgo de confusión curado → inyecta el system_prompt_block del sidecar', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, CONFUSION_HIT));
+      const { confusionEspecieGuard } = await importFresh();
+      const res = await confusionEspecieGuard('¿el limoncillo es lo mismo que la citronela?');
+      expect(res).not.toBeNull();
+      expect(res.has_confusion).toBe(true);
+      expect(res.system_prompt_block).toContain('RIESGO DE FAMILIA/TAXONOMÍA EQUIVOCADA');
+      expect(res.species_familia_botanica).toBe('Poaceae');
+      // POST con user_message a /confusion-especie-guard (mismo contrato que /piso-termico-guard).
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/confusion-especie-guard');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token-123');
+      expect(JSON.parse(opts.body)).toEqual({ user_message: '¿el limoncillo es lo mismo que la citronela?' });
+    });
+
+    it('mensaje SIN riesgo de confusión → has_confusion false + bloque vacío (no se inyecta nada)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, NO_CONFUSION));
+      const { confusionEspecieGuard } = await importFresh();
+      const res = await confusionEspecieGuard('¿a cómo está la papa?');
+      expect(res).not.toBeNull();
+      expect(res.has_confusion).toBe(false);
+      expect(res.system_prompt_block).toBe('');
+    });
+
+    it('normaliza un body parcial del sidecar a la forma contractual (defensivo)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { has_confusion: true, system_prompt_block: 'X' }));
+      const { confusionEspecieGuard } = await importFresh();
+      const res = await confusionEspecieGuard('cómo siembro limoncillo');
+      expect(res.has_confusion).toBe(true);
+      expect(res.system_prompt_block).toBe('X');
+      expect(res.species_id).toBeNull();
+      expect(res.lookalike_nombre_comun).toBeNull();
+      expect(res.reason).toBe('');
+    });
+
+    it('devuelve null sin fetch cuando flag off (degradación graceful)', async () => {
+      disableFlag();
+      const { confusionEspecieGuard } = await importFresh();
+      const res = await confusionEspecieGuard('cómo siembro limoncillo');
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando offline', async () => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+      const { confusionEspecieGuard } = await importFresh();
+      const res = await confusionEspecieGuard('cómo siembro limoncillo');
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando userMessage vacío/no-string', async () => {
+      const { confusionEspecieGuard } = await importFresh();
+      expect(await confusionEspecieGuard('')).toBeNull();
+      expect(await confusionEspecieGuard(null)).toBeNull();
+      expect(await confusionEspecieGuard(undefined)).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('5xx → null sin throw (sidecar caído, FAIL-SAFE: no rompe el turno ni fabrica datos)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(503, { error: 'age down' }));
+      const { confusionEspecieGuard } = await importFresh();
+      const res = await confusionEspecieGuard('cómo siembro limoncillo');
+      expect(res).toBeNull();
+    });
+
+    it('fetch throws → null sin throw', async () => {
+      fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const { confusionEspecieGuard } = await importFresh();
+      const res = await confusionEspecieGuard('cómo siembro limoncillo');
+      expect(res).toBeNull();
+    });
+  });
+
+  describe('pestVsDiseaseGuard — GUARDA confusión plaga vs enfermedad (chagra-pro #293)', () => {
+    const CLASSIFICATION_HIT = {
+      has_classification: true,
+      term_mentioned: 'Hypothenemus hampei (broca)',
+      term_categoria: 'plaga',
+      species_id: 'coffea_arabica',
+      species_nombre_comun: 'Café caturra',
+      heuristica_categoria: 'plaga',
+      source: 'catalogo_confirmado_por_heuristica',
+      manejo_equivocado_detectado: true,
+      system_prompt_block:
+        '[GUARD PLAGA VS ENFERMEDAD — CLASIFICACIÓN VERIFICADA · innegociable]\n' +
+        '"Hypothenemus hampei (broca)" (en el cultivo de Café caturra) ES PLAGA.',
+      reason: 'clasificacion_confirmada_manejo_equivocado_detectado',
+    };
+
+    const NO_CLASSIFICATION = {
+      has_classification: false,
+      term_mentioned: null,
+      term_categoria: null,
+      species_id: null,
+      species_nombre_comun: null,
+      heuristica_categoria: null,
+      source: null,
+      manejo_equivocado_detectado: false,
+      system_prompt_block: '',
+      reason: 'sin_termino_mencionado',
+    };
+
+    it('mensaje con término clasificado (catálogo+heurística coinciden) → inyecta el system_prompt_block del sidecar', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, CLASSIFICATION_HIT));
+      const { pestVsDiseaseGuard } = await importFresh();
+      const res = await pestVsDiseaseGuard('¿qué fungicida uso para la broca del café?');
+      expect(res).not.toBeNull();
+      expect(res.has_classification).toBe(true);
+      expect(res.system_prompt_block).toContain('CLASIFICACIÓN VERIFICADA');
+      expect(res.term_categoria).toBe('plaga');
+      expect(res.manejo_equivocado_detectado).toBe(true);
+      // POST con user_message a /pest-vs-disease-guard (mismo contrato que /confusion-especie-guard).
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/pest-vs-disease-guard');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token-123');
+      expect(JSON.parse(opts.body)).toEqual({ user_message: '¿qué fungicida uso para la broca del café?' });
+    });
+
+    it('mensaje SIN término clasificado (o desacuerdo catálogo↔heurística) → has_classification false + bloque vacío', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, NO_CLASSIFICATION));
+      const { pestVsDiseaseGuard } = await importFresh();
+      const res = await pestVsDiseaseGuard('¿a cómo está la papa?');
+      expect(res).not.toBeNull();
+      expect(res.has_classification).toBe(false);
+      expect(res.system_prompt_block).toBe('');
+    });
+
+    it('normaliza un body parcial del sidecar a la forma contractual (defensivo)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { has_classification: true, system_prompt_block: 'X' }));
+      const { pestVsDiseaseGuard } = await importFresh();
+      const res = await pestVsDiseaseGuard('el trozador es plaga o enfermedad');
+      expect(res.has_classification).toBe(true);
+      expect(res.system_prompt_block).toBe('X');
+      expect(res.species_id).toBeNull();
+      expect(res.manejo_equivocado_detectado).toBe(false);
+      expect(res.reason).toBe('');
+    });
+
+    it('devuelve null sin fetch cuando flag off (degradación graceful)', async () => {
+      disableFlag();
+      const { pestVsDiseaseGuard } = await importFresh();
+      const res = await pestVsDiseaseGuard('el trozador es plaga o enfermedad');
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando offline', async () => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+      const { pestVsDiseaseGuard } = await importFresh();
+      const res = await pestVsDiseaseGuard('el trozador es plaga o enfermedad');
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando userMessage vacío/no-string', async () => {
+      const { pestVsDiseaseGuard } = await importFresh();
+      expect(await pestVsDiseaseGuard('')).toBeNull();
+      expect(await pestVsDiseaseGuard(null)).toBeNull();
+      expect(await pestVsDiseaseGuard(undefined)).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('5xx → null sin throw (sidecar caído, FAIL-SAFE: no rompe el turno ni fabrica datos)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(503, { error: 'age down' }));
+      const { pestVsDiseaseGuard } = await importFresh();
+      const res = await pestVsDiseaseGuard('el trozador es plaga o enfermedad');
+      expect(res).toBeNull();
+    });
+
+    it('fetch throws → null sin throw', async () => {
+      fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const { pestVsDiseaseGuard } = await importFresh();
+      const res = await pestVsDiseaseGuard('el trozador es plaga o enfermedad');
+      expect(res).toBeNull();
+    });
+  });
 });
 
 describe('sidecarClient — getClimaSnapshot elevation (gradiente térmico)', () => {

--- a/src/services/promptAssembler.js
+++ b/src/services/promptAssembler.js
@@ -98,6 +98,8 @@ export const BLOCK_ORDER = [
   'fermento', // GUARDA DR-FOOD-3 (protegido, máxima recency)
   'biopreparado', // GROUNDING biopreparados chagra-pro #248 (protegido, máxima recency — anti-negación)
   'pisoTermico', // GUARDA desajuste de piso térmico chagra-pro #288 (protegido, ÚLTIMA — cross_thermal, SUPRESIÓN-Y-REEMPLAZO)
+  'confusionEspecie', // GUARDA confusión de especie/familia botánica chagra-pro #292 (protegido, máxima recency — confusion_especie, SUPRESIÓN-Y-REEMPLAZO)
+  'pestVsDisease', // GUARDA confusión plaga vs enfermedad chagra-pro #293 (protegido, máxima recency — pest_vs_disease, SUPRESIÓN-Y-REEMPLAZO)
 ];
 
 /**

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -615,6 +615,108 @@ export async function pisoTermicoGuard(userMessage, opts = {}) {
 }
 
 /**
+ * GUARDA de CONFUSIÓN DE ESPECIE / familia botánica equivocada (chagra-pro
+ * #292, determinista, PRE-LLM — segundo driver de contaminación
+ * cross-domain, sonda `confusion_especie` de `bench-contaminacion.mjs`,
+ * ~20% medida 2026-07, el driver siguiente tras `cross_thermal` que
+ * `/piso-termico-guard` bajó de 86.7% a 6.7%). Llama `POST
+ * ${BASE}/confusion-especie-guard` con `{ user_message }` para que el
+ * sidecar detecte si el mensaje menciona una especie del catálogo con (a)
+ * advertencia `_anti_confusion` curada, o (b) otra especie de nombre
+ * parecido pero familia botánica DISTINTA (riesgo algorítmico) y, si aplica,
+ * devuelva un `system_prompt_block` de SUPRESIÓN-Y-REEMPLAZO: el LLM debe
+ * citar la familia REAL primero y no mezclar datos de la especie parecida.
+ *
+ * Espejo exacto de `pisoTermicoGuard`/`biopreparadoGrounding`: FAIL-SAFE,
+ * no-throw. Devuelve null si: flag off, offline, timeout, non-2xx, body
+ * inválido → el caller degrada con gracia (no inyecta bloque, no rompe el
+ * turno). Cuando `has_confusion` es false, NO hay que inyectar nada.
+ *
+ * @param {string} userMessage — texto del operador.
+ * @returns {Promise<null | {
+ *   has_confusion: boolean,
+ *   species_mentioned: string | null,
+ *   species_id: string | null,
+ *   species_nombre_cientifico: string | null,
+ *   species_familia_botanica: string | null,
+ *   confusion_source: string | null,
+ *   lookalike_nombre_comun: string | null,
+ *   lookalike_nombre_cientifico: string | null,
+ *   lookalike_familia_botanica: string | null,
+ *   system_prompt_block: string,
+ *   reason: string,
+ * }>}
+ */
+export async function confusionEspecieGuard(userMessage) {
+  if (!userMessage || typeof userMessage !== 'string') return null;
+  const raw = await postJson('/confusion-especie-guard', { user_message: userMessage }, NLU_TIMEOUT_MS);
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    has_confusion: raw.has_confusion === true,
+    species_mentioned: typeof raw.species_mentioned === 'string' ? raw.species_mentioned : null,
+    species_id: typeof raw.species_id === 'string' ? raw.species_id : null,
+    species_nombre_cientifico: typeof raw.species_nombre_cientifico === 'string' ? raw.species_nombre_cientifico : null,
+    species_familia_botanica: typeof raw.species_familia_botanica === 'string' ? raw.species_familia_botanica : null,
+    confusion_source: typeof raw.confusion_source === 'string' ? raw.confusion_source : null,
+    lookalike_nombre_comun: typeof raw.lookalike_nombre_comun === 'string' ? raw.lookalike_nombre_comun : null,
+    lookalike_nombre_cientifico: typeof raw.lookalike_nombre_cientifico === 'string' ? raw.lookalike_nombre_cientifico : null,
+    lookalike_familia_botanica: typeof raw.lookalike_familia_botanica === 'string' ? raw.lookalike_familia_botanica : null,
+    system_prompt_block: typeof raw.system_prompt_block === 'string' ? raw.system_prompt_block : '',
+    reason: typeof raw.reason === 'string' ? raw.reason : '',
+  };
+}
+
+/**
+ * GUARDA de confusión PLAGA VS ENFERMEDAD (chagra-pro #293, determinista,
+ * PRE-LLM — tercer driver de contaminación cross-domain, sonda
+ * `pest_vs_disease` de `bench-contaminacion.mjs`). Llama `POST
+ * ${BASE}/pest-vs-disease-guard` con `{ user_message }` para que el sidecar
+ * detecte si el mensaje menciona un término de `plagas_criticas`/
+ * `enfermedades_criticas` del catálogo Y la categoría del catálogo NO es
+ * contradicha por la heurística léxica/taxonómica; si `has_classification`,
+ * devuelve un `system_prompt_block` de SUPRESIÓN-Y-REEMPLAZO: el LLM debe
+ * afirmar la categoría REAL primero y recomendar el TIPO de manejo correcto
+ * (nunca fungicida para un insecto ni insecticida para un hongo/bacteria).
+ *
+ * Espejo exacto de `confusionEspecieGuard`/`pisoTermicoGuard`: FAIL-SAFE,
+ * no-throw. Devuelve null si: flag off, offline, timeout, non-2xx, body
+ * inválido → el caller degrada con gracia. Cuando `has_classification` es
+ * false (incluye el caso de desacuerdo catálogo↔heurística, fail-safe a
+ * propósito), NO hay que inyectar nada.
+ *
+ * @param {string} userMessage — texto del operador.
+ * @returns {Promise<null | {
+ *   has_classification: boolean,
+ *   term_mentioned: string | null,
+ *   term_categoria: string | null,
+ *   species_id: string | null,
+ *   species_nombre_comun: string | null,
+ *   heuristica_categoria: string | null,
+ *   source: string | null,
+ *   manejo_equivocado_detectado: boolean,
+ *   system_prompt_block: string,
+ *   reason: string,
+ * }>}
+ */
+export async function pestVsDiseaseGuard(userMessage) {
+  if (!userMessage || typeof userMessage !== 'string') return null;
+  const raw = await postJson('/pest-vs-disease-guard', { user_message: userMessage }, NLU_TIMEOUT_MS);
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    has_classification: raw.has_classification === true,
+    term_mentioned: typeof raw.term_mentioned === 'string' ? raw.term_mentioned : null,
+    term_categoria: typeof raw.term_categoria === 'string' ? raw.term_categoria : null,
+    species_id: typeof raw.species_id === 'string' ? raw.species_id : null,
+    species_nombre_comun: typeof raw.species_nombre_comun === 'string' ? raw.species_nombre_comun : null,
+    heuristica_categoria: typeof raw.heuristica_categoria === 'string' ? raw.heuristica_categoria : null,
+    source: typeof raw.source === 'string' ? raw.source : null,
+    manejo_equivocado_detectado: raw.manejo_equivocado_detectado === true,
+    system_prompt_block: typeof raw.system_prompt_block === 'string' ? raw.system_prompt_block : '',
+    reason: typeof raw.reason === 'string' ? raw.reason : '',
+  };
+}
+
+/**
  * Capa 2 anti-alucinación (cross-check de contexto). Llama
  * `POST ${BASE}/post-validate` con el TEXTO que el LLM ya generó y, opcional,
  * los `nombre_cientifico` de las entidades que la capa 1 resolvió para el turno


### PR DESCRIPTION
Completa el TRÍO de guards deterministas PRE-LLM del bench de contaminación,
cableando los dos hermanos de `cross_thermal` (`/piso-termico-guard` #288/#2067,
ya en prod) al pipeline REAL del chat + al bench honesto.

## Contexto

Los endpoints deterministas ya existían y estaban desplegados en el sidecar
agro-mcp (alpha), pero el PWA **no los consumía**:

- **`/confusion-especie-guard`** (chagra-pro #292) — sonda `confusion_especie`.
- **`/pest-vs-disease-guard`** (chagra-pro #293) — sonda `pest_vs_disease`.

Este PR replica EXACTAMENTE el patrón de wiring de `pisoTermicoGuard` (#2067):
wrapper fail-safe en `sidecarClient.js` → `Promise.all` en `AgentScreen.jsx` →
bloque protegido en `promptAssembler.js` → llamada al mismo endpoint en las
sondas del bench (`bench-contaminacion.mjs`).

## Cambios

- **`src/services/sidecarClient.js`** — wrappers `confusionEspecieGuard()` y
  `pestVsDiseaseGuard()`, espejo de `pisoTermicoGuard`: FAIL-SAFE, no-throw,
  `null` en flag-off/offline/timeout/5xx/body-inválido.
- **`src/components/AgentScreen/AgentScreen.jsx`** — ambos corren en el MISMO
  `Promise.all` que `resolveEntities`/`fermento`/`biopreparado`/`pisoTermico`
  (cero latencia serial). Si disparan, inyectan su `system_prompt_block` de
  SUPRESIÓN-Y-REEMPLAZO con recency máxima.
- **`src/services/promptAssembler.js`** — bloques protegidos `confusionEspecie`
  y `pestVsDisease` al final de `BLOCK_ORDER` (nunca sacrificables).
- **`scripts/bench-contaminacion.mjs`** — el bench llama los MISMOS endpoints
  en `runProbeAgainstAgent` + `buildEnrichedSystemPrompt`, para medir el
  pipeline REAL de prod (evita gaming del número).

## Bench (69 sondas, granite3.3:8b, juez claude-code -p — corrida 2026-07-05)

Guards SÍ disparan en el pipeline real: `confusion_especie_guard_fired` 24/69,
`pest_vs_disease_guard_fired` 15/69.

| Sonda | Baseline (pre-wiring) | Con wiring | Delta |
|---|---:|---:|---:|
| **confusion_especie** | ~14.3–19% | **0%** (0/20) | ✅ −14 a −19 pp |
| **pest_vs_disease** | 33.3% | **5%** (1/20) | ✅ −28.3 pp |
| Global | — | 11.5% (7/61) | — |

El único `pest_vs_disease` restante (roya del café): el guard disparó pero el
modelo cerró llamando "esta plaga" a una enfermedad fúngica — residual del LLM,
no del guard. `cross_thermal` (33.3% en esta corrida) queda fuera de alcance de
estos 2 guards: la contaminación restante ahí es por especies-acompañantes
fabricadas ("asocio"), no por desajuste de viabilidad (varianza no
determinística documentada del bench-borde).

## Verificación

- Sidecar en alpha reconstruido (`tsc` verde) + reiniciado con los **3 guards
  vivos**; `/piso-termico-guard`, `/confusion-especie-guard` y
  `/pest-vs-disease-guard` responden 200 (auth `X-Chagra-Token`).
- `npm run build` verde. Tests: **171 pasan** en los 4 archivos tocados
  (`sidecarClient` +22, `promptAssembler` +2, `bench-contaminacion` +7,
  `AgentScreen` mock actualizado).
- Degradación graceful en TODOS los caminos: endpoint caído/flag-off/offline →
  no-op, nunca rompe el turno ni fabrica una categoría/familia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
