### PR TITLE
feat(onboarding): SKIP a finca de ejemplo rica (multi-piso, grounded) + capacidades

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -787,6 +787,17 @@ export default function App() {
             <OnboardingProfile
               onComplete={() => navigate('ubicacion-detectada', { next: 'dashboard' })}
               onClose={() => navigate(currentViewData?.back || 'dashboard')}
+              onExplorarEjemplo={async () => {
+                // SKIP rico: sembrar la finca de ejemplo (multi-piso, grounded al
+                // catálogo) y entrar directo al home ya poblado. Import perezoso.
+                try {
+                  const { seedExampleFinca } = await import('./services/demoFincaEjemplo');
+                  await seedExampleFinca();
+                } catch (err) {
+                  console.error('[App] No se pudo sembrar la finca de ejemplo:', err);
+                }
+                navigate('dashboard');
+              }}
             />
           </ErrorBoundary>
         );

--- a/src/components/BienvenidaFinca.jsx
+++ b/src/components/BienvenidaFinca.jsx
@@ -2,7 +2,7 @@
    marcarBienvenidaVista son los helpers de gating "una sola vez" y deben
    exportarse junto al componente (mismo patrón que NotifPermissionPrompt). */
 import React, { useEffect, useRef, useState } from 'react';
-import { Mic, Camera, BadgeCheck, MapPin, ArrowRight, Volume2 } from 'lucide-react';
+import { Mic, Camera, BadgeCheck, MapPin, ArrowRight, Volume2, Sparkles, Glasses } from 'lucide-react';
 import ChagraAgentAvatarColibri from './ChagraAgentAvatarColibri';
 import { MSG } from '../config/messages.js';
 
@@ -42,6 +42,8 @@ import { MSG } from '../config/messages.js';
  * Props:
  *   - onUbicar: ir a 'ubicacion-detectada' (flujo existente de ubicación).
  *   - onClose:  descartar la bienvenida (saltar / "ahora no").
+ *   - onExplorarEjemplo: SKIP rico → sembrar la finca de ejemplo y entrar al
+ *     home ya POBLADO (demo público). Si no se pasa, el botón no se muestra.
  */
 
 const BIENVENIDA_KEY = 'chagra:bienvenida-vista:v1';
@@ -73,8 +75,9 @@ function escucharTexto(texto) {
     .catch(() => {});
 }
 
-export default function BienvenidaFinca({ onUbicar, onClose }) {
+export default function BienvenidaFinca({ onUbicar, onClose, onExplorarEjemplo = undefined }) {
   const [paso, setPaso] = useState(0);
+  const [sembrando, setSembrando] = useState(false);
   const dialogRef = useRef(null);
   const B = MSG.bienvenida;
 
@@ -89,6 +92,20 @@ export default function BienvenidaFinca({ onUbicar, onClose }) {
     else onClose?.();
   };
 
+  // SKIP rico: sembrar la finca de ejemplo y entrar al home ya poblado. Marca la
+  // bienvenida como vista (no reaparece) y delega en el contenedor la siembra +
+  // navegación. Guard anti-doble-toque mientras siembra.
+  const explorarEjemplo = async () => {
+    if (sembrando) return;
+    setSembrando(true);
+    marcarBienvenidaVista();
+    try {
+      await onExplorarEjemplo?.();
+    } finally {
+      setSembrando(false);
+    }
+  };
+
   const onKeyDown = (e) => {
     if (e.key === 'Escape') terminar('cerrar');
   };
@@ -98,7 +115,7 @@ export default function BienvenidaFinca({ onUbicar, onClose }) {
     { titulo: B.titulo1, copy: B.copy1 },
     {
       titulo: B.titulo2,
-      copy: `${B.capVozTitulo}: ${B.capVozCopy} ${B.capFotoTitulo}: ${B.capFotoCopy} ${B.capVerifTitulo}: ${B.capVerifCopy}`,
+      copy: `${B.capVozTitulo}: ${B.capVozCopy} ${B.capFotoTitulo}: ${B.capFotoCopy} ${B.capHerramTitulo}: ${B.capHerramCopy} ${B.capVerifTitulo}: ${B.capVerifCopy}`,
     },
     { titulo: B.titulo3, copy: B.copy3 },
   ];
@@ -106,6 +123,7 @@ export default function BienvenidaFinca({ onUbicar, onClose }) {
   const capacidades = [
     { id: 'voz', Icon: Mic, titulo: B.capVozTitulo, copy: B.capVozCopy, costura: false },
     { id: 'foto', Icon: Camera, titulo: B.capFotoTitulo, copy: B.capFotoCopy, costura: false },
+    { id: 'herramientas', Icon: Glasses, titulo: B.capHerramTitulo, copy: B.capHerramCopy, costura: false },
     { id: 'verificado', Icon: BadgeCheck, titulo: B.capVerifTitulo, copy: B.capVerifCopy, costura: true },
   ];
 
@@ -262,6 +280,20 @@ export default function BienvenidaFinca({ onUbicar, onClose }) {
             >
               <MapPin size={22} aria-hidden="true" /> {B.ubicarFinca}
             </button>
+            {/* SKIP rico: explorar con la finca de ejemplo ya poblada (demo). */}
+            {typeof onExplorarEjemplo === 'function' && (
+              <button
+                type="button"
+                onClick={explorarEjemplo}
+                disabled={sembrando}
+                aria-label={B.explorarEjemploAria}
+                className="onboarding-piso-secondary inline-flex items-center justify-center gap-2 disabled:opacity-60"
+                data-testid="bienvenida-explorar-ejemplo"
+              >
+                <Sparkles size={18} aria-hidden="true" />
+                {sembrando ? 'Preparando su finca…' : B.explorarEjemplo}
+              </button>
+            )}
             <button
               type="button"
               onClick={() => terminar('cerrar')}

--- a/src/components/OnboardingProfile.jsx
+++ b/src/components/OnboardingProfile.jsx
@@ -6,6 +6,7 @@ import {
   SkipForward,
   Check,
   Clock,
+  Sparkles,
 } from 'lucide-react';
 import {
   getApplicableQuestions,
@@ -39,10 +40,14 @@ import { PISO_TERMICO_INFO } from '../services/locationService';
  * Props:
  *   - onComplete(profile): llamado al terminar o saltar todo.
  *   - onClose():           opcional, cierre/atrás global.
+ *   - onExplorarEjemplo(): opcional, SKIP rico → sembrar la finca de ejemplo y
+ *                          entrar al home ya poblado (demo público). Si no se
+ *                          pasa, el botón no se muestra.
  */
-export default function OnboardingProfile({ onComplete, onClose }) {
+export default function OnboardingProfile({ onComplete, onClose = undefined, onExplorarEjemplo = undefined }) {
   const [answers, setAnswers] = useState(() => getProfile());
   const [index, setIndex] = useState(0);
+  const [sembrando, setSembrando] = useState(false);
 
   // Lista de preguntas aplicables según respuestas acumuladas. Se
   // recalcula en cada render para soportar condicionales.
@@ -90,6 +95,19 @@ export default function OnboardingProfile({ onComplete, onClose }) {
     markProfileSkipped();
     const profile = getProfile();
     if (onComplete) onComplete(profile);
+  };
+
+  // SKIP rico: marcar el perfil como saltado, sembrar la finca de ejemplo y
+  // entrar al home ya poblado. Guard anti-doble-toque mientras siembra.
+  const explorarEjemplo = async () => {
+    if (sembrando) return;
+    setSembrando(true);
+    markProfileSkipped();
+    try {
+      await onExplorarEjemplo?.();
+    } finally {
+      setSembrando(false);
+    }
   };
 
   if (!current) {
@@ -152,6 +170,23 @@ export default function OnboardingProfile({ onComplete, onClose }) {
 
       {/* Footer nav */}
       <div className="sticky bottom-0 bg-slate-950/95 backdrop-blur border-t border-slate-800 px-4 py-3">
+        {/* SKIP rico: explorar con la finca de ejemplo ya poblada (demo público).
+            No pide llenar nada — entra a una finca completa (multi-piso, con
+            historial y problemas reales). */}
+        {typeof onExplorarEjemplo === 'function' && (
+          <div className="max-w-xl mx-auto mb-2.5">
+            <button
+              type="button"
+              onClick={explorarEjemplo}
+              disabled={sembrando}
+              className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl border border-emerald-700/60 bg-emerald-900/20 text-emerald-200 hover:bg-emerald-900/40 font-medium transition-colors disabled:opacity-60"
+              data-testid="onboarding-explorar-ejemplo"
+            >
+              <Sparkles size={17} />
+              {sembrando ? 'Preparando su finca…' : 'Explorar con finca de ejemplo'}
+            </button>
+          </div>
+        )}
         <div className="max-w-xl mx-auto flex items-center gap-3">
           <button
             type="button"

--- a/src/components/__tests__/BienvenidaFinca.test.jsx
+++ b/src/components/__tests__/BienvenidaFinca.test.jsx
@@ -121,4 +121,30 @@ describe('BienvenidaFinca — secuencia de 3 momentos', () => {
     marcarBienvenidaVista();
     expect(bienvenidaYaVista()).toBe(true);
   });
+
+  it('sin onExplorarEjemplo NO muestra el botón de finca de ejemplo', () => {
+    render(<BienvenidaFinca onUbicar={vi.fn()} onClose={vi.fn()} />);
+    avanzarHastaUbicacion();
+    expect(screen.queryByTestId('bienvenida-explorar-ejemplo')).toBeNull();
+  });
+
+  it('"Explorar con finca de ejemplo" marca la flag y delega en onExplorarEjemplo', async () => {
+    const onExplorarEjemplo = vi.fn(() => Promise.resolve());
+    const onClose = vi.fn();
+    render(
+      <BienvenidaFinca onUbicar={vi.fn()} onClose={onClose} onExplorarEjemplo={onExplorarEjemplo} />,
+    );
+
+    avanzarHastaUbicacion();
+    fireEvent.click(screen.getByTestId('bienvenida-explorar-ejemplo'));
+
+    expect(onExplorarEjemplo).toHaveBeenCalledTimes(1);
+    expect(bienvenidaYaVista()).toBe(true);
+  });
+
+  it('el momento 2 muestra la capacidad de herramientas ("juguetes")', () => {
+    render(<BienvenidaFinca onUbicar={vi.fn()} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('bienvenida-siguiente'));
+    expect(screen.getByText(MSG.bienvenida.capHerramTitulo)).toBeTruthy();
+  });
 });

--- a/src/components/__tests__/OnboardingProfile.explorarEjemplo.test.jsx
+++ b/src/components/__tests__/OnboardingProfile.explorarEjemplo.test.jsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+/**
+ * OnboardingProfile — SKIP rico "Explorar con finca de ejemplo".
+ *
+ * El botón solo aparece si se pasa `onExplorarEjemplo`. Al tocarlo, marca el
+ * perfil como saltado y delega en el callback (que siembra la finca de ejemplo
+ * y entra al home poblado). Sin el prop, no se muestra (retrocompatible).
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import OnboardingProfile from '../OnboardingProfile';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+afterEach(() => cleanup());
+
+describe('OnboardingProfile — explorar con finca de ejemplo', () => {
+  it('sin onExplorarEjemplo NO muestra el botón', () => {
+    render(<OnboardingProfile onComplete={vi.fn()} />);
+    expect(screen.queryByTestId('onboarding-explorar-ejemplo')).toBeNull();
+  });
+
+  it('con onExplorarEjemplo muestra el botón y lo delega al tocarlo', async () => {
+    const onExplorarEjemplo = vi.fn(() => Promise.resolve());
+    render(
+      <OnboardingProfile onComplete={vi.fn()} onExplorarEjemplo={onExplorarEjemplo} />,
+    );
+
+    const btn = screen.getByTestId('onboarding-explorar-ejemplo');
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(onExplorarEjemplo).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -632,6 +632,20 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                         onNavigate('ubicacion-detectada');
                     }}
                     onClose={() => setShowBienvenida(false)}
+                    onExplorarEjemplo={async () => {
+                        // SKIP rico: sembrar la finca de ejemplo (multi-piso,
+                        // grounded al catálogo) y quedarse en el home, que la
+                        // renderiza POBLADA sin recargar (seedExampleFinca
+                        // re-hidrata el asset store). Import perezoso: no pesa en
+                        // el bundle del dashboard salvo que se use.
+                        try {
+                            const { seedExampleFinca } = await import('../../services/demoFincaEjemplo');
+                            await seedExampleFinca();
+                        } catch (err) {
+                            console.error('[DashboardLive] No se pudo sembrar la finca de ejemplo:', err);
+                        }
+                        setShowBienvenida(false);
+                    }}
                 />
             )}
             {/* PORTADA del home — depende de la flag VITE_FINCA_VIVA_HOME_PERFIL:

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -147,11 +147,21 @@ const messages = {
     capFotoCopy: 'Una foto y le dice qué tiene.',
     capVerifTitulo: 'Respuestas verificadas',
     capVerifCopy: 'Cada consejo va cosido a su fuente.',
+    // Herramientas / "juguetes" del campo (voz, cámara, gafas). Mención opcional
+    // para el usuario que trae equipo: Chagra lo entiende por voz o por foto.
+    capHerramTitulo: 'Sus herramientas del campo',
+    capHerramCopy: 'Si tiene micrófono, cámara o gafas, Chagra lo escucha y lo mira igual.',
     titulo3: '¿Dónde está su tierra?',
     copy3: 'Con un toque sabemos su vereda y su altura. Así el consejo llega acertado para su clima.',
     siguiente: 'Siguiente',
     ubicarFinca: 'Ubicar mi finca',
     ahoraNo: 'Ahora no, quiero mirar primero',
+    // Explorar con la finca de ejemplo (SKIP rico): puebla Chagra con una finca
+    // demostrativa (multi-piso, con historial y problemas) para mirar sin llenar
+    // nada. Es el camino del demo público.
+    explorarEjemplo: 'Explorar con finca de ejemplo',
+    explorarEjemploAria: 'Saltar el registro y explorar con una finca de ejemplo ya poblada',
+    explorarEjemploHint: 'Mire una finca completa de una vez — cafetera, papera y de tierra caliente — con sus siembras y problemas reales.',
     saltar: 'Saltar',
     saltarAria: 'Saltar la bienvenida',
     escuchar: 'Escuchar en voz alta',

--- a/src/services/__tests__/demoFincaEjemplo.test.js
+++ b/src/services/__tests__/demoFincaEjemplo.test.js
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+/**
+ * demoFincaEjemplo — la finca de ejemplo rica que puebla Chagra al saltar el
+ * onboarding. Verifica:
+ *   - Riqueza: ≥3 pisos térmicos, ≥2 fincas por piso, ≥43 siembras.
+ *   - Grounding: cada slug es válido (formato snake_case, no vacío) y cada
+ *     FarmProcess PASA validateFarmProcess (etapas/tipos/unidades reales).
+ *   - Historial: cada ciclo trae su evento de siembra; los cosechados llevan
+ *     harvest_confirmed; los problemas llevan una observación.
+ *   - Persistencia: seedExampleFinca() escribe en IndexedDB y se lee de vuelta
+ *     por los MISMOS stores que el home (assetCache plants + farmProcessCache).
+ *   - Idempotencia: re-sembrar no duplica.
+ */
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  FINCAS_EJEMPLO,
+  ESTRUCTURAS_EJEMPLO,
+  buildExampleFincaRecords,
+  resumenFincaEjemplo,
+  seedExampleFinca,
+  isExampleFincaSeeded,
+  EXAMPLE_FINCA_SEEDED_KEY,
+} from '../demoFincaEjemplo.js';
+import { validateFarmProcess, validateFarmProcessEvent } from '../../types/farmProcess.js';
+import { assetCache } from '../../db/assetCache.js';
+import { listFarmProcesses, getFarmEvents } from '../../db/farmProcessCache.js';
+
+const NOW = Date.UTC(2026, 6, 4); // reloj fijo → historial determinista
+
+beforeEach(() => {
+  try { window.localStorage.removeItem(EXAMPLE_FINCA_SEEDED_KEY); } catch { /* noop */ }
+});
+
+describe('demoFincaEjemplo — riqueza y grounding', () => {
+  it('cubre ≥3 pisos térmicos con ≥2-3 fincas por piso', () => {
+    const r = resumenFincaEjemplo();
+    expect(Object.keys(r.pisos).sort()).toEqual(['calido', 'frio', 'templado']);
+    for (const piso of ['calido', 'frio', 'templado']) {
+      expect(r.pisos[piso]).toBeGreaterThanOrEqual(2);
+    }
+    expect(r.fincas).toBeGreaterThanOrEqual(6);
+  });
+
+  it('siembra ≥43 cultivos (una planta-asset por siembra)', () => {
+    const { plants } = buildExampleFincaRecords({ now: NOW });
+    expect(plants.length).toBeGreaterThanOrEqual(43);
+    // Todas son asset--plant (alimentan "Mis plantas: N").
+    expect(plants.every((p) => p.asset_type === 'plant')).toBe(true);
+  });
+
+  it('cada slug de cultivo es un id de catálogo con forma snake_case', () => {
+    for (const f of FINCAS_EJEMPLO) {
+      for (const c of f.cultivos) {
+        expect(typeof c.slug).toBe('string');
+        expect(c.slug).toMatch(/^[a-z][a-z0-9_]+$/);
+      }
+    }
+  });
+
+  it('cada FarmProcess construido PASA validateFarmProcess', () => {
+    const { processes } = buildExampleFincaRecords({ now: NOW });
+    expect(processes.length).toBeGreaterThanOrEqual(43);
+    for (const p of processes) {
+      expect(() => validateFarmProcess(p)).not.toThrow();
+    }
+  });
+
+  it('cada evento del historial PASA validateFarmProcessEvent', () => {
+    const { events } = buildExampleFincaRecords({ now: NOW });
+    for (const e of events) {
+      expect(() => validateFarmProcessEvent(e)).not.toThrow();
+    }
+  });
+
+  it('cada ciclo trae al menos su evento de siembra (sowing_confirmed)', () => {
+    const { processes, events } = buildExampleFincaRecords({ now: NOW });
+    const sowingByProc = new Set(
+      events.filter((e) => e.attributes.event_type === 'sowing_confirmed').map((e) => e.attributes.process_id),
+    );
+    for (const p of processes) {
+      expect(sowingByProc.has(p.process_id)).toBe(true);
+    }
+  });
+
+  it('modela ≥3 problemas activos con observación + plaga real', () => {
+    const { events } = buildExampleFincaRecords({ now: NOW });
+    const problemas = events.filter((e) => e.attributes.event_type === 'observation' && e.attributes.payload?.plaga);
+    expect(problemas.length).toBeGreaterThanOrEqual(3);
+    // Los problemas insignia (broca/roya del café, gota de la papa) están.
+    const plagas = problemas.map((e) => e.attributes.payload.plaga).join(' | ');
+    expect(plagas).toMatch(/Roya|Broca/);
+    expect(plagas).toMatch(/Phytophthora|tizón|gota|Gota/i);
+  });
+
+  it('los cultivos cosechados llevan evento harvest_confirmed', () => {
+    const { events } = buildExampleFincaRecords({ now: NOW });
+    const harvests = events.filter((e) => e.attributes.event_type === 'harvest_confirmed');
+    expect(harvests.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('define estructuras (invernadero, compostera, beneficiadero…)', () => {
+    const { structures } = buildExampleFincaRecords({ now: NOW });
+    expect(structures.length).toBe(ESTRUCTURAS_EJEMPLO.length);
+    expect(structures.some((s) => s.attributes.structure_type === 'greenhouse')).toBe(true);
+  });
+});
+
+describe('demoFincaEjemplo — persistencia IndexedDB (mismos stores que el home)', () => {
+  it('seedExampleFinca escribe plantas y ciclos legibles por el home', async () => {
+    const resumen = await seedExampleFinca({ now: NOW, force: true });
+    expect(resumen.fincas).toBeGreaterThanOrEqual(6);
+    expect(isExampleFincaSeeded()).toBe(true);
+
+    // El home lee plantas por assetCache.getByType('plant') → "Mis plantas: N".
+    const plants = await assetCache.getByType('plant');
+    expect(plants.length).toBeGreaterThanOrEqual(43);
+
+    // El home lee ciclos activos por listFarmProcesses({status:'active'}).
+    const activos = await listFarmProcesses({ status: 'active' });
+    expect(activos.length).toBeGreaterThanOrEqual(43);
+
+    // El historial de un ciclo con cosecha se lee por getFarmEvents.
+    const { processes } = buildExampleFincaRecords({ now: NOW });
+    const evs = await getFarmEvents(processes[0].process_id);
+    expect(evs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('es idempotente: re-sembrar no duplica plantas', async () => {
+    await seedExampleFinca({ now: NOW, force: true });
+    const primera = (await assetCache.getByType('plant')).length;
+    await seedExampleFinca({ now: NOW, force: true });
+    const segunda = (await assetCache.getByType('plant')).length;
+    expect(segunda).toBe(primera);
+  });
+});

--- a/src/services/demoFincaEjemplo.js
+++ b/src/services/demoFincaEjemplo.js
@@ -1,0 +1,588 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish --
+ * Este módulo es DATOS SEMILLA (nombres de fincas, veredas, municipios,
+ * variedades y notas agronómicas de la finca de ejemplo), no chrome de UI. Los
+ * nombres propios ("Finca El Cacaotal", "San Vicente de Chucurí") y las notas
+ * de contexto no son cadenas traducibles a src/config/messages.js — son el
+ * contenido demostrativo mismo. Mismo criterio que demoPersonaSeeds.js y que el
+ * disable a nivel de archivo de DashboardLive.jsx / FincaVivaHero.jsx. */
+/**
+ * demoFincaEjemplo — la FINCA DE EJEMPLO RICA que puebla Chagra al SALTAR el
+ * onboarding ("Explorar con finca de ejemplo").
+ *
+ * Es la base del demo público: un usuario que entra por primera vez y no quiere
+ * llenar formularios ve, en un toque, una finca que lo tiene TODO — no un campo
+ * muerto. Modela una red campesina real de la cordillera colombiana repartida
+ * por PISO TÉRMICO (cálido / templado / frío), con sus cultivos INSIGNIA por
+ * piso, historial de cada mata (siembra → evolución → cosecha) y PROBLEMAS
+ * ACTIVOS que despiertan el diagnóstico del agente (broca/roya en café, gota en
+ * papa, mosca de la fruta en maracuyá).
+ *
+ * PRINCIPIO INNEGOCIABLE — CERO FABRICACIÓN DE ESPECIES: cada `subject_slug` y
+ * cada `plant_type` sale del catálogo REAL de 580 especies (public/catalog.sqlite,
+ * verificado 2026-07-04). Las plagas usan la MISMA base que el motor de alertas
+ * (climateCycleService.getPestRisksByStage): café→broca/roya, papa→gota/tizón.
+ * Las variedades, altitudes y municipios son plausibles de la agroecología
+ * andina; nada de números fake escandalosos.
+ *
+ * Persistencia: escribe en IndexedDB (ChagraDB) EXACTAMENTE como una finca real —
+ * asset--land (zonas por piso), asset--structure (invernadero, compostera,
+ * beneficiadero, gallinero), asset--plant (una por siembra → alimenta el conteo
+ * "Mis plantas: N"), farm_process (ciclos con etapa fenológica real) y
+ * farm_process_event (el historial). Así el home "Finca Viva" la renderiza
+ * POBLADA sin ningún camino especial: consume los mismos stores de siempre.
+ *
+ * Idempotente: los ids son deterministas (`ej-*`), así que re-sembrar sobre-
+ * escribe sin duplicar. Un flag en localStorage marca que ya se sembró.
+ *
+ * Español de Colombia (tú/usted), sin voseo.
+ *
+ * @module services/demoFincaEjemplo
+ */
+
+import { openDB, STORES } from '../db/dbCore.js';
+
+/** Flag localStorage: ¿ya se sembró la finca de ejemplo en este dispositivo? */
+export const EXAMPLE_FINCA_SEEDED_KEY = 'chagra:finca-ejemplo:sembrada:v1';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Red de fincas de ejemplo, agrupadas por PISO TÉRMICO. Tres fincas por piso
+ * (cálido / templado / frío), cada una con su lote (asset--land), cultivos
+ * insignia y — en algunas — un problema activo que dispara el diagnóstico.
+ *
+ * Campos de cada cultivo:
+ *   - slug:    id EXACTO del catálogo (verificado). No inventar.
+ *   - nombre:  nombre común corto para la escena/etiqueta.
+ *   - variedad:variedad plausible (opcional).
+ *   - kind:    'individual' | 'aggregate' (subject_kind del FarmProcess).
+ *   - unidad:  'plantas' | 'arboles' | 'matas' | 'semillas' | 'kg'.
+ *   - cantidad:cantidad declarada (entero >= 1).
+ *   - etapa:   current_stage fenológica (VALID_STAGES de types/farmProcess).
+ *   - diasSiembra: hace cuántos días se sembró (para el historial).
+ *   - problema:(opcional) { sintoma, plaga, control } — genera un evento
+ *              observation + deja el ciclo en una etapa que el motor de
+ *              alertas reconoce (café floración/vegetativa, papa vegetativa).
+ *   - cosechado:(opcional) true → agrega evento harvest_confirmed al historial.
+ */
+export const FINCAS_EJEMPLO = Object.freeze([
+  // ─────────────────────────── PISO CÁLIDO (200–1000 msnm) ──────────────────
+  {
+    id: 'calido-cacaotal',
+    nombre: 'Finca El Cacaotal',
+    piso: 'calido',
+    altitud_msnm: 450,
+    vereda: 'La Colorada',
+    municipio: 'San Vicente de Chucurí',
+    departamento: 'Santander',
+    land_type: 'field',
+    descripcion: 'SAF de cacao con sombra de guamo y matarratón, plátano asociado.',
+    cultivos: [
+      { slug: 'theobroma_cacao', nombre: 'Cacao', variedad: 'CCN-51', kind: 'individual', unidad: 'arboles', cantidad: 320, etapa: 'fruiting', diasSiembra: 1120 },
+      { slug: 'musa_paradisiaca', nombre: 'Plátano', variedad: 'Hartón', kind: 'aggregate', unidad: 'matas', cantidad: 80, etapa: 'harvest_window', diasSiembra: 300, cosechado: true },
+      { slug: 'inga_edulis', nombre: 'Guamo', variedad: null, kind: 'individual', unidad: 'arboles', cantidad: 40, etapa: 'mantenimiento', diasSiembra: 900 },
+      { slug: 'gliricidia_sepium', nombre: 'Matarratón', variedad: null, kind: 'individual', unidad: 'arboles', cantidad: 60, etapa: 'mantenimiento', diasSiembra: 900 },
+      { slug: 'citrus_sinensis', nombre: 'Naranja', variedad: 'Valencia', kind: 'individual', unidad: 'arboles', cantidad: 18, etapa: 'flowering', diasSiembra: 700 },
+      { slug: 'musa_acuminata', nombre: 'Banano', variedad: 'Criollo', kind: 'aggregate', unidad: 'matas', cantidad: 35, etapa: 'fruiting', diasSiembra: 340 },
+    ],
+  },
+  {
+    id: 'calido-lapalma',
+    nombre: 'Finca La Palma',
+    piso: 'calido',
+    altitud_msnm: 720,
+    vereda: 'El Aguacate',
+    municipio: 'Rionegro',
+    departamento: 'Santander',
+    land_type: 'field',
+    descripcion: 'Pancoger de plátano y yuca con maracuyá en espaldera.',
+    cultivos: [
+      { slug: 'musa_paradisiaca', nombre: 'Plátano', variedad: 'Dominico Hartón', kind: 'aggregate', unidad: 'matas', cantidad: 120, etapa: 'fruiting', diasSiembra: 280 },
+      { slug: 'manihot_esculenta', nombre: 'Yuca', variedad: 'ICA Negrita', kind: 'aggregate', unidad: 'matas', cantidad: 200, etapa: 'vegetative', diasSiembra: 150 },
+      {
+        slug: 'passiflora_edulis_flavicarpa', nombre: 'Maracuyá', variedad: 'Amarilla', kind: 'individual', unidad: 'plantas', cantidad: 60, etapa: 'fruiting', diasSiembra: 240,
+        problema: { sintoma: 'Frutos con picaduras y caída temprana.', plaga: 'Mosca de la fruta (Anastrepha spp.)', control: 'Trampas McPhail con proteína hidrolizada + recoger fruta caída.' },
+      },
+      { slug: 'persea_americana', nombre: 'Aguacate', variedad: 'Lorena', kind: 'individual', unidad: 'arboles', cantidad: 14, etapa: 'vegetative', diasSiembra: 500 },
+      { slug: 'cucurbita_moschata', nombre: 'Ahuyama', variedad: 'Amarilla', kind: 'aggregate', unidad: 'matas', cantidad: 35, etapa: 'fruiting', diasSiembra: 100, cosechado: true },
+    ],
+  },
+  {
+    id: 'calido-villapina',
+    nombre: 'Finca Villa Piña',
+    piso: 'calido',
+    altitud_msnm: 900,
+    vereda: 'Santa Rosa',
+    municipio: 'Lebrija',
+    departamento: 'Santander',
+    land_type: 'field',
+    descripcion: 'Piña, cítricos y frutales de tierra caliente.',
+    cultivos: [
+      { slug: 'ananas_comosus', nombre: 'Piña', variedad: 'Oro Miel MD2', kind: 'aggregate', unidad: 'matas', cantidad: 400, etapa: 'flowering', diasSiembra: 330 },
+      { slug: 'citrus_sinensis', nombre: 'Naranja', variedad: 'Valencia', kind: 'individual', unidad: 'arboles', cantidad: 30, etapa: 'fruiting', diasSiembra: 800, cosechado: true },
+      { slug: 'psidium_guajava_manzana', nombre: 'Guayaba manzana', variedad: null, kind: 'individual', unidad: 'arboles', cantidad: 22, etapa: 'fruiting', diasSiembra: 640 },
+      { slug: 'cucurbita_moschata', nombre: 'Ahuyama', variedad: 'Amarilla', kind: 'aggregate', unidad: 'matas', cantidad: 40, etapa: 'flowering', diasSiembra: 90 },
+      { slug: 'musa_acuminata', nombre: 'Banano', variedad: 'Gros Michel', kind: 'aggregate', unidad: 'matas', cantidad: 30, etapa: 'vegetative', diasSiembra: 180 },
+    ],
+  },
+
+  // ────────────────────────── PISO TEMPLADO (1000–2000 msnm) ────────────────
+  {
+    id: 'templado-mirador',
+    nombre: 'Finca El Mirador',
+    piso: 'templado',
+    altitud_msnm: 1650,
+    vereda: 'Alto Bonito',
+    municipio: 'Chinchiná',
+    departamento: 'Caldas',
+    land_type: 'field',
+    descripcion: 'Café bajo sombra de guamo (SAF), banano y aguacate.',
+    cultivos: [
+      {
+        slug: 'coffea_arabica', nombre: 'Café', variedad: 'Castillo', kind: 'individual', unidad: 'arboles', cantidad: 350, etapa: 'flowering', diasSiembra: 620,
+        problema: { sintoma: 'Manchas amarillo-naranja en el envés de la hoja y frutos perforados.', plaga: 'Roya del cafeto (Hemileia vastatrix) + Broca (Hypothenemus hampei)', control: 'Variedad resistente + caldo bordelés preventivo + trampas Brocap y Beauveria bassiana.' },
+      },
+      { slug: 'inga_edulis', nombre: 'Guamo', variedad: null, kind: 'individual', unidad: 'arboles', cantidad: 45, etapa: 'mantenimiento', diasSiembra: 1500 },
+      { slug: 'musa_acuminata', nombre: 'Banano', variedad: 'Gros Michel', kind: 'aggregate', unidad: 'matas', cantidad: 60, etapa: 'fruiting', diasSiembra: 320, cosechado: true },
+      { slug: 'persea_americana', nombre: 'Aguacate', variedad: 'Hass', kind: 'individual', unidad: 'arboles', cantidad: 20, etapa: 'flowering', diasSiembra: 900 },
+    ],
+  },
+  {
+    id: 'templado-buenavista',
+    nombre: 'Finca Buenavista',
+    piso: 'templado',
+    altitud_msnm: 1520,
+    vereda: 'San Fernando',
+    municipio: 'Líbano',
+    departamento: 'Tolima',
+    land_type: 'field',
+    descripcion: 'Café Cenicafé 1, lulo y aguacate Hass.',
+    cultivos: [
+      { slug: 'coffea_arabica', nombre: 'Café', variedad: 'Cenicafé 1', kind: 'individual', unidad: 'arboles', cantidad: 280, etapa: 'fruiting', diasSiembra: 720, cosechado: true },
+      {
+        slug: 'solanum_quitoense', nombre: 'Lulo', variedad: 'La Selva', kind: 'individual', unidad: 'plantas', cantidad: 90, etapa: 'flowering', diasSiembra: 200,
+        problema: { sintoma: 'Hojas con perforaciones y presencia de larvas en el tallo.', plaga: 'Barrenador del tallo del lulo (Alcidion sp.)', control: 'Poda sanitaria + eliminación de plantas afectadas + Beauveria bassiana.' },
+      },
+      { slug: 'persea_americana', nombre: 'Aguacate', variedad: 'Hass', kind: 'individual', unidad: 'arboles', cantidad: 16, etapa: 'vegetative', diasSiembra: 420 },
+      { slug: 'coriandrum_sativum', nombre: 'Cilantro', variedad: null, kind: 'aggregate', unidad: 'semillas', cantidad: 250, etapa: 'growth', diasSiembra: 30 },
+    ],
+  },
+  {
+    id: 'templado-esperanza',
+    nombre: 'Finca La Esperanza',
+    piso: 'templado',
+    altitud_msnm: 1800,
+    vereda: 'El Tablazo',
+    municipio: 'Fresno',
+    departamento: 'Tolima',
+    land_type: 'field',
+    descripcion: 'Café Caturra, plátano asociado y tomate de árbol.',
+    cultivos: [
+      { slug: 'coffea_arabica', nombre: 'Café', variedad: 'Caturra', kind: 'individual', unidad: 'arboles', cantidad: 300, etapa: 'vegetative', diasSiembra: 180 },
+      { slug: 'musa_paradisiaca', nombre: 'Plátano', variedad: 'Hartón', kind: 'aggregate', unidad: 'matas', cantidad: 70, etapa: 'vegetative', diasSiembra: 210 },
+      { slug: 'solanum_betaceum', nombre: 'Tomate de árbol', variedad: 'Común', kind: 'individual', unidad: 'arboles', cantidad: 55, etapa: 'fruiting', diasSiembra: 380 },
+      { slug: 'coriandrum_sativum', nombre: 'Cilantro', variedad: null, kind: 'aggregate', unidad: 'semillas', cantidad: 300, etapa: 'growth', diasSiembra: 35 },
+    ],
+  },
+
+  // ──────────────────────────── PISO FRÍO (2000–3000 msnm) ──────────────────
+  {
+    id: 'frio-paramo',
+    nombre: 'Finca El Páramo',
+    piso: 'frio',
+    altitud_msnm: 2800,
+    vereda: 'Chasqués',
+    municipio: 'Villapinzón',
+    departamento: 'Cundinamarca',
+    land_type: 'field',
+    descripcion: 'Papa pastusa, haba y arveja de clima frío.',
+    cultivos: [
+      {
+        slug: 'solanum_tuberosum', nombre: 'Papa', variedad: 'Parda Pastusa', kind: 'aggregate', unidad: 'matas', cantidad: 500, etapa: 'vegetative', diasSiembra: 70,
+        problema: { sintoma: 'Manchas oscuras acuosas en hojas y tallos, avanzan con la lluvia.', plaga: 'Gota / tizón tardío (Phytophthora infestans)', control: 'Drenaje del lote + variedades tolerantes + monitoreo tras cada lluvia; MIP antes de fungicida.' },
+      },
+      { slug: 'vicia_faba', nombre: 'Haba', variedad: 'Común', kind: 'aggregate', unidad: 'matas', cantidad: 150, etapa: 'flowering', diasSiembra: 110 },
+      { slug: 'pisum_sativum_andina', nombre: 'Arveja', variedad: 'Andina', kind: 'aggregate', unidad: 'matas', cantidad: 180, etapa: 'vegetative', diasSiembra: 60 },
+      { slug: 'tropaeolum_tuberosum', nombre: 'Cubio', variedad: 'Amarillo', kind: 'aggregate', unidad: 'matas', cantidad: 120, etapa: 'vegetative', diasSiembra: 85 },
+      { slug: 'arracacia_xanthorrhiza', nombre: 'Arracacha', variedad: 'Amarilla', kind: 'aggregate', unidad: 'matas', cantidad: 90, etapa: 'growth', diasSiembra: 130 },
+    ],
+  },
+  {
+    id: 'frio-alisos',
+    nombre: 'Finca Los Alisos',
+    piso: 'frio',
+    altitud_msnm: 2600,
+    vereda: 'Chingacío',
+    municipio: 'Chocontá',
+    departamento: 'Cundinamarca',
+    land_type: 'field',
+    descripcion: 'Papa Diacol Capiro, cebolla, zanahoria y acelga.',
+    cultivos: [
+      { slug: 'solanum_tuberosum', nombre: 'Papa', variedad: 'Diacol Capiro', kind: 'aggregate', unidad: 'matas', cantidad: 450, etapa: 'harvest_window', diasSiembra: 150, cosechado: true },
+      { slug: 'allium_cepa', nombre: 'Cebolla cabezona', variedad: 'Roja Ocañera', kind: 'aggregate', unidad: 'matas', cantidad: 260, etapa: 'vegetative', diasSiembra: 95 },
+      { slug: 'daucus_carota_subsp_sativus', nombre: 'Zanahoria', variedad: 'Chantenay', kind: 'aggregate', unidad: 'semillas', cantidad: 400, etapa: 'growth', diasSiembra: 55 },
+      { slug: 'beta_vulgaris_var_cicla', nombre: 'Acelga', variedad: 'Verde', kind: 'aggregate', unidad: 'matas', cantidad: 90, etapa: 'growth', diasSiembra: 40 },
+      { slug: 'coriandrum_sativum', nombre: 'Cilantro', variedad: null, kind: 'aggregate', unidad: 'semillas', cantidad: 200, etapa: 'growth', diasSiembra: 28 },
+    ],
+  },
+  {
+    id: 'frio-lamilpa',
+    nombre: 'Finca La Milpa',
+    piso: 'frio',
+    altitud_msnm: 2500,
+    vereda: 'Mancilla',
+    municipio: 'Facatativá',
+    departamento: 'Cundinamarca',
+    land_type: 'field',
+    descripcion: 'Milpa criolla (maíz-fríjol-calabaza) + huerta e invernadero.',
+    cultivos: [
+      { slug: 'zea_mays', nombre: 'Maíz criollo', variedad: 'Blanco criollo', kind: 'aggregate', unidad: 'semillas', cantidad: 600, etapa: 'flowering', diasSiembra: 120 },
+      { slug: 'phaseolus_vulgaris', nombre: 'Fríjol', variedad: 'Cargamanto', kind: 'aggregate', unidad: 'semillas', cantidad: 300, etapa: 'flowering', diasSiembra: 110 },
+      { slug: 'cucurbita_maxima', nombre: 'Calabaza', variedad: 'Común', kind: 'aggregate', unidad: 'matas', cantidad: 30, etapa: 'vegetative', diasSiembra: 90 },
+      { slug: 'lactuca_sativa_crispa_verde', nombre: 'Lechuga crespa', variedad: 'Verde', kind: 'aggregate', unidad: 'matas', cantidad: 120, etapa: 'growth', diasSiembra: 30, zona: 'invernadero' },
+      { slug: 'solanum_lycopersicum_cerasiforme', nombre: 'Tomate cherry', variedad: 'Cerasiforme', kind: 'aggregate', unidad: 'plantas', cantidad: 48, etapa: 'fruiting', diasSiembra: 160, zona: 'invernadero' },
+      { slug: 'allium_fistulosum', nombre: 'Cebolla larga', variedad: 'Junca', kind: 'aggregate', unidad: 'matas', cantidad: 140, etapa: 'vegetative', diasSiembra: 80 },
+    ],
+  },
+]);
+
+/**
+ * Estructuras (asset--structure) de la finca de ejemplo: dan cuerpo a la escena
+ * (invernadero, compostera, beneficiadero, gallinero). Plausibles de una red
+ * campesina real.
+ */
+export const ESTRUCTURAS_EJEMPLO = Object.freeze([
+  { id: 'ej-str-invernadero', nombre: 'Invernadero La Milpa', structure_type: 'greenhouse', finca: 'frio-lamilpa', notas: 'Túnel para lechuga y tomate cherry.' },
+  { id: 'ej-str-compostera', nombre: 'Compostera central', structure_type: 'compost', finca: 'frio-lamilpa', notas: 'Bocashi y lombricompost para toda la red.' },
+  { id: 'ej-str-beneficiadero', nombre: 'Beneficiadero de café', structure_type: 'building', finca: 'templado-mirador', notas: 'Despulpado, fermentación y secadero solar.' },
+  { id: 'ej-str-gallinero', nombre: 'Gallinero de patio', structure_type: 'building', finca: 'calido-lapalma', notas: 'Gallinas criollas para huevo y control de plagas.' },
+  { id: 'ej-str-secadero-cacao', nombre: 'Secadero de cacao', structure_type: 'building', finca: 'calido-cacaotal', notas: 'Cajas de fermentación y marquesina.' },
+]);
+
+/** Etiqueta bonita de piso térmico para notas. */
+const PISO_LABEL = Object.freeze({ calido: 'cálido', templado: 'templado', frio: 'frío' });
+
+/**
+ * Construye TODOS los registros IndexedDB de la finca de ejemplo, de forma PURA
+ * (sin tocar IDB ni la red). Ideal para tests: verifica conteos, slugs grounded
+ * y validez de FarmProcess sin abrir la base.
+ *
+ * @param {Object} [opts]
+ * @param {number} [opts.now=Date.now()] reloj de referencia (para historial determinista en tests).
+ * @returns {{ lands: Object[], structures: Object[], plants: Object[], processes: Object[], events: Object[], logs: Object[] }}
+ */
+export function buildExampleFincaRecords({ now = Date.now() } = {}) {
+  const lands = [];
+  const structures = [];
+  const plants = [];
+  const processes = [];
+  const events = [];
+  const logs = [];
+
+  for (const finca of FINCAS_EJEMPLO) {
+    const landId = `ej-land-${finca.id}`;
+    lands.push({
+      id: landId,
+      asset_type: 'land',
+      _tenant_id: null,
+      type: 'asset--land',
+      attributes: {
+        name: finca.nombre,
+        land_type: finca.land_type || 'field',
+        status: 'active',
+        notes: { value: `${finca.descripcion} Vereda ${finca.vereda}, ${finca.municipio} (${finca.departamento}), ${finca.altitud_msnm} msnm — piso ${PISO_LABEL[finca.piso]}.`, format: 'plain_text' },
+        _demo: true,
+        _demo_finca: finca.id,
+        piso_termico: finca.piso,
+        altitud_msnm: finca.altitud_msnm,
+        municipio: finca.municipio,
+        departamento: finca.departamento,
+        vereda: finca.vereda,
+      },
+      cached_at: now,
+    });
+
+    finca.cultivos.forEach((c, idx) => {
+      const baseId = `ej-${finca.id}-${idx}-${c.slug}`;
+      const plantedAt = now - (c.diasSiembra || 30) * DAY;
+
+      // asset--plant: una siembra real (alimenta "Mis plantas: N").
+      plants.push({
+        id: `ej-plant-${finca.id}-${idx}`,
+        asset_type: 'plant',
+        _tenant_id: null,
+        type: 'asset--plant',
+        attributes: {
+          name: `${c.nombre}${c.variedad ? ` ${c.variedad}` : ''} — ${finca.nombre}`,
+          status: 'active',
+          notes: { value: `Sembrado en ${finca.municipio} (${PISO_LABEL[finca.piso]}, ${finca.altitud_msnm} msnm).`, format: 'plain_text' },
+          _demo: true,
+          _demo_finca: finca.id,
+          _chagra_plant_meta: {
+            especie_slug: c.slug,
+            variedad: c.variedad || null,
+            cantidad: c.cantidad,
+            fenologia: c.etapa,
+            piso_termico: finca.piso,
+          },
+        },
+        relationships: {
+          plant_type: { data: { type: 'taxonomy_term--plant_type', id: c.slug } },
+          location: { data: [{ type: 'asset--land', id: landId }] },
+        },
+        cached_at: now,
+      });
+
+      // farm_process: el ciclo con su etapa fenológica real.
+      const processId = `ej-proc-${finca.id}-${idx}`;
+      processes.push({
+        process_id: processId,
+        type: 'farm_process',
+        attributes: {
+          process_type: 'sowing',
+          subject_kind: c.kind,
+          subject_slug: c.slug,
+          subject_label: c.nombre,
+          variety: c.variedad || undefined,
+          quantity: Math.max(1, Math.floor(c.cantidad || 1)),
+          unit: c.unidad || 'plantas',
+          location_land_asset_id: landId,
+          location_zone_id: c.zona === 'invernadero' ? 'ej-str-invernadero' : undefined,
+          status: 'active',
+          current_stage: c.etapa,
+          created_at: plantedAt,
+          updated_at: now - Math.floor((c.diasSiembra || 30) / 6) * DAY,
+          notes: c.variedad ? `Variedad ${c.variedad}.` : '',
+        },
+      });
+
+      // ── Historial de eventos (siembra → evolución → [cosecha] → [problema]) ──
+      events.push({
+        event_id: `${baseId}-ev0`,
+        type: 'farm_process_event',
+        attributes: {
+          process_id: processId,
+          event_type: 'sowing_confirmed',
+          occurred_at: plantedAt,
+          actor: 'operator',
+          source: 'operator',
+          notes: `Siembra de ${c.cantidad} ${c.unidad} de ${c.nombre}${c.variedad ? ` (${c.variedad})` : ''}.`,
+        },
+      });
+
+      // Transición de etapa intermedia (mitad del ciclo) → muestra evolución.
+      if (c.etapa !== 'sowing_confirmed' && c.etapa !== 'sowing') {
+        events.push({
+          event_id: `${baseId}-ev1`,
+          type: 'farm_process_event',
+          attributes: {
+            process_id: processId,
+            event_type: 'stage_transition',
+            occurred_at: plantedAt + Math.floor((c.diasSiembra || 30) / 2) * DAY,
+            actor: 'operator',
+            source: 'operator',
+            payload: { to_stage: c.etapa },
+            notes: `${c.nombre} avanzó a etapa "${c.etapa}".`,
+          },
+        });
+      }
+
+      // Cosecha registrada (si aplica) → cierra el arco siembra→cosecha.
+      if (c.cosechado) {
+        const harvestAt = now - 10 * DAY;
+        events.push({
+          event_id: `${baseId}-evH`,
+          type: 'farm_process_event',
+          attributes: {
+            process_id: processId,
+            event_type: 'harvest_confirmed',
+            occurred_at: harvestAt,
+            actor: 'operator',
+            source: 'operator',
+            notes: `Primera cosecha de ${c.nombre} registrada.`,
+          },
+        });
+        logs.push({
+          id: `ej-log-${finca.id}-${idx}-harvest`,
+          _tenant_id: null,
+          type: 'log--harvest',
+          asset_id: `ej-plant-${finca.id}-${idx}`,
+          timestamp: Math.floor(harvestAt / 1000),
+          name: `Cosecha de ${c.nombre} — ${finca.nombre}`,
+          status: 'done',
+          category: 'cosecha',
+          cached_at: now,
+        });
+      }
+
+      // Problema activo → evento de observación con el síntoma (diagnóstico).
+      if (c.problema) {
+        events.push({
+          event_id: `${baseId}-evP`,
+          type: 'farm_process_event',
+          attributes: {
+            process_id: processId,
+            event_type: 'observation',
+            occurred_at: now - 3 * DAY,
+            actor: 'operator',
+            source: 'operator',
+            payload: { plaga: c.problema.plaga, control: c.problema.control },
+            notes: `Problema: ${c.problema.sintoma} Posible: ${c.problema.plaga}.`,
+          },
+        });
+      }
+
+      // Log de siembra (alimenta la actividad reciente del home).
+      logs.push({
+        id: `ej-log-${finca.id}-${idx}-seeding`,
+        _tenant_id: null,
+        type: 'log--seeding',
+        asset_id: `ej-plant-${finca.id}-${idx}`,
+        timestamp: Math.floor(plantedAt / 1000),
+        name: `Siembra de ${c.nombre} — ${finca.nombre}`,
+        status: 'done',
+        category: 'cultivo',
+        cached_at: now,
+      });
+    });
+  }
+
+  // Estructuras (asset--structure).
+  for (const s of ESTRUCTURAS_EJEMPLO) {
+    structures.push({
+      id: s.id,
+      asset_type: 'structure',
+      _tenant_id: null,
+      type: 'asset--structure',
+      attributes: {
+        name: s.nombre,
+        structure_type: s.structure_type,
+        status: 'active',
+        notes: { value: s.notas, format: 'plain_text' },
+        _demo: true,
+        _demo_finca: s.finca,
+      },
+      cached_at: now,
+    });
+  }
+
+  return { lands, structures, plants, processes, events, logs };
+}
+
+/**
+ * Resumen agregado de la finca de ejemplo (para toasts / reportes / tests).
+ * @returns {{ fincas:number, pisos:Object<string,number>, cultivos:number, problemas:number, cosechas:number, estructuras:number, especies:number }}
+ */
+export function resumenFincaEjemplo() {
+  /** @type {Record<string, number>} */
+  const pisos = {};
+  let cultivos = 0;
+  let problemas = 0;
+  let cosechas = 0;
+  const especies = new Set();
+  for (const f of FINCAS_EJEMPLO) {
+    pisos[f.piso] = (pisos[f.piso] || 0) + 1;
+    for (const c of f.cultivos) {
+      cultivos += 1;
+      especies.add(c.slug);
+      if (c.problema) problemas += 1;
+      if (c.cosechado) cosechas += 1;
+    }
+  }
+  return {
+    fincas: FINCAS_EJEMPLO.length,
+    pisos,
+    cultivos,
+    problemas,
+    cosechas,
+    estructuras: ESTRUCTURAS_EJEMPLO.length,
+    especies: especies.size,
+  };
+}
+
+/** ¿Ya se sembró la finca de ejemplo en este dispositivo? Fail-open: si el
+ * storage está roto, respondemos false para permitir re-sembrar (idempotente). */
+export function isExampleFincaSeeded() {
+  try {
+    return window.localStorage.getItem(EXAMPLE_FINCA_SEEDED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function marcarSembrada() {
+  try {
+    window.localStorage.setItem(EXAMPLE_FINCA_SEEDED_KEY, '1');
+  } catch {
+    /* storage no disponible: el flag simplemente no persiste */
+  }
+}
+
+/**
+ * Siembra la finca de ejemplo en IndexedDB (assets, ciclos, eventos y logs) en
+ * una sola transacción atómica. Idempotente: los ids son deterministas, así que
+ * re-invocar sobre-escribe sin duplicar.
+ *
+ * @param {Object} [opts]
+ * @param {boolean} [opts.force=false] re-sembrar aunque el flag ya esté puesto.
+ * @param {number} [opts.now=Date.now()] reloj de referencia.
+ * @returns {Promise<ReturnType<typeof resumenFincaEjemplo>>} resumen de lo sembrado.
+ */
+export async function seedExampleFinca({ force = false, now = Date.now() } = {}) {
+  if (isExampleFincaSeeded() && !force) {
+    return resumenFincaEjemplo();
+  }
+
+  const { lands, structures, plants, processes, events, logs } = buildExampleFincaRecords({ now });
+  const db = await openDB();
+
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction([
+      STORES.ASSETS,
+      STORES.FARM_PROCESSES,
+      STORES.FARM_PROCESS_EVENTS,
+      STORES.LOGS,
+      STORES.SYNC_META,
+    ], 'readwrite');
+
+    const assetStore = tx.objectStore(STORES.ASSETS);
+    for (const a of [...lands, ...structures, ...plants]) assetStore.put(a);
+
+    const fpStore = tx.objectStore(STORES.FARM_PROCESSES);
+    for (const p of processes) fpStore.put(p);
+
+    const fpeStore = tx.objectStore(STORES.FARM_PROCESS_EVENTS);
+    for (const e of events) fpeStore.put(e);
+
+    const logStore = tx.objectStore(STORES.LOGS);
+    for (const l of logs) logStore.put(l);
+
+    tx.objectStore(STORES.SYNC_META).put({ key: 'finca_ejemplo_sembrada', value: true });
+
+    tx.oncomplete = () => resolve(true);
+    tx.onerror = () => reject(tx.error);
+  });
+
+  marcarSembrada();
+
+  // Refrescar el store de activos en memoria para que el home reaccione sin
+  // recargar (fail-silent en tests/SSR sin el store montado).
+  try {
+    const mod = await import('../store/useAssetStore.js');
+    const store = mod.default;
+    if (store && typeof store.getState === 'function') {
+      await store.getState().hydrate();
+    }
+  } catch {
+    /* sin store montado (test/SSR): el home hidratará al montar */
+  }
+
+  const resumen = resumenFincaEjemplo();
+  console.info(
+    `[demoFincaEjemplo] Finca de ejemplo sembrada: ${resumen.fincas} fincas · ` +
+    `${plants.length} siembras · ${resumen.problemas} problemas activos · ${structures.length} estructuras.`,
+  );
+  return resumen;
+}
+
+export default seedExampleFinca;


### PR DESCRIPTION
## Qué

Onboarding mejorado + **finca de ejemplo RICA** que puebla Chagra al **saltar** el registro. Es la base del demo público: quien entra por primera vez y no quiere llenar formularios ve, en un toque, una finca que lo tiene TODO — no un campo muerto.

## Onboarding (más claro, cálido, con "juguetes")
- **BienvenidaFinca**: nueva capacidad **"Sus herramientas del campo"** (voz/cámara/gafas) en el momento de capacidades — menciona los "juguetes" sin ruido.
- Botón **SKIP claro "Explorar con finca de ejemplo"** (icono Sparkles) en el momento final de la bienvenida **y** en el footer del onboarding extendido (`OnboardingProfile`). Al tocarlo siembra la finca y entra al home ya poblado.

## Finca de ejemplo (`src/services/demoFincaEjemplo.js`)
- **9 fincas por PISO TÉRMICO** (3 cálido / 3 templado / 3 frío) con cultivos **insignia** por piso:
  - **Cálido**: cacao (CCN-51) + plátano + guamo + matarratón + naranja + piña + yuca + maracuyá + aguacate…
  - **Templado**: café SAF (Castillo/Cenicafé 1/Caturra) + guamo + banano + aguacate + lulo + tomate de árbol…
  - **Frío**: papa (Pastusa/Diacol) + haba + arveja + cubio + arracacha + milpa (maíz-fríjol-calabaza) + cebolla + zanahoria + lechuga/tomate en invernadero…
- **44 siembras** (`asset--plant`), **44 ciclos** (`farm_process`) con etapa fenológica real, **historial** de eventos (siembra → evolución → cosecha) y **5 estructuras** (invernadero, compostera, beneficiadero, gallinero, secadero).
- **4 problemas activos** que despiertan el diagnóstico del agente: **roya + broca** en café, **gota (Phytophthora)** en papa, **mosca de la fruta** en maracuyá, **barrenador** en lulo — usan la MISMA base del motor de alertas (`climateCycleService`).
- **CERO fabricación**: los **30 slugs de especie** están verificados contra el catálogo real de **580** (`public/catalog.sqlite`). Cada `FarmProcess` pasa `validateFarmProcess`.
- Persiste en **IndexedDB** como cualquier finca real (assets + procesos + eventos + logs), **idempotente** (ids deterministas). El home "Finca Viva" la renderiza poblada sin camino especial: re-hidrata el asset store al sembrar.

## Verificación
Chromium (nix), aislado del login gate (oauth + JSON:API mockeados). Tras el SKIP: **44 plantas, 5 estructuras, 9 lands, 44 procesos** en IDB; el badge del portal "Mi finca" lee **"44 siembras"** y la escena muestra estructuras + cultivos.

## Tests
- `demoFincaEjemplo` (11): riqueza, grounding, validación de ciclos/eventos, persistencia IDB, idempotencia.
- `BienvenidaFinca` (nuevos casos): botón explorar + capacidad herramientas.
- `OnboardingProfile.explorarEjemplo` (2): botón condicional + delegación.
- Build verde · eslint 0 errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)