### PR TITLE
feat(agente): rediseño del AgentScreen por concepto de tema (4 pasadas) — conserva mano/foto/temas/microfono/enviar

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -124,8 +124,12 @@ import ManoChagraGlyph from '../dashboard/ManoChagraGlyph';
 // Ícono del TEMA para el botón Ⓐ del compositor (paridad con home/TopBar y
 // AgentHero): el acceso a capacidades entra por el ícono del tema, no por la
 // mano (operador 2026-06-18). Misma fuente que TopBar.jsx / AgentHero.jsx.
-import { useTheme } from '../../hooks/useTheme';
+import { useTheme, resolveAutoTheme } from '../../hooks/useTheme';
 import { iconForTheme } from '../dashboard/themeIcon';
+// PIEL POR TEMA del agente (rediseño 2026-07): tokens --ag-* + escena
+// ambiental por concepto de tema — el equivalente del chat a las escenas de
+// autor del home finca viva. Ver cabecera de agent-skin.css (4 pasadas).
+import './agent-skin.css';
 import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
 // Agente guiado: selección PURA de un insight verificado proactivo a partir del
 // texto del turno (cultivo detectado → dato con fuente que el usuario no vio).
@@ -3168,35 +3172,54 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
     !((!inputText.trim() && !agentAttachment) || state === STATE_RECORDING || queuePending.length >= 1);
   const agentSendAccent = fincaVivaHomePerfilActivo() && enviarHabilitado;
 
+  // PIEL POR TEMA (rediseño 2026-07): biopunk y biopunk2 comparten piel base
+  // SIN data-theme en <html> — la diferencia (escena "Organismo" vs "Cosecha
+  // mística") se resuelve acá en JS, igual que ESCENA_VIVA_POR_TEMA del home.
+  // El atributo data-agent-tema del root activa el bloque de vars --ag-* del
+  // tema en agent-skin.css (indirección CSS-var, cero parches clase-por-clase).
+  const temaEfectivo = resolveAutoTheme(theme);
+
   return (
-    <div className={`h-[100dvh] flex flex-col overflow-hidden relative text-white ${entranceClassRef.current}`}>
+    <div
+      className={`ag-root h-[100dvh] flex flex-col overflow-hidden relative text-white ${entranceClassRef.current}`}
+      data-agent-tema={temaEfectivo}
+    >
       {/* Velo de legibilidad: deja ver --app-bg-image del body PERO garantiza
           contraste. Token-aware (.agent-scrim → navy denso en bio-punk, crema
           sutil en claros). Antes era bg-slate-950/82 fijo y, accediendo al
           agente directo (#agente), la foto lavaba chips/sugerencias/Volver
           (fix legibilidad 2026-06-15). */}
       <div className="absolute inset-0 agent-scrim backdrop-blur-[2px] pointer-events-none" aria-hidden="true" />
+      {/* ESCENA AMBIENTAL del tema (sobre el velo, bajo el contenido z-10):
+          micelio+esporas (biopunk2) · brasas rojas (biopunk) · amanecer+polen
+          (nature) · dosel+hojitas (verde-vivo) · un solo trazo (minimalista).
+          Puro CSS (agent-skin.css); las <i> son las motas de vida animadas. */}
+      <div className="ag-scene" aria-hidden="true">
+        <i className="ag-mote" /><i className="ag-mote" /><i className="ag-mote" />
+        <i className="ag-mote" /><i className="ag-mote" /><i className="ag-mote" />
+      </div>
       {/* B1: animación de entrada (fade+rise). Respeta prefers-reduced-motion. */}
       <style>{AGENT_ENTRANCE_CSS}{AGENT_COMPOSITOR_CSS}{AGENT_V3_CSS}</style>
 
-      {/* ── Header estilo ScreenShell (2026-06-08): superficie OPACA por token
-          (.agent-bar-surface) + acciones globales. Antes bg-slate-900/50 dejaba
-          pasar la foto detrás del título y los íconos (fix legibilidad 2026-06-15). ── */}
-      <header className="px-4 py-3 flex items-center gap-2 border-b border-slate-800 agent-bar-surface shrink-0">
+      {/* ── Header (rediseño 2026-07): superficie del tema + HILO del acento
+          como firma (.ag-header::after), botones fantasma del tema (.ag-hbtn)
+          y título en la display de la casa. Mismos controles y aria-labels —
+          solo cambió la piel. ── */}
+      <header className="ag-header">
         {/* Back */}
         <button
           type="button"
           onClick={onBack}
-          className="p-3 rounded-full bg-slate-800 hover:bg-slate-700 active:scale-95 transition-all min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
+          className="ag-hbtn"
           aria-label="Volver"
         >
-          <ArrowLeft size={20} className="text-slate-300" />
+          <ArrowLeft size={20} />
         </button>
         {/* Home */}
         <button
           type="button"
           onClick={() => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'dashboard' }))}
-          className="p-3 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:bg-emerald-700/60 transition-all text-emerald-400 min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
+          className="ag-hbtn ag-hbtn--accent"
           aria-label="Volver al inicio"
           title="Inicio"
         >
@@ -3217,15 +3240,18 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           ariaLabel="Chagra IA — doble click silencia/reactiva voz"
         />
         <div className="flex-1 min-w-0">
-          <h1 className="text-sm font-bold text-white leading-tight truncate">Chagra IA</h1>
-          {/* Theme-aware (2026-06-10): clases Tailwind (van por --c-*) en vez
-              de hex inline que ignoraba los temas. + estado "hablando". */}
-          <p className={`text-[10px] font-semibold uppercase tracking-wider leading-tight ${
-            state === STATE_THINKING ? 'text-amber-500'
-              : state === STATE_RECORDING ? 'text-violet-400'
-              : isVoicePlaying ? 'text-emerald-400'
-              : 'text-emerald-300'
-          }`}>
+          <h1 className="ag-title truncate">Chagra IA</h1>
+          {/* Estado con el ACENTO del tema (agent-skin.css por data-state):
+              pensando=ámbar · escuchando=rosa · hablando/idle=acento. */}
+          <p
+            className="ag-status"
+            data-state={
+              state === STATE_THINKING ? 'thinking'
+                : state === STATE_RECORDING ? 'listening'
+                : isVoicePlaying ? 'speaking'
+                : 'idle'
+            }
+          >
             {state === STATE_THINKING && 'pensando…'}
             {state === STATE_RECORDING && 'escuchando…'}
             {state === STATE_IDLE && (isVoicePlaying ? 'hablando…' : 'agente agroecológico')}
@@ -3236,11 +3262,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           type="button"
           onClick={handleNewConversation}
           disabled={state !== STATE_IDLE || messages.length === 0}
-          className={`p-2.5 rounded-full min-h-[44px] min-w-[44px] flex items-center justify-center transition-all ${
-            state !== STATE_IDLE || messages.length === 0
-              ? 'bg-slate-800 text-slate-600 cursor-not-allowed'
-              : 'bg-slate-800 text-slate-300 hover:bg-slate-700 active:scale-95'
-          }`}
+          className="ag-hbtn"
           title="Nueva conversación"
           aria-label="Iniciar nueva conversación"
           data-testid="new-conversation-btn"
@@ -3251,11 +3273,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           type="button"
           disabled={!ttsSupported}
           onClick={() => { if (ttsEnabled) stop(); setTtsEnabled(!ttsEnabled); }}
-          className={`p-2.5 rounded-full min-h-[44px] min-w-[44px] flex items-center justify-center transition-all ${
-            !ttsSupported ? 'bg-slate-800 text-slate-600 cursor-not-allowed'
-              : ttsEnabled ? 'bg-violet-900/40 text-violet-400'
-              : 'bg-slate-800 text-slate-500'
-          }`}
+          className={`ag-hbtn ${ttsEnabled ? 'ag-hbtn--on' : ''}`}
           title={ttsEnabled ? 'Silenciar voz' : 'Activar voz'}
         >
           {ttsEnabled ? <Volume2 size={15} /> : <VolumeX size={15} />}
@@ -3267,16 +3285,14 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         <button
           type="button"
           onClick={() => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'ayuda' }))}
-          className="p-2.5 rounded-full bg-amber-500/15 hover:bg-amber-500/25 active:bg-amber-500/35 text-amber-300 min-h-[44px] min-w-[44px] flex items-center justify-center transition-all"
+          className="ag-hbtn ag-hbtn--warm"
           title="Manual de uso"
           aria-label="Abrir el manual de uso"
           data-testid="agent-help-btn"
         >
           <HelpCircle size={16} strokeWidth={2.5} />
         </button>
-        <div className={`hidden sm:flex items-center gap-1 px-2 py-1 rounded-full text-[10px] ${
-          isOnline ? 'bg-emerald-900/40 text-emerald-400' : 'bg-red-900/40 text-red-400'
-        }`}>
+        <div className={`ag-net ${isOnline ? 'ag-net--on' : 'ag-net--off'}`}>
           {isOnline ? <Wifi size={11} /> : <WifiOff size={11} />}
           {isOnline ? 'Online' : 'Offline'}
         </div>
@@ -3286,9 +3302,9 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           o por botón explícito. Sin esto el operador no entendería por qué su
           history desapareció. Ephemeral — se borra al primer submit. */}
       {showFreshSessionBadge && (
-        <div className="px-4 py-2 mx-4 mt-2 rounded-lg bg-slate-800/60 border border-slate-700/60 flex items-center gap-2">
-          <Sparkles size={14} className="text-violet-400 shrink-0" />
-          <p className="text-xs text-slate-300" data-testid="fresh-session-badge">
+        <div className="ag-banner items-center">
+          <Sparkles size={14} className="shrink-0" style={{ color: `rgb(var(--ag-accent))` }} />
+          <p data-testid="fresh-session-badge">
             Empezamos fresco. Tu historial sigue guardado en tu finca; este
             chat arranca limpio para que el agente se concentre en lo nuevo.
           </p>
@@ -3303,18 +3319,16 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           en GPU M6000). Spinner CSS con animación spin de Tailwind. */}
       {(ollamaWarmStatus === 'warming' || ollamaWarmStatus === 'unknown') && (
         <div
-          className="px-4 py-2 mx-4 mt-2 rounded-lg bg-amber-900/30 border border-amber-800/50 flex items-center gap-2"
+          className="ag-banner ag-banner--warn items-center"
           data-testid="ollama-warming-banner"
           role="status"
           aria-live="polite"
         >
           <span
-            className="w-3 h-3 rounded-full border-2 border-amber-400 border-t-transparent animate-spin shrink-0"
+            className="w-3 h-3 rounded-full border-2 border-current border-t-transparent animate-spin shrink-0"
             aria-hidden="true"
           />
-          <p className="text-xs text-amber-300">
-            Preparando agente IA (~20s)…
-          </p>
+          <p>Preparando agente IA (~20s)…</p>
         </div>
       )}
 
@@ -3334,8 +3348,8 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
 
       {/* Error */}
       {error && (
-        <div className="px-4 py-2 mx-4 mb-2 rounded-lg bg-red-900/30 border border-red-800/50">
-          <p className="text-xs text-red-300">{error}</p>
+        <div className="ag-banner ag-banner--error ag-banner--above">
+          <p>{error}</p>
         </div>
       )}
 
@@ -3346,36 +3360,36 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           fuente del aviso antes de mandar la pregunta. Dismissable. */}
       {alertContextBanner && (
         <div
-          className="mx-4 mb-2 p-3 rounded-lg bg-sky-950/40 border border-sky-800/50 flex items-start gap-3"
+          className="ag-banner ag-banner--info ag-banner--above"
           data-testid="agent-alert-context-banner"
           role="status"
         >
           <div className="flex-1 min-w-0">
             {alertContextBanner.alertContext?.title && (
-              <p className="text-xs font-bold text-sky-200 leading-tight">
+              <p className="font-bold leading-tight">
                 {alertContextBanner.alertContext.title}
               </p>
             )}
             {alertContextBanner.alertContext?.body && (
-              <p className="text-[11px] text-sky-300/85 mt-0.5 leading-snug">
+              <p className="text-[11px] opacity-90 mt-0.5 leading-snug">
                 {alertContextBanner.alertContext.body}
               </p>
             )}
             {(alertContextBanner.sourceLabel || alertContextBanner.sourceUrl) && (
-              <p className="text-[10px] text-slate-400 mt-1.5 leading-tight">
+              <p className="text-[10px] opacity-80 mt-1.5 leading-tight">
                 Fuente:{' '}
                 {alertContextBanner.sourceUrl ? (
                   <a
                     href={alertContextBanner.sourceUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-sky-300 hover:text-sky-200 underline"
+                    className="underline hover:opacity-100"
                     data-testid="agent-alert-source-link"
                   >
                     {alertContextBanner.sourceLabel || 'Ver informe oficial'}
                   </a>
                 ) : (
-                  <span className="text-slate-300">{alertContextBanner.sourceLabel}</span>
+                  <span>{alertContextBanner.sourceLabel}</span>
                 )}
               </p>
             )}
@@ -3383,7 +3397,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           <button
             type="button"
             onClick={() => setAlertContextBanner(null)}
-            className="tap-target shrink-0 p-1.5 rounded-md hover:bg-white/10 text-slate-400"
+            className="tap-target shrink-0 p-1.5 rounded-md hover:bg-white/10"
             aria-label="Cerrar contexto de alerta"
           >
             <X size={16} />
@@ -3396,26 +3410,35 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           el acceso a capacidades es SOLO por este botón o el ícono del tema en
           el compositor, nunca por chips de texto. */}
       {messages.length === 0 && (
-        <div className="px-4 pb-1 pt-1 shrink-0">
+        <div className="relative z-10 px-4 pb-1 pt-1 shrink-0">
+          {/* Rediseño 2026-07: la MANO deja de ser una barrita genérica y pasa
+              a TARJETA VIVA del tema — medallón con el glifo respirando con el
+              acento (teal/rojo/ocre/verde según tema) + jerarquía de texto.
+              Mismo onClick/aria/testid: solo cambió la piel. */}
           <button
             type="button"
             onClick={() => setSheetOpen(true)}
-            className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-emerald-400/60 bg-emerald-700/45 text-emerald-50 text-sm font-semibold shadow-lg shadow-emerald-950/40 active:scale-[.98] transition-transform"
+            className="ag-mano-cta"
             aria-label="Abrir la mano de Chagra"
             data-testid="agent-mano-trigger"
           >
-            <span className="w-[20px] h-[20px] shrink-0 flex items-center justify-center" aria-hidden="true">
-              <ManoChagraGlyph size={20} />
+            <span className="ag-mano-cta-glyph" aria-hidden="true">
+              <ManoChagraGlyph size={26} />
             </span>
-            Toca la mano de Chagra para ver todo lo que puede hacer
+            <span className="flex-1 min-w-0">
+              <span className="ag-mano-cta-title">La mano de Chagra</span>
+              <span className="ag-mano-cta-sub">
+                Tócala y mira todo lo que puedo hacer por tu finca.
+              </span>
+            </span>
           </button>
         </div>
       )}
 
-      {/* ── Compositor pill — paridad completa AgentHero (2026-06-08).
-          Superficie OPACA por token (.agent-bar-surface) para legibilidad sobre
-          la foto de fondo (fix 2026-06-15). ── */}
-      <div className="relative z-10 px-3 pb-[calc(env(safe-area-inset-bottom,0px)+8px)] pt-2 border-t border-slate-800/60 agent-bar-surface shrink-0">
+      {/* ── Compositor (rediseño 2026-07): superficie del tema con LA COSTURA
+          del acento como borde superior (.ag-composer::before) — la misma
+          puntada que firma las respuestas respaldadas y la mochila. ── */}
+      <div className="ag-composer">
 
         {/* Preview de foto adjunta (outbox) */}
         {agentAttachment && (
@@ -3569,7 +3592,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               }
               disabled={queuePending.length >= 1}
               data-testid="agent-input"
-              className="w-full bg-transparent resize-none px-3 py-3 text-sm text-white placeholder-slate-500 focus:outline-none leading-snug"
+              /* Tinta por tema: el color del texto/placeholder lo ponen
+                 .as-bar textarea (--ag-input-ink) y agent-skin.css — antes
+                 text-white fijo era invisible sobre el papel de los claros. */
+              className="w-full bg-transparent resize-none px-3 py-3 text-sm focus:outline-none leading-snug"
               style={{ minHeight: '44px', maxHeight: '140px' }}
             />
           )}
@@ -3662,25 +3688,14 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               aria-label="Enviar al agente"
               className={[
                 'as-send',
-                // PIEL POR TEMA del botón enviar (Fase 2). Con la flag ON y el
-                // botón activo, toma `.agent-send-accent` → themes.css lo pinta
-                // con el acento del tema (teal/ocre/verde), igual que AgentHero,
-                // en vez del gradiente teal→cian fijo. Con OFF queda como hoy.
+                // PIEL POR TEMA del botón enviar (rediseño 2026-07): el fondo/
+                // glow salen de --ag-send-* (agent-skin.css) vía el CSS de
+                // .as-send — teal-cian en biopunk, ocre en nature, verde en
+                // verde-vivo/minimalista. El estado deshabilitado lo apaga
+                // :disabled. `.agent-send-accent` (flag finca viva) sigue
+                // pudiendo forzar el acento sólido del tema (themes.css).
                 agentSendAccent ? 'agent-send-accent' : '',
               ].filter(Boolean).join(' ')}
-              style={{
-                background:
-                  (!inputText.trim() && !agentAttachment) || state === STATE_RECORDING || queuePending.length >= 1
-                    ? 'rgba(51,65,85,0.8)'
-                    // Con `agent-send-accent` activo, el color lo pone themes.css
-                    // (background-color !important del acento del tema); aquí no
-                    // forzamos el gradiente para no taparlo.
-                    : agentSendAccent ? undefined : 'linear-gradient(135deg,#10b981 0%,#0891b2 100%)',
-                boxShadow:
-                  (!inputText.trim() && !agentAttachment) || state === STATE_RECORDING || queuePending.length >= 1
-                    ? 'none'
-                    : '0 0 18px rgba(16,185,129,0.5)',
-              }}
             >
               <ChagraAgentAvatar
                 size={38}
@@ -3771,7 +3786,8 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         {state === STATE_THINKING && (
           <div className="flex flex-col items-center gap-2 mt-2">
             <p
-              className={`text-center text-xs ${showSlowWarning ? 'text-amber-400' : 'text-violet-400'}`}
+              className="ag-thinking-eta text-center text-xs"
+              data-slow={showSlowWarning ? 'true' : undefined}
               data-testid="eta-label"
             >
               {(() => {
@@ -3807,7 +3823,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             </p>
             {queuePending.length >= 1 && (
               <p
-                className="text-center text-[10px] text-violet-300"
+                className="ag-thinking-sub text-center text-[10px]"
                 data-testid="queue-pending-badge"
               >
                 Tienes 1 pregunta en cola — te respondo después de la actual.
@@ -3815,15 +3831,15 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             )}
             {rotatingTip && !hintDismissed && (
               <div
-                className="mt-1 px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/60 flex items-start gap-2 max-w-sm transition-opacity duration-300"
+                className="ag-tipcard"
                 data-testid="rotating-tip"
                 key={rotatingTip.id}
               >
                 <span className="text-base shrink-0 leading-none mt-0.5" aria-hidden="true">
                   {rotatingTip.icon}
                 </span>
-                <p className="text-[11px] text-slate-300 leading-snug flex-1">
-                  <span className="text-violet-400 font-medium block mb-0.5">
+                <p className="text-[11px] leading-snug flex-1">
+                  <span className="ag-tipcard-title block mb-0.5">
                     💡 Tip mientras espero
                   </span>
                   {rotatingTip.text}
@@ -3835,7 +3851,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                     setHintDismissed(true);
                   }}
                   aria-label="Cerrar sugerencia"
-                  className="text-[10px] text-slate-500 hover:text-slate-300 shrink-0 leading-none px-1"
+                  className="ag-tipcard-close shrink-0 leading-none px-1"
                   data-testid="dismiss-tip"
                 >
                   ×
@@ -3845,7 +3861,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             <button
               type="button"
               onClick={handleCancelLLM}
-              className="text-[10px] px-3 py-1 rounded-full bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700 active:scale-95 transition-all"
+              className="ag-cancelbtn"
             >
               Cancelar
             </button>
@@ -3854,17 +3870,17 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
 
         {queueRejectedToast && (
           <div
-            className="mt-2 px-3 py-2 rounded-lg bg-amber-900/40 border border-amber-700/60 flex items-center gap-2"
+            className="ag-banner ag-banner--warn ag-banner--inset items-center"
             data-testid="queue-rejected-toast"
             role="status"
             aria-live="polite"
           >
-            <p className="text-xs text-amber-300 flex-1">{queueRejectedToast}</p>
+            <p className="flex-1">{queueRejectedToast}</p>
             <button
               type="button"
               onClick={() => setQueueRejectedToast('')}
               aria-label="Cerrar aviso"
-              className="text-amber-400 hover:text-amber-200 text-sm leading-none"
+              className="text-sm leading-none opacity-80 hover:opacity-100"
             >
               ×
             </button>

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -149,9 +149,11 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
           onClick={onBack}
           data-testid="chat-floating-back"
           aria-label="Volver"
-          className="chagra-floating-back absolute top-3 left-3 z-20 flex items-center gap-1.5 pl-2 pr-3 py-2 rounded-full bg-slate-900/90 backdrop-blur-sm border border-slate-700 text-amber-300 shadow-lg active:scale-95 hover:bg-slate-800"
+          /* Rediseño 2026-07: superficie/borde por tema (.ag-floatback,
+             agent-skin.css) — el slate-900 fijo era ilegible en claros. */
+          className="chagra-floating-back ag-floatback absolute top-3 left-3 z-20 flex items-center gap-1.5 pl-2 pr-3 py-2 rounded-full backdrop-blur-sm border shadow-lg active:scale-95"
         >
-          <ArrowLeft size={18} className="text-amber-400" />
+          <ArrowLeft size={18} />
           <span className="text-xs font-semibold">Volver</span>
         </button>
       )}

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -59,6 +59,9 @@ vi.mock('../../../services/tierService', () => ({
 
 vi.mock('../../../hooks/useTheme', () => ({
   useTheme: () => ({ theme: 'nature' }),
+  // Rediseño 2026-07: AgentScreen resuelve el tema efectivo (data-agent-tema)
+  // con resolveAutoTheme — el mock lo expone como identidad (tema ya concreto).
+  resolveAutoTheme: (t) => t,
 }));
 
 vi.mock('../../../hooks/useVoiceRecorder', () => ({

--- a/src/components/AgentScreen/agent-skin.css
+++ b/src/components/AgentScreen/agent-skin.css
@@ -1,0 +1,639 @@
+/* ============================================================================
+   agent-skin.css — LA PIEL DEL AGENTE POR CONCEPTO DE TEMA (rediseño 2026-07).
+
+   El operador: "el agente actual es una pieza NO digna del trabajo que se le ha
+   metido" — el home finca-viva tiene escena de autor por tema y el chat se
+   quedó en slate genérico. Este archivo eleva la pantalla del agente a la
+   ALTURA del home: cada tema imprime su alma en el chat vía INDIRECCIÓN de
+   CSS-vars (--ag-*), nunca parches clase-por-clase (política themes-cssvar).
+
+   ARQUITECTURA (4 pasadas):
+     P1 CONCEPTO+LAYOUT  → capa de tokens --ag-* + clases estructurales
+                           (.ag-header, .ag-mano-cta, .ag-composer, .ag-banner)
+                           que el JSX usa SIN colores hardcodeados.
+     P2 PIEL POR TEMA    → un bloque por tema que SOLO redefine vars + su
+                           ESCENA ambiental (.ag-scene) — el equivalente del
+                           chat a las escenas de autor del home:
+             biopunk2    → "Organismo nocturno": micelio + esporas
+                           bioluminiscentes teal sobre la noche #0a0e14.
+             biopunk     → "Cosecha mística": la piel base con el REBELDE rojo
+                           de la Ⓐ anarco-agro (hilo rojo + brasas).
+             nature      → "Árbol de la Vida": amanecer ocre, ramas de café,
+                           polen dorado.
+             verde-vivo  → "Huerto exuberante": dosel de hojas, sol cálido,
+                           hojitas que caen.
+             minimalista → "Un solo trazo": papel, UNA línea, cero ruido.
+     P3 MOTION+PULIDO    → microinteracciones (esporas/hojas/polen, respiración
+                           de la mano, pop del tick grounded) con apagado TOTAL
+                           bajo prefers-reduced-motion.
+     P4 REFINAMIENTO     → jerarquía del header, densidad, focus-visible con el
+                           acento del tema, contraste AA en claros.
+
+   El selector de tema vive en el ROOT del AgentScreen como
+   [data-agent-tema="…"] (lo escribe el JSX con resolveAutoTheme) porque
+   biopunk y biopunk2 comparten piel base SIN data-theme en <html> — igual que
+   ESCENA_VIVA_POR_TEMA del home resuelve la escena en JS.
+
+   Los tokens base salen de los del tema global (--c-* espacio-separado,
+   --t-accent-rgb coma-separado, index.css/themes.css) → un tema futuro hereda
+   una piel coherente sin tocar este archivo. Español Colombia, sin voseo.
+   ========================================================================== */
+
+/* ── P1 · TOKENS BASE (= piel biopunk; los claros los re-tiñen abajo) ─────── */
+.ag-root {
+  /* acento del tema (coma-separado, formato rgba(var(--ag-accent), a)) */
+  --ag-accent: var(--t-accent-rgb, 25, 201, 154);
+  /* acento SECUNDARIO: solo biopunk (rojo Ⓐ) lo separa; default = acento */
+  --ag-accent-2: var(--t-accent-rgb, 25, 201, 154);
+  /* forma: radio "orgánico" de tarjetas/pill — cada tema lo esculpe */
+  --ag-radius: 22px;
+  /* tipografía display de la casa (la misma del home finca viva) */
+  --ag-display: 'Baloo 2', 'Nunito', system-ui, -apple-system, sans-serif;
+  --ag-body: 'Nunito', system-ui, -apple-system, sans-serif;
+
+  /* header */
+  --ag-header-bg: rgb(var(--c-surface-card, 15 23 42) / 0.93);
+  --ag-hairline: linear-gradient(
+    90deg,
+    transparent 4%,
+    rgba(var(--ag-accent), 0.65) 30%,
+    rgba(var(--ag-accent-2), 0.65) 70%,
+    transparent 96%
+  );
+  --ag-hbtn-bg: rgb(var(--c-surface-raised, 30 41 59) / 0.85);
+  --ag-hbtn-ink: rgb(var(--c-slate-300, 203 213 225));
+  --ag-hbtn-border: rgb(var(--c-surface-border, 51 65 85) / 0.85);
+
+  /* compositor (pill .as-bar — consumidos por AGENT_COMPOSITOR_CSS) */
+  --ag-bar-bg: rgb(var(--c-surface-raised, 30 41 59) / 0.9);
+  --ag-bar-border: rgb(var(--c-surface-border, 100 116 139) / 0.55);
+  --ag-bar-shadow: 0 10px 30px -12px rgba(0, 0, 0, 0.5);
+  --ag-input-ink: rgb(var(--c-slate-100, 241 245 249));
+  --ag-iconbtn-bg: rgb(var(--c-surface-raised, 30 41 59) / 0.92);
+  --ag-iconbtn-ink: rgb(var(--c-slate-400, 148 163 184));
+  --ag-iconbtn-ink-hover: rgb(var(--c-slate-100, 255 255 255));
+  --ag-iconbtn-border: rgb(var(--c-surface-border, 100 116 139) / 0.5);
+
+  /* enviar: el punto focal de acción — cada tema pinta el suyo */
+  --ag-send-bg: linear-gradient(135deg, #10b981 0%, #0891b2 100%);
+  --ag-send-glow: 0 0 18px rgba(var(--ag-accent), 0.5);
+
+  /* escena ambiental (grosor de presencia de la escena tras el velo) */
+  --ag-scene-opacity: 1;
+
+  font-family: var(--ag-body);
+}
+
+/* ── P1 · ESCENA AMBIENTAL — el "lienzo de autor" del chat ─────────────────
+   Capa fija detrás del contenido (encima del velo .agent-scrim, debajo del
+   chat z-10). Dos capas de pintura (::before glows / ::after trazos SVG) +
+   6 motas de vida (.ag-mote) que cada tema re-significa: esporas (biopunk2),
+   brasas (biopunk), polen (nature), hojitas (verde-vivo), nada (minimalista). */
+.ag-scene {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  opacity: var(--ag-scene-opacity);
+  z-index: 0;
+}
+.ag-scene::before,
+.ag-scene::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
+/* Default (piel base biopunk/biopunk2): resplandores teal de noche viva. */
+.ag-scene::before {
+  background:
+    radial-gradient(620px 420px at 88% -12%, rgba(var(--ag-accent), 0.16), transparent 62%),
+    radial-gradient(520px 400px at -12% 106%, rgba(8, 145, 178, 0.13), transparent 60%);
+}
+.ag-scene::after {
+  background-image: none;
+  background-repeat: no-repeat;
+  background-position: center bottom;
+  background-size: cover;
+}
+
+/* Mota base: un punto de vida. Posiciones/tempos por nth-child; el color y la
+   forma los decide el tema. Motion en P3 (abajo). */
+.ag-mote {
+  position: absolute;
+  display: block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: rgba(var(--ag-accent), 0.55);
+  box-shadow: 0 0 8px 1px rgba(var(--ag-accent), 0.35);
+  opacity: 0;
+}
+.ag-mote:nth-child(1) { left: 12%; bottom: 22%; animation-delay: 0s; }
+.ag-mote:nth-child(2) { left: 78%; bottom: 30%; width: 3px; height: 3px; animation-delay: 2.4s; }
+.ag-mote:nth-child(3) { left: 32%; bottom: 12%; width: 5px; height: 5px; animation-delay: 4.8s; }
+.ag-mote:nth-child(4) { left: 88%; bottom: 14%; animation-delay: 7.1s; }
+.ag-mote:nth-child(5) { left: 55%; bottom: 26%; width: 3px; height: 3px; animation-delay: 9.6s; }
+.ag-mote:nth-child(6) { left: 20%; bottom: 34%; animation-delay: 12s; }
+
+/* ── P1 · HEADER — jerarquía y aire ────────────────────────────────────────
+   Superficie del tema + HILO del acento como firma (la costura de la marca).
+   `relative z-10` para pintar sobre velo+escena (igual que chat/compositor). */
+.ag-header {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--ag-header-bg);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  flex-shrink: 0;
+}
+.ag-header::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--ag-hairline);
+  pointer-events: none;
+}
+
+/* Botón de header: fantasma del tema (no más pastillas slate genéricas). */
+.ag-hbtn {
+  flex: none;
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: calc(var(--ag-radius) * 0.6);
+  background: var(--ag-hbtn-bg);
+  border: 1px solid var(--ag-hbtn-border);
+  color: var(--ag-hbtn-ink);
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease,
+              transform 0.16s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.ag-hbtn:hover {
+  color: rgb(var(--c-slate-100, 241 245 249));
+  border-color: rgba(var(--ag-accent), 0.55);
+}
+.ag-hbtn:active { transform: scale(0.92); }
+.ag-hbtn:disabled,
+.ag-hbtn[aria-disabled='true'] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+}
+/* Variante acento (Inicio 🏠 y estados "vivos"). */
+.ag-hbtn--accent { color: rgb(var(--ag-accent)); }
+.ag-hbtn--accent:hover { color: rgb(var(--ag-accent)); background: rgba(var(--ag-accent), 0.14); }
+/* Variante cálida (ayuda "?") — puerta amable al manual. La tinta cálida
+   (--ag-warn-ink) la oscurecen los temas claros para pasar AA sobre papel. */
+.ag-hbtn--warm {
+  color: var(--ag-warn-ink, rgb(var(--c-amber-300, 252 211 77)));
+  background: rgb(var(--c-amber-500, 245 158 11) / 0.12);
+  border-color: rgb(var(--c-amber-500, 245 158 11) / 0.35);
+}
+.ag-hbtn--warm:hover { background: rgb(var(--c-amber-500, 245 158 11) / 0.22); }
+/* Variante TTS activo. */
+.ag-hbtn--on {
+  color: rgb(var(--c-violet-400, 167 139 250));
+  background: rgb(var(--c-violet-500, 139 92 246) / 0.14);
+  border-color: rgb(var(--c-violet-500, 139 92 246) / 0.4);
+}
+
+/* Identidad: título en la display de la casa + subtítulo de estado. */
+.ag-title {
+  font-family: var(--ag-display);
+  font-weight: 800;
+  font-size: 15px;
+  letter-spacing: -0.2px;
+  line-height: 1.1;
+  color: rgb(var(--c-slate-100, 241 245 249));
+}
+.ag-status {
+  font-family: var(--ag-body);
+  /* 9px + tracking corto: "AGENTE AGROECOLÓGICO" puede partir en 2 líneas en
+     móviles angostos (como siempre lo hizo) en vez de truncarse en "AGR…". */
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  line-height: 1.25;
+  color: rgba(var(--ag-accent), 0.95);
+}
+.ag-status[data-state='thinking'] { color: var(--ag-warn-ink, rgb(var(--c-amber-400, 251 191 36))); }
+.ag-status[data-state='listening'] { color: rgb(var(--c-rose-400, 251 113 133)); }
+.ag-status[data-state='speaking'] { color: rgb(var(--ag-accent)); }
+
+/* Badge online/offline del header. */
+.ag-net {
+  display: none;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  font-family: var(--ag-body);
+}
+@media (min-width: 640px) { .ag-net { display: inline-flex; } }
+.ag-net--on {
+  color: rgb(var(--ag-accent));
+  background: rgba(var(--ag-accent), 0.12);
+  border: 1px solid rgba(var(--ag-accent), 0.3);
+}
+.ag-net--off {
+  color: rgb(var(--c-red-400, 248 113 113));
+  background: rgb(var(--c-red-500, 239 68 68) / 0.12);
+  border: 1px solid rgb(var(--c-red-500, 239 68 68) / 0.35);
+}
+
+/* ── P1 · LA MANO COMO PROTAGONISTA (pantalla de llegada) ──────────────────
+   Ya no una barrita verde genérica: una TARJETA VIVA del tema — medallón con
+   el glifo de la mano que respira con el acento + jerarquía de texto. */
+.ag-mano-cta {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  text-align: left;
+  padding: 13px 16px;
+  border-radius: var(--ag-radius) var(--ag-radius) var(--ag-radius) calc(var(--ag-radius) * 0.32);
+  background:
+    linear-gradient(135deg, rgba(var(--ag-accent), 0.16), rgb(var(--c-surface-card, 15 23 42) / 0.94) 55%),
+    rgb(var(--c-surface-card, 15 23 42));
+  border: 1.5px solid rgba(var(--ag-accent), 0.5);
+  box-shadow: 0 14px 34px -20px rgba(var(--ag-accent), 0.55);
+  color: rgb(var(--c-slate-100, 241 245 249));
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.25s ease,
+              transform 0.16s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.ag-mano-cta:hover { border-color: rgba(var(--ag-accent-2), 0.8); }
+.ag-mano-cta:active { transform: scale(0.98); }
+.ag-mano-cta-glyph {
+  flex: none;
+  width: 46px;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: rgb(var(--ag-accent-2));
+  background: rgba(var(--ag-accent), 0.13);
+  border: 1px solid rgba(var(--ag-accent), 0.45);
+}
+.ag-mano-cta-title {
+  display: block;
+  font-family: var(--ag-display);
+  font-weight: 800;
+  font-size: 15px;
+  letter-spacing: -0.2px;
+  line-height: 1.15;
+}
+.ag-mano-cta-sub {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  line-height: 1.3;
+  color: rgb(var(--c-slate-400, 148 163 184));
+}
+
+/* ── P1 · COMPOSITOR — la orilla del cuaderno ──────────────────────────────
+   Superficie del tema con la COSTURA (puntada del acento) como borde superior:
+   la misma puntada que firma las respuestas respaldadas y la mochila. */
+.ag-composer {
+  position: relative;
+  z-index: 10;
+  flex-shrink: 0;
+  padding: 9px 12px calc(env(safe-area-inset-bottom, 0px) + 8px);
+  background: var(--ag-header-bg);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+}
+.ag-composer::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 10px;
+  right: 10px;
+  height: 2px;
+  background-image: repeating-linear-gradient(
+    90deg,
+    rgba(var(--ag-accent), 0.55) 0 8px,
+    transparent 8px 15px
+  );
+  pointer-events: none;
+}
+
+/* ── P1 · BANNERS del flujo (sesión nueva / calentando / error / alerta) ───
+   Familia única de avisos del tema, no cuatro estilos slate distintos. */
+.ag-banner {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin: 8px 16px 0;
+  padding: 9px 12px;
+  border-radius: calc(var(--ag-radius) * 0.65);
+  background: rgb(var(--c-surface-raised, 30 41 59) / 0.92);
+  border: 1px solid rgb(var(--c-surface-border, 51 65 85) / 0.9);
+  color: rgb(var(--c-slate-300, 203 213 225));
+  font-size: 12px;
+  line-height: 1.4;
+}
+.ag-banner--warn {
+  background: rgb(var(--c-amber-500, 245 158 11) / 0.12);
+  border-color: rgb(var(--c-amber-500, 245 158 11) / 0.38);
+  color: var(--ag-warn-ink, rgb(var(--c-amber-300, 252 211 77)));
+}
+.ag-banner--error {
+  background: rgb(var(--c-red-500, 239 68 68) / 0.12);
+  border-color: rgb(var(--c-red-500, 239 68 68) / 0.4);
+  color: rgb(var(--c-red-300, 252 165 165));
+}
+.ag-banner--info {
+  background: rgb(var(--c-sky-500, 14 165 233) / 0.1);
+  border-color: rgb(var(--c-sky-500, 14 165 233) / 0.35);
+  color: rgb(var(--c-sky-300, 125 211 252));
+}
+/* Posición: sobre el compositor (margen abajo) / dentro del compositor. */
+.ag-banner--above { margin: 0 16px 8px; }
+.ag-banner--inset { margin: 8px 4px 0; }
+
+/* ── P1 · ZONA "PENSANDO" bajo el compositor ─────────────────────────────── */
+.ag-thinking-eta {
+  font-family: var(--ag-body);
+  color: rgba(var(--ag-accent), 0.95);
+}
+.ag-thinking-eta[data-slow='true'] { color: rgb(var(--c-amber-400, 251 191 36)); }
+.ag-thinking-sub { color: rgba(var(--ag-accent), 0.75); }
+.ag-tipcard {
+  margin-top: 4px;
+  padding: 8px 12px;
+  max-width: 24rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  border-radius: calc(var(--ag-radius) * 0.6);
+  background: rgb(var(--c-surface-raised, 30 41 59) / 0.85);
+  border: 1px solid rgb(var(--c-surface-border, 51 65 85) / 0.8);
+  color: rgb(var(--c-slate-300, 203 213 225));
+  transition: opacity 0.3s ease;
+}
+.ag-tipcard-title {
+  color: rgb(var(--ag-accent));
+  font-weight: 700;
+  font-family: var(--ag-display);
+}
+.ag-tipcard-close { color: rgb(var(--c-slate-400, 148 163 184)); font-size: 10px; }
+.ag-tipcard-close:hover { color: rgb(var(--c-slate-100, 241 245 249)); }
+.ag-cancelbtn {
+  font-size: 10px;
+  padding: 5px 14px;
+  border-radius: 999px;
+  background: rgb(var(--c-surface-raised, 30 41 59) / 0.9);
+  border: 1px solid rgb(var(--c-surface-border, 51 65 85));
+  color: rgb(var(--c-slate-300, 203 213 225));
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.15s ease;
+}
+.ag-cancelbtn:hover { border-color: rgba(var(--ag-accent), 0.5); }
+.ag-cancelbtn:active { transform: scale(0.95); }
+
+/* Botón "Volver" flotante del chat (antes slate-900 fijo — ilegible en claros). */
+.ag-floatback {
+  background: rgb(var(--c-surface-card, 15 23 42) / 0.94) !important;
+  border-color: rgba(var(--ag-accent), 0.4) !important;
+  color: rgb(var(--c-slate-100, 241 245 249)) !important;
+}
+
+/* ── P2 · PIEL POR TEMA ═══════════════════════════════════════════════════ */
+
+/* Común a los TEMAS CLAROS: la tinta "cálida" (ayuda/avisos/pensando) debe ser
+   ámbar OSCURO para pasar AA sobre papel/crema (el amarillo claro del dark se
+   lava). Un solo token — no parches por clase. */
+.ag-root[data-agent-tema='nature'],
+.ag-root[data-agent-tema='verde-vivo'],
+.ag-root[data-agent-tema='minimalista'] {
+  --ag-warn-ink: rgb(var(--c-amber-700, 120 72 32));
+}
+
+/* ── biopunk2 · "ORGANISMO NOCTURNO" (default GO-LIVE) ─────────────────────
+   La Finca Organismo respira de noche: micelio que trepa desde el borde
+   inferior + esporas teal que suben lento. El pill y las tarjetas llevan el
+   radio orgánico grande. (Los tokens base YA son esta piel; aquí va la escena
+   y los matices propios.) */
+.ag-root[data-agent-tema='biopunk2'] .ag-scene::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 412 300' preserveAspectRatio='xMidYMax slice'%3E%3Cg fill='none' stroke='%2319c79a' stroke-width='1.1'%3E%3Cpath stroke-opacity='0.20' d='M-10 300 C 60 240 40 190 110 160 M110 160 C 150 145 170 180 210 150'/%3E%3Cpath stroke-opacity='0.14' d='M120 300 C 160 250 240 260 280 210 C 310 175 380 190 422 150'/%3E%3Cpath stroke-opacity='0.10' d='M300 300 C 320 260 280 230 330 195 M330 195 C 360 175 400 185 422 160'/%3E%3C/g%3E%3Cg fill='%2319c79a'%3E%3Ccircle cx='110' cy='160' r='2.6' fill-opacity='0.35'/%3E%3Ccircle cx='280' cy='210' r='2.2' fill-opacity='0.28'/%3E%3Ccircle cx='330' cy='195' r='1.8' fill-opacity='0.25'/%3E%3Ccircle cx='210' cy='150' r='1.6' fill-opacity='0.3'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: 100% auto;
+  background-position: center bottom;
+}
+
+/* ── biopunk · "COSECHA MÍSTICA" (el clásico, la Ⓐ roja) ───────────────────
+   Misma noche teal PERO con el hilo ROJO anarco-agro de la Ⓐ original: el
+   acento secundario tiñe hairline, medallón de la mano y la mitad de las
+   brasas. Radio más recto — más punk, menos organismo. */
+.ag-root[data-agent-tema='biopunk'] {
+  --ag-accent-2: 192, 57, 43; /* rojo forja de la Ⓐ (themeIcon ANIM-2) */
+  --ag-radius: 15px;
+  --ag-hairline: linear-gradient(
+    90deg,
+    transparent 2%,
+    rgba(192, 57, 43, 0.75) 26%,
+    rgba(var(--ag-accent), 0.7) 74%,
+    transparent 98%
+  );
+}
+.ag-root[data-agent-tema='biopunk'] .ag-scene::before {
+  background:
+    radial-gradient(560px 400px at 88% -12%, rgba(var(--ag-accent), 0.15), transparent 62%),
+    radial-gradient(480px 380px at -10% 108%, rgba(192, 57, 43, 0.13), transparent 58%);
+}
+.ag-root[data-agent-tema='biopunk'] .ag-scene::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 412 300' preserveAspectRatio='xMidYMax slice'%3E%3Cg fill='none' stroke-width='1.2'%3E%3Cpath stroke='%23c0392b' stroke-opacity='0.16' d='M-10 260 L 80 200 L 90 210 L 170 150'/%3E%3Cpath stroke='%2319c79a' stroke-opacity='0.13' d='M412 280 L 330 220 L 320 232 L 240 175'/%3E%3Cpath stroke='%23c0392b' stroke-opacity='0.09' d='M200 300 L 206 240 L 199 236 L 205 180'/%3E%3C/g%3E%3C/svg%3E");
+}
+/* Brasas: alternar rojo/teal. */
+.ag-root[data-agent-tema='biopunk'] .ag-mote:nth-child(odd) {
+  background: rgba(192, 57, 43, 0.6);
+  box-shadow: 0 0 8px 1px rgba(192, 57, 43, 0.4);
+}
+
+/* ── nature · "ÁRBOL DE LA VIDA" ───────────────────────────────────────────
+   Amanecer sobre papel crema: sol ocre arriba, ramas de café que entran por
+   las esquinas, polen dorado que flota. Superficies = papel del tema (los
+   --c-* de nature ya viran todos los tokens base); aquí la luz y la escena. */
+.ag-root[data-agent-tema='nature'] {
+  --ag-radius: 18px;
+  --ag-send-bg: linear-gradient(135deg, #d98a4f 0%, #b86a32 100%);
+  --ag-send-glow: 0 6px 18px -6px rgba(184, 106, 50, 0.55);
+  --ag-bar-shadow: 0 10px 30px -14px rgba(96, 66, 32, 0.28);
+  /* La nota del productor va en TERRACOTA (no el esmeralda genérico): la voz
+     humana lleva el barro; el catálogo lleva la salvia. */
+  --ag-user-bg: linear-gradient(160deg, #c07845 0%, #a8612f 100%);
+  --ag-user-border: rgba(168, 97, 47, 0.55);
+}
+.ag-root[data-agent-tema='nature'] .ag-scene::before {
+  background:
+    radial-gradient(520px 340px at 50% -10%, rgba(255, 214, 150, 0.5), transparent 68%),
+    radial-gradient(420px 320px at 108% 108%, rgba(217, 138, 79, 0.14), transparent 60%);
+}
+.ag-root[data-agent-tema='nature'] .ag-scene::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 412 300' preserveAspectRatio='xMidYMin slice'%3E%3Cg fill='none' stroke='%23a8612f' stroke-width='1.4'%3E%3Cpath stroke-opacity='0.16' d='M-10 30 C 70 55 120 20 190 45 C 240 62 300 35 422 70'/%3E%3Cpath stroke-opacity='0.10' d='M-10 70 C 60 90 130 60 200 85'/%3E%3C/g%3E%3Cg fill='%23a8612f'%3E%3Cellipse cx='120' cy='28' rx='7' ry='3' transform='rotate(-24 120 28)' fill-opacity='0.14'/%3E%3Cellipse cx='250' cy='50' rx='6' ry='2.6' transform='rotate(18 250 50)' fill-opacity='0.12'/%3E%3Cellipse cx='340' cy='52' rx='7' ry='3' transform='rotate(-14 340 52)' fill-opacity='0.11'/%3E%3C/g%3E%3C/svg%3E");
+  background-position: center top;
+  background-size: 100% auto;
+}
+/* Polen dorado: cálido, sin glow neón. */
+.ag-root[data-agent-tema='nature'] .ag-mote {
+  background: rgba(216, 160, 76, 0.55);
+  box-shadow: 0 0 6px 1px rgba(216, 160, 76, 0.3);
+}
+
+/* ── verde-vivo · "HUERTO EXUBERANTE" ──────────────────────────────────────
+   El dosel entra por arriba (hojas verdes), el sol pega en la esquina y
+   caen hojitas. Verde de hoja en el acento (ya viene de --t-accent-rgb). */
+.ag-root[data-agent-tema='verde-vivo'] {
+  --ag-radius: 20px;
+  --ag-send-bg: linear-gradient(135deg, #2e8b3d 0%, #226628 100%);
+  --ag-send-glow: 0 6px 18px -6px rgba(34, 102, 40, 0.55);
+  --ag-bar-shadow: 0 10px 30px -14px rgba(43, 74, 34, 0.3);
+}
+.ag-root[data-agent-tema='verde-vivo'] .ag-scene::before {
+  background:
+    linear-gradient(180deg, rgba(46, 139, 61, 0.16), transparent 22%),
+    radial-gradient(440px 320px at 92% -8%, rgba(255, 224, 130, 0.4), transparent 62%);
+}
+.ag-root[data-agent-tema='verde-vivo'] .ag-scene::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 412 300' preserveAspectRatio='xMidYMin slice'%3E%3Cg fill='%232e8b3d'%3E%3Cpath fill-opacity='0.14' d='M20 0 q 18 26 0 44 q -18 -18 0 -44'/%3E%3Cpath fill-opacity='0.11' d='M70 -8 q 22 30 0 52 q -22 -22 0 -52'/%3E%3Cpath fill-opacity='0.12' d='M360 -4 q 20 28 0 48 q -20 -20 0 -48'/%3E%3Cpath fill-opacity='0.09' d='M320 6 q 15 22 0 38 q -15 -16 0 -38'/%3E%3Cpath fill-opacity='0.08' d='M150 -10 q 16 24 0 42 q -16 -18 0 -42'/%3E%3C/g%3E%3C/svg%3E");
+  background-position: center top;
+  background-size: 100% auto;
+}
+/* Hojitas: forma de hoja (radio asimétrico), verde vivo, giran al caer (P3). */
+.ag-root[data-agent-tema='verde-vivo'] .ag-mote {
+  width: 7px;
+  height: 7px;
+  border-radius: 0 70% 0 70%;
+  background: rgba(46, 139, 61, 0.4);
+  box-shadow: none;
+}
+
+/* ── minimalista · "UN SOLO TRAZO" ─────────────────────────────────────────
+   Papel, tinta y UNA línea que cruza. Nada respira, nada brilla: la elegancia
+   es la ausencia. Radios rectos, sombras casi nulas, motas apagadas. */
+.ag-root[data-agent-tema='minimalista'] {
+  --ag-radius: 11px;
+  --ag-hairline: linear-gradient(90deg, rgba(var(--ag-accent), 0.4), rgba(var(--ag-accent), 0.4));
+  --ag-send-bg: linear-gradient(135deg, #2f6e5a 0%, #2f6e5a 100%);
+  --ag-send-glow: 0 4px 12px -6px rgba(29, 70, 57, 0.4);
+  --ag-bar-shadow: 0 6px 18px -12px rgba(31, 36, 33, 0.22);
+  /* Nota del productor = el MISMO verde del trazo, plano, sin degradé. */
+  --ag-user-bg: #2f6e5a;
+  --ag-user-border: rgba(29, 70, 57, 0.45);
+}
+.ag-root[data-agent-tema='minimalista'] .ag-scene::before { background: none; }
+.ag-root[data-agent-tema='minimalista'] .ag-scene::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 412 300' preserveAspectRatio='xMidYMin slice'%3E%3Cpath fill='none' stroke='%232f6e5a' stroke-opacity='0.14' stroke-width='1.5' d='M-10 84 C 90 44 220 116 300 72 C 340 50 390 62 422 54'/%3E%3C/svg%3E");
+  background-position: center top;
+  background-size: 100% auto;
+}
+.ag-root[data-agent-tema='minimalista'] .ag-mote { display: none; }
+/* La costura del compositor se vuelve UNA línea continua fina. */
+.ag-root[data-agent-tema='minimalista'] .ag-composer::before {
+  background-image: none;
+  background-color: rgba(var(--ag-accent), 0.3);
+  height: 1.5px;
+}
+/* El CTA de la mano pierde el degradé: tarjeta blanca con borde de trazo. */
+.ag-root[data-agent-tema='minimalista'] .ag-mano-cta {
+  background: rgb(var(--c-surface-card, 255 255 255));
+  box-shadow: 0 8px 22px -16px rgba(31, 36, 33, 0.35);
+}
+
+/* ── P3 · MOTION — la vida de la escena y de los controles ─────────────────
+   Todo se APAGA bajo prefers-reduced-motion (bloque final). */
+
+/* Esporas/brasas/polen: suben lento y se desvanecen. */
+@keyframes ag-mote-rise {
+  0%   { opacity: 0; transform: translateY(0) scale(0.8); }
+  12%  { opacity: 1; }
+  78%  { opacity: 0.7; }
+  100% { opacity: 0; transform: translateY(-46vh) scale(1.15); }
+}
+/* Hojitas verde-vivo: caen meciéndose. */
+@keyframes ag-mote-fall {
+  0%   { opacity: 0; transform: translateY(-8vh) rotate(0deg); }
+  14%  { opacity: 0.8; }
+  80%  { opacity: 0.5; }
+  100% { opacity: 0; transform: translateY(38vh) rotate(300deg); }
+}
+.ag-mote { animation: ag-mote-rise 16s linear infinite; }
+.ag-mote:nth-child(2) { animation-duration: 19s; }
+.ag-mote:nth-child(3) { animation-duration: 14s; }
+.ag-mote:nth-child(5) { animation-duration: 21s; }
+.ag-root[data-agent-tema='verde-vivo'] .ag-mote {
+  top: -4vh;
+  bottom: auto;
+  animation-name: ag-mote-fall;
+  animation-timing-function: ease-in-out;
+}
+/* Nature: el polen se mece más corto y suave. */
+.ag-root[data-agent-tema='nature'] .ag-mote {
+  animation-duration: 24s;
+}
+
+/* El glifo de la mano respira con el acento (invita al toque, como el mic). */
+@keyframes ag-mano-breathe {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(var(--ag-accent), 0.35); }
+  50%      { box-shadow: 0 0 0 9px rgba(var(--ag-accent), 0); }
+}
+.ag-mano-cta-glyph { animation: ag-mano-breathe 3.4s ease-in-out infinite; }
+.ag-root[data-agent-tema='minimalista'] .ag-mano-cta-glyph { animation: none; }
+
+/* Tick de grounding: pop sutil al estabilizarse la respuesta. */
+@keyframes ag-tick-pop {
+  0%   { opacity: 0; transform: scale(0.4); }
+  70%  { transform: scale(1.18); }
+  100% { opacity: 1; transform: scale(1); }
+}
+.v3-card [data-testid='grounded-tick'] {
+  animation: ag-tick-pop 0.32s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+
+/* Suavizar el cambio de tema en las superficies grandes. */
+.ag-header,
+.ag-composer,
+.ag-mano-cta {
+  transition-property: background, background-color, border-color, box-shadow, color;
+  transition-duration: 0.35s;
+  transition-timing-function: ease;
+}
+
+/* ── P4 · REFINAMIENTO — foco visible del tema + densidad ────────────────── */
+.ag-root button:focus-visible,
+.ag-root textarea:focus-visible,
+.ag-root a:focus-visible {
+  outline: 2.5px solid rgba(var(--ag-accent), 0.75);
+  outline-offset: 2px;
+}
+
+/* En claros, el placeholder del textarea hereda tinta suave del tema. */
+.ag-root .as-bar textarea::placeholder {
+  color: rgb(var(--c-slate-400, 100 116 139) / 0.9);
+}
+
+/* ── APAGADO TOTAL DE MOVIMIENTO ──────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ag-mote { animation: none !important; opacity: 0.35; }
+  .ag-mano-cta-glyph { animation: none !important; }
+  .v3-card [data-testid='grounded-tick'] { animation: none !important; }
+  .ag-header,
+  .ag-composer,
+  .ag-mano-cta,
+  .ag-hbtn { transition: none !important; }
+}

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -49,43 +49,58 @@ export const AGENT_ENTRANCE_CSS = `
 `;
 
 /**
- * CSS del compositor multimodal del AgentScreen. Idéntico a los tokens de
- * AgentHero para garantizar paridad visual completa (2026-06-08).
+ * CSS del compositor multimodal del AgentScreen.
+ *
+ * REDISEÑO POR TEMA (2026-07): las superficies/acentos ya NO van hardcodeados
+ * en slate/emerald — salen de los tokens --ag-* que define agent-skin.css por
+ * tema (indirección CSS-var, política feedback-themes-cssvar-indirection).
+ * Cada var lleva FALLBACK = el valor histórico exacto, así el pill se ve
+ * idéntico al de siempre si algún contexto no define la piel (p.ej. tests
+ * unitarios que montan el compositor sin el root .ag-root).
  */
 export const AGENT_COMPOSITOR_CSS = `
   .as-bar {
     display: flex; align-items: center; gap: 8px;
-    background: rgba(30,41,59,0.85); border: 1px solid rgba(100,116,139,0.4);
-    border-radius: 20px; padding: 7px 8px;
-    box-shadow: 0 10px 30px -12px rgba(0,0,0,0.5);
-    transition: border-color 0.25s ease, box-shadow 0.25s ease;
+    background: var(--ag-bar-bg, rgba(30,41,59,0.85));
+    border: 1px solid var(--ag-bar-border, rgba(100,116,139,0.4));
+    border-radius: var(--ag-radius, 20px); padding: 7px 8px;
+    box-shadow: var(--ag-bar-shadow, 0 10px 30px -12px rgba(0,0,0,0.5));
+    transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.35s ease;
     position: relative; overflow: hidden;
     flex-direction: column; align-items: stretch;
   }
   .as-bar.is-recording { border-color: rgba(244,63,94,0.6); }
   .as-bar:focus-within {
-    border-color: rgba(16,185,129,0.55);
-    box-shadow: 0 10px 30px -12px rgba(0,0,0,0.5), 0 0 0 3px rgba(16,185,129,0.12);
+    border-color: rgba(var(--t-accent-rgb, 16,185,129), 0.55);
+    box-shadow: var(--ag-bar-shadow, 0 10px 30px -12px rgba(0,0,0,0.5)),
+                0 0 0 3px rgba(var(--t-accent-rgb, 16,185,129), 0.12);
   }
+  .as-bar textarea { color: var(--ag-input-ink, #fff); }
   .as-iconbtn {
     width: 44px; height: 44px; flex: none; border-radius: 50%;
-    background: rgba(30,41,59,0.9); border: 1px solid rgba(100,116,139,0.4);
+    background: var(--ag-iconbtn-bg, rgba(30,41,59,0.9));
+    border: 1px solid var(--ag-iconbtn-border, rgba(100,116,139,0.4));
     display: flex; align-items: center; justify-content: center;
-    color: rgb(148,163,184); cursor: pointer; position: relative;
+    color: var(--ag-iconbtn-ink, rgb(148,163,184)); cursor: pointer; position: relative;
     transition: transform 0.16s cubic-bezier(0.22,0.61,0.36,1),
                 background 0.25s ease, border-color 0.25s ease, color 0.2s ease;
   }
-  .as-iconbtn:hover { color: #fff; border-color: rgba(16,185,129,0.5); }
+  .as-iconbtn:hover {
+    color: var(--ag-iconbtn-ink-hover, #fff);
+    border-color: rgba(var(--t-accent-rgb, 16,185,129), 0.5);
+  }
   .as-iconbtn:active { transform: scale(0.9); }
   .as-iconbtn:disabled { opacity: 0.4; cursor: not-allowed; }
   .as-tool { animation: as-pulse-ring 3.6s cubic-bezier(.22,.61,.36,1) infinite; }
   .as-tool.is-open {
-    background: rgb(16,185,129); border-color: rgb(16,185,129); animation: none;
+    background: rgb(var(--t-accent-rgb, 16,185,129));
+    border-color: rgb(var(--t-accent-rgb, 16,185,129)); animation: none;
+    color: #fff;
   }
   @keyframes as-pulse-ring {
-    0%   { box-shadow: 0 0 0 0 rgba(16,185,129,0.45); }
-    70%  { box-shadow: 0 0 0 12px rgba(16,185,129,0); }
-    100% { box-shadow: 0 0 0 0 rgba(16,185,129,0); }
+    0%   { box-shadow: 0 0 0 0 rgba(var(--t-accent-rgb, 16,185,129),0.45); }
+    70%  { box-shadow: 0 0 0 12px rgba(var(--t-accent-rgb, 16,185,129),0); }
+    100% { box-shadow: 0 0 0 0 rgba(var(--t-accent-rgb, 16,185,129),0); }
   }
   .as-mic-on {
     background: rgb(244,63,94) !important; border-color: rgb(244,63,94) !important;
@@ -140,9 +155,19 @@ export const AGENT_COMPOSITOR_CSS = `
     width: 46px; height: 46px; flex: none; border: none; border-radius: 50%;
     display: flex; align-items: center; justify-content: center; cursor: pointer;
     overflow: hidden; padding: 0;
-    transition: opacity 0.25s ease, box-shadow 0.25s ease;
+    /* PIEL POR TEMA (rediseño 2026-07): el fondo/glow salen de --ag-send-* de
+       agent-skin.css (teal-cian en biopunk, ocre en nature, verde en
+       verde-vivo/minimalista). Antes iban inline en el JSX con el gradiente
+       teal fijo. El estado deshabilitado apaga color y sombra acá mismo. */
+    background: var(--ag-send-bg, linear-gradient(135deg,#10b981 0%,#0891b2 100%));
+    box-shadow: var(--ag-send-glow, 0 0 18px rgba(16,185,129,0.5));
+    transition: opacity 0.25s ease, box-shadow 0.25s ease, background 0.35s ease;
   }
-  .as-send:disabled { opacity: 0.35; cursor: not-allowed; }
+  .as-send:disabled {
+    opacity: 0.35; cursor: not-allowed;
+    background: var(--ag-iconbtn-bg, rgba(51,65,85,0.8));
+    box-shadow: none;
+  }
   @keyframes as-send-shimmer {
     0%   { transform: translateX(-130%); opacity: 0; }
     25%  { opacity: 1; }
@@ -156,7 +181,7 @@ export const AGENT_COMPOSITOR_CSS = `
   }
   .as-shimmer::after {
     content: ''; position: absolute; inset: 0; border-radius: inherit;
-    background: linear-gradient(100deg, transparent 12%, rgba(16,185,129,0.55) 50%, transparent 88%);
+    background: linear-gradient(100deg, transparent 12%, rgba(var(--t-accent-rgb, 16,185,129),0.55) 50%, transparent 88%);
     animation: as-send-shimmer 0.52s cubic-bezier(0.22,0.61,0.36,1) forwards;
     pointer-events: none;
   }
@@ -440,25 +465,27 @@ export const AGENT_V3_CSS = `
     font-family: 'Nunito', system-ui, sans-serif;
   }
   /* LA COSTURA (firma V3): respuesta respaldada por el catálogo = puntada de
-     hilo esmeralda en el borde izquierdo, como la costura de un costal. Las
-     respuestas solo-generativas no llevan hilo. */
+     HILO DEL ACENTO DEL TEMA en el borde izquierdo, como la costura de un
+     costal (rediseño 2026-07: antes esmeralda fija; ahora teal en biopunk,
+     ocre en nature, verde en verde-vivo/minimalista — la misma puntada del
+     compositor y la mochila). Las solo-generativas no llevan hilo. */
   .v3-card[data-grounded="true"] { padding-left: 22px; }
   .v3-card[data-grounded="true"]::before {
     content: ''; position: absolute; left: 9px; top: 12px; bottom: 12px;
     width: 2.5px; border-radius: 2px;
     background-image: repeating-linear-gradient(
       180deg,
-      rgb(var(--c-emerald-500, 16 185 129)) 0 7px,
+      rgba(var(--t-accent-rgb, 16, 185, 129), 0.95) 0 7px,
       transparent 7px 13px
     );
   }
   .v3-bubble-user {
     max-width: 82%; padding: 10px 14px;
     border-radius: 18px 18px 5px 18px;
-    background: rgb(var(--c-emerald-700, 4 120 87));
-    border: 1px solid rgb(var(--c-emerald-500, 16 185 129) / 0.35);
+    background: var(--ag-user-bg, rgb(var(--c-emerald-700, 4 120 87)));
+    border: 1px solid var(--ag-user-border, rgb(var(--c-emerald-500, 16 185 129) / 0.35));
     box-shadow: 0 8px 22px -14px rgb(var(--c-emerald-700, 4 120 87) / 0.8);
-    color: #fff; font-family: 'Nunito', system-ui, sans-serif;
+    color: var(--ag-user-ink, #fff); font-family: 'Nunito', system-ui, sans-serif;
   }
 
   @keyframes v3-rise { from { transform: translateY(100%); } to { transform: translateY(0); } }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -952,52 +952,14 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
 }
 
 /* ===========================================================================
- * COMPOSITOR DEL AGENTE + ContextTip en TEMAS CLAROS (operador 2026-06-22
- * "sigo viendo nature mal", #72).
- *
- * El compositor (.as-bar / .as-iconbtn, AGENT_COMPOSITOR_CSS) está hardcodeado
- * con slate oscuro rgba(30,41,59,…) — correcto en biopunk (oscuro) pero, sobre
- * la crema/papel del AgentScreen claro (ver index.css .agent-scrim por tema),
- * quedaba como una pastilla NEGRA flotando — lo que el operador lee como
- * "nature mal/sucio". El demo (demo-agente.html .bar) usa --superf cremoso con
- * botones --blanco y texto --cafe. Aquí lo viramos a la superficie del tema en
- * nature/minimalista (la indirección --c-* no llega porque son RGBA literales
- * en el <style> inline del JSX). Biopunk no se toca. Español Colombia.
- *
- * También: la tarjeta ContextTip ("¿Una mata enferma?…") usa bg-emerald-950/50;
- * en nature NO existe --c-emerald-950 → caía al verde-oscuro Tailwind. Sobre la
- * crema quedaba como un bloque verde oscuro. La viramos a una tarjeta clara con
- * borde salvia del tema. =========================================================================== */
-
-/* Pastilla del compositor → superficie clara del tema (= --superf del demo). */
-[data-theme="nature"] .as-bar,
-[data-theme="minimalista"] .as-bar,
-[data-theme="verde-vivo"] .as-bar{
-  background: rgb(var(--c-surface-raised) / 0.97);
-  border-color: rgb(var(--c-surface-border));
-  box-shadow: 0 10px 30px -14px rgba(0, 0, 0, 0.22);
-}
-/* Texto que escribe el productor: el textarea es text-white (invisible sobre
- * crema). En claros = café/tinta del tema. El placeholder ya sale de --c-*. */
-[data-theme="nature"] .as-bar textarea,
-[data-theme="minimalista"] .as-bar textarea,
-[data-theme="verde-vivo"] .as-bar textarea{
-  color: rgb(var(--c-slate-100));
-}
-/* Botones de ícono del compositor → blanco/papel con ícono café del tema. */
-[data-theme="nature"] .as-iconbtn,
-[data-theme="minimalista"] .as-iconbtn,
-[data-theme="verde-vivo"] .as-iconbtn{
-  background: rgb(var(--c-surface-card));
-  border-color: rgb(var(--c-surface-border));
-  color: rgb(var(--c-slate-300));
-}
-[data-theme="nature"] .as-iconbtn:hover,
-[data-theme="minimalista"] .as-iconbtn:hover,
-[data-theme="verde-vivo"] .as-iconbtn:hover{
-  color: rgb(var(--c-slate-100));
-  border-color: rgb(var(--t-accent-rgb) / 0.55);
-}
+ * COMPOSITOR DEL AGENTE — MOVIDO (rediseño agente 2026-07).
+ * Los overrides clase-por-clase [data-theme] .as-bar / .as-iconbtn que vivían
+ * acá se retiraron: el compositor ahora consume los tokens --ag-* que define
+ * src/components/AgentScreen/agent-skin.css POR TEMA (indirección CSS-var,
+ * política feedback-themes-cssvar-indirection). Los defaults de esos tokens
+ * derivan de --c-surface-* → en claros el pill ya sale papel/crema sin tocar
+ * nada acá. Se conserva SOLO el ajuste del ContextTip (clase Tailwind sin
+ * token en claros). =========================================================================== */
 
 /* ContextTip ("¿Una mata enferma? Mándeme una foto") — tarjeta clara del tema
  * en vez del verde-oscuro Tailwind (no hay --c-emerald-950 en claros). */

--- a/tests/visual/agent-redesign-temas.mjs
+++ b/tests/visual/agent-redesign-temas.mjs
@@ -1,0 +1,304 @@
+// agent-redesign-temas.mjs — VERIFICACIÓN VISUAL del rediseño del AgentScreen
+// en los 5 temas (biopunk2, biopunk, nature, verde-vivo, minimalista), en DOS
+// estados por tema:
+//   (1) empty  → pantalla de llegada (saludo + CTA de la mano de Chagra)
+//   (2) chat   → conversación sembrada en IndexedDB (turno usuario + respuesta
+//                groundeada + respuesta generativa) → burbujas, costura, badges.
+// Además mide contraste WCAG del texto del compositor y del saludo (los temas
+// claros no pueden lavar el chat) y verifica que los elementos BASE conservados
+// existan: mano (Ⓐ + CTA), cámara, micrófono, enviar, selector de temas
+// (mochila "Temas"), input.
+//
+// NixOS: chromium del nix-store (executablePath) — el bundled de Playwright
+// falla por libs faltantes (memoria reference-playwright-nixos-setup).
+//
+// Uso: node tests/visual/agent-redesign-temas.mjs <baseURL> <label> [outDir]
+//   baseURL sirve el dist a verificar (vite preview). label = before|after.
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const BASE = process.argv[2] || 'http://127.0.0.1:3011';
+const LABEL = process.argv[3] || 'after';
+const OUT_DIR = process.argv[4] || '/tmp/agent-redesign-temas';
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const KNOWN_CHROMIUM = [
+  '/nix/store/r7ifk1v95jfl02775kgbrd61dyr1rfsx-chromium-148.0.7778.178/bin/chromium',
+  '/nix/store/9fjg59mab9j8c5r61dx2k5gcbd2f5mpm-chromium-148.0.7778.96/bin/chromium',
+];
+function resolveChromium() {
+  if (process.env.CHROMIUM_PATH) return process.env.CHROMIUM_PATH;
+  for (const p of KNOWN_CHROMIUM) { try { if (fs.existsSync(p)) return p; } catch { /* sigue */ } }
+  return execSync('nix-shell -p chromium --run "which chromium"', { encoding: 'utf8', timeout: 120000 })
+    .trim().split('\n').pop().trim();
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PROFILE = {
+  nombre: 'Lili', vocacion: 'campesino', rol: 'campesino', finca_tipo: 'rural',
+  finca_altitud: '1900', piso_termico: 'templado', cultivos_actuales: 'café, plátano',
+  objetivo: ['producir_mas'],
+};
+const USER = 'lili';
+
+// Los 5 temas del selector. biopunk y biopunk2 comparten piel base (sin
+// data-theme en <html>) — la diferencia la resuelve el JS (chagra:theme).
+const THEMES = [
+  { id: 'biopunk2', dataTheme: null },
+  { id: 'biopunk', dataTheme: null },
+  { id: 'nature', dataTheme: 'nature' },
+  { id: 'verde-vivo', dataTheme: 'verde-vivo' },
+  { id: 'minimalista', dataTheme: 'minimalista' },
+];
+
+// Turnos sembrados (IDB conversation_memory) — un intercambio realista:
+// pregunta del usuario, respuesta GROUNDEADA (costura + badges) y una segunda
+// pregunta con respuesta GENERATIVA (badge ámbar). Timestamps recientes
+// (< 30 min) para que loadHistory NO la trate como sesión nueva.
+function seedTurns(now) {
+  return [
+    {
+      role: 'user',
+      content: '¿Qué le sirve al café para la broca?',
+      offsetMs: -6 * 60 * 1000,
+    },
+    {
+      role: 'assistant',
+      content: 'Para la broca del café le sirve la avispa Cephalonomia stephanoderis y el hongo Beauveria bassiana. Aplique el hongo en la mañana, con la primera floración. También ayuda recoger los frutos brocados del suelo cada semana.',
+      offsetMs: -5.5 * 60 * 1000,
+      metadata: { tool_used: 'get_pest_controllers', grounded: true, confianza: 'alta' },
+    },
+    {
+      role: 'user',
+      content: '¿Y cada cuánto riego las matas nuevas?',
+      offsetMs: -2 * 60 * 1000,
+    },
+    {
+      role: 'assistant',
+      content: 'Las matas nuevas de café necesitan riego cada 2 o 3 días mientras prenden, según el sol que les caiga. Si la hoja se ve caída en la mañana, riegue ese mismo día. En tierra templada como la suya, la seca de enero pide más cuidado.',
+      offsetMs: -1.5 * 60 * 1000,
+      metadata: { tool_used: null, grounded: false },
+    },
+  ].map((t, i) => ({
+    id: `seed_${now}_${i}`,
+    role: t.role,
+    content: t.content,
+    metadata: t.metadata || null,
+    timestamp: now + t.offsetMs,
+    created_at: new Date(now + t.offsetMs).toISOString(),
+  }));
+}
+
+function stubAuthIDB(page) {
+  return page.evaluate(() => new Promise((resolve, reject) => {
+    const put = (db) => {
+      const tx = db.transaction('syncQueue', 'readwrite');
+      const s = tx.objectStore('syncQueue');
+      s.put('stub-token-for-ui-screenshot', 'farmos_access_token');
+      s.put(Date.now() + 3600e3, 'farmos_token_expiry');
+      tx.oncomplete = () => { db.close(); resolve('ok'); };
+      tx.onerror = () => reject(tx.error);
+    };
+    const o = indexedDB.open('Chagra');
+    o.onupgradeneeded = () => { try { o.result.createObjectStore('syncQueue'); } catch { /* ya existe */ } };
+    o.onerror = () => reject(o.error);
+    o.onsuccess = () => {
+      const db = o.result;
+      if (db.objectStoreNames.contains('syncQueue')) return put(db);
+      const v = db.version + 1; db.close();
+      const up = indexedDB.open('Chagra', v);
+      up.onupgradeneeded = () => up.result.createObjectStore('syncQueue');
+      up.onsuccess = () => put(up.result);
+      up.onerror = () => reject(up.error);
+    };
+  }));
+}
+
+// Siembra la conversación para AMBOS operatorIds posibles (prefs store puede
+// no estar hidratado en el harness → 'default-operator'). OJO: la DB de la app
+// es 'ChagraDB' (dbCore.js) — 'Chagra' es SOLO el stub de auth del login gate.
+function seedConversation(page, turns) {
+  return page.evaluate((turns) => new Promise((resolve, reject) => {
+    const o = indexedDB.open('ChagraDB');
+    o.onerror = () => reject(o.error);
+    o.onsuccess = () => {
+      const db = o.result;
+      if (!db.objectStoreNames.contains('conversation_memory')) {
+        db.close();
+        return reject(new Error('store conversation_memory no existe aún'));
+      }
+      const tx = db.transaction('conversation_memory', 'readwrite');
+      const s = tx.objectStore('conversation_memory');
+      for (const opId of ['default-operator', 'lili']) {
+        for (const t of turns) {
+          s.put({ ...t, id: `${t.id}_${opId}`, operator_id: opId });
+        }
+      }
+      tx.oncomplete = () => { db.close(); resolve('ok'); };
+      tx.onerror = () => reject(tx.error);
+    };
+  }), turns);
+}
+
+function seedLocalStorage(page, themeId) {
+  return page.evaluate(({ profile, user, themeId }) => {
+    localStorage.setItem('chagra:profile:v1', JSON.stringify(profile));
+    localStorage.setItem('chagra:active_tenant_id', user);
+    localStorage.setItem('chagra:profile:done:v1', '1');
+    localStorage.setItem('chagra:theme', themeId);
+    // Silenciar tips de primera vez para capturas estables.
+    try { localStorage.setItem('chagra:context-tips:v1', JSON.stringify({ 'foto-diagnostico': true })); } catch { /* opcional */ }
+  }, { profile: PROFILE, user: USER, themeId });
+}
+
+function applyDataTheme(page, dataTheme) {
+  return page.evaluate((dt) => {
+    if (dt) document.documentElement.setAttribute('data-theme', dt);
+    else document.documentElement.removeAttribute('data-theme');
+  }, dataTheme);
+}
+
+function parseRGB(str) {
+  const m = String(str).match(/rgba?\(([^)]+)\)/);
+  if (!m) return null;
+  const parts = m[1].split(',').map((s) => parseFloat(s.trim()));
+  return { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 };
+}
+function lum({ r, g, b }) {
+  const f = (c) => { c /= 255; return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4; };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+function contrast(fg, bg) {
+  const L1 = lum(fg), L2 = lum(bg);
+  const [hi, lo] = L1 >= L2 ? [L1, L2] : [L2, L1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Contraste de un elemento contra su primer ancestro con fondo sólido.
+function measureContrast(page, selector) {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return null;
+    const cs = getComputedStyle(el);
+    let node = el, bg = null;
+    while (node && node !== document.documentElement) {
+      const b = getComputedStyle(node).backgroundColor;
+      const m = b.match(/rgba?\(([^)]+)\)/);
+      if (m) {
+        const a = m[1].split(',')[3];
+        if (a === undefined || parseFloat(a) > 0.5) { bg = b; break; }
+      }
+      node = node.parentElement;
+    }
+    return { color: cs.color, bg: bg || 'rgb(10,14,20)' };
+  }, selector);
+}
+
+(async () => {
+  const browser = await chromium.launch({
+    executablePath: resolveChromium(), headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-software-rasterizer'],
+  });
+  let anyFail = false;
+  const summary = [];
+
+  for (const t of THEMES) {
+    const ctx = await browser.newContext({
+      viewport: { width: 412, height: 915 }, locale: 'es-CO', deviceScaleFactor: 2, isMobile: true,
+    });
+    // SIN route-stub de farmOS: el preview local responde 502 a la API y la
+    // app degrada limpio (igual que offline). Con el stub 200-vacío, la
+    // identidad del operador cambiaba y el history sembrado no se cargaba
+    // (verificado empíricamente 2026-07-04: sin stub hasCard=true).
+    const page = await ctx.newPage();
+    page.setDefaultTimeout(45000);
+    const errs = [];
+    page.on('pageerror', (e) => errs.push(e.message));
+
+    try {
+      // ── (1) EMPTY STATE ──────────────────────────────────────────────────
+      await page.goto(BASE + '/', { waitUntil: 'domcontentloaded', timeout: 40000 });
+      await stubAuthIDB(page);
+      await seedLocalStorage(page, t.id);
+      await applyDataTheme(page, t.dataTheme);
+      await page.goto(BASE + '/#agente', { waitUntil: 'domcontentloaded', timeout: 40000 });
+      await sleep(1200);
+      await page.evaluate(() => { window.location.hash = '#agente'; });
+      await applyDataTheme(page, t.dataTheme);
+      await page.waitForSelector('[data-testid="agent-mano-trigger"]', { timeout: 30000 });
+      await sleep(2200);
+
+      // Elementos base conservados (mano, cámara, mic, enviar, temas, input).
+      const conserved = await page.evaluate(() => ({
+        manoCta: !!document.querySelector('[data-testid="agent-mano-trigger"]'),
+        aBtn: !!document.querySelector('button.as-tool'),
+        camara: !!document.querySelector('button[aria-label="Tomar o elegir foto"]'),
+        mic: !!document.querySelector('[data-testid="agent-mic-btn"]'),
+        enviar: !!document.querySelector('[data-testid="agent-submit"]'),
+        temas: !!document.querySelector('[data-testid="agent-modos-trigger"]'),
+        input: !!document.querySelector('[data-testid="agent-input"]'),
+      }));
+      const missing = Object.entries(conserved).filter(([, v]) => !v).map(([k]) => k);
+
+      const emptyShot = `${OUT_DIR}/${LABEL}-${t.id}-empty.png`;
+      await page.screenshot({ path: emptyShot, fullPage: false });
+
+      // Contraste del saludo del empty-state.
+      const greet = await measureContrast(
+        page,
+        '[data-testid="proactive-greeting-lead"], [data-testid="chat-scroll"] p, .relative.z-10 p',
+      );
+      let greetContrast = null;
+      if (greet) {
+        const fg = parseRGB(greet.color), bg = parseRGB(greet.bg);
+        if (fg && bg) greetContrast = contrast(fg, bg).toFixed(2);
+      }
+
+      // ── (2) CHAT SEMBRADO ───────────────────────────────────────────────
+      // OJO: goto al MISMO /#agente NO recarga (hash-only) → reload explícito
+      // para que loadHistory hidrate los turnos sembrados.
+      await seedConversation(page, seedTurns(Date.now()));
+      await page.reload({ waitUntil: 'domcontentloaded', timeout: 40000 });
+      await sleep(1200);
+      await page.evaluate(() => { window.location.hash = '#agente'; });
+      await applyDataTheme(page, t.dataTheme);
+      await page.waitForSelector('.v3-card, .v3-bubble-user', { timeout: 30000 });
+      await sleep(2000);
+
+      const chatShot = `${OUT_DIR}/${LABEL}-${t.id}-chat.png`;
+      await page.screenshot({ path: chatShot, fullPage: false });
+
+      // Contraste del texto de la tarjeta del agente.
+      const card = await measureContrast(page, '.v3-card p');
+      let cardContrast = null;
+      if (card) {
+        const fg = parseRGB(card.color), bg = parseRGB(card.bg);
+        if (fg && bg) cardContrast = contrast(fg, bg).toFixed(2);
+      }
+      const costura = await page.evaluate(() => !!document.querySelector('.v3-card[data-grounded="true"]'));
+
+      const ok = missing.length === 0
+        && (greetContrast === null || parseFloat(greetContrast) >= 4.5)
+        && (cardContrast === null || parseFloat(cardContrast) >= 4.5);
+      if (!ok) anyFail = true;
+
+      summary.push({ tema: t.id, ok, missing, greetContrast, cardContrast, costura, emptyShot, chatShot, errs: errs.slice(0, 2) });
+      console.log(`\n══════ ${LABEL} · ${t.id} ══════`);
+      console.log(`  conservados: ${missing.length === 0 ? '✓ todos' : `✗ FALTAN ${missing.join(',')}`}`);
+      console.log(`  contraste saludo=${greetContrast ?? 'n/a'}  tarjeta=${cardContrast ?? 'n/a'}  costura-grounded=${costura ? '✓' : '✗'}`);
+      console.log(`  capturas -> ${emptyShot} | ${chatShot}`);
+      if (errs.length) console.log('  pageerrors:', errs.slice(0, 3));
+    } catch (e) {
+      console.error(`[${t.id}] FAIL:`, e.message);
+      try { await page.screenshot({ path: `${OUT_DIR}/${LABEL}-${t.id}-FAIL.png` }); } catch { /* mejor esfuerzo */ }
+      anyFail = true;
+    } finally {
+      await ctx.close();
+    }
+  }
+  await browser.close();
+  console.log('\n══════ RESUMEN ══════');
+  for (const s of summary) console.log(JSON.stringify(s));
+  process.exitCode = anyFail ? 1 : 0;
+})();


### PR DESCRIPTION
## Rediseño del AgentScreen por concepto de tema (4 pasadas)

El operador: el home finca-viva quedó espectacular pero la pantalla del AGENTE
(chat) se quedó atrás — "una pieza NO digna del trabajo que se le ha metido".
Este PR la eleva a la altura del home: **cada tema imprime su alma en el chat**,
vía indirección CSS-var (tokens `--ag-*`), sin parches clase-por-clase.

### Pasada 1 — Concepto + layout
- Nueva capa de tokens `--ag-*` + clases estructurales (`agent-skin.css`):
  header con jerarquía (`.ag-header` + hilo del acento como firma), botones
  fantasma del tema (`.ag-hbtn`), título en Baloo 2, banners unificados
  (`.ag-banner`), compositor con LA COSTURA del acento como borde superior.
- **La mano protagonista**: el CTA de pantalla vacía pasa de barrita verde
  genérica a tarjeta viva del tema — medallón con `ManoChagraGlyph` que respira
  con el acento + jerarquía de texto.
- El root del agente lleva `data-agent-tema` (resuelto con `resolveAutoTheme`,
  igual que `ESCENA_VIVA_POR_TEMA` del home) porque biopunk/biopunk2 comparten
  piel base sin `data-theme`.

### Pasada 2 — Piel por tema (escena ambiental `.ag-scene`)
- **biopunk2** "Organismo nocturno": micelio SVG + esporas teal que suben.
- **biopunk** "Cosecha mística": el hilo ROJO de la Ⓐ anarco-agro (hairline
  rojo→teal, medallón de la mano rojo, brasas alternadas), radios más rectos.
- **nature** "Árbol de la Vida": amanecer ocre, ramas de café, polen dorado,
  burbuja del productor en terracota, enviar ocre.
- **verde-vivo** "Huerto exuberante": dosel de hojas arriba, sol cálido,
  hojitas que caen meciéndose, enviar verde hoja.
- **minimalista** "Un solo trazo": papel + UNA línea, cero glow, cero motas,
  radios rectos, costura → línea continua fina.
- El compositor (`AGENT_COMPOSITOR_CSS`) y el cuaderno V3 consumen los tokens
  con fallback = valores históricos exactos (tests/contextos sin piel intactos).

### Pasada 3 — Motion + pulido
- Motas de vida por tema (esporas/brasas/polen/hojitas — minimalista ninguna).
- La mano respira con el acento; tick de grounding con pop; shimmer de envío y
  anillo del Ⓐ re-tintados al acento del tema; transición suave al cambiar tema.
- `prefers-reduced-motion` apaga TODO el movimiento nuevo (bloque kill-switch).

### Pasada 4 — Refinamiento
- Subtítulo del header ya no se trunca ("AGENTE AGR…" → parte en 2 líneas).
- Tinta cálida `--ag-warn-ink` oscura en temas claros (banners/ayuda/pensando
  AA sobre papel — el amarillo del dark se lavaba).
- `focus-visible` con el acento del tema; "Volver" flotante y textarea por
  tokens (antes slate/white fijos, ilegibles en claros).
- Limpieza: los overrides `[data-theme] .as-bar/.as-iconbtn` de themes.css se
  retiraron (reemplazados por la indirección — cero duplicación).

### Conservado (elevado, no removido)
Mano de Chagra (Ⓐ + `AgentRedMenu` + CTA), cámara, micrófono grande, enviar,
selector de temas (mochila "Temas"), burbujas + costura grounded, badges de
fuente/confianza, deep-links, flujo NLU/tools/sidecar intacto (cero cambios de
lógica). Compatible con #2076 (SemaphoreBadge): `ChatBubble.jsx` no se tocó.

### Verificación
- `npx vitest run` AgentScreen/agent/ChatBubble: **10 archivos · 87 tests ✓**
- Build vite ✓ · eslint (archivos tocados) ✓
- Visual: harness nuevo `tests/visual/agent-redesign-temas.mjs` (chromium nix,
  aislado del login gate, conversación sembrada en IDB) — 5 temas × 2 estados
  × antes/después = 20 capturas; contraste WCAG saludo/tarjeta ≥ 9.5:1 en
  todos los temas; elementos base verificados presentes en los 5 temas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
