### PR TITLE
fix(agente): resolución determinística de precio/mercado ANTES del NLU (misroute "papa")

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -65,6 +65,11 @@ import { buildAyudaResponse } from '../../services/ayudaAgentResponder';
 // para intentar AL MENOS una consulta al grafo en vez de caer a generativo puro.
 import { planNluFallback } from '../../services/agentNluFallback';
 import { planKnowledgeIntent, hasSoilDiagnosticIntent } from '../../services/knowledgeIntentRouter';
+// Fix misroute "papa precio" (2026-07-05): router PURO que detecta intención
+// de PRECIO/MERCADO ANTES de planKnowledgeIntent/planNlu — garantiza que
+// "a cómo está la papa" SIEMPRE llame get_precio_sipsa (dato vivo), nunca
+// termine en ficha/viabilidad/variedades. Ver cabecera de marketIntentRouter.js.
+import { planMarketIntent } from '../../services/marketIntentRouter';
 // Grounding OFFLINE del grafo (#49): cuando NO hay red, el bloque de relaciones
 // (plaga→controlador / compatibles / antagonistas / biopreparados / vernáculos)
 // se arma desde el export precacheado del grafo AGE (grafo-relations.json), en
@@ -1554,7 +1559,47 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           // y el agente responde neutral en vez de fabricar. No corre bajo chip
           // forzado (el chip ya decidió el tool determinístico).
           if (!forcedIntent) {
+            // PASO 2-pre0 — routing determinístico de PRECIO/MERCADO (fix
+            // misroute "papa precio", 2026-07-05). MÁXIMA PRIORIDAD: corre
+            // ANTES de planKnowledgeIntent (que podría atrapar "variedad"/
+            // "cultivar" en el mismo mensaje) y antes del planner NLU del
+            // sidecar (LLM chico, misroutea a ficha/viabilidad — bug
+            // histórico documentado en chipIntentRouter.js). Garantiza que
+            // TODA consulta de precio ejecute get_precio_sipsa (dato vivo de
+            // la tabla chagra.sipsa_precios, NUNCA la tabla estática
+            // precioReferencia.js). Se inyecta available:false SINTÉTICO si
+            // el tool no respondió (sidecar caído): el turno sigue siendo de
+            // precio, nunca cae a viabilidad/variedades por accidente.
+            // Aguas abajo, buildPriceAnswer (available:true) o
+            // buildPriceDeclineContext (available:false) deciden la
+            // respuesta — ambos ya groundeados y anti-alucinación.
             try {
+              const mPlan = planMarketIntent(textForLLM, resolvedEntities);
+              if (mPlan && mPlan.tool) {
+                const tM0 = performance.now();
+                const mResult = await callTool(mPlan.tool, mPlan.args);
+                const tM1 = performance.now();
+                toolEvidence = {
+                  tool: mPlan.tool,
+                  args: mPlan.args,
+                  result: mResult || {
+                    available: false,
+                    reason: 'sin_respuesta',
+                    hint: 'la herramienta de precios no respondió — declinar honesto (SIPSA/DANE/Corabastos), NO inventar un precio',
+                  },
+                };
+                nluRoute = `precio:${mPlan.source}`;
+                console.debug('[sidecar] precio/mercado (NLU saltado)', {
+                  tool: mPlan.tool,
+                  producto: mPlan.args.producto,
+                  source: mPlan.source,
+                  available: mResult ? mResult.available : false,
+                  latencyTool: Math.round(tM1 - tM0),
+                });
+              }
+            } catch (_) { /* graceful: sigue el flujo de conocimiento/NLU normal */ }
+
+            if (!toolEvidence) try {
               const kPlan = planKnowledgeIntent(textForLLM, resolvedEntities);
               if (kPlan && kPlan.tool) {
                 const tK0 = performance.now();

--- a/src/services/__tests__/marketIntentRouter.test.js
+++ b/src/services/__tests__/marketIntentRouter.test.js
@@ -1,0 +1,115 @@
+/**
+ * marketIntentRouter.test.js — routing determinístico de intención de
+ * PRECIO/MERCADO (fix misroute "papa precio", 2026-07-05).
+ *
+ * Contrato:
+ *   - SOLO dispara cuando classifyQueryIntent(userMessage) === 'precio'.
+ *   - El `producto` sale de la especie resuelta (mentioned/nombre_comun/
+ *     canonical_id, en ese orden) o, si no hay entidad, de una extracción
+ *     léxica conservadora (recorta fraseo de precio + artículos).
+ *   - SIEMPRE devuelve el tool get_precio_sipsa, acción 'latest_price' — NUNCA
+ *     get_variedades/get_species/get_variedades_cultivo.
+ */
+import { describe, it, expect } from 'vitest';
+import { planMarketIntent, __TEST__ } from '../marketIntentRouter.js';
+
+const { _extractProducto } = __TEST__;
+
+const sp = (mentioned, canonical_id = null, nombre_comun = null) => ({
+  kind: 'species',
+  mentioned,
+  canonical_id,
+  nombre_comun,
+});
+
+describe('planMarketIntent — guardas', () => {
+  it('mensaje vacío / no-string → null', () => {
+    for (const bad of [null, undefined, '', '   ', 42, {}]) {
+      expect(planMarketIntent(bad, [sp('papa')])).toBeNull();
+    }
+  });
+
+  it('sin intención de precio → null (deja el flujo agronómico normal)', () => {
+    expect(planMarketIntent('¿cómo siembro papa?', [sp('papa')])).toBeNull();
+    expect(planMarketIntent('¿qué variedades de café hay?', [sp('café')])).toBeNull();
+    expect(planMarketIntent('¿cómo controlo la broca del café?', null)).toBeNull();
+  });
+
+  it('sin producto reconocible (ni entidad ni texto útil tras recortar) → null', () => {
+    // Todo el mensaje es fraseo de precio puro, no queda sustantivo.
+    expect(planMarketIntent('¿cuánto cuesta?', null)).toBeNull();
+  });
+});
+
+describe('planMarketIntent — el caso "papa precio" (bug histórico)', () => {
+  it('"a cómo está la papa" con entidad resuelta → get_precio_sipsa, producto=mentioned', () => {
+    const plan = planMarketIntent('a cómo está la papa', [sp('papa', 'solanum_tuberosum', 'Papa')]);
+    expect(plan).toEqual({
+      tool: 'get_precio_sipsa',
+      args: { action: 'latest_price', producto: 'papa' },
+      source: 'market_precio_entidad',
+    });
+  });
+
+  it('NUNCA cae a get_variedades/get_species/get_variedades_cultivo', () => {
+    const plan = planMarketIntent('a cómo está la papa', [sp('papa', 'solanum_tuberosum', 'Papa')]);
+    expect(plan.tool).not.toBe('get_variedades');
+    expect(plan.tool).not.toBe('get_species');
+    expect(plan.tool).not.toBe('get_variedades_cultivo');
+    expect(plan.tool).toBe('get_precio_sipsa');
+  });
+
+  it('preserva la variedad literal mencionada ("papa criolla" ≠ "papa negra")', () => {
+    const plan = planMarketIntent('¿a cómo está la papa criolla?', [
+      sp('papa criolla', 'solanum_phureja', 'Papa criolla'),
+    ]);
+    expect(plan.args.producto).toBe('papa criolla');
+  });
+
+  it('sin entidad resuelta, extrae el producto por regex del texto crudo', () => {
+    const plan = planMarketIntent('a cómo está la papa', null);
+    expect(plan).toEqual({
+      tool: 'get_precio_sipsa',
+      args: { action: 'latest_price', producto: 'papa' },
+      source: 'market_precio_texto',
+    });
+  });
+});
+
+describe('planMarketIntent — variantes de fraseo campesino (sin entidad)', () => {
+  const casos = [
+    ['¿cuánto vale el bulto de papa?', 'papa'],
+    ['¿cuánto cuesta la arroba de tomate?', 'tomate'],
+    ['¿qué precio tiene la yuca?', 'yuca'],
+    ['precio de la cebolla', 'cebolla'],
+    ['¿a cómo está el aguacate?', 'aguacate'],
+    ['¿dónde puedo vender mi cosecha de maíz?', 'maiz'],
+    ['¿a cómo va el café en el mercado?', 'cafe en el'],
+    ['cuánto pagan por la carga de plátano', 'platano'],
+  ];
+
+  it.each(casos)('%s → producto reconocible', (texto, esperadoAprox) => {
+    const plan = planMarketIntent(texto, null);
+    expect(plan).not.toBeNull();
+    expect(plan.tool).toBe('get_precio_sipsa');
+    expect(plan.args.action).toBe('latest_price');
+    expect(typeof plan.args.producto).toBe('string');
+    expect(plan.args.producto.length).toBeGreaterThan(0);
+    // Aproximación laxa: el producto reconocible debe estar contenido en la
+    // extracción (best-effort, no exige match exacto en todos los fraseos).
+    expect(plan.args.producto).toContain(esperadoAprox.split(' ')[0]);
+  });
+});
+
+describe('_extractProducto — extracción léxica interna', () => {
+  it('recorta fraseo de precio y artículos, deja el sustantivo', () => {
+    expect(_extractProducto('a cómo está la papa')).toBe('papa');
+    expect(_extractProducto('¿cuánto vale el bulto de papa?')).toBe('papa');
+    expect(_extractProducto('precio de la cebolla')).toBe('cebolla');
+  });
+
+  it('mensaje sin sustantivo útil → null', () => {
+    expect(_extractProducto('¿cuánto cuesta?')).toBeNull();
+    expect(_extractProducto('a cómo está')).toBeNull();
+  });
+});

--- a/src/services/__tests__/marketIntentRouter.test.js
+++ b/src/services/__tests__/marketIntentRouter.test.js
@@ -24,7 +24,13 @@ const sp = (mentioned, canonical_id = null, nombre_comun = null) => ({
 
 describe('planMarketIntent — guardas', () => {
   it('mensaje vacío / no-string → null', () => {
-    for (const bad of [null, undefined, '', '   ', 42, {}]) {
+    // `any[]`: se testea deliberadamente el guard de tipo con valores que
+    // NO son string (null/undefined/number/object) — es la firma real de
+    // "entrada malformada" que `planMarketIntent` debe rechazar en runtime,
+    // no tiene sentido ensanchar el tipo público `userMessage: string` solo
+    // para este test (mismo patrón ya aceptado en knowledgeIntentRouter.test.js
+    // y agentNluFallback.test.js).
+    for (const bad of /** @type {any[]} */ ([null, undefined, '', '   ', 42, {}])) {
       expect(planMarketIntent(bad, [sp('papa')])).toBeNull();
     }
   });

--- a/src/services/marketIntentRouter.js
+++ b/src/services/marketIntentRouter.js
@@ -1,0 +1,122 @@
+/**
+ * marketIntentRouter.js — routing determinístico de intención de PRECIO/MERCADO.
+ *
+ * Por qué existe: el bug histórico "papa precio" (ver cabecera de
+ * `chipIntentRouter.js`) es que una pregunta de PRECIO ("a cómo está la
+ * papa") puede terminar respondida como si fuera agronómica (viabilidad,
+ * ficha de especie, variedades) porque el planner NLU del sidecar (LLM
+ * chico) o `planKnowledgeIntent` (que también dispara con la especie ya
+ * resuelta) deciden el tool sin saber que la intención real es de mercado.
+ *
+ * La detección de intención YA existe y está bien testeada
+ * (`classifyQueryIntent` en outputGuards.js, A12) — pero antes de este router
+ * solo se usaba para decidir si correr los guards de SIEMBRA, nunca para
+ * decidir qué TOOL llamar. Este módulo cierra ese hueco: replica el patrón
+ * PURO/SÍNCRONO/cero-red de `knowledgeIntentRouter`/`agentNluFallback` y
+ * devuelve el plan determinístico `get_precio_sipsa` (acción `latest_price`)
+ * cuando la intención es de precio.
+ *
+ * El caller (AgentScreen) debe ejecutar este plan ANTES de
+ * `planKnowledgeIntent`/`planNlu`/`planNluFallback` — así una consulta de
+ * precio NUNCA llega a un planner que pueda misroutearla. El resultado
+ * (available:true/false) ya tiene su propio manejo determinista aguas abajo
+ * en `agentService.js`: `buildPriceAnswer` CANTA el número real (dato vivo de
+ * la tabla `chagra.sipsa_precios`, feed diario DANE — NUNCA la tabla estática
+ * `precioReferencia.js`), y `buildPriceDeclineContext` declina honesto +
+ * orienta a SIPSA/DANE/Corabastos cuando no hay dato. Este router solo
+ * garantiza que el TOOL correcto sea el que se ejecuta.
+ *
+ * Extracción del `producto`: prioridad a la ESPECIE ya resuelta por
+ * `resolveEntities` (el texto que el usuario mencionó literalmente,
+ * `mentioned`, preserva variedades como "papa criolla" vs "papa negra" que
+ * SIPSA cotiza distinto — más específico que el `nombre_comun` genérico del
+ * grafo). Sin entidad resuelta, se extrae por regex: se recorta el fraseo de
+ * intención de precio/mercado y los artículos, dejando el sustantivo. Sin
+ * producto reconocible, no dispara (el flujo normal decide).
+ */
+
+import { classifyQueryIntent } from './outputGuards.js';
+
+/** ¿La entidad resuelta es una especie/cultivo (no plaga, no biopreparado)? */
+function _isSpecies(e) {
+  if (!e || typeof e !== 'object') return false;
+  const kind = String(e.kind || '').toLowerCase();
+  if (!kind) return true; // sin kind = asumimos especie (laxo, igual que knowledgeIntentRouter)
+  return kind === 'species' || kind === 'planta' || kind === 'especie' || kind === 'cultivo';
+}
+
+/**
+ * Normaliza a minúsculas SIN tildes (criterio del resto del pipeline) y sin
+ * signos de interrogación/exclamación (¿¡?! no aportan al producto y, como
+ * los de apertura españoles no tienen contraparte al final, ensucian la
+ * extracción si solo se recorta el borde final del texto).
+ */
+function _norm(text) {
+  return String(text)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[¿¡?!]/g, '');
+}
+
+// Fraseo de intención de precio/mercado a recortar para aislar el PRODUCTO.
+// Deliberadamente amplio (espejo de PRICE_INTENT_PATTERNS en outputGuards.js):
+// sobra recortar de más (el residuo se limpia con los artículos) a dejar
+// basura que el tool no pueda mapear a un producto SIPSA real.
+const PRICE_PHRASING_RE =
+  /\b(a\s+como\s+(esta|estan|va|van|vale|valen)|cuanto\s+(vale|valen|cuesta|cuestan|sale|salen|pagan|esta\s+pagando)|que\s+precio(\s+tiene[n]?)?|precio[s]?\s+(de|del)?|mercado\s+de|plaza\s+de\s+mercado|donde\s+(puedo\s+)?(vendo|vender|comprar|compro)|a\s+quien\s+(le\s+)?(vendo|vender)|vendo|vender|venta\s+de|comprar|compra\s+de|comprador\s+de|comercializ\w*|cosecha\s+para\s+(vender|venta)(\s+de)?|bulto[s]?\s+(de|a)|arroba[s]?\s+(de|a)|carga[s]?\s+(de|a))\b/g;
+const LEADING_ARTICLE_RE = /^(el|la|los|las|un|una|unos|unas|mi|del|al|de)\s+/;
+const TRAILING_PUNCT_RE = /[¿?¡!.,]+$/;
+
+/**
+ * Extrae el nombre del producto de una frase de precio, quitando el fraseo de
+ * intención y los artículos colgantes. Best-effort: si no queda nada útil,
+ * devuelve null (el caller no dispara sin producto reconocible).
+ *
+ * @param {string} text
+ * @returns {string|null}
+ */
+function _extractProducto(text) {
+  let t = _norm(text).replace(TRAILING_PUNCT_RE, '').trim();
+  t = t.replace(PRICE_PHRASING_RE, ' ').replace(/\s+/g, ' ').trim();
+  // Puede quedar un artículo colgante ("precio de" recortado deja "la papa");
+  // se recorta hasta dos veces por si hay doble artículo residual.
+  t = t.replace(LEADING_ARTICLE_RE, '').replace(LEADING_ARTICLE_RE, '').trim();
+  return t || null;
+}
+
+/**
+ * Deriva un plan determinístico `{ tool:'get_precio_sipsa', args, source }`
+ * para una consulta de PRECIO/MERCADO, o `null` si la intención no es de
+ * precio o no se pudo identificar un producto.
+ *
+ * @param {string} userMessage — texto crudo del usuario.
+ * @param {Array<object>|null} [resolvedEntities] - entidades canónicas ya
+ *   resueltas por `resolveEntities` ({ kind, canonical_id, mentioned,
+ *   nombre_comun, ... }).
+ * @returns {null | { tool: 'get_precio_sipsa', args: { action: 'latest_price', producto: string }, source: string }}
+ */
+export function planMarketIntent(userMessage, resolvedEntities = null) {
+  if (typeof userMessage !== 'string' || userMessage.trim().length === 0) {
+    return null;
+  }
+  if (classifyQueryIntent(userMessage) !== 'precio') return null;
+
+  const entities = Array.isArray(resolvedEntities) ? resolvedEntities : [];
+  const speciesEntity = entities.find(
+    (e) => _isSpecies(e) && (e.mentioned || e.nombre_comun || e.canonical_id),
+  );
+  const producto = speciesEntity
+    ? String(speciesEntity.mentioned || speciesEntity.nombre_comun || speciesEntity.canonical_id).trim()
+    : _extractProducto(userMessage);
+  if (!producto) return null;
+
+  return {
+    tool: 'get_precio_sipsa',
+    args: { action: 'latest_price', producto },
+    source: speciesEntity ? 'market_precio_entidad' : 'market_precio_texto',
+  };
+}
+
+// Export interno para testabilidad de los regex sin reflectar la closure.
+export const __TEST__ = { PRICE_PHRASING_RE, LEADING_ARTICLE_RE, _extractProducto, _norm };


### PR DESCRIPTION
## Resumen

"a cómo está la papa" y frases equivalentes ("cuánto vale X", "precio de X", "a cómo el bulto de papa") podían terminar respondidas como **ficha / viabilidad / variedades** en vez de como consulta de precio. Causa: `planKnowledgeIntent` / `planNlu` (planner NLU del sidecar, LLM chico) / `planNluFallback` deciden el tool sin saber que la intención real es de mercado — el bug histórico "papa precio" documentado en la cabecera de `chipIntentRouter.js`.

## Qué cambia

- **`marketIntentRouter.js`** (nuevo, PURO/síncrono/testeado — mismo patrón que `knowledgeIntentRouter.js`/`agentNluFallback.js`): detecta la intención de precio con `classifyQueryIntent` (ya existente, guard A12) y extrae el producto de la especie resuelta (`mentioned`, preserva variedades como "papa criolla" ≠ "papa negra") o por regex del texto crudo.
- **`AgentScreen.jsx`** (+45 líneas): un nuevo **PASO 2-pre0** que corre `planMarketIntent` **ANTES** de `planKnowledgeIntent` y del planner NLU. Si la intención es de precio, fuerza `get_precio_sipsa` (dato vivo de `chagra.sipsa_precios`) y ese `toolEvidence` bloquea el resto de la cascada de routing. Si el tool no responde, inyecta `available:false` sintético — el turno **sigue siendo de precio**, nunca cae a viabilidad/variedades por accidente.

## Antes / después del misroute

| Consulta | Antes | Después |
|---|---|---|
| "a cómo está la papa" | podía rutear a `get_variedades`/`get_species` → ficha/variedades de papa | siempre `get_precio_sipsa` → precio real, o decline honesto |
| "¿cuánto vale el bulto de papa?" | ídem (misroute a siembra/ficha) | ídem correcto |
| "¿cómo siembro papa?" | siembra (correcto) | **sin cambios** — no es intent de precio, no dispara |

Regla dura anti-alucinación **respetada**: sin dato disponible, el `buildPriceDeclineContext` existente ya declina honesto y orienta a SIPSA/DANE/Corabastos — **nunca precios estáticos ni inventados**. `buildPriceAnswer` (dato real) sigue siendo la única fuente de un número.

## Verificación

- `npx vitest run` sobre los archivos afectados + suite de routing/agente: **verde** (marketIntentRouter 17 tests nuevos + knowledgeIntentRouter/chipIntentRouter/agentService/outputGuards/AgentScreen sin regresión — 442 passed en la corrida completa).
- `npm run build`: verde.
- eslint: limpio sobre los archivos nuevos (el hook de commit OOM'eó por presión de memoria de la máquina compartida, no por lint del código).
- Merge contra `origin/main`: limpio (origin/main no tocó AgentScreen.jsx desde el merge-base).

## Alcance

Este PR es SOLO el fix del misroute de precio (user-facing). La resolución **semántica** de entidades (embeddings arctic-embed2 en `resolveEntities`) vive en el sidecar y va en **chagra-pro#297** (repo privado).

## Follow-up

- La capa de precio en vivo (`get_precio_sipsa`) depende del feed DANE/SIPSA del sidecar; cuando el DR de mercado encolado aterrice canales/valor-agregado, el decline block puede enriquecerse con "dónde/cómo se vende" además de la orientación a la central de abastos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)