### PR TITLE
feat(agente): "el organismo que conversa" — escena viva por tema que reacciona al estado

### DIFF
--- a/src/components/AgentScreen/AgentLivingScene.jsx
+++ b/src/components/AgentScreen/AgentLivingScene.jsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import './agent-living-scene.css';
+
+/**
+ * AgentLivingScene — "El organismo que conversa".
+ * ===============================================================================
+ * El fondo del chat del agente como un MUNDO VIVO que respira y REACCIONA al
+ * estado del agente, distinto por tema. Reemplaza el rectángulo plano con velo
+ * (`.agent-scrim`) por una escena de autor — la misma alma del home "Finca
+ * Organismo" que el operador amó, ahora en la conversación.
+ *
+ * Cada tema es un organismo propio:
+ *   · biopunk / biopunk2 → corazón-micelio nocturno (teal neón) con hifas de
+ *     savia y esporas que suben.
+ *   · nature             → amanecer que respira con sol-corazón cálido y polen.
+ *   · verde-vivo         → dosel vivo, sol entre hojas, hojitas que caen.
+ *   · minimalista        → UN solo pulso de tinta salvia sobre papel (cero motas,
+ *     cero glow — el ADN minimalista: una línea que escucha).
+ *
+ * REACTIVIDAD (el "alma") — `state`:
+ *   idle | listening | thinking | speaking → el CSS (agent-living-scene.css)
+ *   cambia el gesto del organismo: respira lento / anillos que contraen hacia el
+ *   corazón / doble latido rápido / ondas que emanan hacia afuera.
+ *
+ * Fondo OPACO (cubre la foto del body): cada tema pinta su propio gradiente
+ * base. Los mensajes van sobre superficies opacas (.v3-card), legibles al sol
+ * sobre cualquier escena. Todo es SVG/CSS declarativo; respeta
+ * prefers-reduced-motion (estado estático digno) vía el CSS.
+ *
+ * @param {Object} props
+ * @param {'biopunk'|'biopunk2'|'nature'|'verde-vivo'|'minimalista'} props.theme
+ *   Tema EFECTIVO (ya resuelto: `auto`→nature/biopunk2 por el caller). biopunk2
+ *   comparte la escena nocturna de biopunk.
+ * @param {'idle'|'listening'|'thinking'|'speaking'} [props.state='idle']
+ *   Estado del agente que dirige la reactividad de la escena.
+ */
+export default function AgentLivingScene({ theme, state = 'idle' }) {
+  const t = theme === 'biopunk2' ? 'biopunk' : theme;
+  const Scene =
+    t === 'nature' ? NatureScene
+      : t === 'verde-vivo' ? DoselScene
+        : t === 'minimalista' ? MinimalScene
+          : NightOrganism;
+  return (
+    <div className="als-root" data-state={state} data-ag-theme={t} aria-hidden="true" data-testid="agent-living-scene">
+      <Scene />
+    </div>
+  );
+}
+
+/* ═══════════════ biopunk / biopunk2 — CORAZÓN-MICELIO NOCTURNO ═══════════════ */
+function NightOrganism() {
+  return (
+    <svg className="als-svg" viewBox="0 0 390 800" preserveAspectRatio="xMidYMid slice" role="img" aria-label="La finca convertida en organismo bioluminiscente que respira mientras conversas">
+      <defs>
+        <linearGradient id="als-nsky" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#04070f" />
+          <stop offset=".5" stopColor="#061321" />
+          <stop offset="1" stopColor="#030509" />
+        </linearGradient>
+        <radialGradient id="als-nheart" cx=".5" cy=".5" r=".5">
+          <stop offset="0" stopColor="#eafff6" />
+          <stop offset=".38" stopColor="#2dffc4" />
+          <stop offset=".8" stopColor="#0a9f74" stopOpacity=".35" />
+          <stop offset="1" stopColor="#0a9f74" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient id="als-nglow" cx=".5" cy=".5" r=".5">
+          <stop offset="0" stopColor="#2dffc4" stopOpacity=".9" />
+          <stop offset="1" stopColor="#2dffc4" stopOpacity="0" />
+        </radialGradient>
+        <filter id="als-nb"><feGaussianBlur stdDeviation="12" /></filter>
+        <radialGradient id="als-nvig" cx=".5" cy=".9" r=".8">
+          <stop offset="0" stopColor="#030509" stopOpacity="0" />
+          <stop offset="1" stopColor="#020308" stopOpacity=".55" />
+        </radialGradient>
+      </defs>
+
+      <rect width="390" height="800" fill="url(#als-nsky)" />
+
+      {/* aurora de páramo: cintas finas y muy sutiles cerca del cielo (no bloques) */}
+      <path className="als-fog" d="M-30,86 C90,66 190,92 300,70 C350,60 380,72 420,64 L420,96 C300,86 200,108 90,94 C40,88 5,100 -30,102 Z" fill="#2dffc4" opacity=".07" filter="url(#als-nb)" />
+      <path className="als-fog" style={{ animationDelay: '-7s' }} d="M-30,54 C100,40 210,60 320,42 L420,32 L420,58 C300,48 190,70 60,56 Z" fill="#b28dff" opacity=".05" filter="url(#als-nb)" />
+
+      {/* estrellas / cocuyos */}
+      <g fill="#dfeffc">
+        <circle className="als-tw" cx="40" cy="60" r="1.2" />
+        <circle className="als-tw" style={{ animationDelay: '-1s' }} cx="96" cy="90" r=".9" />
+        <circle className="als-tw" style={{ animationDelay: '-2.2s' }} cx="150" cy="46" r="1.1" />
+        <circle className="als-tw" style={{ animationDelay: '-.6s' }} cx="300" cy="70" r="1" />
+        <circle className="als-tw" style={{ animationDelay: '-1.7s' }} cx="352" cy="44" r="1.2" />
+        <circle className="als-tw" style={{ animationDelay: '-2.9s' }} cx="64" cy="120" r=".8" fill="#2dffc4" />
+        <circle className="als-tw" style={{ animationDelay: '-1.4s' }} cx="330" cy="120" r=".8" fill="#ff4fd8" />
+      </g>
+
+      {/* ── EL CORAZÓN (presencia) ── */}
+      <circle className="als-halo" cx="195" cy="150" r="46" fill="url(#als-nglow)" opacity=".5" />
+      {/* ondas al hablar */}
+      <circle className="als-wave" cx="195" cy="150" r="30" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
+      <circle className="als-wave als-w2" cx="195" cy="150" r="30" fill="none" stroke="#7affe0" strokeWidth="1.2" />
+      <circle className="als-wave als-w3" cx="195" cy="150" r="30" fill="none" stroke="#ff4fd8" strokeWidth=".9" />
+      {/* anillos al escuchar */}
+      <circle className="als-listenring" cx="195" cy="150" r="30" fill="none" stroke="#2dffc4" strokeWidth="1.4" />
+      <circle className="als-listenring als-l2" cx="195" cy="150" r="30" fill="none" stroke="#7affe0" strokeWidth="1.1" />
+      <circle className="als-listenring als-l3" cx="195" cy="150" r="30" fill="none" stroke="#9dff3f" strokeWidth=".9" />
+      {/* cuerpo del corazón-semilla */}
+      <g className="als-heart">
+        <circle cx="195" cy="150" r="30" fill="url(#als-nheart)" />
+        <path d="M195,134 C205,140 205,160 195,168 C185,160 185,140 195,134 Z" fill="#0e5a44" stroke="#2dffc4" strokeWidth="1.3" />
+        <circle cx="195" cy="151" r="6.5" fill="#eafff6" />
+        <circle cx="195" cy="151" r="2.6" fill="#ff8fe4" />
+      </g>
+
+      {/* ── HIFAS con savia que bajan del corazón y se abren ── */}
+      <g className="als-net" fill="none" stroke="#2dffc4" strokeWidth="1.3" style={{ filter: 'drop-shadow(0 0 3px rgba(45,255,196,.5))' }}>
+        <path className="als-thread" d="M195,180 C140,260 70,360 30,560" />
+        <path className="als-thread als-slow" d="M195,180 C250,260 320,360 360,560" />
+        <path className="als-thread als-rev" d="M195,180 C170,300 150,460 130,660" />
+        <path className="als-thread als-slow als-rev" d="M195,180 C220,300 240,460 262,660" />
+        <path className="als-thread" d="M195,180 C120,340 80,520 96,740" />
+        <path className="als-thread als-slow" d="M195,180 C270,340 310,520 300,740" />
+      </g>
+      {/* bulbos de raíz al final de las hifas */}
+      <g>
+        {[[30, 560], [360, 560], [130, 660], [262, 660], [96, 740], [300, 740]].map(([x, y], i) => (
+          <g key={i}>
+            <circle cx={x} cy={y} r="10" fill="url(#als-nglow)" opacity=".55" />
+            <circle cx={x} cy={y} r="2.4" fill="#bfffe9" />
+          </g>
+        ))}
+      </g>
+
+      {/* viñeta baja: asienta el compositor sin tapar la escena */}
+      <rect y="420" width="390" height="380" fill="url(#als-nvig)" />
+
+      {/* esporas que suben */}
+      {[[70, 620, '#9dff3f', 0], [150, 700, '#2dffc4', -3], [250, 640, '#ff8fe4', -6], [320, 720, '#4fd8ff', -2], [110, 560, '#d8ff6a', -9], [300, 500, '#2dffc4', -5]].map(([x, y, c, d], i) => (
+        <circle key={i} className="als-mote" style={{ animationDelay: `${d}s`, filter: `drop-shadow(0 0 3px ${c})` }} cx={x} cy={y} r="2.2" fill={c} />
+      ))}
+    </svg>
+  );
+}
+
+/* ═══════════════════════ nature — AMANECER QUE RESPIRA ══════════════════════ */
+function NatureScene() {
+  return (
+    <svg className="als-svg" viewBox="0 0 390 800" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Un amanecer de finca que respira mientras conversas: sol cálido, polen y ramas de café">
+      <defs>
+        <radialGradient id="als-asky" cx=".68" cy=".16" r="1">
+          <stop offset="0" stopColor="#ffe8c2" />
+          <stop offset=".28" stopColor="#f8d9a6" />
+          <stop offset=".55" stopColor="#f3c98e" />
+          <stop offset="1" stopColor="#eef0db" />
+        </radialGradient>
+        <radialGradient id="als-sun" cx=".5" cy=".5" r=".5">
+          <stop offset="0" stopColor="#fff6df" />
+          <stop offset=".5" stopColor="#f5b733" />
+          <stop offset="1" stopColor="#f5b733" stopOpacity="0" />
+        </radialGradient>
+        <filter id="als-ab"><feGaussianBlur stdDeviation="6" /></filter>
+      </defs>
+
+      <rect width="390" height="800" fill="url(#als-asky)" />
+
+      {/* haces de sol */}
+      <g className="als-beam" style={{ transformOrigin: '300px 130px' }}>
+        <path d="M300,130 L250,420 L350,420 Z" fill="#ffd98a" opacity=".3" />
+        <path d="M300,130 L200,440 L280,440 Z" fill="#ffe6b0" opacity=".22" />
+      </g>
+
+      {/* ── EL SOL-CORAZÓN (presencia) ── */}
+      <circle className="als-halo" cx="300" cy="130" r="70" fill="url(#als-sun)" opacity=".5" filter="url(#als-ab)" />
+      <circle className="als-wave" cx="300" cy="130" r="40" fill="none" stroke="#f5b733" strokeWidth="1.6" />
+      <circle className="als-wave als-w2" cx="300" cy="130" r="40" fill="none" stroke="#f0a83a" strokeWidth="1.2" />
+      <circle className="als-wave als-w3" cx="300" cy="130" r="40" fill="none" stroke="#d9742a" strokeWidth=".9" />
+      <circle className="als-listenring" cx="300" cy="130" r="40" fill="none" stroke="#f5b733" strokeWidth="1.4" />
+      <circle className="als-listenring als-l2" cx="300" cy="130" r="40" fill="none" stroke="#e79a2f" strokeWidth="1.1" />
+      <g className="als-heart">
+        <circle cx="300" cy="130" r="34" fill="url(#als-sun)" />
+        <circle cx="300" cy="130" r="22" fill="#fff2d0" />
+        <circle cx="300" cy="130" r="22" fill="none" stroke="#f5b733" strokeWidth="1.4" opacity=".7" />
+      </g>
+
+      {/* ramas de café desde las esquinas bajas + hojas salvia */}
+      <g className="als-net" fill="none" stroke="#8a6a3c" strokeWidth="3" strokeLinecap="round" opacity=".8">
+        <path className="als-thread als-slow" d="M-10,800 C40,700 30,600 70,520 C96,466 90,420 120,380" />
+        <path className="als-thread als-slow als-rev" d="M400,800 C350,690 360,600 320,520 C296,470 300,430 276,392" />
+      </g>
+      <g fill="#7a8f4a">
+        {[[70, 520], [96, 466], [120, 380], [320, 520], [296, 470], [276, 392]].map(([x, y], i) => (
+          <ellipse key={i} cx={x} cy={y} rx="9" ry="4.4" transform={`rotate(${i % 2 ? 22 : -22} ${x} ${y})`} />
+        ))}
+      </g>
+      {/* cerezas de café neón cálido */}
+      <g fill="#d9742a">
+        <circle cx="78" cy="528" r="2.4" /><circle cx="128" cy="386" r="2.4" /><circle cx="312" cy="528" r="2.4" /><circle cx="284" cy="398" r="2.4" />
+      </g>
+
+      {/* polen que sube */}
+      {[[120, 620, 0], [200, 700, -3], [270, 640, -6], [90, 560, -8], [320, 700, -2], [180, 560, -10]].map(([x, y, d], i) => (
+        <circle key={i} className="als-mote" style={{ animationDelay: `${d}s` }} cx={x} cy={y} r="2.2" fill={i % 2 ? '#f5b733' : '#e79a2f'} opacity=".8" />
+      ))}
+    </svg>
+  );
+}
+
+/* ══════════════════════ verde-vivo — DOSEL VIVO ═════════════════════════════ */
+function DoselScene() {
+  return (
+    <svg className="als-svg" viewBox="0 0 390 800" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Un dosel de finca viva que respira mientras conversas: sol entre las hojas y hojitas que caen">
+      <defs>
+        <linearGradient id="als-dsky" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#dfeecb" />
+          <stop offset=".4" stopColor="#eef3e2" />
+          <stop offset="1" stopColor="#e6efd4" />
+        </linearGradient>
+        <radialGradient id="als-dsun" cx=".5" cy=".5" r=".5">
+          <stop offset="0" stopColor="#fff6df" />
+          <stop offset=".5" stopColor="#f2b441" />
+          <stop offset="1" stopColor="#f2b441" stopOpacity="0" />
+        </radialGradient>
+        <filter id="als-db"><feGaussianBlur stdDeviation="6" /></filter>
+      </defs>
+
+      <rect width="390" height="800" fill="url(#als-dsky)" />
+
+      {/* dosel: masas de hojas oscuras arriba */}
+      <g fill="#3a6b2b" opacity=".9">
+        <path d="M-20,-10 C40,50 90,30 130,70 C90,80 40,60 -20,90 Z" />
+        <path d="M410,-10 C350,60 300,30 250,74 C300,84 360,64 410,96 Z" />
+        <path d="M120,-10 C160,44 220,40 270,-10 Z" />
+      </g>
+      <g fill="#4c8536" opacity=".7">
+        <path d="M-20,60 C30,96 70,80 100,110 C60,118 20,104 -20,130 Z" />
+        <path d="M410,60 C360,100 320,84 288,114 C330,122 370,110 410,134 Z" />
+      </g>
+
+      {/* haz de sol entre las hojas */}
+      <g className="als-beam" style={{ transformOrigin: '195px 60px' }}>
+        <path d="M195,60 L150,440 L240,440 Z" fill="#fff0c0" opacity=".3" />
+      </g>
+
+      {/* ── EL SOL-CORAZÓN entre el dosel ── */}
+      <circle className="als-halo" cx="195" cy="150" r="64" fill="url(#als-dsun)" opacity=".5" filter="url(#als-db)" />
+      <circle className="als-wave" cx="195" cy="150" r="36" fill="none" stroke="#f2b441" strokeWidth="1.6" />
+      <circle className="als-wave als-w2" cx="195" cy="150" r="36" fill="none" stroke="#2e8b3d" strokeWidth="1.2" />
+      <circle className="als-wave als-w3" cx="195" cy="150" r="36" fill="none" stroke="#e0922e" strokeWidth=".9" />
+      <circle className="als-listenring" cx="195" cy="150" r="36" fill="none" stroke="#f2b441" strokeWidth="1.4" />
+      <circle className="als-listenring als-l2" cx="195" cy="150" r="36" fill="none" stroke="#2e8b3d" strokeWidth="1.1" />
+      <g className="als-heart">
+        <circle cx="195" cy="150" r="30" fill="url(#als-dsun)" />
+        <circle cx="195" cy="150" r="19" fill="#fff4cf" />
+        <circle cx="195" cy="150" r="19" fill="none" stroke="#e0922e" strokeWidth="1.3" opacity=".7" />
+      </g>
+
+      {/* enredaderas que bajan (savia) */}
+      <g className="als-net" fill="none" stroke="#3a6b2b" strokeWidth="2.4" strokeLinecap="round" opacity=".7">
+        <path className="als-thread als-slow" d="M50,120 C40,300 70,500 40,760" />
+        <path className="als-thread als-slow als-rev" d="M340,120 C350,300 320,500 352,760" />
+      </g>
+
+      {/* hojitas que CAEN meciéndose */}
+      {[[70, 240, 0], [150, 200, -4], [250, 260, -7], [320, 220, -2], [110, 300, -9], [290, 320, -5]].map(([x, y, d], i) => (
+        <g key={i} className="als-mote als-fall" style={{ animationDelay: `${d}s` }}>
+          <ellipse cx={x} cy={y} rx="6" ry="3" fill={i % 2 ? '#5aa83a' : '#7ab84a'} transform={`rotate(${i % 2 ? 20 : -18} ${x} ${y})`} />
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+/* ════════════════════ minimalista — UN SOLO PULSO ══════════════════════════ */
+function MinimalScene() {
+  return (
+    <svg className="als-svg" viewBox="0 0 390 800" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Una sola línea de tinta que escucha mientras conversas">
+      <rect width="390" height="800" fill="#f6f3ec" />
+
+      {/* horizonte: una hairline */}
+      <line x1="0" y1="600" x2="390" y2="600" stroke="#e3ddd0" strokeWidth="1" />
+
+      {/* UN solo pulso (tinta salvia) alrededor de un punto-corazón */}
+      <circle className="als-pulse" cx="195" cy="200" r="26" fill="none" stroke="#2f6e5a" strokeWidth="1" opacity=".4" />
+      <circle className="als-wave" cx="195" cy="200" r="20" fill="none" stroke="#2f6e5a" strokeWidth=".9" />
+      <circle className="als-wave als-w2" cx="195" cy="200" r="20" fill="none" stroke="#5a7d6e" strokeWidth=".7" />
+      <circle className="als-listenring" cx="195" cy="200" r="20" fill="none" stroke="#2f6e5a" strokeWidth=".9" />
+      <circle className="als-listenring als-l2" cx="195" cy="200" r="20" fill="none" stroke="#5a7d6e" strokeWidth=".7" />
+      <g className="als-heart">
+        <circle cx="195" cy="200" r="6" fill="none" stroke="#2f6e5a" strokeWidth="1.4" />
+        <circle cx="195" cy="200" r="1.8" fill="#2f6e5a" />
+      </g>
+    </svg>
+  );
+}

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -133,6 +133,11 @@ import { executeAction, setActionGateCallback } from '../../services/actionExecu
 import { getToolsForLLM } from '../../services/llmTools';
 import { useRotatingTip } from '../../services/tipsService';
 import ChatHistory from './ChatHistory';
+// REINVENCIÓN 2026-07 — "El organismo que conversa": el fondo del chat deja de
+// ser un rectángulo plano con velo y pasa a ser un MUNDO VIVO por tema que
+// respira y REACCIONA al estado del agente (idle/escuchando/pensando/hablando),
+// la misma alma del home "Finca Organismo". Reemplaza al `.agent-scrim`.
+import AgentLivingScene from './AgentLivingScene';
 import ActionConfirmModal from '../ActionConfirmModal';
 import FeedbackConsentModal from '../FeedbackConsentModal';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
@@ -144,7 +149,7 @@ import ManoChagraGlyph from '../dashboard/ManoChagraGlyph';
 // Ícono del TEMA para el botón Ⓐ del compositor (paridad con home/TopBar y
 // AgentHero): el acceso a capacidades entra por el ícono del tema, no por la
 // mano (operador 2026-06-18). Misma fuente que TopBar.jsx / AgentHero.jsx.
-import { useTheme } from '../../hooks/useTheme';
+import { useTheme, resolveAutoTheme } from '../../hooks/useTheme';
 import { iconForTheme } from '../dashboard/themeIcon';
 import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
 // Agente guiado: selección PURA de un insight verificado proactivo a partir del
@@ -3486,14 +3491,29 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
     !((!inputText.trim() && !agentAttachment) || state === STATE_RECORDING || queuePending.length >= 1);
   const agentSendAccent = fincaVivaHomePerfilActivo() && enviarHabilitado;
 
+  // REINVENCIÓN "organismo que conversa": el estado del agente DIRIGE la escena
+  // viva de fondo (respira / anillos que contraen al escuchar / doble latido al
+  // pensar / ondas que emanan al hablar). Una sola fuente de verdad para el
+  // fondo Y el nameplate del header — el organismo y la palabra laten juntos.
+  const presenceState =
+    state === STATE_RECORDING ? 'listening'
+      : state === STATE_THINKING ? 'thinking'
+        : isVoicePlaying ? 'speaking'
+          : 'idle';
+  // biopunk/biopunk2 comparten piel base (sin data-theme); `auto` se resuelve a
+  // nature/biopunk2 con la MISMA regla del home (resolveAutoTheme). La escena se
+  // elige con el tema EFECTIVO — así el organismo del agente y la escena del home
+  // hablan el mismo idioma visual.
+  const sceneTheme = resolveAutoTheme(theme);
+
   return (
     <div className={`h-[100dvh] flex flex-col overflow-hidden relative text-white ${entranceClassRef.current}`}>
-      {/* Velo de legibilidad: deja ver --app-bg-image del body PERO garantiza
-          contraste. Token-aware (.agent-scrim → navy denso en bio-punk, crema
-          sutil en claros). Antes era bg-slate-950/82 fijo y, accediendo al
-          agente directo (#agente), la foto lavaba chips/sugerencias/Volver
-          (fix legibilidad 2026-06-15). */}
-      <div className="absolute inset-0 agent-scrim backdrop-blur-[2px] pointer-events-none" aria-hidden="true" />
+      {/* ORGANISMO QUE CONVERSA — el fondo del chat es un mundo vivo por tema que
+          respira y reacciona al estado del agente. Reemplaza al rectángulo plano
+          con velo (`.agent-scrim`): cubre la foto del body con su propio
+          gradiente opaco, y los mensajes van sobre superficies opacas (.v3-card)
+          legibles al sol. Respeta prefers-reduced-motion (estado quieto digno). */}
+      <AgentLivingScene theme={sceneTheme} state={presenceState} />
       {/* B1: animación de entrada (fade+rise). Respeta prefers-reduced-motion. */}
       <style>{AGENT_ENTRANCE_CSS}{AGENT_COMPOSITOR_CSS}{AGENT_V3_CSS}</style>
 

--- a/src/components/AgentScreen/__tests__/AgentLivingScene.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentLivingScene.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AgentLivingScene from '../AgentLivingScene';
+
+/**
+ * AgentLivingScene — "El organismo que conversa".
+ * Smoke + contrato: cada tema monta su escena propia y el estado del agente se
+ * refleja en `data-state` (dirige la reactividad del CSS: respira / anillos que
+ * contraen al escuchar / doble latido al pensar / ondas que emanan al hablar).
+ */
+describe('AgentLivingScene', () => {
+  it('monta la escena con el testid y aria-hidden (capa decorativa)', () => {
+    const { getByTestId } = render(<AgentLivingScene theme="biopunk2" />);
+    const root = getByTestId('agent-living-scene');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveAttribute('aria-hidden', 'true');
+    // idle por defecto.
+    expect(root).toHaveAttribute('data-state', 'idle');
+  });
+
+  it('biopunk y biopunk2 comparten la MISMA escena nocturna (piel base)', () => {
+    const a = render(<AgentLivingScene theme="biopunk2" />);
+    expect(a.getByTestId('agent-living-scene')).toHaveAttribute('data-ag-theme', 'biopunk');
+    a.unmount();
+    const b = render(<AgentLivingScene theme="biopunk" />);
+    expect(b.getByTestId('agent-living-scene')).toHaveAttribute('data-ag-theme', 'biopunk');
+  });
+
+  it.each([
+    ['nature'],
+    ['verde-vivo'],
+    ['minimalista'],
+  ])('cada tema claro monta su propio mundo (%s)', (theme) => {
+    const { getByTestId, container } = render(<AgentLivingScene theme={theme} />);
+    expect(getByTestId('agent-living-scene')).toHaveAttribute('data-ag-theme', theme);
+    // Cada escena es un SVG a pantalla completa.
+    expect(container.querySelector('svg.als-svg')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['idle'],
+    ['listening'],
+    ['thinking'],
+    ['speaking'],
+  ])('el estado del agente dirige la reactividad de la escena (%s)', (state) => {
+    const { getByTestId } = render(<AgentLivingScene theme="biopunk2" state={state} />);
+    expect(getByTestId('agent-living-scene')).toHaveAttribute('data-state', state);
+  });
+
+  it('tema desconocido cae a la escena nocturna (no rompe el render)', () => {
+    const { getByTestId, container } = render(<AgentLivingScene theme="tema-legado-x" />);
+    expect(getByTestId('agent-living-scene')).toBeInTheDocument();
+    expect(container.querySelector('svg.als-svg')).toBeInTheDocument();
+  });
+});

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -59,6 +59,9 @@ vi.mock('../../../services/tierService', () => ({
 
 vi.mock('../../../hooks/useTheme', () => ({
   useTheme: () => ({ theme: 'nature' }),
+  // La escena viva del agente resuelve el tema efectivo (auto→nature/biopunk2)
+  // con resolveAutoTheme; el mock lo pasa tal cual (aquí el tema ya es concreto).
+  resolveAutoTheme: (t) => t,
 }));
 
 vi.mock('../../../hooks/useVoiceRecorder', () => ({

--- a/src/components/AgentScreen/agent-living-scene.css
+++ b/src/components/AgentScreen/agent-living-scene.css
@@ -1,0 +1,191 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   AGENT LIVING SCENE — "El organismo que conversa".
+   ============================================================================
+   El fondo del chat del agente DEJA de ser un rectángulo plano con velo: es un
+   MUNDO VIVO que respira y REACCIONA al estado del agente (idle / escuchando /
+   pensando / hablando), distinto por tema — la misma alma del home "Finca
+   Organismo" que el operador amó, ahora en la conversación.
+
+   Cada tema es un organismo:
+     · biopunk / biopunk2 → corazón-micelio nocturno (teal neón), esporas que
+       suben, hifas con savia que fluye.
+     · nature             → amanecer que respira, sol-corazón cálido, polen ocre.
+     · verde-vivo         → dosel vivo, sol entre hojas, hojitas que caen.
+     · minimalista        → UN solo pulso de tinta salvia sobre papel (cero motas,
+       cero glow — el ADN minimalista: una línea que escucha).
+
+   REACTIVIDAD (el "alma"): la clase raíz lleva data-state y el CSS cambia el
+   ritmo/el gesto del organismo:
+     · idle       → respira lento.
+     · listening  → anillos que CONTRAEN hacia el corazón (te está oyendo).
+     · thinking   → doble latido rápido + savia acelerada (está pensando).
+     · speaking   → ondas que EMANAN del corazón hacia afuera (te está hablando).
+
+   Todo es CSS/SVG declarativo (cero JS por frame). prefers-reduced-motion =
+   estado estático digno (organismo encendido, sin movimiento).
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.als-root {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  /* ritmo cardíaco base compartido por todo el organismo */
+  --als-beat: 5s;
+  --als-flow: 3s;
+  --als-drift: 13s;
+}
+.als-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ── El CORAZÓN / presencia (respira; se acelera al pensar) ─────────────────── */
+.als-heart {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: als-breathe var(--als-beat) ease-in-out infinite;
+}
+@keyframes als-breathe {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  50%      { transform: scale(1.045); filter: brightness(1.18); }
+}
+/* doble latido cardíaco (se activa al pensar) */
+@keyframes als-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  8%  { transform: scale(1.24); filter: brightness(2); }
+  16% { transform: scale(1); }
+  24% { transform: scale(1.14); filter: brightness(1.5); }
+  32% { transform: scale(1); filter: brightness(1); }
+}
+
+/* halo del corazón (respira desfasado) */
+.als-halo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: als-halo calc(var(--als-beat) * 1.4) ease-in-out infinite;
+}
+@keyframes als-halo {
+  0%, 100% { transform: scale(1); opacity: 0.5; }
+  50%      { transform: scale(1.16); opacity: 0.85; }
+}
+
+/* ── ONDAS que emanan (al hablar) / anillos que contraen (al escuchar) ───────── */
+.als-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+}
+.als-listenring {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+}
+
+/* ── HIFAS / ramas con savia que fluye ───────────────────────────────────────── */
+.als-thread {
+  stroke-dasharray: 5 10;
+  animation: als-flow var(--als-flow) linear infinite;
+}
+.als-thread.als-rev { animation-direction: reverse; }
+.als-thread.als-slow { animation-duration: calc(var(--als-flow) * 1.7); stroke-dasharray: 3 12; }
+@keyframes als-flow { to { stroke-dashoffset: -60; } }
+
+/* la red entera se enciende con cada latido */
+.als-net { animation: als-netglow var(--als-beat) ease-in-out infinite; }
+@keyframes als-netglow {
+  0%, 100% { opacity: 0.55; }
+  50%      { opacity: 0.9; }
+}
+
+/* ── MOTAS de vida (esporas / polen / hojitas) que suben o caen y se mecen ────── */
+.als-mote {
+  transform-box: fill-box;
+  animation: als-rise var(--als-drift) linear infinite;
+}
+.als-mote.als-fall { animation-name: als-fall; }
+@keyframes als-rise {
+  0%   { transform: translateY(0) translateX(0); opacity: 0; }
+  12%  { opacity: 0.9; }
+  88%  { opacity: 0.9; }
+  100% { transform: translateY(-120px) translateX(10px); opacity: 0; }
+}
+@keyframes als-fall {
+  0%   { transform: translateY(-10px) rotate(-12deg); opacity: 0; }
+  14%  { opacity: 0.95; }
+  86%  { opacity: 0.95; }
+  100% { transform: translateY(150px) translateX(-16px) rotate(16deg); opacity: 0; }
+}
+
+/* estrellas/cocuyos que titilan */
+.als-tw { animation: als-tw 3.6s ease-in-out infinite; }
+@keyframes als-tw { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
+
+/* niebla que deriva */
+.als-fog { animation: als-fog 18s ease-in-out infinite alternate; }
+@keyframes als-fog { from { transform: translateX(-14px); opacity: 0.5; } to { transform: translateX(14px); opacity: 0.9; } }
+
+/* rayo de sol / haz que respira (nature / verde-vivo) */
+.als-beam { transform-box: fill-box; transform-origin: top center; animation: als-beam 9s ease-in-out infinite; }
+@keyframes als-beam { 0%, 100% { opacity: 0.25; transform: scaleY(0.98); } 50% { opacity: 0.55; transform: scaleY(1.03); } }
+
+/* ── minimalista: el ÚNICO pulso (una línea que escucha) ─────────────────────── */
+.als-pulse {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: als-pulse 6s ease-out infinite;
+  opacity: 0;
+}
+@keyframes als-pulse {
+  0%   { transform: scale(0.4); opacity: 0; }
+  20%  { opacity: 0.55; }
+  100% { transform: scale(2.2); opacity: 0; }
+}
+
+/* ══════════════════ REACTIVIDAD POR ESTADO ══════════════════════════════════ */
+
+/* PENSANDO — el corazón late doble y rápido; la savia corre; la red pulsa fuerte. */
+.als-root[data-state="thinking"] { --als-beat: 2.3s; --als-flow: 1.5s; }
+.als-root[data-state="thinking"] .als-heart { animation: als-beat var(--als-beat) ease-in-out infinite; }
+.als-root[data-state="thinking"] .als-pulse { animation-duration: 2.4s; }
+
+/* HABLANDO — ondas que EMANAN del corazón hacia afuera (con cada frase). */
+.als-root[data-state="speaking"] { --als-beat: 3.4s; --als-flow: 2s; }
+.als-root[data-state="speaking"] .als-wave {
+  animation: als-emanate 3.4s ease-out infinite;
+}
+.als-root[data-state="speaking"] .als-wave.als-w2 { animation-delay: 1.13s; }
+.als-root[data-state="speaking"] .als-wave.als-w3 { animation-delay: 2.26s; }
+.als-root[data-state="speaking"] .als-pulse { animation-duration: 3s; }
+@keyframes als-emanate {
+  0%   { transform: scale(0.3); opacity: 0.75; }
+  80%  { opacity: 0; }
+  100% { transform: scale(2.7); opacity: 0; }
+}
+
+/* ESCUCHANDO — anillos que CONTRAEN hacia el corazón (te está atendiendo). */
+.als-root[data-state="listening"] { --als-beat: 3.8s; }
+.als-root[data-state="listening"] .als-listenring {
+  animation: als-contract 2.4s ease-in infinite;
+}
+.als-root[data-state="listening"] .als-listenring.als-l2 { animation-delay: 0.8s; }
+.als-root[data-state="listening"] .als-listenring.als-l3 { animation-delay: 1.6s; }
+.als-root[data-state="listening"] .als-pulse { animation-duration: 3.4s; }
+@keyframes als-contract {
+  0%   { transform: scale(2.4); opacity: 0; }
+  25%  { opacity: 0.7; }
+  100% { transform: scale(0.35); opacity: 0; }
+}
+
+/* ── reduced-motion: organismo encendido, quieto y digno ─────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .als-heart, .als-halo, .als-net, .als-thread, .als-mote, .als-tw,
+  .als-fog, .als-beam, .als-pulse, .als-wave, .als-listenring {
+    animation: none !important;
+  }
+  .als-wave, .als-listenring, .als-pulse { opacity: 0.28 !important; }
+  .als-net { opacity: 0.7 !important; }
+}

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -62,7 +62,27 @@ export const AGENT_COMPOSITOR_CSS = `
     position: relative; overflow: hidden;
     flex-direction: column; align-items: stretch;
   }
+  /* REINVENCIÓN "organismo que conversa": el compositor lleva una COSTURA VIVA —
+     una hebra del acento del tema en el borde superior que respira, para que el
+     pill se sienta parte del organismo, no una caja muerta sobre la escena. */
+  .as-bar::before {
+    content: ''; position: absolute; top: 0; left: 14px; right: 14px; height: 2px;
+    border-radius: 2px; pointer-events: none;
+    background: linear-gradient(90deg,
+      transparent,
+      rgba(var(--t-accent-rgb, 25, 201, 154), 0.85) 30%,
+      rgba(var(--t-accent-rgb, 25, 201, 154), 0.85) 70%,
+      transparent);
+    animation: as-costura-viva 4.2s ease-in-out infinite;
+  }
+  @keyframes as-costura-viva {
+    0%, 100% { opacity: 0.35; }
+    50%      { opacity: 0.9; }
+  }
   .as-bar.is-recording { border-color: rgba(244,63,94,0.6); }
+  .as-bar.is-recording::before {
+    background: linear-gradient(90deg, transparent, rgba(244,63,94,0.9) 30%, rgba(244,63,94,0.9) 70%, transparent);
+  }
   .as-bar:focus-within {
     border-color: rgba(16,185,129,0.55);
     box-shadow: 0 10px 30px -12px rgba(0,0,0,0.5), 0 0 0 3px rgba(16,185,129,0.12);
@@ -167,6 +187,7 @@ export const AGENT_COMPOSITOR_CSS = `
      texto"). El overlay trae su propio estilo en agent/AgentShell.jsx. */
   @media (prefers-reduced-motion: reduce) {
     .as-shimmer::after, .as-sending { animation: none !important; }
+    .as-bar::before { animation: none !important; opacity: 0.55; }
     .as-tool { animation: none !important; }
     .as-mic-big { animation: none !important; }
     /* Grabación sin movimiento: cae a un anillo estático (::before congelado


### PR DESCRIPTION
## "El organismo que conversa" — el chat del agente reinventado

Reinventa **qué se siente** hablar con Chagra. El chat deja de ser una caja
sobre una foto y pasa a ser un **mundo vivo por tema que respira y REACCIONA al
estado del agente** — a la altura del home "Finca Organismo".

> No es un reskin de tokens (lo que el operador rechazó en #2080). Es un cambio
> **estructural/experiencial**: un componente de escena nuevo detrás del chat +
> un organismo que reacciona + un compositor vivo.

### Divergencia (4 conceptos explorados)
1. **A · Organismo que conversa** — hablas con una presencia viva dentro de su
   mundo; el corazón-micelio late y reacciona. **← ELEGIDO** (más WOW, canaliza
   justo lo que el operador amó del home).
2. **B · La conversación crece** — enredadera que brota hojas por intercambio
   (descartado: el riel izquierdo come ancho en móvil).
3. **C · Mundo inmersivo por tema** — escena de páramo con tarjetas de vidrio
   (descartado: el vidrio sobre escena arriesga la legibilidad al sol).
4. **D · La mano viva** — la mano-organismo central (descartado: la mano gigante
   compite con los mensajes y no escala al crecer el chat).

El elegido **fusiona lo mejor**: la presencia que reacciona (espina), las
tarjetas OPACAS legibles al sol, y la mano/Ⓐ como corazón de la interacción.

### Qué cambia
- **`AgentLivingScene` + `agent-living-scene.css`**: escena de autor a pantalla
  completa, OPACA, distinta por tema:
  - **biopunk / biopunk2** → corazón-micelio nocturno (teal neón): hifas con
    savia, esporas que suben, aurora sutil, viñeta.
  - **nature** → amanecer que respira, sol-corazón cálido, ramas de café, polen.
  - **verde-vivo** → dosel vivo, sol entre hojas, hojitas que caen meciéndose.
  - **minimalista** → UN solo pulso de tinta salvia sobre papel (su ADN).
- **Reactividad (el "alma")**: `data-state` dirige el organismo — idle respira ·
  **escuchando** anillos que contraen hacia el corazón · **pensando** doble
  latido rápido + savia acelerada · **hablando** ondas que emanan. Una sola
  fuente de verdad (`presenceState`) para escena y header.
- **Compositor con costura viva**: hebra del acento del tema que respira en el
  borde superior del pill (rojo en grabación).

### Se conserva TODO
Mano/Ⓐ, foto/cámara, micrófono, enviar, selector de temas, chat, grounding,
semáforo (#2076). **Cero cambios de lógica NLU/tools/sidecar.** Mensajes sobre
superficies opacas (`.v3-card`) legibles al sol. Respeta
`prefers-reduced-motion`.

### Verificación
- **build** verde.
- **Contraste WCAG** del empty-state ≥4.5 en los 3 temas del harness:
  nature 7.64 · minimalista 7.26 · biopunk 13.59.
- **vitest** verde: `AgentLivingScene` (10, nuevo), chipsToolbar, queue, smoke,
  ChatBubble (34), ChatHistory greeting/back.
- **eslint** limpio en archivos nuevos + `agentEntrance.js`. `AgentScreen.jsx`
  no es lintable localmente (hang **pre-existente** — idéntico en `origin/main`,
  también con la regla i18n apagada; eslint corre bien en otros archivos
  grandes como `DashboardLive.jsx`).

### Capturas
Empty-state en los 5 temas (idle + estado reactivo forzado) — ver adjuntos que
mandará el operador. Radicalmente distintos entre sí y de "lo mismo de antes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
