### PR TITLE
feat(guards): cablear companion-species-guard (4to guard, POST-LLM)

### DIFF
--- a/scripts/__tests__/bench-contaminacion.test.mjs
+++ b/scripts/__tests__/bench-contaminacion.test.mjs
@@ -40,6 +40,7 @@ import {
   sidecarReachableLocally,
   generateMarkdownReport,
   buildEnrichedSystemPrompt,
+  companionSpeciesGuard,
 } from '../bench-contaminacion.mjs';
 
 /** Stub por defecto del guard piso térmico: sin desajuste, no-op — evita que
@@ -384,6 +385,34 @@ describe('buildEnrichedSystemPrompt (guard piso térmico chagra-pro #288)', () =
   });
 });
 
+describe('companionSpeciesGuard (post-LLM cross_thermal)', () => {
+  it('devuelve bloque y flag cuando el sidecar corrige una respuesta', async () => {
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        has_companion_species: true,
+        system_prompt_block: '[GUARD COMPANION SPECIES] Corrige la compania.',
+      }),
+    });
+    const res = await companionSpeciesGuard('respuesta del agente', { sidecarUrl: 'http://sidecar', fetchImpl });
+    expect(res).toEqual({
+      has_companion_species: true,
+      system_prompt_block: '[GUARD COMPANION SPECIES] Corrige la compania.',
+    });
+  });
+
+  it('degrada a bloque vacio si el sidecar cae', async () => {
+    const fetchImpl = async () => { throw new Error('down'); };
+    const res = await companionSpeciesGuard('respuesta del agente', { sidecarUrl: 'http://sidecar', fetchImpl });
+    expect(res).toEqual({
+      has_companion_species: false,
+      system_prompt_block: '',
+      error: 'down',
+    });
+  });
+});
+
 // ── orquestación: resolveFn/callFn/validateFn INYECTADOS (sin red real) ────
 
 describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
@@ -555,6 +584,53 @@ describe('runProbeAgainstAgent (dependencias inyectadas, sin red)', () => {
       });
       expect(out.error).toBeNull();
       expect(out.pest_vs_disease_guard_fired).toBe(false);
+    });
+  });
+
+  describe('wiring /companion-species-guard (bench honesto, post-LLM cross_thermal)', () => {
+    const crossThermalProbe = { id: 'ct1', type: 'cross_thermal', query: 'respuesta cruzada', subject: 'S' };
+
+    it('has bloque → antepone la correccion y marca companion_species_guard_fired', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      let seenResponse = null;
+      const callFn = async () => ({ response: 'respuesta base', error: null });
+      const validateFn = async (_query, response) => {
+        seenResponse = response;
+        return { hallucinated: [], detected_count: 0 };
+      };
+      const companionSpeciesFn = async () => ({
+        has_companion_species: true,
+        system_prompt_block: '[GUARD COMPANION SPECIES] Corrige la compania.',
+      });
+      const out = await runProbeAgainstAgent(crossThermalProbe, {
+        resolveFn,
+        callFn,
+        validateFn,
+        pisoTermicoFn: noMismatchPisoTermicoFn,
+        confusionEspecieFn: noConfusionEspecieFn,
+        pestVsDiseaseFn: noPestVsDiseaseFn,
+        companionSpeciesFn,
+      });
+      expect(seenResponse.startsWith('[GUARD COMPANION SPECIES] Corrige la compania.')).toBe(true);
+      expect(out.companion_species_guard_fired).toBe(true);
+    });
+
+    it('companionSpeciesFn caido → degrada limpio y no marca firing', async () => {
+      const resolveFn = async () => ({ entities: [] });
+      const callFn = async () => ({ response: 'respuesta base', error: null });
+      const validateFn = async () => ({ hallucinated: [], detected_count: 0 });
+      const companionSpeciesFn = async () => ({ has_companion_species: false, system_prompt_block: '', error: 'ECONNREFUSED' });
+      const out = await runProbeAgainstAgent(crossThermalProbe, {
+        resolveFn,
+        callFn,
+        validateFn,
+        pisoTermicoFn: noMismatchPisoTermicoFn,
+        confusionEspecieFn: noConfusionEspecieFn,
+        pestVsDiseaseFn: noPestVsDiseaseFn,
+        companionSpeciesFn,
+      });
+      expect(out.companion_species_guard_fired).toBe(false);
+      expect(out.error).toBeNull();
     });
   });
 });

--- a/scripts/bench-contaminacion.mjs
+++ b/scripts/bench-contaminacion.mjs
@@ -82,6 +82,7 @@ import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { performance } from 'node:perf_hooks';
+import { prependCorrectionBlock } from '../src/components/AgentScreen/responseGuards.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
@@ -660,6 +661,41 @@ async function pestVsDiseaseGuard(userMessage, { sidecarUrl = SIDECAR_URL } = {}
 }
 
 /**
+ * companionSpeciesGuard — llama al endpoint POST-LLM `/companion-species-guard`.
+ * El bench lo invoca solo para las sondas cross_thermal, sobre la respuesta ya
+ * generada, para medir si el guard hubiera corregido el turno real.
+ *
+ * FAIL-SAFE: cualquier error/timeout/non-2xx degrada a bloque vacio.
+ * @param {string} responseText
+ * @param {{ sidecarUrl?: string }} [opts]
+ * @returns {Promise<{ has_companion_species: boolean, system_prompt_block: string }>}
+ */
+export async function companionSpeciesGuard(
+  responseText,
+  { sidecarUrl = SIDECAR_URL, fetchImpl = fetch } = {},
+) {
+  const token = getSidecarToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+  try {
+    const res = await fetchImpl(`${sidecarUrl}/companion-species-guard`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ response: responseText }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return { has_companion_species: false, system_prompt_block: '' };
+    const data = await res.json();
+    return {
+      has_companion_species: data.has_companion_species === true || data.has_companion === true || data.needs_correction === true,
+      system_prompt_block: typeof data.system_prompt_block === 'string' ? data.system_prompt_block : '',
+    };
+  } catch (err) {
+    return { has_companion_species: false, system_prompt_block: '', error: err.message };
+  }
+}
+
+/**
  * buildEnrichedSystemPrompt — arma el system prompt que ve el modelo en la
  * fase remote-run. `pisoTermicoBlock`/`confusionEspecieBlock`/
  * `pestVsDiseaseBlock` (opcionales) son los `system_prompt_block` YA
@@ -783,6 +819,7 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     pisoTermicoFn = pisoTermicoGuard,
     confusionEspecieFn = confusionEspecieGuard,
     pestVsDiseaseFn = pestVsDiseaseGuard,
+    companionSpeciesFn = companionSpeciesGuard,
   } = opts;
   const t0 = performance.now();
   const [{ entities }, pisoTermico, confusionEspecie, pestVsDisease] = await Promise.all([
@@ -801,7 +838,16 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     ? pestVsDisease.system_prompt_block
     : '';
   const systemPrompt = buildEnrichedSystemPrompt(entities, pisoTermicoBlock, confusionEspecieBlock, pestVsDiseaseBlock);
-  const { response, error } = await callFn(model, systemPrompt, probe.query);
+  const { response: rawResponse, error } = await callFn(model, systemPrompt, probe.query);
+  let response = rawResponse;
+  let companionSpeciesBlock = '';
+  if (!error && probe.type === 'cross_thermal') {
+    const companionSpecies = await companionSpeciesFn(rawResponse);
+    if (companionSpecies && typeof companionSpecies.system_prompt_block === 'string' && companionSpecies.system_prompt_block.trim()) {
+      companionSpeciesBlock = companionSpecies.system_prompt_block;
+      response = prependCorrectionBlock(response, companionSpeciesBlock);
+    }
+  }
   const validation = error ? { hallucinated: [], detected_count: 0 } : await validateFn(probe.query, response);
   return {
     id: probe.id,
@@ -815,6 +861,7 @@ export async function runProbeAgainstAgent(probe, opts = {}) {
     piso_termico_guard_fired: Boolean(pisoTermicoBlock),
     confusion_especie_guard_fired: Boolean(confusionEspecieBlock),
     pest_vs_disease_guard_fired: Boolean(pestVsDiseaseBlock),
+    companion_species_guard_fired: Boolean(companionSpeciesBlock),
     halluc_detected_count: validation.detected_count,
     latency_ms: Math.round(performance.now() - t0),
   };

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -47,7 +47,7 @@ import { createStreamDeadline } from '../../services/streamDeadline';
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, pisoTermicoGuard, confusionEspecieGuard, pestVsDiseaseGuard, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, pisoTermicoGuard, confusionEspecieGuard, pestVsDiseaseGuard, companionSpeciesGuard, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
@@ -113,6 +113,7 @@ import { selectChipDefs } from '../../services/profileChipSelector';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import { captureExchange } from '../../services/conversationCaptureService';
 import { regionFromProfile, getEnsoOutlook } from '../../services/ensoContext';
+import { prependCorrectionBlock } from './responseGuards';
 // SALUDO PROACTIVO (#162 alertas + #298 tareas + #331 análisis): el agente, de
 // entrada, lidera con lo MÁS importante (1-2 pendientes) si los hay, o da una
 // idea contextual (cultivo/clima/temporada) sin inventar alarmas. Lógica pura
@@ -2284,7 +2285,26 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // `valid`—. La cobertura taxonómica la dan los guards síncronos de
       // applyOutputGuards (#1332 binomio benéfico + 5/5b sustitución/companion)
       // y el grounding de resolve-entities. Ver outputGuards.js.
-      const responseBody = guarded.text;
+      let responseBody = guarded.text;
+      let responseAutoCorrected = guarded.modified === true;
+      // GUARDA POST-LLM de companion species: valida la respuesta ya generada
+      // contra el catalogo. Si dispara, anteponemos el bloque de correccion al
+      // turno final sin romper el flujo si el sidecar falla.
+      if (isOnline && isSidecarEnabled()) {
+        try {
+          const companionSpecies = await companionSpeciesGuard(responseBody);
+          if (companionSpecies && typeof companionSpecies.system_prompt_block === 'string' && companionSpecies.system_prompt_block.trim()) {
+            responseBody = prependCorrectionBlock(responseBody, companionSpecies.system_prompt_block);
+            responseAutoCorrected = true;
+            console.debug('[sidecar] companion-species-guard', {
+              hasCompanionSpecies: companionSpecies.has_companion_species,
+              reason: companionSpecies.reason,
+            });
+          }
+        } catch (companionErr) {
+          console.debug('[sidecar] companion-species-guard fail (sigo sin bloque):', companionErr?.message);
+        }
+      }
       agentSounds.chime();
 
       const { intent } = parseIntent(text);
@@ -2345,7 +2365,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         ...evidenceSourceLink,
         ...groundingBadges,
         ...groundingSemaphoreMeta,
-        auto_corrected: guarded.modified === true,
+        auto_corrected: responseAutoCorrected,
       };
       const profileMode = (() => {
         try {

--- a/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.chipsToolbar.test.jsx
@@ -155,6 +155,7 @@ vi.mock('../../../services/sidecarClient', () => ({
   pisoTermicoGuard: vi.fn(),
   confusionEspecieGuard: vi.fn(),
   pestVsDiseaseGuard: vi.fn(),
+  companionSpeciesGuard: vi.fn(),
   postValidate: vi.fn(),
   getClimaIdeam: vi.fn(),
   isToolAllowed: vi.fn(() => false),

--- a/src/components/AgentScreen/__tests__/responseGuards.test.js
+++ b/src/components/AgentScreen/__tests__/responseGuards.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { prependCorrectionBlock } from '../responseGuards';
+
+describe('prependCorrectionBlock', () => {
+  it('antepone un bloque de correccion a la respuesta', () => {
+    const out = prependCorrectionBlock(
+      'Esta es la respuesta original.',
+      '[CORRECCION] La companion species correcta es otra.',
+    );
+    expect(out).toBe('[CORRECCION] La companion species correcta es otra.\n\nEsta es la respuesta original.');
+  });
+
+  it('es idempotente si el bloque ya esta al inicio', () => {
+    const block = '[CORRECCION] La companion species correcta es otra.';
+    const first = prependCorrectionBlock('Respuesta base.', block);
+    const second = prependCorrectionBlock(first, block);
+    expect(second).toBe(first);
+  });
+
+  it('degrada sin romper si no hay bloque util', () => {
+    expect(prependCorrectionBlock('Respuesta base.', '')).toBe('Respuesta base.');
+    expect(prependCorrectionBlock('Respuesta base.', '   ')).toBe('Respuesta base.');
+    expect(prependCorrectionBlock(null, '[CORRECCION] A')).toBe('[CORRECCION] A');
+  });
+});

--- a/src/components/AgentScreen/responseGuards.js
+++ b/src/components/AgentScreen/responseGuards.js
@@ -1,0 +1,22 @@
+/**
+ * Helpers de respuesta del AgentScreen.
+ *
+ * Mantienen la correccion post-LLM como bloque de prefijo, sin duplicarla si
+ * ya entro antes en el mismo turno.
+ */
+
+/**
+ * Antepone un bloque de correccion a la respuesta, de forma idempotente.
+ *
+ * @param {string} responseText
+ * @param {string} correctionBlock
+ * @returns {string}
+ */
+export function prependCorrectionBlock(responseText, correctionBlock) {
+  const response = typeof responseText === 'string' ? responseText : '';
+  const block = typeof correctionBlock === 'string' ? correctionBlock.trim() : '';
+  if (!block) return response;
+  if (!response) return block;
+  if (response.startsWith(block)) return response;
+  return `${block}\n\n${response}`;
+}

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -1135,3 +1135,44 @@ describe('sidecarClient — getClimaSnapshot elevation (gradiente térmico)', ()
     expect(url).not.toContain('elevation');
   });
 });
+
+describe('sidecarClient — companionSpeciesGuard post-LLM', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  it('200 con bloque de correccion → normaliza has_companion_species y system_prompt_block', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+      has_companion_species: true,
+      system_prompt_block: '[CORRECCION] La especie companera correcta es X.',
+      reason: 'catalog_match',
+    }));
+    const { companionSpeciesGuard } = await importFresh();
+    const res = await companionSpeciesGuard('respuesta del agente ya generada');
+    expect(res).toEqual({
+      has_companion_species: true,
+      system_prompt_block: '[CORRECCION] La especie companera correcta es X.',
+      reason: 'catalog_match',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/mcp/agro/companion-species-guard');
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({ response: 'respuesta del agente ya generada' });
+  });
+
+  it('degrada a null si el endpoint cae o no responde 2xx', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(503, { error: 'down' }));
+    const { companionSpeciesGuard } = await importFresh();
+    expect(await companionSpeciesGuard('respuesta')).toBeNull();
+  });
+
+  it('devuelve null sin fetch cuando la respuesta viene vacia', async () => {
+    const { companionSpeciesGuard } = await importFresh();
+    expect(await companionSpeciesGuard('')).toBeNull();
+    expect(await companionSpeciesGuard('   ')).toBeNull();
+    expect(await companionSpeciesGuard(null)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -751,6 +751,33 @@ export async function pestVsDiseaseGuard(userMessage) {
 }
 
 /**
+ * POST-LLM companion species guard. Valida la respuesta ya generada del
+ * agente contra el catalogo y devuelve un bloque de correccion listo para
+ * anteponer. Es fail-safe: si el endpoint cae, el turno sigue igual.
+ *
+ * @param {string} responseText - salida final del LLM ya generada.
+ * @returns {Promise<null | {
+ *   has_companion_species: boolean,
+ *   system_prompt_block: string,
+ *   reason: string,
+ * }>}
+ */
+export async function companionSpeciesGuard(responseText) {
+  if (!responseText || typeof responseText !== 'string' || !responseText.trim()) return null;
+  const raw = await postJson('/companion-species-guard', { response: responseText }, TOOL_TIMEOUT_MS);
+  if (!raw || typeof raw !== 'object') return null;
+  const hasCompanionSpecies =
+    raw.has_companion_species === true ||
+    raw.has_companion === true ||
+    raw.needs_correction === true;
+  return {
+    has_companion_species: hasCompanionSpecies,
+    system_prompt_block: typeof raw.system_prompt_block === 'string' ? raw.system_prompt_block : '',
+    reason: typeof raw.reason === 'string' ? raw.reason : '',
+  };
+}
+
+/**
  * Capa 2 anti-alucinación (cross-check de contexto). Llama
  * `POST ${BASE}/post-validate` con el TEXTO que el LLM ya generó y, opcional,
  * los `nombre_cientifico` de las entidades que la capa 1 resolvió para el turno


### PR DESCRIPTION
Cablea el companion-species-guard (#299, endpoint ya en el sidecar) en el flujo del agente: wrapper fail-safe en sidecarClient.js, integración POST-LLM en AgentScreen.jsx, y llamada en bench-contaminacion.mjs. Ataca el residual cross_thermal del bench final (alternativas fabricadas tipo 'Guinea Mombasa: fríjol'). Tests: sidecarClient 91 + promptAssembler 15 verdes. PENDIENTE antes de merge: re-bench para confirmar que mueve el residual sin penalizar latencia (es POST-LLM, puede implicar segundo turno).