### PR TITLE
test(services): unit tests reales para 4 services sin cobertura propia

### DIFF
--- a/src/services/__tests__/agentCapabilities.test.js
+++ b/src/services/__tests__/agentCapabilities.test.js
@@ -1,0 +1,164 @@
+/**
+ * agentCapabilities.test.js — cobertura del manifiesto único de capacidades
+ * (src/services/agentCapabilities.js) y de la lógica de DERIVACIÓN de
+ * `CHIP_INTENTS`/`CHIP_DEFS`.
+ *
+ * Consumidores como profileChipSelector.test.js, capabilityHealth.test.js o
+ * manoRamasReachable.test.js ejercitan CAPABILITY_MANIFEST/CHIP_DEFS de forma
+ * indirecta (a través de su propia lógica), pero ninguno valida el manifiesto
+ * ni la transformación (`filter`/`reduce`/`map` con spreads condicionales) EN
+ * SÍ MISMOS. Acá se cubre:
+ *
+ *   - Invariantes estructurales del manifiesto (ids únicos, hero⇒heroRoute,
+ *     heroRoute.kind conocido, featured⇒hero, stub⇒stubMessage+status soon).
+ *   - CHIP_INTENTS: solo entradas con `intent`, mapeo identidad, sin duplicar.
+ *   - CHIP_DEFS: mismo orden y longitud que las entradas con `intent`, y los
+ *     spreads condicionales de `stubMessage`/`moreGroup` (la clave NO debe
+ *     existir cuando el manifiesto no la trae — no basta con que sea
+ *     falsy/undefined).
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ */
+import { describe, it, expect } from 'vitest';
+import { CAPABILITY_MANIFEST, CHIP_INTENTS, CHIP_DEFS } from '../agentCapabilities.js';
+
+const HERO_ROUTE_KINDS = new Set(['ask', 'nav', 'photo', 'unavailable']);
+
+describe('CAPABILITY_MANIFEST — invariantes estructurales', () => {
+  it('todos los ids son únicos', () => {
+    const ids = CAPABILITY_MANIFEST.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('todo intent declarado es único (CHIP_INTENTS no puede pisar entradas)', () => {
+    const intents = CAPABILITY_MANIFEST.filter((e) => e.intent).map((e) => e.intent);
+    expect(new Set(intents).size).toBe(intents.length);
+  });
+
+  it('toda entrada hero:true trae heroRoute con kind conocido', () => {
+    for (const e of CAPABILITY_MANIFEST) {
+      if (e.hero === true) {
+        expect(e.heroRoute, `${e.id}: hero:true sin heroRoute`).toBeTruthy();
+        expect(HERO_ROUTE_KINDS.has(e.heroRoute.kind), `${e.id}: heroRoute.kind desconocido (${e.heroRoute.kind})`).toBe(true);
+      }
+    }
+  });
+
+  it('heroRoute kind "nav" siempre trae view; kind "ask" siempre trae prompt', () => {
+    for (const e of CAPABILITY_MANIFEST) {
+      if (!e.heroRoute) continue;
+      if (e.heroRoute.kind === 'nav') expect(e.heroRoute.view, `${e.id}`).toBeTruthy();
+      if (e.heroRoute.kind === 'ask') expect(e.heroRoute.prompt, `${e.id}`).toBeTruthy();
+    }
+  });
+
+  it('featured:true implica hero:true (no hay destacada fuera del anillo principal)', () => {
+    for (const e of CAPABILITY_MANIFEST) {
+      if (e.featured === true) {
+        expect(e.hero, `${e.id}: featured sin hero:true`).toBe(true);
+      }
+    }
+  });
+
+  it('toda entrada kind:"stub" trae status:"soon" y un stubMessage no vacío', () => {
+    for (const e of CAPABILITY_MANIFEST) {
+      if (e.kind === 'stub') {
+        expect(e.status, `${e.id}`).toBe('soon');
+        expect(typeof e.stubMessage, `${e.id}`).toBe('string');
+        expect(e.stubMessage.trim().length, `${e.id}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('toda entrada kind:"tool" trae un nombre de tool no vacío', () => {
+    for (const e of CAPABILITY_MANIFEST) {
+      if (e.kind === 'tool') {
+        expect(typeof e.tool, `${e.id}`).toBe('string');
+        expect(e.tool.trim().length, `${e.id}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('toda entrada trae un group no vacío', () => {
+    for (const e of CAPABILITY_MANIFEST) {
+      expect(typeof e.group, `${e.id}`).toBe('string');
+      expect(e.group.trim().length, `${e.id}`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('CHIP_INTENTS — derivación (filter + reduce)', () => {
+  const entriesConIntent = CAPABILITY_MANIFEST.filter((e) => e.intent);
+
+  it('tiene exactamente una clave por entrada con intent (sin más, sin menos)', () => {
+    expect(Object.keys(CHIP_INTENTS).length).toBe(entriesConIntent.length);
+  });
+
+  it('excluye entradas del manifiesto sin campo intent (acciones puras de AgentHero)', () => {
+    // 'plantas', 'aprender_hub', 'foto' son acciones de la mano sin chip/intent.
+    expect(CHIP_INTENTS.plantas).toBeUndefined();
+    expect(CHIP_INTENTS.aprender_hub).toBeUndefined();
+    expect(CHIP_INTENTS.foto).toBeUndefined();
+  });
+
+  it('cada clave mapea a sí misma (identidad) para todas las entradas con intent', () => {
+    for (const e of entriesConIntent) {
+      expect(CHIP_INTENTS[e.intent]).toBe(e.intent);
+    }
+  });
+});
+
+describe('CHIP_DEFS — derivación (filter + map con spreads condicionales)', () => {
+  const entriesConIntent = CAPABILITY_MANIFEST.filter((e) => e.intent);
+
+  it('mismo largo y mismo orden que las entradas del manifiesto con intent', () => {
+    expect(CHIP_DEFS.length).toBe(entriesConIntent.length);
+    expect(CHIP_DEFS.map((d) => d.intent)).toEqual(entriesConIntent.map((e) => e.intent));
+  });
+
+  it('cada CHIP_DEF trae emoji/label/kind/placeholder tomados del manifiesto', () => {
+    const siembro = CHIP_DEFS.find((d) => d.intent === 'siembro');
+    const manifiestoSiembro = CAPABILITY_MANIFEST.find((e) => e.id === 'siembro');
+    expect(siembro).toMatchObject({
+      emoji: manifiestoSiembro.icon,
+      label: manifiestoSiembro.label,
+      kind: manifiestoSiembro.kind,
+      placeholder: manifiestoSiembro.placeholder,
+    });
+  });
+
+  it('stubMessage: la CLAVE no existe si el manifiesto no trae stubMessage (no solo undefined)', () => {
+    const siembro = CHIP_DEFS.find((d) => d.intent === 'siembro');
+    expect('stubMessage' in siembro).toBe(false);
+  });
+
+  it('stubMessage: SÍ está presente y con el texto exacto cuando el manifiesto lo define (chip "deep")', () => {
+    const deep = CHIP_DEFS.find((d) => d.intent === 'deep');
+    const manifiestoDeep = CAPABILITY_MANIFEST.find((e) => e.id === 'deep');
+    expect(deep.stubMessage).toBe(manifiestoDeep.stubMessage);
+  });
+
+  it('moreGroup: la CLAVE no existe si el manifiesto no marca chipMore', () => {
+    const siembro = CHIP_DEFS.find((d) => d.intent === 'siembro');
+    expect('moreGroup' in siembro).toBe(false);
+  });
+
+  it('moreGroup:true SOLO en los chips marcados chipMore (grounding oscuro agrupado bajo "Más")', () => {
+    const conMoreGroup = CHIP_DEFS.filter((d) => d.moreGroup === true).map((d) => d.intent).sort();
+    const chipMoreEsperados = CAPABILITY_MANIFEST.filter((e) => e.chipMore).map((e) => e.intent).sort();
+    expect(conMoreGroup).toEqual(chipMoreEsperados);
+    expect(conMoreGroup).toEqual(
+      ['alerta_paramo', 'fenologia', 'polinizacion', 'saberes_tradicionales', 'toxicidad', 'variedades'].sort(),
+    );
+  });
+
+  it('un chip puede tener moreGroup Y stubMessage ausentes a la vez sin heredar claves del vecino', () => {
+    // Regresión: si el spread condicional se rompiera (p. ej. reusando el
+    // mismo objeto acumulador), un chip sin stubMessage podría "heredar" el
+    // del anterior. Verificamos aislamiento entre entradas consecutivas.
+    const plaga = CHIP_DEFS.find((d) => d.intent === 'plaga'); // sin stub, sin moreGroup
+    const deep = CHIP_DEFS.find((d) => d.intent === 'deep'); // con stub, sin moreGroup
+    expect('stubMessage' in plaga).toBe(false);
+    expect(deep.stubMessage).not.toBe(plaga.stubMessage);
+  });
+});

--- a/src/services/__tests__/entityExtractor.contract.test.js
+++ b/src/services/__tests__/entityExtractor.contract.test.js
@@ -1,0 +1,175 @@
+/**
+ * entityExtractor.contract.test.js — cobertura complementaria de
+ * src/services/entityExtractor.js.
+ *
+ * `entityExtractor.tolerantJson.test.js` ya cubre a fondo el parser tolerante
+ * (reparación de JSON truncado/con fences). Este archivo cubre lo que ese NO
+ * cubre:
+ *
+ *   - Entradas inválidas (texto vacío/no-string) devuelven [] SIN llamar red.
+ *   - `resolveSystemPrompt`: resolución del módulo Pro vía moduleRegistry
+ *     (éxito, fallo silencioso al montar, y forma inválida) + cache por
+ *     proceso (no repite el dynamic import en llamadas subsecuentes).
+ *   - Timeout/abort: `AbortError` se traduce al mensaje en español
+ *     "Tiempo agotado al extraer entidades".
+ *   - Variantes de envoltura de la respuesta NO-array del modelo:
+ *     `{entities:[...]}`, `{data:[...]}`, objeto plano único, y objeto sin
+ *     ninguna de esas formas (→ []).
+ *   - `isValidEntity`: quantity no-entero o <=0, location no-string, crop
+ *     vacío se descartan sin inventar valores.
+ *
+ * Nota tsc: usamos `vi.mocked(fn)` (no `.mockX` directo sobre el import) para
+ * quedar limpios contra el gate — mismo patrón de agentTelemetrySync.test.js
+ * (memoria feedback-tsc-gate-bottleneck-nuevos-archivos).
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../ollamaStream', () => ({
+  streamOllama: vi.fn(),
+}));
+vi.mock('../../core/moduleRegistry', () => ({
+  registry: { byCapability: vi.fn(() => []) },
+}));
+
+import { streamOllama } from '../ollamaStream';
+import { registry } from '../../core/moduleRegistry';
+import { extractEntities, resolveSystemPrompt, _resetSystemPromptCache, SYSTEM_PROMPT, MODEL } from '../entityExtractor';
+
+beforeEach(() => {
+  vi.mocked(streamOllama).mockReset();
+  vi.mocked(registry.byCapability).mockReset();
+  vi.mocked(registry.byCapability).mockReturnValue([]);
+  _resetSystemPromptCache();
+});
+
+describe('extractEntities — entradas inválidas (corta antes de la red)', () => {
+  /** @type {Array<[unknown, string]>} */
+  const casosInvalidos = [
+    ['', 'vacío'],
+    [null, 'null'],
+    [undefined, 'undefined'],
+    [42, 'numero'],
+  ];
+
+  it.each(casosInvalidos)('text=%s (%s) → [] sin invocar streamOllama', async (bad, _label) => {
+    const out = await extractEntities(/** @type {any} */ (bad));
+    expect(out).toEqual([]);
+    expect(streamOllama).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveSystemPrompt — resolución Pro vs stub OSS + cache', () => {
+  it('sin módulo Pro registrado → devuelve el stub OSS', async () => {
+    vi.mocked(registry.byCapability).mockReturnValue([]);
+    const prompt = await resolveSystemPrompt();
+    expect(prompt).toBe(SYSTEM_PROMPT);
+  });
+
+  it('módulo Pro registrado con systemPrompt válido → lo usa en vez del stub', async () => {
+    const proPrompt = 'PROMPT PRO CON FEW-SHOTS COLOMBIANOS';
+    vi.mocked(registry.byCapability).mockReturnValue([
+      { mount: vi.fn(async () => ({ default: { systemPrompt: proPrompt } })) },
+    ]);
+    const prompt = await resolveSystemPrompt();
+    expect(prompt).toBe(proPrompt);
+  });
+
+  it('módulo Pro cuyo mount() falla → cae silenciosamente al stub OSS (no lanza)', async () => {
+    vi.mocked(registry.byCapability).mockReturnValue([
+      { mount: vi.fn(async () => { throw new Error('módulo roto'); }) },
+    ]);
+    await expect(resolveSystemPrompt()).resolves.toBe(SYSTEM_PROMPT);
+  });
+
+  it('módulo Pro con systemPrompt vacío/con forma inválida → cae al stub OSS', async () => {
+    vi.mocked(registry.byCapability).mockReturnValue([
+      { mount: vi.fn(async () => ({ default: { systemPrompt: '' } })) },
+    ]);
+    await expect(resolveSystemPrompt()).resolves.toBe(SYSTEM_PROMPT);
+  });
+
+  it('cachea el resultado: la segunda llamada NO vuelve a consultar el registry', async () => {
+    vi.mocked(registry.byCapability).mockReturnValue([]);
+    await resolveSystemPrompt();
+    await resolveSystemPrompt();
+    expect(registry.byCapability).toHaveBeenCalledTimes(1);
+  });
+
+  it('extractEntities usa el prompt Pro resuelto como mensaje system al modelo', async () => {
+    const proPrompt = 'PROMPT PRO XYZ';
+    vi.mocked(registry.byCapability).mockReturnValue([
+      { mount: vi.fn(async () => ({ default: { systemPrompt: proPrompt } })) },
+    ]);
+    vi.mocked(streamOllama).mockResolvedValue('[{"crop":"papa","quantity":2,"location":""}]');
+
+    await extractEntities('sembre dos papas');
+
+    const [, body] = vi.mocked(streamOllama).mock.calls[0];
+    expect(body.messages[0]).toEqual({ role: 'system', content: proPrompt });
+    expect(body.model).toBe(MODEL);
+  });
+});
+
+describe('extractEntities — timeout/abort', () => {
+  it('AbortError del transporte se traduce a mensaje en español', async () => {
+    const abortErr = new Error('The operation was aborted');
+    abortErr.name = 'AbortError';
+    vi.mocked(streamOllama).mockRejectedValue(abortErr);
+
+    await expect(extractEntities('sembre tres yucas')).rejects.toThrow(/tiempo agotado/i);
+  });
+
+  it('un error de red genérico se propaga tal cual (no se disfraza de timeout)', async () => {
+    vi.mocked(streamOllama).mockRejectedValue(new Error('fetch failed: ECONNREFUSED'));
+    await expect(extractEntities('sembre tres yucas')).rejects.toThrow(/ECONNREFUSED/);
+  });
+});
+
+describe('extractEntities — variantes de envoltura NO-array', () => {
+  it('{entities:[...]} se desenvuelve a la lista', async () => {
+    vi.mocked(streamOllama).mockResolvedValue('{"entities":[{"crop":"maiz","quantity":4,"location":"lote1"}]}');
+    const out = await extractEntities('sembre cuatro maices en lote1');
+    expect(out).toEqual([{ crop: 'maiz', quantity: 4, location: 'lote1' }]);
+  });
+
+  it('{data:[...]} se desenvuelve a la lista', async () => {
+    vi.mocked(streamOllama).mockResolvedValue('{"data":[{"crop":"frijol","quantity":6,"location":""}]}');
+    const out = await extractEntities('sembre seis frijoles');
+    expect(out).toEqual([{ crop: 'frijol', quantity: 6, location: '' }]);
+  });
+
+  it('un único objeto plano {crop,quantity,location} se envuelve en array', async () => {
+    vi.mocked(streamOllama).mockResolvedValue('{"crop":"cebolla","quantity":8,"location":"huerta"}');
+    const out = await extractEntities('sembre ocho cebollas en la huerta');
+    expect(out).toEqual([{ crop: 'cebolla', quantity: 8, location: 'huerta' }]);
+  });
+
+  it('objeto sin ninguna forma reconocida → [] (no inventa datos)', async () => {
+    vi.mocked(streamOllama).mockResolvedValue('{"foo":"bar"}');
+    const out = await extractEntities('algo raro');
+    expect(out).toEqual([]);
+  });
+});
+
+describe('extractEntities — isValidEntity (descarte sin inventar)', () => {
+  it('descarta quantity no-entero, quantity<=0, location no-string y crop vacío', async () => {
+    vi.mocked(streamOllama).mockResolvedValue(JSON.stringify([
+      { crop: 'papa', quantity: 3, location: 'norte' }, // válido
+      { crop: 'yuca', quantity: 2.5, location: 'sur' }, // quantity no entero
+      { crop: 'maiz', quantity: 0, location: 'sur' }, // quantity <= 0
+      { crop: 'arroz', quantity: -2, location: 'sur' }, // quantity negativo
+      { crop: 'frijol', quantity: 5, location: /** @type {any} */ (42) }, // location no-string
+      { crop: '  ', quantity: 5, location: 'sur' }, // crop vacío tras trim
+    ]));
+    const out = await extractEntities('mezcla de cultivos');
+    expect(out).toEqual([{ crop: 'papa', quantity: 3, location: 'norte' }]);
+  });
+
+  it('normaliza crop a minúsculas/trim y location a trim, preservando quantity entero', async () => {
+    vi.mocked(streamOllama).mockResolvedValue('[{"crop":"  TOMATE  ","quantity":5,"location":"  Invernadero  "}]');
+    const out = await extractEntities('sembre cinco tomates');
+    expect(out).toEqual([{ crop: 'tomate', quantity: 5, location: 'Invernadero' }]);
+  });
+});

--- a/src/services/__tests__/perennialCalculator.test.js
+++ b/src/services/__tests__/perennialCalculator.test.js
@@ -1,0 +1,122 @@
+/**
+ * perennialCalculator.test.js — cobertura complementaria del resolver de ciclo
+ * HÍBRIDO de perennes (src/services/perennialCalculator.js).
+ *
+ * `src/data/__tests__/perennialCycles.test.js` YA cubre el contrato principal
+ * (fases establishment/productive, regímenes continuous/seasonal/unknown,
+ * degradación sin datos). Este archivo agrega lo que ese no cubre:
+ *
+ *   - Las 4 ramas de `regimeNote` (texto de `annual.note`), incluida la
+ *     variante continuous CON vs SIN picos listados.
+ *   - El límite exacto de la transición de fase (yearsElapsed === minYears).
+ *   - `nextHarvestMonths` cuando el mes actual ES un mes de cosecha.
+ *   - Entradas defensivas: `plantingDate` inválido (negativo/NaN) y
+ *     `now` inválido (0) caen a los defaults documentados.
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolvePerennialCycle } from '../perennialCalculator';
+
+const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
+
+describe('perennialCalculator — regimeNote (annual.note)', () => {
+  it('continuous CON meses listados: nota menciona los picos', () => {
+    // theobroma_cacao: regime continuous, harvest_months no vacío.
+    const res = resolvePerennialCycle({ speciesId: 'theobroma_cacao', now: Date.UTC(2026, 0, 1) });
+    expect(res.annual.regime).toBe('continuous');
+    expect(res.annual.harvestMonths.length).toBeGreaterThan(0);
+    expect(res.annual.note).toBe('Produce casi todo el año, con picos en los meses resaltados.');
+  });
+
+  it('continuous SIN meses listados: nota no promete picos', () => {
+    // rubus_glaucus: regime continuous, harvest_months vacío (dato no firme).
+    const res = resolvePerennialCycle({ speciesId: 'rubus_glaucus', now: Date.UTC(2026, 0, 1) });
+    expect(res.annual.regime).toBe('continuous');
+    expect(res.annual.harvestMonths).toEqual([]);
+    expect(res.annual.note).toBe('Produce casi todo el año una vez establecida.');
+  });
+
+  it('bimodal: nota menciona dos temporadas', () => {
+    const res = resolvePerennialCycle({ speciesId: 'coffea_arabica', now: Date.UTC(2026, 0, 1) });
+    expect(res.annual.regime).toBe('bimodal');
+    expect(res.annual.note).toBe('Tiene dos temporadas de producción al año.');
+  });
+
+  it('seasonal: nota menciona una temporada marcada', () => {
+    const res = resolvePerennialCycle({ speciesId: 'mangifera_indica', now: Date.UTC(2026, 0, 1) });
+    expect(res.annual.regime).toBe('seasonal');
+    expect(res.annual.note).toBe('Tiene una temporada de producción marcada al año.');
+  });
+
+  it('unknown: nota honesta de variabilidad regional', () => {
+    const res = resolvePerennialCycle({ speciesId: 'citrus_sinensis', now: Date.UTC(2026, 0, 1) });
+    expect(res.annual.regime).toBe('unknown');
+    expect(res.annual.note).toBe(
+      'El calendario varía por región y altitud; consulta el comportamiento en tu zona.',
+    );
+  });
+});
+
+describe('perennialCalculator — límite exacto de la transición de fase', () => {
+  it('yearsElapsed === minYears entra en fase productive (borde inclusive)', () => {
+    // persea_americana: years_to_first_harvest [2, 4]. Siembra hace EXACTO
+    // 2 años respecto al `now` fijado → cae justo en el mínimo.
+    const now = Date.UTC(2026, 0, 1);
+    const planting = now - 2 * YEAR_MS;
+    const res = resolvePerennialCycle({ speciesId: 'persea_americana', plantingDate: planting, now });
+    expect(res.phase).toBe('productive');
+  });
+
+  it('un instante ANTES del mínimo sigue en fase establishment', () => {
+    const now = Date.UTC(2026, 0, 1);
+    // Un día antes de cumplir el mínimo de 2 años.
+    const planting = now - (2 * YEAR_MS - 24 * 60 * 60 * 1000);
+    const res = resolvePerennialCycle({ speciesId: 'persea_americana', plantingDate: planting, now });
+    expect(res.phase).toBe('establishment');
+  });
+});
+
+describe('perennialCalculator — nextHarvestMonths', () => {
+  it('cuando el mes actual ES mes de cosecha, aparece primero en la lista', () => {
+    // coffea_arabica cosecha [4,5,6,9,10,11,12]; abril (mes 4) es cosecha.
+    const abril = Date.UTC(2026, 3, 10);
+    const res = resolvePerennialCycle({ speciesId: 'coffea_arabica', now: abril });
+    expect(res.annual.currentMonth).toBe(4);
+    expect(res.annual.isHarvest).toBe(true);
+    expect(res.annual.nextHarvestMonths[0]).toBe(4);
+  });
+
+  it('sin meses de cosecha (continuous sin dato firme) devuelve lista vacía', () => {
+    const res = resolvePerennialCycle({ speciesId: 'rubus_glaucus', now: Date.UTC(2026, 0, 1) });
+    expect(res.annual.nextHarvestMonths).toEqual([]);
+  });
+});
+
+describe('perennialCalculator — entradas defensivas', () => {
+  it('plantingDate negativo se trata como "sin siembra" (no revienta ni da NaN)', () => {
+    const res = resolvePerennialCycle({ speciesId: 'theobroma_cacao', plantingDate: -100, now: Date.UTC(2026, 0, 1) });
+    expect(res.phase).toBe('productive');
+    expect(res.establishment.progress).toBeNull();
+    expect(res.establishment.yearsElapsed).toBeNull();
+  });
+
+  it('plantingDate NaN se trata como "sin siembra"', () => {
+    const res = resolvePerennialCycle({ speciesId: 'theobroma_cacao', plantingDate: NaN, now: Date.UTC(2026, 0, 1) });
+    expect(res.establishment.progress).toBeNull();
+  });
+
+  it('now inválido (0) cae al Date.now() real, no revienta', () => {
+    const res = resolvePerennialCycle({ speciesId: 'theobroma_cacao', now: 0 });
+    expect(res.annual.currentMonth).toBe(new Date().getMonth() + 1);
+  });
+
+  it('progress nunca excede 1 aunque yearsElapsed supere maxYears por mucho', () => {
+    // Siembra hace 50 años: muy por encima del rango [2,5] de theobroma_cacao.
+    const now = Date.UTC(2026, 0, 1);
+    const planting = now - 50 * YEAR_MS;
+    const res = resolvePerennialCycle({ speciesId: 'theobroma_cacao', plantingDate: planting, now });
+    expect(res.establishment.progress).toBe(1);
+    expect(res.phase).toBe('productive');
+  });
+});

--- a/src/services/__tests__/usageTelemetryService.test.js
+++ b/src/services/__tests__/usageTelemetryService.test.js
@@ -1,0 +1,172 @@
+/**
+ * usageTelemetryService.test.js — cobertura de los envoltorios de telemetría
+ * ANÓNIMA de uso (src/services/usageTelemetryService.js).
+ *
+ * Este servicio NUNCA tenía test propio: solo aparecía mockeado en pruebas de
+ * componentes (temas-fase2-1-contraste.test.jsx), que no ejercitan su lógica
+ * real (validación de entrada, filtrado de `extra`, no-throw). Se cubre acá:
+ *
+ *   - Cada función valida el id/categoría requerido (string no vacío tras
+ *     trim) y NO llama a `recordPilotEvent` si falla la validación.
+ *   - `safeExtra` (privacidad, defensa extra): solo deja pasar valores
+ *     number/boolean/string; descarta objetos, arrays, funciones, undefined.
+ *   - `recordAgentQueryCategory` solo manda la CATEGORÍA, nunca texto libre.
+ *   - [BUG documentado, no se toca el fuente] el try/catch de cada wrapper es
+ *     SÍNCRONO: envuelve la llamada a `recordPilotEvent`, no la promesa que
+ *     ésta devuelve. Si `recordPilotEvent` (async) rechazara, el catch NO lo
+ *     atraparía, pese a que el header del archivo documenta "no-throw". En
+ *     producción no se manifiesta porque `recordPilotEvent` real tiene su
+ *     propio try/catch interno y nunca rechaza — pero el wrapper no ofrece
+ *     la protección extra que promete si esa garantía cambiara.
+ *
+ * Nota tsc: `vi.mocked(fn)` en vez de `.mockX` directo sobre el import, y
+ * casts `/** @type {any} *\/` en los valores deliberadamente inválidos que
+ * pasamos a funciones tipadas por JSDoc (memoria
+ * feedback-tsc-gate-bottleneck-nuevos-archivos).
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../pilotTelemetryService.js', () => ({
+  recordPilotEvent: vi.fn(),
+}));
+
+import { recordPilotEvent } from '../pilotTelemetryService.js';
+import {
+  recordGameStart,
+  recordGameComplete,
+  recordScreenView,
+  recordFeatureUse,
+  recordAgentQueryCategory,
+} from '../usageTelemetryService.js';
+
+beforeEach(() => {
+  vi.mocked(recordPilotEvent).mockReset();
+  vi.mocked(recordPilotEvent).mockResolvedValue({ id: 'pt_1' });
+});
+
+describe('recordGameStart', () => {
+  it('registra game_start con el game_id dado', async () => {
+    await recordGameStart('milpa');
+    expect(recordPilotEvent).toHaveBeenCalledWith({
+      event_type: 'game_start',
+      metadata: { game_id: 'milpa' },
+    });
+  });
+
+  /** @type {Array<[unknown, string]>} */
+  const gameIdsInvalidos = [
+    ['', 'vacío'],
+    ['   ', 'solo espacios'],
+    [null, 'null'],
+    [undefined, 'undefined'],
+    [123, 'numero (no-string)'],
+  ];
+
+  it.each(gameIdsInvalidos)('gameId inválido (%s: %s) → null sin llamar a recordPilotEvent', async (bad) => {
+    const out = await recordGameStart(/** @type {any} */ (bad));
+    expect(out).toBeNull();
+    expect(recordPilotEvent).not.toHaveBeenCalled();
+  });
+
+  it('[BUG] promete no-throw pero el try/catch síncrono no atrapa el rechazo async de recordPilotEvent', async () => {
+    vi.mocked(recordPilotEvent).mockRejectedValue(new Error('IndexedDB no disponible'));
+    await expect(recordGameStart('milpa')).rejects.toThrow('IndexedDB no disponible');
+  });
+});
+
+describe('recordGameComplete', () => {
+  it('registra game_complete con game_id y extra sanitizado', async () => {
+    await recordGameComplete('milpa', { score: 42, won: true, level: 'facil' });
+    expect(recordPilotEvent).toHaveBeenCalledWith({
+      event_type: 'game_complete',
+      metadata: { game_id: 'milpa', score: 42, won: true, level: 'facil' },
+    });
+  });
+
+  it('sin extra → metadata solo con game_id', async () => {
+    await recordGameComplete('doom_finca');
+    expect(recordPilotEvent).toHaveBeenCalledWith({
+      event_type: 'game_complete',
+      metadata: { game_id: 'doom_finca' },
+    });
+  });
+
+  it('descarta valores no primitivos de extra (objetos, arrays, funciones, undefined)', async () => {
+    await recordGameComplete('milpa', /** @type {any} */ ({
+      score: 10,
+      nested: { a: 1 },
+      list: [1, 2, 3],
+      cb: () => {},
+      missing: undefined,
+      raw: null,
+    }));
+    const [{ metadata }] = vi.mocked(recordPilotEvent).mock.calls[0];
+    expect(metadata).toEqual({ game_id: 'milpa', score: 10 });
+  });
+
+  it('gameId inválido → null, no llama recordPilotEvent', async () => {
+    const out = await recordGameComplete('');
+    expect(out).toBeNull();
+    expect(recordPilotEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordScreenView', () => {
+  it('registra screen_view con el screen dado', async () => {
+    await recordScreenView('activos');
+    expect(recordPilotEvent).toHaveBeenCalledWith({
+      event_type: 'screen_view',
+      metadata: { screen: 'activos' },
+    });
+  });
+
+  it('screen vacío/blanco → null', async () => {
+    expect(await recordScreenView('')).toBeNull();
+    expect(await recordScreenView('   ')).toBeNull();
+    expect(recordPilotEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordFeatureUse', () => {
+  it('registra feature_use con feature y extra sanitizado', async () => {
+    await recordFeatureUse('foto_diagnostico', { confidence: 0.87, plaga_detectada: true });
+    expect(recordPilotEvent).toHaveBeenCalledWith({
+      event_type: 'feature_use',
+      metadata: { feature: 'foto_diagnostico', confidence: 0.87, plaga_detectada: true },
+    });
+  });
+
+  it('feature inválido (no-string) → null sin llamar a recordPilotEvent', async () => {
+    const out = await recordFeatureUse(/** @type {any} */ (undefined));
+    expect(out).toBeNull();
+    expect(recordPilotEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordAgentQueryCategory — privacidad', () => {
+  it('registra agent_query con SOLO la categoría (ninguna otra clave)', async () => {
+    await recordAgentQueryCategory('controladores_plagas');
+    expect(recordPilotEvent).toHaveBeenCalledTimes(1);
+    const [{ event_type, metadata }] = vi.mocked(recordPilotEvent).mock.calls[0];
+    expect(event_type).toBe('agent_query');
+    expect(Object.keys(metadata)).toEqual(['category']);
+    expect(metadata.category).toBe('controladores_plagas');
+  });
+
+  it('NO tiene forma de adjuntar texto libre del usuario: solo acepta un string y lo manda tal cual como category', async () => {
+    // Esta función no recibe un objeto `extra` (a diferencia de game_complete
+    // y feature_use) — por diseño, no hay superficie para colar texto de
+    // prompt/respuesta. Verificamos que la firma es (category) => ..., y que
+    // pasar algo que no sea string no-vacío se descarta.
+    expect(await recordAgentQueryCategory(/** @type {any} */ (null))).toBeNull();
+    expect(await recordAgentQueryCategory(/** @type {any} */ (42))).toBeNull();
+    expect(recordPilotEvent).not.toHaveBeenCalled();
+  });
+
+  it('[BUG] promete no-throw pero el try/catch síncrono no atrapa el rechazo async de recordPilotEvent', async () => {
+    vi.mocked(recordPilotEvent).mockRejectedValue(new Error('boom'));
+    await expect(recordAgentQueryCategory('fenologia')).rejects.toThrow('boom');
+  });
+});


### PR DESCRIPTION
## Resumen

Agrega 67 unit tests nuevos en `src/services/__tests__/` para 4 services que no tenían archivo de test propio (o tenían solo cobertura parcial/indirecta vía otros archivos):

- **`perennialCalculator.test.js`** (13 tests) — complementa `data/__tests__/perennialCycles.test.js`. Cubre las 4 ramas de `regimeNote` (continuous con/sin picos, bimodal, seasonal, unknown), el límite exacto de la transición de fase `establishment`→`productive` (borde inclusive en `yearsElapsed === minYears`), `nextHarvestMonths` cuando el mes actual ES mes de cosecha, y entradas defensivas (`plantingDate` negativo/NaN, `now` inválido).
- **`entityExtractor.contract.test.js`** (18 tests) — complementa `entityExtractor.tolerantJson.test.js` (que solo cubre el parser tolerante). Cubre entradas inválidas (corta antes de la red), `resolveSystemPrompt` (módulo Pro vs stub OSS, fallo silencioso al montar, cache por proceso), timeout/`AbortError` → mensaje en español, variantes de envoltura no-array de la respuesta del modelo (`{entities:[...]}`, `{data:[...]}`, objeto plano, forma desconocida), e `isValidEntity` (descarta sin inventar).
- **`usageTelemetryService.test.js`** (18 tests) — este service NUNCA tenía test propio (solo aparecía mockeado en un test de componente). Cubre validación de entrada, `safeExtra` (filtro de privacidad por tipo), y la garantía de privacidad de `recordAgentQueryCategory` (solo manda `category`, nunca texto libre).
- **`agentCapabilities.test.js`** (18 tests) — la derivación `CHIP_INTENTS`/`CHIP_DEFS` (filter/reduce/map con spreads condicionales) nunca se testeaba en sí misma, solo indirectamente vía consumidores (`profileChipSelector`, `capabilityHealth`, `manoRamasReachable`). Cubre invariantes estructurales del manifiesto (ids únicos, `hero`⇒`heroRoute`, `featured`⇒`hero`, `stub`⇒`stubMessage`+`status:soon`) y los spreads condicionales de `stubMessage`/`moreGroup`.

## Bug real documentado (no corregido — fuera de alcance de esta tarea)

`usageTelemetryService.js` documenta en su header "Todas las funciones son no-throw: cualquier error se traga y se devuelve null", pero el `try/catch` de cada wrapper (`recordGameStart`, `recordAgentQueryCategory`, etc.) es **síncrono**: envuelve la llamada a `recordPilotEvent`, no la promesa async que ésta devuelve. Si `recordPilotEvent` rechazara, el catch NO lo atraparía. Hoy esto no se manifiesta en producción porque `recordPilotEvent` real tiene su propio try/catch interno y nunca rechaza — pero el wrapper no ofrece la protección extra que promete si esa garantía cambiara. Se agregaron 2 tests `[BUG]` que fijan el comportamiento real actual, para que quede visible si alguien cambia el contrato sin querer. No se tocó el código fuente.

## Notas técnicas

- Solo se agregaron archivos nuevos en `src/services/__tests__/`; no se modificó ningún archivo fuente.
- Los mocks usan `vi.mocked(fn)` en vez de `.mockX` directo sobre el import (patrón ya usado en `agentTelemetrySync.test.js`) para no generar errores nuevos en el gate de `tsc:check` — verificado con `node scripts/tsc-check-gate.mjs`: 1836 = 1836 baseline, 0 errores nuevos.
- Cada archivo se corrió con `npx vitest run <archivo>` individualmente y en conjunto: 67/67 pasan.

## Test plan

- [x] `npx vitest run src/services/__tests__/perennialCalculator.test.js` → 13 passed
- [x] `npx vitest run src/services/__tests__/entityExtractor.contract.test.js` → 18 passed
- [x] `npx vitest run src/services/__tests__/usageTelemetryService.test.js` → 18 passed
- [x] `npx vitest run src/services/__tests__/agentCapabilities.test.js` → 18 passed
- [x] `node scripts/tsc-check-gate.mjs` → OK, sin errores nuevos
- [x] Regresión: consumidores existentes (`profileChipSelector`, `capabilityHealth`, `manoRamasReachable`, `entityExtractor.tolerantJson`, `entityExtractor.multispecies`, `perennialCycles`, `ayudaFunciones`) siguen pasando (122/122)

🤖 Generated with [Claude Code](https://claude.com/claude-code)