### PR TITLE
feat(nutricion): vista "La comida que alimenta" (aporte ICBF por cultivo)

### DIFF
--- a/public/nutricion-humana.json
+++ b/public/nutricion-humana.json
@@ -1,0 +1,869 @@
+{
+  "meta": {
+    "titulo": "La comida que alimenta",
+    "descripcion": "Qué te da comer cada cultivo de la finca — aporte nutricional por 100 gramos de porción comestible.",
+    "fuente": "ICBF — Tabla de Composición de Alimentos Colombianos (TCAC), 2015",
+    "fuente_url": "https://www.minsalud.gov.co/sites/rid/Lists/BibliotecaDigital/RIDE/INEC/IETS/tabla-de-composicion-alimentos-colombianos-2015.pdf",
+    "anio_fuente": 2015,
+    "unidad": "por 100 g de porción comestible",
+    "origen_datos": "Grafo de conocimiento chagra_kg (nodos AporteNutricional → Species vía TIENE_APORTE_NUTRICIONAL), exportado a estático porque la PWA no consulta el grafo en vivo.",
+    "batch": "nutricion-mercado-icbf-dr-2026-07-05",
+    "total_cultivos": 27,
+    "maximos": {
+      "energia_kcal": 468,
+      "proteina_g": 23.1,
+      "hierro_mg": 8.4,
+      "vitamina_a_er": 700
+    },
+    "nutrientes_ref": {
+      "energia_kcal": {
+        "etiqueta": "Energía",
+        "unidad": "kcal",
+        "folk": "Fuerza para el trabajo"
+      },
+      "proteina_g": {
+        "etiqueta": "Proteína",
+        "unidad": "g",
+        "folk": "Para formar el cuerpo"
+      },
+      "hierro_mg": {
+        "etiqueta": "Hierro",
+        "unidad": "mg",
+        "folk": "Para la sangre y la fuerza"
+      },
+      "vitamina_a_er": {
+        "etiqueta": "Vitamina A",
+        "unidad": "ER",
+        "folk": "Para los ojos y las defensas"
+      }
+    },
+    "nota_datos_faltantes": "Donde el ICBF (TCAC 2015) no reporta un valor, el campo va en null y aparece en datos_faltantes. No se inventan cifras."
+  },
+  "grupos": [
+    {
+      "id": "energeticos",
+      "titulo": "Energéticos",
+      "emoji": "🔥",
+      "folk": "Los que dan fuerza para el trabajo",
+      "cientifico": "Ricos en carbohidratos y grasas — el combustible del cuerpo.",
+      "color": "amber"
+    },
+    {
+      "id": "proteicos",
+      "titulo": "Proteicos",
+      "emoji": "💪",
+      "folk": "Los que forman el cuerpo: músculo y sangre",
+      "cientifico": "Ricos en proteína — construyen y reparan los tejidos.",
+      "color": "emerald"
+    },
+    {
+      "id": "protectores",
+      "titulo": "Protectores",
+      "emoji": "🛡️",
+      "folk": "Los que cuidan y defienden: ojos, sangre y defensas",
+      "cientifico": "Ricos en vitaminas y minerales — regulan y protegen.",
+      "color": "sky"
+    }
+  ],
+  "items": [
+    {
+      "id": "aporte_nutricional_coriandrum_sativum",
+      "species_id": "coriandrum_sativum",
+      "crop_key": "cilantro",
+      "nombre_comun": "Cilantro",
+      "nombre_cientifico": "Coriandrum sativum L.",
+      "nombres_comunes": [
+        "culantro"
+      ],
+      "categoria_botanica": "hortalizas_hoja",
+      "grupo": "protectores",
+      "nutriente_estrella": "vitamina_a_er",
+      "forma": "hojas",
+      "alimento_icbf": "Cilantro, hojas",
+      "codigo_icbf": 159,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 52,
+        "proteina_g": 4.2,
+        "hierro_mg": 7.4,
+        "vitamina_a_er": 390
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_cucurbita_maxima",
+      "species_id": "cucurbita_maxima",
+      "crop_key": "ahuyama",
+      "nombre_comun": "Calabaza / Auyama",
+      "nombre_cientifico": "Cucurbita maxima Duchesne",
+      "nombres_comunes": [
+        "ahuyama",
+        "calabacita banana",
+        "calabaza de castilla",
+        "zapallo criollo",
+        "zapallo plomo",
+        "zapallo"
+      ],
+      "categoria_botanica": "hortalizas_fruto_flor",
+      "grupo": "protectores",
+      "nutriente_estrella": "vitamina_a_er",
+      "forma": "sin cascara, cruda",
+      "alimento_icbf": "Ahuyama C. maxima, sin cascara, cruda",
+      "codigo_icbf": 124,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 40,
+        "proteina_g": 0.9,
+        "hierro_mg": null,
+        "vitamina_a_er": 340
+      },
+      "datos_faltantes": [
+        "hierro_mg"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_solanum_lycopersicum",
+      "species_id": "solanum_lycopersicum",
+      "crop_key": "tomate",
+      "nombre_comun": "Tomate chonto",
+      "nombre_cientifico": "Solanum lycopersicum L.",
+      "nombres_comunes": [
+        "frutilla"
+      ],
+      "categoria_botanica": null,
+      "grupo": "protectores",
+      "nutriente_estrella": "vitamina_a_er",
+      "forma": "pulpa",
+      "alimento_icbf": "Tomate, pulpa",
+      "codigo_icbf": 244,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 18,
+        "proteina_g": 0.9,
+        "hierro_mg": 1.5,
+        "vitamina_a_er": 110
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_arracacia_xanthorrhiza_amarilla",
+      "species_id": "arracacia_xanthorrhiza_amarilla",
+      "crop_key": "arracacha",
+      "nombre_comun": "Arracacha amarilla",
+      "nombre_cientifico": "Arracacia xanthorrhiza Bancr. cv. 'Amarilla'",
+      "nombres_comunes": [
+        "apio",
+        "arracacha",
+        "arracache",
+        "maya",
+        "sacha zanahoria",
+        "yurak zanahoria",
+        "zanahoria",
+        "zanahoria blanca"
+      ],
+      "categoria_botanica": "tuberculos_raices",
+      "grupo": "energeticos",
+      "nutriente_estrella": "energia_kcal",
+      "forma": "amarilla, cruda",
+      "alimento_icbf": "Arracacha amarilla, sin cascara, cruda",
+      "codigo_icbf": 135,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 99,
+        "proteina_g": 0.9,
+        "hierro_mg": 0.9,
+        "vitamina_a_er": 24
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_daucus_carota_subsp_sativus",
+      "species_id": "daucus_carota_subsp_sativus",
+      "crop_key": "zanahoria",
+      "nombre_comun": "Zanahoria",
+      "nombre_cientifico": "Daucus carota L. subsp. sativus (Hoffm.) Arcang.",
+      "nombres_comunes": [],
+      "categoria_botanica": "tuberculos_raices",
+      "grupo": "protectores",
+      "nutriente_estrella": "vitamina_a_er",
+      "forma": "cruda",
+      "alimento_icbf": "Zanahoria, cruda",
+      "codigo_icbf": 251,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 37,
+        "proteina_g": 0.7,
+        "hierro_mg": 0.4,
+        "vitamina_a_er": 700
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_solanum_quitoense",
+      "species_id": "solanum_quitoense",
+      "crop_key": "lulo",
+      "nombre_comun": "Lulo / Naranjilla / Chuva",
+      "nombre_cientifico": "Solanum quitoense Lam.",
+      "nombres_comunes": [
+        "daboka",
+        "huevo de perro",
+        "kukuch",
+        "naranjilla",
+        "naranjilla silvestre",
+        "lulo"
+      ],
+      "categoria_botanica": "frutales_perennes",
+      "grupo": "protectores",
+      "nutriente_estrella": null,
+      "forma": "maduro, pulpa",
+      "alimento_icbf": "Lulo, maduro, pulpa",
+      "codigo_icbf": 321,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 37,
+        "proteina_g": 0.9,
+        "hierro_mg": 0.6,
+        "vitamina_a_er": 37
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_solanum_betaceum",
+      "species_id": "solanum_betaceum",
+      "crop_key": "tomate_arbol",
+      "nombre_comun": "Tomate de árbol / Tamarillo",
+      "nombre_cientifico": "Solanum betaceum Cav.",
+      "nombres_comunes": [
+        "lima tomate",
+        "tomate",
+        "tomate extranjero",
+        "tomate de palo",
+        "tomate de árbol",
+        "tomato de arbol",
+        "tamarillo",
+        "tomate serrano"
+      ],
+      "categoria_botanica": "frutales_perennes",
+      "grupo": "protectores",
+      "nutriente_estrella": null,
+      "forma": "rojo, maduro, pulpa",
+      "alimento_icbf": "Tomate de arbol rojo, maduro, pulpa",
+      "codigo_icbf": 358,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 42,
+        "proteina_g": 2,
+        "hierro_mg": 0.9,
+        "vitamina_a_er": 36
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_brassica_oleracea_var_capitata",
+      "species_id": "brassica_oleracea_var_capitata",
+      "crop_key": "repollo",
+      "nombre_comun": "Repollo",
+      "nombre_cientifico": "Brassica oleracea var. capitata L.",
+      "nombres_comunes": [
+        "col",
+        "col repollo",
+        "lombarda",
+        "repollo"
+      ],
+      "categoria_botanica": "hortalizas_hoja",
+      "grupo": "protectores",
+      "nutriente_estrella": null,
+      "forma": "hojas frescas",
+      "alimento_icbf": "Repollo, hojas frescas",
+      "codigo_icbf": 238,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 35,
+        "proteina_g": 1.8,
+        "hierro_mg": 0.8,
+        "vitamina_a_er": 24
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_lactuca_sativa",
+      "species_id": "lactuca_sativa",
+      "crop_key": "lechuga",
+      "nombre_comun": "Lechuga",
+      "nombre_cientifico": "Lactuca sativa L.",
+      "nombres_comunes": [
+        "cogollo",
+        "ensalada",
+        "farfalá",
+        "lechuga",
+        "lechuga arrepollada",
+        "lechugón",
+        "lechuga romana"
+      ],
+      "categoria_botanica": null,
+      "grupo": "protectores",
+      "nutriente_estrella": null,
+      "forma": "comun",
+      "alimento_icbf": "Lechuga comun",
+      "codigo_icbf": 179,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 8,
+        "proteina_g": 0.8,
+        "hierro_mg": 0.9,
+        "vitamina_a_er": 10
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_fragaria_ananassa_monterrey",
+      "species_id": "fragaria_ananassa_monterrey",
+      "crop_key": "fresa",
+      "nombre_comun": "Fresa Monterrey",
+      "nombre_cientifico": "Fragaria × ananassa 'Monterrey'",
+      "nombres_comunes": [
+        "fresa",
+        "fresa ananás"
+      ],
+      "categoria_botanica": "frutales_perennes",
+      "grupo": "protectores",
+      "nutriente_estrella": null,
+      "forma": "maduro, fruto entero",
+      "alimento_icbf": "Fresa, maduro, fruto entero",
+      "codigo_icbf": 302,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 35,
+        "proteina_g": 0.8,
+        "hierro_mg": 1.4,
+        "vitamina_a_er": 4
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_rubus_glaucus",
+      "species_id": "rubus_glaucus",
+      "crop_key": "mora",
+      "nombre_comun": "Mora andina / Mora de Castilla",
+      "nombre_cientifico": "Rubus glaucus Benth.",
+      "nombres_comunes": [
+        "ashpa mora",
+        "mora",
+        "mora de castilla",
+        "mora de monte",
+        "mora grande",
+        "mora blanca",
+        "zarzamora azul"
+      ],
+      "categoria_botanica": "frutales_perennes",
+      "grupo": "protectores",
+      "nutriente_estrella": null,
+      "forma": "pulpa",
+      "alimento_icbf": "Mora de castilla, pulpa",
+      "codigo_icbf": 339,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 63,
+        "proteina_g": 1,
+        "hierro_mg": 1.7,
+        "vitamina_a_er": 0
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_theobroma_cacao",
+      "species_id": "theobroma_cacao",
+      "crop_key": "cacao",
+      "nombre_comun": "Cacao",
+      "nombre_cientifico": "Theobroma cacao L.",
+      "nombres_comunes": [
+        "bikinka",
+        "cacao",
+        "cacao de monte",
+        "cacavo",
+        "chocolate",
+        "kakau",
+        "kope moenka",
+        "kopemowenka"
+      ],
+      "categoria_botanica": "frutales_perennes",
+      "grupo": "energeticos",
+      "nutriente_estrella": "hierro_mg",
+      "forma": "tostado, molido",
+      "alimento_icbf": "Cacao, tostado, molido",
+      "codigo_icbf": 275,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 468,
+        "proteina_g": 14.4,
+        "hierro_mg": 5.8,
+        "vitamina_a_er": 4
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_coffea_arabica",
+      "species_id": "coffea_arabica",
+      "crop_key": "cafe",
+      "nombre_comun": "Café caturra / Castillo / Cenicafé 1",
+      "nombre_cientifico": "Coffea arabica L.",
+      "nombres_comunes": [
+        "cafeto",
+        "cafeto arábigo",
+        "cafeto arábico",
+        "cafeto de arabia"
+      ],
+      "categoria_botanica": "medicinales_alelopaticas",
+      "grupo": "energeticos",
+      "nutriente_estrella": "hierro_mg",
+      "forma": "molido",
+      "alimento_icbf": "Cafe, molido",
+      "codigo_icbf": 727,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 441,
+        "proteina_g": 14.2,
+        "hierro_mg": 5.8,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_persea_americana",
+      "species_id": "persea_americana",
+      "crop_key": "aguacate",
+      "nombre_comun": "Aguacate",
+      "nombre_cientifico": "Persea americana Mill.",
+      "nombres_comunes": [
+        "aguacate",
+        "palta",
+        "palto"
+      ],
+      "categoria_botanica": "frutales_perennes",
+      "grupo": "energeticos",
+      "nutriente_estrella": "energia_kcal",
+      "forma": "hass, maduro, pulpa",
+      "alimento_icbf": "Aguacate hass, maduro, pulpa",
+      "codigo_icbf": 252,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 170,
+        "proteina_g": 1.3,
+        "hierro_mg": null,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "hierro_mg",
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_manihot_esculenta",
+      "species_id": "manihot_esculenta",
+      "crop_key": "yuca",
+      "nombre_comun": "Yuca brava amazónica",
+      "nombre_cientifico": "Manihot esculenta Crantz",
+      "nombres_comunes": [
+        "airo bai a’so",
+        "apach mama",
+        "api lumu",
+        "arajuno lumu",
+        "auka lumu",
+        "awa llakta lumu",
+        "aypi",
+        "a’so"
+      ],
+      "categoria_botanica": "tuberculos_raices",
+      "grupo": "energeticos",
+      "nutriente_estrella": "energia_kcal",
+      "forma": "cruda",
+      "alimento_icbf": "Yuca, cruda",
+      "codigo_icbf": 249,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 153,
+        "proteina_g": 0.9,
+        "hierro_mg": 0.7,
+        "vitamina_a_er": 1
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_phaseolus_vulgaris_habichuela",
+      "species_id": "phaseolus_vulgaris",
+      "crop_key": "habichuela",
+      "nombre_comun": "Frijol arbustivo / voluble",
+      "nombre_cientifico": "Phaseolus vulgaris L.",
+      "nombres_comunes": [
+        "common bean",
+        "frijol",
+        "fréjol",
+        "habichuelas",
+        "mulu fintsumu buli",
+        "poroto",
+        "purutu",
+        "verdura"
+      ],
+      "categoria_botanica": "granos_legumbres",
+      "grupo": "protectores",
+      "nutriente_estrella": null,
+      "forma": "vaina verde, cruda",
+      "alimento_icbf": "Habichuela, cruda",
+      "codigo_icbf": 175,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 31,
+        "proteina_g": 2.1,
+        "hierro_mg": 1,
+        "vitamina_a_er": 17
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_beta_vulgaris_conditiva",
+      "species_id": "beta_vulgaris_conditiva",
+      "crop_key": "remolacha",
+      "nombre_comun": "Remolacha",
+      "nombre_cientifico": "Beta vulgaris L. subsp. vulgaris Conditiva Group",
+      "nombres_comunes": [
+        "acelga",
+        "acelga cardo",
+        "betarraga azucarera",
+        "betarraga forrajera",
+        "remolacha amarilla",
+        "remolacha azucarera",
+        "remolacha colorada",
+        "remolacha de mesa"
+      ],
+      "categoria_botanica": "tuberculos_raices",
+      "grupo": "protectores",
+      "nutriente_estrella": null,
+      "forma": "sin cascara, cruda",
+      "alimento_icbf": "Remolacha, sin cascara, cruda",
+      "codigo_icbf": 234,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 44,
+        "proteina_g": 1.4,
+        "hierro_mg": 0.8,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_allium_cepa",
+      "species_id": "allium_cepa",
+      "crop_key": "cebolla",
+      "nombre_comun": "Cebolla cabezona",
+      "nombre_cientifico": "Allium cepa L.",
+      "nombres_comunes": [
+        "cebolla",
+        "cebolla cabezona"
+      ],
+      "categoria_botanica": "tuberculos_raices",
+      "grupo": "protectores",
+      "nutriente_estrella": null,
+      "forma": "cabezona",
+      "alimento_icbf": "Cebolla cabezona",
+      "codigo_icbf": 150,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 33,
+        "proteina_g": 1.4,
+        "hierro_mg": 0.7,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_zea_mays",
+      "species_id": "zea_mays",
+      "crop_key": "maiz",
+      "nombre_comun": "Maíz criollo",
+      "nombre_cientifico": "Zea mays L.",
+      "nombres_comunes": [
+        "coronta o panocha",
+        "elote o choclo",
+        "maiz",
+        "mazorca",
+        "olote",
+        "choclo",
+        "maíz"
+      ],
+      "categoria_botanica": "cereales",
+      "grupo": "energeticos",
+      "nutriente_estrella": "energia_kcal",
+      "forma": "desgranado",
+      "alimento_icbf": "Maiz comun, desgranado",
+      "codigo_icbf": 60,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 363,
+        "proteina_g": 8.7,
+        "hierro_mg": null,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "hierro_mg",
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_oryza_sativa",
+      "species_id": "oryza_sativa",
+      "crop_key": "arroz",
+      "nombre_comun": "Arroz Clearfield",
+      "nombre_cientifico": "Oryza sativa L. (tecnología Clearfield)",
+      "nombres_comunes": [
+        "arroz"
+      ],
+      "categoria_botanica": null,
+      "grupo": "energeticos",
+      "nutriente_estrella": "energia_kcal",
+      "forma": "blanco, crudo",
+      "alimento_icbf": "Arroz blanco, crudo",
+      "codigo_icbf": 11,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 349,
+        "proteina_g": 6.7,
+        "hierro_mg": 0.8,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_solanum_tuberosum",
+      "species_id": "solanum_tuberosum",
+      "crop_key": "papa",
+      "nombre_comun": "Papa parda pastusa",
+      "nombre_cientifico": "Solanum tuberosum L. subsp. andigenum var. parda pastusa",
+      "nombres_comunes": [
+        "chinpalu",
+        "papa",
+        "papa leona",
+        "papa pulos",
+        "papa uvilla",
+        "patata",
+        "potato",
+        "sacha papa"
+      ],
+      "categoria_botanica": null,
+      "grupo": "energeticos",
+      "nutriente_estrella": "energia_kcal",
+      "forma": "cruda, sin cascara",
+      "alimento_icbf": "Papa comun, sin cascara, cruda",
+      "codigo_icbf": 192,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 93,
+        "proteina_g": 1.9,
+        "hierro_mg": 1.1,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_vicia_faba",
+      "species_id": "vicia_faba",
+      "crop_key": "haba",
+      "nombre_comun": "Haba",
+      "nombre_cientifico": "Vicia faba L.",
+      "nombres_comunes": [
+        "haba"
+      ],
+      "categoria_botanica": "granos_legumbres",
+      "grupo": "proteicos",
+      "nutriente_estrella": "proteina_g",
+      "forma": "seca",
+      "alimento_icbf": "Haba seca",
+      "codigo_icbf": 954,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 308,
+        "proteina_g": 23.1,
+        "hierro_mg": 4.9,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_phaseolus_vulgaris",
+      "species_id": "phaseolus_vulgaris",
+      "crop_key": "frijol",
+      "nombre_comun": "Frijol arbustivo / voluble",
+      "nombre_cientifico": "Phaseolus vulgaris L.",
+      "nombres_comunes": [
+        "common bean",
+        "frijol",
+        "fréjol",
+        "habichuelas",
+        "mulu fintsumu buli",
+        "poroto",
+        "purutu",
+        "verdura"
+      ],
+      "categoria_botanica": "granos_legumbres",
+      "grupo": "proteicos",
+      "nutriente_estrella": "hierro_mg",
+      "forma": "grano seco",
+      "alimento_icbf": "Frijol rojo",
+      "codigo_icbf": 948,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 336,
+        "proteina_g": 20.4,
+        "hierro_mg": 7.1,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_chenopodium_quinoa",
+      "species_id": "chenopodium_quinoa",
+      "crop_key": "quinua",
+      "nombre_comun": "Quinua",
+      "nombre_cientifico": "Chenopodium quinoa Willd.",
+      "nombres_comunes": [
+        "quinua",
+        "quinua de castilla",
+        "quínoa",
+        "quínua"
+      ],
+      "categoria_botanica": "cereales",
+      "grupo": "proteicos",
+      "nutriente_estrella": "hierro_mg",
+      "forma": "grano",
+      "alimento_icbf": "Quinua",
+      "codigo_icbf": 104,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 356,
+        "proteina_g": 14.6,
+        "hierro_mg": 8.4,
+        "vitamina_a_er": null
+      },
+      "datos_faltantes": [
+        "vitamina_a_er"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_pisum_sativum",
+      "species_id": "pisum_sativum",
+      "crop_key": "arveja",
+      "nombre_comun": "Arveja",
+      "nombre_cientifico": "Pisum sativum L.",
+      "nombres_comunes": [],
+      "categoria_botanica": null,
+      "grupo": "proteicos",
+      "nutriente_estrella": "hierro_mg",
+      "forma": "verde, cruda",
+      "alimento_icbf": "Arveja verde, cruda",
+      "codigo_icbf": 139,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 120,
+        "proteina_g": 8.2,
+        "hierro_mg": 2.4,
+        "vitamina_a_er": 22
+      },
+      "datos_faltantes": []
+    },
+    {
+      "id": "aporte_nutricional_physalis_peruviana",
+      "species_id": "physalis_peruviana",
+      "crop_key": "uchuva",
+      "nombre_comun": "Uchuva",
+      "nombre_cientifico": "Physalis peruviana L.",
+      "nombres_comunes": [
+        "aguaymanto",
+        "alquequenje",
+        "capuchos",
+        "capulí",
+        "uchuva",
+        "uvilla"
+      ],
+      "categoria_botanica": "frutales_perennes",
+      "grupo": "protectores",
+      "nutriente_estrella": "vitamina_a_er",
+      "forma": "maduro",
+      "alimento_icbf": "Uchuva, maduro",
+      "codigo_icbf": 361,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 54,
+        "proteina_g": 1.5,
+        "hierro_mg": null,
+        "vitamina_a_er": 202
+      },
+      "datos_faltantes": [
+        "hierro_mg"
+      ]
+    },
+    {
+      "id": "aporte_nutricional_musa_paradisiaca",
+      "species_id": "musa_paradisiaca",
+      "crop_key": "platano",
+      "nombre_comun": "Plátano",
+      "nombre_cientifico": "Musa × paradisiaca L.",
+      "nombres_comunes": [
+        "banano"
+      ],
+      "categoria_botanica": "frutales_perennes",
+      "grupo": "energeticos",
+      "nutriente_estrella": "energia_kcal",
+      "forma": "harton, verde, crudo",
+      "alimento_icbf": "Platano harton, verde, crudo",
+      "codigo_icbf": 228,
+      "confianza": "alta",
+      "unidad": "por 100g porcion comestible",
+      "nutrientes": {
+        "energia_kcal": 158,
+        "proteina_g": 1.2,
+        "hierro_mg": 0.5,
+        "vitamina_a_er": 106
+      },
+      "datos_faltantes": []
+    }
+  ]
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -124,6 +124,10 @@ const SemillaScreen = lazy(() => import('./components/semilla/SemillaScreen'));
 // secado de grano a humedad segura) y transformar el excedente con su punto
 // crítico de inocuidad. Cifras grounded al DR nacional/internacional.
 const PoscosechaScreen = lazy(() => import('./components/PoscosechaScreen'));
+// Módulo "La comida que alimenta" (mundo Mercado y despensa): aporte
+// nutricional (ICBF TCAC 2015) por cultivo, exportado del grafo chagra_kg a
+// public/nutricion-humana.json (la PWA no consulta el grafo en vivo).
+const NutricionHumanaScreen = lazy(() => import('./components/NutricionHumanaScreen'));
 // LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home): un mundo por dentro —
 // las funciones existentes agrupadas por lugar. Re-rutea, no reimplementa.
 const MundoScreen = lazy(() => import('./components/MundoScreen'));
@@ -246,6 +250,9 @@ const HASH_VIEW_ROUTES = {
   poscosecha: 'poscosecha',
   despensa: 'poscosecha',
   'poscosecha-despensa': 'poscosecha',
+  nutricion: 'nutricion',
+  'nutricion-humana': 'nutricion',
+  'comida-que-alimenta': 'nutricion',
 };
 
 // Vistas que cuentan como "módulo" para telemetría de piloto.
@@ -255,7 +262,7 @@ const MODULE_VIEWS = new Set([
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'estiercol',
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'sanidad_sintoma', 'mantenimiento', 'new_task',
-  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'toxicologia', 'aprende', 'directorio', 'mercados',
+  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'nutricion', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
   'usage_stats', 'mercado', 'auditoria_inventario', 'mundo',
@@ -1339,6 +1346,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Poscosecha y Despensa">
               <PoscosechaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'nutricion':
+        // Módulo "La comida que alimenta" (mundo Mercado y despensa): aporte
+        // nutricional por cultivo (energía/proteína/hierro/vitamina A por 100 g)
+        // del ICBF (TCAC 2015). Datos exportados del grafo chagra_kg a
+        // public/nutricion-humana.json; null explícito donde el ICBF no reporta.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="La comida que alimenta">
+              <NutricionHumanaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/NutricionHumanaScreen.jsx
+++ b/src/components/NutricionHumanaScreen.jsx
@@ -1,0 +1,391 @@
+/* i18n (ADR-050): etiquetas user-facing en español Colombia pendientes de
+ * migrar a src/config/messages.js. Misma deuda preexistente que PoscosechaScreen
+ * y SaludSueloScreen; se desactiva la regla soft a nivel de archivo. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ChevronLeft, ChevronDown, Flame, Dumbbell, Droplet, Eye,
+  Info, BookOpen, ExternalLink, Utensils,
+} from 'lucide-react';
+
+/**
+ * NutricionHumanaScreen — mini-app "La comida que alimenta" (mundo Mercado y
+ * despensa). Muestra QUÉ TE DA COMER cada cultivo de la finca: su aporte
+ * nutricional por 100 g, de forma didáctica para campesino.
+ *
+ * FUENTE ÚNICA de las cifras: grafo de conocimiento `chagra_kg` (nodos
+ * AporteNutricional → Species vía TIENE_APORTE_NUTRICIONAL), exportado a
+ * `public/nutricion-humana.json` porque la PWA no consulta el grafo en vivo.
+ * Los números salen del ICBF — Tabla de Composición de Alimentos Colombianos
+ * (TCAC) 2015. CERO invención: donde el ICBF no reporta un valor, se dice
+ * explícito ("el ICBF no lo reporta"), nunca se rellena.
+ *
+ * Legibilidad al sol + WCAG: TODO el texto usa tokens theme-aware (slate/
+ * emerald/amber, remapeados a CSS-vars por tema en tailwind.config.js, y
+ * `text-white` que themes.css convierte en tinta oscura en los temas claros).
+ * Los colores vivos rose/violet/sky (NO remapeados) se usan SOLO como grafismo
+ * (relleno de barras, íconos -500 que pasan contraste sobre blanco, puntos),
+ * nunca como texto sobre superficie clara. Las barras crecen con una animación
+ * sutil que se apaga con prefers-reduced-motion.
+ */
+
+/* ── Identidad visual FIJA de los 4 nutrientes (mismo color/ícono en todas las
+ *    tarjetas para que se aprendan a ojo). `bar` = relleno (grafismo); `icon` =
+ *    -500 (pasa contraste sobre blanco Y se ve sobre oscuro); `borde` para el
+ *    chip de la estrella. El TEXTO de la etiqueta NO se pinta con estos colores
+ *    (usa slate, siempre legible). ─────────────────────────────────────────── */
+const NUTRIENTES = [
+  {
+    key: 'energia_kcal', Icon: Flame, etiqueta: 'Energía', unidad: 'kcal',
+    folk: 'Fuerza para trabajar el día entero.',
+    bar: 'bg-amber-400', icon: 'text-amber-500', borde: 'border-amber-500/60',
+  },
+  {
+    key: 'proteina_g', Icon: Dumbbell, etiqueta: 'Proteína', unidad: 'g',
+    folk: 'Forma músculo y sangre; hace crecer a los pelaos.',
+    bar: 'bg-emerald-400', icon: 'text-emerald-500', borde: 'border-emerald-500/60',
+  },
+  {
+    key: 'hierro_mg', Icon: Droplet, etiqueta: 'Hierro', unidad: 'mg',
+    folk: 'Hace sangre buena; espanta el cansancio y la anemia.',
+    bar: 'bg-rose-400', icon: 'text-rose-500', borde: 'border-rose-500/60',
+  },
+  {
+    key: 'vitamina_a_er', Icon: Eye, etiqueta: 'Vitamina A', unidad: 'ER',
+    folk: 'Cuida los ojos, la piel y las defensas.',
+    bar: 'bg-violet-400', icon: 'text-violet-500', borde: 'border-violet-500/60',
+  },
+];
+const NUTRIENTE_BY_KEY = Object.fromEntries(NUTRIENTES.map((n) => [n.key, n]));
+
+/* La estrella de cada alimento → texto del gancho ("qué te da comer esto"). */
+const ESTRELLA_LABEL = {
+  energia_kcal: 'Da mucha energía',
+  proteina_g: 'Rico en proteína',
+  hierro_mg: 'Rico en hierro',
+  vitamina_a_er: 'Cargado de vitamina A',
+};
+
+/* Estilo por grupo pedagógico. El TÍTULO va en slate (siempre legible); el
+ * color del grupo se comunica con el punto, el emoji, el borde y un velo muy
+ * sutil. Clases LITERALES (Tailwind JIT no ve strings construidos). */
+const GRUPO_ESTILO = {
+  amber: { ring: 'border-amber-500/40', dot: 'bg-amber-400', soft: 'bg-amber-500/10' },
+  emerald: { ring: 'border-emerald-500/40', dot: 'bg-emerald-400', soft: 'bg-emerald-500/10' },
+  sky: { ring: 'border-sky-500/40', dot: 'bg-sky-400', soft: 'bg-sky-500/10' },
+};
+
+function formatValor(v, unidad) {
+  if (v == null) return null;
+  const n = Number.isInteger(v) ? v : Math.round(v * 10) / 10;
+  return `${n} ${unidad}`;
+}
+
+/* ── Barra comparativa de un nutriente. El ancho es RELATIVO al máximo del
+ *    dataset (comparación entre los cultivos de la despensa, etiquetada como
+ *    tal). Sin dato → barra vacía punteada + "el ICBF no lo reporta". ──────── */
+function BarraNutriente({ nutri, valor, maximo, animar }) {
+  const { Icon, etiqueta, unidad, bar, icon } = nutri;
+  const sinDato = valor == null;
+  const pct = sinDato || !maximo ? 0 : Math.max(4, Math.round((valor / maximo) * 100));
+  return (
+    <div className="flex items-center gap-2">
+      <span className="flex items-center gap-1 w-[92px] shrink-0 text-[12px] font-semibold text-slate-100">
+        <Icon size={14} className={icon} aria-hidden="true" />
+        {etiqueta}
+      </span>
+      <div
+        className="relative flex-1 h-5 rounded-full bg-slate-800 overflow-hidden border border-slate-700"
+        role="img"
+        aria-label={sinDato ? `${etiqueta}: el ICBF no lo reporta` : `${etiqueta}: ${formatValor(valor, unidad)}`}
+      >
+        {sinDato ? (
+          <div className="absolute inset-0 flex items-center pl-2 text-[11px] italic text-slate-400 border border-dashed border-slate-500 rounded-full">
+            el ICBF no lo reporta
+          </div>
+        ) : (
+          <div
+            className={`${animar ? 'nutri-bar ' : ''}h-full rounded-full ${bar}`}
+            style={{ width: `${pct}%` }}
+          />
+        )}
+      </div>
+      <span className="w-[62px] shrink-0 text-right text-[12px] font-bold text-slate-100 tabular-nums">
+        {sinDato ? '—' : formatValor(valor, unidad)}
+      </span>
+    </div>
+  );
+}
+
+/* ── Tarjeta de un cultivo. Tap → despliega detalle (código ICBF, forma,
+ *    datos faltantes, confianza). ──────────────────────────────────────────── */
+function CultivoCard({ item, maximos, animar }) {
+  const [abierto, setAbierto] = useState(false);
+  const estrella = item.nutriente_estrella;
+  const estrellaNutri = estrella ? NUTRIENTE_BY_KEY[estrella] : null;
+  return (
+    <div className="rounded-2xl border border-slate-700 bg-slate-900 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setAbierto((v) => !v)}
+        aria-expanded={abierto}
+        className="w-full text-left px-4 pt-3 pb-2 flex items-start gap-3"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-[16px] font-extrabold text-white leading-tight">{item.nombre_comun}</h3>
+            {estrellaNutri && (
+              <span className={`inline-flex items-center gap-1 text-[11px] font-bold px-2 py-0.5 rounded-full border bg-slate-800 text-slate-100 ${estrellaNutri.borde}`}>
+                <estrellaNutri.Icon size={12} className={estrellaNutri.icon} aria-hidden="true" />
+                {ESTRELLA_LABEL[estrella]}
+              </span>
+            )}
+          </div>
+          {item.nombre_cientifico && (
+            <p className="text-[12px] italic text-slate-400 leading-tight">{item.nombre_cientifico}</p>
+          )}
+          {item.forma && (
+            <p className="text-[11px] text-slate-500 leading-tight mt-0.5">Medido: {item.forma}</p>
+          )}
+        </div>
+        <ChevronDown
+          size={18}
+          className={`shrink-0 mt-1 text-slate-400 transition-transform ${abierto ? 'rotate-180' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+
+      {/* Gancho folk de la estrella */}
+      {estrellaNutri && (
+        <p className="px-4 pb-2 text-[13px] text-slate-200 leading-snug">
+          <span className="font-semibold text-slate-100">Qué te da:</span> {estrellaNutri.folk}
+        </p>
+      )}
+
+      {/* Barras comparativas de los 4 nutrientes */}
+      <div className="px-4 pb-3 flex flex-col gap-1.5">
+        {NUTRIENTES.map((nutri) => (
+          <BarraNutriente
+            key={nutri.key}
+            nutri={nutri}
+            valor={item.nutrientes[nutri.key]}
+            maximo={maximos[nutri.key]}
+            animar={animar}
+          />
+        ))}
+      </div>
+
+      {/* Detalle desplegable */}
+      {abierto && (
+        <div className="px-4 pb-4 pt-1 border-t border-slate-800 bg-slate-950/40 text-[12px] text-slate-300 flex flex-col gap-1.5">
+          {item.alimento_icbf && (
+            <p><span className="text-slate-400">Alimento (ICBF):</span> {item.alimento_icbf}
+              {item.codigo_icbf != null && <span className="text-slate-500"> · código {item.codigo_icbf}</span>}
+            </p>
+          )}
+          {Array.isArray(item.nombres_comunes) && item.nombres_comunes.length > 0 && (
+            <p><span className="text-slate-400">También le dicen:</span> {item.nombres_comunes.join(', ')}</p>
+          )}
+          {item.datos_faltantes.length > 0 && (
+            <p className="text-slate-200">
+              <Info size={12} className="inline mb-0.5 mr-1 text-amber-500" aria-hidden="true" />
+              El ICBF (TCAC 2015) no reporta {item.datos_faltantes.map((k) => (NUTRIENTE_BY_KEY[k]?.etiqueta || k)).join(' ni ').toLowerCase()} para este alimento. No inventamos el dato.
+            </p>
+          )}
+          {item.confianza && (
+            <p className="text-slate-500">Confianza del dato: {item.confianza}. Valores por 100 g de porción comestible.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Ilustración SVG propia: un plato servido con el sol arriba. ─────────────── */
+function PlatoIlustracion() {
+  return (
+    <svg
+      viewBox="0 0 240 140"
+      role="img"
+      aria-label="Ilustración de un plato servido de comida de la finca bajo el sol"
+      className="w-full h-auto"
+    >
+      <rect x="0" y="0" width="240" height="140" rx="6" fill="rgb(var(--t-accent-rgb) / 0.08)" />
+      {/* Sol */}
+      <circle cx="202" cy="28" r="13" fill="#f4b83c" className="nh-sun" />
+      <g stroke="#f4b83c" strokeWidth="2" strokeLinecap="round" className="nh-sun">
+        <path d="M202 6 V0" /><path d="M224 28 H231" /><path d="M218 12 L222 8" /><path d="M186 12 L182 8" />
+      </g>
+      {/* Mantel / mesa */}
+      <rect x="14" y="112" width="212" height="8" rx="4" fill="#7a5a3c" />
+      {/* Plato */}
+      <ellipse cx="112" cy="104" rx="78" ry="16" fill="#5a4630" />
+      <ellipse cx="112" cy="98" rx="74" ry="26" fill="#e9e2d2" />
+      <ellipse cx="112" cy="96" rx="58" ry="19" fill="#d8cfb9" />
+      {/* Comida — colores de los grupos */}
+      <circle cx="88" cy="94" r="12" fill="#f0a93c" />{/* energético (ahuyama) */}
+      <circle cx="112" cy="90" r="11" fill="#3f9d5a" />{/* proteico (verde) */}
+      <circle cx="134" cy="95" r="10" fill="#e0603c" />{/* protector (tomate) */}
+      <path d="M100 84 q6 -14 18 -6" stroke="#3f8f4e" strokeWidth="3" fill="none" strokeLinecap="round" />
+      {/* Vapor */}
+      <g stroke="#cbb89a" strokeWidth="2.5" strokeLinecap="round" fill="none" className="nh-steam">
+        <path d="M96 74 q-5 -8 0 -16" /><path d="M120 72 q5 -8 0 -16" />
+      </g>
+    </svg>
+  );
+}
+
+export default function NutricionHumanaScreen({ onBack }) {
+  const [data, setData] = useState(null);
+  const [estado, setEstado] = useState('cargando'); // cargando | listo | error
+  const [filtro, setFiltro] = useState('todos');
+
+  // prefers-reduced-motion: sin animación de crecimiento de barras.
+  const animar = useMemo(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return true;
+    return !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }, []);
+
+  useEffect(() => {
+    let vivo = true;
+    fetch('/nutricion-humana.json')
+      .then((r) => { if (!r.ok) throw new Error('http ' + r.status); return r.json(); })
+      .then((j) => { if (vivo) { setData(j); setEstado('listo'); } })
+      .catch(() => { if (vivo) setEstado('error'); });
+    return () => { vivo = false; };
+  }, []);
+
+  const gruposVisibles = useMemo(() => {
+    if (!data) return [];
+    return data.grupos
+      .filter((g) => filtro === 'todos' || g.id === filtro)
+      .map((g) => ({ ...g, items: data.items.filter((it) => it.grupo === g.id) }))
+      .filter((g) => g.items.length > 0);
+  }, [data, filtro]);
+
+  return (
+    <div className="min-h-[100dvh] text-white">
+      <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Volver"
+          className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
+        >
+          <ChevronLeft size={20} />
+        </button>
+        <div className="min-w-0">
+          <h1 className="text-lg font-bold leading-tight text-white flex items-center gap-1.5">
+            <Utensils size={18} aria-hidden="true" /> La comida que alimenta
+          </h1>
+          <p className="text-xs text-slate-400 leading-tight">Qué te da comer cada cultivo de tu finca</p>
+        </div>
+      </header>
+
+      <div className="px-4 pb-12">
+        {estado === 'cargando' && (
+          <p className="mt-8 text-center text-sm text-slate-400">Cargando el aporte de tus cultivos…</p>
+        )}
+        {estado === 'error' && (
+          <p className="mt-8 text-center text-sm text-slate-100">
+            No se pudo cargar la información de nutrición. Intente de nuevo con conexión.
+          </p>
+        )}
+
+        {estado === 'listo' && data && (
+          <div className="flex flex-col gap-4">
+            {/* Gancho + fuente */}
+            <section className="rounded-2xl border border-slate-700 bg-slate-900 overflow-hidden">
+              <div className="p-4 pb-2"><PlatoIlustracion /></div>
+              <div className="px-4 pb-4">
+                <p className="text-[13px] uppercase tracking-wide font-bold text-slate-400">Cada bocado te da algo</p>
+                <p className="mt-1 text-[15px] text-slate-100 leading-snug">
+                  Lo que usted siembra no solo llena: <span className="font-bold">alimenta</span>. Aquí ve, por cada
+                  100&nbsp;gramos, la <span className="font-semibold">fuerza</span> (energía), el
+                  <span className="font-semibold"> cuerpo</span> (proteína), la <span className="font-semibold">sangre</span> (hierro)
+                  y las <span className="font-semibold">defensas</span> (vitamina A) que le regala cada cultivo.
+                </p>
+                <p className="mt-2 inline-flex items-start gap-1.5 text-[11px] text-slate-400 leading-snug">
+                  <BookOpen size={13} className="mt-0.5 shrink-0" aria-hidden="true" />
+                  <span>
+                    Cifras oficiales del <span className="font-semibold text-slate-200">{data.meta.fuente}</span>.
+                    Las barras comparan entre los cultivos de esta despensa. Donde el ICBF no reporta un valor, lo decimos claro.
+                  </span>
+                </p>
+              </div>
+            </section>
+
+            {/* Filtro por grupo */}
+            <div className="flex flex-wrap gap-2" role="group" aria-label="Filtrar por grupo de alimento">
+              <FiltroChip activo={filtro === 'todos'} onClick={() => setFiltro('todos')} label="Todos" />
+              {data.grupos.map((g) => (
+                <FiltroChip
+                  key={g.id}
+                  activo={filtro === g.id}
+                  onClick={() => setFiltro(g.id)}
+                  label={`${g.emoji} ${g.titulo}`}
+                />
+              ))}
+            </div>
+
+            {/* Grupos + cultivos */}
+            {gruposVisibles.map((g) => {
+              const est = GRUPO_ESTILO[g.color] || GRUPO_ESTILO.sky;
+              return (
+                <section key={g.id} className={`rounded-2xl border ${est.ring} ${est.soft} overflow-hidden`}>
+                  <div className="px-4 pt-3 pb-2">
+                    <h2 className="text-[17px] font-extrabold flex items-center gap-2 text-slate-100">
+                      <span aria-hidden="true">{g.emoji}</span> {g.titulo}
+                      <span className={`w-2.5 h-2.5 rounded-full ${est.dot}`} aria-hidden="true" />
+                    </h2>
+                    <p className="text-[13px] text-slate-100 font-semibold leading-snug">{g.folk}</p>
+                    <p className="text-[12px] text-slate-400 leading-snug">{g.cientifico}</p>
+                  </div>
+                  <div className="px-3 pb-3 flex flex-col gap-2.5">
+                    {g.items.map((it) => (
+                      <CultivoCard key={it.id} item={it} maximos={data.meta.maximos} animar={animar} />
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+
+            {/* Fuente citada — visible y con enlace */}
+            <footer className="rounded-2xl border border-slate-700 bg-slate-900 px-4 py-3 text-[12px] text-slate-300">
+              <p className="font-bold text-slate-100 mb-1">De dónde salen estos números</p>
+              <p className="leading-snug">
+                {data.meta.fuente}. Valores {data.meta.unidad}. {data.meta.total_cultivos} cultivos de la finca.
+              </p>
+              <p className="mt-1 leading-snug text-slate-400">{data.meta.nota_datos_faltantes}</p>
+              <a
+                href={data.meta.fuente_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex items-center gap-1 text-emerald-400 font-semibold underline"
+              >
+                <ExternalLink size={13} aria-hidden="true" /> Ver la tabla del ICBF
+              </a>
+            </footer>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FiltroChip({ activo, onClick, label }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={activo}
+      className={`px-3 py-1.5 rounded-full text-[13px] font-semibold border transition-colors ${
+        activo
+          ? 'bg-slate-100 text-slate-900 border-slate-100'
+          : 'bg-slate-800 text-slate-200 border-slate-700 hover:bg-slate-700'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/NutricionHumanaScreen.jsx
+++ b/src/components/NutricionHumanaScreen.jsx
@@ -235,6 +235,13 @@ function PlatoIlustracion() {
   );
 }
 
+/**
+ * @param {Object} props
+ * @param {() => void} props.onBack
+ * @param {(view: string, data?: any) => void} [props.onNavigate] - aceptado por
+ *   consistencia con el resto de mini-apps (App.jsx siempre lo pasa); esta
+ *   pantalla todavía no lo usa (no hay CTA de navegación cruzada aún).
+ */
 export default function NutricionHumanaScreen({ onBack }) {
   const [data, setData] = useState(null);
   const [estado, setEstado] = useState('cargando'); // cargando | listo | error

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -141,6 +141,7 @@ export const MUNDOS_FINCA = [
         entradas: [
             { view: 'mercado', label: 'Vender y comprar', desc: 'Directo entre fincas, sin intermediarios', emoji: '🤝' },
             { view: 'poscosecha', label: 'Poscosecha y despensa', desc: 'Cosechar en punto, guardar sin que se dañe y transformar', emoji: '🥕' },
+            { view: 'nutricion', label: 'La comida que alimenta', desc: 'Qué te da comer cada cultivo: fuerza, cuerpo, sangre y defensas (ICBF)', emoji: '🍽️' },
             { view: 'bodega', label: 'Bodega de insumos', desc: 'Lo que tiene guardado y lo que se acaba', emoji: '🏚️' },
             { view: 'informes', label: 'Sacar reportes', desc: 'Para imprimir o llevar al banco o la cooperativa', emoji: '🖨️' },
             { view: 'fermentos', label: 'Fermentos de la cocina', desc: 'Masato, chicha y kéfir con sus vetos de seguridad', emoji: '🫙' },

--- a/src/index.css
+++ b/src/index.css
@@ -638,6 +638,39 @@
 }
 
 /* ===========================================================================
+ * LA COMIDA QUE ALIMENTA — micro-animaciones (NutricionHumanaScreen).
+ * El sol respira, el vapor sube y las barras comparativas crecen desde 0 al
+ * montar. Todo sutil; TODO se apaga con prefers-reduced-motion (las barras
+ * quedan directamente a su ancho final, legibles).
+ * =========================================================================== */
+.nh-sun {
+  transform-origin: 202px 28px;
+  animation: pc-breathe 4s ease-in-out infinite;
+}
+.nh-steam path {
+  animation: nh-steam-rise 3.2s ease-in-out infinite;
+}
+.nh-steam path:nth-child(2) { animation-delay: 0.9s; }
+.nutri-bar {
+  transform-origin: left center;
+  animation: nutri-grow 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes nh-steam-rise {
+  0% { opacity: 0.15; transform: translateY(4px); }
+  50% { opacity: 0.75; }
+  100% { opacity: 0; transform: translateY(-6px); }
+}
+@keyframes nutri-grow {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .nh-sun { animation: none; }
+  .nh-steam path { animation: none; opacity: 0.5; }
+  .nutri-bar { animation: none; transform: none; }
+}
+
+/* ===========================================================================
  * LOADING SKELETON DARK — fondo oscuro unificado para estados de carga.
  *
  * Tarea 81: .loading-skeleton-dark evita flash blanco en dark theme


### PR DESCRIPTION
## Qué es

Nueva mini-app **"La comida que alimenta"** en el mundo **Mercado y despensa**: muestra QUÉ TE DA COMER cada cultivo de la finca — **energía / proteína / hierro / vitamina A por 100 g** — de forma didáctica para campesino (folk + científico), agrupado por **grupos de alimentos** (energéticos / proteicos / protectores), con barras comparativas y la **fuente ICBF visible**.

## De dónde salen los datos (grafo → estático)

La PWA **no consulta el grafo AGE en vivo**, así que exporté el aporte nutricional del grafo `chagra_kg` a un JSON estático del frontend:

- **27 nodos `AporteNutricional`** conectados a `Species` vía `TIENE_APORTE_NUTRICIONAL` → `public/nutricion-humana.json`.
- Cifras del **ICBF — Tabla de Composición de Alimentos Colombianos (TCAC) 2015** (fuente + URL en cada item y en el pie).
- **CERO invención**: donde el ICBF no reporta un valor, va `null` y se lista en `datos_faltantes`; la UI lo dice explícito ("el ICBF no lo reporta"). **12 de 27** cultivos tienen faltantes declarados (p. ej. maíz y aguacate sin hierro ni vitamina A).
- Clasificación pedagógica (energéticos/proteicos/protectores) y `nutriente_estrella` derivados de las cifras reales, no inventados.

## Cableado (no queda huérfana)

- `NutricionHumanaScreen.jsx` + `case 'nutricion'` en `App.jsx` (lazy) + alias de hash `#nutricion` / `#comida-que-alimenta`.
- Entrada en el mundo **Mercado y despensa** (`mundosFinca.js`) → el test de reachability sigue verde.

## Legibilidad al sol / temas / accesibilidad

- Todo el texto usa tokens **theme-aware** (slate/emerald/amber remapeados por CSS-var + `text-white` que themes.css convierte en tinta oscura en temas claros). Los colores vivos rose/violet/sky se usan **solo como grafismo** (relleno de barras, íconos, puntos) — nunca como texto sobre superficie clara → sin fallos de contraste WCAG en los temas claros.
- Barras con animación sutil que se **apaga con `prefers-reduced-motion`**.
- Superficies opacas.

## Verificación

- `npm run build` verde.
- Reachability test (`MundosDeMiFinca.reachability.test.jsx`) **8/8**.
- ESLint del componente limpio.
- Capturas headless (Playwright) en **biopunk2 / nature / minimalista / verde-vivo** + detalle expandido — legible en oscuro y claro.

## No toca
AgentScreen / sidecarClient / mundo-suelo (otros agentes).

> Draft: pendiente verificación visual del operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)