### PR TITLE
feat(escucha): widget "Chagra está escuchando" — manos libres (tap hoy, wake-word mañana)

### DIFF
--- a/scripts/escucha-shots.mjs
+++ b/scripts/escucha-shots.mjs
@@ -138,9 +138,39 @@ async function main() {
       () => document.querySelector('#root')?.children.length > 0,
       { timeout: 180_000 },
     );
+    // La app solo crea ChagraDB tras autenticar → sembrar el token (DB
+    // 'Chagra'/syncQueue, mismo contrato de seedAuthToken) y recargar para
+    // que el boot AUTENTICADO cree los object stores antes del seed.
+    await page.evaluate(async () => {
+      const db = await new Promise((resolve, reject) => {
+        const req = indexedDB.open('Chagra');
+        req.onupgradeneeded = () => {
+          if (!req.result.objectStoreNames.contains('syncQueue')) {
+            req.result.createObjectStore('syncQueue');
+          }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      });
+      await new Promise((resolve, reject) => {
+        const tx = db.transaction('syncQueue', 'readwrite');
+        const store = tx.objectStore('syncQueue');
+        store.put('visual-token', 'farmos_access_token');
+        store.put('visual-refresh', 'farmos_refresh_token');
+        store.put(Date.now() + 3600_000, 'farmos_token_expiry');
+        tx.oncomplete = resolve;
+        tx.onerror = () => reject(tx.error);
+      });
+      db.close();
+    });
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(
+      () => document.querySelector('#root')?.children.length > 0,
+      { timeout: 180_000 },
+    );
     await page.waitForFunction(
       async () => (await indexedDB.databases()).some((d) => d.name === 'ChagraDB'),
-      { timeout: 60_000 },
+      { timeout: 90_000 },
     );
     let seeded = false;
     for (let intento = 1; intento <= 3 && !seeded; intento++) {

--- a/scripts/escucha-shots.mjs
+++ b/scripts/escucha-shots.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * escucha-shots.mjs — Capturas headless del widget "Chagra está escuchando".
+ *
+ * Reusa la infra de chagra-shot (visualTestUtils: determinismo + login + seed)
+ * y el patrón NixOS (chromium del nix-store). El micrófono es el FAKE de
+ * Chromium (--use-fake-device-for-media-capture): produce un tono real, así
+ * que los anillos/brotes del iris se mueven con amplitud DE VERDAD.
+ *
+ * Whisper se stubbea con context.route (NO page.route: el SW lo sombrea,
+ * gotcha documentado) para poder capturar la fase "rumbo" sin backend.
+ *
+ * Uso: node scripts/escucha-shots.mjs [--outdir <dir>]
+ */
+import { existsSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { execSync, spawn } from 'node:child_process';
+import { chromium } from 'playwright';
+import { installDeterminism, loginAndSeed } from '../tests/visual/visualTestUtils.js';
+
+const PORT = process.env.ESCUCHA_SHOT_PORT || '5187';
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+const VIEWPORT = { width: 390, height: 844 };
+
+const KNOWN_CHROMIUM_PATHS = [
+  '/nix/store/r7ifk1v95jfl02775kgbrd61dyr1rfsx-chromium-148.0.7778.178/bin/chromium',
+  '/nix/store/9fjg59mab9j8c5r61dx2k5gcbd2f5mpm-chromium-148.0.7778.96/bin/chromium',
+];
+
+function resolveChromiumPath() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) return process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  try {
+    const which = execSync('which chromium 2>/dev/null', { encoding: 'utf8' }).trim();
+    if (which) return which;
+  } catch { /* sigue */ }
+  for (const c of KNOWN_CHROMIUM_PATHS) if (existsSync(c)) return c;
+  try {
+    const nix = execSync("nix-shell -p chromium --run 'which chromium' 2>/dev/null | tail -1", {
+      encoding: 'utf8', timeout: 120_000,
+    }).trim();
+    if (nix.startsWith('/nix/store')) return nix;
+  } catch { /* bundled */ }
+  return undefined;
+}
+
+async function waitForServer(url) {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      if (r.ok || r.status >= 400) return true;
+    } catch { /* retry */ }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Timeout esperando ${url}`);
+}
+
+async function ensureServer() {
+  try {
+    const r = await fetch(BASE_URL, { signal: AbortSignal.timeout(1500) });
+    if (r.ok || r.status >= 400) return null;
+  } catch { /* arrancar */ }
+  const child = spawn('npm', ['run', 'dev', '--', '--host', '127.0.0.1', '--port', PORT, '--strictPort'], {
+    stdio: 'ignore',
+    env: { ...process.env, VITE_FARMOS_URL: '', VITE_FARMOS_CLIENT_ID: 'farm', VITE_OPERATOR_USERNAME: 'op-test' },
+  });
+  await waitForServer(BASE_URL);
+  return child;
+}
+
+const OUTDIR = (() => {
+  const i = process.argv.indexOf('--outdir');
+  return resolve(i > -1 ? process.argv[i + 1] : 'shots-escucha');
+})();
+
+async function abrirEscucha(page, fuente) {
+  await page.evaluate((f) => {
+    window.dispatchEvent(new CustomEvent('chagra:escucha', { detail: { fuente: f, ts: Date.now() } }));
+  }, fuente);
+  await page.waitForSelector('[data-testid="escucha-overlay"][data-fase="oyendo"]', { timeout: 15_000 });
+  // Deja correr el tono fake ~1.2s para que los brotes tengan historia real.
+  await page.waitForTimeout(1200);
+}
+
+async function main() {
+  mkdirSync(OUTDIR, { recursive: true });
+  const server = await ensureServer();
+  const chromiumPath = resolveChromiumPath();
+  const browser = await chromium.launch({
+    ...(chromiumPath ? { executablePath: chromiumPath } : {}),
+    args: [
+      '--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+      '--use-fake-ui-for-media-capture',
+      '--use-fake-device-for-media-capture',
+    ],
+  });
+
+  const temas = [
+    { id: 'biopunk', dataTheme: null },
+    { id: 'nature', dataTheme: 'nature' },
+    { id: 'minimalista', dataTheme: 'minimalista' },
+  ];
+
+  const hechas = [];
+  for (const tema of temas) {
+    const context = await browser.newContext({
+      baseURL: BASE_URL,
+      viewport: VIEWPORT,
+      isMobile: true,
+      hasTouch: true,
+      deviceScaleFactor: 2,
+      locale: 'es-CO',
+      permissions: ['microphone'],
+    });
+    // Whisper stub (context.route — el SW sombrea page.route).
+    await context.route('**/api/whisper/asr*', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ text: 'Lléveme al mercado' }),
+    }));
+
+    const page = await context.newPage();
+    page.setDefaultTimeout(60_000);
+    await installDeterminism(context, page, { profileKey: 'operador' });
+    if (tema.dataTheme) {
+      await page.addInitScript((t) => {
+        localStorage.setItem('chagra:theme', t);
+        document.documentElement?.setAttribute('data-theme', t);
+      }, tema.dataTheme);
+    }
+    await loginAndSeed(page, 'with-data');
+    await page.waitForTimeout(1500);
+
+    // 1) FAB visible en el home
+    const fabShot = `${OUTDIR}/escucha-01-fab-${tema.id}.png`;
+    await page.waitForSelector('[data-testid="escucha-fab"]', { timeout: 20_000 });
+    await page.screenshot({ path: fabShot });
+    hechas.push(fabShot);
+
+    // 2) Widget escuchando (tap)
+    await abrirEscucha(page, 'tap');
+    const oyendoShot = `${OUTDIR}/escucha-02-escuchando-${tema.id}.png`;
+    await page.screenshot({ path: oyendoShot });
+    hechas.push(oyendoShot);
+
+    if (tema.id === 'biopunk') {
+      // 3) Variante wake-word (encabezado «hola Chagra») — solo tema base
+      await page.click('[data-testid="escucha-cancelar"]');
+      await abrirEscucha(page, 'wakeword');
+      const wwShot = `${OUTDIR}/escucha-03-wakeword-biopunk.png`;
+      await page.screenshot({ path: wwShot });
+      hechas.push(wwShot);
+
+      // 4) Fase rumbo: "Lléveme al mercado" → "Abriendo Mercado…"
+      await page.click('[data-testid="escucha-listo"]');
+      await page.waitForSelector('[data-testid="escucha-rumbo"]', { timeout: 20_000 });
+      const rumboShot = `${OUTDIR}/escucha-04-rumbo-biopunk.png`;
+      await page.screenshot({ path: rumboShot });
+      hechas.push(rumboShot);
+    }
+
+    await context.close();
+  }
+
+  await browser.close();
+  if (server) server.kill('SIGTERM');
+  console.log('Capturas listas:');
+  for (const h of hechas) console.log('  ' + h);
+}
+
+main().catch((err) => {
+  console.error(err?.message || err);
+  process.exit(1);
+});

--- a/scripts/escucha-shots.mjs
+++ b/scripts/escucha-shots.mjs
@@ -60,7 +60,8 @@ async function ensureServer() {
     const r = await fetch(BASE_URL, { signal: AbortSignal.timeout(1500) });
     if (r.ok || r.status >= 400) return null;
   } catch { /* arrancar */ }
-  const child = spawn('npm', ['run', 'dev', '--', '--host', '127.0.0.1', '--port', PORT, '--strictPort'], {
+  const mode = process.env.ESCUCHA_SHOT_SERVER || 'dev';
+  const child = spawn('npm', ['run', mode, '--', '--host', '127.0.0.1', '--port', PORT, '--strictPort'], {
     stdio: 'ignore',
     env: { ...process.env, VITE_FARMOS_URL: '', VITE_FARMOS_CLIENT_ID: 'farm', VITE_OPERATOR_USERNAME: 'op-test' },
   });
@@ -128,7 +129,30 @@ async function main() {
         document.documentElement?.setAttribute('data-theme', t);
       }, tema.dataTheme);
     }
-    await loginAndSeed(page, 'with-data');
+    // GOTCHA (dev server frío / caja cargada): loginAndSeed seedea el IDB con
+    // networkidle-catch, y si el app aún NO montó, ChagraDB no existe → el
+    // open del seed la crea VACÍA en v26 y poisonea el contexto ("object
+    // stores was not found"). Esperar boot real + creación de la DB primero.
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 120_000 });
+    await page.waitForFunction(
+      () => document.querySelector('#root')?.children.length > 0,
+      { timeout: 180_000 },
+    );
+    await page.waitForFunction(
+      async () => (await indexedDB.databases()).some((d) => d.name === 'ChagraDB'),
+      { timeout: 60_000 },
+    );
+    let seeded = false;
+    for (let intento = 1; intento <= 3 && !seeded; intento++) {
+      try {
+        await loginAndSeed(page, 'with-data');
+        seeded = true;
+      } catch (err) {
+        console.warn(`[escucha-shots] seed intento ${intento} falló: ${String(err.message).slice(0, 120)}`);
+        await page.waitForTimeout(4000);
+      }
+    }
+    if (!seeded) throw new Error('No se pudo seedear tras 3 intentos');
     await page.waitForTimeout(1500);
 
     // 1) FAB visible en el home

--- a/scripts/escucha-shots.mjs
+++ b/scripts/escucha-shots.mjs
@@ -113,16 +113,32 @@ async function main() {
       locale: 'es-CO',
       permissions: ['microphone'],
     });
-    // Whisper stub (context.route — el SW sombrea page.route).
+    const page = await context.newPage();
+    page.setDefaultTimeout(60_000);
+    await installDeterminism(context, page, { profileKey: 'operador' });
+
+    // GOTCHA: installDeterminism hardcodea el origen del app como :5173 —
+    // en cualquier otro puerto su catch-all intercepta hasta los MÓDULOS JS
+    // y responde {data:[]} → el app jamás monta. Este wrapper se registra
+    // DESPUÉS (Playwright evalúa rutas LIFO): deja PASAR los recursos del
+    // app en nuestro puerto y delega el resto (APIs) con fallback().
+    await context.route('**/*', async (route) => {
+      const url = new URL(route.request().url());
+      const esRecursoApp = url.origin === BASE_URL
+        && !url.pathname.includes('/api/')
+        && !url.pathname.includes('/jsonapi/')
+        && !url.pathname.includes('/oauth/');
+      if (esRecursoApp) return route.continue();
+      return route.fallback();
+    });
+
+    // Whisper stub (después del wrapper → precedencia; y context.route, NO
+    // page.route: el SW lo sombrea).
     await context.route('**/api/whisper/asr*', (route) => route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({ text: 'Lléveme al mercado' }),
     }));
-
-    const page = await context.newPage();
-    page.setDefaultTimeout(60_000);
-    await installDeterminism(context, page, { profileKey: 'operador' });
     if (tema.dataTheme) {
       await page.addInitScript((t) => {
         localStorage.setItem('chagra:theme', t);
@@ -188,9 +204,14 @@ async function main() {
     if (!seeded) throw new Error('No se pudo seedear tras 3 intentos');
     await page.waitForTimeout(1500);
 
-    // 1) FAB visible en el home
+    // 1) FAB visible en una pantalla real (suelo). En el home NO hay FAB
+    // (política AgentFab: el compositor del hero ya trae mic + botón Ⓐ).
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'suelo' } }));
+    });
     const fabShot = `${OUTDIR}/escucha-01-fab-${tema.id}.png`;
     await page.waitForSelector('[data-testid="escucha-fab"]', { timeout: 20_000 });
+    await page.waitForTimeout(4500); // deja cargar el chunk lazy de la vista
     await page.screenshot({ path: fabShot });
     hechas.push(fabShot);
 

--- a/scripts/escucha-shots.mjs
+++ b/scripts/escucha-shots.mjs
@@ -136,6 +136,7 @@ async function main() {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 120_000 });
     await page.waitForFunction(
       () => document.querySelector('#root')?.children.length > 0,
+      undefined,
       { timeout: 180_000 },
     );
     // La app solo crea ChagraDB tras autenticar → sembrar el token (DB
@@ -166,10 +167,12 @@ async function main() {
     await page.reload({ waitUntil: 'domcontentloaded' });
     await page.waitForFunction(
       () => document.querySelector('#root')?.children.length > 0,
+      undefined,
       { timeout: 180_000 },
     );
     await page.waitForFunction(
       async () => (await indexedDB.databases()).some((d) => d.name === 'ChagraDB'),
+      undefined,
       { timeout: 90_000 },
     );
     let seeded = false;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1708,8 +1708,11 @@ export default function App() {
           pregunta al agente punta a punta por voz). El FAB (abajo-izquierda)
           es el trigger de HOY; el wake-word "hola Chagra" de MAÑANA llama el
           mismo activarEscucha() sin tocar nada de esto. Oculto donde ya hay
-          micrófono propio (agente, voz) y en login/onboarding. */}
-      {!['loading', 'login', 'oauth-callback', 'onboarding-perfil', 'ubicacion-detectada', 'agente', 'voz', 'voz_planta', 'registro_voz'].includes(currentView) && <EscuchaFab />}
+          micrófono propio (agente, voz, y el home: el compositor del hero
+          trae mic y el FAB taparía el botón Ⓐ de la mano — misma política
+          que AgentFab) y en login/onboarding. El overlay SÍ vive en el home:
+          el wake-word podrá abrirlo allí. */}
+      {!['loading', 'login', 'oauth-callback', 'onboarding-perfil', 'ubicacion-detectada', 'dashboard', 'agente', 'voz', 'voz_planta', 'registro_voz'].includes(currentView) && <EscuchaFab />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && <EscuchaOverlay />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && <SyncProgressIndicator />}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,8 @@ import { cropAlertEngine } from './services/cropAlertEngine';
 // comentario abajo donde se removió el render).
 // import FieldFeedback from './components/FieldFeedback';
 import AgentFab from './components/AgentFab';
+import EscuchaFab from './components/escucha/EscuchaFab';
+import EscuchaOverlay from './components/escucha/EscuchaOverlay';
 import AgentOfflineGuard from './components/AgentScreen/AgentOfflineGuard';
 // Transición home→conversación: el colibrí en video (~2s). Eager (debe
 // aparecer al instante al enviar desde el hero).
@@ -1700,6 +1702,15 @@ export default function App() {
           ya es el botón de ENVIAR del compositor, así que el FAB flotante ahí
           duplicaría el ave. Sigue en el resto para anunciar "respuesta lista". */}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && <AgentFab onNavigate={navigate} />}
+      {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
+          embarradas — distinto del MicFab removido 2026-05-30: aquel era solo
+          "grabar"; este abre el widget "Chagra está escuchando" que navega o
+          pregunta al agente punta a punta por voz). El FAB (abajo-izquierda)
+          es el trigger de HOY; el wake-word "hola Chagra" de MAÑANA llama el
+          mismo activarEscucha() sin tocar nada de esto. Oculto donde ya hay
+          micrófono propio (agente, voz) y en login/onboarding. */}
+      {!['loading', 'login', 'oauth-callback', 'onboarding-perfil', 'ubicacion-detectada', 'agente', 'voz', 'voz_planta', 'registro_voz'].includes(currentView) && <EscuchaFab />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && <EscuchaOverlay />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && <SyncProgressIndicator />}
       {toast && (

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -550,9 +550,22 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // normal NO debe re-disparar el prompt.
   useEffect(() => {
     if (!initialContext) return;
-    const { prefilledPrompt, sourceLabel, sourceUrl, alertContext } = initialContext;
+    const { prefilledPrompt, sourceLabel, sourceUrl, alertContext, autoSend, fromVoice } = initialContext;
+    let autoSendTimer = null;
     if (typeof prefilledPrompt === 'string' && prefilledPrompt.trim().length > 0) {
-      setInputText(prefilledPrompt);
+      if (autoSend) {
+        // 2026-07-05: widget "Chagra está escuchando" (escucha manos libres,
+        // caso guantes/manos embarradas). La pregunta llega YA transcrita por
+        // Whisper → se envía sola sin que el operador toque la pantalla, y si
+        // vino por voz activamos TTS para que la respuesta se HABLE por
+        // Kokoro (Whisper → agente → Kokoro, punta a punta).
+        if (fromVoice && !ttsEnabled) setTtsEnabled(true);
+        autoSendTimer = setTimeout(() => {
+          handleSubmit(prefilledPrompt, { fromVoice: Boolean(fromVoice) });
+        }, 250);
+      } else {
+        setInputText(prefilledPrompt);
+      }
     }
     if (sourceUrl || sourceLabel || alertContext) {
       setAlertContextBanner({
@@ -561,6 +574,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         alertContext: alertContext || null,
       });
     }
+    return () => { if (autoSendTimer) clearTimeout(autoSendTimer); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/escucha/EscuchaFab.jsx
+++ b/src/components/escucha/EscuchaFab.jsx
@@ -1,0 +1,50 @@
+/**
+ * EscuchaFab — botón flotante persistente que activa la escucha manos libres.
+ *
+ * Es el trigger de HOY (tap). El de MAÑANA es el wake-word "hola Chagra":
+ * ambos llaman `activarEscucha()` (escuchaService) — el widget no distingue.
+ *
+ * Diseño: espejo del AgentFab (colibrí, abajo-derecha): este vive ABAJO A LA
+ * IZQUIERDA, 62px (tamaño guante), micrófono grande + la ramita de la mano de
+ * Chagra como firma, acento del tema por --t-accent-rgb, con un ping perezoso
+ * cada 4s que anuncia "aquí se habla" (apagado con prefers-reduced-motion).
+ *
+ * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+import React from 'react';
+import { Mic } from 'lucide-react';
+import { activarEscucha } from '../../services/escuchaService';
+import './escucha.css';
+
+export default function EscuchaFab() {
+  return (
+    <button
+      type="button"
+      className="escucha-fab"
+      data-testid="escucha-fab"
+      aria-label="Hablar con Chagra sin usar las manos"
+      title="Manos libres: toque y hable — «lléveme al mercado» o pregunte lo que necesite"
+      onClick={() => activarEscucha({ fuente: 'tap' })}
+    >
+      <span className="escucha-fab-ping" aria-hidden="true" />
+      <Mic size={27} strokeWidth={2.4} aria-hidden="true" />
+      {/* La firma de la marca: la ramita con nodos que brota (mano de Chagra) */}
+      <svg
+        className="escucha-fab-brotecito"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        aria-hidden="true"
+      >
+        <path d="M8 13V7" />
+        <path d="M8 7L5.6 4.8M8 7l2.3-2.4" />
+        <circle cx="4.9" cy="4" r="0.8" fill="currentColor" stroke="none" />
+        <circle cx="11" cy="3.8" r="0.8" fill="currentColor" stroke="none" />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/escucha/EscuchaOverlay.jsx
+++ b/src/components/escucha/EscuchaOverlay.jsx
@@ -155,7 +155,14 @@ export default function EscuchaOverlay() {
     setFase(FASE_CERRADO);
   }, [reset]);
 
+  const faseRef = useRef(fase);
+  faseRef.current = fase;
+
   const abrir = useCallback(async (detalle) => {
+    // Guard re-disparo: un wake-word puede gatillar varias veces seguidas
+    // (o el operador toca el FAB mientras ya está abierto). Si ya estamos
+    // oyendo/pensando/en rumbo, ignorar — no duplicar streams del mic.
+    if (faseRef.current !== FASE_CERRADO && faseRef.current !== FASE_ERROR) return;
     setFuente(detalle?.fuente || 'tap');
     setDestino(null);
     setMensajeError('');

--- a/src/components/escucha/EscuchaOverlay.jsx
+++ b/src/components/escucha/EscuchaOverlay.jsx
@@ -1,0 +1,358 @@
+/**
+ * EscuchaOverlay — el widget "Chagra está escuchando" (escucha manos libres).
+ *
+ * CASO DE USO (operador 2026-07-05): el campesino tiene GUANTES o las manos
+ * embarradas. Un tap (EscuchaFab) — o mañana el wake-word "hola Chagra" —
+ * abre este overlay, que graba, transcribe con el pipeline Whisper existente
+ * (useVoiceRecorder + voiceService) y rutea:
+ *
+ *   a) comando de navegación ("lléveme a suelo") → chagraNavigate a esa vista.
+ *   b) pregunta/pedido → agente con autoSend (AgentScreen la envía sola y la
+ *      respuesta se HABLA por Kokoro — punta a punta sin tocar la pantalla).
+ *
+ * TRIGGER DESACOPLADO: este componente NO expone métodos — solo escucha el
+ * evento `chagra:escucha` (ver escuchaService.activarEscucha()). El wake-word
+ * reusa exactamente ese trigger sin tocar este archivo.
+ *
+ * MANOS LIBRES DE VERDAD: detección de silencio — cuando ya habló y calla
+ * ~1.8s, la escucha se cierra sola (el arco que se cierra alrededor del iris
+ * es ese conteo, feedback honesto). "Listo" y "Cancelar" quedan como respaldo
+ * táctil tamaño guante.
+ *
+ * Visual: "la mano que escucha" — ManoChagraGlyph al centro de un iris de
+ * micelio cuyos anillos y brotes respiran con el RMS REAL del micrófono
+ * (audioLevel/amplitudeHistory del recorder — nada de animación fingida).
+ *
+ * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { X, Mic, Keyboard, CornerUpRight, AlertTriangle } from 'lucide-react';
+import useVoiceRecorder from '../../hooks/useVoiceRecorder';
+import { transcribe, queueForRetry } from '../../services/voiceService';
+import { routeUtterance } from '../../services/escuchaIntentRouter';
+import { onEscucha } from '../../services/escuchaService';
+import ManoChagraGlyph from '../dashboard/ManoChagraGlyph';
+import './escucha.css';
+
+/* Fases del widget. 'cerrado' = desmontado visualmente (retorna null). */
+const FASE_CERRADO = 'cerrado';
+const FASE_OYENDO = 'oyendo';
+const FASE_PENSANDO = 'pensando';
+const FASE_RUMBO = 'rumbo';
+const FASE_ERROR = 'error';
+
+/* Manos libres: umbral RMS que cuenta como "está hablando", silencio que
+ * cierra la escucha, y mínimo para no cerrarnos antes de que arranque. */
+const UMBRAL_VOZ = 0.14;
+const SILENCIO_MS = 1800;
+const MIN_ESCUCHA_MS = 1500;
+const TOPE_ESCUCHA_MS = 25000; // por debajo del hard-limit (30s) del recorder
+const PAUSA_RUMBO_MS = 1000;   // deja LEER "Abriendo Mercado…" antes de saltar
+
+const NUM_BROTES = 28;
+
+const formatoSegundos = (ms) => `${(ms / 1000).toFixed(0)}s`;
+
+const navegar = (view, initialData = null) => {
+  window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view, initialData } }));
+};
+
+/**
+ * Iris de micelio: 3 anillos que respiran con el RMS + brotes radiales con la
+ * historia de amplitud + arco de cierre (conteo de silencio). Todo dato real.
+ */
+function IrisEscucha({ nivel, historia, fase, cierre }) {
+  const C = 116; // centro del viewBox 232x232
+  const brotes = [];
+  const muestras = historia.slice(-NUM_BROTES);
+  for (let i = 0; i < NUM_BROTES; i++) {
+    const m = muestras[i] ?? 0;
+    const ang = (i / NUM_BROTES) * Math.PI * 2 - Math.PI / 2;
+    const r0 = 78;
+    const largo = fase === FASE_OYENDO ? 5 + m * 26 : 5;
+    const x1 = C + Math.cos(ang) * r0;
+    const y1 = C + Math.sin(ang) * r0;
+    const x2 = C + Math.cos(ang) * (r0 + largo);
+    const y2 = C + Math.sin(ang) * (r0 + largo);
+    brotes.push(
+      <line
+        key={i}
+        className="escucha-brote"
+        x1={x1} y1={y1} x2={x2} y2={y2}
+        strokeWidth={i % 4 === 0 ? 3 : 2}
+        opacity={0.35 + m * 0.65}
+      />,
+    );
+  }
+
+  // Arco de cierre: circunferencia r=110; se va DIBUJANDO con el silencio.
+  const rArco = 110;
+  const circArco = 2 * Math.PI * rArco;
+
+  const vivo = fase === FASE_OYENDO;
+  return (
+    <div className="escucha-iris" aria-hidden="true">
+      <svg viewBox="0 0 232 232">
+        {/* Anillos de micelio: respiración = RMS real, cada uno a su ritmo */}
+        {[{ r: 58, k: 26, o: 0.5 }, { r: 68, k: 16, o: 0.35 }, { r: 78, k: 8, o: 0.25 }].map(({ r, k, o }, i) => (
+          <circle
+            key={i}
+            className="escucha-anillo"
+            cx={C} cy={C} r={r}
+            fill="none"
+            stroke={`rgba(var(--esc-linea-rgb), ${o + (vivo ? nivel * 0.4 : 0)})`}
+            strokeWidth={i === 0 ? 2.5 : 1.5}
+            strokeDasharray={i === 2 ? '3 7' : i === 1 ? '10 6' : 'none'}
+            style={{ transform: vivo ? `scale(${1 + nivel * (k / 100)})` : 'scale(1)' }}
+          />
+        ))}
+        {brotes}
+        {/* Conteo de silencio: el aro exterior se cierra → "ya casi termino de oír" */}
+        {vivo && cierre > 0 && (
+          <circle
+            className="escucha-arco-cierre"
+            cx={C} cy={C} r={rArco}
+            fill="none"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeDasharray={circArco}
+            strokeDashoffset={circArco * (1 - cierre)}
+            transform={`rotate(-90 ${C} ${C})`}
+          />
+        )}
+      </svg>
+      <div className="escucha-mano">
+        <ManoChagraGlyph size={54} />
+      </div>
+    </div>
+  );
+}
+
+export default function EscuchaOverlay() {
+  const { audioLevel, amplitudeHistory, durationMs, start, stop, reset } = useVoiceRecorder();
+
+  const [fase, setFase] = useState(FASE_CERRADO);
+  const [fuente, setFuente] = useState('tap');
+  const [destino, setDestino] = useState(null);
+  const [mensajeError, setMensajeError] = useState('');
+  const [cierre, setCierre] = useState(0); // 0..1 progreso del conteo de silencio
+
+  const yaHabloRef = useRef(false);
+  const ultimaVozRef = useRef(0);
+  const abiertoTsRef = useRef(0);
+  const finalizandoRef = useRef(false);
+  const rumboTimerRef = useRef(null);
+  const cartaRef = useRef(null);
+
+  const cerrar = useCallback(() => {
+    if (rumboTimerRef.current) { clearTimeout(rumboTimerRef.current); rumboTimerRef.current = null; }
+    reset();
+    finalizandoRef.current = false;
+    yaHabloRef.current = false;
+    setCierre(0);
+    setDestino(null);
+    setMensajeError('');
+    setFase(FASE_CERRADO);
+  }, [reset]);
+
+  const abrir = useCallback(async (detalle) => {
+    setFuente(detalle?.fuente || 'tap');
+    setDestino(null);
+    setMensajeError('');
+    setCierre(0);
+    yaHabloRef.current = false;
+    finalizandoRef.current = false;
+    abiertoTsRef.current = Date.now();
+    ultimaVozRef.current = Date.now();
+    setFase(FASE_OYENDO);
+    try {
+      await start();
+    } catch (err) {
+      setMensajeError(
+        err?.message?.includes('MediaDevices') || err?.message?.includes('Permission')
+          ? 'No pude usar el micrófono. Revise el permiso del navegador.'
+          : (err?.message || 'No pude empezar a escuchar.'),
+      );
+      setFase(FASE_ERROR);
+    }
+  }, [start]);
+
+  /** Cierra la grabación y corre el pipeline Whisper → router → destino. */
+  const finalizar = useCallback(async () => {
+    if (finalizandoRef.current) return;
+    finalizandoRef.current = true;
+    setCierre(0);
+    setFase(FASE_PENSANDO);
+
+    const resultado = await stop();
+    if (!resultado || !resultado.blob || resultado.blob.size === 0) {
+      setMensajeError('No alcancé a oírle. Acérquese al micrófono e intente de nuevo.');
+      setFase(FASE_ERROR);
+      finalizandoRef.current = false;
+      return;
+    }
+
+    let texto;
+    try {
+      texto = await transcribe(resultado.blob);
+    } catch (err) {
+      // Whisper caído / red: guardamos el audio para reintento (mismo
+      // contrato que VoiceCapture) y degradamos amable, nunca error mudo.
+      queueForRetry(resultado.blob, {
+        reason: `escucha: ${err?.message || 'transcribe failed'}`,
+        durationMs: resultado.durationMs || 0,
+      }).catch(() => {});
+      setMensajeError('No pude entenderle esta vez — guardé el audio para reintentarlo. También puede escribir la pregunta.');
+      setFase(FASE_ERROR);
+      finalizandoRef.current = false;
+      return;
+    }
+
+    const ruta = routeUtterance(texto);
+    if (ruta.tipo === 'navegar') {
+      // Camino (a): comando de navegación → mostramos el rumbo y saltamos.
+      setDestino(ruta);
+      setFase(FASE_RUMBO);
+      rumboTimerRef.current = setTimeout(() => {
+        navegar(ruta.view);
+        cerrar();
+      }, PAUSA_RUMBO_MS);
+      return;
+    }
+
+    // Camino (b): pregunta → agente con autoSend + fromVoice (la respuesta
+    // se habla por Kokoro; ver AgentScreen initialContext).
+    navegar('agente', {
+      prefilledPrompt: ruta.prompt,
+      autoSend: true,
+      fromVoice: true,
+      fuente: 'escucha',
+    });
+    cerrar();
+  }, [stop, cerrar]);
+
+  const cancelar = useCallback(() => {
+    // Descarta lo grabado sin procesar (stop() resuelve y se ignora el blob).
+    stop().catch(() => {});
+    cerrar();
+  }, [stop, cerrar]);
+
+  const reintentar = useCallback(() => { abrir({ fuente }); }, [abrir, fuente]);
+
+  const irAEscribir = useCallback(() => {
+    navegar('agente');
+    cerrar();
+  }, [cerrar]);
+
+  // === Trigger desacoplado: tap HOY, wake-word MAÑANA (mismo evento). ===
+  useEffect(() => onEscucha((detalle) => { abrir(detalle); }), [abrir]);
+
+  // Manos libres: vigilar el RMS. Si ya habló y lleva SILENCIO_MS callado,
+  // cerramos solos. El progreso alimenta el arco de cierre del iris.
+  useEffect(() => {
+    if (fase !== FASE_OYENDO) return undefined;
+    if (audioLevel > UMBRAL_VOZ) {
+      yaHabloRef.current = true;
+      ultimaVozRef.current = Date.now();
+    }
+    const timer = setInterval(() => {
+      const ahora = Date.now();
+      const desdeApertura = ahora - abiertoTsRef.current;
+      if (desdeApertura >= TOPE_ESCUCHA_MS) { finalizar(); return; }
+      if (!yaHabloRef.current || desdeApertura < MIN_ESCUCHA_MS) { setCierre(0); return; }
+      const callado = ahora - ultimaVozRef.current;
+      if (callado >= SILENCIO_MS) { finalizar(); return; }
+      setCierre(Math.max(0, Math.min(1, callado / SILENCIO_MS)));
+    }, 120);
+    return () => clearInterval(timer);
+  }, [fase, audioLevel, finalizar]);
+
+  // Escape cancela; foco inicial a la carta (lectores de pantalla anuncian).
+  useEffect(() => {
+    if (fase === FASE_CERRADO) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') cancelar(); };
+    window.addEventListener('keydown', onKey);
+    cartaRef.current?.focus?.();
+    return () => window.removeEventListener('keydown', onKey);
+  }, [fase !== FASE_CERRADO]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (fase === FASE_CERRADO) return null;
+
+  const titulos = {
+    [FASE_OYENDO]: <>Chagra está <b>escuchando</b></>,
+    [FASE_PENSANDO]: <>Entendiendo lo que dijo…</>,
+    [FASE_RUMBO]: <>¡Listo, de una!</>,
+    [FASE_ERROR]: <>No le alcancé a oír</>,
+  };
+  const subtitulos = {
+    [FASE_OYENDO]: <>Hable con confianza: <b>«lléveme al mercado»</b> para ir a una pantalla, o pregúnteme lo que necesite de su finca.</>,
+    [FASE_PENSANDO]: <>Un momento — estoy pasando su voz a palabras.</>,
+    [FASE_RUMBO]: destino ? <>Vamos para allá ahora mismo.</> : null,
+    [FASE_ERROR]: <>{mensajeError}</>,
+  };
+
+  return (
+    <div
+      className="escucha-overlay"
+      data-testid="escucha-overlay"
+      data-fase={fase}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Chagra está escuchando"
+    >
+      <div className="escucha-velo" onClick={cancelar} data-testid="escucha-velo" />
+      <div className="escucha-carta" ref={cartaRef} tabIndex={-1}>
+        <div className="escucha-eyebrow">
+          <span className="escucha-punto" aria-hidden="true" />
+          {fuente === 'wakeword' ? 'Escuché «hola Chagra»' : 'Escucha manos libres'}
+        </div>
+
+        <IrisEscucha nivel={audioLevel} historia={amplitudeHistory} fase={fase} cierre={cierre} />
+
+        <h2 className="escucha-titulo" data-testid="escucha-estado" aria-live="polite">
+          {fase === FASE_ERROR && <AlertTriangle size={22} style={{ display: 'inline', verticalAlign: '-3px', marginRight: 6 }} />}
+          {titulos[fase]}
+        </h2>
+        {subtitulos[fase] && <p className="escucha-sub">{subtitulos[fase]}</p>}
+
+        {fase === FASE_OYENDO && (
+          <div className="escucha-medidor" aria-hidden="true">
+            <span>{formatoSegundos(durationMs)}</span>
+            <span>·</span>
+            <span>{cierre > 0 ? 'lo oí — cierro si se queda callado' : 'grabando'}</span>
+          </div>
+        )}
+
+        {fase === FASE_RUMBO && destino && (
+          <div className="escucha-rumbo" data-testid="escucha-rumbo">
+            <CornerUpRight size={18} />
+            <span>Abriendo <b>{destino.etiqueta}</b>…</span>
+          </div>
+        )}
+
+        <div className="escucha-acciones">
+          {fase === FASE_OYENDO && (
+            <button type="button" className="escucha-btn-listo" data-testid="escucha-listo" onClick={finalizar}>
+              Listo, eso era
+            </button>
+          )}
+          {fase === FASE_ERROR && (
+            <>
+              <button type="button" className="escucha-btn-listo" data-testid="escucha-reintentar" onClick={reintentar}>
+                <Mic size={20} /> Intentar de nuevo
+              </button>
+              <button type="button" className="escucha-btn-sec" data-testid="escucha-escribir" onClick={irAEscribir}>
+                <Keyboard size={18} /> Mejor lo escribo
+              </button>
+            </>
+          )}
+          {fase !== FASE_RUMBO && (
+            <button type="button" className="escucha-btn-cancelar" data-testid="escucha-cancelar" onClick={cancelar}>
+              <X size={16} /> Cancelar
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/escucha/EscuchaOverlay.jsx
+++ b/src/components/escucha/EscuchaOverlay.jsx
@@ -247,14 +247,23 @@ export default function EscuchaOverlay() {
   // === Trigger desacoplado: tap HOY, wake-word MAÑANA (mismo evento). ===
   useEffect(() => onEscucha((detalle) => { abrir(detalle); }), [abrir]);
 
-  // Manos libres: vigilar el RMS. Si ya habló y lleva SILENCIO_MS callado,
-  // cerramos solos. El progreso alimenta el arco de cierre del iris.
+  // Manos libres (1/2): marcar actividad de voz en refs. audioLevel cambia a
+  // ~60fps (setState por frame del recorder) — este efecto SOLO toca refs.
   useEffect(() => {
-    if (fase !== FASE_OYENDO) return undefined;
+    if (fase !== FASE_OYENDO) return;
     if (audioLevel > UMBRAL_VOZ) {
       yaHabloRef.current = true;
       ultimaVozRef.current = Date.now();
     }
+  }, [fase, audioLevel]);
+
+  // Manos libres (2/2): el vigía. UN solo interval por fase — NO depende de
+  // audioLevel: si dependiera, el re-render de cada frame lo recrearía antes
+  // de cumplirse los 120ms y el conteo de silencio jamás dispararía. Si ya
+  // habló y lleva SILENCIO_MS callado, cerramos solos; el progreso alimenta
+  // el arco de cierre del iris.
+  useEffect(() => {
+    if (fase !== FASE_OYENDO) return undefined;
     const timer = setInterval(() => {
       const ahora = Date.now();
       const desdeApertura = ahora - abiertoTsRef.current;
@@ -265,7 +274,7 @@ export default function EscuchaOverlay() {
       setCierre(Math.max(0, Math.min(1, callado / SILENCIO_MS)));
     }, 120);
     return () => clearInterval(timer);
-  }, [fase, audioLevel, finalizar]);
+  }, [fase, finalizar]);
 
   // Escape cancela; foco inicial a la carta (lectores de pantalla anuncian).
   useEffect(() => {

--- a/src/components/escucha/EscuchaOverlay.jsx
+++ b/src/components/escucha/EscuchaOverlay.jsx
@@ -155,14 +155,11 @@ export default function EscuchaOverlay() {
     setFase(FASE_CERRADO);
   }, [reset]);
 
-  const faseRef = useRef(fase);
-  faseRef.current = fase;
-
   const abrir = useCallback(async (detalle) => {
     // Guard re-disparo: un wake-word puede gatillar varias veces seguidas
     // (o el operador toca el FAB mientras ya está abierto). Si ya estamos
     // oyendo/pensando/en rumbo, ignorar — no duplicar streams del mic.
-    if (faseRef.current !== FASE_CERRADO && faseRef.current !== FASE_ERROR) return;
+    if (fase !== FASE_CERRADO && fase !== FASE_ERROR) return;
     setFuente(detalle?.fuente || 'tap');
     setDestino(null);
     setMensajeError('');
@@ -182,7 +179,7 @@ export default function EscuchaOverlay() {
       );
       setFase(FASE_ERROR);
     }
-  }, [start]);
+  }, [start, fase]);
 
   /** Cierra la grabación y corre el pipeline Whisper → router → destino. */
   const finalizar = useCallback(async () => {

--- a/src/components/escucha/__tests__/EscuchaOverlay.test.jsx
+++ b/src/components/escucha/__tests__/EscuchaOverlay.test.jsx
@@ -1,0 +1,167 @@
+/**
+ * Tests del widget "Chagra está escuchando":
+ *  - abre por el trigger desacoplado (activarEscucha — tap hoy, wake-word mañana)
+ *  - camino (a): comando de navegación → chagraNavigate a la vista
+ *  - camino (b): pregunta → agente con autoSend + fromVoice (→ Kokoro)
+ *  - degradación: Whisper caído → audio a la cola + salida por teclado
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import EscuchaOverlay from '../EscuchaOverlay.jsx';
+import EscuchaFab from '../EscuchaFab.jsx';
+import { activarEscucha } from '../../../services/escuchaService.js';
+
+const startMock = vi.fn(async () => {});
+const stopMock = vi.fn(async () => ({
+  blob: new Blob([new Uint8Array(4096)], { type: 'audio/webm' }),
+  durationMs: 2100,
+  mimeType: 'audio/webm',
+}));
+const resetMock = vi.fn();
+
+vi.mock('../../../hooks/useVoiceRecorder', () => ({
+  default: () => ({
+    isRecording: true,
+    audioLevel: 0.3,
+    amplitudeHistory: [0.1, 0.4, 0.2],
+    durationMs: 1200,
+    error: null,
+    start: startMock,
+    stop: stopMock,
+    reset: resetMock,
+    hardLimitMs: 30000,
+  }),
+}));
+
+vi.mock('../../../services/voiceService', () => ({
+  transcribe: vi.fn(),
+  queueForRetry: vi.fn(async () => {}),
+}));
+
+import { transcribe, queueForRetry } from '../../../services/voiceService';
+
+// vi.mocked: acceso tipado a los mocks (el gate tsc:check exige tipos limpios
+// en archivos nuevos — sin esto, mockResolvedValueOnce no existe en el tipo).
+const transcribeMock = vi.mocked(transcribe);
+
+const abrirWidget = async (fuente = 'tap') => {
+  await act(async () => { activarEscucha({ fuente }); });
+  await screen.findByTestId('escucha-overlay');
+};
+
+describe('EscuchaOverlay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('cerrado no renderiza nada', () => {
+    render(<EscuchaOverlay />);
+    expect(screen.queryByTestId('escucha-overlay')).toBeNull();
+  });
+
+  it('activarEscucha() abre el widget escuchando (trigger desacoplado)', async () => {
+    render(<EscuchaOverlay />);
+    await abrirWidget();
+
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('escucha-overlay').dataset.fase).toBe('oyendo');
+    expect(screen.getByTestId('escucha-estado').textContent).toMatch(/escuchando/i);
+    expect(screen.getByTestId('escucha-listo')).toBeTruthy();
+    expect(screen.getByTestId('escucha-cancelar')).toBeTruthy();
+  });
+
+  it('fuente wakeword cambia el encabezado (mismo widget, otro trigger)', async () => {
+    render(<EscuchaOverlay />);
+    await abrirWidget('wakeword');
+    expect(screen.getByText(/hola Chagra/i)).toBeTruthy();
+  });
+
+  it('camino (a): "lléveme al mercado" → navega a mercado', async () => {
+    transcribeMock.mockResolvedValueOnce('Lléveme al mercado');
+    const navSpy = vi.fn();
+    window.addEventListener('chagraNavigate', navSpy);
+
+    render(<EscuchaOverlay />);
+    await abrirWidget();
+    fireEvent.click(screen.getByTestId('escucha-listo'));
+
+    // Primero muestra el rumbo (para que el campesino LEA a dónde va)…
+    await screen.findByTestId('escucha-rumbo');
+    expect(screen.getByTestId('escucha-rumbo').textContent).toMatch(/Mercado/);
+
+    // …y tras la pausa dispara la navegación real.
+    await waitFor(() => {
+      expect(navSpy).toHaveBeenCalled();
+    }, { timeout: 3000 });
+    expect(navSpy.mock.calls[0][0].detail.view).toBe('mercado');
+    window.removeEventListener('chagraNavigate', navSpy);
+  });
+
+  it('camino (b): pregunta → agente con autoSend + fromVoice', async () => {
+    transcribeMock.mockResolvedValueOnce('¿Cuánta agua necesita el café?');
+    const navSpy = vi.fn();
+    window.addEventListener('chagraNavigate', navSpy);
+
+    render(<EscuchaOverlay />);
+    await abrirWidget();
+    fireEvent.click(screen.getByTestId('escucha-listo'));
+
+    await waitFor(() => expect(navSpy).toHaveBeenCalled());
+    const { view, initialData } = navSpy.mock.calls[0][0].detail;
+    expect(view).toBe('agente');
+    expect(initialData).toMatchObject({
+      prefilledPrompt: '¿Cuánta agua necesita el café?',
+      autoSend: true,
+      fromVoice: true,
+    });
+    // El widget se cierra: el agente toma el relevo (y habla por Kokoro).
+    await waitFor(() => expect(screen.queryByTestId('escucha-overlay')).toBeNull());
+    window.removeEventListener('chagraNavigate', navSpy);
+  });
+
+  it('cancelar cierra sin navegar', async () => {
+    const navSpy = vi.fn();
+    window.addEventListener('chagraNavigate', navSpy);
+
+    render(<EscuchaOverlay />);
+    await abrirWidget();
+    fireEvent.click(screen.getByTestId('escucha-cancelar'));
+
+    await waitFor(() => expect(screen.queryByTestId('escucha-overlay')).toBeNull());
+    expect(navSpy).not.toHaveBeenCalled();
+    expect(transcribeMock).not.toHaveBeenCalled();
+    window.removeEventListener('chagraNavigate', navSpy);
+  });
+
+  it('Whisper caído → guarda el audio para reintento y ofrece teclado', async () => {
+    transcribeMock.mockRejectedValueOnce(new Error('Whisper 503'));
+
+    render(<EscuchaOverlay />);
+    await abrirWidget();
+    fireEvent.click(screen.getByTestId('escucha-listo'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('escucha-overlay').dataset.fase).toBe('error');
+    });
+    expect(queueForRetry).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('escucha-reintentar')).toBeTruthy();
+    expect(screen.getByTestId('escucha-escribir')).toBeTruthy();
+  });
+});
+
+describe('EscuchaFab', () => {
+  it('el tap del FAB dispara el mismo trigger que usará el wake-word', async () => {
+    render(
+      <>
+        <EscuchaFab />
+        <EscuchaOverlay />
+      </>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('escucha-fab'));
+    });
+    await screen.findByTestId('escucha-overlay');
+    expect(screen.getByTestId('escucha-overlay').dataset.fase).toBe('oyendo');
+  });
+});

--- a/src/components/escucha/escucha.css
+++ b/src/components/escucha/escucha.css
@@ -1,0 +1,359 @@
+/* ============================================================================
+ * escucha.css — Widget "Chagra está escuchando" (escucha manos libres).
+ *
+ * Estética: "la mano que escucha" — la mano de Chagra al centro de un iris
+ * de micelio que respira con el nivel REAL del micrófono. Biopunk por
+ * defecto; en temas claros (minimalista/nature/verde-vivo) el velo pasa a
+ * papel del tema con tinta oscura (AA al sol).
+ *
+ * Tokens: TODO el acento sale de --t-accent-rgb (themes.css). Este archivo
+ * solo define superficie/tinta del overlay por tema (indirección CSS-var,
+ * NUNCA parche clase-por-clase).
+ * ========================================================================== */
+
+.escucha-overlay {
+  /* Tokens del overlay (default = biopunk noche-bosque) */
+  --esc-bg-rgb: 4, 13, 11;          /* fondo del velo */
+  --esc-carta-rgb: 8, 22, 19;       /* superficie de la carta */
+  --esc-ink-rgb: 236, 253, 245;     /* tinta principal */
+  --esc-dim-rgb: 148, 187, 173;     /* tinta secundaria */
+  --esc-linea-rgb: 25, 201, 154;    /* trazos del iris (= acento biopunk) */
+  --esc-linea-rgb: var(--t-accent-rgb);
+  --esc-cta-ink: #04231b;           /* tinta sobre el botón de acento */
+
+  position: fixed;
+  inset: 0;
+  z-index: 90; /* sobre FABs (40) y chrome; bajo nada — es modal */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  padding-bottom: max(16px, env(safe-area-inset-bottom));
+}
+
+/* Temas claros: papel del tema + tinta oscura (legible a pleno sol). */
+[data-theme="minimalista"] .escucha-overlay {
+  --esc-bg-rgb: 246, 243, 236;
+  --esc-carta-rgb: 252, 250, 245;
+  --esc-ink-rgb: 24, 34, 29;
+  --esc-dim-rgb: 90, 106, 98;
+  --esc-cta-ink: #ffffff;
+}
+[data-theme="nature"] .escucha-overlay {
+  --esc-bg-rgb: 251, 245, 234;
+  --esc-carta-rgb: 254, 250, 242;
+  --esc-ink-rgb: 43, 33, 24;
+  --esc-dim-rgb: 122, 103, 82;
+  --esc-cta-ink: #2b1c10;
+}
+[data-theme="verde-vivo"] .escucha-overlay {
+  --esc-bg-rgb: 238, 243, 226;
+  --esc-carta-rgb: 248, 251, 240;
+  --esc-ink-rgb: 26, 38, 28;
+  --esc-dim-rgb: 84, 104, 88;
+  --esc-cta-ink: #ffffff;
+}
+
+/* Velo: casi opaco a propósito — al sol un velo translúcido no se lee. */
+.escucha-velo {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 120% 80% at 50% 30%, rgba(var(--esc-linea-rgb), 0.10), transparent 60%),
+    rgba(var(--esc-bg-rgb), 0.96);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.escucha-carta {
+  position: relative;
+  width: min(100%, 420px);
+  max-height: 100%;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 22px 20px calc(18px + env(safe-area-inset-bottom));
+  border-radius: 28px;
+  background: rgba(var(--esc-carta-rgb), 0.92);
+  border: 1px solid rgba(var(--esc-linea-rgb), 0.35);
+  box-shadow:
+    0 24px 80px rgba(0, 0, 0, 0.45),
+    0 0 60px rgba(var(--esc-linea-rgb), 0.18);
+  color: rgb(var(--esc-ink-rgb));
+  animation: escucha-entra 0.28s cubic-bezier(0.34, 1.4, 0.64, 1) both;
+}
+
+@keyframes escucha-entra {
+  from { transform: translateY(24px) scale(0.96); opacity: 0; }
+  to   { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+/* --- Eyebrow: "escucha activa" ------------------------------------------ */
+.escucha-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgb(var(--esc-dim-rgb));
+}
+.escucha-punto {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: rgb(var(--esc-linea-rgb));
+  box-shadow: 0 0 0 0 rgba(var(--esc-linea-rgb), 0.55);
+  animation: escucha-latido 1.6s ease-out infinite;
+}
+@keyframes escucha-latido {
+  0%   { box-shadow: 0 0 0 0 rgba(var(--esc-linea-rgb), 0.55); }
+  70%  { box-shadow: 0 0 0 10px rgba(var(--esc-linea-rgb), 0); }
+  100% { box-shadow: 0 0 0 0 rgba(var(--esc-linea-rgb), 0); }
+}
+
+/* --- El iris (la mano que escucha) --------------------------------------- */
+.escucha-iris {
+  position: relative;
+  width: 232px;
+  height: 232px;
+  display: grid;
+  place-items: center;
+  margin: 2px 0;
+}
+.escucha-iris svg { position: absolute; inset: 0; overflow: visible; }
+
+/* Anillos de micelio: el scale lo pone el JSX con el RMS real; acá solo
+ * la transición corta para que el movimiento se sienta orgánico. */
+.escucha-anillo {
+  transform-origin: center;
+  transition: transform 0.09s ease-out, opacity 0.2s ease;
+}
+.escucha-brote {
+  transition: opacity 0.15s ease;
+  stroke: rgb(var(--esc-linea-rgb));
+  stroke-linecap: round;
+}
+.escucha-arco-cierre {
+  stroke: rgb(var(--esc-ink-rgb));
+  opacity: 0.85;
+  transition: stroke-dashoffset 0.15s linear;
+}
+
+/* La mano al centro: disco propio + glifo con el acento del tema. */
+.escucha-mano {
+  position: relative;
+  z-index: 2;
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: rgb(var(--esc-linea-rgb));
+  background:
+    radial-gradient(circle at 32% 28%, rgba(var(--esc-linea-rgb), 0.22), transparent 62%),
+    rgba(var(--esc-carta-rgb), 0.95);
+  border: 2px solid rgba(var(--esc-linea-rgb), 0.55);
+  box-shadow: 0 0 34px rgba(var(--esc-linea-rgb), 0.35);
+}
+.escucha-overlay[data-fase="pensando"] .escucha-mano {
+  animation: escucha-piensa 1.4s ease-in-out infinite;
+}
+@keyframes escucha-piensa {
+  0%, 100% { box-shadow: 0 0 22px rgba(var(--esc-linea-rgb), 0.25); }
+  50%      { box-shadow: 0 0 48px rgba(var(--esc-linea-rgb), 0.55); }
+}
+
+/* --- Título de estado (legible al sol: enorme y extrabold) ---------------- */
+.escucha-titulo {
+  margin: 0;
+  font-size: clamp(1.55rem, 6.4vw, 1.95rem);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+  text-align: center;
+  color: rgb(var(--esc-ink-rgb));
+}
+.escucha-titulo b { color: rgb(var(--esc-linea-rgb)); font-weight: 800; }
+
+.escucha-sub {
+  margin: 0;
+  max-width: 32ch;
+  text-align: center;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  color: rgb(var(--esc-dim-rgb));
+}
+.escucha-sub b { color: rgb(var(--esc-ink-rgb)); font-weight: 700; }
+
+/* --- Medidor: duración + rumbo ------------------------------------------- */
+.escucha-medidor {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: rgb(var(--esc-dim-rgb));
+}
+.escucha-rumbo {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: rgb(var(--esc-ink-rgb));
+  background: rgba(var(--esc-linea-rgb), 0.14);
+  border: 1px solid rgba(var(--esc-linea-rgb), 0.45);
+}
+.escucha-rumbo b { color: rgb(var(--esc-linea-rgb)); }
+
+/* --- Acciones tamaño GUANTE ------------------------------------------------
+ * El caso de uso es manos con guantes/barro: el botón primario ocupa todo el
+ * ancho y mide ≥72px de alto. Nada de targets de 40px acá. */
+.escucha-acciones {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 6px;
+}
+.escucha-btn-listo {
+  width: 100%;
+  min-height: 72px;
+  border: none;
+  border-radius: 20px;
+  font-size: 1.15rem;
+  font-weight: 800;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--esc-cta-ink);
+  background: rgb(var(--esc-linea-rgb));
+  box-shadow: 0 10px 30px rgba(var(--esc-linea-rgb), 0.35);
+  transition: transform 0.12s ease, box-shadow 0.2s ease;
+}
+.escucha-btn-listo:active { transform: scale(0.97); }
+.escucha-btn-sec {
+  width: 100%;
+  min-height: 56px;
+  border-radius: 16px;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: rgb(var(--esc-ink-rgb));
+  background: rgba(var(--esc-ink-rgb), 0.08);
+  border: 1px solid rgba(var(--esc-ink-rgb), 0.22);
+}
+.escucha-btn-cancelar {
+  width: 100%;
+  min-height: 52px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: rgb(var(--esc-dim-rgb));
+}
+.escucha-btn-cancelar:hover { color: rgb(var(--esc-ink-rgb)); }
+
+.escucha-overlay button:focus-visible {
+  outline: 3px solid rgba(var(--esc-linea-rgb), 0.9);
+  outline-offset: 2px;
+}
+
+/* ============================================================================
+ * EscuchaFab — botón flotante persistente (el tap de HOY).
+ * Espejo del AgentFab (colibrí, derecha): este vive a la IZQUIERDA, tamaño
+ * guante (62px), acento del tema, con un ping suave que anuncia "aquí se
+ * habla". El wake-word de mañana NO lo necesita — llama activarEscucha().
+ * ========================================================================== */
+.escucha-fab {
+  position: fixed;
+  bottom: max(90px, calc(env(safe-area-inset-bottom) + 90px));
+  left: 16px;
+  width: 62px;
+  height: 62px;
+  border-radius: 50%;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: rgb(var(--t-accent-rgb));
+  background: radial-gradient(circle at 30% 25%, rgba(var(--t-accent-rgb), 0.16), transparent 65%), rgba(6, 16, 13, 0.92);
+  border: 2px solid rgba(var(--t-accent-rgb), 0.65);
+  box-shadow:
+    0 4px 18px rgba(0, 0, 0, 0.45),
+    0 0 18px rgba(var(--t-accent-rgb), 0.35);
+  transition: transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.25s ease;
+}
+.escucha-fab:hover, .escucha-fab:focus-visible { transform: scale(1.06); }
+.escucha-fab:active { transform: scale(0.94); }
+.escucha-fab:focus-visible {
+  outline: 3px solid rgba(var(--t-accent-rgb), 0.9);
+  outline-offset: 2px;
+}
+
+/* Temas claros: el FAB pasa a disco del acento con tinta clara (contraste). */
+[data-theme="minimalista"] .escucha-fab,
+[data-theme="nature"] .escucha-fab,
+[data-theme="verde-vivo"] .escucha-fab {
+  color: #fff;
+  background: rgb(var(--t-accent-rgb));
+  border-color: rgba(255, 255, 255, 0.65);
+}
+[data-theme="nature"] .escucha-fab { color: #2b1c10; }
+
+/* Ping perezoso: un aro que brota cada 4s — anuncia sin fastidiar. */
+.escucha-fab-ping {
+  position: absolute;
+  inset: -2px;
+  border-radius: 50%;
+  border: 2px solid rgba(var(--t-accent-rgb), 0.55);
+  animation: escucha-fab-brota 4s ease-out infinite;
+  pointer-events: none;
+}
+@keyframes escucha-fab-brota {
+  0%   { transform: scale(1); opacity: 0.7; }
+  30%  { transform: scale(1.45); opacity: 0; }
+  100% { transform: scale(1.45); opacity: 0; }
+}
+
+/* La ramita del glifo sobre el mic: la firma "mano de Chagra" en miniatura. */
+.escucha-fab-brotecito {
+  position: absolute;
+  top: 7px;
+  right: 9px;
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+/* ============================================================================
+ * Movimiento reducido: el organismo queda quieto pero el ESTADO sigue claro
+ * (el arco de cierre y los textos son informativos, no decorativos).
+ * ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .escucha-carta { animation: none; }
+  .escucha-punto { animation: none; }
+  .escucha-anillo { transition: none; }
+  .escucha-overlay[data-fase="pensando"] .escucha-mano { animation: none; }
+  .escucha-fab-ping { animation: none; opacity: 0; }
+  .escucha-fab, .escucha-btn-listo { transition: none; }
+}

--- a/src/components/escucha/escucha.css
+++ b/src/components/escucha/escucha.css
@@ -277,6 +277,13 @@
   outline: 3px solid rgba(var(--esc-linea-rgb), 0.9);
   outline-offset: 2px;
 }
+/* La carta recibe foco PROGRAMÁTICO al abrir (anuncio para lectores de
+ * pantalla); el focus-ring global del app le pintaba un aro ámbar alrededor
+ * de todo el modal. El foco visible se reserva para los botones. */
+.escucha-carta:focus,
+.escucha-carta:focus-visible {
+  outline: none;
+}
 
 /* ============================================================================
  * EscuchaFab — botón flotante persistente (el tap de HOY).

--- a/src/services/__tests__/escuchaIntentRouter.test.js
+++ b/src/services/__tests__/escuchaIntentRouter.test.js
@@ -1,0 +1,91 @@
+/**
+ * Tests del router puro de escucha manos libres (navegación vs agente).
+ * Los dos caminos que pidió el operador: (a) comando de navegación →
+ * redirigir; (b) pregunta/pedido → agente (Whisper → agente → Kokoro).
+ */
+import { describe, it, expect } from 'vitest';
+import { routeUtterance, normalizarHabla, listarDestinos } from '../escuchaIntentRouter.js';
+
+describe('normalizarHabla', () => {
+  it('quita tildes, signos y colapsa espacios', () => {
+    expect(normalizarHabla('¿Lléveme  al MAPA, por favor?')).toBe('lleveme al mapa por favor');
+  });
+  it('tolera null/undefined', () => {
+    expect(normalizarHabla(null)).toBe('');
+    expect(normalizarHabla(undefined)).toBe('');
+  });
+});
+
+describe('routeUtterance — camino (a): comandos de navegación', () => {
+  const casos = [
+    ['Lléveme a suelo', 'suelo'],
+    ['llevame a suelo', 'suelo'],
+    ['abrir mercado', 'mercado'],
+    ['Abra el mercado', 'mercado'],
+    ['muéstrame el mapa', 'mapa'],
+    ['Muéstreme la bitácora', 'historial'],
+    ['vamos al calendario', 'calendario_finca'],
+    ['ir a la bodega', 'bodega'],
+    ['quiero ver el clima', 'clima_boletin'],
+    ['abre biopreparados', 'biopreparados'],
+    ['lléveme a las gallinas', 'animales_gallinas'],
+    ['entrar a mi perfil', 'perfil'],
+    ['vamos a sembrar', 'sembrar'],
+    ['abrir mercados campesinos', 'mercados'],
+    ['muestre la salud del suelo', 'salud_suelo'],
+    ['ve a inicio', 'dashboard'],
+    ['abrir la ayuda', 'ayuda'],
+  ];
+  it.each(casos)('"%s" → navegar:%s', (frase, view) => {
+    expect(routeUtterance(frase)).toMatchObject({
+      tipo: 'navegar',
+      view,
+      etiqueta: expect.any(String),
+    });
+  });
+
+  it('frase corta que ES el destino ("el mercado") también navega', () => {
+    expect(routeUtterance('el mercado')).toMatchObject({ tipo: 'navegar', view: 'mercado' });
+    expect(routeUtterance('mapa')).toMatchObject({ tipo: 'navegar', view: 'mapa' });
+    expect(routeUtterance('a la bodega')).toMatchObject({ tipo: 'navegar', view: 'bodega' });
+  });
+});
+
+describe('routeUtterance — camino (b): preguntas y pedidos → agente', () => {
+  const casos = [
+    '¿Cuánta agua necesita el café?',
+    'qué siembro este mes',
+    'cómo está el suelo de mi finca',        // menciona "suelo" pero es pregunta
+    'cuándo cosecho la papa',
+    'por qué se me amarillan las hojas del tomate',
+    'me recomienda un biopreparado para la gota',
+    'el mercado está caro y no sé si vender ya',  // larga, no es comando
+    'dónde consigo semilla de arracacha certificada',
+    'ayúdeme con una plaga en las gallinas',
+  ];
+  it.each(casos)('"%s" → agente', (frase) => {
+    expect(routeUtterance(frase)).toMatchObject({ tipo: 'agente', prompt: frase.trim() });
+  });
+
+  it('pregunta gana aunque haya verbo de navegación', () => {
+    // "muéstrame cómo hacer compost" = pedido de explicación, no navegación
+    expect(routeUtterance('muéstrame cómo hacer compost').tipo).toBe('agente');
+  });
+
+  it('texto vacío o basura cae al agente sin explotar', () => {
+    expect(routeUtterance('').tipo).toBe('agente');
+    expect(routeUtterance('   ').tipo).toBe('agente');
+    expect(routeUtterance(null).tipo).toBe('agente');
+  });
+});
+
+describe('listarDestinos', () => {
+  it('expone view + etiqueta para cada destino', () => {
+    const destinos = listarDestinos();
+    expect(destinos.length).toBeGreaterThan(10);
+    for (const d of destinos) {
+      expect(typeof d.view).toBe('string');
+      expect(typeof d.etiqueta).toBe('string');
+    }
+  });
+});

--- a/src/services/__tests__/escuchaService.test.js
+++ b/src/services/__tests__/escuchaService.test.js
@@ -1,0 +1,48 @@
+/**
+ * Tests del trigger desacoplado de escucha: HOY lo llama el tap del FAB,
+ * MAÑANA el wake-word "hola Chagra". El contrato es el evento
+ * `chagra:escucha` en window — el overlay no sabe quién lo activó.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { activarEscucha, onEscucha, EVENTO_ESCUCHA } from '../escuchaService.js';
+
+describe('escuchaService — trigger desacoplado', () => {
+  it('activarEscucha() despacha el evento con fuente tap por defecto', () => {
+    const spy = vi.fn();
+    window.addEventListener(EVENTO_ESCUCHA, spy);
+    const ok = activarEscucha();
+    window.removeEventListener(EVENTO_ESCUCHA, spy);
+
+    expect(ok).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail.fuente).toBe('tap');
+    expect(typeof spy.mock.calls[0][0].detail.ts).toBe('number');
+  });
+
+  it('el wake-word de mañana usa el MISMO trigger con fuente wakeword', () => {
+    const recibido = [];
+    const off = onEscucha((detail) => recibido.push(detail));
+    activarEscucha({ fuente: 'wakeword' });
+    off();
+
+    expect(recibido).toHaveLength(1);
+    expect(recibido[0].fuente).toBe('wakeword');
+  });
+
+  it('onEscucha devuelve un desuscriptor que corta el flujo', () => {
+    const cb = vi.fn();
+    const off = onEscucha(cb);
+    activarEscucha();
+    off();
+    activarEscucha();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('fuente inválida degrada a tap', () => {
+    const cb = vi.fn();
+    const off = onEscucha(cb);
+    activarEscucha({ fuente: '' });
+    off();
+    expect(cb.mock.calls[0][0].fuente).toBe('tap');
+  });
+});

--- a/src/services/escuchaIntentRouter.js
+++ b/src/services/escuchaIntentRouter.js
@@ -1,0 +1,172 @@
+/**
+ * escuchaIntentRouter.js — Router PURO de la escucha manos libres.
+ *
+ * Decide qué hacer con lo que el campesino DIJO (ya transcrito por Whisper):
+ *
+ *   a) COMANDO DE NAVEGACIÓN ("lléveme a suelo", "abrir mercado", "el mapa")
+ *      → { tipo: 'navegar', view, etiqueta } — la app redirige a esa pantalla.
+ *   b) PREGUNTA / PEDIDO ("cuánta agua necesita el café", "qué siembro este
+ *      mes") → { tipo: 'agente', prompt } — va al agente (→ respuesta Kokoro).
+ *
+ * Reglas (deliberadamente conservadoras — ante la duda, AGENTE, porque el
+ * agente siempre puede responder "eso está en la pantalla X", mientras que
+ * una navegación equivocada bota al campesino a una pantalla que no pidió):
+ *
+ *   1. Palabra interrogativa (qué/cómo/cuándo/cuánto/por qué/cuál/quién/
+ *      dónde) en cualquier parte → AGENTE, aunque mencione un destino.
+ *   2. Verbo de navegación (lléveme/abra/muéstreme/vamos a/ir a/entrar a/ver)
+ *      + destino conocido → NAVEGAR.
+ *   3. Frase corta (≤ 4 palabras) que es solo un destino con artículos
+ *      ("el mercado", "mapa", "a la bodega") → NAVEGAR.
+ *   4. Todo lo demás → AGENTE.
+ *
+ * Es un módulo PURO (sin red, sin React, sin DOM): testeable en aislamiento
+ * (TDD). Los nombres de vista son los `case` reales del switch de App.jsx —
+ * si una vista se renombra allá, el test de este archivo la caza.
+ *
+ * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+
+/** Quita tildes/diéresis y baja a minúsculas para matching tolerante a Whisper. */
+export function normalizarHabla(texto) {
+  return String(texto || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[¿?¡!.,;:()"«»]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/* Destinos navegables por voz. Clave = palabra(s) normalizada(s) tal como las
+ * dice la gente; view = case real de App.jsx; etiqueta = cómo se lo decimos
+ * de vuelta ("Abriendo Mercado…"). Las claves multi-palabra se evalúan
+ * primero (más específicas ganan). */
+const DESTINOS = Object.freeze([
+  // multi-palabra primero
+  { claves: ['mercados campesinos'], view: 'mercados', etiqueta: 'Mercados campesinos' },
+  { claves: ['salud del suelo'], view: 'salud_suelo', etiqueta: 'Salud del suelo' },
+  { claves: ['registro por voz', 'registrar por voz'], view: 'voz', etiqueta: 'Registro por voz' },
+  // una palabra
+  { claves: ['suelo'], view: 'suelo', etiqueta: 'Suelo' },
+  { claves: ['mercado'], view: 'mercado', etiqueta: 'Mercado' },
+  { claves: ['mercados'], view: 'mercados', etiqueta: 'Mercados campesinos' },
+  { claves: ['mapa'], view: 'mapa', etiqueta: 'Mapa de la finca' },
+  { claves: ['bitacora', 'historial'], view: 'historial', etiqueta: 'Bitácora' },
+  { claves: ['clima', 'boletin'], view: 'clima_boletin', etiqueta: 'Clima' },
+  { claves: ['calendario'], view: 'calendario_finca', etiqueta: 'Calendario de la finca' },
+  { claves: ['semilla', 'semillas'], view: 'semilla', etiqueta: 'Semillas' },
+  { claves: ['agua'], view: 'agua', etiqueta: 'Agua' },
+  { claves: ['bodega'], view: 'bodega', etiqueta: 'Bodega' },
+  { claves: ['insumos'], view: 'insumos', etiqueta: 'Insumos' },
+  { claves: ['animales'], view: 'animales', etiqueta: 'Animales' },
+  { claves: ['gallinas'], view: 'animales_gallinas', etiqueta: 'Gallinas' },
+  { claves: ['abejas'], view: 'animales_abejas', etiqueta: 'Abejas' },
+  { claves: ['vacas'], view: 'animales_vacas', etiqueta: 'Vacas' },
+  { claves: ['biopreparados', 'biopreparado'], view: 'biopreparados', etiqueta: 'Biopreparados' },
+  { claves: ['fermentos'], view: 'fermentos', etiqueta: 'Fermentos' },
+  { claves: ['sembrar', 'siembra', 'siembras'], view: 'sembrar', etiqueta: 'Sembrar' },
+  { claves: ['cosechar', 'cosecha', 'cosechas'], view: 'cosechar', etiqueta: 'Cosechar' },
+  { claves: ['perfil'], view: 'perfil', etiqueta: 'Perfil' },
+  { claves: ['inicio', 'casa', 'portada', 'principal'], view: 'dashboard', etiqueta: 'Inicio' },
+  { claves: ['especies', 'directorio'], view: 'directorio', etiqueta: 'Directorio de especies' },
+  { claves: ['aprende', 'aprender'], view: 'aprende', etiqueta: 'Aprende' },
+  { claves: ['informes'], view: 'informes', etiqueta: 'Informes' },
+  { claves: ['tareas'], view: 'task_log', etiqueta: 'Tareas' },
+  { claves: ['ayuda', 'manual'], view: 'ayuda', etiqueta: 'Ayuda' },
+  { claves: ['juego'], view: 'juego', etiqueta: 'Juego de la finca' },
+  { claves: ['activos'], view: 'activos', etiqueta: 'Mi finca' },
+]);
+
+/* Verbos/locuciones que declaran intención de IR a un lugar de la app.
+ * Aceptamos variantes de tuteo/ustedeo E imperativos que Whisper transcribe
+ * del habla real ("llevame", "abrime") — lo que ESCUCHAMOS no se limita al
+ * dialecto con el que RESPONDEMOS. */
+const VERBOS_NAV = [
+  'llevame', 'lleveme', 'llevanos', 'llevarme',
+  'abrir', 'abre', 'abra', 'abrime', 'abrame',
+  'muestrame', 'muestreme', 'mostrar', 'muestra', 'muestre',
+  'ir a', 'ir al', 'vamos a', 'vamos al', 'vamos para', 've a', 'vaya a',
+  'entrar a', 'entra a', 'entre a', 'entremos a',
+  'quiero ver', 'quiero entrar', 'ver el', 'ver la', 'ver los', 'ver las', 'ver mi', 'ver mis',
+];
+
+/* Palabras interrogativas: si aparecen, es una PREGUNTA → agente, siempre.
+ * (normalizadas: sin tilde). */
+const INTERROGATIVAS = [
+  'que', 'como', 'cuando', 'cuanto', 'cuanta', 'cuantos', 'cuantas',
+  'por que', 'porque', 'cual', 'cuales', 'quien', 'quienes', 'donde',
+  'necesita', 'necesitan', 'sirve', 'debo', 'puedo', 'ayudame', 'ayudeme',
+  'recomienda', 'recomiendame', 'recomiendeme', 'explica', 'explicame', 'expliqueme',
+];
+
+/* Palabras "relleno" tolerables en una frase corta que es solo un destino:
+ * "a la bodega" → bodega. */
+const RELLENO = new Set(['a', 'al', 'el', 'la', 'los', 'las', 'de', 'del', 'mi', 'mis', 'un', 'una', 'chagra', 'por', 'favor']);
+
+const contieneToken = (tokens, frase) => {
+  const partes = frase.split(' ');
+  if (partes.length === 1) return tokens.includes(frase);
+  for (let i = 0; i <= tokens.length - partes.length; i++) {
+    if (partes.every((p, j) => tokens[i + j] === p)) return true;
+  }
+  return false;
+};
+
+function buscarDestino(tokens) {
+  for (const destino of DESTINOS) {
+    for (const clave of destino.claves) {
+      if (contieneToken(tokens, clave)) return destino;
+    }
+  }
+  return null;
+}
+
+/**
+ * Rutea una frase transcrita: ¿navegación o pregunta al agente?
+ *
+ * @param {string} texto - transcripción cruda de Whisper.
+ * @returns {{ tipo: 'navegar', view: string, etiqueta: string }
+ *          | { tipo: 'agente', prompt: string }}
+ * @example
+ * routeUtterance('Lléveme a suelo');        // → { tipo:'navegar', view:'suelo', … }
+ * routeUtterance('abrir mercado');           // → { tipo:'navegar', view:'mercado', … }
+ * routeUtterance('¿cuánta agua pide el café?'); // → { tipo:'agente', prompt:'…' }
+ */
+export function routeUtterance(texto) {
+  const prompt = String(texto || '').trim();
+  const norma = normalizarHabla(prompt);
+  if (!norma) return { tipo: 'agente', prompt };
+
+  const tokens = norma.split(' ');
+
+  // Regla 1: pregunta explícita → agente, sin importar qué destinos mencione.
+  if (INTERROGATIVAS.some((q) => contieneToken(tokens, q))) {
+    return { tipo: 'agente', prompt };
+  }
+
+  const destino = buscarDestino(tokens);
+  if (destino) {
+    // Regla 2: verbo de navegación + destino conocido.
+    if (VERBOS_NAV.some((v) => contieneToken(tokens, v))) {
+      return { tipo: 'navegar', view: destino.view, etiqueta: destino.etiqueta };
+    }
+    // Regla 3: la frase corta ES el destino (con artículos de relleno).
+    if (tokens.length <= 4) {
+      const soloDestino = tokens.every(
+        (t) => RELLENO.has(t) || destino.claves.some((c) => c.split(' ').includes(t)),
+      );
+      if (soloDestino) {
+        return { tipo: 'navegar', view: destino.view, etiqueta: destino.etiqueta };
+      }
+    }
+  }
+
+  // Regla 4: default — al agente (Whisper → agente → Kokoro).
+  return { tipo: 'agente', prompt };
+}
+
+/** Destinos expuestos (para el hint del widget y para tests). */
+export function listarDestinos() {
+  return DESTINOS.map((d) => ({ view: d.view, etiqueta: d.etiqueta }));
+}

--- a/src/services/escuchaService.js
+++ b/src/services/escuchaService.js
@@ -1,0 +1,72 @@
+/**
+ * escuchaService.js — Trigger DESACOPLADO del widget "Chagra está escuchando".
+ *
+ * CONTRATO (decisión operador 2026-07-05, caso de uso manos libres: guantes /
+ * manos embarradas): la activación de la escucha es UN SOLO punto de entrada,
+ * `activarEscucha()`, que HOY dispara un tap en el botón flotante (EscuchaFab)
+ * y MAÑANA disparará el wake-word ("hola Chagra", en prototipado por otro
+ * agente) SIN tocar el widget. El widget (EscuchaOverlay) solo escucha el
+ * evento — no sabe ni le importa quién lo activó.
+ *
+ * === CÓMO ENGANCHAR EL WAKE-WORD (para el agente que lo prototipa) ===
+ *
+ *   import { activarEscucha } from '../services/escuchaService';
+ *   // cuando el detector oiga "hola Chagra":
+ *   activarEscucha({ fuente: 'wakeword' });
+ *
+ * Eso es TODO. El overlay se abre, graba con el pipeline Whisper existente,
+ * rutea (navegación vs pregunta al agente) y habla la respuesta por Kokoro.
+ * La `fuente` solo cambia el copy del encabezado ("La escuché decir
+ * «hola Chagra»") y viaja en el detail para telemetría futura.
+ *
+ * Mecánica: CustomEvent en window (mismo patrón que `chagraNavigate` /
+ * `chagraToast` — cero acoplamiento entre módulos, funciona desde cualquier
+ * pantalla y desde código no-React como un worker de wake-word).
+ *
+ * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+
+/** Nombre del evento global de activación de escucha. */
+export const EVENTO_ESCUCHA = 'chagra:escucha';
+
+/**
+ * Fuentes válidas de activación. No es un enum cerrado a la fuerza (el
+ * detail viaja tal cual), pero estas son las conocidas:
+ *  - 'tap'      → botón flotante EscuchaFab (hoy).
+ *  - 'wakeword' → detector "hola Chagra" (mañana).
+ *  - 'atajo'    → teclado / accesos directos (reserva).
+ */
+export const FUENTES_ESCUCHA = Object.freeze(['tap', 'wakeword', 'atajo']);
+
+/**
+ * Activa el widget "Chagra está escuchando" desde cualquier lugar.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.fuente='tap'] - quién activó ('tap' | 'wakeword' | 'atajo').
+ * @returns {boolean} true si el evento se pudo despachar (hay window).
+ * @example
+ * activarEscucha();                        // tap del FAB
+ * activarEscucha({ fuente: 'wakeword' });  // "hola Chagra"
+ */
+export function activarEscucha(opts = {}) {
+  if (typeof window === 'undefined') return false;
+  const fuente = typeof opts.fuente === 'string' && opts.fuente ? opts.fuente : 'tap';
+  window.dispatchEvent(new CustomEvent(EVENTO_ESCUCHA, {
+    detail: { fuente, ts: Date.now() },
+  }));
+  return true;
+}
+
+/**
+ * Suscribe un listener al evento de activación de escucha.
+ * Lo usa EscuchaOverlay; también sirve para tests o instrumentación.
+ *
+ * @param {(detail: { fuente: string, ts: number }) => void} cb
+ * @returns {() => void} función para desuscribir.
+ */
+export function onEscucha(cb) {
+  if (typeof window === 'undefined') return () => {};
+  const handler = (e) => cb(e.detail || { fuente: 'tap', ts: Date.now() });
+  window.addEventListener(EVENTO_ESCUCHA, handler);
+  return () => window.removeEventListener(EVENTO_ESCUCHA, handler);
+}


### PR DESCRIPTION
## Qué es

El widget **"Chagra está escuchando"**: overlay animado que deja inequívoco que Chagra está oyendo, pensado para el caso **manos libres** (campesino con guantes / manos embarradas que no puede tocar la pantalla).

**Camino (a) — navegación:** «lléveme a suelo», «abrir mercado» → redirige a esa pantalla.
**Camino (b) — pregunta:** «¿cuánta agua necesita el café?» → agente con auto-envío y respuesta **hablada** (Whisper → agente → Kokoro, punta a punta sin tocar la pantalla).

## Trigger desacoplado (contrato para el wake-word)

La activación es UN punto de entrada — `activarEscucha()` (`src/services/escuchaService.js`), que despacha el CustomEvent `chagra:escucha`. Hoy lo llama el tap del FAB; el prototipo de wake-word "hola Chagra" solo necesita:

```js
import { activarEscucha } from '../services/escuchaService';
activarEscucha({ fuente: 'wakeword' });
```

El overlay no sabe quién lo activó (solo cambia el copy del encabezado). Cero reescritura del widget cuando llegue el wake-word.

## Diseño — "la mano que escucha"

- `ManoChagraGlyph` al centro de un **iris de micelio**: 3 anillos que respiran con el **RMS real** del micrófono + 28 brotes radiales con la historia de amplitud (datos reales del `useVoiceRecorder`, nada de animación fingida).
- **Detección de silencio** (~1.8 s callado tras hablar → cierra sola): el **arco que se va cerrando** alrededor del iris ES ese conteo — feedback honesto de manos libres.
- Botones **tamaño guante**: primario ≥72 px, ancho completo.
- Legible al sol: velo casi opaco, título extrabold `clamp(1.55–1.95rem)`, contraste AA en los 4 temas.
- Temas por **CSS-var** (`--t-accent-rgb` + tokens `--esc-*` por `data-theme`): biopunk/biopunk2, minimalista, nature, verde-vivo. `prefers-reduced-motion` respetado (queda quieto pero el estado sigue claro).
- Degradación amable: Whisper caído → audio a `pending_voice_recordings` (mismo contrato de VoiceCapture) + salida por teclado. Nunca error mudo.

## Reusa el pipeline existente (no reinventa)

- `useVoiceRecorder` (MediaRecorder + RMS + hard-limit 30 s)
- `voiceService.transcribe/queueForRetry` (Whisper local)
- `AgentScreen` + Kokoro (`speakSentences`): nuevo soporte `initialContext.autoSend + fromVoice` (activa TTS y envía solo)
- `chagraNavigate` para la redirección
- Router puro nuevo: `escuchaIntentRouter.js` (conservador: ante la duda → agente)

## Cableado (no huérfano)

- `App.jsx`: `EscuchaFab` (persistente, abajo-izquierda, oculto donde ya hay micrófono propio: agente/voz, y en login/onboarding) + `EscuchaOverlay` global.
- Nota: distinto del MicFab removido 2026-05-30 — aquel solo grababa; este navega o pregunta punta a punta (decisión operador 2026-07-05).

## Verificación

- ✅ 40 tests nuevos verdes (router 28 · trigger 4 · overlay+FAB 8): `npx vitest run src/services/__tests__/escuchaIntentRouter.test.js src/services/__tests__/escuchaService.test.js src/components/escucha/__tests__/EscuchaOverlay.test.jsx`
- ✅ `npm run build` verde · `eslint` limpio · `tsc:check` sin errores en archivos nuevos
- ✅ Capturas headless (mic fake de Chromium → amplitud real) con `scripts/escucha-shots.mjs` en biopunk/nature/minimalista — se adjuntan al hilo
- ⚠️ Visual: espera OK del operador antes de merge (política visuales)

🤖 Generated with [Claude Code](https://claude.com/claude-code)