### PR TITLE
feat(directorio): ficha de especie referenciada (via sidecar)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -154,6 +154,7 @@ const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
 const AprenderConAgente = lazy(() => import('./components/Aprende/AprenderConAgente'));
 const DirectorioEspeciesScreen = lazy(() => import('./components/DirectorioEspecies/DirectorioEspeciesScreen'));
+const EspecieFichaScreen = lazy(() => import('./components/DirectorioEspecies/EspecieFichaScreen'));
 const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
 const MiFincaEvolucionScreen = lazy(() => import('./components/hoy/MiFincaEvolucionScreen'));
 const MiFincaVivaScreen = lazy(() => import('./components/juego/MiFincaVivaScreen'));
@@ -265,8 +266,25 @@ const MODULE_VIEWS = new Set([
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'nutricion', 'toxicologia', 'aprende', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
-  'usage_stats', 'mercado', 'auditoria_inventario', 'mundo',
+  'usage_stats', 'mercado', 'auditoria_inventario', 'mundo', 'especie',
 ]);
+
+/**
+ * Ruta paramétrica de la Ficha de Especie: `#especie/<id>` (también `#especie-<id>`).
+ * Devuelve el id snake_case del catálogo o null. El hash ya viene minusculado y
+ * sin el prefijo `#/`; los ids del catálogo son lowercase snake_case, así que no
+ * se pierde información. Es la superficie de deep-link a la que apuntan el agente,
+ * el navegador del grafo y los cultivos (`window.location.hash = '#especie/<id>'`).
+ *
+ * @param {string} hash
+ * @returns {string | null}
+ */
+function parseEspecieHash(hash) {
+  const m = /^especie[/-](.+)$/.exec(hash || '');
+  if (!m) return null;
+  const id = m[1].replace(/^\/+/, '').trim();
+  return id || null;
+}
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
 // useAssetStore() (hook) dispara re-render cuando hydrate()/syncFromServer() actualizan
@@ -539,6 +557,13 @@ export default function App() {
         navigate('login');
         return;
       }
+      // Deep-link a la Ficha de Especie (#especie/<id>): ruta paramétrica que no
+      // vive en HASH_VIEW_ROUTES. Va ANTES del fallback a dashboard.
+      const bootEspecieId = parseEspecieHash(hash);
+      if (bootEspecieId) {
+        navigate('especie', { speciesId: bootEspecieId });
+        return;
+      }
       const targetView = HASH_VIEW_ROUTES[hash] || 'dashboard';
       // Gate de acceso: el módulo glaciar es solo para los beta testers de "La
       // Cordada". Si un usuario fuera de la whitelist aterriza en #glaciar,
@@ -560,6 +585,14 @@ export default function App() {
   useEffect(() => {
     const handleHashRoute = () => {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
+      // Deep-link paramétrico a la Ficha de Especie (#especie/<id>).
+      const especieId = parseEspecieHash(hash);
+      if (especieId) {
+        isAuthenticated().then((isAuth) => {
+          if (isAuth) navigate('especie', { speciesId: especieId });
+        });
+        return;
+      }
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
@@ -1491,6 +1524,24 @@ export default function App() {
               <DirectorioEspeciesScreen
                 onBack={() => navigate('dashboard')}
                 initialQuery={currentViewData?.query || ''}
+                onOpenEspecie={(id) => navigate('especie', { speciesId: id })}
+              />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'especie':
+        // Ficha de Especie REFERENCIADA (#2049): pantalla de detalle photo-forward
+        // de cualquier especie del catálogo, con la base offline enriquecida en
+        // vivo por el sidecar (toxicidad, saberes, variedades, suelo, cadenas).
+        // Se llega por #especie/<id> (deep-link del agente / navegador del grafo /
+        // cultivos) o desde el Directorio. Vuelve al Directorio.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Ficha de especie">
+              <EspecieFichaScreen
+                speciesId={currentViewData?.speciesId || ''}
+                onBack={() => navigate('directorio')}
+                onSelectSpecies={(id) => navigate('especie', { speciesId: id })}
               />
             </ErrorFallback>
           </ErrorBoundary>

--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -23,8 +23,12 @@ import { fvhSkinClass } from '../../config/fvhSkin.js';
  * @param {object} props
  * @param {() => void} [props.onBack]
  * @param {string} [props.initialQuery] - consulta inicial (ej. deep-link).
+ * @param {(id: string) => void} [props.onOpenEspecie] - abre la Ficha de Especie
+ *   referenciada (#especie/<id>): la ficha canónica, enriquecida en vivo por el
+ *   sidecar. Cuando se provee, tocar un resultado navega a ella; si no (p. ej. en
+ *   tests), cae al render inline de la ficha del catálogo (offline).
  */
-export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) {
+export default function DirectorioEspeciesScreen({ onBack, initialQuery = '', onOpenEspecie }) {
   const [query, setQuery] = useState(initialQuery);
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
@@ -59,6 +63,9 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
   }, [query, runSearch, selected]);
 
   const selectSpecies = useCallback(async (id) => {
+    // Ruta canónica: abrir la Ficha de Especie referenciada (sidecar-live).
+    if (typeof onOpenEspecie === 'function') { onOpenEspecie(id); return; }
+    // Fallback (sin router inyectado): ficha del catálogo inline (offline).
     setLoadingFicha(true);
     try {
       const ficha = await buildSpeciesFicha(id);
@@ -69,7 +76,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
     } finally {
       setLoadingFicha(false);
     }
-  }, []);
+  }, [onOpenEspecie]);
 
   // Si un solo candidato exacto, abrir directo al presionar Enter.
   const onSubmit = useCallback(

--- a/src/components/DirectorioEspecies/EspecieFichaScreen.jsx
+++ b/src/components/DirectorioEspecies/EspecieFichaScreen.jsx
@@ -1,0 +1,441 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  ChevronLeft, Leaf, ShieldCheck, ShieldAlert, BookOpen, Layers, Mountain,
+  Share2, Radio, WifiOff, RefreshCw, Sprout, Loader2,
+} from 'lucide-react';
+import SpeciesFicha from './SpeciesFicha.jsx';
+import PedagogicalText from '../common/PedagogicalText.jsx';
+import ChagraGrowLoader from '../ChagraGrowLoader.jsx';
+import { fvhSkinClass } from '../../config/fvhSkin.js';
+import {
+  buildSpeciesFicha,
+  LIVE_KNOWLEDGE_SECTIONS,
+  isLiveGraphAvailable,
+  fetchKnowledgeSection,
+  fetchSpeciesConfirm,
+  fetchLiveCompanions,
+  fetchPestControllers,
+  mergeCompanions,
+  mergeControllers,
+} from '../../services/especieFichaSidecar.js';
+
+/**
+ * EspecieFichaScreen — la Ficha de Especie REFERENCIADA (#2049), pantalla de
+ * DETALLE photo-forward de cualquier especie del catálogo (~700), a la que se
+ * llega por `#especie/<id>` desde el agente, el navegador del grafo o cultivos.
+ *
+ * Arquitectura: la ficha del catálogo (offline, `buildSpeciesFicha`) pinta al
+ * instante — foto + identidad + piso térmico + ciclo + asociaciones/sanidad. En
+ * paralelo, la ficha se ENRIQUECE en VIVO consultando el sidecar agro-mcp (las
+ * mismas tools del agente): asocios frescos, controladores por plaga, y las
+ * capas de conocimiento que la base no tiene (toxicidad, saberes, variedades,
+ * suelo, cadenas multi-salto). Cada capa viva pinta su propio skeleton para no
+ * congelar la ficha, y si el sidecar no responde, la base del catálogo la cubre.
+ *
+ * Reglas: superficie oscura opaca (legible al sol, WCAG AA en los 4 temas),
+ * animaciones que respetan `prefers-reduced-motion`, y deflección honesta —
+ * NUNCA se inventa un dato que el grafo no tiene.
+ *
+ * @param {object} props
+ * @param {string} props.speciesId — id snake_case canónico del catálogo.
+ * @param {() => void} [props.onBack]
+ * @param {(id: string) => void} [props.onSelectSpecies] - navegar a otra especie.
+ */
+export default function EspecieFichaScreen({ speciesId, onBack, onSelectSpecies }) {
+  const [phase, setPhase] = useState('loading'); // 'loading' | 'ready' | 'notfound'
+  const [ficha, setFicha] = useState(null);
+  const [liveMode, setLiveMode] = useState(false);
+  const [confirm, setConfirm] = useState(null); // { speciesName, viabilidad } | null
+  const [confirming, setConfirming] = useState(false);
+  const [sections, setSections] = useState({}); // kind → { status, bloque, nota }
+  const tokenRef = useRef(0);
+
+  // Navegación entre especies: si el caller no la provee, caemos al hash router.
+  const goToEspecie = useCallback(
+    (id) => {
+      if (!id) return;
+      if (typeof onSelectSpecies === 'function') onSelectSpecies(id);
+      else if (typeof window !== 'undefined') window.location.hash = `#especie/${id}`;
+    },
+    [onSelectSpecies],
+  );
+
+  // Dispara las capas VIVAS del grafo (extraído para el botón "reintentar").
+  const runLive = useCallback((id, baseFicha, token) => {
+    // Confirmación viva (get_species) → sello de cabecera.
+    setConfirming(true);
+    fetchSpeciesConfirm(id)
+      .then((c) => { if (tokenRef.current === token) setConfirm(c); })
+      .finally(() => { if (tokenRef.current === token) setConfirming(false); });
+
+    // Asocios vivos (get_companions) → merge en la ficha base.
+    fetchLiveCompanions(id).then((live) => {
+      if (tokenRef.current !== token || !live) return;
+      setFicha((prev) => (prev ? mergeCompanions(prev, live) : prev));
+    });
+
+    // Controladores vivos (get_pest_controllers) por cada plaga de la base
+    // (acotado a 3 llamadas para no saturar el sidecar).
+    const amenazas = Array.isArray(baseFicha?.amenazas) ? baseFicha.amenazas : [];
+    amenazas.slice(0, 3).forEach((a, idx) => {
+      if (!a?.nombre) return;
+      fetchPestControllers(a.nombre).then((ctrls) => {
+        if (tokenRef.current !== token || !ctrls.length) return;
+        setFicha((prev) => (prev ? mergeControllers(prev, idx, ctrls) : prev));
+      });
+    });
+
+    // Capas de conocimiento (bloques grounded) — cada una con su skeleton.
+    setSections(() => {
+      const init = {};
+      for (const s of LIVE_KNOWLEDGE_SECTIONS) init[s.kind] = { status: 'loading' };
+      return init;
+    });
+    for (const s of LIVE_KNOWLEDGE_SECTIONS) {
+      fetchKnowledgeSection(s.tool, id).then((res) => {
+        if (tokenRef.current !== token) return;
+        setSections((prev) => ({ ...prev, [s.kind]: res }));
+      });
+    }
+  }, []);
+
+  // Carga la base offline + dispara el grafo vivo cuando cambia la especie.
+  useEffect(() => {
+    const token = ++tokenRef.current;
+    setPhase('loading');
+    setFicha(null);
+    setConfirm(null);
+    setSections({});
+    if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'auto' });
+
+    if (!speciesId) { setPhase('notfound'); return; }
+
+    let cancelled = false;
+    (async () => {
+      let base = null;
+      try {
+        base = await buildSpeciesFicha(speciesId);
+      } catch (_) {
+        base = null;
+      }
+      if (cancelled || tokenRef.current !== token) return;
+      if (!base) { setPhase('notfound'); return; }
+
+      setFicha(base);
+      setPhase('ready');
+
+      const live = isLiveGraphAvailable();
+      setLiveMode(live);
+      if (live) runLive(speciesId, base, token);
+    })();
+
+    return () => { cancelled = true; };
+  }, [speciesId, runLive]);
+
+  const retryLive = useCallback(() => {
+    if (!speciesId || !ficha) return;
+    const token = ++tokenRef.current;
+    setLiveMode(isLiveGraphAvailable());
+    runLive(speciesId, ficha, token);
+  }, [speciesId, ficha, runLive]);
+
+  // ---- ESTADO: cargando la base ------------------------------------------
+  if (phase === 'loading') {
+    return (
+      <ShellDark>
+        <FichaTopBar onBack={onBack} title="Abriendo la ficha…" subtitle={speciesId} pill={<LivePill state="loading" />} />
+        <div className="px-4 pt-3" data-testid="especie-loading">
+          <div className="flex flex-col items-center justify-center py-10 text-center">
+            <ChagraGrowLoader size={54} ariaLabel="Abriendo la ficha de la especie" />
+            <p className="mt-3 text-sm text-emerald-200/80">Buscando en el catálogo…</p>
+          </div>
+          <FichaSkeleton />
+        </div>
+      </ShellDark>
+    );
+  }
+
+  // ---- ESTADO: no existe en el catálogo ----------------------------------
+  if (phase === 'notfound' || !ficha) {
+    return (
+      <ShellDark>
+        <FichaTopBar onBack={onBack} title="Especie no encontrada" />
+        <div className="px-4 pt-10" data-testid="especie-notfound">
+          <div className="mx-auto max-w-md rounded-2xl border border-slate-800 bg-slate-900/70 p-6 text-center">
+            <Sprout size={34} className="mx-auto text-emerald-400/80" aria-hidden="true" />
+            <h2 className="mt-3 text-lg font-bold text-slate-100">Esta especie no está en el catálogo todavía.</h2>
+            <p className="mt-1.5 text-sm text-slate-400 leading-relaxed">
+              El identificador <code className="rounded bg-slate-800 px-1.5 py-0.5 text-emerald-200">{speciesId || '—'}</code>{' '}
+              no corresponde a ninguna ficha. Búscala por nombre común o científico en el directorio.
+            </p>
+            <button
+              type="button"
+              onClick={onBack}
+              className="mt-5 inline-flex min-h-[44px] items-center gap-2 rounded-xl border border-emerald-600/50 bg-emerald-900/40 px-4 text-sm font-bold text-emerald-100 hover:bg-emerald-800/50"
+            >
+              <ChevronLeft size={18} /> Volver
+            </button>
+          </div>
+        </div>
+      </ShellDark>
+    );
+  }
+
+  // ---- ESTADO: ficha lista (base + enriquecimiento vivo) -----------------
+  return (
+    <ShellDark>
+      <FichaTopBar
+        onBack={onBack}
+        title={ficha.comun}
+        subtitle={ficha.cientifico}
+        pill={<LivePill state={liveMode ? (confirming ? 'loading' : (confirm ? 'live' : 'idle')) : 'offline'} viabilidad={confirm?.viabilidad} onRetry={liveMode ? null : undefined} />}
+      />
+
+      <SpeciesFicha ficha={ficha} onSelectSpecies={goToEspecie} />
+
+      {/* REGIÓN VIVA — conocimiento que solo aporta el grafo del sidecar */}
+      <LiveKnowledgeRegion
+        liveMode={liveMode}
+        sections={sections}
+        onRetry={retryLive}
+      />
+
+      <p className="px-4 pt-8 pb-12 text-center text-[11px] text-slate-600 leading-relaxed">
+        Ficha del catálogo Chagra, enriquecida en vivo desde el grafo de conocimiento.
+        <br />Donde el grafo no tiene el dato, no se inventa nada.
+      </p>
+    </ShellDark>
+  );
+}
+
+/* --------------------------------------------------------------- estructura */
+
+function ShellDark({ children }) {
+  // Fondo sólido oscuro: garantiza contraste AA aunque el tema activo sea claro
+  // (crema/durazno) — legible al sol.
+  return (
+    <div className={fvhSkinClass('jp-especie-ficha min-h-[100dvh] bg-slate-950 text-white')}>
+      {children}
+    </div>
+  );
+}
+
+function FichaTopBar({ onBack, title, subtitle, pill }) {
+  return (
+    <header className="sticky top-0 z-10 flex items-center gap-2 border-b border-slate-800/60 bg-slate-950/85 px-3 pt-[calc(12px+env(safe-area-inset-top))] pb-2 backdrop-blur">
+      {onBack && (
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Volver"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-slate-800 hover:bg-slate-700"
+        >
+          <ChevronLeft size={20} />
+        </button>
+      )}
+      <div className="flex min-w-0 items-center gap-2">
+        <Leaf size={20} className="shrink-0 text-emerald-400" aria-hidden="true" />
+        <div className="min-w-0">
+          <h1 className="jp-tinta truncate text-base font-bold leading-tight text-white">{title}</h1>
+          {subtitle && (
+            <p className="jp-tinta-suave truncate text-xs italic leading-tight text-slate-400">{subtitle}</p>
+          )}
+        </div>
+      </div>
+      {pill && <div className="ml-auto shrink-0">{pill}</div>}
+    </header>
+  );
+}
+
+/**
+ * Sello de estado del grafo vivo (la costura de confianza de la cabecera).
+ *  - 'live'    → verde, confirmado por el grafo (con viabilidad si la trae).
+ *  - 'loading' → consultando el grafo (spinner discreto).
+ *  - 'idle'    → grafo activo pero sin confirmación estructurada; neutro.
+ *  - 'offline' → catálogo (grafo vivo inactivo).
+ */
+function LivePill({ state, viabilidad }) {
+  if (state === 'offline') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-slate-700/60 bg-slate-900/70 px-2.5 py-1 text-[10px] font-bold text-slate-300" title="Grafo vivo inactivo — se muestra la ficha del catálogo.">
+        <WifiOff size={11} aria-hidden="true" /> Catálogo
+      </span>
+    );
+  }
+  if (state === 'loading') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-700/50 bg-emerald-950/50 px-2.5 py-1 text-[10px] font-bold text-emerald-200">
+        <Loader2 size={11} className="animate-spin motion-reduce:animate-none" aria-hidden="true" /> Grafo…
+      </span>
+    );
+  }
+  const via = typeof viabilidad === 'string' ? viabilidad.toLowerCase() : '';
+  const viaLabel = via === 'viable' ? 'viable' : via === 'marginal' ? 'marginal' : via === 'inviable' ? 'no viable' : '';
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full border border-emerald-600/50 bg-emerald-500/15 px-2.5 py-1 text-[10px] font-bold text-emerald-200"
+      title="Datos confirmados en vivo por el grafo de conocimiento."
+    >
+      <Radio size={11} aria-hidden="true" /> Grafo vivo{viaLabel ? ` · ${viaLabel}` : ''}
+    </span>
+  );
+}
+
+/* ------------------------------------------------------------- región viva */
+
+const ACCENT = {
+  rose: { bar: 'from-rose-400 to-pink-400', icon: 'text-rose-300', card: 'border-rose-800/40 bg-rose-950/20' },
+  indigo: { bar: 'from-indigo-400 to-violet-400', icon: 'text-indigo-300', card: 'border-indigo-800/30 bg-indigo-950/20' },
+  teal: { bar: 'from-teal-400 to-cyan-400', icon: 'text-teal-300', card: 'border-teal-700/40 bg-teal-950/25' },
+  amber: { bar: 'from-amber-400 to-orange-400', icon: 'text-amber-300', card: 'border-amber-700/40 bg-amber-950/20' },
+  emerald: { bar: 'from-emerald-400 to-teal-400', icon: 'text-emerald-300', card: 'border-emerald-800/40 bg-emerald-950/25' },
+};
+
+const SECTION_ICON = {
+  toxicidad: ShieldAlert,
+  saberes: BookOpen,
+  variedades: Layers,
+  suelo: Mountain,
+  multihop: Share2,
+};
+
+/**
+ * Región de conocimiento vivo. Muestra las capas del grafo que la base offline
+ * no tiene. Estados: skeleton mientras carga; card grounded cuando hay dato;
+ * y agrupa (compactas) las ausencias honestas y los errores para no meter ruido.
+ */
+function LiveKnowledgeRegion({ liveMode, sections, onRetry }) {
+  // Fallback offline elegante: si el grafo vivo está inactivo, una sola nota.
+  if (!liveMode) {
+    return (
+      <section className="px-4 pt-6" data-testid="especie-live-offline">
+        <div className="flex items-start gap-2.5 rounded-xl border border-slate-800 bg-slate-900/60 p-3.5">
+          <WifiOff size={16} className="mt-0.5 shrink-0 text-slate-400" aria-hidden="true" />
+          <p className="text-xs leading-relaxed text-slate-400">
+            <span className="font-bold text-slate-300">Grafo vivo inactivo.</span> Estás viendo la ficha
+            del catálogo (funciona sin conexión). Cuando el grafo esté disponible, esta ficha suma
+            toxicidad, saberes, variedades, suelo y cadenas ecológicas en vivo.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const ready = [];
+  const loading = [];
+  const empty = [];
+  const errored = [];
+  for (const cfg of LIVE_KNOWLEDGE_SECTIONS) {
+    const st = sections[cfg.kind]?.status || 'loading';
+    if (st === 'ready') ready.push(cfg);
+    else if (st === 'empty') empty.push(cfg);
+    else if (st === 'error') errored.push(cfg);
+    else loading.push(cfg); // 'loading' | 'offline' (transitorio)
+  }
+
+  return (
+    <section className="px-4 pt-7" data-testid="especie-live-region">
+      <h3 className="mb-1 flex items-center gap-2 text-xs font-black uppercase tracking-wider text-slate-300">
+        <span aria-hidden="true" className="h-3.5 w-1 rounded-full bg-gradient-to-b from-emerald-400 to-teal-400" />
+        <Radio size={15} className="text-emerald-300" aria-hidden="true" />
+        Del grafo de conocimiento, en vivo
+      </h3>
+      <p className="mb-3 text-[11px] leading-relaxed text-slate-500">
+        Consultado en el momento al sidecar del proyecto — las mismas fuentes que usa el agente.
+      </p>
+
+      <div className="space-y-4">
+        {loading.map((cfg) => (
+          <KnowledgeSkeleton key={cfg.kind} cfg={cfg} />
+        ))}
+        {ready.map((cfg) => (
+          <KnowledgeCard key={cfg.kind} cfg={cfg} data={sections[cfg.kind]} />
+        ))}
+      </div>
+
+      {empty.length > 0 && (
+        <p className="mt-4 text-[11px] leading-relaxed text-slate-500" data-testid="especie-live-empty">
+          <span className="font-bold text-slate-400">Todavía sin datos en el grafo:</span>{' '}
+          {empty.map((c) => c.title.toLowerCase()).join(' · ')}.
+        </p>
+      )}
+
+      {errored.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-slate-500" data-testid="especie-live-error">
+          <span>No se pudo consultar el grafo para: {errored.map((c) => c.title.toLowerCase()).join(' · ')}.</span>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex min-h-[32px] items-center gap-1 rounded-lg border border-slate-700 bg-slate-900 px-2.5 text-slate-300 hover:bg-slate-800"
+          >
+            <RefreshCw size={12} aria-hidden="true" /> Reintentar
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function KnowledgeCard({ cfg, data }) {
+  const acc = ACCENT[cfg.accent] || ACCENT.emerald;
+  const Icon = SECTION_ICON[cfg.kind] || BookOpen;
+  const bloque = data?.bloque || '';
+  const tone = cfg.kind === 'saberes' || cfg.kind === 'multihop' ? 'indigo' : 'slate';
+  return (
+    <div data-testid={`especie-live-${cfg.kind}`}>
+      <h4 className="mb-2 flex items-center gap-2 text-xs font-black uppercase tracking-wider text-slate-300">
+        <span aria-hidden="true" className={`h-3.5 w-1 rounded-full bg-gradient-to-b ${acc.bar}`} />
+        <Icon size={15} className={acc.icon} aria-hidden="true" />
+        {cfg.title}
+      </h4>
+      <div className={`rounded-xl border p-3.5 ${acc.card}`}>
+        {bloque ? (
+          <PedagogicalText texto={bloque} tone={tone} testId={`especie-live-${cfg.kind}-body`} />
+        ) : (
+          <p className="text-sm italic text-slate-400">{cfg.emptyText}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function KnowledgeSkeleton({ cfg }) {
+  const acc = ACCENT[cfg.accent] || ACCENT.emerald;
+  const Icon = SECTION_ICON[cfg.kind] || BookOpen;
+  return (
+    <div data-testid={`especie-live-${cfg.kind}-skeleton`} role="status" aria-busy="true">
+      <h4 className="mb-2 flex items-center gap-2 text-xs font-black uppercase tracking-wider text-slate-400">
+        <span aria-hidden="true" className={`h-3.5 w-1 rounded-full bg-gradient-to-b ${acc.bar}`} />
+        <Icon size={15} className={acc.icon} aria-hidden="true" />
+        {cfg.title}
+        <span className="ml-1 inline-flex items-center gap-1 text-[10px] font-semibold normal-case tracking-normal text-emerald-300/70">
+          <Loader2 size={10} className="animate-spin motion-reduce:animate-none" aria-hidden="true" /> consultando el grafo…
+        </span>
+      </h4>
+      <div className="space-y-2 rounded-xl border border-slate-800 bg-slate-900/50 p-3.5">
+        <ShimmerLine w="w-3/4" />
+        <ShimmerLine w="w-full" />
+        <ShimmerLine w="w-5/6" />
+      </div>
+    </div>
+  );
+}
+
+function FichaSkeleton() {
+  return (
+    <div className="mt-2 space-y-3" role="status" aria-busy="true" data-testid="especie-ficha-skeleton">
+      <div className="aspect-[16/10] w-full animate-pulse rounded-2xl bg-slate-800/60 motion-reduce:animate-none" />
+      <ShimmerLine w="w-1/2" h="h-5" />
+      <ShimmerLine w="w-2/3" />
+      <div className="grid grid-cols-2 gap-2 pt-1">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="h-16 animate-pulse rounded-xl bg-slate-800/50 motion-reduce:animate-none" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ShimmerLine({ w = 'w-full', h = 'h-3.5' }) {
+  return <div className={`${h} ${w} animate-pulse rounded bg-slate-700/50 motion-reduce:animate-none`} aria-hidden="true" />;
+}

--- a/src/services/especieFichaSidecar.js
+++ b/src/services/especieFichaSidecar.js
@@ -1,0 +1,353 @@
+/**
+ * especieFichaSidecar.js — capa VIVA de la Ficha de Especie (#2049).
+ *
+ * La ficha del catálogo (`buildSpeciesFicha`, offline-first) es el CIMIENTO:
+ * identidad + foto + piso térmico + ciclo + asociaciones/sanidad exportadas del
+ * grafo. Esta capa la ENRIQUECE en vivo consultando el sidecar agro-mcp (las
+ * mismas 30 tools que usa el agente), sin pedir un JSON gigante de 700 especies:
+ *
+ *   - get_companions          → asocios frescos del grafo AGE (merge en la base)
+ *   - get_pest_controllers    → controladores por plaga (merge en sanidad)
+ *   - get_species             → confirmación viva del grafo (binomio/viabilidad)
+ *   - get_toxicidad           → perfil de toxicidad y seguridad (bloque grounded)
+ *   - get_saberes             → usos/saberes tradicionales (bloque, con descargo)
+ *   - get_variedades          → variedades/cultivares registrados (bloque)
+ *   - get_suelo               → requerimientos de suelo/nutrición (bloque)
+ *   - get_multihop_companions → cadenas ecológicas funcionales N-salto (bloque)
+ *
+ * Reglas (idénticas a las del agente):
+ * - Offline-first: si la flag del sidecar está apagada o no hay red, `callTool`
+ *   devuelve `null` de inmediato → la sección queda en estado `offline` y la base
+ *   del catálogo cubre la ficha. NUNCA se cuelga un skeleton eterno.
+ * - Nunca inventa: `found:false` es evidencia útil (deflección honesta). Un error
+ *   de red degrada esa sección con gracia; el resto de la ficha sigue viva.
+ * - Nunca lanza: todo error se atrapa y se traduce a un estado observable.
+ *
+ * El componente dispara cada sección por separado para pintar su propio skeleton
+ * y no bloquear a las demás (latencia = max, no sum).
+ */
+
+import { callTool, isSidecarEnabled } from './sidecarClient.js';
+import { buildSpeciesFicha } from './directorioEspecies.js';
+
+/**
+ * Secciones de CONOCIMIENTO que solo aporta el grafo vivo (la base offline no
+ * las tiene). Cada una consulta una tool y renderiza su `bloque` grounded.
+ * El orden es intencional: seguridad (toxicidad) primero.
+ */
+export const LIVE_KNOWLEDGE_SECTIONS = [
+  {
+    kind: 'toxicidad',
+    tool: 'get_toxicidad',
+    title: 'Toxicidad y seguridad',
+    accent: 'rose',
+    emptyText: 'El grafo no registra alerta de toxicidad para esta especie todavía.',
+  },
+  {
+    kind: 'saberes',
+    tool: 'get_saberes',
+    title: 'Usos y saberes tradicionales',
+    accent: 'indigo',
+    emptyText: 'Sin usos tradicionales documentados en el grafo todavía.',
+  },
+  {
+    kind: 'variedades',
+    tool: 'get_variedades',
+    title: 'Variedades y cultivares',
+    accent: 'teal',
+    emptyText: 'Sin variedades registradas en el grafo para esta especie todavía.',
+  },
+  {
+    kind: 'suelo',
+    tool: 'get_suelo',
+    title: 'Suelo y nutrición',
+    accent: 'amber',
+    emptyText: 'Sin requerimientos de suelo documentados en el grafo todavía.',
+  },
+  {
+    kind: 'multihop',
+    tool: 'get_multihop_companions',
+    title: 'Cadenas ecológicas (multi-salto)',
+    accent: 'emerald',
+    emptyText: 'Sin cadenas de asociación multi-salto en el grafo todavía.',
+  },
+];
+
+/** Args por tool. Se pasan varias claves conocidas para robustez de ruteo. */
+function argsFor(tool, speciesId) {
+  switch (tool) {
+    case 'get_multihop_companions':
+      // El agente la invoca con `cultivo`; incluimos alias por robustez.
+      return { cultivo: speciesId, species_id: speciesId, species_id_or_name: speciesId };
+    case 'get_companions':
+      return { species_id: speciesId, species_id_or_name: speciesId };
+    default:
+      // Tools de conocimiento del grafo (toxicidad/saberes/variedades/suelo).
+      return { species_id_or_name: speciesId, species_id: speciesId };
+  }
+}
+
+/**
+ * ¿Tiene sentido intentar el grafo vivo? (flag encendida + navegador online).
+ * Si es false, el componente ni siquiera dispara las tools: marca todo `offline`
+ * al instante y se apoya en la base del catálogo.
+ *
+ * @returns {boolean}
+ */
+export function isLiveGraphAvailable() {
+  if (!isSidecarEnabled()) return false;
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) return false;
+  return true;
+}
+
+/**
+ * Clasifica el resultado crudo de `callTool` en un estado observable de UI.
+ *
+ * Contrato de `callTool`:
+ *   - `null`                → flag off / offline / no intentado  → 'offline'
+ *   - `{ _error, reason }`  → intentado pero falló (red/timeout) → 'error'
+ *   - `{ available:false }` → grafo caído (graceful)             → 'error'
+ *   - `{ found:false, ... }`→ ausencia GROUNDED (no inventa)     → 'empty'
+ *   - resto                 → dato útil                          → 'ready'
+ *
+ * @param {any} result
+ * @returns {{ status: 'offline'|'error'|'empty'|'ready', bloque?: string, nota?: string, raw?: object }}
+ */
+export function classifySidecarResult(result) {
+  if (result == null) return { status: 'offline' };
+  if (typeof result !== 'object') return { status: 'error' };
+  if (result._error) return { status: 'error', reason: result.reason };
+  if (result.available === false) return { status: 'error', reason: 'unavailable' };
+
+  const bloque = typeof result.bloque === 'string' ? result.bloque.trim() : '';
+  const nota = typeof result.nota === 'string' ? result.nota.trim() : '';
+
+  if (result.found === false) {
+    // La ausencia trae su propia nota anti-invención cuando existe.
+    return { status: 'empty', nota: nota || bloque };
+  }
+  // Sin `bloque` ni señales estructuradas útiles → trátalo como vacío honesto.
+  if (!bloque && !hasStructuredPayload(result)) {
+    return { status: 'empty', nota };
+  }
+  return { status: 'ready', bloque, raw: result };
+}
+
+/** ¿El resultado trae alguna carga estructurada útil (más allá del bloque)? */
+function hasStructuredPayload(result) {
+  const keys = ['companions', 'antagonists', 'controls', 'controladores', 'cadenas', 'variedades', 'usos'];
+  return keys.some((k) => Array.isArray(result[k]) && result[k].length > 0);
+}
+
+/**
+ * Dispara UNA sección de conocimiento del grafo. Nunca lanza.
+ *
+ * @param {string} tool — nombre de la tool del sidecar.
+ * @param {string} speciesId
+ * @returns {Promise<{ status, bloque?, nota?, raw? }>}
+ */
+export async function fetchKnowledgeSection(tool, speciesId) {
+  if (!tool || !speciesId) return { status: 'error' };
+  if (!isLiveGraphAvailable()) return { status: 'offline' };
+  let result = null;
+  try {
+    result = await callTool(tool, argsFor(tool, speciesId));
+  } catch (_) {
+    return { status: 'error' };
+  }
+  return classifySidecarResult(result);
+}
+
+/* ------------------------------------------------- enriquecimiento estructural */
+
+const norm = (s) =>
+  String(s || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+function humanizeId(id) {
+  return String(id || '')
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+
+/** Nombre visible de un nodo-especie del grafo (defensivo ante shapes). */
+function graphSpeciesLabel(o) {
+  if (!o || typeof o !== 'object') return null;
+  const id = o.species_id || o.slug || o.id || '';
+  const comun = o.nombre_comun || o.name_es || o.comun || o.name || o.nombre || (id ? humanizeId(id) : '');
+  if (!id && !comun) return null;
+  return {
+    id: id || norm(comun).replace(/\s+/g, '_'),
+    comun: comun || humanizeId(id),
+    cientifico: o.nombre_cientifico || o.name_la || o.cientifico || '',
+    enCatalogo: Boolean(o.en_catalogo ?? o.enCatalogo ?? o.in_catalog ?? false),
+    fromGraph: true,
+  };
+}
+
+/**
+ * Normaliza la respuesta de `get_companions` a listas de asocios del grafo vivo.
+ *
+ * @param {any} res
+ * @returns {{ compatibles: object[], antagonistas: object[] } | null}
+ */
+export function normalizeCompanions(res) {
+  if (!res || typeof res !== 'object' || res._error || res.available === false) return null;
+  const comp = Array.isArray(res.companions) ? res.companions : [];
+  const ant = Array.isArray(res.antagonists) ? res.antagonists : [];
+  const compatibles = comp.map(graphSpeciesLabel).filter(Boolean);
+  const antagonistas = ant.map(graphSpeciesLabel).filter(Boolean);
+  if (compatibles.length === 0 && antagonistas.length === 0) return null;
+  return { compatibles, antagonistas };
+}
+
+/**
+ * Normaliza la respuesta de `get_pest_controllers` a una lista de controladores
+ * (defensiva: los items pueden venir como string o como objeto).
+ *
+ * @param {any} res
+ * @returns {string[]}
+ */
+export function normalizeControllers(res) {
+  if (!res || typeof res !== 'object' || res._error || res.available === false) return [];
+  const raw = Array.isArray(res.controls) ? res.controls
+    : Array.isArray(res.controladores) ? res.controladores
+    : [];
+  const out = [];
+  for (const c of raw) {
+    if (typeof c === 'string' && c.trim()) out.push(c.trim());
+    else if (c && typeof c === 'object') {
+      const n = c.nombre || c.name || c.comun || c.especie || c.controlador || '';
+      if (n) out.push(String(n));
+    }
+  }
+  return [...new Set(out)];
+}
+
+/**
+ * Fusiona los asocios vivos del grafo dentro de la ficha base (dedupe por
+ * id/nombre normalizado). Devuelve una NUEVA ficha; no muta la original.
+ *
+ * @param {object} ficha — salida de buildSpeciesFicha.
+ * @param {{ compatibles: object[], antagonistas: object[] } | null} live
+ * @returns {object}
+ */
+export function mergeCompanions(ficha, live) {
+  if (!ficha || !live) return ficha;
+  const base = ficha.asociaciones || { compatibles: [], antagonistas: [] };
+  const merge = (existing, incoming) => {
+    const seen = new Set((existing || []).map((x) => norm(x.id) || norm(x.comun)));
+    const extra = (incoming || []).filter((x) => {
+      const key = norm(x.id) || norm(x.comun);
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    return [...(existing || []), ...extra];
+  };
+  return {
+    ...ficha,
+    grafoVivo: true,
+    asociaciones: {
+      compatibles: merge(base.compatibles, live.compatibles),
+      antagonistas: merge(base.antagonistas, live.antagonistas),
+    },
+  };
+}
+
+/**
+ * Fusiona controladores vivos en una amenaza concreta de la ficha (por índice),
+ * deduplicando. Devuelve una NUEVA ficha.
+ *
+ * @param {object} ficha
+ * @param {number} amenazaIndex
+ * @param {string[]} controladores
+ * @returns {object}
+ */
+export function mergeControllers(ficha, amenazaIndex, controladores) {
+  if (!ficha || !Array.isArray(ficha.amenazas) || !controladores?.length) return ficha;
+  if (amenazaIndex < 0 || amenazaIndex >= ficha.amenazas.length) return ficha;
+  const amenazas = ficha.amenazas.map((a, i) => {
+    if (i !== amenazaIndex) return a;
+    const prev = Array.isArray(a.controladores) ? a.controladores : [];
+    const seen = new Set(prev.map(norm));
+    const extra = controladores.filter((c) => c && !seen.has(norm(c)));
+    return { ...a, controladores: [...prev, ...extra] };
+  });
+  return { ...ficha, grafoVivo: true, amenazas };
+}
+
+/**
+ * Extrae la confirmación viva de `get_species` (binomio + viabilidad) para el
+ * sello de estado de la cabecera. Nunca lanza.
+ *
+ * @param {any} res
+ * @returns {{ speciesName?: string, viabilidad?: string } | null}
+ */
+export function normalizeSpeciesConfirm(res) {
+  if (!res || typeof res !== 'object' || res._error || res.available === false) return null;
+  const speciesName = res.species_name || res.nombre_cientifico || res.binomio || '';
+  const viabilidad = typeof res.viabilidad === 'string' ? res.viabilidad : '';
+  if (!speciesName && !viabilidad) return null;
+  return { speciesName: speciesName || undefined, viabilidad: viabilidad || undefined };
+}
+
+/* ------------------------------------------------------ wrappers de fetch vivo */
+
+/**
+ * Confirmación viva de la especie por el grafo (get_species). No lanza; devuelve
+ * null si offline/flag off/error.
+ * @param {string} speciesId
+ * @returns {Promise<{ speciesName?, viabilidad? } | null>}
+ */
+export async function fetchSpeciesConfirm(speciesId) {
+  if (!speciesId || !isLiveGraphAvailable()) return null;
+  try {
+    const res = await callTool('get_species', {
+      query: speciesId, species_id: speciesId, species_id_or_name: speciesId,
+    });
+    return normalizeSpeciesConfirm(res);
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Asocios vivos del grafo (get_companions), ya normalizados. No lanza.
+ * @param {string} speciesId
+ * @returns {Promise<{ compatibles, antagonistas } | null>}
+ */
+export async function fetchLiveCompanions(speciesId) {
+  if (!speciesId || !isLiveGraphAvailable()) return null;
+  try {
+    const res = await callTool('get_companions', argsFor('get_companions', speciesId));
+    return normalizeCompanions(res);
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Controladores biológicos de UNA plaga (get_pest_controllers), normalizados.
+ * No lanza.
+ * @param {string} pestName — nombre o id de la plaga.
+ * @returns {Promise<string[]>}
+ */
+export async function fetchPestControllers(pestName) {
+  if (!pestName || !isLiveGraphAvailable()) return [];
+  try {
+    const res = await callTool('get_pest_controllers', { pest_id_or_name: pestName });
+    return normalizeControllers(res);
+  } catch (_) {
+    return [];
+  }
+}
+
+// Re-export de la base offline para que el componente tenga un único import.
+export { buildSpeciesFicha };


### PR DESCRIPTION
Ficha de detalle de especie photo-forward que consulta el sidecar en vivo (get_species/get_saberes/get_pest_controllers/get_companions). Build VERDE. Rescatado de un fable que murió por error de conexión mid-tests → FALTAN tests + verificación visual antes de merge. Draft para tu OK.