### PR TITLE
feat(conoce): recorrido guiado "Conoce Chagra" — tour opt-in de 7 escenas

### DIFF
--- a/scripts/conoce-shots.mjs
+++ b/scripts/conoce-shots.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * conoce-shots.mjs — capturas headless del recorrido "Conoce Chagra".
+ *
+ * Recorre las 7 escenas del tour en el tema base (biopunk) y las escenas
+ * clave (mano / mundos / cierre) en los demás temas, más la auto-oferta de
+ * primera vez en el dashboard. Mismo harness que chagra-shot.mjs (chromium
+ * del nix-store, determinism, reducedMotion 'reduce' — que además VALIDA que
+ * el tour funciona completo sin animación).
+ *
+ * Uso: node scripts/conoce-shots.mjs --out-dir /ruta/capturas
+ *      (levanta `npm run dev` en :5173 si no hay servidor escuchando)
+ */
+import { existsSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { execSync, spawn } from 'node:child_process';
+import { chromium } from 'playwright';
+import { installDeterminism, loginAndSeed } from '../tests/visual/visualTestUtils.js';
+
+const BASE_URL = 'http://127.0.0.1:5173';
+const VIEWPORT = { width: 390, height: 844 };
+const ESCENA_IDS = ['mano', 'agente', 'confianza', 'mundos', 'voz', 'offgrid', 'cierre'];
+const TEMAS_EXTRA = ['nature', 'minimalista', 'verde-vivo'];
+const ESCENAS_POR_TEMA = ['mano', 'mundos', 'cierre'];
+
+const KNOWN_CHROMIUM_PATHS = [
+  '/nix/store/r7ifk1v95jfl02775kgbrd61dyr1rfsx-chromium-148.0.7778.178/bin/chromium',
+  '/nix/store/9fjg59mab9j8c5r61dx2k5gcbd2f5mpm-chromium-148.0.7778.96/bin/chromium',
+];
+
+function resolveChromiumPath() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) return process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  try {
+    const which = execSync('which chromium 2>/dev/null', { encoding: 'utf8' }).trim();
+    if (which) return which;
+  } catch { /* sigue */ }
+  for (const candidate of KNOWN_CHROMIUM_PATHS) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+async function waitForServer(url, child) {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (child && child.exitCode !== null) {
+      throw new Error(`El servidor terminó antes de estar listo, code=${child.exitCode}`);
+    }
+    try {
+      const r = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(2_000) });
+      if (r.ok || r.status >= 400) return;
+    } catch { /* retry */ }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Timeout esperando servidor en ${url}`);
+}
+
+async function ensureServer() {
+  try {
+    const r = await fetch(BASE_URL, { method: 'GET', signal: AbortSignal.timeout(1_500) });
+    if (r.ok || r.status >= 400) return { started: false, child: null };
+  } catch { /* levantar */ }
+  const child = spawn('npm', ['run', 'dev', '--', '--host', '127.0.0.1', '--port', '5173', '--strictPort'], {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+    env: { ...process.env, VITE_FARMOS_URL: '', VITE_FARMOS_CLIENT_ID: 'farm', VITE_OPERATOR_USERNAME: 'op-test' },
+  });
+  await waitForServer(BASE_URL, child);
+  return { started: true, child };
+}
+
+function parseArgs(argv) {
+  let outDir = null;
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i] === '--out-dir') outDir = argv[++i];
+    else if (argv[i].startsWith('--out-dir=')) outDir = argv[i].slice('--out-dir='.length);
+  }
+  if (!outDir) throw new Error('Uso: node scripts/conoce-shots.mjs --out-dir <dir>');
+  return { outDir: resolve(outDir) };
+}
+
+async function newTourPage(browser, theme) {
+  const context = await browser.newContext({
+    baseURL: BASE_URL,
+    viewport: VIEWPORT,
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 2,
+    locale: 'es-CO',
+    reducedMotion: 'reduce',
+  });
+  const page = await context.newPage();
+  page.setDefaultTimeout(60_000);
+  page.setDefaultNavigationTimeout(60_000);
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await installDeterminism(context, page, { profileKey: 'operador' });
+  if (theme) {
+    await page.addInitScript((t) => {
+      localStorage.setItem('chagra:theme', t);
+      if (document.documentElement) {
+        if (t === 'biopunk' || t === 'biopunk2') document.documentElement.removeAttribute('data-theme');
+        else document.documentElement.setAttribute('data-theme', t);
+      }
+    }, theme);
+  }
+  await loginAndSeed(page, 'empty');
+  return { context, page };
+}
+
+async function abrirTour(page) {
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'conoce' } }));
+  });
+  await page.waitForSelector('[data-testid="conoce-chagra"]', { timeout: 30_000 });
+  await page.waitForTimeout(400);
+}
+
+async function capturarEscenas(page, outDir, tema, escenas) {
+  for (const id of ESCENA_IDS) {
+    const actual = await page.getAttribute('[data-testid="conoce-chagra"]', 'data-escena');
+    if (actual !== id) throw new Error(`Escena esperada ${id}, actual ${actual}`);
+    if (escenas.includes(id)) {
+      const out = resolve(outDir, `conoce-${tema}-${ESCENA_IDS.indexOf(id) + 1}-${id}.png`);
+      await page.screenshot({ path: out });
+      console.log(`[conoce-shots] ${out}`);
+    }
+    if (id !== 'cierre') {
+      await page.click('[data-testid="cnc-siguiente"]');
+      await page.waitForTimeout(250);
+    }
+  }
+}
+
+async function run() {
+  const { outDir } = parseArgs(process.argv);
+  mkdirSync(outDir, { recursive: true });
+  const server = await ensureServer();
+  const chromiumPath = resolveChromiumPath();
+  const browser = await chromium.launch({
+    ...(chromiumPath ? { executablePath: chromiumPath } : {}),
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+
+  try {
+    // 1. Tema base (biopunk): las 7 escenas completas.
+    {
+      const { context, page } = await newTourPage(browser, 'biopunk');
+      await abrirTour(page);
+      await capturarEscenas(page, outDir, 'biopunk', ESCENA_IDS);
+      await context.close();
+    }
+
+    // 2. Temas restantes: escenas clave (mano / mundos / cierre).
+    for (const tema of TEMAS_EXTRA) {
+      const { context, page } = await newTourPage(browser, tema);
+      await abrirTour(page);
+      await capturarEscenas(page, outDir, tema, ESCENAS_POR_TEMA);
+      await context.close();
+    }
+
+    // 3. La auto-oferta de primera vez en el dashboard (sin huella previa).
+    {
+      const { context, page } = await newTourPage(browser, 'biopunk');
+      await page.evaluate(() => localStorage.removeItem('chagra:conoce-visto'));
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await page.waitForSelector('[data-testid="conoce-invite"]', { timeout: 30_000 });
+      await page.waitForTimeout(300);
+      const out = resolve(outDir, 'conoce-invite-dashboard.png');
+      await page.screenshot({ path: out });
+      console.log(`[conoce-shots] ${out}`);
+      await context.close();
+    }
+  } finally {
+    await browser.close().catch(() => {});
+    if (server.started && server.child) server.child.kill('SIGTERM');
+  }
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,6 +54,7 @@ import GpsFincaBanner from './components/GpsFincaBanner';
 import DataLossBanner from './components/DataLossBanner';
 import DemoModeBanner from './components/DemoModeBanner';
 import CriticalAlertBanner from './components/CriticalAlertBanner';
+import ConoceChagraInvite from './components/conoce/ConoceChagraInvite';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ErrorFallback } from './components/common/ErrorFallback';
 
@@ -154,6 +155,10 @@ const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
 const AprenderConAgente = lazy(() => import('./components/Aprende/AprenderConAgente'));
 const CursoChagra = lazy(() => import('./components/curso/CursoChagra'));
+// Recorrido guiado "Conoce Chagra" (tour opt-in de 7 escenas): qué es Chagra
+// y qué puede hacer, para primera vez / pilotos / donantes. NO es el
+// onboarding de perfil (#2078): no pide datos, solo cuenta el alma.
+const ConoceChagra = lazy(() => import('./components/conoce/ConoceChagra'));
 const DirectorioEspeciesScreen = lazy(() => import('./components/DirectorioEspecies/DirectorioEspeciesScreen'));
 const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
 const MiFincaEvolucionScreen = lazy(() => import('./components/hoy/MiFincaEvolucionScreen'));
@@ -192,6 +197,8 @@ const LoadingFallback = () => (
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
+  conoce: 'conoce',
+  'conoce-chagra': 'conoce',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
   inventario: 'activos',
@@ -1495,6 +1502,22 @@ export default function App() {
             </ErrorFallback>
           </ErrorBoundary>
         );
+      case 'conoce':
+        // Recorrido guiado "Conoce Chagra": 7 escenas que muestran qué es
+        // Chagra (agente groundeado, semáforo de confianza, mundos, voz,
+        // off-grid solar). Opt-in desde Manual/Perfil + auto-oferta de primera
+        // vez (ConoceChagraInvite) + deep-link #conoce para compartir con
+        // pilotos y donantes. Skippeable siempre; al cerrar vuelve al home.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Conoce Chagra">
+              <ConoceChagra
+                onClose={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
       case 'mercados':
         // Rama "Vender" de la mano de Chagra (auditoría UX §7.4 P3): superficie
         // HONESTA "en preparación" — alcanzable, no un dead-end. Explica el
@@ -1752,9 +1775,16 @@ export default function App() {
           MENOS el home/dashboard (operador 2026-06-06): en el home el colibrí
           ya es el botón de ENVIAR del compositor, así que el FAB flotante ahí
           duplicaría el ave. Sigue en el resto para anunciar "respuesta lista". */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && <AgentFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'conoce' && <AgentFab onNavigate={navigate} />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && <SyncProgressIndicator />}
+      {/* Auto-oferta de PRIMERA VEZ del recorrido "Conoce Chagra": tarjeta
+          descartable solo en el home, una sola vez (huella en localStorage).
+          NO toca el onboarding de perfil (#2078): cero estado compartido. */}
+      {currentView === 'dashboard' && <ConoceChagraInvite onStart={() => navigate('conoce')} />}
+      {/* 'conoce' excluido: el toast de sync tapaba el botón primario del
+          recorrido (medido en captura headless) — durante el tour no hay
+          nada que sincronizar que no pueda esperar un minuto. */}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'conoce' && <SyncProgressIndicator />}
       {toast && (
         <div
           role={toast.isError ? 'alert' : 'status'}

--- a/src/__tests__/App.conoce-route.test.jsx
+++ b/src/__tests__/App.conoce-route.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Test de RUTA: verifica que App rutea 'conoce' (deep-link #conoce) → el
+// recorrido guiado ConoceChagra. Sin el case en el switch de App, el botón
+// "Conoce Chagra" del Manual/Perfil y la auto-oferta de primera vez quedarían
+// muertos (feature huérfana, memoria feedback-features-ui-huerfanas-sin-cablear).
+//
+// Los efectos pesados de boot (auth, catálogo SQLite WASM, motores de alerta,
+// RAG, warm-up de Ollama) se mockean para que App arranque limpio en jsdom sin
+// tocar red/IDB. No probamos esos sistemas acá; solo el wiring de la ruta.
+
+vi.mock('../services/authService', () => ({
+  isAuthenticated: () => Promise.resolve(true),
+  logoutUser: () => Promise.resolve(),
+}));
+vi.mock('../db/catalogDB', () => ({ initCatalog: () => Promise.resolve() }));
+vi.mock('../services/ragRetriever', () => ({
+  prewarmCorpus: () => {},
+  retrieve: () => Promise.resolve([]),
+}));
+vi.mock('../services/alertEngine', () => ({ alertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/cropAlertEngine', () => ({ cropAlertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/apiService', () => ({
+  fetchFromFarmOS: () => Promise.resolve(null),
+  fetchWithAuthRetry: () => Promise.resolve({ ok: true }),
+}));
+
+// La pantalla destino: stub liviano que delata que se montó. Probamos el WIRING
+// de la ruta, no el render interno del tour (ya cubierto en su propio test).
+vi.mock('../components/conoce/ConoceChagra', () => ({
+  default: () => <div data-testid="conoce-chagra-stub">recorrido stub</div>,
+}));
+
+// Procesos vacíos (sin IDB).
+vi.mock('../db/farmProcessCache', () => ({ listFarmProcesses: () => Promise.resolve([]) }));
+
+import App from '../App';
+
+describe('App — ruta "conoce" (recorrido Conoce Chagra)', () => {
+  beforeEach(() => {
+    window.location.hash = '#conoce';
+    localStorage.clear();
+  });
+  afterEach(() => {
+    window.location.hash = '';
+    vi.clearAllMocks();
+  });
+
+  it('con sesión autenticada y #conoce monta el recorrido ConoceChagra', async () => {
+    render(<App />);
+    await waitFor(
+      () => expect(screen.getByTestId('conoce-chagra-stub')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+  });
+});

--- a/src/components/HelpHomeScreen.jsx
+++ b/src/components/HelpHomeScreen.jsx
@@ -274,6 +274,44 @@ export default function HelpHomeScreen({ onSelect, onNavigate }) {
         Una mano rápida para entrar a Chagra. Toca lo que necesites o busca tu pregunta.
       </p>
 
+      {/* Recorrido guiado "Conoce Chagra" (tour opt-in de 7 escenas): la
+          entrada para primera vez o para MOSTRARLE Chagra a alguien sin que
+          tenga que explorar. Solo sin búsqueda activa (es invitación, no
+          resultado). El acento sale del tema (--t-accent-rgb). */}
+      {!query && (
+        <button
+          type="button"
+          onClick={() => go('conoce')}
+          data-testid="help-conoce-chagra"
+          className="rounded-2xl border p-4 text-left flex items-center gap-3 active:scale-[0.99] motion-reduce:active:scale-100 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+          style={{
+            backgroundColor: 'rgb(var(--c-surface-card))',
+            borderColor: 'rgba(var(--t-accent-rgb), 0.5)',
+          }}
+        >
+          <span
+            className="w-12 h-12 rounded-full flex items-center justify-center shrink-0 border"
+            style={{
+              color: 'rgb(var(--t-accent-rgb))',
+              borderColor: 'rgba(var(--t-accent-rgb), 0.5)',
+              backgroundColor: 'rgba(var(--t-accent-rgb), 0.1)',
+            }}
+            aria-hidden="true"
+          >
+            <ManoChagraGlyph size={26} />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-base font-black leading-tight" style={{ color: 'rgb(var(--c-slate-100))' }}>
+              Conoce Chagra
+            </span>
+            <span className="block text-xs mt-0.5 leading-snug" style={{ color: 'rgb(var(--c-slate-400))' }}>
+              El recorrido de un minuto: qué es Chagra y qué puede hacer por su finca.
+            </span>
+          </span>
+          <ChevronRight size={18} className="shrink-0" style={{ color: 'rgb(var(--t-accent-rgb))' }} aria-hidden="true" />
+        </button>
+      )}
+
       {/* Mapa mental: los cuatro lugares de Chagra (home F2). Solo cuando no
           hay búsqueda activa — es orientación, no un resultado buscable. */}
       {!query && (

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import {
   User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2, Wrench,
   Sprout, ChevronRight, ChevronLeft, Bell, Users, Camera, Trash2, Shield,
-  Archive, LifeBuoy, LayoutGrid, GraduationCap,
+  Archive, LifeBuoy, LayoutGrid, GraduationCap, Compass,
 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { esExtensionistaActual } from '../config/extensionistaAccess';
@@ -107,6 +107,7 @@ const SECTIONS = [
   { id: 'privacidad', label: 'Privacidad', icon: Shield, tint: 'text-violet-300', tintBg: 'bg-violet-900/30 border-violet-700/40', desc: 'Telemetría y permisos' },
   { id: 'respaldo', label: 'Respaldo', icon: Archive, tint: 'text-orange-300', tintBg: 'bg-orange-900/30 border-orange-700/40', desc: 'Copia de datos y PDF' },
   { id: 'ayuda', label: 'Ayuda', icon: LifeBuoy, tint: 'text-amber-300', tintBg: 'bg-amber-900/30 border-amber-700/40', desc: 'Manual de uso', action: true },
+  { id: 'conoce', label: 'Conoce Chagra', icon: Compass, tint: 'text-emerald-300', tintBg: 'bg-emerald-900/30 border-emerald-700/40', desc: 'El recorrido guiado', action: true },
   { id: 'avanzado', label: 'Avanzado', icon: Wrench, tint: 'text-slate-400', tintBg: 'bg-slate-800/60 border-slate-700', desc: 'Modo técnico y más' },
 ];
 
@@ -310,6 +311,7 @@ export default function ProfileScreen({ onBack, onHome }) {
     privacidad: telemetryConsent ? 'Métricas anónimas activas' : 'Solo en tu dispositivo',
     respaldo: 'Copia local + PDF',
     ayuda: 'Manual de uso',
+    conoce: 'Qué es y qué puede hacer',
     avanzado: modoTecnico || verTodo ? 'Modo técnico activo' : 'Todo normal',
   };
 
@@ -324,10 +326,11 @@ export default function ProfileScreen({ onBack, onHome }) {
   };
 
   const openSection = (id) => {
-    if (id === 'ayuda') {
-      // Acción directa: el manual vive en su propia pantalla.
+    if (id === 'ayuda' || id === 'conoce') {
+      // Acción directa: el manual y el recorrido "Conoce Chagra" viven en su
+      // propia pantalla (mismo mecanismo de navegación que usa ScreenShell).
       try {
-        window.dispatchEvent(new CustomEvent('chagra:nav', { detail: { view: 'ayuda' } }));
+        window.dispatchEvent(new CustomEvent('chagra:nav', { detail: { view: id } }));
       } catch (_) { /* noop */ }
       return;
     }

--- a/src/components/conoce/ConoceChagra.jsx
+++ b/src/components/conoce/ConoceChagra.jsx
@@ -1,0 +1,183 @@
+/**
+ * ConoceChagra — el RECORRIDO guiado "Conoce Chagra" (tour opt-in).
+ *
+ * QUÉ ES: 7 escenas cinematográficas de pantalla completa que le muestran a
+ * una campesina (o a un visitante/donante) qué es Chagra y qué puede hacer,
+ * sin que tenga que explorar la app. Doble uso: bienvenida de primera vez
+ * (auto-oferta vía ConoceChagraInvite) y "muéstrame Chagra" (botón en el
+ * Manual y en el Perfil, y deep-link #conoce para compartir).
+ *
+ * QUÉ NO ES: NO es el onboarding de perfil (#2078 / onboarding-perfil) ni lo
+ * reemplaza — no pide datos, no configura nada. Solo cuenta el alma.
+ *
+ * HONESTIDAD (anti-sobrepromesa):
+ *   - "IA en infraestructura propia con energía solar" — NO "on-device".
+ *   - datos "local-first" (viven primero en el teléfono y se sincronizan) —
+ *     NO "todo funciona sin internet": la escena off-grid aclara que el
+ *     agente sí necesita señal; los registros no.
+ *   - la escena de mundos pinta los MUNDOS REALES (mundosFinca.js): si un
+ *     mundo se renombra o se va, el tour lo refleja solo.
+ *
+ * ACCESIBILIDAD: skippeable siempre (Saltar arriba, Escape), navegable con
+ * flechas del teclado y con swipe; prefers-reduced-motion apaga toda la
+ * animación en CSS y el tour funciona completo quieto; el semáforo no es
+ * color-only (texto en cada fila); fondos opacos legibles al sol.
+ *
+ * El guion (escenas + visuales) vive en escenasConoce.jsx; la huella
+ * persistente en conoceVisto.js (compartida con el invite de primera vez).
+ *
+ * Props:
+ *   - onClose():           cerrar/terminar (vuelve a donde estaba el usuario).
+ *   - onNavigate(view):    abrir una pantalla real al cierre ("Ver todo lo
+ *                          que Chagra hace" → ayuda).
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { X, ArrowRight } from 'lucide-react';
+import { ESCENAS } from './escenasConoce.jsx';
+import { CONOCE_VISTO_KEY, marcarConoceVisto } from './conoceVisto.js';
+import './conoce-chagra.css';
+
+export default function ConoceChagra({ onClose, onNavigate = null }) {
+  const [paso, setPaso] = useState(0);
+  const total = ESCENAS.length;
+  const esUltima = paso === total - 1;
+  const escena = ESCENAS[paso];
+  const { Visual } = escena;
+
+  const terminar = (destino) => {
+    marcarConoceVisto('1');
+    if (destino && typeof onNavigate === 'function') {
+      onNavigate(destino);
+      return;
+    }
+    if (typeof onClose === 'function') onClose();
+  };
+
+  const avanzar = () => {
+    if (esUltima) { terminar(); return; }
+    setPaso((p) => Math.min(p + 1, total - 1));
+  };
+  const retroceder = () => setPaso((p) => Math.max(p - 1, 0));
+
+  // Teclado: flechas navegan, Escape salta. (El tour es un overlay modal.)
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'ArrowRight') { e.preventDefault(); avanzar(); }
+      else if (e.key === 'ArrowLeft') { e.preventDefault(); retroceder(); }
+      else if (e.key === 'Escape') { e.preventDefault(); terminar(); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paso]);
+
+  // Swipe horizontal (umbral 48px; el vertical se ignora para no pelear con
+  // el scroll del stage en pantallas bajitas).
+  const touchRef = useRef(null);
+  const onTouchStart = (e) => {
+    const t = e.touches?.[0];
+    if (t) touchRef.current = { x: t.clientX, y: t.clientY };
+  };
+  const onTouchEnd = (e) => {
+    const start = touchRef.current;
+    touchRef.current = null;
+    const t = e.changedTouches?.[0];
+    if (!start || !t) return;
+    const dx = t.clientX - start.x;
+    const dy = t.clientY - start.y;
+    if (Math.abs(dx) < 48 || Math.abs(dx) < Math.abs(dy)) return;
+    if (dx < 0) avanzar(); else retroceder();
+  };
+
+  // Al montar, dejamos huella de que el recorrido ya se ofreció/abrió (el
+  // invite no vuelve a insistir aunque lo abandonen a mitad de camino).
+  useEffect(() => {
+    try {
+      if (!window.localStorage.getItem(CONOCE_VISTO_KEY)) marcarConoceVisto('abierto');
+    } catch (_) { /* noop */ }
+  }, []);
+
+  // Cinturón del overflow:clip: al cambiar de escena, el scroller interno
+  // (.cnc-stage) vuelve arriba — cada escena arranca desde su comienzo.
+  const stageRef = useRef(null);
+  useEffect(() => {
+    if (stageRef.current) stageRef.current.scrollTop = 0;
+  }, [paso]);
+
+  const titleId = 'cnc-titulo';
+  const dots = useMemo(() => ESCENAS.map((e) => e.id), []);
+
+  return (
+    <div
+      className="cnc-root"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      data-testid="conoce-chagra"
+      data-escena={escena.id}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+    >
+      <header className="cnc-top">
+        <div className="cnc-dots" role="tablist" aria-label={`Escena ${paso + 1} de ${total}`}>
+          {dots.map((id, i) => (
+            <button
+              key={id}
+              type="button"
+              role="tab"
+              className="cnc-dot"
+              aria-current={i === paso}
+              aria-label={`Ir a la escena ${i + 1}`}
+              onClick={() => setPaso(i)}
+            />
+          ))}
+        </div>
+        <button
+          type="button"
+          className="cnc-skip"
+          onClick={() => terminar()}
+          data-testid="cnc-saltar"
+        >
+          <span className="inline-flex items-center gap-1">
+            Saltar <X size={14} aria-hidden="true" />
+          </span>
+        </button>
+      </header>
+
+      {/* key={paso} re-monta la escena → re-dispara la animación de entrada
+          (que reduced-motion apaga en CSS; el contenido queda igual). */}
+      <main className="cnc-stage" ref={stageRef}>
+        <section key={paso} className="cnc-scene" aria-live="polite">
+          <div className="cnc-visual"><Visual /></div>
+          <div className="cnc-copy">
+            <p className="cnc-kicker">{escena.kicker}</p>
+            <h2 className="cnc-title" id={titleId}>{escena.titulo}</h2>
+            <p className="cnc-sub">{escena.sub}</p>
+          </div>
+        </section>
+      </main>
+
+      <footer className="cnc-foot">
+        <button
+          type="button"
+          className="cnc-next agent-send-accent"
+          onClick={avanzar}
+          data-testid="cnc-siguiente"
+        >
+          {esUltima ? 'Empezar a andar mi finca' : 'Siguiente'}
+          <ArrowRight size={18} aria-hidden="true" />
+        </button>
+        {esUltima && (
+          <button
+            type="button"
+            className="cnc-secondary"
+            onClick={() => terminar('ayuda')}
+            data-testid="cnc-ver-todo"
+          >
+            Ver todo lo que Chagra hace
+          </button>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/src/components/conoce/ConoceChagraInvite.jsx
+++ b/src/components/conoce/ConoceChagraInvite.jsx
@@ -1,0 +1,100 @@
+/**
+ * ConoceChagraInvite — la auto-oferta de PRIMERA VEZ del recorrido.
+ *
+ * Tarjeta pequeña y descartable (NO un modal que tape el home) que aparece
+ * UNA sola vez en el dashboard si el usuario nunca ha visto ni omitido el
+ * recorrido "Conoce Chagra" (huella CONOCE_VISTO_KEY en localStorage).
+ *
+ * Diseño deliberado para convivir con el onboarding de perfil (#2078, en
+ * integración) sin tocarlo: esto solo se monta en el dashboard (App.jsx la
+ * gatea a currentView === 'dashboard'), con un retraso de cortesía para no
+ * competir con la carga del home, y cualquier interacción la silencia para
+ * siempre. Cero estado compartido con ese flujo.
+ *
+ * Props:
+ *   - onStart(): abrir el recorrido (navigate('conoce')).
+ */
+import React, { useEffect, useState } from 'react';
+import { X, ArrowRight } from 'lucide-react';
+import ManoChagraGlyph from '../dashboard/ManoChagraGlyph.jsx';
+import { conoceYaVisto, marcarConoceVisto } from './conoceVisto.js';
+
+/** Retraso de cortesía antes de ofrecer (el home respira primero). */
+const INVITE_DELAY_MS = 1600;
+
+export default function ConoceChagraInvite({ onStart }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (conoceYaVisto()) return undefined;
+    const t = setTimeout(() => setVisible(true), INVITE_DELAY_MS);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (!visible) return null;
+
+  const abrir = () => {
+    setVisible(false);
+    // El tour marca su propia huella al montar; esto cubre el caso de que
+    // la navegación falle a mitad de camino (no volver a insistir).
+    marcarConoceVisto('abierto');
+    if (typeof onStart === 'function') onStart();
+  };
+
+  const omitir = () => {
+    setVisible(false);
+    marcarConoceVisto('omitido');
+  };
+
+  return (
+    <div
+      role="complementary"
+      aria-label="Invitación al recorrido Conoce Chagra"
+      data-testid="conoce-invite"
+      className="fixed left-1/2 -translate-x-1/2 z-40 w-11/12 max-w-md rounded-2xl border shadow-2xl p-4 flex items-center gap-3"
+      style={{
+        bottom: 'calc(96px + env(safe-area-inset-bottom))',
+        backgroundColor: 'rgb(var(--c-surface-card))',
+        borderColor: 'rgba(var(--t-accent-rgb), 0.5)',
+      }}
+    >
+      <span
+        className="w-11 h-11 rounded-full flex items-center justify-center shrink-0 border"
+        style={{
+          color: 'rgb(var(--t-accent-rgb))',
+          borderColor: 'rgba(var(--t-accent-rgb), 0.5)',
+          backgroundColor: 'rgba(var(--t-accent-rgb), 0.1)',
+        }}
+        aria-hidden="true"
+      >
+        <ManoChagraGlyph size={24} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-bold leading-tight" style={{ color: 'rgb(var(--c-slate-100))' }}>
+          ¿Primera vez por aquí?
+        </p>
+        <p className="text-xs mt-0.5 leading-snug" style={{ color: 'rgb(var(--c-slate-300))' }}>
+          Conozca Chagra en un recorrido de un minuto.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={abrir}
+        data-testid="conoce-invite-ver"
+        className="agent-send-accent shrink-0 min-h-[40px] px-3 rounded-xl text-sm font-extrabold flex items-center gap-1 active:scale-[0.97] motion-reduce:active:scale-100"
+      >
+        Verlo <ArrowRight size={15} aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={omitir}
+        aria-label="Ahora no"
+        data-testid="conoce-invite-cerrar"
+        className="shrink-0 p-1.5 rounded-lg"
+        style={{ color: 'rgb(var(--c-slate-400))' }}
+      >
+        <X size={16} aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/conoce/__tests__/ConoceChagra.test.jsx
+++ b/src/components/conoce/__tests__/ConoceChagra.test.jsx
@@ -1,0 +1,145 @@
+/**
+ * ConoceChagra.test.jsx — recorrido guiado "Conoce Chagra" (tour opt-in).
+ *
+ * Cubre:
+ *   1. Escena 1 (la mano) + Saltar siempre visible.
+ *   2. Avanzar por las 7 escenas hasta el cierre; "Empezar a andar mi finca"
+ *      cierra y deja la huella '1' en localStorage.
+ *   3. Saltar cierra y deja huella (skippeable desde cualquier escena).
+ *   4. La escena de mundos pinta los MUNDOS REALES (fuente única
+ *      mundosFinca.js — si un mundo cambia, el tour lo refleja solo).
+ *   5. "Ver todo lo que Chagra hace" navega a la ayuda.
+ *   6. Honestidad del copy: infraestructura propia (no "on-device") y la
+ *      aclaración de que el agente sí necesita señal.
+ *   7. ConoceChagraInvite: auto-oferta una sola vez (huella la silencia),
+ *      "Ahora no" persiste 'omitido', "Verlo" dispara onStart.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ConoceChagra from '../ConoceChagra.jsx';
+import { ESCENAS } from '../escenasConoce.jsx';
+import ConoceChagraInvite from '../ConoceChagraInvite.jsx';
+import { CONOCE_VISTO_KEY } from '../conoceVisto.js';
+import { MUNDOS_FINCA } from '../../dashboard/mundosFinca.js';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+const avanzarHasta = (escenaIdx) => {
+  for (let i = 0; i < escenaIdx; i += 1) {
+    fireEvent.click(screen.getByTestId('cnc-siguiente'));
+  }
+};
+
+describe('ConoceChagra (el recorrido)', () => {
+  it('tiene 7 escenas con ids únicos', () => {
+    expect(ESCENAS).toHaveLength(7);
+    expect(new Set(ESCENAS.map((e) => e.id)).size).toBe(7);
+  });
+
+  it('abre en la escena de la mano, con Saltar visible', () => {
+    render(<ConoceChagra onClose={vi.fn()} />);
+    expect(screen.getByText('Su mano en el campo.')).toBeInTheDocument();
+    expect(screen.getByTestId('cnc-saltar')).toBeInTheDocument();
+    // Al abrir deja huella "abierto" (el invite no vuelve a insistir).
+    expect(window.localStorage.getItem(CONOCE_VISTO_KEY)).toBe('abierto');
+  });
+
+  it('recorre las 7 escenas y al final "Empezar" cierra con huella', () => {
+    const onClose = vi.fn();
+    render(<ConoceChagra onClose={onClose} />);
+    ESCENAS.forEach((esc, i) => {
+      expect(screen.getByTestId('conoce-chagra')).toHaveAttribute('data-escena', esc.id);
+      expect(screen.getByText(esc.titulo)).toBeInTheDocument();
+      if (i < ESCENAS.length - 1) fireEvent.click(screen.getByTestId('cnc-siguiente'));
+    });
+    fireEvent.click(screen.getByText('Empezar a andar mi finca'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(CONOCE_VISTO_KEY)).toBe('1');
+  });
+
+  it('Saltar cierra desde cualquier escena y deja huella', () => {
+    const onClose = vi.fn();
+    render(<ConoceChagra onClose={onClose} />);
+    avanzarHasta(2);
+    fireEvent.click(screen.getByTestId('cnc-saltar'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(CONOCE_VISTO_KEY)).toBe('1');
+  });
+
+  it('la escena de mundos pinta TODOS los mundos reales de mundosFinca.js', () => {
+    render(<ConoceChagra onClose={vi.fn()} />);
+    const idx = ESCENAS.findIndex((e) => e.id === 'mundos');
+    avanzarHasta(idx);
+    MUNDOS_FINCA.forEach((m) => {
+      expect(screen.getByTestId(`cnc-mundo-${m.id}`)).toBeInTheDocument();
+      expect(screen.getByText(m.titulo)).toBeInTheDocument();
+    });
+  });
+
+  it('"Ver todo lo que Chagra hace" navega a la ayuda con huella', () => {
+    const onNavigate = vi.fn();
+    render(<ConoceChagra onClose={vi.fn()} onNavigate={onNavigate} />);
+    avanzarHasta(ESCENAS.length - 1);
+    fireEvent.click(screen.getByTestId('cnc-ver-todo'));
+    expect(onNavigate).toHaveBeenCalledWith('ayuda');
+    expect(window.localStorage.getItem(CONOCE_VISTO_KEY)).toBe('1');
+  });
+
+  it('copy honesto: infraestructura propia y agente-necesita-señal', () => {
+    const textos = ESCENAS.map((e) => `${e.titulo} ${e.sub}`).join(' ');
+    expect(textos).toMatch(/infraestructura propia/);
+    expect(textos).toMatch(/agente sí necesita señal/);
+    // Anti-sobrepromesa: nunca afirmar on-device ni "todo funciona sin internet".
+    expect(textos).not.toMatch(/on.device/i);
+  });
+
+  it('navega con las flechas del teclado y Escape salta', () => {
+    const onClose = vi.fn();
+    render(<ConoceChagra onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(screen.getByTestId('conoce-chagra')).toHaveAttribute('data-escena', ESCENAS[1].id);
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    expect(screen.getByTestId('conoce-chagra')).toHaveAttribute('data-escena', ESCENAS[0].id);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ConoceChagraInvite (auto-oferta de primera vez)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('aparece tras el retraso de cortesía si no hay huella', () => {
+    render(<ConoceChagraInvite onStart={vi.fn()} />);
+    expect(screen.queryByTestId('conoce-invite')).not.toBeInTheDocument();
+    act(() => vi.advanceTimersByTime(2000));
+    expect(screen.getByTestId('conoce-invite')).toBeInTheDocument();
+  });
+
+  it('NO aparece si ya hay huella (visto/omitido/abierto)', () => {
+    window.localStorage.setItem(CONOCE_VISTO_KEY, 'omitido');
+    render(<ConoceChagraInvite onStart={vi.fn()} />);
+    act(() => vi.advanceTimersByTime(3000));
+    expect(screen.queryByTestId('conoce-invite')).not.toBeInTheDocument();
+  });
+
+  it('"Verlo" dispara onStart y deja huella', () => {
+    const onStart = vi.fn();
+    render(<ConoceChagraInvite onStart={onStart} />);
+    act(() => vi.advanceTimersByTime(2000));
+    fireEvent.click(screen.getByTestId('conoce-invite-ver'));
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(CONOCE_VISTO_KEY)).toBe('abierto');
+  });
+
+  it('"Ahora no" la descarta para siempre', () => {
+    render(<ConoceChagraInvite onStart={vi.fn()} />);
+    act(() => vi.advanceTimersByTime(2000));
+    fireEvent.click(screen.getByTestId('conoce-invite-cerrar'));
+    expect(screen.queryByTestId('conoce-invite')).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(CONOCE_VISTO_KEY)).toBe('omitido');
+  });
+});

--- a/src/components/conoce/conoce-chagra.css
+++ b/src/components/conoce/conoce-chagra.css
@@ -1,0 +1,435 @@
+/*
+ * conoce-chagra.css — "Conoce Chagra", el recorrido guiado (tour opt-in).
+ *
+ * ESTÉTICA: la mano de Chagra / biopunk — pantalla completa, una escena a la
+ * vez, respiración cinematográfica. TODO el color sale de los tokens de tema
+ * (--c-* de index.css + --t-accent-rgb de themes.css): el tour se ve teal
+ * neón en biopunk, ocre en nature, tinta en minimalista, sin una sola regla
+ * por-tema acá (indirección CSS-var, memoria feedback-themes-cssvar-indirection).
+ *
+ * LEGIBILIDAD AL SOL: fondos 100% OPACOS (rgb(var(--c-surface)) plano + un
+ * lavado radial del acento que NUNCA baja el contraste del panel de texto,
+ * que es sólido). Texto principal --c-slate-100 / secundario --c-slate-300:
+ * los temas claros invierten esos tokens, así que el contraste AA se sostiene
+ * en las 5 pieles.
+ *
+ * MOVIMIENTO: las escenas entran con fade+rise y el visual "respira" con un
+ * float suave. @media (prefers-reduced-motion: reduce) apaga TODO — el tour
+ * funciona completo sin animación (se navega igual, solo que quieto).
+ */
+
+.cnc-root {
+  position: fixed;
+  inset: 0;
+  z-index: 60; /* sobre la vista, bajo toasts (z-100) */
+  display: flex;
+  flex-direction: column;
+  background-color: rgb(var(--c-surface)); /* OPACO — legible al sol */
+  color: rgb(var(--c-slate-100));
+  /* `clip` (no `hidden`): hidden deja al contenedor scrollear PROGRAMÁTICAMENTE
+     — al cambiar de escena el scroll-into-view del botón enfocado empujaba
+     cabecera y escena 169px fuera de pantalla (medido en Playwright). clip
+     prohíbe todo scroll; el único scroller legítimo es .cnc-stage. */
+  overflow: clip;
+}
+
+/* Lavado radial del acento del tema: atmósfera, no transparencia — vive
+   DETRÁS del contenido y encima del fondo opaco. */
+.cnc-root::before {
+  content: '';
+  position: absolute;
+  inset: -20%;
+  pointer-events: none;
+  background:
+    radial-gradient(60% 45% at 50% 12%, rgba(var(--t-accent-rgb), 0.16), transparent 70%),
+    radial-gradient(50% 40% at 85% 90%, rgba(var(--t-accent-rgb), 0.08), transparent 70%);
+}
+
+/* ── Cabecera: puntos de avance + Saltar ─────────────────────────────────── */
+.cnc-top {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: calc(14px + env(safe-area-inset-top)) 18px 8px;
+}
+
+.cnc-dots { display: flex; gap: 7px; align-items: center; }
+.cnc-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  border: 1.5px solid rgba(var(--t-accent-rgb), 0.55);
+  background: transparent;
+  padding: 0;
+  transition: background-color 0.3s ease, width 0.3s ease;
+}
+.cnc-dot[aria-current='true'] {
+  width: 22px;
+  background: rgb(var(--t-accent-rgb));
+  border-color: rgb(var(--t-accent-rgb));
+}
+
+.cnc-skip {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: rgb(var(--c-slate-300));
+  background: rgb(var(--c-surface-card));
+  border: 1px solid rgb(var(--c-surface-border));
+  border-radius: 999px;
+  padding: 7px 14px;
+  min-height: 36px;
+}
+.cnc-skip:active { transform: scale(0.97); }
+
+/* ── Escenario (visual + copy) ───────────────────────────────────────────── */
+.cnc-stage {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(14px, 3.5vh, 30px);
+  padding: 8px 22px 4px;
+  text-align: center;
+  overflow-y: auto;
+}
+
+/* Entrada de escena: fade + rise. Se re-dispara al cambiar `key` en React. */
+.cnc-scene {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(14px, 3.5vh, 30px);
+  width: 100%;
+  max-width: 430px;
+  animation: cnc-enter 0.55s cubic-bezier(0.22, 0.9, 0.3, 1) both;
+}
+@keyframes cnc-enter {
+  from { opacity: 0; transform: translateY(18px) scale(0.985); }
+  to { opacity: 1; transform: none; }
+}
+
+.cnc-visual {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  animation: cnc-float 5.5s ease-in-out infinite;
+}
+@keyframes cnc-float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-7px); }
+}
+
+.cnc-copy { display: flex; flex-direction: column; gap: 10px; align-items: center; }
+
+.cnc-kicker {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgb(var(--t-accent-deep-rgb, var(--t-accent-rgb)));
+}
+
+.cnc-title {
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-size: clamp(26px, 7vw, 34px);
+  line-height: 1.12;
+  font-weight: 800;
+  color: rgb(var(--c-slate-100));
+  text-wrap: balance;
+}
+
+.cnc-sub {
+  font-size: 15px;
+  line-height: 1.55;
+  color: rgb(var(--c-slate-300));
+  max-width: 40ch;
+  text-wrap: pretty;
+}
+
+/* ── Pie: acciones ───────────────────────────────────────────────────────── */
+.cnc-foot {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 22px calc(18px + env(safe-area-inset-bottom));
+  max-width: 430px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* Botón primario: acento SÓLIDO del tema. La tinta la resuelve la clase
+   global .agent-send-accent (themes.css) — acá solo forma y tamaño. */
+.cnc-next {
+  min-height: 52px;
+  border-radius: 16px;
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  box-shadow: 0 6px 22px rgba(var(--t-accent-rgb), 0.3);
+}
+.cnc-next:active { transform: scale(0.98); }
+
+.cnc-secondary {
+  min-height: 46px;
+  border-radius: 14px;
+  font-size: 14px;
+  font-weight: 700;
+  color: rgb(var(--c-slate-200));
+  background: rgb(var(--c-surface-card));
+  border: 1px solid rgb(var(--c-surface-border));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.cnc-secondary:active { transform: scale(0.98); }
+
+/* ── Visuales de escena ──────────────────────────────────────────────────── */
+
+/* 1 · La mano: glifo dentro de un anillo del acento que pulsa como semilla. */
+.cnc-mano {
+  position: relative;
+  width: clamp(150px, 38vw, 190px);
+  height: clamp(150px, 38vw, 190px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  color: rgb(var(--t-accent-rgb));
+  background: rgb(var(--c-surface-card));
+  border: 2px solid rgba(var(--t-accent-rgb), 0.55);
+  box-shadow:
+    0 0 0 10px rgba(var(--t-accent-rgb), 0.07),
+    0 0 46px rgba(var(--t-accent-rgb), 0.22);
+}
+.cnc-mano::after {
+  content: '';
+  position: absolute;
+  inset: -14px;
+  border-radius: 999px;
+  border: 1.5px dashed rgba(var(--t-accent-rgb), 0.4);
+  animation: cnc-girar 26s linear infinite;
+}
+@keyframes cnc-girar { to { transform: rotate(360deg); } }
+
+/* Nodos que brotan del anillo (la red de capacidades). display:block porque
+   son <i> (inline por defecto) posicionados en absoluto. */
+.cnc-nodo {
+  position: absolute;
+  display: block;
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  background: rgb(var(--t-accent-rgb));
+  box-shadow: 0 0 10px rgba(var(--t-accent-rgb), 0.6);
+}
+
+/* 2 · Agente: mini-chat. Burbujas SÓLIDAS (sol-proof). */
+.cnc-chat {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  max-width: 340px;
+  text-align: left;
+}
+.cnc-burbuja {
+  border-radius: 16px;
+  padding: 12px 14px;
+  font-size: 14px;
+  line-height: 1.45;
+  border: 1px solid rgb(var(--c-surface-border));
+  animation: cnc-enter 0.5s ease both;
+}
+.cnc-burbuja--yo {
+  align-self: flex-end;
+  max-width: 85%;
+  background: rgba(var(--t-accent-rgb), 0.16);
+  border-color: rgba(var(--t-accent-rgb), 0.45);
+  color: rgb(var(--c-slate-100));
+  border-bottom-right-radius: 6px;
+  animation-delay: 0.15s;
+}
+.cnc-burbuja--chagra {
+  align-self: flex-start;
+  max-width: 92%;
+  background: rgb(var(--c-surface-card));
+  color: rgb(var(--c-slate-200));
+  border-bottom-left-radius: 6px;
+  animation-delay: 0.45s;
+}
+.cnc-fuente {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 9px;
+  font-size: 11px;
+  font-weight: 700;
+  color: rgb(var(--t-accent-deep-rgb, var(--t-accent-rgb)));
+  background: rgba(var(--t-accent-rgb), 0.12);
+  border: 1px solid rgba(var(--t-accent-rgb), 0.4);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+/* 3 · Semáforo de confianza: los colores del semáforo son SEMÁNTICOS y fijos
+   (verde/ámbar/rojo en todos los temas); el texto acompaña (no color-only). */
+.cnc-semaforo {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  max-width: 340px;
+  text-align: left;
+}
+.cnc-semaforo-fila {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgb(var(--c-surface-card));
+  border: 1px solid rgb(var(--c-surface-border));
+  border-radius: 14px;
+  padding: 12px 14px;
+  animation: cnc-enter 0.5s ease both;
+}
+.cnc-semaforo-fila:nth-child(2) { animation-delay: 0.18s; }
+.cnc-semaforo-fila:nth-child(3) { animation-delay: 0.36s; }
+.cnc-luz {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.cnc-luz--verde { background: #22c55e; box-shadow: 0 0 12px rgba(34, 197, 94, 0.55); }
+.cnc-luz--ambar { background: #f59e0b; box-shadow: 0 0 12px rgba(245, 158, 11, 0.55); }
+.cnc-luz--rojo { background: #ef4444; box-shadow: 0 0 12px rgba(239, 68, 68, 0.55); }
+.cnc-semaforo-fila b {
+  display: block;
+  font-size: 14px;
+  color: rgb(var(--c-slate-100));
+}
+.cnc-semaforo-fila small {
+  font-size: 12px;
+  line-height: 1.35;
+  color: rgb(var(--c-slate-400));
+}
+
+/* 4 · Los mundos: rejilla de los 9 mundos REALES (tintes de mundosFinca.js).
+   Los tintes suaves son pasteles claros fijos → tinta oscura fija encima
+   (contraste garantizado, independiente del tema). */
+.cnc-mundos {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 9px;
+  width: 100%;
+  max-width: 350px;
+}
+.cnc-mundo {
+  border-radius: 14px;
+  padding: 10px 6px 9px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  border: 1.5px solid var(--cnc-mundo-a, #3f8f4e);
+  background: var(--cnc-mundo-b, #dcedc9);
+  animation: cnc-enter 0.5s ease both;
+  animation-delay: calc(var(--cnc-i, 0) * 70ms);
+}
+.cnc-mundo span { font-size: 22px; line-height: 1; }
+.cnc-mundo small {
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1.15;
+  color: #26323a; /* tinta fija sobre pastel fijo */
+  text-align: center;
+}
+
+/* 5 · La voz: micrófono + ondas + registro anotado. */
+.cnc-voz { display: flex; flex-direction: column; align-items: center; gap: 16px; width: 100%; }
+.cnc-mic {
+  width: 84px;
+  height: 84px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgb(var(--t-accent-rgb));
+  background: rgb(var(--c-surface-card));
+  border: 2px solid rgba(var(--t-accent-rgb), 0.55);
+  box-shadow: 0 0 0 9px rgba(var(--t-accent-rgb), 0.08), 0 0 34px rgba(var(--t-accent-rgb), 0.2);
+}
+.cnc-ondas { display: flex; align-items: center; gap: 4px; height: 26px; }
+.cnc-onda {
+  width: 4px;
+  border-radius: 999px;
+  background: rgb(var(--t-accent-rgb));
+  height: calc(6px + var(--cnc-h, 8) * 1px);
+  animation: cnc-onda 1.1s ease-in-out infinite;
+  animation-delay: calc(var(--cnc-i, 0) * 90ms);
+}
+@keyframes cnc-onda {
+  0%, 100% { transform: scaleY(0.55); }
+  50% { transform: scaleY(1); }
+}
+.cnc-registro {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgb(var(--c-surface-card));
+  border: 1px solid rgb(var(--c-surface-border));
+  border-left: 4px solid rgb(var(--t-accent-rgb));
+  border-radius: 14px;
+  padding: 12px 14px;
+  max-width: 330px;
+  text-align: left;
+  font-size: 14px;
+  color: rgb(var(--c-slate-200));
+}
+.cnc-registro .cnc-check { color: #22c55e; flex-shrink: 0; }
+
+/* 6 · Off-grid: la escena del monte (SVG propio) + sellos honestos. */
+.cnc-monte { width: min(78vw, 320px); border-radius: 18px; border: 1px solid rgb(var(--c-surface-border)); }
+.cnc-sellos { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; }
+.cnc-sello {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: rgb(var(--c-slate-200));
+  background: rgb(var(--c-surface-card));
+  border: 1px solid rgb(var(--c-surface-border));
+  border-radius: 999px;
+  padding: 6px 11px;
+}
+.cnc-sello svg { color: rgb(var(--t-accent-rgb)); }
+
+/* ── Accesibilidad de movimiento: el tour COMPLETO funciona quieto ───────── */
+@media (prefers-reduced-motion: reduce) {
+  .cnc-scene,
+  .cnc-visual,
+  .cnc-burbuja,
+  .cnc-semaforo-fila,
+  .cnc-mundo,
+  .cnc-onda,
+  .cnc-mano::after {
+    animation: none;
+  }
+  .cnc-dot { transition: none; }
+  .cnc-next:active,
+  .cnc-secondary:active,
+  .cnc-skip:active { transform: none; }
+}

--- a/src/components/conoce/conoceVisto.js
+++ b/src/components/conoce/conoceVisto.js
@@ -1,0 +1,26 @@
+/**
+ * conoceVisto.js — la huella persistente del recorrido "Conoce Chagra".
+ *
+ * Módulo mínimo SIN React ni CSS: lo comparten el tour (chunk lazy) y el
+ * invite de primera vez (bundle principal) sin que el invite arrastre las
+ * escenas completas al bundle inicial.
+ *
+ * Valores de la huella:
+ *   - 'abierto' — abrió el recorrido (aunque no lo terminara).
+ *   - 'omitido' — descartó la invitación ("Ahora no").
+ *   - '1'       — lo terminó o lo saltó desde adentro.
+ * Cualquier valor silencia la auto-oferta para siempre; el tour sigue
+ * disponible opt-in desde el Manual, el Perfil y el deep-link #conoce.
+ */
+
+export const CONOCE_VISTO_KEY = 'chagra:conoce-visto';
+
+/** @param {string} [valor] */
+export function marcarConoceVisto(valor = '1') {
+  try { window.localStorage.setItem(CONOCE_VISTO_KEY, valor); } catch (_) { /* noop */ }
+}
+
+/** @returns {boolean} true si ya vio, abrió u omitió el recorrido. */
+export function conoceYaVisto() {
+  try { return Boolean(window.localStorage.getItem(CONOCE_VISTO_KEY)); } catch (_) { return false; }
+}

--- a/src/components/conoce/escenasConoce.jsx
+++ b/src/components/conoce/escenasConoce.jsx
@@ -1,0 +1,223 @@
+/* eslint-disable react-refresh/only-export-components -- ESCENAS es el guion
+ * (data) del tour y exporta junto a los visuales que referencia; el tour en
+ * sí (ConoceChagra.jsx) queda limpio para fast-refresh. */
+/**
+ * escenasConoce — las 7 ESCENAS del recorrido "Conoce Chagra" + sus visuales.
+ *
+ * Separado de ConoceChagra.jsx para que el componente-pantalla exporte SOLO
+ * componentes (react-refresh/only-export-components) y para que el copy y los
+ * visuales se lean como lo que son: el guion del tour.
+ *
+ * Cada visual es JSX/SVG propio, theme-aware vía tokens (--t-accent-rgb /
+ * --c-* — ver conoce-chagra.css). Sin assets externos: el tour pesa lo que
+ * pesa su código. La escena de mundos importa los MUNDOS REALES
+ * (mundosFinca.js): si un mundo se renombra o se va, el tour lo refleja solo.
+ */
+import React from 'react';
+import {
+  Mic, Check, WifiOff, Sun, Smartphone, BookOpenCheck,
+} from 'lucide-react';
+import ManoChagraGlyph from '../dashboard/ManoChagraGlyph.jsx';
+import { MUNDOS_FINCA } from '../dashboard/mundosFinca.js';
+/** 1 · La mano de Chagra en su anillo-semilla, con los nodos de la red. */
+function VisualMano() {
+  // 6 nodos que brotan sobre el borde del anillo (la red de capacidades):
+  // posicionados por trigonometría sobre el radio del círculo (50% del lado).
+  const nodos = [15, 75, 140, 200, 262, 322];
+  return (
+    <div className="cnc-mano" aria-hidden="true">
+      <ManoChagraGlyph size={92} />
+      {nodos.map((deg) => {
+        const rad = (deg * Math.PI) / 180;
+        const s = Math.sin(rad).toFixed(4);
+        const c = Math.cos(rad).toFixed(4);
+        return (
+          <i
+            key={deg}
+            className="cnc-nodo"
+            style={{
+              left: `calc(50% + 50% * ${s})`,
+              top: `calc(50% - 50% * ${c})`,
+              transform: 'translate(-50%, -50%)',
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/** 2 · El agente: mini-conversación con cita de fuente. */
+function VisualAgente() {
+  return (
+    <div className="cnc-chat" aria-hidden="true">
+      <div className="cnc-burbuja cnc-burbuja--yo">
+        ¿Qué le echo al frijol pa&apos; la mosca blanca?
+      </div>
+      <div className="cnc-burbuja cnc-burbuja--chagra">
+        Revise el envés de las hojas. Para mosca blanca sirve el jabón
+        potásico y sembrar barreras que atraigan a sus enemigos naturales.
+        <span className="cnc-fuente">
+          <BookOpenCheck size={13} aria-hidden="true" /> Fuente verificada · catálogo Chagra
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** 3 · El semáforo de confianza científica (texto en cada fila: no color-only). */
+function VisualSemaforo() {
+  const filas = [
+    ['cnc-luz--verde', 'Validado', 'Con estudios o probado en campo.'],
+    ['cnc-luz--ambar', 'Documentado', 'Hay fuente; úselo con criterio.'],
+    ['cnc-luz--rojo', 'Sin respaldo', 'Chagra prefiere decir «no sé» antes que inventar.'],
+  ];
+  return (
+    <div className="cnc-semaforo">
+      {filas.map(([luz, titulo, desc]) => (
+        <div key={titulo} className="cnc-semaforo-fila">
+          <i className={`cnc-luz ${luz}`} aria-hidden="true" />
+          <div>
+            <b>{titulo}</b>
+            <small>{desc}</small>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** 4 · Los mundos REALES de la finca (fuente única: mundosFinca.js). */
+function VisualMundos() {
+  return (
+    <div className="cnc-mundos">
+      {MUNDOS_FINCA.map((m, i) => (
+        <div
+          key={m.id}
+          className="cnc-mundo"
+          data-testid={`cnc-mundo-${m.id}`}
+          style={{ '--cnc-mundo-a': m.tinte?.[0], '--cnc-mundo-b': m.tinte?.[1], '--cnc-i': i }}
+        >
+          <span aria-hidden="true">{m.emoji}</span>
+          <small>{m.titulo}</small>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** 5 · La voz: micrófono, ondas y un registro que queda anotado. */
+function VisualVoz() {
+  const ondas = [10, 18, 12, 22, 14, 20, 9];
+  return (
+    <div className="cnc-voz" aria-hidden="true">
+      <div className="cnc-mic"><Mic size={36} /></div>
+      <div className="cnc-ondas">
+        {ondas.map((h, i) => (
+          <i key={i} className="cnc-onda" style={{ '--cnc-h': h, '--cnc-i': i }} />
+        ))}
+      </div>
+      <div className="cnc-registro">
+        <Check size={20} className="cnc-check" />
+        <span>&laquo;Sembré 20 matas de frijol en la era 3&raquo; — anotado en su cuaderno.</span>
+      </div>
+    </div>
+  );
+}
+
+/** 6 · Off-grid: el monte, el sol y el panel solar — SVG propio (rsvg-safe). */
+function VisualOffgrid() {
+  return (
+    <div className="cnc-voz" aria-hidden="true">
+      <svg className="cnc-monte" viewBox="0 0 320 150" role="img">
+        <rect width="320" height="150" fill="#0d1f1a" />
+        {/* cielo estrellado sutil */}
+        <g fill="#9fd9c3" opacity="0.6">
+          <circle cx="36" cy="22" r="1.4" /><circle cx="92" cy="14" r="1.1" />
+          <circle cx="150" cy="26" r="1.3" /><circle cx="212" cy="12" r="1.1" />
+        </g>
+        {/* sol/luna de la madrugada campesina */}
+        <circle cx="262" cy="34" r="17" fill="#f2b441" />
+        <circle cx="262" cy="34" r="10.5" fill="#ffd98a" />
+        {/* cordillera */}
+        <path d="M-4 108 L58 56 L108 96 L168 44 L226 98 L288 62 L324 96 V150 H-4 Z" fill="#1d4636" />
+        <path d="M-4 122 L44 92 L116 122 L190 86 L258 120 L324 100 V150 H-4 Z" fill="#2e6b4f" />
+        {/* la casita de la finca con su panel solar */}
+        <g>
+          <rect x="128" y="102" width="42" height="26" rx="2" fill="#3b2b1d" />
+          <path d="M122 104 L149 86 L176 104 Z" fill="#5a422c" />
+          {/* panel solar sobre el techo */}
+          <rect x="138" y="88" width="22" height="10" rx="1.5" fill="#1e3a5f" stroke="#9fd9c3" strokeWidth="1" transform="rotate(-18 149 93)" />
+          <rect x="141" y="112" width="9" height="16" fill="#20140b" />
+          {/* ventana con luz prendida (energía propia) */}
+          <rect x="156" y="110" width="8" height="8" fill="#ffd98a" />
+        </g>
+        {/* señal tachada, honesta */}
+        <g transform="translate(38 96)">
+          <circle r="14" fill="#0d1f1a" stroke="#9fd9c3" strokeWidth="1.4" />
+          <path d="M-6 2 a8.5 8.5 0 0 1 12 0 M-3 5 a4.5 4.5 0 0 1 6 0" stroke="#9fd9c3" strokeWidth="1.8" fill="none" strokeLinecap="round" />
+          <circle cy="8" r="1.4" fill="#9fd9c3" />
+          <line x1="-9" y1="-9" x2="9" y2="9" stroke="#e07a5f" strokeWidth="2.2" strokeLinecap="round" />
+        </g>
+      </svg>
+      <div className="cnc-sellos">
+        <span className="cnc-sello"><Smartphone size={13} /> Sus datos, primero en su teléfono</span>
+        <span className="cnc-sello"><Sun size={13} /> Servidor con energía solar</span>
+        <span className="cnc-sello"><WifiOff size={13} /> Registre sin señal</span>
+      </div>
+    </div>
+  );
+}
+
+/* ── Las 7 escenas: el guion del recorrido ─────────────────────────────── */
+export const ESCENAS = [
+  {
+    id: 'mano',
+    kicker: 'Esto es Chagra',
+    titulo: 'Su mano en el campo.',
+    sub: 'Una app para andar su finca viva: el saber campesino y la ciencia abierta, juntos en su bolsillo.',
+    Visual: VisualMano,
+  },
+  {
+    id: 'agente',
+    kicker: 'El agente',
+    titulo: 'Pregunte como le pregunta a una vecina.',
+    sub: 'Chagra responde con datos verificados de más de 700 especies, plagas y remedios — y le dice de dónde salió cada cosa. La inteligencia corre en infraestructura propia, no en la nube de las grandes.',
+    Visual: VisualAgente,
+  },
+  {
+    id: 'confianza',
+    kicker: 'Confianza científica',
+    titulo: 'Chagra no inventa.',
+    sub: 'Cada respuesta trae su semáforo: qué está validado, qué está documentado y qué es mejor no afirmar. Si no hay respaldo, se lo dice de frente.',
+    Visual: VisualSemaforo,
+  },
+  {
+    id: 'mundos',
+    kicker: 'Los mundos de mi finca',
+    titulo: 'Su finca, en mundos.',
+    sub: 'El suelo vivo, el agua, los cultivos, los animales, la cosecha y el mercado: cada mundo agrupa lo suyo, como los rincones de la finca.',
+    Visual: VisualMundos,
+  },
+  {
+    id: 'voz',
+    kicker: 'La voz',
+    titulo: 'Dígalo, y queda anotado.',
+    sub: 'Registre siembras, cosechas y lo que vea en el campo hablando con Chagra — con las botas puestas y las manos en la tierra.',
+    Visual: VisualVoz,
+  },
+  {
+    id: 'offgrid',
+    kicker: 'Sin señal, sin susto',
+    titulo: 'Funciona en el monte.',
+    sub: 'Sus registros viven primero en su teléfono y se sincronizan cuando vuelve la señal. El agente sí necesita señal para responder — sus datos no. Y el servidor de Chagra trabaja con energía solar.',
+    Visual: VisualOffgrid,
+  },
+  {
+    id: 'cierre',
+    kicker: 'La chagra',
+    titulo: 'Saber campesino + ciencia. Eso es Chagra.',
+    sub: 'Hecha con campesinas y campesinos de Colombia, con código abierto y energía del sol. Bienvenida a su finca viva.',
+    Visual: VisualMano,
+  },
+];


### PR DESCRIPTION
## Qué es

**"Conoce Chagra"**: un recorrido guiado, corto y cinematográfico (7 escenas de pantalla completa) que le muestra a una campesina — o a un piloto/donante — **qué es Chagra y qué puede hacer**, sin tener que explorar la app. Vive en la estética de la mano de Chagra y toma TODO su color de los tokens de tema.

Doble uso:
- **Primera vez**: auto-oferta descartable en el home (tarjeta pequeña, NO un modal que tape; una sola vez, huella en `localStorage`).
- **Mostrar Chagra**: botón "Conoce Chagra" en el Manual y en el Perfil + deep-link compartible `#conoce`.

**NO toca** el onboarding de perfil (#2078) ni los mundos ni AgentScreen: cero estado compartido, un case nuevo en App.jsx.

## Las 7 escenas

1. **La mano** — "Su mano en el campo." (emblema en anillo-semilla con los nodos de la red)
2. **El agente** — "Pregunte como le pregunta a una vecina." (mini-chat con cita de fuente; honesto: "infraestructura propia, no en la nube de las grandes")
3. **Confianza científica** — "Chagra no inventa." (semáforo validado/documentado/sin-respaldo, con texto — no color-only)
4. **Los mundos** — "Su finca, en mundos." (los 9 mundos REALES importados de `mundosFinca.js`)
5. **La voz** — "Dígalo, y queda anotado."
6. **Sin señal, sin susto** — "Funciona en el monte." (local-first + servidor solar; honesto: "el agente sí necesita señal — sus datos no")
7. **Cierre** — "Saber campesino + ciencia. Eso es Chagra." (CTA doble: empezar / ver todas las funciones)

## Detalles técnicos

- **Theming**: solo tokens (`--c-*` + `--t-accent-rgb`); fondos 100% opacos (legible al sol) en las 5 pieles; CTA primario reusa `.agent-send-accent`.
- **Accesibilidad**: skippeable siempre (Saltar / Escape), flechas de teclado, swipe, tabs de escena; `prefers-reduced-motion` apaga TODA la animación (el tour funciona completo quieto — las capturas se toman así).
- **Bug cazado en verificación**: con `overflow:hidden`, el scroll-into-view del botón enfocado corría cabecera y escena 169 px fuera de pantalla al avanzar (medido con Playwright) → `overflow:clip` + reset de scroll por escena.
- **Chunk propio**: `ConoceChagra-*.js/.css` lazy; el invite del bundle principal solo importa `conoceVisto.js` (3 helpers sin React).
- `SyncProgressIndicator` y `AgentFab` excluidos de la vista `conoce` (el toast tapaba el CTA en captura).

## Verificación

- `npm run build` ✅ (chunk lazy propio)
- 13 tests nuevos ✅ (escenas, huella, teclado, mundos reales congelados a la fuente única, copy honesto anti-sobrepromesa, invite) + test de ruta `#conoce`
- tsc baseline: 1836 errores con y sin este diff (aporta 0)
- Capturas headless (390×844, reduced-motion): 7 escenas en biopunk + mano/mundos/cierre en nature, minimalista y verde-vivo + invite en dashboard — `scripts/conoce-shots.mjs --out-dir <dir>` las regenera.

> Draft hasta OK visual del operador (política: visuales esperan aprobación).

🤖 Generated with [Claude Code](https://claude.com/claude-code)