### PR TITLE
feat(mercado): vista "Mercado y despensa" — canales, valor agregado y precio en vivo

### DIFF
--- a/public/mercado-despensa.json
+++ b/public/mercado-despensa.json
@@ -1,0 +1,620 @@
+{
+  "meta": {
+    "titulo": "Mercado y despensa",
+    "subtitulo": "¿Por dónde vendo, cómo le agrego valor y a cómo está?",
+    "origen_datos": "Grafo de conocimiento chagra_kg (nodos CanalComercializacion + ValorAgregado y aristas SE_COMERCIALIZA_EN / SE_TRANSFORMA_EN), exportado a estático porque la PWA no consulta el grafo en vivo.",
+    "batch": "mercado-estructural-dr-2026-07-05",
+    "generado": "2026-07-05",
+    "total_canales": 6,
+    "total_valor_agregado": 4,
+    "total_despensa": 26,
+    "despensa_con_producto_sipsa": 23,
+    "nota_precios": "Este archivo NO contiene precios. Los precios del día los trae el agente en vivo con get_precio_sipsa (SIPSA/DANE). Donde no hay dato en vivo, se dice claro y se remite a la fuente oficial. Nunca se inventa un número.",
+    "fuente_precio_url": "https://www.dane.gov.co/index.php/estadisticas-por-tema/agropecuario/sistema-de-informacion-de-precios-sipsa"
+  },
+  "canales": [
+    {
+      "id": "canal_venta_directa_finca",
+      "nombre": "Venta directa al consumidor (sin intermediacion)",
+      "tipo": "circuito_corto",
+      "descripcion": "Comercializacion directa finca-consumidor; mayor porcentaje del precio final para el productor, relacion directa de confianza, flexibilidad en precio.",
+      "fuente": "FAO Colombia - Agricultura familiar y circuitos cortos de comercializacion",
+      "confianza": "media-alta",
+      "orden": 1,
+      "emoji": "🤝",
+      "titulo_corto": "Venta directa desde la finca",
+      "gancho": "El que más plata le deja: usted le vende directo a quien se lo come.",
+      "tono": "emerald"
+    },
+    {
+      "id": "canal_mercado_campesino",
+      "nombre": "Mercados Campesinos (circuito corto)",
+      "tipo": "circuito_corto",
+      "descripcion": "Venta directa en mercados campesinos/agroferias; modalidades sitio fijo, movil y en linea (canastas a domicilio, pedido a la carta). Dirigido a agricultura familiar campesina y comunitaria (ACFC). Requisitos: cedula + reconocimiento UMATA/ULATA (+ INVIMA si transforma).",
+      "fuente": "Ley 160 de 1994; Resolucion 464 de 2017 (MADR); mercadoscampesinos.gov.co",
+      "confianza": "alta",
+      "orden": 2,
+      "emoji": "🧺",
+      "titulo_corto": "Mercados campesinos",
+      "gancho": "La plaza campesina: sitio fijo, móvil o canastas a domicilio.",
+      "tono": "lime"
+    },
+    {
+      "id": "canal_agroferia_institucional",
+      "nombre": "Agroferia / gran mercado campesino institucional",
+      "tipo": "circuito_corto",
+      "descripcion": "Eventos periodicos de gran escala organizados por entidades territoriales (ej. Bogota, Manizales, Ibague, Putumayo) que conectan decenas/cientos de productores directamente con consumidores urbanos; evidencia de traccion: un Gran Mercado Campesino de Bogota supero $400 millones en ventas y conecto mas de 200 productores (2024-2026 acumulado distrital ~$24.900 millones).",
+      "fuente": "Bogota.gov.co / Secretaria Distrital de Desarrollo Economico",
+      "confianza": "media",
+      "orden": 3,
+      "emoji": "🎪",
+      "titulo_corto": "Agroferias y grandes mercados",
+      "gancho": "Los eventos grandes que arma la alcaldía o la gobernación.",
+      "tono": "amber"
+    },
+    {
+      "id": "canal_compra_publica_acfc",
+      "nombre": "Compras publicas locales a agricultura campesina, familiar y comunitaria",
+      "tipo": "compra_publica",
+      "descripcion": "Ley 2046 de 2020: todo programa/entidad publica o privada que compre alimentos con recursos publicos debe comprar minimo 30% a pequenos productores locales y ACFC (u organizaciones legalmente constituidas). Pago contra entrega (no espera terminos usuales de 30 dias habiles). Aplica a PAE, ICBF, Fuerzas Militares, sistema penitenciario, hospitales, universidades. Demanda PAE+ICBF > 2.6 billones COP/ano.",
+      "fuente": "Ley 2046 de 2020; colombiacompra.gov.co; fao.org/colombia",
+      "confianza": "alta",
+      "orden": 4,
+      "emoji": "🏫",
+      "titulo_corto": "Compra pública (Ley 2046)",
+      "oportunidad": true,
+      "gancho": "La ley obliga a comprarle mínimo 30% a la agricultura campesina. Y le pagan contra entrega.",
+      "tono": "violet"
+    },
+    {
+      "id": "canal_agroindustria_cliente_formal",
+      "nombre": "Venta a cliente formal (restaurante/tienda/agroindustria) via documento soporte DIAN",
+      "tipo": "b2b_formal",
+      "descripcion": "El pequeno productor no obligado a facturar puede venderle a un cliente formal: el comprador genera el 'Documento Soporte en Adquisiciones a No Obligados a Facturar' (Resolucion 000167 de 2021, modificada por Resolucion 000488 de 2022) para registrar costo/deduccion. Requiere nombre/NIT o cedula del productor.",
+      "fuente": "DIAN - Resolucion 000167 de 2021",
+      "confianza": "alta",
+      "orden": 5,
+      "emoji": "🧾",
+      "titulo_corto": "Venderle a un cliente formal",
+      "gancho": "Restaurante, tienda o agroindustria: el comprador hace el papeleo con la DIAN, usted no factura.",
+      "tono": "sky"
+    },
+    {
+      "id": "canal_central_mayorista_sipsa",
+      "nombre": "Central mayorista / SIPSA-DANE",
+      "tipo": "mayorista",
+      "descripcion": "Precios mayoristas de central de abasto publicados por el Sistema de Informacion de Precios y Abastecimiento del Sector Agropecuario (SIPSA-DANE), boletin semanal/diario, cobertura 32 mercados. El precio SIPSA es de central, no de finca: el productor recibe menos por flete e intermediacion.",
+      "fuente": "DANE - SIPSA (dane.gov.co)",
+      "confianza": "alta",
+      "orden": 6,
+      "emoji": "🚛",
+      "titulo_corto": "Central mayorista",
+      "gancho": "El precio de referencia del país (SIPSA/DANE). Ojo: es precio de central, no de finca.",
+      "tono": "slate"
+    }
+  ],
+  "valor_agregado": [
+    {
+      "id": "valor_agregado_panela",
+      "nombre": "Panela",
+      "tipo": "transformacion_artesanal",
+      "descripcion": "Alimento natural que NO requiere Registro Sanitario INVIMA mientras no se le agreguen saborizantes ni transformacion industrial adicional. Si se transforma mas, cambia el regimen sanitario.",
+      "fuente": "Affirma Legal - Productos que requieren Registro Sanitario INVIMA",
+      "confianza": "media-alta",
+      "orden": 1,
+      "emoji": "🟫",
+      "nivel_riesgo": "bajo",
+      "regimen": "No requiere Registro Sanitario INVIMA (mientras sea natural, sin saborizantes).",
+      "gancho": "La panela natural puede arrancar sin registro INVIMA."
+    },
+    {
+      "id": "valor_agregado_cafe_tostado",
+      "nombre": "Cafe tostado y molido",
+      "tipo": "transformacion_agroindustrial",
+      "descripcion": "Transformar cafe pergamino/verde a tostado multiplica el margen: indice ingresos/costos I/C=1,09 (estudio UTP 2018). No requiere el mismo tramite que lacteos pero si buenas practicas de manufactura.",
+      "fuente": "UTP - Simulador costo de produccion de cafe (repositorio institucional)",
+      "confianza": "media",
+      "orden": 2,
+      "emoji": "☕",
+      "nivel_riesgo": "bajo-medio",
+      "regimen": "No pide el mismo trámite que un lácteo, pero sí Buenas Prácticas de Manufactura (BPM).",
+      "gancho": "Tostar y moler el café multiplica el margen frente al pergamino."
+    },
+    {
+      "id": "valor_agregado_mermelada",
+      "nombre": "Mermelada",
+      "tipo": "transformacion_artesanal",
+      "descripcion": "Producto transformado que entra a categorizacion de riesgo INVIMA (Registro/Permiso/Notificacion Sanitaria segun riesgo). Microempresas, cooperativas y asociaciones agropecuarias estan exentas del pago de tarifas de registro sanitario la primera vez (Ley 2069 de 2020).",
+      "fuente": "INVIMA; Ley 2069 de 2020",
+      "confianza": "media",
+      "orden": 3,
+      "emoji": "🍓",
+      "nivel_riesgo": "medio",
+      "regimen": "Entra a categorización de riesgo INVIMA (Registro/Permiso/Notificación según riesgo).",
+      "gancho": "Microempresas y asociaciones NO pagan la tarifa del registro la primera vez (Ley 2069/2020)."
+    },
+    {
+      "id": "valor_agregado_queso",
+      "nombre": "Queso (lacteo transformado)",
+      "tipo": "transformacion_agroindustrial",
+      "descripcion": "Lacteo transformado, categoria de ALTO RIESGO ante INVIMA: requiere Registro Sanitario (RSA) con vigencia de 5 anos, evaluacion documental y tecnica completa, segun Resolucion 719 de 2015 y Resolucion 2674 de 2013.",
+      "fuente": "INVIMA - pasos para registro/permiso/notificacion sanitaria; Res. 719/2015, Res. 2674/2013",
+      "confianza": "media-alta",
+      "orden": 4,
+      "emoji": "🧀",
+      "nivel_riesgo": "alto",
+      "regimen": "Lácteo = ALTO RIESGO: exige Registro Sanitario (RSA), vigencia 5 años (Res. 719/2015, 2674/2013).",
+      "gancho": "El queso vende bien, pero es el trámite sanitario más exigente. Planéelo con tiempo."
+    }
+  ],
+  "despensa": [
+    {
+      "species_id": "persea_americana",
+      "nombre_comun": "Aguacate",
+      "nombre_cientifico": "Persea americana Mill.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_venta_directa_finca"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "aguacate",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608148225/original.jpg",
+        "licencia": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "autor": "Hugo Saulino"
+      }
+    },
+    {
+      "species_id": "arracacia_xanthorrhiza_amarilla",
+      "nombre_comun": "Arracacha amarilla",
+      "nombre_cientifico": "Arracacia xanthorrhiza Bancr. cv. 'Amarilla'",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_mercado_campesino",
+        "canal_central_mayorista_sipsa"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "arracacha",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/182461836/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Nicolás Baresch Uribe"
+      }
+    },
+    {
+      "species_id": "oryza_sativa",
+      "nombre_comun": "Arroz Clearfield",
+      "nombre_cientifico": "Oryza sativa L. (tecnología Clearfield, tolerante a imidazolinonas)",
+      "canales": [
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_compra_publica_acfc"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": null,
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/492154473/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Aditya Rao"
+      }
+    },
+    {
+      "species_id": "pisum_sativum",
+      "nombre_comun": "Arveja",
+      "nombre_cientifico": "Pisum sativum",
+      "canales": [
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_compra_publica_acfc"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "arveja",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/57714057/medium.jpg",
+        "licencia": "cc-by-nc",
+        "autor": "(c) Luca Boscain, some rights reserved (CC BY-NC), uploaded by Luca Boscain"
+      }
+    },
+    {
+      "species_id": "theobroma_cacao",
+      "nombre_comun": "Cacao",
+      "nombre_cientifico": "Theobroma cacao L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": null,
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608761215/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Derek Duplessis"
+      }
+    },
+    {
+      "species_id": "coffea_arabica",
+      "nombre_comun": "Café caturra / Castillo / Cenicafé 1",
+      "nombre_cientifico": "Coffea arabica L.",
+      "canales": [
+        "canal_mercado_campesino",
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa"
+      ],
+      "transforma_en": "valor_agregado_cafe_tostado",
+      "producto_sipsa": null,
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605811844/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Richard Jacob"
+      }
+    },
+    {
+      "species_id": "cucurbita_maxima",
+      "nombre_comun": "Calabaza / Auyama",
+      "nombre_cientifico": "Cucurbita maxima Duchesne",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "calabaza",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607534145/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Joe Dillon"
+      }
+    },
+    {
+      "species_id": "allium_cepa",
+      "nombre_comun": "Cebolla cabezona",
+      "nombre_cientifico": "Allium cepa L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "cebolla cabezona",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/640133931/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Fyodor Pudovikov"
+      }
+    },
+    {
+      "species_id": "coriandrum_sativum",
+      "nombre_comun": "Cilantro",
+      "nombre_cientifico": "Coriandrum sativum L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "cilantro",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/644275211/original.jpg",
+        "licencia": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "autor": "lanechaffin"
+      }
+    },
+    {
+      "species_id": "fragaria_ananassa_monterrey",
+      "nombre_comun": "Fresa Monterrey",
+      "nombre_cientifico": "Fragaria × ananassa 'Monterrey'",
+      "canales": [
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_compra_publica_acfc"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "fresa",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611897519/original.jpg",
+        "licencia": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "autor": "NENP_StBartsNewbury"
+      }
+    },
+    {
+      "species_id": "phaseolus_vulgaris",
+      "nombre_comun": "Frijol arbustivo / voluble",
+      "nombre_cientifico": "Phaseolus vulgaris L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_central_mayorista_sipsa",
+        "canal_venta_directa_finca",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "frijol",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/500118303/original.jpeg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Raúl A. Ruiz M."
+      }
+    },
+    {
+      "species_id": "vicia_faba",
+      "nombre_comun": "Haba",
+      "nombre_cientifico": "Vicia faba L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_mercado_campesino",
+        "canal_central_mayorista_sipsa"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "haba",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604467340/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Tracy PW"
+      }
+    },
+    {
+      "species_id": "lactuca_sativa",
+      "nombre_comun": "Lechuga",
+      "nombre_cientifico": "Lactuca sativa L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_mercado_campesino",
+        "canal_central_mayorista_sipsa"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "lechuga",
+      "imagen": {
+        "url": "https://observation.org/photos/146115174.jpg",
+        "licencia": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+        "autor": "Bram vd Bergh"
+      }
+    },
+    {
+      "species_id": "solanum_quitoense",
+      "nombre_comun": "Lulo / Naranjilla / Chuva",
+      "nombre_cientifico": "Solanum quitoense Lam.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_venta_directa_finca"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "lulo",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610859797/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Alina Martin"
+      }
+    },
+    {
+      "species_id": "zea_mays",
+      "nombre_comun": "Maíz criollo",
+      "nombre_cientifico": "Zea mays L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "maiz",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618509763/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Hannah Stitt"
+      }
+    },
+    {
+      "species_id": "rubus_glaucus",
+      "nombre_comun": "Mora andina / Mora de Castilla",
+      "nombre_cientifico": "Rubus glaucus Benth.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_venta_directa_finca"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "mora",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/462588725/original.jpg",
+        "licencia": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "autor": "Zoltán Stekkelpak"
+      }
+    },
+    {
+      "species_id": "solanum_tuberosum",
+      "nombre_comun": "Papa parda pastusa",
+      "nombre_cientifico": "Solanum tuberosum L. subsp. andigenum var. parda pastusa",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "papa",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607744677/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Elliot Greiner"
+      }
+    },
+    {
+      "species_id": "musa_paradisiaca",
+      "nombre_comun": "Plátano",
+      "nombre_cientifico": "Musa × paradisiaca L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_venta_directa_finca"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "banano",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608043778/original.jpg",
+        "licencia": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "autor": "Sinaloa Silvestre"
+      }
+    },
+    {
+      "species_id": "chenopodium_quinoa",
+      "nombre_comun": "Quinua",
+      "nombre_cientifico": "Chenopodium quinoa Willd.",
+      "canales": [
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_compra_publica_acfc"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "quinua",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/463521370/original.jpeg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Humber Alberto"
+      }
+    },
+    {
+      "species_id": "beta_vulgaris_conditiva",
+      "nombre_comun": "Remolacha",
+      "nombre_cientifico": "Beta vulgaris L. subsp. vulgaris Conditiva Group",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_mercado_campesino",
+        "canal_central_mayorista_sipsa"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "remolacha",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605386667/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Shane Austin"
+      }
+    },
+    {
+      "species_id": "brassica_oleracea_var_capitata",
+      "nombre_comun": "Repollo",
+      "nombre_cientifico": "Brassica oleracea var. capitata L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "repollo",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+        "licencia": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "autor": "Peter de Lange"
+      }
+    },
+    {
+      "species_id": "solanum_lycopersicum",
+      "nombre_comun": "Tomate chonto",
+      "nombre_cientifico": "Solanum lycopersicum L.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "tomate",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608629968/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Dave Richardson"
+      }
+    },
+    {
+      "species_id": "solanum_betaceum",
+      "nombre_comun": "Tomate de árbol / Tamarillo",
+      "nombre_cientifico": "Solanum betaceum Cav.",
+      "canales": [
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_compra_publica_acfc"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "tomate arbol",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605808233/original.jpg",
+        "licencia": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "autor": "Steven Smethurst"
+      }
+    },
+    {
+      "species_id": "physalis_peruviana",
+      "nombre_comun": "Uchuva",
+      "nombre_cientifico": "Physalis peruviana L.",
+      "canales": [
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_compra_publica_acfc"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "uchuva",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606541557/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "desertnaturalist"
+      }
+    },
+    {
+      "species_id": "manihot_esculenta",
+      "nombre_comun": "Yuca brava amazónica",
+      "nombre_cientifico": "Manihot esculenta Crantz",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino",
+        "canal_venta_directa_finca"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "yuca",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608599553/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Mark"
+      }
+    },
+    {
+      "species_id": "daucus_carota_subsp_sativus",
+      "nombre_comun": "Zanahoria",
+      "nombre_cientifico": "Daucus carota L. subsp. sativus (Hoffm.) Arcang.",
+      "canales": [
+        "canal_compra_publica_acfc",
+        "canal_venta_directa_finca",
+        "canal_central_mayorista_sipsa",
+        "canal_mercado_campesino"
+      ],
+      "transforma_en": null,
+      "producto_sipsa": "zanahoria",
+      "imagen": {
+        "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605366692/original.jpg",
+        "licencia": "http://creativecommons.org/licenses/by/4.0/",
+        "autor": "Karen Fry"
+      }
+    }
+  ]
+}

--- a/scripts/export-mercado-to-json.mjs
+++ b/scripts/export-mercado-to-json.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * export-mercado-to-json.mjs — exporta la ESTRUCTURA DE MERCADO del grafo de
+ * conocimiento `chagra_kg` (Apache AGE) a `public/mercado-despensa.json`, que
+ * consume la mini-app "Mercado y despensa" (MercadoDespensaScreen). La PWA NO
+ * consulta el grafo en vivo, así que congelamos un snapshot estático — mismo
+ * patrón que `nutricion-humana.json`.
+ *
+ * FUENTE ÚNICA de los HECHOS (canales, requisitos, marco INVIMA, aristas):
+ *   grafo chagra_kg — nodos CanalComercializacion (6) + ValorAgregado (4) +
+ *   aristas SE_COMERCIALIZA_EN (especie→canal) y SE_TRANSFORMA_EN (especie→valor).
+ *   Batch de origen: `mercado-estructural-dr-2026-07-05`.
+ *
+ * CERO invención de PRECIOS: este JSON no lleva ni un peso. Los precios los
+ * resuelve el agente en vivo con `get_precio_sipsa` (SIPSA/DANE). Aquí solo va
+ * el `producto_sipsa` (la clave para consultar) resuelto vía `sipsaProductMap`.
+ *
+ * Se corre a mano desde `stg` (tiene ssh a `alpha`, donde vive postgres-farm):
+ *   node scripts/export-mercado-to-json.mjs
+ *
+ * Las etiquetas didácticas (emoji, orden narrativo, nivel de riesgo sanitario,
+ * gancho) son PRESENTACIÓN en lenguaje llano de los MISMOS hechos del grafo —
+ * no agregan datos nuevos. Cada afirmación de la UI traza al campo `descripcion`
+ * o `fuente` del nodo correspondiente.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const SSH_HOST = process.env.CHAGRA_KG_SSH_HOST || 'alpha';
+const GRAPH = 'chagra_kg';
+
+/** Corre un query Cypher en AGE vía ssh + podman + psql, devuelve filas crudas.
+ *  El SQL viaja por STDIN (podman exec -i) para no pelear con el escape de `$$`
+ *  del shell remoto (que si no lo expande al PID). */
+function cypher(query, colspec) {
+  const sql =
+    `LOAD 'age'; SET search_path=ag_catalog,public;\n` +
+    `SELECT * FROM cypher('${GRAPH}', $$ ${query} $$) AS (${colspec});\n`;
+  const remote = `sudo podman exec -i postgres-farm psql -U farmos -d ${GRAPH} -tA -F'\t'`;
+  const out = execFileSync('ssh', [SSH_HOST, remote], {
+    input: sql,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return out
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .filter((l) => l && !/^(LOAD|SET)$/.test(l));
+}
+
+/** agtype escalar → JS. Los strings vienen entre comillas; los objetos son JSON. */
+function parseAg(cell) {
+  if (cell == null || cell === '') return null;
+  try {
+    return JSON.parse(cell);
+  } catch {
+    return cell.replace(/^"|"$/g, '');
+  }
+}
+
+// ── 1. Nodos canal + valor agregado (hechos verbatim del grafo) ──────────────
+const canalesRaw = cypher('MATCH (c:CanalComercializacion) RETURN properties(c)', 'p agtype')
+  .map((l) => parseAg(l))
+  .filter(Boolean);
+
+const valorRaw = cypher('MATCH (v:ValorAgregado) RETURN properties(v)', 'p agtype')
+  .map((l) => parseAg(l))
+  .filter(Boolean);
+
+// ── 2. Aristas especie → canal (con nombre común de la especie) ──────────────
+const comercializaRows = cypher(
+  'MATCH (s)-[:SE_COMERCIALIZA_EN]->(c) RETURN s.id, s.nombre_comun, c.id',
+  'sid agtype, nom agtype, cid agtype',
+).map((l) => {
+  const [sid, nom, cid] = l.split('\t');
+  return { species_id: parseAg(sid), nombre_comun: parseAg(nom), canal_id: parseAg(cid) };
+});
+
+// ── 3. Aristas especie → valor agregado ──────────────────────────────────────
+const transformaRows = cypher(
+  'MATCH (s)-[:SE_TRANSFORMA_EN]->(v) RETURN s.id, s.nombre_comun, v.id',
+  'sid agtype, nom agtype, vid agtype',
+).map((l) => {
+  const [sid, nom, vid] = l.split('\t');
+  return { species_id: parseAg(sid), nombre_comun: parseAg(nom), valor_id: parseAg(vid) };
+});
+
+// ── 4. Joins locales: fotos (species-images.json) + producto SIPSA ───────────
+const imgs = JSON.parse(readFileSync(resolve(ROOT, 'public/species-images.json'), 'utf8'));
+const imgById = new Map();
+for (const s of imgs.species) if (s?.species_id && s?.image_url) imgById.set(s.species_id, s);
+
+const sipsaMap = JSON.parse(readFileSync(resolve(ROOT, 'src/data/sipsaProductMap.json'), 'utf8'));
+const slugToProducto = {};
+for (const [producto, slug] of Object.entries(sipsaMap)) {
+  if (producto.startsWith('_')) continue;
+  if (!(slug in slugToProducto)) slugToProducto[slug] = producto;
+}
+// Alias verificados 1:1 para variedades del catálogo cuyo slug exacto no está en
+// el mapa SIPSA pero cuya identidad de cultivo es inequívoca (misma especie
+// comercial, sin ambigüedad de producto). NO son precios: solo la clave de
+// consulta para get_precio_sipsa. Verificado contra sipsaProductMap.json.
+const SIPSA_ALIAS = {
+  arracacia_xanthorrhiza_amarilla: 'arracacha',
+  brassica_oleracea_var_capitata: 'repollo',
+  lactuca_sativa: 'lechuga',
+  pisum_sativum: 'arveja',
+  solanum_lycopersicum: 'tomate',
+};
+const productoSipsa = (slug) => slugToProducto[slug] || SIPSA_ALIAS[slug] || null;
+
+// ── 5. Capa DIDÁCTICA (presentación de los MISMOS hechos, orden narrativo) ────
+// Orden = del canal más cercano al campesino / mejor margen, al mayorista.
+const CANAL_UI = {
+  canal_venta_directa_finca: {
+    orden: 1, emoji: '🤝', titulo_corto: 'Venta directa desde la finca',
+    gancho: 'El que más plata le deja: usted le vende directo a quien se lo come.',
+    tono: 'emerald',
+  },
+  canal_mercado_campesino: {
+    orden: 2, emoji: '🧺', titulo_corto: 'Mercados campesinos',
+    gancho: 'La plaza campesina: sitio fijo, móvil o canastas a domicilio.',
+    tono: 'lime',
+  },
+  canal_agroferia_institucional: {
+    orden: 3, emoji: '🎪', titulo_corto: 'Agroferias y grandes mercados',
+    gancho: 'Los eventos grandes que arma la alcaldía o la gobernación.',
+    tono: 'amber',
+  },
+  canal_compra_publica_acfc: {
+    orden: 4, emoji: '🏫', titulo_corto: 'Compra pública (Ley 2046)', oportunidad: true,
+    gancho: 'La ley obliga a comprarle mínimo 30% a la agricultura campesina. Y le pagan contra entrega.',
+    tono: 'violet',
+  },
+  canal_agroindustria_cliente_formal: {
+    orden: 5, emoji: '🧾', titulo_corto: 'Venderle a un cliente formal',
+    gancho: 'Restaurante, tienda o agroindustria: el comprador hace el papeleo con la DIAN, usted no factura.',
+    tono: 'sky',
+  },
+  canal_central_mayorista_sipsa: {
+    orden: 6, emoji: '🚛', titulo_corto: 'Central mayorista',
+    gancho: 'El precio de referencia del país (SIPSA/DANE). Ojo: es precio de central, no de finca.',
+    tono: 'slate',
+  },
+};
+
+// Régimen sanitario / nivel de riesgo derivado del texto del nodo (verbatim del
+// grafo). El nivel ordena de "puede arrancar ya" a "trámite fuerte".
+const VALOR_UI = {
+  valor_agregado_panela: {
+    orden: 1, emoji: '🟫', nivel_riesgo: 'bajo',
+    regimen: 'No requiere Registro Sanitario INVIMA (mientras sea natural, sin saborizantes).',
+    gancho: 'La panela natural puede arrancar sin registro INVIMA.',
+  },
+  valor_agregado_cafe_tostado: {
+    orden: 2, emoji: '☕', nivel_riesgo: 'bajo-medio',
+    regimen: 'No pide el mismo trámite que un lácteo, pero sí Buenas Prácticas de Manufactura (BPM).',
+    gancho: 'Tostar y moler el café multiplica el margen frente al pergamino.',
+  },
+  valor_agregado_mermelada: {
+    orden: 3, emoji: '🍓', nivel_riesgo: 'medio',
+    regimen: 'Entra a categorización de riesgo INVIMA (Registro/Permiso/Notificación según riesgo).',
+    gancho: 'Microempresas y asociaciones NO pagan la tarifa del registro la primera vez (Ley 2069/2020).',
+  },
+  valor_agregado_queso: {
+    orden: 4, emoji: '🧀', nivel_riesgo: 'alto',
+    regimen: 'Lácteo = ALTO RIESGO: exige Registro Sanitario (RSA), vigencia 5 años (Res. 719/2015, 2674/2013).',
+    gancho: 'El queso vende bien, pero es el trámite sanitario más exigente. Planéelo con tiempo.',
+  },
+};
+
+// ── 6. Ensamble final ────────────────────────────────────────────────────────
+const canales = canalesRaw
+  .map((c) => ({
+    id: c.id,
+    nombre: c.nombre,
+    tipo: c.tipo,
+    descripcion: c.descripcion,
+    fuente: c.fuente,
+    confianza: c.confianza,
+    ...(CANAL_UI[c.id] || { orden: 99, emoji: '•', tono: 'slate' }),
+  }))
+  .sort((a, b) => a.orden - b.orden);
+
+const valorAgregado = valorRaw
+  .map((v) => ({
+    id: v.id,
+    nombre: v.nombre,
+    tipo: v.tipo,
+    descripcion: v.descripcion,
+    fuente: v.fuente,
+    confianza: v.confianza,
+    ...(VALOR_UI[v.id] || { orden: 99, emoji: '•', nivel_riesgo: 'n/d' }),
+  }))
+  .sort((a, b) => a.orden - b.orden);
+
+// Despensa: una entrada por especie que se comercializa, con sus canales, su
+// transformación (si tiene) y su producto SIPSA (para el chip de precio vivo).
+const transformaBySpecies = new Map();
+for (const t of transformaRows) transformaBySpecies.set(t.species_id, t.valor_id);
+
+const despensaMap = new Map();
+for (const row of comercializaRows) {
+  if (!despensaMap.has(row.species_id)) {
+    const img = imgById.get(row.species_id) || null;
+    despensaMap.set(row.species_id, {
+      species_id: row.species_id,
+      nombre_comun: row.nombre_comun,
+      nombre_cientifico: img?.scientific_name || null,
+      canales: [],
+      transforma_en: transformaBySpecies.get(row.species_id) || null,
+      producto_sipsa: productoSipsa(row.species_id),
+      imagen: img
+        ? { url: img.image_url, licencia: img.license || null, autor: img.attribution || null }
+        : null,
+    });
+  }
+  despensaMap.get(row.species_id).canales.push(row.canal_id);
+}
+const despensa = [...despensaMap.values()].sort((a, b) =>
+  a.nombre_comun.localeCompare(b.nombre_comun, 'es'));
+
+const conPrecio = despensa.filter((d) => d.producto_sipsa).length;
+
+const out = {
+  meta: {
+    titulo: 'Mercado y despensa',
+    subtitulo: '¿Por dónde vendo, cómo le agrego valor y a cómo está?',
+    origen_datos:
+      'Grafo de conocimiento chagra_kg (nodos CanalComercializacion + ValorAgregado y aristas ' +
+      'SE_COMERCIALIZA_EN / SE_TRANSFORMA_EN), exportado a estático porque la PWA no consulta el grafo en vivo.',
+    batch: 'mercado-estructural-dr-2026-07-05',
+    generado: new Date().toISOString().slice(0, 10),
+    total_canales: canales.length,
+    total_valor_agregado: valorAgregado.length,
+    total_despensa: despensa.length,
+    despensa_con_producto_sipsa: conPrecio,
+    nota_precios:
+      'Este archivo NO contiene precios. Los precios del día los trae el agente en vivo con get_precio_sipsa ' +
+      '(SIPSA/DANE). Donde no hay dato en vivo, se dice claro y se remite a la fuente oficial. Nunca se inventa un número.',
+    fuente_precio_url: 'https://www.dane.gov.co/index.php/estadisticas-por-tema/agropecuario/sistema-de-informacion-de-precios-sipsa',
+  },
+  canales,
+  valor_agregado: valorAgregado,
+  despensa,
+};
+
+const dest = resolve(ROOT, 'public/mercado-despensa.json');
+writeFileSync(dest, JSON.stringify(out, null, 2) + '\n', 'utf8');
+console.log(
+  `✓ ${dest}\n  ${canales.length} canales · ${valorAgregado.length} valor agregado · ` +
+  `${despensa.length} cultivos en despensa (${conPrecio} con producto SIPSA) · ` +
+  `${transformaRows.length} aristas de transformación`,
+);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -128,6 +128,12 @@ const PoscosechaScreen = lazy(() => import('./components/PoscosechaScreen'));
 // nutricional (ICBF TCAC 2015) por cultivo, exportado del grafo chagra_kg a
 // public/nutricion-humana.json (la PWA no consulta el grafo en vivo).
 const NutricionHumanaScreen = lazy(() => import('./components/NutricionHumanaScreen'));
+// Módulo "Mercado y despensa" (mundo del mismo nombre): los 6 canales de
+// comercialización + los 4 productos con valor agregado (marco INVIMA) + precio
+// del día EN VIVO por cultivo (get_precio_sipsa). Estructura de mercado
+// exportada del grafo chagra_kg a public/mercado-despensa.json; los precios
+// SIEMPRE se traen en vivo (nunca hardcodeados).
+const MercadoDespensaScreen = lazy(() => import('./components/MercadoDespensaScreen'));
 // LOS MUNDOS DE MI FINCA (reestructuración 2.0 del home): un mundo por dentro —
 // las funciones existentes agrupadas por lugar. Re-rutea, no reimplementa.
 const MundoScreen = lazy(() => import('./components/MundoScreen'));
@@ -254,6 +260,9 @@ const HASH_VIEW_ROUTES = {
   nutricion: 'nutricion',
   'nutricion-humana': 'nutricion',
   'comida-que-alimenta': 'nutricion',
+  'mercado-despensa': 'mercado_despensa',
+  mercado_despensa: 'mercado_despensa',
+  'por-donde-vendo': 'mercado_despensa',
   // Curso guiado + deep-links profundos usados por la landing (chagra.bio):
   // permiten que chagra.app/#curso, /#sembrar, /#voz, /#milpa, /#biopreparados,
   // /#sanidad y /#cosechar caigan en su vista real (antes caían a dashboard).
@@ -280,7 +289,7 @@ const MODULE_VIEWS = new Set([
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
-  'usage_stats', 'mercado', 'auditoria_inventario', 'mundo',
+  'usage_stats', 'mercado', 'mercado_despensa', 'auditoria_inventario', 'mundo',
 ]);
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -1373,6 +1382,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="La comida que alimenta">
               <NutricionHumanaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mercado_despensa':
+        // Módulo "Mercado y despensa" (mundo del mismo nombre): ¿por dónde
+        // vendo? (6 canales, ACFC Ley 2046 como oportunidad) · ¿cómo le agrego
+        // valor? (4 valor agregado + marco INVIMA) · ¿a cómo está? (precio del
+        // día EN VIVO por cultivo vía get_precio_sipsa — SIPSA/DANE, nunca
+        // hardcodeado). Estructura exportada del grafo chagra_kg a
+        // public/mercado-despensa.json.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mercado y despensa">
+              <MercadoDespensaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/MercadoDespensaScreen.jsx
+++ b/src/components/MercadoDespensaScreen.jsx
@@ -1,0 +1,592 @@
+/* i18n (ADR-050): etiquetas user-facing en español Colombia pendientes de
+ * migrar a src/config/messages.js. Misma deuda preexistente que
+ * NutricionHumanaScreen / PoscosechaScreen; se desactiva la regla soft aquí. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ChevronLeft, ChevronDown, Store, Sprout, HandCoins, Factory, ShieldCheck,
+  Info, ExternalLink, TrendingUp, Landmark, Loader2, MessageCircle, X,
+} from 'lucide-react';
+import { getPrecioSipsa } from '../services/sidecarClient';
+
+/**
+ * MercadoDespensaScreen — mini-app "Mercado y despensa" (mundo del mismo
+ * nombre). Responde tres preguntas del campesino que ya cosechó:
+ *   1. ¿Por dónde vendo?      → los 6 canales de comercialización + la compra
+ *                               pública ACFC (Ley 2046) como OPORTUNIDAD.
+ *   2. ¿Cómo le agrego valor? → los 4 productos con valor agregado + su marco
+ *                               sanitario real (INVIMA).
+ *   3. ¿A cómo está hoy?      → precio EN VIVO por cultivo vía get_precio_sipsa
+ *                               (SIPSA/DANE). CERO precios hardcodeados: si no
+ *                               hay dato en vivo, se dice claro y se remite a la
+ *                               fuente oficial. Nunca se inventa un número.
+ *
+ * FUENTE de los HECHOS (canales, requisitos, marco INVIMA, aristas): grafo de
+ * conocimiento `chagra_kg`, exportado a `public/mercado-despensa.json` porque la
+ * PWA no consulta el grafo en vivo (mismo patrón que nutricion-humana.json).
+ *
+ * Legibilidad al sol + WCAG: superficies opacas (slate-900/950), texto en
+ * slate-100/white (tinta oscura en temas claros vía themes.css). Los colores
+ * vivos por canal (emerald/violet/amber/…) se usan SOLO como grafismo (punto,
+ * borde, velo), nunca como texto sobre superficie clara. Animaciones sutiles,
+ * todas apagadas con prefers-reduced-motion.
+ */
+
+/* Íconos por tipo de canal (lucide, decorativos). */
+const CANAL_ICON = {
+  canal_venta_directa_finca: HandCoins,
+  canal_mercado_campesino: Store,
+  canal_agroferia_institucional: Store,
+  canal_compra_publica_acfc: Landmark,
+  canal_agroindustria_cliente_formal: Factory,
+  canal_central_mayorista_sipsa: TrendingUp,
+};
+
+/* Paleta por tono — clases LITERALES (Tailwind JIT no ve strings construidos).
+ * `dot`/`ring`/`soft` = grafismo; el texto siempre va en slate, legible. */
+const TONO = {
+  emerald: { dot: 'bg-emerald-400', ring: 'border-emerald-500/40', soft: 'bg-emerald-500/10', icon: 'text-emerald-400' },
+  lime: { dot: 'bg-lime-400', ring: 'border-lime-500/40', soft: 'bg-lime-500/10', icon: 'text-lime-400' },
+  amber: { dot: 'bg-amber-400', ring: 'border-amber-500/40', soft: 'bg-amber-500/10', icon: 'text-amber-400' },
+  violet: { dot: 'bg-violet-400', ring: 'border-violet-500/50', soft: 'bg-violet-500/10', icon: 'text-violet-400' },
+  sky: { dot: 'bg-sky-400', ring: 'border-sky-500/40', soft: 'bg-sky-500/10', icon: 'text-sky-400' },
+  slate: { dot: 'bg-slate-400', ring: 'border-slate-600', soft: 'bg-slate-500/10', icon: 'text-slate-300' },
+};
+
+/* Estilo del badge de riesgo sanitario (valor agregado). */
+const RIESGO_ESTILO = {
+  bajo: { label: 'Trámite bajo', chip: 'border-emerald-500/60 text-emerald-300', dot: 'bg-emerald-400' },
+  'bajo-medio': { label: 'Trámite bajo-medio', chip: 'border-lime-500/60 text-lime-300', dot: 'bg-lime-400' },
+  medio: { label: 'Trámite medio', chip: 'border-amber-500/60 text-amber-300', dot: 'bg-amber-400' },
+  alto: { label: 'Trámite alto', chip: 'border-rose-500/60 text-rose-300', dot: 'bg-rose-400' },
+};
+
+/* COP entero es-CO: 4600 → "4.600". */
+function formatCop(n) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return null;
+  return Math.round(n).toLocaleString('es-CO');
+}
+
+/* "2026-06-25" → "25 de junio". Devuelve la ISO cruda si no parsea. */
+function fechaCorta(iso) {
+  if (typeof iso !== 'string') return '';
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return iso;
+  const meses = ['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+    'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre'];
+  return `${Number(m[3])} de ${meses[Number(m[2]) - 1] || m[2]}`;
+}
+
+/* ── Ilustración SVG propia: un puesto de mercado con toldo, cajón de cosecha y
+ *    el sol. Colores en CSS-var del acento para respirar con el tema. ───────── */
+function PuestoIlustracion() {
+  return (
+    <svg viewBox="0 0 260 140" role="img"
+      aria-label="Ilustración de un puesto de mercado campesino con toldo, cosecha y sol"
+      className="w-full h-auto">
+      <rect x="0" y="0" width="260" height="140" rx="6" fill="rgb(var(--t-accent-rgb) / 0.08)" />
+      {/* Sol */}
+      <circle cx="34" cy="30" r="13" fill="#f4b83c" className="md-sun" />
+      <g stroke="#f4b83c" strokeWidth="2" strokeLinecap="round" className="md-sun">
+        <path d="M34 8 V2" /><path d="M12 30 H5" /><path d="M18 14 L14 10" /><path d="M50 14 L54 10" />
+      </g>
+      {/* Toldo rayado */}
+      <path d="M150 40 h96 l-8 22 h-96 z" fill="#c65b3c" />
+      <path d="M166 40 l-8 22 M182 40 l-8 22 M198 40 l-8 22 M214 40 l-8 22 M230 40 l-8 22" stroke="#e9e2d2" strokeWidth="5" />
+      {/* Postes + mesa */}
+      <rect x="150" y="62" width="4" height="46" fill="#7a5a3c" />
+      <rect x="238" y="62" width="4" height="46" fill="#7a5a3c" />
+      <rect x="142" y="96" width="108" height="10" rx="3" fill="#8a6a44" />
+      {/* Cajón de cosecha con productos */}
+      <rect x="158" y="80" width="74" height="18" rx="3" fill="#6b4e30" />
+      <circle cx="172" cy="82" r="8" fill="#e0603c" /> {/* tomate */}
+      <circle cx="190" cy="80" r="9" fill="#f0a93c" /> {/* ahuyama */}
+      <circle cx="209" cy="82" r="8" fill="#3f9d5a" /> {/* verde */}
+      <circle cx="224" cy="83" r="7" fill="#a05fb4" /> {/* mora/uchuva */}
+      {/* Costal + moneda (venta) */}
+      <path d="M96 108 q-8 -28 14 -30 q22 2 14 30 z" fill="#b98a52" />
+      <ellipse cx="110" cy="78" rx="14" ry="4" fill="#8a6a44" />
+      <circle cx="120" cy="62" r="10" fill="#f4c430" className="md-coin" />
+      <text x="120" y="66" textAnchor="middle" fontSize="11" fontWeight="700" fill="#7a5a1a">$</text>
+    </svg>
+  );
+}
+
+/* ── Tarjeta de un CANAL de comercialización. Tap → despliega la descripción
+ *    grounded (verbatim del grafo) + tipo + confianza + fuente. ─────────────── */
+function CanalCard({ canal }) {
+  const [abierto, setAbierto] = useState(false);
+  const t = TONO[canal.tono] || TONO.slate;
+  const Icon = CANAL_ICON[canal.id] || Store;
+  const esOportunidad = canal.oportunidad === true;
+  return (
+    <div className={`relative rounded-2xl border ${esOportunidad ? 'border-violet-500/60' : t.ring} ${t.soft} overflow-hidden`}>
+      {esOportunidad && (
+        <div className="absolute right-0 top-0 px-2.5 py-1 rounded-bl-xl bg-violet-500 text-white text-[10px] font-extrabold uppercase tracking-wide">
+          Oportunidad
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setAbierto((v) => !v)}
+        aria-expanded={abierto}
+        className={`w-full text-left px-4 pb-3 flex items-start gap-3 ${esOportunidad ? 'pt-9' : 'pt-3.5'}`}
+      >
+        <span className={`shrink-0 mt-0.5 w-10 h-10 rounded-xl bg-slate-900 border border-slate-700 flex items-center justify-center text-xl`} aria-hidden="true">
+          {canal.emoji}
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-[15px] font-extrabold text-white leading-tight flex items-center gap-1.5">
+            <Icon size={15} className={t.icon} aria-hidden="true" />
+            {canal.titulo_corto}
+          </h3>
+          <p className="mt-0.5 text-[13px] text-slate-200 leading-snug">{canal.gancho}</p>
+        </div>
+        <ChevronDown size={18} className={`shrink-0 mt-1 text-slate-400 transition-transform ${abierto ? 'rotate-180' : ''}`} aria-hidden="true" />
+      </button>
+      {abierto && (
+        <div className="px-4 pb-4 pt-1 border-t border-slate-800 bg-slate-950/40 text-[12.5px] text-slate-300 flex flex-col gap-2">
+          <p className="leading-snug">{canal.descripcion}</p>
+          <div className="flex flex-wrap items-center gap-2 pt-0.5">
+            <span className="inline-flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full border border-slate-700 bg-slate-800 text-slate-200">
+              <span className={`w-1.5 h-1.5 rounded-full ${t.dot}`} aria-hidden="true" />
+              {canal.tipo?.replace(/_/g, ' ')}
+            </span>
+            {canal.confianza && (
+              <span className="text-[11px] text-slate-500">Confianza del dato: {canal.confianza}</span>
+            )}
+          </div>
+          {canal.fuente && (
+            <p className="text-[11px] text-slate-500 leading-snug">
+              <span className="text-slate-400">Fuente:</span> {canal.fuente}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Tarjeta de un producto con VALOR AGREGADO. Badge de riesgo sanitario. ──── */
+function ValorCard({ valor }) {
+  const [abierto, setAbierto] = useState(false);
+  const r = RIESGO_ESTILO[valor.nivel_riesgo] || RIESGO_ESTILO.medio;
+  return (
+    <div className="rounded-2xl border border-slate-700 bg-slate-900 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setAbierto((v) => !v)}
+        aria-expanded={abierto}
+        className="w-full text-left px-4 pt-3.5 pb-3 flex items-start gap-3"
+      >
+        <span className="shrink-0 mt-0.5 w-10 h-10 rounded-xl bg-slate-950 border border-slate-700 flex items-center justify-center text-xl" aria-hidden="true">
+          {valor.emoji}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-[15px] font-extrabold text-white leading-tight">{valor.nombre}</h3>
+            <span className={`inline-flex items-center gap-1 text-[10.5px] font-bold px-2 py-0.5 rounded-full border bg-slate-800 ${r.chip}`}>
+              <span className={`w-1.5 h-1.5 rounded-full ${r.dot}`} aria-hidden="true" />
+              {r.label}
+            </span>
+          </div>
+          <p className="mt-0.5 text-[13px] text-slate-200 leading-snug">{valor.gancho}</p>
+        </div>
+        <ChevronDown size={18} className={`shrink-0 mt-1 text-slate-400 transition-transform ${abierto ? 'rotate-180' : ''}`} aria-hidden="true" />
+      </button>
+      {abierto && (
+        <div className="px-4 pb-4 pt-1 border-t border-slate-800 bg-slate-950/40 text-[12.5px] text-slate-300 flex flex-col gap-2">
+          <p className="inline-flex items-start gap-1.5 leading-snug text-slate-200">
+            <ShieldCheck size={14} className="mt-0.5 shrink-0 text-slate-400" aria-hidden="true" />
+            <span><span className="font-semibold text-slate-100">Sanidad (INVIMA):</span> {valor.regimen}</span>
+          </p>
+          <p className="leading-snug">{valor.descripcion}</p>
+          {valor.fuente && (
+            <p className="text-[11px] text-slate-500 leading-snug">
+              <span className="text-slate-400">Fuente:</span> {valor.fuente}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Chip-foto de un cultivo de la despensa (para el explorador de precios). ── */
+function CultivoChip({ item, activo, onClick }) {
+  const [imgOk, setImgOk] = useState(true);
+  const tienePrecio = !!item.producto_sipsa;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={activo}
+      className={`group relative shrink-0 w-[104px] rounded-xl overflow-hidden border text-left transition-transform active:scale-95 ${
+        activo ? 'border-emerald-400 ring-2 ring-emerald-400/50' : 'border-slate-700'
+      }`}
+    >
+      <div className="relative h-[72px] bg-slate-800">
+        {item.imagen?.url && imgOk ? (
+          <img
+            src={item.imagen.url}
+            alt={item.nombre_comun}
+            loading="lazy"
+            onError={() => setImgOk(false)}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-2xl" aria-hidden="true">🧺</div>
+        )}
+        {tienePrecio && (
+          <span className="absolute bottom-1 left-1 text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-emerald-500 text-white">
+            precio vivo
+          </span>
+        )}
+      </div>
+      <div className="px-2 py-1.5 bg-slate-900">
+        <p className="text-[11.5px] font-bold text-slate-100 leading-tight truncate">{item.nombre_comun}</p>
+      </div>
+    </button>
+  );
+}
+
+/* ── Panel de precio EN VIVO para el cultivo seleccionado. Llama a
+ *    get_precio_sipsa; NUNCA inventa. Sin dato → decline honesto + fuente. ──── */
+function PrecioVivo({ item, canalesById, onAskAgent }) {
+  // Estado inicial derivado en el montaje (el componente se re-monta por
+  // `key={species_id}` en el padre, así que el initializer corre por cada
+  // cultivo). Evita setState síncrono dentro del efecto.
+  const [estado, setEstado] = useState(() => (item?.producto_sipsa ? 'loading' : 'idle')); // idle | loading | ok | unavailable | error
+  const [precio, setPrecio] = useState(null);
+
+  useEffect(() => {
+    if (!item?.producto_sipsa) return undefined;
+    let vivo = true;
+    getPrecioSipsa('latest_price', { producto: item.producto_sipsa })
+      .then((res) => {
+        if (!vivo) return;
+        const p = res?.price;
+        const val = p?.precio_promedio_cop_kg;
+        if (res?.available === true && typeof val === 'number' && Number.isFinite(val)) {
+          setPrecio({ price: p, frescura: res.frescura || null, central: res.central_abastos || p?.plaza || null });
+          setEstado('ok');
+        } else {
+          setEstado('unavailable');
+        }
+      })
+      .catch(() => { if (vivo) setEstado('error'); });
+    return () => { vivo = false; };
+  }, [item?.producto_sipsa]);
+
+  const preguntarAgente = () => {
+    if (typeof onAskAgent === 'function') {
+      onAskAgent(`¿A cómo está hoy ${item.nombre_comun.toLowerCase()} en la central de abastos?`);
+    }
+  };
+
+  const canalMayorista = canalesById?.canal_central_mayorista_sipsa;
+
+  return (
+    <div className="rounded-2xl border border-slate-700 bg-slate-900 p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-[15px] font-extrabold text-white">{item.nombre_comun}</span>
+        {item.nombre_cientifico && <span className="text-[12px] italic text-slate-400">{item.nombre_cientifico}</span>}
+      </div>
+
+      {/* Canales por los que se vende (chips) */}
+      {Array.isArray(item.canales) && item.canales.length > 0 && (
+        <div className="mb-3">
+          <p className="text-[11px] uppercase tracking-wide font-bold text-slate-400 mb-1.5">Se vende por</p>
+          <div className="flex flex-wrap gap-1.5">
+            {item.canales.map((cid) => {
+              const c = canalesById?.[cid];
+              if (!c) return null;
+              return (
+                <span key={cid} className="inline-flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full border border-slate-700 bg-slate-800 text-slate-200">
+                  <span aria-hidden="true">{c.emoji}</span> {c.titulo_corto}
+                </span>
+              );
+            })}
+          </div>
+          {item.transforma_en && (
+            <p className="mt-2 text-[12px] text-emerald-300 inline-flex items-center gap-1">
+              <Factory size={13} aria-hidden="true" /> También se puede transformar (mire "¿Cómo le agrego valor?").
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Precio del día */}
+      <div className="pt-3 border-t border-slate-800">
+        <p className="text-[11px] uppercase tracking-wide font-bold text-slate-400 mb-1.5">¿A cómo está hoy?</p>
+
+        {!item.producto_sipsa && (
+          <p className="text-[13px] text-slate-300 leading-snug">
+            Este cultivo no está en el boletín de precios SIPSA/DANE, así que no podemos cotizarlo aquí.
+            Pregúntale al agente por su precio o consulta la fuente oficial abajo.
+          </p>
+        )}
+
+        {estado === 'loading' && (
+          <p className="flex items-center gap-2 text-[13px] text-slate-300">
+            <Loader2 size={15} className="animate-spin text-emerald-400" aria-hidden="true" />
+            Consultando el precio del día…
+          </p>
+        )}
+
+        {estado === 'ok' && precio && (
+          <div className="rounded-xl bg-emerald-500/10 border border-emerald-500/40 p-3">
+            <p className="text-[13px] text-slate-200 leading-tight">
+              {precio.price.producto || item.nombre_comun}
+            </p>
+            <p className="text-[26px] font-extrabold text-white leading-tight tabular-nums">
+              ${formatCop(precio.price.precio_promedio_cop_kg)}
+              <span className="text-[14px] font-bold text-slate-300"> / kg</span>
+            </p>
+            {precio.central && <p className="text-[12.5px] text-slate-300">en {precio.central}</p>}
+            {formatCop(precio.price.precio_min_cop_kg) && formatCop(precio.price.precio_max_cop_kg)
+              && precio.price.precio_min_cop_kg !== precio.price.precio_max_cop_kg && (
+              <p className="text-[12px] text-slate-400 mt-0.5 tabular-nums">
+                Rango del día: ${formatCop(precio.price.precio_min_cop_kg)}–${formatCop(precio.price.precio_max_cop_kg)} / kg
+              </p>
+            )}
+            {precio.frescura?.desactualizado === true && (
+              <p className="mt-1.5 text-[11.5px] text-amber-300 leading-snug">
+                <Info size={12} className="inline mb-0.5 mr-1" aria-hidden="true" />
+                Es el último dato disponible{typeof precio.frescura.dias_desde_dato === 'number'
+                  ? ` (de hace ${precio.frescura.dias_desde_dato} día${precio.frescura.dias_desde_dato === 1 ? '' : 's'})`
+                  : ''}, no el de hoy.
+              </p>
+            )}
+            <p className="mt-2 text-[11px] text-slate-400 leading-snug border-t border-emerald-500/20 pt-1.5">
+              Fuente: SIPSA/DANE{precio.price.fecha ? `, ${fechaCorta(precio.price.fecha)}` : ''}.
+              Es precio mayorista de central: en su vereda puede valer distinto y, por flete e intermediación, usted recibe menos.
+            </p>
+          </div>
+        )}
+
+        {(estado === 'unavailable' || estado === 'error') && (
+          <div className="rounded-xl bg-slate-800/60 border border-slate-700 p-3">
+            <p className="text-[13px] text-slate-200 leading-snug">
+              {estado === 'error'
+                ? 'No pudimos conectarnos para traer el precio (revise su conexión).'
+                : 'Hoy no hay un precio publicado para este producto en SIPSA/DANE.'}
+              {' '}No inventamos un número: consulte el precio del día en la fuente oficial o pregúntele al agente.
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {typeof onAskAgent === 'function' && (
+                <button
+                  type="button"
+                  onClick={preguntarAgente}
+                  className="inline-flex items-center gap-1.5 text-[12.5px] font-semibold px-3 py-1.5 rounded-full bg-emerald-500 text-white active:scale-95 transition-transform"
+                >
+                  <MessageCircle size={13} aria-hidden="true" /> Preguntarle al agente
+                </button>
+              )}
+              {canalMayorista?.fuente && (
+                <span className="text-[11px] text-slate-500 self-center">SIPSA/DANE, boletín mayorista</span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {() => void} props.onBack
+ * @param {(view: string, data?: any) => void} [props.onNavigate]
+ */
+export default function MercadoDespensaScreen({ onBack, onNavigate }) {
+  const [data, setData] = useState(null);
+  const [estado, setEstado] = useState('cargando'); // cargando | listo | error
+  const [seleccion, setSeleccion] = useState(null); // species_id del cultivo abierto
+
+  useEffect(() => {
+    let vivo = true;
+    fetch('/mercado-despensa.json')
+      .then((r) => { if (!r.ok) throw new Error('http ' + r.status); return r.json(); })
+      .then((j) => { if (vivo) { setData(j); setEstado('listo'); } })
+      .catch(() => { if (vivo) setEstado('error'); });
+    return () => { vivo = false; };
+  }, []);
+
+  const canalesById = useMemo(() => {
+    if (!data) return {};
+    return Object.fromEntries(data.canales.map((c) => [c.id, c]));
+  }, [data]);
+
+  const itemSeleccionado = useMemo(() => {
+    if (!data || !seleccion) return null;
+    return data.despensa.find((d) => d.species_id === seleccion) || null;
+  }, [data, seleccion]);
+
+  const askAgent = useMemo(() => {
+    if (typeof onNavigate !== 'function') return undefined;
+    return (pregunta) => onNavigate('agente', { prefilledPrompt: pregunta });
+  }, [onNavigate]);
+
+  return (
+    <div className="min-h-[100dvh] text-white">
+      <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Volver"
+          className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center shrink-0"
+        >
+          <ChevronLeft size={20} />
+        </button>
+        <div className="min-w-0">
+          <h1 className="text-lg font-bold leading-tight text-white flex items-center gap-1.5">
+            <Store size={18} aria-hidden="true" /> Mercado y despensa
+          </h1>
+          <p className="text-xs text-slate-400 leading-tight">¿Por dónde vendo, cómo le agrego valor y a cómo está?</p>
+        </div>
+      </header>
+
+      <div className="px-4 pb-12">
+        {estado === 'cargando' && (
+          <div className="mt-4 flex flex-col gap-3" aria-live="polite">
+            <div className="loading-skeleton-dark h-32 rounded-2xl" />
+            <div className="loading-skeleton-dark h-20 rounded-2xl" />
+            <div className="loading-skeleton-dark h-20 rounded-2xl" />
+            <p className="text-center text-sm text-slate-400">Cargando los canales de venta…</p>
+          </div>
+        )}
+        {estado === 'error' && (
+          <p className="mt-8 text-center text-sm text-slate-100">
+            No se pudo cargar la información de mercado. Intente de nuevo con conexión.
+          </p>
+        )}
+
+        {estado === 'listo' && data && (
+          <div className="flex flex-col gap-5">
+            {/* Hero */}
+            <section className="rounded-2xl border border-slate-700 bg-slate-900 overflow-hidden">
+              <div className="p-4 pb-2"><PuestoIlustracion /></div>
+              <div className="px-4 pb-4">
+                <p className="text-[13px] uppercase tracking-wide font-bold text-slate-400">Sembrar es la mitad</p>
+                <p className="mt-1 text-[15px] text-slate-100 leading-snug">
+                  La otra mitad es <span className="font-bold">venderlo bien</span>. Aquí ve por dónde puede vender,
+                  cómo le saca más valor a su cosecha transformándola, y a cómo está el mercado hoy —
+                  <span className="font-semibold"> con precios en vivo, sin inventar ni un peso</span>.
+                </p>
+              </div>
+            </section>
+
+            {/* ── Sección 1: ¿Por dónde vendo? ─────────────────────────────── */}
+            <section>
+              <SectionHead
+                Icon={Sprout}
+                titulo="¿Por dónde vendo?"
+                sub={`${data.canales.length} caminos para sacar su cosecha. Del que más plata le deja al mayorista.`}
+              />
+              <div className="flex flex-col gap-2.5">
+                {data.canales.map((c) => <CanalCard key={c.id} canal={c} />)}
+              </div>
+            </section>
+
+            {/* ── Sección 2: ¿Cómo le agrego valor? ────────────────────────── */}
+            <section>
+              <SectionHead
+                Icon={Factory}
+                titulo="¿Cómo le agrego valor?"
+                sub="Transformar la cosecha paga más. Cada producto trae su trámite sanitario real (INVIMA)."
+              />
+              <div className="flex flex-col gap-2.5">
+                {data.valor_agregado.map((v) => <ValorCard key={v.id} valor={v} />)}
+              </div>
+              <p className="mt-2 inline-flex items-start gap-1.5 text-[11.5px] text-slate-400 leading-snug">
+                <Info size={13} className="mt-0.5 shrink-0" aria-hidden="true" />
+                El régimen sanitario cambia según lo que produzca. Antes de vender transformado, confirme su caso con
+                el INVIMA o su UMATA/ULATA. Aquí va el marco general, no un trámite personalizado.
+              </p>
+            </section>
+
+            {/* ── Sección 3: ¿A cómo está? + Tu despensa ───────────────────── */}
+            <section>
+              <SectionHead
+                Icon={HandCoins}
+                titulo="¿A cómo está?"
+                sub="Toque un cultivo para ver por dónde se vende y su precio del día (SIPSA/DANE en vivo)."
+              />
+              {/* Carrusel de cultivos */}
+              <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-4 px-4 snap-x" role="list" aria-label="Cultivos de la despensa">
+                {data.despensa.map((it) => (
+                  <div role="listitem" key={it.species_id} className="snap-start">
+                    <CultivoChip
+                      item={it}
+                      activo={seleccion === it.species_id}
+                      onClick={() => setSeleccion((s) => (s === it.species_id ? null : it.species_id))}
+                    />
+                  </div>
+                ))}
+              </div>
+
+              {/* Detalle del cultivo seleccionado */}
+              {itemSeleccionado ? (
+                <div className="mt-3 relative">
+                  <button
+                    type="button"
+                    onClick={() => setSeleccion(null)}
+                    aria-label="Cerrar detalle"
+                    className="absolute -top-1 right-1 z-10 w-8 h-8 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center"
+                  >
+                    <X size={16} />
+                  </button>
+                  <PrecioVivo key={itemSeleccionado.species_id} item={itemSeleccionado} canalesById={canalesById} onAskAgent={askAgent} />
+                </div>
+              ) : (
+                <p className="mt-2 text-[12.5px] text-slate-400 leading-snug">
+                  {data.meta.despensa_con_producto_sipsa} de {data.meta.total_despensa} cultivos tienen precio en vivo
+                  (marcados <span className="text-emerald-300 font-semibold">precio vivo</span>). El resto se orienta al agente.
+                </p>
+              )}
+
+              {/* Nota de honestidad de precios — SIEMPRE visible */}
+              <div className="mt-3 rounded-xl border border-amber-500/40 bg-amber-500/10 p-3">
+                <p className="text-[12px] text-slate-200 leading-snug">
+                  <Info size={13} className="inline mb-0.5 mr-1 text-amber-400" aria-hidden="true" />
+                  Chagra <span className="font-semibold">no fija precios ni los adivina</span>. Cuando hay dato, viene
+                  del boletín oficial SIPSA/DANE en vivo; cuando no lo hay, se lo decimos claro.
+                </p>
+              </div>
+            </section>
+
+            {/* Footer — grounding */}
+            <footer className="rounded-2xl border border-slate-700 bg-slate-900 px-4 py-3 text-[12px] text-slate-300">
+              <p className="font-bold text-slate-100 mb-1">De dónde salen estos datos</p>
+              <p className="leading-snug">{data.meta.origen_datos}</p>
+              <p className="mt-1 leading-snug text-slate-400">{data.meta.nota_precios}</p>
+              <a
+                href={data.meta.fuente_precio_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex items-center gap-1 text-emerald-400 font-semibold underline"
+              >
+                <ExternalLink size={13} aria-hidden="true" /> Ver los precios oficiales SIPSA/DANE
+              </a>
+            </footer>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Encabezado de sección reutilizable. ────────────────────────────────────── */
+function SectionHead(props) {
+  const { titulo, sub } = props;
+  const Icon = props.Icon;
+  return (
+    <div className="mb-2.5">
+      <h2 className="text-[18px] font-extrabold text-white flex items-center gap-2 leading-tight">
+        <Icon size={19} className="text-emerald-400" aria-hidden="true" /> {titulo}
+      </h2>
+      {sub && <p className="text-[13px] text-slate-400 leading-snug mt-0.5">{sub}</p>}
+    </div>
+  );
+}

--- a/src/components/__tests__/MercadoDespensaScreen.test.jsx
+++ b/src/components/__tests__/MercadoDespensaScreen.test.jsx
@@ -1,0 +1,169 @@
+/**
+ * MercadoDespensaScreen — mini-app "Mercado y despensa" (mundo del mismo nombre).
+ *
+ * Contrato cubierto:
+ *   - Carga la estructura de mercado del JSON exportado del grafo chagra_kg.
+ *   - Las 3 preguntas rectoras aparecen (por dónde vendo / valor / a cómo está).
+ *   - La compra pública ACFC se marca como OPORTUNIDAD.
+ *   - El chip de precio consulta get_precio_sipsa EN VIVO y CANTA el número real
+ *     cuando el sidecar responde available:true.
+ *   - Sin dato disponible → decline HONESTO (no inventa) + puente al agente.
+ *   - CERO precios hardcodeados en el JSON de datos.
+ *   - onBack.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react';
+import MercadoDespensaScreen from '../MercadoDespensaScreen';
+
+// Mock del sidecar: controlamos la respuesta de precio por test.
+const getPrecioSipsa = vi.fn();
+vi.mock('../../services/sidecarClient', () => ({
+  getPrecioSipsa: (...a) => getPrecioSipsa(...a),
+}));
+
+const DATA = {
+  meta: {
+    titulo: 'Mercado y despensa',
+    origen_datos: 'Grafo chagra_kg exportado a estático.',
+    nota_precios: 'Este archivo NO contiene precios. Los precios los trae get_precio_sipsa en vivo.',
+    fuente_precio_url: 'https://www.dane.gov.co/sipsa',
+    total_despensa: 2,
+    despensa_con_producto_sipsa: 1,
+  },
+  canales: [
+    {
+      id: 'canal_venta_directa_finca', nombre: 'Venta directa', tipo: 'circuito_corto',
+      descripcion: 'Finca a consumidor.', fuente: 'FAO', confianza: 'media-alta',
+      orden: 1, emoji: '🤝', titulo_corto: 'Venta directa desde la finca', gancho: 'Más plata para usted.', tono: 'emerald',
+    },
+    {
+      id: 'canal_compra_publica_acfc', nombre: 'Compra pública ACFC', tipo: 'compra_publica',
+      descripcion: 'Ley 2046 de 2020: mínimo 30% a pequeños productores.', fuente: 'Ley 2046 de 2020', confianza: 'alta',
+      orden: 4, emoji: '🏫', titulo_corto: 'Compra pública (Ley 2046)', gancho: 'Le compran 30%.', tono: 'violet', oportunidad: true,
+    },
+    {
+      id: 'canal_central_mayorista_sipsa', nombre: 'Central mayorista', tipo: 'mayorista',
+      descripcion: 'Precios SIPSA-DANE.', fuente: 'DANE - SIPSA', confianza: 'alta',
+      orden: 6, emoji: '🚛', titulo_corto: 'Central mayorista', gancho: 'Precio de referencia.', tono: 'slate',
+    },
+  ],
+  valor_agregado: [
+    {
+      id: 'valor_agregado_panela', nombre: 'Panela', tipo: 'transformacion_artesanal',
+      descripcion: 'Natural, sin registro INVIMA.', fuente: 'Affirma Legal', confianza: 'media-alta',
+      orden: 1, emoji: '🟫', nivel_riesgo: 'bajo', regimen: 'No requiere Registro INVIMA.', gancho: 'Arranca sin registro.',
+    },
+    {
+      id: 'valor_agregado_queso', nombre: 'Queso', tipo: 'transformacion_agroindustrial',
+      descripcion: 'Lácteo alto riesgo, RSA 5 años.', fuente: 'INVIMA Res. 719/2015', confianza: 'media-alta',
+      orden: 4, emoji: '🧀', nivel_riesgo: 'alto', regimen: 'Registro Sanitario (RSA).', gancho: 'Trámite exigente.',
+    },
+  ],
+  despensa: [
+    {
+      species_id: 'solanum_tuberosum', nombre_comun: 'Papa', nombre_cientifico: 'Solanum tuberosum L.',
+      canales: ['canal_venta_directa_finca', 'canal_central_mayorista_sipsa'],
+      transforma_en: null, producto_sipsa: 'papa',
+      imagen: { url: 'https://example.org/papa.jpg', licencia: 'CC0', autor: 'x' },
+    },
+    {
+      species_id: 'coffea_arabica', nombre_comun: 'Café', nombre_cientifico: 'Coffea arabica L.',
+      canales: ['canal_venta_directa_finca'],
+      transforma_en: 'valor_agregado_cafe_tostado', producto_sipsa: null, imagen: null,
+    },
+  ],
+};
+
+beforeEach(() => {
+  getPrecioSipsa.mockReset();
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => DATA });
+});
+afterEach(() => cleanup());
+
+const cargar = async () => {
+  render(<MercadoDespensaScreen onBack={() => {}} onNavigate={() => {}} />);
+  await screen.findByText('¿Por dónde vendo?');
+};
+
+describe('MercadoDespensaScreen — estructura', () => {
+  it('muestra las tres preguntas rectoras', async () => {
+    await cargar();
+    expect(screen.getByText('¿Por dónde vendo?')).toBeTruthy();
+    expect(screen.getByText('¿Cómo le agrego valor?')).toBeTruthy();
+    expect(screen.getByText('¿A cómo está?')).toBeTruthy();
+  });
+
+  it('marca la compra pública ACFC como oportunidad', async () => {
+    await cargar();
+    expect(screen.getByText('Compra pública (Ley 2046)')).toBeTruthy();
+    expect(screen.getAllByText(/Oportunidad/i).length).toBeGreaterThan(0);
+  });
+
+  it('muestra el valor agregado con su badge de riesgo sanitario', async () => {
+    await cargar();
+    expect(screen.getByText('Panela')).toBeTruthy();
+    expect(screen.getByText('Queso')).toBeTruthy();
+    expect(screen.getByText(/Trámite alto/i)).toBeTruthy();
+  });
+
+  it('botón volver llama onBack', async () => {
+    const onBack = vi.fn();
+    render(<MercadoDespensaScreen onBack={onBack} onNavigate={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /Volver/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});
+
+describe('MercadoDespensaScreen — precio EN VIVO (get_precio_sipsa)', () => {
+  it('canta el precio real cuando el sidecar responde available:true', async () => {
+    getPrecioSipsa.mockResolvedValue({
+      available: true,
+      central_abastos: 'Corabastos, Bogotá',
+      frescura: { desactualizado: false },
+      price: {
+        producto: 'Papa parda', precio_promedio_cop_kg: 1800,
+        precio_min_cop_kg: 1600, precio_max_cop_kg: 2000, plaza: 'Corabastos, Bogotá', fecha: '2026-07-04',
+      },
+    });
+    await cargar();
+    fireEvent.click(screen.getByRole('button', { name: /Papa/i }));
+    await waitFor(() => expect(getPrecioSipsa).toHaveBeenCalledWith('latest_price', { producto: 'papa' }));
+    expect(await screen.findByText(/\$1\.800/)).toBeTruthy();
+    expect(screen.getByText(/Corabastos/)).toBeTruthy();
+    // "SIPSA/DANE" aparece en el panel de precio + banner + footer: hay varios.
+    expect(screen.getAllByText(/SIPSA\/DANE/).length).toBeGreaterThan(0);
+  });
+
+  it('sin dato disponible NO inventa: decline honesto + puente al agente', async () => {
+    getPrecioSipsa.mockResolvedValue({ available: false });
+    const onNavigate = vi.fn();
+    render(<MercadoDespensaScreen onBack={() => {}} onNavigate={onNavigate} />);
+    await screen.findByText('¿Por dónde vendo?');
+    fireEvent.click(screen.getByRole('button', { name: /Papa/i }));
+    expect(await screen.findByText(/No inventamos un número/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Preguntarle al agente/i }));
+    expect(onNavigate).toHaveBeenCalledWith('agente', expect.objectContaining({ prefilledPrompt: expect.stringMatching(/papa/i) }));
+  });
+
+  it('un cultivo sin producto SIPSA no se cotiza (honesto), remite al agente', async () => {
+    await cargar();
+    // Café no tiene producto SIPSA en el mapa: se selecciona y no llama al tool.
+    const chips = screen.getAllByRole('button', { name: /Café/i });
+    fireEvent.click(chips[0]);
+    expect(await screen.findByText(/no está en el boletín de precios SIPSA\/DANE/i)).toBeTruthy();
+    expect(getPrecioSipsa).not.toHaveBeenCalled();
+  });
+});
+
+describe('MercadoDespensaScreen — honestidad de precios', () => {
+  it('el JSON de datos NO trae ni un precio hardcodeado', () => {
+    // Contrato anti-alucinación: la estructura de mercado no lleva precios.
+    const flat = JSON.stringify(DATA.canales) + JSON.stringify(DATA.valor_agregado) + JSON.stringify(DATA.despensa);
+    expect(flat).not.toMatch(/precio_promedio|cop_kg|\$\s?\d/);
+  });
+
+  it('la nota de honestidad de precios está siempre visible', async () => {
+    await cargar();
+    expect(screen.getByText(/no fija precios ni los adivina/i)).toBeTruthy();
+  });
+});

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -139,6 +139,7 @@ export const MUNDOS_FINCA = [
         lema: 'Venda directo, saque cuentas y transforme su cosecha',
         tinte: ['#b98a2f', '#f7ecd2'],
         entradas: [
+            { view: 'mercado_despensa', label: '¿Por dónde vendo?', desc: 'Los 6 canales de venta, la compra pública (Ley 2046), valor agregado y el precio del día', emoji: '🏪' },
             { view: 'mercado', label: 'Vender y comprar', desc: 'Directo entre fincas, sin intermediarios', emoji: '🤝' },
             { view: 'poscosecha', label: 'Poscosecha y despensa', desc: 'Cosechar en punto, guardar sin que se dañe y transformar', emoji: '🥕' },
             { view: 'nutricion', label: 'La comida que alimenta', desc: 'Qué te da comer cada cultivo: fuerza, cuerpo, sangre y defensas (ICBF)', emoji: '🍽️' },

--- a/src/index.css
+++ b/src/index.css
@@ -685,6 +685,28 @@
 }
 
 /* ===========================================================================
+ * MERCADO Y DESPENSA — micro-animaciones (MercadoDespensaScreen).
+ * El sol respira y la moneda del puesto tintinea (rota apenas). Sutil; TODO se
+ * apaga con prefers-reduced-motion.
+ * =========================================================================== */
+.md-sun {
+  transform-origin: 34px 30px;
+  animation: pc-breathe 4s ease-in-out infinite;
+}
+.md-coin {
+  transform-origin: 120px 62px;
+  animation: md-coin-tilt 3.6s ease-in-out infinite;
+}
+@keyframes md-coin-tilt {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .md-sun { animation: none; }
+  .md-coin { animation: none; transform: none; }
+}
+
+/* ===========================================================================
  * LOADING SKELETON DARK — fondo oscuro unificado para estados de carga.
  *
  * Tarea 81: .loading-skeleton-dark evita flash blanco en dark theme


### PR DESCRIPTION
## Qué es

La **vista de mercado / despensa** del mundo "Mercado y despensa": cómo el campesino **vende y le agrega valor** a lo que produce. Responde tres preguntas, photo-forward y honesta con los precios.

| Pregunta | Qué muestra |
|---|---|
| **¿Por dónde vendo?** | Los **6 canales** de comercialización, con requisitos y fuente citada. La **compra pública ACFC (Ley 2046/2020)** destacada como OPORTUNIDAD (mín. 30% a pequeños productores, pago contra entrega, demanda PAE+ICBF >2.6 billones COP/año). |
| **¿Cómo le agrego valor?** | Los **4 productos con valor agregado** (panela, café tostado, mermelada, queso) con su **marco sanitario INVIMA real** y nivel de trámite (bajo→alto). |
| **¿A cómo está?** | Precio del día **EN VIVO** por cultivo vía `get_precio_sipsa` (SIPSA/DANE). **CERO precios hardcodeados**: sin dato en vivo → decline honesto + puente al agente + fuente oficial. |

## Grounding (grafo `chagra_kg`)

Estructura groundeada anoche al grafo (batch `mercado-estructural-dr-2026-07-05`) y exportada a `public/mercado-despensa.json` por `scripts/export-mercado-to-json.mjs` (patrón nutrición #2087 — la PWA no consulta el grafo en vivo):

- **6** nodos `CanalComercializacion` + **4** `ValorAgregado` (verbatim: descripción, fuente, confianza).
- Aristas `SE_COMERCIALIZA_EN` (**104**, 26 especies) y `SE_TRANSFORMA_EN` (café→tostado).
- **26** cultivos de despensa con foto (`species-images.json`); **23** con producto SIPSA (vía `sipsaProductMap` + 5 alias 1:1 verificados). Café/arroz/cacao quedan sin cotización en vivo (no están en el boletín SIPSA fresco) — honesto, no se inventa.

La capa didáctica (emoji, orden narrativo, nivel de riesgo, gancho) es **presentación en lenguaje llano de los MISMOS hechos** del grafo — cada afirmación traza a `descripcion`/`fuente` del nodo.

## Regla dura de precios

**Ni un peso hardcodeado.** El JSON no lleva precios; los trae el agente en vivo con `get_precio_sipsa`. Estado sin dato → *"No inventamos un número: consulte el precio del día en la fuente oficial o pregúntele al agente."* Test dedicado verifica que el JSON de datos no contenga ningún precio.

## Calidad

- Legibilidad al sol: superficies opacas (slate-900/950), texto slate-100/white (tinta oscura en temas claros), WCAG.
- Temas CSS-var verificados en headless: **biopunk2 / nature / minimalista**.
- `prefers-reduced-motion` apaga las 2 micro-animaciones; skeleton de carga.
- Cableado **mínimo** (por la integración de mundos #2041 en curso): 1 entrada en `mundosFinca.js` + `case` + HASH route + `MODULE_VIEWS` en `App.jsx`. NO se tocó AgentScreen ni los mundos agua/clima/sanidad/poscosecha/cultivos/home.
- `build` verde · `tsc:check` sin errores nuevos vs baseline · **17 tests** (9 componente + 8 reachability) verdes.

## Capturas (headless, stg)

`/tmp/claude-1000/-home-kortux-Workspace-chagra/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/`:
- `mercado-biopunk2-full.png`, `mercado-nature-full.png`, `mercado-minimalista-full.png` — vista completa por tema.
- `mercado-nature-detalle.png` — canal ACFC expandido + panel de precio (decline honesto).
- `mercado-preciovivo-biopunk2.png`, `mercado-preciovivo-nature.png` — estado de **precio en vivo** ($1.850/kg, rango, "precio de central, no de finca") con el sidecar mockeado.

Pendiente: verificación visual del operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
