### PR TITLE
feat(sanidad): cablear "Mi mata está enferma" (fix huérfana) + lámina de esperanza

### DIFF
--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -26,7 +26,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, Mic, CloudRain, Leaf, Gauge } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, Mic, CloudRain, Leaf, Gauge, Stethoscope } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import BienvenidaFinca, { bienvenidaYaVista } from '../BienvenidaFinca';
@@ -168,6 +168,14 @@ const SECTION_COMPONENTS = {
 // dashboard legacy queda intacto, audit "flag OFF = home actual"). Así el copy de
 // la auditoría no rompe el layout de prod ni sus tests.
 const DESTACADO_TILES = [
+    // "Mi mata está enferma" — fix de huérfana (auditoría 2026-07: la pantalla
+    // SanidadSintomaScreen existía con case 'sanidad_sintoma' + hash #sanidad
+    // pero SIN entrada visible en el layout de prod; solo la home F2 flag-ON la
+    // listaba en mundosFinca.js). Es la necesidad #1 del campesino y una
+    // superficie 100% groundeada (AGROSAVIA/Cenicafé), así que va PRIMERA y a
+    // fila completa (span: 2) en el bloque destacado. En F2 NO se duplica: ese
+    // layout ya la trae dentro del mundo "Sanidad de la mata".
+    { view: 'sanidad_sintoma', span: 2, label: 'Mi mata está enferma', icon: Stethoscope, desc: 'Diga qué le ve — "gota", "polvillo", "amarilla" — y sepa qué es y cómo manejarla sin veneno', accent: 'text-orange-400 border-l-orange-500' },
     { view: 'directorio', label: 'Especies', labelF2: 'Qué puedo sembrar', icon: Sprout, desc: 'Directorio: clima, asociaciones, plagas y biopreparados por especie', descF2: 'Qué crece en su clima, con qué se lleva y sus plagas', accent: 'text-lime-400 border-l-lime-500' },
     // Calendario de finca: UN solo calendario que unifica por planta fenología,
     // nutrición, siembra, cosecha, sanidad y ciclo perenne (App.jsx case
@@ -557,7 +565,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
             type="button"
             onClick={() => onNavigate(tile.view, tile.data)}
             aria-label={`${tileLabel(tile)}: ${tileDesc(tile)}`}
-            className={`dash-tile ${large ? 'dash-tile--destacado ' : ''}${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} ${large ? 'rounded-2xl p-4 min-h-[112px]' : 'rounded-xl p-3 min-h-[88px]'} text-left active:bg-slate-800/70 transition-colors flex flex-col`}
+            className={`dash-tile ${large ? 'dash-tile--destacado ' : ''}${tile.span === 2 ? 'col-span-2 ' : ''}${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 ${tile.accent} ${large ? 'rounded-2xl p-4 min-h-[112px]' : 'rounded-xl p-3 min-h-[88px]'} text-left active:bg-slate-800/70 transition-colors flex flex-col`}
         >
             <tile.icon size={large ? 30 : 24} strokeWidth={2} className={`${large ? 'mb-2' : 'mb-1.5'} ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
             <span className={`${large ? 'text-base' : 'text-sm'} font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tileLabel(tile)}</span>

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -243,12 +243,26 @@ describe('Home — flag OFF conserva el layout legacy (prod intacto)', () => {
     const labels = within(aprender).getAllByRole('button').map(labelOf);
     expect(labels[0]).toBe('Aprender');
     expect(labels).toContain('Casos de estudio'); // copy legacy, NO "Casos reales"
-    // DESTACADO con labels legacy.
+    // DESTACADO con labels legacy + "Mi mata está enferma" (fix de huérfana
+    // 2026-07: SanidadSintomaScreen existía sin entrada visible en prod).
     const destacado = screen.getByTestId('destacado-tiles');
-    expect(within(destacado).getAllByRole('button').map(labelOf)).toEqual(['Especies', 'Calendario']);
+    expect(within(destacado).getAllByRole('button').map(labelOf))
+      .toEqual(['Mi mata está enferma', 'Especies', 'Calendario']);
     // GESTIÓN con label legacy "Insumos aplicados" (no "Abonos e insumos").
     const gestion = screen.getByTestId('gestion-tiles');
     expect(within(gestion).getAllByRole('button').map(labelOf))
       .toEqual(['Semilleros', 'Cosechar', 'Insumos aplicados', 'Mantenimiento']);
+  });
+
+  test('"Mi mata está enferma" es alcanzable desde el home de prod (ya NO huérfana)', async () => {
+    const onNavigate = vi.fn();
+    render(<DashboardLive onNavigate={onNavigate} />);
+    const destacado = await screen.findByTestId('destacado-tiles');
+    const tile = within(destacado)
+      .getAllByRole('button')
+      .find((b) => labelOf(b) === 'Mi mata está enferma');
+    expect(tile).toBeTruthy();
+    fireEvent.click(tile);
+    expect(onNavigate).toHaveBeenCalledWith('sanidad_sintoma', undefined);
   });
 });

--- a/src/components/sanidad/SanidadSintomaScreen.jsx
+++ b/src/components/sanidad/SanidadSintomaScreen.jsx
@@ -132,8 +132,10 @@ export default function SanidadSintomaScreen({ onBack, onHome, onNavigate }) {
 function SanidadInicio({ texto, setTexto, onBuscar, sugeridos, noEncontrado, onElegir, onAgente }) {
     return (
         <div className="san-inicio">
+            {/* La lámina de esperanza: hoja enferma → camino del manejo → hoja
+                sana. La tesis de la mini-app dibujada antes de leer nada. */}
             <div className="san-portada" aria-hidden="true">
-                <SanidadSintomaVineta nombre="hojaMordida" />
+                <SanidadSintomaVineta nombre="portadaEsperanza" />
             </div>
             <h2 className="san-h2">¿Qué le pasa a su mata?</h2>
             <p className="san-lead">
@@ -141,6 +143,22 @@ function SanidadInicio({ texto, setTexto, onBuscar, sugeridos, noEncontrado, onE
                 "le salió polvillo", "se seca de la punta". Yo le ayudo a saber qué es
                 y cómo manejarlo sin veneno.
             </p>
+
+            {/* Los 3 pasos reales del flujo — para que sepa qué viene. */}
+            <ol className="san-pasos" aria-label="Cómo funciona, en tres pasos">
+                <li className="san-paso">
+                    <span className="san-paso-n" aria-hidden="true">1</span>
+                    <span><b>Mire</b> la mata con calma</span>
+                </li>
+                <li className="san-paso">
+                    <span className="san-paso-n" aria-hidden="true">2</span>
+                    <span><b>Cuénteme</b> lo que le ve</span>
+                </li>
+                <li className="san-paso">
+                    <span className="san-paso-n" aria-hidden="true">3</span>
+                    <span><b>Remedio</b> sin veneno, con fuente</span>
+                </li>
+            </ol>
 
             <form
                 className="san-buscar"
@@ -333,6 +351,21 @@ function SanidadResultado({ sintoma, causa, camino, onReiniciar, onAgente, onBio
                     <p>{causa.prevencion}</p>
                 </div>
             )}
+
+            {/* El cierre esperanzador: esto tiene manejo, la mata puede volver */}
+            <div className="san-esperanza" data-testid="san-esperanza">
+                <span className="san-esperanza-vineta" aria-hidden="true">
+                    <SanidadSintomaVineta nombre="mataSana" />
+                </span>
+                <div>
+                    <b>Esto tiene manejo</b>
+                    <p>
+                        Con estos cuidados su mata puede recuperarse. Revísela cada dos
+                        o tres días y fíjese si le salen hojas nuevas: esa es la señal
+                        de que va ganando.
+                    </p>
+                </div>
+            </div>
 
             {/* Grounded-pendiente honesto para dosis exactas */}
             {causa.dosisPendiente && (

--- a/src/components/sanidad/SanidadSintomaVinetas.jsx
+++ b/src/components/sanidad/SanidadSintomaVinetas.jsx
@@ -272,6 +272,98 @@ function VHojaAmarilla() {
     );
 }
 
+/** 🌅 LÁMINA DE ESPERANZA — la portada: hoja enferma → camino del manejo →
+ *  hoja sana bajo el sol. El arco punteado ES la tesis de la mini-app: esto
+ *  tiene remedio. Lámina ancha (220×100), mismo lenguaje de mano alzada. */
+function VPortadaEsperanza() {
+    return (
+        <svg className="san-vineta-svg san-vineta-svg--ancha" viewBox="0 0 220 100" aria-hidden="true">
+            <rect width="220" height="100" fill="#f6ded1" />
+            {/* suelo que une las dos matas — la misma tierra, otro cuidado */}
+            <path d="M0 88 H220 V92 H0 Z" fill="#8a5a38" opacity=".9" />
+
+            {/* sol — el que acompaña la recuperación (rayos animables en CSS) */}
+            <g className="san-sol">
+                <circle cx="194" cy="20" r="10" fill="#f4b64d" stroke="#c98a2f" strokeWidth="2" />
+                <g className="san-sol-rayos" stroke="#e8a63c" strokeWidth="2.2" strokeLinecap="round">
+                    <path d="M194 4 v-2" /><path d="M194 36 v2" />
+                    <path d="M178 20 h-2" /><path d="M210 20 h2" />
+                    <path d="M183 9 l-1.6 -1.6" /><path d="M205 31 l1.6 1.6" />
+                    <path d="M205 9 l1.6 -1.6" /><path d="M183 31 l-1.6 1.6" />
+                </g>
+            </g>
+
+            {/* hoja ENFERMA (izquierda): caída, amarillosa, con manchas */}
+            <g transform="translate(10 26) scale(0.64) rotate(9 50 50)">
+                <path d="M50 88 C20 78 14 40 30 20 C50 6 74 16 82 34 C90 58 74 82 50 88 Z" fill="#b3ac52" stroke="#77702c" strokeWidth="3" />
+                <path d="M50 86 C48 60 50 36 56 20" stroke="#77702c" strokeWidth="2.6" fill="none" strokeLinecap="round" />
+                <g fill="#6b4626" opacity=".8">
+                    <ellipse cx="44" cy="50" rx="9" ry="7" />
+                    <ellipse cx="64" cy="64" rx="6" ry="5" />
+                    <ellipse cx="36" cy="66" rx="4.5" ry="3.6" />
+                </g>
+            </g>
+
+            {/* el CAMINO del manejo: arco punteado con la gota de remedio */}
+            <path
+                d="M74 40 C90 14 128 12 144 34"
+                fill="none"
+                stroke="#b0532f"
+                strokeWidth="2.6"
+                strokeLinecap="round"
+                strokeDasharray="1 7"
+            />
+            {/* punta de flecha del arco */}
+            <path d="M144 34 l-7 -4.5 M144 34 l-8 1.5" stroke="#b0532f" strokeWidth="2.4" strokeLinecap="round" fill="none" />
+            {/* la gota de biopreparado en el punto más alto del camino */}
+            <path d="M109 8 q6 8 0 13 q-6 -5 0 -13 Z" fill="#3f8f4e" stroke="#2f6b3a" strokeWidth="1.6" />
+            <path d="M107 15 q1.4 2 3 1" stroke="#bfe3c2" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+
+            {/* hoja SANA (derecha): erguida, verde vivo, con chispas */}
+            <g transform="translate(140 20) scale(0.7)">
+                <path d="M50 88 C20 78 14 40 30 20 C50 6 74 16 82 34 C90 58 74 82 50 88 Z" fill="#5a9e4b" stroke="#2f6b3a" strokeWidth="3" />
+                <path d="M50 86 C48 60 50 36 56 20" stroke="#2f6b3a" strokeWidth="2.6" fill="none" strokeLinecap="round" />
+                <path d="M50 70 L34 58 M51 58 L36 44 M53 46 L40 34" stroke="#2f6b3a" strokeWidth="1.6" fill="none" opacity=".55" strokeLinecap="round" />
+                <path d="M50 70 L70 60 M51 58 L72 48 M53 46 L70 38" stroke="#2f6b3a" strokeWidth="1.6" fill="none" opacity=".55" strokeLinecap="round" />
+            </g>
+            <g fill="#f4b64d">
+                <path d="M136 14 l1.8 4.6 4.6 1.8 -4.6 1.8 -1.8 4.6 -1.8 -4.6 -4.6 -1.8 4.6 -1.8 Z" />
+                <path d="M206 52 l1.4 3.6 3.6 1.4 -3.6 1.4 -1.4 3.6 -1.4 -3.6 -3.6 -1.4 3.6 -1.4 Z" />
+            </g>
+        </svg>
+    );
+}
+
+/** 🌱 Mata sana — el cierre esperanzador del resultado: mata erguida con un
+ *  BROTE NUEVO (la señal de que va ganando, la misma del copy) bajo el sol. */
+function VMataSana() {
+    return (
+        <svg {...P}>
+            <rect width="100" height="100" fill="#f6ded1" />
+            <path d="M0 82 H100 V86 H0 Z" fill="#8a5a38" />
+            {/* tallo erguido */}
+            <path d="M50 82 V40" stroke="#3f7d3a" strokeWidth="3.5" strokeLinecap="round" />
+            {/* hojas paradas, con ganas */}
+            <path d="M50 66 q-16 -2 -22 -14 q14 -4 22 6 Z" fill="#5a9e4b" stroke="#2f6b3a" strokeWidth="2" />
+            <path d="M50 58 q16 -2 22 -14 q-14 -4 -22 6 Z" fill="#5a9e4b" stroke="#2f6b3a" strokeWidth="2" />
+            <path d="M50 46 q-12 -4 -14 -14 q12 -2 16 8 Z" fill="#6fae54" stroke="#2f6b3a" strokeWidth="2" />
+            {/* el brote nuevo — la señal de recuperación */}
+            <path d="M50 40 q0 -8 6 -12" stroke="#7fc25e" strokeWidth="2.6" fill="none" strokeLinecap="round" />
+            <circle cx="57" cy="27" r="3.6" fill="#a4d67f" stroke="#5a9e4b" strokeWidth="1.4" />
+            {/* sol pequeño que acompaña */}
+            <g className="san-sol">
+                <circle cx="19" cy="17" r="7.5" fill="#f4b64d" stroke="#c98a2f" strokeWidth="1.6" />
+                <g className="san-sol-rayos" stroke="#e8a63c" strokeWidth="1.8" strokeLinecap="round">
+                    <path d="M19 5.5 v-2" /><path d="M19 28.5 v2" />
+                    <path d="M7.5 17 h-2" /><path d="M30.5 17 h2" />
+                </g>
+            </g>
+            {/* chispa de ánimo */}
+            <path d="M74 34 l1.6 4 4 1.6 -4 1.6 -1.6 4 -1.6 -4 -4 -1.6 4 -1.6 Z" fill="#f4b64d" />
+        </svg>
+    );
+}
+
 const VINETAS = {
     manchaHumeda: VManchaHumeda,
     manchaOjo: VManchaOjo,
@@ -285,6 +377,8 @@ const VINETAS = {
     hojaRaya: VHojaRaya,
     hojaNegra: VHojaNegra,
     hojaAmarilla: VHojaAmarilla,
+    portadaEsperanza: VPortadaEsperanza,
+    mataSana: VMataSana,
 };
 
 /**

--- a/src/components/sanidad/__tests__/SanidadSintomaScreen.test.jsx
+++ b/src/components/sanidad/__tests__/SanidadSintomaScreen.test.jsx
@@ -69,6 +69,22 @@ describe('SanidadSintomaScreen — flujo síntoma → causa → manejo', () => {
         expect(screen.getByTestId('san-pregunta')).toHaveTextContent(/Dónde está el polvo/i);
     });
 
+    test('la portada orienta: 3 pasos reales del flujo (mire → cuénteme → remedio)', () => {
+        render(<SanidadSintomaScreen />);
+        const pasos = screen.getByRole('list', { name: /tres pasos/i });
+        expect(pasos).toHaveTextContent(/Mire/);
+        expect(pasos).toHaveTextContent(/Cuénteme/);
+        expect(pasos).toHaveTextContent(/Remedio/);
+    });
+
+    test('el resultado cierra con esperanza: "esto tiene manejo" + señal de recuperación', () => {
+        render(<SanidadSintomaScreen />);
+        fireEvent.click(screen.getByTestId('san-sintoma-broca'));
+        const esp = screen.getByTestId('san-esperanza');
+        expect(esp).toHaveTextContent(/Esto tiene manejo/i);
+        expect(esp).toHaveTextContent(/hojas nuevas/i);
+    });
+
     test('el agente queda siempre a la mano en el resultado', () => {
         const onNavigate = vi.fn();
         render(<SanidadSintomaScreen onNavigate={onNavigate} />);

--- a/src/components/sanidad/sanidad-sintoma.css
+++ b/src/components/sanidad/sanidad-sintoma.css
@@ -24,10 +24,28 @@
   --san-display: 'Baloo 2', 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
   --san-body: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
   max-width: 640px;
-  margin: 0 auto;
-  padding: 14px 14px 40px;
+  margin: 10px auto 30px;
+  padding: 16px 14px 30px 22px;
   font-family: var(--san-body);
   color: var(--san-tinta);
+  /* LA PÁGINA del cuaderno: papel de verdad bajo TODA la tinta. Sin esto la
+     tinta oscura caía directo sobre el fondo (oscuro) de la app y los títulos
+     eran ilegibles (WCAG). El papel es fijo — no depende del tema — igual que
+     las láminas: el cuaderno se lee al sol sobre cualquier tema. El margen
+     rojo del canto izquierdo es la seña de identidad de la libreta de campo
+     (la tinta empieza DESPUÉS del margen: padding-left 22px > línea en 12px). */
+  background-color: var(--san-papel);
+  background-image: linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 12px,
+    color-mix(in srgb, var(--san-a) 34%, transparent) 12px,
+    color-mix(in srgb, var(--san-a) 34%, transparent) 13.5px,
+    transparent 13.5px
+  );
+  border: 1px solid rgba(38, 51, 31, 0.16);
+  border-radius: 18px;
+  box-shadow: 0 3px 16px rgba(0, 0, 0, 0.2);
 }
 
 .san-wrap b { color: var(--san-tinta); }
@@ -45,6 +63,57 @@
   place-items: center;
 }
 .san-portada .san-vineta-svg { width: 128px; height: 100%; }
+/* La lámina de esperanza es ANCHA (220×100): llena la portada de lado a lado. */
+.san-portada .san-vineta-svg--ancha { width: 100%; }
+
+/* Único movimiento de la lámina: los rayos del sol respiran, muy despacio.
+   Ambiente, no protagonismo — y apagado con reduced-motion. */
+@keyframes san-sol-respira {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+.san-sol-rayos { animation: san-sol-respira 4.5s ease-in-out infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .san-sol-rayos { animation: none; }
+}
+
+/* ── Los 3 pasos del flujo (mire → cuénteme → remedio) ────────────────────── */
+.san-pasos {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 0 0 4px;
+  padding: 0;
+}
+.san-paso {
+  flex: 1 1 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--san-papel);
+  border: 1px solid rgba(38, 51, 31, 0.14);
+  border-radius: 999px;
+  padding: 6px 12px 6px 6px;
+  font-size: 12.5px;
+  line-height: 1.25;
+  color: var(--san-tinta);
+  box-shadow: 0 1px 5px rgba(38, 51, 31, 0.06);
+}
+.san-paso b { font-family: var(--san-display); font-weight: 800; }
+.san-paso-n {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--san-a);
+  color: #fff;
+  font-family: var(--san-display);
+  font-weight: 800;
+  font-size: 12.5px;
+}
 
 .san-h2 {
   font-family: var(--san-display);
@@ -456,6 +525,42 @@
 }
 .san-prevencion b { font-family: var(--san-display); font-size: 13.5px; }
 .san-prevencion p { margin: 3px 0 0; font-size: 12.8px; line-height: 1.45; }
+/* ── El cierre esperanzador ("esto tiene manejo") ─────────────────────────── */
+.san-esperanza {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  background: #eef6ee;
+  border: 1px solid #b5d8b8;
+  border-left: 4px solid #3f8f4e;
+  border-radius: 13px;
+  padding: 11px 13px;
+}
+.san-esperanza-vineta {
+  flex: 0 0 auto;
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--san-b);
+  border: 1px solid #b5d8b8;
+}
+.san-esperanza-vineta .san-vineta-svg { width: 100%; height: 100%; display: block; }
+.san-esperanza b {
+  font-family: var(--san-display);
+  font-weight: 800;
+  font-size: 14px;
+  color: #256b2c;
+  display: block;
+}
+.san-esperanza p {
+  margin: 3px 0 0;
+  font-size: 12.8px;
+  line-height: 1.45;
+  color: #2c4a2e;
+}
+
 .san-pendiente {
   margin: 12px 0 0;
   font-size: 12px;


### PR DESCRIPTION
## Qué

`SanidadSintomaScreen` (diagnóstico por síntoma folk → causa groundeada AGROSAVIA/Cenicafé → manejo sin veneno) estaba en main pero **HUÉRFANA**: tenía su `case 'sanidad_sintoma'` y el deep-link `#sanidad`, pero ninguna entrada de navegación en el layout de prod (solo la home F2 flag-ON y el curso la listaban). Invisible para una campesina.

## Cableado (descubrible en prod)

- **Tile destacado a fila completa** — primero en el bloque "Lo más sólido de Chagra" del layout legacy (flag OFF = prod), ícono estetoscopio, copy campesino idéntico al de `mundosFinca.js`. En F2 no se duplica (ya vive dentro del mundo "Sanidad de la mata").
- `renderTile` aprende `span: 2` (col-span-2); ningún otro tile cambia.
- El deep-link `#sanidad` / `#sanidad-sintoma` ya existía y queda verificado en vivo.

## Vida (photo-forward, esperanzador, legible al sol)

- **Lámina de esperanza** en la portada: hoja enferma → camino punteado del manejo con la gota de biopreparado → hoja sana bajo el sol. Mismo lenguaje vector de mano alzada de las viñetas (rsvg-safe: sin texto, filtros ni foreignObject).
- **Franja de 3 pasos** reales del flujo: Mire → Cuénteme → Remedio sin veneno, con fuente.
- **Cierre esperanzador** del resultado: viñeta de mata sana con brote nuevo + "Esto tiene manejo" (la señal de recuperación del dibujo es la misma del copy).
- **Fix WCAG real**: el wrap ahora ES la página del cuaderno (papel `#fffdf6` bajo TODA la tinta + margen rojo de libreta en el canto). Antes los títulos ("Manejo agroecológico") y "Fuente: Cenicafé" caían en tinta oscura sobre el fondo oscuro de la app → ilegibles. El papel es fijo, coherente sobre los 4 temas.
- Único movimiento: los rayos del sol respiran (CSS `@keyframes`), apagado bajo `prefers-reduced-motion`.

## Verificación

- `vitest`: 35 tests verdes en las 6 suites afectadas (sanidad + 5 de DashboardLive), incl. **test nuevo de reachability** (click en el tile → `onNavigate('sanidad_sintoma')` — ya NO huérfana).
- `eslint` limpio en los archivos tocados.
- `vite build` verde; `tsc-check-gate`: 1833 errores < baseline 1836 (sin errores nuevos).
- Capturas headless (chromium real contra `vite preview` del dist, flag OFF = layout prod, login mockeado): home con el tile, portada, desambiguación (candelilla), resultado (broca) y cierre esperanzador.

Capturas en stg: `/tmp/claude-1000/-home-kortux-Workspace-chagra/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/0{1..5}-*.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)