### PR TITLE
feat(agua): 2da pasada didáctica de SALUD — parásitos, hepatitis A y chequeo casero «¿mi agua es segura?»

### DIFF
--- a/src/components/agua/AguaScreen.jsx
+++ b/src/components/agua/AguaScreen.jsx
@@ -5,6 +5,7 @@ import {
   Skull, PiggyBank, Biohazard, FlaskConical, Fuel, Beef, Trash2,
   Baby, Activity, ShieldAlert, Ruler, Landmark, HeartPulse,
   Flame, Filter, Camera, ExternalLink, HelpCircle,
+  Worm, Eye, ScanEye, MapPin, ListChecks,
 } from 'lucide-react';
 import { ScreenShell } from '../common/ScreenShell';
 import PedagogicalBlock from '../common/PedagogicalBlock';
@@ -35,6 +36,7 @@ import {
   DISTANCIAS_SEGURIDAD,
   IRCA_RURAL,
   METODOS_POTABILIZACION,
+  CHEQUEO_AGUA_SEGURA,
   FOTO_BASE_AGUA,
   CREDITOS_FOTOS_AGUA,
 } from '../../data/aguaFinca';
@@ -473,6 +475,8 @@ const ICONO_RIESGO = {
 /** Íconos por enfermedad. */
 const ICONO_ENFERMEDAD = {
   diarrea: Activity,
+  parasito: Worm,
+  hepatitis: Eye,
   bebe: Baby,
   intoxicacion: HeartPulse,
 };
@@ -717,6 +721,132 @@ function MiAguaSegura() {
   );
 }
 
+/* ── SALUD · Chequeo casero «¿mi agua es segura?» (lámina + auto-revisión) ── */
+
+/** Lámina propia: una lupa sobre una gota de agua = «revísela antes de tomar».
+ *  Decorativa (aria-hidden): el chequeo con letras va debajo. */
+function LaminaChequeo() {
+  return (
+    <svg viewBox="0 0 120 72" role="img" aria-hidden="true" className="w-full h-auto select-none">
+      {/* gota de agua examinada */}
+      <g className="text-cyan-300">
+        <path d="M52 22 C52 14 60 9 60 9 C60 9 68 14 68 22 C68 28 64 32 60 32 C56 32 52 28 52 22 Z" fill="currentColor" opacity="0.85" />
+      </g>
+      {/* lupa que la revisa */}
+      <g className="text-slate-200">
+        <circle cx="60" cy="30" r="20" fill="none" stroke="currentColor" strokeWidth="3.2" opacity="0.9" />
+        <line x1="74" y1="44" x2="90" y2="60" stroke="currentColor" strokeWidth="4.5" strokeLinecap="round" />
+      </g>
+      {/* señales que se buscan: color, olor, entorno */}
+      <g fontSize="7.5" fontWeight="700">
+        <circle cx="18" cy="18" r="3" className="fill-current text-rose-400" />
+        <text x="24" y="21" className="fill-current text-rose-300">turbia</text>
+        <circle cx="18" cy="36" r="3" className="fill-current text-amber-400" />
+        <text x="24" y="39" className="fill-current text-amber-300">olor</text>
+        <circle cx="18" cy="54" r="3" className="fill-current text-emerald-400" />
+        <text x="24" y="57" className="fill-current text-emerald-300">de dónde viene</text>
+      </g>
+    </svg>
+  );
+}
+
+/** Un grupo del chequeo (sentidos o entorno): cada punto se toca y se marca. */
+function GrupoChequeo({ grupo, icono, marcados, onToggle }) {
+  const Icono = icono; // patrón del módulo: el ícono va a un const capitalizado
+  return (
+    <div className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3">
+      <p className="flex items-center gap-2 text-xs font-black uppercase tracking-wide text-slate-200 mb-2">
+        <Icono size={15} aria-hidden="true" className="text-cyan-300" /> {grupo.titulo}
+      </p>
+      <ul className="space-y-1.5">
+        {grupo.items.map((it) => {
+          const on = marcados.has(it.id);
+          return (
+            <li key={it.id}>
+              <button
+                type="button"
+                onClick={() => onToggle(it.id)}
+                aria-pressed={on}
+                data-testid={`chequeo-item-${it.id}`}
+                className={`w-full flex items-start gap-2.5 rounded-lg border px-2.5 py-2 text-left transition-colors ${
+                  on
+                    ? 'border-rose-500/60 bg-rose-500/15'
+                    : 'border-slate-700/60 bg-slate-900/40 active:bg-slate-800/60'
+                }`}
+              >
+                {/* casilla: vacía por defecto, roja marcada (sí = riesgo) */}
+                <span
+                  aria-hidden="true"
+                  className={`shrink-0 mt-0.5 w-4 h-4 rounded border grid place-items-center text-[10px] font-black ${
+                    on ? 'border-rose-400 bg-rose-500/30 text-rose-100' : 'border-slate-600 text-transparent'
+                  }`}
+                >
+                  ✓
+                </span>
+                <span className={`text-xs leading-snug ${on ? 'text-rose-100' : 'text-slate-200'}`}>{it.texto}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * ChequeoAguaSegura — auto-revisión de la familia: ¿esta agua está para tomar?
+ * Dos miradas (sentidos + entorno) donde marcar SIEMPRE significa riesgo, con un
+ * veredicto vivo. El remate no da falsa tranquilidad: lo peor no se ve, así que
+ * el agua "clarita" también se trata. No inventa cifras (cualitativo, OMS/OPS).
+ */
+function ChequeoAguaSegura() {
+  const [marcados, setMarcados] = useState(() => new Set());
+  const toggle = (id) => setMarcados((prev) => {
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  });
+  const total = marcados.size;
+
+  return (
+    <section className="rounded-2xl border border-cyan-700/40 bg-slate-900/60 p-4 space-y-3" data-testid="agua-chequeo-seguro">
+      <div className="flex items-center gap-3">
+        <div className="shrink-0 w-24" aria-hidden="true"><LaminaChequeo /></div>
+        <div className="min-w-0">
+          <p className="flex items-center gap-2 text-sm font-black text-cyan-200 uppercase tracking-wide">
+            <ListChecks size={16} aria-hidden="true" /> ¿Cómo sé si mi agua es segura?
+          </p>
+          <p className="text-xs leading-snug text-slate-300 mt-1">
+            Revísela antes de tomar. Toque cada señal que note en su agua: si marca aunque sea una, no es de fiar sin tratar.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-2.5">
+        <GrupoChequeo grupo={CHEQUEO_AGUA_SEGURA.sentidos} icono={ScanEye} marcados={marcados} onToggle={toggle} />
+        <GrupoChequeo grupo={CHEQUEO_AGUA_SEGURA.entorno} icono={MapPin} marcados={marcados} onToggle={toggle} />
+      </div>
+
+      {/* Veredicto vivo: cambia según lo que la persona marcó */}
+      {total > 0 && (
+        <div className="flex items-start gap-2.5 rounded-xl border border-rose-600/50 bg-rose-950/30 p-3" data-testid="chequeo-veredicto">
+          <TriangleAlert size={16} aria-hidden="true" className="shrink-0 mt-0.5 text-rose-300" />
+          <p className="text-xs leading-snug text-rose-100">
+            Marcó <strong className="text-white">{total}</strong> {total === 1 ? 'señal' : 'señales'} de riesgo:
+            {' '}<strong className="text-white">no la tome sin tratar</strong>. Hiérvala o desinféctela antes.
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-start gap-2.5 rounded-xl border border-slate-700/50 bg-slate-950/50 p-3" data-testid="chequeo-invisible">
+        <Eye size={16} aria-hidden="true" className="shrink-0 mt-0.5 text-slate-400" />
+        <p className="text-xs leading-snug text-slate-200">{CHEQUEO_AGUA_SEGURA.invisible}</p>
+      </div>
+      <p className="text-[10px] leading-snug text-slate-500">Fuente: {CHEQUEO_AGUA_SEGURA.fuente}</p>
+    </section>
+  );
+}
+
 /* ── SALUD · Cómo potabilizar en casa (4 métodos, paso a paso con foto) ── */
 const ICONO_METODO = { hervir: Flame, cloro: Droplets, sodis: Sun, bioarena: Filter };
 const TONO_METODO = {
@@ -848,6 +978,9 @@ function PilarCuidar() {
     <section className="agua-seccion space-y-4" data-testid="pilar-cuidar">
       {/* SALUD · el gancho: ¿mi agua es segura? (foto real + IRCA + señales) */}
       <MiAguaSegura />
+
+      {/* SALUD · chequeo casero para saber si el agua está para tomar */}
+      <ChequeoAguaSegura />
 
       <p className="text-sm leading-relaxed text-slate-200">
         El agua de la finca son dos cuidados en uno: que la que entra a la casa no

--- a/src/components/agua/AguaScreen.test.jsx
+++ b/src/components/agua/AguaScreen.test.jsx
@@ -148,6 +148,30 @@ describe('AguaScreen — riesgos de contaminación + salud', () => {
     expect(intox).toHaveTextContent(/ICA/);
   });
 
+  it('2da pasada: parásitos (giardia) manda a hervir/filtrar porque resisten al cloro', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    const paras = screen.getByTestId('enfermedad-parasitos');
+    expect(paras).toHaveTextContent(/giardia/i);
+    // Dato safety-critical: resisten el cloro → hervir o filtrar.
+    expect(paras).toHaveTextContent(/resisten al cloro/i);
+    expect(paras).toHaveTextContent(/hervir/i);
+    // Autoridad institucional (nunca una persona).
+    expect(paras).toHaveTextContent(/OMS/);
+    // Los niños como más vulnerables (crecimiento).
+    expect(paras).toHaveTextContent(/niños/i);
+  });
+
+  it('2da pasada: hepatitis A cita la vacuna y a la OMS como autoridad', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    const hep = screen.getByTestId('enfermedad-hepatitis');
+    expect(hep).toHaveTextContent(/hepatitis a/i);
+    expect(hep).toHaveTextContent(/amarill/i); // ictericia
+    expect(hep).toHaveTextContent(/vacuna/i);
+    expect(hep).toHaveTextContent(/OMS/);
+  });
+
   it('muestra la regla de las distancias groundeadas + la ilustración de la finca', () => {
     render(<AguaScreen onBack={() => {}} />);
     fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
@@ -164,6 +188,34 @@ describe('AguaScreen — riesgos de contaminación + salud', () => {
     expect(distancias).toHaveTextContent(/RAS/);
     // Honestidad: el retiro exacto de corrales aún es "dato en camino".
     expect(screen.getByTestId('agua-distancias')).toHaveTextContent(/en camino/i);
+  });
+});
+
+describe('AguaScreen — chequeo casero «¿mi agua es segura?»', () => {
+  it('lista las señales por sentidos y por entorno (corral, letrina, fumigado)', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+
+    const chequeo = screen.getByTestId('agua-chequeo-seguro');
+    expect(chequeo).toHaveTextContent(/turbia/i);
+    expect(chequeo).toHaveTextContent(/huele/i);
+    // Entorno: cercanía a corral, letrina y cultivo fumigado (pedido del operador).
+    expect(screen.getByTestId('chequeo-item-corral')).toHaveTextContent(/corral/i);
+    expect(screen.getByTestId('chequeo-item-letrina')).toHaveTextContent(/letrina/i);
+    expect(screen.getByTestId('chequeo-item-fumigado')).toHaveTextContent(/fumigado/i);
+    // Remate safety-critical: lo peor no se ve → trátela siempre.
+    expect(screen.getByTestId('chequeo-invisible')).toHaveTextContent(/no se ve|trátela siempre/i);
+  });
+
+  it('el veredicto aparece al marcar una señal de riesgo', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    // Sin marcar, no hay veredicto de riesgo.
+    expect(screen.queryByTestId('chequeo-veredicto')).toBeNull();
+    // Al marcar «huele feo», el chequeo manda a tratar el agua.
+    fireEvent.click(screen.getByTestId('chequeo-item-olor'));
+    const veredicto = screen.getByTestId('chequeo-veredicto');
+    expect(veredicto).toHaveTextContent(/no la tome sin tratar/i);
   });
 });
 

--- a/src/data/aguaFinca.js
+++ b/src/data/aguaFinca.js
@@ -346,6 +346,48 @@ export const SENALES_ALERTA_AGUA = [
 ];
 
 /**
+ * CHEQUEO CASERO · ¿mi agua es segura para tomar?
+ *
+ * Lista de auto-revisión para la familia campesina, en dos miradas:
+ *   · SENTIDOS — lo que se ve, huele y prueba (turbidez, color, olor, sabor).
+ *   · ENTORNO  — de dónde viene y qué hay aguas arriba (corral, letrina,
+ *     cultivo fumigado, si el agua pasa por potreros/casas antes de llegar).
+ * Cada punto está redactado para que "sí" SIEMPRE signifique riesgo, de modo
+ * que marcar aunque sea uno mande a tratar el agua.
+ *
+ * Cualitativo (educación sanitaria, OMS/OPS — inspección sanitaria de la
+ * fuente). El remate `invisible` es el mensaje safety-critical: lo peor
+ * (microbios, nitratos, venenos) NO se ve ni se huele, por eso el agua "clarita"
+ * también se trata. Enlaza con IRCA_RURAL (el 37,4 % del agua rural en riesgo).
+ */
+export const CHEQUEO_AGUA_SEGURA = {
+  sentidos: {
+    id: 'sentidos',
+    titulo: 'Lo que ve, huele y prueba',
+    items: [
+      { id: 'turbia', texto: '¿Está turbia, con barro o color, sobre todo después de un aguacero?' },
+      { id: 'olor', texto: '¿Huele feo (a podrido, a huevo dañado) o a químico?' },
+      { id: 'sabor', texto: '¿Deja sabor raro: metálico, a tierra o a jabón?' },
+      { id: 'nata', texto: '¿Tiene nata aceitosa o espuma que no se deshace?' },
+    ],
+  },
+  entorno: {
+    id: 'entorno',
+    titulo: 'De dónde viene y qué hay aguas arriba',
+    items: [
+      { id: 'corral', texto: '¿Hay cochera, corral o establo cerca o loma arriba de la fuente?' },
+      { id: 'letrina', texto: '¿Hay letrina o pozo séptico cerca, o más arriba que el pozo de agua?' },
+      { id: 'fumigado', texto: '¿Hay cultivo fumigado o potrero aguas arriba del nacimiento?' },
+      { id: 'paso', texto: '¿El agua pasa por potreros o casas antes de llegar a la suya?' },
+      { id: 'techo', texto: 'Si es de lluvia: ¿el tanque queda destapado o no desvía la primera lavada sucia del techo?' },
+    ],
+  },
+  // Mensaje safety-critical: cierra el chequeo sin dar falsa tranquilidad.
+  invisible: 'Lo más peligroso no se ve ni se huele: los microbios, los nitratos y los venenos pueden estar en un agua clarita. Marque aunque sea UNA y trátela sí o sí; y aunque no marque ninguna, para tomar trátela SIEMPRE.',
+  fuente: 'OMS/OPS — inspección sanitaria de fuentes de agua; ver también IRCA rural (37,4 % en riesgo alto).',
+};
+
+/**
  * Franja legal de protección alrededor de nacimientos y cauces (metros).
  *
  * GROUNDED (DR agua nacional §4.1, verificado contra norma): son MÍNIMOS
@@ -486,6 +528,30 @@ export const ENFERMEDADES_AGUA = [
     masRiesgo: 'Niños pequeños y adultos mayores.',
     autoridad: 'El agua para tomar no admite NINGUNA E. coli (0 UFC/100 mL). En Colombia, el 37,4 % del agua rural está en riesgo ALTO.',
     fuente: 'Resolución 2115/2007 (MinSalud/MinVivienda); INCA 2023 (MinVivienda/INS)',
+  },
+  {
+    id: 'parasitos',
+    icono: 'parasito',
+    nombre: 'Parásitos: giardia, amebas y lombrices',
+    critico: false,
+    causa: 'Quistes de giardia y amebas, y huevos de lombriz, que llegan al agua desde las heces de personas o animales (letrinas, cocheras, potreros aguas arriba).',
+    senal: 'Diarrea que va y vuelve, retortijón, mucho gas e inflamación; en los niños, bajan de peso y dejan de crecer bien aunque coman.',
+    masRiesgo: 'Niños: la parasitosis repetida les roba el alimento y les frena el crecimiento.',
+    // Dato safety-critical: la giardia y el criptosporidio son resistentes al
+    // cloro; el mensaje correcto es hervir/filtrar, NO clorar y confiarse.
+    autoridad: 'Ojo clave: la giardia y el criptosporidio RESISTEN al cloro. Contra parásitos lo seguro es HERVIR o pasar el agua por un filtro de bioarena — no basta con clorar. El agua de tomar no admite E. coli ni parásitos.',
+    fuente: 'OMS — Guías para la calidad del agua de consumo humano; Resolución 2115/2007 (MinSalud)',
+  },
+  {
+    id: 'hepatitis',
+    icono: 'hepatitis',
+    nombre: 'Hepatitis A — el «mal amarillo»',
+    critico: false,
+    causa: 'Un virus que sale en las heces y entra por agua o alimentos contaminados (la misma ruta fecal-oral de la diarrea).',
+    senal: 'Primero cansancio, falta de apetito, náuseas y fiebre; luego los ojos y la piel se ponen amarillos (ictericia) y la orina oscura.',
+    masRiesgo: 'Niños (muchas veces sin síntomas, pero contagian) y adultos sin vacuna, en quienes suele ser más grave.',
+    autoridad: 'La OMS previene la hepatitis A con agua segura, saneamiento y VACUNA (ya está en el esquema nacional de vacunación infantil). El hervido y el cloro inactivan el virus. Si ve a alguien amarillo, llévelo al médico.',
+    fuente: 'OMS — Hepatitis A; INS/MinSalud — vigilancia y esquema PAI de vacunación',
   },
   {
     id: 'metahemoglobinemia',


### PR DESCRIPTION
## Qué es

Segunda pasada **didáctica** sobre **AGUA Y SALUD** en el mundo Agua, profundizando el ángulo salud para el campesino y su familia. Sigue el patrón **photo-forward** ya existente (fotos CC reales con atribución + láminas SVG propias) — **no** inventa motor nuevo. Todo va cableado dentro del pilar **«Cuidar el agua»** (no huérfano).

## Cómo se llega

`Mundo Agua` → tab **«Cuidar el agua»**. Ahí, en orden:
1. Héroe **«¿Mi agua es segura?»** (ya existía) → **NUEVO: Chequeo casero** debajo.
2. Galería de potabilización (4 métodos) → tarjetas de enfermedades → **NUEVAS: parásitos + hepatitis A** intercaladas antes del «bebé azul».

## Qué agrega

**Enfermedades (2 tarjetas nuevas)** — respaldadas SIEMPRE con autoridad institucional, nunca una persona:
- **Parásitos** (giardia, amebas, lombrices): dato safety-critical → la giardia y el criptosporidio **resisten al cloro**, así que contra parásitos hay que **hervir o filtrar** (bioarena), no clorar y confiarse. Niños como más vulnerables (crecimiento). *Fuente: OMS + Resolución 2115/2007.*
- **Hepatitis A** («el mal amarillo»): ruta fecal-oral, ictericia como señal, **vacuna** en el esquema PAI, hervido/cloro inactivan el virus. *Fuente: OMS + INS.*

**«¿Cómo sé si mi agua es segura?»** (sección nueva, interactiva):
- Auto-revisión en dos miradas: por los **sentidos** (turbidez, olor, sabor, nata) y por el **entorno** (corral/cochera, letrina/séptico, cultivo fumigado, paso por potreros aguas arriba). Marcar siempre = riesgo → **veredicto vivo**.
- Remate safety-critical sin falsa tranquilidad: lo peor no se ve ni se huele (microbios, nitratos, venenos) → para tomar, **trátela siempre**.
- **Lámina SVG propia** (lupa sobre gota).

## Verificación

- `npx vitest run src/components/agua/AguaScreen.test.jsx` → **16/16** (incluye 4 nuevos: parásitos, hepatitis, chequeo, veredicto).
- `npm run build` → **verde**.
- `eslint` + guards de voseo (archivo + comentarios) → **limpios**.
- Capturas reales del pilar Cuidar (chequeo con veredicto + enfermedades nuevas) verificadas en Chromium.

Copy en **español Colombia (usted)**. Contenido campesino válido, cifras groundeadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)