### PR TITLE
feat(a11y): pasada transversal de accesibilidad + legibilidad al sol

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3435,6 +3435,8 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               : 'bg-slate-800 text-slate-500'
           }`}
           title={ttsEnabled ? 'Silenciar voz' : 'Activar voz'}
+          aria-label={ttsEnabled ? 'Silenciar voz' : 'Activar voz'}
+          aria-pressed={ttsEnabled}
         >
           {ttsEnabled ? <Volume2 size={15} /> : <VolumeX size={15} />}
         </button>
@@ -4000,7 +4002,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                 <span className="text-base shrink-0 leading-none mt-0.5" aria-hidden="true">
                   {rotatingTip.icon}
                 </span>
-                <p className="text-[11px] text-slate-300 leading-snug flex-1">
+                <p className="text-xs text-slate-300 leading-snug flex-1">
                   <span className="text-violet-400 font-medium block mb-0.5">
                     💡 Tip mientras espero
                   </span>
@@ -4013,7 +4015,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                     setHintDismissed(true);
                   }}
                   aria-label="Cerrar sugerencia"
-                  className="text-[10px] text-slate-500 hover:text-slate-300 shrink-0 leading-none px-1"
+                  className="tap-target text-sm text-slate-400 hover:text-slate-200 shrink-0 leading-none px-1"
                   data-testid="dismiss-tip"
                 >
                   ×
@@ -4023,7 +4025,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             <button
               type="button"
               onClick={handleCancelLLM}
-              className="text-[10px] px-3 py-1 rounded-full bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700 active:scale-95 transition-all"
+              className="tap-target text-xs px-4 py-1.5 rounded-full bg-slate-800 hover:bg-slate-700 text-slate-200 border border-slate-600 active:scale-95 motion-reduce:transition-none motion-reduce:active:scale-100 transition-all"
             >
               Cancelar
             </button>
@@ -4042,7 +4044,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               type="button"
               onClick={() => setQueueRejectedToast('')}
               aria-label="Cerrar aviso"
-              className="text-amber-400 hover:text-amber-200 text-sm leading-none"
+              className="tap-target text-amber-400 hover:text-amber-200 text-sm leading-none"
             >
               ×
             </button>

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -258,17 +258,25 @@ export const AGENT_V3_CSS = `
     animation: v3-pop 0.22s cubic-bezier(0.22, 0.61, 0.36, 1) both;
   }
   .v3-modo-tag-txt {
-    min-width: 0; font-size: 12.5px; font-weight: 700; letter-spacing: 0.1px;
+    min-width: 0; font-size: 13px; font-weight: 700; letter-spacing: 0.1px;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  /* Salida rápida del modo activo (un toque, sin reabrir la mochila). */
+  /* Salida rápida del modo activo (un toque, sin reabrir la mochila).
+     30px visuales pero hit-area de 44px vía ::after (patrón .tap-target de
+     index.css) — dedos de campo. */
   .v3-modo-clear {
+    position: relative;
     flex: none; width: 30px; height: 30px; border-radius: 50%;
     display: inline-flex; align-items: center; justify-content: center;
     background: rgb(var(--c-surface-raised, 30 41 59) / 0.9);
     border: 1px solid rgb(var(--c-surface-border, 100 116 139) / 0.55);
     color: rgb(var(--c-slate-400, 148 163 184)); cursor: pointer;
     transition: color 0.18s ease, border-color 0.18s ease, transform 0.16s ease;
+  }
+  .v3-modo-clear::after {
+    content: ''; position: absolute; left: 50%; top: 50%;
+    width: max(100%, 44px); height: max(100%, 44px);
+    transform: translate(-50%, -50%);
   }
   .v3-modo-clear:hover { color: rgb(var(--c-slate-100, 241 245 249)); }
   .v3-modo-clear:active { transform: scale(0.9); }
@@ -323,7 +331,7 @@ export const AGENT_V3_CSS = `
   }
   .v3-mochila-titwrap p {
     font-family: 'Nunito', system-ui, sans-serif;
-    font-size: 12.5px; line-height: 1.35; margin-top: 2px;
+    font-size: 13.5px; line-height: 1.35; margin-top: 2px;
     color: rgb(var(--c-slate-400, 148 163 184));
   }
   .v3-mochila-close {

--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -215,7 +215,7 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
                         <span className="jp-tinta-suave block text-xs italic text-slate-400 leading-tight truncate">{r.cientifico}</span>
                       )}
                       {r.familia && (
-                        <span className="jp-tinta-suave block text-[11px] text-slate-400 leading-tight">{r.familia}</span>
+                        <span className="jp-tinta-suave block text-xs text-slate-400 leading-tight">{r.familia}</span>
                       )}
                     </span>
                   </button>

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -394,9 +394,9 @@ export default function ProfileScreen({ onBack, onHome }) {
               </div>
               <div className="min-w-0 flex-1">
                 <h2 className="text-xl font-black text-white leading-tight break-words">{name}</h2>
-                <p className="text-[10px] text-emerald-400 uppercase tracking-widest font-bold mt-0.5">{currentRoleLabel}</p>
+                <p className="text-[11px] text-emerald-400 uppercase tracking-widest font-bold mt-0.5">{currentRoleLabel}</p>
                 {(municipio || activeFincaSlug) && (
-                  <p className="text-[11px] text-slate-400 mt-1 flex items-center gap-1">
+                  <p className="text-xs text-slate-400 mt-1 flex items-center gap-1">
                     <MapPin size={11} aria-hidden="true" className="shrink-0" />
                     <span className="truncate">
                       {[activeFincaSlug, municipio ? String(municipio).split(',')[0] : null].filter(Boolean).join(' · ')}
@@ -410,7 +410,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                   <button
                     type="button"
                     onClick={handlePhotoRemove}
-                    className="text-[10px] text-slate-500 hover:text-slate-300 inline-flex items-center gap-1 mt-1"
+                    className="tap-target text-xs text-slate-400 hover:text-slate-300 inline-flex items-center gap-1 mt-1"
                   >
                     <Trash2 size={11} aria-hidden="true" /> Quitar foto
                   </button>
@@ -441,7 +441,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                       </span>
                       <span className="min-w-0 flex-1">
                         <span className="block text-sm font-bold text-white leading-tight">{s.label}</span>
-                        <span className="block text-[10px] text-slate-500 leading-snug mt-0.5">{s.desc}</span>
+                        <span className="block text-xs text-slate-400 leading-snug mt-0.5">{s.desc}</span>
                       </span>
                       <ChevronRight size={16} className="text-slate-600 shrink-0 mt-1" aria-hidden="true" />
                     </div>
@@ -467,7 +467,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                       </span>
                     )}
 
-                    <span className={`mt-auto pt-2 flex items-center gap-1.5 text-[10px] font-semibold ${lit ? 'text-emerald-400' : 'text-slate-500'}`}>
+                    <span className={`mt-auto pt-2 flex items-center gap-1.5 text-[11px] font-semibold ${lit ? 'text-emerald-400' : 'text-slate-400'}`}>
                       <span
                         className={`w-1.5 h-1.5 rounded-full shrink-0 ${lit ? 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.8)]' : 'bg-slate-600'}`}
                         aria-hidden="true"
@@ -540,7 +540,7 @@ export default function ProfileScreen({ onBack, onHome }) {
               >
                 {savedFlash ? <><Check size={18} /> Guardado</> : <><Save size={18} /> {MSG.perfilScreen.guardarCambios}</>}
               </button>
-              <p className="text-[10px] text-slate-500 text-center leading-relaxed">
+              <p className="text-xs text-slate-400 text-center leading-relaxed">
                 El nombre y el rol se guardan en tu dispositivo. Tu foto de perfil
                 se sincroniza con el servidor para verla en otros dispositivos.
               </p>
@@ -559,7 +559,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                 <Palette size={18} className="text-emerald-400" />
                 <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Tema de la app</h3>
               </div>
-              <p className="text-[11px] text-slate-500 leading-snug px-1">
+              <p className="text-xs text-slate-400 leading-snug px-1">
                 Cada tarjeta muestra cómo se verá Chagra con ese tema. Toca una
                 para aplicarla al instante — puedes devolverte cuando quieras.
               </p>
@@ -576,7 +576,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                 <Bell size={18} className="text-emerald-400" />
                 <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Botón de avisos</h3>
               </div>
-              <p className="text-[11px] text-slate-500 leading-snug px-1">
+              <p className="text-xs text-slate-400 leading-snug px-1">
                 Elige cuál campana te muestra los avisos (alertas, tareas y sincronización). Solo se muestra una.
               </p>
               <div className="grid grid-cols-2 gap-3" role="radiogroup" aria-label="Estilo de avisos">
@@ -597,7 +597,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                     }`}
                   >
                     <p className="text-sm font-bold text-white">{opt.label}</p>
-                    <p className="text-[11px] text-slate-400 mt-0.5 leading-snug">{opt.desc}</p>
+                    <p className="text-xs text-slate-400 mt-0.5 leading-snug">{opt.desc}</p>
                   </button>
                 ))}
               </div>
@@ -634,7 +634,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                     >
                       <span className="flex-1">
                         <span className="block text-sm font-bold text-white">{n.label}</span>
-                        <span className="block text-[11px] text-slate-400 mt-0.5 leading-snug">{n.desc}</span>
+                        <span className="block text-xs text-slate-400 mt-0.5 leading-snug">{n.desc}</span>
                       </span>
                       {active && <Check size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />}
                     </button>
@@ -710,7 +710,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                 <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Módulos del Home</h3>
               </div>
 
-              <p className="text-[11px] text-slate-500 leading-snug px-1">
+              <p className="text-xs text-slate-400 leading-snug px-1">
                 Elige qué módulos quieres ver en tu pantalla de inicio. Puedes ocultar
                 los que no usas para tener una vista más limpia. Todos los módulos están
                 activados por defecto.
@@ -737,7 +737,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                         >
                           <div className="flex flex-col gap-0.5 flex-1">
                             <span className="text-sm font-bold text-slate-200">{module.label}</span>
-                            <span className="text-[10px] text-slate-500 leading-snug">{module.description}</span>
+                            <span className="text-xs text-slate-400 leading-snug">{module.description}</span>
                           </div>
                           <button
                             type="button"
@@ -748,7 +748,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                               ...prev,
                               [module.id]: prev[module.id] === false ? true : false,
                             }))}
-                            className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+                            className={`tap-target relative w-12 h-7 rounded-full transition-colors shrink-0 ${
                               moduleVisibility[module.id] !== false ? 'bg-emerald-600' : 'bg-slate-700'
                             }`}
                           >
@@ -794,14 +794,14 @@ export default function ProfileScreen({ onBack, onHome }) {
               <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
                 <div className="flex flex-col gap-0.5">
                   <span className="text-sm font-bold text-slate-200">Habilitar telemetría</span>
-                  <span className="text-[10px] text-slate-500">{MSG.perfilScreen.telemetriaVozDesc}</span>
+                  <span className="text-xs text-slate-400">{MSG.perfilScreen.telemetriaVozDesc}</span>
                 </div>
                 <button
                   type="button"
                   role="switch"
                   aria-checked={telemetryEnabled}
                   onClick={() => setTelemetryEnabled((v) => !v)}
-                  className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+                  className={`tap-target relative w-12 h-7 rounded-full transition-colors shrink-0 ${
                     telemetryEnabled ? 'bg-emerald-600' : 'bg-slate-700'
                   }`}
                 >
@@ -826,7 +826,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                 </select>
               </label>
 
-              <p className="text-[10px] text-slate-500 px-1 leading-relaxed">
+              <p className="text-xs text-slate-400 px-1 leading-relaxed">
                 La telemetría sigue grabándose en el dispositivo (privacy-safe, NUNCA prompt ni respuesta).
                 El dashboard de visualización se migró al panel privado del operador (ADR-020 anti-leak / ADR-029 Capa C).
               </p>
@@ -843,7 +843,7 @@ export default function ProfileScreen({ onBack, onHome }) {
               <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
                 <div className="flex flex-col gap-0.5">
                   <span className="text-sm font-bold text-slate-200">Enviar métricas anónimas</span>
-                  <span className="text-[10px] text-slate-500">{MSG.perfilScreen.telemetriaAgenteDesc}</span>
+                  <span className="text-xs text-slate-400">{MSG.perfilScreen.telemetriaAgenteDesc}</span>
                 </div>
                 <button
                   type="button"
@@ -856,7 +856,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                     setTelemetryConsent(next);
                     setTelemetryConsentState(next);
                   }}
-                  className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+                  className={`tap-target relative w-12 h-7 rounded-full transition-colors shrink-0 ${
                     telemetryConsent ? 'bg-emerald-600' : 'bg-slate-700'
                   }`}
                 >
@@ -868,7 +868,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                 </button>
               </label>
 
-              <p className="text-[10px] text-slate-500 px-1 leading-relaxed">
+              <p className="text-xs text-slate-400 px-1 leading-relaxed">
                 Si lo activas, se envían al servidor métricas agregadas de tus consultas (modelo usado, tipo de
                 consulta, tiempos de respuesta y conteo de tokens). Nunca se envían el texto de tus preguntas ni
                 las respuestas, ni tu ubicación. Puedes desactivarlo cuando quieras.
@@ -904,7 +904,7 @@ export default function ProfileScreen({ onBack, onHome }) {
               <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
                 <div className="flex flex-col gap-0.5 flex-1">
                   <span className="text-sm font-bold text-slate-200">Mostrar información GPU</span>
-                  <span className="text-[10px] text-slate-500 leading-snug">
+                  <span className="text-xs text-slate-400 leading-snug">
                     Para curiosos: muestra qué modelos de IA están cargados en GPU
                     y cuánta memoria usan. No es necesario para usar Chagra.
                   </span>
@@ -915,7 +915,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                   aria-checked={modoTecnico}
                   aria-label="Activar o desactivar modo técnico"
                   onClick={() => setModoTecnico((v) => !v)}
-                  className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+                  className={`tap-target relative w-12 h-7 rounded-full transition-colors shrink-0 ${
                     modoTecnico ? 'bg-slate-500' : 'bg-slate-700'
                   }`}
                 >
@@ -945,7 +945,7 @@ export default function ProfileScreen({ onBack, onHome }) {
               <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
                 <div className="flex flex-col gap-0.5 flex-1">
                   <span className="text-sm font-bold text-slate-200">Mostrar todas las capacidades</span>
-                  <span className="text-[10px] text-slate-500 leading-snug">
+                  <span className="text-xs text-slate-400 leading-snug">
                     Activa todos los módulos, tarjetas de seguimiento y opciones del
                     home, saltándose el filtrado por perfil. Útil para demos y para
                     el administrador del producto.
@@ -958,7 +958,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                   aria-label="Activar o desactivar la visión total del operador"
                   data-testid="operator-override-toggle"
                   onClick={handleVerTodo}
-                  className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+                  className={`tap-target relative w-12 h-7 rounded-full transition-colors shrink-0 ${
                     verTodo ? 'bg-amber-600' : 'bg-slate-700'
                   }`}
                 >
@@ -988,7 +988,7 @@ export default function ProfileScreen({ onBack, onHome }) {
                 >
                   <div className="flex flex-col gap-0.5 flex-1">
                     <span className="text-sm font-bold text-slate-200">Fincas que acompaño</span>
-                    <span className="text-[10px] text-slate-500 leading-snug">
+                    <span className="text-xs text-slate-400 leading-snug">
                       Panel del extensionista: revisa el estado de las fincas que
                       supervisas. Vista previa con datos de ejemplo.
                     </span>
@@ -1002,10 +1002,10 @@ export default function ProfileScreen({ onBack, onHome }) {
 
         {/* App Info Footer — común a hub y secciones */}
         <div className="mt-8 pt-6 border-t border-slate-800/50 text-center">
-          <p className="text-[10px] text-slate-600 font-mono tracking-tighter uppercase">
+          <p className="text-[11px] text-slate-500 font-mono tracking-tighter uppercase">
             Chagra • v1.0.0
           </p>
-          <p className="text-[9px] text-slate-700 mt-1 max-w-[200px] mx-auto leading-tight">
+          <p className="text-[11px] text-slate-500 mt-1 max-w-[220px] mx-auto leading-tight">
             Diseñado para la soberanía alimentaria y la regeneración ecosistémica.
           </p>
         </div>
@@ -1044,7 +1044,7 @@ function AgentVoiceSection() {
       <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
         <div className="flex flex-col gap-0.5 flex-1">
           <span className="text-sm font-bold text-slate-200">Voz del agente activa</span>
-          <span className="text-[10px] text-slate-500 leading-snug">
+          <span className="text-xs text-slate-400 leading-snug">
             Cuando está activa, Chagra IA lee en voz alta sus respuestas (Kokoro TTS,
             con respaldo al sintetizador del navegador). Doble click en el avatar
             colibrí silencia o reactiva sin abrir esta pantalla.
@@ -1056,7 +1056,7 @@ function AgentVoiceSection() {
           aria-checked={ttsEnabled}
           aria-label="Activar o silenciar la voz del agente"
           onClick={handleToggle}
-          className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+          className={`tap-target relative w-12 h-7 rounded-full transition-colors shrink-0 ${
             ttsEnabled ? 'bg-violet-600' : 'bg-slate-700'
           }`}
         >
@@ -1117,7 +1117,7 @@ function MultifincaGpsSection() {
         <div className="flex items-center justify-between gap-3 p-3 rounded-xl bg-amber-900/20 border border-amber-700/40">
           <div className="flex flex-col gap-0.5 flex-1">
             <span className="text-sm font-bold text-amber-200">Modo manual activo</span>
-            <span className="text-[10px] text-amber-300/70">
+            <span className="text-xs text-amber-200/90">
               El banner GPS no consultará tu ubicación hasta que vuelvas a modo auto.
             </span>
           </div>
@@ -1136,7 +1136,7 @@ function MultifincaGpsSection() {
         <span className="text-xs font-bold text-slate-400 uppercase tracking-wide flex items-center gap-1.5">
           <Home size={12} /> Zona indoor (invernadero)
         </span>
-        <span className="text-[10px] text-slate-500 leading-relaxed">
+        <span className="text-xs text-slate-400 leading-relaxed">
           Cuando estás bajo techo y el GPS pierde fix, Chagra recuerda esta zona
           para no volver a "out of range". Vacío = sin zona indoor activa.
         </span>
@@ -1157,7 +1157,7 @@ function MultifincaGpsSection() {
           </button>
         </div>
         {indoorZone && (
-          <p className="text-[10px] text-emerald-400/80">
+          <p className="text-xs text-emerald-400">
             Activo: <strong>{indoorZone}</strong>
           </p>
         )}
@@ -1167,7 +1167,7 @@ function MultifincaGpsSection() {
       <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
         <div className="flex flex-col gap-0.5 flex-1">
           <span className="text-sm font-bold text-slate-200">Sincronizar histórico GPS</span>
-          <span className="text-[10px] text-slate-500 leading-snug">
+          <span className="text-xs text-slate-400 leading-snug">
             Off por default. Cuando activo, Chagra envía tu ubicación al server
             para análisis multifinca. Off = solo lookup local sin persistencia.
           </span>
@@ -1177,7 +1177,7 @@ function MultifincaGpsSection() {
           role="switch"
           aria-checked={gpsHistoryEnabled}
           onClick={() => setGpsHistoryEnabled(!gpsHistoryEnabled)}
-          className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+          className={`tap-target relative w-12 h-7 rounded-full transition-colors shrink-0 ${
             gpsHistoryEnabled ? 'bg-emerald-600' : 'bg-slate-700'
           }`}
         >

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -348,7 +348,7 @@ html[data-theme="biopunk"] .fvh {
 .fvh-brand-txt span {
   font-family: var(--fvh-body);
   font-weight: 700;
-  font-size: 10px;
+  font-size: 11px;
   color: var(--fvh-tinta-suave);
   text-transform: uppercase;
   letter-spacing: 1.6px;
@@ -401,7 +401,7 @@ html[data-theme="biopunk"] .fvh {
 .fvh-ubic-txt b {
   font-family: var(--fvh-display);
   font-weight: 700;
-  font-size: 12.5px;
+  font-size: 13px;
   color: var(--fvh-sello);
   line-height: 1.12;
   white-space: nowrap;
@@ -411,7 +411,7 @@ html[data-theme="biopunk"] .fvh {
 .fvh-ubic-txt em {
   font-style: normal;
   font-weight: 800;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--fvh-tinta-suave);
   letter-spacing: 0.2px;
   white-space: nowrap;
@@ -421,8 +421,12 @@ html[data-theme="biopunk"] .fvh {
 
 .fvh-top-pills { margin-left: auto; display: flex; gap: 9px; flex: 0 0 auto; }
 .fvh-pill {
-  width: 42px;
-  height: 42px;
+  /* A11y dedos de campo: 44px mínimo (WCAG 2.5.5). En ≤430px la píldora
+     compacta a 40px visuales pero el ::after conserva el hit-area de 44px
+     (mismo patrón .tap-target de index.css). */
+  position: relative;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
   display: grid;
   place-items: center;
@@ -436,14 +440,25 @@ html[data-theme="biopunk"] .fvh {
   cursor: pointer;
 }
 .fvh-pill svg { display: block; }
+.fvh-pill::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: max(100%, 44px);
+  height: max(100%, 44px);
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+}
 /* El botón de PERFIL (feedback #2: "solo aparece el ?") se distingue del de
    ayuda con un anillo de acento del tema, para que SIEMPRE se reconozca como el
    acceso al perfil junto al "?". */
 .fvh-pill.fvh-pill-perfil {
   box-shadow: 0 4px 11px rgba(60, 40, 10, 0.18),
               0 0 0 2px rgb(var(--c-emerald-500, 47 107 58) / 0.55);
-  /* La foto de perfil (fvh-pill-foto) llena la píldora redonda sin desbordarla. */
-  overflow: hidden;
+  /* La foto de perfil (fvh-pill-foto) se auto-recorta con su border-radius:50%.
+     Sin overflow:hidden aquí: recortaría también el ::after que garantiza el
+     hit-area de 44px de la píldora en móvil angosto. */
 }
 /* Foto de perfil fijada por el usuario dentro de la píldora (hotfix P0
    2026-07-04: el home F2 mostraba SIEMPRE el ícono genérico aunque hubiera
@@ -461,7 +476,7 @@ html[data-theme="biopunk"] .fvh {
    no cabía y el PERFIL quedaba fuera de pantalla. Se recupera aire ocultando
    el wordmark "Chagra / Su finca viva" (la A de marca queda como sello, y ES
    el botón del agente) y compactando gaps/píldoras. Los 4 botones quedan
-   SIEMPRE visibles y tocables (≥40px). */
+   SIEMPRE visibles y tocables (visual 40px, hit-area 44px vía ::after). */
 @media (max-width: 430px) {
   .fvh-topbar { gap: 8px; padding-left: 12px; padding-right: 12px; }
   .fvh-brand { gap: 0; }
@@ -554,7 +569,7 @@ html[data-theme="biopunk"] .fvh {
 }
 .fvh-colibri-globo small {
   font-weight: 700;
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: var(--fvh-card-tinta-suave);
   line-height: 1.32;
   display: block;
@@ -839,7 +854,7 @@ html[data-theme="biopunk"] .fvh {
 .fvh-composer-hint {
   text-align: center;
   font-weight: 700;
-  font-size: 11px;
+  font-size: 13px;
   color: var(--fvh-tinta-suave);
   margin: 9px 16px 0;
 }
@@ -864,10 +879,13 @@ html[data-theme="biopunk"] .fvh {
   border: 0;
   cursor: pointer;
   border-radius: 999px;
-  padding: 5px 13px;
+  /* A11y: altura táctil real (38px + 3px×2 del padding del pill = 44px) y
+     fuente legible al sol — este toggle lo usan manos mayores. */
+  min-height: 38px;
+  padding: 8px 15px;
   font-family: var(--fvh-body);
   font-weight: 800;
-  font-size: 11.5px;
+  font-size: 13px;
   color: var(--fvh-card-tinta-suave);
   background: transparent;
   transition: background 160ms ease, color 160ms ease;
@@ -883,7 +901,7 @@ html[data-theme="biopunk"] .fvh {
 
 /* ── HERO TEXT ─────────────────────────────────────────────────────────────── */
 .fvh-hero-saludo { padding: 14px 20px 0; position: relative; z-index: 3; }
-.fvh-hero-saludo .h-small { font-weight: 800; font-size: 12.5px; color: var(--fvh-sello); letter-spacing: 0.2px; }
+.fvh-hero-saludo .h-small { font-weight: 800; font-size: 13px; color: var(--fvh-sello); letter-spacing: 0.2px; }
 .fvh-hero-saludo h1 {
   font-family: var(--fvh-display);
   font-weight: 800;
@@ -896,7 +914,7 @@ html[data-theme="biopunk"] .fvh {
 .fvh-hero-saludo h1 em { font-style: normal; color: var(--fvh-verde-1); }
 .fvh-hero-saludo p {
   font-weight: 600;
-  font-size: 13px;
+  font-size: 14px;
   color: var(--fvh-tinta-suave);
   margin-top: 6px;
   line-height: 1.35;
@@ -1005,8 +1023,8 @@ html[data-theme="biopunk"] .fvh {
   position: relative;
   z-index: 2;
   font-weight: 700;
-  font-size: 11.5px;
-  line-height: 1.25;
+  font-size: 13px;
+  line-height: 1.3;
   margin-top: 6px;
   opacity: 0.98;
   text-shadow: 0 1px 7px rgba(15, 25, 12, 0.78);
@@ -1021,7 +1039,7 @@ html[data-theme="biopunk"] .fvh {
   border: 1.5px solid rgba(255, 255, 255, 0.5);
   border-radius: 999px;
   font-weight: 800;
-  font-size: 10px;
+  font-size: 11px;
   padding: 3px 9px;
   -webkit-backdrop-filter: blur(2px);
   backdrop-filter: blur(2px);
@@ -1040,7 +1058,7 @@ html[data-theme="biopunk"] .fvh {
   background: var(--fvh-lima-claro);
   color: #274200;
   font-weight: 800;
-  font-size: 9.5px;
+  font-size: 10.5px;
   letter-spacing: 0.3px;
   padding: 3px 8px;
   border-radius: 999px;

--- a/src/components/dashboard/finca-viva-resto.css
+++ b/src/components/dashboard/finca-viva-resto.css
@@ -71,7 +71,7 @@
   background: linear-gradient(180deg, #4ade80, #2f6b3a);
 }
 .fvh-resto-sub {
-  font-size: 12.5px;
+  font-size: 14px;
   color: var(--fvh-tinta-suave);
   margin: 0 2px 12px;
   line-height: 1.35;

--- a/src/components/dashboard/mundos-finca.css
+++ b/src/components/dashboard/mundos-finca.css
@@ -53,7 +53,7 @@
       #3f8f4e 0 6px, transparent 6px 10px);
 }
 .mf-sub {
-  font-size: 12.5px;
+  font-size: 14px;
   line-height: 1.4;
   color: var(--mf-tinta-suave);
   margin: 4px 0 0;
@@ -131,7 +131,7 @@
   background: rgba(255, 253, 246, 0.92);
   border: 1px solid var(--mf-a, #3f8f4e);
   color: var(--mf-tinta);
-  font-size: 10.5px;
+  font-size: 11.5px;
   font-weight: 800;
   letter-spacing: 0.02em;
 }
@@ -157,11 +157,11 @@
 .mf-card--featured .mf-nombre { font-size: 18px; }
 .mf-emoji { font-size: 18px; line-height: 1; }
 .mf-lema {
-  font-size: 11.5px;
+  font-size: 13px;
   line-height: 1.35;
   color: var(--mf-tinta-suave);
 }
-.mf-card--featured .mf-lema { font-size: 12.5px; }
+.mf-card--featured .mf-lema { font-size: 14px; }
 
 /* "Adentro": chips de las herramientas del mundo. */
 .mf-adentro {
@@ -171,7 +171,7 @@
   margin-top: 6px;
 }
 .mf-chip {
-  font-size: 10px;
+  font-size: 11.5px;
   font-weight: 700;
   line-height: 1;
   padding: 4px 7px;
@@ -296,7 +296,7 @@
   line-height: 1.2;
 }
 .mf-entrada-txt small {
-  font-size: 11.5px;
+  font-size: 12.5px;
   line-height: 1.3;
   color: var(--mf-tinta-suave);
 }
@@ -333,7 +333,7 @@
 }
 .mf-agente small {
   display: block;
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: var(--mf-tinta-suave);
 }
 .mf-agente:focus-visible {
@@ -343,7 +343,7 @@
 
 /* Índice de mundos (fallback sin id): lista sencilla de láminas. */
 .mf-indice-intro {
-  font-size: 13px;
+  font-size: 14px;
   color: #4e5c42;
   margin: 0 2px 10px;
 }
@@ -372,7 +372,7 @@
 }
 .mf-indice-txt small {
   display: block;
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: #4e5c42;
 }
 .mf-indice-item:focus-visible {

--- a/src/components/sanidad/sanidad-sintoma.css
+++ b/src/components/sanidad/sanidad-sintoma.css
@@ -173,7 +173,9 @@
   padding: 8px 0;
 }
 .san-input:focus { outline: none; }
-.san-input::placeholder { color: #9aa08e; }
+/* Placeholder legible al sol: la tinta suave del mundo (#9aa08e no llegaba a AA
+   sobre el papel). */
+.san-input::placeholder { color: var(--san-tinta-suave); }
 .san-buscar-btn {
   flex: 0 0 auto;
   border: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -365,13 +365,16 @@
     box-shadow: none !important;
   }
 
+  /* Focus teclado GLOBAL (a11y): anillo verde + offset que respira con el TEMA
+   * (antes ring-offset-slate-950 fijo → halo navy pesado en los temas claros;
+   * con la superficie del tema el anillo se lee como anillo en claro y oscuro). */
   button,
   [role="button"],
   a,
   input,
   select,
   textarea {
-    @apply focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 outline-none;
+    @apply focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgb(var(--c-surface))] outline-none;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -379,6 +382,7 @@
       animation-duration: 0.01ms !important;
       animation-iteration-count: 1 !important;
       transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
     }
   }
 }

--- a/src/styles/juego-pulido.css
+++ b/src/styles/juego-pulido.css
@@ -166,7 +166,7 @@
   box-shadow: inset 0 0 0 1px var(--jp-vida-clara), 0 0 12px var(--jp-vida-suave);
 }
 .fvh-skin .df-beneficio-nombre {
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   color: var(--jp-tinta-2);
   letter-spacing: 0.005em;
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -174,7 +174,7 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  font-size: 0.78rem;
+  font-size: 0.8125rem;
   line-height: 1.35;
 }
 
@@ -232,7 +232,7 @@
 }
 
 .onboarding-piso-card-compact .onboarding-piso-secondary {
-  font-size: 0.74rem;
+  font-size: 0.78rem;
 }
 
 .onboarding-piso-secondary:hover {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,10 @@ export default {
     theme: {
         extend: {
             fontSize: {
-                '2xs': ['0.6875rem', { lineHeight: '1rem' }],
+                // A11y legibilidad al sol (2026-07): 11px → 12px. El token se usa
+                // ~200 veces (badges/metadatos); 12px es el piso legible para el
+                // usuario campesino mayor sin romper layouts (1px de delta).
+                '2xs': ['0.75rem', { lineHeight: '1.05rem' }],
             },
             colors: {
                 // -------------------------------------------------------------


### PR DESCRIPTION
## Qué es

Capa de pulido ACOTADA de accesibilidad y legibilidad al sol, pensada en el usuario real: campesino, a veces mayor, con el celular bajo sol fuerte y dedos gruesos o con tierra. No reescribe pantallas ni lógica — reusa la infraestructura existente (`.tap-target`, tokens `--c-*`, focus-visible global, `prefers-reduced-motion` global).

## Cambios por dimensión

### Touch targets ≥44px
- **Píldoras del topbar del home** (campana / ayuda / perfil): 42→44px; en ≤430px conservan los 40px visuales que exige el layout pero un `::after` (patrón `.tap-target`) garantiza el hit-area de 44px. Se quitó el `overflow:hidden` de la píldora de perfil (la foto se auto-recorta) para no recortar ese hit-area.
- **Toggle "Claro y corto / Con detalle"** del hero: de ~26px a 44px de altura táctil total, fuente 11.5→13px. Es el control de nivel de respuesta que más usan las manos mayores.
- **AgentScreen**: "x" de salir de modo (30px visual → 44px hit-area en el CSS inline), botón **Cancelar** (antes ~20px de alto), "x" de tip y de toast → `.tap-target`.
- **Perfil**: "Quitar foto" y los **7 switches** de 28px → `.tap-target`.

### Contraste WCAG AA
- **ProfileScreen** (hallazgo sistémico): todo el cuerpo de lectura usaba `text-[10px]/[11px] text-slate-500/600/700` sobre paneles navy (~4:1, falla AA; el footer a 9px slate-700 era casi invisible). Reemplazo sistemático por `text-xs text-slate-400`+.
- **Focus teclado global** (`index.css`): el `ring-offset` ahora usa la superficie del tema (`--c-surface`) en lugar de `slate-950` fijo — el anillo verde se lee como anillo también en los temas claros.
- Placeholder de sanidad `#9aa08e` → `var(--san-tinta-suave)` (6.97:1 sobre papel).
- Verificado que NO había que tocar: `--mf-tinta-suave` (#4e5c42 = 6.97:1, pasa AA), los portales del hero (ya tienen scrim + text-shadow), el Directorio (gobernado por `jp-tinta` AA por tema).

### Legibilidad al sol (piso de fuente)
- **Token `text-2xs`: 11px → 12px** en `tailwind.config.js` — un solo cambio que sube ~200 usos en toda la app.
- Home hero: hint del compositor 11→13px, saludo 13→14px, descripción de portales 11.5→13px, ubicación 11→12px, badges 9.5-10→10.5-11px.
- Mundos de mi finca: subtítulo 12.5→14px, lemas 11.5→13px, chips 10→11.5px, smalls 11.5→12.5px.
- Onboarding compacto (primera pantalla del usuario nuevo), juego y mochila del agente: pisos suben a 12.5-13.5px.

### Aria + movimiento
- Toggle de voz TTS del agente: `aria-label` + `aria-pressed` (solo tenía `title`, invisible para lectores).
- `prefers-reduced-motion` global ahora también fija `scroll-behavior: auto`.
- Botón Cancelar respeta `motion-reduce`.

### Auditado sin acción necesaria
- Toggle del hero ya usa `role="radiogroup"` + `aria-checked` correcto.
- Todos los clickeables de las pantallas top son `<button>` reales.
- No hay nav persistente → `aria-current` no aplica (la nav es por eventos `chagra:nav`).

## Verificación
- `npm run build` verde (y el `ring-offset` token-aware confirmado en el CSS emitido).
- 216 tests dirigidos verdes: dashboard (hero estructura/portales/nivel/temas, mundos reachability), perfil (hub/foto), agente (photoPipeline/smoke), contraste temas-fase2.
- `tsc:check`: delta CERO vs main (1833 errores preexistentes del entorno antes y después).
- `eslint` limpio en los 4 archivos JS/JSX tocados.

> Cambio VISUAL: pendiente del OK del operador antes de merge (política de visuales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)