### PR TITLE
fix(clima): legibilidad del velo climático nocturno sobre el tema oscuro (biopunk)

### DIFF
--- a/src/styles/__tests__/climaAtmosferaNoche.test.js
+++ b/src/styles/__tests__/climaAtmosferaNoche.test.js
@@ -1,0 +1,154 @@
+/**
+ * Legibilidad del velo climático NOCTURNO sobre el tema OSCURO (biopunk base).
+ *
+ * Contexto (2026-07-06): los topes duros del tinte (0.26/0.20) se calcularon
+ * para temas CLAROS. Sobre el tema oscuro la misma alpha comprime el doble el
+ * contraste del texto claro (medido: slate-400/raised 5.7:1 → 3.4:1 con niebla
+ * nocturna al tope). El fix baja los topes a 0.10/0.08 en biopunk de noche y
+ * apaga el tinte navy residual de noche despejada (biopunk exento por diseño).
+ *
+ * Este test parsea clima-atmosfera.css REAL (no un mock) y reproduce la
+ * mecánica exacta del velo: si alguien sube los topes nocturnos o re-vela
+ * biopunk de noche, falla con el par y el ratio medidos.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(join(__dirname, '..', 'clima-atmosfera.css'), 'utf8');
+
+/* ── helpers WCAG ────────────────────────────────────────────────────────── */
+function luminance([r, g, b]) {
+  const f = (c) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+function contrast(fg, bg) {
+  const [hi, lo] = [luminance(fg), luminance(bg)].sort((a, b) => b - a);
+  return (hi + 0.05) / (lo + 0.05);
+}
+/* blending alpha-compuesto del velo: c' = c + (velo - c) * a */
+const blend = (c, veil, a) => c.map((v, i) => v + (veil[i] - v) * a);
+
+/* ── parseo del CSS real ─────────────────────────────────────────────────── */
+/** Devuelve el cuerpo del primer bloque cuyo selector matchea `selectorRe`. */
+function blockBody(selectorRe) {
+  const re = new RegExp(selectorRe.source + String.raw`[^{]*\{([^}]*)\}`, 'm');
+  const m = css.match(re);
+  return m ? m[1] : null;
+}
+function decl(body, prop) {
+  const m = body && body.match(new RegExp(String.raw`${prop}\s*:\s*([^;]+);`));
+  return m ? m[1].trim() : null;
+}
+const num = (s) => (s == null ? null : parseFloat(s));
+const rgb = (s) => (s == null ? null : s.split(/\s+/).map(Number));
+
+const noche = blockBody(/html:not\(\[data-theme\]\)\[data-luz="noche"\]/);
+const root = blockBody(/^:root/m);
+
+// Velos de clima que caen sobre biopunk de noche (reglas :not([data-theme])
+// posteriores al bloque noche → ganan el tinte a igual especificidad).
+const bpNublado = blockBody(/html:not\(\[data-theme\]\)\[data-clima="nublado"\]/);
+const bpLluvia = blockBody(/html:not\(\[data-theme\]\)\[data-clima="lluvia"\]/);
+const bpNiebla = blockBody(/html:not\(\[data-theme\]\)\[data-clima="niebla"\]/);
+
+/* ── tokens biopunk (index.css :root — chrome oscuro, valores Tailwind) ──── */
+const SLATE_100 = [241, 245, 249];
+const SLATE_300 = [203, 213, 225];
+const SLATE_400 = [148, 163, 184];
+const WHITE = [255, 255, 255];
+const SURFACE = [2, 6, 23]; // slate-950
+const CARD = [15, 23, 42]; // slate-900
+const RAISED = [30, 41, 59]; // slate-800
+const EMERALD_700 = [4, 120, 87]; // botón sólido
+
+/* Pares del chrome oscuro que SON AA de base y deben SEGUIR siéndolo velados. */
+const PAIRS = [
+  ['slate-100 / surface', SLATE_100, SURFACE],
+  ['slate-100 / card', SLATE_100, CARD],
+  ['slate-300 / card', SLATE_300, CARD],
+  ['slate-300 / raised', SLATE_300, RAISED],
+  ['slate-400 / card', SLATE_400, CARD],
+  ['slate-400 / raised', SLATE_400, RAISED],
+  ['blanco / botón emerald-700', WHITE, EMERALD_700],
+];
+
+/* Peor caso del multiplicador: ENSO niña (tinte ×1.25) × cal sensores 1.5. */
+const ENSO_NINA = 1.25;
+const CAL_MAX = 1.5;
+
+describe('clima-atmosfera — velo nocturno sobre el tema oscuro (biopunk)', () => {
+  it('el bloque noche de biopunk existe y apaga velo navy Y tinte residual', () => {
+    expect(noche).toBeTruthy();
+    expect(num(decl(noche, '--w-night-a'))).toBe(0);
+    expect(num(decl(noche, '--w-tint-a'))).toBe(0);
+  });
+
+  it('biopunk de noche baja los topes del tinte (cap ≤ 0.10 / ≤ 0.08)', () => {
+    const capTop = num(decl(noche, '--w-tint-cap-top'));
+    const capBot = num(decl(noche, '--w-tint-cap-bot'));
+    expect(capTop).not.toBeNull();
+    expect(capBot).not.toBeNull();
+    expect(capTop).toBeLessThanOrEqual(0.1);
+    expect(capBot).toBeLessThanOrEqual(0.08);
+    expect(capBot).toBeLessThanOrEqual(capTop);
+  });
+
+  it('el compuesto del velo usa los topes por var (no min() hardcodeado)', () => {
+    expect(css).toMatch(/min\(var\(--w-tint-cap-top[^)]*\)/);
+    expect(css).toMatch(/min\(var\(--w-tint-cap-bot[^)]*\)/);
+    // y :root conserva el tope de diseño para los temas claros
+    expect(num(decl(root, '--w-tint-cap-top'))).toBeCloseTo(0.26, 5);
+    expect(num(decl(root, '--w-tint-cap-bot'))).toBeCloseTo(0.2, 5);
+  });
+
+  it('peor caso nocturno (clima × niña × cal 1.5): los pares AA del chrome oscuro siguen AA', () => {
+    const capTop = num(decl(noche, '--w-tint-cap-top'));
+    // Velos de clima que aplican a biopunk de noche, con los valores REALES
+    // parseados del CSS (rgb del bloque específico o del genérico si hereda).
+    const generic = {
+      nublado: blockBody(/html\[data-clima="nublado"\]/),
+      lluvia: blockBody(/html\[data-clima="lluvia"\]/),
+      niebla: blockBody(/html\[data-clima="niebla"\]/),
+    };
+    const climas = [
+      ['nublado', bpNublado, generic.nublado],
+      ['lluvia', bpLluvia, generic.lluvia],
+      ['niebla', bpNiebla, generic.niebla],
+    ];
+    const fails = [];
+    for (const [nombre, bp, gen] of climas) {
+      const tintRgb = rgb(decl(bp, '--w-tint-rgb')) || rgb(decl(gen, '--w-tint-rgb'));
+      const tintA = num(decl(bp, '--w-tint-a')) ?? num(decl(gen, '--w-tint-a'));
+      expect(tintRgb, `--w-tint-rgb de ${nombre}`).toBeTruthy();
+      expect(tintA, `--w-tint-a de ${nombre}`).not.toBeNull();
+      // alpha efectiva arriba de la pantalla = min(cap, a × enso × cal)
+      const a = Math.min(capTop, tintA * ENSO_NINA * CAL_MAX);
+      for (const [par, fg, bg] of PAIRS) {
+        const base = contrast(fg, bg);
+        if (base < 4.5) continue; // pares no-AA de base no son contrato de este velo
+        const velado = contrast(blend(fg, tintRgb, a), blend(bg, tintRgb, a));
+        if (velado < 4.5) {
+          fails.push(`${nombre} · ${par}: ${base.toFixed(2)} → ${velado.toFixed(2)} (< 4.5)`);
+        }
+      }
+    }
+    expect(fails, `pares que pierden AA de noche:\n  ${fails.join('\n  ')}`).toEqual([]);
+  });
+
+  it('los temas claros siguen exentos del velo nocturno (siempre claros)', () => {
+    for (const tema of ['nature', 'minimalista', 'verde-vivo']) {
+      const body = blockBody(
+        new RegExp(String.raw`html\[data-theme="${tema}"\]\[data-luz="noche"\]`)
+      );
+      expect(body, `exención nocturna de ${tema}`).toBeTruthy();
+      expect(decl(body, '--w-night-a')).toMatch(/^0\s*!important/);
+      expect(decl(body, '--w-tint-a')).toMatch(/^0\s*!important/);
+    }
+  });
+});

--- a/src/styles/clima-atmosfera.css
+++ b/src/styles/clima-atmosfera.css
@@ -21,7 +21,10 @@
  *    (0.20 glow / 0.26 tinte / 0.25 noche) que ni la calibración ni el ENSO
  *    pueden superar. Peor caso CALCULADO (niebla nature al tope 0.26): tinta
  *    café sobre crema velada ≈ 4.9:1 → sigue AA. A 0.32 caía a 4.1 → por eso
- *    el tope es 0.26.
+ *    el tope es 0.26. El tope del TINTE es var por CONTEXTO
+ *    (--w-tint-cap-top/-bot): 0.26/0.20 en claros; biopunk DE NOCHE lo baja a
+ *    0.10/0.08 porque sobre oscuro la misma alpha comprime el doble (ver
+ *    bloque noche).
  *  - Sin atributos → sin velo (ni siquiera se genera el ::after).
  *  - `prefers-contrast: more` apaga TODA la capa (campo, sol directo).
  *  - Calibración sensores: `--w-cal` (atmosphereService, 0..1.5) escala todo.
@@ -52,6 +55,16 @@
   /* Capa 3: veladura nocturna (solo temas claros). */
   --w-night-rgb: 24 32 48;
   --w-night-a: 0;
+  /* TOPES del tinte por CONTEXTO (legibilidad 2026-07-06). El 0.26/0.20 del
+   * diseño original se CALCULÓ para temas claros (tinta café sobre crema
+   * ≈ 4.9:1 AA al tope). Sobre el tema OSCURO la misma alpha comprime el
+   * DOBLE: el texto claro pierde luminancia y el fondo casi no gana (medido:
+   * slate-400 sobre raised 5.7:1 → 3.4:1 y blanco sobre botón emerald-700
+   * 5.5:1 → 3.5:1 con niebla/lluvia nocturna al tope). El contexto
+   * biopunk-de-noche baja estos topes (ver bloque noche); el velo sigue
+   * respirando, pero nunca por debajo de AA en los pares del chrome. */
+  --w-tint-cap-top: 0.26;
+  --w-tint-cap-bot: 0.20;
   /* Lienzo biopunk (themes.css §4): alpha del glow ambiental teal. El clima lo
    * "respira": sol pleno lo aviva, lluvia/niebla lo amortiguan. */
   --bp-glow-a: 0.10;
@@ -76,9 +89,20 @@ html[data-luz="noche"] {
 }
 /* Biopunk es el tema NOCTURNO por diseño ("cosecha mística"): de noche no se
  * vela nada — se respeta su modo oscuro tal cual (patrón del modo auto:
- * noche→biopunk). */
+ * noche→biopunk). Legibilidad 2026-07-06: además del velo navy, se apaga el
+ * TINTE azul residual de `html[data-luz="noche"]` (0.10) que sí caía sobre
+ * biopunk en noche despejada, contradiciendo este mismo comentario (los velos
+ * de CLIMA — nublado/lluvia/niebla — se re-declaran después con la misma
+ * especificidad y GANAN, así que la lluvia de noche se sigue sintiendo). Y se
+ * bajan los topes del tinte a 0.10/0.08: calibrado con sonda WCAG para que el
+ * peor caso nocturno (niebla ×niña ×cal 1.5) conserve AA en los pares
+ * apretados del chrome oscuro (slate-400/raised 4.6:1, blanco/emerald-700
+ * 4.7:1). La estética biopunk NO se toca: esto solo LIMITA el velo externo. */
 html:not([data-theme])[data-luz="noche"] {
   --w-night-a: 0;
+  --w-tint-a: 0;
+  --w-tint-cap-top: 0.10;
+  --w-tint-cap-bot: 0.08;
 }
 /* TEMAS CLAROS SIEMPRE CLAROS (operador 2026-06-20: "siempre claro como los
  * demos"). nature, minimalista y verde-vivo NO adoptan la veladura navy ni el
@@ -226,8 +250,8 @@ html[data-clima] body::after {
     ),
     linear-gradient(
       180deg,
-      rgb(var(--w-tint-rgb) / min(0.26, calc(var(--w-tint-a) * var(--w-enso-tint) * var(--w-cal)))) 0%,
-      rgb(var(--w-tint-rgb) / min(0.20, calc(var(--w-tint-a) * 0.55 * var(--w-enso-tint) * var(--w-cal)))) 100%
+      rgb(var(--w-tint-rgb) / min(var(--w-tint-cap-top, 0.26), calc(var(--w-tint-a) * var(--w-enso-tint) * var(--w-cal)))) 0%,
+      rgb(var(--w-tint-rgb) / min(var(--w-tint-cap-bot, 0.20), calc(var(--w-tint-a) * 0.55 * var(--w-enso-tint) * var(--w-cal)))) 100%
     ),
     rgb(var(--w-night-rgb) / min(0.25, calc(var(--w-night-a) * var(--w-cal))));
 }


### PR DESCRIPTION
## Qué

Pulido acotado de legibilidad de los **temas oscuros de noche**: el velo climático (`clima-atmosfera.css`) comprimía el contraste del texto/controles sobre el chrome oscuro (biopunk/biopunk2 — lo que ve el modo auto de noche) por debajo de WCAG AA.

## Causa raíz (medida, no estimada)

Los topes duros del tinte (`min(0.26 / 0.20)`) se calcularon para **temas claros** (tinta café sobre crema ≈ 4.9:1 al tope). Sobre el tema oscuro la misma alpha comprime el doble: el texto claro pierde luminancia y el fondo casi no gana. Sonda WCAG sobre los tokens reales de `index.css`, peor caso nocturno (ENSO niña ×1.25 · `--w-cal` 1.5):

| Par (chrome oscuro) | Base | Antes (velado) | Después |
|---|---|---|---|
| slate-400 / raised (cards) | 5.71 | **3.39** (niebla) | ≥ 4.6 |
| blanco / botón emerald-700 | 5.48 | **3.49** (niebla) | ≥ 4.7 |
| slate-400 / card | 6.96 | **4.15** (niebla) | ≥ 5.6 |

Además, biopunk en **noche despejada** recibía un tinte navy residual 0.10 que contradecía la exención documentada en el propio archivo ("de noche no se vela nada").

## Cómo (patrón existente, sin sistema nuevo)

Solo indirección por CSS-var — mismo patrón del archivo:

- Topes del tinte pasan a vars de contexto `--w-tint-cap-top/-bot` (`:root` conserva 0.26/0.20 → **temas claros byte-idénticos**).
- `html:not([data-theme])[data-luz="noche"]` baja el tope a **0.10/0.08** (calibrado con la sonda para que el peor caso vuelva a AA) y apaga el tinte navy residual. Los velos de clima (nublado/lluvia/niebla) se siguen sintiendo de noche — solo quedan limitados.
- **La estética biopunk no se toca**: se limita el velo externo encima; el lienzo neón (`--bp-glow-a`) queda intacto. De hecho la piel oscura queda más viva de noche.

## Test

`src/styles/__tests__/climaAtmosferaNoche.test.js` parsea el **CSS real** (no mock) y reproduce la mecánica exacta del velo: si alguien sube los topes nocturnos o re-vela biopunk de noche, falla con el par y el ratio medidos. Validado por mutación (subir el tope a 0.26 → 2 tests fallan). También asegura que los 3 temas claros sigan exentos de noche.

## Verificación

- `npm run build` verde (10.2s).
- `npx vitest run src/styles/__tests__/` → 4 archivos, 34 tests verdes (+ suite atmosphereService verde).
- eslint limpio en el archivo nuevo; imports node:* con el mismo patrón de `themes.coverage.test.js` (ya pasa el gate tsc en CI).
- **Visual en navegador real** (Playwright + chromium, dev server logueado, viewport móvil): home/agente, biopreparados y login con `data-luz=noche` × despejado/lluvia/niebla, antes/después. La bruma lechosa de niebla y el azul denso de lluvia dejan de lavar texto secundario, chips y el aviso de toxicología; en despejado el lienzo biopunk recupera su negro profundo.

## Nota (fuera de alcance, para seguimiento)

La misma compresión existe **de día** sobre biopunk con lluvia/niebla (slate-400/raised 4.4 y 4.0 al tope): menor severidad (de día el modo auto usa nature y hay luz ambiente). Si se quiere, es la misma palanca: bajar `--w-tint-cap-*` también para biopunk diurno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)