### PR TITLE
feat(ux): estados de carga con contexto — fases del agente + fallback Suspense contextual

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -184,14 +184,70 @@ localforage.config({
   storeName: 'syncQueue'
 });
 
-const LoadingFallback = () => (
-  <div
-    className="h-[100dvh] bg-slate-950 flex items-center justify-center text-muzo-glow"
-    data-testid="app-suspense-fallback"
-  >
-    <ChagraGrowLoader size={80} showLabel labelText="Chagra..." />
-  </div>
-);
+// Etiquetas contextuales del fallback de Suspense (perceived performance):
+// mientras baja el chunk lazy de la vista destino, el loader dice A DÓNDE
+// vas en lugar del "Chagra..." genérico — la espera se siente intencional.
+// Vistas sin entrada caen al label genérico (abajo).
+const VIEW_LOADING_LABELS = {
+  loading: 'Preparando tu chagra…',
+  dashboard: 'Preparando tu chagra…',
+  hoy_finca: 'Preparando tu chagra…',
+  agente: 'Despertando al agente…',
+  voz: 'Preparando el modo voz…',
+  voz_planta: 'Preparando el modo voz…',
+  directorio: 'Abriendo el catálogo de especies…',
+  especies: 'Abriendo el catálogo de especies…',
+  toxicologia: 'Abriendo el catálogo de especies…',
+  mundo: 'Abriendo el mundo…',
+  mundo_cultivos: 'Abriendo tus cultivos…',
+  agua: 'Abriendo el mundo del agua…',
+  suelo: 'Abriendo el mundo del suelo…',
+  salud_suelo: 'Abriendo el mundo del suelo…',
+  semilla: 'Abriendo el mundo de la semilla…',
+  poscosecha: 'Abriendo la poscosecha…',
+  almacenamiento: 'Abriendo el almacenamiento…',
+  nutricion: 'Abriendo la comida que alimenta…',
+  animales: 'Abriendo tus animales…',
+  ciclo_vivo: 'Abriendo el ciclo vivo…',
+  calendario: 'Abriendo el calendario…',
+  calendario_finca: 'Abriendo el calendario…',
+  mapa: 'Abriendo el mapa…',
+  mercado: 'Abriendo el mercado…',
+  mercados: 'Abriendo el mercado…',
+  aprende: 'Abriendo los cursos…',
+  bitacora: 'Abriendo la bitácora…',
+  historial: 'Abriendo la bitácora…',
+  informes: 'Preparando los informes…',
+};
+
+// Si el chunk tarda más que esto, mostramos una línea de calma (UX paciente:
+// típico en campo con señal débil o en la primera visita sin caché).
+const SLOW_LOAD_HINT_MS = 4000;
+
+const LoadingFallback = ({ view = null }) => {
+  const [slow, setSlow] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setSlow(true), SLOW_LOAD_HINT_MS);
+    return () => clearTimeout(t);
+  }, []);
+  return (
+    <div
+      className="h-[100dvh] bg-slate-950 flex flex-col items-center justify-center gap-3 text-muzo-glow"
+      data-testid="app-suspense-fallback"
+    >
+      <ChagraGrowLoader size={80} showLabel labelText={VIEW_LOADING_LABELS[view] || 'Cargando…'} />
+      {slow && (
+        <p
+          className="text-xs text-slate-400 text-center px-8 max-w-xs"
+          data-testid="app-suspense-slow-hint"
+          aria-live="polite"
+        >
+          Sigue cargando — con señal de campo puede tardar un poco más. No se perdió nada.
+        </p>
+      )}
+    </div>
+  );
+};
 
 // CÓDIGO MUERTO REMOVIDO 2026-06-24 (descubribilidad): `NAV_TILES` +
 // `ACCENT_CLASSES` solo los consumía `DashboardView` (la grilla de 16 tiles del
@@ -821,7 +877,7 @@ export default function App() {
 
     switch (currentView) {
       case 'loading':
-        return <LoadingFallback />;
+        return <LoadingFallback view="loading" />;
       case 'login':
         return (
           <ErrorBoundary>
@@ -1809,7 +1865,9 @@ export default function App() {
       {/* #315 — banner crítico global: surfacea alertas graves (helada, sensor
           crítico) sin abrir la campana. Imposible de ignorar. */}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && <CriticalAlertBanner onNavigate={navigate} />}
-      <Suspense fallback={<LoadingFallback />}>
+      {/* El fallback conoce la vista destino: mientras baja el chunk lazy
+          muestra "Abriendo el catálogo…" etc. en vez del genérico. */}
+      <Suspense fallback={<LoadingFallback view={currentView} />}>
         {renderView()}
       </Suspense>
       {/* FAB feedback flotante REMOVIDO 2026-05-21: el reporte de errores

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -52,6 +52,9 @@ import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities,
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
 // el chip cuyo backend aún no existe (deep).
 import { planForcedIntent, isStubIntent, isDeepResearchIntent, CHIP_DEFS } from '../../services/chipIntentRouter';
+// Fases visibles del "pensando" (MSG.agente.fases) — perceived performance:
+// la espera larga muestra en qué va el pipeline, no un "Pensando" opaco.
+import { MSG } from '../../config/messages';
 // «Chagra enseña a usar Chagra» (ayuda groundeada): detecta preguntas META
 // («¿cómo uso X?», «¿qué puede hacer Chagra?», «¿dónde veo los precios?») y
 // responde DESDE el manifiesto (ayudaFunciones) — sin LLM, nunca inventa una
@@ -223,6 +226,11 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   const [agentAttachment, setAgentAttachment] = useState(null); // {blob,mime,previewUrl,fileName}
   const [agentPickError, setAgentPickError] = useState('');
   const [streamingContent, setStreamingContent] = useState('');
+  // Fase visible del pipeline mientras state === STATE_THINKING (perceived
+  // performance): 'transcribiendo' | 'entendiendo' | 'consultando' |
+  // 'escribiendo' | null. Cada entrada al pipeline la setea fresca, así que
+  // no hace falta limpiarla al salir de THINKING (solo se renderiza ahí).
+  const [thinkingPhase, setThinkingPhase] = useState(null);
   const [isOnline, setIsOnline] = useState(navigator.onLine);
   const [error, setError] = useState('');
   const [actionModal, setActionModal] = useState({ isOpen: false, intent: null, llmResponse: '' });
@@ -824,6 +832,9 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // puras, testeables y medibles fuera de React).
 
   const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null, fermentoBlock = '', subgrafoBloque = '', biopreparadoBlock = '', pisoTermicoBlock = '', confusionEspecieBlock = '', pestVsDiseaseBlock = '', groundingPolicyBlock = '') => {
+    // Fase 3 del "pensando" visible: generación en el LLM. Cuando llega el
+    // primer token, la UI pasa sola al parcial streaming (streamingContent).
+    setThinkingPhase('escribiendo');
     const analysis = analyzeQuery(query);
     // El base recibe query/historial/isEnum para inyectar SOLO los glosarios
     // y reglas condicionales que la conversación toca (re-arquitectura GR-10).
@@ -1331,6 +1342,8 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
     }
     setStreamingContent('');
     setState(STATE_THINKING);
+    // Fase 1 del "pensando" visible: contexto + RAG + resolución de entidades.
+    setThinkingPhase('entendiendo');
     setError('');
     agentSounds.start();
 
@@ -1438,6 +1451,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // del grafo AGE para queries relacionales (plaga+cultivo). '' = no-op.
       let subgrafoBloque = '';
       if (isOnline && isSidecarEnabled()) {
+        // Fase 2 del "pensando" visible: grounding real contra el sidecar
+        // (entidades, guards, grafo, tools). Es el tramo más largo antes de
+        // generar — mostrarlo evita la sensación de "se colgó".
+        setThinkingPhase('consultando');
         try {
           // PASO 1 — pre-validation AGE (DR taxonómico Tier 1 B, PR #59).
           // Resuelve entidades vegetales/plagas a binomio canónico autoritativo
@@ -2940,6 +2957,9 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       }
       const { blob } = result;
       setState(STATE_THINKING);
+      // Fase de voz: transcripción Whisper antes de entrar al pipeline de
+      // texto (que setea sus propias fases al arrancar).
+      setThinkingPhase('transcribiendo');
 
       try {
         const text = await transcribe(blob);
@@ -3501,6 +3521,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         messages={messages}
         streamingContent={streamingContent}
         isStreaming={state === STATE_THINKING}
+        thinkingLabel={MSG.agente.fases[thinkingPhase] || null}
         onConsentNeeded={handleFeedbackConsentNeeded}
         onRetryOrphan={handleRetryOrphan}
         onCancelDeepResearch={handleCancelDeepResearch}
@@ -3957,6 +3978,9 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                 // pedimos "toca de nuevo" — la pregunta está guardada y, si se
                 // corta, se reintenta sola. Aun el caso lento ofrece SOLO
                 // Cancelar (acción voluntaria), nunca insinúa que se perdió.
+                // La fase visible (thinkingPhase) reemplaza el "Pensando"
+                // genérico para que la espera muestre avance real.
+                const faseLabel = MSG.agente.fases[thinkingPhase] || null;
                 if (showSlowWarning) {
                   return 'Sigo pensando — esto puede tardar en el campo. Tu pregunta está guardada.';
                 }
@@ -3978,9 +4002,9 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                   if (stretching) {
                     return `Casi listo… (${Math.floor(elapsed / 1000)}s)`;
                   }
-                  return `Pensando tu respuesta… ~${secsLeft}s`;
+                  return `${faseLabel || 'Pensando tu respuesta'}… ~${secsLeft}s`;
                 }
-                return 'Pensando… (puede tardar en el campo)';
+                return `${faseLabel || 'Pensando'}… (puede tardar en el campo)`;
               })()}
             </p>
             {queuePending.length >= 1 && (

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -28,9 +28,12 @@ const FLOATING_BACK_THRESHOLD_PX = 160;
  * @param {Function} props.onCancelDeepResearch - Callback para cancelar una investigación profunda en curso.
  * @param {Function} [props.onAyudaAction] - Callback del deep-link «Abrir …» de la ayuda groundeada (AYUDA_FUNCIONES).
  * @param {Object|null} [props.proactiveGreeting=null] - Datos del saludo proactivo dinámico.
+ * @param {string|null} [props.thinkingLabel=null] - Fase visible del pipeline mientras
+ *   se espera el primer token ("Entendiendo tu pregunta", "Consultando el catálogo…").
+ *   Si es null cae al "Pensando" genérico — perceived performance, la espera avanza.
  * @param {Function} props.onBack - Callback para volver a la pantalla anterior.
  */
-export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, onDismissInsight, onAyudaAction, proactiveGreeting = null, onBack }) {
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, thinkingLabel = null, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, onDismissInsight, onAyudaAction, proactiveGreeting = null, onBack }) {
   const bottomRef = useRef(null);
   const scrollRef = useRef(null);
   // (B) Botón "Volver" flotante: visible solo cuando el operador se alejó del
@@ -254,8 +257,8 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
             </span>
             <span>Chagra</span>
           </div>
-          <div className="v3-card text-sm italic text-slate-300">
-            {MSG.agente.pensandoTexto}
+          <div className="v3-card text-sm italic text-slate-300" aria-live="polite">
+            {thinkingLabel || MSG.agente.pensandoTexto}
             <span className="inline-block ml-1 animate-thinkingDot">·</span>
             <span className="inline-block ml-0.5 animate-thinkingDot [animation-delay:200ms]">·</span>
             <span className="inline-block ml-0.5 animate-thinkingDot [animation-delay:400ms]">·</span>

--- a/src/components/common/ScreenLoadingStatus.jsx
+++ b/src/components/common/ScreenLoadingStatus.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
-import { Loader2, AlertTriangle, PackageOpen } from 'lucide-react';
+import { AlertTriangle, PackageOpen } from 'lucide-react';
+import ChagraGrowLoader from '../ChagraGrowLoader';
 
 /**
  * ScreenLoadingStatus — estado de carga / vacio / error reutilizable.
  *
  * Props:
- *  - isLoading (boolean) — muestra spinner centrado
+ *  - isLoading (boolean) — muestra el loader de la casa (ChagraGrowLoader)
+ *  - loadingMessage (string) — mensaje contextual de carga ("Cargando el
+ *    catálogo…"); pásalo SIEMPRE que sepas qué se está cargando — el
+ *    "Cargando..." genérico es solo el último recurso (perceived performance)
  *  - isEmpty (boolean) — muestra estado vacio
  *  - hasError (boolean) — muestra estado de error
  *  - emptyTitle (string) — titulo del estado vacio
@@ -15,6 +19,7 @@ import { Loader2, AlertTriangle, PackageOpen } from 'lucide-react';
  */
 export default function ScreenLoadingStatus({
   isLoading = false,
+  loadingMessage = 'Cargando...',
   isEmpty = false,
   hasError = false,
   emptyTitle = '',
@@ -26,8 +31,11 @@ export default function ScreenLoadingStatus({
     return (
       <div className="h-[100dvh] w-full flex items-center justify-center bg-slate-950">
         <div className="flex flex-col items-center gap-4">
-          <Loader2 size={40} className="text-emerald-400 animate-spin" aria-hidden="true" />
-          <p className="text-slate-400 text-sm font-medium">Cargando...</p>
+          {/* Loader de la casa (planta que crece; respeta reduced-motion) en
+              lugar del spinner genérico — misma gramática visual que el
+              fallback de Suspense y el directorio. */}
+          <ChagraGrowLoader size={56} ariaLabel={loadingMessage} />
+          <p className="text-slate-400 text-sm font-medium" aria-hidden="true">{loadingMessage}</p>
         </div>
       </div>
     );

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -92,6 +92,16 @@ const messages = {
     // estado completo para lectores de pantalla.
     pensandoTexto: 'Pensando',
     pensandoAria: 'Chagra IA está pensando',
+    // Fases visibles del "pensando" (perceived performance): el pipeline
+    // interno (transcripción → entendimiento → grounding/tools → generación)
+    // se asoma a la UI para que la espera larga se sienta viva y con avance,
+    // no colgada. Las claves las setea AgentScreen (thinkingPhase).
+    fases: {
+      transcribiendo: 'Entendiendo tu voz',
+      entendiendo: 'Entendiendo tu pregunta',
+      consultando: 'Consultando el catálogo y tu chagra',
+      escribiendo: 'Escribiendo tu respuesta',
+    },
     confianzaAlta: 'Confianza alta',
     confianzaMedia: 'Confianza media',
     confianzaBaja: 'Confianza baja',


### PR DESCRIPTION
## Qué ataca

La queja recurrente: *"a veces se queda pensando más de la cuenta / parece colgado"*. NO es optimización de fondo — es que las cargas >1.5s se SIENTAN intencionales. Cero lógica nueva de datos, cero animaciones nuevas: todo reusa los loaders existentes (ChagraGrowLoader, SkeletonCampo) que ya respetan `prefers-reduced-motion`.

## Pantallas mejoradas (antes → después)

### 1. Agente mientras piensa (`AgentScreen.jsx`, `ChatHistory.jsx`)
- **Antes**: todo el pipeline (NLU → grounding/tools → generación) corría bajo un único "Pensando···" opaco. En preguntas con grounding (5-20s) parecía colgado.
- **Después**: nuevo estado `thinkingPhase` expone las fases reales a la UI:
  - `Entendiendo tu voz` (transcripción Whisper, flujo voz)
  - `Entendiendo tu pregunta` (contexto + RAG + entidades)
  - `Consultando el catálogo y tu chagra` (sidecar: guards, grafo, tools — el tramo más largo)
  - `Escribiendo tu respuesta` (generación; al primer token pasa solo al streaming)
- La fase se ve en DOS superficies ya existentes: el placeholder del chat (antes "Pensando···" estático, ahora con `aria-live="polite"`) y la línea de ETA (`Consultando el catálogo y tu chagra… ~8s`). Los mensajes UX-paciente del caso lento quedan intactos.

### 2. Transiciones entre pantallas/mundos (`App.jsx`)
- **Antes**: fallback de Suspense genérico `ChagraGrowLoader` + "Chagra..." para las ~90 vistas lazy.
- **Después**: el fallback conoce la vista destino (`VIEW_LOADING_LABELS`, ~30 entradas): "Abriendo el catálogo de especies…", "Despertando al agente…", "Abriendo el mundo del agua…", etc. Y si el chunk tarda >4s aparece una línea de calma: *"Sigue cargando — con señal de campo puede tardar un poco más. No se perdió nada."*

### 3. Catálogo de especies
- **Auditado, ya estaba bien resuelto** (SkeletonCampo con forma real + "Buscando en el catálogo…" / "Abriendo la ficha…"). Su mejora aquí es el label contextual del Suspense al entrar ("Abriendo el catálogo de especies…").

### 4. Home al arrancar
- **Auditado, ya estaba bien resuelto** (pre-loader 🌱 inline en index.html sin flash blanco). Mejora: el estado `loading` inicial ahora dice "Preparando tu chagra…" en vez de "Chagra...".

### 5. `ScreenLoadingStatus` (componente compartido)
- **Antes**: spinner genérico `Loader2` + "Cargando..." — el anti-patrón exacto.
- **Después**: `ChagraGrowLoader` (loader de la casa) + prop `loadingMessage` contextual. Quien lo use hereda el patrón correcto.

## Accesibilidad / reduced-motion
- Sin animaciones nuevas — solo texto que cambia. Los loaders reusados ya apagan animación bajo `prefers-reduced-motion`.
- Fase del chat y aviso de carga lenta con `aria-live="polite"`; svg del loader `aria-hidden`.

## Verificación
- `npm run build` ✅ (24.8s)
- `npm run tsc:check` ✅ (exit 0)
- `npx eslint` sobre los 5 archivos tocados ✅ (exit 0)
- Suites relevantes: `empty-states`, `screen-reader`, `loading-skeleton-dark`, `AgentScreen/*`, `src/__tests__/App.*` → **102 tests, todos verdes**

🤖 Generated with [Claude Code](https://claude.com/claude-code)