### PR TITLE
feat(ux): estados vacíos y de error cálidos — ErrorStateCampo + mensajeErrorCampesino

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square, Sprout, HelpCircle } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
+import { mensajeErrorCampesino } from '../../utils/mensajeErrorCampesino';
 import { transcribe, queueForRetry } from '../../services/voiceService';
 import VoiceStatusStrip from './VoiceStatusStrip';
 import ChipsToolbar from '../ChipsToolbar';
@@ -2530,7 +2531,9 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         // (timeout/abort: dejamos durableRequestIdRef.current intacto en IDB como
         // 'queued'; solo soltamos la ref local en el finally.)
       } else {
-        setError(e.message || 'No pude conectarme al asistente. Intenta de nuevo.');
+        // NUNCA e.message crudo al banner ("Failed to fetch", stacktraces):
+        // mensajeErrorCampesino respeta frases ya curadas y traduce lo técnico.
+        setError(mensajeErrorCampesino(e, 'No pude con esa pregunta. Intente de nuevo, o pregunte de otra forma.'));
         // Error NO-interrupción (HTTP 5xx, sesión, etc.): marcar failed. El
         // prompt queda intacto en IDB; la cola durable NO lo reintenta (no es
         // recuperable solo con reintentar), pero NO se pierde el dato.

--- a/src/components/CycleContentRenderer.jsx
+++ b/src/components/CycleContentRenderer.jsx
@@ -1,5 +1,11 @@
+/* i18n (ADR-050): etiquetas user-facing en español Colombia. La regla
+ * chagra-i18n es soft (warn); se desactiva a nivel de archivo siguiendo el
+ * mismo criterio que MercadosScreen/GerminacionScreen para no bloquear el
+ * pre-commit (max-warnings=0). Los errores reales siguen activos. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import React, { useEffect, useState } from 'react';
 import { Sprout, AlertTriangle, Users, Beaker, Mountain, BookOpen, Loader2, FileEdit } from 'lucide-react';
+import ErrorStateCampo from './common/ErrorStateCampo.jsx';
 
 /**
  * Sanitiza strings de fuente para ocultar jerga interna DR-034 al usuario
@@ -52,28 +58,58 @@ const DIFFICULTY_BADGE = {
  */
 export default function CycleContentRenderer({ slug, onClose }) {
   const [state, setState] = useState({ slug: null, data: null, error: null });
+  const [reintento, setReintento] = useState(0);
 
   useEffect(() => {
     const ctrl = new AbortController();
     fetch(`${import.meta.env.BASE_URL}cycle-content/${slug}.json`, { signal: ctrl.signal })
       .then((r) => {
-        if (!r.ok) throw new Error(`No se encontró el ciclo de ${slug}`);
+        if (!r.ok) {
+          // Marcada como "no encontrada" para distinguirla de un fallo de red:
+          // sin la guía no hay nada que reintentar; sin señal sí.
+          throw Object.assign(new Error(`Todavía no está escrita la guía de ${slug}.`), { notFound: true });
+        }
         return r.json();
       })
       .then((j) => setState({ slug, data: j, error: null }))
-      .catch((e) => { if (e.name !== 'AbortError') setState({ slug, data: null, error: e.message }); });
+      .catch((e) => {
+        if (e.name === 'AbortError') return;
+        setState({ slug, data: null, error: { notFound: !!e.notFound, message: e.message } });
+      });
     return () => ctrl.abort();
-  }, [slug]);
+  }, [slug, reintento]);
 
   const isLoading = state.slug !== slug;
   const data = isLoading ? null : state.data;
   const error = isLoading ? null : state.error;
 
   if (error) {
+    // NUNCA el e.message crudo ("Failed to fetch"): frase campesina + acción.
     return (
-      <div className="p-4 rounded-xl bg-rose-900/20 border border-rose-800/50">
-        <p className="text-sm text-rose-300">{error}</p>
-        <button type="button" onClick={onClose} className="mt-2 text-xs underline text-slate-400">Volver</button>
+      <div className="py-6" data-testid="ciclo-error">
+        <ErrorStateCampo
+          title={error.notFound ? 'Esta guía todavía no está escrita.' : 'No pudimos cargar esta guía.'}
+          hint={
+            error.notFound
+              ? 'Estamos completando el cuaderno especie por especie. Vuelva a mirar más adelante.'
+              : 'Puede ser la señal. Espere un momento y vuelva a intentar.'
+          }
+          onRetry={
+            error.notFound
+              ? null
+              : () => {
+                  // Vuelve al estado "cargando" mientras se reintenta.
+                  setState({ slug: null, data: null, error: null });
+                  setReintento((n) => n + 1);
+                }
+          }
+        >
+          {onClose && (
+            <button type="button" onClick={onClose} className="mt-3 text-xs underline text-slate-400">
+              Volver
+            </button>
+          )}
+        </ErrorStateCampo>
       </div>
     );
   }

--- a/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
+++ b/src/components/DirectorioEspecies/DirectorioEspeciesScreen.jsx
@@ -3,6 +3,7 @@ import { ChevronLeft, Search, Sprout, Leaf, X } from 'lucide-react';
 import { searchSpecies, buildSpeciesFicha } from '../../services/directorioEspecies.js';
 import SpeciesFicha from './SpeciesFicha.jsx';
 import EmptyStateCampo from '../common/EmptyStateCampo.jsx';
+import ErrorStateCampo from '../common/ErrorStateCampo.jsx';
 import SkeletonCampo from '../common/SkeletonCampo.jsx';
 import ChagraGrowLoader from '../ChagraGrowLoader.jsx';
 import { fvhSkinClass } from '../../config/fvhSkin.js';
@@ -28,8 +29,10 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
   const [query, setQuery] = useState(initialQuery);
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState(false); // el catálogo no cargó (≠ sin resultados)
   const [selected, setSelected] = useState(null); // ficha construida
   const [loadingFicha, setLoadingFicha] = useState(false);
+  const [fichaErrorId, setFichaErrorId] = useState(null); // id cuya ficha falló al abrir
   const [touched, setTouched] = useState(false);
   const debounceRef = useRef(null);
 
@@ -37,14 +40,19 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
     if (!q || q.trim().length < 2) {
       setResults([]);
       setSearching(false);
+      setSearchError(false);
       return;
     }
     setSearching(true);
+    setSearchError(false);
     try {
       const found = await searchSpecies(q);
       setResults(found);
     } catch (_) {
+      // Un catálogo que no cargó NO es lo mismo que "no encontramos esa mata":
+      // se marca el error para ofrecer reintento en vez del empty engañoso.
       setResults([]);
+      setSearchError(true);
     } finally {
       setSearching(false);
     }
@@ -60,12 +68,15 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
 
   const selectSpecies = useCallback(async (id) => {
     setLoadingFicha(true);
+    setFichaErrorId(null);
     try {
       const ficha = await buildSpeciesFicha(id);
       setSelected(ficha);
       if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'auto' });
     } catch (_) {
+      // Antes esto dejaba la lista muda, como si nada hubiera pasado.
       setSelected(null);
+      setFichaErrorId(id);
     } finally {
       setLoadingFicha(false);
     }
@@ -76,9 +87,16 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
     async (e) => {
       e.preventDefault();
       setTouched(true);
-      const found = await searchSpecies(query);
-      setResults(found);
-      if (found.length === 1) selectSpecies(found[0].id);
+      try {
+        const found = await searchSpecies(query);
+        setResults(found);
+        setSearchError(false);
+        if (found.length === 1) selectSpecies(found[0].id);
+      } catch (_) {
+        // Sin este catch, un fallo aquí era un rechazo sin manejar (blanco).
+        setResults([]);
+        setSearchError(true);
+      }
     },
     [query, selectSpecies],
   );
@@ -183,7 +201,32 @@ export default function DirectorioEspeciesScreen({ onBack, initialQuery = '' }) 
           />
         )}
 
-        {!loadingFicha && !searching && touched && query.trim().length >= 2 && results.length === 0 && (
+        {/* El catálogo no cargó: reintento honesto en vez de "sin resultados". */}
+        {!loadingFicha && !searching && searchError && (
+          <div className="py-8" data-testid="directorio-error">
+            <ErrorStateCampo
+              title={<span className="jp-tinta">No pudimos abrir el catálogo.</span>}
+              hint={<span className="jp-tinta-suave">Sus datos están a salvo. Espere un momento y vuelva a intentar.</span>}
+              onRetry={() => runSearch(query)}
+            />
+          </div>
+        )}
+
+        {/* La ficha de una especie no abrió: avisar y dejar reintentar. */}
+        {!loadingFicha && !searchError && fichaErrorId && (
+          <div className="flex items-center justify-between gap-3 mb-3 px-3 py-2 rounded-lg bg-amber-900/20 border border-amber-800/40" data-testid="directorio-ficha-error">
+            <p className="jp-tinta-suave text-xs text-amber-200">No pudimos abrir esa ficha.</p>
+            <button
+              type="button"
+              onClick={() => selectSpecies(fichaErrorId)}
+              className="text-xs font-bold text-amber-300 underline shrink-0"
+            >
+              Reintentar
+            </button>
+          </div>
+        )}
+
+        {!loadingFicha && !searching && !searchError && touched && query.trim().length >= 2 && results.length === 0 && (
           <div className="py-8" data-testid="directorio-empty">
             <EmptyStateCampo
               variant="busqueda"

--- a/src/components/InventoryDashboard.jsx
+++ b/src/components/InventoryDashboard.jsx
@@ -10,6 +10,7 @@ import { exportTraceabilityCsv } from '../services/exportService';
 import { getAllPlans, markStepExecuted } from '../services/planGeneratorService';
 import { getCurrentOperatorHash } from '../services/operatorIdentityService';
 import { MSG } from '../config/messages.js';
+import { mensajeErrorCampesino } from '../utils/mensajeErrorCampesino';
 
 // Autopilot #10 (2026-05-03): banner top + sort low-stock primero. Reduce
 // chance que el operador no se entere de stock bajo hasta que use el material.
@@ -183,7 +184,8 @@ export const InventoryDashboard = () => {
       await markStepExecuted(planId, stepId, hash);
       loadUpcomingSteps();
     } catch (e) {
-      alert("Error: " + e.message);
+      // Sin "Error: TypeError…" al campesino: frase clara y reintentable.
+      alert(mensajeErrorCampesino(e, MSG.ui.errorMarcarPaso));
     }
   };
 

--- a/src/components/MercadosScreen.jsx
+++ b/src/components/MercadosScreen.jsx
@@ -6,9 +6,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Store, Plus, Search, MapPin, Phone, Trash2, ArrowLeft, Tag, Info,
-  PackageOpen, Sprout, AlertCircle, CheckCircle2,
+  Sprout, AlertCircle, CheckCircle2,
 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
+import EmptyStateCampo from './common/EmptyStateCampo.jsx';
+import ErrorStateCampo from './common/ErrorStateCampo.jsx';
+import SkeletonCampo from './common/SkeletonCampo.jsx';
 import PhotoCaptureField from './PhotoCaptureField';
 import { blobToDataUrl } from '../utils/imageProcessor';
 import { marketplaceOfertas } from '../db/marketplaceOfertas';
@@ -55,6 +58,7 @@ export default function MercadosScreen({ onBack, onNavigate: _onNavigate }) {
   const [tab, setTab] = useState('explorar'); // 'explorar' | 'publicar'
   const [publicadas, setPublicadas] = useState([]);
   const [cargando, setCargando] = useState(true);
+  const [errorCarga, setErrorCarga] = useState(false);
   const [mostrarEjemplos, setMostrarEjemplos] = useState(true);
   const [filtroCat, setFiltroCat] = useState('');
   const [filtroTexto, setFiltroTexto] = useState('');
@@ -65,9 +69,13 @@ export default function MercadosScreen({ onBack, onNavigate: _onNavigate }) {
     try {
       const lista = await marketplaceOfertas.getAll();
       setPublicadas(lista);
+      setErrorCarga(false);
     } catch (e) {
+      // Un fallo de lectura NO debe verse igual que un mercado vacío: se
+      // marca para que ExplorarPanel muestre el estado de error con reintento.
       console.warn('[Mercados] no se pudieron leer las ofertas:', e?.message);
       setPublicadas([]);
+      setErrorCarga(true);
     } finally {
       setCargando(false);
     }
@@ -151,6 +159,8 @@ export default function MercadosScreen({ onBack, onNavigate: _onNavigate }) {
         {tab === 'explorar' && (
           <ExplorarPanel
             cargando={cargando}
+            errorCarga={errorCarga}
+            onReintentar={recargar}
             ofertas={visibles}
             filtroCat={filtroCat}
             setFiltroCat={setFiltroCat}
@@ -182,7 +192,7 @@ export default function MercadosScreen({ onBack, onNavigate: _onNavigate }) {
 /* ════════════════════════ EXPLORAR ════════════════════════ */
 
 function ExplorarPanel({
-  cargando, ofertas, filtroCat, setFiltroCat, filtroTexto, setFiltroTexto,
+  cargando, errorCarga, onReintentar, ofertas, filtroCat, setFiltroCat, filtroTexto, setFiltroTexto,
   mostrarEjemplos, setMostrarEjemplos, onContactar, onPublicarCta,
 }) {
   return (
@@ -226,29 +236,59 @@ function ExplorarPanel({
       </label>
 
       {cargando ? (
-        <p className="text-center text-slate-500 py-10 text-sm">Cargando ofertas…</p>
-      ) : ofertas.length === 0 ? (
-        <div className="text-center py-10">
-          <PackageOpen className="mx-auto text-slate-600 mb-3" size={40} />
-          <p className="text-slate-400 text-sm mb-4">
-            No hay ofertas que coincidan. Sé el primero en publicar lo que vende tu finca.
-          </p>
-          <button
-            type="button"
-            onClick={onPublicarCta}
-            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-bold text-sm"
-          >
-            <Plus size={16} /> Publicar mi producto
-          </button>
+        <SkeletonCampo variant="lista" count={3} label="Cargando ofertas…" />
+      ) : errorCarga && ofertas.length === 0 ? (
+        <div className="py-10" data-testid="mercado-error">
+          <ErrorStateCampo
+            title="No pudimos abrir el mercado."
+            hint="Sus ofertas guardadas están a salvo en este dispositivo. Espere un momento y vuelva a intentar."
+            onRetry={onReintentar}
+          />
         </div>
       ) : (
-        <ul className="space-y-3">
-          {ofertas.map((o) => (
-            <li key={o.id}>
-              <OfertaCard oferta={o} onContactar={onContactar} />
-            </li>
-          ))}
-        </ul>
+        <>
+          {/* Si falló la lectura de las ofertas propias pero los ejemplos sí se
+              ven, se avisa sin tapar la lista. */}
+          {errorCarga && (
+            <div className="flex items-center justify-between gap-3 mb-3 px-3 py-2 rounded-lg bg-amber-900/20 border border-amber-800/40">
+              <p className="text-xs text-amber-200">
+                No pudimos leer sus ofertas guardadas. Las de ejemplo sí se ven.
+              </p>
+              <button
+                type="button"
+                onClick={onReintentar}
+                className="text-xs font-bold text-amber-300 underline shrink-0"
+              >
+                Reintentar
+              </button>
+            </div>
+          )}
+          {ofertas.length === 0 ? (
+            <div className="py-10" data-testid="mercado-empty">
+              <EmptyStateCampo
+                variant="busqueda"
+                title="No hay ofertas que coincidan todavía."
+                hint="Sea el primero: publique lo que vende su finca y aparecerá aquí para los vecinos."
+              >
+                <button
+                  type="button"
+                  onClick={onPublicarCta}
+                  className="mt-4 inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-bold text-sm"
+                >
+                  <Plus size={16} /> Publicar mi producto
+                </button>
+              </EmptyStateCampo>
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {ofertas.map((o) => (
+                <li key={o.id}>
+                  <OfertaCard oferta={o} onContactar={onContactar} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/__tests__/error-state-campo.test.jsx
+++ b/src/components/__tests__/error-state-campo.test.jsx
@@ -1,0 +1,56 @@
+/**
+ * ErrorStateCampo — estado de error inline de la familia campo.
+ * Verifica: copy cálido, botón de reintento funcional, slot children.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi } from 'vitest';
+import ErrorStateCampo from '../common/ErrorStateCampo.jsx';
+
+describe('ErrorStateCampo', () => {
+  test('renderiza title y hint personalizados', () => {
+    render(
+      <ErrorStateCampo
+        title="No pudimos cargar el mercado."
+        hint="Puede ser la señal. Vuelva a intentar."
+      />,
+    );
+    expect(screen.getByText('No pudimos cargar el mercado.')).toBeInTheDocument();
+    expect(screen.getByText('Puede ser la señal. Vuelva a intentar.')).toBeInTheDocument();
+  });
+
+  test('sin props muestra el copy default (negación explícita, sin jerga)', () => {
+    render(<ErrorStateCampo />);
+    expect(screen.getByText('Esto no cargó.')).toBeInTheDocument();
+    expect(screen.getByText(/Espere un momento y vuelva a intentar/)).toBeInTheDocument();
+  });
+
+  test('con onRetry muestra el botón y lo dispara al tocar', () => {
+    const onRetry = vi.fn();
+    render(<ErrorStateCampo onRetry={onRetry} />);
+    const btn = screen.getByRole('button', { name: /Intentar de nuevo/ });
+    fireEvent.click(btn);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test('sin onRetry no renderiza botón de reintento', () => {
+    render(<ErrorStateCampo />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('children se renderiza debajo (slot para CTA secundario)', () => {
+    render(
+      <ErrorStateCampo>
+        <a href="#volver">Volver</a>
+      </ErrorStateCampo>,
+    );
+    expect(screen.getByText('Volver')).toBeInTheDocument();
+  });
+
+  test('la viñeta SVG está oculta a lectores de pantalla', () => {
+    const { container } = render(<ErrorStateCampo />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/components/common/ErrorStateCampo.jsx
+++ b/src/components/common/ErrorStateCampo.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { RotateCcw } from 'lucide-react';
+import './campo-states.css';
+
+/**
+ * ErrorStateCampo — estado de ERROR con identidad de cuaderno de campo.
+ *
+ * Completa la familia campo (EmptyStateCampo = vacío, SkeletonCampo = carga)
+ * para secciones INLINE de una pantalla: lista del mercado, panel de una guía,
+ * resultados del directorio. No reemplaza a ScreenLoadingStatus (que es
+ * full-screen, h-[100dvh]) ni a los ErrorBoundary (que capturan errores de
+ * render); este componente es para fallos de datos/red manejados en el flujo.
+ *
+ * La escena: una nube pasajera tapó el sol, pero el brote sigue vivo y la
+ * chagra intacta. Un fallo aquí es un aguacero que pasa, no una tragedia:
+ * nada se perdió y casi siempre basta con volver a intentar.
+ *
+ * Componente PURAMENTE presentacional: sin estado, sin efectos, sin fetch.
+ * NUNCA le pase un `error.message` crudo como title/hint — use frases curadas
+ * (o `mensajeErrorCampesino` de utils para traducir excepciones).
+ *
+ * @param {object} props
+ * @param {React.ReactNode} [props.title]  - frase principal, en lenguaje campesino.
+ * @param {React.ReactNode} [props.hint]   - qué puede hacer el usuario ahora.
+ * @param {() => void} [props.onRetry]     - si viene, muestra el botón de reintento.
+ * @param {React.ReactNode} [props.retryLabel]
+ * @param {string} [props.className]
+ * @param {React.ReactNode} [props.children] - contenido extra (ej. link "Volver") debajo.
+ */
+
+// Paleta compartida con EmptyStateCampo (sobre slate-900/950):
+const INK = '#94a3b8'; // trazo principal (slate-400)
+const INK_SOFT = '#64748b'; // trazo secundario (slate-500)
+const TIERRA = '#8b7d6b'; // suelo, gris cálido
+const BROTE = '#34d399'; // el elemento vivo (emerald-400)
+const BROTE_CLARO = '#6ee7b7';
+const SOL = '#fbbf24'; // amber-400
+
+/** Nube pasajera que tapa el sol: el problema es de paso, no de fondo. */
+const VignetteNube = () => (
+  <>
+    {/* Cerro andino al fondo */}
+    <path
+      d="M18,60 Q46,32 70,54 Q88,68 108,56 Q126,46 142,58"
+      fill="none"
+      stroke={INK_SOFT}
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      opacity="0.4"
+    />
+    {/* Sol asomándose detrás de la nube: sigue ahí */}
+    <g stroke={SOL} strokeWidth="1.4" strokeLinecap="round" fill="none" opacity="0.85">
+      <path d="M104,26 A8,8 0 0 1 118,29" />
+      <line x1="100" y1="18" x2="102" y2="20" />
+      <line x1="112" y1="14" x2="112" y2="17" />
+      <line x1="123" y1="19" x2="121" y2="21" />
+    </g>
+    {/* La nube, trazo de tinta */}
+    <path
+      d="M88,38 Q90,28 100,29 Q104,22 113,25 Q122,22 126,30 Q135,31 133,39 Q130,45 121,44 L96,44 Q88,45 88,38 Z"
+      fill="rgba(148,163,184,0.10)"
+      stroke={INK}
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+    {/* Gotas cortas: aguacero suave que ya casi escampa */}
+    <g stroke={INK_SOFT} strokeWidth="1.3" strokeLinecap="round" opacity="0.55">
+      <line x1="99" y1="51" x2="97" y2="56" />
+      <line x1="110" y1="49" x2="108" y2="54" />
+      <line x1="121" y1="51" x2="119" y2="56" />
+    </g>
+    {/* Suelo */}
+    <line x1="18" y1="88" x2="142" y2="88" stroke={TIERRA} strokeWidth="1.5" strokeLinecap="round" opacity="0.55" />
+    {/* El brote sigue vivo: nada se perdió */}
+    <g className="esc-vivo">
+      <line x1="52" y1="88" x2="52" y2="70" stroke={BROTE} strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M52,76 Q44,70 38,72 Q45,79 52,80 Z" fill={BROTE} />
+      <path d="M52,72 Q60,66 66,68 Q59,75 52,76 Z" fill={BROTE_CLARO} />
+    </g>
+  </>
+);
+
+/**
+ * @param {{
+ *   title?: React.ReactNode,
+ *   hint?: React.ReactNode,
+ *   onRetry?: (() => void) | null,
+ *   retryLabel?: React.ReactNode,
+ *   className?: string,
+ *   children?: React.ReactNode,
+ * }} props
+ */
+export default function ErrorStateCampo({
+  title = 'Esto no cargó.',
+  hint = 'Puede ser la señal. Espere un momento y vuelva a intentar.',
+  onRetry = null,
+  retryLabel = 'Intentar de nuevo',
+  className = '',
+  children = null,
+}) {
+  return (
+    <div className={`flex flex-col items-center text-center px-6 ${className}`} role="status">
+      <svg
+        className="esc-scene mb-3"
+        viewBox="0 0 160 100"
+        width="176"
+        height="110"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <VignetteNube />
+      </svg>
+      {title && <p className="text-sm font-bold text-slate-200 leading-snug max-w-xs mx-auto">{title}</p>}
+      {hint && <p className="text-xs text-slate-400 mt-1.5 leading-relaxed max-w-xs mx-auto">{hint}</p>}
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-bold text-sm"
+        >
+          <RotateCcw size={16} aria-hidden="true" /> {retryLabel}
+        </button>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -193,6 +193,7 @@ const messages = {
     ingresoBitacora: 'Registrar en Bitácora',
     errorReporteCsv: 'No se pudo generar el reporte CSV.',
     errorAbastecer: 'No se pudo abastecer el insumo. Verifique el almacenamiento.',
+    errorMarcarPaso: 'No se pudo marcar el paso como hecho. Intente de nuevo en un momento.',
     errorGps: 'No se pudo iniciar la captura GPS.',
     errorPermisoNegado: 'Permiso de ubicación denegado. En iPhone: Ajustes > Safari > Ubicación.',
     errorPermisoNegadoAndroid: 'Permiso de ubicación denegado. En iPhone: Ajustes > Safari > Ubicación. En Android: toca el candado de la barra de URL.',

--- a/src/utils/__tests__/mensajeErrorCampesino.test.js
+++ b/src/utils/__tests__/mensajeErrorCampesino.test.js
@@ -1,0 +1,48 @@
+/**
+ * mensajeErrorCampesino — el usuario nunca ve un error técnico crudo.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  mensajeErrorCampesino,
+  MENSAJE_ERROR_RED,
+  MENSAJE_ERROR_GENERICO,
+} from '../mensajeErrorCampesino';
+
+describe('mensajeErrorCampesino', () => {
+  test('errores de red se traducen a la frase de señal', () => {
+    expect(mensajeErrorCampesino(new TypeError('Failed to fetch'))).toBe(MENSAJE_ERROR_RED);
+    expect(mensajeErrorCampesino(new Error('NetworkError when attempting to fetch resource.'))).toBe(MENSAJE_ERROR_RED);
+    expect(mensajeErrorCampesino(new Error('Load failed'))).toBe(MENSAJE_ERROR_RED);
+  });
+
+  test('errores técnicos de JS/parseo caen al fallback, nunca crudos', () => {
+    expect(mensajeErrorCampesino(new Error("Cannot read properties of undefined (reading 'x')"))).toBe(
+      MENSAJE_ERROR_GENERICO,
+    );
+    expect(mensajeErrorCampesino(new Error('Unexpected token < in JSON at position 0'))).toBe(MENSAJE_ERROR_GENERICO);
+    expect(mensajeErrorCampesino(new Error('HTTP 502'))).toBe(MENSAJE_ERROR_GENERICO);
+    expect(mensajeErrorCampesino(new Error('Request timed out'))).toBe(MENSAJE_ERROR_GENERICO);
+  });
+
+  test('acepta un fallback curado propio del contexto', () => {
+    const propio = 'No se pudo marcar el paso como hecho. Intente de nuevo en un momento.';
+    expect(mensajeErrorCampesino(new Error('HTTP 500 internal server error'), propio)).toBe(propio);
+  });
+
+  test('mensajes ya curados en español se respetan tal cual', () => {
+    const curado = 'No se encontró el ciclo de yuca';
+    expect(mensajeErrorCampesino(new Error(curado))).toBe(curado);
+  });
+
+  test('error vacío, null o raro cae al fallback sin reventar', () => {
+    expect(mensajeErrorCampesino(null)).toBe(MENSAJE_ERROR_GENERICO);
+    expect(mensajeErrorCampesino(undefined)).toBe(MENSAJE_ERROR_GENERICO);
+    expect(mensajeErrorCampesino(new Error(''))).toBe(MENSAJE_ERROR_GENERICO);
+    expect(mensajeErrorCampesino({})).toBe(MENSAJE_ERROR_GENERICO);
+  });
+
+  test('strings crudos también se filtran', () => {
+    expect(mensajeErrorCampesino('Failed to fetch')).toBe(MENSAJE_ERROR_RED);
+    expect(mensajeErrorCampesino('TypeError: x is not a function')).toBe(MENSAJE_ERROR_GENERICO);
+  });
+});

--- a/src/utils/mensajeErrorCampesino.js
+++ b/src/utils/mensajeErrorCampesino.js
@@ -1,0 +1,60 @@
+/**
+ * mensajeErrorCampesino — traduce excepciones técnicas a frases que un
+ * campesino entiende, sin asustar y sin jerga.
+ *
+ * Regla: al usuario NUNCA se le muestra un `error.message` crudo tipo
+ * "Failed to fetch", "Unexpected token", "TypeError: x is undefined". Si el
+ * mensaje ya viene curado en español (lo lanzó nuestro propio código con
+ * texto pensado para el usuario), se respeta tal cual; si huele a técnico,
+ * se reemplaza por una frase cálida y accionable.
+ *
+ * Uso:
+ *   catch (e) { setError(mensajeErrorCampesino(e)); }
+ *   catch (e) { alert(mensajeErrorCampesino(e, 'No se pudo guardar el paso.')); }
+ */
+
+export const MENSAJE_ERROR_RED =
+  'Se fue la señal y no pudimos completar eso. Revise su conexión y vuelva a intentar.';
+
+export const MENSAJE_ERROR_GENERICO =
+  'No pude con eso. Intente de nuevo en un momento, o pregunte de otra forma.';
+
+/* Huellas de error de RED: el remedio es esperar/revisar señal y reintentar. */
+const RED_RE =
+  /failed to fetch|networkerror|network request failed|load failed|fetch failed|econnrefused|econnreset|etimedout|socket hang up|err_internet_disconnected|err_network/i;
+
+/* Huellas de mensaje TÉCNICO (no apto para mostrar): excepciones de JS,
+ * parseo, HTTP crudo, timeouts en inglés, stacktraces. */
+const TECNICO_RE = new RegExp(
+  [
+    /^(type|reference|syntax|range)error/i.source,
+    /unexpected (token|end of)/i.source,
+    /is not (a function|defined|iterable)/i.source,
+    /(of|read properties of)? (undefined|null)/i.source,
+    /\bjson\b/i.source,
+    /http\s*(error)?\s*\d{3}/i.source,
+    /\b5\d\d\b.*(server|gateway|unavailable)|internal server error|bad gateway|service unavailable/i.source,
+    /request (timed out|timeout)|timeout|timed out/i.source,
+    /\babort(ed|error)?\b/i.source,
+    /\bat\s+\S+\s+\(.*:\d+:\d+\)/.source, // línea de stacktrace
+    /indexeddb|quotaexceeded|transaction/i.source,
+  ].join('|'),
+  'i',
+);
+
+/**
+ * @param {unknown} error - la excepción atrapada (Error, string o lo que llegue).
+ * @param {string} [fallback] - frase curada propia del contexto (si no se pasa,
+ *   se usa el genérico). Solo se usa cuando el mensaje original es técnico.
+ * @returns {string} frase segura para mostrar al usuario.
+ */
+export function mensajeErrorCampesino(error, fallback = MENSAJE_ERROR_GENERICO) {
+  const e = /** @type {{ message?: unknown } | string | null | undefined} */ (error);
+  const raw = String((e && typeof e === 'object' ? e.message : e) || '').trim();
+  if (!raw) return fallback;
+  if (RED_RE.test(raw)) return MENSAJE_ERROR_RED;
+  if (TECNICO_RE.test(raw)) return fallback;
+  return raw; // mensaje ya curado por nuestro código: se respeta.
+}
+
+export default mensajeErrorCampesino;


### PR DESCRIPTION
## Qué

Pulido acotado de estados VACÍOS y de ERROR en las pantallas top, para que el campesino nunca quede ante un blanco, un "Failed to fetch" literal o un `alert("Error: TypeError…")`.

### Piezas compartidas (nuevas)

- **`src/components/common/ErrorStateCampo.jsx`** — completa la familia campo (EmptyStateCampo = vacío, SkeletonCampo = carga). Viñeta SVG en la misma gramática "cuaderno de campo": una nube pasajera tapó el sol pero el brote sigue vivo — el fallo es un aguacero que pasa, no una tragedia. Props: `title`, `hint`, `onRetry` (botón Reintentar), `children` (CTA secundario). Es para secciones **inline**; NO duplica `ScreenLoadingStatus` (full-screen `h-[100dvh]`) ni los ErrorBoundary (errores de render).
- **`src/utils/mensajeErrorCampesino.js`** — sanitizador de copy: errores de red → "Se fue la señal…", excepciones técnicas (TypeError, JSON, HTTP 5xx, timeout) → fallback curado del contexto; mensajes ya escritos en español para el usuario pasan intactos.

### Estados mejorados

| Pantalla | Antes | Ahora |
|---|---|---|
| **Mercado** (`MercadosScreen`) — vacío/búsqueda | Ícono gris a mano + texto pelado | `EmptyStateCampo` variant `busqueda` + CTA "Publicar mi producto" |
| **Mercado** — fallo de lectura IndexedDB | Silencioso: se veía idéntico a mercado vacío | `ErrorStateCampo` con Reintentar; si los ejemplos sí cargaron, aviso ámbar sin tapar la lista |
| **Mercado** — cargando | Texto pelado | `SkeletonCampo` |
| **Cursos/ciclo** (`CycleContentRenderer`) | `e.message` crudo: **"Failed to fetch" literal** en pantalla | Distingue "guía todavía no escrita" (sin retry, honesto) vs fallo de señal (Reintentar que vuelve a cargar) + Volver |
| **Directorio de especies** — catálogo no carga | `catch(_) → []`: fingía "No encontramos X" | `ErrorStateCampo` "No pudimos abrir el catálogo" con Reintentar |
| **Directorio** — ficha falla al abrir | Pantalla muda, como si nada | Aviso ámbar "No pudimos abrir esa ficha" + Reintentar |
| **Directorio** — `onSubmit` (Enter) | `await` sin catch → rechazo sin manejar | catch → mismo estado de error |
| **Agente** (`AgentScreen`) — banner de error | `setError(e.message)` → podía mostrar "Failed to fetch"/stacktrace | `mensajeErrorCampesino`: "No pude con esa pregunta. Intente de nuevo, o pregunte de otra forma." (respeta mensajes ya curados) |
| **Bodega** (`InventoryDashboard`) | `alert("Error: " + e.message)` | `alert(mensajeErrorCampesino(e, MSG.ui.errorMarcarPaso))` — string migrado a `messages.js` (ADR-050) |

### Fuera de alcance (deliberado, para no inflar el diff)

- Pantallas de voz con `${err.message}` interpolado (patrón repetido en 7+ archivos: RegistroVoz, ProcesosPorVoz, VoiceCapture, etc.) — merece PR aparte reutilizando `mensajeErrorCampesino`.
- `AprenderConAgente` (dato estático, impacto bajo).

## Verificación

- 12 tests nuevos (`error-state-campo.test.jsx`, `mensajeErrorCampesino.test.js`) + suites existentes de las pantallas tocadas (Directorio, Mercados, empty-states, InventoryPage, BackNavigation, AgentScreen queue/chips): todas verdes.
- `tsc:check`: **cero errores nuevos** vs origin/main (diff de listas de errores; los 4 que introduje inicialmente quedaron corregidos).
- `npm run build` verde.
- eslint `--max-warnings=0` limpio en todos los archivos tocados; `AgentScreen.jsx` no se pudo lintear localmente (eslint OOM con ese archivo aun con 6GB heap, limitación conocida del entorno) — el cambio ahí es de 3 líneas y no introduce patrones de la regla i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)