### PR TITLE
fix(agente): AFFECTS-gate corta la contaminación cruzada de cultivo en el sello "Catálogo verificado"

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -75,7 +75,17 @@ import { planMarketIntent } from '../../services/marketIntentRouter';
 // se arma desde el export precacheado del grafo AGE (grafo-relations.json), en
 // vez de quedarse sin grounding relacional. resolveSpecies mapea el query a un
 // id del catálogo SIN red (catalogDB + BM25 local).
-import { buildOfflineGroundingBlock } from '../../services/grafoRelations';
+import { buildOfflineGroundingBlock, getPestIndex, getPestSynonyms } from '../../services/grafoRelations';
+// AFFECTS-GATE (anti-contaminación cruzada de cultivo): el sello "Catálogo
+// verificado" NO debe pintarse cuando la evidencia surfacea un organismo que no
+// afecta al cultivo en foco (arista AFFECTS ausente). Ver affectsGate.js.
+import {
+  extractAffectsFromEvidence,
+  resolvePestAffects,
+  scanTextForPestAffects,
+  detectCrossCropContamination,
+  gateSourceMetadataByAffects,
+} from '../../services/affectsGate';
 import { resolveSpecies } from '../../services/speciesResolver';
 // Deep Research (A6/A7): cliente HTTP del endpoint async de investigación
 // profunda del sidecar. Feature flag VITE_DEEP_RESEARCH_ENABLED (default false).
@@ -2269,6 +2279,52 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         ...groundingSemaphoreMeta,
         auto_corrected: guarded.modified === true,
       };
+
+      // AFFECTS-GATE (auditoría anti-contaminación cruzada de cultivo, 2026-07):
+      // el sello "Catálogo verificado" NO debe pintarse cuando la evidencia
+      // surfacea un organismo (plaga) que NO afecta al cultivo EN FOCO. Caso
+      // confirmado: BROCA (plaga de CAFÉ, Hypothenemus hampei) mostrada como
+      // "Dato verificado" en una conversación de CACAO — verificado ≠ relevante.
+      // La arista AFFECTS ya viaja en la evidencia (get_pest_controllers →
+      // target_species) y en el índice offline del grafo (_pest_index); esto es
+      // SOLO la comprobación (wiring), no grounding nuevo. Suppress-and-replace
+      // del SELLO: grounded→false + marca explícita cross_crop (el ChatBubble
+      // pinta "Dato de otro cultivo · verifica"). Solo corre sobre turnos que
+      // IBAN a salir verificados. Graceful: cualquier fallo deja el sello
+      // intacto (jamás degrada por error).
+      if (sourceMetadata && sourceMetadata.grounded === true) {
+        try {
+          const cropInFocusIds = Array.from(new Set(
+            (resolvedEntities || [])
+              .filter((e) => e && ['cultivo', 'especie', 'species', 'planta'].includes(e.kind))
+              .map((e) => e.canonical_id)
+              .filter((id) => typeof id === 'string' && id.trim().length > 0)
+          ));
+          if (cropInFocusIds.length > 0) {
+            const [pestIndex, pestSynonyms] = await Promise.all([getPestIndex(), getPestSynonyms()]);
+            const maps = { pestIndex, pestSynonyms };
+            const pestAffectsList = [
+              ...extractAffectsFromEvidence(toolEvidence),
+              ...(resolvedEntities || [])
+                .filter((e) => e && (e.kind === 'pest' || e.kind === 'plaga'))
+                .map((e) => resolvePestAffects(e.canonical_id || e.mentioned, maps))
+                .filter(Boolean),
+              ...scanTextForPestAffects(response, maps),
+            ];
+            const gateResult = detectCrossCropContamination({ cropInFocusIds, pestAffectsList });
+            if (gateResult.crossCrop) {
+              sourceMetadata = gateSourceMetadataByAffects(sourceMetadata, gateResult, { cropInFocusIds });
+              console.debug('[affects-gate] cross-crop → sello degradado', {
+                cropInFocusIds,
+                organismos: gateResult.offending.map((o) => o.pest),
+              });
+            }
+          }
+        } catch (gErr) {
+          // El gate jamás bloquea el chat: si algo falla, el sello queda como estaba.
+          console.debug('[affects-gate] no aplicado (sigo con el sello original):', gErr?.message);
+        }
+      }
 
       // Capa 2 anti-alucinación — cross-check de contexto (operador 2026-05-30).
       // Tras generar la respuesta, le pedimos al sidecar que correlacione cada

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -89,6 +89,31 @@ function SourceBadge({ metadata }) {
     );
   }
 
+  // AFFECTS-GATE (anti-contaminación cruzada de cultivo): la evidencia surfaceó
+  // un organismo (plaga) que NO afecta al cultivo en foco — la arista AFFECTS no
+  // existe (ej. la BROCA, plaga de café, en una conversación de cacao). El sello
+  // "Catálogo verificado" YA se degradó aguas arriba (grounded=false); acá lo
+  // decimos explícito y honesto: el dato es de OTRO cultivo. Ámbar, no verde.
+  // Wording sobrio, cero hype. Ver services/affectsGate.js.
+  const crossCrop = md.cross_crop === true;
+  if (crossCrop) {
+    const organismos = Array.isArray(md.cross_crop_organisms)
+      ? md.cross_crop_organisms.filter((s) => typeof s === 'string' && s.trim().length > 0)
+      : [];
+    const detalle = organismos.length > 0 ? ` (${organismos.join(', ')})` : '';
+    return (
+      <span
+        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-amber-600/20 text-amber-300 border border-amber-700"
+        data-testid="cross-crop-badge"
+        data-source="cross-crop"
+        title={`Este dato${detalle} existe en el catálogo pero corresponde a OTRO cultivo, no al que tienes en foco. No es un "dato verificado" para tu cultivo: verifícalo antes de aplicarlo.`}
+      >
+        <AlertTriangle size={12} aria-hidden="true" />
+        <span>Dato de otro cultivo · verifica</span>
+      </span>
+    );
+  }
+
   if (toolUsed && grounded) {
     return (
       <span

--- a/src/components/AgentScreen/__tests__/ChatBubble.crossCrop.test.jsx
+++ b/src/components/AgentScreen/__tests__/ChatBubble.crossCrop.test.jsx
@@ -1,0 +1,67 @@
+/**
+ * ChatBubble.crossCrop.test.jsx — el SELLO ante contaminación cruzada de cultivo.
+ *
+ * Verifica el cableado visual del AFFECTS-GATE: un turno cuya metadata quedó
+ * marcada como cross_crop (la broca, plaga de café, surfaced en una conversación
+ * de cacao) NO debe pintar el verde "Catálogo verificado", sino el ámbar
+ * explícito "Dato de otro cultivo · verifica". Un turno grounded normal SÍ pinta
+ * el verde (control, sin regresión).
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+
+// Dependencias pesadas del ChatBubble que no aportan al test del sello.
+vi.mock('../../ChagraAgentAvatar', () => ({ default: () => <div data-testid="avatar-mock" /> }));
+vi.mock('../../FeedbackButtons', () => ({ default: () => <div data-testid="feedback-mock" /> }));
+vi.mock('../../AIBetaBadge', () => ({ default: () => <div data-testid="aibeta-mock" /> }));
+vi.mock('../../../services/ttsService', () => ({
+  speak: vi.fn(), speakKokoro: vi.fn(), stop: vi.fn(),
+  isSpeaking: () => false, isKokoroAvailable: async () => false,
+}));
+vi.mock('../../../services/agentSoundService', () => ({
+  agentSounds: { chime: vi.fn(), cancel: vi.fn() },
+}));
+
+import ChatBubble from '../ChatBubble';
+
+describe('ChatBubble — sello ante cross-crop (AFFECTS-GATE)', () => {
+  it('turno cross-crop (broca en cacao): NO pinta "Catálogo verificado", pinta "de otro cultivo"', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Para tu cacao, la broca se controla con Beauveria bassiana.',
+      timestamp: Date.now(),
+      metadata: {
+        tool_used: 'get_pest_controllers',
+        grounded: false, // degradado por el gate
+        cross_crop: true,
+        cross_crop_organisms: ['Broca del café'],
+        cross_crop_focus: ['theobroma_cacao'],
+      },
+    };
+    render(<ChatBubble message={message} />);
+
+    // El sello verde NO aparece.
+    expect(screen.queryByText(/Catálogo verificado/i)).toBeNull();
+    // Aparece la marca explícita "de otro cultivo".
+    const badge = screen.getByTestId('cross-crop-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent(/Dato de otro cultivo/i);
+    // Tampoco el tick esmeralda de grounding.
+    expect(screen.queryByTestId('grounded-tick')).toBeNull();
+  });
+
+  it('control: turno grounded normal SÍ pinta "Catálogo verificado" (sin regresión)', () => {
+    const message = {
+      role: 'assistant',
+      content: 'El café se controla la broca con Beauveria bassiana.',
+      timestamp: Date.now(),
+      metadata: { tool_used: 'get_pest_controllers', grounded: true },
+    };
+    render(<ChatBubble message={message} />);
+
+    expect(screen.getByTestId('source-badge')).toHaveTextContent(/Catálogo verificado/i);
+    expect(screen.queryByTestId('cross-crop-badge')).toBeNull();
+  });
+});

--- a/src/services/__tests__/affectsGate.test.js
+++ b/src/services/__tests__/affectsGate.test.js
@@ -1,0 +1,205 @@
+/**
+ * affectsGate.test.js — AFFECTS-GATE contra la contaminación cruzada de cultivo.
+ *
+ * Reproduce el BUG de la auditoría: en una conversación de CACAO el agente
+ * mostró la BROCA (Hypothenemus hampei, plaga de CAFÉ) con el sello "Dato
+ * verificado". Verificado ≠ relevante: la broca solo afecta a Coffea (arista
+ * AFFECTS del grafo). El gate debe detectar el cross-crop y evitar que ese turno
+ * salga como "Catálogo verificado".
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  extractAffectsFromEvidence,
+  resolvePestAffects,
+  scanTextForPestAffects,
+  detectCrossCropContamination,
+  gateSourceMetadataByAffects,
+} from '../affectsGate';
+import { computeSourceMetadata } from '../conversationMemory';
+
+// Fixture recortado del export offline real del grafo (public/grafo-relations.json).
+// `_pest_index` (plaga canónica → cultivos afectados) es la arista AFFECTS.
+const pestIndex = {
+  'Broca del café': ['coffea_arabica'],
+  'hypothenemus_hampei_broca': ['coffea_arabica'],
+  'moniliasis del cacao': ['theobroma_cacao'],
+  'escoba de bruja cacao': ['theobroma_cacao'],
+};
+const pestSynonyms = {
+  'broca': 'Broca del café',
+  'broca del café': 'Broca del café',
+  'broca del cafe': 'Broca del café',
+  'hypothenemus_hampei_broca': 'Broca del café',
+  'monilia': 'moniliasis del cacao',
+  'moniliasis del cacao': 'moniliasis del cacao',
+};
+const maps = { pestIndex, pestSynonyms };
+
+const CACAO = 'theobroma_cacao';
+const CAFE = 'coffea_arabica';
+
+// Evidencia real de get_pest_controllers para la BROCA: la arista AFFECTS viaja
+// en matches[].target_species (los cultivos que la plaga afecta).
+const brocaControllersEvidence = {
+  tool: 'get_pest_controllers',
+  args: { pest: 'broca' },
+  result: {
+    matches_count: 1,
+    matches: [
+      {
+        pest_id: 'hypothenemus_hampei_broca',
+        plaga: 'Broca del café',
+        target_species: [{ id: 'coffea_arabica', nombre: 'Café' }],
+        biopreparados: [{ id: 'beauveria', nombre: 'Hongo entomopatógeno (beauveria)' }],
+      },
+    ],
+  },
+};
+
+describe('extractAffectsFromEvidence', () => {
+  test('saca la arista AFFECTS de get_pest_controllers (broca → café)', () => {
+    expect(extractAffectsFromEvidence(brocaControllersEvidence)).toEqual([
+      { pest: 'hypothenemus_hampei_broca', affects: ['coffea_arabica'] },
+    ]);
+  });
+
+  test('ignora tools que no son get_pest_controllers', () => {
+    expect(extractAffectsFromEvidence({ tool: 'get_species', result: { found: true } })).toEqual([]);
+  });
+
+  test('soporta tool_chain (array de evidencias)', () => {
+    const chain = [{ tool: 'get_species', result: { found: true } }, brocaControllersEvidence];
+    expect(extractAffectsFromEvidence(chain)).toEqual([
+      { pest: 'hypothenemus_hampei_broca', affects: ['coffea_arabica'] },
+    ]);
+  });
+
+  test('null / basura → []', () => {
+    expect(extractAffectsFromEvidence(null)).toEqual([]);
+    expect(extractAffectsFromEvidence({})).toEqual([]);
+  });
+});
+
+describe('resolvePestAffects', () => {
+  test('resuelve el término coloquial "broca" a su arista AFFECTS (café)', () => {
+    expect(resolvePestAffects('broca', maps)).toEqual({ pest: 'Broca del café', affects: ['coffea_arabica'] });
+  });
+  test('resuelve por etiqueta canónica directa', () => {
+    expect(resolvePestAffects('moniliasis del cacao', maps)).toEqual({
+      pest: 'moniliasis del cacao',
+      affects: ['theobroma_cacao'],
+    });
+  });
+  test('término desconocido → null', () => {
+    expect(resolvePestAffects('dragón morado', maps)).toBeNull();
+  });
+});
+
+describe('scanTextForPestAffects', () => {
+  test('detecta la broca citada en el cuerpo de una respuesta de cacao', () => {
+    const respuesta =
+      'Para tu cacao, cuidado con la broca (Hypothenemus hampei), que perfora el grano.';
+    const found = scanTextForPestAffects(respuesta, maps);
+    expect(found).toContainEqual({ pest: 'Broca del café', affects: ['coffea_arabica'] });
+  });
+
+  test('no caza ruido en un texto sin plagas del grafo', () => {
+    expect(scanTextForPestAffects('El cacao necesita sombra y suelo bien drenado.', maps)).toEqual([]);
+  });
+});
+
+describe('detectCrossCropContamination', () => {
+  test('BUG: broca (café) en foco de CACAO → cross-crop', () => {
+    const res = detectCrossCropContamination({
+      cropInFocusIds: [CACAO],
+      pestAffectsList: [{ pest: 'Broca del café', affects: [CAFE] }],
+    });
+    expect(res.crossCrop).toBe(true);
+    expect(res.offending.map((o) => o.pest)).toContain('Broca del café');
+    expect(res.relevant).toEqual([]);
+  });
+
+  test('broca en foco de CAFÉ → NO es cross-crop (la broca sí afecta al café)', () => {
+    const res = detectCrossCropContamination({
+      cropInFocusIds: [CAFE],
+      pestAffectsList: [{ pest: 'Broca del café', affects: [CAFE] }],
+    });
+    expect(res.crossCrop).toBe(false);
+    expect(res.relevant.map((o) => o.pest)).toContain('Broca del café');
+  });
+
+  test('mezcla: monilia (cacao) + broca (café) en foco de CACAO → NO cross-crop (hay una relevante)', () => {
+    const res = detectCrossCropContamination({
+      cropInFocusIds: [CACAO],
+      pestAffectsList: [
+        { pest: 'moniliasis del cacao', affects: [CACAO] },
+        { pest: 'Broca del café', affects: [CAFE] },
+      ],
+    });
+    expect(res.crossCrop).toBe(false);
+  });
+
+  test('sin cultivo en foco → nunca decide (fail-safe)', () => {
+    const res = detectCrossCropContamination({
+      cropInFocusIds: [],
+      pestAffectsList: [{ pest: 'Broca del café', affects: [CAFE] }],
+    });
+    expect(res.crossCrop).toBe(false);
+  });
+
+  test('arista AFFECTS desconocida → el gate no opina (fail-safe, sello intacto)', () => {
+    const res = detectCrossCropContamination({
+      cropInFocusIds: [CACAO],
+      pestAffectsList: [{ pest: 'plaga misteriosa', affects: [] }],
+    });
+    expect(res.crossCrop).toBe(false);
+    expect(res.offending).toEqual([]);
+  });
+});
+
+describe('gateSourceMetadataByAffects', () => {
+  test('degrada el sello (grounded→false) y marca cross_crop cuando es cross-crop', () => {
+    const base = { tool_used: 'get_pest_controllers', grounded: true };
+    const gated = gateSourceMetadataByAffects(
+      base,
+      { crossCrop: true, offending: [{ pest: 'Broca del café' }] },
+      { cropInFocusIds: [CACAO] },
+    );
+    expect(gated.grounded).toBe(false);
+    expect(gated.cross_crop).toBe(true);
+    expect(gated.cross_crop_organisms).toEqual(['Broca del café']);
+    expect(gated.cross_crop_focus).toEqual([CACAO]);
+    // No muta la entrada.
+    expect(base.grounded).toBe(true);
+    expect(base.cross_crop).toBeUndefined();
+  });
+
+  test('turno legítimo (no cross-crop) → metadata intacta', () => {
+    const base = { tool_used: 'get_pest_controllers', grounded: true };
+    const gated = gateSourceMetadataByAffects(base, { crossCrop: false, offending: [] });
+    expect(gated).toEqual(base);
+  });
+});
+
+describe('REPRODUCCIÓN end-to-end: broca-en-cacao NO sale como "Catálogo verificado"', () => {
+  test('sin gate el turno saldría verificado; con el gate se degrada a "de otro cultivo"', () => {
+    // 1) Sin el gate, la evidencia de la broca haría el turno "grounded" (verde).
+    const md = computeSourceMetadata(brocaControllersEvidence);
+    expect(md).toEqual({ tool_used: 'get_pest_controllers', grounded: true });
+
+    // 2) El gate arma la lista AFFECTS desde la MISMA evidencia + el cuerpo del
+    //    turno, con el cultivo en foco = CACAO.
+    const respuesta = 'Para tu cacao, la broca se controla con Beauveria bassiana.';
+    const pestAffectsList = [
+      ...extractAffectsFromEvidence(brocaControllersEvidence),
+      ...scanTextForPestAffects(respuesta, maps),
+    ];
+    const gateResult = detectCrossCropContamination({ cropInFocusIds: [CACAO], pestAffectsList });
+    expect(gateResult.crossCrop).toBe(true);
+
+    // 3) El sello se degrada: NO grounded → el ChatBubble no pinta el verde.
+    const gated = gateSourceMetadataByAffects(md, gateResult, { cropInFocusIds: [CACAO] });
+    expect(gated.grounded).toBe(false);
+    expect(gated.cross_crop).toBe(true);
+  });
+});

--- a/src/services/affectsGate.js
+++ b/src/services/affectsGate.js
@@ -1,0 +1,194 @@
+/**
+ * affectsGate.js — AFFECTS-GATE: corta la contaminación cruzada de cultivo en el
+ * sello "Catálogo verificado" del agente.
+ *
+ * BUG CONFIRMADO (auditoría real): en una conversación de CACAO el agente mostró
+ * la BROCA (Hypothenemus hampei, plaga de CAFÉ) con el sello "Dato verificado".
+ * El dato existe en el catálogo, sí — pero VERIFICADO ≠ RELEVANTE: la broca solo
+ * afecta a Coffea. El grafo lo dice explícito con la arista AFFECTS (plaga→cultivo,
+ * ~1.301 aristas). Este gate comprueba esa arista entre el organismo que la
+ * evidencia surfacea y el cultivo EN FOCO. Si NO existe la relación (cross-crop),
+ * el turno NO se marca como "Catálogo verificado": el sello se degrada (grounded
+ * → false) y se marca explícito como "de otro cultivo".
+ *
+ * NO es grounding nuevo. La relación AFFECTS YA viaja en los datos:
+ *   - online:  la evidencia de `get_pest_controllers` trae
+ *              `result.matches[].{pest_id|plaga, target_species[].id}` — donde
+ *              `target_species` son justamente los cultivos que la plaga afecta.
+ *   - offline: el índice `_pest_index` del grafo (grafoRelations.getPestIndex)
+ *              mapea plaga canónica → ids de especie afectadas; `_pest_synonyms`
+ *              resuelve el término mencionado a esa etiqueta canónica.
+ * Esto es SOLO el wiring de la comprobación.
+ *
+ * Diseño conservador (fail-safe, cero regresión):
+ *   - Solo decide si hay un cultivo EN FOCO (id canónico resuelto).
+ *   - Solo mira organismos con arista AFFECTS CONOCIDA (si no la conocemos, no
+ *     opina — el sello se queda como estaba).
+ *   - Cross-crop SOLO si NINGÚN organismo surfaced afecta el cultivo en foco y
+ *     al menos uno apunta a otro cultivo. Basta con que uno afecte el foco para
+ *     considerar el sello legítimo para el turno.
+ */
+
+/** Normaliza para matching tolerante (minúsculas, sin tildes, espacios colapsados). */
+function _norm(s) {
+  return String(s || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function _escapeRe(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Extrae la arista AFFECTS (plaga → cultivos afectados) de la evidencia ONLINE
+ * de `get_pest_controllers`. Soporta tool_chain (array de evidencias). Ignora
+ * cualquier otra tool (no toca su evidencia). Devuelve `[]` si no hay señal.
+ *
+ * @param {object|Array<object>|null|undefined} toolEvidence
+ * @returns {Array<{ pest: string, affects: string[] }>}
+ */
+export function extractAffectsFromEvidence(toolEvidence) {
+  const out = [];
+  const visit = (ev) => {
+    if (!ev) return;
+    if (Array.isArray(ev)) { ev.forEach(visit); return; }
+    if (typeof ev !== 'object' || ev.tool !== 'get_pest_controllers') return;
+    const result = ev.result;
+    const matches = result && Array.isArray(result.matches) ? result.matches : [];
+    for (const m of matches) {
+      if (!m || typeof m !== 'object') continue;
+      const pest = m.pest_id || m.plaga || m.pest || null;
+      const targets = Array.isArray(m.target_species) ? m.target_species : [];
+      const affects = targets
+        .map((t) => (t && typeof t === 'object' ? (t.id || t.species_id) : t))
+        .filter((x) => typeof x === 'string' && x.trim().length > 0)
+        .map(String);
+      if (typeof pest === 'string' && pest.trim() && affects.length > 0) {
+        out.push({ pest: String(pest), affects });
+      }
+    }
+  };
+  visit(toolEvidence);
+  return out;
+}
+
+/**
+ * Resuelve un término de plaga (mencionado por el usuario, citado en la
+ * respuesta, o el canonical_id/mentioned de una entidad resuelta) a su etiqueta
+ * canónica y su arista AFFECTS, usando los mapas del grafo offline inyectados.
+ *
+ * @param {string} term
+ * @param {{ pestIndex?: Record<string,string[]>, pestSynonyms?: Record<string,string> }} maps
+ * @returns {{ pest: string, affects: string[] } | null}
+ */
+export function resolvePestAffects(term, { pestIndex = {}, pestSynonyms = {} } = {}) {
+  const q = _norm(term);
+  if (!q) return null;
+  // 1) término = sinónimo → canónica
+  for (const [syn, canonical] of Object.entries(pestSynonyms)) {
+    if (_norm(syn) === q) {
+      const affects = Array.isArray(pestIndex[canonical]) ? pestIndex[canonical].slice() : [];
+      return { pest: canonical, affects };
+    }
+  }
+  // 2) término = etiqueta canónica directa
+  for (const canonical of Object.keys(pestIndex)) {
+    if (_norm(canonical) === q) {
+      return { pest: canonical, affects: (pestIndex[canonical] || []).slice() };
+    }
+  }
+  return null;
+}
+
+/**
+ * Escanea un texto (la respuesta del agente) buscando MENCIONES de plagas del
+ * grafo (por sinónimo o etiqueta canónica, palabra completa) y devuelve su
+ * arista AFFECTS. Conservador: solo términos de ≥4 caracteres, para no cazar
+ * ruido. Dedup por etiqueta canónica.
+ *
+ * @param {string} text
+ * @param {{ pestIndex?: Record<string,string[]>, pestSynonyms?: Record<string,string> }} maps
+ * @returns {Array<{ pest: string, affects: string[] }>}
+ */
+export function scanTextForPestAffects(text, { pestIndex = {}, pestSynonyms = {} } = {}) {
+  const hay = _norm(text);
+  if (!hay) return [];
+  const found = new Map(); // canonical -> affects[]
+  const consider = (label, canonical) => {
+    const n = _norm(label);
+    if (n.length < 4) return;
+    if (found.has(canonical)) return;
+    const re = new RegExp(`(^|[^a-z0-9])${_escapeRe(n)}([^a-z0-9]|$)`);
+    if (re.test(hay)) {
+      found.set(canonical, Array.isArray(pestIndex[canonical]) ? pestIndex[canonical].slice() : []);
+    }
+  };
+  for (const [syn, canonical] of Object.entries(pestSynonyms)) consider(syn, canonical);
+  for (const canonical of Object.keys(pestIndex)) consider(canonical, canonical);
+  return Array.from(found.entries()).map(([pest, affects]) => ({ pest, affects }));
+}
+
+/**
+ * Decisión pura del gate: ¿la evidencia del turno es contaminación cruzada de
+ * cultivo respecto al cultivo en foco?
+ *
+ * @param {{ cropInFocusIds?: string[], pestAffectsList?: Array<{pest:string, affects:string[]}> }} p
+ * @returns {{ crossCrop: boolean, offending: Array<{pest:string, affects:string[]}>, relevant: Array<{pest:string, affects:string[]}> }}
+ */
+export function detectCrossCropContamination({ cropInFocusIds = [], pestAffectsList = [] } = {}) {
+  const focus = new Set((cropInFocusIds || []).map(_norm).filter(Boolean));
+  if (focus.size === 0) return { crossCrop: false, offending: [], relevant: [] };
+
+  const offending = [];
+  const relevant = [];
+  const seen = new Set();
+  for (const pa of pestAffectsList || []) {
+    if (!pa || typeof pa.pest !== 'string' || !pa.pest.trim()) continue;
+    const key = _norm(pa.pest);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const affects = (Array.isArray(pa.affects) ? pa.affects : []).map(_norm).filter(Boolean);
+    if (affects.length === 0) continue; // arista desconocida → el gate no opina (fail-safe)
+    if (affects.some((a) => focus.has(a))) relevant.push(pa);
+    else offending.push(pa);
+  }
+
+  const crossCrop = relevant.length === 0 && offending.length > 0;
+  return { crossCrop, offending, relevant };
+}
+
+/**
+ * Suppress-and-replace del SELLO (no del cuerpo del LLM): si el turno resultó
+ * cross-crop, degradamos la metadata de fuente para que el ChatBubble NO pinte
+ * el verde "Catálogo verificado" y en su lugar marque explícito "de otro
+ * cultivo". Puro e idempotente (no muta la entrada). Si no es cross-crop,
+ * devuelve una copia intacta.
+ *
+ * @param {object} metadata — metadata de fuente ya computada (computeSourceMetadata).
+ * @param {{crossCrop:boolean, offending:Array<{pest:string}>}} gateResult
+ * @param {{ cropInFocusIds?: string[] }} [ctx]
+ * @returns {object} nueva metadata.
+ */
+export function gateSourceMetadataByAffects(metadata, gateResult, { cropInFocusIds = [] } = {}) {
+  const md = { ...(metadata && typeof metadata === 'object' ? metadata : {}) };
+  if (!gateResult || gateResult.crossCrop !== true) return md;
+  md.grounded = false;
+  md.cross_crop = true;
+  md.cross_crop_organisms = (gateResult.offending || [])
+    .map((o) => o && o.pest)
+    .filter((p) => typeof p === 'string' && p.trim().length > 0);
+  md.cross_crop_focus = (cropInFocusIds || []).slice();
+  return md;
+}
+
+export default {
+  extractAffectsFromEvidence,
+  resolvePestAffects,
+  scanTextForPestAffects,
+  detectCrossCropContamination,
+  gateSourceMetadataByAffects,
+};

--- a/src/services/grafoRelations.js
+++ b/src/services/grafoRelations.js
@@ -267,11 +267,24 @@ export async function resolvePestSynonym(term) {
 
 /**
  * Índice plaga canónica → ids de especies que afecta (según el grafo offline).
+ * Es la arista AFFECTS (plaga→cultivo) materializada offline.
  * @returns {Promise<Record<string, string[]>>}
  */
 export async function getPestIndex() {
   await loadGrafoRelations();
   return (rootCache && rootCache._pest_index) || {};
+}
+
+/**
+ * Mapa de sinónimos de plaga (término coloquial/regional/científico → etiqueta
+ * canónica del grafo). Espeja `_pest_synonyms` del export offline. Permite
+ * resolver una plaga MENCIONADA (por el usuario o citada en la respuesta) a su
+ * etiqueta canónica y, de ahí, a su arista AFFECTS vía `getPestIndex`.
+ * @returns {Promise<Record<string, string>>}
+ */
+export async function getPestSynonyms() {
+  await loadGrafoRelations();
+  return (rootCache && rootCache._pest_synonyms) || {};
 }
 
 /**


### PR DESCRIPTION
## Bug (auditoría real)

En una conversación de **CACAO** el agente mostró la **BROCA** (*Hypothenemus hampei*, plaga de **CAFÉ**) con el sello **"Dato verificado"**. El dato existe en el catálogo, pero **verificado ≠ relevante**: la broca solo afecta a *Coffea*, y el grafo lo dice explícito con la arista **AFFECTS** (plaga→cultivo, ~1.301 aristas).

**Causa raíz:** el sello verde `Catálogo verificado · <tool>` (`SourceBadge` en `ChatBubble.jsx`) se pinta únicamente con `metadata.grounded === true`. Ese flag lo marca `computeSourceMetadata()` en cuanto un tool (`get_pest_controllers` / `get_species`) devuelve un match de catálogo — **sin comprobar que el organismo surfaced sea relevante al cultivo EN FOCO**.

## Fix — AFFECTS-gate

Wiring de una comprobación que **ya tiene los datos** (NO es grounding nuevo):

- La arista AFFECTS **ya viaja**: `get_pest_controllers` → `matches[].target_species` (cultivos que la plaga afecta) y el índice offline del grafo `_pest_index` (`grafoRelations`). `broca → ['coffea_arabica']`.
- **`services/affectsGate.js`** (nuevo, puro y testeable): extrae la arista de la evidencia, resuelve plagas mencionadas contra el índice del grafo, y decide cross-crop de forma **conservadora / fail-safe** — solo si hay cultivo en foco, ningún organismo surfaced afecta ese foco, y al menos uno apunta a otro cultivo. Si no conoce la arista, **no opina** (el sello queda como estaba).
- **`AgentScreen.jsx`**: tras armar `sourceMetadata` y **solo** sobre turnos que iban a salir verificados, junta el cultivo en foco (entidades `cultivo/especie` resueltas) + la lista plaga→afecta (evidencia + entidades plaga + escaneo del cuerpo) y corre el gate. Al detectar cross-crop degrada el sello: `grounded → false` + `cross_crop`.
- **`ChatBubble.jsx`**: pinta el ámbar explícito **"Dato de otro cultivo · verifica"** en vez del verde. Suppress-and-replace del **SELLO**, no un aviso antepuesto (mismo estilo que `confusion_especie` / `pest_vs_disease` / `cross_thermal`).

Graceful en todo: cualquier fallo del gate deja el sello intacto (jamás degrada por error).

## Cómo probarlo

- `npx vitest run src/services/__tests__/affectsGate.test.js` — reproduce broca-en-cacao: la evidencia haría el turno `grounded:true`, y con el gate + cultivo en foco = cacao sale `grounded:false, cross_crop:true`. Cubre también broca-en-café (NO cross-crop), mezcla monilia+broca en cacao (NO cross-crop), sin foco / arista desconocida (fail-safe).
- `npx vitest run src/components/AgentScreen/__tests__/ChatBubble.crossCrop.test.jsx` — el turno cross-crop **no** pinta "Catálogo verificado" y sí "Dato de otro cultivo"; control grounded normal sigue verde (sin regresión).

## Verificación

- `vitest` de los archivos nuevos: **19/19** verdes; suites relacionadas (`conversationMemory.sourceMetadata`, `grafoRelations`): **82/82** verdes.
- `tsc:check`: **verde** (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)