### PR TITLE
fix(agente): fuga ubicación default 0 msnm + deflección de pregunta genérica

### DIFF
--- a/src/services/__tests__/agentNluFallback.test.js
+++ b/src/services/__tests__/agentNluFallback.test.js
@@ -95,6 +95,70 @@ describe('planNluFallback — (b) keywords cuando no hay entidad resuelta', () =
   });
 });
 
+// ── BUG 2 (audit conversación): DEFLECCIÓN de pregunta GENÉRICA mal ruteada ──
+// Una pregunta genérica/conversacional SIN especie/plaga clara NO debe forzar
+// get_species con la frase cruda (el sidecar la resuelve como found:false y el
+// agente deflecta "el catálogo no tiene esa especie"). Debe devolver null →
+// respuesta conversacional. Ver feedback-agente-pregunta-general-misruteo-tool-especie.
+describe('planNluFallback — (c) pregunta genérica sin sujeto → null (deflección conversacional)', () => {
+  it('saludos / smalltalk → null', () => {
+    for (const q of ['hola', 'buenos días', 'buenas tardes', 'qué más', 'gracias', 'hey']) {
+      expect(planNluFallback(q, null)).toBeNull();
+    }
+  });
+
+  it('meta-ayuda / capacidades de la app → null', () => {
+    for (const q of [
+      'qué puedes hacer',
+      'para qué sirves',
+      'cómo funcionas',
+      'quién eres',
+      'qué es chagra',
+      'ayúdame',
+    ]) {
+      expect(planNluFallback(q, null)).toBeNull();
+    }
+  });
+
+  it('consejo general de suelo/finca SIN cultivo nombrado → null', () => {
+    for (const q of [
+      'cómo mejoro mi suelo',
+      'cómo puedo mejorar mi tierra',
+      'qué le echo a la tierra',
+      'cómo hago un buen compost',
+      'cómo empiezo mi huerta',
+      'qué me recomiendas hoy',
+    ]) {
+      expect(planNluFallback(q, null)).toBeNull();
+    }
+  });
+
+  it('NO roba queries con cultivo nombrado: siguen ruteando a get_species', () => {
+    // La rama de consejo general exige un sustantivo genérico de finca como
+    // objeto (suelo/tierra/...), NUNCA un cultivo → estas mantienen get_species.
+    for (const q of [
+      'cómo cuido el aguacate',
+      'cómo mejoro el rendimiento del café',
+      'a qué altitud se da la quinua',
+      'cómo abono el tomate',
+    ]) {
+      const plan = planNluFallback(q, null);
+      expect(plan).not.toBeNull();
+      expect(plan.tool).toBe('get_species');
+    }
+  });
+
+  it('una entidad de especie/plaga resuelta GANA a la deflección genérica', () => {
+    // Aunque el texto luzca general, si el grafo resolvió una entidad canónica
+    // la señal fuerte manda (no se deflecta).
+    const entities = [{ mentioned: 'café', kind: 'species', canonical_id: 'coffea_arabica' }];
+    const plan = planNluFallback('cómo mejoro mi suelo para el café', entities);
+    expect(plan).not.toBeNull();
+    expect(plan.tool).toBe('get_species');
+    expect(plan.args).toEqual({ id_or_name: 'coffea_arabica' });
+  });
+});
+
 describe('planNluFallback — entidades de baja calidad no rompen', () => {
   it('entidad sin canonical_id → cae al heurístico por keywords', () => {
     const entities = [{ mentioned: 'algo', kind: 'species' }]; // sin canonical_id

--- a/src/services/__tests__/agentService.test.js
+++ b/src/services/__tests__/agentService.test.js
@@ -926,6 +926,54 @@ describe('agentService — Task #202 Profile Context', () => {
       expect(ctx).toContain('200');
     });
 
+    // ── BUG 1 (audit conversación cacao): FUGA DE UBICACIÓN DEFAULT (0 msnm) ──
+    // Con el perfil SIN altitud capturada, el caller pasa `fincaAltitud = null`.
+    // `Number(null) === 0`, así que un 0 FANTASMA se colaba como nivel del mar:
+    // cacao (200–900 m) caía "MARGINAL/al límite" y el prompt afirmaba "tu finca a
+    // 0 msnm", derivando consejos de heladas/microclima ABRIGADO — al revés para
+    // tierra baja tropical. Sin altitud confirmada NO debe emitir veredicto.
+    it('BUG-1: fincaAltitud null NO produce veredicto para cacao (no inventa 0 msnm)', () => {
+      const cacao = [
+        {
+          mentioned: 'cacao', kind: 'species', nombre_comun: 'Cacao',
+          nombre_cientifico: 'Theobroma cacao', altitud_min: 200, altitud_max: 900,
+        },
+      ];
+      const ctx = buildViabilityContext({ fincaAltitud: null, resolvedEntities: cacao });
+      expect(ctx).toBe('');
+      // No debe filtrar el 0 fantasma ni marcar "al límite/marginal".
+      expect(ctx).not.toContain('0 msnm');
+      expect(ctx).not.toMatch(/MARGINAL|MUY BAJA|LÍMITE/i);
+    });
+
+    it('BUG-1: fincaAltitud undefined / "" / 0 se tratan como SIN altitud (no fantasma cálido)', () => {
+      const cacao = [
+        {
+          mentioned: 'cacao', kind: 'species', nombre_comun: 'Cacao',
+          nombre_cientifico: 'Theobroma cacao', altitud_min: 200, altitud_max: 900,
+        },
+      ];
+      for (const alt of [undefined, '', 0, '0', null]) {
+        const ctx = buildViabilityContext({ fincaAltitud: alt, resolvedEntities: cacao });
+        expect(ctx).toBe('');
+      }
+    });
+
+    it('BUG-1: con altitud REAL de tierra baja (350 m) SÍ evalúa cacao como viable', () => {
+      // Sanidad: el fix no rompe la altitud legítima — a 350 m cacao es viable
+      // (dentro de 200–900) y no se emite línea de advertencia.
+      const ctx = buildViabilityContext({
+        fincaAltitud: 350,
+        resolvedEntities: [
+          {
+            mentioned: 'cacao', kind: 'species', nombre_comun: 'Cacao',
+            nombre_cientifico: 'Theobroma cacao', altitud_min: 200, altitud_max: 900,
+          },
+        ],
+      });
+      expect(ctx).toBe('');
+    });
+
     it('ignora plagas/biopreparados (solo evalúa especies sembrables)', () => {
       const ctx = buildViabilityContext({
         fincaAltitud: 2580,

--- a/src/services/agentNluFallback.js
+++ b/src/services/agentNluFallback.js
@@ -29,9 +29,15 @@
  * devolvió null. Si `callTool` falla, el turno sigue (igual que hoy) — pero al
  * menos lo INTENTAMOS en vez de saltarnos el grounding.
  *
- * Conservador por diseño: para una consulta agro real SIEMPRE devuelve un plan
- * (peor caso: get_species genérico). Devuelve null solo si el mensaje no es un
- * string útil (no hay nada que groundear).
+ * Conservador por diseño: para una consulta agro real con SUJETO (especie/plaga)
+ * SIEMPRE devuelve un plan (peor caso: get_species genérico). Devuelve null si el
+ * mensaje no es un string útil, O si es una pregunta GENÉRICA/conversacional sin
+ * especie/plaga clara (saludo, meta-ayuda, consejo general de suelo/huerta): en
+ * ese caso forzar `get_species` con la frase cruda misrutea a una ficha de
+ * especie que el sidecar resuelve como `found:false` y el agente deflecta con un
+ * "el catálogo no tiene esa especie" irrelevante (bug audit conversación + memoria
+ * feedback-agente-pregunta-general-misruteo-tool-especie). Sin tool → el LLM
+ * responde conversacional con el grounding ligero de resolveEntities.
  */
 
 /**
@@ -49,6 +55,32 @@ const PEST_KEYWORDS_RE =
  */
 const BIOPREP_KEYWORDS_RE =
   /\b(biopreparado[s]?|bioinsumo[s]?|caldo\s+(bordeles|sulfocalcico|de\s+ceniza)|purin(es)?|biol\b|extracto[s]?\s+vegetal|receta\s+(organica|casera)|preparado\s+casero|abono\s+organico|microorganismo[s]?\s+eficientes|jabon\s+potasico)\b/;
+
+/**
+ * SALUDO / smalltalk PURO ("hola", "buenos días", "gracias", "hey"). Solo se
+ * trata como deflección cuando el saludo ES el mensaje (mensaje corto): así
+ * "buenas, ¿cómo cuido el aguacate?" NO se deflecta por el prefijo de saludo —
+ * la longitud lo distingue de un saludo suelto. Sobre el texto normalizado.
+ */
+const GREETING_RE =
+  /^\s*(hola|holas|buenas|buenos\s+dias|buenas\s+(tardes|noches)|que\s+mas|qu?iubo|hey|hello|gracias|muchas\s+gracias|chao|listo|oki?|dale|saludos)\b/i;
+
+/**
+ * META-AYUDA / capacidades de la app y pedido de consejo SIN sujeto ("qué puedes
+ * hacer", "para qué sirves", "cómo funcionas", "qué me recomiendas"). Patrones
+ * AUTO-CONTENIDOS y específicos → seguros aun en mensajes largos (no dependen de
+ * la longitud). Sobre el texto normalizado.
+ */
+const META_QUERY_RE =
+  /\b(que|para\s+que)\s+(puedes|sabes|podes|haces|sirves|ofreces|me\s+ofreces)\b|\bpara\s+que\s+sirves\b|\bcomo\s+funciona[s]?\b|\bquien\s+eres\b|\bque\s+eres\b|\bque\s+es\s+chagra\b|\bayuda(me|rme)?\b|\bhelp\b|\bque\s+me\s+recomiend/i;
+
+/**
+ * Rama de CONSEJO GENERAL de finca/suelo sin cultivo nombrado. Necesita un verbo
+ * de manejo + un objeto GENÉRICO de finca (no un cultivo). Sobre el texto
+ * normalizado.
+ */
+const GENERIC_MANEJO_RE =
+  /\b(como|que)\s+(?:\w+\s+){0,2}(mejor\w*|cuid\w*|enriquec\w*|prepar\w*|nutr\w*|recuper\w*|arregl\w*|trabaj\w*|manej\w*|abon\w*|fertiliz\w*|empie\w*|empez\w*|arranc\w*|inici\w*|comien\w*|comenz\w*)\s+(?:mi\s+|el\s+|la\s+|un\s+|una\s+)?(suelo|tierra|finca|huerta|parcela|chagra)\b|\bque\s+le\s+(echo|pongo|hecho)\s+a\s+(la\s+tierra|mi\s+suelo|mi\s+tierra)\b|\bcomo\s+(?:se\s+)?(hago|hacer|preparo|preparar)\s+(?:un\s+|el\s+)?(?:buen\s+)?(compost|abono\s+organico|humus|lombricompost|bocashi|bocachi)\b/i;
 
 /**
  * Normaliza a minúsculas SIN tildes para el matching de keywords (replica el
@@ -115,10 +147,27 @@ export function planNluFallback(userMessage, resolvedEntities = null) {
     return { tool: 'get_biopreparados', args: { query }, source: 'fallback_keyword_biopreparado' };
   }
 
-  // (c) DEFAULT — ficha de especie con el query crudo. Grounding genérico, pero
+  // (c) DEFLECCIÓN — pregunta GENÉRICA/conversacional SIN especie/plaga clara.
+  // Corre DESPUÉS de las señales de entidad/keyword (una plaga o cultivo nombrado
+  // ya se habría capturado arriba): lo que queda aquí y matchea es smalltalk,
+  // meta-ayuda o consejo general de finca/suelo. Forzar get_species con la frase
+  // cruda misrutea a una ficha inexistente → found:false → deflección irrelevante.
+  // Devolvemos null: el caller (AgentScreen) NO invoca tool y el LLM responde
+  // conversacional con el grounding ligero de resolveEntities.
+  //
+  // El saludo PURO solo deflecta si ES el mensaje (≤4 palabras): un saludo que
+  // prefija una pregunta real ("buenas, cómo cuido el aguacate") NO se deflecta.
+  // Meta-ayuda y consejo general son auto-contenidos → deflectan sin importar largo.
+  const wordCount = norm.split(/\s+/).filter(Boolean).length;
+  const isPureGreeting = GREETING_RE.test(norm) && wordCount <= 4;
+  if (isPureGreeting || META_QUERY_RE.test(norm) || GENERIC_MANEJO_RE.test(norm)) {
+    return null;
+  }
+
+  // (d) DEFAULT — ficha de especie con el query crudo. Grounding genérico, pero
   // preferible a generativo puro: el sidecar resuelve el cultivo por nombre.
   return { tool: 'get_species', args: { query }, source: 'fallback_default_species' };
 }
 
 // Export interno para testabilidad de los regex sin reflectar la closure.
-export const __TEST__ = { PEST_KEYWORDS_RE, BIOPREP_KEYWORDS_RE, _norm };
+export const __TEST__ = { PEST_KEYWORDS_RE, BIOPREP_KEYWORDS_RE, GREETING_RE, META_QUERY_RE, GENERIC_MANEJO_RE, _norm };

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -764,8 +764,18 @@ export function buildViabilityContext({
 } = {}) {
   if (!Array.isArray(resolvedEntities) || resolvedEntities.length === 0) return '';
 
+  // FUGA DE UBICACIÓN DEFAULT (0 msnm) — incidente audit de conversación (cacao):
+  // cuando el perfil NO tiene altitud capturada, el caller (AgentScreen) pasa
+  // `fincaAltitud = null`. `Number(null) === 0` (¡NO NaN!), así que la altitud
+  // FANTASMA 0 msnm se colaba como si fuera real: nivel del mar → piso cálido →
+  // cacao (200–900 m) caía "MARGINAL" (0 está 200 m bajo el mínimo, dentro del
+  // margen de 300) y el prompt afirmaba "tu finca a 0 msnm… al límite de su rango",
+  // con consejos de heladas/microclima ABRIGADO que en tierra baja tropical son
+  // agronómicamente al REVÉS. Un 0 default NO es un hecho: exigimos altitud
+  // POSITIVA y finita. Sin altitud confirmada NO se emite veredicto de viabilidad
+  // (degrada a neutral) — alineado con clima/saludo, que usan la ubicación GUARDADA.
   const alt = Number(fincaAltitud);
-  const haveAlt = Number.isFinite(alt);
+  const haveAlt = Number.isFinite(alt) && alt > 0;
   const fincaPiso = haveAlt ? pisoTermicoFromAltitud(alt) : null;
 
   const marginales = [];


### PR DESCRIPTION
## Contexto

Dos defectos **confirmados** del agente Chagra (audit de una conversación real), corregidos con tests de reproducción.

## BUG 1 — Fuga de ubicación default (0 msnm)

**Síntoma:** en un chat sobre CACAO el agente afirmó "tu finca está a 0 msnm… al límite de su rango ideal (200-900)" y recomendó "protección contra heladas y microclimas abrigados". A 0 msnm tropical no hay heladas y para cacao (calor-húmedo de tierra baja) el consejo es agronómicamente al revés.

**Causa raíz:** `buildViabilityContext` (`src/services/agentService.js`) hacía `const alt = Number(fincaAltitud)`. Cuando el perfil **no** tiene altitud capturada, el caller (`AgentScreen`) pasa `fincaAltitud = null` — y **`Number(null) === 0`** (no `NaN`). Ese 0 fantasma pasaba `Number.isFinite` → `haveAlt = true` → nivel del mar → piso cálido. Cacao (200–900 m) quedaba a 200 m bajo el mínimo, dentro del margen de 300 → veredicto "MARGINAL / al límite", y la línea `; tu finca a ${alt} msnm` inyectaba literalmente "tu finca a 0 msnm" al prompt.

**Fix:** exigir altitud **finita y positiva** (`Number.isFinite(alt) && alt > 0`). Sin altitud confirmada no se emite veredicto de viabilidad (degrada a neutral) — alineado con clima/saludo, que usan la ubicación **guardada** del perfil, no un default.

## BUG 2 — Deflección de pregunta general mal ruteada a tool de especie

**Síntoma:** una pregunta genérica (sin especie/plaga clara) misrutea a una tool de especie y el agente responde algo irrelevante ("el catálogo no tiene esa especie").

**Causa raíz:** en `planNluFallback` (`src/services/agentNluFallback.js`, el router de fallback cuando el NLU del sidecar muere), el caso por defecto forzaba `get_species` con la frase cruda para **cualquier** query sin entidad resuelta ni keyword de plaga/biopreparado. Una pregunta conversacional/general → `get_species("cómo mejoro mi suelo")` → `found:false` → deflección irrelevante.

**Fix:** detectar query **genérica/conversacional sin sujeto** y devolver `null` (⇒ `use_tool=false` ⇒ respuesta conversacional con el grounding ligero de `resolveEntities`). Tres señales, tras las de entidad/keyword:
- Saludo/smalltalk **puro** (≤4 palabras) — un saludo que prefija una pregunta real ("buenas, cómo cuido el aguacate") **no** se deflecta.
- Meta-ayuda / capacidades ("qué puedes hacer", "cómo funcionas", "qué me recomiendas").
- Consejo general de finca/suelo con **objeto genérico** (suelo/tierra/finca/huerta), nunca un cultivo → "cómo cuido el aguacate" sigue ruteando a `get_species`.

Alinea el frontend con el fix R0b2 del sidecar (PR #250, `feedback-agente-pregunta-general-misruteo-tool-especie`).

## Verificación
- `npx vitest run` sobre las suites afectadas (agentNluFallback, nluDegradeGrounding, agentService, locationService.pisoTermico, buildFincaContext, cropSuggestions, outputGuards.hardAltitudeViability, sidecarClient.nluTimeout): **verde**.
- `npm run build`: **verde**.
- `eslint` sobre los archivos tocados: **verde**.
- Tests nuevos reproducen ambos bugs (cacao a 0 msnm fantasma → sin veredicto; saludos/meta/consejo-general → null; cultivos nombrados → siguen a `get_species`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)