### PR TITLE
feat(agente): cablear 3 tools de grounding al cliente PWA (fase 1 §7.3)

### DIFF
--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -362,6 +362,40 @@ const ALLOWED_TOOLS = new Set([
   // (nunca inventa). El cliente además intercepta la mayoría de estas preguntas
   // localmente (metaAyudaIntent), pero se expone para el ruteo del NLU en chat.
   'get_ayuda_funcion',
+  // ── Reconciliación allow-list cliente ↔ 41 tools del NLU · Fase 1 (fix
+  //    grounding P0, CAPABILITIES_STATUS.md §7.3). El sidecar NLU (nlu.ts) ya
+  //    define y rutea estas 3, pero el cliente las rechazaba con
+  //    {_error, reason:'not_allowed'} → el turno degradaba a RAG SIN grounding
+  //    en silencio. Las 3 son read-only del grafo AGE, con args que el NLU SÍ
+  //    puede rellenar desde una frase de chat (mismo patrón que tools ya
+  //    expuestas), así que son seguras y valiosas de exponer:
+  //  - get_cultivos_viables: cultivos VIABLES a una altitud (grafo AGE). Arg
+  //    `altitud` (msnm) — idéntico patrón a get_diseno_silvopastoril/restauracion
+  //    ya expuestas. Alternativas honestas cuando el usuario propone un cultivo
+  //    inviable para su piso térmico. Degrada a {available:false} si AGE cae.
+  //  - get_diseno_finca: policultivo agroecológico estilo Restrepo por rol
+  //    funcional (polinizadores/abonos_verdes/sombra/cercas_vivas/alelopaticas)
+  //    y VIABLE a la altitud. Mismo arg `altitud`. Degrada si AGE cae.
+  //  - get_dosis_biopreparado: dosis, periodo de carencia, incompatibilidades y
+  //    registro ICA de biopreparados (grafo AGE). SEGURIDAD: responde
+  //    "¿cuánto le pongo? ¿cada cuánto? ¿tiene carencia?". Args
+  //    `biopreparado_id`|`pest_id` (snake_case) — mismo patrón que get_biopreparados
+  //    ya expuesta. Degrada a found:false si el grafo no tiene el dato.
+  'get_cultivos_viables',
+  'get_diseno_finca',
+  'get_dosis_biopreparado',
+  // FASE 2 (deferidas, NO exponer aún):
+  //  - get_grado_dia: requiere `fecha_siembra` (ISO YYYY-MM-DD, sin default) que
+  //    el NLU no puede sintetizar con fiabilidad desde una frase libre de chat.
+  //    Se cablea mejor desde un contexto estructurado (asset plant con fecha de
+  //    siembra conocida) o un chip dedicado, no desde el ruteo NLU. Mientras
+  //    tanto queda en deflección honesta (guard `not_allowed` en AgentScreen).
+  //
+  // NO se exponen (siguen en deflección honesta) las que exigen credenciales
+  // farmOS, coords de dispositivo o NIT DIAN — el NLU no puede rellenar esos
+  // args desde una frase de chat: add_planta_finca (write), get_finca_overview,
+  // get_sensor_finca, get_weather_data, get_clima_finca, get_ubicacion_actual,
+  // get_documento_soporte_dian.
 ]);
 
 /**


### PR DESCRIPTION
## Qué

Cierra la fase 1 de la brecha de grounding silencioso del agente (CAPABILITIES_STATUS.md §7.3): el sidecar MCP/NLU conoce 41 tools y el cliente PWA rechazaba algunas con `{_error, reason:'not_allowed'}` -> el turno degradaba a RAG SIN grounding en silencio.

Estado real al partir (NO era 41-vs-19; ese snapshot estaba stale, PR #1851 ya subio el cliente a 31): **41 sidecar vs 31 cliente**. Esta PR sube el cliente a **34**.

## Diff 41 (sidecar) vs 31 (cliente) — gap = 11 tools solo-sidecar

| Tool | Grounding que aporta | Decision |
|---|---|---|
| `get_cultivos_viables` | cultivos VIABLES a una altitud (grafo AGE) | **EXPONER (fase 1)** |
| `get_diseno_finca` | policultivo agroecologico por rol funcional (grafo AGE) | **EXPONER (fase 1)** |
| `get_dosis_biopreparado` | dosis + carencia + incompatibilidades + registro ICA (grafo AGE, SEGURIDAD) | **EXPONER (fase 1)** |
| `get_grado_dia` | modelo grado-dia/fenologico | **FASE 2** — requiere `fecha_siembra` (ISO) que el NLU no sintetiza fiable desde chat libre |
| `add_planta_finca` | write a farmOS | excluida (creds farmOS + write) |
| `get_finca_overview` | overview finca | excluida (creds farmOS) |
| `get_sensor_finca` | sensores IoT | excluida (creds farmOS) |
| `get_weather_data` | clima farmOS | excluida (creds farmOS) |
| `get_clima_finca` | clima estacion IDEAM cercana | excluida (creds farmOS) |
| `get_ubicacion_actual` | geocoding + altitud | excluida (coords de dispositivo) |
| `get_documento_soporte_dian` | doc soporte DIAN | excluida (NIT DIAN) |

Las 3 expuestas son read-only del grafo AGE con args que el NLU SI rellena desde una frase de chat (mismo patron que tools ya expuestas: `altitud` como `get_diseno_silvopastoril`; `biopreparado_id`/`pest_id` como `get_biopreparados`). El sidecar NLU (`nlu.ts`) ya las define y rutea; solo el gate del cliente las bloqueaba.

## Sin riesgo de saturacion del modelo NLU

`planNlu` envia solo `{user_message, context}` — la lista de tools que ve el modelo local es 100% sidecar-side (ya son las 41). Esta PR NO agrega nada al prompt del modelo; solo deja de rechazar 3 tools que ya podia elegir. Coste de contexto del NLU = cero delta.

## Fase 2 documentada

`get_grado_dia` queda en deflexion honesta hasta cablearla desde un contexto estructurado (asset plant con fecha de siembra) o un chip dedicado. Las 7 de credenciales/coords/NIT siguen excluidas por diseno (el NLU no puede rellenar esos args desde chat).

## Verificacion

- `sidecarClient.allowlist.test.js`, `sidecarClient.toolChain.test.js`, `agentCapabilities.audit.test.js`, `mcpHonestidad.test.js`, `nluDegradeGrounding.test.js` verdes
- `tsc:check` verde
- build verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
