### PR TITLE
feat(datos): capa de datos — croquis de lotes + "Mi cosecha" (groundwork Fable)

### DIFF
--- a/src/components/cosecha/MiCosechaPlaceholder.jsx
+++ b/src/components/cosecha/MiCosechaPlaceholder.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect } from 'react';
+import { Apple, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import useCosechaStore from '../../store/useCosechaStore';
+
+/**
+ * MiCosechaPlaceholder — PLACEHOLDER MÍNIMO de "Mi cosecha".
+ *
+ * ⚠️ Fable REEMPLAZA esta vista por el tablero visual (tarjetas de rendimiento,
+ * gráfica de tendencia, kg/planta por cultivo). Aquí solo cableamos la CAPA DE
+ * DATOS (useCosechaStore + cosechaService) con los números ya agregados:
+ *
+ *   - summary.totalKg          → total cosechado (kg)
+ *   - summary.topCrop          → cultivo estrella
+ *   - summary.byCrop[]         → producción por cultivo
+ *   - summary.byLote[]         → rendimiento por lote (kg/planta, kg/ha)
+ *   - summary.trend            → serie mensual + dirección (subiendo/bajando)
+ *
+ * NO es la UI final: es el andamiaje de datos. Ver services/cosechaService.js.
+ */
+export default function MiCosechaPlaceholder() {
+  const summary = useCosechaStore((s) => s.summary);
+  const isLoading = useCosechaStore((s) => s.isLoading);
+  const loadHarvests = useCosechaStore((s) => s.loadHarvests);
+
+  useEffect(() => {
+    loadHarvests();
+  }, [loadHarvests]);
+
+  if (isLoading && !summary) {
+    return <div className="p-4 text-sm text-slate-400">Cargando tus cosechas…</div>;
+  }
+
+  if (!summary || summary.totalHarvests === 0) {
+    return (
+      <div className="p-4 text-sm text-slate-400 flex items-center gap-2">
+        <Apple size={16} aria-hidden="true" /> Todavía no hay cosechas registradas. Registra una en “Cosechar”.
+      </div>
+    );
+  }
+
+  const TrendIcon = summary.trend.direction === 'subiendo' ? TrendingUp
+    : summary.trend.direction === 'bajando' ? TrendingDown : Minus;
+
+  return (
+    <div className="p-4 flex flex-col gap-4 text-slate-100">
+      <div className="rounded-xl border border-dashed border-emerald-600/60 bg-emerald-950/20 p-4">
+        <p className="text-sm text-emerald-300 font-semibold flex items-center gap-2">
+          <Apple size={16} aria-hidden="true" /> Aquí va el tablero de rendimiento (lo pinta Fable)
+        </p>
+        <p className="text-xs text-emerald-200/70 mt-1">
+          Placeholder de datos: la agregación ya está lista en <code>cosechaService</code>.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-lg bg-slate-900 border border-slate-800 p-3">
+          <div className="text-xs text-slate-400">Total cosechado</div>
+          <div className="text-2xl font-bold">{summary.totalKg.toFixed(1)} <span className="text-sm font-normal text-slate-400">kg</span></div>
+        </div>
+        <div className="rounded-lg bg-slate-900 border border-slate-800 p-3">
+          <div className="text-xs text-slate-400">Cultivo estrella</div>
+          <div className="text-lg font-bold truncate">{summary.topCrop?.crop || '—'}</div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-slate-900 border border-slate-800 p-3">
+        <div className="text-xs text-slate-400 flex items-center gap-1.5">
+          <TrendIcon size={14} aria-hidden="true" /> Tendencia: {summary.trend.direction}
+        </div>
+        <div className="text-xs text-slate-500 mt-1">
+          {summary.trend.series.length} mes(es) con registro · {summary.totalHarvests} cosecha(s)
+        </div>
+      </div>
+
+      <div>
+        <h4 className="text-sm font-bold mb-2">Por cultivo</h4>
+        <ul className="flex flex-col gap-1.5">
+          {summary.byCrop.map((c) => (
+            <li key={c.cropKey} className="flex justify-between text-sm bg-slate-900 border border-slate-800 rounded px-3 py-2">
+              <span className="truncate">{c.crop}</span>
+              <span className="text-slate-400 shrink-0 ml-2">
+                {c.totalKg > 0 ? `${c.totalKg.toFixed(1)} kg` : `${c.totalCount} und`}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/lotes/LoteCroquisPlaceholder.jsx
+++ b/src/components/lotes/LoteCroquisPlaceholder.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect } from 'react';
+import { MapPin, Pentagon, Plus } from 'lucide-react';
+import useLoteStore from '../../store/useLoteStore';
+import { summarizeLote, LAND_TYPES } from '../../services/loteService';
+
+/**
+ * LoteCroquisPlaceholder — PLACEHOLDER MÍNIMO del croquis de lotes.
+ *
+ * ⚠️ Fable REEMPLAZA este componente por el canvas de dibujo real (Leaflet +
+ * herramienta de polígono/punto). Aquí solo cableamos la CAPA DE DATOS
+ * (useLoteStore + loteService) para que la vista quede lista para pintar:
+ *
+ *   - `lotes`            → lista reactiva de lotes (espejo de useAssetStore.lands)
+ *   - `setDrawMode()`    → arranca el modo dibujo ('polygon' | 'point')
+ *   - `addDraftVertex()` → el canvas empuja vértices aquí
+ *   - `saveDraftAsLote()`→ persiste el trazo como asset--land (offline-first)
+ *   - `summarizeLote()`  → área/centroide/cultivos para la ficha de cada lote
+ *
+ * NO es la UI final: es el andamiaje de datos. Ver services/loteService.js.
+ */
+export default function LoteCroquisPlaceholder() {
+  const lotes = useLoteStore((s) => s.lotes);
+  const drawMode = useLoteStore((s) => s.drawMode);
+  const hydrate = useLoteStore((s) => s.hydrate);
+  const setDrawMode = useLoteStore((s) => s.setDrawMode);
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  return (
+    <div className="p-4 flex flex-col gap-4 text-slate-100">
+      <div className="rounded-xl border border-dashed border-amber-600/60 bg-amber-950/20 p-4">
+        <p className="text-sm text-amber-300 font-semibold flex items-center gap-2">
+          <Pentagon size={16} aria-hidden="true" /> Aquí va el canvas de dibujo (lo pinta Fable)
+        </p>
+        <p className="text-xs text-amber-200/70 mt-1">
+          Placeholder de datos: el modelo, el CRUD y la geometría ya están listos
+          en <code>loteService</code> / <code>useLoteStore</code>.
+        </p>
+        <div className="flex flex-wrap gap-2 mt-3">
+          <button
+            type="button"
+            onClick={() => setDrawMode('polygon')}
+            className={`px-3 py-1.5 rounded-lg text-xs font-bold ${drawMode === 'polygon' ? 'bg-amber-600 text-white' : 'bg-slate-800 text-slate-300'}`}
+          >
+            Dibujar lote (polígono)
+          </button>
+          <button
+            type="button"
+            onClick={() => setDrawMode('point')}
+            className={`px-3 py-1.5 rounded-lg text-xs font-bold ${drawMode === 'point' ? 'bg-amber-600 text-white' : 'bg-slate-800 text-slate-300'}`}
+          >
+            Marcar punto
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-bold flex items-center gap-2">
+          <MapPin size={18} aria-hidden="true" /> Mis lotes ({lotes.length})
+        </h3>
+      </div>
+
+      {lotes.length === 0 ? (
+        <p className="text-sm text-slate-400 flex items-center gap-2">
+          <Plus size={14} aria-hidden="true" /> Aún no has dibujado lotes. Usa el canvas para empezar.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {lotes.map((lote) => {
+            const s = summarizeLote(lote, { plants: [], animals: [] });
+            const typeLabel = LAND_TYPES.find((t) => t.value === s.landType)?.label || s.landType;
+            return (
+              <li key={lote.id} className="rounded-lg bg-slate-900 border border-slate-800 p-3">
+                <div className="font-semibold text-sm">{s.name}</div>
+                <div className="text-xs text-slate-400 mt-0.5">
+                  {typeLabel}
+                  {s.hasGeometry && s.areaM2 > 0 && ` · ${s.areaM2.toFixed(0)} m² (${s.areaHa.toFixed(3)} ha)`}
+                  {!s.hasGeometry && ' · sin geometría'}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/services/__tests__/cosechaService.test.js
+++ b/src/services/__tests__/cosechaService.test.js
@@ -1,0 +1,235 @@
+/**
+ * cosechaService — agregación y rendimiento de "Mi cosecha".
+ *
+ * Cubre la matemática DETERMINISTA sobre log--harvest:
+ *   - Conversión de unidades a kg (incl. arroba/libra/quintal colombianos).
+ *   - Normalización robusta de la cantidad (array / aplanado / {decimal}).
+ *   - Nombre de cultivo derivado del nombre del log.
+ *   - Agregación por cultivo / lote (kg/planta, kg/ha) y tendencia temporal.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeUnit,
+  toKilograms,
+  readHarvestQuantity,
+  cropLabelFromName,
+  normalizeHarvestLog,
+  normalizeHarvests,
+  aggregateByCrop,
+  aggregateByAsset,
+  aggregateByLote,
+  yieldPerPlantByCrop,
+  temporalTrend,
+  harvestSummary,
+} from '../cosechaService';
+
+// Helper: log--harvest con quantity aplanado (shape de addHarvestLog/logCache).
+const harvest = ({ id, assetId = null, name = '', value, unit, ts }) => ({
+  id,
+  type: 'log--harvest',
+  asset_id: assetId,
+  name,
+  timestamp: ts,
+  status: 'done',
+  quantity: { value, unit, measure: 'weight' },
+});
+
+describe('normalizeUnit — plural español y unidades campesinas', () => {
+  it('singulariza -s y -es correctamente', () => {
+    expect(normalizeUnit('Kilogramos')).toBe('kilogramo');
+    expect(normalizeUnit('Gramos')).toBe('gramo');
+    expect(normalizeUnit('Libras')).toBe('libra');
+    expect(normalizeUnit('Unidades')).toBe('unidad');
+    expect(normalizeUnit('Quintales')).toBe('quintal');
+    expect(normalizeUnit('@')).toBe('@');
+  });
+});
+
+describe('toKilograms — conversión de peso', () => {
+  it('convierte gramos, kilos y toneladas', () => {
+    expect(toKilograms(1000, 'g')).toEqual({ kg: 1, isWeight: true });
+    expect(toKilograms(3, 'Kilogramos')).toEqual({ kg: 3, isWeight: true });
+    expect(toKilograms(2, 'Toneladas')).toEqual({ kg: 2000, isWeight: true });
+  });
+
+  it('soporta la arroba (12.5 kg) y la libra colombianas', () => {
+    expect(toKilograms(2, '@')).toEqual({ kg: 25, isWeight: true }); // 2 arrobas
+    expect(toKilograms(1, 'arroba').kg).toBeCloseTo(12.5, 5);
+    expect(toKilograms(1, 'Libra').kg).toBeCloseTo(0.45359237, 6);
+    expect(toKilograms(1, 'quintal').kg).toBe(50);
+  });
+
+  it('las unidades de conteo NO son peso (kg=null)', () => {
+    expect(toKilograms(12, 'Unidades')).toEqual({ kg: null, isWeight: false });
+    expect(toKilograms(3, 'Manojos')).toEqual({ kg: null, isWeight: false });
+  });
+});
+
+describe('readHarvestQuantity — shapes heterogéneos', () => {
+  it('lee quantity aplanado {value,unit}', () => {
+    expect(readHarvestQuantity({ quantity: { value: 10, unit: 'Kilogramos' } }))
+      .toEqual({ value: 10, unit: 'Kilogramos', measure: null });
+  });
+
+  it('lee quantity array JSON:API con value {decimal}', () => {
+    const log = {
+      quantity: [{ attributes: { value: { decimal: '2.5' }, label: 'Kilogramos', measure: 'weight' } }],
+    };
+    expect(readHarvestQuantity(log)).toEqual({ value: 2.5, unit: 'Kilogramos', measure: 'weight' });
+  });
+
+  it('cae a attributes.quantity cuando no hay quantity top-level', () => {
+    const log = { attributes: { quantity: { value: 4, unit: 'Unidades' } } };
+    expect(readHarvestQuantity(log)).toEqual({ value: 4, unit: 'Unidades', measure: null });
+  });
+});
+
+describe('cropLabelFromName', () => {
+  it('quita el prefijo "Cosecha de" y el sufijo de fecha', () => {
+    expect(cropLabelFromName('Cosecha de Fresa Monterrey')).toBe('Fresa Monterrey');
+    expect(cropLabelFromName('Cosecha: Mora - 2026-07-01')).toBe('Mora');
+    expect(cropLabelFromName('Cosecha de Café - 2026-07-01')).toBe('Café');
+    expect(cropLabelFromName('')).toBe('Sin cultivo');
+  });
+});
+
+describe('normalizeHarvestLog', () => {
+  it('normaliza a un registro plano con kg y mes', () => {
+    const ts = Math.floor(Date.parse('2026-07-01T00:00:00Z') / 1000);
+    const n = normalizeHarvestLog(harvest({ id: 'h1', assetId: 'p1', name: 'Cosecha de Fresa', value: 3, unit: 'Kilogramos', ts }));
+    expect(n.crop).toBe('Fresa');
+    expect(n.kg).toBe(3);
+    expect(n.isWeight).toBe(true);
+    expect(n.month).toBe('2026-07');
+    expect(n.assetId).toBe('p1');
+  });
+
+  it('descarta logs con cantidad <= 0', () => {
+    expect(normalizeHarvestLog(harvest({ id: 'x', value: 0, unit: 'kg', ts: 1 }))).toBeNull();
+  });
+
+  it('registros de conteo dejan kg=null pero conservan value', () => {
+    const n = normalizeHarvestLog(harvest({ id: 'h', assetId: 'a', name: 'Cosecha de Huevos', value: 30, unit: 'Unidades', ts: 1 }));
+    expect(n.kg).toBeNull();
+    expect(n.isWeight).toBe(false);
+    expect(n.value).toBe(30);
+  });
+});
+
+describe('aggregateByCrop', () => {
+  it('agrupa por cultivo ignorando mayúsculas/tildes y ordena por kg', () => {
+    const norm = normalizeHarvests([
+      harvest({ id: '1', name: 'Cosecha de Fresa', value: 2, unit: 'kg', ts: 1 }),
+      harvest({ id: '2', name: 'Cosecha de FRESA', value: 3, unit: 'kg', ts: 2 }),
+      harvest({ id: '3', name: 'Cosecha de Mora', value: 1, unit: 'kg', ts: 3 }),
+    ]);
+    const byCrop = aggregateByCrop(norm);
+    expect(byCrop[0].crop).toBe('Fresa');
+    expect(byCrop[0].totalKg).toBe(5);
+    expect(byCrop[0].harvestCount).toBe(2);
+    expect(byCrop[1].totalKg).toBe(1);
+  });
+});
+
+describe('aggregateByAsset', () => {
+  it('suma por asset cosechado', () => {
+    const norm = normalizeHarvests([
+      harvest({ id: '1', assetId: 'p1', name: 'Cosecha de Fresa', value: 2, unit: 'kg', ts: 1 }),
+      harvest({ id: '2', assetId: 'p1', name: 'Cosecha de Fresa', value: 3, unit: 'kg', ts: 2 }),
+    ]);
+    const byAsset = aggregateByAsset(norm);
+    expect(byAsset).toHaveLength(1);
+    expect(byAsset[0]).toMatchObject({ assetId: 'p1', totalKg: 5, harvestCount: 2 });
+  });
+});
+
+describe('aggregateByLote — rendimiento espacial', () => {
+  it('suma cosechas de plantas del lote y calcula kg/planta y kg/ha', () => {
+    const plants = [
+      { id: 'p1', relationships: { parent: { data: [{ type: 'asset--land', id: 'lote1' }] } } },
+      { id: 'p2', relationships: { parent: { data: [{ type: 'asset--land', id: 'lote1' }] } } },
+    ];
+    const lands = [{ id: 'lote1', attributes: { name: 'Era 1' } }];
+    const norm = normalizeHarvests([
+      harvest({ id: '1', assetId: 'p1', name: 'Cosecha de Fresa', value: 5, unit: 'kg', ts: 1 }),
+      harvest({ id: '2', assetId: 'p2', name: 'Cosecha de Fresa', value: 5, unit: 'kg', ts: 2 }),
+    ]);
+    const byLote = aggregateByLote(norm, { plants, lands, areaOf: () => 10000 /* 1 ha */ });
+    expect(byLote).toHaveLength(1);
+    const l = byLote[0];
+    expect(l.name).toBe('Era 1');
+    expect(l.totalKg).toBe(10);
+    expect(l.plantCount).toBe(2);
+    expect(l.kgPerPlant).toBe(5);
+    expect(l.kgPerHa).toBe(10);
+  });
+
+  it('atribuye una cosecha colgada del lote directo', () => {
+    const lands = [{ id: 'lote2', attributes: { name: 'Potrero' } }];
+    const norm = normalizeHarvests([
+      harvest({ id: '1', assetId: 'lote2', name: 'Cosecha de Pasto', value: 100, unit: 'kg', ts: 1 }),
+    ]);
+    const byLote = aggregateByLote(norm, { plants: [], lands, areaOf: () => 0 });
+    expect(byLote[0].totalKg).toBe(100);
+    expect(byLote[0].kgPerHa).toBeNull(); // sin área no se puede rendir por ha
+  });
+});
+
+describe('yieldPerPlantByCrop', () => {
+  it('divide kg del cultivo entre nº de plantas', () => {
+    const plants = [
+      { id: 'p1', attributes: { name: 'Fresa' } },
+      { id: 'p2', attributes: { name: 'Fresa' } },
+    ];
+    const norm = normalizeHarvests([
+      harvest({ id: '1', assetId: 'p1', name: 'Cosecha de Fresa', value: 8, unit: 'kg', ts: 1 }),
+    ]);
+    const y = yieldPerPlantByCrop(norm, plants);
+    expect(y[0]).toMatchObject({ crop: 'Fresa', plantCount: 2, kgPerPlant: 4 });
+  });
+});
+
+describe('temporalTrend', () => {
+  it('detecta tendencia al alza en meses consecutivos', () => {
+    const mk = (m, v) => harvest({ id: `${m}-${v}`, name: 'Cosecha de Fresa', value: v, unit: 'kg', ts: Math.floor(Date.parse(`2026-0${m}-15T00:00:00Z`) / 1000) });
+    const norm = normalizeHarvests([mk(1, 1), mk(2, 3), mk(3, 6)]);
+    const t = temporalTrend(norm);
+    expect(t.series.map((s) => s.period)).toEqual(['2026-01', '2026-02', '2026-03']);
+    expect(t.series.map((s) => s.totalKg)).toEqual([1, 3, 6]);
+    expect(t.direction).toBe('subiendo');
+    expect(t.slope).toBeGreaterThan(0);
+  });
+
+  it('marca estable con un solo mes', () => {
+    const norm = normalizeHarvests([harvest({ id: '1', name: 'Cosecha de Fresa', value: 5, unit: 'kg', ts: 1 })]);
+    expect(temporalTrend(norm).direction).toBe('estable');
+  });
+});
+
+describe('harvestSummary — integración', () => {
+  it('compone total, top-crop, por-lote y tendencia', () => {
+    const plants = [
+      { id: 'p1', attributes: { name: 'Fresa' }, relationships: { parent: { data: [{ id: 'lote1' }] } } },
+    ];
+    const lands = [{ id: 'lote1', attributes: { name: 'Era 1' } }];
+    const logs = [
+      harvest({ id: '1', assetId: 'p1', name: 'Cosecha de Fresa', value: 4, unit: 'kg', ts: Math.floor(Date.parse('2026-06-01T00:00:00Z') / 1000) }),
+      harvest({ id: '2', assetId: 'p1', name: 'Cosecha de Fresa', value: 6, unit: 'kg', ts: Math.floor(Date.parse('2026-07-01T00:00:00Z') / 1000) }),
+    ];
+    const s = harvestSummary(logs, { plants, lands, areaOf: () => 5000 });
+    expect(s.totalKg).toBe(10);
+    expect(s.totalHarvests).toBe(2);
+    expect(s.topCrop.crop).toBe('Fresa');
+    expect(s.byLote[0].loteId).toBe('lote1');
+    expect(s.byLote[0].kgPerHa).toBe(20); // 10 kg / 0.5 ha
+    expect(s.trend.direction).toBe('subiendo');
+    expect(s.dateRange.firstMs).toBeLessThan(s.dateRange.lastMs);
+  });
+
+  it('resumen vacío con 0 cosechas', () => {
+    const s = harvestSummary([], {});
+    expect(s.totalHarvests).toBe(0);
+    expect(s.topCrop).toBeNull();
+    expect(s.dateRange).toEqual({ firstMs: null, lastMs: null });
+  });
+});

--- a/src/services/__tests__/loteService.test.js
+++ b/src/services/__tests__/loteService.test.js
@@ -1,0 +1,216 @@
+/**
+ * loteService — CRUD y geometría del croquis de lotes (asset--land).
+ *
+ * Usa el IndexedDB real (fake-indexeddb/auto del setup) + assetCache real, así
+ * que ejercita el camino offline-first completo: commit optimista + encolado.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { openDB, STORES } from '../../db/dbCore';
+import { _resetForTests } from '../../services/tenantContext';
+import useAssetStore from '../../store/useAssetStore';
+import {
+  geometryFromDraft,
+  buildLotePayload,
+  validateLoteInput,
+  loteAreaSqMeters,
+  loteAreaHectares,
+  loteCentroid,
+  createLote,
+  updateLote,
+  deleteLote,
+  listLotes,
+  getLote,
+  getLoteContents,
+  summarizeLote,
+  parentLandIdOf,
+  assignAssetToLote,
+} from '../loteService';
+
+// Cuadro ~111 m × 111 m cerca de Choachí (Cundinamarca).
+const SQUARE = [
+  { lat: 4.5306, lng: -73.9247 },
+  { lat: 4.5316, lng: -73.9247 },
+  { lat: 4.5316, lng: -73.9237 },
+  { lat: 4.5306, lng: -73.9237 },
+];
+
+const clearStore = async (name) => {
+  const db = await openDB();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction(name, 'readwrite');
+    tx.objectStore(name).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+};
+
+beforeEach(async () => {
+  _resetForTests();
+  await clearStore(STORES.ASSETS);
+  await clearStore(STORES.PENDING_TX);
+  useAssetStore.setState({
+    plants: [], structures: [], equipment: [], materials: [], lands: [],
+    isHydrated: true, selectedAssetId: null, error: null,
+  });
+});
+
+describe('geometryFromDraft', () => {
+  it('construye un Polygon desde ≥3 vértices', () => {
+    const geo = geometryFromDraft({ mode: 'polygon', latlngs: SQUARE });
+    expect(geo.type).toBe('Polygon');
+    // cierra el anillo: primer y último coinciden.
+    const ring = geo.coordinates[0];
+    expect(ring[0]).toEqual(ring[ring.length - 1]);
+  });
+
+  it('rechaza polígonos con <3 vértices', () => {
+    expect(geometryFromDraft({ mode: 'polygon', latlngs: SQUARE.slice(0, 2) })).toBeNull();
+  });
+
+  it('construye un Point', () => {
+    const geo = geometryFromDraft({ mode: 'point', point: { lat: 4.53, lng: -73.92 } });
+    expect(geo).toEqual({ type: 'Point', coordinates: [-73.92, 4.53] });
+  });
+});
+
+describe('geometría del lote (área / centroide)', () => {
+  const lote = buildLotePayload({ name: 'Lote', geometry: geometryFromDraft({ mode: 'polygon', latlngs: SQUARE }) }).asset;
+
+  it('calcula un área plausible (~1.2 ha para 111×111 m)', () => {
+    const m2 = loteAreaSqMeters(lote);
+    expect(m2).toBeGreaterThan(10000);
+    expect(m2).toBeLessThan(15000);
+    expect(loteAreaHectares(lote)).toBeCloseTo(m2 / 10000, 6);
+  });
+
+  it('el centroide cae dentro del cuadro', () => {
+    const c = loteCentroid(lote);
+    expect(c.lat).toBeGreaterThan(4.5306);
+    expect(c.lat).toBeLessThan(4.5316);
+    expect(c.lng).toBeGreaterThan(-73.9247);
+    expect(c.lng).toBeLessThan(-73.9237);
+  });
+});
+
+describe('validateLoteInput', () => {
+  it('exige nombre', () => {
+    expect(validateLoteInput({ name: '' }).valid).toBe(false);
+    expect(validateLoteInput({ name: 'Huerta' }).valid).toBe(true);
+  });
+
+  it('rechaza land_type desconocido', () => {
+    const r = validateLoteInput({ name: 'x', landType: 'volcano' });
+    expect(r.valid).toBe(false);
+    expect(r.errors.landType).toBeTruthy();
+  });
+});
+
+describe('buildLotePayload', () => {
+  it('produce un asset--land con land_type, geometría WKT y pending_tx POST', () => {
+    const geo = geometryFromDraft({ mode: 'polygon', latlngs: SQUARE });
+    const { asset, pendingTx } = buildLotePayload({ name: 'Potrero', landType: 'paddock', geometry: geo, notes: 'para las vacas' });
+    expect(asset.type).toBe('asset--land');
+    expect(asset.attributes.land_type).toBe('paddock');
+    expect(asset.attributes.name).toBe('Potrero');
+    expect(asset.attributes.intrinsic_geometry.value).toMatch(/^POLYGON\(\(/);
+    expect(asset.attributes.notes).toEqual({ value: 'para las vacas' });
+    expect(asset.relationships.parent.data[0].type).toBe('asset--land');
+    expect(pendingTx).toMatchObject({ type: 'asset_land', endpoint: '/api/asset/land', method: 'POST' });
+    expect(pendingTx.id).toBe(asset.id);
+  });
+});
+
+describe('CRUD offline-first', () => {
+  it('createLote persiste en IDB y lo refleja en useAssetStore.lands', async () => {
+    const geo = geometryFromDraft({ mode: 'polygon', latlngs: SQUARE });
+    const lote = await createLote({ name: 'Era de cilantro', landType: 'bed', geometry: geo });
+
+    // reflejo en memoria (→ FarmMap dibuja al instante)
+    const lands = useAssetStore.getState().lands;
+    expect(lands.some((l) => l.id === lote.id)).toBe(true);
+
+    // persistido en IDB con asset_type correcto
+    const listed = await listLotes();
+    expect(listed.some((l) => l.id === lote.id)).toBe(true);
+
+    // pending_tx encolada
+    const db = await openDB();
+    const txs = await new Promise((res) => {
+      const t = db.transaction(STORES.PENDING_TX, 'readonly');
+      const req = t.objectStore(STORES.PENDING_TX).getAll();
+      req.onsuccess = () => res(req.result);
+    });
+    expect(txs.some((tx) => tx.id === lote.id && tx.endpoint === '/api/asset/land')).toBe(true);
+  });
+
+  it('getLote devuelve el land; null para id inexistente', async () => {
+    const lote = await createLote({ name: 'Lote A', landType: 'field' });
+    expect((await getLote(lote.id)).id).toBe(lote.id);
+    expect(await getLote('no-existe')).toBeNull();
+  });
+
+  it('updateLote cambia el nombre', async () => {
+    const lote = await createLote({ name: 'Viejo nombre', landType: 'field' });
+    await updateLote(lote.id, { name: 'Nuevo nombre' });
+    const reloaded = await getLote(lote.id);
+    expect(reloaded.attributes.name).toBe('Nuevo nombre');
+  });
+
+  it('deleteLote lo saca de IDB y del store', async () => {
+    const lote = await createLote({ name: 'Temporal', landType: 'field' });
+    await deleteLote(lote.id);
+    expect(await getLote(lote.id)).toBeNull();
+    expect(useAssetStore.getState().lands.some((l) => l.id === lote.id)).toBe(false);
+  });
+
+  it('createLote rechaza input sin nombre', async () => {
+    await expect(createLote({ name: '' })).rejects.toThrow();
+  });
+});
+
+describe('cultivos/animales del lote', () => {
+  const plantIn = (id, loteId) => ({
+    id,
+    type: 'asset--plant',
+    attributes: { name: 'Cilantro' },
+    relationships: { parent: { data: [{ type: 'asset--land', id: loteId }] } },
+  });
+
+  it('parentLandIdOf lee parent con fallback a location', () => {
+    expect(parentLandIdOf(plantIn('p1', 'lote1'))).toBe('lote1');
+    expect(parentLandIdOf({ relationships: { location: { data: [{ id: 'L' }] } } })).toBe('L');
+    expect(parentLandIdOf({})).toBeNull();
+  });
+
+  it('getLoteContents filtra por lote y summarizeLote resume', async () => {
+    const geo = geometryFromDraft({ mode: 'polygon', latlngs: SQUARE });
+    const lote = await createLote({ name: 'Era 1', landType: 'bed', geometry: geo });
+    const pools = {
+      plants: [plantIn('p1', lote.id), plantIn('p2', lote.id), plantIn('p3', 'otro')],
+      animals: [],
+    };
+    const contents = getLoteContents(lote.id, pools);
+    expect(contents.plants).toHaveLength(2);
+
+    const s = summarizeLote(lote, contents);
+    expect(s.name).toBe('Era 1');
+    expect(s.cropCount).toBe(2);
+    expect(s.hasGeometry).toBe(true);
+    expect(s.areaM2).toBeGreaterThan(10000);
+    expect(s.species).toEqual(['Cilantro']);
+  });
+
+  it('assignAssetToLote fija location+parent del cultivo al lote', async () => {
+    const lote = await createLote({ name: 'Lote destino', landType: 'field' });
+    const plant = { id: 'plant-x', type: 'asset--plant', attributes: { name: 'Tomate' }, relationships: {} };
+    useAssetStore.setState({ plants: [plant] });
+
+    const updated = await assignAssetToLote({ assetType: 'plant', asset: plant, loteId: lote.id });
+    expect(updated.relationships.parent.data[0].id).toBe(lote.id);
+    expect(updated.relationships.location.data[0].id).toBe(lote.id);
+
+    // reflejado en el store
+    const stored = useAssetStore.getState().plants.find((p) => p.id === 'plant-x');
+    expect(parentLandIdOf(stored)).toBe(lote.id);
+  });
+});

--- a/src/services/cosechaService.js
+++ b/src/services/cosechaService.js
@@ -1,0 +1,442 @@
+/**
+ * cosechaService.js — CAPA DE DATOS de "Mi cosecha" (producción / rendimiento).
+ *
+ * FEATURE "Mi cosecha": registrar y VER cuánto produce la finca por cultivo y
+ * por lote, y cómo cambia en el tiempo. Esta capa NO registra cosechas (eso ya
+ * lo hace HarvestLog.jsx → savePayload('harvest') / useAssetStore.addHarvestLog):
+ * solo AGREGA los `log--harvest` existentes y calcula rendimiento. Es pura y
+ * determinista — la vista (Fable) solo pinta los números que salen de aquí.
+ *
+ * ── Fuente de datos (grounded en farmOS, offline-first) ─────────────────────
+ * Un registro de cosecha ES un `log--harvest`:
+ *   - relationships.asset → el asset--plant (o asset--land) cosechado.
+ *   - relationships.quantity / attributes.quantity → { value, unit, measure }.
+ *   - attributes.timestamp → fecha (unix segundos o ISO).
+ *   - attributes.name → "Cosecha de Fresa Monterrey" (de ahí sale el cultivo).
+ *
+ * `logCache.getByType('log--harvest')` entrega estos logs offline. El shape de
+ * `quantity` varía según el origen (array JSON:API crudo, objeto aplanado, o
+ * `{ value: { decimal } }`), así que `readHarvestQuantity` los normaliza todos.
+ *
+ * ── Rendimiento ─────────────────────────────────────────────────────────────
+ *   - kg/planta  = total kg cosechado / nº de plantas del cultivo o lote.
+ *   - kg/era (lote) = total kg de las plantas cuyo parent es el lote / área.
+ *   - tendencia temporal = kg agregados por mes + pendiente (subiendo/bajando).
+ */
+
+export const HARVEST_LOG_TYPE = 'log--harvest';
+
+// ── Normalización de unidades a kilogramos ──────────────────────────────────
+// Incluye unidades campesinas colombianas (arroba = 12.5 kg, bulto, libra).
+// Las unidades de CONTEO (unidades, manojos, racimos, …) NO son peso: se
+// cuentan aparte, nunca se convierten a kg.
+
+/** Factores unidad→kg. Claves normalizadas (lowercase, sin tilde, sin plural). */
+const WEIGHT_TO_KG = {
+  kg: 1,
+  kilo: 1,
+  kilogramo: 1,
+  g: 0.001,
+  gr: 0.001,
+  gramo: 0.001,
+  mg: 0.000001,
+  t: 1000,
+  tonelada: 1000,
+  lb: 0.45359237,
+  libra: 0.45359237,
+  '@': 12.5, // arroba colombiana (agrícola) = 12.5 kg
+  arroba: 12.5,
+  quintal: 50, // quintal colombiano ≈ 50 kg (4 arrobas)
+  bulto: 50, // bulto/costal típico de café/grano ≈ 50 kg (aprox; varía)
+  carga: 125, // carga = 10 arrobas = 125 kg (café pergamino)
+};
+
+/** Unidades de conteo conocidas (no son peso). */
+const COUNT_UNITS = new Set([
+  'unidad', 'und', 'u', 'manojo', 'atado', 'racimo', 'docena', 'ciento',
+  'caja', 'canasta', 'balde', 'guacal', 'mata', 'planta', 'penca', 'cabeza',
+]);
+
+/**
+ * Normaliza el string de una unidad: lowercase, sin tildes, singular simple.
+ * @param {string} unit
+ * @returns {string}
+ */
+export const normalizeUnit = (unit) => {
+  if (!unit) return '';
+  let u = String(unit).toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').trim();
+  if (u === '@') return '@';
+  // Plural español → singular. El caso "-es" va primero para que
+  // "unidades"→"unidad" y "quintales"→"quintal" (no "unidade"/"quintale").
+  if (u.endsWith('es') && u.length > 4) u = u.slice(0, -2);
+  else if (u.endsWith('s') && u.length > 2) u = u.slice(0, -1);
+  return u;
+};
+
+/**
+ * Convierte (value, unit) a kilogramos.
+ * @param {number} value
+ * @param {string} unit
+ * @returns {{ kg: number|null, isWeight: boolean }} kg=null si es unidad de conteo.
+ */
+export const toKilograms = (value, unit) => {
+  const v = Number(value);
+  if (!Number.isFinite(v)) return { kg: null, isWeight: false };
+  const u = normalizeUnit(unit);
+  if (Object.prototype.hasOwnProperty.call(WEIGHT_TO_KG, u)) {
+    return { kg: v * WEIGHT_TO_KG[u], isWeight: true };
+  }
+  if (COUNT_UNITS.has(u)) return { kg: null, isWeight: false };
+  // Sin unidad reconocida: asumimos que ya viene en kg si measure='weight' lo
+  // dirá el caller; por defecto lo tratamos como conteo (no peso) para no
+  // inventar kilos que no existen.
+  return { kg: null, isWeight: false };
+};
+
+// ── Lectura robusta de la cantidad de un log--harvest ───────────────────────
+
+/**
+ * Extrae { value, unit, measure } de un log--harvest sin importar el shape.
+ * Soporta: quantity aplanado {value,unit}, array [{...}], y {value:{decimal}}.
+ * @param {object} log
+ * @returns {{ value:number, unit:string|null, measure:string|null }}
+ */
+export const readHarvestQuantity = (log) => {
+  let q = log?.quantity ?? log?.attributes?.quantity ?? null;
+  if (Array.isArray(q)) q = q[0] || null;
+  if (!q) return { value: 0, unit: null, measure: null };
+
+  // El valor puede estar en q.value (número o {decimal}) o en q.attributes.value.
+  const attrs = q.attributes || q;
+  let raw = attrs.value;
+  if (raw && typeof raw === 'object') raw = raw.decimal ?? raw.value ?? 0;
+  const value = Number.parseFloat(raw);
+
+  return {
+    value: Number.isFinite(value) ? value : 0,
+    unit: attrs.unit || attrs.label || null,
+    measure: attrs.measure || null,
+  };
+};
+
+/**
+ * Deriva el nombre del cultivo desde el nombre del log de cosecha.
+ * "Cosecha de Fresa Monterrey" → "Fresa Monterrey"
+ * "Cosecha: Mora - 2026-07-01" → "Mora"
+ * @param {string} name
+ * @returns {string}
+ */
+export const cropLabelFromName = (name) => {
+  if (!name) return 'Sin cultivo';
+  let s = String(name).trim();
+  s = s.replace(/^cosecha\s+de\s+/i, '');
+  s = s.replace(/^cosecha\s*:\s*/i, '');
+  s = s.replace(/^cosecha\s+/i, '');
+  // Quitar sufijo " - fecha" (ISO o d/m/a).
+  s = s.replace(/\s*[-–]\s*\d{1,4}[-/]\d{1,2}([-/]\d{1,4})?\s*$/, '');
+  return s.trim() || 'Sin cultivo';
+};
+
+/** Clave normalizada de cultivo para agrupar (lowercase, sin tildes). */
+const cropKey = (label) =>
+  String(label || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').trim();
+
+/** Convierte un timestamp de log (unix seg o ISO) a milisegundos. */
+const toMillis = (timestamp) => {
+  if (timestamp == null) return null;
+  if (typeof timestamp === 'number') {
+    // Heurística: < 1e12 se asume en segundos.
+    return timestamp < 1e12 ? timestamp * 1000 : timestamp;
+  }
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/** 'YYYY-MM' de un timestamp en ms (UTC). */
+const monthBucket = (ms) => {
+  const d = new Date(ms);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+};
+
+/**
+ * Normaliza un log--harvest a un registro plano de cosecha.
+ * @param {object} log
+ * @returns {object|null} null si no tiene cantidad utilizable.
+ */
+export const normalizeHarvestLog = (log) => {
+  if (!log) return null;
+  const { value, unit, measure } = readHarvestQuantity(log);
+  if (!(value > 0)) return null;
+  const { kg, isWeight } = toKilograms(value, unit);
+  const ms = toMillis(log.timestamp ?? log.attributes?.timestamp);
+  const label = cropLabelFromName(log.name || log.attributes?.name);
+  return {
+    id: log.id,
+    assetId: log.asset_id ?? log.relationships?.asset?.data?.[0]?.id ?? null,
+    crop: label,
+    cropKey: cropKey(label),
+    value,
+    unit: unit || null,
+    measure: measure || null,
+    kg: isWeight ? kg : null,
+    isWeight,
+    timestampMs: ms,
+    month: ms != null ? monthBucket(ms) : null,
+    status: log.status || log.attributes?.status || 'done',
+  };
+};
+
+/**
+ * Normaliza y filtra una lista de log--harvest.
+ * @param {object[]} logs
+ * @returns {object[]} registros de cosecha válidos.
+ */
+export const normalizeHarvests = (logs = []) =>
+  logs.map(normalizeHarvestLog).filter(Boolean);
+
+// ── Agregaciones ────────────────────────────────────────────────────────────
+
+const emptyBucket = () => ({
+  totalKg: 0,
+  totalCount: 0, // suma de cantidades de unidades NO-peso (unidades, manojos…)
+  harvestCount: 0, // nº de registros de cosecha
+  firstMs: null,
+  lastMs: null,
+});
+
+const foldInto = (bucket, h) => {
+  bucket.harvestCount += 1;
+  if (h.isWeight && h.kg != null) bucket.totalKg += h.kg;
+  else bucket.totalCount += h.value;
+  if (h.timestampMs != null) {
+    if (bucket.firstMs == null || h.timestampMs < bucket.firstMs) bucket.firstMs = h.timestampMs;
+    if (bucket.lastMs == null || h.timestampMs > bucket.lastMs) bucket.lastMs = h.timestampMs;
+  }
+};
+
+/**
+ * Agrega por cultivo.
+ * @param {object[]} norm - salida de normalizeHarvests.
+ * @returns {Array<{crop:string, cropKey:string, totalKg:number, totalCount:number, harvestCount:number, firstMs:number|null, lastMs:number|null}>}
+ *   ordenado por totalKg desc.
+ */
+export const aggregateByCrop = (norm = []) => {
+  const map = new Map();
+  for (const h of norm) {
+    if (!map.has(h.cropKey)) map.set(h.cropKey, { crop: h.crop, cropKey: h.cropKey, ...emptyBucket() });
+    foldInto(map.get(h.cropKey), h);
+  }
+  return Array.from(map.values()).sort((a, b) => b.totalKg - a.totalKg || b.totalCount - a.totalCount);
+};
+
+/**
+ * Agrega por asset cosechado (planta individual o land).
+ * @param {object[]} norm
+ * @returns {Array<{assetId:string, totalKg:number, totalCount:number, harvestCount:number, firstMs:number|null, lastMs:number|null}>}
+ */
+export const aggregateByAsset = (norm = []) => {
+  const map = new Map();
+  for (const h of norm) {
+    if (h.assetId == null) continue;
+    if (!map.has(h.assetId)) map.set(h.assetId, { assetId: h.assetId, ...emptyBucket() });
+    foldInto(map.get(h.assetId), h);
+  }
+  return Array.from(map.values()).sort((a, b) => b.totalKg - a.totalKg);
+};
+
+/**
+ * Mapa assetId → loteId, resolviendo parent/location de cada planta.
+ * @param {object[]} plants
+ * @returns {Map<string,string>}
+ */
+const buildPlantLoteMap = (plants = []) => {
+  const map = new Map();
+  for (const p of plants) {
+    const rel = p.relationships?.parent?.data ?? p.relationships?.location?.data;
+    const loteId = Array.isArray(rel) ? rel[0]?.id : rel?.id;
+    if (p.id && loteId) map.set(p.id, loteId);
+  }
+  return map;
+};
+
+/**
+ * Agrega por lote (era/potrero) + calcula rendimiento espacial.
+ * Suma las cosechas de las plantas cuyo parent es el lote, MÁS las cosechas
+ * cuyo asset_id es el lote directamente. Rinde kg/planta y kg/ha con el área
+ * del polígono del lote (si la tiene) y el nº de plantas asignadas.
+ *
+ * @param {object[]} norm - registros normalizados.
+ * @param {{plants?:object[], lands?:object[], areaOf?:(lote:object)=>number}} ctx
+ *   - areaOf: función para calcular área (m²) de un lote; se inyecta desde
+ *     loteService.loteAreaSqMeters para evitar acoplar este módulo a geo.
+ * @returns {Array<object>} por lote: { loteId, name, totalKg, totalCount, harvestCount, plantCount, areaM2, kgPerPlant, kgPerHa, kgPerM2 }
+ */
+export const aggregateByLote = (norm = [], ctx = {}) => {
+  const plants = ctx.plants || [];
+  const lands = ctx.lands || [];
+  const areaOf = ctx.areaOf || (() => 0);
+
+  const plantLote = buildPlantLoteMap(plants);
+  const landIds = new Set(lands.map((l) => l.id));
+  const plantCountByLote = new Map();
+  for (const loteId of plantLote.values()) {
+    plantCountByLote.set(loteId, (plantCountByLote.get(loteId) || 0) + 1);
+  }
+
+  const map = new Map();
+  const ensure = (loteId) => {
+    if (!map.has(loteId)) map.set(loteId, { loteId, ...emptyBucket() });
+    return map.get(loteId);
+  };
+
+  for (const h of norm) {
+    if (h.assetId == null) continue;
+    // La cosecha puede colgar de una planta (→ su lote) o del lote directo.
+    const loteId = plantLote.get(h.assetId) || (landIds.has(h.assetId) ? h.assetId : null);
+    if (!loteId) continue;
+    foldInto(ensure(loteId), h);
+  }
+
+  const landById = new Map(lands.map((l) => [l.id, l]));
+  return Array.from(map.values()).map((b) => {
+    const lote = landById.get(b.loteId) || null;
+    const areaM2 = lote ? areaOf(lote) : 0;
+    const plantCount = plantCountByLote.get(b.loteId) || 0;
+    return {
+      ...b,
+      name: lote?.attributes?.name || lote?.name || 'Lote',
+      plantCount,
+      areaM2,
+      kgPerPlant: plantCount > 0 ? b.totalKg / plantCount : null,
+      kgPerHa: areaM2 > 0 ? b.totalKg / (areaM2 / 10000) : null,
+      kgPerM2: areaM2 > 0 ? b.totalKg / areaM2 : null,
+    };
+  }).sort((a, b) => b.totalKg - a.totalKg);
+};
+
+/**
+ * Rendimiento kg/planta por cultivo (total kg del cultivo / nº de plantas de
+ * ese cultivo). Empareja por nombre de especie del asset con el cultivo del log.
+ *
+ * @param {object[]} norm
+ * @param {object[]} plants
+ * @returns {Array<{crop:string, totalKg:number, plantCount:number, kgPerPlant:number|null}>}
+ */
+export const yieldPerPlantByCrop = (norm = [], plants = []) => {
+  const byCrop = aggregateByCrop(norm);
+  // Contar plantas por cultivo (clave normalizada del nombre del asset).
+  const plantCountByCrop = new Map();
+  for (const p of plants) {
+    const k = cropKey(p.attributes?.name || p.name);
+    if (!k) continue;
+    plantCountByCrop.set(k, (plantCountByCrop.get(k) || 0) + 1);
+  }
+  return byCrop.map((c) => {
+    // match laxo: el cultivo del log incluye o coincide con el nombre de la planta.
+    let plantCount = plantCountByCrop.get(c.cropKey) || 0;
+    if (plantCount === 0) {
+      for (const [pk, count] of plantCountByCrop) {
+        if (pk.includes(c.cropKey) || c.cropKey.includes(pk)) { plantCount += count; }
+      }
+    }
+    return {
+      crop: c.crop,
+      totalKg: c.totalKg,
+      plantCount,
+      kgPerPlant: plantCount > 0 ? c.totalKg / plantCount : null,
+    };
+  });
+};
+
+// ── Tendencia temporal ──────────────────────────────────────────────────────
+
+/** Pendiente de mínimos cuadrados de una serie y[] (x = índice). */
+const leastSquaresSlope = (ys) => {
+  const n = ys.length;
+  if (n < 2) return 0;
+  let sx = 0, sy = 0, sxy = 0, sxx = 0;
+  for (let i = 0; i < n; i += 1) {
+    sx += i; sy += ys[i]; sxy += i * ys[i]; sxx += i * i;
+  }
+  const denom = n * sxx - sx * sx;
+  if (denom === 0) return 0;
+  return (n * sxy - sx * sy) / denom;
+};
+
+/**
+ * Serie temporal de cosecha por mes + dirección de la tendencia.
+ * @param {object[]} norm
+ * @returns {{ series: Array<{period:string, totalKg:number, totalCount:number, harvestCount:number}>, slope:number, direction:'subiendo'|'bajando'|'estable' }}
+ */
+export const temporalTrend = (norm = []) => {
+  const map = new Map();
+  for (const h of norm) {
+    if (!h.month) continue;
+    if (!map.has(h.month)) map.set(h.month, { period: h.month, ...emptyBucket() });
+    foldInto(map.get(h.month), h);
+  }
+  const series = Array.from(map.values())
+    .map(({ period, totalKg, totalCount, harvestCount }) => ({ period, totalKg, totalCount, harvestCount }))
+    .sort((a, b) => a.period.localeCompare(b.period));
+
+  const useKg = series.some((s) => s.totalKg > 0);
+  const ys = series.map((s) => (useKg ? s.totalKg : s.totalCount));
+  const slope = leastSquaresSlope(ys);
+  const magnitude = ys.length ? Math.max(...ys) : 0;
+  // Umbral relativo para no marcar tendencia por ruido mínimo.
+  const eps = magnitude * 0.05;
+  /** @type {'subiendo'|'bajando'|'estable'} */
+  let direction = 'estable';
+  if (slope > eps) direction = 'subiendo';
+  else if (slope < -eps) direction = 'bajando';
+  return { series, slope, direction };
+};
+
+// ── Resumen compuesto (lo que la vista pinta) ───────────────────────────────
+
+/**
+ * Resumen completo de "Mi cosecha" a partir de los log--harvest.
+ * @param {object[]} logs - log--harvest crudos (de logCache.getByType).
+ * @param {{plants?:object[], lands?:object[], areaOf?:(lote:object)=>number}} ctx
+ * @returns {object} { totalKg, totalHarvests, cropCount, byCrop, byLote, yieldPerPlant, trend, topCrop, dateRange }
+ */
+export const harvestSummary = (logs = [], ctx = {}) => {
+  const norm = normalizeHarvests(logs);
+  const byCrop = aggregateByCrop(norm);
+  const byLote = aggregateByLote(norm, ctx);
+  const yieldPerPlant = yieldPerPlantByCrop(norm, ctx.plants || []);
+  const trend = temporalTrend(norm);
+
+  const totalKg = norm.reduce((acc, h) => acc + (h.kg || 0), 0);
+  const allMs = norm.map((h) => h.timestampMs).filter((m) => m != null);
+
+  return {
+    totalKg,
+    totalHarvests: norm.length,
+    cropCount: byCrop.length,
+    byCrop,
+    byLote,
+    yieldPerPlant,
+    trend,
+    topCrop: byCrop[0] || null,
+    dateRange: allMs.length
+      ? { firstMs: Math.min(...allMs), lastMs: Math.max(...allMs) }
+      : { firstMs: null, lastMs: null },
+  };
+};
+
+export default {
+  HARVEST_LOG_TYPE,
+  normalizeUnit,
+  toKilograms,
+  readHarvestQuantity,
+  cropLabelFromName,
+  normalizeHarvestLog,
+  normalizeHarvests,
+  aggregateByCrop,
+  aggregateByAsset,
+  aggregateByLote,
+  yieldPerPlantByCrop,
+  temporalTrend,
+  harvestSummary,
+};

--- a/src/services/loteService.js
+++ b/src/services/loteService.js
@@ -1,0 +1,454 @@
+/**
+ * loteService.js — CAPA DE DATOS del croquis de la finca (lotes dibujables).
+ *
+ * FEATURE "Croquis / mapa de la finca": el campesino DIBUJA sus lotes, eras y
+ * potreros (polígonos o puntos), les pone nombre y tipo, y les asigna cultivos
+ * o animales. Esta capa expone una API limpia para que la vista (canvas de
+ * Fable) solo pinte — NO decide dónde ni cómo se persiste.
+ *
+ * ── Modelo de datos (grounded en farmOS, sin backend nuevo) ─────────────────
+ * Un "lote" ES un `asset--land` de farmOS (mismo tipo que ya lee FarmMap.jsx):
+ *
+ *   asset--land {
+ *     attributes: {
+ *       name,                         // "Potrero de abajo", "Era de cilantro"
+ *       status: 'active',
+ *       land_type,                    // field | bed | greenhouse | paddock | …
+ *                                     //   (fuente: utils/landTypes.LAND_TYPES)
+ *       intrinsic_geometry: { value },// WKT — POLYGON((lon lat, …)) o POINT(lon lat)
+ *       notes: { value } | string,    // texto libre opcional
+ *     },
+ *     relationships: {
+ *       location: { data: [{ type:'asset--land', id: parentLandId }] },
+ *       parent:   { data: [{ type:'asset--land', id: parentLandId }] },
+ *     }
+ *   }
+ *
+ * Los cultivos/animales de un lote NO son un campo del lote: son `asset--plant`
+ * / `asset--animal` cuyo `parent`/`location` apunta al id del lote (jerarquía
+ * espacial canónica de farmOS — exactamente lo que FarmMap ya filtra por zona).
+ * Así el mismo dato sirve al mapa, a la ficha del lote y al rendimiento (kg/era).
+ *
+ * ── Offline-first ───────────────────────────────────────────────────────────
+ * Toda escritura pasa por `useAssetStore` (commit atómico IndexedDB + encolado
+ * en `pending_transactions`), así que sobrevive sin red y sincroniza a farmOS
+ * cuando vuelve la conexión. Mismo patrón que el resto de assets.
+ */
+
+import { assetCache } from '../db/assetCache';
+import useAssetStore from '../store/useAssetStore';
+import { LAND_TYPES, isUrbanLandType } from '../utils/landTypes';
+import {
+  geoJsonToWkt,
+  wktToGeoJson,
+  latLngToPoint,
+  latLngsToPolygon,
+  polygonAreaSqMeters,
+} from '../utils/geo';
+
+/** Tipo de asset farmOS que respalda un lote. */
+export const LOTE_ASSET_TYPE = 'land';
+
+/** Catálogo de tipos de lote reutilizable por la vista (re-export). */
+export { LAND_TYPES, isUrbanLandType };
+
+/** Id del land raíz de la finca (parent por defecto de un lote nuevo). */
+const DEFAULT_PARENT_LAND_ID = 'farmos-alpha-location-01';
+
+/** Tipos de asset que `useAssetStore` refleja en memoria (buckets). */
+const STORE_TRACKED_TYPES = new Set(['plant', 'structure', 'equipment', 'material', 'land']);
+
+// ── Helpers de geometría ────────────────────────────────────────────────────
+
+/**
+ * Construye una geometría GeoJSON a partir de lo que dibujó el usuario.
+ *
+ * @param {{ mode:'polygon'|'point', latlngs?:Array<{lat:number,lng:number}>, point?:{lat:number,lng:number} }} draft
+ * @returns {{type:string, coordinates:any}|null} GeoJSON o null si el trazo es inválido.
+ */
+export const geometryFromDraft = (draft) => {
+  if (!draft || !draft.mode) return null;
+  if (draft.mode === 'point') {
+    const p = draft.point || (draft.latlngs && draft.latlngs[0]);
+    if (!p || !Number.isFinite(p.lat) || !Number.isFinite(p.lng)) return null;
+    return latLngToPoint(p);
+  }
+  if (draft.mode === 'polygon') {
+    const pts = (draft.latlngs || []).filter((p) => p && Number.isFinite(p.lat) && Number.isFinite(p.lng));
+    if (pts.length < 3) return null; // un polígono necesita ≥3 vértices
+    return latLngsToPolygon(pts);
+  }
+  return null;
+};
+
+/** Extrae el WKT crudo de un lote (soporta string u objeto {value}). */
+export const wktOf = (lote) => {
+  const geo = lote?.attributes?.intrinsic_geometry;
+  if (!geo) return null;
+  return typeof geo === 'string' ? geo : geo.value || null;
+};
+
+/** GeoJSON de la geometría del lote, o null. */
+export const loteGeoJson = (lote) => {
+  const wkt = wktOf(lote);
+  return wkt ? wktToGeoJson(wkt) : null;
+};
+
+/** Convierte un anillo GeoJSON [[lon,lat],…] a vértices {lat,lng}. */
+const ringToLatLng = (ring) => (ring || []).map(([lon, lat]) => ({ lat, lng: lon }));
+
+/**
+ * Área del lote en metros cuadrados (0 si es un punto o no tiene polígono).
+ * @param {object} lote
+ * @returns {number}
+ */
+export const loteAreaSqMeters = (lote) => {
+  const geo = loteGeoJson(lote);
+  if (!geo || geo.type !== 'Polygon') return 0;
+  return polygonAreaSqMeters(ringToLatLng(geo.coordinates[0]));
+};
+
+/** Área del lote en hectáreas (1 ha = 10.000 m²). */
+export const loteAreaHectares = (lote) => loteAreaSqMeters(lote) / 10000;
+
+/**
+ * Centroide del lote {lat,lng} para colocar la etiqueta/pin, o null.
+ * Para un polígono es el promedio de sus vértices; para un punto, el punto.
+ * @param {object} lote
+ * @returns {{lat:number,lng:number}|null}
+ */
+export const loteCentroid = (lote) => {
+  const geo = loteGeoJson(lote);
+  if (!geo) return null;
+  if (geo.type === 'Point') {
+    const [lng, lat] = geo.coordinates;
+    return { lat, lng };
+  }
+  if (geo.type === 'Polygon') {
+    const ring = ringToLatLng(geo.coordinates[0]);
+    if (ring.length === 0) return null;
+    // No promediar el vértice de cierre duplicado si existe.
+    const closed = ring.length > 1
+      && ring[0].lat === ring[ring.length - 1].lat
+      && ring[0].lng === ring[ring.length - 1].lng;
+    const pts = closed ? ring.slice(0, -1) : ring;
+    const sum = pts.reduce((acc, p) => ({ lat: acc.lat + p.lat, lng: acc.lng + p.lng }), { lat: 0, lng: 0 });
+    return { lat: sum.lat / pts.length, lng: sum.lng / pts.length };
+  }
+  return null;
+};
+
+// ── Validación ──────────────────────────────────────────────────────────────
+
+/**
+ * Valida los datos de un lote antes de persistir.
+ * @param {{name?:string, landType?:string, geometry?:object}} input
+ * @returns {{valid:boolean, errors:Record<string,string>}}
+ */
+export const validateLoteInput = (input = {}) => {
+  /** @type {Record<string, string>} */
+  const errors = {};
+  if (!input.name || !input.name.trim()) errors.name = 'Ponle un nombre al lote';
+  if (input.landType && !LAND_TYPES.some((t) => t.value === input.landType)) {
+    errors.landType = 'Tipo de lote no reconocido';
+  }
+  // La geometría es opcional para zonas urbanas (un balcón no tiene contorno),
+  // pero si viene, debe ser serializable a WKT.
+  if (input.geometry && !geoJsonToWkt(input.geometry)) {
+    errors.geometry = 'La geometría dibujada no es válida';
+  }
+  return { valid: Object.keys(errors).length === 0, errors };
+};
+
+// ── Construcción de payload farmOS ──────────────────────────────────────────
+
+const normalizeNotes = (notes) => {
+  if (!notes) return undefined;
+  if (typeof notes === 'string') return notes.trim() ? { value: notes.trim() } : undefined;
+  if (notes.value && String(notes.value).trim()) return { value: String(notes.value).trim() };
+  return undefined;
+};
+
+/**
+ * Construye el asset--land optimista + su pending_transaction (POST) a farmOS.
+ *
+ * @param {object} input
+ * @param {string} input.name
+ * @param {string} [input.landType='field']
+ * @param {object} [input.geometry] - GeoJSON (Polygon/Point).
+ * @param {string|{value:string}} [input.notes]
+ * @param {string} [input.parentLandId]
+ * @param {string} [input.id] - fuerza un id (tests / idempotencia). Default UUID.
+ * @returns {{ asset: object, pendingTx: object }}
+ */
+export const buildLotePayload = (input) => {
+  const id = input.id || crypto.randomUUID();
+  const landType = input.landType || 'field';
+  const parentLandId = input.parentLandId || DEFAULT_PARENT_LAND_ID;
+
+  /** @type {Record<string, any>} */
+  const attributes = {
+    name: input.name.trim(),
+    status: 'active',
+    land_type: landType,
+  };
+  const notes = normalizeNotes(input.notes);
+  if (notes) attributes.notes = notes;
+  if (input.geometry) {
+    const wkt = geoJsonToWkt(input.geometry);
+    if (wkt) attributes.intrinsic_geometry = { value: wkt };
+  }
+
+  const relationships = {
+    location: { data: [{ type: 'asset--land', id: parentLandId }] },
+    parent: { data: [{ type: 'asset--land', id: parentLandId }] },
+  };
+
+  const asset = {
+    id,
+    type: 'asset--land',
+    attributes,
+    relationships,
+    _pending: true,
+    _createdAt: Date.now(),
+  };
+
+  const pendingTx = {
+    id,
+    type: 'asset_land',
+    endpoint: '/api/asset/land',
+    payload: { data: { type: 'asset--land', id, attributes, relationships } },
+    method: 'POST',
+  };
+
+  return { asset, pendingTx };
+};
+
+// ── CRUD ────────────────────────────────────────────────────────────────────
+
+/**
+ * Crea un lote (asset--land) offline-first. Refleja en `useAssetStore.lands`
+ * (→ el mapa lo dibuja al instante) y encola el POST a farmOS.
+ *
+ * @param {object} input - ver buildLotePayload.
+ * @returns {Promise<object>} el asset--land creado (optimista).
+ */
+export const createLote = async (input) => {
+  const { valid, errors } = validateLoteInput(input);
+  if (!valid) {
+    const err = /** @type {Error & { validation?: Record<string, string> }} */ (
+      new Error(Object.values(errors)[0] || 'Datos de lote inválidos')
+    );
+    err.validation = errors;
+    throw err;
+  }
+  const { asset, pendingTx } = buildLotePayload(input);
+  await useAssetStore.getState().addAsset(LOTE_ASSET_TYPE, asset, [pendingTx]);
+  return asset;
+};
+
+/**
+ * Actualiza campos de un lote existente (nombre, tipo, geometría, notas).
+ * Fusiona sobre el asset actual y encola un PATCH.
+ *
+ * @param {string} loteId
+ * @param {{name?:string, landType?:string, geometry?:object, notes?:string|{value:string}}} patch
+ * @returns {Promise<object>} el asset--land actualizado (optimista).
+ */
+export const updateLote = async (loteId, patch = {}) => {
+  const current = await assetCache.getAsset(loteId);
+  if (!current) throw new Error('Lote no encontrado');
+
+  const attributes = { ...(current.attributes || {}) };
+  if (patch.name !== undefined) attributes.name = String(patch.name).trim();
+  if (patch.landType !== undefined) attributes.land_type = patch.landType;
+  if (patch.notes !== undefined) {
+    const n = normalizeNotes(patch.notes);
+    if (n) attributes.notes = n; else delete attributes.notes;
+  }
+  if (patch.geometry !== undefined) {
+    if (patch.geometry === null) {
+      delete attributes.intrinsic_geometry;
+    } else {
+      const wkt = geoJsonToWkt(patch.geometry);
+      if (wkt) attributes.intrinsic_geometry = { value: wkt };
+    }
+  }
+
+  const updated = {
+    ...current,
+    type: current.type || 'asset--land',
+    attributes,
+    _pending: true,
+  };
+
+  const pendingTx = {
+    id: crypto.randomUUID(),
+    type: 'asset_land',
+    remoteId: loteId,
+    endpoint: `/api/asset/land/${loteId}`,
+    method: 'PATCH',
+    payload: { data: { type: 'asset--land', id: loteId, attributes } },
+  };
+
+  await useAssetStore.getState().updateAsset(LOTE_ASSET_TYPE, updated, [pendingTx]);
+  return updated;
+};
+
+/**
+ * Elimina un lote (borrado local + DELETE encolado). No borra en cascada los
+ * cultivos/animales que apuntaban a él — quedan "sin lote" hasta reasignarse.
+ * @param {string} loteId
+ * @returns {Promise<void>}
+ */
+export const deleteLote = async (loteId) => {
+  await useAssetStore.getState().removeAsset(LOTE_ASSET_TYPE, loteId);
+};
+
+/**
+ * Lista todos los lotes (asset--land) desde IndexedDB, scoped al tenant activo.
+ * @returns {Promise<object[]>}
+ */
+export const listLotes = async () => assetCache.getByType(LOTE_ASSET_TYPE);
+
+/**
+ * Obtiene un lote por id (o null si no existe o no es un land).
+ * @param {string} loteId
+ * @returns {Promise<object|null>}
+ */
+export const getLote = async (loteId) => {
+  const asset = await assetCache.getAsset(loteId);
+  if (!asset) return null;
+  const t = asset.asset_type || asset.type;
+  if (t !== 'land' && t !== 'asset--land') return null;
+  return asset;
+};
+
+// ── Cultivos / animales dentro de un lote ───────────────────────────────────
+
+/** id del land padre de un asset (parent, con fallback a location). */
+export const parentLandIdOf = (asset) => {
+  const rel = asset?.relationships?.parent?.data ?? asset?.relationships?.location?.data;
+  if (Array.isArray(rel)) return rel[0]?.id || null;
+  return rel?.id || null;
+};
+
+/**
+ * Deriva los cultivos/animales que "viven" en un lote: assets cuyo parent
+ * (o location) apunta al id del lote. Selector PURO — no toca IndexedDB.
+ *
+ * @param {string} loteId
+ * @param {{plants?:object[], animals?:object[]}} pools
+ * @returns {{plants:object[], animals:object[]}}
+ */
+export const getLoteContents = (loteId, pools = {}) => {
+  const inLote = (a) => parentLandIdOf(a) === loteId;
+  return {
+    plants: (pools.plants || []).filter(inLote),
+    animals: (pools.animals || []).filter(inLote),
+  };
+};
+
+/**
+ * Resumen de un lote para pintar su ficha/etiqueta.
+ * @param {object} lote
+ * @param {{plants:object[], animals:object[]}} contents - salida de getLoteContents.
+ * @returns {{name:string, landType:string, areaM2:number, areaHa:number, cropCount:number, animalCount:number, species:string[], centroid:{lat:number,lng:number}|null, hasGeometry:boolean}}
+ */
+export const summarizeLote = (lote, contents = { plants: [], animals: [] }) => {
+  const areaM2 = loteAreaSqMeters(lote);
+  const species = Array.from(new Set(
+    (contents.plants || [])
+      .map((p) => p.attributes?.name || p.name)
+      .filter(Boolean)
+  ));
+  return {
+    name: lote?.attributes?.name || lote?.name || 'Lote sin nombre',
+    landType: lote?.attributes?.land_type || 'field',
+    areaM2,
+    areaHa: areaM2 / 10000,
+    cropCount: (contents.plants || []).length,
+    animalCount: (contents.animals || []).length,
+    species,
+    centroid: loteCentroid(lote),
+    hasGeometry: !!wktOf(lote),
+  };
+};
+
+/**
+ * Asigna un cultivo/animal EXISTENTE a un lote: fija su `location`+`parent` al
+ * id del lote y encola el PATCH. Es la operación canónica de "meter" un asset
+ * en una zona (lo mismo que hace el drill-down por zona del mapa).
+ *
+ * @param {object} params
+ * @param {string} params.assetType - 'plant' | 'animal' | 'structure' | …
+ * @param {object} params.asset - el asset a mover (shape del store/IDB).
+ * @param {string} params.loteId - id del asset--land destino.
+ * @returns {Promise<object>} el asset actualizado (optimista).
+ */
+export const assignAssetToLote = async ({ assetType, asset, loteId }) => {
+  if (!asset?.id) throw new Error('assignAssetToLote requiere un asset con id');
+  if (!loteId) throw new Error('assignAssetToLote requiere un loteId');
+
+  const rel = { data: [{ type: 'asset--land', id: loteId }] };
+  const updated = {
+    ...asset,
+    relationships: {
+      ...(asset.relationships || {}),
+      location: rel,
+      parent: rel,
+    },
+    _pending: true,
+  };
+
+  const bundle = (asset.type || `asset--${assetType}`).replace('asset--', '');
+  const pendingTx = {
+    id: crypto.randomUUID(),
+    type: `asset_${assetType}`,
+    remoteId: asset.id,
+    endpoint: `/api/asset/${bundle}/${asset.id}`,
+    method: 'PATCH',
+    payload: {
+      data: {
+        type: asset.type || `asset--${assetType}`,
+        id: asset.id,
+        relationships: { location: rel, parent: rel },
+      },
+    },
+  };
+
+  if (STORE_TRACKED_TYPES.has(assetType)) {
+    await useAssetStore.getState().updateAsset(assetType, updated, [pendingTx]);
+  } else {
+    // Tipos que el store no refleja en memoria (p. ej. asset--animal): commit
+    // directo a IndexedDB + encolado, sin pasar por un bucket de Zustand.
+    await assetCache.commitOptimisticUpdate([{ assetType, asset: updated }], [pendingTx]);
+    if (typeof navigator !== 'undefined') {
+      navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });
+    }
+  }
+  return updated;
+};
+
+export default {
+  LOTE_ASSET_TYPE,
+  LAND_TYPES,
+  isUrbanLandType,
+  geometryFromDraft,
+  wktOf,
+  loteGeoJson,
+  loteAreaSqMeters,
+  loteAreaHectares,
+  loteCentroid,
+  validateLoteInput,
+  buildLotePayload,
+  createLote,
+  updateLote,
+  deleteLote,
+  listLotes,
+  getLote,
+  parentLandIdOf,
+  getLoteContents,
+  summarizeLote,
+  assignAssetToLote,
+};

--- a/src/store/__tests__/useCosechaStore.test.js
+++ b/src/store/__tests__/useCosechaStore.test.js
@@ -1,0 +1,69 @@
+/**
+ * useCosechaStore — carga los log--harvest de IndexedDB y calcula el resumen.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { openDB, STORES } from '../../db/dbCore';
+import { _resetForTests } from '../../services/tenantContext';
+import { logCache } from '../../db/logCache';
+import useAssetStore from '../useAssetStore';
+import useCosechaStore from '../useCosechaStore';
+
+const clearStore = async (name) => {
+  const db = await openDB();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction(name, 'readwrite');
+    tx.objectStore(name).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+};
+
+const harvestLog = (id, assetId, name, value, ts) => ({
+  id,
+  type: 'log--harvest',
+  asset_id: assetId,
+  name,
+  timestamp: ts,
+  status: 'done',
+  quantity: { value, unit: 'Kilogramos', measure: 'weight' },
+});
+
+beforeEach(async () => {
+  _resetForTests();
+  await clearStore(STORES.LOGS);
+  useAssetStore.setState({ plants: [], lands: [], isHydrated: true });
+  useCosechaStore.getState().reset();
+});
+
+describe('loadHarvests', () => {
+  it('agrega los log--harvest desde IndexedDB', async () => {
+    await logCache.put(harvestLog('h1', 'p1', 'Cosecha de Fresa', 4, Math.floor(Date.parse('2026-06-01T00:00:00Z') / 1000)));
+    await logCache.put(harvestLog('h2', 'p1', 'Cosecha de Fresa', 6, Math.floor(Date.parse('2026-07-01T00:00:00Z') / 1000)));
+    useAssetStore.setState({
+      plants: [{ id: 'p1', attributes: { name: 'Fresa' }, relationships: { parent: { data: [{ id: 'lote1' }] } } }],
+      lands: [{ id: 'lote1', attributes: { name: 'Era 1' } }],
+    });
+
+    const summary = await useCosechaStore.getState().loadHarvests();
+    expect(summary.totalKg).toBe(10);
+    expect(summary.totalHarvests).toBe(2);
+    expect(summary.topCrop.crop).toBe('Fresa');
+    expect(summary.byLote[0].loteId).toBe('lote1');
+    expect(useCosechaStore.getState().summary).toBe(summary);
+    expect(useCosechaStore.getState().lastComputedAt).toBeTruthy();
+  });
+
+  it('resumen vacío cuando no hay cosechas', async () => {
+    const summary = await useCosechaStore.getState().loadHarvests();
+    expect(summary.totalHarvests).toBe(0);
+    expect(summary.topCrop).toBeNull();
+  });
+
+  it('computeFrom agrega logs ya en memoria sin tocar IDB', () => {
+    const summary = useCosechaStore.getState().computeFrom([
+      harvestLog('h1', 'p1', 'Cosecha de Mora', 3, 1),
+    ]);
+    expect(summary.totalKg).toBe(3);
+    expect(summary.topCrop.crop).toBe('Mora');
+  });
+});

--- a/src/store/__tests__/useLoteStore.test.js
+++ b/src/store/__tests__/useLoteStore.test.js
@@ -1,0 +1,91 @@
+/**
+ * useLoteStore — estado de interacción del croquis (draft + orquestación CRUD).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { openDB, STORES } from '../../db/dbCore';
+import { _resetForTests } from '../../services/tenantContext';
+import useAssetStore from '../useAssetStore';
+import useLoteStore from '../useLoteStore';
+
+const SQUARE = [
+  { lat: 4.5306, lng: -73.9247 },
+  { lat: 4.5316, lng: -73.9247 },
+  { lat: 4.5316, lng: -73.9237 },
+];
+
+const clearStore = async (name) => {
+  const db = await openDB();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction(name, 'readwrite');
+    tx.objectStore(name).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+};
+
+beforeEach(async () => {
+  _resetForTests();
+  await clearStore(STORES.ASSETS);
+  await clearStore(STORES.PENDING_TX);
+  useAssetStore.setState({
+    plants: [], structures: [], equipment: [], materials: [], lands: [],
+    isHydrated: true, error: null,
+  });
+  useLoteStore.setState({ drawMode: null, draftLatLngs: [], draftPoint: null, selectedLoteId: null, editingLoteId: null, error: null, isSaving: false });
+});
+
+describe('dibujo en curso (draft)', () => {
+  it('acumula vértices y produce un Polygon válido', () => {
+    const s = useLoteStore.getState();
+    s.setDrawMode('polygon');
+    SQUARE.forEach((v) => useLoteStore.getState().addDraftVertex(v));
+    expect(useLoteStore.getState().draftLatLngs).toHaveLength(3);
+    const geo = useLoteStore.getState().getDraftGeometry();
+    expect(geo.type).toBe('Polygon');
+  });
+
+  it('en modo point fija un único punto', () => {
+    useLoteStore.getState().setDrawMode('point');
+    useLoteStore.getState().addDraftVertex({ lat: 4.53, lng: -73.92 });
+    useLoteStore.getState().addDraftVertex({ lat: 4.54, lng: -73.93 });
+    expect(useLoteStore.getState().draftPoint).toEqual({ lat: 4.54, lng: -73.93 });
+    expect(useLoteStore.getState().getDraftGeometry()).toEqual({ type: 'Point', coordinates: [-73.93, 4.54] });
+  });
+
+  it('removeLastVertex y clearDraft', () => {
+    useLoteStore.getState().setDrawMode('polygon');
+    SQUARE.forEach((v) => useLoteStore.getState().addDraftVertex(v));
+    useLoteStore.getState().removeLastVertex();
+    expect(useLoteStore.getState().draftLatLngs).toHaveLength(2);
+    useLoteStore.getState().clearDraft();
+    expect(useLoteStore.getState().drawMode).toBeNull();
+    expect(useLoteStore.getState().draftLatLngs).toEqual([]);
+  });
+});
+
+describe('saveDraftAsLote', () => {
+  it('persiste el trazo y espeja en lotes + limpia el draft', async () => {
+    useLoteStore.getState().setDrawMode('polygon');
+    SQUARE.forEach((v) => useLoteStore.getState().addDraftVertex(v));
+
+    const lote = await useLoteStore.getState().saveDraftAsLote({ name: 'Lote dibujado', landType: 'field' });
+    expect(lote).toBeTruthy();
+    expect(lote.attributes.name).toBe('Lote dibujado');
+
+    // fuente de verdad
+    expect(useAssetStore.getState().lands.some((l) => l.id === lote.id)).toBe(true);
+    // espejo reactivo
+    expect(useLoteStore.getState().lotes.some((l) => l.id === lote.id)).toBe(true);
+    // draft limpio + selección
+    expect(useLoteStore.getState().drawMode).toBeNull();
+    expect(useLoteStore.getState().selectedLoteId).toBe(lote.id);
+  });
+
+  it('setea error si falta el nombre', async () => {
+    useLoteStore.getState().setDrawMode('polygon');
+    SQUARE.forEach((v) => useLoteStore.getState().addDraftVertex(v));
+    const res = await useLoteStore.getState().saveDraftAsLote({ name: '' });
+    expect(res).toBeNull();
+    expect(useLoteStore.getState().error).toBeTruthy();
+  });
+});

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -14,6 +14,29 @@ import { MSG } from '../config/messages';
 /** @typedef {import('../types').ChagraSpecies} ChagraSpecies */
 /** @typedef {import('../types').ChagraBiopreparado} ChagraBiopreparado */
 
+// Mapa canónico assetType → clave del estado en memoria. Incluir `land`
+// (Fase 17 / croquis de lotes): antes el fallback mandaba `land` al bucket
+// `materials`, así que un lote creado de forma optimista NO aparecía en
+// `lands` (ni en el mapa) hasta un re-hydrate desde IndexedDB. Ese re-hydrate
+// SÍ lo colocaba bien porque `commitOptimisticUpdate` persiste con el
+// `asset_type` correcto — el bug era solo en el reflejo en memoria. Ver
+// services/loteService.js, que apoya el CRUD de lotes en estas acciones.
+const ASSET_BUCKET = {
+  plant: 'plants',
+  structure: 'structures',
+  equipment: 'equipment',
+  material: 'materials',
+  land: 'lands',
+};
+
+/**
+ * Resuelve la clave del store para un assetType. Fallback conservador a
+ * `materials` para tipos desconocidos (comportamiento histórico).
+ * @param {string} assetType
+ * @returns {'plants'|'structures'|'equipment'|'materials'|'lands'}
+ */
+const bucketKey = (assetType) => ASSET_BUCKET[assetType] || 'materials';
+
 /**
  * Store global de Activos (Zustand)
  * Patrón Offline-First: memoria (Zustand) ← IndexedDB ← FarmOS API
@@ -248,10 +271,7 @@ const useAssetStore = create((set, get) => ({
     try {
       await assetCache.commitOptimisticUpdate([{ assetType, asset }], pendingTxs);
       set((state) => {
-        const key = assetType === 'plant' ? 'plants'
-          : assetType === 'structure' ? 'structures'
-            : assetType === 'equipment' ? 'equipment'
-              : 'materials';
+        const key = bucketKey(assetType);
         return { [key]: [...state[key], asset] };
       });
       // emptyDbDetector: huella para post-clear-cache detection.
@@ -287,10 +307,7 @@ const useAssetStore = create((set, get) => ({
       const updates = assets.map((asset) => ({ assetType, asset }));
       await assetCache.commitOptimisticUpdate(updates, pendingTxs);
       set((state) => {
-        const key = assetType === 'plant' ? 'plants'
-          : assetType === 'structure' ? 'structures'
-            : assetType === 'equipment' ? 'equipment'
-              : 'materials';
+        const key = bucketKey(assetType);
         return { [key]: [...state[key], ...assets] };
       });
       navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });
@@ -305,10 +322,7 @@ const useAssetStore = create((set, get) => ({
     try {
       await assetCache.commitOptimisticUpdate([{ assetType, asset }], pendingTxs);
       set((state) => {
-        const key = assetType === 'plant' ? 'plants'
-          : assetType === 'structure' ? 'structures'
-            : assetType === 'equipment' ? 'equipment'
-              : 'materials';
+        const key = bucketKey(assetType);
         return { [key]: state[key].map((a) => a.id === asset.id ? asset : a) };
       });
       navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });
@@ -347,10 +361,7 @@ const useAssetStore = create((set, get) => ({
       });
 
       set((state) => {
-        const key = assetType === 'plant' ? 'plants'
-          : assetType === 'structure' ? 'structures'
-            : assetType === 'equipment' ? 'equipment'
-              : 'materials';
+        const key = bucketKey(assetType);
         return { [key]: state[key].filter((a) => a.id !== assetId) };
       });
       navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });

--- a/src/store/useCosechaStore.js
+++ b/src/store/useCosechaStore.js
@@ -1,0 +1,68 @@
+import { create } from 'zustand';
+import { logCache } from '../db/logCache';
+import useAssetStore from './useAssetStore';
+import { harvestSummary, HARVEST_LOG_TYPE } from '../services/cosechaService';
+import { loteAreaSqMeters } from '../services/loteService';
+
+/**
+ * useCosechaStore — estado reactivo de "Mi cosecha". Carga los `log--harvest`
+ * desde IndexedDB (offline-first) y expone el `summary` ya agregado por
+ * cosechaService para que la vista de Fable solo pinte.
+ *
+ * Fuente de verdad: los logs viven en `logCache`; las plantas/lotes en
+ * `useAssetStore`. Este store no persiste nada — solo lee y agrega.
+ */
+const useCosechaStore = create((set) => ({
+  /** Resumen agregado (ver cosechaService.harvestSummary) o null si no cargado. */
+  summary: null,
+  isLoading: false,
+  error: null,
+  lastComputedAt: null,
+
+  /**
+   * Carga los log--harvest desde IndexedDB y recalcula el resumen usando las
+   * plantas/lotes actuales del store de assets.
+   * @returns {Promise<object|null>} el summary calculado.
+   */
+  loadHarvests: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const logs = await logCache.getByType(HARVEST_LOG_TYPE);
+      const { plants, lands } = useAssetStore.getState();
+      const summary = harvestSummary(logs, {
+        plants,
+        lands,
+        areaOf: loteAreaSqMeters,
+      });
+      set({ summary, isLoading: false, lastComputedAt: Date.now() });
+      return summary;
+    } catch (err) {
+      set({ isLoading: false, error: err.message || 'No se pudieron cargar las cosechas' });
+      return null;
+    }
+  },
+
+  /**
+   * Recalcula el resumen a partir de una lista de logs ya en memoria (evita
+   * el round-trip a IndexedDB cuando el caller ya los tiene).
+   * @param {object[]} logs
+   */
+  computeFrom: (logs) => {
+    const { plants, lands } = useAssetStore.getState();
+    const summary = harvestSummary(logs || [], { plants, lands, areaOf: loteAreaSqMeters });
+    set({ summary, lastComputedAt: Date.now() });
+    return summary;
+  },
+
+  reset: () => set({ summary: null, isLoading: false, error: null, lastComputedAt: null }),
+}));
+
+// Al cambiar de finca (tenant), invalidar el resumen: los logs del tenant
+// anterior no deben quedar cacheados en memoria.
+if (typeof window !== 'undefined') {
+  window.addEventListener('tenantChanged', () => {
+    useCosechaStore.getState().reset();
+  });
+}
+
+export default useCosechaStore;

--- a/src/store/useLoteStore.js
+++ b/src/store/useLoteStore.js
@@ -1,0 +1,180 @@
+import { create } from 'zustand';
+import useAssetStore from './useAssetStore';
+import * as loteService from '../services/loteService';
+
+/**
+ * useLoteStore — estado de INTERACCIÓN del croquis de lotes (Feature "Croquis /
+ * mapa de la finca"). Es la fachada que el canvas de Fable consume.
+ *
+ * Responsabilidades:
+ *   1. Estado efímero del DIBUJO en curso (modo, vértices, punto).
+ *   2. Selección / edición de un lote.
+ *   3. Orquestar el CRUD delegando en `loteService` (que persiste offline-first).
+ *   4. Espejar la lista canónica de lotes (`useAssetStore.lands`) en `lotes`
+ *      para que la vista tenga UN solo import reactivo.
+ *
+ * IMPORTANTE: la fuente de verdad de los lotes sigue siendo `useAssetStore`
+ * (lo que FarmMap.jsx ya lee). Aquí `lotes` es un espejo mantenido por la
+ * suscripción de abajo — nunca se escribe a mano salvo por ese espejo.
+ */
+const useLoteStore = create((set, get) => ({
+  // ── Espejo de datos (canónico: useAssetStore.lands) ──────────────────────
+  lotes: [],
+
+  // ── Dibujo en curso ──────────────────────────────────────────────────────
+  /** null | 'polygon' | 'point' */
+  drawMode: null,
+  /** vértices del polígono en curso: [{lat,lng}] */
+  draftLatLngs: [],
+  /** punto en curso: {lat,lng} | null */
+  draftPoint: null,
+
+  // ── Selección / edición ──────────────────────────────────────────────────
+  selectedLoteId: null,
+  editingLoteId: null,
+
+  // ── Estado de UI ─────────────────────────────────────────────────────────
+  isSaving: false,
+  error: null,
+
+  // ── Acciones de dibujo ───────────────────────────────────────────────────
+  setDrawMode: (mode) => set({
+    drawMode: mode,
+    draftLatLngs: [],
+    draftPoint: null,
+    error: null,
+  }),
+
+  /** Agrega un vértice al polígono (o fija el punto en modo 'point'). */
+  addDraftVertex: (latlng) => {
+    if (!latlng || !Number.isFinite(latlng.lat) || !Number.isFinite(latlng.lng)) return;
+    const mode = get().drawMode;
+    if (mode === 'point') {
+      set({ draftPoint: { lat: latlng.lat, lng: latlng.lng } });
+    } else {
+      set((s) => ({ draftLatLngs: [...s.draftLatLngs, { lat: latlng.lat, lng: latlng.lng }] }));
+    }
+  },
+
+  /** Mueve un vértice existente (arrastre en el canvas). */
+  updateDraftVertex: (index, latlng) => set((s) => {
+    if (index < 0 || index >= s.draftLatLngs.length) return {};
+    const next = s.draftLatLngs.slice();
+    next[index] = { lat: latlng.lat, lng: latlng.lng };
+    return { draftLatLngs: next };
+  }),
+
+  removeLastVertex: () => set((s) => ({ draftLatLngs: s.draftLatLngs.slice(0, -1) })),
+
+  clearDraft: () => set({ drawMode: null, draftLatLngs: [], draftPoint: null }),
+
+  /** GeoJSON del trazo en curso (o null si aún no es válido). */
+  getDraftGeometry: () => {
+    const { drawMode, draftLatLngs, draftPoint } = get();
+    return loteService.geometryFromDraft({ mode: drawMode, latlngs: draftLatLngs, point: draftPoint });
+  },
+
+  // ── Selección ────────────────────────────────────────────────────────────
+  selectLote: (loteId) => set({ selectedLoteId: loteId }),
+  startEditing: (loteId) => set({ editingLoteId: loteId }),
+  stopEditing: () => set({ editingLoteId: null }),
+
+  // ── CRUD orquestado (delegado a loteService) ─────────────────────────────
+
+  /**
+   * Guarda el trazo en curso como un lote nuevo.
+   * @param {{name:string, landType?:string, notes?:string, parentLandId?:string}} meta
+   * @returns {Promise<object|null>} el lote creado, o null si falló.
+   */
+  saveDraftAsLote: async (meta) => {
+    set({ isSaving: true, error: null });
+    try {
+      const geometry = get().getDraftGeometry();
+      const lote = await loteService.createLote({ ...meta, geometry });
+      set({ isSaving: false, drawMode: null, draftLatLngs: [], draftPoint: null, selectedLoteId: lote.id });
+      return lote;
+    } catch (err) {
+      set({ isSaving: false, error: err.message || 'No se pudo guardar el lote' });
+      return null;
+    }
+  },
+
+  /**
+   * Crea un lote con datos ya listos (geometría incluida). Útil cuando el
+   * canvas construye su propia geometría en vez de usar el draft del store.
+   * @param {object} input - ver loteService.createLote.
+   */
+  createLote: async (input) => {
+    set({ isSaving: true, error: null });
+    try {
+      const lote = await loteService.createLote(input);
+      set({ isSaving: false, selectedLoteId: lote.id });
+      return lote;
+    } catch (err) {
+      set({ isSaving: false, error: err.message || 'No se pudo crear el lote' });
+      return null;
+    }
+  },
+
+  updateLote: async (loteId, patch) => {
+    set({ isSaving: true, error: null });
+    try {
+      const lote = await loteService.updateLote(loteId, patch);
+      set({ isSaving: false, editingLoteId: null });
+      return lote;
+    } catch (err) {
+      set({ isSaving: false, error: err.message || 'No se pudo actualizar el lote' });
+      return null;
+    }
+  },
+
+  removeLote: async (loteId) => {
+    try {
+      await loteService.deleteLote(loteId);
+      set((s) => ({ selectedLoteId: s.selectedLoteId === loteId ? null : s.selectedLoteId }));
+      return true;
+    } catch (err) {
+      set({ error: err.message || 'No se pudo eliminar el lote' });
+      return false;
+    }
+  },
+
+  /**
+   * Asigna un cultivo/animal existente al lote (fija su ubicación).
+   * @param {{assetType:string, asset:object, loteId:string}} params
+   */
+  assignAsset: async (params) => {
+    try {
+      return await loteService.assignAssetToLote(params);
+    } catch (err) {
+      set({ error: err.message || 'No se pudo asignar al lote' });
+      return null;
+    }
+  },
+
+  // ── Hidratación ──────────────────────────────────────────────────────────
+  /** Asegura que useAssetStore esté hidratado y refresca el espejo `lotes`. */
+  hydrate: async () => {
+    const assetState = useAssetStore.getState();
+    if (!assetState.isHydrated) {
+      await assetState.hydrate();
+    }
+    set({ lotes: useAssetStore.getState().lands });
+  },
+}));
+
+// ── Espejo lands → lotes ─────────────────────────────────────────────────────
+// La fuente de verdad de los lotes es `useAssetStore.lands`. Aquí lo reflejamos
+// en `useLoteStore.lotes` para que el canvas de Fable tenga un único store.
+if (typeof window !== 'undefined') {
+  // Semilla inicial con lo que ya haya en el store de assets.
+  useLoteStore.setState({ lotes: useAssetStore.getState().lands });
+  // Mantener el espejo sincronizado (solo cuando cambia la referencia de lands).
+  useAssetStore.subscribe((state, prev) => {
+    if (state.lands !== prev.lands) {
+      useLoteStore.setState({ lotes: state.lands });
+    }
+  });
+}
+
+export default useLoteStore;


### PR DESCRIPTION
Groundwork Opus (modelo + lógica) para dos features que **Fable pinta encima**. Todo offline-first y grounded en el modelo farmOS existente (asset--land + log--harvest), sin backend nuevo.

## FEATURE 1 — Croquis / mapa de la finca (lotes dibujables)

**Modelo de datos:** un "lote" ES un `asset--land` (mismo tipo que ya lee `FarmMap.jsx`):
- `attributes.name`, `attributes.land_type` (field/bed/greenhouse/paddock/…), `attributes.intrinsic_geometry.value` (WKT POLYGON/POINT), `attributes.notes`.
- Cultivos/animales del lote = `asset--plant`/`asset--animal` cuyo `parent`/`location` apunta al id del lote (jerarquía espacial canónica de farmOS — lo que FarmMap ya filtra por zona). Sirve al mapa, a la ficha del lote y al rendimiento kg/era.

**API para Fable:**
- `services/loteService.js`: `geometryFromDraft`, `buildLotePayload`, `createLote/updateLote/deleteLote/listLotes/getLote`, `loteAreaSqMeters/loteAreaHectares/loteCentroid`, `getLoteContents`, `summarizeLote`, `assignAssetToLote`.
- `store/useLoteStore.js` (fachada del canvas): draft (`setDrawMode/addDraftVertex/updateDraftVertex/removeLastVertex/getDraftGeometry`), selección, `saveDraftAsLote`, y `lotes` (espejo reactivo de `useAssetStore.lands`).

**Fix incluido:** `useAssetStore` bucketeaba `land` en `materials`, así que un lote optimista no aparecía en el mapa hasta un re-hydrate. Ahora hay un mapa canónico `assetType→bucket`.

## FEATURE 2 — "Mi cosecha" (producción / rendimiento)

**Modelo:** agrega los `log--harvest` existentes (no los crea; eso ya lo hace HarvestLog). Lee `quantity` en todos sus shapes ({value,unit}, array JSON:API, {value:{decimal}}).

**API para Fable (`services/cosechaService.js`, puro y testeado):**
- Conversión a kg con **unidades campesinas colombianas** (arroba=12.5kg, libra, quintal, bulto) + unidades de conteo separadas.
- `aggregateByCrop`, `aggregateByAsset`, `aggregateByLote` (kg/planta, kg/ha, kg/m²), `yieldPerPlantByCrop`, `temporalTrend` (serie mensual + dirección subiendo/bajando), `harvestSummary` (compuesto).
- `store/useCosechaStore.js`: `loadHarvests()` (IDB → summary), `computeFrom(logs)`.

## Qué falta para que Fable solo pinte
- **F1:** reemplazar `components/lotes/LoteCroquisPlaceholder.jsx` por el canvas Leaflet real (dibujo polígono/punto → `useLoteStore.addDraftVertex` → `saveDraftAsLote`). Datos, geometría y CRUD ya resueltos. Cablear ruta en App.jsx (case `mapa`/nuevo `croquis`).
- **F2:** reemplazar `components/cosecha/MiCosechaPlaceholder.jsx` por el tablero visual (tarjetas + gráfica de tendencia) consumiendo `useCosechaStore.summary`. Cablear ruta.

## Gates
- Tests: **44 casos nuevos** (geometría, CRUD offline con IDB real, conversión de unidades, agregación, tendencia). Verdes.
- `vite build` ✅ · `tsc:check` sin errores nuevos ✅ · `eslint` sin errores ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)