### PR TITLE
fix(catalog): AMB-32 guard género→familia (confusiones de bench: guayaba/plátano/morera)

### DIFF
--- a/scripts/__tests__/validate-catalog.test.mjs
+++ b/scripts/__tests__/validate-catalog.test.mjs
@@ -27,6 +27,9 @@ import {
   validateAmb28_taxonomicConfusion,
   validateAmb29_speciesInBiopreparados,
   validateAmb31_crossContaminationInsectoPatogeno,
+  GENUS_FAMILY_CANONICAL,
+  extractGenus,
+  validateAmb32_genusFamilyConsistency,
 } from '../validate-catalog.mjs';
 
 describe('AMB-25 — autoridad canónica estricta', () => {
@@ -694,5 +697,111 @@ describe('AMB-31 — contaminación cruzada insecto ↔ patógeno', () => {
     const errors = validateAmb31_crossContaminationInsectoPatogeno(catalog);
     expect(errors).toHaveLength(2);
     expect(errors.every(e => e.includes('roya'))).toBe(true);
+  });
+});
+
+describe('AMB-32 — consistencia género → familia (confusables)', () => {
+  it('mapa canónico cubre los géneros confusables de los benches', () => {
+    for (const [genus, fam] of [
+      ['psidium', 'Myrtaceae'],       // guayaba
+      ['acca', 'Myrtaceae'],          // feijoa
+      ['musa', 'Musaceae'],           // plátano/banano
+      ['morus', 'Moraceae'],          // morera
+      ['passiflora', 'Passifloraceae'], // gulupa/maracuyá/granadilla/curuba
+      ['rubus', 'Rosaceae'],          // mora andina/frambuesa
+      ['fragaria', 'Rosaceae'],       // fresa
+      ['persea', 'Lauraceae'],        // aguacate
+    ]) {
+      expect(GENUS_FAMILY_CANONICAL.get(genus)).toBe(fam);
+    }
+  });
+
+  it('extractGenus obtiene el género tolerando híbridos y autoridad', () => {
+    expect(extractGenus('Psidium guajava L.')).toBe('psidium');
+    expect(extractGenus('Musa × paradisiaca L.')).toBe('musa');
+    expect(extractGenus("Fragaria × ananassa 'Monterrey'")).toBe('fragaria');
+    expect(extractGenus('Passiflora edulis f. edulis Sims')).toBe('passiflora');
+    expect(extractGenus('Rubus glaucus Benth.')).toBe('rubus');
+    expect(extractGenus('')).toBe('');
+    expect(extractGenus(null)).toBe('');
+  });
+
+  it('acepta las asignaciones correctas sin error', () => {
+    const catalog = {
+      species: [
+        { id: 'psidium_guajava', nombre_cientifico: 'Psidium guajava L.', familia_botanica: 'Myrtaceae' },
+        { id: 'musa_paradisiaca', nombre_cientifico: 'Musa × paradisiaca L.', familia_botanica: 'Musaceae' },
+        { id: 'morus_alba', nombre_cientifico: 'Morus alba L.', familia_botanica: 'Moraceae' },
+        { id: 'passiflora_ligularis', nombre_cientifico: 'Passiflora ligularis Juss.', familia_botanica: 'Passifloraceae' },
+        { id: 'rubus_glaucus', nombre_cientifico: 'Rubus glaucus Benth.', familia_botanica: 'Rosaceae' },
+      ],
+    };
+    expect(validateAmb32_genusFamilyConsistency(catalog)).toEqual([]);
+  });
+
+  it('caza guayaba (Psidium) metida en Passifloraceae', () => {
+    const catalog = {
+      species: [
+        { id: 'psidium_guajava', nombre_cientifico: 'Psidium guajava L.', familia_botanica: 'Passifloraceae' },
+      ],
+    };
+    const errors = validateAmb32_genusFamilyConsistency(catalog);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('psidium_guajava');
+    expect(errors[0]).toContain('Myrtaceae');
+    expect(errors[0]).toContain('Passifloraceae');
+  });
+
+  it('caza plátano (Musa) metido en Passifloraceae', () => {
+    const catalog = {
+      species: [
+        { id: 'musa_paradisiaca', nombre_cientifico: 'Musa × paradisiaca L.', familia_botanica: 'Passifloraceae' },
+      ],
+    };
+    const errors = validateAmb32_genusFamilyConsistency(catalog);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Musaceae');
+  });
+
+  it('caza morera (Morus) colada en Rosaceae', () => {
+    const catalog = {
+      species: [
+        { id: 'morus_alba', nombre_cientifico: 'Morus alba L.', familia_botanica: 'Rosaceae' },
+      ],
+    };
+    const errors = validateAmb32_genusFamilyConsistency(catalog);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Moraceae');
+  });
+
+  it('NO confunde mora andina (Rubus, Rosaceae) con morera (Morus, Moraceae)', () => {
+    const catalog = {
+      species: [
+        { id: 'rubus_glaucus', nombre_cientifico: 'Rubus glaucus Benth.', familia_botanica: 'Rosaceae' },
+        { id: 'morus_nigra', nombre_cientifico: 'Morus nigra L.', familia_botanica: 'Moraceae' },
+      ],
+    };
+    expect(validateAmb32_genusFamilyConsistency(catalog)).toEqual([]);
+  });
+
+  it('ignora géneros no confusables fuera del mapa (p.ej. Mora Fabaceae, nato)', () => {
+    const catalog = {
+      species: [
+        // "Mora" (Fabaceae, nato) NO es "Morus" — no debe dispararse
+        { id: 'mora_megistosperma', nombre_cientifico: 'Mora megistosperma (Pittier) Britton & Rose', familia_botanica: 'Fabaceae' },
+        { id: 'solanum_betaceum', nombre_cientifico: 'Solanum betaceum Cav.', familia_botanica: 'Solanaceae' },
+      ],
+    };
+    expect(validateAmb32_genusFamilyConsistency(catalog)).toEqual([]);
+  });
+
+  it('ignora species sin nombre_cientifico o sin familia_botanica', () => {
+    const catalog = {
+      species: [
+        { id: 'sin_sci', familia_botanica: 'Myrtaceae' },
+        { id: 'sin_fam', nombre_cientifico: 'Psidium guajava L.' },
+      ],
+    };
+    expect(validateAmb32_genusFamilyConsistency(catalog)).toEqual([]);
   });
 });

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -852,6 +852,73 @@ export function validateAmb31_crossContaminationInsectoPatogeno(catalog) {
   return errors;
 }
 
+// AMB-32: consistencia género → familia botánica para taxones de confusión
+// conocida (regresión-guard). Introducido 2026-07-05 tras que los benches de
+// contaminación reportaran confusiones de FAMILIA que AMB-28 NO cubre:
+//   - guayaba (Psidium) y plátano (Musa) metidos en Passifloraceae
+//   - morera (Morus) colada en Rosaceae (confusión con mora andina Rubus)
+// AMB-28 chequea nombre_comun/id (patrón gulupa→guayaba), pero NO valida que
+// familia_botanica sea coherente con el género del nombre_cientifico. Si alguien
+// re-introduce `familia_botanica: "Passifloraceae"` en psidium_guajava o
+// "Rosaceae" en Morus, AMB-28 no lo caza porque el id/nombre no dispara el
+// patrón. Este validador cierra ese hueco con un mapa CURADO género→familia
+// canónica de alta confianza, verificado contra el GBIF Backbone Taxonomy (con
+// POWO/Kew como autoridad taxonómica de respaldo). Solo cubre los géneros
+// confusables reportados por los benches + sus parejas de confusión — NO es un
+// checker taxonómico exhaustivo (eso daría falsos positivos por reclasificaciones
+// APG). Error duro: solo dispara ante contradicción definitiva.
+//
+// Fuentes (familia aceptada por género — GBIF Backbone Taxonomy · POWO):
+//   Psidium    → Myrtaceae      (GBIF 5420380 · Psidium guajava; guayaba)
+//   Acca       → Myrtaceae      (GBIF 5418629 · Acca sellowiana / syn. Feijoa; feijoa)
+//   Musa       → Musaceae       (GBIF 2760990; plátano/banano)
+//   Morus      → Moraceae       (GBIF 5361889 · Morus alba; morera)
+//   Passiflora → Passifloraceae (GBIF 2874172; gulupa/maracuyá/granadilla/curuba/badea)
+//   Rubus      → Rosaceae       (GBIF 2988638; mora andina/frambuesa)
+//   Fragaria   → Rosaceae       (GBIF 3029779; fresa)
+//   Persea     → Lauraceae      (GBIF 3034041; aguacate)
+export const GENUS_FAMILY_CANONICAL = new Map([
+  ['psidium', 'Myrtaceae'],
+  ['acca', 'Myrtaceae'],
+  ['musa', 'Musaceae'],
+  ['morus', 'Moraceae'],
+  ['passiflora', 'Passifloraceae'],
+  ['rubus', 'Rosaceae'],
+  ['fragaria', 'Rosaceae'],
+  ['persea', 'Lauraceae'],
+]);
+
+// Extrae el género (primer token alfabético) de un nombre científico, tolerando
+// un marcador de híbrido inicial ("× " o "x "). Devuelve lowercase. El match
+// es de PALABRA COMPLETA (no prefijo) para no colisionar géneros distintos que
+// comparten prefijo (p.ej. Mora Fabaceae vs Morus Moraceae, Moringa, Muscari).
+export function extractGenus(nombreCientifico) {
+  if (typeof nombreCientifico !== 'string') return '';
+  const cleaned = nombreCientifico.trim().replace(/^[×xX]\s+/, '');
+  const m = cleaned.match(/^[A-Za-zÀ-ÿ][A-Za-zÀ-ÿ-]+/);
+  return m ? m[0].toLowerCase() : '';
+}
+
+export function validateAmb32_genusFamilyConsistency(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const sci = sp.nombre_cientifico;
+    const fam = sp.familia_botanica;
+    if (typeof sci !== 'string' || typeof fam !== 'string' || !fam) continue;
+    const genus = extractGenus(sci);
+    const expected = GENUS_FAMILY_CANONICAL.get(genus);
+    if (expected && fam !== expected) {
+      errors.push(
+        `AMB-32 [${sp.id}]: género "${genus}" (de nombre_cientifico "${sci}") ` +
+        `pertenece a ${expected} pero familia_botanica="${fam}". ` +
+        `Fuente: GBIF Backbone / POWO. Confusión histórica cazada por benches ` +
+        `(guayaba/plátano→Passifloraceae, morera→Rosaceae).`,
+      );
+    }
+  }
+  return errors;
+}
+
 // ----------------------------------------------------------------
 // Main (CLI). Gated por `import.meta.url === file://${process.argv[1]}` para
 // permitir importar las funciones validador desde tests (scripts/__tests__/
@@ -998,6 +1065,15 @@ function runCli() {
     // y viceversa.
     ['AMB-31 contaminación cruzada insecto ↔ patógeno', (c) => ({
       errors: validateAmb31_crossContaminationInsectoPatogeno(c),
+      warnings: [],
+    })],
+    // AMB-32 introducido 2026-07-05 (fix/catalog-genus-family-guard-amb32) como
+    // regresión-guard de las confusiones de FAMILIA cazadas por los benches de
+    // contaminación (guayaba/plátano→Passifloraceae, morera→Rosaceae). Error
+    // duro: verifica coherencia género→familia canónica (GBIF/POWO) para los
+    // taxones confusables. Complementa AMB-28 (que solo mira nombre_comun/id).
+    ['AMB-32 consistencia género → familia (confusables)', (c) => ({
+      errors: validateAmb32_genusFamilyConsistency(c),
       warnings: [],
     })],
   ];


### PR DESCRIPTION
## Contexto

Los benches de contaminación reportaron confusiones de **familia botánica**:
- guayaba y plátano metidos en Passifloraceae
- morera colada en Rosaceae (confundida con la mora andina)

## Hallazgo de verificación (empírico)

Verifiqué las asignaciones de familia en **todas** las fuentes de datos. **Ya están correctas** — no había datos que corregir. Cada asignación verificada contra GBIF Backbone / POWO:

| Especie | Familia registrada | Correcta (GBIF/POWO) | Estado |
|---|---|---|---|
| Guayaba (`Psidium guajava`) | Myrtaceae | Myrtaceae (GBIF 5420380) | ✅ correcto |
| Guayaba manzana (`Psidium guajava 'Manzana'`) | Myrtaceae | Myrtaceae | ✅ correcto |
| Plátano (`Musa × paradisiaca`) | Musaceae | Musaceae (GBIF 2760990) | ✅ correcto |
| Banano Cavendish (`Musa AAA`) | Musaceae | Musaceae | ✅ correcto |
| Morera blanca (`Morus alba`) | Moraceae | Moraceae (GBIF 5361889) | ✅ correcto |
| Mora de árbol (`Morus nigra`) | Moraceae | Moraceae | ✅ correcto |
| Mora andina (`Rubus glaucus`) | Rosaceae | Rosaceae (GBIF 2988638) | ✅ correcto |
| Gulupa/Granadilla/… (`Passiflora spp.`) | Passifloraceae | Passifloraceae (GBIF 2874172) | ✅ correcto |

Fuentes revisadas, todas consistentes:
- `catalog/chagra-catalog-oss-subset-v3.2.json` (canónico, 580 sp) y v3.1 / graph-export
- **Grafo AGE en vivo** (`chagra_kg`): `MATCH (s:Species)-[:HAS_FAMILY]->(f:Family)` confirma toda la membresía de Passifloraceae (solo *Passiflora*) y Rosaceae (solo géneros Rosaceae legítimos: *Cydonia, Eriobotrya, Fragaria, Hesperomeles, Malus, Polylepis, Prunus, Pyrus, Rubus*).
- Reglas anti-confusión en `src/services/agentPromptBase.js` (gulupa=Passiflora≠guayaba; mora andina=Rubus≠Morus; guayaba=Psidium≠feijoa): correctas.

Estas confusiones ya habían sido corregidas; el catálogo incluso lleva notas `_anti_confusion` explícitas. Consistencia interna: cada género del catálogo mapea a exactamente una familia.

## El hueco real: faltaba un guard de regresión

`AMB-28` solo inspecciona `nombre_comun`/`id` (patrón gulupa→guayaba); **no** valida coherencia género↔familia. Si alguien re-introdujera `familia_botanica: "Passifloraceae"` en `psidium_guajava`, AMB-28 no lo cazaría.

**AMB-32** cierra ese hueco: mapa curado género→familia canónica (verificado contra GBIF Backbone, POWO/Kew de respaldo) para los taxones confusables + sus parejas: `Psidium→Myrtaceae`, `Acca→Myrtaceae`, `Musa→Musaceae`, `Morus→Moraceae`, `Passiflora→Passifloraceae`, `Rubus→Rosaceae`, `Fragaria→Rosaceae`, `Persea→Lauraceae`. Error duro, cero falsos positivos sobre el catálogo actual. Distingue morera (`Morus`, Moraceae) de mora andina (`Rubus`, Rosaceae) y no colisiona con el género `Mora` (Fabaceae, nato).

## Sobre resolveEntities / stopwords (#301)

El `resolveEntities` de este repo (`src/services/sidecarClient.js`) es un proxy al sidecar `agro-mcp`. La inyección de géneros fantasma por abreviatura de autoridad (Kunth→N géneros) y su fix de stopwords viven en el **backend agro-mcp**, no en este frontend — fuera del alcance de este PR.

## Verificación

- `node scripts/validate-catalog.mjs --lenient-schema` → **exit 0**, AMB-32 PASS (580 sp)
- `node scripts/audit-contaminacion.mjs --check` → OK (baseline 61/61)
- `eslint` limpio en los 2 archivos
- Tests AMB-32: 9 casos nuevos, todos verdes
- Nota: 2 tests **preexistentes** de AMB-31 (`Royas del cafeto…` matchea 2 keywords) fallan en `main` independientemente de este PR (probado con stash) y no están en ningún gate de CI (`unit-tests.yml` corre un allowlist que no incluye `scripts/__tests__`). No los toqué para no enmascarar comportamiento de AMB-31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)