### PR TITLE
feat(rag): kill-switch reversible de la semántica arctic-embed2 + mitigación OOM keep_alive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,17 @@ VITE_CHAGRA_MCP_TOKEN=
 VITE_CHAGRA_TIER=OSS
 VITE_CHAGRA_CATALOG_URL=
 
+# Capa SEMÁNTICA del RAG híbrido (snowflake-arctic-embed2, coseno) en
+# ragRetriever.js. ACTIVADA por defecto: mejora la resolución folk (papa
+# criolla↔Solanum phureja, broca, roya) frente al puro BM25 / scorer literal.
+# Este flag es un KILL-SWITCH REVERSIBLE — para REVERTIR a BM25-only, ponga el
+# valor en `false` (o 0/off/no) y reconstruya; ausente/vacío ⇒ ON.
+# Riesgo mitigado: la semántica embebe la query EN VIVO vía Ollama; el embed
+# usa keep_alive:'0s' para que arctic-embed2 (4.6 GB) NO co-resida sostenido
+# con granite3.3:8b en la M6000 (12 GiB) y dispare OOM. Este flag es el corte
+# de emergencia si aún así hay presión de VRAM en prod.
+VITE_RAG_SEMANTIC=true
+
 # Deep Research (A6/A7) — pro-only, pesado. Default false (prod-free).
 # Activar en pre-prod con VITE_DEEP_RESEARCH_ENABLED=true.
 # Cuando exista el sistema de tier/allowlist, el gating por tier

--- a/docs/RAG.md
+++ b/docs/RAG.md
@@ -20,6 +20,29 @@ Query del campesino
 | Offline | ollama caído / sin red | Solo BM25 + sinónimos campesinos |
 | Sin asset | embeddings.json no existe | Solo BM25 + sinónimos |
 
+## Kill-switch semántico — `VITE_RAG_SEMANTIC`
+
+La capa semántica va **ACTIVADA por defecto** (default seguro de producción):
+mejora la resolución folk (papa criolla↔*Solanum phureja*, broca, roya) frente
+al puro BM25 / scorer literal — ver la tabla de recall más abajo. Modo extra en
+la tabla de arriba: con `VITE_RAG_SEMANTIC=false` (o `0`/`off`/`no`) el retrieve
+degrada a solo-BM25.
+
+- **Activar (default):** no hacer nada. Ausente/vacío/cualquier valor distinto
+  de los de apagado ⇒ ON. Ver `isSemanticEnabled()` en `ragRetriever.js`.
+- **REVERTIR a BM25-only:** ponga `VITE_RAG_SEMANTIC=false` (también valen `0`,
+  `off`, `no`) en el `.env` de build y reconstruya (`npm run build`). No requiere
+  cambio de código ni deploy de lógica. Con OFF, `retrieveInternal` corta antes
+  de `loadEmbeddings()` / `embedQuery()` → cero llamadas a Ollama.
+- **Por qué es un kill-switch y no "siempre on":** la semántica embebe la query
+  **EN VIVO** vía Ollama. El embed usa `keep_alive: '0s'` para que
+  `snowflake-arctic-embed2` (4.6 GB) se descargue tras cada embed y NO co-resida
+  sostenidamente con `granite3.3:8b` (~7.2 GB) en la M6000 (12 GiB) — evita el
+  `cudaMalloc` OOM que tumba al agente (memoria
+  `reference-num-gpu-0-no-fuerza-cpu-ollama-024`; `options.num_gpu:0` NO fuerza
+  CPU en Ollama 0.24). El flag es el corte de emergencia si aún así hay presión
+  de VRAM en prod.
+
 ## Asset de embeddings
 
 - Archivo: `public/rag-embeddings.json` (501 vectores × 1024d, verificado 2026-07-02)

--- a/src/services/__tests__/ragRetriever.semanticFlag.test.js
+++ b/src/services/__tests__/ragRetriever.semanticFlag.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Test del kill-switch REVERSIBLE de la capa semántica (VITE_RAG_SEMANTIC) y
+// de la mitigación OOM (keep_alive:'0s') del embed en vivo. Confirma que:
+//   1. La semántica está ACTIVA por defecto (default de prod, flag ausente).
+//   2. Un valor de apagado explícito la desactiva → BM25-only (sin embed vivo).
+//   3. El embed de la query lleva keep_alive:'0s' (anti-OOM por co-residencia).
+
+const MANIFEST = {
+  generated_at: '2026-07-06T00:00:00Z',
+  slugs: ['coffea_lexical', 'coffea_semantic', 'coffea_noise'],
+};
+
+const DOCS = {
+  coffea_lexical: {
+    species_slug: 'coffea_lexical',
+    valor_pedagogico: 'plaga plaga larva oruga cafe cafe cafe broca broca broca',
+  },
+  coffea_semantic: {
+    species_slug: 'coffea_semantic',
+    valor_pedagogico: 'cafe manejo sombra roya hipotetico',
+  },
+  coffea_noise: {
+    species_slug: 'coffea_noise',
+    valor_pedagogico: 'suelo lluvia drenaje materia organica',
+  },
+};
+
+const EMBEDDINGS = {
+  coffea_lexical: [0, 1, 0],
+  coffea_semantic: [1, 0, 0],
+  coffea_noise: [0, 0, 1],
+};
+
+// Captura los cuerpos de request enviados a /api/ollama/api/embeddings para
+// poder aseverar el keep_alive del embed en vivo.
+function setupFetchMock(embedBodies) {
+  const fn = vi.fn((url, opts) => {
+    const u = String(url);
+    if (u.endsWith('/cycle-content/manifest.json')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
+        json: () => Promise.resolve(MANIFEST),
+      });
+    }
+    const match = u.match(/\/cycle-content\/([^/]+)\.json$/);
+    if (match) {
+      const doc = DOCS[match[1]];
+      if (!doc) return Promise.resolve({ ok: false, status: 404, headers: { get: () => '' } });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
+        json: () => Promise.resolve(doc),
+      });
+    }
+    if (u.endsWith('/rag-embeddings.json')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
+        json: () => Promise.resolve(EMBEDDINGS),
+      });
+    }
+    if (u.includes('/api/ollama/api/embeddings')) {
+      try {
+        embedBodies.push(JSON.parse(opts?.body ?? '{}'));
+      } catch {
+        embedBodies.push({ __unparseable: opts?.body });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ embedding: [1, 0, 0] }),
+      });
+    }
+    return Promise.resolve({ ok: false, status: 404, headers: { get: () => '' } });
+  });
+  // El mock no calza con la firma completa de `fetch` (Response); cast a través
+  // de unknown — irreducible para un stub de test, no toca runtime.
+  return /** @type {typeof globalThis.fetch} */ (/** @type {unknown} */ (fn));
+}
+
+describe('ragRetriever - kill-switch semántico + mitigación OOM', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockResolvedValue(Object.keys(DOCS).map((id) => ({ id }))),
+    }));
+  });
+
+  afterEach(() => {
+    delete globalThis.fetch;
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('la semántica está ACTIVA por defecto (flag ausente = ON en prod)', async () => {
+    const { isSemanticEnabled } = await import('../ragRetriever.js');
+    expect(isSemanticEnabled()).toBe(true);
+  });
+
+  it('por defecto embebe la query en vivo y el semántico manda el ranking', async () => {
+    const embedBodies = [];
+    globalThis.fetch = setupFetchMock(embedBodies);
+    const { retrieve } = await import('../ragRetriever.js');
+
+    const hits = await retrieve('gusano del cafe', 1, 'bench');
+
+    // El doc semántico gana (embedding alineado a la query), no el lexical.
+    expect(hits).toHaveLength(1);
+    expect(hits[0].species).toBe('coffea_semantic');
+    // Confirma que SÍ hubo embed en vivo (semántica activa).
+    expect(embedBodies.length).toBeGreaterThan(0);
+  });
+
+  it('el embed en vivo lleva keep_alive:"0s" (mitigación OOM anti co-residencia)', async () => {
+    const embedBodies = [];
+    globalThis.fetch = setupFetchMock(embedBodies);
+    const { retrieve } = await import('../ragRetriever.js');
+
+    await retrieve('gusano del cafe', 1, 'bench');
+
+    expect(embedBodies.length).toBeGreaterThan(0);
+    for (const body of embedBodies) {
+      expect(body.keep_alive).toBe('0s');
+      expect(body.model).toBe('snowflake-arctic-embed2');
+    }
+  });
+
+  it('VITE_RAG_SEMANTIC=false REVIERTE a BM25-only (sin embed en vivo)', async () => {
+    vi.stubEnv('VITE_RAG_SEMANTIC', 'false');
+    const embedBodies = [];
+    globalThis.fetch = setupFetchMock(embedBodies);
+    const { retrieve, isSemanticEnabled } = await import('../ragRetriever.js');
+
+    expect(isSemanticEnabled()).toBe(false);
+    const hits = await retrieve('gusano del cafe', 1, 'bench');
+
+    // BM25-only: gana el doc lexical (frecuencia de términos), no el semántico.
+    expect(hits).toHaveLength(1);
+    expect(hits[0].species).toBe('coffea_lexical');
+    // Kill-switch: NO se embebió la query en vivo → cero llamadas a Ollama.
+    expect(embedBodies).toHaveLength(0);
+  });
+
+  it.each(['0', 'off', 'no', 'FALSE'])(
+    'trata "%s" como apagado explícito',
+    async (val) => {
+      vi.stubEnv('VITE_RAG_SEMANTIC', val);
+      const { isSemanticEnabled } = await import('../ragRetriever.js');
+      expect(isSemanticEnabled()).toBe(false);
+    },
+  );
+
+  it.each(['true', '1', 'on', '', 'cualquier-cosa'])(
+    'trata "%s" como ACTIVADO (default seguro)',
+    async (val) => {
+      vi.stubEnv('VITE_RAG_SEMANTIC', val);
+      const { isSemanticEnabled } = await import('../ragRetriever.js');
+      expect(isSemanticEnabled()).toBe(true);
+    },
+  );
+});

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -20,6 +20,51 @@ const BM25_PARAMS = {
 const BM25_WEIGHT = 1.0;
 const SEMANTIC_WEIGHT = 1.5;
 
+// ── Kill-switch REVERSIBLE de la capa SEMÁNTICA (arctic-embed2) ────────────
+// La semántica (similitud coseno sobre embeddings snowflake-arctic-embed2) va
+// ACTIVADA por defecto en producción — es el comportamiento aprobado: mejora
+// la resolución folk (papa criolla↔Solanum phureja, broca↔Hypothenemus,
+// roya↔Hemileia) frente al puro BM25 / scorer literal.
+//
+// `VITE_RAG_SEMANTIC` es el corte de emergencia: cualquier valor "apagado"
+// explícito ('0'|'false'|'off'|'no') degrada a BM25-only sin tocar código
+// (rebuild con la env var, sin deploy de lógica). Ausente/vacío/cualquier otro
+// valor ⇒ ON (default seguro para prod). Ver .env.example y docs/RAG.md.
+//
+// Por qué existe el flag y no es "siempre on": la mitad SEMÁNTICA embebe la
+// query EN VIVO vía Ollama (embedQuery). Si el embedder arctic-embed2 (4.6 GB)
+// co-reside con granite3.3:8b (~7.2 GB) en la M6000 (12 GiB) puede disparar un
+// cudaMalloc OOM que tumba al agente. La mitigación de runtime es
+// keep_alive:'0s' (ver embedQuery); este flag es el kill-switch si aún así hay
+// presión de VRAM en prod.
+const SEMANTIC_DISABLED_VALUES = new Set(['0', 'false', 'off', 'no']);
+
+/**
+ * ¿Está activa la capa semántica del RAG híbrido? Default ON (producción).
+ * Solo un valor de apagado explícito en `VITE_RAG_SEMANTIC` la desactiva.
+ * Exportada para que un caller/telemetría pueda short-circuitear sin correr
+ * el retrieve (mismo patrón que `isSidecarEnabled` en sidecarClient.js).
+ * @returns {boolean}
+ */
+export function isSemanticEnabled() {
+  try {
+    // `import.meta.env` lo inyecta Vite en build/runtime, pero jsconfig no
+    // incluye los tipos de `vite/client`, así que `ImportMeta` no declara
+    // `.env` (mismo caso que las ~93 lecturas VITE_* del repo). Cast local a
+    // any: irreducible sin cambiar la config global de tipos; el
+    // optional-chaining ya degrada a undefined en node (benches/tests).
+    const meta = /** @type {any} */ (import.meta);
+    const raw = meta?.env?.VITE_RAG_SEMANTIC;
+    if (raw === false) return false;
+    if (typeof raw === 'string' && SEMANTIC_DISABLED_VALUES.has(raw.trim().toLowerCase())) {
+      return false;
+    }
+    return true;
+  } catch (_) {
+    return true;
+  }
+}
+
 let corpusCache = null;
 let avgDocLen = 0;
 
@@ -468,6 +513,13 @@ async function retrieveInternal(query, topK) {
       score,
     }));
 
+  // Kill-switch reversible: con la semántica apagada (VITE_RAG_SEMANTIC =
+  // 0/false/off/no) NO cargamos embeddings ni embebemos la query en vivo →
+  // BM25-only. Corte de emergencia anti-OOM sin tocar código.
+  if (!isSemanticEnabled()) {
+    return bm25Top.slice(0, topK);
+  }
+
   const embeddings = await loadEmbeddings();
   if (!embeddings) {
     return bm25Top.slice(0, topK);
@@ -565,17 +617,26 @@ async function loadEmbeddings() {
  * Embebe una query via Ollama (POST /api/ollama/api/embeddings).
  * Si falla (sin red, modelo caído), retorna null → fallback a BM25 solo.
  *
- * `options.num_gpu: 0` fuerza el embed a CPU (P0 warm, audit 2026-06-28): evita
- * que el embedder co-resida en la GPU del chat y dispare OOM.
+ * MITIGACIÓN OOM (verificada EN VIVO 2026-07-06 — memoria
+ * reference-num-gpu-0-no-fuerza-cpu-ollama-024): `keep_alive: '0s'` hace que
+ * Ollama DESCARGUE arctic-embed2 (4.6 GB) apenas termina cada embed, y así lo
+ * serializa contra la generación de granite3.3:8b (~7.2 GB) en la M6000
+ * (12 GiB) — evita la co-residencia sostenida que dispara cudaMalloc OOM y
+ * tumba al agente. `options.num_gpu:0` se conserva pero en Ollama 0.24 NO
+ * fuerza CPU (arctic carga igual en GPU aunque `ollama ps` reporte "100% CPU");
+ * por eso la mitigación REAL es keep_alive:'0s', no num_gpu:0.
  */
 async function embedQuery(queryText) {
   try {
     const res = await fetchWithAuthRetry('/api/ollama/api/embeddings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      // num_gpu:0 → el embedder corre en CPU, NO en la M6000 (12 GiB). La
-      // co-residencia embedder + granite3.3:8b puede disparar un cudaMalloc
-      // OOM y tumbar el runner compartido.
+      // keep_alive:'0s' → Ollama descarga arctic-embed2 (4.6 GB) apenas
+      // termina el embed, serializándolo contra granite3.3:8b (~7.2 GB) para
+      // que NO co-residan sostenidamente en la M6000 (12 GiB) y disparen un
+      // cudaMalloc OOM que tumbe al runner compartido del agente. num_gpu:0 se
+      // conserva pero en Ollama 0.24 NO fuerza CPU (verificado en vivo) — la
+      // mitigación que sí funciona es keep_alive:'0s'.
       //
       // FIX P0 (auditoría RAG 2026-07-02): el commit anterior de esta rama
       // había puesto `model: 'nomic-embed-text'` aquí, con el comentario (falso)
@@ -597,6 +658,8 @@ async function embedQuery(queryText) {
       body: JSON.stringify({
         model: 'snowflake-arctic-embed2',
         prompt: queryText,
+        // Descarga arctic tras el embed (anti-OOM por co-residencia con granite).
+        keep_alive: '0s',
         options: { num_gpu: 0 },
       }),
       signal: AbortSignal.timeout(TOOL_TIMEOUT_MS),


### PR DESCRIPTION
## Qué hace

Activa la capa **SEMÁNTICA** del RAG híbrido (`snowflake-arctic-embed2`, coseno) en `src/services/ragRetriever.js` de forma **explícita y REVERSIBLE**, y corrige la mitigación OOM del embed en vivo. Aprobado por el operador (la semántica mejora la resolución folk vs BM25/scorer literal — recall@1 ~42% vs ~14% en `docs/RAG.md`).

## Cómo estaba

- La semántica corría **implícita** (sin flag): si `rag-embeddings.json` cargaba y `embedQuery` respondía, se fusionaba; no había kill-switch.
- Su "mitigación" de OOM era `options.num_gpu:0`, que en **Ollama 0.24 NO fuerza CPU** — arctic-embed2 (4.6 GB) carga igual en la M6000 y, co-residente con `granite3.3:8b` (~7.2 GB), dispara `cudaMalloc` OOM que tumba al agente (verificado en vivo, memoria `reference-num-gpu-0-no-fuerza-cpu-ollama-024`).

## Cómo queda

- **`VITE_RAG_SEMANTIC`** — kill-switch reversible, **default ON** (activado en prod). `false`/`0`/`off`/`no` degrada a **BM25-only** sin tocar código. Gate en `retrieveInternal` **antes** de `loadEmbeddings()`/`embedQuery()` → con OFF, cero llamadas a Ollama. Exporta `isSemanticEnabled()` (mismo patrón que `isSidecarEnabled`).
- **Embebe EN VIVO** la query (docs precomputados en `public/rag-embeddings.json`, pero la query se embebe en runtime). Mitigación OOM aplicada: **`keep_alive:'0s'`** en el embed → Ollama descarga arctic tras cada embed, serializándolo contra granite (evita co-residencia sostenida). `num_gpu:0` se conserva pero se documenta que no fuerza CPU en 0.24.

## Cómo revertir

`VITE_RAG_SEMANTIC=false` (o `0`/`off`/`no`) en el `.env` de build + `npm run build`. Sin deploy de lógica. Ver `.env.example` y `docs/RAG.md`.

## Verde

- `node scripts/tsc-check-gate.mjs`: sin errores nuevos vs baseline.
- `npm run build`: exit 0.
- 46 tests RAG (`ragRetriever*`, `rag-embedding`) verdes, incluidos 13 nuevos que confirman: semántica activa por defecto, `keep_alive:'0s'` presente, y OFF → BM25-only sin embed.

## Nota de alcance (para revisión humana)

La consigna mencionaba "arctic-embed2 en `resolveEntities`". Aclaración verificada: el `resolveEntities` del sidecar (`agro-mcp/resolve-entities.ts`) hace match exacto n-gramas + Levenshtein, **cero semántica** — no tiene arctic ni flag que activar. La ÚNICA capa arctic-embed2 con coseno/precomputados/embed-en-vivo en este repo es `ragRetriever.js` (el RAG híbrido), que es la que este PR vuelve reversible y OOM-safe. Cablear arctic a `resolveEntities` sería un trabajo aparte en el repo `chagra-pro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)