### PR TITLE
fix(perfil+mundos): la foto de perfil persiste offline (IndexedDB) + 3 pendientes de mundos

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -574,9 +574,15 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // normal NO debe re-disparar el prompt.
   useEffect(() => {
     if (!initialContext) return;
-    const { prefilledPrompt, sourceLabel, sourceUrl, alertContext } = initialContext;
-    if (typeof prefilledPrompt === 'string' && prefilledPrompt.trim().length > 0) {
-      setInputText(prefilledPrompt);
+    const { prefilledPrompt, prompt, sourceLabel, sourceUrl, alertContext } = initialContext;
+    // Alias defensivo: varias pantallas de mundo pasaban la clave `prompt`
+    // (SemillaScreen, PlatanoBanano, Poscosecha, Almacenamiento, Compost,
+    // SaludSuelo…) creyendo que prellenaban el input, pero solo se leía
+    // `prefilledPrompt` → el prompt se descartaba y el agente abría vacío.
+    // Aceptar ambas claves repara ese hueco sin tocar cada call site.
+    const seed = prefilledPrompt ?? prompt;
+    if (typeof seed === 'string' && seed.trim().length > 0) {
+      setInputText(seed);
     }
     if (sourceUrl || sourceLabel || alertContext) {
       setAlertContextBanner({

--- a/src/components/MundoScreen.jsx
+++ b/src/components/MundoScreen.jsx
@@ -104,12 +104,16 @@ export default function MundoScreen({ mundoId, onBack, onNavigate }) {
                     ))}
                 </nav>
 
-                {/* El agente siempre presente, con el contexto del mundo. */}
+                {/* El agente siempre presente, con el contexto del mundo: el
+                    prompt arranca sembrado con el tema del mundo (AgentScreen lo
+                    pone en el input, editable — no lo envía solo). */}
                 <button
                     type="button"
                     className="mf-agente"
                     data-testid="mundo-agente"
-                    onClick={() => onNavigate?.('agente')}
+                    onClick={() => onNavigate?.('agente', {
+                        prefilledPrompt: `Tengo una duda sobre ${mundo.titulo.toLowerCase()}: `,
+                    })}
                     aria-label={`Pregúntele a Chagra sobre ${mundo.titulo.toLowerCase()}`}
                 >
                     <span aria-hidden="true">💬</span>

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -135,6 +135,22 @@ export default function ProfileScreen({ onBack, onHome }) {
   const [photoBusy, setPhotoBusy] = useState(false);
   const photoInputRef = useRef(null);
 
+  // La foto vive en IndexedDB (localforage) y se hidrata async. El primer
+  // render puede pintar el placeholder antes de que responda IndexedDB (o si el
+  // espejo síncrono de localStorage quedó vacío por cuota llena). Al resolver la
+  // hidratación —o al subir/quitar la foto en otra pestaña— se emite
+  // `chagra:operator-update`; re-leemos para reflejarla sin recargar. Mismo
+  // patrón que TopBar (misma foto, misma fuente).
+  useEffect(() => {
+    const refresh = () => setPhotoData(getOperatorPhoto());
+    window.addEventListener('chagra:operator-update', refresh);
+    window.addEventListener('storage', refresh);
+    return () => {
+      window.removeEventListener('chagra:operator-update', refresh);
+      window.removeEventListener('storage', refresh);
+    };
+  }, []);
+
   const handlePhotoSelected = async (e) => {
     setPhotoError(null);
     const file = e.target.files?.[0];

--- a/src/components/cultivos/MundoCultivosHub.jsx
+++ b/src/components/cultivos/MundoCultivosHub.jsx
@@ -184,12 +184,15 @@ export default function MundoCultivosHub({ onBack, onNavigate }) {
                     </p>
                 </section>
 
-                {/* El agente, siempre a la mano, con el contexto del mundo. */}
+                {/* El agente, siempre a la mano, con el contexto del mundo: el
+                    prompt arranca sembrado con el tema (editable en el input). */}
                 <button
                     type="button"
                     className="mch-agente"
                     data-testid="mch-agente"
-                    onClick={() => onNavigate?.('agente')}
+                    onClick={() => onNavigate?.('agente', {
+                        prefilledPrompt: 'Tengo una duda sobre cultivos y semillas: ',
+                    })}
                     aria-label="Pregúntele a Chagra sobre cultivos y semillas"
                 >
                     <span aria-hidden="true">💬</span>

--- a/src/components/cultivos/__tests__/MundoCultivosHub.test.jsx
+++ b/src/components/cultivos/__tests__/MundoCultivosHub.test.jsx
@@ -54,11 +54,15 @@ describe('MundoCultivosHub — portada del mundo cultivos', () => {
         expect(screen.getByTestId('calc-por-dia')).toHaveTextContent('4.5');
     });
 
-    test('el agente queda a la mano al pie', () => {
+    test('el agente queda a la mano al pie, con contexto del mundo', () => {
         const onNavigate = vi.fn();
         render(<MundoCultivosHub onBack={vi.fn()} onNavigate={onNavigate} />);
         fireEvent.click(screen.getByTestId('mch-agente'));
-        expect(onNavigate).toHaveBeenCalledWith('agente');
+        // Arranca el prompt sembrado con el tema (editable en el input, no se envía solo).
+        expect(onNavigate).toHaveBeenCalledWith(
+            'agente',
+            expect.objectContaining({ prefilledPrompt: expect.stringContaining('cultivos') }),
+        );
     });
 });
 

--- a/src/components/dashboard/MundoVinetas.jsx
+++ b/src/components/dashboard/MundoVinetas.jsx
@@ -48,6 +48,47 @@ function VinetaCultivos() {
     );
 }
 
+/** ☕ El café — ladera de cafetal, rama con cerezas maduras y sol de montaña. */
+function VinetaCafe() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#efe0cf" />
+            {/* montañas del eje cafetero al fondo */}
+            <path d="M-4 46 L38 20 L82 46 Z" fill="#c3a888" opacity=".7" />
+            <path d="M64 48 L116 16 L170 48 Z" fill="#b0916e" opacity=".75" />
+            {/* sol suave de mañana */}
+            <circle cx="150" cy="20" r="10" fill="#ffe6b0" />
+            {/* laderas del cafetal */}
+            <path d="M-4 46 Q60 34 120 46 T184 42 V90 H-4 Z" fill="#6f9a52" />
+            <path d="M-4 62 Q70 50 184 60 V90 H-4 Z" fill="#547e3c" />
+            {/* hileras de cafetos en curva de nivel (matas redondas en fila) */}
+            <g fill="#3f7a3a">
+                <circle cx="22" cy="58" r="6" /><circle cx="46" cy="55" r="6" /><circle cx="70" cy="57" r="6" />
+                <circle cx="130" cy="54" r="6" /><circle cx="154" cy="57" r="6" />
+            </g>
+            <g fill="#4c8a44" opacity=".85">
+                <circle cx="22" cy="56" r="3" /><circle cx="46" cy="53" r="3" /><circle cx="70" cy="55" r="3" />
+                <circle cx="130" cy="52" r="3" /><circle cx="154" cy="55" r="3" />
+            </g>
+            {/* rama de café protagonista en primer plano, con cerezas maduras */}
+            <g transform="translate(96 58)">
+                <path d="M-42 28 Q-8 10 34 3" stroke="#7a5230" strokeWidth="3.4" strokeLinecap="round" fill="none" />
+                {/* hojas lanceoladas */}
+                <path d="M-20 17 Q-28 9 -24 -2 Q-13 4 -16 15 Z" fill="#2f6b3a" />
+                <path d="M0 9 Q-6 -1 0 -10 Q9 -2 5 9 Z" fill="#2f6b3a" />
+                <path d="M20 5 Q16 -5 25 -10 Q31 -1 25 6 Z" fill="#3f8f4e" />
+                {/* cerezas de café (rojas) agrupadas en el nudo, como en la mata real */}
+                <g>
+                    <circle cx="-26" cy="19" r="3.4" fill="#c8321f" /><circle cx="-19" cy="21" r="3.4" fill="#d94f30" />
+                    <circle cx="-5" cy="11" r="3.4" fill="#d94f30" /><circle cx="2" cy="13" r="3.4" fill="#c8321f" />
+                    <circle cx="16" cy="6" r="3.2" fill="#d94f30" /><circle cx="23" cy="8" r="3.2" fill="#c8321f" />
+                    <circle cx="31" cy="4" r="3" fill="#e06a48" />
+                </g>
+            </g>
+        </svg>
+    );
+}
+
 /** 🌱 El suelo vivo — corte de tierra en capas con raíces y lombriz. */
 function VinetaSuelo() {
     return (
@@ -311,6 +352,7 @@ function VinetaDisenio() {
 /** Viñeta por id de mundo (fuente única para tarjeta + pantalla de mundo). */
 const VINETAS = {
     cultivos: VinetaCultivos,
+    cafe: VinetaCafe,
     suelo: VinetaSuelo,
     agua: VinetaAgua,
     abono: VinetaAbono,

--- a/src/components/dashboard/__tests__/MundosDeMiFinca.reachability.test.jsx
+++ b/src/components/dashboard/__tests__/MundosDeMiFinca.reachability.test.jsx
@@ -29,6 +29,7 @@ import { describe, test, expect, vi, afterEach } from 'vitest';
 import { MUNDOS_FINCA, mundosViews, getMundo } from '../mundosFinca';
 import MundosDeMiFinca from '../MundosDeMiFinca';
 import MundoScreen from '../../MundoScreen';
+import MundoVineta from '../MundoVinetas';
 
 afterEach(() => cleanup());
 
@@ -79,6 +80,17 @@ describe('Mundos — el mapa cubre todo lo que el home F2 exponía (sin huérfan
       expect(tieneDirecto !== tieneEntradas, `${m.id} debe ser directo O tener entradas`).toBe(true);
     }
   });
+
+  // Regresión: TODO mundo debe tener su ilustración (viñeta). El mundo 'café'
+  // se había quedado sin registrar en MundoVinetas → su tarjeta salía con el
+  // hueco vacío. Este test congela que ningún mundo quede sin dibujo.
+  test('cada mundo tiene su viñeta ilustrada (ninguna tarjeta queda vacía)', () => {
+    for (const m of MUNDOS_FINCA) {
+      const { container } = render(<MundoVineta mundoId={m.id} />);
+      expect(container.querySelector('svg'), `el mundo '${m.id}' no tiene viñeta`).not.toBeNull();
+      cleanup();
+    }
+  });
 });
 
 describe('MundosDeMiFinca — grilla del home', () => {
@@ -108,11 +120,15 @@ describe('MundoScreen — el mundo por dentro re-rutea a las vistas reales', () 
     expect(onNavigate).toHaveBeenCalledWith('biopreparados', { back: 'dashboard' });
   });
 
-  test('el agente queda siempre presente en el pie del mundo', () => {
+  test('el agente queda siempre presente en el pie del mundo, con contexto', () => {
     const onNavigate = vi.fn();
     render(<MundoScreen mundoId="suelo" onBack={vi.fn()} onNavigate={onNavigate} />);
     fireEvent.click(screen.getByTestId('mundo-agente'));
-    expect(onNavigate).toHaveBeenCalledWith('agente');
+    // Ahora arranca el prompt sembrado con el tema del mundo (editable en el input).
+    expect(onNavigate).toHaveBeenCalledWith(
+      'agente',
+      expect.objectContaining({ prefilledPrompt: expect.stringContaining('suelo vivo') }),
+    );
   });
 
   test('sin id (recarga/enlace viejo) muestra el índice de mundos, no un error', () => {

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -203,6 +203,9 @@ export function mundosViews() {
     const out = new Set();
     for (const m of MUNDOS_FINCA) {
         if (m.directo) out.add(m.directo.view);
+        // La portada a medida del mundo también es una vista real de App.jsx:
+        // incluirla congela su reachability (antes se colaba sin validar).
+        if (m.portada) out.add(m.portada);
         for (const e of m.entradas || []) out.add(e.view);
     }
     return [...out];

--- a/src/services/__tests__/operatorPhotoService.test.js
+++ b/src/services/__tests__/operatorPhotoService.test.js
@@ -7,6 +7,7 @@
  * cross-device) con apiService/authService mockeados.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import localforage from 'localforage';
 
 // Mocks de red: apiService (POST/GET FarmOS + descarga con auth-retry).
 const sendToFarmOS = vi.fn();
@@ -28,6 +29,8 @@ import {
   uploadToFarmOS,
   loadFromFarmOS,
   setOperatorPhotoFromFile,
+  hydrateOperatorPhoto,
+  _resetForTests as _resetPhotoForTests,
   __test,
 } from '../operatorPhotoService.js';
 import { setActiveTenantId, _resetForTests } from '../tenantContext.js';
@@ -71,9 +74,11 @@ function installCanvasMocks({ width = 1024, height = 768 } = {}) {
 }
 
 describe('operatorPhotoService', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     localStorage.clear();
+    await localforage.clear(); // el store DURABLE (IndexedDB) también persiste entre tests
     _resetForTests();
+    _resetPhotoForTests(); // limpia el cache en memoria del módulo de foto
     sendToFarmOS.mockReset();
     fetchFromFarmOS.mockReset();
     fetchWithAuthRetry.mockReset();
@@ -120,6 +125,91 @@ describe('operatorPhotoService', () => {
       expect(localStorage.getItem(PHOTO_SYNC_META_KEY)).toBeNull();
       expect(handler.mock.calls.at(-1)[0].detail).toEqual({ key: PHOTO_STORAGE_KEY, value: '' });
       window.removeEventListener('chagra:operator-update', handler);
+    });
+  });
+
+  // ── BUG FIX 2026-07-05: durabilidad en IndexedDB (localforage) ────────────
+  // La foto YA NO depende del cubo frágil de localStorage (~5 MB, síncrono, se
+  // llena y revienta en silencio con QuotaExceededError → la foto "desaparecía"
+  // al recargar). La fuente de verdad pasó a localforage/IndexedDB; el espejo de
+  // localStorage es best-effort. Estos tests prueban que la foto SOBREVIVE una
+  // recarga aunque el espejo síncrono se pierda, y que migra fotos legadas.
+  describe('durabilidad en IndexedDB (localforage)', () => {
+    it('setOperatorPhotoLocal persiste en el store durable (localforage)', async () => {
+      setOperatorPhotoLocal(SAMPLE_DATA_URL);
+      // La escritura durable es fire-and-forget: esperamos a que asiente.
+      await vi.waitFor(async () =>
+        expect(await localforage.getItem(PHOTO_STORAGE_KEY)).toBe(SAMPLE_DATA_URL),
+      );
+    });
+
+    it('la foto sobrevive una "recarga" aunque el espejo de localStorage se pierda', async () => {
+      setOperatorPhotoLocal(SAMPLE_DATA_URL);
+      await vi.waitFor(async () =>
+        expect(await localforage.getItem(PHOTO_STORAGE_KEY)).toBe(SAMPLE_DATA_URL),
+      );
+
+      // Simula recarga con el espejo síncrono VACÍO (cuota llena la sesión
+      // pasada, o el usuario limpió localStorage): SOLO IndexedDB tiene la foto.
+      _resetPhotoForTests();
+      localStorage.removeItem(PHOTO_STORAGE_KEY);
+
+      // El primer render pinta '' (espejo vacío) pero dispara la hidratación…
+      expect(getOperatorPhoto()).toBe('');
+      // …y al hidratar desde IndexedDB, la foto vuelve (antes se perdía).
+      expect(await hydrateOperatorPhoto()).toBe(SAMPLE_DATA_URL);
+      expect(getOperatorPhoto()).toBe(SAMPLE_DATA_URL);
+    });
+
+    it('hidratar emite chagra:operator-update para que TopBar/ProfileScreen re-lean', async () => {
+      await localforage.setItem(PHOTO_STORAGE_KEY, SAMPLE_DATA_URL);
+      _resetPhotoForTests();
+      const handler = vi.fn();
+      window.addEventListener('chagra:operator-update', handler);
+
+      await hydrateOperatorPhoto();
+
+      expect(handler).toHaveBeenCalled();
+      expect(handler.mock.calls.at(-1)[0].detail).toEqual({
+        key: PHOTO_STORAGE_KEY, value: SAMPLE_DATA_URL,
+      });
+      window.removeEventListener('chagra:operator-update', handler);
+    });
+
+    it('MIGRA una foto legada que vivía SOLO en localStorage al store durable', async () => {
+      // Usuario de una versión previa: la foto está solo en localStorage.
+      localStorage.setItem(PHOTO_STORAGE_KEY, SAMPLE_DATA_URL);
+      _resetPhotoForTests();
+      expect(await localforage.getItem(PHOTO_STORAGE_KEY)).toBeNull();
+
+      const hydrated = await hydrateOperatorPhoto();
+
+      expect(hydrated).toBe(SAMPLE_DATA_URL);
+      // Quedó copiada a IndexedDB (durable de ahí en más).
+      expect(await localforage.getItem(PHOTO_STORAGE_KEY)).toBe(SAMPLE_DATA_URL);
+    });
+
+    it('si el espejo localStorage revienta por cuota, la foto igual persiste en IndexedDB', async () => {
+      const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        const e = new Error('QuotaExceededError');
+        e.name = 'QuotaExceededError';
+        throw e;
+      });
+
+      // NO revienta la UI (el bug original se tragaba el error y perdía la foto)…
+      expect(() => setOperatorPhotoLocal(SAMPLE_DATA_URL)).not.toThrow();
+      // …y el cache en memoria refleja la foto de inmediato (render sin flash).
+      expect(getOperatorPhoto()).toBe(SAMPLE_DATA_URL);
+
+      spy.mockRestore();
+
+      // Durabilidad: aunque el espejo falló, IndexedDB SÍ guardó la foto.
+      await vi.waitFor(async () =>
+        expect(await localforage.getItem(PHOTO_STORAGE_KEY)).toBe(SAMPLE_DATA_URL),
+      );
+      // Y tras "recargar", se restaura desde IndexedDB.
+      _resetPhotoForTests();
+      expect(await hydrateOperatorPhoto()).toBe(SAMPLE_DATA_URL);
     });
   });
 

--- a/src/services/operatorPhotoService.js
+++ b/src/services/operatorPhotoService.js
@@ -8,10 +8,29 @@
  * en su propio módulo para no romper esa garantía.
  *
  * ── Persistencia local (siempre, offline-first) ──────────────────────────
- *   - Data-URL JPEG redimensionado a 256×256 (calidad 0.82 ≈ 15-40 KB) en
- *     `localStorage[chagra:operator:photo:v1]`. Holgado dentro de la cuota
- *     de ~5 MB por origen.
- *   - La portada (TopBar) lee de aquí: render inmediato sin red.
+ *   - Data-URL JPEG redimensionado a 256×256 (calidad 0.82 ≈ 15-40 KB).
+ *   - Store DURABLE = IndexedDB vía localforage, clave `chagra:operator:photo:v1`
+ *     (mismo motor offline que el resto de la app: authService, dataBackup,
+ *     conversationMemory). Cuota holgada (cientos de MB), NUNCA compite con el
+ *     presupuesto síncrono de ~5 MB de localStorage.
+ *
+ *   BUG HISTÓRICO (2026-07-05, "la foto no persiste al recargar"): antes la foto
+ *   se guardaba SOLO como base64 en `localStorage`. Ese cubo tiene ~5 MB por
+ *   origen, es síncrono y ya lo llenan 50+ claves `chagra:*` + el fondo elegido;
+ *   base64 infla el blob ~33%. Cuando el `setItem` reventaba con
+ *   `QuotaExceededError`, se tragaba en silencio (console.warn) → la foto NO se
+ *   guardaba y al recargar `getOperatorPhoto()` devolvía '' (la foto "desaparecía").
+ *   Rompía además la regla del propio repo ("Blobs grandes → IndexedDB, NO
+ *   localStorage", dbCore v16/v17, ADR-030 Regla 8). Fix: la fuente de verdad
+ *   pasó a localforage/IndexedDB; localStorage queda como ESPEJO best-effort
+ *   opcional (solo pinta sin flash en la recarga; si revienta la cuota, no pasa
+ *   nada porque la durabilidad la garantiza IndexedDB).
+ *
+ *   - Render inmediato (offline-first, sin flash): `getOperatorPhoto()` es
+ *     SÍNCRONO — devuelve un cache en memoria (o el espejo de localStorage la
+ *     primera vez) y dispara la hidratación desde IndexedDB en segundo plano.
+ *     Al resolver, emite `chagra:operator-update` y los consumidores (TopBar,
+ *     ProfileScreen) re-leen. La portada (TopBar) lee de aquí sin red.
  *
  * ── Sincronización a FarmOS (cuando hay sesión) ──────────────────────────
  *   Reutiliza el patrón YA existente en el repo (`useBackgroundImage` +
@@ -39,11 +58,12 @@
  * @module operatorPhotoService
  */
 
+import localforage from 'localforage';
 import { getActiveTenantId } from './tenantContext';
 
 export const PHOTO_STORAGE_KEY = 'chagra:operator:photo:v1';
 // Metadatos de la última sync (UUID del file en FarmOS) — evita re-subir/
-// re-descargar la misma foto. Plano en localStorage, separado del data-URL.
+// re-descargar la misma foto. Plano en localStorage (es pequeño, sin blob).
 export const PHOTO_SYNC_META_KEY = 'chagra:operator:photo:sync:v1';
 export const PHOTO_MAX_DIMENSION = 256;
 export const PHOTO_JPEG_QUALITY = 0.82;
@@ -52,6 +72,93 @@ export const PHOTO_JPEG_QUALITY = 0.82;
 const FARMOS_PHOTO_PREFIX = 'chagra-operator-photo';
 
 const hasStorage = () => typeof window !== 'undefined' && !!window.localStorage;
+
+// ── Cache en memoria = fuente SÍNCRONA para render inmediato ─────────────
+// null = aún no hidratado desde IndexedDB; '' = hidratado sin foto; string = foto.
+let _memoryPhoto = null;
+// Promesa de hidratación (idempotente): la primera lectura la dispara.
+let _hydratePromise = null;
+
+/**
+ * Lee el ESPEJO de localStorage (síncrono). Sirve para (a) pintar sin flash la
+ * primera vez antes de que responda IndexedDB y (b) migrar fotos de usuarios
+ * que ya la tenían en localStorage antes de esta versión. NO es la fuente de
+ * verdad (lo es IndexedDB).
+ */
+function readMirror() {
+  if (!hasStorage()) return '';
+  try {
+    return window.localStorage.getItem(PHOTO_STORAGE_KEY) || '';
+  } catch (e) {
+    console.warn('[operatorPhoto] readMirror:', e);
+    return '';
+  }
+}
+
+/**
+ * Escribe el espejo síncrono best-effort. Si la cuota de localStorage está
+ * llena (el bug histórico), se ignora SIN romper: la durabilidad ya la
+ * garantiza localforage/IndexedDB; el espejo es solo un acelerador de pintado.
+ */
+function writeMirror(dataUrl) {
+  if (!hasStorage()) return;
+  try {
+    if (dataUrl) window.localStorage.setItem(PHOTO_STORAGE_KEY, dataUrl);
+    else window.localStorage.removeItem(PHOTO_STORAGE_KEY);
+  } catch (e) {
+    // QuotaExceededError — precisamente lo que motivó mover el store a IndexedDB.
+    console.warn('[operatorPhoto] espejo localStorage lleno (no fatal):', e?.name || e);
+  }
+}
+
+/** Dispara la hidratación desde IndexedDB una sola vez (idempotente). */
+function ensureHydrated() {
+  if (!_hydratePromise) _hydratePromise = hydrateOperatorPhoto();
+  return _hydratePromise;
+}
+
+/**
+ * Hidrata `_memoryPhoto` desde el store DURABLE (localforage/IndexedDB) y, si
+ * hiciera falta, MIGRA una foto legada que viviera solo en localStorage. Emite
+ * `chagra:operator-update` si el valor cambió, para que TopBar/ProfileScreen
+ * re-lean en vivo. No-throw. Llamar al bootstrap y/o perezosamente desde
+ * `getOperatorPhoto`. Segura de correr varias veces.
+ *
+ * @returns {Promise<string>} el data-URL efectivo tras hidratar ('' si no hay).
+ */
+export async function hydrateOperatorPhoto() {
+  let durable = '';
+  try {
+    const raw = await localforage.getItem(PHOTO_STORAGE_KEY);
+    if (typeof raw === 'string') durable = raw;
+  } catch (e) {
+    console.warn('[operatorPhoto] hydrate localforage falló:', e?.message || e);
+  }
+
+  if (durable) {
+    const changed = _memoryPhoto !== durable;
+    _memoryPhoto = durable;
+    writeMirror(durable); // mantener el espejo síncrono al día
+    if (changed) emitOperatorUpdate(durable);
+    return durable;
+  }
+
+  // IndexedDB vacío: ¿hay una foto legada en localStorage (versiones previas)?
+  // Migrarla al store durable de una vez.
+  const legacy = readMirror();
+  if (legacy) {
+    try {
+      await localforage.setItem(PHOTO_STORAGE_KEY, legacy);
+    } catch (e) {
+      console.warn('[operatorPhoto] migración a localforage falló:', e?.message || e);
+    }
+    _memoryPhoto = legacy;
+    return legacy;
+  }
+
+  _memoryPhoto = '';
+  return '';
+}
 
 /**
  * Redimensiona un File de imagen a un data-URL JPEG ≤256px lado mayor.
@@ -90,16 +197,16 @@ export async function resizePhotoToDataUrl(file) {
 }
 
 /**
- * @returns {string} data-URL de la foto local, o '' si no hay.
+ * @returns {string} data-URL de la foto local, o '' si no hay. SÍNCRONO
+ * (offline-first, render inmediato): devuelve el cache en memoria si ya se
+ * hidrató; si no, dispara la hidratación desde IndexedDB en segundo plano y
+ * devuelve el espejo síncrono de localStorage para pintar sin flash. Cuando la
+ * hidratación resuelve, emite `chagra:operator-update` y los consumidores re-leen.
  */
 export function getOperatorPhoto() {
-  if (!hasStorage()) return '';
-  try {
-    return window.localStorage.getItem(PHOTO_STORAGE_KEY) || '';
-  } catch (e) {
-    console.warn('[operatorPhoto] getOperatorPhoto:', e);
-    return '';
-  }
+  if (_memoryPhoto !== null) return _memoryPhoto;
+  ensureHydrated();
+  return readMirror();
 }
 
 /**
@@ -117,21 +224,24 @@ function emitOperatorUpdate(value) {
 
 /**
  * Persiste la foto local (sin tocar red) y notifica a los consumidores.
+ * Fuente de verdad = localforage/IndexedDB (durable, cuota holgada). El cache
+ * en memoria se actualiza SÍNCRONO para render inmediato; el espejo de
+ * localStorage es best-effort (no fatal si la cuota está llena).
  * @param {string} dataUrl
  */
 export function setOperatorPhotoLocal(dataUrl) {
-  if (!hasStorage()) return;
-  try {
-    if (dataUrl) {
-      window.localStorage.setItem(PHOTO_STORAGE_KEY, dataUrl);
-    } else {
-      window.localStorage.removeItem(PHOTO_STORAGE_KEY);
-    }
-  } catch (e) {
-    // QuotaExceeded u otro — no romper la UI; la foto simplemente no persiste.
-    console.warn('[operatorPhoto] setOperatorPhotoLocal:', e);
-  }
-  emitOperatorUpdate(dataUrl || '');
+  const value = dataUrl || '';
+  _memoryPhoto = value;
+  _hydratePromise = Promise.resolve(value); // ya está hidratado con este valor
+  // Durable primero (IndexedDB) — fire-and-forget, no-throw.
+  const durableWrite = value
+    ? localforage.setItem(PHOTO_STORAGE_KEY, value)
+    : localforage.removeItem(PHOTO_STORAGE_KEY);
+  Promise.resolve(durableWrite)
+    .catch((e) => console.warn('[operatorPhoto] persist localforage falló:', e?.message || e));
+  // Espejo síncrono best-effort (pinta sin flash en la próxima recarga).
+  writeMirror(value);
+  emitOperatorUpdate(value);
 }
 
 /**
@@ -297,10 +407,21 @@ export async function setOperatorPhotoFromFile(file) {
   return dataUrl;
 }
 
+/**
+ * Resetea el estado en memoria del módulo (cache + hidratación). Solo para
+ * tests: en prod el módulo vive lo que dure la pestaña.
+ */
+export function _resetForTests() {
+  _memoryPhoto = null;
+  _hydratePromise = null;
+}
+
 export const __test = {
   FARMOS_PHOTO_PREFIX,
   latestPhotoEndpoint,
   dataUrlToBlob,
   readSyncMeta,
   writeSyncMeta,
+  readMirror,
+  writeMirror,
 };


### PR DESCRIPTION
## BUG 1 — La foto de perfil no persistía al recargar

**Causa raíz.** `operatorPhotoService` guardaba la foto **solo como base64 en `localStorage`** (`chagra:operator:photo:v1`). Ese cubo es ~5 MB por origen, síncrono, y ya lo llenan 50+ claves `chagra:*` + el fondo elegido; base64 infla el blob ~33%. Cuando el `setItem` reventaba con `QuotaExceededError` se **tragaba en silencio** (`console.warn`) → la foto no se guardaba y al recargar `getOperatorPhoto()` devolvía `''` (la foto "desaparecía"). Rompía además la regla del propio repo ("Blobs grandes → IndexedDB, NO localStorage", `dbCore` v16/v17, ADR-030 Regla 8). Es la hipótesis (a): se guardaba en un sitio que no persiste con fiabilidad, no en localforage/IndexedDB.

**Fix (offline-first, mismo patrón que `useBackgroundImage` / `authService`).**
- Fuente de verdad = **localforage/IndexedDB** (cuota holgada).
- `getOperatorPhoto()` sigue **síncrono**: devuelve un cache en memoria y, la primera vez, el espejo síncrono de localStorage para pintar **sin flash**; dispara `hydrateOperatorPhoto()` que lee IndexedDB y, al resolver, emite `chagra:operator-update` para que TopBar/ProfileScreen re-lean.
- `localStorage` queda como **espejo best-effort** (si revienta la cuota no pasa nada: la durabilidad la garantiza IndexedDB).
- **Migración transparente** de fotos legadas que vivían solo en localStorage.
- `ProfileScreen` ahora escucha `chagra:operator-update` (como TopBar) para reflejar la hidratación async.
- La subida/descarga a FarmOS (`file--file`) **no cambia**.

**Tests:** +5 (durabilidad en IndexedDB, sobrevive recarga con el espejo vacío, evento de hidratación, migración legada, resiliencia a cuota llena).

## BUG 2 — 3 pendientes concretos de los mundos

1. **Faltaba la viñeta del mundo "café".** `MundoVinetas` registraba 9 de 10 mundos → la tarjeta "El café" salía con el hueco de ilustración **vacío**. Se agregó `VinetaCafe` (SVG rsvg-safe, mismo lenguaje) + registro.
2. **El agente no recibía contexto del mundo** aunque el copy lo prometía: `MundoScreen` y `MundoCultivosHub` llamaban `onNavigate('agente')` sin datos. Ahora pasan `prefilledPrompt` sembrado con el tema (editable en el input). Además `AgentScreen` acepta el alias `prompt` además de `prefilledPrompt`, reparando varias pantallas de mundo que pasaban `prompt` y se descartaba.
3. **El test de reachability ignoraba `portada`:** `mundosViews()` no incluía la portada del mundo → nunca se validaba su `case` en `App.jsx`. Corregido + test de regresión "cada mundo tiene su viñeta".

## Verificación
- `build` verde.
- `tsc-gate` verde (sin errores nuevos vs baseline; de hecho -1).
- Tests verdes (los del área tocada: perfil/foto, TopBar, AgentScreen, dashboard/mundos).

⚠️ Pendiente de verificación visual del operador: la nueva viñeta del café y el prompt sembrado del agente (cambios visibles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)