### PR TITLE
feat(guards): cazar INSTITUCIONES/FUENTES fabricadas en la salida (#2133)

### DIFF
--- a/src/services/__tests__/outputGuards.fabricatedInstitution.test.js
+++ b/src/services/__tests__/outputGuards.fabricatedInstitution.test.js
@@ -1,0 +1,194 @@
+/**
+ * outputGuards.fabricatedInstitution.test.js
+ *
+ * #2133 (bench anti-alucinación 2026-07-06). El agente CITA instituciones/fuentes
+ * de apoyo que NO existen como si fueran autoridades reales — fabricación de
+ * autoridad. `guardInventedContact` (#1949) cubre teléfono/URL/resolución, pero no
+ * el nombre de la entidad. `guardFabricatedInstitution` es su análogo institucional
+ * (como `guardInventedBrand` #1305 lo es para marcas comerciales): contrasta contra
+ * una allowlist curada de instituciones REALES colombianas/agro y SUPRIME-y-
+ * REEMPLAZA quirúrgicamente por oración la cita de una institución fabricada,
+ * degradando a "sin fuente verificada" (ICA/Agrosavia/UMATA/CAR).
+ *
+ * Casos REALES del bench (deben suprimirse):
+ *   - "Centro Nacional de Historia Natural (CNHN)"
+ *   - "Instituto de Investigación Biológica Los Andes Caldwell"
+ *   - "SERAGRO en tu región"
+ *   - "CATI (Centro Nacional de Investigación de Maíz y Tubérculos)"
+ * Anti-FP CRÍTICO: NO debe tocar ICA, Agrosavia, Cenicafé, Corpoica, IDEAM, UNAL,
+ * universidades reales, corporaciones autónomas (CARs), Humboldt, Invemar, Sinchi,
+ * UMATA, ni instalaciones genéricas (Centro de Acopio), ni siglas no-institución
+ * (NPK, MIP).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { guardFabricatedInstitution, applyOutputGuards } from '../outputGuards.js';
+
+describe('guardFabricatedInstitution — casos reales del bench #2133', () => {
+  it('Caso A: suprime CNHN + "Los Andes Caldwell" y conserva el agronómico correcto', () => {
+    const llm =
+      'El kale rizado verde no se da en piso térmico de páramo: hace demasiado frío ' +
+      'para esa hortaliza, así que no te lo recomiendo ahí.\n\n' +
+      'Para más información, considera consultar con un experto local o con ' +
+      'instituciones especializadas como el Centro Nacional de Historia Natural (CNHN) ' +
+      'o el Instituto de Investigación Biológica Los Andes Caldwell.';
+    const out = guardFabricatedInstitution(llm);
+    expect(out.modified).toBe(true);
+    // las instituciones fabricadas desaparecen del cuerpo
+    expect(out.text).not.toMatch(/CNHN/);
+    expect(out.text).not.toMatch(/Historia Natural/i);
+    expect(out.text).not.toMatch(/Los Andes Caldwell/i);
+    // el agronómico correcto (kale no va en páramo) se conserva
+    expect(out.text).toMatch(/no se da en piso térmico de páramo/i);
+    // degrada a "sin fuente verificada" + redirige a fuentes reales
+    expect(out.text).toMatch(/no te puedo confirmar esa institución como fuente verificada/i);
+    expect(out.text).toMatch(/ICA|Agrosavia|UMATA/);
+    expect(out.reason).toMatch(/institucion_fabricada/i);
+  });
+
+  it('Caso B: suprime la sigla suelta "SERAGRO en tu región"', () => {
+    const llm =
+      'A 2600 metros de clima frío puedes sembrar papa, arveja o cebolla de rama, que ' +
+      'dan cosecha rápido y tienen buen mercado.\n\n' +
+      'Para acompañamiento técnico, puedes consultar con entidades de apoyo como ' +
+      'SERAGRO en tu región.';
+    const out = guardFabricatedInstitution(llm);
+    expect(out.modified).toBe(true);
+    expect(out.text).not.toMatch(/SERAGRO/);
+    // conserva la recomendación agronómica útil
+    expect(out.text).toMatch(/papa, arveja o cebolla/i);
+    expect(out.text).toMatch(/no te puedo confirmar esa institución como fuente verificada/i);
+    expect(out.reason).toMatch(/SERAGRO/);
+  });
+
+  it('Caso CATI: suprime la sigla + el centro fabricado que la deletrea', () => {
+    const llm =
+      'Sobre la semilla de maíz, te recomiendo consultar con CATI (Centro Nacional de ' +
+      'Investigación de Maíz y Tubérculos) para conseguir material certificado.';
+    const out = guardFabricatedInstitution(llm);
+    expect(out.modified).toBe(true);
+    expect(out.text).not.toMatch(/CATI/);
+    expect(out.text).not.toMatch(/Maíz y Tubérculos/i);
+    expect(out.text).toMatch(/no te puedo confirmar esa institución como fuente verificada/i);
+  });
+
+  it('idempotente: no re-dispara sobre su propio reemplazo', () => {
+    const llm =
+      'Consulta con instituciones especializadas como el Instituto Fantasma de Agronomía Tropical Andina.';
+    const once = guardFabricatedInstitution(llm);
+    expect(once.modified).toBe(true);
+    const twice = guardFabricatedInstitution(once.text);
+    expect(twice.modified).toBe(false);
+    expect(twice.text).toBe(once.text);
+  });
+});
+
+describe('guardFabricatedInstitution — anti-FP: instituciones REALES no se tocan', () => {
+  const realCases = [
+    ['ICA + Agrosavia',
+     'Para el manejo de esa plaga cuarentenaria, consulta con el Instituto Colombiano Agropecuario (ICA) o con Agrosavia.'],
+    ['UMATA + ICA + Cenicafé + Corpoica',
+     'Verifica el contacto oficial con tu UMATA local o el ICA; también Cenicafé y Corpoica tienen guías de manejo.'],
+    ['Universidades reales (Nacional + Caldas)',
+     'Según la Universidad Nacional de Colombia y la Universidad de Caldas, el cultivo responde bien al abono orgánico.'],
+    ['Corporación Autónoma Regional',
+     'Consulta con la Corporación Autónoma Regional de Boyacá (Corpoboyacá) para el permiso de aprovechamiento.'],
+    ['Instituto Alexander von Humboldt',
+     'Según el Instituto Alexander von Humboldt, esa especie es nativa; verifica también con el IDEAM.'],
+    ['Invemar',
+     'Para temas de manglar, consulta con el Instituto de Investigaciones Marinas y Costeras (Invemar).'],
+    ['Instituto Sinchi + IIAP',
+     'El Instituto Amazónico de Investigaciones Científicas Sinchi lo reportó; también puedes consultar el IIAP.'],
+    ['Federación Nacional de Cafeteros',
+     'Según la Federación Nacional de Cafeteros, esa variedad resiste la roya.'],
+    ['SENA',
+     'El Servicio Nacional de Aprendizaje (SENA) ofrece cursos de agroecología; también consulta el ICA.'],
+    // Regresión: sigla REAL en MAYÚSCULAS con tilde no debe fragmentarse por el
+    // word-boundary ASCII ("CENICAFÉ" ≠ "CENICAF").
+    ['CENICAFÉ en mayúsculas con tilde',
+     'Para el café usa variedades resistentes (Castillo) y caldo bordelés según CENICAFÉ.'],
+    ['ICA / AGROSAVIA en mayúsculas',
+     'Consulta con el ICA y con AGROSAVIA para el registro del predio.'],
+  ];
+  for (const [name, txt] of realCases) {
+    it(`no toca: ${name}`, () => {
+      const out = guardFabricatedInstitution(txt);
+      expect(out.modified).toBe(false);
+      expect(out.text).toBe(txt);
+    });
+  }
+});
+
+describe('guardFabricatedInstitution — anti-FP: no-institución', () => {
+  it('instalación genérica (Centro de Acopio) no es autoridad fabricada', () => {
+    const out = guardFabricatedInstitution(
+      'Consulta el precio y lleva tu cosecha al Centro de Acopio Municipal para venderla mejor.',
+    );
+    expect(out.modified).toBe(false);
+  });
+
+  it('sin cue de autoridad/fuente no dispara', () => {
+    const out = guardFabricatedInstitution(
+      'El maíz necesita buen sol y riego parejo; un abono balanceado ayuda al crecimiento.',
+    );
+    expect(out.modified).toBe(false);
+  });
+
+  it('siglas no-institución (NPK / MIP) en contexto de consejo no disparan', () => {
+    const out = guardFabricatedInstitution(
+      'Te recomiendo un plan MIP y una fertilización NPK equilibrada según el análisis de suelo.',
+    );
+    expect(out.modified).toBe(false);
+  });
+
+  it('sistema de precios REAL sin marco institucional (SIPSA/DANE) no dispara', () => {
+    const out = guardFabricatedInstitution(
+      'No tengo el precio del bulto de papa; consulta SIPSA/DANE o la central de abastos.',
+    );
+    expect(out.modified).toBe(false);
+  });
+
+  it('sigla de fertilizante/insumo introducida con conector (de DAP) no dispara', () => {
+    const out = guardFabricatedInstitution(
+      'Para arrancar, puedes aplicar una mezcla de DAP según el análisis de suelo que te recomiendo hacer.',
+    );
+    expect(out.modified).toBe(false);
+  });
+
+  it('SÍ dispara con una sigla fabricada ENMARCADA como entidad ("entidad de apoyo como XYZAG")', () => {
+    const out = guardFabricatedInstitution(
+      'Consulta con la entidad de apoyo como XYZAG para más datos técnicos.',
+    );
+    expect(out.modified).toBe(true);
+    expect(out.text).not.toMatch(/XYZAG/);
+  });
+
+  it('mensaje vacío / no-string → no-op', () => {
+    expect(guardFabricatedInstitution('').modified).toBe(false);
+    expect(guardFabricatedInstitution(null).modified).toBe(false);
+    expect(guardFabricatedInstitution(undefined).modified).toBe(false);
+  });
+});
+
+describe('guardFabricatedInstitution — cableado en applyOutputGuards', () => {
+  it('applyOutputGuards suprime la institución fabricada del Caso A', () => {
+    const llm =
+      'El kale no se da en páramo por el frío.\n\n' +
+      'Para más información, considera consultar con instituciones especializadas como ' +
+      'el Centro Nacional de Historia Natural (CNHN).';
+    const res = applyOutputGuards(llm, { userMessage: '¿puedo sembrar kale en páramo?' });
+    expect(res.modified).toBe(true);
+    expect(res.text).not.toMatch(/CNHN/);
+    expect(res.text).not.toMatch(/Historia Natural/i);
+    expect(res.text).toMatch(/no te puedo confirmar esa institución como fuente verificada/i);
+    expect(res.reasons.join(' ')).toMatch(/institucion_fabricada/i);
+  });
+
+  it('applyOutputGuards NO altera una respuesta que cita fuentes reales', () => {
+    const llm =
+      'El kale no se da en páramo por el frío. Para orientarte mejor, consulta con el ICA o Agrosavia.';
+    const res = applyOutputGuards(llm, { userMessage: '¿puedo sembrar kale en páramo?' });
+    expect(res.reasons.join(' ')).not.toMatch(/institucion_fabricada/i);
+    expect(res.text).toMatch(/ICA|Agrosavia/);
+  });
+});

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -2485,6 +2485,261 @@ export function guardInventedContact(responseText, _resolvedEntities = null, _fi
   return { text: responseText, modified: false, reason: null };
 }
 
+// ── GUARD: INSTITUCIÓN / FUENTE DE APOYO FABRICADA (#2133) ───────────────────
+
+/**
+ * Siglas de instituciones/fuentes REALES colombianas y de agro (allowlist curada,
+ * normalizada en minúscula). El agente puede citarlas como autoridad; cualquier
+ * OTRA "institución especializada" o "entidad de apoyo" nombrada como fuente que
+ * NO matchee esta allowlist (ni la de nombres) se trata como FABRICACIÓN DE
+ * AUTORIDAD (#2133: "Centro Nacional de Historia Natural (CNHN)", "Instituto de
+ * Investigación Biológica Los Andes Caldwell", "SERAGRO", "CATI").
+ *
+ * Es el análogo institucional de `guardInventedContact` (#1949, teléfono/URL/
+ * resolución) y de `guardInventedBrand` (#1305, marca comercial): mismo eje
+ * (afirmar una fuente que no existe), otro vector (el nombre de la entidad).
+ */
+const REAL_INSTITUTION_ACRONYMS = new Set([
+  // Agro / fitosanitario nacional
+  'ica', 'agrosavia', 'corpoica', 'cenicafe', 'cenicana', 'cenipalma', 'fedearroz',
+  'fedepapa', 'fedecacao', 'fedegan', 'fedepalma', 'fenalce', 'asohofrucol', 'augura',
+  'fnc', 'fedecafe', 'porkcolombia', 'asocana', 'analac', 'ceniuva', 'agronet',
+  // Ambiental / científico
+  'ideam', 'sinchi', 'iiap', 'invemar', 'humboldt', 'igac', 'anla', 'pnn', 'minambiente',
+  // Estado / rural / educación técnica / precios / sanidad
+  'sena', 'upra', 'icbf', 'dane', 'dian', 'adr', 'ant', 'upme', 'minagricultura',
+  'minciencias', 'colciencias', 'umata', 'epsagro', 'ins', 'sipsa', 'sic', 'finagro',
+  'aunap', 'invima', 'anvisa', 'snia', 'incoder', 'inderena',
+  // Universidades públicas más citadas (toda "Universidad …" se allowlistea por
+  // categoría en REAL_INSTITUTION_NAME_RE; estas siglas cubren la mención suelta)
+  'unal', 'uniandes', 'udea', 'univalle', 'unicauca', 'unillanos', 'uptc', 'uis',
+  'unimagdalena', 'unicordoba',
+  // Corporaciones autónomas regionales (CARs) comunes
+  'car', 'cvc', 'cvs', 'crq', 'cas', 'csb', 'cra', 'cdmb', 'carder', 'crc',
+  'corantioquia', 'corpoboyaca', 'cornare', 'cormacarena', 'corpocaldas', 'corpamag',
+  'cortolima', 'corpoguavio', 'codechoco', 'corpouraba', 'cardique', 'corponarino',
+  'corpochivor', 'corpocesar', 'corpomojana', 'corpoamazonia', 'corpoorinoquia',
+  // Internacionales agro/salud reconocidas
+  'ciat', 'iica', 'fao', 'cgiar', 'bioversity', 'embrapa', 'oms', 'who', 'fda',
+  'efsa', 'usda', 'inta',
+]);
+
+/**
+ * Firmas de NOMBRE (substrings normalizados) que identifican una institución REAL
+ * cuando aparece deletreada. Con que UNA matchee el nombre extraído, la institución
+ * es real y NO se suprime. Incluye `universidad` como categoría entera: Colombia
+ * tiene decenas de universidades públicas/privadas reales, así que #2133 las
+ * allowlistea en bloque (el vector fabricado del bench es Instituto/Centro, no una
+ * universidad). NO listamos "los andes" a secas (existe "Universidad de los Andes"
+ * real, pero "Instituto … Los Andes Caldwell" es fabricado) — solo la forma
+ * completa "universidad de los andes".
+ */
+const REAL_INSTITUTION_NAME_RE =
+  /\b(agrosavia|corpoica|colombian[oa]\s+(de\s+investigacion\s+)?agropecuari|corporacion\s+autonoma|autonoma\s+regional|universidad|nacional\s+de\s+aprendizaje|bienestar\s+familiar|planificacion\s+rural\s+agropecuaria|investigaciones?\s+de\s+cafe|cenicafe|investigacion(es)?\s+de\s+la\s+cana|cenicana|palma\s+de\s+aceite|cenipalma|federacion\s+nacional\s+de\s+cafeteros|nacional\s+de\s+cafeteros|nacional\s+de\s+cerealistas|cultivadores\s+de\s+cereales|fedearroz|arroceros|fedepapa|paperos|fedecacao|cacaoteros|hidrologia|meteorologia|ideam|von\s+humboldt|humboldt|alexander|recursos\s+biologicos|amazonic[oa]\s+de\s+investigaciones|sinchi|invemar|marinas\s+y\s+costeras|investigaciones?\s+ambientales?\s+del\s+pacifico|agricultura\s+tropical|geografic[oa]|codazzi|jardin\s+botanico|ministerio\s+de\s+(agricultura|ambiente|ciencia)|asistencia\s+tecnica\s+agropecuaria|umata)\b/;
+
+/**
+ * Instalación GENÉRICA (no una "autoridad" de conocimiento): un "Centro de Acopio",
+ * "Centro de Salud", "Centro Comercial" no es una fuente científica fabricada aunque
+ * no esté en la allowlist. Excluir evita sobre-supresión.
+ */
+const GENERIC_FACILITY_NAME_RE =
+  /\b(acopio|salud|hospital|comercial|comercio|recreativ|deportiv|cultural|penitenciari|carcelari|poblad|convenciones|eventos|logistic|distribucion|zoologic|acuatic)\b/;
+
+/**
+ * Sustantivo-cabeza de una institución NOMBRADA (Título-Caso) + su nombre propio +
+ * su sigla opcional entre paréntesis. Case-sensitive: los nombres propios van
+ * capitalizados, así que "centro de acopio" (minúscula) no dispara. `Universidad`
+ * NO va en la cabeza (toda universidad se allowlistea por categoría → evita FP con
+ * las decenas de universidades reales).
+ */
+const INSTITUTION_HEAD_RE =
+  /\b(Instituto|Centro|Corporaci[oó]n|Fundaci[oó]n|Federaci[oó]n|Laboratorio|Observatorio|Comisi[oó]n)((?:\s+(?:de|del|la|los|las|y|e|para|en|el|von|san|santa)\b|\s+[A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑáéíóúñ.]+){1,9})(?:\s*\(([A-Za-zÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑáéíóúñ.-]{1,14})\))?/g;
+
+/**
+ * Sigla en mayúsculas suelta (3–8 letras) candidata a nombre de entidad. Usa
+ * lookaround ACENTO-AWARE en vez de `\b` porque el word-boundary ASCII de JS corta
+ * en las tildes ("CENICAFÉ" → "CENICAF", que no matchearía la allowlist "cenicafe").
+ */
+const BARE_ACRONYM_RE = /(?<![A-Za-zÁÉÍÓÚÑáéíóúñ0-9])([A-ZÁÉÍÓÚÑ]{3,8})(?![A-Za-zÁÉÍÓÚÑáéíóúñ0-9])/g;
+
+/**
+ * Siglas en mayúsculas que NO son instituciones (unidades, químicos, formatos,
+ * jerga). Se saltan para no confundir "NPK"/"MIP"/"pH" con una entidad fabricada.
+ */
+const ALLCAPS_NON_INSTITUTION = new Set([
+  'npk', 'mip', 'adn', 'arn', 'ndvi', 'pvc', 'co2', 'gps', 'pdf', 'onu', 'iva',
+  'rut', 'nit', 'url', 'faq', 'ong', 'led', 'usb', 'pib', 'pyme', 'pymes', 'msnm',
+  'otan', 'eeuu', 'usa', 'iot', 'api', 'ppm', 'usd', 'cop', 'eur', 'gmo', 'ogm',
+  'abc', 'xyz', 'sos', 'html', 'http', 'https', 'ceo', 'vip', 'atp', 'cic', 'pcr',
+  'vih', 'sida', 'epoc', 'iso', 'sst', 'epp', 'bpa', 'poa',
+  // Insumos / fertilizantes / combustibles (no son entidades)
+  'acpm', 'dap', 'map', 'tsp', 'kcl', 'sku', 'cafe',
+]);
+
+/**
+ * Sustantivos de INSTITUCIÓN en el contexto previo a una sigla. El PATRÓN 2 exige
+ * uno (o el cierre "en tu/su región") para no confundir una sigla de químico/
+ * fertilizante ("de DAP") o un sistema de precios ("consulta SIPSA") con una entidad
+ * fabricada: la fabricación real del bench viene enmarcada ("entidades de apoyo como
+ * SERAGRO", "instituciones especializadas como …"). Normalizado.
+ */
+const INSTITUTION_NOUN_CTX_RE =
+  /\b(institucion\w*|entidad\w*|organismo\w*|organizacion\w*|centro\w*|instituto\w*|agencia\w*|corporacion\w*|cooperativa\w*|asociacion\w*|federacion\w*|gremio\w*|autoridad\w*|laboratorio\w*|fundacion\w*|universidad\w*|observatorio\w*|comision\w*|dependencia\w*)\b/;
+
+/**
+ * Cue de que una entidad se está presentando como AUTORIDAD / FUENTE / contacto a
+ * consultar. Sin cue no hay "fabricación de autoridad" que cazar (gate barato).
+ * Normalizado.
+ */
+const INSTITUTION_AUTHORITY_CUE_RE =
+  /\b(consult\w*|segun\b|de\s+acuerdo\s+con|acorde\s+con|reportad\w*|public\w*|estudi\w*|investigac\w*|fuente[s]?\b|instituci\w*|entidad\w*|avalad\w*|certificad\w*|respald\w*|recomiend\w*|recomend\w*|acerc\w*|comunic\w*|contact\w*|acude\w*|dirig\w*|escrib\w*|asesor\w*|especializ\w*|apoyo\b)\b/;
+
+/** Marca idempotente del reemplazo de institución fabricada. */
+const FABRICATED_INSTITUTION_MARKER = 'no te puedo confirmar esa institución como fuente verificada';
+
+/**
+ * Redirección honesta que REEMPLAZA la oración que cita una institución fabricada.
+ * No nombra la entidad inventada: degrada a "sin fuente verificada" y manda a las
+ * fuentes reales. Estable para idempotencia (contiene `FABRICATED_INSTITUTION_MARKER`).
+ */
+const FABRICATED_INSTITUTION_REPLACEMENT =
+  `Sobre esa recomendación, ${FABRICATED_INSTITUTION_MARKER}. Para orientación con respaldo, ` +
+  'acude a una fuente real: la autoridad fitosanitaria (el ICA), Agrosavia, tu UMATA local o la ' +
+  'corporación autónoma regional de tu zona.';
+
+/**
+ * Detecta menciones de instituciones FABRICADAS (fuera de la allowlist) en UNA
+ * oración. Devuelve la lista de nombres/siglas fabricados hallados.
+ *   PATRÓN 1 — institución nombrada: sustantivo-cabeza + Título-Caso (+ sigla opc.).
+ *   PATRÓN 2 — sigla suelta presentada como entidad ("como SERAGRO", "SERAGRO en
+ *              tu región").
+ *
+ * @param {string} sentence  oración cruda (con mayúsculas).
+ * @param {string} _sNorm    misma oración normalizada (reservado).
+ * @returns {string[]}
+ */
+function _fabricatedInstitutionsInSentence(sentence, _sNorm) {
+  const found = [];
+
+  // PATRÓN 1 — institución NOMBRADA (Título-Caso).
+  INSTITUTION_HEAD_RE.lastIndex = 0;
+  let m;
+  while ((m = INSTITUTION_HEAD_RE.exec(sentence)) !== null) {
+    const tail = m[2] || '';
+    // Exige ≥1 palabra propia (Título-Caso) en el nombre — descarta "Centro de"
+    // suelto o cabezas seguidas solo de conectores en minúscula.
+    if (!/[A-ZÁÉÍÓÚÑ][a-záéíóúñ]/.test(tail)) continue;
+    const fullName = `${m[1]}${tail}`.replace(/\s+/g, ' ').replace(/[.,;:]+$/, '').trim();
+    const acronym = m[3] ? _stripDiacritics(m[3]) : null;
+    const nameNorm = _stripDiacritics(fullName);
+    // Real por sigla o por firma de nombre → no es fabricada.
+    if (acronym && REAL_INSTITUTION_ACRONYMS.has(acronym)) continue;
+    if (REAL_INSTITUTION_NAME_RE.test(nameNorm)) continue;
+    // Instalación genérica (acopio/salud/comercial…) → no es autoridad fabricada.
+    if (GENERIC_FACILITY_NAME_RE.test(nameNorm)) continue;
+    found.push(m[3] ? `${fullName} (${m[3]})` : fullName);
+  }
+
+  // PATRÓN 2 — SIGLA suelta presentada como ENTIDAD/INSTITUCIÓN.
+  BARE_ACRONYM_RE.lastIndex = 0;
+  while ((m = BARE_ACRONYM_RE.exec(sentence)) !== null) {
+    const raw = m[1];
+    const acr = _stripDiacritics(raw);
+    if (REAL_INSTITUTION_ACRONYMS.has(acr)) continue;
+    if (ALLCAPS_NON_INSTITUTION.has(acr)) continue;
+    const before = _stripDiacritics(sentence.slice(Math.max(0, m.index - 48), m.index));
+    const after = _stripDiacritics(sentence.slice(m.index + raw.length, m.index + raw.length + 28));
+    // Debe (a) ir tras un conector de mención Y (b) tener un sustantivo de
+    // INSTITUCIÓN en la ventana previa (o cerrarse con "en tu/su región"). Así una
+    // sigla de químico/fertilizante ("de DAP") o de un sistema de precios ("consulta
+    // SIPSA") SIN marco institucional NO se confunde con una entidad fabricada; la
+    // fabricación real viene enmarcada ("entidades de apoyo como SERAGRO").
+    const introduced = /\b(como|con|segun|por|ante|de|del)\s*$/.test(before);
+    if (!introduced) continue;
+    const institutionalCtx = INSTITUTION_NOUN_CTX_RE.test(before);
+    const asRegionalEntity = /^\s*(en|de)\s+(tu|su|la|mi)\s+region/.test(after);
+    if (!institutionalCtx && !asRegionalEntity) continue;
+    if (!found.includes(raw)) found.push(raw);
+  }
+
+  return found;
+}
+
+/**
+ * guardFabricatedInstitution — #2133. SUPPRESS-AND-REPLACE quirúrgico por oración:
+ * cuando la respuesta cita una institución/entidad/fuente de apoyo que NO existe en
+ * la allowlist curada de instituciones REALES colombianas/agro (Agrosavia, ICA,
+ * Cenicafé, IDEAM, UNAL, Fenalce, Corpoica, FNC, SENA, UPRA, MinAgricultura, CARs,
+ * CIAT, IICA, FAO…) como AUTORIDAD a consultar/fuente, sustituye ESA oración por la
+ * redirección honesta ("no te puedo confirmar esa institución como fuente
+ * verificada; acude al ICA/Agrosavia/UMATA/CAR"). Análogo institucional de
+ * `guardInventedContact` (#1949) y `guardInventedBrand` (#1305).
+ *
+ * Determinista, PURO y SÍNCRONO. Quirúrgico (no nuke): el resto de la respuesta —el
+ * agronómico correcto, p.ej. "el kale no va en páramo"— se conserva; solo se
+ * reemplaza la oración con la fabricación. Va tras la marca inventada en
+ * `applyOutputGuards`. Idempotente por marcador.
+ *
+ * GATING (anti-sobre-supresión): la oración debe (1) tener un cue de autoridad/
+ * fuente (`INSTITUTION_AUTHORITY_CUE_RE`) Y (2) nombrar ≥1 institución fabricada
+ * (fuera de allowlist de siglas y de nombres, y que no sea instalación genérica).
+ *
+ * @param {string} responseText
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardFabricatedInstitution(responseText) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  // Idempotencia: nuestra redirección ya está.
+  if (responseText.includes(FABRICATED_INSTITUTION_MARKER)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  // Gate barato: sin cue de autoridad en todo el texto no hay nada que cazar.
+  if (!INSTITUTION_AUTHORITY_CUE_RE.test(_stripDiacritics(responseText))) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const sentences = _splitSentences(responseText);
+  const fabricated = [];
+  let changed = false;
+  let lastWasReplacement = false;
+
+  const out = sentences
+    .map((sentence) => {
+      const sNorm = _stripDiacritics(sentence);
+      // La oración debe presentar una entidad como autoridad/fuente.
+      if (!INSTITUTION_AUTHORITY_CUE_RE.test(sNorm)) {
+        lastWasReplacement = false;
+        return sentence;
+      }
+      const hits = _fabricatedInstitutionsInSentence(sentence, sNorm);
+      if (hits.length === 0) {
+        lastWasReplacement = false;
+        return sentence;
+      }
+      for (const h of hits) if (!fabricated.includes(h)) fabricated.push(h);
+      changed = true;
+      // Colapsa reemplazos en oraciones consecutivas (una sola redirección).
+      if (lastWasReplacement) return '';
+      lastWasReplacement = true;
+      const trailing = sentence.match(/\s*$/)?.[0] || ' ';
+      return `${FABRICATED_INSTITUTION_REPLACEMENT}${trailing}`;
+    })
+    .join('');
+
+  if (!changed) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('fabricated_institution');
+  return {
+    text: out.trim(),
+    modified: true,
+    reason: `institucion_fabricada_suprimida: ${[...new Set(fabricated)].slice(0, 5).join(', ')}`,
+  };
+}
+
 // ── GUARD: receta EXACTA de caldo clásico pedida en dosis (BORDE-003 / 004) ──
 
 /**
@@ -9638,6 +9893,20 @@ export function applyOutputGuards(
     text = contactRes.text;
     modified = true;
     if (contactRes.reason) reasons.push(contactRes.reason);
+  }
+  // Guard SAFETY de INSTITUCIÓN / FUENTE FABRICADA (#2133): firma propia (solo el
+  // texto). Corre SIEMPRE (no es de siembra). SUPPRESS-AND-REPLACE quirúrgico por
+  // oración: si el cuerpo cita una institución/entidad de apoyo que NO está en la
+  // allowlist curada de instituciones reales colombianas/agro ("Centro Nacional de
+  // Historia Natural (CNHN)", "…Los Andes Caldwell", "SERAGRO") como autoridad a
+  // consultar, sustituye esa oración por la redirección honesta (sin fuente
+  // verificada → ICA/Agrosavia/UMATA/CAR). Análogo institucional de la marca y el
+  // contacto inventados: va justo tras ellos. Idempotente.
+  const institutionRes = guardFabricatedInstitution(text);
+  if (institutionRes && institutionRes.modified) {
+    text = institutionRes.text;
+    modified = true;
+    if (institutionRes.reason) reasons.push(institutionRes.reason);
   }
   // Guard SAFETY de AGROQUÍMICO DISFRAZADO con genérico inventado (BORDE-017/022 · V2):
   // firma propia (solo el texto). Corre SIEMPRE (no es de siembra). SUPPRESS-AND-REPLACE:


### PR DESCRIPTION
## Qué

Cierra el hueco del bench #2133: el agente **citaba instituciones/fuentes de apoyo que no existen** como si fueran autoridades reales ("Centro Nacional de Historia Natural (CNHN)", "Instituto de Investigación Biológica Los Andes Caldwell", "SERAGRO", "CATI") — fabricación de autoridad. `guardInventedContact` (#1949) cubre teléfono/URL/resolución pero **no el nombre de la entidad**.

Nuevo **`guardFabricatedInstitution`**, análogo institucional de `guardInventedBrand` (#1305) y `guardInventedContact` (#1949):
- Contrasta cada institución/sigla citada como **autoridad/fuente** contra una **allowlist curada** de instituciones REALES colombianas/agro (ICA, Agrosavia, Cenicafé, Corpoica, IDEAM, UNAL, Fenalce, FNC, SENA, UPRA, MinAgricultura, CARs, CIAT, IICA, FAO, SIPSA/DANE, universidades por categoría…).
- Si la cita no matchea → **SUPPRESS-AND-REPLACE quirúrgico por oración** (NO solo antepone aviso, ver `feedback-guards-suppress-not-prepend`): reemplaza **solo esa oración** por la redirección honesta *"no te puedo confirmar esa institución como fuente verificada; acude al ICA/Agrosavia/UMATA/CAR"*, **conservando el agronómico correcto** del resto (p. ej. "el kale no va en páramo").
- Cableado en `applyOutputGuards` tras la marca/contacto inventados. Determinista, puro, síncrono, idempotente.

## Detección (2 patrones)

- **P1** institución nombrada: sustantivo-cabeza Título-Caso (`Instituto`/`Centro`/`Corporación`/…) + nombre + sigla opcional. `Universidad` se allowlistea por categoría (decenas de universidades reales).
- **P2** sigla suelta **enmarcada como entidad** ("entidades de apoyo como SERAGRO"): exige un sustantivo de institución en el contexto previo → una sigla de químico/fertilizante ("de DAP") o de un sistema de precios ("consulta SIPSA") **no** se confunde con entidad fabricada.

## Anti-falso-positivo

No toca: instituciones reales (incl. universidades, CARs, Humboldt/Invemar/Sinchi), instalaciones genéricas (Centro de Acopio), sistemas de precios (SIPSA/DANE), ni siglas de insumo/químico (NPK/MIP/DAP/ACPM). Fix de borde: `\b` ASCII cortaba siglas con tilde ("CENICAFÉ"→"CENICAF") → lookaround acento-aware.

## Gates

- **Tests**: `outputGuards.fabricatedInstitution.test.js` (casos reales del bench + batería anti-FP). Corpus completo `outputGuards`: **37 files / 768 tests verdes**.
- **tsc:check gate**: verde (0 errores nuevos vs baseline).
- **build** (`vite build`): verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
