### PR TITLE
feat(recorrido): tripas del recorrido de finca por voz (GPS→lote, sesión, readback, voz→cámara)

### DIFF
--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -301,6 +301,9 @@ const messages = {
     estadoError: 'Hubo un problema',
     grabandoHableAhora: 'Grabando… hable ahora',
     errorCargaLibs: 'No se pudo cargar {src}',
+  // Recorrido de finca por voz (useRecorridoStore / recorridoService).
+  recorrido: {
+    errorRegistro: 'No se pudo registrar la observación',
   },
   format,
 };

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -301,6 +301,7 @@ const messages = {
     estadoError: 'Hubo un problema',
     grabandoHableAhora: 'Grabando… hable ahora',
     errorCargaLibs: 'No se pudo cargar {src}',
+  },
   // Recorrido de finca por voz (useRecorridoStore / recorridoService).
   recorrido: {
     errorRegistro: 'No se pudo registrar la observación',

--- a/src/hooks/__tests__/useRecorridoVoz.test.jsx
+++ b/src/hooks/__tests__/useRecorridoVoz.test.jsx
@@ -1,0 +1,120 @@
+/**
+ * useRecorridoVoz — pegamento del recorrido por voz.
+ * Enruta transcripciones a cámara / resumen / observación y cierra el loop de
+ * cámara con el reconocimiento de especie.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// aiService trae dependencias pesadas (sidecar, telemetría): lo mockeamos.
+vi.mock('../../services/aiService', () => ({
+  recognizeSpeciesGrounded: vi.fn(),
+}));
+
+import { useRecorridoVoz } from '../useRecorridoVoz';
+import useRecorridoStore from '../../store/useRecorridoStore';
+
+const POTRERO = {
+  id: 'potrero',
+  type: 'asset--land',
+  attributes: {
+    name: 'Potrero de abajo',
+    land_type: 'field',
+    intrinsic_geometry: {
+      value: 'POLYGON((-73.925 4.529, -73.925 4.531, -73.923 4.531, -73.923 4.529, -73.925 4.529))',
+    },
+  },
+};
+const gpsDentro = () => vi.fn().mockResolvedValue({ lat: 4.530, lng: -73.924, accuracy: 6 });
+
+beforeEach(() => {
+  useRecorridoStore.getState().reset();
+  useRecorridoStore.getState().iniciarRecorrido();
+});
+
+describe('procesarTranscripcion', () => {
+  it('enruta "mira esta mata" a la cámara (señal + callback)', async () => {
+    const onCameraRequested = vi.fn();
+    const { result } = renderHook(() => useRecorridoVoz({ onCameraRequested }));
+    /** @type {any} */
+    let out;
+    await act(async () => { out = await result.current.procesarTranscripcion('mira esta mata'); });
+    expect(out.accion).toBe('camara');
+    expect(onCameraRequested).toHaveBeenCalledTimes(1);
+    expect(result.current.pendingCamera).toMatchObject({ sujeto: 'planta', frase: 'mira esta mata' });
+  });
+
+  it('enruta "cómo quedó el recorrido" al resumen hablado', async () => {
+    const speak = vi.fn().mockResolvedValue(true);
+    const onResumen = vi.fn();
+    const { result } = renderHook(() => useRecorridoVoz({ onResumen, resumenOpts: { speak } }));
+    /** @type {any} */
+    let out;
+    await act(async () => { out = await result.current.procesarTranscripcion('cómo quedó el recorrido'); });
+    expect(out.accion).toBe('resumen');
+    expect(speak).toHaveBeenCalledTimes(1);
+    expect(onResumen).toHaveBeenCalledWith(out.texto);
+  });
+
+  it('enruta narración normal a observación (GPS + lote)', async () => {
+    const registroOpts = { lotes: [POTRERO], getPosition: gpsDentro(), now: 10 };
+    const onObservacion = vi.fn();
+    const { result } = renderHook(() => useRecorridoVoz({ registroOpts, onObservacion }));
+    /** @type {any} */
+    let out;
+    await act(async () => {
+      out = await result.current.procesarTranscripcion('aquí sembré 20 tomates');
+    });
+    expect(out.accion).toBe('observacion');
+    expect(out.observacion.loteId).toBe('potrero');
+    expect(onObservacion).toHaveBeenCalledTimes(1);
+    expect(useRecorridoStore.getState().observaciones).toHaveLength(1);
+  });
+
+  it('ignora transcripción vacía', async () => {
+    const { result } = renderHook(() => useRecorridoVoz({}));
+    /** @type {any} */
+    let out;
+    await act(async () => { out = await result.current.procesarTranscripcion('   '); });
+    expect(out.accion).toBe('ignorado');
+  });
+});
+
+describe('capturarEspecie', () => {
+  it('reconoce la especie, registra observación planta_foto y limpia la señal', async () => {
+    const recognizer = vi.fn().mockResolvedValue({
+      scientific_name: 'Musa paradisiaca',
+      common_name: 'plátano',
+    });
+    const registroOpts = { lotes: [POTRERO], getPosition: gpsDentro(), now: 20 };
+    const { result } = renderHook(() => useRecorridoVoz({ recognizer, registroOpts }));
+
+    // Primero dispara la cámara para tener pendingCamera con la frase.
+    await act(async () => { await result.current.procesarTranscripcion('mira esta mata'); });
+
+    /** @type {any} */
+    let out;
+    await act(async () => { out = await result.current.capturarEspecie(new Blob(['x'])); });
+
+    expect(recognizer).toHaveBeenCalledTimes(1);
+    expect(out.especie.common_name).toBe('plátano');
+    expect(out.observacion.tipo).toBe('planta_foto');
+    expect(out.observacion.especie.scientific_name).toBe('Musa paradisiaca');
+    expect(out.observacion.loteId).toBe('potrero');
+    expect(result.current.pendingCamera).toBeNull();
+    // Una sola observación (sin doble-apilado).
+    expect(useRecorridoStore.getState().observaciones).toHaveLength(1);
+  });
+
+  it('si el reconocedor falla registra observación "sin identificar"', async () => {
+    const recognizer = vi.fn().mockRejectedValue(new Error('vision down'));
+    const registroOpts = { lotes: [POTRERO], getPosition: gpsDentro(), now: 30 };
+    const { result } = renderHook(() => useRecorridoVoz({ recognizer, registroOpts }));
+    /** @type {any} */
+    let out;
+    await act(async () => { out = await result.current.capturarEspecie(new Blob(['x'])); });
+    expect(out.especie).toBeNull();
+    expect(out.observacion.tipo).toBe('planta_foto');
+    expect(out.observacion.texto).toMatch(/sin identificar/i);
+  });
+});

--- a/src/hooks/useRecorridoVoz.js
+++ b/src/hooks/useRecorridoVoz.js
@@ -1,0 +1,152 @@
+/**
+ * useRecorridoVoz — PEGAMENTO del "Recorrido de finca por voz".
+ *
+ * Compone las tripas (recorridoService + useRecorridoStore) en una API que el
+ * modo campo / la escucha empujan y que Fable consume. NO maneja la escucha ni
+ * el wake-word: recibe transcripciones ya listas y las enruta.
+ *
+ * ── Flujo por transcripción (procesarTranscripcion) ─────────────────────────
+ *   1. Intención cámara ("mira esta mata") → expone `pendingCamera` (señal para
+ *      que la UI abra la cámara) y llama onCameraRequested. NO registra todavía.
+ *   2. Intención resumen ("¿cómo quedó el recorrido?") → arma y LEE el resumen
+ *      (TTS kokoro) y llama onResumen con el texto.
+ *   3. Cualquier otra cosa → registra la observación (GPS + lote) en el store.
+ *
+ * ── Cierre del loop de cámara (capturarEspecie) ─────────────────────────────
+ * Cuando la UI ya tomó la foto, llama `capturarEspecie(blob)`: corre
+ * `recognizeSpeciesGrounded` (que ya existe), captura GPS + lote y apila una
+ * observación tipo 'planta_foto' con la especie reconocida. Devuelve el
+ * resultado para que la UI muestre el diagnóstico.
+ *
+ * `recognizer` y (en el store) `getPosition` son inyectables para tests.
+ *
+ * // TODO fable: la UI del recorrido debe:
+ * //   - llamar `procesarTranscripcion(texto)` por cada transcripción del modo
+ * //     campo (escuchaService / useModoCampo) sin apagar la escucha;
+ * //   - cuando `pendingCamera` != null, abrir la cámara y al capturar la foto
+ * //     llamar `capturarEspecie(blob)`, luego `limpiarCamara()`;
+ * //   - pintar el estado de useRecorridoStore (observaciones / croquis).
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ *
+ * @module useRecorridoVoz
+ */
+import { useCallback, useState } from 'react';
+import useRecorridoStore from '../store/useRecorridoStore';
+import {
+  detectarIntencionCamara,
+  detectarIntencionResumen,
+} from '../services/recorridoService';
+import { recognizeSpeciesGrounded } from '../services/aiService';
+
+/**
+ * @typedef {Object} SeñalCamara
+ * @property {'planta'} sujeto
+ * @property {string} frase       transcripción que disparó la cámara.
+ * @property {number} requestedAt epoch ms.
+ */
+
+/**
+ * @param {Object} [options]
+ * @param {(deteccion:{sujeto:'planta'|null, frase:string})=>void} [options.onCameraRequested]
+ * @param {(texto:string)=>void} [options.onResumen]
+ * @param {(obs:Object|null)=>void} [options.onObservacion]
+ * @param {(blob:Blob, opts?:Object)=>Promise<Object|null>} [options.recognizer]
+ *   — default: recognizeSpeciesGrounded.
+ * @param {{ maxPorLote?: number, speak?: Function }} [options.resumenOpts]
+ * @param {{ lotes?: Array<Object>, getPosition?: Function, now?: number }} [options.registroOpts]
+ */
+export function useRecorridoVoz(options = {}) {
+  const {
+    onCameraRequested,
+    onResumen,
+    onObservacion,
+    recognizer = recognizeSpeciesGrounded,
+    resumenOpts,
+    registroOpts,
+  } = options;
+
+  /** @type {[SeñalCamara|null, Function]} */
+  const [pendingCamera, setPendingCamera] = useState(null);
+
+  const registrarObservacion = useRecorridoStore((s) => s.registrarObservacion);
+  const leerResumen = useRecorridoStore((s) => s.leerResumen);
+
+  /**
+   * Enruta una transcripción del modo campo. No throwea: cualquier fallo se
+   * refleja en el `accion` retornado.
+   *
+   * @param {string} texto
+   * @returns {Promise<{accion:'ignorado'|'camara'|'resumen'|'observacion', [k:string]:any}>}
+   */
+  const procesarTranscripcion = useCallback(async (texto) => {
+    const clean = (texto || '').toString().trim();
+    if (!clean) return { accion: 'ignorado' };
+
+    // 1. Cámara ("mira esta mata").
+    const cam = detectarIntencionCamara(clean);
+    if (cam.match) {
+      const señal = { sujeto: 'planta', frase: cam.frase, requestedAt: Date.now() };
+      setPendingCamera(señal);
+      if (typeof onCameraRequested === 'function') onCameraRequested(cam);
+      return { accion: 'camara', deteccion: cam };
+    }
+
+    // 2. Resumen ("¿cómo quedó el recorrido?").
+    const res = detectarIntencionResumen(clean);
+    if (res.match) {
+      const dicho = await leerResumen(resumenOpts);
+      if (typeof onResumen === 'function') onResumen(dicho);
+      return { accion: 'resumen', texto: dicho };
+    }
+
+    // 3. Observación normal.
+    const obs = await registrarObservacion(clean, 'observacion', registroOpts);
+    if (typeof onObservacion === 'function') onObservacion(obs);
+    return { accion: 'observacion', observacion: obs };
+  }, [registrarObservacion, leerResumen, onCameraRequested, onResumen, onObservacion, resumenOpts, registroOpts]);
+
+  /**
+   * Cierra el loop de cámara: reconoce la especie de la foto (grounded),
+   * captura GPS + lote y apila una observación 'planta_foto'. Devuelve el
+   * reconocimiento (o null) para que la UI pinte el diagnóstico.
+   *
+   * @param {Blob} imageBlob
+   * @param {Object} [recognizeOpts] - pasado al recognizer (onToken, signal).
+   * @returns {Promise<{ especie: Object|null, observacion: Object|null }>}
+   */
+  const capturarEspecie = useCallback(async (imageBlob, recognizeOpts = {}) => {
+    let especie = null;
+    try {
+      especie = await recognizer(imageBlob, recognizeOpts);
+    } catch (_) {
+      especie = null;
+    }
+    const etiqueta = especie
+      ? (especie.common_name || especie.scientific_name || 'planta reconocida')
+      : 'planta sin identificar';
+    const frase = pendingCamera?.frase || '';
+    const texto = frase ? `${frase} — ${etiqueta}` : `Foto de ${etiqueta}`;
+
+    // Un solo registro: captura GPS + lote y adjunta la especie reconocida.
+    const obs = await registrarObservacion(texto, 'planta_foto', {
+      ...registroOpts,
+      especie,
+    });
+    setPendingCamera(null);
+    return { especie, observacion: obs };
+  }, [recognizer, registrarObservacion, pendingCamera, registroOpts]);
+
+  /** Descarta la señal de cámara (usuario canceló la foto). */
+  const limpiarCamara = useCallback(() => setPendingCamera(null), []);
+
+  return {
+    /** @type {SeñalCamara|null} */
+    pendingCamera,
+    procesarTranscripcion,
+    capturarEspecie,
+    limpiarCamara,
+  };
+}
+
+export default useRecorridoVoz;

--- a/src/services/__tests__/recorridoService.test.js
+++ b/src/services/__tests__/recorridoService.test.js
@@ -1,0 +1,284 @@
+/**
+ * recorridoService — tripas del "Recorrido de finca por voz".
+ * Cubre: point-in-polygon, resolución de lote (dentro / anidado / cercano /
+ * sin lote), construcción y captura de observación, detectores de intención y
+ * readback del resumen.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  pointInRing,
+  loteRing,
+  pointInLote,
+  resolveLoteForPoint,
+  buildObservacion,
+  capturarObservacion,
+  detectarIntencionCamara,
+  detectarIntencionResumen,
+  construirResumenRecorrido,
+  leerResumenRecorrido,
+} from '../recorridoService';
+
+// ── Fixtures de lotes (asset--land con WKT) ──────────────────────────────────
+
+/** Construye un asset--land con geometría polígono desde vértices [lng,lat]. */
+const lotePoligono = (id, name, ringLngLat) => ({
+  id,
+  type: 'asset--land',
+  attributes: {
+    name,
+    land_type: 'field',
+    intrinsic_geometry: {
+      value: `POLYGON((${ringLngLat.map(([lng, lat]) => `${lng} ${lat}`).join(', ')}))`,
+    },
+  },
+});
+
+/** Construye un asset--land tipo punto (sin polígono). */
+const lotePunto = (id, name, lng, lat) => ({
+  id,
+  type: 'asset--land',
+  attributes: {
+    name,
+    land_type: 'bed',
+    intrinsic_geometry: { value: `POINT(${lng} ${lat})` },
+  },
+});
+
+// Cuadrado grande ~ (4.529..4.531, -73.925..-73.923)
+const POTRERO = lotePoligono('potrero', 'Potrero de abajo', [
+  [-73.925, 4.529],
+  [-73.925, 4.531],
+  [-73.923, 4.531],
+  [-73.923, 4.529],
+  [-73.925, 4.529],
+]);
+
+// Cuadrado pequeño DENTRO del potrero (era anidada).
+const ERA = lotePoligono('era', 'Era de cilantro', [
+  [-73.9245, 4.5295],
+  [-73.9245, 4.5300],
+  [-73.9240, 4.5300],
+  [-73.9240, 4.5295],
+  [-73.9245, 4.5295],
+]);
+
+describe('pointInRing', () => {
+  const ring = [
+    { lat: 0, lng: 0 },
+    { lat: 0, lng: 2 },
+    { lat: 2, lng: 2 },
+    { lat: 2, lng: 0 },
+  ];
+  it('detecta un punto interior', () => {
+    expect(pointInRing({ lat: 1, lng: 1 }, ring)).toBe(true);
+  });
+  it('rechaza un punto exterior', () => {
+    expect(pointInRing({ lat: 5, lng: 5 }, ring)).toBe(false);
+  });
+  it('es defensivo con entradas inválidas', () => {
+    expect(pointInRing(null, ring)).toBe(false);
+    expect(pointInRing({ lat: 1, lng: 1 }, [])).toBe(false);
+    expect(pointInRing({ lat: NaN, lng: 1 }, ring)).toBe(false);
+  });
+});
+
+describe('loteRing / pointInLote', () => {
+  it('extrae el anillo de un lote polígono', () => {
+    const ring = loteRing(POTRERO);
+    expect(Array.isArray(ring)).toBe(true);
+    expect(ring.length).toBeGreaterThanOrEqual(4);
+    expect(ring[0]).toHaveProperty('lat');
+    expect(ring[0]).toHaveProperty('lng');
+  });
+  it('devuelve null para un lote punto', () => {
+    expect(loteRing(lotePunto('p', 'Punto', -73.9, 4.6))).toBeNull();
+  });
+  it('pointInLote respeta la geometría', () => {
+    expect(pointInLote({ lat: 4.530, lng: -73.924 }, POTRERO)).toBe(true);
+    expect(pointInLote({ lat: 4.540, lng: -73.900 }, POTRERO)).toBe(false);
+  });
+});
+
+describe('resolveLoteForPoint', () => {
+  it('resuelve DENTRO cuando el punto cae en el polígono', () => {
+    const r = resolveLoteForPoint({ lat: 4.530, lng: -73.924 }, [POTRERO]);
+    expect(r.pertenencia).toBe('dentro');
+    expect(r.loteId).toBe('potrero');
+    expect(r.loteNombre).toBe('Potrero de abajo');
+    expect(r.distanciaM).toBe(0);
+  });
+
+  it('con lotes anidados gana el de menor área (más específico)', () => {
+    // Punto dentro de la era (que está dentro del potrero).
+    const r = resolveLoteForPoint({ lat: 4.52975, lng: -73.92425 }, [POTRERO, ERA]);
+    expect(r.pertenencia).toBe('dentro');
+    expect(r.loteId).toBe('era');
+  });
+
+  it('cae a CERCANO por centroide cuando no hay contención', () => {
+    const punto = lotePunto('semillero', 'Semillero', -73.8, 4.6);
+    // ~11 m al norte del centroide del punto.
+    const r = resolveLoteForPoint({ lat: 4.6001, lng: -73.8 }, [punto], { maxNearbyM: 30 });
+    expect(r.pertenencia).toBe('cercano');
+    expect(r.loteId).toBe('semillero');
+    expect(r.distanciaM).toBeGreaterThan(0);
+    expect(r.distanciaM).toBeLessThanOrEqual(30);
+  });
+
+  it('devuelve SIN_LOTE cuando está lejos de todo', () => {
+    const r = resolveLoteForPoint({ lat: 10, lng: -70 }, [POTRERO, ERA]);
+    expect(r.pertenencia).toBe('sin_lote');
+    expect(r.loteId).toBeNull();
+  });
+
+  it('es defensivo con coordenada inválida', () => {
+    expect(resolveLoteForPoint(null, [POTRERO]).pertenencia).toBe('sin_lote');
+    expect(resolveLoteForPoint({ lat: NaN, lng: 1 }, [POTRERO]).pertenencia).toBe('sin_lote');
+  });
+});
+
+describe('buildObservacion', () => {
+  it('arma una observación con lote resuelto', () => {
+    const obs = buildObservacion({
+      texto: '  aquí sembré 20 tomates  ',
+      tipo: 'observacion',
+      coord: { lat: 4.530, lng: -73.924 },
+      accuracy: 8,
+      lotes: [POTRERO],
+      now: 1000,
+      id: 'obs-1',
+    });
+    expect(obs).toMatchObject({
+      id: 'obs-1',
+      texto: 'aquí sembré 20 tomates',
+      tipo: 'observacion',
+      coord: { lat: 4.530, lng: -73.924 },
+      accuracy: 8,
+      loteId: 'potrero',
+      pertenencia: 'dentro',
+      timestamp: 1000,
+    });
+  });
+
+  it('sin coord → sin lote, coord null', () => {
+    const obs = buildObservacion({ texto: 'este lote está seco', coord: null, lotes: [POTRERO], now: 5 });
+    expect(obs.coord).toBeNull();
+    expect(obs.pertenencia).toBe('sin_lote');
+    expect(obs.loteId).toBeNull();
+    expect(typeof obs.id).toBe('string');
+  });
+});
+
+describe('capturarObservacion', () => {
+  it('captura GPS inyectado y resuelve el lote', async () => {
+    const getPosition = vi.fn().mockResolvedValue({ lat: 4.530, lng: -73.924, accuracy: 6 });
+    const obs = await capturarObservacion({
+      texto: 'mata de plátano cargada',
+      lotes: [POTRERO],
+      getPosition,
+      now: 42,
+    });
+    expect(getPosition).toHaveBeenCalledTimes(1);
+    expect(obs.coord).toEqual({ lat: 4.530, lng: -73.924 });
+    expect(obs.accuracy).toBe(6);
+    expect(obs.loteId).toBe('potrero');
+    expect(obs.timestamp).toBe(42);
+  });
+
+  it('si el GPS falla registra igual SIN coord (offline-first)', async () => {
+    const getPosition = vi.fn().mockRejectedValue(new Error('permission_denied'));
+    const obs = await capturarObservacion({ texto: 'lote seco', lotes: [POTRERO], getPosition, now: 7 });
+    expect(obs.coord).toBeNull();
+    expect(obs.pertenencia).toBe('sin_lote');
+    expect(obs.texto).toBe('lote seco');
+  });
+});
+
+describe('detectarIntencionCamara', () => {
+  it.each([
+    'mira esta mata',
+    'revisa esta planta que está rara',
+    'qué tiene este árbol',
+    'tómale foto a esta matica',
+    'reconoce este arbolito',
+  ])('detecta "%s"', (frase) => {
+    const r = detectarIntencionCamara(frase);
+    expect(r.match).toBe(true);
+    expect(r.sujeto).toBe('planta');
+    expect(r.frase).toBe(frase);
+  });
+
+  it.each([
+    'aquí sembré veinte tomates',
+    'mira el cielo que está despejado',
+    'este lote está seco',
+    '',
+  ])('NO dispara con "%s"', (frase) => {
+    expect(detectarIntencionCamara(frase).match).toBe(false);
+  });
+});
+
+describe('detectarIntencionResumen', () => {
+  it.each([
+    'cómo quedó el recorrido',
+    'resumen del recorrido por favor',
+    'qué llevo registrado hoy',
+    'léeme el recorrido',
+  ])('detecta "%s"', (frase) => {
+    expect(detectarIntencionResumen(frase).match).toBe(true);
+  });
+
+  it.each([
+    'aquí sembré veinte tomates',
+    'mira esta mata',
+    'este lote está seco',
+    '',
+  ])('NO dispara con "%s"', (frase) => {
+    expect(detectarIntencionResumen(frase).match).toBe(false);
+  });
+});
+
+describe('construirResumenRecorrido', () => {
+  it('mensaje vacío sin observaciones', () => {
+    expect(construirResumenRecorrido([])).toMatch(/todav[ií]a no has registrado/i);
+  });
+
+  it('agrupa por lote y cuenta', () => {
+    const obs = [
+      { texto: 'sembré 20 tomates', loteNombre: 'Potrero de abajo' },
+      { texto: 'está seco', loteNombre: 'Potrero de abajo' },
+      { texto: 'mata cargada', loteNombre: 'Era de cilantro' },
+    ];
+    const texto = construirResumenRecorrido(obs);
+    expect(texto).toContain('3 observaciones');
+    expect(texto).toContain('Potrero de abajo');
+    expect(texto).toContain('Era de cilantro');
+    // Sin markdown (apto TTS).
+    expect(texto).not.toMatch(/[*`#]/);
+  });
+
+  it('agrupa las sin lote como "Sin lote asignado"', () => {
+    const texto = construirResumenRecorrido([{ texto: 'algo', loteNombre: null }]);
+    expect(texto).toContain('Sin lote asignado');
+  });
+});
+
+describe('leerResumenRecorrido', () => {
+  it('arma el texto y lo pasa al speaker inyectado', async () => {
+    const speak = vi.fn().mockResolvedValue(true);
+    const texto = await leerResumenRecorrido(
+      [{ texto: 'sembré tomates', loteNombre: 'Potrero' }],
+      { speak },
+    );
+    expect(speak).toHaveBeenCalledTimes(1);
+    expect(speak).toHaveBeenCalledWith(texto);
+    expect(texto).toContain('1 observación');
+  });
+
+  it('un TTS caído no tumba el resumen (devuelve el texto)', async () => {
+    const speak = vi.fn().mockRejectedValue(new Error('kokoro down'));
+    const texto = await leerResumenRecorrido([{ texto: 'x', loteNombre: 'L' }], { speak });
+    expect(typeof texto).toBe('string');
+    expect(texto.length).toBeGreaterThan(0);
+  });
+});

--- a/src/services/recorridoService.js
+++ b/src/services/recorridoService.js
@@ -1,0 +1,426 @@
+/**
+ * recorridoService.js — TRIPAS del "Recorrido de finca por voz".
+ *
+ * FEATURE: el campesino camina su finca con el modo campo prendido y narra lo
+ * que ve ("aquí sembré 20 tomates", "este lote está seco", "mira esta mata").
+ * Chagra registra cada narración, le pega la coordenada GPS actual, resuelve a
+ * qué lote pertenece (point-in-polygon contra la geometría del asset--land) y
+ * arma un resumen que puede leer en voz alta.
+ *
+ * Esta capa es PURA / testable y NO decide UI: expone la lógica para que el
+ * canvas del croquis (Fable) y el hook de voz solo consuman.
+ *
+ * ── Piezas ──────────────────────────────────────────────────────────────────
+ *   1. GPS → lote:  pointInRing / resolveLoteForPoint / buildObservacion /
+ *      capturarObservacion  (deliverable 1).
+ *   3. Readback:    construirResumenRecorrido / leerResumenRecorrido
+ *      (deliverable 3 — arma el texto y dispara el TTS kokoro existente).
+ *   4. Intención:   detectarIntencionCamara / detectarIntencionResumen
+ *      (deliverable 4 — detectores deterministas on-device, sin red).
+ *
+ * ── Grounding / offline-first ────────────────────────────────────────────────
+ * - La geometría de los lotes se lee del MISMO loteService (asset--land WKT)
+ *   que ya usa el croquis; no inventamos backend ni fuente de datos nueva.
+ * - Si el GPS falla (permiso denegado, timeout, sin señal), la observación se
+ *   registra igual SIN coordenada — el recorrido nunca se cae por falta de
+ *   señal (offline-first).
+ * - Los detectores de intención son deterministas y síncronos (sin red, sin
+ *   LLM), en la línea de voiceFieldExtractor: funcionan caminando sin datos.
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ *
+ * @module recorridoService
+ */
+
+import { getCurrentPosition } from './gpsFincaDetector';
+import * as loteService from './loteService';
+import { haversineMeters } from '../utils/geo';
+import { speakSentences } from './ttsService';
+import { normalize } from '../utils/entityMatcher';
+import { newUlid } from '../utils/id';
+
+/**
+ * @typedef {{ lat:number, lng:number }} LatLng
+ */
+
+/**
+ * @typedef {Object} ObservacionRecorrido
+ * @property {string} id             ULID único de la observación.
+ * @property {string} texto          transcripción cruda de lo que narró el campesino.
+ * @property {string} tipo           'observacion' | 'planta_foto' | string libre.
+ * @property {LatLng|null} coord     coordenada capturada, o null si no hubo GPS.
+ * @property {number|null} accuracy  precisión GPS en metros, o null.
+ * @property {string|null} loteId    id del asset--land resuelto, o null.
+ * @property {string|null} loteNombre nombre legible del lote, o null.
+ * @property {'dentro'|'cercano'|'sin_lote'} pertenencia  cómo se resolvió el lote.
+ * @property {number|null} distanciaM  distancia al lote (0 si dentro), o null.
+ * @property {number} timestamp      epoch ms del registro.
+ * @property {Object|null} [especie] resultado de reconocimiento (si vino de cámara).
+ */
+
+/**
+ * @typedef {Object} ResolucionLote
+ * @property {Object|null} lote
+ * @property {string|null} loteId
+ * @property {string|null} loteNombre
+ * @property {'dentro'|'cercano'|'sin_lote'} pertenencia
+ * @property {number|null} distanciaM
+ */
+
+// ── 1. GPS → lote ─────────────────────────────────────────────────────────────
+
+/** Radio (m) para considerar que una coord "cae cerca" de un lote sin contenerla. */
+const DEFAULT_MAX_NEARBY_M = 30;
+
+/** Resolución vacía reutilizable (sin lote). */
+const SIN_LOTE = Object.freeze({
+  lote: null,
+  loteId: null,
+  loteNombre: null,
+  pertenencia: 'sin_lote',
+  distanciaM: null,
+});
+
+/**
+ * Point-in-polygon por ray casting (algoritmo par/impar). El anillo se da como
+ * lista de vértices {lat,lng}; el punto como {lat,lng}. No requiere que el
+ * anillo esté cerrado (usa el vértice anterior de forma circular).
+ *
+ * @param {LatLng} point
+ * @param {Array<LatLng>} ring
+ * @returns {boolean} true si el punto cae dentro del anillo.
+ */
+export function pointInRing(point, ring) {
+  if (!point || !Array.isArray(ring) || ring.length < 3) return false;
+  const x = point.lng;
+  const y = point.lat;
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return false;
+
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i, i += 1) {
+    const xi = ring[i].lng;
+    const yi = ring[i].lat;
+    const xj = ring[j].lng;
+    const yj = ring[j].lat;
+    if (!Number.isFinite(xi) || !Number.isFinite(yi) || !Number.isFinite(xj) || !Number.isFinite(yj)) {
+      continue;
+    }
+    const intersect = (yi > y) !== (yj > y)
+      && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+/**
+ * Extrae el anillo exterior de un lote como lista de vértices {lat,lng}, o null
+ * si el lote no tiene geometría de polígono (un punto no "contiene" nada).
+ *
+ * @param {Object} lote - asset--land (shape de loteService).
+ * @returns {Array<LatLng>|null}
+ */
+export function loteRing(lote) {
+  const geo = /** @type {any} */ (loteService.loteGeoJson(lote));
+  if (!geo || geo.type !== 'Polygon' || !Array.isArray(geo.coordinates)) return null;
+  const ring = geo.coordinates[0];
+  if (!Array.isArray(ring) || ring.length < 3) return null;
+  return ring
+    .filter((c) => Array.isArray(c) && c.length >= 2)
+    .map(([lon, lat]) => ({ lat, lng: lon }));
+}
+
+/** ¿La coordenada cae DENTRO del polígono del lote? */
+export function pointInLote(point, lote) {
+  const ring = loteRing(lote);
+  return ring ? pointInRing(point, ring) : false;
+}
+
+const nombreDe = (lote) => lote?.attributes?.name || lote?.name || 'Lote sin nombre';
+
+/**
+ * Resuelve a qué lote pertenece una coordenada.
+ *
+ * Estrategia:
+ *   1. Contención: los lotes cuyo polígono contiene el punto. Si varios lo
+ *      contienen (lotes anidados: una era dentro de un potrero) gana el de
+ *      MENOR área — el más específico.
+ *   2. Cercanía (fallback): si ningún polígono lo contiene, el lote con el
+ *      centroide más cercano dentro de `maxNearbyM` metros → pertenencia
+ *      'cercano' (cubre lotes-punto y GPS impreciso en el borde).
+ *   3. Nada → 'sin_lote'.
+ *
+ * @param {LatLng} point
+ * @param {Array<Object>} lotes - asset--land[].
+ * @param {{ maxNearbyM?: number }} [opts]
+ * @returns {ResolucionLote}
+ */
+export function resolveLoteForPoint(point, lotes = [], opts = {}) {
+  const maxNearbyM = Number.isFinite(opts.maxNearbyM) ? opts.maxNearbyM : DEFAULT_MAX_NEARBY_M;
+  if (!point || !Number.isFinite(point.lat) || !Number.isFinite(point.lng) || !Array.isArray(lotes)) {
+    return { ...SIN_LOTE };
+  }
+
+  // 1. Contención (el más específico = menor área).
+  /** @type {Array<{lote:any, area:number}>} */
+  const containers = [];
+  for (const lote of lotes) {
+    if (pointInLote(point, lote)) {
+      const area = loteService.loteAreaSqMeters(lote) || Number.POSITIVE_INFINITY;
+      containers.push({ lote, area });
+    }
+  }
+  if (containers.length > 0) {
+    containers.sort((a, b) => a.area - b.area);
+    const best = containers[0].lote;
+    return {
+      lote: best,
+      loteId: best.id || null,
+      loteNombre: nombreDe(best),
+      pertenencia: 'dentro',
+      distanciaM: 0,
+    };
+  }
+
+  // 2. Cercanía por centroide.
+  let nearest = null;
+  let nearestD = Number.POSITIVE_INFINITY;
+  for (const lote of lotes) {
+    const c = loteService.loteCentroid(lote);
+    if (!c) continue;
+    const d = haversineMeters(point, c);
+    if (d < nearestD) {
+      nearestD = d;
+      nearest = lote;
+    }
+  }
+  if (nearest && nearestD <= maxNearbyM) {
+    return {
+      lote: nearest,
+      loteId: nearest.id || null,
+      loteNombre: nombreDe(nearest),
+      pertenencia: 'cercano',
+      distanciaM: Math.round(nearestD),
+    };
+  }
+
+  return { ...SIN_LOTE };
+}
+
+/**
+ * Construye (SIN tocar GPS ni red) una observación de recorrido a partir de una
+ * coordenada ya conocida. Función pura — el punto de prueba para el pipeline.
+ *
+ * @param {Object} [args]
+ * @param {string} [args.texto='']
+ * @param {string} [args.tipo='observacion']
+ * @param {LatLng|null} [args.coord=null]
+ * @param {number|null} [args.accuracy=null]
+ * @param {Array<Object>} [args.lotes=[]]
+ * @param {number} [args.now=Date.now()]
+ * @param {string} [args.id]
+ * @param {Object|null} [args.especie=null]
+ * @returns {ObservacionRecorrido}
+ */
+export function buildObservacion({
+  texto = '',
+  tipo = 'observacion',
+  coord = null,
+  accuracy = null,
+  lotes = [],
+  now = Date.now(),
+  id,
+  especie = null,
+} = {}) {
+  const validCoord = coord && Number.isFinite(coord.lat) && Number.isFinite(coord.lng)
+    ? { lat: coord.lat, lng: coord.lng }
+    : null;
+  const resolved = validCoord ? resolveLoteForPoint(validCoord, lotes) : { ...SIN_LOTE };
+  return {
+    id: id || newUlid(),
+    texto: (texto || '').toString().trim(),
+    tipo: tipo || 'observacion',
+    coord: validCoord,
+    accuracy: Number.isFinite(accuracy) ? accuracy : null,
+    loteId: resolved.loteId,
+    loteNombre: resolved.loteNombre,
+    pertenencia: resolved.pertenencia,
+    distanciaM: resolved.distanciaM,
+    timestamp: Number.isFinite(now) ? now : Date.now(),
+    especie: especie || null,
+  };
+}
+
+/**
+ * Captura la posición GPS actual, resuelve el lote y arma la observación.
+ * Orquestador async del deliverable 1.
+ *
+ * `getPosition` es inyectable (default: gpsFincaDetector.getCurrentPosition)
+ * para poder testear sin navegador. Si la captura de GPS falla, la observación
+ * se registra igual sin coordenada (offline-first): perder señal NO puede
+ * perder la nota del campesino.
+ *
+ * @param {Object} [args]
+ * @param {string} [args.texto='']
+ * @param {string} [args.tipo='observacion']
+ * @param {Array<Object>} [args.lotes=[]]
+ * @param {Function} [args.getPosition] - default: gpsFincaDetector.getCurrentPosition.
+ * @param {number} [args.now]
+ * @param {number} [args.timeout]
+ * @param {Object|null} [args.especie]
+ * @returns {Promise<ObservacionRecorrido>}
+ */
+export async function capturarObservacion({
+  texto = '',
+  tipo = 'observacion',
+  lotes = [],
+  getPosition = getCurrentPosition,
+  now,
+  timeout,
+  especie = null,
+} = {}) {
+  const ts = Number.isFinite(now) ? now : Date.now();
+  let coord = null;
+  let accuracy = null;
+  try {
+    const pos = await getPosition({ timeout });
+    if (pos && Number.isFinite(pos.lat) && Number.isFinite(pos.lng)) {
+      coord = { lat: pos.lat, lng: pos.lng };
+      accuracy = Number.isFinite(pos.accuracy) ? pos.accuracy : null;
+    }
+  } catch (_) {
+    // Sin GPS (permiso denegado / timeout / offline): registramos sin coord.
+    coord = null;
+  }
+  return buildObservacion({ texto, tipo, coord, accuracy, lotes, now: ts, especie });
+}
+
+// ── 4. Detección de intención (on-device, sin red) ───────────────────────────
+
+// "mira esta mata", "revisa esta planta", "qué tiene este árbol", "tómale foto".
+const CAMARA_VERB_RE = /\b(mira|mire|mir[aá]|vea|ve[aá]|revisa|revis[aá]|chequea|chequ[eé]a|observa|f[ií]jate|f[ií]jese|toma|t[oó]male|reconoce|reconoc[eé]|identifica|identific[aá]|foto|fotea|retrata|que\s+es|qu[eé]\s+es|que\s+tiene|qu[eé]\s+tiene|que\s+le\s+pasa|qu[eé]\s+le\s+pasa)\b/;
+// Sujeto deíctico + sustantivo de planta ("esta mata", "ese palo", "aquel arbolito").
+// (el texto llega normalizado: sin acentos y en minúscula).
+const CAMARA_SUJETO_RE = /\b(esta|este|esa|ese|aquella|aquel|la|el)\s+(mata|matas|matica|maticas|planta|plantas|plantica|planticas|palo|palito|arbol|arbolito|arbolitos|arbusto|arbustos|hoja|hojas|fruto|frutos|flor|flores|racimo|racimos|cultivo|siembra|rama|ramas)\b/;
+
+/**
+ * Detecta la intención "mira esta mata / revisa esta planta" → señal para abrir
+ * la cámara y correr `recognizeSpeciesGrounded`. Determinista, sin red.
+ *
+ * Requiere AMBOS: un verbo/gatillo de mirar-fotografiar Y un sujeto deíctico de
+ * planta ("esta mata"). Así "mira el cielo" o "revisa la cerca" NO disparan.
+ *
+ * @param {string} texto - transcripción cruda.
+ * @returns {{ match: boolean, sujeto: 'planta'|null, frase: string }}
+ */
+export function detectarIntencionCamara(texto) {
+  const t = normalize((texto || '').toString());
+  if (!t) return { match: false, sujeto: null, frase: '' };
+  const match = CAMARA_VERB_RE.test(t) && CAMARA_SUJETO_RE.test(t);
+  return {
+    match,
+    sujeto: match ? 'planta' : null,
+    frase: match ? (texto || '').toString().trim() : '',
+  };
+}
+
+// Gatillo de resumen ("cómo quedó", "resumen", "qué llevo registrado", "léeme").
+const RESUMEN_CUE_RE = /\b(resumen|res[uú]meme|resume|repasa|repaso|leeme|l[eé]eme|leel[oa]|l[eé]el[oa]|como\s+quedo|como\s+qued[oó]|como\s+va|como\s+vamos|como\s+fue|que\s+llevo|qu[eé]\s+llevo|que\s+registr\w*|qu[eé]\s+registr\w*|que\s+anot\w*|qu[eé]\s+anot\w*|que\s+apunt\w*|qu[eé]\s+apunt\w*)\b/;
+// Contexto que confirma que se habla DEL recorrido (no otra cosa).
+const RESUMEN_CONTEXTO_RE = /\b(recorrido|recorri\w*|caminata|vuelta|la\s+finca|registrad\w*|apuntad\w*|anotad\w*|hoy)\b/;
+
+/**
+ * Detecta la intención "¿cómo quedó el recorrido?" → señal para armar y leer el
+ * resumen hablado. Determinista, sin red.
+ *
+ * @param {string} texto
+ * @returns {{ match: boolean, frase: string }}
+ */
+export function detectarIntencionResumen(texto) {
+  const t = normalize((texto || '').toString());
+  if (!t) return { match: false, frase: '' };
+  const match = RESUMEN_CUE_RE.test(t) && RESUMEN_CONTEXTO_RE.test(t);
+  return { match, frase: match ? (texto || '').toString().trim() : '' };
+}
+
+// ── 3. Readback hablado del resumen ──────────────────────────────────────────
+
+/**
+ * Forma mínima que necesita el readback (subconjunto de ObservacionRecorrido).
+ * @typedef {{ texto: string, loteNombre?: (string|null) }} ResumenItem
+ */
+
+/**
+ * Arma el TEXTO del resumen del recorrido, agrupado por lote y listo para TTS
+ * (sin markdown). Función pura — testeable sin audio.
+ *
+ * @param {Array<ResumenItem>} observaciones
+ * @param {{ maxPorLote?: number }} [opts]
+ * @returns {string} resumen hablado en español colombiano.
+ */
+export function construirResumenRecorrido(observaciones = [], opts = {}) {
+  const maxPorLote = Number.isFinite(opts.maxPorLote) ? opts.maxPorLote : 3;
+  const obs = Array.isArray(observaciones)
+    ? observaciones.filter((o) => o && typeof o.texto === 'string' && o.texto.trim())
+    : [];
+  if (obs.length === 0) {
+    return 'Todavía no has registrado nada en este recorrido.';
+  }
+
+  const total = obs.length;
+  /** @type {Map<string, Array<ResumenItem>>} */
+  const grupos = new Map();
+  for (const o of obs) {
+    const key = o.loteNombre || 'Sin lote';
+    if (!grupos.has(key)) grupos.set(key, []);
+    grupos.get(key)?.push(o);
+  }
+
+  const partes = [
+    `En este recorrido registraste ${total} ${total === 1 ? 'observación' : 'observaciones'}.`,
+  ];
+  for (const [nombre, items] of grupos) {
+    const etiqueta = nombre === 'Sin lote' ? 'Sin lote asignado' : nombre;
+    const textos = items.map((i) => i.texto.trim()).filter(Boolean);
+    const listadas = textos.slice(0, maxPorLote).join('; ');
+    const restantes = textos.length - Math.min(textos.length, maxPorLote);
+    const colita = restantes > 0 ? ` y ${restantes} más` : '';
+    const nNotas = items.length === 1 ? 'nota' : 'notas';
+    partes.push(`En ${etiqueta}: ${items.length} ${nNotas}. ${listadas}${colita}.`);
+  }
+  return partes.join(' ');
+}
+
+/**
+ * Arma el resumen y lo lee en voz alta con el TTS existente (kokoro vía
+ * speakSentences, con fallback Web Speech interno). Deliverable 3.
+ *
+ * `speak` es inyectable (default: ttsService.speakSentences) para tests. Un TTS
+ * caído NO tumba el resumen: el texto igual se devuelve para que la UI lo pinte.
+ *
+ * @param {Array<ResumenItem>} observaciones
+ * @param {{ maxPorLote?: number, speak?: (t:string)=>Promise<any> }} [opts]
+ * @returns {Promise<string>} el texto del resumen (ya emitido a TTS).
+ */
+export async function leerResumenRecorrido(observaciones = [], opts = {}) {
+  const texto = construirResumenRecorrido(observaciones, opts);
+  const hablar = typeof opts.speak === 'function' ? opts.speak : speakSentences;
+  try {
+    await hablar(texto);
+  } catch (_) {
+    // TTS caído: devolvemos el texto igual para que la vista lo muestre.
+  }
+  return texto;
+}
+
+export default {
+  pointInRing,
+  loteRing,
+  pointInLote,
+  resolveLoteForPoint,
+  buildObservacion,
+  capturarObservacion,
+  detectarIntencionCamara,
+  detectarIntencionResumen,
+  construirResumenRecorrido,
+  leerResumenRecorrido,
+};

--- a/src/store/__tests__/useRecorridoStore.test.js
+++ b/src/store/__tests__/useRecorridoStore.test.js
@@ -1,0 +1,115 @@
+/**
+ * useRecorridoStore — sesión del "Recorrido de finca por voz".
+ * GPS y lotes se inyectan (sin navegador ni IndexedDB).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import useRecorridoStore from '../useRecorridoStore';
+
+const POTRERO = {
+  id: 'potrero',
+  type: 'asset--land',
+  attributes: {
+    name: 'Potrero de abajo',
+    land_type: 'field',
+    intrinsic_geometry: {
+      value: 'POLYGON((-73.925 4.529, -73.925 4.531, -73.923 4.531, -73.923 4.529, -73.925 4.529))',
+    },
+  },
+};
+
+const gpsDentro = () => vi.fn().mockResolvedValue({ lat: 4.530, lng: -73.924, accuracy: 6 });
+
+beforeEach(() => {
+  useRecorridoStore.getState().reset();
+});
+
+describe('ciclo de vida', () => {
+  it('iniciarRecorrido activa la sesión y limpia', () => {
+    useRecorridoStore.getState().iniciarRecorrido();
+    const s = useRecorridoStore.getState();
+    expect(s.activo).toBe(true);
+    expect(s.startedAt).toBeTypeOf('number');
+    expect(s.observaciones).toEqual([]);
+  });
+
+  it('terminarRecorrido desactiva y devuelve el resumen', async () => {
+    const s = useRecorridoStore.getState();
+    s.iniciarRecorrido();
+    await s.registrarObservacion('sembré 20 tomates', 'observacion', {
+      lotes: [POTRERO], getPosition: gpsDentro(), now: 1,
+    });
+    const resumen = useRecorridoStore.getState().terminarRecorrido();
+    expect(useRecorridoStore.getState().activo).toBe(false);
+    expect(resumen.total).toBe(1);
+    expect(resumen.lotes).toContain('Potrero de abajo');
+    expect(resumen.texto).toContain('1 observación');
+  });
+});
+
+describe('registrarObservacion', () => {
+  it('NO registra fuera de un recorrido activo', async () => {
+    const obs = await useRecorridoStore.getState().registrarObservacion('algo', 'observacion', {
+      lotes: [POTRERO], getPosition: gpsDentro(),
+    });
+    expect(obs).toBeNull();
+    expect(useRecorridoStore.getState().observaciones).toHaveLength(0);
+  });
+
+  it('registra con GPS + lote resuelto y apila', async () => {
+    const s = useRecorridoStore.getState();
+    s.iniciarRecorrido();
+    const getPosition = gpsDentro();
+    const obs = await s.registrarObservacion('este lote está seco', 'observacion', {
+      lotes: [POTRERO], getPosition, now: 100,
+    });
+    expect(obs).not.toBeNull();
+    expect(obs.loteId).toBe('potrero');
+    expect(obs.pertenencia).toBe('dentro');
+    const st = useRecorridoStore.getState();
+    expect(st.observaciones).toHaveLength(1);
+    expect(st.ultimaObservacion).toEqual(obs);
+    expect(st.registrando).toBe(false);
+  });
+
+  it('ignora texto vacío', async () => {
+    const s = useRecorridoStore.getState();
+    s.iniciarRecorrido();
+    expect(await s.registrarObservacion('   ', 'observacion', {})).toBeNull();
+    expect(useRecorridoStore.getState().observaciones).toHaveLength(0);
+  });
+
+  it('adjunta la especie cuando viene de cámara', async () => {
+    const s = useRecorridoStore.getState();
+    s.iniciarRecorrido();
+    const especie = { scientific_name: 'Musa paradisiaca', common_name: 'plátano' };
+    const obs = await s.registrarObservacion('mira esta mata — plátano', 'planta_foto', {
+      lotes: [POTRERO], getPosition: gpsDentro(), now: 3, especie,
+    });
+    expect(obs.tipo).toBe('planta_foto');
+    expect(obs.especie).toEqual(especie);
+  });
+});
+
+describe('resumen / readback', () => {
+  it('leerResumen usa el speaker inyectado', async () => {
+    const s = useRecorridoStore.getState();
+    s.iniciarRecorrido();
+    await s.registrarObservacion('sembré tomates', 'observacion', {
+      lotes: [POTRERO], getPosition: gpsDentro(), now: 1,
+    });
+    const speak = vi.fn().mockResolvedValue(true);
+    const texto = await useRecorridoStore.getState().leerResumen({ speak });
+    expect(speak).toHaveBeenCalledWith(texto);
+    expect(texto).toContain('1 observación');
+  });
+
+  it('agregarObservacionListo apila una observación ya construida', () => {
+    const s = useRecorridoStore.getState();
+    s.iniciarRecorrido();
+    const obs = { id: 'x1', texto: 'nota', loteNombre: 'Potrero' };
+    const out = s.agregarObservacionListo(obs);
+    expect(out).toEqual(obs);
+    expect(useRecorridoStore.getState().observaciones).toHaveLength(1);
+    expect(s.agregarObservacionListo(null)).toBeNull();
+  });
+});

--- a/src/store/useRecorridoStore.js
+++ b/src/store/useRecorridoStore.js
@@ -1,0 +1,175 @@
+import { create } from 'zustand';
+import useLoteStore from './useLoteStore';
+import { MSG } from '../config/messages.js';
+import {
+  capturarObservacion,
+  construirResumenRecorrido,
+  leerResumenRecorrido,
+} from '../services/recorridoService';
+
+/**
+ * useRecorridoStore — estado de la SESIÓN de "Recorrido de finca por voz".
+ *
+ * Acumula las observaciones que el campesino narra mientras camina la finca con
+ * el modo campo prendido, SIN apagar la escucha. Cada observación entra por voz
+ * → captura GPS → resuelve lote (recorridoService) → se apila acá.
+ *
+ * Composición con modo campo: este store NO maneja la escucha ni el wake-word
+ * (eso vive en useModoCampo / escuchaService cuando aterrice). El hook de voz
+ * (useRecorridoVoz) es el pegamento: enruta cada transcripción del modo campo a
+ * `registrarObservacion` / `leerResumen`. Así empezar/terminar el recorrido es
+ * ortogonal a prender/apagar la escucha — se puede recorrer con la escucha ya
+ * activa.
+ *
+ * Fuente de verdad de los lotes: useLoteStore.lotes (espejo de useAssetStore.
+ * lands). Este store solo lee esos lotes al momento de resolver la coordenada;
+ * no persiste nada a farmOS (las observaciones del recorrido son estado de
+ * sesión efímero; su persistencia definitiva la decide la capa de arriba).
+ *
+ * // TODO fable: canvas del croquis / vista del recorrido — consumir
+ * //   `observaciones`, `ultimaObservacion` y `resumen()` para pintar los pines
+ * //   sobre el mapa y la lista lateral. Este store es la única fuente reactiva.
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+const useRecorridoStore = create((set, get) => ({
+  // ── Estado de sesión ───────────────────────────────────────────────────────
+  /** ¿Hay un recorrido en curso? */
+  activo: false,
+  /** epoch ms de inicio, o null. */
+  startedAt: null,
+  /** epoch ms de fin, o null. */
+  endedAt: null,
+  /** @type {Array<import('../services/recorridoService').ObservacionRecorrido>} */
+  observaciones: [],
+  /** última observación registrada (para toasts / centrar el mapa). */
+  ultimaObservacion: null,
+  /** true mientras se captura GPS + resuelve lote de una observación. */
+  registrando: false,
+  error: null,
+
+  // ── Ciclo de vida del recorrido ─────────────────────────────────────────────
+
+  /** Empieza un recorrido nuevo (limpia el anterior). */
+  iniciarRecorrido: () => {
+    set({
+      activo: true,
+      startedAt: Date.now(),
+      endedAt: null,
+      observaciones: [],
+      ultimaObservacion: null,
+      registrando: false,
+      error: null,
+    });
+  },
+
+  /**
+   * Termina el recorrido. NO limpia las observaciones (la vista todavía las
+   * muestra / las persiste). Devuelve el resumen para el readback.
+   * @returns {{ total:number, startedAt:number|null, endedAt:number|null, lotes:string[], observaciones:Array<Object>, texto:string }}
+   */
+  terminarRecorrido: () => {
+    set({ activo: false, endedAt: Date.now() });
+    return get().resumen();
+  },
+
+  // ── Registro de observaciones ───────────────────────────────────────────────
+
+  /**
+   * Registra una observación narrada: captura GPS, resuelve lote y la apila.
+   * Solo opera con un recorrido activo (evita capturar GPS por transcripciones
+   * sueltas fuera del recorrido).
+   *
+   * @param {string} texto - transcripción cruda.
+   * @param {string} [tipo='observacion']
+   * @param {{ lotes?: Array<Object>, getPosition?: Function, now?: number, especie?: Object|null }} [opts]
+   *   — `lotes`/`getPosition` inyectables para tests; en runtime toma los lotes
+   *   del store y el GPS real. `especie` adjunta un reconocimiento de cámara.
+   * @returns {Promise<import('../services/recorridoService').ObservacionRecorrido|null>}
+   */
+  registrarObservacion: async (texto, tipo = 'observacion', opts = {}) => {
+    if (!get().activo) return null;
+    const clean = (texto || '').toString().trim();
+    if (!clean) return null;
+
+    set({ registrando: true, error: null });
+    try {
+      const lotes = opts.lotes || useLoteStore.getState().lotes || [];
+      const obs = await capturarObservacion({
+        texto: clean,
+        tipo,
+        lotes,
+        getPosition: opts.getPosition,
+        now: opts.now,
+        especie: opts.especie || null,
+      });
+      set((s) => ({
+        observaciones: [...s.observaciones, obs],
+        ultimaObservacion: obs,
+        registrando: false,
+      }));
+      return obs;
+    } catch (err) {
+      set({ registrando: false, error: err?.message || MSG.recorrido.errorRegistro });
+      return null;
+    }
+  },
+
+  /**
+   * Apila una observación YA construida (p. ej. tras reconocer una especie con
+   * la cámara, donde el hook ya capturó GPS + especie). Síncrono.
+   *
+   * @param {import('../services/recorridoService').ObservacionRecorrido} obs
+   * @returns {import('../services/recorridoService').ObservacionRecorrido|null}
+   */
+  agregarObservacionListo: (obs) => {
+    if (!obs || !obs.id) return null;
+    set((s) => ({
+      observaciones: [...s.observaciones, obs],
+      ultimaObservacion: obs,
+    }));
+    return obs;
+  },
+
+  // ── Resumen / readback ──────────────────────────────────────────────────────
+
+  /**
+   * Resumen estructurado del recorrido (para la UI y el readback).
+   * @returns {{ total:number, startedAt:number|null, endedAt:number|null, lotes:string[], observaciones:Array<Object>, texto:string }}
+   */
+  resumen: () => {
+    const { observaciones, startedAt, endedAt } = get();
+    const lotes = Array.from(
+      new Set(observaciones.map((o) => o.loteNombre).filter(Boolean)),
+    );
+    return {
+      total: observaciones.length,
+      startedAt,
+      endedAt,
+      lotes,
+      observaciones,
+      texto: construirResumenRecorrido(observaciones),
+    };
+  },
+
+  /**
+   * Arma y LEE en voz alta el resumen del recorrido (TTS kokoro). Devuelve el
+   * texto emitido. `opts.speak` inyectable para tests.
+   * @param {{ maxPorLote?: number, speak?: (t:string)=>Promise<any> }} [opts]
+   * @returns {Promise<string>}
+   */
+  leerResumen: async (opts = {}) => leerResumenRecorrido(get().observaciones, opts),
+
+  /** Resetea todo el estado de sesión. */
+  reset: () => set({
+    activo: false,
+    startedAt: null,
+    endedAt: null,
+    observaciones: [],
+    ultimaObservacion: null,
+    registrando: false,
+    error: null,
+  }),
+}));
+
+export default useRecorridoStore;


### PR DESCRIPTION
## Qué es

Piezas **NO-visuales** (lógica/servicios/estado) del **Recorrido de finca por voz**: el campesino camina su finca con el modo campo prendido, narra lo que ve ("aquí sembré 20 tomates", "este lote está seco", "mira esta mata") y Chagra lo registra con GPS, lo mapea al lote y lo diagnostica.

El **canvas del croquis / vista del recorrido es de la capa visual** (Fable). Este PR deja los puntos de UI como placeholders `// TODO fable:` y expone una API limpia para que la vista solo pinte.

## Piezas (deliverables)

1. **voz-log → GPS → lote** — `src/services/recorridoService.js`
   - `pointInRing` (ray casting) + `loteRing`/`pointInLote` contra la geometría WKT de los `asset--land` (vía `loteService.loteGeoJson`).
   - `resolveLoteForPoint`: contención (lote más específico = menor área en lotes anidados), fallback por centroide cercano, o `sin_lote`.
   - `capturarObservacion`: captura GPS (`getCurrentPosition` existente de `gpsFincaDetector`) + resuelve lote + arma la observación.
2. **Sesión de recorrido** — `src/store/useRecorridoStore.js`
   - `iniciar/terminarRecorrido`, acumula `{texto, coord, lote, timestamp, tipo}` sin apagar la escucha. No maneja el wake-word (ortogonal a `useModoCampo`/`escuchaService`).
3. **Readback hablado** — `construirResumenRecorrido` (texto agrupado por lote, apto TTS) + `leerResumenRecorrido` (dispara `speakSentences` de kokoro, `ttsService`).
4. **Trigger voz→cámara** — `detectarIntencionCamara` / `detectarIntencionResumen` (deterministas, sin red) + hook `src/hooks/useRecorridoVoz.js` que enruta cada transcripción a cámara/resumen/observación y cierra el loop con `recognizeSpeciesGrounded` (existente).

`src/config/messages.js`: string de error del recorrido (ADR-050 i18n).

## Grounding / offline-first
- Geometría de lotes desde el `loteService` existente (asset--land WKT). Sin backend nuevo.
- Si el GPS falla (permiso/timeout/sin señal) la observación se registra **igual sin coordenada** — perder señal no pierde la nota.
- Detectores de intención deterministas on-device (línea de `voiceFieldExtractor`).

## API que le queda a Fable
- `useRecorridoVoz({...})` → `{ pendingCamera, procesarTranscripcion(texto), capturarEspecie(blob), limpiarCamara() }`.
- `useRecorridoStore` → `observaciones`, `ultimaObservacion`, `resumen()`, `iniciar/terminarRecorrido`.
- Falta solo pintar: croquis con pines por observación, lista lateral, botón de cámara cuando `pendingCamera != null`, y cablear `procesarTranscripcion` a la escucha del modo campo.

## Verificación
- `npm run build` ✓ (1m 2s)
- `vitest` ✓ 51 tests nuevos (service + store + hook)
- `tsc-check-gate` ✓ sin errores nuevos respecto al baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)