### PR TITLE
fix(offline): recover data banner and stale sw

### DIFF
--- a/src/components/DataLossBanner.jsx
+++ b/src/components/DataLossBanner.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { AlertTriangle, Upload, X } from 'lucide-react';
+import { AlertTriangle, RefreshCcw, Upload, X } from 'lucide-react';
+import { MSG } from '../config/messages';
 import { shouldWarnDataLoss } from '../services/emptyDbDetector';
+import { recoverDataFromFarmOS } from '../services/dataRecovery';
 
 /**
  * DataLossBanner — banner rojo prominente que aparece cuando detectamos que
@@ -29,6 +31,7 @@ export default function DataLossBanner({ onDismiss }) {
   const [status, setStatus] = useState({ shouldWarn: false, lastKnownCount: 0, lastMarkedAt: null });
   const [hidden, setHidden] = useState(false);
   const [showImportModal, setShowImportModal] = useState(false);
+  const [isRecovering, setIsRecovering] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -37,7 +40,7 @@ export default function DataLossBanner({ onDismiss }) {
         if (mounted) setStatus(s);
       })
       .catch((err) => {
-        console.warn('[DataLossBanner] No se pudo chequear data-loss status:', err);
+        console.warn('[DataLossBanner] Failed to check data-loss status:', err);
       });
     return () => {
       mounted = false;
@@ -66,7 +69,7 @@ export default function DataLossBanner({ onDismiss }) {
               ¿Hiciste clear cache?
             </p>
             <p className="text-sm mt-1 leading-snug">
-              No encontramos tu información local.{' '}
+              No encontramos tu informacion local.{' '}
               {status.lastKnownCount > 0 ? (
                 <>
                   Antes tenías al menos <strong>{status.lastKnownCount}</strong> activos registrados
@@ -77,17 +80,39 @@ export default function DataLossBanner({ onDismiss }) {
               )}
             </p>
             <p className="text-xs mt-2 leading-snug text-red-100/90">
-              Esto puede pasar si borraste el cache del navegador o reinstalaste la app.
-              Lo que estaba sin sincronizar con FarmOS (fotos, plantas nuevas) se perdió.
+              Tus datos guardados en la nube de Chagra estan a salvo; toca aqui para recuperarlos.
             </p>
             <div className="flex flex-wrap gap-2 mt-3">
               <button
                 type="button"
-                onClick={() => setShowImportModal(true)}
+                onClick={async () => {
+                  setIsRecovering(true);
+                  try {
+                    await recoverDataFromFarmOS();
+                    setHidden(true);
+                    onDismiss?.();
+                  } catch (err) {
+                    console.warn('[DataLossBanner] Failed to recover data from FarmOS:', err);
+                  } finally {
+                    setIsRecovering(false);
+                  }
+                }}
+                disabled={isRecovering}
+                className="px-3 py-2 rounded-lg bg-emerald-300 text-slate-950 font-black text-sm flex items-center gap-2 hover:bg-emerald-200 transition-colors min-h-[40px] disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                <RefreshCcw size={16} aria-hidden="true" className={isRecovering ? 'animate-spin' : ''} />
+                {isRecovering ? 'Recuperando...' : 'Recuperar mis datos'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowImportModal(true);
+                }}
                 className="px-3 py-2 rounded-lg bg-white text-red-900 font-bold text-sm flex items-center gap-2 hover:bg-red-50 transition-colors min-h-[40px]"
+                disabled={isRecovering}
               >
                 <Upload size={16} aria-hidden="true" />
-                Importar copia anterior
+                Importar copia
               </button>
               <button
                 type="button"
@@ -95,8 +120,9 @@ export default function DataLossBanner({ onDismiss }) {
                   setHidden(true);
                   onDismiss?.();
                 }}
-                className="px-3 py-2 rounded-lg bg-red-800 text-red-100 font-bold text-sm flex items-center gap-2 hover:bg-red-700 transition-colors min-h-[40px]"
+                className="px-3 py-2 rounded-lg bg-red-800 text-red-100 font-bold text-sm flex items-center gap-2 hover:bg-red-700 transition-colors min-h-[40px] disabled:opacity-60 disabled:cursor-not-allowed"
                 aria-label="Cerrar advertencia"
+                disabled={isRecovering}
               >
                 <X size={16} aria-hidden="true" />
                 Entendido
@@ -150,7 +176,7 @@ function ImportPreviewModal({ onClose }) {
         localStorageKeys: Object.keys(parsed.localStorage || {}).length,
       });
     } catch (err) {
-      setError(err.message || 'No se pudo leer el archivo.');
+      setError(err.message || MSG.status.backupReadFailed);
     }
   };
 

--- a/src/components/__tests__/DataLossBanner.test.jsx
+++ b/src/components/__tests__/DataLossBanner.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockShouldWarnDataLoss,
+  mockRecoverDataFromFarmOS,
+} = vi.hoisted(() => ({
+  mockShouldWarnDataLoss: vi.fn(),
+  mockRecoverDataFromFarmOS: vi.fn(),
+}));
+
+vi.mock('../../services/emptyDbDetector', () => ({
+  shouldWarnDataLoss: mockShouldWarnDataLoss,
+}));
+
+vi.mock('../../services/dataRecovery', () => ({
+  recoverDataFromFarmOS: mockRecoverDataFromFarmOS,
+}));
+
+import DataLossBanner from '../DataLossBanner';
+
+describe('DataLossBanner', () => {
+  beforeEach(() => {
+    mockShouldWarnDataLoss.mockReset();
+    mockRecoverDataFromFarmOS.mockReset();
+    mockShouldWarnDataLoss.mockResolvedValue({
+      shouldWarn: true,
+      lastKnownCount: 12,
+      lastMarkedAt: '2026-07-01T12:00:00.000Z',
+    });
+    mockRecoverDataFromFarmOS.mockResolvedValue(undefined);
+  });
+
+  it('muestra el CTA de recuperar datos y mantiene acciones secundarias', async () => {
+    render(<DataLossBanner onDismiss={vi.fn()} />);
+
+    expect(await screen.findByRole('alert')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /recuperar mis datos/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /importar copia/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /cerrar advertencia/i })).toBeTruthy();
+    expect(screen.getByText(/tus datos guardados en la nube de chagra estan a salvo/i)).toBeTruthy();
+  });
+
+  it('el CTA principal fuerza el re-pull desde FarmOS y oculta el banner', async () => {
+    const onDismiss = vi.fn();
+    render(<DataLossBanner onDismiss={onDismiss} />);
+
+    await screen.findByRole('alert');
+    fireEvent.click(screen.getByRole('button', { name: /recuperar mis datos/i }));
+
+    await waitFor(() => expect(mockRecoverDataFromFarmOS).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -80,6 +80,9 @@ const messages = {
     pendientes: 'Pendientes',
     errorGeneral: 'Algo no salió bien. Inténtelo otra vez.',
     errorSincronizar: 'No se pudieron subir los cambios. Chagra vuelve a intentar solo.',
+    dataLossCheckFailed: 'No se pudo verificar el estado de pérdida de datos.',
+    dataRecoveryFailed: 'No se pudieron recuperar los datos desde FarmOS.',
+    backupReadFailed: 'No se pudo leer el archivo.',
     sinConexionPendientes: (count) =>
       `Sin señal. ${count} registro${count !== 1 ? 's' : ''} guardado${count !== 1 ? 's' : ''} en su teléfono.`,
     sinConexionSinPendientes: 'Sin señal. Sus datos quedaron guardados en el teléfono.',

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -17,7 +17,7 @@ import { PRIMARY_WORKER_NAME } from './config/workerConfig'
 import { renameWorker } from './services/assetService'
 import { getAccessToken } from './services/authService'
 import { registerServiceWorker } from './services/swRegistration'
-import { runSelfHealCheck, RUNNING_BUILD_SHA } from './services/versionCheck'
+import { runSelfHealCheck, installBundleRecoveryGuards, RUNNING_BUILD_SHA } from './services/versionCheck'
 
 // Exponer el SHA del bundle CORRIENDO para diagnóstico + el smoke post-deploy
 // (tests/e2e-real/sw-self-heal.smoke.mjs compara window.__CHAGRA_BUILD_SHA__
@@ -84,6 +84,8 @@ if ('serviceWorker' in navigator) {
 
   registerServiceWorker();
 }
+
+installBundleRecoveryGuards();
 
 // Auto-recuperación por versión (self-heal) — NO depende del ciclo de vida del
 // SW. Compara el SHA del bundle corriendo (__BUILD_SHA__) contra /version.json

--- a/src/services/__tests__/swRegistration.test.js
+++ b/src/services/__tests__/swRegistration.test.js
@@ -22,6 +22,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   registerServiceWorker,
   AUTO_UPDATE_DELAY_MS,
+  unregisterRegisteredServiceWorker,
 } from '../swRegistration';
 import { ACK_STORAGE_KEY } from '../swUpdateAck';
 import { reloadPage } from '../pageReload';
@@ -258,5 +259,18 @@ describe('swRegistration — AUTO-UPDATE seguro', () => {
     // Asegurar que no existe.
     delete navigator.serviceWorker;
     expect(() => registerServiceWorker()).not.toThrow();
+  });
+
+  it('unregisterRegisteredServiceWorker desregistra sin tocar IndexedDB', async () => {
+    const unregister = vi.fn(async () => true);
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        getRegistration: vi.fn(async () => ({ unregister })),
+      },
+    });
+
+    await expect(unregisterRegisteredServiceWorker()).resolves.toBe(true);
+    expect(unregister).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/__tests__/versionCheck.test.js
+++ b/src/services/__tests__/versionCheck.test.js
@@ -8,19 +8,26 @@
  *  2. shouldSelfHeal: solo true cuando online + no recargado + SHAs difieren +
  *     runningSha real (no 'dev'). Offline / ya-recargado / sin deployedSha /
  *     dev → false (offline-first + anti-loop).
- *  3. fetchDeployedSha: parsea {sha}/{commit}/{build}; null en !ok / no-JSON /
+ *  3. isBundleFetchFailure: detecta fallos de chunks/bundles lazy sin confundir
+ *     fetches de API.
+ *  4. fetchDeployedSha: parsea {sha}/{commit}/{build}; null en !ok / no-JSON /
  *     fetch lanzando (offline). Pide cache:'no-store'.
- *  4. runSelfHealCheck: primera detección avisa + marca pending; el siguiente
- *     arranque con el mismo SHA pendiente recarga UNA vez.
+ *  5. runSelfHealCheck: mismatch de versión desregistra el SW + recarga UNA
+ *     vez, con guard de sesión.
+ *  6. installBundleRecoveryGuards: un unhandledrejection de bundle/chunk
+ *     dispara el mismo recovery y no entra en loop.
  */
 import { describe, it, expect, vi } from 'vitest';
 import {
   shasMatch,
   shouldSelfHeal,
+  isBundleFetchFailure,
   fetchDeployedSha,
   runSelfHealCheck,
+  installBundleRecoveryGuards,
   VERSION_ENDPOINT,
-  PENDING_UPDATE_SHA_KEY,
+  SELF_HEAL_GUARD_KEY,
+  hasSelfHealReloaded,
 } from '../versionCheck';
 
 describe('shasMatch', () => {
@@ -69,6 +76,22 @@ describe('shouldSelfHeal', () => {
   });
 });
 
+describe('isBundleFetchFailure', () => {
+  it('detecta failed fetch de chunk o module lazy', () => {
+    expect(
+      isBundleFetchFailure(new TypeError('Failed to fetch dynamically imported module: https://x/assets/App-abc.js')),
+    ).toBe(true);
+    expect(
+      isBundleFetchFailure('Loading chunk DashboardLive failed.'),
+    ).toBe(true);
+  });
+
+  it('no confunde fetch de API o errores genéricos', () => {
+    expect(isBundleFetchFailure(new Error('NetworkError when attempting to fetch resource'))).toBe(false);
+    expect(isBundleFetchFailure('Error al consultar FarmOS')).toBe(false);
+  });
+});
+
 describe('fetchDeployedSha', () => {
   const okResponse = (body) => ({ ok: true, json: async () => body });
 
@@ -108,11 +131,8 @@ describe('fetchDeployedSha', () => {
 describe('runSelfHealCheck', () => {
   function makeDeps(overrides = {}) {
     const reload = vi.fn();
-    const skipWaiting = vi.fn(async () => {});
+    const unregisterServiceWorker = vi.fn(async () => true);
     const markReloaded = vi.fn();
-    const writePending = vi.fn();
-    const clearPending = vi.fn();
-    const notifyUpdateAvailable = vi.fn();
     return {
       deps: {
         runningSha: 'a1b2c3d',
@@ -120,94 +140,99 @@ describe('runSelfHealCheck', () => {
         isOnline: () => true,
         alreadyReloaded: () => false,
         markReloaded,
-        readPending: () => null,
-        writePending,
-        clearPending,
-        notifyUpdateAvailable,
-        skipWaiting,
+        unregisterServiceWorker,
         reload,
         ...overrides,
       },
       reload,
-      skipWaiting,
+      unregisterServiceWorker,
       markReloaded,
-      writePending,
-      clearPending,
-      notifyUpdateAvailable,
     };
   }
 
-  it('primer mismatch → muestra banner, marca pending y manda skipWaiting sin recarga directa', async () => {
-    const { deps, reload, skipWaiting, markReloaded, writePending, notifyUpdateAvailable } = makeDeps();
-    const res = await runSelfHealCheck(deps);
-    expect(res.healed).toBe(false);
-    expect(res.reason).toBe('update-pending');
-    expect(writePending).toHaveBeenCalledWith('f9e8d7c');
-    expect(notifyUpdateAvailable).toHaveBeenCalledWith('f9e8d7c');
-    expect(skipWaiting).toHaveBeenCalledTimes(1);
-    expect(markReloaded).not.toHaveBeenCalled();
-    expect(reload).not.toHaveBeenCalled();
-  });
-
-  it('mismatch ya pendiente de un arranque anterior → recarga UNA vez', async () => {
-    const { deps, reload, skipWaiting, markReloaded } = makeDeps({
-      readPending: () => 'f9e8d7c',
-    });
+  it('mismatch de versión → desregistra el SW y recarga una sola vez', async () => {
+    const { deps, reload, unregisterServiceWorker, markReloaded } = makeDeps();
     const res = await runSelfHealCheck(deps);
     expect(res.healed).toBe(true);
     expect(res.reason).toBe('sha-mismatch');
-    expect(skipWaiting).toHaveBeenCalledTimes(1);
     expect(markReloaded).toHaveBeenCalledTimes(1);
+    expect(unregisterServiceWorker).toHaveBeenCalledTimes(1);
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
   it('SHAs en sync → no-op (no recarga)', async () => {
-    const { deps, reload, clearPending } = makeDeps({ getDeployedSha: async () => 'a1b2c3d' });
+    const { deps, reload, unregisterServiceWorker, markReloaded } = makeDeps({ getDeployedSha: async () => 'a1b2c3d' });
     const res = await runSelfHealCheck(deps);
     expect(res.healed).toBe(false);
-    expect(clearPending).toHaveBeenCalledTimes(1);
+    expect(markReloaded).not.toHaveBeenCalled();
+    expect(unregisterServiceWorker).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
 
   it('offline → no-op (offline-first)', async () => {
-    const { deps, reload, skipWaiting } = makeDeps({ isOnline: () => false });
+    const { deps, reload, unregisterServiceWorker } = makeDeps({ isOnline: () => false });
     const res = await runSelfHealCheck(deps);
     expect(res.healed).toBe(false);
     expect(res.reason).toBe('offline');
     expect(reload).not.toHaveBeenCalled();
-    expect(skipWaiting).not.toHaveBeenCalled();
+    expect(unregisterServiceWorker).not.toHaveBeenCalled();
   });
 
   it('ya recargado → no-op (anti-loop)', async () => {
-    const { deps, reload } = makeDeps({ alreadyReloaded: () => true });
+    const { deps, reload, unregisterServiceWorker } = makeDeps({ alreadyReloaded: () => true });
     const res = await runSelfHealCheck(deps);
     expect(res.healed).toBe(false);
     expect(res.reason).toBe('already-reloaded');
     expect(reload).not.toHaveBeenCalled();
+    expect(unregisterServiceWorker).not.toHaveBeenCalled();
   });
 
   it('/version.json no disponible → no-op (no rompe boot)', async () => {
-    const { deps, reload } = makeDeps({ getDeployedSha: async () => null });
+    const { deps, reload, unregisterServiceWorker } = makeDeps({ getDeployedSha: async () => null });
     const res = await runSelfHealCheck(deps);
     expect(res.healed).toBe(false);
     expect(reload).not.toHaveBeenCalled();
+    expect(unregisterServiceWorker).not.toHaveBeenCalled();
   });
 
-  it('skipWaiting lanza en primera detección → queda pending y no bloquea el boot', async () => {
-    const { deps, reload } = makeDeps({ skipWaiting: async () => { throw new Error('no SW'); } });
-    const res = await runSelfHealCheck(deps);
-    expect(res.healed).toBe(false);
-    expect(res.reason).toBe('update-pending');
-    expect(reload).not.toHaveBeenCalled();
+  it('marca la sesión al recuperar, para no reentrar en loop', async () => {
+    sessionStorage.removeItem(SELF_HEAL_GUARD_KEY);
+    const { deps } = makeDeps({ markReloaded: undefined });
+    await runSelfHealCheck(deps);
+    expect(hasSelfHealReloaded()).toBe(true);
   });
+});
 
-  it('helpers de pending usan localStorage', async () => {
-    localStorage.clear();
-    const { writePendingUpdateSha, readPendingUpdateSha, clearPendingUpdateSha } = await import('../versionCheck');
-    writePendingUpdateSha('abc1234');
-    expect(localStorage.getItem(PENDING_UPDATE_SHA_KEY)).toBe('abc1234');
-    expect(readPendingUpdateSha()).toBe('abc1234');
-    clearPendingUpdateSha();
-    expect(readPendingUpdateSha()).toBeNull();
+describe('installBundleRecoveryGuards', () => {
+  it('un unhandledrejection de chunk dispara unregister + reload una sola vez', async () => {
+    sessionStorage.removeItem(SELF_HEAL_GUARD_KEY);
+    const unregisterServiceWorker = vi.fn(async () => true);
+    const reload = vi.fn();
+    const cleanup = installBundleRecoveryGuards({
+      unregisterServiceWorker,
+      reload,
+    });
+
+    const makeEvt = () => {
+      const evt = new Event('unhandledrejection');
+      Object.defineProperty(evt, 'reason', {
+        configurable: true,
+        value: new TypeError('Failed to fetch dynamically imported module: https://example.com/assets/App-123.js'),
+      });
+      return evt;
+    };
+
+    window.dispatchEvent(makeEvt());
+    await Promise.resolve();
+
+    expect(unregisterServiceWorker).toHaveBeenCalledTimes(1);
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(makeEvt());
+    await Promise.resolve();
+
+    expect(unregisterServiceWorker).toHaveBeenCalledTimes(1);
+    expect(reload).toHaveBeenCalledTimes(1);
+    cleanup();
   });
 });

--- a/src/services/dataRecovery.js
+++ b/src/services/dataRecovery.js
@@ -1,0 +1,41 @@
+import { fetchFromFarmOS } from './apiService';
+import useAssetStore from '../store/useAssetStore';
+import { useLogStore } from '../store/useLogStore';
+
+/**
+ * Recupera los datos locales desde FarmOS usando los mismos caminos que usa la
+ * app al entrar al dashboard.
+ *
+ * El orden replica el boot normal:
+ *  1. Hidratar el store de assets desde IndexedDB.
+ *  2. Re-pull completo de assets desde FarmOS.
+ *  3. Re-pull reciente de logs desde FarmOS.
+ *
+ * Si la red o la sesión no están listas, los stores ya degradan en silencio.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<void>} [deps.hydrateAssets]
+ * @param {(fetchFn: Function) => Promise<void>} [deps.syncAssets]
+ * @param {(fetchFn: Function) => Promise<void>} [deps.pullLogs]
+ * @param {Function} [deps.fetchFn]
+ */
+export async function recoverDataFromFarmOS(deps = {}) {
+  const {
+    hydrateAssets = useAssetStore.getState().hydrate,
+    syncAssets = useAssetStore.getState().syncFromServer,
+    pullLogs = useLogStore.getState().pullRecentLogs,
+    fetchFn = fetchFromFarmOS,
+  } = deps;
+
+  if (typeof hydrateAssets === 'function') {
+    await hydrateAssets();
+  }
+
+  if (typeof syncAssets === 'function') {
+    await syncAssets(fetchFn);
+  }
+
+  if (typeof pullLogs === 'function') {
+    await pullLogs(fetchFn);
+  }
+}

--- a/src/services/swRegistration.js
+++ b/src/services/swRegistration.js
@@ -93,6 +93,30 @@ export function isReloadSafe() {
 }
 
 /**
+ * Desregistra el SW activo sin tocar IndexedDB ni limpiar site data.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<ServiceWorkerRegistration|null>} [deps.getRegistration]
+ * @returns {Promise<boolean>} true si se encontró una registration y se intentó desregistrar.
+ */
+export async function unregisterRegisteredServiceWorker({
+  getRegistration = () =>
+    navigator.serviceWorker.getRegistration(),
+} = {}) {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return false;
+  try {
+    const registration = await getRegistration();
+    if (!registration) return false;
+    if (typeof registration.unregister === 'function') {
+      await registration.unregister();
+    }
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
  * Registra el Service Worker e instala el flujo de AUTO-UPDATE seguro.
  *
  * Idempotente respecto al guard interno por llamada (cada `registerServiceWorker`

--- a/src/services/versionCheck.js
+++ b/src/services/versionCheck.js
@@ -109,16 +109,17 @@ export function shouldSelfHeal({ runningSha, deployedSha, alreadyReloaded, onlin
  * @returns {boolean}
  */
 export function isBundleFetchFailure(input) {
-  if (input && typeof input === 'object' && typeof input.filename === 'string' && input.filename.includes('/assets/')) {
+  const obj = /** @type {{ filename?: unknown, message?: unknown, reason?: any }} */ (
+    input && typeof input === 'object' ? input : {}
+  );
+  if (typeof obj.filename === 'string' && obj.filename.includes('/assets/')) {
     return true;
   }
   const msg = (() => {
     if (typeof input === 'string') return input;
-    if (input && typeof input === 'object') {
-      if (typeof input.message === 'string') return input.message;
-      if (typeof input.reason === 'string') return input.reason;
-      if (input.reason && typeof input.reason.message === 'string') return input.reason.message;
-    }
+    if (typeof obj.message === 'string') return obj.message;
+    if (typeof obj.reason === 'string') return obj.reason;
+    if (obj.reason && typeof obj.reason.message === 'string') return obj.reason.message;
     return '';
   })().toLowerCase();
   return BUNDLE_FETCH_FAILURE_RE.test(msg) || (/\/assets\//.test(msg) && /(error|failed|load|chunk|module)/i.test(msg));
@@ -315,8 +316,13 @@ function defaultReload() {
  * Instala guards de runtime para recuperar bundles/chunks que fallan al cargar.
  * Debe montarse una sola vez al inicio de la app.
  *
- * @param {object} [deps]
- * @param {() => Promise<boolean|{recovered?: boolean}>} [deps.recover]
+ * @param {{
+ *   alreadyReloaded?: () => boolean,
+ *   markReloaded?: () => void,
+ *   unregisterServiceWorker?: () => Promise<unknown>,
+ *   reload?: () => void,
+ *   recover?: () => Promise<boolean|{recovered?: boolean}>,
+ * }} [deps]
  * @returns {() => void} cleanup
  */
 export function installBundleRecoveryGuards(deps = {}) {

--- a/src/services/versionCheck.js
+++ b/src/services/versionCheck.js
@@ -17,8 +17,8 @@
  * por Vite `define`). Al arrancar CON conexión, el cliente hace fetch `no-store`
  * a `/version.json` (lo emite el deploy con el SHA desplegado). Si el SHA que
  * está CORRIENDO ≠ el SHA DESPLEGADO → hay un bundle nuevo en el servidor que
- * este cliente no tomó: mandamos SKIP_WAITING al SW en waiting y recargamos UNA
- * sola vez. Tras la recarga, el navegador pide el index.html fresco
+ * este cliente no tomó: desregistramos el SW viejo y recargamos UNA sola vez.
+ * Tras la recarga, el navegador pide el index.html fresco
  * (Network-First en el SW) → bundle nuevo → SHA coincide → no recarga otra vez.
  *
  * Es belt-and-suspenders del auto-update: si éste ya recargó, el SHA coincide y
@@ -41,6 +41,7 @@
  * Funciones puras + helpers para que versionCheck.test.js cubra los casos sin
  * mockear navigator entero.
  */
+import { unregisterRegisteredServiceWorker } from './swRegistration';
 
 /**
  * SHA del build embebido en el bundle. Lo inyecta Vite `define` desde
@@ -57,6 +58,8 @@ export const PENDING_UPDATE_SHA_KEY = 'chagra:self-heal-pending-sha';
 export const VERSION_ENDPOINT = '/version.json';
 // Timeout corto: el self-heal NO debe bloquear el boot ni colgarse en red rural.
 export const VERSION_FETCH_TIMEOUT_MS = 4000;
+const BUNDLE_FETCH_FAILURE_RE =
+  /(?:failed to fetch dynamically imported module|error loading dynamically imported module|loading chunk [^ ]+ failed|chunkloaderror|importing a module script failed|failed to load module script|failed to fetch.*(?:chunk|module))/i;
 
 /**
  * Normaliza un SHA para comparar (trim, lowercase). Acepta short o full SHA y
@@ -100,6 +103,28 @@ export function shouldSelfHeal({ runningSha, deployedSha, alreadyReloaded, onlin
 }
 
 /**
+ * Detecta fallos de carga de bundles o chunks lazy, no fetches de API.
+ *
+ * @param {unknown} input
+ * @returns {boolean}
+ */
+export function isBundleFetchFailure(input) {
+  if (input && typeof input === 'object' && typeof input.filename === 'string' && input.filename.includes('/assets/')) {
+    return true;
+  }
+  const msg = (() => {
+    if (typeof input === 'string') return input;
+    if (input && typeof input === 'object') {
+      if (typeof input.message === 'string') return input.message;
+      if (typeof input.reason === 'string') return input.reason;
+      if (input.reason && typeof input.reason.message === 'string') return input.reason.message;
+    }
+    return '';
+  })().toLowerCase();
+  return BUNDLE_FETCH_FAILURE_RE.test(msg) || (/\/assets\//.test(msg) && /(error|failed|load|chunk|module)/i.test(msg));
+}
+
+/**
  * Lee /version.json con timeout y cache-busting (no-store). Devuelve el SHA
  * desplegado o null si no se pudo obtener (offline/timeout/JSON inválido).
  * NUNCA lanza.
@@ -134,6 +159,23 @@ export async function fetchDeployedSha({
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+async function reloadAfterUnregister({
+  unregisterServiceWorker = unregisterRegisteredServiceWorker,
+  markReloaded = () => markSelfHealReloaded(),
+  reload = defaultReload,
+  alreadyReloaded = () => hasSelfHealReloaded(),
+} = {}) {
+  if (alreadyReloaded()) return { recovered: false, reason: 'already-reloaded' };
+  markReloaded();
+  try {
+    await unregisterServiceWorker();
+  } catch (_) {
+    /* unregister falló, pero el reload sigue para salir del bundle roto */
+  }
+  reload();
+  return { recovered: true, reason: 'reloaded-after-unregister' };
 }
 
 function safeSessionStorage() {
@@ -201,19 +243,9 @@ export function clearPendingUpdateSha(storage = safeLocalStorage()) {
   }
 }
 
-function defaultNotifyUpdateAvailable(version) {
-  try {
-    window.dispatchEvent(
-      new CustomEvent('chagra:update-available', { detail: { version } }),
-    );
-  } catch (_) {
-    /* entorno sin window/CustomEvent: no-op */
-  }
-}
-
 /**
- * Orquesta el self-heal: lee /version.json, decide, y si procede manda
- * SKIP_WAITING al SW en waiting + recarga UNA sola vez (marcando el guard).
+ * Orquesta el self-heal: lee /version.json, decide, y si procede unregister
+ * del SW + recarga UNA sola vez (marcando el guard).
  *
  * Dependencias inyectables para test (sin tocar navigator/location reales).
  *
@@ -223,11 +255,7 @@ function defaultNotifyUpdateAvailable(version) {
  * @param {() => boolean} [deps.isOnline]
  * @param {() => boolean} [deps.alreadyReloaded]
  * @param {() => void} [deps.markReloaded]
- * @param {() => string|null} [deps.readPending]
- * @param {(sha:string) => void} [deps.writePending]
- * @param {() => void} [deps.clearPending]
- * @param {(version:string) => void} [deps.notifyUpdateAvailable]
- * @param {() => Promise<void>} [deps.skipWaiting] - manda SKIP_WAITING al SW.
+ * @param {() => Promise<boolean>} [deps.unregisterServiceWorker]
  * @param {() => void} [deps.reload] - recarga la página.
  * @returns {Promise<{healed: boolean, reason: string}>}
  */
@@ -239,11 +267,7 @@ export async function runSelfHealCheck(deps = {}) {
       typeof navigator === 'undefined' ? true : navigator.onLine !== false,
     alreadyReloaded = () => hasSelfHealReloaded(),
     markReloaded = () => markSelfHealReloaded(),
-    readPending = () => readPendingUpdateSha(),
-    writePending = (sha) => writePendingUpdateSha(sha),
-    clearPending = () => clearPendingUpdateSha(),
-    notifyUpdateAvailable = defaultNotifyUpdateAvailable,
-    skipWaiting = defaultSkipWaiting,
+    unregisterServiceWorker = unregisterRegisteredServiceWorker,
     reload = defaultReload,
   } = deps;
 
@@ -251,53 +275,23 @@ export async function runSelfHealCheck(deps = {}) {
   if (alreadyReloaded()) return { healed: false, reason: 'already-reloaded' };
 
   const deployedSha = await getDeployedSha();
-  if (deployedSha && shasMatch(runningSha, deployedSha)) {
-    clearPending();
-  }
   const decision = shouldSelfHeal({
     runningSha,
     deployedSha,
     alreadyReloaded: alreadyReloaded(),
     online: isOnline(),
   });
-  if (!decision) return { healed: false, reason: 'in-sync-or-unknown' };
-
-  const pendingSha = readPending();
-  const wasPendingFromPreviousStart = shasMatch(pendingSha, deployedSha);
-  writePending(deployedSha);
-  notifyUpdateAvailable(deployedSha);
-  try {
-    await skipWaiting();
-  } catch (_) {
-    /* SW no disponible: el próximo arranque sigue protegido por pendingSha. */
+  if (!decision) {
+    return { healed: false, reason: deployedSha ? 'in-sync' : 'inconclusive' };
   }
 
-  if (!wasPendingFromPreviousStart) {
-    return { healed: false, reason: 'update-pending' };
-  }
-
-  // Marcar ANTES de recargar: si la recarga es instantánea, el guard ya quedó
-  // escrito para que el próximo arranque no re-dispare en bucle.
-  markReloaded();
-  reload();
-  return { healed: true, reason: 'sha-mismatch' };
-}
-
-/**
- * Manda SKIP_WAITING al SW en `waiting` (si lo hay). Reusa el mismo flujo que
- * el botón del banner: dispara `chagra:sw-update-requested` para que el guard
- * de controllerchange de swRegistration recargue, por si el reload directo de
- * abajo no alcanzara. No-op si no hay SW / waiting.
- */
-async function defaultSkipWaiting() {
-  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
-  try {
-    window.dispatchEvent(new CustomEvent('chagra:sw-update-requested'));
-  } catch (_) { /* CustomEvent existe en todos los browsers soportados */ }
-  const reg = await navigator.serviceWorker.getRegistration();
-  if (reg && reg.waiting) {
-    reg.waiting.postMessage({ type: 'SKIP_WAITING' });
-  }
+  const result = await reloadAfterUnregister({
+    unregisterServiceWorker,
+    markReloaded,
+    reload,
+    alreadyReloaded,
+  });
+  return { healed: result.recovered, reason: 'sha-mismatch' };
 }
 
 function defaultReload() {
@@ -306,4 +300,64 @@ function defaultReload() {
   try {
     window.location.reload();
   } catch (_) { /* entorno sin window (SSR/test) — no-op */ }
+}
+
+/**
+ * Instala guards de runtime para recuperar bundles/chunks que fallan al cargar.
+ * Debe montarse una sola vez al inicio de la app.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<boolean|{recovered?: boolean}>} [deps.recover]
+ * @returns {() => void} cleanup
+ */
+export function installBundleRecoveryGuards(deps = {}) {
+  if (typeof window === 'undefined') return () => {};
+  const {
+    alreadyReloaded = () => hasSelfHealReloaded(),
+    markReloaded = () => markSelfHealReloaded(),
+    unregisterServiceWorker = unregisterRegisteredServiceWorker,
+    reload = defaultReload,
+  } = deps;
+
+  const maybeRecover = async (input) => {
+    if (!isBundleFetchFailure(input)) return;
+    await reloadAfterUnregister({
+      alreadyReloaded,
+      markReloaded,
+      unregisterServiceWorker,
+      reload,
+    });
+  };
+
+  const onError = (event) => {
+    const filename = typeof event?.filename === 'string' ? event.filename : '';
+    const targetSrc = typeof event?.target?.src === 'string' ? event.target.src : '';
+    const targetHref = typeof event?.target?.href === 'string' ? event.target.href : '';
+    const message = [
+      event?.message,
+      event?.error?.message,
+      event?.error?.toString?.(),
+      filename,
+      targetSrc,
+      targetHref,
+    ].filter(Boolean).join(' ');
+    if (!filename.includes('/assets/') && !targetSrc.includes('/assets/') && !targetHref.includes('/assets/') && !isBundleFetchFailure(message)) {
+      return;
+    }
+    void maybeRecover(message || event);
+  };
+
+  const onRejection = (event) => {
+    const reason = event?.reason;
+    if (!isBundleFetchFailure(reason)) return;
+    void maybeRecover(reason);
+  };
+
+  window.addEventListener('error', onError, true);
+  window.addEventListener('unhandledrejection', onRejection);
+
+  return () => {
+    window.removeEventListener('error', onError, true);
+    window.removeEventListener('unhandledrejection', onRejection);
+  };
 }

--- a/src/services/versionCheck.js
+++ b/src/services/versionCheck.js
@@ -161,6 +161,15 @@ export async function fetchDeployedSha({
   }
 }
 
+/**
+ * @param {{
+ *   unregisterServiceWorker?: () => Promise<unknown>,
+ *   markReloaded?: () => void,
+ *   reload?: () => void,
+ *   alreadyReloaded?: () => boolean,
+ * }} [deps]
+ * @returns {Promise<{ recovered: boolean, reason: string }>}
+ */
 async function reloadAfterUnregister({
   unregisterServiceWorker = unregisterRegisteredServiceWorker,
   markReloaded = () => markSelfHealReloaded(),

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -354,4 +354,6 @@ export interface ChagraBiopreparado {
   expiration: string;
 }
 
+declare const __BUILD_SHA__: string;
+
 export {};


### PR DESCRIPTION
## Summary
- Add a real FarmOS recovery action to the DataLossBanner primary CTA.
- Add a dataRecovery helper that rehydrates assets and pulls fresh assets/logs from FarmOS.
- Add bundle-chunk failure recovery that unregisters the stale Service Worker and reloads once per session.
- Keep IndexedDB intact and avoid site-data clearing.

## Test plan
- `npx vitest run src/components/__tests__/DataLossBanner.test.jsx src/services/__tests__/versionCheck.test.js src/services/__tests__/swRegistration.test.js`
- `npx eslint src/components/__tests__/DataLossBanner.test.jsx src/components/DataLossBanner.jsx src/services/dataRecovery.js src/services/versionCheck.js src/services/swRegistration.js src/services/__tests__/versionCheck.test.js src/services/__tests__/swRegistration.test.js src/main.jsx src/config/messages.js --max-warnings=0`
- `npm run build`

## Notes
- Full `npx vitest run` currently fails in `scripts/__tests__/validate-catalog.test.mjs` with two unrelated catalog assertions. That file was not modified by this fix.
