### PR TITLE
feat(almanaque): calendario agrícola + lunar campesino (vista hermana photo-forward)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -116,6 +116,7 @@ const CicloCultivoScreen = lazy(() => import('./components/CicloCultivoScreen'))
 const GerminacionScreen = lazy(() => import('./components/GerminacionScreen'));
 const CicloNutrientesScreen = lazy(() => import('./components/CicloNutrientesScreen'));
 const CalendarioFincaScreen = lazy(() => import('./components/CalendarioFincaScreen'));
+const AlmanaqueScreen = lazy(() => import('./components/almanaque/AlmanaqueScreen'));
 const SeguimientoProcesoScreen = lazy(() => import('./components/SeguimientoProcesoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
 // Módulo "Agua de la finca": cosecha de lluvia (calculadora determinista),
@@ -288,6 +289,7 @@ const VIEW_LOADING_LABELS = {
   ciclo_vivo: 'Abriendo el ciclo vivo…',
   calendario: 'Abriendo el calendario…',
   calendario_finca: 'Abriendo el calendario…',
+  almanaque: 'Abriendo el almanaque…',
   mapa: 'Abriendo el mapa…',
   mercado: 'Abriendo el mercado…',
   mercados: 'Abriendo el mercado…',
@@ -365,6 +367,8 @@ const HASH_VIEW_ROUTES = {
   'ciclo-nutrientes': 'ciclo_nutrientes',
   calendario: 'calendario_finca',
   'calendario-finca': 'calendario_finca',
+  almanaque: 'almanaque',
+  'almanaque-campesino': 'almanaque',
   animales: 'animales',
   'animales-gallinas': 'animales_gallinas',
   'animales-abejas': 'animales_abejas',
@@ -467,7 +471,7 @@ const MODULE_VIEWS = new Set([
   'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'sanidad_sintoma', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'aromaticas', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
-  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'cafe', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
+  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'almanaque', 'suelo', 'agua', 'cafe', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'platano', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'cacao', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'hortalizas', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
@@ -1738,6 +1742,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Aromáticas y condimentarias">
               <AromaticasScreen onBack={() => navigate('mundo_cultivos')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'almanaque':
+        // Vista HERMANA de calendario_finca (no la duplica): el "Almanaque de la
+        // finca" enseña el año campesino a lo grande — aguas y secas, qué da cada
+        // piso térmico (ventanas de cosecha grounded en perennialCycles) y el
+        // saber lunar tradicional (cultura, no receta). Photo-forward reusando
+        // fotos CC ya en /public; enlaza al calendario grounded de detalle.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Almanaque de la finca">
+              <AlmanaqueScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/almanaque/AlmanaqueScreen.jsx
+++ b/src/components/almanaque/AlmanaqueScreen.jsx
@@ -1,0 +1,507 @@
+import { useMemo, useState } from 'react';
+import {
+  CalendarDays, CloudRain, Sun, Sprout, Apple, Mountain, Moon,
+  Info, ChevronRight, Camera, ExternalLink, MessageCircle,
+  Hourglass, Leaf,
+} from 'lucide-react';
+import { ScreenShell } from '../common/ScreenShell';
+import { getProfile } from '../../services/userProfileService';
+import {
+  FOTOS_ALMANAQUE,
+  TEMPORADAS_ANIO,
+  HITOS_PRONOSTICO,
+  PISOS_TERMICOS,
+  LUNA_FASES,
+  LUNA_GRUPOS,
+  LUNA_CAVEAT,
+  LUNA_FUENTE,
+  ALMANAQUE_FUENTES,
+  CREDITOS_FOTOS_ALMANAQUE,
+  ventanaCosecha,
+  regimenCultivo,
+} from '../../data/almanaqueFinca';
+import './almanaque.css';
+
+/**
+ * AlmanaqueScreen — "Almanaque de la finca": el calendario agrícola y lunar
+ * campesino, contado a lo grande. Vista HERMANA (no duplicado) de
+ * CalendarioFincaScreen: aquel arma el calendario grounded mata-por-mata de la
+ * finca del usuario; este enseña el año campesino de Colombia — aguas y secas,
+ * qué da cada piso térmico, y el saber lunar tradicional — y remata enlazando al
+ * calendario de detalle.
+ *
+ * Photo-forward (patrón de Café/Agua): REUTILIZA fotos CC que ya viven en
+ * /public (no engorda el bundle). Todo lo agronómico va grounded en
+ * perennialCycles.js; lo folk (temporadas, luna) se cita como saber campesino,
+ * con el aviso honesto de que "es cultura, no receta".
+ */
+
+/* ── Chip honesto para cifras/fechas aún sin grounding ─────────────────── */
+function SlotPendiente({ children = null }) {
+  return (
+    <span
+      data-testid="slot-grounded-pendiente"
+      className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] font-bold text-amber-300"
+    >
+      <Hourglass size={11} aria-hidden="true" />
+      {children || 'Dato en camino'}
+    </span>
+  );
+}
+
+/* ── Foto reusada con scrim fijo + crédito + fallback a ícono ───────────── */
+function FotoAlmanaque({ fotoKey, alt, ratio = 'aspect-[16/9]', Fallback = Sprout, children = null }) {
+  const [ok, setOk] = useState(true);
+  const foto = FOTOS_ALMANAQUE[fotoKey];
+  const IconoFallback = Fallback;
+  return (
+    <div className={`relative overflow-hidden bg-[#2a1c12] ${ratio}`}>
+      {ok && foto ? (
+        <img
+          src={foto.src}
+          alt={alt}
+          loading="lazy"
+          decoding="async"
+          onError={() => setOk(false)}
+          className="alm-foto absolute inset-0 w-full h-full object-cover"
+        />
+      ) : (
+        <div className="absolute inset-0 grid place-items-center" aria-hidden="true">
+          <IconoFallback size={38} className="text-amber-900/70" />
+        </div>
+      )}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/25 to-black/5" aria-hidden="true" />
+      {children}
+      {foto?.autor && (
+        <span className="absolute bottom-1 right-1.5 rounded bg-black/55 px-1 py-0.5 text-[9px] leading-none text-white/75">
+          Foto: {foto.autor}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/* ── Glifo de luna en SVG puro (rsvg-safe: sin filtros ni foreignObject) ── */
+function MoonGlyph({ fase, size = 34 }) {
+  const r = 15;
+  const c = 17;
+  return (
+    <svg className="alm-luna-glifo" width={size} height={size} viewBox="0 0 34 34" aria-hidden="true">
+      {/* disco oscuro base */}
+      <circle className="alm-luna-disco" cx={c} cy={c} r={r} />
+      {fase === 'llena' && <circle className="alm-luna-luz" cx={c} cy={c} r={r} />}
+      {fase === 'creciente' && (
+        // mitad derecha iluminada
+        <path className="alm-luna-luz" d={`M ${c} ${c - r} A ${r} ${r} 0 0 1 ${c} ${c + r} Z`} />
+      )}
+      {fase === 'menguante' && (
+        // mitad izquierda iluminada
+        <path className="alm-luna-luz" d={`M ${c} ${c - r} A ${r} ${r} 0 0 0 ${c} ${c + r} Z`} />
+      )}
+      {fase === 'nueva' && <circle className="alm-luna-borde" cx={c} cy={c} r={r - 1} />}
+    </svg>
+  );
+}
+
+/* ── SECCIÓN 1 · El año campesino (aguas y secas) ──────────────────────── */
+function SeccionAnio() {
+  return (
+    <section className="space-y-4" data-testid="alm-seccion-anio">
+      <div className="rounded-2xl border border-amber-800/40 overflow-hidden bg-[#241811]/60">
+        <FotoAlmanaque fotoKey="siembra_lluvia" alt="Siembra al entrar las lluvias en la ladera andina" ratio="aspect-[16/9]" Fallback={CloudRain}>
+          <div className="absolute inset-0 flex flex-col justify-end p-4">
+            <p className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wider text-sky-200">
+              <CloudRain size={14} aria-hidden="true" /> Aguas y secas
+            </p>
+            <h3 className="text-xl font-black text-white leading-tight drop-shadow">El año no tiene cuatro estaciones</h3>
+          </div>
+        </FotoAlmanaque>
+      </div>
+
+      <p className="text-sm leading-relaxed text-slate-200">
+        En Colombia no hay primavera ni otoño: hay <b>aguas</b> (picos de lluvia) y{' '}
+        <b>secas</b>. El campesino siembra al <b>entrar las aguas</b>. En buena parte de
+        la zona andina el régimen es <b>bimodal</b>: dos ventanas de siembra al año.
+        En los Llanos y el piedemonte es de una sola temporada larga.
+      </p>
+
+      {/* Tira del año: temporadas grounded en el léxico folk-climático */}
+      <div className="space-y-2" data-testid="alm-temporadas">
+        {TEMPORADAS_ANIO.map((t) => {
+          const esLluvia = t.tono === 'lluvia';
+          const Icono = esLluvia ? CloudRain : Sun;
+          return (
+            <div
+              key={t.id}
+              className={`rounded-xl bg-[#241811]/50 border border-slate-700/50 p-3 ${esLluvia ? 'alm-temporada-lluvia' : 'alm-temporada-seca'}`}
+              data-testid={`temporada-${t.id}`}
+            >
+              <p className="flex flex-wrap items-center gap-2 text-sm font-bold text-slate-100 leading-tight">
+                <Icono size={15} aria-hidden="true" className={esLluvia ? 'text-sky-300' : 'text-amber-300'} />
+                {t.nombre}
+                <span className="rounded-full bg-slate-700/50 px-2 py-0.5 text-[10px] font-bold text-slate-300">{t.meses}</span>
+              </p>
+              <p className="mt-1 text-xs leading-snug text-slate-300">{t.que}</p>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Saberes folk de pronóstico */}
+      <div className="rounded-2xl border border-slate-700/60 bg-[#241811]/50 p-4 space-y-2.5" data-testid="alm-pronostico">
+        <p className="flex items-center gap-2 text-sm font-black text-amber-200 uppercase tracking-wide">
+          <CalendarDays size={16} aria-hidden="true" /> Cómo lee el campesino el año
+        </p>
+        {HITOS_PRONOSTICO.map((h) => (
+          <div key={h.id} className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3" data-testid={`pronostico-${h.id}`}>
+            <p className="text-sm font-bold text-slate-100 leading-tight">{h.termino}</p>
+            <p className="mt-0.5 text-xs leading-snug text-slate-300">{h.que}</p>
+          </div>
+        ))}
+        <p className="text-[10px] leading-snug text-slate-500">
+          Saber folk-climático campesino de Colombia (léxico etnolingüístico Chagra). Es costumbre y observación, no pronóstico oficial: para la lluvia real, mire el boletín del clima.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+/* ── SECCIÓN 2 · Pisos térmicos ────────────────────────────────────────── */
+function CultivoFila({ cultivo }) {
+  const ventana = ventanaCosecha(cultivo.slug);
+  const reg = regimenCultivo(cultivo.slug);
+  return (
+    <li className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3" data-testid={`cultivo-${cultivo.slug || cultivo.nombre}`}>
+      <p className="flex flex-wrap items-center gap-2 text-sm font-bold text-slate-100 leading-tight">
+        <Sprout size={14} aria-hidden="true" className="text-lime-400 shrink-0" />
+        {cultivo.nombre}
+        <span className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${reg.tone === 'ok' ? 'bg-emerald-500/15 text-emerald-200 border border-emerald-600/40' : 'bg-amber-500/10 text-amber-300 border border-amber-500/40'}`}>
+          {reg.label}
+        </span>
+      </p>
+      <p className="mt-1 text-xs leading-snug text-slate-300">{cultivo.nota}</p>
+      <p className="mt-1.5 flex items-center gap-1.5 text-[11px] leading-snug">
+        <Apple size={12} aria-hidden="true" className="shrink-0 text-orange-300" />
+        {ventana ? (
+          <span className="text-slate-200">Cosecha (aprox.): <b className="text-orange-200">{ventana}</b></span>
+        ) : (
+          <SlotPendiente>ventana de cosecha en camino</SlotPendiente>
+        )}
+      </p>
+    </li>
+  );
+}
+
+function SeccionPisos({ altitudeM }) {
+  // Piso por defecto según la altitud del perfil (si la hay).
+  const pisoDefault = useMemo(() => {
+    if (!altitudeM) return 'templado';
+    if (altitudeM < 1000) return 'calido';
+    if (altitudeM < 2000) return 'templado';
+    if (altitudeM < 3000) return 'frio';
+    return 'paramo';
+  }, [altitudeM]);
+  const [pisoSel, setPisoSel] = useState(pisoDefault);
+  const piso = PISOS_TERMICOS.find((p) => p.id === pisoSel) || PISOS_TERMICOS[1];
+
+  return (
+    <section className="space-y-4" data-testid="alm-seccion-pisos">
+      <p className="text-sm leading-relaxed text-slate-200">
+        La misma mata cambia según a qué altura viva. Escoja su piso térmico y vea
+        qué da y cuándo cosecha. {altitudeM ? (
+          <span className="text-slate-400">Su finca está a <b>{altitudeM} msnm</b>.</span>
+        ) : (
+          <span className="text-slate-400">Ponga su altitud en el perfil para que lo elija por usted.</span>
+        )}
+      </p>
+
+      {/* Selector de piso térmico */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2" role="tablist" aria-label="Pisos térmicos">
+        {PISOS_TERMICOS.map((p) => {
+          const activo = p.id === pisoSel;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              role="tab"
+              aria-selected={activo}
+              data-testid={`piso-tab-${p.id}`}
+              onClick={() => setPisoSel(p.id)}
+              className={`alm-tab rounded-xl border px-2 py-2.5 text-center ${
+                activo
+                  ? 'alm-tab-activa border-amber-500/70 bg-amber-500/15 text-amber-100'
+                  : 'border-slate-700 bg-[#241811]/50 text-slate-300 active:bg-slate-800/70'
+              }`}
+            >
+              <span className="block text-lg leading-none" aria-hidden="true">{p.emoji}</span>
+              <span className="block text-xs font-black leading-tight mt-1">{p.nombre}</span>
+              <span className="block text-[10px] text-slate-400 leading-tight">{p.rango}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Cabecera del piso elegido, con foto si la hay */}
+      {piso.foto ? (
+        <div className="rounded-2xl border border-slate-700/60 overflow-hidden bg-[#241811]/60" data-testid="alm-piso-hero">
+          <FotoAlmanaque fotoKey={piso.foto} alt={`Cultivos de ${piso.nombre}`} ratio="aspect-[16/9]" Fallback={Mountain}>
+            <div className="absolute inset-0 flex flex-col justify-end p-4">
+              <p className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wider text-amber-200">
+                <Mountain size={14} aria-hidden="true" /> {piso.rango} · {piso.temp}
+              </p>
+              <h3 className="text-xl font-black text-white leading-tight drop-shadow">{piso.nombre}</h3>
+              <p className="text-xs text-white/80 leading-tight mt-0.5">{piso.lema}</p>
+            </div>
+          </FotoAlmanaque>
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-sky-800/40 bg-[#101b26]/70 p-4" data-testid="alm-piso-hero">
+          <p className="flex items-center gap-2 text-sm font-black text-sky-200">
+            <span aria-hidden="true" className="text-lg">{piso.emoji}</span> {piso.nombre}
+            <span className="text-[11px] font-normal text-slate-400">{piso.rango} · {piso.temp}</span>
+          </p>
+          <p className="mt-1 text-xs leading-snug text-slate-300">{piso.lema}</p>
+        </div>
+      )}
+
+      {/* Cultivos del piso, con ventana de cosecha grounded */}
+      {piso.cultivos.length > 0 ? (
+        <ul className="space-y-2" data-testid="alm-piso-cultivos">
+          {piso.cultivos.map((cultivo) => (
+            <CultivoFila key={cultivo.slug || cultivo.nombre} cultivo={cultivo} />
+          ))}
+        </ul>
+      ) : (
+        <p className="rounded-xl border border-sky-800/40 bg-sky-950/20 p-3 text-xs leading-snug text-sky-100 flex items-start gap-1.5" data-testid="alm-piso-nota">
+          <Info size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-sky-300" />
+          {piso.nota}
+        </p>
+      )}
+
+      <p className="text-[10px] leading-snug text-slate-500">
+        Ventanas de cosecha derivadas de los ciclos del catálogo Chagra (Agrosavia, Cenicafé, Fedecacao, ICA, U. Nacional). Aproximadas; cambian con la región, la altitud y el manejo. Donde no hay dato firme, se dice.
+      </p>
+    </section>
+  );
+}
+
+/* ── SECCIÓN 3 · La luna (saber campesino) ─────────────────────────────── */
+const GRUPO_CLASE = { hoja: 'alm-grupo-hoja', fruto: 'alm-grupo-fruto', raiz: 'alm-grupo-raiz' };
+const GRUPO_LABEL = { hoja: 'hoja', fruto: 'fruto', raiz: 'raíz' };
+
+function SeccionLuna() {
+  return (
+    <section className="space-y-4" data-testid="alm-seccion-luna">
+      {/* Encuadre honesto: cultura, no receta (misma política de MundoCultivos) */}
+      <div className="alm-luna-bloque rounded-2xl p-4 space-y-2" data-testid="alm-luna-caveat">
+        <p className="flex items-center gap-2 text-sm font-black text-slate-100">
+          <Moon size={18} aria-hidden="true" className="text-slate-200" /> La luna, saber campesino
+        </p>
+        <p className="text-xs leading-relaxed text-slate-300">{LUNA_CAVEAT}</p>
+      </div>
+
+      {/* Las cuatro fases, con su glifo y su labor folk */}
+      <div className="space-y-2" data-testid="alm-luna-fases">
+        {LUNA_FASES.map((f) => (
+          <div key={f.id} className="alm-luna-fase rounded-xl p-3 flex gap-3" data-testid={`luna-fase-${f.id}`}>
+            <span className="shrink-0 mt-0.5"><MoonGlyph fase={f.icono} size={38} /></span>
+            <div className="min-w-0">
+              <p className="flex flex-wrap items-center gap-2 text-sm font-bold text-slate-100 leading-tight">
+                {f.fase}
+                <span className="text-[10px] font-normal italic text-slate-400">«{f.folk}»</span>
+              </p>
+              <p className="text-[11px] leading-snug text-slate-400 mt-0.5">{f.dice}</p>
+              <p className="text-xs leading-snug text-slate-200 mt-1">{f.labores}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Regla mnemónica folk: hoja / fruto / raíz */}
+      <div className="rounded-2xl border border-slate-700/60 bg-[#241811]/50 p-4 space-y-2.5" data-testid="alm-luna-grupos">
+        <p className="flex items-center gap-2 text-sm font-black text-slate-200 uppercase tracking-wide">
+          <Leaf size={16} aria-hidden="true" /> La regla de la abuela
+        </p>
+        <p className="text-xs leading-snug text-slate-400">
+          Se agrupa el cultivo por la parte que se come, y esa parte manda la luna:
+        </p>
+        {LUNA_GRUPOS.map((g) => (
+          <div key={g.id} className="flex items-center gap-2 rounded-xl border border-slate-700/50 bg-slate-950/40 p-2.5" data-testid={`luna-grupo-${g.id}`}>
+            <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-black uppercase ${GRUPO_CLASE[g.id]}`}>
+              {GRUPO_LABEL[g.id]}
+            </span>
+            <span className="min-w-0 flex-1 text-xs text-slate-300 leading-tight">{g.ejemplos}</span>
+            <span className="shrink-0 text-[11px] font-bold text-slate-200">luna {g.luna}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Puente etnolingüístico: entender el habla del campo */}
+      <div className="rounded-xl border border-amber-700/40 bg-amber-950/20 p-3" data-testid="alm-luna-habla">
+        <p className="flex items-start gap-1.5 text-[11px] leading-snug text-amber-100">
+          <Info size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-amber-300" />
+          <span>
+            Si en su casa dicen <b>«hay que sembrar en luna tierna»</b>, se refieren a la
+            luna nueva; <b>«cortar en menguante»</b> es la fase en que baja la savia. El
+            agente de Chagra entiende estas expresiones y le responde en su mismo lenguaje.
+          </span>
+        </p>
+      </div>
+
+      <p className="text-[10px] leading-snug text-slate-500 flex items-start gap-1.5">
+        <Info size={11} aria-hidden="true" className="shrink-0 mt-0.5" />
+        <span>Fuente: {LUNA_FUENTE}</span>
+      </p>
+    </section>
+  );
+}
+
+/* ── Créditos de fotos (cumplimiento licencia abierta) ─────────────────── */
+function CreditosFotos() {
+  const [abierto, setAbierto] = useState(false);
+  if (!CREDITOS_FOTOS_ALMANAQUE.length) return null;
+  return (
+    <div className="rounded-xl border border-slate-700/60 bg-[#241811]/50 p-3" data-testid="alm-creditos-fotos">
+      <button
+        type="button"
+        onClick={() => setAbierto((v) => !v)}
+        aria-expanded={abierto}
+        className="w-full flex items-center gap-2 text-left"
+      >
+        <Camera size={15} className="text-slate-400 shrink-0" aria-hidden="true" />
+        <span className="flex-1 text-xs font-bold text-slate-300">Créditos de las fotos (licencia abierta)</span>
+        <ChevronRight size={16} className={`text-slate-500 transition-transform ${abierto ? 'rotate-90' : ''}`} aria-hidden="true" />
+      </button>
+      {abierto && (
+        <ul className="mt-2.5 pt-2.5 border-t border-slate-700/60 flex flex-col gap-1.5">
+          {CREDITOS_FOTOS_ALMANAQUE.map((cr) => (
+            <li key={cr.slug} className="text-[11px] leading-snug text-slate-400">
+              <a
+                href={cr.fuenteUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-slate-200 hover:text-white underline decoration-slate-600 underline-offset-2 inline-flex items-center gap-0.5"
+              >
+                {cr.slug}<ExternalLink size={10} className="inline shrink-0" aria-hidden="true" />
+              </a>
+              <span className="text-slate-500"> — {cr.autor} · {cr.licencia} · Wikimedia Commons</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+const SECCIONES = [
+  { id: 'anio', titulo: 'El año', desc: 'Aguas y secas', Icon: CloudRain },
+  { id: 'pisos', titulo: 'Pisos térmicos', desc: 'Qué da su altura', Icon: Mountain },
+  { id: 'luna', titulo: 'La luna', desc: 'Saber campesino', Icon: Moon },
+];
+
+/* ── Pantalla principal ────────────────────────────────────────────────── */
+export default function AlmanaqueScreen({ onBack, onNavigate = undefined }) {
+  const [seccion, setSeccion] = useState('anio');
+
+  const altitudeM = useMemo(() => {
+    const n = Number(getProfile()?.finca_altitud);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }, []);
+
+  return (
+    <ScreenShell title="Almanaque" icon={CalendarDays} onBack={onBack}>
+      <div className="alm-screen max-w-2xl mx-auto p-4 space-y-4" data-testid="almanaque-screen">
+        {/* Portada */}
+        <div className="alm-portada rounded-2xl border border-amber-800/40 p-4">
+          <p className="flex items-center gap-2 text-sm font-black text-amber-200 leading-tight">
+            <CalendarDays size={18} aria-hidden="true" className="shrink-0" />
+            El almanaque campesino
+          </p>
+          <p className="mt-1.5 text-xs italic leading-snug text-slate-300">
+            El año de la finca contado a lo grande: cuándo entran las aguas y cuándo
+            secan, qué da cada piso térmico y cuándo cosecha, y el saber lunar de los
+            mayores. Para el detalle de sus propias matas, entre al Calendario de la finca.
+          </p>
+        </div>
+
+        {/* Navegación entre secciones */}
+        <div className="grid grid-cols-3 gap-2" role="tablist" aria-label="Secciones del almanaque">
+          {SECCIONES.map((s) => {
+            const activo = seccion === s.id;
+            const Icono = s.Icon;
+            return (
+              <button
+                key={s.id}
+                type="button"
+                role="tab"
+                aria-selected={activo}
+                data-testid={`alm-tab-${s.id}`}
+                onClick={() => setSeccion(s.id)}
+                className={`alm-tab rounded-xl border px-2 py-2.5 text-center ${
+                  activo
+                    ? 'alm-tab-activa border-amber-500/70 bg-amber-500/15 text-amber-100'
+                    : 'border-slate-700 bg-[#241811]/50 text-slate-300 active:bg-slate-800/70'
+                }`}
+              >
+                <Icono size={17} aria-hidden="true" className="mx-auto" />
+                <span className="block text-sm font-black leading-tight mt-1">{s.titulo}</span>
+                <span className={`block text-[10px] leading-tight ${activo ? 'text-amber-200/90' : 'text-slate-500'}`}>{s.desc}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {seccion === 'anio' && <SeccionAnio />}
+        {seccion === 'pisos' && <SeccionPisos altitudeM={altitudeM} />}
+        {seccion === 'luna' && <SeccionLuna />}
+
+        {/* Puente al Calendario de la finca (la vista hermana grounded) */}
+        {typeof onNavigate === 'function' && (
+          <button
+            type="button"
+            data-testid="alm-ir-calendario"
+            onClick={() => onNavigate('calendario_finca')}
+            className="w-full flex items-center gap-3 rounded-2xl border border-emerald-700/50 bg-emerald-900/20 p-3.5 text-left active:bg-emerald-900/40 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-10 h-10 rounded-xl bg-emerald-500/15 grid place-items-center">
+              <CalendarDays size={20} className="text-emerald-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">Calendario de la finca</span>
+              <span className="block text-xs text-slate-400 leading-tight mt-0.5">El detalle mata por mata: cuándo sembrar, abonar, vigilar y cosechar sus plantas.</span>
+            </span>
+            <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+        )}
+
+        {/* Créditos de fotos */}
+        <CreditosFotos />
+
+        {/* Puente al agente */}
+        {typeof onNavigate === 'function' && (
+          <button
+            type="button"
+            data-testid="alm-preguntar-agente"
+            onClick={() => onNavigate('agente', { prefilledPrompt: '¿Qué me conviene sembrar este mes según mi altura y las lluvias de mi zona?' })}
+            className="w-full flex items-center gap-3 rounded-2xl border border-slate-700/60 bg-slate-900/40 p-3.5 text-left active:bg-slate-800/60 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-10 h-10 rounded-xl bg-amber-500/15 grid place-items-center">
+              <MessageCircle size={20} className="text-amber-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">¿Su finca es distinta?</span>
+              <span className="block text-xs text-slate-400 leading-tight mt-0.5">Cuéntele al agente su altura y su clima: le afina el mes de siembra y de cosecha.</span>
+            </span>
+            <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+        )}
+
+        {/* Pie: fuentes */}
+        <p className="text-[10px] text-slate-500 flex items-start gap-1.5 border-t border-slate-800 pt-3">
+          <Info size={11} aria-hidden="true" className="shrink-0 mt-0.5" />
+          <span>{ALMANAQUE_FUENTES}</span>
+        </p>
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/almanaque/AlmanaqueScreen.test.jsx
+++ b/src/components/almanaque/AlmanaqueScreen.test.jsx
@@ -1,0 +1,91 @@
+/**
+ * AlmanaqueScreen — "Almanaque de la finca" (photo-forward): vista hermana del
+ * Calendario de la finca.
+ *
+ * Contrato cubierto:
+ *   - Las 3 secciones son navegables (El año / Pisos térmicos / La luna).
+ *   - El año: temporadas de aguas y secas del régimen bimodal.
+ *   - Pisos térmicos: los 4 pisos; el café en templado muestra ventana de
+ *     cosecha grounded; el páramo NO lista cultivos (nota honesta).
+ *   - La luna: encuadre "cultura, no receta" + las 4 fases + el puente
+ *     etnolingüístico ("luna tierna").
+ *   - Puentes: onBack, enlace al Calendario de la finca y al agente.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import AlmanaqueScreen from './AlmanaqueScreen';
+
+afterEach(() => cleanup());
+
+const irASeccion = (id) => fireEvent.click(screen.getByTestId(`alm-tab-${id}`));
+
+describe('AlmanaqueScreen — navegación y portada', () => {
+  it('monta, arranca en "El año" y muestra las 3 secciones', () => {
+    render(<AlmanaqueScreen onBack={() => {}} onNavigate={() => {}} />);
+    expect(screen.getByTestId('almanaque-screen')).toBeTruthy();
+    expect(screen.getByTestId('alm-seccion-anio')).toBeTruthy();
+    for (const id of ['anio', 'pisos', 'luna']) {
+      expect(screen.getByTestId(`alm-tab-${id}`)).toBeTruthy();
+    }
+  });
+
+  it('el botón volver llama onBack', () => {
+    const onBack = vi.fn();
+    render(<AlmanaqueScreen onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Volver' }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});
+
+describe('AlmanaqueScreen — el año campesino (aguas y secas)', () => {
+  it('muestra temporadas de lluvia y de seca', () => {
+    render(<AlmanaqueScreen onBack={() => {}} />);
+    expect(screen.getByTestId('temporada-aguas1')).toBeTruthy();
+    expect(screen.getByTestId('temporada-secas1')).toBeTruthy();
+  });
+});
+
+describe('AlmanaqueScreen — pisos térmicos (grounded)', () => {
+  it('el café en templado muestra ventana de cosecha grounded (no inventada)', () => {
+    render(<AlmanaqueScreen onBack={() => {}} />);
+    irASeccion('pisos');
+    fireEvent.click(screen.getByTestId('piso-tab-templado'));
+    // El café tiene meses firmes en perennialCycles → aparece su fila.
+    expect(screen.getByTestId('cultivo-coffea_arabica')).toBeTruthy();
+  });
+
+  it('el páramo NO lista cultivos: muestra la nota honesta de conservación', () => {
+    render(<AlmanaqueScreen onBack={() => {}} />);
+    irASeccion('pisos');
+    fireEvent.click(screen.getByTestId('piso-tab-paramo'));
+    expect(screen.getByTestId('alm-piso-nota')).toBeTruthy();
+    expect(screen.queryByTestId('alm-piso-cultivos')).toBeNull();
+  });
+});
+
+describe('AlmanaqueScreen — la luna (saber campesino, cultura no receta)', () => {
+  it('enmarca la luna como cultura no receta y expone el puente etnolingüístico', () => {
+    render(<AlmanaqueScreen onBack={() => {}} />);
+    irASeccion('luna');
+    const caveat = screen.getByTestId('alm-luna-caveat');
+    expect(caveat.textContent).toMatch(/no promete más cosecha/i);
+    expect(caveat.textContent).toMatch(/cultura, no receta/i);
+    // Hueco etnolingüístico: "luna tierna" explicado.
+    expect(screen.getByTestId('alm-luna-habla').textContent).toMatch(/luna tierna/i);
+    // Las 4 fases están presentes.
+    for (const f of ['creciente', 'llena', 'menguante', 'nueva']) {
+      expect(screen.getByTestId(`luna-fase-${f}`)).toBeTruthy();
+    }
+  });
+});
+
+describe('AlmanaqueScreen — puentes', () => {
+  it('enlaza al Calendario de la finca (vista hermana) y al agente', () => {
+    const onNavigate = vi.fn();
+    render(<AlmanaqueScreen onBack={() => {}} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('alm-ir-calendario'));
+    expect(onNavigate).toHaveBeenCalledWith('calendario_finca');
+    fireEvent.click(screen.getByTestId('alm-preguntar-agente'));
+    expect(onNavigate).toHaveBeenCalledWith('agente', expect.objectContaining({ prefilledPrompt: expect.any(String) }));
+  });
+});

--- a/src/components/almanaque/almanaque.css
+++ b/src/components/almanaque/almanaque.css
@@ -1,0 +1,57 @@
+/* almanaque.css — estilos del Almanaque de la finca (photo-forward).
+ * Paleta cálida tierra/ocre como Café; el bloque lunar usa un azul noche sobrio
+ * para diferenciar el saber cultural de lo agronómico. Sin dependencias nuevas.
+ * El scrim de las fotos es FIJO (no lo vira el remapeo de temas claros) para que
+ * el texto encima quede legible al sol. */
+
+.alm-screen {
+  --alm-tierra: #241811;
+  --alm-ocre: #c98a3c;
+}
+
+/* Portada */
+.alm-portada {
+  background: linear-gradient(160deg, rgba(36, 24, 17, 0.72), rgba(36, 24, 17, 0.45));
+}
+
+/* Pestañas de sección — legibles al sol, mínimo 56px de alto */
+.alm-tab {
+  min-height: 58px;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+.alm-tab-activa {
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.08) inset;
+}
+
+/* Foto reusada: cubre, con scrim fijo */
+.alm-foto {
+  transition: transform 0.4s ease;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .alm-foto-zoom:active .alm-foto { transform: scale(1.03); }
+}
+
+/* Tira del año: aguas (azul) vs secas (ámbar) */
+.alm-temporada-lluvia { border-left: 4px solid #3f92c4; }
+.alm-temporada-seca { border-left: 4px solid #d59a3a; }
+
+/* ── Glifos de luna (SVG puro; rsvg-safe, sin filtros ni foreignObject) ──── */
+.alm-luna-glifo { display: block; }
+.alm-luna-disco { fill: #0f1830; }
+.alm-luna-luz { fill: #f4ecd6; }
+.alm-luna-borde { fill: none; stroke: #64748b; stroke-width: 2; }
+
+/* Bloque lunar: fondo noche para separar el saber cultural de lo agronómico */
+.alm-luna-bloque {
+  background: linear-gradient(165deg, #10182e, #0b1122);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+.alm-luna-fase {
+  background: rgba(148, 163, 184, 0.06);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+/* Chip de parte de la planta (hoja/fruto/raíz) */
+.alm-grupo-hoja { background: rgba(52, 153, 96, 0.15); color: #86efac; border: 1px solid rgba(52, 153, 96, 0.4); }
+.alm-grupo-fruto { background: rgba(217, 119, 66, 0.15); color: #fdba74; border: 1px solid rgba(217, 119, 66, 0.4); }
+.alm-grupo-raiz { background: rgba(168, 133, 92, 0.15); color: #e6c79c; border: 1px solid rgba(168, 133, 92, 0.4); }

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -55,6 +55,7 @@ export const MUNDOS_FINCA = [
             { view: 'cacao', label: 'El cacao', desc: 'Cultivo bandera de la paz: clones, sombra, monilia y escoba, y el beneficio que hace el precio', emoji: '🍫' },
             { view: 'hortalizas', label: 'Hortalizas de la huerta', desc: 'La comida diaria de la casa: siembra, agua, vecinas, plagas y cosecha de tomate, cebolla, zanahoria y más', emoji: '🥕' },
             { view: 'calendario_finca', label: 'Calendario de la finca', desc: 'Cuándo sembrar, abonar y cosechar, todo junto', emoji: '🗓️' },
+            { view: 'almanaque', label: 'Almanaque campesino', desc: 'El año a lo grande: aguas y secas, qué da su piso térmico y el saber lunar', emoji: '🌙' },
             { view: 'activos', label: 'Mis matas', desc: 'Las plantas que tiene sembradas y cómo van', emoji: '🪴' },
             { view: 'mapa', label: 'Zonas de la finca', desc: 'Sus lotes, eras y potreros en el mapa', emoji: '🗺️' },
             { view: 'semilla', label: 'Semilla propia', desc: 'Seleccione, guarde y pruebe su semilla criolla', emoji: '🌾' },

--- a/src/data/__tests__/almanaqueFinca.test.js
+++ b/src/data/__tests__/almanaqueFinca.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PISOS_TERMICOS,
+  TEMPORADAS_ANIO,
+  LUNA_FASES,
+  LUNA_GRUPOS,
+  LUNA_CAVEAT,
+  FOTOS_ALMANAQUE,
+  CREDITOS_FOTOS_ALMANAQUE,
+  ventanaCosecha,
+  regimenCultivo,
+} from '../almanaqueFinca';
+import { PERENNIAL_CYCLES } from '../perennialCycles';
+
+describe('almanaqueFinca — grounding y honestidad', () => {
+  it('los 4 pisos térmicos están presentes y ordenados de cálido a páramo', () => {
+    const ids = PISOS_TERMICOS.map((p) => p.id);
+    expect(ids).toEqual(['calido', 'templado', 'frio', 'paramo']);
+    // El páramo NO tiene cultivos listados, pero sí una nota honesta.
+    const paramo = PISOS_TERMICOS.find((p) => p.id === 'paramo');
+    expect(paramo.cultivos).toHaveLength(0);
+    expect(paramo.nota).toMatch(/agua|conserv|no se cultiva/i);
+  });
+
+  it('ventanaCosecha NUNCA inventa meses: refleja exactamente perennialCycles', () => {
+    // Café: bimodal con meses firmes → debe devolver los mismos meses.
+    const cafe = ventanaCosecha('coffea_arabica');
+    expect(cafe).toBeTruthy();
+    // abr · may · jun · sep · oct · nov · dic (7 meses del ciclo)
+    expect(cafe.split('·').length).toBe(PERENNIAL_CYCLES.coffea_arabica.harvest_months.length);
+  });
+
+  it('ventanaCosecha devuelve null cuando el ciclo no lista meses (regime unknown)', () => {
+    // Aguacate: regime 'unknown', sin harvest_months → no se inventa nada.
+    expect(ventanaCosecha('persea_americana')).toBeNull();
+    // Slug inexistente → null (no explota, no inventa).
+    expect(ventanaCosecha('slug_que_no_existe')).toBeNull();
+    expect(ventanaCosecha(null)).toBeNull();
+  });
+
+  it('regimenCultivo marca honestamente lo variable como pendiente', () => {
+    expect(regimenCultivo('persea_americana').tone).toBe('pendiente');
+    expect(regimenCultivo('coffea_arabica').tone).toBe('ok');
+    expect(regimenCultivo(null).tone).toBe('pendiente');
+  });
+
+  it('cada cultivo con slug apunta a una especie real del catálogo de perennes', () => {
+    for (const piso of PISOS_TERMICOS) {
+      for (const c of piso.cultivos) {
+        if (c.slug) {
+          expect(PERENNIAL_CYCLES[c.slug], `slug desconocido: ${c.slug}`).toBeTruthy();
+        }
+      }
+    }
+  });
+
+  it('el bloque lunar se enmarca como cultura, no receta (encuadre honesto)', () => {
+    expect(LUNA_CAVEAT).toMatch(/no promete más cosecha/i);
+    expect(LUNA_CAVEAT).toMatch(/cultura, no receta/i);
+    // No debe prometer rendimiento ni hablar como ciencia dura.
+    expect(LUNA_CAVEAT).not.toMatch(/%|por ?ciento|garantiza/i);
+  });
+
+  it('las 4 fases lunares y los 3 grupos folk están completos', () => {
+    expect(LUNA_FASES.map((f) => f.id)).toEqual(['creciente', 'llena', 'menguante', 'nueva']);
+    expect(LUNA_GRUPOS.map((g) => g.id)).toEqual(['hoja', 'fruto', 'raiz']);
+    // Ataca el hueco etnolingüístico: la luna nueva se nombra "tierna".
+    const nueva = LUNA_FASES.find((f) => f.id === 'nueva');
+    expect(nueva.fase).toMatch(/tierna/i);
+  });
+
+  it('las temporadas cubren aguas y secas del régimen bimodal', () => {
+    const tonos = new Set(TEMPORADAS_ANIO.map((t) => t.tono));
+    expect(tonos.has('lluvia')).toBe(true);
+    expect(tonos.has('seca')).toBe(true);
+  });
+
+  it('cada crédito de foto trae autor, licencia y fuente Wikimedia', () => {
+    expect(CREDITOS_FOTOS_ALMANAQUE.length).toBe(Object.keys(FOTOS_ALMANAQUE).length);
+    for (const cr of CREDITOS_FOTOS_ALMANAQUE) {
+      expect(cr.autor).toBeTruthy();
+      expect(cr.licencia).toMatch(/CC/);
+      expect(cr.fuenteUrl).toMatch(/commons\.wikimedia\.org/);
+    }
+  });
+});

--- a/src/data/almanaqueFinca.js
+++ b/src/data/almanaqueFinca.js
@@ -1,0 +1,324 @@
+/**
+ * almanaqueFinca — datos del "Almanaque de la finca": el calendario agrícola y
+ * lunar campesino, contado a lo grande (patrón photo-forward de Café/Agua).
+ *
+ * Es la vista HERMANA de CalendarioFincaScreen: mientras aquel arma el
+ * calendario GROUNDED, mata por mata, de la finca del usuario, este enseña el
+ * año campesino colombiano a nivel país — las temporadas de aguas y secas, qué
+ * da cada piso térmico, y el saber lunar tradicional — para orientar antes de
+ * entrar al detalle. Uno NO reemplaza al otro; se complementan y se enlazan.
+ *
+ * GROUNDING (anti-alucinación, crítico):
+ *   - Las ventanas de cosecha de los perennes salen de `perennialCycles.js`
+ *     (Agrosavia/Cenicafé/Fedecacao). NO se inventan meses: si el ciclo dice
+ *     `regime: 'unknown'` o no lista meses, aquí sale "dato en camino".
+ *   - Las temporadas de aguas/secas y los hitos folk (cabañuelas, veranillo de
+ *     San Juan, mitaca, cordonazo de San Francisco, San Isidro) vienen del
+ *     léxico etnolingüístico Chagra (public/lexico-campesino.json), que a su vez
+ *     viene de DR calendario-folk-lunar-agricola-colombia.
+ *   - Los pisos térmicos son la clasificación de Caldas (estándar IGAC): rangos
+ *     de altitud y temperatura verificables, no opinión.
+ *
+ * SABER LUNAR — encuadre honesto (misma política que MundoCultivosHub):
+ *   Se presenta como CULTURA, no como receta agronómica. Se dice explícito que
+ *   "no promete más cosecha". Ataca el hueco etnolingüístico (que el usuario y
+ *   el agente entiendan "sembrar en luna tierna") SIN venderlo como ciencia
+ *   dura. Nada de porcentajes de rendimiento ni promesas causales.
+ */
+
+import { PERENNIAL_CYCLES, monthShortName } from './perennialCycles';
+
+/* ── Fotos reales reutilizadas (Wikimedia Commons, licencia abierta) ────────
+ * Para no engordar el bundle (presupuesto apretado), el almanaque REUTILIZA
+ * fotos que ya viven en /public de otros mundos, con su crédito original. No
+ * agrega megas nuevos. Cada entrada trae su ruta absoluta y su crédito. */
+export const FOTOS_ALMANAQUE = {
+  siembra_lluvia: {
+    src: '/milpa/siembra.jpg',
+    autor: 'Anna Juchnowicz',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Three_Sisters_companion_planting_technique.jpg',
+  },
+  maiz_seco: {
+    src: '/milpa/maiz.jpg',
+    autor: 'Shixart1985',
+    licencia: 'CC BY 2.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Corn_cobs_drying_on_a_wall_in_a_rustic_setting.jpg',
+  },
+  milpa_viva: {
+    src: '/milpa/milpaviva.jpg',
+    autor: 'Feria de Productores',
+    licencia: 'CC BY 2.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Milpa_llena_de_vida.jpg',
+  },
+  montana_cafe: {
+    src: '/cafe/cafetal.jpg',
+    autor: 'Timothy A. Gonsalves',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Coffee_Shade_Trees_Paddy_Fields_Coorg_Feb24_R16_07670.jpg',
+  },
+  platano_racimo: {
+    src: '/platano-banano/racimo-verde.jpg',
+    autor: 'NiferO',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Freshly_Harvested_Green_Bananas.jpg',
+  },
+  cacao_mazorca: {
+    src: '/cacao/mazorca.jpg',
+    autor: 'Pkraemer',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Cocoa_pod.jpg',
+  },
+  huerta_lechuga: {
+    src: '/hortalizas/lechuga.jpg',
+    autor: 'Basile Morin',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Green_lettuce_in_a_kitchen_garden.jpg',
+  },
+  zanahoria_cosecha: {
+    src: '/hortalizas/zanahoria.jpg',
+    autor: 'woodleywonderworks',
+    licencia: 'CC BY 2.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Carrot_harvest.jpg',
+  },
+};
+
+/** Créditos deduplicados para el pie de fotos (cumplimiento licencia abierta). */
+export const CREDITOS_FOTOS_ALMANAQUE = Object.entries(FOTOS_ALMANAQUE).map(
+  ([slug, f]) => ({ slug, autor: f.autor, licencia: f.licencia, fuenteUrl: f.fuenteUrl }),
+);
+
+/* ── El año campesino: aguas y secas + hitos folk ──────────────────────────
+ * Colombia no tiene cuatro estaciones: tiene picos de lluvia (aguas) y periodos
+ * secos (secas). El campesino siembra al ENTRAR las aguas. Estos hitos vienen
+ * del léxico etnolingüístico (public/lexico-campesino.json, categoría
+ * "calendario"); se citan como saber folk, no como pronóstico oficial. */
+export const TEMPORADAS_ANIO = [
+  {
+    id: 'aguas1',
+    nombre: 'Primeras aguas',
+    meses: 'abril – mayo',
+    tono: 'lluvia',
+    que: 'La ventana grande de siembra en zona andina bimodal. Entra la humedad buena y el maíz, el fríjol y la huerta nacen parejo.',
+  },
+  {
+    id: 'veranillo',
+    nombre: 'Veranillo de San Juan',
+    meses: '~24 de junio',
+    tono: 'seca',
+    que: 'Pausa seca corta en plena temporada de lluvias. El campesino la aprovecha para deshierbar, abonar y no sembrar lo que se ahogue.',
+  },
+  {
+    id: 'secas1',
+    nombre: 'Secas grandes',
+    meses: 'junio – agosto',
+    tono: 'seca',
+    que: 'Menos lluvia. Es tiempo de cosecha de lo sembrado en las primeras aguas, de secar grano y guardar semilla, y de preparar la tierra.',
+  },
+  {
+    id: 'aguas2',
+    nombre: 'Segundas aguas',
+    meses: 'octubre – noviembre',
+    tono: 'lluvia',
+    que: 'La segunda ventana de siembra del año en zona bimodal. Vuelve la humedad y se repite el ciclo con los cultivos de ciclo corto.',
+  },
+  {
+    id: 'cordonazo',
+    nombre: 'Cordonazo de San Francisco',
+    meses: '~4 de octubre',
+    tono: 'lluvia',
+    que: 'Aguaceros y vientos fuertes que marcan el cierre de la seca. Creencia: si no llega a tiempo, el invierno viene corrido.',
+  },
+  {
+    id: 'secas2',
+    nombre: 'Secas de fin de año',
+    meses: 'diciembre – febrero',
+    tono: 'seca',
+    que: 'La seca larga. Buen tiempo para cosechar, secar café y grano, podar y planear la siembra de las primeras aguas.',
+  },
+];
+
+/** Dos saberes folk de pronóstico que el campesino lee para planear el año. */
+export const HITOS_PRONOSTICO = [
+  {
+    id: 'cabanuelas',
+    termino: 'Cabañuelas',
+    que: 'Los primeros días de enero se leen como espejo de los doce meses del año: el 1 pronostica enero, el 2 febrero, y así. Método folk para planear las siembras.',
+  },
+  {
+    id: 'san-isidro',
+    termino: 'San Isidro Labrador',
+    que: 'El 15 de mayo, patrón de los agricultores. Marca el inicio del buen tiempo; en muchos pueblos se bendicen las semillas antes de sembrar.',
+  },
+  {
+    id: 'mitaca',
+    termino: 'La mitaca',
+    que: 'La cosecha menor o de "traviesa", sobre todo en café y frutales — la segunda del año, más pequeña que la principal. En la región central cae hacia abril–junio.',
+  },
+];
+
+/* ── Pisos térmicos (clasificación de Caldas, estándar IGAC) ────────────────
+ * Rangos de altitud/temperatura verificables. Los cultivos de cada piso salen
+ * del catálogo (rangos de altitud de perennialCycles.region_note) y de la
+ * milpa; las ventanas de cosecha de los perennes se derivan abajo, GROUNDED. */
+export const PISOS_TERMICOS = [
+  {
+    id: 'calido',
+    nombre: 'Tierra caliente',
+    rango: '0 – 1000 msnm',
+    temp: 'más de 24 °C',
+    emoji: '🌴',
+    foto: 'platano_racimo',
+    color: '#c2681f',
+    lema: 'Plátano, cacao, cítricos y frutas de calor',
+    cultivos: [
+      { nombre: 'Plátano y banano', slug: 'musa_paradisiaca', nota: 'Pancoger de la casa; produce escalonado todo el año.' },
+      { nombre: 'Cacao', slug: 'theobroma_cacao', nota: 'Bajo sombra, por debajo de 1250 msnm.' },
+      { nombre: 'Maracuyá', slug: 'passiflora_edulis_flavicarpa', nota: 'Clima cálido hasta ~1000 msnm.' },
+      { nombre: 'Piña', slug: 'ananas_comosus', nota: 'Según manejo e inducción de floración.' },
+      { nombre: 'Lima Tahití', slug: 'citrus_latifolia', nota: 'Del nivel del mar hasta ~2100 msnm.' },
+    ],
+  },
+  {
+    id: 'templado',
+    nombre: 'Tierra templada',
+    rango: '1000 – 2000 msnm',
+    temp: '17 – 24 °C',
+    emoji: '☕',
+    foto: 'montana_cafe',
+    color: '#7a4a24',
+    lema: 'El piso del café, el aguacate y la mora',
+    cultivos: [
+      { nombre: 'Café', slug: 'coffea_arabica', nota: 'El cultivo bandera; entre 1200 y 2200 msnm.' },
+      { nombre: 'Aguacate', slug: 'persea_americana', nota: 'Óptimo 1800–2000 msnm.' },
+      { nombre: 'Mora de Castilla', slug: 'rubus_glaucus', nota: 'Amplio: 1200–3200 msnm.' },
+      { nombre: 'Lulo', slug: 'solanum_quitoense', nota: 'Estudiado entre 1800 y 2600 msnm.' },
+      { nombre: 'Granadilla', slug: 'passiflora_ligularis', nota: '1700–2100 msnm.' },
+    ],
+  },
+  {
+    id: 'frio',
+    nombre: 'Tierra fría',
+    rango: '2000 – 3000 msnm',
+    temp: '12 – 17 °C',
+    emoji: '🥬',
+    foto: 'huerta_lechuga',
+    color: '#3f7a4e',
+    lema: 'La huerta, la papa y las frutas frías',
+    cultivos: [
+      { nombre: 'Hortalizas de hoja', slug: null, nota: 'Lechuga, repollo, acelga: ciclo corto, siembra escalonada.' },
+      { nombre: 'Raíces de la huerta', slug: null, nota: 'Zanahoria, remolacha, cebolla: cultivos de clima frío.' },
+      { nombre: 'Tomate de árbol', slug: 'solanum_betaceum', nota: 'Frío moderado andino (16–20 °C).' },
+      { nombre: 'Uchuva', slug: 'physalis_peruviana', nota: 'Se adapta entre 1800 y 2800 msnm.' },
+      { nombre: 'Feijoa', slug: 'acca_sellowiana', nota: 'Óptimo 2100–2600 msnm.' },
+      { nombre: 'Curuba', slug: 'passiflora_tripartita_mollissima', nota: 'Alturas frías, 1800–3500 msnm.' },
+    ],
+  },
+  {
+    id: 'paramo',
+    nombre: 'Páramo',
+    rango: 'más de 3000 msnm',
+    temp: 'menos de 12 °C',
+    emoji: '🏔️',
+    foto: null,
+    color: '#4b6b7a',
+    lema: 'Zona de agua: casi no se cultiva',
+    cultivos: [],
+    nota: 'Por encima de los 3000 msnm casi no se cultiva: es la fábrica de agua de la finca y del país. Se cuida el frailejón y la cobertura nativa, no se ara. Algunos cultivos frescos (arándano, agraz) llegan hasta el borde inferior con manejo.',
+  },
+];
+
+/**
+ * Ventana de cosecha GROUNDED de un perenne, derivada de perennialCycles.
+ * Devuelve un texto corto de meses (p. ej. "abr · may · jun · sep · oct...") o
+ * null si el ciclo no lista meses (regime 'unknown' o continuo sin picos).
+ * Nunca inventa.
+ * @param {string} slug
+ * @returns {string|null}
+ */
+export function ventanaCosecha(slug) {
+  const cy = slug ? PERENNIAL_CYCLES[slug] : null;
+  if (!cy || !Array.isArray(cy.harvest_months) || cy.harvest_months.length === 0) {
+    return null;
+  }
+  const meses = [...cy.harvest_months].sort((a, b) => a - b);
+  return meses.map((m) => monthShortName(m)).join(' · ');
+}
+
+/**
+ * Etiqueta honesta del régimen de un perenne para la UI.
+ * @param {string} slug
+ * @returns {{ label: string, tone: 'ok'|'pendiente' }}
+ */
+export function regimenCultivo(slug) {
+  const cy = slug ? PERENNIAL_CYCLES[slug] : null;
+  if (!cy) return { label: 'Ciclo por confirmar', tone: 'pendiente' };
+  if (cy.regime === 'unknown') return { label: 'Calendario variable por zona', tone: 'pendiente' };
+  if (cy.regime === 'bimodal') return { label: 'Dos cosechas al año', tone: 'ok' };
+  if (cy.regime === 'seasonal') return { label: 'Una cosecha al año', tone: 'ok' };
+  return { label: 'Produce casi todo el año', tone: 'ok' };
+}
+
+/* ── La luna: saber campesino (cultura, no receta) ──────────────────────────
+ * Encuadre honesto idéntico al de MundoCultivosHub: se presenta como CULTURA,
+ * con el aviso explícito de que "no promete más cosecha". Su valor aquí es
+ * DOBLE: (1) respeta y ordena el saber tradicional; (2) cierra el hueco
+ * etnolingüístico — que el usuario y el agente entiendan expresiones como
+ * "sembrar en luna tierna" o "cortar en menguante". Los significados vienen del
+ * léxico etnolingüístico (public/lexico-campesino.json). */
+export const LUNA_FASES = [
+  {
+    id: 'creciente',
+    fase: 'Luna creciente',
+    icono: 'creciente',
+    folk: 'La savia sube',
+    dice: 'Se dice que la savia asciende a tallos y ramas.',
+    labores: 'Ventana folk para lo de HOJA y de PORTE ALTO: lechuga, espinaca, coles, maíz, injertos y trasplantes.',
+    grupo: 'hoja',
+  },
+  {
+    id: 'llena',
+    fase: 'Luna llena',
+    icono: 'llena',
+    folk: 'Todo arriba',
+    dice: 'La savia acumulada en tallos y hojas, según el saber.',
+    labores: 'Ventana folk para COSECHA de frutos jugosos y corte de madera; también se usa para bioestimular.',
+    grupo: 'fruto',
+  },
+  {
+    id: 'menguante',
+    fase: 'Luna menguante',
+    icono: 'menguante',
+    folk: 'La savia baja',
+    dice: 'Se dice que la savia desciende y se concentra en las raíces.',
+    labores: 'Ventana folk para lo de RAÍZ: zanahoria, papa, cebolla, remolacha, yuca; también podas.',
+    grupo: 'raiz',
+  },
+  {
+    id: 'nueva',
+    fase: 'Luna nueva (tierna)',
+    icono: 'nueva',
+    folk: 'Reposo',
+    dice: 'Llamada "luna tierna": periodo de reposo, poco crecimiento.',
+    labores: 'Se recomienda descansar la tierra; algunos siembran raíces o hacen poda de raíz y trasplante.',
+    grupo: 'raiz',
+  },
+];
+
+/** Los tres grupos folk de cultivo por la parte que se aprovecha. */
+export const LUNA_GRUPOS = [
+  { id: 'hoja', titulo: 'De hoja', ejemplos: 'lechuga, espinaca, coles, cilantro', luna: 'creciente' },
+  { id: 'fruto', titulo: 'De fruto', ejemplos: 'tomate, fríjol, calabaza, frutales', luna: 'creciente / llena' },
+  { id: 'raiz', titulo: 'De raíz', ejemplos: 'zanahoria, papa, cebolla, yuca', luna: 'menguante' },
+];
+
+/** Aviso honesto obligatorio del bloque lunar (encuadre "cultura, no receta"). */
+export const LUNA_CAVEAT =
+  'El calendario lunar es saber campesino que sirve para organizar las labores y transmitir la costumbre. No promete más cosecha: es cultura, no receta. Lo agronómico firme —qué da su piso térmico y cuándo cosecha cada mata— está en el resto del almanaque y en el Calendario de la finca.';
+
+export const LUNA_FUENTE =
+  'Léxico etnolingüístico campesino Chagra (calendario folk-lunar agrícola de Colombia); registro etnográfico, no recomendación agronómica.';
+
+/** Fuentes globales del almanaque, para el pie de página. */
+export const ALMANAQUE_FUENTES =
+  'Ciclos y ventanas de cosecha: Agrosavia, Cenicafé, Fedecacao, ICA y Universidad Nacional (catálogo Chagra). Temporadas y saber folk: léxico etnolingüístico campesino de Colombia. Pisos térmicos: clasificación de Caldas (IGAC).';


### PR DESCRIPTION
## Qué es

Nueva vista **Almanaque de la finca** (`AlmanaqueScreen`), **hermana** de `CalendarioFincaScreen` — no la duplica. El Calendario de la finca arma el calendario *grounded, mata por mata*, de la finca del usuario; el Almanaque enseña el **año campesino a lo grande** y remata enlazando a ese detalle.

Sigue el patrón **photo-forward** de Café/Agua (misma `FotoAlmanaque` con scrim fijo + crédito + fallback; chips `SlotPendiente` honestos). NO inventa motor nuevo.

## Cómo se llega

`Dashboard → mundo «Cultivos y semillas» → tarjeta «Almanaque campesino» 🌙` (justo debajo de «Calendario de la finca»). Router: `case 'almanaque'`.

## Contenido (3 secciones)

1. **El año** — aguas y secas del régimen bimodal + hitos folk (cabañuelas, veranillo de San Juan, mitaca, cordonazo de San Francisco, San Isidro).
2. **Pisos térmicos** — los 4 pisos (clasificación de Caldas / IGAC), qué da cada uno y la **ventana de cosecha GROUNDED** derivada de `perennialCycles.js` (Agrosavia/Cenicafé/Fedecacao). Sin dato firme → «dato en camino»; el páramo no lista cultivos (nota honesta de conservación). Auto-selecciona el piso por la altitud del perfil.
3. **La luna** — saber campesino enmarcado como **cultura, no receta** («no promete más cosecha»), mismo encuadre ya shippeado en `MundoCultivosHub`. Cierra el **hueco etnolingüístico**: explica «sembrar en luna tierna», «cortar en menguante» y la regla hoja/fruto/raíz. Glifos de luna en **SVG puro** (rsvg-safe).

## Grounding / honestidad

- Meses de cosecha derivados EXACTAMENTE de `perennialCycles.js`; nunca se inventan (test lo congela).
- Lo lunar se cita como registro etnográfico (léxico etnolingüístico campesino), no como ciencia dura.

## Presupuesto y deps

- **0 MB nuevos**: reutiliza fotos CC que ya viven en `/public` (milpa, café, plátano, cacao, hortalizas) con su crédito original.
- Budget de arranque: **23.9 / 25.0 MB** (`check-perf-budget.mjs`). Chunk lazy propio ~27 KB.
- Sin dependencias npm nuevas.

## Verificación

- `vite build`: verde.
- `check-perf-budget.mjs`: dentro de umbrales (23.9/25 MB).
- `tsc:check`: **1829 errores = baseline exacto**, 0 en archivos tocados (App.jsx, mundosFinca.js) y 0 en los nuevos.
- Tests: 9 de datos (grounding/anti-alucinación) + 7 de render/interacción — 16/16 verdes.

## Pendiente

- ⏳ Verificación visual del operador (política UX). Fotos y layout listos para revisar en la app.