### PR TITLE
feat(modo-campo): tarjeta de ejemplos de voz con onda animada

### DIFF
--- a/src/components/modoCampo/EjemplosVoz.jsx
+++ b/src/components/modoCampo/EjemplosVoz.jsx
@@ -1,0 +1,142 @@
+/**
+ * EjemplosVoz — tarjeta "qué puedo decirle" del modo campo (wake-word
+ * «hola chagra»). Vive dentro de ModoCampoPanel (Perfil → voz).
+ *
+ * Muestra 3 ejemplos REALES y bien diferenciados de lo que se puede hacer
+ * por voz — registrar en el cuaderno, pedir consejo hablado, preguntar un
+ * dato en vivo — rotando uno cada ~4s con una onda de voz sutil que late.
+ *
+ * Honestidad del copy: NO promete "IA en su teléfono". El reconocimiento
+ * del wake-word sí es on-device, pero el agente necesita señal para
+ * responder — por eso el encabezado vende el gesto ("con las manos
+ * ocupadas"), no una capacidad que no existe.
+ *
+ * Accesibilidad: respeta prefers-reduced-motion — sin animación, los 3
+ * ejemplos se muestran quietos en lista (misma información, cero vaivén).
+ *
+ * Solo UI/copy: cero lógica de wake-word, cero deps nuevas (emoji + CSS).
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+import React, { useEffect, useState } from 'react';
+import './ejemplosVoz.css';
+
+/** Los 3 ejemplos canónicos — cada uno una capacidad DISTINTA. */
+// eslint-disable-next-line react-refresh/only-export-components -- constante de copy que los tests validan junto al componente (patrón NotifPermissionPrompt)
+export const EJEMPLOS_VOZ = [
+  {
+    emoji: '🎙️',
+    capacidad: 'Anotar en su cuaderno',
+    frase: '«Hola Chagra, anota que fumigué el lote 2 con caldo bordelés»',
+    resultado: 'Queda escrito en su cuaderno de campo, sin sacarse los guantes.',
+  },
+  {
+    emoji: '🌱',
+    capacidad: 'Pedir un consejo',
+    frase: '«Hola Chagra, ¿por qué se me está amarillando el café?»',
+    resultado: 'El agente le responde hablado, con lo que sabe de su finca.',
+  },
+  {
+    emoji: '💰',
+    capacidad: 'Preguntar un dato en vivo',
+    frase: '«Hola Chagra, ¿a cómo está el aguacate esta semana?»',
+    resultado: 'Le trae el precio del día y se lo dice de una.',
+  },
+];
+
+const ROTACION_MS = 4000;
+
+/** ¿El usuario pidió movimiento reducido a nivel de sistema? */
+const prefiereMenosMovimiento = () =>
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : false;
+
+/** Onda de voz decorativa: 9 barras que laten (CSS puro, sin datos falsos de
+ *  micrófono — es ilustración, y con reduced-motion queda quieta). */
+function OndaVoz() {
+  return (
+    <div className="ejemplos-voz-onda" aria-hidden="true">
+      {Array.from({ length: 9 }, (_, i) => (
+        <span key={i} className="ejemplos-voz-barra" style={{ '--i': i }} />
+      ))}
+    </div>
+  );
+}
+
+function Ejemplo({ ejemplo }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="text-2xl leading-none mt-0.5 shrink-0" aria-hidden="true">{ejemplo.emoji}</span>
+      <div className="min-w-0">
+        <p className="text-[10px] font-bold uppercase tracking-wider text-emerald-400/90 mb-0.5">
+          {ejemplo.capacidad}
+        </p>
+        <p className="text-[13px] text-slate-200 font-medium leading-snug">{ejemplo.frase}</p>
+        <p className="text-[11px] text-slate-500 leading-snug mt-1">→ {ejemplo.resultado}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function EjemplosVoz() {
+  // Se lee UNA vez al montar: si el usuario cambia la preferencia del sistema
+  // con el panel abierto, el próximo montaje la recoge (suficiente acá).
+  const [sinMovimiento] = useState(prefiereMenosMovimiento);
+  const [idx, setIdx] = useState(0);
+
+  useEffect(() => {
+    if (sinMovimiento) return undefined;
+    const timer = setInterval(() => {
+      setIdx((i) => (i + 1) % EJEMPLOS_VOZ.length);
+    }, ROTACION_MS);
+    return () => clearInterval(timer);
+  }, [sinMovimiento]);
+
+  return (
+    <div
+      className="ejemplos-voz rounded-xl border border-slate-700/50 bg-slate-800/40 p-4 space-y-3"
+      data-testid="ejemplos-voz"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h4 className="text-[13px] font-bold text-slate-200">
+          Háblele con las manos ocupadas
+        </h4>
+        <OndaVoz />
+      </div>
+
+      {sinMovimiento ? (
+        <div className="space-y-3" data-testid="ejemplos-voz-lista">
+          {EJEMPLOS_VOZ.map((e) => <Ejemplo key={e.capacidad} ejemplo={e} />)}
+        </div>
+      ) : (
+        <>
+          {/* key={idx} remonta el nodo → la animación de entrada corre en cada
+              rotación. min-height evita brincos entre frases de largo distinto. */}
+          <div className="ejemplos-voz-escena" aria-live="off">
+            <div className="ejemplos-voz-paso" key={idx} data-testid="ejemplos-voz-activo">
+              <Ejemplo ejemplo={EJEMPLOS_VOZ[idx]} />
+            </div>
+          </div>
+          <div className="flex justify-center gap-1.5" aria-hidden="true">
+            {EJEMPLOS_VOZ.map((e, i) => (
+              <span
+                key={e.capacidad}
+                className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
+                  i === idx ? 'bg-emerald-400' : 'bg-slate-600'
+                }`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      <p
+        className="text-[11px] text-slate-500 leading-relaxed border-t border-slate-700/50 pt-2.5"
+        data-testid="ejemplos-voz-guia"
+      >
+        Diga <strong className="text-slate-400">«hola chagra»</strong> y hable. La primera vez,
+        enséñele su voz (1 minuto).
+      </p>
+    </div>
+  );
+}

--- a/src/components/modoCampo/ModoCampoPanel.jsx
+++ b/src/components/modoCampo/ModoCampoPanel.jsx
@@ -18,6 +18,7 @@ import { Radio, Mic, BatteryWarning, GraduationCap } from 'lucide-react';
 import { useModoCampoContext } from '../../hooks/ModoCampoContext';
 import { hasPersonalVoiceMarker, forgetPersonalVoice } from '../../services/wakeWordService';
 import EnrollmentModoCampo from './EnrollmentModoCampo';
+import EjemplosVoz from './EjemplosVoz';
 import { MSG } from '../../config/messages';
 
 const CONSENT_KEY = 'chagra:modoCampo:consentimiento';
@@ -89,6 +90,8 @@ export default function ModoCampoPanel() {
         EN su celular — nunca sale audio a internet. La pantalla se queda encendida mientras esté
         activo.
       </p>
+
+      <EjemplosVoz />
 
       <button
         type="button"

--- a/src/components/modoCampo/__tests__/EjemplosVoz.test.jsx
+++ b/src/components/modoCampo/__tests__/EjemplosVoz.test.jsx
@@ -1,0 +1,82 @@
+/**
+ * Tests de EjemplosVoz — la tarjeta de ejemplos del modo campo:
+ *  - encabezado honesto + micro-guía siempre visibles
+ *  - con movimiento normal: muestra UN ejemplo y ROTA cada ~4s
+ *  - con prefers-reduced-motion: lista estática con los 3 ejemplos, sin timer
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import EjemplosVoz, { EJEMPLOS_VOZ } from '../EjemplosVoz.jsx';
+
+const mockMatchMedia = (reduce) => {
+  // Cast local: el stub solo trae lo que EjemplosVoz consulta (.matches);
+  // tipar MediaQueryList completo acá no aporta nada al test (mismo patrón
+  // de casts locales que modoCampoFlag.js frente al gate de tsc:check).
+  window.matchMedia = /** @type {any} */ (vi.fn(() => ({
+    matches: reduce,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })));
+};
+
+describe('EjemplosVoz', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('define exactamente 3 ejemplos, cada uno con capacidad distinta', () => {
+    expect(EJEMPLOS_VOZ).toHaveLength(3);
+    const capacidades = EJEMPLOS_VOZ.map((e) => e.capacidad);
+    expect(new Set(capacidades).size).toBe(3);
+    // Cada frase arranca con el wake-word real.
+    EJEMPLOS_VOZ.forEach((e) => {
+      expect(e.frase.toLowerCase()).toContain('hola chagra');
+    });
+  });
+
+  it('muestra encabezado honesto y micro-guía', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    expect(screen.getByText('Háblele con las manos ocupadas')).toBeInTheDocument();
+    expect(screen.getByTestId('ejemplos-voz-guia').textContent).toContain('«hola chagra»');
+    expect(screen.getByTestId('ejemplos-voz-guia').textContent).toContain('enséñele su voz');
+  });
+
+  it('con movimiento normal muestra un ejemplo a la vez y rota cada ~4s', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    // Arranca en el primero.
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[0].frase);
+    expect(screen.queryByText(EJEMPLOS_VOZ[1].frase)).not.toBeInTheDocument();
+    // Tras ~4s pasa al segundo.
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[1].frase);
+    // Y da la vuelta completa (tercero → primero).
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[2].frase);
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[0].frase);
+  });
+
+  it('con prefers-reduced-motion lista los 3 ejemplos estáticos, sin rotar', () => {
+    mockMatchMedia(true);
+    render(<EjemplosVoz />);
+    expect(screen.getByTestId('ejemplos-voz-lista')).toBeInTheDocument();
+    EJEMPLOS_VOZ.forEach((e) => {
+      expect(screen.getByText(e.frase)).toBeInTheDocument();
+    });
+    // No hay carrusel montado.
+    expect(screen.queryByTestId('ejemplos-voz-activo')).not.toBeInTheDocument();
+    // Y avanzar el reloj no cambia nada (no hay interval vivo).
+    act(() => { vi.advanceTimersByTime(9000); });
+    EJEMPLOS_VOZ.forEach((e) => {
+      expect(screen.getByText(e.frase)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/modoCampo/ejemplosVoz.css
+++ b/src/components/modoCampo/ejemplosVoz.css
@@ -1,0 +1,56 @@
+/* ============================================================================
+ * ejemplosVoz.css — tarjeta de ejemplos del modo campo («hola chagra»).
+ *
+ * Solo lo que Tailwind no da: la onda de voz que late y la transición de
+ * entrada del ejemplo que rota. Acento vía --t-accent-rgb (themes.css) con
+ * fallback al esmeralda del panel — indirección CSS-var, nunca color duro
+ * por tema.
+ * ========================================================================== */
+
+/* --- Onda de voz: 9 barras que laten desfasadas (decorativa) -------------- */
+.ejemplos-voz-onda {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 22px;
+  flex-shrink: 0;
+}
+.ejemplos-voz-barra {
+  width: 3px;
+  border-radius: 2px;
+  background: rgba(var(--t-accent-rgb, 52, 211, 153), 0.85);
+  /* Altura base variada (perfil de onda) + latido escalado por barra. */
+  height: calc(6px + (var(--i) - 4) * (var(--i) - 4) * -0.8px + 14px);
+  transform-origin: center;
+  animation: ejemplos-voz-late 1.5s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 0.13s);
+}
+@keyframes ejemplos-voz-late {
+  0%, 100% { transform: scaleY(0.45); opacity: 0.55; }
+  50%      { transform: scaleY(1);    opacity: 1; }
+}
+
+/* --- Escena del ejemplo que rota ------------------------------------------ */
+/* min-height reserva el espacio de la frase más larga en dos líneas:
+ * sin brincos de layout cuando cambia el ejemplo. */
+.ejemplos-voz-escena {
+  min-height: 86px;
+  display: flex;
+  align-items: flex-start;
+}
+.ejemplos-voz-paso {
+  width: 100%;
+  animation: ejemplos-voz-entra 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes ejemplos-voz-entra {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* --- Movimiento reducido ---------------------------------------------------
+ * El JSX ya cambia a lista estática (matchMedia); esto cubre además el caso
+ * de que la preferencia cambie con el panel ya montado: todo quieto. */
+@media (prefers-reduced-motion: reduce) {
+  .ejemplos-voz-barra { animation: none; opacity: 0.8; }
+  .ejemplos-voz-paso { animation: none; }
+}


### PR DESCRIPTION
## Qué hace

Mejora la presentación del MODO CAMPO / wake-word «hola chagra» con una tarjeta de ejemplos dentro de `ModoCampoPanel` (Perfil → Mi agente → junto a los ajustes de voz).

- **Encabezado honesto**: "Háblele con las manos ocupadas" — no promete "IA en su teléfono"; el reconocimiento del wake-word es on-device pero el agente necesita señal para responder.
- **3 ejemplos que ROTAN** (uno cada ~4s, entrada suave), cada uno una capacidad distinta:
  1. 🎙️ «Hola Chagra, anota que fumigué el lote 2 con caldo bordelés» → anotar en su cuaderno
  2. 🌱 «Hola Chagra, ¿por qué se me está amarillando el café?» → consejo del agente hablado
  3. 💰 «Hola Chagra, ¿a cómo está el aguacate esta semana?» → dato en vivo
- **Onda de voz** sutil (9 barras CSS que laten desfasadas) junto al encabezado.
- **prefers-reduced-motion**: sin animación — los 3 ejemplos se muestran quietos en lista (mismo contenido, cero vaivén). Doble cobertura: `matchMedia` en JSX + `@media` en CSS.
- **Micro-guía**: "Diga «hola chagra» y hable. La primera vez, enséñele su voz (1 minuto)."
- Indicador de puntos (3) para orientar la rotación.

## Qué NO hace

- No toca la lógica del wake-word ni `EscuchaOverlay` — solo UI/copy.
- Cero deps npm nuevas, cero fotos: emoji + CSS puro.
- Acento vía `--t-accent-rgb` con fallback esmeralda (indirección CSS-var, patrón de temas).

## Verificación

- `npx vitest run` (EjemplosVoz + EscuchaOverlay + ProfileScreen.hub): 18/18 pass.
- `tsc-check-gate`: 1829 = baseline, **0 errores nuevos**.
- `eslint src/components/modoCampo/`: limpio.
- `npm run build` verde; `check-perf-budget`: 23.9 MB / 25 MB (TF.js lazy excluido).
- Capturas reales (dev server + Playwright, viewport 390×844) enviadas al operador por Telegram: rotación funcionando (ejemplo 1 → 2 → 3) y variante reduced-motion en lista.

Visual — espera OK del operador antes de merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)