### PR TITLE
feat(modo-campo): capa viva — ejemplos en cascada + iris de escucha espectacular

### DIFF
--- a/src/components/escucha/EscuchaFab.jsx
+++ b/src/components/escucha/EscuchaFab.jsx
@@ -6,8 +6,12 @@
  *
  * Diseño: espejo del AgentFab (colibrí, abajo-derecha): este vive ABAJO A LA
  * IZQUIERDA, 62px (tamaño guante), micrófono grande + la ramita de la mano de
- * Chagra como firma, acento del tema por --t-accent-rgb, con un ping perezoso
- * cada 4s que anuncia "aquí se habla" (apagado con prefers-reduced-motion).
+ * Chagra como firma, acento del tema por --t-accent-rgb.
+ *
+ * Estado REPOSO ("respira suave"): aurora de gradiente que respira detrás,
+ * un filo de luz cónico que orbita el borde y dos pings desfasados que
+ * brotan — el botón se siente VIVO sin gritar. Todo CSS (transform/opacity,
+ * GPU) y apagado con prefers-reduced-motion (queda un aro estático claro).
  *
  * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
  */
@@ -26,7 +30,11 @@ export default function EscuchaFab() {
       title="Manos libres: toque y hable — «lléveme al mercado» o pregunte lo que necesite"
       onClick={() => activarEscucha({ fuente: 'tap' })}
     >
+      {/* Capa viva del reposo: aurora que respira + filo de luz que orbita. */}
+      <span className="escucha-fab-aurora" aria-hidden="true" />
+      <span className="escucha-fab-giro" aria-hidden="true" />
       <span className="escucha-fab-ping" aria-hidden="true" />
+      <span className="escucha-fab-ping escucha-fab-ping-b" aria-hidden="true" />
       <Mic size={27} strokeWidth={2.4} aria-hidden="true" />
       {/* La firma de la marca: la ramita con nodos que brota (mano de Chagra) */}
       <svg

--- a/src/components/escucha/EscuchaOverlay.jsx
+++ b/src/components/escucha/EscuchaOverlay.jsx
@@ -51,6 +51,20 @@ const PAUSA_RUMBO_MS = 1000;   // deja LEER "Abriendo Mercado…" antes de salta
 
 const NUM_BROTES = 28;
 
+/* Micro-partículas (esporas) que orbitan el iris: posiciones DETERMINISTAS
+ * por ángulo áureo (137.5°) — se ven orgánicas sin aleatoriedad por render.
+ * Dos órbitas contrarrotantes (CSS); la opacidad la sube el RMS real. */
+const ESPORAS = Array.from({ length: 14 }, (_, i) => {
+  const ang = ((i * 137.5) % 360) * (Math.PI / 180);
+  const r = 86 + (i % 5) * 5.5;
+  return {
+    x: 116 + Math.cos(ang) * r,
+    y: 116 + Math.sin(ang) * r,
+    tam: 1.1 + (i % 3) * 0.55,
+    orbita: i % 2 === 0 ? 'a' : 'b',
+  };
+});
+
 const formatoSegundos = (ms) => `${(ms / 1000).toFixed(0)}s`;
 
 const navegar = (view, initialData = null) => {
@@ -60,6 +74,12 @@ const navegar = (view, initialData = null) => {
 /**
  * Iris de micelio: 3 anillos que respiran con el RMS + brotes radiales con la
  * historia de amplitud + arco de cierre (conteo de silencio). Todo dato real.
+ *
+ * Capa "viva" (solo visual, cero lógica): aurora de gradiente que gira lenta
+ * detrás, halo cónico que orbita el borde, esporas contrarrotantes y un glow
+ * central — TODOS escalados por --nivel (el RMS real vía CSS var). En
+ * "pensando", dos arcos contrarrotantes + shimmer sobre la mano (el loop de
+ * "estoy trabajando"). Ver escucha.css para el detalle de cada capa.
  */
 function IrisEscucha({ nivel, historia, fase, cierre }) {
   const C = 116; // centro del viewBox 232x232
@@ -90,9 +110,39 @@ function IrisEscucha({ nivel, historia, fase, cierre }) {
   const circArco = 2 * Math.PI * rArco;
 
   const vivo = fase === FASE_OYENDO;
+  const pensando = fase === FASE_PENSANDO;
+  // Arcos de "pensando": dos aros parciales contrarrotantes (CSS los gira).
+  const rPensarA = 100;
+  const rPensarB = 91;
+
   return (
-    <div className="escucha-iris" aria-hidden="true">
+    <div
+      className="escucha-iris"
+      aria-hidden="true"
+      style={{ '--nivel': vivo ? Number(nivel.toFixed(3)) : 0 }}
+    >
+      {/* Aurora: gradiente bicolor que gira lento detrás de todo — el
+          "organismo" respira solo y se enciende con la voz (var --nivel). */}
+      <div className="escucha-aurora">
+        <span className="escucha-aurora-giro" />
+      </div>
+      {/* Halo cónico: una luz que ORBITA el borde del iris (en pensando
+          acelera — el loop de trabajo). */}
+      <div className="escucha-halo-giro" />
+      {/* Glow central reactivo: late detrás de la mano con el RMS real. */}
+      <div className="escucha-glow" />
       <svg viewBox="0 0 232 232">
+        {/* Esporas: micro-partículas en dos órbitas contrarrotantes. */}
+        <g className="escucha-orbita escucha-orbita-a">
+          {ESPORAS.filter((e) => e.orbita === 'a').map((e, i) => (
+            <circle key={i} className="escucha-espora" cx={e.x} cy={e.y} r={e.tam} />
+          ))}
+        </g>
+        <g className="escucha-orbita escucha-orbita-b">
+          {ESPORAS.filter((e) => e.orbita === 'b').map((e, i) => (
+            <circle key={i} className="escucha-espora escucha-espora-alt" cx={e.x} cy={e.y} r={e.tam} />
+          ))}
+        </g>
         {/* Anillos de micelio: respiración = RMS real, cada uno a su ritmo */}
         {[{ r: 58, k: 26, o: 0.5 }, { r: 68, k: 16, o: 0.35 }, { r: 78, k: 8, o: 0.25 }].map(({ r, k, o }, i) => (
           <circle
@@ -107,6 +157,28 @@ function IrisEscucha({ nivel, historia, fase, cierre }) {
           />
         ))}
         {brotes}
+        {/* Pensando: dos arcos contrarrotantes alrededor del iris — el
+            shimmer/loop de "estoy trabajando con lo que dijo". */}
+        {pensando && (
+          <>
+            <circle
+              className="escucha-arco-pensar escucha-arco-pensar-a"
+              cx={C} cy={C} r={rPensarA}
+              fill="none"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeDasharray={`${2 * Math.PI * rPensarA * 0.22} ${2 * Math.PI * rPensarA * 0.78}`}
+            />
+            <circle
+              className="escucha-arco-pensar escucha-arco-pensar-b"
+              cx={C} cy={C} r={rPensarB}
+              fill="none"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeDasharray={`${2 * Math.PI * rPensarB * 0.14} ${2 * Math.PI * rPensarB * 0.86}`}
+            />
+          </>
+        )}
         {/* Conteo de silencio: el aro exterior se cierra → "ya casi termino de oír" */}
         {vivo && cierre > 0 && (
           <circle

--- a/src/components/escucha/escucha.css
+++ b/src/components/escucha/escucha.css
@@ -19,6 +19,7 @@
   --esc-dim-rgb: 148, 187, 173;     /* tinta secundaria */
   --esc-linea-rgb: 25, 201, 154;    /* trazos del iris (= acento biopunk) */
   --esc-linea-rgb: var(--t-accent-rgb);
+  --esc-linea2-rgb: 125, 211, 252;  /* segundo tono del gradiente vivo (cian) */
   --esc-cta-ink: #04231b;           /* tinta sobre el botón de acento */
 
   position: fixed;
@@ -37,6 +38,7 @@
   --esc-carta-rgb: 252, 250, 245;
   --esc-ink-rgb: 24, 34, 29;
   --esc-dim-rgb: 90, 106, 98;
+  --esc-linea2-rgb: 59, 130, 246;   /* azul: legible sobre papel */
   --esc-cta-ink: #ffffff;
 }
 [data-theme="nature"] .escucha-overlay {
@@ -44,6 +46,7 @@
   --esc-carta-rgb: 254, 250, 242;
   --esc-ink-rgb: 43, 33, 24;
   --esc-dim-rgb: 122, 103, 82;
+  --esc-linea2-rgb: 217, 119, 6;    /* ámbar: cálido sobre papel crema */
   --esc-cta-ink: #2b1c10;
 }
 [data-theme="verde-vivo"] .escucha-overlay {
@@ -51,6 +54,7 @@
   --esc-carta-rgb: 248, 251, 240;
   --esc-ink-rgb: 26, 38, 28;
   --esc-dim-rgb: 84, 104, 88;
+  --esc-linea2-rgb: 101, 163, 13;   /* lima: pariente del acento */
   --esc-cta-ink: #ffffff;
 }
 
@@ -115,8 +119,12 @@
   100% { box-shadow: 0 0 0 0 rgba(var(--esc-linea-rgb), 0); }
 }
 
-/* --- El iris (la mano que escucha) --------------------------------------- */
+/* --- El iris (la mano que escucha) -----------------------------------------
+ * Capa VIVA: todo lo que se mueve acá es transform/opacity (composita en
+ * GPU) y todo lo reactivo lee --nivel = RMS REAL del micrófono (la pone el
+ * JSX en .escucha-iris). Nada de animación fingida de audio. */
 .escucha-iris {
+  --nivel: 0;
   position: relative;
   width: 232px;
   height: 232px;
@@ -124,7 +132,116 @@
   place-items: center;
   margin: 2px 0;
 }
-.escucha-iris svg { position: absolute; inset: 0; overflow: visible; }
+.escucha-iris svg { position: absolute; inset: 0; overflow: visible; z-index: 1; }
+
+/* Aurora: gradiente bicolor que gira lento detrás de todo el iris. Los
+ * radial-gradients con caída larga dan el look "desenfocado" SIN filter:
+ * blur (que forzaría re-rasterizado por frame). La voz la enciende. */
+.escucha-aurora {
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  z-index: 0;
+  transform: scale(calc(1 + var(--nivel) * 0.16));
+  opacity: calc(0.65 + var(--nivel) * 0.35);
+  transition: transform 0.12s ease-out, opacity 0.15s ease-out;
+  pointer-events: none;
+}
+.escucha-aurora-giro {
+  position: absolute;
+  inset: 0;
+  display: block;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 32% 28%, rgba(var(--esc-linea-rgb), 0.30), transparent 52%),
+    radial-gradient(circle at 70% 68%, rgba(var(--esc-linea2-rgb), 0.22), transparent 55%),
+    radial-gradient(circle at 55% 45%, rgba(var(--esc-linea-rgb), 0.10), transparent 70%);
+  animation: escucha-aurora-vive 13s linear infinite;
+}
+@keyframes escucha-aurora-vive {
+  0%   { transform: rotate(0deg) scale(1); }
+  50%  { transform: rotate(180deg) scale(1.07); }
+  100% { transform: rotate(360deg) scale(1); }
+}
+
+/* Halo cónico: un filo de luz que ORBITA el borde del iris (máscara en
+ * anillo). En "pensando" acelera y se vuelve el loop de trabajo; en error
+ * se apaga casi del todo. */
+.escucha-halo-giro {
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  z-index: 0;
+  pointer-events: none;
+  background: conic-gradient(
+    from 0deg,
+    transparent 0deg,
+    rgba(var(--esc-linea-rgb), 0.85) 70deg,
+    rgba(var(--esc-linea2-rgb), 0.55) 110deg,
+    transparent 170deg,
+    rgba(var(--esc-linea-rgb), 0.30) 260deg,
+    transparent 320deg
+  );
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 4px), #000 calc(100% - 3px));
+  mask: radial-gradient(farthest-side, transparent calc(100% - 4px), #000 calc(100% - 3px));
+  opacity: calc(0.55 + var(--nivel) * 0.45);
+  animation: escucha-gira 5.5s linear infinite;
+}
+.escucha-overlay[data-fase="pensando"] .escucha-halo-giro { animation-duration: 1.5s; }
+.escucha-overlay[data-fase="error"] .escucha-halo-giro {
+  animation-play-state: paused;
+  opacity: 0.18;
+}
+@keyframes escucha-gira {
+  to { transform: rotate(360deg); }
+}
+
+/* Glow central: late detrás de la mano con la voz (RMS real vía --nivel). */
+.escucha-glow {
+  position: absolute;
+  width: 156px;
+  height: 156px;
+  border-radius: 50%;
+  z-index: 0;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(var(--esc-linea-rgb), 0.42), rgba(var(--esc-linea-rgb), 0.10) 48%, transparent 72%);
+  transform: scale(calc(0.9 + var(--nivel) * 0.55));
+  opacity: calc(0.4 + var(--nivel) * 0.6);
+  transition: transform 0.1s ease-out, opacity 0.15s ease-out;
+}
+
+/* Esporas: micro-partículas en dos órbitas contrarrotantes. La voz las
+ * enciende (opacidad por --nivel); en pensando se recogen hacia el centro
+ * (scale del grupo) como "concentrándose". */
+.escucha-orbita {
+  transform-origin: 116px 116px;
+  opacity: calc(0.30 + var(--nivel) * 0.70);
+  transition: opacity 0.2s ease;
+}
+.escucha-orbita-a { animation: escucha-gira 26s linear infinite; }
+.escucha-orbita-b { animation: escucha-gira-inversa 18s linear infinite; }
+@keyframes escucha-gira-inversa {
+  to { transform: rotate(-360deg); }
+}
+.escucha-overlay[data-fase="pensando"] .escucha-orbita-a { animation-duration: 7s; }
+.escucha-overlay[data-fase="pensando"] .escucha-orbita-b { animation-duration: 5s; }
+.escucha-espora { fill: rgb(var(--esc-linea-rgb)); }
+.escucha-espora-alt { fill: rgb(var(--esc-linea2-rgb)); }
+
+/* Pensando: dos arcos contrarrotantes (dasharray parcial, round cap) — el
+ * "shimmer loop" de estoy-trabajando, honesto y hermoso. */
+.escucha-arco-pensar {
+  transform-origin: 116px 116px;
+}
+.escucha-arco-pensar-a {
+  stroke: rgb(var(--esc-linea-rgb));
+  animation: escucha-gira 1.4s cubic-bezier(0.45, 0.1, 0.55, 0.9) infinite;
+}
+.escucha-arco-pensar-b {
+  stroke: rgb(var(--esc-linea2-rgb));
+  opacity: 0.75;
+  animation: escucha-gira-inversa 2.1s cubic-bezier(0.45, 0.1, 0.55, 0.9) infinite;
+}
 
 /* Anillos de micelio: el scale lo pone el JSX con el RMS real; acá solo
  * la transición corta para que el movimiento se sienta orgánico. */
@@ -160,11 +277,32 @@
   box-shadow: 0 0 34px rgba(var(--esc-linea-rgb), 0.35);
 }
 .escucha-overlay[data-fase="pensando"] .escucha-mano {
+  overflow: hidden; /* contiene el barrido de luz al disco */
   animation: escucha-piensa 1.4s ease-in-out infinite;
 }
 @keyframes escucha-piensa {
   0%, 100% { box-shadow: 0 0 22px rgba(var(--esc-linea-rgb), 0.25); }
   50%      { box-shadow: 0 0 48px rgba(var(--esc-linea-rgb), 0.55); }
+}
+/* Shimmer: un barrido de luz cruza la mano mientras piensa (transform puro). */
+.escucha-overlay[data-fase="pensando"] .escucha-mano::after {
+  content: '';
+  position: absolute;
+  inset: -30%;
+  background: linear-gradient(
+    115deg,
+    transparent 40%,
+    rgba(var(--esc-linea2-rgb), 0.16) 47%,
+    rgba(255, 255, 255, 0.28) 51%,
+    rgba(var(--esc-linea-rgb), 0.14) 55%,
+    transparent 62%
+  );
+  animation: escucha-shimmer 1.6s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes escucha-shimmer {
+  from { transform: translateX(-65%); }
+  to   { transform: translateX(65%); }
 }
 
 /* --- Título de estado (legible al sol: enorme y extrabold) ---------------- */
@@ -328,7 +466,59 @@
 }
 [data-theme="nature"] .escucha-fab { color: #2b1c10; }
 
-/* Ping perezoso: un aro que brota cada 4s — anuncia sin fastidiar. */
+/* Aurora del reposo: un aliento de luz detrás del FAB que respira lento —
+ * "aquí vive algo". Solo transform/opacity (GPU). */
+.escucha-fab-aurora {
+  position: absolute;
+  inset: -12px;
+  border-radius: 50%;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 35% 30%, rgba(var(--t-accent-rgb), 0.40), transparent 58%),
+    radial-gradient(circle at 68% 72%, rgba(var(--t-accent-rgb), 0.22), transparent 62%);
+  animation: escucha-fab-respira 4.2s ease-in-out infinite;
+}
+@keyframes escucha-fab-respira {
+  0%, 100% { transform: scale(0.96); opacity: 0.5; }
+  50%      { transform: scale(1.1);  opacity: 0.95; }
+}
+
+/* Filo de luz que orbita el borde del FAB (gradiente cónico + máscara en
+ * anillo, girado con transform — compositor puro). */
+.escucha-fab-giro {
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  pointer-events: none;
+  background: conic-gradient(
+    from 0deg,
+    transparent 8%,
+    rgba(var(--t-accent-rgb), 0.95) 22%,
+    transparent 42%,
+    rgba(var(--t-accent-rgb), 0.35) 68%,
+    transparent 90%
+  );
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 2px));
+  mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 2px));
+  animation: escucha-gira 7s linear infinite;
+}
+
+/* Sobre el disco sólido de los temas claros el filo del acento no se ve:
+ * pasa a luz blanca. */
+[data-theme="minimalista"] .escucha-fab-giro,
+[data-theme="nature"] .escucha-fab-giro,
+[data-theme="verde-vivo"] .escucha-fab-giro {
+  background: conic-gradient(
+    from 0deg,
+    transparent 8%,
+    rgba(255, 255, 255, 0.95) 22%,
+    transparent 42%,
+    rgba(255, 255, 255, 0.35) 68%,
+    transparent 90%
+  );
+}
+
+/* Pings perezosos: dos aros desfasados que brotan — anuncian sin fastidiar. */
 .escucha-fab-ping {
   position: absolute;
   inset: -2px;
@@ -337,6 +527,7 @@
   animation: escucha-fab-brota 4s ease-out infinite;
   pointer-events: none;
 }
+.escucha-fab-ping-b { animation-delay: 2s; }
 @keyframes escucha-fab-brota {
   0%   { transform: scale(1); opacity: 0.7; }
   30%  { transform: scale(1.45); opacity: 0; }
@@ -363,4 +554,19 @@
   .escucha-overlay[data-fase="pensando"] .escucha-mano { animation: none; }
   .escucha-fab-ping { animation: none; opacity: 0; }
   .escucha-fab, .escucha-btn-listo { transition: none; }
+
+  /* Capa viva quieta pero LEGIBLE: la aurora y el halo quedan como aro/luz
+   * estáticos (el estado sigue claro), las esporas tenues y sin órbita, el
+   * shimmer apagado. Los arcos de "pensando" quedan fijos: junto al texto
+   * "Entendiendo lo que dijo…" siguen comunicando el estado. */
+  .escucha-aurora,
+  .escucha-aurora-giro,
+  .escucha-halo-giro,
+  .escucha-orbita,
+  .escucha-arco-pensar { animation: none; transition: none; }
+  .escucha-glow { transition: none; }
+  .escucha-orbita { opacity: 0.25; }
+  .escucha-overlay[data-fase="pensando"] .escucha-mano::after { animation: none; content: none; }
+  .escucha-fab-aurora { animation: none; opacity: 0.45; }
+  .escucha-fab-giro { animation: none; opacity: 0.5; }
 }

--- a/src/components/modoCampo/EjemplosVoz.jsx
+++ b/src/components/modoCampo/EjemplosVoz.jsx
@@ -1,0 +1,142 @@
+/**
+ * EjemplosVoz — tarjeta "qué puedo decirle" del modo campo (wake-word
+ * «hola chagra»). Vive dentro de ModoCampoPanel (Perfil → voz).
+ *
+ * Muestra 3 ejemplos REALES y bien diferenciados de lo que se puede hacer
+ * por voz — registrar en el cuaderno, pedir consejo hablado, preguntar un
+ * dato en vivo — rotando uno cada ~4s con una onda de voz sutil que late.
+ *
+ * Honestidad del copy: NO promete "IA en su teléfono". El reconocimiento
+ * del wake-word sí es on-device, pero el agente necesita señal para
+ * responder — por eso el encabezado vende el gesto ("con las manos
+ * ocupadas"), no una capacidad que no existe.
+ *
+ * Accesibilidad: respeta prefers-reduced-motion — sin animación, los 3
+ * ejemplos se muestran quietos en lista (misma información, cero vaivén).
+ *
+ * Solo UI/copy: cero lógica de wake-word, cero deps nuevas (emoji + CSS).
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+import React, { useEffect, useState } from 'react';
+import './ejemplosVoz.css';
+
+/** Los 3 ejemplos canónicos — cada uno una capacidad DISTINTA. */
+// eslint-disable-next-line react-refresh/only-export-components -- constante de copy que los tests validan junto al componente (patrón NotifPermissionPrompt)
+export const EJEMPLOS_VOZ = [
+  {
+    emoji: '🎙️',
+    capacidad: 'Anotar en su cuaderno',
+    frase: '«Hola Chagra, anota que fumigué el lote 2 con caldo bordelés»',
+    resultado: 'Queda escrito en su cuaderno de campo, sin sacarse los guantes.',
+  },
+  {
+    emoji: '🌱',
+    capacidad: 'Pedir un consejo',
+    frase: '«Hola Chagra, ¿por qué se me está amarillando el café?»',
+    resultado: 'El agente le responde hablado, con lo que sabe de su finca.',
+  },
+  {
+    emoji: '💰',
+    capacidad: 'Preguntar un dato en vivo',
+    frase: '«Hola Chagra, ¿a cómo está el aguacate esta semana?»',
+    resultado: 'Le trae el precio del día y se lo dice de una.',
+  },
+];
+
+const ROTACION_MS = 4000;
+
+/** ¿El usuario pidió movimiento reducido a nivel de sistema? */
+const prefiereMenosMovimiento = () =>
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : false;
+
+/** Onda de voz decorativa: 9 barras que laten (CSS puro, sin datos falsos de
+ *  micrófono — es ilustración, y con reduced-motion queda quieta). */
+function OndaVoz() {
+  return (
+    <div className="ejemplos-voz-onda" aria-hidden="true">
+      {Array.from({ length: 9 }, (_, i) => (
+        <span key={i} className="ejemplos-voz-barra" style={{ '--i': i }} />
+      ))}
+    </div>
+  );
+}
+
+function Ejemplo({ ejemplo }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="text-2xl leading-none mt-0.5 shrink-0" aria-hidden="true">{ejemplo.emoji}</span>
+      <div className="min-w-0">
+        <p className="text-[10px] font-bold uppercase tracking-wider text-emerald-400/90 mb-0.5">
+          {ejemplo.capacidad}
+        </p>
+        <p className="text-[13px] text-slate-200 font-medium leading-snug">{ejemplo.frase}</p>
+        <p className="text-[11px] text-slate-500 leading-snug mt-1">→ {ejemplo.resultado}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function EjemplosVoz() {
+  // Se lee UNA vez al montar: si el usuario cambia la preferencia del sistema
+  // con el panel abierto, el próximo montaje la recoge (suficiente acá).
+  const [sinMovimiento] = useState(prefiereMenosMovimiento);
+  const [idx, setIdx] = useState(0);
+
+  useEffect(() => {
+    if (sinMovimiento) return undefined;
+    const timer = setInterval(() => {
+      setIdx((i) => (i + 1) % EJEMPLOS_VOZ.length);
+    }, ROTACION_MS);
+    return () => clearInterval(timer);
+  }, [sinMovimiento]);
+
+  return (
+    <div
+      className="ejemplos-voz rounded-xl border border-slate-700/50 bg-slate-800/40 p-4 space-y-3"
+      data-testid="ejemplos-voz"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h4 className="text-[13px] font-bold text-slate-200">
+          Háblele con las manos ocupadas
+        </h4>
+        <OndaVoz />
+      </div>
+
+      {sinMovimiento ? (
+        <div className="space-y-3" data-testid="ejemplos-voz-lista">
+          {EJEMPLOS_VOZ.map((e) => <Ejemplo key={e.capacidad} ejemplo={e} />)}
+        </div>
+      ) : (
+        <>
+          {/* key={idx} remonta el nodo → la animación de entrada corre en cada
+              rotación. min-height evita brincos entre frases de largo distinto. */}
+          <div className="ejemplos-voz-escena" aria-live="off">
+            <div className="ejemplos-voz-paso" key={idx} data-testid="ejemplos-voz-activo">
+              <Ejemplo ejemplo={EJEMPLOS_VOZ[idx]} />
+            </div>
+          </div>
+          <div className="flex justify-center gap-1.5" aria-hidden="true">
+            {EJEMPLOS_VOZ.map((e, i) => (
+              <span
+                key={e.capacidad}
+                className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
+                  i === idx ? 'bg-emerald-400' : 'bg-slate-600'
+                }`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      <p
+        className="text-[11px] text-slate-500 leading-relaxed border-t border-slate-700/50 pt-2.5"
+        data-testid="ejemplos-voz-guia"
+      >
+        Diga <strong className="text-slate-400">«hola chagra»</strong> y hable. La primera vez,
+        enséñele su voz (1 minuto).
+      </p>
+    </div>
+  );
+}

--- a/src/components/modoCampo/EjemplosVoz.jsx
+++ b/src/components/modoCampo/EjemplosVoz.jsx
@@ -2,17 +2,23 @@
  * EjemplosVoz — tarjeta "qué puedo decirle" del modo campo (wake-word
  * «hola chagra»). Vive dentro de ModoCampoPanel (Perfil → voz).
  *
- * Muestra 3 ejemplos REALES y bien diferenciados de lo que se puede hacer
- * por voz — registrar en el cuaderno, pedir consejo hablado, preguntar un
- * dato en vivo — rotando uno cada ~4s con una onda de voz sutil que late.
+ * Coreografía en dos actos (la tarjeta "cobra vida" al abrirse):
+ *
+ *   1. ENTRADA — al montar, los 3 ejemplos IRRUMPEN en cascada (stagger):
+ *      cada uno se desliza desde la derecha con un pequeño rebote, uno tras
+ *      otro. Se quedan un momento para leerse completos.
+ *   2. CARRUSEL — los dos de abajo se despiden con gracia y el primero se
+ *      queda al mando; desde ahí rota UN ejemplo cada ~4s con la onda de voz
+ *      sutil que late (el comportamiento de siempre).
  *
  * Honestidad del copy: NO promete "IA en su teléfono". El reconocimiento
  * del wake-word sí es on-device, pero el agente necesita señal para
  * responder — por eso el encabezado vende el gesto ("con las manos
  * ocupadas"), no una capacidad que no existe.
  *
- * Accesibilidad: respeta prefers-reduced-motion — sin animación, los 3
- * ejemplos se muestran quietos en lista (misma información, cero vaivén).
+ * Accesibilidad: respeta prefers-reduced-motion — sin coreografía ni
+ * rotación, los 3 ejemplos se muestran quietos en lista (misma información,
+ * cero vaivén).
  *
  * Solo UI/copy: cero lógica de wake-word, cero deps nuevas (emoji + CSS).
  * Español colombiano (tú/usted), NUNCA voseo argentino.
@@ -44,6 +50,11 @@ export const EJEMPLOS_VOZ = [
 ];
 
 const ROTACION_MS = 4000;
+/* Coreografía de entrada: cuánto se quedan los 3 en pantalla (da tiempo de
+ * leerlos tras la cascada) y cuánto dura la despedida de los dos de abajo.
+ * Los tests avanzan el reloj con estos números — si cambian, cambiarlos allá. */
+const ENTRADA_HOLD_MS = 4600;
+const ENTRADA_SALIDA_MS = 450;
 
 /** ¿El usuario pidió movimiento reducido a nivel de sistema? */
 const prefiereMenosMovimiento = () =>
@@ -82,15 +93,31 @@ export default function EjemplosVoz() {
   // Se lee UNA vez al montar: si el usuario cambia la preferencia del sistema
   // con el panel abierto, el próximo montaje la recoge (suficiente acá).
   const [sinMovimiento] = useState(prefiereMenosMovimiento);
+  // Actos: 'entrada' (los 3 en cascada) → 'saliendo' (despedida de 2 y 3)
+  // → 'carrusel' (rotación de siempre). Con reduced-motion no hay actos.
+  const [acto, setActo] = useState('entrada');
   const [idx, setIdx] = useState(0);
+  // El carrusel arranca mostrando el MISMO primer ejemplo que quedó de la
+  // entrada: esa primera pintura no debe re-animar (leería como glitch).
+  const [yaRoto, setYaRoto] = useState(false);
 
   useEffect(() => {
-    if (sinMovimiento) return undefined;
+    if (sinMovimiento || acto === 'carrusel') return undefined;
+    const timer = setTimeout(
+      () => setActo(acto === 'entrada' ? 'saliendo' : 'carrusel'),
+      acto === 'entrada' ? ENTRADA_HOLD_MS : ENTRADA_SALIDA_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [sinMovimiento, acto]);
+
+  useEffect(() => {
+    if (sinMovimiento || acto !== 'carrusel') return undefined;
     const timer = setInterval(() => {
+      setYaRoto(true);
       setIdx((i) => (i + 1) % EJEMPLOS_VOZ.length);
     }, ROTACION_MS);
     return () => clearInterval(timer);
-  }, [sinMovimiento]);
+  }, [sinMovimiento, acto]);
 
   return (
     <div
@@ -108,12 +135,32 @@ export default function EjemplosVoz() {
         <div className="space-y-3" data-testid="ejemplos-voz-lista">
           {EJEMPLOS_VOZ.map((e) => <Ejemplo key={e.capacidad} ejemplo={e} />)}
         </div>
+      ) : acto !== 'carrusel' ? (
+        /* Acto 1: los 3 ejemplos irrumpen en cascada al abrir el panel.
+           En 'saliendo', los dos de abajo se despiden y el alto colapsa
+           suave hacia la escena del carrusel (una sola vez, no es loop). */
+        <div
+          className={`ejemplos-voz-entrada${acto === 'saliendo' ? ' ejemplos-voz-entrada-saliendo' : ''}`}
+          data-testid="ejemplos-voz-entrada"
+          aria-live="off"
+        >
+          {EJEMPLOS_VOZ.map((e, i) => (
+            <div key={e.capacidad} className="ejemplos-voz-entrada-item" style={{ '--i': i }}>
+              <Ejemplo ejemplo={e} />
+            </div>
+          ))}
+        </div>
       ) : (
         <>
           {/* key={idx} remonta el nodo → la animación de entrada corre en cada
-              rotación. min-height evita brincos entre frases de largo distinto. */}
+              rotación (menos en la primera pintura, que hereda el ejemplo que
+              dejó la cascada). min-height evita brincos entre frases. */}
           <div className="ejemplos-voz-escena" aria-live="off">
-            <div className="ejemplos-voz-paso" key={idx} data-testid="ejemplos-voz-activo">
+            <div
+              className={`ejemplos-voz-paso${yaRoto ? ' ejemplos-voz-paso-anima' : ''}`}
+              key={idx}
+              data-testid="ejemplos-voz-activo"
+            >
               <Ejemplo ejemplo={EJEMPLOS_VOZ[idx]} />
             </div>
           </div>

--- a/src/components/modoCampo/ModoCampoPanel.jsx
+++ b/src/components/modoCampo/ModoCampoPanel.jsx
@@ -18,6 +18,7 @@ import { Radio, Mic, BatteryWarning, GraduationCap } from 'lucide-react';
 import { useModoCampoContext } from '../../hooks/ModoCampoContext';
 import { hasPersonalVoiceMarker, forgetPersonalVoice } from '../../services/wakeWordService';
 import EnrollmentModoCampo from './EnrollmentModoCampo';
+import EjemplosVoz from './EjemplosVoz';
 import { MSG } from '../../config/messages';
 
 const CONSENT_KEY = 'chagra:modoCampo:consentimiento';
@@ -89,6 +90,8 @@ export default function ModoCampoPanel() {
         EN su celular — nunca sale audio a internet. La pantalla se queda encendida mientras esté
         activo.
       </p>
+
+      <EjemplosVoz />
 
       <button
         type="button"

--- a/src/components/modoCampo/__tests__/EjemplosVoz.test.jsx
+++ b/src/components/modoCampo/__tests__/EjemplosVoz.test.jsx
@@ -1,7 +1,8 @@
 /**
  * Tests de EjemplosVoz — la tarjeta de ejemplos del modo campo:
  *  - encabezado honesto + micro-guía siempre visibles
- *  - con movimiento normal: muestra UN ejemplo y ROTA cada ~4s
+ *  - con movimiento normal: al ABRIR los 3 ejemplos entran en cascada
+ *    (acto de entrada), luego colapsa a UN ejemplo que ROTA cada ~4s
  *  - con prefers-reduced-motion: lista estática con los 3 ejemplos, sin timer
  *
  * Español colombiano (tú/usted), NUNCA voseo argentino.
@@ -48,10 +49,30 @@ describe('EjemplosVoz', () => {
     expect(screen.getByTestId('ejemplos-voz-guia').textContent).toContain('enséñele su voz');
   });
 
-  it('con movimiento normal muestra un ejemplo a la vez y rota cada ~4s', () => {
+  it('al abrir, los 3 ejemplos entran en cascada (acto de entrada)', () => {
     mockMatchMedia(false);
     render(<EjemplosVoz />);
-    // Arranca en el primero.
+    // Acto 1: cascada con los 3 ejemplos visibles a la vez.
+    expect(screen.getByTestId('ejemplos-voz-entrada')).toBeInTheDocument();
+    EJEMPLOS_VOZ.forEach((e) => {
+      expect(screen.getByText(e.frase)).toBeInTheDocument();
+    });
+    // El stagger va por CSS (animation-delay con --i): cada item lo declara.
+    const items = screen.getByTestId('ejemplos-voz-entrada').querySelectorAll('.ejemplos-voz-entrada-item');
+    expect(items).toHaveLength(3);
+    // Todavía no hay carrusel montado.
+    expect(screen.queryByTestId('ejemplos-voz-activo')).not.toBeInTheDocument();
+  });
+
+  it('tras la entrada colapsa a un ejemplo a la vez y rota cada ~4s', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    // Deja pasar la coreografía de entrada en dos pasos — hold (~4.6s) y
+    // salida (~0.45s) — porque el segundo timer se agenda en el re-render.
+    act(() => { vi.advanceTimersByTime(4700); });
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(screen.queryByTestId('ejemplos-voz-entrada')).not.toBeInTheDocument();
+    // El carrusel arranca en el primero (el que dejó la cascada).
     expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[0].frase);
     expect(screen.queryByText(EJEMPLOS_VOZ[1].frase)).not.toBeInTheDocument();
     // Tras ~4s pasa al segundo.

--- a/src/components/modoCampo/__tests__/EjemplosVoz.test.jsx
+++ b/src/components/modoCampo/__tests__/EjemplosVoz.test.jsx
@@ -1,0 +1,82 @@
+/**
+ * Tests de EjemplosVoz — la tarjeta de ejemplos del modo campo:
+ *  - encabezado honesto + micro-guía siempre visibles
+ *  - con movimiento normal: muestra UN ejemplo y ROTA cada ~4s
+ *  - con prefers-reduced-motion: lista estática con los 3 ejemplos, sin timer
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import EjemplosVoz, { EJEMPLOS_VOZ } from '../EjemplosVoz.jsx';
+
+const mockMatchMedia = (reduce) => {
+  // Cast local: el stub solo trae lo que EjemplosVoz consulta (.matches);
+  // tipar MediaQueryList completo acá no aporta nada al test (mismo patrón
+  // de casts locales que modoCampoFlag.js frente al gate de tsc:check).
+  window.matchMedia = /** @type {any} */ (vi.fn(() => ({
+    matches: reduce,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })));
+};
+
+describe('EjemplosVoz', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('define exactamente 3 ejemplos, cada uno con capacidad distinta', () => {
+    expect(EJEMPLOS_VOZ).toHaveLength(3);
+    const capacidades = EJEMPLOS_VOZ.map((e) => e.capacidad);
+    expect(new Set(capacidades).size).toBe(3);
+    // Cada frase arranca con el wake-word real.
+    EJEMPLOS_VOZ.forEach((e) => {
+      expect(e.frase.toLowerCase()).toContain('hola chagra');
+    });
+  });
+
+  it('muestra encabezado honesto y micro-guía', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    expect(screen.getByText('Háblele con las manos ocupadas')).toBeInTheDocument();
+    expect(screen.getByTestId('ejemplos-voz-guia').textContent).toContain('«hola chagra»');
+    expect(screen.getByTestId('ejemplos-voz-guia').textContent).toContain('enséñele su voz');
+  });
+
+  it('con movimiento normal muestra un ejemplo a la vez y rota cada ~4s', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    // Arranca en el primero.
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[0].frase);
+    expect(screen.queryByText(EJEMPLOS_VOZ[1].frase)).not.toBeInTheDocument();
+    // Tras ~4s pasa al segundo.
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[1].frase);
+    // Y da la vuelta completa (tercero → primero).
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[2].frase);
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[0].frase);
+  });
+
+  it('con prefers-reduced-motion lista los 3 ejemplos estáticos, sin rotar', () => {
+    mockMatchMedia(true);
+    render(<EjemplosVoz />);
+    expect(screen.getByTestId('ejemplos-voz-lista')).toBeInTheDocument();
+    EJEMPLOS_VOZ.forEach((e) => {
+      expect(screen.getByText(e.frase)).toBeInTheDocument();
+    });
+    // No hay carrusel montado.
+    expect(screen.queryByTestId('ejemplos-voz-activo')).not.toBeInTheDocument();
+    // Y avanzar el reloj no cambia nada (no hay interval vivo).
+    act(() => { vi.advanceTimersByTime(9000); });
+    EJEMPLOS_VOZ.forEach((e) => {
+      expect(screen.getByText(e.frase)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/modoCampo/ejemplosVoz.css
+++ b/src/components/modoCampo/ejemplosVoz.css
@@ -1,10 +1,15 @@
 /* ============================================================================
  * ejemplosVoz.css — tarjeta de ejemplos del modo campo («hola chagra»).
  *
- * Solo lo que Tailwind no da: la onda de voz que late y la transición de
- * entrada del ejemplo que rota. Acento vía --t-accent-rgb (themes.css) con
- * fallback al esmeralda del panel — indirección CSS-var, nunca color duro
- * por tema.
+ * Solo lo que Tailwind no da: la coreografía de entrada (los 3 ejemplos
+ * irrumpen en cascada al abrir el panel), la onda de voz que late y la
+ * transición del ejemplo que rota. Acento vía --t-accent-rgb (themes.css)
+ * con fallback al esmeralda del panel — indirección CSS-var, nunca color
+ * duro por tema.
+ *
+ * Presupuesto de movimiento: transform + opacity en todo lo que se repite
+ * (GPU, cero layout thrash). La única animación de alto (el colapso de la
+ * cascada al carrusel) corre UNA vez al abrir, sobre ~200px, y listo.
  * ========================================================================== */
 
 /* --- Onda de voz: 9 barras que laten desfasadas (decorativa) -------------- */
@@ -30,7 +35,49 @@
   50%      { transform: scaleY(1);    opacity: 1; }
 }
 
-/* --- Escena del ejemplo que rota ------------------------------------------ */
+/* --- Acto 1: la cascada de entrada -----------------------------------------
+ * Al montar, cada ejemplo IRRUMPE desde la derecha con un pequeño rebote
+ * (overshoot del cubic-bezier), uno tras otro (--i escala el delay). La
+ * tarjeta se siente viva desde el primer instante, no esperando su turno. */
+.ejemplos-voz-entrada {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow: hidden;
+  max-height: 320px;
+}
+.ejemplos-voz-entrada-item {
+  animation: ejemplos-voz-irrumpe 0.6s cubic-bezier(0.34, 1.45, 0.64, 1) both;
+  animation-delay: calc(0.12s + var(--i) * 0.22s);
+}
+@keyframes ejemplos-voz-irrumpe {
+  from { opacity: 0; transform: translateX(32px) scale(0.94); }
+  to   { opacity: 1; transform: translateX(0) scale(1); }
+}
+
+/* Despedida: los ejemplos 2 y 3 se van (abajo→arriba en orden inverso) y el
+ * alto colapsa hacia la escena del carrusel. El primero se queda quieto: es
+ * el mismo que el carrusel muestra al arrancar — continuidad sin brincos.
+ * El colapso anima max-height (layout) pero corre UNA sola vez al abrir. */
+.ejemplos-voz-entrada-saliendo {
+  animation: ejemplos-voz-colapsa 0.45s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+.ejemplos-voz-entrada-saliendo .ejemplos-voz-entrada-item {
+  animation: ejemplos-voz-sale 0.32s ease-in both;
+  animation-delay: calc((2 - var(--i)) * 0.07s);
+}
+.ejemplos-voz-entrada-saliendo .ejemplos-voz-entrada-item:first-child {
+  animation: none;
+}
+@keyframes ejemplos-voz-sale {
+  to { opacity: 0; transform: translateY(-12px) scale(0.97); }
+}
+@keyframes ejemplos-voz-colapsa {
+  from { max-height: 320px; }
+  to   { max-height: 86px; }
+}
+
+/* --- Acto 2: escena del ejemplo que rota ----------------------------------- */
 /* min-height reserva el espacio de la frase más larga en dos líneas:
  * sin brincos de layout cuando cambia el ejemplo. */
 .ejemplos-voz-escena {
@@ -40,6 +87,8 @@
 }
 .ejemplos-voz-paso {
   width: 100%;
+}
+.ejemplos-voz-paso-anima {
   animation: ejemplos-voz-entra 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 @keyframes ejemplos-voz-entra {
@@ -52,5 +101,8 @@
  * de que la preferencia cambie con el panel ya montado: todo quieto. */
 @media (prefers-reduced-motion: reduce) {
   .ejemplos-voz-barra { animation: none; opacity: 0.8; }
-  .ejemplos-voz-paso { animation: none; }
+  .ejemplos-voz-paso-anima { animation: none; }
+  .ejemplos-voz-entrada,
+  .ejemplos-voz-entrada-item,
+  .ejemplos-voz-entrada-saliendo .ejemplos-voz-entrada-item { animation: none; }
 }

--- a/src/components/modoCampo/ejemplosVoz.css
+++ b/src/components/modoCampo/ejemplosVoz.css
@@ -1,0 +1,56 @@
+/* ============================================================================
+ * ejemplosVoz.css — tarjeta de ejemplos del modo campo («hola chagra»).
+ *
+ * Solo lo que Tailwind no da: la onda de voz que late y la transición de
+ * entrada del ejemplo que rota. Acento vía --t-accent-rgb (themes.css) con
+ * fallback al esmeralda del panel — indirección CSS-var, nunca color duro
+ * por tema.
+ * ========================================================================== */
+
+/* --- Onda de voz: 9 barras que laten desfasadas (decorativa) -------------- */
+.ejemplos-voz-onda {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 22px;
+  flex-shrink: 0;
+}
+.ejemplos-voz-barra {
+  width: 3px;
+  border-radius: 2px;
+  background: rgba(var(--t-accent-rgb, 52, 211, 153), 0.85);
+  /* Altura base variada (perfil de onda) + latido escalado por barra. */
+  height: calc(6px + (var(--i) - 4) * (var(--i) - 4) * -0.8px + 14px);
+  transform-origin: center;
+  animation: ejemplos-voz-late 1.5s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 0.13s);
+}
+@keyframes ejemplos-voz-late {
+  0%, 100% { transform: scaleY(0.45); opacity: 0.55; }
+  50%      { transform: scaleY(1);    opacity: 1; }
+}
+
+/* --- Escena del ejemplo que rota ------------------------------------------ */
+/* min-height reserva el espacio de la frase más larga en dos líneas:
+ * sin brincos de layout cuando cambia el ejemplo. */
+.ejemplos-voz-escena {
+  min-height: 86px;
+  display: flex;
+  align-items: flex-start;
+}
+.ejemplos-voz-paso {
+  width: 100%;
+  animation: ejemplos-voz-entra 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes ejemplos-voz-entra {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* --- Movimiento reducido ---------------------------------------------------
+ * El JSX ya cambia a lista estática (matchMedia); esto cubre además el caso
+ * de que la preferencia cambie con el panel ya montado: todo quieto. */
+@media (prefers-reduced-motion: reduce) {
+  .ejemplos-voz-barra { animation: none; opacity: 0.8; }
+  .ejemplos-voz-paso { animation: none; }
+}


### PR DESCRIPTION
> Stacked sobre #2158 (`feat/modo-campo-ejemplos-voz`). Solo capa visual — cero lógica de wake-word/escucha tocada.

## 1. Los ejemplos cobran vida al abrir

Al montar la tarjeta (Perfil → Mi agente), los 3 ejemplos **irrumpen en cascada** (stagger con rebote, uno tras otro desde la derecha), se dejan leer ~4.6s, y los dos de abajo se despiden con gracia hacia el carrusel de siempre (1 ejemplo cada ~4s). El colapso de alto corre UNA sola vez al abrir.

## 2. Iris/botón de escucha "IA de verdad"

- **Aurora**: gradiente bicolor que gira lento detrás del iris y **se enciende con la voz** (`--nivel` = RMS real del micrófono vía CSS var — nada de animación fingida).
- **Halo cónico**: un filo de luz que orbita el borde; en *pensando* acelera.
- **Esporas**: 14 micro-partículas en dos órbitas contrarrotantes (posiciones deterministas por ángulo áureo); la voz les sube la opacidad.
- **Glow central** reactivo detrás de la mano.
- **Pensando**: dos arcos contrarrotantes (verde + cian) + barrido de luz (shimmer) sobre el disco de la mano.
- **FAB en reposo** (hoy dark en App): aurora que respira + filo de luz orbital + doble ping desfasado.

Segundo tono por tema vía token `--esc-linea2-rgb` (cian biopunk / azul minimalista / ámbar nature / lima verde-vivo).

## Presupuesto técnico

- CSS/SVG puro: solo `transform`/`opacity` en loops (GPU, cero layout thrash), sin `filter: blur` animado, **cero deps npm nuevas, cero fotos**.
- `prefers-reduced-motion`: ejemplos en lista estática sin coreografía; iris con halo/aro estáticos legibles, shimmer y órbitas apagados.
- Tests: 13/13 verdes (EjemplosVoz 5 — 2 nuevos de la cascada — + EscuchaOverlay 8). Build Vite verde. `tsc:check` = 1829 errores (== baseline, cero nuevos). ESLint 0 errores (3 warnings i18n pre-existentes de la base).

## Capturas (biopunk, 390×844)

| Estado | Qué se ve |
|---|---|
| Reposo (FAB) | disco con aurora respirando + filo orbital + pings |
| Escuchando | aurora encendida, halo orbitando, esporas, anillos con RMS real |
| Pensando | arcos contrarrotantes verde/cian + shimmer sobre la mano |
| Ejemplos entrando | cascada a mitad de stagger (1º puesto, 2º en el aire, 3º asomando) |

(Las capturas van al hilo de Telegram del operador para aprobación visual — pendiente OK visual antes de merge, política de visuales.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)