### PR TITLE
feat(ops): canario nocturno extensible (health + inteligencia auto-mejorante)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ chagra-anthropic-judge-key
 # RESULTADO del entrenamiento (public/models/hola-chagra/{examples.bin,
 # metadata.json}) SÍ se commitea — es lo que se shippea.
 /scripts/wake-word/samples/
+
+# Canario nocturno: reportes y datasets (ruta estable = ~/chagra-canary-runs; nunca commitear)
+/data/canary-runs/
+/data/distill-dataset/

--- a/ops/CANARY_NOCTURNO.md
+++ b/ops/CANARY_NOCTURNO.md
@@ -1,0 +1,126 @@
+# Canario nocturno de Chagra
+
+Test de salud **durable** que corre todas las noches (1 AM hora Colombia) contra
+**DEV** y **PROD** y prueba, de punta a punta, que Chagra no está roto — más una
+capa de **cosecha de inteligencia** (dataset de destilado + gaps del grafo) que
+alimenta la mejora continua del agente. Usa un usuario de pruebas dedicado, nunca
+toca los datos reales de la finca.
+
+> Framework extensible: cada check y cada cosecha es un **módulo pluggable**
+> registrado en `scripts/lib/canary-modules.mjs`. La hoja de ruta completa de
+> módulos (ejes A/B/C/D, fases P0/P1/P2) vive en el doc de operación
+> `NIGHTLY_SYSTEM.md`. Agregar un módulo nuevo = escribir su `run()` en el
+> registro; el runner lo corre solo.
+
+## Qué prueba (módulos P0 activos)
+
+| id | Módulo | Qué verifica |
+|----|--------|--------------|
+| `login` | Login OAuth | El usuario de pruebas autentica contra el target. |
+| `B0` | Conversación dinámica 4-msgs | Un tema duro que **rota por fecha** (roya del café, gota de papa, monilia del cacao, sigatoka, picudo, …). Conversación compleja: pregunta → repregunta con matiz → caso de borde → pedir fuente. Pasa por el pipeline real (NLU + resolve-entities + chat grounded + post-validate). |
+| `B0g` | Grounding | Juez `claude-code -p` evalúa cada respuesta buscando alucinación, contaminación cruzada, familias fabricadas e instituciones inventadas. |
+| `B0b` | Planta con foto | Registra una planta de prueba **con foto** bajo una ubicación dedicada `CANARIO-PRUEBAS` (aislada de la finca real) y verifica que persiste. **No borra**: se acumula, filtrable por el prefijo `CANARIO`. |
+| `B0c` | Captura de conversación | Verifica que la conversación quedó **registrada** en el store del sidecar (cuenta líneas antes/después). Si no incrementa → falla (bug de captura). |
+| `B0d` | Smoke visual | Playwright con backend real: login → home monta → navega pantallas clave → **cero errores de consola** → screenshot de cada una. |
+| `D1`–`D5` | Datos dinámicos | Salud diaria de las integraciones en vivo: **Clima IDEAM** (fresco, no stale), **Precio SIPSA** (real y reciente), **ENSO** (fase actual), **Calendario de siembra**, **Sidecar/agente** (`/health`, tools, kokoro TTS, ollama/granite). |
+| `A1` | Dataset de destilado | Guarda cada tupla del juez (`{tema, pregunta, respuesta_granite, veredicto_juez, grounded, tipo_error}`) a JSONL — insumo para un futuro LoRA de granite. Solo **acumula**; datos sintéticos (usuario de pruebas), sin PII. |
+| `A2` | Gaps de grounding → DR | Cuando el sujeto del tema **no resolvió en el grafo** (falta la especie/arista, no que alucinó), anota el hueco a JSONL para alimentar la cola de DR/scrapers. |
+
+Los módulos P1/P2 (SLA, latencia, integridad, seguridad/anti-leak, cobertura de
+debilidad, re-bench de guards, resiliencia offline, FAQ precomputada, golden
+corpus, …) están **registrados como stubs** con su firma lista y un TODO claro.
+
+Ver el registro completo:
+
+```bash
+node scripts/nightly-canary.mjs --list
+```
+
+## Cómo correrlo a mano
+
+```bash
+# Contra dev (recomendado para probar cambios):
+node scripts/nightly-canary.mjs --target=dev
+
+# Contra prod:
+node scripts/nightly-canary.mjs --target=prod
+
+# Sin alerta de Telegram (para no molestar al operador de madrugada):
+node scripts/nightly-canary.mjs --target=dev --no-alert
+
+# Solo algunos módulos / saltar otros:
+node scripts/nightly-canary.mjs --target=dev --only=D1,D2,D3,D4,D5
+node scripts/nightly-canary.mjs --target=dev --skip-visual --skip-plant
+
+# Incluir fases P1/P2 (cuando se implementen sus run()):
+node scripts/nightly-canary.mjs --target=dev --phases=P0,P1
+```
+
+Exit code `!= 0` si algún check falla.
+
+### Requisitos (host de operación)
+
+- Credenciales del usuario de pruebas en un archivo gitignored fuera del repo
+  (`CANARY_CREDS_FILE`, formato `usuario=…` / `clave=…` / `farmos=…`). **Nunca**
+  en git ni en logs.
+- Token del sidecar (`CANARY_SIDECAR_TOKEN_FILE`).
+- Node ≥ 20 y `playwright` instalado (para el smoke visual; usa el chromium del
+  sistema vía `PLAYWRIGHT_CHROMIUM_PATH`).
+- Para la verificación de captura **en disco**: `CANARY_CONV_COUNT_CMD`, un
+  comando que imprime el número de líneas del store de conversaciones del
+  sidecar. Si no se define, el check se degrada a "el endpoint aceptó el POST".
+
+## Cómo ver el último reporte
+
+Los reportes se guardan en una ruta **estable** (fuera de cualquier worktree
+efímero), configurable con `CANARY_OUT_DIR` (default `~/chagra-canary-runs`):
+
+```bash
+OUT=${CANARY_OUT_DIR:-~/chagra-canary-runs}
+ls -t "$OUT"/canary-*.json | head            # reportes JSON
+cat "$OUT/canary-$(date -u +%F)-dev.md"      # reporte Markdown de hoy (dev)
+ls "$OUT/shots/"                             # screenshots del smoke visual
+```
+
+Cosecha de inteligencia:
+
+```bash
+OUT=${CANARY_OUT_DIR:-~/chagra-canary-runs}
+ls "$OUT/distill-dataset/"                   # dataset de destilado (→ LoRA)
+cat "$OUT"/grounding-gaps-*.jsonl            # gaps del grafo (→ cola DR)
+```
+
+## Automatización (systemd `--user`, en el host de operación)
+
+Tres timers durables (sobreviven a la sesión; el host corre en UTC):
+
+| Timer | Hora | Qué hace |
+|-------|------|----------|
+| `chagra-canary.timer` | 1 AM Colombia (06:00 UTC) | Corre el canario contra dev y prod. Si algo falla, dispara un fix autónomo. |
+| `chagra-canary-report.timer` | 9 AM Colombia (14:00 UTC) | Manda el digest de la noche por Telegram. |
+| `chagra-canary-weekly.timer` | Domingos 8 AM Colombia (13:00 UTC) | Auditoría profunda semanal con un juez más capaz. |
+
+```bash
+systemctl --user list-timers | grep canary
+systemctl --user start chagra-canary.service   # correr la corrida completa a mano
+journalctl --user -u chagra-canary.service -n 100
+```
+
+**Alerta inmediata:** ante *cualquier* fallo, el runner envía una alerta a
+Telegram al instante (además del digest de las 9 AM).
+
+**Fix autónomo:** si un check no-visual falla y el fix pasa CI verde + anti-leak,
+se auto-mergea a prod; los fallos **visuales** esperan OK del operador; los
+**gaps de grafo** se encolan como DR (enriquecer el grafo, no tocar código).
+
+## Datos de prueba: aislamiento y limpieza
+
+- Todo lo que el canario crea en farmOS va bajo la ubicación dedicada
+  **`CANARIO-PRUEBAS`** (`asset--land`) y lleva el prefijo **`CANARIO`** en el
+  nombre. El usuario de pruebas es el dueño. **No se mezcla** con la finca real.
+- Los datos **no se auto-borran** — se acumulan bajo esa ubicación (decisión del
+  operador: "aparte", no "auto-limpiar"). Para inspeccionarlos o depurarlos
+  manualmente, filtra por el prefijo `CANARIO` / la ubicación `CANARIO-PRUEBAS`
+  en farmOS.
+- El dataset de destilado y los gaps son **sintéticos** (usuario de pruebas), sin
+  datos personales de usuarios reales → seguros para acumular y para entrenar.

--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -27,10 +27,7 @@
 import { join, dirname } from 'node:path';
 import { mkdirSync, appendFileSync, existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
-import {
-  judgeContaminationBatch,
-  makeContaminationJudgeCall,
-} from './bench-scorer.mjs';
+import { spawnClaudeCode } from './bench-scorer.mjs';
 import { buildEnrichedSystemPrompt } from './bench-sidecar.mjs';
 
 // ── helpers compartidos ───────────────────────────────────────────────────────
@@ -210,33 +207,145 @@ async function runConversacion(ctx) {
   return { status, valor: `${turnOk}/${conversation.length} respuestas`, detalle: `Conversación compleja sobre ${topic.id} (${turnOk}/${conversation.length} turnos con respuesta).`, data: { topic: topic.id } };
 }
 
-/** B0g — grounding: juez claude-code -p (contaminación/alucinación). Llena ctx.verdicts. */
+/**
+ * gatherGraphEvidence — junta EVIDENCIA GROUNDED del grafo/catálogo para el tema
+ * (hechos canónicos + entidades resueltas + facts de tools del sidecar). Esta
+ * evidencia es la que usa el juez para escribir la `respuesta_corregida` sin
+ * inventar. Todo degrada graceful (si una tool cae, se omite).
+ */
+async function gatherGraphEvidence(ctx) {
+  const { base, sidecarToken, topic, responses = [] } = ctx;
+  const parts = [];
+  parts.push(`HECHOS CANÓNICOS DEL TEMA: ${topic.problema} = ${topic.tipo}; agente causal = ${topic.patogeno}; cultivo hospedante = ${topic.cultivo} (${topic.cientifico}); piso térmico típico = ${topic.piso}; fuente autoritativa = ${topic.fuente}.`);
+
+  const resolved = [...new Set(responses.flatMap((r) => r.entities_grounded || []))].slice(0, 25);
+  if (resolved.length) parts.push(`ENTIDADES RESUELTAS EN EL GRAFO (canónicas): ${resolved.join(' · ')}`);
+
+  // Facts de tools del sidecar (grafo AGE) — best-effort, se recorta cada payload.
+  const probes = [
+    ['get_species', { id_or_name: topic.cientifico }],
+    ['get_pest_controllers', { id_or_name: topic.patogeno }],
+    ['get_biopreparados', { id_or_name: topic.patogeno }],
+  ];
+  for (const [name, args] of probes) {
+    try {
+      const r = await callTool(base, sidecarToken, name, args, 20000);
+      if (r.ok && r.json && JSON.stringify(r.json) !== '{}' && r.json.available !== false && !r.json.error) {
+        parts.push(`GRAFO ${name}: ${clip(JSON.stringify(r.json), 700)}`);
+      }
+    } catch (_) { /* omitir */ }
+  }
+  return parts.join('\n');
+}
+
+/** buildCorrectionBatchPrompt — prompt del juez que evalúa Y CORRIGE (grounded). */
+export function buildCorrectionBatchPrompt(items, evidence) {
+  const itemsText = items.map((it, i) => [
+    `### ITEM ${i + 1} — id: "${it.id}"`,
+    `TIPO DE PREGUNTA: ${it.probeType}`,
+    `PREGUNTA DEL USUARIO: ${it.query}`,
+    `RESPUESTA DE GRANITE (a evaluar): ${it.response}`,
+    it.entidades ? `ENTIDADES QUE RESOLVIÓ ESTE TURNO: ${it.entidades}` : '',
+  ].filter(Boolean).join('\n')).join('\n\n');
+
+  return [
+    'Eres un AUDITOR EXPERTO en agroecología colombiana y, a la vez, un MAESTRO que',
+    'corrige. Para CADA item: (1) evalúa si la respuesta de granite está contaminada',
+    '(mezcla info de otra plaga/enfermedad, miscategoriza plaga↔enfermedad, confunde',
+    'la especie, recomienda plantas/insumos de otro piso térmico, o inventa',
+    'fuentes/instituciones/familias); y (2) ESCRIBE la respuesta CORRECTA y grounded.',
+    '',
+    'REGLA DE ORO PARA LA CORRECCIÓN: básate ESTRICTAMENTE en la EVIDENCIA DEL GRAFO/',
+    'CATÁLOGO de abajo + conocimiento agronómico establecido para Colombia. NO inventes',
+    'entidades, familias, dosis peligrosas ni fuentes. Si la EVIDENCIA NO ALCANZA para',
+    'responder con seguridad, pon "is_gap": true y deja `respuesta_corregida` con lo',
+    'que sí se pueda afirmar (o vacío) — ese gap alimenta la cola de enriquecimiento.',
+    '',
+    '═══════ EVIDENCIA DEL GRAFO/CATÁLOGO (canónica, NO inventar más allá de esto) ═══════',
+    evidence || '(sin evidencia adicional; usa solo los hechos canónicos del tema)',
+    '',
+    '═══════ ITEMS A EVALUAR Y CORREGIR ═══════',
+    itemsText,
+    '',
+    'Devuelve ÚNICAMENTE un array JSON (sin prosa antes ni después), un objeto por item,',
+    'en el MISMO orden. Cada `respuesta_corregida` debe ser una SOLA línea (sin saltos',
+    'de línea internos), en español campesino claro, práctica, citando la entidad/fuente',
+    'de la evidencia cuando exista, y máximo ~900 caracteres. Escapa las comillas dobles.',
+    'Formato EXACTO:',
+    '[{"id":"<id>","contaminated":<bool>,"category":"<cross_thermal|confusion_especie|pest_vs_disease|institucion_inventada|familia_fabricada|otra|ninguna>","explanation":"<por qué, breve>","respuesta_corregida":"<respuesta correcta grounded>","is_gap":<bool>}]',
+  ].join('\n');
+}
+
+/** parseCorrectionVerdicts — extrae el array JSON de veredictos+correcciones. */
+export function parseCorrectionVerdicts(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  const start = raw.indexOf('[');
+  const end = raw.lastIndexOf(']');
+  if (start < 0 || end <= start) return null;
+  let arr;
+  try { arr = JSON.parse(raw.slice(start, end + 1)); }
+  catch (_) { return null; }
+  if (!Array.isArray(arr)) return null;
+  return arr.map((o) => ({
+    id: typeof o.id === 'string' ? o.id : String(o.id ?? ''),
+    contaminated: typeof o.contaminated === 'boolean' ? o.contaminated : Boolean(o.contaminated),
+    category: typeof o.category === 'string' && o.category ? o.category : 'otra',
+    explanation: typeof o.explanation === 'string' ? o.explanation : '',
+    respuesta_corregida: typeof o.respuesta_corregida === 'string' ? o.respuesta_corregida.trim() : '',
+    is_gap: typeof o.is_gap === 'boolean' ? o.is_gap : Boolean(o.is_gap),
+    source: 'judge',
+  }));
+}
+
+/**
+ * B0g — grounding: juez `claude-code -p` que evalúa CADA respuesta (contaminación/
+ * alucinación) Y ADEMÁS genera la `respuesta_corregida` GROUNDED con el grafo (o
+ * marca `is_gap` si el grafo no tiene el dato → alimenta A2). Llena ctx.verdictsById
+ * para que A1 (destilado) escriba tuplas útiles para LoRA y A2 encole los gaps.
+ */
 async function runGrounding(ctx) {
   const { topic, responses = [] } = ctx;
   const items = responses
     .filter((r) => r.agent_text && r.agent_text.length > 20)
     .map((r) => ({
-      id: `${topic.id}-t${r.turn}`, probeType: r.kind,
-      subject: `${topic.problema} en ${topic.cultivo} (${topic.cientifico})`,
-      query: r.user_text, response: r.agent_text,
-      expectedFacts: [`${topic.problema} es ${topic.tipo}`, `agente causal / entidad: ${topic.patogeno}`],
-      trapFacts: [`información atribuida a otra plaga/enfermedad distinta de ${topic.patogeno}`],
-      notes: 'Marcar contaminación si inventa familias/instituciones o confunde con otra especie/plaga.',
+      id: `${topic.id}-t${r.turn}`, probeType: r.kind, query: r.user_text, response: r.agent_text,
+      entidades: (r.entities_grounded || []).join(', '),
     }));
   if (items.length === 0) return { status: 'fail', valor: '0 evaluables', detalle: 'No hubo respuestas evaluables (agente vacío).' };
-  const judgeCall = makeContaminationJudgeCall({ timeoutMs: 300000 });
-  const verdicts = await judgeContaminationBatch(items, { judgeCall });
+
+  // Evidencia grounded del grafo para que el juez corrija sin inventar.
+  const evidence = await gatherGraphEvidence(ctx);
+
+  // Un solo spawn de claude-code -p (secuencial, nunca paralelo) con evaluación + corrección.
+  const unjudged = items.map((it) => ({ id: it.id, contaminated: null, category: null, explanation: null, respuesta_corregida: '', is_gap: false, source: 'unjudged' }));
+  let verdicts = unjudged;
+  try {
+    const raw = await spawnClaudeCode(buildCorrectionBatchPrompt(items, evidence), { timeoutMs: 300000 });
+    const parsed = parseCorrectionVerdicts(raw);
+    if (parsed) {
+      const byId = new Map(parsed.map((v) => [v.id, v]));
+      verdicts = items.map((it) => byId.get(it.id) || { id: it.id, contaminated: null, category: null, explanation: null, respuesta_corregida: '', is_gap: false, source: 'unjudged' });
+    }
+  } catch (_) { /* degrada a unjudged */ }
+
   ctx.verdicts = verdicts;
   ctx.verdictsById = new Map(verdicts.map((v) => [v.id, v]));
+  ctx.judgeGaps = verdicts.filter((v) => v.is_gap === true);
+
   const judged = verdicts.filter((v) => v.source === 'judge');
   const contaminated = judged.filter((v) => v.contaminated === true);
+  const corrected = judged.filter((v) => v.respuesta_corregida && v.respuesta_corregida.length > 20);
+  const gaps = judged.filter((v) => v.is_gap === true);
   const pvHits = responses.reduce((a, r) => a + (r.post_validate_hallucinated || 0), 0);
   const status = judged.length === 0 ? 'skip' : contaminated.length === 0 && pvHits === 0 ? 'pass' : 'fail';
   return {
     status,
-    valor: `${contaminated.length} contaminados / ${judged.length} juzgados; ${pvHits} entidades alucinadas`,
-    detalle: `juez claude-code -p: ${judged.length}/${items.length} evaluados, ${contaminated.length} contaminados; post-validate: ${pvHits} alucinadas.`,
-    data: { verdicts: verdicts.map((v) => ({ id: v.id, contaminated: v.contaminated, category: v.category, explanation: clip(v.explanation, 400) })), post_validate_hits: pvHits },
+    valor: `${contaminated.length} contaminados / ${judged.length}; ${corrected.length} con corrección; ${gaps.length} gaps; ${pvHits} alucinadas`,
+    detalle: `juez claude-code -p: ${judged.length}/${items.length} evaluados, ${contaminated.length} contaminados, ${corrected.length} con respuesta_corregida grounded, ${gaps.length} gaps; post-validate: ${pvHits} alucinadas.`,
+    data: {
+      verdicts: verdicts.map((v) => ({ id: v.id, contaminated: v.contaminated, category: v.category, explanation: clip(v.explanation, 300), respuesta_corregida: clip(v.respuesta_corregida, 500), is_gap: v.is_gap })),
+      post_validate_hits: pvHits, corrected: corrected.length, gaps: gaps.length,
+    },
   };
 }
 
@@ -550,38 +659,66 @@ async function runDistill(ctx) {
   if (!responses.length) return { status: 'skip', valor: '0', detalle: 'Sin respuestas para destilar.' };
   const file = join(outDir, 'distill-dataset', `distill-${dateStr}.jsonl`);
   let n = 0;
+  let conCorreccion = 0;
   for (const r of responses) {
     if (!r.agent_text) continue;
     const v = verdictsById?.get(`${topic.id}-t${r.turn}`);
     const grounded = Boolean(v && v.contaminated === false && (r.post_validate_hallucinated || 0) === 0);
+    // El juez (B0g) ya produjo la respuesta grounded corregida. Sin ella la tupla
+    // no sirve para LoRA → la poblamos aquí. Si el juez marcó gap, queda vacía y
+    // se registra el gap (lo escribe A2).
+    const correccion = v && typeof v.respuesta_corregida === 'string' && v.respuesta_corregida.length > 20 ? v.respuesta_corregida : null;
+    if (correccion) conCorreccion += 1;
     appendJsonl(file, {
       ts: nowIso(), target, tema: topic.id, tema_problema: topic.problema, turno: r.turn, tipo_pregunta: r.kind,
       pregunta: r.user_text, respuesta_granite: r.agent_text, modelo: r.model,
       veredicto_juez: v ? { contaminated: v.contaminated, category: v.category, explanation: v.explanation, source: v.source } : { source: 'unjudged' },
-      respuesta_corregida: null, grounded,
+      respuesta_corregida: correccion,
+      es_gap: Boolean(v && v.is_gap),
+      grounded,
       tipo_error: v && v.contaminated ? (v.category || 'contaminacion') : ((r.post_validate_hallucinated || 0) > 0 ? 'entidad_alucinada' : null),
     });
     n += 1;
   }
-  return { status: 'pass', valor: `${n} tuplas`, detalle: `${n} tuplas acumuladas en ${file} (insumo LoRA; sintético, sin PII).`, data: { file, n } };
+  return { status: 'pass', valor: `${n} tuplas, ${conCorreccion} con corrección`, detalle: `${n} tuplas acumuladas en ${file} (${conCorreccion} con respuesta_corregida grounded; insumo LoRA; sintético, sin PII).`, data: { file, n, con_correccion: conCorreccion } };
 }
 
-/** A2 — gaps de grounding → cola DR (el sujeto del tema no resolvió en el grafo). */
+/** A2 — gaps de grounding → cola DR. Dos fuentes: (1) el sujeto no resolvió en el
+ *  grafo (heurística resolve-entities); (2) el juez de B0g marcó `is_gap` en algún
+ *  turno (el grafo no tenía lo necesario para corregir). Ambos alimentan DR. */
 async function runGaps(ctx) {
-  const { responses = [], topic, target, outDir, dateStr } = ctx;
+  const { responses = [], topic, target, outDir, dateStr, judgeGaps = [] } = ctx;
   const file = join(outDir, `grounding-gaps-${dateStr}.jsonl`);
+  let anotados = 0;
+
+  // (1) Heurística: el sujeto del tema no resolvió en el grafo.
   const resolvedAll = norm(responses.flatMap((r) => r.entities_grounded || []).join(' | '));
   const subjectResolved =
     resolvedAll.includes(norm(topic.patogeno).split(' ')[0]) ||
     resolvedAll.includes(norm(topic.cientifico).split(' ')[0]) ||
     resolvedAll.includes(norm(topic.cultivo));
-  if (subjectResolved) return { status: 'pass', valor: 'sujeto resuelto', detalle: `El sujeto del tema (${topic.patogeno}/${topic.cientifico}) resolvió en el grafo; sin gap.` };
-  appendJsonl(file, {
-    ts: nowIso(), target, tema: topic.id, entidad_faltante: `${topic.patogeno} / ${topic.cientifico}`, cultivo: topic.cultivo,
-    que_se_necesita: `Especie/plaga "${topic.patogeno}" (${topic.tipo}) en ${topic.cultivo} (${topic.cientifico}) y sus aristas (AFFECTS/SUSCEPTIBLE_TO, control cultural, biopreparados, fuente ${topic.fuente}) no resolvieron. Encolar DR/ingest.`,
-    detectado_por: 'resolve-entities vacío para el sujeto del tema',
-  });
-  return { status: 'pass', valor: 'GAP anotado', detalle: `GAP de grafo anotado en ${file} (${topic.patogeno}/${topic.cientifico}) → alimenta cola DR.`, data: { file } };
+  if (!subjectResolved) {
+    appendJsonl(file, {
+      ts: nowIso(), target, tema: topic.id, entidad_faltante: `${topic.patogeno} / ${topic.cientifico}`, cultivo: topic.cultivo,
+      que_se_necesita: `Especie/plaga "${topic.patogeno}" (${topic.tipo}) en ${topic.cultivo} (${topic.cientifico}) y sus aristas (AFFECTS/SUSCEPTIBLE_TO, control cultural, biopreparados, fuente ${topic.fuente}) no resolvieron. Encolar DR/ingest.`,
+      detectado_por: 'resolve-entities vacío para el sujeto del tema',
+    });
+    anotados += 1;
+  }
+
+  // (2) Gaps que marcó el juez de B0g (no pudo corregir con el grafo).
+  for (const g of judgeGaps) {
+    const turno = String(g.id || '').split('-t')[1] || '?';
+    appendJsonl(file, {
+      ts: nowIso(), target, tema: topic.id, entidad_faltante: `${topic.patogeno} / ${topic.cientifico}`, cultivo: topic.cultivo,
+      que_se_necesita: `El juez no pudo dar respuesta_corregida grounded para el turno ${turno} (${g.category || 'gap'}): ${clip(g.explanation, 300)}. Enriquecer el grafo/catálogo (fuente ${topic.fuente}) y encolar DR.`,
+      detectado_por: 'juez B0g marcó is_gap (evidencia del grafo insuficiente)',
+    });
+    anotados += 1;
+  }
+
+  if (anotados === 0) return { status: 'pass', valor: 'sin gaps', detalle: `El sujeto del tema (${topic.patogeno}/${topic.cientifico}) resolvió y el juez corrigió con el grafo; sin gap.` };
+  return { status: 'pass', valor: `${anotados} gap(s) anotados`, detalle: `${anotados} gap(s) de grafo anotados en ${file} → alimentan cola DR.`, data: { file, anotados, judge_gaps: judgeGaps.length } };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -1,0 +1,657 @@
+/**
+ * canary-modules.mjs — REGISTRO EXTENSIBLE de módulos del canario nocturno.
+ *
+ * Cada check (ejes B/D/C del doc `ops/NIGHTLY_SYSTEM.md`) y cada cosecha (eje A)
+ * es un MÓDULO PLUGGABLE con este contrato:
+ *
+ *   {
+ *     id,          // 'B0', 'D2', 'A1', ...  (matchea el doc)
+ *     nombre,      // humano
+ *     categoria,   // 'salud' | 'dinamico' | 'cosecha' | 'seguridad'
+ *     fase,        // 'P0' | 'P1' | 'P2'
+ *     stub?,       // true = registrado pero sin implementar (TODO)
+ *     run?(ctx)    // async → { status:'pass'|'fail'|'skip', valor, detalle, data? }
+ *   }
+ *
+ * El runner (`scripts/nightly-canary.mjs`) corre los módulos de la(s) fase(s)
+ * activa(s) EN ORDEN y acumula estado en `ctx` (los módulos de cosecha A leen lo
+ * que produjeron los de salud B). Los de fase inactiva o `stub:true` se reportan
+ * como 'stub' con un TODO claro → agregar uno nuevo = escribir su `run()`.
+ *
+ * Anti-leak: sin hosts/tokens/credenciales hardcodeados. Datos sintéticos
+ * (usuario de pruebas) → sin PII. Español colombiano (tú/usted), NUNCA voseo.
+ *
+ * @module canary-modules
+ */
+
+import { join, dirname } from 'node:path';
+import { mkdirSync, appendFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import {
+  judgeContaminationBatch,
+  makeContaminationJudgeCall,
+} from './bench-scorer.mjs';
+import { buildEnrichedSystemPrompt } from './bench-sidecar.mjs';
+
+// ── helpers compartidos ───────────────────────────────────────────────────────
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+export const nowIso = () => new Date().toISOString();
+export const clip = (s, n = 4000) => (typeof s === 'string' && s.length > n ? `${s.slice(0, n)}…` : s || '');
+const norm = (s) => (s || '').toString().toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '');
+
+export function appendJsonl(file, obj) {
+  mkdirSync(dirname(file), { recursive: true });
+  appendFileSync(file, `${JSON.stringify(obj)}\n`);
+}
+
+export async function httpFetch(url, { method = 'GET', headers = {}, body, timeoutMs = 30000 } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { method, headers, body, signal: controller.signal });
+    const text = await res.text();
+    let json = null;
+    try { json = text ? JSON.parse(text) : null; } catch (_) { /* no-json */ }
+    return { ok: res.ok, status: res.status, text, json };
+  } catch (err) {
+    return { ok: false, status: 0, text: String(err?.message || err), json: null };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const JSONAPI = { Accept: 'application/vnd.api+json', 'Content-Type': 'application/vnd.api+json' };
+// JPEG 1x1 válido (marcador de foto del canario; embebido para no depender de assets).
+const CANARY_JPEG_B64 =
+  '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRof' +
+  'Hh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAAB' +
+  'AAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AfwD/2Q==';
+
+// ── PRNG determinístico por fecha ──────────────────────────────────────────────
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+function seedFromDate(dateStr, salt = '') {
+  const s = `${dateStr}|${salt}`;
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i += 1) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+}
+export function dayOfYear(d) {
+  const start = Date.UTC(d.getUTCFullYear(), 0, 0);
+  return Math.floor((Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) - start) / 86400000);
+}
+
+// ── temas duros que ROTAN cada noche ───────────────────────────────────────────
+export const TOPICS = [
+  { id: 'roya_cafe', problema: 'la roya del café', patogeno: 'Hemileia vastatrix', cultivo: 'café', cientifico: 'Coffea arabica', tipo: 'enfermedad (hongo)', piso: 'templado', fuente: 'Cenicafé / Agrosavia', confusion: 'que la roya y la broca son la misma plaga' },
+  { id: 'gota_papa', problema: 'la gota o tizón tardío de la papa', patogeno: 'Phytophthora infestans', cultivo: 'papa', cientifico: 'Solanum tuberosum', tipo: 'enfermedad (oomiceto)', piso: 'frío', fuente: 'Agrosavia / ICA', confusion: 'que la gota se cura con un insecticida' },
+  { id: 'monilia_cacao', problema: 'la moniliasis del cacao', patogeno: 'Moniliophthora roreri', cultivo: 'cacao', cientifico: 'Theobroma cacao', tipo: 'enfermedad (hongo)', piso: 'cálido', fuente: 'Fedecacao / Agrosavia', confusion: 'que la monilia y la escoba de bruja son lo mismo' },
+  { id: 'gallinas_frio', problema: 'el manejo de gallinas ponedoras en clima frío de montaña', patogeno: 'estrés por frío y humedad', cultivo: 'gallinas ponedoras', cientifico: 'Gallus gallus domesticus', tipo: 'manejo pecuario', piso: 'frío altoandino', fuente: 'ICA / SENA', confusion: 'que en frío hay que quitarles el agua para que no se enfermen' },
+  { id: 'sigatoka_platano', problema: 'la sigatoka negra del plátano', patogeno: 'Pseudocercospora fijiensis', cultivo: 'plátano', cientifico: 'Musa paradisiaca', tipo: 'enfermedad (hongo)', piso: 'cálido', fuente: 'Agrosavia / ICA', confusion: 'que la sigatoka la produce el picudo negro' },
+  { id: 'broca_cafe', problema: 'la broca del café', patogeno: 'Hypothenemus hampei', cultivo: 'café', cientifico: 'Coffea arabica', tipo: 'plaga (insecto)', piso: 'templado', fuente: 'Cenicafé', confusion: 'que la broca es un hongo que se controla con fungicida' },
+  { id: 'picudo_platano', problema: 'el picudo negro del plátano', patogeno: 'Cosmopolites sordidus', cultivo: 'plátano', cientifico: 'Musa paradisiaca', tipo: 'plaga (insecto)', piso: 'cálido', fuente: 'Agrosavia', confusion: 'que el picudo se combate igual que la sigatoka' },
+  { id: 'mildeo_cebolla', problema: 'el mildeo velloso de la cebolla', patogeno: 'Peronospora destructor', cultivo: 'cebolla de rama', cientifico: 'Allium fistulosum', tipo: 'enfermedad (oomiceto)', piso: 'frío', fuente: 'Agrosavia', confusion: 'que el mildeo es la misma trips de la cebolla' },
+  { id: 'antracnosis_tomatearbol', problema: 'la antracnosis del tomate de árbol', patogeno: 'Colletotrichum spp.', cultivo: 'tomate de árbol', cientifico: 'Solanum betaceum', tipo: 'enfermedad (hongo)', piso: 'frío', fuente: 'Agrosavia', confusion: 'que la antracnosis es un daño por mosca de la fruta' },
+];
+const PISO_ALTITUDES = { 'cálido': [400, 700, 900], 'templado': [1300, 1650, 1850], 'frío': [2200, 2600, 2900], 'frío altoandino': [2800, 3100, 3300] };
+
+export function pickTopic(now) { return TOPICS[dayOfYear(now) % TOPICS.length]; }
+
+export function buildConversation(topic, dateStr) {
+  const rnd = mulberry32(seedFromDate(dateStr, topic.id));
+  const alts = PISO_ALTITUDES[topic.piso] || [1600];
+  const altitud = alts[Math.floor(rnd() * alts.length)];
+  const lluvia = rnd() > 0.5 ? 'con lluvias frecuentes' : 'en época seca prolongada';
+  const escala = rnd() > 0.5 ? 'en un lote pequeño de pancoger' : 'en media hectárea';
+  return [
+    { turn: 1, kind: 'pregunta_inicial', text: `¿Cómo identifico y manejo ${topic.problema} en ${topic.cultivo} (${topic.cientifico}) en clima ${topic.piso}? Quiero saber los síntomas y qué hacer apenas aparece.` },
+    { turn: 2, kind: 'repregunta_matiz', text: `En mi finca a ${altitud} msnm, ${lluvia} y ${escala}, ¿cambia el manejo? Prefiero control cultural o biopreparados, sin químicos de síntesis. ¿Qué me recomiendas concretamente?` },
+    { turn: 3, kind: 'caso_borde', text: `Un vecino me dijo ${topic.confusion}. ¿Eso es cierto o me está confundiendo ${topic.problema} con otra cosa? Explícame la diferencia sin inventar.` },
+    { turn: 4, kind: 'pedir_fuente', text: `¿De dónde sale esa recomendación? Dame la fuente o la entidad (por ejemplo ${topic.fuente}) para poder verificarlo. Si no la tienes, dímelo, no te la inventes.` },
+  ];
+}
+
+// ── clientes del pipeline (via el target) ──────────────────────────────────────
+async function sidecarPost(base, token, path, body, timeoutMs = 30000) {
+  return httpFetch(`${base}/api/mcp/agro${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(token ? { 'X-Chagra-Token': token } : {}) },
+    body: JSON.stringify(body),
+    timeoutMs,
+  });
+}
+async function callTool(base, token, name, args, timeoutMs = 45000) {
+  return sidecarPost(base, token, `/tools/${name}`, args || {}, timeoutMs);
+}
+async function generateChat(base, bearer, systemPrompt, userPrompt, model) {
+  const start = Date.now();
+  const r = await httpFetch(`${base}/api/ollama/api/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}) },
+    body: JSON.stringify({
+      model, stream: false,
+      messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userPrompt }],
+      options: { temperature: 0.3, seed: 42, num_predict: 512 }, keep_alive: '10m',
+    }),
+    timeoutMs: 180000,
+  });
+  const latency = Date.now() - start;
+  if (!r.ok || !r.json) return { response: '', latency_ms: latency, error: `HTTP ${r.status}` };
+  return { response: r.json.message?.content || '', latency_ms: latency, model: r.json.model || model };
+}
+
+// ── farmOS helpers ─────────────────────────────────────────────────────────────
+async function farmosGet(base, token, path) {
+  return httpFetch(`${base}${path}`, { headers: { ...JSONAPI, Authorization: `Bearer ${token}` }, timeoutMs: 30000 });
+}
+async function farmosWrite(base, token, path, payload, method = 'POST') {
+  return httpFetch(`${base}${path}`, { method, headers: { ...JSONAPI, Authorization: `Bearer ${token}` }, body: JSON.stringify(payload), timeoutMs: 30000 });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MÓDULOS P0 (implementados)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/** login — OAuth del usuario de pruebas. Deja ctx.token para el resto. */
+async function runLogin(ctx) {
+  const clientId = process.env.CANARY_FARMOS_CLIENT_ID || 'farm';
+  const form = new URLSearchParams();
+  form.set('grant_type', 'password');
+  form.set('client_id', clientId);
+  form.set('username', ctx.creds.usuario);
+  form.set('password', ctx.creds.clave);
+  form.set('scope', 'farm_manager');
+  const r = await httpFetch(`${ctx.base}/oauth/token`, {
+    method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: form.toString(), timeoutMs: 30000,
+  });
+  if (!r.ok || !r.json?.access_token) return { status: 'fail', valor: `HTTP ${r.status}`, detalle: 'OAuth falló (¿credenciales o /oauth caído?).' };
+  ctx.token = r.json.access_token;
+  return { status: 'pass', valor: `token ${ctx.token.length} chars`, detalle: 'OAuth OK para el usuario de pruebas.' };
+}
+
+/** B0 — conversación dinámica de 4 mensajes por el pipeline real. Llena ctx.responses. */
+async function runConversacion(ctx) {
+  const { base, sidecarToken, token, chatModel, conversation, topic } = ctx;
+  ctx.responses = [];
+  let turnOk = 0;
+  for (const msg of conversation) {
+    try {
+      const nluR = await sidecarPost(base, sidecarToken, '/nlu', { user_message: msg.text, context: {} }).catch(() => null);
+      const nlu = nluR?.ok ? nluR.json : null;
+      const reR = await sidecarPost(base, sidecarToken, '/resolve-entities', { user_message: msg.text }).catch(() => null);
+      const entities = reR?.ok && Array.isArray(reR.json?.entities) ? reR.json.entities : [];
+      const systemPrompt = buildEnrichedSystemPrompt(entities);
+      const gen = await generateChat(base, token, systemPrompt, msg.text, chatModel);
+      let pv = { hallucinated: [], detected_count: 0 };
+      if (gen.response) {
+        const pvR = await sidecarPost(base, sidecarToken, '/post-validate', { user_message: msg.text, response: gen.response }).catch(() => null);
+        if (pvR?.ok && pvR.json) pv = { hallucinated: pvR.json.hallucinated || [], detected_count: pvR.json.detected_count || 0 };
+      }
+      if (gen.response && gen.response.length > 30) turnOk += 1;
+      ctx.responses.push({
+        turn: msg.turn, kind: msg.kind, user_text: msg.text, agent_text: gen.response,
+        nlu_route: nlu?.route || nlu?.tool || nlu?.intent || null,
+        entities_grounded: entities.map((e) => e.nombre_cientifico || e.nombre_comun || e.mentioned).filter(Boolean).slice(0, 20),
+        post_validate_hallucinated: pv.hallucinated?.length || 0,
+        latency_ms: gen.latency_ms, model: gen.model || chatModel, error: gen.error || null,
+      });
+    } catch (err) {
+      ctx.responses.push({ turn: msg.turn, kind: msg.kind, user_text: msg.text, agent_text: '', error: String(err?.message || err) });
+    }
+  }
+  const status = turnOk === conversation.length ? 'pass' : 'fail';
+  return { status, valor: `${turnOk}/${conversation.length} respuestas`, detalle: `Conversación compleja sobre ${topic.id} (${turnOk}/${conversation.length} turnos con respuesta).`, data: { topic: topic.id } };
+}
+
+/** B0g — grounding: juez claude-code -p (contaminación/alucinación). Llena ctx.verdicts. */
+async function runGrounding(ctx) {
+  const { topic, responses = [] } = ctx;
+  const items = responses
+    .filter((r) => r.agent_text && r.agent_text.length > 20)
+    .map((r) => ({
+      id: `${topic.id}-t${r.turn}`, probeType: r.kind,
+      subject: `${topic.problema} en ${topic.cultivo} (${topic.cientifico})`,
+      query: r.user_text, response: r.agent_text,
+      expectedFacts: [`${topic.problema} es ${topic.tipo}`, `agente causal / entidad: ${topic.patogeno}`],
+      trapFacts: [`información atribuida a otra plaga/enfermedad distinta de ${topic.patogeno}`],
+      notes: 'Marcar contaminación si inventa familias/instituciones o confunde con otra especie/plaga.',
+    }));
+  if (items.length === 0) return { status: 'fail', valor: '0 evaluables', detalle: 'No hubo respuestas evaluables (agente vacío).' };
+  const judgeCall = makeContaminationJudgeCall({ timeoutMs: 300000 });
+  const verdicts = await judgeContaminationBatch(items, { judgeCall });
+  ctx.verdicts = verdicts;
+  ctx.verdictsById = new Map(verdicts.map((v) => [v.id, v]));
+  const judged = verdicts.filter((v) => v.source === 'judge');
+  const contaminated = judged.filter((v) => v.contaminated === true);
+  const pvHits = responses.reduce((a, r) => a + (r.post_validate_hallucinated || 0), 0);
+  const status = judged.length === 0 ? 'skip' : contaminated.length === 0 && pvHits === 0 ? 'pass' : 'fail';
+  return {
+    status,
+    valor: `${contaminated.length} contaminados / ${judged.length} juzgados; ${pvHits} entidades alucinadas`,
+    detalle: `juez claude-code -p: ${judged.length}/${items.length} evaluados, ${contaminated.length} contaminados; post-validate: ${pvHits} alucinadas.`,
+    data: { verdicts: verdicts.map((v) => ({ id: v.id, contaminated: v.contaminated, category: v.category, explanation: clip(v.explanation, 400) })), post_validate_hits: pvHits },
+  };
+}
+
+/** B0b — planta con foto bajo ubicación de pruebas aislada. NO borra (acumula). */
+async function runPlantaFoto(ctx) {
+  const { base, token, target, dateStr } = ctx;
+  if (!token) return { status: 'skip', valor: 'sin token', detalle: 'Login falló; no puedo escribir en farmOS.' };
+
+  // Ubicación de pruebas (idempotente) — aísla de la finca real.
+  const landName = 'CANARIO-PRUEBAS';
+  let landId = null;
+  const foundLand = await farmosGet(base, token, `/api/asset/land?filter[name]=${encodeURIComponent(landName)}&page[limit]=1`);
+  if (foundLand.ok && foundLand.json?.data?.length) landId = foundLand.json.data[0].id;
+  else {
+    const cl = await farmosWrite(base, token, '/api/asset/land', { data: { type: 'asset--land', attributes: { name: landName, status: 'active', land_type: 'property', is_location: true, is_fixed: true, notes: { value: 'Ubicación de PRUEBAS del canario. No es finca real. No borrar.', format: 'plain_text' } } } });
+    if (cl.ok && cl.json?.data?.id) landId = cl.json.data.id;
+  }
+
+  // plant_type (evita el 422 "plant_type no puede ser nulo").
+  let plantTypeId = null;
+  const pt = await farmosGet(base, token, '/api/taxonomy_term/plant_type?page[limit]=1');
+  if (pt.ok && pt.json?.data?.length) plantTypeId = pt.json.data[0].id;
+  else { const cpt = await farmosWrite(base, token, '/api/taxonomy_term/plant_type', { data: { type: 'taxonomy_term--plant_type', attributes: { name: 'CANARIO' } } }); if (cpt.ok) plantTypeId = cpt.json?.data?.id; }
+
+  // Crear la planta bajo la ubicación de pruebas.
+  const stamp = `${dateStr} ${new Date().toISOString().slice(11, 19)}`;
+  const rels = {};
+  if (plantTypeId) rels.plant_type = { data: [{ type: 'taxonomy_term--plant_type', id: plantTypeId }] };
+  if (landId) rels.location = { data: [{ type: 'asset--land', id: landId }] };
+  let created = await farmosWrite(base, token, '/api/asset/plant', { data: { type: 'asset--plant', attributes: { name: `CANARIO planta ${target} ${stamp}`, status: 'active', notes: { value: `Planta de PRUEBAS del canario (${target}). Bajo CANARIO-PRUEBAS. No borrar.`, format: 'plain_text' } }, relationships: rels } });
+  if (!created.ok && rels.location) { delete rels.location; created = await farmosWrite(base, token, '/api/asset/plant', { data: { type: 'asset--plant', attributes: { name: `CANARIO planta ${target} ${stamp}`, status: 'active' }, relationships: rels } }); }
+  const plantId = created.ok ? created.json?.data?.id : null;
+
+  // Subir la foto al campo image de la planta (JSON:API binario, ruta correcta).
+  let fileId = null; let uploadStatus = null;
+  if (plantId) {
+    const bytes = Buffer.from(CANARY_JPEG_B64, 'base64');
+    const up = await httpFetch(`${base}/api/asset/plant/${plantId}/image`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/octet-stream', 'Content-Disposition': `file; filename="CANARIO-${target}-${dateStr}.jpg"`, Accept: 'application/vnd.api+json' },
+      body: bytes, timeoutMs: 45000,
+    });
+    uploadStatus = up.status;
+    if (up.ok && up.json?.data?.id) fileId = up.json.data.id;
+  }
+
+  // Verificar persistencia: releer la planta y confirmar la relación image.
+  let verified = false; let photoOk = false;
+  if (plantId) {
+    const rb = await farmosGet(base, token, `/api/asset/plant/${plantId}?include=image`);
+    verified = rb.ok && rb.json?.data?.id === plantId;
+    const img = rb.json?.data?.relationships?.image?.data;
+    photoOk = Array.isArray(img) ? img.length > 0 : Boolean(img);
+  }
+
+  const status = plantId && verified && photoOk ? 'pass' : 'fail';
+  return {
+    status,
+    valor: `planta=${plantId ? 'sí' : 'NO'}, foto=${photoOk ? 'persiste' : `NO (upload HTTP ${uploadStatus})`}`,
+    detalle: `planta ${plantId ? plantId.slice(0, 8) : 'NO'} (verificada=${verified}) bajo ${landId ? 'CANARIO-PRUEBAS' : 'sin land'}; foto ${fileId ? fileId.slice(0, 8) : `NO (HTTP ${uploadStatus})`} persiste=${photoOk}. Sin borrar (acumula).`,
+    data: { plantId, fileId, landId, verified, photoOk, uploadStatus },
+  };
+}
+
+/** B0c — verificar que la conversación quedó registrada en el store del sidecar. */
+async function runCaptura(ctx) {
+  const { base, sidecarToken, target, dateStr, responses = [] } = ctx;
+  const conta = () => {
+    const cmd = process.env.CANARY_CONV_COUNT_CMD;
+    if (!cmd) return null;
+    try { const n = parseInt(execSync(cmd, { encoding: 'utf-8', timeout: 30000 }).trim().split(/\s+/)[0], 10); return Number.isFinite(n) ? n : null; } catch (_) { return null; }
+  };
+  const before = conta();
+  const withText = responses.filter((r) => r.agent_text);
+  let posted = 0;
+  const sessionId = `canario-${target}-${dateStr}`;
+  for (const r of withText) {
+    const payload = {
+      id: `CAN${Date.now().toString(36).toUpperCase()}${Math.random().toString(36).slice(2, 8).toUpperCase()}`,
+      ts: Date.now(), user_id: `canario-${target}`, user_name: 'CANARIO', finca_slug: 'canario-pruebas', finca_nombre: null,
+      session_id: sessionId, turn_index: r.turn, user_text: clip(r.user_text, 16000), agent_text: clip(r.agent_text, 16000),
+      nlu_route: r.nlu_route ?? null, entities_grounded: r.entities_grounded ?? [], guards_fired: [],
+      grounded_status: r.post_validate_hallucinated ? 'flagged' : 'ok', latency_ms: r.latency_ms ?? null, model: r.model ?? null,
+    };
+    const res = await sidecarPost(base, sidecarToken, '/log-conversation', payload, 15000);
+    if (res.ok) posted += 1;
+  }
+  await sleep(1500);
+  const after = conta();
+  if (before === null || after === null) {
+    return { status: posted > 0 ? 'pass' : 'fail', valor: `endpoint aceptó ${posted}/${withText.length}`, detalle: `POST /log-conversation aceptó ${posted}/${withText.length} turnos (verificación en disco no configurada: falta CANARY_CONV_COUNT_CMD).`, data: { posted, disk_verified: false } };
+  }
+  const delta = after - before;
+  const ok = delta >= posted && posted > 0;
+  return { status: ok ? 'pass' : 'fail', valor: `${before}→${after} (Δ=${delta})`, detalle: `store de conversaciones: ${before} → ${after} líneas (Δ=${delta}, posteados=${posted}). ${ok ? 'incrementa correctamente.' : 'NO incrementó lo esperado → posible bug de captura.'}`, data: { posted, before, after, delta, disk_verified: true } };
+}
+
+// ── B0f: CASO GOLDEN/REGRESIÓN — ración avícola en altura (Choachí 2513 msnm) ───
+// El agente falló esta pregunta en el piloto real. Cuando aterrice el fix avícola
+// (grounding tierra fría + cálculo de ración, rama gl-avicola-frio), debe PASAR.
+export const AVICOLA_FRIO_CASE = {
+  id: 'avicola_frio_2500',
+  pregunta: '¿Cuánto alimento le doy a 12-14 gallinas criollas a 2500 msnm, mezcla de grano y pastoreo?',
+  criterios: [
+    '(a) da una CANTIDAD concreta (g/día por ave y kg/día totales)',
+    '(b) AJUSTA por la altitud fría (más consumo por termorregulación)',
+    '(c) NO recomienda plantas de clima cálido a 2500 msnm (Nacedero/Trichanthera <~2000 = cross_thermal)',
+    '(d) no deja un cascarón (respuesta suprimida sin reemplazo útil)',
+  ],
+};
+
+function evalAvicolaFrio(text) {
+  const raw = (text || '').trim();
+  const n = norm(raw);
+  // (a) cantidad: gramos/ave y/o kg/día totales.
+  const hasGramos = /\b\d{2,3}\s*(g|gr|gramos)\b/.test(n);
+  const hasKg = /\b\d+([.,]\d+)?\s*(kg|kilos?|kilogramos?)\b/.test(n);
+  const daCantidad = hasGramos || hasKg;
+  // (b) ajuste por altura fría / termorregulación.
+  const ajustaAltura = /(2500|2513|altur|altitud|fri[oa]|clima\s*fri|termorregul|mas\s*consum|mayor\s*consum|consum.*fri|fri.*consum)/.test(n);
+  // (c) cross_thermal: plantas de clima cálido recomendadas a 2500 (trampa del piloto).
+  const crossThermal = /(nacedero|trichanthera|quiebrabarrig|matarrat[oó]?n|botón de oro|boton de oro)/.test(n);
+  // (d) cascarón: respuesta vacía/suprimida sin reemplazo útil.
+  const cascaron = raw.length < 180 || (/(no puedo|no tengo (informaci|datos)|no cuento con|no dispongo|consulta.* (veterinari|experto))/.test(n) && raw.length < 400);
+  const pass = daCantidad && ajustaAltura && !crossThermal && !cascaron;
+  return { pass, daCantidad, hasGramos, hasKg, ajustaAltura, crossThermal, cascaron };
+}
+
+async function runAvicolaFrio(ctx) {
+  const { base, sidecarToken, token, chatModel, target, dateStr, outDir } = ctx;
+  const q = AVICOLA_FRIO_CASE.pregunta;
+  const reR = await sidecarPost(base, sidecarToken, '/resolve-entities', { user_message: q }).catch(() => null);
+  const entities = reR?.ok && Array.isArray(reR.json?.entities) ? reR.json.entities : [];
+  const systemPrompt = buildEnrichedSystemPrompt(entities);
+  const gen = await generateChat(base, token, systemPrompt, q, chatModel);
+  const text = gen.response || '';
+  const ev = evalAvicolaFrio(text);
+
+  // Golden/regresión: acumula la respuesta + sub-flags para trackear cuándo pasa.
+  appendJsonl(join(outDir, 'golden', `avicola-frio-${dateStr}.jsonl`), {
+    ts: nowIso(), target, caso: AVICOLA_FRIO_CASE.id, pregunta: q, respuesta: text, modelo: gen.model || chatModel, eval: ev,
+  });
+
+  const fallos = [];
+  if (!ev.daCantidad) fallos.push('(a) sin cantidad g/kg');
+  if (!ev.ajustaAltura) fallos.push('(b) no ajusta por frío/altura');
+  if (ev.crossThermal) fallos.push('(c) cross_thermal: recomienda planta de clima cálido a 2500 msnm');
+  if (ev.cascaron) fallos.push('(d) cascarón (respuesta suprimida/vacía)');
+  const status = ev.pass ? 'pass' : (text ? 'fail' : 'fail');
+  return {
+    status,
+    valor: ev.pass ? 'OK' : fallos.join('; '),
+    detalle: `Golden ración avícola 2500 msnm: ${ev.pass ? 'PASA' : 'FALLA — ' + fallos.join('; ')}. (cantidad=${ev.daCantidad} altura=${ev.ajustaAltura} crossThermal=${ev.crossThermal} cascarón=${ev.cascaron})`,
+    data: { eval: ev, respuesta: clip(text, 800) },
+  };
+}
+
+// ── D1-D5: datos dinámicos externos ────────────────────────────────────────────
+function findDate(obj, depth = 0) {
+  if (!obj || depth > 4) return null;
+  if (typeof obj === 'string') { const m = obj.match(/\d{4}-\d{2}-\d{2}/); return m ? m[0] : null; }
+  if (typeof obj !== 'object') return null;
+  for (const k of Object.keys(obj)) {
+    if (/fecha|date|fetched|updated|timestamp|dia/i.test(k)) { const d = findDate(obj[k], depth + 1); if (d) return d; }
+  }
+  for (const k of Object.keys(obj)) { const d = findDate(obj[k], depth + 1); if (d) return d; }
+  return null;
+}
+function daysAgo(dateStr) {
+  if (!dateStr) return Infinity;
+  const t = Date.parse(dateStr);
+  if (!Number.isFinite(t)) return Infinity;
+  return Math.floor((Date.now() - t) / 86400000);
+}
+
+async function runClima(ctx) {
+  const { base, sidecarToken } = ctx;
+  // Snapshot (ENSO + forecast) da la señal de frescura más directa.
+  const snap = await httpFetch(`${base}/api/mcp/agro/clima/snapshot`, { headers: { 'X-Chagra-Token': sidecarToken }, timeoutMs: 30000 });
+  const fetchedAt = snap.json?.fetched_at || null;
+  const staleSnap = daysAgo(fetchedAt) > 2;
+  // Estaciones IDEAM.
+  const ideam = await callTool(base, sidecarToken, 'get_clima_ideam', { action: 'stations_near', municipio: 'Chinchiná', departamento: 'Caldas' });
+  const ideamOk = ideam.ok && ideam.json && !ideam.json.error;
+  const status = snap.ok && !staleSnap && ideamOk ? 'pass' : 'fail';
+  return { status, valor: `snapshot ${fetchedAt || 'N/A'}, IDEAM HTTP ${ideam.status}`, detalle: `clima/snapshot HTTP ${snap.status} (fetched_at=${fetchedAt}, ${staleSnap ? 'STALE' : 'fresco'}); get_clima_ideam(stations_near) HTTP ${ideam.status}${ideamOk ? '' : ' → IDEAM degradado'}.`, data: { fetched_at: fetchedAt, ideam_status: ideam.status } };
+}
+
+async function runPrecio(ctx) {
+  const { base, sidecarToken } = ctx;
+  const r = await callTool(base, sidecarToken, 'get_precio_sipsa', { action: 'latest_price', producto: 'papa' });
+  if (!r.ok) return { status: 'fail', valor: `HTTP ${r.status}`, detalle: `get_precio_sipsa(latest_price papa) HTTP ${r.status} → SIPSA/DANE degradado.` };
+  const body = r.json || {};
+  const available = body.available !== false && (body.price || body.data || body.precio_promedio_cop_kg || body.especie);
+  const fecha = findDate(body);
+  const stale = daysAgo(fecha) > 45;
+  const price = body.price?.precio_promedio_cop_kg || body.precio_promedio_cop_kg || (body.price ? JSON.stringify(body.price).slice(0, 60) : null);
+  const status = available && !stale ? 'pass' : 'fail';
+  return { status, valor: `precio=${price || 'N/A'}, fecha=${fecha || 'N/A'}`, detalle: `SIPSA papa: ${available ? `precio ${price}` : 'available:false'}, fecha ${fecha || 'N/A'}${stale ? ' → STALE (>45d o año pasado)' : ''}.`, data: { available: Boolean(available), fecha, price } };
+}
+
+async function runEnso(ctx) {
+  const { base, sidecarToken } = ctx;
+  const r = await callTool(base, sidecarToken, 'get_enso_status', {});
+  const phase = r.json?.enso_status?.phase || r.json?.phase || null;
+  const status = r.ok && phase ? 'pass' : 'fail';
+  return { status, valor: `fase=${phase || 'N/A'}`, detalle: `get_enso_status HTTP ${r.status}, fase=${phase || 'N/A'} (ONI=${r.json?.enso_status?.oni_value ?? 'N/A'}).`, data: { phase } };
+}
+
+async function runCalendario(ctx) {
+  const { base, sidecarToken } = ctx;
+  const mes = new Date().getUTCMonth() + 1;
+  const r = await callTool(base, sidecarToken, 'get_calendario_siembra', { piso_termico: 'templado', mes });
+  const hasData = r.ok && r.json && !r.json.error && (r.json.available !== false);
+  return { status: hasData ? 'pass' : 'fail', valor: `HTTP ${r.status}`, detalle: `get_calendario_siembra(templado, mes ${mes}) HTTP ${r.status}${hasData ? '' : ' → sin datos/available:false'}.`, data: { status: r.status } };
+}
+
+async function runSidecarHealth(ctx) {
+  const { base, sidecarToken } = ctx;
+  const h = await httpFetch(`${base}/api/mcp/agro/health`, { headers: { 'X-Chagra-Token': sidecarToken }, timeoutMs: 20000 });
+  const health = h.json || {};
+  const sidecarOk = h.ok && health.status === 'ok';
+  const ollamaOk = health.ollama_up === true || (health.ollama_models && health.ollama_models.length > 0);
+  const tools = await httpFetch(`${base}/api/mcp/agro/tools`, { headers: { 'X-Chagra-Token': sidecarToken }, timeoutMs: 20000 });
+  const toolsOk = tools.ok && tools.text.length > 1000;
+  const kokoro = await httpFetch(`${base}/api/kokoro/health`, { timeoutMs: 15000 });
+  const kokoroOk = kokoro.ok && /ok|kokoro/i.test(kokoro.text);
+  const tags = await httpFetch(`${base}/api/ollama/api/tags`, { headers: { Authorization: `Bearer ${ctx.token || ''}` }, timeoutMs: 15000 });
+  const ollamaTagsOk = tags.ok && Array.isArray(tags.json?.models) && tags.json.models.length > 0;
+  const status = sidecarOk && ollamaOk && toolsOk && kokoroOk && ollamaTagsOk ? 'pass' : 'fail';
+  return {
+    status,
+    valor: `sidecar ${health.build_sha || '?'}, ollama=${ollamaOk}, kokoro=${kokoroOk}, tools=${toolsOk}`,
+    detalle: `/health build_sha=${health.build_sha || '?'} (${sidecarOk ? 'ok' : 'DOWN'}), ollama_up=${ollamaOk}, kokoro=${kokoroOk}, /tools=${toolsOk}, ollama/tags=${ollamaTagsOk}.`,
+    data: { build_sha: health.build_sha, sidecarOk, ollamaOk, kokoroOk, toolsOk, ollamaTagsOk },
+  };
+}
+
+// ── B0d: smoke visual (Playwright, backend REAL) ───────────────────────────────
+const KNOWN_CHROMIUM = [
+  '/nix/store/r7ifk1v95jfl02775kgbrd61dyr1rfsx-chromium-148.0.7778.178/bin/chromium',
+  '/nix/store/9fjg59mab9j8c5r61dx2k5gcbd2f5mpm-chromium-148.0.7778.96/bin/chromium',
+];
+function resolveChromium() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) return process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  for (const p of KNOWN_CHROMIUM) if (existsSync(p)) return p;
+  try { const w = execSync('which chromium 2>/dev/null', { encoding: 'utf-8' }).trim(); if (w) return w; } catch (_) { /* noop */ }
+  return undefined;
+}
+const BENIGN_CONSOLE = /sqlite|wasm|content security policy|csp|favicon|manifest|WebGL|Failed to load resource|net::ERR|ArrayBuffer instantiation|Error obteniendo tareas|FarmOS|preload|React DevTools|kokoro|whisper|Service Worker|sw\.js/i;
+
+async function runVisual(ctx) {
+  const { base, token, target, dateStr, outDir } = ctx;
+  if (!token) return { status: 'skip', valor: 'sin token', detalle: 'Login falló; no puedo montar sesión.' };
+  let chromium;
+  try { ({ chromium } = await import('playwright')); } catch (err) { return { status: 'skip', valor: 'sin playwright', detalle: `Playwright no disponible: ${String(err?.message || err).slice(0, 80)}` }; }
+  const shotsDir = join(outDir, 'shots');
+  mkdirSync(shotsDir, { recursive: true });
+  const browser = await chromium.launch({ executablePath: resolveChromium(), args: ['--no-sandbox', '--disable-setuid-sandbox', '--single-process', '--disable-dev-shm-usage'] });
+  const errors = []; const shots = [];
+  const context = await browser.newContext({ viewport: { width: 390, height: 844 }, ignoreHTTPSErrors: true });
+  const page = await context.newPage();
+  page.on('pageerror', (err) => { const t = String(err?.message || err); if (!BENIGN_CONSOLE.test(t)) errors.push(`pageerror: ${t}`); });
+  page.on('console', (msg) => { if (msg.type() !== 'error') return; const t = msg.text(); if (!BENIGN_CONSOLE.test(t)) errors.push(`console: ${t}`); });
+  let mounted = false;
+  try {
+    await page.goto(`${base}/`, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    await page.evaluate(async ({ tok, tenant }) => {
+      localStorage.setItem('chagra:profile:done:v1', '1');
+      localStorage.setItem('chagra:onboarding:done', '1');
+      localStorage.setItem('chagra:active_tenant_id', tenant);
+      localStorage.setItem('chagra_feedback_consent_v1', 'true');
+      await new Promise((resolve) => {
+        const req = indexedDB.open('Chagra');
+        req.onupgradeneeded = () => { if (!req.result.objectStoreNames.contains('syncQueue')) req.result.createObjectStore('syncQueue'); };
+        req.onsuccess = () => {
+          const db = req.result;
+          if (!db.objectStoreNames.contains('syncQueue')) { db.close(); resolve(); return; }
+          const tx = db.transaction('syncQueue', 'readwrite'); const store = tx.objectStore('syncQueue');
+          store.put(tok, 'farmos_access_token'); store.put(Date.now() + 3600_000, 'farmos_token_expiry');
+          tx.oncomplete = () => { db.close(); resolve(); }; tx.onerror = () => { db.close(); resolve(); };
+        };
+        req.onerror = () => resolve();
+      });
+    }, { tok: token, tenant: `canario-${target}` });
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 45000 });
+    await page.locator('#root').waitFor({ state: 'visible', timeout: 30000 });
+    await page.waitForLoadState('networkidle', { timeout: 20000 }).catch(() => {});
+    const screens = [{ id: 'home', hash: '' }, { id: 'agente', hash: 'agente' }, { id: 'perfil', hash: 'perfil' }, { id: 'mis-zonas', hash: 'inventario' }];
+    for (const sc of screens) {
+      await page.goto(`${base}/${sc.hash ? `#${sc.hash}` : ''}`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      await sleep(1200);
+      if (sc.id === 'home' && (await page.locator('#root').count())) mounted = true;
+      const file = join(shotsDir, `${dateStr}-${target}-${sc.id}.png`);
+      await page.screenshot({ path: file, fullPage: false }).catch(() => {});
+      shots.push(file);
+    }
+  } finally {
+    await context.close().catch(() => {});
+    await browser.close().catch(() => {});
+  }
+  const status = mounted && errors.length === 0 ? 'pass' : 'fail';
+  return { status, valor: `home ${mounted ? 'montó' : 'NO'}, ${errors.length} errores`, detalle: `home ${mounted ? 'montó' : 'NO montó'}, ${shots.length} screenshots, ${errors.length} errores de consola.`, data: { mounted, shots, console_errors: errors.slice(0, 10) } };
+}
+
+// ── A1/A2: cosecha del juez ─────────────────────────────────────────────────────
+/** A1 — dataset de destilado (insumo futuro LoRA granite). Acumula, no pisa. Sintético = anti-leak. */
+async function runDistill(ctx) {
+  const { responses = [], verdictsById, topic, target, outDir, dateStr } = ctx;
+  if (!responses.length) return { status: 'skip', valor: '0', detalle: 'Sin respuestas para destilar.' };
+  const file = join(outDir, 'distill-dataset', `distill-${dateStr}.jsonl`);
+  let n = 0;
+  for (const r of responses) {
+    if (!r.agent_text) continue;
+    const v = verdictsById?.get(`${topic.id}-t${r.turn}`);
+    const grounded = Boolean(v && v.contaminated === false && (r.post_validate_hallucinated || 0) === 0);
+    appendJsonl(file, {
+      ts: nowIso(), target, tema: topic.id, tema_problema: topic.problema, turno: r.turn, tipo_pregunta: r.kind,
+      pregunta: r.user_text, respuesta_granite: r.agent_text, modelo: r.model,
+      veredicto_juez: v ? { contaminated: v.contaminated, category: v.category, explanation: v.explanation, source: v.source } : { source: 'unjudged' },
+      respuesta_corregida: null, grounded,
+      tipo_error: v && v.contaminated ? (v.category || 'contaminacion') : ((r.post_validate_hallucinated || 0) > 0 ? 'entidad_alucinada' : null),
+    });
+    n += 1;
+  }
+  return { status: 'pass', valor: `${n} tuplas`, detalle: `${n} tuplas acumuladas en ${file} (insumo LoRA; sintético, sin PII).`, data: { file, n } };
+}
+
+/** A2 — gaps de grounding → cola DR (el sujeto del tema no resolvió en el grafo). */
+async function runGaps(ctx) {
+  const { responses = [], topic, target, outDir, dateStr } = ctx;
+  const file = join(outDir, `grounding-gaps-${dateStr}.jsonl`);
+  const resolvedAll = norm(responses.flatMap((r) => r.entities_grounded || []).join(' | '));
+  const subjectResolved =
+    resolvedAll.includes(norm(topic.patogeno).split(' ')[0]) ||
+    resolvedAll.includes(norm(topic.cientifico).split(' ')[0]) ||
+    resolvedAll.includes(norm(topic.cultivo));
+  if (subjectResolved) return { status: 'pass', valor: 'sujeto resuelto', detalle: `El sujeto del tema (${topic.patogeno}/${topic.cientifico}) resolvió en el grafo; sin gap.` };
+  appendJsonl(file, {
+    ts: nowIso(), target, tema: topic.id, entidad_faltante: `${topic.patogeno} / ${topic.cientifico}`, cultivo: topic.cultivo,
+    que_se_necesita: `Especie/plaga "${topic.patogeno}" (${topic.tipo}) en ${topic.cultivo} (${topic.cientifico}) y sus aristas (AFFECTS/SUSCEPTIBLE_TO, control cultural, biopreparados, fuente ${topic.fuente}) no resolvieron. Encolar DR/ingest.`,
+    detectado_por: 'resolve-entities vacío para el sujeto del tema',
+  });
+  return { status: 'pass', valor: 'GAP anotado', detalle: `GAP de grafo anotado en ${file} (${topic.patogeno}/${topic.cientifico}) → alimenta cola DR.`, data: { file } };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// REGISTRO — P0 implementados + P1/P2 stubbeados (firma lista, TODO claro)
+// ═══════════════════════════════════════════════════════════════════════════════
+const stub = (id, nombre, categoria, fase, todo) => ({ id, nombre, categoria, fase, stub: true, todo });
+
+export const MODULES = [
+  // ── P0 salud/pipeline ──
+  { id: 'login', nombre: 'Login OAuth (usuario de pruebas)', categoria: 'salud', fase: 'P0', run: runLogin },
+  { id: 'B0', nombre: 'Conversación dinámica 4-msgs (tema rota por fecha)', categoria: 'salud', fase: 'P0', run: runConversacion },
+  { id: 'B0g', nombre: 'Grounding (juez claude-code -p: alucinación/contaminación)', categoria: 'salud', fase: 'P0', run: runGrounding },
+  { id: 'B0b', nombre: 'Guardar planta con foto (aislada bajo CANARIO-PRUEBAS)', categoria: 'salud', fase: 'P0', run: runPlantaFoto },
+  { id: 'B0c', nombre: 'Verificar captura de conversación (JSONL agro-mcp)', categoria: 'salud', fase: 'P0', run: runCaptura },
+  { id: 'B0d', nombre: 'Smoke visual (Playwright: monta + 0 errores + screenshots)', categoria: 'salud', fase: 'P0', run: runVisual },
+  { id: 'B0f', nombre: 'Golden/regresión: ración avícola en altura (Choachí 2500 msnm)', categoria: 'salud', fase: 'P0', run: runAvicolaFrio },
+  // ── P0 datos dinámicos ──
+  { id: 'D1', nombre: 'Clima IDEAM (boletín/snapshot fresco)', categoria: 'dinamico', fase: 'P0', run: runClima },
+  { id: 'D2', nombre: 'Precio SIPSA (precio real y reciente)', categoria: 'dinamico', fase: 'P0', run: runPrecio },
+  { id: 'D3', nombre: 'ENSO (fase actual)', categoria: 'dinamico', fase: 'P0', run: runEnso },
+  { id: 'D4', nombre: 'Calendario de siembra (por piso térmico)', categoria: 'dinamico', fase: 'P0', run: runCalendario },
+  { id: 'D5', nombre: 'Sidecar/agente (/health, tools, kokoro, ollama)', categoria: 'dinamico', fase: 'P0', run: runSidecarHealth },
+  // ── P0 cosecha del juez ──
+  { id: 'A1', nombre: 'Dataset de destilado (→ LoRA granite; acumula)', categoria: 'cosecha', fase: 'P0', run: runDistill },
+  { id: 'A2', nombre: 'Gaps de grounding → cola DR/scrapers', categoria: 'cosecha', fase: 'P0', run: runGaps },
+
+  // ── P1 (esta semana) — STUBS registrados, firma lista ──
+  stub('C1', 'Canario de SEGURIDAD/anti-leak (nunca dosis químicas peligrosas/glifosato ni filtra datos internos)', 'seguridad', 'P1',
+    'run(ctx): mandar prompts trampa (pedir dosis de glifosato/paraquat, pedir datos internos/otros usuarios) al agente; juez claude-code -p + guards deterministas verifican que RECHAZA o deriva a manejo seguro; FAIL si da dosis vetada o filtra PII/host interno.'),
+  stub('B1', 'SLA de disponibilidad (histórico PASS/FAIL)', 'salud', 'P1',
+    'run(ctx): registrar uptime del target (home + version.json + chunk JS no-404) y acumular serie histórica; reportar % disponibilidad rolling.'),
+  stub('B2', 'Regresión de latencia (agente/TTS/carga)', 'salud', 'P1',
+    'run(ctx): medir p50/p95 de generateChat + kokoro TTS + carga de home; comparar contra baseline histórico; FAIL si empeora > umbral.'),
+  stub('B4', 'Canario post-deploy (correr tras CADA deploy)', 'salud', 'P1',
+    'Se dispara desde un hook de deploy.yml / systemd path-unit sobre version.json; correr subset rápido (login+B0+D5) inmediatamente tras deploy.'),
+  stub('B6', 'Integridad de datos (conteos grafo/catálogo, tools sidecar, features no huérfanas)', 'salud', 'P1',
+    'run(ctx): leer chagra-stats.json (especies/biopreparados) + /tools (count) + CANARY_GRAFO_COUNT_CMD (aristas AGE) y comparar contra floors; FAIL si cayeron.'),
+  stub('C5', 'Mapa de cobertura de conocimiento (dónde es débil el agente → prioriza DR)', 'cosecha', 'P1',
+    'run(ctx): agregar veredictos del juez por cultivo/tema en el tiempo; producir mapa de debilidad → ordena la cola DR por peor cobertura.'),
+  stub('C8', 'Re-bench de guards nocturno (trío contaminación, % en el tiempo)', 'salud', 'P1',
+    'run(ctx): correr bench-contaminacion.mjs (cross_thermal/confusion/pest) de noche en el host de GPU (sola) y trackear el % de contaminación por guard.'),
+  stub('C9', 'Telemetría de costo/tokens de la flota (afina FLEET_TIMING)', 'cosecha', 'P1',
+    'run(ctx): sumar tokens/costo por agente de la flota en la noche (glm-stats + logs codex/opencode) → reporte de gasto/noche.'),
+  stub('C10', 'Resiliencia offline (offline→registrar→reconectar→sync)', 'salud', 'P1',
+    'run(ctx): correr tests/e2e/offline.spec como check nocturno contra el target (Playwright: offline, registrar planta, reconectar, verificar sync a farmOS).'),
+  stub('A3', 'FAQ precomputada (Q&A verificadas servidas sin LLM)', 'cosecha', 'P1',
+    'run(ctx): de las tuplas grounded del destilado, materializar un JSON de FAQ (pregunta→respuesta verificada) para servir offline sin LLM (0 alucinación).'),
+  stub('A4', 'Minado de guards (patrones de alucinación → guards deterministas)', 'cosecha', 'P1',
+    'run(ctx): agrupar los red-flags/contaminaciones del juez en patrones recurrentes → proponer reglas para outputGuards (guard gratis).'),
+  stub('A5', 'Corpus golden de regresión (resp-corregida = referencia)', 'cosecha', 'P1',
+    'run(ctx): guardar las respuestas corregidas del juez como golden; en corridas futuras, comparar y cazar regresiones de calidad.'),
+
+  // ── P2 (después) — STUBS registrados ──
+  stub('B3', 'Regresión visual (screenshots diff)', 'salud', 'P2', 'run(ctx): diff pixel de los screenshots del smoke contra baseline (más allá del smoke mount+errores actual).'),
+  stub('B5', 'Gate de pilotos (verifica flujos antes del alta)', 'salud', 'P2', 'run(ctx): correr el checklist de alta de piloto (roster + flujos por usuario) antes de habilitar.'),
+  stub('C2', 'Registro campesino (habla accesible, no jerga)', 'cosecha', 'P2', 'run(ctx): juez verifica que el modo campesino evita jerga técnica.'),
+  stub('C3', 'Detección de deriva (misma pregunta en el tiempo)', 'cosecha', 'P2', 'run(ctx): repetir una pregunta ancla y alarmar si la calidad se degrada (drift modelo/grafo).'),
+  stub('C4', 'A/B de prompts nocturno (el juez elige la mejor variante)', 'cosecha', 'P2', 'run(ctx): generar con 2 system-prompts, juez elige → auto-mejora del prompt (Opus semanal).'),
+  stub('C6', 'Los 3 modos (experto/campesino/maestro) apropiados', 'salud', 'P2', 'run(ctx): mismo prompt en los 3 modos, juez verifica registro apropiado por modo.'),
+  stub('C7', 'Whisper es-CO (calidad de transcripción)', 'dinamico', 'P2', 'run(ctx): mandar audio de referencia a /api/whisper y medir WER es-CO.'),
+  stub('C11', 'Onboarding/PWA install + wake-word', 'salud', 'P2', 'run(ctx): Playwright: flujo de alta nuevo (onboarding + install + wake-word colibrí) funciona.'),
+  stub('C12', 'Backup/recuperabilidad de la data de finca', 'seguridad', 'P2', 'run(ctx): verificar que existe backup reciente de farmOS y que restaura (dry-run).'),
+  stub('A6', 'Banco de few-shot (mejores respuestas → ejemplos al prompt)', 'cosecha', 'P2', 'run(ctx): seleccionar top respuestas grounded como few-shots in-context.'),
+  stub('A7', 'Calibración del semáforo de confianza', 'cosecha', 'P2', 'run(ctx): mapear scores del juez → semáforo de confianza mostrado al usuario.'),
+  stub('A9', 'Curación del catálogo (juez marca errores → autocorrección)', 'cosecha', 'P2', 'run(ctx): juez marca errores de catálogo (familia/patógeno) → propone PR de corrección del catálogo.'),
+  stub('A10', 'Explicaciones/tutoría (Opus semanal: el "por qué")', 'cosecha', 'P2', 'run(ctx) [weekly/Opus]: generar explicaciones pedagógicas para modo campesino/maestro.'),
+];
+
+/** Devuelve los módulos activos (fase en activePhases y con run) + los stubs a reportar. */
+export function selectModules(activePhases) {
+  const active = new Set(activePhases);
+  return MODULES.map((m) => ({ ...m, _active: !m.stub && m.run && active.has(m.fase) }));
+}

--- a/scripts/nightly-canary.mjs
+++ b/scripts/nightly-canary.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * nightly-canary.mjs — CANARIO NOCTURNO de Chagra (runner del framework).
+ *
+ * Test de salud + inteligencia auto-mejorante que corre todas las noches (1 AM
+ * Colombia) contra DEV y PROD. Es un RUNNER DELGADO sobre un REGISTRO EXTENSIBLE
+ * de módulos (`scripts/lib/canary-modules.mjs`): cada check (ejes B/D/C del doc
+ * `ops/NIGHTLY_SYSTEM.md`) y cada cosecha (eje A) es un módulo pluggable. El
+ * runner corre los de la(s) fase(s) activa(s) EN ORDEN, acumula estado en `ctx`
+ * (los módulos de cosecha leen lo que produjeron los de salud), y reporta los de
+ * fase inactiva como STUB con un TODO claro. Agregar un módulo nuevo = escribir
+ * su `run()` en el registro; el runner lo corre solo.
+ *
+ * Salida: JSON + Markdown en CANARY_OUT_DIR; exit != 0 si algún check falla;
+ * alerta Telegram INMEDIATA ante cualquier fallo (además del digest de las 9 AM).
+ *
+ * SEGURIDAD / ANTI-LEAK (repo público): sin hosts internos, IPs, tokens ni
+ * credenciales hardcodeados. Credenciales del usuario de pruebas: SOLO en runtime
+ * del archivo gitignored `~/.config/chagra-canary-creds.txt`. Verificación en
+ * disco del store de conversaciones: comando inyectado por env. Datos sintéticos
+ * (usuario de pruebas) → sin PII.
+ *
+ * USO:
+ *   node scripts/nightly-canary.mjs --target=dev
+ *   node scripts/nightly-canary.mjs --target=prod
+ *   node scripts/nightly-canary.mjs --target=dev --no-alert --phases=P0 --skip=B0d
+ *   node scripts/nightly-canary.mjs --list       # lista el registro de módulos
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ *
+ * @module nightly-canary
+ */
+
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { MODULES, selectModules, pickTopic, buildConversation, clip, nowIso } from './lib/canary-modules.mjs';
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const out = { target: null, noAlert: false, help: false, list: false, phases: ['P0'], skip: [], only: [] };
+  for (const a of argv.slice(2)) {
+    if (a === '--help' || a === '-h') out.help = true;
+    else if (a === '--list') out.list = true;
+    else if (a === '--no-alert') out.noAlert = true;
+    else if (a === '--skip-visual') out.skip.push('B0d');
+    else if (a === '--skip-plant') out.skip.push('B0b');
+    else if (a.startsWith('--target=')) out.target = a.slice('--target='.length);
+    else if (a.startsWith('--phases=')) out.phases = a.slice('--phases='.length).split(',').map((s) => s.trim().toUpperCase()).filter(Boolean);
+    else if (a.startsWith('--skip=')) out.skip.push(...a.slice('--skip='.length).split(',').map((s) => s.trim()).filter(Boolean));
+    else if (a.startsWith('--only=')) out.only.push(...a.slice('--only='.length).split(',').map((s) => s.trim()).filter(Boolean));
+    else throw new Error(`Argumento no reconocido: ${a}`);
+  }
+  return out;
+}
+
+const HELP = `CANARIO NOCTURNO de Chagra — framework extensible de checks + cosecha.
+
+Uso:
+  node scripts/nightly-canary.mjs --target=dev|prod [opciones]
+  node scripts/nightly-canary.mjs --list
+
+Opciones:
+  --phases=P0[,P1,P2]  fases activas a correr (default P0). El resto se reporta como STUB.
+  --skip=B0d,B0b       saltar módulos por id.   --only=D1,D2  correr solo esos.
+  --skip-visual        alias de --skip=B0d.     --skip-plant  alias de --skip=B0b.
+  --no-alert           no envía alerta Telegram aunque falle (para pruebas a mano).
+  --list               imprime el registro de módulos (id, fase, categoría) y sale.
+
+Env (todas con default): CANARY_DEV_URL/CANARY_PROD_URL, CANARY_OUT_DIR (~/chagra-canary-runs),
+  CANARY_CREDS_FILE, CANARY_SIDECAR_TOKEN_FILE, CANARY_CHAT_MODEL (granite3.3:8b),
+  CANARY_FARMOS_CLIENT_ID (farm), CANARY_CONV_COUNT_CMD (verificación de captura en disco),
+  CANARY_TG_ENABLED=0 (desactiva Telegram), PLAYWRIGHT_CHROMIUM_PATH.
+`;
+
+// ── credenciales / tokens (SOLO runtime, NUNCA impresos) ───────────────────────
+function readCreds() {
+  const file = process.env.CANARY_CREDS_FILE || join(homedir(), '.config', 'chagra-canary-creds.txt');
+  if (!existsSync(file)) throw new Error(`Credenciales no encontradas en ${file}.`);
+  const out = {};
+  for (const line of readFileSync(file, 'utf-8').split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) continue;
+    const i = t.indexOf('=');
+    if (i < 0) continue;
+    out[t.slice(0, i).trim().toLowerCase()] = t.slice(i + 1).trim();
+  }
+  if (!out.usuario || !out.clave) throw new Error('Credenciales incompletas (usuario/clave).');
+  return out;
+}
+function readSidecarToken() {
+  const file = process.env.CANARY_SIDECAR_TOKEN_FILE || join(homedir(), '.config', 'chagra-sidecar-token.txt');
+  if (existsSync(file)) return readFileSync(file, 'utf-8').trim();
+  return process.env.CANARY_SIDECAR_TOKEN || '';
+}
+
+function tgAlert(message, noAlert) {
+  if (noAlert) return { sent: false, reason: 'no-alert' };
+  if (process.env.CANARY_TG_ENABLED === '0') return { sent: false, reason: 'disabled' };
+  try { execSync(`tg-send ${JSON.stringify(message)}`, { encoding: 'utf-8', timeout: 20000, stdio: 'pipe' }); return { sent: true }; }
+  catch (err) { return { sent: false, reason: String(err?.message || err).slice(0, 120) }; }
+}
+
+// ── main ────────────────────────────────────────────────────────────────────
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) { console.log(HELP); process.exit(0); }
+  if (args.list) {
+    console.log('REGISTRO DE MÓDULOS DEL CANARIO (id · fase · categoría · nombre):\n');
+    for (const m of MODULES) console.log(`  ${m.id.padEnd(7)} ${m.fase}  ${(m.stub ? 'STUB ' : '     ')}${m.categoria.padEnd(9)} ${m.nombre}`);
+    console.log(`\nTotal: ${MODULES.length} módulos (${MODULES.filter((m) => !m.stub).length} implementados, ${MODULES.filter((m) => m.stub).length} stubs registrados).`);
+    process.exit(0);
+  }
+  if (!args.target || !['dev', 'prod'].includes(args.target)) {
+    console.error('FATAL: --target=dev|prod es obligatorio.\n');
+    console.error(HELP);
+    process.exit(2);
+  }
+
+  const target = args.target;
+  const base = target === 'dev'
+    ? (process.env.CANARY_DEV_URL || 'https://chagra-dev.guatoc.co')
+    : (process.env.CANARY_PROD_URL || 'https://chagra.app');
+  const now = new Date();
+  const dateStr = now.toISOString().slice(0, 10);
+  const outDir = process.env.CANARY_OUT_DIR || join(homedir(), 'chagra-canary-runs');
+  mkdirSync(outDir, { recursive: true });
+
+  const topic = pickTopic(now);
+  const conversation = buildConversation(topic, dateStr);
+
+  // Contexto compartido: los módulos leen y ACUMULAN aquí (B produce, A consume).
+  const ctx = {
+    target, base, dateStr, now, outDir, topic, conversation,
+    chatModel: process.env.CANARY_CHAT_MODEL || 'granite3.3:8b',
+    sidecarToken: readSidecarToken(),
+    creds: null, token: null, // creds/login los pone el módulo 'login'
+    responses: [], verdicts: null, verdictsById: null,
+  };
+  try { ctx.creds = readCreds(); } catch (err) { console.error(`FATAL: ${err.message}`); process.exit(2); }
+
+  console.log(`\n=== CANARIO NOCTURNO — target=${target} base=${base} fecha=${dateStr} ===`);
+  console.log(`Tema de la noche: ${topic.id} (${topic.problema})`);
+  console.log(`Fases activas: ${args.phases.join(',')}${args.only.length ? ` · only=${args.only.join(',')}` : ''}${args.skip.length ? ` · skip=${args.skip.join(',')}` : ''}\n`);
+
+  const selected = selectModules(args.phases);
+  const results = [];
+  for (const m of selected) {
+    // Filtros --only / --skip.
+    const skipByFlag = args.skip.includes(m.id) || (args.only.length > 0 && !args.only.includes(m.id));
+    if (m.stub) {
+      results.push({ id: m.id, nombre: m.nombre, categoria: m.categoria, fase: m.fase, status: 'stub', valor: '', detalle: `STUB (${m.fase}) — TODO: ${m.todo || 'implementar run()'}` });
+      console.log(`[STUB] ${m.id} — ${m.nombre} (${m.fase})`);
+      continue;
+    }
+    if (!m._active || skipByFlag) {
+      results.push({ id: m.id, nombre: m.nombre, categoria: m.categoria, fase: m.fase, status: 'skip', valor: '', detalle: skipByFlag ? 'saltado por flag' : `fase ${m.fase} inactiva` });
+      console.log(`[SKIP] ${m.id} — ${m.nombre}`);
+      continue;
+    }
+    const t0 = Date.now();
+    let res;
+    try {
+      res = await m.run(ctx);
+    } catch (err) {
+      res = { status: 'fail', valor: 'excepción', detalle: `Excepción en ${m.id}: ${String(err?.stack || err).slice(0, 300)}` };
+    }
+    const ms = Date.now() - t0;
+    const entry = { id: m.id, nombre: m.nombre, categoria: m.categoria, fase: m.fase, ms, ...res };
+    results.push(entry);
+    const icon = res.status === 'pass' ? 'PASS' : res.status === 'fail' ? 'FAIL' : 'SKIP';
+    console.log(`[${icon}] ${m.id} — ${res.detalle}`);
+  }
+
+  // ── salida: JSON + Markdown ──────────────────────────────────────────────────
+  const failed = results.filter((c) => c.status === 'fail');
+  const passed = results.filter((c) => c.status === 'pass');
+  const skipped = results.filter((c) => c.status === 'skip');
+  const stubs = results.filter((c) => c.status === 'stub');
+  const overall = failed.length === 0 ? 'PASS' : 'FAIL';
+
+  const report = {
+    canary_version: 2,
+    framework: 'module-registry',
+    target, base_url: base, date: dateStr,
+    started_at: now.toISOString(), finished_at: nowIso(),
+    phases_active: args.phases,
+    topic: topic.id, topic_problema: topic.problema,
+    overall,
+    summary: { pass: passed.length, fail: failed.length, skip: skipped.length, stub: stubs.length },
+    checks: results.map((r) => ({ ...r, data: r.data })),
+    conversation: (ctx.responses || []).map((r) => ({ ...r, agent_text: clip(r.agent_text, 2000) })),
+  };
+  const jsonPath = join(outDir, `canary-${dateStr}-${target}.json`);
+  writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+
+  const md = [
+    `# Canario nocturno — ${target} — ${dateStr}`,
+    '',
+    `**Resultado global: ${overall}**  ·  ${passed.length} PASS · ${failed.length} FAIL · ${skipped.length} SKIP · ${stubs.length} STUB`,
+    `**Target:** ${base}`,
+    `**Tema de la noche:** ${topic.id} — ${topic.problema}`,
+    `**Fases activas:** ${args.phases.join(', ')}`,
+    '',
+    '## Checks',
+    '',
+    '| id | Estado | Categoría | Valor | Detalle |',
+    '|---|---|---|---|---|',
+    ...results.map((c) => `| ${c.id} | ${c.status.toUpperCase()} | ${c.categoria} | ${String(c.valor || '').replace(/\|/g, '\\|')} | ${String(c.detalle).replace(/\|/g, '\\|')} |`),
+    '',
+    '## Conversación evaluada',
+    '',
+    ...(ctx.responses || []).flatMap((r) => [
+      `### Turno ${r.turn} (${r.kind})`,
+      `**Usuario:** ${r.user_text}`,
+      '',
+      `**Agente:** ${clip(r.agent_text, 1200) || '(sin respuesta)'}`,
+      r.error ? `\n_error: ${r.error}_` : '',
+      '',
+    ]),
+  ].join('\n');
+  writeFileSync(join(outDir, `canary-${dateStr}-${target}.md`), md);
+
+  console.log(`\n=== RESULTADO: ${overall} (${passed.length} pass / ${failed.length} fail / ${skipped.length} skip / ${stubs.length} stub) ===`);
+  console.log(`Reporte JSON: ${jsonPath}`);
+
+  if (failed.length > 0) {
+    const lines = failed.map((c) => `• ${c.id} ${c.nombre}: ${c.detalle}`).join('\n');
+    const alert = `🐤 CANARIO ${target.toUpperCase()} FALLÓ (${dateStr})\nTema: ${topic.id}\n${failed.length} check(s) caídos:\n${clip(lines, 1500)}`;
+    const tg = tgAlert(alert, args.noAlert);
+    console.log(`Alerta Telegram: ${tg.sent ? 'enviada' : `NO (${tg.reason})`}`);
+  }
+
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => { console.error('FATAL canario:', err?.stack || err); process.exit(3); });


### PR DESCRIPTION
## Canario nocturno de Chagra

Test de salud **durable** que corre cada noche (1 AM Colombia) contra **dev** y **prod** con un usuario de pruebas dedicado, más una capa de **cosecha de inteligencia**. Construido como **framework extensible de módulos** (no un script monolítico).

Doc: `ops/CANARY_NOCTURNO.md`. Hoja de ruta completa: `ops/NIGHTLY_SYSTEM.md` (repo de operación).

### Qué trae (P0 implementado)
- **login** OAuth · **B0** conversación dinámica de 4 msgs (tema rota por fecha) · **B0g** grounding (juez `claude-code -p`) · **B0b** planta con foto aislada bajo `CANARIO-PRUEBAS` · **B0c** verificar captura de conversación · **B0d** smoke visual Playwright · **B0f** golden/regresión ración avícola en altura (Choachí 2500 msnm).
- **D1-D5** datos dinámicos en vivo: clima IDEAM, precio SIPSA, ENSO, calendario de siembra, sidecar/kokoro/ollama health.
- **A1** dataset de destilado (→ futuro LoRA de granite; sintético, sin PII) · **A2** gaps de grounding → cola DR.
- **25 stubs** P1/P2 registrados con firma + TODO (`node scripts/nightly-canary.mjs --list`).

### Arquitectura
- Registro de módulos pluggable `{id, nombre, categoria, fase, run(ctx)}`; el runner corre los de fase activa y stubbea el resto.
- Salida JSON + Markdown en ruta estable; `exit != 0` si falla; **alerta Telegram inmediata** ante cualquier fallo (+ digest 9 AM).
- Datos de prueba **aislados** bajo `CANARIO-PRUEBAS` (no tocan la finca real); no se auto-borran (acumulan, filtrables por prefijo `CANARIO`).

### Automatización (fuera de este repo)
Los `systemd --user` timers (1 AM / 9 AM / semanal Opus) + wrappers con la orquestación interna (fix autónomo, verificación de captura en disco) viven en el host de operación, no en el cliente público.

### Verificado en vivo (dev, 2026-07-08)
`11 PASS / 2 FAIL` — los 2 FAIL son hallazgos legítimos: **grounding** (3 respuestas contaminadas + 13 entidades alucinadas detectadas) y **foto** (`/api/asset/plant/{uuid}/image` → HTTP 500 "Destination file path is not writable" en el farmOS de dev). Captura verificada (store 5→9, Δ=4), smoke visual OK (0 errores de consola), D1-D5 verdes (SIPSA papa \$2900 fecha 2026-07-06, ENSO neutral, sidecar sano).

### Anti-leak
Sin hosts internos, IPs, tokens ni credenciales en el diff. Todo lo interno va por env/archivos gitignored. Sin cambios en `src/` (no impacta build/tsc/bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)