### PR TITLE
feat(escucha): rediseño "presencia etérea" del overlay de escucha

### DIFF
--- a/scripts/escucha-shots.mjs
+++ b/scripts/escucha-shots.mjs
@@ -5,7 +5,7 @@
  * Reusa la infra de chagra-shot (visualTestUtils: determinismo + login + seed)
  * y el patrón NixOS (chromium del nix-store). El micrófono es el FAKE de
  * Chromium (--use-fake-device-for-media-capture): produce un tono real, así
- * que los anillos/brotes del iris se mueven con amplitud DE VERDAD.
+ * que los rayos/partículas del portal se mueven con amplitud DE VERDAD.
  *
  * Whisper se stubbea con context.route (NO page.route: el SW lo sombrea,
  * gotcha documentado) para poder capturar la fase "rumbo" sin backend.
@@ -79,7 +79,7 @@ async function abrirEscucha(page, fuente) {
     window.dispatchEvent(new CustomEvent('chagra:escucha', { detail: { fuente: f, ts: Date.now() } }));
   }, fuente);
   await page.waitForSelector('[data-testid="escucha-overlay"][data-fase="oyendo"]', { timeout: 15_000 });
-  // Deja correr el tono fake ~1.2s para que los brotes tengan historia real.
+  // Deja correr el tono fake ~1.2s para que los rayos tengan historia real.
   await page.waitForTimeout(1200);
 }
 
@@ -206,14 +206,21 @@ async function main() {
 
     // 1) FAB visible en una pantalla real (suelo). En el home NO hay FAB
     // (política AgentFab: el compositor del hero ya trae mic + botón Ⓐ).
+    // GOTCHA: el tap del FAB está DESHABILITADO en App.jsx (el trigger de
+    // usuarios es el wake-word) — si no está montado, se omite esa captura
+    // en vez de reventar (para capturarlo: descomentar <EscuchaFab /> local).
     await page.evaluate(() => {
       window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'suelo' } }));
     });
-    const fabShot = `${OUTDIR}/escucha-01-fab-${tema.id}.png`;
-    await page.waitForSelector('[data-testid="escucha-fab"]', { timeout: 20_000 });
     await page.waitForTimeout(4500); // deja cargar el chunk lazy de la vista
-    await page.screenshot({ path: fabShot });
-    hechas.push(fabShot);
+    const hayFab = await page.locator('[data-testid="escucha-fab"]').count() > 0;
+    if (hayFab) {
+      const fabShot = `${OUTDIR}/escucha-01-fab-${tema.id}.png`;
+      await page.screenshot({ path: fabShot });
+      hechas.push(fabShot);
+    } else {
+      console.warn(`[escucha-shots] FAB no montado (deshabilitado en App.jsx) — captura 01 omitida (${tema.id})`);
+    }
 
     // 2) Widget escuchando (tap)
     await abrirEscucha(page, 'tap');
@@ -228,6 +235,19 @@ async function main() {
       const wwShot = `${OUTDIR}/escucha-03-wakeword-biopunk.png`;
       await page.screenshot({ path: wwShot });
       hechas.push(wwShot);
+
+      // 3b) Fase "pensando" (solo VISUAL): se fuerza data-fase en el DOM para
+      // ver la animación de proceso sin depender del timing real de Whisper.
+      await page.evaluate(() => {
+        document.querySelector('[data-testid="escucha-overlay"]')?.setAttribute('data-fase', 'pensando');
+      });
+      await page.waitForTimeout(700);
+      const pensShot = `${OUTDIR}/escucha-03b-pensando-biopunk.png`;
+      await page.screenshot({ path: pensShot });
+      hechas.push(pensShot);
+      await page.evaluate(() => {
+        document.querySelector('[data-testid="escucha-overlay"]')?.setAttribute('data-fase', 'oyendo');
+      });
 
       // 4) Fase rumbo: "Lléveme al mercado" → "Abriendo Mercado…"
       await page.click('[data-testid="escucha-listo"]');

--- a/src/components/escucha/EscuchaFab.jsx
+++ b/src/components/escucha/EscuchaFab.jsx
@@ -4,10 +4,12 @@
  * Es el trigger de HOY (tap). El de MAÑANA es el wake-word "hola Chagra":
  * ambos llaman `activarEscucha()` (escuchaService) — el widget no distingue.
  *
- * Diseño: espejo del AgentFab (colibrí, abajo-derecha): este vive ABAJO A LA
- * IZQUIERDA, 62px (tamaño guante), micrófono grande + la ramita de la mano de
- * Chagra como firma, acento del tema por --t-accent-rgb, con un ping perezoso
- * cada 4s que anuncia "aquí se habla" (apagado con prefers-reduced-motion).
+ * Diseño: "LA PRESENCIA" en miniatura — un mini-portal de espacio profundo
+ * (mismo lenguaje del overlay): el marco lleva el acento del tema (Chagra),
+ * adentro un núcleo de luz suspendido LEVITA con dos motas en órbita, y el
+ * micrófono flota sobre la luz. Un pulso de presencia se dilata cada 4s
+ * ("aquí se habla" sin fastidiar; apagado con prefers-reduced-motion).
+ * Vive ABAJO A LA IZQUIERDA (espejo del AgentFab), 62px tamaño guante.
  *
  * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
  */
@@ -26,24 +28,26 @@ export default function EscuchaFab() {
       title="Manos libres: toque y hable — «lléveme al mercado» o pregunte lo que necesite"
       onClick={() => activarEscucha({ fuente: 'tap' })}
     >
-      <span className="escucha-fab-ping" aria-hidden="true" />
-      <Mic size={27} strokeWidth={2.4} aria-hidden="true" />
-      {/* La firma de la marca: la ramita con nodos que brota (mano de Chagra) */}
+      <span className="escucha-fab-pulso" aria-hidden="true" />
+      {/* El otro lado en miniatura: espacio + órbita + núcleo suspendido */}
+      <span className="escucha-fab-espacio" aria-hidden="true">
+        <span className="escucha-fab-orbita">
+          <span className="escucha-fab-mota escucha-fab-mota-a" />
+          <span className="escucha-fab-mota escucha-fab-mota-b" />
+        </span>
+        <span className="escucha-fab-nucleo" />
+      </span>
+      <Mic className="escucha-fab-mic" size={26} strokeWidth={2.4} aria-hidden="true" />
+      {/* La firma: un destello de 4 puntas — la Presencia deja su chispa */}
       <svg
-        className="escucha-fab-brotecito"
-        width="16"
-        height="16"
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
+        className="escucha-fab-destello"
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="currentColor"
         aria-hidden="true"
       >
-        <path d="M8 13V7" />
-        <path d="M8 7L5.6 4.8M8 7l2.3-2.4" />
-        <circle cx="4.9" cy="4" r="0.8" fill="currentColor" stroke="none" />
-        <circle cx="11" cy="3.8" r="0.8" fill="currentColor" stroke="none" />
+        <path d="M7 0.5 L8.3 5.7 L13.5 7 L8.3 8.3 L7 13.5 L5.7 8.3 L0.5 7 L5.7 5.7 Z" />
       </svg>
     </button>
   );

--- a/src/components/escucha/EscuchaOverlay.jsx
+++ b/src/components/escucha/EscuchaOverlay.jsx
@@ -15,17 +15,22 @@
  * reusa exactamente ese trigger sin tocar este archivo.
  *
  * MANOS LIBRES DE VERDAD: detección de silencio — cuando ya habló y calla
- * ~1.8s, la escucha se cierra sola (el arco que se cierra alrededor del iris
- * es ese conteo, feedback honesto). "Listo" y "Cancelar" quedan como respaldo
- * táctil tamaño guante.
+ * ~1.8s, la escucha se cierra sola (el sello de luz que se cierra alrededor
+ * del portal es ese conteo, feedback honesto). "Listo" y "Cancelar" quedan
+ * como respaldo táctil tamaño guante.
  *
- * Visual: "la mano que escucha" — ManoChagraGlyph al centro de un iris de
- * micelio cuyos anillos y brotes respiran con el RMS REAL del micrófono
- * (audioLevel/amplitudeHistory del recorder — nada de animación fingida).
+ * Visual: "LA PRESENCIA" — un portal circular a otra dimensión. El marco es
+ * de Chagra (acento del tema); adentro hay espacio profundo, un núcleo de luz
+ * suspendido (un OJO de energía con la mano de Chagra en la pupila), geometría
+ * sagrada que respira, y un campo de partículas que vive en CAOS y se ORDENA
+ * en anillos cuando usted habla: el parámetro de orden es el RMS REAL del
+ * micrófono (audioLevel/amplitudeHistory del recorder — nada de animación
+ * fingida). El espectro radial se espeja izquierda/derecha: la voz dibuja un
+ * mandala de luz, no ruido.
  *
  * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
  */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { X, Mic, Keyboard, CornerUpRight, AlertTriangle } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe, queueForRetry } from '../../services/voiceService';
@@ -49,80 +54,229 @@ const MIN_ESCUCHA_MS = 1500;
 const TOPE_ESCUCHA_MS = 25000; // por debajo del hard-limit (30s) del recorder
 const PAUSA_RUMBO_MS = 1000;   // deja LEER "Abriendo Mercado…" antes de saltar
 
-const NUM_BROTES = 28;
-
 const formatoSegundos = (ms) => `${(ms / 1000).toFixed(0)}s`;
 
 const navegar = (view, initialData = null) => {
   window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view, initialData } }));
 };
 
+/* ============================================================================
+ * LA PRESENCIA — geometría del portal (módulo: se calcula UNA vez).
+ * ========================================================================== */
+const VB = 260;   // lado del viewBox cuadrado
+const CTR = 130;  // centro
+const NUM_RAYOS = 44;      // espectro radial (espejado → mandala)
+const NUM_PARTICULAS = 36; // campo caos→orden
+
+/** Pseudo-azar determinista (sin Math.random: capturas y tests reproducibles). */
+const azar = (i, sal) => {
+  const s = Math.sin(i * 127.1 + sal * 311.7) * 43758.5453;
+  return s - Math.floor(s);
+};
+
 /**
- * Iris de micelio: 3 anillos que respiran con el RMS + brotes radiales con la
- * historia de amplitud + arco de cierre (conteo de silencio). Todo dato real.
+ * Campo de partículas: cada una tiene una posición CAÓTICA (reposo, deriva) y
+ * una posición ORDENADA (anillos concéntricos). El RMS real interpola entre
+ * ambas: hablar = el caos se ordena. Esa es la firma del diseño.
  */
-function IrisEscucha({ nivel, historia, fase, cierre }) {
-  const C = 116; // centro del viewBox 232x232
-  const brotes = [];
-  const muestras = historia.slice(-NUM_BROTES);
-  for (let i = 0; i < NUM_BROTES; i++) {
-    const m = muestras[i] ?? 0;
-    const ang = (i / NUM_BROTES) * Math.PI * 2 - Math.PI / 2;
-    const r0 = 78;
-    const largo = fase === FASE_OYENDO ? 5 + m * 26 : 5;
-    const x1 = C + Math.cos(ang) * r0;
-    const y1 = C + Math.sin(ang) * r0;
-    const x2 = C + Math.cos(ang) * (r0 + largo);
-    const y2 = C + Math.sin(ang) * (r0 + largo);
-    brotes.push(
+const PARTICULAS = Array.from({ length: NUM_PARTICULAS }, (_, i) => {
+  const aCaos = azar(i, 1) * Math.PI * 2;
+  const rCaos = 40 + azar(i, 2) * 66;
+  const anillo = i % 3;
+  const porAnillo = NUM_PARTICULAS / 3;
+  const aOrden = (Math.floor(i / 3) / porAnillo) * Math.PI * 2 + anillo * (Math.PI / porAnillo);
+  const rOrden = 66 + anillo * 12;
+  return {
+    cx: CTR + Math.cos(aCaos) * rCaos,
+    cy: CTR + Math.sin(aCaos) * rCaos,
+    ox: CTR + Math.cos(aOrden) * rOrden,
+    oy: CTR + Math.sin(aOrden) * rOrden,
+    r: 1.1 + azar(i, 3) * 1.5,
+    tono: i % 3, // 0 blanco lunar, 1 cian, 2 violeta
+  };
+});
+
+/** Estrellas fijas del espacio profundo (fondo del portal). */
+const ESTRELLAS = Array.from({ length: 18 }, (_, i) => {
+  const a = azar(i, 5) * Math.PI * 2;
+  const r = 20 + azar(i, 6) * 86;
+  return {
+    x: +(CTR + Math.cos(a) * r).toFixed(1),
+    y: +(CTR + Math.sin(a) * r).toFixed(1),
+    rad: +(0.5 + azar(i, 7) * 0.9).toFixed(2),
+    o: +(0.15 + azar(i, 8) * 0.5).toFixed(2),
+    titila: i % 5 === 0,
+  };
+});
+
+const poligono = (lados, radio, rot = 0) =>
+  Array.from({ length: lados }, (_, i) => {
+    const a = (i / lados) * Math.PI * 2 + rot;
+    return `${(CTR + Math.cos(a) * radio).toFixed(1)},${(CTR + Math.sin(a) * radio).toFixed(1)}`;
+  }).join(' ');
+
+/* Geometría SAGRADA (no HUD): un hexagrama — dos triángulos entrelazados —
+ * más un anillo de nodos (semilla-de-vida) y un aro limpio. La compuerta de
+ * la Presencia respira y contra-rota; los nodos son la retícula del portal. */
+const GEO_TRI_A = poligono(3, 94, -Math.PI / 2);
+const GEO_TRI_B = poligono(3, 94, Math.PI / 2);
+const NODOS = Array.from({ length: 12 }, (_, i) => {
+  const a = (i / 12) * Math.PI * 2 - Math.PI / 2;
+  return { x: +(CTR + Math.cos(a) * 96).toFixed(1), y: +(CTR + Math.sin(a) * 96).toFixed(1) };
+});
+
+/**
+ * El portal de la Presencia: espacio profundo + geometría sagrada + campo de
+ * partículas caos→orden + espectro-mandala + núcleo de luz (ojo de energía)
+ * con la mano de Chagra en la pupila. TODO el movimiento reactivo es dato real
+ * (RMS/amplitud del micrófono); el resto es respiración ambiental CSS.
+ */
+function PortalPresencia({ nivel, historia, fase, cierre }) {
+  const oyendo = fase === FASE_OYENDO;
+
+  // Movimiento reducido → composición estática y legible: campo ordenado,
+  // espectro en patrón fijo, sin deriva. El sello de cierre (informativo) queda.
+  const reducida = useMemo(
+    () => typeof window !== 'undefined' && !!window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches,
+    [],
+  );
+
+  // Orden del campo (0 = caos, 1 = anillos): promedio corto del RMS real —
+  // sube rápido al hablar, cae suave al callar. Pensando/rumbo = orden pleno
+  // (la energía "procesa" ya recompuesta).
+  let orden;
+  if (reducida || fase === FASE_PENSANDO || fase === FASE_RUMBO) {
+    orden = 1;
+  } else if (!oyendo) {
+    orden = 0.1;
+  } else {
+    const cola = historia.slice(-9);
+    const prom = cola.length ? cola.reduce((s, v) => s + v, 0) / cola.length : 0;
+    orden = Math.max(0.08, Math.min(1, prom * 2.6 + nivel * 0.5));
+  }
+
+  // Espectro radial ESPEJADO (mandala): las muestras reales de amplitud se
+  // reflejan izquierda/derecha — la voz dibuja simetría, no ruido.
+  const mitad = NUM_RAYOS / 2;
+  const muestras = historia.slice(-mitad);
+  const rayos = [];
+  for (let i = 0; i < NUM_RAYOS; i++) {
+    const j = i < mitad ? i : NUM_RAYOS - 1 - i;
+    const m = oyendo && !reducida ? (muestras[j] ?? 0) : 0;
+    const ang = (i / NUM_RAYOS) * Math.PI * 2 - Math.PI / 2;
+    const r0 = 60;
+    const largo = reducida && oyendo ? 10 + (j % 4) * 4 : (oyendo ? 5 + m * 40 : 3);
+    const x1 = CTR + Math.cos(ang) * r0;
+    const y1 = CTR + Math.sin(ang) * r0;
+    const x2 = CTR + Math.cos(ang) * (r0 + largo);
+    const y2 = CTR + Math.sin(ang) * (r0 + largo);
+    const tono = i % 3;
+    rayos.push(
       <line
-        key={i}
-        className="escucha-brote"
+        key={`g${i}`}
+        className={`escucha-rayo-glow escucha-tono-${tono}`}
         x1={x1} y1={y1} x2={x2} y2={y2}
-        strokeWidth={i % 4 === 0 ? 3 : 2}
-        opacity={0.35 + m * 0.65}
+        strokeWidth={6}
+        opacity={0.1 + m * 0.4}
+      />,
+      <line
+        key={`r${i}`}
+        className={`escucha-rayo escucha-tono-${tono}`}
+        x1={x1} y1={y1} x2={x2} y2={y2}
+        strokeWidth={i % 4 === 0 ? 2.2 : 1.3}
+        opacity={0.42 + m * 0.58}
       />,
     );
   }
 
-  // Arco de cierre: circunferencia r=110; se va DIBUJANDO con el silencio.
-  const rArco = 110;
-  const circArco = 2 * Math.PI * rArco;
+  // Sello de silencio: el aro de luz que se cierra alrededor del portal
+  // (conteo honesto de "ya lo oí, cierro si se queda callado").
+  const rSello = 108;
+  const circSello = 2 * Math.PI * rSello;
+  const escala = 1 + (oyendo ? nivel * 0.35 : 0);
 
-  const vivo = fase === FASE_OYENDO;
   return (
-    <div className="escucha-iris" aria-hidden="true">
-      <svg viewBox="0 0 232 232">
-        {/* Anillos de micelio: respiración = RMS real, cada uno a su ritmo */}
-        {[{ r: 58, k: 26, o: 0.5 }, { r: 68, k: 16, o: 0.35 }, { r: 78, k: 8, o: 0.25 }].map(({ r, k, o }, i) => (
+    <div className="escucha-portal" aria-hidden="true">
+      {/* La ventana al otro lado: espacio profundo con estrellas fijas */}
+      <div className="escucha-espacio">
+        <svg viewBox={`0 0 ${VB} ${VB}`}>
+          {ESTRELLAS.map((e, i) => (
+            <circle
+              key={i}
+              className={e.titila ? 'escucha-estrella escucha-estrella-titila' : 'escucha-estrella'}
+              cx={e.x} cy={e.y} r={e.rad} opacity={e.o}
+            />
+          ))}
+        </svg>
+      </div>
+
+      {/* Compuerta de geometría SAGRADA: hexagrama (dos triángulos entrelazados)
+          con dispersión cromática + anillo de nodos semilla-de-vida contra-
+          rotando. Pensando acelera ambos: la energía procesa. */}
+      <svg className="escucha-geo escucha-geo-a" viewBox={`0 0 ${VB} ${VB}`}>
+        <polygon points={GEO_TRI_A} className="escucha-geo-fantasma-a" transform={`rotate(2 ${CTR} ${CTR})`} />
+        <polygon points={GEO_TRI_B} className="escucha-geo-fantasma-b" transform={`rotate(-2 ${CTR} ${CTR})`} />
+        <polygon points={GEO_TRI_A} className="escucha-geo-linea" />
+        <polygon points={GEO_TRI_B} className="escucha-geo-linea" />
+      </svg>
+      <svg className="escucha-geo escucha-geo-b" viewBox={`0 0 ${VB} ${VB}`}>
+        <circle cx={CTR} cy={CTR} r="96" className="escucha-geo-aro" />
+        {NODOS.map((n, i) => (
+          <circle key={i} cx={n.x} cy={n.y} r={i % 3 === 0 ? 2.4 : 1.5} className="escucha-geo-nodo" />
+        ))}
+      </svg>
+
+      {/* Campo de partículas: caos ⇄ orden con el RMS real (deriva lenta CSS) */}
+      <svg className="escucha-campo" viewBox={`0 0 ${VB} ${VB}`}>
+        {PARTICULAS.map((p, i) => (
           <circle
             key={i}
-            className="escucha-anillo"
-            cx={C} cy={C} r={r}
-            fill="none"
-            stroke={`rgba(var(--esc-linea-rgb), ${o + (vivo ? nivel * 0.4 : 0)})`}
-            strokeWidth={i === 0 ? 2.5 : 1.5}
-            strokeDasharray={i === 2 ? '3 7' : i === 1 ? '10 6' : 'none'}
-            style={{ transform: vivo ? `scale(${1 + nivel * (k / 100)})` : 'scale(1)' }}
+            className={`escucha-particula escucha-tono-${p.tono}`}
+            cx={p.cx + (p.ox - p.cx) * orden}
+            cy={p.cy + (p.oy - p.cy) * orden}
+            r={p.r}
+            opacity={0.25 + orden * 0.55}
           />
         ))}
-        {brotes}
-        {/* Conteo de silencio: el aro exterior se cierra → "ya casi termino de oír" */}
-        {vivo && cierre > 0 && (
-          <circle
-            className="escucha-arco-cierre"
-            cx={C} cy={C} r={rArco}
-            fill="none"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeDasharray={circArco}
-            strokeDashoffset={circArco * (1 - cierre)}
-            transform={`rotate(-90 ${C} ${C})`}
-          />
+      </svg>
+
+      {/* Espectro-mandala + sello de silencio (capa que NO rota) */}
+      <svg className="escucha-mandala" viewBox={`0 0 ${VB} ${VB}`}>
+        {rayos}
+        {oyendo && cierre > 0 && (
+          <>
+            <circle
+              className="escucha-sello-glow"
+              cx={CTR} cy={CTR} r={rSello}
+              fill="none"
+              strokeWidth="7"
+              strokeLinecap="round"
+              strokeDasharray={circSello}
+              strokeDashoffset={circSello * (1 - cierre)}
+              transform={`rotate(-90 ${CTR} ${CTR})`}
+            />
+            <circle
+              className="escucha-sello"
+              cx={CTR} cy={CTR} r={rSello}
+              fill="none"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeDasharray={circSello}
+              strokeDashoffset={circSello * (1 - cierre)}
+              transform={`rotate(-90 ${CTR} ${CTR})`}
+            />
+          </>
         )}
       </svg>
-      <div className="escucha-mano">
-        <ManoChagraGlyph size={54} />
+
+      {/* El núcleo: un OJO de energía. Halo volumétrico + iris de luz con su
+          anillo de apertura + la mano de Chagra en la pupila — alguien está
+          ahí, mirando. Escala = RMS real. */}
+      <div className="escucha-nucleo" style={{ transform: `scale(${escala.toFixed(3)})` }}>
+        <span className="escucha-nucleo-halo" />
+        <span className="escucha-nucleo-luz" />
+        <span className="escucha-nucleo-apertura" />
+        <ManoChagraGlyph size={46} className="escucha-nucleo-mano" />
       </div>
     </div>
   );
@@ -265,7 +419,7 @@ export default function EscuchaOverlay() {
   // audioLevel: si dependiera, el re-render de cada frame lo recrearía antes
   // de cumplirse los 120ms y el conteo de silencio jamás dispararía. Si ya
   // habló y lleva SILENCIO_MS callado, cerramos solos; el progreso alimenta
-  // el arco de cierre del iris.
+  // el sello de cierre del portal.
   useEffect(() => {
     if (fase !== FASE_OYENDO) return undefined;
     const timer = setInterval(() => {
@@ -320,7 +474,7 @@ export default function EscuchaOverlay() {
           {fuente === 'wakeword' ? 'Escuché «hola Chagra»' : 'Escucha manos libres'}
         </div>
 
-        <IrisEscucha nivel={audioLevel} historia={amplitudeHistory} fase={fase} cierre={cierre} />
+        <PortalPresencia nivel={audioLevel} historia={amplitudeHistory} fase={fase} cierre={cierre} />
 
         <h2 className="escucha-titulo" data-testid="escucha-estado" aria-live="polite">
           {fase === FASE_ERROR && <AlertTriangle size={22} style={{ display: 'inline', verticalAlign: '-3px', marginRight: 6 }} />}

--- a/src/components/escucha/escucha.css
+++ b/src/components/escucha/escucha.css
@@ -1,14 +1,20 @@
 /* ============================================================================
  * escucha.css — Widget "Chagra está escuchando" (escucha manos libres).
  *
- * Estética: "la mano que escucha" — la mano de Chagra al centro de un iris
- * de micelio que respira con el nivel REAL del micrófono. Biopunk por
- * defecto; en temas claros (minimalista/nature/verde-vivo) el velo pasa a
- * papel del tema con tinta oscura (AA al sol).
+ * Estética: "LA PRESENCIA" — el widget es un portal circular a otra
+ * dimensión. El MARCO es de Chagra (acento del tema, --t-accent-rgb); lo que
+ * hay ADENTRO no es de aquí: espacio profundo, un núcleo de luz suspendido
+ * (un OJO de energía), geometría sagrada que respira, y un campo de partículas
+ * que se ordena con la voz (RMS real). La carta alrededor sigue las reglas del
+ * app: papel del tema en temas claros (AA al sol), tinta legible, botones
+ * tamaño guante.
  *
- * Tokens: TODO el acento sale de --t-accent-rgb (themes.css). Este archivo
- * solo define superficie/tinta del overlay por tema (indirección CSS-var,
- * NUNCA parche clase-por-clase).
+ * Luz espectral de la Presencia (cian/violeta/blanco lunar): es SUYA, no del
+ * tema — la entidad trae su propia luz. El portal siempre es oscuro por
+ * dentro, así el contraste de la luz está garantizado en cualquier tema.
+ *
+ * GPU-friendly: solo transform/opacity animados; nada de filter/blur en
+ * animación. prefers-reduced-motion → composición estática y legible.
  * ========================================================================== */
 
 .escucha-overlay {
@@ -17,9 +23,13 @@
   --esc-carta-rgb: 8, 22, 19;       /* superficie de la carta */
   --esc-ink-rgb: 236, 253, 245;     /* tinta principal */
   --esc-dim-rgb: 148, 187, 173;     /* tinta secundaria */
-  --esc-linea-rgb: 25, 201, 154;    /* trazos del iris (= acento biopunk) */
-  --esc-linea-rgb: var(--t-accent-rgb);
+  --esc-linea-rgb: var(--t-accent-rgb); /* acento del tema (marco/CTA) */
   --esc-cta-ink: #04231b;           /* tinta sobre el botón de acento */
+
+  /* La luz de la Presencia (propia, no del tema) */
+  --pre-a-rgb: 120, 235, 255;       /* cian etéreo */
+  --pre-b-rgb: 178, 140, 255;       /* violeta */
+  --pre-w-rgb: 240, 250, 255;       /* blanco lunar */
 
   position: fixed;
   inset: 0;
@@ -31,7 +41,15 @@
   padding-bottom: max(16px, env(safe-area-inset-bottom));
 }
 
-/* Temas claros: papel del tema + tinta oscura (legible a pleno sol). */
+/* Error: la luz de la Presencia vira a ámbar (aviso sin gritar). */
+.escucha-overlay[data-fase="error"] {
+  --pre-a-rgb: 255, 200, 120;
+  --pre-b-rgb: 255, 145, 95;
+  --pre-w-rgb: 255, 244, 228;
+}
+
+/* Temas claros: papel del tema + tinta oscura (legible a pleno sol).
+ * El portal NO cambia: adentro siempre es el otro lado (oscuro). */
 [data-theme="minimalista"] .escucha-overlay {
   --esc-bg-rgb: 246, 243, 236;
   --esc-carta-rgb: 252, 250, 245;
@@ -59,7 +77,7 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(ellipse 120% 80% at 50% 30%, rgba(var(--esc-linea-rgb), 0.10), transparent 60%),
+    radial-gradient(ellipse 120% 80% at 50% 30%, rgba(var(--pre-b-rgb), 0.08), transparent 60%),
     rgba(var(--esc-bg-rgb), 0.96);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
@@ -80,7 +98,7 @@
   border: 1px solid rgba(var(--esc-linea-rgb), 0.35);
   box-shadow:
     0 24px 80px rgba(0, 0, 0, 0.45),
-    0 0 60px rgba(var(--esc-linea-rgb), 0.18);
+    0 0 60px rgba(var(--pre-b-rgb), 0.14);
   color: rgb(var(--esc-ink-rgb));
   animation: escucha-entra 0.28s cubic-bezier(0.34, 1.4, 0.64, 1) both;
 }
@@ -115,56 +133,176 @@
   100% { box-shadow: 0 0 0 0 rgba(var(--esc-linea-rgb), 0); }
 }
 
-/* --- El iris (la mano que escucha) --------------------------------------- */
-.escucha-iris {
+/* ============================================================================
+ * EL PORTAL — la ventana circular al otro lado.
+ * Capas (atrás→adelante): espacio con estrellas · geometría sagrada · campo
+ * de partículas (caos⇄orden, deriva lenta) · espectro-mandala + sello ·
+ * núcleo de luz (ojo de energía) con la mano de Chagra en la pupila.
+ * ========================================================================== */
+.escucha-portal {
   position: relative;
-  width: 232px;
-  height: 232px;
+  width: 250px;
+  height: 250px;
   display: grid;
   place-items: center;
   margin: 2px 0;
 }
-.escucha-iris svg { position: absolute; inset: 0; overflow: visible; }
+.escucha-portal > svg,
+.escucha-espacio > svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
 
-/* Anillos de micelio: el scale lo pone el JSX con el RMS real; acá solo
- * la transición corta para que el movimiento se sienta orgánico. */
-.escucha-anillo {
+/* El espacio profundo: siempre oscuro — la luz de adentro no es del tema.
+ * Doble marco: hilo del acento (Chagra) afuera, aliento cian en el borde. */
+.escucha-espacio {
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 38%,
+    #141838 0%, #0b0d24 45%, #060713 76%, #030309 100%);
+  border: 1px solid rgba(var(--pre-a-rgb), 0.35);
+  box-shadow:
+    inset 0 0 34px rgba(var(--pre-b-rgb), 0.20),
+    inset 0 -20px 44px rgba(var(--pre-a-rgb), 0.07),
+    0 0 44px rgba(var(--pre-b-rgb), 0.28),
+    0 0 0 4px rgba(var(--esc-carta-rgb), 0.9),
+    0 0 0 5px rgba(var(--esc-linea-rgb), 0.45);
+}
+.escucha-estrella { fill: rgb(var(--pre-w-rgb)); }
+.escucha-estrella-titila { animation: escucha-titila 3.8s ease-in-out infinite; }
+@keyframes escucha-titila {
+  0%, 100% { opacity: 0.15; }
+  50%      { opacity: 0.75; }
+}
+
+/* Geometría sagrada: rotación lentísima en reposo; PENSANDO la acelera y
+ * contra-rota — la energía procesa. Fantasmas cian/violeta = dispersión
+ * cromática (luz que no enfoca del todo en este plano). */
+.escucha-geo {
+  fill: none;
   transform-origin: center;
-  transition: transform 0.09s ease-out, opacity 0.2s ease;
+  overflow: visible;
 }
-.escucha-brote {
-  transition: opacity 0.15s ease;
-  stroke: rgb(var(--esc-linea-rgb));
+.escucha-geo-a { animation: escucha-gira 80s linear infinite; }
+.escucha-geo-b { animation: escucha-gira-rev 55s linear infinite; }
+.escucha-overlay[data-fase="pensando"] .escucha-geo-a { animation: escucha-gira 7s linear infinite; }
+.escucha-overlay[data-fase="pensando"] .escucha-geo-b { animation: escucha-gira-rev 4.5s linear infinite; }
+@keyframes escucha-gira     { from { transform: rotate(0deg); }   to { transform: rotate(360deg); } }
+@keyframes escucha-gira-rev { from { transform: rotate(360deg); } to { transform: rotate(0deg); } }
+.escucha-geo-linea      { stroke: rgba(var(--pre-w-rgb), 0.34); stroke-width: 1; }
+.escucha-geo-fantasma-a { stroke: rgba(var(--pre-a-rgb), 0.26); stroke-width: 1; }
+.escucha-geo-fantasma-b { stroke: rgba(var(--pre-b-rgb), 0.26); stroke-width: 1; }
+.escucha-geo-aro  { fill: none; stroke: rgba(var(--pre-a-rgb), 0.20); stroke-width: 1; }
+.escucha-geo-nodo { fill: rgba(var(--pre-a-rgb), 0.65); }
+
+/* Campo de partículas: la posición caos⇄orden la pone el JSX con el RMS
+ * real; acá solo la deriva ambiental (rotación lenta del plano entero) y el
+ * remolino de PENSANDO (espiral hacia el centro). */
+.escucha-campo {
+  transform-origin: center;
+  animation: escucha-gira 90s linear infinite;
+}
+.escucha-overlay[data-fase="pensando"] .escucha-campo {
+  animation: escucha-remolino 5s linear infinite;
+}
+@keyframes escucha-remolino {
+  0%   { transform: rotate(0deg) scale(1); }
+  50%  { transform: rotate(180deg) scale(0.86); }
+  100% { transform: rotate(360deg) scale(1); }
+}
+.escucha-particula { transition: opacity 0.2s ease; }
+
+/* Tonos espectrales (partículas y rayos): la dispersión de la Presencia. */
+.escucha-tono-0 { fill: rgb(var(--pre-w-rgb)); stroke: rgb(var(--pre-w-rgb)); }
+.escucha-tono-1 { fill: rgb(var(--pre-a-rgb)); stroke: rgb(var(--pre-a-rgb)); }
+.escucha-tono-2 { fill: rgb(var(--pre-b-rgb)); stroke: rgb(var(--pre-b-rgb)); }
+
+/* Espectro-mandala: doble trazo (aliento ancho + filo fino) por rayo. */
+.escucha-mandala { overflow: visible; }
+.escucha-rayo,
+.escucha-rayo-glow {
+  fill: none;
   stroke-linecap: round;
+  transition: opacity 0.15s ease;
 }
-.escucha-arco-cierre {
-  stroke: rgb(var(--esc-ink-rgb));
-  opacity: 0.85;
+
+/* Sello de silencio: aro de luz blanca que se cierra (conteo honesto). */
+.escucha-sello {
+  stroke: rgb(var(--pre-w-rgb));
+  opacity: 0.9;
+  transition: stroke-dashoffset 0.15s linear;
+}
+.escucha-sello-glow {
+  stroke: rgba(var(--pre-a-rgb), 0.35);
   transition: stroke-dashoffset 0.15s linear;
 }
 
-/* La mano al centro: disco propio + glifo con el acento del tema. */
-.escucha-mano {
+/* El núcleo: un OJO de energía. Halo volumétrico (violeta) + cuerpo de luz
+ * (iris cian-blanco) + anillo de apertura brillante + la mano de Chagra como
+ * pupila oscura: alguien está ahí, mirando. El scale lo pone el JSX (RMS). */
+.escucha-nucleo {
   position: relative;
   z-index: 2;
-  width: 96px;
-  height: 96px;
-  border-radius: 50%;
+  width: 92px;
+  height: 92px;
   display: grid;
   place-items: center;
-  color: rgb(var(--esc-linea-rgb));
-  background:
-    radial-gradient(circle at 32% 28%, rgba(var(--esc-linea-rgb), 0.22), transparent 62%),
-    rgba(var(--esc-carta-rgb), 0.95);
-  border: 2px solid rgba(var(--esc-linea-rgb), 0.55);
-  box-shadow: 0 0 34px rgba(var(--esc-linea-rgb), 0.35);
+  transition: transform 0.09s ease-out;
 }
-.escucha-overlay[data-fase="pensando"] .escucha-mano {
-  animation: escucha-piensa 1.4s ease-in-out infinite;
+.escucha-nucleo-halo {
+  position: absolute;
+  inset: -30px;
+  border-radius: 50%;
+  background: radial-gradient(circle,
+    rgba(var(--pre-b-rgb), 0.30) 0%,
+    rgba(var(--pre-b-rgb), 0.10) 42%,
+    transparent 70%);
+  animation: escucha-respira 5s ease-in-out infinite;
 }
-@keyframes escucha-piensa {
-  0%, 100% { box-shadow: 0 0 22px rgba(var(--esc-linea-rgb), 0.25); }
-  50%      { box-shadow: 0 0 48px rgba(var(--esc-linea-rgb), 0.55); }
+@keyframes escucha-respira {
+  0%, 100% { transform: scale(1);    opacity: 0.85; }
+  50%      { transform: scale(1.12); opacity: 1; }
+}
+.escucha-nucleo-luz {
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 46%,
+    rgba(var(--pre-w-rgb), 0.55) 0%,
+    rgba(255, 255, 255, 0.94) 30%,
+    rgba(var(--pre-a-rgb), 0.60) 56%,
+    rgba(var(--pre-b-rgb), 0.20) 78%,
+    transparent 90%);
+  box-shadow:
+    0 0 34px rgba(var(--pre-a-rgb), 0.45),
+    0 0 80px rgba(var(--pre-b-rgb), 0.30);
+}
+.escucha-nucleo-apertura {
+  position: absolute;
+  inset: 11px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(255, 255, 255, 0.85);
+  box-shadow:
+    0 0 14px rgba(var(--pre-a-rgb), 0.7),
+    inset 0 0 10px rgba(var(--pre-a-rgb), 0.5);
+  pointer-events: none;
+}
+.escucha-nucleo-mano {
+  position: relative;
+  z-index: 1;
+  color: #0a0d24; /* pupila: silueta oscura en la luz */
+  opacity: 0.95;
+}
+.escucha-overlay[data-fase="pensando"] .escucha-nucleo {
+  animation: escucha-nucleo-procesa 1.6s ease-in-out infinite;
+}
+@keyframes escucha-nucleo-procesa {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.09); }
 }
 
 /* --- Título de estado (legible al sol: enorme y extrabold) ---------------- */
@@ -287,11 +425,17 @@
 
 /* ============================================================================
  * EscuchaFab — botón flotante persistente (el tap de HOY).
- * Espejo del AgentFab (colibrí, derecha): este vive a la IZQUIERDA, tamaño
- * guante (62px), acento del tema, con un ping suave que anuncia "aquí se
- * habla". El wake-word de mañana NO lo necesita — llama activarEscucha().
+ * "La Presencia" en miniatura: marco del tema (Chagra) + espacio profundo
+ * adentro + núcleo de luz que LEVITA con dos motas en órbita. Tamaño guante
+ * (62px), abajo a la IZQUIERDA (espejo del AgentFab). El wake-word de mañana
+ * NO lo necesita — llama activarEscucha().
  * ========================================================================== */
 .escucha-fab {
+  /* La luz de la Presencia (misma del overlay) */
+  --pre-a-rgb: 120, 235, 255;
+  --pre-b-rgb: 178, 140, 255;
+  --pre-w-rgb: 240, 250, 255;
+
   position: fixed;
   bottom: max(90px, calc(env(safe-area-inset-bottom) + 90px));
   left: 16px;
@@ -299,16 +443,15 @@
   height: 62px;
   border-radius: 50%;
   z-index: 40;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: grid;
+  place-items: center;
+  padding: 0;
   cursor: pointer;
-  color: rgb(var(--t-accent-rgb));
-  background: radial-gradient(circle at 30% 25%, rgba(var(--t-accent-rgb), 0.16), transparent 65%), rgba(6, 16, 13, 0.92);
-  border: 2px solid rgba(var(--t-accent-rgb), 0.65);
+  background: transparent;
+  border: 2px solid rgba(var(--t-accent-rgb), 0.55); /* el marco es de Chagra */
   box-shadow:
     0 4px 18px rgba(0, 0, 0, 0.45),
-    0 0 18px rgba(var(--t-accent-rgb), 0.35);
+    0 0 20px rgba(var(--pre-b-rgb), 0.30);
   transition: transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.25s ease;
 }
 .escucha-fab:hover, .escucha-fab:focus-visible { transform: scale(1.06); }
@@ -318,49 +461,128 @@
   outline-offset: 2px;
 }
 
-/* Temas claros: el FAB pasa a disco del acento con tinta clara (contraste). */
-[data-theme="minimalista"] .escucha-fab,
-[data-theme="nature"] .escucha-fab,
-[data-theme="verde-vivo"] .escucha-fab {
-  color: #fff;
-  background: rgb(var(--t-accent-rgb));
-  border-color: rgba(255, 255, 255, 0.65);
+/* El otro lado en miniatura (siempre oscuro — contraste en cualquier tema). */
+.escucha-fab-espacio {
+  position: absolute;
+  inset: 2px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 50% 36%,
+    #151a3c 0%, #0b0d24 48%, #050610 82%);
+  box-shadow:
+    inset 0 0 12px rgba(var(--pre-b-rgb), 0.25),
+    inset 0 -6px 14px rgba(var(--pre-a-rgb), 0.10);
 }
-[data-theme="nature"] .escucha-fab { color: #2b1c10; }
 
-/* Ping perezoso: un aro que brota cada 4s — anuncia sin fastidiar. */
-.escucha-fab-ping {
+/* Órbita: dos motas de luz girando alrededor del núcleo. */
+.escucha-fab-orbita {
+  position: absolute;
+  inset: 5px;
+  border-radius: 50%;
+  animation: escucha-gira 8s linear infinite;
+}
+.escucha-fab-mota {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+}
+.escucha-fab-mota-a {
+  top: 0;
+  left: 50%;
+  margin-left: -2px;
+  background: rgb(var(--pre-a-rgb));
+  box-shadow: 0 0 6px rgba(var(--pre-a-rgb), 0.9);
+}
+.escucha-fab-mota-b {
+  bottom: 3px;
+  right: 8px;
+  width: 3px;
+  height: 3px;
+  background: rgb(var(--pre-b-rgb));
+  box-shadow: 0 0 5px rgba(var(--pre-b-rgb), 0.9);
+}
+
+/* Núcleo suspendido: levita (translateY suave, GPU) bajo el micrófono. */
+.escucha-fab-nucleo {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 42%,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(var(--pre-a-rgb), 0.55) 45%,
+    rgba(var(--pre-b-rgb), 0.18) 72%,
+    transparent 86%);
+  box-shadow:
+    0 0 14px rgba(var(--pre-a-rgb), 0.55),
+    0 0 30px rgba(var(--pre-b-rgb), 0.35);
+  animation: escucha-levita 4s ease-in-out infinite;
+}
+@keyframes escucha-levita {
+  0%, 100% { transform: translateY(1.5px); }
+  50%      { transform: translateY(-1.5px); }
+}
+
+/* El micrófono flota sobre la luz: silueta oscura, legible. */
+.escucha-fab-mic {
+  position: relative;
+  z-index: 2;
+  color: #0a0d24;
+}
+
+/* Pulso de presencia: un aro que se dilata cada 4s — anuncia sin fastidiar. */
+.escucha-fab-pulso {
   position: absolute;
   inset: -2px;
   border-radius: 50%;
-  border: 2px solid rgba(var(--t-accent-rgb), 0.55);
-  animation: escucha-fab-brota 4s ease-out infinite;
+  border: 2px solid rgba(var(--pre-a-rgb), 0.55);
+  animation: escucha-fab-pulsa 4s ease-out infinite;
   pointer-events: none;
 }
-@keyframes escucha-fab-brota {
+@keyframes escucha-fab-pulsa {
   0%   { transform: scale(1); opacity: 0.7; }
   30%  { transform: scale(1.45); opacity: 0; }
   100% { transform: scale(1.45); opacity: 0; }
 }
 
-/* La ramita del glifo sobre el mic: la firma "mano de Chagra" en miniatura. */
-.escucha-fab-brotecito {
+/* La firma: destello de 4 puntas titilando suave arriba a la derecha. */
+.escucha-fab-destello {
   position: absolute;
-  top: 7px;
-  right: 9px;
-  opacity: 0.9;
+  top: 6px;
+  right: 8px;
+  z-index: 2;
+  color: rgba(var(--pre-w-rgb), 0.95);
+  animation: escucha-destella 4s ease-in-out infinite;
   pointer-events: none;
+}
+@keyframes escucha-destella {
+  0%, 100% { transform: scale(0.8); opacity: 0.5; }
+  50%      { transform: scale(1);   opacity: 1; }
 }
 
 /* ============================================================================
- * Movimiento reducido: el organismo queda quieto pero el ESTADO sigue claro
- * (el arco de cierre y los textos son informativos, no decorativos).
+ * Movimiento reducido: la Presencia queda QUIETA pero hermosa — campo
+ * ordenado, geometría fija, núcleo estable. El ESTADO sigue claro (el sello
+ * de cierre y los textos son informativos, no decorativos).
  * ========================================================================== */
 @media (prefers-reduced-motion: reduce) {
   .escucha-carta { animation: none; }
   .escucha-punto { animation: none; }
-  .escucha-anillo { transition: none; }
-  .escucha-overlay[data-fase="pensando"] .escucha-mano { animation: none; }
-  .escucha-fab-ping { animation: none; opacity: 0; }
+  .escucha-estrella-titila { animation: none; }
+  .escucha-geo-a, .escucha-geo-b,
+  .escucha-overlay[data-fase="pensando"] .escucha-geo-a,
+  .escucha-overlay[data-fase="pensando"] .escucha-geo-b { animation: none; }
+  .escucha-campo,
+  .escucha-overlay[data-fase="pensando"] .escucha-campo { animation: none; }
+  .escucha-nucleo-halo { animation: none; }
+  .escucha-overlay[data-fase="pensando"] .escucha-nucleo { animation: none; }
+  .escucha-nucleo { transition: none; }
+  .escucha-particula, .escucha-rayo, .escucha-rayo-glow { transition: none; }
+  .escucha-fab-orbita { animation: none; }
+  .escucha-fab-nucleo { animation: none; }
+  .escucha-fab-pulso { animation: none; opacity: 0; }
+  .escucha-fab-destello { animation: none; }
   .escucha-fab, .escucha-btn-listo { transition: none; }
 }


### PR DESCRIPTION
## Concepto: LA PRESENCIA

El overlay de escucha es un **portal a otra dimensión**: la sensación de conversar con una entidad de inteligencia presente, no con una app. Es distinto del intento A (orgánico/biológico); este es **etéreo / energético / de luz**.

## Estados

- **REPOSO**: núcleo suspendido latiendo, partículas en calma.
- **ESCUCHANDO**: el campo de partículas se ordena con el **RMS real del micrófono**; el espectro-mandala responde a la voz.
- **PENSANDO**: la geometría sagrada acelera y contra-rota, las partículas entran en remolino.

## Técnica

- CSS/SVG puro; solo se animan `transform`/`opacity` (sin `filter`/`blur` animado) → GPU-friendly.
- `prefers-reduced-motion` → composición estática legible.
- Cero deps npm nuevas, cero fotos.
- Reusa la lógica del wake-word **sin tocarla** (cambio solo visual).

## Nota

El tap del FAB sigue deshabilitado en `App.jsx` (política existente); el trigger real es el wake-word. El rediseño del FAB aplica igual cuando se habilite.