### PR TITLE
feat(mundos): "Restauración y bosque de alimentos" (food forest groundeado)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -142,6 +142,7 @@ const FrutalesScreen = lazy(() => import('./components/frutales/FrutalesScreen')
 // grafo (Diatraea AFFECTS caña; Cotesia/Trichogramma CONTROLS Diatraea) +
 // Cenicaña/AGROSAVIA/FEDEPANELA/INVIMA; el bagazo cierra ciclo hacia el compost.
 const CanaScreen = lazy(() => import('./components/cana/CanaScreen'));
+const RestauracionScreen = lazy(() => import('./components/restauracion/RestauracionScreen'));
 // Mundo "Quinua y granos andinos": recuperación de los granos ancestrales de la
 // montaña (quinua, amaranto/bledo, chía, cañihua y tarwi). Photo-forward (patrón
 // Café) y groundeado en las fichas de ciclo (cycle-content) + nutrición ICBF; el
@@ -439,6 +440,12 @@ const HASH_VIEW_ROUTES = {
   trapiche: 'cana',
   canaveral: 'cana',
   cañaveral: 'cana',
+  restauracion: 'restauracion',
+  'restauracion-bosque': 'restauracion',
+  'bosque-de-alimentos': 'restauracion',
+  'bosque-comestible': 'restauracion',
+  agroforesteria: 'restauracion',
+  'food-forest': 'restauracion',
   'milpa-cultivo': 'milpa_cultivo',
   'tres-hermanas': 'milpa_cultivo',
   'salud-suelo': 'salud_suelo',
@@ -512,7 +519,7 @@ const MODULE_VIEWS = new Set([
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'aromaticas', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'cafe', 'frutales', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'almanaque', 'suelo', 'agua', 'cafe', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
-  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'cafe', 'cana', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
+  'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'cafe', 'cana', 'restauracion', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'platano', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'cacao', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'hortalizas', 'tuberculos', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
@@ -1849,6 +1856,21 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="La caña y la panela">
               <CanaScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'restauracion':
+        // Mundo "Restauración y bosque de alimentos" (dentro de "Diseño de la
+        // finca"): COMPLEMENTA reforestación/silvopastoreo/páramo con el enfoque
+        // food-forest — los 7 estratos, la sucesión ecológica y la restauración
+        // del suelo, como MÉTODO. 5 estaciones photo-forward (fotos CC reusadas de
+        // otros mundos, 0 KB de aporte). GROUNDING RESPONSABLE: toda especie es un
+        // id real de public/grafo-relations.json (el test de grounding lo verifica);
+        // nada de especies inventadas; cifras de sitio = "dato en camino".
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Restauración y bosque de alimentos">
+              <RestauracionScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -195,6 +195,7 @@ export const MUNDOS_FINCA = [
         tinte: ['#2f6b3a', '#d8e9d2'],
         entradas: [
             { view: 'asociaciones', label: 'Buenas vecinas', desc: 'Qué cultivos se ayudan sembrados juntos', emoji: '🌻' },
+            { view: 'restauracion', label: 'Restauración y bosque de alimentos', desc: 'Los 7 estratos del bosque comestible, la sucesión ecológica y cómo restaurar un suelo herido — con especies nativas y multipropósito del catálogo', emoji: '🌳' },
             { view: 'biodiversidad', label: 'El monte de la finca', desc: 'Plantas y animales silvestres que la acompañan', emoji: '🦜' },
             { view: 'seguimiento_reforestacion', label: 'Reforestación', desc: 'Restauración con árboles nativos', emoji: '🌳' },
             { view: 'seguimiento_silvopastoreo', label: 'Silvopastoreo', desc: 'Árboles + pasto + ganado en el mismo lote', emoji: '🐂' },

--- a/src/components/restauracion/RestauracionScreen.jsx
+++ b/src/components/restauracion/RestauracionScreen.jsx
@@ -1,0 +1,630 @@
+import React, { useState } from 'react';
+import {
+  Trees, TreeDeciduous, Sprout, Leaf, Layers, Recycle, ChevronRight, Camera,
+  ExternalLink, Info, Hourglass, ShieldCheck, Mountain, Bug,
+  ArrowUpNarrowWide, Shovel, FlaskConical, Flower2, TriangleAlert, Bird,
+} from 'lucide-react';
+import { ScreenShell } from '../common/ScreenShell';
+import PedagogicalBlock from '../common/PedagogicalBlock';
+import {
+  FOTOS_RESTAURACION,
+  CREDITOS_FOTOS_RESTAURACION,
+  ESTACIONES_RESTAURACION,
+  BOSQUE_INTRO,
+  BOSQUE_VS_MONO,
+  ESTRATOS,
+  SUCESION_INTRO,
+  SUCESION_ETAPAS,
+  SUELO_HERIDO,
+  SUELO_METODO,
+  SUELO_NOTA_SIN_CIFRAS,
+  ESPECIES_RESTAURACION,
+  NOTA_GROUNDING,
+} from '../../data/restauracionFinca';
+import './restauracion.css';
+
+/**
+ * RestauracionScreen — mundo "Restauración y bosque de alimentos".
+ *
+ * COMPLEMENTA el mundo "Diseño de la finca" (reforestación/silvopastoreo/páramo)
+ * con el enfoque del BOSQUE DE ALIMENTOS: los 7 estratos, la sucesión ecológica
+ * y la restauración del suelo — el MÉTODO — sembrados con especies REALES.
+ *
+ * Patrón photo-forward de AguaScreen/CafeScreen/CompostScreen (NO motor nuevo).
+ * Cinco estaciones (pestañas):
+ *   1. El bosque de alimentos — qué es e imita al monte (vs monocultivo).
+ *   2. Los 7 estratos         — los pisos de plantas, con especies groundeadas.
+ *   3. Sucesión               — de pioneras fijadoras a bosque de clímax.
+ *   4. Restaurar el suelo     — del suelo herido a la tierra viva.
+ *   5. Con qué sembrar        — especies multipropósito del catálogo, con papel.
+ *
+ * GROUNDING RESPONSABLE (memoria feedback-restauracion-grounding-fabrica-
+ * especies): toda especie es un id real de public/grafo-relations.json — el test
+ * de grounding lo verifica. Nada de especies inventadas; sin dato = "dato en
+ * camino".
+ */
+
+/** Chip honesto para lo que aún no tiene grounding (mismo criterio que Café). */
+function SlotPendiente({ children = null }) {
+  return (
+    <span
+      data-testid="slot-grounded-pendiente"
+      className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] font-bold text-amber-300"
+    >
+      <Hourglass size={11} aria-hidden="true" />
+      {children || 'Dato en camino'}
+    </span>
+  );
+}
+
+/** Pastilla "Nativa" — resalta el criterio de restauración con especies propias. */
+function ChipNativo() {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/50 bg-emerald-500/15 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-emerald-200">
+      <ShieldCheck size={11} aria-hidden="true" /> Nativa
+    </span>
+  );
+}
+
+/* ── Foto reusada (photo-forward, 0 KB de aporte) ──────────────────────────
+ * Toma una clave de FOTOS_RESTAURACION → su `src` público ya existente. Scrim
+ * fijo para legibilidad al sol; fallback a ícono si no carga; crédito visible. */
+function FotoRest({ nombre, alt, ratio = 'aspect-[16/9]', rounded = '', Fallback = Trees, children = null }) {
+  const [ok, setOk] = useState(true);
+  const foto = FOTOS_RESTAURACION[nombre];
+  const IconoFallback = Fallback;
+  return (
+    <div className={`relative overflow-hidden bg-[#14231a] ${ratio} ${rounded}`}>
+      {ok && foto ? (
+        <img
+          src={foto.src}
+          alt={alt}
+          loading="lazy"
+          decoding="async"
+          onError={() => setOk(false)}
+          className="rest-foto absolute inset-0 w-full h-full object-cover"
+        />
+      ) : (
+        <div className="absolute inset-0 grid place-items-center" aria-hidden="true">
+          <IconoFallback size={38} className="text-emerald-900/70" />
+        </div>
+      )}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/25 to-black/5" aria-hidden="true" />
+      {children}
+      {ok && foto?.autor && (
+        <span className="absolute bottom-1 right-1.5 rounded bg-black/55 px-1 py-0.5 text-[9px] leading-none text-white/75">
+          Foto: {foto.autor}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Lista de especies groundeadas (nombre común + científico + badge nativa). */
+function ListaEspecies({ especies, testidPrefix }) {
+  return (
+    <ul className="flex flex-wrap gap-1.5" data-testid={`${testidPrefix}-especies`}>
+      {especies.map((e) => (
+        <li
+          key={e.id}
+          data-testid={`especie-${e.id}`}
+          data-species-id={e.id}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-700/60 bg-slate-950/40 px-2 py-1"
+        >
+          <span className="text-xs font-bold text-slate-100 leading-tight">{e.comun}</span>
+          <span className="text-[10px] italic text-slate-400 leading-tight">{e.cientifico}</span>
+          {e.nativo && <ChipNativo />}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/* ── ESTACIÓN 1 · El bosque de alimentos ──────────────────────────────── */
+function EstacionBosque({ onNavigate }) {
+  return (
+    <section className="rest-seccion space-y-4" data-testid="estacion-bosque">
+      <div className="rounded-2xl border border-emerald-800/40 overflow-hidden bg-[#16261c]/60">
+        <FotoRest nombre="agroforestal" alt="Sistema agroforestal: varios pisos de árboles y cultivos juntos" ratio="aspect-[16/9]" Fallback={Trees}>
+          <div className="absolute inset-0 flex flex-col justify-end p-4">
+            <p className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wider text-emerald-200">
+              <Trees size={14} aria-hidden="true" /> Una huerta que imita al monte
+            </p>
+            <h3 className="text-xl font-black text-[#ffffff] leading-tight drop-shadow">El bosque de alimentos</h3>
+          </div>
+        </FotoRest>
+      </div>
+
+      <PedagogicalBlock icon={Trees} lead={BOSQUE_INTRO.lead} clave={BOSQUE_INTRO.clave}>
+        <p>{BOSQUE_INTRO.cuerpo}</p>
+      </PedagogicalBlock>
+
+      {/* Bosque de alimentos vs monocultivo (comparación honesta) */}
+      <div className="rounded-2xl border border-slate-700/60 bg-[#16261c]/50 p-4 space-y-2.5" data-testid="rest-vs-mono">
+        <p className="flex items-center gap-2 text-sm font-black text-emerald-200 uppercase tracking-wide">
+          <Layers size={16} aria-hidden="true" /> Por qué en pisos y no en fila
+        </p>
+        {BOSQUE_VS_MONO.map((r) => (
+          <div key={r.id} className="grid grid-cols-2 gap-2" data-testid={`vs-${r.id}`}>
+            <div className="rounded-lg border border-emerald-700/40 bg-emerald-950/25 p-2.5">
+              <p className="flex items-center gap-1 text-[10px] font-black uppercase tracking-wide text-emerald-300 mb-1">
+                <Sprout size={12} aria-hidden="true" /> Bosque de alimentos
+              </p>
+              <p className="text-xs leading-snug text-slate-200">{r.bosque}</p>
+            </div>
+            <div className="rounded-lg border border-slate-700/50 bg-slate-950/40 p-2.5">
+              <p className="flex items-center gap-1 text-[10px] font-black uppercase tracking-wide text-slate-400 mb-1">
+                <TriangleAlert size={12} aria-hidden="true" /> Un solo cultivo
+              </p>
+              <p className="text-xs leading-snug text-slate-400">{r.mono}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Puente al mundo hermano de diseño (asociaciones), sin duplicarlo */}
+      {typeof onNavigate === 'function' && (
+        <button
+          type="button"
+          data-testid="rest-ir-asociaciones"
+          onClick={() => onNavigate('asociaciones')}
+          className="w-full flex items-center gap-3 rounded-xl border border-slate-700/60 bg-slate-900/40 p-3 text-left active:bg-slate-800/60 transition-colors"
+        >
+          <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-lg bg-emerald-500/15 grid place-items-center">
+            <Flower2 size={18} className="text-emerald-300" />
+          </span>
+          <span className="flex-1 min-w-0">
+            <span className="block text-sm font-bold text-slate-100 leading-tight">Buenas vecinas</span>
+            <span className="block text-xs text-slate-400 leading-tight mt-0.5">Qué cultivos se ayudan sembrados juntos, en el mundo del diseño de la finca.</span>
+          </span>
+          <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+        </button>
+      )}
+    </section>
+  );
+}
+
+/* ── ESTACIÓN 2 · Los 7 estratos ──────────────────────────────────────── */
+const ICONO_ESTRATO = {
+  dosel: Trees,
+  arboles_bajos: TreeDeciduous,
+  arbustos: Leaf,
+  herbaceas: Sprout,
+  cobertura: Recycle,
+  raices: Shovel,
+  trepadoras: ArrowUpNarrowWide,
+};
+
+function EstratoCard({ estrato }) {
+  const Icono = ICONO_ESTRATO[estrato.id] || Leaf;
+  return (
+    <article className="rounded-2xl border border-emerald-800/40 bg-[#16261c]/50 overflow-hidden" data-testid={`estrato-${estrato.id}`}>
+      {estrato.foto ? (
+        <FotoRest nombre={estrato.foto} alt={`${estrato.titulo}: ${estrato.subtitulo}`} ratio="aspect-[16/9]" Fallback={Icono}>
+          <div className="absolute inset-0 flex flex-col justify-end p-4">
+            <p className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wider text-emerald-200">
+              <Icono size={14} aria-hidden="true" /> Estrato {estrato.n}
+            </p>
+            <h3 className="text-lg font-black text-[#ffffff] leading-tight drop-shadow">{estrato.titulo}</h3>
+            <p className="text-[11px] text-white/75 leading-tight">{estrato.subtitulo}</p>
+          </div>
+        </FotoRest>
+      ) : (
+        <div className="p-4 pb-0">
+          <p className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wider text-emerald-300">
+            <Icono size={16} aria-hidden="true" /> Estrato {estrato.n}
+          </p>
+          <h3 className="text-lg font-black text-slate-100 leading-tight">{estrato.titulo}</h3>
+          <p className="text-[11px] text-slate-400 leading-tight">{estrato.subtitulo}</p>
+        </div>
+      )}
+      <div className="p-4 space-y-2.5">
+        <p className="text-xs leading-snug text-slate-300">{estrato.papel}</p>
+        <ListaEspecies especies={estrato.especies} testidPrefix={`estrato-${estrato.id}`} />
+      </div>
+    </article>
+  );
+}
+
+function EstacionEstratos() {
+  return (
+    <section className="rest-seccion space-y-4" data-testid="estacion-estratos">
+      <div className="rounded-2xl border border-emerald-800/40 overflow-hidden bg-[#16261c]/60">
+        <FotoRest nombre="cafetal" alt="Varios pisos de vegetación: árboles altos, arbustos y suelo cubierto" ratio="aspect-[16/9]" Fallback={Layers}>
+          <div className="absolute inset-0 flex flex-col justify-end p-4">
+            <p className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wider text-emerald-200">
+              <Layers size={14} aria-hidden="true" /> Un piso sobre otro
+            </p>
+            <h3 className="text-xl font-black text-[#ffffff] leading-tight drop-shadow">Los 7 estratos del bosque</h3>
+          </div>
+        </FotoRest>
+      </div>
+
+      <PedagogicalBlock
+        icon={Layers}
+        lead="El bosque de alimentos se siembra en 7 pisos: cada uno aprovecha una altura de luz y un espacio de raíz distinto, sin estorbarse."
+        clave="Del árbol grande a la raíz bajo tierra: mientras más pisos llenos, más comida por metro y menos suelo desperdiciado."
+      >
+        <p>
+          Piense en el monte: hay árboles altos, otros medianos debajo, arbustos,
+          matas de tallo blando, rastreras que tapan el piso, raíces que trabajan
+          bajo tierra y bejucos que suben por los troncos. Estos son los estratos.
+          Sembrando en todos, la finca se llena de vida y de cosecha.
+        </p>
+      </PedagogicalBlock>
+
+      {ESTRATOS.map((e) => <EstratoCard key={e.id} estrato={e} />)}
+
+      <p className="flex items-start gap-1.5 text-[11px] leading-snug text-slate-400">
+        <Info size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-slate-500" />
+        <span>
+          Las especies de cada piso salen del catálogo Chagra. La distancia entre
+          matas y cuántas por piso dependen de su clima y su terreno{' '}
+          <SlotPendiente>distancias según el predio</SlotPendiente> — eso no se inventa.
+        </span>
+      </p>
+    </section>
+  );
+}
+
+/* ── ESTACIÓN 3 · Sucesión ecológica ──────────────────────────────────── */
+const ICONO_ETAPA = { pioneras: Sprout, climax: TreeDeciduous };
+
+function EstacionSucesion() {
+  return (
+    <section className="rest-seccion space-y-4" data-testid="estacion-sucesion">
+      <div className="rounded-2xl border border-emerald-800/40 overflow-hidden bg-[#16261c]/60">
+        <FotoRest nombre="nodulos" alt="Nódulos en la raíz de una leguminosa: donde se fija el nitrógeno" ratio="aspect-[16/9]" Fallback={Sprout}>
+          <div className="absolute inset-0 flex flex-col justify-end p-4">
+            <p className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wider text-emerald-200">
+              <Recycle size={14} aria-hidden="true" /> El monte se arma por etapas
+            </p>
+            <h3 className="text-xl font-black text-[#ffffff] leading-tight drop-shadow">Sucesión ecológica</h3>
+          </div>
+        </FotoRest>
+      </div>
+
+      <PedagogicalBlock icon={Recycle} lead={SUCESION_INTRO.lead} clave={SUCESION_INTRO.clave} />
+
+      {SUCESION_ETAPAS.map((etapa, i) => {
+        const Icono = ICONO_ETAPA[etapa.id] || Sprout;
+        return (
+          <div key={etapa.id} className="rounded-2xl border border-slate-700/60 bg-[#16261c]/50 p-4 space-y-3" data-testid={`sucesion-${etapa.id}`}>
+            <div className="flex items-start gap-3">
+              <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-xl bg-emerald-500/15 grid place-items-center relative">
+                <Icono size={18} className="text-emerald-300" />
+                <span className="absolute -top-1.5 -left-1.5 w-5 h-5 rounded-full bg-emerald-500 text-[11px] font-black text-[#14231a] grid place-items-center">{i + 1}</span>
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-black text-slate-100 leading-tight">{etapa.titulo}</p>
+                <p className="text-xs leading-snug text-slate-300 mt-1">{etapa.detalle}</p>
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              {etapa.especies.map((e) => (
+                <div key={e.id} data-testid={`especie-${e.id}`} data-species-id={e.id} className="rounded-lg border border-slate-700/50 bg-slate-950/40 px-3 py-2">
+                  <p className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-sm font-bold text-slate-100 leading-tight">
+                    {e.comun}
+                    <span className="text-[10px] italic font-normal text-slate-400">{e.cientifico}</span>
+                    {e.nativo && <ChipNativo />}
+                  </p>
+                  <p className="mt-0.5 text-[11px] font-semibold text-emerald-300/90 leading-snug">{e.rol}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+/* ── ESTACIÓN 4 · Restaurar el suelo ──────────────────────────────────── */
+const ICONO_METODO = { tapar: Leaf, materia: Recycle, vida: Bug, nitrogeno: Sprout };
+
+function EstacionSuelo({ onNavigate }) {
+  return (
+    <section className="rest-seccion space-y-4" data-testid="estacion-suelo">
+      {/* El suelo herido (el problema) */}
+      <div className="grid grid-cols-2 gap-2" data-testid="rest-suelo-herido">
+        {SUELO_HERIDO.map((h) => (
+          <div key={h.id} className="rounded-xl border border-rose-800/40 overflow-hidden bg-[#16261c]/50" data-testid={`herido-${h.id}`}>
+            <FotoRest nombre={h.foto} alt={h.titulo} ratio="aspect-[4/3]" Fallback={Mountain}>
+              <div className="absolute inset-0 flex flex-col justify-end p-2.5">
+                <p className="flex items-center gap-1 text-[10px] font-black uppercase tracking-wide text-rose-200">
+                  <TriangleAlert size={12} aria-hidden="true" /> {h.titulo}
+                </p>
+              </div>
+            </FotoRest>
+            <p className="p-2.5 text-[11px] leading-snug text-slate-300">{h.detalle}</p>
+          </div>
+        ))}
+      </div>
+
+      <PedagogicalBlock
+        icon={Sprout}
+        lead="Un suelo herido no se cura con bolsa: se cura devolviéndole cobertura, materia orgánica y vida. La restauración es de abajo hacia arriba."
+        clave="Suelo tapado + materia orgánica + vida del suelo + fijadoras de nitrógeno = tierra que se vuelve a hacer sola."
+      />
+
+      {/* El método, paso a paso */}
+      <ol className="space-y-3" data-testid="rest-suelo-metodo">
+        {SUELO_METODO.map((m, i) => {
+          const Icono = ICONO_METODO[m.id] || Leaf;
+          return (
+            <li key={m.id} className="rounded-2xl border border-slate-700/60 bg-[#16261c]/50 p-4" data-testid={`metodo-${m.id}`}>
+              <div className="flex items-start gap-3">
+                <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-xl bg-emerald-500/15 grid place-items-center relative">
+                  <Icono size={18} className="text-emerald-300" />
+                  <span className="absolute -top-1.5 -left-1.5 w-5 h-5 rounded-full bg-emerald-500 text-[11px] font-black text-[#14231a] grid place-items-center">{i + 1}</span>
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-bold text-slate-100 leading-tight">{m.titulo}</p>
+                  <p className="text-xs leading-snug text-slate-300 mt-1">{m.detalle}</p>
+                  {m.fotos && (
+                    <div className="mt-2.5 grid grid-cols-3 gap-1.5">
+                      {m.fotos.map((f) => (
+                        <FotoRest key={f} nombre={f} alt={f} ratio="aspect-square" rounded="rounded-lg" Fallback={FlaskConical} />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {/* Guard anti-cifras inventadas */}
+      <div className="rounded-xl border border-amber-700/40 bg-amber-950/20 p-3" data-testid="rest-suelo-nota">
+        <p className="flex items-start gap-1.5 text-[11px] leading-snug text-amber-100">
+          <Info size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-amber-300" />
+          <span>{SUELO_NOTA_SIN_CIFRAS}</span>
+        </p>
+      </div>
+
+      {/* Puentes a los mundos hermanos (suelo vivo, abono) */}
+      {typeof onNavigate === 'function' && (
+        <div className="grid grid-cols-1 gap-2">
+          <button
+            type="button"
+            data-testid="rest-ir-suelo"
+            onClick={() => onNavigate('salud_suelo')}
+            className="w-full flex items-center gap-3 rounded-xl border border-slate-700/60 bg-slate-900/40 p-3 text-left active:bg-slate-800/60 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-lg bg-amber-500/15 grid place-items-center">
+              <Mountain size={18} className="text-amber-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">Cuaderno del suelo</span>
+              <span className="block text-xs text-slate-400 leading-tight mt-0.5">Lea su análisis y sepa qué corregir antes de sembrar.</span>
+            </span>
+            <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            data-testid="rest-ir-compost"
+            onClick={() => onNavigate('compost')}
+            className="w-full flex items-center gap-3 rounded-xl border border-lime-700/50 bg-lime-900/20 p-3 text-left active:bg-lime-900/40 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-lg bg-lime-500/20 grid place-items-center">
+              <Recycle size={18} className="text-lime-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">El compost, paso a paso</span>
+              <span className="block text-xs text-slate-400 leading-tight mt-0.5">La materia orgánica que le devuelve la vida al suelo.</span>
+            </span>
+            <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/* ── ESTACIÓN 5 · Con qué sembrar (especies groundeadas) ──────────────── */
+function EspecieCard({ especie }) {
+  return (
+    <article
+      className="rounded-2xl border border-slate-700/60 bg-[#16261c]/50 p-3.5"
+      data-testid={`especie-${especie.id}`}
+      data-species-id={especie.id}
+    >
+      <p className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-sm font-bold text-slate-100 leading-tight">
+        {especie.comun}
+        <span className="text-[11px] italic font-normal text-slate-400">{especie.cientifico}</span>
+        {especie.nativo && <ChipNativo />}
+      </p>
+      <div className="mt-1.5 flex flex-wrap gap-1.5">
+        {especie.papeles.map((p) => (
+          <span key={p} className="rounded-full bg-emerald-500/15 border border-emerald-600/40 px-2 py-0.5 text-[10px] font-bold text-emerald-200">
+            {p}
+          </span>
+        ))}
+      </div>
+      <p className="mt-2 text-xs leading-snug text-slate-300">{especie.nota}</p>
+    </article>
+  );
+}
+
+function EstacionEspecies({ onNavigate }) {
+  return (
+    <section className="rest-seccion space-y-4" data-testid="estacion-especies">
+      <PedagogicalBlock
+        icon={TreeDeciduous}
+        lead="Estas son especies del catálogo Chagra para restaurar y armar bosque de alimentos, con su papel de verdad: fijar nitrógeno, dar sombra, madera, fruto o tapar el suelo."
+        clave="Para restaurar, primero las nativas: son las que pertenecen a este monte y las que la fauna reconoce."
+      >
+        <p>
+          Muchas son leguminosas que fijan nitrógeno (abono del aire) y otras
+          acumulan minerales o hacen sombra. Se combinan por estratos y por
+          etapas de sucesión — no todas de una.
+        </p>
+      </PedagogicalBlock>
+
+      <div className="grid grid-cols-1 gap-2.5" data-testid="rest-especies-lista">
+        {ESPECIES_RESTAURACION.map((e) => <EspecieCard key={e.id} especie={e} />)}
+      </div>
+
+      {/* Guard anti-fabricación de especies */}
+      <div className="rounded-xl border border-emerald-700/40 bg-emerald-950/20 p-3" data-testid="rest-nota-grounding">
+        <p className="flex items-start gap-1.5 text-[11px] leading-snug text-emerald-100">
+          <ShieldCheck size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-emerald-300" />
+          <span>{NOTA_GROUNDING}</span>
+        </p>
+      </div>
+
+      {/* Puentes a los mundos hermanos de diseño/monte */}
+      {typeof onNavigate === 'function' && (
+        <div className="grid grid-cols-1 gap-2">
+          <button
+            type="button"
+            data-testid="rest-ir-reforestacion"
+            onClick={() => onNavigate('seguimiento_reforestacion')}
+            className="w-full flex items-center gap-3 rounded-xl border border-slate-700/60 bg-slate-900/40 p-3 text-left active:bg-slate-800/60 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-lg bg-emerald-500/15 grid place-items-center">
+              <Trees size={18} className="text-emerald-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">Lleve la restauración a un proyecto</span>
+              <span className="block text-xs text-slate-400 leading-tight mt-0.5">Registre y siga su reforestación con árboles nativos.</span>
+            </span>
+            <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            data-testid="rest-ir-biodiversidad"
+            onClick={() => onNavigate('biodiversidad')}
+            className="w-full flex items-center gap-3 rounded-xl border border-slate-700/60 bg-slate-900/40 p-3 text-left active:bg-slate-800/60 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-lg bg-teal-500/15 grid place-items-center">
+              <Bird size={18} className="text-teal-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">El monte de la finca</span>
+              <span className="block text-xs text-slate-400 leading-tight mt-0.5">Las plantas y animales silvestres que la restauración trae de vuelta.</span>
+            </span>
+            <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** Créditos de las fotos — cumplimiento de licencia abierta (patrón Café). */
+function CreditosFotos() {
+  const [abierto, setAbierto] = useState(false);
+  if (!CREDITOS_FOTOS_RESTAURACION.length) return null;
+  return (
+    <div className="rounded-xl border border-slate-700/60 bg-[#16261c]/50 p-3" data-testid="rest-creditos-fotos">
+      <button
+        type="button"
+        onClick={() => setAbierto((v) => !v)}
+        aria-expanded={abierto}
+        className="w-full flex items-center gap-2 text-left"
+      >
+        <Camera size={15} className="text-slate-400 shrink-0" aria-hidden="true" />
+        <span className="flex-1 text-xs font-bold text-slate-300">Créditos de las fotos (licencia abierta, reusadas de otros mundos)</span>
+        <ChevronRight size={16} className={`text-slate-500 transition-transform ${abierto ? 'rotate-90' : ''}`} aria-hidden="true" />
+      </button>
+      {abierto && (
+        <ul className="mt-2.5 pt-2.5 border-t border-slate-700/60 flex flex-col gap-1.5">
+          {CREDITOS_FOTOS_RESTAURACION.map((cr) => (
+            <li key={cr.slug} className="text-[11px] leading-snug text-slate-400">
+              <a
+                href={cr.fuenteUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-slate-200 hover:text-white underline decoration-slate-600 underline-offset-2 inline-flex items-center gap-0.5"
+              >
+                {cr.slug}<ExternalLink size={10} className="inline shrink-0" aria-hidden="true" />
+              </a>
+              <span className="text-slate-500"> — {cr.autor} · {cr.licencia} · Wikimedia Commons</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/* ── Pantalla principal ───────────────────────────────────────────────── */
+export default function RestauracionScreen({ onBack, onNavigate = undefined }) {
+  const [estacion, setEstacion] = useState('bosque');
+
+  return (
+    <ScreenShell title="Restauración y bosque de alimentos" icon={Trees} onBack={onBack}>
+      <div className="max-w-2xl mx-auto p-4 space-y-4" data-testid="restauracion-screen">
+        {/* Portada breve del mundo */}
+        <div className="rounded-2xl border border-emerald-800/40 bg-[#16261c]/50 p-4">
+          <p className="flex items-center gap-2 text-sm font-black text-emerald-200 leading-tight">
+            <Trees size={18} aria-hidden="true" className="shrink-0" />
+            Sembrar un monte que da de comer
+          </p>
+          <p className="mt-1.5 text-xs italic leading-snug text-slate-400">
+            Restaurar el suelo herido y armar un bosque de alimentos: muchos pisos
+            de plantas útiles, la sucesión de pioneras a bosque maduro, y la tierra
+            que se vuelve a hacer sola — todo con especies del catálogo.
+          </p>
+        </div>
+
+        {/* Navegación entre estaciones (2×3 → 5 en fila, legible al sol) */}
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-2" role="tablist" aria-label="Secciones de la restauración">
+          {ESTACIONES_RESTAURACION.map((e) => {
+            const activo = estacion === e.id;
+            return (
+              <button
+                key={e.id}
+                type="button"
+                role="tab"
+                aria-selected={activo}
+                data-testid={`estacion-tab-${e.id}`}
+                onClick={() => setEstacion(e.id)}
+                className={`rounded-xl border px-2 py-2.5 text-center transition-colors min-h-[56px] ${
+                  activo
+                    ? 'rest-estacion-activa border-emerald-500/70 bg-emerald-500/15 text-emerald-100'
+                    : 'border-slate-700 bg-[#16261c]/50 text-slate-300 active:bg-slate-800/70'
+                }`}
+              >
+                <span className="block text-sm font-black leading-tight">{e.titulo}</span>
+                <span className={`block text-[10px] leading-tight mt-0.5 ${activo ? 'text-emerald-200/90' : 'text-slate-500'}`}>
+                  {e.descripcion}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {estacion === 'bosque' && <EstacionBosque onNavigate={onNavigate} />}
+        {estacion === 'estratos' && <EstacionEstratos />}
+        {estacion === 'sucesion' && <EstacionSucesion />}
+        {estacion === 'suelo' && <EstacionSuelo onNavigate={onNavigate} />}
+        {estacion === 'especies' && <EstacionEspecies onNavigate={onNavigate} />}
+
+        {/* Créditos de todas las fotos del mundo (cumplimiento licencia abierta) */}
+        <CreditosFotos />
+
+        {/* Puente al agente para lo que el mundo no alcanza */}
+        {typeof onNavigate === 'function' && (
+          <button
+            type="button"
+            data-testid="rest-preguntar-agente"
+            onClick={() => onNavigate('agente', { prefilledPrompt: '¿Cómo armo un bosque de alimentos para restaurar un lote degradado en mi finca?' })}
+            className="w-full flex items-center gap-3 rounded-2xl border border-slate-700/60 bg-slate-900/40 p-3.5 text-left active:bg-slate-800/60 transition-colors"
+          >
+            <span aria-hidden="true" className="shrink-0 w-10 h-10 rounded-xl bg-emerald-500/15 grid place-items-center">
+              <Trees size={20} className="text-emerald-300" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-bold text-slate-100 leading-tight">¿Su terreno es distinto?</span>
+              <span className="block text-xs text-slate-400 leading-tight mt-0.5">Cuénteselo al agente: él conoce su clima, su altura y qué especies le sirven.</span>
+            </span>
+            <ChevronRight size={18} className="shrink-0 text-slate-500" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/restauracion/RestauracionScreen.test.jsx
+++ b/src/components/restauracion/RestauracionScreen.test.jsx
@@ -1,0 +1,185 @@
+/**
+ * RestauracionScreen — mundo "Restauración y bosque de alimentos"
+ * (photo-forward, 5 estaciones). COMPLEMENTA el mundo de diseño con el enfoque
+ * food-forest.
+ *
+ * Contrato cubierto:
+ *   - Las 5 estaciones son navegables y cada una muestra su contenido.
+ *   - Los 7 estratos están presentes y en orden.
+ *   - La sucesión distingue pioneras (fijadoras) de bosque de clímax.
+ *   - La restauración de suelo trae el método SIN cifras inventadas (guard).
+ *   - GROUNDING: TODA especie referida es un id real de grafo-relations.json y
+ *     el flag `nativo` coincide con establishment_means === 'nativo' (anti
+ *     fabricación de especies — memoria feedback-restauracion-grounding).
+ *   - Puentes: onBack; enlaces a asociaciones, salud_suelo, compost,
+ *     reforestación, biodiversidad y agente.
+ *   - Créditos de fotos con atribución (cumplimiento CC).
+ */
+// @types/node no está instalado en el repo (gap conocido y ya tolerado en
+// MundosDeMiFinca.reachability.test.jsx / dataJsonValidity.test.js): tsc no
+// resuelve los specifiers "node:*". Runtime (vitest/node) sí los resuelve.
+// @ts-expect-error TS2591 — ver comentario arriba.
+import fs from 'node:fs';
+// @ts-expect-error TS2591 — ver comentario arriba.
+import path from 'node:path';
+// @ts-expect-error TS2591 — ver comentario arriba.
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import RestauracionScreen from './RestauracionScreen';
+import {
+  CREDITOS_FOTOS_RESTAURACION,
+  ESTRATOS,
+  SUCESION_ETAPAS,
+  ESPECIES_RESTAURACION,
+} from '../../data/restauracionFinca';
+
+afterEach(() => cleanup());
+
+const irAEstacion = (id) => fireEvent.click(screen.getByTestId(`estacion-tab-${id}`));
+
+describe('RestauracionScreen — navegación y portada', () => {
+  it('arranca en "el bosque de alimentos" y muestra las 5 pestañas', () => {
+    render(<RestauracionScreen onBack={() => {}} onNavigate={() => {}} />);
+    expect(screen.getByTestId('restauracion-screen')).toBeTruthy();
+    expect(screen.getByTestId('estacion-bosque')).toBeTruthy();
+    for (const id of ['bosque', 'estratos', 'sucesion', 'suelo', 'especies']) {
+      expect(screen.getByTestId(`estacion-tab-${id}`)).toBeTruthy();
+    }
+  });
+
+  it('el botón volver llama onBack', () => {
+    const onBack = vi.fn();
+    render(<RestauracionScreen onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Volver' }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('enlaza a "buenas vecinas" del mundo de diseño (complementa, no duplica)', () => {
+    const onNavigate = vi.fn();
+    render(<RestauracionScreen onBack={() => {}} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('rest-ir-asociaciones'));
+    expect(onNavigate).toHaveBeenCalledWith('asociaciones');
+  });
+});
+
+describe('RestauracionScreen — los 7 estratos', () => {
+  it('muestra los 7 estratos en orden', () => {
+    render(<RestauracionScreen onBack={() => {}} />);
+    irAEstacion('estratos');
+    expect(ESTRATOS).toHaveLength(7);
+    for (const e of ESTRATOS) {
+      expect(screen.getByTestId(`estrato-${e.id}`)).toBeTruthy();
+    }
+  });
+
+  it('las distancias de siembra no se inventan: se marcan como dato en camino', () => {
+    render(<RestauracionScreen onBack={() => {}} />);
+    irAEstacion('estratos');
+    expect(screen.getByTestId('slot-grounded-pendiente')).toBeTruthy();
+  });
+});
+
+describe('RestauracionScreen — sucesión ecológica', () => {
+  it('distingue pioneras de bosque de clímax', () => {
+    render(<RestauracionScreen onBack={() => {}} />);
+    irAEstacion('sucesion');
+    expect(screen.getByTestId('sucesion-pioneras')).toBeTruthy();
+    expect(screen.getByTestId('sucesion-climax')).toBeTruthy();
+    // El aliso (nativo, fija N con Frankia) es la pionera andina groundeada.
+    expect(screen.getByText(/Alnus acuminata/i)).toBeTruthy();
+  });
+});
+
+describe('RestauracionScreen — restaurar el suelo (método, sin cifras)', () => {
+  it('muestra el método y el guard anti-cifras inventadas', () => {
+    render(<RestauracionScreen onBack={() => {}} />);
+    irAEstacion('suelo');
+    expect(screen.getByTestId('rest-suelo-metodo')).toBeTruthy();
+    const nota = screen.getByTestId('rest-suelo-nota');
+    expect(nota.textContent).toMatch(/no se inventa|no encontrará/i);
+  });
+
+  it('enlaza al cuaderno del suelo y al compost', () => {
+    const onNavigate = vi.fn();
+    render(<RestauracionScreen onBack={() => {}} onNavigate={onNavigate} />);
+    irAEstacion('suelo');
+    fireEvent.click(screen.getByTestId('rest-ir-suelo'));
+    expect(onNavigate).toHaveBeenCalledWith('salud_suelo');
+    fireEvent.click(screen.getByTestId('rest-ir-compost'));
+    expect(onNavigate).toHaveBeenCalledWith('compost');
+  });
+});
+
+describe('RestauracionScreen — especies groundeadas y puentes', () => {
+  it('lista especies para restaurar con su guard anti-fabricación', () => {
+    render(<RestauracionScreen onBack={() => {}} />);
+    irAEstacion('especies');
+    expect(screen.getByTestId('rest-especies-lista')).toBeTruthy();
+    const nota = screen.getByTestId('rest-nota-grounding');
+    expect(nota.textContent).toMatch(/catálogo Chagra/i);
+  });
+
+  it('enlaza a reforestación y al monte de la finca (mundos hermanos)', () => {
+    const onNavigate = vi.fn();
+    render(<RestauracionScreen onBack={() => {}} onNavigate={onNavigate} />);
+    irAEstacion('especies');
+    fireEvent.click(screen.getByTestId('rest-ir-reforestacion'));
+    expect(onNavigate).toHaveBeenCalledWith('seguimiento_reforestacion');
+    fireEvent.click(screen.getByTestId('rest-ir-biodiversidad'));
+    expect(onNavigate).toHaveBeenCalledWith('biodiversidad');
+  });
+
+  it('el agente queda presente en el pie con prompt de restauración', () => {
+    const onNavigate = vi.fn();
+    render(<RestauracionScreen onBack={() => {}} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('rest-preguntar-agente'));
+    expect(onNavigate).toHaveBeenCalledWith('agente', expect.objectContaining({
+      prefilledPrompt: expect.stringMatching(/bosque de alimentos/i),
+    }));
+  });
+});
+
+describe('RestauracionScreen — créditos de fotos (cumplimiento CC)', () => {
+  it('todas las fotos traen autor, licencia y fuente de Wikimedia', () => {
+    expect(CREDITOS_FOTOS_RESTAURACION.length).toBeGreaterThanOrEqual(6);
+    for (const cr of CREDITOS_FOTOS_RESTAURACION) {
+      expect(cr.autor).toBeTruthy();
+      expect(cr.licencia).toBeTruthy();
+      expect(cr.fuenteUrl).toMatch(/^https?:\/\/([a-z0-9-]+\.)*wikimedia\.org\//);
+    }
+  });
+});
+
+// ── GROUNDING: cada especie del mundo existe en el grafo (anti-fabricación) ──
+describe('RestauracionScreen — grounding contra el catálogo (grafo)', () => {
+  // El grafo es el mismo que consume la app en runtime (public/grafo-relations).
+  // Se lee del disco (mismo criterio que la reachability test) para no acoplar
+  // el test a fetch ni a un import JSON.
+  const __dir = path.dirname(fileURLToPath(import.meta.url));
+  const grafoPath = path.resolve(__dir, '../../../public/grafo-relations.json');
+  const grafo = JSON.parse(fs.readFileSync(grafoPath, 'utf8'));
+  const species = grafo.species || {};
+
+  const idsDelMundo = [
+    ...ESTRATOS.flatMap((e) => e.especies),
+    ...SUCESION_ETAPAS.flatMap((e) => e.especies),
+    ...ESPECIES_RESTAURACION,
+  ];
+
+  it('cada especie referida es un id REAL del grafo (0 inventadas)', () => {
+    for (const e of idsDelMundo) {
+      expect(species[e.id], `especie fabricada (no está en el grafo): ${e.id}`).toBeTruthy();
+    }
+  });
+
+  it('el flag `nativo` coincide con establishment_means del grafo', () => {
+    for (const e of idsDelMundo) {
+      const esNativoEnGrafo = species[e.id]?.establishment_means === 'nativo';
+      expect(
+        !!e.nativo,
+        `nativo desalineado para ${e.id}: mundo=${!!e.nativo} grafo=${esNativoEnGrafo}`,
+      ).toBe(esNativoEnGrafo);
+    }
+  });
+});

--- a/src/components/restauracion/restauracion.css
+++ b/src/components/restauracion/restauracion.css
@@ -1,0 +1,45 @@
+/*
+ * restauracion.css — micro-animaciones del mundo "Restauración y bosque de
+ * alimentos". Mismos principios que cafe.css / agua.css:
+ *   · Sutiles y baratas (solo transform/opacity, nada de layout).
+ *   · prefers-reduced-motion las apaga todas.
+ *   · Los colores salen de las clases Tailwind del componente (paleta slate +
+ *     acentos verde/esmeralda), que reaccionan a los temas vía data-theme; aquí
+ *     solo hay movimiento, ningún color de tema fijado.
+ */
+
+/* Entrada suave del contenido de la estación al cambiar de pestaña. */
+@keyframes rest-seccion-entra {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.rest-seccion {
+  animation: rest-seccion-entra 0.3s ease-out;
+}
+
+/* Estación activa: aro que pulsa una sola vez al seleccionar. */
+@keyframes rest-estacion-pulso {
+  0% { transform: scale(0.94); opacity: 0.5; }
+  60% { transform: scale(1.05); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+.rest-estacion-activa {
+  animation: rest-estacion-pulso 0.45s ease-out;
+}
+
+/* Fotos reales: aparición suave (solo opacity, sin reflow) al montarse. */
+@keyframes rest-foto-entra {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.rest-foto {
+  animation: rest-foto-entra 0.5s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rest-seccion,
+  .rest-estacion-activa,
+  .rest-foto {
+    animation: none;
+  }
+}

--- a/src/data/restauracionFinca.js
+++ b/src/data/restauracionFinca.js
@@ -1,0 +1,380 @@
+/*
+ * i18n (ADR-050): este archivo es CONTENIDO/copy campesino en español Colombia
+ * (bosque de alimentos, sucesión ecológica y restauración de suelo), pendiente
+ * de migrar a src/config/messages.js — mismo criterio que cafeFinca.js /
+ * canaFinca.js / aguaFinca.js.
+ */
+/**
+ * restauracionFinca.js — CONTENIDO del mundo "Restauración y bosque de alimentos".
+ *
+ * COMPLEMENTA (no duplica) el mundo "Diseño de la finca" (disenio), que ya trae
+ * reforestación / silvopastoreo / páramo. Aquí el enfoque es el BOSQUE DE
+ * ALIMENTOS (food forest): los 7 estratos, la sucesión ecológica y la
+ * restauración del suelo degradado — el MÉTODO — sembrado con especies REALES.
+ *
+ * ─── REGLA ANTI-ALUCINACIÓN (memoria feedback-restauracion-grounding-fabrica-
+ *     especies) ─────────────────────────────────────────────────────────────
+ * La restauración FABRICA especies si no se ancla al catálogo. Por eso TODA
+ * especie de este archivo es un id REAL de public/grafo-relations.json
+ * (species.<id>). El test restauracionFinca.grounding.test.js cruza cada id
+ * contra el grafo y verifica además que el flag `nativo` coincide con
+ * `establishment_means === 'nativo'`. Si una especie no está groundeada, NO se
+ * inventa: el campo se deja como SlotPendiente ("dato en camino").
+ *
+ * Los PAPELES funcionales (fija nitrógeno, sombra, cobertura, dinamizadora…) y
+ * los ESTRATOS son método ecológico (Robert Hart / agroforestería / AGROSAVIA),
+ * puestos SOBRE especies del catálogo. No hay cifras de sitio inventadas
+ * (densidades, dosis, distancias): esas se remiten al diseño del predio / al
+ * agente.
+ *
+ * FOTOS: photo-forward REUSANDO fotos CC que ya viven en public/ (café,
+ * soil-life, frutales, plátano, cacao) — aporte 0 KB al bundle (el budget está
+ * apretado). Cada foto conserva su atribución real (ver CREDITOS_FOTOS_RESTAURACION).
+ */
+
+export const ESTADO_GROUNDED_PENDIENTE = 'grounded_pendiente';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * FOTOS (reusadas de otros mundos — 0 KB de aporte). El `src` es una ruta
+ * pública ya existente; NO se copian bytes. La atribución se conserva.
+ * ──────────────────────────────────────────────────────────────────────── */
+export const FOTOS_RESTAURACION = {
+  agroforestal: {
+    src: '/cacao/agroforestal.jpg',
+    autor: 'Mvfarrell',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Shade_Cacao_Plantation,_Ixcacao_Mayan_Chocolate,_Belize.JPG',
+  },
+  cafetal: {
+    src: '/cafe/cafetal.jpg',
+    autor: 'Timothy A. Gonsalves',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Coffee_Shade_Trees_Paddy_Fields_Coorg_Feb24_R16_07670.jpg',
+  },
+  cafeSombra: {
+    src: '/platano-banano/cafe-sombra.jpg',
+    autor: 'Kateregga1',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Coffee_and_banana_plantation_in_Uganda.jpg',
+  },
+  aguacate: {
+    src: '/frutales/aguacate.jpg',
+    autor: 'B.navez',
+    licencia: 'CC BY-SA 3.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Persea_americana_fruit_2.JPG',
+  },
+  lulo: {
+    src: '/frutales/lulo.jpg',
+    autor: 'Photo by David J. Stang',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Solanum_quitoense_14zz.jpg',
+  },
+  mora: {
+    src: '/frutales/mora.jpg',
+    autor: 'Forest & Kim Starr',
+    licencia: 'CC BY 3.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Starr_051123-5474_Rubus_glaucus.jpg',
+  },
+  platanera: {
+    src: '/platano-banano/platanera-mata.jpg',
+    autor: 'Ssemmanda will',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Banana_Plantation_01.jpg',
+  },
+  nodulos: {
+    src: '/soil-life/nodulos.jpg',
+    autor: 'Louisa Howard — Dartmouth Electron Microscope Facility',
+    licencia: 'Dominio público',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Root-nodule01.jpg',
+  },
+  micorriza: {
+    src: '/soil-life/micorriza.jpg',
+    autor: 'Rajarshi Rit',
+    licencia: 'CC BY 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Vesicular_Arbuscular_Mycorrhizae_40X0031_03.jpg',
+  },
+  micelio: {
+    src: '/soil-life/micelio.jpg',
+    autor: 'Rob Hille',
+    licencia: 'CC BY-SA 3.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Mycelium_RH_(1).jpg',
+  },
+  humus: {
+    src: '/soil-life/humus.jpg',
+    autor: 'Suiseisekiryu',
+    licencia: 'CC0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Germination_and_humus.jpg',
+  },
+  lombriz: {
+    src: '/soil-life/lombriz.jpg',
+    autor: 'Jochem Kuhnen',
+    licencia: 'CC BY 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Aporrectodea_rosea_(Gelderland,_Netherlands).jpg',
+  },
+  erosion: {
+    src: '/soil-life/erosion.jpg',
+    autor: 'Desmanthus4food',
+    licencia: 'CC BY-SA 3.0 US',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Erosion_gulleys_on_unterraced_farmland_in_Yunnan.jpg',
+  },
+  costra: {
+    src: '/soil-life/costra.jpg',
+    autor: 'Ibrahim Achiri',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Dry_cracked_soil_ground.jpg',
+  },
+};
+
+/** Créditos de fotos (cumplimiento CC) — derivados de FOTOS_RESTAURACION. */
+export const CREDITOS_FOTOS_RESTAURACION = Object.entries(FOTOS_RESTAURACION).map(
+  ([slug, f]) => ({ slug, autor: f.autor, licencia: f.licencia, fuenteUrl: f.fuenteUrl }),
+);
+
+/* ────────────────────────────────────────────────────────────────────────
+ * ESTACIONES (pestañas del mundo)
+ * ──────────────────────────────────────────────────────────────────────── */
+export const ESTACIONES_RESTAURACION = [
+  { id: 'bosque', titulo: 'El bosque de alimentos', descripcion: 'Qué es y por qué imita al monte' },
+  { id: 'estratos', titulo: 'Los 7 estratos', descripcion: 'Los pisos de plantas, uno sobre otro' },
+  { id: 'sucesion', titulo: 'Sucesión', descripcion: 'De pioneras rústicas a bosque maduro' },
+  { id: 'suelo', titulo: 'Restaurar el suelo', descripcion: 'Del suelo herido a la tierra viva' },
+  { id: 'especies', titulo: 'Con qué sembrar', descripcion: 'Especies del catálogo, con su papel' },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * ESTACIÓN 1 · EL BOSQUE DE ALIMENTOS
+ * ──────────────────────────────────────────────────────────────────────── */
+export const BOSQUE_INTRO = {
+  lead: 'Un bosque de alimentos es una huerta que imita al monte: muchas plantas útiles en varios pisos, viviendo juntas, que se cuidan entre ellas y dan de comer todo el año.',
+  clave: 'No se siembra un solo cultivo en fila: se arma un monte comestible. El suelo nunca queda pelado y la finca se defiende sola.',
+  cuerpo:
+    'En el monte natural nadie abona ni riega y, sin embargo, todo crece: los árboles grandes dan sombra, las hojas caen y hacen tierra, las raíces se ayudan bajo el suelo. El bosque de alimentos copia ese arreglo, pero con matas que dan comida, leña, forraje y remedio. Se siembra en varios pisos a la vez para aprovechar toda la luz, tapar el suelo y cosechar en distintas épocas.',
+};
+
+/** Por qué el bosque de alimentos le gana al monocultivo (comparación honesta). */
+export const BOSQUE_VS_MONO = [
+  { id: 'suelo', bosque: 'El suelo siempre tapado: hojarasca y raíces vivas', mono: 'Suelo desnudo entre surcos: se lava y se seca' },
+  { id: 'cosecha', bosque: 'Cosecha escalonada todo el año, de varios pisos', mono: 'Una sola cosecha; el resto del año, nada' },
+  { id: 'plagas', bosque: 'La mezcla confunde a las plagas y aloja a sus enemigos', mono: 'Una plaga encuentra su comida servida en todo el lote' },
+  { id: 'agua', bosque: 'La sombra guarda humedad; menos riego', mono: 'El sol pega directo; más sed y más riego' },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * ESTACIÓN 2 · LOS 7 ESTRATOS
+ * Cada estrato = un PISO del bosque, sembrado con especies REALES del catálogo.
+ * `nativo` refleja establishment_means del grafo (lo verifica el test).
+ * ──────────────────────────────────────────────────────────────────────── */
+export const ESTRATOS = [
+  {
+    id: 'dosel',
+    n: 1,
+    titulo: 'Dosel alto',
+    subtitulo: 'El techo del monte: los árboles grandes',
+    foto: 'cafeSombra',
+    papel: 'Dan la sombra madre, cortan el viento y sus hojas caídas alimentan a todo lo de abajo.',
+    especies: [
+      { id: 'samanea_saman', comun: 'Samán', cientifico: 'Samanea saman', nativo: true },
+      { id: 'quercus_humboldtii', comun: 'Roble negro andino', cientifico: 'Quercus humboldtii', nativo: true },
+      { id: 'cordia_alliodora', comun: 'Nogal cafetero', cientifico: 'Cordia alliodora', nativo: false },
+      { id: 'tabebuia_rosea', comun: 'Guayacán rosado', cientifico: 'Tabebuia rosea', nativo: false },
+      { id: 'enterolobium_cyclocarpum', comun: 'Orejero', cientifico: 'Enterolobium cyclocarpum', nativo: false },
+      { id: 'euterpe_oleracea', comun: 'Asaí', cientifico: 'Euterpe oleracea', nativo: true },
+    ],
+  },
+  {
+    id: 'arboles_bajos',
+    n: 2,
+    titulo: 'Árboles bajos y frutales',
+    subtitulo: 'Debajo del techo, a media altura',
+    foto: 'aguacate',
+    papel: 'Los frutales de la casa y los árboles de servicio que viven a la sombra suave del dosel.',
+    especies: [
+      { id: 'persea_americana', comun: 'Aguacate', cientifico: 'Persea americana', nativo: false },
+      { id: 'mangifera_indica', comun: 'Mango', cientifico: 'Mangifera indica', nativo: false },
+      { id: 'inga_edulis', comun: 'Guamo', cientifico: 'Inga edulis', nativo: false },
+      { id: 'erythrina_edulis', comun: 'Chachafruto / Balú', cientifico: 'Erythrina edulis', nativo: false },
+      { id: 'theobroma_cacao', comun: 'Cacao', cientifico: 'Theobroma cacao', nativo: false },
+      { id: 'psidium_guajava', comun: 'Guayaba', cientifico: 'Psidium guajava', nativo: false },
+      { id: 'eriobotrya_japonica', comun: 'Níspero', cientifico: 'Eriobotrya japonica', nativo: false },
+    ],
+  },
+  {
+    id: 'arbustos',
+    n: 3,
+    titulo: 'Arbustos',
+    subtitulo: 'Matas leñosas a la altura de la mano',
+    foto: 'lulo',
+    papel: 'La cosecha del día a día: café, frutas ácidas y arbustos que llenan el piso medio.',
+    especies: [
+      { id: 'coffea_arabica', comun: 'Café', cientifico: 'Coffea arabica', nativo: false },
+      { id: 'solanum_quitoense', comun: 'Lulo', cientifico: 'Solanum quitoense', nativo: false },
+      { id: 'solanum_betaceum', comun: 'Tomate de árbol', cientifico: 'Solanum betaceum', nativo: false },
+      { id: 'vaccinium_meridionale', comun: 'Mortino / Agraz', cientifico: 'Vaccinium meridionale', nativo: true },
+      { id: 'physalis_peruviana', comun: 'Uchuva', cientifico: 'Physalis peruviana', nativo: false },
+      { id: 'rubus_glaucus', comun: 'Mora', cientifico: 'Rubus glaucus', nativo: false },
+      { id: 'lupinus_mutabilis', comun: 'Tarwi / Chocho', cientifico: 'Lupinus mutabilis', nativo: false },
+    ],
+  },
+  {
+    id: 'herbaceas',
+    n: 4,
+    titulo: 'Herbáceas',
+    subtitulo: 'Matas de tallo blando',
+    foto: 'platanera',
+    papel: 'Las matas que dan rápido y se renuevan cada ciclo: pancoger y granos.',
+    especies: [
+      { id: 'musa_paradisiaca', comun: 'Plátano', cientifico: 'Musa × paradisiaca', nativo: false },
+      { id: 'zea_mays', comun: 'Maíz', cientifico: 'Zea mays', nativo: false },
+      { id: 'chenopodium_quinoa', comun: 'Quinua', cientifico: 'Chenopodium quinoa', nativo: false },
+      { id: 'amaranthus_caudatus', comun: 'Amaranto', cientifico: 'Amaranthus caudatus', nativo: false },
+      { id: 'phaseolus_vulgaris', comun: 'Fríjol', cientifico: 'Phaseolus vulgaris', nativo: false },
+      { id: 'vicia_faba', comun: 'Haba', cientifico: 'Vicia faba', nativo: false },
+    ],
+  },
+  {
+    id: 'cobertura',
+    n: 5,
+    titulo: 'Cobertura',
+    subtitulo: 'Las rastreras que tapan el suelo',
+    foto: 'humus',
+    papel: 'La manta viva del suelo: rastreras que lo tapan para que no se lave ni se seque.',
+    especies: [
+      { id: 'ipomoea_batatas', comun: 'Batata / Camote', cientifico: 'Ipomoea batatas', nativo: false },
+      { id: 'cucurbita_maxima', comun: 'Calabaza / Auyama', cientifico: 'Cucurbita maxima', nativo: false },
+      { id: 'fragaria_vesca', comun: 'Fresa silvestre andina', cientifico: 'Fragaria vesca', nativo: false },
+      { id: 'tropaeolum_majus', comun: 'Capuchina', cientifico: 'Tropaeolum majus', nativo: false },
+      { id: 'mucuna_pruriens', comun: 'Fríjol terciopelo', cientifico: 'Mucuna pruriens', nativo: false },
+    ],
+  },
+  {
+    id: 'raices',
+    n: 6,
+    titulo: 'Raíces y subsuelo',
+    subtitulo: 'Lo que crece bajo tierra',
+    foto: null,
+    papel: 'El piso invisible: raíces y tubérculos que aran el suelo por dentro y guardan comida.',
+    especies: [
+      { id: 'arracacia_xanthorrhiza', comun: 'Arracacha', cientifico: 'Arracacia xanthorrhiza', nativo: false },
+      { id: 'manihot_esculenta', comun: 'Yuca', cientifico: 'Manihot esculenta', nativo: false },
+      { id: 'oxalis_tuberosa', comun: 'Oca', cientifico: 'Oxalis tuberosa', nativo: false },
+      { id: 'tropaeolum_tuberosum', comun: 'Cubio / Mashua', cientifico: 'Tropaeolum tuberosum', nativo: true },
+      { id: 'ullucus_tuberosus', comun: 'Ulluco / Chugua', cientifico: 'Ullucus tuberosus', nativo: false },
+      { id: 'smallanthus_sonchifolius', comun: 'Yacón', cientifico: 'Smallanthus sonchifolius', nativo: true },
+    ],
+  },
+  {
+    id: 'trepadoras',
+    n: 7,
+    titulo: 'Trepadoras',
+    subtitulo: 'Las que suben por los troncos',
+    foto: 'mora',
+    papel: 'Aprovechan el aire: suben por los árboles y cargan fruta donde no cabría otra mata.',
+    especies: [
+      { id: 'passiflora_ligularis', comun: 'Granadilla', cientifico: 'Passiflora ligularis', nativo: false },
+      { id: 'passiflora_edulis_flavicarpa', comun: 'Maracuyá', cientifico: 'Passiflora edulis f. flavicarpa', nativo: false },
+      { id: 'passiflora_tripartita_mollissima', comun: 'Curuba', cientifico: 'Passiflora tripartita var. mollissima', nativo: false },
+      { id: 'passiflora_edulis_morada', comun: 'Gulupa', cientifico: 'Passiflora edulis f. edulis', nativo: false },
+      { id: 'dioscorea_alata', comun: 'Ñame', cientifico: 'Dioscorea alata', nativo: false },
+    ],
+  },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * ESTACIÓN 3 · SUCESIÓN ECOLÓGICA
+ * El monte se arma solo, por etapas. En restauración se imita esa fila:
+ * pioneras rústicas primero (arreglan luz, sombra y suelo) → luego las de
+ * dosel/clímax. Todo groundeado (leguminosas fijadoras + aliso actinorrizo).
+ * ──────────────────────────────────────────────────────────────────────── */
+export const SUCESION_INTRO = {
+  lead: 'El monte no nace maduro: primero llegan las plantas rústicas que aguantan el sol y el suelo pobre, y solo cuando ellas hacen sombra y tierra aparecen las de bosque grande.',
+  clave: 'En restauración se siembra imitando esa fila: pioneras que fijan nitrógeno y hacen sombra primero; las maderables y de clímax, debajo, para el largo plazo.',
+};
+
+export const SUCESION_ETAPAS = [
+  {
+    id: 'pioneras',
+    titulo: 'Pioneras (los primeros años)',
+    detalle: 'Rústicas, rápidas y casi todas leguminosas: fijan nitrógeno del aire, hacen sombra en poco tiempo y se podan para tapar el suelo (poda-y-tira).',
+    especies: [
+      { id: 'gliricidia_sepium', comun: 'Matarratón', cientifico: 'Gliricidia sepium', nativo: false, rol: 'Fija N · cerca viva · poda-y-tira' },
+      { id: 'inga_edulis', comun: 'Guamo', cientifico: 'Inga edulis', nativo: false, rol: 'Fija N · sombra · fruto' },
+      { id: 'erythrina_edulis', comun: 'Chachafruto', cientifico: 'Erythrina edulis', nativo: false, rol: 'Fija N · comida' },
+      { id: 'alnus_acuminata', comun: 'Aliso andino', cientifico: 'Alnus acuminata', nativo: true, rol: 'Fija N (Frankia) · restaura laderas' },
+      { id: 'lupinus_mutabilis', comun: 'Tarwi / Chocho', cientifico: 'Lupinus mutabilis', nativo: false, rol: 'Fija N · abono verde de altura' },
+      { id: 'mucuna_pruriens', comun: 'Fríjol terciopelo', cientifico: 'Mucuna pruriens', nativo: false, rol: 'Fija N · abono verde de choque' },
+    ],
+  },
+  {
+    id: 'climax',
+    titulo: 'Bosque maduro (para el largo plazo)',
+    detalle: 'Crecen despacio pero llegan lejos: se siembran bajo la sombra que hicieron las pioneras y son el bosque que queda — madera, dosel y refugio de fauna.',
+    especies: [
+      { id: 'cordia_alliodora', comun: 'Nogal cafetero', cientifico: 'Cordia alliodora', nativo: false, rol: 'Madera fina · dosel' },
+      { id: 'quercus_humboldtii', comun: 'Roble negro andino', cientifico: 'Quercus humboldtii', nativo: true, rol: 'Clímax andino · protegido' },
+      { id: 'weinmannia_tomentosa', comun: 'Encenillo', cientifico: 'Weinmannia tomentosa', nativo: true, rol: 'Bosque altoandino · borde de páramo' },
+      { id: 'tabebuia_rosea', comun: 'Guayacán rosado', cientifico: 'Tabebuia rosea', nativo: false, rol: 'Dosel · flor para polinizadores' },
+    ],
+  },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * ESTACIÓN 4 · RESTAURAR EL SUELO
+ * Suelo herido (erosión, costra, compactación) → tierra viva. Método, sin
+ * cifras inventadas. Enlaza a los mundos hermanos (suelo, abono).
+ * ──────────────────────────────────────────────────────────────────────── */
+export const SUELO_HERIDO = [
+  { id: 'erosion', foto: 'erosion', titulo: 'Erosión', detalle: 'El agua se lleva la capa fértil por las cárcavas cuando el suelo queda desnudo en pendiente.' },
+  { id: 'costra', foto: 'costra', titulo: 'Costra y resquebrajado', detalle: 'Sin cobertura, el sol reseca y endurece la superficie: el agua ya no entra, resbala.' },
+];
+
+export const SUELO_METODO = [
+  {
+    id: 'tapar',
+    titulo: 'Nunca dejar el suelo pelado',
+    detalle: 'Cobertura viva (rastreras) y hojarasca encima. Tapado, el suelo guarda humedad, no se lava y se llena de vida.',
+  },
+  {
+    id: 'materia',
+    titulo: 'Meterle materia orgánica',
+    detalle: 'La poda-y-tira de las fijadoras (matarratón, guamo) y el compost devuelven al suelo lo que la cosecha se lleva.',
+  },
+  {
+    id: 'vida',
+    titulo: 'Cuidar la vida del suelo',
+    detalle: 'Lombrices, hongos y micorrizas hacen el trabajo. No quemar, arar poco: el fuego y el arado de más matan esa vida.',
+    fotos: ['lombriz', 'micorriza', 'micelio'],
+  },
+  {
+    id: 'nitrogeno',
+    titulo: 'Fijadoras de nitrógeno',
+    detalle: 'Las leguminosas y el aliso guardan nitrógeno del aire en sus raíces (los nódulos) y se lo pasan al suelo — abono sin bolsa.',
+    fotos: ['nodulos'],
+  },
+];
+
+export const SUELO_NOTA_SIN_CIFRAS =
+  'Aquí no encontrará kilos por hectárea ni dosis: cuánta cobertura, cuánto compost y qué corregir dependen de SU suelo. Eso se mira en el cuaderno del suelo o con el agente, no se inventa.';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * ESTACIÓN 5 · CON QUÉ SEMBRAR (especies multipropósito para restaurar)
+ * Curaduría groundeada: nativas primero, con su papel funcional real. Solo ids
+ * del catálogo. Lo que no está groundeado = "dato en camino".
+ * ──────────────────────────────────────────────────────────────────────── */
+export const ESPECIES_RESTAURACION = [
+  { id: 'alnus_acuminata', comun: 'Aliso andino', cientifico: 'Alnus acuminata', nativo: true, papeles: ['Fija N', 'Madera', 'Restaura laderas'], nota: 'La pionera andina por excelencia: fija nitrógeno con Frankia y arma suelo rápido en tierra herida.' },
+  { id: 'quercus_humboldtii', comun: 'Roble negro andino', cientifico: 'Quercus humboldtii', nativo: true, papeles: ['Dosel', 'Clímax', 'Fauna'], nota: 'Árbol protegido y clave del bosque andino: se siembra para el largo plazo, bajo sombra ya hecha.' },
+  { id: 'weinmannia_tomentosa', comun: 'Encenillo', cientifico: 'Weinmannia tomentosa', nativo: true, papeles: ['Bosque altoandino', 'Borde de páramo'], nota: 'Nativa del frío alto: restaura los bordes de bosque y páramo donde poco más prende.' },
+  { id: 'inga_edulis', comun: 'Guamo', cientifico: 'Inga edulis', nativo: false, papeles: ['Fija N', 'Sombra', 'Fruto'], nota: 'Sombra de café y guama para comer; sus hojas caídas hacen mantillo espeso.' },
+  { id: 'erythrina_edulis', comun: 'Chachafruto / Balú', cientifico: 'Erythrina edulis', nativo: false, papeles: ['Fija N', 'Comida', 'Cerca viva'], nota: 'Fija nitrógeno y da un fruto proteico; sirve de cerca viva y de sombra.' },
+  { id: 'gliricidia_sepium', comun: 'Matarratón', cientifico: 'Gliricidia sepium', nativo: false, papeles: ['Fija N', 'Cerca viva', 'Poda-y-tira', 'Forraje'], nota: 'Prende de estaca: cerca viva que se poda seguido para tapar el suelo y alimentar animales.' },
+  { id: 'samanea_saman', comun: 'Samán', cientifico: 'Samanea saman', nativo: true, papeles: ['Dosel amplio', 'Fija N', 'Sombra'], nota: 'Copa enorme para sombra de potrero; leguminosa que enriquece el suelo debajo.' },
+  { id: 'albizia_guachapele', comun: 'Iguá', cientifico: 'Albizia niopoides', nativo: true, papeles: ['Fija N', 'Madera'], nota: 'Nativa maderable que fija nitrógeno: buena para enriquecer y dar sombra alta.' },
+  { id: 'cordia_alliodora', comun: 'Nogal cafetero', cientifico: 'Cordia alliodora', nativo: false, papeles: ['Madera fina', 'Dosel'], nota: 'Madera valiosa que convive con el café; se autopoda y deja pasar luz.' },
+  { id: 'tabebuia_rosea', comun: 'Guayacán rosado', cientifico: 'Tabebuia rosea', nativo: false, papeles: ['Dosel', 'Flor / néctar', 'Madera'], nota: 'Florece en rosado y alimenta polinizadores; madera y sombra alta.' },
+  { id: 'vaccinium_meridionale', comun: 'Mortino / Agraz', cientifico: 'Vaccinium meridionale', nativo: true, papeles: ['Arbusto nativo', 'Fruto silvestre'], nota: 'Arbusto altoandino nativo para restaurar y cosechar fruto silvestre.' },
+  { id: 'mucuna_pruriens', comun: 'Fríjol terciopelo', cientifico: 'Mucuna pruriens', nativo: false, papeles: ['Abono verde', 'Fija N', 'Cobertura'], nota: 'Abono verde de choque: tapa el suelo rápido, ahoga la maleza y fija nitrógeno.' },
+  { id: 'urtica_dioica', comun: 'Ortiga', cientifico: 'Urtica dioica', nativo: false, papeles: ['Dinamizadora', 'Biomasa', 'Purín'], nota: 'Acumula minerales en su hoja: se corta para mantillo o purín que dinamiza el suelo.' },
+];
+
+export const NOTA_GROUNDING =
+  'Todas estas especies existen en el catálogo Chagra. Si busca una que no aparece, no se la inventamos: pregúntele al agente o quedará como "dato en camino" hasta groundearla.';


### PR DESCRIPTION
## Qué es

Nuevo mundo **photo-forward** "Restauración y bosque de alimentos" que **complementa** (no duplica) el mundo *Diseño de la finca* (que ya trae reforestación/silvopastoreo/páramo). Enfoque **food forest**: los 7 estratos, la sucesión ecológica y la restauración de suelos degradados, enmarcados como **método**.

Sigue el patrón de `AguaScreen`/`CafeScreen`/`CompostScreen` — mismas piezas (`ScreenShell`, `PedagogicalBlock`, foto con scrim+fallback+crédito, pestañas de estaciones). No inventa motor nuevo.

## Cómo se llega
Home → mundo **"Diseño de la finca"** (🌳) → entrada **"Restauración y bosque de alimentos"**. Deep-links: `#restauracion`, `#bosque-de-alimentos`, `#agroforesteria`.

## Grounding responsable
Memoria `feedback-restauracion-grounding-fabrica-especies`: la restauración fabrica especies si no se ancla al catálogo. Aquí **toda** especie es un id real de `public/grafo-relations.json`. Un test cruza cada id contra el grafo y verifica que el flag `nativo` coincide con `establishment_means === 'nativo'`. Cifras de sitio (distancias, dosis) = "dato en camino" (SlotPendiente). Guards anti-fabricación en las estaciones de suelo y especies.

## 5 estaciones
1. **El bosque de alimentos** — qué es e imita al monte (vs monocultivo).
2. **Los 7 estratos** — dosel → raíces → trepadoras, cada piso con especies groundeadas.
3. **Sucesión** — pioneras fijadoras (matarratón, guamo, chachafruto, aliso, tarwi, mucuna) → bosque de clímax (nogal, roble negro, encenillo, guayacán).
4. **Restaurar el suelo** — suelo herido (erosión/costra) → método: cobertura, materia orgánica, vida del suelo, fijadoras de N.
5. **Con qué sembrar** — especies multipropósito, nativas primero, con su papel funcional real.

Puentes: `asociaciones`, `salud_suelo`, `compost`, `seguimiento_reforestacion`, `biodiversidad`, `agente`.

## Presupuesto / assets
Photo-forward **reusando** fotos CC ya presentes en `public/` (café, soil-life, frutales, plátano, cacao) con su atribución conservada — **0 KB de imágenes** al bundle. Chunk lazy nuevo ≈ 39 KB JS + 0.5 KB CSS.

## Verificación
- `npm run build` OK
- perf-budget **24.8 / 25 MB** (within thresholds)
- tsc-gate **1829 = baseline** (0 errores nuevos)
- vitest: 14 tests del mundo (incl. grounding cross-check) + reachability + dashboard (169 total) verdes
- eslint limpio · español Colombia sin voseo

🤖 Generated with [Claude Code](https://claude.com/claude-code)