### PR TITLE
feat(clima): enriquecimiento visual del módulo de clima (CSS/SVG, byte-neutral)

### DIFF
--- a/src/components/dashboard/ClimaIconoVivo.jsx
+++ b/src/components/dashboard/ClimaIconoVivo.jsx
@@ -1,0 +1,150 @@
+import './clima-vivo.css';
+
+/**
+ * ClimaIconoVivo — iconografía SVG animada del módulo de clima.
+ *
+ * Reemplaza los íconos estáticos de lucide en el pronóstico por SVG inline
+ * con capas que "respiran": rayos del sol girando lento, nubes que vagan
+ * 1-2 px, gotas de lluvia cayendo en bucle, bandas de niebla que van y
+ * vienen. Todo con `transform`/`opacity` (GPU-friendly, cero repaints) y con
+ * `prefers-reduced-motion: reduce` → estático legible (clima-vivo.css).
+ *
+ * Restricción de bundle (24.9/25 MB): CERO assets nuevos — cada ícono son
+ * ~10 líneas de path inline, mismo lenguaje visual stroke de lucide
+ * (viewBox 24, stroke currentColor, cap redondo) para no desentonar con el
+ * resto del dashboard.
+ *
+ * Las condiciones son EXACTAMENTE las de skyConditionService (despejado |
+ * parcial | nublado | niebla | lluvia) — este componente no reinterpreta el
+ * dato, solo lo pinta. Condición desconocida → cae a `parcial` (mismo
+ * fallback que tenía el mapa CONDITION_ICONS de ClimaStrip).
+ *
+ * `frost` agrega un copo pequeño en la esquina: SOLO para días con mínima
+ * pronosticada ≤ 0 °C (helada REAL — no confundir con el umbral de
+ * vigilancia por piso térmico, que es aviso, no helada).
+ *
+ * Decorativo: `aria-hidden` siempre — la celda/tarjeta que lo usa pone el
+ * `title`/`aria-label` con el texto honesto de la condición.
+ */
+
+/** Path de nube estilo lucide (compartido por parcial/nublado/niebla/lluvia). */
+const NUBE = 'M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z';
+
+/** Copo de esquina para días de helada real (mínima ≤ 0 °C). */
+function CopoBadge() {
+    return (
+        <g className="cv-anim cv-copo text-cyan-300" strokeWidth="1.4" aria-hidden="true">
+            <line x1="19" y1="2.2" x2="19" y2="8.2" />
+            <line x1="16.4" y1="3.7" x2="21.6" y2="6.7" />
+            <line x1="16.4" y1="6.7" x2="21.6" y2="3.7" />
+        </g>
+    );
+}
+
+const ICONOS = {
+    despejado: () => (
+        <>
+            <g className="cv-anim cv-rayos" opacity="0.9">
+                <line x1="12" y1="2.2" x2="12" y2="4.6" />
+                <line x1="12" y1="19.4" x2="12" y2="21.8" />
+                <line x1="2.2" y1="12" x2="4.6" y2="12" />
+                <line x1="19.4" y1="12" x2="21.8" y2="12" />
+                <line x1="5.1" y1="5.1" x2="6.8" y2="6.8" />
+                <line x1="17.2" y1="17.2" x2="18.9" y2="18.9" />
+                <line x1="5.1" y1="18.9" x2="6.8" y2="17.2" />
+                <line x1="17.2" y1="6.8" x2="18.9" y2="5.1" />
+            </g>
+            <circle className="cv-anim cv-sol" cx="12" cy="12" r="4.6" />
+        </>
+    ),
+    parcial: () => (
+        <>
+            {/* Sol arriba-izquierda, nube abajo-derecha: sin solaparse no hace
+                falta rellenar la nube (el fondo varía por tema). */}
+            <g className="cv-anim cv-sol" opacity="0.95">
+                <circle cx="7.5" cy="7" r="2.8" />
+                <line x1="7.5" y1="1.8" x2="7.5" y2="3.3" />
+                <line x1="1.8" y1="7" x2="3.3" y2="7" />
+                <line x1="3.4" y1="2.9" x2="4.5" y2="4" />
+                <line x1="10.5" y1="4" x2="11.6" y2="2.9" />
+            </g>
+            <g transform="translate(4.5 5.5) scale(0.78)">
+                <g className="cv-anim cv-nube">
+                    <path d={NUBE} />
+                </g>
+            </g>
+        </>
+    ),
+    nublado: () => (
+        <>
+            <g transform="translate(5 -1.5) scale(0.62)" opacity="0.45">
+                <g className="cv-anim cv-nube-lenta">
+                    <path d={NUBE} />
+                </g>
+            </g>
+            <g transform="translate(0.5 2) scale(0.88)">
+                <g className="cv-anim cv-nube">
+                    <path d={NUBE} />
+                </g>
+            </g>
+        </>
+    ),
+    niebla: () => (
+        <>
+            <g transform="translate(1 -1.5) scale(0.82)">
+                <g className="cv-anim cv-nube">
+                    <path d={NUBE} />
+                </g>
+            </g>
+            <line className="cv-anim cv-niebla-1" x1="5" y1="18.5" x2="17" y2="18.5" />
+            <line className="cv-anim cv-niebla-2" x1="8" y1="21.5" x2="19" y2="21.5" />
+        </>
+    ),
+    lluvia: () => (
+        <>
+            <g transform="translate(1 -2) scale(0.86)">
+                <g className="cv-anim cv-nube">
+                    <path d={NUBE} />
+                </g>
+            </g>
+            {/* Opacidad base en el markup: con reduced-motion (animation: none)
+                las gotas quedan visibles estáticas, no invisibles. */}
+            <g className="text-sky-400" strokeWidth="1.8">
+                <line className="cv-anim cv-gota" opacity="0.9" x1="8" y1="17.5" x2="7.4" y2="19.5" />
+                <line className="cv-anim cv-gota cv-gota-2" opacity="0.9" x1="12.2" y1="18.5" x2="11.6" y2="20.5" />
+                <line className="cv-anim cv-gota cv-gota-3" opacity="0.9" x1="16.2" y1="17.5" x2="15.6" y2="19.5" />
+            </g>
+        </>
+    ),
+};
+
+/**
+ * @param {object} props
+ * @param {'despejado'|'parcial'|'nublado'|'niebla'|'lluvia'|string|null} [props.condition]
+ *   Condición de skyConditionService. Desconocida/null → `parcial`.
+ * @param {number} [props.size] Lado en px (default 22, como lucide en el strip).
+ * @param {string} [props.className] Clases de color/layout (p. ej. `text-amber-300`).
+ * @param {boolean} [props.frost] Copo de helada REAL (mínima ≤ 0 °C) en la esquina.
+ */
+export default function ClimaIconoVivo({ condition = 'parcial', size = 22, className = '', frost = false }) {
+    const Capas = ICONOS[condition] || ICONOS.parcial;
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+            aria-hidden="true"
+            data-testid="clima-icono-vivo"
+            data-condition-icon={ICONOS[condition] ? condition : 'parcial'}
+        >
+            <Capas />
+            {frost && <CopoBadge />}
+        </svg>
+    );
+}

--- a/src/components/dashboard/ClimaStrip.jsx
+++ b/src/components/dashboard/ClimaStrip.jsx
@@ -1,12 +1,14 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { Cloud, CloudRain, CloudFog, Sun, CloudSun, Droplets, Wind, Thermometer, MapPin, AlertCircle, Pencil } from 'lucide-react';
-import { fetchClimaSnapshot, getCachedClimaSnapshot } from '../../services/climaService';
-import { fetchSkyConditions, getCachedSkyConditions, skyForDay } from '../../services/skyConditionService';
+import { Cloud, Droplets, Snowflake, Thermometer, MapPin, AlertCircle, Pencil } from 'lucide-react';
+import { fetchClimaSnapshot, getCachedClimaSnapshot, describePhase } from '../../services/climaService';
+import { fetchSkyConditions, getCachedSkyConditions, skyForDay, pisoFromMsnm } from '../../services/skyConditionService';
 import { findMunicipio } from '../../utils/colombiaLocations';
-import { isSavedLocationCoarse } from '../../services/locationService';
+import { isSavedLocationCoarse, getPisoTermicoInfo } from '../../services/locationService';
+import { FORECAST_THRESHOLDS } from '../../constants/alertThresholds';
 import { FARM_CONFIG } from '../../config/defaults';
 import useFincaActiveStore from '../../services/fincaActiveStore';
 import { getProfile, getProfileMunicipio } from '../../services/userProfileService';
+import ClimaIconoVivo from './ClimaIconoVivo';
 
 /**
  * ClimaStrip — pronóstico real de 7 días debajo del agente.
@@ -44,7 +46,7 @@ import { getProfile, getProfileMunicipio } from '../../services/userProfileServi
 const DAY_LABELS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
 
 /**
- * Ícono + color por CONDICIÓN REAL del cielo (fix Choachí 2026-06).
+ * Color por CONDICIÓN REAL del cielo (fix Choachí 2026-06).
  *
  * Antes: <2 mm de precipitación → "solecito" ámbar. En los pueblos altoandinos
  * (nubosidad orográfica + niebla SIN lluvia medible) eso prometía ~4 días de
@@ -52,13 +54,16 @@ const DAY_LABELS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
  * nubosidad real de Open-Meteo + corrección por piso térmico + ENSO; sin dato
  * de nube cae a un prior conservador (piso frío → variable, no sol).
  * El ámbar de "sol" queda RESERVADO para despejado de verdad.
+ *
+ * El dibujo ahora lo pone ClimaIconoVivo (SVG animado sutil, GPU-friendly);
+ * este mapa solo aporta el color por condición.
  */
-const CONDITION_ICONS = {
-    despejado: { Icon: Sun, cls: 'text-amber-300' },
-    parcial: { Icon: CloudSun, cls: 'text-slate-200' },
-    nublado: { Icon: Cloud, cls: 'text-slate-400' },
-    niebla: { Icon: CloudFog, cls: 'text-slate-300' },
-    lluvia: { Icon: CloudRain, cls: 'text-sky-400' },
+const CONDITION_COLORS = {
+    despejado: 'text-amber-300',
+    parcial: 'text-slate-200',
+    nublado: 'text-slate-400',
+    niebla: 'text-slate-300',
+    lluvia: 'text-sky-400',
 };
 
 function dayLabel(isoDate, i) {
@@ -324,6 +329,36 @@ export default function ClimaStrip({ onNavigate, embedded = false }) {
     const hasReal = filled.some((d) => d.tempMaxC != null);
     const headerLabel = (municipio || '').split(',')[0] || 'su finca';
 
+    // ── Piso térmico (grounding térmico por ALTITUD GUARDADA del perfil) ──
+    // Refuerza visualmente el dato que el agente más confunde: a qué piso
+    // pertenece la finca y que el pronóstico YA viene corregido a esa altitud.
+    // Sin altitud → "dato en camino", jamás un piso inventado.
+    const pisoInfo = geo?.elevation != null ? getPisoTermicoInfo(geo.elevation) : null;
+    const pisoSlug = geo?.elevation != null ? pisoFromMsnm(geo.elevation) : null;
+
+    // ── Helada BIEN CALIBRADA ──────────────────────────────────────────────
+    // Helada REAL = mínima pronosticada ≤ 0 °C. Punto. Por encima de 0 °C y
+    // hasta el umbral de VIGILANCIA del piso térmico (los mismos
+    // FORECAST_THRESHOLDS.HELADA_MIN_C que usa alertEngine: páramo 6°, frío 4°,
+    // templado 2°, cálido 1°) es "noche fría / riesgo", nunca "helada". Esto es
+    // coherente con el guard del agente en curso (helada ≤ 0 °C, no 14 °C).
+    const umbralVigilancia = FORECAST_THRESHOLDS.HELADA_MIN_C[pisoSlug]
+        ?? FORECAST_THRESHOLDS.HELADA_MIN_C.default;
+    const heladaDia = filled.find((d) => d.tempMinC != null && d.tempMinC <= 0) || null;
+    const nocheFriaDia = heladaDia
+        ? null
+        : filled.find((d) => d.tempMinC != null && d.tempMinC <= umbralVigilancia) || null;
+
+    // ── ENSO/temporada — SOLO si el dato existe en el snapshot ────────────
+    // Sin fase del sidecar no se muestra nada (cero fabricación). El guard
+    // `typeof describePhase === 'function'` cubre los tests que mockean
+    // climaService parcialmente (solo fetch/getCached).
+    const ensoPhaseRaw = snapshot?.enso_status?.phase || null;
+    const ensoTexto = ensoPhaseRaw && typeof describePhase === 'function'
+        ? describePhase(ensoPhaseRaw)
+        : null;
+    const ensoVisible = ensoTexto && !/desconocido/i.test(ensoTexto) ? ensoTexto : null;
+
     return (
         <div className={embedded ? 'px-4 pb-4 pt-1' : 'bg-gradient-to-br from-sky-950/70 to-indigo-950/60 backdrop-blur-xl border border-sky-800/40 rounded-2xl p-5'}>
             <div className={`flex items-center justify-between ${embedded ? 'mb-2' : 'mb-3'}`}>
@@ -353,6 +388,39 @@ export default function ClimaStrip({ onNavigate, embedded = false }) {
                         <Pencil size={13} aria-hidden="true" />
                     </button>
                 </div>
+            </div>
+
+            {/* Contexto de grounding: piso térmico por ALTITUD GUARDADA + ENSO.
+                El chip de piso refuerza el dato térmico correcto (el que el
+                agente más confunde) y explicita que el pronóstico ya viene
+                corregido a la altitud de la finca. Sin altitud → "dato en
+                camino" (cero invención). ENSO solo si el snapshot lo trae. */}
+            <div className={`flex flex-wrap items-center gap-1.5 ${embedded ? 'mb-2' : 'mb-3'}`} data-testid="clima-contexto">
+                {pisoInfo ? (
+                    <span
+                        data-testid="clima-piso-termico"
+                        title={`Piso térmico ${pisoInfo.label} (${pisoInfo.rango}). El pronóstico ya está corregido a la altitud de su finca.`}
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg bg-emerald-500/10 border border-emerald-500/25 text-[10px] font-bold text-emerald-200"
+                    >
+                        <span aria-hidden="true">{pisoInfo.emoji}</span>
+                        Piso {pisoInfo.label.toLowerCase()} · {Math.round(geo.elevation)} msnm
+                    </span>
+                ) : (
+                    <span
+                        data-testid="clima-piso-pendiente"
+                        className="inline-flex items-center px-2 py-0.5 rounded-lg bg-white/[0.04] border border-white/[0.08] text-[10px] text-slate-400"
+                    >
+                        Altitud de la finca: dato en camino
+                    </span>
+                )}
+                {ensoVisible && (
+                    <span
+                        data-testid="clima-enso"
+                        className="inline-flex items-center px-2 py-0.5 rounded-lg bg-sky-500/10 border border-sky-500/25 text-[10px] text-sky-200"
+                    >
+                        {ensoVisible}
+                    </span>
+                )}
             </div>
 
             {/* mitad geo de #364: aviso de confianza cuando la ubicación GUARDADA
@@ -392,23 +460,69 @@ export default function ClimaStrip({ onNavigate, embedded = false }) {
                 </p>
             )}
 
+            {/* Aviso de helada CALIBRADO: banner solo con helada REAL (mínima
+                ≤ 0 °C) en el pronóstico. Noches frías por encima de 0 °C pero
+                bajo el umbral de vigilancia del piso térmico → nota suave que
+                además ENSEÑA la calibración (no grita "helada" a 14 °C). */}
+            {heladaDia && (
+                <div
+                    data-testid="clima-helada-aviso"
+                    className="mb-3 rounded-xl bg-cyan-950/40 border border-cyan-700/50 p-3 text-xs text-cyan-100 flex gap-2"
+                >
+                    <Snowflake size={14} className="shrink-0 mt-0.5 text-cyan-300" aria-hidden="true" />
+                    <p className="leading-relaxed">
+                        <span className="font-bold">Helada en el pronóstico:</span>{' '}
+                        {heladaDia.label} con mínima de {Math.round(heladaDia.tempMinC)} °C
+                        (helada real = 0 °C o menos). Proteja los cultivos sensibles
+                        antes del anochecer.
+                    </p>
+                </div>
+            )}
+            {nocheFriaDia && pisoInfo && (
+                <p data-testid="clima-noche-fria" className="text-[11px] text-sky-200/80 mb-3 leading-relaxed">
+                    Noches frías en el pronóstico (mínima {Math.round(nocheFriaDia.tempMinC)} °C,
+                    vigilancia desde {umbralVigilancia} °C en piso {pisoInfo.label.toLowerCase()}).
+                    Helada real solo si baja a 0 °C o menos.
+                </p>
+            )}
+
             <div className="grid grid-cols-7 gap-1.5 sm:gap-2">
                 {filled.map((d, i) => {
-                    const { Icon, cls } = CONDITION_ICONS[d.condition] || CONDITION_ICONS.parcial;
+                    const cls = CONDITION_COLORS[d.condition] || CONDITION_COLORS.parcial;
+                    // Copo/realce SOLO con helada real (≤ 0 °C), coherente con el banner.
+                    const esHelada = d.tempMinC != null && d.tempMinC <= 0;
                     return (
                         <div
                             key={i}
                             data-condition={d.condition}
-                            title={d.conditionLabel}
-                            className={`flex flex-col items-center gap-1 ${embedded ? 'py-1.5' : 'py-2.5'} rounded-xl bg-white/[0.04] border border-white/[0.06]`}
+                            title={esHelada
+                                ? `${d.conditionLabel} · Helada: mínima de ${Math.round(d.tempMinC)} °C`
+                                : d.conditionLabel}
+                            style={{ '--cv-i': i }}
+                            className={`clima-dia-card flex flex-col items-center gap-1 ${embedded ? 'py-1.5' : 'py-2.5'} rounded-xl border ${esHelada
+                                ? 'bg-cyan-500/10 border-cyan-400/40'
+                                : i === 0
+                                    ? 'bg-white/[0.07] border-white/[0.16]'
+                                    : 'bg-white/[0.04] border-white/[0.06]'}`}
                         >
-                            <span className="text-[10px] font-bold text-slate-400 uppercase tracking-wide">{d.label}</span>
-                            <Icon size={embedded ? 18 : 22} className={cls} />
+                            <span className={`text-[10px] font-bold uppercase tracking-wide ${i === 0 ? 'text-slate-200' : 'text-slate-400'}`}>{d.label}</span>
+                            <ClimaIconoVivo
+                                condition={d.condition}
+                                frost={esHelada}
+                                size={embedded ? 18 : 22}
+                                className={cls}
+                            />
                             {d.tempMaxC != null && (
                                 <span className={`${embedded ? 'text-xs' : 'text-sm'} font-bold text-white tabular-nums`}>{Math.round(d.tempMaxC)}°</span>
                             )}
                             {d.tempMinC != null && (
-                                <span className="text-[10px] text-slate-400 tabular-nums">{Math.round(d.tempMinC)}°</span>
+                                <span className={`text-[10px] tabular-nums ${esHelada ? 'text-cyan-300 font-bold' : 'text-slate-400'}`}>{Math.round(d.tempMinC)}°</span>
+                            )}
+                            {/* Lluvia esperada del día: solo con dato real ≥ 1 mm. */}
+                            {d.precipMm != null && d.precipMm >= 1 && (
+                                <span className="text-[9px] text-sky-300/80 tabular-nums leading-none">
+                                    {Math.round(d.precipMm)} mm
+                                </span>
                             )}
                         </div>
                     );
@@ -428,9 +542,12 @@ export default function ClimaStrip({ onNavigate, embedded = false }) {
                         <Droplets size={14} className="text-sky-400" />
                         <span className="truncate">Lluvia</span>
                     </div>
+                    {/* Antes decía "Viento", pero el strip nunca pinta viento —
+                        leyenda huérfana. En su lugar, la calibración de helada
+                        (≤ 0 °C real) que sí se usa en celdas y banner. */}
                     <div className="flex items-center gap-1.5 text-slate-300">
-                        <Wind size={14} className="text-emerald-400" />
-                        <span className="truncate">Viento</span>
+                        <Snowflake size={14} className="text-cyan-300" />
+                        <span className="truncate">Helada ≤ 0 °C</span>
                     </div>
                 </div>
             )}

--- a/src/components/dashboard/HoyEnFincaStrip.jsx
+++ b/src/components/dashboard/HoyEnFincaStrip.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Sun, CloudSun, Cloud, CloudFog, CloudRain, Sunrise, Bell, ClipboardList, ChevronRight } from 'lucide-react';
+import { Sunrise, Bell, ClipboardList, ChevronRight } from 'lucide-react';
+import ClimaIconoVivo from './ClimaIconoVivo';
 import useAlertStore from '../../store/useAlertStore';
 import { listFarmProcesses } from '../../db/farmProcessCache';
 import {
@@ -27,12 +28,13 @@ import { buildClimaHoy, buildTareasSemana, buildAgenda, agendaPorDia } from '../
  * para los tres paneles fundidos. Solo cambia la capa visual; datos idénticos.
  */
 
-const CONDITION_ICONS = {
-    despejado: { Icon: Sun, cls: 'text-amber-300' },
-    parcial: { Icon: CloudSun, cls: 'text-slate-200' },
-    nublado: { Icon: Cloud, cls: 'text-slate-400' },
-    niebla: { Icon: CloudFog, cls: 'text-slate-300' },
-    lluvia: { Icon: CloudRain, cls: 'text-sky-400' },
+/* El dibujo lo pone ClimaIconoVivo (SVG animado sutil); aquí solo el color. */
+const CONDITION_COLORS = {
+    despejado: 'text-amber-300',
+    parcial: 'text-slate-200',
+    nublado: 'text-slate-400',
+    niebla: 'text-slate-300',
+    lluvia: 'text-sky-400',
 };
 
 export default function HoyEnFincaStrip({ onNavigate, embedded = false }) {
@@ -88,7 +90,7 @@ export default function HoyEnFincaStrip({ onNavigate, embedded = false }) {
         [],
     );
 
-    const { Icon: CondIcon, cls: condCls } = CONDITION_ICONS[clima.condition] || CONDITION_ICONS.parcial;
+    const condCls = CONDITION_COLORS[clima.condition] || CONDITION_COLORS.parcial;
 
     return (
         <button
@@ -117,7 +119,12 @@ export default function HoyEnFincaStrip({ onNavigate, embedded = false }) {
                 <div className="flex items-center gap-2 min-w-0 flex-1">
                     {clima.hasData ? (
                         <>
-                            <CondIcon size={32} className={`${condCls} shrink-0`} aria-hidden="true" />
+                            <ClimaIconoVivo
+                                condition={clima.condition}
+                                frost={clima.tempMinC != null && clima.tempMinC <= 0}
+                                size={32}
+                                className={`${condCls} shrink-0`}
+                            />
                             <div className="min-w-0">
                                 <p className="text-sm font-bold text-white truncate">{clima.label}</p>
                                 {clima.tempMaxC != null && (

--- a/src/components/dashboard/__tests__/ClimaStrip.pisoHelada.test.jsx
+++ b/src/components/dashboard/__tests__/ClimaStrip.pisoHelada.test.jsx
@@ -1,0 +1,151 @@
+/**
+ * ClimaStrip.pisoHelada.test.jsx — enriquecimiento visual del clima (2026-07).
+ *
+ * Cubre las tres piezas nuevas de grounding visual del strip:
+ *   1. Chip de PISO TÉRMICO por altitud GUARDADA del perfil (nunca geo en
+ *      vivo): refuerza el grounding térmico correcto. Sin altitud → "dato en
+ *      camino" (cero invención).
+ *   2. Aviso de HELADA BIEN CALIBRADO: banner solo con mínima ≤ 0 °C (helada
+ *      REAL). Mínimas frías por encima de 0 °C pero bajo el umbral de
+ *      vigilancia del piso (FORECAST_THRESHOLDS.HELADA_MIN_C, el mismo del
+ *      alertEngine) → nota de "noches frías", nunca "helada".
+ *   3. Chip ENSO en lenguaje llano SOLO si el snapshot trae la fase.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import ClimaStrip from '../ClimaStrip';
+
+// Mock de climaService: cada test arma su snapshot. describePhase pasa la
+// fase a texto llano (versión mínima del real — el componente lo guarda con
+// typeof por los tests que mockean el módulo sin este export).
+vi.mock('../../../services/climaService', () => ({
+    fetchClimaSnapshot: vi.fn(() => Promise.resolve(null)),
+    getCachedClimaSnapshot: vi.fn(() => null),
+    describePhase: vi.fn((phase) => (
+        phase === 'nina_moderada' ? 'La Niña moderada — mas lluvia de lo normal' : 'Estado del clima desconocido'
+    )),
+}));
+import { fetchClimaSnapshot } from '../../../services/climaService';
+
+vi.mock('../../../utils/colombiaLocations', () => ({
+    findMunicipio: vi.fn(() => null),
+}));
+
+vi.mock('../../../services/fincaActiveStore', () => {
+    const store = { activeFincaSlug: 'guatoc', fincas: [] };
+    const useFincaActiveStore = (selector) => selector(store);
+    return { default: useFincaActiveStore };
+});
+
+vi.mock('../../../config/defaults', () => ({
+    FARM_CONFIG: { MUNICIPIO: null },
+}));
+
+// Perfil con ubicación GUARDADA completa (coords + altitud de finca fría).
+vi.mock('../../../services/userProfileService', () => {
+    const getProfile = vi.fn(() => /** @type {Record<string, any>} */ ({}));
+    const getProfileMunicipio = vi.fn(() => getProfile()?.municipio ?? null);
+    return { getProfile, getProfileMunicipio, isModuleVisible: vi.fn(() => true) };
+});
+import { getProfile } from '../../../services/userProfileService';
+
+const PERFIL_FRIO = {
+    municipio: 'Choachí, Cundinamarca',
+    ubicacion_lat: 4.53,
+    ubicacion_lng: -73.92,
+    finca_altitud: 2580, // piso frío (2000-3000) → umbral de vigilancia 4 °C
+};
+
+/** Snapshot Open-Meteo con la mínima del día 2 parametrizable. */
+function snapshotConMinima(minDia2, extra = {}) {
+    const base = new Date();
+    const dias = Array.from({ length: 7 }, (_, i) => {
+        const d = new Date(base.getTime() + i * 24 * 60 * 60 * 1000);
+        return {
+            date: d.toISOString().slice(0, 10),
+            temp_max_c: 18,
+            temp_min_c: i === 1 ? minDia2 : 8,
+            precip_mm: i === 2 ? 6.4 : 0,
+        };
+    });
+    return {
+        openmeteo: { available: true, forecast_7d: dias },
+        ...extra,
+    };
+}
+
+beforeEach(() => {
+    vi.mocked(fetchClimaSnapshot).mockReset();
+    vi.mocked(fetchClimaSnapshot).mockResolvedValue(null);
+    vi.mocked(getProfile).mockReturnValue(PERFIL_FRIO);
+    localStorage.clear();
+});
+
+describe('ClimaStrip — piso térmico por altitud guardada', () => {
+    test('muestra el chip de piso frío con la altitud del perfil', async () => {
+        vi.mocked(fetchClimaSnapshot).mockResolvedValue(snapshotConMinima(8));
+        render(<ClimaStrip onNavigate={() => {}} />);
+        const chip = await screen.findByTestId('clima-piso-termico');
+        expect(chip).toHaveTextContent(/piso frío/i);
+        expect(chip).toHaveTextContent('2580 msnm');
+    });
+
+    test('sin altitud ni match DANE → "dato en camino", jamás un piso inventado', async () => {
+        vi.mocked(getProfile).mockReturnValue({
+            municipio: 'Choachí, Cundinamarca',
+            ubicacion_lat: 4.53,
+            ubicacion_lng: -73.92,
+            // sin finca_altitud/altitud (findMunicipio mockeado → null)
+        });
+        render(<ClimaStrip onNavigate={() => {}} />);
+        expect(await screen.findByTestId('clima-piso-pendiente')).toHaveTextContent(/dato en camino/i);
+        expect(screen.queryByTestId('clima-piso-termico')).not.toBeInTheDocument();
+    });
+});
+
+describe('ClimaStrip — aviso de helada calibrado (helada real = ≤ 0 °C)', () => {
+    test('mínima de -1 °C → banner de helada con la calibración explícita', async () => {
+        vi.mocked(fetchClimaSnapshot).mockResolvedValue(snapshotConMinima(-1));
+        render(<ClimaStrip onNavigate={() => {}} />);
+        const aviso = await screen.findByTestId('clima-helada-aviso');
+        expect(aviso).toHaveTextContent(/helada en el pronóstico/i);
+        expect(aviso).toHaveTextContent(/0 °C o menos/i);
+    });
+
+    test('mínima de 3 °C en piso frío → NO es helada; nota de noches frías', async () => {
+        vi.mocked(fetchClimaSnapshot).mockResolvedValue(snapshotConMinima(3));
+        render(<ClimaStrip onNavigate={() => {}} />);
+        const nota = await screen.findByTestId('clima-noche-fria');
+        expect(nota).toHaveTextContent(/noches frías/i);
+        expect(nota).toHaveTextContent(/0 °C o menos/i);
+        expect(screen.queryByTestId('clima-helada-aviso')).not.toBeInTheDocument();
+    });
+
+    test('mínima de 8 °C → ni banner de helada ni nota de noches frías', async () => {
+        vi.mocked(fetchClimaSnapshot).mockResolvedValue(snapshotConMinima(8));
+        render(<ClimaStrip onNavigate={() => {}} />);
+        await screen.findByTestId('clima-piso-termico');
+        expect(screen.queryByTestId('clima-helada-aviso')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('clima-noche-fria')).not.toBeInTheDocument();
+    });
+});
+
+describe('ClimaStrip — ENSO solo con dato real', () => {
+    test('snapshot con fase ENSO → chip en lenguaje llano', async () => {
+        vi.mocked(fetchClimaSnapshot).mockResolvedValue(
+            snapshotConMinima(8, { enso_status: { phase: 'nina_moderada' } }),
+        );
+        render(<ClimaStrip onNavigate={() => {}} />);
+        const chip = await screen.findByTestId('clima-enso');
+        expect(chip).toHaveTextContent(/la niña moderada/i);
+    });
+
+    test('snapshot sin enso_status → no hay chip ENSO (cero fabricación)', async () => {
+        vi.mocked(fetchClimaSnapshot).mockResolvedValue(snapshotConMinima(8));
+        render(<ClimaStrip onNavigate={() => {}} />);
+        await screen.findByTestId('clima-piso-termico');
+        expect(screen.queryByTestId('clima-enso')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/dashboard/clima-vivo.css
+++ b/src/components/dashboard/clima-vivo.css
@@ -1,0 +1,95 @@
+/**
+ * clima-vivo.css — animaciones sutiles del módulo de clima.
+ *
+ * Presupuesto GPU (bundle al tope 24.9/25 MB → cero assets nuevos, solo CSS):
+ *   - SOLO `transform` y `opacity` (composited, no repaint). Nada de
+ *     filter/blur/box-shadow ANIMADOS.
+ *   - Duraciones largas y amplitudes de ~1-4 px: el clima "respira", no baila.
+ *   - `prefers-reduced-motion: reduce` → todo estático y legible (las gotas
+ *     de lluvia quedan visibles porque su opacidad base está en el markup).
+ *
+ * Consumidor: ClimaIconoVivo.jsx (íconos SVG del pronóstico) y las celdas de
+ * día de ClimaStrip (`.clima-dia-card`).
+ */
+
+/* Los grupos animados de un SVG rotan/escalan sobre su propio centro. */
+.cv-anim {
+    transform-box: fill-box;
+    transform-origin: 50% 50%;
+}
+
+@keyframes cv-rayos-girar {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@keyframes cv-sol-latir {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.06); }
+}
+
+@keyframes cv-nube-vagar {
+    0%, 100% { transform: translateX(-0.9px); }
+    50% { transform: translateX(0.9px); }
+}
+
+@keyframes cv-gota-caer {
+    0% { transform: translateY(-1.5px); opacity: 0; }
+    35% { opacity: 1; }
+    100% { transform: translateY(3.5px); opacity: 0; }
+}
+
+@keyframes cv-niebla-vagar {
+    0%, 100% { transform: translateX(-1.4px); opacity: 0.5; }
+    50% { transform: translateX(1.4px); opacity: 0.95; }
+}
+
+@keyframes cv-copo-girar {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+/* Entrada escalonada de las celdas del pronóstico (una sola vez). */
+@keyframes cv-entrar {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.cv-rayos { animation: cv-rayos-girar 48s linear infinite; }
+.cv-sol { animation: cv-sol-latir 6s ease-in-out infinite; }
+.cv-nube { animation: cv-nube-vagar 7s ease-in-out infinite; }
+.cv-nube-lenta { animation: cv-nube-vagar 11s ease-in-out infinite reverse; }
+.cv-gota { animation: cv-gota-caer 1.6s ease-in infinite; }
+.cv-gota-2 { animation-delay: 0.45s; }
+.cv-gota-3 { animation-delay: 0.9s; }
+.cv-niebla-1 { animation: cv-niebla-vagar 6s ease-in-out infinite; }
+.cv-niebla-2 { animation: cv-niebla-vagar 8s ease-in-out infinite; animation-delay: 1.2s; }
+.cv-copo { animation: cv-copo-girar 36s linear infinite; }
+
+.clima-dia-card {
+    animation: cv-entrar 0.45s ease both;
+    animation-delay: calc(var(--cv-i, 0) * 45ms);
+    transition: transform 0.18s ease;
+}
+
+.clima-dia-card:hover { transform: translateY(-2px); }
+
+@media (prefers-reduced-motion: reduce) {
+    .cv-rayos,
+    .cv-sol,
+    .cv-nube,
+    .cv-nube-lenta,
+    .cv-gota,
+    .cv-niebla-1,
+    .cv-niebla-2,
+    .cv-copo,
+    .clima-dia-card {
+        animation: none;
+    }
+
+    .clima-dia-card {
+        transition: none;
+    }
+
+    .clima-dia-card:hover { transform: none; }
+}

--- a/src/components/hoy/HoyEnFincaScreen.jsx
+++ b/src/components/hoy/HoyEnFincaScreen.jsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-    Sun, CloudSun, Cloud, CloudFog, CloudRain, Sunrise,
+    Cloud, Sunrise,
     Bell, BellOff, MapPin, Droplets, Sprout, Mic, Bug,
     Package, ClipboardList, MessageCircle, Map as MapIcon, ChevronRight, WifiOff,
 } from 'lucide-react';
+import ClimaIconoVivo from '../dashboard/ClimaIconoVivo';
 import { ScreenShell } from '../common/ScreenShell';
 import AgendaCampesina from './AgendaCampesina';
 import JourneyGuideCard from './JourneyGuideCard';
@@ -18,6 +19,7 @@ import {
     describePhase,
 } from '../../services/climaService';
 import { getCachedSkyConditions, fetchSkyConditions } from '../../services/skyConditionService';
+import { getPisoTermicoInfo } from '../../services/locationService';
 import { buildClimaHoy, buildTareasSemana, buildAgenda } from '../../services/hoyEnFincaService';
 
 /**
@@ -45,12 +47,13 @@ import { buildClimaHoy, buildTareasSemana, buildAgenda } from '../../services/ho
  * y sin cache → estados vacíos honestos, jamás datos inventados.
  */
 
-const CONDITION_ICONS = {
-    despejado: { Icon: Sun, cls: 'text-amber-300' },
-    parcial: { Icon: CloudSun, cls: 'text-slate-200' },
-    nublado: { Icon: Cloud, cls: 'text-slate-400' },
-    niebla: { Icon: CloudFog, cls: 'text-slate-300' },
-    lluvia: { Icon: CloudRain, cls: 'text-sky-400' },
+/* El dibujo lo pone ClimaIconoVivo (SVG animado sutil); aquí solo el color. */
+const CONDITION_COLORS = {
+    despejado: 'text-amber-300',
+    parcial: 'text-slate-200',
+    nublado: 'text-slate-400',
+    niebla: 'text-slate-300',
+    lluvia: 'text-sky-400',
 };
 
 const SEVERITY_STYLES = {
@@ -159,7 +162,10 @@ export default function HoyEnFincaScreen({ onBack, onHome, onNavigate }) {
         );
     }, [goAgente]);
 
-    const { Icon: CondIcon, cls: condCls } = CONDITION_ICONS[clima.condition] || CONDITION_ICONS.parcial;
+    const condCls = CONDITION_COLORS[clima.condition] || CONDITION_COLORS.parcial;
+    // Piso térmico desde la ALTITUD GUARDADA del perfil (grounding térmico):
+    // sin altitud no se muestra nada — jamás un piso inventado.
+    const pisoInfo = elevationM != null ? getPisoTermicoInfo(elevationM) : null;
 
     return (
         <ScreenShell title="Hoy en finca" icon={Sunrise} onBack={onBack} onHome={onHome}>
@@ -238,7 +244,12 @@ export default function HoyEnFincaScreen({ onBack, onHome, onNavigate }) {
                         </div>
                         {clima.hasData ? (
                             <div className="flex items-center gap-4">
-                                <CondIcon size={52} className={`${condCls} shrink-0`} aria-hidden="true" />
+                                <ClimaIconoVivo
+                                    condition={clima.condition}
+                                    frost={clima.tempMinC != null && clima.tempMinC <= 0}
+                                    size={52}
+                                    className={`${condCls} shrink-0`}
+                                />
                                 <div className="flex-1 min-w-0">
                                     <p className="text-xl font-black text-white leading-tight" data-testid="clima-hoy-label">
                                         {clima.label}
@@ -263,6 +274,15 @@ export default function HoyEnFincaScreen({ onBack, onHome, onNavigate }) {
                                     <p className="text-xs text-slate-400 mt-1.5" data-testid="enso-llano">
                                         {describePhase(ensoPhase)}
                                     </p>
+                                    {/* Piso térmico por altitud GUARDADA — refuerza el
+                                        grounding térmico correcto (el pronóstico ya viene
+                                        corregido a la altitud de la finca). */}
+                                    {pisoInfo && (
+                                        <p className="text-[10px] text-emerald-300/80 mt-1" data-testid="clima-piso-termico-hoy">
+                                            <span aria-hidden="true">{pisoInfo.emoji} </span>
+                                            Piso {pisoInfo.label.toLowerCase()} · {Math.round(elevationM)} msnm — pronóstico ajustado a su altitud
+                                        </p>
+                                    )}
                                 </div>
                                 <ChevronRight size={18} className="text-slate-500 shrink-0" aria-hidden="true" />
                             </div>


### PR DESCRIPTION
## Qué hace

Enriquece VISUALMENTE el pilar de clima (el que más consulta el piloto) sin subir bytes al bundle: **cero fotos, cero deps — solo CSS + SVG inline**, animaciones GPU-friendly (`transform`/`opacity`, nada de filter/blur animado).

### Piezas

1. **`ClimaIconoVivo`** (nuevo): iconografía SVG inline animada sutil por condición real del cielo (skyConditionService): rayos del sol girando lento, nubes que vagan 1-2 px, gotas de lluvia en bucle, bandas de niebla. Mismo lenguaje visual stroke de lucide. `prefers-reduced-motion: reduce` → estático legible (las gotas quedan visibles por opacidad base en el markup). Usado en ClimaStrip (celdas 7 días), HoyEnFincaStrip y HoyEnFincaScreen.
2. **Chip de PISO TÉRMICO** por altitud **GUARDADA** del perfil (nunca geo en vivo — memoria `feedback-clima-usa-ubicacion-guardada`): `⛅ Piso frío · 2580 msnm` con title que explica que el pronóstico ya viene corregido a esa altitud. Refuerza el grounding térmico que el agente más confunde. Sin altitud → **"dato en camino"**, jamás un piso inventado.
3. **Aviso de helada BIEN CALIBRADO**: banner solo con mínima pronosticada **≤ 0 °C (helada real)**; mínimas frías por encima de 0 °C pero bajo el umbral de vigilancia del piso (`FORECAST_THRESHOLDS.HELADA_MIN_C`, el MISMO del alertEngine: páramo 6°/frío 4°/templado 2°/cálido 1°) → nota de "noches frías" que además enseña la calibración. Coherente con el fix de guard en curso (helada ≠ 14 °C).
4. **Chip ENSO/temporada** en lenguaje llano (`describePhase`) SOLO si el snapshot del sidecar trae la fase — cero fabricación.
5. **Tarjetas vivas**: entrada escalonada (una vez), hoy realzado, hover lift, mm de lluvia por día cuando hay dato real ≥ 1 mm, celda de helada con copo + realce cian.
6. Leyenda: "Viento" (huérfana — el strip nunca pintó viento) → "Helada ≤ 0 °C".

### Gates (corridos en local)
- [x] `vitest`: suites de clima/dashboard/hoy/services — 334 passed; los 3 archivos con 6 fails (userProfileService, sidecarClient, agentService.especieDesconocida) **fallan igual en origin/main** (pre-existentes, verificado en detached HEAD).
- [x] Suite nueva `ClimaStrip.pisoHelada.test.jsx` (7 tests: piso por altitud guardada, 'dato en camino', helada ≤0 °C vs noches frías, ENSO solo con dato).
- [x] `tsc-check-gate`: 1829 = baseline, sin errores nuevos.
- [x] eslint: sin errores nuevos (el `set-state-in-effect` de ClimaStrip pre-existe en main, verificado contra origin/main).
- [x] **Bytes ≈ 0**: dist rama 35 745 908 B vs main 35 737 839 B → **+8 069 B (+0.02 %)**, solo CSS+SVG minificado. `check-perf-budget`: 25.0/25.0 MB verde (TF.js lazy excluido como en main).

### Cómo se ve
Capturas (normal + prefers-reduced-motion) enviadas al operador por Telegram para el OK visual (política: visuales esperan aprobación — por eso queda en draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)