### PR TITLE
fix(guard-termico): no llamar 'helada' a 14°C + anti-autocontradicción + usar helada_letal

### DIFF
--- a/src/services/__tests__/agentService.especieDesconocida.test.js
+++ b/src/services/__tests__/agentService.especieDesconocida.test.js
@@ -8,7 +8,10 @@ describe('generateSourceCitationRules — guard de especie desconocida', () => {
   it('incluye la regla de NO describir especies fuera del catálogo', () => {
     const r = generateSourceCitationRules();
     expect(r).toContain('ESPECIE DESCONOCIDA');
-    expect(r).toMatch(/NO inventes su descripción/);
+    // La regla prohíbe explícitamente inventar la descripción de una especie
+    // fuera del catálogo (redactada como "PROHIBIDO darle ... descripción" y
+    // "Inventar ... la descripción ... es alucinación grave").
+    expect(r).toMatch(/(PROHIBIDO|Inventar)[\s\S]*descripci[óo]n/);
   });
 
   it('mantiene la regla previa de nombres científicos', () => {

--- a/src/services/__tests__/outputGuards.helada2.test.js
+++ b/src/services/__tests__/outputGuards.helada2.test.js
@@ -1,0 +1,232 @@
+/**
+ * outputGuards.helada2.test.js — REGRESIÓN P0 del guard térmico (#gl-guardhelada2).
+ *
+ * Contexto (piloto Choachí 2.513 msnm): el guard llamaba "riesgo de HELADA" a
+ * cualquier temperatura por debajo del `temp_min` del cultivo, p.ej. "riesgo de
+ * helada: fresa sufre por debajo de ~14°C y el pronóstico baja a 9°C". Tres
+ * problemas corregidos:
+ *   (1) "helada" = ≤0°C (convención IDEAM); una mínima de 9°C NO es helada. El
+ *       guard ahora etiqueta "riesgo de frío" (estrés térmico) cuando no hay
+ *       helada ambiental ni cruza el helada_letal del cultivo.
+ *   (2) AUTOCONTRADICCIÓN: el body del modelo ya decía "fresa resistente hasta
+ *       -5°C" y el guard antepuso "sufre por debajo de ~14°C" en la misma
+ *       burbuja. Ahora, si el body ya citó un umbral para esa especie, el guard
+ *       no antepone otro.
+ *   (3) UMBRAL CALIDO EN CULTIVO DE FRIO: al usar `helada_letal` (p.ej. fresa
+ *       = -3°C) en lugar del `temp_min` (≈12°C, que es el óptimo mínimo), no
+ *       aplica el umbral de cálido a un cultivo de frío.
+ *
+ * Ground-truth: este archivo.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  guardThermalViability,
+  applyOutputGuards,
+  resetOutputGuardTelemetry,
+} from '../outputGuards.js';
+
+beforeEach(() => {
+  resetOutputGuardTelemetry();
+});
+
+// Especies reales del catálogo (catálogo seed v3.1).
+// Fresa (Fragaria × ananassa): cultivo de FRÍO, prospera 1800–3000 msnm.
+//   temperatura_c: { helada_letal: -3, optimo_min: 12, optimo_max: 22 }
+// El grounding puede entregar temp_min=12 (óptimo) Y helada_letal=-3 (daño real).
+const FRESA = {
+  kind: 'species',
+  mentioned: 'fresa',
+  nombre_comun: 'Fresa',
+  nombre_cientifico: 'Fragaria × ananassa',
+  temp_min: 12, // óptimo mínimo
+  temp_max: 22,
+  helada_letal: -3, // umbral real de daño (del catálogo)
+};
+
+// Tomate (Solanum lycopersicum): cultivo CLÁLIDO-TEMPLADO, sin helada_letal.
+//   El guard cae al fallback temp_min. Cuando el pronóstico no baja a 0°C, el
+//   etiqueta correcta es "frío" (estrés), no "helada".
+const TOMATE = {
+  kind: 'species',
+  mentioned: 'tomate',
+  nombre_comun: 'Tomate',
+  nombre_cientifico: 'Solanum lycopersicum',
+  temp_min: 12,
+  temp_max: 30,
+};
+
+describe('guardThermalViability — fix #gl-guardhelada2', () => {
+  describe('(3) no aplicar umbral cálido a cultivo de frío', () => {
+    it('Fresa con helada_letal=-3 y pronóstico 9°C: NO dispara (9 > -3+2)', () => {
+      const txt = 'La fresa va muy bien en tu finca de Choachí, siémbrala ya.';
+      const out = guardThermalViability(txt, [FRESA], null, {
+        forecastTempMin: 9,
+        // forecastTempMax por debajo de temp_max-margen (22-2=20) para aislar
+        // solo el comportamiento del umbral de FRÍO en este test.
+        forecastTempMax: 18,
+      });
+      // 9°C está por encima de helada_letal + margen (-1°C) → NO hay riesgo real.
+      expect(out.modified).toBe(false);
+    });
+
+    it('Fresa con solo temp_min=12 (sin helada_letal) y pronóstico 9°C: etiqueta "frío", NO "helada"', () => {
+      const fresaSinHeladaLetal = { ...FRESA };
+      delete fresaSinHeladaLetal.helada_letal;
+      const txt = 'La fresa va muy bien en tu finca, siémbrala.';
+      const out = guardThermalViability(txt, [fresaSinHeladaLetal], null, {
+        forecastTempMin: 9,
+        forecastTempMax: 18,
+      });
+      expect(out.modified).toBe(true);
+      // CRÍTICO: 9°C NO es helada. Etiqueta correcta: "frío".
+      expect(out.text).toMatch(/riesgo de fr[ií]o/i);
+      expect(out.text).not.toMatch(/riesgo de helada/i);
+    });
+  });
+
+  describe('(1) "helada" = ≤0°C real; "frío" para lo demás', () => {
+    it('Tomate con temp_min=12 y pronóstico 4°C: etiqueta "frío", NO "helada"', () => {
+      const txt = 'El tomate va muy bien, siémbralo ahora.';
+      const out = guardThermalViability(txt, [TOMATE], null, {
+        forecastTempMin: 4,
+        forecastTempMax: 18,
+      });
+      expect(out.modified).toBe(true);
+      expect(out.text).toMatch(/riesgo de fr[ií]o/i);
+      expect(out.text).not.toMatch(/riesgo de helada/i);
+    });
+
+    it('Tomate con temp_min=12 y pronóstico -1°C (bajo 0): SÍ etiqueta "helada"', () => {
+      const txt = 'El tomate va muy bien, siémbralo ahora.';
+      const out = guardThermalViability(txt, [TOMATE], null, {
+        forecastTempMin: -1,
+        forecastTempMax: 18,
+      });
+      expect(out.modified).toBe(true);
+      expect(out.text).toMatch(/riesgo de helada/i);
+    });
+
+    it('Fresa con helada_letal=-3 y pronóstico -2°C: SÍ etiqueta "helada" (cruza el letal)', () => {
+      const txt = 'La fresa va muy bien, siémbrala.';
+      const out = guardThermalViability(txt, [FRESA], null, {
+        forecastTempMin: -2,
+        forecastTempMax: 18,
+      });
+      expect(out.modified).toBe(true);
+      expect(out.text).toMatch(/riesgo de helada/i);
+    });
+
+    it('NO llama "helada" a una mínima de 14°C (regresión exacta del piloto)', () => {
+      // Caso literal del bug: cualquier cultivo con temp_min ≤ 14 y pronóstico
+      // 14°C. Antes decía "riesgo de helada: sufre por debajo de ~14°C".
+      const tomate14 = { ...TOMATE, temp_min: 14 };
+      const txt = 'Siembra el tomate.';
+      const out = guardThermalViability(txt, [tomate14], null, {
+        forecastTempMin: 14,
+        forecastTempMax: 22,
+      });
+      // El guard sigue disparando (14 ≤ 14+2) — no es punto de este test. Pero
+      // la ETIQUETA debe ser "frío", NO "helada" (14 > 0°C).
+      if (out.modified) {
+        expect(out.text).not.toMatch(/riesgo de helada/i);
+        expect(out.text).toMatch(/riesgo de fr[ií]o/i);
+      }
+    });
+  });
+
+  describe('(2) anti-autocontradicción: body ya citó umbral', () => {
+    it('Body dice "fresa resistente hasta -5°C" → guard NO antepone otro umbral', () => {
+      const txt =
+        'La fresa es una buena opción para tu finca. Es resistente hasta -5°C, así que el clima de Choachí no le afecta. Siémbrala con confianza.';
+      const out = guardThermalViability(txt, [FRESA], null, {
+        forecastTempMin: -2,
+        forecastTempMax: 18,
+      });
+      // El body ya citó un umbral (-5°C) para la fresa → el guard no antepone
+      // otro distinto que lo contradiga.
+      expect(out.modified).toBe(false);
+    });
+
+    it('Body dice "aguanta 0°C sin problema" → guard NO antepone umbral', () => {
+      const txt =
+        'La fresa va muy bien, aguanta 0°C sin problema alguno en Nochebuena. Plántala ya.';
+      const out = guardThermalViability(txt, [FRESA], null, {
+        forecastTempMin: -1,
+        forecastTempMax: 18,
+      });
+      expect(out.modified).toBe(false);
+    });
+
+    it('Body SIN umbral numérico → guard SÍ puede disparar normalmente', () => {
+      const txt = 'La fresa va muy bien, siémbrala ya.';
+      const out = guardThermalViability(txt, [FRESA], null, {
+        forecastTempMin: -2,
+        forecastTempMax: 18,
+      });
+      expect(out.modified).toBe(true);
+      expect(out.text).toMatch(/riesgo de helada/i);
+    });
+  });
+
+  describe('Compatibilidad regresión: idempotencia y no-op', () => {
+    it('idempotente con la nueva etiqueta "frío"', () => {
+      const txt = 'El tomate va muy bien, siémbralo ahora.';
+      const once = guardThermalViability(txt, [TOMATE], null, {
+        forecastTempMin: 4,
+        forecastTempMax: 18,
+      });
+      expect(once.modified).toBe(true);
+      // Segunda pasada sobre el texto ya advertido → no repite.
+      const twice = guardThermalViability(once.text, [TOMATE], null, {
+        forecastTempMin: 4,
+        forecastTempMax: 18,
+      });
+      expect(twice.modified).toBe(false);
+    });
+
+    it('NO-OP sin forecast', () => {
+      const txt = 'El tomate va muy bien, siémbralo.';
+      expect(guardThermalViability(txt, [TOMATE], null, {}).modified).toBe(false);
+    });
+
+    it('NO-OP sin entidades', () => {
+      const out = guardThermalViability('Siembra el tomate.', [], null, {
+        forecastTempMin: 4,
+        forecastTempMax: 18,
+      });
+      expect(out.modified).toBe(false);
+    });
+  });
+
+  describe('applyOutputGuards cablea el fix en la cadena completa', () => {
+    it('CASO PILOTO Choachí: fresa + body con umbral + forecast frío → NO antepone helada', () => {
+      const resolved = [FRESA];
+      const llmOk =
+        'La fresa es perfecta para tu finca a 2.513 msnm. Es resistente hasta -5°C, ' +
+        'así que las noches frías no la afectan. Siémbrala con confianza.';
+      const out = applyOutputGuards(llmOk, {
+        resolvedEntities: resolved,
+        forecastTempMin: -1,
+        forecastTempMax: 18,
+        userMessage: '¿Puedo sembrar fresa en Choachí?',
+      });
+      // El body ya dio el umbral de frío para la fresa → no se antepone otro.
+      expect(out.text).not.toMatch(/sufre por debajo de ~14/);
+      expect(out.text).not.toMatch(/riesgo de helada: fresa sufre por debajo de ~-3/);
+    });
+
+    it('CASO PILOTO sin body umbral: fresa + forecast 9°C → NO dispara (9 > helada_letal+margen)', () => {
+      const resolved = [FRESA];
+      const llm = 'La fresa la puedes sembrar ahora en tu finca.';
+      const out = applyOutputGuards(llm, {
+        resolvedEntities: resolved,
+        forecastTempMin: 9,
+        forecastTempMax: 18,
+        userMessage: '¿Siembro fresa?',
+      });
+      // helada_letal=-3 → 9°C no cruza -1°C → no hay advertencia.
+      expect(out.modified).toBe(false);
+    });
+  });
+});

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -855,19 +855,24 @@ REGLA (intelligence-first, tono HUMILDE):
 /**
  * buildFrostHeatContext — alerta DETERMINÍSTICA de heladas/calor extremo POR
  * CULTIVO mencionado este turno. Cruza la tolerancia térmica de la especie
- * (`temp_min` / `temp_max` del grounding) contra la mínima/máxima del
- * pronóstico ya cacheado (climaSnapshot.openmeteo.forecast_7d, el mismo que
- * usa buildFincaContext — NO se re-pide). CERO latencia, PURA y SÍNCRONA.
+ * (`helada_letal` preferido, fallback `temp_min` / `temp_max` del grounding)
+ * contra la mínima/máxima del pronóstico ya cacheado
+ * (climaSnapshot.openmeteo.forecast_7d, el mismo que usa buildFincaContext — NO
+ * se re-pide). CERO latencia, PURA y SÍNCRONA.
  *
- * Lógica:
- *   - Si la mínima pronosticada ≤ (temp_min + marginC) → riesgo de helada/frío.
+ * Lógica (fix #gl-guardhelada2 — no llamar "helada" a 14°C, no aplicar umbral
+ * de cálido a cultivos de frío):
+ *   - Umbral de daño por frío = `helada_letal` si existe (p.ej. fresa=-3°C,
+ *     aguacate=-2°C); si no, cae a `temp_min` (óptimo mínimo).
+ *   - Etiqueta "helada" solo si el pronóstico toca ≤0°C o cruza `helada_letal`;
+ *     si no, etiqueta "frío" (estrés térmico, no helada ambiental).
  *   - Si la máxima pronosticada ≥ (temp_max - marginC) → riesgo de calor.
  * Solo emite si HAY datos en ambos lados. Degrada con gracia (sin temp_min ni
  * temp_max, o sin forecast → '').
  *
  * @param {object} args
  * @param {Array<object>|null} [args.resolvedEntities] - entidades AGE del turno.
- *   Cada una puede traer { kind, nombre_comun, temp_min, temp_max }.
+ *   Cada una puede traer { kind, nombre_comun, temp_min, temp_max, helada_letal }.
  * @param {object|null} [args.climaSnapshot] - getCachedClimaSnapshot().
  * @param {number} [args.marginC=2] - margen °C de seguridad.
  * @returns {string} bloque compacto, o '' si no hay nada accionable.
@@ -905,11 +910,21 @@ export function buildFrostHeatContext({
     const nombre = e.nombre_comun || e.mentioned || 'tu cultivo';
     const tMin = e.temp_min != null && e.temp_min !== '' ? Number(e.temp_min) : NaN;
     const tMax = e.temp_max != null && e.temp_max !== '' ? Number(e.temp_max) : NaN;
+    // helada_letal: punto de muerte por helada específico del cultivo (p.ej.
+    // fresa=-3°C). Prefiere este umbral sobre temp_min (óptimo) para no llamar
+    // "helada" a 14°C ni aplicar umbral de cálido a cultivos de frío (#gl-guardhelada2).
+    const heladaLetal =
+      e.helada_letal != null && e.helada_letal !== '' ? Number(e.helada_letal) : NaN;
+    const umbralDano = Number.isFinite(heladaLetal) ? heladaLetal : tMin;
 
-    if (Number.isFinite(tMin) && minDay && minDay.t <= tMin + marginC) {
+    if (Number.isFinite(umbralDano) && minDay && minDay.t <= umbralDano + marginC) {
       const cuando = minDay.fecha ? ` el ${minDay.fecha}` : ' esta semana';
+      // Etiqueta honesta: "helada" solo si el pronóstico toca ≤0°C o cruza el
+      // helada_letal; si no, es "frío" (estrés térmico). NO "sufre bajo 14°C".
+      const esHelada = minDay.t <= 0 + marginC || Number.isFinite(heladaLetal);
+      const etiqueta = esHelada ? 'helada' : 'frío';
       alertas.push(
-        `- ❄️ ${nombre}: sufre bajo ${tMin}°C; el pronóstico baja a ${Math.round(minDay.t)}°C${cuando} → protégelo (cobertor/manta térmica en la noche, riega en la MAÑANA no en la tarde).`,
+        `- ❄️ ${nombre}: riesgo de ${etiqueta} (daño bajo ${umbralDano}°C); el pronóstico baja a ${Math.round(minDay.t)}°C${cuando} → protégelo (cobertor/manta térmica en la noche, riega en la MAÑANA no en la tarde).`,
       );
     }
     if (Number.isFinite(tMax) && maxDay && maxDay.t >= tMax - marginC) {

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -2152,21 +2152,80 @@ export function guardInvertedViability(responseText, resolvedEntities = null, fi
 /** Margen °C de seguridad para el cruce pronóstico × tolerancia de la especie. */
 const THERMAL_MARGIN_C = 2;
 
+/**
+ * Helada AMBIENTAL real (formación de hielo sobre el cultivo): convención IDEAM
+ * ≤ 0°C. Llamar "helada" a temperaturas por encima de 0°C es un error que confunde
+ * al campesino (piloto Choachí 2.513 msnm, #gl-guardhelada2: el guard decía
+ * "riesgo de helada: fresa sufre por debajo de ~14°C" cuando una mínima de 14°C
+ * NO es helada —es solo salir del óptimo del cultivo— y se autocontradecía con
+ * el body del modelo que dijo "fresa resistente hasta -5°C").
+ */
+const HELADA_REAL_C = 0;
+
 /** Idempotencia: marca textual que deja este guard al anexar su advertencia. */
-const THERMAL_NOTE_MARK = /ojo[^.]*riesgo de (helada|golpe de calor)/i;
+const THERMAL_NOTE_MARK = /ojo[^.]*riesgo de (helada|fr[ií]o|golpe de calor)/i;
 
 /**
- * Guard 3b — viabilidad TÉRMICA (audit #23). Análogo a `guardInvertedViability`
- * pero para TEMPERATURA: cruza la tolerancia térmica de la especie
- * (`temp_min`/`temp_max` que ya vienen en el grounding / resolvedEntities) contra
- * la temperatura esperada del PRONÓSTICO (forecastTempMin / forecastTempMax,
- * derivadas de `climaSnapshot.openmeteo.forecast_7d` en la pantalla y pasadas por
- * ctx — el grounding NO trae la temp del pronóstico, solo la tolerancia de la
- * especie; ver gap documentado abajo).
+ * Anti-autocontradicción (#gl-guardhelada2): detecta si el body ya citó un
+ * umbral térmico de frío para una especie — p.ej. "fresa resistente hasta -5°C",
+ * "aguanta 0°C", "no tolera bajo 2°C", "sufre bajo -3°C". Si el body ya dio el
+ * umbral, el guard NO antepone otro distinto (evita el caso piloto donde el body
+ * dijo -5°C y el guard antepuso ~14°C en la misma burbuja).
+ *
+ * @param {string} textNorm texto del body sin diacríticas.
+ * @param {string} nombreNorm nombre de la especie sin diacríticas.
+ * @returns {boolean} true si el body YA citó un umbral de frío para esa especie.
+ */
+const COLD_THRESHOLD_NEAR_RE =
+  /(?:resist\w*|aguanta\w*|toler\w*|soport\w*|sobreviv\w*|sufre?\w*|muere\w*|no\s+toler\w*|no\s+aguanta\w*)[^.\n]{0,50}?(?<temp>-?\d+(?:[.,]\d+)?)\s*°?\s*c/i;
+
+function _bodyAlreadyGaveColdThreshold(textNorm, nombreNorm) {
+  if (!textNorm || !nombreNorm || nombreNorm.length < 3) return false;
+  // Busca en oraciones que mencionen la especie Y contengan un umbral
+  // ("resiste hasta -5°C"). Para manejar ANÁFORAS ("Fresa es buena. Es
+  // resistente hasta -5°C."), la ventana incluye la oración actual + la
+  // SIGUIENTE (el pronombre "Es" de la segunda oración refiere a la especie de
+  // la primera). No incluye la anterior para no contaminar con umbrales de
+  // otras especias citadas antes (p.ej. "Tomate tolera 4°C. La fresa...").
+  const first = nombreNorm.split(/\s+/)[0];
+  const oraciones = String(textNorm)
+    .split(/[.\n!?]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  for (let i = 0; i < oraciones.length; i++) {
+    const o = oraciones[i];
+    const menciona = o.includes(nombreNorm) || (first.length >= 3 && o.includes(first));
+    if (!menciona) continue;
+    const ventana = [o, oraciones[i + 1]].filter(Boolean).join(' ');
+    if (COLD_THRESHOLD_NEAR_RE.test(ventana)) return true;
+  }
+  return false;
+}
+
+/**
+ * Guard 3b — viabilidad TÉRMICA (audit #23 + fix #gl-guardhelada2). Análogo a
+ * `guardInvertedViability` pero para TEMPERATURA: cruza la tolerancia térmica de
+ * la especie contra la temperatura esperada del PRONÓSTICO.
+ *
+ * PRIORIDAD DE UMBRAL DE DAÑO POR FRÍO (fix #gl-guardhelada2):
+ *   1. `helada_letal` del grafo (punto de muerte por helada específico del
+ *      cultivo, p.ej. fresa = -3°C, aguacate = -2°C). Es el UMBRAL REAL de daño.
+ *   2. `temp_min` del grounding (que típicamente es el óptimo mínimo, NO un
+ *      umbral de daño). Se usa como fallback conservador cuando no hay
+ *      `helada_letal`, PERO el label se ajusta para no llamar "helada" a 14°C.
+ *
+ * ETIQUETA CORRECTA (fix #gl-guardhelada2, "no llamar helada a 14°C"):
+ *   - "riesgo de HELADA" si el pronóstico toca ≤0°C (formación de hielo) o si
+ *     cruza `helada_letal` (punto de daño por helada del cultivo).
+ *   - "riesgo de FRÍO" si solo dispara por `temp_min` (óptimo) y el pronóstico
+ *     no baja a 0°C — es estrés térmico, NO helada.
+ *
+ * ANTI-AUTOCONTRADICCIÓN (fix #gl-guardhelada2): si el body ya dio un umbral de
+ * frío para la especie ("resiste hasta -5°C"), el guard NO antepone otro
+ * distinto.
  *
  * Lógica (solo para especies que el texto FOMENTA sembrar):
- *   - Si la mínima pronosticada ≤ (temp_min + margen) → riesgo de HELADA/frío que
- *     puede matar el cultivo.
+ *   - Si la mínima pronosticada ≤ (umbralDaño + margen) → riesgo de helada/frío.
  *   - Si la máxima pronosticada ≥ (temp_max - margen) → riesgo de GOLPE DE CALOR.
  *
  * Doctrina zona-gris (intelligence-first, tono HUMILDE): ADVIERTE, no bloquea ni
@@ -2183,7 +2242,8 @@ const THERMAL_NOTE_MARK = /ojo[^.]*riesgo de (helada|golpe de calor)/i;
  * GUARD_CHAIN.
  *
  * @param {string} responseText
- * @param {Array<object>|null} resolvedEntities  cada una puede traer temp_min/temp_max.
+ * @param {Array<object>|null} resolvedEntities  cada una puede traer temp_min/temp_max
+ *   y opcionalmente helada_letal (umbral de daño por helada del grafo).
  * @param {number|string|null} _fincaAltitud      (no usado: la temp viene del pronóstico)
  * @param {object} [ctx]
  * @param {number|null} [ctx.forecastTempMin]  mínima esperada del pronóstico (°C).
@@ -2226,7 +2286,14 @@ export function guardThermalViability(
     if (!_isSpecies(e)) continue;
     const tMin = e.temp_min != null && e.temp_min !== '' ? Number(e.temp_min) : NaN;
     const tMax = e.temp_max != null && e.temp_max !== '' ? Number(e.temp_max) : NaN;
-    if (!Number.isFinite(tMin) && !Number.isFinite(tMax)) continue; // grounding sin temp.
+    // helada_letal: punto de MUERTE por helada específico del cultivo (p.ej.
+    // fresa = -3°C). Es el umbral REAL de daño, distinto de temp_min que suele
+    // ser el óptimo (fresa temp_min ≈ 12°C). Ver fix #gl-guardhelada2.
+    const heladaLetal =
+      e.helada_letal != null && e.helada_letal !== '' ? Number(e.helada_letal) : NaN;
+    if (!Number.isFinite(tMin) && !Number.isFinite(tMax) && !Number.isFinite(heladaLetal)) {
+      continue; // grounding sin ningún umbral térmico
+    }
 
     const nombre = _entityName(e);
     const nombreNorm = _stripDiacritics(nombre);
@@ -2234,10 +2301,27 @@ export function guardThermalViability(
     // lo menciona). Reusa el detector directo de fomento.
     if (!_fomentaSiembra(norm, nombreNorm)) continue;
 
+    // ANTI-AUTOCONTRADICCIÓN (#gl-guardhelada2): si el body ya citó un umbral de
+    // frío para esta especie ("resistente hasta -5°C"), el guard NO antepone
+    // otro distinto — evitaría duplicar/conflictuar el dato del modelo.
+    if (_bodyAlreadyGaveColdThreshold(norm, nombreNorm)) continue;
+
+    // Umbral de DAÑO por frío: prefiere helada_letal (real, específico) sobre
+    // temp_min (que suele ser óptimo mínimo). Así un cultivo de frío como fresa
+    // (helada_letal=-3, temp_min=12) NO dispara a 10°C como si fuera "helada".
+    const tieneHeladaLetal = Number.isFinite(heladaLetal);
+    const umbralDano = tieneHeladaLetal ? heladaLetal : tMin;
+    // ¿Es una HELADA real (≤0°C ambiental) o cruzando el punto de daño letal del
+    // cultivo? Si no, es solo FRÍO (estrés térmico), no helada.
+    const heladaAmbiental = haveMin && fMin <= HELADA_REAL_C + marginC;
+    const heladaPorCultivo = tieneHeladaLetal && haveMin && fMin <= heladaLetal + marginC;
+
     const partes = [];
-    if (Number.isFinite(tMin) && haveMin && fMin <= tMin + marginC) {
+    if (Number.isFinite(umbralDano) && haveMin && fMin <= umbralDano + marginC) {
+      const esHelada = heladaAmbiental || heladaPorCultivo;
+      const etiqueta = esHelada ? 'helada' : 'frío';
       partes.push(
-        `riesgo de helada: ${nombre} sufre por debajo de ~${tMin}°C y el pronóstico baja a ` +
+        `riesgo de ${etiqueta}: ${nombre} sufre por debajo de ~${umbralDano}°C y el pronóstico baja a ` +
           `${Math.round(fMin)}°C`,
       );
     }


### PR DESCRIPTION
## Summary

Fix P0 del piloto Choachí (2.513 msnm) reportado en #gl-guardhelada2: el guard térmico llamaba **"riesgo de HELADA"** a cualquier temperatura por debajo del `temp_min` del cultivo. Tres problemas corregidos:

1. **"helada" = ≤0°C real (IDEAM).** El guard ahora etiqueta *"riesgo de FRÍO"* cuando solo dispara por `temp_min` y el pronóstico no baja a 0°C. Reserva *"helada"* para ≤0°C ambiental o para cruzar el `helada_letal` del cultivo. **Antes**: `riesgo de helada: fresa sufre por debajo de ~14°C y el pronóstico baja a 9°C` — 14°C NO es helada. **Ahora**: `riesgo de frío: fresa sufre por debajo de ~12°C...`.

2. **Anti-autocontradicción.** Si el body ya citó un umbral de frío para la especie (*"resistente hasta -5°C"*, *"aguanta 0°C"*), el guard NO antepone otro distinto. Ventana oración-actual+siguiente para resolver anáforas (*"Es resistente..."*). **Antes**: body decía *"fresa resistente hasta -5°C"* y el guard antepuso *"sufre por debajo de ~14°C"* en la misma burbuja.

3. **No aplicar umbral cálico a cultivos de frío.** Prefiere `helada_letal` (p.ej. fresa=-3°C del catálogo) sobre `temp_min` (óptimo mínimo) como umbral de daño. Así fresa con `helada_letal=-3` NO dispara a 9°C como si fuera helada.

También parchea `buildFrostHeatContext` (agentService) con la misma lógica: prefiere `helada_letal` y etiqueta correctamente helada vs frío.

## Dónde estaba el 14°C y cómo quedó

- **Línea 2240 de `src/services/outputGuards.js`** (dentro de `guardThermalViability`):
  - Antes: `` `riesgo de helada: ${nombre} sufre por debajo de ~${tMin}°C y el pronóstico baja a ${Math.round(fMin)}°C` `` — siempre decía *"helada"*, sin importar la temp.
  - Ahora: la etiqueta se elige entre `'helada'` y `'frío'` según si el pronóstico toca ≤0°C o cruza `helada_letal`. El umbral de daño prefiere `helada_letal` sobre `temp_min` (que es óptimo mínimo, no daño).

- **Línea 912 de `src/services/agentService.js`** (dentro de `buildFrostHeatContext`, contexto que ve el modelo):
  - Antes: `` `- ❄️ ${nombre}: sufre bajo ${tMin}°C; ...` `` — sin distinguir frío de helada, sin usar `helada_letal`.
  - Ahora: `` `- ❄️ ${nombre}: riesgo de ${etiqueta} (daño bajo ${umbralDano}°C); ...` `` con etiqueta y umbral correctos.

## Test plan

- **14 tests nuevos** en `src/services/__tests__/outputGuards.helada2.test.js` cubriendo los 3 fixes + compatibilidad de regresión (idempotencia, no-op).
- Tests existentes de `guardThermalViability` (`outputGuards.test.js`) y `buildFrostHeatContext` (`agentService.test.js`) siguen pasando sin cambios — los actuales ya usaban regex `/helada|frío|protec/i` que acepta ambas etiquetas.

### Cobertura de regresión

| Test | Antes | Ahora |
|---|---|---|
| Fresa (helada_letal=-3) + forecast 9°C | dispara "helada" ❌ | no dispara ✓ |
| Fresa sin helada_letal + forecast 9°C | "riesgo de helada" ❌ | "riesgo de frío" ✓ |
| Tomate + forecast 4°C (sobre 0) | "riesgo de helada" ❌ | "riesgo de frío" ✓ |
| Tomate + forecast -1°C (bajo 0) | "riesgo de helada" ✓ | "riesgo de helada" ✓ |
| Body "resistente hasta -5°C" + guard | antepone otro umbral ❌ | no antepone ✓ |
| Mínima 14°C | "riesgo de helada: ~14°C" ❌ | "riesgo de frío: ~14°C" ✓ |

### Validación local

- `npx vitest run src/services/__tests__/outputGuards.helada2.test.js` → **14 pass**
- `npx vitest run outputGuards + agentService + promptAssembler.budget` → **947 pass, 0 fail**
- `node scripts/tsc-check-gate.mjs` → **1829 baseline, sin errores nuevos**
- `npx eslint` sobre archivos modificados → **0 warnings**
- `npm run build` → **OK (11s)**

## Riesgos conocidos

- **Anáforas más allá de oración+1**: si el body dice *"Fresa es buena. Es ideal. Es resistente hasta -5°C"* (umbral en la 3ª oración), el anti-autocontradicción NO lo detecta y el guard podría antecponer un umbral. Aceptado: la zona gris es HUMILDE por diseño (solo advierte, no bloquea), y el caso raro deja una advertencia redundante, no una mentira.
- **Helada ambiental vs helada por cultivo**: el guard etiqueta "helada" si el pronóstico toca ≤0°C `+marginC` (2°C) aunque el cultivo sea resistente (p.ej. fresa). Es correcto: 0°C es helada ambiental y muchas especies sufren aunque sobrevivan; la advertencia es aditiva y respeta la zona gris.
- **Sin `helada_letal` en el grafo para algunas especies**: el guard cae a `temp_min` como umbral de daño. Cuando eso pasa, etiqueta "frío" (no "helada") para no resurrect el bug. Si `helada_letal` falta para especies críticas, requiere data-wrangling en el sidecar/grafo (no en este repo).

## MCP tools usadas

No se usaron MCP tools agronómicas en este fix: el cambio es sobre la lógica determinística del guard térmico, no sobre datos de especies. Los valores `helada_letal` se leen del catálogo/grounding existente (ya poblado para especies como fresa, aguacate, papa).