### PR TITLE
feat(agua): 2ª pasada riesgos de contaminación — aguas mieles, sedimentos, metales y regla por uso

### DIFF
--- a/src/components/agua/AguaScreen.jsx
+++ b/src/components/agua/AguaScreen.jsx
@@ -6,6 +6,7 @@ import {
   Baby, Activity, ShieldAlert, Ruler, Landmark, HeartPulse,
   Flame, Filter, Camera, ExternalLink, HelpCircle,
   Worm, Eye, ScanEye, MapPin, ListChecks,
+  Coffee, Layers, Pickaxe, GlassWater, Salad, PawPrint,
 } from 'lucide-react';
 import { ScreenShell } from '../common/ScreenShell';
 import PedagogicalBlock from '../common/PedagogicalBlock';
@@ -39,6 +40,9 @@ import {
   CHEQUEO_AGUA_SEGURA,
   FOTO_BASE_AGUA,
   CREDITOS_FOTOS_AGUA,
+  CAFE_AGUAS_MIELES,
+  METALES_AGUA,
+  PARA_QUE_SIRVE,
 } from '../../data/aguaFinca';
 import { getEnsoPhase, getEnsoLabel } from '../../services/ensoService';
 import './agua.css';
@@ -470,6 +474,17 @@ const ICONO_RIESGO = {
   combustible: Fuel,
   matadero: Beef,
   basura: Trash2,
+  cafe: Coffee,
+  sedimento: Layers,
+  metal: Pickaxe,
+};
+
+/** Íconos por uso del agua (¿esta agua sirve para...?). */
+const ICONO_USO = {
+  tomar: GlassWater,
+  hortaliza: Salad,
+  animales: PawPrint,
+  riego: Sprout,
 };
 
 /** Íconos por enfermedad. */
@@ -499,6 +514,101 @@ function SemaforoPeligro({ nivel }) {
       />
       Peligro {alto ? 'alto' : 'medio'}
     </span>
+  );
+}
+
+/** Lámina propia del beneficiadero: la cereza de café y los DOS destinos del
+ *  agua miel — a la fosa/pozo (bien) o a la quebrada (mal). Decorativa
+ *  (aria-hidden): el paso a paso con letras va debajo. Solo SVG, cero fotos. */
+function LaminaAguasMieles() {
+  return (
+    <svg viewBox="0 0 180 100" aria-hidden="true" className="w-full h-auto select-none">
+      {/* rama de café con cerezas maduras */}
+      <g>
+        <path d="M14 30 q 18 -14 38 -8" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-emerald-700" strokeLinecap="round" />
+        <ellipse cx="30" cy="18" rx="9" ry="4.5" transform="rotate(-24 30 18)" className="fill-current text-emerald-600" />
+        <circle cx="22" cy="32" r="6" className="fill-current text-rose-500" />
+        <circle cx="34" cy="36" r="6" className="fill-current text-rose-600" />
+        <circle cx="45" cy="31" r="6" className="fill-current text-rose-500" />
+      </g>
+      {/* tolva del beneficiadero */}
+      <g className="text-slate-300">
+        <path d="M62 22 L94 22 L86 44 L70 44 Z" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinejoin="round" />
+        <rect x="73" y="44" width="10" height="10" fill="none" stroke="currentColor" strokeWidth="2.5" />
+      </g>
+      {/* gotas de agua miel saliendo del beneficio */}
+      <g className="text-amber-400">
+        <path d="M78 60 q -3.5 5 0 8 q 3.5 -3 0 -8 z" fill="currentColor" />
+      </g>
+      {/* camino BUENO: al pozo/fosa techada (check) */}
+      <g>
+        <path d="M86 68 q 20 10 34 10" fill="none" stroke="currentColor" strokeWidth="2" className="text-emerald-400" strokeDasharray="4 3" strokeLinecap="round" />
+        <path d="M126 70 L150 70 L148 88 L128 88 Z" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-emerald-400" strokeLinejoin="round" />
+        <path d="M123 70 L138 61 L153 70" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-emerald-300" strokeLinejoin="round" />
+        <path d="M133 79 l 4 4 l 7 -8" fill="none" stroke="currentColor" strokeWidth="3" className="text-emerald-300" strokeLinecap="round" strokeLinejoin="round" />
+        <text x="126" y="98" fontSize="8" fontWeight="700" className="fill-current text-emerald-300">a su pozo</text>
+      </g>
+      {/* camino MALO: a la quebrada (equis roja sobre el agua) */}
+      <g>
+        <path d="M70 68 q -20 10 -34 12" fill="none" stroke="currentColor" strokeWidth="2" className="text-rose-400" strokeDasharray="4 3" strokeLinecap="round" />
+        <path d="M8 88 q 6 -4 12 0 t 12 0 t 12 0" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-cyan-400 agua-hilo" strokeLinecap="round" />
+        <g className="text-rose-400" strokeLinecap="round">
+          <line x1="18" y1="72" x2="30" y2="84" stroke="currentColor" strokeWidth="3.5" />
+          <line x1="30" y1="72" x2="18" y2="84" stroke="currentColor" strokeWidth="3.5" />
+        </g>
+        <text x="8" y="70" fontSize="8" fontWeight="700" className="fill-current text-rose-300">quebrada NO</text>
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * AguasMielesCafe — el caso icónico de la finca cafetera: el beneficiadero.
+ * Qué son las aguas mieles, por qué matan la quebrada (le roban el oxígeno) y
+ * el paso a paso del beneficio ecológico (Cenicafé, cualitativo). La cifra de
+ * carga contaminante (DBO) es slot grounded-pendiente: se promete, no se
+ * inventa.
+ */
+function AguasMielesCafe() {
+  return (
+    <section className="rounded-2xl border border-amber-700/40 bg-slate-900/60 p-4 space-y-3" data-testid="agua-aguas-mieles">
+      <div className="flex items-start gap-3">
+        <span aria-hidden="true" className="shrink-0 w-9 h-9 rounded-xl bg-amber-500/15 grid place-items-center text-amber-300">
+          <Coffee size={18} />
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-black text-amber-200 uppercase tracking-wide leading-tight">{CAFE_AGUAS_MIELES.titulo}</p>
+          <p className="text-[11px] text-slate-400 leading-snug mt-0.5">El caso del beneficiadero, para finca cafetera</p>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-slate-700/50 bg-slate-950/50 p-2">
+        <LaminaAguasMieles />
+      </div>
+
+      <p className="text-xs leading-snug text-slate-200">{CAFE_AGUAS_MIELES.resumen}</p>
+
+      <ol className="space-y-2.5">
+        {CAFE_AGUAS_MIELES.queHacer.map((paso, i) => (
+          <li key={paso.id} className="flex gap-3" data-testid={`mieles-paso-${paso.id}`}>
+            <span aria-hidden="true" className="shrink-0 w-6 h-6 rounded-full bg-amber-500/20 border border-amber-500/40 text-amber-300 text-xs font-black grid place-items-center">
+              {i + 1}
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-bold text-slate-100 leading-tight">{paso.titulo}</p>
+              <p className="text-xs leading-snug text-slate-300 mt-0.5">{paso.detalle}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <p className="text-[11px] leading-snug text-slate-400">
+        ¿Qué tanto contamina un beneficio sin manejo? La cifra medida viene en camino{' '}
+        <SlotPendiente>carga orgánica (DBO) en camino (Cenicafé)</SlotPendiente>. Lo que ya es
+        seguro: agua miel a la quebrada = quebrada sin oxígeno.
+      </p>
+      <p className="text-[10px] leading-snug text-slate-500">Fuente: {CAFE_AGUAS_MIELES.fuente}.</p>
+    </section>
   );
 }
 
@@ -564,7 +674,21 @@ function RiesgosSalud() {
             );
           })}
         </ul>
+        {/* Metales: el único foco SIN tratamiento casero — el límite legal es casi cero */}
+        <p className="flex items-start gap-1.5 text-[11px] leading-snug text-slate-400" data-testid="agua-metales-limite">
+          <Pickaxe size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-slate-500" />
+          <span>
+            Con los metales no hay remedio casero: hervir <strong className="text-slate-300">no</strong> los
+            quita. Por eso la ley los deja casi en cero en el agua de tomar — mercurio máximo{' '}
+            <strong className="text-slate-300">{fmt(METALES_AGUA.limitesMgL.mercurio)} mg/L</strong>, plomo y arsénico{' '}
+            <strong className="text-slate-300">{fmt(METALES_AGUA.limitesMgL.plomo)} mg/L</strong> (Resolución 2115/2007).
+            La única defensa es cambiar de fuente.
+          </span>
+        </p>
       </section>
+
+      {/* ── A2 · Caso cafetero: las aguas mieles del beneficiadero ── */}
+      <AguasMielesCafe />
 
       {/* ── B · Qué enferma (autoridad institucional, nunca una persona) ── */}
       <section className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 space-y-3" data-testid="agua-enfermedades">
@@ -666,6 +790,41 @@ function RiesgosSalud() {
         </p>
       </section>
     </div>
+  );
+}
+
+/**
+ * ParaQueSirve — «¿esta agua sirve para...?»: la regla por USO, del más
+ * exigente (tomar/tetero) al menos (riego). Complementa la escalera por
+ * fuente ("Cada agua para lo suyo") en la dirección en que pregunta la gente.
+ */
+function ParaQueSirve() {
+  return (
+    <section className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 space-y-3" data-testid="agua-para-que-sirve">
+      <p className="flex items-center gap-2 text-sm font-black text-slate-100 uppercase tracking-wide">
+        <HelpCircle size={16} aria-hidden="true" className="text-cyan-300" /> ¿Esta agua sirve para...?
+      </p>
+      <p className="text-xs leading-snug text-slate-300">
+        De lo más delicado a lo menos: entre más arriba en la lista, más limpia tiene que llegar el agua.
+      </p>
+      <ol className="space-y-2.5">
+        {PARA_QUE_SIRVE.map((u) => {
+          const Icono = ICONO_USO[u.icono] || Droplets;
+          return (
+            <li key={u.id} className="rounded-xl border border-slate-700/50 bg-slate-950/40 p-3" data-testid={`uso-${u.id}`}>
+              <p className="flex flex-wrap items-center gap-2 text-sm font-bold text-slate-100 leading-tight">
+                <Icono size={16} aria-hidden="true" className="shrink-0 text-cyan-300" />
+                {u.uso}
+                <span className="rounded-full bg-slate-700/50 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-slate-300">
+                  {u.exige}
+                </span>
+              </p>
+              <p className="mt-1 text-xs leading-snug text-slate-300">{u.regla}</p>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
   );
 }
 
@@ -998,6 +1157,9 @@ function PilarCuidar() {
           </div>
         ))}
       </div>
+
+      {/* ¿Esta agua sirve para...? — la misma pregunta, mirada desde el USO */}
+      <ParaQueSirve />
 
       {/* SALUD · Cómo potabilizar en casa — galería photo-forward, 4 métodos */}
       <MetodosPotabilizacion />

--- a/src/components/agua/AguaScreen.test.jsx
+++ b/src/components/agua/AguaScreen.test.jsx
@@ -191,6 +191,67 @@ describe('AguaScreen — riesgos de contaminación + salud', () => {
   });
 });
 
+describe('AguaScreen — 2ª pasada: aguas mieles, sedimentos, metales y usos', () => {
+  it('lista las aguas mieles del café como riesgo alto (roban el oxígeno)', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    const mieles = screen.getByTestId('riesgo-aguas-mieles');
+    expect(mieles).toHaveTextContent(/aguas mieles del café/i);
+    expect(mieles).toHaveTextContent(/oxígeno/i);
+    expect(mieles).toHaveTextContent(/peligro alto/i);
+  });
+
+  it('el caso del beneficiadero da el paso a paso y deja la DBO como dato en camino (Cenicafé)', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    const caso = screen.getByTestId('agua-aguas-mieles');
+    expect(caso).toHaveTextContent(/beneficiadero/i);
+    // Prácticas del beneficio ecológico: fosa techada + pozo propio para mieles.
+    expect(screen.getByTestId('mieles-paso-fosa-pulpa')).toHaveTextContent(/fosa/i);
+    expect(screen.getByTestId('mieles-paso-pozo-mieles')).toHaveTextContent(/pozo o tanque/i);
+    // Honestidad grounded: la cifra de carga (DBO) NO se inventa.
+    expect(caso).toHaveTextContent(/en camino/i);
+    expect(caso).toHaveTextContent(/Cenicafé/);
+  });
+
+  it('los sedimentos avisan que el agua turbia le quita fuerza al cloro y al sol', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    const sed = screen.getByTestId('riesgo-sedimentos');
+    expect(sed).toHaveTextContent(/erosión/i);
+    expect(sed).toHaveTextContent(/le quita fuerza al cloro/i);
+    // El ganado bebe en bebedero, no dentro del cauce.
+    expect(sed).toHaveTextContent(/bebedero/i);
+  });
+
+  it('metales/minería: NO salen hirviendo y el límite legal es casi cero (Res. 2115/2007)', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    const min = screen.getByTestId('riesgo-mineria');
+    expect(min).toHaveTextContent(/mercurio/i);
+    expect(min).toHaveTextContent(/ni hervida/i);
+    // Límite grounded, formateado es-CO (0,001 mg/L de mercurio).
+    const limite = screen.getByTestId('agua-metales-limite');
+    expect(limite).toHaveTextContent('0,001 mg/L');
+    expect(limite).toHaveTextContent(/Resolución 2115\/2007/);
+  });
+
+  it('«¿esta agua sirve para...?» da la regla por uso: tomar, hortaliza cruda, animales y riego', () => {
+    render(<AguaScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByTestId('pilar-tab-cuidar'));
+    expect(screen.getByTestId('agua-para-que-sirve')).toBeInTheDocument();
+    // Tomar: siempre tratada, y el tetero con la mejor agua.
+    expect(screen.getByTestId('uso-tomar')).toHaveTextContent(/siempre tratada/i);
+    expect(screen.getByTestId('uso-tomar')).toHaveTextContent(/tetero/i);
+    // Hortaliza que se come cruda: nada de agua de corrales/letrinas.
+    expect(screen.getByTestId('uso-hortaliza')).toHaveTextContent(/cruda/i);
+    // Animales: la más limpia que tenga, en bebedero.
+    expect(screen.getByTestId('uso-animales')).toHaveTextContent(/bebedero/i);
+    // Riego: la bomba de fumigar no se lava en el cauce + norma de reúso.
+    expect(screen.getByTestId('uso-riego')).toHaveTextContent(/Resolución 1256\/2021/);
+  });
+});
+
 describe('AguaScreen — chequeo casero «¿mi agua es segura?»', () => {
   it('lista las señales por sentidos y por entorno (corral, letrina, fumigado)', () => {
     render(<AguaScreen onBack={() => {}} />);

--- a/src/data/aguaFinca.js
+++ b/src/data/aguaFinca.js
@@ -495,6 +495,120 @@ export const RIESGOS_CONTAMINACION = [
     nivel: 'medio',
     prevenir: 'Nada de botaderos al lado del cauce; separe, composte lo orgánico y saque el resto de la ronda del agua.',
   },
+  /* ── 2ª pasada (pedido del operador): aguas mieles, sedimentos, metales ── */
+  {
+    id: 'aguas-mieles',
+    icono: 'cafe',
+    fuente: 'Aguas mieles del café',
+    via: 'Escorrentía directa',
+    aporta: 'El agua del despulpado y del lavado baja cargada de miel (mucílago) y pulpa. Esa dulzura alimenta tantos microbios que le acaban el oxígeno a la quebrada: aguas abajo se mueren peces y camarones.',
+    nivel: 'alto',
+    prevenir: 'Ni la pulpa ni el agua del lavado van al cauce: pulpa a fosa techada y aguas mieles a su propio pozo o tanque (ver el caso del beneficiadero, abajo).',
+  },
+  {
+    id: 'sedimentos',
+    icono: 'sedimento',
+    fuente: 'Sedimentos: tierra suelta y erosión',
+    via: 'Escorrentía',
+    aporta: 'El barro de potreros pelados, quemas, caminos y del ganado metido al cauce enturbia el agua y entierra bocatomas y acequias — y los venenos y microbios viajan pegados a ese barro.',
+    nivel: 'medio',
+    prevenir: 'Suelo tapado y sin quemas ladera arriba, zanjas a nivel, y el ganado bebe en bebedero, no dentro de la quebrada. Ojo: el agua turbia además le quita fuerza al cloro y al sol (SODIS).',
+  },
+  {
+    id: 'mineria',
+    icono: 'metal',
+    fuente: 'Metales pesados (minería aguas arriba)',
+    via: 'Escorrentía y sedimentos',
+    aporta: 'Donde hay minería aguas arriba —sobre todo de oro— el mercurio y otros metales bajan con el agua y el barro, se van acumulando en el cuerpo y en los peces, y NO salen hirviendo el agua.',
+    nivel: 'alto',
+    prevenir: 'Si hay mina o entable aguas arriba, esa agua no es para tomar ni cocinar — ni hervida. Consígala de otra fuente y avise a la autoridad de salud de su municipio.',
+  },
+];
+
+/**
+ * Metales pesados en el agua de tomar — límites legales.
+ *
+ * GROUNDED (DR agua nacional §3.1 — Resolución 2115/2007, MinSalud): el agua
+ * para consumo humano admite como máximo mercurio 0,001 mg/L, plomo 0,01 mg/L
+ * y arsénico 0,01 mg/L — prácticamente CERO. Y el hervido NO remueve químicos
+ * ni metales (DR §3.3, OMS/EPA): contra metales no hay tratamiento casero, la
+ * única defensa es cambiar de fuente. Confianza: alta (norma citada a texto).
+ */
+export const METALES_AGUA = {
+  estado: 'grounded',
+  limitesMgL: { mercurio: 0.001, plomo: 0.01, arsenico: 0.01 },
+  hervirNoLosQuita: true,
+  fuente: 'Resolución 2115/2007 (MinSalud); OMS/EPA — el hervido no remueve químicos ni metales (DR agua §3.1 y §3.3)',
+  confianza: 'alta',
+};
+
+/**
+ * CASO CAFETERO · Las aguas mieles del beneficiadero.
+ *
+ * Es EL riesgo icónico de la finca cafetera colombiana: el agua dulce del
+ * despulpado y lavado ("aguas mieles") es de las cargas orgánicas más
+ * concentradas que produce una finca. El plan es CUALITATIVO (prácticas del
+ * beneficio ecológico difundidas por Cenicafé: despulpado en seco, fosa
+ * techada para la pulpa, lavar con poca agua, aguas mieles a pozo/tanque).
+ * La CIFRA de carga contaminante (DBO / equivalencia) queda como slot
+ * grounded-pendiente: NO se inventa.
+ */
+export const CAFE_AGUAS_MIELES = {
+  id: 'cafe-aguas-mieles',
+  titulo: 'Las aguas mieles del café',
+  resumen: 'En una finca cafetera, el punto que más contamina no es el cafetal: es el beneficiadero. La miel (mucílago) que suelta el grano es puro alimento para microbios — al caer a la quebrada se lo comen tan rápido que le acaban el oxígeno al agua.',
+  queHacer: [
+    { id: 'despulpe-seco', titulo: 'Despulpe sin agua', detalle: 'El despulpado en seco (sin chorro) es el primer ahorro: menos agua sucia que manejar y la miel queda concentrada donde usted la controla.' },
+    { id: 'fosa-pulpa', titulo: 'La pulpa a fosa techada', detalle: 'La pulpa va a una fosa con techo — nunca al cauce ni amontonada en la orilla, porque el aguacero la lava derecho a la quebrada. Bien manejada se vuelve abono para el mismo cafetal.' },
+    { id: 'lavar-poca-agua', titulo: 'Lave con poca agua', detalle: 'Lavar en tanque (tina) reutilizando el agua gasta muchísimo menos que lavar bajo el chorro. Menos agua usada = menos agua miel que tratar.' },
+    { id: 'pozo-mieles', titulo: 'Las aguas mieles, a su propio pozo', detalle: 'El agua del lavado va a un pozo o tanque aparte para que se asiente y se descomponga — de ahí sale para compost o biofertilizante, no para la quebrada.' },
+  ],
+  cifraCarga: {
+    estado: ESTADO_GROUNDED_PENDIENTE,
+    valor: null,
+    fuentePrevista: 'Cenicafé — carga orgánica (DBO) del beneficio tradicional vs beneficio ecológico',
+  },
+  fuente: 'Cenicafé — prácticas del beneficio ecológico del café (cualitativo)',
+};
+
+/**
+ * ¿ESTA AGUA SIRVE PARA...? — la regla por USO (del más exigente al menos).
+ *
+ * Complementa la escalera USOS_DEL_AGUA (que va por FUENTE): aquí la persona
+ * parte del uso que necesita y recibe la regla para decidir. Cualitativo
+ * (saneamiento básico OMS/OPS + inspección sanitaria); el punto de riego con
+ * agua reusada tiene norma colombiana (Resolución 1256/2021, DR agua §5.2).
+ * `icono` = clave que el componente mapea a un ícono.
+ */
+export const PARA_QUE_SIRVE = [
+  {
+    id: 'tomar',
+    icono: 'tomar',
+    uso: 'Tomar, cocinar y preparar tetero',
+    exige: 'La más exigente',
+    regla: 'SIEMPRE tratada (hervida, clorada, al sol o filtrada y rematada con cloro), venga de donde venga — el agua clarita también. Para el tetero del bebé, la mejor agua de la casa.',
+  },
+  {
+    id: 'hortaliza',
+    icono: 'hortaliza',
+    uso: 'Regar hortaliza que se come cruda',
+    exige: 'Exigente',
+    regla: 'Nada de agua que venga de corrales, letrinas o casas aguas arriba: lo que toca la lechuga o el tomate se lo come la familia tal cual. En la duda, riegue al pie de la mata y no sobre la hoja.',
+  },
+  {
+    id: 'animales',
+    icono: 'animales',
+    uso: 'Dar de beber a los animales',
+    exige: 'Media',
+    regla: 'Los animales también se enferman con agua podrida: deles la más limpia que tenga, en bebedero y no directo del cauce (así cuidan al animal Y a la quebrada). Ternero o lechón con diarrea es plata que se va en agua sucia.',
+  },
+  {
+    id: 'riego',
+    icono: 'riego',
+    uso: 'Riego general y lavar equipos',
+    exige: 'La menos exigente',
+    regla: 'Quebrada, acequia o lluvia sirven — pero si huele a químico, tiene nata o mató peces, tampoco: ese veneno se le pega al cultivo. Y la bomba de fumigar NO se lava en el cauce. El reúso de aguas tratadas para riego tiene norma propia (Resolución 1256/2021).',
+  },
 ];
 
 /**


### PR DESCRIPTION
## Qué agrega (pedido directo del operador: DIDÁCTICO riesgos + salud)

**Pilar «Cuidar el agua» del mundo El agua (AguaScreen):**

1. **Aguas mieles del café** — el riesgo icónico de finca cafetera que faltaba:
   - Tarjeta de riesgo (peligro alto): el mucílago le roba el oxígeno a la quebrada.
   - Caso del beneficiadero con lámina SVG propia (cereza → tolva → dos destinos: pozo ✓ / quebrada ✗) + paso a paso del beneficio ecológico (despulpe en seco, pulpa a fosa techada, lavar con poca agua, aguas mieles a pozo propio). Cualitativo Cenicafé; la cifra de DBO va como **dato en camino** (no se inventa).
2. **Sedimentos/erosión** (peligro medio): potreros pelados, quemas, ganado en el cauce; y el gancho didáctico: *el agua turbia le quita fuerza al cloro y al SODIS* (DR agua §3.3).
3. **Metales pesados / minería** (peligro alto): no salen hirviendo; límites legales casi cero — mercurio 0,001 · plomo/arsénico 0,01 mg/L (**Res. 2115/2007**, grounded vía DR agua nacional §3.1). Única defensa: cambiar de fuente.
4. **«¿Esta agua sirve para...?»** — la regla por USO, del más exigente al menos: tomar/tetero → hortaliza que se come cruda → animales (en bebedero; ternero con diarrea = plata que se va) → riego/lavar equipos (Res. 1256/2021 para reúso).

## Grounding
- Cifras nuevas: solo Res. 2115/2007 (metales) y Res. 1256/2021 (reúso), ambas verificadas en `Chagra-strategy/deepresearch/2026-07-03-agua-manejo-nacional-CO.md` (§3.1, §5.2).
- Todo lo demás cualitativo; DBO del beneficio = SlotPendiente (fuentePrevista: Cenicafé).

## Presupuesto/bundle
- **Cero fotos nuevas** (bundle al tope): solo SVG inline + lucide ya presentes.
- Animaciones: reusa clases existentes de agua.css (prefers-reduced-motion ya cubierto).

## Tests
- +5 tests (aguas mieles, DBO en camino, sedimentos/cloro, metales/Res. 2115, regla por uso): **21/21 verdes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)