### PR TITLE
feat(estiercol): 2ª pasada visual del mundo Estiércoles — hero photo-forward + microinteracciones

### DIFF
--- a/src/components/EstiercolScreen.jsx
+++ b/src/components/EstiercolScreen.jsx
@@ -48,6 +48,50 @@ const PILARES = [
   { id: 'abonos', label: 'Abonos', Icon: Sprout },
 ];
 
+/* ── Fotos reales (licencia abierta) — REUSO de /estiercol-compost ──────────
+ * 2ª pasada visual: mismas fotos que ya embarca CompostScreen (0 bytes nuevos
+ * en dist), mismo patrón "photo-forward" foto + scrim FIJO + crédito visible.
+ * Solo se usan donde la foto es temáticamente exacta. Licencias auditadas en
+ * public/estiercol-compost/_meta.json. */
+const FOTO_BASE_ESTIERCOL = '/estiercol-compost';
+const CREDITOS_FOTOS_ESTIERCOL = {
+  recoleccion: { autor: 'DS Pugh', lic: 'CC BY-SA 2.0' },
+  volteo: { autor: 'SB Johnny', lic: 'CC BY-SA 3.0' },
+  lombriz: { autor: 'Gordon Joly', lic: 'CC BY-SA 4.0' },
+};
+
+/**
+ * FotoEstiercol — foto a sangre con scrim inferior fijo (legible al sol en los
+ * 4 temas), crédito de autor y fallback silencioso (si la foto no carga queda
+ * el fondo de la card, sin hueco). `children` va SOBRE la foto.
+ */
+function FotoEstiercol({ slug, alt, className = '', imgClassName = '', children = null }) {
+  const [ok, setOk] = useState(true);
+  const credito = CREDITOS_FOTOS_ESTIERCOL[slug];
+  return (
+    <div className={`relative overflow-hidden bg-slate-950 ${className}`}>
+      {ok && (
+        <img
+          src={`${FOTO_BASE_ESTIERCOL}/${slug}.jpg`}
+          alt={alt}
+          loading="lazy"
+          decoding="async"
+          onError={() => setOk(false)}
+          className={`absolute inset-0 w-full h-full object-cover ${imgClassName}`}
+        />
+      )}
+      {/* Scrim fijo (no lo vira el remapeo de temas claros) */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/30 to-black/10" aria-hidden="true" />
+      {children}
+      {ok && credito && (
+        <span className="absolute bottom-1 right-1.5 rounded bg-black/55 px-1 py-0.5 text-[9px] leading-none text-white/75">
+          Foto: {credito.autor} · {credito.lic}
+        </span>
+      )}
+    </div>
+  );
+}
+
 /* ── Piezas de UI reutilizables ─────────────────────────────────────────── */
 
 /** Card de sección con encabezado a color (patrón de las pantallas de Chagra). */
@@ -55,7 +99,7 @@ function SeccionCard({ Icon, tono, titulo, children, className = '' }) {
   return (
     <section className={`rounded-2xl border ${tono.border} ${tono.bg} p-4 ${className}`}>
       {titulo && (
-        <h2 className={`flex items-center gap-2 text-base font-black ${tono.text}`}>
+        <h2 className={`flex items-center gap-2 text-base font-black tracking-tight ${tono.text}`}>
           {Icon && <Icon size={18} aria-hidden="true" />}
           {titulo}
         </h2>
@@ -138,7 +182,7 @@ function PilarOlores() {
       </div>
 
       <SeccionCard Icon={Info} tono={{ border: 'border-amber-600/40', bg: 'bg-amber-900/20', text: 'text-amber-200' }} titulo="Por qué huele">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1 estiercol-stagger">
           {OLOR_CAUSAS.map((c) => (
             <div key={c.t} className="rounded-xl bg-black/20 border border-slate-700/50 p-3">
               <p className="flex items-center gap-2 font-bold text-slate-100">
@@ -153,13 +197,13 @@ function PilarOlores() {
 
       {/* De esto → a esto (antes/después) */}
       <div className="rounded-2xl border border-slate-700/50 bg-slate-900/30 p-3.5 flex items-center gap-3">
-        <div className="flex-1 text-center">
+        <div className="flex-1 text-center rounded-xl border border-rose-700/30 bg-rose-950/30 py-2.5 px-2">
           <p className="text-2xl" aria-hidden="true">💩</p>
           <p className="text-xs font-bold text-rose-300 mt-1">Pila húmeda y tapada</p>
           <p className="text-2xs text-slate-400">huele a amoníaco</p>
         </div>
-        <ArrowRight size={22} className="text-emerald-400 shrink-0" aria-hidden="true" />
-        <div className="flex-1 text-center">
+        <ArrowRight size={22} className="estiercol-nudge text-emerald-400 shrink-0" aria-hidden="true" />
+        <div className="flex-1 text-center rounded-xl border border-emerald-700/30 bg-emerald-950/30 py-2.5 px-2">
           <p className="text-2xl" aria-hidden="true">🌱</p>
           <p className="text-xs font-bold text-emerald-300 mt-1">Compost aireado</p>
           <p className="text-2xs text-slate-400">huele a tierra</p>
@@ -225,7 +269,7 @@ function PilarBiodigestor() {
       </div>
 
       <SeccionCard Icon={CheckCircle2} tono={tono} titulo="Para qué sirve">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1 estiercol-stagger">
           {BIODIGESTOR_BENEFICIOS.map((b) => (
             <div key={b.t} className="rounded-xl bg-black/20 border border-slate-700/50 p-3">
               <p className="flex items-center gap-2 font-bold text-slate-100">
@@ -377,7 +421,8 @@ function ResultCard({ Icon, valor, unidad, etiqueta, tono }) {
     <div className="rounded-xl bg-black/25 border border-slate-700/50 p-3">
       {Icon && <Icon size={18} className={`${tono} mb-1`} aria-hidden="true" />}
       <p className="leading-none">
-        <span className={`text-2xl font-black ${tono}`}>{texto}</span>{' '}
+        {/* key={texto}: al cambiar la cifra el span se re-monta y "asienta" con pop */}
+        <span key={texto} className={`estiercol-pop text-2xl font-black tabular-nums ${tono}`}>{texto}</span>{' '}
         <span className="text-xs text-slate-400 font-bold">{unidad}</span>
       </p>
       <p className="text-2xs text-slate-400 mt-1 leading-tight">{etiqueta}</p>
@@ -420,12 +465,14 @@ const ABONOS = [
   },
   {
     tipo: 'compost', nombre: 'Compost', de: 'Pila aireada',
+    foto: { slug: 'volteo', alt: 'Volteo de una pila de compost caliente con horqueta' },
     que: 'Estiércol + material seco, volteado con aire hasta que huele a tierra. El abono más versátil.',
     pasos: ['Mezcle estiércol con material seco (2–3 : 1).', 'Voltee cada pocos días y mantenga húmedo como esponja escurrida.', 'Listo cuando huele a tierra y no se reconoce el material.'],
     tono: { border: 'border-emerald-600/40', bg: 'bg-emerald-900/20', text: 'text-emerald-200' },
   },
   {
     tipo: 'lombricompost', nombre: 'Lombricompost', de: 'Con lombriz roja',
+    foto: { slug: 'lombriz', alt: 'Lombrices rojas trabajando el compost' },
     que: 'Estiércol digerido por lombriz roja californiana. El humus más fino y de mejor calidad.',
     pasos: ['Prepare camas con estiércol ya pre-compostado (frío).', 'Siembre la lombriz y manténgala húmeda y a la sombra.', 'Cose­che el humus del lecho cada pocos meses.'],
     tono: { border: 'border-teal-600/40', bg: 'bg-teal-900/20', text: 'text-teal-200' },
@@ -440,19 +487,30 @@ function AbonoCard({ abono }) {
         type="button"
         onClick={() => setAbierto((v) => !v)}
         aria-expanded={abierto}
-        className="w-full flex items-center gap-3 p-3.5 text-left"
+        className="estiercol-card-btn w-full flex items-center gap-3 p-3.5 text-left rounded-2xl"
       >
-        <span className="shrink-0 w-11 h-11 rounded-xl bg-black/25 border border-slate-700/50 grid place-items-center">
+        <span className={`estiercol-glifo-tile ${abierto ? 'estiercol-glifo-tile--abierto' : ''} shrink-0 w-11 h-11 rounded-xl bg-black/25 border border-slate-700/50 grid place-items-center`}>
           <AbonoGlifo tipo={abono.tipo} size={34} />
         </span>
         <span className="flex-1 min-w-0">
-          <span className={`block font-black leading-tight ${abono.tono.text}`}>{abono.nombre}</span>
+          <span className={`block font-black leading-tight tracking-tight ${abono.tono.text}`}>{abono.nombre}</span>
           <span className="block text-2xs text-slate-400">{abono.de}</span>
         </span>
-        <ChevronRight size={18} className={`shrink-0 text-slate-500 transition-transform ${abierto ? 'rotate-90' : ''}`} aria-hidden="true" />
+        <ChevronRight
+          size={18}
+          className={`estiercol-chevron ${abierto ? 'estiercol-chevron--abierto' : ''} shrink-0 text-slate-500`}
+          aria-hidden="true"
+        />
       </button>
       {abierto && (
         <div className="px-3.5 pb-3.5 -mt-1 space-y-2 estiercol-enter">
+          {abono.foto && (
+            <FotoEstiercol
+              slug={abono.foto.slug}
+              alt={abono.foto.alt}
+              className="rounded-xl border border-slate-700/50 aspect-[16/7]"
+            />
+          )}
           <p className="text-sm text-slate-300/90 leading-snug">{abono.que}</p>
           <div>
             <p className="text-xs font-bold text-slate-300 mb-1">Cómo se hace</p>
@@ -481,7 +539,7 @@ function PilarAbonos() {
           hace y —cuando la investigación lo confirme— cuánto aplicar.
         </p>
       </SeccionCard>
-      <div className="space-y-2.5">
+      <div className="space-y-2.5 estiercol-stagger">
         {ABONOS.map((a) => <AbonoCard key={a.tipo} abono={a} />)}
       </div>
     </div>
@@ -498,32 +556,55 @@ function PilarInicio({ onIr }) {
   ];
   return (
     <div className="space-y-4 estiercol-enter">
-      <div className="rounded-2xl border border-emerald-700/40 bg-gradient-to-b from-emerald-900/20 to-transparent p-4">
-        <p className="text-sm text-slate-200/95 leading-relaxed">
-          En la finca <b>nada sobra</b>. El estiércol del corral, bien manejado, se
-          vuelve <b className="text-lime-200">abono</b>, <b className="text-amber-200">gas para cocinar</b> y
-          suelo vivo. Aquí aprende a aprovecharlo sin malos olores.
-        </p>
-        <div className="mt-2 max-w-[240px] mx-auto">
-          <CicloCorralAbono />
+      {/* Hero photo-forward: pila de estiércol real (reuso CC, 0 bytes nuevos).
+          El copy es el MISMO de la 1ª pasada, ahora sobre la foto. */}
+      <FotoEstiercol
+        slug="recoleccion"
+        alt="Pila de estiércol en una finca, lista para volverse abono"
+        className="rounded-2xl border border-emerald-700/40 min-h-[196px] flex"
+        imgClassName="estiercol-hero-img"
+      >
+        <div className="relative z-[1] mt-auto p-4 pb-5 w-full">
+          <p className="text-2xs font-black uppercase tracking-[0.14em] text-emerald-300">
+            Ciclo vivo · Estiércoles y abonos
+          </p>
+          <p className="mt-1 text-2xl font-black text-white leading-tight [text-shadow:0_1px_8px_rgba(0,0,0,0.6)]">
+            En la finca nada sobra
+          </p>
+          <p className="mt-1.5 max-w-md text-sm text-slate-100/95 leading-relaxed [text-shadow:0_1px_6px_rgba(0,0,0,0.7)]">
+            El estiércol del corral, bien manejado, se
+            vuelve <b className="text-lime-300">abono</b>, <b className="text-amber-300">gas para cocinar</b> y
+            suelo vivo. Aquí aprende a aprovecharlo sin malos olores.
+          </p>
         </div>
-      </div>
-      <div className="space-y-2.5">
+      </FotoEstiercol>
+
+      <div className="space-y-2.5 estiercol-stagger">
         {cards.map((c) => (
           <button
             key={c.id}
             type="button"
             onClick={() => onIr(c.id)}
-            className={`estiercol-pilar-btn w-full flex items-center gap-3 rounded-2xl border border-slate-800 border-l-4 ${c.tono.split(' ')[0]} bg-slate-900/40 p-4 text-left`}
+            className={`estiercol-card-btn w-full flex items-center gap-3 rounded-2xl border border-slate-800 border-l-4 ${c.tono.split(' ')[0]} bg-slate-900/40 p-4 text-left`}
           >
             <c.Icon size={26} className={`shrink-0 ${c.tono.split(' ')[1]}`} aria-hidden="true" />
             <span className="flex-1 min-w-0">
-              <span className={`block font-black ${c.tono.split(' ')[1]}`}>{c.t}</span>
+              <span className={`block font-black tracking-tight ${c.tono.split(' ')[1]}`}>{c.t}</span>
               <span className="block text-xs text-slate-400 mt-0.5">{c.d}</span>
             </span>
-            <ChevronRight size={20} className="shrink-0 text-slate-500" aria-hidden="true" />
+            <ChevronRight size={20} className="estiercol-chevron shrink-0 text-slate-500" aria-hidden="true" />
           </button>
         ))}
+      </div>
+
+      {/* El emblema del módulo: el ciclo cerrado corral → abono. */}
+      <div className="rounded-2xl border border-emerald-700/40 bg-gradient-to-b from-emerald-900/20 to-transparent p-4">
+        <p className="text-2xs font-black uppercase tracking-[0.14em] text-emerald-300/90 text-center">
+          El ciclo cerrado
+        </p>
+        <div className="mt-1 max-w-[240px] mx-auto">
+          <CicloCorralAbono />
+        </div>
       </div>
     </div>
   );

--- a/src/components/EstiercolScreen.jsx
+++ b/src/components/EstiercolScreen.jsx
@@ -562,10 +562,10 @@ function PilarInicio({ onIr }) {
         slug="recoleccion"
         alt="Pila de estiércol en una finca, lista para volverse abono"
         className="rounded-2xl border border-emerald-700/40 min-h-[196px] flex"
-        imgClassName="estiercol-hero-img"
+        imgClassName="estiercol-hero-img object-[68%_62%]"
       >
         <div className="relative z-[1] mt-auto p-4 pb-5 w-full">
-          <p className="text-2xs font-black uppercase tracking-[0.14em] text-emerald-300">
+          <p className="text-2xs font-black uppercase tracking-[0.14em] text-emerald-300 [text-shadow:0_1px_6px_rgba(0,0,0,0.85)]">
             Ciclo vivo · Estiércoles y abonos
           </p>
           <p className="mt-1 text-2xl font-black text-white leading-tight [text-shadow:0_1px_8px_rgba(0,0,0,0.6)]">

--- a/src/components/estiercol/EstiercolIlustraciones.jsx
+++ b/src/components/estiercol/EstiercolIlustraciones.jsx
@@ -19,6 +19,10 @@ const C = {
   agua: '#3f9fd4',
   trazo: '#2c1c0f',
   cielo: '#cfe8d6',
+  /* 2ª pasada: rótulos/flechas del emblema del ciclo. Vive SIEMPRE sobre la
+     card oscura del inicio (esta pantalla usa cards slate fijas en los 4
+     temas), así que el rótulo va claro — el trazo oscuro se perdía. */
+  crema: '#f1e9da',
 };
 
 /**
@@ -166,8 +170,8 @@ export function CicloCorralAbono({ animated = true, className = '' }) {
     <circle cx={x} cy={y} r="30" fill={fill} opacity="0.16" stroke={fill} strokeWidth="2" />
   );
   const flecha = (d) => (
-    <path d={d} fill="none" stroke={C.trazo} strokeWidth="2.4" strokeLinecap="round"
-      opacity="0.75" className={animated ? 'estiercol-flujo' : undefined} />
+    <path d={d} fill="none" stroke={C.crema} strokeWidth="2.4" strokeLinecap="round"
+      opacity="0.7" className={animated ? 'estiercol-flujo' : undefined} />
   );
   return (
     <svg
@@ -180,19 +184,19 @@ export function CicloCorralAbono({ animated = true, className = '' }) {
       {/* Nodos */}
       {nodo(150, 52, C.tierra)}
       <text x="150" y="49" textAnchor="middle" fontSize="26">🐖</text>
-      <text x="150" y="92" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Corral</text>
+      <text x="150" y="92" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.crema}>Corral</text>
 
       {nodo(248, 150, C.gas)}
       <text x="248" y="147" textAnchor="middle" fontSize="24">🛢️</text>
-      <text x="248" y="190" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Procesa</text>
+      <text x="248" y="190" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.crema}>Procesa</text>
 
       {nodo(150, 248, C.biol)}
       <text x="150" y="245" textAnchor="middle" fontSize="24">💧</text>
-      <text x="150" y="220" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Biol y biogás</text>
+      <text x="150" y="220" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.crema}>Biol y biogás</text>
 
       {nodo(52, 150, C.biolClaro)}
       <text x="52" y="147" textAnchor="middle" fontSize="24">🌱</text>
-      <text x="52" y="190" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.trazo}>Suelo</text>
+      <text x="52" y="190" textAnchor="middle" fontSize="12" fontWeight="800" fill={C.crema}>Suelo</text>
 
       {/* Flechas del ciclo (sentido horario) */}
       {flecha('M182 66 Q222 84 236 122')}

--- a/src/components/estiercol/estiercol.css
+++ b/src/components/estiercol/estiercol.css
@@ -3,6 +3,10 @@
    Sutiles, cálidas, tipo cuaderno de campo. Todas se apagan con
    prefers-reduced-motion. No hardcodean color de tema (usan currentColor /
    opacidad) para vivir bien en los 4 temas y ser legibles al sol.
+
+   2ª pasada visual (jerarquía + vida): hero photo-forward, entrada escalonada,
+   hover/focus vivos, pop de resultados. SOLO transform/opacity (GPU-friendly);
+   nada de filter/blur animado.
    ─────────────────────────────────────────────────────────────────────────── */
 
 /* Entrada suave de cada sección al cambiar de pilar. */
@@ -12,6 +16,31 @@
 }
 .estiercol-enter {
   animation: estiercol-fade-up 0.34s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* Entrada escalonada de los hijos directos (listas de cards): cada tarjeta
+   llega un pelito después de la anterior — la pantalla "se arma" sola. */
+.estiercol-stagger > * {
+  animation: estiercol-fade-up 0.38s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.estiercol-stagger > *:nth-child(1) { animation-delay: 0.03s; }
+.estiercol-stagger > *:nth-child(2) { animation-delay: 0.09s; }
+.estiercol-stagger > *:nth-child(3) { animation-delay: 0.15s; }
+.estiercol-stagger > *:nth-child(4) { animation-delay: 0.21s; }
+.estiercol-stagger > *:nth-child(5) { animation-delay: 0.27s; }
+.estiercol-stagger > *:nth-child(6) { animation-delay: 0.33s; }
+.estiercol-stagger > *:nth-child(7) { animation-delay: 0.39s; }
+.estiercol-stagger > *:nth-child(n+8) { animation-delay: 0.45s; }
+
+/* Hero photo-forward: la foto respira un Ken Burns MUY leve al entrar
+   (solo transform, una vez) y el contenido sube por encima del scrim. */
+@keyframes estiercol-hero-kb {
+  from { transform: scale(1.07); }
+  to   { transform: scale(1); }
+}
+.estiercol-hero-img {
+  animation: estiercol-hero-kb 1.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: transform;
 }
 
 /* Burbujas de gas subiendo dentro del biodigestor (SVG). */
@@ -62,17 +91,82 @@
   animation: estiercol-flujo 1.1s linear infinite;
 }
 
-/* Chip/pastilla del pilar activo — sutil elevación. */
+/* Chip/pastilla del pilar activo — elevación sutil + foco accesible visible.
+   Se comparte con botones de la calculadora y accesos del inicio. */
 .estiercol-pilar-btn {
-  transition: transform 0.16s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  transition: transform 0.16s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+@media (hover: hover) {
+  .estiercol-pilar-btn:hover { transform: translateY(-1px); }
 }
 .estiercol-pilar-btn:active { transform: scale(0.97); }
+.estiercol-pilar-btn:focus-visible,
+.estiercol-card-btn:focus-visible {
+  outline: 2px solid rgba(52, 211, 153, 0.9); /* emerald-400 */
+  outline-offset: 2px;
+}
+
+/* Tarjeta-acceso (inicio) y tarjeta de abono: levantan al pasar el dedo/mouse
+   y el chevrón se corre — invitan a tocar. Solo transform/opacity. */
+.estiercol-card-btn {
+  transition: transform 0.18s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.22s ease,
+    border-color 0.2s ease, background-color 0.2s ease;
+}
+@media (hover: hover) {
+  .estiercol-card-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 18px -8px rgba(0, 0, 0, 0.55);
+  }
+  .estiercol-card-btn:hover .estiercol-chevron { transform: translateX(3px); }
+}
+.estiercol-card-btn:active { transform: scale(0.985); }
+.estiercol-chevron { transition: transform 0.18s cubic-bezier(0.22, 1, 0.36, 1); }
+.estiercol-chevron--abierto { transform: rotate(90deg); }
+@media (hover: hover) {
+  .estiercol-card-btn:hover .estiercol-chevron--abierto {
+    transform: rotate(90deg) translateY(-3px); /* eje rotado: sigue "saliendo" */
+  }
+}
+
+/* Glifo del abono: al abrir la tarjeta crece un pelo, como asintiendo. */
+.estiercol-glifo-tile { transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1); }
+.estiercol-glifo-tile--abierto { transform: scale(1.08); }
+
+/* Resultado de la calculadora: cuando la cifra cambia, "asienta" con un pop.
+   Se re-dispara montando el span con key={texto}. */
+@keyframes estiercol-pop {
+  0%   { opacity: 0;   transform: translateY(4px) scale(0.94); }
+  60%  { opacity: 1;   transform: translateY(0)   scale(1.03); }
+  100% { opacity: 1;   transform: translateY(0)   scale(1); }
+}
+.estiercol-pop {
+  display: inline-block;
+  animation: estiercol-pop 0.32s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* Flecha "de esto → a esto" (olores): empuja suave hacia la solución. */
+@keyframes estiercol-nudge {
+  0%, 100% { transform: translateX(0);   opacity: 0.85; }
+  50%      { transform: translateX(4px); opacity: 1; }
+}
+.estiercol-nudge { animation: estiercol-nudge 1.6s ease-in-out infinite; }
 
 @media (prefers-reduced-motion: reduce) {
   .estiercol-enter,
+  .estiercol-stagger > *,
+  .estiercol-hero-img,
   .estiercol-burbuja,
   .estiercol-cupula,
   .estiercol-llama,
-  .estiercol-flujo { animation: none; }
-  .estiercol-cupula { transition: none; }
+  .estiercol-flujo,
+  .estiercol-pop,
+  .estiercol-nudge { animation: none; }
+  .estiercol-cupula,
+  .estiercol-pilar-btn,
+  .estiercol-card-btn,
+  .estiercol-chevron,
+  .estiercol-glifo-tile { transition: none; }
+  .estiercol-card-btn:hover,
+  .estiercol-pilar-btn:hover { transform: none; }
 }


### PR DESCRIPTION
## Qué

2ª pasada visual de **EstiercolScreen** ("Del corral al abono") — de bueno a impresionante, con estructura, contenido y grounding intactos.

## Cambios (solo .jsx/.css, byte-neutral)

- **Hero photo-forward** en Inicio: foto real de pila de estiércol **reusada** de `/estiercol-compost/recoleccion.jpg` (ya embarcada por CompostScreen → **0 bytes nuevos en dist**), scrim fijo, crédito CC visible, Ken Burns leve solo-transform.
- **Fotos en tarjetas de abonos** donde son temáticamente exactas: Compost (volteo.jpg) y Lombricompost (lombriz.jpg), con crédito.
- **Microinteracciones GPU-friendly** (transform/opacity, cero filter/blur animado): entrada escalonada de tarjetas, hover-lift con chevrón que se corre, glifo que "asiente" al abrir, pop de la cifra de la calculadora, flecha antes→después con empuje.
- **Accesibilidad**: `:focus-visible` con anillo esmeralda en pastillas y tarjetas; `prefers-reduced-motion` apaga TODA animación y transición; aria intacto.
- **Tipografía**: tracking-tight en títulos, kickers uppercase con tracking abierto, tabular-nums en resultados.

## Qué NO cambió

- Copy campesino, GroundedSlots, cifras groundeadas (CIPAV/LRRD), calculadora, estructura de pilares, tests existentes.
- Cero dependencias npm nuevas, cero imágenes nuevas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)