### PR TITLE
feat: EL AÑO DE LA FINCA — línea de tiempo visual del año del usuario

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,6 +117,7 @@ const GerminacionScreen = lazy(() => import('./components/GerminacionScreen'));
 const CicloNutrientesScreen = lazy(() => import('./components/CicloNutrientesScreen'));
 const CalendarioFincaScreen = lazy(() => import('./components/CalendarioFincaScreen'));
 const AlmanaqueScreen = lazy(() => import('./components/almanaque/AlmanaqueScreen'));
+const AnoFincaScreen = lazy(() => import('./components/anofinca/AnoFincaScreen'));
 const SeguimientoProcesoScreen = lazy(() => import('./components/SeguimientoProcesoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
 // Módulo "Agua de la finca": cosecha de lluvia (calculadora determinista),
@@ -321,6 +322,7 @@ const VIEW_LOADING_LABELS = {
   calendario: 'Abriendo el calendario…',
   calendario_finca: 'Abriendo el calendario…',
   almanaque: 'Abriendo el almanaque…',
+  ano_finca: 'Recorriendo su año…',
   mapa: 'Abriendo el mapa…',
   mercado: 'Abriendo el mercado…',
   mercados: 'Abriendo el mercado…',
@@ -400,6 +402,8 @@ const HASH_VIEW_ROUTES = {
   'calendario-finca': 'calendario_finca',
   almanaque: 'almanaque',
   'almanaque-campesino': 'almanaque',
+  'ano-finca': 'ano_finca',
+  'ano-de-la-finca': 'ano_finca',
   animales: 'animales',
   'animales-gallinas': 'animales_gallinas',
   'animales-abejas': 'animales_abejas',
@@ -1662,6 +1666,25 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Calendario de Finca">
               <CalendarioFincaScreen
+                onBack={() => navigate('dashboard')}
+                onHome={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'ano_finca':
+        // Módulo EL AÑO DE LA FINCA: la línea de tiempo del año del usuario —
+        // qué sembró, cosechó, trabajó y floreció (registros reales: ciclos,
+        // log--harvest, eventos) y lo que viene (calendario groundeado por su
+        // altitud). Complementa al calendario_finca (agenda por planta/capa) y
+        // al almanaque (el año a lo grande): esta es la vista TEMPORAL de SU
+        // finca. cosechaService es SOLO LECTURA aquí ("Mi cosecha" es dueña
+        // del tablero de cantidades).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El año de la finca">
+              <AnoFincaScreen
                 onBack={() => navigate('dashboard')}
                 onHome={() => navigate('dashboard')}
                 onNavigate={navigate}

--- a/src/components/anofinca/AnoFincaScreen.jsx
+++ b/src/components/anofinca/AnoFincaScreen.jsx
@@ -1,0 +1,584 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Route, Sprout, Apple, Flower2, Wrench, FlaskConical,
+  Mountain, Info, AlertTriangle, RotateCcw,
+} from 'lucide-react';
+import { ScreenShell } from '../common/ScreenShell';
+import ChagraGrowLoader from '../ChagraGrowLoader';
+import { listFarmProcesses, hydrateCyclesFromFarmOS, getFarmEvents } from '../../db/farmProcessCache';
+import { logCache } from '../../db/logCache';
+import { HARVEST_LOG_TYPE } from '../../services/cosechaService';
+import { getProfile } from '../../services/userProfileService';
+import { getAllSpecies } from '../../db/catalogDB';
+import { matchSpeciesInCatalog } from '../../utils/speciesResolver';
+import { agruparEntradas, claveMataAgrupada } from '../../utils/agruparEntradas';
+import { buildPlantCalendar } from '../../services/farmCalendarService';
+import {
+  buildAnoFinca, HITO_TIPOS, HITO_META, MESES_CORTOS, MESES_LARGOS,
+} from '../../services/anoFincaService';
+import './ano-finca.css';
+
+/**
+ * AnoFincaScreen — "EL AÑO DE LA FINCA": la línea de tiempo del año del
+ * usuario. Un camino SVG cruza los 12 meses (SÓLIDO hasta hoy = lo vivido y
+ * registrado; PUNTEADO de hoy en adelante = lo estimado por el calendario
+ * groundeado), con las temporadas de aguas/secas del almanaque de fondo y los
+ * hitos reales colgados en su mes: sembró X, cosechó Y, floreció Z, y lo que
+ * viene.
+ *
+ * DISTINTA de "Mi cosecha" (tablero de cantidades — cosechaService es SOLO
+ * LECTURA aquí) y del "Calendario de finca" (agenda por planta/capa): esta es
+ * la vista TEMPORAL de la finca — cuándo pasó y cuándo viene cada cosa.
+ *
+ * Fuentes: ver anoFincaService (nada se inventa; sin registros → estado vacío
+ * acogedor). Byte-neutral: solo CSS/SVG, cero fotos, cero deps.
+ */
+
+// Mismo lenguaje de color que el Calendario de finca (LAYER_STYLE): teal =
+// siembra, orange = cosecha, violet = fenología/floración, sky = nutrición.
+// Labor toma amber (no colisiona con ninguna capa existente). `hex` pinta el
+// SVG; `chip`/`solid` pintan la UI HTML (clases estáticas para el JIT).
+const TIPO_STYLE = {
+  siembra: { Icon: Sprout, hex: '#2dd4bf', solid: 'bg-teal-700 text-white', chip: 'bg-teal-500/15 text-teal-300' },
+  cosecha: { Icon: Apple, hex: '#fb923c', solid: 'bg-orange-700 text-white', chip: 'bg-orange-500/15 text-orange-300' },
+  floracion: { Icon: Flower2, hex: '#a78bfa', solid: 'bg-violet-600 text-white', chip: 'bg-violet-500/15 text-violet-300' },
+  labor: { Icon: Wrench, hex: '#fbbf24', solid: 'bg-amber-600 text-white', chip: 'bg-amber-500/15 text-amber-300' },
+  nutricion: { Icon: FlaskConical, hex: '#38bdf8', solid: 'bg-sky-700 text-white', chip: 'bg-sky-500/15 text-sky-300' },
+};
+
+// ── Geometría del camino (SVG hecho a mano) ─────────────────────────────────
+const COL_W = 72; // ancho de cada mes
+const RAIL_W = COL_W * 12; // 864
+const RAIL_H = 128;
+
+/** Punto del camino en el centro de cada mes: ondulación suave de sendero de
+ * ladera (senoide fija, determinista — no es dato, es dibujo). */
+const puntoCamino = (i) => ({
+  x: i * COL_W + COL_W / 2,
+  y: 78 + Math.round(16 * Math.sin(i * 0.85 + 0.7)),
+});
+const PUNTOS = Array.from({ length: 12 }, (_, i) => puntoCamino(i));
+
+/** Path suave (Catmull-Rom simplificado a curvas cuadráticas por punto medio). */
+function caminoPath(puntos) {
+  if (puntos.length === 0) return '';
+  let d = `M ${-8} ${puntos[0].y} L ${puntos[0].x} ${puntos[0].y}`;
+  for (let i = 0; i < puntos.length - 1; i++) {
+    const a = puntos[i];
+    const b = puntos[i + 1];
+    const mx = (a.x + b.x) / 2;
+    d += ` Q ${a.x + (mx - a.x) * 0.9} ${a.y}, ${mx} ${(a.y + b.y) / 2}`;
+    d += ` Q ${b.x - (b.x - mx) * 0.9} ${b.y}, ${b.x} ${b.y}`;
+  }
+  d += ` L ${RAIL_W + 8} ${puntos[11].y}`;
+  return d;
+}
+const CAMINO_D = caminoPath(PUNTOS);
+
+/** Tinte de fondo por tono de temporada (aguas/secas del almanaque). */
+const TONO_FILL = {
+  lluvia: 'rgba(56, 189, 248, 0.09)',
+  seca: 'rgba(251, 191, 36, 0.07)',
+  transicion: 'transparent',
+};
+const TONO_LABEL = { lluvia: 'aguas', seca: 'secas', transicion: '' };
+
+/** Días del mes (para ubicar el marcador de "hoy" dentro de su mes). */
+const diasDelMes = (year, month) => new Date(year, month, 0).getDate();
+
+export default function AnoFincaScreen({ onBack, onHome, onNavigate }) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [timeline, setTimeline] = useState(null);
+  const [activeTipos, setActiveTipos] = useState(() => new Set(HITO_TIPOS));
+  const [selectedMonth, setSelectedMonth] = useState(() => new Date().getMonth() + 1);
+  const scrollRef = useRef(null);
+
+  const altitudeM = useMemo(() => {
+    const n = Number(getProfile()?.finca_altitud);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const now = Date.now();
+      const speciesList = await getAllSpecies().catch(() => []);
+      const catalog = Array.isArray(speciesList) ? speciesList : [];
+
+      // 1. Ciclos reales de la finca (mismo cargado que el Calendario de finca).
+      let cycles = [];
+      try {
+        cycles = await listFarmProcesses({ status: 'active' });
+        cycles = await hydrateCyclesFromFarmOS(cycles, { altitudeM });
+      } catch (cyErr) {
+        console.warn('[AnoFinca] no pude leer ciclos de finca:', cyErr?.message || cyErr);
+        cycles = Array.isArray(cycles) ? cycles : [];
+      }
+
+      // 2. Cosechas registradas (log--harvest, SOLO LECTURA de la fuente que
+      // usa "Mi cosecha" — aquí solo nos importa CUÁNDO).
+      const harvestLogs = await logCache.getByType(HARVEST_LOG_TYPE).catch(() => []);
+
+      // 3. Labores/eventos de cada ciclo (cap defensivo: una finca real tiene
+      // decenas de ciclos, no miles; si hubiera más, los primeros bastan).
+      /** @type {Object<string, Array>} */
+      const eventsByProcess = {};
+      const conId = cycles.filter((c) => c.process_id || c.id).slice(0, 80);
+      await Promise.all(conId.map(async (c) => {
+        const id = c.process_id || c.id;
+        eventsByProcess[id] = await getFarmEvents(id).catch(() => []);
+      }));
+
+      // 4. Lo que viene: calendario groundeado por planta, con la MISMA
+      // agrupación de matas equivalentes del Calendario de finca (Fresa ×20
+      // = una fila, no veinte).
+      const grupos = agruparEntradas(cycles, (cycle) => {
+        const a = cycle.attributes || {};
+        return claveMataAgrupada({
+          species: a.subject_slug,
+          name: a.subject_label,
+          date: a.created_at,
+          bed: a.location_land_asset_id,
+        });
+      });
+      const calendars = grupos.map((grupo) => {
+        const a = grupo.representative.attributes || {};
+        const species = matchSpeciesInCatalog(catalog, a.subject_slug, a.subject_label);
+        const speciesSlug = species?.id || species?.slug || a.subject_slug;
+        const plant = buildPlantCalendar({
+          id: grupo.representative.process_id || grupo.representative.id,
+          name: a.subject_label || species?.nombre_comun || speciesSlug,
+          speciesSlug,
+          species,
+          sowingDate: a.created_at,
+          altitudeM,
+          now,
+        });
+        plant.count = grupo.count;
+        return plant;
+      });
+
+      setTimeline(buildAnoFinca({ cycles, harvestLogs, eventsByProcess, calendars, now }));
+    } catch (err) {
+      setError(`No pude armar el año de su finca: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [altitudeM]);
+
+  useEffect(() => { load(); }, [load]); // eslint-disable-line react-hooks/set-state-in-effect -- load es async
+
+  // Centrar el carril en el mes actual al cargar (sin animación si el usuario
+  // pidió reducir movimiento).
+  useEffect(() => {
+    if (loading || !timeline || !scrollRef.current) return;
+    const el = scrollRef.current;
+    const x = (timeline.currentMonth - 0.5) * COL_W - el.clientWidth / 2;
+    el.scrollLeft = Math.max(0, x);
+  }, [loading, timeline]);
+
+  const toggleTipo = useCallback((tipo) => {
+    setActiveTipos((prev) => {
+      const next = new Set(prev);
+      if (next.has(tipo)) next.delete(tipo); else next.add(tipo);
+      return next.size === 0 ? new Set(HITO_TIPOS) : next;
+    });
+  }, []);
+
+  // porMes con el filtro de tipos aplicado (el service entrega todo; filtrar
+  // es presentación).
+  const meses = useMemo(() => {
+    if (!timeline) return [];
+    return timeline.porMes.map((m) => {
+      const hitos = m.hitos.filter((h) => activeTipos.has(h.tipo));
+      const counts = {};
+      for (const h of hitos) {
+        const key = `${h.tipo}|${h.pasado ? 'p' : 'f'}`;
+        counts[key] = (counts[key] || 0) + h.count;
+      }
+      return { ...m, hitos, counts, total: hitos.length };
+    });
+  }, [timeline, activeTipos]);
+
+  const mesSel = meses[selectedMonth - 1] || null;
+  const hitosPasadosSel = mesSel ? mesSel.hitos.filter((h) => h.pasado) : [];
+  const hitosFuturosSel = mesSel ? mesSel.hitos.filter((h) => !h.pasado) : [];
+
+  // ── Marcador "hoy": posición x dentro de su mes, por día ──────────────────
+  const hoy = useMemo(() => {
+    const d = new Date();
+    const month = d.getMonth() + 1;
+    const frac = (d.getDate() - 0.5) / diasDelMes(d.getFullYear(), month);
+    return { month, x: (month - 1) * COL_W + frac * COL_W };
+  }, []);
+
+  if (loading) {
+    return (
+      <ScreenShell title="El año de la finca" icon={Route} onBack={onBack} onHome={onHome}>
+        <div className="flex justify-center py-16">
+          <ChagraGrowLoader size={72} showLabel labelText="Recorriendo su año…" />
+        </div>
+      </ScreenShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <ScreenShell title="El año de la finca" icon={Route} onBack={onBack} onHome={onHome}>
+        <div className="flex flex-col items-center gap-4 py-12 px-4">
+          <AlertTriangle size={44} className="text-amber-400" />
+          <p className="text-sm text-amber-200 text-center max-w-sm">{error}</p>
+          <button onClick={load} className="px-5 py-2.5 bg-slate-800 hover:bg-slate-700 rounded-xl font-bold flex items-center gap-2">
+            <RotateCcw size={16} /> Reintentar
+          </button>
+        </div>
+      </ScreenShell>
+    );
+  }
+
+  const vacio = !timeline || timeline.vacio;
+
+  return (
+    <ScreenShell title="El año de la finca" icon={Route} onBack={onBack} onHome={onHome}>
+      <div className="px-4 py-3 flex flex-col gap-4 max-w-2xl mx-auto">
+        {/* Intro */}
+        <div className="flex flex-col gap-1">
+          <p className="text-sm text-slate-300 leading-snug">
+            El camino de su año {timeline?.year}: lo que sembró, cosechó y trabajó
+            (trazo lleno) y lo que viene en camino (trazo punteado).
+          </p>
+          <p className="text-2xs text-slate-500 flex items-center gap-1.5">
+            <Mountain size={11} className="shrink-0" />
+            {altitudeM
+              ? `Lo que viene está ajustado a su finca (${altitudeM} msnm).`
+              : 'Ponga la altitud en su perfil para afinar lo que viene a su piso térmico.'}
+          </p>
+        </div>
+
+        {vacio ? (
+          <EstadoVacio onNavigate={onNavigate} />
+        ) : (
+          <>
+            {/* Leyenda-filtro por tipo de hito (mismo gesto que el Calendario) */}
+            <div className="flex flex-wrap gap-2" role="group" aria-label="Filtrar por tipo de hito">
+              {HITO_TIPOS.map((tipo) => {
+                const st = TIPO_STYLE[tipo];
+                const on = activeTipos.has(tipo);
+                const Icon = st.Icon;
+                return (
+                  <button
+                    key={tipo}
+                    type="button"
+                    aria-pressed={on}
+                    onClick={() => toggleTipo(tipo)}
+                    className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-full text-xs font-bold border transition-colors ${
+                      on ? `${st.solid} border-transparent shadow-sm` : 'bg-transparent text-slate-500 border-slate-700 hover:text-slate-300'
+                    }`}
+                  >
+                    <Icon size={13} aria-hidden="true" />
+                    {HITO_META[tipo].label}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* El camino del año: carril horizontal de 12 meses */}
+            <div className="bg-slate-900 border border-slate-800 rounded-xl p-3">
+              <div className="flex items-baseline justify-between gap-2 mb-1">
+                <p className="text-2xs uppercase font-bold text-slate-500 tracking-wide">El camino del año</p>
+                <p className="text-2xs text-slate-600">deslice y toque un mes</p>
+              </div>
+
+              {/* Resumen para lectores de pantalla (el SVG es decorativo). */}
+              <p className="sr-only">
+                Línea de tiempo del año {timeline.year}: {timeline.totalPasado} hitos
+                registrados y {timeline.totalFuturo} por venir. Use los botones de mes
+                para ver el detalle de cada mes en la lista de abajo.
+              </p>
+
+              <div ref={scrollRef} className="anofinca-scroll overflow-x-auto pb-1">
+                <div style={{ width: RAIL_W }}>
+                  <svg
+                    viewBox={`0 0 ${RAIL_W} ${RAIL_H}`}
+                    width={RAIL_W}
+                    height={RAIL_H}
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <defs>
+                      <clipPath id="anofinca-clip-pasado">
+                        <rect x="0" y="0" width={hoy.x} height={RAIL_H} />
+                      </clipPath>
+                      <clipPath id="anofinca-clip-futuro">
+                        <rect x={hoy.x} y="0" width={RAIL_W - hoy.x} height={RAIL_H} />
+                      </clipPath>
+                    </defs>
+
+                    {/* Temporadas del almanaque (aguas/secas) de fondo */}
+                    {meses.map((m, i) => (
+                      <g key={`tono-${m.mes}`}>
+                        <rect x={i * COL_W} y="0" width={COL_W} height={RAIL_H} fill={TONO_FILL[m.tono]} />
+                        {m.tono === 'lluvia' && (
+                          // Tres gotitas de lluvia (trazos cortos inclinados)
+                          <g stroke="#38bdf8" strokeWidth="1.4" strokeLinecap="round" opacity="0.5">
+                            <line x1={i * COL_W + 20} y1="9" x2={i * COL_W + 17} y2="16" />
+                            <line x1={i * COL_W + 38} y1="6" x2={i * COL_W + 35} y2="13" />
+                            <line x1={i * COL_W + 54} y1="10" x2={i * COL_W + 51} y2="17" />
+                          </g>
+                        )}
+                        {m.tono === 'seca' && (
+                          // Un solecito de trazos
+                          <g stroke="#fbbf24" strokeWidth="1.4" strokeLinecap="round" opacity="0.55">
+                            <circle cx={i * COL_W + 36} cy="11" r="4" fill="none" />
+                            <line x1={i * COL_W + 36} y1="3" x2={i * COL_W + 36} y2="5" />
+                            <line x1={i * COL_W + 36} y1="17" x2={i * COL_W + 36} y2="19" />
+                            <line x1={i * COL_W + 28} y1="11" x2={i * COL_W + 26} y2="11" />
+                            <line x1={i * COL_W + 46} y1="11" x2={i * COL_W + 44} y2="11" />
+                          </g>
+                        )}
+                        {/* Divisor sutil entre meses */}
+                        {i > 0 && <line x1={i * COL_W} y1="4" x2={i * COL_W} y2={RAIL_H - 4} stroke="#1e293b" strokeWidth="1" />}
+                      </g>
+                    ))}
+
+                    {/* El camino: sólido hasta hoy (lo vivido), punteado después
+                        (lo estimado). Mismo path, dos recortes. */}
+                    <path
+                      d={CAMINO_D}
+                      className="anofinca-camino-pasado"
+                      clipPath="url(#anofinca-clip-pasado)"
+                      fill="none"
+                      stroke="#94a3b8"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                    />
+                    <path
+                      d={CAMINO_D}
+                      clipPath="url(#anofinca-clip-futuro)"
+                      fill="none"
+                      stroke="#64748b"
+                      strokeWidth="2"
+                      strokeDasharray="5 7"
+                      strokeLinecap="round"
+                    />
+
+                    {/* Hitos por mes: apilados sobre el camino. Llenos = pasó;
+                        huecos punteados = viene. El radio crece con el conteo. */}
+                    {meses.map((m, i) => {
+                      const base = PUNTOS[i];
+                      const grupos = HITO_TIPOS
+                        .flatMap((tipo) => ['p', 'f'].map((cual) => ({ tipo, cual, n: m.counts[`${tipo}|${cual}`] || 0 })))
+                        .filter((g) => g.n > 0);
+                      return grupos.map((g, k) => {
+                        const r = 4.5 + Math.min(g.n - 1, 4);
+                        const cy = base.y - 14 - k * 15;
+                        const hex = TIPO_STYLE[g.tipo].hex;
+                        return (
+                          <g key={`${m.mes}-${g.tipo}-${g.cual}`}>
+                            {/* Tallito que cuelga el hito del camino */}
+                            {k === 0 && <line x1={base.x} y1={base.y} x2={base.x} y2={cy + r} stroke="#334155" strokeWidth="1" />}
+                            <circle
+                              cx={base.x}
+                              cy={cy}
+                              r={r}
+                              fill={g.cual === 'p' ? hex : 'none'}
+                              stroke={hex}
+                              strokeWidth={g.cual === 'p' ? 0 : 1.6}
+                              strokeDasharray={g.cual === 'p' ? undefined : '2.5 2.5'}
+                              opacity={g.cual === 'p' ? 0.95 : 0.8}
+                            />
+                            {g.n > 1 && (
+                              <text
+                                x={base.x}
+                                y={cy + 2.6}
+                                textAnchor="middle"
+                                fontSize="7.5"
+                                fontWeight="700"
+                                fill={g.cual === 'p' ? '#0f172a' : hex}
+                              >
+                                {g.n}
+                              </text>
+                            )}
+                          </g>
+                        );
+                      });
+                    })}
+
+                    {/* Marcador de HOY: estaca con banderita, parte el año en dos */}
+                    <g>
+                      <line
+                        x1={hoy.x} y1="6" x2={hoy.x} y2={RAIL_H - 4}
+                        stroke="#34d399" strokeWidth="1.6"
+                        className="anofinca-hoy-pulso"
+                      />
+                      <path d={`M ${hoy.x} 6 L ${hoy.x + 11} 10.5 L ${hoy.x} 15 Z`} fill="#34d399" />
+                      <text x={hoy.x + 14} y="13.5" fontSize="9" fontWeight="700" fill="#34d399">hoy</text>
+                    </g>
+                  </svg>
+
+                  {/* Botones de mes, alineados con las columnas del SVG */}
+                  <div className="grid grid-cols-12" role="group" aria-label="Elegir mes">
+                    {meses.map((m) => {
+                      const isSel = m.mes === selectedMonth;
+                      const isToday = m.estado === 'hoy';
+                      return (
+                        <button
+                          key={m.mes}
+                          type="button"
+                          aria-pressed={isSel}
+                          aria-label={`${MESES_LARGOS[m.mes - 1]}${isToday ? ' (mes actual)' : ''}: ${m.total} hitos`}
+                          onClick={() => setSelectedMonth(m.mes)}
+                          className={`anofinca-mes flex flex-col items-center gap-0.5 rounded-lg py-1.5 mx-0.5 transition-colors ${
+                            isSel ? 'bg-slate-800 ring-2 ring-emerald-400' : 'hover:bg-slate-800/60'
+                          }`}
+                        >
+                          <span className={`text-2xs font-bold ${
+                            isToday ? 'text-emerald-400' : m.estado === 'pasado' ? 'text-slate-500' : 'text-slate-300'
+                          }`}
+                          >
+                            {MESES_CORTOS[m.mes - 1]}
+                          </span>
+                          <span className={`text-2xs tabular-nums ${m.total > 0 ? 'text-slate-400' : 'text-slate-700'}`}>
+                            {m.total > 0 ? m.total : '·'}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              {/* Mini-leyenda de temporadas (fuente: almanaque campesino) */}
+              <p className="text-2xs text-slate-600 mt-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+                <span className="flex items-center gap-1">
+                  <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: 'rgba(56,189,248,0.35)' }} aria-hidden="true" />
+                  aguas
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: 'rgba(251,191,36,0.35)' }} aria-hidden="true" />
+                  secas
+                </span>
+                <span>Temporadas del almanaque (zona andina bimodal) — la de su vereda puede correrse.</span>
+              </p>
+            </div>
+
+            {/* Detalle del mes elegido — TAMBIÉN es la alternativa textual de la
+                línea de tiempo para lectores de pantalla. */}
+            {mesSel && (
+              <section aria-label={`Hitos de ${MESES_LARGOS[selectedMonth - 1]}`} className="flex flex-col gap-2">
+                <h2 className="text-sm font-bold text-slate-200 capitalize">
+                  {MESES_LARGOS[selectedMonth - 1]}
+                  {mesSel.estado === 'hoy' && <span className="ml-2 text-2xs font-bold text-emerald-400 uppercase">este mes</span>}
+                </h2>
+
+                {mesSel.total === 0 && (
+                  <p className="text-xs text-slate-500 bg-slate-900/60 border border-slate-800 rounded-xl px-3 py-3">
+                    {mesSel.estado === 'proximo'
+                      ? 'Nada agendado todavía para este mes.'
+                      : 'Este mes no quedó nada registrado.'}
+                  </p>
+                )}
+
+                {hitosPasadosSel.length > 0 && (
+                  <ul className="flex flex-col gap-1.5" aria-label="Lo vivido">
+                    {hitosPasadosSel.map((h) => <HitoRow key={h.id} hito={h} />)}
+                  </ul>
+                )}
+
+                {hitosFuturosSel.length > 0 && (
+                  <>
+                    <h3 className="text-2xs uppercase font-bold text-slate-500 tracking-wide mt-1">Lo que viene</h3>
+                    <ul className="flex flex-col gap-1.5" aria-label="Lo que viene">
+                      {hitosFuturosSel.map((h) => <HitoRow key={h.id} hito={h} />)}
+                    </ul>
+                  </>
+                )}
+              </section>
+            )}
+          </>
+        )}
+      </div>
+    </ScreenShell>
+  );
+}
+
+/** Una fila de hito: glifo del tipo + qué pasó/viene + cuándo. */
+function HitoRow({ hito }) {
+  const st = TIPO_STYLE[hito.tipo] || TIPO_STYLE.labor;
+  const Icon = st.Icon;
+  return (
+    <li className={`flex items-center gap-2.5 rounded-xl px-3 py-2 border ${
+      hito.pasado ? 'bg-slate-900 border-slate-800' : 'bg-slate-900/40 border-dashed border-slate-700'
+    }`}
+    >
+      <span className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center ${st.chip}`}>
+        <Icon size={14} aria-hidden="true" />
+      </span>
+      <span className="flex-1 min-w-0">
+        <span className="block text-xs font-bold text-slate-200 truncate">
+          {hito.label}
+          {hito.count > 1 && hito.pasado && <span className="ml-1.5 text-slate-500 font-normal">×{hito.count}</span>}
+        </span>
+        {hito.detail && <span className="block text-2xs text-slate-500 truncate">{hito.detail}</span>}
+      </span>
+      <span className="shrink-0 text-2xs text-slate-500 tabular-nums">
+        {hito.pasado
+          ? `${hito.day} ${MESES_CORTOS[hito.month - 1]}`
+          : <span className="px-1.5 py-0.5 rounded-full border border-slate-700 text-slate-400">estimado</span>}
+      </span>
+    </li>
+  );
+}
+
+/** Estado vacío acogedor: el camino apenas empieza. */
+function EstadoVacio({ onNavigate }) {
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-xl px-4 py-6 flex flex-col items-center gap-4 text-center">
+      <svg viewBox="0 0 220 70" width="220" height="70" aria-hidden="true" focusable="false">
+        <path
+          d="M 4 44 Q 40 30, 74 42 T 146 40 T 216 38"
+          fill="none" stroke="#475569" strokeWidth="2.5" strokeLinecap="round" strokeDasharray="5 7"
+        />
+        {/* La primera matica del camino */}
+        <g stroke="#34d399" strokeWidth="2.2" strokeLinecap="round" fill="none">
+          <line x1="20" y1="42" x2="20" y2="28" />
+          <path d="M 20 34 Q 12 32, 10 24" />
+          <path d="M 20 31 Q 28 29, 30 21" />
+        </g>
+        <circle cx="20" cy="43" r="2.6" fill="#34d399" />
+      </svg>
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-bold text-slate-200">Su año apenas empieza</p>
+        <p className="text-xs text-slate-400 max-w-xs leading-snug">
+          Este camino se irá llenando a medida que registre: cada siembra, cosecha
+          y labor queda marcada en su mes.
+        </p>
+      </div>
+      {typeof onNavigate === 'function' && (
+        <div className="flex flex-wrap justify-center gap-2">
+          <button
+            type="button"
+            onClick={() => onNavigate('sembrar')}
+            className="px-4 py-2 bg-emerald-700 hover:bg-emerald-600 text-white rounded-xl text-xs font-bold flex items-center gap-1.5"
+          >
+            {/* eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- copy campesino pendiente de migrar a messages.js (ADR-050, deuda soft igual que mundosFinca) */}
+            <Sprout size={14} aria-hidden="true" /> Registrar una siembra
+          </button>
+          <button
+            type="button"
+            onClick={() => onNavigate('cosechar')}
+            className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-slate-200 rounded-xl text-xs font-bold flex items-center gap-1.5"
+          >
+            <Apple size={14} aria-hidden="true" /> Anotar una cosecha
+          </button>
+        </div>
+      )}
+      <p className="text-2xs text-slate-600 flex items-center gap-1.5">
+        <Info size={11} className="shrink-0" aria-hidden="true" />
+        Cuando registre sus matas, aquí también verá lo que viene según su altitud.
+      </p>
+    </div>
+  );
+}

--- a/src/components/anofinca/ano-finca.css
+++ b/src/components/anofinca/ano-finca.css
@@ -1,0 +1,51 @@
+/**
+ * ano-finca.css — El año de la finca (línea de tiempo anual).
+ *
+ * Solo lo que Tailwind no expresa bien: el dibujado del camino (una vez, al
+ * cargar), el pulso del marcador "hoy" y el scroll-snap del carril. Todas las
+ * animaciones son de stroke/opacity (baratas, sin relayout) y se APAGAN con
+ * prefers-reduced-motion.
+ */
+
+.anofinca-scroll {
+  scroll-snap-type: x proximity;
+  -webkit-overflow-scrolling: touch;
+}
+
+.anofinca-mes {
+  scroll-snap-align: center;
+}
+
+/* El camino recorrido se "camina" al entrar: un solo trazo, una sola vez.
+   El dasharray (2000) supera con holgura el largo real del path (<1000),
+   así el trazo termina SÓLIDO — el punteado del futuro es otro path. */
+.anofinca-camino-pasado {
+  stroke-dasharray: 2000;
+  stroke-dashoffset: 2000;
+  animation: anofinca-dibujar 1.2s ease-out 0.15s forwards;
+}
+
+@keyframes anofinca-dibujar {
+  to { stroke-dashoffset: 0; }
+}
+
+/* El marcador de "hoy" respira suave (solo opacity, GPU-friendly). */
+.anofinca-hoy-pulso {
+  animation: anofinca-pulso 2.6s ease-in-out infinite;
+}
+
+@keyframes anofinca-pulso {
+  0%, 100% { opacity: 0.85; }
+  50% { opacity: 0.35; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .anofinca-camino-pasado {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+  .anofinca-hoy-pulso {
+    animation: none;
+    opacity: 0.85;
+  }
+}

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -60,6 +60,7 @@ export const MUNDOS_FINCA = [
             { view: 'fique', label: 'El fique y las fibras', desc: 'El cultivo de ladera que cuida el suelo: la cabuya, cómo se cría, el desfibrado de la penca, empaques y artesanía, y aprovechar el bagazo y el jugo sin contaminar el agua', emoji: '🪢' },
             { view: 'calendario_finca', label: 'Calendario de la finca', desc: 'Cuándo sembrar, abonar y cosechar, todo junto', emoji: '🗓️' },
             { view: 'almanaque', label: 'Almanaque campesino', desc: 'El año a lo grande: aguas y secas, qué da su piso térmico y el saber lunar', emoji: '🌙' },
+            { view: 'ano_finca', label: 'El año de la finca', desc: 'La línea de tiempo de SU año: qué sembró, cosechó y trabajó, y lo que viene en camino', emoji: '🛤️' },
             { view: 'activos', label: 'Mis matas', desc: 'Las plantas que tiene sembradas y cómo van', emoji: '🪴' },
             { view: 'mapa', label: 'Zonas de la finca', desc: 'Sus lotes, eras y potreros en el mapa', emoji: '🗺️' },
             { view: 'semilla', label: 'Semilla propia', desc: 'Seleccione, guarde y pruebe su semilla criolla', emoji: '🌾' },

--- a/src/services/__tests__/anoFincaService.test.js
+++ b/src/services/__tests__/anoFincaService.test.js
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAnoFinca,
+  hitosDeSiembras,
+  hitosDeCosechas,
+  hitosDeEventos,
+  hitosFuturos,
+  stageLabel,
+  TEMPORADA_POR_MES,
+} from '../anoFincaService';
+
+// Año fijo para no depender del reloj: 15 de junio de 2026, 12:00.
+const NOW = new Date(2026, 5, 15, 12, 0, 0).getTime();
+const YEAR = 2026;
+const ts = (month, day) => new Date(YEAR, month - 1, day, 10, 0, 0).getTime();
+
+const cycle = (id, label, createdAt, extra = {}) => ({
+  process_id: id,
+  type: 'farm_process',
+  attributes: {
+    process_type: 'sowing',
+    subject_label: label,
+    subject_slug: extra.slug || label.toLowerCase(),
+    created_at: createdAt,
+    location_land_asset_id: extra.lote || 'lote-1',
+    status: 'active',
+    ...extra,
+  },
+});
+
+describe('hitosDeSiembras', () => {
+  it('agrupa matas equivalentes (misma especie + día + lote) en un hito con count', () => {
+    const cycles = [
+      cycle('p1', 'Fresa #01', ts(3, 4), { slug: 'fragaria' }),
+      cycle('p2', 'Fresa #02', ts(3, 4), { slug: 'fragaria' }),
+      cycle('p3', 'Fresa #03', ts(3, 4), { slug: 'fragaria' }),
+      cycle('p4', 'Maíz', ts(4, 20), { slug: 'zea_mays' }),
+    ];
+    const hitos = hitosDeSiembras(cycles, YEAR);
+    expect(hitos).toHaveLength(2);
+    const fresa = hitos.find((h) => h.label === 'Sembró Fresa');
+    expect(fresa.count).toBe(3);
+    expect(fresa.month).toBe(3);
+    expect(fresa.tipo).toBe('siembra');
+    expect(fresa.pasado).toBe(true);
+  });
+
+  it('excluye siembras de otros años y sin fecha', () => {
+    const cycles = [
+      cycle('p1', 'Café', new Date(2024, 2, 1).getTime()),
+      cycle('p2', 'Yuca', null),
+    ];
+    expect(hitosDeSiembras(cycles, YEAR)).toHaveLength(0);
+  });
+});
+
+describe('hitosDeCosechas', () => {
+  it('ubica cada log--harvest del año con su cantidad tal como se registró', () => {
+    const logs = [
+      {
+        id: 'h1',
+        type: 'log--harvest',
+        name: 'Cosecha de Mora',
+        timestamp: Math.floor(ts(5, 10) / 1000), // farmOS: epoch segundos
+        quantity: { value: 3, unit: 'kg' },
+        status: 'done',
+      },
+      {
+        id: 'h2',
+        type: 'log--harvest',
+        name: 'Cosecha de Mora',
+        timestamp: Math.floor(new Date(2025, 10, 2).getTime() / 1000), // otro año
+        quantity: { value: 1, unit: 'kg' },
+      },
+    ];
+    const hitos = hitosDeCosechas(logs, YEAR);
+    expect(hitos).toHaveLength(1);
+    expect(hitos[0].label).toBe('Cosechó Mora');
+    expect(hitos[0].detail).toBe('3 kg');
+    expect(hitos[0].month).toBe(5);
+    expect(hitos[0].tipo).toBe('cosecha');
+  });
+
+  it('descarta logs sin cantidad utilizable (regla de cosechaService)', () => {
+    const logs = [{ id: 'h3', name: 'Cosecha de Lulo', timestamp: Math.floor(ts(2, 1) / 1000) }];
+    expect(hitosDeCosechas(logs, YEAR)).toHaveLength(0);
+  });
+});
+
+describe('hitosDeEventos', () => {
+  const cyclesById = { p1: cycle('p1', 'Lulo #01', ts(1, 10), { slug: 'solanum_quitoense' }) };
+  const ev = (id, type, occurredAt, payload = {}, notes = '') => ({
+    event_id: id,
+    type: 'farm_process_event',
+    attributes: { process_id: 'p1', event_type: type, occurred_at: occurredAt, payload, notes },
+  });
+
+  it('convierte la transición a flowering en hito de floración con el nombre de la mata', () => {
+    const eventos = { p1: [ev('e1', 'stage_transition', ts(4, 2), { to_stage: 'flowering' })] };
+    const hitos = hitosDeEventos(eventos, cyclesById, YEAR);
+    expect(hitos).toHaveLength(1);
+    expect(hitos[0].tipo).toBe('floracion');
+    expect(hitos[0].label).toBe('Floreció Lulo');
+    expect(hitos[0].month).toBe(4);
+  });
+
+  it('otras transiciones y tareas quedan como labores; observaciones se agregan por mes', () => {
+    const eventos = {
+      p1: [
+        ev('e1', 'stage_transition', ts(2, 5), { to_stage: 'vegetative' }),
+        ev('e2', 'task_completed', ts(3, 8), { task_label: 'Deshierbe' }),
+        ev('e3', 'observation', ts(3, 9)),
+        ev('e4', 'observation', ts(3, 20)),
+        ev('e5', 'sowing_confirmed', ts(1, 10)), // omitido (duplicaría la siembra)
+      ],
+    };
+    const hitos = hitosDeEventos(eventos, cyclesById, YEAR);
+    expect(hitos).toHaveLength(3);
+    expect(hitos.find((h) => h.id === 'evento-e1').label).toBe('Lulo pasó a crecimiento');
+    expect(hitos.find((h) => h.id === 'evento-e2').detail).toBe('Deshierbe');
+    const obs = hitos.find((h) => h.id.startsWith('obs-'));
+    expect(obs.count).toBe(2);
+    expect(obs.label).toBe('2 apuntes: Lulo');
+  });
+});
+
+describe('hitosFuturos', () => {
+  const calendar = (id, name, entries, extra = {}) => ({
+    id, name, status: 'ok', entries, count: extra.count || 1,
+  });
+
+  it('proyecta cosecha/floración/nutrición SOLO en meses por venir del año', () => {
+    const cal = calendar('c1', 'Mora', [
+      { layer: 'cosecha', title: 'Cosecha', months: [3, 8, 9], approximate: true, source: 'Ciclo perenne del catálogo' },
+      { layer: 'fenologia', stageCode: 'flowering', title: 'Floración', months: [7], approximate: true },
+      { layer: 'nutricion', anchored: true, title: 'Abonado', months: [10], approximate: false },
+      { layer: 'nutricion', anchored: false, title: 'Abonado sin anclar', months: [11] }, // sin siembra real → fuera
+      { layer: 'sanidad', months: [8], title: 'Caldo bordelés' }, // capa sin agenda → fuera
+    ]);
+    const hitos = hitosFuturos([cal], { year: YEAR, currentMonth: 6 });
+    expect(hitos.map((h) => `${h.tipo}:${h.month}`).sort()).toEqual([
+      'cosecha:8', 'cosecha:9', 'floracion:7', 'nutricion:10',
+    ]);
+    expect(hitos.every((h) => h.pasado === false)).toBe(true);
+    expect(hitos.find((h) => h.month === 8).label).toBe('Viene cosecha de Mora');
+  });
+
+  it('resume una cosecha continua en UN hito, no en 12 puntos', () => {
+    const cal = calendar('c2', 'Plátano', [
+      { layer: 'cosecha', continuous: true, months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], title: 'Cosecha casi todo el año' },
+    ]);
+    const hitos = hitosFuturos([cal], { year: YEAR, currentMonth: 6 });
+    expect(hitos).toHaveLength(1);
+    expect(hitos[0].month).toBe(7);
+    expect(hitos[0].label).toBe('Plátano: cosecha casi todo el año');
+  });
+});
+
+describe('buildAnoFinca', () => {
+  it('arma los 12 meses con estado temporal, tono de temporada y conteos', () => {
+    const resultado = buildAnoFinca({
+      cycles: [cycle('p1', 'Maíz', ts(4, 20), { slug: 'zea_mays' })],
+      harvestLogs: [{
+        id: 'h1', name: 'Cosecha de Maíz',
+        timestamp: Math.floor(ts(6, 10) / 1000),
+        quantity: { value: 2, unit: 'arrobas' },
+      }],
+      eventsByProcess: {},
+      calendars: [{
+        id: 'p1', name: 'Maíz', status: 'ok',
+        entries: [{ layer: 'cosecha', months: [8], title: 'Cosecha', approximate: true }],
+      }],
+      now: NOW,
+    });
+
+    expect(resultado.year).toBe(YEAR);
+    expect(resultado.currentMonth).toBe(6);
+    expect(resultado.porMes).toHaveLength(12);
+    expect(resultado.vacio).toBe(false);
+    expect(resultado.totalPasado).toBe(2);
+    expect(resultado.totalFuturo).toBe(1);
+
+    const abril = resultado.porMes[3];
+    expect(abril.estado).toBe('pasado');
+    expect(abril.tono).toBe('lluvia'); // primeras aguas del almanaque
+    expect(abril.counts.siembra).toBe(1);
+
+    const junio = resultado.porMes[5];
+    expect(junio.estado).toBe('hoy');
+    expect(junio.counts.cosecha).toBe(1);
+
+    const agosto = resultado.porMes[7];
+    expect(agosto.estado).toBe('proximo');
+    expect(agosto.hitos[0].pasado).toBe(false);
+  });
+
+  it('sin registros ni calendario → vacio true (estado acogedor en la UI)', () => {
+    const resultado = buildAnoFinca({ now: NOW });
+    expect(resultado.vacio).toBe(true);
+    expect(resultado.porMes.every((m) => m.total === 0)).toBe(true);
+  });
+});
+
+describe('helpers', () => {
+  it('stageLabel traduce códigos conocidos y devuelve el crudo si no hay traducción', () => {
+    expect(stageLabel('flowering')).toBe('Floración');
+    expect(stageLabel('growth')).toBe('Crecimiento');
+    expect(stageLabel('sowing_confirmed')).toBe('Siembra');
+    expect(stageLabel('etapa_rara')).toBe('etapa_rara');
+  });
+
+  it('TEMPORADA_POR_MES cubre los 12 meses con el mapeo bimodal del almanaque', () => {
+    expect(TEMPORADA_POR_MES).toHaveLength(12);
+    expect(TEMPORADA_POR_MES.filter((t) => t.tono === 'lluvia').map((t) => t.mes)).toEqual([4, 5, 10, 11]);
+    expect(TEMPORADA_POR_MES.filter((t) => t.tono === 'transicion').map((t) => t.mes)).toEqual([3, 9]);
+  });
+});

--- a/src/services/__tests__/anoFincaService.test.js
+++ b/src/services/__tests__/anoFincaService.test.js
@@ -137,7 +137,7 @@ describe('hitosFuturos', () => {
       { layer: 'nutricion', anchored: false, title: 'Abonado sin anclar', months: [11] }, // sin siembra real → fuera
       { layer: 'sanidad', months: [8], title: 'Caldo bordelés' }, // capa sin agenda → fuera
     ]);
-    const hitos = hitosFuturos([cal], { year: YEAR, currentMonth: 6 });
+    const hitos = hitosFuturos([cal], { currentMonth: 6 });
     expect(hitos.map((h) => `${h.tipo}:${h.month}`).sort()).toEqual([
       'cosecha:8', 'cosecha:9', 'floracion:7', 'nutricion:10',
     ]);
@@ -149,7 +149,7 @@ describe('hitosFuturos', () => {
     const cal = calendar('c2', 'Plátano', [
       { layer: 'cosecha', continuous: true, months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], title: 'Cosecha casi todo el año' },
     ]);
-    const hitos = hitosFuturos([cal], { year: YEAR, currentMonth: 6 });
+    const hitos = hitosFuturos([cal], { currentMonth: 6 });
     expect(hitos).toHaveLength(1);
     expect(hitos[0].month).toBe(7);
     expect(hitos[0].label).toBe('Plátano: cosecha casi todo el año');

--- a/src/services/anoFincaService.js
+++ b/src/services/anoFincaService.js
@@ -1,0 +1,389 @@
+/**
+ * anoFincaService — arma la LÍNEA DE TIEMPO del año de la finca del usuario
+ * ("El año de la finca"): qué pasó (siembras, cosechas, labores, floraciones
+ * REGISTRADAS) y qué viene (ventanas de cosecha/floración/nutrición del
+ * calendario groundeado), todo ubicado en los 12 meses del año en curso.
+ *
+ * FUENTES (todas existentes, este servicio NO inventa datos):
+ *   - Siembras   → FarmProcess de la finca (listFarmProcesses + hydrate):
+ *                  `attributes.created_at` es el día 0 del ciclo.
+ *   - Cosechas   → `log--harvest` de logCache, normalizados por cosechaService
+ *                  (SOLO LECTURA: la vista "Mi cosecha" es dueña del tablero
+ *                  de cantidades; aquí solo ubicamos el hito en el tiempo).
+ *   - Labores    → FarmProcessEvent (task_completed, observation,
+ *                  pest_management_confirmed, stage_transition).
+ *   - Floración  → stage_transition con to_stage 'flowering' (dato del usuario).
+ *   - Lo que viene → PlantCalendar de farmCalendarService (buildPlantCalendar),
+ *                  que ya es groundeado y honesto (approximate/confidence).
+ *
+ * REGLA DURA (anti-alucinación): un hito sin fecha real no se pinta. Los hitos
+ * futuros heredan `approximate` del calendario y se marcan `pasado: false`.
+ *
+ * Todo es puro y client-side: la vista (AnoFincaScreen) hace el I/O.
+ */
+import { normalizeHarvests } from './cosechaService';
+import { STAGE_LABELS } from './hoyEnFincaService';
+import { stripInstanceSuffix, dayBucket } from '../utils/agruparEntradas';
+
+/** Tipos de hito del año. El orden es el de dibujado/leyenda. */
+export const HITO_TIPOS = Object.freeze(['siembra', 'cosecha', 'floracion', 'labor', 'nutricion']);
+
+export const HITO_META = Object.freeze({
+  siembra: { label: 'Siembra', emoji: '🌱' },
+  cosecha: { label: 'Cosecha', emoji: '🧺' },
+  floracion: { label: 'Floración', emoji: '🌸' },
+  labor: { label: 'Labor', emoji: '🛠️' },
+  nutricion: { label: 'Nutrición', emoji: '🧪' },
+});
+
+export const MESES_CORTOS = Object.freeze(['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic']);
+export const MESES_LARGOS = Object.freeze([
+  'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+  'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
+]);
+
+/**
+ * Tono de temporada por mes 1-12, MAPEO FIEL de las temporadas del almanaque
+ * campesino (data/almanaqueFinca.js TEMPORADAS_ANIO, zona andina bimodal):
+ *   primeras aguas "abril – mayo" → 4,5 · secas grandes "junio – agosto" →
+ *   6,7,8 · segundas aguas "octubre – noviembre" → 10,11 · secas de fin de año
+ *   "diciembre – febrero" → 12,1,2. Marzo y septiembre no están cubiertos por
+ *   el texto del almanaque → 'transicion' (no se inventa tono).
+ */
+export const TEMPORADA_POR_MES = Object.freeze([
+  { mes: 1, tono: 'seca', temporadaId: 'secas2' },
+  { mes: 2, tono: 'seca', temporadaId: 'secas2' },
+  { mes: 3, tono: 'transicion', temporadaId: null },
+  { mes: 4, tono: 'lluvia', temporadaId: 'aguas1' },
+  { mes: 5, tono: 'lluvia', temporadaId: 'aguas1' },
+  { mes: 6, tono: 'seca', temporadaId: 'secas1' },
+  { mes: 7, tono: 'seca', temporadaId: 'secas1' },
+  { mes: 8, tono: 'seca', temporadaId: 'secas1' },
+  { mes: 9, tono: 'transicion', temporadaId: null },
+  { mes: 10, tono: 'lluvia', temporadaId: 'aguas2' },
+  { mes: 11, tono: 'lluvia', temporadaId: 'aguas2' },
+  { mes: 12, tono: 'seca', temporadaId: 'secas2' },
+]);
+
+/** Etiquetas de etapa que STAGE_LABELS (hoyEnFincaService) no cubre pero que
+ * los ciclos reales usan (current_stage de farmProcess / demo). */
+const EXTRA_STAGE_LABELS = Object.freeze({
+  sowing_confirmed: 'Siembra',
+  germination: 'Germinación',
+  growth: 'Crecimiento',
+  harvest: 'Cosecha',
+  fallow: 'Descanso',
+});
+
+/**
+ * Etiqueta en llano de un código de etapa. Devuelve el código crudo si no hay
+ * traducción (mejor mostrar el dato real que inventar).
+ * @param {string} code
+ * @returns {string}
+ */
+export function stageLabel(code) {
+  const base = String(code || '').replace(/_confirmed$/, '');
+  return STAGE_LABELS[base] || EXTRA_STAGE_LABELS[code] || EXTRA_STAGE_LABELS[base] || code || '';
+}
+
+const isFiniteTs = (ts) => Number.isFinite(ts) && ts > 0;
+const yearOf = (ts) => new Date(ts).getFullYear();
+const monthOf = (ts) => new Date(ts).getMonth() + 1;
+const dayOf = (ts) => new Date(ts).getDate();
+
+/**
+ * Hitos de SIEMBRA del año: uno por grupo (especie + día + lote), con `count`
+ * de matas equivalentes (misma agrupación que el Calendario de finca, para no
+ * pintar 20 puntos de "Fresa #01..#20").
+ *
+ * @param {Array} cycles — FarmProcess[] (attributes.created_at = siembra)
+ * @param {number} year
+ * @returns {Array} hitos
+ */
+export function hitosDeSiembras(cycles = [], year) {
+  const grupos = new Map();
+  for (const cycle of cycles) {
+    const a = cycle?.attributes || {};
+    const ts = a.created_at;
+    if (!isFiniteTs(ts) || yearOf(ts) !== year) continue;
+    const nombre = stripInstanceSuffix(a.subject_label) || a.subject_label || a.subject_slug || 'Cultivo';
+    const key = `${a.subject_slug || nombre}|${dayBucket(ts)}|${a.location_land_asset_id || ''}`;
+    const prev = grupos.get(key);
+    if (prev) {
+      prev.count += 1;
+    } else {
+      grupos.set(key, {
+        id: `siembra-${cycle.process_id || cycle.id || key}`,
+        tipo: 'siembra',
+        pasado: true,
+        ts,
+        month: monthOf(ts),
+        day: dayOf(ts),
+        label: `Sembró ${nombre}`,
+        detail: a.variety ? `Variedad ${a.variety}` : '',
+        count: 1,
+        approximate: false,
+        source: 'Ciclo de cultivo registrado en su finca',
+      });
+    }
+  }
+  return [...grupos.values()];
+}
+
+/**
+ * Hitos de COSECHA del año desde los `log--harvest` (normalizados por
+ * cosechaService — solo lectura). El detalle trae la cantidad tal como se
+ * registró; los kg agregados son negocio de "Mi cosecha", no de esta vista.
+ *
+ * @param {Array} harvestLogs — logs crudos de logCache
+ * @param {number} year
+ * @returns {Array} hitos
+ */
+export function hitosDeCosechas(harvestLogs = [], year) {
+  return normalizeHarvests(harvestLogs)
+    .filter((h) => isFiniteTs(h.timestampMs) && yearOf(h.timestampMs) === year)
+    .map((h) => ({
+      id: `cosecha-${h.id}`,
+      tipo: 'cosecha',
+      pasado: true,
+      ts: h.timestampMs,
+      month: monthOf(h.timestampMs),
+      day: dayOf(h.timestampMs),
+      label: `Cosechó ${h.crop}`,
+      detail: h.value > 0 ? `${h.value} ${h.unit || ''}`.trim() : '',
+      count: 1,
+      approximate: false,
+      source: 'Cosecha registrada en su finca',
+    }));
+}
+
+/**
+ * Hitos de LABORES y FLORACIONES del año desde los eventos de ciclo
+ * (FarmProcessEvent). Reglas:
+ *   - task_completed / pest_management_confirmed → labor.
+ *   - stage_transition a 'flowering' → floración ("floreció Z", dato real).
+ *   - stage_transition a otra etapa → labor "X pasó a {etapa}".
+ *   - observation → se AGREGAN por planta+mes ("N apuntes de X") para no
+ *     inundar el carril.
+ *   - sowing_confirmed / harvest_confirmed se OMITEN: ya vienen como hitos de
+ *     siembra (proceso) y cosecha (log--harvest); incluirlos duplicaría.
+ *
+ * @param {Object<string, Array>} eventsByProcess — process_id → eventos
+ * @param {Object<string, Object>} cyclesById — process_id → FarmProcess
+ * @param {number} year
+ * @returns {Array} hitos
+ */
+export function hitosDeEventos(eventsByProcess = {}, cyclesById = {}, year) {
+  const hitos = [];
+  const observaciones = new Map(); // `${processId}|${month}` → agregado
+
+  for (const [processId, events] of Object.entries(eventsByProcess)) {
+    const cycle = cyclesById[processId];
+    const nombre = stripInstanceSuffix(cycle?.attributes?.subject_label)
+      || cycle?.attributes?.subject_label || cycle?.attributes?.subject_slug || 'la mata';
+
+    for (const ev of events || []) {
+      const a = ev?.attributes || {};
+      const ts = a.occurred_at;
+      if (!isFiniteTs(ts) || yearOf(ts) !== year) continue;
+
+      if (a.event_type === 'stage_transition' || a.event_type === 'stage_confirmed') {
+        const to = a.payload?.to_stage || a.payload?.stage || '';
+        const base = String(to).replace(/_confirmed$/, '');
+        if (!to) continue;
+        hitos.push({
+          id: `evento-${ev.event_id || `${processId}-${ts}`}`,
+          tipo: base === 'flowering' ? 'floracion' : 'labor',
+          pasado: true,
+          ts,
+          month: monthOf(ts),
+          day: dayOf(ts),
+          label: base === 'flowering' ? `Floreció ${nombre}` : `${nombre} pasó a ${stageLabel(to).toLowerCase()}`,
+          detail: '',
+          count: 1,
+          approximate: false,
+          source: 'Etapa registrada en el ciclo de cultivo',
+        });
+      } else if (a.event_type === 'task_completed' || a.event_type === 'pest_management_confirmed') {
+        hitos.push({
+          id: `evento-${ev.event_id || `${processId}-${ts}`}`,
+          tipo: 'labor',
+          pasado: true,
+          ts,
+          month: monthOf(ts),
+          day: dayOf(ts),
+          label: a.event_type === 'pest_management_confirmed'
+            ? `Manejo de plaga en ${nombre}`
+            : `Labor en ${nombre}`,
+          detail: a.payload?.task_label || a.payload?.pest_name || a.notes || '',
+          count: 1,
+          approximate: false,
+          source: 'Labor registrada en el ciclo de cultivo',
+        });
+      } else if (a.event_type === 'observation') {
+        const key = `${processId}|${monthOf(ts)}`;
+        const prev = observaciones.get(key);
+        if (prev) {
+          prev.count += 1;
+          if (ts > prev.ts) { prev.ts = ts; prev.day = dayOf(ts); }
+        } else {
+          observaciones.set(key, {
+            id: `obs-${key}`,
+            tipo: 'labor',
+            pasado: true,
+            ts,
+            month: monthOf(ts),
+            day: dayOf(ts),
+            label: `Apuntes de ${nombre}`,
+            detail: '',
+            count: 1,
+            approximate: false,
+            source: 'Observaciones registradas en el ciclo',
+          });
+        }
+      }
+      // Otros event_type (photo_attached, weather_snapshot, note, sowing/
+      // harvest_confirmed) se omiten a propósito (ver docstring).
+    }
+  }
+
+  for (const obs of observaciones.values()) {
+    if (obs.count > 1) obs.label = `${obs.count} apuntes: ${obs.label.replace(/^Apuntes de /, '')}`;
+    hitos.push(obs);
+  }
+  return hitos;
+}
+
+/**
+ * Hitos FUTUROS del resto del año desde los PlantCalendar groundeados
+ * (farmCalendarService.buildPlantCalendar). Solo capas con valor de agenda:
+ * cosecha (qué viene a canasta), floración (fenología stageCode 'flowering') y
+ * nutrición ANCLADA a siembra real. Un hito por (planta, entrada, mes futuro).
+ * Las entradas `continuous` (produce todo el año) se resumen en UN hito en el
+ * mes siguiente, no en 12 puntos.
+ *
+ * @param {Array} calendars — PlantCalendar[] con status 'ok'
+ * @param {Object} cfg
+ * @param {number} cfg.year
+ * @param {number} cfg.currentMonth — 1-12 (los hitos van de currentMonth+1 a 12)
+ * @returns {Array} hitos con pasado: false
+ */
+export function hitosFuturos(calendars = [], { year, currentMonth } = {}) {
+  const hitos = [];
+  for (const plant of calendars) {
+    if (!plant || plant.status !== 'ok') continue;
+    for (const entry of plant.entries || []) {
+      const esFloracion = entry.layer === 'fenologia' && entry.stageCode === 'flowering';
+      const esNutricion = entry.layer === 'nutricion' && entry.anchored;
+      const esCosecha = entry.layer === 'cosecha';
+      if (!esCosecha && !esFloracion && !esNutricion) continue;
+
+      const tipo = esCosecha ? 'cosecha' : esFloracion ? 'floracion' : 'nutricion';
+      const verbo = esCosecha ? 'Viene cosecha de' : esFloracion ? 'Floración esperada de' : 'Abonar';
+
+      const mesesFuturos = (entry.months || []).filter((m) => m > currentMonth && m <= 12);
+      if (mesesFuturos.length === 0) continue;
+
+      if (entry.continuous) {
+        // Produce casi todo el año: un solo hito-resumen, no 12 puntos.
+        hitos.push({
+          id: `futuro-${plant.id}-${entry.layer}-cont`,
+          tipo,
+          pasado: false,
+          ts: null,
+          month: Math.min(...mesesFuturos),
+          day: null,
+          label: `${plant.name}: cosecha casi todo el año`,
+          detail: entry.detail || '',
+          count: plant.count || 1,
+          approximate: true,
+          source: entry.source || 'Calendario de la finca',
+        });
+        continue;
+      }
+
+      for (const m of mesesFuturos) {
+        hitos.push({
+          id: `futuro-${plant.id}-${entry.layer}-${entry.stageCode || entry.title}-${m}`,
+          tipo,
+          pasado: false,
+          ts: null,
+          month: m,
+          day: null,
+          label: `${verbo} ${plant.name}`,
+          detail: entry.title && entry.title !== plant.name ? entry.title : '',
+          count: plant.count || 1,
+          approximate: Boolean(entry.approximate),
+          source: entry.source || 'Calendario de la finca',
+        });
+      }
+    }
+  }
+  return hitos;
+}
+
+/**
+ * Arma la línea de tiempo completa del año en curso.
+ *
+ * @param {Object} cfg
+ * @param {Array} [cfg.cycles] — FarmProcess[] de la finca
+ * @param {Array} [cfg.harvestLogs] — log--harvest crudos (logCache)
+ * @param {Object<string, Array>} [cfg.eventsByProcess] — process_id → eventos
+ * @param {Array} [cfg.calendars] — PlantCalendar[] (farmCalendarService)
+ * @param {number} [cfg.now] — epoch ms (inyectable en tests)
+ * @returns {{
+ *   year: number, currentMonth: number, hitos: Array,
+ *   porMes: Array<{mes:number, estado:'pasado'|'hoy'|'proximo', tono:string,
+ *                  hitos:Array, counts:Object, total:number}>,
+ *   totalPasado: number, totalFuturo: number, vacio: boolean
+ * }}
+ */
+export function buildAnoFinca({ cycles = [], harvestLogs = [], eventsByProcess = {}, calendars = [], now } = {}) {
+  const ref = isFiniteTs(now) ? now : Date.now();
+  const year = yearOf(ref);
+  const currentMonth = monthOf(ref);
+
+  const cyclesById = {};
+  for (const c of cycles) {
+    const id = c?.process_id || c?.id;
+    if (id) cyclesById[id] = c;
+  }
+
+  const pasados = [
+    ...hitosDeSiembras(cycles, year),
+    ...hitosDeCosechas(harvestLogs, year),
+    ...hitosDeEventos(eventsByProcess, cyclesById, year),
+  ];
+  const futuros = hitosFuturos(calendars, { year, currentMonth });
+  const hitos = [...pasados, ...futuros];
+
+  const porMes = TEMPORADA_POR_MES.map(({ mes, tono, temporadaId }) => {
+    const delMes = hitos.filter((h) => h.month === mes);
+    // Cronológico dentro del mes; los futuros (sin ts) al final.
+    delMes.sort((a, b) => {
+      if (a.pasado !== b.pasado) return a.pasado ? -1 : 1;
+      return (a.ts || 0) - (b.ts || 0);
+    });
+    const counts = {};
+    for (const h of delMes) counts[h.tipo] = (counts[h.tipo] || 0) + 1;
+    return {
+      mes,
+      estado: mes === currentMonth ? 'hoy' : mes < currentMonth ? 'pasado' : 'proximo',
+      tono,
+      temporadaId,
+      hitos: delMes,
+      counts,
+      total: delMes.length,
+    };
+  });
+
+  return {
+    year,
+    currentMonth,
+    hitos,
+    porMes,
+    totalPasado: pasados.length,
+    totalFuturo: futuros.length,
+    vacio: hitos.length === 0,
+  };
+}

--- a/src/services/anoFincaService.js
+++ b/src/services/anoFincaService.js
@@ -263,12 +263,11 @@ export function hitosDeEventos(eventsByProcess = {}, cyclesById = {}, year) {
  * mes siguiente, no en 12 puntos.
  *
  * @param {Array} calendars — PlantCalendar[] con status 'ok'
- * @param {Object} cfg
- * @param {number} cfg.year
- * @param {number} cfg.currentMonth — 1-12 (los hitos van de currentMonth+1 a 12)
+ * @param {{currentMonth?: number}} [cfg] - mes actual 1-12 (los hitos van de
+ *   currentMonth+1 a 12)
  * @returns {Array} hitos con pasado: false
  */
-export function hitosFuturos(calendars = [], { year, currentMonth } = {}) {
+export function hitosFuturos(calendars = [], { currentMonth } = {}) {
   const hitos = [];
   for (const plant of calendars) {
     if (!plant || plant.status !== 'ok') continue;
@@ -326,14 +325,14 @@ export function hitosFuturos(calendars = [], { year, currentMonth } = {}) {
  * Arma la línea de tiempo completa del año en curso.
  *
  * @param {Object} cfg
- * @param {Array} [cfg.cycles] — FarmProcess[] de la finca
- * @param {Array} [cfg.harvestLogs] — log--harvest crudos (logCache)
- * @param {Object<string, Array>} [cfg.eventsByProcess] — process_id → eventos
- * @param {Array} [cfg.calendars] — PlantCalendar[] (farmCalendarService)
- * @param {number} [cfg.now] — epoch ms (inyectable en tests)
+ * @param {Array} [cfg.cycles] - FarmProcess[] de la finca
+ * @param {Array} [cfg.harvestLogs] - log--harvest crudos (logCache)
+ * @param {Object<string, Array>} [cfg.eventsByProcess] - process_id a eventos
+ * @param {Array} [cfg.calendars] - PlantCalendar[] (farmCalendarService)
+ * @param {number} [cfg.now] - epoch ms (inyectable en tests)
  * @returns {{
  *   year: number, currentMonth: number, hitos: Array,
- *   porMes: Array<{mes:number, estado:'pasado'|'hoy'|'proximo', tono:string,
+ *   porMes: Array<{mes:number, estado:string, tono:string, temporadaId:(string|null),
  *                  hitos:Array, counts:Object, total:number}>,
  *   totalPasado: number, totalFuturo: number, vacio: boolean
  * }}
@@ -354,7 +353,7 @@ export function buildAnoFinca({ cycles = [], harvestLogs = [], eventsByProcess =
     ...hitosDeCosechas(harvestLogs, year),
     ...hitosDeEventos(eventsByProcess, cyclesById, year),
   ];
-  const futuros = hitosFuturos(calendars, { year, currentMonth });
+  const futuros = hitosFuturos(calendars, { currentMonth });
   const hitos = [...pasados, ...futuros];
 
   const porMes = TEMPORADA_POR_MES.map(({ mes, tono, temporadaId }) => {


### PR DESCRIPTION
## Qué es

Vista Tier-1 **byte-neutral** (solo CSS/SVG, cero fotos, cero deps npm): **EL AÑO DE LA FINCA** — la línea de tiempo de los 12 meses del año del usuario. Un camino SVG hecho a mano cruza el año: **sólido hasta hoy** (lo registrado: sembró X, cosechó Y, labores, floreció Z) y **punteado de hoy en adelante** (lo que viene según el calendario groundeado por su altitud). Bandas de aguas/secas del almanaque de fondo.

Distinta de "Mi Cosecha" (tablero de cantidades): esta es la vista TEMPORAL. **cosechaService es SOLO LECTURA aquí** — cero cambios a ese archivo.

## Cómo se llega
Home → Los mundos de mi finca → **Cultivos y semillas** → entrada 🛤️ **El año de la finca** (junto a Calendario/Almanaque, complementa sin duplicar). También `#/ano-finca`.

## Fuentes de datos (todas existentes, nada inventado)
- Siembras → FarmProcess (`listFarmProcesses` + `hydrateCyclesFromFarmOS`), `created_at` = día 0; matas equivalentes agrupadas ×N (mismo criterio que Calendario de finca).
- Cosechas → `log--harvest` de logCache normalizados por `cosechaService`.
- Labores/floraciones → `FarmProcessEvent` (task_completed, pest_management, stage_transition→flowering; observaciones agregadas por mes).
- Lo que viene → `buildPlantCalendar` (farmCalendarService), hereda `approximate` → pill "estimado".
- Banda lluvia/seca → mapeo fiel de `TEMPORADAS_ANIO` del almanaque (marzo/sept = transición honesta, sin tono inventado).

## Accesibilidad y rendimiento
- SVG decorativo (`aria-hidden`); navegación por botones de mes reales (`aria-pressed`) + lista cronológica textual por mes + resumen `sr-only`.
- `prefers-reduced-motion` apaga el dibujado del camino y el pulso de "hoy" (solo stroke/opacity, GPU-friendly).
- Estado vacío acogedor ("Su año apenas empieza… se irá llenando a medida que registre") con CTAs a sembrar/cosechar.

## Gates
- [x] `anoFincaService.js` puro + 12 tests unitarios (vitest)
- [x] Reachability test de mundos verde (9/9)
- [x] tsc-gate: 1829 = baseline (0 errores nuevos)
- [x] Budget: 25.0 / 25.5 MB (chunk lazy nuevo ~22 KB raw / ~8 KB gzip ≈ bytes 0; cero fotos)
- [x] Verificado EN VIVO (vite dev + Playwright/chromium): estado vacío y con datos sembrados en IndexedDB (capturas en el hilo de Telegram)

🤖 Generated with [Claude Code](https://claude.com/claude-code)