### PR TITLE
feat(modo-campo): rotación suave de ejemplos «hola chagra» (6s, cross-fade, pausa hover/focus)

### DIFF
--- a/src/components/modoCampo/EjemplosVoz.jsx
+++ b/src/components/modoCampo/EjemplosVoz.jsx
@@ -4,23 +4,31 @@
  *
  * Muestra 3 ejemplos REALES y bien diferenciados de lo que se puede hacer
  * por voz — registrar en el cuaderno, pedir consejo hablado, preguntar un
- * dato en vivo — rotando uno cada ~4s con una onda de voz sutil que late.
+ * dato en vivo — rotando uno cada ~6s con cross-fade suave (el que sale se
+ * desvanece hacia arriba mientras entra el siguiente; solo transform/opacity,
+ * amigable con la GPU). La rotación se PAUSA mientras el usuario tiene el
+ * mouse encima o el foco dentro de la tarjeta (está leyendo), y los puntos
+ * indicadores son botones: un toque salta directo a ese ejemplo.
  *
  * Honestidad del copy: NO promete "IA en su teléfono". El reconocimiento
  * del wake-word sí es on-device, pero el agente necesita señal para
  * responder — por eso el encabezado vende el gesto ("con las manos
  * ocupadas"), no una capacidad que no existe.
  *
- * Accesibilidad: respeta prefers-reduced-motion — sin animación, los 3
- * ejemplos se muestran quietos en lista (misma información, cero vaivén).
+ * Accesibilidad: respeta prefers-reduced-motion — sin animación ni timer,
+ * los 3 ejemplos se muestran quietos en lista (misma información, cero
+ * vaivén). Con movimiento normal la escena anuncia el ejemplo vigente vía
+ * aria-live="polite".
  *
  * Solo UI/copy: cero lógica de wake-word, cero deps nuevas (emoji + CSS).
  * Español colombiano (tú/usted), NUNCA voseo argentino.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import './ejemplosVoz.css';
 
-/** Los 3 ejemplos canónicos — cada uno una capacidad DISTINTA. */
+/** Los 3 ejemplos canónicos — cada uno una capacidad DISTINTA y groundeada:
+ *  registrar en la bitácora, consejo sobre un mundo real (café), y la
+ *  capability `precio` (precios mayoristas del día) de agentCapabilities. */
 // eslint-disable-next-line react-refresh/only-export-components -- constante de copy que los tests validan junto al componente (patrón NotifPermissionPrompt)
 export const EJEMPLOS_VOZ = [
   {
@@ -43,7 +51,9 @@ export const EJEMPLOS_VOZ = [
   },
 ];
 
-const ROTACION_MS = 4000;
+const ROTACION_MS = 6000;
+/** Duración de la animación de salida (debe calzar con ejemplos-voz-sale). */
+const SALIDA_MS = 450;
 
 /** ¿El usuario pidió movimiento reducido a nivel de sistema? */
 const prefiereMenosMovimiento = () =>
@@ -83,19 +93,49 @@ export default function EjemplosVoz() {
   // con el panel abierto, el próximo montaje la recoge (suficiente acá).
   const [sinMovimiento] = useState(prefiereMenosMovimiento);
   const [idx, setIdx] = useState(0);
+  // Índice del ejemplo que está SALIENDO (cross-fade); null si no hay salida.
+  const [saliente, setSaliente] = useState(null);
+  // Pausado mientras el usuario lee (hover o foco dentro de la tarjeta).
+  const [pausado, setPausado] = useState(false);
+  // Espejo de idx para que el interval no dependa del render (sin re-crear
+  // el timer en cada rotación) y sin setState dentro de un updater.
+  const idxRef = useRef(0);
+
+  const irA = useCallback((siguiente) => {
+    if (siguiente === idxRef.current) return;
+    setSaliente(idxRef.current);
+    idxRef.current = siguiente;
+    setIdx(siguiente);
+  }, []);
 
   useEffect(() => {
-    if (sinMovimiento) return undefined;
+    if (sinMovimiento || pausado) return undefined;
     const timer = setInterval(() => {
-      setIdx((i) => (i + 1) % EJEMPLOS_VOZ.length);
+      irA((idxRef.current + 1) % EJEMPLOS_VOZ.length);
     }, ROTACION_MS);
     return () => clearInterval(timer);
-  }, [sinMovimiento]);
+  }, [sinMovimiento, pausado, irA]);
+
+  // Desmonta el ejemplo saliente al terminar su animación. Timeout (no
+  // onAnimationEnd) para que funcione igual en jsdom, donde las animaciones
+  // CSS no corren.
+  useEffect(() => {
+    if (saliente === null) return undefined;
+    const timer = setTimeout(() => setSaliente(null), SALIDA_MS);
+    return () => clearTimeout(timer);
+  }, [saliente, idx]);
+
+  const pausar = useCallback(() => setPausado(true), []);
+  const reanudar = useCallback(() => setPausado(false), []);
 
   return (
     <div
       className="ejemplos-voz rounded-xl border border-slate-700/50 bg-slate-800/40 p-4 space-y-3"
       data-testid="ejemplos-voz"
+      onMouseEnter={pausar}
+      onMouseLeave={reanudar}
+      onFocus={pausar}
+      onBlur={reanudar}
     >
       <div className="flex items-center justify-between gap-3">
         <h4 className="text-[13px] font-bold text-slate-200">
@@ -110,21 +150,41 @@ export default function EjemplosVoz() {
         </div>
       ) : (
         <>
-          {/* key={idx} remonta el nodo → la animación de entrada corre en cada
-              rotación. min-height evita brincos entre frases de largo distinto. */}
-          <div className="ejemplos-voz-escena" aria-live="off">
+          {/* Cross-fade: el saliente (absoluto, decorativo) se desvanece
+              mientras el entrante (key={idx} → remonta y anima) aparece.
+              min-height en la escena evita brincos entre frases distintas. */}
+          <div className="ejemplos-voz-escena" aria-live="polite" aria-atomic="true">
+            {saliente !== null && (
+              <div
+                className="ejemplos-voz-paso ejemplos-voz-paso--sale"
+                key={`sale-${saliente}`}
+                aria-hidden="true"
+              >
+                <Ejemplo ejemplo={EJEMPLOS_VOZ[saliente]} />
+              </div>
+            )}
             <div className="ejemplos-voz-paso" key={idx} data-testid="ejemplos-voz-activo">
               <Ejemplo ejemplo={EJEMPLOS_VOZ[idx]} />
             </div>
           </div>
-          <div className="flex justify-center gap-1.5" aria-hidden="true">
+          <div className="flex justify-center gap-1" role="group" aria-label="Elegir ejemplo">
             {EJEMPLOS_VOZ.map((e, i) => (
-              <span
+              <button
                 key={e.capacidad}
-                className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
-                  i === idx ? 'bg-emerald-400' : 'bg-slate-600'
-                }`}
-              />
+                type="button"
+                onClick={() => irA(i)}
+                aria-label={`Ver ejemplo: ${e.capacidad}`}
+                aria-current={i === idx ? 'true' : undefined}
+                data-testid={`ejemplos-voz-punto-${i}`}
+                className="p-1.5 rounded-full group"
+              >
+                <span
+                  aria-hidden="true"
+                  className={`block w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
+                    i === idx ? 'bg-emerald-400' : 'bg-slate-600 group-hover:bg-slate-500'
+                  }`}
+                />
+              </button>
             ))}
           </div>
         </>

--- a/src/components/modoCampo/__tests__/EjemplosVoz.test.jsx
+++ b/src/components/modoCampo/__tests__/EjemplosVoz.test.jsx
@@ -1,14 +1,16 @@
 /**
  * Tests de EjemplosVoz — la tarjeta de ejemplos del modo campo:
  *  - encabezado honesto + micro-guía siempre visibles
- *  - con movimiento normal: muestra UN ejemplo y ROTA cada ~4s
+ *  - con movimiento normal: muestra UN ejemplo y ROTA cada ~6s (aria-live polite)
+ *  - la rotación se PAUSA con hover/foco encima y se reanuda al salir
+ *  - los puntos indicadores son botones que saltan a ese ejemplo
  *  - con prefers-reduced-motion: lista estática con los 3 ejemplos, sin timer
  *
  * Español colombiano (tú/usted), NUNCA voseo argentino.
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import EjemplosVoz, { EJEMPLOS_VOZ } from '../EjemplosVoz.jsx';
 
 const mockMatchMedia = (reduce) => {
@@ -48,20 +50,77 @@ describe('EjemplosVoz', () => {
     expect(screen.getByTestId('ejemplos-voz-guia').textContent).toContain('enséñele su voz');
   });
 
-  it('con movimiento normal muestra un ejemplo a la vez y rota cada ~4s', () => {
+  it('con movimiento normal muestra un ejemplo a la vez y rota cada ~6s', () => {
     mockMatchMedia(false);
     render(<EjemplosVoz />);
     // Arranca en el primero.
     expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[0].frase);
     expect(screen.queryByText(EJEMPLOS_VOZ[1].frase)).not.toBeInTheDocument();
-    // Tras ~4s pasa al segundo.
-    act(() => { vi.advanceTimersByTime(4200); });
+    // Tras ~6s pasa al segundo.
+    act(() => { vi.advanceTimersByTime(6200); });
     expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[1].frase);
     // Y da la vuelta completa (tercero → primero).
-    act(() => { vi.advanceTimersByTime(4200); });
+    act(() => { vi.advanceTimersByTime(6200); });
     expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[2].frase);
-    act(() => { vi.advanceTimersByTime(4200); });
+    act(() => { vi.advanceTimersByTime(6200); });
     expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[0].frase);
+  });
+
+  it('la escena anuncia el ejemplo vigente con aria-live polite', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    const escena = screen.getByTestId('ejemplos-voz-activo').parentElement;
+    expect(escena.getAttribute('aria-live')).toBe('polite');
+    expect(escena.getAttribute('aria-atomic')).toBe('true');
+  });
+
+  it('el cross-fade muestra brevemente el ejemplo saliente y luego lo desmonta', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    act(() => { vi.advanceTimersByTime(6200); });
+    // Justo tras rotar, el primero sigue en el DOM desvaneciéndose (decorativo,
+    // oculto a lectores de pantalla)…
+    const saliente = screen.getByText(EJEMPLOS_VOZ[0].frase).closest('.ejemplos-voz-paso--sale');
+    expect(saliente).not.toBeNull();
+    expect(saliente.getAttribute('aria-hidden')).toBe('true');
+    // …y al terminar la animación de salida se desmonta.
+    act(() => { vi.advanceTimersByTime(600); });
+    expect(screen.queryByText(EJEMPLOS_VOZ[0].frase)).not.toBeInTheDocument();
+  });
+
+  it('pausa la rotación con el mouse encima y la reanuda al salir', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    fireEvent.mouseEnter(screen.getByTestId('ejemplos-voz'));
+    // Con hover no rota, aunque pase de sobra el intervalo.
+    act(() => { vi.advanceTimersByTime(14000); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[0].frase);
+    // Al quitar el mouse, retoma la rotación.
+    fireEvent.mouseLeave(screen.getByTestId('ejemplos-voz'));
+    act(() => { vi.advanceTimersByTime(6200); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[1].frase);
+  });
+
+  it('pausa la rotación mientras el foco está dentro de la tarjeta', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    fireEvent.focus(screen.getByTestId('ejemplos-voz-punto-0'));
+    act(() => { vi.advanceTimersByTime(14000); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[0].frase);
+    fireEvent.blur(screen.getByTestId('ejemplos-voz-punto-0'));
+    act(() => { vi.advanceTimersByTime(6200); });
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[1].frase);
+  });
+
+  it('los puntos son botones que saltan directo a ese ejemplo', () => {
+    mockMatchMedia(false);
+    render(<EjemplosVoz />);
+    const punto2 = screen.getByTestId('ejemplos-voz-punto-2');
+    expect(punto2.getAttribute('aria-label')).toContain(EJEMPLOS_VOZ[2].capacidad);
+    fireEvent.click(punto2);
+    expect(screen.getByTestId('ejemplos-voz-activo').textContent).toContain(EJEMPLOS_VOZ[2].frase);
+    expect(punto2.getAttribute('aria-current')).toBe('true');
+    expect(screen.getByTestId('ejemplos-voz-punto-0').getAttribute('aria-current')).toBeNull();
   });
 
   it('con prefers-reduced-motion lista los 3 ejemplos estáticos, sin rotar', () => {
@@ -74,7 +133,7 @@ describe('EjemplosVoz', () => {
     // No hay carrusel montado.
     expect(screen.queryByTestId('ejemplos-voz-activo')).not.toBeInTheDocument();
     // Y avanzar el reloj no cambia nada (no hay interval vivo).
-    act(() => { vi.advanceTimersByTime(9000); });
+    act(() => { vi.advanceTimersByTime(13000); });
     EJEMPLOS_VOZ.forEach((e) => {
       expect(screen.getByText(e.frase)).toBeInTheDocument();
     });

--- a/src/components/modoCampo/ejemplosVoz.css
+++ b/src/components/modoCampo/ejemplosVoz.css
@@ -30,10 +30,13 @@
   50%      { transform: scaleY(1);    opacity: 1; }
 }
 
-/* --- Escena del ejemplo que rota ------------------------------------------ */
+/* --- Escena del ejemplo que rota (cross-fade) ------------------------------ */
 /* min-height reserva el espacio de la frase más larga en dos líneas:
- * sin brincos de layout cuando cambia el ejemplo. */
+ * sin brincos de layout cuando cambia el ejemplo. position:relative ancla al
+ * ejemplo saliente (absoluto) mientras se desvanece. Solo transform/opacity:
+ * GPU-friendly, cero reflow. */
 .ejemplos-voz-escena {
+  position: relative;
   min-height: 86px;
   display: flex;
   align-items: flex-start;
@@ -42,15 +45,29 @@
   width: 100%;
   animation: ejemplos-voz-entra 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
+/* El que sale: se superpone (absoluto) y se desvanece hacia arriba mientras
+ * entra el siguiente — la duración calza con SALIDA_MS del componente. */
+.ejemplos-voz-paso--sale {
+  position: absolute;
+  inset: 0;
+  animation: ejemplos-voz-sale 0.45s ease-out both;
+  pointer-events: none;
+}
 @keyframes ejemplos-voz-entra {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+@keyframes ejemplos-voz-sale {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-8px); }
+}
 
 /* --- Movimiento reducido ---------------------------------------------------
  * El JSX ya cambia a lista estática (matchMedia); esto cubre además el caso
- * de que la preferencia cambie con el panel ya montado: todo quieto. */
+ * de que la preferencia cambie con el panel ya montado: todo quieto y el
+ * saliente oculto de una (sin doble texto superpuesto). */
 @media (prefers-reduced-motion: reduce) {
   .ejemplos-voz-barra { animation: none; opacity: 0.8; }
   .ejemplos-voz-paso { animation: none; }
+  .ejemplos-voz-paso--sale { animation: none; display: none; }
 }


### PR DESCRIPTION
## Qué hace

Mejora la tarjeta de ejemplos del modo campo (`EjemplosVoz`, Perfil → voz) — la tira donde la usuaria ve qué puede decirle al agente con «hola chagra»:

- **Rotación cada ~6s** (antes 4s) entre los 3 ejemplos canónicos, con **cross-fade suave**: el saliente se desvanece hacia arriba mientras entra el siguiente. Solo `transform`/`opacity` (GPU-friendly, cero reflow).
- **Pausa en hover/focus**: mientras la usuaria lee (mouse encima o foco dentro), la rotación se detiene y se reanuda al salir.
- **Puntos indicadores → botones**: un toque salta directo a ese ejemplo (`aria-label`, `aria-current`, área táctil ampliada).
- **Accesibilidad**: escena con `aria-live=polite` + `aria-atomic`; el ejemplo saliente `aria-hidden`. `prefers-reduced-motion` intacto: lista estática de los 3, sin timer.

## Los 3 ejemplos (groundeados, sin cambios de copy)

1. 🎙️ «Hola Chagra, anota que fumigué el lote 2 con caldo bordelés» → registro en bitácora
2. 🌱 «Hola Chagra, ¿por qué se me está amarillando el café?» → consejo (mundo café/plagas)
3. 💰 «Hola Chagra, ¿a cómo está el aguacate esta semana?» → capability `precio` (agentCapabilities.js)

## Byte-neutral

Cero deps npm, cero assets nuevos. Solo `.jsx` + `.css` + tests.

## Tests

9/9 verdes en `src/components/modoCampo/__tests__/EjemplosVoz.test.jsx` (rotación 6s, pausa hover, pausa focus, puntos-botón, cross-fade desmonta, aria-live, reduced-motion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)