### PR TITLE
feat(visual): 2ª pasada Germinación — hero manos-siembra + semáforo % + micro-animaciones

### DIFF
--- a/src/components/GerminacionScreen.jsx
+++ b/src/components/GerminacionScreen.jsx
@@ -7,11 +7,12 @@ import { useCallback, useMemo, useState } from 'react';
 import {
   Sprout, Beaker, ClipboardList, Plus, Trash2, ChevronRight, ChevronLeft,
   Droplets, CalendarDays, CheckCircle2, AlertTriangle, XCircle, Info,
-  Percent, BookOpen, Trees, Lightbulb,
+  Percent, BookOpen, Trees, Lightbulb, Camera,
 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { formatColombiaDate } from '../utils/colombiaDate';
 import { listGerminationReferences, getGerminationReference } from '../services/germinationReference';
+import './germinacion-vivo.css';
 
 /**
  * GerminacionScreen — MÓDULO GERMINACIÓN de la finca.
@@ -38,6 +39,12 @@ import { listGerminationReferences, getGerminationReference } from '../services/
  * método de prueba de germinación en papel/algodón = práctica estándar de
  * análisis de semillas (ISTA / FAO seed testing), enseñada por AGROSAVIA y el
  * SENA para semilla criolla.
+ *
+ * 2ª PASADA VISUAL (germinacion-vivo.css): hero photo-forward con foto real
+ * ya embarcada en dist (/bienvenida/manos-siembra.jpg, CC BY-SA 4.0) + CTA
+ * final sobre /milpa/milpaviva.jpg (CC BY 2.0) — 0 bytes de assets nuevos.
+ * Entradas escalonadas, semáforo del % con chips grandes, micro-animaciones
+ * transform/opacity y prefers-reduced-motion. Contenido y fuentes INTACTOS.
  */
 
 const STORAGE_KEY = 'chagra:germinacion:v1';
@@ -142,11 +149,36 @@ const PASOS_PRUEBA = [
   'Saca la cuenta: germinadas dividido entre las que pusiste, por 100. Ese es tu % de germinación. Anótalo aquí abajo.',
 ];
 
+/* ── Fotos reales (licencia abierta) — REUSO de /bienvenida y /milpa ──────
+ * 2ª pasada visual: mismas fotos que ya embarca dist (0 bytes nuevos),
+ * patrón "photo-forward" foto + scrim fijo + crédito visible enlazado.
+ * Licencias auditadas en public/bienvenida/creditos.json y
+ * public/milpa/_meta.json. */
+const FOTOS = {
+  hero: {
+    src: '/bienvenida/manos-siembra.jpg',
+    alt: 'Manos campesinas acomodando una plántula recién germinada en la tierra',
+    autor: 'Robbieross123',
+    licencia: 'CC BY-SA 4.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Plant_a_Sapling_for_Better_Future.jpg',
+  },
+  siembra: {
+    src: '/milpa/milpaviva.jpg',
+    alt: 'Campesino caminando entre matas de maíz recién germinadas en su lote',
+    autor: 'Feria de Productores',
+    licencia: 'CC BY 2.0',
+    fuenteUrl: 'https://commons.wikimedia.org/wiki/File:Milpa_llena_de_vida.jpg',
+  },
+};
+
 /* ════════════════════════════════════════════════════════════════════ */
 
-function Card({ children, className = '' }) {
+function Card({ children, className = '', style }) {
   return (
-    <section className={`rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 ${className}`}>
+    <section
+      style={style}
+      className={`rounded-2xl border border-slate-700/60 bg-slate-900/50 p-4 ${className}`}
+    >
       {children}
     </section>
   );
@@ -158,10 +190,11 @@ function PruebaCard({ prueba, onDelete }) {
   const info = interpretar(pct);
   const { Icon } = info;
   return (
-    <li className={`rounded-2xl border ${info.border} ${info.bg} p-3`}>
+    <li className={`gm-card gm-pop rounded-2xl border ${info.border} ${info.bg} p-3`}>
       <div className="flex items-start gap-3">
-        <span className="relative grid place-items-center shrink-0 w-12 h-12 rounded-xl bg-black/30">
+        <span className={`relative grid place-items-center shrink-0 w-12 h-12 rounded-xl bg-black/30 ring-1 ring-inset ${info.border.replace('border-', 'ring-')}`}>
           <span className={`text-lg font-extrabold ${info.text}`}>{pct}%</span>
+          <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full ${info.dot}`} aria-hidden="true" />
         </span>
         <div className="flex-1 min-w-0">
           <p className="text-sm font-bold text-white leading-tight truncate">{prueba.especie}</p>
@@ -179,7 +212,7 @@ function PruebaCard({ prueba, onDelete }) {
           type="button"
           onClick={() => onDelete(prueba.id)}
           aria-label={`Borrar prueba de ${prueba.especie}`}
-          className="shrink-0 p-2 rounded-lg text-slate-500 hover:text-rose-300 hover:bg-rose-900/30 transition-colors"
+          className="gm-focus shrink-0 p-2 rounded-lg text-slate-500 hover:text-rose-300 hover:bg-rose-900/30 transition-colors"
         >
           <Trash2 size={16} aria-hidden="true" />
         </button>
@@ -281,15 +314,53 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
   return (
     <ScreenShell title="Germinación" icon={Sprout} onBack={onBack} onHome={onHome}>
       <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
-        {/* Intro — el valor de la prueba en campesino. */}
-        <p className="text-sm text-slate-300 leading-relaxed">
-          Antes de sembrar, vale la pena saber si tu semilla está viva. La prueba
-          de germinación es fácil, casera y te dice qué tan buena es tu semilla,
-          para no botar plata ni tiempo sembrando semilla muerta.
-        </p>
+        {/* Hero photo-forward: manos sembrando una plántula (reuso CC, 0 bytes
+            nuevos). El copy del intro es el MISMO de la 1ª pasada, ahora sobre
+            la foto con scrim fijo para leerse al sol. */}
+        <figure
+          className="gm-hero gm-in relative overflow-hidden rounded-2xl border border-lime-800/50 bg-slate-900 m-0"
+          style={{ '--gm-i': 0 }}
+        >
+          <img
+            src={FOTOS.hero.src}
+            alt={FOTOS.hero.alt}
+            className="w-full aspect-[16/10] object-cover"
+            decoding="async"
+          />
+          {/* Velo de tierra: legible al sol sin tapar la foto */}
+          <div
+            className="absolute inset-0 bg-gradient-to-t from-slate-950/95 via-slate-950/35 to-transparent"
+            aria-hidden="true"
+          />
+          <div className="absolute inset-x-0 bottom-6 px-4 pb-1.5">
+            <p className="text-[11px] uppercase tracking-[0.2em] font-bold text-lime-300 [text-shadow:0_1px_6px_rgba(0,0,0,0.85)]">
+              Semillas · Prueba casera
+            </p>
+            <p className="mt-0.5 text-[22px] font-extrabold text-white leading-tight drop-shadow">
+              ¿Tu semilla está viva?
+            </p>
+            <p className="mt-1 max-w-md text-sm text-slate-100/95 leading-snug [text-shadow:0_1px_6px_rgba(0,0,0,0.7)]">
+              Antes de sembrar, vale la pena saber si tu semilla está viva. La
+              prueba de germinación es fácil, casera y te dice qué tan buena es
+              tu semilla, para no botar plata ni tiempo sembrando semilla muerta.
+            </p>
+          </div>
+          <figcaption className="absolute inset-x-0 bottom-0 bg-slate-950/82 px-2 py-1 backdrop-blur-sm">
+            <a
+              href={FOTOS.hero.fuenteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="gm-focus flex items-center gap-1 truncate text-[9px] text-slate-300 underline decoration-slate-600 underline-offset-2"
+              title={`${FOTOS.hero.autor} · ${FOTOS.hero.licencia} · Wikimedia Commons`}
+            >
+              <Camera size={9} className="shrink-0" aria-hidden="true" />
+              <span className="truncate">Foto: {FOTOS.hero.autor} · {FOTOS.hero.licencia} · Wikimedia</span>
+            </a>
+          </figcaption>
+        </figure>
 
         {/* Tip del valor — destacado. */}
-        <div className="rounded-2xl border border-lime-600/50 bg-lime-900/25 p-3.5 flex gap-3">
+        <div className="gm-in rounded-2xl border border-lime-600/50 bg-lime-900/25 p-3.5 flex gap-3" style={{ '--gm-i': 1 }}>
           <Lightbulb size={20} className="shrink-0 text-lime-300 mt-0.5" aria-hidden="true" />
           <p className="text-sm text-lime-100/90 leading-relaxed">
             <span className="font-bold text-lime-200">¿Por qué hacerla?</span> Si la
@@ -300,7 +371,7 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
         </div>
 
         {/* GUÍA: la prueba de germinación casera, paso a paso. */}
-        <Card>
+        <Card className="gm-in gm-card" style={{ '--gm-i': 2 }}>
           <h2 className="flex items-center gap-2 text-base font-bold text-sky-200">
             <Beaker size={18} aria-hidden="true" />
             La prueba de germinación casera
@@ -330,30 +401,36 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
           </div>
         </Card>
 
-        {/* GUÍA DE INTERPRETACIÓN del % . */}
-        <Card>
+        {/* GUÍA DE INTERPRETACIÓN del % — semáforo de la semilla, de un vistazo. */}
+        <Card className="gm-in gm-card" style={{ '--gm-i': 3 }}>
           <h2 className="flex items-center gap-2 text-base font-bold text-slate-100">
             <BookOpen size={18} aria-hidden="true" />
             Cómo leer el resultado
           </h2>
           <ul className="mt-3 flex flex-col gap-2">
             <li className="flex items-start gap-3 rounded-xl border border-emerald-600/40 bg-emerald-900/20 p-3">
-              <span className="mt-1 w-2.5 h-2.5 rounded-full bg-emerald-400 shrink-0" aria-hidden="true" />
-              <p className="text-sm text-emerald-100/90">
+              <span className="shrink-0 grid place-items-center min-w-[52px] h-9 rounded-lg bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 font-extrabold text-xs tabular-nums" aria-hidden="true">
+                +80%
+              </span>
+              <p className="text-sm text-emerald-100/90 pt-0.5">
                 <span className="font-bold text-emerald-200">Más de 80% — Excelente.</span> Semilla
                 buena. Siémbrala normal, con confianza.
               </p>
             </li>
             <li className="flex items-start gap-3 rounded-xl border border-amber-600/40 bg-amber-900/20 p-3">
-              <span className="mt-1 w-2.5 h-2.5 rounded-full bg-amber-400 shrink-0" aria-hidden="true" />
-              <p className="text-sm text-amber-100/90">
+              <span className="shrink-0 grid place-items-center min-w-[52px] h-9 rounded-lg bg-amber-500/20 border border-amber-500/40 text-amber-200 font-extrabold text-xs tabular-nums" aria-hidden="true">
+                60–80
+              </span>
+              <p className="text-sm text-amber-100/90 pt-0.5">
                 <span className="font-bold text-amber-200">60% a 80% — Aceptable.</span> Sirve,
                 pero siembra más densa para alcanzar las plantas que necesitas.
               </p>
             </li>
             <li className="flex items-start gap-3 rounded-xl border border-rose-600/40 bg-rose-900/20 p-3">
-              <span className="mt-1 w-2.5 h-2.5 rounded-full bg-rose-400 shrink-0" aria-hidden="true" />
-              <p className="text-sm text-rose-100/90">
+              <span className="shrink-0 grid place-items-center min-w-[52px] h-9 rounded-lg bg-rose-500/20 border border-rose-500/40 text-rose-200 font-extrabold text-xs tabular-nums" aria-hidden="true">
+                &lt;60%
+              </span>
+              <p className="text-sm text-rose-100/90 pt-0.5">
                 <span className="font-bold text-rose-200">Menos de 60% — Baja.</span> Mejor
                 descarta el lote o siembra muy densa y consigue semilla nueva.
               </p>
@@ -362,7 +439,7 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
         </Card>
 
         {/* REFERENCIA de días a germinar por especie (dato real del repo). */}
-        <Card>
+        <Card className="gm-in gm-card" style={{ '--gm-i': 4 }}>
           <h2 className="flex items-center gap-2 text-base font-bold text-teal-200">
             <CalendarDays size={18} aria-hidden="true" />
             ¿A cuántos días contar?
@@ -383,10 +460,15 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
                       elegirReferencia(r);
                       setMostrarForm(true);
                     }}
-                    className="flex-1 min-w-0 text-left"
+                    className="gm-row gm-focus group flex-1 min-w-0 text-left flex items-center gap-1.5"
                     aria-label={`Usar ${r.label} en una nueva prueba`}
                   >
                     <span className="block text-sm font-semibold text-slate-100 truncate">{r.label}</span>
+                    <ChevronRight
+                      size={14}
+                      className="shrink-0 text-teal-400 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity"
+                      aria-hidden="true"
+                    />
                   </button>
                   <span className="shrink-0 text-sm font-bold text-teal-200 tabular-nums">
                     {r.minDays}–{r.maxDays} días
@@ -413,12 +495,13 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
           <button
             type="button"
             onClick={() => { resetForm(); setMostrarForm(true); }}
-            className="w-full min-h-[52px] rounded-2xl font-bold text-base flex items-center justify-center gap-2 text-white bg-lime-700 hover:bg-lime-600 active:scale-[0.99] transition-all"
+            className="gm-in gm-btn gm-focus w-full min-h-[52px] rounded-2xl font-bold text-base flex items-center justify-center gap-2 text-white bg-lime-700 hover:bg-lime-600 shadow-lg shadow-lime-950/40"
+            style={{ '--gm-i': 5 }}
           >
             <Plus size={20} aria-hidden="true" /> Registrar una prueba
           </button>
         ) : (
-          <Card className="border-lime-700/50">
+          <Card className="gm-pop border-lime-700/50">
             <h2 className="flex items-center gap-2 text-base font-bold text-lime-200">
               <ClipboardList size={18} aria-hidden="true" />
               Registrar una prueba
@@ -523,7 +606,7 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
 
               {/* Vista previa del % en vivo. */}
               {previaInfo ? (
-                <div className={`rounded-xl border ${previaInfo.border} ${previaInfo.bg} p-3 flex items-center gap-3`}>
+                <div className={`gm-pop rounded-xl border ${previaInfo.border} ${previaInfo.bg} p-3 flex items-center gap-3`}>
                   <Droplets size={20} className={`shrink-0 ${previaInfo.text}`} aria-hidden="true" />
                   <p className="text-sm text-slate-100">
                     Te da <span className={`font-extrabold ${previaInfo.text}`}>{previaPct}% de germinación</span> —{' '}
@@ -543,14 +626,14 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
                 <button
                   type="button"
                   onClick={() => { setMostrarForm(false); setError(''); }}
-                  className="flex-1 min-h-[48px] rounded-xl font-bold text-sm bg-slate-800 hover:bg-slate-700 text-slate-200"
+                  className="gm-btn gm-focus flex-1 min-h-[48px] rounded-xl font-bold text-sm bg-slate-800 hover:bg-slate-700 text-slate-200"
                 >
                   Cancelar
                 </button>
                 <button
                   type="button"
                   onClick={guardar}
-                  className="flex-1 min-h-[48px] rounded-xl font-bold text-sm bg-lime-700 hover:bg-lime-600 text-white flex items-center justify-center gap-2"
+                  className="gm-btn gm-focus flex-1 min-h-[48px] rounded-xl font-bold text-sm bg-lime-700 hover:bg-lime-600 text-white flex items-center justify-center gap-2"
                 >
                   <CheckCircle2 size={18} aria-hidden="true" /> Guardar prueba
                 </button>
@@ -561,7 +644,7 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
 
         {/* HISTORIAL de pruebas — varias por especie, comparables. */}
         {pruebas.length > 0 ? (
-          <section>
+          <section className="gm-in" style={{ '--gm-i': 6 }}>
             <h2 className="flex items-center gap-2 text-base font-bold text-slate-100 mb-2 mt-1">
               <ClipboardList size={18} aria-hidden="true" />
               Mis pruebas
@@ -573,43 +656,68 @@ export default function GerminacionScreen({ onBack, onHome, onNavigate }) {
             </ul>
           </section>
         ) : (
-          <p className="text-sm text-slate-500 text-center py-2">
+          <p className="gm-in text-sm text-slate-500 text-center py-2" style={{ '--gm-i': 6 }}>
             Todavía no has registrado pruebas. Cuando hagas una, quedará guardada
             aquí para que compares lotes y especies.
           </p>
         )}
 
-        {/* CONEXIÓN con el ciclo: invitar a sembrar después de probar. */}
+        {/* CONEXIÓN con el ciclo: invitar a sembrar después de probar.
+            Photo-forward: la milpa recién germinada (reuso CC de /milpa,
+            0 bytes nuevos) le pone imagen al "siguiente paso es sembrar". */}
         {onNavigate ? (
-          <div className="rounded-2xl border border-emerald-700/40 bg-emerald-900/20 p-4">
-            <h2 className="flex items-center gap-2 text-base font-bold text-emerald-200">
-              <Trees size={18} aria-hidden="true" />
-              ¿Ya probaste tu semilla?
-            </h2>
-            <p className="mt-2 text-sm text-emerald-100/90 leading-relaxed">
-              Si tu semilla germinó bien, el siguiente paso es sembrar y abrirle su
-              ciclo en Chagra para hacerle seguimiento (etapas, labores y riesgos).
-            </p>
-            <button
-              type="button"
-              onClick={() => onNavigate('procesos')}
-              className="mt-3 w-full min-h-[48px] rounded-xl font-bold text-sm bg-emerald-700 hover:bg-emerald-600 text-white flex items-center justify-center gap-2"
+          <div
+            className="gm-in gm-foto-cta relative overflow-hidden rounded-2xl border border-emerald-700/40 bg-emerald-900/20"
+            style={{ '--gm-i': 7 }}
+          >
+            <img
+              src={FOTOS.siembra.src}
+              alt={FOTOS.siembra.alt}
+              loading="lazy"
+              decoding="async"
+              className="absolute inset-0 w-full h-full object-cover object-[center_35%]"
+            />
+            {/* Scrim fijo: legible al sol en los 4 temas */}
+            <div className="absolute inset-0 bg-gradient-to-t from-slate-950/95 via-slate-950/75 to-slate-950/35" aria-hidden="true" />
+            <a
+              href={FOTOS.siembra.fuenteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="gm-focus absolute top-1.5 right-1.5 rounded bg-black/55 px-1.5 py-0.5 text-[9px] leading-none text-white/75 underline decoration-white/30 underline-offset-2"
+              title={`${FOTOS.siembra.autor} · ${FOTOS.siembra.licencia} · Wikimedia Commons`}
             >
-              <Sprout size={18} aria-hidden="true" /> Registrar mi siembra
-              <ChevronRight size={16} aria-hidden="true" />
-            </button>
-            <button
-              type="button"
-              onClick={() => onNavigate('ciclo')}
-              className="mt-2 w-full min-h-[44px] rounded-xl font-bold text-sm bg-slate-800 hover:bg-slate-700 text-slate-200 flex items-center justify-center gap-2"
-            >
-              Ver mis ciclos de cultivo
-              <ChevronRight size={16} aria-hidden="true" />
-            </button>
+              Foto: {FOTOS.siembra.autor} · {FOTOS.siembra.licencia}
+            </a>
+            <div className="relative z-[1] p-4">
+              <h2 className="flex items-center gap-2 text-base font-bold text-emerald-200 [text-shadow:0_1px_6px_rgba(0,0,0,0.85)]">
+                <Trees size={18} aria-hidden="true" />
+                ¿Ya probaste tu semilla?
+              </h2>
+              <p className="mt-2 text-sm text-emerald-100/95 leading-relaxed [text-shadow:0_1px_6px_rgba(0,0,0,0.7)]">
+                Si tu semilla germinó bien, el siguiente paso es sembrar y abrirle su
+                ciclo en Chagra para hacerle seguimiento (etapas, labores y riesgos).
+              </p>
+              <button
+                type="button"
+                onClick={() => onNavigate('procesos')}
+                className="gm-btn gm-focus mt-3 w-full min-h-[48px] rounded-xl font-bold text-sm bg-emerald-700 hover:bg-emerald-600 text-white flex items-center justify-center gap-2 shadow-lg shadow-emerald-950/40"
+              >
+                <Sprout size={18} aria-hidden="true" /> Registrar mi siembra
+                <ChevronRight size={16} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                onClick={() => onNavigate('ciclo')}
+                className="gm-btn gm-focus mt-2 w-full min-h-[44px] rounded-xl font-bold text-sm bg-slate-800/90 hover:bg-slate-700 text-slate-200 flex items-center justify-center gap-2"
+              >
+                Ver mis ciclos de cultivo
+                <ChevronRight size={16} aria-hidden="true" />
+              </button>
+            </div>
           </div>
         ) : null}
 
-        <p className="text-[11px] text-slate-500 pt-1 flex items-start gap-1.5">
+        <p className="gm-in text-[11px] text-slate-500 pt-1 flex items-start gap-1.5" style={{ '--gm-i': 8 }}>
           <ChevronLeft size={12} className="shrink-0 mt-0.5 rotate-180 opacity-0" aria-hidden="true" />
           La prueba de germinación en papel/algodón es práctica estándar de
           análisis de semilla (FAO/ISTA), enseñada por AGROSAVIA y el SENA. Los

--- a/src/components/germinacion-vivo.css
+++ b/src/components/germinacion-vivo.css
@@ -1,0 +1,78 @@
+/* ===========================================================================
+ * GERMINACIÓN — 2ª pasada visual (GerminacionScreen).
+ *
+ * "La semilla despierta": los bloques brotan escalonados desde la tierra
+ * (translateY + opacity), el hero llega con un acercamiento lentísimo, las
+ * tarjetas levantan al tacto y el % de la vista previa germina con un pop.
+ * Todo es transform/opacity (GPU-friendly, sin filter/blur animado) y TODO
+ * se apaga con prefers-reduced-motion. Cero bytes de assets nuevos: las
+ * fotos son las que ya embarca dist (/bienvenida, /milpa).
+ * =========================================================================== */
+
+/* Brote escalonado: cada bloque entra con su índice (--gm-i). */
+@keyframes gm-brotar {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.gm-in {
+  animation: gm-brotar 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(var(--gm-i, 0) * 60ms);
+}
+
+/* Hero: la foto llega con un acercamiento lentísimo, una sola vez. */
+.gm-hero img {
+  animation: gm-acercar 14s cubic-bezier(0.16, 1, 0.3, 1) both;
+  transform-origin: center 42%;
+}
+@keyframes gm-acercar {
+  from { transform: scale(1.07); }
+  to { transform: scale(1); }
+}
+
+/* Tarjeta viva: levanta al pasar y asienta al presionar. */
+.gm-card {
+  transition: transform 0.22s ease, border-color 0.22s ease;
+}
+.gm-card:hover { transform: translateY(-2px); }
+.gm-card:active { transform: translateY(0) scale(0.99); }
+
+/* Filas de la tabla de referencia: empujón leve hacia la acción. */
+.gm-row { transition: transform 0.2s ease; }
+.gm-row:hover { transform: translateX(3px); }
+
+/* Botones de acción (registrar, guardar, sembrar): levante breve. */
+.gm-btn { transition: transform 0.18s ease; }
+.gm-btn:hover { transform: translateY(-1px); }
+.gm-btn:active { transform: translateY(0) scale(0.985); }
+
+/* La vista previa del % germina: pop de escala al aparecer. */
+@keyframes gm-pop {
+  from { opacity: 0; transform: scale(0.92); }
+  to { opacity: 1; transform: scale(1); }
+}
+.gm-pop { animation: gm-pop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) both; }
+
+/* El CTA del final respira con la foto: zoom sutil solo-transform al hover. */
+.gm-foto-cta img { transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1); }
+.gm-foto-cta:hover img { transform: scale(1.04); }
+
+/* Foco accesible y vivo, con el acento del tema (fallback lima). */
+.gm-focus:focus-visible,
+.gm-row:focus-visible,
+.gm-btn:focus-visible {
+  outline: 3px solid rgb(var(--t-accent-rgb, 163 230 53) / 0.9);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+/* Reduced motion: quieto todo — entradas, zoom del hero, pops y levantes. */
+@media (prefers-reduced-motion: reduce) {
+  .gm-in { animation: none; }
+  .gm-hero img { animation: none; }
+  .gm-pop { animation: none; }
+  .gm-card, .gm-row, .gm-btn, .gm-foto-cta img { transition: none; }
+  .gm-card:hover, .gm-card:active,
+  .gm-row:hover,
+  .gm-btn:hover, .gm-btn:active,
+  .gm-foto-cta:hover img { transform: none; }
+}


### PR DESCRIPTION
## Pantalla elegida: GerminacionScreen

**Por qué era la más floja**: 621 líneas de puro texto + tarjetas planas — cero fotos, cero hero, cero animación. Era la pantalla de semillas (candidata "SemillasScreen" del barrido) con menos vida de todo src/components.

## Antes → Después
- **Antes**: párrafo intro suelto, tarjetas slate uniformes, semáforo del % con punticos de 2.5px, CTA final plano.
- **Después**:
  - Hero photo-forward con `/bienvenida/manos-siembra.jpg` (manos + plántula en tierra — la imagen exacta de germinación), scrim de tierra, kicker + título "¿Tu semilla está viva?" y el copy del intro INTACTO sobre la foto. Crédito enlazado (Robbieross123 · CC BY-SA 4.0 · Wikimedia).
  - CTA final "¿Ya probaste tu semilla?" sobre `/milpa/milpaviva.jpg` (milpa recién germinada · Feria de Productores · CC BY 2.0).
  - Semáforo del %: chips grandes legibles (+80 / 60–80 / <60) en vez de puntos.
  - Micro-animaciones GPU-friendly (`germinacion-vivo.css`): brote escalonado `gm-in`, acercamiento lento del hero, hover/active en tarjetas/botones/filas, pop del % en vivo — todo transform/opacity, TODO apagado con `prefers-reduced-motion`.

## Byte-neutral
- **CERO assets nuevos**: ambas fotos ya embarcan en dist (bienvenida + milpa). Solo +1 CSS (~2.6KB fuente) y el JSX.

## Grounding intacto
- Todo el contenido, fuentes (Agrosavia/FAO/ISTA), lógica del formulario, localStorage e interpretación del % quedan idénticos.

## Verificación
- [ ] build + tsc + tests verdes
- [ ] dist < 25.5MB (delta assets = 0)
- [ ] captura Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)