### PR TITLE
feat(mockup): El Espíritu de tu Finca — biopunk 2ª pasada (refinada)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2387,7 +2387,8 @@ export default function App() {
           MENOS el home/dashboard (operador 2026-06-06): en el home el colibrí
           ya es el botón de ENVIAR del compositor, así que el FAB flotante ahí
           duplicaría el ave. Sigue en el resto para anunciar "respuesta lista". */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && <AgentFab onNavigate={navigate} />}
+      {/* (el mockup avatar-biopunk también va sin FAB: es una escena full-screen) */}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'mockup_avatar_biopunk' && <AgentFab onNavigate={navigate} />}
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o
           pregunta al agente punta a punta por voz.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,6 +69,9 @@ import { ErrorFallback } from './components/common/ErrorFallback';
 
 // Lazy-loaded route components
 const LoginScreen = lazy(() => import('./components/LoginScreen'));
+// Mockup dev (sin gate, datos de muestra): dirección visual del "juego final"
+// — el avatar/espíritu de la finca en tema biopunk. Ruta #/mockups/avatar-biopunk.
+const AvatarGameBiopunk = lazy(() => import('./mockups/AvatarGameBiopunk'));
 const OAuthCallback = lazy(() => import('./components/OAuthCallback'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
@@ -530,6 +533,9 @@ const HASH_VIEW_ROUTES = {
   cosechar: 'cosechar',
   'mi-cosecha': 'mi_cosecha',
   micosecha: 'mi_cosecha',
+  // Mockup dev del juego final (avatar biopunk): vista aislada con datos de
+  // muestra, sin gate — no toca datos reales ni requiere sesión.
+  'mockups/avatar-biopunk': 'mockup_avatar_biopunk',
 };
 
 // Vistas que cuentan como "módulo" para telemetría de piloto.
@@ -821,6 +827,13 @@ export default function App() {
       return;
     }
 
+    // Mockup dev (#/mockups/avatar-biopunk): vista aislada con datos de
+    // muestra — se monta sin sesión (no lee ni escribe datos reales).
+    if (hash === 'mockups/avatar-biopunk') {
+      Promise.resolve().then(() => navigate('mockup_avatar_biopunk'));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -849,6 +862,11 @@ export default function App() {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
+      // Mockup dev: sin gate ni sesión (datos de muestra).
+      if (routeView === 'mockup_avatar_biopunk') {
+        navigate(routeView);
+        return;
+      }
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
       if (routeView === 'extensionista' && !esExtensionistaActual()) {
         navigate('dashboard');
@@ -1210,6 +1228,16 @@ export default function App() {
                 onBack={() => navigate('juego')}
                 onHome={() => navigate('dashboard')}
               />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_avatar_biopunk':
+        // Mockup dev del juego final (El Espíritu de tu Finca, biopunk).
+        // Full-screen, datos de muestra, sin gate — solo para decidir dirección.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mockup Avatar Biopunk">
+              <AvatarGameBiopunk onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/AvatarGameBiopunk.jsx
+++ b/src/mockups/AvatarGameBiopunk.jsx
@@ -1,0 +1,881 @@
+/**
+ * AvatarGameBiopunk — MOCKUP de dirección del "juego final de Chagra":
+ * El Espíritu de tu Finca (tema biopunk).
+ *
+ * La finca es un organismo vivo NAVEGABLE (ramas = mundos, hojas = especies,
+ * frutos = cosechas, raíces/micelio = suelo, luna = clima) y un AVATAR de
+ * especie nativa colombiana vive en él: evoluciona semilla→espíritu radiante
+ * y su brillo refleja la salud real de la finca. El reloj del frailejón
+ * (scrubber inferior) muestra la finca creciendo a 5 años.
+ *
+ * Es un mockup: datos de muestra hardcodeados, sin servicios reales.
+ * Estética: extiende SceneFincaOrganismo (#2190). Ruta dev:
+ * #/mockups/avatar-biopunk (sin gate). Prefijo `agb-`.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import './avatar-game-biopunk.css';
+
+const ANIO_BASE = 2026;
+const MAX_ANIO = 5;
+
+const ETAPAS = [
+  'Semilla de espíritu',
+  'Cría de luz',
+  'Joven espíritu',
+  'Joven espíritu',
+  'Guardián de la finca',
+  'Espíritu radiante',
+];
+
+/* salud simulada por año (0..5): la trayectoria de una finca bien cuidada */
+const SALUD = {
+  agua: [38, 50, 61, 70, 81, 90],
+  suelo: [30, 44, 58, 69, 80, 92],
+  biodiversidad: [22, 35, 49, 62, 78, 94],
+  constancia: [45, 58, 66, 75, 86, 95],
+};
+const HOJAS_ANIO = [3, 7, 12, 18, 26, 34]; /* especies registradas */
+const FRUTOS_ANIO = [0, 2, 6, 11, 19, 28]; /* cosechas anotadas */
+
+const EJES_PANEL = [
+  { id: 'agua', emoji: '💧', c1: '#4fd8ff', c2: '#2dffc4' },
+  { id: 'suelo', emoji: '🪱', c1: '#ffb54f', c2: '#9dff3f' },
+  { id: 'biodiversidad', emoji: '🦋', c1: '#ff4fd8', c2: '#b28dff' },
+  { id: 'constancia', emoji: '🔥', c1: '#9dff3f', c2: '#2dffc4' },
+];
+
+const ESPECIES = [
+  {
+    id: 'chivito',
+    corto: 'Chivito',
+    nombre: 'Chivito de páramo',
+    cientifico: 'Oxypogon guerinii',
+    eje: 'Páramo sano y flores nativas',
+    glifo: '🐦',
+  },
+  {
+    id: 'rana',
+    corto: 'Rana dorada',
+    nombre: 'Rana dorada',
+    cientifico: 'Phyllobates terribilis',
+    eje: 'Agua limpia',
+    glifo: '🐸',
+  },
+  {
+    id: 'abeja',
+    corto: 'Angelita',
+    nombre: 'Abeja angelita',
+    cientifico: 'Tetragonisca angustula',
+    eje: 'Floración y biodiversidad',
+    glifo: '🐝',
+  },
+  {
+    id: 'oso',
+    corto: 'Oso',
+    nombre: 'Oso de anteojos',
+    cientifico: 'Tremarctos ornatus',
+    eje: 'Bosque y agroforestería',
+    glifo: '🐻',
+  },
+  {
+    id: 'lombriz',
+    corto: 'Lombriz',
+    nombre: 'Lombriz-micelio',
+    cientifico: 'La red que teje el suelo',
+    eje: 'Suelo vivo',
+    glifo: '🪱',
+  },
+];
+
+/* ramas del organismo = mundos (de mundosFinca.js, muestra) */
+const MUNDOS = [
+  {
+    id: 'cultivos', rama: 'RAMA I', titulo: 'Cultivos y semillas', glifo: '🌽', minYear: 0,
+    node: [70, 378], path: 'M195,438 C158,430 112,410 78,384', origen: [195, 438],
+    desc: 'La milpa, la huerta, sus matas y la semilla propia.', hojas: 9, frutos: 12,
+  },
+  {
+    id: 'cafe', rama: 'RAMA II', titulo: 'El café', glifo: '☕', minYear: 0,
+    node: [320, 362], path: 'M195,432 C240,424 286,398 314,370', origen: [195, 432],
+    desc: 'Del palo a la taza: cereza, beneficio y secado.', hojas: 6, frutos: 8,
+  },
+  {
+    id: 'agua', rama: 'RAMA III', titulo: 'El agua', glifo: '💧', minYear: 1,
+    node: [58, 256], path: 'M195,404 C148,384 96,326 64,266', origen: [195, 404],
+    desc: 'Nacederos, reservorios y riego que no desperdicia.', hojas: 4, frutos: 3,
+  },
+  {
+    id: 'animales', rama: 'RAMA IV', titulo: 'Los animales', glifo: '🐔', minYear: 2,
+    node: [330, 240], path: 'M195,396 C246,372 302,308 326,250', origen: [195, 396],
+    desc: 'Gallinas, abejas y vacas: del corral al abono.', hojas: 5, frutos: 6,
+  },
+  {
+    id: 'sanidad', rama: 'RAMA V', titulo: 'Sanidad vegetal', glifo: '🌿', minYear: 3,
+    node: [128, 158], path: 'M195,378 C178,318 152,232 132,168', origen: [195, 378],
+    desc: 'Plagas y enfermedades sin veneno: biopreparados.', hojas: 3, frutos: 2,
+  },
+  {
+    id: 'mercado', rama: 'RAMA VI', titulo: 'El mercado', glifo: '🧺', minYear: 4,
+    node: [268, 142], path: 'M195,374 C212,312 244,222 264,152', origen: [195, 374],
+    desc: 'Vender bien lo cosechado: precio justo y despensa.', hojas: 2, frutos: 5,
+  },
+  {
+    id: 'suelo', rama: 'RAÍZ MADRE', titulo: 'El suelo vivo', glifo: '🤲', minYear: 0,
+    node: [84, 552], path: 'M195,478 C158,506 120,532 96,546', origen: [195, 478],
+    desc: 'Compost, micorrizas y el cuaderno del suelo.', hojas: 7, frutos: 4,
+  },
+];
+
+const MUNDO_CLIMA = {
+  id: 'clima', rama: 'EL CIELO', titulo: 'El clima', glifo: '🌙',
+  desc: 'El cielo real de su vereda: sol, luna, lluvia y heladas.', hojas: 0, frutos: 0,
+};
+
+/* hojas del follaje: puntos sobre cada rama, con año mínimo (follaje = especies) */
+const HOJAS_SVG = [
+  { x: 150, y: 424, r: 8, rot: -30, minYear: 0 }, { x: 112, y: 408, r: 9, rot: -50, minYear: 0 },
+  { x: 92, y: 394, r: 7, rot: -70, minYear: 1 },
+  { x: 244, y: 420, r: 8, rot: 35, minYear: 0 }, { x: 284, y: 400, r: 9, rot: 55, minYear: 1 },
+  { x: 303, y: 382, r: 7, rot: 70, minYear: 2 },
+  { x: 142, y: 376, r: 8, rot: -45, minYear: 1 }, { x: 102, y: 330, r: 9, rot: -60, minYear: 2 },
+  { x: 76, y: 292, r: 7, rot: -75, minYear: 2 },
+  { x: 252, y: 366, r: 8, rot: 45, minYear: 2 }, { x: 296, y: 316, r: 9, rot: 60, minYear: 3 },
+  { x: 318, y: 276, r: 7, rot: 72, minYear: 3 },
+  { x: 176, y: 312, r: 8, rot: -25, minYear: 3 }, { x: 158, y: 240, r: 9, rot: -40, minYear: 4 },
+  { x: 140, y: 196, r: 7, rot: -55, minYear: 4 },
+  { x: 212, y: 308, r: 8, rot: 25, minYear: 4 }, { x: 236, y: 232, r: 9, rot: 40, minYear: 5 },
+  { x: 256, y: 186, r: 7, rot: 55, minYear: 5 },
+  { x: 186, y: 358, r: 7, rot: -15, minYear: 0 }, { x: 206, y: 350, r: 7, rot: 15, minYear: 1 },
+];
+
+/* frutos del organismo (= cosechas): brotan cerca de las ramas productivas */
+const FRUTOS_SVG = [
+  { x: 130, y: 416, c: '#ff4fd8', minYear: 2 }, { x: 96, y: 396, c: '#ffb54f', minYear: 2 },
+  { x: 262, y: 412, c: '#ff4fd8', minYear: 2 }, { x: 298, y: 388, c: '#ff4fd8', minYear: 3 },
+  { x: 118, y: 344, c: '#4fd8ff', minYear: 3 }, { x: 306, y: 300, c: '#ffb54f', minYear: 4 },
+  { x: 166, y: 262, c: '#ff4fd8', minYear: 4 }, { x: 244, y: 210, c: '#ffb54f', minYear: 5 },
+  { x: 148, y: 214, c: '#ff4fd8', minYear: 5 }, { x: 224, y: 322, c: '#ff4fd8', minYear: 5 },
+];
+
+/* raíces profundas: el organismo también crece hacia abajo */
+const RAICES_SVG = [
+  { d: 'M195,478 C230,504 268,528 296,544', minYear: 1, origen: [195, 478], tip: [296, 544] },
+  { d: 'M195,480 C192,520 186,556 176,588', minYear: 3, origen: [195, 480], tip: [176, 588] },
+  { d: 'M195,478 C160,516 130,556 116,596', minYear: 5, origen: [195, 478], tip: [116, 596] },
+];
+
+const clamp01 = (v) => Math.max(0, Math.min(100, v));
+
+/* ------------------------------------------------------------------------- */
+/* piezas SVG                                                                  */
+/* ------------------------------------------------------------------------- */
+
+function Hoja({ x, y, r, rot, delayClass }) {
+  return (
+    <g className={`agb-leaf ${delayClass}`} transform={`translate(${x},${y}) rotate(${rot})`}>
+      <ellipse cx={-r * 0.55} cy="0" rx={r} ry={r * 0.42} fill="#123024" stroke="#9dff3f" strokeWidth="0.8" strokeOpacity="0.85" />
+      <ellipse cx={r * 0.55} cy="0" rx={r} ry={r * 0.42} fill="#0e3324" stroke="#2dffc4" strokeWidth="0.7" strokeOpacity="0.7" />
+      <line x1={-r * 1.4} y1="0" x2={r * 1.4} y2="0" stroke="#d8ff6a" strokeWidth="0.6" opacity="0.8" />
+    </g>
+  );
+}
+
+function NodoMundo({ mundo, activo, visible, onOpen }) {
+  const [nx, ny] = mundo.node;
+  const [ox, oy] = mundo.origen;
+  return (
+    <g className={`agb-g${visible ? ' on' : ''}`} style={{ transformOrigin: `${ox}px ${oy}px` }}>
+      <path d={mundo.path} fill="none" stroke="#0f8f6c" strokeWidth="3.4" strokeLinecap="round" opacity="0.9" />
+      <path d={mundo.path} fill="none" stroke="#2dffc4" strokeWidth="1" strokeLinecap="round" opacity="0.5" />
+      <path className="agb-sap agb-s2" d={mundo.path} fill="none" stroke="#9dff3f" strokeWidth="1.2" strokeLinecap="round" opacity="0.9" />
+      <g
+        className={`agb-nodo${activo ? ' agb-nodo-activo' : ''}`}
+        role="button"
+        tabIndex={visible ? 0 : -1}
+        aria-label={`Entrar al mundo ${mundo.titulo}`}
+        onClick={() => onOpen(mundo)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpen(mundo); }
+        }}
+      >
+        <circle className="agb-nodo-halo" cx={nx} cy={ny} r="19" fill="url(#agb-bulbo)" />
+        <circle className="agb-nodo-anillo" cx={nx} cy={ny} r="12.5" fill="rgba(7,16,48,0.85)" stroke="#2dffc4" strokeWidth="1.3" style={{ filter: 'drop-shadow(0 0 6px rgba(45,255,196,0.6))' }} />
+        <text x={nx} y={ny + 4.5} textAnchor="middle" fontSize="12">{mundo.glifo}</text>
+        <text
+          x={nx} y={ny + 27} textAnchor="middle" fontFamily="ui-monospace,monospace"
+          fontSize="7" letterSpacing="1.4" fill="#bfffe9" opacity="0.85"
+        >
+          {mundo.titulo.toUpperCase()}
+        </text>
+      </g>
+    </g>
+  );
+}
+
+/* --------------------------- los cinco avatares ---------------------------- */
+
+function AvatarChivito() {
+  return (
+    <g className="agb-av-vuela">
+      <circle className="agb-estela" r="6" fill="#2dffc4" opacity="0.5" filter="url(#agb-blur3)" />
+      <circle className="agb-estela agb-e2" r="5" fill="#ff4fd8" opacity="0.4" filter="url(#agb-blur3)" />
+      <circle className="agb-estela agb-e3" r="4" fill="#4fd8ff" opacity="0.4" filter="url(#agb-blur3)" />
+      <g filter="url(#agb-glow1)">
+        <path d="M-6,-0.5 L-17,-4.5 L-12,0 L-17,4.2 Z" fill="#1f9f86" />
+        <path d="M-6.5,0 C0,-6.5 10,-6 14,-1.4 C17,1 17,3 14,4.6 C8.5,8 0,7.6 -6.5,1.4 Z" fill="#2dffc4" />
+        <path d="M-3.5,3 C3,5.3 10,5 14,2.5 C10,6.8 1.5,7.1 -4.8,2.2 Z" fill="#bfffe9" opacity="0.7" />
+        <circle cx="12.6" cy="-2.2" r="4" fill="#9dff3f" />
+        <path d="M11,-5.4 L12.6,-9 L14.4,-5 Z" fill="#4fd8ff" />
+        {/* la barba blanca del chivito (Oxypogon) */}
+        <path d="M12,1.2 C11.4,5.4 12.2,9 13.6,12 C14.8,8.8 15.6,5 14.8,1 Z" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 4px #eafff6)' }} />
+        <circle cx="13.6" cy="-2.8" r="1.15" fill="#04160f" />
+        <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+        <path d="M16.2,-1.6 C21,-2.1 25,-2.8 28.6,-4.2" stroke="#eafff6" strokeWidth="1.3" fill="none" strokeLinecap="round" />
+        <path className="agb-ala" d="M4,-1.4 C-4,-16 10,-23 17,-14 C14.4,-5.6 8,-1.4 4,-1.4 Z" fill="#ff4fd8" opacity="0.85" />
+        <path className="agb-ala" style={{ animationDelay: '-0.06s' }} d="M5.5,1.7 C0,13 13,17.5 17,10 C14,4.2 9.5,1.7 5.5,1.7 Z" fill="#b28dff" opacity="0.5" />
+      </g>
+    </g>
+  );
+}
+
+function AvatarRana() {
+  return (
+    <g filter="url(#agb-glow1)">
+      <ellipse cx="0" cy="8" rx="15" ry="3" fill="#000" opacity="0.35" />
+      <path d="M-13,7 C-16,2 -13,-4 -7,-7 C-1,-10 8,-9 12,-4 C15,-1 15,4 12,7 Z" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 8px rgba(255,181,79,0.8))' }} />
+      <path d="M-11,6 C-13,2 -10,-3 -5,-5 C1,-8 8,-7 11,-3" fill="none" stroke="#fff3c9" strokeWidth="1" opacity="0.7" />
+      <circle cx="-4" cy="1" r="1.2" fill="#7a4a10" opacity="0.65" />
+      <circle cx="2" cy="-3" r="1" fill="#7a4a10" opacity="0.6" />
+      <circle cx="5" cy="2" r="1.1" fill="#7a4a10" opacity="0.6" />
+      {/* patas dobladas */}
+      <path d="M-13,7 C-17,6 -19,3 -18,-1" fill="none" stroke="#ff9d3f" strokeWidth="2.6" strokeLinecap="round" />
+      <path d="M8,7 C12,8 16,7 18,4" fill="none" stroke="#ff9d3f" strokeWidth="2.6" strokeLinecap="round" />
+      {/* garganta que croa (pulso de vida) */}
+      <ellipse className="agb-croa" cx="9" cy="3.4" rx="3.4" ry="2.6" fill="#fff3c9" opacity="0.85" />
+      {/* ojo grande */}
+      <circle cx="8.6" cy="-5.4" r="3.4" fill="#04160f" />
+      <circle cx="8.6" cy="-5.4" r="3.4" fill="none" stroke="#ffd76a" strokeWidth="1" />
+      <circle cx="9.6" cy="-6.4" r="1.1" fill="#eafff6" />
+      <path d="M10.8,-1.4 Q13,-0.6 14.6,-1.8" stroke="#7a4a10" strokeWidth="0.8" fill="none" strokeLinecap="round" />
+    </g>
+  );
+}
+
+function AvatarAbeja() {
+  return (
+    <g className="agb-abeja-orbita">
+      <g filter="url(#agb-glow1)">
+        <ellipse cx="0" cy="0" rx="6.5" ry="4.2" fill="#ffb54f" style={{ filter: 'drop-shadow(0 0 5px rgba(255,181,79,0.9))' }} />
+        <path d="M-2.4,-3.8 L-2.4,3.8 M0.6,-4 L0.6,4 M3.4,-3.2 L3.4,3.2" stroke="#3a2410" strokeWidth="1.4" strokeLinecap="round" />
+        <circle cx="6.4" cy="-0.6" r="2.6" fill="#ffd76a" />
+        <circle cx="7.3" cy="-1.2" r="0.7" fill="#04160f" />
+        <path d="M8.8,-1.8 C10,-2.6 11,-2.6 11.8,-2" stroke="#3a2410" strokeWidth="0.6" fill="none" />
+        <ellipse className="agb-aleteo" cx="-1.4" cy="-5.4" rx="4.6" ry="2.8" fill="#4fd8ff" opacity="0.65" />
+        <ellipse className="agb-aleteo" style={{ animationDelay: '-0.06s' }} cx="1.8" cy="-5" rx="3.6" ry="2.2" fill="#bfeaff" opacity="0.5" />
+        <circle cx="-7.4" cy="1" r="1" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #d8ff6a)' }} />
+      </g>
+    </g>
+  );
+}
+
+function AvatarOso() {
+  return (
+    <g filter="url(#agb-glow1)">
+      <ellipse cx="0" cy="21" rx="15" ry="3" fill="#000" opacity="0.4" />
+      <g className="agb-oso-cuerpo">
+        <path d="M-11,20 C-14,8 -10,-4 0,-6 C10,-4 14,8 11,20 Z" fill="#171030" stroke="#2dffc4" strokeWidth="0.8" strokeOpacity="0.5" />
+        {/* marca del pecho */}
+        <path d="M-3,6 C-1,10 1,10 3,6 C2,12 -2,12 -3,6 Z" fill="#eafff6" opacity="0.85" />
+        {/* patas */}
+        <path d="M-8,20 L-8,14 M8,20 L8,14" stroke="#0f0a20" strokeWidth="4.4" strokeLinecap="round" />
+        {/* cabeza */}
+        <circle cx="0" cy="-9" r="8" fill="#1c1338" stroke="#2dffc4" strokeWidth="0.8" strokeOpacity="0.5" />
+        <path d="M-7,-15 A2.8,2.8 0 1 1 -3,-17.5 M7,-15 A2.8,2.8 0 1 0 3,-17.5" fill="#1c1338" stroke="#2dffc4" strokeWidth="0.7" strokeOpacity="0.5" />
+        {/* los anteojos de luz */}
+        <circle cx="-3.2" cy="-10" r="3" fill="none" stroke="#eafff6" strokeWidth="1.3" style={{ filter: 'drop-shadow(0 0 4px #eafff6)' }} />
+        <circle cx="3.2" cy="-10" r="3" fill="none" stroke="#eafff6" strokeWidth="1.3" style={{ filter: 'drop-shadow(0 0 4px #eafff6)' }} />
+        <path d="M-0.4,-10 L0.4,-10" stroke="#eafff6" strokeWidth="1" />
+        <circle cx="-3.2" cy="-10" r="1" fill="#2dffc4" />
+        <circle cx="3.2" cy="-10" r="1" fill="#2dffc4" />
+        <ellipse cx="0" cy="-5.4" rx="2.6" ry="1.9" fill="#d8b48a" />
+        <circle cx="0" cy="-6" r="0.9" fill="#04160f" />
+      </g>
+    </g>
+  );
+}
+
+function AvatarLombriz() {
+  return (
+    <g filter="url(#agb-glow1)">
+      <g className="agb-repta">
+        <path d="M-16,4 C-8,-1 0,5 8,0 C13,-3 17,-1 19,3" fill="none" stroke="#ff8fb0" strokeWidth="4.6" strokeLinecap="round" opacity="0.9" />
+        <path d="M-16,4 C-8,-1 0,5 8,0 C13,-3 17,-1 19,3" fill="none" stroke="#ffd0dc" strokeWidth="1.4" strokeLinecap="round" opacity="0.55" />
+        <path d="M-2,2.4 L3,0.6" stroke="#ff6f8a" strokeWidth="5.2" strokeLinecap="round" />
+        <path d="M-10,1.4 L-10,4.6 M-6,1 L-6,4 M11,-1.6 L11,1.4 M15,0 L15,3" stroke="#e06a8e" strokeWidth="0.8" opacity="0.65" />
+      </g>
+      {/* el micelio que la lombriz teje: hilos de luz */}
+      <g stroke="#2dffc4" strokeWidth="0.8" fill="none" opacity="0.8" strokeLinecap="round">
+        <path className="agb-sap" d="M-14,5 C-18,10 -24,13 -30,14" />
+        <path className="agb-sap agb-s2" d="M0,4 C-2,10 -2,16 2,21" />
+        <path className="agb-sap agb-s3" d="M16,4 C20,9 26,12 32,13" />
+      </g>
+      <circle className="agb-micnodo" cx="-30" cy="14" r="1.3" fill="#bfffe9" />
+      <circle className="agb-micnodo agb-n2" cx="2" cy="21" r="1.3" fill="#bfffe9" />
+      <circle className="agb-micnodo agb-n3" cx="32" cy="13" r="1.3" fill="#bfffe9" />
+    </g>
+  );
+}
+
+const AVATAR_RENDER = {
+  chivito: { pos: [148, 208], Cuerpo: AvatarChivito },
+  rana: { pos: [80, 282], Cuerpo: AvatarRana },
+  abeja: { pos: [108, 340], Cuerpo: AvatarAbeja },
+  oso: { pos: [248, 438], Cuerpo: AvatarOso },
+  lombriz: { pos: [140, 590], Cuerpo: AvatarLombriz },
+};
+
+function Avatar({ especie, etapa, vitalidad }) {
+  const { pos, Cuerpo } = AVATAR_RENDER[especie.id];
+  const [ax, ay] = pos;
+  const escala = 0.62 + etapa * 0.1;
+  const aura = 0.14 + (vitalidad / 100) * 0.4;
+  return (
+    <g className="agb-avatar agb-av-pop" key={`${especie.id}-${etapa === 0 ? 'huevo' : 'ser'}`}>
+      <circle
+        className="agb-av-aura" cx={ax} cy={ay} r={20 + etapa * 4}
+        fill="url(#agb-aura-grad)" style={{ '--agb-aura': aura }}
+      />
+      {etapa >= 4 && (
+        <g className="agb-av-corona" style={{ transformOrigin: `${ax}px ${ay}px` }}>
+          <circle cx={ax} cy={ay} r={26 + etapa * 3} fill="none" stroke="#2dffc4" strokeWidth="0.8" strokeDasharray="2 7" opacity="0.8" />
+          <circle cx={ax} cy={ay - 26 - etapa * 3} r="1.6" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 4px #eafff6)' }} />
+          <circle cx={ax + 22} cy={ay + 16} r="1.2" fill="#ff8fe4" style={{ filter: 'drop-shadow(0 0 4px #ff4fd8)' }} />
+        </g>
+      )}
+      {etapa === 5 && (
+        <g stroke="#eafff6" strokeWidth="1" strokeLinecap="round" opacity="0.75">
+          <path d={`M${ax},${ay - 34} L${ax},${ay - 42}`} />
+          <path d={`M${ax - 26},${ay - 20} L${ax - 32},${ay - 25}`} />
+          <path d={`M${ax + 26},${ay - 20} L${ax + 32},${ay - 25}`} />
+        </g>
+      )}
+      {etapa === 0 ? (
+        <g className="agb-huevo" transform={`translate(${ax},${ay})`}>
+          <ellipse cx="0" cy="0" rx="9" ry="11.5" fill="#0e5a44" stroke="#2dffc4" strokeWidth="1.4" style={{ filter: 'drop-shadow(0 0 8px rgba(45,255,196,0.7))' }} />
+          <path d="M-3,-4 L0,-1 L-2,2 M3,3 L1,6" stroke="#9dff3f" strokeWidth="0.8" fill="none" opacity="0.8" />
+          <circle cx="0" cy="0" r="3.4" fill="#eafff6" opacity="0.9" />
+          <circle cx="0" cy="0" r="1.4" fill="#ff8fe4" />
+        </g>
+      ) : (
+        <g transform={`translate(${ax},${ay}) scale(${escala.toFixed(2)})`}>
+          <Cuerpo />
+        </g>
+      )}
+      <text
+        x={ax} y={ay + 34 + etapa * 2} textAnchor="middle" fontFamily="ui-monospace,monospace"
+        fontSize="6.5" letterSpacing="1.2" fill="#2dffc4" opacity="0.9"
+      >
+        {(etapa === 0 ? 'SEMILLA DE ' : '') + especie.nombre.toUpperCase()}
+      </text>
+    </g>
+  );
+}
+
+/* ------------------------------------------------------------------------- */
+/* la escena completa                                                          */
+/* ------------------------------------------------------------------------- */
+
+function EscenaOrganismo({ year, especie, etapa, vitalidad, mundoAbierto, onOpenMundo }) {
+  const on = (minYear) => year >= minYear;
+  const delayLeaf = ['', 'agb-l2', 'agb-l3'];
+  return (
+    <svg
+      viewBox="0 0 390 844"
+      preserveAspectRatio="xMidYMid slice"
+      role="img"
+      aria-label="Su finca convertida en un organismo bioluminiscente navegable: cada rama es un mundo, las hojas son sus especies, los frutos sus cosechas, las raíces y el micelio son el suelo, y su espíritu guardián vive dentro."
+      data-testid="agb-escena"
+    >
+      <defs>
+        <linearGradient id="agb-cielo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#020412" />
+          <stop offset="0.4" stopColor="#071030" />
+          <stop offset="0.56" stopColor="#0d1e44" />
+        </linearGradient>
+        <linearGradient id="agb-suelo-g" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#0c1026" />
+          <stop offset="1" stopColor="#02040c" />
+        </linearGradient>
+        <radialGradient id="agb-luna" cx="0.38" cy="0.35" r="1">
+          <stop offset="0" stopColor="#eafff6" />
+          <stop offset="0.7" stopColor="#a8e8d4" />
+          <stop offset="1" stopColor="#6fc4b0" />
+        </radialGradient>
+        <radialGradient id="agb-bulbo" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0" stopColor="#2dffc4" stopOpacity="0.9" />
+          <stop offset="0.55" stopColor="#2dffc4" stopOpacity="0.25" />
+          <stop offset="1" stopColor="#2dffc4" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient id="agb-corazon" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0" stopColor="#eafff6" />
+          <stop offset="0.35" stopColor="#2dffc4" />
+          <stop offset="0.8" stopColor="#0a9f74" stopOpacity="0.4" />
+          <stop offset="1" stopColor="#0a9f74" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient id="agb-aura-grad" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0" stopColor="#2dffc4" stopOpacity="0.55" />
+          <stop offset="0.6" stopColor="#2dffc4" stopOpacity="0.18" />
+          <stop offset="1" stopColor="#2dffc4" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="agb-tallo" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0" stopColor="#0f8f6c" />
+          <stop offset="1" stopColor="#9dff3f" />
+        </linearGradient>
+        <filter id="agb-blur8"><feGaussianBlur stdDeviation="8" /></filter>
+        <filter id="agb-blur3"><feGaussianBlur stdDeviation="3" /></filter>
+        <filter id="agb-glow1" x="-80%" y="-80%" width="260%" height="260%">
+          <feGaussianBlur stdDeviation="2.2" result="b" />
+          <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+        </filter>
+      </defs>
+
+      {/* ============ CIELO ============ */}
+      <rect width="390" height="470" fill="url(#agb-cielo)" />
+      <path
+        className="agb-aurora"
+        d="M-10,150 C70,105 150,140 230,100 C300,72 350,108 400,84 L400,168 C310,146 240,176 150,158 C80,146 30,172 -10,164 Z"
+        fill="#2dffc4" opacity="0.13" filter="url(#agb-blur8)"
+      />
+      <path
+        className="agb-aurora" style={{ animationDelay: '-4.5s' }}
+        d="M-10,110 C90,84 170,116 260,82 L400,58 L400,112 C300,96 200,130 90,116 Z"
+        fill="#b28dff" opacity="0.08" filter="url(#agb-blur8)"
+      />
+      <g fill="#dfeffc">
+        <circle className="agb-tw" cx="30" cy="36" r="1.2" />
+        <circle className="agb-tw" style={{ animationDelay: '-1s' }} cx="86" cy="66" r="0.9" />
+        <circle className="agb-tw" style={{ animationDelay: '-2.2s' }} cx="140" cy="30" r="1.1" />
+        <circle className="agb-tw" style={{ animationDelay: '-0.6s' }} cx="196" cy="58" r="0.8" />
+        <circle className="agb-tw" style={{ animationDelay: '-1.7s' }} cx="236" cy="26" r="1.2" />
+        <circle className="agb-tw" style={{ animationDelay: '-2.9s' }} cx="60" cy="118" r="0.9" />
+        <circle className="agb-tw" style={{ animationDelay: '-0.3s' }} cx="356" cy="150" r="1.1" />
+        <circle className="agb-tw" style={{ animationDelay: '-1.4s' }} cx="20" cy="200" r="0.8" />
+        <circle className="agb-tw" style={{ animationDelay: '-2.5s' }} cx="368" cy="210" r="0.9" fill="#2dffc4" />
+        <circle className="agb-tw" style={{ animationDelay: '-1.9s' }} cx="102" cy="92" r="0.9" fill="#ff4fd8" />
+        <circle className="agb-tw" style={{ animationDelay: '-3.1s' }} cx="290" cy="66" r="0.8" fill="#9dff3f" />
+      </g>
+
+      {/* luna = mundo Clima (tocable) */}
+      <g
+        className="agb-nodo"
+        role="button"
+        tabIndex={0}
+        aria-label="Entrar al mundo El clima"
+        onClick={() => onOpenMundo(MUNDO_CLIMA)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenMundo(MUNDO_CLIMA); }
+        }}
+      >
+        <circle cx="322" cy="86" r="52" fill="#2dffc4" opacity="0.05" filter="url(#agb-blur8)" />
+        <circle className="agb-halo" cx="322" cy="86" r="33" fill="none" stroke="#2dffc4" strokeWidth="1" opacity="0.45" />
+        <circle className={mundoAbierto === 'clima' ? 'agb-nodo-anillo' : undefined} cx="322" cy="86" r="20" fill="url(#agb-luna)" stroke="#eafff6" strokeWidth="0.7" strokeOpacity="0.5" />
+        <circle cx="330" cy="80" r="18.2" fill="#061027" opacity="0.94" />
+        <circle cx="313" cy="93" r="2.2" fill="#5fb89e" opacity="0.4" />
+        <circle cx="309" cy="85" r="1.3" fill="#5fb89e" opacity="0.35" />
+        <text x="322" y="128" textAnchor="middle" fontFamily="ui-monospace,monospace" fontSize="7" letterSpacing="1.4" fill="#bfffe9" opacity="0.7">EL CLIMA</text>
+      </g>
+
+      {/* ============ MONTAÑAS ============ */}
+      <path d="M0,392 C70,360 140,384 210,364 C280,348 340,376 390,358 L390,470 L0,470 Z" fill="#0a1734" />
+      <path d="M0,426 C80,402 170,422 260,404 C320,392 360,410 390,398 L390,470 L0,470 Z" fill="#0d1e40" />
+
+      {/* niebla de páramo */}
+      <ellipse className="agb-fog" cx="90" cy="400" rx="130" ry="16" fill="#9fd4ff" opacity="0.07" filter="url(#agb-blur8)" />
+      <ellipse className="agb-fog agb-g2" cx="290" cy="386" rx="140" ry="14" fill="#b28dff" opacity="0.06" filter="url(#agb-blur8)" />
+
+      {/* ============ EL ORGANISMO (respira) ============ */}
+      <g className="agb-organismo">
+        {/* follaje base + hojas por año */}
+        {HOJAS_SVG.map((h, i) => (
+          <g key={i} className={`agb-g${on(h.minYear) ? ' on' : ''}`} style={{ transformOrigin: `${h.x}px ${h.y}px` }}>
+            <Hoja {...h} delayClass={delayLeaf[i % 3]} />
+          </g>
+        ))}
+
+        {/* tronco */}
+        <path d="M186,472 C188,436 190,410 193,384 L197,384 C200,410 202,436 204,472 Z" fill="url(#agb-tallo)" opacity="0.9" />
+        <path d="M186,472 C188,436 190,410 193,384" fill="none" stroke="#2dffc4" strokeWidth="1" opacity="0.6" />
+        <path d="M204,472 C202,436 200,410 197,384" fill="none" stroke="#2dffc4" strokeWidth="1" opacity="0.6" />
+        <path className="agb-sap" d="M195,470 C195,440 195,412 195,386" fill="none" stroke="#d8ff6a" strokeWidth="1.6" strokeLinecap="round" />
+        {/* yema apical: lo que la finca todavía va a ser */}
+        <g className={`agb-g${on(0) ? ' on' : ''}`} style={{ transformOrigin: '195px 384px' }}>
+          <circle className="agb-fruit" cx="195" cy="380" r="4" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 8px #9dff3f)' }} />
+        </g>
+
+        {/* ramas-mundo */}
+        {MUNDOS.filter((m) => m.id !== 'suelo').map((m) => (
+          <NodoMundo key={m.id} mundo={m} visible={on(m.minYear)} activo={mundoAbierto === m.id} onOpen={onOpenMundo} />
+        ))}
+
+        {/* frutos = cosechas */}
+        {FRUTOS_SVG.map((f, i) => (
+          <g key={i} className={`agb-g${on(f.minYear) ? ' on' : ''}`} style={{ transformOrigin: `${f.x}px ${f.y}px` }}>
+            <circle className={`agb-fruit ${['', 'agb-fr2', 'agb-fr3'][i % 3]}`} cx={f.x} cy={f.y} r="3" fill={f.c} style={{ filter: `drop-shadow(0 0 4px ${f.c})` }} />
+          </g>
+        ))}
+
+        {/* flor para la angelita */}
+        <g className={`agb-g${on(1) ? ' on' : ''}`} style={{ transformOrigin: '108px 352px' }}>
+          <g transform="translate(108,352)">
+            <path d="M0,10 L0,2" stroke="#0f8f6c" strokeWidth="1.6" strokeLinecap="round" />
+            <g fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 4px #ff4fd8)' }}>
+              <ellipse cx="0" cy="-4" rx="2.2" ry="3.4" />
+              <ellipse cx="-3.4" cy="0" rx="3.4" ry="2.2" />
+              <ellipse cx="3.4" cy="0" rx="3.4" ry="2.2" />
+            </g>
+            <circle cx="0" cy="0" r="2" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 4px #ffb54f)' }} />
+          </g>
+        </g>
+
+        {/* cocuyos */}
+        <circle className="agb-fly" cx="120" cy="300" r="1.6" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 4px #d8ff6a)' }} />
+        <circle className="agb-fly agb-f2" cx="262" cy="278" r="1.4" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px #2dffc4)' }} />
+        <circle className="agb-fly agb-f3" cx="180" cy="230" r="1.4" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 4px #ff4fd8)' }} />
+        <circle className="agb-fly agb-f4" cx="300" cy="330" r="1.5" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 4px #4fd8ff)' }} />
+      </g>
+
+      {/* ============ CORTE DE SUELO ============ */}
+      <rect y="470" width="390" height="374" fill="url(#agb-suelo-g)" />
+      <path d="M0,470 L390,470" stroke="#2dffc4" strokeWidth="1.4" opacity="0.55" />
+      <path d="M0,472.5 L390,472.5" stroke="#ff4fd8" strokeWidth="0.7" opacity="0.25" />
+      <ellipse cx="52" cy="530" rx="12" ry="7" fill="#0d1226" />
+      <ellipse cx="342" cy="516" rx="10" ry="6" fill="#0d1226" />
+      <ellipse cx="300" cy="620" rx="14" ry="8" fill="#0b0f20" />
+
+      <g className="agb-net">
+        {/* hifas troncales desde el corazón */}
+        <g fill="none" stroke="#2dffc4" strokeWidth="1.4" opacity="0.75" style={{ filter: 'drop-shadow(0 0 3px rgba(45,255,196,0.5))' }}>
+          <path d="M195,556 C160,540 118,520 76,494" />
+          <path d="M195,556 C232,538 274,520 314,496" />
+          <path d="M195,556 C196,522 195,498 195,472" />
+          <path d="M195,556 C150,586 104,606 60,610" />
+          <path d="M195,556 C244,584 292,600 336,602" />
+        </g>
+        {/* hifas secundarias */}
+        <g fill="none" stroke="#4fd8ff" strokeWidth="0.9" opacity="0.5">
+          <path d="M76,494 C60,488 46,482 36,476 M76,494 C86,486 100,480 116,477" />
+          <path d="M314,496 C328,488 342,482 354,477 M314,496 C300,488 286,482 272,478" />
+          <path d="M60,610 C48,618 40,630 36,644 M336,602 C348,610 356,622 360,636" />
+        </g>
+        {/* micelio fino dendrítico */}
+        <g fill="none" stroke="#2dffc4" strokeWidth="0.6" opacity="0.35" strokeLinecap="round">
+          <path d="M150,540 C140,534 132,526 128,516 M128,516 C124,508 118,504 110,502 M128,516 C132,506 130,498 126,492" />
+          <path d="M240,538 C252,532 260,524 264,514 M264,514 C268,506 276,502 284,500 M264,514 C260,504 262,496 268,490" />
+          <path d="M195,592 C186,600 176,606 164,610 M164,610 C154,614 148,622 146,632" />
+          <path d="M195,592 C206,600 216,606 228,610 M228,610 C240,614 246,622 248,632" />
+          <path d="M110,570 C98,566 88,566 78,570 M78,570 C68,574 60,572 52,566" />
+          <path d="M280,572 C292,568 302,568 312,572 M312,572 C322,576 330,574 338,568" />
+        </g>
+        {/* nodos micorrízicos */}
+        <g fill="#bfffe9">
+          <circle className="agb-micnodo" cx="36" cy="476" r="1" />
+          <circle className="agb-micnodo agb-n2" cx="116" cy="477" r="1.1" />
+          <circle className="agb-micnodo agb-n3" cx="272" cy="478" r="1" />
+          <circle className="agb-micnodo" cx="354" cy="477" r="1.1" />
+          <circle className="agb-micnodo agb-n2" cx="36" cy="644" r="1" />
+          <circle className="agb-micnodo agb-n3" cx="360" cy="636" r="1" />
+        </g>
+      </g>
+
+      {/* raíces que crecen con los años */}
+      {RAICES_SVG.map((r, i) => (
+        <g key={i} className={`agb-g${on(r.minYear) ? ' on' : ''}`} style={{ transformOrigin: `${r.origen[0]}px ${r.origen[1]}px` }}>
+          <path d={r.d} fill="none" stroke="#9dff3f" strokeWidth="1.6" strokeLinecap="round" opacity="0.55" />
+          <circle className="agb-micnodo" cx={r.tip[0]} cy={r.tip[1]} r="1.4" fill="#bfffe9" />
+        </g>
+      ))}
+
+      {/* raíz-mundo: el suelo vivo */}
+      <NodoMundo mundo={MUNDOS.find((m) => m.id === 'suelo')} visible={on(0)} activo={mundoAbierto === 'suelo'} onOpen={onOpenMundo} />
+
+      {/* corazón-semilla que late */}
+      <ellipse cx="195" cy="556" rx="40" ry="34" fill="#02040c" opacity="0.55" />
+      <ellipse cx="195" cy="556" rx="40" ry="34" fill="none" stroke="#0f3a30" strokeWidth="1" opacity="0.55" />
+      <circle className="agb-heart-wave" cx="195" cy="556" r="22" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
+      <circle className="agb-heart-wave" style={{ animationDelay: '0.6s' }} cx="195" cy="556" r="22" fill="none" stroke="#ff4fd8" strokeWidth="1" />
+      <circle className="agb-heart" cx="195" cy="556" r="14" fill="url(#agb-corazon)" />
+      <g className="agb-heart">
+        <path d="M195,541 C205,547 205,565 195,572 C185,565 185,547 195,541 Z" fill="#0e5a44" stroke="#2dffc4" strokeWidth="1.4" style={{ filter: 'drop-shadow(0 0 6px rgba(45,255,196,0.55))' }} />
+        <circle cx="195" cy="556" r="4.6" fill="#eafff6" />
+        <circle cx="195" cy="556" r="2" fill="#ff8fe4" />
+      </g>
+
+      {/* nutrientes viajando (paths en CSS) */}
+      <circle className="agb-spark agb-p1" r="2" fill="#bfffe9" />
+      <circle className="agb-spark agb-p2" r="2" fill="#d8ff6a" />
+      <circle className="agb-spark agb-p3" r="2.2" fill="#bfffe9" />
+      <circle className="agb-spark agb-p4" r="1.8" fill="#ffb54f" />
+      <circle className="agb-spark agb-p5" r="1.8" fill="#ff9ee8" />
+
+      {/* etiqueta viva */}
+      <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity="0.6">
+        <text x="195" y="614" fill="#2dffc4" textAnchor="middle">CORAZÓN DE LA FINCA · VIVO</text>
+        <text x="195" y="626" fill="#5b7f93" textAnchor="middle" letterSpacing="1">toque una rama para entrar a su mundo</text>
+      </g>
+
+      {/* ============ EL AVATAR: el espíritu vive en el organismo ============ */}
+      <Avatar especie={especie} etapa={etapa} vitalidad={vitalidad} />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------------- */
+/* el mockup completo (escena + HUD)                                           */
+/* ------------------------------------------------------------------------- */
+
+export default function AvatarGameBiopunk({ onBack }) {
+  const [year, setYear] = useState(0);
+  const [especieId, setEspecieId] = useState('chivito');
+  const [mundo, setMundo] = useState(null);
+  const [nota, setNota] = useState('');
+  const autoplayRef = useRef(null);
+  const notaRef = useRef(null);
+
+  const especie = ESPECIES.find((e) => e.id === especieId);
+  const etapa = Math.min(year, 5);
+  const vitalidad = Math.round(
+    (SALUD.agua[year] + SALUD.suelo[year] + SALUD.biodiversidad[year] + SALUD.constancia[year]) / 4,
+  );
+
+  const pararAutoplay = useCallback(() => {
+    if (autoplayRef.current) {
+      clearInterval(autoplayRef.current);
+      autoplayRef.current = null;
+    }
+  }, []);
+
+  const reproducir = useCallback(() => {
+    pararAutoplay();
+    setYear(0);
+    let y = 0;
+    autoplayRef.current = setInterval(() => {
+      y += 1;
+      setYear(y);
+      if (y >= MAX_ANIO) pararAutoplay();
+    }, 1050);
+  }, [pararAutoplay]);
+
+  /* cinematográfica de entrada: la finca crece sola hasta 2031 */
+  useEffect(() => {
+    const quieto = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (quieto) {
+      setYear(MAX_ANIO);
+      return undefined;
+    }
+    const arranque = setTimeout(reproducir, 2300);
+    return () => {
+      clearTimeout(arranque);
+      pararAutoplay();
+    };
+  }, [reproducir, pararAutoplay]);
+
+  useEffect(() => () => clearTimeout(notaRef.current), []);
+
+  const avisar = (texto) => {
+    setNota(texto);
+    clearTimeout(notaRef.current);
+    notaRef.current = setTimeout(() => setNota(''), 2600);
+  };
+
+  const abrirMundo = (m) => {
+    pararAutoplay();
+    setMundo(m);
+  };
+
+  const entrarMundo = () => {
+    avisar(`(mockup) aquí entraría al mundo ${mundo.titulo}`);
+    setMundo(null);
+  };
+
+  const escogerEspecie = (id) => {
+    pararAutoplay();
+    setEspecieId(id);
+    const e = ESPECIES.find((x) => x.id === id);
+    avisar(`${e.nombre} — guardián de: ${e.eje.toLowerCase()}`);
+  };
+
+  const circ = 2 * Math.PI * 26;
+
+  return (
+    <div className="agb" data-year={year} data-testid="agb-mockup">
+      <div className="agb-wings" aria-hidden="true" />
+      <div className="agb-scene agb-enter">
+        <EscenaOrganismo
+          year={year}
+          especie={especie}
+          etapa={etapa}
+          vitalidad={vitalidad}
+          mundoAbierto={mundo?.id}
+          onOpenMundo={abrirMundo}
+        />
+      </div>
+
+      {onBack && (
+        <button type="button" className="agb-volver agb-enter agb-d4" onClick={onBack}>
+          ← SALIR
+        </button>
+      )}
+
+      <div className="agb-hud">
+        <div className="agb-top">
+          <header className="agb-titulo agb-rise agb-d3">
+            <p className="agb-eyebrow">CHAGRA · EL JUEGO FINAL</p>
+            <h1 className="agb-h1">El Espíritu de tu Finca</h1>
+            <p className="agb-sub">
+              Su finca es un organismo vivo. Cuídela de verdad y su espíritu guardián crece con ella.
+            </p>
+          </header>
+
+          <aside className="agb-panel agb-rise agb-d4" aria-label="Salud y evolución del espíritu">
+            <p className="agb-panel-cab">VITALIDAD DEL ESPÍRITU</p>
+            <div className="agb-vital">
+              <svg width="60" height="60" viewBox="0 0 60 60" aria-hidden="true">
+                <circle className="agb-ring-track" cx="30" cy="30" r="26" fill="none" strokeWidth="4" />
+                <circle
+                  className="agb-ring-val" cx="30" cy="30" r="26" fill="none" strokeWidth="4"
+                  strokeLinecap="round" strokeDasharray={circ}
+                  strokeDashoffset={circ * (1 - vitalidad / 100)}
+                  transform="rotate(-90 30 30)"
+                />
+                <text x="30" y="35" textAnchor="middle" fontSize="14" fontWeight="800" fill="#eafff6" fontFamily="inherit">
+                  {vitalidad}
+                </text>
+              </svg>
+              <div>
+                <span className="agb-vital-num">{HOJAS_ANIO[year]}<small> sp.</small></span>
+                <span className="agb-vital-cap">ESPECIES VIVAS</span>
+              </div>
+            </div>
+
+            <div className="agb-ejes">
+              {EJES_PANEL.map((eje) => (
+                <div className="agb-eje" key={eje.id}>
+                  <span className="agb-eje-emoji" aria-hidden="true">{eje.emoji}</span>
+                  <span className="agb-eje-riel">
+                    <span
+                      className="agb-eje-fill"
+                      style={{ width: `${clamp01(SALUD[eje.id][year])}%`, '--agb-c1': eje.c1, '--agb-c2': eje.c2 }}
+                    />
+                  </span>
+                  <span className="agb-eje-val">{SALUD[eje.id][year]}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="agb-etapa">
+              <span className="agb-etapa-nombre">{ETAPAS[etapa]}</span>
+              <div className="agb-etapa-track" aria-label={`Etapa ${etapa + 1} de 6`}>
+                {ETAPAS.map((nombre, i) => (
+                  <span key={nombre + i} className={`agb-etapa-dot${i <= etapa ? ' on' : ''}`} />
+                ))}
+              </div>
+            </div>
+
+            <div className="agb-conteos">
+              <span>🍃 <b>{HOJAS_ANIO[year]}</b> especies registradas</span>
+              <span>✦ <b>{FRUTOS_ANIO[year]}</b> cosechas anotadas</span>
+              <span>◐ <b>{year}</b> anillos del frailejón</span>
+            </div>
+          </aside>
+        </div>
+
+        {nota && <div className="agb-nota" role="status">{nota}</div>}
+
+        <div className="agb-carta-zona">
+          {mundo && (
+            <section className="agb-carta" aria-label={`Mundo ${mundo.titulo}`}>
+              <div className="agb-carta-cab">
+                <span className="agb-carta-glifo" aria-hidden="true">{mundo.glifo}</span>
+                <div>
+                  <p className="agb-carta-rama">{mundo.rama} DEL ORGANISMO</p>
+                  <h2 className="agb-carta-titulo">{mundo.titulo}</h2>
+                </div>
+                <button type="button" className="agb-carta-x" onClick={() => setMundo(null)} aria-label="Cerrar">✕</button>
+              </div>
+              <p className="agb-carta-desc">{mundo.desc}</p>
+              <div className="agb-carta-stats">
+                <span>🍃 <b>{Math.round(mundo.hojas * (0.3 + 0.14 * year))}</b> hojas</span>
+                <span>✦ <b>{Math.round(mundo.frutos * (0.2 + 0.16 * year))}</b> frutos</span>
+                <span>◍ savia fluyendo</span>
+              </div>
+              <button type="button" className="agb-carta-entrar" onClick={entrarMundo}>
+                Entrar al mundo →
+              </button>
+            </section>
+          )}
+        </div>
+
+        <div className="agb-dock agb-rise agb-d5">
+          <div className="agb-dock-cab">
+            <span>SU GUARDIÁN — ESCOJA UNA ESPECIE NATIVA</span>
+            <span>{especie.cientifico}</span>
+          </div>
+          <div className="agb-chips" role="radiogroup" aria-label="Especie del guardián">
+            {ESPECIES.map((e) => (
+              <button
+                key={e.id}
+                type="button"
+                role="radio"
+                aria-checked={e.id === especieId}
+                className={`agb-chip${e.id === especieId ? ' on' : ''}`}
+                onClick={() => escogerEspecie(e.id)}
+              >
+                <span className="agb-chip-glifo" aria-hidden="true">{e.glifo}</span>
+                {e.corto}
+              </button>
+            ))}
+          </div>
+
+          <div className="agb-reloj">
+            <div className="agb-reloj-fila">
+              <button type="button" className="agb-play" onClick={reproducir} aria-label="Ver crecer la finca 5 años">
+                ▶
+              </button>
+              <div className="agb-anillos">
+                <div className="agb-tics" aria-hidden="true">
+                  {Array.from({ length: MAX_ANIO + 1 }, (_, i) => (
+                    <span
+                      key={i}
+                      className={`agb-tic${i <= year ? ' on' : ''}`}
+                      style={{ left: `${(i / MAX_ANIO) * 100}%` }}
+                    />
+                  ))}
+                </div>
+                <input
+                  className="agb-range"
+                  type="range"
+                  min="0"
+                  max={MAX_ANIO}
+                  step="1"
+                  value={year}
+                  aria-label="Año de la finca"
+                  onPointerDown={pararAutoplay}
+                  onChange={(e) => { pararAutoplay(); setYear(Number(e.target.value)); }}
+                />
+              </div>
+              <span className="agb-reloj-anio">{ANIO_BASE + year}</span>
+            </div>
+            <div className="agb-reloj-pie">
+              <span>EL RELOJ DEL FRAILEJÓN · UN ANILLO POR AÑO</span>
+              <span className={`agb-reloj-cap${year >= 3 ? ' futuro' : ''}`}>
+                {year === 0 ? 'SU FINCA HOY' : `ASÍ SE VERÍA EN ${ANIO_BASE + year}`}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <span className="agb-sello">MOCKUP · DATOS DE MUESTRA</span>
+    </div>
+  );
+}

--- a/src/mockups/AvatarGameBiopunk.jsx
+++ b/src/mockups/AvatarGameBiopunk.jsx
@@ -21,10 +21,18 @@ const MAX_ANIO = 5;
 const ETAPAS = [
   'Semilla de espíritu',
   'Cría de luz',
-  'Joven espíritu',
+  'Brote andante',
   'Joven espíritu',
   'Guardián de la finca',
   'Espíritu radiante',
+];
+
+/* lo que dice el espíritu al tocarlo, según la vitalidad real de la finca */
+const FRASES_ESPIRITU = [
+  { tope: 45, frase: 'Su espíritu apenas despierta — anote agua y suelo para darle fuerza.' },
+  { tope: 70, frase: 'Su espíritu va tomando cuerpo: la finca se siente cuidada.' },
+  { tope: 90, frase: 'Su espíritu brilla — la biodiversidad de su finca lo alimenta.' },
+  { tope: 101, frase: 'Espíritu radiante: su finca es un organismo pleno.' },
 ];
 
 /* salud simulada por año (0..5): la trayectoria de una finca bien cuidada */
@@ -44,6 +52,7 @@ const EJES_PANEL = [
   { id: 'constancia', emoji: '🔥', c1: '#9dff3f', c2: '#2dffc4' },
 ];
 
+/* cada guardián trae su propio acento de luz: el HUD entero se re-tiñe con él */
 const ESPECIES = [
   {
     id: 'chivito',
@@ -52,6 +61,7 @@ const ESPECIES = [
     cientifico: 'Oxypogon guerinii',
     eje: 'Páramo sano y flores nativas',
     glifo: '🐦',
+    acc: '#2dffc4', accRgb: '45, 255, 196', acc2: '#ff4fd8',
   },
   {
     id: 'rana',
@@ -60,6 +70,7 @@ const ESPECIES = [
     cientifico: 'Phyllobates terribilis',
     eje: 'Agua limpia',
     glifo: '🐸',
+    acc: '#ffd76a', accRgb: '255, 215, 106', acc2: '#ff9d3f',
   },
   {
     id: 'abeja',
@@ -68,6 +79,7 @@ const ESPECIES = [
     cientifico: 'Tetragonisca angustula',
     eje: 'Floración y biodiversidad',
     glifo: '🐝',
+    acc: '#ffb54f', accRgb: '255, 181, 79', acc2: '#4fd8ff',
   },
   {
     id: 'oso',
@@ -76,6 +88,7 @@ const ESPECIES = [
     cientifico: 'Tremarctos ornatus',
     eje: 'Bosque y agroforestería',
     glifo: '🐻',
+    acc: '#b28dff', accRgb: '178, 141, 255', acc2: '#2dffc4',
   },
   {
     id: 'lombriz',
@@ -84,8 +97,36 @@ const ESPECIES = [
     cientifico: 'La red que teje el suelo',
     eje: 'Suelo vivo',
     glifo: '🪱',
+    acc: '#ff8fb0', accRgb: '255, 143, 176', acc2: '#9dff3f',
   },
 ];
+
+/* el guardián también está escrito en el cielo: una constelación por especie */
+const CONSTELACIONES = {
+  chivito: {
+    lineas: [[[18, 149], [40, 140], [66, 122], [90, 130], [112, 104], [136, 118], [122, 146], [90, 140]]],
+    label: [58, 206],
+  },
+  rana: {
+    lineas: [[[52, 132], [70, 110], [96, 106], [118, 120], [110, 144], [78, 150], [52, 132]]],
+    label: [58, 206],
+  },
+  abeja: {
+    lineas: [
+      [[60, 134], [80, 124], [102, 128], [118, 140], [96, 148], [74, 146], [60, 134]],
+      [[84, 122], [76, 100], [96, 104]],
+    ],
+    label: [58, 206],
+  },
+  oso: {
+    lineas: [[[46, 148], [58, 120], [86, 108], [114, 114], [128, 136], [108, 152], [72, 156], [46, 148]]],
+    label: [58, 206],
+  },
+  lombriz: {
+    lineas: [[[30, 148], [54, 132], [78, 146], [102, 128], [126, 142], [150, 126], [172, 138]]],
+    label: [58, 206],
+  },
+};
 
 /* ramas del organismo = mundos (de mundosFinca.js, muestra) */
 const MUNDOS = [
@@ -169,6 +210,47 @@ const clamp01 = (v) => Math.max(0, Math.min(100, v));
 /* ------------------------------------------------------------------------- */
 /* piezas SVG                                                                  */
 /* ------------------------------------------------------------------------- */
+
+/* la constelación del guardián: se dibuja sola al escoger especie */
+function Constelacion({ especie }) {
+  const c = CONSTELACIONES[especie.id];
+  return (
+    <g key={especie.id} className="agb-constel" aria-hidden="true">
+      {c.lineas.map((linea, i) => (
+        <polyline
+          key={i}
+          className="agb-constel-linea"
+          points={linea.map((p) => p.join(',')).join(' ')}
+          pathLength="1"
+          fill="none"
+          stroke="#eafff6"
+          strokeWidth="0.6"
+          opacity="0.35"
+          style={{ animationDelay: `${0.25 + i * 0.5}s` }}
+        />
+      ))}
+      {c.lineas.flat().map(([x, y], i) => (
+        <circle
+          key={`${x}-${y}-${i}`}
+          className="agb-constel-estrella"
+          cx={x}
+          cy={y}
+          r={i === 0 ? 1.5 : 1.05}
+          fill={especie.acc}
+          style={{ animationDelay: `${0.15 + i * 0.09}s`, filter: `drop-shadow(0 0 3px ${especie.acc})` }}
+        />
+      ))}
+      <text
+        className="agb-constel-label"
+        x={c.label[0]} y={c.label[1]} textAnchor="middle"
+        fontFamily="ui-monospace,monospace" fontSize="6" letterSpacing="1.6"
+        fill="#bfffe9" opacity="0.55"
+      >
+        {`CONSTELACIÓN · ${especie.corto.toUpperCase()}`}
+      </text>
+    </g>
+  );
+}
 
 function Hoja({ x, y, r, rot, delayClass }) {
   return (
@@ -327,20 +409,44 @@ function AvatarLombriz() {
 }
 
 const AVATAR_RENDER = {
-  chivito: { pos: [148, 208], Cuerpo: AvatarChivito },
+  chivito: { pos: [152, 218], Cuerpo: AvatarChivito },
   rana: { pos: [80, 282], Cuerpo: AvatarRana },
   abeja: { pos: [108, 340], Cuerpo: AvatarAbeja },
   oso: { pos: [248, 438], Cuerpo: AvatarOso },
   lombriz: { pos: [140, 590], Cuerpo: AvatarLombriz },
 };
 
-function Avatar({ especie, etapa, vitalidad }) {
+/* el filamento de savia que une el corazón de la finca con su espíritu */
+function VinculoEspiritu({ especie }) {
+  const [ax, ay] = AVATAR_RENDER[especie.id].pos;
+  const mx = (195 + ax) / 2 + (ax < 195 ? -26 : 26);
+  const my = (556 + ay) / 2 + 10;
+  const d = `M195,556 Q${mx},${my} ${ax},${ay + 16}`;
+  return (
+    <g key={especie.id} aria-hidden="true">
+      <path className="agb-vinculo" d={d} fill="none" stroke={especie.acc} strokeWidth="1" strokeLinecap="round" opacity="0.3" />
+      <circle className="agb-vinculo-spark" r="1.7" fill="#eafff6" style={{ offsetPath: `path('${d}')`, filter: `drop-shadow(0 0 3px ${especie.acc})` }} />
+    </g>
+  );
+}
+
+function Avatar({ especie, etapa, vitalidad, evo, onTocar }) {
   const { pos, Cuerpo } = AVATAR_RENDER[especie.id];
   const [ax, ay] = pos;
   const escala = 0.62 + etapa * 0.1;
   const aura = 0.14 + (vitalidad / 100) * 0.4;
   return (
-    <g className="agb-avatar agb-av-pop" key={`${especie.id}-${etapa === 0 ? 'huevo' : 'ser'}`}>
+    <g
+      className="agb-avatar agb-av-pop"
+      key={`${especie.id}-${etapa === 0 ? 'huevo' : 'ser'}`}
+      role="button"
+      tabIndex={0}
+      aria-label={`Tocar a su espíritu: ${especie.nombre}`}
+      onClick={onTocar}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onTocar(); }
+      }}
+    >
       <circle
         className="agb-av-aura" cx={ax} cy={ay} r={20 + etapa * 4}
         fill="url(#agb-aura-grad)" style={{ '--agb-aura': aura }}
@@ -373,10 +479,36 @@ function Avatar({ especie, etapa, vitalidad }) {
       )}
       <text
         x={ax} y={ay + 34 + etapa * 2} textAnchor="middle" fontFamily="ui-monospace,monospace"
-        fontSize="6.5" letterSpacing="1.2" fill="#2dffc4" opacity="0.9"
+        fontSize="6.5" letterSpacing="1.2" fill={especie.acc} opacity="0.9"
       >
         {(etapa === 0 ? 'SEMILLA DE ' : '') + especie.nombre.toUpperCase()}
       </text>
+      {/* el momento de evolución: ondas + rayos + anuncio, una sola vez por etapa */}
+      {evo && (
+        <g key={`evo-${etapa}`} className="agb-evo" aria-hidden="true">
+          <circle className="agb-evo-onda" cx={ax} cy={ay} r="16" fill="none" stroke="#eafff6" strokeWidth="1.4" />
+          <circle className="agb-evo-onda agb-eo2" cx={ax} cy={ay} r="16" fill="none" stroke={especie.acc} strokeWidth="1" />
+          <g className="agb-evo-rayos" stroke="#eafff6" strokeWidth="1" strokeLinecap="round" style={{ transformOrigin: `${ax}px ${ay}px` }}>
+            {[0, 60, 120, 180, 240, 300].map((ang) => {
+              const rad = (ang * Math.PI) / 180;
+              return (
+                <line
+                  key={ang}
+                  x1={ax + Math.cos(rad) * 24} y1={ay + Math.sin(rad) * 24}
+                  x2={ax + Math.cos(rad) * 33} y2={ay + Math.sin(rad) * 33}
+                />
+              );
+            })}
+          </g>
+          <text
+            className="agb-evo-texto" x={ax} y={ay - 46} textAnchor="middle"
+            fontFamily="ui-monospace,monospace" fontSize="8" letterSpacing="2" fontWeight="700"
+            fill="#eafff6" style={{ filter: `drop-shadow(0 0 6px ${especie.acc})` }}
+          >
+            ✦ EVOLUCIONÓ ✦
+          </text>
+        </g>
+      )}
     </g>
   );
 }
@@ -385,7 +517,10 @@ function Avatar({ especie, etapa, vitalidad }) {
 /* la escena completa                                                          */
 /* ------------------------------------------------------------------------- */
 
-function EscenaOrganismo({ year, especie, etapa, vitalidad, mundoAbierto, onOpenMundo }) {
+function EscenaOrganismo({
+  year, especie, etapa, vitalidad, mundoAbierto, evo, pulso,
+  onOpenMundo, onPulso, onTocarEspiritu,
+}) {
   const on = (minYear) => year >= minYear;
   const delayLeaf = ['', 'agb-l2', 'agb-l3'];
   return (
@@ -464,6 +599,9 @@ function EscenaOrganismo({ year, especie, etapa, vitalidad, mundoAbierto, onOpen
         <circle className="agb-tw" style={{ animationDelay: '-1.9s' }} cx="102" cy="92" r="0.9" fill="#ff4fd8" />
         <circle className="agb-tw" style={{ animationDelay: '-3.1s' }} cx="290" cy="66" r="0.8" fill="#9dff3f" />
       </g>
+
+      {/* la constelación del guardián se dibuja al escogerlo */}
+      <Constelacion especie={especie} />
 
       {/* luna = mundo Clima (tocable) */}
       <g
@@ -598,17 +736,37 @@ function EscenaOrganismo({ year, especie, etapa, vitalidad, mundoAbierto, onOpen
       {/* raíz-mundo: el suelo vivo */}
       <NodoMundo mundo={MUNDOS.find((m) => m.id === 'suelo')} visible={on(0)} activo={mundoAbierto === 'suelo'} onOpen={onOpenMundo} />
 
-      {/* corazón-semilla que late */}
-      <ellipse cx="195" cy="556" rx="40" ry="34" fill="#02040c" opacity="0.55" />
-      <ellipse cx="195" cy="556" rx="40" ry="34" fill="none" stroke="#0f3a30" strokeWidth="1" opacity="0.55" />
-      <circle className="agb-heart-wave" cx="195" cy="556" r="22" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
-      <circle className="agb-heart-wave" style={{ animationDelay: '0.6s' }} cx="195" cy="556" r="22" fill="none" stroke="#ff4fd8" strokeWidth="1" />
-      <circle className="agb-heart" cx="195" cy="556" r="14" fill="url(#agb-corazon)" />
-      <g className="agb-heart">
-        <path d="M195,541 C205,547 205,565 195,572 C185,565 185,547 195,541 Z" fill="#0e5a44" stroke="#2dffc4" strokeWidth="1.4" style={{ filter: 'drop-shadow(0 0 6px rgba(45,255,196,0.55))' }} />
-        <circle cx="195" cy="556" r="4.6" fill="#eafff6" />
-        <circle cx="195" cy="556" r="2" fill="#ff8fe4" />
+      {/* corazón-semilla que late — TOCABLE: manda un pulso de savia al organismo */}
+      <g
+        className="agb-nodo agb-heart-hit"
+        role="button"
+        tabIndex={0}
+        aria-label="Tocar el corazón de la finca para enviar un pulso de vida"
+        onClick={onPulso}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onPulso(); }
+        }}
+      >
+        <ellipse cx="195" cy="556" rx="40" ry="34" fill="#02040c" opacity="0.55" />
+        <ellipse cx="195" cy="556" rx="40" ry="34" fill="none" stroke="#0f3a30" strokeWidth="1" opacity="0.55" />
+        <circle className="agb-heart-wave" cx="195" cy="556" r="22" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
+        <circle className="agb-heart-wave" style={{ animationDelay: '0.6s' }} cx="195" cy="556" r="22" fill="none" stroke="#ff4fd8" strokeWidth="1" />
+        <circle className="agb-heart" cx="195" cy="556" r="14" fill="url(#agb-corazon)" />
+        <g className="agb-heart">
+          <path d="M195,541 C205,547 205,565 195,572 C185,565 185,547 195,541 Z" fill="#0e5a44" stroke="#2dffc4" strokeWidth="1.4" style={{ filter: 'drop-shadow(0 0 6px rgba(45,255,196,0.55))' }} />
+          <circle cx="195" cy="556" r="4.6" fill="#eafff6" />
+          <circle cx="195" cy="556" r="2" fill="#ff8fe4" />
+        </g>
       </g>
+
+      {/* onda expansiva del pulso de vida (se re-monta por toque) */}
+      {pulso > 0 && (
+        <g key={pulso} aria-hidden="true">
+          <circle className="agb-pulso-onda" cx="195" cy="556" r="18" fill="none" stroke="#eafff6" strokeWidth="1.6" />
+          <circle className="agb-pulso-onda agb-po2" cx="195" cy="556" r="18" fill="none" stroke={especie.acc} strokeWidth="1.1" />
+          <circle className="agb-pulso-onda agb-po3" cx="195" cy="556" r="18" fill="none" stroke="#9dff3f" strokeWidth="0.8" />
+        </g>
+      )}
 
       {/* nutrientes viajando (paths en CSS) */}
       <circle className="agb-spark agb-p1" r="2" fill="#bfffe9" />
@@ -624,7 +782,9 @@ function EscenaOrganismo({ year, especie, etapa, vitalidad, mundoAbierto, onOpen
       </g>
 
       {/* ============ EL AVATAR: el espíritu vive en el organismo ============ */}
-      <Avatar especie={especie} etapa={etapa} vitalidad={vitalidad} />
+      {/* filamento de savia corazón→espíritu: el vínculo que lo alimenta */}
+      <VinculoEspiritu especie={especie} />
+      <Avatar especie={especie} etapa={etapa} vitalidad={vitalidad} evo={evo} onTocar={onTocarEspiritu} />
     </svg>
   );
 }
@@ -638,8 +798,14 @@ export default function AvatarGameBiopunk({ onBack }) {
   const [especieId, setEspecieId] = useState('chivito');
   const [mundo, setMundo] = useState(null);
   const [nota, setNota] = useState('');
+  const [playing, setPlaying] = useState(false);
+  const [pulso, setPulso] = useState(0); /* contador: cada toque re-monta la onda */
+  const [evo, setEvo] = useState(false);
   const autoplayRef = useRef(null);
   const notaRef = useRef(null);
+  const pulsoRef = useRef(null);
+  const evoRef = useRef(null);
+  const etapaPrevRef = useRef(0);
 
   const especie = ESPECIES.find((e) => e.id === especieId);
   const etapa = Math.min(year, 5);
@@ -652,11 +818,13 @@ export default function AvatarGameBiopunk({ onBack }) {
       clearInterval(autoplayRef.current);
       autoplayRef.current = null;
     }
+    setPlaying(false);
   }, []);
 
   const reproducir = useCallback(() => {
     pararAutoplay();
     setYear(0);
+    setPlaying(true);
     let y = 0;
     autoplayRef.current = setInterval(() => {
       y += 1;
@@ -665,21 +833,35 @@ export default function AvatarGameBiopunk({ onBack }) {
     }, 1050);
   }, [pararAutoplay]);
 
+  /* el momento de evolución: cuando la etapa sube, el espíritu lo celebra */
+  useEffect(() => {
+    if (etapa > etapaPrevRef.current) {
+      setEvo(true);
+      clearTimeout(evoRef.current);
+      evoRef.current = setTimeout(() => setEvo(false), 2000);
+    }
+    etapaPrevRef.current = etapa;
+  }, [etapa]);
+
   /* cinematográfica de entrada: la finca crece sola hasta 2031 */
   useEffect(() => {
     const quieto = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (quieto) {
-      setYear(MAX_ANIO);
-      return undefined;
-    }
-    const arranque = setTimeout(reproducir, 2300);
+    /* con reduced-motion no hay cinematográfica: se salta directo al año 5
+       (diferido para no encadenar renders dentro del efecto) */
+    const arranque = quieto
+      ? setTimeout(() => setYear(MAX_ANIO), 0)
+      : setTimeout(reproducir, 2300);
     return () => {
       clearTimeout(arranque);
       pararAutoplay();
     };
   }, [reproducir, pararAutoplay]);
 
-  useEffect(() => () => clearTimeout(notaRef.current), []);
+  useEffect(() => () => {
+    clearTimeout(notaRef.current);
+    clearTimeout(pulsoRef.current);
+    clearTimeout(evoRef.current);
+  }, []);
 
   const avisar = (texto) => {
     setNota(texto);
@@ -704,10 +886,35 @@ export default function AvatarGameBiopunk({ onBack }) {
     avisar(`${e.nombre} — guardián de: ${e.eje.toLowerCase()}`);
   };
 
+  /* tocar el corazón: un pulso de savia recorre el organismo entero */
+  const enviarPulso = () => {
+    setPulso((n) => n + 1);
+    clearTimeout(pulsoRef.current);
+    pulsoRef.current = setTimeout(() => setPulso(0), 1700);
+    avisar('El corazón late fuerte — la savia corre a su espíritu ✦');
+  };
+
+  /* tocar al espíritu: dice cómo se siente según la vitalidad real */
+  const tocarEspiritu = () => {
+    const nivel = FRASES_ESPIRITU.find((f) => vitalidad < f.tope);
+    if (nivel) avisar(nivel.frase);
+  };
+
+  const alternarReproduccion = () => {
+    if (playing) pararAutoplay();
+    else reproducir();
+  };
+
   const circ = 2 * Math.PI * 26;
 
   return (
-    <div className="agb" data-year={year} data-testid="agb-mockup">
+    <div
+      className={`agb${pulso > 0 ? ' agb-pulsando' : ''}`}
+      data-year={year}
+      data-especie={especieId}
+      data-testid="agb-mockup"
+      style={{ '--agb-acc': especie.acc, '--agb-acc-rgb': especie.accRgb, '--agb-acc2': especie.acc2 }}
+    >
       <div className="agb-wings" aria-hidden="true" />
       <div className="agb-scene agb-enter">
         <EscenaOrganismo
@@ -716,9 +923,15 @@ export default function AvatarGameBiopunk({ onBack }) {
           etapa={etapa}
           vitalidad={vitalidad}
           mundoAbierto={mundo?.id}
+          evo={evo}
+          pulso={pulso}
           onOpenMundo={abrirMundo}
+          onPulso={enviarPulso}
+          onTocarEspiritu={tocarEspiritu}
         />
       </div>
+      {/* velo de foco: al abrir un mundo, el resto de la finca se apaga un poco */}
+      <div className={`agb-velo${mundo ? ' on' : ''}`} aria-hidden="true" />
 
       {onBack && (
         <button type="button" className="agb-volver agb-enter agb-d4" onClick={onBack}>
@@ -818,7 +1031,7 @@ export default function AvatarGameBiopunk({ onBack }) {
         <div className="agb-dock agb-rise agb-d5">
           <div className="agb-dock-cab">
             <span>SU GUARDIÁN — ESCOJA UNA ESPECIE NATIVA</span>
-            <span>{especie.cientifico}</span>
+            <span className="agb-dock-cientifico">{especie.cientifico}</span>
           </div>
           <div className="agb-chips" role="radiogroup" aria-label="Especie del guardián">
             {ESPECIES.map((e) => (
@@ -838,8 +1051,13 @@ export default function AvatarGameBiopunk({ onBack }) {
 
           <div className="agb-reloj">
             <div className="agb-reloj-fila">
-              <button type="button" className="agb-play" onClick={reproducir} aria-label="Ver crecer la finca 5 años">
-                ▶
+              <button
+                type="button"
+                className={`agb-play${playing ? ' agb-play-on' : ''}`}
+                onClick={alternarReproduccion}
+                aria-label={playing ? 'Pausar el crecimiento' : 'Ver crecer la finca 5 años'}
+              >
+                {playing ? '❚❚' : '▶'}
               </button>
               <div className="agb-anillos">
                 <div className="agb-tics" aria-hidden="true">
@@ -863,7 +1081,7 @@ export default function AvatarGameBiopunk({ onBack }) {
                   onChange={(e) => { pararAutoplay(); setYear(Number(e.target.value)); }}
                 />
               </div>
-              <span className="agb-reloj-anio">{ANIO_BASE + year}</span>
+              <span key={year} className="agb-reloj-anio agb-anio-pop">{ANIO_BASE + year}</span>
             </div>
             <div className="agb-reloj-pie">
               <span>EL RELOJ DEL FRAILEJÓN · UN ANILLO POR AÑO</span>

--- a/src/mockups/avatar-game-biopunk.css
+++ b/src/mockups/avatar-game-biopunk.css
@@ -1,0 +1,786 @@
+/* ===========================================================================
+ * AVATAR GAME — BIOPUNK (mockup de dirección, "El Espíritu de tu Finca")
+ * ---------------------------------------------------------------------------
+ * Extiende la estética de SceneFincaOrganismo (#2190): bioluminiscencia,
+ * oscuro orgánico, micelio que titila, savia que fluye. Prefijo `agb-` para
+ * no chocar con nada. Todo se apaga con prefers-reduced-motion (estado
+ * estático digno). Datos de muestra — no cablea servicios reales.
+ * =========================================================================== */
+
+@font-face {
+  font-family: 'Baloo 2';
+  font-style: normal;
+  font-weight: 400 800;
+  font-display: swap;
+  src: url('/fonts/baloo2-latin.woff2') format('woff2');
+}
+
+.agb {
+  --agb-noche-0: #020412;
+  --agb-noche-1: #071030;
+  --agb-noche-2: #0d1e44;
+  --agb-savia: #2dffc4;
+  --agb-acido: #9dff3f;
+  --agb-magenta: #ff4fd8;
+  --agb-cian: #4fd8ff;
+  --agb-violeta: #b28dff;
+  --agb-ambar: #ffb54f;
+  --agb-crema: #eafff6;
+  --agb-tinta: #5b7f93;
+  --agb-vidrio: rgba(7, 16, 48, 0.66);
+  --agb-borde: rgba(45, 255, 196, 0.28);
+  --agb-display: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  --agb-mono: ui-monospace, 'SFMono-Regular', Menlo, monospace;
+
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 60% at 50% -10%, #0d1e44 0%, transparent 60%),
+    linear-gradient(180deg, var(--agb-noche-0) 0%, var(--agb-noche-1) 52%, #04060f 100%);
+  color: var(--agb-crema);
+  font-family: var(--agb-display);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ---- escenario: el organismo full-bleed (móvil) / columna-escenario (desktop) */
+.agb-scene {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+}
+.agb-scene svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+@media (min-width: 900px) {
+  .agb-scene svg {
+    width: auto;
+    max-width: none;
+    filter: drop-shadow(0 0 60px rgba(45, 255, 196, 0.08));
+  }
+}
+
+/* alas atmosféricas laterales (solo desktop, para que el full-screen respire) */
+.agb-wings {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  display: none;
+  background:
+    radial-gradient(34% 50% at 6% 30%, rgba(178, 141, 255, 0.10), transparent 70%),
+    radial-gradient(30% 46% at 95% 62%, rgba(45, 255, 196, 0.09), transparent 70%),
+    radial-gradient(26% 40% at 8% 82%, rgba(255, 79, 216, 0.07), transparent 70%);
+}
+@media (min-width: 900px) {
+  .agb-wings { display: block; }
+}
+
+/* =============================== INTRO ==================================== */
+.agb-enter { opacity: 0; animation: agb-enter 1s ease forwards; }
+.agb-enter.agb-d1 { animation-delay: 0.25s; }
+.agb-enter.agb-d2 { animation-delay: 0.55s; }
+.agb-enter.agb-d3 { animation-delay: 0.9s; }
+.agb-enter.agb-d4 { animation-delay: 1.3s; }
+@keyframes agb-enter { to { opacity: 1; } }
+
+.agb-rise { opacity: 0; transform: translateY(14px); animation: agb-rise 0.9s cubic-bezier(0.2, 0.8, 0.3, 1) forwards; }
+.agb-rise.agb-d3 { animation-delay: 1.1s; }
+.agb-rise.agb-d4 { animation-delay: 1.35s; }
+.agb-rise.agb-d5 { animation-delay: 1.6s; }
+@keyframes agb-rise { to { opacity: 1; transform: translateY(0); } }
+
+/* ============================ CIELO / AMBIENTE ============================ */
+@keyframes agb-tw { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
+.agb-tw { animation: agb-tw 3.2s ease-in-out infinite; }
+
+@keyframes agb-aurora { from { opacity: 0.10; transform: translateX(-10px); } to { opacity: 0.26; transform: translateX(12px); } }
+.agb-aurora { animation: agb-aurora 9s ease-in-out infinite alternate; }
+
+@keyframes agb-halo { 0%, 100% { transform: scale(1); opacity: 0.5; } 50% { transform: scale(1.12); opacity: 0.9; } }
+.agb-halo { transform-box: fill-box; transform-origin: center; animation: agb-halo 5.5s ease-in-out infinite; }
+
+@keyframes agb-fog { from { transform: translateX(-24px); } to { transform: translateX(26px); } }
+.agb-fog { animation: agb-fog 16s ease-in-out infinite alternate; }
+.agb-fog.agb-g2 { animation-delay: -6s; animation-duration: 20s; }
+
+@keyframes agb-fly {
+  0%, 100% { transform: translate(0, 0); opacity: 0.4; }
+  25% { transform: translate(9px, -7px); opacity: 1; }
+  55% { transform: translate(-6px, -13px); opacity: 0.6; }
+  80% { transform: translate(5px, -3px); opacity: 0.95; }
+}
+.agb-fly { animation: agb-fly 7s ease-in-out infinite; }
+.agb-fly.agb-f2 { animation-delay: -2.4s; animation-duration: 8.5s; }
+.agb-fly.agb-f3 { animation-delay: -4.8s; animation-duration: 6.2s; }
+.agb-fly.agb-f4 { animation-delay: -1.2s; animation-duration: 9.4s; }
+
+/* ============================ EL ORGANISMO ================================ */
+/* crecimiento por año: cada órgano lleva .agb-g y prende con .on */
+.agb-g {
+  opacity: 0;
+  transform: scale(0.22);
+  transform-box: view-box;
+  transition:
+    opacity 1s ease,
+    transform 1.25s cubic-bezier(0.18, 0.85, 0.3, 1.08);
+}
+.agb-g.on { opacity: 1; transform: scale(1); }
+
+@keyframes agb-breathe { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.008, 1.014); } }
+.agb-organismo {
+  transform-box: view-box;
+  transform-origin: 195px 470px;
+  animation: agb-breathe 7s ease-in-out infinite;
+}
+
+@keyframes agb-sap { to { stroke-dashoffset: -60; } }
+.agb-sap {
+  stroke-dasharray: 3 9;
+  animation: agb-sap 3.2s linear infinite;
+}
+.agb-sap.agb-s2 { animation-delay: -1.1s; animation-duration: 4s; }
+.agb-sap.agb-s3 { animation-delay: -2.2s; animation-duration: 3.6s; }
+
+@keyframes agb-leaf { 0%, 100% { opacity: 0.7; } 50% { opacity: 1; } }
+.agb-leaf { animation: agb-leaf 4.4s ease-in-out infinite; }
+.agb-leaf.agb-l2 { animation-delay: -1.6s; }
+.agb-leaf.agb-l3 { animation-delay: -2.9s; }
+
+@keyframes agb-fruit { 0%, 100% { opacity: 0.55; transform: scale(1); } 50% { opacity: 1; transform: scale(1.3); } }
+.agb-fruit { transform-box: fill-box; transform-origin: center; animation: agb-fruit 3.4s ease-in-out infinite; }
+.agb-fruit.agb-fr2 { animation-delay: -1.2s; }
+.agb-fruit.agb-fr3 { animation-delay: -2.3s; }
+
+/* nodo-órgano de mundo: tocable */
+.agb-nodo { cursor: pointer; }
+.agb-nodo circle,
+.agb-nodo text { transition: opacity 0.3s ease; }
+@keyframes agb-nodopulse { 0%, 100% { transform: scale(1); opacity: 0.75; } 50% { transform: scale(1.16); opacity: 1; } }
+.agb-nodo .agb-nodo-halo { transform-box: fill-box; transform-origin: center; animation: agb-nodopulse 4.6s ease-in-out infinite; }
+.agb-nodo:hover .agb-nodo-halo,
+.agb-nodo:focus-visible .agb-nodo-halo { animation-duration: 1.6s; }
+.agb-nodo:focus-visible { outline: none; }
+.agb-nodo:focus-visible .agb-nodo-anillo { stroke: var(--agb-crema); stroke-width: 2; }
+.agb-nodo.agb-nodo-activo .agb-nodo-anillo { stroke: var(--agb-crema); }
+
+@keyframes agb-heart {
+  0%, 100% { transform: scale(1); }
+  12% { transform: scale(1.12); }
+  22% { transform: scale(1.02); }
+  32% { transform: scale(1.1); }
+  46% { transform: scale(1); }
+}
+.agb-heart { transform-box: fill-box; transform-origin: center; animation: agb-heart 2.4s ease-in-out infinite; }
+
+@keyframes agb-hwave {
+  0% { transform: scale(0.35); opacity: 0.85; }
+  100% { transform: scale(2.1); opacity: 0; }
+}
+.agb-heart-wave { transform-box: fill-box; transform-origin: center; animation: agb-hwave 2.4s ease-out infinite; }
+
+@keyframes agb-netglow { 0%, 100% { opacity: 0.5; } 8% { opacity: 1; } 16% { opacity: 0.65; } 24% { opacity: 0.9; } 38% { opacity: 0.5; } }
+.agb-net { animation: agb-netglow 6s ease-in-out infinite; }
+
+@keyframes agb-nodotw { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
+.agb-micnodo { animation: agb-nodotw 3.8s ease-in-out infinite; }
+.agb-micnodo.agb-n2 { animation-delay: -1.3s; }
+.agb-micnodo.agb-n3 { animation-delay: -2.5s; }
+
+/* nutrientes viajando por las hifas */
+@keyframes agb-travel {
+  0% { offset-distance: 0%; opacity: 0; }
+  12% { opacity: 1; }
+  85% { opacity: 1; }
+  100% { offset-distance: 100%; opacity: 0; }
+}
+.agb-spark { offset-rotate: 0deg; animation: agb-travel 4.6s linear infinite; }
+.agb-spark.agb-p1 { offset-path: path('M195,556 C160,540 118,520 76,494'); }
+.agb-spark.agb-p2 { offset-path: path('M195,556 C232,538 274,520 314,496'); animation-delay: 1.5s; animation-duration: 5.4s; }
+.agb-spark.agb-p3 { offset-path: path('M195,556 C196,522 195,498 195,472'); animation-delay: 2.6s; animation-duration: 3.8s; }
+.agb-spark.agb-p4 { offset-path: path('M195,556 C150,586 104,606 60,610'); animation-delay: 0.8s; animation-duration: 6s; }
+.agb-spark.agb-p5 { offset-path: path('M195,556 C244,584 292,600 336,602'); animation-delay: 3.4s; animation-duration: 6s; }
+
+/* ============================== EL AVATAR ================================= */
+.agb-avatar { transform-box: view-box; }
+@keyframes agb-hover {
+  0%, 100% { transform: translate(0, 0); }
+  30% { transform: translate(4px, -6px); }
+  60% { transform: translate(-5px, -2px); }
+  80% { transform: translate(2px, -8px); }
+}
+.agb-av-vuela { animation: agb-hover 6.5s ease-in-out infinite; }
+
+@keyframes agb-ala { from { transform: rotate(-24deg); } to { transform: rotate(32deg); } }
+.agb-ala { transform-box: fill-box; transform-origin: 15% 85%; animation: agb-ala 0.14s linear infinite alternate; }
+
+@keyframes agb-estela { 0% { transform: scale(0.4); opacity: 0.9; } 100% { transform: scale(2.6); opacity: 0; } }
+.agb-estela { transform-box: fill-box; transform-origin: center; animation: agb-estela 1.4s ease-out infinite; }
+.agb-estela.agb-e2 { animation-delay: -0.5s; }
+.agb-estela.agb-e3 { animation-delay: -0.9s; }
+
+@keyframes agb-croa { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.35, 1.5); } }
+.agb-croa { transform-box: fill-box; transform-origin: center; animation: agb-croa 2.2s ease-in-out infinite; }
+
+@keyframes agb-orbita {
+  from { offset-distance: 0%; }
+  to { offset-distance: 100%; }
+}
+.agb-abeja-orbita {
+  offset-path: path('M0,0 a26,15 0 1,0 52,0 a26,15 0 1,0 -52,0');
+  offset-rotate: auto;
+  animation: agb-orbita 5.2s linear infinite;
+}
+@keyframes agb-aleteo { 0%, 100% { transform: scaleY(1); } 50% { transform: scaleY(0.35); } }
+.agb-aleteo { transform-box: fill-box; transform-origin: center bottom; animation: agb-aleteo 0.12s linear infinite; }
+
+@keyframes agb-oso-respira { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.03, 1.05); } }
+.agb-oso-cuerpo { transform-box: fill-box; transform-origin: center bottom; animation: agb-oso-respira 4.2s ease-in-out infinite; }
+
+@keyframes agb-repta { 0%, 100% { transform: translateX(0) scaleX(1); } 50% { transform: translateX(6px) scaleX(0.92); } }
+.agb-repta { transform-box: fill-box; transform-origin: center; animation: agb-repta 3.6s ease-in-out infinite; }
+
+@keyframes agb-aura {
+  0%, 100% { opacity: var(--agb-aura, 0.35); transform: scale(1); }
+  50% { opacity: calc(var(--agb-aura, 0.35) + 0.25); transform: scale(1.15); }
+}
+.agb-av-aura { transform-box: fill-box; transform-origin: center; animation: agb-aura 3.6s ease-in-out infinite; }
+
+@keyframes agb-corona-gira { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.agb-av-corona { transform-box: fill-box; transform-origin: center; animation: agb-corona-gira 14s linear infinite; }
+
+@keyframes agb-huevo { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.05, 1.08); } }
+.agb-huevo { transform-box: fill-box; transform-origin: center bottom; animation: agb-huevo 2.4s ease-in-out infinite; }
+
+/* transición al evolucionar / cambiar especie */
+.agb-av-pop { animation: agb-av-pop 0.9s cubic-bezier(0.2, 0.9, 0.3, 1.2); }
+@keyframes agb-av-pop {
+  0% { opacity: 0; transform: scale(0.3); }
+  60% { opacity: 1; transform: scale(1.15); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+/* ================================ UI: HUD ================================= */
+.agb-hud {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  pointer-events: none;
+  padding: max(14px, env(safe-area-inset-top)) 14px max(12px, env(safe-area-inset-bottom));
+}
+.agb-hud > * { pointer-events: auto; }
+
+.agb-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.agb-titulo { max-width: 200px; }
+.agb-eyebrow {
+  font-family: var(--agb-mono);
+  font-size: 9px;
+  letter-spacing: 2.4px;
+  color: var(--agb-savia);
+  opacity: 0.85;
+  margin: 0 0 4px;
+}
+.agb-h1 {
+  font-family: var(--agb-display);
+  font-weight: 800;
+  font-size: 24px;
+  line-height: 1.04;
+  margin: 0;
+  color: var(--agb-crema);
+  text-shadow: 0 0 18px rgba(45, 255, 196, 0.35);
+}
+.agb-sub {
+  margin: 6px 0 0;
+  font-size: 11.5px;
+  line-height: 1.35;
+  color: var(--agb-tinta);
+  max-width: 190px;
+}
+
+/* -------- panel del Espíritu (vitalidad + evolución) -------- */
+.agb-panel {
+  width: 156px;
+  border-radius: 16px;
+  border: 1px solid var(--agb-borde);
+  background: var(--agb-vidrio);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow: 0 6px 30px rgba(2, 4, 18, 0.6), inset 0 0 24px rgba(45, 255, 196, 0.05);
+  padding: 10px 12px 12px;
+}
+.agb-panel-cab {
+  font-family: var(--agb-mono);
+  font-size: 8px;
+  letter-spacing: 1.8px;
+  color: var(--agb-savia);
+  opacity: 0.85;
+  margin: 0 0 8px;
+}
+.agb-vital {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.agb-vital-num {
+  font-weight: 800;
+  font-size: 25px;
+  line-height: 1;
+  color: var(--agb-crema);
+  text-shadow: 0 0 14px rgba(45, 255, 196, 0.6);
+}
+.agb-vital-num small { font-size: 12px; opacity: 0.7; font-weight: 600; }
+.agb-vital-cap {
+  display: block;
+  font-family: var(--agb-mono);
+  font-size: 7.5px;
+  letter-spacing: 1px;
+  color: var(--agb-tinta);
+  margin-top: 3px;
+}
+.agb-ring-track { stroke: rgba(45, 255, 196, 0.14); }
+.agb-ring-val {
+  stroke: var(--agb-savia);
+  filter: drop-shadow(0 0 4px rgba(45, 255, 196, 0.8));
+  transition: stroke-dashoffset 1.1s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+.agb-ejes { margin: 10px 0 0; display: grid; gap: 6px; }
+.agb-eje {
+  display: grid;
+  grid-template-columns: 14px 1fr 24px;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+}
+.agb-eje-emoji { font-size: 10px; line-height: 1; }
+.agb-eje-riel {
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(45, 255, 196, 0.12);
+  overflow: hidden;
+}
+.agb-eje-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: linear-gradient(90deg, var(--agb-c1, var(--agb-savia)), var(--agb-c2, var(--agb-acido)));
+  box-shadow: 0 0 6px var(--agb-c1, var(--agb-savia));
+  transition: width 1.1s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+.agb-eje-val {
+  font-family: var(--agb-mono);
+  font-size: 8.5px;
+  color: var(--agb-tinta);
+  text-align: right;
+}
+
+.agb-etapa { margin-top: 10px; }
+.agb-etapa-nombre {
+  font-weight: 700;
+  font-size: 12px;
+  color: var(--agb-acido);
+  text-shadow: 0 0 10px rgba(157, 255, 63, 0.5);
+}
+.agb-etapa-track {
+  display: flex;
+  gap: 5px;
+  margin-top: 5px;
+  align-items: center;
+}
+.agb-etapa-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(45, 255, 196, 0.15);
+  border: 1px solid rgba(45, 255, 196, 0.3);
+  transition: all 0.5s ease;
+}
+.agb-etapa-dot.on {
+  background: var(--agb-savia);
+  box-shadow: 0 0 8px var(--agb-savia);
+  border-color: var(--agb-crema);
+}
+.agb-conteos {
+  margin-top: 9px;
+  padding-top: 8px;
+  border-top: 1px dashed rgba(45, 255, 196, 0.18);
+  font-family: var(--agb-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.4px;
+  color: var(--agb-tinta);
+  display: grid;
+  gap: 3px;
+}
+.agb-conteos b { color: var(--agb-crema); font-weight: 600; }
+
+/* ------------------------------ tarjeta de mundo ------------------------- */
+.agb-carta-zona {
+  margin-top: auto;
+  display: flex;
+  justify-content: center;
+  padding-bottom: 10px;
+}
+.agb-carta {
+  width: min(340px, 100%);
+  border-radius: 18px;
+  border: 1px solid var(--agb-borde);
+  background: var(--agb-vidrio);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 10px 40px rgba(2, 4, 18, 0.7), inset 0 0 30px rgba(45, 255, 196, 0.06);
+  padding: 12px 14px;
+  animation: agb-carta 0.45s cubic-bezier(0.2, 0.9, 0.3, 1.15);
+}
+@keyframes agb-carta {
+  from { opacity: 0; transform: translateY(16px) scale(0.94); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.agb-carta-cab {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.agb-carta-glifo {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 20px;
+  background: radial-gradient(circle at 40% 35%, rgba(45, 255, 196, 0.25), rgba(45, 255, 196, 0.04));
+  border: 1px solid var(--agb-borde);
+  box-shadow: 0 0 14px rgba(45, 255, 196, 0.25);
+}
+.agb-carta-titulo {
+  font-weight: 800;
+  font-size: 16px;
+  margin: 0;
+  color: var(--agb-crema);
+}
+.agb-carta-rama {
+  font-family: var(--agb-mono);
+  font-size: 8px;
+  letter-spacing: 1.6px;
+  color: var(--agb-savia);
+  margin: 0 0 2px;
+}
+.agb-carta-x {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--agb-tinta);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 4px 6px;
+  line-height: 1;
+  font-family: inherit;
+}
+.agb-carta-x:hover { color: var(--agb-crema); }
+.agb-carta-desc {
+  margin: 8px 0 0;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: #a9c3d2;
+}
+.agb-carta-stats {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+  font-family: var(--agb-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.5px;
+  color: var(--agb-tinta);
+}
+.agb-carta-stats b { color: var(--agb-acido); font-weight: 600; }
+.agb-carta-entrar {
+  margin-top: 10px;
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--agb-savia);
+  background: linear-gradient(180deg, rgba(45, 255, 196, 0.22), rgba(45, 255, 196, 0.08));
+  color: var(--agb-crema);
+  font-family: var(--agb-display);
+  font-weight: 700;
+  font-size: 13px;
+  padding: 9px 12px;
+  cursor: pointer;
+  box-shadow: 0 0 18px rgba(45, 255, 196, 0.25);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.agb-carta-entrar:hover { transform: translateY(-1px); box-shadow: 0 0 26px rgba(45, 255, 196, 0.4); }
+.agb-carta-entrar:active { transform: translateY(0); }
+
+/* nota flotante (mockup honesto) */
+.agb-nota {
+  position: absolute;
+  left: 50%;
+  bottom: 190px;
+  transform: translateX(-50%);
+  background: var(--agb-vidrio);
+  border: 1px solid var(--agb-borde);
+  border-radius: 999px;
+  padding: 7px 14px;
+  font-family: var(--agb-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.6px;
+  color: var(--agb-savia);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  animation: agb-carta 0.35s ease;
+  white-space: nowrap;
+}
+
+/* ------------------------------- dock inferior --------------------------- */
+.agb-dock {
+  border-radius: 20px;
+  border: 1px solid var(--agb-borde);
+  background: var(--agb-vidrio);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow: 0 -6px 40px rgba(2, 4, 18, 0.6), inset 0 0 34px rgba(45, 255, 196, 0.05);
+  padding: 10px 12px 11px;
+}
+.agb-dock-cab {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: var(--agb-mono);
+  font-size: 8px;
+  letter-spacing: 1.8px;
+  color: var(--agb-savia);
+  opacity: 0.9;
+  margin-bottom: 7px;
+}
+.agb-dock-cab span:last-child { color: var(--agb-tinta); letter-spacing: 0.6px; }
+
+.agb-chips {
+  display: flex;
+  gap: 7px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  padding-bottom: 2px;
+}
+.agb-chips::-webkit-scrollbar { display: none; }
+.agb-chip {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(45, 255, 196, 0.2);
+  background: rgba(13, 30, 68, 0.5);
+  color: #a9c3d2;
+  font-family: var(--agb-display);
+  font-weight: 600;
+  font-size: 11px;
+  padding: 6px 11px 6px 7px;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+.agb-chip-glifo {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  background: radial-gradient(circle at 40% 35%, rgba(45, 255, 196, 0.22), rgba(45, 255, 196, 0.02));
+}
+.agb-chip.on {
+  border-color: var(--agb-savia);
+  color: var(--agb-crema);
+  background: linear-gradient(180deg, rgba(45, 255, 196, 0.2), rgba(45, 255, 196, 0.05));
+  box-shadow: 0 0 16px rgba(45, 255, 196, 0.35);
+}
+.agb-chip:focus-visible { outline: 2px solid var(--agb-crema); outline-offset: 2px; }
+
+/* --------- el reloj del frailejón (scrubber de años) — firma ------------- */
+.agb-reloj { margin-top: 10px; }
+.agb-reloj-fila {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.agb-play {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--agb-savia);
+  background: radial-gradient(circle at 38% 32%, rgba(45, 255, 196, 0.3), rgba(45, 255, 196, 0.06));
+  color: var(--agb-crema);
+  font-size: 13px;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 0 14px rgba(45, 255, 196, 0.3);
+  transition: transform 0.15s ease;
+}
+.agb-play:hover { transform: scale(1.08); }
+.agb-play:focus-visible { outline: 2px solid var(--agb-crema); outline-offset: 2px; }
+
+.agb-anillos {
+  position: relative;
+  flex: 1;
+  height: 34px;
+  display: flex;
+  align-items: center;
+}
+.agb-range {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 34px;
+  margin: 0;
+  background: transparent;
+  cursor: pointer;
+  position: relative;
+  z-index: 2;
+}
+.agb-range::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, rgba(45, 255, 196, 0.55), rgba(157, 255, 63, 0.55), rgba(255, 79, 216, 0.5));
+  box-shadow: 0 0 8px rgba(45, 255, 196, 0.35);
+}
+.agb-range::-moz-range-track {
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, rgba(45, 255, 196, 0.55), rgba(157, 255, 63, 0.55), rgba(255, 79, 216, 0.5));
+}
+.agb-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  margin-top: -8px;
+  border-radius: 50%;
+  border: 2px solid var(--agb-crema);
+  background:
+    radial-gradient(circle at 50% 50%, var(--agb-crema) 0 22%, transparent 24%),
+    radial-gradient(circle at 50% 50%, transparent 0 38%, rgba(234, 255, 246, 0.85) 40% 46%, transparent 48%),
+    radial-gradient(circle, var(--agb-savia), #0a9f74);
+  box-shadow: 0 0 14px var(--agb-savia);
+}
+.agb-range::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid var(--agb-crema);
+  background: radial-gradient(circle, var(--agb-savia), #0a9f74);
+  box-shadow: 0 0 14px var(--agb-savia);
+}
+.agb-range:focus-visible { outline: 2px solid var(--agb-crema); outline-offset: 4px; border-radius: 8px; }
+
+/* anillos del frailejón: un tic-anillo por año bajo el riel */
+.agb-tics {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  top: 50%;
+  height: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+.agb-tic {
+  position: absolute;
+  top: -5px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(45, 255, 196, 0.35);
+  transform: translateX(-50%);
+  transition: all 0.4s ease;
+}
+.agb-tic.on {
+  border-color: var(--agb-savia);
+  box-shadow: 0 0 8px rgba(45, 255, 196, 0.7), inset 0 0 4px rgba(45, 255, 196, 0.8);
+}
+.agb-reloj-pie {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 5px;
+  font-family: var(--agb-mono);
+  font-size: 8.5px;
+  letter-spacing: 1px;
+  color: var(--agb-tinta);
+}
+.agb-reloj-anio {
+  color: var(--agb-crema);
+  font-family: var(--agb-display);
+  font-weight: 800;
+  font-size: 13px;
+  letter-spacing: 0.4px;
+  text-shadow: 0 0 12px rgba(45, 255, 196, 0.5);
+}
+.agb-reloj-cap { transition: color 0.4s ease; }
+.agb-reloj-cap.futuro { color: var(--agb-magenta); text-shadow: 0 0 10px rgba(255, 79, 216, 0.4); }
+
+/* pie mockup */
+.agb-sello {
+  position: absolute;
+  right: 12px;
+  bottom: 3px;
+  font-family: var(--agb-mono);
+  font-size: 7px;
+  letter-spacing: 1.6px;
+  color: rgba(91, 127, 147, 0.6);
+  pointer-events: none;
+}
+
+/* botón volver */
+.agb-volver {
+  position: absolute;
+  top: max(12px, env(safe-area-inset-top));
+  right: 12px;
+  z-index: 5;
+  border: 1px solid rgba(45, 255, 196, 0.3);
+  background: var(--agb-vidrio);
+  color: var(--agb-tinta);
+  border-radius: 999px;
+  font-family: var(--agb-mono);
+  font-size: 9px;
+  letter-spacing: 1px;
+  padding: 6px 12px;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.agb-volver:hover { color: var(--agb-crema); border-color: var(--agb-savia); }
+
+/* ============================ DESKTOP ≥900px ============================== */
+@media (min-width: 900px) {
+  .agb-hud { padding: 26px 34px; }
+  .agb-titulo { max-width: 330px; }
+  .agb-h1 { font-size: 40px; }
+  .agb-sub { font-size: 13.5px; max-width: 300px; }
+  .agb-panel { width: 196px; padding: 14px 16px 16px; }
+  .agb-vital-num { font-size: 31px; }
+  .agb-dock { max-width: 620px; margin: 0 auto; width: 100%; }
+  .agb-carta { width: 400px; }
+}
+
+/* ======================= REDUCED MOTION: digno y quieto =================== */
+@media (prefers-reduced-motion: reduce) {
+  .agb *,
+  .agb *::before,
+  .agb *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+  .agb-enter,
+  .agb-rise { opacity: 1; transform: none; }
+  .agb-g { opacity: 0; }
+  .agb-g.on { opacity: 1; transform: scale(1); }
+  .agb-spark { display: none; }
+}

--- a/src/mockups/avatar-game-biopunk.css
+++ b/src/mockups/avatar-game-biopunk.css
@@ -31,10 +31,17 @@
   --agb-borde: rgba(45, 255, 196, 0.28);
   --agb-display: 'Baloo 2', 'Nunito', system-ui, sans-serif;
   --agb-mono: ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  /* acento vivo del guardián escogido (lo inyecta React por especie):
+     el HUD entero respira del mismo color que el espíritu */
+  --agb-acc: var(--agb-savia);
+  --agb-acc-rgb: 45, 255, 196;
+  --agb-acc2: var(--agb-magenta);
 
   position: fixed;
   inset: 0;
-  z-index: 60;
+  /* por encima de los FAB del app shell (colibrí/agente): el mockup es
+     full-screen y nada de la app debe flotarle encima */
+  z-index: 1200;
   overflow: hidden;
   background:
     radial-gradient(120% 60% at 50% -10%, #0d1e44 0%, transparent 60%),
@@ -61,6 +68,9 @@
     width: auto;
     max-width: none;
     filter: drop-shadow(0 0 60px rgba(45, 255, 196, 0.08));
+    /* funde los bordes del escenario con la noche: sin filo duro */
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 9%, #000 91%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 9%, #000 91%, transparent);
   }
 }
 
@@ -106,6 +116,27 @@
 @keyframes agb-fog { from { transform: translateX(-24px); } to { transform: translateX(26px); } }
 .agb-fog { animation: agb-fog 16s ease-in-out infinite alternate; }
 .agb-fog.agb-g2 { animation-delay: -6s; animation-duration: 20s; }
+
+/* --------- constelación del guardián: se dibuja al escoger especie -------- */
+@keyframes agb-constel-draw { from { stroke-dashoffset: 1; } to { stroke-dashoffset: 0; } }
+.agb-constel-linea {
+  stroke-dasharray: 1;
+  animation: agb-constel-draw 1.5s cubic-bezier(0.3, 0.6, 0.3, 1) backwards;
+}
+@keyframes agb-constel-pop {
+  from { opacity: 0; transform: scale(0); }
+  60% { opacity: 1; transform: scale(1.8); }
+  to { opacity: 1; transform: scale(1); }
+}
+.agb-constel-estrella {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation:
+    agb-constel-pop 0.5s cubic-bezier(0.2, 0.9, 0.3, 1.4) backwards,
+    agb-tw 4.6s ease-in-out 1.4s infinite;
+}
+@keyframes agb-constel-label { from { opacity: 0; } to { opacity: 0.55; } }
+.agb-constel-label { animation: agb-constel-label 1s ease 1.2s backwards; }
 
 @keyframes agb-fly {
   0%, 100% { transform: translate(0, 0); opacity: 0.4; }
@@ -176,6 +207,38 @@
 }
 .agb-heart { transform-box: fill-box; transform-origin: center; animation: agb-heart 2.4s ease-in-out infinite; }
 
+/* el corazón es tocable: invita con un latido más presente al pasar el dedo */
+.agb-heart-hit { cursor: pointer; }
+.agb-heart-hit:hover .agb-heart,
+.agb-heart-hit:focus-visible .agb-heart { animation-duration: 1.2s; }
+.agb-heart-hit:focus-visible { outline: none; }
+
+/* pulso de vida: onda triple que recorre la finca desde el corazón */
+@keyframes agb-pulso-onda {
+  0% { transform: scale(0.3); opacity: 0.95; }
+  100% { transform: scale(9); opacity: 0; }
+}
+.agb-pulso-onda {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agb-pulso-onda 1.5s cubic-bezier(0.15, 0.6, 0.4, 1) forwards;
+}
+.agb-pulso-onda.agb-po2 { animation-delay: 0.14s; }
+.agb-pulso-onda.agb-po3 { animation-delay: 0.3s; }
+
+/* mientras el pulso viaja, TODO el organismo se acelera: la savia corre,
+   las chispas vuelan y el espíritu brinca (van después de sus reglas base
+   para ganar la cascada) */
+.agb-pulsando .agb-sap { animation-duration: 0.9s; }
+.agb-pulsando .agb-spark { animation-duration: 1.6s; }
+.agb-pulsando .agb-vinculo-spark { animation-duration: 1.1s; }
+@keyframes agb-salto {
+  0%, 100% { transform: translateY(0); }
+  35% { transform: translateY(-11px); }
+  65% { transform: translateY(2px); }
+}
+.agb-pulsando .agb-avatar { animation: agb-salto 0.85s cubic-bezier(0.3, 1.4, 0.4, 1) 0.35s; }
+
 @keyframes agb-hwave {
   0% { transform: scale(0.35); opacity: 0.85; }
   100% { transform: scale(2.1); opacity: 0; }
@@ -204,8 +267,21 @@
 .agb-spark.agb-p4 { offset-path: path('M195,556 C150,586 104,606 60,610'); animation-delay: 0.8s; animation-duration: 6s; }
 .agb-spark.agb-p5 { offset-path: path('M195,556 C244,584 292,600 336,602'); animation-delay: 3.4s; animation-duration: 6s; }
 
+/* --- vínculo corazón→espíritu: el filamento de savia que lo alimenta ------ */
+.agb-vinculo {
+  stroke-dasharray: 2.5 9;
+  animation: agb-sap 3s linear infinite;
+}
+.agb-vinculo-spark {
+  offset-rotate: 0deg;
+  animation: agb-travel 3.4s linear infinite;
+}
+
 /* ============================== EL AVATAR ================================= */
-.agb-avatar { transform-box: view-box; }
+.agb-avatar { transform-box: view-box; cursor: pointer; }
+.agb-avatar:focus-visible { outline: none; }
+.agb-avatar:hover .agb-av-aura,
+.agb-avatar:focus-visible .agb-av-aura { animation-duration: 1.6s; }
 @keyframes agb-hover {
   0%, 100% { transform: translate(0, 0); }
   30% { transform: translate(4px, -6px); }
@@ -263,6 +339,31 @@
   100% { opacity: 1; transform: scale(1); }
 }
 
+/* --- el momento de evolución: ondas, rayos que giran y anuncio ------------ */
+@keyframes agb-evo-onda {
+  0% { transform: scale(0.4); opacity: 1; }
+  100% { transform: scale(4.4); opacity: 0; }
+}
+.agb-evo-onda {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agb-evo-onda 1.4s cubic-bezier(0.15, 0.6, 0.4, 1) forwards;
+}
+.agb-evo-onda.agb-eo2 { animation-delay: 0.18s; }
+@keyframes agb-evo-rayos {
+  0% { opacity: 0; transform: rotate(0deg) scale(0.5); }
+  25% { opacity: 1; }
+  100% { opacity: 0; transform: rotate(80deg) scale(1.5); }
+}
+.agb-evo-rayos { animation: agb-evo-rayos 1.9s ease-out forwards; }
+@keyframes agb-evo-texto {
+  0% { opacity: 0; transform: translateY(8px); }
+  18% { opacity: 1; transform: translateY(0); }
+  78% { opacity: 1; }
+  100% { opacity: 0; transform: translateY(-6px); }
+}
+.agb-evo-texto { animation: agb-evo-texto 2s ease forwards; }
+
 /* ================================ UI: HUD ================================= */
 .agb-hud {
   position: absolute;
@@ -283,6 +384,9 @@
 
 .agb-titulo { max-width: 200px; }
 .agb-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-family: var(--agb-mono);
   font-size: 9px;
   letter-spacing: 2.4px;
@@ -290,14 +394,28 @@
   opacity: 0.85;
   margin: 0 0 4px;
 }
+/* punto de vida antes del eyebrow: late con el acento del guardián */
+@keyframes agb-latido-dot { 0%, 100% { opacity: 0.5; transform: scale(1); } 50% { opacity: 1; transform: scale(1.35); } }
+.agb-eyebrow::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--agb-acc);
+  box-shadow: 0 0 7px var(--agb-acc);
+  animation: agb-latido-dot 2.4s ease-in-out infinite;
+}
 .agb-h1 {
   font-family: var(--agb-display);
   font-weight: 800;
   font-size: 24px;
   line-height: 1.04;
   margin: 0;
-  color: var(--agb-crema);
-  text-shadow: 0 0 18px rgba(45, 255, 196, 0.35);
+  background: linear-gradient(115deg, var(--agb-crema) 40%, var(--agb-acc) 85%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  filter: drop-shadow(0 0 16px rgba(var(--agb-acc-rgb), 0.35));
 }
 .agb-sub {
   margin: 6px 0 0;
@@ -309,6 +427,10 @@
 
 /* -------- panel del Espíritu (vitalidad + evolución) -------- */
 .agb-panel {
+  position: relative;
+  overflow: hidden;
+  /* deja aire para el botón SALIR que flota arriba a la derecha */
+  margin-top: 30px;
   width: 156px;
   border-radius: 16px;
   border: 1px solid var(--agb-borde);
@@ -317,6 +439,19 @@
   -webkit-backdrop-filter: blur(10px);
   box-shadow: 0 6px 30px rgba(2, 4, 18, 0.6), inset 0 0 24px rgba(45, 255, 196, 0.05);
   padding: 10px 12px 12px;
+}
+/* filo superior con el acento del guardián: el panel es SU lectura de vida */
+.agb-panel::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 12px;
+  right: 12px;
+  height: 1.5px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, transparent, var(--agb-acc), transparent);
+  opacity: 0.8;
+  transition: background 0.5s ease;
 }
 .agb-panel-cab {
   font-family: var(--agb-mono);
@@ -336,7 +471,8 @@
   font-size: 25px;
   line-height: 1;
   color: var(--agb-crema);
-  text-shadow: 0 0 14px rgba(45, 255, 196, 0.6);
+  text-shadow: 0 0 14px rgba(var(--agb-acc-rgb), 0.6);
+  transition: text-shadow 0.5s ease;
 }
 .agb-vital-num small { font-size: 12px; opacity: 0.7; font-weight: 600; }
 .agb-vital-cap {
@@ -347,11 +483,11 @@
   color: var(--agb-tinta);
   margin-top: 3px;
 }
-.agb-ring-track { stroke: rgba(45, 255, 196, 0.14); }
+.agb-ring-track { stroke: rgba(var(--agb-acc-rgb), 0.14); }
 .agb-ring-val {
-  stroke: var(--agb-savia);
-  filter: drop-shadow(0 0 4px rgba(45, 255, 196, 0.8));
-  transition: stroke-dashoffset 1.1s cubic-bezier(0.2, 0.8, 0.3, 1);
+  stroke: var(--agb-acc);
+  filter: drop-shadow(0 0 4px rgba(var(--agb-acc-rgb), 0.8));
+  transition: stroke-dashoffset 1.1s cubic-bezier(0.2, 0.8, 0.3, 1), stroke 0.5s ease;
 }
 
 .agb-ejes { margin: 10px 0 0; display: grid; gap: 6px; }
@@ -519,24 +655,40 @@
 .agb-carta-entrar:hover { transform: translateY(-1px); box-shadow: 0 0 26px rgba(45, 255, 196, 0.4); }
 .agb-carta-entrar:active { transform: translateY(0); }
 
-/* nota flotante (mockup honesto) */
+/* velo de foco: al abrir un mundo el resto de la finca se apaga un poco */
+.agb-velo {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background: radial-gradient(90% 70% at 50% 46%, transparent 30%, rgba(2, 4, 18, 0.55) 100%);
+  opacity: 0;
+  transition: opacity 0.45s ease;
+}
+.agb-velo.on { opacity: 1; }
+
+/* nota flotante: la voz del organismo (habla con el acento del guardián) */
 .agb-nota {
   position: absolute;
   left: 50%;
   bottom: 190px;
   transform: translateX(-50%);
+  max-width: min(92vw, 480px);
   background: var(--agb-vidrio);
-  border: 1px solid var(--agb-borde);
+  border: 1px solid rgba(var(--agb-acc-rgb), 0.45);
   border-radius: 999px;
   padding: 7px 14px;
   font-family: var(--agb-mono);
   font-size: 9.5px;
   letter-spacing: 0.6px;
-  color: var(--agb-savia);
+  color: var(--agb-acc);
+  box-shadow: 0 0 20px rgba(var(--agb-acc-rgb), 0.18);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   animation: agb-carta 0.35s ease;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* ------------------------------- dock inferior --------------------------- */
@@ -561,6 +713,7 @@
   margin-bottom: 7px;
 }
 .agb-dock-cab span:last-child { color: var(--agb-tinta); letter-spacing: 0.6px; }
+.agb-dock-cientifico { font-style: italic; transition: color 0.4s ease; }
 
 .agb-chips {
   display: flex;
@@ -595,11 +748,15 @@
   font-size: 12px;
   background: radial-gradient(circle at 40% 35%, rgba(45, 255, 196, 0.22), rgba(45, 255, 196, 0.02));
 }
+.agb-chip:hover { border-color: rgba(45, 255, 196, 0.45); color: var(--agb-crema); }
 .agb-chip.on {
-  border-color: var(--agb-savia);
+  border-color: var(--agb-acc);
   color: var(--agb-crema);
-  background: linear-gradient(180deg, rgba(45, 255, 196, 0.2), rgba(45, 255, 196, 0.05));
-  box-shadow: 0 0 16px rgba(45, 255, 196, 0.35);
+  background: linear-gradient(180deg, rgba(var(--agb-acc-rgb), 0.22), rgba(var(--agb-acc-rgb), 0.05));
+  box-shadow: 0 0 16px rgba(var(--agb-acc-rgb), 0.35);
+}
+.agb-chip.on .agb-chip-glifo {
+  background: radial-gradient(circle at 40% 35%, rgba(var(--agb-acc-rgb), 0.35), rgba(var(--agb-acc-rgb), 0.04));
 }
 .agb-chip:focus-visible { outline: 2px solid var(--agb-crema); outline-offset: 2px; }
 
@@ -615,17 +772,20 @@
   width: 34px;
   height: 34px;
   border-radius: 50%;
-  border: 1px solid var(--agb-savia);
-  background: radial-gradient(circle at 38% 32%, rgba(45, 255, 196, 0.3), rgba(45, 255, 196, 0.06));
+  border: 1px solid var(--agb-acc);
+  background: radial-gradient(circle at 38% 32%, rgba(var(--agb-acc-rgb), 0.3), rgba(var(--agb-acc-rgb), 0.06));
   color: var(--agb-crema);
   font-size: 13px;
   cursor: pointer;
   display: grid;
   place-items: center;
-  box-shadow: 0 0 14px rgba(45, 255, 196, 0.3);
-  transition: transform 0.15s ease;
+  box-shadow: 0 0 14px rgba(var(--agb-acc-rgb), 0.3);
+  transition: transform 0.15s ease, box-shadow 0.3s ease;
 }
 .agb-play:hover { transform: scale(1.08); }
+/* reproduciendo: el botón respira al ritmo del crecimiento */
+@keyframes agb-play-latido { 0%, 100% { box-shadow: 0 0 10px rgba(var(--agb-acc-rgb), 0.25); } 50% { box-shadow: 0 0 22px rgba(var(--agb-acc-rgb), 0.6); } }
+.agb-play-on { font-size: 10px; animation: agb-play-latido 1.05s ease-in-out infinite; }
 .agb-play:focus-visible { outline: 2px solid var(--agb-crema); outline-offset: 2px; }
 
 .agb-anillos {
@@ -668,16 +828,16 @@
   background:
     radial-gradient(circle at 50% 50%, var(--agb-crema) 0 22%, transparent 24%),
     radial-gradient(circle at 50% 50%, transparent 0 38%, rgba(234, 255, 246, 0.85) 40% 46%, transparent 48%),
-    radial-gradient(circle, var(--agb-savia), #0a9f74);
-  box-shadow: 0 0 14px var(--agb-savia);
+    radial-gradient(circle, var(--agb-acc), #0a9f74);
+  box-shadow: 0 0 14px var(--agb-acc);
 }
 .agb-range::-moz-range-thumb {
   width: 18px;
   height: 18px;
   border-radius: 50%;
   border: 2px solid var(--agb-crema);
-  background: radial-gradient(circle, var(--agb-savia), #0a9f74);
-  box-shadow: 0 0 14px var(--agb-savia);
+  background: radial-gradient(circle, var(--agb-acc), #0a9f74);
+  box-shadow: 0 0 14px var(--agb-acc);
 }
 .agb-range:focus-visible { outline: 2px solid var(--agb-crema); outline-offset: 4px; border-radius: 8px; }
 
@@ -721,8 +881,16 @@
   font-weight: 800;
   font-size: 13px;
   letter-spacing: 0.4px;
-  text-shadow: 0 0 12px rgba(45, 255, 196, 0.5);
+  text-shadow: 0 0 12px rgba(var(--agb-acc-rgb), 0.5);
+  min-width: 34px;
+  text-align: right;
 }
+/* el año hace "tic" al cambiar (se re-monta por key) */
+@keyframes agb-anio-pop {
+  0% { transform: scale(1.35); color: var(--agb-acc); }
+  100% { transform: scale(1); color: var(--agb-crema); }
+}
+.agb-anio-pop { display: inline-block; animation: agb-anio-pop 0.5s cubic-bezier(0.2, 0.8, 0.3, 1); }
 .agb-reloj-cap { transition: color 0.4s ease; }
 .agb-reloj-cap.futuro { color: var(--agb-magenta); text-shadow: 0 0 10px rgba(255, 79, 216, 0.4); }
 
@@ -782,5 +950,12 @@
   .agb-rise { opacity: 1; transform: none; }
   .agb-g { opacity: 0; }
   .agb-g.on { opacity: 1; transform: scale(1); }
-  .agb-spark { display: none; }
+  .agb-spark,
+  .agb-vinculo-spark,
+  .agb-pulso-onda,
+  .agb-evo-onda,
+  .agb-evo-rayos { display: none; }
+  /* la constelación queda dibujada y quieta (sus keyframes van de oculto a
+     visible: sin animación, el estado base ya es el final) */
+  .agb-constel-linea { stroke-dashoffset: 0; }
 }


### PR DESCRIPTION
## Qué es

2ª pasada del mockup del juego de avatar de Chagra en dirección **biopunk** ("El Espíritu de tu Finca"). El operador vio la 1ª versión y pidió empujar ESTA dirección más lejos: más craft, interacciones más pulidas, coherencia biopunk más fuerte, momentos de deleite.

- Ruta dev: `#/mockups/avatar-biopunk` (sin gate, datos de muestra)
- Archivos: `src/mockups/AvatarGameBiopunk.jsx` + `src/mockups/avatar-game-biopunk.css` (+ cableado en `App.jsx`)
- Byte-neutral: cero fotos nuevas, todo SVG/CSS · GPU-friendly (transform/opacity/offset-path) · `prefers-reduced-motion` completo

## Qué se refinó vs la 1ª versión

1. **Acento vivo por guardián** — escoger especie re-tiñe TODO el HUD (anillo de vitalidad, chips, botón play, thumb del reloj, notas, degradado del H1, filo del panel) con el color de esa criatura: rana=oro, oso=violeta, lombriz=rosa, abeja=ámbar, chivito=savia. El mockup pasa de "escena bonita" a **sistema de producto**.
2. **Pulso de vida** — el corazón de la finca ahora es tocable: onda triple expansiva, la savia de TODO el organismo se acelera y el espíritu brinca.
3. **Constelación del guardián** — la especie escogida se dibuja en el cielo con trazo animado + estrellas que brotan (una forma por especie).
4. **Vínculo corazón→espíritu** — filamento de savia con chispa viajera entre el corazón y el avatar: se LEE que el espíritu vive de la finca.
5. **Momento de evolución** — al subir de etapa: ondas + rayos giratorios + "✦ EVOLUCIONÓ ✦". Etapas sin duplicado (nuevo: "Brote andante").
6. **Espíritu tocable** — responde cómo se siente según la vitalidad real (4 niveles de frase).
7. **Reloj del frailejón** — play/pausa real (late mientras corre la cinematográfica), año con tic animado.
8. **Craft general** — velo de foco al abrir un mundo, bordes del escenario fundidos en desktop (mask), panel ya no choca con SALIR, FAB del colibrí excluido de la vista full-screen, eyebrow con punto que late.

## Verificación

- Headless Playwright (chromium nix-store) contra vite dev: cinematográfica llega a año 5, cambio de especie re-tiñe HUD, pulso/espíritu/mundo responden. Capturas móvil 390×844 y desktop 1440×900 enviadas al operador.
- `eslint` 0 errores · `tsc-check-gate` OK (1829 = baseline) · `check-perf-budget` 25.2/25.5 MB · tests de rutas de App verdes.

## Estado

- [x] Base: 1ª versión rebasada sobre main actual + ruta cableada
- [x] Refinamiento 2ª pasada
- [x] Capturas

🤖 Generated with [Claude Code](https://claude.com/claude-code)