### PR TITLE
fix(perfil)+feat(onboarding): foto de perfil sube a farmOS + onboarding refinado (tarea #16)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2358,8 +2358,11 @@ export default function App() {
       {/* AgentFab (colibrí flotante "respuesta lista") en TODAS las pantallas
           MENOS el home/dashboard (operador 2026-06-06): en el home el colibrí
           ya es el botón de ENVIAR del compositor, así que el FAB flotante ahí
-          duplicaría el ave. Sigue en el resto para anunciar "respuesta lista". */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && <AgentFab onNavigate={navigate} />}
+          duplicaría el ave. Sigue en el resto para anunciar "respuesta lista".
+          Tampoco en onboarding-perfil (tarea #16): el FAB se encimaba sobre el
+          CTA "Explorar con finca de ejemplo" del footer y la usuaria nueva aún
+          no conoce al agente — ruido en su primer flujo. */}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && <AgentFab onNavigate={navigate} />}
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o
           pregunta al agente punta a punta por voz.

--- a/src/components/OnboardingProfile.jsx
+++ b/src/components/OnboardingProfile.jsx
@@ -44,6 +44,81 @@ import { PISO_TERMICO_INFO } from '../services/locationService';
  *                          entrar al home ya poblado (demo público). Si no se
  *                          pasa, el botón no se muestra.
  */
+/**
+ * Ancla VISUAL por pregunta (refinamiento tarea #16, baja alfabetización):
+ * cada pregunta abre con un emoji grande + una "miga" de categoría en palabras
+ * llanas. La usuaria sabe DE QUÉ le están preguntando antes de leer una letra.
+ * Solo presentación: no toca PROFILE_QUESTIONS ni lo que se guarda.
+ */
+const CATEGORY_META = {
+  identidad: { label: 'Sobre usted', emoji: '👋' },
+  finca: { label: 'Su tierra', emoji: '🏡' },
+  experiencia: { label: 'Su experiencia', emoji: '🌱' },
+  objetivos: { label: 'Sus metas', emoji: '🎯' },
+  preferencias: { label: 'A su gusto', emoji: '💬' },
+};
+
+const QUESTION_EMOJI = {
+  nombre: '👋',
+  region: '🗺️',
+  vocacion: '🧑‍🌾',
+  rol: '🌾',
+  finca_tipo: '🏡',
+  finca_hectareas: '📏',
+  finca_altitud: '🏔️',
+  invernadero_tiene: '🏠',
+  invernadero_forma: '📐',
+  invernadero_tamano: '📏',
+  composicion: '🌽',
+  cultivos_actuales: '🌱',
+  animales: '🐄',
+  gallinas_manejo: '🐔',
+  restauracion_objetivo: '🌳',
+  anios_cultivando: '🗓️',
+  manejo: '🍃',
+  problemas: '🐛',
+  objetivo: '🎯',
+  cultivos_interes: '✨',
+  nivel_respuestas: '💬',
+  notif_clima: '🌦️',
+  estrato: '🏙️',
+  espacio_urbano: '🪟',
+  riego: '💧',
+};
+
+/**
+ * Emoji por OPCIÓN para las preguntas cuyos labels no lo traen ya (varias del
+ * catálogo sí: rol, composición, animales...). Ícono legible junto a cada
+ * botón = escoger sin leer. Solo presentación.
+ */
+const OPTION_EMOJI = {
+  vocacion: { campesino: '🧑‍🌾', urbano: '🏙️', tecnico: '🔬', curioso: '🌱' },
+  finca_tipo: { rural: '⛰️', balcon: '🪟', terraza: '🏠', invernadero: '🏕️' },
+  finca_hectareas: { menos_1: '🌱', '1_5': '🌿', '5_20': '🌳', mas_20: '🌲' },
+  gallinas_manejo: { libres: '🌾', galpon: '🏠', corral: '🚧', mixto: '🔄' },
+  anios_cultivando: { apenas: '🌱', menos_5: '🌿', '5_15': '🌳', toda_vida: '🌲' },
+  manejo: { organico: '🍃', convencional: '🧪', mixto: '⚖️', transicion: '🔄' },
+  problemas: { plagas: '🐛', enfermedades: '🍂', clima: '🌦️', suelo: '🪨', malezas: '🌿', mercado: '🧺' },
+  objetivo: { producir_mas: '🧺', reducir_quimicos: '🍃', aprender: '📖', registrar: '📝', biodiversidad: '🦋', vender: '🤝' },
+  nivel_respuestas: { simple: '💬', detallado: '📖', maestro: '🎓' },
+  notif_clima: { si: '🔔', no: '🔕' },
+  estrato: { '1_2': '🏘️', '3_4': '🏙️', '5_6': '🌆' },
+  espacio_urbano: { materas: '🪴', balcon_lleno: '🪟', terraza_grande: '🏠' },
+  riego: { lluvia: '🌧️', manguera: '🚿', goteo: '💧', acequia: '⛲' },
+};
+
+/**
+ * Ejemplos TOCABLES para las preguntas de texto ("mucho ejemplo, poco
+ * texto"): un toque llena el campo — la usuaria no tiene que redactar. En las
+ * preguntas de lista (cultivos) los toques se van sumando con coma.
+ */
+const EXAMPLE_CHIPS = {
+  region: { values: ['Choachí', 'Fómeque', 'Cauca', 'Boyacá'], append: false },
+  cultivos_actuales: { values: ['Café', 'Plátano', 'Tomate', 'Mora', 'Maíz'], append: true },
+  cultivos_interes: { values: ['Aguacate', 'Cacao', 'Uchuva', 'Hortalizas'], append: true },
+  invernadero_tamano: { values: ['6 x 10 metros', 'Uno pequeño', 'Media hectárea'], append: false },
+};
+
 export default function OnboardingProfile({ onComplete, onClose = undefined, onExplorarEjemplo = undefined }) {
   const [answers, setAnswers] = useState(() => getProfile());
   const [index, setIndex] = useState(0);
@@ -129,6 +204,9 @@ export default function OnboardingProfile({ onComplete, onClose = undefined, onE
             </h1>
             <p className="text-xs text-slate-400">
               Pregunta {Math.min(index + 1, total)} de {total}
+              {progress >= 75 && (
+                <span className="text-amber-300 font-medium"> · ¡Ya casi termina!</span>
+              )}
             </p>
           </div>
           <button
@@ -140,16 +218,17 @@ export default function OnboardingProfile({ onComplete, onClose = undefined, onE
           </button>
         </div>
 
-        {/* Progress bar */}
+        {/* Progress bar — más gruesa y con gradiente cálido: el avance se VE
+            sin leer el contador (baja alfabetización). */}
         <div
-          className="h-1.5 w-full rounded-full bg-slate-800 overflow-hidden"
+          className="h-2 w-full rounded-full bg-slate-800 overflow-hidden"
           role="progressbar"
           aria-valuenow={progress}
           aria-valuemin={0}
           aria-valuemax={100}
         >
           <div
-            className="h-full bg-emerald-500 transition-all duration-300"
+            className="h-full rounded-full bg-gradient-to-r from-emerald-600 via-emerald-500 to-lime-400 transition-all duration-500 ease-out"
             style={{ width: `${progress}%` }}
           />
         </div>
@@ -191,7 +270,7 @@ export default function OnboardingProfile({ onComplete, onClose = undefined, onE
           <button
             type="button"
             onClick={goBack}
-            className="inline-flex items-center gap-1 px-3 py-2.5 rounded-xl text-slate-400 hover:text-white transition-colors"
+            className="inline-flex items-center gap-1 px-3 py-3 min-h-[48px] rounded-xl text-slate-400 hover:text-white transition-colors"
           >
             <ChevronLeft size={18} /> Atrás
           </button>
@@ -199,7 +278,7 @@ export default function OnboardingProfile({ onComplete, onClose = undefined, onE
           <button
             type="button"
             onClick={skipQuestion}
-            className="text-xs text-slate-500 hover:text-slate-300 underline underline-offset-2"
+            className="px-2 py-3 min-h-[48px] text-xs text-slate-500 hover:text-slate-300 underline underline-offset-2"
           >
             Saltar pregunta
           </button>
@@ -209,15 +288,15 @@ export default function OnboardingProfile({ onComplete, onClose = undefined, onE
           <button
             type="button"
             onClick={goNext}
-            className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-xl bg-emerald-700 hover:bg-emerald-600 font-medium transition-colors"
+            className="inline-flex items-center gap-1.5 px-6 py-3 min-h-[48px] rounded-xl bg-emerald-600 hover:bg-emerald-500 active:scale-[0.98] text-base font-bold shadow-lg shadow-emerald-900/40 transition-all"
           >
             {index >= total - 1 ? (
               <>
-                <Check size={18} /> Terminar
+                <Check size={19} /> Terminar
               </>
             ) : (
               <>
-                Siguiente <ChevronRight size={18} />
+                Siguiente <ChevronRight size={19} />
               </>
             )}
           </button>
@@ -279,22 +358,70 @@ function PisoTermicoQuickPick({ selected, onPick }) {
  */
 function QuestionView({ question, value, onChange, onChangeOther, extraAnswers, onAdvanceSingle }) {
   const { type, title, help, options, placeholder, unit } = question;
+  const catMeta = CATEGORY_META[question.category] || CATEGORY_META.identidad;
+  const emoji = QUESTION_EMOJI[question.id] || catMeta.emoji;
+  const optionEmoji = OPTION_EMOJI[question.id] || {};
+  const chips = EXAMPLE_CHIPS[question.id];
+
+  // Un toque en un ejemplo llena el campo. En preguntas de lista (cultivos)
+  // los toques se suman con coma; repetir el toque no duplica.
+  const pickExample = (ejemplo) => {
+    if (!chips?.append || !value) {
+      onChange(ejemplo);
+      return;
+    }
+    const partes = String(value).split(',').map((s) => s.trim()).filter(Boolean);
+    if (partes.some((p) => p.toLowerCase() === ejemplo.toLowerCase())) return;
+    onChange([...partes, ejemplo].join(', '));
+  };
 
   return (
-    <div className="py-4">
-      <h2 className="text-xl font-bold text-white leading-snug">{title}</h2>
-      {help && <p className="text-sm text-slate-400 mt-1.5 leading-relaxed">{help}</p>}
+    <div className="py-4 anim-brota">
+      {/* Ancla visual: emoji grande + miga de categoría. La usuaria ubica el
+          tema de la pregunta de un vistazo, antes de leer. */}
+      <div className="flex items-center gap-3.5">
+        <div
+          className="w-16 h-16 shrink-0 rounded-2xl bg-emerald-900/30 border border-emerald-700/40 flex items-center justify-center text-4xl leading-none"
+          aria-hidden="true"
+        >
+          {emoji}
+        </div>
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase tracking-widest font-bold text-emerald-400/90">
+            {catMeta.label}
+          </p>
+          <h2 className="text-xl font-bold text-white leading-snug mt-0.5">{title}</h2>
+        </div>
+      </div>
+      {help && <p className="text-sm text-slate-400 mt-2.5 leading-relaxed">{help}</p>}
 
       <div className="mt-5 space-y-2.5">
         {type === 'text' && (
-          <input
-            type="text"
-            value={value || ''}
-            onChange={(e) => onChange(e.target.value)}
-            placeholder={placeholder}
-            autoFocus
-            className="w-full px-4 py-3 rounded-xl bg-slate-900 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-emerald-500/60"
-          />
+          <>
+            <input
+              type="text"
+              value={value || ''}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder={placeholder}
+              autoFocus
+              className="w-full px-4 py-3.5 text-base rounded-xl bg-slate-900 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-emerald-500/60"
+            />
+            {chips && (
+              <div className="flex flex-wrap items-center gap-2 pt-1 anim-brota" style={{ '--i': 1 }}>
+                <span className="text-xs text-slate-500">Toque un ejemplo:</span>
+                {chips.values.map((ej) => (
+                  <button
+                    key={ej}
+                    type="button"
+                    onClick={() => pickExample(ej)}
+                    className="px-3 py-1.5 rounded-full text-sm bg-slate-900 border border-slate-700 text-slate-300 hover:border-emerald-600 hover:text-emerald-200 active:scale-95 transition-all"
+                  >
+                    {ej}
+                  </button>
+                ))}
+              </div>
+            )}
+          </>
         )}
 
         {type === 'number' && (
@@ -306,7 +433,7 @@ function QuestionView({ question, value, onChange, onChangeOther, extraAnswers, 
               onChange={(e) => onChange(e.target.value)}
               placeholder={placeholder}
               autoFocus
-              className="w-full px-4 py-3 rounded-xl bg-slate-900 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-emerald-500/60"
+              className="w-full px-4 py-3.5 text-base rounded-xl bg-slate-900 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-emerald-500/60"
             />
             {unit && (
               <span className="absolute right-4 top-1/2 -translate-y-1/2 text-sm text-slate-500 pointer-events-none">
@@ -325,8 +452,9 @@ function QuestionView({ question, value, onChange, onChangeOther, extraAnswers, 
         )}
 
         {type === 'single' &&
-          options.map((opt) => {
+          options.map((opt, i) => {
             const selected = value === opt.value;
+            const optEmoji = optionEmoji[opt.value];
             return (
               <button
                 key={opt.value}
@@ -338,22 +466,29 @@ function QuestionView({ question, value, onChange, onChangeOther, extraAnswers, 
                   // volver atrás.
                   if (onAdvanceSingle) setTimeout(onAdvanceSingle, 180);
                 }}
-                className={`w-full text-left px-4 py-3 rounded-xl border transition-colors flex items-center justify-between gap-2 ${
+                className={`anim-brota w-full text-left px-4 py-3.5 min-h-[52px] rounded-xl border transition-all active:scale-[0.99] flex items-center justify-between gap-2 ${
                   selected
-                    ? 'bg-emerald-900/30 border-emerald-600 text-white'
-                    : 'bg-slate-900 border-slate-700 text-slate-200 hover:border-slate-600'
+                    ? 'bg-emerald-900/40 border-emerald-500 ring-1 ring-emerald-500/40 text-white'
+                    : 'bg-slate-900 border-slate-700 text-slate-200 hover:border-slate-500'
                 }`}
+                style={{ '--i': i + 1 }}
               >
-                <span>{opt.label}</span>
+                <span className="flex items-center gap-2.5 text-[15px]">
+                  {optEmoji && (
+                    <span className="text-xl leading-none shrink-0" aria-hidden="true">{optEmoji}</span>
+                  )}
+                  <span>{opt.label}</span>
+                </span>
                 {selected && <Check size={18} className="text-emerald-400 shrink-0" />}
               </button>
             );
           })}
 
         {type === 'multi' &&
-          options.map((opt) => {
+          options.map((opt, i) => {
             const arr = Array.isArray(value) ? value : [];
             const selected = arr.includes(opt.value);
+            const optEmoji = optionEmoji[opt.value];
             return (
               <button
                 key={opt.value}
@@ -364,19 +499,25 @@ function QuestionView({ question, value, onChange, onChangeOther, extraAnswers, 
                     : [...arr, opt.value];
                   onChange(next);
                 }}
-                className={`w-full text-left px-4 py-3 rounded-xl border transition-colors flex items-center justify-between gap-2 ${
+                className={`anim-brota w-full text-left px-4 py-3.5 min-h-[52px] rounded-xl border transition-all active:scale-[0.99] flex items-center justify-between gap-2 ${
                   selected
-                    ? 'bg-emerald-900/30 border-emerald-600 text-white'
-                    : 'bg-slate-900 border-slate-700 text-slate-200 hover:border-slate-600'
+                    ? 'bg-emerald-900/40 border-emerald-500 ring-1 ring-emerald-500/40 text-white'
+                    : 'bg-slate-900 border-slate-700 text-slate-200 hover:border-slate-500'
                 }`}
+                style={{ '--i': i + 1 }}
               >
-                <span>{opt.label}</span>
+                <span className="flex items-center gap-2.5 text-[15px]">
+                  {optEmoji && (
+                    <span className="text-xl leading-none shrink-0" aria-hidden="true">{optEmoji}</span>
+                  )}
+                  <span>{opt.label}</span>
+                </span>
                 <span
-                  className={`w-5 h-5 rounded-md border flex items-center justify-center shrink-0 ${
+                  className={`w-6 h-6 rounded-md border flex items-center justify-center shrink-0 transition-colors ${
                     selected ? 'bg-emerald-600 border-emerald-600' : 'border-slate-600'
                   }`}
                 >
-                  {selected && <Check size={14} className="text-white" />}
+                  {selected && <Check size={15} className="text-white" />}
                 </span>
               </button>
             );

--- a/src/services/__tests__/operatorPhotoService.test.js
+++ b/src/services/__tests__/operatorPhotoService.test.js
@@ -13,10 +13,12 @@ import localforage from 'localforage';
 const sendToFarmOS = vi.fn();
 const fetchFromFarmOS = vi.fn();
 const fetchWithAuthRetry = vi.fn();
+const uploadBinaryToFarmOS = vi.fn();
 vi.mock('../apiService.js', () => ({
   sendToFarmOS: (...a) => sendToFarmOS(...a),
   fetchFromFarmOS: (...a) => fetchFromFarmOS(...a),
   fetchWithAuthRetry: (...a) => fetchWithAuthRetry(...a),
+  uploadBinaryToFarmOS: (...a) => uploadBinaryToFarmOS(...a),
 }));
 
 import {
@@ -82,6 +84,7 @@ describe('operatorPhotoService', () => {
     sendToFarmOS.mockReset();
     fetchFromFarmOS.mockReset();
     fetchWithAuthRetry.mockReset();
+    uploadBinaryToFarmOS.mockReset();
     // onLine = true por defecto (jsdom navigator es read-only → defineProperty).
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
   });
@@ -232,7 +235,7 @@ describe('operatorPhotoService', () => {
       const r = await uploadToFarmOS(SAMPLE_DATA_URL);
       expect(r.ok).toBe(false);
       expect(r.reason).toBe('no-session');
-      expect(sendToFarmOS).not.toHaveBeenCalled();
+      expect(uploadBinaryToFarmOS).not.toHaveBeenCalled();
     });
 
     it('no sube en offline', async () => {
@@ -240,32 +243,84 @@ describe('operatorPhotoService', () => {
       Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
       const r = await uploadToFarmOS(SAMPLE_DATA_URL);
       expect(r.reason).toBe('offline');
-      expect(sendToFarmOS).not.toHaveBeenCalled();
+      expect(uploadBinaryToFarmOS).not.toHaveBeenCalled();
     });
 
-    it('POST /api/file/upload con filename scopeado por usuario y guarda meta', async () => {
+    it('sube por el flujo Drupal (upload por campo), adjunta a un log y guarda meta', async () => {
       setActiveTenantId('alice');
-      sendToFarmOS.mockResolvedValue({ data: { id: 'uuid-123', type: 'file--file' } });
+      uploadBinaryToFarmOS.mockResolvedValue({ data: { id: 'uuid-123', type: 'file--file' } });
+      sendToFarmOS.mockResolvedValue({ data: { id: 'log-uuid-1', type: 'log--observation' } });
 
       const r = await uploadToFarmOS(SAMPLE_DATA_URL);
 
       expect(r.ok).toBe(true);
       expect(r.fileUuid).toBe('uuid-123');
+      // Paso A: binario por upload-por-campo (la ruta /api/file/upload NO
+      // existe en farmOS 4.x — bug 2026-07-08).
+      expect(uploadBinaryToFarmOS).toHaveBeenCalledTimes(1);
+      const [blob, filename, target] = uploadBinaryToFarmOS.mock.calls[0];
+      expect(blob).toBeInstanceOf(Blob);
+      expect(filename).toMatch(/^chagra-operator-photo-alice-\d+\.jpg$/);
+      expect(target).toEqual({ entity: 'log', bundle: 'observation', field: 'file' });
+      // Paso B: se adjunta a un log--observation para volver el file permanente.
       expect(sendToFarmOS).toHaveBeenCalledTimes(1);
-      const [endpoint, formData, method] = sendToFarmOS.mock.calls[0];
-      expect(endpoint).toBe('/api/file/upload');
-      expect(method).toBe('POST');
-      expect(formData).toBeInstanceOf(FormData);
-      const uploaded = formData.get('file');
-      expect(uploaded).toBeInstanceOf(Blob);
-      expect(uploaded.name).toMatch(/^chagra-operator-photo-alice-\d+\.jpg$/);
-      // meta persistida para evitar re-descargas redundantes.
+      const [logEndpoint, logPayload, logMethod] = sendToFarmOS.mock.calls[0];
+      expect(logEndpoint).toBe('/api/log/observation');
+      expect(logMethod).toBe('POST');
+      expect(logPayload.data.attributes.name).toBe('chagra-operator-photo-alice');
+      expect(logPayload.data.relationships.file.data).toEqual([
+        { type: 'file--file', id: 'uuid-123' },
+      ]);
+      // meta persistida para evitar re-descargas redundantes + reusar el log.
       expect(__test.readSyncMeta().fileUuid).toBe('uuid-123');
+      expect(__test.readSyncMeta().logUuid).toBe('log-uuid-1');
+    });
+
+    it('reusa el log existente (PATCH) al cambiar la foto', async () => {
+      setActiveTenantId('alice');
+      __test.writeSyncMeta({ fileUuid: 'old', logUuid: 'log-uuid-1', tenantId: 'alice' });
+      uploadBinaryToFarmOS.mockResolvedValue({ data: { id: 'uuid-456' } });
+      sendToFarmOS.mockResolvedValue({ data: { id: 'log-uuid-1' } });
+
+      const r = await uploadToFarmOS(SAMPLE_DATA_URL);
+
+      expect(r.ok).toBe(true);
+      const [logEndpoint, logPayload, logMethod] = sendToFarmOS.mock.calls[0];
+      expect(logEndpoint).toBe('/api/log/observation/log-uuid-1');
+      expect(logMethod).toBe('PATCH');
+      expect(logPayload.data.id).toBe('log-uuid-1');
+      expect(__test.readSyncMeta().logUuid).toBe('log-uuid-1');
+    });
+
+    it('si el PATCH al log guardado falla (borrado remoto), crea uno nuevo', async () => {
+      setActiveTenantId('alice');
+      __test.writeSyncMeta({ fileUuid: 'old', logUuid: 'log-muerto', tenantId: 'alice' });
+      uploadBinaryToFarmOS.mockResolvedValue({ data: { id: 'uuid-789' } });
+      sendToFarmOS
+        .mockRejectedValueOnce(new Error('404')) // PATCH al log muerto
+        .mockResolvedValueOnce({ data: { id: 'log-nuevo' } }); // POST nuevo
+
+      const r = await uploadToFarmOS(SAMPLE_DATA_URL);
+
+      expect(r.ok).toBe(true);
+      expect(__test.readSyncMeta().logUuid).toBe('log-nuevo');
+    });
+
+    it('sigue ok aunque el attach al log falle (el file quedó subido)', async () => {
+      setActiveTenantId('alice');
+      uploadBinaryToFarmOS.mockResolvedValue({ data: { id: 'uuid-999' } });
+      sendToFarmOS.mockRejectedValue(new Error('403'));
+
+      const r = await uploadToFarmOS(SAMPLE_DATA_URL);
+
+      expect(r.ok).toBe(true);
+      expect(r.fileUuid).toBe('uuid-999');
+      expect(__test.readSyncMeta().logUuid).toBe(null);
     });
 
     it('no-throw si la red falla', async () => {
       setActiveTenantId('alice');
-      sendToFarmOS.mockRejectedValue(new Error('500'));
+      uploadBinaryToFarmOS.mockRejectedValue(new Error('500'));
       const r = await uploadToFarmOS(SAMPLE_DATA_URL);
       expect(r.ok).toBe(false);
       expect(r.reason).toBe('error');
@@ -339,7 +394,8 @@ describe('operatorPhotoService', () => {
     it('redimensiona, persiste local y devuelve el data-URL (sync dispara en background)', async () => {
       installCanvasMocks();
       setActiveTenantId('alice');
-      sendToFarmOS.mockResolvedValue({ data: { id: 'bg-uuid' } });
+      uploadBinaryToFarmOS.mockResolvedValue({ data: { id: 'bg-uuid' } });
+      sendToFarmOS.mockResolvedValue({ data: { id: 'bg-log' } });
       const file = new File([new Uint8Array(10)], 'foto.jpg', { type: 'image/jpeg' });
 
       const out = await setOperatorPhotoFromFile(file);
@@ -348,7 +404,11 @@ describe('operatorPhotoService', () => {
       expect(getOperatorPhoto()).toBe(SAMPLE_DATA_URL);
       // El upload corre en background (fire-and-forget); esperamos a que llegue.
       await vi.waitFor(() =>
-        expect(sendToFarmOS).toHaveBeenCalledWith('/api/file/upload', expect.any(FormData), 'POST'),
+        expect(uploadBinaryToFarmOS).toHaveBeenCalledWith(
+          expect.any(Blob),
+          expect.stringMatching(/^chagra-operator-photo-alice-\d+\.jpg$/),
+          { entity: 'log', bundle: 'observation', field: 'file' },
+        ),
       );
     });
   });

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -354,3 +354,49 @@ export const sendToFarmOS = async (endpoint, payload, method = 'POST') => {
 
   return await fetchFromFarmOS(endpoint, options);
 };
+
+/**
+ * Sube un binario (foto/evidencia) a FarmOS por el flujo NATIVO de
+ * Drupal 10 JSON:API — "file upload por campo":
+ *
+ *   POST /api/{entity}/{bundle}/{field}
+ *   Content-Type: application/octet-stream
+ *   Content-Disposition: file; filename="nombre.jpg"
+ *
+ * Crea un `file--file` NUEVO (sin adjuntar) y devuelve la respuesta JSON:API
+ * con su UUID en `data.id`.
+ *
+ * BUG HISTÓRICO (2026-07-08, "la foto de perfil no sube a farmOS"): el código
+ * usaba `POST /api/file/upload` con FormData — una ruta que NO EXISTE en
+ * farmOS 4.x / Drupal 10 (verificado en vivo: 404). Drupal solo expone la
+ * subida de archivos por campo de entidad (`/api/log/observation/file` → 403
+ * sin auth = la ruta sí existe). Como el caller tragaba el error con un
+ * `console.warn` "no bloqueante", la subida fallaba en silencio desde siempre.
+ *
+ * ⚠️ IMPORTANTE (durabilidad): el file creado queda TEMPORAL (status 0) hasta
+ * que alguna entidad lo referencie; el cron de Drupal borra los temporales
+ * (~6 h). El caller DEBE adjuntarlo (POST/PATCH con relationships) para que
+ * sobreviva — ver uploadToFarmOS (operatorPhotoService) y la evidencia de
+ * syncManager (Paso B ya lo hacía).
+ *
+ * @param {Blob} blob - binario a subir
+ * @param {string} filename - nombre del archivo (se sanea para el header)
+ * @param {{entity?: string, bundle?: string, field?: string}} [target]
+ *   Entidad/bundle/campo destino. Default: log observation, campo `file`.
+ * @returns {Promise<Object>} respuesta JSON:API (`data.id` = UUID del file--file)
+ * @throws {Error} si el servidor responde no-2xx / red caída (mismo contrato
+ *   que fetchFromFarmOS; el caller decide si es fatal)
+ */
+export const uploadBinaryToFarmOS = async (blob, filename, target = {}) => {
+  const { entity = 'log', bundle = 'observation', field = 'file' } = target;
+  // Sanear el filename para el header (sin comillas ni saltos de línea).
+  const safeName = String(filename || 'archivo.jpg').replace(/["\r\n]/g, '');
+  return await fetchFromFarmOS(`/api/${entity}/${bundle}/${field}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': `file; filename="${safeName}"`,
+    },
+    body: blob,
+  });
+};

--- a/src/services/operatorPhotoService.js
+++ b/src/services/operatorPhotoService.js
@@ -33,11 +33,14 @@
  *     ProfileScreen) re-leen. La portada (TopBar) lee de aquí sin red.
  *
  * ── Sincronización a FarmOS (cuando hay sesión) ──────────────────────────
- *   Reutiliza el patrón YA existente en el repo (`useBackgroundImage` +
- *   `syncManager`): NO inventa endpoints.
- *     - Subida:  POST /api/file/upload (FormData) → crea un `file--file` con
- *       filename `chagra-operator-photo-<tenantId>-<ts>.jpg`. El prefijo por
- *       usuario evita colisiones entre operadores que comparten backend.
+ *   Usa el flujo NATIVO de Drupal 10 JSON:API (`uploadBinaryToFarmOS`):
+ *     - Subida:  POST /api/log/observation/file (octet-stream +
+ *       Content-Disposition) → crea un `file--file` con filename
+ *       `chagra-operator-photo-<tenantId>-<ts>.jpg` (el prefijo por usuario
+ *       evita colisiones entre operadores que comparten backend) y se adjunta
+ *       a un log--observation estable por usuario para que Drupal lo marque
+ *       PERMANENTE (bug 2026-07-08: la ruta vieja /api/file/upload no existe
+ *       → 404 silencioso, la foto nunca subía).
  *     - Carga:   GET /api/file/file?filter[filename][operator]=CONTAINS
  *       &filter[filename][value]=chagra-operator-photo-<tenantId>-&sort=-created
  *       &page[limit]=1 → descarga el blob más reciente con Bearer token y lo
@@ -303,15 +306,25 @@ export async function uploadToFarmOS(dataUrl) {
     return { ok: false, reason: 'offline' };
   }
   try {
-    const { sendToFarmOS } = await import('./apiService.js');
+    const { sendToFarmOS, uploadBinaryToFarmOS } = await import('./apiService.js');
     const blob = dataUrlToBlob(dataUrl);
     const filename = `${FARMOS_PHOTO_PREFIX}-${tenantId}-${Date.now()}.jpg`;
-    const formData = new FormData();
-    formData.append('file', blob, filename);
-    const result = await sendToFarmOS('/api/file/upload', formData, 'POST');
+    // BUG FIX 2026-07-08 ("no sube a farmOS"): la ruta vieja POST
+    // /api/file/upload NO EXISTE en farmOS 4.x / Drupal 10 (404 verificado en
+    // vivo) — la subida fallaba en silencio desde siempre. La vía real de
+    // Drupal es el upload POR CAMPO: POST /api/log/observation/file con
+    // octet-stream + Content-Disposition (403 sin auth = la ruta sí existe).
+    const result = await uploadBinaryToFarmOS(blob, filename, {
+      entity: 'log', bundle: 'observation', field: 'file',
+    });
     const fileUuid = result?.data?.id;
     if (fileUuid) {
-      writeSyncMeta({ fileUuid, filename, syncedAt: Date.now(), tenantId });
+      // Durabilidad: un file--file SIN referencia queda "temporal" y el cron
+      // de Drupal lo borra (~6 h) → la foto "desaparecía" del server. Se
+      // adjunta a UN log--observation por usuario (reusado entre cambios de
+      // foto vía logUuid en el sync meta) para marcarlo permanente.
+      const logUuid = await attachPhotoToLog(sendToFarmOS, fileUuid, tenantId);
+      writeSyncMeta({ fileUuid, filename, logUuid, syncedAt: Date.now(), tenantId });
       return { ok: true, fileUuid };
     }
     return { ok: false, reason: 'no-uuid' };
@@ -319,6 +332,53 @@ export async function uploadToFarmOS(dataUrl) {
     // Falla de red/permiso no es fatal: el local sigue funcionando.
     console.warn('[operatorPhoto] uploadToFarmOS falló (no bloqueante):', err?.message || err);
     return { ok: false, reason: 'error' };
+  }
+}
+
+/**
+ * Adjunta el file subido a un `log--observation` estable por usuario
+ * (`chagra-operator-photo-<tenantId>`) para que Drupal marque el archivo como
+ * PERMANENTE (sin referencia lo garbage-collectea en horas). Reusa el mismo
+ * log entre cambios de foto (PATCH); si el log guardado ya no existe (o nunca
+ * se creó), crea uno nuevo. No-throw: devuelve el logUuid efectivo o null.
+ *
+ * @param {Function} sendToFarmOS - inyectado por el caller (ya importado)
+ * @param {string} fileUuid
+ * @param {string} tenantId
+ * @returns {Promise<string|null>}
+ */
+async function attachPhotoToLog(sendToFarmOS, fileUuid, tenantId) {
+  const relationships = {
+    file: { data: [{ type: 'file--file', id: fileUuid }] },
+  };
+  const prevLogUuid = readSyncMeta().logUuid || null;
+  if (prevLogUuid) {
+    try {
+      await sendToFarmOS(`/api/log/observation/${prevLogUuid}`, {
+        data: { type: 'log--observation', id: prevLogUuid, relationships },
+      }, 'PATCH');
+      return prevLogUuid;
+    } catch (e) {
+      // Log borrado remotamente / permiso — caer a crear uno nuevo.
+      console.warn('[operatorPhoto] PATCH log foto falló, creando nuevo:', e?.message || e);
+    }
+  }
+  try {
+    const res = await sendToFarmOS('/api/log/observation', {
+      data: {
+        type: 'log--observation',
+        attributes: {
+          name: `${FARMOS_PHOTO_PREFIX}-${tenantId}`,
+          status: 'done',
+        },
+        relationships,
+      },
+    }, 'POST');
+    return res?.data?.id || null;
+  } catch (e) {
+    // No fatal: el file quedó subido; el próximo cambio de foto reintenta.
+    console.warn('[operatorPhoto] attach log foto falló (no bloqueante):', e?.message || e);
+    return null;
   }
 }
 

--- a/src/services/syncManager.js
+++ b/src/services/syncManager.js
@@ -1,6 +1,6 @@
 // Sync conflict strategy (Task 109): Logs append-only idempotent by id.
 // Assets LWW at field level. Queue dedup by transaction id (upsert).
-import { sendToFarmOS, fetchFromFarmOS } from './apiService';
+import { sendToFarmOS, fetchFromFarmOS, uploadBinaryToFarmOS } from './apiService';
 import { openDB, STORES } from '../db/dbCore';
 import { logCache } from '../db/logCache';
 import { newId } from '../utils/id';
@@ -478,12 +478,16 @@ export class SyncManager {
         const diagnoses = [];
 
         for (const item of mediaItems) {
-          // Paso A: POST /api/file/upload con FormData
-          const formData = new FormData();
+          // Paso A: subir el binario por el flujo NATIVO de Drupal 10
+          // (upload por campo, octet-stream). BUG FIX 2026-07-08: la ruta
+          // vieja POST /api/file/upload (FormData) NO existe en farmOS 4.x
+          // (404 verificado en vivo) — la evidencia nunca subía y el warn
+          // "no bloqueante" se lo tragaba. El file queda temporal hasta que
+          // el Paso B lo referencia en el log (ahí Drupal lo hace permanente).
           const filename = `evidence_${logId}_${item.id}.webp`;
-          formData.append('file', item.blob, filename);
-
-          const fileResult = await sendToFarmOS('/api/file/upload', formData, 'POST');
+          const fileResult = await uploadBinaryToFarmOS(item.blob, filename, {
+            entity: 'log', bundle: 'observation', field: 'file',
+          });
           const fileUuid = fileResult?.data?.id;
           if (fileUuid) {
             fileUuids.push({ type: 'file--file', id: fileUuid });


### PR DESCRIPTION
## 1 · Bug foto de perfil — diagnosticado + arreglado

**Causa raíz (verificada EN VIVO contra farmOS):** `POST /api/file/upload` devuelve **404** — esa ruta NO existe en farmOS 4.x / Drupal 10. La foto de perfil (y la evidencia de syncManager) fallaba en silencio desde siempre porque el error se trataba como 'no bloqueante'. Es la mitad 'no sube a farmOS' del bug (la mitad 'no persiste local' ya la cerró #2144 con IndexedDB).

**Fix:**
- `uploadBinaryToFarmOS` (apiService): flujo NATIVO de Drupal 10 — `POST /api/{entity}/{bundle}/{field}` con `application/octet-stream` + `Content-Disposition` (verificado: `/api/log/observation/file` → 403 sin auth = la ruta existe).
- Durabilidad: la foto se adjunta a un `log--observation` estable por usuario (reusado vía PATCH) — un file sin referencia queda temporal y el cron de Drupal lo borra en ~6h.
- syncManager (evidencia de logs) migrado al mismo flujo — mismo bug raíz; su Paso B (PATCH relationships.file) ya la volvía permanente.
- Tests: operatorPhotoService 24/24 + syncManager 31/31 verdes (nuevos casos: attach, reuso de log, fallback log muerto, no-throw).

## 2 · Onboarding refinado (baja alfabetización, tarea #16)

Solo presentación — `PROFILE_QUESTIONS` y lo persistido intactos:
- **Ancla visual por pregunta**: emoji grande en halo esmeralda + miga de categoría en palabras llanas (Sobre usted / Su tierra / Su experiencia / Sus metas / A su gusto).
- **Emoji por opción** donde faltaba (vocación, riego, manejo, problemas, metas…) — escoger sin leer.
- **Ejemplos tocables** en preguntas de texto (región, cultivos, invernadero): un toque llena el campo; en listas se suman con coma.
- **Transiciones suaves** reutilizando motion.css (`.anim-brota` escalonado; prefers-reduced-motion cubierto por el sistema).
- **Progreso visible**: barra h-2 gradiente esmeralda→lima + '¡Ya casi termina!' desde el 75%.
- **Targets ≥48–52px**, texto de opción 15px, botón Siguiente con peso real.
- **Sin colibrí (AgentFab) en onboarding-perfil**: se encimaba sobre el CTA 'Explorar con finca de ejemplo'.

## Verificación
- build ✅ · tsc gate 1829 = baseline ✅ · budget 25.1/25.5 MB ✅ · eslint 0 errores en tocados ✅
- Suites relevantes verdes: OnboardingProfile 5/5, AgentFab 2/2, foto 24/24, sync 31/31.
- Capturas móviles (390px) contra dist real enviadas por Telegram — **espera OK visual del operador** (por eso draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)