### PR TITLE
feat(pro): entrada gated "El Espíritu de tu Finca" (capability avatar-espiritu)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -290,6 +290,10 @@ const MundoSubsuelo = lazy(() => import('./components/juego/MundoSubsuelo'));
 // Modo extensionista (panel supervisor multi-finca, ADR-048 MVP). Gateado por
 // feature flag VITE_FEATURE_EXTENSIONISTA + rol (ver config/extensionistaAccess).
 const ExtensionistaScreen = lazy(() => import('./components/ExtensionistaScreen'));
+// Entrada Pro GATED por capability `avatar-espiritu` (módulo del repo privado
+// chagra-pro). La pantalla pública NO contiene código visual: solo consulta el
+// registry y monta el módulo Pro si está presente; si no, fallback discreto.
+const EspirituProScreen = lazy(() => import('./components/EspirituProScreen'));
 import HomeRegionalGreeting from './components/HomeRegionalGreeting';
 import { fincaVivaHomePerfilActivo } from './config/fincaVivaHomeFlag';
 import { esExtensionistaActual } from './config/extensionistaAccess';
@@ -530,6 +534,9 @@ const HASH_VIEW_ROUTES = {
   cosechar: 'cosechar',
   'mi-cosecha': 'mi_cosecha',
   micosecha: 'mi_cosecha',
+  // Entrada Pro (capability avatar-espiritu). Gated: sin módulo Pro cargado
+  // la pantalla degrada a fallback discreto.
+  espiritu: 'espiritu_pro',
 };
 
 // Vistas que cuentan como "módulo" para telemetría de piloto.
@@ -1236,6 +1243,12 @@ export default function App() {
                 <MundoSubsuelo />
               </ScreenShell>
             </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'espiritu_pro':
+        return (
+          <ErrorBoundary>
+            <EspirituProScreen onBack={() => navigate('dashboard')} />
           </ErrorBoundary>
         );
       case 'sembrar':

--- a/src/components/EspirituProScreen.jsx
+++ b/src/components/EspirituProScreen.jsx
@@ -1,0 +1,114 @@
+/* eslint-disable react-hooks/set-state-in-effect -- El set de estado en el
+   efecto refleja el resultado (síncrono o asíncrono) de consultar/montar la
+   capability Pro; mismo patrón que GuildSuggestions.jsx (capa 3 enriquecida). */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- Copy mínimo de fallback en
+   español Colombia, pendiente de migrar a src/config/messages.js (ADR-050). */
+import React, { useEffect, useState } from 'react';
+import { registry } from '../core/moduleRegistry';
+
+/**
+ * EspirituProScreen — entrada pública GATED a la experiencia inmersiva de
+ * "finca viva" (capability `avatar-espiritu`), provista por un módulo Pro
+ * del repo privado (chagra-pro).
+ *
+ * ADR-002/011 — asimetría de imports: esta pantalla NO contiene NADA del
+ * código visual de la experiencia. Solo consulta la capability vía el
+ * registry; si un módulo Pro está registrado, lo monta y renderiza su
+ * componente; si no, degrada a un fallback discreto (sin UI de la
+ * experiencia).
+ *
+ * Gate: permisivo por ahora (cualquier cuenta que tenga el módulo Pro
+ * cargado), pero estructuralmente gated — la experiencia SOLO aparece cuando
+ * la capability está presente (build con VITE_PRO_MODULES_PATH + módulo Pro
+ * servido). En el build puro OSS no hay módulo → fallback, cero UI extra.
+ *
+ * @param {{ onBack?: () => void, variant?: string }} props
+ *   `variant` es opcional (follow-up: selector de tema). Sin él, el módulo
+ *   Pro usa su tema por defecto.
+ */
+export default function EspirituProScreen({ onBack, variant }) {
+  const [Comp, setComp] = useState(null);
+  const [status, setStatus] = useState('loading'); // 'loading' | 'ready' | 'unavailable'
+
+  useEffect(() => {
+    let alive = true;
+    const mods = registry.byCapability('avatar-espiritu');
+    if (mods.length === 0) {
+      setStatus('unavailable');
+      return undefined;
+    }
+    mods[0]
+      .mount()
+      .then((m) => {
+        if (!alive) return;
+        if (m && m.default) {
+          setComp(() => m.default);
+          setStatus('ready');
+        } else {
+          setStatus('unavailable');
+        }
+      })
+      .catch(() => {
+        if (alive) setStatus('unavailable');
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (status === 'ready' && Comp) {
+    // El módulo Pro provee la experiencia completa (a pantalla) con su propio
+    // onBack. `variant` queda disponible para el selector de tema (follow-up).
+    return <Comp onBack={onBack} variant={variant} />;
+  }
+
+  const shell = {
+    minHeight: '100dvh',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '0.75rem',
+    padding: '1.5rem',
+    textAlign: 'center',
+    color: '#cbd5e1',
+    background: '#0f172a',
+  };
+
+  if (status === 'loading') {
+    return (
+      <div style={shell} data-testid="espiritu-pro-loading">
+        <span style={{ fontSize: '2rem' }} aria-hidden="true">
+          🌱
+        </span>
+        <p style={{ opacity: 0.8 }}>Cargando…</p>
+      </div>
+    );
+  }
+
+  // 'unavailable' → fallback discreto: sin UI de la experiencia.
+  return (
+    <div style={shell} data-testid="espiritu-pro-unavailable">
+      <p style={{ opacity: 0.8, maxWidth: '28rem' }}>
+        Esta función no está disponible en su plan.
+      </p>
+      {typeof onBack === 'function' && (
+        <button
+          type="button"
+          onClick={onBack}
+          style={{
+            marginTop: '0.5rem',
+            padding: '0.5rem 1rem',
+            borderRadius: '0.5rem',
+            border: '1px solid #334155',
+            background: 'transparent',
+            color: '#cbd5e1',
+            cursor: 'pointer',
+          }}
+        >
+          Volver
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/core/loadProModules.js
+++ b/src/core/loadProModules.js
@@ -14,11 +14,31 @@
  * Módulos Pro esperados (actualizar cuando se agreguen al catálogo
  * privado):
  *   - gremios-receta-pro (capability: enriched-guild-suggestions)
+ *   - avatar-espiritu-pro (capability: avatar-espiritu)
  *   - export-ecocert-pro (capability: export-ecocert)  [v0.9.0+]
  *   - plan-nutricion-pro (capability: auto-plan-nutricion) [v0.9.1+]
+ *
+ * REACT COMPARTIDO: algunos módulos Pro traen componentes React
+ * pre-construidos (ESM de navegador). Para que usen la MISMA instancia de
+ * React que el público (si no, los hooks rompen con "Invalid hook call"),
+ * este loader publica `globalThis.__CHAGRA_VENDOR__ = { React, jsxRuntime }`
+ * ANTES de importar cualquier módulo Pro. El bundle Pro resuelve `react` /
+ * `react/jsx-runtime` contra ese global (ver chagra-pro/.../build.mjs).
  */
 
+import React from 'react';
+import * as JsxRuntime from 'react/jsx-runtime';
 import { registry } from './moduleRegistry';
+
+// Expone el React del host para los módulos Pro que traen componentes
+// pre-construidos. Idempotente; solo se llama cuando hay módulos Pro que
+// cargar (no toca el global en un build puro OSS).
+function ensureVendorGlobals() {
+  if (typeof globalThis === 'undefined') return;
+  if (!globalThis.__CHAGRA_VENDOR__) {
+    globalThis.__CHAGRA_VENDOR__ = { React, jsxRuntime: JsxRuntime };
+  }
+}
 
 // Vite resuelve import.meta.glob en build-time. El path con variable
 // de entorno no se resuelve estáticamente, así que el bundle público no
@@ -28,7 +48,7 @@ const PRO_MODULES_ENV = (import.meta.env && import.meta.env.VITE_PRO_MODULES_PAT
 
 // Lista explícita de módulos Pro que conocemos. Añadir aquí cuando
 // el equipo Pro confirme el id y capability del nuevo módulo.
-const KNOWN_PRO_MODULES = ['gremios-receta-pro', 'voice-entity-extractor-pro'];
+const KNOWN_PRO_MODULES = ['gremios-receta-pro', 'voice-entity-extractor-pro', 'avatar-espiritu-pro'];
 
 export async function loadProModules() {
   if (!PRO_MODULES_ENV) {
@@ -37,6 +57,9 @@ export async function loadProModules() {
     }
     return { loaded: [], skipped: KNOWN_PRO_MODULES };
   }
+
+  // Publica el React del host antes de importar módulos Pro (React compartido).
+  ensureVendorGlobals();
 
   const loaded = [];
   const skipped = [];


### PR DESCRIPTION
Integra la experiencia inmersiva de finca viva a producción **como FEATURE PRO**, sin traer NADA del código visual al repo público (ADR-002/011). El avatar vive en el módulo privado `avatar-espiritu-pro` (chagra-pro PR #304).

## Público (este PR)
- **`loadProModules`**: registra `avatar-espiritu-pro` en `KNOWN_PRO_MODULES` y publica el React del host en `globalThis.__CHAGRA_VENDOR__` **antes** de importar módulos Pro, para que los componentes pre-construidos usen la **misma** instancia de React (si no, los hooks rompen con "Invalid hook call").
- **`EspirituProScreen`**: pantalla pública **GATED** — solo consulta `registry.byCapability("avatar-espiritu")`; si el módulo Pro está presente lo monta y renderiza, si no degrada a un fallback discreto (sin UI de la experiencia). Permisiva ahora, pero **estructuralmente gated**.
- **`App.jsx`**: ruta por hash `#/espiritu` → vista `espiritu_pro`.
- **Cero** código visual del avatar en el repo público (grep anti-leak: 0).

## Cómo se resuelve el JSX/build del módulo Pro
El loader hace un `import()` de navegador **crudo** en prod (no pasa por Vite). Por eso el módulo Pro se **pre-construye** con esbuild a un ESM autocontenido; `react`/`react/jsx-runtime` se resuelven contra `globalThis.__CHAGRA_VENDOR__` (una sola instancia). Detalle en el PR de chagra-pro.

## Verificación
- **tsc-gate**: sin regresión (1829 = baseline).
- **eslint / lefthook** (secret/infra/strategic/pro-import/voseo): verde.
- **Build de prod** con `VITE_PRO_MODULES_PATH=/pro-modules`: el path + `avatar-espiritu-pro` + `__CHAGRA_VENDOR__` quedan baked en el bundle.
- **E2E (jsdom)** contra el bundle **servido**: `byCapability` → `mount` → render de **ambos** temas (biopunk-v3 default + verde-vivo-v3), con inyección de CSS.

## Pasos faltantes para activar en prod (infra)
1. Servir el bundle Pro en `/pro-modules/avatar-espiritu-pro/index.js` (mismo origen → CSP `script-src 'self'`).
2. Añadir `VITE_PRO_MODULES_PATH=/pro-modules` al step Build de `deploy.yml`.
3. Excluir `/pro-modules/` del `rsync --delete` del deploy (si no, lo borra).

Sin (1)+(2) el build público degrada limpio (fallback discreto). Placement del tile de menú = follow-up (requiere visto bueno visual del operador).

🤖 Generated with [Claude Code](https://claude.com/claude-code)