### PR TITLE
fix(agente): tip de foto-diagnóstico discreto (línea sutil, no tarjeta)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3722,16 +3722,18 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
 
         {/* Tip de primera vez (feat/onboarding-ayuda): cómo pedir diagnóstico
             con foto. Apunta al botón 📷 real del compositor de abajo;
-            descartable y no se repite (contextTips). */}
+            descartable y no se repite (contextTips). Variante 'subtle' = una
+            línea discreta, NO tarjeta (operador 2026-07-08: el aviso grande
+            gritaba encima del compositor). */}
         {state !== STATE_RECORDING && !agentAttachment && (
           <ContextTip
             id="foto-diagnostico"
+            variant="subtle"
             emoji="📷"
             title="¿Una mata enferma? Mándeme una foto"
-            className="mb-2"
+            className="mb-1.5"
           >
-            Toque la cámara aquí abajo y tome la foto cerquita de la hoja, con
-            buena luz de día. Yo le digo qué veo.
+            ¿Una mata enferma? Toque la cámara aquí abajo y mándeme la foto.
           </ContextTip>
         )}
 

--- a/src/components/ContextTip.jsx
+++ b/src/components/ContextTip.jsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
 
 import React, { useState } from 'react';
+import { X } from 'lucide-react';
 import { hasSeenTip, markTipSeen } from '../services/contextTips';
 
 /**
@@ -28,8 +29,12 @@ import { hasSeenTip, markTipSeen } from '../services/contextTips';
  *   - children:  texto del tip (1-2 frases).
  *   - moreLabel / onMore: acción secundaria opcional (ej. abrir el Manual).
  *   - className: clases extra del contenedor.
+ *   - variant:   'card' (default, tarjeta con botón Entendido) o 'subtle'
+ *                (una sola línea discreta con "x" — para lugares donde una
+ *                tarjeta grita, ej. encima del compositor del agente;
+ *                operador 2026-07-08). Misma mecánica contextTips.
  */
-export default function ContextTip({ id, emoji, title, children, moreLabel, onMore, className = '' }) {
+export default function ContextTip({ id, emoji, title, children, moreLabel, onMore, className = '', variant = 'card' }) {
   const [visible, setVisible] = useState(() => !hasSeenTip(id));
 
   if (!visible) return null;
@@ -38,6 +43,28 @@ export default function ContextTip({ id, emoji, title, children, moreLabel, onMo
     markTipSeen(id);
     setVisible(false);
   };
+
+  if (variant === 'subtle') {
+    return (
+      <div
+        role="note"
+        aria-label={title}
+        data-testid={`context-tip-${id}`}
+        className={`flex items-center gap-1.5 px-1 ${className}`}
+      >
+        <span className="text-sm shrink-0 leading-none" aria-hidden="true">{emoji}</span>
+        <p className="flex-1 min-w-0 text-xs text-slate-400 leading-snug">{children}</p>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label={`Entendido, ocultar: ${title}`}
+          className="tap-target shrink-0 p-1 rounded-md text-slate-500 hover:text-slate-300 hover:bg-white/10 transition-colors"
+        >
+          <X size={13} aria-hidden="true" />
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/ContextTip.jsx
+++ b/src/components/ContextTip.jsx
@@ -34,7 +34,7 @@ import { hasSeenTip, markTipSeen } from '../services/contextTips';
  *                tarjeta grita, ej. encima del compositor del agente;
  *                operador 2026-07-08). Misma mecánica contextTips.
  */
-export default function ContextTip({ id, emoji, title, children, moreLabel, onMore, className = '', variant = 'card' }) {
+export default function ContextTip({ id, emoji, title, children, moreLabel = null, onMore = null, className = '', variant = 'card' }) {
   const [visible, setVisible] = useState(() => !hasSeenTip(id));
 
   if (!visible) return null;

--- a/src/components/__tests__/ContextTip.test.jsx
+++ b/src/components/__tests__/ContextTip.test.jsx
@@ -72,6 +72,21 @@ describe('ContextTip', () => {
     expect(onMore).toHaveBeenCalled();
   });
 
+  it('variant="subtle" es una línea discreta: sin tarjeta ni botón Entendido, "x" descarta y marca visto', () => {
+    render(
+      <ContextTip id="foto-diagnostico" variant="subtle" emoji="📷" title="¿Una mata enferma? Mándeme una foto">
+        ¿Una mata enferma? Toque la cámara aquí abajo y mándeme la foto.
+      </ContextTip>,
+    );
+    const tip = screen.getByTestId('context-tip-foto-diagnostico');
+    expect(tip.className).not.toMatch(/bg-emerald-950/); // sin fondo de tarjeta
+    expect(screen.queryByRole('button', { name: /^entendido$/i })).toBeNull();
+    expect(screen.getByRole('note')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /entendido, ocultar/i }));
+    expect(screen.queryByTestId('context-tip-foto-diagnostico')).toBeNull();
+    expect(hasSeenTip('foto-diagnostico')).toBe(true);
+  });
+
   it('es no intrusivo: role=note, no dialog modal', () => {
     render(
       <ContextTip id="tip-a11y" emoji="💡" title="Tip">


### PR DESCRIPTION
## Qué cambia
El aviso 📷 '¿Una mata enferma? Mándeme una foto' se mostraba como **tarjeta grande** (emoji 3xl + título bold + botón Entendido de 44px) encima del compositor del chat del agente. El operador la quiere **discreta**.

- `ContextTip`: nueva prop `variant='subtle'` — una sola línea gris pequeña (emoji chico + texto `text-xs` + 'x' para descartar). Misma mecánica `contextTips` (se muestra una vez, descartable, no repite). La variante `card` por defecto queda intacta (VoiceCapture, SoilDiagnosticScreen, RegistroVozScreen no cambian).
- `AgentScreen`: el tip usa `variant='subtle'` con texto de una línea: '¿Una mata enferma? Toque la cámara aquí abajo y mándeme la foto.' Cambio quirúrgico — solo el bloque del tip.
- Test nuevo en `ContextTip.test.jsx` para la variante subtle (sin tarjeta, sin botón Entendido, la 'x' marca visto).

## Por qué así
Opción (a) del encargo: reducirlo a una línea sutil junto al compositor, apuntando al botón de cámara real. Se descartó meterlo en chips (mandato del operador 2026-06-18: capacidades no entran por chips de texto) y el placeholder ya está ocupado por los estados de cola/adjunto.

Colores por tokens slate → theme-aware en los 4 temas sin overrides nuevos en themes.css.

🤖 Generated with [Claude Code](https://claude.com/claude-code)