### PR TITLE
ci(deploy): sirve módulos Pro (VITE_PRO_MODULES_PATH) + preserva /pro-modules del rsync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,6 +137,15 @@ jobs:
           # Los assets vendoreados (TF.js/modelo, ~9 MB) NO se precachean:
           # cache-on-use del SW (WAKE_WORD_PATH_PREFIXES) al activarlo online.
           VITE_MODO_CAMPO: "true"
+          # AVATAR-ESPIRITU / módulos Pro (chagra #2210 + chagra-pro #304):
+          # ruta del bundle Pro pre-construido servido desde el MISMO origen
+          # (mismo-origin ⇒ CSP script-src 'self' lo cubre). loadProModules.js
+          # hace import() dinámico de `${VITE_PRO_MODULES_PATH}/<mod>/index.js`.
+          # Los bundles viven en /mnt/fast/appdata/farmos-pwa/pro-modules/ (montados
+          # manualmente en alpha, FUERA del repo público — anti-leak OSS/Pro). Si
+          # el path no resuelve, el import falla en silencio (try/catch) y la UI
+          # degrada: build puro OSS sin Pro. Preservado del rsync --delete abajo.
+          VITE_PRO_MODULES_PATH: "/pro-modules"
 
       - if: env.SKIP_DEPLOY != '1'
         name: Deploy to production
@@ -180,9 +189,16 @@ jobs:
         #     3) GC de chunks viejos para no crecer infinito: borra archivos en
         #        TARGET/assets/ con mtime > 30 dias. 30 dias cubre de sobra el
         #        tiempo para que un cliente instalado se actualice.
+        #
+        # /pro-modules/ es montado manualmente en el docroot (bundles Pro pre-
+        # construidos de chagra-pro, NO viven en el repo público → no están en
+        # dist/). Sin excluirlo, `rsync --delete` lo consideraría "sobrante" y lo
+        # borraría en cada deploy (mismo patrón que los manuales de escotillas que
+        # ya se perdieron). `--exclude='/pro-modules/'` lo preserva (ADR-002 +
+        # VITE_PRO_MODULES_PATH arriba).
         run: |
           umask 022
-          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' dist/ /mnt/fast/appdata/farmos-pwa/
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' --exclude='/pro-modules/' dist/ /mnt/fast/appdata/farmos-pwa/
           rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ /mnt/fast/appdata/farmos-pwa/assets/
           find /mnt/fast/appdata/farmos-pwa/assets/ -type f -mtime +30 -delete || true
           find /mnt/fast/appdata/farmos-pwa -type f -user runner ! -perm 644 -exec chmod 644 {} + || true


### PR DESCRIPTION
## Qué

Deploy plumbing para la activación del **avatar-espíritu** en prod (chagra #2210 + chagra-pro #304, ruta `#/espiritu`). Cubre 2 de los 3 pasos de despliegue documentados por la migración:

- **(b)** Agrega `VITE_PRO_MODULES_PATH=/pro-modules` al step **Build**. `src/core/loadProModules.js` hace `import()` dinámico de `${VITE_PRO_MODULES_PATH}/<mod>/index.js` (ADR-002: el bundle Pro NO entra al grafo estático de Vite). Mismo-origen ⇒ **CSP `script-src 'self'` lo cubre**.
- **(c)** Agrega `--exclude='/pro-modules/'` al `rsync --delete` del deploy. Los bundles Pro se montan manualmente en `/mnt/fast/appdata/farmos-pwa/pro-modules/` (fuera del repo público, frontera OSS/Pro). Sin excluirlos, `rsync --delete` los borraría en cada deploy (mismo patrón que los manuales de escotillas ya perdidos).

El paso **(a)** — colocar el bundle pre-construido en `/pro-modules/avatar-espiritu-pro/index.js` en alpha — se ejecuta fuera de este repo.

## Seguridad / degradación

- **Inerte hasta go-live**: sin `/pro-modules` en el docroot y sin el módulo en `KNOWN_PRO_MODULES` (chagra #2210), `loadProModules` intenta el import, recibe 404 y lo captura en `try/catch` → build puro OSS. **Cero impacto en usuarios actuales.**
- No toca credenciales ni el árbol público. YAML validado (js-yaml OK).

## Secuencia de go-live (coordinación)

1. Merge de este PR.
2. Merge chagra #2210 (ruta `#/espiritu` + `avatar-espiritu-pro` en `KNOWN_PRO_MODULES`) — **visual, requiere OK del operador**.
3. Merge + build chagra-pro #304 → bundle `avatar-espiritu-pro/index.js`.
4. Colocar el bundle en `/mnt/fast/appdata/farmos-pwa/pro-modules/avatar-espiritu-pro/index.js` (alpha).
5. Deploy → avatar vivo bajo `#/espiritu` (gated, permisivo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)