### PR TITLE
feat(agente): loading states contextuales por fase — la espera muestra avance real

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3609,7 +3609,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         messages={messages}
         streamingContent={streamingContent}
         isStreaming={state === STATE_THINKING}
-        thinkingLabel={MSG.agente.fases[thinkingPhase] || null}
+        thinkingPhase={thinkingPhase}
         onConsentNeeded={handleFeedbackConsentNeeded}
         onRetryOrphan={handleRetryOrphan}
         onCancelDeepResearch={handleCancelDeepResearch}

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -4,6 +4,7 @@ import ChatBubble from './ChatBubble';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import DeepResearchCard from '../DeepResearchCard';
 import InsightProactivoCard from '../Aprende/InsightProactivoCard';
+import ThinkingSteps from './ThinkingSteps';
 import { MSG } from '../../config/messages';
 
 // Bug piloto 2026-06-04 (B): "para devolverme tengo que ir hasta el inicio de
@@ -28,12 +29,14 @@ const FLOATING_BACK_THRESHOLD_PX = 160;
  * @param {Function} props.onCancelDeepResearch - Callback para cancelar una investigación profunda en curso.
  * @param {Function} [props.onAyudaAction] - Callback del deep-link «Abrir …» de la ayuda groundeada (AYUDA_FUNCIONES).
  * @param {Object|null} [props.proactiveGreeting=null] - Datos del saludo proactivo dinámico.
- * @param {string|null} [props.thinkingLabel=null] - Fase visible del pipeline mientras
- *   se espera el primer token ("Entendiendo tu pregunta", "Consultando el catálogo…").
- *   Si es null cae al "Pensando" genérico — perceived performance, la espera avanza.
+ * @param {string|null} [props.thinkingPhase=null] - Fase REAL del pipeline mientras
+ *   se espera el primer token ('entendiendo' | 'consultando' | 'escribiendo' | ...).
+ *   ThinkingSteps la traduce a pasos contextuales con ícono ("Consultando el
+ *   catálogo…" → "Revisando el grafo…") y rota los de la fase larga. Si es
+ *   null cae al "Pensando" genérico — perceived performance, la espera avanza.
  * @param {Function} props.onBack - Callback para volver a la pantalla anterior.
  */
-export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, thinkingLabel = null, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, onDismissInsight, onAyudaAction, proactiveGreeting = null, onBack }) {
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, thinkingPhase = null, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, onDismissInsight, onAyudaAction, proactiveGreeting = null, onBack }) {
   const bottomRef = useRef(null);
   const scrollRef = useRef(null);
   // (B) Botón "Volver" flotante: visible solo cuando el operador se alejó del
@@ -258,7 +261,7 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
             <span>Chagra</span>
           </div>
           <div className="v3-card text-sm italic text-slate-300" aria-live="polite">
-            {thinkingLabel || MSG.agente.pensandoTexto}
+            <ThinkingSteps phase={thinkingPhase} />
             <span className="inline-block ml-1 animate-thinkingDot">·</span>
             <span className="inline-block ml-0.5 animate-thinkingDot [animation-delay:200ms]">·</span>
             <span className="inline-block ml-0.5 animate-thinkingDot [animation-delay:400ms]">·</span>

--- a/src/components/AgentScreen/ThinkingSteps.jsx
+++ b/src/components/AgentScreen/ThinkingSteps.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import { MSG } from '../../config/messages';
+
+/**
+ * ThinkingSteps — loading contextual por fase mientras el agente "piensa"
+ * (lever de velocidad PERCIBIDA: ataca la queja "se queda pensando").
+ *
+ * La fase REAL la emite el pipeline de AgentScreen (thinkingPhase):
+ *   'transcribiendo' → 'entendiendo' → 'consultando' → 'escribiendo'.
+ * Dentro de cada fase, MSG.agente.fasesPasos define 1..N pasos {icon, texto}.
+ * La fase larga ('consultando': grounding contra el sidecar — catálogo,
+ * grafo AGE, guards) rota sus pasos cada STEP_ROTATE_MS como secuencia
+ * temporizada creíble: avanza y SE QUEDA en el último (nunca loopea hacia
+ * atrás — el avance debe sentirse hacia adelante). Al cambiar la fase real,
+ * el índice se resetea.
+ *
+ * Accesibilidad:
+ *   - Lectores de pantalla: el contenedor del ChatHistory ya es aria-live
+ *     polite. Para no parlotear cada 2s, el texto rotativo va aria-hidden y
+ *     un span sr-only anuncia SOLO la fase real (cambia con eventos reales).
+ *   - prefers-reduced-motion: se apaga el fade de entrada (animation: none).
+ *     El texto SÍ sigue cambiando — es información de estado, no decoración;
+ *     congelarlo devolvería la sensación de "colgado" que este componente
+ *     existe para eliminar.
+ */
+const STEP_ROTATE_MS = 2000;
+
+export default function ThinkingSteps({ phase }) {
+  const steps = (phase && MSG.agente.fasesPasos[phase]) || null;
+  const [stepIdx, setStepIdx] = useState(0);
+
+  useEffect(() => {
+    // Fase nueva (evento real del pipeline) → arrancar en su primer paso.
+    setStepIdx(0);
+    const count = (phase && MSG.agente.fasesPasos[phase] || []).length;
+    if (count <= 1) return undefined;
+    const id = setInterval(() => {
+      // Avanza y se detiene en el último paso (setState idéntico → React
+      // no re-renderiza; el interval residual es inofensivo y se limpia al
+      // cambiar de fase o desmontar).
+      setStepIdx((i) => Math.min(i + 1, count - 1));
+    }, STEP_ROTATE_MS);
+    return () => clearInterval(id);
+  }, [phase]);
+
+  // Fase desconocida o null (p. ej. Deep Research u otro flujo que no setea
+  // thinkingPhase) → "Pensando" genérico, el comportamiento de siempre.
+  if (!steps || steps.length === 0) {
+    return <span>{MSG.agente.pensandoTexto}</span>;
+  }
+
+  const step = steps[Math.min(stepIdx, steps.length - 1)];
+  const faseLabel = MSG.agente.fases[phase] || MSG.agente.pensandoTexto;
+
+  return (
+    <>
+      <style>{THINKING_STEPS_CSS}</style>
+      {/* Anuncio estable para lectores de pantalla: solo la fase real. */}
+      <span className="sr-only">{faseLabel}</span>
+      {/* key por fase+paso re-monta el span → replay del fade de entrada. */}
+      <span
+        key={`${phase}-${stepIdx}`}
+        className="chagra-thinking-step"
+        data-testid="thinking-step"
+        data-phase={phase}
+        aria-hidden="true"
+      >
+        <span className="chagra-thinking-step-icon">{step.icon}</span>
+        {step.texto}
+      </span>
+    </>
+  );
+}
+
+/**
+ * CSS del paso rotativo. Fade+rise corto al entrar cada paso; neutralizado
+ * bajo prefers-reduced-motion siguiendo el patrón del proyecto (agentEntrance,
+ * FLOATING_BACK_CSS). El ícono fuerza font-style normal porque la tarjeta
+ * "pensando" del ChatHistory es italic y el emoji heredaría la inclinación.
+ */
+const THINKING_STEPS_CSS = `
+@keyframes chagra-thinking-step-kf {
+  0% { opacity: 0; transform: translateY(3px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+.chagra-thinking-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  animation: chagra-thinking-step-kf 260ms ease-out both;
+}
+.chagra-thinking-step-icon { font-style: normal; }
+@media (prefers-reduced-motion: reduce) {
+  .chagra-thinking-step { animation: none !important; }
+}
+`;

--- a/src/components/AgentScreen/__tests__/ThinkingSteps.test.jsx
+++ b/src/components/AgentScreen/__tests__/ThinkingSteps.test.jsx
@@ -1,0 +1,86 @@
+/**
+ * Tests para ThinkingSteps — loading contextual por fase del "pensando"
+ * (lever de velocidad PERCIBIDA: reemplaza el spinner mudo).
+ *
+ * Contrato:
+ *   - Fase real del pipeline (thinkingPhase) → paso contextual ícono+texto.
+ *   - Fase larga 'consultando' rota sus pasos cada ~2s SIN loopear:
+ *     catálogo → grafo → fuentes, y se queda en el último.
+ *   - Cambio de fase real resetea al primer paso de la fase nueva.
+ *   - Fase null/desconocida → "Pensando" genérico (comportamiento previo).
+ *   - a11y: texto rotativo aria-hidden + sr-only con la fase real estable.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import ThinkingSteps from '../ThinkingSteps.jsx';
+import { MSG } from '../../../config/messages';
+
+describe('ThinkingSteps — loading contextual por fase', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fase null cae al "Pensando" genérico', () => {
+    render(<ThinkingSteps phase={null} />);
+    expect(screen.getByText(MSG.agente.pensandoTexto)).toBeTruthy();
+    expect(screen.queryByTestId('thinking-step')).toBeNull();
+  });
+
+  it('fase desconocida cae al "Pensando" genérico', () => {
+    render(<ThinkingSteps phase="fase-inventada" />);
+    expect(screen.getByText(MSG.agente.pensandoTexto)).toBeTruthy();
+  });
+
+  it("fase 'entendiendo' muestra su paso con ícono", () => {
+    render(<ThinkingSteps phase="entendiendo" />);
+    const step = screen.getByTestId('thinking-step');
+    expect(step.textContent).toContain('Entendiendo tu pregunta');
+    expect(step.textContent).toContain('🌱');
+  });
+
+  it("fase 'consultando' rota catálogo → grafo → fuentes y se queda en el último", () => {
+    render(<ThinkingSteps phase="consultando" />);
+    expect(screen.getByTestId('thinking-step').textContent).toContain('Consultando el catálogo');
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(screen.getByTestId('thinking-step').textContent).toContain('Revisando el grafo de tu finca');
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(screen.getByTestId('thinking-step').textContent).toContain('Verificando las fuentes');
+
+    // Sin loop hacia atrás: mucho después sigue en el último paso.
+    act(() => vi.advanceTimersByTime(10000));
+    expect(screen.getByTestId('thinking-step').textContent).toContain('Verificando las fuentes');
+  });
+
+  it('cambio de fase real resetea al primer paso de la fase nueva', () => {
+    const { rerender } = render(<ThinkingSteps phase="consultando" />);
+    act(() => vi.advanceTimersByTime(4000)); // → último paso (fuentes)
+    expect(screen.getByTestId('thinking-step').textContent).toContain('Verificando las fuentes');
+
+    rerender(<ThinkingSteps phase="escribiendo" />);
+    const step = screen.getByTestId('thinking-step');
+    expect(step.textContent).toContain('Preparando la respuesta');
+    expect(step.textContent).toContain('✍️');
+  });
+
+  it('fases de UN paso no programan rotación (no cambia con el tiempo)', () => {
+    render(<ThinkingSteps phase="escribiendo" />);
+    act(() => vi.advanceTimersByTime(8000));
+    expect(screen.getByTestId('thinking-step').textContent).toContain('Preparando la respuesta');
+  });
+
+  it('a11y: paso rotativo aria-hidden + sr-only anuncia solo la fase real', () => {
+    render(<ThinkingSteps phase="consultando" />);
+    const step = screen.getByTestId('thinking-step');
+    expect(step.getAttribute('aria-hidden')).toBe('true');
+    // El sr-only lleva el label de la fase real (estable, no rota cada 2s).
+    expect(screen.getByText(MSG.agente.fases.consultando).className).toContain('sr-only');
+    act(() => vi.advanceTimersByTime(2000));
+    expect(screen.getByText(MSG.agente.fases.consultando).className).toContain('sr-only');
+  });
+});

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -105,6 +105,23 @@ const messages = {
       consultando: 'Consultando el catálogo y tu chagra',
       escribiendo: 'Escribiendo tu respuesta',
     },
+    // Loading contextual (lever de velocidad PERCIBIDA): PASOS visibles dentro
+    // de cada fase del "pensando". La fase REAL la marca el pipeline
+    // (thinkingPhase en AgentScreen); dentro de 'consultando' — el tramo más
+    // largo (grounding: catálogo + grafo AGE + guards/fuentes) — los pasos
+    // rotan temporizados (~2s, sin loop: avanzan y se quedan en el último)
+    // para que la espera de 22-34s se sienta viva y con avance, no colgada.
+    // Ícono + texto corto: legible para baja alfabetización.
+    fasesPasos: {
+      transcribiendo: [{ icon: '🎙️', texto: 'Escuchando tu voz' }],
+      entendiendo: [{ icon: '🌱', texto: 'Entendiendo tu pregunta' }],
+      consultando: [
+        { icon: '📖', texto: 'Consultando el catálogo' },
+        { icon: '🌾', texto: 'Revisando el grafo de tu finca' },
+        { icon: '🔍', texto: 'Verificando las fuentes' },
+      ],
+      escribiendo: [{ icon: '✍️', texto: 'Preparando la respuesta' }],
+    },
     confianzaAlta: 'Confianza alta',
     confianzaMedia: 'Confianza media',
     confianzaBaja: 'Confianza baja',


### PR DESCRIPTION
## Qué
Lever de velocidad PERCIBIDA: reemplaza el label estático del "pensando" del agente por **pasos contextuales con ícono** que muestran en qué va el pipeline. Ataca directo la queja "se queda pensando" en esperas de 22-34s.

## Fases visibles
El esqueleto son las fases **REALES** del pipeline (`thinkingPhase`, ya emitidas por AgentScreen en los puntos reales: submit → grounding sidecar → generación LLM). Dentro de la fase larga `consultando` (grounding: catálogo + grafo AGE + guards — el tramo que más dura), los pasos rotan **temporizados cada 2s, sin loop** (avanzan y se quedan en el último):

1. 🌱 Entendiendo tu pregunta *(evento real: submit)*
2. 📖 Consultando el catálogo *(evento real: entra al grounding)*
3. 🌾 Revisando el grafo de tu finca *(temporizado +2s)*
4. 🔍 Verificando las fuentes *(temporizado +4s, se queda aquí)*
5. ✍️ Preparando la respuesta *(evento real: arranca la generación)*

Voz añade 🎙️ *Escuchando tu voz* al inicio (evento real: transcripción).

## Cómo (quirúrgico)
- `ThinkingSteps.jsx` **nuevo**: componente autocontenido; resetea al primer paso con cada fase real; fase null/desconocida cae al "Pensando" genérico de siempre.
- `ChatHistory.jsx`: prop `thinkingLabel` (string) → `thinkingPhase` (clave), render del componente. Los puntos suspensivos animados quedan igual.
- `AgentScreen.jsx`: **UNA línea** (pasa `thinkingPhase` crudo). El pipeline delicado queda intacto — cero `setThinkingPhase` nuevos.
- Copy en `MSG.agente.fasesPasos` (ícono + texto corto — baja alfabetización).

## a11y
- `sr-only` anuncia solo la fase real (el contenedor es `aria-live=polite`; sin esto parlotearía cada 2s). El paso rotativo va `aria-hidden`.
- `prefers-reduced-motion`: apaga el fade de entrada; el texto SÍ sigue cambiando (es información de estado — congelarlo devolvería la sensación de colgado).

## Tests
- 7 unitarios nuevos (`ThinkingSteps.test.jsx`, fake timers): rotación, no-loop, reset por fase, fallback genérico, a11y.
- Tests adyacentes de ChatHistory (backButton, greeting) verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)