### PR TITLE
fix(agente): quitar caja morada 'está pensando' redundante

### DIFF
--- a/src/components/AgentScreen/VoiceStatusStrip.jsx
+++ b/src/components/AgentScreen/VoiceStatusStrip.jsx
@@ -95,7 +95,7 @@ export default function VoiceStatusStrip({
   const showRepeat = phase === 'idle' && canRepeat && typeof onRepeat === 'function';
   const showNotice = typeof notice === 'string' && notice.length > 0;
 
-  if (!isListening && !isThinking && !isSpeaking && !showRepeat && !showNotice) {
+  if (!isListening && !isSpeaking && !showRepeat && !showNotice) {
     return null;
   }
 
@@ -104,7 +104,7 @@ export default function VoiceStatusStrip({
       <style>{STRIP_CSS}</style>
 
       {/* Estado activo: ícono + animación + frase corta, grande y legible */}
-      {(isListening || isThinking || isSpeaking) && (
+      {(isListening || isSpeaking) && (
         <div
           className={`flex items-center gap-3 rounded-2xl px-4 py-3 border ${
             isListening


### PR DESCRIPTION
El operador: la caja morada 'Chagra está pensando' de abajo sobra (redundante con los estados de carga contextuales de #2219), fea y distrae. Se suprime el estado thinking del VoiceStatusStrip; escuchando/hablando quedan. 🤖 Generated with [Claude Code](https://claude.com/claude-code)