### PR TITLE
feat(agent): footer cientifico deterministico

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -102,6 +102,7 @@ import DeepResearchCard from '../DeepResearchCard';
 import { normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildPriceAnswer, buildSuggestedEntitiesContext, isLowConfidenceEntity, buildFallbackResponse, pisoTermicoFromAltitud, groupAndLimitCultivos } from '../../services/agentService';
 import { buildPriceReferenceAnswer } from '../../services/marketplaceService';
 import { buildBasePrompt, analyzeQuery, buildQueryAnalysisBlock, buildCorpusVariants, buildResolvedEntitiesBlock, formatToolEvidence, truncateEdgesBlock } from '../../services/agentPromptBase';
+import { appendScientificFooter } from '../../services/semaforoConfianza';
 // Nubosidad real para el grounding (fix Choachí 2026-06) — solo lee caches.
 import { summarizeSkyForGrounding } from '../../services/skyConditionService';
 import { assembleSystemContent, TOP_N_RAG } from '../../services/promptAssembler';
@@ -2270,7 +2271,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // `valid`—. La cobertura taxonómica la dan los guards síncronos de
       // applyOutputGuards (#1332 binomio benéfico + 5/5b sustitución/companion)
       // y el grounding de resolve-entities. Ver outputGuards.js.
-      let response = guarded.text;
+      const responseBody = guarded.text;
       agentSounds.chime();
 
       const { intent } = parseIntent(text);
@@ -2324,6 +2325,17 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         ...groundingSemaphoreMeta,
         auto_corrected: guarded.modified === true,
       };
+      const profileMode = (() => {
+        try {
+          return getProfile()?.nivel_respuestas || '';
+        } catch (_) {
+          return '';
+        }
+      })();
+      const response = appendScientificFooter(responseBody, {
+        mode: profileMode,
+        metadata: sourceMetadata,
+      });
 
       // AFFECTS-GATE (auditoría anti-contaminación cruzada de cultivo, 2026-07):
       // el sello "Catálogo verificado" NO debe pintarse cuando la evidencia
@@ -2354,7 +2366,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                 .filter((e) => e && (['pest', 'plaga'].includes(e.kind)))
                 .map((e) => resolvePestAffects(e.canonical_id || e.mentioned, maps))
                 .filter(Boolean),
-              ...scanTextForPestAffects(response, maps),
+              ...scanTextForPestAffects(responseBody, maps),
             ];
             const gateResult = detectCrossCropContamination({ cropInFocusIds, pestAffectsList });
             if (gateResult.crossCrop) {
@@ -2392,7 +2404,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             .map((e) => e?.nombre_cientifico)
             .filter((n) => typeof n === 'string' && n.trim().length > 0);
           if (expected.length > 0) {
-            const pv = await postValidate(response, expected);
+            const pv = await postValidate(responseBody, expected);
             sourceMetadata = mergePostValidateMetadata(sourceMetadata, pv);
             if (sourceMetadata.hallucinated_names || sourceMetadata.suspect_names) {
               console.debug('[sidecar] post-validate flags', {
@@ -2422,7 +2434,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // expandir el dato. Funciones puras (detectarSlugEnTexto/elegirInsight).
       let insightProactivo = null;
       try {
-        const textoTurno = `${text || ''} ${response || ''}`;
+        const textoTurno = `${text || ''} ${responseBody || ''}`;
         const slug = detectarSlugEnTexto(textoTurno);
         if (slug) {
           const candidato = elegirInsight(slug, insightsVistosRef.current);
@@ -2541,11 +2553,11 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           // latencia hasta-primer-audio de "esperar respuesta entera"
           // (3-23s) a "esperar primera frase" (<2s). Internamente fallback
           // a speakKokoro/speak en caso de error en la primera frase.
-          speakSentences(response, { rate: 0.9, pitch: 1.0 })
+          speakSentences(responseBody, { rate: 0.9, pitch: 1.0 })
             .then((ok) => { if (!ok) warnIfMute(); })
             .catch(() => warnIfMute());
         } else {
-          const utterance = speak(response, { rate: 0.9, pitch: 1.0 });
+          const utterance = speak(responseBody, { rate: 0.9, pitch: 1.0 });
           if (!utterance) warnIfMute();
         }
       }
@@ -2567,7 +2579,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             ...(intent.quantity && intent.unit && { quantity: intent.quantity, unit: intent.unit }),
           },
           intent: text,
-          llm_response: response,
+          llm_response: responseBody,
           timestamp: new Date().toISOString(),
         };
         const result = await executeAction(proposal, operatorId);

--- a/src/services/__tests__/agentPromptBase.expertMode.test.js
+++ b/src/services/__tests__/agentPromptBase.expertMode.test.js
@@ -30,13 +30,9 @@ describe('buildModoExpertoBlock', () => {
 
     expect(block).toContain('=== MODO EXPERTO ===');
     expect(block).toContain('=== FIN ===');
-    expect(block).toContain('CONTRATO CITA:');
-    expect(block).toContain('científico exacto');
-    expect(block).toContain('dosis con unidad');
-    expect(block).toContain('mecanismo de acción');
-    expect(block).toContain('piso térmico');
-    expect(block).toContain('ENTIDADES RESUELTAS');
-    expect(block).toContain('DATOS VERIFICADOS');
+    expect(block).toContain('CONTRATO TÉCNICO:');
+    expect(block).toContain('evidencia disponible');
+    expect(block).not.toContain('citado');
   });
 
   it('INYECTA bloque SIN grounding cuando nivel es "detallado" pero hasGrounding es false', () => {
@@ -61,8 +57,8 @@ describe('buildModoExpertoBlock', () => {
     const block = buildModoExpertoBlock({ nivelRespuestas: 'detallado', hasGrounding: true });
 
     expect(block).toContain('RESPUESTA:');
-    expect(block).toContain('preciso, citado');
-    expect(block).toContain('honesto cuando no la haya');
+    expect(block).toContain('preciso y honesto');
+    expect(block).toContain('Si hay evidencia, úsala con claridad');
   });
 });
 
@@ -206,9 +202,9 @@ describe('integración buildResponseModeBlock con experto estructurado', () => {
     expect(block).toContain('CONTRATO TÉCNICO');
   });
 
-  it('buildResponseModeBlock("detallado", true) devuelve CONTRATO CITA', () => {
+  it('buildResponseModeBlock("detallado", true) devuelve CONTRATO TÉCNICO', () => {
     const block = buildResponseModeBlock('detallado', true);
-    expect(block).toContain('CONTRATO CITA:');
+    expect(block).toContain('CONTRATO TÉCNICO:');
   });
 
   it('buildResponseModeBlock("simple") NO devuelve MODO EXPERTO', () => {

--- a/src/services/__tests__/promptAssembler.budget.test.js
+++ b/src/services/__tests__/promptAssembler.budget.test.js
@@ -433,17 +433,14 @@ describe('presupuesto del prompt ensamblado (regresión GR-10)', () => {
       expect(assembled.content).not.toContain('=== MODO EXPERTO ===');
     });
 
-    it('INYECTA MODO EXPERTO CONTRATO CITA cuando nivelRespuestas es "detallado" con grounding', () => {
+    it('INYECTA MODO EXPERTO CONTRATO TÉCNICO cuando nivelRespuestas es "detallado" con grounding', () => {
       const { assembled } = assembleForQuery({
         ...QUERIES.q1_relacional,
         nivelRespuestas: 'detallado',
       });
       expect(assembled.content).toContain('=== MODO EXPERTO ===');
-      expect(assembled.content).toContain('CONTRATO CITA:');
-      expect(assembled.content).toContain('científico exacto');
-      expect(assembled.content).toContain('dosis con unidad');
-      expect(assembled.content).toContain('mecanismo de acción');
-      expect(assembled.content).toContain('piso térmico');
+      expect(assembled.content).toContain('CONTRATO TÉCNICO:');
+      expect(assembled.content).toContain('evidencia disponible');
     });
 
     it('INYECTA MODO EXPERTO CONTRATO TÉCNICO cuando es "detallado" sin grounding', () => {

--- a/src/services/__tests__/semaforoConfianza.test.js
+++ b/src/services/__tests__/semaforoConfianza.test.js
@@ -20,6 +20,8 @@ import {
   confianzaPorcentaje,
   SEMAFORO_COPY,
   MOTIVO_COPY,
+  buildScientificFooter,
+  appendScientificFooter,
 } from '../semaforoConfianza';
 
 const item = (overrides = {}) => ({
@@ -231,5 +233,46 @@ describe('nivelValidacionInfo / humanizarEntidad / confianzaPorcentaje', () => {
     expect(confianzaPorcentaje(NaN)).toBeNull();
     expect(confianzaPorcentaje('x')).toBeNull();
     expect(confianzaPorcentaje(null)).toBeNull();
+  });
+});
+
+describe('footer cientifico deterministico', () => {
+  const metadata = {
+    grounding_semaphore: 'verde',
+    grounding_policy: 'answer',
+    grounding_provenance: [
+      {
+        entity_id: 'coffea-arabica',
+        confidence: 0.91,
+        source: 'https://doi.org/10.1016/j.cropro.2020.105123',
+        validation_level: 'published',
+      },
+      {
+        entity_id: 'coffea-arabica',
+        confidence: 0.88,
+        source: 'Agrosavia',
+        validation_level: 'expert_reviewed',
+      },
+    ],
+  };
+
+  it('buildScientificFooter arma fuentes + semaforo desde la metadata', () => {
+    const footer = buildScientificFooter({ metadata });
+    expect(footer).toContain('Fuentes: DOI 10.1016/j.cropro.2020.105123 + Agrosavia.');
+    expect(footer).toContain('Semáforo: verde, Dato respaldado.');
+  });
+
+  it('appendScientificFooter adjunta el footer aunque la respuesta base no cite nada', () => {
+    const base = 'La recomendacion es revisar el drenaje y evitar encharcamientos.';
+    const decorated = appendScientificFooter(base, { mode: 'detallado', metadata });
+    expect(decorated).toContain(base);
+    expect(decorated).toContain('Fuentes: DOI 10.1016/j.cropro.2020.105123 + Agrosavia.');
+    expect(decorated).toContain('Semáforo: verde, Dato respaldado.');
+    expect(decorated).not.toBe(base);
+  });
+
+  it('appendScientificFooter deja intacto el modo campesino', () => {
+    const base = 'Mire, revise el drenaje y no encharque el lote.';
+    expect(appendScientificFooter(base, { mode: 'simple', metadata })).toBe(base);
   });
 });

--- a/src/services/agentPromptBase.js
+++ b/src/services/agentPromptBase.js
@@ -371,9 +371,8 @@ export function buildExpertModeBlock() {
 
 /**
  * buildModoExpertoBlock — bloque MODO EXPERTO ESTRUCTURADO con CONTRATO
- * verificable. Reemplaza el experto simple con un bloque que exige nombre
- * científico, dosis con unidad, mecanismo de acción y piso térmico cuando
- * el grounding lo provea.
+ * verificable. Reemplaza el experto simple con un bloque que pide precisión
+ * y honestidad cuando hay grounding, sin delegar la trazabilidad al modelo.
  *
  * @param {object} opts
  * @param {string} [opts.nivelRespuestas] - 'simple' | 'detallado'
@@ -386,13 +385,13 @@ export function buildModoExpertoBlock(opts = {}) {
   if (nivelRespuestas !== 'detallado') return '';
 
   const contrato = hasGrounding
-    ? `CONTRATO CITA: científico exacto de ENTIDADES RESUELTAS/DATOS VERIFICADOS, dosis con unidad (ej: 1x10^9 conidias/mL), mecanismo de acción, piso térmico si grounding la menciona.`
+    ? `CONTRATO TÉCNICO: usa la evidencia disponible con precisión; no inventes datos numéricos, dosis ni nombres científicos.`
     : `CONTRATO TÉCNICO: profundiza en por qué/factores/integración; si no hay datos del catálogo, dilo explícitamente.`;
 
   return `=== MODO EXPERTO ===
 ${contrato}
 PROHIBICIONES: NO uses técnica para disimular incertidumbre; NO inventes dosis/datos numéricos; NO mezcles datos de especies.
-RESPUESTA: preciso, citado cuando hay evidencia, honesto cuando no la haya.
+RESPUESTA: preciso y honesto. Si hay evidencia, úsala con claridad; si no la hay, dilo de frente.
 === FIN ===`;
 }
 
@@ -680,13 +679,6 @@ Responde en español colombiano (tú/usted, sin voseo argentino). Sé específic
   // buildResponseModeBlock arriba a partir de nivel_respuestas; NO reenviamos
   // nivelRespuestas a buildProfileContext para no duplicar el bloque de nivel.
   sections.push(buildProfileContext(finca, { climaQuery: CLIMA_QUERY_RE.test(mention) }));
-
-  if (profileMode === 'experto') {
-    const footer = buildSourceFooter({ toolEvidence, resolvedEntities, hasCorpus });
-    if (footer) {
-      sections.push(footer.replace(/^\n\n/, ''));
-    }
-  }
 
   return sections.join('\n\n');
 }

--- a/src/services/semaforoConfianza.js
+++ b/src/services/semaforoConfianza.js
@@ -356,3 +356,75 @@ export function confianzaPorcentaje(confidence) {
   if (!Number.isFinite(n)) return null;
   return Math.round(Math.min(1, Math.max(0, n)) * 100);
 }
+
+function normalizeResponseMode(mode) {
+  if (!mode || typeof mode !== 'string') return '';
+  const normalized = mode.toLowerCase().trim();
+  if (['simple', 'campesino', 'campesina', 'rural'].includes(normalized)) return 'campesino';
+  if (['detallado', 'detallada', 'experto', 'experta', 'tecnico', 'técnico'].includes(normalized)) return 'experto';
+  if (['maestro', 'maestra', 'profesor', 'profesora', 'mentor'].includes(normalized)) return 'maestro';
+  return '';
+}
+
+function uniquePush(list, value) {
+  if (value && !list.includes(value)) list.push(value);
+}
+
+function buildSourceLineFromProvenance(provenance) {
+  const items = Array.isArray(provenance)
+    ? provenance.filter((p) => p && typeof p === 'object')
+    : [];
+  const sources = [];
+  for (const item of items) {
+    const { label } = describeFuente(item.source);
+    uniquePush(sources, label);
+  }
+  if (sources.length === 0) return '';
+  return `Fuentes: ${sources.join(' + ')}.`;
+}
+
+/**
+ * Construye el footer visible del modo científico desde la metadata ya
+ * persistida del turno. El modelo no tiene que citar nada: el código toma la
+ * procedencia y el semáforo y los pinta al final de la respuesta.
+ *
+ * @param {object} [opts]
+ * @param {object|null|undefined} [opts.metadata] metadata del turno.
+ * @returns {string}
+ */
+export function buildScientificFooter({ metadata } = {}) {
+  const semaforo = computeSemaforoTurno(metadata);
+  if (!semaforo) return '';
+
+  const provenance = Array.isArray(metadata?.grounding_provenance)
+    ? metadata.grounding_provenance.filter((p) => p && typeof p === 'object')
+    : [];
+  const sourceLine = buildSourceLineFromProvenance(provenance);
+  if (!sourceLine) return '';
+
+  const copy = SEMAFORO_COPY[semaforo.nivel] || SEMAFORO_COPY.ambar;
+  return `\n\n---\n\n${sourceLine}\nSemáforo: ${semaforo.nivel}, ${copy.label}.`;
+}
+
+/**
+ * Aplica el footer científico de forma determinística a una respuesta ya
+ * generada. En modo campesino deja el texto intacto. En modo experto o
+ * maestro agrega el pie visible con fuentes + semáforo.
+ *
+ * @param {string} response
+ * @param {object} [opts]
+ * @param {string} [opts.mode]
+ * @param {object|null|undefined} [opts.metadata]
+ * @returns {string}
+ */
+export function appendScientificFooter(response, opts = {}) {
+  const text = typeof response === 'string' ? response : '';
+  if (!text) return '';
+
+  const mode = normalizeResponseMode(opts.mode);
+  if (mode !== 'experto' && mode !== 'maestro') return text;
+
+  const footer = buildScientificFooter({ metadata: opts.metadata });
+  if (!footer) return text;
+  return `${text}${footer}`;
+}


### PR DESCRIPTION
## Summary\n- Forces the scientific/expert response footer in code after the model returns, using grounding provenance plus the confidence semaphore.\n- Removes the citation ask from the expert prompt path, so the model is not relied on for citations.\n- Keeps campesino mode free of the academic footer.\n\n## Test plan\n- npx vitest run src/services/__tests__/semaforoConfianza.test.js src/services/__tests__/agentPromptBase.expertMode.test.js src/services/__tests__/promptAssembler.budget.test.js\n- npm run build\n- npx vitest run exposed unrelated preexisting failures in other areas of the repo; they are not caused by this patch.\n- npx eslint . --max-warnings=0 did not complete in this environment, so I also checked the touched files with the same command and it stalled there as well.