### PR TITLE
fix(mundos): ruta #quinua, truncado del header, banner PWA y crédito poscosecha

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -539,6 +539,24 @@ const HASH_VIEW_ROUTES = {
   penca: 'fique',
   furcraea: 'fique',
   fibras: 'fique',
+  // Mundo "Quinua y granos andinos" (dentro de Cultivos y semillas). El switch
+  // ya tenía el `case 'quinua'` pero faltaba la ruta hash → #quinua caía al
+  // dashboard (bug funcional QA-VISUAL-MUNDOS 2026-07-08: mundo inalcanzable por
+  // deep-link/QR). Aliases = los granos que cubre + nombre científico, igual
+  // que los mundos hermanos (mango→mangifera, uchuva→physalis).
+  quinua: 'quinua',
+  'granos-andinos': 'quinua',
+  'granos-ancestrales': 'quinua',
+  granos: 'quinua',
+  quinoa: 'quinua',
+  chenopodium: 'quinua',
+  amaranto: 'quinua',
+  bledo: 'quinua',
+  chia: 'quinua',
+  chía: 'quinua',
+  cañihua: 'quinua',
+  canihua: 'quinua',
+  tarwi: 'quinua',
   'milpa-cultivo': 'milpa_cultivo',
   'tres-hermanas': 'milpa_cultivo',
   'salud-suelo': 'salud_suelo',

--- a/src/__tests__/App.install-banner-login-gate.test.jsx
+++ b/src/__tests__/App.install-banner-login-gate.test.jsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
 // Test de REGRESIÓN VISUAL (bug prod 2026-06-25): el prompt de instalación PWA
-// (IosInstallBanner / AndroidInstallBanner) es un overlay `fixed bottom-24
+// (IosInstallBanner / AndroidInstallBanner) es un overlay `fixed bottom-20
 // left-1/2 z-50` y se renderizaba en TODAS las vistas, incluida la de login.
 // Sobre el formulario de login (campos Usuario/Contraseña/Ingresar) se encimaba:
 // en desktop tapaba e interceptaba el clic del campo "Usuario"; en móvil empujaba

--- a/src/components/AndroidInstallBanner.jsx
+++ b/src/components/AndroidInstallBanner.jsx
@@ -68,13 +68,17 @@ const AndroidInstallBanner = () => {
   if (installed || dismissed || !canInstall) return null;
 
   return (
-    <div className="pwa-install-banner fixed bottom-24 left-1/2 -translate-x-1/2 z-50 w-11/12 max-w-md animate-in fade-in slide-in-from-bottom-5 duration-500">
-      <div className="bg-slate-900 border border-slate-700 shadow-2xl rounded-2xl p-4 flex items-center gap-3 relative overflow-hidden">
+    <div className="pwa-install-banner fixed bottom-20 left-1/2 -translate-x-1/2 z-50 w-11/12 max-w-md animate-in fade-in slide-in-from-bottom-5 duration-500">
+      {/* Footprint compacto (QA-VISUAL-MUNDOS 2026-07-08): el banner tapaba
+          ~150px del contenido inferior en móvil. Se bajó (bottom-24→bottom-20) y
+          se compactó (p-4→p-2.5, ícono 24→20) para que quepa dentro del pb del
+          contenido y deje de tapar los CTAs del final de página. */}
+      <div className="bg-slate-900 border border-slate-700 shadow-2xl rounded-2xl p-2.5 flex items-center gap-2.5 relative overflow-hidden">
         {/* Acento bio-punk, igual que IosInstallBanner */}
         <div className="absolute top-0 left-0 w-1 h-full bg-muzo-glow" />
 
-        <div className="bg-muzo-glow/20 p-2 rounded-xl flex-shrink-0">
-          <Download className="text-muzo-glow" size={24} />
+        <div className="bg-muzo-glow/20 p-1.5 rounded-xl flex-shrink-0">
+          <Download className="text-muzo-glow" size={20} />
         </div>
 
         <div className="flex-1 min-w-0">

--- a/src/components/IosInstallBanner.jsx
+++ b/src/components/IosInstallBanner.jsx
@@ -27,13 +27,16 @@ const IosInstallBanner = () => {
     if (!showBanner) return null;
 
     return (
-        <div className="pwa-install-banner fixed bottom-24 left-1/2 -translate-x-1/2 z-50 w-11/12 max-w-md animate-in fade-in slide-in-from-bottom-5 duration-500">
-            <div className="bg-slate-900 border border-slate-700 shadow-2xl rounded-2xl p-4 flex items-center gap-4 relative overflow-hidden">
+        <div className="pwa-install-banner fixed bottom-20 left-1/2 -translate-x-1/2 z-50 w-11/12 max-w-md animate-in fade-in slide-in-from-bottom-5 duration-500">
+            {/* Footprint compacto (QA-VISUAL-MUNDOS 2026-07-08): mismo ajuste que
+                el banner de Android — bajado y compactado para no tapar los CTAs
+                del final de página en móvil. */}
+            <div className="bg-slate-900 border border-slate-700 shadow-2xl rounded-2xl p-2.5 flex items-center gap-2.5 relative overflow-hidden">
                 {/* Bio-punk accent */}
                 <div className="absolute top-0 left-0 w-1 h-full bg-muzo-glow"></div>
 
-                <div className="bg-muzo-glow/20 p-2 rounded-xl flex-shrink-0">
-                    <Share className="text-muzo-glow" size={24} />
+                <div className="bg-muzo-glow/20 p-1.5 rounded-xl flex-shrink-0">
+                    <Share className="text-muzo-glow" size={20} />
                 </div>
 
                 <div className="flex-1">

--- a/src/components/PoscosechaScreen.jsx
+++ b/src/components/PoscosechaScreen.jsx
@@ -59,7 +59,7 @@ function CreditoFoto({ slug, className = '' }) {
       href={c.fuenteUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className={`pc-focus flex items-center gap-1 truncate text-[9px] text-slate-300 underline decoration-slate-600 underline-offset-2 ${className}`}
+      className={`pc-focus flex items-center gap-1 truncate text-[9px] text-slate-100 underline decoration-slate-400 underline-offset-2 [text-shadow:0_1px_2px_rgba(0,0,0,0.9)] ${className}`}
       title={`${c.autor} · ${c.licencia} · Wikimedia Commons`}
     >
       <Camera size={9} className="shrink-0" aria-hidden="true" />
@@ -79,7 +79,9 @@ function Foto({ slug, ratio = 'aspect-[16/10]', className = '' }) {
         loading="lazy"
         className={`pc-photo w-full ${ratio} object-cover`}
       />
-      <figcaption className="absolute inset-x-0 bottom-0 bg-slate-950/82 px-2 py-1 backdrop-blur-sm">
+      {/* Franja del crédito: fondo casi opaco para pasar contraste incluso sobre
+          fotos claras (p.ej. el gorgojo blanco) — QA-VISUAL-MUNDOS 2026-07-08. */}
+      <figcaption className="absolute inset-x-0 bottom-0 bg-slate-950/90 px-2 py-1 backdrop-blur-sm">
         <CreditoFoto slug={slug} />
       </figcaption>
     </figure>
@@ -206,7 +208,7 @@ function Hub({ onIr, onNavigate }) {
           />
           {/* Velo de contraste para leer sobre la foto (gradiente estático, sin filter) */}
           <div className="absolute inset-0 bg-gradient-to-t from-slate-950/95 via-slate-950/35 to-slate-950/5" aria-hidden="true" />
-          <span className="absolute top-2 right-2 rounded-full bg-slate-950/80 px-2 py-0.5 max-w-[70%]">
+          <span className="absolute top-2 right-2 rounded-full bg-slate-950/90 px-2 py-0.5 max-w-[70%]">
             <CreditoFoto slug="secado-maiz" />
           </span>
           <div className="absolute inset-x-0 bottom-0 px-4 pb-3">

--- a/src/components/common/ScreenShell.jsx
+++ b/src/components/common/ScreenShell.jsx
@@ -103,9 +103,16 @@ export const ScreenShell = ({ title, onBack, onHome, icon: Icon, children, actio
                     >
                         <Home size={20} />
                     </button>
-                    <h1 className="text-xl font-bold text-white flex items-center gap-2 truncate">
+                    {/* FIX truncado (QA-VISUAL-MUNDOS 2026-07-08): el `truncate`
+                        iba sobre el <h1> que es `display:flex`, así que el título
+                        (nodo de texto = flex-item anónimo) se recortaba en seco SIN
+                        elipsis a 390px ("La botica car", "El fique y las", "Quinua y
+                        gra"). El text-overflow:ellipsis solo aplica a un hijo
+                        propio con overflow:hidden; por eso el título va ahora en su
+                        propio <span className="truncate"> (el h1 conserva flex). */}
+                    <h1 className="text-xl font-bold text-white flex items-center gap-2 min-w-0">
                         {Icon && <Icon className="text-morpho shrink-0" size={20} />}
-                        {title}
+                        <span className="truncate min-w-0">{title}</span>
                     </h1>
                 </div>
                 <div className="flex items-center gap-1.5 shrink-0">
@@ -189,7 +196,10 @@ function ScreenShellF2({ title, onBack, handleHome, Icon, actions, children }) {
                                 <Icon size={20} />
                             </span>
                         )}
-                        {title}
+                        {/* Mismo fix que el shell legacy: el título va en su propio
+                            span truncable (el h1 es flex → la elipsis no aplica al
+                            nodo de texto suelto). */}
+                        <span className="screen-shell-f2-title-text">{title}</span>
                     </h1>
                 </div>
                 <div className="screen-shell-f2-right">

--- a/src/components/common/screen-shell-f2.css
+++ b/src/components/common/screen-shell-f2.css
@@ -132,8 +132,13 @@ html[data-luz="noche"][data-theme="minimalista"] .screen-shell-f2 {
   gap: 8px;
   min-width: 0;
   color: var(--ssf2-titulo);
-  white-space: nowrap;
+}
+/* La elipsis vive en el span del texto, no en el <h1> flex (si no, el nodo de
+   texto —flex-item anónimo— se recorta sin elipsis). QA-VISUAL 2026-07-08. */
+.screen-shell-f2-title-text {
+  min-width: 0;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
 }
 .screen-shell-f2-title-icon {


### PR DESCRIPTION
## Contexto
Arregla los bugs que el QA visual encontró en los mundos de Chagra (móvil 390×844). Reporte: `Chagra-strategy/ops/QA-VISUAL-MUNDOS-2026-07-08.md`.

## Fixes (por severidad)

1. **[❌ funcional] Ruta `#quinua` faltante** — `HASH_VIEW_ROUTES` (src/App.jsx) no tenía la clave `quinua` (solo el `case 'quinua'` del switch), así que el deep-link caía al dashboard: mundo inalcanzable por enlace/QR/marcador. Se agrega `quinua: 'quinua'` + aliases (`granos-andinos`, `granos-ancestrales`, `granos`, `quinoa`, `chenopodium`, `amaranto`, `bledo`, `chia`, `chía`, `cañihua`, `canihua`, `tarwi`), al estilo de los mundos hermanos (mango→mangifera, uchuva→physalis).

2. **[⚠️ transversal] Título del header cortado en seco a 390px** ("La botica car", "El fique y las", "Quinua y gra") — el `truncate` iba sobre el `<h1>` que es `display:flex`, así que el texto (flex-item anónimo) se recortaba **sin** elipsis. Se mueve la truncación a un `<span>` propio en **ambos** shells (legacy + Finca-Viva F2). Fix único en el componente compartido `ScreenShell`.

3. **[⚠️] Banner "Instale Chagra" tapaba ~150px del contenido inferior** — se baja (`bottom-24`→`bottom-20`) y se compacta (`p-4`→`p-2.5`, ícono 24→20) en ambos banners (Android/iOS) para reducir su footprint y no tapar los CTAs del final de página.

4. **[⚠️] Contraste del crédito de foto en poscosecha** (ilegible sobre la foto clara del gorgojo) — texto a `slate-100` + `text-shadow` y franja/chip de crédito más opacos (`bg-slate-950/90`). El componente `PoscosechaScreen` vive en `main`; las fotos de `/public/poscosecha/` siguen en la rama `fable/mundo-poscosecha-fotos-cc` pendiente de merge (nota: esa rama tiene una copia paralela del mismo componente que debe recibir el mismo ajuste al mergear).

## Verificación
- **Headless (390×844, deviceScaleFactor 2, sesión campesina sembrada, requests externos bloqueados):** `#quinua` y el alias `#granos-andinos` montan la `QuinuaScreen` (h1 "Quinua y granos andinos", **no** el dashboard). Los títulos de quinua/botica/fique truncan **con elipsis** (`overflow:hidden` + `text-overflow:ellipsis` activos; `scrollWidth > clientWidth`).
- **tsc gate:** 1820 errores vs baseline 1829 — sin errores nuevos.
- **Tests:** suites de ScreenShell, banners, PoscosechaScreen, quinua/fique/botica verdes (65/65).
- **Budget:** 23.5 MB / 25.5 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)