### PR TITLE
feat(mockup): home con ojos de campesino (#/mockups/home-campesino)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,6 +89,10 @@ const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').
 // 2026-06-30. Se alcanza desde 'bodega' vía el botón "Auditoría y
 // reconciliación", o directo por hash (#auditoria-inventario).
 const InventoryPage = lazy(() => import('./pages/InventoryPage'));
+// Mockup dev del HOME CON OJOS DE CAMPESINO (rediseño de jerarquía del home:
+// preguntar + anotar + 6 puertas grandes). Ruta #/mockups/home-campesino —
+// sin gate ni sesión (datos de muestra, no toca datos reales).
+const HomeCampesinoMockup = lazy(() => import('./mockups/HomeCampesino'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -417,6 +421,7 @@ const LoadingFallback = ({ view = null }) => {
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
 
 const HASH_VIEW_ROUTES = {
+  'mockups/home-campesino': 'mockup_home_campesino',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -896,6 +901,13 @@ export default function App() {
       return;
     }
 
+    // Mockups dev (#/mockups/*): vistas aisladas de decisión visual — se
+    // montan sin sesión (no leen ni escriben datos reales).
+    if (hash === 'mockups/home-campesino') {
+      Promise.resolve().then(() => navigate('mockup_home_campesino'));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -924,6 +936,11 @@ export default function App() {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
+      // Mockups dev: sin gate ni sesión (datos de muestra).
+      if (routeView === 'mockup_home_campesino') {
+        navigate(routeView);
+        return;
+      }
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
       if (routeView === 'extensionista' && !esExtensionistaActual()) {
         navigate('dashboard');
@@ -1228,6 +1245,16 @@ export default function App() {
         return (
           <ErrorBoundary>
             <DashboardLiveView onNavigate={navigate} onLogout={handleLogout} lastLogMessage={lastLogMessage} />
+          </ErrorBoundary>
+        );
+      case 'mockup_home_campesino':
+        // Mockup dev del home con ojos de campesino (rediseño de jerarquía).
+        // Full-screen, sin gate — solo para decidir dirección.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mockup Home Campesino">
+              <HomeCampesinoMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'hoy_finca':
@@ -2517,7 +2544,7 @@ export default function App() {
           Tampoco en onboarding-perfil (tarea #16): el FAB se encimaba sobre el
           CTA "Explorar con finca de ejemplo" del footer y la usuaria nueva aún
           no conoce al agente — ruido en su primer flujo. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && <AgentFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && !currentView.startsWith('mockup_') && <AgentFab onNavigate={navigate} />}
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o
           pregunta al agente punta a punta por voz.

--- a/src/mockups/HomeCampesino.jsx
+++ b/src/mockups/HomeCampesino.jsx
@@ -1,0 +1,222 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish --
+ * MOCKUP DEV (#/mockups/home-campesino): copy de muestra en español de
+ * Colombia para decidir dirección visual. No es UI de producción; si el
+ * rediseño se adopta, sus textos migran a src/config/messages.js (ADR-050). */
+/**
+ * HomeCampesino.jsx — MOCKUP DEV del HOME CON OJOS DE CAMPESINO
+ * (#/mockups/home-campesino, sin gate ni sesión — datos de muestra).
+ *
+ * Auditoría 2026-07-09 del home actual (FincaVivaHero + secciones): para una
+ * campesina con poca costumbre de apps, con afán y a veces sin leer de
+ * corrido, el home de hoy es LARGO (≈6 pantallas de scroll, ~20 tarjetas y
+ * ~35 chips), repite "preguntar" en 4 formas distintas sin que ninguna mande,
+ * esconde "anotar lo que hice" a 2.5 pantallas, y habla en ingeniero
+ * ("IA LOCAL", "Cola de tareas", "fenología", "análisis"). Este mockup
+ * invierte la jerarquía:
+ *
+ *   1. EL CORAZÓN ES EL BOTÓN DE HABLAR. La metáfora central de la escena
+ *      biopunk (el corazón-semilla que late bajo la finca) deja de ser
+ *      decoración y pasa a ser LA acción principal: un botón gigante que
+ *      late, "PREGUNTE — toque y hable".
+ *   2. Dos acciones dominan el fold: PREGUNTAR (voz) y ANOTAR SU DÍA.
+ *      Lo demás espera.
+ *   3. SEIS PUERTAS grandes de una-dos palabras (Mis matas / Mis animales /
+ *      El tiempo / Vender / Aprender / Toda mi finca). Sin descripciones,
+ *      sin chips: dibujo grande + palabra grande.
+ *   4. El TIEMPO de hoy en palabras del campo, arriba, junto al saludo.
+ *   5. UN solo recado en cristiano ("Mañana llueve — guarde el café").
+ *   6. TODO se puede ESCUCHAR (🔊): pensado para baja alfabetización.
+ *   7. Vista "pleno sol": variante clara de alto contraste para leer el
+ *      teléfono a mediodía en el campo (el biopunk nocturno va bien de
+ *      noche, pero de día al rayo del sol un fondo oscuro no se ve).
+ *
+ * Técnica: CSS puro + emojis grandes (cero deps, cero fotos), targets
+ * mínimos 88px, tipografía Baloo 2 / Nunito ya self-host. Los toques
+ * muestran un aviso "aquí se abre X" (mockup honesto: no navega de verdad).
+ * `prefers-reduced-motion` apaga el latido. Español de Colombia (usted).
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import './home-campesino.css';
+
+// ── Datos de muestra (los reales saldrían de perfil + clima + recordatorios) ──
+const MUESTRA = {
+  nombre: 'María',
+  vereda: 'Vereda La Esperanza',
+  climaNoche: { emoji: '🌧️', frase: 'Esta noche llueve suave', manana: 'Mañana sale el sol' },
+  climaDia: { emoji: '⛅', frase: 'Hoy: sol con nubes', manana: 'Por la tarde puede llover' },
+  recado: 'Mañana llueve por la tarde. Guarde el café que tiene secando.',
+};
+
+const PUERTAS = [
+  { id: 'matas', emoji: '🌱', nombre: 'Mis matas', tinte: 'verde', abre: 'sus siembras y cultivos' },
+  { id: 'animales', emoji: '🐔', nombre: 'Mis animales', tinte: 'teja', abre: 'sus gallinas, cerdos y demás animales' },
+  { id: 'tiempo', emoji: '🌦️', nombre: 'El tiempo', tinte: 'cielo', abre: 'el clima de hoy y los próximos días' },
+  { id: 'vender', emoji: '🧺', nombre: 'Vender', tinte: 'ambar', abre: 'precios, mercado y su despensa' },
+  { id: 'aprender', emoji: '📖', nombre: 'Aprender', tinte: 'uva', abre: 'las lecciones y guías del campo' },
+  { id: 'finca', emoji: '🏡', nombre: 'Toda mi finca', tinte: 'menta', abre: 'todos los mundos de su finca' },
+];
+
+function saludoPorHora(h) {
+  if (h >= 5 && h < 12) return 'Buenos días';
+  if (h >= 12 && h < 18) return 'Buenas tardes';
+  return 'Buenas noches';
+}
+
+export default function HomeCampesino({ onBack }) {
+  const hora = new Date().getHours();
+  const esDeNoche = hora >= 18 || hora < 5;
+  const [modo, setModo] = useState(esDeNoche ? 'noche' : 'dia');
+  const [aviso, setAviso] = useState(null);
+  const avisoTimer = useRef(null);
+
+  const clima = modo === 'noche' ? MUESTRA.climaNoche : MUESTRA.climaDia;
+  const saludo = `${saludoPorHora(modo === 'noche' ? 20 : 10)}, ${MUESTRA.nombre}`;
+
+  // Aviso honesto del mockup: qué abriría cada toque en la app real.
+  const avisar = (texto) => {
+    setAviso(texto);
+    if (avisoTimer.current) clearTimeout(avisoTimer.current);
+    avisoTimer.current = setTimeout(() => setAviso(null), 2600);
+  };
+  useEffect(() => () => { if (avisoTimer.current) clearTimeout(avisoTimer.current); }, []);
+
+  // 🔊 Escuchar: lee el home en voz alta (baja alfabetización). En la app real
+  // esto usa el TTS propio (kokoro); aquí, la voz del sistema como demo.
+  const textoLectura = useMemo(
+    () => `${saludo}. ${clima.frase}. ${clima.manana}. `
+      + 'Puede preguntar con su voz, anotar su día, o entrar a: mis matas, mis animales, '
+      + `el tiempo, vender, aprender, o toda su finca. Recado de hoy: ${MUESTRA.recado}`,
+    [saludo, clima],
+  );
+  const escuchar = () => {
+    try {
+      const u = new SpeechSynthesisUtterance(textoLectura);
+      u.lang = 'es-CO';
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(u);
+    } catch (_) {
+      avisar('Aquí Chagra le lee la pantalla en voz alta.');
+    }
+  };
+
+  return (
+    <div className="hcm" data-modo={modo} data-testid="mockup-home-campesino">
+      {/* ── Barra del mockup (no es parte del diseño propuesto) ── */}
+      <div className="hcm-mockbar">
+        {typeof onBack === 'function' && (
+          <button type="button" className="hcm-mockchip" onClick={onBack}>← Salir del mockup</button>
+        )}
+        <div className="hcm-mockmodos" role="group" aria-label="Vista del mockup">
+          <button
+            type="button"
+            className={`hcm-mockchip ${modo === 'noche' ? 'on' : ''}`}
+            aria-pressed={modo === 'noche'}
+            onClick={() => setModo('noche')}
+          >
+            🌙 Noche
+          </button>
+          <button
+            type="button"
+            className={`hcm-mockchip ${modo === 'dia' ? 'on' : ''}`}
+            aria-pressed={modo === 'dia'}
+            onClick={() => setModo('dia')}
+          >
+            ☀️ Pleno sol
+          </button>
+        </div>
+      </div>
+
+      <main className="hcm-shell">
+        {/* ── 1. CIELO: saludo + el tiempo en palabras, y el botón de escuchar ── */}
+        <header className="hcm-cielo">
+          <span className="hcm-astro" aria-hidden="true">{modo === 'noche' ? '🌙' : '☀️'}</span>
+          <h1 className="hcm-saludo">{saludo}</h1>
+          <p className="hcm-clima">
+            <span className="hcm-clima-emoji" aria-hidden="true">{clima.emoji}</span>
+            {clima.frase}. <b>{clima.manana}.</b>
+          </p>
+          <button type="button" className="hcm-escuchar" onClick={escuchar}>
+            🔊 Escuchar
+          </button>
+        </header>
+
+        {/* ── 2. LAS DOS ACCIONES GRANDES ── */}
+        <button
+          type="button"
+          className="hcm-accion hcm-preguntar"
+          data-testid="hcm-preguntar"
+          onClick={() => avisar('Aquí se abre el agente: usted habla y Chagra le contesta.')}
+        >
+          {/* El corazón de la finca — ahora ES el botón de hablar */}
+          <span className="hcm-corazon" aria-hidden="true">
+            <span className="hcm-pulso" />
+            <span className="hcm-pulso hcm-pulso2" />
+            <svg viewBox="0 0 24 24" width="34" height="34" fill="none" aria-hidden="true">
+              <rect x="9" y="2.5" width="6" height="11.5" rx="3" fill="#12260a" />
+              <path d="M5.5 11a6.5 6.5 0 0 0 13 0M12 17.5V21M8.5 21h7" stroke="#12260a" strokeWidth="2.4" strokeLinecap="round" />
+            </svg>
+          </span>
+          <span className="hcm-accion-txt">
+            <b>Pregunte</b>
+            <small>Toque y hable. Chagra le contesta.</small>
+          </span>
+        </button>
+
+        <button
+          type="button"
+          className="hcm-accion hcm-anotar"
+          data-testid="hcm-anotar"
+          onClick={() => avisar('Aquí se abre Registrar: cuente qué hizo, por voz o a mano.')}
+        >
+          <span className="hcm-accion-icono" aria-hidden="true">✍️</span>
+          <span className="hcm-accion-txt">
+            <b>Anote su día</b>
+            <small>Qué cosechó, qué abonó, qué vio.</small>
+          </span>
+        </button>
+
+        {/* ── 3. LAS SEIS PUERTAS ── */}
+        <h2 className="hcm-tit">¿A dónde va?</h2>
+        <nav className="hcm-puertas" aria-label="Lugares de su finca">
+          {PUERTAS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              className={`hcm-puerta t-${p.tinte}`}
+              aria-label={`${p.nombre}: abre ${p.abre}`}
+              onClick={() => avisar(`Aquí se abren ${p.abre}.`)}
+            >
+              <span className="hcm-puerta-emoji" aria-hidden="true">{p.emoji}</span>
+              <span className="hcm-puerta-nombre">{p.nombre}</span>
+            </button>
+          ))}
+        </nav>
+
+        {/* ── 4. UN SOLO RECADO, EN CRISTIANO ── */}
+        <section className="hcm-recado" aria-label="Recado de hoy">
+          <span className="hcm-recado-icono" aria-hidden="true">🔔</span>
+          <p><b>Recado de hoy:</b> {MUESTRA.recado}</p>
+        </section>
+
+        {/* ── 5. AYUDA Y PERFIL, GRANDES Y AL FINAL ── */}
+        <div className="hcm-pie">
+          <button type="button" className="hcm-pie-btn" onClick={() => avisar('Aquí se abre la ayuda, con explicación paso a paso.')}>
+            🙋 Necesito ayuda
+          </button>
+          <button type="button" className="hcm-pie-btn" onClick={() => avisar('Aquí se abre su perfil y su finca.')}>
+            👤 Mi perfil
+          </button>
+        </div>
+
+        <p className="hcm-marca">{MUESTRA.vereda} · 1.800 msnm</p>
+        <p className="hcm-mocknota">MOCKUP · datos de muestra</p>
+      </main>
+
+      {/* Aviso honesto del mockup */}
+      {aviso && (
+        <div className="hcm-aviso" role="status">{aviso}</div>
+      )}
+    </div>
+  );
+}

--- a/src/mockups/home-campesino.css
+++ b/src/mockups/home-campesino.css
@@ -1,0 +1,311 @@
+/* home-campesino.css — MOCKUP DEV #/mockups/home-campesino (prefijo hcm-).
+ *
+ * Dos modos por CSS vars: data-modo="noche" (biopunk nocturno, coherente con
+ * biopunk2) y data-modo="dia" ("pleno sol": claro de ALTO contraste para leer
+ * a mediodía en el campo). Tipografía Baloo 2 (display) + Nunito (cuerpo),
+ * ya self-host en la app (font-src 'self').
+ * Targets: acciones >= 96px, puertas >= 108px, pie >= 60px. */
+
+.hcm {
+  /* ── modo NOCHE (default): biopunk nocturno ── */
+  --hcm-fondo: #0a1424;
+  --hcm-cielo-a: #0d1b31;
+  --hcm-cielo-b: #12233b;
+  --hcm-aurora: rgba(94, 234, 212, 0.14);
+  --hcm-superficie: #13253f;
+  --hcm-borde: rgba(148, 197, 255, 0.16);
+  --hcm-tinta: #f2f7ee;
+  --hcm-tinta-suave: #b8c7bd;
+  --hcm-vivo: #a3e635;          /* lime: la acción de voz */
+  --hcm-vivo-tinta: #12260a;
+  --hcm-calido: #fbbf24;        /* ámbar: anotar la jornada */
+  --hcm-calido-fondo: rgba(251, 191, 36, 0.12);
+  --hcm-recado: rgba(251, 191, 36, 0.1);
+  --hcm-sombra: 0 10px 28px rgba(0, 0, 0, 0.45);
+
+  min-height: 100dvh;
+  background: var(--hcm-fondo);
+  color: var(--hcm-tinta);
+  font-family: 'Nunito', system-ui, sans-serif;
+  padding-bottom: 28px;
+}
+
+.hcm[data-modo='dia'] {
+  /* ── modo PLENO SOL: claro, contraste duro, cero brillos oscuros ── */
+  --hcm-fondo: #f5f2e3;
+  --hcm-cielo-a: #eaf4fb;
+  --hcm-cielo-b: #f5f2e3;
+  --hcm-aurora: rgba(56, 152, 199, 0.12);
+  --hcm-superficie: #fffdf4;
+  --hcm-borde: rgba(28, 42, 26, 0.22);
+  --hcm-tinta: #1c2a1a;
+  --hcm-tinta-suave: #44543f;
+  --hcm-vivo: #4d7c0f;
+  --hcm-vivo-tinta: #f7fee7;
+  --hcm-calido: #b45309;
+  --hcm-calido-fondo: rgba(180, 83, 9, 0.1);
+  --hcm-recado: rgba(180, 83, 9, 0.1);
+  --hcm-sombra: 0 8px 20px rgba(28, 42, 26, 0.14);
+}
+
+/* ── barra del mockup (herramienta de revisión, no parte del diseño) ── */
+.hcm-mockbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px 0;
+  max-width: 560px;
+  margin: 0 auto;
+}
+.hcm-mockmodos { display: flex; gap: 6px; }
+.hcm-mockchip {
+  border: 1px dashed var(--hcm-borde);
+  background: transparent;
+  color: var(--hcm-tinta-suave);
+  font: 700 12px/1 'Nunito', sans-serif;
+  padding: 8px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.hcm-mockchip.on { color: var(--hcm-tinta); border-style: solid; border-color: var(--hcm-tinta-suave); }
+
+.hcm-shell { max-width: 560px; margin: 0 auto; padding: 0 16px; }
+
+/* ── 1. CIELO: saludo + tiempo ── */
+.hcm-cielo {
+  position: relative;
+  margin-top: 10px;
+  padding: 18px 118px 18px 18px;
+  border-radius: 22px;
+  background:
+    radial-gradient(120% 90% at 85% -20%, var(--hcm-aurora), transparent 60%),
+    linear-gradient(165deg, var(--hcm-cielo-a), var(--hcm-cielo-b));
+  border: 1px solid var(--hcm-borde);
+  overflow: hidden;
+}
+.hcm-astro {
+  position: absolute;
+  top: 14px;
+  right: 18px;
+  font-size: 44px;
+  line-height: 1;
+  filter: drop-shadow(0 0 14px var(--hcm-aurora));
+}
+.hcm-saludo {
+  font-family: 'Baloo 2', 'Nunito', sans-serif;
+  font-size: 27px;
+  line-height: 1.15;
+  margin: 0 0 6px;
+  letter-spacing: 0.2px;
+}
+.hcm-clima {
+  font-size: 18px;
+  line-height: 1.35;
+  margin: 0 0 12px;
+  color: var(--hcm-tinta);
+  font-weight: 700;
+}
+.hcm-clima b { color: var(--hcm-tinta-suave); font-weight: 700; }
+.hcm-clima-emoji { font-size: 22px; margin-right: 6px; }
+.hcm-escuchar {
+  min-height: 48px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 2px solid var(--hcm-borde);
+  background: var(--hcm-superficie);
+  color: var(--hcm-tinta);
+  font: 800 16px/1 'Nunito', sans-serif;
+  cursor: pointer;
+}
+.hcm-escuchar:active { transform: scale(0.97); }
+
+/* ── 2. ACCIONES GRANDES ── */
+.hcm-accion {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  min-height: 104px;
+  margin-top: 14px;
+  padding: 16px 18px;
+  border-radius: 24px;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  box-shadow: var(--hcm-sombra);
+}
+.hcm-accion:active { transform: scale(0.985); }
+.hcm-accion-txt { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.hcm-accion-txt b {
+  font-family: 'Baloo 2', 'Nunito', sans-serif;
+  font-size: 26px;
+  line-height: 1.1;
+}
+.hcm-accion-txt small { font-size: 16px; font-weight: 700; opacity: 0.85; }
+
+/* PREGUNTAR: el corazón de la finca hecho botón */
+.hcm-preguntar { background: var(--hcm-vivo); color: var(--hcm-vivo-tinta); }
+.hcm-preguntar .hcm-accion-txt small { color: inherit; }
+.hcm-corazon {
+  position: relative;
+  flex: 0 0 auto;
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(255, 255, 255, 0.55), transparent 58%),
+    var(--hcm-vivo);
+  border: 3px solid var(--hcm-vivo-tinta);
+}
+.hcm[data-modo='dia'] .hcm-corazon { background: #d9f99d; }
+.hcm[data-modo='dia'] .hcm-corazon svg rect { fill: #1f3300; }
+.hcm[data-modo='dia'] .hcm-corazon svg path { stroke: #1f3300; }
+.hcm-pulso {
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  border: 2px solid var(--hcm-vivo-tinta);
+  opacity: 0;
+  animation: hcm-late 2.4s ease-out infinite;
+}
+.hcm-pulso2 { animation-delay: 1.2s; }
+@keyframes hcm-late {
+  0% { transform: scale(1); opacity: 0.55; }
+  70% { transform: scale(1.55); opacity: 0; }
+  100% { transform: scale(1.55); opacity: 0; }
+}
+
+/* ANOTAR */
+.hcm-anotar {
+  background: var(--hcm-superficie);
+  color: var(--hcm-tinta);
+  border: 2px solid var(--hcm-calido);
+}
+.hcm-anotar .hcm-accion-txt b { color: var(--hcm-calido); }
+.hcm-accion-icono {
+  flex: 0 0 auto;
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 34px;
+  background: var(--hcm-calido-fondo);
+  border: 3px solid var(--hcm-calido);
+}
+
+/* ── 3. PUERTAS ── */
+.hcm-tit {
+  font-family: 'Baloo 2', 'Nunito', sans-serif;
+  font-size: 21px;
+  margin: 24px 2px 10px;
+}
+.hcm-puertas {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.hcm-puerta {
+  min-height: 112px;
+  border-radius: 22px;
+  border: 2px solid var(--hcm-p-borde, var(--hcm-borde));
+  background: var(--hcm-superficie);
+  color: var(--hcm-tinta);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 12px 8px;
+  box-shadow: var(--hcm-sombra);
+}
+.hcm-puerta:active { transform: scale(0.97); }
+.hcm-puerta-emoji { font-size: 42px; line-height: 1; }
+.hcm-puerta-nombre {
+  font-family: 'Baloo 2', 'Nunito', sans-serif;
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1.1;
+  text-align: center;
+}
+/* tinte por puerta: solo el borde y un velo, para no volver arcoíris el home */
+.hcm-puerta.t-verde { --hcm-p-borde: rgba(132, 204, 22, 0.55); }
+.hcm-puerta.t-teja { --hcm-p-borde: rgba(234, 88, 12, 0.55); }
+.hcm-puerta.t-cielo { --hcm-p-borde: rgba(56, 189, 248, 0.55); }
+.hcm-puerta.t-ambar { --hcm-p-borde: rgba(245, 158, 11, 0.6); }
+.hcm-puerta.t-uva { --hcm-p-borde: rgba(167, 139, 250, 0.55); }
+.hcm-puerta.t-menta { --hcm-p-borde: rgba(45, 212, 191, 0.55); }
+.hcm[data-modo='dia'] .hcm-puerta.t-verde { --hcm-p-borde: #4d7c0f; }
+.hcm[data-modo='dia'] .hcm-puerta.t-teja { --hcm-p-borde: #c2410c; }
+.hcm[data-modo='dia'] .hcm-puerta.t-cielo { --hcm-p-borde: #0369a1; }
+.hcm[data-modo='dia'] .hcm-puerta.t-ambar { --hcm-p-borde: #b45309; }
+.hcm[data-modo='dia'] .hcm-puerta.t-uva { --hcm-p-borde: #6d28d9; }
+.hcm[data-modo='dia'] .hcm-puerta.t-menta { --hcm-p-borde: #0f766e; }
+
+/* ── 4. RECADO ── */
+.hcm-recado {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 18px;
+  background: var(--hcm-recado);
+  border: 1.5px solid var(--hcm-calido);
+}
+.hcm-recado-icono { font-size: 26px; line-height: 1.2; }
+.hcm-recado p { margin: 0; font-size: 17px; line-height: 1.45; font-weight: 700; }
+.hcm-recado b { color: var(--hcm-calido); }
+
+/* ── 5. PIE ── */
+.hcm-pie { display: flex; gap: 12px; margin-top: 20px; }
+.hcm-pie-btn {
+  flex: 1;
+  min-height: 62px;
+  border-radius: 18px;
+  border: 2px solid var(--hcm-borde);
+  background: var(--hcm-superficie);
+  color: var(--hcm-tinta);
+  font: 800 17px/1.2 'Nunito', sans-serif;
+  cursor: pointer;
+}
+.hcm-marca {
+  text-align: center;
+  color: var(--hcm-tinta-suave);
+  font-size: 14px;
+  font-weight: 700;
+  margin: 22px 0 0;
+}
+.hcm-mocknota {
+  text-align: center;
+  color: var(--hcm-tinta-suave);
+  opacity: 0.6;
+  font-size: 11px;
+  letter-spacing: 2px;
+  margin: 6px 0 0;
+}
+
+/* aviso honesto del mockup */
+.hcm-aviso {
+  position: fixed;
+  left: 50%;
+  bottom: 26px;
+  transform: translateX(-50%);
+  max-width: min(92vw, 480px);
+  background: var(--hcm-tinta);
+  color: var(--hcm-fondo);
+  font: 700 15px/1.35 'Nunito', sans-serif;
+  padding: 12px 18px;
+  border-radius: 14px;
+  box-shadow: var(--hcm-sombra);
+  z-index: 50;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hcm-pulso { animation: none; opacity: 0; }
+  .hcm-accion:active, .hcm-puerta:active, .hcm-escuchar:active { transform: none; }
+}


### PR DESCRIPTION
## Qué es

Mockup dev (`#/mockups/home-campesino`, sin gate ni sesión) del rediseño del home para que sea obvio para una campesina de baja alfabetización, con afán y poca costumbre de apps. Para decidir dirección — **no toca el home de prod**.

## Auditoría del home actual (con ojos de campesino)

- ≈6 pantallas de scroll, ~20 tarjetas y ~35 chips → sobrecarga de decisión.
- "Preguntar" aparece en 4 formas distintas (A del topbar, globo de la escena, compositor, portal morado) sin que ninguna mande.
- "Anotar lo que hice" (la acción diaria #1) está a 2.5 pantallas de scroll.
- El clima a 2 pantallas; los animales a 4; vender a 5.
- Jerga de ingeniero: "SU AGENTE AGROECOLÓGICO", "IA LOCAL", "ANÁLISIS CHAGRA", "Cola de tareas 0", "fenología", "MIP", "Cromatografía", "HLB", "antracnosis".
- Tarjetas con 3-4 líneas de texto chico y chips truncados ("Poscosecha y despe…").
- La escena, bellísima, ocupa el 60% del fold sin acciones táctiles obvias.

## El rediseño (mockup)

1. **El corazón de la finca ES el botón de hablar**: PREGUNTE gigante que late (la metáfora central del biopunk deja de ser decoración).
2. Dos acciones dominan el fold: **Pregunte** (voz) y **Anote su día**.
3. **Seis puertas** de una-dos palabras: Mis matas / Mis animales / El tiempo / Vender / Aprender / Toda mi finca.
4. El tiempo de hoy **en palabras del campo**, arriba, junto al saludo.
5. **Un solo recado** en cristiano + botón **Escuchar** 🔊 que lee la pantalla en voz alta (baja alfabetización).
6. Vista **"pleno sol"**: variante clara de alto contraste para leer el teléfono a mediodía en el campo.

Targets ≥ 96px, Baloo 2/Nunito self-host, CSS puro + emojis (cero deps), `prefers-reduced-motion`, español de Colombia (usted).

## Gates

- tsc:check vs baseline: **1820 ≤ 1829, sin errores nuevos** ✅
- perf budget: **23.5 MB / 25.5 MB** ✅
- Verificado EN VIVO con Playwright (móvil 390×844, modos noche y pleno sol) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)