### PR TITLE
feat(home): 8 mejoras de usabilidad campesina en el home biopunk (F2)

### DIFF
--- a/src/components/CicloVivo/cicloVivoData.js
+++ b/src/components/CicloVivo/cicloVivoData.js
@@ -51,7 +51,7 @@ export const PHASES = [
     key: 'crecimiento', name: 'Crecimiento', short: 'Crece', color: '#4C7A3D',
     functions: [
       { label: 'Tómele foto', cap: 'diagnostico_foto', camera: true },
-      { label: 'Plagas de esta etapa (MIP)', cap: 'mip_plagas' },
+      { label: 'Plagas de esta etapa', cap: 'mip_plagas' }, // sin la sigla MIP (jerga) en la UI
       { label: 'Nutrición', cap: 'nutricion' },
       { label: 'Asociaciones', cap: 'asociaciones' },
       { label: '¿En qué fase va?', cap: 'fenologia' },

--- a/src/components/PendingTasksWidget.jsx
+++ b/src/components/PendingTasksWidget.jsx
@@ -127,7 +127,9 @@ export default function PendingTasksWidget({ onEdit }) {
       >
         <div className="flex items-center gap-3">
           <span className={`w-3 h-3 rounded-full ${pendingCount > 0 ? (criticalCount > 0 ? 'bg-red-500 animate-pulse' : 'bg-amber-500') : 'bg-green-500'}`}></span>
-          <h3 className="text-base font-bold text-slate-100">Cola de tareas</h3>
+          {/* Sin jerga de ingeniero (usabilidad campesina #1): antes "Cola de
+              tareas" — palabras del campo. */}
+          <h3 className="text-base font-bold text-slate-100">Tareas pendientes</h3>
           <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${pendingCount > 0 ? 'bg-amber-600/20 text-amber-400' : 'bg-green-600/20 text-green-400'}`}>
             {pendingCount}
           </span>

--- a/src/components/dashboard/AnalisisProactivoIA.jsx
+++ b/src/components/dashboard/AnalisisProactivoIA.jsx
@@ -286,11 +286,11 @@ export default function AnalisisProactivoIA({ sensors = [], climaSnapshot = null
                             className="absolute -top-1 -right-1 text-emerald-300 animate-pulse"
                         />
                     </div>
+                    {/* Sin jerga de ingeniero (usabilidad campesina #1): antes
+                        "Análisis Chagra · IA local". El recado es la figura del
+                        campo: lo que Chagra le deja dicho hoy. */}
                     <span className="text-[10px] font-bold text-cyan-200 uppercase tracking-[0.18em]">
-                        Análisis Chagra
-                    </span>
-                    <span className="px-1.5 py-0.5 rounded text-[8px] font-black bg-emerald-500/15 text-emerald-200 uppercase tracking-wider">
-                        IA local
+                        El recado de Chagra
                     </span>
                     <span className="ml-auto text-[9px] text-slate-500" aria-hidden>
                         {hora.icono}
@@ -369,11 +369,11 @@ export default function AnalisisProactivoIA({ sensors = [], climaSnapshot = null
                     type="button"
                     onClick={handleAgent}
                     className="mt-3 w-full flex items-center justify-between gap-2 px-3 py-2 rounded-xl bg-cyan-500/10 hover:bg-cyan-500/15 border border-cyan-600/30 transition-colors text-left group"
-                    aria-label="Hablar con el agente Chagra sobre este análisis"
+                    aria-label="Pregúntele a Chagra sobre este recado"
                 >
                     <span className="flex items-center gap-1.5 text-[11px] text-cyan-100">
                         <TrendingUp size={12} className="text-cyan-300" />
-                        Habla con el agente sobre esto
+                        Pregúntele a Chagra sobre esto
                     </span>
                     <ArrowRight
                         size={13}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -544,6 +544,22 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
         }
     }, []);
 
+    // LOS MUNDOS PLEGADOS (usabilidad campesina #5): la grilla completa de
+    // mundos (~13 tarjetas + ~35 chips) ya no está siempre abierta en el home
+    // — el primer pantallazo son las 6 PUERTAS del hero. "Toda mi finca" (la
+    // sexta puerta) o el botón ancho del bloque la despliegan. Todo sigue
+    // alcanzable con UN toque; MundosDeMiFinca no cambia.
+    const [mundosAbiertos, setMundosAbiertos] = useState(false);
+    const revelarMundos = useCallback(() => {
+        setMundosAbiertos(true);
+        if (typeof document === 'undefined') return;
+        // El scroll corre tras el render del bloque expandido.
+        requestAnimationFrame(() => {
+            const seccion = document.getElementById('bloque-mundos');
+            if (seccion?.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+    }, []);
+
     // ── Helpers de render (compartidos entre el layout F2 y el legacy) ────────
     // Rótulo de bloque con la barrita de color. Función pura que DEVUELVE JSX (no
     // un componente, para no violar react-hooks/static-components al definirlo
@@ -693,6 +709,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                         onNavigate={onNavigate}
                         onOpenAgent={() => onNavigate('agente')}
                         onGestionar={revelarGestion}
+                        onTodaMiFinca={revelarMundos}
                         titulo={esExtensionista ? 'Red de fincas que acompaño' : 'Mi finca viva'}
                     >
                         {esExtensionista ? (
@@ -867,12 +884,37 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     vieja vive DENTRO de su mundo (mundosFinca.js es la fuente
                     única; el test de reachability congela el contrato). El gate
                     de Animales por perfil se conserva (mostrarAnimales). */}
-                <div className="px-4 pt-4 fvh-resto-block" data-testid="bloque-mundos">
-                    <MundosDeMiFinca
-                        onNavigate={onNavigate}
-                        mostrarAnimales={mostrarAnimales}
-                        plantsCount={plantsCount}
-                    />
+                <div id="bloque-mundos" className="px-4 pt-4 fvh-resto-block" data-testid="bloque-mundos" style={{ scrollMarginTop: '88px' }}>
+                    {mundosAbiertos ? (
+                        <MundosDeMiFinca
+                            onNavigate={onNavigate}
+                            mostrarAnimales={mostrarAnimales}
+                            plantsCount={plantsCount}
+                        />
+                    ) : (
+                        // PLEGADO (default): una sola puerta ancha ≥96px. La
+                        // grilla completa se abre aquí o desde la puerta "Toda
+                        // mi finca" del hero (revelarMundos).
+                        <button
+                            type="button"
+                            data-testid="abrir-mundos"
+                            onClick={revelarMundos}
+                            aria-expanded={false}
+                            aria-label="Toda mi finca: abrir todos los mundos de su finca"
+                            className={`w-full dash-tile ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 border-l-teal-500 rounded-2xl p-4 min-h-[96px] text-left active:bg-slate-800/70 transition-colors flex items-center gap-4`}
+                        >
+                            <span aria-hidden="true" className="shrink-0 w-14 h-14 rounded-2xl bg-teal-700/20 border border-teal-600/40 flex items-center justify-center text-3xl">
+                                🏡
+                            </span>
+                            <span className="min-w-0 flex-1">
+                                <span className="text-lg font-black block leading-tight fvh-tile-label text-teal-500">Toda mi finca</span>
+                                <span className={`text-xs mt-1 leading-snug block fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-400'}`}>
+                                    Todos los mundos: suelo, agua, sanidad, mercado y más
+                                </span>
+                            </span>
+                            <ChevronRight size={22} className="shrink-0 text-slate-500" aria-hidden="true" />
+                        </button>
+                    )}
                 </div>
 
                 {/* El Ciclo Vivo: portal a la rueda de las 7 fases. Estado real
@@ -909,6 +951,17 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                         className="text-xs font-bold underline underline-offset-2 fvh-block-label"
                     >
                         Ayuda
+                    </button>
+                    <span aria-hidden="true" className="fvh-block-label">·</span>
+                    {/* "Jugar" conserva su entrada en el home: antes era uno de
+                        los 4 portales del hero (reemplazados por las 6 puertas);
+                        el juego sigue alcanzable desde aquí. */}
+                    <button
+                        type="button"
+                        onClick={() => onNavigate('juego')}
+                        className="text-xs font-bold underline underline-offset-2 fvh-block-label"
+                    >
+                        Jugar
                     </button>
                 </div>
             </>

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -4,12 +4,13 @@
  * la TAREA i18n de ADR-050 (transversal a toda la app), fuera del alcance de esta
  * feature visual — mismo criterio que MiFincaVivaHomeCard.jsx, FincaCards.jsx y
  * FincaRedInstitucional.jsx en este mismo directorio. */
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { listFarmProcesses } from '../../db/farmProcessCache';
 import useAssetStore from '../../store/useAssetStore';
 import { buildFincaScene } from '../../services/fincaSceneService';
 import { selectSceneVariant, SCENE_KINDS } from '../../services/fincaSceneProfileSelector';
-import { getProfile, saveProfile, getInvernaderoEstructura } from '../../services/userProfileService';
+import { getProfile, saveProfile, getInvernaderoEstructura, hasManualModuleVisibility } from '../../services/userProfileService';
+import { esPerfilUrbano } from '../../services/homeModuleSelector';
 import { getOperatorPhoto } from '../../services/operatorPhotoService';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import { deriveAtmosphere } from '../../services/atmosphereService';
@@ -107,10 +108,13 @@ const COLIBRI_REAL = colibriRealActivo();
  *   la MISMA página, bajo el hero, así que el portal "Gestionar" la REVELA con un
  *   scroll a su ancla — NO navega a otra vista (mucho menos al juego). Si no se
  *   pasa, cae a un scroll directo al ancla #finca-gestion (mismo destino).
+ * @param {Function} [props.onTodaMiFinca]  revela LOS MUNDOS completos (la
+ *   puerta "Toda mi finca"): DashboardLive expande el bloque plegado y hace
+ *   scroll. Sin callback, cae a un scroll directo al ancla #bloque-mundos.
  * @param {React.ReactNode} [props.children]  escena alterna (red institucional).
  * @param {string} [props.titulo]  título accesible (default "Mi finca viva").
  */
-export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, children, titulo }) {
+export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, onTodaMiFinca, children, titulo }) {
   // Piel del tema activo: el ícono de marca del agente (la A roja en biopunk, la
   // sol-mano en verde-vivo, etc.) sigue al tema, igual que la escena toma su piel
   // del tema vía los tokens --c-*/--fvh-* del CSS. Con la flag OFF este hero no se
@@ -134,6 +138,19 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
       if (seccion?.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   };
+  // La puerta "Toda mi finca" abre LOS MUNDOS completos, que viven en la hoja
+  // bajo el hero (DashboardLive los revela con onTodaMiFinca: expandir +
+  // scroll). Sin callback, cae a un scroll directo al ancla del bloque.
+  const irATodaMiFinca = () => {
+    if (onTodaMiFinca) { onTodaMiFinca(); return; }
+    if (typeof document !== 'undefined') {
+      const seccion = document.getElementById('bloque-mundos');
+      if (seccion?.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+  // El bloque "Registrar en la finca" sigue alcanzable por scroll en la misma
+  // página (irAGestion queda como puente del ancla para quien lo necesite).
+  void irAGestion;
 
   // ── Datos reales de la finca (offline-first) ─────────────────────────────
   const [processes, setProcesses] = useState([]);
@@ -288,6 +305,63 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
   // usan). Tras el split vive en biopunk2 (donde quedó la Finca Organismo).
   const organismoActivo = escenaVivaActiva && temaEfectivo === 'biopunk2';
 
+  // ── GATE DE ANIMALES para la puerta "Mis animales" ────────────────────────
+  // Mismo criterio que DashboardLive.mostrarAnimales (el usuario solo ve lo
+  // que necesita): un urbano de balcón/terraza no ve la puerta; el control
+  // manual del home (#1560) y el operador la conservan.
+  const [mostrarAnimales] = useState(() => {
+    try {
+      if (esOperadorActual()) return true;
+      if (hasManualModuleVisibility()) return true;
+      return !esPerfilUrbano(getProfile());
+    } catch (_) {
+      return true; // Fail-open: no esconder la puerta por un error.
+    }
+  });
+
+  // ── MODO "PLENO SOL" (usabilidad campesina #7) ────────────────────────────
+  // Alto contraste claro para leer el teléfono a mediodía al aire libre: el
+  // biopunk nocturno va bien de noche, pero al rayo del sol un fondo oscuro
+  // no se ve. AUTOMÁTICO de día (deriveAtmosphere → luz 'dia') con override
+  // MANUAL persistido ('1' forzado ON, '0' forzado OFF, ausente = auto).
+  const [solPref, setSolPref] = useState(() => {
+    try { return localStorage.getItem(PLENO_SOL_KEY) || 'auto'; }
+    catch (_) { return 'auto'; }
+  });
+  const plenoSol = solPref === '1' || (solPref === 'auto' && tonoLuz(atmosfera) === 'dia');
+  const alternarSol = () => {
+    const next = plenoSol ? '0' : '1';
+    setSolPref(next);
+    try { localStorage.setItem(PLENO_SOL_KEY, next); } catch (_) { /* incógnito */ }
+  };
+
+  // ── "ESCUCHAR" 🔊 (usabilidad campesina #6, baja alfabetización) ──────────
+  // Lee la pantalla en voz alta con el TTS propio (kokoro + fallback Web
+  // Speech, ttsService). Import perezoso: el peso del TTS no entra al chunk
+  // del home salvo que se use. Mientras habla, el botón pasa a "Parar".
+  const [hablando, setHablando] = useState(false);
+  const ttsUnsubRef = useRef(null);
+  useEffect(() => () => { if (ttsUnsubRef.current) ttsUnsubRef.current(); }, []);
+  const textoEscuchar = () => {
+    const puertasTxt = 'sus matas, sus animales, el tiempo, vender, aprender, o toda su finca';
+    const estadoTxt = poblada
+      ? 'Todo tranquilo en su finca.'
+      : 'Su finca está empezando. Registre su primera siembra y la escena cobra vida.';
+    return `Buenas, soy Chagra. Esta es su finca viva. ${estadoTxt} `
+      + 'Toque el botón verde grande, hable, y yo le contesto. '
+      + `También puede entrar a: ${puertasTxt}.`;
+  };
+  const escuchar = async () => {
+    try {
+      const tts = await import('../../services/ttsService');
+      if (!ttsUnsubRef.current) {
+        ttsUnsubRef.current = tts.onSpeakingChange((v) => setHablando(!!v));
+      }
+      if (tts.isAudioPlaying()) { tts.stop(); return; }
+      await tts.speakSentences(textoEscuchar());
+    } catch (_) { /* sin audio disponible: el botón no rompe el home */ }
+  };
+
   return (
     <section
       data-testid="finca-viva-hero"
@@ -295,6 +369,7 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
       className="fvh"
       data-luz={atmosfera.luz || undefined}
       data-clima={atmosfera.condicion || undefined}
+      data-plenosol={plenoSol ? '1' : undefined}
     >
       <div className="fvh-shell">
         {/* ── TOPBAR (con jerarquía y aire — feedback #3) ───────────────────── */}
@@ -464,8 +539,11 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
                       /* ESCENA VIVA DEL TEMA ACTIVO (organismo/árbol de la
                          vida/huerto/trazo). Lleva la estructura declarada
                          (#34): la estructura de cada escena porta el marcador
-                         fvh-estructura solo si fue declarada. */
-                      <EscenaViva estructura={estructuraFinca} />
+                         fvh-estructura solo si fue declarada. `onPregunte`
+                         vuelve TAPPABLE el corazón-semilla de la Finca
+                         Organismo (abre el agente, mismo patrón que el
+                         potrero→animales); las demás escenas lo ignoran. */
+                      <EscenaViva estructura={estructuraFinca} onPregunte={abrirAgente} />
                     ) : (
                       <SceneFinca
                         poblada={poblada}
@@ -526,25 +604,58 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
 
           {/* ── COLUMNA derecha en desktop / debajo en móvil ────────────────── */}
           <div className="fvh-aside">
-            {/* COMPOSITOR DEL AGENTE */}
+            {/* LA acción dominante: "PREGUNTE" (usabilidad campesina #2).
+                Antes "preguntar" aparecía en 4 formas sin que ninguna mandara
+                (la A del header, el globo del colibrí, este compositor y un
+                portal). Ahora ESTE botón manda: grande (≥96px), late como el
+                corazón de la escena y habla en cristiano. Las otras entradas
+                quedan de apoyo (la A del header, el corazón de la escena). */}
             <div className="fvh-composer-wrap">
               <button
                 type="button"
-                className="fvh-composer"
+                className="fvh-composer fvh-composer--pregunte"
                 onClick={abrirAgente}
                 data-testid="finca-viva-agent-fab"
-                aria-label="Pregúntele a Chagra"
+                aria-label="Pregúntele a Chagra: toque y hable, Chagra le contesta"
               >
-                <span className="av" aria-hidden="true"><ColibriAvatar /></span>
-                <span className="ph">Pregúntele a Chagra…</span>
-                <span className="mic" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-                    <rect x="9" y="3" width="6" height="11" rx="3" fill="#1f3300" />
-                    <path d="M6 11a6 6 0 0 0 12 0M12 17v3" stroke="#1f3300" strokeWidth="2" strokeLinecap="round" />
+                <span className="fvh-corazon-btn" aria-hidden="true">
+                  <span className="fvh-corazon-pulso" />
+                  <span className="fvh-corazon-pulso fvh-corazon-pulso2" />
+                  <svg viewBox="0 0 24 24" width="30" height="30" fill="none" aria-hidden="true">
+                    <rect x="9" y="3" width="6" height="11" rx="3" fill="#12260a" />
+                    <path d="M6 11a6 6 0 0 0 12 0M12 17v3M8.5 20h7" stroke="#12260a" strokeWidth="2.2" strokeLinecap="round" />
                   </svg>
                 </span>
+                <span className="fvh-pregunte-txt">
+                  <b>Pregunte</b>
+                  <small>Toque y hable. Chagra le contesta.</small>
+                </span>
               </button>
-              <div className="fvh-composer-hint">Toque 🎙️ y pregunte en voz alta — o escriba arriba</div>
+              {/* Escuchar (🔊 lee la pantalla, baja alfabetización) + Pleno sol
+                  (alto contraste de mediodía). Pareja de pastillas bajo la
+                  acción dominante. */}
+              <div className="fvh-audio-sol">
+                <button
+                  type="button"
+                  className="fvh-escuchar"
+                  data-testid="fvh-escuchar"
+                  aria-pressed={hablando}
+                  aria-label={hablando ? 'Parar la lectura en voz alta' : 'Escuchar: Chagra le lee la pantalla en voz alta'}
+                  onClick={escuchar}
+                >
+                  {hablando ? '⏹ Parar' : '🔊 Escuchar'}
+                </button>
+                <button
+                  type="button"
+                  className="fvh-sol-toggle"
+                  data-testid="fvh-pleno-sol"
+                  aria-pressed={plenoSol}
+                  aria-label={plenoSol ? 'Volver a la vista de noche' : 'Pleno sol: vista clara para leer a mediodía'}
+                  onClick={alternarSol}
+                >
+                  {plenoSol ? '🌙 Noche' : '☀️ Pleno sol'}
+                </button>
+              </div>
 
               {/* NIVEL DE RESPUESTA — junto al agente, porque define CÓMO le
                   responde Chagra. Renombrado del antiguo "Campesino/Experto"
@@ -578,33 +689,36 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
               </div>
             </div>
 
-            {/* HERO TEXT */}
+            {/* HERO TEXT — sin jerga de ingeniero (antes "SU AGENTE
+                AGROECOLÓGICO"): palabras del campo. */}
             <div className="fvh-hero-saludo">
-              <div className="h-small">SU AGENTE AGROECOLÓGICO</div>
+              <div className="h-small">CHAGRA, SU COMPAÑERO DE CAMPO</div>
               <h1 dangerouslySetInnerHTML={{ __html: HERO[escala][0] }} />
               <p>{HERO[escala][1]}</p>
             </div>
           </div>
         </main>
 
-        {/* ── 4 PORTALES = LUGARES DE LA FINCA ───────────────────────────────── */}
-        <div className="fvh-portales-tit">Lugares de su finca <span /></div>
-        <nav className="fvh-portales" aria-label="Lugares de su finca" data-testid="finca-viva-portales">
-          {buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, escala }).map((p) => (
+        {/* ── LAS 6 PUERTAS (usabilidad campesina #5) ─────────────────────────
+            Antes: 4 portales con descripción + ~20 tarjetas + ~35 chips abajo.
+            Ahora: SEIS puertas de una-dos palabras, dibujo grande + palabra
+            grande, targets ≥96px (#8). Cada una enruta a un mundo/vista que YA
+            existe (nada nuevo que mantener). "Toda mi finca" abre los mundos
+            completos en la hoja de abajo. */}
+        <div className="fvh-portales-tit">¿A dónde va? <span /></div>
+        <nav className="fvh-puertas" aria-label="Puertas de su finca" data-testid="finca-viva-puertas">
+          {buildPuertas({ onNavigate, irATodaMiFinca, mostrarAnimales }).map((p, i) => (
             <button
               key={p.id}
               type="button"
-              className={`fvh-portal ${p.clase}`}
+              className={`fvh-puerta t-${p.tinte}`}
+              data-testid={`puerta-${p.id}`}
               onClick={p.onClick}
-              style={{ animationDelay: p.delay }}
-              aria-label={`${p.titulo}: ${p.desc}`}
+              style={{ animationDelay: `${0.08 + i * 0.06}s` }}
+              aria-label={`${p.nombre}: abre ${p.abre}`}
             >
-              <span className="ir" aria-hidden="true">Entrar →</span>
-              {p.placeSvg}
-              <span className="fvh-p-scrim" aria-hidden="true" />
-              <span className="fvh-p-nuevo">{p.badge}</span>
-              <div className="p-head"><div className="p-emoji" aria-hidden="true">{p.emoji}</div><h3>{p.titulo}</h3></div>
-              <p>{p.desc}</p>
+              <span className="fvh-puerta-emoji" aria-hidden="true">{p.emoji}</span>
+              <span className="fvh-puerta-nombre">{p.nombre}</span>
             </button>
           ))}
         </nav>
@@ -1040,35 +1154,6 @@ function ColibriVuela() {
   );
 }
 
-/** Mismo colibrí en versión avatar redondo para el compositor del agente. */
-function ColibriAvatar() {
-  return (
-    <svg viewBox="0 0 48 48" width="26" height="26" aria-hidden="true">
-      <defs>
-        <linearGradient id="fvh-colibri-av-plum" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0" stopColor="#34d399" />
-          <stop offset="45%" stopColor="#10b981" />
-          <stop offset="75%" stopColor="#22d3ee" />
-          <stop offset="100%" stopColor="#a78bfa" />
-        </linearGradient>
-        <radialGradient id="fvh-colibri-av-gor" cx="50%" cy="50%" r="50%">
-          <stop offset="0" stopColor="#fde68a" />
-          <stop offset="50%" stopColor="#f59e0b" />
-          <stop offset="100%" stopColor="#dc2626" />
-        </radialGradient>
-      </defs>
-      <path d="M8 26 L2 22 L6 28 L1 32 L7 31 L5 37 L12 30 Z" fill="url(#fvh-colibri-av-plum)" opacity="0.9" />
-      <path d="M20 22 Q10 15 4 22 Q11 29 21 25 Z" fill="url(#fvh-colibri-av-plum)" opacity="0.6" />
-      <ellipse cx="22" cy="25" rx="11" ry="6.6" fill="url(#fvh-colibri-av-plum)" transform="rotate(-16 22 25)" />
-      <circle cx="33" cy="20" r="5.6" fill="url(#fvh-colibri-av-plum)" />
-      <ellipse cx="34" cy="24" rx="3" ry="2" fill="url(#fvh-colibri-av-gor)" opacity="0.95" />
-      <circle cx="34.4" cy="18.6" r="1.3" fill="#0c0a09" />
-      <circle cx="34" cy="18.2" r="0.45" fill="#fff" />
-      <path d="M38.5 20 Q46 22 47 27" fill="none" stroke="#e2e8f0" strokeWidth="1.5" strokeLinecap="round" />
-    </svg>
-  );
-}
-
 // ── Catálogos de texto (refinados del mockup F2) ───────────────────────────
 
 /**
@@ -1105,259 +1190,39 @@ const HERO = {
     'Camine a un lugar de la finca, o escríbame abajo. Hablo claro y solo con datos verificados.',
   ],
 };
+// Un solo "pregunte" que mande (usabilidad campesina #2): el globo del colibrí
+// ya NO repite "pregúnteme aquí abajo" — saluda y orienta; preguntar vive en
+// el botón grande "Pregunte" (y en el corazón de la escena biopunk).
 const COLIBRI = {
-  balcon: ['Buenas, soy Chagra', 'Su balcón está al día. Toque una matera o pregúnteme aquí abajo.'],
-  invernadero: ['Buenas, soy Chagra', 'Sus hileras están bien. ¿Reviso riego o plagas? Pregúnteme abajo.'],
-  finca: ['Buenas, soy Chagra', 'Todo tranquilo en su finca. Toque un lugar para entrar, o pregúnteme aquí abajo.'],
+  balcon: ['Buenas, soy Chagra', 'Su balcón está al día. Toque una matera para verla de cerca.'],
+  invernadero: ['Buenas, soy Chagra', 'Sus hileras están bien. Toque un lugar para revisarlo.'],
+  finca: ['Buenas, soy Chagra', 'Todo tranquilo en su finca. Toque una puerta para entrar.'],
 };
 
+// Preferencia persistida del modo "pleno sol" ('1' ON, '0' OFF, ausente=auto).
+const PLENO_SOL_KEY = 'chagra:home:pleno-sol';
+
 /**
- * Los 4 portales/lugares del home F2 ("Mi finca", "Aprender", "Jugar",
- * "Pregúntele a Chagra"). El badge del portal "Mi finca" refleja el DATO
- * REAL de la finca (0 siembras → "EMPIECE AQUÍ"; con siembras → resumen real).
+ * LAS 6 PUERTAS del home (usabilidad campesina #5): una-dos palabras, dibujo
+ * grande, targets ≥96px. Cada puerta enruta a un mundo/vista que YA existe:
+ *   · Mis matas     → la portada del mundo Cultivos ('mundo_cultivos').
+ *   · Mis animales  → el mundo Animales ('mundo' + {mundo:'animales'}),
+ *                     gateado por perfil (mostrarAnimales, igual que el home).
+ *   · El tiempo     → 'hoy_finca' (su día: lluvia, heladas y avisos).
+ *   · Vender        → 'mercado'.
+ *   · Aprender      → 'aprende'.
+ *   · Toda mi finca → LOS MUNDOS completos en la hoja de abajo (revelar).
  */
-function buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, escala }) {
-  const total = Number(scene?.totalCultivos) || 0;
-  const animales = Array.isArray(scene?.animales) ? scene.animales.length : 0;
-  let badgeGestionar;
-  if (!poblada || total + animales === 0) {
-    badgeGestionar = escala === 'balcon'
-      ? 'EMPIECE AQUÍ · 0 materas'
-      : escala === 'invernadero'
-        ? 'EMPIECE AQUÍ · 0 trasplantes'
-        : 'EMPIECE AQUÍ · 0 siembras';
-  } else {
-    const partes = [];
-    if (total > 0) partes.push(total === 1 ? '1 siembra' : `${total} siembras`);
-    if (animales > 0) partes.push('animales');
-    badgeGestionar = partes.join(' · ') || 'Su finca';
-  }
-
-  return [
-    {
-      id: 'gestionar',
-      titulo: 'Mi finca',
-      desc: 'Registre y cuide sus siembras, zonas y animales.',
-      emoji: '🌱',
-      clase: 'p-gestionar',
-      delay: '.1s',
-      badge: badgeGestionar,
-      placeSvg: <PlaceGestionar />,
-      // GESTIÓN, no el juego: revela la sección de registros/acciones de la
-      // finca (siembras, zonas, animales) en esta misma página. El bug viejo
-      // mandaba a onNavigate('juego') — el mismo destino que el portal "Jugar".
-      onClick: () => irAGestion(),
-    },
-    {
-      id: 'aprender',
-      titulo: 'Aprender',
-      desc: 'Suelo vivo, milpa, biopreparados, MIP y fenología.',
-      emoji: '📚',
-      clase: 'p-aprender',
-      delay: '.18s',
-      badge: '5 lecciones',
-      placeSvg: <PlaceAprender />,
-      onClick: () => onNavigate?.('aprende'),
-    },
-    {
-      id: 'jugar',
-      titulo: 'Jugar',
-      desc: 'Haga crecer su finca y defiéndala jugando.',
-      emoji: '🎮',
-      clase: 'p-jugar',
-      delay: '.26s',
-      badge: 'Mi Finca Viva',
-      placeSvg: <PlaceJugar />,
-      onClick: () => onNavigate?.('juego'),
-    },
-    {
-      id: 'agente',
-      titulo: 'Pregúntele a Chagra',
-      desc: 'Pregunte lo que sea: respuestas con su fuente.',
-      emoji: '💬',
-      clase: 'p-agente',
-      delay: '.34s',
-      badge: 'Voz y foto',
-      placeSvg: <PlaceAgente />,
-      onClick: () => abrirAgente(),
-    },
+function buildPuertas({ onNavigate, irATodaMiFinca, mostrarAnimales }) {
+  const puertas = [
+    { id: 'matas', emoji: '🌱', nombre: 'Mis matas', tinte: 'verde', abre: 'sus siembras y cultivos', onClick: () => onNavigate?.('mundo_cultivos') },
+    { id: 'animales', emoji: '🐔', nombre: 'Mis animales', tinte: 'teja', abre: 'sus gallinas, cerdos y demás animales', onClick: () => onNavigate?.('mundo', { mundo: 'animales' }) },
+    { id: 'tiempo', emoji: '🌦️', nombre: 'El tiempo', tinte: 'cielo', abre: 'el clima de hoy y los próximos días', onClick: () => onNavigate?.('hoy_finca') },
+    { id: 'vender', emoji: '🧺', nombre: 'Vender', tinte: 'ambar', abre: 'precios, mercado y su despensa', onClick: () => onNavigate?.('mercado') },
+    { id: 'aprender', emoji: '📖', nombre: 'Aprender', tinte: 'uva', abre: 'las lecciones y guías del campo', onClick: () => onNavigate?.('aprende') },
+    { id: 'finca', emoji: '🏡', nombre: 'Toda mi finca', tinte: 'menta', abre: 'todos los mundos de su finca', onClick: () => irATodaMiFinca() },
   ];
-}
-
-// ── SVG de los 4 portales (place-svg) ────────────────────────────────────────
-// Cada portal es un LUGAR ilustrado con horizonte, tierra y un foco propio
-// (parcela con casita · rancho de lectura · isla de juego · claro del agente).
-// Sin <text> con emoji dentro del SVG: en Android/iOS viejos esos glifos
-// renderizan monocromos o vacíos — todo es dibujo vectorial propio.
-
-function PlaceGestionar() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* amanecer del lugar: sol suave + loma de fondo */}
-      <circle cx="146" cy="26" r="14" fill="#ffe08a" opacity=".5" />
-      <circle cx="146" cy="26" r="8" fill="#ffedb3" opacity=".8" />
-      <path d="M-4 66 Q50 42 104 62 T184 58 V90 H-4 Z" fill="#356b42" opacity=".55" />
-      {/* parcela isométrica con surcos */}
-      <polygon points="90,44 152,80 90,116 28,80" fill="#3f7a4e" />
-      <polygon points="90,44 152,80 90,82 28,80" fill="#4f9460" opacity=".7" />
-      <g stroke="#2f6b3a" strokeWidth="2.4" strokeLinecap="round" fill="none" opacity=".7">
-        <path d="M56 82 L90 100" /><path d="M70 74 L108 95" /><path d="M84 66 L122 87" />
-      </g>
-      {/* matas en hilera (tallo + copa + fruto) */}
-      <g className="fvh-p-mata">
-        <g strokeLinecap="round">
-          <path d="M64 84 v-12" stroke="#2f6b3a" strokeWidth="2.2" fill="none" />
-          <circle cx="64" cy="69" r="5" fill="#7fc06f" /><circle cx="62" cy="67" r="2.6" fill="#a7e17a" />
-          <circle cx="67" cy="72" r="2" fill="#ff5d44" />
-        </g>
-        <g strokeLinecap="round">
-          <path d="M88 96 v-13" stroke="#2f6b3a" strokeWidth="2.2" fill="none" />
-          <circle cx="88" cy="79" r="5.5" fill="#7fc06f" /><circle cx="86" cy="77" r="2.8" fill="#a7e17a" />
-          <circle cx="91" cy="82" r="2" fill="#ffd24d" />
-        </g>
-        <g strokeLinecap="round">
-          <path d="M112 88 v-11" stroke="#2f6b3a" strokeWidth="2.2" fill="none" />
-          <circle cx="112" cy="73" r="4.6" fill="#7fc06f" /><circle cx="110" cy="71" r="2.4" fill="#a7e17a" />
-        </g>
-      </g>
-      {/* casita campesina al fondo (pared clara, techo terracota, humo) */}
-      <g transform="translate(38 52)">
-        <path className="fvh-p-humo" d="M14 -12 q-3 -5 1 -8 q4 -3 1 -7" stroke="#f4efe2" strokeWidth="2.2" fill="none" strokeLinecap="round" opacity=".75" />
-        <rect x="11" y="-14" width="5" height="8" fill="#8a5a38" />
-        <polygon points="0,-6 13,-16 26,-6" fill="#c2562f" />
-        <polygon points="2,-6 24,-6 24,10 2,10" fill="#f6efe0" />
-        <rect x="10" y="0" width="6" height="10" fill="#7a5230" />
-        <rect x="4" y="-2" width="4.5" height="4.5" fill="#9fc9d8" />
-        <rect x="18" y="-2" width="4.5" height="4.5" fill="#9fc9d8" />
-      </g>
-      {/* letrero de madera de la parcela */}
-      <g transform="translate(126 92)">
-        <rect x="6" y="0" width="3" height="12" rx="1.5" fill="#7a5230" />
-        <rect x="-2" y="-8" width="19" height="10" rx="2.5" fill="#caa066" />
-        <path d="M2 -3 h11" stroke="#7a5230" strokeWidth="1.6" strokeLinecap="round" />
-      </g>
-    </svg>
-  );
-}
-function PlaceAprender() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* tarde dorada + loma ocre */}
-      <circle cx="34" cy="24" r="12" fill="#ffe6a8" opacity=".55" />
-      <path d="M-4 70 Q60 48 120 66 T184 62 V96 H-4 Z" fill="#9a5f24" opacity=".45" />
-      {/* explanada de tierra */}
-      <polygon points="90,50 152,84 90,118 28,84" fill="#c47b2f" />
-      <polygon points="90,50 152,84 90,86 28,84" fill="#d18c3f" opacity=".7" />
-      {/* rancho de lectura: paja a trazos + horcones + libro abierto DIBUJADO */}
-      <g transform="translate(90 58)">
-        <polygon points="-30,16 0,0 30,16 24,20 0,7 -24,20" fill="#a85d28" />
-        <polygon points="-26,17 0,4 26,17 0,17" fill="#8a4b20" opacity=".9" />
-        <g stroke="#e8bd7a" strokeWidth="1.4" opacity=".65" strokeLinecap="round">
-          <path d="M-20 13 L0 3" /><path d="M-12 15 L2 8" /><path d="M20 13 L0 3" /><path d="M12 15 L-2 8" />
-        </g>
-        <g stroke="#7a5230" strokeWidth="3" strokeLinecap="round">
-          <path d="M-22 18 V36" /><path d="M22 18 V36" />
-        </g>
-        {/* mesa + libro abierto (páginas blancas, lomo, renglones) */}
-        <polygon points="-16,34 0,26 16,34 0,42" fill="#8a6038" />
-        <g className="fvh-p-libro">
-          <path d="M-11 30 Q-5 26 0 28 L0 36 Q-5 34 -11 37 Z" fill="#fdf8ea" />
-          <path d="M11 30 Q5 26 0 28 L0 36 Q5 34 11 37 Z" fill="#f4ecd8" />
-          <path d="M0 28 V36" stroke="#c9b98e" strokeWidth="1" />
-          <g stroke="#b9a87c" strokeWidth=".9" opacity=".8">
-            <path d="M-8 31 Q-4 29 -1.5 30" /><path d="M-8 33.5 Q-4 31.5 -1.5 32.5" />
-            <path d="M8 31 Q4 29 1.5 30" /><path d="M8 33.5 Q4 31.5 1.5 32.5" />
-          </g>
-        </g>
-      </g>
-      {/* hojas-página que flotan (el saber que vuela) */}
-      <g className="fvh-p-hoja" fill="#e6c873" opacity=".9">
-        <path d="M132 52 q6 -4 10 0 q-4 6 -10 0 Z" />
-        <path d="M44 64 q5 -4 9 0 q-4 5 -9 0 Z" opacity=".8" />
-      </g>
-    </svg>
-  );
-}
-function PlaceJugar() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* cielo lúdico con estrellitas de juego */}
-      <g fill="#e8f6ff" className="fvh-p-brillo">
-        <path d="M38 26 l2 5 5 2 -5 2 -2 5 -2 -5 -5 -2 5 -2 Z" opacity=".9" />
-        <path d="M142 34 l1.6 4 4 1.6 -4 1.6 -1.6 4 -1.6 -4 -4 -1.6 4 -1.6 Z" opacity=".7" />
-      </g>
-      {/* isla-tablero: casillas isométricas alternadas */}
-      <polygon points="90,50 152,84 90,118 28,84" fill="#4f8fc0" />
-      <g>
-        <polygon points="90,58 121,75 90,92 59,75" fill="#9fe3ee" opacity=".9" />
-        <polygon points="90,58 105.5,66.5 90,75 74.5,66.5" fill="#7fc06f" />
-        <polygon points="105.5,66.5 121,75 105.5,83.5 90,75" fill="#c8f0f6" />
-        <polygon points="74.5,66.5 90,75 74.5,83.5 59,75" fill="#c8f0f6" />
-        <polygon points="90,75 105.5,83.5 90,92 74.5,83.5" fill="#7fc06f" />
-      </g>
-      {/* dado isométrico */}
-      <g className="fvh-p-dado" transform="translate(90 66)">
-        <polygon points="0,-10 11,-4 0,2 -11,-4" fill="#fdf8ea" />
-        <polygon points="-11,-4 0,2 0,15 -11,9" fill="#dfe8ea" />
-        <polygon points="11,-4 0,2 0,15 11,9" fill="#c3d3d8" />
-        <circle cx="0" cy="-4.5" r="1.8" fill="#38506a" />
-        <circle cx="-5.5" cy="3.5" r="1.6" fill="#38506a" /><circle cx="-5.5" cy="9" r="1.6" fill="#38506a" />
-        <circle cx="5.5" cy="3.5" r="1.6" fill="#38506a" /><circle cx="5.5" cy="9" r="1.6" fill="#38506a" /><circle cx="5.5" cy="6.2" r="1.6" fill="#38506a" />
-      </g>
-      {/* banderín de meta */}
-      <g transform="translate(124 78)">
-        <path d="M0 14 V-10" stroke="#38506a" strokeWidth="2.4" strokeLinecap="round" />
-        <path d="M0 -10 L14 -6 L0 -2 Z" fill="#ff5d44" />
-      </g>
-      {/* mariquita dibujada (fauna aliada del juego) */}
-      <g className="fvh-p-bicho" transform="translate(50 88)">
-        <ellipse cx="0" cy="0" rx="6" ry="4.6" fill="#e0532f" />
-        <path d="M0 -4.6 V4.6" stroke="#3a2024" strokeWidth="1.2" />
-        <circle cx="-2.4" cy="-1.4" r="1.1" fill="#3a2024" /><circle cx="2.6" cy="1" r="1.1" fill="#3a2024" />
-        <circle cx="0" cy="-5.4" r="2" fill="#3a2024" />
-      </g>
-      {/* mariposa dibujada */}
-      <g className="fvh-p-bicho" transform="translate(128 58)" style={{ animationDelay: '.6s' }}>
-        <path d="M0 0 q-6 -7 -10 -2 q-2 4 5 5 Z" fill="#f2b441" />
-        <path d="M0 0 q6 -7 10 -2 q2 4 -5 5 Z" fill="#ffd24d" />
-        <path d="M0 -2 V5" stroke="#5a4329" strokeWidth="1.3" strokeLinecap="round" />
-      </g>
-    </svg>
-  );
-}
-function PlaceAgente() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* claro crepuscular con estrellas del agente */}
-      <g fill="#e9e3ff" className="fvh-p-brillo">
-        <circle cx="36" cy="26" r="1.6" /><circle cx="146" cy="22" r="1.3" /><circle cx="120" cy="38" r="1" />
-      </g>
-      <polygon points="90,50 152,84 90,118 28,84" fill="#5d4db0" />
-      <polygon points="90,50 152,84 90,86 28,84" fill="#6f5ec4" opacity=".65" />
-      {/* claro luminoso: anillos concéntricos que laten */}
-      <circle cx="90" cy="80" r="30" fill="#11281f" />
-      <circle className="fvh-p-anillo" cx="90" cy="80" r="30" fill="none" stroke="#a3e635" strokeWidth="2.5" opacity=".8" />
-      <circle className="fvh-p-anillo" cx="90" cy="80" r="36" fill="none" stroke="#a3e635" strokeWidth="1.2" opacity=".35" style={{ animationDelay: '.9s' }} />
-      {/* colibrí insignia (pico largo, gorget ámbar) */}
-      <g transform="translate(74 72)">
-        <path d="M4 12 L-3 9 L1 14 L-4 17 L3 16 Z" fill="#8b5cf6" opacity=".85" />
-        <ellipse cx="9" cy="10" rx="9" ry="5" fill="#10b981" transform="rotate(-16 9 10)" />
-        <circle cx="18" cy="7" r="4.4" fill="#06b6d4" />
-        <ellipse cx="19" cy="10" rx="2.4" ry="1.6" fill="#f59e0b" />
-        <circle cx="19" cy="6" r="1" fill="#0c0a09" />
-        <path d="M22 7 Q30 8 33 12" fill="none" stroke="#e2e8f0" strokeWidth="1.4" strokeLinecap="round" />
-        <path d="M10 7 Q3 1 -3 5 Q4 12 12 8 Z" fill="#8b5cf6" opacity="0.8" />
-      </g>
-      {/* globo de conversación con puntitos (la voz del agente) */}
-      <g className="fvh-p-globo" transform="translate(114 50)">
-        <rect x="-14" y="-10" width="30" height="18" rx="9" fill="#fdf8ea" />
-        <path d="M-6 7 L-10 14 L-1 8 Z" fill="#fdf8ea" />
-        <circle cx="-6" cy="-1" r="1.8" fill="#5d4db0" />
-        <circle cx="1" cy="-1" r="1.8" fill="#5d4db0" />
-        <circle cx="8" cy="-1" r="1.8" fill="#5d4db0" />
-      </g>
-    </svg>
-  );
+  return mostrarAnimales ? puertas : puertas.filter((p) => p.id !== 'animales');
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/src/components/dashboard/SceneFincaOrganismo.jsx
+++ b/src/components/dashboard/SceneFincaOrganismo.jsx
@@ -26,16 +26,25 @@
  *   el invernadero-célula de la escena lleva el data-testid/data-forma del
  *   contrato de FincaVivaHero.estructura.test.jsx (misma semántica que
  *   SceneFinca: el marcador aparece SOLO si la estructura está declarada).
+ * @param {?() => void} [props.onPregunte] al tocar el CORAZÓN-SEMILLA abre el
+ *   agente ("Pregunte"): la metáfora central de la escena deja de ser
+ *   decoración y se vuelve LA acción principal (usabilidad campesina #4).
+ *   Sin handler, el corazón queda como arte (sin rol ni foco).
  */
-export default function SceneFincaOrganismo({ estructura }) {
+export default function SceneFincaOrganismo({ estructura, onPregunte }) {
   const conEstructura = !!estructura?.tiene;
+  const conPregunte = typeof onPregunte === 'function';
+  const ariaEscena = 'Su finca convertida en organismo bioluminiscente, con el sol o la luna según la hora y el cielo real de su vereda: un corazón-semilla late bajo la tierra y su red de micorrizas conecta las raíces de cada planta, con lombrices y bichitos trabajando el suelo; cultivos con savia de neón, invernadero-célula que respira, campesino con su perro y colibrí de luz.';
   return (
     <svg
       className="fvo-svg"
       viewBox="0 0 390 486"
       preserveAspectRatio="xMidYMid slice"
-      role="img"
-      aria-label="Su finca convertida en organismo bioluminiscente, con el sol o la luna según la hora y el cielo real de su vereda: un corazón-semilla late bajo la tierra y su red de micorrizas conecta las raíces de cada planta, con lombrices y bichitos trabajando el suelo; cultivos con savia de neón, invernadero-célula que respira, campesino con su perro y colibrí de luz."
+      /* con el corazón tappable el SVG deja de ser imagen plana: role="img"
+         volvería PRESENTACIONALES a sus hijos y el botón "Pregunte" no
+         existiría para lectores de pantalla. */
+      role={conPregunte ? 'group' : 'img'}
+      aria-label={ariaEscena}
       data-testid="fvo-escena"
     >
       <defs>
@@ -638,10 +647,36 @@ export default function SceneFincaOrganismo({ estructura }) {
         <path d="M327.6,445.4 Q326,444 325.2,442.6" stroke="#d8ff6a" strokeWidth=".7" fill="none" opacity=".8" />
       </g>
 
-      {/* ============ CORAZÓN-SEMILLA MICORRÍZICO (la vida bajo la tierra) ============ */}
+      {/* ============ CORAZÓN-SEMILLA MICORRÍZICO (la vida bajo la tierra) ============
+          Con `onPregunte` el corazón entero es un BOTÓN (tap / Enter / Espacio)
+          que abre el agente — el mismo patrón del potrero→animales: la metáfora
+          central deja de ser decoración y pasa a ser LA acción de preguntar.
+          Sin handler queda como arte (aria-hidden, sin foco). */}
+      <g
+        className={`fvo-corazon-grupo${conPregunte ? ' fvo-corazon-tap' : ''}`}
+        data-testid="fvo-corazon"
+        {...(conPregunte
+          ? {
+              role: 'button',
+              tabIndex: 0,
+              'aria-label': 'El corazón de su finca: toque y pregúntele a Chagra con su voz.',
+              onClick: () => onPregunte(),
+              onKeyDown: (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onPregunte();
+                }
+              },
+            }
+          : { 'aria-hidden': true })}
+      >
       {/* cámara de suelo: da contexto y contraste al órgano */}
       <ellipse cx="195" cy="406" rx="42" ry="36" fill="#02040c" opacity=".55" />
       <ellipse cx="195" cy="406" rx="42" ry="36" fill="none" stroke="#0f3a30" strokeWidth="1" opacity=".55" />
+      {/* halo-invitación del tap (solo cuando el corazón es botón) */}
+      {conPregunte && (
+        <circle className="fvo-corazon-halo" cx="195" cy="406" r="32" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".5" />
+      )}
       {/* ondas de latido */}
       <circle className="fvo-heart-wave" cx="195" cy="406" r="24" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
       <circle className="fvo-heart-wave" style={{ animationDelay: '.6s' }} cx="195" cy="406" r="24" fill="none" stroke="#ff4fd8" strokeWidth="1" />
@@ -676,6 +711,8 @@ export default function SceneFincaOrganismo({ estructura }) {
         <circle cx="195" cy="407" r="5.2" fill="#eafff6" />
         <circle cx="195" cy="407" r="2.2" fill="#ff8fe4" />
       </g>
+      {/* cierre del grupo tappable del corazón (la etiqueta va aparte, abajo) */}
+      </g>
 
       {/* nutrientes viajando */}
       <circle className="fvo-spark fvo-p1" r="2.2" fill="#bfffe9" />
@@ -707,10 +744,13 @@ export default function SceneFincaOrganismo({ estructura }) {
         </g>
       </g>
 
-      {/* etiqueta viva */}
-      <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity=".65">
+      {/* etiqueta viva — con el corazón tappable invita a la acción (y deja
+          la jerga de laboratorio: "micorrízica" no es palabra del campo) */}
+      <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity=".65" aria-hidden="true">
         <text x="195" y="452" fill="#2dffc4" textAnchor="middle">CORAZÓN DE LA FINCA · VIVO</text>
-        <text x="195" y="464" fill="#5b7f93" textAnchor="middle" letterSpacing="1">la red micorrízica conecta cada planta</text>
+        <text x="195" y="464" fill="#5b7f93" textAnchor="middle" letterSpacing="1">
+          {conPregunte ? 'toque el corazón y pregúntele a Chagra' : 'las raíces de su finca están conectadas'}
+        </text>
       </g>
     </svg>
   );

--- a/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, cleanup, waitFor, within } from '@testing-library/react';
+import { render, screen, cleanup, waitFor, within, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -101,8 +101,11 @@ describe('DashboardLive — operador/extensionista ve los mundos (aditivo, no re
     expect(screen.getByTestId('finca-viva-hero').getAttribute('data-titulo'))
       .toBe('Red de fincas que acompaño');
 
-    // Y la hoja .fvh-resto NO se oculta: la grilla de mundos está presente.
+    // Y la hoja .fvh-resto NO se oculta: el bloque de mundos está presente.
+    // Desde la usabilidad campesina #5 los mundos arrancan PLEGADOS ("Toda mi
+    // finca"): un toque abre la grilla completa (reachability intacta).
     const bloque = screen.getByTestId('bloque-mundos');
+    fireEvent.click(within(bloque).getByTestId('abrir-mundos'));
     expect(within(bloque).getByTestId('mundos-finca')).toBeInTheDocument();
     // La hoja completa se renderiza (antes era null para el extensionista).
     expect(screen.getByTestId('fvh-resto')).toBeInTheDocument();

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -145,9 +145,22 @@ describe('Home F2 — reestructuración 2.0 "Los mundos de mi finca" (V4)', () =
     expect(ancla).toBe(block);
   });
 
-  test('LOS MUNDOS: la grilla monta los 9 mundos con su copy', async () => {
+  test('LOS MUNDOS arrancan PLEGADOS tras "Toda mi finca" (usabilidad #5) y un toque los abre completos', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
     const block = await screen.findByTestId('bloque-mundos');
+    // Plegados por defecto: el primer pantallazo son las 6 puertas del hero,
+    // no ~13 tarjetas + ~35 chips. La grilla NO está montada aún.
+    expect(within(block).queryByTestId('mundos-finca')).toBeNull();
+    const abrir = within(block).getByTestId('abrir-mundos');
+    expect(abrir).toBeInTheDocument();
+    fireEvent.click(abrir); // un solo toque: reachability intacta
+    expect(within(block).getByTestId('mundos-finca')).toBeInTheDocument();
+  });
+
+  test('LOS MUNDOS: la grilla (abierta) monta los 9 mundos con su copy', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('bloque-mundos');
+    fireEvent.click(within(block).getByTestId('abrir-mundos'));
     expect(within(block).getByTestId('mundos-finca')).toBeInTheDocument();
     for (const id of ['cultivos', 'suelo', 'agua', 'abono', 'sanidad', 'clima', 'animales', 'mercado', 'disenio']) {
       expect(within(block).getByTestId(`mundo-${id}`)).toBeInTheDocument();
@@ -160,7 +173,8 @@ describe('Home F2 — reestructuración 2.0 "Los mundos de mi finca" (V4)', () =
   test('mundos con pantalla propia navegan a la ruta mundo; los directos a su vista', async () => {
     const onNavigate = vi.fn();
     render(<DashboardLive onNavigate={onNavigate} />);
-    await screen.findByTestId('bloque-mundos');
+    const block = await screen.findByTestId('bloque-mundos');
+    fireEvent.click(within(block).getByTestId('abrir-mundos'));
 
     // Cultivos tiene PORTADA a medida (hub) → navega a su vista propia.
     fireEvent.click(screen.getByTestId('mundo-cultivos'));

--- a/src/components/dashboard/__tests__/FincaVivaHero.portales.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaHero.portales.test.jsx
@@ -3,12 +3,16 @@ import { render, screen, fireEvent, cleanup, within } from '@testing-library/rea
 import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Home F2 "Finca Viva" — los 4 portales del hero deben llevar a SU destino:
-//   · Mi finca  → la GESTIÓN de la finca (registros/acciones), NO el juego.
-//                 (bug: iba a onNavigate('juego'), igual que el portal "Jugar".)
-//   · Aprender  → la vista 'aprende'.
-//   · Jugar     → la vista 'juego' (ese SÍ es el juego).
-//   · Pregúntele a Chagra → abre el agente (onOpenAgent).
+// Home F2 "Finca Viva" — LAS 6 PUERTAS del hero (usabilidad campesina #5,
+// fold del mockup #/mockups/home-campesino) deben llevar a SU destino, que YA
+// existe en App.jsx:
+//   · Mis matas     → 'mundo_cultivos' (portada del mundo Cultivos).
+//   · Mis animales  → 'mundo' + { mundo: 'animales' } (gate por perfil).
+//   · El tiempo     → 'hoy_finca'.
+//   · Vender        → 'mercado'.
+//   · Aprender      → 'aprende'.
+//   · Toda mi finca → onTodaMiFinca (revela LOS MUNDOS en la hoja de abajo);
+//                     sin callback, scroll directo al ancla #bloque-mundos.
 // Y el resto del shell F2 (chip de ubicación, pastilla de ayuda, pastilla de
 // perfil) debe navegar a su ruta, sin botones muertos.
 
@@ -18,7 +22,10 @@ vi.mock('../../../db/farmProcessCache', () => ({ listFarmProcesses: vi.fn(async 
 vi.mock('../../../store/useAssetStore', () => ({
   default: (selector) => selector({ plants: [], lands: [], materials: [], isHydrated: true }),
 }));
-vi.mock('../../../services/userProfileService', () => ({ getProfile: () => ({ rol: 'campesino' }) }));
+vi.mock('../../../services/userProfileService', () => ({
+  getProfile: () => ({ rol: 'campesino' }),
+  hasManualModuleVisibility: () => false,
+}));
 vi.mock('../../../config/glaciarAccess', () => ({
   tieneAccesoGlaciarActual: () => false,
   esOperadorActual: () => false,
@@ -32,113 +39,148 @@ vi.mock('../../NotificationsBell', () => ({
 
 import FincaVivaHero from '../FincaVivaHero';
 
-const portalLabel = (el) => el.getAttribute('aria-label')?.split(':')[0];
+const puertaLabel = (el) => el.getAttribute('aria-label')?.split(':')[0];
 
 afterEach(() => cleanup());
 beforeEach(() => vi.clearAllMocks());
 
-describe('FincaVivaHero — los 4 portales llevan a su destino correcto', () => {
+describe('FincaVivaHero — las 6 puertas llevan a su destino correcto', () => {
   function renderHero(extra = {}) {
     const onNavigate = vi.fn();
     const onOpenAgent = vi.fn();
-    const onGestionar = vi.fn();
+    const onTodaMiFinca = vi.fn();
     render(
       <FincaVivaHero
         onNavigate={onNavigate}
         onOpenAgent={onOpenAgent}
-        onGestionar={onGestionar}
+        onTodaMiFinca={onTodaMiFinca}
         {...extra}
       />,
     );
-    return { onNavigate, onOpenAgent, onGestionar };
+    return { onNavigate, onOpenAgent, onTodaMiFinca };
   }
 
-  const getPortal = (nombre) => {
-    const nav = screen.getByTestId('finca-viva-portales');
+  const getPuerta = (nombre) => {
+    const nav = screen.getByTestId('finca-viva-puertas');
     return within(nav)
       .getAllByRole('button')
-      .find((b) => portalLabel(b) === nombre);
+      .find((b) => puertaLabel(b) === nombre);
   };
 
-  test('el portal "Mi finca" NO navega al juego', () => {
+  test('se renderizan las 6 puertas, de 1-2 palabras', () => {
+    renderHero();
+    const nav = screen.getByTestId('finca-viva-puertas');
+    const puertas = within(nav).getAllByRole('button');
+    expect(puertas).toHaveLength(6);
+    expect(puertas.map(puertaLabel)).toEqual([
+      'Mis matas', 'Mis animales', 'El tiempo', 'Vender', 'Aprender', 'Toda mi finca',
+    ]);
+  });
+
+  test('"Mis matas" abre la portada del mundo Cultivos', () => {
     const { onNavigate } = renderHero();
-    fireEvent.click(getPortal('Mi finca'));
-    expect(onNavigate).not.toHaveBeenCalledWith('juego');
+    fireEvent.click(getPuerta('Mis matas'));
+    expect(onNavigate).toHaveBeenCalledWith('mundo_cultivos');
   });
 
-  test('el portal "Mi finca" abre la GESTIÓN de la finca (onGestionar), no otra vista', () => {
-    const { onNavigate, onOpenAgent, onGestionar } = renderHero();
-    fireEvent.click(getPortal('Mi finca'));
-    expect(onGestionar).toHaveBeenCalledTimes(1);
-    // No se cuela a ninguna otra ruta ni al agente.
+  test('"Mis animales" abre el mundo Animales', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPuerta('Mis animales'));
+    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'animales' });
+  });
+
+  test('"El tiempo" abre su día en la finca (hoy_finca)', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPuerta('El tiempo'));
+    expect(onNavigate).toHaveBeenCalledWith('hoy_finca');
+  });
+
+  test('"Vender" abre el mercado', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPuerta('Vender'));
+    expect(onNavigate).toHaveBeenCalledWith('mercado');
+  });
+
+  test('"Aprender" abre las lecciones (aprende)', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPuerta('Aprender'));
+    expect(onNavigate).toHaveBeenCalledWith('aprende');
+  });
+
+  test('"Toda mi finca" revela LOS MUNDOS (onTodaMiFinca), no navega a otra vista', () => {
+    const { onNavigate, onTodaMiFinca } = renderHero();
+    fireEvent.click(getPuerta('Toda mi finca'));
+    expect(onTodaMiFinca).toHaveBeenCalledTimes(1);
     expect(onNavigate).not.toHaveBeenCalled();
-    expect(onOpenAgent).not.toHaveBeenCalled();
   });
 
-  test('sin onGestionar, "Mi finca" hace scroll al ancla #finca-gestion (no al juego)', () => {
+  test('sin onTodaMiFinca, "Toda mi finca" hace scroll al ancla #bloque-mundos', () => {
     const onNavigate = vi.fn();
     const seccion = document.createElement('div');
-    seccion.id = 'finca-gestion';
+    seccion.id = 'bloque-mundos';
     seccion.scrollIntoView = vi.fn();
     document.body.appendChild(seccion);
 
     render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
-    fireEvent.click(getPortal('Mi finca'));
+    fireEvent.click(getPuerta('Toda mi finca'));
 
     expect(seccion.scrollIntoView).toHaveBeenCalledTimes(1);
-    expect(onNavigate).not.toHaveBeenCalledWith('juego');
+    expect(onNavigate).not.toHaveBeenCalled();
     document.body.removeChild(seccion);
   });
 
-  test('el portal "Aprender" navega a la vista aprende', () => {
-    const { onNavigate } = renderHero();
-    fireEvent.click(getPortal('Aprender'));
-    expect(onNavigate).toHaveBeenCalledWith('aprende');
-  });
-
-  test('el portal "Jugar" SÍ navega al juego', () => {
-    const { onNavigate } = renderHero();
-    fireEvent.click(getPortal('Jugar'));
-    expect(onNavigate).toHaveBeenCalledWith('juego');
-  });
-
-  test('el portal "Pregúntele a Chagra" abre el agente (onOpenAgent), no navega a una vista', () => {
+  test('el botón dominante "Pregunte" (compositor) abre el agente', () => {
     const { onNavigate, onOpenAgent } = renderHero();
-    fireEvent.click(getPortal('Pregúntele a Chagra'));
+    fireEvent.click(screen.getByTestId('finca-viva-agent-fab'));
     expect(onOpenAgent).toHaveBeenCalledTimes(1);
     expect(onNavigate).not.toHaveBeenCalled();
   });
+});
 
-  test('cada portal mapea a un destino distinto (Mi finca ≠ Jugar)', () => {
-    const { onNavigate, onOpenAgent, onGestionar } = renderHero();
-    fireEvent.click(getPortal('Mi finca'));
-    fireEvent.click(getPortal('Jugar'));
-    // Mi finca fue a la gestión; Jugar al juego. No coinciden.
-    expect(onGestionar).toHaveBeenCalledTimes(1);
-    expect(onNavigate).toHaveBeenCalledWith('juego');
-    expect(onNavigate).not.toHaveBeenCalledWith('gestionar');
-    expect(onOpenAgent).not.toHaveBeenCalled();
+describe('FincaVivaHero — Escuchar (🔊) y Pleno sol (☀️)', () => {
+  test('el botón Escuchar existe y lee la pantalla con el TTS propio (kokoro)', async () => {
+    const onNavigate = vi.fn();
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
+    const btn = screen.getByTestId('fvh-escuchar');
+    expect(btn).toBeInTheDocument();
+    // El TTS se importa perezoso al primer toque; aquí basta con que el toque
+    // no reviente sin backend de audio (jsdom sin speechSynthesis).
+    fireEvent.click(btn);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  test('el toggle Pleno sol alterna la variante de alto contraste (data-plenosol)', () => {
+    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} />);
+    const hero = screen.getByTestId('finca-viva-hero');
+    const toggle = screen.getByTestId('fvh-pleno-sol');
+    const antes = hero.getAttribute('data-plenosol');
+    fireEvent.click(toggle);
+    const despues = hero.getAttribute('data-plenosol');
+    expect(despues).not.toBe(antes);
+    // Alterna de vuelta (override manual persistido, no se queda pegado).
+    fireEvent.click(toggle);
+    expect(hero.getAttribute('data-plenosol')).toBe(antes);
   });
 });
 
 describe('FincaVivaHero — barra superior sin botones muertos', () => {
   test('la pastilla de Ayuda navega a la vista ayuda (no era un botón muerto)', () => {
     const onNavigate = vi.fn();
-    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: 'Ayuda' }));
     expect(onNavigate).toHaveBeenCalledWith('ayuda');
   });
 
   test('la pastilla de Perfil navega a la vista perfil', () => {
     const onNavigate = vi.fn();
-    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
     // feedback operador #2: el acceso a PERFIL debe existir junto al "?".
     fireEvent.click(screen.getByRole('button', { name: 'Mi perfil' }));
     expect(onNavigate).toHaveBeenCalledWith('perfil');
   });
 
   test('el botón de Perfil está presente en el topbar junto al de Ayuda (no se pierde)', () => {
-    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} />);
     const ayuda = screen.getByRole('button', { name: 'Ayuda' });
     const perfil = screen.getByTestId('finca-viva-perfil');
     expect(perfil).toBeInTheDocument();
@@ -150,9 +192,9 @@ describe('FincaVivaHero — barra superior sin botones muertos', () => {
   test('regresión 2026-07-04: agente(A) + campana + ayuda + perfil COEXISTEN en el header', () => {
     const onNavigate = vi.fn();
     const onOpenAgent = vi.fn();
-    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={onOpenAgent} onGestionar={vi.fn()} />);
-    // La A de marca ES el botón del agente (en biopunk la A invoca al agente),
-    // NO el perfil — son botones distintos y ambos deben estar.
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={onOpenAgent} />);
+    // La A de marca ES el botón del agente (en biopunk la A de la mano de
+    // Chagra invoca al agente), NO el perfil — son botones distintos.
     const agenteA = screen.getByTestId('fvh-brand-agente');
     fireEvent.click(agenteA);
     expect(onOpenAgent).toHaveBeenCalledTimes(1);

--- a/src/components/dashboard/__tests__/FincaVivaResto.noSolapa.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaResto.noSolapa.test.jsx
@@ -120,21 +120,21 @@ beforeEach(() => vi.clearAllMocks());
 // (necesita los 4 portales reales) — el import() dinámico del componente real
 // (2000+ líneas) tarda más que el default de testing-library (1000ms) en el
 // pipeline de transform de vitest, sobre todo bajo carga del host.
-describe('Bug 2 · DOM — hero F2: 4 portales visibles + hoja "resto" separada', () => {
-  test('renderiza los 4 portales del hero (ninguno queda sin montar)', { retry: 2 }, async () => {
+describe('Bug 2 · DOM — hero F2: 6 puertas visibles + hoja "resto" separada', () => {
+  test('renderiza las 6 puertas del hero (ninguna queda sin montar)', { retry: 2 }, async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const nav = await screen.findByTestId('finca-viva-portales', {}, { timeout: 15000 });
-    const portales = within(nav).getAllByRole('button');
-    expect(portales).toHaveLength(4);
-    const labels = portales.map((b) => b.getAttribute('aria-label')?.split(':')[0]);
-    // Copy campesino vigente (#1883/#1884): "Mi finca" (gestión), "Aprender",
-    // "Jugar", "Pregúntele a Chagra" (agente). Antes eran Gestionar/Agente.
-    expect(labels).toEqual(['Mi finca', 'Aprender', 'Jugar', 'Pregúntele a Chagra']);
+    const nav = await screen.findByTestId('finca-viva-puertas', {}, { timeout: 15000 });
+    const puertas = within(nav).getAllByRole('button');
+    expect(puertas).toHaveLength(6);
+    const labels = puertas.map((b) => b.getAttribute('aria-label')?.split(':')[0]);
+    // Usabilidad campesina #5 (2026-07): SEIS puertas de 1-2 palabras
+    // reemplazan los 4 portales con descripción.
+    expect(labels).toEqual(['Mis matas', 'Mis animales', 'El tiempo', 'Vender', 'Aprender', 'Toda mi finca']);
   });
 
-  test('la hoja "resto" NO contiene los portales (superficies separadas)', { retry: 2 }, async () => {
+  test('la hoja "resto" NO contiene las puertas (superficies separadas)', { retry: 2 }, async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const nav = await screen.findByTestId('finca-viva-portales', {}, { timeout: 15000 });
+    const nav = await screen.findByTestId('finca-viva-puertas', {}, { timeout: 15000 });
     // La hoja "resto" se reorganizó en bloques (#1883/#1884); su contenedor es
     // .fvh-resto (data-testid estable), ya no el título "El resto de su finca".
     const hoja = screen.getByTestId('fvh-resto');
@@ -144,9 +144,9 @@ describe('Bug 2 · DOM — hero F2: 4 portales visibles + hoja "resto" separada'
     expect(hoja.contains(nav)).toBe(false);
   });
 
-  test('en orden de documento, los portales van ANTES de la hoja "resto"', { retry: 2 }, async () => {
+  test('en orden de documento, las puertas van ANTES de la hoja "resto"', { retry: 2 }, async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const nav = await screen.findByTestId('finca-viva-portales', {}, { timeout: 15000 });
+    const nav = await screen.findByTestId('finca-viva-puertas', {}, { timeout: 15000 });
     const tit = screen.getByTestId('fvh-resto');
     await waitFor(() => expect(nav).toBeInTheDocument());
     // compareDocumentPosition: nav precede a tit → DOCUMENT_POSITION_FOLLOWING.

--- a/src/components/dashboard/__tests__/SceneFincaOrganismo.corazon.test.jsx
+++ b/src/components/dashboard/__tests__/SceneFincaOrganismo.corazon.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+import SceneFincaOrganismo from '../SceneFincaOrganismo';
+
+/**
+ * El CORAZÓN-SEMILLA de la Finca Organismo = botón "Pregunte" (usabilidad
+ * campesina #4): con `onPregunte` el corazón es tappable (tap / Enter /
+ * Espacio) y abre el agente — el MISMO patrón del potrero→animales. Sin
+ * handler queda como arte (sin rol ni foco) y el SVG vuelve a ser imagen.
+ */
+
+afterEach(() => cleanup());
+
+describe('SceneFincaOrganismo — el corazón de la escena abre el agente', () => {
+  test('con onPregunte, el corazón es un botón enfocable que dispara al tocarlo', () => {
+    const onPregunte = vi.fn();
+    render(<SceneFincaOrganismo onPregunte={onPregunte} />);
+    const corazon = screen.getByTestId('fvo-corazon');
+    expect(corazon).toHaveAttribute('role', 'button');
+    expect(corazon).toHaveAttribute('tabindex', '0');
+    fireEvent.click(corazon);
+    expect(onPregunte).toHaveBeenCalledTimes(1);
+  });
+
+  test('el corazón responde a Enter y Espacio (accesible por teclado)', () => {
+    const onPregunte = vi.fn();
+    render(<SceneFincaOrganismo onPregunte={onPregunte} />);
+    const corazon = screen.getByTestId('fvo-corazon');
+    fireEvent.keyDown(corazon, { key: 'Enter' });
+    fireEvent.keyDown(corazon, { key: ' ' });
+    expect(onPregunte).toHaveBeenCalledTimes(2);
+  });
+
+  test('con el corazón tappable el SVG deja de ser imagen plana (role=group)', () => {
+    render(<SceneFincaOrganismo onPregunte={vi.fn()} />);
+    expect(screen.getByTestId('fvo-escena')).toHaveAttribute('role', 'group');
+  });
+
+  test('sin onPregunte, el corazón queda decorativo y el SVG es imagen', () => {
+    render(<SceneFincaOrganismo />);
+    expect(screen.getByTestId('fvo-escena')).toHaveAttribute('role', 'img');
+    const corazon = screen.getByTestId('fvo-corazon');
+    expect(corazon).not.toHaveAttribute('role');
+    expect(corazon).not.toHaveAttribute('tabindex');
+    expect(corazon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('la etiqueta invita a preguntar (sin jerga de laboratorio)', () => {
+    render(<SceneFincaOrganismo onPregunte={vi.fn()} />);
+    expect(screen.getByTestId('fvo-escena')).toHaveTextContent('toque el corazón y pregúntele a Chagra');
+    expect(screen.getByTestId('fvo-escena')).not.toHaveTextContent('micorrízica');
+  });
+});

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -1276,3 +1276,186 @@ html[data-theme="biopunk"] .fvh {
 /* Sin velo/veladura genérica (::after) — duplicaba brillos/tramas sobre la
    atmósfera propia de cada escena (aurora neón, rayo dorado, rocío, papel). */
 .fvh .fvh-escena-wrap--viva::after { opacity: 0; }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   USABILIDAD CAMPESINA (fold del mockup #/mockups/home-campesino, 2026-07)
+   ──────────────────────────────────────────────────────────────────────────
+   · "PREGUNTE" dominante: el compositor pasa de barra de texto a BOTÓN GRANDE
+     (≥96px) que late como el corazón de la escena.
+   · Pastillas "Escuchar" (🔊 TTS) y "Pleno sol" (alto contraste mediodía).
+   · LAS 6 PUERTAS: 1-2 palabras, dibujo grande, targets ≥96px.
+   · Variante [data-plenosol="1"]: claro de ALTO contraste para el rayo del
+     sol (el biopunk nocturno va bien de noche; a mediodía no se ve).
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* ── El botón dominante "Pregunte" ── */
+.fvh-composer.fvh-composer--pregunte {
+  min-height: 96px;
+  gap: 16px;
+  padding: 14px 18px;
+  border-radius: 26px;
+  background: linear-gradient(135deg, var(--fvh-lima), #8fd62e);
+  box-shadow: 0 16px 34px rgba(40, 60, 40, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.25) inset;
+}
+.fvh-corazon-btn {
+  position: relative;
+  flex: 0 0 auto;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 50% 40%, rgba(255, 255, 255, 0.6), transparent 60%), var(--fvh-lima-claro);
+  border: 3px solid #12260a;
+}
+.fvh-corazon-pulso {
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  border: 2px solid #12260a;
+  opacity: 0;
+  animation: fvh-corazon-late 2.4s ease-out infinite;
+}
+.fvh-corazon-pulso2 { animation-delay: 1.2s; }
+@keyframes fvh-corazon-late {
+  0% { transform: scale(1); opacity: 0.5; }
+  70%, 100% { transform: scale(1.5); opacity: 0; }
+}
+.fvh-pregunte-txt { display: flex; flex-direction: column; gap: 2px; min-width: 0; color: #12260a; }
+.fvh-pregunte-txt b {
+  font-family: var(--fvh-display);
+  font-size: 25px;
+  line-height: 1.05;
+  letter-spacing: 0.2px;
+}
+.fvh-pregunte-txt small { font-size: 14.5px; font-weight: 800; opacity: 0.9; }
+
+/* ── Pastillas Escuchar + Pleno sol ── */
+.fvh-audio-sol {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: 10px 4px 0;
+}
+.fvh-escuchar,
+.fvh-sol-toggle {
+  min-height: 48px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 2px solid var(--fvh-pill-border);
+  background: var(--fvh-pill-bg);
+  color: var(--fvh-pill-ink);
+  font: 800 15px/1 var(--fvh-body);
+  cursor: pointer;
+}
+.fvh-escuchar[aria-pressed="true"] { border-color: var(--fvh-lima); }
+.fvh-escuchar:active,
+.fvh-sol-toggle:active { transform: scale(0.97); }
+
+/* ── LAS 6 PUERTAS ── */
+.fvh-puertas {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  padding: 0 16px;
+}
+@media (min-width: 720px) { .fvh-puertas { grid-template-columns: repeat(3, 1fr); } }
+.fvh-puerta {
+  min-height: 112px;
+  border-radius: 22px;
+  border: 2px solid var(--fvh-p-borde, var(--fvh-card-border));
+  background: var(--fvh-card-bg);
+  color: var(--fvh-card-tinta);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 12px 8px;
+  box-shadow: 0 10px 24px rgba(20, 30, 20, 0.25);
+  animation: fvh-puerta-brota 0.5s ease-out both;
+}
+.fvh-puerta:active { transform: scale(0.97); }
+.fvh-puerta:focus-visible { outline: 3px solid var(--fvh-lima); outline-offset: 2px; }
+.fvh-puerta-emoji { font-size: 40px; line-height: 1; }
+.fvh-puerta-nombre {
+  font-family: var(--fvh-display);
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1.1;
+  text-align: center;
+}
+@keyframes fvh-puerta-brota {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+/* tinte por puerta: solo el borde, para no volver arcoíris el home */
+.fvh-puerta.t-verde { --fvh-p-borde: rgba(132, 204, 22, 0.6); }
+.fvh-puerta.t-teja { --fvh-p-borde: rgba(234, 88, 12, 0.6); }
+.fvh-puerta.t-cielo { --fvh-p-borde: rgba(56, 189, 248, 0.6); }
+.fvh-puerta.t-ambar { --fvh-p-borde: rgba(245, 158, 11, 0.65); }
+.fvh-puerta.t-uva { --fvh-p-borde: rgba(167, 139, 250, 0.6); }
+.fvh-puerta.t-menta { --fvh-p-borde: rgba(45, 212, 191, 0.6); }
+
+/* ── VARIANTE "PLENO SOL" (alto contraste de mediodía) ─────────────────────
+   Redefine los tokens del hero a un papel claro con tinta oscura dura. Va al
+   FINAL del archivo y con especificidad doblada para ganarle a las pieles por
+   tema (html[data-theme] .fvh). La hoja .fvh-resto ya es clara de por sí. */
+html .fvh.fvh.fvh[data-plenosol="1"] {
+  --fvh-cielo-a: #eaf4fb;
+  --fvh-cielo-b: #f5f2e3;
+  --fvh-tinta: #1c2a1a;
+  --fvh-tinta-suave: #44543f;
+  /* la tinta "sobre el cielo" tambien pasa a oscura de contraste duro */
+  --fvh-on-cielo: #1c2a1a;
+  --fvh-on-cielo-suave: #33472a;
+  --fvh-on-cielo-acento: #3f6212;
+  --fvh-on-cielo-sombra: 0 1px 2px rgba(255, 255, 255, 0.55);
+  --fvh-on-cielo-div: linear-gradient(90deg, rgba(63, 98, 18, 0.5), transparent);
+  --fvh-verde-1: #3f6212;
+  --fvh-sello: #365314;
+  --fvh-lima: #4d7c0f;
+  --fvh-lima-claro: #d9f99d;
+  --fvh-card-bg: #fffdf4;
+  --fvh-card-border: rgba(28, 42, 26, 0.35);
+  --fvh-card-tinta: #1c2a1a;
+  --fvh-card-tinta-suave: #44543f;
+  --fvh-pill-bg: #fffdf4;
+  --fvh-pill-border: rgba(28, 42, 26, 0.35);
+  --fvh-pill-ink: #1c2a1a;
+}
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-composer--pregunte {
+  background: linear-gradient(135deg, #65a30d, #4d7c0f);
+  box-shadow: 0 10px 22px rgba(28, 42, 26, 0.25);
+}
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-pregunte-txt { color: #f7fee7; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-corazon-btn { background: #d9f99d; border-color: #1f3300; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-corazon-pulso { border-color: #1f3300; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-brand-txt b,
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-brand-txt span { color: #1c2a1a; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-hero-saludo h1,
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-hero-saludo p { color: #1c2a1a; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-hero-saludo h1 em { color: #3f6212; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-portales-tit { color: #1c2a1a; }
+/* la escena nocturna se enmarca como tarjeta (arte de noche sobre papel claro) */
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-escena-wrap--viva {
+  border-radius: 20px;
+  box-shadow: 0 8px 20px rgba(28, 42, 26, 0.18);
+}
+/* tintes de puerta con contraste duro a pleno sol */
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-verde { --fvh-p-borde: #4d7c0f; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-teja { --fvh-p-borde: #c2410c; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-cielo { --fvh-p-borde: #0369a1; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-ambar { --fvh-p-borde: #b45309; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-uva { --fvh-p-borde: #6d28d9; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-menta { --fvh-p-borde: #0f766e; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta { box-shadow: 0 6px 16px rgba(28, 42, 26, 0.14); }
+
+@media (prefers-reduced-motion: reduce) {
+  .fvh-corazon-pulso { animation: none; opacity: 0; }
+  .fvh-puerta { animation: none; }
+  .fvh-puerta:active,
+  .fvh-escuchar:active,
+  .fvh-sol-toggle:active { transform: none; }
+}

--- a/src/components/dashboard/mundos-finca.css
+++ b/src/components/dashboard/mundos-finca.css
@@ -177,16 +177,20 @@
 .mf-chip {
   font-size: 11.5px;
   font-weight: 700;
-  line-height: 1;
-  padding: 4px 7px;
-  border-radius: 999px;
+  /* Fix chips truncados (usabilidad campesina #3): antes nowrap + overflow
+     hidden cortaba las etiquetas largas a media palabra en móvil
+     ("Almacenamiento y conse…"). Ahora la etiqueta ENVUELVE dentro de la
+     pastilla — se lee completa siempre. */
+  line-height: 1.2;
+  padding: 4px 8px;
+  border-radius: 12px;
   background: var(--mf-b, #eef3e2);
   border: 1px solid color-mix(in srgb, var(--mf-a, #3f8f4e) 35%, transparent);
   color: var(--mf-tinta);
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: break-word;
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  text-align: left;
 }
 .mf-chip--mas,
 .mf-chip--entrar {

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -123,7 +123,9 @@ export const MUNDOS_FINCA = [
         id: 'citricos',
         titulo: 'Los cítricos',
         emoji: '🍊',
-        lema: 'Naranja, mandarina, limón y lima: variedad e injerto, piso térmico, plagas y HLB, y cosecha',
+        // Sin siglas de ingeniero en el home (#1): HLB se nombra como lo conoce
+        // el campo — "el dragón amarillo" (la pantalla del mundo ya lo explica).
+        lema: 'Naranja, mandarina, limón y lima: variedad e injerto, piso térmico, plagas como el dragón amarillo, y cosecha',
         tinte: ['#c9791f', '#f7e6c8'],
         // Mundo de una sola pantalla (photo-forward, 5 estaciones del ciclo
         // cítrico). Profundización dedicada del frutal cítrico que refuerza el

--- a/src/components/dashboard/scene-finca-organismo.css
+++ b/src/components/dashboard/scene-finca-organismo.css
@@ -349,3 +349,30 @@
   .fvo-micelio { opacity: 0.38; }
   .fvo-nodo { opacity: 0.85; }
 }
+
+/* ── CORAZÓN TAPPABLE = "PREGUNTE" (usabilidad campesina #4) ───────────────
+   Cuando FincaVivaHero pasa onPregunte, el corazón-semilla es un botón que
+   abre el agente. Cursor, foco visible para teclado y un halo-invitación que
+   respira (se apaga con prefers-reduced-motion, quedando el halo fijo). */
+.fvo-corazon-tap {
+  cursor: pointer;
+  outline: none;
+}
+.fvo-corazon-tap:focus-visible ellipse:first-of-type {
+  stroke: #eafff6;
+  stroke-width: 2;
+  opacity: 0.9;
+}
+.fvo-corazon-tap:active .fvo-heart { opacity: 0.85; }
+.fvo-corazon-halo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-corazon-invita 2.4s ease-out infinite;
+}
+@keyframes fvo-corazon-invita {
+  0% { transform: scale(0.8); opacity: 0.55; }
+  70%, 100% { transform: scale(1.35); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fvo-corazon-halo { animation: none !important; opacity: 0.4; }
+}


### PR DESCRIPTION
## Qué hace

Fold **INCREMENTAL** (no reescritura) de las 8 mejoras aprobadas por el operador sobre el home biopunk real (`FincaVivaHero` + `DashboardLive`, flag F2), con el mockup `#/mockups/home-campesino` (#2227) como guía de estilo.

### Las 8 aplicadas
1. **Sin jerga de ingeniero** en textos visibles: `SU AGENTE AGROECOLÓGICO` → *CHAGRA, SU COMPAÑERO DE CAMPO* · `Análisis Chagra · IA local` → *El recado de Chagra* · `Cola de tareas` → *Tareas pendientes* · `HLB` → *el dragón amarillo* · `(MIP)` fuera · `micorrízica` fuera de la etiqueta de la escena.
2. **Un solo "pregunte" que manda**: el compositor pasa a botón dominante **Pregunte — toque y hable** (late como el corazón). El globo del colibrí ya no repite "pregúnteme aquí abajo" y el portal duplicado desaparece.
3. **Chips sin cortar a media palabra**: los `.mf-chip` de los mundos envuelven dentro de la pastilla (antes `nowrap` + `overflow:hidden`).
4. **El corazón de la escena biopunk = botón "Pregunte"**: el corazón-semilla de `SceneFincaOrganismo` es tappable (role=button, Enter/Espacio, halo-invitación) y abre el agente — mismo patrón que el potrero→animales de #2229 (tappables distintos; si hay conflicto de archivo, respetar ambos).
5. **6 puertas de 1-2 palabras** (Mis matas / Mis animales / El tiempo / Vender / Aprender / Toda mi finca) en vez de 4 portales + grilla siempre abierta; enrutan a vistas existentes (`mundo_cultivos`, mundo animales gateado por perfil, `hoy_finca`, `mercado`, `aprende`). Los mundos completos quedan **plegados** tras "Toda mi finca" (un toque, reachability intacta). "Jugar" conserva su entrada en el pie.
6. **Botón "Escuchar" 🔊** (baja alfabetización): lee la pantalla con el TTS propio (`ttsService` kokoro + fallback Web Speech, import perezoso); pasa a "Parar" mientras habla.
7. **Variante "pleno sol"** de alto contraste para mediodía al aire libre: automática de día (`deriveAtmosphere`) + toggle manual persistido (`chagra:home:pleno-sol`).
8. **Targets ≥96px**: puertas 112px, botón "Pregunte" 96px.

NO se subió "Anote su día" (descartado por el operador).

## Verificación
- **EN VIVO (Playwright, móvil 390x844, dev server flag F2 ON): 21/21** — las 6 puertas enrutan y salen del home, el corazón abre el agente, "Escuchar" dispara `/api/kokoro/tts` (mock) y reproduce, pleno sol alterna, persiste tras reload y ningún chip desborda (`scrollWidth <= clientWidth`).
- Suite dashboard completa: **27 archivos / 185 tests verdes** (incluye `SceneFincaOrganismo.corazon.test.jsx` nuevo y los 3 tests actualizados al contrato de puertas/mundos plegados).
- `tsc` gate: **1820 errores < baseline 1829**, sin archivos nuevos con errores.
- Build + budget: **24.0 MB / 25.5 MB**, main bundle 284 KB.
- Capturas noche + pleno sol enviadas al operador por Telegram.

## Notas de integración
- `SceneFincaOrganismo.jsx` también lo toca #2229 (potrero): el corazón (`onPregunte`) y el potrero (`onAnimales`) son grupos tappables **independientes**; al integrar, el `role` del SVG queda `group` si cualquiera de los dos handlers llega.
- Todo detrás de la flag `VITE_FINCA_VIVA_HOME_PERFIL` (dev-only): **prod con flag OFF queda intacto** (layout legacy sin tocar, salvo los renombres de jerga en `AnalisisProactivoIA`/`PendingTasksWidget` que también aplican al legacy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)