### PR TITLE
fix(agente): 6 bugs visuales del chat (auditoría IA Fable 2026-07-08)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -67,7 +67,7 @@ import { buildAyudaResponse } from '../../services/ayudaAgentResponder';
 // turno NO debe saltarse el grounding: este router PURO deriva el tool obvio
 // (entidad resuelta o keyword → get_species/get_pest_controllers/get_biopreparados)
 // para intentar AL MENOS una consulta al grafo en vez de caer a generativo puro.
-import { planNluFallback } from '../../services/agentNluFallback';
+import { planNluFallback, esSaludoPuro } from '../../services/agentNluFallback';
 import { planKnowledgeIntent, hasSoilDiagnosticIntent } from '../../services/knowledgeIntentRouter';
 // Fix misroute "papa precio" (2026-07-05): router PURO que detecta intención
 // de PRECIO/MERCADO ANTES de planKnowledgeIntent/planNlu — garantiza que
@@ -206,6 +206,19 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // banner — la primera query caerá al cold-start clásico con su propio
   // indicador ("pensando...") que ya cubre la espera percibida.
   const ollamaWarmStatus = useOllamaWarmStore((s) => s.status);
+  const startOllamaWarmup = useOllamaWarmStore((s) => s.startWarmup);
+  // Bug visual Vi1 (auditoría IA 2026-07-08): el banner "Preparando agente
+  // IA" quedaba pegado PARA SIEMPRE si el status nunca salía de 'unknown'
+  // (rutas de entrada que no pasan por login/dashboard no disparaban el
+  // warm-up → nadie resolvía el estado). Kick idempotente al montar: si
+  // nadie calentó todavía, lo intentamos aquí y el status transiciona a
+  // warming → warm/failed, y el banner se va solo.
+  useEffect(() => {
+    if (useOllamaWarmStore.getState().status === 'unknown') {
+      startOllamaWarmup();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   // Task #121: queue UX del agente. Permite 2 preguntas max (1 procesando +
   // 1 pendiente). 3ra rechazada con toast claro. ETA dinámico basado en
   // EMA de latencia por modelo (ruta simple más rápida, ruta complex más
@@ -2302,7 +2315,16 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // pinte SIN volver a calcularlo — el semáforo es 1:1 con lo que el
       // agente ya decidió. Graceful: sin decisión del sidecar → no añade nada
       // (no contamina sourceMetadata con null).
-      const groundingSemaphoreMeta = groundingDecisionMeta
+      //
+      // Bug A6 (auditoría IA 2026-07-08): un saludo puro ("hola chagra")
+      // salía con semáforo ROJO "Sin verificar — se lo decimos de frente".
+      // Es correcto que el sidecar diga abstain (cero entidades), pero un
+      // turno puramente conversacional NO es un dato que verificar: marcarlo
+      // rojo igual que un dato dudoso vacía de significado el semáforo. Para
+      // saludos/smalltalk (mismo criterio esSaludoPuro de la deflección NLU)
+      // NO adjuntamos la metadata del semáforo → la UI no pinta semáforo
+      // (estado neutro), igual que un turno sin señal de grounding.
+      const groundingSemaphoreMeta = groundingDecisionMeta && !esSaludoPuro(text)
         ? {
             grounding_semaphore: groundingDecisionMeta.semaphore,
             grounding_policy: groundingDecisionMeta.policy,
@@ -3478,7 +3500,13 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       {/* ── Header estilo ScreenShell (2026-06-08): superficie OPACA por token
           (.agent-bar-surface) + acciones globales. Antes bg-slate-900/50 dejaba
           pasar la foto detrás del título y los íconos (fix legibilidad 2026-06-15). ── */}
-      <header className="px-4 py-3 flex items-center gap-2 border-b border-slate-800 agent-bar-surface shrink-0">
+      {/* Bug visual Vi3 (auditoría IA 2026-07-08): en 320px los 6 controles de
+          44px + gaps + padding sumaban más que el viewport → el título se
+          encimaba con los íconos y el avatar pisaba el texto; en 412px el
+          subtítulo se clipaba sin gracia. Fix: padding/gap compactos bajo
+          400px, botón Home oculto bajo 360px (Volver sigue presente), avatar
+          shrink-0 y subtítulo con truncate (elipsis, nunca encimado). */}
+      <header className="px-2 min-[400px]:px-4 py-3 flex items-center gap-1 min-[400px]:gap-2 border-b border-slate-800 agent-bar-surface shrink-0">
         {/* Back */}
         <button
           type="button"
@@ -3492,7 +3520,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         <button
           type="button"
           onClick={() => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'dashboard' }))}
-          className="p-3 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:bg-emerald-700/60 transition-all text-emerald-400 min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
+          className="max-[359px]:hidden p-3 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:bg-emerald-700/60 transition-all text-emerald-400 min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
           aria-label="Volver al inicio"
           title="Inicio"
         >
@@ -3511,12 +3539,13 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             if (ok) agentSounds.chime();
           }}
           ariaLabel="Chagra IA — doble click silencia/reactiva voz"
+          className="shrink-0"
         />
         <div className="flex-1 min-w-0">
           <h1 className="text-sm font-bold text-white leading-tight truncate">Chagra IA</h1>
           {/* Theme-aware (2026-06-10): clases Tailwind (van por --c-*) en vez
               de hex inline que ignoraba los temas. + estado "hablando". */}
-          <p className={`text-[10px] font-semibold uppercase tracking-wider leading-tight ${
+          <p className={`text-[10px] font-semibold uppercase tracking-wider leading-tight truncate ${
             state === STATE_THINKING ? 'text-amber-500'
               : state === STATE_RECORDING ? 'text-violet-400'
               : isVoicePlaying ? 'text-emerald-400'
@@ -3598,8 +3627,13 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           Aparece solo en status 'unknown' o 'warming' — en 'warm' o 'failed'
           queda oculto. Se mostraría típicamente si el operador navega al
           agente MUY rápido tras login antes que termine el warm-up (~25-40s
-          en GPU M6000). Spinner CSS con animación spin de Tailwind. */}
-      {(ollamaWarmStatus === 'warming' || ollamaWarmStatus === 'unknown') && (
+          en GPU M6000). Spinner CSS con animación spin de Tailwind.
+          Bug visual Vi1 (auditoría IA 2026-07-08): además del status, el
+          banner SOLO vive mientras el chat está vacío — al primer mensaje
+          (el agente ya demostró estar respondiendo) desaparece, aunque el
+          warm-up siga en vuelo. Antes quedaba pegado sobre la conversación
+          entera dando sensación de "cargando eternamente". */}
+      {(ollamaWarmStatus === 'warming' || ollamaWarmStatus === 'unknown') && messages.length === 0 && (
         <div
           className="px-4 py-2 mx-4 mt-2 rounded-lg bg-amber-900/30 border border-amber-800/50 flex items-center gap-2"
           data-testid="ollama-warming-banner"
@@ -3694,12 +3728,23 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           red de capacidades (única fuente, igual que el home). Operador 2026-06-18:
           el acceso a capacidades es SOLO por este botón o el ícono del tema en
           el compositor, nunca por chips de texto. */}
+      {/* Bug visual Vi5 (auditoría IA 2026-07-08): el CTA quedaba casi
+          invisible (crema sobre crema). Causa doble: (1) el wrapper NO
+          escapaba del velo `.agent-scrim` (absolute inset-0, crema ~0.94 en
+          temas claros) que pintaba ENCIMA — mismo bug ya corregido en el
+          empty-state y el compositor con `relative z-10`; (2) el fondo
+          `bg-emerald-700/45` translúcido sobre crema dejaba el texto claro
+          sin contraste. Ahora: z-10 + acento sólido `bg-emerald-600 text-white`
+          — el par exacto de la EXCEPCIÓN de themes.css ("sobre un botón de
+          acento sólido el blanco sigue siendo lo correcto"): en los temas
+          claros text-white vira a tinta café salvo sobre bg-emerald-500/600,
+          donde se mantiene #fff sobre el verde oscuro del tema (AA). */}
       {messages.length === 0 && (
-        <div className="px-4 pb-1 pt-1 shrink-0">
+        <div className="relative z-10 px-4 pb-1 pt-1 shrink-0">
           <button
             type="button"
             onClick={() => setSheetOpen(true)}
-            className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-emerald-400/60 bg-emerald-700/45 text-emerald-50 text-sm font-semibold shadow-lg shadow-emerald-950/40 active:scale-[.98] transition-transform"
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-emerald-400/60 bg-emerald-600 text-white text-sm font-semibold shadow-lg shadow-emerald-950/40 active:scale-[.98] transition-transform"
             aria-label="Abrir la mano de Chagra"
             data-testid="agent-mano-trigger"
           >

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -15,6 +15,14 @@ import { MSG } from '../../config/messages';
 // no estamos viendo el header.
 const FLOATING_BACK_THRESHOLD_PX = 160;
 
+// Bug visual Vi4 (auditoría IA 2026-07-08): el botón flotante TAPABA las
+// primeras palabras de cada línea mientras el operador LEÍA (peor en 320px).
+// El botón es un overlay — siempre va a cubrir algo — así que la corrección
+// es temporal, no espacial: visible mientras el operador scrollea (cuando lo
+// necesita para salir) y se esconde solo tras esta pausa sin scroll (cuando
+// está leyendo). Cualquier scroll nuevo lo trae de vuelta.
+const FLOATING_BACK_IDLE_HIDE_MS = 2200;
+
 /**
  * Área de historial de mensajes del chat con el agente. Renderiza burbujas de
  * chat, tarjetas de Deep Research, saludo proactivo dinámico y estados vacíos.
@@ -43,10 +51,28 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
   // inicio (header fuera de vista). Arriba del todo lo ocultamos porque el
   // header ya ofrece su propio "Volver" y no queremos duplicar affordance.
   const [showFloatingBack, setShowFloatingBack] = useState(false);
+  // (Vi4) Timer del auto-ocultado por inactividad de scroll. Ref, no state:
+  // solo lo toca el handler; no debe re-renderizar.
+  const floatingBackIdleTimerRef = useRef(null);
 
   const handleScroll = useCallback((e) => {
     const top = e?.target?.scrollTop ?? scrollRef.current?.scrollTop ?? 0;
-    setShowFloatingBack(top > FLOATING_BACK_THRESHOLD_PX);
+    const lejosDelInicio = top > FLOATING_BACK_THRESHOLD_PX;
+    setShowFloatingBack(lejosDelInicio);
+    // (Vi4) El botón se esconde solo cuando el scroll se queda quieto — así
+    // no tapa el texto mientras el operador lee. Cada evento de scroll
+    // reinicia la cuenta; al vencer, el botón se va hasta el próximo scroll.
+    if (floatingBackIdleTimerRef.current) clearTimeout(floatingBackIdleTimerRef.current);
+    if (lejosDelInicio) {
+      floatingBackIdleTimerRef.current = setTimeout(() => {
+        setShowFloatingBack(false);
+      }, FLOATING_BACK_IDLE_HIDE_MS);
+    }
+  }, []);
+
+  // (Vi4) Limpieza del timer al desmontar (evita setState sobre componente muerto).
+  useEffect(() => () => {
+    if (floatingBackIdleTimerRef.current) clearTimeout(floatingBackIdleTimerRef.current);
   }, []);
 
   // Fuente ÚNICA del auto-scroll del chat (tarea #58). El contenedor scrollable

--- a/src/components/AgentScreen/__tests__/ChatHistory.backButton.test.jsx
+++ b/src/components/AgentScreen/__tests__/ChatHistory.backButton.test.jsx
@@ -17,9 +17,9 @@
  *   - Sin handler onBack, no se renderiza (backward compat / empty state).
  */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
 import ChatHistory from '../ChatHistory';
 
 // jsdom no implementa scrollIntoView — ChatHistory lo llama en su efecto de
@@ -74,6 +74,49 @@ describe('ChatHistory — botón Volver flotante (alcanzable sin scroll al inici
     const scroller = container.querySelector('[data-testid="chat-scroll"]');
     scrollContainerTo(scroller, 400);
     expect(screen.queryByTestId('chat-floating-back')).toBeNull();
+  });
+
+  // Bug visual Vi4 (auditoría IA 2026-07-08): el botón flotante tapaba las
+  // primeras palabras del mensaje mientras el operador LEÍA. Ahora se
+  // auto-oculta tras una pausa sin scroll y reaparece con cualquier scroll.
+  describe('auto-ocultado por inactividad (no tapar el texto al leer)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('tras la pausa sin scroll, el botón se esconde solo', () => {
+      vi.useFakeTimers();
+      const { container } = render(<ChatHistory messages={longConversation} onBack={vi.fn()} onConsentNeeded={vi.fn()} onRetryOrphan={vi.fn()} onCancelDeepResearch={vi.fn()} />);
+      const scroller = container.querySelector('[data-testid="chat-scroll"]');
+      scrollContainerTo(scroller, 400);
+      expect(screen.getByTestId('chat-floating-back')).toBeInTheDocument();
+      act(() => vi.advanceTimersByTime(3000));
+      expect(screen.queryByTestId('chat-floating-back')).toBeNull();
+    });
+
+    it('un scroll nuevo lo trae de vuelta después de esconderse', () => {
+      vi.useFakeTimers();
+      const { container } = render(<ChatHistory messages={longConversation} onBack={vi.fn()} onConsentNeeded={vi.fn()} onRetryOrphan={vi.fn()} onCancelDeepResearch={vi.fn()} />);
+      const scroller = container.querySelector('[data-testid="chat-scroll"]');
+      scrollContainerTo(scroller, 400);
+      act(() => vi.advanceTimersByTime(3000));
+      expect(screen.queryByTestId('chat-floating-back')).toBeNull();
+      scrollContainerTo(scroller, 500);
+      expect(screen.getByTestId('chat-floating-back')).toBeInTheDocument();
+    });
+
+    it('cada evento de scroll reinicia la cuenta (no parpadea mientras scrollea)', () => {
+      vi.useFakeTimers();
+      const { container } = render(<ChatHistory messages={longConversation} onBack={vi.fn()} onConsentNeeded={vi.fn()} onRetryOrphan={vi.fn()} onCancelDeepResearch={vi.fn()} />);
+      const scroller = container.querySelector('[data-testid="chat-scroll"]');
+      scrollContainerTo(scroller, 400);
+      act(() => vi.advanceTimersByTime(1500));
+      scrollContainerTo(scroller, 600); // sigue scrolleando antes del timeout
+      act(() => vi.advanceTimersByTime(1500)); // 1.5s desde el ÚLTIMO scroll (< 2.2s)
+      expect(screen.getByTestId('chat-floating-back')).toBeInTheDocument();
+      act(() => vi.advanceTimersByTime(1000)); // ya pasó la pausa completa
+      expect(screen.queryByTestId('chat-floating-back')).toBeNull();
+    });
   });
 
   it('el contenedor scrollable reserva padding inferior para que el último mensaje no quede tapado por el input fijo', () => {

--- a/src/services/__tests__/agentNluFallback.test.js
+++ b/src/services/__tests__/agentNluFallback.test.js
@@ -22,7 +22,7 @@
  *     keyword de biopreparado > especie por defecto.
  */
 import { describe, it, expect } from 'vitest';
-import { planNluFallback } from '../agentNluFallback.js';
+import { planNluFallback, esSaludoPuro } from '../agentNluFallback.js';
 
 describe('planNluFallback — invariante: NUNCA devuelve null para un mensaje agro real', () => {
   it('mensaje vacío / no-string → null (no hay nada que groundear)', () => {
@@ -173,5 +173,31 @@ describe('planNluFallback — entidades de baja calidad no rompen', () => {
     const plan = planNluFallback('cómo riego el café', 'no-soy-array');
     expect(plan.tool).toBe('get_species');
     expect(plan.source).toBe('fallback_default_species');
+  });
+});
+
+// Bug A6 auditoría IA 2026-07-08: "hola chagra" salía con semáforo ROJO.
+// esSaludoPuro es el criterio compartido (deflección NLU + gate del semáforo
+// en AgentScreen): saludo/smalltalk corto → turno conversacional, sin semáforo.
+describe('esSaludoPuro — saludo/smalltalk puro vs pregunta real', () => {
+  it('saludos sueltos → true (con y sin tildes, mayúsculas)', () => {
+    for (const s of ['hola', 'hola chagra', 'Buenos días', 'buenas tardes', 'qué más', 'gracias', 'HOLA']) {
+      expect(esSaludoPuro(s), s).toBe(true);
+    }
+  });
+
+  it('saludo que PREFIJA una pregunta real (>4 palabras) → false', () => {
+    expect(esSaludoPuro('buenas, ¿cómo cuido el aguacate?')).toBe(false);
+    expect(esSaludoPuro('hola chagra, mi mata de café tiene hojas amarillas')).toBe(false);
+  });
+
+  it('pregunta agro directa → false', () => {
+    expect(esSaludoPuro('¿a cómo está la papa?')).toBe(false);
+  });
+
+  it('input no-string / vacío → false (defensivo)', () => {
+    for (const bad of [null, undefined, '', '   ', 42, {}]) {
+      expect(esSaludoPuro(bad)).toBe(false);
+    }
   });
 });

--- a/src/services/agentNluFallback.js
+++ b/src/services/agentNluFallback.js
@@ -94,6 +94,27 @@ function _norm(text) {
 }
 
 /**
+ * ¿El mensaje es un SALUDO/smalltalk puro ("hola", "buenos días", "gracias")?
+ * Mismo criterio que la deflección (c) de planNluFallback: matchea GREETING_RE
+ * y es corto (≤4 palabras) — así "buenas, ¿cómo cuido el aguacate?" NO cuenta
+ * como saludo puro. Exportado para que AgentScreen no pinte el semáforo de
+ * confianza en turnos puramente conversacionales (bug A6 auditoría IA
+ * 2026-07-08: "hola chagra" salía con semáforo ROJO "Sin verificar" — marcar
+ * un saludo igual que un dato dudoso vacía de significado el semáforo).
+ *
+ * @param {*} userMessage
+ * @returns {boolean}
+ */
+export function esSaludoPuro(userMessage) {
+  if (typeof userMessage !== 'string' || userMessage.trim().length === 0) {
+    return false;
+  }
+  const norm = _norm(userMessage.trim());
+  const wordCount = norm.split(/\s+/).filter(Boolean).length;
+  return GREETING_RE.test(norm) && wordCount <= 4;
+}
+
+/**
  * ¿La entidad es una plaga? (kind del sidecar). Tolerante a sinónimos español.
  */
 function _isPest(e) {
@@ -158,9 +179,7 @@ export function planNluFallback(userMessage, resolvedEntities = null) {
   // El saludo PURO solo deflecta si ES el mensaje (≤4 palabras): un saludo que
   // prefija una pregunta real ("buenas, cómo cuido el aguacate") NO se deflecta.
   // Meta-ayuda y consejo general son auto-contenidos → deflectan sin importar largo.
-  const wordCount = norm.split(/\s+/).filter(Boolean).length;
-  const isPureGreeting = GREETING_RE.test(norm) && wordCount <= 4;
-  if (isPureGreeting || META_QUERY_RE.test(norm) || GENERIC_MANEJO_RE.test(norm)) {
+  if (esSaludoPuro(query) || META_QUERY_RE.test(norm) || GENERIC_MANEJO_RE.test(norm)) {
     return null;
   }
 

--- a/src/styles/sello-confianza.css
+++ b/src/styles/sello-confianza.css
@@ -42,6 +42,11 @@
   align-items: center;
   gap: 5px;
   padding: 3px 9px 3px 4px;
+  /* Bug visual Vi2 (auditoría IA 2026-07-08): labels largos ("Fuente
+   * verificable: Agrosavia/Corpoica — manejo integrado…") desbordaban la
+   * burbuja por la derecha en nature/biopunk. El sello nunca puede ser más
+   * ancho que su contenedor: el texto interno hace wrap (abajo). */
+  max-width: 100%;
   border-radius: 999px;
   border: 1px solid rgb(var(--sello-rgb) / 0.38);
   background: rgb(var(--sello-rgb) / 0.12);
@@ -135,7 +140,15 @@ button.sello[aria-expanded="true"] {
 }
 
 .sello-texto {
-  white-space: nowrap;
+  /* Bug visual Vi2: antes `white-space: nowrap` — una cita larga se salía de
+   * la burbuja y se cortaba contra el margen. Ahora el texto envuelve DENTRO
+   * del sello (que a su vez respeta max-width: 100% del card). Los sellos
+   * cortos ("Dato respaldado") siguen viéndose de una sola línea. */
+  white-space: normal;
+  overflow-wrap: anywhere;
+  min-width: 0;
+  line-height: 1.3;
+  text-align: left;
   padding-top: 1px; /* óptico: centra el x-height de Nunito contra la lámpara */
 }
 .sello-texto .sello-sub {


### PR DESCRIPTION
Corrige los 6 bugs de UI/layout/contraste del chat del agente reportados en la auditoría de IA (Chagra-strategy/ops/AUDITORIA-IA-FABLE-2026-07-08.md, sección 3 VISUAL + A6). Sin cambios de contenido/grounding.

## Los 6 fixes

| # | Bug | Fix |
|---|-----|-----|
| Vi1 | Banner "Preparando agente IA (~20s)" pegado para siempre | Se oculta al primer mensaje (`messages.length === 0` en la condición) + AgentScreen dispara `startWarmup()` al montar si el status quedó `unknown` (rutas que no pasan por login ya no dejan el banner eterno) |
| Vi2 | Sello "Fuente verificable: Agrosavia/Corpoica — …" desbordando la burbuja (nature y biopunk) | `.sello-texto` envuelve (`white-space: normal` + `overflow-wrap: anywhere`) y `.sello` respeta `max-width: 100%` — el label largo queda DENTRO del card; los sellos cortos siguen de una línea |
| Vi4 | Botón "Volver" flotante tapando el texto del mensaje | Auto-ocultado tras 2.2s sin scroll (reaparece con cualquier scroll): visible cuando se necesita (scrolleando para salir), fuera cuando se lee |
| Vi5 | CTA "Toca la mano de Chagra" casi invisible (crema sobre crema) | Causa doble: el wrapper no escapaba del velo `.agent-scrim` (faltaba `relative z-10`, mismo bug documentado del empty-state) y el fondo `bg-emerald-700/45` translúcido no contrastaba. Ahora `bg-emerald-600 text-white` — el par exacto de la excepción de themes.css que garantiza #fff sobre acento sólido en los temas claros |
| A6 | Semáforo ROJO "Sin verificar" en un simple "hola" | Turnos puramente conversacionales (helper `esSaludoPuro`, mismo criterio de la deflección NLU existente) no adjuntan la metadata del semáforo → estado neutro, sin sello alarmante. Preguntas reales siguen mostrando el semáforo del sidecar tal cual |
| Vi3 | Header cortado/encimado a 320px (y subtítulo clipado a 412px) | Padding/gap compactos bajo 400px, botón Home oculto bajo 360px (Volver sigue), avatar `shrink-0`, subtítulo con `truncate` (elipsis, nunca encimado sobre los íconos) |

## Verificación (headless, sidecar mockeado)

Sidecar/alpha está OFF → verificado con Playwright contra builds estáticos before/after, sidecar mockeado vía `context.route` (no `page.route` — el SW lo sombrea), en nature y biopunk, 412px y 320px:

| Métrica | before | after |
|---|---|---|
| Banner visible tras el primer mensaje | `true` | `false` |
| Semáforos en saludo "hola chagra" | 1 (rojo) | 0 |
| Overflow del sello vs borde del card | **+417px** (se sale del viewport) | −15px (adentro) |
| "Volver" visible tras 3s sin scroll | `true` (tapando texto) | `false` |
| Subtítulo del header 320px | clipado sin elipsis | `truncate` con elipsis, 0 overlaps |
| CTA mano (nature) | texto crema lavado por el scrim, wrapper `z auto` | blanco sobre verde sólido, wrapper `z-10` |

Capturas before/after enviadas al Telegram del operador.

## Pendiente de verificación en vivo (requiere alpha/sidecar arriba)
- **A6 semáforo**: el gate se probó con respuesta mockeada del sidecar (grounding `abstain/rojo`); falta confirmar con granite + sidecar reales que un saludo en prod ya no pinta rojo.
- Vi1 con el warm-up real de ollama (aquí se simuló con el request colgado).

## Gates
- Tests: 27 en los archivos tocados + suite AgentScreen/ChatBubble verdes (única falla: `VoiceStatusStrip.test.jsx` que ya falla en origin/main, pre-existente).
- Tests nuevos: `esSaludoPuro` (4) y auto-ocultado del Volver (3).
- `tsc-check-gate`: OK, −3 errores vs baseline.
- Build + `check-perf-budget`: 24.0 / 25.5 MB.
- Sin archivos nuevos de src (solo ediciones) — no dispara el cuello del gate tsc por archivos nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)