### PR TITLE
feat(espiritu): entrada visible Pro-gated al avatar-espíritu + fix dev-deploy

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -61,6 +61,14 @@ jobs:
           # deploy.yml (prod) → prod conserva el colibrí 2D / video actual.
           VITE_COLIBRI: "true"
           VITE_CHAGRA_MCP_TOKEN: ${{ secrets.VITE_CHAGRA_MCP_TOKEN }}
+          # AVATAR-ESPIRITU / módulos Pro: mismo valor y patrón que deploy.yml
+          # (prod). Sin esta variable, loadProModules.js ni intenta el import
+          # dinámico y en dev #/espiritu caía SIEMPRE al fallback "no
+          # disponible en su plan" aunque los bundles Pro estuvieran servidos.
+          # Los bundles viven montados en el docroot bajo /pro-modules/ (FUERA
+          # del repo público — anti-leak OSS/Pro); si el path no resuelve, el
+          # import falla en silencio y la UI degrada a build puro OSS.
+          VITE_PRO_MODULES_PATH: "/pro-modules"
 
       - if: env.SKIP_DEPLOY != '1'
         name: Deploy to dev
@@ -87,8 +95,13 @@ jobs:
           # tocar sus permisos/borrarlo con --delete y aborta con exit 23
           # (partial transfer) -> deploy PARCIAL -> index.html referencia
           # assets que nunca se copiaron -> pantalla negra. Lo dejamos intacto.
+          #
+          # --exclude='/pro-modules/': bundles Pro pre-construidos montados
+          # manualmente en el docroot (NO vienen en dist/ — anti-leak OSS/Pro,
+          # ver VITE_PRO_MODULES_PATH arriba y deploy.yml de prod). Sin el
+          # exclude, --delete los borraria en cada deploy de dev.
           rsync -avzO --no-perms --delete --no-group --chmod=F644 \
-            --exclude='/assets/' --exclude='/mockups/' dist/ "$TARGET/"
+            --exclude='/assets/' --exclude='/mockups/' --exclude='/pro-modules/' dist/ "$TARGET/"
           rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ "$TARGET/assets/"
           find "$TARGET/assets/" -type f -mtime +30 -delete || true
           find "$TARGET" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true

--- a/src/components/dashboard/MundosDeMiFinca.jsx
+++ b/src/components/dashboard/MundosDeMiFinca.jsx
@@ -4,7 +4,36 @@
  */
 import { MUNDOS_FINCA } from './mundosFinca';
 import MundoVineta from './MundoVinetas';
+import { useProCapability } from '../../hooks/useProCapability';
 import './mundos-finca.css';
+
+/**
+ * Glifo del espíritu de la finca: una llama-hoja con su brote adentro,
+ * dibujada a mano (SVG inline, cero assets). Acompaña la entrada Pro de
+ * abajo; el color lo hereda del texto (currentColor).
+ */
+function EspirituGlyph() {
+    return (
+        <svg viewBox="0 0 24 24" width="26" height="26" fill="none" aria-hidden="true">
+            {/* aura exterior (llama/hoja) */}
+            <path
+                d="M12 2.6c3.6 3.4 6.4 6.8 6.4 10.6 0 4.4-2.9 7.6-6.4 8.2-3.5-.6-6.4-3.8-6.4-8.2C5.6 9.4 8.4 6 12 2.6Z"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+                opacity="0.9"
+            />
+            {/* brote interior */}
+            <path
+                d="M12 17.5v-4.2m0 0c0-2 1.3-3.2 3-3.4.1 2.1-1 3.4-3 3.4Zm0-1.2c0-1.6-1-2.6-2.4-2.8-.1 1.7.8 2.8 2.4 2.8Z"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}
 
 /**
  * MundosDeMiFinca — la grilla de LOS MUNDOS DE MI FINCA en el home F2.
@@ -28,6 +57,13 @@ import './mundos-finca.css';
  */
 export default function MundosDeMiFinca({ onNavigate, mostrarAnimales = true, plantsCount = 0 }) {
     const mundos = MUNDOS_FINCA.filter((m) => m.gate !== 'animales' || mostrarAnimales);
+    // Entrada Pro "El espíritu de su finca" (capability avatar-espiritu,
+    // módulo del repo privado chagra-pro). GATE por capability: solo se
+    // renderiza cuando el módulo Pro está cargado en el registry — mismo
+    // criterio permisivo-estructural de EspirituProScreen. Para cuentas /
+    // builds sin Pro: CERO rastro (ni botón muerto ni teaser). Reactivo:
+    // loadProModules es async, la banda aparece sola cuando el módulo llega.
+    const tieneEspiritu = useProCapability('avatar-espiritu');
 
     const abrir = (m) => {
         if (m.portada) onNavigate?.(m.portada);
@@ -99,6 +135,31 @@ export default function MundosDeMiFinca({ onNavigate, mostrarAnimales = true, pl
                     );
                 })}
             </div>
+
+            {/* ── Entrada Pro: EL ESPÍRITU DE SU FINCA (#/espiritu) ──────────
+                Banda discreta DEBAJO de la grilla (no es un mundo más: es la
+                finca ENTERA vista como un solo ser vivo — y la política de la
+                grilla es ~10 tarjetas top-level). El corazón de la escena ya
+                se usó para "Pregunte" (#2230), por eso la entrada vive aquí.
+                Gate arriba (tieneEspiritu): sin módulo Pro no se renderiza. */}
+            {tieneEspiritu && (
+                <button
+                    type="button"
+                    className="mf-espiritu"
+                    data-testid="entrada-espiritu"
+                    onClick={() => onNavigate?.('espiritu_pro')}
+                    aria-label="El espíritu de su finca: véala respirar como un solo ser vivo (experiencia de su plan)"
+                >
+                    <span className="mf-espiritu-glifo" aria-hidden="true">
+                        <EspirituGlyph />
+                    </span>
+                    <span className="mf-espiritu-txt">
+                        <b>El espíritu de su finca</b>
+                        <small>Véala respirar: toda su finca como un solo ser vivo</small>
+                    </span>
+                    <span className="mf-espiritu-sello" aria-hidden="true">Pro</span>
+                </button>
+            )}
         </section>
     );
 }

--- a/src/components/dashboard/__tests__/MundosDeMiFinca.espiritu.test.jsx
+++ b/src/components/dashboard/__tests__/MundosDeMiFinca.espiritu.test.jsx
@@ -1,0 +1,91 @@
+/**
+ * MundosDeMiFinca — entrada Pro "El espíritu de su finca" (GATE por capability).
+ *
+ * El avatar-espíritu (#/espiritu, EspirituProScreen) estaba HUÉRFANO: montado y
+ * sirviendo pero sin NINGUNA entrada visible en la UI (la lección de
+ * features-ui-huerfanas-sin-cablear). Este test congela el cableado:
+ *   1. SIN módulo Pro registrado → cero rastro (ni botón muerto ni teaser).
+ *   2. CON módulo Pro (capability avatar-espiritu) → la banda aparece y su
+ *      click navega a la vista real 'espiritu_pro' (case de App.jsx, alias
+ *      hash #/espiritu).
+ *   3. Registro TARDÍO (loadProModules es async) → la banda aparece sola,
+ *      sin remontar el componente.
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+import MundosDeMiFinca from '../MundosDeMiFinca';
+import { registry } from '../../../core/moduleRegistry';
+
+const MODULO_FAKE = {
+  id: 'avatar-espiritu-pro',
+  version: '0.0.0-test',
+  capabilities: ['avatar-espiritu'],
+  mount: async () => ({ default: () => null }),
+};
+
+afterEach(() => {
+  registry.unregister(MODULO_FAKE.id);
+  cleanup();
+});
+
+describe('Entrada Pro — El espíritu de su finca', () => {
+  test('sin módulo Pro registrado NO se renderiza (cero rastro)', () => {
+    render(<MundosDeMiFinca onNavigate={vi.fn()} />);
+    expect(screen.queryByTestId('entrada-espiritu')).not.toBeInTheDocument();
+    expect(screen.queryByText(/espíritu de su finca/i)).not.toBeInTheDocument();
+  });
+
+  test('con capability avatar-espiritu aparece y navega a espiritu_pro', () => {
+    registry.register(MODULO_FAKE);
+    const onNavigate = vi.fn();
+    render(<MundosDeMiFinca onNavigate={onNavigate} />);
+
+    const entrada = screen.getByTestId('entrada-espiritu');
+    expect(entrada).toBeInTheDocument();
+    expect(entrada).toHaveTextContent(/el espíritu de su finca/i);
+    // Sello honesto: la banda declara que es del plan Pro.
+    expect(entrada).toHaveTextContent(/pro/i);
+
+    fireEvent.click(entrada);
+    expect(onNavigate).toHaveBeenCalledWith('espiritu_pro');
+  });
+
+  test('registro TARDÍO del módulo (async) hace aparecer la banda sin remontar', () => {
+    render(<MundosDeMiFinca onNavigate={vi.fn()} />);
+    expect(screen.queryByTestId('entrada-espiritu')).not.toBeInTheDocument();
+
+    // loadProModules corre después del primer render: simular el aterrizaje.
+    act(() => {
+      registry.register(MODULO_FAKE);
+    });
+    expect(screen.getByTestId('entrada-espiritu')).toBeInTheDocument();
+
+    // Y si el módulo se va (unregister), la banda desaparece — sin botón muerto.
+    act(() => {
+      registry.unregister(MODULO_FAKE.id);
+    });
+    expect(screen.queryByTestId('entrada-espiritu')).not.toBeInTheDocument();
+  });
+
+  test('la vista destino espiritu_pro existe en el router real (App.jsx)', async () => {
+    // Anti-huérfano en la otra dirección: la entrada no puede apuntar a una
+    // vista fantasma. Mismo criterio que el test de reachability.
+    // @types/node no está instalado en el repo (gap conocido, mismo criterio y
+    // comentario que MundosDeMiFinca.reachability.test.jsx): tsc no resuelve
+    // los specifiers "node:*", pero vitest/node sí. Irreducible sin sumar la
+    // dependencia @types/node al repo entero.
+    // @ts-expect-error TS2591 — ver comentario arriba.
+    const fs = await import('node:fs');
+    // @ts-expect-error TS2591 — ver comentario arriba.
+    const path = await import('node:path');
+    // @ts-expect-error TS2591 — ver comentario arriba.
+    const { fileURLToPath } = await import('node:url');
+    const __dir = path.dirname(fileURLToPath(import.meta.url));
+    const appSrc = fs.readFileSync(path.resolve(__dir, '../../../App.jsx'), 'utf8');
+    expect(appSrc).toMatch(/case 'espiritu_pro':/);
+    expect(appSrc).toMatch(/espiritu: 'espiritu_pro'/);
+  });
+});

--- a/src/components/dashboard/mundos-finca.css
+++ b/src/components/dashboard/mundos-finca.css
@@ -498,6 +498,82 @@ html[data-theme="biopunk"] .mf-indice-item {
 html:not([data-theme]) .mf-indice-txt small,
 html[data-theme="biopunk"] .mf-indice-txt small { color: rgb(var(--c-slate-300)); }
 
+/* ── Entrada Pro: EL ESPÍRITU DE SU FINCA ─────────────────────────────────────
+   Banda discreta bajo la grilla de mundos (gated por capability
+   avatar-espiritu — sin módulo Pro no se renderiza). No es una lámina de
+   papel más: es una VENTANA DE NOCHE en el cuaderno — la finca entera vista
+   como un solo ser vivo. Autocontenida en oscuro (misma clave #0f172a de la
+   experiencia), así lee igual sobre el cuaderno crema y sobre los temas navy. */
+.mf-espiritu {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 12px;
+  min-height: 58px;
+  padding: 10px 14px;
+  border-radius: 15px;
+  border: 1.5px solid rgba(94, 234, 178, 0.28);
+  background:
+    radial-gradient(120% 160% at 12% 20%, rgba(45, 212, 160, 0.16), transparent 55%),
+    linear-gradient(120deg, #0f172a, #123028);
+  color: #d9f5e6;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.mf-espiritu-glifo {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  color: #5eeab2;
+  background: rgba(94, 234, 178, 0.1);
+  animation: mf-espiritu-respira 4.5s ease-in-out infinite;
+}
+.mf-espiritu-txt { flex: 1 1 auto; min-width: 0; }
+.mf-espiritu-txt b {
+  display: block;
+  font-family: var(--mf-display, 'Baloo 2', 'Nunito', system-ui, sans-serif);
+  font-weight: 800;
+  font-size: 14.5px;
+  color: #eafcf2;
+}
+.mf-espiritu-txt small {
+  display: block;
+  font-size: 12.5px;
+  line-height: 1.35;
+  color: rgba(217, 245, 230, 0.78);
+}
+.mf-espiritu-sello {
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 234, 178, 0.45);
+  color: #5eeab2;
+}
+.mf-espiritu:focus-visible {
+  outline: 3px solid #5eeab2;
+  outline-offset: 2px;
+}
+.mf-espiritu:active { transform: scale(0.99); }
+/* La respiración del espíritu: el aura del glifo crece y afloja, lenta. */
+@keyframes mf-espiritu-respira {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(94, 234, 178, 0.0); transform: scale(1); }
+  50% { box-shadow: 0 0 0 6px rgba(94, 234, 178, 0.12); transform: scale(1.05); }
+}
+/* Sobre los temas navy la banda ya es oscura: solo afinar el borde al sistema. */
+html:not([data-theme]) .mf-espiritu,
+html[data-theme="biopunk"] .mf-espiritu {
+  border-color: color-mix(in srgb, #5eeab2 30%, rgb(var(--c-surface-border, 51 65 85)));
+}
+
 /* ── Accesibilidad de movimiento ──────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .mf-card {
@@ -507,6 +583,8 @@ html[data-theme="biopunk"] .mf-indice-txt small { color: rgb(var(--c-slate-300))
   .mf-card:active,
   .mf-entrada:active { transform: none; }
   .mf-entrada { transition: none; }
+  .mf-espiritu-glifo { animation: none; }
+  .mf-espiritu:active { transform: none; }
   @media (hover: hover) {
     .mf-card:hover { transform: none; }
   }

--- a/src/core/moduleRegistry.js
+++ b/src/core/moduleRegistry.js
@@ -28,6 +28,33 @@
 class ModuleRegistry {
   constructor() {
     this._modules = new Map();
+    // Suscriptores a cambios del registro. Los módulos Pro se cargan ASYNC
+    // (loadProModules corre después del primer render), así que la UI que
+    // gatea por capability necesita enterarse cuando un módulo aterriza —
+    // sin esto, un chequeo único al montar se pierde el registro tardío y
+    // la entrada Pro queda invisible aunque el módulo esté servido.
+    this._listeners = new Set();
+  }
+
+  /**
+   * Suscribe un callback a cambios del registro (register/unregister).
+   * Contrato compatible con useSyncExternalStore: devuelve el unsubscribe.
+   * @param {() => void} fn
+   * @returns {() => void}
+   */
+  subscribe(fn) {
+    this._listeners.add(fn);
+    return () => this._listeners.delete(fn);
+  }
+
+  _notify() {
+    for (const fn of this._listeners) {
+      try {
+        fn();
+      } catch (e) {
+        console.warn('[registry] listener falló:', e);
+      }
+    }
   }
 
   register(module_) {
@@ -39,10 +66,12 @@ class ModuleRegistry {
       console.warn(`[registry] sobreescribiendo módulo existente "${module_.id}"`);
     }
     this._modules.set(module_.id, module_);
+    this._notify();
   }
 
   unregister(id) {
     this._modules.delete(id);
+    this._notify();
   }
 
   has(id) {

--- a/src/hooks/useProCapability.js
+++ b/src/hooks/useProCapability.js
@@ -1,0 +1,29 @@
+/**
+ * useProCapability — ¿hay un módulo Pro registrado con esta capability?
+ * =====================================================================
+ * Gate de UI para entradas Pro (ADR-002/011): la entrada solo se muestra
+ * cuando el módulo Pro correspondiente está CARGADO en el moduleRegistry
+ * (build con VITE_PRO_MODULES_PATH + bundle Pro servido). En el build puro
+ * OSS —o para cuentas sin el plan— el módulo nunca se registra y la UI
+ * degrada a cero rastro (sin botones muertos).
+ *
+ * Reactivo: loadProModules corre DESPUÉS del primer render (async), así que
+ * el hook se suscribe al registry (useSyncExternalStore) y la entrada
+ * aparece sola cuando el módulo aterriza — un chequeo único al montar se lo
+ * perdería (misma lección de features huérfanas: cablear ≠ chequear una vez).
+ *
+ * @param {string} capability  ej. 'avatar-espiritu'
+ * @returns {boolean} true si al menos un módulo registrado la declara.
+ */
+import { useSyncExternalStore } from 'react';
+import { registry } from '../core/moduleRegistry';
+
+export function useProCapability(capability) {
+  return useSyncExternalStore(
+    (onStoreChange) => registry.subscribe(onStoreChange),
+    () => registry.byCapability(capability).length > 0,
+    () => false, // SSR/snapshot de servidor: sin módulos Pro.
+  );
+}
+
+export default useProCapability;

--- a/tests/e2e-espiritu-entrada.spec.js
+++ b/tests/e2e-espiritu-entrada.spec.js
@@ -1,0 +1,149 @@
+/* global process */
+import { test, expect } from '@playwright/test';
+
+/**
+ * e2e-espiritu-entrada.spec.js — la entrada visible al AVATAR-ESPÍRITU
+ * (#/espiritu) en el home, GATED por capability Pro.
+ *
+ * Contexto: el módulo avatar-espiritu-pro estaba montado y sirviendo pero
+ * HUÉRFANO (cero entradas en la UI — feedback-features-ui-huerfanas-sin-
+ * cablear). La entrada nueva vive bajo la grilla de LOS MUNDOS DE MI FINCA
+ * (MundosDeMiFinca, banda .mf-espiritu) y SOLO se renderiza cuando el
+ * registry tiene un módulo con capability 'avatar-espiritu'.
+ *
+ * Pro SIMULADO: el dev server corre en modo DEV, donde main.jsx expone
+ * window.__chagraRegistry. Registramos un módulo fake con la capability y el
+ * mount devolviendo un componente marcador (los componentes React pueden
+ * devolver string — cero dependencia del React del bundle). Esto ejercita el
+ * MISMO camino que loadProModules en prod: registry.register() → suscripción
+ * (useSyncExternalStore) → la banda aparece sin recargar.
+ *
+ * Patrones de la suite: mock OAuth/API en context.route, ORIGIN 5173,
+ * data-testid como selectores.
+ */
+
+// Servidor 5174 (webServer segundo de playwright.config.js): corre con
+// VITE_FINCA_VIVA_HOME_PERFIL=true — la realidad de prod/stg. La grilla de
+// mundos (y con ella esta entrada) SOLO existe en el home F2; en el 5173
+// legacy (flag OFF) el bloque no se renderiza.
+const ORIGIN = 'http://localhost:5174';
+
+const REGISTRAR_MODULO_FAKE = () => {
+  window.__chagraRegistry.register({
+    id: 'avatar-espiritu-pro',
+    version: '0.0.0-e2e',
+    capabilities: ['avatar-espiritu'],
+    mount: async () => ({ default: () => 'AVATAR ESPIRITU PRO MONTADO (E2E)' }),
+  });
+};
+
+test.describe('Entrada visible al avatar-espíritu (gate Pro)', () => {
+  test.beforeEach(async ({ context }) => {
+    // Mock OAuth — sin FarmOS real.
+    await context.route('**/oauth/token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-espiritu-fake-token',
+          refresh_token: 'e2e-espiritu-fake-refresh',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      }),
+    );
+    // Mock API — offline-first.
+    for (const pattern of ['**/api/**', '**/jsonapi/**']) {
+      await context.route(pattern, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [] }),
+        }),
+      );
+    }
+    // Silenciar sidecar / NLU (el grafo live está OFF y no dependemos de él).
+    await context.route('**/nlu**', (route) => route.abort('blockedbyclient'));
+    await context.route('**/resolve-entities**', (route) => route.abort('blockedbyclient'));
+  });
+
+  // Saltar onboarding + wizard de perfil (mismo patrón de e2e-smoke-pilotos):
+  // sin perfil sembrado, el wizard "Esta chagra es suya" tapa el home.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem('chagra:onboarding:done', '1');
+        window.localStorage.setItem('chagra:bienvenida-vista:v1', '1');
+        window.localStorage.setItem(
+          'chagra:profile:v1',
+          JSON.stringify({
+            rol: 'agricultor',
+            vocacion: 'campesino',
+            animales: [],
+            finca_tipo: 'rural',
+            finca_altitud: '1800',
+            piso_confirmado: '1',
+          }),
+        );
+      } catch (_) {
+        /* noop */
+      }
+    });
+  });
+
+  test('sin Pro no hay rastro; con Pro aparece, navega y monta el avatar', async ({ page }) => {
+    // ── Login ──────────────────────────────────────────────────────────
+    await page.goto(ORIGIN);
+    await page.getByLabel(/usuario/i).fill('e2e-espiritu');
+    await page.getByRole('textbox', { name: /contraseña/i }).fill('e2e-pass');
+    await page.getByRole('button', { name: /ingresar/i }).click();
+    await expect(page.getByTestId('mundos-finca')).toBeVisible({ timeout: 20_000 });
+
+    // ── 1. SIN módulo Pro: cero rastro (ni botón muerto ni teaser) ─────
+    await expect(page.getByTestId('entrada-espiritu')).toHaveCount(0);
+
+    // ── 2. Simular Pro: registrar el módulo fake (camino real de
+    //       loadProModules). La banda debe aparecer SOLA (suscripción). ──
+    await page.waitForFunction(() => !!window.__chagraRegistry);
+    await page.evaluate(REGISTRAR_MODULO_FAKE);
+    const entrada = page.getByTestId('entrada-espiritu');
+    await expect(entrada).toBeVisible({ timeout: 5_000 });
+    await expect(entrada).toContainText(/el espíritu de su finca/i);
+
+    // ── 3. Click → navega a la vista espiritu_pro y monta el avatar ────
+    await entrada.scrollIntoViewIfNeeded();
+    // Captura opcional para revisión del operador (ESPIRITU_SHOTS=dir).
+    if (process.env.ESPIRITU_SHOTS) {
+      await page.waitForTimeout(400);
+      await page.screenshot({ path: `${process.env.ESPIRITU_SHOTS}/espiritu-entrada-home.png` });
+    }
+    await entrada.click();
+    await expect(page.getByText('AVATAR ESPIRITU PRO MONTADO (E2E)')).toBeVisible({
+      timeout: 10_000,
+    });
+    // La grilla del home ya no está: navegó de verdad.
+    await expect(page.getByTestId('mundos-finca')).toHaveCount(0);
+    if (process.env.ESPIRITU_SHOTS) {
+      await page.screenshot({ path: `${process.env.ESPIRITU_SHOTS}/espiritu-vista-montada.png` });
+    }
+  });
+
+  test('la ruta #/espiritu (alias hash) monta la misma vista con Pro', async ({ page }) => {
+    await page.goto(ORIGIN);
+    await page.getByLabel(/usuario/i).fill('e2e-espiritu');
+    await page.getByRole('textbox', { name: /contraseña/i }).fill('e2e-pass');
+    await page.getByRole('button', { name: /ingresar/i }).click();
+    await expect(page.getByTestId('mundos-finca')).toBeVisible({ timeout: 20_000 });
+
+    await page.waitForFunction(() => !!window.__chagraRegistry);
+    await page.evaluate(REGISTRAR_MODULO_FAKE);
+
+    // Deep-link por hash (listener hashchange de App.jsx).
+    await page.evaluate(() => {
+      window.location.hash = '#/espiritu';
+    });
+    await expect(page.getByText('AVATAR ESPIRITU PRO MONTADO (E2E)')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});


### PR DESCRIPTION
## Qué

El módulo `avatar-espiritu-pro` estaba **huérfano**: montado y sirviendo en prod (`#/espiritu` vía `loadProModules` + `EspirituProScreen`) pero sin ninguna entrada visible en la UI.

### Entrada visible (Pro-gated)
- Banda discreta **"El espíritu de su finca"** debajo de la grilla de LOS MUNDOS DE MI FINCA (`MundosDeMiFinca`), con glifo SVG propio (llama-hoja con brote, `currentColor`) y sello `Pro`.
- **Gate por capability** `avatar-espiritu` del `moduleRegistry` — mismo criterio permisivo-estructural de `EspirituProScreen`. Sin módulo Pro cargado: **cero rastro** (ni botón muerto ni teaser).
- No agrega tarjeta top-level a la grilla (se queda en ~10 mundos) y no toca el corazón de la escena (ya usado por #2230). Click → vista `espiritu_pro` (alias hash `#/espiritu`).
- `moduleRegistry` ahora expone `subscribe()` (notify en register/unregister) + hook `useProCapability(cap)` con `useSyncExternalStore`: `loadProModules` es async y un chequeo único al montar se perdía el registro tardío.

### Fix dev-deploy.yml
- `VITE_PRO_MODULES_PATH: "/pro-modules"` (mismo valor/patrón que `deploy.yml` de prod). Sin esto, en dev `#/espiritu` caía siempre al fallback "no disponible en su plan".
- `--exclude='/pro-modules/'` en el rsync `--delete` (como en prod) para no borrar los bundles Pro montados en el docroot en cada deploy.

## Verificación
- **Unit** (`MundosDeMiFinca.espiritu.test.jsx`, 4 tests): sin módulo → cero rastro; con capability → aparece y navega a `espiritu_pro`; registro tardío/unregister reactivo; anti-vista-fantasma (el case existe en App.jsx).
- **E2E Playwright** (`tests/e2e-espiritu-entrada.spec.js`, 2 tests, contra 5174 = flag F2 ON como prod): login → sin Pro no hay entrada; Pro simulado vía registry → banda aparece sola, click monta el avatar; deep-link `#/espiritu` monta la misma vista. **2 passed**.
- `tsc` gate: 1820 vs baseline 1829 (sin errores nuevos). Perf budget: 24.0 MB / 25.5 MB. Lint limpio. Tests de registry existentes (36) verdes.
- Capturas enviadas al operador por Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)