### PR TITLE
fix(voz): santa por defecto, sin saltos de voz, selector de baja friccion

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -2551,9 +2551,9 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         if (kokoroReady) {
           // Free 7→10 fix-pack #4: streaming frase-por-frase reduce la
           // latencia hasta-primer-audio de "esperar respuesta entera"
-          // (3-23s) a "esperar primera frase" (<2s). Internamente fallback
-          // a speakKokoro/speak en caso de error en la primera frase.
-          speakSentences(responseBody, { rate: 0.9, pitch: 1.0 })
+          // (3-23s) a "esperar primera frase" (<2s). Sin rate hardcodeado:
+          // hereda la velocidad preferida del operador (getPreferredRate).
+          speakSentences(responseBody)
             .then((ok) => { if (!ok) warnIfMute(); })
             .catch(() => warnIfMute());
         } else {

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -440,7 +440,8 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
     try {
       const kokoroReady = await isKokoroAvailable();
       if (kokoroReady) {
-        await speakKokoro(message.content, { rate: 0.9, pitch: 1.0 });
+        // Sin rate hardcodeado: hereda la velocidad preferida del operador.
+        await speakKokoro(message.content);
       } else {
         speak(message.content, { rate: 0.9, pitch: 1.0 });
       }

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -1070,9 +1070,9 @@ function AgentVoiceSection() {
         <div className="flex flex-col gap-0.5 flex-1">
           <span className="text-sm font-bold text-slate-200">Voz del agente activa</span>
           <span className="text-xs text-slate-400 leading-snug">
-            Cuando está activa, Chagra IA lee en voz alta sus respuestas (Kokoro TTS,
-            con respaldo al sintetizador del navegador). Doble click en el avatar
-            colibrí silencia o reactiva sin abrir esta pantalla.
+            Cuando está activa, Chagra IA lee en voz alta sus respuestas con una
+            sola voz natural. Doble click en el avatar colibrí silencia o
+            reactiva sin abrir esta pantalla.
           </span>
         </div>
         <button

--- a/src/components/Settings/VoiceSelector.jsx
+++ b/src/components/Settings/VoiceSelector.jsx
@@ -1,25 +1,25 @@
 /**
- * VoiceSelector — Task #124 (2026-05-24).
+ * VoiceSelector — la voz de Chagra (rediseño de mínima fricción, 2026-07-09).
  *
- * Componente de Settings para elegir la voz Kokoro del asistente Chagra
- * y la velocidad de reproducción. Persiste preferencias en localStorage
- * vía `ttsService.setPreferredVoice` / `setPreferredRate`.
+ * El operador quiere que el campesino elija la voz OYENDO, con el mínimo de
+ * pasos y sin jerga. Antes había un dropdown + una lista "comparar" + un botón
+ * "Guardar" aparte + un slider: demasiados pasos y vocabulario técnico
+ * ("catálogo upstream", "acento neutro hispano").
  *
- * Diseñado para integrarse dentro de ProfileScreen (sección "Voz del
- * asistente") o cualquier futura pantalla de Ajustes. Mobile-first:
- * botones grandes (min-h 48px), sin scroll horizontal, dropdown nativo
- * que respeta el selector OS en mobile.
+ * Rediseño:
+ *   - Una tarjeta GRANDE por voz. UN TOQUE hace dos cosas a la vez: pone esa
+ *     voz como la de Chagra (persiste de una, sin botón Guardar) y la
+ *     REPRODUCE para que el usuario la oiga. La última que toca queda puesta.
+ *   - La voz puesta se marca con un check y "Puesta". Cero jerga.
+ *   - Velocidad opcional en 3 botones grandes (Despacio / Normal / Rápido),
+ *     no un slider fino.
  *
- * Contrato UX:
- *   - Dropdown con voces curadas (`KOKORO_VOICES` desde ttsService).
- *   - Botón "Probar" por voz → llama speakKokoro con frase fija.
- *   - Botón "Guardar" persiste voice + rate y flash de confirmación.
- *   - El estado del dropdown es local hasta apretar "Guardar".
- *   - Si Kokoro no está disponible, "Probar" cae al fallback speak()
- *     transparente (lo maneja speakKokoro internamente).
+ * Las voces vienen de KOKORO_VOICES (curadas por el oído del operador). La
+ * reproducción usa speakKokoro, que ahora prefiere kokoro SIEMPRE y nunca
+ * salta a la voz robótica del navegador (ver ttsService: consistencia de voz).
  */
-import React, { useState, useRef } from 'react';
-import { Volume2, Play, Save, Check } from 'lucide-react';
+import React, { useState } from 'react';
+import { Volume2, Play, Check } from 'lucide-react';
 import {
   speakKokoro,
   stop as stopTTS,
@@ -28,48 +28,56 @@ import {
   getPreferredRate,
   setPreferredRate,
   KOKORO_VOICES,
-  DEFAULT_KOKORO_VOICE,
-  KOKORO_RATE_MIN,
-  KOKORO_RATE_MAX,
 } from '../../services/ttsService';
 
 const SAMPLE_TEXT =
-  'Hola, soy el asistente Chagra. Probemos cómo suena mi voz en su finca.';
+  'Buenas, soy Chagra. Cuénteme qué le pasa a su matica y le ayudo.';
+
+// Velocidad en 3 pasos claros (mapean al rango soportado por ttsService).
+const SPEEDS = [
+  { id: 'slow', label: 'Despacio', rate: 0.85 },
+  { id: 'normal', label: 'Normal', rate: 1.0 },
+  { id: 'fast', label: 'Rápido', rate: 1.1 },
+];
+
+function speedIdFromRate(rate) {
+  // El más cercano gana (defensivo ante valores viejos como 0.9).
+  let best = SPEEDS[1];
+  let bestDelta = Infinity;
+  for (const s of SPEEDS) {
+    const d = Math.abs(s.rate - rate);
+    if (d < bestDelta) { bestDelta = d; best = s; }
+  }
+  return best.id;
+}
 
 export default function VoiceSelector() {
   const [selectedVoice, setSelectedVoice] = useState(() => getPreferredVoice());
-  const [rate, setRate] = useState(() => getPreferredRate());
-  const [savedFlash, setSavedFlash] = useState(false);
-  const [previewingVoice, setPreviewingVoice] = useState(null);
-  const flashTimerRef = useRef(null);
+  const [speedId, setSpeedId] = useState(() => speedIdFromRate(getPreferredRate()));
+  const [playingVoice, setPlayingVoice] = useState(null);
 
-  const handlePreview = async (voiceId) => {
-    // Cortar cualquier audio previo (preview, agente, lo que sea) antes
-    // de mandar el nuevo sample. Sin esto el operador escucha samples
-    // encimados si presiona "Probar" varias veces seguidas.
+  const currentRate = SPEEDS.find((s) => s.id === speedId)?.rate ?? 1.0;
+
+  // UN toque: elige la voz (persiste de una) + la reproduce para oírla.
+  const handleChooseAndPlay = async (voiceId) => {
     stopTTS();
-    setPreviewingVoice(voiceId);
+    setSelectedVoice(voiceId);
+    setPreferredVoice(voiceId); // persiste inmediato — sin botón "Guardar"
+    setPlayingVoice(voiceId);
     try {
-      await speakKokoro(SAMPLE_TEXT, { voice: voiceId, rate });
+      await speakKokoro(SAMPLE_TEXT, { voice: voiceId, rate: currentRate });
     } catch (_) {
-      // speakKokoro ya cae a Web Speech internamente. Si falla hasta acá
-      // es algo más raro; no romper la UI por un preview.
+      // speakKokoro nunca lanza hasta aquí (maneja su propio fallback); si
+      // pasara, no rompemos la UI.
     } finally {
-      setPreviewingVoice(null);
+      setPlayingVoice(null);
     }
   };
 
-  const handleSave = () => {
-    setPreferredVoice(selectedVoice);
-    setPreferredRate(rate);
-    setSavedFlash(true);
-    if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
-    flashTimerRef.current = setTimeout(() => setSavedFlash(false), 1500);
+  const handleSpeed = (speed) => {
+    setSpeedId(speed.id);
+    setPreferredRate(speed.rate);
   };
-
-  const selectedVoiceMeta =
-    KOKORO_VOICES.find((v) => v.id === selectedVoice) ||
-    KOKORO_VOICES.find((v) => v.id === DEFAULT_KOKORO_VOICE);
 
   return (
     <div
@@ -79,142 +87,102 @@ export default function VoiceSelector() {
       <div className="flex items-center gap-2 px-1">
         <Volume2 size={18} className="text-violet-400" />
         <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">
-          Voz del asistente
+          La voz de Chagra
         </h3>
       </div>
 
-      <p className="text-[11px] text-slate-500 leading-relaxed px-1">
-        Elija la voz con la que Chagra IA leerá sus respuestas. Pruebe cada
-        opción y guarde la que mejor le suene en su finca. Se usa Kokoro
-        TTS local; el catálogo upstream tiene varias voces probadas para
-        acento más neutro hispano.
+      <p className="text-xs text-slate-400 leading-relaxed px-1">
+        Toque una voz para escucharla. La que toque queda puesta.
       </p>
 
-      <label className="flex flex-col gap-2">
-        <span className="text-xs font-bold text-slate-400 uppercase tracking-wide">
-          Voz
-        </span>
-        <select
-          value={selectedVoice}
-          onChange={(e) => setSelectedVoice(e.target.value)}
-          className="p-3 rounded-xl bg-slate-800 border border-slate-700 focus:border-violet-500 outline-none text-white text-base min-h-[48px] appearance-none"
-          aria-label="Seleccionar voz del asistente"
-          data-testid="voice-dropdown"
-        >
-          {KOKORO_VOICES.map((voice) => (
-            <option key={voice.id} value={voice.id}>
-              {voice.label}
-            </option>
-          ))}
-        </select>
-        {selectedVoiceMeta && (
-          <span className="text-[10px] text-slate-500 leading-snug px-1">
-            {selectedVoiceMeta.description}
-          </span>
-        )}
-      </label>
-
-      {/* Botón Probar para la voz seleccionada en el dropdown */}
-      <button
-        type="button"
-        onClick={() => handlePreview(selectedVoice)}
-        disabled={previewingVoice !== null}
-        className="w-full p-3 rounded-xl font-bold flex items-center justify-center gap-2 bg-slate-800 hover:bg-slate-700 text-violet-400 transition-colors min-h-[48px] disabled:opacity-50"
-        data-testid="voice-preview-button"
-      >
-        <Play size={18} />
-        {previewingVoice === selectedVoice
-          ? 'Reproduciendo...'
-          : 'Probar esta voz'}
-      </button>
-
-      {/* Lista de previews rápidos por voz — útil para comparar A/B */}
-      <div className="space-y-2">
-        <span className="text-xs font-bold text-slate-400 uppercase tracking-wide px-1">
-          Comparar voces
-        </span>
-        <div className="grid grid-cols-1 gap-2">
-          {KOKORO_VOICES.map((voice) => (
+      {/* Tarjetas grandes de voz — un toque elige y reproduce. */}
+      <div className="flex flex-col gap-3">
+        {KOKORO_VOICES.map((voice) => {
+          const isSelected = voice.id === selectedVoice;
+          const isPlaying = playingVoice === voice.id;
+          return (
             <button
               key={voice.id}
               type="button"
-              onClick={() => handlePreview(voice.id)}
-              disabled={previewingVoice !== null}
-              className={`p-3 rounded-xl flex items-center justify-between gap-2 transition-colors min-h-[48px] disabled:opacity-50 ${
-                voice.id === selectedVoice
-                  ? 'bg-violet-900/30 border border-violet-700/50'
-                  : 'bg-slate-800/50 border border-slate-700/50 hover:bg-slate-800'
+              onClick={() => handleChooseAndPlay(voice.id)}
+              disabled={playingVoice !== null && !isPlaying}
+              data-testid={`voice-option-${voice.id}`}
+              aria-pressed={isSelected}
+              aria-label={`Voz ${voice.label}. ${isSelected ? 'Puesta. ' : ''}Tocar para escuchar y poner.`}
+              className={`w-full text-left rounded-2xl p-4 border transition-all flex items-center gap-4 min-h-[72px] active:scale-[0.99] motion-reduce:active:scale-100 disabled:opacity-50 ${
+                isSelected
+                  ? 'bg-violet-900/30 border-violet-600/60'
+                  : 'bg-slate-800/50 border-slate-700/60 hover:bg-slate-800'
               }`}
-              data-testid={`voice-row-${voice.id}`}
             >
-              <span className="flex flex-col items-start text-left flex-1 min-w-0">
-                <span className="text-sm font-bold text-slate-200 truncate w-full">
+              {/* Círculo de reproducir — señal grande y clara de "tocar = oír". */}
+              <span
+                className={`w-12 h-12 rounded-full flex items-center justify-center shrink-0 border ${
+                  isSelected
+                    ? 'bg-violet-600/40 border-violet-500/60'
+                    : 'bg-slate-900/60 border-slate-700'
+                }`}
+                aria-hidden="true"
+              >
+                <Play
+                  size={22}
+                  className={isPlaying ? 'text-violet-300 animate-pulse' : 'text-violet-300'}
+                />
+              </span>
+
+              <span className="flex flex-col flex-1 min-w-0">
+                <span className="text-base font-bold text-white leading-tight">
                   {voice.label}
                 </span>
-                <span className="text-[10px] text-slate-500 truncate w-full">
-                  {voice.gender}
+                <span className="text-xs text-slate-400 leading-snug mt-0.5">
+                  {isPlaying ? 'Escuchando…' : voice.description}
                 </span>
               </span>
-              <Play
-                size={16}
-                className={
-                  previewingVoice === voice.id
-                    ? 'text-violet-400 animate-pulse'
-                    : 'text-slate-400'
-                }
-              />
+
+              {isSelected && (
+                <span
+                  className="flex items-center gap-1 text-[11px] font-bold text-violet-300 shrink-0"
+                  data-testid={`voice-puesta-${voice.id}`}
+                >
+                  <Check size={16} aria-hidden="true" /> Puesta
+                </span>
+              )}
             </button>
-          ))}
+          );
+        })}
+      </div>
+
+      {/* Velocidad — opcional, 3 botones grandes en vez de un slider fino. */}
+      <div className="space-y-2 pt-1">
+        <span className="text-xs font-bold text-slate-400 uppercase tracking-wide px-1">
+          Qué tan rápido habla
+        </span>
+        <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Velocidad de la voz">
+          {SPEEDS.map((speed) => {
+            const active = speed.id === speedId;
+            return (
+              <button
+                key={speed.id}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                onClick={() => handleSpeed(speed)}
+                data-testid={`voice-speed-${speed.id}`}
+                className={`p-3 rounded-xl text-sm font-bold transition-colors min-h-[48px] border ${
+                  active
+                    ? 'bg-violet-900/30 border-violet-600/60 text-violet-200'
+                    : 'bg-slate-800/50 border-slate-700/60 text-slate-300 hover:bg-slate-800'
+                }`}
+              >
+                {speed.label}
+              </button>
+            );
+          })}
         </div>
       </div>
 
-      {/* Slider de velocidad */}
-      <label className="flex flex-col gap-2">
-        <span className="text-xs font-bold text-slate-400 uppercase tracking-wide">
-          Velocidad ({rate.toFixed(2)}x)
-        </span>
-        <input
-          type="range"
-          min={KOKORO_RATE_MIN}
-          max={KOKORO_RATE_MAX}
-          step="0.05"
-          value={rate}
-          onChange={(e) => setRate(Number.parseFloat(e.target.value))}
-          className="w-full accent-violet-500 min-h-[24px]"
-          aria-label="Velocidad de reproducción de la voz"
-          data-testid="voice-rate-slider"
-        />
-        <div className="flex justify-between text-[10px] text-slate-500 px-1">
-          <span>Más lenta ({KOKORO_RATE_MIN}x)</span>
-          <span>Más rápida ({KOKORO_RATE_MAX}x)</span>
-        </div>
-      </label>
-
-      <button
-        type="button"
-        onClick={handleSave}
-        className={`w-full p-3 rounded-xl font-bold flex items-center justify-center gap-2 transition-all min-h-[48px] ${
-          savedFlash
-            ? 'bg-violet-600 text-white'
-            : 'bg-slate-800 hover:bg-slate-700 text-violet-400'
-        }`}
-        data-testid="voice-save-button"
-      >
-        {savedFlash ? (
-          <>
-            <Check size={18} /> Guardado
-          </>
-        ) : (
-          <>
-            <Save size={18} /> Guardar preferencias
-          </>
-        )}
-      </button>
-
-      <p className="text-[10px] text-slate-500 text-center leading-relaxed">
-        Las preferencias se guardan localmente en su dispositivo. La voz
-        por defecto es <strong className="text-slate-400">Dora</strong>
-        {' '}para no romper a operadores ya acostumbrados.
+      <p className="text-[11px] text-slate-500 text-center leading-relaxed">
+        Lo que elija se guarda solo, en su teléfono.
       </p>
     </div>
   );

--- a/src/components/Settings/__tests__/VoiceSelector.test.jsx
+++ b/src/components/Settings/__tests__/VoiceSelector.test.jsx
@@ -1,21 +1,21 @@
 /**
- * Tests para VoiceSelector — task #124 (2026-05-24).
+ * Tests para VoiceSelector — rediseño de mínima fricción (2026-07-09).
  *
  * Cubre:
- *   - Renderiza dropdown con las voces curadas (KOKORO_VOICES)
- *   - "Probar" dispara speakKokoro con la voz seleccionada
- *   - "Guardar" persiste voice + rate en localStorage
- *   - Cambiar dropdown actualiza el state local (no persiste hasta Save)
- *   - Cada fila de "comparar voces" tiene su propio botón preview
+ *   - Renderiza una tarjeta grande por voz (KOKORO_VOICES), sin dropdown.
+ *   - UN toque en una voz: la reproduce (speakKokoro) Y la persiste de una
+ *     (sin botón "Guardar").
+ *   - La voz puesta se marca ("Puesta").
+ *   - Tocar corta el audio previo (stop) antes de reproducir.
+ *   - La velocidad se elige en 3 botones y persiste.
  */
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 
-// Mock del ttsService — solo necesitamos verificar que speakKokoro se llame
-// con los args esperados; el detalle interno (fetch, audio) lo cubren los
-// tests del service.
+// Mock del ttsService — solo interceptamos speakKokoro/stop; el resto (persist
+// en localStorage) usa el módulo real para verificar la persistencia inmediata.
 vi.mock('../../../services/ttsService', async () => {
   const actual = await vi.importActual('../../../services/ttsService');
   return {
@@ -33,100 +33,72 @@ import {
   DEFAULT_KOKORO_VOICE,
 } from '../../../services/ttsService';
 
-describe('VoiceSelector — task #124', () => {
+describe('VoiceSelector — rediseño mínima fricción', () => {
   beforeEach(() => {
     localStorage.clear();
     speakKokoro.mockClear();
     stopTTS.mockClear();
   });
 
-  test('renderiza dropdown con todas las voces curadas', () => {
+  test('renderiza una tarjeta por voz curada (sin dropdown)', () => {
     render(<VoiceSelector />);
-    const dropdown = screen.getByTestId('voice-dropdown');
-    expect(dropdown).toBeInTheDocument();
-    // El select debe tener una option por voz.
-    const options = dropdown.querySelectorAll('option');
-    expect(options.length).toBe(KOKORO_VOICES.length);
+    expect(screen.queryByTestId('voice-dropdown')).not.toBeInTheDocument();
     for (const voice of KOKORO_VOICES) {
-      expect(dropdown.textContent).toContain(voice.label);
+      const card = screen.getByTestId(`voice-option-${voice.id}`);
+      expect(card).toBeInTheDocument();
+      expect(card.textContent).toContain(voice.label);
     }
   });
 
-  test('selección inicial es la voz preferida del storage (o default)', () => {
-    localStorage.setItem('chagra:tts:voice', 'ef_aoede');
+  test('marca la voz por defecto como "Puesta" al abrir (storage vacío)', () => {
     render(<VoiceSelector />);
-    const dropdown = screen.getByTestId('voice-dropdown');
-    expect(dropdown.value).toBe('ef_aoede');
+    expect(screen.getByTestId(`voice-puesta-${DEFAULT_KOKORO_VOICE}`)).toBeInTheDocument();
   });
 
-  test('selección inicial cae a default si storage vacío', () => {
+  test('respeta la voz preferida persistida', () => {
+    localStorage.setItem('chagra:tts:voice', 'pm_santa');
     render(<VoiceSelector />);
-    const dropdown = screen.getByTestId('voice-dropdown');
-    expect(dropdown.value).toBe(DEFAULT_KOKORO_VOICE);
+    expect(screen.getByTestId('voice-puesta-pm_santa')).toBeInTheDocument();
   });
 
-  test('click "Probar esta voz" llama speakKokoro con la voz seleccionada', async () => {
+  test('UN toque reproduce la voz Y la persiste de una (sin Guardar)', async () => {
     render(<VoiceSelector />);
-    const dropdown = screen.getByTestId('voice-dropdown');
-    fireEvent.change(dropdown, { target: { value: 'ef_kore' } });
-    const previewBtn = screen.getByTestId('voice-preview-button');
-    fireEvent.click(previewBtn);
+    fireEvent.click(screen.getByTestId('voice-option-em_alex'));
+
     await waitFor(() => {
       expect(speakKokoro).toHaveBeenCalledTimes(1);
     });
     const [text, opts] = speakKokoro.mock.calls[0];
-    expect(text).toMatch(/asistente Chagra/i);
-    expect(opts).toMatchObject({ voice: 'ef_kore' });
+    expect(text).toMatch(/soy Chagra/i);
+    expect(opts.voice).toBe('em_alex');
+    // Persistió inmediatamente, sin botón Guardar.
+    expect(localStorage.getItem('chagra:tts:voice')).toBe('em_alex');
   });
 
-  test('click "Guardar" persiste voice + rate en localStorage', async () => {
+  test('tocar corta el audio previo antes de reproducir (evita overlap)', async () => {
     render(<VoiceSelector />);
-    const dropdown = screen.getByTestId('voice-dropdown');
-    fireEvent.change(dropdown, { target: { value: 'em_alex' } });
-    const slider = screen.getByTestId('voice-rate-slider');
-    fireEvent.change(slider, { target: { value: '1.05' } });
-    const saveBtn = screen.getByTestId('voice-save-button');
-    fireEvent.click(saveBtn);
-    await waitFor(() => {
-      expect(localStorage.getItem('chagra:tts:voice')).toBe('em_alex');
-    });
-    expect(Number.parseFloat(localStorage.getItem('chagra:tts:rate'))).toBeCloseTo(1.05);
-    // Flash de "Guardado" debe aparecer.
-    expect(saveBtn).toHaveTextContent(/Guardado/i);
-  });
-
-  test('cada fila de "comparar voces" tiene su propio botón preview', async () => {
-    render(<VoiceSelector />);
-    for (const voice of KOKORO_VOICES) {
-      const row = screen.getByTestId(`voice-row-${voice.id}`);
-      expect(row).toBeInTheDocument();
-      expect(row.textContent).toContain(voice.label);
-    }
-    // Click en una fila específica dispara preview de esa voz.
-    const aoedeRow = screen.getByTestId('voice-row-ef_aoede');
-    fireEvent.click(aoedeRow);
-    await waitFor(() => {
-      expect(speakKokoro).toHaveBeenCalledTimes(1);
-    });
-    const [, opts] = speakKokoro.mock.calls[0];
-    expect(opts.voice).toBe('ef_aoede');
-  });
-
-  test('cambiar dropdown NO persiste hasta apretar Guardar (state local)', () => {
-    render(<VoiceSelector />);
-    const dropdown = screen.getByTestId('voice-dropdown');
-    fireEvent.change(dropdown, { target: { value: 'ef_kore' } });
-    // No tocamos Guardar — localStorage debe seguir sin la nueva voz.
-    expect(localStorage.getItem('chagra:tts:voice')).toBeNull();
-  });
-
-  test('preview corta cualquier audio previo antes de reproducir (evita overlap)', async () => {
-    render(<VoiceSelector />);
-    const previewBtn = screen.getByTestId('voice-preview-button');
-    fireEvent.click(previewBtn);
+    fireEvent.click(screen.getByTestId('voice-option-pm_santa'));
     await waitFor(() => {
       expect(stopTTS).toHaveBeenCalled();
       expect(speakKokoro).toHaveBeenCalledTimes(1);
     });
+  });
+
+  test('la velocidad se elige en botones y persiste', async () => {
+    render(<VoiceSelector />);
+    fireEvent.click(screen.getByTestId('voice-speed-fast'));
+    await waitFor(() => {
+      expect(Number.parseFloat(localStorage.getItem('chagra:tts:rate'))).toBeCloseTo(1.1);
+    });
+    // Y esa velocidad viaja en el siguiente preview.
+    fireEvent.click(screen.getByTestId('voice-option-em_alex'));
+    await waitFor(() => expect(speakKokoro).toHaveBeenCalled());
+    const [, opts] = speakKokoro.mock.calls[0];
+    expect(opts.rate).toBeCloseTo(1.1);
+  });
+
+  test('ya no ofrece a Dora (ef_dora): el operador la quitó', () => {
+    render(<VoiceSelector />);
+    expect(screen.queryByTestId('voice-option-ef_dora')).not.toBeInTheDocument();
   });
 });

--- a/src/services/__tests__/ttsService.consistency.test.js
+++ b/src/services/__tests__/ttsService.consistency.test.js
@@ -1,0 +1,197 @@
+/**
+ * Tests de CONSISTENCIA DE VOZ (2026-07-09).
+ *
+ * Bug reportado por el operador: "a veces habla una voz y luego otra". Causa:
+ * cuando kokoro fallaba/timeouteaba, el TTS saltaba a window.speechSynthesis
+ * (voz robótica del navegador) — a media sesión e incluso a media respuesta
+ * (fallback por-frase en speakSentences). Resultado: la voz cambiaba de golpe.
+ *
+ * Fix: preferir kokoro SIEMPRE. Ante un fallo, reintentar con backoff; si aun
+ * así falla, guardar SILENCIO consistente en vez de cambiar a la voz robótica.
+ * El respaldo del navegador queda detrás de un flag OFF por defecto
+ * (getBrowserVoiceFallback), que el operador puede reactivar a propósito.
+ *
+ * Estos tests verifican que, con el flag por defecto (OFF):
+ *   - speakKokoro fallando NO llama a window.speechSynthesis.speak.
+ *   - speakSentences fallando (synth o playback) NO llama a speechSynthesis.
+ *   - reintenta antes de rendirse (recupera un blip transitorio).
+ * Y que, con el flag ON, sí cae al navegador (comportamiento explícito).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  speakKokoro,
+  speakSentences,
+  getBrowserVoiceFallback,
+  setBrowserVoiceFallback,
+  KOKORO_MAX_RETRIES,
+} from '../ttsService.js';
+
+// MockAudio con cola de comportamientos de play() ('ok' | 'reject').
+let audioInstances = [];
+let playBehaviors = [];
+class MockAudio {
+  constructor(url) {
+    this.url = url;
+    this.paused = true;
+    this.onended = null;
+    this.onerror = null;
+    this.playbackRate = 1;
+    this._behavior = playBehaviors.shift() || 'ok';
+    audioInstances.push(this);
+  }
+  play() {
+    if (this._behavior === 'reject') return Promise.reject(new Error('play failed'));
+    this.paused = false;
+    return Promise.resolve();
+  }
+  pause() {
+    this.paused = true;
+  }
+}
+
+/**
+ * Avanza la "cadena" de speakSentences: dispara onended() de cada audio que
+ * está sonando para que su playSentenceBlob resuelva y el loop avance. Mismo
+ * patrón que ttsService.speakingState.test.js.
+ */
+async function drainSentenceChain() {
+  for (let guard = 0; guard < 40; guard++) {
+    await new Promise((r) => setTimeout(r, 0));
+    const playing = audioInstances.find((a) => !a.paused && a.onended);
+    if (playing) {
+      playing.paused = true;
+      playing.onended();
+    }
+  }
+}
+
+const TWO_SENTENCES =
+  'La primera frase del agente es suficientemente larga para el pipeline de voz. ' +
+  'La segunda frase tambien supera el umbral de caracteres minimo necesario.';
+
+describe('ttsService — consistencia de voz (no saltar a la voz robótica)', () => {
+  let fetchMock;
+  let speechSynthesisMock;
+  let originalAudio;
+
+  beforeEach(() => {
+    localStorage.clear();
+    audioInstances = [];
+    playBehaviors = [];
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+    originalAudio = globalThis.Audio;
+    // Mocks de globals de jsdom → casts a any (irreducibles: no implementamos
+    // las interfaces completas HTMLAudioElement/SpeechSynthesis).
+    globalThis.Audio = /** @type {any} */ (MockAudio);
+    URL.createObjectURL = vi.fn(() => 'blob:fake-url');
+    URL.revokeObjectURL = vi.fn();
+    speechSynthesisMock = {
+      speak: vi.fn(),
+      cancel: vi.fn(),
+      getVoices: () => [],
+      speaking: false,
+      paused: false,
+    };
+    window.speechSynthesis = /** @type {any} */ (speechSynthesisMock);
+    // SpeechSynthesisUtterance debe existir para que speak() no reviente si
+    // (indebidamente) se invocara.
+    globalThis.SpeechSynthesisUtterance = /** @type {any} */ (
+      class {
+        constructor(t) { this.text = t; }
+      }
+    );
+  });
+
+  afterEach(() => {
+    globalThis.Audio = originalAudio;
+    delete window.speechSynthesis;
+    vi.restoreAllMocks();
+  });
+
+  describe('flag getBrowserVoiceFallback', () => {
+    it('por defecto es false (una sola voz natural)', () => {
+      expect(getBrowserVoiceFallback()).toBe(false);
+    });
+
+    it('set/get roundtrip', () => {
+      expect(setBrowserVoiceFallback(true)).toBe(true);
+      expect(getBrowserVoiceFallback()).toBe(true);
+      setBrowserVoiceFallback(false);
+      expect(getBrowserVoiceFallback()).toBe(false);
+    });
+  });
+
+  describe('speakKokoro cuando kokoro falla', () => {
+    it('NO salta a speechSynthesis por defecto (silencio consistente)', async () => {
+      fetchMock.mockRejectedValue(new Error('kokoro caído'));
+
+      const result = await speakKokoro('Hola, soy Chagra.');
+
+      expect(result).toBeNull();
+      expect(speechSynthesisMock.speak).not.toHaveBeenCalled();
+    });
+
+    it('reintenta antes de rendirse (KOKORO_MAX_RETRIES + 1 intentos)', async () => {
+      fetchMock.mockRejectedValue(new Error('503'));
+
+      await speakKokoro('Texto de prueba.');
+
+      // 1 intento inicial + KOKORO_MAX_RETRIES reintentos.
+      expect(fetchMock).toHaveBeenCalledTimes(KOKORO_MAX_RETRIES + 1);
+      expect(speechSynthesisMock.speak).not.toHaveBeenCalled();
+    });
+
+    it('un blip transitorio se recupera sin cambiar de voz', async () => {
+      fetchMock
+        .mockRejectedValueOnce(new Error('blip 503'))
+        .mockResolvedValue({
+          ok: true,
+          blob: async () => new Blob(['audio'], { type: 'audio/opus' }),
+        });
+
+      const audio = await speakKokoro('Recupera el blip.');
+
+      expect(audio).toBeInstanceOf(MockAudio);
+      expect(fetchMock).toHaveBeenCalledTimes(2); // falla 1, éxito al 2do
+      expect(speechSynthesisMock.speak).not.toHaveBeenCalled();
+    });
+
+    it('CON el flag ON sí cae al navegador (comportamiento explícito)', async () => {
+      setBrowserVoiceFallback(true);
+      fetchMock.mockRejectedValue(new Error('kokoro caído'));
+
+      await speakKokoro('Hola con respaldo.');
+
+      expect(speechSynthesisMock.speak).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('speakSentences cuando kokoro falla', () => {
+    it('NO salta a speechSynthesis si TODAS las frases fallan la síntesis', async () => {
+      fetchMock.mockRejectedValue(new Error('kokoro caído'));
+
+      const ok = await speakSentences(TWO_SENTENCES);
+
+      expect(ok).toBe(false);
+      expect(speechSynthesisMock.speak).not.toHaveBeenCalled();
+    });
+
+    it('NO salta a speechSynthesis si una frase FALLA EL PLAYBACK a media respuesta', async () => {
+      // Síntesis siempre OK; el playback de la 2da frase falla.
+      fetchMock.mockResolvedValue({
+        ok: true,
+        blob: async () => new Blob(['audio'], { type: 'audio/opus' }),
+      });
+      // 1ra frase suena, 2da rechaza play() → antes caía a speak() robótico.
+      playBehaviors = ['ok', 'reject', 'ok', 'ok'];
+
+      const promise = speakSentences(TWO_SENTENCES);
+      await drainSentenceChain();
+      const ok = await promise;
+
+      expect(ok).toBe(true); // la primera frase sí sonó (kokoro)
+      expect(speechSynthesisMock.speak).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/__tests__/ttsService.voice.test.js
+++ b/src/services/__tests__/ttsService.voice.test.js
@@ -69,14 +69,14 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
   });
 
   describe('getPreferredVoice', () => {
-    it('devuelve default ef_dora si localStorage está vacío', () => {
+    it('devuelve el default (pm_santa) si localStorage está vacío', () => {
       expect(getPreferredVoice()).toBe(DEFAULT_KOKORO_VOICE);
-      expect(getPreferredVoice()).toBe('ef_dora');
+      expect(getPreferredVoice()).toBe('pm_santa');
     });
 
     it('devuelve la voz persistida si está en KOKORO_VOICES', () => {
-      localStorage.setItem('chagra:tts:voice', 'ef_aoede');
-      expect(getPreferredVoice()).toBe('ef_aoede');
+      localStorage.setItem('chagra:tts:voice', 'pm_santa');
+      expect(getPreferredVoice()).toBe('pm_santa');
     });
 
     it('devuelve default si el valor persistido NO está en KOKORO_VOICES (defensa contra corrupción)', () => {
@@ -94,12 +94,17 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
 
   describe('setPreferredVoice', () => {
     it('persiste voces válidas y devuelve true', () => {
-      expect(setPreferredVoice('ef_aoede')).toBe(true);
-      expect(localStorage.getItem('chagra:tts:voice')).toBe('ef_aoede');
+      expect(setPreferredVoice('pm_santa')).toBe(true);
+      expect(localStorage.getItem('chagra:tts:voice')).toBe('pm_santa');
     });
 
     it('rechaza voces no listadas y devuelve false', () => {
       expect(setPreferredVoice('ef_basura')).toBe(false);
+      expect(localStorage.getItem('chagra:tts:voice')).toBeNull();
+    });
+
+    it('rechaza ef_dora: se quitó del catálogo (operador no la quiere)', () => {
+      expect(setPreferredVoice('ef_dora')).toBe(false);
       expect(localStorage.getItem('chagra:tts:voice')).toBeNull();
     });
 
@@ -139,36 +144,53 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
   });
 
   describe('speakKokoro respeta preferencia persistida', () => {
-    it('sin voice explícito usa getPreferredVoice (default ef_dora cuando vacío)', async () => {
+    it('sin voice explícito usa getPreferredVoice (default pm_santa cuando vacío)', async () => {
       await speakKokoro('Hola mundo');
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
-      expect(body.voice).toBe('ef_dora');
+      expect(body.voice).toBe('pm_santa');
     });
 
     it('sin voice explícito usa la voz preferida persistida', async () => {
-      setPreferredVoice('ef_kore');
+      setPreferredVoice('if_sara');
       await speakKokoro('Hola mundo');
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
-      expect(body.voice).toBe('ef_kore');
+      expect(body.voice).toBe('if_sara');
     });
 
     it('voice explícito en options gana sobre la voz preferida (backwards compat)', async () => {
-      setPreferredVoice('ef_kore');
+      setPreferredVoice('pm_santa');
       await speakKokoro('Hola mundo', { voice: 'em_alex' });
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
       expect(body.voice).toBe('em_alex');
     });
 
-    it('voice explícito ef_dora también gana aunque sea el default (asegura no se "promueve" preferencia)', async () => {
-      setPreferredVoice('ef_aoede');
+    it('voice explícito gana aunque sea distinto del default (no se "promueve" preferencia)', async () => {
+      setPreferredVoice('pm_santa');
+      await speakKokoro('Hola', { voice: 'if_sara' });
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init.body);
+      expect(body.voice).toBe('if_sara');
+    });
+
+    it('coerciona ef_dora (no servible) a la default santa: dora NUNCA viaja al server', async () => {
       await speakKokoro('Hola', { voice: 'ef_dora' });
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
-      expect(body.voice).toBe('ef_dora');
+      expect(body.voice).toBe('pm_santa');
+    });
+
+    it('coerciona voces inglesas inexistentes (ef_aoede/ef_kore) a santa, no a dora', async () => {
+      await speakKokoro('Hola', { voice: 'ef_aoede' });
+      await speakKokoro('Hola', { voice: 'ef_kore' });
+      for (const call of fetchMock.mock.calls) {
+        const body = JSON.parse(call[1].body);
+        expect(body.voice).toBe('pm_santa');
+        expect(body.voice).not.toBe('ef_dora');
+      }
     });
   });
 });

--- a/src/services/__tests__/ttsService.xtts.test.js
+++ b/src/services/__tests__/ttsService.xtts.test.js
@@ -163,23 +163,34 @@ describe('ttsService — XTTS-v2 voz colombiana (task #124)', () => {
 
   describe('speakXTTS fallback a Kokoro', () => {
     it('intenta fallback a speakKokoro cuando XTTS retorna HTTP error', async () => {
-      fetchMock.mockRejectedValueOnce(new Error('HTTP 500'));
+      // XTTS falla una vez; el fallback a Kokoro responde OK al primer intento
+      // (sin reintentos), así el total es exactamente 2 llamadas.
+      fetchMock
+        .mockRejectedValueOnce(new Error('HTTP 500'))
+        .mockResolvedValue({
+          ok: true,
+          blob: async () => new Blob(['fake-audio'], { type: 'audio/opus' }),
+        });
 
-      // speakXTTS debería intentar fallback a Kokoro
-      // Kokoro también llamará a fetch, así que esperamos 2 llamadas
       await speakXTTS('Test');
 
-      // Debería haber intentado fetch para XTTS y luego para Kokoro
+      // 1 fetch para XTTS (falla) + 1 para Kokoro (ok al primer intento).
       expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1][0]).toBe('/api/kokoro/tts');
     });
 
     it('intenta fallback a speakKokoro cuando response no es ok', async () => {
-      fetchMock.mockRejectedValueOnce(new Error('HTTP 404'));
+      fetchMock
+        .mockRejectedValueOnce(new Error('HTTP 404'))
+        .mockResolvedValue({
+          ok: true,
+          blob: async () => new Blob(['fake-audio'], { type: 'audio/opus' }),
+        });
 
       await speakXTTS('Test');
 
-      // Debería haber intentado fetch para XTTS y luego para Kokoro
       expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1][0]).toBe('/api/kokoro/tts');
     });
 
     // TODO: Test de timeout requiere mock complejo de AbortController + timers

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -67,35 +67,43 @@ function applyVoseoGuard(text) {
  * otras voces ef_ / em_ en futuras iteraciones. Si descubrimos una voz
  * específicamente colombiana en upstream, la agregamos acá.
  */
+/*
+ * ACTUALIZACIÓN 2026-07-09 (voz de Chagra): el bloque de arriba quedó
+ * DESACTUALIZADO. Se verificó el catálogo REAL contra el servidor (/health):
+ * la lista servible es KOKORO_VOICES (abajo), curada por el oído del operador
+ * — pm_santa (DEFAULT), if_sara, em_alex. Se retiró la vieja voz por defecto
+ * del selector por decisión del operador.
+ *
+ * GOTCHA IMPORTANTE: `ef_aoede`/`ef_kore` NO existen en el servidor (son
+ * `af_aoede`/`af_kore`, inglesas). Ante una voz desconocida el servidor cae
+ * SILENCIOSAMENTE a su DEFAULT_VOICE — por eso una preferencia vieja hacía
+ * "sonar" la voz retirada. La guarda toServableVoice() coacciona cualquier voz
+ * no servible a la default (santa) antes de ir al server: la voz retirada nunca
+ * suena, ni por el fallback del servidor.
+ */
 export const KOKORO_VOICES = Object.freeze([
   {
-    id: 'ef_dora',
-    label: 'Dora (femenina, default)',
-    description: 'Voz por defecto. Tono suave. Puede sentirse con acento anglo.',
-    gender: 'femenina',
+    id: 'pm_santa',
+    label: 'Santa',
+    description: 'Voz de hombre, cálida y tranquila.',
+    gender: 'masculina',
   },
   {
-    id: 'ef_aoede',
-    label: 'Aoede (femenina, más neutra)',
-    description: 'Voz femenina musical. Acento hispano más neutro según comunidad.',
-    gender: 'femenina',
-  },
-  {
-    id: 'ef_kore',
-    label: 'Kore (femenina, articulación firme)',
-    description: 'Voz femenina con articulación clara. Buena para campo con ruido.',
+    id: 'if_sara',
+    label: 'Sara',
+    description: 'Voz de mujer, dulce y cercana.',
     gender: 'femenina',
   },
   {
     id: 'em_alex',
-    label: 'Alex (masculina, cálida)',
-    description: 'Voz masculina cálida. Alternativa al perfil femenino.',
+    label: 'Álex',
+    description: 'Voz de hombre, natural y de tono medio.',
     gender: 'masculina',
   },
 ]);
 
-export const DEFAULT_KOKORO_VOICE = 'ef_dora';
-export const DEFAULT_KOKORO_RATE = 0.9;
+export const DEFAULT_KOKORO_VOICE = 'pm_santa';
+export const DEFAULT_KOKORO_RATE = 1.0;
 export const KOKORO_RATE_MIN = 0.85;
 export const KOKORO_RATE_MAX = 1.1;
 
@@ -113,7 +121,33 @@ export const XTTS_ENABLED_KEY = 'chagra:tts:xtts_enabled';
 const STORAGE_KEY_VOICE = 'chagra:tts:voice';
 const STORAGE_KEY_RATE = 'chagra:tts:rate';
 
+// Consistencia de voz (2026-07-09): por defecto NO caemos a la voz del
+// navegador (window.speechSynthesis, robótica y con acento). El operador
+// reportó "a veces habla una voz y luego otra": era este fallback saltando a
+// media sesión cuando kokoro fallaba/timeouteaba. Preferimos UNA sola voz
+// natural: si kokoro falla, reintentamos y, si no, silencio consistente.
+// Este flag deja al operador reactivar el respaldo del navegador a propósito.
+const STORAGE_KEY_BROWSER_FALLBACK = 'chagra:tts:browser_fallback';
+
 const VALID_VOICE_IDS = new Set(KOKORO_VOICES.map((v) => v.id));
+
+/**
+ * Coerciona una voz a una que EXISTE de verdad en el servidor kokoro.
+ *
+ * Orden del operador (2026-07-09): dora NUNCA debe sonar, ni siquiera en el
+ * fallback del servidor. El servidor kokoro, ante una voz DESCONOCIDA, cae
+ * SILENCIOSAMENTE a su DEFAULT_VOICE (ef_dora) — por eso "a veces sonaba dora"
+ * aunque se quitó del selector: una preferencia vieja como 'ef_aoede'/'ef_kore'
+ * (voces inglesas inexistentes) o la propia 'ef_dora' viajaba al server y este
+ * la resolvía a dora.
+ *
+ * Garantía dura: si la voz pedida NO está en KOKORO_VOICES (las que sabemos que
+ * existen de verdad), la sustituimos por DEFAULT_KOKORO_VOICE (santa). Así el
+ * servidor jamás recibe una voz que resuelva a dora.
+ */
+function toServableVoice(voice) {
+  return VALID_VOICE_IDS.has(voice) ? voice : DEFAULT_KOKORO_VOICE;
+}
 
 /**
  * Task #124: lee la voz Kokoro preferida persistida en localStorage.
@@ -213,6 +247,39 @@ export function setXTTSEnabled(enabled) {
   try {
     if (typeof localStorage === 'undefined') return false;
     localStorage.setItem(XTTS_ENABLED_KEY, String(enabled));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Consistencia de voz (2026-07-09): ¿permitir el respaldo a la voz del
+ * navegador (window.speechSynthesis) cuando kokoro falla?
+ *
+ * Default FALSE: preferimos una sola voz natural. Si kokoro no responde,
+ * reintentamos y, si aun así falla, guardamos silencio en vez de cambiar
+ * abruptamente a la voz robótica del navegador (era la causa del "a veces
+ * habla una voz y luego otra"). El operador puede reactivarlo a propósito.
+ */
+export function getBrowserVoiceFallback() {
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    return localStorage.getItem(STORAGE_KEY_BROWSER_FALLBACK) === 'true';
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Persiste la preferencia de respaldo a la voz del navegador.
+ *
+ * @returns {boolean} true si guardó, false si storage falló.
+ */
+export function setBrowserVoiceFallback(enabled) {
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    localStorage.setItem(STORAGE_KEY_BROWSER_FALLBACK, String(!!enabled));
     return true;
   } catch (_) {
     return false;
@@ -403,26 +470,79 @@ export function splitIntoSentences(text) {
   return sentences.filter((s) => s.length > 0);
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Reintentos + política de fallback (consistencia de voz, 2026-07-09)
+// ──────────────────────────────────────────────────────────────────────────
+// Un blip transitorio de kokoro (503 por saturación de GPU/CPU, timeout, un
+// corte de red momentáneo) NO debe cambiar de voz a media respuesta. Antes de
+// rendirnos reintentamos con un backoff corto. AbortError (el operador apretó
+// stop()) NUNCA se reintenta.
+export const KOKORO_MAX_RETRIES = 2;
+const KOKORO_RETRY_BASE_MS = 250;
+
+function clampRate(rate) {
+  const r = Number.isFinite(rate) ? rate : DEFAULT_KOKORO_RATE;
+  return Math.min(KOKORO_RATE_MAX, Math.max(KOKORO_RATE_MIN, r));
+}
+
+/**
+ * POST a /api/kokoro/tts con reintentos + backoff. Devuelve el blob de audio.
+ * Lanza el último error si agota los reintentos, o AbortError si el signal
+ * se abortó (no se reintenta en ese caso).
+ */
+async function fetchKokoroBlob(cleanText, voice, format, lang, signal) {
+  let lastErr = null;
+  for (let attempt = 0; attempt <= KOKORO_MAX_RETRIES; attempt++) {
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    try {
+      const res = await fetch('/api/kokoro/tts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: cleanText, voice, format, lang }),
+        signal,
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return await res.blob();
+    } catch (e) {
+      if (e?.name === 'AbortError') throw e;
+      lastErr = e;
+      if (attempt < KOKORO_MAX_RETRIES) {
+        await new Promise((r) => setTimeout(r, KOKORO_RETRY_BASE_MS * (attempt + 1)));
+      }
+    }
+  }
+  throw lastErr || new Error('kokoro TTS falló');
+}
+
+/**
+ * Fallback CONSISTENTE cuando kokoro falla definitivamente.
+ *
+ * Por defecto: SILENCIO (return null) — no cambiamos a la voz robótica del
+ * navegador. Solo si el operador activó `setBrowserVoiceFallback(true)` a
+ * propósito usamos speak() (Web Speech). Esto garantiza "una sola voz": el
+ * campesino nunca oye a Chagra saltar de la voz neuronal a la del navegador
+ * a media sesión.
+ */
+function browserFallback(text, options) {
+  if (getBrowserVoiceFallback()) {
+    return speak(text, options);
+  }
+  return null;
+}
+
 /**
  * Sintetiza una sola frase con Kokoro y devuelve un blob URL listo para Audio.
- * Internamente reusa el endpoint /api/kokoro/tts.
+ * Internamente reusa fetchKokoroBlob (con reintentos).
  *
- * Lanza si HTTP no-OK o si la frase está vacía. El caller (speakSentences)
- * captura el error y decide si fallback a speak() Web Speech.
+ * Lanza si agota reintentos; devuelve null si la frase está vacía. El caller
+ * (speakSentences) captura el error y decide (por defecto, silencio).
  *
  * @returns {Promise<string|null>} blob URL o null si frase vacía.
  */
 async function synthesizeSentence(sentence, voice, format, lang, signal) {
   const clean = sanitizeForTTS(sentence);
   if (!clean || clean.length === 0) return null;
-  const res = await fetch('/api/kokoro/tts', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text: clean, voice, format, lang }),
-    signal,
-  });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const blob = await res.blob();
+  const blob = await fetchKokoroBlob(clean, voice, format, lang, signal);
   return URL.createObjectURL(blob);
 }
 
@@ -430,9 +550,10 @@ async function synthesizeSentence(sentence, voice, format, lang, signal) {
  * Reproduce un blob URL como Audio, retorna Promise que resuelve al onended.
  * Setea currentKokoroAudio/currentKokoroUrl para que stop() pueda matarlo.
  */
-function playSentenceBlob(url) {
+function playSentenceBlob(url, rate) {
   return new Promise((resolve, reject) => {
     const audio = new Audio(url);
+    audio.playbackRate = clampRate(rate);
     currentKokoroAudio = audio;
     currentKokoroUrl = url;
     const cleanup = () => {
@@ -486,7 +607,12 @@ export async function speakSentences(text, options = {}) {
     voice = getPreferredVoice(),
     format = 'opus',
     lang = 'es',
+    rate = getPreferredRate(),
   } = options;
+
+  // toServableVoice: la voz que viaja al server SIEMPRE existe → dora nunca
+  // suena por el fallback silencioso del servidor (orden operador 2026-07-09).
+  const servableVoice = toServableVoice(voice);
 
   stop();
   sentenceQueueCancelled = false;
@@ -515,7 +641,7 @@ export async function speakSentences(text, options = {}) {
   const prefetch = (idx) => {
     if (idx >= sentences.length || sentenceQueueCancelled) return null;
     return synthesizeSentence(
-      sentences[idx], voice, format, lang, sentenceQueueController.signal
+      sentences[idx], servableVoice, format, lang, sentenceQueueController.signal
     ).catch((e) => {
       if (e?.name !== 'AbortError') {
         console.warn('[TTS streaming] sentence prefetch failed:', e.message);
@@ -550,13 +676,15 @@ export async function speakSentences(text, options = {}) {
       const next = i + 1 < sentences.length ? prefetch(i + 1) : null;
       if (prefetched) {
         try {
-          await playSentenceBlob(prefetched);
+          await playSentenceBlob(prefetched, rate);
           firstFrameSucceeded = true;
         } catch (e) {
           console.warn('[TTS streaming] playback error frase', i, ':', e?.message || e);
-          // Para frases tardías que fallan, fallback Web Speech por frase.
+          // Consistencia de voz: NO saltamos a la voz del navegador a media
+          // respuesta. browserFallback = silencio salvo que el operador haya
+          // activado el respaldo del navegador a propósito.
           if (i > 0 && !sentenceQueueCancelled) {
-            try { speak(sentences[i], options); } catch (_) { /* ignore */ }
+            try { browserFallback(sentences[i], options); } catch (_) { /* ignore */ }
           }
         }
       }
@@ -744,13 +872,14 @@ export async function isKokoroAvailable() {
 
 export async function speakKokoro(text, options = {}) {
   // Task #124: si el caller NO pasa `voice` explícito, usar la voz
-  // preferida del operador desde localStorage (fallback ef_dora si
-  // no hay preferencia o storage inaccesible). Callers que pasan voice
-  // explícito (tests, casos avanzados) conservan ese override.
+  // preferida del operador desde localStorage (fallback a DEFAULT_KOKORO_VOICE
+  // = santa si no hay preferencia o storage inaccesible). Callers que pasan
+  // voice explícito (tests, casos avanzados) conservan ese override.
   const {
     voice = getPreferredVoice(),
     format = 'opus',
     lang = 'es',
+    rate = getPreferredRate(),
   } = options;
 
   stop();
@@ -773,17 +902,13 @@ export async function speakKokoro(text, options = {}) {
   }
 
   try {
-    const res = await fetch('/api/kokoro/tts', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text: cleanText, voice, format, lang }),
-    });
-
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-
-    const blob = await res.blob();
+    // fetchKokoroBlob reintenta con backoff ante blips transitorios antes de
+    // rendirse — así un 503/timeout momentáneo no cambia de voz.
+    // toServableVoice: dora nunca suena, ni por fallback del server.
+    const blob = await fetchKokoroBlob(cleanText, toServableVoice(voice), format, lang);
     const url = URL.createObjectURL(blob);
     const audio = new Audio(url);
+    audio.playbackRate = clampRate(rate);
 
     currentKokoroUrl = url;
     currentKokoroAudio = audio;
@@ -802,12 +927,17 @@ export async function speakKokoro(text, options = {}) {
     notifySpeaking(true);
     return audio;
   } catch (e) {
-    console.warn('[TTS] Kokoro failed, fallback to Web Speech:', e.message);
-    // Si el play() falló después de notificar, limpiar antes del fallback —
-    // speak() gestionará su propio onstart/onend.
+    if (e?.name === 'AbortError') {
+      // stop() del operador: no es un fallo, no hacer fallback.
+      notifySpeaking(false);
+      return null;
+    }
+    // Kokoro falló tras reintentos. Por defecto NO cambiamos a la voz robótica
+    // del navegador (evita el "a veces habla una voz y luego otra"): silencio
+    // consistente salvo que el operador haya activado el respaldo del navegador.
+    console.warn('[TTS] Kokoro falló tras reintentos:', e?.message || e);
     notifySpeaking(false);
-    speak(text, options);
-    return null;
+    return browserFallback(text, options);
   }
 }
 
@@ -916,12 +1046,10 @@ export function isPaused() {
 export async function replayLast({ useKokoro = null } = {}) {
   if (!lastSpoken) return false;
   const opts = lastSpokenOptions || {};
-  // Decisión por defecto: probar Kokoro si la última vez fue Kokoro
-  // (heurística: opts trae `voice` ef_*). Sino Web Speech.
-  const shouldUseKokoro =
-    useKokoro !== null
-      ? useKokoro
-      : typeof opts.voice === 'string' && opts.voice.startsWith('ef_');
+  // Preferimos SIEMPRE kokoro (voz consistente). El heurístico viejo miraba
+  // opts.voice.startsWith('ef_') y fallaba con las voces masculinas (em_*),
+  // mandándolas a la voz del navegador. El caller puede forzar con useKokoro.
+  const shouldUseKokoro = useKokoro !== null ? useKokoro : true;
   try {
     if (shouldUseKokoro) {
       await speakKokoro(lastSpoken, opts);
@@ -942,6 +1070,28 @@ export function getLastSpoken() {
 
 export function init() {
   loadVoices();
+}
+
+// Hook E2E (solo con ?e2e en la URL): expone el servicio de voz para que
+// Playwright verifique la CONSISTENCIA — que un fallo de kokoro NO salte a la
+// voz robótica del navegador. En prod nadie navega con ?e2e y solo expone
+// funciones de voz (sin datos ni secretos). Mismo patrón que window.__doomPlayer.
+if (typeof window !== 'undefined') {
+  try {
+    const hasE2EParam =
+      typeof location !== 'undefined' && new URLSearchParams(location.search).has('e2e');
+    if (hasE2EParam) {
+      // window no tiene tipada la prop de test → cast puntual (irreducible).
+      /** @type {any} */ (window).__ttsE2E = {
+        speakKokoro,
+        speakSentences,
+        getBrowserVoiceFallback,
+        setBrowserVoiceFallback,
+      };
+    }
+  } catch (_) {
+    /* noop — el hook E2E nunca debe romper el arranque */
+  }
 }
 
 export default {
@@ -972,8 +1122,13 @@ export default {
   setPreferredRate,
   getXTTSEnabled,
   setXTTSEnabled,
+  // Consistencia de voz (2026-07-09): política de respaldo a la voz del
+  // navegador (default OFF → una sola voz natural).
+  getBrowserVoiceFallback,
+  setBrowserVoiceFallback,
   KOKORO_VOICES,
   DEFAULT_KOKORO_VOICE,
+  DEFAULT_KOKORO_RATE,
   DEFAULT_COLOMBIAN_VOICE,
   XTTS_TIMEOUT_MS,
 };

--- a/tests/tts-voz-consistencia.spec.js
+++ b/tests/tts-voz-consistencia.spec.js
@@ -1,0 +1,141 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * tts-voz-consistencia.spec.js — la voz de Chagra NO debe "saltar".
+ *
+ * Bug del operador: "a veces habla una voz y luego otra". Causa: cuando kokoro
+ * (TTS neuronal) fallaba/timeouteaba, el cliente saltaba a
+ * window.speechSynthesis (voz robótica del navegador) a media sesión.
+ *
+ * Este spec verifica, en el navegador REAL, que con kokoro MOCKEADO A FALLO el
+ * cliente NO invoca window.speechSynthesis.speak (política por defecto: una
+ * sola voz natural; silencio consistente ante fallo). Como control, al activar
+ * explícitamente el respaldo del navegador, sí debe caer a speechSynthesis.
+ *
+ * Se apoya en el hook window.__ttsE2E (solo dev/?e2e, ver ttsService.js). Los
+ * mocks van en context.route (el SW sombrea page.route — ver
+ * feedback-sw-shadows-playwright-route). speechSynthesis se reemplaza por un
+ * doble grabador vía addInitScript ANTES de que cargue la app.
+ */
+
+async function installSpeechRecorder(page) {
+  await page.addInitScript(() => {
+    // Neutralizar el Service Worker: en este entorno el SW re-emite los fetch y
+    // context.route no siempre los alcanza, dejando colgado el fetch mockeado.
+    // Sin SW, el mock de /api/kokoro/tts aplica limpio y el fallo es inmediato.
+    try {
+      if ('serviceWorker' in navigator) {
+        // @ts-ignore — override de test
+        navigator.serviceWorker.register = () => Promise.reject(new Error('SW off (test)'));
+        // @ts-ignore
+        navigator.serviceWorker.getRegistrations = () => Promise.resolve([]);
+        // @ts-ignore
+        navigator.serviceWorker.getRegistration = () => Promise.resolve(undefined);
+      }
+    } catch (_) { /* noop */ }
+
+    window.__spoke = [];
+    const fake = {
+      speak: (u) => { window.__spoke.push(u && u.text ? u.text : true); },
+      cancel: () => {},
+      pause: () => {},
+      resume: () => {},
+      getVoices: () => [],
+      speaking: false,
+      paused: false,
+      onvoiceschanged: null,
+    };
+    try {
+      Object.defineProperty(window, 'speechSynthesis', { value: fake, configurable: true });
+    } catch (_) {
+      window.speechSynthesis = fake;
+    }
+  });
+}
+
+async function failKokoro(page) {
+  // Todo POST a kokoro devuelve 500 → el cliente reintenta y termina fallando.
+  await page.context().route('**/api/kokoro/tts', (route) =>
+    route.fulfill({ status: 500, contentType: 'application/json', body: '{"error":"down"}' })
+  );
+  await page.context().route('**/api/kokoro/health', (route) =>
+    route.fulfill({ status: 500, contentType: 'application/json', body: '{"status":"down"}' })
+  );
+}
+
+async function waitForHook(page) {
+  return page.evaluate(async () => {
+    const deadline = Date.now() + 12000;
+    while (Date.now() < deadline) {
+      if (window.__ttsE2E && typeof window.__ttsE2E.speakKokoro === 'function') return true;
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    return !!(window.__ttsE2E && window.__ttsE2E.speakKokoro);
+  });
+}
+
+test.describe('Consistencia de voz — kokoro caído NO salta a la voz del navegador', () => {
+  test('speakKokoro con kokoro caído NO invoca speechSynthesis (default)', async ({ page }) => {
+    await installSpeechRecorder(page);
+    await failKokoro(page);
+
+    await page.goto('/?e2e=1');
+    await page.waitForLoadState('domcontentloaded');
+
+    const hookReady = await waitForHook(page);
+    test.skip(!hookReady, 'Hook __ttsE2E no disponible en este entorno — no aplica.');
+
+    // Confirmar que el default de la política es "no fallback al navegador".
+    const fallbackDefault = await page.evaluate(() => window.__ttsE2E.getBrowserVoiceFallback());
+    expect(fallbackDefault).toBe(false);
+
+    const result = await page.evaluate(async () => {
+      const r = await window.__ttsE2E.speakKokoro('Prueba de consistencia de la voz de Chagra.');
+      return { r, spoke: window.__spoke.length };
+    });
+
+    // Kokoro falló → speakKokoro devuelve null y NO habló el navegador.
+    expect(result.r).toBeNull();
+    expect(result.spoke).toBe(0);
+  });
+
+  test('speakSentences con kokoro caído NO invoca speechSynthesis a media respuesta', async ({ page }) => {
+    await installSpeechRecorder(page);
+    await failKokoro(page);
+
+    await page.goto('/?e2e=1');
+    await page.waitForLoadState('domcontentloaded');
+    const hookReady = await waitForHook(page);
+    test.skip(!hookReady, 'Hook __ttsE2E no disponible en este entorno — no aplica.');
+
+    const spoke = await page.evaluate(async () => {
+      const texto =
+        'La primera frase del agente es suficientemente larga para el pipeline. ' +
+        'La segunda frase también supera el umbral de caracteres necesario.';
+      await window.__ttsE2E.speakSentences(texto);
+      return window.__spoke.length;
+    });
+
+    expect(spoke).toBe(0);
+  });
+
+  test('CONTROL: con el respaldo del navegador activado, sí cae a speechSynthesis', async ({ page }) => {
+    await installSpeechRecorder(page);
+    await failKokoro(page);
+
+    await page.goto('/?e2e=1');
+    await page.waitForLoadState('domcontentloaded');
+    const hookReady = await waitForHook(page);
+    test.skip(!hookReady, 'Hook __ttsE2E no disponible en este entorno — no aplica.');
+
+    const spoke = await page.evaluate(async () => {
+      window.__ttsE2E.setBrowserVoiceFallback(true);
+      await window.__ttsE2E.speakKokoro('Con respaldo del navegador activado a propósito.');
+      return window.__spoke.length;
+    });
+
+    // El control prueba que el recorder funciona y que el flag SÍ habilita el
+    // fallback cuando el operador lo pide explícitamente.
+    expect(spoke).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Voz ES: pm_santa (aprobada por el operador) como DEFAULT; neutraliza el fallback silencioso del servidor a ef_dora (la vieja voz que el operador no quiere); arregla el salto a Web Speech (voz robotica) cuando kokoro fallaba; selector de voz simple en el perfil. Generated with Claude Code