### PR TITLE
feat(home): home biopunk completo — escena enriquecida + vaca/gallinas (#2229) + 8 adopciones campesinas (#2230)

### DIFF
--- a/src/components/CicloVivo/cicloVivoData.js
+++ b/src/components/CicloVivo/cicloVivoData.js
@@ -51,7 +51,7 @@ export const PHASES = [
     key: 'crecimiento', name: 'Crecimiento', short: 'Crece', color: '#4C7A3D',
     functions: [
       { label: 'Tómele foto', cap: 'diagnostico_foto', camera: true },
-      { label: 'Plagas de esta etapa (MIP)', cap: 'mip_plagas' },
+      { label: 'Plagas de esta etapa', cap: 'mip_plagas' }, // sin la sigla MIP (jerga) en la UI
       { label: 'Nutrición', cap: 'nutricion' },
       { label: 'Asociaciones', cap: 'asociaciones' },
       { label: '¿En qué fase va?', cap: 'fenologia' },

--- a/src/components/PendingTasksWidget.jsx
+++ b/src/components/PendingTasksWidget.jsx
@@ -127,7 +127,9 @@ export default function PendingTasksWidget({ onEdit }) {
       >
         <div className="flex items-center gap-3">
           <span className={`w-3 h-3 rounded-full ${pendingCount > 0 ? (criticalCount > 0 ? 'bg-red-500 animate-pulse' : 'bg-amber-500') : 'bg-green-500'}`}></span>
-          <h3 className="text-base font-bold text-slate-100">Cola de tareas</h3>
+          {/* Sin jerga de ingeniero (usabilidad campesina #1): antes "Cola de
+              tareas" — palabras del campo. */}
+          <h3 className="text-base font-bold text-slate-100">Tareas pendientes</h3>
           <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${pendingCount > 0 ? 'bg-amber-600/20 text-amber-400' : 'bg-green-600/20 text-green-400'}`}>
             {pendingCount}
           </span>

--- a/src/components/dashboard/AnalisisProactivoIA.jsx
+++ b/src/components/dashboard/AnalisisProactivoIA.jsx
@@ -286,11 +286,11 @@ export default function AnalisisProactivoIA({ sensors = [], climaSnapshot = null
                             className="absolute -top-1 -right-1 text-emerald-300 animate-pulse"
                         />
                     </div>
+                    {/* Sin jerga de ingeniero (usabilidad campesina #1): antes
+                        "Análisis Chagra · IA local". El recado es la figura del
+                        campo: lo que Chagra le deja dicho hoy. */}
                     <span className="text-[10px] font-bold text-cyan-200 uppercase tracking-[0.18em]">
-                        Análisis Chagra
-                    </span>
-                    <span className="px-1.5 py-0.5 rounded text-[8px] font-black bg-emerald-500/15 text-emerald-200 uppercase tracking-wider">
-                        IA local
+                        El recado de Chagra
                     </span>
                     <span className="ml-auto text-[9px] text-slate-500" aria-hidden>
                         {hora.icono}
@@ -369,11 +369,11 @@ export default function AnalisisProactivoIA({ sensors = [], climaSnapshot = null
                     type="button"
                     onClick={handleAgent}
                     className="mt-3 w-full flex items-center justify-between gap-2 px-3 py-2 rounded-xl bg-cyan-500/10 hover:bg-cyan-500/15 border border-cyan-600/30 transition-colors text-left group"
-                    aria-label="Hablar con el agente Chagra sobre este análisis"
+                    aria-label="Pregúntele a Chagra sobre este recado"
                 >
                     <span className="flex items-center gap-1.5 text-[11px] text-cyan-100">
                         <TrendingUp size={12} className="text-cyan-300" />
-                        Habla con el agente sobre esto
+                        Pregúntele a Chagra sobre esto
                     </span>
                     <ArrowRight
                         size={13}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -544,6 +544,22 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
         }
     }, []);
 
+    // LOS MUNDOS PLEGADOS (usabilidad campesina #5): la grilla completa de
+    // mundos (~13 tarjetas + ~35 chips) ya no está siempre abierta en el home
+    // — el primer pantallazo son las 6 PUERTAS del hero. "Toda mi finca" (la
+    // sexta puerta) o el botón ancho del bloque la despliegan. Todo sigue
+    // alcanzable con UN toque; MundosDeMiFinca no cambia.
+    const [mundosAbiertos, setMundosAbiertos] = useState(false);
+    const revelarMundos = useCallback(() => {
+        setMundosAbiertos(true);
+        if (typeof document === 'undefined') return;
+        // El scroll corre tras el render del bloque expandido.
+        requestAnimationFrame(() => {
+            const seccion = document.getElementById('bloque-mundos');
+            if (seccion?.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+    }, []);
+
     // ── Helpers de render (compartidos entre el layout F2 y el legacy) ────────
     // Rótulo de bloque con la barrita de color. Función pura que DEVUELVE JSX (no
     // un componente, para no violar react-hooks/static-components al definirlo
@@ -693,6 +709,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                         onNavigate={onNavigate}
                         onOpenAgent={() => onNavigate('agente')}
                         onGestionar={revelarGestion}
+                        onTodaMiFinca={revelarMundos}
                         titulo={esExtensionista ? 'Red de fincas que acompaño' : 'Mi finca viva'}
                     >
                         {esExtensionista ? (
@@ -867,12 +884,37 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     vieja vive DENTRO de su mundo (mundosFinca.js es la fuente
                     única; el test de reachability congela el contrato). El gate
                     de Animales por perfil se conserva (mostrarAnimales). */}
-                <div className="px-4 pt-4 fvh-resto-block" data-testid="bloque-mundos">
-                    <MundosDeMiFinca
-                        onNavigate={onNavigate}
-                        mostrarAnimales={mostrarAnimales}
-                        plantsCount={plantsCount}
-                    />
+                <div id="bloque-mundos" className="px-4 pt-4 fvh-resto-block" data-testid="bloque-mundos" style={{ scrollMarginTop: '88px' }}>
+                    {mundosAbiertos ? (
+                        <MundosDeMiFinca
+                            onNavigate={onNavigate}
+                            mostrarAnimales={mostrarAnimales}
+                            plantsCount={plantsCount}
+                        />
+                    ) : (
+                        // PLEGADO (default): una sola puerta ancha ≥96px. La
+                        // grilla completa se abre aquí o desde la puerta "Toda
+                        // mi finca" del hero (revelarMundos).
+                        <button
+                            type="button"
+                            data-testid="abrir-mundos"
+                            onClick={revelarMundos}
+                            aria-expanded={false}
+                            aria-label="Toda mi finca: abrir todos los mundos de su finca"
+                            className={`w-full dash-tile ${fincaVivaFlag ? 'fvh-tile-claro' : 'bg-slate-900/60'} border border-slate-800 border-l-4 border-l-teal-500 rounded-2xl p-4 min-h-[96px] text-left active:bg-slate-800/70 transition-colors flex items-center gap-4`}
+                        >
+                            <span aria-hidden="true" className="shrink-0 w-14 h-14 rounded-2xl bg-teal-700/20 border border-teal-600/40 flex items-center justify-center text-3xl">
+                                🏡
+                            </span>
+                            <span className="min-w-0 flex-1">
+                                <span className="text-lg font-black block leading-tight fvh-tile-label text-teal-500">Toda mi finca</span>
+                                <span className={`text-xs mt-1 leading-snug block fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-400'}`}>
+                                    Todos los mundos: suelo, agua, sanidad, mercado y más
+                                </span>
+                            </span>
+                            <ChevronRight size={22} className="shrink-0 text-slate-500" aria-hidden="true" />
+                        </button>
+                    )}
                 </div>
 
                 {/* El Ciclo Vivo: portal a la rueda de las 7 fases. Estado real
@@ -909,6 +951,17 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                         className="text-xs font-bold underline underline-offset-2 fvh-block-label"
                     >
                         Ayuda
+                    </button>
+                    <span aria-hidden="true" className="fvh-block-label">·</span>
+                    {/* "Jugar" conserva su entrada en el home: antes era uno de
+                        los 4 portales del hero (reemplazados por las 6 puertas);
+                        el juego sigue alcanzable desde aquí. */}
+                    <button
+                        type="button"
+                        onClick={() => onNavigate('juego')}
+                        className="text-xs font-bold underline underline-offset-2 fvh-block-label"
+                    >
+                        Jugar
                     </button>
                 </div>
             </>

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -9,7 +9,8 @@ import { listFarmProcesses } from '../../db/farmProcessCache';
 import useAssetStore from '../../store/useAssetStore';
 import { buildFincaScene } from '../../services/fincaSceneService';
 import { selectSceneVariant, SCENE_KINDS } from '../../services/fincaSceneProfileSelector';
-import { getProfile, saveProfile, getInvernaderoEstructura } from '../../services/userProfileService';
+import { getProfile, saveProfile, getInvernaderoEstructura, hasManualModuleVisibility } from '../../services/userProfileService';
+import { esPerfilUrbano } from '../../services/homeModuleSelector';
 import { getOperatorPhoto } from '../../services/operatorPhotoService';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import { deriveAtmosphere } from '../../services/atmosphereService';
@@ -288,6 +289,25 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
   // usan). Tras el split vive en biopunk2 (donde quedó la Finca Organismo).
   const organismoActivo = escenaVivaActiva && temaEfectivo === 'biopunk2';
 
+  // ── ENTRADA AL MUNDO ANIMALES desde la escena ────────────────────────────
+  // El potrero (vaca + gallinas) de la Finca Organismo es un punto de entrada
+  // tappable al mundo de los animales — con el MISMO gate por perfil que usa
+  // el home para esconder ese mundo (DashboardLive.mostrarAnimales): un urbano
+  // de balcón/terraza no lo ve; control manual del home (#1560) y operador lo
+  // conservan. Mismo destino que MundosDeMiFinca: la portada del mundo.
+  const [mostrarAnimales] = useState(() => {
+    try {
+      if (esOperadorActual()) return true;
+      if (hasManualModuleVisibility()) return true;
+      return !esPerfilUrbano(getProfile());
+    } catch (_) {
+      return true; // Fail-open: no esconder la entrada por un error.
+    }
+  });
+  const onAnimales = mostrarAnimales
+    ? () => onNavigate?.('mundo', { mundo: 'animales' })
+    : null;
+
   return (
     <section
       data-testid="finca-viva-hero"
@@ -464,8 +484,10 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
                       /* ESCENA VIVA DEL TEMA ACTIVO (organismo/árbol de la
                          vida/huerto/trazo). Lleva la estructura declarada
                          (#34): la estructura de cada escena porta el marcador
-                         fvh-estructura solo si fue declarada. */
-                      <EscenaViva estructura={estructuraFinca} />
+                         fvh-estructura solo si fue declarada. `onAnimales`
+                         (gate por perfil) vuelve tappable el potrero de la
+                         Finca Organismo — las demás escenas lo ignoran hoy. */
+                      <EscenaViva estructura={estructuraFinca} onAnimales={onAnimales} />
                     ) : (
                       <SceneFinca
                         poblada={poblada}

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -4,12 +4,13 @@
  * la TAREA i18n de ADR-050 (transversal a toda la app), fuera del alcance de esta
  * feature visual — mismo criterio que MiFincaVivaHomeCard.jsx, FincaCards.jsx y
  * FincaRedInstitucional.jsx en este mismo directorio. */
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { listFarmProcesses } from '../../db/farmProcessCache';
 import useAssetStore from '../../store/useAssetStore';
 import { buildFincaScene } from '../../services/fincaSceneService';
 import { selectSceneVariant, SCENE_KINDS } from '../../services/fincaSceneProfileSelector';
-import { getProfile, saveProfile, getInvernaderoEstructura } from '../../services/userProfileService';
+import { getProfile, saveProfile, getInvernaderoEstructura, hasManualModuleVisibility } from '../../services/userProfileService';
+import { esPerfilUrbano } from '../../services/homeModuleSelector';
 import { getOperatorPhoto } from '../../services/operatorPhotoService';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import { deriveAtmosphere } from '../../services/atmosphereService';
@@ -107,10 +108,13 @@ const COLIBRI_REAL = colibriRealActivo();
  *   la MISMA página, bajo el hero, así que el portal "Gestionar" la REVELA con un
  *   scroll a su ancla — NO navega a otra vista (mucho menos al juego). Si no se
  *   pasa, cae a un scroll directo al ancla #finca-gestion (mismo destino).
+ * @param {Function} [props.onTodaMiFinca]  revela LOS MUNDOS completos (la
+ *   puerta "Toda mi finca"): DashboardLive expande el bloque plegado y hace
+ *   scroll. Sin callback, cae a un scroll directo al ancla #bloque-mundos.
  * @param {React.ReactNode} [props.children]  escena alterna (red institucional).
  * @param {string} [props.titulo]  título accesible (default "Mi finca viva").
  */
-export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, children, titulo }) {
+export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, onTodaMiFinca, children, titulo }) {
   // Piel del tema activo: el ícono de marca del agente (la A roja en biopunk, la
   // sol-mano en verde-vivo, etc.) sigue al tema, igual que la escena toma su piel
   // del tema vía los tokens --c-*/--fvh-* del CSS. Con la flag OFF este hero no se
@@ -134,6 +138,19 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
       if (seccion?.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   };
+  // La puerta "Toda mi finca" abre LOS MUNDOS completos, que viven en la hoja
+  // bajo el hero (DashboardLive los revela con onTodaMiFinca: expandir +
+  // scroll). Sin callback, cae a un scroll directo al ancla del bloque.
+  const irATodaMiFinca = () => {
+    if (onTodaMiFinca) { onTodaMiFinca(); return; }
+    if (typeof document !== 'undefined') {
+      const seccion = document.getElementById('bloque-mundos');
+      if (seccion?.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+  // El bloque "Registrar en la finca" sigue alcanzable por scroll en la misma
+  // página (irAGestion queda como puente del ancla para quien lo necesite).
+  void irAGestion;
 
   // ── Datos reales de la finca (offline-first) ─────────────────────────────
   const [processes, setProcesses] = useState([]);
@@ -288,6 +305,63 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
   // usan). Tras el split vive en biopunk2 (donde quedó la Finca Organismo).
   const organismoActivo = escenaVivaActiva && temaEfectivo === 'biopunk2';
 
+  // ── GATE DE ANIMALES para la puerta "Mis animales" ────────────────────────
+  // Mismo criterio que DashboardLive.mostrarAnimales (el usuario solo ve lo
+  // que necesita): un urbano de balcón/terraza no ve la puerta; el control
+  // manual del home (#1560) y el operador la conservan.
+  const [mostrarAnimales] = useState(() => {
+    try {
+      if (esOperadorActual()) return true;
+      if (hasManualModuleVisibility()) return true;
+      return !esPerfilUrbano(getProfile());
+    } catch (_) {
+      return true; // Fail-open: no esconder la puerta por un error.
+    }
+  });
+
+  // ── MODO "PLENO SOL" (usabilidad campesina #7) ────────────────────────────
+  // Alto contraste claro para leer el teléfono a mediodía al aire libre: el
+  // biopunk nocturno va bien de noche, pero al rayo del sol un fondo oscuro
+  // no se ve. AUTOMÁTICO de día (deriveAtmosphere → luz 'dia') con override
+  // MANUAL persistido ('1' forzado ON, '0' forzado OFF, ausente = auto).
+  const [solPref, setSolPref] = useState(() => {
+    try { return localStorage.getItem(PLENO_SOL_KEY) || 'auto'; }
+    catch (_) { return 'auto'; }
+  });
+  const plenoSol = solPref === '1' || (solPref === 'auto' && tonoLuz(atmosfera) === 'dia');
+  const alternarSol = () => {
+    const next = plenoSol ? '0' : '1';
+    setSolPref(next);
+    try { localStorage.setItem(PLENO_SOL_KEY, next); } catch (_) { /* incógnito */ }
+  };
+
+  // ── "ESCUCHAR" 🔊 (usabilidad campesina #6, baja alfabetización) ──────────
+  // Lee la pantalla en voz alta con el TTS propio (kokoro + fallback Web
+  // Speech, ttsService). Import perezoso: el peso del TTS no entra al chunk
+  // del home salvo que se use. Mientras habla, el botón pasa a "Parar".
+  const [hablando, setHablando] = useState(false);
+  const ttsUnsubRef = useRef(null);
+  useEffect(() => () => { if (ttsUnsubRef.current) ttsUnsubRef.current(); }, []);
+  const textoEscuchar = () => {
+    const puertasTxt = 'sus matas, sus animales, el tiempo, vender, aprender, o toda su finca';
+    const estadoTxt = poblada
+      ? 'Todo tranquilo en su finca.'
+      : 'Su finca está empezando. Registre su primera siembra y la escena cobra vida.';
+    return `Buenas, soy Chagra. Esta es su finca viva. ${estadoTxt} `
+      + 'Toque el botón verde grande, hable, y yo le contesto. '
+      + `También puede entrar a: ${puertasTxt}.`;
+  };
+  const escuchar = async () => {
+    try {
+      const tts = await import('../../services/ttsService');
+      if (!ttsUnsubRef.current) {
+        ttsUnsubRef.current = tts.onSpeakingChange((v) => setHablando(!!v));
+      }
+      if (tts.isAudioPlaying()) { tts.stop(); return; }
+      await tts.speakSentences(textoEscuchar());
+    } catch (_) { /* sin audio disponible: el botón no rompe el home */ }
+  };
+
   return (
     <section
       data-testid="finca-viva-hero"
@@ -295,6 +369,7 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
       className="fvh"
       data-luz={atmosfera.luz || undefined}
       data-clima={atmosfera.condicion || undefined}
+      data-plenosol={plenoSol ? '1' : undefined}
     >
       <div className="fvh-shell">
         {/* ── TOPBAR (con jerarquía y aire — feedback #3) ───────────────────── */}
@@ -464,8 +539,11 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
                       /* ESCENA VIVA DEL TEMA ACTIVO (organismo/árbol de la
                          vida/huerto/trazo). Lleva la estructura declarada
                          (#34): la estructura de cada escena porta el marcador
-                         fvh-estructura solo si fue declarada. */
-                      <EscenaViva estructura={estructuraFinca} />
+                         fvh-estructura solo si fue declarada. `onPregunte`
+                         vuelve TAPPABLE el corazón-semilla de la Finca
+                         Organismo (abre el agente, mismo patrón que el
+                         potrero→animales); las demás escenas lo ignoran. */
+                      <EscenaViva estructura={estructuraFinca} onPregunte={abrirAgente} />
                     ) : (
                       <SceneFinca
                         poblada={poblada}
@@ -526,25 +604,58 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
 
           {/* ── COLUMNA derecha en desktop / debajo en móvil ────────────────── */}
           <div className="fvh-aside">
-            {/* COMPOSITOR DEL AGENTE */}
+            {/* LA acción dominante: "PREGUNTE" (usabilidad campesina #2).
+                Antes "preguntar" aparecía en 4 formas sin que ninguna mandara
+                (la A del header, el globo del colibrí, este compositor y un
+                portal). Ahora ESTE botón manda: grande (≥96px), late como el
+                corazón de la escena y habla en cristiano. Las otras entradas
+                quedan de apoyo (la A del header, el corazón de la escena). */}
             <div className="fvh-composer-wrap">
               <button
                 type="button"
-                className="fvh-composer"
+                className="fvh-composer fvh-composer--pregunte"
                 onClick={abrirAgente}
                 data-testid="finca-viva-agent-fab"
-                aria-label="Pregúntele a Chagra"
+                aria-label="Pregúntele a Chagra: toque y hable, Chagra le contesta"
               >
-                <span className="av" aria-hidden="true"><ColibriAvatar /></span>
-                <span className="ph">Pregúntele a Chagra…</span>
-                <span className="mic" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-                    <rect x="9" y="3" width="6" height="11" rx="3" fill="#1f3300" />
-                    <path d="M6 11a6 6 0 0 0 12 0M12 17v3" stroke="#1f3300" strokeWidth="2" strokeLinecap="round" />
+                <span className="fvh-corazon-btn" aria-hidden="true">
+                  <span className="fvh-corazon-pulso" />
+                  <span className="fvh-corazon-pulso fvh-corazon-pulso2" />
+                  <svg viewBox="0 0 24 24" width="30" height="30" fill="none" aria-hidden="true">
+                    <rect x="9" y="3" width="6" height="11" rx="3" fill="#12260a" />
+                    <path d="M6 11a6 6 0 0 0 12 0M12 17v3M8.5 20h7" stroke="#12260a" strokeWidth="2.2" strokeLinecap="round" />
                   </svg>
                 </span>
+                <span className="fvh-pregunte-txt">
+                  <b>Pregunte</b>
+                  <small>Toque y hable. Chagra le contesta.</small>
+                </span>
               </button>
-              <div className="fvh-composer-hint">Toque 🎙️ y pregunte en voz alta — o escriba arriba</div>
+              {/* Escuchar (🔊 lee la pantalla, baja alfabetización) + Pleno sol
+                  (alto contraste de mediodía). Pareja de pastillas bajo la
+                  acción dominante. */}
+              <div className="fvh-audio-sol">
+                <button
+                  type="button"
+                  className="fvh-escuchar"
+                  data-testid="fvh-escuchar"
+                  aria-pressed={hablando}
+                  aria-label={hablando ? 'Parar la lectura en voz alta' : 'Escuchar: Chagra le lee la pantalla en voz alta'}
+                  onClick={escuchar}
+                >
+                  {hablando ? '⏹ Parar' : '🔊 Escuchar'}
+                </button>
+                <button
+                  type="button"
+                  className="fvh-sol-toggle"
+                  data-testid="fvh-pleno-sol"
+                  aria-pressed={plenoSol}
+                  aria-label={plenoSol ? 'Volver a la vista de noche' : 'Pleno sol: vista clara para leer a mediodía'}
+                  onClick={alternarSol}
+                >
+                  {plenoSol ? '🌙 Noche' : '☀️ Pleno sol'}
+                </button>
+              </div>
 
               {/* NIVEL DE RESPUESTA — junto al agente, porque define CÓMO le
                   responde Chagra. Renombrado del antiguo "Campesino/Experto"
@@ -578,33 +689,36 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
               </div>
             </div>
 
-            {/* HERO TEXT */}
+            {/* HERO TEXT — sin jerga de ingeniero (antes "SU AGENTE
+                AGROECOLÓGICO"): palabras del campo. */}
             <div className="fvh-hero-saludo">
-              <div className="h-small">SU AGENTE AGROECOLÓGICO</div>
+              <div className="h-small">CHAGRA, SU COMPAÑERO DE CAMPO</div>
               <h1 dangerouslySetInnerHTML={{ __html: HERO[escala][0] }} />
               <p>{HERO[escala][1]}</p>
             </div>
           </div>
         </main>
 
-        {/* ── 4 PORTALES = LUGARES DE LA FINCA ───────────────────────────────── */}
-        <div className="fvh-portales-tit">Lugares de su finca <span /></div>
-        <nav className="fvh-portales" aria-label="Lugares de su finca" data-testid="finca-viva-portales">
-          {buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, escala }).map((p) => (
+        {/* ── LAS 6 PUERTAS (usabilidad campesina #5) ─────────────────────────
+            Antes: 4 portales con descripción + ~20 tarjetas + ~35 chips abajo.
+            Ahora: SEIS puertas de una-dos palabras, dibujo grande + palabra
+            grande, targets ≥96px (#8). Cada una enruta a un mundo/vista que YA
+            existe (nada nuevo que mantener). "Toda mi finca" abre los mundos
+            completos en la hoja de abajo. */}
+        <div className="fvh-portales-tit">¿A dónde va? <span /></div>
+        <nav className="fvh-puertas" aria-label="Puertas de su finca" data-testid="finca-viva-puertas">
+          {buildPuertas({ onNavigate, irATodaMiFinca, mostrarAnimales }).map((p, i) => (
             <button
               key={p.id}
               type="button"
-              className={`fvh-portal ${p.clase}`}
+              className={`fvh-puerta t-${p.tinte}`}
+              data-testid={`puerta-${p.id}`}
               onClick={p.onClick}
-              style={{ animationDelay: p.delay }}
-              aria-label={`${p.titulo}: ${p.desc}`}
+              style={{ animationDelay: `${0.08 + i * 0.06}s` }}
+              aria-label={`${p.nombre}: abre ${p.abre}`}
             >
-              <span className="ir" aria-hidden="true">Entrar →</span>
-              {p.placeSvg}
-              <span className="fvh-p-scrim" aria-hidden="true" />
-              <span className="fvh-p-nuevo">{p.badge}</span>
-              <div className="p-head"><div className="p-emoji" aria-hidden="true">{p.emoji}</div><h3>{p.titulo}</h3></div>
-              <p>{p.desc}</p>
+              <span className="fvh-puerta-emoji" aria-hidden="true">{p.emoji}</span>
+              <span className="fvh-puerta-nombre">{p.nombre}</span>
             </button>
           ))}
         </nav>
@@ -1040,35 +1154,6 @@ function ColibriVuela() {
   );
 }
 
-/** Mismo colibrí en versión avatar redondo para el compositor del agente. */
-function ColibriAvatar() {
-  return (
-    <svg viewBox="0 0 48 48" width="26" height="26" aria-hidden="true">
-      <defs>
-        <linearGradient id="fvh-colibri-av-plum" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0" stopColor="#34d399" />
-          <stop offset="45%" stopColor="#10b981" />
-          <stop offset="75%" stopColor="#22d3ee" />
-          <stop offset="100%" stopColor="#a78bfa" />
-        </linearGradient>
-        <radialGradient id="fvh-colibri-av-gor" cx="50%" cy="50%" r="50%">
-          <stop offset="0" stopColor="#fde68a" />
-          <stop offset="50%" stopColor="#f59e0b" />
-          <stop offset="100%" stopColor="#dc2626" />
-        </radialGradient>
-      </defs>
-      <path d="M8 26 L2 22 L6 28 L1 32 L7 31 L5 37 L12 30 Z" fill="url(#fvh-colibri-av-plum)" opacity="0.9" />
-      <path d="M20 22 Q10 15 4 22 Q11 29 21 25 Z" fill="url(#fvh-colibri-av-plum)" opacity="0.6" />
-      <ellipse cx="22" cy="25" rx="11" ry="6.6" fill="url(#fvh-colibri-av-plum)" transform="rotate(-16 22 25)" />
-      <circle cx="33" cy="20" r="5.6" fill="url(#fvh-colibri-av-plum)" />
-      <ellipse cx="34" cy="24" rx="3" ry="2" fill="url(#fvh-colibri-av-gor)" opacity="0.95" />
-      <circle cx="34.4" cy="18.6" r="1.3" fill="#0c0a09" />
-      <circle cx="34" cy="18.2" r="0.45" fill="#fff" />
-      <path d="M38.5 20 Q46 22 47 27" fill="none" stroke="#e2e8f0" strokeWidth="1.5" strokeLinecap="round" />
-    </svg>
-  );
-}
-
 // ── Catálogos de texto (refinados del mockup F2) ───────────────────────────
 
 /**
@@ -1105,259 +1190,39 @@ const HERO = {
     'Camine a un lugar de la finca, o escríbame abajo. Hablo claro y solo con datos verificados.',
   ],
 };
+// Un solo "pregunte" que mande (usabilidad campesina #2): el globo del colibrí
+// ya NO repite "pregúnteme aquí abajo" — saluda y orienta; preguntar vive en
+// el botón grande "Pregunte" (y en el corazón de la escena biopunk).
 const COLIBRI = {
-  balcon: ['Buenas, soy Chagra', 'Su balcón está al día. Toque una matera o pregúnteme aquí abajo.'],
-  invernadero: ['Buenas, soy Chagra', 'Sus hileras están bien. ¿Reviso riego o plagas? Pregúnteme abajo.'],
-  finca: ['Buenas, soy Chagra', 'Todo tranquilo en su finca. Toque un lugar para entrar, o pregúnteme aquí abajo.'],
+  balcon: ['Buenas, soy Chagra', 'Su balcón está al día. Toque una matera para verla de cerca.'],
+  invernadero: ['Buenas, soy Chagra', 'Sus hileras están bien. Toque un lugar para revisarlo.'],
+  finca: ['Buenas, soy Chagra', 'Todo tranquilo en su finca. Toque una puerta para entrar.'],
 };
 
+// Preferencia persistida del modo "pleno sol" ('1' ON, '0' OFF, ausente=auto).
+const PLENO_SOL_KEY = 'chagra:home:pleno-sol';
+
 /**
- * Los 4 portales/lugares del home F2 ("Mi finca", "Aprender", "Jugar",
- * "Pregúntele a Chagra"). El badge del portal "Mi finca" refleja el DATO
- * REAL de la finca (0 siembras → "EMPIECE AQUÍ"; con siembras → resumen real).
+ * LAS 6 PUERTAS del home (usabilidad campesina #5): una-dos palabras, dibujo
+ * grande, targets ≥96px. Cada puerta enruta a un mundo/vista que YA existe:
+ *   · Mis matas     → la portada del mundo Cultivos ('mundo_cultivos').
+ *   · Mis animales  → el mundo Animales ('mundo' + {mundo:'animales'}),
+ *                     gateado por perfil (mostrarAnimales, igual que el home).
+ *   · El tiempo     → 'hoy_finca' (su día: lluvia, heladas y avisos).
+ *   · Vender        → 'mercado'.
+ *   · Aprender      → 'aprende'.
+ *   · Toda mi finca → LOS MUNDOS completos en la hoja de abajo (revelar).
  */
-function buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, escala }) {
-  const total = Number(scene?.totalCultivos) || 0;
-  const animales = Array.isArray(scene?.animales) ? scene.animales.length : 0;
-  let badgeGestionar;
-  if (!poblada || total + animales === 0) {
-    badgeGestionar = escala === 'balcon'
-      ? 'EMPIECE AQUÍ · 0 materas'
-      : escala === 'invernadero'
-        ? 'EMPIECE AQUÍ · 0 trasplantes'
-        : 'EMPIECE AQUÍ · 0 siembras';
-  } else {
-    const partes = [];
-    if (total > 0) partes.push(total === 1 ? '1 siembra' : `${total} siembras`);
-    if (animales > 0) partes.push('animales');
-    badgeGestionar = partes.join(' · ') || 'Su finca';
-  }
-
-  return [
-    {
-      id: 'gestionar',
-      titulo: 'Mi finca',
-      desc: 'Registre y cuide sus siembras, zonas y animales.',
-      emoji: '🌱',
-      clase: 'p-gestionar',
-      delay: '.1s',
-      badge: badgeGestionar,
-      placeSvg: <PlaceGestionar />,
-      // GESTIÓN, no el juego: revela la sección de registros/acciones de la
-      // finca (siembras, zonas, animales) en esta misma página. El bug viejo
-      // mandaba a onNavigate('juego') — el mismo destino que el portal "Jugar".
-      onClick: () => irAGestion(),
-    },
-    {
-      id: 'aprender',
-      titulo: 'Aprender',
-      desc: 'Suelo vivo, milpa, biopreparados, MIP y fenología.',
-      emoji: '📚',
-      clase: 'p-aprender',
-      delay: '.18s',
-      badge: '5 lecciones',
-      placeSvg: <PlaceAprender />,
-      onClick: () => onNavigate?.('aprende'),
-    },
-    {
-      id: 'jugar',
-      titulo: 'Jugar',
-      desc: 'Haga crecer su finca y defiéndala jugando.',
-      emoji: '🎮',
-      clase: 'p-jugar',
-      delay: '.26s',
-      badge: 'Mi Finca Viva',
-      placeSvg: <PlaceJugar />,
-      onClick: () => onNavigate?.('juego'),
-    },
-    {
-      id: 'agente',
-      titulo: 'Pregúntele a Chagra',
-      desc: 'Pregunte lo que sea: respuestas con su fuente.',
-      emoji: '💬',
-      clase: 'p-agente',
-      delay: '.34s',
-      badge: 'Voz y foto',
-      placeSvg: <PlaceAgente />,
-      onClick: () => abrirAgente(),
-    },
+function buildPuertas({ onNavigate, irATodaMiFinca, mostrarAnimales }) {
+  const puertas = [
+    { id: 'matas', emoji: '🌱', nombre: 'Mis matas', tinte: 'verde', abre: 'sus siembras y cultivos', onClick: () => onNavigate?.('mundo_cultivos') },
+    { id: 'animales', emoji: '🐔', nombre: 'Mis animales', tinte: 'teja', abre: 'sus gallinas, cerdos y demás animales', onClick: () => onNavigate?.('mundo', { mundo: 'animales' }) },
+    { id: 'tiempo', emoji: '🌦️', nombre: 'El tiempo', tinte: 'cielo', abre: 'el clima de hoy y los próximos días', onClick: () => onNavigate?.('hoy_finca') },
+    { id: 'vender', emoji: '🧺', nombre: 'Vender', tinte: 'ambar', abre: 'precios, mercado y su despensa', onClick: () => onNavigate?.('mercado') },
+    { id: 'aprender', emoji: '📖', nombre: 'Aprender', tinte: 'uva', abre: 'las lecciones y guías del campo', onClick: () => onNavigate?.('aprende') },
+    { id: 'finca', emoji: '🏡', nombre: 'Toda mi finca', tinte: 'menta', abre: 'todos los mundos de su finca', onClick: () => irATodaMiFinca() },
   ];
-}
-
-// ── SVG de los 4 portales (place-svg) ────────────────────────────────────────
-// Cada portal es un LUGAR ilustrado con horizonte, tierra y un foco propio
-// (parcela con casita · rancho de lectura · isla de juego · claro del agente).
-// Sin <text> con emoji dentro del SVG: en Android/iOS viejos esos glifos
-// renderizan monocromos o vacíos — todo es dibujo vectorial propio.
-
-function PlaceGestionar() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* amanecer del lugar: sol suave + loma de fondo */}
-      <circle cx="146" cy="26" r="14" fill="#ffe08a" opacity=".5" />
-      <circle cx="146" cy="26" r="8" fill="#ffedb3" opacity=".8" />
-      <path d="M-4 66 Q50 42 104 62 T184 58 V90 H-4 Z" fill="#356b42" opacity=".55" />
-      {/* parcela isométrica con surcos */}
-      <polygon points="90,44 152,80 90,116 28,80" fill="#3f7a4e" />
-      <polygon points="90,44 152,80 90,82 28,80" fill="#4f9460" opacity=".7" />
-      <g stroke="#2f6b3a" strokeWidth="2.4" strokeLinecap="round" fill="none" opacity=".7">
-        <path d="M56 82 L90 100" /><path d="M70 74 L108 95" /><path d="M84 66 L122 87" />
-      </g>
-      {/* matas en hilera (tallo + copa + fruto) */}
-      <g className="fvh-p-mata">
-        <g strokeLinecap="round">
-          <path d="M64 84 v-12" stroke="#2f6b3a" strokeWidth="2.2" fill="none" />
-          <circle cx="64" cy="69" r="5" fill="#7fc06f" /><circle cx="62" cy="67" r="2.6" fill="#a7e17a" />
-          <circle cx="67" cy="72" r="2" fill="#ff5d44" />
-        </g>
-        <g strokeLinecap="round">
-          <path d="M88 96 v-13" stroke="#2f6b3a" strokeWidth="2.2" fill="none" />
-          <circle cx="88" cy="79" r="5.5" fill="#7fc06f" /><circle cx="86" cy="77" r="2.8" fill="#a7e17a" />
-          <circle cx="91" cy="82" r="2" fill="#ffd24d" />
-        </g>
-        <g strokeLinecap="round">
-          <path d="M112 88 v-11" stroke="#2f6b3a" strokeWidth="2.2" fill="none" />
-          <circle cx="112" cy="73" r="4.6" fill="#7fc06f" /><circle cx="110" cy="71" r="2.4" fill="#a7e17a" />
-        </g>
-      </g>
-      {/* casita campesina al fondo (pared clara, techo terracota, humo) */}
-      <g transform="translate(38 52)">
-        <path className="fvh-p-humo" d="M14 -12 q-3 -5 1 -8 q4 -3 1 -7" stroke="#f4efe2" strokeWidth="2.2" fill="none" strokeLinecap="round" opacity=".75" />
-        <rect x="11" y="-14" width="5" height="8" fill="#8a5a38" />
-        <polygon points="0,-6 13,-16 26,-6" fill="#c2562f" />
-        <polygon points="2,-6 24,-6 24,10 2,10" fill="#f6efe0" />
-        <rect x="10" y="0" width="6" height="10" fill="#7a5230" />
-        <rect x="4" y="-2" width="4.5" height="4.5" fill="#9fc9d8" />
-        <rect x="18" y="-2" width="4.5" height="4.5" fill="#9fc9d8" />
-      </g>
-      {/* letrero de madera de la parcela */}
-      <g transform="translate(126 92)">
-        <rect x="6" y="0" width="3" height="12" rx="1.5" fill="#7a5230" />
-        <rect x="-2" y="-8" width="19" height="10" rx="2.5" fill="#caa066" />
-        <path d="M2 -3 h11" stroke="#7a5230" strokeWidth="1.6" strokeLinecap="round" />
-      </g>
-    </svg>
-  );
-}
-function PlaceAprender() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* tarde dorada + loma ocre */}
-      <circle cx="34" cy="24" r="12" fill="#ffe6a8" opacity=".55" />
-      <path d="M-4 70 Q60 48 120 66 T184 62 V96 H-4 Z" fill="#9a5f24" opacity=".45" />
-      {/* explanada de tierra */}
-      <polygon points="90,50 152,84 90,118 28,84" fill="#c47b2f" />
-      <polygon points="90,50 152,84 90,86 28,84" fill="#d18c3f" opacity=".7" />
-      {/* rancho de lectura: paja a trazos + horcones + libro abierto DIBUJADO */}
-      <g transform="translate(90 58)">
-        <polygon points="-30,16 0,0 30,16 24,20 0,7 -24,20" fill="#a85d28" />
-        <polygon points="-26,17 0,4 26,17 0,17" fill="#8a4b20" opacity=".9" />
-        <g stroke="#e8bd7a" strokeWidth="1.4" opacity=".65" strokeLinecap="round">
-          <path d="M-20 13 L0 3" /><path d="M-12 15 L2 8" /><path d="M20 13 L0 3" /><path d="M12 15 L-2 8" />
-        </g>
-        <g stroke="#7a5230" strokeWidth="3" strokeLinecap="round">
-          <path d="M-22 18 V36" /><path d="M22 18 V36" />
-        </g>
-        {/* mesa + libro abierto (páginas blancas, lomo, renglones) */}
-        <polygon points="-16,34 0,26 16,34 0,42" fill="#8a6038" />
-        <g className="fvh-p-libro">
-          <path d="M-11 30 Q-5 26 0 28 L0 36 Q-5 34 -11 37 Z" fill="#fdf8ea" />
-          <path d="M11 30 Q5 26 0 28 L0 36 Q5 34 11 37 Z" fill="#f4ecd8" />
-          <path d="M0 28 V36" stroke="#c9b98e" strokeWidth="1" />
-          <g stroke="#b9a87c" strokeWidth=".9" opacity=".8">
-            <path d="M-8 31 Q-4 29 -1.5 30" /><path d="M-8 33.5 Q-4 31.5 -1.5 32.5" />
-            <path d="M8 31 Q4 29 1.5 30" /><path d="M8 33.5 Q4 31.5 1.5 32.5" />
-          </g>
-        </g>
-      </g>
-      {/* hojas-página que flotan (el saber que vuela) */}
-      <g className="fvh-p-hoja" fill="#e6c873" opacity=".9">
-        <path d="M132 52 q6 -4 10 0 q-4 6 -10 0 Z" />
-        <path d="M44 64 q5 -4 9 0 q-4 5 -9 0 Z" opacity=".8" />
-      </g>
-    </svg>
-  );
-}
-function PlaceJugar() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* cielo lúdico con estrellitas de juego */}
-      <g fill="#e8f6ff" className="fvh-p-brillo">
-        <path d="M38 26 l2 5 5 2 -5 2 -2 5 -2 -5 -5 -2 5 -2 Z" opacity=".9" />
-        <path d="M142 34 l1.6 4 4 1.6 -4 1.6 -1.6 4 -1.6 -4 -4 -1.6 4 -1.6 Z" opacity=".7" />
-      </g>
-      {/* isla-tablero: casillas isométricas alternadas */}
-      <polygon points="90,50 152,84 90,118 28,84" fill="#4f8fc0" />
-      <g>
-        <polygon points="90,58 121,75 90,92 59,75" fill="#9fe3ee" opacity=".9" />
-        <polygon points="90,58 105.5,66.5 90,75 74.5,66.5" fill="#7fc06f" />
-        <polygon points="105.5,66.5 121,75 105.5,83.5 90,75" fill="#c8f0f6" />
-        <polygon points="74.5,66.5 90,75 74.5,83.5 59,75" fill="#c8f0f6" />
-        <polygon points="90,75 105.5,83.5 90,92 74.5,83.5" fill="#7fc06f" />
-      </g>
-      {/* dado isométrico */}
-      <g className="fvh-p-dado" transform="translate(90 66)">
-        <polygon points="0,-10 11,-4 0,2 -11,-4" fill="#fdf8ea" />
-        <polygon points="-11,-4 0,2 0,15 -11,9" fill="#dfe8ea" />
-        <polygon points="11,-4 0,2 0,15 11,9" fill="#c3d3d8" />
-        <circle cx="0" cy="-4.5" r="1.8" fill="#38506a" />
-        <circle cx="-5.5" cy="3.5" r="1.6" fill="#38506a" /><circle cx="-5.5" cy="9" r="1.6" fill="#38506a" />
-        <circle cx="5.5" cy="3.5" r="1.6" fill="#38506a" /><circle cx="5.5" cy="9" r="1.6" fill="#38506a" /><circle cx="5.5" cy="6.2" r="1.6" fill="#38506a" />
-      </g>
-      {/* banderín de meta */}
-      <g transform="translate(124 78)">
-        <path d="M0 14 V-10" stroke="#38506a" strokeWidth="2.4" strokeLinecap="round" />
-        <path d="M0 -10 L14 -6 L0 -2 Z" fill="#ff5d44" />
-      </g>
-      {/* mariquita dibujada (fauna aliada del juego) */}
-      <g className="fvh-p-bicho" transform="translate(50 88)">
-        <ellipse cx="0" cy="0" rx="6" ry="4.6" fill="#e0532f" />
-        <path d="M0 -4.6 V4.6" stroke="#3a2024" strokeWidth="1.2" />
-        <circle cx="-2.4" cy="-1.4" r="1.1" fill="#3a2024" /><circle cx="2.6" cy="1" r="1.1" fill="#3a2024" />
-        <circle cx="0" cy="-5.4" r="2" fill="#3a2024" />
-      </g>
-      {/* mariposa dibujada */}
-      <g className="fvh-p-bicho" transform="translate(128 58)" style={{ animationDelay: '.6s' }}>
-        <path d="M0 0 q-6 -7 -10 -2 q-2 4 5 5 Z" fill="#f2b441" />
-        <path d="M0 0 q6 -7 10 -2 q2 4 -5 5 Z" fill="#ffd24d" />
-        <path d="M0 -2 V5" stroke="#5a4329" strokeWidth="1.3" strokeLinecap="round" />
-      </g>
-    </svg>
-  );
-}
-function PlaceAgente() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* claro crepuscular con estrellas del agente */}
-      <g fill="#e9e3ff" className="fvh-p-brillo">
-        <circle cx="36" cy="26" r="1.6" /><circle cx="146" cy="22" r="1.3" /><circle cx="120" cy="38" r="1" />
-      </g>
-      <polygon points="90,50 152,84 90,118 28,84" fill="#5d4db0" />
-      <polygon points="90,50 152,84 90,86 28,84" fill="#6f5ec4" opacity=".65" />
-      {/* claro luminoso: anillos concéntricos que laten */}
-      <circle cx="90" cy="80" r="30" fill="#11281f" />
-      <circle className="fvh-p-anillo" cx="90" cy="80" r="30" fill="none" stroke="#a3e635" strokeWidth="2.5" opacity=".8" />
-      <circle className="fvh-p-anillo" cx="90" cy="80" r="36" fill="none" stroke="#a3e635" strokeWidth="1.2" opacity=".35" style={{ animationDelay: '.9s' }} />
-      {/* colibrí insignia (pico largo, gorget ámbar) */}
-      <g transform="translate(74 72)">
-        <path d="M4 12 L-3 9 L1 14 L-4 17 L3 16 Z" fill="#8b5cf6" opacity=".85" />
-        <ellipse cx="9" cy="10" rx="9" ry="5" fill="#10b981" transform="rotate(-16 9 10)" />
-        <circle cx="18" cy="7" r="4.4" fill="#06b6d4" />
-        <ellipse cx="19" cy="10" rx="2.4" ry="1.6" fill="#f59e0b" />
-        <circle cx="19" cy="6" r="1" fill="#0c0a09" />
-        <path d="M22 7 Q30 8 33 12" fill="none" stroke="#e2e8f0" strokeWidth="1.4" strokeLinecap="round" />
-        <path d="M10 7 Q3 1 -3 5 Q4 12 12 8 Z" fill="#8b5cf6" opacity="0.8" />
-      </g>
-      {/* globo de conversación con puntitos (la voz del agente) */}
-      <g className="fvh-p-globo" transform="translate(114 50)">
-        <rect x="-14" y="-10" width="30" height="18" rx="9" fill="#fdf8ea" />
-        <path d="M-6 7 L-10 14 L-1 8 Z" fill="#fdf8ea" />
-        <circle cx="-6" cy="-1" r="1.8" fill="#5d4db0" />
-        <circle cx="1" cy="-1" r="1.8" fill="#5d4db0" />
-        <circle cx="8" cy="-1" r="1.8" fill="#5d4db0" />
-      </g>
-    </svg>
-  );
+  return mostrarAnimales ? puertas : puertas.filter((p) => p.id !== 'animales');
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -4,7 +4,7 @@
  * la TAREA i18n de ADR-050 (transversal a toda la app), fuera del alcance de esta
  * feature visual — mismo criterio que MiFincaVivaHomeCard.jsx, FincaCards.jsx y
  * FincaRedInstitucional.jsx en este mismo directorio. */
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { listFarmProcesses } from '../../db/farmProcessCache';
 import useAssetStore from '../../store/useAssetStore';
 import { buildFincaScene } from '../../services/fincaSceneService';
@@ -108,10 +108,13 @@ const COLIBRI_REAL = colibriRealActivo();
  *   la MISMA página, bajo el hero, así que el portal "Gestionar" la REVELA con un
  *   scroll a su ancla — NO navega a otra vista (mucho menos al juego). Si no se
  *   pasa, cae a un scroll directo al ancla #finca-gestion (mismo destino).
+ * @param {Function} [props.onTodaMiFinca]  revela LOS MUNDOS completos (la
+ *   puerta "Toda mi finca"): DashboardLive expande el bloque plegado y hace
+ *   scroll. Sin callback, cae a un scroll directo al ancla #bloque-mundos.
  * @param {React.ReactNode} [props.children]  escena alterna (red institucional).
  * @param {string} [props.titulo]  título accesible (default "Mi finca viva").
  */
-export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, children, titulo }) {
+export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, onTodaMiFinca, children, titulo }) {
   // Piel del tema activo: el ícono de marca del agente (la A roja en biopunk, la
   // sol-mano en verde-vivo, etc.) sigue al tema, igual que la escena toma su piel
   // del tema vía los tokens --c-*/--fvh-* del CSS. Con la flag OFF este hero no se
@@ -135,6 +138,19 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
       if (seccion?.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   };
+  // La puerta "Toda mi finca" abre LOS MUNDOS completos, que viven en la hoja
+  // bajo el hero (DashboardLive los revela con onTodaMiFinca: expandir +
+  // scroll). Sin callback, cae a un scroll directo al ancla del bloque.
+  const irATodaMiFinca = () => {
+    if (onTodaMiFinca) { onTodaMiFinca(); return; }
+    if (typeof document !== 'undefined') {
+      const seccion = document.getElementById('bloque-mundos');
+      if (seccion?.scrollIntoView) seccion.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+  // El bloque "Registrar en la finca" sigue alcanzable por scroll en la misma
+  // página (irAGestion queda como puente del ancla para quien lo necesite).
+  void irAGestion;
 
   // ── Datos reales de la finca (offline-first) ─────────────────────────────
   const [processes, setProcesses] = useState([]);
@@ -289,24 +305,67 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
   // usan). Tras el split vive en biopunk2 (donde quedó la Finca Organismo).
   const organismoActivo = escenaVivaActiva && temaEfectivo === 'biopunk2';
 
-  // ── ENTRADA AL MUNDO ANIMALES desde la escena ────────────────────────────
-  // El potrero (vaca + gallinas) de la Finca Organismo es un punto de entrada
-  // tappable al mundo de los animales — con el MISMO gate por perfil que usa
-  // el home para esconder ese mundo (DashboardLive.mostrarAnimales): un urbano
-  // de balcón/terraza no lo ve; control manual del home (#1560) y operador lo
-  // conservan. Mismo destino que MundosDeMiFinca: la portada del mundo.
+  // ── GATE DE ANIMALES (potrero de la escena + puerta "Mis animales") ───────
+  // Mismo criterio que DashboardLive.mostrarAnimales (el usuario solo ve lo
+  // que necesita): gobierna DOS entradas al mundo de los animales — el potrero
+  // tappable (vaca + gallinas) de la Finca Organismo y la puerta "Mis
+  // animales". Un urbano de balcón/terraza no ve ninguna; el control manual
+  // del home (#1560) y el operador las conservan. Fail-open ante error.
   const [mostrarAnimales] = useState(() => {
     try {
       if (esOperadorActual()) return true;
       if (hasManualModuleVisibility()) return true;
       return !esPerfilUrbano(getProfile());
     } catch (_) {
-      return true; // Fail-open: no esconder la entrada por un error.
+      return true; // Fail-open: no esconder la entrada/puerta por un error.
     }
   });
   const onAnimales = mostrarAnimales
     ? () => onNavigate?.('mundo', { mundo: 'animales' })
     : null;
+
+  // ── MODO "PLENO SOL" (usabilidad campesina #7) ────────────────────────────
+  // Alto contraste claro para leer el teléfono a mediodía al aire libre: el
+  // biopunk nocturno va bien de noche, pero al rayo del sol un fondo oscuro
+  // no se ve. AUTOMÁTICO de día (deriveAtmosphere → luz 'dia') con override
+  // MANUAL persistido ('1' forzado ON, '0' forzado OFF, ausente = auto).
+  const [solPref, setSolPref] = useState(() => {
+    try { return localStorage.getItem(PLENO_SOL_KEY) || 'auto'; }
+    catch (_) { return 'auto'; }
+  });
+  const plenoSol = solPref === '1' || (solPref === 'auto' && tonoLuz(atmosfera) === 'dia');
+  const alternarSol = () => {
+    const next = plenoSol ? '0' : '1';
+    setSolPref(next);
+    try { localStorage.setItem(PLENO_SOL_KEY, next); } catch (_) { /* incógnito */ }
+  };
+
+  // ── "ESCUCHAR" 🔊 (usabilidad campesina #6, baja alfabetización) ──────────
+  // Lee la pantalla en voz alta con el TTS propio (kokoro + fallback Web
+  // Speech, ttsService). Import perezoso: el peso del TTS no entra al chunk
+  // del home salvo que se use. Mientras habla, el botón pasa a "Parar".
+  const [hablando, setHablando] = useState(false);
+  const ttsUnsubRef = useRef(null);
+  useEffect(() => () => { if (ttsUnsubRef.current) ttsUnsubRef.current(); }, []);
+  const textoEscuchar = () => {
+    const puertasTxt = 'sus matas, sus animales, el tiempo, vender, aprender, o toda su finca';
+    const estadoTxt = poblada
+      ? 'Todo tranquilo en su finca.'
+      : 'Su finca está empezando. Registre su primera siembra y la escena cobra vida.';
+    return `Buenas, soy Chagra. Esta es su finca viva. ${estadoTxt} `
+      + 'Toque el botón verde grande, hable, y yo le contesto. '
+      + `También puede entrar a: ${puertasTxt}.`;
+  };
+  const escuchar = async () => {
+    try {
+      const tts = await import('../../services/ttsService');
+      if (!ttsUnsubRef.current) {
+        ttsUnsubRef.current = tts.onSpeakingChange((v) => setHablando(!!v));
+      }
+      if (tts.isAudioPlaying()) { tts.stop(); return; }
+      await tts.speakSentences(textoEscuchar());
+    } catch (_) { /* sin audio disponible: el botón no rompe el home */ }
+  };
 
   return (
     <section
@@ -315,6 +374,7 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
       className="fvh"
       data-luz={atmosfera.luz || undefined}
       data-clima={atmosfera.condicion || undefined}
+      data-plenosol={plenoSol ? '1' : undefined}
     >
       <div className="fvh-shell">
         {/* ── TOPBAR (con jerarquía y aire — feedback #3) ───────────────────── */}
@@ -486,8 +546,14 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
                          (#34): la estructura de cada escena porta el marcador
                          fvh-estructura solo si fue declarada. `onAnimales`
                          (gate por perfil) vuelve tappable el potrero de la
-                         Finca Organismo — las demás escenas lo ignoran hoy. */
-                      <EscenaViva estructura={estructuraFinca} onAnimales={onAnimales} />
+                         Finca Organismo; `onPregunte` vuelve TAPPABLE el
+                         corazón-semilla (abre el agente). Las demás escenas
+                         ignoran ambos handlers hoy. */
+                      <EscenaViva
+                        estructura={estructuraFinca}
+                        onAnimales={onAnimales}
+                        onPregunte={abrirAgente}
+                      />
                     ) : (
                       <SceneFinca
                         poblada={poblada}
@@ -548,25 +614,58 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
 
           {/* ── COLUMNA derecha en desktop / debajo en móvil ────────────────── */}
           <div className="fvh-aside">
-            {/* COMPOSITOR DEL AGENTE */}
+            {/* LA acción dominante: "PREGUNTE" (usabilidad campesina #2).
+                Antes "preguntar" aparecía en 4 formas sin que ninguna mandara
+                (la A del header, el globo del colibrí, este compositor y un
+                portal). Ahora ESTE botón manda: grande (≥96px), late como el
+                corazón de la escena y habla en cristiano. Las otras entradas
+                quedan de apoyo (la A del header, el corazón de la escena). */}
             <div className="fvh-composer-wrap">
               <button
                 type="button"
-                className="fvh-composer"
+                className="fvh-composer fvh-composer--pregunte"
                 onClick={abrirAgente}
                 data-testid="finca-viva-agent-fab"
-                aria-label="Pregúntele a Chagra"
+                aria-label="Pregúntele a Chagra: toque y hable, Chagra le contesta"
               >
-                <span className="av" aria-hidden="true"><ColibriAvatar /></span>
-                <span className="ph">Pregúntele a Chagra…</span>
-                <span className="mic" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-                    <rect x="9" y="3" width="6" height="11" rx="3" fill="#1f3300" />
-                    <path d="M6 11a6 6 0 0 0 12 0M12 17v3" stroke="#1f3300" strokeWidth="2" strokeLinecap="round" />
+                <span className="fvh-corazon-btn" aria-hidden="true">
+                  <span className="fvh-corazon-pulso" />
+                  <span className="fvh-corazon-pulso fvh-corazon-pulso2" />
+                  <svg viewBox="0 0 24 24" width="30" height="30" fill="none" aria-hidden="true">
+                    <rect x="9" y="3" width="6" height="11" rx="3" fill="#12260a" />
+                    <path d="M6 11a6 6 0 0 0 12 0M12 17v3M8.5 20h7" stroke="#12260a" strokeWidth="2.2" strokeLinecap="round" />
                   </svg>
                 </span>
+                <span className="fvh-pregunte-txt">
+                  <b>Pregunte</b>
+                  <small>Toque y hable. Chagra le contesta.</small>
+                </span>
               </button>
-              <div className="fvh-composer-hint">Toque 🎙️ y pregunte en voz alta — o escriba arriba</div>
+              {/* Escuchar (🔊 lee la pantalla, baja alfabetización) + Pleno sol
+                  (alto contraste de mediodía). Pareja de pastillas bajo la
+                  acción dominante. */}
+              <div className="fvh-audio-sol">
+                <button
+                  type="button"
+                  className="fvh-escuchar"
+                  data-testid="fvh-escuchar"
+                  aria-pressed={hablando}
+                  aria-label={hablando ? 'Parar la lectura en voz alta' : 'Escuchar: Chagra le lee la pantalla en voz alta'}
+                  onClick={escuchar}
+                >
+                  {hablando ? '⏹ Parar' : '🔊 Escuchar'}
+                </button>
+                <button
+                  type="button"
+                  className="fvh-sol-toggle"
+                  data-testid="fvh-pleno-sol"
+                  aria-pressed={plenoSol}
+                  aria-label={plenoSol ? 'Volver a la vista de noche' : 'Pleno sol: vista clara para leer a mediodía'}
+                  onClick={alternarSol}
+                >
+                  {plenoSol ? '🌙 Noche' : '☀️ Pleno sol'}
+                </button>
+              </div>
 
               {/* NIVEL DE RESPUESTA — junto al agente, porque define CÓMO le
                   responde Chagra. Renombrado del antiguo "Campesino/Experto"
@@ -600,33 +699,36 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, ch
               </div>
             </div>
 
-            {/* HERO TEXT */}
+            {/* HERO TEXT — sin jerga de ingeniero (antes "SU AGENTE
+                AGROECOLÓGICO"): palabras del campo. */}
             <div className="fvh-hero-saludo">
-              <div className="h-small">SU AGENTE AGROECOLÓGICO</div>
+              <div className="h-small">CHAGRA, SU COMPAÑERO DE CAMPO</div>
               <h1 dangerouslySetInnerHTML={{ __html: HERO[escala][0] }} />
               <p>{HERO[escala][1]}</p>
             </div>
           </div>
         </main>
 
-        {/* ── 4 PORTALES = LUGARES DE LA FINCA ───────────────────────────────── */}
-        <div className="fvh-portales-tit">Lugares de su finca <span /></div>
-        <nav className="fvh-portales" aria-label="Lugares de su finca" data-testid="finca-viva-portales">
-          {buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, escala }).map((p) => (
+        {/* ── LAS 6 PUERTAS (usabilidad campesina #5) ─────────────────────────
+            Antes: 4 portales con descripción + ~20 tarjetas + ~35 chips abajo.
+            Ahora: SEIS puertas de una-dos palabras, dibujo grande + palabra
+            grande, targets ≥96px (#8). Cada una enruta a un mundo/vista que YA
+            existe (nada nuevo que mantener). "Toda mi finca" abre los mundos
+            completos en la hoja de abajo. */}
+        <div className="fvh-portales-tit">¿A dónde va? <span /></div>
+        <nav className="fvh-puertas" aria-label="Puertas de su finca" data-testid="finca-viva-puertas">
+          {buildPuertas({ onNavigate, irATodaMiFinca, mostrarAnimales }).map((p, i) => (
             <button
               key={p.id}
               type="button"
-              className={`fvh-portal ${p.clase}`}
+              className={`fvh-puerta t-${p.tinte}`}
+              data-testid={`puerta-${p.id}`}
               onClick={p.onClick}
-              style={{ animationDelay: p.delay }}
-              aria-label={`${p.titulo}: ${p.desc}`}
+              style={{ animationDelay: `${0.08 + i * 0.06}s` }}
+              aria-label={`${p.nombre}: abre ${p.abre}`}
             >
-              <span className="ir" aria-hidden="true">Entrar →</span>
-              {p.placeSvg}
-              <span className="fvh-p-scrim" aria-hidden="true" />
-              <span className="fvh-p-nuevo">{p.badge}</span>
-              <div className="p-head"><div className="p-emoji" aria-hidden="true">{p.emoji}</div><h3>{p.titulo}</h3></div>
-              <p>{p.desc}</p>
+              <span className="fvh-puerta-emoji" aria-hidden="true">{p.emoji}</span>
+              <span className="fvh-puerta-nombre">{p.nombre}</span>
             </button>
           ))}
         </nav>
@@ -1062,35 +1164,6 @@ function ColibriVuela() {
   );
 }
 
-/** Mismo colibrí en versión avatar redondo para el compositor del agente. */
-function ColibriAvatar() {
-  return (
-    <svg viewBox="0 0 48 48" width="26" height="26" aria-hidden="true">
-      <defs>
-        <linearGradient id="fvh-colibri-av-plum" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0" stopColor="#34d399" />
-          <stop offset="45%" stopColor="#10b981" />
-          <stop offset="75%" stopColor="#22d3ee" />
-          <stop offset="100%" stopColor="#a78bfa" />
-        </linearGradient>
-        <radialGradient id="fvh-colibri-av-gor" cx="50%" cy="50%" r="50%">
-          <stop offset="0" stopColor="#fde68a" />
-          <stop offset="50%" stopColor="#f59e0b" />
-          <stop offset="100%" stopColor="#dc2626" />
-        </radialGradient>
-      </defs>
-      <path d="M8 26 L2 22 L6 28 L1 32 L7 31 L5 37 L12 30 Z" fill="url(#fvh-colibri-av-plum)" opacity="0.9" />
-      <path d="M20 22 Q10 15 4 22 Q11 29 21 25 Z" fill="url(#fvh-colibri-av-plum)" opacity="0.6" />
-      <ellipse cx="22" cy="25" rx="11" ry="6.6" fill="url(#fvh-colibri-av-plum)" transform="rotate(-16 22 25)" />
-      <circle cx="33" cy="20" r="5.6" fill="url(#fvh-colibri-av-plum)" />
-      <ellipse cx="34" cy="24" rx="3" ry="2" fill="url(#fvh-colibri-av-gor)" opacity="0.95" />
-      <circle cx="34.4" cy="18.6" r="1.3" fill="#0c0a09" />
-      <circle cx="34" cy="18.2" r="0.45" fill="#fff" />
-      <path d="M38.5 20 Q46 22 47 27" fill="none" stroke="#e2e8f0" strokeWidth="1.5" strokeLinecap="round" />
-    </svg>
-  );
-}
-
 // ── Catálogos de texto (refinados del mockup F2) ───────────────────────────
 
 /**
@@ -1127,259 +1200,39 @@ const HERO = {
     'Camine a un lugar de la finca, o escríbame abajo. Hablo claro y solo con datos verificados.',
   ],
 };
+// Un solo "pregunte" que mande (usabilidad campesina #2): el globo del colibrí
+// ya NO repite "pregúnteme aquí abajo" — saluda y orienta; preguntar vive en
+// el botón grande "Pregunte" (y en el corazón de la escena biopunk).
 const COLIBRI = {
-  balcon: ['Buenas, soy Chagra', 'Su balcón está al día. Toque una matera o pregúnteme aquí abajo.'],
-  invernadero: ['Buenas, soy Chagra', 'Sus hileras están bien. ¿Reviso riego o plagas? Pregúnteme abajo.'],
-  finca: ['Buenas, soy Chagra', 'Todo tranquilo en su finca. Toque un lugar para entrar, o pregúnteme aquí abajo.'],
+  balcon: ['Buenas, soy Chagra', 'Su balcón está al día. Toque una matera para verla de cerca.'],
+  invernadero: ['Buenas, soy Chagra', 'Sus hileras están bien. Toque un lugar para revisarlo.'],
+  finca: ['Buenas, soy Chagra', 'Todo tranquilo en su finca. Toque una puerta para entrar.'],
 };
 
+// Preferencia persistida del modo "pleno sol" ('1' ON, '0' OFF, ausente=auto).
+const PLENO_SOL_KEY = 'chagra:home:pleno-sol';
+
 /**
- * Los 4 portales/lugares del home F2 ("Mi finca", "Aprender", "Jugar",
- * "Pregúntele a Chagra"). El badge del portal "Mi finca" refleja el DATO
- * REAL de la finca (0 siembras → "EMPIECE AQUÍ"; con siembras → resumen real).
+ * LAS 6 PUERTAS del home (usabilidad campesina #5): una-dos palabras, dibujo
+ * grande, targets ≥96px. Cada puerta enruta a un mundo/vista que YA existe:
+ *   · Mis matas     → la portada del mundo Cultivos ('mundo_cultivos').
+ *   · Mis animales  → el mundo Animales ('mundo' + {mundo:'animales'}),
+ *                     gateado por perfil (mostrarAnimales, igual que el home).
+ *   · El tiempo     → 'hoy_finca' (su día: lluvia, heladas y avisos).
+ *   · Vender        → 'mercado'.
+ *   · Aprender      → 'aprende'.
+ *   · Toda mi finca → LOS MUNDOS completos en la hoja de abajo (revelar).
  */
-function buildPortales({ onNavigate, abrirAgente, irAGestion, scene, poblada, escala }) {
-  const total = Number(scene?.totalCultivos) || 0;
-  const animales = Array.isArray(scene?.animales) ? scene.animales.length : 0;
-  let badgeGestionar;
-  if (!poblada || total + animales === 0) {
-    badgeGestionar = escala === 'balcon'
-      ? 'EMPIECE AQUÍ · 0 materas'
-      : escala === 'invernadero'
-        ? 'EMPIECE AQUÍ · 0 trasplantes'
-        : 'EMPIECE AQUÍ · 0 siembras';
-  } else {
-    const partes = [];
-    if (total > 0) partes.push(total === 1 ? '1 siembra' : `${total} siembras`);
-    if (animales > 0) partes.push('animales');
-    badgeGestionar = partes.join(' · ') || 'Su finca';
-  }
-
-  return [
-    {
-      id: 'gestionar',
-      titulo: 'Mi finca',
-      desc: 'Registre y cuide sus siembras, zonas y animales.',
-      emoji: '🌱',
-      clase: 'p-gestionar',
-      delay: '.1s',
-      badge: badgeGestionar,
-      placeSvg: <PlaceGestionar />,
-      // GESTIÓN, no el juego: revela la sección de registros/acciones de la
-      // finca (siembras, zonas, animales) en esta misma página. El bug viejo
-      // mandaba a onNavigate('juego') — el mismo destino que el portal "Jugar".
-      onClick: () => irAGestion(),
-    },
-    {
-      id: 'aprender',
-      titulo: 'Aprender',
-      desc: 'Suelo vivo, milpa, biopreparados, MIP y fenología.',
-      emoji: '📚',
-      clase: 'p-aprender',
-      delay: '.18s',
-      badge: '5 lecciones',
-      placeSvg: <PlaceAprender />,
-      onClick: () => onNavigate?.('aprende'),
-    },
-    {
-      id: 'jugar',
-      titulo: 'Jugar',
-      desc: 'Haga crecer su finca y defiéndala jugando.',
-      emoji: '🎮',
-      clase: 'p-jugar',
-      delay: '.26s',
-      badge: 'Mi Finca Viva',
-      placeSvg: <PlaceJugar />,
-      onClick: () => onNavigate?.('juego'),
-    },
-    {
-      id: 'agente',
-      titulo: 'Pregúntele a Chagra',
-      desc: 'Pregunte lo que sea: respuestas con su fuente.',
-      emoji: '💬',
-      clase: 'p-agente',
-      delay: '.34s',
-      badge: 'Voz y foto',
-      placeSvg: <PlaceAgente />,
-      onClick: () => abrirAgente(),
-    },
+function buildPuertas({ onNavigate, irATodaMiFinca, mostrarAnimales }) {
+  const puertas = [
+    { id: 'matas', emoji: '🌱', nombre: 'Mis matas', tinte: 'verde', abre: 'sus siembras y cultivos', onClick: () => onNavigate?.('mundo_cultivos') },
+    { id: 'animales', emoji: '🐔', nombre: 'Mis animales', tinte: 'teja', abre: 'sus gallinas, cerdos y demás animales', onClick: () => onNavigate?.('mundo', { mundo: 'animales' }) },
+    { id: 'tiempo', emoji: '🌦️', nombre: 'El tiempo', tinte: 'cielo', abre: 'el clima de hoy y los próximos días', onClick: () => onNavigate?.('hoy_finca') },
+    { id: 'vender', emoji: '🧺', nombre: 'Vender', tinte: 'ambar', abre: 'precios, mercado y su despensa', onClick: () => onNavigate?.('mercado') },
+    { id: 'aprender', emoji: '📖', nombre: 'Aprender', tinte: 'uva', abre: 'las lecciones y guías del campo', onClick: () => onNavigate?.('aprende') },
+    { id: 'finca', emoji: '🏡', nombre: 'Toda mi finca', tinte: 'menta', abre: 'todos los mundos de su finca', onClick: () => irATodaMiFinca() },
   ];
-}
-
-// ── SVG de los 4 portales (place-svg) ────────────────────────────────────────
-// Cada portal es un LUGAR ilustrado con horizonte, tierra y un foco propio
-// (parcela con casita · rancho de lectura · isla de juego · claro del agente).
-// Sin <text> con emoji dentro del SVG: en Android/iOS viejos esos glifos
-// renderizan monocromos o vacíos — todo es dibujo vectorial propio.
-
-function PlaceGestionar() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* amanecer del lugar: sol suave + loma de fondo */}
-      <circle cx="146" cy="26" r="14" fill="#ffe08a" opacity=".5" />
-      <circle cx="146" cy="26" r="8" fill="#ffedb3" opacity=".8" />
-      <path d="M-4 66 Q50 42 104 62 T184 58 V90 H-4 Z" fill="#356b42" opacity=".55" />
-      {/* parcela isométrica con surcos */}
-      <polygon points="90,44 152,80 90,116 28,80" fill="#3f7a4e" />
-      <polygon points="90,44 152,80 90,82 28,80" fill="#4f9460" opacity=".7" />
-      <g stroke="#2f6b3a" strokeWidth="2.4" strokeLinecap="round" fill="none" opacity=".7">
-        <path d="M56 82 L90 100" /><path d="M70 74 L108 95" /><path d="M84 66 L122 87" />
-      </g>
-      {/* matas en hilera (tallo + copa + fruto) */}
-      <g className="fvh-p-mata">
-        <g strokeLinecap="round">
-          <path d="M64 84 v-12" stroke="#2f6b3a" strokeWidth="2.2" fill="none" />
-          <circle cx="64" cy="69" r="5" fill="#7fc06f" /><circle cx="62" cy="67" r="2.6" fill="#a7e17a" />
-          <circle cx="67" cy="72" r="2" fill="#ff5d44" />
-        </g>
-        <g strokeLinecap="round">
-          <path d="M88 96 v-13" stroke="#2f6b3a" strokeWidth="2.2" fill="none" />
-          <circle cx="88" cy="79" r="5.5" fill="#7fc06f" /><circle cx="86" cy="77" r="2.8" fill="#a7e17a" />
-          <circle cx="91" cy="82" r="2" fill="#ffd24d" />
-        </g>
-        <g strokeLinecap="round">
-          <path d="M112 88 v-11" stroke="#2f6b3a" strokeWidth="2.2" fill="none" />
-          <circle cx="112" cy="73" r="4.6" fill="#7fc06f" /><circle cx="110" cy="71" r="2.4" fill="#a7e17a" />
-        </g>
-      </g>
-      {/* casita campesina al fondo (pared clara, techo terracota, humo) */}
-      <g transform="translate(38 52)">
-        <path className="fvh-p-humo" d="M14 -12 q-3 -5 1 -8 q4 -3 1 -7" stroke="#f4efe2" strokeWidth="2.2" fill="none" strokeLinecap="round" opacity=".75" />
-        <rect x="11" y="-14" width="5" height="8" fill="#8a5a38" />
-        <polygon points="0,-6 13,-16 26,-6" fill="#c2562f" />
-        <polygon points="2,-6 24,-6 24,10 2,10" fill="#f6efe0" />
-        <rect x="10" y="0" width="6" height="10" fill="#7a5230" />
-        <rect x="4" y="-2" width="4.5" height="4.5" fill="#9fc9d8" />
-        <rect x="18" y="-2" width="4.5" height="4.5" fill="#9fc9d8" />
-      </g>
-      {/* letrero de madera de la parcela */}
-      <g transform="translate(126 92)">
-        <rect x="6" y="0" width="3" height="12" rx="1.5" fill="#7a5230" />
-        <rect x="-2" y="-8" width="19" height="10" rx="2.5" fill="#caa066" />
-        <path d="M2 -3 h11" stroke="#7a5230" strokeWidth="1.6" strokeLinecap="round" />
-      </g>
-    </svg>
-  );
-}
-function PlaceAprender() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* tarde dorada + loma ocre */}
-      <circle cx="34" cy="24" r="12" fill="#ffe6a8" opacity=".55" />
-      <path d="M-4 70 Q60 48 120 66 T184 62 V96 H-4 Z" fill="#9a5f24" opacity=".45" />
-      {/* explanada de tierra */}
-      <polygon points="90,50 152,84 90,118 28,84" fill="#c47b2f" />
-      <polygon points="90,50 152,84 90,86 28,84" fill="#d18c3f" opacity=".7" />
-      {/* rancho de lectura: paja a trazos + horcones + libro abierto DIBUJADO */}
-      <g transform="translate(90 58)">
-        <polygon points="-30,16 0,0 30,16 24,20 0,7 -24,20" fill="#a85d28" />
-        <polygon points="-26,17 0,4 26,17 0,17" fill="#8a4b20" opacity=".9" />
-        <g stroke="#e8bd7a" strokeWidth="1.4" opacity=".65" strokeLinecap="round">
-          <path d="M-20 13 L0 3" /><path d="M-12 15 L2 8" /><path d="M20 13 L0 3" /><path d="M12 15 L-2 8" />
-        </g>
-        <g stroke="#7a5230" strokeWidth="3" strokeLinecap="round">
-          <path d="M-22 18 V36" /><path d="M22 18 V36" />
-        </g>
-        {/* mesa + libro abierto (páginas blancas, lomo, renglones) */}
-        <polygon points="-16,34 0,26 16,34 0,42" fill="#8a6038" />
-        <g className="fvh-p-libro">
-          <path d="M-11 30 Q-5 26 0 28 L0 36 Q-5 34 -11 37 Z" fill="#fdf8ea" />
-          <path d="M11 30 Q5 26 0 28 L0 36 Q5 34 11 37 Z" fill="#f4ecd8" />
-          <path d="M0 28 V36" stroke="#c9b98e" strokeWidth="1" />
-          <g stroke="#b9a87c" strokeWidth=".9" opacity=".8">
-            <path d="M-8 31 Q-4 29 -1.5 30" /><path d="M-8 33.5 Q-4 31.5 -1.5 32.5" />
-            <path d="M8 31 Q4 29 1.5 30" /><path d="M8 33.5 Q4 31.5 1.5 32.5" />
-          </g>
-        </g>
-      </g>
-      {/* hojas-página que flotan (el saber que vuela) */}
-      <g className="fvh-p-hoja" fill="#e6c873" opacity=".9">
-        <path d="M132 52 q6 -4 10 0 q-4 6 -10 0 Z" />
-        <path d="M44 64 q5 -4 9 0 q-4 5 -9 0 Z" opacity=".8" />
-      </g>
-    </svg>
-  );
-}
-function PlaceJugar() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* cielo lúdico con estrellitas de juego */}
-      <g fill="#e8f6ff" className="fvh-p-brillo">
-        <path d="M38 26 l2 5 5 2 -5 2 -2 5 -2 -5 -5 -2 5 -2 Z" opacity=".9" />
-        <path d="M142 34 l1.6 4 4 1.6 -4 1.6 -1.6 4 -1.6 -4 -4 -1.6 4 -1.6 Z" opacity=".7" />
-      </g>
-      {/* isla-tablero: casillas isométricas alternadas */}
-      <polygon points="90,50 152,84 90,118 28,84" fill="#4f8fc0" />
-      <g>
-        <polygon points="90,58 121,75 90,92 59,75" fill="#9fe3ee" opacity=".9" />
-        <polygon points="90,58 105.5,66.5 90,75 74.5,66.5" fill="#7fc06f" />
-        <polygon points="105.5,66.5 121,75 105.5,83.5 90,75" fill="#c8f0f6" />
-        <polygon points="74.5,66.5 90,75 74.5,83.5 59,75" fill="#c8f0f6" />
-        <polygon points="90,75 105.5,83.5 90,92 74.5,83.5" fill="#7fc06f" />
-      </g>
-      {/* dado isométrico */}
-      <g className="fvh-p-dado" transform="translate(90 66)">
-        <polygon points="0,-10 11,-4 0,2 -11,-4" fill="#fdf8ea" />
-        <polygon points="-11,-4 0,2 0,15 -11,9" fill="#dfe8ea" />
-        <polygon points="11,-4 0,2 0,15 11,9" fill="#c3d3d8" />
-        <circle cx="0" cy="-4.5" r="1.8" fill="#38506a" />
-        <circle cx="-5.5" cy="3.5" r="1.6" fill="#38506a" /><circle cx="-5.5" cy="9" r="1.6" fill="#38506a" />
-        <circle cx="5.5" cy="3.5" r="1.6" fill="#38506a" /><circle cx="5.5" cy="9" r="1.6" fill="#38506a" /><circle cx="5.5" cy="6.2" r="1.6" fill="#38506a" />
-      </g>
-      {/* banderín de meta */}
-      <g transform="translate(124 78)">
-        <path d="M0 14 V-10" stroke="#38506a" strokeWidth="2.4" strokeLinecap="round" />
-        <path d="M0 -10 L14 -6 L0 -2 Z" fill="#ff5d44" />
-      </g>
-      {/* mariquita dibujada (fauna aliada del juego) */}
-      <g className="fvh-p-bicho" transform="translate(50 88)">
-        <ellipse cx="0" cy="0" rx="6" ry="4.6" fill="#e0532f" />
-        <path d="M0 -4.6 V4.6" stroke="#3a2024" strokeWidth="1.2" />
-        <circle cx="-2.4" cy="-1.4" r="1.1" fill="#3a2024" /><circle cx="2.6" cy="1" r="1.1" fill="#3a2024" />
-        <circle cx="0" cy="-5.4" r="2" fill="#3a2024" />
-      </g>
-      {/* mariposa dibujada */}
-      <g className="fvh-p-bicho" transform="translate(128 58)" style={{ animationDelay: '.6s' }}>
-        <path d="M0 0 q-6 -7 -10 -2 q-2 4 5 5 Z" fill="#f2b441" />
-        <path d="M0 0 q6 -7 10 -2 q2 4 -5 5 Z" fill="#ffd24d" />
-        <path d="M0 -2 V5" stroke="#5a4329" strokeWidth="1.3" strokeLinecap="round" />
-      </g>
-    </svg>
-  );
-}
-function PlaceAgente() {
-  return (
-    <svg className="place-svg" viewBox="0 0 180 140" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      {/* claro crepuscular con estrellas del agente */}
-      <g fill="#e9e3ff" className="fvh-p-brillo">
-        <circle cx="36" cy="26" r="1.6" /><circle cx="146" cy="22" r="1.3" /><circle cx="120" cy="38" r="1" />
-      </g>
-      <polygon points="90,50 152,84 90,118 28,84" fill="#5d4db0" />
-      <polygon points="90,50 152,84 90,86 28,84" fill="#6f5ec4" opacity=".65" />
-      {/* claro luminoso: anillos concéntricos que laten */}
-      <circle cx="90" cy="80" r="30" fill="#11281f" />
-      <circle className="fvh-p-anillo" cx="90" cy="80" r="30" fill="none" stroke="#a3e635" strokeWidth="2.5" opacity=".8" />
-      <circle className="fvh-p-anillo" cx="90" cy="80" r="36" fill="none" stroke="#a3e635" strokeWidth="1.2" opacity=".35" style={{ animationDelay: '.9s' }} />
-      {/* colibrí insignia (pico largo, gorget ámbar) */}
-      <g transform="translate(74 72)">
-        <path d="M4 12 L-3 9 L1 14 L-4 17 L3 16 Z" fill="#8b5cf6" opacity=".85" />
-        <ellipse cx="9" cy="10" rx="9" ry="5" fill="#10b981" transform="rotate(-16 9 10)" />
-        <circle cx="18" cy="7" r="4.4" fill="#06b6d4" />
-        <ellipse cx="19" cy="10" rx="2.4" ry="1.6" fill="#f59e0b" />
-        <circle cx="19" cy="6" r="1" fill="#0c0a09" />
-        <path d="M22 7 Q30 8 33 12" fill="none" stroke="#e2e8f0" strokeWidth="1.4" strokeLinecap="round" />
-        <path d="M10 7 Q3 1 -3 5 Q4 12 12 8 Z" fill="#8b5cf6" opacity="0.8" />
-      </g>
-      {/* globo de conversación con puntitos (la voz del agente) */}
-      <g className="fvh-p-globo" transform="translate(114 50)">
-        <rect x="-14" y="-10" width="30" height="18" rx="9" fill="#fdf8ea" />
-        <path d="M-6 7 L-10 14 L-1 8 Z" fill="#fdf8ea" />
-        <circle cx="-6" cy="-1" r="1.8" fill="#5d4db0" />
-        <circle cx="1" cy="-1" r="1.8" fill="#5d4db0" />
-        <circle cx="8" cy="-1" r="1.8" fill="#5d4db0" />
-      </g>
-    </svg>
-  );
+  return mostrarAnimales ? puertas : puertas.filter((p) => p.id !== 'animales');
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/src/components/dashboard/SceneFincaOrganismo.jsx
+++ b/src/components/dashboard/SceneFincaOrganismo.jsx
@@ -26,16 +26,25 @@
  *   el invernadero-célula de la escena lleva el data-testid/data-forma del
  *   contrato de FincaVivaHero.estructura.test.jsx (misma semántica que
  *   SceneFinca: el marcador aparece SOLO si la estructura está declarada).
+ * @param {?() => void} [props.onPregunte] al tocar el CORAZÓN-SEMILLA abre el
+ *   agente ("Pregunte"): la metáfora central de la escena deja de ser
+ *   decoración y se vuelve LA acción principal (usabilidad campesina #4).
+ *   Sin handler, el corazón queda como arte (sin rol ni foco).
  */
-export default function SceneFincaOrganismo({ estructura }) {
+export default function SceneFincaOrganismo({ estructura, onPregunte }) {
   const conEstructura = !!estructura?.tiene;
+  const conPregunte = typeof onPregunte === 'function';
+  const ariaEscena = 'Su finca convertida en organismo bioluminiscente, con el sol o la luna según la hora y el cielo real de su vereda: un corazón-semilla late bajo la tierra y su red de micorrizas conecta las raíces de cada planta, con lombrices y bichitos trabajando el suelo; cultivos con savia de neón, invernadero-célula que respira, campesino con su perro y colibrí de luz.';
   return (
     <svg
       className="fvo-svg"
       viewBox="0 0 390 486"
       preserveAspectRatio="xMidYMid slice"
-      role="img"
-      aria-label="Su finca convertida en organismo bioluminiscente, con el sol o la luna según la hora y el cielo real de su vereda: un corazón-semilla late bajo la tierra y su red de micorrizas conecta las raíces de cada planta, con lombrices y bichitos trabajando el suelo; cultivos con savia de neón, invernadero-célula que respira, campesino con su perro y colibrí de luz."
+      /* con el corazón tappable el SVG deja de ser imagen plana: role="img"
+         volvería PRESENTACIONALES a sus hijos y el botón "Pregunte" no
+         existiría para lectores de pantalla. */
+      role={conPregunte ? 'group' : 'img'}
+      aria-label={ariaEscena}
       data-testid="fvo-escena"
     >
       <defs>
@@ -638,10 +647,36 @@ export default function SceneFincaOrganismo({ estructura }) {
         <path d="M327.6,445.4 Q326,444 325.2,442.6" stroke="#d8ff6a" strokeWidth=".7" fill="none" opacity=".8" />
       </g>
 
-      {/* ============ CORAZÓN-SEMILLA MICORRÍZICO (la vida bajo la tierra) ============ */}
+      {/* ============ CORAZÓN-SEMILLA MICORRÍZICO (la vida bajo la tierra) ============
+          Con `onPregunte` el corazón entero es un BOTÓN (tap / Enter / Espacio)
+          que abre el agente — el mismo patrón del potrero→animales: la metáfora
+          central deja de ser decoración y pasa a ser LA acción de preguntar.
+          Sin handler queda como arte (aria-hidden, sin foco). */}
+      <g
+        className={`fvo-corazon-grupo${conPregunte ? ' fvo-corazon-tap' : ''}`}
+        data-testid="fvo-corazon"
+        {...(conPregunte
+          ? {
+              role: 'button',
+              tabIndex: 0,
+              'aria-label': 'El corazón de su finca: toque y pregúntele a Chagra con su voz.',
+              onClick: () => onPregunte(),
+              onKeyDown: (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onPregunte();
+                }
+              },
+            }
+          : { 'aria-hidden': true })}
+      >
       {/* cámara de suelo: da contexto y contraste al órgano */}
       <ellipse cx="195" cy="406" rx="42" ry="36" fill="#02040c" opacity=".55" />
       <ellipse cx="195" cy="406" rx="42" ry="36" fill="none" stroke="#0f3a30" strokeWidth="1" opacity=".55" />
+      {/* halo-invitación del tap (solo cuando el corazón es botón) */}
+      {conPregunte && (
+        <circle className="fvo-corazon-halo" cx="195" cy="406" r="32" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".5" />
+      )}
       {/* ondas de latido */}
       <circle className="fvo-heart-wave" cx="195" cy="406" r="24" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
       <circle className="fvo-heart-wave" style={{ animationDelay: '.6s' }} cx="195" cy="406" r="24" fill="none" stroke="#ff4fd8" strokeWidth="1" />
@@ -676,6 +711,8 @@ export default function SceneFincaOrganismo({ estructura }) {
         <circle cx="195" cy="407" r="5.2" fill="#eafff6" />
         <circle cx="195" cy="407" r="2.2" fill="#ff8fe4" />
       </g>
+      {/* cierre del grupo tappable del corazón (la etiqueta va aparte, abajo) */}
+      </g>
 
       {/* nutrientes viajando */}
       <circle className="fvo-spark fvo-p1" r="2.2" fill="#bfffe9" />
@@ -707,10 +744,13 @@ export default function SceneFincaOrganismo({ estructura }) {
         </g>
       </g>
 
-      {/* etiqueta viva */}
-      <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity=".65">
+      {/* etiqueta viva — con el corazón tappable invita a la acción (y deja
+          la jerga de laboratorio: "micorrízica" no es palabra del campo) */}
+      <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity=".65" aria-hidden="true">
         <text x="195" y="452" fill="#2dffc4" textAnchor="middle">CORAZÓN DE LA FINCA · VIVO</text>
-        <text x="195" y="464" fill="#5b7f93" textAnchor="middle" letterSpacing="1">la red micorrízica conecta cada planta</text>
+        <text x="195" y="464" fill="#5b7f93" textAnchor="middle" letterSpacing="1">
+          {conPregunte ? 'toque el corazón y pregúntele a Chagra' : 'las raíces de su finca están conectadas'}
+        </text>
       </g>
     </svg>
   );

--- a/src/components/dashboard/SceneFincaOrganismo.jsx
+++ b/src/components/dashboard/SceneFincaOrganismo.jsx
@@ -13,6 +13,15 @@
  *     neón, casita campesina con fogón (brasas), campesino con ruana +
  *     farol + perro criollo, frailejones que exhalan luz, luna verde
  *     bioluminiscente, cocuyos, aurora de páramo, niebla y hongos con esporas.
+ *   · QUEBRADA bioluminiscente que baja de la montaña por las terrazas y
+ *     remansa en un pocito que se filtra hacia la red micorrízica; platanera
+ *     con racimo neón junto a la casita; polillas rondando el farol y una
+ *     cordillera lejana + rayo del astro que dan profundidad de capas.
+ *   · POTRERO con VACA bioluminiscente (respira, pasta y espanta con la
+ *     cola) + 3 GALLINAS que picotean: es la ENTRADA VIVA al mundo de los
+ *     animales — si `onAnimales` llega, el grupo es un botón (tap/Enter)
+ *     que navega al módulo; sin handler queda como arte decorativo (el
+ *     MISMO gate por perfil que esconde el mundo Animales en el home).
  *
  * Solo se monta con el tema biopunk (lo decide FincaVivaHero); los demás
  * temas conservan sus escenas isométricas intactas. Las clases/ids llevan
@@ -26,16 +35,26 @@
  *   el invernadero-célula de la escena lleva el data-testid/data-forma del
  *   contrato de FincaVivaHero.estructura.test.jsx (misma semántica que
  *   SceneFinca: el marcador aparece SOLO si la estructura está declarada).
+ * @param {?() => void} [props.onAnimales] al tocar el potrero (vaca +
+ *   gallinas) navega al mundo de los animales. `null`/ausente = el perfil no
+ *   ve ese mundo (gate `mostrarAnimales` del home) y el potrero queda
+ *   decorativo, sin rol ni foco.
  */
-export default function SceneFincaOrganismo({ estructura }) {
+export default function SceneFincaOrganismo({ estructura, onAnimales }) {
   const conEstructura = !!estructura?.tiene;
+  const conAnimales = typeof onAnimales === 'function';
+  const ariaEscena =
+    'Su finca convertida en organismo bioluminiscente, con el sol o la luna según la hora y el cielo real de su vereda: un corazón-semilla late bajo la tierra y su red de micorrizas conecta las raíces de cada planta, con lombrices y bichitos trabajando el suelo; una quebrada baja de la montaña, cultivos con savia de neón, invernadero-célula que respira, potrero con vaca y gallinas, campesino con su perro y colibrí de luz.';
   return (
     <svg
       className="fvo-svg"
       viewBox="0 0 390 486"
       preserveAspectRatio="xMidYMid slice"
-      role="img"
-      aria-label="Su finca convertida en organismo bioluminiscente, con el sol o la luna según la hora y el cielo real de su vereda: un corazón-semilla late bajo la tierra y su red de micorrizas conecta las raíces de cada planta, con lombrices y bichitos trabajando el suelo; cultivos con savia de neón, invernadero-célula que respira, campesino con su perro y colibrí de luz."
+      /* con el potrero tappable el SVG deja de ser imagen plana: role="img"
+         volvería PRESENTACIONALES a sus hijos y el botón de los animales no
+         existiría para lectores de pantalla. */
+      role={conAnimales ? 'group' : 'img'}
+      aria-label={ariaEscena}
       data-testid="fvo-escena"
     >
       <defs>
@@ -88,6 +107,16 @@ export default function SceneFincaOrganismo({ estructura }) {
         <linearGradient id="fvo-tallo" x1="0" y1="1" x2="0" y2="0">
           <stop offset="0" stopColor="#0f8f6c" />
           <stop offset="1" stopColor="#9dff3f" />
+        </linearGradient>
+        {/* agua de la quebrada: azul profundo que se enciende hacia el remanso */}
+        <linearGradient id="fvo-agua-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#0a2b4a" />
+          <stop offset="1" stopColor="#12466e" />
+        </linearGradient>
+        {/* rayo del astro: cae en diagonal sobre la finca y se disuelve */}
+        <linearGradient id="fvo-rayo-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#eafff6" stopOpacity=".14" />
+          <stop offset="1" stopColor="#eafff6" stopOpacity="0" />
         </linearGradient>
         <filter id="fvo-blur8"><feGaussianBlur stdDeviation="8" /></filter>
         <filter id="fvo-blur3"><feGaussianBlur stdDeviation="3" /></filter>
@@ -217,9 +246,17 @@ export default function SceneFincaOrganismo({ estructura }) {
         </g>
       </g>
 
-      {/* ============ MONTAÑAS ============ */}
+      {/* ============ MONTAÑAS (3 capas = profundidad) ============ */}
+      {/* cordillera LEJANA: la capa nueva de atrás, casi cielo — con la niebla
+          que deriva entre capas la escena gana paralaje sin mover montañas */}
+      <path d="M0,196 C55,162 130,186 210,164 C285,146 340,172 390,152 L390,262 L0,262 Z" fill="#071126" />
+      <ellipse className="fvo-fog fvo-g3" cx="180" cy="196" rx="170" ry="13" fill="#9fd4ff" opacity=".05" filter="url(#fvo-blur8)" />
       <path d="M0,206 C60,176 122,196 190,180 C258,166 322,192 390,174 L390,262 L0,262 Z" fill="#0a1734" />
       <path d="M0,234 C70,208 150,228 232,212 C302,200 352,220 390,208 L390,282 L0,282 Z" fill="#0d1e40" />
+
+      {/* rayo del astro: la luz de la luna/el sol cae en diagonal sobre la
+          finca (respira suave; da volumen de iluminación a toda la escena) */}
+      <path className="fvo-rayo" d="M292,88 L188,336 L390,336 L346,86 Z" fill="url(#fvo-rayo-grad)" />
 
       {/* frailejones que exhalan luz (páramo) */}
       <g className="fvo-frailejon" strokeLinecap="round">
@@ -254,6 +291,35 @@ export default function SceneFincaOrganismo({ estructura }) {
         <path d="M0,296 C90,286 190,296 280,288 C330,284 364,290 390,284 L390,336 L0,336 Z" fill="#123354" />
         <path d="M0,296 C90,286 190,296 280,288 C330,284 364,290 390,284" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".5" />
 
+        {/* ============ QUEBRADA BIOLUMINISCENTE (el agua de la finca) ============
+            Baja de la montaña por el costado izquierdo, salta las terrazas en
+            dos cascaditas y remansa en un pocito al pie de la milpa. El flujo
+            es el mismo truco de las hifas (dash que corre); el remanso ondea. */}
+        <g aria-hidden="true">
+          {/* cauce (lecho oscuro + agua) */}
+          <path d="M14,232 C6,248 24,262 14,278 C4,294 22,308 12,320 C9,326 5,331 2,334" fill="none" stroke="#0a2b4a" strokeWidth="9" strokeLinecap="round" />
+          <path d="M14,232 C6,248 24,262 14,278 C4,294 22,308 12,320 C9,326 5,331 2,334" fill="none" stroke="#123f66" strokeWidth="6" strokeLinecap="round" />
+          {/* corriente neón (dos hilos desfasados) */}
+          <path className="fvo-agua" d="M14,232 C6,248 24,262 14,278 C4,294 22,308 12,320 C9,326 5,331 2,334" fill="none" stroke="#4fd8ff" strokeWidth="1.8" strokeLinecap="round" opacity=".8" style={{ filter: 'drop-shadow(0 0 3px rgba(79,216,255,.6))' }} />
+          <path className="fvo-agua fvo-a2" d="M16,234 C9,249 25,263 16,279 C7,294 23,308 14,320" fill="none" stroke="#bfeaff" strokeWidth=".9" strokeLinecap="round" opacity=".6" />
+          {/* cascaditas donde el agua salta cada terraza */}
+          <line className="fvo-destello" x1="15" y1="256" x2="14" y2="262" stroke="#bfeaff" strokeWidth="2.2" strokeLinecap="round" opacity=".8" />
+          <line className="fvo-destello" style={{ animationDelay: '-1.3s' }} x1="13" y1="294" x2="12" y2="300" stroke="#bfeaff" strokeWidth="2" strokeLinecap="round" opacity=".75" />
+          {/* pocito / remanso (refleja la luz del cielo y ondea) */}
+          <ellipse cx="18" cy="331" rx="19" ry="4.4" fill="url(#fvo-agua-grad)" />
+          <ellipse cx="18" cy="331" rx="19" ry="4.4" fill="none" stroke="#4fd8ff" strokeWidth=".9" opacity=".7" />
+          <ellipse className="fvo-reflejo" cx="12" cy="330.4" rx="6.5" ry="1.3" fill="#bfeaff" opacity=".45" />
+          <ellipse className="fvo-onda" cx="18" cy="331" rx="6" ry="1.6" fill="none" stroke="#4fd8ff" strokeWidth=".8" />
+          <ellipse className="fvo-onda fvo-on2" cx="18" cy="331" rx="6" ry="1.6" fill="none" stroke="#bfeaff" strokeWidth=".6" />
+          {/* juncos de la orilla + luciérnaga de agua */}
+          <g stroke="#0f8f6c" strokeWidth="1.2" strokeLinecap="round" fill="none">
+            <path className="fvo-sap fvo-s3" d="M33,330 C33,324 34,320 33,316" />
+            <path className="fvo-sap fvo-s5" d="M36,331 C36,326 37,323 36.5,319" />
+          </g>
+          <circle cx="33" cy="315" r="1.2" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+          <circle className="fvo-fly fvo-f5" cx="26" cy="320" r="1.2" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 4px #4fd8ff)' }} />
+        </g>
+
         {/* casita campesina con fogón */}
         <g>
           <rect x="52" y="250" width="26" height="17" rx="1.5" fill="#160f2e" />
@@ -265,6 +331,31 @@ export default function SceneFincaOrganismo({ estructura }) {
           <circle className="fvo-brasa" cx="74" cy="238" r="1.5" fill="#ff7a3d" />
           <circle className="fvo-brasa fvo-br2" cx="75.5" cy="238" r="1.1" fill="#ffb54f" />
           <circle className="fvo-brasa fvo-br3" cx="73" cy="238" r=".9" fill="#ff4fd8" />
+          {/* la puerta abierta derrama luz cálida al patio */}
+          <ellipse className="fvo-ventana" cx="71.5" cy="268.5" rx="6.5" ry="1.8" fill="#ffb54f" opacity=".16" />
+        </g>
+
+        {/* platanera del patio: hojas que arquean con venas de savia y un
+            racimo con su bellota neón (queda medio detrás del cafetal — capa) */}
+        <g aria-hidden="true">
+          <path d="M92,296 C92,284 91,274 92,266" fill="none" stroke="#14503c" strokeWidth="3" strokeLinecap="round" />
+          <path className="fvo-sap fvo-s2" d="M92,294 C92,284 91.4,274 92,267" fill="none" stroke="#2dffc4" strokeWidth=".8" opacity=".6" strokeLinecap="round" />
+          <path d="M92,266 C83,264 76,257.5 74,250 C80.5,250 89,255.5 92,262 Z" fill="#14503c" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          <path d="M92,266 C101,264 108,257.5 110,250 C103.5,250 95,255.5 92,262 Z" fill="#14503c" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          <path d="M92,264 C86,258 84,250 86.5,243 C90.5,247.5 93,256 92.4,262 Z" fill="#186047" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          <path d="M92,264 C98,258 100,250 97.5,243 C93.5,247.5 91,256 91.6,262 Z" fill="#186047" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          {/* venas de las hojas (laten con la savia) */}
+          <g className="fvo-sap fvo-s4" fill="none" stroke="#9dff3f" strokeWidth=".6" opacity=".65" strokeLinecap="round">
+            <path d="M92,264 C86,260 81,255 78,251" />
+            <path d="M92,264 C98,260 103,255 106,251" />
+            <path d="M91.6,262 C90,255 88.6,250 87.6,246" />
+            <path d="M92.4,262 C94,255 95.4,250 96.4,246" />
+          </g>
+          {/* racimo + bellota (flor) colgando */}
+          <path d="M92,268 C89.6,269.5 88.4,271.5 88.6,274" fill="none" stroke="#0f8f6c" strokeWidth="1" />
+          <circle className="fvo-berry fvo-b2" cx="89.6" cy="269.6" r="1.3" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 3px #ffb54f)' }} />
+          <circle className="fvo-berry fvo-b4" cx="88" cy="271.6" r="1.3" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 3px #ffb54f)' }} />
+          <path d="M88.6,274 L87.4,277.6 L90,277.2 Z" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
         </g>
 
         {/* cafetales con cerezas neón (terraza alta) */}
@@ -375,6 +466,133 @@ export default function SceneFincaOrganismo({ estructura }) {
           {/* base / cimiento luminoso */}
           <rect x="247" y="328" width="102" height="5" rx="2.5" fill="#0c2a20" />
           <rect x="247" y="328" width="102" height="1.6" rx="1" fill="#2dffc4" opacity=".7" />
+        </g>
+
+        {/* ============ POTRERO: VACA + 3 GALLINAS = ENTRADA AL MUNDO ANIMALES ============
+            El grupo entero es la puerta viva al módulo de animales: con
+            `onAnimales` es un botón (tap / Enter / Espacio) con halo-invitación
+            y etiqueta; sin handler (gate por perfil) queda como arte. La vaca
+            respira, pasta y espanta con la cola; las gallinas picotean. */}
+        <g
+          className="fvo-animales"
+          data-testid="fvo-animales"
+          {...(conAnimales
+            ? {
+                role: 'button',
+                tabIndex: 0,
+                'data-tap': '1',
+                'aria-label': 'Los animales de su finca: la vaca y las gallinas. Toque para entrar al mundo de los animales.',
+                onClick: () => onAnimales(),
+                onKeyDown: (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onAnimales();
+                  }
+                },
+              }
+            : { 'aria-hidden': true })}
+        >
+          {/* pasto del potrero */}
+          <ellipse cx="222" cy="278" rx="31" ry="5.5" fill="#16405a" opacity=".5" />
+          <g stroke="#9dff3f" strokeWidth=".8" strokeLinecap="round" opacity=".6" fill="none">
+            <path d="M197,278 L196,274.4" /><path d="M199.5,278.4 L199.5,275" />
+            <path d="M246,276 L245,272.6" /><path d="M248.5,276.4 L249,273.2" />
+            <path d="M215,282 L214.4,279" /><path d="M231,282.4 L231.6,279.4" />
+          </g>
+
+          {/* cerca viva del potrero (madera oscura + hilos neón) */}
+          <g>
+            <g fill="#241c3e">
+              <rect x="194.2" y="244.5" width="1.8" height="10.5" rx=".9" />
+              <rect x="208.2" y="243.8" width="1.8" height="10.5" rx=".9" />
+              <rect x="222.2" y="243.5" width="1.8" height="10.5" rx=".9" />
+              <rect x="236.2" y="243.8" width="1.8" height="10.5" rx=".9" />
+              <rect x="250.2" y="244.5" width="1.8" height="10.5" rx=".9" />
+            </g>
+            <path d="M194,247.4 C208,246.2 238,246.2 252,247.4" fill="none" stroke="#b28dff" strokeWidth=".9" opacity=".55" />
+            <path d="M194,251.4 C208,250.2 238,250.2 252,251.4" fill="none" stroke="#2dffc4" strokeWidth=".9" opacity=".5" />
+            <circle className="fvo-nodo" cx="223.1" cy="243.2" r="1" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+          </g>
+
+          {/* VACA bioluminiscente (mira hacia la casa; el organismo la abraza:
+              sus manchas laten con el MISMO pulso de la red micorrízica) */}
+          <g className="fvo-vaca">
+            <ellipse cx="221" cy="280" rx="18" ry="3" fill="#000" opacity=".35" />
+            {/* cola (espanta de a ratos) + borla-cocuyo */}
+            <g className="fvo-vaca-cola">
+              <path d="M236.5,258 C240.5,262 241.5,268 239.5,274" fill="none" stroke="#241c3e" strokeWidth="1.6" strokeLinecap="round" />
+              <circle cx="239.5" cy="275" r="1.9" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px #2dffc4)' }} />
+            </g>
+            {/* patas con pezuñas de luz */}
+            <g stroke="#241c3e" strokeWidth="3" strokeLinecap="round">
+              <path d="M210,271 L209.4,279" /><path d="M215.5,272.5 L215.5,279.6" />
+              <path d="M228.5,272.5 L228.5,279.6" /><path d="M234,271 L234.6,279" />
+            </g>
+            <g fill="#b28dff" opacity=".8">
+              <circle cx="209.4" cy="279.6" r=".9" /><circle cx="215.5" cy="280.2" r=".9" />
+              <circle cx="228.5" cy="280.2" r=".9" /><circle cx="234.6" cy="279.6" r=".9" />
+            </g>
+            {/* cuerpo (respira) con manchas que laten al pulso del corazón */}
+            <g className="fvo-vaca-cuerpo">
+              <ellipse cx="222" cy="264" rx="16" ry="9.5" fill="#241c3e" stroke="#b28dff" strokeWidth=".8" strokeOpacity=".45" />
+              <path className="fvo-mancha" d="M210,259 C215,255.5 221,256 223.5,260 C221,264.5 213.5,265.5 209.5,262.5 Z" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px rgba(45,255,196,.7))' }} />
+              <path className="fvo-mancha fvo-m2" d="M229,266 C233.5,264 237,266 236,269.5 C233,271.5 228.5,270.5 227.5,268 Z" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 3px rgba(79,216,255,.7))' }} />
+              <circle className="fvo-mancha fvo-m3" cx="216" cy="269" r="2.4" fill="#ff8fe4" style={{ filter: 'drop-shadow(0 0 3px rgba(255,143,228,.7))' }} />
+              {/* ubre con su lucecita (la leche también es vida) */}
+              <path d="M226.5,272.5 a3.2,2.6 0 0 0 6.2,0 Z" fill="#ff9ee8" opacity=".85" />
+            </g>
+            {/* cabeza: pasta y se alza a mirar; orejas que espantan */}
+            <g className="fvo-vaca-cabeza">
+              <path d="M209,258 L213,260" stroke="#241c3e" strokeWidth="5" strokeLinecap="round" />
+              <ellipse cx="204.5" cy="257" rx="6.2" ry="5" fill="#241c3e" stroke="#b28dff" strokeWidth=".7" strokeOpacity=".4" />
+              {/* cachos de luna */}
+              <g fill="none" stroke="#e8dcff" strokeWidth="1.2" strokeLinecap="round">
+                <path d="M201.5,252.6 C200,250 200.8,248.4 202.8,247.8" />
+                <path d="M207.5,252.4 C209,250 208.4,248.2 206.4,247.8" />
+              </g>
+              <path className="fvo-vaca-oreja" d="M209.5,254 Q212.5,251.5 213.5,253.5 Q212,256 209.8,256 Z" fill="#3a2f52" />
+              {/* hocico + ollar */}
+              <ellipse cx="200" cy="259.5" rx="3.4" ry="2.5" fill="#3a2f52" />
+              <circle cx="198.8" cy="259.3" r=".5" fill="#0a0618" />
+              {/* ojo de cocuyo */}
+              <circle cx="206" cy="255.8" r="1.05" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 3px #2dffc4)' }} />
+              <circle cx="206.35" cy="255.45" r=".35" fill="#eafff6" />
+              {/* mancha de la frente */}
+              <path className="fvo-mancha fvo-m2" d="M203,253.6 C204.6,252.6 206.4,253 206.8,254.4 C205.6,255.6 203.6,255.4 203,253.6 Z" fill="#2dffc4" opacity=".7" />
+            </g>
+          </g>
+
+          {/* 3 GALLINAS que picotean (cada una con su color y su ritmo) */}
+          <GallinaLuz x={205} y={281} cuerpo="#ffb54f" cola="#ff9d3f" clase="" />
+          <GallinaLuz x={220.5} y={283.5} cuerpo="#ff8fe4" cola="#d86ac0" clase="fvo-ga2" espejo />
+          <GallinaLuz x={237} y={281} cuerpo="#8fc8ef" cola="#5a9fd4" clase="fvo-ga3" />
+
+          {/* halo-invitación + etiqueta (solo cuando el potrero es la puerta
+              al módulo; el anillo de foco lo enciende :focus-visible) */}
+          {conAnimales && (
+            <g>
+              <ellipse className="fvo-cta-halo" cx="222" cy="264" rx="34" ry="22" fill="none" stroke="#ffb54f" strokeWidth="1" />
+              <ellipse className="fvo-cta-anillo" cx="222" cy="264" rx="34" ry="22" fill="none" stroke="#ffd76a" strokeWidth="1.4" opacity="0" />
+              <text
+                className="fvo-cta-tag"
+                x="222"
+                y="238"
+                fill="#ffb54f"
+                fontFamily="ui-monospace,monospace"
+                fontSize="7"
+                letterSpacing="1.5"
+                textAnchor="middle"
+              >
+                LOS ANIMALES ▸
+              </text>
+              {/* zona de tap generosa (invisible) sobre todo el potrero.
+                  OJO: sin <title> a propósito — un <title> en el subárbol
+                  aporta un rect degenerado en el origen del SVG y Chromium
+                  infla el boundingClientRect del botón hasta cubrir media
+                  escena (el aria-label del grupo ya cubre accesibilidad). */}
+              <rect x="190" y="230" width="66" height="58" fill="#000" opacity="0" style={{ pointerEvents: 'all' }} />
+            </g>
+          )}
         </g>
 
         {/* ============ MILPA FRONTAL: maíz de savia neón ============ */}
@@ -489,12 +707,18 @@ export default function SceneFincaOrganismo({ estructura }) {
           <path d="M250,329.5 Q252.5,331.4 255,329.4" stroke="#2dffc4" strokeWidth=".8" fill="none" opacity=".8" />
         </g>
 
+        {/* polillas rondando el farol (la luz siempre convoca su corte) */}
+        <circle className="fvo-polilla" cx="233" cy="318" r="1" fill="#eafff6" opacity=".8" />
+        <circle className="fvo-polilla fvo-po2" cx="244" cy="321" r=".8" fill="#ffe6c9" opacity=".75" />
+
         {/* cocuyos */}
         <circle className="fvo-fly" cx="100" cy="272" r="1.7" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 4px #d8ff6a)' }} />
         <circle className="fvo-fly fvo-f2" cx="210" cy="258" r="1.5" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px #2dffc4)' }} />
         <circle className="fvo-fly fvo-f3" cx="172" cy="300" r="1.4" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 4px #ff4fd8)' }} />
         <circle className="fvo-fly fvo-f4" cx="248" cy="318" r="1.6" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 4px #d8ff6a)' }} />
         <circle className="fvo-fly fvo-f5" cx="30" cy="290" r="1.4" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 4px #4fd8ff)' }} />
+        <circle className="fvo-fly fvo-f2" style={{ animationDelay: '-6s, -1.8s', filter: 'drop-shadow(0 0 4px #d8ff6a)' }} cx="140" cy="264" r="1.3" fill="#d8ff6a" />
+        <circle className="fvo-fly fvo-f3" style={{ animationDelay: '-2.4s, -1.1s', filter: 'drop-shadow(0 0 4px #ff8fe4)' }} cx="356" cy="304" r="1.4" fill="#ff8fe4" />
       </g>
 
       {/* niebla de páramo */}
@@ -685,9 +909,18 @@ export default function SceneFincaOrganismo({ estructura }) {
       <circle className="fvo-spark fvo-p5" r="1.9" fill="#ff9ee8" />
       <circle className="fvo-spark fvo-p6" r="2.2" fill="#bfffe9" />
 
+      {/* el pocito se FILTRA: el agua alimenta la red micorrízica (gotea al
+          bulbo más cercano — la quebrada también es parte del organismo) */}
+      <g aria-hidden="true">
+        <path className="fvo-hypha fvo-slow" d="M20,336 C26,342 32,346 38,348" fill="none" stroke="#4fd8ff" strokeWidth=".9" opacity=".5" />
+        <g stroke="#4fd8ff" strokeWidth=".8" strokeLinecap="round" opacity=".35">
+          <path d="M10,338 L9,344" /><path d="M18,339 L17.4,346" /><path d="M27,338 L26.4,343" />
+        </g>
+      </g>
+
       {/* hongos bioluminiscentes en el borde del corte */}
       <g>
-        <g transform="translate(22,336)">
+        <g transform="translate(58,336)">
           <path d="M0,0 L0,-7" stroke="#9fd4ff" strokeWidth="2" strokeLinecap="round" opacity=".8" />
           <path className="fvo-cap" d="M-7,-6 A7,4.6 0 0 1 7,-6 Z" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 6px #4fd8ff)' }} />
           <path d="M4,0 L4,-5" stroke="#9fd4ff" strokeWidth="1.6" strokeLinecap="round" opacity=".7" />
@@ -713,5 +946,58 @@ export default function SceneFincaOrganismo({ estructura }) {
         <text x="195" y="464" fill="#5b7f93" textAnchor="middle" letterSpacing="1">la red micorrízica conecta cada planta</text>
       </g>
     </svg>
+  );
+}
+
+/**
+ * GallinaLuz — gallina criolla bioluminiscente del potrero. Picotea con el
+ * ritmo de su clase (`fvo-gallina` + variante) — la animación vive en
+ * scene-finca-organismo.css. Coordenadas locales: el (0,0) es el piso bajo
+ * el cuerpo; mira a la DERECHA salvo `espejo` (que también invierte el
+ * sentido del picoteo vía la clase `fvo-ga-esp`).
+ *
+ * @param {Object} props
+ * @param {number} props.x posición (viewBox) del piso bajo la gallina.
+ * @param {number} props.y ídem.
+ * @param {string} props.cuerpo color del plumaje.
+ * @param {string} props.cola color de la cola/ala (más oscuro).
+ * @param {string} [props.clase] variante de ritmo (fvo-ga2 / fvo-ga3).
+ * @param {boolean} [props.espejo] mirar a la izquierda.
+ */
+function GallinaLuz({ x, y, cuerpo, cola, clase = '', espejo = false }) {
+  return (
+    /* el translate vive en su PROPIO <g>: la animación CSS (transform) del
+       picoteo PISARÍA el atributo transform si compartieran elemento y la
+       gallina se iría al origen del SVG (bug real de la 1.ª pasada). */
+    <g transform={`translate(${x},${y})`} aria-hidden="true">
+      <ellipse cx="0" cy=".6" rx="4.2" ry="1" fill="#000" opacity=".3" />
+      <g className={`fvo-gallina ${clase}${espejo ? ' fvo-ga-esp' : ''}`.trim()}>
+        <g transform={espejo ? 'scale(-1,1)' : undefined}>
+          {/* patas */}
+          <g stroke="#d8ff6a" strokeWidth=".9" strokeLinecap="round" opacity=".9">
+            <path d="M-1.2,-2.2 L-1.4,0" /><path d="M1.4,-2.2 L1.6,0" />
+          </g>
+          {/* cola */}
+          <path d="M-4.2,-6.5 Q-7.6,-9.5 -6.6,-12 Q-3.6,-10 -3.2,-7 Z" fill={cola} />
+          {/* cuerpo */}
+          <path
+            d="M-4.8,-5.5 C-4.6,-8.6 -1.6,-10.2 1.2,-9.6 C4.4,-9 5.6,-6.4 4.4,-4 C3.2,-1.8 -1.2,-1.4 -3.4,-3 C-4.4,-3.8 -4.9,-4.5 -4.8,-5.5 Z"
+            fill={cuerpo}
+            stroke="#eafff6"
+            strokeWidth=".4"
+            strokeOpacity=".3"
+          />
+          {/* ala */}
+          <path d="M-2.8,-6 Q-.4,-8 2,-6.2 Q-.2,-4.6 -2.8,-6 Z" fill={cola} opacity=".85" />
+          {/* cabeza con cresta neón */}
+          <circle cx="4.6" cy="-10.6" r="2.2" fill={cuerpo} />
+          <path d="M3.6,-12.6 Q3.9,-14.4 5.2,-14 Q5.6,-12.6 4.9,-12.2 Z" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 2px #ff4fd8)' }} />
+          <path d="M6.7,-10.8 L9,-10 L6.7,-9.4 Z" fill="#ffd76a" />
+          <circle cx="5.9" cy="-9" r=".7" fill="#ff4fd8" opacity=".8" />
+          <circle cx="5.2" cy="-11" r=".55" fill="#0a0618" />
+          <circle cx="5.4" cy="-11.2" r=".2" fill="#eafff6" />
+        </g>
+      </g>
+    </g>
   );
 }

--- a/src/components/dashboard/SceneFincaOrganismo.jsx
+++ b/src/components/dashboard/SceneFincaOrganismo.jsx
@@ -39,10 +39,15 @@
  *   gallinas) navega al mundo de los animales. `null`/ausente = el perfil no
  *   ve ese mundo (gate `mostrarAnimales` del home) y el potrero queda
  *   decorativo, sin rol ni foco.
+ * @param {?() => void} [props.onPregunte] al tocar el CORAZÓN-SEMILLA abre el
+ *   agente ("Pregunte"): la metáfora central de la escena deja de ser
+ *   decoración y se vuelve LA acción principal (usabilidad campesina #4).
+ *   Sin handler, el corazón queda como arte (sin rol ni foco).
  */
-export default function SceneFincaOrganismo({ estructura, onAnimales }) {
+export default function SceneFincaOrganismo({ estructura, onAnimales, onPregunte }) {
   const conEstructura = !!estructura?.tiene;
   const conAnimales = typeof onAnimales === 'function';
+  const conPregunte = typeof onPregunte === 'function';
   const ariaEscena =
     'Su finca convertida en organismo bioluminiscente, con el sol o la luna según la hora y el cielo real de su vereda: un corazón-semilla late bajo la tierra y su red de micorrizas conecta las raíces de cada planta, con lombrices y bichitos trabajando el suelo; una quebrada baja de la montaña, cultivos con savia de neón, invernadero-célula que respira, potrero con vaca y gallinas, campesino con su perro y colibrí de luz.';
   return (
@@ -50,10 +55,10 @@ export default function SceneFincaOrganismo({ estructura, onAnimales }) {
       className="fvo-svg"
       viewBox="0 0 390 486"
       preserveAspectRatio="xMidYMid slice"
-      /* con el potrero tappable el SVG deja de ser imagen plana: role="img"
-         volvería PRESENTACIONALES a sus hijos y el botón de los animales no
-         existiría para lectores de pantalla. */
-      role={conAnimales ? 'group' : 'img'}
+      /* con el potrero y/o el corazón tappables el SVG deja de ser imagen
+         plana: role="img" volvería PRESENTACIONALES a sus hijos y los botones
+         (animales y "Pregunte") no existirían para lectores de pantalla. */
+      role={conAnimales || conPregunte ? 'group' : 'img'}
       aria-label={ariaEscena}
       data-testid="fvo-escena"
     >
@@ -862,10 +867,36 @@ export default function SceneFincaOrganismo({ estructura, onAnimales }) {
         <path d="M327.6,445.4 Q326,444 325.2,442.6" stroke="#d8ff6a" strokeWidth=".7" fill="none" opacity=".8" />
       </g>
 
-      {/* ============ CORAZÓN-SEMILLA MICORRÍZICO (la vida bajo la tierra) ============ */}
+      {/* ============ CORAZÓN-SEMILLA MICORRÍZICO (la vida bajo la tierra) ============
+          Con `onPregunte` el corazón entero es un BOTÓN (tap / Enter / Espacio)
+          que abre el agente — el mismo patrón del potrero→animales: la metáfora
+          central deja de ser decoración y pasa a ser LA acción de preguntar.
+          Sin handler queda como arte (aria-hidden, sin foco). */}
+      <g
+        className={`fvo-corazon-grupo${conPregunte ? ' fvo-corazon-tap' : ''}`}
+        data-testid="fvo-corazon"
+        {...(conPregunte
+          ? {
+              role: 'button',
+              tabIndex: 0,
+              'aria-label': 'El corazón de su finca: toque y pregúntele a Chagra con su voz.',
+              onClick: () => onPregunte(),
+              onKeyDown: (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onPregunte();
+                }
+              },
+            }
+          : { 'aria-hidden': true })}
+      >
       {/* cámara de suelo: da contexto y contraste al órgano */}
       <ellipse cx="195" cy="406" rx="42" ry="36" fill="#02040c" opacity=".55" />
       <ellipse cx="195" cy="406" rx="42" ry="36" fill="none" stroke="#0f3a30" strokeWidth="1" opacity=".55" />
+      {/* halo-invitación del tap (solo cuando el corazón es botón) */}
+      {conPregunte && (
+        <circle className="fvo-corazon-halo" cx="195" cy="406" r="32" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".5" />
+      )}
       {/* ondas de latido */}
       <circle className="fvo-heart-wave" cx="195" cy="406" r="24" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
       <circle className="fvo-heart-wave" style={{ animationDelay: '.6s' }} cx="195" cy="406" r="24" fill="none" stroke="#ff4fd8" strokeWidth="1" />
@@ -899,6 +930,8 @@ export default function SceneFincaOrganismo({ estructura, onAnimales }) {
         <circle cx="195" cy="407" r="9.5" fill="#bfffe9" opacity=".3" />
         <circle cx="195" cy="407" r="5.2" fill="#eafff6" />
         <circle cx="195" cy="407" r="2.2" fill="#ff8fe4" />
+      </g>
+      {/* cierre del grupo tappable del corazón (la etiqueta va aparte, abajo) */}
       </g>
 
       {/* nutrientes viajando */}
@@ -940,10 +973,13 @@ export default function SceneFincaOrganismo({ estructura, onAnimales }) {
         </g>
       </g>
 
-      {/* etiqueta viva */}
-      <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity=".65">
+      {/* etiqueta viva — con el corazón tappable invita a la acción (y deja
+          la jerga de laboratorio: "micorrízica" no es palabra del campo) */}
+      <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity=".65" aria-hidden="true">
         <text x="195" y="452" fill="#2dffc4" textAnchor="middle">CORAZÓN DE LA FINCA · VIVO</text>
-        <text x="195" y="464" fill="#5b7f93" textAnchor="middle" letterSpacing="1">la red micorrízica conecta cada planta</text>
+        <text x="195" y="464" fill="#5b7f93" textAnchor="middle" letterSpacing="1">
+          {conPregunte ? 'toque el corazón y pregúntele a Chagra' : 'las raíces de su finca están conectadas'}
+        </text>
       </g>
     </svg>
   );

--- a/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, cleanup, waitFor, within } from '@testing-library/react';
+import { render, screen, cleanup, waitFor, within, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -101,8 +101,11 @@ describe('DashboardLive — operador/extensionista ve los mundos (aditivo, no re
     expect(screen.getByTestId('finca-viva-hero').getAttribute('data-titulo'))
       .toBe('Red de fincas que acompaño');
 
-    // Y la hoja .fvh-resto NO se oculta: la grilla de mundos está presente.
+    // Y la hoja .fvh-resto NO se oculta: el bloque de mundos está presente.
+    // Desde la usabilidad campesina #5 los mundos arrancan PLEGADOS ("Toda mi
+    // finca"): un toque abre la grilla completa (reachability intacta).
     const bloque = screen.getByTestId('bloque-mundos');
+    fireEvent.click(within(bloque).getByTestId('abrir-mundos'));
     expect(within(bloque).getByTestId('mundos-finca')).toBeInTheDocument();
     // La hoja completa se renderiza (antes era null para el extensionista).
     expect(screen.getByTestId('fvh-resto')).toBeInTheDocument();

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -145,9 +145,22 @@ describe('Home F2 — reestructuración 2.0 "Los mundos de mi finca" (V4)', () =
     expect(ancla).toBe(block);
   });
 
-  test('LOS MUNDOS: la grilla monta los 9 mundos con su copy', async () => {
+  test('LOS MUNDOS arrancan PLEGADOS tras "Toda mi finca" (usabilidad #5) y un toque los abre completos', async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
     const block = await screen.findByTestId('bloque-mundos');
+    // Plegados por defecto: el primer pantallazo son las 6 puertas del hero,
+    // no ~13 tarjetas + ~35 chips. La grilla NO está montada aún.
+    expect(within(block).queryByTestId('mundos-finca')).toBeNull();
+    const abrir = within(block).getByTestId('abrir-mundos');
+    expect(abrir).toBeInTheDocument();
+    fireEvent.click(abrir); // un solo toque: reachability intacta
+    expect(within(block).getByTestId('mundos-finca')).toBeInTheDocument();
+  });
+
+  test('LOS MUNDOS: la grilla (abierta) monta los 9 mundos con su copy', async () => {
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    const block = await screen.findByTestId('bloque-mundos');
+    fireEvent.click(within(block).getByTestId('abrir-mundos'));
     expect(within(block).getByTestId('mundos-finca')).toBeInTheDocument();
     for (const id of ['cultivos', 'suelo', 'agua', 'abono', 'sanidad', 'clima', 'animales', 'mercado', 'disenio']) {
       expect(within(block).getByTestId(`mundo-${id}`)).toBeInTheDocument();
@@ -160,7 +173,8 @@ describe('Home F2 — reestructuración 2.0 "Los mundos de mi finca" (V4)', () =
   test('mundos con pantalla propia navegan a la ruta mundo; los directos a su vista', async () => {
     const onNavigate = vi.fn();
     render(<DashboardLive onNavigate={onNavigate} />);
-    await screen.findByTestId('bloque-mundos');
+    const block = await screen.findByTestId('bloque-mundos');
+    fireEvent.click(within(block).getByTestId('abrir-mundos'));
 
     // Cultivos tiene PORTADA a medida (hub) → navega a su vista propia.
     fireEvent.click(screen.getByTestId('mundo-cultivos'));

--- a/src/components/dashboard/__tests__/FincaVivaHero.portales.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaHero.portales.test.jsx
@@ -3,12 +3,16 @@ import { render, screen, fireEvent, cleanup, within } from '@testing-library/rea
 import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Home F2 "Finca Viva" — los 4 portales del hero deben llevar a SU destino:
-//   · Mi finca  → la GESTIÓN de la finca (registros/acciones), NO el juego.
-//                 (bug: iba a onNavigate('juego'), igual que el portal "Jugar".)
-//   · Aprender  → la vista 'aprende'.
-//   · Jugar     → la vista 'juego' (ese SÍ es el juego).
-//   · Pregúntele a Chagra → abre el agente (onOpenAgent).
+// Home F2 "Finca Viva" — LAS 6 PUERTAS del hero (usabilidad campesina #5,
+// fold del mockup #/mockups/home-campesino) deben llevar a SU destino, que YA
+// existe en App.jsx:
+//   · Mis matas     → 'mundo_cultivos' (portada del mundo Cultivos).
+//   · Mis animales  → 'mundo' + { mundo: 'animales' } (gate por perfil).
+//   · El tiempo     → 'hoy_finca'.
+//   · Vender        → 'mercado'.
+//   · Aprender      → 'aprende'.
+//   · Toda mi finca → onTodaMiFinca (revela LOS MUNDOS en la hoja de abajo);
+//                     sin callback, scroll directo al ancla #bloque-mundos.
 // Y el resto del shell F2 (chip de ubicación, pastilla de ayuda, pastilla de
 // perfil) debe navegar a su ruta, sin botones muertos.
 
@@ -18,7 +22,10 @@ vi.mock('../../../db/farmProcessCache', () => ({ listFarmProcesses: vi.fn(async 
 vi.mock('../../../store/useAssetStore', () => ({
   default: (selector) => selector({ plants: [], lands: [], materials: [], isHydrated: true }),
 }));
-vi.mock('../../../services/userProfileService', () => ({ getProfile: () => ({ rol: 'campesino' }) }));
+vi.mock('../../../services/userProfileService', () => ({
+  getProfile: () => ({ rol: 'campesino' }),
+  hasManualModuleVisibility: () => false,
+}));
 vi.mock('../../../config/glaciarAccess', () => ({
   tieneAccesoGlaciarActual: () => false,
   esOperadorActual: () => false,
@@ -32,113 +39,148 @@ vi.mock('../../NotificationsBell', () => ({
 
 import FincaVivaHero from '../FincaVivaHero';
 
-const portalLabel = (el) => el.getAttribute('aria-label')?.split(':')[0];
+const puertaLabel = (el) => el.getAttribute('aria-label')?.split(':')[0];
 
 afterEach(() => cleanup());
 beforeEach(() => vi.clearAllMocks());
 
-describe('FincaVivaHero — los 4 portales llevan a su destino correcto', () => {
+describe('FincaVivaHero — las 6 puertas llevan a su destino correcto', () => {
   function renderHero(extra = {}) {
     const onNavigate = vi.fn();
     const onOpenAgent = vi.fn();
-    const onGestionar = vi.fn();
+    const onTodaMiFinca = vi.fn();
     render(
       <FincaVivaHero
         onNavigate={onNavigate}
         onOpenAgent={onOpenAgent}
-        onGestionar={onGestionar}
+        onTodaMiFinca={onTodaMiFinca}
         {...extra}
       />,
     );
-    return { onNavigate, onOpenAgent, onGestionar };
+    return { onNavigate, onOpenAgent, onTodaMiFinca };
   }
 
-  const getPortal = (nombre) => {
-    const nav = screen.getByTestId('finca-viva-portales');
+  const getPuerta = (nombre) => {
+    const nav = screen.getByTestId('finca-viva-puertas');
     return within(nav)
       .getAllByRole('button')
-      .find((b) => portalLabel(b) === nombre);
+      .find((b) => puertaLabel(b) === nombre);
   };
 
-  test('el portal "Mi finca" NO navega al juego', () => {
+  test('se renderizan las 6 puertas, de 1-2 palabras', () => {
+    renderHero();
+    const nav = screen.getByTestId('finca-viva-puertas');
+    const puertas = within(nav).getAllByRole('button');
+    expect(puertas).toHaveLength(6);
+    expect(puertas.map(puertaLabel)).toEqual([
+      'Mis matas', 'Mis animales', 'El tiempo', 'Vender', 'Aprender', 'Toda mi finca',
+    ]);
+  });
+
+  test('"Mis matas" abre la portada del mundo Cultivos', () => {
     const { onNavigate } = renderHero();
-    fireEvent.click(getPortal('Mi finca'));
-    expect(onNavigate).not.toHaveBeenCalledWith('juego');
+    fireEvent.click(getPuerta('Mis matas'));
+    expect(onNavigate).toHaveBeenCalledWith('mundo_cultivos');
   });
 
-  test('el portal "Mi finca" abre la GESTIÓN de la finca (onGestionar), no otra vista', () => {
-    const { onNavigate, onOpenAgent, onGestionar } = renderHero();
-    fireEvent.click(getPortal('Mi finca'));
-    expect(onGestionar).toHaveBeenCalledTimes(1);
-    // No se cuela a ninguna otra ruta ni al agente.
+  test('"Mis animales" abre el mundo Animales', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPuerta('Mis animales'));
+    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'animales' });
+  });
+
+  test('"El tiempo" abre su día en la finca (hoy_finca)', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPuerta('El tiempo'));
+    expect(onNavigate).toHaveBeenCalledWith('hoy_finca');
+  });
+
+  test('"Vender" abre el mercado', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPuerta('Vender'));
+    expect(onNavigate).toHaveBeenCalledWith('mercado');
+  });
+
+  test('"Aprender" abre las lecciones (aprende)', () => {
+    const { onNavigate } = renderHero();
+    fireEvent.click(getPuerta('Aprender'));
+    expect(onNavigate).toHaveBeenCalledWith('aprende');
+  });
+
+  test('"Toda mi finca" revela LOS MUNDOS (onTodaMiFinca), no navega a otra vista', () => {
+    const { onNavigate, onTodaMiFinca } = renderHero();
+    fireEvent.click(getPuerta('Toda mi finca'));
+    expect(onTodaMiFinca).toHaveBeenCalledTimes(1);
     expect(onNavigate).not.toHaveBeenCalled();
-    expect(onOpenAgent).not.toHaveBeenCalled();
   });
 
-  test('sin onGestionar, "Mi finca" hace scroll al ancla #finca-gestion (no al juego)', () => {
+  test('sin onTodaMiFinca, "Toda mi finca" hace scroll al ancla #bloque-mundos', () => {
     const onNavigate = vi.fn();
     const seccion = document.createElement('div');
-    seccion.id = 'finca-gestion';
+    seccion.id = 'bloque-mundos';
     seccion.scrollIntoView = vi.fn();
     document.body.appendChild(seccion);
 
     render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
-    fireEvent.click(getPortal('Mi finca'));
+    fireEvent.click(getPuerta('Toda mi finca'));
 
     expect(seccion.scrollIntoView).toHaveBeenCalledTimes(1);
-    expect(onNavigate).not.toHaveBeenCalledWith('juego');
+    expect(onNavigate).not.toHaveBeenCalled();
     document.body.removeChild(seccion);
   });
 
-  test('el portal "Aprender" navega a la vista aprende', () => {
-    const { onNavigate } = renderHero();
-    fireEvent.click(getPortal('Aprender'));
-    expect(onNavigate).toHaveBeenCalledWith('aprende');
-  });
-
-  test('el portal "Jugar" SÍ navega al juego', () => {
-    const { onNavigate } = renderHero();
-    fireEvent.click(getPortal('Jugar'));
-    expect(onNavigate).toHaveBeenCalledWith('juego');
-  });
-
-  test('el portal "Pregúntele a Chagra" abre el agente (onOpenAgent), no navega a una vista', () => {
+  test('el botón dominante "Pregunte" (compositor) abre el agente', () => {
     const { onNavigate, onOpenAgent } = renderHero();
-    fireEvent.click(getPortal('Pregúntele a Chagra'));
+    fireEvent.click(screen.getByTestId('finca-viva-agent-fab'));
     expect(onOpenAgent).toHaveBeenCalledTimes(1);
     expect(onNavigate).not.toHaveBeenCalled();
   });
+});
 
-  test('cada portal mapea a un destino distinto (Mi finca ≠ Jugar)', () => {
-    const { onNavigate, onOpenAgent, onGestionar } = renderHero();
-    fireEvent.click(getPortal('Mi finca'));
-    fireEvent.click(getPortal('Jugar'));
-    // Mi finca fue a la gestión; Jugar al juego. No coinciden.
-    expect(onGestionar).toHaveBeenCalledTimes(1);
-    expect(onNavigate).toHaveBeenCalledWith('juego');
-    expect(onNavigate).not.toHaveBeenCalledWith('gestionar');
-    expect(onOpenAgent).not.toHaveBeenCalled();
+describe('FincaVivaHero — Escuchar (🔊) y Pleno sol (☀️)', () => {
+  test('el botón Escuchar existe y lee la pantalla con el TTS propio (kokoro)', async () => {
+    const onNavigate = vi.fn();
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
+    const btn = screen.getByTestId('fvh-escuchar');
+    expect(btn).toBeInTheDocument();
+    // El TTS se importa perezoso al primer toque; aquí basta con que el toque
+    // no reviente sin backend de audio (jsdom sin speechSynthesis).
+    fireEvent.click(btn);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  test('el toggle Pleno sol alterna la variante de alto contraste (data-plenosol)', () => {
+    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} />);
+    const hero = screen.getByTestId('finca-viva-hero');
+    const toggle = screen.getByTestId('fvh-pleno-sol');
+    const antes = hero.getAttribute('data-plenosol');
+    fireEvent.click(toggle);
+    const despues = hero.getAttribute('data-plenosol');
+    expect(despues).not.toBe(antes);
+    // Alterna de vuelta (override manual persistido, no se queda pegado).
+    fireEvent.click(toggle);
+    expect(hero.getAttribute('data-plenosol')).toBe(antes);
   });
 });
 
 describe('FincaVivaHero — barra superior sin botones muertos', () => {
   test('la pastilla de Ayuda navega a la vista ayuda (no era un botón muerto)', () => {
     const onNavigate = vi.fn();
-    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: 'Ayuda' }));
     expect(onNavigate).toHaveBeenCalledWith('ayuda');
   });
 
   test('la pastilla de Perfil navega a la vista perfil', () => {
     const onNavigate = vi.fn();
-    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
     // feedback operador #2: el acceso a PERFIL debe existir junto al "?".
     fireEvent.click(screen.getByRole('button', { name: 'Mi perfil' }));
     expect(onNavigate).toHaveBeenCalledWith('perfil');
   });
 
   test('el botón de Perfil está presente en el topbar junto al de Ayuda (no se pierde)', () => {
-    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} onGestionar={vi.fn()} />);
+    render(<FincaVivaHero onNavigate={vi.fn()} onOpenAgent={vi.fn()} />);
     const ayuda = screen.getByRole('button', { name: 'Ayuda' });
     const perfil = screen.getByTestId('finca-viva-perfil');
     expect(perfil).toBeInTheDocument();
@@ -150,9 +192,9 @@ describe('FincaVivaHero — barra superior sin botones muertos', () => {
   test('regresión 2026-07-04: agente(A) + campana + ayuda + perfil COEXISTEN en el header', () => {
     const onNavigate = vi.fn();
     const onOpenAgent = vi.fn();
-    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={onOpenAgent} onGestionar={vi.fn()} />);
-    // La A de marca ES el botón del agente (en biopunk la A invoca al agente),
-    // NO el perfil — son botones distintos y ambos deben estar.
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={onOpenAgent} />);
+    // La A de marca ES el botón del agente (en biopunk la A de la mano de
+    // Chagra invoca al agente), NO el perfil — son botones distintos.
     const agenteA = screen.getByTestId('fvh-brand-agente');
     fireEvent.click(agenteA);
     expect(onOpenAgent).toHaveBeenCalledTimes(1);

--- a/src/components/dashboard/__tests__/FincaVivaResto.noSolapa.test.jsx
+++ b/src/components/dashboard/__tests__/FincaVivaResto.noSolapa.test.jsx
@@ -120,21 +120,21 @@ beforeEach(() => vi.clearAllMocks());
 // (necesita los 4 portales reales) — el import() dinámico del componente real
 // (2000+ líneas) tarda más que el default de testing-library (1000ms) en el
 // pipeline de transform de vitest, sobre todo bajo carga del host.
-describe('Bug 2 · DOM — hero F2: 4 portales visibles + hoja "resto" separada', () => {
-  test('renderiza los 4 portales del hero (ninguno queda sin montar)', { retry: 2 }, async () => {
+describe('Bug 2 · DOM — hero F2: 6 puertas visibles + hoja "resto" separada', () => {
+  test('renderiza las 6 puertas del hero (ninguna queda sin montar)', { retry: 2 }, async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const nav = await screen.findByTestId('finca-viva-portales', {}, { timeout: 15000 });
-    const portales = within(nav).getAllByRole('button');
-    expect(portales).toHaveLength(4);
-    const labels = portales.map((b) => b.getAttribute('aria-label')?.split(':')[0]);
-    // Copy campesino vigente (#1883/#1884): "Mi finca" (gestión), "Aprender",
-    // "Jugar", "Pregúntele a Chagra" (agente). Antes eran Gestionar/Agente.
-    expect(labels).toEqual(['Mi finca', 'Aprender', 'Jugar', 'Pregúntele a Chagra']);
+    const nav = await screen.findByTestId('finca-viva-puertas', {}, { timeout: 15000 });
+    const puertas = within(nav).getAllByRole('button');
+    expect(puertas).toHaveLength(6);
+    const labels = puertas.map((b) => b.getAttribute('aria-label')?.split(':')[0]);
+    // Usabilidad campesina #5 (2026-07): SEIS puertas de 1-2 palabras
+    // reemplazan los 4 portales con descripción.
+    expect(labels).toEqual(['Mis matas', 'Mis animales', 'El tiempo', 'Vender', 'Aprender', 'Toda mi finca']);
   });
 
-  test('la hoja "resto" NO contiene los portales (superficies separadas)', { retry: 2 }, async () => {
+  test('la hoja "resto" NO contiene las puertas (superficies separadas)', { retry: 2 }, async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const nav = await screen.findByTestId('finca-viva-portales', {}, { timeout: 15000 });
+    const nav = await screen.findByTestId('finca-viva-puertas', {}, { timeout: 15000 });
     // La hoja "resto" se reorganizó en bloques (#1883/#1884); su contenedor es
     // .fvh-resto (data-testid estable), ya no el título "El resto de su finca".
     const hoja = screen.getByTestId('fvh-resto');
@@ -144,9 +144,9 @@ describe('Bug 2 · DOM — hero F2: 4 portales visibles + hoja "resto" separada'
     expect(hoja.contains(nav)).toBe(false);
   });
 
-  test('en orden de documento, los portales van ANTES de la hoja "resto"', { retry: 2 }, async () => {
+  test('en orden de documento, las puertas van ANTES de la hoja "resto"', { retry: 2 }, async () => {
     render(<DashboardLive onNavigate={vi.fn()} />);
-    const nav = await screen.findByTestId('finca-viva-portales', {}, { timeout: 15000 });
+    const nav = await screen.findByTestId('finca-viva-puertas', {}, { timeout: 15000 });
     const tit = screen.getByTestId('fvh-resto');
     await waitFor(() => expect(nav).toBeInTheDocument());
     // compareDocumentPosition: nav precede a tit → DOCUMENT_POSITION_FOLLOWING.

--- a/src/components/dashboard/__tests__/SceneFincaOrganismo.animales.test.jsx
+++ b/src/components/dashboard/__tests__/SceneFincaOrganismo.animales.test.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Escena "Finca Organismo" — POTRERO (vaca + 3 gallinas) como ENTRADA VIVA al
+// mundo de los animales (2026-07). Contrato:
+//   · con `onAnimales` → el potrero es un BOTÓN accesible (tap + Enter/Espacio)
+//     y el SVG raíz deja de ser role="img" (que volvería presentacionales a
+//     sus hijos y borraría el botón del árbol de accesibilidad).
+//   · sin `onAnimales` (gate por perfil del home) → arte decorativo: sin rol,
+//     sin foco, aria-hidden.
+//   · cableado en FincaVivaHero: tocar el potrero navega al MISMO destino que
+//     la tarjeta del mundo en el home → onNavigate('mundo', { mundo: 'animales' }).
+
+import SceneFincaOrganismo from '../SceneFincaOrganismo';
+
+afterEach(() => cleanup());
+
+describe('SceneFincaOrganismo — potrero vaca + gallinas (entrada al mundo animales)', () => {
+  test('con onAnimales: el potrero es un botón y el tap navega', () => {
+    const onAnimales = vi.fn();
+    render(<SceneFincaOrganismo onAnimales={onAnimales} />);
+
+    const potrero = screen.getByTestId('fvo-animales');
+    expect(potrero).toHaveAttribute('role', 'button');
+    expect(potrero).toHaveAttribute('tabindex', '0');
+    expect(potrero).toHaveAttribute('aria-label', expect.stringMatching(/mundo de los animales/i));
+
+    fireEvent.click(potrero);
+    expect(onAnimales).toHaveBeenCalledTimes(1);
+  });
+
+  test('con onAnimales: Enter y Espacio también entran (accesible por teclado)', () => {
+    const onAnimales = vi.fn();
+    render(<SceneFincaOrganismo onAnimales={onAnimales} />);
+
+    const potrero = screen.getByTestId('fvo-animales');
+    fireEvent.keyDown(potrero, { key: 'Enter' });
+    fireEvent.keyDown(potrero, { key: ' ' });
+    expect(onAnimales).toHaveBeenCalledTimes(2);
+    // Teclas ajenas NO navegan.
+    fireEvent.keyDown(potrero, { key: 'Escape' });
+    expect(onAnimales).toHaveBeenCalledTimes(2);
+  });
+
+  test('con onAnimales: el SVG raíz NO es role="img" (los hijos de una imagen son presentacionales)', () => {
+    render(<SceneFincaOrganismo onAnimales={vi.fn()} />);
+    expect(screen.getByTestId('fvo-escena')).toHaveAttribute('role', 'group');
+  });
+
+  test('sin onAnimales (gate por perfil): el potrero queda decorativo y la escena sigue siendo imagen', () => {
+    render(<SceneFincaOrganismo />);
+
+    const potrero = screen.getByTestId('fvo-animales');
+    expect(potrero).not.toHaveAttribute('role');
+    expect(potrero).not.toHaveAttribute('tabindex');
+    expect(potrero).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('fvo-escena')).toHaveAttribute('role', 'img');
+  });
+
+  test('la vaca y las 3 gallinas están dibujadas dentro del potrero', () => {
+    const { container } = render(<SceneFincaOrganismo />);
+    const potrero = container.querySelector('[data-testid="fvo-animales"]');
+    expect(potrero.querySelector('.fvo-vaca')).not.toBeNull();
+    expect(potrero.querySelectorAll('.fvo-gallina')).toHaveLength(3);
+  });
+});
+
+// ── Cableado en el home (FincaVivaHero, tema default biopunk2) ──────────────
+
+// Escena determinista: finca sin procesos ni plantas (patrón de
+// FincaVivaHero.estructura.test.jsx).
+vi.mock('../../../db/farmProcessCache', () => ({ listFarmProcesses: vi.fn(async () => []) }));
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [], lands: [], materials: [], isHydrated: true }),
+}));
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => false,
+}));
+
+let perfilMock = {};
+vi.mock('../../../services/userProfileService', async (importOriginal) => {
+  const real = /** @type {typeof import('../../../services/userProfileService')} */ (await importOriginal());
+  return {
+    ...real,
+    getProfile: () => perfilMock,
+    saveProfile: vi.fn(),
+  };
+});
+
+import FincaVivaHero from '../FincaVivaHero';
+
+describe('FincaVivaHero — el potrero navega al mundo de los animales', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    perfilMock = { rol: 'campesino', finca_tipo: 'rural' };
+  });
+
+  test('tocar la vaca + gallinas → onNavigate("mundo", { mundo: "animales" }) — el MISMO destino que la tarjeta del home', () => {
+    const onNavigate = vi.fn();
+    render(<FincaVivaHero onNavigate={onNavigate} onOpenAgent={vi.fn()} />);
+
+    const potrero = screen.getByTestId('fvo-animales');
+    expect(potrero).toHaveAttribute('role', 'button');
+    fireEvent.click(potrero);
+    expect(onNavigate).toHaveBeenCalledWith('mundo', { mundo: 'animales' });
+  });
+});

--- a/src/components/dashboard/__tests__/SceneFincaOrganismo.corazon.test.jsx
+++ b/src/components/dashboard/__tests__/SceneFincaOrganismo.corazon.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+import SceneFincaOrganismo from '../SceneFincaOrganismo';
+
+/**
+ * El CORAZÓN-SEMILLA de la Finca Organismo = botón "Pregunte" (usabilidad
+ * campesina #4): con `onPregunte` el corazón es tappable (tap / Enter /
+ * Espacio) y abre el agente — el MISMO patrón del potrero→animales. Sin
+ * handler queda como arte (sin rol ni foco) y el SVG vuelve a ser imagen.
+ */
+
+afterEach(() => cleanup());
+
+describe('SceneFincaOrganismo — el corazón de la escena abre el agente', () => {
+  test('con onPregunte, el corazón es un botón enfocable que dispara al tocarlo', () => {
+    const onPregunte = vi.fn();
+    render(<SceneFincaOrganismo onPregunte={onPregunte} />);
+    const corazon = screen.getByTestId('fvo-corazon');
+    expect(corazon).toHaveAttribute('role', 'button');
+    expect(corazon).toHaveAttribute('tabindex', '0');
+    fireEvent.click(corazon);
+    expect(onPregunte).toHaveBeenCalledTimes(1);
+  });
+
+  test('el corazón responde a Enter y Espacio (accesible por teclado)', () => {
+    const onPregunte = vi.fn();
+    render(<SceneFincaOrganismo onPregunte={onPregunte} />);
+    const corazon = screen.getByTestId('fvo-corazon');
+    fireEvent.keyDown(corazon, { key: 'Enter' });
+    fireEvent.keyDown(corazon, { key: ' ' });
+    expect(onPregunte).toHaveBeenCalledTimes(2);
+  });
+
+  test('con el corazón tappable el SVG deja de ser imagen plana (role=group)', () => {
+    render(<SceneFincaOrganismo onPregunte={vi.fn()} />);
+    expect(screen.getByTestId('fvo-escena')).toHaveAttribute('role', 'group');
+  });
+
+  test('sin onPregunte, el corazón queda decorativo y el SVG es imagen', () => {
+    render(<SceneFincaOrganismo />);
+    expect(screen.getByTestId('fvo-escena')).toHaveAttribute('role', 'img');
+    const corazon = screen.getByTestId('fvo-corazon');
+    expect(corazon).not.toHaveAttribute('role');
+    expect(corazon).not.toHaveAttribute('tabindex');
+    expect(corazon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('la etiqueta invita a preguntar (sin jerga de laboratorio)', () => {
+    render(<SceneFincaOrganismo onPregunte={vi.fn()} />);
+    expect(screen.getByTestId('fvo-escena')).toHaveTextContent('toque el corazón y pregúntele a Chagra');
+    expect(screen.getByTestId('fvo-escena')).not.toHaveTextContent('micorrízica');
+  });
+});

--- a/src/components/dashboard/finca-viva-hero.css
+++ b/src/components/dashboard/finca-viva-hero.css
@@ -1276,3 +1276,186 @@ html[data-theme="biopunk"] .fvh {
 /* Sin velo/veladura genérica (::after) — duplicaba brillos/tramas sobre la
    atmósfera propia de cada escena (aurora neón, rayo dorado, rocío, papel). */
 .fvh .fvh-escena-wrap--viva::after { opacity: 0; }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   USABILIDAD CAMPESINA (fold del mockup #/mockups/home-campesino, 2026-07)
+   ──────────────────────────────────────────────────────────────────────────
+   · "PREGUNTE" dominante: el compositor pasa de barra de texto a BOTÓN GRANDE
+     (≥96px) que late como el corazón de la escena.
+   · Pastillas "Escuchar" (🔊 TTS) y "Pleno sol" (alto contraste mediodía).
+   · LAS 6 PUERTAS: 1-2 palabras, dibujo grande, targets ≥96px.
+   · Variante [data-plenosol="1"]: claro de ALTO contraste para el rayo del
+     sol (el biopunk nocturno va bien de noche; a mediodía no se ve).
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* ── El botón dominante "Pregunte" ── */
+.fvh-composer.fvh-composer--pregunte {
+  min-height: 96px;
+  gap: 16px;
+  padding: 14px 18px;
+  border-radius: 26px;
+  background: linear-gradient(135deg, var(--fvh-lima), #8fd62e);
+  box-shadow: 0 16px 34px rgba(40, 60, 40, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.25) inset;
+}
+.fvh-corazon-btn {
+  position: relative;
+  flex: 0 0 auto;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 50% 40%, rgba(255, 255, 255, 0.6), transparent 60%), var(--fvh-lima-claro);
+  border: 3px solid #12260a;
+}
+.fvh-corazon-pulso {
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  border: 2px solid #12260a;
+  opacity: 0;
+  animation: fvh-corazon-late 2.4s ease-out infinite;
+}
+.fvh-corazon-pulso2 { animation-delay: 1.2s; }
+@keyframes fvh-corazon-late {
+  0% { transform: scale(1); opacity: 0.5; }
+  70%, 100% { transform: scale(1.5); opacity: 0; }
+}
+.fvh-pregunte-txt { display: flex; flex-direction: column; gap: 2px; min-width: 0; color: #12260a; }
+.fvh-pregunte-txt b {
+  font-family: var(--fvh-display);
+  font-size: 25px;
+  line-height: 1.05;
+  letter-spacing: 0.2px;
+}
+.fvh-pregunte-txt small { font-size: 14.5px; font-weight: 800; opacity: 0.9; }
+
+/* ── Pastillas Escuchar + Pleno sol ── */
+.fvh-audio-sol {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: 10px 4px 0;
+}
+.fvh-escuchar,
+.fvh-sol-toggle {
+  min-height: 48px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 2px solid var(--fvh-pill-border);
+  background: var(--fvh-pill-bg);
+  color: var(--fvh-pill-ink);
+  font: 800 15px/1 var(--fvh-body);
+  cursor: pointer;
+}
+.fvh-escuchar[aria-pressed="true"] { border-color: var(--fvh-lima); }
+.fvh-escuchar:active,
+.fvh-sol-toggle:active { transform: scale(0.97); }
+
+/* ── LAS 6 PUERTAS ── */
+.fvh-puertas {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  padding: 0 16px;
+}
+@media (min-width: 720px) { .fvh-puertas { grid-template-columns: repeat(3, 1fr); } }
+.fvh-puerta {
+  min-height: 112px;
+  border-radius: 22px;
+  border: 2px solid var(--fvh-p-borde, var(--fvh-card-border));
+  background: var(--fvh-card-bg);
+  color: var(--fvh-card-tinta);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 12px 8px;
+  box-shadow: 0 10px 24px rgba(20, 30, 20, 0.25);
+  animation: fvh-puerta-brota 0.5s ease-out both;
+}
+.fvh-puerta:active { transform: scale(0.97); }
+.fvh-puerta:focus-visible { outline: 3px solid var(--fvh-lima); outline-offset: 2px; }
+.fvh-puerta-emoji { font-size: 40px; line-height: 1; }
+.fvh-puerta-nombre {
+  font-family: var(--fvh-display);
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1.1;
+  text-align: center;
+}
+@keyframes fvh-puerta-brota {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+/* tinte por puerta: solo el borde, para no volver arcoíris el home */
+.fvh-puerta.t-verde { --fvh-p-borde: rgba(132, 204, 22, 0.6); }
+.fvh-puerta.t-teja { --fvh-p-borde: rgba(234, 88, 12, 0.6); }
+.fvh-puerta.t-cielo { --fvh-p-borde: rgba(56, 189, 248, 0.6); }
+.fvh-puerta.t-ambar { --fvh-p-borde: rgba(245, 158, 11, 0.65); }
+.fvh-puerta.t-uva { --fvh-p-borde: rgba(167, 139, 250, 0.6); }
+.fvh-puerta.t-menta { --fvh-p-borde: rgba(45, 212, 191, 0.6); }
+
+/* ── VARIANTE "PLENO SOL" (alto contraste de mediodía) ─────────────────────
+   Redefine los tokens del hero a un papel claro con tinta oscura dura. Va al
+   FINAL del archivo y con especificidad doblada para ganarle a las pieles por
+   tema (html[data-theme] .fvh). La hoja .fvh-resto ya es clara de por sí. */
+html .fvh.fvh.fvh[data-plenosol="1"] {
+  --fvh-cielo-a: #eaf4fb;
+  --fvh-cielo-b: #f5f2e3;
+  --fvh-tinta: #1c2a1a;
+  --fvh-tinta-suave: #44543f;
+  /* la tinta "sobre el cielo" tambien pasa a oscura de contraste duro */
+  --fvh-on-cielo: #1c2a1a;
+  --fvh-on-cielo-suave: #33472a;
+  --fvh-on-cielo-acento: #3f6212;
+  --fvh-on-cielo-sombra: 0 1px 2px rgba(255, 255, 255, 0.55);
+  --fvh-on-cielo-div: linear-gradient(90deg, rgba(63, 98, 18, 0.5), transparent);
+  --fvh-verde-1: #3f6212;
+  --fvh-sello: #365314;
+  --fvh-lima: #4d7c0f;
+  --fvh-lima-claro: #d9f99d;
+  --fvh-card-bg: #fffdf4;
+  --fvh-card-border: rgba(28, 42, 26, 0.35);
+  --fvh-card-tinta: #1c2a1a;
+  --fvh-card-tinta-suave: #44543f;
+  --fvh-pill-bg: #fffdf4;
+  --fvh-pill-border: rgba(28, 42, 26, 0.35);
+  --fvh-pill-ink: #1c2a1a;
+}
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-composer--pregunte {
+  background: linear-gradient(135deg, #65a30d, #4d7c0f);
+  box-shadow: 0 10px 22px rgba(28, 42, 26, 0.25);
+}
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-pregunte-txt { color: #f7fee7; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-corazon-btn { background: #d9f99d; border-color: #1f3300; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-corazon-pulso { border-color: #1f3300; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-brand-txt b,
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-brand-txt span { color: #1c2a1a; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-hero-saludo h1,
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-hero-saludo p { color: #1c2a1a; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-hero-saludo h1 em { color: #3f6212; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-portales-tit { color: #1c2a1a; }
+/* la escena nocturna se enmarca como tarjeta (arte de noche sobre papel claro) */
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-escena-wrap--viva {
+  border-radius: 20px;
+  box-shadow: 0 8px 20px rgba(28, 42, 26, 0.18);
+}
+/* tintes de puerta con contraste duro a pleno sol */
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-verde { --fvh-p-borde: #4d7c0f; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-teja { --fvh-p-borde: #c2410c; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-cielo { --fvh-p-borde: #0369a1; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-ambar { --fvh-p-borde: #b45309; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-uva { --fvh-p-borde: #6d28d9; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta.t-menta { --fvh-p-borde: #0f766e; }
+html .fvh.fvh.fvh[data-plenosol="1"] .fvh-puerta { box-shadow: 0 6px 16px rgba(28, 42, 26, 0.14); }
+
+@media (prefers-reduced-motion: reduce) {
+  .fvh-corazon-pulso { animation: none; opacity: 0; }
+  .fvh-puerta { animation: none; }
+  .fvh-puerta:active,
+  .fvh-escuchar:active,
+  .fvh-sol-toggle:active { transform: none; }
+}

--- a/src/components/dashboard/mundos-finca.css
+++ b/src/components/dashboard/mundos-finca.css
@@ -177,16 +177,20 @@
 .mf-chip {
   font-size: 11.5px;
   font-weight: 700;
-  line-height: 1;
-  padding: 4px 7px;
-  border-radius: 999px;
+  /* Fix chips truncados (usabilidad campesina #3): antes nowrap + overflow
+     hidden cortaba las etiquetas largas a media palabra en móvil
+     ("Almacenamiento y conse…"). Ahora la etiqueta ENVUELVE dentro de la
+     pastilla — se lee completa siempre. */
+  line-height: 1.2;
+  padding: 4px 8px;
+  border-radius: 12px;
   background: var(--mf-b, #eef3e2);
   border: 1px solid color-mix(in srgb, var(--mf-a, #3f8f4e) 35%, transparent);
   color: var(--mf-tinta);
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: break-word;
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  text-align: left;
 }
 .mf-chip--mas,
 .mf-chip--entrar {

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -123,7 +123,9 @@ export const MUNDOS_FINCA = [
         id: 'citricos',
         titulo: 'Los cítricos',
         emoji: '🍊',
-        lema: 'Naranja, mandarina, limón y lima: variedad e injerto, piso térmico, plagas y HLB, y cosecha',
+        // Sin siglas de ingeniero en el home (#1): HLB se nombra como lo conoce
+        // el campo — "el dragón amarillo" (la pantalla del mundo ya lo explica).
+        lema: 'Naranja, mandarina, limón y lima: variedad e injerto, piso térmico, plagas como el dragón amarillo, y cosecha',
         tinte: ['#c9791f', '#f7e6c8'],
         // Mundo de una sola pantalla (photo-forward, 5 estaciones del ciclo
         // cítrico). Profundización dedicada del frutal cítrico que refuerza el

--- a/src/components/dashboard/scene-finca-organismo.css
+++ b/src/components/dashboard/scene-finca-organismo.css
@@ -349,3 +349,30 @@
   .fvo-micelio { opacity: 0.38; }
   .fvo-nodo { opacity: 0.85; }
 }
+
+/* ── CORAZÓN TAPPABLE = "PREGUNTE" (usabilidad campesina #4) ───────────────
+   Cuando FincaVivaHero pasa onPregunte, el corazón-semilla es un botón que
+   abre el agente. Cursor, foco visible para teclado y un halo-invitación que
+   respira (se apaga con prefers-reduced-motion, quedando el halo fijo). */
+.fvo-corazon-tap {
+  cursor: pointer;
+  outline: none;
+}
+.fvo-corazon-tap:focus-visible ellipse:first-of-type {
+  stroke: #eafff6;
+  stroke-width: 2;
+  opacity: 0.9;
+}
+.fvo-corazon-tap:active .fvo-heart { opacity: 0.85; }
+.fvo-corazon-halo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-corazon-invita 2.4s ease-out infinite;
+}
+@keyframes fvo-corazon-invita {
+  0% { transform: scale(0.8); opacity: 0.55; }
+  70%, 100% { transform: scale(1.35); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fvo-corazon-halo { animation: none !important; opacity: 0.4; }
+}

--- a/src/components/dashboard/scene-finca-organismo.css
+++ b/src/components/dashboard/scene-finca-organismo.css
@@ -327,6 +327,170 @@
   94% { transform: translate(-5px, 0); }
 }
 
+/* ── QUEBRADA: el agua corre, cae en cascaditas y ondea en el pocito ───────
+   La corriente es el mismo truco de las hifas (dash que corre); los destellos
+   de cascada titilan; el remanso emite ondas concéntricas. Todo dash/opacity/
+   transform — nada de filtros animados. */
+.fvo-agua { stroke-dasharray: 8 5; animation: fvo-aguaflow 1.9s linear infinite; }
+.fvo-agua.fvo-a2 { stroke-dasharray: 4 8; animation-duration: 2.7s; animation-delay: -0.8s; }
+@keyframes fvo-aguaflow { to { stroke-dashoffset: -52; } }
+
+.fvo-destello { animation: fvo-tw 2.6s ease-in-out infinite; }
+
+.fvo-onda {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-onda 4.2s ease-out infinite;
+}
+
+.fvo-onda.fvo-on2 { animation-delay: -2.1s; }
+
+@keyframes fvo-onda {
+  0% { transform: scale(0.3); opacity: 0.8; }
+  70%, 100% { transform: scale(1.7); opacity: 0; }
+}
+
+.fvo-reflejo { animation: fvo-reflejo 5s ease-in-out infinite; }
+@keyframes fvo-reflejo { 0%, 100% { opacity: 0.25; } 50% { opacity: 0.6; } }
+
+/* ── RAYO DEL ASTRO: la luz cae en diagonal y respira ── */
+.fvo-rayo { animation: fvo-rayo 9s ease-in-out infinite; }
+@keyframes fvo-rayo { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
+
+/* ── POTRERO: LA VACA ──────────────────────────────────────────────────────
+   Respira con la panza (scaleY desde el vientre), pasta de a ratos (la
+   cabeza baja y vuelve), espanta con la cola y las manchas bioluminiscentes
+   laten con el MISMO pulso var(--fvo-beat) de la red — la vaca es parte del
+   organismo, no un sticker encima. */
+.fvo-vaca-cuerpo {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: fvo-vacabreathe 3.8s ease-in-out infinite;
+}
+
+@keyframes fvo-vacabreathe {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.04); }
+}
+
+.fvo-vaca-cabeza {
+  transform-box: fill-box;
+  transform-origin: 92% 42%;
+  animation: fvo-vacapasta 11s ease-in-out infinite;
+}
+
+@keyframes fvo-vacapasta {
+  0%, 36%, 100% { transform: rotate(0deg); }
+  44%, 66% { transform: rotate(13deg); }
+  52% { transform: rotate(11deg); }
+  76% { transform: rotate(-2deg); }
+  84% { transform: rotate(0deg); }
+}
+
+.fvo-vaca-cola {
+  transform-box: fill-box;
+  transform-origin: 20% 6%;
+  animation: fvo-vacacola 6.5s ease-in-out infinite;
+}
+
+@keyframes fvo-vacacola {
+  0%, 52%, 100% { transform: rotate(0deg); }
+  60% { transform: rotate(18deg); }
+  70% { transform: rotate(-12deg); }
+  80% { transform: rotate(9deg); }
+  88% { transform: rotate(0deg); }
+}
+
+.fvo-vaca-oreja {
+  transform-box: fill-box;
+  transform-origin: 10% 90%;
+  animation: fvo-vacaoreja 7s ease-in-out infinite;
+}
+
+@keyframes fvo-vacaoreja {
+  0%, 78%, 100% { transform: rotate(0deg); }
+  84% { transform: rotate(-16deg); }
+  90% { transform: rotate(4deg); }
+}
+
+/* manchas de la vaca: laten con el corazón de la finca */
+.fvo-mancha { animation: fvo-mancha var(--fvo-beat) ease-in-out infinite; }
+.fvo-mancha.fvo-m2 { animation-delay: 0.3s; }
+.fvo-mancha.fvo-m3 { animation-delay: 0.6s; }
+@keyframes fvo-mancha { 0%, 100% { opacity: 0.45; } 8% { opacity: 1; } 16% { opacity: 0.6; } 24% { opacity: 0.85; } 36% { opacity: 0.45; } }
+
+/* ── POTRERO: LAS GALLINAS pican el pasto (doble picoteo con pausa; cada
+   una a su ritmo). La espejada (mira a la izquierda) picotea al revés. */
+.fvo-gallina {
+  transform-box: fill-box;
+  transform-origin: 64% 100%;
+  animation: fvo-picoteo 3.6s ease-in-out infinite;
+}
+
+.fvo-gallina.fvo-ga2 { animation-duration: 4.4s; animation-delay: -1.3s; }
+.fvo-gallina.fvo-ga3 { animation-duration: 3.1s; animation-delay: -2.2s; }
+
+@keyframes fvo-picoteo {
+  0%, 34%, 100% { transform: rotate(0deg); }
+  40% { transform: rotate(24deg); }
+  46% { transform: rotate(5deg); }
+  52% { transform: rotate(26deg); }
+  58% { transform: rotate(0deg); }
+}
+
+.fvo-gallina.fvo-ga-esp {
+  transform-origin: 36% 100%;
+  animation-name: fvo-picoteo-esp;
+}
+
+@keyframes fvo-picoteo-esp {
+  0%, 34%, 100% { transform: rotate(0deg); }
+  40% { transform: rotate(-24deg); }
+  46% { transform: rotate(-5deg); }
+  52% { transform: rotate(-26deg); }
+  58% { transform: rotate(0deg); }
+}
+
+/* ── POTRERO como PUERTA al mundo de los animales ──────────────────────────
+   Con data-tap el grupo es un botón: cursor, halo-invitación que emana cada
+   6s, etiqueta que respira y anillo de foco accesible (:focus-visible). */
+.fvo-animales[data-tap='1'] { cursor: pointer; outline: none; }
+
+.fvo-cta-halo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-ctahalo 6s ease-out infinite;
+  opacity: 0;
+}
+
+@keyframes fvo-ctahalo {
+  0%, 55% { transform: scale(0.55); opacity: 0; }
+  62% { opacity: 0.7; }
+  100% { transform: scale(1.12); opacity: 0; }
+}
+
+.fvo-cta-tag { animation: fvo-ctatag 6s ease-in-out infinite; }
+@keyframes fvo-ctatag { 0%, 100% { opacity: 0.55; } 60% { opacity: 1; } }
+
+.fvo-animales[data-tap='1']:focus-visible .fvo-cta-anillo { opacity: 1; }
+.fvo-animales[data-tap='1']:hover .fvo-cta-tag { opacity: 1; animation: none; }
+
+/* ── polillas del farol (revolotean cortico y titilan) ── */
+.fvo-polilla {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-polilla 3.4s ease-in-out infinite alternate, fvo-blink 1.7s ease-in-out infinite;
+}
+
+.fvo-polilla.fvo-po2 { animation-duration: 2.6s, 2.3s; animation-delay: -1.3s, -0.6s; }
+
+@keyframes fvo-polilla {
+  from { transform: translate(0, 0); }
+  33% { transform: translate(-4px, -5px); }
+  66% { transform: translate(3px, -2px); }
+  to { transform: translate(-2px, 3px); }
+}
+
 /* ── reduced motion: estado estático DIGNO (como el mockup) ────────────────
    El apagado global de animaciones ya lo hace finca-viva-hero.css
    (`.fvh * { animation: none !important }`); aquí se compone la foto fija:
@@ -348,4 +512,16 @@
   /* la vida del suelo queda quieta pero visible (foto fija digna) */
   .fvo-micelio { opacity: 0.38; }
   .fvo-nodo { opacity: 0.85; }
+  /* la quebrada queda llena (sin dash), el remanso quieto y brillante */
+  .fvo-agua { stroke-dasharray: none; }
+  .fvo-onda { opacity: 0; }
+  .fvo-reflejo { opacity: 0.5; }
+  .fvo-destello { opacity: 0.7; }
+  .fvo-rayo { opacity: 0.7; }
+  /* el potrero posa: vaca erguida, manchas encendidas, gallinas de pie;
+     la invitación al mundo animales queda como etiqueta fija visible */
+  .fvo-mancha { opacity: 0.85; }
+  .fvo-cta-halo { opacity: 0; }
+  .fvo-cta-tag { opacity: 0.9; }
+  .fvo-polilla { opacity: 0.7; }
 }

--- a/src/components/dashboard/scene-finca-organismo.css
+++ b/src/components/dashboard/scene-finca-organismo.css
@@ -525,3 +525,30 @@
   .fvo-cta-tag { opacity: 0.9; }
   .fvo-polilla { opacity: 0.7; }
 }
+
+/* ── CORAZÓN TAPPABLE = "PREGUNTE" (usabilidad campesina #4) ───────────────
+   Cuando FincaVivaHero pasa onPregunte, el corazón-semilla es un botón que
+   abre el agente. Cursor, foco visible para teclado y un halo-invitación que
+   respira (se apaga con prefers-reduced-motion, quedando el halo fijo). */
+.fvo-corazon-tap {
+  cursor: pointer;
+  outline: none;
+}
+.fvo-corazon-tap:focus-visible ellipse:first-of-type {
+  stroke: #eafff6;
+  stroke-width: 2;
+  opacity: 0.9;
+}
+.fvo-corazon-tap:active .fvo-heart { opacity: 0.85; }
+.fvo-corazon-halo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-corazon-invita 2.4s ease-out infinite;
+}
+@keyframes fvo-corazon-invita {
+  0% { transform: scale(0.8); opacity: 0.55; }
+  70%, 100% { transform: scale(1.35); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fvo-corazon-halo { animation: none !important; opacity: 0.4; }
+}

--- a/tests/e2e-ciclo-completo.spec.js
+++ b/tests/e2e-ciclo-completo.spec.js
@@ -185,9 +185,9 @@ test.describe('Ciclo completo del cultivo (offline-first)', () => {
     await page.getByRole('textbox', { name: /contraseña/i }).fill('e2e-pass');
     await page.getByRole('button', { name: /ingresar/i }).click();
 
-    // Dashboard cargado: el dashboard en vivo muestra "Cola de tareas"
+    // Dashboard cargado: el dashboard en vivo muestra "Tareas pendientes"
     // en su pie. (No hay OnboardingHero en DashboardLive.)
-    await expect(page.getByText('Cola de tareas')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('Tareas pendientes')).toBeVisible({ timeout: 15_000 });
 
     // ─── Paso 1: Navegar a Sembrar ──────────────────────────────
     // Vía el evento de navegación interno del app (ver nota 1 del header).

--- a/tests/entrega-hoy-dura.spec.js
+++ b/tests/entrega-hoy-dura.spec.js
@@ -393,7 +393,7 @@ async function login(page, user) {
   await page.getByRole('textbox', { name: /usuario/i }).fill(user.username);
   await page.locator('input[type="password"]').fill('e2e-pass');
   await page.getByRole('button', { name: /ingresar/i }).click();
-  await expect(page.getByText(/Soy Chagra|Cola de tareas|Mis plantas/i).first()).toBeVisible({ timeout: 25_000 });
+  await expect(page.getByText(/Soy Chagra|Tareas pendientes|Mis plantas/i).first()).toBeVisible({ timeout: 25_000 });
 }
 
 async function navigate(page, view) {

--- a/tests/offline.spec.js
+++ b/tests/offline.spec.js
@@ -101,7 +101,7 @@ test.describe('IDB schema v9 — índice compuesto asset_id+timestamp', () => {
     await page.getByRole('textbox', { name: /contraseña/i }).fill('e2e-pass');
     await page.getByRole('button', { name: /ingresar/i }).click();
 await expect(
-      page.getByText('Cola de tareas')
+      page.getByText('Tareas pendientes')
     ).toBeVisible({ timeout: 15_000 });
 
     const result = await page.evaluate(async () => {
@@ -238,7 +238,7 @@ test.describe('Offline-first — siembra pendiente y reconexión', () => {
 
     // Confirmamos Dashboard cargado.
     await expect(
-      page.getByText('Cola de tareas')
+      page.getByText('Tareas pendientes')
     ).toBeVisible({ timeout: 15_000 });
 
     // Precarga del servicio mientras todavia hay red.

--- a/tests/syncManager-quarantine.spec.js
+++ b/tests/syncManager-quarantine.spec.js
@@ -80,7 +80,7 @@ const loginAndWaitForMain = async (page, context) => {
   await page.getByLabel(/usuario/i).fill('e2e-quarantine-op');
   await page.getByRole('textbox', { name: /contraseña/i }).fill('e2e-quarantine-pass');
   await page.getByRole('button', { name: /ingresar/i }).click();
-  await expect(page.getByText('Cola de tareas')).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText('Tareas pendientes')).toBeVisible({ timeout: 15_000 });
 };
 
 // Helper: insertar una transacción manualmente en `pending_transactions`


### PR DESCRIPTION
## Integración a PROD del home biopunk completo

Une **#2229** (escena biopunk enriquecida + potrero vaca/3 gallinas → mundo animales) y **#2230** (8 mejoras de usabilidad campesina) en una sola entrega, resolviendo por **UNIÓN** los solapes en `SceneFincaOrganismo.jsx` y `FincaVivaHero.jsx`.

### Unión (ambas features conviven)
- **#2229 — potrero → animales**: prop `onAnimales`, el potrero (vaca + gallinas) es tappable y entra al mundo de los animales (gate por perfil `mostrarAnimales`).
- **#2230 — corazón → agente**: prop `onPregunte`, el corazón-semilla abre el agente. Más: 6 puertas, "Escuchar" (TTS), modo "Pleno sol", puerta "Mis animales".
- `SceneFincaOrganismo` acepta **ambos** props; `role` del SVG = `group` si `conAnimales || conPregunte`; aria describe corazón **y** potrero.
- `FincaVivaHero` renderiza `<EscenaViva onAnimales onPregunte />`; el gate `mostrarAnimales` gobierna potrero + puerta "Mis animales".

### Fix de CI (F1 de #2230)
#2230 renombró el header del widget "Cola de tareas" → **"Tareas pendientes"** (usabilidad, sin jerga). Eso rompía el gate `offline.spec.js` (y specs e2e ciclo-completo / syncManager / entrega-hoy) que aserta ese texto como marca de "Dashboard cargado". Se actualizaron las aserciones al texto nuevo.

### Verificación local (worktree off origin/main)
- `npm run build` OK
- Budget: **24.0 MB / 25.5 MB**
- `tsc:check` vs baseline: **1820 ≤ 1829**, sin errores nuevos
- vitest (11 archivos, 71 tests) de los componentes tocados: verde
- Anti-leak: 0

Cierra #2229 y #2230.