### PR TITLE
feat(grounding): curar DRs 2026-07-09 — léxico narinense + plagas cacao/aguacate

### DIFF
--- a/src/components/aguacate/AguacateScreen.jsx
+++ b/src/components/aguacate/AguacateScreen.jsx
@@ -16,6 +16,7 @@ import {
   SUELO_AGUA,
   ASOCIACION_AGUACATE,
   MALES_AGUACATE,
+  MALES_FUENTE,
   BIOPREPARADOS_AGUACATE,
   NOTA_SIN_QUIMICOS,
   FLORACION_POLINIZACION,
@@ -365,6 +366,7 @@ function EstacionSanidad({ onNavigate }) {
       <div className="space-y-2.5" data-testid="aguacate-males">
         {MALES_AGUACATE.map((mal) => <MalCard key={mal.id} mal={mal} />)}
       </div>
+      <p className="text-[10px] leading-snug text-slate-500" data-testid="aguacate-males-fuente">Fuente: {MALES_FUENTE}</p>
 
       {/* Biopreparados groundeados de la especie */}
       <div className="rounded-2xl border border-slate-700/60 bg-[#1a2413]/50 p-4" data-testid="aguacate-biopreparados">

--- a/src/components/cacao/CacaoScreen.jsx
+++ b/src/components/cacao/CacaoScreen.jsx
@@ -22,6 +22,8 @@ import {
   PROPAGACION_CACAO,
   PODAS_CACAO,
   ENFERMEDADES_CACAO,
+  OTRAS_PLAGAS_CACAO,
+  OTRAS_PLAGAS_CACAO_FUENTE,
   CACAO_NO_CONFUNDIR,
   CACAO_NO_CONFUNDIR_FUENTE,
   COSECHA_CACAO,
@@ -436,6 +438,52 @@ function EstacionSanidad() {
       </PedagogicalBlock>
 
       {ENFERMEDADES_CACAO.map((e) => <TarjetaEnfermedad key={e.id} e={e} />)}
+
+      {/* Otras plagas de la mazorca (insectos): barrenador y trips */}
+      <div className="rounded-2xl border border-stone-700/60 bg-stone-900/50 p-4 space-y-3" data-testid="cacao-otras-plagas">
+        <p className="flex items-center gap-2 text-sm font-black text-stone-100 uppercase tracking-wide">
+          <Bug size={16} aria-hidden="true" className="text-amber-300" /> Otras plagas de la mazorca
+        </p>
+        <p className="text-xs leading-snug text-stone-300">Estas no son hongos: son insectos que perforan o raspan el fruto. Se manejan recogiendo y sacando lo dañado, no con veneno.</p>
+        <div className="space-y-2.5">
+          {OTRAS_PLAGAS_CACAO.map((p) => (
+            <div key={p.id} className="rounded-xl border border-stone-700/50 bg-stone-950/40 p-3 space-y-2" data-testid={`otra-plaga-${p.id}`}>
+              <div>
+                <p className="text-xs font-bold text-stone-100 leading-tight">{p.nombre} <span className="italic font-normal text-stone-400">({p.cientifico})</span></p>
+                <p className="text-[11px] leading-snug text-stone-400">{p.tambien} {p.ataca}</p>
+              </div>
+              <ul className="space-y-1">
+                {p.comoSeVe.map((s, i) => (
+                  <li key={i} className="flex gap-1.5 text-[11px] leading-snug text-stone-200">
+                    <span aria-hidden="true" className="text-amber-400">•</span><span className="flex-1 min-w-0">{s}</span>
+                  </li>
+                ))}
+              </ul>
+              {typeof p.umbral === 'string' ? (
+                <p className="inline-flex items-center gap-1.5 rounded-lg border border-amber-600/40 bg-amber-500/15 px-2.5 py-1 text-[11px] font-bold text-amber-200">
+                  <TriangleAlert size={12} aria-hidden="true" className="shrink-0" /> {p.umbral}
+                </p>
+              ) : (
+                <p className="text-[11px] italic text-stone-500">Umbral: dato en camino.</p>
+              )}
+              <div className="rounded-lg border border-emerald-700/40 bg-emerald-950/20 p-2.5">
+                <p className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wide text-emerald-300 mb-1.5">
+                  <ShieldCheck size={12} aria-hidden="true" /> Cómo se maneja (sin veneno)
+                </p>
+                <ul className="space-y-1">
+                  {p.manejo.map((m, i) => (
+                    <li key={i} className="flex gap-1.5 text-[11px] leading-snug text-stone-200">
+                      <span aria-hidden="true" className="text-emerald-400">•</span><span className="flex-1 min-w-0">{m}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <p className="text-[10px] leading-snug text-stone-500">Fuente: {p.fuente}</p>
+            </div>
+          ))}
+        </div>
+        <p className="text-[10px] leading-snug text-stone-500">{OTRAS_PLAGAS_CACAO_FUENTE}</p>
+      </div>
 
       {/* No confundir */}
       <div className="rounded-2xl border border-stone-700/60 bg-stone-900/50 p-4 space-y-3" data-testid="cacao-no-confundir">

--- a/src/data/aguacateFinca.js
+++ b/src/data/aguacateFinca.js
@@ -299,6 +299,15 @@ export const MALES_AGUACATE = [
 ];
 
 /**
+ * Fuente de la sección de plagas — el grafo Chagra da los nodos y el manejo, y
+ * la autoridad publicada es la guía de AGROSAVIA (verificada contra Crossref en
+ * el DR grounding-aguacate-hass-plagas-colombia, 2026-06-19). No añade plagas
+ * fuera del grafo: solo cita la fuente que respalda las que ya están.
+ */
+export const MALES_FUENTE =
+  'Grafo Chagra (persea_americana) + AGROSAVIA — Carabalí Muñoz, Caicedo Vallejo y Holguín (2021), “Guía para el reconocimiento y manejo de las principales plagas de aguacate cv. Hass en Colombia”, DOI 10.21930/agrosavia.nbook.7404913 (verificado Crossref).';
+
+/**
  * Biopreparados de apoyo — GROUNDED: la lista propia de persea_americana en el
  * grafo. Son apoyo agroecológico, no reemplazan el manejo cultural (drenaje,
  * recolección, material sano). No se dan dosis de veneno de síntesis.
@@ -353,7 +362,7 @@ export const FLORACION_POLINIZACION = {
   ],
   abejas: 'Quien lleva el polen de flor a flor son las ABEJAS. Un huerto con colmenas cerca, flores alrededor y sin venenos en plena floración cuaja mucho mejor. Cuidar los polinizadores es cuidar la cosecha.',
   tipoCriolloNota: 'El tipo floral exacto de un criollo local se confirma observando el árbol (a qué hora abre la flor hembra); no se puede afirmar de memoria por variedad.',
-  fuente: 'AGROSAVIA, Universidad Nacional de Colombia (biología floral del aguacate)',
+  fuente: 'AGROSAVIA, Universidad Nacional de Colombia (biología floral del aguacate); polinizadores: Carabalí et al. (2017), “Insectos polinizadores del aguacate cv. Hass en Colombia”, DOI 10.21930/978-958-740-235-3 (verificado Crossref)',
 };
 
 /* ────────────────────────────────────────────────────────────────────────

--- a/src/data/cacaoFinca.js
+++ b/src/data/cacaoFinca.js
@@ -224,6 +224,63 @@ export const ENFERMEDADES_CACAO = [
 ];
 
 /**
+ * Otras plagas de la mazorca — grounding curado del DR
+ * grounding-cacao-plagas-colombia (gemini, 2026-06-19), verificado contra
+ * AGROSAVIA/Crossref. NO son hongos como la monilia: son INSECTOS que perforan
+ * o raspan el fruto. El manejo sigue siendo cultural y sanitario (recolección,
+ * embolsado/solarización, control biológico) — Chagra no da dosis de veneno.
+ *
+ * El barrenador (Carmenta foraseminis) tiene DOI real verificado; el trips
+ * (Selenothrips rubrocinctus) es de menor peso y su cifra fina queda como
+ * "dato en camino".
+ */
+export const OTRAS_PLAGAS_CACAO = [
+  {
+    id: 'barrenador',
+    nombre: 'Barrenador del fruto y la semilla',
+    cientifico: 'Carmenta foraseminis',
+    tambien: 'Perforador de la mazorca (Lepidoptera: Sesiidae).',
+    ataca: 'La larva barrena por dentro la mazorca y daña el grano.',
+    comoSeVe: [
+      'Perforaciones en la cáscara de la mazorca con excretas granuladas afuera (los campesinos le dicen la “peca”).',
+      'Por dentro, granos comidos y dañados: se cae el peso y la calidad del grano comercial.',
+    ],
+    umbral: 'En Antioquia llega a llevarse cerca del 30% del grano comercial, y en lotes descuidados hasta el 50%.',
+    manejo: [
+      'Recoja seguido las mazorcas picadas y sáquelas del cultivo; no deje cacota (residuo de cosecha) regada.',
+      'Embolse o solarice las mazorcas infestadas, o entiérrelas bien: se corta el ciclo de la plaga.',
+      'Trampas McPhail con proteína hidrolizada para monitorear.',
+      'Control biológico con la avispita Trichogramma (parasita los huevos).',
+    ],
+    fuente:
+      'AGROSAVIA — Carabalí Muñoz, Senejoa Lizcano y Montes Prado (2018), “Reconocimiento, daño y opciones de manejo de Carmenta foraseminis…”, DOI 10.21930/agrosavia.manual.7402599 (verificado Crossref).',
+  },
+  {
+    id: 'trips',
+    nombre: 'Trips del cacao',
+    cientifico: 'Selenothrips rubrocinctus',
+    tambien: 'Trips de banda roja.',
+    ataca: 'Raspa y chupa la mazorca y el follaje.',
+    comoSeVe: [
+      'Bronceado o plateado en la cáscara de la mazorca y en las hojas, con puntico oscuro (sus excretas).',
+      'En ataques fuertes la mazorca se mancha y el brote se reseca.',
+    ],
+    umbral: {
+      estado: 'dato en camino',
+      fuentePrevista: 'AGROSAVIA / ICA — umbral de acción del trips en cacao (grounded pendiente)',
+    },
+    manejo: [
+      'Elimine residuos de cosecha infestados; embolse o solarice las mazorcas afectadas.',
+      'Favorezca los enemigos naturales (parasitoides de huevos) manejando bien la sombra y sin venenos que los maten.',
+    ],
+    fuente: 'AGROSAVIA / ICA (manejo fitosanitario del cacao). Confianza media.',
+  },
+];
+
+export const OTRAS_PLAGAS_CACAO_FUENTE =
+  'AGROSAVIA, ICA — DR grounding-cacao-plagas-colombia (2026-06-19), DOIs verificados. El barrenador se maneja recogiendo y sacando lo picado; nada de recetas de veneno.';
+
+/**
  * No confundir — el guard visual del "anti_confusion" del nodo monilia:
  * monilia, escoba de bruja y mazorca negra se manejan distinto, así que primero
  * hay que distinguirlas bien.

--- a/src/data/glosario-regional-narinense.json
+++ b/src/data/glosario-regional-narinense.json
@@ -1,0 +1,23 @@
+{
+  "_meta": {
+    "version": "v1",
+    "fecha": "2026-07-09",
+    "region": "narino",
+    "scope": "español rural del altiplano nariñense andino (papa, cuy, cebada) — nombres folk campesinos que el corpus genérico Chagra y el glosario del Cauca NO cubren. Mapean a un equivalente estándar (nombre científico de la plaga o término técnico) para que el LLM entienda al campesino pastuso y no responda genérico por mismatch léxico.",
+    "metodologia": "Curados del DR lexico-regional-narinense-andino (gemini, grounded, 2026-06-19) cruzado con AGROSAVIA y Fedepapa (Boletín regional Nariño). Solo se guardan términos FOLK que el LLM probablemente malinterpreta o desconoce; se DESCARTAN los nombres propios de cultivar (Diacol Capiro, ICA Única, Pastusa…) porque son enciclopédicos, no folk, y colisionan con el normalizador. Regla dura: ningún valor contiene a su propia clave (idempotencia). Clave lowercase; el matching es case-insensitive con boundaries de palabra.",
+    "como_extender": "Agregar entrada {local: estandar}. Verificar que el valor NO contenga ninguna clave del glosario (si no, el normalizador cascada). NO meter aquí saber tradicional protegido sin permiso (memoria project-oss-pro-boundary-decisions).",
+    "advertencia_jergas": "Algunos términos son polysem ('gota' se EXCLUYE a propósito: choca con 'gota de agua'). El mapeo es la acepción AGRÍCOLA más frecuente en el altiplano nariñense; es best-effort y va gated por región Nariño.",
+    "fuente": "DR lexico-regional-narinense-andino (gemini grounded, 2026-06-19); AGROSAVIA; Fedepapa — Boletín regional Nariño."
+  },
+  "terminos": {
+    "cobayo": "cuy",
+    "cuyera": "galpón de cuyes",
+    "gusano blanco": "Premnotrypes vorax",
+    "pulguilla saltona": "Epitrix",
+    "pulguilla": "Epitrix",
+    "toya": "papa de rebrote",
+    "toyas": "papa de rebrote",
+    "chicha de jora": "atrayente fermentado de maíz",
+    "criolla colombia": "papa criolla"
+  }
+}

--- a/src/services/__tests__/glosarioNarino.test.js
+++ b/src/services/__tests__/glosarioNarino.test.js
@@ -1,0 +1,109 @@
+/**
+ * Tests para el glosario regional del altiplano nariñense (papa/cuy/cebada),
+ * añadido de forma aditiva sobre glosarioCaucaService.
+ *
+ * Verifica que:
+ *   - `isInNarinoRegion` detecta Nariño (departamento/zona) y solo Nariño.
+ *   - Con finca de Nariño, `normalizeUserInput` aplica el glosario nariñense.
+ *   - El Cauca sigue intacto (una finca de Nariño NO recibe términos del Cauca
+ *     y viceversa) y las fincas fuera de región son passthrough.
+ *   - `localizeAgentOutput` hace el reverse en Nariño.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isInNarinoRegion,
+  isInCaucaRegion,
+  normalizeUserInput,
+  localizeAgentOutput,
+  getGlosarioStatsNarino,
+} from '../glosarioCaucaService.js';
+
+describe('glosario narinense — gate de región', () => {
+  it('detecta departamento Nariño (con y sin tilde, case-insensitive)', () => {
+    expect(isInNarinoRegion({ departamento: 'narino' })).toBe(true);
+    expect(isInNarinoRegion({ departamento: 'Nariño' })).toBe(true);
+    expect(isInNarinoRegion({ departamento: 'NARIÑO' })).toBe(true);
+    expect(isInNarinoRegion({ region: 'narino' })).toBe(true);
+  });
+
+  it('detecta zona biocultural narinense', () => {
+    expect(isInNarinoRegion({ biocultural_zone: 'narinense' })).toBe(true);
+    expect(isInNarinoRegion({ biocultural_zone: 'altiplano_narinense' })).toBe(true);
+  });
+
+  it('NO detecta otras regiones ni input inválido', () => {
+    expect(isInNarinoRegion({ departamento: 'cauca' })).toBe(false);
+    expect(isInNarinoRegion({ biocultural_zone: 'valle_caucano' })).toBe(false);
+    expect(isInNarinoRegion(null)).toBe(false);
+    expect(isInNarinoRegion({})).toBe(false);
+    expect(isInNarinoRegion('narino')).toBe(false);
+  });
+
+  it('Nariño y Cauca son mutuamente excluyentes', () => {
+    const nar = { departamento: 'narino' };
+    expect(isInNarinoRegion(nar)).toBe(true);
+    expect(isInCaucaRegion(nar)).toBe(false);
+  });
+});
+
+describe('glosario narinense — normalizeUserInput (forward)', () => {
+  const fincaNarino = { departamento: 'narino' };
+
+  it('mapea folk de plaga a nombre científico', () => {
+    expect(
+      normalizeUserInput('se me metió el gusano blanco a la papa', { finca: fincaNarino })
+    ).toBe('se me metió el Premnotrypes vorax a la papa');
+  });
+
+  it('mapea cobayo → cuy', () => {
+    expect(normalizeUserInput('crío cobayo', { finca: fincaNarino })).toBe('crío cuy');
+  });
+
+  it('mapea el cultivar folk criolla colombia → papa criolla', () => {
+    expect(normalizeUserInput('sembré criolla colombia', { finca: fincaNarino })).toBe(
+      'sembré papa criolla'
+    );
+  });
+
+  it('respeta case-insensitive (término más largo gana)', () => {
+    expect(
+      normalizeUserInput('PULGUILLA SALTONA en el lote', { finca: fincaNarino })
+    ).toBe('Epitrix en el lote');
+  });
+
+  it('NO aplica el glosario del Cauca a una finca de Nariño', () => {
+    // "papa runa" es término del Cauca; en Nariño debe quedar intacto.
+    const t = 'tengo papa runa';
+    expect(normalizeUserInput(t, { finca: fincaNarino })).toBe(t);
+  });
+
+  it('passthrough cuando la finca no es de Nariño ni Cauca', () => {
+    const t = 'crío cobayo';
+    expect(normalizeUserInput(t, { finca: { departamento: 'antioquia' } })).toBe(t);
+  });
+
+  it('es idempotente', () => {
+    const once = normalizeUserInput('crío cobayo', { finca: fincaNarino });
+    const twice = normalizeUserInput(once, { finca: fincaNarino });
+    expect(twice).toBe(once);
+  });
+});
+
+describe('glosario narinense — localizeAgentOutput (reverse)', () => {
+  it('reemplaza estándar → folk nariñense', () => {
+    const out = localizeAgentOutput('cría de cuy en galpón de cuyes', {
+      finca: { departamento: 'narino' },
+    });
+    expect(out).toContain('cobayo');
+    expect(out).toContain('cuyera');
+  });
+});
+
+describe('glosario narinense — getGlosarioStatsNarino', () => {
+  it('reporta versión y región nariñense', () => {
+    const stats = getGlosarioStatsNarino();
+    expect(stats.version).toBe('v1');
+    expect(stats.region).toBe('narino');
+    expect(stats.totalTerminos).toBeGreaterThan(0);
+  });
+});

--- a/src/services/glosarioCaucaService.js
+++ b/src/services/glosarioCaucaService.js
@@ -1,6 +1,11 @@
 /**
- * glosarioCaucaService.js — normalización léxica regional Cauca para el agente
+ * glosarioCaucaService.js — normalización léxica regional para el agente
  * (Free 7→10 fix-pack #5, memoria project-free-7-10-analysis-2026-05-28 hipótesis #2).
+ *
+ * Region-aware: arrancó con el habla del Cauca (andino/pacífico) y ahora suma,
+ * de forma puramente aditiva, el altiplano nariñense (papa/cuy/cebada). El
+ * dispatcher `pickRegion(finca, force)` elige el glosario por región de la finca
+ * (Nariño → Cauca → ninguno); el contrato previo del Cauca queda intacto.
  *
  * Bug observado: Free (campesino-target Cauca rural) usa términos del habla
  * regional que el LLM no reconoce. Ejemplo: dice "papa runa" en vez de "papa
@@ -27,12 +32,16 @@
  */
 
 import glosario from '../data/glosario-regional-cauca.json' with { type: 'json' };
+import glosarioNarino from '../data/glosario-regional-narinense.json' with { type: 'json' };
 
 const GLOSARIO_TERMINOS = glosario?.terminos || {};
+const GLOSARIO_TERMINOS_NARINO = glosarioNarino?.terminos || {};
 
 // Construido lazy en el primer uso para no penalizar el cold-start.
 let _forwardEntries = null;
 let _reverseEntries = null;
+let _forwardEntriesNarino = null;
+let _reverseEntriesNarino = null;
 
 /**
  * Escapa caracteres regex en una clave para usarla en RegExp segura.
@@ -76,6 +85,48 @@ function getReverseEntries() {
   return _reverseEntries;
 }
 
+/** Forward Nariño (regional → estándar), mismo criterio que el Cauca. */
+function getForwardEntriesNarino() {
+  if (_forwardEntriesNarino === null) {
+    _forwardEntriesNarino = Object.entries(GLOSARIO_TERMINOS_NARINO)
+      .filter(([k, v]) => typeof k === 'string' && typeof v === 'string')
+      .sort((a, b) => b[0].length - a[0].length);
+  }
+  return _forwardEntriesNarino;
+}
+
+/** Reverse Nariño (estándar → regional), primera ocurrencia por estándar. */
+function getReverseEntriesNarino() {
+  if (_reverseEntriesNarino === null) {
+    const reverseMap = {};
+    Object.entries(GLOSARIO_TERMINOS_NARINO).forEach(([local, estandar]) => {
+      if (typeof estandar === 'string' && !(estandar in reverseMap)) {
+        reverseMap[estandar] = local;
+      }
+    });
+    _reverseEntriesNarino = Object.entries(reverseMap)
+      .sort((a, b) => b[0].length - a[0].length);
+  }
+  return _reverseEntriesNarino;
+}
+
+/**
+ * Decide qué glosario regional aplicar para una finca activa.
+ *
+ * Prioridad: Nariño → Cauca → ninguno. Preserva EXACTAMENTE el contrato
+ * previo del Cauca (force y finca===null aplican Cauca; finca fuera de región
+ * conocida = passthrough), y suma Nariño de forma puramente aditiva.
+ *
+ * @returns {'cauca'|'narino'|null}
+ */
+function pickRegion(finca, force) {
+  if (force) return 'cauca';
+  if (finca === null || finca === undefined) return 'cauca';
+  if (isInNarinoRegion(finca)) return 'narino';
+  if (isInCaucaRegion(finca)) return 'cauca';
+  return null;
+}
+
 /**
  * Decide si el glosario regional Cauca debe aplicarse para una finca activa.
  *
@@ -101,6 +152,23 @@ export function isInCaucaRegion(finca) {
 }
 
 /**
+ * Decide si el glosario regional del altiplano nariñense aplica para una
+ * finca activa. Conservador: departamento Nariño o zona biocultural
+ * narinense/altiplano andino. Si no hay info de finca, NO aplica.
+ *
+ * @param {Object|null|undefined} finca
+ * @returns {boolean}
+ */
+export function isInNarinoRegion(finca) {
+  if (!finca || typeof finca !== 'object') return false;
+  const zone = (finca.biocultural_zone || '').toLowerCase();
+  const depto = (finca.departamento || finca.region || '').toLowerCase();
+  if (depto === 'narino' || depto === 'nariño' || depto === 'narino_dpto' || depto === 'nariño_dpto') return true;
+  if (zone === 'narinense' || zone === 'andino_narinense' || zone === 'altiplano_narinense') return true;
+  return false;
+}
+
+/**
  * Normaliza el input del usuario antes de mandarlo al LLM.
  *
  * Reemplaza términos regionales del Cauca por sus equivalentes estándar
@@ -121,10 +189,12 @@ export function isInCaucaRegion(finca) {
 export function normalizeUserInput(text, opts = {}) {
   if (typeof text !== 'string' || text.length === 0) return text;
   const { finca = null, force = false } = opts;
-  if (!force && finca !== null && !isInCaucaRegion(finca)) return text;
+  const region = pickRegion(finca, force);
+  if (region === null) return text;
+  const forwardEntries = region === 'narino' ? getForwardEntriesNarino() : getForwardEntries();
 
   let out = text;
-  for (const [local, estandar] of getForwardEntries()) {
+  for (const [local, estandar] of forwardEntries) {
     // Word boundaries `\b` no funcionan bien con caracteres acentuados en
     // todos los browsers. Usamos look-around manual: precedido por start
     // o non-letter, seguido por end o non-letter.
@@ -156,10 +226,12 @@ export function normalizeUserInput(text, opts = {}) {
 export function localizeAgentOutput(text, opts = {}) {
   if (typeof text !== 'string' || text.length === 0) return text;
   const { finca = null, force = false } = opts;
-  if (!force && finca !== null && !isInCaucaRegion(finca)) return text;
+  const region = pickRegion(finca, force);
+  if (region === null) return text;
+  const reverseEntries = region === 'narino' ? getReverseEntriesNarino() : getReverseEntries();
 
   let out = text;
-  for (const [estandar, local] of getReverseEntries()) {
+  for (const [estandar, local] of reverseEntries) {
     const escaped = escapeRegex(estandar);
     const re = new RegExp(`(^|[^\\p{L}\\p{N}_])${escaped}(?![\\p{L}\\p{N}_])`, 'giu');
     out = out.replace(re, (match, pre) => `${pre}${local}`);
@@ -178,9 +250,20 @@ export function getGlosarioStats() {
   };
 }
 
+/** Contador del glosario regional del altiplano nariñense — tests y debug. */
+export function getGlosarioStatsNarino() {
+  return {
+    version: glosarioNarino?._meta?.version || 'unknown',
+    region: glosarioNarino?._meta?.region || 'unknown',
+    totalTerminos: Object.keys(GLOSARIO_TERMINOS_NARINO).length,
+  };
+}
+
 export default {
   isInCaucaRegion,
+  isInNarinoRegion,
   normalizeUserInput,
   localizeAgentOutput,
   getGlosarioStats,
+  getGlosarioStatsNarino,
 };


### PR DESCRIPTION
## Qué

Curación **verificada** de los DRs frescos (gemini+glm web_search, slug fecha 2026-06-19) en entradas de grounding con `fuente`. Trabajo de juicio: solo se integró lo verificable; DOIs fabricados y tablas rotas se descartaron.

## Grounding curado por tema

- **Léxico regional narinense** → `src/data/glosario-regional-narinense.json` (nuevo): folk pastuso papa/cuy/cebada (cobayo→cuy, gusano blanco→*Premnotrypes vorax*, toya→papa de rebrote, chicha de jora→atrayente, etc.). `glosarioCaucaService` ahora es **region-aware** (dispatcher Nariño→Cauca→ninguno) sin tocar el contrato del Cauca. Test nuevo `glosarioNarino.test.js`.
- **Cacao** → `cacaoFinca.js` `OTRAS_PLAGAS_CACAO`: barrenador **Carmenta foraseminis** (DOI `10.21930/agrosavia.manual.7402599`, Carabalí Muñoz et al. 2018, **verificado Crossref**) + trips **Selenothrips rubrocinctus** (umbral = "dato en camino"). Bloque compacto en CacaoScreen.
- **Aguacate** → `aguacateFinca.js`: fuente verificada de la sección de plagas (guía AGROSAVIA Carabalí 2021, DOI `10.21930/agrosavia.nbook.7404913`) y de polinizadores (Carabalí 2017, DOI `10.21930/978-958-740-235-3`). El archivo es grafo-disciplinado: se **reforzó la fuente**, no se inventaron plagas.

## Fuentes verificadas vs descartadas

- **Verificadas (Crossref, on-topic):** 5 DOIs citados (Carmenta 2018, guía plagas aguacate 2021, polinizadores aguacate 2017, frutales caducifolios Boyacá 2006, regionalización cacao 2022).
- **Descartadas:** DOIs fabricados de las tablas glm (frutales/hortalizas/narinense-glm — p. ej. `10.1016/j.applanim...` es *Applied Animal Behaviour*), errores taxonómicos (glm: *Diatraea*=salivazo — es barrenador; *Cylas formicarius*=gorgojo de papa — es del camote), y listas inventadas (caña glm: CC 93-1..1565).

## DRs sin material útil

- **Léxico llanos** (gemini y glm): sin léxico folk real (gemini = disclaimer de que requiere trabajo etnográfico; glm = contenido genérico mal etiquetado, país "Brasil"). No integrado.
- **Caña panelera**: tabla gemini rota (whitespace) y glm fabricado. Solo quedan DOIs verificados; sin integración segura.
- **Hortalizas / abejas / frutales-caducifolios / plátano**: nombres científicos correctos pero DOIs de tabla fabricados y/o sin archivo destino wireado. Plátano (sigatoka/picudo/moko) es sólido pero no hay `platanoFinca.js` — **deferido** (proponer estructura).

## Gates

- build ✅ · tsc `-p jsconfig.json` = **1818 err ≤ baseline 1829** ✅ · vitest glosarios (150) + pantallas cacao/aguacate (20) ✅ · eslint ✅ · anti-leak grep ✅ · español sin voseo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)