### PR TITLE
fix(temas): legibilidad de los temas claros — título sobre foto, tabs de estaciones, header del agente y Activos (QA visual 2026-07-09)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3504,7 +3504,8 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           44px + gaps + padding sumaban más que el viewport → el título se
           encimaba con los íconos y el avatar pisaba el texto; en 412px el
           subtítulo se clipaba sin gracia. Fix: padding/gap compactos bajo
-          400px, botón Home oculto bajo 360px (Volver sigue presente), avatar
+          400px, botón Home oculto bajo 420px (Volver sigue presente; QA temas
+          2026-07-09: en 390px el Home dejaba el título en "Chag…"), avatar
           shrink-0 y subtítulo con truncate (elipsis, nunca encimado). */}
       <header className="px-2 min-[400px]:px-4 py-3 flex items-center gap-1 min-[400px]:gap-2 border-b border-slate-800 agent-bar-surface shrink-0">
         {/* Back */}
@@ -3520,7 +3521,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         <button
           type="button"
           onClick={() => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'dashboard' }))}
-          className="max-[359px]:hidden p-3 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:bg-emerald-700/60 transition-all text-emerald-400 min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
+          className="max-[419px]:hidden p-3 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:bg-emerald-700/60 transition-all text-emerald-400 min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
           aria-label="Volver al inicio"
           title="Inicio"
         >

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -1645,12 +1645,16 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
   return (
     <div className="h-[100dvh] w-full bg-slate-950 text-slate-100 flex flex-col overflow-hidden">
       {/* Header */}
-      <header className="p-4 bg-slate-950 border-b border-slate-800 flex items-center gap-4 shrink-0 shadow-md">
+      {/* QA temas 2026-07-09: en 390px el título flex-1 no podía encoger (sin
+          min-w-0) y el grupo de acciones empujaba el botón de sincronizar
+          FUERA del borde derecho. Gap/padding compactos en angosto + título
+          truncable + nombre de finca más corto → los 4 controles caben. */}
+      <header className="px-2 py-4 min-[480px]:px-4 bg-slate-950 border-b border-slate-800 flex items-center gap-2 min-[480px]:gap-4 shrink-0 shadow-md">
         <button onClick={/** @type {React.MouseEventHandler<HTMLButtonElement>} */ (onBack)} aria-label="Volver al panel principal" className="p-3 bg-slate-800 rounded-full active:bg-slate-700 min-h-[48px] min-w-[48px] flex justify-center items-center shrink-0">
           <ArrowLeft size={24} aria-hidden="true" />
         </button>
-        <h2 className="text-2xl font-black flex-1">Activos</h2>
-        <div className="flex items-center gap-2">
+        <h2 className="text-xl min-[480px]:text-2xl font-black flex-1 min-w-0 truncate">Activos</h2>
+        <div className="flex items-center gap-1.5 min-[480px]:gap-2 shrink-0">
           {/* Toggle Lista / Mapa (Fase 17.3) */}
           <div className="flex bg-slate-800 rounded-lg p-1">
             <button
@@ -1681,7 +1685,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
             data-testid="assets-finca-switcher"
           >
             <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse group-hover:scale-125 transition-transform"></div>
-            <span className="truncate max-w-[10ch]">{fincaNombre}</span>
+            <span className="truncate max-w-[7ch] min-[480px]:max-w-[10ch]">{fincaNombre}</span>
             {hasMultipleFincas && (
               <ChevronDown size={12} aria-hidden="true" className="-mr-0.5 opacity-80 group-hover:translate-y-0.5 transition-transform" />
             )}
@@ -1810,10 +1814,12 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
       {viewMode === 'list' && activeTab === 'plant' && !currentZoneId && (
         <div className="flex-1">
           {lands.length === 0 && orphanPlants.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-slate-500">
+            <div className="flex flex-col items-center justify-center py-12 px-6 text-center text-slate-500">
+              {/* QA temas 2026-07-09: el empty-state iba pegado al borde (sin
+                  padding lateral ni text-center) y con jerga técnica en tuteo. */}
               <MapPin size={48} className="mb-3 opacity-30" />
               <p className="text-lg">Sin zonas registradas</p>
-              <p className="text-sm mt-1">Crea una zona (asset--land) desde FarmOS o la tab Infraestructura</p>
+              <p className="text-sm mt-1">Cree su primera zona desde la pestaña Infraestructura, o desde farmOS</p>
             </div>
           ) : (
             <Virtuoso

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -636,7 +636,17 @@
 [data-theme="verde-vivo"] .text-amber-200,
 [data-theme="verde-vivo"] .text-amber-300,
 [data-theme="verde-vivo"] .text-amber-400,
-[data-theme="verde-vivo"] .text-amber-500{
+[data-theme="verde-vivo"] .text-amber-500,
+/* Variantes con ALPHA (QA temas 2026-07-09, bug #2): `text-amber-200/90` y
+ * `text-amber-100/90` son clases APARTE que este bloque no cubría → el
+ * subtítulo de la tab activa de los mundos quedaba ámbar pálido sobre
+ * durazno (ilegible en nature/verde-vivo). Mismo ocre oscuro AA. */
+[data-theme="minimalista"] .text-amber-100\/90,
+[data-theme="minimalista"] .text-amber-200\/90,
+[data-theme="nature"] .text-amber-100\/90,
+[data-theme="nature"] .text-amber-200\/90,
+[data-theme="verde-vivo"] .text-amber-100\/90,
+[data-theme="verde-vivo"] .text-amber-200\/90{
   color: rgb(160, 76, 20) !important;
   text-shadow: none !important;
 }
@@ -738,7 +748,17 @@
 [data-theme="verde-vivo"] .text-indigo-300{ color: rgb(55 48 163) !important; text-shadow: none !important; }
 [data-theme="nature"] .text-cyan-200,
 [data-theme="minimalista"] .text-cyan-200,
-[data-theme="verde-vivo"] .text-cyan-200{ color: rgb(21 94 117) !important; text-shadow: none !important; }
+[data-theme="verde-vivo"] .text-cyan-200,
+/* cyan-300 y su variante alpha (QA temas 2026-07-09, bug de Agua): el
+ * subtítulo de la tab activa ("Del techo al tanque…") usa `text-cyan-300/90`
+ * y los titulares de sección `text-cyan-300` — cian claro sin remapear sobre
+ * card clara = ilegible en nature/verde-vivo. Mismo cian profundo AA. */
+[data-theme="nature"] .text-cyan-300,
+[data-theme="minimalista"] .text-cyan-300,
+[data-theme="verde-vivo"] .text-cyan-300,
+[data-theme="nature"] .text-cyan-300\/90,
+[data-theme="minimalista"] .text-cyan-300\/90,
+[data-theme="verde-vivo"] .text-cyan-300\/90{ color: rgb(21 94 117) !important; text-shadow: none !important; }
 [data-theme="nature"] .text-green-300,
 [data-theme="minimalista"] .text-green-300,
 [data-theme="verde-vivo"] .text-green-300{ color: rgb(22 101 52) !important; text-shadow: none !important; }
@@ -832,6 +852,105 @@
 [data-theme="nature"] [class*="bg-white\/"],
 [data-theme="verde-vivo"] [class*="bg-white\/"]{
   background-color: rgb(var(--c-surface-raised) / 0.55) !important;
+}
+
+/* ===========================================================================
+ * §3e. TEXTO SOBRE FOTO (QA temas 2026-07-09, bug #1 — el peor).
+ *    Los mundos "photo-forward" (café/agua/cacao/fique/…) ponen el título del
+ *    héroe SOBRE la foto, protegido por un scrim negro FIJO
+ *    (`bg-gradient-to-t from-black/85 …`, ver FotoCafe/FotoAgua/etc.). Ese
+ *    scrim NO lo vira el remapeo de temas claros, así que ahí la tinta CLARA
+ *    original (blanco/ámbar/cian claro) sigue siendo la correcta — pero los
+ *    remapeos de §3bis/§3d la viraban a tinta oscura → título ilegible sobre
+ *    la foto (medido: "El café, de la semilla a la taza" casi negro sobre
+ *    cerezas en nature/minimalista/verde-vivo).
+ *    CONTEXTO: el scrim siempre es un hermano ANTERIOR del overlay de texto
+ *    (o su contenedor directo, caso SpeciesFicha/SaludSuelo), así que
+ *    `[class*="from-black"]` + `~ *` identifica "estoy sobre una foto" sin
+ *    tocar 20 JSX. Revertimos a los literales Tailwind (paridad exacta con
+ *    biopunk, que el QA validó como "se lee perfecto"). Especificidad (0,3,0)
+ *    > remapeos genéricos (0,2,0). Solo temas claros.
+ * =========================================================================== */
+
+/* Blancos: el título del héroe y sus variantes con alpha vuelven a blanco. */
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-white{ color: #fff !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-white\/70{ color: rgb(255 255 255 / 0.7) !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-white\/60{ color: rgb(255 255 255 / 0.6) !important; }
+
+/* Slate: la rampa está INVERTIDA en claros (slate-100 = tinta oscura) → sobre
+ * el scrim negro quedaba oscuro-sobre-oscuro. Literales Tailwind claros. */
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-100{ color: #f1f5f9 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-100\/95{ color: rgb(241 245 249 / 0.95) !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-200{ color: #e2e8f0 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-300{ color: #cbd5e1 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-300\/90{ color: rgb(203 213 225 / 0.9) !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-400{ color: #94a3b8 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-slate-500{ color: #64748b !important; }
+
+/* Familias de acento que §3bis/§3d viran a tono -700/-800 oscuro (correcto
+ * sobre crema, ilegible sobre el scrim negro): de vuelta al literal claro. */
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-amber-100, .text-amber-100\/90){ color: #fef3c7 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-amber-200, .text-amber-200\/90){ color: #fde68a !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-amber-300{ color: #fcd34d !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-amber-400{ color: #fbbf24 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-emerald-100, .text-emerald-100\/90){ color: #d1fae5 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-emerald-200, .text-emerald-200\/90, .text-emerald-200\/70){ color: #a7f3d0 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-emerald-300{ color: #6ee7b7 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-rose-200{ color: #fecdd3 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-rose-300{ color: #fda4af !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-sky-200{ color: #bae6fd !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) :is(.text-cyan-200, .text-cyan-300, .text-cyan-300\/90){ color: #a5f3fc !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-teal-200{ color: #99f6e4 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-teal-300{ color: #5eead4 !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-orange-200{ color: #fed7aa !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-indigo-200{ color: #c7d2fe !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-red-200{ color: #fecaca !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-violet-200{ color: #ddd6fe !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-green-300{ color: #86efac !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-blue-300{ color: #93c5fd !important; }
+:is([data-theme="minimalista"], [data-theme="nature"], [data-theme="verde-vivo"])
+  :is([class*="from-black"], [class*="from-black"] ~ *) .text-pink-300{ color: #f9a8d4 !important; }
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * §3f. PARDO CAFETERO HARD-CODEADO (QA temas 2026-07-09, bug #2): las cards y
+ * tabs de los mundos Café/Almanaque usan `bg-[#241811]/50|60` (tierra tostada,
+ * fuera de la indirección CSS-var). Sobre la crema de los temas claros quedaba
+ * un pardo sucio que no combina con la tinta remapeada (subtítulos de tabs
+ * invisibles). → superficie de card del tema, como el resto de cards. En
+ * biopunk/biopunk2 (sin remap) el pardo original se conserva. */
+[data-theme="minimalista"] [class*="bg-[#241811]"],
+[data-theme="nature"] [class*="bg-[#241811]"],
+[data-theme="verde-vivo"] [class*="bg-[#241811]"]{
+  background-color: rgb(var(--c-surface-card)) !important;
 }
 
 /* ===========================================================================


### PR DESCRIPTION
## Qué arregla

Los 4 bugs de legibilidad del QA visual de temas (`Chagra-strategy/ops/QA-TEMAS-2026-07-09.md`), verificados EN VIVO con Playwright en los 5 temas (biopunk, biopunk2, nature, minimalista, verde-vivo) × 4 pantallas (home, mundo café, mundo agua, agente, activos).

### 1. Título de mundo ILEGIBLE sobre la foto en temas claros (el peor)
El remapeo de §3bis (`.text-white` → tinta oscura) pisaba los títulos de héroe que van SOBRE la foto con scrim negro fijo (`from-black/85`). Nuevo bloque **§3e** en `src/styles/themes.css`: dentro del contexto foto (`[class*="from-black"]` y sus hermanos posteriores) la tinta clara vuelve a su literal Tailwind (paridad exacta con biopunk, que el QA validó). Cubre white/slate/amber/emerald/cyan/teal/rose/sky/orange/indigo/red/violet/green/blue/pink y variantes con alpha. CSS-only: aplica a TODOS los mundos photo-forward sin tocar 20 JSX.

### 2. Tabs de estaciones con subtítulos invisibles en claros
- **§3f**: el pardo hard-codeado `bg-[#241811]/50|60` (cards/tabs de Café y Almanaque) se remapea a `--c-surface-card` en los 3 temas claros (indirección por tema; biopunk conserva el pardo).
- El remapeo ámbar ahora cubre las variantes con alpha (`text-amber-200/90`, `text-amber-100/90`) → subtítulo de la tab activa legible.
- `text-cyan-300` y `text-cyan-300/90` entran al remapeo cian (tab activa y titulares del mundo Agua).

### 3. Activos: botón de sincronizar cortado + empty-state sin padding
`AssetsDashboard.jsx`: el título `flex-1` sin `min-w-0` no podía encoger y empujaba el botón de sync fuera del borde a 390px → gaps/padding compactos en angosto, título truncable, nombre de finca `max-w-[7ch]` en angosto. Empty-state con `px-6 text-center` y copy en usted sin jerga ("Cree su primera zona desde la pestaña Infraestructura, o desde farmOS").

### 4. Header del agente truncado ("Chag…" / "AGENTE AGROECOLÓ")
`AgentScreen.jsx`: el botón Home (redundante — "Volver" está al lado) se oculta hasta 419px (antes 359px) → a 390px el título "Chagra IA" y el subtítulo "AGENTE AGROECOLÓGICO" caben completos.

## Verificación (en vivo, build de esta rama, 390×844 @2x)

| Pantalla | biopunk | biopunk2 | nature | minimalista | verde-vivo |
|---|---|---|---|---|---|
| Mundo Café (héroe + tabs) | ✅ | ✅ | ✅ | ✅ | ✅ |
| Mundo Agua (tabs + héroe) | ✅ | ✅ | ✅ | ✅ | ✅ |
| Agente (header completo) | ✅ | ✅ | ✅ | ✅ | ✅ |
| Activos (sync + empty-state) | ✅ | ✅ | ✅ | ✅ | ✅ |

Los temas oscuros no cambian (las reglas nuevas solo aplican bajo `[data-theme]` claro; capturas biopunk/biopunk2 idénticas al estado previo).

## Gates
- `check-perf-budget`: 23.9 MB / 25.5 MB ✅
- tsc: 0 errores en archivos del proyecto tocados ✅
- `themes.coverage.test.js`: 24/26 — los 2 fallos (`--fx-particles` en `:root` de index.css) ya fallan en `origin/main` y no tocan estos archivos.

Antes/después enviados por Telegram al operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)