### PR TITLE
feat(mockup): Montaña de los Mundos — navegación como paisaje de pisos térmicos, 3 direcciones artísticas

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,6 +89,10 @@ const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').
 // 2026-06-30. Se alcanza desde 'bodega' vía el botón "Auditoría y
 // reconciliación", o directo por hash (#auditoria-inventario).
 const InventoryPage = lazy(() => import('./pages/InventoryPage'));
+// Mockup dev "La Montaña de los Mundos" (navegación como paisaje vertical de
+// pisos térmicos, 3 direcciones artísticas para decidir dirección visual).
+// Ruta #/mockups/montana-mundos — sin gate ni sesión (datos de muestra).
+const MontanaMundosMockup = lazy(() => import('./mockups/MontanaMundos'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -418,6 +422,7 @@ const LoadingFallback = ({ view = null }) => {
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
 
 const HASH_VIEW_ROUTES = {
+  'mockups/montana-mundos': 'mockup_montana_mundos',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -915,6 +920,13 @@ export default function App() {
       return;
     }
 
+    // Mockups dev (#/mockups/*): vistas aisladas de decisión visual — se
+    // montan sin sesión (datos de muestra, no tocan datos reales).
+    if (hash === 'mockups/montana-mundos') {
+      Promise.resolve().then(() => navigate('mockup_montana_mundos'));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -943,6 +955,11 @@ export default function App() {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
+      // Mockups dev: sin gate ni sesión (datos de muestra).
+      if (routeView === 'mockup_montana_mundos') {
+        navigate(routeView);
+        return;
+      }
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
       if (routeView === 'extensionista' && !esExtensionistaActual()) {
         navigate('dashboard');
@@ -1265,6 +1282,17 @@ export default function App() {
               onConfirm={() => navigate(currentViewData?.next || 'dashboard')}
               onBack={() => navigate(currentViewData?.back || 'dashboard')}
             />
+          </ErrorBoundary>
+        );
+      case 'mockup_montana_mundos':
+        // Mockup dev "La Montaña de los Mundos": navegación como paisaje de
+        // pisos térmicos, 3 direcciones artísticas. Full-screen, sin gate —
+        // solo para decidir dirección visual.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mockup Montaña de los Mundos">
+              <MontanaMundosMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'dashboard':
@@ -2560,7 +2588,7 @@ export default function App() {
           Tampoco en onboarding-perfil (tarea #16): el FAB se encimaba sobre el
           CTA "Explorar con finca de ejemplo" del footer y la usuaria nueva aún
           no conoce al agente — ruido en su primer flujo. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && <AgentFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && !currentView.startsWith('mockup_') && <AgentFab onNavigate={navigate} />}
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o
           pregunta al agente punta a punta por voz.

--- a/src/mockups/MontanaMundos.jsx
+++ b/src/mockups/MontanaMundos.jsx
@@ -1,0 +1,596 @@
+/**
+ * MontanaMundos.jsx — MOCKUP DEV "La Montaña de los Mundos"
+ * (#/mockups/montana-mundos, sin gate ni sesión — datos de muestra).
+ *
+ * La navegación de Chagra como PAISAJE VERTICAL DE PISOS TÉRMICOS — el modelo
+ * mental que el campesino ya usa (café=templado, papa=frío, frailejón=páramo).
+ * Referencia: Sierra Nevada de Santa Marta (del río al nevado en una sola
+ * montaña). Cada altura contiene la entrada a su mundo: el árbol de mango
+ * (cálido) lleva al mundo del mango; el frailejón (páramo) a restauración;
+ * el río al agua; el cafetal (templado) al café. Los mundos que no son
+ * ecosistema viven como OBJETOS de la escena: la casa → el agente, el troje →
+ * la cosecha, el mercado → vender, la luna → el calendario, el corral → los
+ * animales.
+ *
+ * Interacción (decidida con el operador):
+ *   - Abre CENTRADO EN LA FINCA del usuario (su piso térmico resaltado, los
+ *     demás pisos tenues arriba/abajo). Con un gesto (pellizco hacia adentro
+ *     o el botón "Ver toda la montaña") hace zoom-out a la montaña completa.
+ *   - Atajo permanente: el botón Ⓐ del agente + "Anotar mi día" SIEMPRE
+ *     visibles — ninguna tarea queda detrás de escalar la montaña.
+ *   - Afordancia obvia: cada mundo tocable lleva halo que pulsa + etiqueta.
+ *
+ * TRES DIRECCIONES ARTÍSTICAS conmutables (misma montaña, mismos mundos):
+ *   1. Sierra naturalista — pictórica, cálida, luz dorada de montaña.
+ *   2. Biopunk — neón orgánico nocturno, coherente con el home en prod;
+ *      la red viva (micelio) conecta los pisos.
+ *   3. Verde vivo — botánica, luminosa, diurna. El contraste claro.
+ *
+ * Técnica: SVG + CSS puros (cero deps, cero fotos), prefers-reduced-motion
+ * apaga toda la vida de la escena, targets ≥ 48px, español de Colombia
+ * (usted). Los toques muestran "aquí se abre X" (mockup honesto: no navega).
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import './montana-mundos.css';
+
+// ── Geometría de la escena (unidades del viewBox 390×1440) ──────────────────
+const VB_W = 390;
+const VB_H = 1440;
+
+// Pisos térmicos de arriba (nevado) a abajo (río). `y0/y1` = franja en el
+// viewBox; los msnm son los reales del modelo campesino colombiano.
+const PISOS = [
+  { id: 'nevado', nombre: 'Nevado', msnm: '4.800 m', y0: 96, y1: 320 },
+  { id: 'paramo', nombre: 'Páramo', msnm: '3.500 m', y0: 320, y1: 560 },
+  { id: 'frio', nombre: 'Clima frío', msnm: '2.600 m', y0: 560, y1: 800 },
+  { id: 'templado', nombre: 'Clima templado', msnm: '1.700 m', y0: 800, y1: 1060, finca: true },
+  { id: 'calido', nombre: 'Clima cálido', msnm: '800 m', y0: 1060, y1: 1300 },
+  { id: 'rio', nombre: 'El río', msnm: '400 m', y0: 1300, y1: 1440 },
+];
+const PISO_FINCA = PISOS.findIndex((p) => p.finca);
+
+// Mundos tocables: ancla (x,y) en unidades del viewBox, sobre el dibujo del
+// elemento que les da cuerpo en la escena. `abre` = aviso honesto del mockup.
+const MUNDOS = [
+  { id: 'calendario', x: 316, y: 96, piso: 0, etiqueta: 'Calendario', abre: 'el calendario y el almanaque del campo' },
+  { id: 'glaciar', x: 195, y: 228, piso: 0, etiqueta: 'Glaciar', abre: 'los glaciares y el agua de alta montaña' },
+  { id: 'restauracion', x: 132, y: 434, piso: 1, etiqueta: 'Restaurar', abre: 'la restauración del páramo y el bosque' },
+  { id: 'papa', x: 118, y: 662, piso: 2, etiqueta: 'La papa', abre: 'la papa y los tubérculos' },
+  { id: 'animales', x: 272, y: 700, piso: 2, etiqueta: 'Mis animales', abre: 'sus animales: gallinas, vacas, cabras' },
+  { id: 'agente', x: 195, y: 892, piso: 3, etiqueta: 'Hablar con Chagra', abre: 'el agente: pregunte con su voz' },
+  { id: 'cosecha', x: 296, y: 848, piso: 3, etiqueta: 'Mi cosecha', abre: 'su cosecha guardada en el troje' },
+  { id: 'cafe', x: 96, y: 942, piso: 3, etiqueta: 'El café', abre: 'el mundo del café' },
+  { id: 'vender', x: 300, y: 986, piso: 3, etiqueta: 'Vender', abre: 'el mercado: precios y ventas' },
+  { id: 'mango', x: 92, y: 1136, piso: 4, etiqueta: 'El mango', abre: 'el mundo del mango' },
+  { id: 'platano', x: 292, y: 1168, piso: 4, etiqueta: 'El plátano', abre: 'el plátano y el banano' },
+  { id: 'rio', x: 190, y: 1372, piso: 5, etiqueta: 'El río', abre: 'el agua, el riego y la pesca' },
+];
+
+const DIRECCIONES = [
+  { id: 'naturalista', num: 1, corto: 'Sierra', nombre: 'Sierra naturalista', lema: 'luz cálida de montaña' },
+  { id: 'biopunk', num: 2, corto: 'Biopunk', nombre: 'Biopunk', lema: 'neón orgánico nocturno, como el home actual' },
+  { id: 'verde', num: 3, corto: 'Verde vivo', nombre: 'Verde vivo', lema: 'botánico luminoso de día' },
+];
+
+// Transform del zoom: 'finca' encuadra el piso activo (los demás tenues);
+// 'montana' encaja la montaña completa en el alto de la pantalla.
+function calcularTransform(vp, modo, piso) {
+  const escenaH = vp.w * (VB_H / VB_W);
+  if (modo === 'montana') {
+    const s = Math.min(vp.h / escenaH, 1);
+    return { s, tx: (vp.w - vp.w * s) / 2, ty: Math.max((vp.h - escenaH * s) / 2, 0) };
+  }
+  const p = PISOS[piso];
+  const bandaH = ((p.y1 - p.y0) / VB_H) * escenaH;
+  const s = Math.max(1, Math.min((vp.h * 0.94) / bandaH, 2.4));
+  const cy = (((p.y0 + p.y1) / 2) / VB_H) * escenaH;
+  let ty = vp.h / 2 - cy * s;
+  ty = Math.max(vp.h - escenaH * s, Math.min(0, ty));
+  const tx = (vp.w - vp.w * s) / 2;
+  return { s, tx, ty };
+}
+
+// ── Piezas de la escena (SVG) ────────────────────────────────────────────────
+
+/** Frailejón: tronco lanudo + roseta que respira. */
+function Frailejon({ x, y, s = 1 }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`}>
+      <rect x="-3.4" y="-4" width="6.8" height="30" rx="3" className="mm-frailejon-tronco" />
+      <g className="mm-frailejon-roseta">
+        {[-72, -48, -24, 0, 24, 48, 72].map((a) => (
+          <ellipse key={a} cx="0" cy="-16" rx="3.4" ry="14" transform={`rotate(${a} 0 -2)`} className="mm-frailejon-hoja" />
+        ))}
+        <circle cx="0" cy="-6" r="4.6" className="mm-frailejon-flor" />
+      </g>
+    </g>
+  );
+}
+
+/** Mata de café con frutos rojos. */
+function MataCafe({ x, y, s = 1 }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`}>
+      <circle cx="0" cy="0" r="8" className="mm-cafe-mata" />
+      <circle cx="-3.4" cy="-1.5" r="1.6" className="mm-cafe-fruto" />
+      <circle cx="2.6" cy="-3.4" r="1.6" className="mm-cafe-fruto" />
+      <circle cx="1.4" cy="2.8" r="1.6" className="mm-cafe-fruto" />
+    </g>
+  );
+}
+
+/** Animal del corral (silueta simple: cuerpo + cabeza + patas). */
+function Animalito({ x, y, s = 1, clase = 'mm-oveja' }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`} className={clase}>
+      <ellipse cx="0" cy="0" rx="8.4" ry="5.4" />
+      <circle cx="8.2" cy="-3.2" r="3.1" />
+      <rect x="-6" y="3" width="2.2" height="6" rx="1" />
+      <rect x="3.6" y="3" width="2.2" height="6" rx="1" />
+    </g>
+  );
+}
+
+export default function MontanaMundos({ onBack }) {
+  const [dir, setDir] = useState('naturalista');
+  const [modo, setModo] = useState('finca'); // 'finca' | 'montana'
+  const [piso, setPiso] = useState(PISO_FINCA);
+  const [aviso, setAviso] = useState(null);
+  const avisoTimer = useRef(null);
+  const viewportRef = useRef(null);
+  const [vp, setVp] = useState({ w: 390, h: 700 });
+
+  useEffect(() => {
+    const medir = () => {
+      const el = viewportRef.current;
+      if (el) setVp({ w: el.clientWidth, h: el.clientHeight });
+    };
+    medir();
+    window.addEventListener('resize', medir);
+    return () => window.removeEventListener('resize', medir);
+  }, []);
+
+  const t = useMemo(() => calcularTransform(vp, modo, piso), [vp, modo, piso]);
+  const escenaH = vp.w * (VB_H / VB_W);
+
+  const avisar = (texto) => {
+    setAviso(texto);
+    if (avisoTimer.current) clearTimeout(avisoTimer.current);
+    avisoTimer.current = setTimeout(() => setAviso(null), 2600);
+  };
+  useEffect(() => () => { if (avisoTimer.current) clearTimeout(avisoTimer.current); }, []);
+
+  // Gestos: pellizco (2 dedos) alterna finca ↔ montaña; deslizar vertical
+  // (1 dedo, en modo finca) sube o baja de piso — como caminar la montaña.
+  const pinchRef = useRef(null);
+  const swipeRef = useRef(null);
+  const distancia = (touches) =>
+    Math.hypot(touches[0].clientX - touches[1].clientX, touches[0].clientY - touches[1].clientY);
+  const onTouchStart = (e) => {
+    if (e.touches.length === 2) {
+      pinchRef.current = distancia(e.touches);
+      swipeRef.current = null;
+    } else if (e.touches.length === 1) {
+      swipeRef.current = e.touches[0].clientY;
+    }
+  };
+  const onTouchMove = (e) => {
+    if (e.touches.length === 2 && pinchRef.current != null) {
+      const razon = distancia(e.touches) / pinchRef.current;
+      if (razon < 0.78) { setModo('montana'); pinchRef.current = null; }
+      if (razon > 1.28) { setModo('finca'); pinchRef.current = null; }
+    }
+  };
+  const onTouchEnd = (e) => {
+    if (pinchRef.current == null && swipeRef.current != null && modo === 'finca' && e.changedTouches.length === 1) {
+      const delta = e.changedTouches[0].clientY - swipeRef.current;
+      if (delta < -72 && piso < PISOS.length - 1) setPiso(piso + 1); // desliza arriba → baja la montaña
+      if (delta > 72 && piso > 0) setPiso(piso - 1); // desliza abajo → sube la montaña
+    }
+    if (e.touches.length < 2) pinchRef.current = null;
+    if (e.touches.length === 0) swipeRef.current = null;
+  };
+
+  const alternarZoom = () => setModo(modo === 'finca' ? 'montana' : 'finca');
+  const irAPiso = (i) => { setPiso(i); setModo('finca'); };
+  const pisoActual = PISOS[piso];
+  const direccion = DIRECCIONES.find((d) => d.id === dir) || DIRECCIONES[0];
+
+  const pct = (v, total) => `${(v / total) * 100}%`;
+
+  return (
+    <div className="mm" data-dir={dir} data-modo={modo}>
+      {/* ── Barra del mockup (herramienta de revisión, no parte del diseño) ── */}
+      <header className="mm-cabecera">
+        <div className="mm-mockbar">
+          <button type="button" className="mm-volver" onClick={() => onBack && onBack()}>← Volver</button>
+          <span className="mm-mockbar-titulo">MOCKUP · decidir dirección</span>
+        </div>
+        <h1 className="mm-titulo">La Montaña de los Mundos</h1>
+        <div className="mm-direcciones" role="tablist" aria-label="Dirección artística">
+          {DIRECCIONES.map((d) => (
+            <button
+              key={d.id}
+              type="button"
+              role="tab"
+              aria-selected={dir === d.id}
+              data-testid={`mm-dir-${d.id}`}
+              className={`mm-dir-btn${dir === d.id ? ' es-activa' : ''}`}
+              onClick={() => setDir(d.id)}
+            >
+              <span className="mm-dir-num">{d.num}</span> {d.corto}
+            </button>
+          ))}
+        </div>
+        <p className="mm-dir-lema" data-testid="mm-dir-lema">
+          Dirección {direccion.num} · <strong>{direccion.nombre}</strong> — {direccion.lema}
+        </p>
+      </header>
+
+      {/* ── Ventana a la montaña ── */}
+      <div
+        className="mm-viewport"
+        ref={viewportRef}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        data-testid="mm-viewport"
+      >
+        <div
+          className="mm-escena"
+          style={{
+            height: `${escenaH}px`,
+            transform: `translate3d(${t.tx}px, ${t.ty}px, 0) scale(${t.s})`,
+          }}
+        >
+          <MontanaSvg />
+
+          {/* Velos: en modo finca, los pisos que no son el activo quedan tenues. */}
+          <div
+            className="mm-velo mm-velo-arriba"
+            style={{ height: pct(pisoActual.y0, VB_H) }}
+            aria-hidden="true"
+          />
+          <div
+            className="mm-velo mm-velo-abajo"
+            style={{ top: pct(pisoActual.y1, VB_H) }}
+            aria-hidden="true"
+          />
+
+          {/* Marcador de la finca del usuario (siempre en su piso). */}
+          <div className="mm-finca-pin" style={{ left: pct(195, VB_W), top: pct(838, VB_H) }} aria-hidden="true">
+            ⭐ Su finca
+          </div>
+
+          {/* Mundos tocables: halo que pulsa + etiqueta (afordancia obvia). */}
+          {MUNDOS.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              className={`mm-mundo${modo === 'finca' && m.piso !== piso ? ' es-tenue' : ''}`}
+              style={{ left: pct(m.x, VB_W), top: pct(m.y, VB_H) }}
+              data-testid={`mm-mundo-${m.id}`}
+              aria-label={`${m.etiqueta}: abre ${m.abre}`}
+              onClick={() => avisar(`Aquí se abre ${m.abre}.`)}
+            >
+              <span className="mm-mundo-halo" aria-hidden="true" />
+              <span className="mm-mundo-etiqueta">{m.etiqueta}</span>
+            </button>
+          ))}
+
+          {/* Franjas de piso: en la montaña completa, tocar un piso lo acerca. */}
+          {PISOS.map((p, i) => (
+            <button
+              key={p.id}
+              type="button"
+              className="mm-franja"
+              style={{ top: pct(p.y0, VB_H), height: pct(p.y1 - p.y0, VB_H) }}
+              data-testid={`mm-franja-${p.id}`}
+              tabIndex={modo === 'montana' ? 0 : -1}
+              aria-label={`Acercarse a ${p.nombre}, ${p.msnm}`}
+              onClick={() => irAPiso(i)}
+            >
+              <span className="mm-franja-rotulo">
+                {p.nombre} · {p.msnm}{p.finca ? ' ⭐' : ''}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {/* Indicador del piso + flechas para caminar la montaña (modo finca). */}
+        <div className="mm-brujula" data-testid="mm-brujula">
+          <span className="mm-brujula-piso">
+            {pisoActual.nombre} · {pisoActual.msnm}{pisoActual.finca ? ' — aquí está su finca ⭐' : ''}
+          </span>
+        </div>
+        {modo === 'finca' && piso > 0 && (
+          <button type="button" className="mm-paso mm-paso-arriba" data-testid="mm-paso-arriba" onClick={() => setPiso(piso - 1)}>
+            ▲ Subir a {PISOS[piso - 1].nombre}
+          </button>
+        )}
+        {modo === 'finca' && piso < PISOS.length - 1 && (
+          <button type="button" className="mm-paso mm-paso-abajo" data-testid="mm-paso-abajo" onClick={() => setPiso(piso + 1)}>
+            ▼ Bajar a {PISOS[piso + 1].nombre}
+          </button>
+        )}
+
+        {/* Alternador de zoom: el gesto del pellizco hecho botón visible. */}
+        <button type="button" className="mm-zoom" data-testid="mm-zoom-toggle" onClick={alternarZoom}>
+          {modo === 'finca' ? '🏔 Ver toda la montaña' : '🏡 Volver a mi finca'}
+        </button>
+      </div>
+
+      {/* ── Atajos permanentes: nada queda detrás de escalar la montaña ── */}
+      <nav className="mm-atajos" aria-label="Atajos permanentes">
+        <button
+          type="button"
+          className="mm-atajo-anotar"
+          data-testid="mm-atajo-anotar"
+          onClick={() => avisar('Aquí se anota lo que hizo hoy en su finca.')}
+        >
+          📝 Anotar mi día
+        </button>
+        <button
+          type="button"
+          className="mm-atajo-agente"
+          data-testid="mm-atajo-agente"
+          aria-label="Hablar con Chagra, el agente"
+          onClick={() => avisar('Aquí se abre el agente: pregunte con su voz.')}
+        >
+          Ⓐ
+        </button>
+      </nav>
+
+      {aviso && (
+        <output className="mm-aviso" data-testid="mm-aviso">{aviso}</output>
+      )}
+    </div>
+  );
+}
+
+// ── La montaña (una sola escena SVG; las 3 direcciones la re-pintan por CSS) ──
+function MontanaSvg() {
+  return (
+    <svg
+      className="mm-svg"
+      viewBox={`0 0 ${VB_W} ${VB_H}`}
+      preserveAspectRatio="xMidYMid slice"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        <linearGradient id="mm-g-cielo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm-stop-cielo-a" />
+          <stop offset="1" className="mm-stop-cielo-b" />
+        </linearGradient>
+        <radialGradient id="mm-g-halo" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0" className="mm-stop-halo-a" />
+          <stop offset="1" className="mm-stop-halo-b" />
+        </radialGradient>
+        <linearGradient id="mm-g-rio" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm-stop-rio-a" />
+          <stop offset="1" className="mm-stop-rio-b" />
+        </linearGradient>
+        {/* La montaña recorta sus pisos: nada se pinta fuera de su silueta. */}
+        <clipPath id="mm-clip-montana">
+          <path d="M-2 1442 L-2 760 Q56 706 96 596 Q136 486 160 366 Q178 268 195 176 Q212 268 230 366 Q254 486 294 596 Q334 706 392 760 L392 1442 Z" />
+        </clipPath>
+      </defs>
+
+      {/* Cielo */}
+      <rect x="0" y="0" width="390" height="1440" fill="url(#mm-g-cielo)" />
+
+      {/* Estrellas (viven de noche: biopunk; tenues en la sierra) */}
+      <g className="mm-estrellas">
+        {[[24, 60, 1.6], [70, 130, 1.1], [120, 44, 1.4], [170, 96, 1], [250, 60, 1.5],
+          [292, 150, 1.1], [350, 40, 1.3], [366, 120, 1], [46, 210, 1.2], [340, 210, 1.4],
+          [96, 300, 1], [300, 300, 1.1]].map(([cx, cy, r]) => (
+            <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r={r} className="mm-estrella" />
+          ))}
+      </g>
+
+      {/* El astro (sol de día, luna de noche) → mundo Calendario */}
+      <g className="mm-astro">
+        <circle cx="316" cy="96" r="52" fill="url(#mm-g-halo)" />
+        <circle cx="316" cy="96" r="24" className="mm-astro-disco" />
+        <circle cx="308" cy="88" r="4.6" className="mm-astro-crater" />
+        <circle cx="324" cy="102" r="3.2" className="mm-astro-crater" />
+        <circle cx="314" cy="108" r="2.4" className="mm-astro-crater" />
+      </g>
+
+      {/* Nubes que pasan despacio (sierra y verde vivo) */}
+      <g className="mm-nubes">
+        <g className="mm-nube mm-nube-1">
+          <ellipse cx="80" cy="180" rx="34" ry="10" />
+          <ellipse cx="104" cy="172" rx="22" ry="8" />
+        </g>
+        <g className="mm-nube mm-nube-2">
+          <ellipse cx="300" cy="250" rx="40" ry="11" />
+          <ellipse cx="272" cy="242" rx="24" ry="8" />
+        </g>
+      </g>
+
+      {/* Cordilleras de atrás: profundidad de sierra */}
+      <path className="mm-ridge mm-ridge-a" d="M-2 1442 L-2 700 Q40 660 72 560 Q104 452 128 392 Q150 452 176 540 L200 640 L200 1442 Z" />
+      <path className="mm-ridge mm-ridge-b" d="M392 1442 L392 680 Q350 640 322 556 Q296 470 276 408 Q258 470 236 560 L214 660 L214 1442 Z" />
+
+      {/* ── Cuerpo de la montaña: pisos térmicos apilados ── */}
+      <g clipPath="url(#mm-clip-montana)">
+        {/* base páramo→abajo; cada piso tapa al anterior con borde ondulado */}
+        <rect x="-2" y="170" width="394" height="1272" className="mm-piso-paramo" />
+        <path className="mm-piso-frio" d="M-2 574 Q46 556 94 566 Q152 578 200 564 Q258 550 306 564 Q350 576 392 562 L392 1442 L-2 1442 Z" />
+        <path className="mm-piso-templado" d="M-2 816 Q50 798 104 808 Q160 820 212 806 Q266 792 316 806 Q356 816 392 804 L392 1442 L-2 1442 Z" />
+        <path className="mm-piso-calido" d="M-2 1076 Q54 1058 110 1068 Q166 1080 222 1066 Q276 1052 330 1066 Q364 1074 392 1062 L392 1442 L-2 1442 Z" />
+        <path className="mm-piso-valle" d="M-2 1316 Q60 1300 130 1310 Q210 1322 280 1308 Q340 1298 392 1308 L392 1442 L-2 1442 Z" />
+
+        {/* Nieve: cae sobre el páramo con lengua de glaciar */}
+        <path className="mm-nieve" d="M195 168 Q210 240 228 292 Q216 306 204 296 Q198 330 188 356 Q178 322 172 300 Q160 312 150 298 Q170 246 195 168 Z" />
+        <path className="mm-nieve" d="M195 168 Q170 250 148 302 Q136 296 130 306 Q148 322 142 338 Q120 330 108 342 Q132 250 160 214 Z" opacity="0.92" />
+        <path className="mm-nieve" d="M195 168 Q220 250 242 302 Q254 296 260 306 Q244 322 250 336 Q272 330 284 340 Q258 248 230 214 Z" opacity="0.92" />
+
+        {/* Bordes de piso: rima de luz (neón en biopunk) */}
+        <path className="mm-borde-piso" d="M-2 574 Q46 556 94 566 Q152 578 200 564 Q258 550 306 564 Q350 576 392 562" />
+        <path className="mm-borde-piso" d="M-2 816 Q50 798 104 808 Q160 820 212 806 Q266 792 316 806 Q356 816 392 804" />
+        <path className="mm-borde-piso" d="M-2 1076 Q54 1058 110 1068 Q166 1080 222 1066 Q276 1052 330 1066 Q364 1074 392 1062" />
+        <path className="mm-borde-piso" d="M-2 1316 Q60 1300 130 1310 Q210 1322 280 1308 Q340 1298 392 1308" />
+
+        {/* Niebla entre pisos */}
+        <ellipse className="mm-niebla" cx="120" cy="566" rx="120" ry="16" />
+        <ellipse className="mm-niebla" cx="290" cy="812" rx="130" ry="18" />
+        <ellipse className="mm-niebla" cx="110" cy="1072" rx="120" ry="16" />
+
+        {/* ── PÁRAMO: frailejones + laguna ── */}
+        <ellipse className="mm-laguna" cx="248" cy="486" rx="44" ry="11" />
+        <path className="mm-laguna-brillo" d="M218 484 Q248 478 278 484" />
+        <Frailejon x={132} y={436} s={1.25} />
+        <Frailejon x={170} y={470} s={0.95} />
+        <Frailejon x={100} y={482} s={0.8} />
+
+        {/* ── FRÍO: surcos de papa + corral ── */}
+        <g className="mm-surcos">
+          <path d="M70 636 Q118 626 166 636" />
+          <path d="M62 656 Q118 644 174 656" />
+          <path d="M56 676 Q118 662 180 676" />
+          <path d="M52 696 Q118 682 184 696" />
+        </g>
+        <g className="mm-matas-papa">
+          {[[80, 632], [112, 628], [144, 632], [72, 652], [108, 646], [148, 652],
+            [66, 672], [106, 664], [152, 672], [62, 692], [104, 684], [156, 692]].map(([cx, cy]) => (
+              <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="3" />
+            ))}
+        </g>
+        <g className="mm-corral">
+          {[236, 258, 280, 302, 318].map((x) => (
+            <rect key={x} x={x} y={694} width="3.2" height="16" rx="1.4" className="mm-cerca-poste" />
+          ))}
+          <rect x="234" y="697" width="88" height="2.6" rx="1.3" className="mm-cerca-riel" />
+          <rect x="234" y="704" width="88" height="2.6" rx="1.3" className="mm-cerca-riel" />
+          <Animalito x={258} y={688} s={0.9} clase="mm-oveja" />
+          <Animalito x={296} y={690} s={1.05} clase="mm-vaca" />
+        </g>
+
+        {/* ── TEMPLADO: la casa (finca del usuario), troje, cafetal, mercado ── */}
+        <g className="mm-casa">
+          {/* humo del fogón */}
+          <g className="mm-humo">
+            <circle className="mm-humo-1" cx="212" cy="856" r="3.4" />
+            <circle className="mm-humo-2" cx="214" cy="848" r="4.4" />
+            <circle className="mm-humo-3" cx="217" cy="838" r="5.4" />
+          </g>
+          <rect x="206" y="856" width="7" height="14" rx="1.5" className="mm-casa-chimenea" />
+          <rect x="168" y="874" width="56" height="34" rx="3" className="mm-casa-muro" />
+          <path d="M162 876 L196 850 L230 876 Z" className="mm-casa-techo" />
+          <rect x="176" y="884" width="12" height="12" rx="2" className="mm-casa-ventana" />
+          <rect x="200" y="882" width="14" height="26" rx="2.5" className="mm-casa-puerta" />
+          <path d="M150 908 Q196 916 244 908" className="mm-casa-camino" />
+        </g>
+        <g className="mm-troje">
+          <rect x="282" y="856" width="4" height="16" className="mm-troje-pata" />
+          <rect x="306" y="856" width="4" height="16" className="mm-troje-pata" />
+          <rect x="276" y="836" width="40" height="22" rx="3" className="mm-troje-cuerpo" />
+          <path d="M272 838 L296 822 L320 838 Z" className="mm-troje-techo" />
+          <circle cx="290" cy="847" r="3" className="mm-troje-grano" />
+          <circle cx="298" cy="849" r="3" className="mm-troje-grano" />
+          <circle cx="304" cy="846" r="3" className="mm-troje-grano" />
+        </g>
+        <g className="mm-cafetal">
+          <MataCafe x={72} y={938} s={1.1} />
+          <MataCafe x={98} y={930} s={1} />
+          <MataCafe x={124} y={940} s={1.15} />
+          <MataCafe x={84} y={958} s={0.95} />
+          <MataCafe x={112} y={956} s={1.05} />
+        </g>
+        <g className="mm-mercado">
+          <rect x="278" y="988" width="46" height="20" rx="2.5" className="mm-mercado-meson" />
+          {[278, 289.5, 301, 312.5].map((x, i) => (
+            <rect key={x} x={x} y={974} width="11.5" height="10" rx="1.5" className={i % 2 ? 'mm-toldo-b' : 'mm-toldo-a'} />
+          ))}
+          <rect x="276" y="982" width="50" height="4" rx="2" className="mm-mercado-tabla" />
+          <circle cx="288" cy="994" r="3.4" className="mm-mercado-fruta-a" />
+          <circle cx="298" cy="994" r="3.4" className="mm-mercado-fruta-b" />
+          <circle cx="308" cy="994" r="3.4" className="mm-mercado-fruta-a" />
+        </g>
+
+        {/* ── CÁLIDO: mango, platanera, cañaduzal ── */}
+        <g className="mm-arbol-mango">
+          <path d="M90 1172 Q88 1150 94 1136" className="mm-mango-tronco" />
+          <circle cx="80" cy="1128" r="20" className="mm-mango-copa" />
+          <circle cx="104" cy="1124" r="17" className="mm-mango-copa" />
+          <circle cx="92" cy="1112" r="16" className="mm-mango-copa" />
+          {[[74, 1132], [96, 1120], [106, 1132], [86, 1116]].map(([cx, cy]) => (
+            <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="3.2" className="mm-mango-fruto" />
+          ))}
+        </g>
+        <g className="mm-platanera">
+          {[-58, -30, 0, 30, 58].map((a) => (
+            <path
+              key={a}
+              d="M0 0 Q4 -22 0 -40 Q-4 -22 0 0"
+              transform={`translate(292 1180) rotate(${a} 0 0)`}
+              className="mm-platano-hoja"
+            />
+          ))}
+          <rect x="289" y="1180" width="6" height="18" rx="2.6" className="mm-platano-tallo" />
+          <g className="mm-racimo">
+            {[[284, 1170], [281, 1176], [284, 1182]].map(([cx, cy]) => (
+              <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="3" />
+            ))}
+          </g>
+        </g>
+        <g className="mm-cana">
+          {[176, 188, 200, 212].map((x, i) => (
+            <path key={x} d={`M${x} 1252 Q${x + (i % 2 ? 5 : -5)} 1222 ${x + (i % 2 ? 2 : -2)} 1200`} className="mm-cana-tallo" />
+          ))}
+        </g>
+
+        {/* ── RÍO: baja de la montaña y se abre en el valle ── */}
+        <path
+          className="mm-rio"
+          d="M236 1004 Q248 1050 232 1096 Q214 1146 228 1196 Q244 1250 214 1300 Q186 1350 196 1400 L204 1442 L146 1442 Q136 1390 158 1338 Q182 1290 168 1240 Q152 1186 172 1136 Q192 1090 208 1052 Q218 1024 224 1004 Z"
+          fill="url(#mm-g-rio)"
+        />
+        <g className="mm-flujo">
+          <path d="M226 1030 Q234 1072 222 1112 Q206 1158 218 1204" />
+          <path d="M228 1230 Q238 1272 210 1318 Q188 1356 194 1404" />
+          <path d="M212 1080 Q200 1130 212 1178" />
+        </g>
+        <ellipse className="mm-piedra" cx="182" cy="1368" rx="8" ry="5" />
+        <ellipse className="mm-piedra" cx="222" cy="1322" rx="6" ry="4" />
+      </g>
+
+      {/* Red viva (solo biopunk): el micelio conecta los pisos */}
+      <g className="mm-micelio">
+        <path d="M316 120 Q260 200 195 300 Q140 400 132 440 Q120 520 150 600 Q170 660 195 700 Q220 760 195 880 Q180 940 230 1000 Q260 1060 240 1140 Q220 1240 195 1300 Q180 1340 190 1380" />
+        <path d="M132 440 Q180 520 272 700" opacity="0.55" />
+        <path d="M195 880 Q140 920 96 942" opacity="0.55" />
+        <path d="M230 1000 Q270 1080 292 1168" opacity="0.55" />
+        {MUNDOS.map((m) => (
+          <circle key={m.id} cx={m.x} cy={m.y} r="3" className="mm-micelio-nodo" />
+        ))}
+      </g>
+
+      {/* Mariposas (solo verde vivo) */}
+      <g className="mm-mariposas">
+        <g transform="translate(150 860)">
+          <g className="mm-mariposa mm-mariposa-1">
+            <ellipse cx="-3" cy="0" rx="3.4" ry="2.2" />
+            <ellipse cx="3" cy="0" rx="3.4" ry="2.2" />
+          </g>
+        </g>
+        <g transform="translate(260 1120)">
+          <g className="mm-mariposa mm-mariposa-2">
+            <ellipse cx="-3" cy="0" rx="3" ry="2" />
+            <ellipse cx="3" cy="0" rx="3" ry="2" />
+          </g>
+        </g>
+      </g>
+
+      {/* Aves lejanas (solo sierra naturalista) */}
+      <g className="mm-aves">
+        <path d="M96 236 q6 -6 12 0 q6 -6 12 0" />
+        <path d="M130 258 q5 -5 10 0 q5 -5 10 0" />
+      </g>
+    </svg>
+  );
+}

--- a/src/mockups/MontanaMundos.jsx
+++ b/src/mockups/MontanaMundos.jsx
@@ -58,7 +58,7 @@ const MUNDOS = [
   { id: 'restauracion', x: 132, y: 434, piso: 1, etiqueta: 'Restaurar', abre: 'la restauración del páramo y el bosque' },
   { id: 'papa', x: 118, y: 662, piso: 2, etiqueta: 'La papa', abre: 'la papa y los tubérculos' },
   { id: 'animales', x: 272, y: 700, piso: 2, etiqueta: 'Mis animales', abre: 'sus animales: gallinas, vacas, cabras' },
-  { id: 'agente', x: 195, y: 892, piso: 3, etiqueta: 'Hablar con Chagra', abre: 'el agente: pregunte con su voz' },
+  { id: 'agente', x: 207, y: 896, piso: 3, etiqueta: 'Hablar con Chagra', abre: 'el agente: pregunte con su voz' },
   { id: 'cosecha', x: 296, y: 848, piso: 3, etiqueta: 'Mi cosecha', abre: 'su cosecha guardada en el troje' },
   { id: 'cafe', x: 96, y: 942, piso: 3, etiqueta: 'El café', abre: 'el mundo del café' },
   { id: 'vender', x: 300, y: 986, piso: 3, etiqueta: 'Vender', abre: 'el mercado: precios y ventas' },
@@ -78,12 +78,16 @@ const DIRECCIONES = [
 function calcularTransform(vp, modo, piso) {
   const escenaH = vp.w * (VB_H / VB_W);
   if (modo === 'montana') {
-    const s = Math.min(vp.h / escenaH, 1);
-    return { s, tx: (vp.w - vp.w * s) / 2, ty: Math.max((vp.h - escenaH * s) / 2, 0) };
+    // Deja aire para la brújula (arriba) y el botón de zoom (abajo), que
+    // tapaban el rótulo de "El río" cuando la montaña llenaba todo el alto.
+    const s = Math.min((vp.h - 150) / escenaH, 1);
+    return { s, tx: (vp.w - vp.w * s) / 2, ty: 84 };
   }
   const p = PISOS[piso];
   const bandaH = ((p.y1 - p.y0) / VB_H) * escenaH;
-  const s = Math.max(1, Math.min((vp.h * 0.94) / bandaH, 2.4));
+  // Tope 1.35: con más acercamiento el piso pierde su ancho (el cafetal y
+  // el troje quedaban por fuera de la pantalla) y las etiquetas gigantes.
+  const s = Math.max(1, Math.min((vp.h * 0.94) / bandaH, 1.35));
   const cy = (((p.y0 + p.y1) / 2) / VB_H) * escenaH;
   let ty = vp.h / 2 - cy * s;
   ty = Math.max(vp.h - escenaH * s, Math.min(0, ty));
@@ -372,6 +376,13 @@ function MontanaSvg() {
           <stop offset="0" className="mm-stop-rio-a" />
           <stop offset="1" className="mm-stop-rio-b" />
         </linearGradient>
+        {/* Luz de montaña: baña la ladera de arriba (cálida/neón/blanca según
+            dirección) y hunde el valle — profundidad pictórica sin más capas. */}
+        <linearGradient id="mm-g-luz" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm-stop-luz-a" />
+          <stop offset="0.45" stopColor="rgba(0,0,0,0)" />
+          <stop offset="1" className="mm-stop-luz-b" />
+        </linearGradient>
         {/* La montaña recorta sus pisos: nada se pinta fuera de su silueta. */}
         <clipPath id="mm-clip-montana">
           <path d="M-2 1442 L-2 760 Q56 706 96 596 Q136 486 160 366 Q178 268 195 176 Q212 268 230 366 Q254 486 294 596 Q334 706 392 760 L392 1442 Z" />
@@ -411,9 +422,9 @@ function MontanaSvg() {
         </g>
       </g>
 
-      {/* Cordilleras de atrás: profundidad de sierra */}
-      <path className="mm-ridge mm-ridge-a" d="M-2 1442 L-2 700 Q40 660 72 560 Q104 452 128 392 Q150 452 176 540 L200 640 L200 1442 Z" />
-      <path className="mm-ridge mm-ridge-b" d="M392 1442 L392 680 Q350 640 322 556 Q296 470 276 408 Q258 470 236 560 L214 660 L214 1442 Z" />
+      {/* Cordilleras de atrás: lomas redondas y brumosas, más bajas que el pico */}
+      <path className="mm-ridge mm-ridge-a" d="M-2 1442 L-2 720 Q50 600 96 486 Q120 430 150 470 Q180 540 196 640 L196 1442 Z" />
+      <path className="mm-ridge mm-ridge-b" d="M392 1442 L392 700 Q346 590 306 500 Q284 452 258 496 Q230 560 214 660 L214 1442 Z" />
 
       {/* ── Cuerpo de la montaña: pisos térmicos apilados ── */}
       <g clipPath="url(#mm-clip-montana)">
@@ -424,10 +435,9 @@ function MontanaSvg() {
         <path className="mm-piso-calido" d="M-2 1076 Q54 1058 110 1068 Q166 1080 222 1066 Q276 1052 330 1066 Q364 1074 392 1062 L392 1442 L-2 1442 Z" />
         <path className="mm-piso-valle" d="M-2 1316 Q60 1300 130 1310 Q210 1322 280 1308 Q340 1298 392 1308 L392 1442 L-2 1442 Z" />
 
-        {/* Nieve: cae sobre el páramo con lengua de glaciar */}
-        <path className="mm-nieve" d="M195 168 Q210 240 228 292 Q216 306 204 296 Q198 330 188 356 Q178 322 172 300 Q160 312 150 298 Q170 246 195 168 Z" />
-        <path className="mm-nieve" d="M195 168 Q170 250 148 302 Q136 296 130 306 Q148 322 142 338 Q120 330 108 342 Q132 250 160 214 Z" opacity="0.92" />
-        <path className="mm-nieve" d="M195 168 Q220 250 242 302 Q254 296 260 306 Q244 322 250 336 Q272 330 284 340 Q258 248 230 214 Z" opacity="0.92" />
+        {/* Nieve: casquete ancho con ruana dentada y lengua de glaciar */}
+        <path className="mm-nieve" d="M195 140 Q168 220 138 320 L154 306 L166 324 L182 306 L196 330 L212 306 L226 322 L240 304 L254 318 Q222 220 195 140 Z" />
+        <path className="mm-nieve" d="M196 330 Q192 358 184 382 Q178 360 182 336 Z" opacity="0.9" />
 
         {/* Bordes de piso: rima de luz (neón en biopunk) */}
         <path className="mm-borde-piso" d="M-2 574 Q46 556 94 566 Q152 578 200 564 Q258 550 306 564 Q350 576 392 562" />
@@ -494,6 +504,13 @@ function MontanaSvg() {
           <circle cx="298" cy="849" r="3" className="mm-troje-grano" />
           <circle cx="304" cy="846" r="3" className="mm-troje-grano" />
         </g>
+        {/* Sombríos del café (guamos): el cafetal colombiano crece a la sombra */}
+        <g className="mm-sombrio">
+          <path d="M52 940 Q50 924 54 912" />
+          <path d="M146 936 Q144 920 148 908" />
+        </g>
+        <ellipse className="mm-sombrio-copa" cx="54" cy="906" rx="17" ry="9" />
+        <ellipse className="mm-sombrio-copa" cx="148" cy="902" rx="19" ry="10" />
         <g className="mm-cafetal">
           <MataCafe x={72} y={938} s={1.1} />
           <MataCafe x={98} y={930} s={1} />
@@ -557,6 +574,9 @@ function MontanaSvg() {
         </g>
         <ellipse className="mm-piedra" cx="182" cy="1368" rx="8" ry="5" />
         <ellipse className="mm-piedra" cx="222" cy="1322" rx="6" ry="4" />
+
+        {/* Luz de montaña sobre toda la ladera (dentro del recorte) */}
+        <rect x="-2" y="120" width="394" height="1322" fill="url(#mm-g-luz)" pointerEvents="none" />
       </g>
 
       {/* Red viva (solo biopunk): el micelio conecta los pisos */}
@@ -590,6 +610,14 @@ function MontanaSvg() {
       <g className="mm-aves">
         <path d="M96 236 q6 -6 12 0 q6 -6 12 0" />
         <path d="M130 258 q5 -5 10 0 q5 -5 10 0" />
+      </g>
+
+      {/* Follaje botánico en primer plano (solo verde vivo) */}
+      <g className="mm-botanica">
+        <path d="M-4 1442 Q10 1380 44 1352 Q26 1394 22 1442 Z" />
+        <path d="M-4 1442 Q28 1402 74 1392 Q40 1420 34 1442 Z" opacity="0.75" />
+        <path d="M394 1442 Q380 1376 344 1348 Q364 1392 368 1442 Z" />
+        <path d="M394 1442 Q360 1400 316 1390 Q352 1418 358 1442 Z" opacity="0.75" />
       </g>
     </svg>
   );

--- a/src/mockups/MontanaMundos.jsx
+++ b/src/mockups/MontanaMundos.jsx
@@ -136,7 +136,9 @@ function Animalito({ x, y, s = 1, clase = 'mm-oveja' }) {
   );
 }
 
-export default function MontanaMundos({ onBack }) {
+// `onBack` con default: los tests montan el mockup sin prop (TS2741 del gate
+// tsc en checkJs infiere el prop como requerido si no tiene valor por defecto).
+export default function MontanaMundos({ onBack = null }) {
   const [dir, setDir] = useState('naturalista');
   const [modo, setModo] = useState('finca'); // 'finca' | 'montana'
   const [piso, setPiso] = useState(PISO_FINCA);

--- a/src/mockups/MontanaMundos.jsx
+++ b/src/mockups/MontanaMundos.jsx
@@ -55,7 +55,7 @@ const PISO_FINCA = PISOS.findIndex((p) => p.finca);
 const MUNDOS = [
   { id: 'calendario', x: 316, y: 96, piso: 0, etiqueta: 'Calendario', abre: 'el calendario y el almanaque del campo' },
   { id: 'glaciar', x: 195, y: 228, piso: 0, etiqueta: 'Glaciar', abre: 'los glaciares y el agua de alta montaña' },
-  { id: 'restauracion', x: 132, y: 434, piso: 1, etiqueta: 'Restaurar', abre: 'la restauración del páramo y el bosque' },
+  { id: 'restauracion', x: 168, y: 420, piso: 1, etiqueta: 'Restaurar', abre: 'la restauración del páramo y el bosque' },
   { id: 'papa', x: 118, y: 662, piso: 2, etiqueta: 'La papa', abre: 'la papa y los tubérculos' },
   { id: 'animales', x: 272, y: 700, piso: 2, etiqueta: 'Mis animales', abre: 'sus animales: gallinas, vacas, cabras' },
   { id: 'agente', x: 207, y: 896, piso: 3, etiqueta: 'Hablar con Chagra', abre: 'el agente: pregunte con su voz' },
@@ -450,12 +450,23 @@ function MontanaSvg() {
         <ellipse className="mm-niebla" cx="290" cy="812" rx="130" ry="18" />
         <ellipse className="mm-niebla" cx="110" cy="1072" rx="120" ry="16" />
 
-        {/* ── PÁRAMO: frailejones + laguna ── */}
-        <ellipse className="mm-laguna" cx="248" cy="486" rx="44" ry="11" />
-        <path className="mm-laguna-brillo" d="M218 484 Q248 478 278 484" />
-        <Frailejon x={132} y={436} s={1.25} />
-        <Frailejon x={170} y={470} s={0.95} />
-        <Frailejon x={100} y={482} s={0.8} />
+        {/* ── PÁRAMO: frailejones, pajonal y laguna (el cono es angosto a esta
+            altura: todo vive entre x≈140 y x≈255 para no caer del recorte) ── */}
+        <ellipse className="mm-laguna" cx="222" cy="512" rx="34" ry="9" />
+        <path className="mm-laguna-brillo" d="M198 510 Q222 504 246 510" />
+        <g className="mm-pajonal">
+          <path d="M196 452 q-3 -10 -7 -13 M196 452 q0 -12 1 -15 M196 452 q4 -9 8 -12" />
+          <path d="M216 436 q-3 -9 -6 -11 M216 436 q0 -10 1 -13 M216 436 q3 -8 7 -10" />
+          <path d="M160 508 q-3 -9 -6 -11 M160 508 q0 -10 1 -13 M160 508 q3 -8 7 -10" />
+          <path d="M186 528 q-3 -8 -6 -10 M186 528 q0 -9 1 -12 M186 528 q3 -7 6 -9" />
+          <path d="M250 486 q-3 -9 -6 -11 M250 486 q0 -10 1 -13 M250 486 q3 -8 7 -10" />
+        </g>
+        <ellipse className="mm-piedra" cx="150" cy="532" rx="9" ry="5" />
+        <ellipse className="mm-piedra" cx="228" cy="456" rx="6" ry="3.6" />
+        <Frailejon x={168} y={438} s={1.25} />
+        <Frailejon x={204} y={472} s={0.95} />
+        <Frailejon x={150} y={488} s={0.8} />
+        <Frailejon x={240} y={530} s={0.7} />
 
         {/* ── FRÍO: surcos de papa + corral ── */}
         <g className="mm-surcos">
@@ -581,8 +592,8 @@ function MontanaSvg() {
 
       {/* Red viva (solo biopunk): el micelio conecta los pisos */}
       <g className="mm-micelio">
-        <path d="M316 120 Q260 200 195 300 Q140 400 132 440 Q120 520 150 600 Q170 660 195 700 Q220 760 195 880 Q180 940 230 1000 Q260 1060 240 1140 Q220 1240 195 1300 Q180 1340 190 1380" />
-        <path d="M132 440 Q180 520 272 700" opacity="0.55" />
+        <path d="M316 120 Q260 200 195 300 Q160 390 168 428 Q150 520 160 600 Q175 660 195 700 Q220 760 195 880 Q180 940 230 1000 Q260 1060 240 1140 Q220 1240 195 1300 Q180 1340 190 1380" />
+        <path d="M168 428 Q200 520 272 700" opacity="0.55" />
         <path d="M195 880 Q140 920 96 942" opacity="0.55" />
         <path d="M230 1000 Q270 1080 292 1168" opacity="0.55" />
         {MUNDOS.map((m) => (

--- a/src/mockups/__tests__/MontanaMundos.smoke.test.jsx
+++ b/src/mockups/__tests__/MontanaMundos.smoke.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MontanaMundos from '../MontanaMundos';
+
+// Smoke del mockup "La Montaña de los Mundos" (#/mockups/montana-mundos).
+// Cubre lo que el operador va a revisar en vivo: (1) las 3 direcciones
+// artísticas conmutan, (2) el zoom finca ↔ montaña completa funciona,
+// (3) los mundos tocables existen con su etiqueta, (4) los atajos
+// permanentes (Ⓐ + anotar) siempre están, (5) el aviso honesto aparece.
+
+describe('MontanaMundos (mockup)', () => {
+  it('abre centrado en la finca (piso templado) con los atajos permanentes visibles', () => {
+    render(<MontanaMundos />);
+    expect(screen.getByText('La Montaña de los Mundos')).toBeTruthy();
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('templado');
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('su finca');
+    expect(screen.getByTestId('mm-atajo-agente')).toBeTruthy();
+    expect(screen.getByTestId('mm-atajo-anotar')).toBeTruthy();
+  });
+
+  it('conmuta las 3 direcciones artísticas (data-dir en la raíz)', () => {
+    const { container } = render(<MontanaMundos />);
+    const raiz = container.querySelector('.mm');
+    expect(raiz.getAttribute('data-dir')).toBe('naturalista');
+    fireEvent.click(screen.getByTestId('mm-dir-biopunk'));
+    expect(raiz.getAttribute('data-dir')).toBe('biopunk');
+    expect(screen.getByTestId('mm-dir-lema').textContent).toContain('Biopunk');
+    fireEvent.click(screen.getByTestId('mm-dir-verde'));
+    expect(raiz.getAttribute('data-dir')).toBe('verde');
+    fireEvent.click(screen.getByTestId('mm-dir-naturalista'));
+    expect(raiz.getAttribute('data-dir')).toBe('naturalista');
+  });
+
+  it('hace zoom-out a la montaña completa y vuelve a la finca', () => {
+    const { container } = render(<MontanaMundos />);
+    const raiz = container.querySelector('.mm');
+    expect(raiz.getAttribute('data-modo')).toBe('finca');
+    const toggle = screen.getByTestId('mm-zoom-toggle');
+    expect(toggle.textContent).toContain('Ver toda la montaña');
+    fireEvent.click(toggle);
+    expect(raiz.getAttribute('data-modo')).toBe('montana');
+    expect(toggle.textContent).toContain('Volver a mi finca');
+    // En la montaña completa, tocar un piso acerca a ese piso.
+    fireEvent.click(screen.getByTestId('mm-franja-paramo'));
+    expect(raiz.getAttribute('data-modo')).toBe('finca');
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('Páramo');
+  });
+
+  it('sube y baja de piso con los pasos', () => {
+    render(<MontanaMundos />);
+    fireEvent.click(screen.getByTestId('mm-paso-arriba'));
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('frío');
+    fireEvent.click(screen.getByTestId('mm-paso-abajo'));
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('templado');
+  });
+
+  it('cada mundo tocable muestra el aviso honesto de qué abriría', () => {
+    render(<MontanaMundos />);
+    // Los 12 mundos están en la escena.
+    ['calendario', 'glaciar', 'restauracion', 'papa', 'animales', 'agente',
+      'cosecha', 'cafe', 'vender', 'mango', 'platano', 'rio'].forEach((id) => {
+      expect(screen.getByTestId(`mm-mundo-${id}`)).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('mm-mundo-mango'));
+    // El mango está en el piso cálido (tenue desde templado) — el mockup
+    // exige moverse de piso; el tocable activo sí avisa:
+    fireEvent.click(screen.getByTestId('mm-mundo-agente'));
+    expect(screen.getByTestId('mm-aviso').textContent).toContain('agente');
+  });
+
+  it('el botón volver llama onBack', () => {
+    const onBack = vi.fn();
+    render(<MontanaMundos onBack={onBack} />);
+    fireEvent.click(screen.getByText('← Volver'));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/src/mockups/montana-mundos.css
+++ b/src/mockups/montana-mundos.css
@@ -61,6 +61,8 @@
   --mm-platano-tallo: #8aa14f;
   --mm-cana: #a9bd68;
   --mm-piedra: #b7ab8d;
+  --mm-luz-a: rgba(255, 240, 200, 0.22);
+  --mm-luz-b: rgba(46, 32, 10, 0.16);
   --mm-halo-mundo: rgba(255, 205, 110, 0.9);
   --mm-etiqueta-bg: rgba(255, 248, 232, 0.94);
   --mm-etiqueta-ink: #4a3a20;
@@ -132,6 +134,8 @@
   --mm-platano-tallo: #24684a;
   --mm-cana: #2f7a52;
   --mm-piedra: #23405c;
+  --mm-luz-a: rgba(103, 232, 249, 0.10);
+  --mm-luz-b: rgba(2, 6, 16, 0.30);
   --mm-halo-mundo: rgba(34, 211, 238, 0.85);
   --mm-etiqueta-bg: rgba(8, 18, 34, 0.88);
   --mm-etiqueta-ink: #d9fbf3;
@@ -195,6 +199,8 @@
   --mm-platano-tallo: #94b757;
   --mm-cana: #b7d377;
   --mm-piedra: #c9c2a4;
+  --mm-luz-a: rgba(255, 255, 255, 0.26);
+  --mm-luz-b: rgba(28, 64, 30, 0.12);
   --mm-halo-mundo: rgba(120, 200, 90, 0.9);
   --mm-etiqueta-bg: rgba(255, 255, 255, 0.94);
   --mm-etiqueta-ink: #24532b;
@@ -302,7 +308,7 @@
   margin: 0 auto;
   overflow: hidden;
   touch-action: none;
-  background: var(--mm-cielo-a);
+  background: linear-gradient(180deg, var(--mm-cielo-a), var(--mm-cielo-b));
   transition: background 0.5s ease;
 }
 
@@ -345,7 +351,7 @@
   position: absolute;
   transform: translate(-50%, -100%);
   z-index: 4;
-  font: 800 9px 'Nunito', sans-serif;
+  font: 800 10.5px 'Nunito', sans-serif;
   color: var(--mm-etiqueta-ink);
   background: var(--mm-etiqueta-bg);
   border: 1px solid var(--mm-etiqueta-borde);
@@ -359,8 +365,8 @@
 .mm-mundo {
   position: absolute;
   transform: translate(-50%, -50%);
-  width: 30px;
-  height: 30px;
+  width: 38px;
+  height: 38px;
   padding: 0;
   border: none;
   background: transparent;
@@ -372,10 +378,10 @@
 }
 
 .mm-mundo-halo {
-  width: 20px;
-  height: 20px;
+  width: 23px;
+  height: 23px;
   border-radius: 50%;
-  border: 1.6px solid var(--mm-halo-mundo);
+  border: 2px solid var(--mm-halo-mundo);
   box-shadow: 0 0 10px var(--mm-halo-mundo), inset 0 0 6px var(--mm-halo-mundo);
   animation: mm-pulso 2.6s ease-in-out infinite;
 }
@@ -386,7 +392,7 @@
   left: 50%;
   transform: translateX(-50%);
   margin-top: 1px;
-  font: 800 7.5px 'Nunito', sans-serif;
+  font: 800 10px 'Nunito', sans-serif;
   color: var(--mm-etiqueta-ink);
   background: var(--mm-etiqueta-bg);
   border: 1px solid var(--mm-etiqueta-borde);
@@ -560,9 +566,11 @@
 .mm-stop-halo-b { stop-color: var(--mm-halo-b); }
 .mm-stop-rio-a { stop-color: var(--mm-rio-a); }
 .mm-stop-rio-b { stop-color: var(--mm-rio-b); }
+.mm-stop-luz-a { stop-color: var(--mm-luz-a); }
+.mm-stop-luz-b { stop-color: var(--mm-luz-b); }
 
-.mm-ridge-a { fill: var(--mm-ridge-a); opacity: 0.75; }
-.mm-ridge-b { fill: var(--mm-ridge-b); opacity: 0.65; }
+.mm-ridge-a { fill: var(--mm-ridge-a); opacity: 0.5; }
+.mm-ridge-b { fill: var(--mm-ridge-b); opacity: 0.42; }
 
 .mm-piso-paramo { fill: var(--mm-paramo); }
 .mm-piso-frio { fill: var(--mm-frio); }
@@ -579,7 +587,9 @@
 }
 
 .mm[data-dir='biopunk'] .mm-borde-piso {
-  filter: drop-shadow(0 0 3px rgba(34, 211, 238, 0.7));
+  stroke-width: 2.4;
+  opacity: 0.85;
+  filter: drop-shadow(0 0 4px rgba(34, 211, 238, 0.8));
 }
 
 .mm-niebla { fill: var(--mm-niebla); }
@@ -663,6 +673,10 @@
 .mm-mercado-fruta-a { fill: var(--mm-fruta-a); }
 .mm-mercado-fruta-b { fill: var(--mm-fruta-b); }
 
+/* Sombríos del cafetal */
+.mm-sombrio path { fill: none; stroke: var(--mm-tronco); stroke-width: 4; stroke-linecap: round; }
+.mm-sombrio-copa { fill: var(--mm-mango-copa); opacity: 0.88; }
+
 /* Cálido */
 .mm-mango-tronco { fill: none; stroke: var(--mm-tronco); stroke-width: 7; stroke-linecap: round; }
 .mm-mango-copa { fill: var(--mm-mango-copa); }
@@ -702,6 +716,10 @@
   stroke: none;
   animation: mm-titila 2.8s ease-in-out infinite alternate;
 }
+
+/* Follaje botánico en primer plano (solo verde vivo) */
+.mm-botanica { display: none; }
+.mm[data-dir='verde'] .mm-botanica { display: block; fill: #4c9a4f; }
 
 /* Mariposas (solo verde vivo) */
 .mm-mariposas { display: none; }

--- a/src/mockups/montana-mundos.css
+++ b/src/mockups/montana-mundos.css
@@ -1,0 +1,759 @@
+/* montana-mundos.css — MOCKUP DEV #/mockups/montana-mundos (prefijo mm-).
+ *
+ * UNA sola escena SVG; las tres direcciones artísticas la re-pintan con
+ * variables CSS conmutadas por [data-dir]:
+ *   1. naturalista — Sierra Nevada pictórica, luz dorada de montaña.
+ *   2. biopunk     — neón orgánico nocturno (paleta del home en prod:
+ *                    navy #0c1830 + cian 34,211,238 + magenta + lima).
+ *   3. verde       — verde vivo botánico, luminoso, diurno.
+ *
+ * La vida de la escena (agua que baja, frailejón que respira, humo de la
+ * casa, micelio que late) es CSS puro y muere entera con
+ * prefers-reduced-motion. Tipografía Baloo 2 / Nunito (ya self-host). */
+
+.mm {
+  /* ── Dirección 1 (default): SIERRA NATURALISTA ── */
+  --mm-cielo-a: #f0c98d;
+  --mm-cielo-b: #e9ddbd;
+  --mm-astro: #ffdf8e;
+  --mm-halo-a: rgba(255, 199, 112, 0.55);
+  --mm-halo-b: rgba(255, 199, 112, 0);
+  --mm-ridge-a: #c9a072;
+  --mm-ridge-b: #bd9268;
+  --mm-nieve: #fdf6ec;
+  --mm-paramo: #a8a469;
+  --mm-frio: #7d9a58;
+  --mm-templado: #55824a;
+  --mm-calido: #94aa52;
+  --mm-valle: #c0bf75;
+  --mm-rio-a: #93c6be;
+  --mm-rio-b: #6da9ae;
+  --mm-flujo: rgba(255, 255, 255, 0.75);
+  --mm-laguna: #9fd0c9;
+  --mm-niebla: rgba(255, 250, 235, 0.34);
+  --mm-borde-piso: rgba(255, 244, 214, 0.42);
+  --mm-frailejon-hoja: #b9c46b;
+  --mm-frailejon-flor: #e8c95a;
+  --mm-tronco: #8a6e4b;
+  --mm-casa-muro: #f3e6cf;
+  --mm-casa-techo: #b3563d;
+  --mm-ventana: #ffd166;
+  --mm-ventana-glow: rgba(255, 209, 102, 0.75);
+  --mm-puerta: #7a5236;
+  --mm-camino: rgba(230, 205, 160, 0.8);
+  --mm-cafe-mata: #3f6b3a;
+  --mm-cafe-fruto: #d64545;
+  --mm-cerca: #8a6e4b;
+  --mm-oveja: #f5efe2;
+  --mm-vaca: #e3d3ba;
+  --mm-surco: rgba(90, 116, 62, 0.55);
+  --mm-mata-papa: #4d7a43;
+  --mm-troje-cuerpo: #caa36a;
+  --mm-troje-techo: #8a5c3c;
+  --mm-grano: #e9c96a;
+  --mm-toldo-a: #d9603b;
+  --mm-toldo-b: #f4e9d2;
+  --mm-fruta-a: #e5a33c;
+  --mm-fruta-b: #c94f4f;
+  --mm-mango-copa: #4c8043;
+  --mm-mango-fruto: #f2a541;
+  --mm-platano-hoja: #5f9c4a;
+  --mm-platano-tallo: #8aa14f;
+  --mm-cana: #a9bd68;
+  --mm-piedra: #b7ab8d;
+  --mm-halo-mundo: rgba(255, 205, 110, 0.9);
+  --mm-etiqueta-bg: rgba(255, 248, 232, 0.94);
+  --mm-etiqueta-ink: #4a3a20;
+  --mm-etiqueta-borde: rgba(122, 82, 54, 0.28);
+  --mm-velo: rgba(59, 44, 22, 0.45);
+  --mm-ui-fondo: #f7ecd7;
+  --mm-ui-tinta: #3c2f1c;
+  --mm-ui-suave: #7b6a4d;
+  --mm-ui-acento: #b3563d;
+  --mm-ui-acento-tinta: #fff6ea;
+  --mm-ui-borde: rgba(90, 70, 40, 0.2);
+
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--mm-ui-fondo);
+  color: var(--mm-ui-tinta);
+  font-family: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+/* ── Dirección 2: BIOPUNK (coherente con el home en prod) ── */
+.mm[data-dir='biopunk'] {
+  --mm-cielo-a: #0c1830;
+  --mm-cielo-b: #16263f;
+  --mm-astro: #dff6ff;
+  --mm-halo-a: rgba(34, 211, 238, 0.4);
+  --mm-halo-b: rgba(34, 211, 238, 0);
+  --mm-ridge-a: #101f36;
+  --mm-ridge-b: #0d1a2e;
+  --mm-nieve: #cfe6f2;
+  --mm-paramo: #143349;
+  --mm-frio: #123f3e;
+  --mm-templado: #175035;
+  --mm-calido: #1d5c33;
+  --mm-valle: #24683a;
+  --mm-rio-a: #1b4a66;
+  --mm-rio-b: #0f2f4a;
+  --mm-flujo: rgba(103, 232, 249, 0.85);
+  --mm-laguna: #1d5a70;
+  --mm-niebla: rgba(34, 211, 238, 0.08);
+  --mm-borde-piso: rgba(34, 211, 238, 0.5);
+  --mm-frailejon-hoja: #3f7a63;
+  --mm-frailejon-flor: #a3e635;
+  --mm-tronco: #2a4a44;
+  --mm-casa-muro: #1b2c44;
+  --mm-casa-techo: #24405e;
+  --mm-ventana: #f0abfc;
+  --mm-ventana-glow: rgba(240, 171, 252, 0.8);
+  --mm-puerta: #101d31;
+  --mm-camino: rgba(34, 211, 238, 0.35);
+  --mm-cafe-mata: #1f5c40;
+  --mm-cafe-fruto: #fb7185;
+  --mm-cerca: #2c4258;
+  --mm-oveja: #b8c7d9;
+  --mm-vaca: #9fb4c9;
+  --mm-surco: rgba(47, 191, 143, 0.4);
+  --mm-mata-papa: #2fbf8f;
+  --mm-troje-cuerpo: #22354e;
+  --mm-troje-techo: #2c4a66;
+  --mm-grano: #fbbf24;
+  --mm-toldo-a: #22d3ee;
+  --mm-toldo-b: #16263f;
+  --mm-fruta-a: #a3e635;
+  --mm-fruta-b: #f0abfc;
+  --mm-mango-copa: #1f6b45;
+  --mm-mango-fruto: #fbbf24;
+  --mm-platano-hoja: #2f8a5a;
+  --mm-platano-tallo: #24684a;
+  --mm-cana: #2f7a52;
+  --mm-piedra: #23405c;
+  --mm-halo-mundo: rgba(34, 211, 238, 0.85);
+  --mm-etiqueta-bg: rgba(8, 18, 34, 0.88);
+  --mm-etiqueta-ink: #d9fbf3;
+  --mm-etiqueta-borde: rgba(34, 211, 238, 0.45);
+  --mm-velo: rgba(4, 10, 22, 0.6);
+  --mm-ui-fondo: #0a1424;
+  --mm-ui-tinta: #ecfeff;
+  --mm-ui-suave: #93b4c4;
+  --mm-ui-acento: #22d3ee;
+  --mm-ui-acento-tinta: #06202a;
+  --mm-ui-borde: rgba(148, 197, 255, 0.18);
+}
+
+/* ── Dirección 3: VERDE VIVO (botánico luminoso diurno) ── */
+.mm[data-dir='verde'] {
+  --mm-cielo-a: #aee3f0;
+  --mm-cielo-b: #eef7d6;
+  --mm-astro: #fff4a3;
+  --mm-halo-a: rgba(255, 238, 150, 0.6);
+  --mm-halo-b: rgba(255, 238, 150, 0);
+  --mm-ridge-a: #9fd3c0;
+  --mm-ridge-b: #8cc7b2;
+  --mm-nieve: #ffffff;
+  --mm-paramo: #b5cf7d;
+  --mm-frio: #8abf68;
+  --mm-templado: #5aab5c;
+  --mm-calido: #a8d162;
+  --mm-valle: #d3e89e;
+  --mm-rio-a: #8fd8d2;
+  --mm-rio-b: #5fbdb7;
+  --mm-flujo: rgba(255, 255, 255, 0.9);
+  --mm-laguna: #9fe0da;
+  --mm-niebla: rgba(255, 255, 255, 0.3);
+  --mm-borde-piso: rgba(255, 255, 255, 0.55);
+  --mm-frailejon-hoja: #c4d97a;
+  --mm-frailejon-flor: #ffd95e;
+  --mm-tronco: #9b7b52;
+  --mm-casa-muro: #fffdf2;
+  --mm-casa-techo: #e0784a;
+  --mm-ventana: #ffdf70;
+  --mm-ventana-glow: rgba(255, 223, 112, 0.7);
+  --mm-puerta: #8a5c3c;
+  --mm-camino: rgba(232, 220, 174, 0.9);
+  --mm-cafe-mata: #3e8a4a;
+  --mm-cafe-fruto: #e64f4f;
+  --mm-cerca: #9b7b52;
+  --mm-oveja: #ffffff;
+  --mm-vaca: #f2e8d8;
+  --mm-surco: rgba(94, 138, 66, 0.5);
+  --mm-mata-papa: #4c9a4f;
+  --mm-troje-cuerpo: #e6c185;
+  --mm-troje-techo: #a06a44;
+  --mm-grano: #ffd95e;
+  --mm-toldo-a: #57b26a;
+  --mm-toldo-b: #fffdf2;
+  --mm-fruta-a: #f2a541;
+  --mm-fruta-b: #e64f4f;
+  --mm-mango-copa: #57a84e;
+  --mm-mango-fruto: #ffb547;
+  --mm-platano-hoja: #66bb55;
+  --mm-platano-tallo: #94b757;
+  --mm-cana: #b7d377;
+  --mm-piedra: #c9c2a4;
+  --mm-halo-mundo: rgba(120, 200, 90, 0.9);
+  --mm-etiqueta-bg: rgba(255, 255, 255, 0.94);
+  --mm-etiqueta-ink: #24532b;
+  --mm-etiqueta-borde: rgba(60, 130, 70, 0.3);
+  --mm-velo: rgba(235, 248, 220, 0.55);
+  --mm-ui-fondo: #f3fae4;
+  --mm-ui-tinta: #1e3d24;
+  --mm-ui-suave: #5c7a58;
+  --mm-ui-acento: #3e8a4a;
+  --mm-ui-acento-tinta: #f4fbef;
+  --mm-ui-borde: rgba(60, 110, 60, 0.22);
+}
+
+/* ── Cabecera (barra del mockup + conmutador de dirección) ── */
+.mm-cabecera {
+  flex: 0 0 auto;
+  padding: 8px 12px 10px;
+  max-width: 560px;
+  width: 100%;
+  margin: 0 auto;
+  border-bottom: 1px solid var(--mm-ui-borde);
+  transition: background 0.5s ease, color 0.5s ease;
+}
+
+.mm-mockbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.mm-volver {
+  border: 1px solid var(--mm-ui-borde);
+  background: transparent;
+  color: var(--mm-ui-tinta);
+  font: 700 13px 'Nunito', sans-serif;
+  border-radius: 999px;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+
+.mm-mockbar-titulo {
+  font: 700 10px 'Nunito', sans-serif;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--mm-ui-suave);
+}
+
+.mm-titulo {
+  margin: 6px 0 8px;
+  font: 700 21px/1.1 'Baloo 2', 'Nunito', sans-serif;
+  color: var(--mm-ui-tinta);
+}
+
+.mm-direcciones {
+  display: flex;
+  gap: 6px;
+}
+
+.mm-dir-btn {
+  flex: 1;
+  min-height: 44px;
+  border: 1.5px solid var(--mm-ui-borde);
+  border-radius: 14px;
+  background: transparent;
+  color: var(--mm-ui-tinta);
+  font: 700 13.5px 'Nunito', sans-serif;
+  cursor: pointer;
+  transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+}
+
+.mm-dir-btn.es-activa {
+  background: var(--mm-ui-acento);
+  border-color: var(--mm-ui-acento);
+  color: var(--mm-ui-acento-tinta);
+}
+
+.mm-dir-num {
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  font-size: 11px;
+  margin-right: 2px;
+  vertical-align: -3px;
+}
+
+.mm-dir-lema {
+  margin: 7px 2px 0;
+  font-size: 12.5px;
+  color: var(--mm-ui-suave);
+}
+
+.mm-dir-lema strong { color: var(--mm-ui-tinta); }
+
+/* ── Ventana a la montaña ── */
+.mm-viewport {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-width: 560px;
+  width: 100%;
+  margin: 0 auto;
+  overflow: hidden;
+  touch-action: none;
+  background: var(--mm-cielo-a);
+  transition: background 0.5s ease;
+}
+
+.mm-escena {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  transform-origin: 0 0;
+  transition: transform 0.7s cubic-bezier(0.22, 0.9, 0.3, 1);
+  will-change: transform;
+}
+
+.mm-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ── Velos: pisos no activos tenues en modo finca ── */
+.mm-velo {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: var(--mm-velo);
+  opacity: 1;
+  transition: opacity 0.7s ease, background 0.5s ease;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.mm-velo-arriba { top: 0; }
+.mm-velo-abajo { bottom: 0; }
+.mm[data-modo='montana'] .mm-velo { opacity: 0; }
+
+/* ── Marcador de la finca ── */
+.mm-finca-pin {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  z-index: 4;
+  font: 800 9px 'Nunito', sans-serif;
+  color: var(--mm-etiqueta-ink);
+  background: var(--mm-etiqueta-bg);
+  border: 1px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  padding: 3px 7px;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+}
+
+/* ── Mundos tocables: halo + etiqueta ── */
+.mm-mundo {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 5;
+  transition: opacity 0.5s ease;
+}
+
+.mm-mundo-halo {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1.6px solid var(--mm-halo-mundo);
+  box-shadow: 0 0 10px var(--mm-halo-mundo), inset 0 0 6px var(--mm-halo-mundo);
+  animation: mm-pulso 2.6s ease-in-out infinite;
+}
+
+.mm-mundo-etiqueta {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 1px;
+  font: 800 7.5px 'Nunito', sans-serif;
+  color: var(--mm-etiqueta-ink);
+  background: var(--mm-etiqueta-bg);
+  border: 1px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  padding: 2.5px 6px;
+  white-space: nowrap;
+}
+
+.mm-mundo.es-tenue { opacity: 0.24; pointer-events: none; }
+.mm[data-modo='montana'] .mm-mundo { opacity: 0; pointer-events: none; }
+
+/* ── Franjas de piso (solo montaña completa): tocar acerca ── */
+.mm-franja {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  border: none;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 6;
+  transition: opacity 0.5s ease;
+}
+
+.mm[data-modo='montana'] .mm-franja { opacity: 1; pointer-events: auto; }
+
+.mm-franja-rotulo {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  font: 800 26px 'Baloo 2', 'Nunito', sans-serif;
+  color: var(--mm-etiqueta-ink);
+  background: var(--mm-etiqueta-bg);
+  border: 2px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  padding: 6px 18px;
+  white-space: nowrap;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+}
+
+.mm-franja:focus-visible .mm-franja-rotulo,
+.mm-franja:active .mm-franja-rotulo { border-color: var(--mm-ui-acento); }
+
+/* ── Brújula del piso + pasos + zoom (encima de la escena, tamaño real) ── */
+.mm-brujula {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  pointer-events: none;
+}
+
+.mm-brujula-piso {
+  font: 800 12.5px 'Nunito', sans-serif;
+  color: var(--mm-etiqueta-ink);
+  background: var(--mm-etiqueta-bg);
+  border: 1px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  padding: 6px 14px;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.16);
+  white-space: nowrap;
+}
+
+.mm-paso {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  min-height: 40px;
+  border: 1px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  background: var(--mm-etiqueta-bg);
+  color: var(--mm-etiqueta-ink);
+  font: 800 12.5px 'Nunito', sans-serif;
+  padding: 8px 16px;
+  cursor: pointer;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.16);
+}
+
+.mm-paso-arriba { top: 46px; }
+.mm-paso-abajo { bottom: 64px; }
+
+.mm-zoom {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 11;
+  min-height: 46px;
+  border: none;
+  border-radius: 999px;
+  background: var(--mm-ui-acento);
+  color: var(--mm-ui-acento-tinta);
+  font: 800 14.5px 'Nunito', sans-serif;
+  padding: 10px 20px;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+  white-space: nowrap;
+}
+
+/* ── Atajos permanentes (Ⓐ + anotar): nunca detrás de la montaña ── */
+.mm-atajos {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  max-width: 560px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 10px 12px calc(10px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid var(--mm-ui-borde);
+  background: var(--mm-ui-fondo);
+  transition: background 0.5s ease;
+}
+
+.mm-atajo-anotar {
+  flex: 1;
+  min-height: 52px;
+  border: 1.5px solid var(--mm-ui-borde);
+  border-radius: 16px;
+  background: transparent;
+  color: var(--mm-ui-tinta);
+  font: 800 15px 'Nunito', sans-serif;
+  cursor: pointer;
+}
+
+.mm-atajo-agente {
+  flex: 0 0 auto;
+  width: 56px;
+  height: 56px;
+  border: none;
+  border-radius: 50%;
+  background: var(--mm-ui-acento);
+  color: var(--mm-ui-acento-tinta);
+  font: 800 26px/1 'Baloo 2', 'Nunito', sans-serif;
+  cursor: pointer;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--mm-ui-acento) 25%, transparent), 0 6px 16px rgba(0, 0, 0, 0.25);
+}
+
+/* ── Aviso honesto del mockup ── */
+.mm-aviso {
+  position: fixed;
+  left: 50%;
+  bottom: 92px;
+  transform: translateX(-50%);
+  z-index: 60;
+  max-width: min(86vw, 420px);
+  font: 700 13.5px 'Nunito', sans-serif;
+  color: #fffdf4;
+  background: rgba(20, 28, 24, 0.92);
+  border-radius: 14px;
+  padding: 10px 16px;
+  text-align: center;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.mm button:focus-visible {
+  outline: 2.5px solid var(--mm-ui-acento);
+  outline-offset: 2px;
+}
+
+/* ═══════════ La escena SVG: pintura por dirección ═══════════ */
+
+.mm-stop-cielo-a { stop-color: var(--mm-cielo-a); }
+.mm-stop-cielo-b { stop-color: var(--mm-cielo-b); }
+.mm-stop-halo-a { stop-color: var(--mm-halo-a); }
+.mm-stop-halo-b { stop-color: var(--mm-halo-b); }
+.mm-stop-rio-a { stop-color: var(--mm-rio-a); }
+.mm-stop-rio-b { stop-color: var(--mm-rio-b); }
+
+.mm-ridge-a { fill: var(--mm-ridge-a); opacity: 0.75; }
+.mm-ridge-b { fill: var(--mm-ridge-b); opacity: 0.65; }
+
+.mm-piso-paramo { fill: var(--mm-paramo); }
+.mm-piso-frio { fill: var(--mm-frio); }
+.mm-piso-templado { fill: var(--mm-templado); }
+.mm-piso-calido { fill: var(--mm-calido); }
+.mm-piso-valle { fill: var(--mm-valle); }
+.mm-nieve { fill: var(--mm-nieve); }
+
+.mm-borde-piso {
+  fill: none;
+  stroke: var(--mm-borde-piso);
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.mm[data-dir='biopunk'] .mm-borde-piso {
+  filter: drop-shadow(0 0 3px rgba(34, 211, 238, 0.7));
+}
+
+.mm-niebla { fill: var(--mm-niebla); }
+
+/* Astro: sol (día) o luna (biopunk, con cráteres) */
+.mm-astro-disco { fill: var(--mm-astro); }
+.mm-astro-crater { fill: rgba(140, 175, 195, 0.5); display: none; }
+.mm[data-dir='biopunk'] .mm-astro-crater { display: block; }
+
+/* Estrellas: solo en la noche biopunk, titilan */
+.mm-estrellas { display: none; }
+.mm[data-dir='biopunk'] .mm-estrellas { display: block; }
+.mm-estrella { fill: #cdeffb; animation: mm-titila 3.2s ease-in-out infinite alternate; }
+.mm-estrella:nth-of-type(2n) { animation-delay: 1.1s; }
+.mm-estrella:nth-of-type(3n) { animation-delay: 2s; }
+
+/* Nubes: pasan despacio en las direcciones de día */
+.mm-nube { fill: rgba(255, 255, 255, 0.8); }
+.mm-nube-1 { animation: mm-deriva 18s ease-in-out infinite alternate; }
+.mm-nube-2 { animation: mm-deriva 24s ease-in-out infinite alternate-reverse; }
+.mm[data-dir='biopunk'] .mm-nubes { display: none; }
+
+/* Aves lejanas: solo la sierra */
+.mm-aves { display: none; }
+.mm[data-dir='naturalista'] .mm-aves {
+  display: block;
+  fill: none;
+  stroke: #6b5334;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+}
+
+/* Páramo */
+.mm-frailejon-tronco { fill: var(--mm-tronco); }
+.mm-frailejon-hoja { fill: var(--mm-frailejon-hoja); }
+.mm-frailejon-flor { fill: var(--mm-frailejon-flor); }
+.mm-frailejon-roseta {
+  transform-box: fill-box;
+  transform-origin: 50% 88%;
+  animation: mm-respira 4.6s ease-in-out infinite alternate;
+}
+
+.mm-laguna { fill: var(--mm-laguna); }
+.mm-laguna-brillo { fill: none; stroke: var(--mm-flujo); stroke-width: 1.6; stroke-linecap: round; opacity: 0.7; }
+
+/* Frío */
+.mm-surcos path { fill: none; stroke: var(--mm-surco); stroke-width: 5; stroke-linecap: round; }
+.mm-matas-papa circle { fill: var(--mm-mata-papa); }
+.mm-cerca-poste, .mm-cerca-riel { fill: var(--mm-cerca); }
+.mm-oveja { fill: var(--mm-oveja); }
+.mm-vaca { fill: var(--mm-vaca); }
+
+/* Templado: la casa viva */
+.mm-casa-muro { fill: var(--mm-casa-muro); }
+.mm-casa-techo { fill: var(--mm-casa-techo); }
+.mm-casa-chimenea { fill: var(--mm-casa-techo); }
+.mm-casa-puerta { fill: var(--mm-puerta); }
+.mm-casa-ventana {
+  fill: var(--mm-ventana);
+  filter: drop-shadow(0 0 4px var(--mm-ventana-glow));
+}
+.mm-casa-camino { fill: none; stroke: var(--mm-camino); stroke-width: 4; stroke-linecap: round; }
+
+.mm-humo circle { fill: rgba(235, 235, 235, 0.55); }
+.mm[data-dir='biopunk'] .mm-humo circle { fill: rgba(167, 230, 255, 0.35); }
+.mm-humo-1 { animation: mm-humo 3.2s ease-out infinite; }
+.mm-humo-2 { animation: mm-humo 3.2s ease-out infinite 1.05s; }
+.mm-humo-3 { animation: mm-humo 3.2s ease-out infinite 2.1s; }
+
+.mm-troje-cuerpo { fill: var(--mm-troje-cuerpo); }
+.mm-troje-techo { fill: var(--mm-troje-techo); }
+.mm-troje-pata { fill: var(--mm-puerta); }
+.mm-troje-grano { fill: var(--mm-grano); }
+
+.mm-cafe-mata { fill: var(--mm-cafe-mata); }
+.mm-cafe-fruto { fill: var(--mm-cafe-fruto); }
+
+.mm-mercado-meson, .mm-mercado-tabla { fill: var(--mm-troje-cuerpo); }
+.mm-toldo-a { fill: var(--mm-toldo-a); }
+.mm-toldo-b { fill: var(--mm-toldo-b); }
+.mm-mercado-fruta-a { fill: var(--mm-fruta-a); }
+.mm-mercado-fruta-b { fill: var(--mm-fruta-b); }
+
+/* Cálido */
+.mm-mango-tronco { fill: none; stroke: var(--mm-tronco); stroke-width: 7; stroke-linecap: round; }
+.mm-mango-copa { fill: var(--mm-mango-copa); }
+.mm-mango-fruto { fill: var(--mm-mango-fruto); }
+.mm-platano-hoja { fill: var(--mm-platano-hoja); }
+.mm-platano-tallo { fill: var(--mm-platano-tallo); }
+.mm-racimo circle { fill: var(--mm-grano); }
+.mm-cana-tallo { fill: none; stroke: var(--mm-cana); stroke-width: 3.4; stroke-linecap: round; }
+.mm-piedra { fill: var(--mm-piedra); }
+
+/* Río: el agua baja siempre */
+.mm-flujo path {
+  fill: none;
+  stroke: var(--mm-flujo);
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-dasharray: 10 16;
+  animation: mm-baja 2.4s linear infinite;
+  opacity: 0.75;
+}
+
+/* Micelio: la red viva conecta los pisos (solo biopunk) */
+.mm-micelio { display: none; }
+.mm[data-dir='biopunk'] .mm-micelio {
+  display: block;
+  fill: none;
+  stroke: #67e8f9;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-dasharray: 2 9;
+  opacity: 0.65;
+  filter: drop-shadow(0 0 3px rgba(103, 232, 249, 0.8));
+  animation: mm-micelio-fluye 7s linear infinite;
+}
+.mm[data-dir='biopunk'] .mm-micelio-nodo {
+  fill: #a3e635;
+  stroke: none;
+  animation: mm-titila 2.8s ease-in-out infinite alternate;
+}
+
+/* Mariposas (solo verde vivo) */
+.mm-mariposas { display: none; }
+.mm[data-dir='verde'] .mm-mariposas { display: block; }
+.mm-mariposa-1 { fill: #f2a541; animation: mm-flota 3.6s ease-in-out infinite alternate; }
+.mm-mariposa-2 { fill: #e05f8a; animation: mm-flota 4.4s ease-in-out infinite alternate-reverse; }
+
+/* ── Vida de la escena ── */
+@keyframes mm-pulso {
+  0%, 100% { transform: scale(1); opacity: 0.95; }
+  50% { transform: scale(1.22); opacity: 0.55; }
+}
+
+@keyframes mm-respira {
+  from { transform: scale(1); }
+  to { transform: scale(1.05); }
+}
+
+@keyframes mm-humo {
+  0% { transform: translateY(0); opacity: 0.55; }
+  100% { transform: translateY(-18px); opacity: 0; }
+}
+
+@keyframes mm-baja {
+  from { stroke-dashoffset: 0; }
+  to { stroke-dashoffset: -52; }
+}
+
+@keyframes mm-micelio-fluye {
+  from { stroke-dashoffset: 0; }
+  to { stroke-dashoffset: -110; }
+}
+
+@keyframes mm-titila {
+  from { opacity: 0.35; }
+  to { opacity: 1; }
+}
+
+@keyframes mm-deriva {
+  from { transform: translateX(-12px); }
+  to { transform: translateX(14px); }
+}
+
+@keyframes mm-flota {
+  from { transform: translate(0, 0) rotate(-6deg); }
+  to { transform: translate(10px, -10px) rotate(8deg); }
+}
+
+/* La montaña se queda quieta si la persona lo pide */
+@media (prefers-reduced-motion: reduce) {
+  .mm *, .mm *::before, .mm *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/mockups/montana-mundos.css
+++ b/src/mockups/montana-mundos.css
@@ -632,6 +632,14 @@
   animation: mm-respira 4.6s ease-in-out infinite alternate;
 }
 
+.mm-pajonal path {
+  fill: none;
+  stroke: var(--mm-frailejon-hoja);
+  stroke-width: 2;
+  stroke-linecap: round;
+  opacity: 0.75;
+}
+
 .mm-laguna { fill: var(--mm-laguna); }
 .mm-laguna-brillo { fill: none; stroke: var(--mm-flujo); stroke-width: 1.6; stroke-linecap: round; opacity: 0.7; }
 


### PR DESCRIPTION
## Qué

Mockup de decisión visual **#/mockups/montana-mundos** (sin gate ni sesión): la navegación de Chagra como **paisaje vertical de pisos térmicos** — el modelo mental que el campesino ya usa (café=templado, papa=frío, frailejón=páramo). Referencia: Sierra Nevada de Santa Marta, del río al nevado en una sola montaña.

- **Abre centrado en la finca del usuario** (su piso térmico resaltado, los demás tenues); pellizco o botón visible hacen **zoom-out a la montaña completa**; tocar un piso lo acerca; deslizar vertical sube/baja de piso.
- **12 mundos tocables** con halo pulsante + etiqueta (afordancia obvia): luna→calendario, glaciar, frailejón→restauración, papa, corral→animales, casa→agente, troje→cosecha, cafetal→café, mercado→vender, mango, platanera→plátano, río→agua.
- **Atajos permanentes** siempre visibles: botón Ⓐ del agente + Anotar mi día — ninguna tarea queda detrás de escalar la montaña.
- **3 direcciones artísticas conmutables y rotuladas** sobre la MISMA escena SVG (variables CSS por `data-dir`):
  1. **Sierra naturalista** — pictórica, luz dorada de montaña.
  2. **Biopunk** — neón orgánico nocturno, paleta del home en prod (navy #0c1830 + cian + magenta + lima) con la red de micelio conectando pisos.
  3. **Verde vivo** — botánico luminoso diurno, follaje en primer plano.
- **Vida sutil**: agua que baja, frailejón que respira, humo de la casa, estrellas/micelio (biopunk), nubes/aves (sierra), mariposas (verde). Todo muere con `prefers-reduced-motion`.
- SVG/CSS puro: cero dependencias nuevas, cero fotos. Cableado idéntico a los otros mockups (HASH_VIEW_ROUTES + boot + hashchange + case; AgentFab global excluido de vistas `mockup_*`).

## Test plan

- `npx vitest run src/mockups/__tests__/MontanaMundos.smoke.test.jsx` → 6/6 verdes (3 direcciones conmutan, zoom finca↔montaña, franjas de piso, 12 mundos + aviso, pasos de piso, onBack).
- `node scripts/tsc-check-gate.mjs` → 1818 errores vs baseline 1829 (sin errores nuevos).
- `npx eslint` sobre archivos tocados → 0 errores.
- `npm run build` + `npm run perf-budget` → 24.3 MB / 25.5 MB dentro del budget.
- Verificado EN VIVO con Playwright (390x844, táctil): las 3 direcciones renderizan, el zoom-out funciona, franja→piso→mundo→aviso responden. Capturas por dirección enviadas al operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
