### PR TITLE
fix(agente): renderizado markdown en chat (rescate)

### DIFF
--- a/src/components/AgentScreen/AgentMarkdown.jsx
+++ b/src/components/AgentScreen/AgentMarkdown.jsx
@@ -1,0 +1,33 @@
+import React, { useMemo } from 'react';
+import { renderAgentMarkdown } from '../../utils/renderAgentMarkdown';
+
+/**
+ * AgentMarkdown — pinta el texto de una respuesta del agente como markdown
+ * renderizado (negritas, viñetas, títulos) en vez de mostrar `**`/`###` crudos.
+ *
+ * SEGURIDAD: el HTML que inyectamos viene EXCLUSIVAMENTE de `renderAgentMarkdown`,
+ * que escapa todo el HTML de entrada y luego sanitiza con DOMPurify (allow-list
+ * estrecha, sin atributos, sin <a>/<img>/onclick). Por eso el uso de
+ * `dangerouslySetInnerHTML` es seguro aquí: la cadena nunca contiene HTML del
+ * usuario ni del modelo sin sanitizar. NO pasar a este componente HTML de otra
+ * fuente.
+ *
+ * El styling (tipografía clara, viñetas con punto, títulos legibles) lo aporta
+ * la clase `agent-md` definida en index.css — pensado para que un campesino o una
+ * niña lo lea limpio, sin asteriscos a la vista.
+ *
+ * @param {Object} props
+ * @param {string} props.content - Texto del agente (con o sin markdown).
+ * @param {string} [props.className] - Clases extra para el contenedor.
+ */
+export default function AgentMarkdown({ content, className = '' }) {
+  const html = useMemo(() => renderAgentMarkdown(content), [content]);
+  return (
+    <div
+      className={`agent-md text-sm leading-relaxed ${className}`.trim()}
+      /* HTML ya sanitizado por renderAgentMarkdown (escape de entrada + DOMPurify
+         con allow-list estrecha, sin atributos/href/onclick). Seguro por contrato. */
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -10,6 +10,7 @@ import usePrefsStore from '../../store/usePrefsStore';
 import FeedbackButtons from '../FeedbackButtons';
 import AIBetaBadge from '../AIBetaBadge';
 import SemaforoConfianza from './SemaforoConfianza';
+import AgentMarkdown from './AgentMarkdown';
 
 function formatTime(timestamp) {
   if (!timestamp) return '';
@@ -505,14 +506,24 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
           {/* #339: fallback visible si el contenido del assistant llega vacío
               (respuesta degradada del LLM, stream sin tokens, etc.). Nunca
               dejamos la burbuja en blanco — el usuario campesino no debe ver
-              una respuesta "fantasma". Para el usuario sí mostramos su texto
-              tal cual (puede ser vacío sólo si tipeó vacío, que el submit ya
-              previene). Cero hype, español colombiano. */}
-          <p className="text-[15px] leading-relaxed whitespace-pre-wrap">
-            {!isUser && (typeof message.content !== 'string' || message.content.trim().length === 0)
-              ? <span className="italic text-slate-400">No recibí respuesta del asistente. Intenta de nuevo.</span>
-              : message.content}
-          </p>
+              una respuesta "fantasma". Cero hype, español colombiano.
+
+              Task #58: el agente emite markdown (**negritas**, ### títulos,
+              * viñetas). Antes se mostraba CRUDO (whitespace-pre-wrap) y el
+              campesino/niña veía los asteriscos. Ahora las respuestas YA
+              ESTABILIZADAS del agente se renderizan como markdown limpio
+              (AgentMarkdown → escape + DOMPurify). El texto del usuario y el
+              streaming en curso siguen como texto plano: el del usuario no es
+              markdown, y el streaming evita parpadeo por `**` aún sin cerrar. */}
+          {!isUser && (typeof message.content !== 'string' || message.content.trim().length === 0) ? (
+            <p className="text-[15px] leading-relaxed whitespace-pre-wrap">
+              <span className="italic text-slate-400">No recibí respuesta del asistente. Intenta de nuevo.</span>
+            </p>
+          ) : !isUser && !isStreaming ? (
+            <AgentMarkdown content={message.content} />
+          ) : (
+            <p className="text-[15px] leading-relaxed whitespace-pre-wrap">{message.content}</p>
+          )}
           {/* UX-1 (#284): badge "beta" permanente cerca de cualquier respuesta
               IA del agente. NO reemplaza a SourceBadge (que es la fuente
               grounded vs generativa) — convive. Suprimido para mensajes de

--- a/src/components/AgentScreen/__tests__/ChatBubble.markdown.test.jsx
+++ b/src/components/AgentScreen/__tests__/ChatBubble.markdown.test.jsx
@@ -17,6 +17,11 @@ vi.mock('../../../services/agentSoundService', () => ({
 vi.mock('../../FeedbackButtons', () => ({ default: () => <div data-testid="feedback-mock" /> }));
 vi.mock('../../AIBetaBadge', () => ({ default: () => <div data-testid="beta-mock" /> }));
 
+// ChatBubble tipa onConsentNeeded/onRetryOrphan como requeridos (feedback y
+// recuperación de huérfanos, ninguno relevante para el render de markdown) —
+// no-ops que solo satisfacen el contrato de props.
+const noop = () => {};
+
 /**
  * Task #58: la burbuja del AGENTE debe renderizar markdown limpio (negritas,
  * viñetas), NO mostrar `**`/`###` crudos al campesino/niña. El texto del USUARIO
@@ -28,6 +33,8 @@ describe('ChatBubble — render de markdown del agente (#58)', () => {
       <ChatBubble
         message={{ role: 'assistant', content: 'Aplica **caldo bordelés** por la mañana.' }}
         isStreaming={false}
+        onConsentNeeded={noop}
+        onRetryOrphan={noop}
       />,
     );
     const strong = screen.getByText('caldo bordelés');
@@ -41,6 +48,8 @@ describe('ChatBubble — render de markdown del agente (#58)', () => {
       <ChatBubble
         message={{ role: 'assistant', content: 'Compañeras:\n* Caléndula\n* Albahaca' }}
         isStreaming={false}
+        onConsentNeeded={noop}
+        onRetryOrphan={noop}
       />,
     );
     expect(screen.getByText('Caléndula').tagName).toBe('LI');
@@ -53,6 +62,8 @@ describe('ChatBubble — render de markdown del agente (#58)', () => {
       <ChatBubble
         message={{ role: 'user', content: 'tengo **plaga** en el tomate' }}
         isStreaming={false}
+        onConsentNeeded={noop}
+        onRetryOrphan={noop}
       />,
     );
     // El texto del usuario conserva sus asteriscos literales (no es markdown).
@@ -64,6 +75,8 @@ describe('ChatBubble — render de markdown del agente (#58)', () => {
       <ChatBubble
         message={{ role: 'assistant', content: 'Voy a explicarte **cómo' }}
         isStreaming={true}
+        onConsentNeeded={noop}
+        onRetryOrphan={noop}
       />,
     );
     // Durante streaming no rompemos el render con markdown a medias.
@@ -72,7 +85,12 @@ describe('ChatBubble — render de markdown del agente (#58)', () => {
 
   it('respuesta vacía del agente: muestra fallback, no burbuja en blanco', () => {
     render(
-      <ChatBubble message={{ role: 'assistant', content: '' }} isStreaming={false} />,
+      <ChatBubble
+        message={{ role: 'assistant', content: '' }}
+        isStreaming={false}
+        onConsentNeeded={noop}
+        onRetryOrphan={noop}
+      />,
     );
     expect(screen.getByText(/No recibí respuesta/)).toBeInTheDocument();
   });

--- a/src/components/AgentScreen/__tests__/ChatBubble.markdown.test.jsx
+++ b/src/components/AgentScreen/__tests__/ChatBubble.markdown.test.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import ChatBubble from '../ChatBubble';
+
+// El avatar y servicios de voz traen assets/animaciones que no aportan al test
+// del render de markdown. Los mockeamos para aislar la burbuja.
+vi.mock('../../ChagraAgentAvatar', () => ({ default: () => <div data-testid="avatar-mock" /> }));
+vi.mock('../../../services/ttsService', () => ({
+  speak: vi.fn(), speakKokoro: vi.fn(), stop: vi.fn(),
+  isSpeaking: () => false, isKokoroAvailable: async () => false,
+}));
+vi.mock('../../../services/agentSoundService', () => ({
+  agentSounds: { chime: vi.fn(), cancel: vi.fn() },
+}));
+vi.mock('../../FeedbackButtons', () => ({ default: () => <div data-testid="feedback-mock" /> }));
+vi.mock('../../AIBetaBadge', () => ({ default: () => <div data-testid="beta-mock" /> }));
+
+/**
+ * Task #58: la burbuja del AGENTE debe renderizar markdown limpio (negritas,
+ * viñetas), NO mostrar `**`/`###` crudos al campesino/niña. El texto del USUARIO
+ * y el streaming en curso siguen como texto plano.
+ */
+describe('ChatBubble — render de markdown del agente (#58)', () => {
+  it('respuesta del agente: **negrita** se renderiza como <strong>, sin asteriscos', () => {
+    render(
+      <ChatBubble
+        message={{ role: 'assistant', content: 'Aplica **caldo bordelés** por la mañana.' }}
+        isStreaming={false}
+      />,
+    );
+    const strong = screen.getByText('caldo bordelés');
+    expect(strong.tagName).toBe('STRONG');
+    // Ningún asterisco crudo visible en la burbuja.
+    expect(document.body.textContent).not.toContain('**');
+  });
+
+  it('respuesta del agente: viñetas markdown → lista real <li>', () => {
+    render(
+      <ChatBubble
+        message={{ role: 'assistant', content: 'Compañeras:\n* Caléndula\n* Albahaca' }}
+        isStreaming={false}
+      />,
+    );
+    expect(screen.getByText('Caléndula').tagName).toBe('LI');
+    expect(screen.getByText('Albahaca').tagName).toBe('LI');
+    expect(document.body.textContent).not.toContain('* ');
+  });
+
+  it('mensaje del USUARIO se muestra como texto plano (no se interpreta markdown)', () => {
+    render(
+      <ChatBubble
+        message={{ role: 'user', content: 'tengo **plaga** en el tomate' }}
+        isStreaming={false}
+      />,
+    );
+    // El texto del usuario conserva sus asteriscos literales (no es markdown).
+    expect(screen.getByText('tengo **plaga** en el tomate')).toBeInTheDocument();
+  });
+
+  it('streaming en curso: texto plano (evita parpadeo por ** sin cerrar)', () => {
+    render(
+      <ChatBubble
+        message={{ role: 'assistant', content: 'Voy a explicarte **cómo' }}
+        isStreaming={true}
+      />,
+    );
+    // Durante streaming no rompemos el render con markdown a medias.
+    expect(screen.getByText(/Voy a explicarte/)).toBeInTheDocument();
+  });
+
+  it('respuesta vacía del agente: muestra fallback, no burbuja en blanco', () => {
+    render(
+      <ChatBubble message={{ role: 'assistant', content: '' }} isStreaming={false} />,
+    );
+    expect(screen.getByText(/No recibí respuesta/)).toBeInTheDocument();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -533,6 +533,8 @@
     width: max(100%, 44px);
     height: max(100%, 44px);
     transform: translate(-50%, -50%);
+  }
+
   /* Markdown renderizado de las respuestas del agente (task #58). Tipografía
    * limpia para campesino/niña: negritas marcadas, viñetas reales con punto,
    * títulos legibles — CERO asteriscos a la vista. El HTML viene sanitizado por

--- a/src/index.css
+++ b/src/index.css
@@ -533,6 +533,64 @@
     width: max(100%, 44px);
     height: max(100%, 44px);
     transform: translate(-50%, -50%);
+  /* Markdown renderizado de las respuestas del agente (task #58). Tipografía
+   * limpia para campesino/niña: negritas marcadas, viñetas reales con punto,
+   * títulos legibles — CERO asteriscos a la vista. El HTML viene sanitizado por
+   * renderAgentMarkdown (escape + DOMPurify allow-list). */
+  .agent-md > :first-child {
+    margin-top: 0;
+  }
+  .agent-md > :last-child {
+    margin-bottom: 0;
+  }
+  .agent-md p {
+    margin: 0 0 0.5rem;
+  }
+  .agent-md strong {
+    font-weight: 700;
+    color: inherit;
+  }
+  .agent-md em {
+    font-style: italic;
+  }
+  .agent-md h3 {
+    font-size: 0.95rem;
+    font-weight: 800;
+    margin: 0.6rem 0 0.3rem;
+    line-height: 1.3;
+  }
+  .agent-md h4 {
+    font-size: 0.88rem;
+    font-weight: 700;
+    margin: 0.5rem 0 0.25rem;
+    line-height: 1.3;
+  }
+  .agent-md ul,
+  .agent-md ol {
+    margin: 0.25rem 0 0.6rem;
+    padding-left: 1.25rem;
+  }
+  .agent-md ul {
+    list-style: disc;
+  }
+  .agent-md ol {
+    list-style: decimal;
+  }
+  .agent-md li {
+    margin: 0.15rem 0;
+  }
+  .agent-md code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85em;
+    background-color: rgb(var(--c-surface-raised) / 0.6);
+    padding: 0.05em 0.3em;
+    border-radius: 0.25rem;
+  }
+  .agent-md blockquote {
+    margin: 0.4rem 0;
+    padding-left: 0.7rem;
+    border-left: 3px solid rgb(var(--t-accent-rgb) / 0.5);
+    opacity: 0.92;
   }
 }
 

--- a/src/utils/renderAgentMarkdown.js
+++ b/src/utils/renderAgentMarkdown.js
@@ -1,0 +1,187 @@
+import DOMPurify from 'dompurify';
+
+/**
+ * renderAgentMarkdown — convierte el markdown que emite el agente (granite3.3)
+ * a HTML *limpio y seguro* para mostrarlo en la burbuja del chat.
+ *
+ * POR QUÉ existe (task #58, queja del operador 2026-06-19): el agente respondía
+ * con `**negritas**`, `*cursivas*`, `### títulos` y `* viñetas` en CRUDO. El
+ * campesino —o una niña— veía asteriscos y almohadillas literales en pantalla.
+ * Antes la burbuja pintaba `message.content` como texto plano (whitespace-pre-wrap),
+ * así que el markdown quedaba a la vista. Aquí lo renderizamos de verdad: negritas
+ * reales, viñetas reales, títulos legibles, cero asteriscos visibles.
+ *
+ * DISEÑO (mínimo + seguro, sin dependencias nuevas de parser):
+ *   1. Escapamos TODO el HTML de entrada primero (`escapeHtml`). El texto del LLM
+ *      NUNCA se trata como HTML — si el modelo emite `<script>`, queda como texto.
+ *   2. Aplicamos un subconjunto pequeño de markdown sobre el texto ya escapado:
+ *      encabezados, negrita, cursiva, código inline, viñetas, listas numeradas,
+ *      enlaces (a texto plano — no abrimos URLs del modelo), y saltos de línea.
+ *   3. Pasamos el resultado por DOMPurify con una allow-list ESTRECHA de etiquetas
+ *      seguras (sin <a href>, sin <img>, sin atributos). Defensa en profundidad:
+ *      aun si el paso 2 dejara pasar algo, DOMPurify lo limpia.
+ *
+ * El resultado es una cadena HTML lista para `dangerouslySetInnerHTML`. Es seguro
+ * SOLO porque pasa por DOMPurify con esta config; no usar el output crudo del
+ * paso 2 sin sanitizar.
+ *
+ * Tipografía / legibilidad pensada para campesino/niña: viñetas reales con punto,
+ * negrita marcada, títulos un poco más grandes — el styling final lo da el
+ * contenedor (clases `.agent-md` en ChatBubble), aquí solo emitimos la estructura.
+ */
+
+/** Etiquetas permitidas en la salida final (allow-list estrecha). */
+const ALLOWED_TAGS = [
+  'p', 'br', 'strong', 'em', 'code',
+  'ul', 'ol', 'li',
+  'h3', 'h4',
+  'blockquote',
+];
+
+/** Escapa los 5 caracteres HTML peligrosos. Primer y principal escudo anti-XSS. */
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Aplica el markdown inline (negrita, cursiva, código, enlaces) a UNA línea
+ * de texto YA escapada. No toca estructura de bloque (eso lo hace el caller).
+ */
+function inlineMarkdown(line) {
+  return (
+    line
+      // Código inline `texto` (antes que negrita/cursiva para no romper el código)
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      // Negrita **texto** o __texto__ (antes que cursiva: comparten el `*`)
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/__([^_]+)__/g, '<strong>$1</strong>')
+      // Cursiva *texto* o _texto_ (evita snake_case: _ debe estar entre no-letras)
+      .replace(/\*([^*\n]+)\*/g, '<em>$1</em>')
+      .replace(/(?<![A-Za-z0-9])_([^_\n]+)_(?![A-Za-z0-9])/g, '<em>$1</em>')
+      // Enlaces [texto](url) → solo el texto visible (no exponemos URLs del modelo)
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+  );
+}
+
+/**
+ * Convierte markdown del agente a una cadena HTML segura y sanitizada.
+ *
+ * @param {string} text - Texto del agente (posiblemente con markdown).
+ * @returns {string} HTML seguro (allow-list estrecha) listo para inyectar.
+ */
+export function renderAgentMarkdown(text) {
+  if (typeof text !== 'string' || text.length === 0) return '';
+
+  // 1) Escapar primero. A partir de aquí trabajamos sobre texto inerte.
+  const escaped = escapeHtml(text);
+
+  // 2) Recorremos línea por línea, agrupando bloques (listas, párrafos).
+  const lines = escaped.split(/\r?\n/);
+  const out = [];
+  let listType = null; // 'ul' | 'ol' | null
+  let paragraph = []; // líneas acumuladas del párrafo actual
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    // Saltos de línea simples dentro del párrafo → <br>.
+    const html = paragraph.map(inlineMarkdown).join('<br>');
+    out.push(`<p>${html}</p>`);
+    paragraph = [];
+  };
+
+  const closeList = () => {
+    if (listType) {
+      out.push(`</${listType}>`);
+      listType = null;
+    }
+  };
+
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, '');
+    const trimmed = line.trim();
+
+    // Línea en blanco → cierra párrafo y lista (separa bloques).
+    if (trimmed === '') {
+      flushParagraph();
+      closeList();
+      continue;
+    }
+
+    // Separador horizontal (---, ***, ===) → lo ignoramos (ruido visual).
+    if (/^([-*=])\1{2,}$/.test(trimmed)) {
+      flushParagraph();
+      closeList();
+      continue;
+    }
+
+    // Encabezados # .. ###### → h3 (### y más profundos) / h4 (no usamos h1/h2
+    // dentro de una burbuja para no romper la jerarquía de la página).
+    const heading = trimmed.match(/^(#{1,6})\s+(.*)$/);
+    if (heading) {
+      flushParagraph();
+      closeList();
+      const tag = heading[1].length <= 3 ? 'h3' : 'h4';
+      out.push(`<${tag}>${inlineMarkdown(heading[2].trim())}</${tag}>`);
+      continue;
+    }
+
+    // Cita > texto → blockquote (una línea por simplicidad).
+    const quote = trimmed.match(/^>\s?(.*)$/);
+    if (quote) {
+      flushParagraph();
+      closeList();
+      out.push(`<blockquote>${inlineMarkdown(quote[1].trim())}</blockquote>`);
+      continue;
+    }
+
+    // Viñeta - * + texto → <ul><li>.
+    const bullet = trimmed.match(/^[-*+]\s+(.*)$/);
+    if (bullet) {
+      flushParagraph();
+      if (listType !== 'ul') {
+        closeList();
+        out.push('<ul>');
+        listType = 'ul';
+      }
+      out.push(`<li>${inlineMarkdown(bullet[1].trim())}</li>`);
+      continue;
+    }
+
+    // Numerada 1. 2) texto → <ol><li>.
+    const numbered = trimmed.match(/^\d+[.)]\s+(.*)$/);
+    if (numbered) {
+      flushParagraph();
+      if (listType !== 'ol') {
+        closeList();
+        out.push('<ol>');
+        listType = 'ol';
+      }
+      out.push(`<li>${inlineMarkdown(numbered[1].trim())}</li>`);
+      continue;
+    }
+
+    // Texto normal: si veníamos en lista, la cerramos y arrancamos párrafo.
+    closeList();
+    paragraph.push(trimmed);
+  }
+
+  flushParagraph();
+  closeList();
+
+  const html = out.join('');
+
+  // 3) Sanitización final con allow-list estrecha. Sin atributos, sin <a>,
+  //    sin <img>, sin estilos inline. Defensa en profundidad.
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR: [],
+    USE_PROFILES: { html: true },
+  });
+}
+
+export default renderAgentMarkdown;

--- a/src/utils/renderAgentMarkdown.js
+++ b/src/utils/renderAgentMarkdown.js
@@ -71,7 +71,10 @@ function inlineMarkdown(line) {
 /**
  * Convierte markdown del agente a una cadena HTML segura y sanitizada.
  *
- * @param {string} text - Texto del agente (posiblemente con markdown).
+ * @param {*} text - Texto del agente (posiblemente con markdown). Tipado laxo
+ *   a propósito: degrada limpio (cadena vacía) ante `null`/`undefined`/no-string
+ *   en vez de lanzar — el guard `typeof text !== 'string'` de abajo es el
+ *   contrato real, no una excepción del tipo.
  * @returns {string} HTML seguro (allow-list estrecha) listo para inyectar.
  */
 export function renderAgentMarkdown(text) {

--- a/src/utils/renderAgentMarkdown.test.js
+++ b/src/utils/renderAgentMarkdown.test.js
@@ -1,0 +1,142 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- fixtures de test (entradas
+   de markdown del agente), no strings de UI; exentas de ADR-050. */
+import { describe, it, expect } from 'vitest';
+import { renderAgentMarkdown } from './renderAgentMarkdown';
+
+/**
+ * Tests del renderer de markdown del agente (task #58). La queja del operador:
+ * el agente mostraba `**`, `*` y `###` CRUDOS, ilegible para el campesino/niña.
+ * Aquí blindamos: (a) el markdown se convierte a HTML real, (b) NO quedan
+ * asteriscos/almohadillas residuales a la vista, (c) la entrada está sanitizada
+ * (sin XSS, sin <script>, sin onclick, sin href de javascript:).
+ */
+describe('renderAgentMarkdown — negritas y cursivas', () => {
+  it('**x** → <strong>x</strong>, sin asteriscos visibles', () => {
+    const html = renderAgentMarkdown('Usa **caldo bordelés** en la mañana.');
+    expect(html).toContain('<strong>caldo bordelés</strong>');
+    expect(html).not.toContain('*');
+  });
+
+  it('__x__ también es negrita', () => {
+    const html = renderAgentMarkdown('Esto es __importante__.');
+    expect(html).toContain('<strong>importante</strong>');
+    expect(html).not.toContain('_');
+  });
+
+  it('*x* → <em>x</em> (cursiva), sin asteriscos visibles', () => {
+    const html = renderAgentMarkdown('Es *opcional* aplicarlo.');
+    expect(html).toContain('<em>opcional</em>');
+    expect(html).not.toContain('*');
+  });
+
+  it('NO confunde snake_case con cursiva (coffea_arabica intacto)', () => {
+    const html = renderAgentMarkdown('La especie coffea_arabica crece bien.');
+    expect(html).toContain('coffea_arabica');
+    expect(html).not.toContain('<em>');
+  });
+});
+
+describe('renderAgentMarkdown — encabezados', () => {
+  it('### Título → <h3>, sin almohadillas visibles', () => {
+    const html = renderAgentMarkdown('### Cómo preparar\nMezcla los ingredientes.');
+    expect(html).toContain('<h3>Cómo preparar</h3>');
+    expect(html).not.toContain('#');
+  });
+
+  it('#### o más profundo → <h4>', () => {
+    const html = renderAgentMarkdown('#### Detalle fino');
+    expect(html).toContain('<h4>Detalle fino</h4>');
+    expect(html).not.toContain('#');
+  });
+
+  it('# y ## se degradan a h3 dentro de la burbuja (no rompen jerarquía)', () => {
+    const html = renderAgentMarkdown('# Plagas comunes');
+    expect(html).toContain('<h3>Plagas comunes</h3>');
+  });
+});
+
+describe('renderAgentMarkdown — listas (viñetas reales)', () => {
+  it('viñetas con * o - → <ul><li>, cero asteriscos a la vista', () => {
+    const md = 'Compañeras:\n* Caléndula\n* Albahaca\n- Cilantro';
+    const html = renderAgentMarkdown(md);
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li>Caléndula</li>');
+    expect(html).toContain('<li>Albahaca</li>');
+    expect(html).toContain('<li>Cilantro</li>');
+    expect(html).not.toContain('*');
+  });
+
+  it('lista numerada 1. 2. → <ol><li>', () => {
+    const md = 'Pasos:\n1. Hervir el agua\n2. Agregar la planta';
+    const html = renderAgentMarkdown(md);
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<li>Hervir el agua</li>');
+    expect(html).toContain('<li>Agregar la planta</li>');
+  });
+
+  it('viñetas con negrita interna se renderizan combinadas', () => {
+    const html = renderAgentMarkdown('* **Riego**: cada 3 días');
+    expect(html).toContain('<li><strong>Riego</strong>: cada 3 días</li>');
+    expect(html).not.toContain('*');
+  });
+});
+
+describe('renderAgentMarkdown — estructura y saltos', () => {
+  it('párrafos separados por línea en blanco → <p> distintos', () => {
+    const html = renderAgentMarkdown('Primer párrafo.\n\nSegundo párrafo.');
+    expect(html).toContain('<p>Primer párrafo.</p>');
+    expect(html).toContain('<p>Segundo párrafo.</p>');
+  });
+
+  it('salto de línea simple dentro de un párrafo → <br>', () => {
+    const html = renderAgentMarkdown('Línea uno\nLínea dos');
+    expect(html).toContain('Línea uno<br>Línea dos');
+  });
+
+  it('texto plano sin markdown → un solo párrafo legible', () => {
+    const html = renderAgentMarkdown('Hola, soy tu asistente.');
+    expect(html).toBe('<p>Hola, soy tu asistente.</p>');
+  });
+
+  it('entrada vacía o no-string → cadena vacía', () => {
+    expect(renderAgentMarkdown('')).toBe('');
+    expect(renderAgentMarkdown(null)).toBe('');
+    expect(renderAgentMarkdown(undefined)).toBe('');
+    expect(renderAgentMarkdown(42)).toBe('');
+  });
+});
+
+describe('renderAgentMarkdown — sanitización (anti-XSS)', () => {
+  it('NO ejecuta <script>: queda escapado, no como tag', () => {
+    const html = renderAgentMarkdown('Hola <script>alert("xss")</script>');
+    expect(html).not.toContain('<script>');
+    expect(html.toLowerCase()).not.toContain('<script');
+  });
+
+  it('NO deja un <div onclick> VIVO: el tag entra escapado (inerte)', () => {
+    const html = renderAgentMarkdown('<div onclick="alert(1)">click</div>');
+    // El div NO es un elemento real (quedó escapado como texto), por eso no hay
+    // atributo onclick ejecutable. "onclick" puede sobrevivir como TEXTO inerte.
+    expect(html).not.toContain('<div');
+    expect(html).toContain('&lt;div');
+  });
+
+  it('NO produce <a href> (los enlaces se aplanan a texto)', () => {
+    const html = renderAgentMarkdown('Mira [esto](javascript:alert(1)) aquí.');
+    expect(html).not.toContain('<a');
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('esto');
+  });
+
+  it('NO produce <img> (sin vectores de carga remota)', () => {
+    const html = renderAgentMarkdown('![x](https://evil.example/x.png)');
+    expect(html).not.toContain('<img');
+  });
+
+  it('caracteres HTML en el texto se escapan, no se interpretan', () => {
+    const html = renderAgentMarkdown('1 < 2 && 3 > 2');
+    expect(html).not.toContain('<2');
+    // El contenido sigue siendo legible para el usuario tras desescapar.
+    expect(html).toMatch(/&lt;|&amp;|&gt;/);
+  });
+});


### PR DESCRIPTION
## Contexto
Rama huérfana rescatada durante auditoría de limpieza de ramas remotas (2026-07-09). Sin PR previo — el trabajo quedó sin integrar cuando el agente que lo generó fue detenido (último commit: "wip: salvado al consolidar (agente detenido por RAM)").

## Verificación de contenido no-integrado
`AgentMarkdown.jsx` / `renderAgentMarkdown.js` **no existen en `main`** — el chat del agente actualmente no renderiza markdown. Esta rama sí lo implementa (ChatBubble, ChatHistory, AgentScreen + tests).

## Pendiente
- Revisar si el enfoque sigue vigente frente al AgentScreen actual (main avanzó bastante desde el fork point — puede requerir rebase/adaptación, no merge directo).
- QA visual antes de mergear.

_PR draft abierto por auditoría automatizada de ramas — no mergear sin revisión._