### PR TITLE
style(home-biopunk): pulir los 4 paneles del home finca-viva (vitalidad · guardián · menú-árbol · reloj)

### DIFF
--- a/src/components/dashboard/ArbolDeMundos.jsx
+++ b/src/components/dashboard/ArbolDeMundos.jsx
@@ -86,13 +86,15 @@ function ramaD([ox, oy], [nx, ny]) {
   return `M${ox},${oy} C${c1x},${c1y} ${c2x},${c2y} ${nx},${ny}`;
 }
 
-/** Etiqueta-cápsula dentro del SVG (misma receta del mockup aprobado). */
+/** Etiqueta-cápsula dentro del SVG (misma receta del mockup aprobado).
+ * Legible al sol: cápsula más opaca, borde más presente y tipo un punto
+ * más grande que el mockup (en pantalla real el SVG se ve más chico). */
 function TagSvg({ x, y, texto }) {
-  const w = texto.length * 4.6 + 16;
+  const w = texto.length * 5 + 17;
   return (
     <g className="adm-tag" aria-hidden="true">
-      <rect x={x - w / 2} y={y} width={w} height="13" rx="6.5" fill="rgba(4,10,28,0.78)" stroke="rgba(45,255,196,0.35)" strokeWidth="0.6" />
-      <text x={x} y={y + 8.8} textAnchor="middle" fontFamily="ui-monospace,monospace" fontSize="6.5" letterSpacing="1.2" fill="#bfffe9">
+      <rect x={x - w / 2} y={y} width={w} height="13.5" rx="6.75" fill="rgba(4,10,28,0.88)" stroke="rgba(45,255,196,0.45)" strokeWidth="0.7" />
+      <text x={x} y={y + 9.3} textAnchor="middle" fontFamily="ui-monospace,monospace" fontSize="7.2" letterSpacing="1.1" fill="#d4ffee">
         {texto}
       </text>
     </g>
@@ -104,7 +106,7 @@ function TagSvg({ x, y, texto }) {
  * La vaina completa es el botón (membrana + núcleo + glifo + etiqueta), con
  * un hit-area invisible r=30 (~60px en móvil) para dedos de campo.
  */
-function RamaMundo({ mundo, lugar, sello, onOpen }) {
+function RamaMundo({ mundo, lugar, sello, onOpen, idx = 0 }) {
   const [nx, ny] = lugar.node;
   const d = ramaD(lugar.origen, lugar.node);
   const entrar = () => onOpen(mundo);
@@ -112,7 +114,12 @@ function RamaMundo({ mundo, lugar, sello, onOpen }) {
     if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpen(mundo); }
   };
   return (
-    <g className="adm-rama" style={{ '--adm-acc': lugar.acc }}>
+    <g
+      className="adm-rama"
+      /* brote escalonado: cada rama aparece un tris después de la anterior
+         (solo opacity — GPU-friendly y sin pelear con el transform del SVG) */
+      style={{ '--adm-acc': lugar.acc, animationDelay: `${0.12 + idx * 0.07}s` }}
+    >
       {/* la rama: corteza + brillo + savia que fluye hacia la vaina */}
       <path d={d} fill="none" stroke={lugar.raiz ? '#6b8f2f' : '#0f8f6c'} strokeWidth="3.4" strokeLinecap="round" opacity="0.9" />
       <path d={d} fill="none" stroke={lugar.acc} strokeWidth="1" strokeLinecap="round" opacity="0.45" />
@@ -264,8 +271,8 @@ export default function ArbolDeMundos({ onNavigate, mostrarAnimales = true, plan
 
           {/* LAS RAMAS VIVAS: una por mundo real de la finca (fuente única
               mundosFinca.js — mismo gate y mismas rutas que la grilla) */}
-          {mundos.map((m) => (
-            <RamaMundo key={m.id} mundo={m} lugar={lugarDe(m)} sello={sello(m)} onOpen={abrir} />
+          {mundos.map((m, i) => (
+            <RamaMundo key={m.id} mundo={m} lugar={lugarDe(m)} sello={sello(m)} onOpen={abrir} idx={i} />
           ))}
 
           {/* EL CORAZÓN DE LA FINCA: late y bombea savia a todas las ramas */}

--- a/src/components/dashboard/GuardianEspiritu.jsx
+++ b/src/components/dashboard/GuardianEspiritu.jsx
@@ -261,16 +261,30 @@ export default function GuardianEspiritu({ onChange = null }) {
       data-testid="guardian-selector"
       data-guardian={activoId}
     >
+      {/* noche viva: estrellas sutiles detrás de todo (solo opacity) */}
+      <svg className="ge-stars" viewBox="0 0 320 110" preserveAspectRatio="none" aria-hidden="true" focusable="false">
+        <circle className="ge-tw" cx="26" cy="16" r="1" fill="#eafff6" />
+        <circle className="ge-tw ge-tw2" cx="88" cy="34" r="0.8" fill="#bfffe9" />
+        <circle className="ge-tw ge-tw3" cx="158" cy="12" r="1.1" fill="#eafff6" />
+        <circle className="ge-tw" cx="224" cy="28" r="0.8" fill="#2dffc4" />
+        <circle className="ge-tw ge-tw2" cx="286" cy="14" r="1" fill="#eafff6" />
+        <circle className="ge-tw ge-tw3" cx="304" cy="52" r="0.7" fill="#b28dff" />
+        <circle className="ge-tw ge-tw2" cx="46" cy="72" r="0.7" fill="#9dff3f" />
+      </svg>
+
       <header className="ge-head">
         <span className="ge-kicker">SU GUARDIÁN</span>
         <h2 className="ge-title">Escoja una especie nativa</h2>
         <p className="ge-sub">
-          El guardián que elija se vuelve el espíritu de su finca. Fauna nativa colombiana, real y verificable.
+          {elegido
+            ? 'Este espíritu ya acompaña su finca. Toque otra especie si quiere cambiarlo.'
+            : 'El guardián que elija se vuelve el espíritu de su finca. Fauna nativa colombiana, real y verificable.'}
         </p>
       </header>
 
-      {/* héroe: el guardián elegido, en grande, con su nombre científico */}
-      <div className="ge-hero" data-testid="guardian-hero">
+      {/* héroe: el guardián elegido, en grande, con su nombre científico.
+          key=activoId re-monta el bloque al cambiar → animación de llegada */}
+      <div className="ge-hero" data-testid="guardian-hero" key={activoId}>
         <span className="ge-hero-avatar">
           <GuardianAvatar id={activoId} size={78} />
         </span>

--- a/src/components/dashboard/PanelVitalidadEspiritu.jsx
+++ b/src/components/dashboard/PanelVitalidadEspiritu.jsx
@@ -59,10 +59,13 @@ export default function PanelVitalidadEspiritu({ modelo }) {
                 : `Vitalidad de la finca: dato en camino. ${vitalidad.fuente}`}
             >
               <circle className="pve-ring-track" cx="31" cy="31" r="26" fill="none" strokeWidth="4" />
+              {/* --pve-circ = punto de partida (anillo vacío) de la animación
+                  de llenado al montar (pve-ring-in en el CSS) */}
               <circle
                 className="pve-ring-val" cx="31" cy="31" r="26" fill="none" strokeWidth="4"
                 strokeLinecap="round" strokeDasharray={CIRC} strokeDashoffset={offset}
                 transform="rotate(-90 31 31)"
+                style={{ '--pve-circ': CIRC }}
               />
               <text x="31" y="36" textAnchor="middle" className="pve-ring-num">
                 {vitalidadOk ? vitalidad.valor : '—'}

--- a/src/components/dashboard/RelojFrailejon.jsx
+++ b/src/components/dashboard/RelojFrailejon.jsx
@@ -33,17 +33,58 @@ const R_PASO = 6.5;
 const MAX_ANILLOS_COMODOS = 12;
 
 export default function RelojFrailejon({ onNavigate }) {
-  const [reloj, setReloj] = useState(null);
+  // undefined = leyendo los registros · null = sin datos (no se dibuja nada
+  // inventado) · objeto = los años reales de la finca.
+  const [reloj, setReloj] = useState(undefined);
 
   useEffect(() => {
     let alive = true;
     getAniosFinca()
-      .then((r) => { if (alive) setReloj(r); })
-      .catch(() => { /* honesto: sin datos no se dibuja nada inventado */ });
+      .then((r) => { if (alive) setReloj(r || null); })
+      .catch(() => { if (alive) setReloj(null); /* honesto: nada inventado */ });
     return () => { alive = false; };
   }, []);
 
-  if (!reloj) return null;
+  // Sin datos reales el reloj no existe: mejor ausencia que historia inventada.
+  if (reloj === null) return null;
+
+  // LEYENDO: el frailejón germina mientras llegan los registros reales — un
+  // esqueleto vivo (semilla que late + anillos punteados girando), no un hueco.
+  if (reloj === undefined) {
+    return (
+      <div
+        className="adm-reloj adm-reloj-espera"
+        data-testid="reloj-frailejon-cargando"
+        role="status"
+        aria-label="Leyendo los anillos de su finca en los registros"
+      >
+        <svg className="adm-reloj-svg" viewBox="0 0 120 120" aria-hidden="true" focusable="false">
+          <circle cx="60" cy="60" r="44" fill="#2dffc4" opacity="0.05" />
+          <circle
+            className="adm-reloj-espera-anillo"
+            cx="60" cy="60" r="20" fill="none"
+            stroke="#57a453" strokeWidth="1.5" strokeDasharray="4 8"
+            strokeLinecap="round" opacity="0.55"
+          />
+          <circle
+            className="adm-reloj-espera-anillo adm-reloj-espera-r2"
+            cx="60" cy="60" r="33" fill="none"
+            stroke="#9dff3f" strokeWidth="1.2" strokeDasharray="3 10"
+            strokeLinecap="round" opacity="0.3"
+          />
+          <circle className="adm-reloj-corazon" cx="60" cy="60" r="4" fill="#ffb54f" />
+          <circle cx="60" cy="60" r="1.6" fill="#fff3c9" />
+        </svg>
+        <span className="adm-reloj-texto">
+          <span className="adm-reloj-cab">EL RELOJ DEL FRAILEJÓN</span>
+          <strong className="adm-reloj-anios">Contando sus anillos…</strong>
+          <span className="adm-reloj-nota">
+            Leyendo los años reales de su finca en los registros.
+          </span>
+        </span>
+      </div>
+    );
+  }
 
   const { anios, primerAnio, anioActual, fincaNueva } = reloj;
   const n = anios.length;

--- a/src/components/dashboard/arbol-de-mundos.css
+++ b/src/components/dashboard/arbol-de-mundos.css
@@ -56,6 +56,13 @@
 
 /* ── vainas (las entradas a los mundos) ─────────────────────────────────── */
 
+/* brote escalonado al montar: cada rama aparece un tris después de la
+   anterior (delay inline por rama). Solo opacity — compositable, y sin
+   tocar `transform` (el posicionamiento vive en el atributo del SVG). */
+.adm-rama {
+  animation: adm-brota 0.7s ease-out backwards;
+}
+
 .adm-nodo {
   cursor: pointer;
   outline: none;
@@ -226,6 +233,31 @@
   color: #2dffc4;
 }
 
+/* estado LEYENDO: el frailejón germina mientras llegan los registros —
+   semilla que late + anillos punteados girando despacio (solo transform). */
+.adm-reloj-espera {
+  cursor: default;
+}
+
+.adm-reloj-espera:hover {
+  border-color: rgba(157, 255, 63, 0.28);
+  box-shadow: none;
+}
+
+.adm-reloj-espera .adm-reloj-anios {
+  color: #bfffe9;
+}
+
+.adm-reloj-espera-anillo {
+  transform-origin: 60px 60px;
+  animation: adm-gira 16s linear infinite;
+}
+
+.adm-reloj-espera-r2 {
+  animation-direction: reverse;
+  animation-duration: 24s;
+}
+
 /* ── keyframes ──────────────────────────────────────────────────────────── */
 
 @keyframes adm-sap {
@@ -285,6 +317,15 @@
 @keyframes adm-aparece {
   from { opacity: 0; }
   to { opacity: 1; }
+}
+
+@keyframes adm-brota {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes adm-gira {
+  to { transform: rotate(360deg); }
 }
 
 /* ── reduced motion: quietud digna, nada desaparece ─────────────────────── */

--- a/src/components/dashboard/guardian-espiritu.css
+++ b/src/components/dashboard/guardian-espiritu.css
@@ -32,8 +32,11 @@
     inset 0 0 40px rgba(45, 255, 196, 0.05);
 }
 
-/* estrellas de fondo, sutiles */
-.ge-stars { position: absolute; inset: 0; pointer-events: none; opacity: 0.7; }
+/* estrellas de fondo, sutiles (solo opacity — compositable) */
+.ge-stars { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; opacity: 0.7; }
+.ge-tw { animation: ge-tw 3.6s ease-in-out infinite; }
+.ge-tw2 { animation-delay: -1.3s; animation-duration: 4.4s; }
+.ge-tw3 { animation-delay: -2.5s; animation-duration: 5.2s; }
 
 /* ---------------------------- cabecera ----------------------------------- */
 .ge-head { position: relative; display: flex; flex-direction: column; gap: 2px; margin-bottom: 12px; }
@@ -65,8 +68,10 @@
   background: linear-gradient(180deg, rgba(var(--ge-acc-rgb), 0.1), rgba(var(--ge-acc-rgb), 0.02));
   border: 1px solid rgba(var(--ge-acc-rgb), 0.28);
   margin-bottom: 12px;
+  animation: ge-hero-in 0.38s cubic-bezier(0.2, 0.8, 0.3, 1) backwards;
 }
 .ge-hero-avatar {
+  position: relative;
   flex: 0 0 auto;
   width: 78px;
   height: 78px;
@@ -74,6 +79,16 @@
   place-items: center;
   border-radius: 50%;
   background: radial-gradient(circle at 42% 36%, rgba(var(--ge-acc-rgb), 0.28), rgba(var(--ge-acc-rgb), 0.02) 70%);
+}
+/* aura viva del espíritu elegido: un anillo que respira (transform+opacity) */
+.ge-hero-avatar::before {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  border: 1px solid rgba(var(--ge-acc-rgb), 0.55);
+  animation: ge-aura 3.2s ease-in-out infinite;
+  pointer-events: none;
 }
 .ge-hero-avatar svg { width: 100%; height: 100%; }
 .ge-hero-txt { min-width: 0; }
@@ -98,9 +113,9 @@
   display: inline-block;
   margin-top: 5px;
   font-family: var(--ge-mono);
-  font-size: 8.5px;
+  font-size: 9px;
   letter-spacing: 0.6px;
-  color: rgba(169, 195, 210, 0.7);
+  color: rgba(183, 207, 221, 0.85); /* legible al sol: un paso más de contraste */
 }
 
 /* --------------------------- chips de especie --------------------------- */
@@ -134,8 +149,9 @@
 }
 .ge-chip-avatar svg { width: 100%; height: 100%; }
 .ge-chip-nombre { font-size: 11px; font-weight: 700; line-height: 1.15; color: var(--ge-crema); }
-.ge-chip-eje { font-size: 8.5px; line-height: 1.2; color: rgba(169, 195, 210, 0.8); }
+.ge-chip-eje { font-size: 9px; line-height: 1.2; color: rgba(183, 207, 221, 0.88); }
 .ge-chip:hover { border-color: rgba(45, 255, 196, 0.42); transform: translateY(-1px); }
+.ge-chip:active { transform: translateY(0) scale(0.97); }
 .ge-chip.on {
   border-color: var(--ge-chip-acc, var(--ge-savia));
   background: linear-gradient(180deg, rgba(var(--ge-chip-acc-rgb), 0.24), rgba(var(--ge-chip-acc-rgb), 0.05));
@@ -185,7 +201,23 @@
   to { transform: scaleX(1); opacity: 0.8; }
 }
 
+@keyframes ge-tw {
+  0%, 100% { opacity: 0.25; }
+  50% { opacity: 1; }
+}
+
+@keyframes ge-hero-in {
+  from { opacity: 0; transform: translateY(5px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ge-aura {
+  0%, 100% { transform: scale(1); opacity: 0.55; }
+  50% { transform: scale(1.07); opacity: 0.95; }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .ge-av-vuela, .ge-av-flota, .ge-ala, .ge-aleteo { animation: none !important; }
+  .ge-av-vuela, .ge-av-flota, .ge-ala, .ge-aleteo,
+  .ge-tw, .ge-hero, .ge-hero-avatar::before { animation: none !important; }
   .ge-chip { transition: none; }
 }

--- a/src/components/dashboard/panel-vitalidad-espiritu.css
+++ b/src/components/dashboard/panel-vitalidad-espiritu.css
@@ -16,8 +16,8 @@
   --pve-acido: #9dff3f;
   --pve-ambar: #ffb54f;
   --pve-crema: #eafff6;
-  --pve-tinta: #7fa3b8; /* la tinta del mockup (#5b7f93) aclarada un paso:
-                           sobre el home real hay menos negro detrás */
+  --pve-tinta: #93b7cb; /* la tinta del mockup (#5b7f93) aclarada dos pasos:
+                           legible al sol sobre el vidrio del home real */
   --pve-vidrio: rgba(7, 16, 48, 0.72);
   --pve-borde: rgba(45, 255, 196, 0.28);
   --pve-acc: var(--pve-ambar); /* acento de la guardiana (la angelita) */
@@ -95,7 +95,20 @@
 .pve-ring-val {
   stroke: var(--pve-acc);
   filter: drop-shadow(0 0 4px rgba(var(--pve-acc-rgb), 0.8));
+  /* llenado real al montar (una transition nunca dispara en el primer render):
+     arranca vacío (--pve-circ inline) y llega al offset del dato + una
+     respiración lenta de opacidad (compositable) que lo mantiene vivo */
+  animation:
+    pve-ring-in 1.2s 0.45s cubic-bezier(0.2, 0.8, 0.3, 1) backwards,
+    pve-alma 4.5s 2s ease-in-out infinite;
   transition: stroke-dashoffset 1.1s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+@keyframes pve-ring-in {
+  from { stroke-dashoffset: var(--pve-circ, 164); }
+}
+@keyframes pve-alma {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.78; }
 }
 .pve-ring-num {
   font-size: 15px;
@@ -122,7 +135,7 @@
 .pve-vivas-cap {
   display: block;
   font-family: var(--pve-mono);
-  font-size: 8px;
+  font-size: 8.5px;
   letter-spacing: 1px;
   color: var(--pve-tinta);
   margin-top: 3px;
@@ -154,11 +167,21 @@
   border-radius: 2px;
   background: linear-gradient(90deg, var(--pve-c1, var(--pve-savia)), var(--pve-c2, var(--pve-acido)));
   box-shadow: 0 0 6px var(--pve-c1, var(--pve-savia));
+  /* crecen al montar (from width:0 → el ancho del dato), escalonadas por eje;
+     costo de layout solo en la entrada, después quedan quietas */
+  animation: pve-fill-in 1s cubic-bezier(0.2, 0.8, 0.3, 1) backwards;
   transition: width 1.1s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+.pve-eje:nth-child(1) .pve-eje-fill { animation-delay: 0.55s; }
+.pve-eje:nth-child(2) .pve-eje-fill { animation-delay: 0.7s; }
+.pve-eje:nth-child(3) .pve-eje-fill { animation-delay: 0.85s; }
+.pve-eje:nth-child(4) .pve-eje-fill { animation-delay: 1s; }
+@keyframes pve-fill-in {
+  from { width: 0; }
 }
 .pve-eje-val {
   font-family: var(--pve-mono);
-  font-size: 9px;
+  font-size: 9.5px;
   color: var(--pve-tinta);
   text-align: right;
   white-space: nowrap;
@@ -182,7 +205,7 @@
   padding-top: 9px;
   border-top: 1px dashed rgba(45, 255, 196, 0.18);
   font-family: var(--pve-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   letter-spacing: 0.4px;
   color: var(--pve-tinta);
   display: flex;
@@ -202,7 +225,7 @@
 .pve-nota {
   margin: 9px 0 0;
   font-family: var(--pve-mono);
-  font-size: 8.5px;
+  font-size: 9px;
   letter-spacing: 0.4px;
   color: var(--pve-tinta);
   opacity: 0.85;
@@ -215,5 +238,9 @@
     transform: none;
   }
   .pve-ring-val,
-  .pve-eje-fill { transition: none; }
+  .pve-eje-fill {
+    /* quietud digna: sin llenado ni respiración, el dato queda pintado */
+    animation: none;
+    transition: none;
+  }
 }


### PR DESCRIPTION
## Qué es

Pulido visual final de los 4 paneles del home biopunk "finca-viva" para que se vean terminados y coherentes. Sin cambios de lógica, rutas ni contratos: mismos testids, mismo grounding, mismos destinos de navegación.

## Los 4 paneles

### 1. Vitalidad (`PanelVitalidadEspiritu`)
- El anillo de vitalidad ahora **sí se llena al montar**: la `transition` de `stroke-dashoffset` nunca disparaba en el primer render (el círculo ya nacía con el offset final). Ahora un keyframe arranca desde el anillo vacío (`--pve-circ` inline) y llega al dato real en 1.2s.
- Respiración lenta de opacidad en el anillo (compositable) — el panel queda vivo sin costo de GPU.
- Las 4 barras (clima/suelo/biodiversidad/energía) crecen escalonadas al montar (delay por eje).
- Legibilidad al sol: tinta `#7fa3b8 → #93b7cb` y captions mono un paso más grandes (8–9.5px → 8.5–10px).

### 2. Guardián (`GuardianEspiritu`)
- Estrellas de fondo sutiles: la clase `.ge-stars` existía en el CSS pero **nunca tuvo elemento** — ahora 7 estrellas parpadeando (solo opacity).
- Aura viva alrededor del guardián elegido: anillo del acento de la especie que respira (transform+opacity).
- Al cambiar de especie el héroe llega con animación (`key={activoId}` re-monta el bloque).
- El copy distingue estados: sin elegir → invitación; elegido → "Este espíritu ya acompaña su finca…".
- Feedback táctil `:active` en los chips; nombre científico y fuente con más contraste.

### 3. Menú-árbol (`ArbolDeMundos`)
- Brote escalonado: cada rama aparece 70ms después de la anterior al montar (solo opacity — sin pelear con el `transform` del atributo SVG de las vainas).
- Etiquetas-cápsula legibles al sol: tipo 6.5→7.2, cápsula más opaca (0.78→0.88), borde más presente.

### 4. Reloj (`RelojFrailejon`)
- **Estado de carga con vida**: antes devolvía `null` mientras leía los registros (el panel aparecía de golpe o dejaba un hueco). Ahora germina: semilla ámbar que late + dos anillos punteados girando despacio + "Contando sus anillos…" (`role=status`, testid propio `reloj-frailejon-cargando`).
- El contrato honesto se mantiene intacto: si el servicio no trae datos reales, no se dibuja nada inventado (render null, test existente verde).

## Presupuesto de movimiento
Todo compositable (opacity/transform); `width` solo en la entrada de las barras (one-shot). `prefers-reduced-motion` deja estado estático digno en los 4 paneles (nada desaparece).

## Verificación
- `npx vitest run` de los 3 suites de paneles: **18/18 verdes** (contratos de grounding y navegación intactos).
- `npm run build`: **verde** (12.7s).
- Draft porque es visual: espera el OK del operador antes de merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)