### PR TITLE
feat(mockup): Montaña de los Mundos — pasada 3 cinematográfica

### DIFF
--- a/captura-tmp.mjs
+++ b/captura-tmp.mjs
@@ -1,0 +1,57 @@
+// Verificación EN VIVO de la pasada 2 (móvil 390x844, chromium del nix-store).
+import { chromium } from 'playwright';
+
+const BASE = 'http://localhost:4823/#/mockups/montana-mundos-cine';
+const OUT = '/tmp/claude-1000/-home-kortux-Workspace-chagra/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad';
+
+const browser = await chromium.launch({ executablePath: '/run/current-system/sw/bin/chromium' });
+const page = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2 });
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE-ERROR:', m.text()); });
+
+await page.goto(BASE, { waitUntil: 'networkidle' });
+// Anti falso-pass: el mockup debe montar de verdad.
+await page.waitForSelector('.mm2', { timeout: 15000 });
+await page.waitForSelector('[data-testid="mm2-mundo-agente"]', { timeout: 15000 });
+console.log('MONTADO: .mm2 presente');
+
+const capas = await page.$$eval('.mm2-capa', (els) => els.map((e) => e.className.replace('mm2-capa ', '')));
+console.log('CAPAS:', capas.join(' | '));
+
+await page.waitForTimeout(1600);
+await page.screenshot({ path: `${OUT}/p2-1-naturalista-finca.png` });
+
+await page.click('[data-testid="mm2-dir-biopunk"]');
+await page.waitForTimeout(1400);
+await page.screenshot({ path: `${OUT}/p2-2-biopunk-finca.png` });
+
+await page.click('[data-testid="mm2-dir-verde"]');
+await page.waitForTimeout(1400);
+await page.screenshot({ path: `${OUT}/p2-3-verde-finca.png` });
+
+// Zoom-out a la montaña completa (naturalista)
+await page.click('[data-testid="mm2-dir-naturalista"]');
+await page.waitForTimeout(600);
+await page.click('[data-testid="mm2-zoom-toggle"]');
+await page.waitForTimeout(1600);
+await page.screenshot({ path: `${OUT}/p2-4-naturalista-montana.png` });
+
+// Volver a la finca y caminar al páramo (grade + parallax)
+await page.click('[data-testid="mm2-zoom-toggle"]');
+await page.waitForTimeout(1200);
+await page.click('[data-testid="mm2-paso-arriba"]');
+await page.waitForTimeout(500);
+await page.click('[data-testid="mm2-paso-arriba"]');
+await page.waitForTimeout(1600);
+await page.screenshot({ path: `${OUT}/p2-5-naturalista-paramo.png` });
+
+// Bajar al río (extremo inferior del viaje)
+for (let i = 0; i < 4; i++) { await page.click('[data-testid="mm2-paso-abajo"]'); await page.waitForTimeout(420); }
+await page.waitForTimeout(1400);
+await page.screenshot({ path: `${OUT}/p2-6-naturalista-rio.png` });
+
+const brujula = await page.textContent('[data-testid="mm2-brujula"]');
+console.log('BRUJULA-FINAL:', brujula);
+
+await browser.close();
+console.log('OK capturas');

--- a/public/chagra-stats.json
+++ b/public/chagra-stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-09T15:26:08.643Z",
+  "generated_at": "2026-07-09T23:33:42.619Z",
   "schema_version": "1.1.0",
   "catalogo": {
     "especies": 581,

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-09T15:26:08.367Z",
+  "generated_at": "2026-07-09T23:33:42.432Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -93,9 +93,10 @@ const InventoryPage = lazy(() => import('./pages/InventoryPage'));
 // pisos térmicos, 3 direcciones artísticas para decidir dirección visual).
 // Ruta #/mockups/montana-mundos — sin gate ni sesión (datos de muestra).
 const MontanaMundosMockup = lazy(() => import('./mockups/MontanaMundos'));
-// Pasada 2 cinematográfica del mismo mockup (parallax de 6 capas, luz
-// atmosférica por piso, full-bleed). Ruta #/mockups/montana-mundos-cine —
-// la pasada 1 se conserva en su ruta para comparar lado a lado.
+// Pasada 3 cinematográfica del mismo mockup (parallax de 6 capas, luz
+// atmosférica por piso, full-bleed, profundidad de campo, momento de
+// llegada a la finca y vida ambiental). Ruta #/mockups/montana-mundos-cine
+// — la pasada 1 se conserva en su ruta para comparar lado a lado.
 const MontanaMundosCineMockup = lazy(() => import('./mockups/MontanaMundosCine'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,6 +89,10 @@ const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').
 // 2026-06-30. Se alcanza desde 'bodega' vía el botón "Auditoría y
 // reconciliación", o directo por hash (#auditoria-inventario).
 const InventoryPage = lazy(() => import('./pages/InventoryPage'));
+// Mockup dev "La Montaña de los Mundos" (navegación como paisaje vertical de
+// pisos térmicos, 3 direcciones artísticas para decidir dirección visual).
+// Ruta #/mockups/montana-mundos — sin gate ni sesión (datos de muestra).
+const MontanaMundosMockup = lazy(() => import('./mockups/MontanaMundos'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -418,6 +422,7 @@ const LoadingFallback = ({ view = null }) => {
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
 
 const HASH_VIEW_ROUTES = {
+  'mockups/montana-mundos': 'mockup_montana_mundos',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -915,6 +920,13 @@ export default function App() {
       return;
     }
 
+    // Mockups dev (#/mockups/*): vistas aisladas de decisión visual — se
+    // montan sin sesión (datos de muestra, no tocan datos reales).
+    if (hash === 'mockups/montana-mundos') {
+      Promise.resolve().then(() => navigate('mockup_montana_mundos'));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -943,6 +955,11 @@ export default function App() {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
+      // Mockups dev: sin gate ni sesión (datos de muestra).
+      if (routeView === 'mockup_montana_mundos') {
+        navigate(routeView);
+        return;
+      }
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
       if (routeView === 'extensionista' && !esExtensionistaActual()) {
         navigate('dashboard');
@@ -1265,6 +1282,17 @@ export default function App() {
               onConfirm={() => navigate(currentViewData?.next || 'dashboard')}
               onBack={() => navigate(currentViewData?.back || 'dashboard')}
             />
+          </ErrorBoundary>
+        );
+      case 'mockup_montana_mundos':
+        // Mockup dev "La Montaña de los Mundos": navegación como paisaje de
+        // pisos térmicos, 3 direcciones artísticas. Full-screen, sin gate —
+        // solo para decidir dirección visual.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mockup Montaña de los Mundos">
+              <MontanaMundosMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'dashboard':
@@ -2560,7 +2588,7 @@ export default function App() {
           Tampoco en onboarding-perfil (tarea #16): el FAB se encimaba sobre el
           CTA "Explorar con finca de ejemplo" del footer y la usuaria nueva aún
           no conoce al agente — ruido en su primer flujo. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && <AgentFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && !currentView.startsWith('mockup_') && <AgentFab onNavigate={navigate} />}
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o
           pregunta al agente punta a punta por voz.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -93,6 +93,10 @@ const InventoryPage = lazy(() => import('./pages/InventoryPage'));
 // pisos térmicos, 3 direcciones artísticas para decidir dirección visual).
 // Ruta #/mockups/montana-mundos — sin gate ni sesión (datos de muestra).
 const MontanaMundosMockup = lazy(() => import('./mockups/MontanaMundos'));
+// Pasada 2 cinematográfica del mismo mockup (parallax de 6 capas, luz
+// atmosférica por piso, full-bleed). Ruta #/mockups/montana-mundos-cine —
+// la pasada 1 se conserva en su ruta para comparar lado a lado.
+const MontanaMundosCineMockup = lazy(() => import('./mockups/MontanaMundosCine'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -423,6 +427,7 @@ const LoadingFallback = ({ view = null }) => {
 
 const HASH_VIEW_ROUTES = {
   'mockups/montana-mundos': 'mockup_montana_mundos',
+  'mockups/montana-mundos-cine': 'mockup_montana_mundos_cine',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -922,8 +927,9 @@ export default function App() {
 
     // Mockups dev (#/mockups/*): vistas aisladas de decisión visual — se
     // montan sin sesión (datos de muestra, no tocan datos reales).
-    if (hash === 'mockups/montana-mundos') {
-      Promise.resolve().then(() => navigate('mockup_montana_mundos'));
+    if (hash === 'mockups/montana-mundos' || hash === 'mockups/montana-mundos-cine') {
+      const vistaMockup = HASH_VIEW_ROUTES[hash];
+      Promise.resolve().then(() => navigate(vistaMockup));
       return;
     }
 
@@ -956,7 +962,7 @@ export default function App() {
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
       // Mockups dev: sin gate ni sesión (datos de muestra).
-      if (routeView === 'mockup_montana_mundos') {
+      if (routeView === 'mockup_montana_mundos' || routeView === 'mockup_montana_mundos_cine') {
         navigate(routeView);
         return;
       }
@@ -1292,6 +1298,16 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Mockup Montaña de los Mundos">
               <MontanaMundosMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_montana_mundos_cine':
+        // Pasada 2 cinematográfica del mockup: parallax de 6 capas, luz
+        // atmosférica por piso, full-bleed. Sin gate, solo decisión visual.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mockup Montaña de los Mundos (cine)">
+              <MontanaMundosCineMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/MontanaMundos.jsx
+++ b/src/mockups/MontanaMundos.jsx
@@ -1,0 +1,596 @@
+/**
+ * MontanaMundos.jsx — MOCKUP DEV "La Montaña de los Mundos"
+ * (#/mockups/montana-mundos, sin gate ni sesión — datos de muestra).
+ *
+ * La navegación de Chagra como PAISAJE VERTICAL DE PISOS TÉRMICOS — el modelo
+ * mental que el campesino ya usa (café=templado, papa=frío, frailejón=páramo).
+ * Referencia: Sierra Nevada de Santa Marta (del río al nevado en una sola
+ * montaña). Cada altura contiene la entrada a su mundo: el árbol de mango
+ * (cálido) lleva al mundo del mango; el frailejón (páramo) a restauración;
+ * el río al agua; el cafetal (templado) al café. Los mundos que no son
+ * ecosistema viven como OBJETOS de la escena: la casa → el agente, el troje →
+ * la cosecha, el mercado → vender, la luna → el calendario, el corral → los
+ * animales.
+ *
+ * Interacción (decidida con el operador):
+ *   - Abre CENTRADO EN LA FINCA del usuario (su piso térmico resaltado, los
+ *     demás pisos tenues arriba/abajo). Con un gesto (pellizco hacia adentro
+ *     o el botón "Ver toda la montaña") hace zoom-out a la montaña completa.
+ *   - Atajo permanente: el botón Ⓐ del agente + "Anotar mi día" SIEMPRE
+ *     visibles — ninguna tarea queda detrás de escalar la montaña.
+ *   - Afordancia obvia: cada mundo tocable lleva halo que pulsa + etiqueta.
+ *
+ * TRES DIRECCIONES ARTÍSTICAS conmutables (misma montaña, mismos mundos):
+ *   1. Sierra naturalista — pictórica, cálida, luz dorada de montaña.
+ *   2. Biopunk — neón orgánico nocturno, coherente con el home en prod;
+ *      la red viva (micelio) conecta los pisos.
+ *   3. Verde vivo — botánica, luminosa, diurna. El contraste claro.
+ *
+ * Técnica: SVG + CSS puros (cero deps, cero fotos), prefers-reduced-motion
+ * apaga toda la vida de la escena, targets ≥ 48px, español de Colombia
+ * (usted). Los toques muestran "aquí se abre X" (mockup honesto: no navega).
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import './montana-mundos.css';
+
+// ── Geometría de la escena (unidades del viewBox 390×1440) ──────────────────
+const VB_W = 390;
+const VB_H = 1440;
+
+// Pisos térmicos de arriba (nevado) a abajo (río). `y0/y1` = franja en el
+// viewBox; los msnm son los reales del modelo campesino colombiano.
+const PISOS = [
+  { id: 'nevado', nombre: 'Nevado', msnm: '4.800 m', y0: 96, y1: 320 },
+  { id: 'paramo', nombre: 'Páramo', msnm: '3.500 m', y0: 320, y1: 560 },
+  { id: 'frio', nombre: 'Clima frío', msnm: '2.600 m', y0: 560, y1: 800 },
+  { id: 'templado', nombre: 'Clima templado', msnm: '1.700 m', y0: 800, y1: 1060, finca: true },
+  { id: 'calido', nombre: 'Clima cálido', msnm: '800 m', y0: 1060, y1: 1300 },
+  { id: 'rio', nombre: 'El río', msnm: '400 m', y0: 1300, y1: 1440 },
+];
+const PISO_FINCA = PISOS.findIndex((p) => p.finca);
+
+// Mundos tocables: ancla (x,y) en unidades del viewBox, sobre el dibujo del
+// elemento que les da cuerpo en la escena. `abre` = aviso honesto del mockup.
+const MUNDOS = [
+  { id: 'calendario', x: 316, y: 96, piso: 0, etiqueta: 'Calendario', abre: 'el calendario y el almanaque del campo' },
+  { id: 'glaciar', x: 195, y: 228, piso: 0, etiqueta: 'Glaciar', abre: 'los glaciares y el agua de alta montaña' },
+  { id: 'restauracion', x: 132, y: 434, piso: 1, etiqueta: 'Restaurar', abre: 'la restauración del páramo y el bosque' },
+  { id: 'papa', x: 118, y: 662, piso: 2, etiqueta: 'La papa', abre: 'la papa y los tubérculos' },
+  { id: 'animales', x: 272, y: 700, piso: 2, etiqueta: 'Mis animales', abre: 'sus animales: gallinas, vacas, cabras' },
+  { id: 'agente', x: 195, y: 892, piso: 3, etiqueta: 'Hablar con Chagra', abre: 'el agente: pregunte con su voz' },
+  { id: 'cosecha', x: 296, y: 848, piso: 3, etiqueta: 'Mi cosecha', abre: 'su cosecha guardada en el troje' },
+  { id: 'cafe', x: 96, y: 942, piso: 3, etiqueta: 'El café', abre: 'el mundo del café' },
+  { id: 'vender', x: 300, y: 986, piso: 3, etiqueta: 'Vender', abre: 'el mercado: precios y ventas' },
+  { id: 'mango', x: 92, y: 1136, piso: 4, etiqueta: 'El mango', abre: 'el mundo del mango' },
+  { id: 'platano', x: 292, y: 1168, piso: 4, etiqueta: 'El plátano', abre: 'el plátano y el banano' },
+  { id: 'rio', x: 190, y: 1372, piso: 5, etiqueta: 'El río', abre: 'el agua, el riego y la pesca' },
+];
+
+const DIRECCIONES = [
+  { id: 'naturalista', num: 1, corto: 'Sierra', nombre: 'Sierra naturalista', lema: 'luz cálida de montaña' },
+  { id: 'biopunk', num: 2, corto: 'Biopunk', nombre: 'Biopunk', lema: 'neón orgánico nocturno, como el home actual' },
+  { id: 'verde', num: 3, corto: 'Verde vivo', nombre: 'Verde vivo', lema: 'botánico luminoso de día' },
+];
+
+// Transform del zoom: 'finca' encuadra el piso activo (los demás tenues);
+// 'montana' encaja la montaña completa en el alto de la pantalla.
+function calcularTransform(vp, modo, piso) {
+  const escenaH = vp.w * (VB_H / VB_W);
+  if (modo === 'montana') {
+    const s = Math.min(vp.h / escenaH, 1);
+    return { s, tx: (vp.w - vp.w * s) / 2, ty: Math.max((vp.h - escenaH * s) / 2, 0) };
+  }
+  const p = PISOS[piso];
+  const bandaH = ((p.y1 - p.y0) / VB_H) * escenaH;
+  const s = Math.max(1, Math.min((vp.h * 0.94) / bandaH, 2.4));
+  const cy = (((p.y0 + p.y1) / 2) / VB_H) * escenaH;
+  let ty = vp.h / 2 - cy * s;
+  ty = Math.max(vp.h - escenaH * s, Math.min(0, ty));
+  const tx = (vp.w - vp.w * s) / 2;
+  return { s, tx, ty };
+}
+
+// ── Piezas de la escena (SVG) ────────────────────────────────────────────────
+
+/** Frailejón: tronco lanudo + roseta que respira. */
+function Frailejon({ x, y, s = 1 }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`}>
+      <rect x="-3.4" y="-4" width="6.8" height="30" rx="3" className="mm-frailejon-tronco" />
+      <g className="mm-frailejon-roseta">
+        {[-72, -48, -24, 0, 24, 48, 72].map((a) => (
+          <ellipse key={a} cx="0" cy="-16" rx="3.4" ry="14" transform={`rotate(${a} 0 -2)`} className="mm-frailejon-hoja" />
+        ))}
+        <circle cx="0" cy="-6" r="4.6" className="mm-frailejon-flor" />
+      </g>
+    </g>
+  );
+}
+
+/** Mata de café con frutos rojos. */
+function MataCafe({ x, y, s = 1 }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`}>
+      <circle cx="0" cy="0" r="8" className="mm-cafe-mata" />
+      <circle cx="-3.4" cy="-1.5" r="1.6" className="mm-cafe-fruto" />
+      <circle cx="2.6" cy="-3.4" r="1.6" className="mm-cafe-fruto" />
+      <circle cx="1.4" cy="2.8" r="1.6" className="mm-cafe-fruto" />
+    </g>
+  );
+}
+
+/** Animal del corral (silueta simple: cuerpo + cabeza + patas). */
+function Animalito({ x, y, s = 1, clase = 'mm-oveja' }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`} className={clase}>
+      <ellipse cx="0" cy="0" rx="8.4" ry="5.4" />
+      <circle cx="8.2" cy="-3.2" r="3.1" />
+      <rect x="-6" y="3" width="2.2" height="6" rx="1" />
+      <rect x="3.6" y="3" width="2.2" height="6" rx="1" />
+    </g>
+  );
+}
+
+export default function MontanaMundos({ onBack }) {
+  const [dir, setDir] = useState('naturalista');
+  const [modo, setModo] = useState('finca'); // 'finca' | 'montana'
+  const [piso, setPiso] = useState(PISO_FINCA);
+  const [aviso, setAviso] = useState(null);
+  const avisoTimer = useRef(null);
+  const viewportRef = useRef(null);
+  const [vp, setVp] = useState({ w: 390, h: 700 });
+
+  useEffect(() => {
+    const medir = () => {
+      const el = viewportRef.current;
+      if (el) setVp({ w: el.clientWidth, h: el.clientHeight });
+    };
+    medir();
+    window.addEventListener('resize', medir);
+    return () => window.removeEventListener('resize', medir);
+  }, []);
+
+  const t = useMemo(() => calcularTransform(vp, modo, piso), [vp, modo, piso]);
+  const escenaH = vp.w * (VB_H / VB_W);
+
+  const avisar = (texto) => {
+    setAviso(texto);
+    if (avisoTimer.current) clearTimeout(avisoTimer.current);
+    avisoTimer.current = setTimeout(() => setAviso(null), 2600);
+  };
+  useEffect(() => () => { if (avisoTimer.current) clearTimeout(avisoTimer.current); }, []);
+
+  // Gestos: pellizco (2 dedos) alterna finca ↔ montaña; deslizar vertical
+  // (1 dedo, en modo finca) sube o baja de piso — como caminar la montaña.
+  const pinchRef = useRef(null);
+  const swipeRef = useRef(null);
+  const distancia = (touches) =>
+    Math.hypot(touches[0].clientX - touches[1].clientX, touches[0].clientY - touches[1].clientY);
+  const onTouchStart = (e) => {
+    if (e.touches.length === 2) {
+      pinchRef.current = distancia(e.touches);
+      swipeRef.current = null;
+    } else if (e.touches.length === 1) {
+      swipeRef.current = e.touches[0].clientY;
+    }
+  };
+  const onTouchMove = (e) => {
+    if (e.touches.length === 2 && pinchRef.current != null) {
+      const razon = distancia(e.touches) / pinchRef.current;
+      if (razon < 0.78) { setModo('montana'); pinchRef.current = null; }
+      if (razon > 1.28) { setModo('finca'); pinchRef.current = null; }
+    }
+  };
+  const onTouchEnd = (e) => {
+    if (pinchRef.current == null && swipeRef.current != null && modo === 'finca' && e.changedTouches.length === 1) {
+      const delta = e.changedTouches[0].clientY - swipeRef.current;
+      if (delta < -72 && piso < PISOS.length - 1) setPiso(piso + 1); // desliza arriba → baja la montaña
+      if (delta > 72 && piso > 0) setPiso(piso - 1); // desliza abajo → sube la montaña
+    }
+    if (e.touches.length < 2) pinchRef.current = null;
+    if (e.touches.length === 0) swipeRef.current = null;
+  };
+
+  const alternarZoom = () => setModo(modo === 'finca' ? 'montana' : 'finca');
+  const irAPiso = (i) => { setPiso(i); setModo('finca'); };
+  const pisoActual = PISOS[piso];
+  const direccion = DIRECCIONES.find((d) => d.id === dir) || DIRECCIONES[0];
+
+  const pct = (v, total) => `${(v / total) * 100}%`;
+
+  return (
+    <div className="mm" data-dir={dir} data-modo={modo}>
+      {/* ── Barra del mockup (herramienta de revisión, no parte del diseño) ── */}
+      <header className="mm-cabecera">
+        <div className="mm-mockbar">
+          <button type="button" className="mm-volver" onClick={() => onBack && onBack()}>← Volver</button>
+          <span className="mm-mockbar-titulo">MOCKUP · decidir dirección</span>
+        </div>
+        <h1 className="mm-titulo">La Montaña de los Mundos</h1>
+        <div className="mm-direcciones" role="tablist" aria-label="Dirección artística">
+          {DIRECCIONES.map((d) => (
+            <button
+              key={d.id}
+              type="button"
+              role="tab"
+              aria-selected={dir === d.id}
+              data-testid={`mm-dir-${d.id}`}
+              className={`mm-dir-btn${dir === d.id ? ' es-activa' : ''}`}
+              onClick={() => setDir(d.id)}
+            >
+              <span className="mm-dir-num">{d.num}</span> {d.corto}
+            </button>
+          ))}
+        </div>
+        <p className="mm-dir-lema" data-testid="mm-dir-lema">
+          Dirección {direccion.num} · <strong>{direccion.nombre}</strong> — {direccion.lema}
+        </p>
+      </header>
+
+      {/* ── Ventana a la montaña ── */}
+      <div
+        className="mm-viewport"
+        ref={viewportRef}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        data-testid="mm-viewport"
+      >
+        <div
+          className="mm-escena"
+          style={{
+            height: `${escenaH}px`,
+            transform: `translate3d(${t.tx}px, ${t.ty}px, 0) scale(${t.s})`,
+          }}
+        >
+          <MontanaSvg />
+
+          {/* Velos: en modo finca, los pisos que no son el activo quedan tenues. */}
+          <div
+            className="mm-velo mm-velo-arriba"
+            style={{ height: pct(pisoActual.y0, VB_H) }}
+            aria-hidden="true"
+          />
+          <div
+            className="mm-velo mm-velo-abajo"
+            style={{ top: pct(pisoActual.y1, VB_H) }}
+            aria-hidden="true"
+          />
+
+          {/* Marcador de la finca del usuario (siempre en su piso). */}
+          <div className="mm-finca-pin" style={{ left: pct(195, VB_W), top: pct(838, VB_H) }} aria-hidden="true">
+            ⭐ Su finca
+          </div>
+
+          {/* Mundos tocables: halo que pulsa + etiqueta (afordancia obvia). */}
+          {MUNDOS.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              className={`mm-mundo${modo === 'finca' && m.piso !== piso ? ' es-tenue' : ''}`}
+              style={{ left: pct(m.x, VB_W), top: pct(m.y, VB_H) }}
+              data-testid={`mm-mundo-${m.id}`}
+              aria-label={`${m.etiqueta}: abre ${m.abre}`}
+              onClick={() => avisar(`Aquí se abre ${m.abre}.`)}
+            >
+              <span className="mm-mundo-halo" aria-hidden="true" />
+              <span className="mm-mundo-etiqueta">{m.etiqueta}</span>
+            </button>
+          ))}
+
+          {/* Franjas de piso: en la montaña completa, tocar un piso lo acerca. */}
+          {PISOS.map((p, i) => (
+            <button
+              key={p.id}
+              type="button"
+              className="mm-franja"
+              style={{ top: pct(p.y0, VB_H), height: pct(p.y1 - p.y0, VB_H) }}
+              data-testid={`mm-franja-${p.id}`}
+              tabIndex={modo === 'montana' ? 0 : -1}
+              aria-label={`Acercarse a ${p.nombre}, ${p.msnm}`}
+              onClick={() => irAPiso(i)}
+            >
+              <span className="mm-franja-rotulo">
+                {p.nombre} · {p.msnm}{p.finca ? ' ⭐' : ''}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {/* Indicador del piso + flechas para caminar la montaña (modo finca). */}
+        <div className="mm-brujula" data-testid="mm-brujula">
+          <span className="mm-brujula-piso">
+            {pisoActual.nombre} · {pisoActual.msnm}{pisoActual.finca ? ' — aquí está su finca ⭐' : ''}
+          </span>
+        </div>
+        {modo === 'finca' && piso > 0 && (
+          <button type="button" className="mm-paso mm-paso-arriba" data-testid="mm-paso-arriba" onClick={() => setPiso(piso - 1)}>
+            ▲ Subir a {PISOS[piso - 1].nombre}
+          </button>
+        )}
+        {modo === 'finca' && piso < PISOS.length - 1 && (
+          <button type="button" className="mm-paso mm-paso-abajo" data-testid="mm-paso-abajo" onClick={() => setPiso(piso + 1)}>
+            ▼ Bajar a {PISOS[piso + 1].nombre}
+          </button>
+        )}
+
+        {/* Alternador de zoom: el gesto del pellizco hecho botón visible. */}
+        <button type="button" className="mm-zoom" data-testid="mm-zoom-toggle" onClick={alternarZoom}>
+          {modo === 'finca' ? '🏔 Ver toda la montaña' : '🏡 Volver a mi finca'}
+        </button>
+      </div>
+
+      {/* ── Atajos permanentes: nada queda detrás de escalar la montaña ── */}
+      <nav className="mm-atajos" aria-label="Atajos permanentes">
+        <button
+          type="button"
+          className="mm-atajo-anotar"
+          data-testid="mm-atajo-anotar"
+          onClick={() => avisar('Aquí se anota lo que hizo hoy en su finca.')}
+        >
+          📝 Anotar mi día
+        </button>
+        <button
+          type="button"
+          className="mm-atajo-agente"
+          data-testid="mm-atajo-agente"
+          aria-label="Hablar con Chagra, el agente"
+          onClick={() => avisar('Aquí se abre el agente: pregunte con su voz.')}
+        >
+          Ⓐ
+        </button>
+      </nav>
+
+      {aviso && (
+        <output className="mm-aviso" data-testid="mm-aviso">{aviso}</output>
+      )}
+    </div>
+  );
+}
+
+// ── La montaña (una sola escena SVG; las 3 direcciones la re-pintan por CSS) ──
+function MontanaSvg() {
+  return (
+    <svg
+      className="mm-svg"
+      viewBox={`0 0 ${VB_W} ${VB_H}`}
+      preserveAspectRatio="xMidYMid slice"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        <linearGradient id="mm-g-cielo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm-stop-cielo-a" />
+          <stop offset="1" className="mm-stop-cielo-b" />
+        </linearGradient>
+        <radialGradient id="mm-g-halo" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0" className="mm-stop-halo-a" />
+          <stop offset="1" className="mm-stop-halo-b" />
+        </radialGradient>
+        <linearGradient id="mm-g-rio" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm-stop-rio-a" />
+          <stop offset="1" className="mm-stop-rio-b" />
+        </linearGradient>
+        {/* La montaña recorta sus pisos: nada se pinta fuera de su silueta. */}
+        <clipPath id="mm-clip-montana">
+          <path d="M-2 1442 L-2 760 Q56 706 96 596 Q136 486 160 366 Q178 268 195 176 Q212 268 230 366 Q254 486 294 596 Q334 706 392 760 L392 1442 Z" />
+        </clipPath>
+      </defs>
+
+      {/* Cielo */}
+      <rect x="0" y="0" width="390" height="1440" fill="url(#mm-g-cielo)" />
+
+      {/* Estrellas (viven de noche: biopunk; tenues en la sierra) */}
+      <g className="mm-estrellas">
+        {[[24, 60, 1.6], [70, 130, 1.1], [120, 44, 1.4], [170, 96, 1], [250, 60, 1.5],
+          [292, 150, 1.1], [350, 40, 1.3], [366, 120, 1], [46, 210, 1.2], [340, 210, 1.4],
+          [96, 300, 1], [300, 300, 1.1]].map(([cx, cy, r]) => (
+            <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r={r} className="mm-estrella" />
+          ))}
+      </g>
+
+      {/* El astro (sol de día, luna de noche) → mundo Calendario */}
+      <g className="mm-astro">
+        <circle cx="316" cy="96" r="52" fill="url(#mm-g-halo)" />
+        <circle cx="316" cy="96" r="24" className="mm-astro-disco" />
+        <circle cx="308" cy="88" r="4.6" className="mm-astro-crater" />
+        <circle cx="324" cy="102" r="3.2" className="mm-astro-crater" />
+        <circle cx="314" cy="108" r="2.4" className="mm-astro-crater" />
+      </g>
+
+      {/* Nubes que pasan despacio (sierra y verde vivo) */}
+      <g className="mm-nubes">
+        <g className="mm-nube mm-nube-1">
+          <ellipse cx="80" cy="180" rx="34" ry="10" />
+          <ellipse cx="104" cy="172" rx="22" ry="8" />
+        </g>
+        <g className="mm-nube mm-nube-2">
+          <ellipse cx="300" cy="250" rx="40" ry="11" />
+          <ellipse cx="272" cy="242" rx="24" ry="8" />
+        </g>
+      </g>
+
+      {/* Cordilleras de atrás: profundidad de sierra */}
+      <path className="mm-ridge mm-ridge-a" d="M-2 1442 L-2 700 Q40 660 72 560 Q104 452 128 392 Q150 452 176 540 L200 640 L200 1442 Z" />
+      <path className="mm-ridge mm-ridge-b" d="M392 1442 L392 680 Q350 640 322 556 Q296 470 276 408 Q258 470 236 560 L214 660 L214 1442 Z" />
+
+      {/* ── Cuerpo de la montaña: pisos térmicos apilados ── */}
+      <g clipPath="url(#mm-clip-montana)">
+        {/* base páramo→abajo; cada piso tapa al anterior con borde ondulado */}
+        <rect x="-2" y="170" width="394" height="1272" className="mm-piso-paramo" />
+        <path className="mm-piso-frio" d="M-2 574 Q46 556 94 566 Q152 578 200 564 Q258 550 306 564 Q350 576 392 562 L392 1442 L-2 1442 Z" />
+        <path className="mm-piso-templado" d="M-2 816 Q50 798 104 808 Q160 820 212 806 Q266 792 316 806 Q356 816 392 804 L392 1442 L-2 1442 Z" />
+        <path className="mm-piso-calido" d="M-2 1076 Q54 1058 110 1068 Q166 1080 222 1066 Q276 1052 330 1066 Q364 1074 392 1062 L392 1442 L-2 1442 Z" />
+        <path className="mm-piso-valle" d="M-2 1316 Q60 1300 130 1310 Q210 1322 280 1308 Q340 1298 392 1308 L392 1442 L-2 1442 Z" />
+
+        {/* Nieve: cae sobre el páramo con lengua de glaciar */}
+        <path className="mm-nieve" d="M195 168 Q210 240 228 292 Q216 306 204 296 Q198 330 188 356 Q178 322 172 300 Q160 312 150 298 Q170 246 195 168 Z" />
+        <path className="mm-nieve" d="M195 168 Q170 250 148 302 Q136 296 130 306 Q148 322 142 338 Q120 330 108 342 Q132 250 160 214 Z" opacity="0.92" />
+        <path className="mm-nieve" d="M195 168 Q220 250 242 302 Q254 296 260 306 Q244 322 250 336 Q272 330 284 340 Q258 248 230 214 Z" opacity="0.92" />
+
+        {/* Bordes de piso: rima de luz (neón en biopunk) */}
+        <path className="mm-borde-piso" d="M-2 574 Q46 556 94 566 Q152 578 200 564 Q258 550 306 564 Q350 576 392 562" />
+        <path className="mm-borde-piso" d="M-2 816 Q50 798 104 808 Q160 820 212 806 Q266 792 316 806 Q356 816 392 804" />
+        <path className="mm-borde-piso" d="M-2 1076 Q54 1058 110 1068 Q166 1080 222 1066 Q276 1052 330 1066 Q364 1074 392 1062" />
+        <path className="mm-borde-piso" d="M-2 1316 Q60 1300 130 1310 Q210 1322 280 1308 Q340 1298 392 1308" />
+
+        {/* Niebla entre pisos */}
+        <ellipse className="mm-niebla" cx="120" cy="566" rx="120" ry="16" />
+        <ellipse className="mm-niebla" cx="290" cy="812" rx="130" ry="18" />
+        <ellipse className="mm-niebla" cx="110" cy="1072" rx="120" ry="16" />
+
+        {/* ── PÁRAMO: frailejones + laguna ── */}
+        <ellipse className="mm-laguna" cx="248" cy="486" rx="44" ry="11" />
+        <path className="mm-laguna-brillo" d="M218 484 Q248 478 278 484" />
+        <Frailejon x={132} y={436} s={1.25} />
+        <Frailejon x={170} y={470} s={0.95} />
+        <Frailejon x={100} y={482} s={0.8} />
+
+        {/* ── FRÍO: surcos de papa + corral ── */}
+        <g className="mm-surcos">
+          <path d="M70 636 Q118 626 166 636" />
+          <path d="M62 656 Q118 644 174 656" />
+          <path d="M56 676 Q118 662 180 676" />
+          <path d="M52 696 Q118 682 184 696" />
+        </g>
+        <g className="mm-matas-papa">
+          {[[80, 632], [112, 628], [144, 632], [72, 652], [108, 646], [148, 652],
+            [66, 672], [106, 664], [152, 672], [62, 692], [104, 684], [156, 692]].map(([cx, cy]) => (
+              <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="3" />
+            ))}
+        </g>
+        <g className="mm-corral">
+          {[236, 258, 280, 302, 318].map((x) => (
+            <rect key={x} x={x} y={694} width="3.2" height="16" rx="1.4" className="mm-cerca-poste" />
+          ))}
+          <rect x="234" y="697" width="88" height="2.6" rx="1.3" className="mm-cerca-riel" />
+          <rect x="234" y="704" width="88" height="2.6" rx="1.3" className="mm-cerca-riel" />
+          <Animalito x={258} y={688} s={0.9} clase="mm-oveja" />
+          <Animalito x={296} y={690} s={1.05} clase="mm-vaca" />
+        </g>
+
+        {/* ── TEMPLADO: la casa (finca del usuario), troje, cafetal, mercado ── */}
+        <g className="mm-casa">
+          {/* humo del fogón */}
+          <g className="mm-humo">
+            <circle className="mm-humo-1" cx="212" cy="856" r="3.4" />
+            <circle className="mm-humo-2" cx="214" cy="848" r="4.4" />
+            <circle className="mm-humo-3" cx="217" cy="838" r="5.4" />
+          </g>
+          <rect x="206" y="856" width="7" height="14" rx="1.5" className="mm-casa-chimenea" />
+          <rect x="168" y="874" width="56" height="34" rx="3" className="mm-casa-muro" />
+          <path d="M162 876 L196 850 L230 876 Z" className="mm-casa-techo" />
+          <rect x="176" y="884" width="12" height="12" rx="2" className="mm-casa-ventana" />
+          <rect x="200" y="882" width="14" height="26" rx="2.5" className="mm-casa-puerta" />
+          <path d="M150 908 Q196 916 244 908" className="mm-casa-camino" />
+        </g>
+        <g className="mm-troje">
+          <rect x="282" y="856" width="4" height="16" className="mm-troje-pata" />
+          <rect x="306" y="856" width="4" height="16" className="mm-troje-pata" />
+          <rect x="276" y="836" width="40" height="22" rx="3" className="mm-troje-cuerpo" />
+          <path d="M272 838 L296 822 L320 838 Z" className="mm-troje-techo" />
+          <circle cx="290" cy="847" r="3" className="mm-troje-grano" />
+          <circle cx="298" cy="849" r="3" className="mm-troje-grano" />
+          <circle cx="304" cy="846" r="3" className="mm-troje-grano" />
+        </g>
+        <g className="mm-cafetal">
+          <MataCafe x={72} y={938} s={1.1} />
+          <MataCafe x={98} y={930} s={1} />
+          <MataCafe x={124} y={940} s={1.15} />
+          <MataCafe x={84} y={958} s={0.95} />
+          <MataCafe x={112} y={956} s={1.05} />
+        </g>
+        <g className="mm-mercado">
+          <rect x="278" y="988" width="46" height="20" rx="2.5" className="mm-mercado-meson" />
+          {[278, 289.5, 301, 312.5].map((x, i) => (
+            <rect key={x} x={x} y={974} width="11.5" height="10" rx="1.5" className={i % 2 ? 'mm-toldo-b' : 'mm-toldo-a'} />
+          ))}
+          <rect x="276" y="982" width="50" height="4" rx="2" className="mm-mercado-tabla" />
+          <circle cx="288" cy="994" r="3.4" className="mm-mercado-fruta-a" />
+          <circle cx="298" cy="994" r="3.4" className="mm-mercado-fruta-b" />
+          <circle cx="308" cy="994" r="3.4" className="mm-mercado-fruta-a" />
+        </g>
+
+        {/* ── CÁLIDO: mango, platanera, cañaduzal ── */}
+        <g className="mm-arbol-mango">
+          <path d="M90 1172 Q88 1150 94 1136" className="mm-mango-tronco" />
+          <circle cx="80" cy="1128" r="20" className="mm-mango-copa" />
+          <circle cx="104" cy="1124" r="17" className="mm-mango-copa" />
+          <circle cx="92" cy="1112" r="16" className="mm-mango-copa" />
+          {[[74, 1132], [96, 1120], [106, 1132], [86, 1116]].map(([cx, cy]) => (
+            <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="3.2" className="mm-mango-fruto" />
+          ))}
+        </g>
+        <g className="mm-platanera">
+          {[-58, -30, 0, 30, 58].map((a) => (
+            <path
+              key={a}
+              d="M0 0 Q4 -22 0 -40 Q-4 -22 0 0"
+              transform={`translate(292 1180) rotate(${a} 0 0)`}
+              className="mm-platano-hoja"
+            />
+          ))}
+          <rect x="289" y="1180" width="6" height="18" rx="2.6" className="mm-platano-tallo" />
+          <g className="mm-racimo">
+            {[[284, 1170], [281, 1176], [284, 1182]].map(([cx, cy]) => (
+              <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="3" />
+            ))}
+          </g>
+        </g>
+        <g className="mm-cana">
+          {[176, 188, 200, 212].map((x, i) => (
+            <path key={x} d={`M${x} 1252 Q${x + (i % 2 ? 5 : -5)} 1222 ${x + (i % 2 ? 2 : -2)} 1200`} className="mm-cana-tallo" />
+          ))}
+        </g>
+
+        {/* ── RÍO: baja de la montaña y se abre en el valle ── */}
+        <path
+          className="mm-rio"
+          d="M236 1004 Q248 1050 232 1096 Q214 1146 228 1196 Q244 1250 214 1300 Q186 1350 196 1400 L204 1442 L146 1442 Q136 1390 158 1338 Q182 1290 168 1240 Q152 1186 172 1136 Q192 1090 208 1052 Q218 1024 224 1004 Z"
+          fill="url(#mm-g-rio)"
+        />
+        <g className="mm-flujo">
+          <path d="M226 1030 Q234 1072 222 1112 Q206 1158 218 1204" />
+          <path d="M228 1230 Q238 1272 210 1318 Q188 1356 194 1404" />
+          <path d="M212 1080 Q200 1130 212 1178" />
+        </g>
+        <ellipse className="mm-piedra" cx="182" cy="1368" rx="8" ry="5" />
+        <ellipse className="mm-piedra" cx="222" cy="1322" rx="6" ry="4" />
+      </g>
+
+      {/* Red viva (solo biopunk): el micelio conecta los pisos */}
+      <g className="mm-micelio">
+        <path d="M316 120 Q260 200 195 300 Q140 400 132 440 Q120 520 150 600 Q170 660 195 700 Q220 760 195 880 Q180 940 230 1000 Q260 1060 240 1140 Q220 1240 195 1300 Q180 1340 190 1380" />
+        <path d="M132 440 Q180 520 272 700" opacity="0.55" />
+        <path d="M195 880 Q140 920 96 942" opacity="0.55" />
+        <path d="M230 1000 Q270 1080 292 1168" opacity="0.55" />
+        {MUNDOS.map((m) => (
+          <circle key={m.id} cx={m.x} cy={m.y} r="3" className="mm-micelio-nodo" />
+        ))}
+      </g>
+
+      {/* Mariposas (solo verde vivo) */}
+      <g className="mm-mariposas">
+        <g transform="translate(150 860)">
+          <g className="mm-mariposa mm-mariposa-1">
+            <ellipse cx="-3" cy="0" rx="3.4" ry="2.2" />
+            <ellipse cx="3" cy="0" rx="3.4" ry="2.2" />
+          </g>
+        </g>
+        <g transform="translate(260 1120)">
+          <g className="mm-mariposa mm-mariposa-2">
+            <ellipse cx="-3" cy="0" rx="3" ry="2" />
+            <ellipse cx="3" cy="0" rx="3" ry="2" />
+          </g>
+        </g>
+      </g>
+
+      {/* Aves lejanas (solo sierra naturalista) */}
+      <g className="mm-aves">
+        <path d="M96 236 q6 -6 12 0 q6 -6 12 0" />
+        <path d="M130 258 q5 -5 10 0 q5 -5 10 0" />
+      </g>
+    </svg>
+  );
+}

--- a/src/mockups/MontanaMundos.jsx
+++ b/src/mockups/MontanaMundos.jsx
@@ -58,7 +58,7 @@ const MUNDOS = [
   { id: 'restauracion', x: 132, y: 434, piso: 1, etiqueta: 'Restaurar', abre: 'la restauración del páramo y el bosque' },
   { id: 'papa', x: 118, y: 662, piso: 2, etiqueta: 'La papa', abre: 'la papa y los tubérculos' },
   { id: 'animales', x: 272, y: 700, piso: 2, etiqueta: 'Mis animales', abre: 'sus animales: gallinas, vacas, cabras' },
-  { id: 'agente', x: 195, y: 892, piso: 3, etiqueta: 'Hablar con Chagra', abre: 'el agente: pregunte con su voz' },
+  { id: 'agente', x: 207, y: 896, piso: 3, etiqueta: 'Hablar con Chagra', abre: 'el agente: pregunte con su voz' },
   { id: 'cosecha', x: 296, y: 848, piso: 3, etiqueta: 'Mi cosecha', abre: 'su cosecha guardada en el troje' },
   { id: 'cafe', x: 96, y: 942, piso: 3, etiqueta: 'El café', abre: 'el mundo del café' },
   { id: 'vender', x: 300, y: 986, piso: 3, etiqueta: 'Vender', abre: 'el mercado: precios y ventas' },
@@ -78,12 +78,16 @@ const DIRECCIONES = [
 function calcularTransform(vp, modo, piso) {
   const escenaH = vp.w * (VB_H / VB_W);
   if (modo === 'montana') {
-    const s = Math.min(vp.h / escenaH, 1);
-    return { s, tx: (vp.w - vp.w * s) / 2, ty: Math.max((vp.h - escenaH * s) / 2, 0) };
+    // Deja aire para la brújula (arriba) y el botón de zoom (abajo), que
+    // tapaban el rótulo de "El río" cuando la montaña llenaba todo el alto.
+    const s = Math.min((vp.h - 150) / escenaH, 1);
+    return { s, tx: (vp.w - vp.w * s) / 2, ty: 84 };
   }
   const p = PISOS[piso];
   const bandaH = ((p.y1 - p.y0) / VB_H) * escenaH;
-  const s = Math.max(1, Math.min((vp.h * 0.94) / bandaH, 2.4));
+  // Tope 1.35: con más acercamiento el piso pierde su ancho (el cafetal y
+  // el troje quedaban por fuera de la pantalla) y las etiquetas gigantes.
+  const s = Math.max(1, Math.min((vp.h * 0.94) / bandaH, 1.35));
   const cy = (((p.y0 + p.y1) / 2) / VB_H) * escenaH;
   let ty = vp.h / 2 - cy * s;
   ty = Math.max(vp.h - escenaH * s, Math.min(0, ty));
@@ -372,6 +376,13 @@ function MontanaSvg() {
           <stop offset="0" className="mm-stop-rio-a" />
           <stop offset="1" className="mm-stop-rio-b" />
         </linearGradient>
+        {/* Luz de montaña: baña la ladera de arriba (cálida/neón/blanca según
+            dirección) y hunde el valle — profundidad pictórica sin más capas. */}
+        <linearGradient id="mm-g-luz" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm-stop-luz-a" />
+          <stop offset="0.45" stopColor="rgba(0,0,0,0)" />
+          <stop offset="1" className="mm-stop-luz-b" />
+        </linearGradient>
         {/* La montaña recorta sus pisos: nada se pinta fuera de su silueta. */}
         <clipPath id="mm-clip-montana">
           <path d="M-2 1442 L-2 760 Q56 706 96 596 Q136 486 160 366 Q178 268 195 176 Q212 268 230 366 Q254 486 294 596 Q334 706 392 760 L392 1442 Z" />
@@ -411,9 +422,9 @@ function MontanaSvg() {
         </g>
       </g>
 
-      {/* Cordilleras de atrás: profundidad de sierra */}
-      <path className="mm-ridge mm-ridge-a" d="M-2 1442 L-2 700 Q40 660 72 560 Q104 452 128 392 Q150 452 176 540 L200 640 L200 1442 Z" />
-      <path className="mm-ridge mm-ridge-b" d="M392 1442 L392 680 Q350 640 322 556 Q296 470 276 408 Q258 470 236 560 L214 660 L214 1442 Z" />
+      {/* Cordilleras de atrás: lomas redondas y brumosas, más bajas que el pico */}
+      <path className="mm-ridge mm-ridge-a" d="M-2 1442 L-2 720 Q50 600 96 486 Q120 430 150 470 Q180 540 196 640 L196 1442 Z" />
+      <path className="mm-ridge mm-ridge-b" d="M392 1442 L392 700 Q346 590 306 500 Q284 452 258 496 Q230 560 214 660 L214 1442 Z" />
 
       {/* ── Cuerpo de la montaña: pisos térmicos apilados ── */}
       <g clipPath="url(#mm-clip-montana)">
@@ -424,10 +435,9 @@ function MontanaSvg() {
         <path className="mm-piso-calido" d="M-2 1076 Q54 1058 110 1068 Q166 1080 222 1066 Q276 1052 330 1066 Q364 1074 392 1062 L392 1442 L-2 1442 Z" />
         <path className="mm-piso-valle" d="M-2 1316 Q60 1300 130 1310 Q210 1322 280 1308 Q340 1298 392 1308 L392 1442 L-2 1442 Z" />
 
-        {/* Nieve: cae sobre el páramo con lengua de glaciar */}
-        <path className="mm-nieve" d="M195 168 Q210 240 228 292 Q216 306 204 296 Q198 330 188 356 Q178 322 172 300 Q160 312 150 298 Q170 246 195 168 Z" />
-        <path className="mm-nieve" d="M195 168 Q170 250 148 302 Q136 296 130 306 Q148 322 142 338 Q120 330 108 342 Q132 250 160 214 Z" opacity="0.92" />
-        <path className="mm-nieve" d="M195 168 Q220 250 242 302 Q254 296 260 306 Q244 322 250 336 Q272 330 284 340 Q258 248 230 214 Z" opacity="0.92" />
+        {/* Nieve: casquete ancho con ruana dentada y lengua de glaciar */}
+        <path className="mm-nieve" d="M195 140 Q168 220 138 320 L154 306 L166 324 L182 306 L196 330 L212 306 L226 322 L240 304 L254 318 Q222 220 195 140 Z" />
+        <path className="mm-nieve" d="M196 330 Q192 358 184 382 Q178 360 182 336 Z" opacity="0.9" />
 
         {/* Bordes de piso: rima de luz (neón en biopunk) */}
         <path className="mm-borde-piso" d="M-2 574 Q46 556 94 566 Q152 578 200 564 Q258 550 306 564 Q350 576 392 562" />
@@ -494,6 +504,13 @@ function MontanaSvg() {
           <circle cx="298" cy="849" r="3" className="mm-troje-grano" />
           <circle cx="304" cy="846" r="3" className="mm-troje-grano" />
         </g>
+        {/* Sombríos del café (guamos): el cafetal colombiano crece a la sombra */}
+        <g className="mm-sombrio">
+          <path d="M52 940 Q50 924 54 912" />
+          <path d="M146 936 Q144 920 148 908" />
+        </g>
+        <ellipse className="mm-sombrio-copa" cx="54" cy="906" rx="17" ry="9" />
+        <ellipse className="mm-sombrio-copa" cx="148" cy="902" rx="19" ry="10" />
         <g className="mm-cafetal">
           <MataCafe x={72} y={938} s={1.1} />
           <MataCafe x={98} y={930} s={1} />
@@ -557,6 +574,9 @@ function MontanaSvg() {
         </g>
         <ellipse className="mm-piedra" cx="182" cy="1368" rx="8" ry="5" />
         <ellipse className="mm-piedra" cx="222" cy="1322" rx="6" ry="4" />
+
+        {/* Luz de montaña sobre toda la ladera (dentro del recorte) */}
+        <rect x="-2" y="120" width="394" height="1322" fill="url(#mm-g-luz)" pointerEvents="none" />
       </g>
 
       {/* Red viva (solo biopunk): el micelio conecta los pisos */}
@@ -590,6 +610,14 @@ function MontanaSvg() {
       <g className="mm-aves">
         <path d="M96 236 q6 -6 12 0 q6 -6 12 0" />
         <path d="M130 258 q5 -5 10 0 q5 -5 10 0" />
+      </g>
+
+      {/* Follaje botánico en primer plano (solo verde vivo) */}
+      <g className="mm-botanica">
+        <path d="M-4 1442 Q10 1380 44 1352 Q26 1394 22 1442 Z" />
+        <path d="M-4 1442 Q28 1402 74 1392 Q40 1420 34 1442 Z" opacity="0.75" />
+        <path d="M394 1442 Q380 1376 344 1348 Q364 1392 368 1442 Z" />
+        <path d="M394 1442 Q360 1400 316 1390 Q352 1418 358 1442 Z" opacity="0.75" />
       </g>
     </svg>
   );

--- a/src/mockups/MontanaMundos.jsx
+++ b/src/mockups/MontanaMundos.jsx
@@ -136,7 +136,9 @@ function Animalito({ x, y, s = 1, clase = 'mm-oveja' }) {
   );
 }
 
-export default function MontanaMundos({ onBack }) {
+// `onBack` con default: los tests montan el mockup sin prop (TS2741 del gate
+// tsc en checkJs infiere el prop como requerido si no tiene valor por defecto).
+export default function MontanaMundos({ onBack = null }) {
   const [dir, setDir] = useState('naturalista');
   const [modo, setModo] = useState('finca'); // 'finca' | 'montana'
   const [piso, setPiso] = useState(PISO_FINCA);

--- a/src/mockups/MontanaMundos.jsx
+++ b/src/mockups/MontanaMundos.jsx
@@ -55,7 +55,7 @@ const PISO_FINCA = PISOS.findIndex((p) => p.finca);
 const MUNDOS = [
   { id: 'calendario', x: 316, y: 96, piso: 0, etiqueta: 'Calendario', abre: 'el calendario y el almanaque del campo' },
   { id: 'glaciar', x: 195, y: 228, piso: 0, etiqueta: 'Glaciar', abre: 'los glaciares y el agua de alta montaña' },
-  { id: 'restauracion', x: 132, y: 434, piso: 1, etiqueta: 'Restaurar', abre: 'la restauración del páramo y el bosque' },
+  { id: 'restauracion', x: 168, y: 420, piso: 1, etiqueta: 'Restaurar', abre: 'la restauración del páramo y el bosque' },
   { id: 'papa', x: 118, y: 662, piso: 2, etiqueta: 'La papa', abre: 'la papa y los tubérculos' },
   { id: 'animales', x: 272, y: 700, piso: 2, etiqueta: 'Mis animales', abre: 'sus animales: gallinas, vacas, cabras' },
   { id: 'agente', x: 207, y: 896, piso: 3, etiqueta: 'Hablar con Chagra', abre: 'el agente: pregunte con su voz' },
@@ -450,12 +450,23 @@ function MontanaSvg() {
         <ellipse className="mm-niebla" cx="290" cy="812" rx="130" ry="18" />
         <ellipse className="mm-niebla" cx="110" cy="1072" rx="120" ry="16" />
 
-        {/* ── PÁRAMO: frailejones + laguna ── */}
-        <ellipse className="mm-laguna" cx="248" cy="486" rx="44" ry="11" />
-        <path className="mm-laguna-brillo" d="M218 484 Q248 478 278 484" />
-        <Frailejon x={132} y={436} s={1.25} />
-        <Frailejon x={170} y={470} s={0.95} />
-        <Frailejon x={100} y={482} s={0.8} />
+        {/* ── PÁRAMO: frailejones, pajonal y laguna (el cono es angosto a esta
+            altura: todo vive entre x≈140 y x≈255 para no caer del recorte) ── */}
+        <ellipse className="mm-laguna" cx="222" cy="512" rx="34" ry="9" />
+        <path className="mm-laguna-brillo" d="M198 510 Q222 504 246 510" />
+        <g className="mm-pajonal">
+          <path d="M196 452 q-3 -10 -7 -13 M196 452 q0 -12 1 -15 M196 452 q4 -9 8 -12" />
+          <path d="M216 436 q-3 -9 -6 -11 M216 436 q0 -10 1 -13 M216 436 q3 -8 7 -10" />
+          <path d="M160 508 q-3 -9 -6 -11 M160 508 q0 -10 1 -13 M160 508 q3 -8 7 -10" />
+          <path d="M186 528 q-3 -8 -6 -10 M186 528 q0 -9 1 -12 M186 528 q3 -7 6 -9" />
+          <path d="M250 486 q-3 -9 -6 -11 M250 486 q0 -10 1 -13 M250 486 q3 -8 7 -10" />
+        </g>
+        <ellipse className="mm-piedra" cx="150" cy="532" rx="9" ry="5" />
+        <ellipse className="mm-piedra" cx="228" cy="456" rx="6" ry="3.6" />
+        <Frailejon x={168} y={438} s={1.25} />
+        <Frailejon x={204} y={472} s={0.95} />
+        <Frailejon x={150} y={488} s={0.8} />
+        <Frailejon x={240} y={530} s={0.7} />
 
         {/* ── FRÍO: surcos de papa + corral ── */}
         <g className="mm-surcos">
@@ -581,8 +592,8 @@ function MontanaSvg() {
 
       {/* Red viva (solo biopunk): el micelio conecta los pisos */}
       <g className="mm-micelio">
-        <path d="M316 120 Q260 200 195 300 Q140 400 132 440 Q120 520 150 600 Q170 660 195 700 Q220 760 195 880 Q180 940 230 1000 Q260 1060 240 1140 Q220 1240 195 1300 Q180 1340 190 1380" />
-        <path d="M132 440 Q180 520 272 700" opacity="0.55" />
+        <path d="M316 120 Q260 200 195 300 Q160 390 168 428 Q150 520 160 600 Q175 660 195 700 Q220 760 195 880 Q180 940 230 1000 Q260 1060 240 1140 Q220 1240 195 1300 Q180 1340 190 1380" />
+        <path d="M168 428 Q200 520 272 700" opacity="0.55" />
         <path d="M195 880 Q140 920 96 942" opacity="0.55" />
         <path d="M230 1000 Q270 1080 292 1168" opacity="0.55" />
         {MUNDOS.map((m) => (

--- a/src/mockups/MontanaMundosCine.jsx
+++ b/src/mockups/MontanaMundosCine.jsx
@@ -1,34 +1,42 @@
 /**
- * MontanaMundosCine.jsx — MOCKUP DEV, PASADA 2 CINEMATOGRÁFICA de
+ * MontanaMundosCine.jsx — MOCKUP DEV, PASADA 3 CINEMATOGRÁFICA de
  * "La Montaña de los Mundos" (#/mockups/montana-mundos-cine, sin gate).
  *
- * La pasada 1 (MontanaMundos.jsx, se conserva en #/mockups/montana-mundos)
- * probó la estructura: pisos térmicos, mundos ubicados, zoom finca↔montaña.
- * Esta pasada le sube el CINE, según el plan acordado con el operador:
+ * La pasada 1 (MontanaMundos.jsx, #/mockups/montana-mundos) probó la
+ * estructura; la pasada 2 partió la escena en 6 capas de cámara con
+ * parallax, luz atmosférica por piso, full-bleed y elementos rediseñados.
+ * Esta pasada 3 lleva el cine al máximo (plan acordado con el operador):
  *
- *   1. PROFUNDIDAD REAL — la escena se parte en 6 capas de cámara:
- *      cielo (astro + god-rays) → cordillera lejana → cordillera media →
- *      montaña principal (pisos + mundos) → niebla volumétrica → primer
- *      plano botánico. Al caminar de piso, cada capa viaja a su velocidad
- *      (parallax) y con su propia inercia — cámara física, no scroll.
- *   2. LUZ ATMOSFÉRICA POR PISO — un grade cinematográfico cambia la
- *      temperatura de la luz al subir o bajar: azul glacial en el nevado,
- *      hora dorada en la finca, ámbar en el cálido, turquesa en el río.
- *   3. FULL-BLEED — la montaña ocupa el 100% del viewport; la UI flota
- *      sobre el paisaje con scrims de cine, sin cajas ni márgenes muertos.
- *   4. ELEMENTOS REDISEÑADOS — frailejón con roseta doble y vara de flor,
- *      casa campesina con corredor, tejas y geranios, cafetal con hojas y
- *      sombrío, mango con frutos colgando, río con orillas, reflejo del
- *      cielo y cascada entre pisos, nevado con cara de sombra y grietas.
+ *   1. PROFUNDIDAD DE CAMPO — en el plano cercano (modo finca) la cámara
+ *      enfoca la montaña principal: cielo, cordilleras y primer plano
+ *      quedan fuera de foco (blur ESTÁTICO por modo, nunca animado). En
+ *      el gran plano general todo vuelve a foco profundo.
+ *   2. TRANSICIÓN PULIDA — easing con leve asentamiento en las capas
+ *      cercanas (inercia física), zoom-out majestuoso con duraciones
+ *      escalonadas, y un estado de VIAJE: mientras la cámara se mueve la
+ *      niebla se abre y las etiquetas se retiran; todo vuelve al asentar.
+ *   3. TEXTURA — afloramientos de roca con vetas y pedrisco en el páramo,
+ *      cicatrices foliares en el tronco del frailejón, jirones finos de
+ *      niebla entre los bancos, destellos que titilan sobre la nieve.
+ *   4. MOMENTO DE LLEGADA A LA FINCA (el "wow") — al arribar al piso de
+ *      la finca (también al abrir: la app lo recibe en casa) florece un
+ *      bloom de hora dorada sobre la casa, dos anillos de luz se
+ *      expanden, unas chispas suben como pavesas, el pin ⭐ aterriza con
+ *      rebote y la ventana late — la montaña lo reconoce a usted.
+ *   5. VIDA AMBIENTAL — una bandada cruza el cielo (naturalista y verde),
+ *      un colibrí ronda los geranios del corredor (naturalista), las
+ *      luciérnagas parpadean en la noche biopunk, caen hojas en el verde
+ *      vivo y los animales del corral pastan. Micromovimiento sutil.
  *
- * Se conserva TODO lo validado de la pasada 1: abre centrado en la finca,
- * pellizco/botón para ver la montaña completa, deslizar (y ahora también la
- * rueda del mouse) para caminar entre pisos, atajos permanentes Ⓐ + anotar,
- * halo + etiqueta en cada mundo, 3 direcciones artísticas conmutables.
+ * Se conserva TODO lo validado: abre centrado en la finca, pellizco/botón
+ * para la montaña completa, deslizar/rueda para caminar pisos, atajos
+ * permanentes Ⓐ + anotar, 3 direcciones artísticas conmutables.
  *
  * Técnica: SVG + CSS puros (cero deps, cero fotos). Solo transform/opacity
- * se animan (GPU); los "volúmenes" de luz y niebla son degradados estáticos.
- * prefers-reduced-motion deja un plano final digno. Español de Colombia.
+ * se animan (GPU); luz y niebla son degradados estáticos y el blur de la
+ * profundidad de campo jamás se interpola (cambia escondido bajo el viaje
+ * de cámara). prefers-reduced-motion deja un plano final digno, sin vida
+ * animada ni momento de llegada. Español de Colombia.
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -74,6 +82,17 @@ const DIRECCIONES = [
 // < 1 = lejos (se mueve menos) · > 1 = más cerca que la montaña.
 const CAPAS_F = { cielo: 0.1, lejos: 0.22, medio: 0.45, principal: 1, niebla: 1.12, cerca: 1.3 };
 
+// Chispas del momento de llegada: hacia dónde vuela cada pavesa (px del
+// viewport) y con qué demora arranca. Suben desde la casa, como del fogón.
+const CHISPAS = [
+  { dx: -34, dy: -52, demora: 0.55 },
+  { dx: 20, dy: -64, demora: 0.7 },
+  { dx: 44, dy: -34, demora: 0.85 },
+  { dx: -50, dy: -24, demora: 1 },
+  { dx: 6, dy: -76, demora: 1.15 },
+  { dx: -14, dy: -42, demora: 1.3 },
+];
+
 // La escena SANGRA 150 unidades por debajo del río (dibujadas fuera del
 // viewBox con overflow visible): sin ese respiro, el piso del río quedaba
 // escondido detrás de la UI inferior en full-bleed.
@@ -101,12 +120,18 @@ function calcularTransform(vp, modo, piso) {
 
 // ── Piezas de la escena (SVG) ────────────────────────────────────────────────
 
-/** Frailejón pasada 2: faldón de hojas secas, roseta doble, varas de flor. */
+/** Frailejón pasada 3: faldón, roseta doble, varas de flor y — textura —
+ * cicatrices foliares en el tronco (los anillos de hojas viejas del
+ * frailejón real, lo que le da su cuerpo peludo a distancia). */
 function Frailejon({ x, y, s = 1 }) {
   return (
     <g transform={`translate(${x} ${y}) scale(${s})`}>
       <path className="mm2-frailejon-faldon" d="M-4 4 Q-9 10 -8 18 M0 6 Q-1 12 0 20 M4 4 Q9 10 8 18" />
       <rect x="-3.6" y="-4" width="7.2" height="30" rx="3.2" className="mm2-frailejon-tronco" />
+      <path
+        className="mm2-frailejon-cicatriz"
+        d="M-3 1 Q0 2.4 3 1 M-3 6 Q0 7.4 3 6 M-3 11 Q0 12.4 3 11 M-3 16 Q0 17.4 3 16 M-3 21 Q0 22.4 3 21"
+      />
       <g className="mm2-frailejon-roseta">
         {[-84, -56, -28, 0, 28, 56, 84].map((a) => (
           <ellipse key={`e${a}`} cx="0" cy="-14" rx="3" ry="13" transform={`rotate(${a} 0 -1)`} className="mm2-frailejon-hoja" />
@@ -146,14 +171,17 @@ function MataCafe({ x, y, s = 1 }) {
   );
 }
 
-/** Animal del corral (silueta simple: cuerpo + cabeza + patas). */
+/** Animal del corral (silueta simple: cuerpo + cabeza + patas). El grupo
+ * interior pasta — se inclina apenas hacia el suelo y vuelve (vida). */
 function Animalito({ x, y, s = 1, clase = 'mm2-oveja' }) {
   return (
     <g transform={`translate(${x} ${y}) scale(${s})`} className={clase}>
-      <ellipse cx="0" cy="0" rx="8.4" ry="5.4" />
-      <circle cx="8.2" cy="-3.2" r="3.1" />
-      <rect x="-6" y="3" width="2.2" height="6" rx="1" />
-      <rect x="3.6" y="3" width="2.2" height="6" rx="1" />
+      <g className="mm2-pasta">
+        <ellipse cx="0" cy="0" rx="8.4" ry="5.4" />
+        <circle cx="8.2" cy="-3.2" r="3.1" />
+        <rect x="-6" y="3" width="2.2" height="6" rx="1" />
+        <rect x="3.6" y="3" width="2.2" height="6" rx="1" />
+      </g>
     </g>
   );
 }
@@ -225,6 +253,17 @@ function CieloSvg() {
         </g>
         <g className="mm2-nube-alta mm2-nube-2">
           <ellipse cx="250" cy="190" rx="38" ry="6" />
+        </g>
+      </g>
+
+      {/* Bandada en V que CRUZA el cielo de lado a lado (naturalista y
+          verde vivo): pasa una vez, descansa fuera de cuadro y vuelve. */}
+      <g transform="translate(0 218)" className="mm2-bandada">
+        <g className="mm2-bandada-vuelo">
+          <path d="M0 0 q6 -6 12 0 q6 -6 12 0" />
+          <path d="M-26 12 q5 -5 10 0 q5 -5 10 0" />
+          <path d="M-14 24 q5 -5 10 0 q5 -5 10 0" />
+          <path d="M-44 30 q4 -4 8 0 q4 -4 8 0" />
         </g>
       </g>
     </svg>
@@ -331,6 +370,14 @@ function MontanaPrincipalSvg() {
         <path className="mm2-nieve" d="M196 330 Q192 358 184 382 Q178 360 182 336 Z" opacity="0.9" />
         <path className="mm2-grieta" d="M186 348 q4 3 8 2" opacity="0.7" />
 
+        {/* Destellos sobre la nieve: el hielo titila con la luz */}
+        <g className="mm2-destellos">
+          <path className="mm2-destello" d="M186 206 l1.8 3.4 -1.8 3.4 -1.8 -3.4 Z" />
+          <path className="mm2-destello" d="M208 252 l1.6 3 -1.6 3 -1.6 -3 Z" />
+          <path className="mm2-destello" d="M176 288 l1.5 2.8 -1.5 2.8 -1.5 -2.8 Z" />
+          <path className="mm2-destello" d="M222 296 l1.4 2.6 -1.4 2.6 -1.4 -2.6 Z" />
+        </g>
+
         {/* Bordes de piso: la rima de luz entre climas */}
         <path className="mm2-borde-piso" d="M-2 574 Q46 556 94 566 Q152 578 200 564 Q258 550 306 564 Q350 576 392 562" />
         <path className="mm2-borde-piso" d="M-2 816 Q50 798 104 808 Q160 820 212 806 Q266 792 316 806 Q356 816 392 804" />
@@ -351,6 +398,23 @@ function MontanaPrincipalSvg() {
         </g>
         <ellipse className="mm2-piedra" cx="150" cy="532" rx="9" ry="5" />
         <ellipse className="mm2-piedra" cx="228" cy="456" rx="6" ry="3.6" />
+
+        {/* Textura de roca: afloramientos con vetas al pie del nevado,
+            y el pedrisco que suelta el deshielo */}
+        <g className="mm2-rocas">
+          <path className="mm2-roca" d="M146 398 q9 -13 21 -9 q7 9 -1 17 q-14 6 -20 -8 Z" />
+          <path className="mm2-roca-veta" d="M150 398 q9 -6 15 -4 M152 405 q7 -4 11 -3" />
+          <path className="mm2-roca" d="M238 410 q11 -11 20 -5 q4 11 -5 16 q-12 3 -15 -11 Z" />
+          <path className="mm2-roca-veta" d="M242 410 q8 -5 13 -3 M244 417 q6 -3 9 -2" />
+          <path className="mm2-roca" d="M196 380 q7 -9 14 -6 q4 8 -2 13 q-9 3 -12 -7 Z" />
+          <path className="mm2-roca-veta" d="M199 380 q6 -4 10 -3" />
+        </g>
+        <g className="mm2-pedrisco">
+          {[[160, 416], [172, 424], [230, 430], [244, 434], [206, 396], [186, 410]].map(([cx, cy], i) => (
+            <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r={i % 2 ? 1.6 : 2.2} />
+          ))}
+        </g>
+
         <Frailejon x={168} y={438} s={1.25} />
         <Frailejon x={204} y={472} s={0.95} />
         <Frailejon x={150} y={488} s={0.8} />
@@ -409,6 +473,18 @@ function MontanaPrincipalSvg() {
           <circle cx="229.8" cy="897" r="2.6" className="mm2-geranio" />
           <path d="M150 908 Q196 916 244 908" className="mm2-casa-camino" />
         </g>
+
+        {/* Colibrí (solo naturalista): ronda los geranios del corredor con
+            aleteo rápido — el visitante de toda casa campesina */}
+        <g transform="translate(243 886)" className="mm2-colibri">
+          <g className="mm2-colibri-ronda">
+            <path className="mm2-colibri-cola" d="M-3.6 0.6 L-8.6 3.6 L-7.2 -0.4 Z" />
+            <ellipse cx="0" cy="0" rx="4" ry="2.2" className="mm2-colibri-torso" />
+            <circle cx="4.4" cy="-1.6" r="1.8" className="mm2-colibri-torso" />
+            <path className="mm2-colibri-pico" d="M6 -1.9 L10.6 -3" />
+            <path className="mm2-colibri-ala" d="M-0.6 -1 Q-3.4 -8 -8.6 -9.4 Q-4 -4 -1.6 0.4 Z" />
+          </g>
+        </g>
         <g className="mm2-troje">
           <rect x="282" y="856" width="4" height="16" className="mm2-troje-pata" />
           <rect x="306" y="856" width="4" height="16" className="mm2-troje-pata" />
@@ -444,6 +520,14 @@ function MontanaPrincipalSvg() {
           <circle cx="308" cy="994" r="3.4" className="mm2-mercado-fruta-a" />
         </g>
 
+        {/* Luciérnagas (solo biopunk): parpadean y derivan por el aire
+            tibio de la finca y el cálido — la noche está viva */}
+        <g className="mm2-luciernagas">
+          {[[152, 912], [238, 932], [186, 962], [298, 1012], [122, 1002], [262, 882], [90, 1098]].map(([cx, cy]) => (
+            <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="1.8" className="mm2-luciernaga" />
+          ))}
+        </g>
+
         {/* ── CÁLIDO: mango con frutos colgando, platanera, cañaduzal ── */}
         <g className="mm2-arbol-mango">
           <path d="M90 1172 Q86 1152 82 1140 M90 1172 Q92 1150 98 1136" className="mm2-mango-tronco" />
@@ -473,6 +557,13 @@ function MontanaPrincipalSvg() {
             <ellipse cx="281" cy="1188" rx="2.6" ry="3.6" className="mm2-bellota" />
           </g>
         </g>
+        {/* Hojas que caen (solo verde vivo): del mango y del cafetal */}
+        <g className="mm2-hojas-caen">
+          <ellipse cx="112" cy="1102" rx="2.6" ry="1.4" className="mm2-hoja-cae mm2-hoja-cae-1" />
+          <ellipse cx="72" cy="1116" rx="2.4" ry="1.3" className="mm2-hoja-cae mm2-hoja-cae-2" />
+          <ellipse cx="132" cy="916" rx="2.4" ry="1.3" className="mm2-hoja-cae mm2-hoja-cae-3" />
+        </g>
+
         <g className="mm2-cana">
           {[176, 188, 200, 212].map((x, i) => (
             <g key={x}>
@@ -593,6 +684,16 @@ function NieblaSvg() {
       <g className="mm2-banco-valle-2">
         <ellipse cx="290" cy="1400" rx="150" ry="28" fill="url(#mm2n-nucleo)" />
       </g>
+      {/* Jirones: hilachas finas de niebla que derivan en contra de los
+          bancos grandes — la textura deshilachada de la niebla real */}
+      <g className="mm2-jirones">
+        <ellipse cx="60" cy="588" rx="52" ry="7" fill="url(#mm2n-nucleo)" />
+        <ellipse cx="248" cy="598" rx="38" ry="5" fill="url(#mm2n-nucleo)" />
+        <ellipse cx="330" cy="828" rx="58" ry="8" fill="url(#mm2n-nucleo)" />
+        <ellipse cx="70" cy="842" rx="42" ry="6" fill="url(#mm2n-nucleo)" />
+        <ellipse cx="186" cy="1094" rx="66" ry="9" fill="url(#mm2n-nucleo)" />
+        <ellipse cx="300" cy="1342" rx="54" ry="8" fill="url(#mm2n-nucleo)" />
+      </g>
     </svg>
   );
 }
@@ -646,6 +747,36 @@ export default function MontanaMundosCine({ onBack = null }) {
   const viewportRef = useRef(null);
   const [vp, setVp] = useState({ w: 390, h: 700 });
 
+  // ── Pasada 3: la cámara sabe cuándo VIAJA y cuándo LLEGA a la finca ──
+  // viaje: mientras el plano se mueve, la niebla se abre y las etiquetas
+  // se retiran. llegada: al arribar al piso de la finca se dispara el
+  // momento de bienvenida — bloom, anillos, chispas. Ambos se marcan en
+  // los manejadores de gesto (no en un efecto) y un timer los apaga.
+  // La app abre centrada en la finca: la llegada corre desde el arranque.
+  const [viaje, setViaje] = useState(false);
+  const [llegada, setLlegada] = useState(true);
+  const viajeTimer = useRef(null);
+  const llegadaTimer = useRef(null);
+  const marcarCine = (nuevoModo, nuevoPiso) => {
+    setViaje(true);
+    if (viajeTimer.current) clearTimeout(viajeTimer.current);
+    // El zoom a la montaña completa viaja más lento que el paso de piso.
+    viajeTimer.current = setTimeout(() => setViaje(false), nuevoModo === 'montana' ? 1700 : 1050);
+    if (nuevoModo === 'finca' && nuevoPiso === PISO_FINCA) {
+      setLlegada(true);
+      if (llegadaTimer.current) clearTimeout(llegadaTimer.current);
+      llegadaTimer.current = setTimeout(() => setLlegada(false), 3600);
+    }
+  };
+  useEffect(() => {
+    // Apaga el momento de llegada inicial y limpia los timers al salir.
+    llegadaTimer.current = setTimeout(() => setLlegada(false), 3600);
+    return () => {
+      if (viajeTimer.current) clearTimeout(viajeTimer.current);
+      if (llegadaTimer.current) clearTimeout(llegadaTimer.current);
+    };
+  }, []);
+
   useEffect(() => {
     const medir = () => {
       const el = viewportRef.current;
@@ -685,48 +816,63 @@ export default function MontanaMundosCine({ onBack = null }) {
       swipeRef.current = e.touches[0].clientY;
     }
   };
+  // Todo movimiento de cámara pasa por aquí: cambia el estado Y marca el
+  // viaje (y la llegada si el destino es la finca) para el pulido de cine.
+  const caminarA = (nuevoPiso) => { setPiso(nuevoPiso); marcarCine('finca', nuevoPiso); };
+  const cambiarModo = (nuevoModo) => {
+    if (nuevoModo === modo) return;
+    setModo(nuevoModo);
+    marcarCine(nuevoModo, piso);
+  };
   const onTouchMove = (e) => {
     if (e.touches.length === 2 && pinchRef.current != null) {
       const razon = distancia(e.touches) / pinchRef.current;
-      if (razon < 0.78) { setModo('montana'); pinchRef.current = null; }
-      if (razon > 1.28) { setModo('finca'); pinchRef.current = null; }
+      if (razon < 0.78) { cambiarModo('montana'); pinchRef.current = null; }
+      if (razon > 1.28) { cambiarModo('finca'); pinchRef.current = null; }
     }
   };
   const onTouchEnd = (e) => {
     if (pinchRef.current == null && swipeRef.current != null && modo === 'finca' && e.changedTouches.length === 1) {
       const delta = e.changedTouches[0].clientY - swipeRef.current;
-      if (delta < -72 && piso < PISOS.length - 1) setPiso(piso + 1); // desliza arriba → baja la montaña
-      if (delta > 72 && piso > 0) setPiso(piso - 1); // desliza abajo → sube la montaña
+      if (delta < -72 && piso < PISOS.length - 1) caminarA(piso + 1); // desliza arriba → baja la montaña
+      if (delta > 72 && piso > 0) caminarA(piso - 1); // desliza abajo → sube la montaña
     }
     if (e.touches.length < 2) pinchRef.current = null;
     if (e.touches.length === 0) swipeRef.current = null;
   };
   const onWheel = (e) => {
     if (modo !== 'finca') return;
-    const ahora = Date.now();
+    const ahora = e.timeStamp; // reloj del evento (ms): estable y sin impurezas en render
     const rueda = ruedaRef.current;
     if (ahora < rueda.bloqueadaHasta) return;
     rueda.acumulado += e.deltaY;
     if (rueda.acumulado > 140 && piso < PISOS.length - 1) {
-      setPiso(piso + 1); // rueda abajo → baja la montaña
+      caminarA(piso + 1); // rueda abajo → baja la montaña
       rueda.acumulado = 0;
       rueda.bloqueadaHasta = ahora + 700;
     } else if (rueda.acumulado < -140 && piso > 0) {
-      setPiso(piso - 1); // rueda arriba → sube la montaña
+      caminarA(piso - 1); // rueda arriba → sube la montaña
       rueda.acumulado = 0;
       rueda.bloqueadaHasta = ahora + 700;
     }
   };
 
-  const alternarZoom = () => setModo(modo === 'finca' ? 'montana' : 'finca');
-  const irAPiso = (i) => { setPiso(i); setModo('finca'); };
+  const alternarZoom = () => cambiarModo(modo === 'finca' ? 'montana' : 'finca');
+  const irAPiso = (i) => { setPiso(i); setModo('finca'); marcarCine('finca', i); };
   const pisoActual = PISOS[piso];
   const direccion = DIRECCIONES.find((d) => d.id === dir) || DIRECCIONES[0];
 
   const pct = (v, total) => `${(v / total) * 100}%`;
 
   return (
-    <div className="mm2" data-dir={dir} data-modo={modo} data-piso={pisoActual.id}>
+    <div
+      className="mm2"
+      data-dir={dir}
+      data-modo={modo}
+      data-piso={pisoActual.id}
+      data-viaje={viaje ? 'true' : undefined}
+      data-llegada={llegada ? 'true' : undefined}
+    >
       <div
         className="mm2-viewport"
         ref={viewportRef}
@@ -762,6 +908,30 @@ export default function MontanaMundosCine({ onBack = null }) {
           <div className="mm2-finca-pin" style={{ left: pct(195, VB_W), top: pct(838, VB_H) }} aria-hidden="true">
             ⭐ Su finca
           </div>
+
+          {/* Momento de LLEGADA a la finca: bloom de hora dorada sobre la
+              casa, anillos que se expanden y chispas que suben del fogón.
+              Se monta solo mientras dura (las animaciones one-shot corren
+              de cero en cada arribo) y no intercepta ningún toque. */}
+          {llegada && (
+            <div
+              className="mm2-llegada"
+              style={{ left: pct(196, VB_W), top: pct(874, VB_H) }}
+              data-testid="mm2-llegada"
+              aria-hidden="true"
+            >
+              <span className="mm2-llegada-bloom" />
+              <span className="mm2-llegada-anillo" />
+              <span className="mm2-llegada-anillo mm2-anillo-2" />
+              {CHISPAS.map((c) => (
+                <span
+                  key={`${c.dx}-${c.dy}`}
+                  className="mm2-chispa"
+                  style={{ '--mm2-cdx': `${c.dx}px`, '--mm2-cdy': `${c.dy}px`, '--mm2-cd': `${c.demora}s` }}
+                />
+              ))}
+            </div>
+          )}
 
           {/* Mundos tocables: halo que pulsa + etiqueta */}
           {MUNDOS.map((m) => (
@@ -822,12 +992,12 @@ export default function MontanaMundosCine({ onBack = null }) {
           </span>
         </div>
         {modo === 'finca' && piso > 0 && (
-          <button type="button" className="mm2-paso mm2-paso-arriba" data-testid="mm2-paso-arriba" onClick={() => setPiso(piso - 1)}>
+          <button type="button" className="mm2-paso mm2-paso-arriba" data-testid="mm2-paso-arriba" onClick={() => caminarA(piso - 1)}>
             ▲ Subir a {PISOS[piso - 1].nombre}
           </button>
         )}
         {modo === 'finca' && piso < PISOS.length - 1 && (
-          <button type="button" className="mm2-paso mm2-paso-abajo" data-testid="mm2-paso-abajo" onClick={() => setPiso(piso + 1)}>
+          <button type="button" className="mm2-paso mm2-paso-abajo" data-testid="mm2-paso-abajo" onClick={() => caminarA(piso + 1)}>
             ▼ Bajar a {PISOS[piso + 1].nombre}
           </button>
         )}
@@ -841,7 +1011,7 @@ export default function MontanaMundosCine({ onBack = null }) {
         <header className="mm2-cabecera">
           <div className="mm2-mockbar">
             <button type="button" className="mm2-volver" onClick={() => onBack && onBack()}>← Volver</button>
-            <span className="mm2-mockbar-titulo">Mockup · pasada 2 · cine</span>
+            <span className="mm2-mockbar-titulo">Mockup · pasada 3 · cine</span>
           </div>
           <h1 className="mm2-titulo">La Montaña de los Mundos</h1>
           <div className="mm2-direcciones" role="tablist" aria-label="Dirección artística">

--- a/src/mockups/MontanaMundosCine.jsx
+++ b/src/mockups/MontanaMundosCine.jsx
@@ -1,0 +1,894 @@
+/**
+ * MontanaMundosCine.jsx — MOCKUP DEV, PASADA 2 CINEMATOGRÁFICA de
+ * "La Montaña de los Mundos" (#/mockups/montana-mundos-cine, sin gate).
+ *
+ * La pasada 1 (MontanaMundos.jsx, se conserva en #/mockups/montana-mundos)
+ * probó la estructura: pisos térmicos, mundos ubicados, zoom finca↔montaña.
+ * Esta pasada le sube el CINE, según el plan acordado con el operador:
+ *
+ *   1. PROFUNDIDAD REAL — la escena se parte en 6 capas de cámara:
+ *      cielo (astro + god-rays) → cordillera lejana → cordillera media →
+ *      montaña principal (pisos + mundos) → niebla volumétrica → primer
+ *      plano botánico. Al caminar de piso, cada capa viaja a su velocidad
+ *      (parallax) y con su propia inercia — cámara física, no scroll.
+ *   2. LUZ ATMOSFÉRICA POR PISO — un grade cinematográfico cambia la
+ *      temperatura de la luz al subir o bajar: azul glacial en el nevado,
+ *      hora dorada en la finca, ámbar en el cálido, turquesa en el río.
+ *   3. FULL-BLEED — la montaña ocupa el 100% del viewport; la UI flota
+ *      sobre el paisaje con scrims de cine, sin cajas ni márgenes muertos.
+ *   4. ELEMENTOS REDISEÑADOS — frailejón con roseta doble y vara de flor,
+ *      casa campesina con corredor, tejas y geranios, cafetal con hojas y
+ *      sombrío, mango con frutos colgando, río con orillas, reflejo del
+ *      cielo y cascada entre pisos, nevado con cara de sombra y grietas.
+ *
+ * Se conserva TODO lo validado de la pasada 1: abre centrado en la finca,
+ * pellizco/botón para ver la montaña completa, deslizar (y ahora también la
+ * rueda del mouse) para caminar entre pisos, atajos permanentes Ⓐ + anotar,
+ * halo + etiqueta en cada mundo, 3 direcciones artísticas conmutables.
+ *
+ * Técnica: SVG + CSS puros (cero deps, cero fotos). Solo transform/opacity
+ * se animan (GPU); los "volúmenes" de luz y niebla son degradados estáticos.
+ * prefers-reduced-motion deja un plano final digno. Español de Colombia.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import './montana-mundos-cine.css';
+
+// ── Geometría de la escena (unidades del viewBox 390×1440) ──────────────────
+const VB_W = 390;
+const VB_H = 1440;
+
+const PISOS = [
+  { id: 'nevado', nombre: 'Nevado', msnm: '4.800 m', y0: 96, y1: 320 },
+  { id: 'paramo', nombre: 'Páramo', msnm: '3.500 m', y0: 320, y1: 560 },
+  { id: 'frio', nombre: 'Clima frío', msnm: '2.600 m', y0: 560, y1: 800 },
+  { id: 'templado', nombre: 'Clima templado', msnm: '1.700 m', y0: 800, y1: 1060, finca: true },
+  { id: 'calido', nombre: 'Clima cálido', msnm: '800 m', y0: 1060, y1: 1300 },
+  { id: 'rio', nombre: 'El río', msnm: '400 m', y0: 1300, y1: 1440 },
+];
+const PISO_FINCA = PISOS.findIndex((p) => p.finca);
+
+// Mundos tocables (mismas anclas que la pasada 1 — geometría validada).
+const MUNDOS = [
+  { id: 'calendario', x: 316, y: 96, piso: 0, etiqueta: 'Calendario', abre: 'el calendario y el almanaque del campo' },
+  { id: 'glaciar', x: 195, y: 228, piso: 0, etiqueta: 'Glaciar', abre: 'los glaciares y el agua de alta montaña' },
+  { id: 'restauracion', x: 168, y: 420, piso: 1, etiqueta: 'Restaurar', abre: 'la restauración del páramo y el bosque' },
+  { id: 'papa', x: 118, y: 662, piso: 2, etiqueta: 'La papa', abre: 'la papa y los tubérculos' },
+  { id: 'animales', x: 272, y: 700, piso: 2, etiqueta: 'Mis animales', abre: 'sus animales: gallinas, vacas, cabras' },
+  { id: 'agente', x: 207, y: 896, piso: 3, etiqueta: 'Hablar con Chagra', abre: 'el agente: pregunte con su voz' },
+  { id: 'cosecha', x: 296, y: 848, piso: 3, etiqueta: 'Mi cosecha', abre: 'su cosecha guardada en el troje' },
+  { id: 'cafe', x: 96, y: 942, piso: 3, etiqueta: 'El café', abre: 'el mundo del café' },
+  { id: 'vender', x: 300, y: 986, piso: 3, etiqueta: 'Vender', abre: 'el mercado: precios y ventas' },
+  { id: 'mango', x: 92, y: 1136, piso: 4, etiqueta: 'El mango', abre: 'el mundo del mango' },
+  { id: 'platano', x: 292, y: 1168, piso: 4, etiqueta: 'El plátano', abre: 'el plátano y el banano' },
+  { id: 'rio', x: 190, y: 1372, piso: 5, etiqueta: 'El río', abre: 'el agua, el riego y la pesca' },
+];
+
+const DIRECCIONES = [
+  { id: 'naturalista', num: 1, corto: 'Sierra', nombre: 'Sierra naturalista', lema: 'hora dorada de montaña, cine de naturaleza' },
+  { id: 'biopunk', num: 2, corto: 'Biopunk', nombre: 'Biopunk', lema: 'noche de neón orgánico, como el home actual' },
+  { id: 'verde', num: 3, corto: 'Verde vivo', nombre: 'Verde vivo', lema: 'mañana botánica luminosa' },
+];
+
+// Factores de parallax: cuánto viaja cada capa respecto a la principal.
+// < 1 = lejos (se mueve menos) · > 1 = más cerca que la montaña.
+const CAPAS_F = { cielo: 0.1, lejos: 0.22, medio: 0.45, principal: 1, niebla: 1.12, cerca: 1.3 };
+
+// La escena SANGRA 150 unidades por debajo del río (dibujadas fuera del
+// viewBox con overflow visible): sin ese respiro, el piso del río quedaba
+// escondido detrás de la UI inferior en full-bleed.
+const VB_SANGRADO = 150;
+
+// Transform de la cámara base (geometría de la pasada 1 + sangrado).
+function calcularTransform(vp, modo, piso) {
+  const escenaH = vp.w * (VB_H / VB_W);
+  if (modo === 'montana') {
+    // Aire arriba (cabecera) y abajo (zoom + atajos): que el rótulo del río
+    // no quede detrás del botón de zoom.
+    const s = Math.min((vp.h - 230) / escenaH, 1);
+    return { s, tx: (vp.w - vp.w * s) / 2, ty: 72 };
+  }
+  const p = PISOS[piso];
+  const bandaH = ((p.y1 - p.y0) / VB_H) * escenaH;
+  const s = Math.max(1, Math.min((vp.h * 0.94) / bandaH, 1.35));
+  const cy = (((p.y0 + p.y1) / 2) / VB_H) * escenaH;
+  const sangradoPx = (VB_SANGRADO / VB_H) * escenaH * s;
+  let ty = vp.h / 2 - cy * s;
+  ty = Math.max(vp.h - escenaH * s - sangradoPx, Math.min(0, ty));
+  const tx = (vp.w - vp.w * s) / 2;
+  return { s, tx, ty };
+}
+
+// ── Piezas de la escena (SVG) ────────────────────────────────────────────────
+
+/** Frailejón pasada 2: faldón de hojas secas, roseta doble, varas de flor. */
+function Frailejon({ x, y, s = 1 }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`}>
+      <path className="mm2-frailejon-faldon" d="M-4 4 Q-9 10 -8 18 M0 6 Q-1 12 0 20 M4 4 Q9 10 8 18" />
+      <rect x="-3.6" y="-4" width="7.2" height="30" rx="3.2" className="mm2-frailejon-tronco" />
+      <g className="mm2-frailejon-roseta">
+        {[-84, -56, -28, 0, 28, 56, 84].map((a) => (
+          <ellipse key={`e${a}`} cx="0" cy="-14" rx="3" ry="13" transform={`rotate(${a} 0 -1)`} className="mm2-frailejon-hoja" />
+        ))}
+        {[-34, -12, 12, 34].map((a) => (
+          <ellipse key={`i${a}`} cx="0" cy="-17" rx="2.4" ry="11" transform={`rotate(${a} 0 -3)`} className="mm2-frailejon-hoja mm2-hoja-int" />
+        ))}
+        <path className="mm2-frailejon-tallo" d="M-2 -14 Q-6 -26 -8 -34" />
+        <path className="mm2-frailejon-tallo" d="M2 -14 Q6 -28 8 -38" />
+        <circle cx="-8" cy="-36" r="2.8" className="mm2-frailejon-flor" />
+        <circle cx="8" cy="-40" r="3.2" className="mm2-frailejon-flor" />
+      </g>
+    </g>
+  );
+}
+
+/** Mata de café pasada 2: tallo, pares de hojas y cerezas rojas. */
+function MataCafe({ x, y, s = 1 }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`}>
+      <path className="mm2-cafe-tallo" d="M0 9 L0 -7" />
+      {[[-1, -5, -34], [1, -4, 34], [-1, -1, -48], [1, 0, 48], [-1, 3, -60], [1, 4, 60]].map(([lado, cy, rot], i) => (
+        <ellipse
+          key={`h${i}`}
+          cx={lado * 4.6}
+          cy={cy}
+          rx="4.6"
+          ry="2"
+          transform={`rotate(${rot} ${lado * 4.6} ${cy})`}
+          className="mm2-cafe-hoja"
+        />
+      ))}
+      <circle cx="-2.6" cy="0.5" r="1.6" className="mm2-cafe-fruto" />
+      <circle cx="2.4" cy="-2.4" r="1.6" className="mm2-cafe-fruto" />
+      <circle cx="1.8" cy="3.2" r="1.6" className="mm2-cafe-fruto" />
+    </g>
+  );
+}
+
+/** Animal del corral (silueta simple: cuerpo + cabeza + patas). */
+function Animalito({ x, y, s = 1, clase = 'mm2-oveja' }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`} className={clase}>
+      <ellipse cx="0" cy="0" rx="8.4" ry="5.4" />
+      <circle cx="8.2" cy="-3.2" r="3.1" />
+      <rect x="-6" y="3" width="2.2" height="6" rx="1" />
+      <rect x="3.6" y="3" width="2.2" height="6" rx="1" />
+    </g>
+  );
+}
+
+/** Arbolito del bosque altoandino (cono doble + tronco). */
+function Arbolito({ x, y, s = 1 }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`}>
+      <rect x="-1.4" y="4" width="2.8" height="6" className="mm2-arbolito-tronco" />
+      <path d="M0 -14 L7 0 L-7 0 Z" className="mm2-arbolito" />
+      <path d="M0 -7 L8.5 6 L-8.5 6 Z" className="mm2-arbolito" />
+    </g>
+  );
+}
+
+// ── Capa 1: CIELO (astro, estrellas, god-rays, nubes altas) — f 0.10 ────────
+function CieloSvg() {
+  return (
+    <svg className="mm2-svg" viewBox={`0 0 ${VB_W} ${VB_H}`} preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
+      <defs>
+        <linearGradient id="mm2c-cielo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm2-stop-cielo-a" />
+          <stop offset="0.5" className="mm2-stop-cielo-m" />
+          <stop offset="1" className="mm2-stop-cielo-b" />
+        </linearGradient>
+        <radialGradient id="mm2c-halo" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0" className="mm2-stop-halo-a" />
+          <stop offset="1" className="mm2-stop-halo-b" />
+        </radialGradient>
+        <linearGradient id="mm2c-rayo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm2-stop-rayo-a" />
+          <stop offset="1" className="mm2-stop-rayo-b" />
+        </linearGradient>
+      </defs>
+
+      <rect x="0" y="0" width={VB_W} height={VB_H} fill="url(#mm2c-cielo)" />
+
+      {/* Estrellas (noche biopunk) */}
+      <g className="mm2-estrellas">
+        {[[24, 60, 1.6], [70, 130, 1.1], [120, 44, 1.4], [170, 96, 1], [250, 60, 1.5],
+          [292, 150, 1.1], [350, 40, 1.3], [366, 120, 1], [46, 210, 1.2], [340, 210, 1.4],
+          [96, 300, 1], [300, 300, 1.1], [150, 170, 1.2], [210, 40, 1], [30, 350, 1.1],
+          [360, 320, 1.2], [190, 260, 1], [260, 220, 1.3]].map(([cx, cy, r]) => (
+            <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r={r} className="mm2-estrella" />
+          ))}
+      </g>
+
+      {/* God-rays: abanico de luz volumétrica desde el astro, baña la ladera */}
+      <g className="mm2-rayos">
+        <path className="mm2-rayo mm2-rayo-1" d="M300 106 L96 620 L168 660 Z" fill="url(#mm2c-rayo)" />
+        <path className="mm2-rayo mm2-rayo-2" d="M314 118 L238 700 L306 706 Z" fill="url(#mm2c-rayo)" />
+        <path className="mm2-rayo mm2-rayo-3" d="M330 108 L420 560 L354 620 Z" fill="url(#mm2c-rayo)" />
+      </g>
+
+      {/* El astro (sol de día, luna con cráteres de noche) → mundo Calendario */}
+      <g className="mm2-astro">
+        <circle cx="316" cy="96" r="60" fill="url(#mm2c-halo)" />
+        <circle cx="316" cy="96" r="24" className="mm2-astro-disco" />
+        <circle cx="308" cy="88" r="4.6" className="mm2-astro-crater" />
+        <circle cx="324" cy="102" r="3.2" className="mm2-astro-crater" />
+        <circle cx="314" cy="108" r="2.4" className="mm2-astro-crater" />
+      </g>
+
+      {/* Cirros altos, casi quietos */}
+      <g className="mm2-nubes">
+        <g className="mm2-nube-alta mm2-nube-1">
+          <ellipse cx="90" cy="70" rx="44" ry="7" />
+          <ellipse cx="120" cy="64" rx="26" ry="5" />
+        </g>
+        <g className="mm2-nube-alta mm2-nube-2">
+          <ellipse cx="250" cy="190" rx="38" ry="6" />
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+// ── Capa 2: CORDILLERA LEJANA (perspectiva atmosférica) — f 0.22 ────────────
+function CordilleraLejosSvg() {
+  return (
+    <svg className="mm2-svg" viewBox={`0 0 ${VB_W} ${VB_H}`} preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
+      <path
+        className="mm2-lejos-a"
+        d="M-2 1442 L-2 460 Q40 380 84 410 Q130 445 186 385 Q244 325 300 390 Q348 440 392 405 L392 1442 Z"
+      />
+      <path
+        className="mm2-lejos-b"
+        d="M-2 1442 L-2 640 Q56 560 124 596 Q200 636 268 570 Q330 512 392 570 L392 1442 Z"
+      />
+      {/* banda de bruma que funde la cordillera con el cielo */}
+      <rect className="mm2-bruma-banda" x="-2" y="560" width="394" height="120" opacity="0.55" />
+    </svg>
+  );
+}
+
+// ── Capa 3: CORDILLERA MEDIA (+ aves y nubes de media altura) — f 0.45 ──────
+function CordilleraMediaSvg() {
+  return (
+    <svg className="mm2-svg" viewBox={`0 0 ${VB_W} ${VB_H}`} preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
+      <path
+        className="mm2-medio-a"
+        d="M-2 1442 L-2 700 Q48 590 100 480 Q126 424 158 468 Q192 540 210 640 L210 1442 Z"
+      />
+      <path
+        className="mm2-medio-b"
+        d="M392 1442 L392 680 Q344 572 302 486 Q278 436 252 482 Q224 548 208 650 L208 1442 Z"
+      />
+      <g className="mm2-nubes">
+        <g className="mm2-nube mm2-nube-3">
+          <ellipse cx="86" cy="560" rx="40" ry="10" />
+          <ellipse cx="112" cy="552" rx="24" ry="8" />
+        </g>
+      </g>
+      <g className="mm2-aves">
+        <g className="mm2-ave-1">
+          <path d="M96 336 q6 -6 12 0 q6 -6 12 0" />
+          <path d="M130 358 q5 -5 10 0 q5 -5 10 0" />
+        </g>
+        <path d="M270 430 q5 -5 10 0 q5 -5 10 0" />
+      </g>
+      {/* bruma al pie de la cordillera media */}
+      <rect className="mm2-bruma-banda" x="-2" y="640" width="394" height="90" opacity="0.4" />
+    </svg>
+  );
+}
+
+// ── Capa 4: MONTAÑA PRINCIPAL (pisos térmicos + todos los mundos) — f 1 ─────
+function MontanaPrincipalSvg() {
+  return (
+    <svg className="mm2-svg" viewBox={`0 0 ${VB_W} ${VB_H}`} preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
+      <defs>
+        <linearGradient id="mm2p-rio" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm2-stop-rio-a" />
+          <stop offset="1" className="mm2-stop-rio-b" />
+        </linearGradient>
+        <linearGradient id="mm2p-reflejo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" className="mm2-stop-reflejo-a" />
+          <stop offset="0.6" className="mm2-stop-reflejo-b" />
+        </linearGradient>
+        {/* Luz direccional: el astro está arriba a la derecha — la cara
+            derecha del cono recibe luz, la izquierda cae en sombra. */}
+        <linearGradient id="mm2p-ladera" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" className="mm2-stop-ladera-sombra" />
+          <stop offset="0.48" className="mm2-stop-transparente" />
+          <stop offset="1" className="mm2-stop-ladera-luz" />
+        </linearGradient>
+        <clipPath id="mm2p-clip-montana">
+          {/* El recorte baja hasta el sangrado (1590): el valle sigue vivo
+              debajo del viewBox para que la cámara pueda centrar el río. */}
+          <path d="M-2 1590 L-2 760 Q56 706 96 596 Q136 486 160 366 Q178 268 195 176 Q212 268 230 366 Q254 486 294 596 Q334 706 392 760 L392 1590 Z" />
+        </clipPath>
+      </defs>
+
+      {/* ── Cuerpo de la montaña: pisos térmicos apilados ── */}
+      <g clipPath="url(#mm2p-clip-montana)">
+        <rect x="-2" y="170" width="394" height="1272" className="mm2-piso-paramo" />
+        <path className="mm2-piso-frio" d="M-2 574 Q46 556 94 566 Q152 578 200 564 Q258 550 306 564 Q350 576 392 562 L392 1442 L-2 1442 Z" />
+        <path className="mm2-piso-templado" d="M-2 816 Q50 798 104 808 Q160 820 212 806 Q266 792 316 806 Q356 816 392 804 L392 1442 L-2 1442 Z" />
+        <path className="mm2-piso-calido" d="M-2 1076 Q54 1058 110 1068 Q166 1080 222 1066 Q276 1052 330 1066 Q364 1074 392 1062 L392 1442 L-2 1442 Z" />
+        <path className="mm2-piso-valle" d="M-2 1316 Q60 1300 130 1310 Q210 1322 280 1308 Q340 1298 392 1308 L392 1442 L-2 1442 Z" />
+
+        {/* Curvas de nivel: escala real de montaña, sutiles */}
+        <path className="mm2-contorno" d="M60 640 Q140 620 250 640" />
+        <path className="mm2-contorno" d="M40 730 Q150 706 300 730" />
+        <path className="mm2-contorno" d="M30 900 Q170 876 340 900" />
+        <path className="mm2-contorno" d="M24 1000 Q180 976 360 1000" />
+        <path className="mm2-contorno" d="M30 1160 Q190 1136 358 1160" />
+        <path className="mm2-contorno" d="M40 1250 Q200 1228 350 1250" />
+
+        {/* Nevado: casquete con ruana dentada, cara de sombra y grietas */}
+        <path className="mm2-nieve" d="M195 140 Q168 220 138 320 L154 306 L166 324 L182 306 L196 330 L212 306 L226 322 L240 304 L254 318 Q222 220 195 140 Z" />
+        <path className="mm2-nieve-sombra" d="M195 140 Q180 196 162 268 Q178 246 190 252 Q196 208 195 140 Z" />
+        <path className="mm2-grieta" d="M180 260 q8 4 16 2" />
+        <path className="mm2-grieta" d="M198 292 q7 3 13 1" />
+        <path className="mm2-nieve" d="M196 330 Q192 358 184 382 Q178 360 182 336 Z" opacity="0.9" />
+        <path className="mm2-grieta" d="M186 348 q4 3 8 2" opacity="0.7" />
+
+        {/* Bordes de piso: la rima de luz entre climas */}
+        <path className="mm2-borde-piso" d="M-2 574 Q46 556 94 566 Q152 578 200 564 Q258 550 306 564 Q350 576 392 562" />
+        <path className="mm2-borde-piso" d="M-2 816 Q50 798 104 808 Q160 820 212 806 Q266 792 316 806 Q356 816 392 804" />
+        <path className="mm2-borde-piso" d="M-2 1076 Q54 1058 110 1068 Q166 1080 222 1066 Q276 1052 330 1066 Q364 1074 392 1062" />
+        <path className="mm2-borde-piso" d="M-2 1316 Q60 1300 130 1310 Q210 1322 280 1308 Q340 1298 392 1308" />
+
+        {/* ── PÁRAMO: laguna con reflejo, pajonal, frailejones ── */}
+        <ellipse className="mm2-laguna" cx="222" cy="512" rx="34" ry="9" />
+        <ellipse cx="222" cy="512" rx="34" ry="9" fill="url(#mm2p-reflejo)" />
+        <path className="mm2-laguna-brillo" d="M198 510 Q222 504 246 510" />
+        <g className="mm2-pajonal">
+          <path d="M196 452 q-3 -10 -7 -13 M196 452 q0 -12 1 -15 M196 452 q4 -9 8 -12" />
+          <path d="M216 436 q-3 -9 -6 -11 M216 436 q0 -10 1 -13 M216 436 q3 -8 7 -10" />
+          <path d="M160 508 q-3 -9 -6 -11 M160 508 q0 -10 1 -13 M160 508 q3 -8 7 -10" />
+          <path d="M186 528 q-3 -8 -6 -10 M186 528 q0 -9 1 -12 M186 528 q3 -7 6 -9" />
+          <path d="M250 486 q-3 -9 -6 -11 M250 486 q0 -10 1 -13 M250 486 q3 -8 7 -10" />
+          <path d="M232 540 q-3 -8 -6 -10 M232 540 q0 -9 1 -12 M232 540 q3 -7 6 -9" />
+        </g>
+        <ellipse className="mm2-piedra" cx="150" cy="532" rx="9" ry="5" />
+        <ellipse className="mm2-piedra" cx="228" cy="456" rx="6" ry="3.6" />
+        <Frailejon x={168} y={438} s={1.25} />
+        <Frailejon x={204} y={472} s={0.95} />
+        <Frailejon x={150} y={488} s={0.8} />
+        <Frailejon x={240} y={530} s={0.7} />
+
+        {/* ── FRÍO: surcos de papa, corral, bosque altoandino ── */}
+        <g className="mm2-surcos">
+          <path d="M70 636 Q118 626 166 636" />
+          <path d="M62 656 Q118 644 174 656" />
+          <path d="M56 676 Q118 662 180 676" />
+          <path d="M52 696 Q118 682 184 696" />
+        </g>
+        <g className="mm2-matas-papa">
+          {[[80, 632], [112, 628], [144, 632], [72, 652], [108, 646], [148, 652],
+            [66, 672], [106, 664], [152, 672], [62, 692], [104, 684], [156, 692]].map(([cx, cy]) => (
+              <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="3" />
+            ))}
+        </g>
+        <Arbolito x={210} y={618} s={1} />
+        <Arbolito x={190} y={640} s={0.8} />
+        <Arbolito x={330} y={640} s={0.9} />
+        <g className="mm2-corral">
+          {[236, 258, 280, 302, 318].map((x) => (
+            <rect key={x} x={x} y={694} width="3.2" height="16" rx="1.4" className="mm2-cerca-poste" />
+          ))}
+          <rect x="234" y="697" width="88" height="2.6" rx="1.3" className="mm2-cerca-riel" />
+          <rect x="234" y="704" width="88" height="2.6" rx="1.3" className="mm2-cerca-riel" />
+          <Animalito x={258} y={688} s={0.9} clase="mm2-oveja" />
+          <Animalito x={296} y={690} s={1.05} clase="mm2-vaca" />
+        </g>
+
+        {/* ── TEMPLADO: casa campesina con corredor, troje, cafetal, mercado ── */}
+        <g className="mm2-casa">
+          <g className="mm2-humo">
+            <circle className="mm2-humo-1" cx="212" cy="854" r="3.4" />
+            <circle className="mm2-humo-2" cx="214" cy="846" r="4.4" />
+            <circle className="mm2-humo-3" cx="217" cy="836" r="5.4" />
+          </g>
+          <rect x="206" y="854" width="7" height="16" rx="1.5" className="mm2-casa-chimenea" />
+          {/* cuerpo + corredor campesino (zócalo, columnas) */}
+          <rect x="166" y="874" width="60" height="34" rx="2.5" className="mm2-casa-muro" />
+          <rect x="162" y="905" width="68" height="4" rx="2" className="mm2-casa-zocalo" />
+          <rect x="169" y="884" width="2.6" height="21" className="mm2-casa-columna" />
+          <rect x="221" y="884" width="2.6" height="21" className="mm2-casa-columna" />
+          {/* techo a dos aguas con canales de teja */}
+          <path d="M158 878 L196 848 L234 878 Z" className="mm2-casa-techo" />
+          <path className="mm2-casa-teja" d="M186 856 L176 876 M196 851 L196 876 M206 856 L216 876" />
+          {/* ventana con marco (encendida: alguien está en casa) */}
+          <rect x="176" y="886" width="12" height="11" rx="2" className="mm2-casa-ventana" />
+          <rect x="181" y="886" width="1.6" height="11" className="mm2-casa-marco" />
+          <rect x="200" y="883" width="14" height="25" rx="2.5" className="mm2-casa-puerta" />
+          {/* materas con geranios en el corredor */}
+          <rect x="163" y="899" width="5.6" height="6" rx="1" className="mm2-matera" />
+          <circle cx="165.8" cy="897" r="2.6" className="mm2-geranio" />
+          <rect x="227" y="899" width="5.6" height="6" rx="1" className="mm2-matera" />
+          <circle cx="229.8" cy="897" r="2.6" className="mm2-geranio" />
+          <path d="M150 908 Q196 916 244 908" className="mm2-casa-camino" />
+        </g>
+        <g className="mm2-troje">
+          <rect x="282" y="856" width="4" height="16" className="mm2-troje-pata" />
+          <rect x="306" y="856" width="4" height="16" className="mm2-troje-pata" />
+          <rect x="276" y="836" width="40" height="22" rx="3" className="mm2-troje-cuerpo" />
+          <path d="M272 838 L296 822 L320 838 Z" className="mm2-troje-techo" />
+          <circle cx="290" cy="847" r="3" className="mm2-troje-grano" />
+          <circle cx="298" cy="849" r="3" className="mm2-troje-grano" />
+          <circle cx="304" cy="846" r="3" className="mm2-troje-grano" />
+        </g>
+        {/* Cafetal a la sombra de los guamos, en hileras */}
+        <g className="mm2-sombrio">
+          <path d="M52 940 Q50 924 54 912" />
+          <path d="M146 936 Q144 920 148 908" />
+        </g>
+        <ellipse className="mm2-sombrio-copa" cx="54" cy="904" rx="18" ry="9" />
+        <ellipse className="mm2-sombrio-copa" cx="148" cy="900" rx="20" ry="10" />
+        <g className="mm2-cafetal">
+          <MataCafe x={72} y={936} s={1.1} />
+          <MataCafe x={98} y={928} s={1} />
+          <MataCafe x={124} y={938} s={1.15} />
+          <MataCafe x={84} y={958} s={0.95} />
+          <MataCafe x={112} y={956} s={1.05} />
+          <MataCafe x={58} y={952} s={0.85} />
+        </g>
+        <g className="mm2-mercado">
+          <rect x="278" y="988" width="46" height="20" rx="2.5" className="mm2-mercado-meson" />
+          {[278, 289.5, 301, 312.5].map((x, i) => (
+            <rect key={x} x={x} y={974} width="11.5" height="10" rx="1.5" className={i % 2 ? 'mm2-toldo-b' : 'mm2-toldo-a'} />
+          ))}
+          <rect x="276" y="982" width="50" height="4" rx="2" className="mm2-mercado-tabla" />
+          <circle cx="288" cy="994" r="3.4" className="mm2-mercado-fruta-a" />
+          <circle cx="298" cy="994" r="3.4" className="mm2-mercado-fruta-b" />
+          <circle cx="308" cy="994" r="3.4" className="mm2-mercado-fruta-a" />
+        </g>
+
+        {/* ── CÁLIDO: mango con frutos colgando, platanera, cañaduzal ── */}
+        <g className="mm2-arbol-mango">
+          <path d="M90 1172 Q86 1152 82 1140 M90 1172 Q92 1150 98 1136" className="mm2-mango-tronco" />
+          <circle cx="92" cy="1122" r="25" className="mm2-mango-copa-sombra" />
+          <circle cx="80" cy="1128" r="18" className="mm2-mango-copa" />
+          <circle cx="104" cy="1122" r="16" className="mm2-mango-copa" />
+          <circle cx="92" cy="1108" r="15" className="mm2-mango-copa" />
+          {[[76, 1142], [98, 1138], [108, 1130]].map(([cx, cy]) => (
+            <g key={`${cx}-${cy}`}>
+              <path className="mm2-mango-pezon" d={`M${cx} ${cy - 9} L${cx} ${cy - 3}`} />
+              <ellipse cx={cx} cy={cy} rx="3" ry="3.8" className="mm2-mango-fruto" />
+            </g>
+          ))}
+        </g>
+        <g className="mm2-platanera">
+          {[-58, -30, 0, 30, 58].map((a) => (
+            <g key={a} transform={`translate(292 1180) rotate(${a} 0 0)`}>
+              <path d="M0 0 Q5 -20 1.5 -38 L0 -30 L-1.5 -38 Q-5 -20 0 0" className="mm2-platano-hoja" />
+              <path d="M0 -4 L0 -30" className="mm2-platano-nervio" />
+            </g>
+          ))}
+          <rect x="289" y="1180" width="6" height="18" rx="2.6" className="mm2-platano-tallo" />
+          <g className="mm2-racimo">
+            {[[284, 1168], [281, 1174], [284, 1180]].map(([cx, cy]) => (
+              <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="3" />
+            ))}
+            <ellipse cx="281" cy="1188" rx="2.6" ry="3.6" className="mm2-bellota" />
+          </g>
+        </g>
+        <g className="mm2-cana">
+          {[176, 188, 200, 212].map((x, i) => (
+            <g key={x}>
+              <path d={`M${x} 1252 Q${x + (i % 2 ? 5 : -5)} 1222 ${x + (i % 2 ? 2 : -2)} 1200`} className="mm2-cana-tallo" />
+              <path d={`M${x + (i % 2 ? 2 : -2)} 1204 q-6 -6 -10 -7 M${x + (i % 2 ? 2 : -2)} 1204 q6 -7 10 -8`} className="mm2-cana-hoja" />
+            </g>
+          ))}
+        </g>
+
+        {/* ── RÍO: orillas, reflejo del cielo, cascada entre pisos, flujo ── */}
+        <path
+          className="mm2-rio-orilla"
+          d="M236 1004 Q248 1050 232 1096 Q214 1146 228 1196 Q244 1250 214 1300 Q186 1350 196 1400 L204 1442 L146 1442 Q136 1390 158 1338 Q182 1290 168 1240 Q152 1186 172 1136 Q192 1090 208 1052 Q218 1024 224 1004 Z"
+          fill="none"
+        />
+        <path
+          className="mm2-rio"
+          d="M236 1004 Q248 1050 232 1096 Q214 1146 228 1196 Q244 1250 214 1300 Q186 1350 196 1400 L204 1442 L146 1442 Q136 1390 158 1338 Q182 1290 168 1240 Q152 1186 172 1136 Q192 1090 208 1052 Q218 1024 224 1004 Z"
+          fill="url(#mm2p-rio)"
+        />
+        {/* reflejo del cielo sobre el agua */}
+        <path
+          d="M236 1004 Q248 1050 232 1096 Q214 1146 228 1196 Q244 1250 214 1300 Q186 1350 196 1400 L204 1442 L146 1442 Q136 1390 158 1338 Q182 1290 168 1240 Q152 1186 172 1136 Q192 1090 208 1052 Q218 1024 224 1004 Z"
+          fill="url(#mm2p-reflejo)"
+        />
+        {/* cascada: el río salta el borde templado→cálido */}
+        <g className="mm2-cascada">
+          <path className="mm2-cascada-caida" d="M222 1062 L234 1062 L236 1082 L219 1082 Z" />
+          <circle className="mm2-espuma" cx="222" cy="1084" r="2.6" />
+          <circle className="mm2-espuma" cx="229" cy="1086" r="3" />
+          <circle className="mm2-espuma" cx="235" cy="1084" r="2.2" />
+        </g>
+        <g className="mm2-flujo">
+          <path d="M226 1030 Q234 1072 222 1112 Q206 1158 218 1204" />
+          <path d="M228 1230 Q238 1272 210 1318 Q188 1356 194 1404" />
+          <path d="M212 1080 Q200 1130 212 1178" />
+        </g>
+        <ellipse className="mm2-piedra" cx="182" cy="1368" rx="8" ry="5" />
+        <ellipse className="mm2-piedra" cx="222" cy="1322" rx="6" ry="4" />
+
+        {/* Sangrado del valle: el paisaje continúa bajo el viewBox */}
+        <rect x="-2" y="1436" width="394" height="156" className="mm2-piso-valle" />
+        <path
+          d="M146 1436 L204 1436 L212 1548 Q186 1572 152 1548 Z"
+          fill="url(#mm2p-rio)"
+        />
+        <ellipse className="mm2-piedra" cx="240" cy="1478" rx="9" ry="5" />
+        <ellipse className="mm2-piedra" cx="132" cy="1508" rx="7" ry="4" />
+        <g className="mm2-pajonal">
+          <path d="M110 1490 q-3 -10 -7 -13 M110 1490 q0 -12 1 -15 M110 1490 q4 -9 8 -12" />
+          <path d="M266 1500 q-3 -9 -6 -11 M266 1500 q0 -10 1 -13 M266 1500 q3 -8 7 -10" />
+        </g>
+
+        {/* Luz direccional de ladera (el astro a la derecha) */}
+        <rect x="-2" y="120" width="394" height="1470" fill="url(#mm2p-ladera)" pointerEvents="none" />
+      </g>
+
+      {/* Red viva (solo biopunk): el micelio conecta los pisos */}
+      <g className="mm2-micelio">
+        <path d="M316 120 Q260 200 195 300 Q160 390 168 428 Q150 520 160 600 Q175 660 195 700 Q220 760 195 880 Q180 940 230 1000 Q260 1060 240 1140 Q220 1240 195 1300 Q180 1340 190 1380" />
+        <path d="M168 428 Q200 520 272 700" opacity="0.55" />
+        <path d="M195 880 Q140 920 96 942" opacity="0.55" />
+        <path d="M230 1000 Q270 1080 292 1168" opacity="0.55" />
+        {MUNDOS.map((m) => (
+          <circle key={m.id} cx={m.x} cy={m.y} r="3" className="mm2-micelio-nodo" />
+        ))}
+      </g>
+
+      {/* Mariposas (solo verde vivo) */}
+      <g className="mm2-mariposas">
+        <g transform="translate(150 860)">
+          <g className="mm2-mariposa-1">
+            <ellipse cx="-3" cy="0" rx="3.4" ry="2.2" />
+            <ellipse cx="3" cy="0" rx="3.4" ry="2.2" />
+          </g>
+        </g>
+        <g transform="translate(260 1120)">
+          <g className="mm2-mariposa-2">
+            <ellipse cx="-3" cy="0" rx="3" ry="2" />
+            <ellipse cx="3" cy="0" rx="3" ry="2" />
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+// ── Capa 5: NIEBLA VOLUMÉTRICA entre pisos (la del valle SUBE) — f 1.12 ─────
+function NieblaSvg() {
+  return (
+    <svg className="mm2-svg" viewBox={`0 0 ${VB_W} ${VB_H}`} preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
+      <defs>
+        <radialGradient id="mm2n-nucleo" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0" className="mm2-stop-niebla-a" />
+          <stop offset="1" className="mm2-stop-niebla-b" />
+        </radialGradient>
+      </defs>
+      {/* banco páramo/frío */}
+      <g className="mm2-banco-1">
+        <ellipse cx="110" cy="562" rx="150" ry="24" fill="url(#mm2n-nucleo)" />
+        <ellipse cx="280" cy="578" rx="120" ry="19" fill="url(#mm2n-nucleo)" />
+      </g>
+      {/* banco frío/templado */}
+      <g className="mm2-banco-2">
+        <ellipse cx="290" cy="808" rx="150" ry="24" fill="url(#mm2n-nucleo)" />
+        <ellipse cx="90" cy="822" rx="110" ry="18" fill="url(#mm2n-nucleo)" />
+      </g>
+      {/* banco templado/cálido */}
+      <g className="mm2-banco-3">
+        <ellipse cx="110" cy="1070" rx="140" ry="22" fill="url(#mm2n-nucleo)" />
+        <ellipse cx="300" cy="1082" rx="100" ry="16" fill="url(#mm2n-nucleo)" />
+      </g>
+      {/* niebla de valle: nace sobre el río, sube y se disipa */}
+      <g className="mm2-banco-valle">
+        <ellipse cx="190" cy="1350" rx="190" ry="34" fill="url(#mm2n-nucleo)" />
+        <ellipse cx="90" cy="1382" rx="120" ry="24" fill="url(#mm2n-nucleo)" />
+      </g>
+      <g className="mm2-banco-valle-2">
+        <ellipse cx="290" cy="1400" rx="150" ry="28" fill="url(#mm2n-nucleo)" />
+      </g>
+    </svg>
+  );
+}
+
+// ── Capa 6: PRIMER PLANO botánico (enmarca el plano; sale al alejar) — f 1.3 ─
+// Cada grupo vive a la altura que le corresponde según el piso encuadrado
+// (con f=1.3 el pie de pantalla cae más abajo en el viewBox — por eso las
+// formas del cálido/río se dibujan pasado 1440; overflow visible del SVG).
+function PrimerPlanoSvg() {
+  return (
+    <svg className="mm2-svg" viewBox={`0 0 ${VB_W} ${VB_H}`} preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
+      {/* nevado: filo de roca */}
+      <path className="mm2-cerca-forma-suave" d="M-4 640 Q40 596 96 608 Q60 626 44 648 L-4 664 Z" />
+      {/* páramo: silueta de frailejón grande a la izquierda */}
+      <g className="mm2-cerca-forma">
+        <rect x="18" y="742" width="9" height="52" rx="4" />
+        {[-64, -32, 0, 32, 64].map((a) => (
+          <ellipse key={a} cx="22.5" cy="726" rx="4.4" ry="18" transform={`rotate(${a} 22.5 740)`} />
+        ))}
+      </g>
+      {/* frío: rama de arbusto por la derecha */}
+      <g className="mm2-cerca-forma-suave">
+        <path d="M394 1046 Q340 1030 300 1044 Q336 1052 360 1066 L394 1078 Z" />
+        <path d="M394 1084 Q352 1076 326 1088 Q356 1094 372 1104 L394 1112 Z" />
+      </g>
+      {/* templado: hojas grandes de cafetal por ambas esquinas */}
+      <g className="mm2-cerca-forma">
+        <path d="M-4 1408 Q28 1354 78 1338 Q42 1382 34 1428 L-4 1442 Z" />
+        <path d="M394 1400 Q356 1352 310 1340 Q348 1384 356 1430 L394 1442 Z" />
+      </g>
+      {/* cálido/río: hoja de plátano gigante + juncos (bajo el viewBox) */}
+      <g className="mm2-cerca-forma">
+        <path d="M-4 1700 Q40 1600 120 1570 Q64 1636 48 1706 L-4 1730 Z" />
+        <path d="M394 1690 Q348 1610 280 1584 Q330 1646 344 1712 L394 1734 Z" />
+      </g>
+      <g className="mm2-cerca-forma-suave">
+        <path d="M150 1740 q-3 -44 -8 -56 M170 1742 q0 -50 -2 -62 M190 1740 q3 -46 8 -58" />
+        <path d="M240 1744 q-2 -40 -6 -50 M258 1744 q1 -44 3 -54" />
+      </g>
+    </svg>
+  );
+}
+
+// `onBack` con default: los tests montan el mockup sin prop (gate tsc checkJs).
+export default function MontanaMundosCine({ onBack = null }) {
+  const [dir, setDir] = useState('naturalista');
+  const [modo, setModo] = useState('finca'); // 'finca' | 'montana'
+  const [piso, setPiso] = useState(PISO_FINCA);
+  const [aviso, setAviso] = useState(null);
+  const avisoTimer = useRef(null);
+  const viewportRef = useRef(null);
+  const [vp, setVp] = useState({ w: 390, h: 700 });
+
+  useEffect(() => {
+    const medir = () => {
+      const el = viewportRef.current;
+      if (el) setVp({ w: el.clientWidth, h: el.clientHeight });
+    };
+    medir();
+    window.addEventListener('resize', medir);
+    return () => window.removeEventListener('resize', medir);
+  }, []);
+
+  const t = useMemo(() => calcularTransform(vp, modo, piso), [vp, modo, piso]);
+  const escenaH = vp.w * (VB_H / VB_W);
+
+  // Transform por capa: la cámara base viaja completa (f=1); las capas
+  // lejanas la siguen amortiguadas y las cercanas la adelantan — parallax.
+  const transformCapa = (f) => `translate3d(${t.tx}px, ${t.ty * f}px, 0) scale(${t.s})`;
+
+  const avisar = (texto) => {
+    setAviso(texto);
+    if (avisoTimer.current) clearTimeout(avisoTimer.current);
+    avisoTimer.current = setTimeout(() => setAviso(null), 2600);
+  };
+  useEffect(() => () => { if (avisoTimer.current) clearTimeout(avisoTimer.current); }, []);
+
+  // Gestos: pellizco (2 dedos) alterna finca ↔ montaña; deslizar vertical
+  // (1 dedo) camina de piso; la rueda del mouse también camina la montaña.
+  const pinchRef = useRef(null);
+  const swipeRef = useRef(null);
+  const ruedaRef = useRef({ acumulado: 0, bloqueadaHasta: 0 });
+  const distancia = (touches) =>
+    Math.hypot(touches[0].clientX - touches[1].clientX, touches[0].clientY - touches[1].clientY);
+  const onTouchStart = (e) => {
+    if (e.touches.length === 2) {
+      pinchRef.current = distancia(e.touches);
+      swipeRef.current = null;
+    } else if (e.touches.length === 1) {
+      swipeRef.current = e.touches[0].clientY;
+    }
+  };
+  const onTouchMove = (e) => {
+    if (e.touches.length === 2 && pinchRef.current != null) {
+      const razon = distancia(e.touches) / pinchRef.current;
+      if (razon < 0.78) { setModo('montana'); pinchRef.current = null; }
+      if (razon > 1.28) { setModo('finca'); pinchRef.current = null; }
+    }
+  };
+  const onTouchEnd = (e) => {
+    if (pinchRef.current == null && swipeRef.current != null && modo === 'finca' && e.changedTouches.length === 1) {
+      const delta = e.changedTouches[0].clientY - swipeRef.current;
+      if (delta < -72 && piso < PISOS.length - 1) setPiso(piso + 1); // desliza arriba → baja la montaña
+      if (delta > 72 && piso > 0) setPiso(piso - 1); // desliza abajo → sube la montaña
+    }
+    if (e.touches.length < 2) pinchRef.current = null;
+    if (e.touches.length === 0) swipeRef.current = null;
+  };
+  const onWheel = (e) => {
+    if (modo !== 'finca') return;
+    const ahora = Date.now();
+    const rueda = ruedaRef.current;
+    if (ahora < rueda.bloqueadaHasta) return;
+    rueda.acumulado += e.deltaY;
+    if (rueda.acumulado > 140 && piso < PISOS.length - 1) {
+      setPiso(piso + 1); // rueda abajo → baja la montaña
+      rueda.acumulado = 0;
+      rueda.bloqueadaHasta = ahora + 700;
+    } else if (rueda.acumulado < -140 && piso > 0) {
+      setPiso(piso - 1); // rueda arriba → sube la montaña
+      rueda.acumulado = 0;
+      rueda.bloqueadaHasta = ahora + 700;
+    }
+  };
+
+  const alternarZoom = () => setModo(modo === 'finca' ? 'montana' : 'finca');
+  const irAPiso = (i) => { setPiso(i); setModo('finca'); };
+  const pisoActual = PISOS[piso];
+  const direccion = DIRECCIONES.find((d) => d.id === dir) || DIRECCIONES[0];
+
+  const pct = (v, total) => `${(v / total) * 100}%`;
+
+  return (
+    <div className="mm2" data-dir={dir} data-modo={modo} data-piso={pisoActual.id}>
+      <div
+        className="mm2-viewport"
+        ref={viewportRef}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        onWheel={onWheel}
+        data-testid="mm2-viewport"
+      >
+        {/* ── Las 6 capas de la cámara (lejos → cerca) ── */}
+        <div className="mm2-capa mm2-capa-cielo" style={{ height: `${escenaH}px`, transform: transformCapa(CAPAS_F.cielo) }}>
+          <CieloSvg />
+        </div>
+        <div className="mm2-capa mm2-capa-lejos" style={{ height: `${escenaH}px`, transform: transformCapa(CAPAS_F.lejos) }}>
+          <CordilleraLejosSvg />
+        </div>
+        <div className="mm2-capa mm2-capa-medio" style={{ height: `${escenaH}px`, transform: transformCapa(CAPAS_F.medio) }}>
+          <CordilleraMediaSvg />
+        </div>
+
+        {/* Capa principal: la montaña con sus pisos y mundos tocables */}
+        <div
+          className="mm2-capa mm2-capa-principal"
+          style={{ height: `${escenaH}px`, transform: transformCapa(CAPAS_F.principal) }}
+        >
+          <MontanaPrincipalSvg />
+
+          {/* Velos: en modo finca, los pisos no activos quedan tenues */}
+          <div className="mm2-velo mm2-velo-arriba" style={{ height: pct(pisoActual.y0, VB_H) }} aria-hidden="true" />
+          <div className="mm2-velo mm2-velo-abajo" style={{ top: pct(pisoActual.y1, VB_H) }} aria-hidden="true" />
+
+          {/* Marcador de la finca del usuario */}
+          <div className="mm2-finca-pin" style={{ left: pct(195, VB_W), top: pct(838, VB_H) }} aria-hidden="true">
+            ⭐ Su finca
+          </div>
+
+          {/* Mundos tocables: halo que pulsa + etiqueta */}
+          {MUNDOS.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              className={`mm2-mundo${modo === 'finca' && m.piso !== piso ? ' es-tenue' : ''}`}
+              style={{ left: pct(m.x, VB_W), top: pct(m.y, VB_H) }}
+              data-testid={`mm2-mundo-${m.id}`}
+              aria-label={`${m.etiqueta}: abre ${m.abre}`}
+              onClick={() => avisar(`Aquí se abre ${m.abre}.`)}
+            >
+              <span className="mm2-mundo-halo" aria-hidden="true" />
+              <span className="mm2-mundo-etiqueta">{m.etiqueta}</span>
+            </button>
+          ))}
+
+          {/* Franjas de piso: en la montaña completa, tocar un piso lo acerca */}
+          {PISOS.map((p, i) => (
+            <button
+              key={p.id}
+              type="button"
+              className="mm2-franja"
+              style={{ top: pct(p.y0, VB_H), height: pct(p.y1 - p.y0, VB_H) }}
+              data-testid={`mm2-franja-${p.id}`}
+              tabIndex={modo === 'montana' ? 0 : -1}
+              aria-label={`Acercarse a ${p.nombre}, ${p.msnm}`}
+              onClick={() => irAPiso(i)}
+            >
+              <span className="mm2-franja-rotulo">
+                {p.nombre} · {p.msnm}{p.finca ? ' ⭐' : ''}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div className="mm2-capa mm2-capa-niebla" style={{ height: `${escenaH}px`, transform: transformCapa(CAPAS_F.niebla) }}>
+          <NieblaSvg />
+        </div>
+        <div className="mm2-capa mm2-capa-cerca" style={{ height: `${escenaH}px`, transform: transformCapa(CAPAS_F.cerca) }}>
+          <PrimerPlanoSvg />
+        </div>
+
+        {/* ── Luz de cine fija al encuadre ── */}
+        <div className="mm2-grades" aria-hidden="true">
+          {PISOS.map((p) => (
+            <div key={p.id} className={`mm2-grade mm2-grade-${p.id}${p.id === pisoActual.id ? ' es-activo' : ''}`} />
+          ))}
+        </div>
+        <div className="mm2-vineta" aria-hidden="true" />
+        <div className="mm2-scrim-arriba" aria-hidden="true" />
+        <div className="mm2-scrim-abajo" aria-hidden="true" />
+
+        {/* Indicador del piso + pasos para caminar la montaña */}
+        <div className="mm2-brujula" data-testid="mm2-brujula">
+          <span className="mm2-brujula-piso">
+            {pisoActual.nombre} · {pisoActual.msnm}{pisoActual.finca ? ' — aquí está su finca ⭐' : ''}
+          </span>
+        </div>
+        {modo === 'finca' && piso > 0 && (
+          <button type="button" className="mm2-paso mm2-paso-arriba" data-testid="mm2-paso-arriba" onClick={() => setPiso(piso - 1)}>
+            ▲ Subir a {PISOS[piso - 1].nombre}
+          </button>
+        )}
+        {modo === 'finca' && piso < PISOS.length - 1 && (
+          <button type="button" className="mm2-paso mm2-paso-abajo" data-testid="mm2-paso-abajo" onClick={() => setPiso(piso + 1)}>
+            ▼ Bajar a {PISOS[piso + 1].nombre}
+          </button>
+        )}
+
+        {/* Alternador de zoom: el gesto del pellizco hecho botón visible */}
+        <button type="button" className="mm2-zoom" data-testid="mm2-zoom-toggle" onClick={alternarZoom}>
+          {modo === 'finca' ? '🏔 Ver toda la montaña' : '🏡 Volver a mi finca'}
+        </button>
+
+        {/* ── Cabecera del mockup (flota sobre el paisaje) ── */}
+        <header className="mm2-cabecera">
+          <div className="mm2-mockbar">
+            <button type="button" className="mm2-volver" onClick={() => onBack && onBack()}>← Volver</button>
+            <span className="mm2-mockbar-titulo">Mockup · pasada 2 · cine</span>
+          </div>
+          <h1 className="mm2-titulo">La Montaña de los Mundos</h1>
+          <div className="mm2-direcciones" role="tablist" aria-label="Dirección artística">
+            {DIRECCIONES.map((d) => (
+              <button
+                key={d.id}
+                type="button"
+                role="tab"
+                aria-selected={dir === d.id}
+                data-testid={`mm2-dir-${d.id}`}
+                className={`mm2-dir-btn${dir === d.id ? ' es-activa' : ''}`}
+                onClick={() => setDir(d.id)}
+              >
+                <span className="mm2-dir-num">{d.num}</span> {d.corto}
+              </button>
+            ))}
+          </div>
+          <p className="mm2-dir-lema" data-testid="mm2-dir-lema">
+            Dirección {direccion.num} · <strong>{direccion.nombre}</strong> — {direccion.lema}
+          </p>
+        </header>
+
+        {/* ── Atajos permanentes: nada queda detrás de escalar la montaña ── */}
+        <nav className="mm2-atajos" aria-label="Atajos permanentes">
+          <button
+            type="button"
+            className="mm2-atajo-anotar"
+            data-testid="mm2-atajo-anotar"
+            onClick={() => avisar('Aquí se anota lo que hizo hoy en su finca.')}
+          >
+            📝 Anotar mi día
+          </button>
+          <button
+            type="button"
+            className="mm2-atajo-agente"
+            data-testid="mm2-atajo-agente"
+            aria-label="Hablar con Chagra, el agente"
+            onClick={() => avisar('Aquí se abre el agente: pregunte con su voz.')}
+          >
+            Ⓐ
+          </button>
+        </nav>
+      </div>
+
+      {aviso && (
+        <output className="mm2-aviso" data-testid="mm2-aviso">{aviso}</output>
+      )}
+    </div>
+  );
+}

--- a/src/mockups/__tests__/MontanaMundos.smoke.test.jsx
+++ b/src/mockups/__tests__/MontanaMundos.smoke.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MontanaMundos from '../MontanaMundos';
+
+// Smoke del mockup "La Montaña de los Mundos" (#/mockups/montana-mundos).
+// Cubre lo que el operador va a revisar en vivo: (1) las 3 direcciones
+// artísticas conmutan, (2) el zoom finca ↔ montaña completa funciona,
+// (3) los mundos tocables existen con su etiqueta, (4) los atajos
+// permanentes (Ⓐ + anotar) siempre están, (5) el aviso honesto aparece.
+
+describe('MontanaMundos (mockup)', () => {
+  it('abre centrado en la finca (piso templado) con los atajos permanentes visibles', () => {
+    render(<MontanaMundos />);
+    expect(screen.getByText('La Montaña de los Mundos')).toBeTruthy();
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('templado');
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('su finca');
+    expect(screen.getByTestId('mm-atajo-agente')).toBeTruthy();
+    expect(screen.getByTestId('mm-atajo-anotar')).toBeTruthy();
+  });
+
+  it('conmuta las 3 direcciones artísticas (data-dir en la raíz)', () => {
+    const { container } = render(<MontanaMundos />);
+    const raiz = container.querySelector('.mm');
+    expect(raiz.getAttribute('data-dir')).toBe('naturalista');
+    fireEvent.click(screen.getByTestId('mm-dir-biopunk'));
+    expect(raiz.getAttribute('data-dir')).toBe('biopunk');
+    expect(screen.getByTestId('mm-dir-lema').textContent).toContain('Biopunk');
+    fireEvent.click(screen.getByTestId('mm-dir-verde'));
+    expect(raiz.getAttribute('data-dir')).toBe('verde');
+    fireEvent.click(screen.getByTestId('mm-dir-naturalista'));
+    expect(raiz.getAttribute('data-dir')).toBe('naturalista');
+  });
+
+  it('hace zoom-out a la montaña completa y vuelve a la finca', () => {
+    const { container } = render(<MontanaMundos />);
+    const raiz = container.querySelector('.mm');
+    expect(raiz.getAttribute('data-modo')).toBe('finca');
+    const toggle = screen.getByTestId('mm-zoom-toggle');
+    expect(toggle.textContent).toContain('Ver toda la montaña');
+    fireEvent.click(toggle);
+    expect(raiz.getAttribute('data-modo')).toBe('montana');
+    expect(toggle.textContent).toContain('Volver a mi finca');
+    // En la montaña completa, tocar un piso acerca a ese piso.
+    fireEvent.click(screen.getByTestId('mm-franja-paramo'));
+    expect(raiz.getAttribute('data-modo')).toBe('finca');
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('Páramo');
+  });
+
+  it('sube y baja de piso con los pasos', () => {
+    render(<MontanaMundos />);
+    fireEvent.click(screen.getByTestId('mm-paso-arriba'));
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('frío');
+    fireEvent.click(screen.getByTestId('mm-paso-abajo'));
+    expect(screen.getByTestId('mm-brujula').textContent).toContain('templado');
+  });
+
+  it('cada mundo tocable muestra el aviso honesto de qué abriría', () => {
+    render(<MontanaMundos />);
+    // Los 12 mundos están en la escena.
+    ['calendario', 'glaciar', 'restauracion', 'papa', 'animales', 'agente',
+      'cosecha', 'cafe', 'vender', 'mango', 'platano', 'rio'].forEach((id) => {
+      expect(screen.getByTestId(`mm-mundo-${id}`)).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('mm-mundo-mango'));
+    // El mango está en el piso cálido (tenue desde templado) — el mockup
+    // exige moverse de piso; el tocable activo sí avisa:
+    fireEvent.click(screen.getByTestId('mm-mundo-agente'));
+    expect(screen.getByTestId('mm-aviso').textContent).toContain('agente');
+  });
+
+  it('el botón volver llama onBack', () => {
+    const onBack = vi.fn();
+    render(<MontanaMundos onBack={onBack} />);
+    fireEvent.click(screen.getByText('← Volver'));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/src/mockups/__tests__/MontanaMundosCine.smoke.test.jsx
+++ b/src/mockups/__tests__/MontanaMundosCine.smoke.test.jsx
@@ -3,13 +3,15 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import MontanaMundosCine from '../MontanaMundosCine';
 
-// Smoke de la PASADA 2 CINEMATOGRÁFICA (#/mockups/montana-mundos-cine).
+// Smoke de la PASADA 3 CINEMATOGRÁFICA (#/mockups/montana-mundos-cine).
 // Cubre lo que el operador va a revisar en vivo: (1) las 3 direcciones
 // conmutan, (2) el zoom finca ↔ montaña funciona, (3) los mundos tocables
 // existen, (4) los atajos permanentes están, (5) el grade de luz sigue al
-// piso activo, (6) las 6 capas parallax montan, (7) la rueda camina pisos.
+// piso activo, (6) las 6 capas parallax montan, (7) la rueda camina pisos,
+// (8) el momento de llegada a la finca dispara, (9) el estado de viaje se
+// marca al mover la cámara, (10) la vida ambiental de la pasada 3 monta.
 
-describe('MontanaMundosCine (mockup pasada 2)', () => {
+describe('MontanaMundosCine (mockup pasada 3)', () => {
   it('abre centrado en la finca (piso templado) con los atajos permanentes visibles', () => {
     render(<MontanaMundosCine />);
     expect(screen.getByText('La Montaña de los Mundos')).toBeTruthy();
@@ -93,5 +95,42 @@ describe('MontanaMundosCine (mockup pasada 2)', () => {
     render(<MontanaMundosCine onBack={onBack} />);
     fireEvent.click(screen.getByText('← Volver'));
     expect(onBack).toHaveBeenCalled();
+  });
+
+  // ── Pasada 3 ──
+
+  it('dispara el momento de llegada a la finca al abrir (bloom + anillos + chispas)', () => {
+    const { container } = render(<MontanaMundosCine />);
+    // Abre en la finca: la app lo recibe en casa con el momento "wow".
+    expect(container.querySelector('.mm2').getAttribute('data-llegada')).toBe('true');
+    const llegada = screen.getByTestId('mm2-llegada');
+    expect(llegada.querySelector('.mm2-llegada-bloom')).toBeTruthy();
+    expect(llegada.querySelectorAll('.mm2-llegada-anillo').length).toBe(2);
+    expect(llegada.querySelectorAll('.mm2-chispa').length).toBe(6);
+  });
+
+  it('marca el estado de viaje cuando la cámara se mueve de piso', () => {
+    const { container } = render(<MontanaMundosCine />);
+    const raiz = container.querySelector('.mm2');
+    expect(raiz.getAttribute('data-viaje')).toBeNull();
+    fireEvent.click(screen.getByTestId('mm2-paso-arriba'));
+    expect(raiz.getAttribute('data-viaje')).toBe('true');
+  });
+
+  it('vuelve a disparar la llegada al regresar a la finca desde otro piso', () => {
+    const { container } = render(<MontanaMundosCine />);
+    const raiz = container.querySelector('.mm2');
+    fireEvent.click(screen.getByTestId('mm2-paso-arriba')); // sale de la finca
+    fireEvent.click(screen.getByTestId('mm2-paso-abajo')); // regresa
+    expect(raiz.getAttribute('data-llegada')).toBe('true');
+    expect(screen.getByTestId('mm2-llegada')).toBeTruthy();
+  });
+
+  it('monta la vida ambiental y la textura de la pasada 3', () => {
+    const { container } = render(<MontanaMundosCine />);
+    ['mm2-bandada', 'mm2-colibri', 'mm2-luciernagas', 'mm2-hojas-caen',
+      'mm2-rocas', 'mm2-pedrisco', 'mm2-destellos', 'mm2-jirones', 'mm2-pasta'].forEach((clase) => {
+      expect(container.querySelector(`.${clase}`), clase).toBeTruthy();
+    });
   });
 });

--- a/src/mockups/__tests__/MontanaMundosCine.smoke.test.jsx
+++ b/src/mockups/__tests__/MontanaMundosCine.smoke.test.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MontanaMundosCine from '../MontanaMundosCine';
+
+// Smoke de la PASADA 2 CINEMATOGRÁFICA (#/mockups/montana-mundos-cine).
+// Cubre lo que el operador va a revisar en vivo: (1) las 3 direcciones
+// conmutan, (2) el zoom finca ↔ montaña funciona, (3) los mundos tocables
+// existen, (4) los atajos permanentes están, (5) el grade de luz sigue al
+// piso activo, (6) las 6 capas parallax montan, (7) la rueda camina pisos.
+
+describe('MontanaMundosCine (mockup pasada 2)', () => {
+  it('abre centrado en la finca (piso templado) con los atajos permanentes visibles', () => {
+    render(<MontanaMundosCine />);
+    expect(screen.getByText('La Montaña de los Mundos')).toBeTruthy();
+    expect(screen.getByTestId('mm2-brujula').textContent).toContain('templado');
+    expect(screen.getByTestId('mm2-brujula').textContent).toContain('su finca');
+    expect(screen.getByTestId('mm2-atajo-agente')).toBeTruthy();
+    expect(screen.getByTestId('mm2-atajo-anotar')).toBeTruthy();
+  });
+
+  it('monta las 6 capas de cámara del parallax', () => {
+    const { container } = render(<MontanaMundosCine />);
+    ['cielo', 'lejos', 'medio', 'principal', 'niebla', 'cerca'].forEach((capa) => {
+      expect(container.querySelector(`.mm2-capa-${capa}`)).toBeTruthy();
+    });
+    // Cada capa lleva su propio transform (velocidades distintas de cámara).
+    const cielo = container.querySelector('.mm2-capa-cielo');
+    const principal = container.querySelector('.mm2-capa-principal');
+    expect(cielo.style.transform).not.toBe(principal.style.transform);
+  });
+
+  it('conmuta las 3 direcciones artísticas (data-dir en la raíz)', () => {
+    const { container } = render(<MontanaMundosCine />);
+    const raiz = container.querySelector('.mm2');
+    expect(raiz.getAttribute('data-dir')).toBe('naturalista');
+    fireEvent.click(screen.getByTestId('mm2-dir-biopunk'));
+    expect(raiz.getAttribute('data-dir')).toBe('biopunk');
+    expect(screen.getByTestId('mm2-dir-lema').textContent).toContain('Biopunk');
+    fireEvent.click(screen.getByTestId('mm2-dir-verde'));
+    expect(raiz.getAttribute('data-dir')).toBe('verde');
+    fireEvent.click(screen.getByTestId('mm2-dir-naturalista'));
+    expect(raiz.getAttribute('data-dir')).toBe('naturalista');
+  });
+
+  it('hace zoom-out a la montaña completa y vuelve a la finca', () => {
+    const { container } = render(<MontanaMundosCine />);
+    const raiz = container.querySelector('.mm2');
+    expect(raiz.getAttribute('data-modo')).toBe('finca');
+    const toggle = screen.getByTestId('mm2-zoom-toggle');
+    expect(toggle.textContent).toContain('Ver toda la montaña');
+    fireEvent.click(toggle);
+    expect(raiz.getAttribute('data-modo')).toBe('montana');
+    expect(toggle.textContent).toContain('Volver a mi finca');
+    fireEvent.click(screen.getByTestId('mm2-franja-paramo'));
+    expect(raiz.getAttribute('data-modo')).toBe('finca');
+    expect(screen.getByTestId('mm2-brujula').textContent).toContain('Páramo');
+  });
+
+  it('el grade de luz atmosférica sigue al piso activo', () => {
+    const { container } = render(<MontanaMundosCine />);
+    // Abre en la finca: hora dorada del templado encendida.
+    expect(container.querySelector('.mm2-grade-templado.es-activo')).toBeTruthy();
+    expect(container.querySelector('.mm2-grade-nevado.es-activo')).toBeFalsy();
+    fireEvent.click(screen.getByTestId('mm2-paso-arriba'));
+    expect(container.querySelector('.mm2-grade-frio.es-activo')).toBeTruthy();
+    expect(container.querySelector('.mm2-grade-templado.es-activo')).toBeFalsy();
+  });
+
+  it('sube y baja de piso con los pasos y con la rueda', () => {
+    render(<MontanaMundosCine />);
+    fireEvent.click(screen.getByTestId('mm2-paso-arriba'));
+    expect(screen.getByTestId('mm2-brujula').textContent).toContain('frío');
+    fireEvent.click(screen.getByTestId('mm2-paso-abajo'));
+    expect(screen.getByTestId('mm2-brujula').textContent).toContain('templado');
+    // La rueda del mouse también camina la montaña (scroll suave por pisos).
+    fireEvent.wheel(screen.getByTestId('mm2-viewport'), { deltaY: 200 });
+    expect(screen.getByTestId('mm2-brujula').textContent).toContain('cálido');
+  });
+
+  it('cada mundo tocable muestra el aviso honesto de qué abriría', () => {
+    render(<MontanaMundosCine />);
+    ['calendario', 'glaciar', 'restauracion', 'papa', 'animales', 'agente',
+      'cosecha', 'cafe', 'vender', 'mango', 'platano', 'rio'].forEach((id) => {
+      expect(screen.getByTestId(`mm2-mundo-${id}`)).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('mm2-mundo-agente'));
+    expect(screen.getByTestId('mm2-aviso').textContent).toContain('agente');
+  });
+
+  it('el botón volver llama onBack', () => {
+    const onBack = vi.fn();
+    render(<MontanaMundosCine onBack={onBack} />);
+    fireEvent.click(screen.getByText('← Volver'));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/src/mockups/montana-mundos-cine.css
+++ b/src/mockups/montana-mundos-cine.css
@@ -1,17 +1,27 @@
 /* montana-mundos-cine.css — MOCKUP DEV #/mockups/montana-mundos-cine
- * (prefijo mm2-). PASADA 2 CINEMATOGRÁFICA de "La Montaña de los Mundos".
+ * (prefijo mm2-). PASADA 3 CINEMATOGRÁFICA de "La Montaña de los Mundos".
  *
- * Qué cambia frente a la pasada 1 (montana-mundos.css):
- *   - La escena se parte en 6 CAPAS DE CÁMARA (cielo → cordillera lejana →
- *     cordillera media → montaña principal → niebla volumétrica → primer
- *     plano). Cada capa viaja a su propia velocidad y con su propia inercia
- *     (duración de transición distinta) — parallax de cine, no un scroll.
- *   - LUZ ATMOSFÉRICA POR PISO: al subir o bajar la montaña, un "grade"
- *     cinematográfico cambia la temperatura de la luz (azul frío del nevado,
- *     hora dorada del templado, ámbar del cálido, turquesa del río).
- *   - God-rays desde el astro + bancos de niebla de valle que suben.
- *   - FULL-BLEED: la montaña ocupa el 100% del viewport; la UI flota sobre
- *     el paisaje (scrims degradados), no hay cajas ni márgenes muertos.
+ * Hereda de la pasada 2: 6 capas de cámara con parallax e inercia propia,
+ * luz atmosférica por piso (grades), god-rays, niebla volumétrica de valle
+ * y full-bleed con la UI flotando sobre scrims.
+ *
+ * Qué SUMA la pasada 3:
+ *   - PROFUNDIDAD DE CAMPO: en modo finca el cielo, las cordilleras y el
+ *     primer plano quedan fuera de foco (blur ESTÁTICO por modo — jamás se
+ *     interpola; el cambio ocurre escondido bajo el viaje de cámara). En la
+ *     montaña completa, foco profundo.
+ *   - TRANSICIÓN PULIDA: easing con leve asentamiento en las capas cercanas
+ *     (inercia física), zoom-out majestuoso con duraciones escalonadas, y
+ *     el estado data-viaje — la niebla se ABRE mientras la cámara viaja y
+ *     las etiquetas se retiran hasta que el plano asienta.
+ *   - MOMENTO DE LLEGADA (data-llegada): bloom de hora dorada sobre la
+ *     casa, anillos expansivos, chispas que suben, el pin ⭐ aterriza con
+ *     rebote y la ventana late — one-shot en cada arribo a la finca.
+ *   - TEXTURA: rocas con vetas y pedrisco, cicatrices en el frailejón,
+ *     jirones de niebla a contracorriente, destellos sobre la nieve.
+ *   - VIDA AMBIENTAL por dirección: bandada que cruza (naturalista/verde),
+ *     colibrí (naturalista), luciérnagas (biopunk), hojas cayendo (verde),
+ *     animales que pastan.
  *
  * Todo GPU-friendly: SOLO transform y opacity se animan; los degradados
  * "volumétricos" son fills estáticos (radialGradient pre-suavizado, sin
@@ -281,7 +291,9 @@
 
 /* Cada capa viaja a su velocidad (transform inline desde React) y con su
  * propia INERCIA: las lejanas se asientan más lento — la cámara se siente
- * física, no un scroll. Solo transform: composición GPU pura. */
+ * física, no un scroll. Solo transform: composición GPU pura.
+ * Pasada 3: las capas CERCANAS asientan con un leve sobrepaso (la inercia
+ * de una cámara con peso); las lejanas llegan suaves, sin rebote. */
 .mm2-capa {
   position: absolute;
   top: 0;
@@ -289,19 +301,48 @@
   width: 100%;
   transform-origin: 0 0;
   will-change: transform;
-  transition: transform 0.9s cubic-bezier(0.22, 0.9, 0.3, 1), opacity 0.7s ease;
+  transition: transform 0.95s cubic-bezier(0.3, 0.86, 0.24, 1.02), opacity 0.7s ease;
   pointer-events: none;
 }
 
-.mm2-capa-cielo { transition-duration: 1.2s, 0.7s; }
-.mm2-capa-lejos { transition-duration: 1.08s, 0.7s; }
-.mm2-capa-medio { transition-duration: 0.99s, 0.7s; }
+.mm2-capa-cielo { transition-duration: 1.24s, 0.7s; transition-timing-function: cubic-bezier(0.26, 0.7, 0.32, 1), ease; }
+.mm2-capa-lejos { transition-duration: 1.12s, 0.7s; transition-timing-function: cubic-bezier(0.26, 0.72, 0.3, 1), ease; }
+.mm2-capa-medio { transition-duration: 1.02s, 0.7s; }
 .mm2-capa-principal { pointer-events: auto; }
-.mm2-capa-niebla { transition-duration: 0.84s, 0.7s; }
-.mm2-capa-cerca { transition-duration: 0.78s, 0.7s; }
+.mm2-capa-niebla { transition-duration: 0.88s, 0.7s; transition-timing-function: cubic-bezier(0.32, 1.08, 0.3, 1), ease; }
+.mm2-capa-cerca { transition-duration: 0.8s, 0.7s; transition-timing-function: cubic-bezier(0.34, 1.14, 0.3, 1), ease; }
+
+/* Zoom-out a la montaña completa: gran plano general MAJESTUOSO — todas
+ * las capas viajan más lento y escalonadas (el cielo tarda casi 2s en
+ * asentar), sin sobrepaso: la cámara se aleja con solemnidad. */
+.mm2[data-modo='montana'] .mm2-capa { transition-duration: 1.5s, 0.9s; transition-timing-function: cubic-bezier(0.3, 0.6, 0.22, 1), ease; }
+.mm2[data-modo='montana'] .mm2-capa-cielo { transition-duration: 1.9s, 0.9s; }
+.mm2[data-modo='montana'] .mm2-capa-lejos { transition-duration: 1.76s, 0.9s; }
+.mm2[data-modo='montana'] .mm2-capa-medio { transition-duration: 1.62s, 0.9s; }
+.mm2[data-modo='montana'] .mm2-capa-niebla { transition-duration: 1.4s, 0.9s; }
+.mm2[data-modo='montana'] .mm2-capa-cerca { transition-duration: 1.3s, 0.9s; }
 
 /* Al alejar la cámara (montaña completa) el primer plano sale de cuadro. */
 .mm2[data-modo='montana'] .mm2-capa-cerca { opacity: 0; }
+
+/* ── PROFUNDIDAD DE CAMPO (pasada 3) ──
+ * En el plano cercano la cámara enfoca la montaña principal: el cielo y
+ * las cordilleras quedan atrás del foco y el primer plano botánico delante
+ * (bokeh de lente). El blur es ESTÁTICO por modo — nunca se anima: el
+ * cambio se esconde bajo el movimiento del viaje de cámara, así no cuesta
+ * ni un frame en un Android de gama baja. En la montaña completa (gran
+ * plano general) el filtro desaparece: foco profundo de paisaje. */
+.mm2[data-modo='finca'] .mm2-capa-cielo { filter: blur(1.4px); }
+.mm2[data-modo='finca'] .mm2-capa-lejos { filter: blur(2.6px) saturate(0.93); }
+.mm2[data-modo='finca'] .mm2-capa-medio { filter: blur(1.3px); }
+.mm2[data-modo='finca'] .mm2-capa-cerca { filter: blur(2px); }
+
+/* ── LA CÁMARA VIAJA (data-viaje): la niebla se ABRE para dejar pasar el
+ * plano y las etiquetas se retiran — vuelven cuando el encuadre asienta.
+ * Solo opacity: el crossfade corre en el compositor. */
+.mm2[data-viaje] .mm2-capa-niebla { opacity: 0.3; }
+.mm2[data-viaje] .mm2-mundo-etiqueta,
+.mm2[data-viaje] .mm2-finca-pin { opacity: 0; }
 
 .mm2-svg {
   position: absolute;
@@ -618,7 +659,71 @@
   padding: 3px 7px;
   white-space: nowrap;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  transition: opacity 0.45s ease;
 }
+
+/* En la llegada el pin ATERRIZA: cae con rebote corto después de que la
+ * cámara asienta (la animación manda sobre la transición de data-viaje). */
+.mm2[data-llegada] .mm2-finca-pin {
+  animation: mm2-pin-llega 1.1s cubic-bezier(0.32, 1.4, 0.36, 1) 0.7s both;
+}
+
+/* ── MOMENTO DE LLEGADA A LA FINCA (el "wow" de la pasada 3) ──
+ * Anclado a la casa dentro de la capa principal (viaja y escala con la
+ * montaña). Todo one-shot con forwards: bloom de hora dorada que florece
+ * y se apaga, dos anillos que se expanden, chispas que suben como pavesas
+ * del fogón. Base opacity 0: con reduced-motion (animation: none) nada de
+ * esto aparece — el plano queda digno y quieto. */
+.mm2-llegada {
+  position: absolute;
+  width: 0;
+  height: 0;
+  z-index: 4;
+  pointer-events: none;
+}
+
+.mm2-llegada-bloom {
+  position: absolute;
+  left: -92px;
+  top: -92px;
+  width: 184px;
+  height: 184px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--mm2-halo-a), var(--mm2-halo-b) 70%);
+  mix-blend-mode: screen;
+  opacity: 0;
+  animation: mm2-bloom 3s ease-in-out 0.45s forwards;
+}
+
+.mm2-llegada-anillo {
+  position: absolute;
+  left: -30px;
+  top: -30px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 2px solid var(--mm2-halo-mundo);
+  opacity: 0;
+  animation: mm2-anillo 1.7s cubic-bezier(0.2, 0.7, 0.3, 1) 0.55s forwards;
+}
+
+.mm2-anillo-2 { animation-delay: 0.95s; }
+
+.mm2-chispa {
+  position: absolute;
+  left: -2px;
+  top: -2px;
+  width: 4.5px;
+  height: 4.5px;
+  border-radius: 50%;
+  background: var(--mm2-halo-mundo);
+  box-shadow: 0 0 6px var(--mm2-halo-mundo);
+  opacity: 0;
+  animation: mm2-chispa 2.1s ease-out var(--mm2-cd, 0.6s) forwards;
+}
+
+/* La ventana de la casa late dos veces al llegar: hay alguien esperando. */
+.mm2[data-llegada] .mm2-casa-ventana { animation: mm2-ventana-late 1.3s ease-in-out 0.75s 2; }
 
 .mm2-mundo {
   position: absolute;
@@ -657,6 +762,7 @@
   border-radius: 999px;
   padding: 2.5px 6px;
   white-space: nowrap;
+  transition: opacity 0.45s ease;
 }
 
 .mm2-mundo.es-tenue { opacity: 0.24; pointer-events: none; }
@@ -756,6 +862,20 @@
 }
 .mm2-ave-1 { animation: mm2-deriva 30s ease-in-out infinite alternate; }
 
+/* Bandada en V (pasada 3): cruza el cielo de lado a lado, desaparece por
+ * el borde y descansa fuera de cuadro antes de volver a pasar. */
+.mm2-bandada { display: none; }
+.mm2[data-dir='naturalista'] .mm2-bandada,
+.mm2[data-dir='verde'] .mm2-bandada {
+  display: block;
+  fill: none;
+  stroke: #5c4a30;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+}
+.mm2[data-dir='verde'] .mm2-bandada { stroke: #3f7a4a; }
+.mm2-bandada-vuelo { animation: mm2-cruza 46s linear infinite; }
+
 /* Capa principal: cuerpo de la montaña */
 .mm2-piso-paramo { fill: var(--mm2-paramo); }
 .mm2-piso-frio { fill: var(--mm2-frio); }
@@ -784,6 +904,16 @@
 
 .mm2-piedra { fill: var(--mm2-piedra); }
 
+/* Textura de roca (pasada 3): afloramientos con vetas y pedrisco */
+.mm2-roca { fill: var(--mm2-piedra); opacity: 0.85; }
+.mm2-roca-veta { fill: none; stroke: rgba(22, 22, 34, 0.24); stroke-width: 1.2; stroke-linecap: round; }
+.mm2-pedrisco circle { fill: var(--mm2-piedra); opacity: 0.7; }
+
+/* Destellos de hielo sobre la nieve: titilan desfasados */
+.mm2-destello { fill: #ffffff; opacity: 0.25; animation: mm2-titila 2.8s ease-in-out infinite alternate; }
+.mm2-destello:nth-of-type(2n) { animation-delay: 0.9s; }
+.mm2-destello:nth-of-type(3n) { animation-delay: 1.8s; }
+
 /* Páramo */
 .mm2-frailejon-tronco { fill: var(--mm2-tronco); }
 .mm2-frailejon-faldon { fill: none; stroke: var(--mm2-frailejon-seca); stroke-width: 2; stroke-linecap: round; }
@@ -791,6 +921,9 @@
 .mm2-hoja-int { fill: color-mix(in srgb, var(--mm2-frailejon-hoja) 80%, #ffffff); }
 .mm2-frailejon-tallo { fill: none; stroke: var(--mm2-frailejon-seca); stroke-width: 1.6; stroke-linecap: round; }
 .mm2-frailejon-flor { fill: var(--mm2-frailejon-flor); }
+/* Cicatrices foliares: los anillos de hojas viejas del tronco (textura) */
+.mm2-frailejon-cicatriz { fill: none; stroke: rgba(64, 48, 26, 0.35); stroke-width: 1; stroke-linecap: round; }
+.mm2[data-dir='biopunk'] .mm2-frailejon-cicatriz { stroke: rgba(103, 232, 249, 0.22); }
 .mm2-frailejon-roseta {
   transform-box: fill-box;
   transform-origin: 50% 92%;
@@ -818,6 +951,14 @@
 .mm2-cerca-poste, .mm2-cerca-riel { fill: var(--mm2-cerca-madera); }
 .mm2-oveja { fill: var(--mm2-oveja); }
 .mm2-vaca { fill: var(--mm2-vaca); }
+
+/* Los animales pastan: se inclinan apenas hacia el suelo y vuelven */
+.mm2-pasta {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: mm2-pasta 6.2s ease-in-out infinite;
+}
+.mm2-vaca .mm2-pasta { animation-duration: 7.6s; animation-delay: 1.8s; }
 
 /* Templado: la casa campesina */
 .mm2-casa-muro { fill: var(--mm2-casa-muro); }
@@ -921,6 +1062,34 @@
 .mm2-mariposa-1 { fill: #f2a541; animation: mm2-flota 3.6s ease-in-out infinite alternate; }
 .mm2-mariposa-2 { fill: #e05f8a; animation: mm2-flota 4.4s ease-in-out infinite alternate-reverse; }
 
+/* Colibrí (solo naturalista): aleteo rápido + ronda lenta por los geranios */
+.mm2-colibri { display: none; }
+.mm2[data-dir='naturalista'] .mm2-colibri { display: block; }
+.mm2-colibri-torso { fill: #2f8a72; }
+.mm2-colibri-cola { fill: #256b5a; }
+.mm2-colibri-pico { fill: none; stroke: #3c3020; stroke-width: 1.2; stroke-linecap: round; }
+.mm2-colibri-ala {
+  fill: #6cc9a4;
+  transform-box: fill-box;
+  transform-origin: 85% 92%;
+  animation: mm2-aleteo 0.24s ease-in-out infinite alternate;
+}
+.mm2-colibri-ronda { animation: mm2-ronda 5.4s ease-in-out infinite alternate; }
+
+/* Luciérnagas (solo biopunk): parpadean mientras derivan hacia arriba */
+.mm2-luciernagas { display: none; }
+.mm2[data-dir='biopunk'] .mm2-luciernagas { display: block; }
+.mm2-luciernaga { fill: #a3e635; opacity: 0; animation: mm2-luciernaga 6.6s ease-in-out infinite; }
+.mm2-luciernaga:nth-of-type(2n) { animation-delay: 2.2s; animation-duration: 7.8s; }
+.mm2-luciernaga:nth-of-type(3n) { animation-delay: 4.1s; animation-duration: 5.7s; }
+
+/* Hojas que caen (solo verde vivo): giran y planean hasta el suelo */
+.mm2-hojas-caen { display: none; }
+.mm2[data-dir='verde'] .mm2-hojas-caen { display: block; }
+.mm2-hoja-cae { fill: #7fae4f; opacity: 0; animation: mm2-hoja-cae 8.5s linear infinite; }
+.mm2-hoja-cae-2 { animation-delay: 3.1s; animation-duration: 9.6s; }
+.mm2-hoja-cae-3 { animation-delay: 5.7s; animation-duration: 7.4s; }
+
 /* Capa niebla volumétrica: bancos que derivan; el del valle SUBE y se
  * disipa en loop — la niebla de la Sierra Nevada de verdad. */
 .mm2-banco-1 { animation: mm2-niebla-deriva 26s ease-in-out infinite alternate; }
@@ -928,6 +1097,9 @@
 .mm2-banco-3 { animation: mm2-niebla-deriva 30s ease-in-out infinite alternate; }
 .mm2-banco-valle { animation: mm2-niebla-sube 22s ease-in-out infinite; }
 .mm2-banco-valle-2 { animation: mm2-niebla-sube 28s ease-in-out infinite 9s; }
+/* Jirones: hilachas finas que derivan A CONTRACORRIENTE de los bancos —
+ * dos velocidades de niebla = volumen (textura de la pasada 3). */
+.mm2-jirones { opacity: 0.7; animation: mm2-niebla-deriva 44s ease-in-out infinite alternate-reverse; }
 
 /* Capa primer plano: siluetas botánicas que enmarcan el plano */
 .mm2-cerca-forma { fill: var(--mm2-cerca); opacity: 0.88; }
@@ -996,11 +1168,86 @@
   100% { transform: translateY(-52px); opacity: 0; }
 }
 
+/* ── Pasada 3: vida ambiental ── */
+@keyframes mm2-cruza {
+  0% { transform: translate(-80px, 0); opacity: 0; }
+  4% { opacity: 1; }
+  40% { transform: translate(440px, -24px); opacity: 1; }
+  44% { transform: translate(468px, -26px); opacity: 0; }
+  100% { transform: translate(468px, -26px); opacity: 0; }
+}
+
+@keyframes mm2-aleteo {
+  from { transform: rotate(-22deg); }
+  to { transform: rotate(28deg); }
+}
+
+@keyframes mm2-ronda {
+  from { transform: translate(0, 0); }
+  to { transform: translate(-8px, -5px); }
+}
+
+@keyframes mm2-luciernaga {
+  0%, 100% { opacity: 0; transform: translate(0, 0); }
+  22% { opacity: 0.95; }
+  50% { opacity: 0.25; transform: translate(7px, -9px); }
+  74% { opacity: 0.8; transform: translate(-4px, -16px); }
+}
+
+@keyframes mm2-hoja-cae {
+  0% { opacity: 0; transform: translate(0, -10px) rotate(0deg); }
+  10% { opacity: 0.9; }
+  78% { opacity: 0.85; }
+  100% { opacity: 0; transform: translate(-16px, 46px) rotate(200deg); }
+}
+
+@keyframes mm2-pasta {
+  0%, 52%, 100% { transform: rotate(0deg); }
+  68% { transform: rotate(-4deg) translateY(0.6px); }
+  84% { transform: rotate(-3.4deg) translateY(0.5px); }
+}
+
+/* ── Pasada 3: momento de llegada a la finca ── */
+@keyframes mm2-bloom {
+  0% { opacity: 0; transform: scale(0.55); }
+  35% { opacity: 0.9; }
+  100% { opacity: 0; transform: scale(1.28); }
+}
+
+@keyframes mm2-anillo {
+  0% { opacity: 0.9; transform: scale(0.25); }
+  100% { opacity: 0; transform: scale(2.4); }
+}
+
+@keyframes mm2-chispa {
+  0% { opacity: 0; transform: translate(0, 0) scale(0.5); }
+  18% { opacity: 1; }
+  100% { opacity: 0; transform: translate(var(--mm2-cdx, 0px), var(--mm2-cdy, -60px)) scale(1); }
+}
+
+@keyframes mm2-pin-llega {
+  0% { transform: translate(-50%, -100%) translateY(-14px) scale(0.7); opacity: 0; }
+  60% { transform: translate(-50%, -100%) translateY(2px) scale(1.06); opacity: 1; }
+  100% { transform: translate(-50%, -100%) scale(1); opacity: 1; }
+}
+
+@keyframes mm2-ventana-late {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
 /* La montaña se queda quieta si la persona lo pide: plano final digno,
- * sin parallax animado ni vida — pero con toda la luz y la composición. */
+ * sin parallax animado, sin vida ni momento de llegada (los elementos del
+ * "wow" tienen base opacity 0 y sin animación jamás aparecen) — pero con
+ * toda la luz, la profundidad de campo y la composición. Sin transición
+ * de cámara el estado de viaje no dura nada: las etiquetas ni parpadean. */
 @media (prefers-reduced-motion: reduce) {
   .mm2 *, .mm2 *::before, .mm2 *::after {
     animation: none !important;
     transition: none !important;
   }
+
+  .mm2[data-viaje] .mm2-capa-niebla { opacity: 1; }
+  .mm2[data-viaje] .mm2-mundo-etiqueta,
+  .mm2[data-viaje] .mm2-finca-pin { opacity: 1; }
 }

--- a/src/mockups/montana-mundos-cine.css
+++ b/src/mockups/montana-mundos-cine.css
@@ -1,0 +1,1006 @@
+/* montana-mundos-cine.css — MOCKUP DEV #/mockups/montana-mundos-cine
+ * (prefijo mm2-). PASADA 2 CINEMATOGRÁFICA de "La Montaña de los Mundos".
+ *
+ * Qué cambia frente a la pasada 1 (montana-mundos.css):
+ *   - La escena se parte en 6 CAPAS DE CÁMARA (cielo → cordillera lejana →
+ *     cordillera media → montaña principal → niebla volumétrica → primer
+ *     plano). Cada capa viaja a su propia velocidad y con su propia inercia
+ *     (duración de transición distinta) — parallax de cine, no un scroll.
+ *   - LUZ ATMOSFÉRICA POR PISO: al subir o bajar la montaña, un "grade"
+ *     cinematográfico cambia la temperatura de la luz (azul frío del nevado,
+ *     hora dorada del templado, ámbar del cálido, turquesa del río).
+ *   - God-rays desde el astro + bancos de niebla de valle que suben.
+ *   - FULL-BLEED: la montaña ocupa el 100% del viewport; la UI flota sobre
+ *     el paisaje (scrims degradados), no hay cajas ni márgenes muertos.
+ *
+ * Todo GPU-friendly: SOLO transform y opacity se animan; los degradados
+ * "volumétricos" son fills estáticos (radialGradient pre-suavizado, sin
+ * filter animado). prefers-reduced-motion apaga la vida entera y deja un
+ * plano final digno. Tipografía Baloo 2 / Nunito (ya self-host). */
+
+.mm2 {
+  /* ── Dirección 1 (default): SIERRA NATURALISTA — hora dorada ── */
+  --mm2-cielo-a: #dfa96f;
+  --mm2-cielo-m: #f0cf9a;
+  --mm2-cielo-b: #ece2c4;
+  --mm2-astro: #ffdf8e;
+  --mm2-halo-a: rgba(255, 199, 112, 0.6);
+  --mm2-halo-b: rgba(255, 199, 112, 0);
+  --mm2-rayo: rgba(255, 214, 150, 0.42);
+  --mm2-lejos-a: #dcbb92;
+  --mm2-lejos-b: #d2b083;
+  --mm2-medio-a: #bf9c70;
+  --mm2-medio-b: #b18d63;
+  --mm2-bruma: rgba(255, 236, 200, 0.5);
+  --mm2-niebla-nucleo: rgba(255, 248, 235, 0.72);
+  --mm2-cerca: #4c3a22;
+  --mm2-vineta: rgba(43, 26, 8, 0.34);
+  --mm2-nieve: #fdf6ec;
+  --mm2-nieve-sombra: rgba(96, 116, 168, 0.3);
+  --mm2-paramo: #a8a469;
+  --mm2-frio: #7d9a58;
+  --mm2-templado: #55824a;
+  --mm2-calido: #94aa52;
+  --mm2-valle: #c0bf75;
+  --mm2-rio-a: #93c6be;
+  --mm2-rio-b: #6da9ae;
+  --mm2-rio-orilla: rgba(70, 96, 78, 0.55);
+  --mm2-flujo: rgba(255, 255, 255, 0.75);
+  --mm2-laguna: #9fd0c9;
+  --mm2-borde-piso: rgba(255, 244, 214, 0.42);
+  --mm2-contorno: rgba(40, 52, 26, 0.14);
+  --mm2-luz-ladera: rgba(255, 236, 180, 0.16);
+  --mm2-sombra-ladera: rgba(24, 22, 48, 0.18);
+  --mm2-frailejon-hoja: #b9c46b;
+  --mm2-frailejon-seca: #a08a52;
+  --mm2-frailejon-flor: #e8c95a;
+  --mm2-tronco: #8a6e4b;
+  --mm2-arbolito: #5d7a45;
+  --mm2-casa-muro: #f3e6cf;
+  --mm2-casa-techo: #b3563d;
+  --mm2-casa-teja: rgba(120, 50, 32, 0.55);
+  --mm2-ventana: #ffd166;
+  --mm2-ventana-glow: rgba(255, 209, 102, 0.75);
+  --mm2-puerta: #7a5236;
+  --mm2-camino: rgba(230, 205, 160, 0.8);
+  --mm2-geranio: #d64545;
+  --mm2-cafe-hoja: #3f6b3a;
+  --mm2-cafe-fruto: #d64545;
+  --mm2-cerca-madera: #8a6e4b;
+  --mm2-oveja: #f5efe2;
+  --mm2-vaca: #e3d3ba;
+  --mm2-surco: rgba(90, 116, 62, 0.55);
+  --mm2-mata-papa: #4d7a43;
+  --mm2-troje-cuerpo: #caa36a;
+  --mm2-troje-techo: #8a5c3c;
+  --mm2-grano: #e9c96a;
+  --mm2-toldo-a: #d9603b;
+  --mm2-toldo-b: #f4e9d2;
+  --mm2-fruta-a: #e5a33c;
+  --mm2-fruta-b: #c94f4f;
+  --mm2-mango-copa: #4c8043;
+  --mm2-mango-sombra: #3a6634;
+  --mm2-mango-fruto: #f2a541;
+  --mm2-platano-hoja: #5f9c4a;
+  --mm2-platano-nervio: rgba(36, 74, 30, 0.5);
+  --mm2-platano-tallo: #8aa14f;
+  --mm2-bellota: #8a4a6a;
+  --mm2-cana: #a9bd68;
+  --mm2-piedra: #b7ab8d;
+  --mm2-halo-mundo: rgba(255, 205, 110, 0.9);
+  --mm2-etiqueta-bg: rgba(255, 248, 232, 0.94);
+  --mm2-etiqueta-ink: #4a3a20;
+  --mm2-etiqueta-borde: rgba(122, 82, 54, 0.28);
+  --mm2-velo: rgba(59, 44, 22, 0.45);
+  --mm2-ui-tinta: #fff6e6;
+  --mm2-ui-acento: #b3563d;
+  --mm2-ui-acento-tinta: #fff6ea;
+  --mm2-scrim: rgba(30, 18, 6, 0.38);
+  --mm2-grades-fuerza: 1;
+
+  position: relative;
+  height: 100dvh;
+  overflow: hidden;
+  background: var(--mm2-cielo-m);
+  color: var(--mm2-ui-tinta);
+  font-family: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+/* ── Dirección 2: BIOPUNK — noche de neón orgánico (como el home en prod) ── */
+.mm2[data-dir='biopunk'] {
+  --mm2-cielo-a: #091226;
+  --mm2-cielo-m: #0e1c36;
+  --mm2-cielo-b: #16263f;
+  --mm2-astro: #dff6ff;
+  --mm2-halo-a: rgba(34, 211, 238, 0.42);
+  --mm2-halo-b: rgba(34, 211, 238, 0);
+  --mm2-rayo: rgba(125, 235, 255, 0.26);
+  --mm2-lejos-a: #17283f;
+  --mm2-lejos-b: #142338;
+  --mm2-medio-a: #101d33;
+  --mm2-medio-b: #0d192e;
+  --mm2-bruma: rgba(34, 211, 238, 0.1);
+  --mm2-niebla-nucleo: rgba(140, 220, 240, 0.18);
+  --mm2-cerca: #071120;
+  --mm2-vineta: rgba(0, 4, 12, 0.52);
+  --mm2-nieve: #cfe6f2;
+  --mm2-nieve-sombra: rgba(20, 50, 90, 0.45);
+  --mm2-paramo: #143349;
+  --mm2-frio: #123f3e;
+  --mm2-templado: #175035;
+  --mm2-calido: #1d5c33;
+  --mm2-valle: #24683a;
+  --mm2-rio-a: #1b4a66;
+  --mm2-rio-b: #0f2f4a;
+  --mm2-rio-orilla: rgba(34, 211, 238, 0.3);
+  --mm2-flujo: rgba(103, 232, 249, 0.85);
+  --mm2-laguna: #1d5a70;
+  --mm2-borde-piso: rgba(34, 211, 238, 0.5);
+  --mm2-contorno: rgba(103, 232, 249, 0.1);
+  --mm2-luz-ladera: rgba(103, 232, 249, 0.08);
+  --mm2-sombra-ladera: rgba(0, 4, 14, 0.35);
+  --mm2-frailejon-hoja: #3f7a63;
+  --mm2-frailejon-seca: #27503f;
+  --mm2-frailejon-flor: #a3e635;
+  --mm2-tronco: #2a4a44;
+  --mm2-arbolito: #1c4a3c;
+  --mm2-casa-muro: #1b2c44;
+  --mm2-casa-techo: #24405e;
+  --mm2-casa-teja: rgba(103, 232, 249, 0.22);
+  --mm2-ventana: #f0abfc;
+  --mm2-ventana-glow: rgba(240, 171, 252, 0.8);
+  --mm2-puerta: #101d31;
+  --mm2-camino: rgba(34, 211, 238, 0.35);
+  --mm2-geranio: #f0abfc;
+  --mm2-cafe-hoja: #1f5c40;
+  --mm2-cafe-fruto: #fb7185;
+  --mm2-cerca-madera: #2c4258;
+  --mm2-oveja: #b8c7d9;
+  --mm2-vaca: #9fb4c9;
+  --mm2-surco: rgba(47, 191, 143, 0.4);
+  --mm2-mata-papa: #2fbf8f;
+  --mm2-troje-cuerpo: #22354e;
+  --mm2-troje-techo: #2c4a66;
+  --mm2-grano: #fbbf24;
+  --mm2-toldo-a: #22d3ee;
+  --mm2-toldo-b: #16263f;
+  --mm2-fruta-a: #a3e635;
+  --mm2-fruta-b: #f0abfc;
+  --mm2-mango-copa: #1f6b45;
+  --mm2-mango-sombra: #144832;
+  --mm2-mango-fruto: #fbbf24;
+  --mm2-platano-hoja: #2f8a5a;
+  --mm2-platano-nervio: rgba(103, 232, 249, 0.35);
+  --mm2-platano-tallo: #24684a;
+  --mm2-bellota: #c084fc;
+  --mm2-cana: #2f7a52;
+  --mm2-piedra: #23405c;
+  --mm2-halo-mundo: rgba(34, 211, 238, 0.85);
+  --mm2-etiqueta-bg: rgba(8, 18, 34, 0.88);
+  --mm2-etiqueta-ink: #d9fbf3;
+  --mm2-etiqueta-borde: rgba(34, 211, 238, 0.45);
+  --mm2-velo: rgba(4, 10, 22, 0.6);
+  --mm2-ui-tinta: #ecfeff;
+  --mm2-ui-acento: #22d3ee;
+  --mm2-ui-acento-tinta: #06202a;
+  --mm2-scrim: rgba(2, 8, 18, 0.55);
+  --mm2-grades-fuerza: 0.45;
+}
+
+/* ── Dirección 3: VERDE VIVO — mañana botánica luminosa ── */
+.mm2[data-dir='verde'] {
+  --mm2-cielo-a: #9cdbee;
+  --mm2-cielo-m: #c9edda;
+  --mm2-cielo-b: #eef7d6;
+  --mm2-astro: #fff4a3;
+  --mm2-halo-a: rgba(255, 238, 150, 0.65);
+  --mm2-halo-b: rgba(255, 238, 150, 0);
+  --mm2-rayo: rgba(255, 255, 235, 0.42);
+  --mm2-lejos-a: #b9dfc9;
+  --mm2-lejos-b: #abd6bd;
+  --mm2-medio-a: #92c8a8;
+  --mm2-medio-b: #83bd9a;
+  --mm2-bruma: rgba(255, 255, 255, 0.46);
+  --mm2-niebla-nucleo: rgba(255, 255, 255, 0.66);
+  --mm2-cerca: #2c6b3a;
+  --mm2-vineta: rgba(20, 60, 30, 0.22);
+  --mm2-nieve: #ffffff;
+  --mm2-nieve-sombra: rgba(120, 160, 200, 0.28);
+  --mm2-paramo: #b5cf7d;
+  --mm2-frio: #8abf68;
+  --mm2-templado: #5aab5c;
+  --mm2-calido: #a8d162;
+  --mm2-valle: #d3e89e;
+  --mm2-rio-a: #8fd8d2;
+  --mm2-rio-b: #5fbdb7;
+  --mm2-rio-orilla: rgba(60, 120, 80, 0.5);
+  --mm2-flujo: rgba(255, 255, 255, 0.9);
+  --mm2-laguna: #9fe0da;
+  --mm2-borde-piso: rgba(255, 255, 255, 0.55);
+  --mm2-contorno: rgba(30, 70, 36, 0.12);
+  --mm2-luz-ladera: rgba(255, 255, 255, 0.2);
+  --mm2-sombra-ladera: rgba(24, 60, 40, 0.14);
+  --mm2-frailejon-hoja: #c4d97a;
+  --mm2-frailejon-seca: #a89858;
+  --mm2-frailejon-flor: #ffd95e;
+  --mm2-tronco: #9b7b52;
+  --mm2-arbolito: #4f9a54;
+  --mm2-casa-muro: #fffdf2;
+  --mm2-casa-techo: #e0784a;
+  --mm2-casa-teja: rgba(150, 70, 40, 0.4);
+  --mm2-ventana: #ffdf70;
+  --mm2-ventana-glow: rgba(255, 223, 112, 0.7);
+  --mm2-puerta: #8a5c3c;
+  --mm2-camino: rgba(232, 220, 174, 0.9);
+  --mm2-geranio: #e64f4f;
+  --mm2-cafe-hoja: #3e8a4a;
+  --mm2-cafe-fruto: #e64f4f;
+  --mm2-cerca-madera: #9b7b52;
+  --mm2-oveja: #ffffff;
+  --mm2-vaca: #f2e8d8;
+  --mm2-surco: rgba(94, 138, 66, 0.5);
+  --mm2-mata-papa: #4c9a4f;
+  --mm2-troje-cuerpo: #e6c185;
+  --mm2-troje-techo: #a06a44;
+  --mm2-grano: #ffd95e;
+  --mm2-toldo-a: #57b26a;
+  --mm2-toldo-b: #fffdf2;
+  --mm2-fruta-a: #f2a541;
+  --mm2-fruta-b: #e64f4f;
+  --mm2-mango-copa: #57a84e;
+  --mm2-mango-sombra: #418840;
+  --mm2-mango-fruto: #ffb547;
+  --mm2-platano-hoja: #66bb55;
+  --mm2-platano-nervio: rgba(30, 84, 30, 0.4);
+  --mm2-platano-tallo: #94b757;
+  --mm2-bellota: #a05a80;
+  --mm2-cana: #b7d377;
+  --mm2-piedra: #c9c2a4;
+  --mm2-halo-mundo: rgba(120, 200, 90, 0.9);
+  --mm2-etiqueta-bg: rgba(255, 255, 255, 0.94);
+  --mm2-etiqueta-ink: #24532b;
+  --mm2-etiqueta-borde: rgba(60, 130, 70, 0.3);
+  --mm2-velo: rgba(235, 248, 220, 0.55);
+  --mm2-ui-tinta: #f4fbef;
+  --mm2-ui-acento: #3e8a4a;
+  --mm2-ui-acento-tinta: #f4fbef;
+  --mm2-scrim: rgba(16, 44, 24, 0.34);
+  --mm2-grades-fuerza: 0.75;
+}
+
+/* ═══════════ La cámara: viewport full-bleed + capas parallax ═══════════ */
+
+.mm2-viewport {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  touch-action: none;
+  background: linear-gradient(180deg, var(--mm2-cielo-a), var(--mm2-cielo-m) 55%, var(--mm2-cielo-b));
+  transition: background 0.6s ease;
+}
+
+/* Cada capa viaja a su velocidad (transform inline desde React) y con su
+ * propia INERCIA: las lejanas se asientan más lento — la cámara se siente
+ * física, no un scroll. Solo transform: composición GPU pura. */
+.mm2-capa {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  transform-origin: 0 0;
+  will-change: transform;
+  transition: transform 0.9s cubic-bezier(0.22, 0.9, 0.3, 1), opacity 0.7s ease;
+  pointer-events: none;
+}
+
+.mm2-capa-cielo { transition-duration: 1.2s, 0.7s; }
+.mm2-capa-lejos { transition-duration: 1.08s, 0.7s; }
+.mm2-capa-medio { transition-duration: 0.99s, 0.7s; }
+.mm2-capa-principal { pointer-events: auto; }
+.mm2-capa-niebla { transition-duration: 0.84s, 0.7s; }
+.mm2-capa-cerca { transition-duration: 0.78s, 0.7s; }
+
+/* Al alejar la cámara (montaña completa) el primer plano sale de cuadro. */
+.mm2[data-modo='montana'] .mm2-capa-cerca { opacity: 0; }
+
+.mm2-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  overflow: visible; /* el primer plano dibuja más abajo del viewBox */
+}
+
+/* ── LUZ ATMOSFÉRICA POR PISO: el grade cinematográfico ──
+ * Seis planos de color fijos al viewport; solo el del piso activo enciende
+ * (crossfade de opacity — GPU). La temperatura de la luz cuenta la altura:
+ * azul glacial → páramo cian → frío neutro → HORA DORADA en la finca →
+ * ámbar del cálido → turquesa del río. */
+.mm2-grades {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 7;
+}
+
+.mm2-grade {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 1.1s ease;
+}
+
+.mm2-grade-nevado { background: linear-gradient(180deg, rgba(150, 190, 255, 0.24), rgba(150, 190, 255, 0) 45%, rgba(20, 40, 90, 0.12)); }
+.mm2-grade-paramo { background: linear-gradient(180deg, rgba(160, 218, 228, 0.18), rgba(160, 218, 228, 0) 48%, rgba(30, 70, 80, 0.1)); }
+.mm2-grade-frio { background: linear-gradient(180deg, rgba(190, 228, 200, 0.13), rgba(190, 228, 200, 0) 50%, rgba(36, 66, 46, 0.08)); }
+.mm2-grade-templado { background: linear-gradient(0deg, rgba(255, 170, 80, 0.18), rgba(255, 170, 80, 0) 55%, rgba(255, 220, 160, 0.1)); }
+.mm2-grade-calido { background: linear-gradient(0deg, rgba(255, 150, 60, 0.22), rgba(255, 150, 60, 0) 58%, rgba(255, 200, 120, 0.09)); }
+.mm2-grade-rio { background: linear-gradient(0deg, rgba(60, 190, 180, 0.2), rgba(60, 190, 180, 0) 55%, rgba(200, 240, 240, 0.07)); }
+
+.mm2[data-modo='finca'] .mm2-grade.es-activo { opacity: var(--mm2-grades-fuerza); }
+
+/* Viñeta de cine: enfoca el centro, hunde las esquinas. Estática. */
+.mm2-vineta {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 8;
+  background: radial-gradient(ellipse 130% 105% at 50% 42%, rgba(0, 0, 0, 0) 55%, var(--mm2-vineta) 100%);
+  transition: background 0.6s ease;
+}
+
+/* Scrims: la UI flota sobre el paisaje sin cajas — arriba y abajo un
+ * degradado de cine para que el texto siempre lea. */
+.mm2-scrim-arriba,
+.mm2-scrim-abajo {
+  position: absolute;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+  z-index: 9;
+  transition: background 0.6s ease;
+}
+
+.mm2-scrim-arriba {
+  top: 0;
+  height: 172px;
+  background: linear-gradient(180deg, var(--mm2-scrim), rgba(0, 0, 0, 0));
+}
+
+.mm2-scrim-abajo {
+  bottom: 0;
+  height: 148px;
+  background: linear-gradient(0deg, var(--mm2-scrim), rgba(0, 0, 0, 0));
+}
+
+/* ═══════════ UI flotante (full-bleed: nada en cajas) ═══════════ */
+
+.mm2-cabecera {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  padding: 10px 12px 0;
+  pointer-events: none;
+}
+
+.mm2-cabecera > * { pointer-events: auto; }
+
+.mm2-mockbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.mm2-volver {
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(0, 0, 0, 0.28);
+  color: var(--mm2-ui-tinta);
+  font: 700 13px 'Nunito', sans-serif;
+  border-radius: 999px;
+  padding: 6px 13px;
+  cursor: pointer;
+}
+
+.mm2-mockbar-titulo {
+  font: 700 9.5px 'Nunito', sans-serif;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(0, 0, 0, 0.28);
+  border-radius: 999px;
+  padding: 5px 10px;
+}
+
+.mm2-titulo {
+  margin: 8px 0 6px;
+  font: 700 20px/1.1 'Baloo 2', 'Nunito', sans-serif;
+  color: var(--mm2-ui-tinta);
+  text-shadow: 0 1px 10px rgba(0, 0, 0, 0.45);
+}
+
+.mm2-direcciones {
+  display: flex;
+  gap: 6px;
+}
+
+.mm2-dir-btn {
+  flex: 1;
+  min-height: 42px;
+  border: 1.5px solid rgba(255, 255, 255, 0.32);
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.26);
+  color: var(--mm2-ui-tinta);
+  font: 700 13px 'Nunito', sans-serif;
+  cursor: pointer;
+  transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+}
+
+.mm2-dir-btn.es-activa {
+  background: var(--mm2-ui-acento);
+  border-color: var(--mm2-ui-acento);
+  color: var(--mm2-ui-acento-tinta);
+}
+
+.mm2-dir-num {
+  display: inline-grid;
+  place-items: center;
+  width: 17px;
+  height: 17px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  font-size: 10.5px;
+  margin-right: 2px;
+  vertical-align: -3px;
+}
+
+.mm2-dir-lema {
+  margin: 6px 2px 0;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.5);
+}
+
+.mm2-dir-lema strong { color: #ffffff; }
+
+/* ── Brújula del piso + pasos + zoom: vidrio flotante sobre el paisaje ── */
+.mm2-brujula {
+  position: absolute;
+  top: 148px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 12;
+  pointer-events: none;
+  transition: opacity 0.5s ease;
+}
+
+/* En la montaña completa los rótulos de piso ya nombran todo — la brújula
+ * se retira para despejar el plano. */
+.mm2[data-modo='montana'] .mm2-brujula { opacity: 0; }
+
+.mm2-brujula-piso {
+  font: 800 12.5px 'Nunito', sans-serif;
+  color: var(--mm2-etiqueta-ink);
+  background: var(--mm2-etiqueta-bg);
+  border: 1px solid var(--mm2-etiqueta-borde);
+  border-radius: 999px;
+  padding: 6px 14px;
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.22);
+  white-space: nowrap;
+}
+
+.mm2-paso {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 12;
+  min-height: 40px;
+  border: 1px solid var(--mm2-etiqueta-borde);
+  border-radius: 999px;
+  background: var(--mm2-etiqueta-bg);
+  color: var(--mm2-etiqueta-ink);
+  font: 800 12.5px 'Nunito', sans-serif;
+  padding: 8px 16px;
+  cursor: pointer;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+}
+
+.mm2-paso-arriba { top: 188px; }
+.mm2-paso-abajo { bottom: 136px; }
+
+.mm2-zoom {
+  position: absolute;
+  bottom: 84px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 21;
+  min-height: 46px;
+  border: none;
+  border-radius: 999px;
+  background: var(--mm2-ui-acento);
+  color: var(--mm2-ui-acento-tinta);
+  font: 800 14.5px 'Nunito', sans-serif;
+  padding: 10px 20px;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+  white-space: nowrap;
+}
+
+/* ── Atajos permanentes flotantes: nada queda detrás de la montaña ── */
+.mm2-atajos {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 22;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 12px calc(12px + env(safe-area-inset-bottom, 0px));
+}
+
+.mm2-atajo-anotar {
+  flex: 1;
+  min-height: 52px;
+  border: 1.5px solid rgba(255, 255, 255, 0.35);
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.3);
+  color: #ffffff;
+  font: 800 15px 'Nunito', sans-serif;
+  cursor: pointer;
+}
+
+.mm2-atajo-agente {
+  flex: 0 0 auto;
+  width: 58px;
+  height: 58px;
+  border: none;
+  border-radius: 50%;
+  background: var(--mm2-ui-acento);
+  color: var(--mm2-ui-acento-tinta);
+  font: 800 27px/1 'Baloo 2', 'Nunito', sans-serif;
+  cursor: pointer;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--mm2-ui-acento) 28%, transparent), 0 6px 18px rgba(0, 0, 0, 0.3);
+}
+
+/* ── Aviso honesto del mockup ── */
+.mm2-aviso {
+  position: fixed;
+  left: 50%;
+  bottom: 92px;
+  transform: translateX(-50%);
+  z-index: 60;
+  max-width: min(86vw, 420px);
+  font: 700 13.5px 'Nunito', sans-serif;
+  color: #fffdf4;
+  background: rgba(20, 28, 24, 0.92);
+  border-radius: 14px;
+  padding: 10px 16px;
+  text-align: center;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.mm2 button:focus-visible {
+  outline: 2.5px solid var(--mm2-ui-acento);
+  outline-offset: 2px;
+}
+
+/* ═══════════ Sobre la capa principal: velos, mundos, franjas ═══════════ */
+
+.mm2-velo {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: var(--mm2-velo);
+  opacity: 1;
+  transition: opacity 0.9s ease, background 0.5s ease;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.mm2-velo-arriba { top: 0; }
+.mm2-velo-abajo { bottom: 0; }
+.mm2[data-modo='montana'] .mm2-velo { opacity: 0; }
+
+.mm2-finca-pin {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  z-index: 4;
+  font: 800 10.5px 'Nunito', sans-serif;
+  color: var(--mm2-etiqueta-ink);
+  background: var(--mm2-etiqueta-bg);
+  border: 1px solid var(--mm2-etiqueta-borde);
+  border-radius: 999px;
+  padding: 3px 7px;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+}
+
+.mm2-mundo {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 5;
+  transition: opacity 0.6s ease;
+}
+
+.mm2-mundo-halo {
+  width: 23px;
+  height: 23px;
+  border-radius: 50%;
+  border: 2px solid var(--mm2-halo-mundo);
+  box-shadow: 0 0 10px var(--mm2-halo-mundo), inset 0 0 6px var(--mm2-halo-mundo);
+  animation: mm2-pulso 2.6s ease-in-out infinite;
+}
+
+.mm2-mundo-etiqueta {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 1px;
+  font: 800 10px 'Nunito', sans-serif;
+  color: var(--mm2-etiqueta-ink);
+  background: var(--mm2-etiqueta-bg);
+  border: 1px solid var(--mm2-etiqueta-borde);
+  border-radius: 999px;
+  padding: 2.5px 6px;
+  white-space: nowrap;
+}
+
+.mm2-mundo.es-tenue { opacity: 0.24; pointer-events: none; }
+.mm2[data-modo='montana'] .mm2-mundo { opacity: 0; pointer-events: none; }
+
+.mm2-franja {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  border: none;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 6;
+  transition: opacity 0.5s ease;
+}
+
+.mm2[data-modo='montana'] .mm2-franja { opacity: 1; pointer-events: auto; }
+
+.mm2-franja-rotulo {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  font: 800 26px 'Baloo 2', 'Nunito', sans-serif;
+  color: var(--mm2-etiqueta-ink);
+  background: var(--mm2-etiqueta-bg);
+  border: 2px solid var(--mm2-etiqueta-borde);
+  border-radius: 999px;
+  padding: 6px 18px;
+  white-space: nowrap;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+}
+
+.mm2-franja:focus-visible .mm2-franja-rotulo,
+.mm2-franja:active .mm2-franja-rotulo { border-color: var(--mm2-ui-acento); }
+
+/* ═══════════ Pintura de la escena por dirección ═══════════ */
+
+.mm2-stop-cielo-a { stop-color: var(--mm2-cielo-a); }
+.mm2-stop-cielo-m { stop-color: var(--mm2-cielo-m); }
+.mm2-stop-cielo-b { stop-color: var(--mm2-cielo-b); }
+.mm2-stop-halo-a { stop-color: var(--mm2-halo-a); }
+.mm2-stop-halo-b { stop-color: var(--mm2-halo-b); }
+.mm2-stop-rayo-a { stop-color: var(--mm2-rayo); }
+.mm2-stop-rayo-b { stop-color: rgba(255, 255, 255, 0); }
+.mm2-stop-rio-a { stop-color: var(--mm2-rio-a); }
+.mm2-stop-rio-b { stop-color: var(--mm2-rio-b); }
+.mm2-stop-niebla-a { stop-color: var(--mm2-niebla-nucleo); }
+.mm2-stop-niebla-b { stop-color: rgba(255, 255, 255, 0); }
+.mm2[data-dir='biopunk'] .mm2-stop-niebla-b { stop-color: rgba(140, 220, 240, 0); }
+.mm2-stop-reflejo-a { stop-color: rgba(255, 255, 255, 0.16); }
+.mm2-stop-reflejo-b { stop-color: rgba(255, 255, 255, 0); }
+
+/* Capa cielo */
+.mm2-estrellas { display: none; }
+.mm2[data-dir='biopunk'] .mm2-estrellas { display: block; }
+.mm2-estrella { fill: #cdeffb; animation: mm2-titila 3.2s ease-in-out infinite alternate; }
+.mm2-estrella:nth-of-type(2n) { animation-delay: 1.1s; }
+.mm2-estrella:nth-of-type(3n) { animation-delay: 2s; }
+
+.mm2-astro-disco { fill: var(--mm2-astro); }
+.mm2-astro-crater { fill: rgba(140, 175, 195, 0.5); display: none; }
+.mm2[data-dir='biopunk'] .mm2-astro-crater { display: block; }
+
+/* God-rays: abanico de luz desde el astro. Solo la OPACIDAD respira (GPU);
+ * el degradado del rayo es estático. */
+.mm2-rayo {
+  mix-blend-mode: screen;
+  animation: mm2-rayo-respira 9s ease-in-out infinite alternate;
+}
+.mm2-rayo-2 { animation-delay: 2.4s; animation-duration: 11s; }
+.mm2-rayo-3 { animation-delay: 4.8s; animation-duration: 13s; }
+
+.mm2-nube { fill: rgba(255, 255, 255, 0.8); }
+.mm2-nube-alta { fill: rgba(255, 255, 255, 0.55); }
+.mm2-nube-1 { animation: mm2-deriva 26s ease-in-out infinite alternate; }
+.mm2-nube-2 { animation: mm2-deriva 34s ease-in-out infinite alternate-reverse; }
+.mm2-nube-3 { animation: mm2-deriva 22s ease-in-out infinite alternate; }
+.mm2[data-dir='biopunk'] .mm2-nubes { display: none; }
+
+/* Capas de cordillera: perspectiva atmosférica (lejos = color del cielo) */
+.mm2-lejos-a { fill: var(--mm2-lejos-a); }
+.mm2-lejos-b { fill: var(--mm2-lejos-b); }
+.mm2-medio-a { fill: var(--mm2-medio-a); }
+.mm2-medio-b { fill: var(--mm2-medio-b); }
+.mm2-bruma-banda { fill: var(--mm2-bruma); }
+
+.mm2-aves { display: none; }
+.mm2[data-dir='naturalista'] .mm2-aves {
+  display: block;
+  fill: none;
+  stroke: #6b5334;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+}
+.mm2-ave-1 { animation: mm2-deriva 30s ease-in-out infinite alternate; }
+
+/* Capa principal: cuerpo de la montaña */
+.mm2-piso-paramo { fill: var(--mm2-paramo); }
+.mm2-piso-frio { fill: var(--mm2-frio); }
+.mm2-piso-templado { fill: var(--mm2-templado); }
+.mm2-piso-calido { fill: var(--mm2-calido); }
+.mm2-piso-valle { fill: var(--mm2-valle); }
+.mm2-nieve { fill: var(--mm2-nieve); }
+.mm2-nieve-sombra { fill: var(--mm2-nieve-sombra); }
+.mm2-grieta { fill: none; stroke: var(--mm2-nieve-sombra); stroke-width: 1.6; stroke-linecap: round; }
+
+.mm2-borde-piso {
+  fill: none;
+  stroke: var(--mm2-borde-piso);
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.mm2[data-dir='biopunk'] .mm2-borde-piso {
+  stroke-width: 2.4;
+  opacity: 0.85;
+  filter: drop-shadow(0 0 4px rgba(34, 211, 238, 0.8));
+}
+
+/* Curvas de nivel: escala de montaña real, casi invisibles */
+.mm2-contorno { fill: none; stroke: var(--mm2-contorno); stroke-width: 1.4; stroke-linecap: round; }
+
+.mm2-piedra { fill: var(--mm2-piedra); }
+
+/* Páramo */
+.mm2-frailejon-tronco { fill: var(--mm2-tronco); }
+.mm2-frailejon-faldon { fill: none; stroke: var(--mm2-frailejon-seca); stroke-width: 2; stroke-linecap: round; }
+.mm2-frailejon-hoja { fill: var(--mm2-frailejon-hoja); }
+.mm2-hoja-int { fill: color-mix(in srgb, var(--mm2-frailejon-hoja) 80%, #ffffff); }
+.mm2-frailejon-tallo { fill: none; stroke: var(--mm2-frailejon-seca); stroke-width: 1.6; stroke-linecap: round; }
+.mm2-frailejon-flor { fill: var(--mm2-frailejon-flor); }
+.mm2-frailejon-roseta {
+  transform-box: fill-box;
+  transform-origin: 50% 92%;
+  animation: mm2-respira 4.6s ease-in-out infinite alternate;
+}
+
+.mm2-pajonal path {
+  fill: none;
+  stroke: var(--mm2-frailejon-hoja);
+  stroke-width: 2;
+  stroke-linecap: round;
+  opacity: 0.75;
+}
+
+.mm2-laguna { fill: var(--mm2-laguna); }
+.mm2-laguna-brillo { fill: none; stroke: var(--mm2-flujo); stroke-width: 1.6; stroke-linecap: round; opacity: 0.7; }
+
+/* Bosque achaparrado / altoandino */
+.mm2-arbolito { fill: var(--mm2-arbolito); }
+.mm2-arbolito-tronco { fill: var(--mm2-tronco); }
+
+/* Frío */
+.mm2-surcos path { fill: none; stroke: var(--mm2-surco); stroke-width: 5; stroke-linecap: round; }
+.mm2-matas-papa circle { fill: var(--mm2-mata-papa); }
+.mm2-cerca-poste, .mm2-cerca-riel { fill: var(--mm2-cerca-madera); }
+.mm2-oveja { fill: var(--mm2-oveja); }
+.mm2-vaca { fill: var(--mm2-vaca); }
+
+/* Templado: la casa campesina */
+.mm2-casa-muro { fill: var(--mm2-casa-muro); }
+.mm2-casa-techo { fill: var(--mm2-casa-techo); }
+.mm2-casa-teja { fill: none; stroke: var(--mm2-casa-teja); stroke-width: 1.6; stroke-linecap: round; }
+.mm2-casa-columna { fill: var(--mm2-puerta); }
+.mm2-casa-zocalo { fill: var(--mm2-troje-cuerpo); }
+.mm2-casa-chimenea { fill: var(--mm2-casa-techo); }
+.mm2-casa-puerta { fill: var(--mm2-puerta); }
+.mm2-casa-ventana {
+  fill: var(--mm2-ventana);
+  filter: drop-shadow(0 0 4px var(--mm2-ventana-glow));
+}
+.mm2-casa-marco { fill: var(--mm2-puerta); opacity: 0.6; }
+.mm2-casa-camino { fill: none; stroke: var(--mm2-camino); stroke-width: 4; stroke-linecap: round; }
+.mm2-matera { fill: var(--mm2-troje-techo); }
+.mm2-geranio { fill: var(--mm2-geranio); }
+
+.mm2-humo circle { fill: rgba(235, 235, 235, 0.55); }
+.mm2[data-dir='biopunk'] .mm2-humo circle { fill: rgba(167, 230, 255, 0.35); }
+.mm2-humo-1 { animation: mm2-humo 3.2s ease-out infinite; }
+.mm2-humo-2 { animation: mm2-humo 3.2s ease-out infinite 1.05s; }
+.mm2-humo-3 { animation: mm2-humo 3.2s ease-out infinite 2.1s; }
+
+.mm2-troje-cuerpo { fill: var(--mm2-troje-cuerpo); }
+.mm2-troje-techo { fill: var(--mm2-troje-techo); }
+.mm2-troje-pata { fill: var(--mm2-puerta); }
+.mm2-troje-grano { fill: var(--mm2-grano); }
+
+.mm2-cafe-tallo { fill: none; stroke: var(--mm2-tronco); stroke-width: 2; stroke-linecap: round; }
+.mm2-cafe-hoja { fill: var(--mm2-cafe-hoja); }
+.mm2-cafe-fruto { fill: var(--mm2-cafe-fruto); }
+
+.mm2-sombrio path { fill: none; stroke: var(--mm2-tronco); stroke-width: 4; stroke-linecap: round; }
+.mm2-sombrio-copa { fill: var(--mm2-mango-copa); opacity: 0.88; }
+
+.mm2-mercado-meson, .mm2-mercado-tabla { fill: var(--mm2-troje-cuerpo); }
+.mm2-toldo-a { fill: var(--mm2-toldo-a); }
+.mm2-toldo-b { fill: var(--mm2-toldo-b); }
+.mm2-mercado-fruta-a { fill: var(--mm2-fruta-a); }
+.mm2-mercado-fruta-b { fill: var(--mm2-fruta-b); }
+
+/* Cálido */
+.mm2-mango-tronco { fill: none; stroke: var(--mm2-tronco); stroke-width: 6; stroke-linecap: round; }
+.mm2-mango-copa { fill: var(--mm2-mango-copa); }
+.mm2-mango-copa-sombra { fill: var(--mm2-mango-sombra); }
+.mm2-mango-fruto { fill: var(--mm2-mango-fruto); }
+.mm2-mango-pezon { fill: none; stroke: var(--mm2-tronco); stroke-width: 1.4; stroke-linecap: round; }
+.mm2-platano-hoja { fill: var(--mm2-platano-hoja); }
+.mm2-platano-nervio { fill: none; stroke: var(--mm2-platano-nervio); stroke-width: 1.2; stroke-linecap: round; }
+.mm2-platano-tallo { fill: var(--mm2-platano-tallo); }
+.mm2-racimo circle { fill: var(--mm2-grano); }
+.mm2-bellota { fill: var(--mm2-bellota); }
+.mm2-cana-tallo { fill: none; stroke: var(--mm2-cana); stroke-width: 3.4; stroke-linecap: round; }
+.mm2-cana-hoja { fill: none; stroke: var(--mm2-cana); stroke-width: 2; stroke-linecap: round; }
+
+/* Río: orilla + reflejo del cielo + agua que baja + cascada */
+.mm2-rio-orilla { fill: none; stroke: var(--mm2-rio-orilla); stroke-width: 3; }
+.mm2-flujo path {
+  fill: none;
+  stroke: var(--mm2-flujo);
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-dasharray: 10 16;
+  animation: mm2-baja 2.4s linear infinite;
+  opacity: 0.75;
+}
+.mm2-cascada-caida { fill: rgba(255, 255, 255, 0.55); }
+.mm2[data-dir='biopunk'] .mm2-cascada-caida { fill: rgba(103, 232, 249, 0.45); }
+.mm2-espuma { fill: rgba(255, 255, 255, 0.7); animation: mm2-espuma 1.8s ease-in-out infinite; }
+.mm2-espuma:nth-of-type(2n) { animation-delay: 0.6s; }
+.mm2-espuma:nth-of-type(3n) { animation-delay: 1.2s; }
+
+/* Luz de ladera direccional (el astro está a la derecha) */
+.mm2-stop-ladera-sombra { stop-color: var(--mm2-sombra-ladera); }
+.mm2-stop-ladera-luz { stop-color: var(--mm2-luz-ladera); }
+.mm2-stop-transparente { stop-color: rgba(0, 0, 0, 0); }
+
+/* Micelio: la red viva conecta los pisos (solo biopunk) */
+.mm2-micelio { display: none; }
+.mm2[data-dir='biopunk'] .mm2-micelio {
+  display: block;
+  fill: none;
+  stroke: #67e8f9;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-dasharray: 2 9;
+  opacity: 0.65;
+  filter: drop-shadow(0 0 3px rgba(103, 232, 249, 0.8));
+  animation: mm2-micelio-fluye 7s linear infinite;
+}
+.mm2[data-dir='biopunk'] .mm2-micelio-nodo {
+  fill: #a3e635;
+  stroke: none;
+  animation: mm2-titila 2.8s ease-in-out infinite alternate;
+}
+
+/* Mariposas (solo verde vivo) */
+.mm2-mariposas { display: none; }
+.mm2[data-dir='verde'] .mm2-mariposas { display: block; }
+.mm2-mariposa-1 { fill: #f2a541; animation: mm2-flota 3.6s ease-in-out infinite alternate; }
+.mm2-mariposa-2 { fill: #e05f8a; animation: mm2-flota 4.4s ease-in-out infinite alternate-reverse; }
+
+/* Capa niebla volumétrica: bancos que derivan; el del valle SUBE y se
+ * disipa en loop — la niebla de la Sierra Nevada de verdad. */
+.mm2-banco-1 { animation: mm2-niebla-deriva 26s ease-in-out infinite alternate; }
+.mm2-banco-2 { animation: mm2-niebla-deriva 34s ease-in-out infinite alternate-reverse; }
+.mm2-banco-3 { animation: mm2-niebla-deriva 30s ease-in-out infinite alternate; }
+.mm2-banco-valle { animation: mm2-niebla-sube 22s ease-in-out infinite; }
+.mm2-banco-valle-2 { animation: mm2-niebla-sube 28s ease-in-out infinite 9s; }
+
+/* Capa primer plano: siluetas botánicas que enmarcan el plano */
+.mm2-cerca-forma { fill: var(--mm2-cerca); opacity: 0.88; }
+.mm2-cerca-forma-suave { fill: var(--mm2-cerca); opacity: 0.55; }
+
+/* ── Vida de la escena ── */
+@keyframes mm2-pulso {
+  0%, 100% { transform: scale(1); opacity: 0.95; }
+  50% { transform: scale(1.22); opacity: 0.55; }
+}
+
+@keyframes mm2-respira {
+  from { transform: scale(1); }
+  to { transform: scale(1.05); }
+}
+
+@keyframes mm2-humo {
+  0% { transform: translateY(0); opacity: 0.55; }
+  100% { transform: translateY(-18px); opacity: 0; }
+}
+
+@keyframes mm2-baja {
+  from { stroke-dashoffset: 0; }
+  to { stroke-dashoffset: -52; }
+}
+
+@keyframes mm2-espuma {
+  0%, 100% { transform: translateY(0); opacity: 0.7; }
+  50% { transform: translateY(-2.5px); opacity: 0.95; }
+}
+
+@keyframes mm2-micelio-fluye {
+  from { stroke-dashoffset: 0; }
+  to { stroke-dashoffset: -110; }
+}
+
+@keyframes mm2-titila {
+  from { opacity: 0.35; }
+  to { opacity: 1; }
+}
+
+@keyframes mm2-deriva {
+  from { transform: translateX(-14px); }
+  to { transform: translateX(16px); }
+}
+
+@keyframes mm2-flota {
+  from { transform: translate(0, 0) rotate(-6deg); }
+  to { transform: translate(10px, -10px) rotate(8deg); }
+}
+
+@keyframes mm2-rayo-respira {
+  from { opacity: 0.35; }
+  to { opacity: 0.9; }
+}
+
+@keyframes mm2-niebla-deriva {
+  from { transform: translateX(-22px); }
+  to { transform: translateX(26px); }
+}
+
+@keyframes mm2-niebla-sube {
+  0% { transform: translateY(14px); opacity: 0; }
+  22% { opacity: 0.85; }
+  62% { opacity: 0.55; }
+  100% { transform: translateY(-52px); opacity: 0; }
+}
+
+/* La montaña se queda quieta si la persona lo pide: plano final digno,
+ * sin parallax animado ni vida — pero con toda la luz y la composición. */
+@media (prefers-reduced-motion: reduce) {
+  .mm2 *, .mm2 *::before, .mm2 *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/mockups/montana-mundos.css
+++ b/src/mockups/montana-mundos.css
@@ -61,6 +61,8 @@
   --mm-platano-tallo: #8aa14f;
   --mm-cana: #a9bd68;
   --mm-piedra: #b7ab8d;
+  --mm-luz-a: rgba(255, 240, 200, 0.22);
+  --mm-luz-b: rgba(46, 32, 10, 0.16);
   --mm-halo-mundo: rgba(255, 205, 110, 0.9);
   --mm-etiqueta-bg: rgba(255, 248, 232, 0.94);
   --mm-etiqueta-ink: #4a3a20;
@@ -132,6 +134,8 @@
   --mm-platano-tallo: #24684a;
   --mm-cana: #2f7a52;
   --mm-piedra: #23405c;
+  --mm-luz-a: rgba(103, 232, 249, 0.10);
+  --mm-luz-b: rgba(2, 6, 16, 0.30);
   --mm-halo-mundo: rgba(34, 211, 238, 0.85);
   --mm-etiqueta-bg: rgba(8, 18, 34, 0.88);
   --mm-etiqueta-ink: #d9fbf3;
@@ -195,6 +199,8 @@
   --mm-platano-tallo: #94b757;
   --mm-cana: #b7d377;
   --mm-piedra: #c9c2a4;
+  --mm-luz-a: rgba(255, 255, 255, 0.26);
+  --mm-luz-b: rgba(28, 64, 30, 0.12);
   --mm-halo-mundo: rgba(120, 200, 90, 0.9);
   --mm-etiqueta-bg: rgba(255, 255, 255, 0.94);
   --mm-etiqueta-ink: #24532b;
@@ -302,7 +308,7 @@
   margin: 0 auto;
   overflow: hidden;
   touch-action: none;
-  background: var(--mm-cielo-a);
+  background: linear-gradient(180deg, var(--mm-cielo-a), var(--mm-cielo-b));
   transition: background 0.5s ease;
 }
 
@@ -345,7 +351,7 @@
   position: absolute;
   transform: translate(-50%, -100%);
   z-index: 4;
-  font: 800 9px 'Nunito', sans-serif;
+  font: 800 10.5px 'Nunito', sans-serif;
   color: var(--mm-etiqueta-ink);
   background: var(--mm-etiqueta-bg);
   border: 1px solid var(--mm-etiqueta-borde);
@@ -359,8 +365,8 @@
 .mm-mundo {
   position: absolute;
   transform: translate(-50%, -50%);
-  width: 30px;
-  height: 30px;
+  width: 38px;
+  height: 38px;
   padding: 0;
   border: none;
   background: transparent;
@@ -372,10 +378,10 @@
 }
 
 .mm-mundo-halo {
-  width: 20px;
-  height: 20px;
+  width: 23px;
+  height: 23px;
   border-radius: 50%;
-  border: 1.6px solid var(--mm-halo-mundo);
+  border: 2px solid var(--mm-halo-mundo);
   box-shadow: 0 0 10px var(--mm-halo-mundo), inset 0 0 6px var(--mm-halo-mundo);
   animation: mm-pulso 2.6s ease-in-out infinite;
 }
@@ -386,7 +392,7 @@
   left: 50%;
   transform: translateX(-50%);
   margin-top: 1px;
-  font: 800 7.5px 'Nunito', sans-serif;
+  font: 800 10px 'Nunito', sans-serif;
   color: var(--mm-etiqueta-ink);
   background: var(--mm-etiqueta-bg);
   border: 1px solid var(--mm-etiqueta-borde);
@@ -560,9 +566,11 @@
 .mm-stop-halo-b { stop-color: var(--mm-halo-b); }
 .mm-stop-rio-a { stop-color: var(--mm-rio-a); }
 .mm-stop-rio-b { stop-color: var(--mm-rio-b); }
+.mm-stop-luz-a { stop-color: var(--mm-luz-a); }
+.mm-stop-luz-b { stop-color: var(--mm-luz-b); }
 
-.mm-ridge-a { fill: var(--mm-ridge-a); opacity: 0.75; }
-.mm-ridge-b { fill: var(--mm-ridge-b); opacity: 0.65; }
+.mm-ridge-a { fill: var(--mm-ridge-a); opacity: 0.5; }
+.mm-ridge-b { fill: var(--mm-ridge-b); opacity: 0.42; }
 
 .mm-piso-paramo { fill: var(--mm-paramo); }
 .mm-piso-frio { fill: var(--mm-frio); }
@@ -579,7 +587,9 @@
 }
 
 .mm[data-dir='biopunk'] .mm-borde-piso {
-  filter: drop-shadow(0 0 3px rgba(34, 211, 238, 0.7));
+  stroke-width: 2.4;
+  opacity: 0.85;
+  filter: drop-shadow(0 0 4px rgba(34, 211, 238, 0.8));
 }
 
 .mm-niebla { fill: var(--mm-niebla); }
@@ -663,6 +673,10 @@
 .mm-mercado-fruta-a { fill: var(--mm-fruta-a); }
 .mm-mercado-fruta-b { fill: var(--mm-fruta-b); }
 
+/* Sombríos del cafetal */
+.mm-sombrio path { fill: none; stroke: var(--mm-tronco); stroke-width: 4; stroke-linecap: round; }
+.mm-sombrio-copa { fill: var(--mm-mango-copa); opacity: 0.88; }
+
 /* Cálido */
 .mm-mango-tronco { fill: none; stroke: var(--mm-tronco); stroke-width: 7; stroke-linecap: round; }
 .mm-mango-copa { fill: var(--mm-mango-copa); }
@@ -702,6 +716,10 @@
   stroke: none;
   animation: mm-titila 2.8s ease-in-out infinite alternate;
 }
+
+/* Follaje botánico en primer plano (solo verde vivo) */
+.mm-botanica { display: none; }
+.mm[data-dir='verde'] .mm-botanica { display: block; fill: #4c9a4f; }
 
 /* Mariposas (solo verde vivo) */
 .mm-mariposas { display: none; }

--- a/src/mockups/montana-mundos.css
+++ b/src/mockups/montana-mundos.css
@@ -1,0 +1,759 @@
+/* montana-mundos.css — MOCKUP DEV #/mockups/montana-mundos (prefijo mm-).
+ *
+ * UNA sola escena SVG; las tres direcciones artísticas la re-pintan con
+ * variables CSS conmutadas por [data-dir]:
+ *   1. naturalista — Sierra Nevada pictórica, luz dorada de montaña.
+ *   2. biopunk     — neón orgánico nocturno (paleta del home en prod:
+ *                    navy #0c1830 + cian 34,211,238 + magenta + lima).
+ *   3. verde       — verde vivo botánico, luminoso, diurno.
+ *
+ * La vida de la escena (agua que baja, frailejón que respira, humo de la
+ * casa, micelio que late) es CSS puro y muere entera con
+ * prefers-reduced-motion. Tipografía Baloo 2 / Nunito (ya self-host). */
+
+.mm {
+  /* ── Dirección 1 (default): SIERRA NATURALISTA ── */
+  --mm-cielo-a: #f0c98d;
+  --mm-cielo-b: #e9ddbd;
+  --mm-astro: #ffdf8e;
+  --mm-halo-a: rgba(255, 199, 112, 0.55);
+  --mm-halo-b: rgba(255, 199, 112, 0);
+  --mm-ridge-a: #c9a072;
+  --mm-ridge-b: #bd9268;
+  --mm-nieve: #fdf6ec;
+  --mm-paramo: #a8a469;
+  --mm-frio: #7d9a58;
+  --mm-templado: #55824a;
+  --mm-calido: #94aa52;
+  --mm-valle: #c0bf75;
+  --mm-rio-a: #93c6be;
+  --mm-rio-b: #6da9ae;
+  --mm-flujo: rgba(255, 255, 255, 0.75);
+  --mm-laguna: #9fd0c9;
+  --mm-niebla: rgba(255, 250, 235, 0.34);
+  --mm-borde-piso: rgba(255, 244, 214, 0.42);
+  --mm-frailejon-hoja: #b9c46b;
+  --mm-frailejon-flor: #e8c95a;
+  --mm-tronco: #8a6e4b;
+  --mm-casa-muro: #f3e6cf;
+  --mm-casa-techo: #b3563d;
+  --mm-ventana: #ffd166;
+  --mm-ventana-glow: rgba(255, 209, 102, 0.75);
+  --mm-puerta: #7a5236;
+  --mm-camino: rgba(230, 205, 160, 0.8);
+  --mm-cafe-mata: #3f6b3a;
+  --mm-cafe-fruto: #d64545;
+  --mm-cerca: #8a6e4b;
+  --mm-oveja: #f5efe2;
+  --mm-vaca: #e3d3ba;
+  --mm-surco: rgba(90, 116, 62, 0.55);
+  --mm-mata-papa: #4d7a43;
+  --mm-troje-cuerpo: #caa36a;
+  --mm-troje-techo: #8a5c3c;
+  --mm-grano: #e9c96a;
+  --mm-toldo-a: #d9603b;
+  --mm-toldo-b: #f4e9d2;
+  --mm-fruta-a: #e5a33c;
+  --mm-fruta-b: #c94f4f;
+  --mm-mango-copa: #4c8043;
+  --mm-mango-fruto: #f2a541;
+  --mm-platano-hoja: #5f9c4a;
+  --mm-platano-tallo: #8aa14f;
+  --mm-cana: #a9bd68;
+  --mm-piedra: #b7ab8d;
+  --mm-halo-mundo: rgba(255, 205, 110, 0.9);
+  --mm-etiqueta-bg: rgba(255, 248, 232, 0.94);
+  --mm-etiqueta-ink: #4a3a20;
+  --mm-etiqueta-borde: rgba(122, 82, 54, 0.28);
+  --mm-velo: rgba(59, 44, 22, 0.45);
+  --mm-ui-fondo: #f7ecd7;
+  --mm-ui-tinta: #3c2f1c;
+  --mm-ui-suave: #7b6a4d;
+  --mm-ui-acento: #b3563d;
+  --mm-ui-acento-tinta: #fff6ea;
+  --mm-ui-borde: rgba(90, 70, 40, 0.2);
+
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--mm-ui-fondo);
+  color: var(--mm-ui-tinta);
+  font-family: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+/* ── Dirección 2: BIOPUNK (coherente con el home en prod) ── */
+.mm[data-dir='biopunk'] {
+  --mm-cielo-a: #0c1830;
+  --mm-cielo-b: #16263f;
+  --mm-astro: #dff6ff;
+  --mm-halo-a: rgba(34, 211, 238, 0.4);
+  --mm-halo-b: rgba(34, 211, 238, 0);
+  --mm-ridge-a: #101f36;
+  --mm-ridge-b: #0d1a2e;
+  --mm-nieve: #cfe6f2;
+  --mm-paramo: #143349;
+  --mm-frio: #123f3e;
+  --mm-templado: #175035;
+  --mm-calido: #1d5c33;
+  --mm-valle: #24683a;
+  --mm-rio-a: #1b4a66;
+  --mm-rio-b: #0f2f4a;
+  --mm-flujo: rgba(103, 232, 249, 0.85);
+  --mm-laguna: #1d5a70;
+  --mm-niebla: rgba(34, 211, 238, 0.08);
+  --mm-borde-piso: rgba(34, 211, 238, 0.5);
+  --mm-frailejon-hoja: #3f7a63;
+  --mm-frailejon-flor: #a3e635;
+  --mm-tronco: #2a4a44;
+  --mm-casa-muro: #1b2c44;
+  --mm-casa-techo: #24405e;
+  --mm-ventana: #f0abfc;
+  --mm-ventana-glow: rgba(240, 171, 252, 0.8);
+  --mm-puerta: #101d31;
+  --mm-camino: rgba(34, 211, 238, 0.35);
+  --mm-cafe-mata: #1f5c40;
+  --mm-cafe-fruto: #fb7185;
+  --mm-cerca: #2c4258;
+  --mm-oveja: #b8c7d9;
+  --mm-vaca: #9fb4c9;
+  --mm-surco: rgba(47, 191, 143, 0.4);
+  --mm-mata-papa: #2fbf8f;
+  --mm-troje-cuerpo: #22354e;
+  --mm-troje-techo: #2c4a66;
+  --mm-grano: #fbbf24;
+  --mm-toldo-a: #22d3ee;
+  --mm-toldo-b: #16263f;
+  --mm-fruta-a: #a3e635;
+  --mm-fruta-b: #f0abfc;
+  --mm-mango-copa: #1f6b45;
+  --mm-mango-fruto: #fbbf24;
+  --mm-platano-hoja: #2f8a5a;
+  --mm-platano-tallo: #24684a;
+  --mm-cana: #2f7a52;
+  --mm-piedra: #23405c;
+  --mm-halo-mundo: rgba(34, 211, 238, 0.85);
+  --mm-etiqueta-bg: rgba(8, 18, 34, 0.88);
+  --mm-etiqueta-ink: #d9fbf3;
+  --mm-etiqueta-borde: rgba(34, 211, 238, 0.45);
+  --mm-velo: rgba(4, 10, 22, 0.6);
+  --mm-ui-fondo: #0a1424;
+  --mm-ui-tinta: #ecfeff;
+  --mm-ui-suave: #93b4c4;
+  --mm-ui-acento: #22d3ee;
+  --mm-ui-acento-tinta: #06202a;
+  --mm-ui-borde: rgba(148, 197, 255, 0.18);
+}
+
+/* ── Dirección 3: VERDE VIVO (botánico luminoso diurno) ── */
+.mm[data-dir='verde'] {
+  --mm-cielo-a: #aee3f0;
+  --mm-cielo-b: #eef7d6;
+  --mm-astro: #fff4a3;
+  --mm-halo-a: rgba(255, 238, 150, 0.6);
+  --mm-halo-b: rgba(255, 238, 150, 0);
+  --mm-ridge-a: #9fd3c0;
+  --mm-ridge-b: #8cc7b2;
+  --mm-nieve: #ffffff;
+  --mm-paramo: #b5cf7d;
+  --mm-frio: #8abf68;
+  --mm-templado: #5aab5c;
+  --mm-calido: #a8d162;
+  --mm-valle: #d3e89e;
+  --mm-rio-a: #8fd8d2;
+  --mm-rio-b: #5fbdb7;
+  --mm-flujo: rgba(255, 255, 255, 0.9);
+  --mm-laguna: #9fe0da;
+  --mm-niebla: rgba(255, 255, 255, 0.3);
+  --mm-borde-piso: rgba(255, 255, 255, 0.55);
+  --mm-frailejon-hoja: #c4d97a;
+  --mm-frailejon-flor: #ffd95e;
+  --mm-tronco: #9b7b52;
+  --mm-casa-muro: #fffdf2;
+  --mm-casa-techo: #e0784a;
+  --mm-ventana: #ffdf70;
+  --mm-ventana-glow: rgba(255, 223, 112, 0.7);
+  --mm-puerta: #8a5c3c;
+  --mm-camino: rgba(232, 220, 174, 0.9);
+  --mm-cafe-mata: #3e8a4a;
+  --mm-cafe-fruto: #e64f4f;
+  --mm-cerca: #9b7b52;
+  --mm-oveja: #ffffff;
+  --mm-vaca: #f2e8d8;
+  --mm-surco: rgba(94, 138, 66, 0.5);
+  --mm-mata-papa: #4c9a4f;
+  --mm-troje-cuerpo: #e6c185;
+  --mm-troje-techo: #a06a44;
+  --mm-grano: #ffd95e;
+  --mm-toldo-a: #57b26a;
+  --mm-toldo-b: #fffdf2;
+  --mm-fruta-a: #f2a541;
+  --mm-fruta-b: #e64f4f;
+  --mm-mango-copa: #57a84e;
+  --mm-mango-fruto: #ffb547;
+  --mm-platano-hoja: #66bb55;
+  --mm-platano-tallo: #94b757;
+  --mm-cana: #b7d377;
+  --mm-piedra: #c9c2a4;
+  --mm-halo-mundo: rgba(120, 200, 90, 0.9);
+  --mm-etiqueta-bg: rgba(255, 255, 255, 0.94);
+  --mm-etiqueta-ink: #24532b;
+  --mm-etiqueta-borde: rgba(60, 130, 70, 0.3);
+  --mm-velo: rgba(235, 248, 220, 0.55);
+  --mm-ui-fondo: #f3fae4;
+  --mm-ui-tinta: #1e3d24;
+  --mm-ui-suave: #5c7a58;
+  --mm-ui-acento: #3e8a4a;
+  --mm-ui-acento-tinta: #f4fbef;
+  --mm-ui-borde: rgba(60, 110, 60, 0.22);
+}
+
+/* ── Cabecera (barra del mockup + conmutador de dirección) ── */
+.mm-cabecera {
+  flex: 0 0 auto;
+  padding: 8px 12px 10px;
+  max-width: 560px;
+  width: 100%;
+  margin: 0 auto;
+  border-bottom: 1px solid var(--mm-ui-borde);
+  transition: background 0.5s ease, color 0.5s ease;
+}
+
+.mm-mockbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.mm-volver {
+  border: 1px solid var(--mm-ui-borde);
+  background: transparent;
+  color: var(--mm-ui-tinta);
+  font: 700 13px 'Nunito', sans-serif;
+  border-radius: 999px;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+
+.mm-mockbar-titulo {
+  font: 700 10px 'Nunito', sans-serif;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--mm-ui-suave);
+}
+
+.mm-titulo {
+  margin: 6px 0 8px;
+  font: 700 21px/1.1 'Baloo 2', 'Nunito', sans-serif;
+  color: var(--mm-ui-tinta);
+}
+
+.mm-direcciones {
+  display: flex;
+  gap: 6px;
+}
+
+.mm-dir-btn {
+  flex: 1;
+  min-height: 44px;
+  border: 1.5px solid var(--mm-ui-borde);
+  border-radius: 14px;
+  background: transparent;
+  color: var(--mm-ui-tinta);
+  font: 700 13.5px 'Nunito', sans-serif;
+  cursor: pointer;
+  transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+}
+
+.mm-dir-btn.es-activa {
+  background: var(--mm-ui-acento);
+  border-color: var(--mm-ui-acento);
+  color: var(--mm-ui-acento-tinta);
+}
+
+.mm-dir-num {
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  font-size: 11px;
+  margin-right: 2px;
+  vertical-align: -3px;
+}
+
+.mm-dir-lema {
+  margin: 7px 2px 0;
+  font-size: 12.5px;
+  color: var(--mm-ui-suave);
+}
+
+.mm-dir-lema strong { color: var(--mm-ui-tinta); }
+
+/* ── Ventana a la montaña ── */
+.mm-viewport {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-width: 560px;
+  width: 100%;
+  margin: 0 auto;
+  overflow: hidden;
+  touch-action: none;
+  background: var(--mm-cielo-a);
+  transition: background 0.5s ease;
+}
+
+.mm-escena {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  transform-origin: 0 0;
+  transition: transform 0.7s cubic-bezier(0.22, 0.9, 0.3, 1);
+  will-change: transform;
+}
+
+.mm-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ── Velos: pisos no activos tenues en modo finca ── */
+.mm-velo {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: var(--mm-velo);
+  opacity: 1;
+  transition: opacity 0.7s ease, background 0.5s ease;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.mm-velo-arriba { top: 0; }
+.mm-velo-abajo { bottom: 0; }
+.mm[data-modo='montana'] .mm-velo { opacity: 0; }
+
+/* ── Marcador de la finca ── */
+.mm-finca-pin {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  z-index: 4;
+  font: 800 9px 'Nunito', sans-serif;
+  color: var(--mm-etiqueta-ink);
+  background: var(--mm-etiqueta-bg);
+  border: 1px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  padding: 3px 7px;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+}
+
+/* ── Mundos tocables: halo + etiqueta ── */
+.mm-mundo {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 5;
+  transition: opacity 0.5s ease;
+}
+
+.mm-mundo-halo {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1.6px solid var(--mm-halo-mundo);
+  box-shadow: 0 0 10px var(--mm-halo-mundo), inset 0 0 6px var(--mm-halo-mundo);
+  animation: mm-pulso 2.6s ease-in-out infinite;
+}
+
+.mm-mundo-etiqueta {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 1px;
+  font: 800 7.5px 'Nunito', sans-serif;
+  color: var(--mm-etiqueta-ink);
+  background: var(--mm-etiqueta-bg);
+  border: 1px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  padding: 2.5px 6px;
+  white-space: nowrap;
+}
+
+.mm-mundo.es-tenue { opacity: 0.24; pointer-events: none; }
+.mm[data-modo='montana'] .mm-mundo { opacity: 0; pointer-events: none; }
+
+/* ── Franjas de piso (solo montaña completa): tocar acerca ── */
+.mm-franja {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  border: none;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 6;
+  transition: opacity 0.5s ease;
+}
+
+.mm[data-modo='montana'] .mm-franja { opacity: 1; pointer-events: auto; }
+
+.mm-franja-rotulo {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  font: 800 26px 'Baloo 2', 'Nunito', sans-serif;
+  color: var(--mm-etiqueta-ink);
+  background: var(--mm-etiqueta-bg);
+  border: 2px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  padding: 6px 18px;
+  white-space: nowrap;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+}
+
+.mm-franja:focus-visible .mm-franja-rotulo,
+.mm-franja:active .mm-franja-rotulo { border-color: var(--mm-ui-acento); }
+
+/* ── Brújula del piso + pasos + zoom (encima de la escena, tamaño real) ── */
+.mm-brujula {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  pointer-events: none;
+}
+
+.mm-brujula-piso {
+  font: 800 12.5px 'Nunito', sans-serif;
+  color: var(--mm-etiqueta-ink);
+  background: var(--mm-etiqueta-bg);
+  border: 1px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  padding: 6px 14px;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.16);
+  white-space: nowrap;
+}
+
+.mm-paso {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  min-height: 40px;
+  border: 1px solid var(--mm-etiqueta-borde);
+  border-radius: 999px;
+  background: var(--mm-etiqueta-bg);
+  color: var(--mm-etiqueta-ink);
+  font: 800 12.5px 'Nunito', sans-serif;
+  padding: 8px 16px;
+  cursor: pointer;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.16);
+}
+
+.mm-paso-arriba { top: 46px; }
+.mm-paso-abajo { bottom: 64px; }
+
+.mm-zoom {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 11;
+  min-height: 46px;
+  border: none;
+  border-radius: 999px;
+  background: var(--mm-ui-acento);
+  color: var(--mm-ui-acento-tinta);
+  font: 800 14.5px 'Nunito', sans-serif;
+  padding: 10px 20px;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+  white-space: nowrap;
+}
+
+/* ── Atajos permanentes (Ⓐ + anotar): nunca detrás de la montaña ── */
+.mm-atajos {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  max-width: 560px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 10px 12px calc(10px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid var(--mm-ui-borde);
+  background: var(--mm-ui-fondo);
+  transition: background 0.5s ease;
+}
+
+.mm-atajo-anotar {
+  flex: 1;
+  min-height: 52px;
+  border: 1.5px solid var(--mm-ui-borde);
+  border-radius: 16px;
+  background: transparent;
+  color: var(--mm-ui-tinta);
+  font: 800 15px 'Nunito', sans-serif;
+  cursor: pointer;
+}
+
+.mm-atajo-agente {
+  flex: 0 0 auto;
+  width: 56px;
+  height: 56px;
+  border: none;
+  border-radius: 50%;
+  background: var(--mm-ui-acento);
+  color: var(--mm-ui-acento-tinta);
+  font: 800 26px/1 'Baloo 2', 'Nunito', sans-serif;
+  cursor: pointer;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--mm-ui-acento) 25%, transparent), 0 6px 16px rgba(0, 0, 0, 0.25);
+}
+
+/* ── Aviso honesto del mockup ── */
+.mm-aviso {
+  position: fixed;
+  left: 50%;
+  bottom: 92px;
+  transform: translateX(-50%);
+  z-index: 60;
+  max-width: min(86vw, 420px);
+  font: 700 13.5px 'Nunito', sans-serif;
+  color: #fffdf4;
+  background: rgba(20, 28, 24, 0.92);
+  border-radius: 14px;
+  padding: 10px 16px;
+  text-align: center;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.mm button:focus-visible {
+  outline: 2.5px solid var(--mm-ui-acento);
+  outline-offset: 2px;
+}
+
+/* ═══════════ La escena SVG: pintura por dirección ═══════════ */
+
+.mm-stop-cielo-a { stop-color: var(--mm-cielo-a); }
+.mm-stop-cielo-b { stop-color: var(--mm-cielo-b); }
+.mm-stop-halo-a { stop-color: var(--mm-halo-a); }
+.mm-stop-halo-b { stop-color: var(--mm-halo-b); }
+.mm-stop-rio-a { stop-color: var(--mm-rio-a); }
+.mm-stop-rio-b { stop-color: var(--mm-rio-b); }
+
+.mm-ridge-a { fill: var(--mm-ridge-a); opacity: 0.75; }
+.mm-ridge-b { fill: var(--mm-ridge-b); opacity: 0.65; }
+
+.mm-piso-paramo { fill: var(--mm-paramo); }
+.mm-piso-frio { fill: var(--mm-frio); }
+.mm-piso-templado { fill: var(--mm-templado); }
+.mm-piso-calido { fill: var(--mm-calido); }
+.mm-piso-valle { fill: var(--mm-valle); }
+.mm-nieve { fill: var(--mm-nieve); }
+
+.mm-borde-piso {
+  fill: none;
+  stroke: var(--mm-borde-piso);
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.mm[data-dir='biopunk'] .mm-borde-piso {
+  filter: drop-shadow(0 0 3px rgba(34, 211, 238, 0.7));
+}
+
+.mm-niebla { fill: var(--mm-niebla); }
+
+/* Astro: sol (día) o luna (biopunk, con cráteres) */
+.mm-astro-disco { fill: var(--mm-astro); }
+.mm-astro-crater { fill: rgba(140, 175, 195, 0.5); display: none; }
+.mm[data-dir='biopunk'] .mm-astro-crater { display: block; }
+
+/* Estrellas: solo en la noche biopunk, titilan */
+.mm-estrellas { display: none; }
+.mm[data-dir='biopunk'] .mm-estrellas { display: block; }
+.mm-estrella { fill: #cdeffb; animation: mm-titila 3.2s ease-in-out infinite alternate; }
+.mm-estrella:nth-of-type(2n) { animation-delay: 1.1s; }
+.mm-estrella:nth-of-type(3n) { animation-delay: 2s; }
+
+/* Nubes: pasan despacio en las direcciones de día */
+.mm-nube { fill: rgba(255, 255, 255, 0.8); }
+.mm-nube-1 { animation: mm-deriva 18s ease-in-out infinite alternate; }
+.mm-nube-2 { animation: mm-deriva 24s ease-in-out infinite alternate-reverse; }
+.mm[data-dir='biopunk'] .mm-nubes { display: none; }
+
+/* Aves lejanas: solo la sierra */
+.mm-aves { display: none; }
+.mm[data-dir='naturalista'] .mm-aves {
+  display: block;
+  fill: none;
+  stroke: #6b5334;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+}
+
+/* Páramo */
+.mm-frailejon-tronco { fill: var(--mm-tronco); }
+.mm-frailejon-hoja { fill: var(--mm-frailejon-hoja); }
+.mm-frailejon-flor { fill: var(--mm-frailejon-flor); }
+.mm-frailejon-roseta {
+  transform-box: fill-box;
+  transform-origin: 50% 88%;
+  animation: mm-respira 4.6s ease-in-out infinite alternate;
+}
+
+.mm-laguna { fill: var(--mm-laguna); }
+.mm-laguna-brillo { fill: none; stroke: var(--mm-flujo); stroke-width: 1.6; stroke-linecap: round; opacity: 0.7; }
+
+/* Frío */
+.mm-surcos path { fill: none; stroke: var(--mm-surco); stroke-width: 5; stroke-linecap: round; }
+.mm-matas-papa circle { fill: var(--mm-mata-papa); }
+.mm-cerca-poste, .mm-cerca-riel { fill: var(--mm-cerca); }
+.mm-oveja { fill: var(--mm-oveja); }
+.mm-vaca { fill: var(--mm-vaca); }
+
+/* Templado: la casa viva */
+.mm-casa-muro { fill: var(--mm-casa-muro); }
+.mm-casa-techo { fill: var(--mm-casa-techo); }
+.mm-casa-chimenea { fill: var(--mm-casa-techo); }
+.mm-casa-puerta { fill: var(--mm-puerta); }
+.mm-casa-ventana {
+  fill: var(--mm-ventana);
+  filter: drop-shadow(0 0 4px var(--mm-ventana-glow));
+}
+.mm-casa-camino { fill: none; stroke: var(--mm-camino); stroke-width: 4; stroke-linecap: round; }
+
+.mm-humo circle { fill: rgba(235, 235, 235, 0.55); }
+.mm[data-dir='biopunk'] .mm-humo circle { fill: rgba(167, 230, 255, 0.35); }
+.mm-humo-1 { animation: mm-humo 3.2s ease-out infinite; }
+.mm-humo-2 { animation: mm-humo 3.2s ease-out infinite 1.05s; }
+.mm-humo-3 { animation: mm-humo 3.2s ease-out infinite 2.1s; }
+
+.mm-troje-cuerpo { fill: var(--mm-troje-cuerpo); }
+.mm-troje-techo { fill: var(--mm-troje-techo); }
+.mm-troje-pata { fill: var(--mm-puerta); }
+.mm-troje-grano { fill: var(--mm-grano); }
+
+.mm-cafe-mata { fill: var(--mm-cafe-mata); }
+.mm-cafe-fruto { fill: var(--mm-cafe-fruto); }
+
+.mm-mercado-meson, .mm-mercado-tabla { fill: var(--mm-troje-cuerpo); }
+.mm-toldo-a { fill: var(--mm-toldo-a); }
+.mm-toldo-b { fill: var(--mm-toldo-b); }
+.mm-mercado-fruta-a { fill: var(--mm-fruta-a); }
+.mm-mercado-fruta-b { fill: var(--mm-fruta-b); }
+
+/* Cálido */
+.mm-mango-tronco { fill: none; stroke: var(--mm-tronco); stroke-width: 7; stroke-linecap: round; }
+.mm-mango-copa { fill: var(--mm-mango-copa); }
+.mm-mango-fruto { fill: var(--mm-mango-fruto); }
+.mm-platano-hoja { fill: var(--mm-platano-hoja); }
+.mm-platano-tallo { fill: var(--mm-platano-tallo); }
+.mm-racimo circle { fill: var(--mm-grano); }
+.mm-cana-tallo { fill: none; stroke: var(--mm-cana); stroke-width: 3.4; stroke-linecap: round; }
+.mm-piedra { fill: var(--mm-piedra); }
+
+/* Río: el agua baja siempre */
+.mm-flujo path {
+  fill: none;
+  stroke: var(--mm-flujo);
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-dasharray: 10 16;
+  animation: mm-baja 2.4s linear infinite;
+  opacity: 0.75;
+}
+
+/* Micelio: la red viva conecta los pisos (solo biopunk) */
+.mm-micelio { display: none; }
+.mm[data-dir='biopunk'] .mm-micelio {
+  display: block;
+  fill: none;
+  stroke: #67e8f9;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-dasharray: 2 9;
+  opacity: 0.65;
+  filter: drop-shadow(0 0 3px rgba(103, 232, 249, 0.8));
+  animation: mm-micelio-fluye 7s linear infinite;
+}
+.mm[data-dir='biopunk'] .mm-micelio-nodo {
+  fill: #a3e635;
+  stroke: none;
+  animation: mm-titila 2.8s ease-in-out infinite alternate;
+}
+
+/* Mariposas (solo verde vivo) */
+.mm-mariposas { display: none; }
+.mm[data-dir='verde'] .mm-mariposas { display: block; }
+.mm-mariposa-1 { fill: #f2a541; animation: mm-flota 3.6s ease-in-out infinite alternate; }
+.mm-mariposa-2 { fill: #e05f8a; animation: mm-flota 4.4s ease-in-out infinite alternate-reverse; }
+
+/* ── Vida de la escena ── */
+@keyframes mm-pulso {
+  0%, 100% { transform: scale(1); opacity: 0.95; }
+  50% { transform: scale(1.22); opacity: 0.55; }
+}
+
+@keyframes mm-respira {
+  from { transform: scale(1); }
+  to { transform: scale(1.05); }
+}
+
+@keyframes mm-humo {
+  0% { transform: translateY(0); opacity: 0.55; }
+  100% { transform: translateY(-18px); opacity: 0; }
+}
+
+@keyframes mm-baja {
+  from { stroke-dashoffset: 0; }
+  to { stroke-dashoffset: -52; }
+}
+
+@keyframes mm-micelio-fluye {
+  from { stroke-dashoffset: 0; }
+  to { stroke-dashoffset: -110; }
+}
+
+@keyframes mm-titila {
+  from { opacity: 0.35; }
+  to { opacity: 1; }
+}
+
+@keyframes mm-deriva {
+  from { transform: translateX(-12px); }
+  to { transform: translateX(14px); }
+}
+
+@keyframes mm-flota {
+  from { transform: translate(0, 0) rotate(-6deg); }
+  to { transform: translate(10px, -10px) rotate(8deg); }
+}
+
+/* La montaña se queda quieta si la persona lo pide */
+@media (prefers-reduced-motion: reduce) {
+  .mm *, .mm *::before, .mm *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/mockups/montana-mundos.css
+++ b/src/mockups/montana-mundos.css
@@ -632,6 +632,14 @@
   animation: mm-respira 4.6s ease-in-out infinite alternate;
 }
 
+.mm-pajonal path {
+  fill: none;
+  stroke: var(--mm-frailejon-hoja);
+  stroke-width: 2;
+  stroke-linecap: round;
+  opacity: 0.75;
+}
+
 .mm-laguna { fill: var(--mm-laguna); }
 .mm-laguna-brillo { fill: none; stroke: var(--mm-flujo); stroke-width: 1.6; stroke-linecap: round; opacity: 0.7; }
 


### PR DESCRIPTION
## Pasada 3 — el cine al máximo

Ruta: `#/mockups/montana-mundos-cine` (sin gate). Construida **sobre la pasada 2** (#2258, incluye sus commits); la pasada 1 sigue en `#/mockups/montana-mundos` para comparar.

### Qué suma esta pasada
1. **Profundidad de campo** — en el plano cercano (modo finca) la cámara enfoca la montaña principal: cielo, cordilleras y primer plano botánico quedan fuera de foco (blur estático por modo, **jamás animado** — el cambio se esconde bajo el viaje de cámara, cero costo por frame). En la montaña completa, foco profundo de paisaje.
2. **Transición pulida** — las capas cercanas asientan con leve sobrepaso (inercia de cámara con peso), las lejanas llegan suaves; el zoom-out a la montaña completa es majestuoso (duraciones escalonadas, el cielo asienta en ~1.9s). Nuevo estado `data-viaje`: mientras la cámara se mueve **la niebla se abre** y las etiquetas se retiran — vuelven al asentar el encuadre.
3. **Momento de llegada a la finca (el "wow")** — al arribar al piso de la finca (también al abrir la app): florece un bloom de hora dorada sobre la casa, dos anillos de luz se expanden, seis chispas suben como pavesas del fogón, el pin ⭐ aterriza con rebote y la ventana late dos veces — la montaña lo recibe en casa.
4. **Textura** — afloramientos de roca con vetas + pedrisco al pie del nevado, cicatrices foliares en el tronco del frailejón, jirones de niebla que derivan a contracorriente de los bancos (dos velocidades = volumen), destellos de hielo sobre la nieve.
5. **Vida ambiental por dirección** — bandada en V que cruza el cielo (naturalista/verde), colibrí que ronda los geranios del corredor (naturalista), luciérnagas que parpadean (biopunk), hojas que caen girando (verde vivo), los animales del corral pastan.

### Invariantes respetados
- SVG/CSS puro, cero deps, cero fotos. Solo `transform`/`opacity` animados; el blur de la profundidad de campo nunca se interpola.
- `prefers-reduced-motion`: plano final digno — sin vida animada ni momento de llegada (los elementos del wow tienen base `opacity: 0`).
- Se conserva todo lo validado: 3 direcciones conmutables, pellizco/rueda/deslizar, atajos permanentes Ⓐ + anotar, mundos tocables con aviso honesto.

### Verificación
- `npx vitest run` smoke del mockup: **12/12 verdes** (8 heredados + 4 nuevos: llegada al abrir, viaje de cámara, re-llegada al regresar, vida/textura montadas).
- `npm run build`: verde (14-16s).
- eslint: verde (de paso se corrigió `Date.now()` → `e.timeStamp` en el handler de rueda, regla react-hooks/purity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)