### PR TITLE
fix(restauracion): grounding de especies + nativas mal marcadas (audit 2026-07-09)

### DIFF
--- a/docs/RESTAURACION.md
+++ b/docs/RESTAURACION.md
@@ -13,3 +13,19 @@
 - Páramo → restauración PASIVA + Ley 1930
 - Retamo NO quemar (rebrota)
 - Densidad excesiva es MITO
+
+## Grounding (anti-fabricación)
+
+Toda especie de `restauracionFinca.js` y de `restauracion-especies.json` debe
+existir en `public/grafo-relations.json` (id real, no inventado) — lo
+verifican `RestauracionScreen.test.jsx` (mundo bosque de alimentos) y
+`restauracionEspecies.grounding.test.js` (lo que el LLM inyecta vía
+`restauracionDiagnostic.js`). Ver auditoría
+`Chagra-strategy/ops/AUDIT-RESTAURACION-GROUNDING-2026-07-09.md`.
+
+Trazabilidad conocida y documentada (NO corregida por alcance/riesgo del
+pipeline generado, ver nota en `restauracionFinca.js`): el id
+`albizia_guachapele` guarda el binomio *Albizia niopoides* (Iguá hoja
+menuda), no *Pseudosamanea guachapele* (el guachapele real, id
+`pseudosamanea_guachapele`). Ambos registros son especies nativas reales y
+correctas dentro de su propio id; solo el NOMBRE del slug es engañoso.

--- a/public/grafo-relations.json
+++ b/public/grafo-relations.json
@@ -15,13 +15,14 @@
       "threat_status",
       "conservation_status"
     ],
-    "species_count": 108,
+    "species_count": 129,
     "relation_count": 1297,
     "note": "Datos derivados del grafo AGE. NO contiene infraestructura ni secretos.",
     "pest_synonyms_count": 162,
     "pest_labels_count": 78,
     "pest_synonyms_added": "2026-06-25",
-    "frutales_tuberculos_fable_enriched": "2026-07-06"
+    "frutales_tuberculos_fable_enriched": "2026-07-06",
+    "restauracion_grounding_fix_2026_07_09": "+21 especies (audit AUDIT-RESTAURACION-GROUNDING-2026-07-09.md); establishment_means corregido en cordia_alliodora, tabebuia_rosea, enterolobium_cyclocarpum"
   },
   "_pest_synonyms": {
     "gota": "Tizon tardio / gota (papa y tomate)",
@@ -836,7 +837,7 @@
     "enterolobium_cyclocarpum": {
       "nombre_comun": "Orejero",
       "nombre_cientifico": "Enterolobium cyclocarpum (Jacq.) Griseb.",
-      "establishment_means": "introducido",
+      "establishment_means": "nativo",
       "threat_status": "LEAST_CONCERN",
       "conservation_status": "nativo_silvestre",
       "compatible_with": [
@@ -3127,7 +3128,7 @@
     "cordia_alliodora": {
       "nombre_comun": "Nogal cafetero",
       "nombre_cientifico": "Cordia alliodora (Ruiz & Pav.) Oken",
-      "establishment_means": "introducido",
+      "establishment_means": "nativo",
       "threat_status": "LEAST_CONCERN",
       "conservation_status": "nativo_silvestre",
       "compatible_with": [
@@ -3143,7 +3144,7 @@
     "tabebuia_rosea": {
       "nombre_comun": "Guayacán rosado",
       "nombre_cientifico": "Tabebuia rosea (Bertol.) DC.",
-      "establishment_means": "introducido",
+      "establishment_means": "nativo",
       "threat_status": "LEAST_CONCERN",
       "conservation_status": "nativo_silvestre",
       "compatible_with": [
@@ -4985,6 +4986,156 @@
           ]
         }
       ]
+    },
+    "ochroma_pyramidale": {
+      "nombre_comun": "Balso",
+      "nombre_cientifico": "Ochroma pyramidale (Cav. ex Lam.) Urb.",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "guazuma_ulmifolia": {
+      "nombre_comun": "Guácimo",
+      "nombre_cientifico": "Guazuma ulmifolia Lam.",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "trichanthera_gigantea": {
+      "nombre_comun": "Nacedero",
+      "nombre_cientifico": "Trichanthera gigantea (Bonpl.) Nees",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "guadua_angustifolia": {
+      "nombre_comun": "Guadua",
+      "nombre_cientifico": "Guadua angustifolia Kunth",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "cedrela_odorata": {
+      "nombre_comun": "Cedro",
+      "nombre_cientifico": "Cedrela odorata L.",
+      "establishment_means": "nativo",
+      "threat_status": "VULNERABLE",
+      "conservation_status": "nativo_protegido"
+    },
+    "anacardium_excelsum": {
+      "nombre_comun": "Caracolí",
+      "nombre_cientifico": "Anacardium excelsum (Bertero & Balb. ex Kunth) Skeels",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "ceiba_pentandra": {
+      "nombre_comun": "Ceiba",
+      "nombre_cientifico": "Ceiba pentandra (L.) Gaertn.",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "baccharis_latifolia": {
+      "nombre_comun": "Chilco",
+      "nombre_cientifico": "Baccharis latifolia (Ruiz & Pav.) Pers.",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "myrcianthes_leucoxyla": {
+      "nombre_comun": "Arrayán",
+      "nombre_cientifico": "Myrcianthes leucoxyla (Ortega) McVaugh",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_protegido"
+    },
+    "morella_pubescens": {
+      "nombre_comun": "Laurel de cera",
+      "nombre_cientifico": "Morella pubescens (Humb. & Bonpl. ex Willd.) Wilbur",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "cedrela_montana": {
+      "nombre_comun": "Cedro andino",
+      "nombre_cientifico": "Cedrela montana Moritz ex Turcz.",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_protegido"
+    },
+    "juglans_neotropica": {
+      "nombre_comun": "Nogal",
+      "nombre_cientifico": "Juglans neotropica Diels",
+      "establishment_means": "nativo",
+      "threat_status": "ENDANGERED",
+      "conservation_status": "nativo_protegido"
+    },
+    "hesperomeles_goudotiana": {
+      "nombre_comun": "Mortiño",
+      "nombre_cientifico": "Hesperomeles goudotiana (Decne.) Killip",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "polylepis_quadrijuga": {
+      "nombre_comun": "Polylepis / Colorado",
+      "nombre_cientifico": "Polylepis quadrijuga Bitter",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_protegido"
+    },
+    "ceroxylon_quindiuense": {
+      "nombre_comun": "Palma de cera del Quindío",
+      "nombre_cientifico": "Ceroxylon quindiuense (H.Karst.) H.Wendl.",
+      "establishment_means": "nativo",
+      "threat_status": "ENDANGERED",
+      "conservation_status": "nativo_protegido"
+    },
+    "diplostephium_rosmarinifolium": {
+      "nombre_comun": "Romero de páramo",
+      "nombre_cientifico": "Diplostephium rosmarinifolium (Benth.) Wedd.",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "hypericum_juniperinum": {
+      "nombre_comun": "Chite",
+      "nombre_cientifico": "Hypericum juniperinum Kunth",
+      "establishment_means": "nativo",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "nativo_silvestre"
+    },
+    "espeletia_grandiflora": {
+      "nombre_comun": "Frailejón",
+      "nombre_cientifico": "Espeletia grandiflora Humb. & Bonpl.",
+      "establishment_means": "nativo",
+      "threat_status": "LEAST_CONCERN",
+      "conservation_status": "nativo_protegido"
+    },
+    "genista_monspessulana": {
+      "nombre_comun": "Retamo liso",
+      "nombre_cientifico": "Genista monspessulana (L.) L.A.S.Johnson",
+      "establishment_means": "introducido",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "invasor"
+    },
+    "thunbergia_alata": {
+      "nombre_comun": "Ojo de poeta",
+      "nombre_cientifico": "Thunbergia alata Bojer ex Sims",
+      "establishment_means": "introducido",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "invasor"
+    },
+    "cenchrus_clandestinus": {
+      "nombre_comun": "Kikuyo",
+      "nombre_cientifico": "Cenchrus clandestinus (Hochst. ex Chiov.) Morrone",
+      "nombres_comunes": [
+        "pasto kikuyo"
+      ],
+      "establishment_means": "introducido",
+      "threat_status": "NOT_EVALUATED",
+      "conservation_status": "invasor"
     }
   }
 }

--- a/scripts/__tests__/fix-age-establishment-means-nativas-2026-07-09.test.mjs
+++ b/scripts/__tests__/fix-age-establishment-means-nativas-2026-07-09.test.mjs
@@ -1,0 +1,61 @@
+/**
+ * scripts/__tests__/fix-age-establishment-means-nativas-2026-07-09.test.mjs
+ *
+ * Cobertura del delta que corrige establishment_means para 3 nativas
+ * neotropicales mal marcadas 'introducido' en chagra_kg (audit
+ * AUDIT-RESTAURACION-GROUNDING-2026-07-09.md, hallazgo #3). Verifica que el
+ * delta solo toca las 3 especies esperadas, usa MERGE...SET (nunca
+ * CREATE/ON CREATE) y es idempotente.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { FIXES, buildStatements } from '../fix-age-establishment-means-nativas-2026-07-09.mjs';
+
+describe('FIXES — alcance exacto del delta', () => {
+  it('corrige exactamente las 3 especies del hallazgo #3, todas a nativo', () => {
+    expect(FIXES.map((f) => f.id).sort()).toEqual([
+      'cordia_alliodora',
+      'enterolobium_cyclocarpum',
+      'tabebuia_rosea',
+    ]);
+    for (const f of FIXES) expect(f.establishment_means).toBe('nativo');
+  });
+});
+
+describe('buildStatements', () => {
+  const stmts = buildStatements();
+
+  it('emite exactamente un statement por especie', () => {
+    expect(stmts).toHaveLength(FIXES.length);
+  });
+
+  it('nunca usa CREATE ni ON CREATE SET (solo MERGE + SET idempotente)', () => {
+    for (const s of stmts) {
+      expect(s).not.toMatch(/\bCREATE\s*\(/i);
+      expect(s).not.toMatch(/ON CREATE/i);
+    }
+  });
+
+  it('cada statement hace MERGE por id y SET solo establishment_means (no toca otros campos)', () => {
+    for (const f of FIXES) {
+      const s = stmts.find((st) => st.includes(`MERGE (n:Species {id: '${f.id}'})`));
+      expect(s, `falta statement para ${f.id}`).toBeTruthy();
+      expect(s).toContain("establishment_means: 'nativo'");
+      // El delta es de un solo campo: no debe traer otras props (threat_status,
+      // conservation_status, compatible_with...) que pisen lo ya cargado.
+      expect(s).not.toContain('threat_status');
+      expect(s).not.toContain('conservation_status');
+      expect(s).not.toContain('compatible_with');
+    }
+  });
+
+  it('corre contra el grafo chagra_kg', () => {
+    for (const s of stmts) {
+      expect(s).toContain("cypher('chagra_kg'");
+    }
+  });
+
+  it('es idempotente: correrlo dos veces produce el mismo output', () => {
+    expect(buildStatements()).toEqual(stmts);
+  });
+});

--- a/scripts/fix-age-establishment-means-nativas-2026-07-09.mjs
+++ b/scripts/fix-age-establishment-means-nativas-2026-07-09.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * scripts/fix-age-establishment-means-nativas-2026-07-09.mjs
+ *
+ * Corrige `establishment_means` para 3 especies neotropicales nativas que el
+ * grafo `chagra_kg` marca por error como `introducido`, CONTRADICIENDO su
+ * propio campo `conservation_status: 'nativo_silvestre'` en el mismo
+ * registro (verificado en public/grafo-relations.json y en
+ * catalog/chagra-catalog-oss-subset-v3.2.json, 2026-07-09):
+ *
+ *   - cordia_alliodora        (Cordia alliodora)         — Nogal cafetero
+ *   - tabebuia_rosea          (Tabebuia rosea)            — Guayacán rosado
+ *   - enterolobium_cyclocarpum (Enterolobium cyclocarpum) — Orejero
+ *
+ * Fuente del hallazgo: Chagra-strategy/ops/AUDIT-RESTAURACION-GROUNDING-2026-07-09.md
+ * (hallazgo #3, severidad media-alta). El error es contraproducente en
+ * restauración: `restauracionFinca.js` heredaba `establishment_means` para
+ * pintar el flag `nativo`, así que estas 3 nativas neotropicales excelentes
+ * (nodrizas/dosel) se le mostraban al campesino como si fueran exóticas.
+ *
+ * Las 3 especies son nativas neotropicales ampliamente documentadas
+ * (Cordia alliodora, Tabebuia rosea y Enterolobium cyclocarpum se distribuyen
+ * naturalmente en bosque seco/húmedo tropical de Colombia — no son
+ * introducidas de otro continente como sí lo son, por contraste, especies
+ * genuinamente exóticas del catálogo como Gliricidia sepium o Coffea
+ * arabica). El PR que acompaña este script corrige `restauracionFinca.js`
+ * (flag `nativo`) y `public/grafo-relations.json` (export offline) en el
+ * mismo commit; este script es el delta idempotente para replicar el mismo
+ * fix contra el grafo AGE vivo (`chagra_kg`) cuando el operador decida
+ * aplicarlo.
+ *
+ * Patrón MERGE...SET (memoria reference-age-ingest-mecanica-gotchas): usa
+ * `emitNode()` de catalog-to-age.mjs, que hace
+ * `MERGE (n:Species {id: <slug>}) SET n += {establishment_means: 'nativo'}`
+ * — SET con `+=` solo TOCA el campo indicado, preserva el resto del nodo
+ * (compatible_with, threat_status, etc.), y MERGE nunca duplica porque el
+ * id ya existe en el grafo.
+ *
+ * Este script NO se conecta a postgres/AGE ni ejecuta nada contra el grafo
+ * de producción — solo imprime (o escribe con --out) el .sql idempotente
+ * para revisión humana, igual que el resto de los loaders de scripts/.
+ *
+ * Uso:
+ *   node scripts/fix-age-establishment-means-nativas-2026-07-09.mjs > fix.sql
+ *   node scripts/fix-age-establishment-means-nativas-2026-07-09.mjs --out .local/fix.sql
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import { emitNode, wrapCypher } from './catalog-to-age.mjs';
+
+const GRAPH = 'chagra_kg';
+
+/**
+ * Las 3 especies a corregir. `establishment_means: 'nativo'` es el ÚNICO
+ * campo que este delta toca — MERGE + `SET n +=` preserva todo lo demás del
+ * nodo ya cargado en chagra_kg.
+ */
+export const FIXES = [
+  { id: 'cordia_alliodora', nombre_comun: 'Nogal cafetero', establishment_means: 'nativo' },
+  { id: 'tabebuia_rosea', nombre_comun: 'Guayacán rosado', establishment_means: 'nativo' },
+  { id: 'enterolobium_cyclocarpum', nombre_comun: 'Orejero', establishment_means: 'nativo' },
+];
+
+/** Construye la lista de statements SQL (uno MERGE...SET por especie). */
+export function buildStatements() {
+  return FIXES.map((f) => wrapCypher(GRAPH, emitNode('Species', {
+    id: f.id,
+    establishment_means: f.establishment_means,
+  })));
+}
+
+function buildSql() {
+  const header = [
+    '-- fix-age-establishment-means-nativas-2026-07-09',
+    '-- Delta idempotente (MERGE...SET, NUNCA CREATE / ON CREATE) que corrige',
+    "-- establishment_means: 'introducido' -> 'nativo' para 3 especies neotropicales",
+    '-- nativas mal marcadas (contradecian su propio conservation_status).',
+    '-- Fuente: Chagra-strategy/ops/AUDIT-RESTAURACION-GROUNDING-2026-07-09.md (hallazgo #3).',
+    '-- Generado por scripts/fix-age-establishment-means-nativas-2026-07-09.mjs',
+    `-- Especies corregidas: ${FIXES.map((f) => f.id).join(', ')}`,
+    "LOAD 'age';",
+    'SET search_path = ag_catalog, "$user", public;',
+    '',
+  ].join('\n');
+  return `${header}\n${buildStatements().join('\n')}\n`;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const outIdx = argv.indexOf('--out');
+  const sql = buildSql();
+  if (outIdx !== -1 && argv[outIdx + 1]) {
+    const outPath = resolve(process.cwd(), argv[outIdx + 1]);
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, sql, 'utf8');
+    process.stderr.write(`[fix-establishment-means] SQL -> ${argv[outIdx + 1]} (${FIXES.length} especies)\n`);
+  } else {
+    process.stdout.write(sql);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/src/data/restauracion-especies.json
+++ b/src/data/restauracion-especies.json
@@ -10,8 +10,7 @@
       ],
       "intermedias": [
         { "nombre": "Nacedero", "cientifico": "Trichanthera gigantea", "nota": "Forrajera, ripario" },
-        { "nombre": "Guadua", "cientifico": "Guadua angustifolia", "nota": "Bambu nativo, fija laderas" },
-        { "nombre": "Caniafistula", "cientifico": "Cassia fistula", "nota": "Ornamental, nitrogeno" }
+        { "nombre": "Guadua", "cientifico": "Guadua angustifolia", "nota": "Bambu nativo, fija laderas" }
       ],
       "climax": [
         { "nombre": "Cedro", "cientifico": "Cedrela odorata", "nota": "Madera noble, lento" },
@@ -56,16 +55,13 @@
       ],
       "intermedias": [
         { "nombre": "Frailejon", "cientifico": "Espeletia grandiflora", "nota": "1 cm/ano de crecimiento. 200-300 anos de vida. NO trasplantar adulto" }
-      ],
-      "climax": [
-        { "nombre": "Frailejonal maduro", "cientifico": "Complejo Espeletia spp.", "nota": "Ecosistema paramuno maduro. Captura niebla = agua" }
       ]
     }
   },
   "invasoras_manejo": [
     { "nombre": "Retamo espinoso", "cientifico": "Ulex europaeus", "manejo": "Control manual antes de floracion. NO quemar (rebrota). Minimo 3 anos de seguimiento." },
     { "nombre": "Retamo liso", "cientifico": "Genista monspessulana", "manejo": "Similar al retamo espinoso. Raiz profunda, arrancar completo." },
-    { "nombre": "Kikuyo", "cientifico": "Pennisetum clandestinum", "manejo": "Sombreado con pioneras de rapido crecimiento. Mulch denso." },
+    { "nombre": "Kikuyo", "cientifico": "Cenchrus clandestinus", "manejo": "Sombreado con pioneras de rapido crecimiento. Mulch denso." },
     { "nombre": "Ojo de poeta", "cientifico": "Thunbergia alata", "manejo": "Control manual. Trepadora invasora de bordes de bosque." }
   ]
 }

--- a/src/data/restauracion.json
+++ b/src/data/restauracion.json
@@ -4,7 +4,7 @@
   "roles_sucesion": {
     "calido_0_1000": {
       "pioneras": ["balso", "matarraton", "guacimo"],
-      "intermedias": ["nacedero", "guadua", "caniafistula"],
+      "intermedias": ["nacedero", "guadua"],
       "climax": ["cedro", "caracoli", "ceiba"]
     },
     "templado_1000_2000": {
@@ -33,7 +33,7 @@
   "invasoras": [
     { "nombre": "Retamo espinoso (Ulex europaeus)", "manejo": "Control manual antes de floracion. NO quemar (rebrota). Minimo 3 anos de seguimiento." },
     { "nombre": "Retamo liso (Genista monspessulana)", "manejo": "Similar al retamo espinoso." },
-    { "nombre": "Kikuyo (Pennisetum clandestinum)", "manejo": "Pastoreo controlado, mulch denso, cobertura de nativas." },
+    { "nombre": "Kikuyo (Cenchrus clandestinus)", "manejo": "Pastoreo controlado, mulch denso, cobertura de nativas." },
     { "nombre": "Ojo de poeta (Thunbergia alata)", "manejo": "Control manual. Trepadora invasora de bordes." }
   ],
   "normativa": [

--- a/src/data/restauracionFinca.js
+++ b/src/data/restauracionFinca.js
@@ -175,9 +175,9 @@ export const ESTRATOS = [
     especies: [
       { id: 'samanea_saman', comun: 'Samán', cientifico: 'Samanea saman', nativo: true },
       { id: 'quercus_humboldtii', comun: 'Roble negro andino', cientifico: 'Quercus humboldtii', nativo: true },
-      { id: 'cordia_alliodora', comun: 'Nogal cafetero', cientifico: 'Cordia alliodora', nativo: false },
-      { id: 'tabebuia_rosea', comun: 'Guayacán rosado', cientifico: 'Tabebuia rosea', nativo: false },
-      { id: 'enterolobium_cyclocarpum', comun: 'Orejero', cientifico: 'Enterolobium cyclocarpum', nativo: false },
+      { id: 'cordia_alliodora', comun: 'Nogal cafetero', cientifico: 'Cordia alliodora', nativo: true },
+      { id: 'tabebuia_rosea', comun: 'Guayacán rosado', cientifico: 'Tabebuia rosea', nativo: true },
+      { id: 'enterolobium_cyclocarpum', comun: 'Orejero', cientifico: 'Enterolobium cyclocarpum', nativo: true },
       { id: 'euterpe_oleracea', comun: 'Asaí', cientifico: 'Euterpe oleracea', nativo: true },
     ],
   },
@@ -309,10 +309,10 @@ export const SUCESION_ETAPAS = [
     titulo: 'Bosque maduro (para el largo plazo)',
     detalle: 'Crecen despacio pero llegan lejos: se siembran bajo la sombra que hicieron las pioneras y son el bosque que queda — madera, dosel y refugio de fauna.',
     especies: [
-      { id: 'cordia_alliodora', comun: 'Nogal cafetero', cientifico: 'Cordia alliodora', nativo: false, rol: 'Madera fina · dosel' },
+      { id: 'cordia_alliodora', comun: 'Nogal cafetero', cientifico: 'Cordia alliodora', nativo: true, rol: 'Madera fina · dosel' },
       { id: 'quercus_humboldtii', comun: 'Roble negro andino', cientifico: 'Quercus humboldtii', nativo: true, rol: 'Clímax andino · protegido' },
       { id: 'weinmannia_tomentosa', comun: 'Encenillo', cientifico: 'Weinmannia tomentosa', nativo: true, rol: 'Bosque altoandino · borde de páramo' },
-      { id: 'tabebuia_rosea', comun: 'Guayacán rosado', cientifico: 'Tabebuia rosea', nativo: false, rol: 'Dosel · flor para polinizadores' },
+      { id: 'tabebuia_rosea', comun: 'Guayacán rosado', cientifico: 'Tabebuia rosea', nativo: true, rol: 'Dosel · flor para polinizadores' },
     ],
   },
 ];
@@ -368,9 +368,19 @@ export const ESPECIES_RESTAURACION = [
   { id: 'erythrina_edulis', comun: 'Chachafruto / Balú', cientifico: 'Erythrina edulis', nativo: false, papeles: ['Fija N', 'Comida', 'Cerca viva'], nota: 'Fija nitrógeno y da un fruto proteico; sirve de cerca viva y de sombra.' },
   { id: 'gliricidia_sepium', comun: 'Matarratón', cientifico: 'Gliricidia sepium', nativo: false, papeles: ['Fija N', 'Cerca viva', 'Poda-y-tira', 'Forraje'], nota: 'Prende de estaca: cerca viva que se poda seguido para tapar el suelo y alimentar animales.' },
   { id: 'samanea_saman', comun: 'Samán', cientifico: 'Samanea saman', nativo: true, papeles: ['Dosel amplio', 'Fija N', 'Sombra'], nota: 'Copa enorme para sombra de potrero; leguminosa que enriquece el suelo debajo.' },
+  // NOTA DE TRAZABILIDAD (audit AUDIT-RESTAURACION-GROUNDING-2026-07-09.md,
+  // hallazgo #6): el id `albizia_guachapele` es historico y ENGAÑA por nombre
+  // — guarda el binomio real *Albizia niopoides* (Iguá hoja menuda), NO
+  // *Pseudosamanea guachapele* (el guachapele verdadero, que vive aparte bajo
+  // el id `pseudosamanea_guachapele` en el catálogo). Ambas son especies
+  // nativas reales y el binomio mostrado aquí (Albizia niopoides) es
+  // correcto — el defecto es solo el NOMBRE del slug, no el dato. No se
+  // renombra en este PR (tocaría catalog/*.json + public/rag-embeddings.json
+  // + public/cycle-content/, generados por el pipeline AGE, fuera de
+  // alcance); queda documentado para quien lo traiga junto con esos exports.
   { id: 'albizia_guachapele', comun: 'Iguá', cientifico: 'Albizia niopoides', nativo: true, papeles: ['Fija N', 'Madera'], nota: 'Nativa maderable que fija nitrógeno: buena para enriquecer y dar sombra alta.' },
-  { id: 'cordia_alliodora', comun: 'Nogal cafetero', cientifico: 'Cordia alliodora', nativo: false, papeles: ['Madera fina', 'Dosel'], nota: 'Madera valiosa que convive con el café; se autopoda y deja pasar luz.' },
-  { id: 'tabebuia_rosea', comun: 'Guayacán rosado', cientifico: 'Tabebuia rosea', nativo: false, papeles: ['Dosel', 'Flor / néctar', 'Madera'], nota: 'Florece en rosado y alimenta polinizadores; madera y sombra alta.' },
+  { id: 'cordia_alliodora', comun: 'Nogal cafetero', cientifico: 'Cordia alliodora', nativo: true, papeles: ['Madera fina', 'Dosel'], nota: 'Madera valiosa que convive con el café; se autopoda y deja pasar luz.' },
+  { id: 'tabebuia_rosea', comun: 'Guayacán rosado', cientifico: 'Tabebuia rosea', nativo: true, papeles: ['Dosel', 'Flor / néctar', 'Madera'], nota: 'Florece en rosado y alimenta polinizadores; madera y sombra alta.' },
   { id: 'vaccinium_meridionale', comun: 'Mortino / Agraz', cientifico: 'Vaccinium meridionale', nativo: true, papeles: ['Arbusto nativo', 'Fruto silvestre'], nota: 'Arbusto altoandino nativo para restaurar y cosechar fruto silvestre.' },
   { id: 'mucuna_pruriens', comun: 'Fríjol terciopelo', cientifico: 'Mucuna pruriens', nativo: false, papeles: ['Abono verde', 'Fija N', 'Cobertura'], nota: 'Abono verde de choque: tapa el suelo rápido, ahoga la maleza y fija nitrógeno.' },
   { id: 'urtica_dioica', comun: 'Ortiga', cientifico: 'Urtica dioica', nativo: false, papeles: ['Dinamizadora', 'Biomasa', 'Purín'], nota: 'Acumula minerales en su hoja: se corta para mantillo o purín que dinamiza el suelo.' },

--- a/src/services/__tests__/restauracionEspecies.grounding.test.js
+++ b/src/services/__tests__/restauracionEspecies.grounding.test.js
@@ -1,0 +1,123 @@
+/**
+ * restauracionEspecies.grounding.test.js
+ *
+ * GROUNDING de src/data/restauracion-especies.json — la fuente que el LLM
+ * REALMENTE inyecta en el prompt vía
+ * restauracionDiagnostic.formatearGroundingRestauracion() (con la
+ * instrucción "usa SOLO estas, NO inventes otras").
+ *
+ * Motivo (auditoría Chagra-strategy/ops/AUDIT-RESTAURACION-GROUNDING-2026-07-09.md):
+ * `restauracionFinca.js` (mundo "bosque de alimentos") YA tenía este candado
+ * — ver el bloque "GROUNDING" en RestauracionScreen.test.jsx, que cruza cada
+ * id contra public/grafo-relations.json. Pero `restauracion-especies.json`
+ * NO lo tenía: 23 de 31 especies eran binomios reales pero "colgados" (sin
+ * respaldo del catálogo) — exactamente el hueco por donde se reabriría el
+ * modo de falla histórico (memoria feedback-restauracion-grounding-fabrica-
+ * especies) si alguien edita este archivo sin este test.
+ *
+ * Este test le aplica a restauracion-especies.json el MISMO candado: cada
+ * entrada con campo `cientifico` (en especies_por_rol.*.* y en
+ * invasoras_manejo) debe resolver, por binomio género+especie normalizado, a
+ * una especie real de public/grafo-relations.json.
+ *
+ * Las 23 especies colgadas encontradas por la auditoría se resolvieron así
+ * (ver PR que introduce este test):
+ *   - 21 eran binomios reales y andinos/colombianos → se añadieron al
+ *     catálogo (public/grafo-relations.json).
+ *   - "Cassia fistula" (cañafístula) → exótica del subcontinente indio, NO
+ *     fija nitrógeno (Caesalpinioideae) → se sacó del injector.
+ *   - "Complejo Espeletia spp." → agregado de género sin epíteto específico
+ *     (no es un binomio real sluggeable, mismo criterio que
+ *     scripts/load-age-paramo-species-2026-07-09.mjs) → se sacó del injector.
+ *   - "Pennisetum clandestinum" (kikuyo) → sinonimia: el nombre aceptado hoy
+ *     es Cenchrus clandestinus → se corrigió el campo `cientifico`.
+ */
+// @types/node no está instalado en el repo (gap conocido, ver
+// RestauracionScreen.test.jsx / dataJsonValidity.test.js): tsc no resuelve
+// los specifiers "node:*". Runtime (vitest/node) sí los resuelve.
+// @ts-expect-error TS2591 — ver comentario arriba.
+import fs from 'node:fs';
+// @ts-expect-error TS2591 — ver comentario arriba.
+import path from 'node:path';
+// @ts-expect-error TS2591 — ver comentario arriba.
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import ESPECIES_DATA from '../../data/restauracion-especies.json';
+
+// El grafo es el mismo que consume la app en runtime (public/grafo-relations).
+// Se lee del disco para no acoplar el test a fetch ni a un import JSON.
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+const grafoPath = path.resolve(__dir, '../../../public/grafo-relations.json');
+const grafo = JSON.parse(fs.readFileSync(grafoPath, 'utf8'));
+const species = grafo.species || {};
+
+/**
+ * Normaliza un binomio ("Cordia alliodora (Ruiz & Pav.) Oken") a
+ * `genero_especie` en minúsculas, sin autor ni acentos — mismo criterio que
+ * `binomialSlug()` de scripts/load-age-paramo-species-2026-07-09.mjs, para
+ * poder cruzar el nombre científico de restauracion-especies.json (que no
+ * trae id de catálogo) contra los slugs reales del grafo.
+ */
+function binomKey(nombreCientifico) {
+  const cleaned = String(nombreCientifico || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '');
+  const tokens = cleaned
+    .trim()
+    .split(/\s+/)
+    .map((t) => t.toLowerCase().replace(/[^a-z]/g, ''));
+  const [genus, epithet] = tokens;
+  if (!genus || !epithet) return null;
+  return `${genus}_${epithet}`;
+}
+
+const CATALOG_BINOMIOS = new Set(
+  Object.values(species)
+    .map((sp) => binomKey(sp.nombre_cientifico))
+    .filter(Boolean),
+);
+
+/** Junta todas las entradas con `cientifico` de restauracion-especies.json. */
+function todasLasEntradas() {
+  const entradas = [];
+  const roles = ESPECIES_DATA.especies_por_rol || {};
+  for (const [piso, grupos] of Object.entries(roles)) {
+    for (const [rol, arr] of Object.entries(grupos || {})) {
+      for (const e of arr || []) entradas.push({ piso, rol, ...e });
+    }
+  }
+  for (const e of ESPECIES_DATA.invasoras_manejo || []) {
+    entradas.push({ piso: null, rol: 'invasora', ...e });
+  }
+  return entradas;
+}
+
+describe('restauracion-especies.json — grounding contra el catálogo (anti-fabricación)', () => {
+  const entradas = todasLasEntradas();
+
+  it('el archivo tiene contenido (no quedó vacío por un error de edición)', () => {
+    expect(entradas.length).toBeGreaterThan(10);
+  });
+
+  it('cada entrada trae un binomio de 2+ tokens (nada de "Complejo X spp.")', () => {
+    for (const e of entradas) {
+      expect(
+        binomKey(e.cientifico),
+        `binomio no-parseable (¿solo género, sin epíteto?): ${e.nombre} (${e.cientifico})`,
+      ).toBeTruthy();
+    }
+  });
+
+  it('cada especie referida EXISTE en el catálogo (public/grafo-relations.json) — 0 colgadas', () => {
+    const colgadas = entradas.filter((e) => !CATALOG_BINOMIOS.has(binomKey(e.cientifico)));
+    const detalle = colgadas
+      .map((e) => `${e.nombre} (${e.cientifico}) [${e.piso ?? 'invasora'}/${e.rol}]`)
+      .join('; ');
+    expect(colgadas, `especies sin respaldo del catálogo: ${detalle}`).toHaveLength(0);
+  });
+
+  it('Cassia fistula (cañafístula, exótica del subcontinente indio) NO está en las recomendaciones', () => {
+    const presente = entradas.some((e) => binomKey(e.cientifico) === 'cassia_fistula');
+    expect(presente, 'Cassia fistula debe estar fuera del injector (hallazgo #1 de la auditoría)').toBe(false);
+  });
+});

--- a/src/services/restauracionDiagnostic.js
+++ b/src/services/restauracionDiagnostic.js
@@ -73,7 +73,11 @@ export function formatearGroundingRestauracion(d) {
   const partes = [];
   if (d.arreglo) partes.push(`**Arreglo recomendado:** ${d.arreglo.nombre} — ${d.arreglo.detalle} (${d.arreglo.densidad}).`);
   if (d.especies) {
-    partes.push('**Sucesion ecologica — especies nativas de tu piso termico (usa SOLO estas, NO inventes otras):**');
+    // No todas las especies de la lista son nativas (p. ej. matarraton/guamo son
+    // introducidas de uso agroforestal legitimo) — el rotulo "nativas" aqui era
+    // una sobre-generalizacion falsa (audit AUDIT-RESTAURACION-GROUNDING-2026-07-09.md,
+    // hallazgo #1/#11). Se deja "verificadas" (existen en el catalogo), no "nativas".
+    partes.push('**Sucesion ecologica — especies verificadas de tu piso termico (usa SOLO estas, NO inventes otras):**');
     const fmt = (arr) => arr.map((e) => `${e.nombre} (${e.cientifico})${e.nota ? ` — ${e.nota}` : ''}`).join('; ');
     if (d.especies.pioneras) partes.push(`- Pioneras: ${fmt(d.especies.pioneras)}`);
     if (d.especies.intermedias) partes.push(`- Intermedias: ${fmt(d.especies.intermedias)}`);
@@ -86,7 +90,7 @@ export function formatearGroundingRestauracion(d) {
   }
   if (d.alertas.length > 0) { partes.push('**ALERTAS:**'); d.alertas.forEach((a) => partes.push(`- ${a}`)); }
   if (d.guardas.length > 0) { partes.push('**GUARDAS:**'); d.guardas.forEach((g) => partes.push(`- ${g}`)); }
-  partes.push('IMPORTANTE: recomienda SOLO especies nativas verificadas de la lista anterior; si no hay lista para este piso, dilo y sugiere el vivero local o la CAR. NUNCA inventes nombres de especies.');
+  partes.push('IMPORTANTE: recomienda SOLO especies verificadas de la lista anterior (indica si cada una es nativa o introducida, no asumas que todas son nativas); si no hay lista para este piso, dilo y sugiere el vivero local o la CAR. NUNCA inventes nombres de especies.');
   partes.push(`Fuente: ${d.fuente}`);
   return partes.join('\n\n');
 }


### PR DESCRIPTION
Corrige los hallazgos de la auditoría de grounding de restauración (`ops/AUDIT-RESTAURACION-GROUNDING-2026-07-09.md`).

## 1. Candado de grounding para `restauracion-especies.json`
Esta es la fuente que el LLM **realmente inyecta** vía `restauracionDiagnostic.formatearGroundingRestauracion()`. Antes solo 8/31 especies existían en el catálogo; las otras 23 estaban "colgadas" (binomios reales, pero sin la red de seguridad del grafo) — el hueco por donde reaparecería el modo de falla histórico de fabricación de especies.

Nuevo test `restauracionEspecies.grounding.test.js` cruza cada binomio (género+especie normalizado, mismo criterio que `binomialSlug` del loader de páramo) contra `public/grafo-relations.json` y **falla si alguna especie no está en el catálogo** — el mismo candado que ya protegía `restauracionFinca.js` (ver bloque GROUNDING en `RestauracionScreen.test.jsx`).

Resolución de las 23 colgadas (no se borraron a ciegas):
- **+21 binomios reales andinos/colombianos añadidos al catálogo** (`grafo-relations.json`, 108→129 especies): balso, guácimo, nacedero, guadua, cedro, caracolí, ceiba, chilco, arrayán, laurel de cera, cedro andino, nogal, mortiño, polylepis, palma de cera, romero de páramo, chite, frailejón, retamo liso, ojo de poeta, kikuyo. `establishment_means`/`conservation_status`/`threat_status` tomados de los `cycle-content/<slug>.json` ya vetados cuando existen; UICN solo con alta confianza (si no, `NOT_EVALUATED` — no se inventa categoría).
- **`Cassia fistula` (cañafístula)** — hallazgo 🔴: exótica del subcontinente indio que **NO fija nitrógeno** (Caesalpinioideae, no nodula). Sacada del injector; además se corrige el rótulo falso "especies **nativas**" del formateador y la nota "nitrogeno".
- **"Complejo Espeletia spp."** — agregado de género sin epíteto específico (no es un binomio sluggeable): sacado del injector.
- **Kikuyo** — sinonimia: `Pennisetum clandestinum` → nombre aceptado hoy `Cenchrus clandestinus`.

## 2. Tres nativas neotropicales mal marcadas `introducido`
`cordia_alliodora`, `tabebuia_rosea`, `enterolobium_cyclocarpum` tenían `establishment_means: 'introducido'` contradiciendo su propio `conservation_status: 'nativo_silvestre'`. En restauración esto desalienta árboles nativos excelentes (nodrizas/dosel) presentándolos como exóticos.
- Corregido `establishment_means`→`'nativo'` en `grafo-relations.json` y el flag `nativo` en `restauracionFinca.js`.
- Script **MERGE...SET idempotente** `scripts/fix-age-establishment-means-nativas-2026-07-09.mjs` (estilo `load-age-*.mjs`) para replicar el fix contra el grafo vivo `chagra_kg` — **NO ejecutado contra el grafo**, solo genera el SQL para revisión humana. Con su test.

## 3. Slug engañoso `albizia_guachapele`
Guarda `Albizia niopoides` (el guachapele real es *Pseudosamanea guachapele*, id `pseudosamanea_guachapele`). Ambos registros son nativas reales correctas dentro de su id; solo el nombre del slug engaña. **Documentada la trazabilidad** en `restauracionFinca.js` y `docs/RESTAURACION.md` sin renombrar (renombrar tocaría `catalog/*.json` + `rag-embeddings.json` + `cycle-content/`, generados por el pipeline AGE — fuera de alcance).

## Verificación
- `npm run build` ✅
- vitest de lo tocado: **96 verdes** (grounding restauración nuevo + `RestauracionScreen` + `restauracionDiagnostic` + `restauracionRecetaFormatter` + `carbonoSeguimiento` + `load-age-paramo-species` + `grafoRelations` + el test del nuevo script). Sin Playwright.
- eslint + guards de lefthook (secret/infra/estratégico/voseo) verificados manualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)