### PR TITLE
fix(a11y): contraste y tamaño legible (hallazgos ALTA botica/glaciar/agente/ciclo)

### DIFF
--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -378,7 +378,7 @@ function ProactiveGreeting({ greeting }) {
       )}
 
       {isPending && restCount > 0 && (
-        <p className="text-[11px] text-slate-500 mb-3" data-testid="proactive-greeting-rest">
+        <p className="text-[11px] text-slate-400 mb-3" data-testid="proactive-greeting-rest">
           {restCount === 1
             ? 'Hay 1 pendiente más en la campana 🔔.'
             : `Hay ${restCount} pendientes más en la campana 🔔.`}

--- a/src/components/CicloVivo/cicloVivo.css
+++ b/src/components/CicloVivo/cicloVivo.css
@@ -189,6 +189,13 @@
   background: var(--cv-cream-2); font-size: 12px; color: var(--cv-ink-soft);
   display: flex; align-items: center; justify-content: center; border: none; cursor: pointer;
 }
+/* Target táctil de 44px (a11y) sin alterar el círculo visible de 30px:
+   overlay transparente centrado; el pseudo-elemento recibe el toque por el botón. */
+.cv-sheet-close::after {
+  content: ""; position: absolute; top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: 44px; height: 44px; border-radius: 50%;
+}
 .cv-sheet-header { display: flex; align-items: center; gap: 13px; margin-bottom: 4px; padding-right: 34px; }
 .cv-sheet-glyph {
   width: 58px; height: 58px; border-radius: 19px; flex-shrink: 0;

--- a/src/components/GlaciarReporteScreen.jsx
+++ b/src/components/GlaciarReporteScreen.jsx
@@ -435,7 +435,7 @@ export default function GlaciarReporteScreen({ onBack, onVerHistorial = null }) 
               placeholder="ej. RITACUBA-FRENTE-01"
               className="w-full p-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white outline-none focus:border-sky-500"
             />
-            <p className="text-[11px] text-slate-500 mt-1">
+            <p className="text-[11px] text-slate-400 mt-1">
               Repita el mismo id en cada visita: así se ve cuánto retrocede el frente del hielo.
             </p>
 
@@ -518,7 +518,7 @@ export default function GlaciarReporteScreen({ onBack, onVerHistorial = null }) 
               placeholder="ej. 135"
               icon={<Compass size={18} />}
             />
-            <p className="text-[11px] text-slate-500 mt-1">
+            <p className="text-[11px] text-slate-400 mt-1">
               Anote hacia dónde apunta la cámara: clave para repetir el mismo encuadre con el tiempo.
             </p>
 
@@ -565,7 +565,7 @@ export default function GlaciarReporteScreen({ onBack, onVerHistorial = null }) 
               <Layers size={16} className="text-sky-300" />
               <Label className="mb-0">Perfil por capas (superficie → fondo)</Label>
             </div>
-            <p className="text-[11px] text-slate-500 mb-3">
+            <p className="text-[11px] text-slate-400 mb-3">
               La capa de arriba manda el tránsito. Agregue capas más profundas para contar la historia del hielo.
             </p>
             <div className="space-y-3">

--- a/src/components/botica/BoticaScreen.jsx
+++ b/src/components/botica/BoticaScreen.jsx
@@ -64,7 +64,7 @@ function FotoBotica({ slug, alt, ratio = 'aspect-[16/10]', rounded = '', Fallbac
   const credito = creditoDe(slug);
   const IconoFallback = Fallback;
   return (
-    <div className={`relative overflow-hidden bg-[#182016] ${ratio} ${rounded}`}>
+    <div className={`relative overflow-hidden bg-surface-card ${ratio} ${rounded}`}>
       {ok ? (
         <img
           src={`${FOTO_BASE_BOTICA}/${slug}.jpg`}
@@ -137,7 +137,7 @@ function PlantaCard({ planta }) {
   const peligrosa = p.grupo === 'cuidado';
   return (
     <article
-      className={`rounded-2xl border overflow-hidden ${peligrosa ? 'border-rose-700/50 bg-rose-950/20' : 'border-emerald-900/40 bg-[#141b12]/60'}`}
+      className={`rounded-2xl border overflow-hidden ${peligrosa ? 'border-rose-700/50 bg-rose-950/20' : 'border-emerald-900/40 bg-surface-card/60'}`}
       data-testid={`planta-${p.slug}`}
     >
       <FotoBotica
@@ -175,7 +175,7 @@ function PlantaCard({ planta }) {
           )}
           <p className="text-sm leading-snug text-slate-200">{p.usoTradicional}</p>
           {p.comoSePrepara && (
-            <p className="mt-1.5 flex items-start gap-1.5 text-[11px] leading-snug text-slate-400">
+            <p className="mt-1.5 flex items-start gap-1.5 text-2xs leading-snug text-slate-400">
               <Info size={12} aria-hidden="true" className="shrink-0 mt-0.5 text-slate-500" />
               <span><span className="font-bold text-slate-300">En la casa:</span> {p.comoSePrepara}</span>
             </p>
@@ -185,7 +185,7 @@ function PlantaCard({ planta }) {
         {/* Veto de seguridad honesto (cuando la mata lo pide) */}
         {p.veto && (
           <div className="rounded-lg border border-rose-600/50 bg-rose-950/30 p-2.5" data-testid={`veto-${p.slug}`}>
-            <p className="flex items-start gap-1.5 text-[11px] leading-snug text-rose-100">
+            <p className="flex items-start gap-1.5 text-2xs leading-snug text-rose-100">
               <TriangleAlert size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-rose-300" />
               <span><span className="font-black uppercase tracking-wide">Cuidado:</span> {p.veto}</span>
             </p>
@@ -213,7 +213,7 @@ function PlantaCard({ planta }) {
           </div>
         )}
 
-        <p className="text-[10px] leading-snug text-slate-500">
+        <p className="text-[10px] leading-snug text-slate-400">
           Cultivo groundeado en el catálogo Chagra (piso térmico, luz, agua, propagación). Usos: saber popular campesino.
         </p>
       </div>
@@ -256,7 +256,7 @@ function EstacionCultivo() {
       </PedagogicalBlock>
 
       {/* Tabla-resumen del piso térmico de cada mata (grounded) */}
-      <div className="rounded-2xl border border-slate-700/60 bg-[#141b12]/50 overflow-hidden" data-testid="botica-tabla-cultivo">
+      <div className="rounded-2xl border border-slate-700/60 bg-surface-card/50 overflow-hidden" data-testid="botica-tabla-cultivo">
         <div className="p-3 border-b border-slate-700/60">
           <p className="flex items-center gap-2 text-sm font-black text-emerald-200 uppercase tracking-wide">
             <Mountain size={16} aria-hidden="true" /> Qué mata en qué clima
@@ -283,7 +283,7 @@ function EstacionCultivo() {
       </div>
 
       {/* Cómo secar y guardar (común a toda la botica) */}
-      <div className="rounded-2xl border border-amber-800/40 bg-[#141b12]/50 p-4 space-y-2" data-testid="botica-secado">
+      <div className="rounded-2xl border border-amber-800/40 bg-surface-card/50 p-4 space-y-2" data-testid="botica-secado">
         <p className="flex items-center gap-2 text-sm font-black text-amber-200 uppercase tracking-wide">
           <Scissors size={16} aria-hidden="true" /> Cosechar, secar y guardar
         </p>
@@ -311,7 +311,7 @@ function EstacionCuidado({ onNavigate }) {
       </div>
 
       {/* Reglas de seguridad honestas */}
-      <div className="rounded-2xl border border-slate-700/60 bg-[#141b12]/50 p-4 space-y-3" data-testid="botica-reglas">
+      <div className="rounded-2xl border border-slate-700/60 bg-surface-card/50 p-4 space-y-3" data-testid="botica-reglas">
         <p className="flex items-center gap-2 text-sm font-black text-slate-100 uppercase tracking-wide">
           <ShieldCheck size={16} aria-hidden="true" className="text-emerald-300" /> Reglas de la casa
         </p>
@@ -363,7 +363,7 @@ function CreditosFotos() {
   const [abierto, setAbierto] = useState(false);
   if (!CREDITOS_FOTOS_BOTICA.length) return null;
   return (
-    <div className="rounded-xl border border-slate-700/60 bg-[#141b12]/50 p-3" data-testid="botica-creditos-fotos">
+    <div className="rounded-xl border border-slate-700/60 bg-surface-card/50 p-3" data-testid="botica-creditos-fotos">
       <button
         type="button"
         onClick={() => setAbierto((v) => !v)}
@@ -386,7 +386,7 @@ function CreditosFotos() {
               >
                 {cr.slug}<ExternalLink size={10} className="inline shrink-0" aria-hidden="true" />
               </a>
-              <span className="text-slate-500"> — {cr.autor} · {cr.licencia} · Wikimedia Commons</span>
+              <span className="text-slate-400"> — {cr.autor} · {cr.licencia} · Wikimedia Commons</span>
             </li>
           ))}
         </ul>
@@ -403,7 +403,7 @@ export default function BoticaScreen({ onBack, onNavigate = undefined }) {
     <ScreenShell title="La botica campesina" icon={Leaf} onBack={onBack}>
       <div className="max-w-2xl mx-auto p-4 space-y-4" data-testid="botica-screen">
         {/* Portada breve del mundo + disclaimer siempre visible */}
-        <div className="rounded-2xl border border-emerald-800/40 bg-[#141b12]/50 p-4">
+        <div className="rounded-2xl border border-emerald-800/40 bg-surface-card/50 p-4">
           <p className="flex items-center gap-2 text-sm font-black text-emerald-200 leading-tight">
             <Flower2 size={18} aria-hidden="true" className="shrink-0" />
             La huerta que cura de la finca andina
@@ -414,7 +414,7 @@ export default function BoticaScreen({ onBack, onNavigate = undefined }) {
             y se cosechan. Complementa la huerta de aromáticas de la cocina: esto es la botica.
           </p>
           <div className="mt-2.5 rounded-lg border border-amber-600/40 bg-amber-950/20 p-2.5">
-            <p className="flex items-start gap-1.5 text-[11px] leading-snug text-amber-100">
+            <p className="flex items-start gap-1.5 text-2xs leading-snug text-amber-100">
               <Stethoscope size={13} aria-hidden="true" className="shrink-0 mt-0.5 text-amber-300" />
               <span><span className="font-black">Saber tradicional, no medicina.</span> Estas plantas acompañan molestias leves; no curan enfermedades ni reemplazan al médico. En embarazo, con niños o si toma remedios, consulte a un profesional de la salud.</span>
             </p>
@@ -436,11 +436,11 @@ export default function BoticaScreen({ onBack, onNavigate = undefined }) {
                 className={`rounded-xl border px-2 py-2.5 text-center transition-colors min-h-[56px] ${
                   activo
                     ? 'botica-estacion-activa border-emerald-500/70 bg-emerald-500/15 text-emerald-100'
-                    : 'border-slate-700 bg-[#141b12]/50 text-slate-300 active:bg-slate-800/70'
+                    : 'border-slate-700 bg-surface-card/50 text-slate-300 active:bg-slate-800/70'
                 }`}
               >
                 <span className="block text-sm font-black leading-tight">{e.titulo}</span>
-                <span className={`block text-[10px] leading-tight mt-0.5 ${activo ? 'text-emerald-200/90' : 'text-slate-500'}`}>
+                <span className={`block text-[10px] leading-tight mt-0.5 ${activo ? 'text-emerald-200/90' : 'text-slate-400'}`}>
                   {e.descripcion}
                 </span>
               </button>

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -602,7 +602,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
         >
             <tile.icon size={large ? 30 : 24} strokeWidth={2} className={`${large ? 'mb-2' : 'mb-1.5'} ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
             <span className={`${large ? 'text-base' : 'text-sm'} font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tileLabel(tile)}</span>
-            <span className={`${large ? 'text-xs mt-1 leading-snug' : 'text-2xs mt-0.5 leading-tight'} block fvh-tile-desc ${fincaVivaFlag ? '' : (large ? 'text-slate-400' : 'text-slate-500')}`}>{tileDesc(tile)}</span>
+            <span className={`${large ? 'text-xs mt-1 leading-snug' : 'text-2xs mt-0.5 leading-tight'} block fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-400'}`}>{tileDesc(tile)}</span>
         </button>
     );
 
@@ -620,7 +620,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     <MERCADO_TILE.icon size={26} strokeWidth={2} className={`${MERCADO_TILE.accent.split(' ')[0]} shrink-0`} aria-hidden="true" />
                     <span className="flex-1 min-w-0">
                         <span className={`text-sm font-black block leading-tight fvh-tile-label ${MERCADO_TILE.accent.split(' ')[0]}`}>{MERCADO_TILE.label}</span>
-                        <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-500'}`}>{MERCADO_TILE.desc}</span>
+                        <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-400'}`}>{MERCADO_TILE.desc}</span>
                     </span>
                     <ChevronRight size={18} className={`shrink-0 ${MERCADO_TILE.accent.split(' ')[0]} opacity-70`} aria-hidden="true" />
                 </button>


### PR DESCRIPTION
## Qué

Aplica los hallazgos de **severidad ALTA** de la auditoría a11y + responsive 320px (2026-07-10). Solo contraste, tamaño de fuente y target táctil — **sin cambios de layout ni de diseño**.

## Cambios

| # | Pantalla | Fix | Archivo:línea |
|---|----------|-----|---------------|
| 1 | Botica | 8 fondos hardcodeados `bg-[#141b12]` / `bg-[#182016]` → token theme-aware `bg-surface-card` (en temas claros el texto slate se invertía a tinta sobre oliva oscuro → ~1.2:1 ilegible) | `botica/BoticaScreen.jsx:67,140,259,286,314,366,406,439` |
| 2 | Botica | Info de seguridad (veto/contraindicación, disclaimer, preparación) `text-[11px]` → `text-2xs` (piso 12px del proyecto) | `botica/BoticaScreen.jsx:178,188,417` |
| 3 | Botica · Glaciar · Agente · Dashboard | `text-slate-500` en texto informativo <12px → `text-slate-400` (~6-7:1, cumple AA) | `botica/BoticaScreen.jsx:216,389,443` · `GlaciarReporteScreen.jsx:438,521,568` · `AgentScreen/ChatHistory.jsx:381` · `dashboard/DashboardLive.jsx:605,623` |
| 4 | El Ciclo | Target táctil del cierre del sheet 30×30 → 44px vía overlay transparente `::after` (círculo visible intacto) | `CicloVivo/cicloVivo.css:187` |

## Notas de implementación

- `bg-surface-card` resuelve a `rgb(var(--c-surface-card) / <alpha>)` — verificado que Tailwind emite `.bg-surface-card`, `.bg-surface-card\/50` y `\/60` en el CSS compilado. Alinea la botica con el resto de sus tarjetas (que ya usan tokens slate).
- El cierre del Ciclo mantiene el círculo crema de 30px; el `::after` transparente de 44px solo agranda el área de toque (el pseudo-elemento recibe el evento por el botón). Cero cambio visual.
- Fuera de alcance (severidad MEDIA/BAJA de la auditoría): resize del resto de literales `text-[9-11px]`, grids `grid-cols-3`, HUD del hero.

## Verificación

- `npm run build` verde (11.6s). Sin Playwright (worktree aislado, no alpha).