### PR TITLE
fix(ux): quitar jerga de BD y unificar a usted (fugas P1 audit campesino)

### DIFF
--- a/src/components/AnimalesScreen.jsx
+++ b/src/components/AnimalesScreen.jsx
@@ -87,7 +87,7 @@ const VERTICALES = [
     emoji: '🐝',
     titulo: 'Abejas y apicultura',
     subtitulo: 'Colmenas, miel, cera y sanidad',
-    aporte: 'Polinización de tus cultivos',
+    aporte: 'Polinización de sus cultivos',
     bar: 'from-yellow-300 to-amber-300',
   },
 ];
@@ -143,9 +143,9 @@ export default function AnimalesScreen({ onBack, onHome, onNavigate }) {
       <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto">
         {/* Intro corta — qué es este módulo y por qué importa el ciclo cerrado. */}
         <p className="text-sm text-slate-300 leading-relaxed mb-4">
-          La cría es parte de la finca integrada. Bien manejados, tus animales te
-          dan comida y, además, alimentan tus plantas: el estiércol se convierte en
-          abono y las abejas polinizan tus cultivos.
+          La cría es parte de la finca integrada. Bien manejados, sus animales le
+          dan comida y, además, alimentan sus plantas: el estiércol se convierte en
+          abono y las abejas polinizan sus cultivos.
         </p>
 
         {/* Sub-botones photo-forward de cada vertical animal. */}
@@ -160,11 +160,11 @@ export default function AnimalesScreen({ onBack, onHome, onNavigate }) {
         <section className="mt-6 rounded-2xl border border-emerald-700/40 bg-emerald-900/20 p-4">
           <h2 className="flex items-center gap-2 text-base font-bold text-emerald-200">
             <Recycle size={18} aria-hidden="true" />
-            El ciclo cerrado de tu finca
+            El ciclo cerrado de su finca
           </h2>
           <p className="mt-2 text-sm text-emerald-100/90 leading-relaxed">
             Nada se pierde: lo que sale de un animal entra como comida de la
-            tierra. Así cierras el círculo y gastas menos en abonos comprados.
+            tierra. Así cierra el círculo y gasta menos en abonos comprados.
           </p>
           <div className="mt-3 flex flex-wrap items-center gap-2 text-xs font-bold">
             <span className="px-2.5 py-1 rounded-full bg-amber-500/20 text-amber-200 border border-amber-500/40">Animal</span>
@@ -183,7 +183,7 @@ export default function AnimalesScreen({ onBack, onHome, onNavigate }) {
             <li>• <span className="font-bold text-orange-200">Cabras y ovejas</span> → la majada (pelotitas) se recoge seca y va directo al compost.</li>
             <li>• <span className="font-bold text-orange-200">Vacas</span> → la boñiga (bovinaza) es el estiércol clásico del <span className="font-bold">biol</span> y también entra al <span className="font-bold">bocashi</span>.</li>
             <li>• <span className="font-bold text-pink-200">Cerdos</span> → la porquinaza entra al <span className="font-bold">biol</span>, el <span className="font-bold">supermagro</span> y el <span className="font-bold">compost</span>.</li>
-            <li>• <span className="font-bold text-yellow-200">Abejas</span> → no dan abono, pero polinizan tus matas y mejoran el cuaje y la cosecha.</li>
+            <li>• <span className="font-bold text-yellow-200">Abejas</span> → no dan abono, pero polinizan sus matas y mejoran el cuaje y la cosecha.</li>
           </ul>
           <div className="mt-4 flex flex-col gap-2">
             <button

--- a/src/components/CicloCultivoScreen.jsx
+++ b/src/components/CicloCultivoScreen.jsx
@@ -56,7 +56,7 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
       }
     } catch (err) {
       if (mounted) {
-        setError(`No pude leer tus ciclos: ${err.message}`);
+        setError(`No pude leer sus ciclos: ${err.message}`);
       }
     } finally {
       if (mounted) {
@@ -121,7 +121,7 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
     return (
       <div className="min-h-[100dvh] text-white">
         {Header}
-        <div className="flex flex-col items-center gap-3 py-16"><ChagraGrowLoader size={56} /><p className="text-sm text-slate-400">Cargando tus ciclos…</p></div>
+        <div className="flex flex-col items-center gap-3 py-16"><ChagraGrowLoader size={56} /><p className="text-sm text-slate-400">Cargando sus ciclos…</p></div>
       </div>
     );
   }
@@ -156,7 +156,7 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
       {cycles.length === 0 ? (
         <div className="flex flex-col items-center gap-4 py-14 px-6 text-center">
           <Sprout size={48} className="text-lime-500/70" />
-          <p className="text-sm text-slate-300 max-w-xs">Aún no tienes ciclos de cultivo. Registra uno contándole a Chagra qué sembraste.</p>
+          <p className="text-sm text-slate-300 max-w-xs">Aún no tiene ciclos de cultivo. Registre uno contándole a Chagra qué sembró.</p>
           <button
             onClick={() => onNavigate?.('procesos')}
             className="px-6 py-3 min-h-[44px] bg-lime-700 hover:bg-lime-600 rounded-xl font-bold flex items-center gap-2"
@@ -169,7 +169,7 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
             onClick={() => onNavigate?.('germinacion')}
             className="px-5 py-2.5 min-h-[44px] bg-slate-800 hover:bg-slate-700 border border-sky-700/40 text-slate-200 rounded-xl font-bold text-sm flex items-center gap-2"
           >
-            <Beaker size={16} className="text-sky-300" /> Haz una prueba de germinación primero
+            <Beaker size={16} className="text-sky-300" /> Haga una prueba de germinación primero
           </button>
         </div>
       ) : (
@@ -183,7 +183,7 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
               className="w-full text-left bg-sky-900/20 border border-sky-700/40 hover:border-sky-600/60 rounded-xl p-3 flex items-center gap-2.5 text-sm text-sky-100"
             >
               <Beaker size={16} className="text-sky-300 shrink-0" />
-              <span className="flex-1">¿Vas a sembrar otro lote? Hazle primero una prueba de germinación.</span>
+              <span className="flex-1">¿Va a sembrar otro lote? Hágale primero una prueba de germinación.</span>
               <ChevronLeft size={16} className="text-sky-400/70 rotate-180 shrink-0" />
             </button>
           ) : null}

--- a/src/components/CicloNutrientesScreen.jsx
+++ b/src/components/CicloNutrientesScreen.jsx
@@ -48,7 +48,7 @@ const ANIMALES = [
     emoji: '🐔',
     nombre: 'Gallinas',
     estiercol: 'Gallinaza',
-    detalle: 'Recógela seca de la cama profunda. Compóstala o madúrala antes de usarla (fresca quema las matas).',
+    detalle: 'Recójala seca de la cama profunda. Compóstela o madúrela antes de usarla (fresca quema las matas).',
     alimenta: 'Bocashi',
     text: 'text-amber-200',
     border: 'border-amber-600/40',
@@ -61,7 +61,7 @@ const ANIMALES = [
     emoji: '🐄',
     nombre: 'Vacas',
     estiercol: 'Boñiga (bovinaza)',
-    detalle: 'El estiércol clásico del biol (el biol tradicional de Restrepo se hace con boñiga de vaca). Madúrala antes de aplicarla.',
+    detalle: 'El estiércol clásico del biol (el biol tradicional de Restrepo se hace con boñiga de vaca). Madúrela antes de aplicarla.',
     alimenta: 'Biol, bocashi y compost',
     text: 'text-orange-200',
     border: 'border-orange-600/40',
@@ -74,7 +74,7 @@ const ANIMALES = [
     emoji: '🐖',
     nombre: 'Cerdos',
     estiercol: 'Porcinaza',
-    detalle: 'La porcinaza y el estiércol del lote entran al biol, el supermagro y el compost. Madúrala siempre antes de usar.',
+    detalle: 'La porcinaza y el estiércol del lote entran al biol, el supermagro y el compost. Madúrela siempre antes de usar.',
     alimenta: 'Biol, supermagro y compost',
     text: 'text-pink-200',
     border: 'border-pink-600/40',
@@ -139,7 +139,7 @@ const PASOS_PLAN = [
     momento: 'Al sembrar / trasplantar (día 0)',
     insumo: 'Bocashi al hoyo o surco',
     propio: true,
-    nota: 'Abono de FONDO. Aquí entra la gallinaza de tus gallinas convertida en bocashi.',
+    nota: 'Abono de FONDO. Aquí entra la gallinaza de sus gallinas convertida en bocashi.',
   },
   {
     momento: 'Mientras crece (≈día 15–25)',
@@ -157,7 +157,7 @@ const PASOS_PLAN = [
     momento: 'Mantenimiento (en producción)',
     insumo: 'Té de compost',
     propio: true,
-    nota: 'Microbios para sostener la planta. Sale de tu compost (estiércol maduro de cualquier animal de la finca).',
+    nota: 'Microbios para sostener la planta. Sale de su compost (estiércol maduro de cualquier animal de la finca).',
   },
 ];
 
@@ -192,10 +192,10 @@ export default function CicloNutrientesScreen({ onBack, onHome, onNavigate }) {
       <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
         {/* Intro — la idea en campesino. */}
         <p className="text-sm text-slate-300 leading-relaxed">
-          En una finca agroecológica nada se bota. Lo que sale de tus animales
-          vuelve a la tierra como comida para las plantas. Aquí ves el camino
+          En una finca agroecológica nada se bota. Lo que sale de sus animales
+          vuelve a la tierra como comida para las plantas. Aquí ve el camino
           completo, eslabón por eslabón: el estiércol del animal se transforma en
-          biopreparado y ese abono entra en el plan de alimentación de tus
+          biopreparado y ese abono entra en el plan de alimentación de sus
           cultivos.
         </p>
 
@@ -214,10 +214,10 @@ export default function CicloNutrientesScreen({ onBack, onHome, onNavigate }) {
         <Card className="border-amber-700/40">
           <h2 className="flex items-center gap-2 text-base font-bold text-amber-200">
             <PawPrint size={18} aria-hidden="true" />
-            1. Tus animales y su estiércol
+            1. Sus animales y su estiércol
           </h2>
           <p className="mt-2 text-sm text-slate-300 leading-relaxed">
-            Cada animal deja un abono distinto. Recógelo y madúralo antes de
+            Cada animal deja un abono distinto. Recójalo y madúrelo antes de
             usarlo (el estiércol fresco quema las matas).
           </p>
           <ul className="mt-3 flex flex-col gap-2">
@@ -249,7 +249,7 @@ export default function CicloNutrientesScreen({ onBack, onHome, onNavigate }) {
           </ul>
           <p className="mt-3 flex items-start gap-2 text-[11px] text-slate-500">
             <Info size={13} className="shrink-0 mt-0.5" aria-hidden="true" />
-            Las abejas no dan abono, pero polinizan tus cultivos y mejoran el
+            Las abejas no dan abono, pero polinizan sus cultivos y mejoran el
             cuaje y la cosecha — también cierran ciclo, por otro lado.
           </p>
         </Card>
@@ -311,7 +311,7 @@ export default function CicloNutrientesScreen({ onBack, onHome, onNavigate }) {
             3. El abono entra en el plan de las plantas
           </h2>
           <p className="mt-2 text-sm text-slate-300 leading-relaxed">
-            En el plan de alimentación de cada cultivo, tu propio abono ocupa los
+            En el plan de alimentación de cada cultivo, su propio abono ocupa los
             pasos clave. Estos son los momentos y qué entra en cada uno:
           </p>
           <ol className="mt-3 flex flex-col gap-2">
@@ -336,7 +336,7 @@ export default function CicloNutrientesScreen({ onBack, onHome, onNavigate }) {
                       p.propio ? 'text-emerald-200' : 'text-stone-300'
                     }`}>
                       {p.propio
-                        ? <><Recycle size={12} aria-hidden="true" /> {p.insumo} — abono de tu finca</>
+                        ? <><Recycle size={12} aria-hidden="true" /> {p.insumo} — abono de su finca</>
                         : <><Mountain size={12} aria-hidden="true" /> {p.insumo} — mineral comprado</>}
                     </p>
                     <p className="mt-1 text-xs text-slate-300/90 leading-snug">{p.nota}</p>
@@ -366,12 +366,12 @@ export default function CicloNutrientesScreen({ onBack, onHome, onNavigate }) {
         <div className="rounded-2xl border border-emerald-700/40 bg-emerald-900/20 p-4">
           <h2 className="flex items-center gap-2 text-base font-bold text-emerald-200">
             <Trees size={18} aria-hidden="true" />
-            Cierra el círculo en tu finca
+            Cierre el círculo en su finca
           </h2>
           <p className="mt-2 text-sm text-emerald-100/90 leading-relaxed">
-            Lleva la cuenta del estiércol que producen tus animales y de los
-            biopreparados que preparas: así sabes cuánto abono propio tienes para
-            el plan de tus cultivos y cuánto te ahorras en abonos comprados.
+            Lleve la cuenta del estiércol que producen sus animales y de los
+            biopreparados que prepara: así sabe cuánto abono propio tiene para
+            el plan de sus cultivos y cuánto se ahorra en abonos comprados.
           </p>
           <button
             type="button"

--- a/src/components/MercadosScreen.jsx
+++ b/src/components/MercadosScreen.jsx
@@ -433,8 +433,8 @@ function DetalleOferta({ oferta, onClose, onEliminar }) {
             <div className="rounded-lg border border-slate-700 bg-slate-800/60 p-3 flex gap-2 text-sm text-slate-300">
               <Info size={16} className="text-slate-400 shrink-0 mt-0.5" />
               {oferta.demo
-                ? 'Esta es una oferta de ejemplo: no tiene un contacto real. Publica la tuya para que te puedan escribir.'
-                : 'Este vendedor no dejó un contacto directo. Coordina con él en tu mercado campesino o agrofería.'}
+                ? 'Esta es una oferta de ejemplo: no tiene un contacto real. Publique la suya para que le puedan escribir.'
+                : 'Este vendedor no dejó un contacto directo. Coordine con él en su mercado campesino o agrofería.'}
             </div>
           )}
 
@@ -577,7 +577,7 @@ function PublicarPanel({ onPublicada, onCancelar }) {
       onPublicada();
     } catch (e) {
       console.warn('[Mercados] no se pudo publicar la oferta:', e?.message);
-      setErrors({ producto: 'No se pudo guardar. Intenta de nuevo.' });
+      setErrors({ producto: 'No se pudo guardar. Intente de nuevo.' });
     } finally {
       setGuardando(false);
     }
@@ -585,7 +585,7 @@ function PublicarPanel({ onPublicada, onCancelar }) {
 
   return (
     <div className="space-y-4">
-      <Field label="¿Qué vendes?" error={errors.producto} required>
+      <Field label="¿Qué vende?" error={errors.producto} required>
         <input
           type="text"
           value={form.producto}
@@ -624,7 +624,7 @@ function PublicarPanel({ onPublicada, onCancelar }) {
 
       {refPrecio && <PrecioReferenciaBloque referencia={refPrecio} contexto="publicar" />}
 
-      <Field label="Precio por unidad (opcional)" error={errors.precio} hint="Déjalo vacío si prefieres 'a convenir'. Chagra no sugiere precios.">
+      <Field label="Precio por unidad (opcional)" error={errors.precio} hint="Déjelo vacío si prefiere 'a convenir'. Chagra no sugiere precios.">
         <div className="relative">
           <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500">$</span>
           <input
@@ -650,7 +650,7 @@ function PublicarPanel({ onPublicada, onCancelar }) {
 
       <div className="grid grid-cols-1 gap-3">
         <Field label="Finca (opcional)">
-          <input type="text" value={form.finca} onChange={(e) => set('finca', e.target.value)} placeholder="Nombre de tu finca" className="form-input" />
+          <input type="text" value={form.finca} onChange={(e) => set('finca', e.target.value)} placeholder="Nombre de su finca" className="form-input" />
         </Field>
         <div className="grid grid-cols-2 gap-3">
           <Field label="Vereda (opcional)">
@@ -662,7 +662,7 @@ function PublicarPanel({ onPublicada, onCancelar }) {
         </div>
       </div>
 
-      <Field label="Teléfono de contacto (opcional)" hint="Para que te escriban por WhatsApp. Si no lo pones, coordinas en el mercado.">
+      <Field label="Teléfono de contacto (opcional)" hint="Para que le escriban por WhatsApp. Si no lo pone, coordina en el mercado.">
         <div className="relative">
           <Phone className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" size={15} />
           <input
@@ -681,7 +681,7 @@ function PublicarPanel({ onPublicada, onCancelar }) {
           value={form.nota}
           onChange={(e) => set('nota', e.target.value)}
           rows={3}
-          placeholder="Cómo lo produces, cuándo entregas, calidad…"
+          placeholder="Cómo lo produce, cuándo entrega, calidad…"
           className="form-input resize-none"
         />
       </Field>

--- a/src/components/aguacate/AguacateScreen.jsx
+++ b/src/components/aguacate/AguacateScreen.jsx
@@ -293,7 +293,7 @@ function EstacionSuelo({ onNavigate }) {
           </p>
           <p className="mt-1 text-xs leading-snug text-rose-100/90">{a.antagonista.detalle}</p>
         </div>
-        <p className="text-[10px] leading-snug text-slate-500">Compatibilidades del catálogo Chagra (grafo).</p>
+        <p className="text-[10px] leading-snug text-slate-500">Compatibilidades del catálogo Chagra.</p>
       </div>
 
       {/* Puente al cuaderno del suelo */}
@@ -378,7 +378,7 @@ function EstacionSanidad({ onNavigate }) {
             <span key={i} className="rounded-full border border-slate-600/50 bg-slate-800/40 px-2 py-0.5 text-[11px] text-slate-200">{b}</span>
           ))}
         </div>
-        <p className="mt-2 text-[10px] leading-snug text-slate-500">Biopreparados del grafo Chagra (persea_americana). Son apoyo, no reemplazan el manejo cultural.</p>
+        <p className="mt-2 text-[10px] leading-snug text-slate-500">Biopreparados del catálogo Chagra. Son apoyo, no reemplazan el manejo cultural.</p>
       </div>
 
       {/* Guard anti-receta */}

--- a/src/components/animales/CicloCerrado.jsx
+++ b/src/components/animales/CicloCerrado.jsx
@@ -18,7 +18,7 @@ export default function CicloCerrado({ animalKey, onNavigate }) {
     <section className="rounded-2xl border border-lime-600/50 bg-lime-900/25 p-4">
       <h2 className="flex items-center gap-2 text-base font-bold text-lime-200">
         <Recycle size={18} aria-hidden="true" />
-        Cierra el ciclo de tu finca
+        Cierre el ciclo de su finca
       </h2>
       <p className="mt-2 text-sm text-slate-200/90 leading-relaxed">
         {info.abono && <><span className="font-bold text-lime-100">{info.abono}:</span>{' '}</>}

--- a/src/components/citricos/CitricosScreen.jsx
+++ b/src/components/citricos/CitricosScreen.jsx
@@ -155,13 +155,13 @@ function EstacionVariedades() {
               {v.nombre}
               <span className="text-[11px] italic font-normal text-slate-400">{v.cientifico}</span>
               {v.enGrafo
-                ? <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/50 bg-emerald-500/15 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-emerald-200"><ShieldCheck size={11} aria-hidden="true" /> En el grafo</span>
+                ? <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/50 bg-emerald-500/15 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-emerald-200"><ShieldCheck size={11} aria-hidden="true" /> En el catálogo</span>
                 : <SlotPendiente>ficha en camino</SlotPendiente>}
             </p>
             <p className="mt-1 text-xs leading-snug text-slate-300">{v.nota}</p>
           </div>
         ))}
-        <p className="text-[10px] leading-snug text-slate-500">Fuente: grafo Chagra (citrus_sinensis, citrus_reticulata, citrus_latifolia) · AGROSAVIA / ICA.</p>
+        <p className="text-[10px] leading-snug text-slate-500">Fuente: catálogo Chagra (naranja, mandarina, limón Tahití) · AGROSAVIA / ICA.</p>
       </div>
 
       {/* Por qué injertado (foto real del injerto de yema) */}
@@ -388,7 +388,7 @@ function PlagaCard({ plaga }) {
         </p>
         <div>
           <p className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wide text-emerald-300 mb-1.5">
-            <ShieldCheck size={12} aria-hidden="true" /> Manejo sin veneno (biocontroles del grafo)
+            <ShieldCheck size={12} aria-hidden="true" /> Manejo sin veneno
           </p>
           <div className="flex flex-wrap gap-1.5">
             {plaga.biocontrol.map((b, i) => (
@@ -415,7 +415,7 @@ function EstacionPlagas({ onNavigate }) {
       >
         <p>
           Reconocerlos temprano es media pelea ganada. Los bichos buenos y los
-          biocontroles que ve en cada tarjeta salen del grafo Chagra (a qué le
+          biocontroles que ve en cada tarjeta salen del catálogo Chagra (a qué le
           pega cada plaga y quién la controla).
         </p>
       </PedagogicalBlock>
@@ -483,7 +483,7 @@ function EstacionPlagas({ onNavigate }) {
             <span key={i} className="rounded-full border border-slate-600/50 bg-slate-800/40 px-2 py-0.5 text-[11px] text-slate-200">{b}</span>
           ))}
         </div>
-        <p className="text-[10px] leading-snug text-slate-500 mt-2">Fuente: grafo Chagra (biopreparados de las especies cítricas).</p>
+        <p className="text-[10px] leading-snug text-slate-500 mt-2">Fuente: catálogo Chagra (biopreparados de las especies cítricas).</p>
       </div>
 
       {/* Guard anti-receta */}

--- a/src/components/mango/MangoScreen.jsx
+++ b/src/components/mango/MangoScreen.jsx
@@ -347,7 +347,7 @@ function EstacionClima({ onNavigate }) {
             <p className="mt-1 text-xs leading-snug text-slate-300">{v.nota}</p>
           </div>
         ))}
-        <p className="text-[10px] leading-snug text-slate-500">Compañías compatibles del catálogo Chagra (mismo piso térmico) — grafo Chagra.</p>
+        <p className="text-[10px] leading-snug text-slate-500">Compañías compatibles del catálogo Chagra (mismo piso térmico).</p>
       </div>
 
       {typeof onNavigate === 'function' && (
@@ -529,7 +529,7 @@ function EstacionMales({ onNavigate }) {
             </div>
           </div>
         ))}
-        <p className="text-[10px] leading-snug text-slate-500">Plagas y controladores del grafo Chagra (mangifera_indica).</p>
+        <p className="text-[10px] leading-snug text-slate-500">Plagas y controladores del catálogo Chagra.</p>
       </div>
 
       {/* Biopreparados de apoyo */}

--- a/src/data/aguacateFinca.js
+++ b/src/data/aguacateFinca.js
@@ -63,7 +63,7 @@ export const CICLO_AGUACATE = {
   altitud: '1340–2420 msnm (óptimo 1800–2000 para Hass)',
   regionNota:
     'El calendario de floración y cosecha depende fuerte de la localidad, la altitud y el patrón; hay fincas de montaña que producen casi todo el año. No hay un mes fijo que sirva para todas.',
-  fuente: 'AGROSAVIA, Universidad Nacional de Colombia (grafo Chagra: perennialCycles.persea_americana, confianza media)',
+  fuente: 'AGROSAVIA, Universidad Nacional de Colombia (catálogo Chagra, confianza media)',
 };
 
 /**
@@ -217,14 +217,14 @@ export const ASOCIACION_AGUACATE = {
       nombre: 'Hobo / ciruela',
       cientifico: 'Spondias dulcis',
       papel: 'Frutal compatible',
-      detalle: 'Otro frutal que el grafo marca compatible con el aguacate: buena vecina para armar un huerto diverso.',
+      detalle: 'Otro frutal que el catálogo marca compatible con el aguacate: buena vecina para armar un huerto diverso.',
     },
   ],
   antagonista: {
     id: 'eucalipto',
     nombre: 'Eucalipto',
     cientifico: 'Eucalyptus globulus',
-    detalle: 'El grafo lo marca ANTAGONISTA del aguacate: seca y acapara el suelo, y su hojarasca no lo deja. No siembre aguacate a la sombra ni al pie de eucaliptos.',
+    detalle: 'El catálogo lo marca ANTAGONISTA del aguacate: seca y acapara el suelo, y su hojarasca no lo deja. No siembre aguacate a la sombra ni al pie de eucaliptos.',
   },
 };
 
@@ -305,7 +305,7 @@ export const MALES_AGUACATE = [
  * fuera del grafo: solo cita la fuente que respalda las que ya están.
  */
 export const MALES_FUENTE =
-  'Grafo Chagra (persea_americana) + AGROSAVIA — Carabalí Muñoz, Caicedo Vallejo y Holguín (2021), “Guía para el reconocimiento y manejo de las principales plagas de aguacate cv. Hass en Colombia”, DOI 10.21930/agrosavia.nbook.7404913 (verificado Crossref).';
+  'Catálogo Chagra + AGROSAVIA — Carabalí Muñoz, Caicedo Vallejo y Holguín (2021), “Guía para el reconocimiento y manejo de las principales plagas de aguacate cv. Hass en Colombia”, DOI 10.21930/agrosavia.nbook.7404913 (verificado Crossref).';
 
 /**
  * Biopreparados de apoyo — GROUNDED: la lista propia de persea_americana en el

--- a/src/data/citricosFinca.js
+++ b/src/data/citricosFinca.js
@@ -63,8 +63,8 @@ export const VARIEDADES_CITRICOS = [
     cientifico: 'Citrus × sinensis',
     foto: 'naranja',
     enGrafo: true,
-    nota: 'La reina del solar: Valencia (jugo), Washington/ombliga (mesa, sin pepa) y las criollas. De clima cálido a medio. La fecha de cosecha varía MUCHO por región; el grafo la marca con confianza baja.',
-    fuente: 'AGROSAVIA / ICA (grafo: citrus_sinensis)',
+    nota: 'La reina del solar: Valencia (jugo), Washington/ombliga (mesa, sin pepa) y las criollas. De clima cálido a medio. La fecha de cosecha varía MUCHO por región; el catálogo la marca con confianza baja.',
+    fuente: 'AGROSAVIA / ICA',
   },
   {
     id: 'mandarina',
@@ -72,8 +72,8 @@ export const VARIEDADES_CITRICOS = [
     cientifico: 'Citrus reticulata',
     foto: 'mandarina',
     enGrafo: true,
-    nota: 'La de pelar con la mano: Arrayana (la criolla colombiana), Oneco, Clementina. Dulce y temprana. Su calendario exacto de cosecha aún es dato en camino en el grafo.',
-    fuente: 'AGROSAVIA / ICA (grafo: citrus_reticulata)',
+    nota: 'La de pelar con la mano: Arrayana (la criolla colombiana), Oneco, Clementina. Dulce y temprana. Su calendario exacto de cosecha aún es dato en camino.',
+    fuente: 'AGROSAVIA / ICA',
   },
   {
     id: 'lima',
@@ -81,8 +81,8 @@ export const VARIEDADES_CITRICOS = [
     cientifico: 'Citrus × latifolia',
     foto: 'limon',
     enGrafo: true,
-    nota: 'El limón de exportación: sin pepa, jugoso, produce casi todo el año. Es el cítrico que MÁS altura aguanta (hasta ~2100 msnm). El grafo lo tiene con confianza alta.',
-    fuente: 'AGROSAVIA (grafo: citrus_latifolia, confianza alta)',
+    nota: 'El limón de exportación: sin pepa, jugoso, produce casi todo el año. Es el cítrico que MÁS altura aguanta (hasta ~2100 msnm). El catálogo lo tiene con confianza alta.',
+    fuente: 'AGROSAVIA (confianza alta)',
   },
   {
     id: 'limon-criollo',
@@ -90,7 +90,7 @@ export const VARIEDADES_CITRICOS = [
     cientifico: 'Citrus × aurantiifolia',
     foto: 'limon',
     enGrafo: false,
-    nota: 'El limoncito de la casa, muy ácido y espinoso, de tierra caliente. Es real y muy sembrado, pero AÚN no tiene ficha propia en el grafo Chagra: se maneja igual que el grupo cítrico.',
+    nota: 'El limoncito de la casa, muy ácido y espinoso, de tierra caliente. Es real y muy sembrado, pero AÚN no tiene ficha propia en el catálogo Chagra: se maneja igual que el grupo cítrico.',
     fuente: 'Uso campesino (nodo propio: dato en camino)',
   },
 ];
@@ -118,8 +118,8 @@ export const INJERTO_CITRICOS = {
 export const ASOCIACION_CITRICOS = {
   especie: 'Arazá',
   cientifico: 'Eugenia stipitata',
-  nota: 'El grafo Chagra reporta a la naranja compatible con el arazá: dos frutales de clima cálido que se acompañan bien en el solar.',
-  fuente: 'grafo Chagra (citrus_sinensis compatible_with eugenia_stipitata)',
+  nota: 'El catálogo Chagra reporta a la naranja compatible con el arazá: dos frutales de clima cálido que se acompañan bien en el solar.',
+  fuente: 'catálogo Chagra (naranja compatible con arazá)',
 };
 
 /* ────────────────────────────────────────────────────────────────────────
@@ -161,7 +161,7 @@ export const PISO_TERMICO = {
       rango: '1800 – 2100 msnm',
       clima: 'El límite',
       apto: 'limite',
-      nota: 'Solo el limón Tahití (lima ácida) aguanta hasta aquí, según el grafo (AGROSAVIA). Naranja y mandarina ya rinden poco. Por encima, mejor no.',
+      nota: 'Solo el limón Tahití (lima ácida) aguanta hasta aquí, según el catálogo (AGROSAVIA). Naranja y mandarina ya rinden poco. Por encima, mejor no.',
     },
     {
       id: 'frio',
@@ -173,7 +173,7 @@ export const PISO_TERMICO = {
   ],
   aguaLuz:
     'Pleno sol y, sobre todo, suelo bien DRENADO: el cítrico odia el encharcamiento (le pudre la raíz y le da gomosis). Riego parejo en la floración y el llenado del fruto; en veranos largos, riego de apoyo para que no bote la cosecha.',
-  fuente: 'grafo Chagra (citrus_latifolia 0–2100 msnm, AGROSAVIA, confianza alta) + práctica ICA',
+  fuente: 'catálogo Chagra (limón Tahití 0–2100 msnm, AGROSAVIA, confianza alta) + práctica ICA',
   // Redirección honesta para fincas de clima frío (no dejar al campesino sin salida).
   redireccionFrio: {
     texto: '¿Su finca es de clima frío alto? El cítrico no es lo suyo. Pregúntele al agente por frutales de frío (mora, tomate de árbol, uchuva).',
@@ -248,7 +248,7 @@ export const PLAGAS_CITRICOS = [
     tipo: 'plaga',
     plagaGrafo: 'Minador de la hoja de cítricos',
     senal: 'Caminitos plateados y retorcidos DENTRO de las hojas nuevas; la hoja se enrolla y se deforma. Pega duro en los arbolitos y en los brotes tiernos. Las heridas que deja abren la puerta a la cancrosis.',
-    biocontrol: ['Avispitas parasitoides (parasitoide del grafo)', 'Caldo ceniza-jabón sobre el brote tierno', 'Aceite de nim en los flujos de brotación'],
+    biocontrol: ['Avispitas parasitoides (parasitoide natural)', 'Caldo ceniza-jabón sobre el brote tierno', 'Aceite de nim en los flujos de brotación'],
   },
   {
     id: 'mosca-fruta',
@@ -265,7 +265,7 @@ export const PLAGAS_CITRICOS = [
     foto: 'psilido',
     plagaGrafo: 'Psílido asiático de los cítricos',
     senal: 'Un insectico chupador que se para "de pico abajo" en los brotes tiernos, casi a 45°. Suelta una melaza que ensucia la hoja. Es peligroso NO por lo que chupa, sino porque reparte el HLB (dragón amarillo) de árbol en árbol.',
-    biocontrol: ['Mariquita roja (depredador del grafo)', 'Hongos entomopatógenos (Beauveria, Isaria/Cordyceps, Paecilomyces)', 'Avispitas parasitoides', 'Vigilar los brotes tiernos, que es donde se cría'],
+    biocontrol: ['Mariquita roja (depredador natural)', 'Hongos entomopatógenos (Beauveria, Isaria/Cordyceps, Paecilomyces)', 'Avispitas parasitoides', 'Vigilar los brotes tiernos, que es donde se cría'],
   },
   {
     id: 'afido-tristeza',
@@ -313,7 +313,7 @@ export const PLAGAS_CITRICOS = [
     tipo: 'enfermedad',
     plagaGrafo: 'Mancha negra de los cítricos',
     senal: 'Manchas negras redondas y hundidas en la cáscara (mancha negra) o pardas en fruto y hoja (alternaria). Dañan la presentación de la fruta y son de control cuarentenario en exportación.',
-    biocontrol: ['Microorganismos de control biológico (biofungicida del grafo)', 'Recoger hojarasca y fruta caída', 'Poda para airear', 'Caldo bordelés protector'],
+    biocontrol: ['Microorganismos de control biológico (biofungicida natural)', 'Recoger hojarasca y fruta caída', 'Poda para airear', 'Caldo bordelés protector'],
   },
 ];
 
@@ -339,7 +339,7 @@ export const HLB_CUARENTENA = {
     'Controle el psílido (su vector): mariquita roja y hongos entomopatógenos, vigilando los brotes tiernos.',
     'REPORTE al ICA si ve los síntomas: es de reporte obligatorio. Un árbol enfermo confirmado se elimina para no contagiar el resto.',
   ],
-  fuente: 'ICA (plaga cuarentenaria) · grafo Chagra (HLB + psílido vector)',
+  fuente: 'ICA (plaga cuarentenaria) · catálogo Chagra (HLB + psílido vector)',
 };
 
 /**
@@ -353,7 +353,7 @@ export const GOMOSIS_PENDIENTE = {
   titulo: 'La gomosis del tronco (Phytophthora)',
   estado: ESTADO_GROUNDED_PENDIENTE,
   texto:
-    'La gomosis —una pudrición del tronco y la raíz que suelta goma— es real y grave en cítricos, pero todavía NO está en el grafo Chagra: por eso no le damos aquí un manejo con dosis (sería inventarlo). Lo que SÍ sirve y está probado es prevenir: drenaje, injerto por encima de la tierra y patrón resistente. Para su caso, el agente o el técnico del ICA.',
+    'La gomosis —una pudrición del tronco y la raíz que suelta goma— es real y grave en cítricos, pero todavía NO está en el catálogo Chagra: por eso no le damos aquí un manejo con dosis (sería inventarlo). Lo que SÍ sirve y está probado es prevenir: drenaje, injerto por encima de la tierra y patrón resistente. Para su caso, el agente o el técnico del ICA.',
 };
 
 /** Biopreparados de apoyo (grounded: lista compartida de las 3 especies cítricas). */
@@ -405,9 +405,9 @@ export const FERTILIZACION_CITRICOS = {
  */
 export const COSECHA_CITRICOS = {
   primeraCosecha: [
-    { id: 'lima', nombre: 'Limón Tahití', valor: '3–4 años', grounded: true, nota: 'Produce casi todo el año, con pico nov–mar (grafo, confianza alta).' },
-    { id: 'naranja', nombre: 'Naranja', valor: '3–5 años', grounded: true, nota: 'El calendario varía mucho por región (grafo, confianza baja).' },
-    { id: 'mandarina', nombre: 'Mandarina', valor: 'dato en camino', grounded: false, nota: 'El ciclo de la mandarina aún no está en el grafo Chagra.' },
+    { id: 'lima', nombre: 'Limón Tahití', valor: '3–4 años', grounded: true, nota: 'Produce casi todo el año, con pico nov–mar (catálogo, confianza alta).' },
+    { id: 'naranja', nombre: 'Naranja', valor: '3–5 años', grounded: true, nota: 'El calendario varía mucho por región (catálogo, confianza baja).' },
+    { id: 'mandarina', nombre: 'Mandarina', valor: 'dato en camino', grounded: false, nota: 'El ciclo de la mandarina aún no está en el catálogo Chagra.' },
   ],
   noClimaterico:
     'El cítrico NO madura después de cogido: hay que cogerlo EN EL PUNTO. Cogido verde, se queda ácido y sin jugo para siempre. La naranja y la mandarina se prueban; el limón Tahití se coge verde-lustroso, el criollo pintón, según el mercado.',
@@ -416,7 +416,7 @@ export const COSECHA_CITRICOS = {
     'Manéjelo con cuidado — el golpe se pudre. Guárdelo fresco, ventilado y a la sombra.',
     'El limón dura más si se coge sin el sol fuerte del mediodía. La fruta con hongo se aparta para que no contagie el resto.',
   ],
-  fuente: 'AGROSAVIA / ICA (grafo: perennialCycles citrus_latifolia y citrus_sinensis)',
+  fuente: 'AGROSAVIA / ICA',
 };
 
 /* ────────────────────────────────────────────────────────────────────────

--- a/src/data/mangoFinca.js
+++ b/src/data/mangoFinca.js
@@ -194,7 +194,7 @@ export const PISO_TERMICO_MANGO = [
 export const PISO_TERMICO_NOTA =
   'El mango es de TIERRA CÁLIDA (óptimo por debajo de ~1200 msnm). Estas franjas son orientadoras y cambian por región y microclima (una ladera abrigada y soleada rinde más que un cañón húmedo a la misma altura). La regla no cambia: entre más frío, menos mango.';
 
-export const PISO_TERMICO_FUENTE = 'AGROSAVIA (perennialCycles: mangifera_indica, confianza media)';
+export const PISO_TERMICO_FUENTE = 'AGROSAVIA (confianza media)';
 
 /** Luz y agua del mango (cualitativo). GROUNDED: AGROSAVIA. */
 export const AGUA_LUZ_MANGO = {
@@ -240,7 +240,7 @@ export const CICLO_FLOR_MANGO = {
   altitud: 'Tierra cálida, óptimo bajo ~1200 msnm',
   disparador: 'La floración la disparan el calor, el sol y el estrés hídrico de la temporada seca; no un mes fijo del calendario.',
   regionNota: 'Fechas de referencia del Tolima: cambian según la región (en la Costa, los Llanos o el Magdalena medio la temporada cae en otros meses).',
-  fuente: 'AGROSAVIA (perennialCycles: mangifera_indica, confianza media)',
+  fuente: 'AGROSAVIA (confianza media)',
   pasos: [
     {
       id: 'floracion',
@@ -293,7 +293,7 @@ export const MALES_MANGO = [
       { titulo: 'Hongos y bacterias antagonistas', detalle: 'Trichoderma y bacterias antagonistas (biofungicidas) ayudan a controlar el hongo. Funcionan mejor como parte del manejo, acompañando la poda y el florecer en seco.' },
       { titulo: 'Caldo bordelés protector', detalle: 'El caldo bordelés (cobre + cal) sirve de protección preventiva en floración y cuaje. Es apoyo, no reemplaza la poda ni el buen sitio soleado.' },
     ],
-    fuente: 'AGROSAVIA (manejo de antracnosis) · controladores del grafo Chagra',
+    fuente: 'AGROSAVIA (manejo de antracnosis) · controladores del catálogo Chagra',
   },
   {
     id: 'mosca',
@@ -313,7 +313,7 @@ export const MALES_MANGO = [
       { titulo: 'Control biológico', detalle: 'Avispitas parasitoides que atacan las larvas y el hongo Beauveria ayudan en el manejo integrado. Acompañan la recolección de fruta, no la reemplazan.' },
       { titulo: 'Embolsar el fruto', detalle: 'En huerto casero o pocas matas, embolsar los frutos en sazón con bolsa de papel/tela los protege de la picada. Trabajoso pero muy efectivo sin veneno.' },
     ],
-    fuente: 'ICA / AGROSAVIA (manejo de mosca de la fruta) · controladores del grafo Chagra',
+    fuente: 'ICA / AGROSAVIA (manejo de mosca de la fruta) · controladores del catálogo Chagra',
   },
 ];
 


### PR DESCRIPTION
## Qué

Aplica las **dos fugas transversales P1** del audit UX-campesino (`ops/AUDIT-UX-CAMPESINO-MUNDOS-2026-07-10.md`). Solo cambios de **texto/presentación** — no toca la lógica de grounding.

### 1. Jerga de base de datos fuera de la cara del usuario
Mundos **cítricos, mango, aguacate**:
- `"grafo Chagra" / "del grafo" / "En el grafo"` → `"catálogo Chagra"` (o se omite cuando no aporta).
- Ids en latín impresos en pantalla (`persea_americana`, `mangifera_indica`, `citrus_sinensis/reticulata/latifolia`) → nombre común en español. Los **binomios bien formateados** (`Citrus × sinensis`, `Chrysophyllum cainito`, …) se conservan.
- El **grounding interno intacto**: comentarios JSDoc, `plagaGrafo`, `enGrafo` y las fuentes AGROSAVIA/ICA siguen igual. Solo se dejó de imprimir la jerga.

### 2. Tuteo → usted colombiano
Pantallas **Animales, Ciclo de cultivo, Ciclo de nutrientes, CicloCerrado y Mercado**: labels, hints, placeholders e imperativos pasados a *usted* (le/sus/registre/haga/déjelo/recójala…). Sin voseo argentino.

## Pantallas tocadas
- `citricos/CitricosScreen.jsx` + `data/citricosFinca.js`
- `mango/MangoScreen.jsx` + `data/mangoFinca.js`
- `aguacate/AguacateScreen.jsx` + `data/aguacateFinca.js`
- `AnimalesScreen.jsx` · `animales/CicloCerrado.jsx`
- `CicloCultivoScreen.jsx` · `CicloNutrientesScreen.jsx` · `MercadosScreen.jsx`

## Verificación
- `npm run build` verde.
- `voseo-scan` (regex del guard lefthook) limpio en los 11 archivos.
- 65 tests de las pantallas afectadas pasan (citricos, mango, aguacate, mercado, ciclo, animales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)