### PR TITLE
feat(mockup): hoja de vida VIVA de una mata — lámina que evoluciona por etapa

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,6 +107,9 @@ const CompostScreen = lazy(() => import('./components/CompostScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const OnboardingCondensado = lazy(() => import('./components/OnboardingCondensado'));
+// Galería de mockups (diseño): rutas públicas `#/mockups/<slug>`, sin auth ni
+// gate, datos de muestra. No cuentan como módulo de piloto. Ver MOCKUP_HASH_ROUTES.
+const HojaVidaMataMockup = lazy(() => import('./components/mockups/HojaVidaMataMockup'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const PlantaPorVozScreen = lazy(() => import('./components/PlantaPorVozScreen'));
@@ -416,6 +419,15 @@ const LoadingFallback = ({ view = null }) => {
 // viva (HERRAMIENTAS_TILES en DashboardLive). Las rutas `casos`/`caso_detail`/
 // `javier`/`usage_stats` siguen vivas en el router (más abajo) y por hash.
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
+
+// Rutas de MOCKUP de diseño (galería): PÚBLICAS — sin auth ni gate, datos de
+// muestra. Se resuelven ANTES del check de sesión (igual que el callback OAuth),
+// para que una lámina/ficha se pueda revisar sin cuenta. Patrón `#/mockups/<slug>`
+// (el hash se normaliza a `mockups/<slug>`). No entran en HASH_VIEW_ROUTES para
+// dejar explícito que NO pasan por los gates de sesión/rol.
+const MOCKUP_HASH_ROUTES = {
+  'mockups/hoja-vida-mata': 'mockup_hoja_vida_mata',
+};
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
@@ -915,6 +927,14 @@ export default function App() {
       return;
     }
 
+    // Mockups de diseño: públicos, sin auth. Se resuelven antes de isAuthenticated
+    // para que la galería (#/mockups/<slug>) abra sin cuenta.
+    const mockupView = MOCKUP_HASH_ROUTES[hash];
+    if (mockupView) {
+      Promise.resolve().then(() => navigate(mockupView));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -941,6 +961,12 @@ export default function App() {
   useEffect(() => {
     const handleHashRoute = () => {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
+      // Mockups públicos: navegar directo, sin pasar por auth ni gates.
+      const mockupView = MOCKUP_HASH_ROUTES[hash];
+      if (mockupView) {
+        navigate(mockupView);
+        return;
+      }
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
@@ -2490,6 +2516,17 @@ export default function App() {
             </ErrorFallback>
           </ErrorBoundary>
         );
+      case 'mockup_hoja_vida_mata':
+        // Mockup de galería (público, datos de muestra): la hoja de vida VIVA de
+        // una mata individual — lámina que se redibuja por etapa + línea de
+        // tiempo de cuaderno de campo. Ruta #/mockups/hoja-vida-mata.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Hoja de vida de la mata">
+              <HojaVidaMataMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
       default:
         return (
           <ErrorBoundary>
@@ -2563,7 +2600,7 @@ export default function App() {
           Tampoco en onboarding-perfil (tarea #16): el FAB se encimaba sobre el
           CTA "Explorar con finca de ejemplo" del footer y la usuaria nueva aún
           no conoce al agente — ruido en su primer flujo. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && <AgentFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && currentView !== 'mockup_hoja_vida_mata' && <AgentFab onNavigate={navigate} />}
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o
           pregunta al agente punta a punta por voz.

--- a/src/components/mockups/HojaVidaMataMockup.jsx
+++ b/src/components/mockups/HojaVidaMataMockup.jsx
@@ -1,0 +1,232 @@
+/*
+ * i18n (ADR-050): copy de campo en español Colombia (usted). Es un MOCKUP de
+ * galería con datos de muestra, sin gate ni auth; el copy final migraría a
+ * src/config/messages.js — mismo criterio que los hubs de mundo.
+ */
+import { useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import LaminaMataEtapa from './LaminaMataEtapa';
+import './hoja-vida-mata.css';
+
+/**
+ * HojaVidaMataMockup — la HOJA DE VIDA VIVA de una mata individual.
+ *
+ * Moonshot de galería: la ficha de UNA planta concreta como una lámina de
+ * cuaderno de campo que EVOLUCIONA con su estado real. Un selector recorre las
+ * seis etapas (semilla → plántula → juvenil → adulta → floración → cosecha) y la
+ * lámina se REDIBUJA distinta en cada una (ver LaminaMataEtapa). Debajo, la
+ * línea de tiempo de eventos reales de esta mata al estilo cuaderno.
+ *
+ * Anti-gamificación (dirección educativa de Chagra): no hay puntos ni medallas.
+ * El eje es la OBSERVACIÓN y la PACIENCIA — la ficha narra lo que se vio y lo que
+ * se hizo, no lo que se "ganó". Tono campesino, usted colombiano.
+ *
+ * Ruta pública `#/mockups/hoja-vida-mata` (sin auth, datos de muestra).
+ *
+ * @param {Object} props
+ * @param {Function} [props.onBack] volver al dashboard.
+ */
+
+// Datos de muestra de UNA mata concreta. En producción saldrían del asset +
+// sus logs (siembra/observación/cosecha) — el modelo asset-flat + log de Chagra.
+const MATA = {
+  nombre: 'Tomate #7',
+  variedad: 'Tomate chonto',
+  ubicacion: 'era 3 · huerta de la casa',
+  sembrada: '08 de marzo, 2026',
+  etapaActual: 'cosecha',
+};
+
+// Las seis etapas, con el día desde la siembra y una lectura de campo de qué
+// mirar en cada una. `dia` es el número de días transcurridos (dato observado).
+const ETAPAS = [
+  {
+    id: 'semilla',
+    orden: 1,
+    nombre: 'Semilla',
+    dia: 0,
+    lectura:
+      'La semilla en la tierra. Arriba no se ve nada: está echando raíz. Aquí toca esperar y mantener el semillero húmedo, sin encharcarlo.',
+  },
+  {
+    id: 'plantula',
+    orden: 2,
+    nombre: 'Plántula',
+    dia: 12,
+    lectura:
+      'Rompió el suelo. Esos dos gajitos de abajo (los cotiledones) no son hoja de verdad; la hoja verdadera es la del centro. Está tiernita: cuídela del sol fuerte y del frío.',
+  },
+  {
+    id: 'juvenil',
+    orden: 3,
+    nombre: 'Juvenil',
+    dia: 28,
+    lectura:
+      'Ya es una matica. Echa hojas y sube derecha. Es buen momento para pasarla al surco, con la tierra suelta y bien abonada.',
+  },
+  {
+    id: 'adulto',
+    orden: 4,
+    nombre: 'Adulta',
+    dia: 45,
+    lectura:
+      'La mata se hizo. Pide tutor para no irse al suelo con el peso. Tallo grueso y hojas grandes: está lista para florecer.',
+  },
+  {
+    id: 'floracion',
+    orden: 5,
+    nombre: 'Floración',
+    dia: 57,
+    lectura:
+      'Salieron las flores amarillas en racimo. De cada flor, si cuaja, sale un tomate. No le falte agua pareja en esta etapa o bota la flor.',
+  },
+  {
+    id: 'cosecha',
+    orden: 6,
+    nombre: 'Cosecha',
+    dia: 110,
+    lectura:
+      'Los racimos cargados. Se recoge el tomate cuando empieza a pintar y termina de madurar en la mata. Vaya cosechando parejo para que siga cargando.',
+  },
+];
+
+// La línea de tiempo: lo que REALMENTE le pasó a esta mata. `tipo` marca el
+// punto (hito de crecimiento / cuidado que se atendió / estado de hoy).
+const EVENTOS = [
+  {
+    etapa: 'semilla',
+    fecha: '08 mar',
+    tipo: 'hito',
+    titulo: 'Se sembró',
+    nota: 'Se puso la semilla en el semillero, en era 3, sobre lombricompuesto. Se anotó la fecha para contar los días.',
+  },
+  {
+    etapa: 'plantula',
+    fecha: '20 mar',
+    tipo: 'hito',
+    titulo: 'Sacó la primera hoja',
+    nota: 'A los 12 días asomó el tallito con sus dos cotiledones y, al centro, la primera hoja verdadera.',
+  },
+  {
+    etapa: 'juvenil',
+    fecha: '05 abr',
+    tipo: 'hito',
+    titulo: 'Se pasó al surco',
+    nota: 'Trasplante a la era. Prendió bien; a los tres días ya estaba parada y con color.',
+  },
+  {
+    etapa: 'adulto',
+    fecha: '22 abr',
+    tipo: 'hito',
+    titulo: 'Se le puso el tutor',
+    nota: 'La mata se hizo y empezó a pesar. Se entutoró con una estaca y se amarró suave para no ahorcar el tallo.',
+  },
+  {
+    etapa: 'floracion',
+    fecha: '04 may',
+    tipo: 'hito',
+    titulo: 'Empezó a florecer',
+    nota: 'Primeros racimos de flor amarilla. Se cuidó el riego parejo para que cuajaran y no botara flor.',
+  },
+  {
+    etapa: 'floracion',
+    fecha: '18 may',
+    tipo: 'cuidado',
+    titulo: 'Aguantó la gota',
+    nota: 'Aparecieron manchas de gota (tizón) en las hojas de abajo. Se quitaron esas hojas, se aireó la mata y se ayudó con caldo de cola de caballo. Se recuperó.',
+  },
+  {
+    etapa: 'cosecha',
+    fecha: '26 jun',
+    tipo: 'actual',
+    titulo: 'Primeros tomates',
+    nota: 'Cuajó y maduró el primer racimo. Desde acá se cosecha parejo, a medida que van pintando.',
+  },
+];
+
+const TIPO_CLASE = { hito: 'is-hito', cuidado: 'is-cuidado', actual: 'is-actual' };
+
+export default function HojaVidaMataMockup({ onBack }) {
+  const [etapaId, setEtapaId] = useState(MATA.etapaActual);
+  const etapa = ETAPAS.find((e) => e.id === etapaId) || ETAPAS[0];
+  const volver = onBack || (() => { window.location.hash = ''; });
+
+  return (
+    <div className="hvm">
+      <div className="hvm-top">
+        <button type="button" className="hvm-volver" onClick={volver}>
+          <ArrowLeft size={16} aria-hidden="true" /> Volver
+        </button>
+        <span className="hvm-sello">Muestra</span>
+      </div>
+
+      {/* Cabecera de la ficha */}
+      <header className="hvm-cabecera">
+        <h1 className="hvm-titulo">{MATA.nombre} · {MATA.ubicacion.split(' · ')[0]}</h1>
+        <p className="hvm-sub">{MATA.variedad}</p>
+        <div className="hvm-meta">
+          <span className="hvm-chip">Sembrada el {MATA.sembrada}</span>
+          <span className="hvm-chip">{MATA.ubicacion}</span>
+          <span className="hvm-chip">Hoy: {etapa.nombre.toLowerCase()} · día {ETAPAS.find((e) => e.id === MATA.etapaActual).dia}</span>
+        </div>
+      </header>
+
+      {/* Lámina viva + selector de etapa */}
+      <section className="hvm-lamina-card" aria-label="Lámina de la mata por etapa">
+        <div className="hvm-lamina-marco">
+          <LaminaMataEtapa etapa={etapa.id} />
+        </div>
+
+        <div className="hvm-etapas" role="group" aria-label="Etapas de la mata">
+          {ETAPAS.map((e) => (
+            <button
+              key={e.id}
+              type="button"
+              className="hvm-etapa-btn"
+              aria-pressed={e.id === etapaId}
+              onClick={() => setEtapaId(e.id)}
+            >
+              <span className="hvm-etapa-orden">{e.orden} de {ETAPAS.length}</span>
+              <span className="hvm-etapa-nom">{e.nombre}</span>
+              <span className="hvm-etapa-dia">día {e.dia}</span>
+            </button>
+          ))}
+        </div>
+
+        <div className="hvm-lamina-pie">
+          <p className="hvm-estado-hoy">
+            {etapa.nombre}
+            {etapa.id === MATA.etapaActual ? ' — así está hoy' : ` — día ${etapa.dia}`}
+          </p>
+          <p className="hvm-estado-desc">{etapa.lectura}</p>
+        </div>
+      </section>
+
+      {/* Línea de tiempo del cuaderno de campo */}
+      <h2 className="hvm-seccion-tit">Lo que le ha pasado a esta mata</h2>
+      <p className="hvm-seccion-lema">Sin puntos ni medallas. Solo lo que se vio, cuándo, y qué se hizo.</p>
+      <ol className="hvm-linea">
+        {EVENTOS.map((ev, i) => (
+          <li
+            key={`${ev.fecha}-${i}`}
+            className={`hvm-evento ${TIPO_CLASE[ev.tipo] || ''} ${ev.etapa === etapaId ? 'is-foco' : ''}`}
+          >
+            <span className="hvm-evento-punto" aria-hidden="true" />
+            <div className="hvm-evento-fecha">{ev.fecha}</div>
+            <div className="hvm-evento-tit">{ev.titulo}</div>
+            <p className="hvm-evento-nota">{ev.nota}</p>
+            {ev.tipo === 'actual' && <span className="hvm-evento-ahora">Aquí va hoy</span>}
+          </li>
+        ))}
+      </ol>
+
+      {/* Nota de cierre — dimensión educativa, anti-gamificación */}
+      <p className="hvm-cierre">
+        Esta hoja de vida no premia ni califica. Es un cuaderno: usted anota lo que
+        vio y lo que hizo, y la mata le va enseñando con su tiempo. <strong>A veces se
+        demora, a veces le da duro una plaga y la supera.</strong> Observar y tener
+        paciencia es el trabajo — no ganar puntos.
+      </p>
+    </div>
+  );
+}

--- a/src/components/mockups/LaminaMataEtapa.jsx
+++ b/src/components/mockups/LaminaMataEtapa.jsx
@@ -1,0 +1,281 @@
+import React from 'react';
+
+/**
+ * LaminaMataEtapa — la lámina VIVA de una mata individual.
+ *
+ * Misma familia que `LaminaSiembra`/`LaminaAporque` (cuaderno de campo: corte de
+ * suelo, trazo redondo, formas simples, colores de tinta sobre papel) pero aquí
+ * el dibujo NO es fijo: cambia según la ETAPA real de la mata. Cada etapa se
+ * compone distinta —
+ *
+ *   semilla    la semilla enterrada, con su radícula asomando          (bajo tierra)
+ *   plántula   el tallito que rompe el suelo: dos cotiledones + 1 hoja  (recién nacida)
+ *   juvenil    la mata que crece: varias hojas, sin flor                (creciendo)
+ *   adulta     la mata hecha, con su tutor y raíz honda                 (robusta)
+ *   floración  la misma mata, ahora con racimos de flor amarilla        (florece)
+ *   cosecha    los racimos cargados de tomate maduro colgando           (da fruto)
+ *
+ * Es DECORATIVA (aria-hidden): la ficha de al lado narra el estado real. El
+ * dibujo respira con las etapas — la raíz se hace honda, el tallo sube, la copa
+ * se llena — para que se LEA la evolución sin leer una palabra. Sin dependencia
+ * de las variables --c-* del tema: es una hoja de papel pegada encima, legible
+ * al sol sobre los cuatro temas. rsvg-safe (sin <text>, sin emoji-en-SVG).
+ *
+ * @param {Object} props
+ * @param {'semilla'|'plantula'|'juvenil'|'adulto'|'floracion'|'cosecha'} props.etapa
+ * @param {string} [props.className]
+ */
+
+// ── Paleta de tinta (fija, para leerse al sol; no hereda del tema) ──────────────
+const C = {
+  cielo: '#f4f6ea',
+  sol: '#e9c33f',
+  tierra: '#e7dabb',
+  tierraHonda: '#d9c79c',
+  surco: '#b98a2f',
+  raiz: '#a9843f',
+  raizHonda: '#8a6a2f',
+  tallo: '#3f8f4e',
+  talloHondo: '#2f6b3a',
+  hoja: '#4a9b57',
+  hojaTierna: '#7cba5a',
+  vena: '#2f6b3a',
+  cotiledon: '#9ccb6a',
+  flor: '#f2c53d',
+  florCentro: '#c9962c',
+  frutoMaduro: '#cc4b37',
+  frutoVerde: '#8aa54e',
+  caliz: '#3f8f4e',
+};
+
+// Una hoja ovada con nervadura (apunta hacia arriba desde su base en 0,0).
+function Hoja({ rot = 0, escala = 1, tono = C.hoja }) {
+  return (
+    <g transform={`rotate(${rot}) scale(${escala})`}>
+      <path
+        d="M0 0 C -11 -9 -10 -25 0 -33 C 10 -25 11 -9 0 0 Z"
+        fill={tono}
+        stroke={C.talloHondo}
+        strokeWidth="0.8"
+        strokeLinejoin="round"
+      />
+      <g stroke={C.vena} strokeWidth="0.9" strokeLinecap="round" fill="none" opacity="0.55">
+        <path d="M0 -2 L0 -30" />
+        <path d="M0 -12 L-6 -17" />
+        <path d="M0 -12 L6 -17" />
+        <path d="M0 -20 L-5 -25" />
+        <path d="M0 -20 L5 -25" />
+      </g>
+    </g>
+  );
+}
+
+// Flor de tomate: cinco pétalos en estrella + centro ocre.
+function Flor({ x = 0, y = 0, escala = 1 }) {
+  const petalos = [0, 72, 144, 216, 288];
+  return (
+    <g transform={`translate(${x} ${y}) scale(${escala})`}>
+      {petalos.map((a) => (
+        <ellipse key={a} cx="0" cy="-6" rx="2.6" ry="5.2" fill={C.flor} stroke={C.florCentro} strokeWidth="0.5" transform={`rotate(${a})`} />
+      ))}
+      <circle cx="0" cy="0" r="2.4" fill={C.florCentro} />
+    </g>
+  );
+}
+
+// Tomate: fruto con brillo y su cáliz de estrella verde arriba.
+function Tomate({ x = 0, y = 0, r = 7, maduro = true }) {
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <circle cx="0" cy="0" r={r} fill={maduro ? C.frutoMaduro : C.frutoVerde} stroke={C.raizHonda} strokeWidth="0.6" />
+      <ellipse cx={-r * 0.32} cy={-r * 0.34} rx={r * 0.34} ry={r * 0.22} fill="#ffffff" opacity="0.35" />
+      <g stroke={C.caliz} strokeWidth="1.4" strokeLinecap="round" fill="none">
+        <path d={`M0 ${-r} l-3 -3`} />
+        <path d={`M0 ${-r} l0 -4`} />
+        <path d={`M0 ${-r} l3 -3`} />
+      </g>
+    </g>
+  );
+}
+
+// Raíces: pivotante honda + laterales. `hondura` en px marca cuánto baja.
+function Raices({ hondura = 40 }) {
+  const lat = Math.min(1, hondura / 80);
+  return (
+    <g stroke={C.raiz} fill="none" strokeLinecap="round">
+      <path d={`M0 0 q 4 ${hondura * 0.4} -2 ${hondura}`} strokeWidth="2.4" stroke={C.raizHonda} />
+      <path d={`M0 6 q -${18 * lat} 8 -${24 * lat} ${28 * lat}`} strokeWidth="1.6" />
+      <path d={`M0 12 q ${18 * lat} 8 ${26 * lat} ${30 * lat}`} strokeWidth="1.6" />
+      <path d={`M-2 ${hondura * 0.45} q -${10 * lat} 6 -${14 * lat} ${18 * lat}`} strokeWidth="1.2" />
+      <path d={`M0 ${hondura * 0.6} q ${10 * lat} 6 ${13 * lat} ${16 * lat}`} strokeWidth="1.2" />
+    </g>
+  );
+}
+
+// El tutor (estaca) con sus amarres, para la mata ya hecha.
+function Tutor() {
+  return (
+    <g>
+      <line x1="24" y1="2" x2="24" y2="-112" stroke={C.surco} strokeWidth="4" strokeLinecap="round" />
+      <g stroke={C.raizHonda} strokeWidth="1.4" strokeLinecap="round">
+        <path d="M24 -30 q -12 -3 -22 -1" fill="none" />
+        <path d="M24 -66 q -14 -3 -24 -2" fill="none" />
+        <path d="M24 -96 q -12 -2 -20 -2" fill="none" />
+      </g>
+    </g>
+  );
+}
+
+// ── Cada etapa dibuja su propia mata (arte por etapa) ───────────────────────────
+function MataPorEtapa({ etapa }) {
+  switch (etapa) {
+    case 'semilla':
+      return (
+        <g>
+          <Raices hondura={30} />
+          {/* la semilla enterrada, inclinada */}
+          <g transform="rotate(-18)">
+            <ellipse cx="0" cy="16" rx="12" ry="8" fill={C.tierraHonda} stroke={C.raiz} strokeWidth="1.2" />
+            <path d="M-7 16 q 7 -4 14 0" fill="none" stroke={C.raizHonda} strokeWidth="0.9" />
+          </g>
+          {/* radícula que empieza a bajar */}
+          <path d="M0 22 q 3 12 -2 24" fill="none" stroke={C.raizHonda} strokeWidth="1.8" strokeLinecap="round" />
+          {/* el ganchito del brote que va a asomar */}
+          <path d="M0 8 q -2 -8 2 -13" fill="none" stroke={C.hojaTierna} strokeWidth="2.4" strokeLinecap="round" />
+        </g>
+      );
+    case 'plantula':
+      return (
+        <g>
+          <Raices hondura={40} />
+          {/* tallito */}
+          <path d="M0 0 q -2 -22 0 -46" fill="none" stroke={C.tallo} strokeWidth="3" strokeLinecap="round" />
+          {/* dos cotiledones opuestos */}
+          <ellipse cx="-11" cy="-44" rx="10" ry="4.6" fill={C.cotiledon} stroke={C.talloHondo} strokeWidth="0.7" transform="rotate(-18 -11 -44)" />
+          <ellipse cx="11" cy="-44" rx="10" ry="4.6" fill={C.cotiledon} stroke={C.talloHondo} strokeWidth="0.7" transform="rotate(18 11 -44)" />
+          {/* la primera hoja verdadera, tiernita */}
+          <g transform="translate(0 -48)"><Hoja rot={0} escala={0.7} tono={C.hojaTierna} /></g>
+        </g>
+      );
+    case 'juvenil':
+      return (
+        <g>
+          <Raices hondura={58} />
+          <path d="M0 0 q -3 -40 1 -82" fill="none" stroke={C.tallo} strokeWidth="4" strokeLinecap="round" />
+          {/* hojas alternas subiendo */}
+          <g transform="translate(-2 -22)"><Hoja rot={-58} escala={0.9} /></g>
+          <g transform="translate(1 -40)"><Hoja rot={62} escala={0.95} /></g>
+          <g transform="translate(-1 -58)"><Hoja rot={-52} escala={0.9} /></g>
+          <g transform="translate(1 -72)"><Hoja rot={54} escala={0.85} /></g>
+          <g transform="translate(0 -82)"><Hoja rot={0} escala={0.8} /></g>
+        </g>
+      );
+    case 'adulto':
+      return (
+        <g>
+          <Raices hondura={78} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -24)"><Hoja rot={-62} escala={1.1} /></g>
+          <g transform="translate(2 -40)"><Hoja rot={64} escala={1.15} /></g>
+          <g transform="translate(-2 -58)"><Hoja rot={-58} escala={1.1} /></g>
+          <g transform="translate(3 -74)"><Hoja rot={60} escala={1.05} /></g>
+          <g transform="translate(-2 -90)"><Hoja rot={-54} escala={1} /></g>
+          <g transform="translate(2 -102)"><Hoja rot={40} escala={0.9} /></g>
+          <g transform="translate(0 -108)"><Hoja rot={0} escala={0.85} /></g>
+        </g>
+      );
+    case 'floracion':
+      return (
+        <g>
+          <Raices hondura={80} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -26)"><Hoja rot={-62} escala={1.1} /></g>
+          <g transform="translate(2 -44)"><Hoja rot={64} escala={1.1} /></g>
+          <g transform="translate(-2 -64)"><Hoja rot={-58} escala={1.05} /></g>
+          <g transform="translate(3 -82)"><Hoja rot={58} escala={1} /></g>
+          <g transform="translate(0 -100)"><Hoja rot={0} escala={0.85} /></g>
+          {/* racimos de flor amarilla colgando de los nudos */}
+          <path d="M-6 -38 q -10 4 -14 12" fill="none" stroke={C.talloHondo} strokeWidth="1.4" />
+          <Flor x={-16} y={-26} escala={0.85} />
+          <Flor x={-24} y={-22} escala={0.75} />
+          <path d="M8 -70 q 12 3 16 12" fill="none" stroke={C.talloHondo} strokeWidth="1.4" />
+          <Flor x={20} y={-56} escala={0.9} />
+          <Flor x={27} y={-50} escala={0.75} />
+          <Flor x={14} y={-52} escala={0.7} />
+        </g>
+      );
+    case 'cosecha':
+      return (
+        <g>
+          <Raices hondura={82} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -26)"><Hoja rot={-62} escala={1.05} /></g>
+          <g transform="translate(2 -46)"><Hoja rot={64} escala={1.05} /></g>
+          <g transform="translate(-2 -66)"><Hoja rot={-58} escala={1} /></g>
+          <g transform="translate(3 -84)"><Hoja rot={58} escala={0.95} /></g>
+          <g transform="translate(0 -100)"><Hoja rot={0} escala={0.8} /></g>
+          {/* racimo cargado a la izquierda: maduros + uno verde */}
+          <path d="M-6 -40 q -12 6 -16 16" fill="none" stroke={C.talloHondo} strokeWidth="1.6" />
+          <Tomate x={-22} y={-22} r={7} maduro />
+          <Tomate x={-12} y={-16} r={6.5} maduro />
+          <Tomate x={-26} y={-33} r={5.5} maduro={false} />
+          {/* racimo a la derecha */}
+          <path d="M8 -72 q 14 6 18 16" fill="none" stroke={C.talloHondo} strokeWidth="1.6" />
+          <Tomate x={26} y={-52} r={7} maduro />
+          <Tomate x={16} y={-46} r={6} maduro />
+          <Tomate x={30} y={-63} r={5.5} maduro={false} />
+        </g>
+      );
+    default:
+      return null;
+  }
+}
+
+export default function LaminaMataEtapa({ etapa = 'semilla', className = '' }) {
+  return (
+    <svg
+      viewBox="0 0 320 300"
+      role="img"
+      aria-hidden="true"
+      className={`hvm-lamina-svg ${className}`}
+      data-testid="lamina-mata-etapa"
+      data-etapa={etapa}
+    >
+      {/* cielo tenue */}
+      <rect x="0" y="0" width="320" height="198" fill={C.cielo} />
+      {/* sol de cuaderno, arriba a la derecha */}
+      <g opacity="0.7">
+        <circle cx="272" cy="40" r="15" fill={C.sol} />
+        <g stroke={C.sol} strokeWidth="2.2" strokeLinecap="round">
+          <line x1="272" y1="14" x2="272" y2="6" />
+          <line x1="296" y1="40" x2="304" y2="40" />
+          <line x1="290" y1="22" x2="296" y2="16" />
+          <line x1="290" y1="58" x2="296" y2="64" />
+        </g>
+      </g>
+
+      {/* corte de suelo: superficie ondulada + cuerpo de tierra */}
+      <path d="M0 198 Q 80 192 160 197 T 320 195 L320 300 L0 300 Z" fill={C.tierra} />
+      <path d="M0 198 Q 80 192 160 197 T 320 195" fill="none" stroke={C.surco} strokeWidth="2.2" strokeLinecap="round" opacity="0.6" />
+      {/* motas de tierra (rsvg-safe, sin filtros) */}
+      <g fill={C.surco} opacity="0.32">
+        <circle cx="46" cy="232" r="2.1" />
+        <circle cx="92" cy="262" r="1.6" />
+        <circle cx="128" cy="240" r="1.9" />
+        <circle cx="214" cy="230" r="2" />
+        <circle cx="250" cy="264" r="1.7" />
+        <circle cx="286" cy="238" r="2.1" />
+        <circle cx="70" cy="284" r="1.5" />
+        <circle cx="190" cy="278" r="1.8" />
+      </g>
+
+      {/* la mata, re-montada por etapa para que reanime su crecimiento */}
+      <g key={etapa} transform="translate(160 197)" className="hvm-lamina-mata">
+        <MataPorEtapa etapa={etapa} />
+      </g>
+    </svg>
+  );
+}

--- a/src/components/mockups/hoja-vida-mata.css
+++ b/src/components/mockups/hoja-vida-mata.css
@@ -1,0 +1,320 @@
+/* ============================================================================
+   hoja-vida-mata.css — la HOJA DE VIDA VIVA de una mata (mockup de galería).
+
+   Identidad: CUADERNO DE CAMPO, la misma que el mundo Cultivos (papel crema,
+   tinta verde, Baloo 2 en títulos / Nunito en cuerpo). Es "papel pegado
+   encima": NO depende de las variables --c-* del tema, así se lee igual sobre
+   los cuatro temas y al sol. Namespace propio `.hvm-`.
+
+   Anti-gamificación: nada de puntos, medallas ni barras de progreso premiando.
+   El eje es la OBSERVACIÓN y la PACIENCIA — la línea de tiempo cuenta lo que
+   pasó, no lo que se "ganó". prefers-reduced-motion: fotograma final digno.
+   ========================================================================== */
+
+.hvm {
+  --hvm-papel: #fffdf6;
+  --hvm-papel-2: #f4f6ea;
+  --hvm-crema: #eaf3da;
+  --hvm-tinta: #26331f;
+  --hvm-tinta-suave: #4e5c42;
+  --hvm-verde: #3f8f4e;
+  --hvm-verde-hondo: #2f6b3a;
+  --hvm-ocre: #b98a2f;
+  --hvm-borde: rgba(38, 51, 31, 0.14);
+  --hvm-display: 'Baloo 2', 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --hvm-body: 'Nunito', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 10px 14px 40px;
+  font-family: var(--hvm-body);
+  color: var(--hvm-tinta);
+}
+
+/* ── Barra superior (volver + sello de mockup) ──────────────────────────────── */
+.hvm-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.hvm-volver {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--hvm-borde);
+  background: var(--hvm-papel);
+  color: var(--hvm-tinta);
+  font-family: var(--hvm-body);
+  font-weight: 700;
+  font-size: 14px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.hvm-volver:hover { background: var(--hvm-papel-2); }
+.hvm-sello {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--hvm-ocre);
+  border: 1px dashed var(--hvm-ocre);
+  border-radius: 6px;
+  padding: 3px 8px;
+}
+
+/* ── Encabezado de la ficha ─────────────────────────────────────────────────── */
+.hvm-cabecera {
+  border: 1px solid var(--hvm-borde);
+  border-bottom: 4px solid var(--hvm-verde);
+  border-radius: 18px;
+  background: var(--hvm-papel);
+  padding: 14px 16px;
+  box-shadow: 0 3px 14px rgba(38, 51, 31, 0.1);
+}
+.hvm-titulo {
+  margin: 0;
+  font-family: var(--hvm-display);
+  font-weight: 800;
+  font-size: clamp(21px, 6vw, 27px);
+  line-height: 1.1;
+}
+.hvm-sub {
+  margin: 5px 0 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--hvm-tinta-suave);
+}
+.hvm-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  margin-top: 11px;
+}
+.hvm-chip {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--hvm-verde-hondo);
+  background: var(--hvm-crema);
+  border: 1px solid var(--hvm-borde);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+/* ── Lámina + selector de etapa ─────────────────────────────────────────────── */
+.hvm-lamina-card {
+  margin-top: 16px;
+  border: 1px solid var(--hvm-borde);
+  border-radius: 18px;
+  background: var(--hvm-papel);
+  overflow: hidden;
+  box-shadow: 0 3px 14px rgba(38, 51, 31, 0.1);
+}
+.hvm-lamina-marco {
+  background: linear-gradient(180deg, var(--hvm-papel-2), var(--hvm-crema));
+  border-bottom: 1px solid var(--hvm-borde);
+}
+.hvm-lamina-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 340px;
+  margin: 0 auto;
+  user-select: none;
+}
+.hvm-lamina-pie {
+  padding: 11px 14px 13px;
+}
+.hvm-estado-hoy {
+  font-family: var(--hvm-display);
+  font-weight: 800;
+  font-size: 16px;
+  color: var(--hvm-verde-hondo);
+  margin: 0;
+}
+.hvm-estado-desc {
+  margin: 3px 0 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--hvm-tinta-suave);
+}
+
+/* El selector: escala de etapas semilla→cosecha, como una regla del cuaderno. */
+.hvm-etapas {
+  display: flex;
+  gap: 6px;
+  padding: 12px 12px 4px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+}
+.hvm-etapa-btn {
+  flex: 1 0 auto;
+  min-width: 92px;
+  border: 1px solid var(--hvm-borde);
+  background: var(--hvm-papel);
+  border-radius: 12px;
+  padding: 7px 8px 8px;
+  cursor: pointer;
+  text-align: center;
+  font-family: var(--hvm-body);
+  color: var(--hvm-tinta-suave);
+  transition: transform 0.14s ease, border-color 0.14s ease, background 0.14s ease;
+}
+.hvm-etapa-btn:hover { background: var(--hvm-papel-2); }
+.hvm-etapa-btn[aria-pressed='true'] {
+  background: var(--hvm-crema);
+  border-color: var(--hvm-verde);
+  color: var(--hvm-verde-hondo);
+  transform: translateY(-2px);
+  box-shadow: 0 3px 0 var(--hvm-verde);
+}
+.hvm-etapa-orden {
+  display: block;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  opacity: 0.65;
+}
+.hvm-etapa-nom {
+  display: block;
+  font-family: var(--hvm-display);
+  font-weight: 800;
+  font-size: 14px;
+  line-height: 1.1;
+  margin-top: 1px;
+}
+.hvm-etapa-dia {
+  display: block;
+  font-size: 10.5px;
+  font-weight: 700;
+  opacity: 0.7;
+  margin-top: 1px;
+}
+
+/* ── Línea de tiempo del cuaderno ───────────────────────────────────────────── */
+.hvm-seccion-tit {
+  font-family: var(--hvm-display);
+  font-weight: 800;
+  font-size: 18px;
+  margin: 22px 0 4px;
+}
+.hvm-seccion-lema {
+  margin: 0 0 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--hvm-tinta-suave);
+}
+.hvm-linea {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+/* el hilo vertical del cuaderno */
+.hvm-linea::before {
+  content: '';
+  position: absolute;
+  left: 9px;
+  top: 6px;
+  bottom: 10px;
+  width: 2px;
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--hvm-ocre) 0 5px,
+    transparent 5px 10px
+  );
+  opacity: 0.5;
+}
+.hvm-evento {
+  position: relative;
+  padding: 0 4px 16px 32px;
+}
+.hvm-evento-punto {
+  position: absolute;
+  left: 3px;
+  top: 3px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: var(--hvm-papel);
+  border: 3px solid var(--hvm-verde);
+  box-sizing: border-box;
+}
+.hvm-evento.is-hito .hvm-evento-punto {
+  background: var(--hvm-verde);
+  border-color: var(--hvm-verde-hondo);
+}
+.hvm-evento.is-cuidado .hvm-evento-punto { border-color: var(--hvm-ocre); }
+.hvm-evento.is-actual .hvm-evento-punto {
+  border-color: var(--hvm-verde-hondo);
+  box-shadow: 0 0 0 4px rgba(63, 143, 78, 0.18);
+}
+.hvm-evento-fecha {
+  font-size: 11.5px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: var(--hvm-ocre);
+}
+.hvm-evento-tit {
+  font-family: var(--hvm-display);
+  font-weight: 800;
+  font-size: 15px;
+  margin: 1px 0 2px;
+}
+.hvm-evento-nota {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--hvm-tinta-suave);
+  margin: 0;
+}
+.hvm-evento-ahora {
+  display: inline-block;
+  margin-top: 5px;
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--hvm-verde-hondo);
+  background: var(--hvm-crema);
+  border: 1px solid var(--hvm-verde);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+/* ── Nota de cierre (dimensión educativa, anti-gamificación) ─────────────────── */
+.hvm-cierre {
+  margin-top: 20px;
+  border-left: 4px solid var(--hvm-ocre);
+  background: var(--hvm-papel);
+  border-radius: 0 12px 12px 0;
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--hvm-tinta-suave);
+}
+.hvm-cierre strong { color: var(--hvm-tinta); }
+
+/* ── Animación de crecimiento al cambiar de etapa ───────────────────────────── */
+.hvm-lamina-mata {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: hvm-brota 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes hvm-brota {
+  from { opacity: 0; transform: scaleY(0.82) translateY(4px); }
+  to   { opacity: 1; transform: scaleY(1) translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hvm-lamina-mata { animation: none; }
+  .hvm-etapa-btn { transition: none; }
+  .hvm-etapa-btn[aria-pressed='true'] { transform: none; }
+}
+
+/* ── 320px: la ficha respira en pantalla angosta ────────────────────────────── */
+@media (max-width: 360px) {
+  .hvm { padding: 8px 10px 36px; }
+  .hvm-etapa-btn { min-width: 82px; }
+}


### PR DESCRIPTION
## Qué es

Mockup de galería (moonshot): la **hoja de vida VIVA de una mata individual** — la ficha de UNA planta concreta como una lámina de cuaderno de campo que **se redibuja según su etapa real**.

Ruta pública **`#/mockups/hoja-vida-mata`** (sin auth ni gate, datos de muestra). Datos de muestra: **Tomate #7 · era 3**.

## Las 6 etapas (arte generativo por etapa)

Un selector recorre `semilla → plántula → juvenil → adulta → floración → cosecha` y la lámina SVG se compone distinta en cada una:

- **Semilla** — la semilla enterrada con su radícula asomando (todo bajo tierra).
- **Plántula** — el tallito que rompe el suelo: dos cotiledones + la primera hoja verdadera.
- **Juvenil** — la matica que sube, varias hojas alternas, sin flor.
- **Adulta** — la mata hecha, con su tutor (estaca + amarres) y raíz honda.
- **Floración** — la misma mata con racimos de flor amarilla en estrella.
- **Cosecha** — los racimos cargados de tomate maduro (+ alguno verde) colgando.

La evolución se **lee sin leer**: la raíz se hace honda, el tallo sube, la copa se llena, aparecen flor y fruto. Animación de crecimiento al cambiar de etapa (`prefers-reduced-motion` = fotograma final digno).

## Cuaderno de campo

Debajo, la **línea de tiempo** de lo que le pasó a esta mata: sembrada, primera hoja, trasplante, se le puso el tutor, floró, **aguantó la gota** (plaga superada, manejo agroecológico), primeros tomates.

## Diseño y decisiones

- Reusa la identidad **cuaderno de campo** del mundo Cultivos (papel crema, tinta verde, Baloo 2 / Nunito) y la familia de láminas `LaminaSiembra`/`LaminaAporque` (corte de suelo, trazo redondo, tinta sobre `currentColor`/paleta fija, `rsvg-safe`). No depende de `--c-*`: se lee sobre los 4 temas y al sol.
- **Anti-gamificación** (dirección educativa de Chagra): nada de puntos ni medallas. El eje es la **observación y la paciencia** — la ficha narra lo que se vio y se hizo, no lo que se "ganó".
- Tono campesino, **usted colombiano**, sin voseo.
- **Responsive 320px**. Componente autocontenido (no arrastra stores/NotificationsBell) para que la ruta pública abra sin sesión.

## Cableado

- `MOCKUP_HASH_ROUTES` (público, resuelto antes de `isAuthenticated`, patrón del callback OAuth) + case en el switch de render + exclusión del `AgentFab`.

## Verificación

- `npm run build` verde; chunk `HojaVidaMataMockup` emitido con CSS.
- `eslint` limpio en archivos nuevos + `App.jsx`.
- Tests de routing existentes (compost, glaciar-gate) siguen verdes.
- Sin Playwright / sin alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)