### PR TITLE
feat(mockup): guardianes que aparecen — fauna nativa narrativa

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -121,6 +121,10 @@ const AlmanaqueScreen = lazy(() => import('./components/almanaque/AlmanaqueScree
 const AnoFincaScreen = lazy(() => import('./components/anofinca/AnoFincaScreen'));
 const SeguimientoProcesoScreen = lazy(() => import('./components/SeguimientoProcesoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
+// Mockup "Guardianes que aparecen" (#/mockups/guardianes-narrativos): pieza
+// visual sin gate ni auth, datos de muestra. Los guardianes de fauna nativa
+// LLEGAN contextualmente a la pantalla (floración→angelita, suelo→lombriz…).
+const MockupGuardianesNarrativos = lazy(() => import('./mockups/MockupGuardianesNarrativos'));
 // Módulo "Agua de la finca": cosecha de lluvia (calculadora determinista),
 // riego con medida (ETc; Kc/ETo = slots grounded-pendiente) y cuidar el agua
 // (calidad + nacimiento, caso "se me seca el nacimiento en verano").
@@ -418,6 +422,8 @@ const LoadingFallback = ({ view = null }) => {
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
 
 const HASH_VIEW_ROUTES = {
+  // Mockups (sin gate, datos de muestra) — se resuelven ANTES del auth check.
+  'mockups/guardianes-narrativos': 'mockup_guardianes',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -915,6 +921,17 @@ export default function App() {
       return;
     }
 
+    // Rutas de MOCKUP (#/mockups/...): piezas visuales sin gate ni auth, con
+    // datos de muestra. Se resuelven antes del isAuthenticated() para que se
+    // puedan revisar sin sesión (igual espíritu que las rutas públicas).
+    if (hash.startsWith('mockups/')) {
+      const mockView = HASH_VIEW_ROUTES[hash];
+      if (mockView) {
+        navigate(mockView);
+        return;
+      }
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -943,6 +960,11 @@ export default function App() {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
+      // Mockups sin gate: navegar directo sin pasar por isAuthenticated().
+      if (hash.startsWith('mockups/')) {
+        navigate(routeView);
+        return;
+      }
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
       if (routeView === 'extensionista' && !esExtensionistaActual()) {
         navigate('dashboard');
@@ -1186,6 +1208,13 @@ export default function App() {
     switch (currentView) {
       case 'loading':
         return <LoadingFallback view="loading" />;
+      case 'mockup_guardianes':
+        // Mockup "Guardianes que aparecen" — sin gate, datos de muestra.
+        return (
+          <ErrorBoundary>
+            <MockupGuardianesNarrativos onBack={() => navigate('dashboard')} />
+          </ErrorBoundary>
+        );
       case 'login':
         return (
           <ErrorBoundary>

--- a/src/mockups/MockupGuardianesNarrativos.jsx
+++ b/src/mockups/MockupGuardianesNarrativos.jsx
@@ -18,15 +18,22 @@
  *   - Mariposa pasionaria .. Dione juno (Nymphalidae, néctar de flores de la huerta)
  *   - Escarabajo estercolero Dichotomius belus (propio de Colombia, entierra el estiércol)
  *
+ * REUSO: los cuerpos de los guardianes YA NO se dibujan aquí — vienen de la
+ * librería visual `src/visual/creatures` (personajes de fauna reutilizables).
+ * Esta pantalla los consume en modo `inline` y solo aporta el ESCENARIO y la
+ * coreografía de LLEGADA. Si mejora un bicho, mejórelo en la librería.
+ *
  * TÉCNICA (catálogo 2026-07-10): SVG + CSS puros, cero deps; solo transform/
  * opacity animados (GPU, Android gama baja); glow feGaussianBlur+feMerge de la
  * familia GuardianEspiritu; acento que re-tiñe la escena (`--gn-acc`); transform
- * de posición en <g> externo y animación en <g> interno; prefers-reduced-motion
- * = fotograma final digno (los guardianes aparecen sin volar). Datos de muestra.
+ * de posición en <g> externo y ENTRADA en el <g> de la criatura;
+ * prefers-reduced-motion = fotograma final digno (los guardianes aparecen sin
+ * volar). Datos de muestra.
  *
  * Voz: usted-cordial colombiano, frases cortas (sin voseo).
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { AbejaAngelita, Colibri, Lombriz, Mariposa, Escarabajo } from '../visual/creatures';
 import './guardianes-narrativos.css';
 
 /* ─── ROSTER — fauna nativa REAL con binomio verificado ────────────────────── */
@@ -99,15 +106,11 @@ const ESTADOS = [
 
 const estadoById = (id) => ESTADOS.find((e) => e.id === id) || ESTADOS[0];
 
-/* ─── filtros SVG compartidos (glow + blur suave) — familia GuardianEspiritu ── */
+/* ─── filtros SVG del ESCENARIO — gradientes de agua/suelo. El glow de cada
+   guardián lo aporta ahora su propio componente de `src/visual/creatures`. ─── */
 function GnDefs() {
   return (
     <defs>
-      <filter id="gn-glow" x="-80%" y="-80%" width="260%" height="260%">
-        <feGaussianBlur stdDeviation="2.1" result="b" />
-        <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
-      </filter>
-      <filter id="gn-blur3"><feGaussianBlur stdDeviation="3" /></filter>
       <linearGradient id="gn-agua-grad" x1="0" y1="0" x2="0" y2="1">
         <stop offset="0" stopColor="#4fd8ff" stopOpacity="0.55" />
         <stop offset="1" stopColor="#2b7fbf" stopOpacity="0.15" />
@@ -120,158 +123,25 @@ function GnDefs() {
   );
 }
 
-/* ─── GUARDIANES ILUSTRADOS ─────────────────────────────────────────────────
-   Regla de la casa: transform de POSICIÓN en el <g> externo (lo pone el stage);
-   la ENTRADA en el <g> `.gn-anim`; la vida perpetua (aleteo) en el <g> interno. */
-
-/* Abeja angelita — cuerpo ámbar rayado, alitas de tul (Tetragonisca angustula) */
-function GuardianAbeja() {
-  return (
-    <g className="gn-anim gn-anim-flota">
-      <g filter="url(#gn-glow)">
-        <circle r="6" fill="#ffb54f" opacity="0.35" filter="url(#gn-blur3)" />
-        <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
-          style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
-        <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
-          stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
-        <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
-        <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
-        <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
-        <ellipse className="gn-ala" cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
-        <ellipse className="gn-ala" style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
-      </g>
-    </g>
-  );
-}
-
-/* Colibrí chillón — pico largo, garganta violeta, ala que bate (Colibri coruscans) */
-function GuardianColibri() {
-  return (
-    <g className="gn-anim gn-anim-vuela">
-      <g filter="url(#gn-glow)">
-        <circle r="6" fill="#2dffc4" opacity="0.35" filter="url(#gn-blur3)" />
-        {/* cola */}
-        <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
-        {/* cuerpo */}
-        <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
-        <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
-        {/* cabeza */}
-        <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
-        {/* garganta violeta iridiscente del chillón */}
-        <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
-        <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
-        <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
-        {/* pico largo y recto */}
-        <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
-        {/* alas que baten */}
-        <path className="gn-ala" d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
-        <path className="gn-ala" style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
-      </g>
-    </g>
-  );
-}
-
-/* Lombriz de tierra — cuerpo segmentado que ASOMA del suelo (Martiodrilus crassus) */
-function GuardianLombriz() {
-  return (
-    <g className="gn-anim gn-anim-sube">
-      <g filter="url(#gn-glow)">
-        {/* cuerpo curvo segmentado que sube */}
-        <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
-          fill="none" stroke="#c0715a" strokeWidth="7.4" strokeLinecap="round" />
-        <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
-          fill="none" stroke="#ff9d6a" strokeWidth="4.4" strokeLinecap="round" opacity="0.85" />
-        {/* anillos / segmentos */}
-        <g stroke="#7a3f2e" strokeWidth="0.9" opacity="0.65" strokeLinecap="round">
-          <path d="M-1.4,22 L1.4,20.5" /><path d="M-1.2,16.5 L2.2,15.5" />
-          <path d="M2.4,11.5 L5.6,11" /><path d="M3.4,5.5 L6.4,5.6" />
-          <path d="M2.8,-0.5 L5.6,-1.4" /><path d="M4.6,-6 L7.4,-7.6" />
-        </g>
-        {/* clitelo (banda clara característica) */}
-        <path d="M3.2,3 C2,-1 4,-4 6.6,-5" fill="none" stroke="#ffd9b0" strokeWidth="4.6" strokeLinecap="round" opacity="0.75" />
-        {/* cabecita */}
-        <circle cx="12.2" cy="-9.4" r="2.2" fill="#ff9d6a" />
-        <circle cx="13.2" cy="-10" r="0.6" fill="#3a1c12" opacity="0.7" />
-      </g>
-    </g>
-  );
-}
-
-/* Mariposa pasionaria — alas que abren y cierran (Dione juno) */
-function GuardianMariposa() {
-  return (
-    <g className="gn-anim gn-anim-mariposa">
-      <g filter="url(#gn-glow)">
-        {/* ala trasera izq/der */}
-        <g className="gn-mari-ala gn-mari-ala-izq">
-          <path d="M0,2 C-13,4 -18,12 -12,15 C-6,17 -1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
-          <circle cx="-9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
-        </g>
-        <g className="gn-mari-ala gn-mari-ala-der">
-          <path d="M0,2 C13,4 18,12 12,15 C6,17 1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
-          <circle cx="9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
-        </g>
-        {/* ala delantera izq/der (alas largas de Dione) */}
-        <g className="gn-mari-ala gn-mari-ala-izq">
-          <path d="M0,-2 C-16,-11 -24,-6 -22,0 C-20,5 -8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
-          <path d="M-20,-3 C-14,-2 -7,-1 -1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
-          <circle cx="-16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
-        </g>
-        <g className="gn-mari-ala gn-mari-ala-der">
-          <path d="M0,-2 C16,-11 24,-6 22,0 C20,5 8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
-          <path d="M20,-3 C14,-2 7,-1 1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
-          <circle cx="16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
-        </g>
-        {/* cuerpo + antenas */}
-        <ellipse cx="0" cy="2" rx="1.7" ry="9" fill="#2a1712" />
-        <circle cx="0" cy="-8" r="1.9" fill="#2a1712" />
-        <path d="M-0.8,-9.4 C-3,-13 -4.5,-14 -6,-13.6 M0.8,-9.4 C3,-13 4.5,-14 6,-13.6"
-          stroke="#2a1712" strokeWidth="0.8" fill="none" strokeLinecap="round" />
-        <circle cx="-6" cy="-13.6" r="0.9" fill="#ff6ad0" />
-        <circle cx="6" cy="-13.6" r="0.9" fill="#ff6ad0" />
-      </g>
-    </g>
-  );
-}
-
-/* Escarabajo estercolero — cuerpo negro brillante que rueda su bola (Dichotomius belus) */
-function GuardianEscarabajo() {
-  return (
-    <g className="gn-anim gn-anim-rueda">
-      {/* bola de abono que empuja (rueda) */}
-      <g className="gn-bola">
-        <circle cx="-13" cy="7" r="6.5" fill="#5a4230" />
-        <circle cx="-13" cy="7" r="6.5" fill="none" stroke="#3a2c1c" strokeWidth="1" />
-        <circle cx="-15" cy="5" r="1.5" fill="#6e5238" opacity="0.7" />
-        <circle cx="-11.5" cy="9" r="1.1" fill="#42301f" opacity="0.7" />
-      </g>
-      <g filter="url(#gn-glow)">
-        {/* patas que se mueven */}
-        <g className="gn-patas" stroke="#0c1206" strokeWidth="1.7" strokeLinecap="round">
-          <path d="M-4,4 L-9,10" /><path d="M0,5 L-1,11" /><path d="M4,4 L8,10" />
-        </g>
-        {/* élitros brillantes */}
-        <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="#141c10"
-          style={{ filter: 'drop-shadow(0 0 5px rgba(157,214,106,0.7))' }} />
-        <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="none" stroke="#9dd66a" strokeWidth="0.7" strokeOpacity="0.6" />
-        {/* sutura + brillo */}
-        <path d="M0,-5.6 L0,5.6" stroke="#0c1206" strokeWidth="0.8" />
-        <ellipse cx="-3.5" cy="-2.8" rx="2.6" ry="1.4" fill="#3d5a24" opacity="0.55" />
-        {/* cabeza + cuerno (Dichotomius) */}
-        <path d="M8,-3.4 C12,-3.8 13.4,-1 12.4,1.4 C11.4,3.6 9,3.6 8.2,2.6 C9.4,1 9.2,-1.4 8,-3.4 Z" fill="#0f150b" />
-        <path d="M11.2,-3.2 C12.6,-5 13.4,-4.4 13.2,-2.8" fill="none" stroke="#0f150b" strokeWidth="1.7" strokeLinecap="round" />
-        <circle cx="10.4" cy="-0.6" r="0.7" fill="#9dd66a" opacity="0.8" />
-      </g>
-    </g>
-  );
-}
-
+/* ─── GUARDIANES ILUSTRADOS — reusados de la librería `src/visual/creatures` ──
+   Regla de la escena: transform de POSICIÓN en el <g> externo (lo pone el
+   stage); la ENTRADA (`gn-anim-*`) viaja en el `className` de la criatura
+   `inline`; la vida perpetua (aleteo, alas, bola) la trae la propia criatura. */
 const CUERPO = {
-  abeja: GuardianAbeja,
-  colibri: GuardianColibri,
-  lombriz: GuardianLombriz,
-  mariposa: GuardianMariposa,
-  escarabajo: GuardianEscarabajo,
+  abeja: AbejaAngelita,
+  colibri: Colibri,
+  lombriz: Lombriz,
+  mariposa: Mariposa,
+  escarabajo: Escarabajo,
+};
+
+/* Coreografía de LLEGADA por guardián (definida en guardianes-narrativos.css). */
+const ENTRADA = {
+  abeja: 'gn-anim-flota',
+  colibri: 'gn-anim-vuela',
+  lombriz: 'gn-anim-sube',
+  mariposa: 'gn-anim-mariposa',
+  escarabajo: 'gn-anim-rueda',
 };
 
 /* Posición del guardián dentro del stage (viewBox 0 0 340 210). El colibrí y la
@@ -286,7 +156,7 @@ const POS = {
 
 /* ─── El STAGE: pequeña finca de noche con corte de suelo + hilo de agua ─────── */
 function Escena({ guardianId, keyTick }) {
-  const Cuerpo = CUERPO[guardianId] || GuardianAbeja;
+  const Cuerpo = CUERPO[guardianId] || AbejaAngelita;
   return (
     <svg className="gn-svg" viewBox="0 0 340 210" role="img"
       aria-label={`Escena: llegó ${GUARDIANES[guardianId].nombre}`}>
@@ -336,7 +206,7 @@ function Escena({ guardianId, keyTick }) {
       </g>
       {/* EL GUARDIÁN — remonta con key para re-disparar su entrada */}
       <g key={`g-${keyTick}`} transform={POS[guardianId]}>
-        <Cuerpo />
+        <Cuerpo inline className={`gn-anim ${ENTRADA[guardianId]}`} />
       </g>
     </svg>
   );

--- a/src/mockups/MockupGuardianesNarrativos.jsx
+++ b/src/mockups/MockupGuardianesNarrativos.jsx
@@ -1,0 +1,458 @@
+/*
+ * MOCKUP — "Guardianes que aparecen" (#/mockups/guardianes-narrativos)
+ * ---------------------------------------------------------------------------
+ * Los guardianes de fauna de la chagra como PERSONAJES ILUSTRADOS que LLEGAN
+ * contextualmente a la pantalla: la abeja angelita visita cuando el cultivo
+ * florece, la lombriz sube cuando el suelo mejora, el colibrí vuelve tras la
+ * lluvia, la mariposa ronda en cosecha, el escarabajo entierra el abono.
+ *
+ * HILO MÍTICO (muisca vivo, NO gamificación): Bachué —la Madre Agua que salió
+ * de la laguna de Iguaque y pobló la tierra— manda a sus mensajeros. El agua es
+ * el hilo que corre al pie de la escena. Sin puntos, sin logros, sin niveles:
+ * los guardianes solo APARECEN cuando algo está pasando bien.
+ *
+ * GROUNDING: cada guardián es fauna REAL con binomio verificado (ver `fuente`).
+ *   - Abeja angelita ....... Tetragonisca angustula (meliponino nativo, SIN aguijón — NO Apis)
+ *   - Colibrí chillón ...... Colibri coruscans (colibrí nativo de jardines andinos)
+ *   - Lombriz de tierra .... Martiodrilus crassus (lombriz gigante nativa de los Andes)
+ *   - Mariposa pasionaria .. Dione juno (Nymphalidae, néctar de flores de la huerta)
+ *   - Escarabajo estercolero Dichotomius belus (propio de Colombia, entierra el estiércol)
+ *
+ * TÉCNICA (catálogo 2026-07-10): SVG + CSS puros, cero deps; solo transform/
+ * opacity animados (GPU, Android gama baja); glow feGaussianBlur+feMerge de la
+ * familia GuardianEspiritu; acento que re-tiñe la escena (`--gn-acc`); transform
+ * de posición en <g> externo y animación en <g> interno; prefers-reduced-motion
+ * = fotograma final digno (los guardianes aparecen sin volar). Datos de muestra.
+ *
+ * Voz: usted-cordial colombiano, frases cortas (sin voseo).
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import './guardianes-narrativos.css';
+
+/* ─── ROSTER — fauna nativa REAL con binomio verificado ────────────────────── */
+const GUARDIANES = {
+  abeja: {
+    nombre: 'Abeja angelita',
+    cientifico: 'Tetragonisca angustula',
+    acc: '#ffb54f', accRgb: '255, 181, 79',
+    fuente: 'Meliponino nativo sin aguijón — polinizador de la chagra',
+  },
+  colibri: {
+    nombre: 'Colibrí chillón',
+    cientifico: 'Colibri coruscans',
+    acc: '#2dffc4', accRgb: '45, 255, 196',
+    fuente: 'Colibrí nativo de los Andes — visitante común de los jardines',
+  },
+  lombriz: {
+    nombre: 'Lombriz de tierra',
+    cientifico: 'Martiodrilus crassus',
+    acc: '#ff9d6a', accRgb: '255, 157, 106',
+    fuente: 'Lombriz gigante nativa de los Andes — ingeniera del suelo vivo',
+  },
+  mariposa: {
+    nombre: 'Mariposa pasionaria',
+    cientifico: 'Dione juno',
+    acc: '#ff6ad0', accRgb: '255, 106, 208',
+    fuente: 'Mariposa de alas largas — néctar de las flores de la huerta',
+  },
+  escarabajo: {
+    nombre: 'Escarabajo estercolero',
+    cientifico: 'Dichotomius belus',
+    acc: '#9dd66a', accRgb: '157, 214, 106',
+    fuente: 'Escarabajo del abono, propio de Colombia — entierra el estiércol',
+  },
+};
+
+/* ─── ESTADOS DE MUESTRA — el contexto que hace LLEGAR a cada guardián ──────── */
+const ESTADOS = [
+  {
+    id: 'floracion', guardian: 'abeja',
+    chip: 'Floración', signo: 'Su cultivo está floreciendo',
+    narrativa:
+      'Vea, llegó la angelita. Eso quiere decir que su cultivo está floreciendo bien; ella va de flor en flor y le cuaja la cosecha.',
+  },
+  {
+    id: 'suelo', guardian: 'lombriz',
+    chip: 'Suelo mejorando', signo: 'La tierra va recobrando vida',
+    narrativa:
+      'La lombriz está trabajando su suelo. Cuando ella asoma, es que la tierra volvió a estar viva y aireada.',
+  },
+  {
+    id: 'lluvia', guardian: 'colibri',
+    chip: 'Después de la lluvia', signo: 'Escampó sobre la finca',
+    narrativa:
+      'Escampó y salió el colibrí a las flores nuevas. El agua que dejó Bachué despertó el néctar de su huerta.',
+  },
+  {
+    id: 'cosecha', guardian: 'mariposa',
+    chip: 'Cosecha', signo: 'Su cultivo está para cosechar',
+    narrativa:
+      'La mariposa ronda su cultivo maduro. Donde ella baila hay flores sanas y frutos que ya vienen.',
+  },
+  {
+    id: 'abono', guardian: 'escarabajo',
+    chip: 'Abonó la tierra', signo: 'Echó estiércol al cultivo',
+    narrativa:
+      'Llegó el escarabajo. Él entierra el abono por usted y le afloja la tierra sin herramienta.',
+  },
+];
+
+const estadoById = (id) => ESTADOS.find((e) => e.id === id) || ESTADOS[0];
+
+/* ─── filtros SVG compartidos (glow + blur suave) — familia GuardianEspiritu ── */
+function GnDefs() {
+  return (
+    <defs>
+      <filter id="gn-glow" x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.1" result="b" />
+        <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+      </filter>
+      <filter id="gn-blur3"><feGaussianBlur stdDeviation="3" /></filter>
+      <linearGradient id="gn-agua-grad" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stopColor="#4fd8ff" stopOpacity="0.55" />
+        <stop offset="1" stopColor="#2b7fbf" stopOpacity="0.15" />
+      </linearGradient>
+      <linearGradient id="gn-suelo-grad" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stopColor="#3a2c22" />
+        <stop offset="1" stopColor="#1a120d" />
+      </linearGradient>
+    </defs>
+  );
+}
+
+/* ─── GUARDIANES ILUSTRADOS ─────────────────────────────────────────────────
+   Regla de la casa: transform de POSICIÓN en el <g> externo (lo pone el stage);
+   la ENTRADA en el <g> `.gn-anim`; la vida perpetua (aleteo) en el <g> interno. */
+
+/* Abeja angelita — cuerpo ámbar rayado, alitas de tul (Tetragonisca angustula) */
+function GuardianAbeja() {
+  return (
+    <g className="gn-anim gn-anim-flota">
+      <g filter="url(#gn-glow)">
+        <circle r="6" fill="#ffb54f" opacity="0.35" filter="url(#gn-blur3)" />
+        <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
+          style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
+        <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
+          stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
+        <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
+        <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
+        <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+        <ellipse className="gn-ala" cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
+        <ellipse className="gn-ala" style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+      </g>
+    </g>
+  );
+}
+
+/* Colibrí chillón — pico largo, garganta violeta, ala que bate (Colibri coruscans) */
+function GuardianColibri() {
+  return (
+    <g className="gn-anim gn-anim-vuela">
+      <g filter="url(#gn-glow)">
+        <circle r="6" fill="#2dffc4" opacity="0.35" filter="url(#gn-blur3)" />
+        {/* cola */}
+        <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
+        {/* cuerpo */}
+        <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
+        <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
+        {/* cabeza */}
+        <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
+        {/* garganta violeta iridiscente del chillón */}
+        <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
+        <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
+        <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+        {/* pico largo y recto */}
+        <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+        {/* alas que baten */}
+        <path className="gn-ala" d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
+        <path className="gn-ala" style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
+      </g>
+    </g>
+  );
+}
+
+/* Lombriz de tierra — cuerpo segmentado que ASOMA del suelo (Martiodrilus crassus) */
+function GuardianLombriz() {
+  return (
+    <g className="gn-anim gn-anim-sube">
+      <g filter="url(#gn-glow)">
+        {/* cuerpo curvo segmentado que sube */}
+        <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+          fill="none" stroke="#c0715a" strokeWidth="7.4" strokeLinecap="round" />
+        <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+          fill="none" stroke="#ff9d6a" strokeWidth="4.4" strokeLinecap="round" opacity="0.85" />
+        {/* anillos / segmentos */}
+        <g stroke="#7a3f2e" strokeWidth="0.9" opacity="0.65" strokeLinecap="round">
+          <path d="M-1.4,22 L1.4,20.5" /><path d="M-1.2,16.5 L2.2,15.5" />
+          <path d="M2.4,11.5 L5.6,11" /><path d="M3.4,5.5 L6.4,5.6" />
+          <path d="M2.8,-0.5 L5.6,-1.4" /><path d="M4.6,-6 L7.4,-7.6" />
+        </g>
+        {/* clitelo (banda clara característica) */}
+        <path d="M3.2,3 C2,-1 4,-4 6.6,-5" fill="none" stroke="#ffd9b0" strokeWidth="4.6" strokeLinecap="round" opacity="0.75" />
+        {/* cabecita */}
+        <circle cx="12.2" cy="-9.4" r="2.2" fill="#ff9d6a" />
+        <circle cx="13.2" cy="-10" r="0.6" fill="#3a1c12" opacity="0.7" />
+      </g>
+    </g>
+  );
+}
+
+/* Mariposa pasionaria — alas que abren y cierran (Dione juno) */
+function GuardianMariposa() {
+  return (
+    <g className="gn-anim gn-anim-mariposa">
+      <g filter="url(#gn-glow)">
+        {/* ala trasera izq/der */}
+        <g className="gn-mari-ala gn-mari-ala-izq">
+          <path d="M0,2 C-13,4 -18,12 -12,15 C-6,17 -1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+          <circle cx="-9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+        </g>
+        <g className="gn-mari-ala gn-mari-ala-der">
+          <path d="M0,2 C13,4 18,12 12,15 C6,17 1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+          <circle cx="9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+        </g>
+        {/* ala delantera izq/der (alas largas de Dione) */}
+        <g className="gn-mari-ala gn-mari-ala-izq">
+          <path d="M0,-2 C-16,-11 -24,-6 -22,0 C-20,5 -8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+          <path d="M-20,-3 C-14,-2 -7,-1 -1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+          <circle cx="-16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+        </g>
+        <g className="gn-mari-ala gn-mari-ala-der">
+          <path d="M0,-2 C16,-11 24,-6 22,0 C20,5 8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+          <path d="M20,-3 C14,-2 7,-1 1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+          <circle cx="16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+        </g>
+        {/* cuerpo + antenas */}
+        <ellipse cx="0" cy="2" rx="1.7" ry="9" fill="#2a1712" />
+        <circle cx="0" cy="-8" r="1.9" fill="#2a1712" />
+        <path d="M-0.8,-9.4 C-3,-13 -4.5,-14 -6,-13.6 M0.8,-9.4 C3,-13 4.5,-14 6,-13.6"
+          stroke="#2a1712" strokeWidth="0.8" fill="none" strokeLinecap="round" />
+        <circle cx="-6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+        <circle cx="6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+      </g>
+    </g>
+  );
+}
+
+/* Escarabajo estercolero — cuerpo negro brillante que rueda su bola (Dichotomius belus) */
+function GuardianEscarabajo() {
+  return (
+    <g className="gn-anim gn-anim-rueda">
+      {/* bola de abono que empuja (rueda) */}
+      <g className="gn-bola">
+        <circle cx="-13" cy="7" r="6.5" fill="#5a4230" />
+        <circle cx="-13" cy="7" r="6.5" fill="none" stroke="#3a2c1c" strokeWidth="1" />
+        <circle cx="-15" cy="5" r="1.5" fill="#6e5238" opacity="0.7" />
+        <circle cx="-11.5" cy="9" r="1.1" fill="#42301f" opacity="0.7" />
+      </g>
+      <g filter="url(#gn-glow)">
+        {/* patas que se mueven */}
+        <g className="gn-patas" stroke="#0c1206" strokeWidth="1.7" strokeLinecap="round">
+          <path d="M-4,4 L-9,10" /><path d="M0,5 L-1,11" /><path d="M4,4 L8,10" />
+        </g>
+        {/* élitros brillantes */}
+        <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="#141c10"
+          style={{ filter: 'drop-shadow(0 0 5px rgba(157,214,106,0.7))' }} />
+        <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="none" stroke="#9dd66a" strokeWidth="0.7" strokeOpacity="0.6" />
+        {/* sutura + brillo */}
+        <path d="M0,-5.6 L0,5.6" stroke="#0c1206" strokeWidth="0.8" />
+        <ellipse cx="-3.5" cy="-2.8" rx="2.6" ry="1.4" fill="#3d5a24" opacity="0.55" />
+        {/* cabeza + cuerno (Dichotomius) */}
+        <path d="M8,-3.4 C12,-3.8 13.4,-1 12.4,1.4 C11.4,3.6 9,3.6 8.2,2.6 C9.4,1 9.2,-1.4 8,-3.4 Z" fill="#0f150b" />
+        <path d="M11.2,-3.2 C12.6,-5 13.4,-4.4 13.2,-2.8" fill="none" stroke="#0f150b" strokeWidth="1.7" strokeLinecap="round" />
+        <circle cx="10.4" cy="-0.6" r="0.7" fill="#9dd66a" opacity="0.8" />
+      </g>
+    </g>
+  );
+}
+
+const CUERPO = {
+  abeja: GuardianAbeja,
+  colibri: GuardianColibri,
+  lombriz: GuardianLombriz,
+  mariposa: GuardianMariposa,
+  escarabajo: GuardianEscarabajo,
+};
+
+/* Posición del guardián dentro del stage (viewBox 0 0 340 210). El colibrí y la
+   abeja llegan a las flores (alto); lombriz y escarabajo a la línea de suelo. */
+const POS = {
+  abeja: 'translate(232 74)',
+  colibri: 'translate(120 66)',
+  lombriz: 'translate(168 150)',
+  mariposa: 'translate(214 70)',
+  escarabajo: 'translate(150 150)',
+};
+
+/* ─── El STAGE: pequeña finca de noche con corte de suelo + hilo de agua ─────── */
+function Escena({ guardianId, keyTick }) {
+  const Cuerpo = CUERPO[guardianId] || GuardianAbeja;
+  return (
+    <svg className="gn-svg" viewBox="0 0 340 210" role="img"
+      aria-label={`Escena: llegó ${GUARDIANES[guardianId].nombre}`}>
+      <GnDefs />
+      {/* cielo/velo de la escena */}
+      <rect x="0" y="0" width="340" height="210" fill="#0a1420" />
+      {/* luna tenue */}
+      <circle cx="286" cy="34" r="13" fill="#eafff6" opacity="0.14" />
+      <circle cx="286" cy="34" r="8.5" fill="#eafff6" opacity="0.12" />
+      {/* estrellas */}
+      <g fill="#eafff6" opacity="0.5">
+        <circle cx="40" cy="30" r="1" /><circle cx="90" cy="20" r="0.8" />
+        <circle cx="150" cy="34" r="0.7" /><circle cx="210" cy="24" r="0.9" />
+        <circle cx="250" cy="46" r="0.7" /><circle cx="316" cy="60" r="0.8" />
+      </g>
+      {/* flores (contexto de los polinizadores) */}
+      <g stroke="#2f6e5a" strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.9">
+        <path d="M60,166 C58,140 66,128 62,112" />
+        <path d="M264,166 C266,142 258,130 262,116" />
+      </g>
+      <g>
+        <circle cx="62" cy="110" r="4.2" fill="#ff6ad0" opacity="0.85" />
+        <circle cx="62" cy="110" r="1.6" fill="#ffd76a" />
+        <circle cx="262" cy="114" r="4.2" fill="#b28dff" opacity="0.85" />
+        <circle cx="262" cy="114" r="1.6" fill="#ffd76a" />
+      </g>
+      {/* corte de suelo */}
+      <path d="M0,168 C60,162 120,166 180,164 C240,162 300,166 340,164 L340,210 L0,210 Z"
+        fill="url(#gn-suelo-grad)" />
+      <path d="M0,168 C60,162 120,166 180,164 C240,162 300,166 340,164"
+        fill="none" stroke="#4a3728" strokeWidth="1.4" opacity="0.7" />
+      {/* raicillas + micelio tenue en el suelo */}
+      <g stroke="#6e5238" strokeWidth="0.7" opacity="0.4" fill="none">
+        <path d="M40,172 C42,180 38,186 44,192" /><path d="M110,174 C112,182 108,188 114,196" />
+        <path d="M300,172 C298,182 304,188 300,196" />
+      </g>
+      {/* EL HILO DE AGUA DE BACHUÉ — corre al pie de la escena (Madre Agua) */}
+      <g className="gn-agua" aria-hidden="true">
+        <path d="M-10,202 C40,198 80,206 130,201 C180,196 220,206 270,201 C310,197 340,203 350,201 L350,212 L-10,212 Z"
+          fill="url(#gn-agua-grad)" />
+        <path className="gn-agua-brillo" d="M-10,200 C40,196 80,204 130,199 C180,194 220,204 270,199 C310,195 340,201 350,199"
+          fill="none" stroke="#bfeaff" strokeWidth="1" opacity="0.5" />
+      </g>
+      {/* halo de llegada (re-teñido por el guardián) */}
+      <g key={`halo-${keyTick}`} transform={POS[guardianId]}>
+        <circle className="gn-halo" r="10" fill="none" stroke="var(--gn-acc)" strokeWidth="1.4" opacity="0.7" />
+      </g>
+      {/* EL GUARDIÁN — remonta con key para re-disparar su entrada */}
+      <g key={`g-${keyTick}`} transform={POS[guardianId]}>
+        <Cuerpo />
+      </g>
+    </svg>
+  );
+}
+
+export default function MockupGuardianesNarrativos({ onBack = null }) {
+  const [estadoId, setEstadoId] = useState(ESTADOS[0].id);
+  const [saliendo, setSaliendo] = useState(false);
+  const [keyTick, setKeyTick] = useState(0); // fuerza remonte → re-dispara la entrada
+  const [auto, setAuto] = useState(false);
+  const timers = useRef([]);
+
+  const estado = estadoById(estadoId);
+  const guardian = GUARDIANES[estado.guardian];
+
+  const limpiar = () => { timers.current.forEach(clearTimeout); timers.current = []; };
+
+  // Cambio de guardián: el actual se DESPIDE (fade + deriva) y el nuevo LLEGA.
+  const irA = useCallback((next) => {
+    if (next === estadoId) return;
+    setSaliendo(true);
+    const t = setTimeout(() => {
+      setEstadoId(next);
+      setSaliendo(false);
+      setKeyTick((k) => k + 1);
+    }, 340);
+    timers.current.push(t);
+  }, [estadoId]);
+
+  // "Que lleguen solos": ciclo suave que muestra la aparición contextual.
+  useEffect(() => {
+    if (!auto) return undefined;
+    const orden = ESTADOS.map((e) => e.id);
+    const paso = () => {
+      setEstadoId((cur) => {
+        const idx = orden.indexOf(cur);
+        return orden[(idx + 1) % orden.length];
+      });
+      setKeyTick((k) => k + 1);
+    };
+    const iv = setInterval(paso, 4200);
+    return () => clearInterval(iv);
+  }, [auto]);
+
+  useEffect(() => limpiar, []);
+
+  return (
+    <div
+      className="gn-wrap"
+      style={{ '--gn-acc': guardian.acc, '--gn-acc-rgb': guardian.accRgb }}
+      data-guardian={estado.guardian}
+    >
+      <header className="gn-top">
+        <button type="button" className="gn-back" onClick={() => onBack && onBack()} aria-label="Volver">
+          <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+            <path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+        <div className="gn-top-txt">
+          <span className="gn-kicker">GUARDIANES QUE LLEGAN</span>
+          <span className="gn-top-sub">Mockup · datos de muestra</span>
+        </div>
+      </header>
+
+      {/* HILO MÍTICO — Bachué, la Madre Agua */}
+      <p className="gn-mito">
+        Bachué, la Madre Agua, manda sus mensajeros a su chagra. Cuando aparecen, es que algo está pasando bien.
+      </p>
+
+      {/* LA ESCENA donde el guardián aparece */}
+      <section className={`gn-stage ${saliendo ? 'saliendo' : 'entrando'}`} aria-live="polite">
+        <Escena guardianId={estado.guardian} keyTick={keyTick} />
+
+        {/* micro-narrativa que sube suave con el guardián */}
+        <div key={`n-${keyTick}`} className="gn-narrativa">
+          <div className="gn-narra-head">
+            <span className="gn-narra-nombre">{guardian.nombre}</span>
+            <span className="gn-narra-cientifico">{guardian.cientifico}</span>
+          </div>
+          <p className="gn-narra-frase">{estado.narrativa}</p>
+          <span className="gn-narra-fuente">{guardian.fuente}</span>
+        </div>
+      </section>
+
+      {/* SELECTOR de estado — el contexto que hace llegar a cada guardián */}
+      <div className="gn-selector" role="radiogroup" aria-label="Estado de la finca">
+        <span className="gn-selector-label">¿Qué está pasando en su finca?</span>
+        <div className="gn-chips">
+          {ESTADOS.map((e) => {
+            const on = e.id === estadoId;
+            const g = GUARDIANES[e.guardian];
+            return (
+              <button
+                key={e.id}
+                type="button"
+                role="radio"
+                aria-checked={on}
+                className={`gn-chip ${on ? 'on' : ''}`}
+                style={{ '--gn-chip-acc': g.acc, '--gn-chip-acc-rgb': g.accRgb }}
+                onClick={() => irA(e.id)}
+              >
+                <span className="gn-chip-signo">{e.chip}</span>
+                <span className="gn-chip-quien">{g.nombre}</span>
+              </button>
+            );
+          })}
+        </div>
+        <button
+          type="button"
+          className={`gn-auto ${auto ? 'on' : ''}`}
+          aria-pressed={auto}
+          onClick={() => setAuto((v) => !v)}
+        >
+          {auto ? 'Dejando que lleguen solos…' : 'Dejar que lleguen solos'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/mockups/guardianes-narrativos.css
+++ b/src/mockups/guardianes-narrativos.css
@@ -1,0 +1,273 @@
+/* MOCKUP "Guardianes que aparecen" — SVG+CSS puros, solo transform/opacity.
+   Familia visual GuardianEspiritu (glow neón orgánico). Acento por guardián
+   (--gn-acc / --gn-acc-rgb) re-tiñe la escena. reduced-motion = fotograma digno. */
+
+.gn-wrap {
+  --gn-acc: #2dffc4;
+  --gn-acc-rgb: 45, 255, 196;
+  min-height: 100dvh;
+  margin: 0 auto;
+  max-width: 480px;
+  padding: 14px 14px calc(20px + env(safe-area-inset-bottom));
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: #eafff6;
+  background:
+    radial-gradient(120% 60% at 50% -10%, rgba(var(--gn-acc-rgb), 0.14), transparent 60%),
+    linear-gradient(180deg, #071019 0%, #0a1420 42%, #06101b 100%);
+  font-family: 'Nunito', system-ui, -apple-system, sans-serif;
+}
+
+/* ── barra superior ── */
+.gn-top { display: flex; align-items: center; gap: 10px; }
+.gn-back {
+  flex: 0 0 auto;
+  width: 40px; height: 40px;
+  display: grid; place-items: center;
+  border: 1px solid rgba(var(--gn-acc-rgb), 0.35);
+  border-radius: 999px;
+  background: rgba(var(--gn-acc-rgb), 0.08);
+  color: var(--gn-acc);
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.2s ease;
+}
+.gn-back:hover { background: rgba(var(--gn-acc-rgb), 0.16); }
+.gn-back:active { transform: scale(0.94); }
+.gn-back:focus-visible { outline: 2px solid var(--gn-acc); outline-offset: 2px; }
+.gn-top-txt { display: flex; flex-direction: column; line-height: 1.15; }
+.gn-kicker {
+  font-family: 'Baloo 2', 'Nunito', sans-serif;
+  font-weight: 700; letter-spacing: 0.13em; font-size: 0.82rem;
+  color: var(--gn-acc);
+  text-shadow: 0 0 12px rgba(var(--gn-acc-rgb), 0.5);
+}
+.gn-top-sub { font-size: 0.68rem; opacity: 0.55; letter-spacing: 0.04em; }
+
+/* ── hilo mítico ── */
+.gn-mito {
+  margin: 0; padding: 0 2px;
+  font-size: 0.86rem; line-height: 1.4;
+  color: #cfe9df; opacity: 0.9;
+}
+
+/* ── EL STAGE ── */
+.gn-stage {
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(var(--gn-acc-rgb), 0.28);
+  background: #0a1420;
+  box-shadow: 0 0 40px rgba(var(--gn-acc-rgb), 0.14) inset, 0 8px 30px rgba(0,0,0,0.4);
+  transition: opacity 0.34s ease, transform 0.34s ease, border-color 0.5s ease;
+}
+.gn-stage.saliendo { opacity: 0; transform: translateY(8px) scale(0.99); }
+.gn-stage.entrando { opacity: 1; transform: none; }
+
+.gn-svg { display: block; width: 100%; height: auto; }
+
+/* halo de llegada (una vez) */
+.gn-halo {
+  transform-box: fill-box; transform-origin: center;
+  animation: gn-halo 0.9s ease-out both;
+}
+@keyframes gn-halo {
+  0% { transform: scale(0.2); opacity: 0; }
+  40% { opacity: 0.8; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+
+/* hilo de agua vivo (Madre Agua) */
+.gn-agua-brillo {
+  animation: gn-agua-brillo 6s ease-in-out infinite;
+}
+@keyframes gn-agua-brillo {
+  0%, 100% { opacity: 0.25; transform: translateX(0); }
+  50% { opacity: 0.6; transform: translateX(-6px); }
+}
+
+/* ── micro-narrativa flotante ── */
+.gn-narrativa {
+  position: absolute;
+  left: 12px; right: 12px; bottom: 12px;
+  padding: 11px 13px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(6,16,26,0.72), rgba(6,16,26,0.9));
+  backdrop-filter: blur(3px);
+  border: 1px solid rgba(var(--gn-acc-rgb), 0.3);
+  box-shadow: 0 0 22px rgba(var(--gn-acc-rgb), 0.16);
+  animation: gn-narra-in 0.6s cubic-bezier(0.22, 0.8, 0.3, 1) both;
+  animation-delay: 0.22s;
+}
+@keyframes gn-narra-in {
+  0% { opacity: 0; transform: translateY(14px); }
+  100% { opacity: 1; transform: none; }
+}
+.gn-narra-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.gn-narra-nombre {
+  font-family: 'Baloo 2', 'Nunito', sans-serif;
+  font-weight: 700; font-size: 1rem; color: var(--gn-acc);
+  text-shadow: 0 0 10px rgba(var(--gn-acc-rgb), 0.45);
+}
+.gn-narra-cientifico { font-size: 0.72rem; font-style: italic; opacity: 0.62; }
+.gn-narra-frase { margin: 5px 0 6px; font-size: 0.9rem; line-height: 1.38; color: #eafff6; }
+.gn-narra-fuente {
+  display: inline-block; font-size: 0.66rem; letter-spacing: 0.02em;
+  color: #a9c7bd; opacity: 0.85;
+  border-left: 2px solid rgba(var(--gn-acc-rgb), 0.6); padding-left: 7px;
+}
+
+/* ── SELECTOR de estado ── */
+.gn-selector { display: flex; flex-direction: column; gap: 9px; }
+.gn-selector-label {
+  font-size: 0.8rem; opacity: 0.7; padding-left: 2px;
+  font-family: 'Baloo 2', 'Nunito', sans-serif; font-weight: 600;
+}
+.gn-chips {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(126px, 1fr));
+  gap: 8px;
+}
+.gn-chip {
+  --gn-chip-acc: #2dffc4;
+  --gn-chip-acc-rgb: 45, 255, 196;
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 9px 11px;
+  text-align: left;
+  border-radius: 13px;
+  border: 1px solid rgba(var(--gn-chip-acc-rgb), 0.28);
+  background: rgba(var(--gn-chip-acc-rgb), 0.06);
+  color: #eafff6;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.gn-chip:hover { background: rgba(var(--gn-chip-acc-rgb), 0.12); }
+.gn-chip:active { transform: scale(0.98); }
+.gn-chip:focus-visible { outline: 2px solid var(--gn-chip-acc); outline-offset: 2px; }
+.gn-chip.on {
+  border-color: rgba(var(--gn-chip-acc-rgb), 0.9);
+  background: rgba(var(--gn-chip-acc-rgb), 0.16);
+  box-shadow: 0 0 20px rgba(var(--gn-chip-acc-rgb), 0.28);
+}
+.gn-chip-signo {
+  font-family: 'Baloo 2', 'Nunito', sans-serif; font-weight: 700; font-size: 0.86rem;
+  color: var(--gn-chip-acc);
+}
+.gn-chip-quien { font-size: 0.72rem; opacity: 0.72; }
+
+.gn-auto {
+  align-self: flex-start;
+  margin-top: 2px;
+  padding: 7px 14px;
+  border-radius: 999px;
+  border: 1px dashed rgba(var(--gn-acc-rgb), 0.5);
+  background: transparent;
+  color: var(--gn-acc);
+  font-size: 0.78rem; font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.12s ease;
+}
+.gn-auto:hover { background: rgba(var(--gn-acc-rgb), 0.1); }
+.gn-auto:active { transform: scale(0.97); }
+.gn-auto:focus-visible { outline: 2px solid var(--gn-acc); outline-offset: 2px; }
+.gn-auto.on { background: rgba(var(--gn-acc-rgb), 0.14); border-style: solid; }
+
+/* ═══ ENTRADAS ORGÁNICAS POR GUARDIÁN (posición en <g> externo, entrada aquí) ═══ */
+
+/* abeja / mariposa: flotan hacia su flor con un arco */
+.gn-anim-flota { animation: gn-in-flota 0.7s cubic-bezier(0.2, 0.8, 0.3, 1) both; }
+.gn-anim-flota > g { animation: gn-flota 3.4s ease-in-out infinite; }
+@keyframes gn-in-flota {
+  0% { opacity: 0; transform: translate(18px, -14px) scale(0.7); }
+  100% { opacity: 1; transform: none; }
+}
+@keyframes gn-flota {
+  0%, 100% { transform: translateY(0) rotate(-2deg); }
+  50% { transform: translateY(-5px) rotate(2deg); }
+}
+
+/* colibrí: entra volando desde la izquierda y se queda meciéndose */
+.gn-anim-vuela { animation: gn-in-vuela 0.85s cubic-bezier(0.22, 0.9, 0.28, 1) both; }
+.gn-anim-vuela > g { animation: gn-vuela-idle 2.6s ease-in-out infinite; }
+@keyframes gn-in-vuela {
+  0% { opacity: 0; transform: translate(-64px, 10px) scale(0.85); }
+  60% { opacity: 1; }
+  100% { transform: none; }
+}
+@keyframes gn-vuela-idle {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-3px, -4px); }
+}
+
+/* lombriz: ASOMA subiendo de la tierra (la línea de suelo la recorta) */
+.gn-anim-sube { animation: gn-in-sube 0.9s cubic-bezier(0.3, 0.9, 0.35, 1) both; }
+.gn-anim-sube > g { animation: gn-sube-idle 3.6s ease-in-out infinite; transform-origin: bottom; }
+@keyframes gn-in-sube {
+  0% { opacity: 0; transform: translateY(30px); }
+  55% { opacity: 1; }
+  100% { transform: none; }
+}
+@keyframes gn-sube-idle {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(4deg); }
+}
+
+/* mariposa: entra en camino ondulado + alas que abren/cierran */
+.gn-anim-mariposa { animation: gn-in-mariposa 1s cubic-bezier(0.3, 0.7, 0.3, 1) both; }
+@keyframes gn-in-mariposa {
+  0% { opacity: 0; transform: translate(40px, -26px) rotate(-8deg); }
+  40% { opacity: 1; transform: translate(14px, 6px) rotate(6deg); }
+  70% { transform: translate(-6px, -4px) rotate(-3deg); }
+  100% { transform: none; }
+}
+.gn-mari-ala { transform-box: fill-box; transform-origin: center; animation: gn-aletea 0.5s ease-in-out infinite; }
+.gn-mari-ala-izq { transform-origin: right center; }
+.gn-mari-ala-der { transform-origin: left center; }
+@keyframes gn-aletea {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.4); }
+}
+
+/* escarabajo: RUEDA su bola de abono entrando desde la derecha */
+.gn-anim-rueda { animation: gn-in-rueda 1s cubic-bezier(0.25, 0.7, 0.35, 1) both; }
+@keyframes gn-in-rueda {
+  0% { opacity: 0; transform: translateX(72px); }
+  60% { opacity: 1; }
+  100% { transform: none; }
+}
+.gn-bola { transform-box: fill-box; transform-origin: center; animation: gn-rueda 1.1s linear infinite; }
+@keyframes gn-rueda { 0% { transform: rotate(0); } 100% { transform: rotate(-360deg); } }
+.gn-patas { animation: gn-pasos 0.5s ease-in-out infinite; }
+@keyframes gn-pasos {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-1.2px); }
+}
+
+/* alas genéricas (abeja/colibrí): batir rápido */
+.gn-ala { transform-box: fill-box; transform-origin: center bottom; animation: gn-batir 0.13s ease-in-out infinite alternate; }
+@keyframes gn-batir {
+  0% { transform: scaleY(1) scaleX(1); }
+  100% { transform: scaleY(0.6) scaleX(0.9); }
+}
+
+/* ═══ reduced-motion: los guardianes APARECEN sin volar (fotograma digno) ═══ */
+@media (prefers-reduced-motion: reduce) {
+  .gn-stage { transition: opacity 0.2s ease; }
+  .gn-stage.saliendo { transform: none; }
+  .gn-anim-flota, .gn-anim-vuela, .gn-anim-sube, .gn-anim-mariposa, .gn-anim-rueda,
+  .gn-anim-flota > g, .gn-anim-vuela > g, .gn-anim-sube > g,
+  .gn-mari-ala, .gn-bola, .gn-patas, .gn-ala, .gn-halo, .gn-agua-brillo {
+    animation: gn-solo-aparece 0.35s ease both !important;
+  }
+  @keyframes gn-solo-aparece { from { opacity: 0; } to { opacity: 1; } }
+  .gn-narrativa { animation: gn-solo-aparece 0.35s ease both; }
+}
+
+/* ═══ responsive 320px ═══ */
+@media (max-width: 360px) {
+  .gn-wrap { padding: 12px 10px calc(18px + env(safe-area-inset-bottom)); gap: 10px; }
+  .gn-chips { grid-template-columns: 1fr 1fr; }
+  .gn-narra-frase { font-size: 0.85rem; }
+  .gn-mito { font-size: 0.82rem; }
+}

--- a/src/mockups/guardianes-narrativos.css
+++ b/src/mockups/guardianes-narrativos.css
@@ -1,6 +1,9 @@
 /* MOCKUP "Guardianes que aparecen" — SVG+CSS puros, solo transform/opacity.
    Familia visual GuardianEspiritu (glow neón orgánico). Acento por guardián
-   (--gn-acc / --gn-acc-rgb) re-tiñe la escena. reduced-motion = fotograma digno. */
+   (--gn-acc / --gn-acc-rgb) re-tiñe la escena. reduced-motion = fotograma digno.
+   NOTA: la VIDA PERPETUA de cada bicho (aleteo, alas, bola, patas) vive ahora
+   en `src/visual/creatures/creatures.css`. Aquí queda solo el ESCENARIO y la
+   coreografía de LLEGADA de los guardianes. */
 
 .gn-wrap {
   --gn-acc: #2dffc4;
@@ -173,7 +176,8 @@
 .gn-auto:focus-visible { outline: 2px solid var(--gn-acc); outline-offset: 2px; }
 .gn-auto.on { background: rgba(var(--gn-acc-rgb), 0.14); border-style: solid; }
 
-/* ═══ ENTRADAS ORGÁNICAS POR GUARDIÁN (posición en <g> externo, entrada aquí) ═══ */
+/* ═══ ENTRADAS ORGÁNICAS POR GUARDIÁN (posición en <g> externo, entrada aquí) ═══
+   La vida perpetua de cada bicho la trae la librería `src/visual/creatures`. */
 
 /* abeja / mariposa: flotan hacia su flor con un arco */
 .gn-anim-flota { animation: gn-in-flota 0.7s cubic-bezier(0.2, 0.8, 0.3, 1) both; }
@@ -213,20 +217,13 @@
   50% { transform: rotate(4deg); }
 }
 
-/* mariposa: entra en camino ondulado + alas que abren/cierran */
+/* mariposa: entra en camino ondulado (sus alas las bate la propia criatura) */
 .gn-anim-mariposa { animation: gn-in-mariposa 1s cubic-bezier(0.3, 0.7, 0.3, 1) both; }
 @keyframes gn-in-mariposa {
   0% { opacity: 0; transform: translate(40px, -26px) rotate(-8deg); }
   40% { opacity: 1; transform: translate(14px, 6px) rotate(6deg); }
   70% { transform: translate(-6px, -4px) rotate(-3deg); }
   100% { transform: none; }
-}
-.gn-mari-ala { transform-box: fill-box; transform-origin: center; animation: gn-aletea 0.5s ease-in-out infinite; }
-.gn-mari-ala-izq { transform-origin: right center; }
-.gn-mari-ala-der { transform-origin: left center; }
-@keyframes gn-aletea {
-  0%, 100% { transform: scaleX(1); }
-  50% { transform: scaleX(0.4); }
 }
 
 /* escarabajo: RUEDA su bola de abono entrando desde la derecha */
@@ -236,20 +233,6 @@
   60% { opacity: 1; }
   100% { transform: none; }
 }
-.gn-bola { transform-box: fill-box; transform-origin: center; animation: gn-rueda 1.1s linear infinite; }
-@keyframes gn-rueda { 0% { transform: rotate(0); } 100% { transform: rotate(-360deg); } }
-.gn-patas { animation: gn-pasos 0.5s ease-in-out infinite; }
-@keyframes gn-pasos {
-  0%, 100% { transform: translateX(0); }
-  50% { transform: translateX(-1.2px); }
-}
-
-/* alas genéricas (abeja/colibrí): batir rápido */
-.gn-ala { transform-box: fill-box; transform-origin: center bottom; animation: gn-batir 0.13s ease-in-out infinite alternate; }
-@keyframes gn-batir {
-  0% { transform: scaleY(1) scaleX(1); }
-  100% { transform: scaleY(0.6) scaleX(0.9); }
-}
 
 /* ═══ reduced-motion: los guardianes APARECEN sin volar (fotograma digno) ═══ */
 @media (prefers-reduced-motion: reduce) {
@@ -257,7 +240,7 @@
   .gn-stage.saliendo { transform: none; }
   .gn-anim-flota, .gn-anim-vuela, .gn-anim-sube, .gn-anim-mariposa, .gn-anim-rueda,
   .gn-anim-flota > g, .gn-anim-vuela > g, .gn-anim-sube > g,
-  .gn-mari-ala, .gn-bola, .gn-patas, .gn-ala, .gn-halo, .gn-agua-brillo {
+  .gn-halo, .gn-agua-brillo {
     animation: gn-solo-aparece 0.35s ease both !important;
   }
   @keyframes gn-solo-aparece { from { opacity: 0; } to { opacity: 1; } }

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,0 +1,61 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
+   Apis). Cuerpo ámbar rayado, cabeza clara, alitas de tul. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-15 -15 32 30';
+
+export function AbejaAngelita({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Abeja angelita',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#ffb54f" opacity="0.35" filter={`url(#${blur})`} />
+      <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
+        style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
+      <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
+        stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
+      <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
+      <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
+      <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
+      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="abeja-angelita">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default AbejaAngelita;

--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,0 +1,62 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Colibrí chillón — Colibri coruscans (nativo de los Andes). Pico largo y
+   recto, garganta violeta iridiscente, alas que baten. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-22 -28 58 52';
+
+export function Colibri({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Colibrí',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#2dffc4" opacity="0.35" filter={`url(#${blur})`} />
+      <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
+      <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
+      <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
+      <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
+      <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
+      <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
+      <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+      <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <path className={wing} d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
+      <path className={wing} style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="colibri">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="colibri" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Colibri;

--- a/src/visual/creatures/Escarabajo.jsx
+++ b/src/visual/creatures/Escarabajo.jsx
@@ -1,0 +1,73 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Escarabajo estercolero — Dichotomius belus (propio de Colombia). Élitros
+   negros brillantes con sutura, cabeza con cuerno, patas que caminan y la bola
+   de abono que rueda. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-23 -12 42 30';
+
+export function Escarabajo({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Escarabajo estercolero',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const bola = animated ? 'crt-ball' : undefined;
+  const patas = animated ? 'crt-legs' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const bolaG = (
+    <g className={bola}>
+      <circle cx="-13" cy="7" r="6.5" fill="#5a4230" />
+      <circle cx="-13" cy="7" r="6.5" fill="none" stroke="#3a2c1c" strokeWidth="1" />
+      <circle cx="-15" cy="5" r="1.5" fill="#6e5238" opacity="0.7" />
+      <circle cx="-11.5" cy="9" r="1.1" fill="#42301f" opacity="0.7" />
+    </g>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={patas} stroke="#0c1206" strokeWidth="1.7" strokeLinecap="round">
+        <path d="M-4,4 L-9,10" /><path d="M0,5 L-1,11" /><path d="M4,4 L8,10" />
+      </g>
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="#141c10"
+        style={{ filter: 'drop-shadow(0 0 5px rgba(157,214,106,0.7))' }} />
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="none" stroke="#9dd66a" strokeWidth="0.7" strokeOpacity="0.6" />
+      <path d="M0,-5.6 L0,5.6" stroke="#0c1206" strokeWidth="0.8" />
+      <ellipse cx="-3.5" cy="-2.8" rx="2.6" ry="1.4" fill="#3d5a24" opacity="0.55" />
+      <path d="M8,-3.4 C12,-3.8 13.4,-1 12.4,1.4 C11.4,3.6 9,3.6 8.2,2.6 C9.4,1 9.2,-1.4 8,-3.4 Z" fill="#0f150b" />
+      <path d="M11.2,-3.2 C12.6,-5 13.4,-4.4 13.2,-2.8" fill="none" stroke="#0f150b" strokeWidth="1.7" strokeLinecap="round" />
+      <circle cx="10.4" cy="-0.6" r="0.7" fill="#9dd66a" opacity="0.8" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="escarabajo">
+        {defs}
+        {bolaG}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="escarabajo" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {bolaG}
+      {body}
+    </svg>
+  );
+}
+
+export default Escarabajo;

--- a/src/visual/creatures/Lombriz.jsx
+++ b/src/visual/creatures/Lombriz.jsx
@@ -1,0 +1,64 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Lombriz de tierra — Martiodrilus crassus (lombriz gigante nativa de los
+   Andes). Cuerpo curvo segmentado con clitelo (banda clara) y cabecita.
+   Su movimiento en escena (asomar/mecerse) lo aporta la escena, no la
+   criatura. Versión canónica del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-8 -16 30 48';
+
+export function Lombriz({
+  size = 64,
+  className,
+  inline = false,
+  // eslint-disable-next-line no-unused-vars
+  animated = true,
+  title = 'Lombriz de tierra',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#c0715a" strokeWidth="7.4" strokeLinecap="round" />
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#ff9d6a" strokeWidth="4.4" strokeLinecap="round" opacity="0.85" />
+      <g stroke="#7a3f2e" strokeWidth="0.9" opacity="0.65" strokeLinecap="round">
+        <path d="M-1.4,22 L1.4,20.5" /><path d="M-1.2,16.5 L2.2,15.5" />
+        <path d="M2.4,11.5 L5.6,11" /><path d="M3.4,5.5 L6.4,5.6" />
+        <path d="M2.8,-0.5 L5.6,-1.4" /><path d="M4.6,-6 L7.4,-7.6" />
+      </g>
+      <path d="M3.2,3 C2,-1 4,-4 6.6,-5" fill="none" stroke="#ffd9b0" strokeWidth="4.6" strokeLinecap="round" opacity="0.75" />
+      <circle cx="12.2" cy="-9.4" r="2.2" fill="#ff9d6a" />
+      <circle cx="13.2" cy="-10" r="0.6" fill="#3a1c12" opacity="0.7" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="lombriz">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="lombriz" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Lombriz;

--- a/src/visual/creatures/Mariposa.jsx
+++ b/src/visual/creatures/Mariposa.jsx
@@ -1,0 +1,76 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Mariposa pasionaria — Dione juno (Nymphalidae, alas largas). Cuatro alas
+   independientes (delanteras + traseras, izq/der) que abren y cierran, cuerpo,
+   cabeza, antenas y ocelos. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-27 -18 54 40';
+
+export function Mariposa({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Mariposa',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const alaL = animated ? 'crt-fwing crt-fwing-l' : undefined;
+  const alaR = animated ? 'crt-fwing crt-fwing-r' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={alaL}>
+        <path d="M0,2 C-13,4 -18,12 -12,15 C-6,17 -1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="-9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,2 C13,4 18,12 12,15 C6,17 1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaL}>
+        <path d="M0,-2 C-16,-11 -24,-6 -22,0 C-20,5 -8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M-20,-3 C-14,-2 -7,-1 -1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="-16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,-2 C16,-11 24,-6 22,0 C20,5 8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M20,-3 C14,-2 7,-1 1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <ellipse cx="0" cy="2" rx="1.7" ry="9" fill="#2a1712" />
+      <circle cx="0" cy="-8" r="1.9" fill="#2a1712" />
+      <path d="M-0.8,-9.4 C-3,-13 -4.5,-14 -6,-13.6 M0.8,-9.4 C3,-13 4.5,-14 6,-13.6"
+        stroke="#2a1712" strokeWidth="0.8" fill="none" strokeLinecap="round" />
+      <circle cx="-6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+      <circle cx="6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="mariposa">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="mariposa" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Mariposa;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -1,0 +1,74 @@
+# `src/visual/creatures` — personajes de fauna reutilizables
+
+Librería de **personajes de fauna de la chagra** como componentes SVG limpios,
+parametrizables y sin dependencias nuevas. Nace para **dejar de redibujar el
+mismo bicho** en cada mockup/escena: hoy el colibrí, la abeja angelita, la
+lombriz, la mariposa y el escarabajo aparecían dibujados por separado en varios
+sitios (`mockups/MockupGuardianesNarrativos`, `dashboard/Scene*`,
+`FincaVivaHero`, `MundoVinetas`, `MundoSubsuelo`, avatares del colibrí…) con
+calidad dispar. Aquí vive la **versión canónica** de cada uno.
+
+## Regla de la casa
+
+> **Antes de dibujar un personaje de fauna, búscalo aquí.**
+> Si existe → **reúsalo** (y si podés, **mejorá** la versión canónica en su
+> archivo, para que todos hereden la mejora).
+> Si dibujás un personaje nuevo reutilizable → **agregalo aquí en el mismo PR**
+> (componente + entrada en `index.js` + fila en esta tabla).
+
+## Personajes
+
+| Componente | Especie (binomio verificado) | Notas |
+|---|---|---|
+| `AbejaAngelita` | *Tetragonisca angustula* | Meliponino nativo **SIN aguijón** — NO *Apis*. Alitas de tul que baten. |
+| `Colibri` | *Colibri coruscans* | Colibrí chillón andino. Pico largo, garganta violeta, alas que baten. |
+| `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
+| `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
+| `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
+
+## Props
+
+Todos comparten la misma firma:
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `size` | `number \| string` | `64` | Ancho/alto en modo standalone (`<svg>`). Ignorado en modo `inline`. |
+| `className` | `string` | — | Clase(s) del nodo raíz. En modo `inline` es donde la escena engancha su coreografía de entrada/posición. |
+| `inline` | `boolean` | `false` | `false` → `<svg>` autónomo (avatares, catálogo, botones). `true` → solo un `<g>` para incrustar en una escena SVG existente. |
+| `animated` | `boolean` | `true` | Activa la vida perpetua (aleteo, alas, bola, patas). `false` = quieto. Siempre reduced-motion-safe. |
+| `title` | `string` | nombre del bicho | `aria-label` + `<title>` accesible. |
+
+Props extra (`...rest`) se pasan al `<svg>` en modo standalone.
+
+## Uso
+
+```jsx
+import { Colibri, AbejaAngelita } from '@/visual/creatures';
+
+// Avatar / catálogo — SVG autónomo:
+<Colibri size={48} title="Colibrí chillón" />
+<AbejaAngelita size={40} animated={false} />
+
+// Dentro de una escena SVG propia (la escena pone posición y entrada):
+<svg viewBox="0 0 340 210">
+  {/* …fondo, suelo… */}
+  <g transform="translate(120 66)">
+    <Colibri inline className="mi-entrada-volando" />
+  </g>
+</svg>
+```
+
+Consumidor de referencia: **`src/mockups/MockupGuardianesNarrativos.jsx`**
+(usa las 5 criaturas en modo `inline`).
+
+## Técnica
+
+- SVG + CSS puros, **cero dependencias nuevas**; solo `transform`/`opacity`
+  (GPU, Android gama baja). Familia visual del glow de `GuardianEspiritu`.
+- Cada instancia genera **ids de filtro únicos** (`useId`), así se pueden
+  repetir muchas criaturas en una misma página sin colisión.
+- La **vida perpetua** vive en `creatures.css` (clases `crt-*`), es intrínseca
+  a la criatura y **reduced-motion-safe** (sin animación → fotograma digno).
+- La **coreografía de LLEGADA** (entrar volando, asomar del suelo, rodar) NO
+  vive aquí: es responsabilidad de la escena que consume la criatura, sobre el
+  `className` del modo `inline`.

--- a/src/visual/creatures/_filters.jsx
+++ b/src/visual/creatures/_filters.jsx
@@ -1,0 +1,23 @@
+/*
+ * Filtro SVG compartido de la familia visual "creatures": glow orgánico
+ * (feGaussianBlur + feMerge) heredado de GuardianEspiritu + blur suave.
+ * Cada criatura instancia estos filtros con ids ÚNICOS (useId) para poder
+ * repetirse muchas veces en una misma página sin colisión de ids.
+ * Interno de la librería — no se exporta desde el barrel.
+ */
+export function CreatureFilters({ glow, blur }) {
+  return (
+    <>
+      <filter id={glow} x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.1" result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      <filter id={blur}>
+        <feGaussianBlur stdDeviation="3" />
+      </filter>
+    </>
+  );
+}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1,0 +1,51 @@
+/* ─── Vida perpetua de las CREATURES — SVG + CSS puros, solo transform/opacity
+   (GPU, Android gama baja). Reutilizable en cualquier escena o avatar.
+   La coreografía de LLEGADA (entrar volando, asomar del suelo) NO vive aquí:
+   es responsabilidad de la escena que consume la criatura.
+   reduced-motion = criatura quieta en un fotograma digno. ─── */
+
+/* aleteo rápido (abeja / colibrí) */
+.crt-wing {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: crt-wingbeat 0.13s ease-in-out infinite alternate;
+}
+@keyframes crt-wingbeat {
+  0% { transform: scaleY(1) scaleX(1); }
+  100% { transform: scaleY(0.6) scaleX(0.9); }
+}
+
+/* alas de mariposa que abren y cierran */
+.crt-fwing {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-flutter 0.5s ease-in-out infinite;
+}
+.crt-fwing-l { transform-origin: right center; }
+.crt-fwing-r { transform-origin: left center; }
+@keyframes crt-flutter {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.4); }
+}
+
+/* bola de abono que rueda (escarabajo) */
+.crt-ball {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-roll 1.1s linear infinite;
+}
+@keyframes crt-roll {
+  0% { transform: rotate(0); }
+  100% { transform: rotate(-360deg); }
+}
+
+/* patas que dan pasos (escarabajo) */
+.crt-legs { animation: crt-step 0.5s ease-in-out infinite; }
+@keyframes crt-step {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-1.2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crt-wing, .crt-fwing, .crt-ball, .crt-legs { animation: none !important; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -1,0 +1,32 @@
+/*
+ * Librería visual de PERSONAJES DE FAUNA de la chagra (creatures).
+ * Fuente única y reutilizable. Antes de dibujar un bicho, búscalo aquí.
+ *
+ * Cada componente:
+ *   - Modo standalone (por defecto): renderiza su propio <svg> con viewBox,
+ *     dimensionado por `size` — ideal para avatares, catálogo, botones.
+ *   - Modo `inline`: renderiza solo el <g> para incrustarse en una escena SVG
+ *     que ya define su viewBox y su coreografía de entrada/posición.
+ *
+ * Props comunes: { size, className, inline, animated, title }.
+ */
+export { AbejaAngelita } from './AbejaAngelita.jsx';
+export { Colibri } from './Colibri.jsx';
+export { Lombriz } from './Lombriz.jsx';
+export { Mariposa } from './Mariposa.jsx';
+export { Escarabajo } from './Escarabajo.jsx';
+
+import AbejaAngelita from './AbejaAngelita.jsx';
+import Colibri from './Colibri.jsx';
+import Lombriz from './Lombriz.jsx';
+import Mariposa from './Mariposa.jsx';
+import Escarabajo from './Escarabajo.jsx';
+
+/* Registro consultable: slug → componente + binomio verificado. */
+export const CREATURES = {
+  'abeja-angelita': { Component: AbejaAngelita, nombre: 'Abeja angelita', cientifico: 'Tetragonisca angustula' },
+  colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
+  lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
+  mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
+  escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },
+};


### PR DESCRIPTION
## Moonshot #6 — "Guardianes que aparecen"

Mockup de galería (**sin gate, datos de muestra**) en `#/mockups/guardianes-narrativos`. Los guardianes de fauna nativa son **personajes ilustrados que LLEGAN contextualmente** a la pantalla según el estado de la finca, con micro-narrativa en usted colombiano. El hilo mítico muisca (**Bachué / Madre Agua**) enmarca la escena — sin gamificación (nada de puntos, logros ni niveles): los guardianes solo aparecen cuando algo está pasando bien.

### Guardianes ↔ estados (binomios verificados)
| Estado de muestra | Guardián | Binomio |
|---|---|---|
| Floración | Abeja angelita | *Tetragonisca angustula* (meliponino nativo **sin aguijón — NO Apis**) |
| Suelo mejorando | Lombriz de tierra | *Martiodrilus crassus* (lombriz gigante nativa de los Andes) |
| Después de la lluvia | Colibrí chillón | *Colibri coruscans* (nativo de jardines andinos) |
| Cosecha | Mariposa pasionaria | *Dione juno* (néctar de la huerta) |
| Abonó la tierra | Escarabajo estercolero | *Dichotomius belus* (propio de Colombia, entierra el estiércol) |

### Cómo aparecen
Entrada/salida orgánica **por guardián** (no popups bruscos): la lombriz **asoma del suelo**, el escarabajo **rueda su bola de abono**, el colibrí **entra volando** desde el borde, la abeja y la mariposa **flotan hacia la flor** con alas que baten. Al cambiar de estado el guardián actual se despide (fade + deriva) y el nuevo llega con su halo. Selector de estado + modo **"dejar que lleguen solos"** (ciclo automático que demuestra la aparición contextual).

### Técnica (catálogo 2026-07-10)
- SVG + CSS puros, cero deps; solo `transform`/`opacity` animados (GPU, Android gama baja).
- Familia visual **GuardianEspiritu**: glow `feGaussianBlur`+`feMerge`, acento que **re-tiñe** la escena (`--gn-acc`).
- Regla de la casa: transform de posición en `<g>` externo, animación en `<g>` interno.
- `prefers-reduced-motion` = **fotograma final digno** (los guardianes aparecen sin volar).
- **Responsive 320px**. Español Colombia usted, sin voseo.
- Hilo de agua de Bachué corre al pie de la escena (Madre Agua).

### Ruta
`#/mockups/guardianes-narrativos` — cableada en `App.jsx` sin auth (bypass en boot + hashchange, patrón de mockup).

**Build:** `npm run build` verde. Lint limpio. Sin Playwright (no alpha).