### PR TITLE
feat(mockup): mapa de la finca como acuarela viva (#/mockups/mapa-acuarela)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,6 +89,12 @@ const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').
 // 2026-06-30. Se alcanza desde 'bodega' vía el botón "Auditoría y
 // reconciliación", o directo por hash (#auditoria-inventario).
 const InventoryPage = lazy(() => import('./pages/InventoryPage'));
+// Mockup dev "El croquis de la finca como acuarela viva" (moonshot #5):
+// el mapa de la finca dibujado como acuarela de cuaderno de campo — lotes
+// que laten según su salud, tinta sepia, lindero cosido. Reemplaza la idea
+// de mapa "de ingeniero" por algo que el campesino sienta suyo. Ruta
+// #/mockups/mapa-acuarela — sin gate ni sesión (datos de muestra).
+const MapaAcuarelaMockup = lazy(() => import('./mockups/MapaAcuarela'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -418,6 +424,7 @@ const LoadingFallback = ({ view = null }) => {
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
 
 const HASH_VIEW_ROUTES = {
+  'mockups/mapa-acuarela': 'mockup_mapa_acuarela',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -915,6 +922,13 @@ export default function App() {
       return;
     }
 
+    // Mockups dev (#/mockups/*): vistas aisladas de decisión visual — se
+    // montan sin sesión (datos de muestra, no tocan datos reales).
+    if (hash === 'mockups/mapa-acuarela') {
+      Promise.resolve().then(() => navigate(HASH_VIEW_ROUTES[hash]));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -943,6 +957,11 @@ export default function App() {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
+      // Mockups dev: sin gate ni sesión (datos de muestra).
+      if (routeView === 'mockup_mapa_acuarela') {
+        navigate(routeView);
+        return;
+      }
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
       if (routeView === 'extensionista' && !esExtensionistaActual()) {
         navigate('dashboard');
@@ -1097,7 +1116,9 @@ export default function App() {
   // loading. Body className toggled según currentView. Estilos en
   // src/index.css clase .app-bg-biodiversidad (nombre histórico).
   useEffect(() => {
-    const showBg = currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback';
+    // Mockups dev (#/mockups/*): la lámina se evalúa aislada — sin la foto
+    // de fondo de la app encimándose al papel del croquis.
+    const showBg = currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !currentView.startsWith('mockup_');
     if (showBg) {
       document.body.classList.add('app-bg-biodiversidad');
     } else {
@@ -1265,6 +1286,19 @@ export default function App() {
               onConfirm={() => navigate(currentViewData?.next || 'dashboard')}
               onBack={() => navigate(currentViewData?.back || 'dashboard')}
             />
+          </ErrorBoundary>
+        );
+      case 'mockup_mapa_acuarela':
+        // Mockup "El croquis de la finca como acuarela viva" (moonshot #5):
+        // croquis SVG con lavados de acuarela + tinta sepia; los lotes laten
+        // según su salud (verde=sana, ocre=estrés, punto rojo=alerta) y se
+        // tocan para leer la nota campesina. Full-screen, sin gate — solo
+        // para decidir dirección visual del futuro mapa.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mockup Mapa acuarela">
+              <MapaAcuarelaMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'dashboard':
@@ -2505,7 +2539,10 @@ export default function App() {
   const isPreAuthView =
     currentView === 'loading' ||
     currentView === 'login' ||
-    currentView === 'oauth-callback';
+    currentView === 'oauth-callback' ||
+    // Mockups dev (#/mockups/*): vistas de decisión visual sin sesión — los
+    // banners de instalación taparían la lámina que se está evaluando.
+    currentView.startsWith('mockup_');
 
   return (
     <>
@@ -2563,7 +2600,7 @@ export default function App() {
           Tampoco en onboarding-perfil (tarea #16): el FAB se encimaba sobre el
           CTA "Explorar con finca de ejemplo" del footer y la usuaria nueva aún
           no conoce al agente — ruido en su primer flujo. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && <AgentFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && !currentView.startsWith('mockup_') && <AgentFab onNavigate={navigate} />}
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o
           pregunta al agente punta a punta por voz.

--- a/src/mockups/MapaAcuarela.jsx
+++ b/src/mockups/MapaAcuarela.jsx
@@ -1,0 +1,434 @@
+// Mockup dev "El croquis de la finca como acuarela viva" — MOONSHOT #5.
+//
+// Reemplaza la idea de mapa "de ingeniero" (cuadrículas frías, tiles, capas
+// GIS) por el croquis que un campesino dibujaría en su cuaderno de campo:
+// lavados de acuarela sobre papel kraft, tinta sepia encima, el lindero
+// cosido con la puntada de la marca (LA COSTURA, §6 del catálogo) y los
+// lotes que LATEN suavecito según su salud:
+//
+//   verde vivo  → sana        → late tranquilo (5.2s, el pulso de la casa
+//                               --fvo-beat de SceneFincaOrganismo)
+//   ocre        → pide cuidado → late corto y superficial
+//   punto rojo  → alerta      → pulso rápido + anillos que se expanden
+//
+// Técnica acuarela SIN costo por frame (regla de la casa: blur/filtros
+// ESTÁTICOS, solo transform/opacity animados):
+//   - feTurbulence + feDisplacementMap por forma → borde irregular de
+//     pincel. El filtro rasteriza UNA vez.
+//   - El latido anima opacity/scale del <g> PADRE de la forma filtrada
+//     (compositing barato, el filtro no se re-evalúa).
+//   - Sangrado (bleed) = la misma silueta con stroke gordo translúcido y
+//     desplazamiento más bravo; charco de borde = stroke fino más oscuro.
+//
+// Datos 100% de muestra (finca fría de muestra, sin gate ni sesión).
+// Ruta: #/mockups/mapa-acuarela. Reusa del catálogo 2026-07-10: pulso
+// compartido, costura, velo de hora dorada + viñeta, vida ambiental
+// (mariposa, humo), reduced-motion = fotograma digno, hit-areas generosas.
+
+import React, { useState } from 'react';
+import './mapa-acuarela.css';
+
+// ---------------------------------------------------------------------------
+// Datos de muestra: qué cuenta cada sitio cuando se toca.
+// Formato campesino: "Lote 2 · Maíz y frijol · 65 días · Pide agua".
+// ---------------------------------------------------------------------------
+const SITIOS = {
+  l1: {
+    titulo: 'Lote 1 · Papa pastusa',
+    meta: '42 días de sembrada',
+    estado: 'Va bien',
+    salud: 'sana',
+    nota: 'El follaje va parejo y sin señas de gota. Siga con el riego como viene.',
+  },
+  l2: {
+    titulo: 'Lote 2 · Maíz y frijol',
+    meta: '65 días de sembrada',
+    estado: 'Pide agua',
+    salud: 'estres',
+    nota: 'La milpa lleva 8 días sin lluvia. Riegue esta semana, antes de que abra flor.',
+  },
+  l3: {
+    titulo: 'Lote 3 · Huerta casera',
+    meta: '20 días de sembrada',
+    estado: 'Va bien',
+    salud: 'sana',
+    nota: 'Cilantro y cebolla emparejados. En unos días toca un deshierbe suave.',
+  },
+  l4: {
+    titulo: 'Lote 4 · Café con plátano',
+    meta: '3 años de sembrado',
+    estado: 'Necesita su visita',
+    salud: 'alerta',
+    nota: 'Se observó broca en la esquina de la quebrada. Recoja los frutos del suelo y revise las trampas.',
+  },
+  l5: {
+    titulo: 'Lote 5 · Potrero en descanso',
+    meta: '90 días descansando',
+    estado: 'Va bien',
+    salud: 'sana',
+    nota: 'El pasto se está recuperando. En unas dos semanas puede volver a rotar la vaca.',
+  },
+  agua: {
+    titulo: 'Nacimiento de agua',
+    meta: 'Protegido con bosque',
+    estado: 'Vivo',
+    salud: 'sana',
+    nota: 'El bosquecito que lo rodea lo mantiene fresco. De aquí baja la quebrada que riega la finca.',
+  },
+  casa: {
+    titulo: 'La casa',
+    meta: 'El corazón de la finca',
+    estado: 'En orden',
+    salud: 'sana',
+    nota: 'Desde el corredor se ve todo el croquis. Aquí llega la cosecha y se toman las decisiones.',
+  },
+};
+
+const ESTADO_LABEL = {
+  sana: 'Va bien',
+  estres: 'Pide cuidado',
+  alerta: 'Necesita su visita',
+};
+
+// Helper de accesibilidad: cada sitio del croquis se comporta como botón
+// (tap con dedo embarrado + Enter/Espacio con teclado). Hit-area = la
+// silueta completa del lote (>>48px, regla de la casa).
+function sitioProps(id, sel, setSel) {
+  return {
+    role: 'button',
+    tabIndex: 0,
+    'aria-label': `${SITIOS[id].titulo}. ${SITIOS[id].meta}. ${SITIOS[id].estado}.`,
+    'aria-pressed': sel === id,
+    onClick: () => setSel((prev) => (prev === id ? null : id)),
+    onKeyDown: (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        setSel((prev) => (prev === id ? null : id));
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Siluetas orgánicas de los lotes (béziers suaves; el feDisplacementMap les
+// pone el temblor de pincel, así que los paths se mantienen simples).
+// ---------------------------------------------------------------------------
+const FORMA = {
+  l1: 'M48,80 C70,52 150,48 178,70 C196,86 192,140 176,160 C150,182 78,180 56,162 C38,146 36,100 48,80 Z',
+  l2: 'M46,215 C70,195 152,193 174,212 C190,228 188,290 172,306 C148,324 72,322 54,306 C38,290 36,236 46,215 Z',
+  l3: 'M212,98 C232,80 282,78 296,96 C308,112 306,160 292,176 C272,192 228,190 214,174 C202,158 202,116 212,98 Z',
+  l4: 'M46,362 C72,342 150,340 170,360 C186,376 184,462 168,478 C144,494 72,492 54,476 C40,460 38,384 46,362 Z',
+  l5: 'M248,358 C270,340 316,340 330,358 C342,374 340,462 326,476 C306,490 262,488 250,474 C238,458 238,378 248,358 Z',
+  patio: 'M186,222 C200,210 246,210 258,224 C266,236 264,288 254,298 C240,308 200,306 190,296 C180,284 178,236 186,222 Z',
+  pozo: 'M306,60 C314,52 336,52 342,62 C348,72 346,86 338,92 C328,98 310,96 304,88 C298,80 300,66 306,60 Z',
+};
+
+// Un lote acuarela completo: sangrado + cuerpo + charco de borde + velo de
+// vida que late. El grupo exterior posiciona/recibe el tap; la animación
+// vive en grupos internos (regla de la casa: transform externo, animación
+// interna — si no, la animación pisa el transform y el dibujo salta).
+function LoteAcuarela({ id, salud, grad, sel, setSel, children }) {
+  return (
+    <g
+      className={`acq-lote${sel === id ? ' es-sel' : ''}`}
+      data-salud={salud}
+      {...sitioProps(id, sel, setSel)}
+    >
+      {/* Sangrado: la aguada se sale del trazo (borde deshilachado). */}
+      <path className="acq-sangrado" d={FORMA[id]} filter="url(#acq-borde-bravo)" style={{ stroke: `var(--acq-${grad}-claro)` }} />
+      {/* Cuerpo del lavado. */}
+      <path className="acq-cuerpo" d={FORMA[id]} fill={`url(#acq-g-${grad})`} filter="url(#acq-borde)" />
+      {/* Charco: el pigmento se acumula en el borde al secar. */}
+      <path className="acq-charco" d={FORMA[id]} filter="url(#acq-borde)" style={{ stroke: `var(--acq-${grad}-hondo)` }} />
+      {/* Velo de vida: ESTE es el que late (opacity/scale del <g>). */}
+      <g className="acq-vida-late">
+        <path className="acq-vida" d={FORMA[id]} filter="url(#acq-borde)" />
+      </g>
+      {/* Marcas de tinta del cultivo + rótulo (encima del lavado). */}
+      {children}
+    </g>
+  );
+}
+
+// Rótulo de cuaderno: numerito en circulito de tinta + nombre corto.
+function Rotulo({ x, y, n, texto }) {
+  return (
+    <g className="acq-rotulo" aria-hidden="true">
+      <circle cx={x} cy={y} r="9" className="acq-rotulo-aro" />
+      <text x={x} y={y + 4} textAnchor="middle" className="acq-rotulo-n">{n}</text>
+      <text x={x + 14} y={y + 4} className="acq-rotulo-txt">{texto}</text>
+    </g>
+  );
+}
+
+// Arbolito de tinta con copa acuarela (se riega por el croquis).
+function Arbolito({ x, y, s = 1, tono = 'verde' }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`} aria-hidden="true">
+      <path className="acq-copa" d="M0,-14 C-11,-14 -15,-4 -9,1 C-13,7 -4,12 1,9 C8,13 15,6 11,0 C16,-7 9,-15 0,-14 Z" fill={`url(#acq-g-${tono})`} filter="url(#acq-borde)" />
+      <path className="acq-tinta" d="M0,10 L0,-2 M0,2 L-4,-3 M0,4 L4,-1" />
+    </g>
+  );
+}
+
+// Vaquita de tinta (potrero) — dos trazos, cuaderno puro.
+function Vaquita({ x, y }) {
+  return (
+    <g className="acq-tinta" transform={`translate(${x} ${y})`} aria-hidden="true">
+      <path d="M0,0 C2,-6 16,-6 18,0 C18,4 16,7 14,7 L14,11 M4,7 L4,11 M9,7 L9,11 M16,7 L16,11 M0,0 C-3,-1 -4,2 -2,4 M18,-2 C21,-4 24,-2 23,1 C22,3 20,3 19,2" />
+      <path d="M23,1 C24,2 24,3 23,3" />
+    </g>
+  );
+}
+
+export default function MapaAcuarela({ onBack }) {
+  const [sel, setSel] = useState(null);
+  const ficha = sel ? SITIOS[sel] : null;
+
+  return (
+    <div className="acq" data-sel={sel || 'ninguno'}>
+      {/* ---------- Cabecera de cuaderno ---------- */}
+      <header className="acq-cabecera">
+        <button type="button" className="acq-volver" onClick={onBack} aria-label="Volver al inicio">←</button>
+        <div>
+          <p className="acq-ceja">Cuaderno de campo · datos de muestra</p>
+          <h1 className="acq-titulo">El croquis de su finca</h1>
+          <p className="acq-sub">Finca de muestra · Vereda San Isidro · 2.650 msnm</p>
+        </div>
+      </header>
+
+      {/* ---------- La hoja del croquis ---------- */}
+      <div className="acq-hoja">
+        <svg
+          className="acq-svg"
+          viewBox="0 0 390 540"
+          role="img"
+          aria-label="Croquis en acuarela de la finca de muestra: cinco lotes, la casa, el nacimiento de agua y la quebrada. Cada lote se puede tocar."
+        >
+          <defs>
+            {/* Bordes de pincel: turbulencia + desplazamiento, ESTÁTICOS. */}
+            <filter id="acq-borde" x="-12%" y="-12%" width="124%" height="124%">
+              <feTurbulence type="fractalNoise" baseFrequency="0.035" numOctaves="3" seed="7" result="n" />
+              <feDisplacementMap in="SourceGraphic" in2="n" scale="9" />
+            </filter>
+            <filter id="acq-borde-bravo" x="-18%" y="-18%" width="136%" height="136%">
+              <feTurbulence type="fractalNoise" baseFrequency="0.022" numOctaves="3" seed="31" result="n" />
+              <feDisplacementMap in="SourceGraphic" in2="n" scale="18" />
+            </filter>
+            <filter id="acq-tiembla" x="-8%" y="-8%" width="116%" height="116%">
+              <feTurbulence type="fractalNoise" baseFrequency="0.09" numOctaves="2" seed="11" result="n" />
+              <feDisplacementMap in="SourceGraphic" in2="n" scale="2.4" />
+            </filter>
+            {/* Grano del papel (una pasada, opacidad bajita). */}
+            <filter id="acq-grano">
+              <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" seed="3" result="g" />
+              <feColorMatrix in="g" type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.35  0 0 0 0 0.24  0 0 0 0.5 0" />
+              <feComposite operator="in" in2="SourceGraphic" />
+            </filter>
+            {/* Aguadas: más pigmento al centro, agua en el borde. */}
+            <radialGradient id="acq-g-verde" cx="42%" cy="38%" r="75%">
+              <stop offset="0%" stopColor="#a9cf86" />
+              <stop offset="70%" stopColor="#7fae62" />
+              <stop offset="100%" stopColor="#63955a" />
+            </radialGradient>
+            <radialGradient id="acq-g-pasto" cx="45%" cy="40%" r="75%">
+              <stop offset="0%" stopColor="#c3d795" />
+              <stop offset="100%" stopColor="#8fab63" />
+            </radialGradient>
+            <radialGradient id="acq-g-ocre" cx="45%" cy="38%" r="75%">
+              <stop offset="0%" stopColor="#e3b56e" />
+              <stop offset="100%" stopColor="#b9824a" />
+            </radialGradient>
+            <radialGradient id="acq-g-cafe" cx="45%" cy="40%" r="78%">
+              <stop offset="0%" stopColor="#96bd74" />
+              <stop offset="100%" stopColor="#5f8b4f" />
+            </radialGradient>
+            <radialGradient id="acq-g-agua" cx="45%" cy="40%" r="75%">
+              <stop offset="0%" stopColor="#b8d9e4" />
+              <stop offset="100%" stopColor="#79b0c5" />
+            </radialGradient>
+            <radialGradient id="acq-g-patio" cx="48%" cy="42%" r="75%">
+              <stop offset="0%" stopColor="#ecd6ae" />
+              <stop offset="100%" stopColor="#d6b988" />
+            </radialGradient>
+          </defs>
+
+          {/* Grano de papel sobre toda la hoja. */}
+          <rect x="0" y="0" width="390" height="540" className="acq-grano" filter="url(#acq-grano)" />
+
+          {/* Lindero: la finca va COSIDA al papel (puntada de la marca). */}
+          <path
+            className="acq-lindero"
+            d="M30,44 C110,26 288,28 360,42 C372,120 374,420 358,506 C270,524 112,522 32,508 C18,420 16,128 30,44 Z"
+            filter="url(#acq-tiembla)"
+          />
+
+          {/* Norte de mano alzada. */}
+          <g className="acq-tinta acq-norte" transform="translate(46 68)" aria-hidden="true">
+            <path d="M0,10 L0,-8 M0,-8 L-4,-1 M0,-8 L4,-1" />
+            <text x="0" y="24" textAnchor="middle" className="acq-rotulo-txt">N</text>
+          </g>
+
+          {/* Quebrada: baja del nacimiento por el costado derecho. */}
+          <g className="acq-quebrada" aria-hidden="true">
+            <path id="acq-q" className="acq-quebrada-agua" d="M322,86 C332,130 314,190 326,240 C338,290 318,360 334,420 C342,458 348,490 344,524" filter="url(#acq-borde)" />
+            <path className="acq-quebrada-flujo" d="M322,86 C332,130 314,190 326,240 C338,290 318,360 334,420 C342,458 348,490 344,524" />
+          </g>
+
+          {/* Camino de tierra: de la casa al portón. */}
+          <path className="acq-camino" d="M216,298 C208,340 228,380 214,420 C202,456 214,494 206,534" filter="url(#acq-borde)" aria-hidden="true" />
+          <path className="acq-camino-huella" d="M216,298 C208,340 228,380 214,420 C202,456 214,494 206,534" aria-hidden="true" />
+          {/* Portón: dos postes de tinta. */}
+          <g className="acq-tinta" aria-hidden="true">
+            <path d="M192,522 L192,534 M222,522 L222,534" />
+          </g>
+
+          {/* ---------- Lote 1 · papa (sana) ---------- */}
+          <LoteAcuarela id="l1" salud="sana" grad="verde" sel={sel} setSel={setSel}>
+            <g className="acq-tinta" aria-hidden="true">
+              <path d="M66,96 C96,88 140,88 164,96 M62,118 C96,109 142,109 168,118 M62,140 C96,131 142,131 168,140 M70,160 C98,153 136,153 158,160" />
+            </g>
+            <Rotulo x={78} y={76} n="1" texto="Papa" />
+          </LoteAcuarela>
+
+          {/* ---------- Lote 3 · huerta (sana) ---------- */}
+          <LoteAcuarela id="l3" salud="sana" grad="pasto" sel={sel} setSel={setSel}>
+            <g className="acq-tinta" aria-hidden="true">
+              <path d="M222,116 L286,116 M222,134 L286,134 M222,152 L286,152 M226,168 L280,168" strokeDasharray="1.5 6" />
+            </g>
+            <Rotulo x={232} y={98} n="3" texto="Huerta" />
+          </LoteAcuarela>
+
+          {/* ---------- Lote 2 · milpa (estrés hídrico → ocre) ---------- */}
+          <LoteAcuarela id="l2" salud="estres" grad="ocre" sel={sel} setSel={setSel}>
+            <g className="acq-tinta" aria-hidden="true">
+              {/* Matas de maíz: tallo + hojas en V, la milpa entera. */}
+              <path d="M70,290 L70,260 M70,272 L61,263 M70,268 L79,260 M70,281 L62,275" />
+              <path d="M104,292 L104,258 M104,272 L94,262 M104,266 L114,258 M104,282 L96,275" />
+              <path d="M138,290 L138,260 M138,273 L129,264 M138,268 L147,260 M138,281 L146,275" />
+              <path d="M87,246 L87,222 M87,232 L80,225 M87,229 L94,222" />
+              <path d="M121,246 L121,220 M121,231 L113,224 M121,228 L129,221" />
+              <path d="M155,244 L155,222 M155,232 L148,226 M155,229 L162,223" />
+            </g>
+            <Rotulo x={64} y={210} n="2" texto="Maíz y frijol" />
+          </LoteAcuarela>
+
+          {/* ---------- Lote 4 · café con plátano (alerta) ---------- */}
+          <LoteAcuarela id="l4" salud="alerta" grad="cafe" sel={sel} setSel={setSel}>
+            <g className="acq-tinta" aria-hidden="true">
+              {/* Matas de café: garabato redondo con palito. */}
+              <path d="M70,412 C64,404 72,396 80,400 C88,394 96,402 90,410 C96,416 86,424 79,419 C71,424 64,418 70,412 Z M79,424 L79,432" />
+              <path d="M118,438 C112,430 120,422 128,426 C136,420 144,428 138,436 C144,442 134,450 127,445 C119,450 112,444 118,438 Z M127,450 L127,458" />
+              <path d="M74,458 C68,450 76,442 84,446 C92,440 100,448 94,456 C100,462 90,470 83,465 C75,470 68,464 74,458 Z M83,470 L83,477" />
+              {/* Plátano: pencas largas. */}
+              <path d="M142,392 C136,378 142,364 152,358 M152,394 C152,378 156,364 152,358 M160,392 C166,380 160,366 152,358 M152,394 L152,404" />
+            </g>
+            {/* Punto de alerta: late + anillos que se expanden. */}
+            <g className="acq-alerta" transform="translate(146 424)" aria-hidden="true">
+              <circle className="acq-alerta-anillo" r="6" />
+              <circle className="acq-alerta-anillo a2" r="6" />
+              <circle className="acq-alerta-punto" r="5" />
+            </g>
+            <Rotulo x={66} y={378} n="4" texto="Café" />
+          </LoteAcuarela>
+
+          {/* ---------- Lote 5 · potrero (sana) ---------- */}
+          <LoteAcuarela id="l5" salud="sana" grad="pasto" sel={sel} setSel={setSel}>
+            <g className="acq-tinta" aria-hidden="true">
+              {/* Matas de pasto. */}
+              <path d="M262,392 L258,384 M262,392 L262,382 M262,392 L266,384" />
+              <path d="M306,378 L302,370 M306,378 L306,368 M306,378 L310,370" />
+              <path d="M270,452 L266,444 M270,452 L270,442 M270,452 L274,444" />
+              <path d="M316,460 L312,452 M316,460 L316,450 M316,460 L320,452" />
+            </g>
+            <Vaquita x={280} y={414} />
+            <Arbolito x={318} y={418} s={0.9} tono="verde" />
+            <Rotulo x={266} y={362} n="5" texto="Potrero" />
+          </LoteAcuarela>
+
+          {/* ---------- Nacimiento de agua + bosquecito ---------- */}
+          <g className={`acq-lote acq-agua${sel === 'agua' ? ' es-sel' : ''}`} data-salud="sana" {...sitioProps('agua', sel, setSel)}>
+            {/* Hit-area generosa: el pozo dibujado es chiquito. */}
+            <circle cx="322" cy="72" r="34" className="acq-hit" />
+            <Arbolito x={300} y={46} s={0.8} />
+            <Arbolito x={344} y={52} s={0.7} />
+            <path className="acq-cuerpo" d={FORMA.pozo} fill="url(#acq-g-agua)" filter="url(#acq-borde)" />
+            <g className="acq-vida-late">
+              <path className="acq-vida" d={FORMA.pozo} filter="url(#acq-borde)" />
+            </g>
+            {/* Juncos. */}
+            <g className="acq-tinta" aria-hidden="true">
+              <path d="M310,86 L308,74 M314,88 L314,76 M318,88 L321,77" />
+            </g>
+            <text x="322" y="112" textAnchor="middle" className="acq-rotulo-txt acq-rotulo-centro">Nacimiento</text>
+          </g>
+
+          {/* ---------- La casa (patio + casita con humo) ---------- */}
+          <g className={`acq-lote acq-casa${sel === 'casa' ? ' es-sel' : ''}`} data-salud="sana" {...sitioProps('casa', sel, setSel)}>
+            <path className="acq-cuerpo" d={FORMA.patio} fill="url(#acq-g-patio)" filter="url(#acq-borde)" />
+            <g className="acq-vida-late">
+              <path className="acq-vida" d={FORMA.patio} filter="url(#acq-borde)" />
+            </g>
+            {/* Casita: teja acuarela + muros de tinta + ventana encendida. */}
+            <path d="M192,254 L221,230 L250,254 Z" className="acq-teja" filter="url(#acq-tiembla)" aria-hidden="true" />
+            <g className="acq-tinta" aria-hidden="true">
+              <path d="M192,254 L221,230 L250,254 M198,254 L198,290 L244,254 L244,290 M198,290 L244,290" />
+              <path d="M216,290 L216,272 L228,272 L228,290" />
+            </g>
+            <rect x="203" y="262" width="9" height="9" rx="1.5" className="acq-ventana" aria-hidden="true" />
+            {/* Humo del fogón: sube y se deshace (posición en <g> externo,
+                animación en el interno — regla de la casa). */}
+            <g transform="translate(246 226)" aria-hidden="true">
+              <g className="acq-humo"><path d="M0,0 C4,-6 -2,-10 2,-16" /></g>
+              <g className="acq-humo h2"><path d="M2,-2 C6,-8 0,-12 4,-18" /></g>
+            </g>
+            <text x="221" y="312" textAnchor="middle" className="acq-rotulo-txt acq-rotulo-centro">La casa</text>
+          </g>
+
+          {/* Árboles de lindero, sueltos. */}
+          <Arbolito x={368} y={250} s={0.75} />
+          <Arbolito x={26} y={340} s={0.7} tono="cafe" />
+
+          {/* Mariposa: vida ambiental, cruza el croquis cada tanto. */}
+          <g className="acq-mariposa-vuelo" aria-hidden="true">
+            <g className="acq-mariposa">
+              <path className="acq-ala" d="M0,0 C-6,-7 -12,-3 -8,2 C-12,6 -5,9 0,3 Z" />
+              <path className="acq-ala a2" d="M0,0 C6,-7 12,-3 8,2 C12,6 5,9 0,3 Z" />
+            </g>
+          </g>
+        </svg>
+
+        {/* Velo de hora dorada + viñeta (velos del catálogo, §13.5). */}
+        <div className="acq-velo" aria-hidden="true" />
+      </div>
+
+      {/* ---------- Ficha del lote tocado (nota al margen) ---------- */}
+      <section className="acq-ficha" aria-live="polite">
+        {ficha ? (
+          <div className="acq-ficha-nota" data-salud={ficha.salud} key={sel}>
+            <div className="acq-ficha-linea">
+              <h2 className="acq-ficha-titulo">{ficha.titulo}</h2>
+              <button type="button" className="acq-ficha-cerrar" onClick={() => setSel(null)} aria-label="Cerrar la nota">×</button>
+            </div>
+            <p className="acq-ficha-meta">
+              {ficha.meta} · <strong className="acq-ficha-estado">{ficha.estado}</strong>
+            </p>
+            <p className="acq-ficha-nota-txt">{ficha.nota}</p>
+          </div>
+        ) : (
+          <p className="acq-ficha-pista">Toque un lote, la casa o el agua para ver cómo va.</p>
+        )}
+      </section>
+
+      {/* ---------- Leyenda cálida ---------- */}
+      <footer className="acq-leyenda">
+        <p className="acq-leyenda-titulo">El croquis late con la salud de su finca</p>
+        <ul className="acq-leyenda-lista">
+          <li><span className="acq-muestra sana" aria-hidden="true" /> Verde vivo: {ESTADO_LABEL.sana.toLowerCase()}, late tranquilo</li>
+          <li><span className="acq-muestra estres" aria-hidden="true" /> Ocre: {ESTADO_LABEL.estres.toLowerCase()}, late corto</li>
+          <li><span className="acq-muestra alerta" aria-hidden="true" /> Punto rojo: {ESTADO_LABEL.alerta.toLowerCase()}</li>
+        </ul>
+      </footer>
+    </div>
+  );
+}

--- a/src/mockups/mapa-acuarela.css
+++ b/src/mockups/mapa-acuarela.css
@@ -1,0 +1,519 @@
+/* Mockup "El croquis de la finca como acuarela viva" (#/mockups/mapa-acuarela)
+ *
+ * Paleta de cuaderno de campo:
+ *   papel kraft #efe5cf / hoja #f7f0de · tinta sepia #5b4a36
+ *   aguadas: verde vivo (sana) · ocre (estrés) · siena/teja · azul quebrada
+ *
+ * Reglas de la casa: solo transform/opacity animados; los filtros de
+ * acuarela (feTurbulence/feDisplacementMap) son ESTÁTICOS — el latido anima
+ * el <g> PADRE de la forma filtrada, así el navegador cachea el raster del
+ * filtro y solo composita. prefers-reduced-motion = fotograma digno.
+ */
+
+.acq {
+  /* Tokens del cuaderno. */
+  --acq-papel: #efe5cf;
+  --acq-hoja: #f7f0de;
+  --acq-tinta: #5b4a36;
+  --acq-tinta-suave: rgba(91, 74, 54, 0.62);
+  --acq-verde-claro: #a9cf86;
+  --acq-verde-hondo: #4e7d46;
+  --acq-pasto-claro: #c3d795;
+  --acq-pasto-hondo: #71904c;
+  --acq-ocre-claro: #e3b56e;
+  --acq-ocre-hondo: #9c6a38;
+  --acq-cafe-claro: #96bd74;
+  --acq-cafe-hondo: #47703c;
+  --acq-agua-claro: #b8d9e4;
+  --acq-agua-hondo: #5f97ad;
+  --acq-patio-claro: #ecd6ae;
+  --acq-patio-hondo: #b99a68;
+  --acq-alerta: #b3402e;
+  /* EL latido de la casa: misma duración que --fvo-beat (la finca-organismo). */
+  --acq-beat: 5.2s;
+
+  min-height: 100dvh;
+  padding: 14px 14px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 560px;
+  margin: 0 auto;
+  color: var(--acq-tinta);
+  font-family: 'Nunito', system-ui, sans-serif;
+  /* Kraft: papel con fibra fina (receta FincaVivaHero). */
+  background:
+    repeating-linear-gradient(0deg, rgba(120, 96, 60, 0.045) 0 1px, transparent 1px 3px),
+    repeating-linear-gradient(90deg, rgba(120, 96, 60, 0.03) 0 1px, transparent 1px 4px),
+    var(--acq-papel);
+}
+
+/* ---------- Cabecera ---------- */
+
+.acq-cabecera {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.acq-volver {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: 1.6px solid var(--acq-tinta-suave);
+  background: var(--acq-hoja);
+  color: var(--acq-tinta);
+  font-size: 19px;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+.acq-volver:active { transform: scale(0.94); }
+
+.acq-ceja {
+  margin: 2px 0 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--acq-tinta-suave);
+}
+
+.acq-titulo {
+  margin: 2px 0 0;
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-size: clamp(1.35rem, 6vw, 1.7rem);
+  line-height: 1.12;
+  color: #46372a;
+}
+
+.acq-sub {
+  margin: 3px 0 0;
+  font-size: 12.5px;
+  color: var(--acq-tinta-suave);
+}
+
+/* ---------- La hoja ---------- */
+
+.acq-hoja {
+  position: relative;
+  border-radius: 16px;
+  background: var(--acq-hoja);
+  box-shadow:
+    0 1px 0 rgba(91, 74, 54, 0.14),
+    0 10px 26px -14px rgba(70, 55, 42, 0.45);
+  overflow: hidden;
+}
+
+.acq-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* Velo de hora dorada + viñeta de cine (catálogo §13.2 y §13.5):
+   la luz cálida entra por arriba-izquierda, las esquinas se hunden apenas. */
+.acq-velo {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(120% 90% at 22% 8%, rgba(255, 205, 120, 0.14), transparent 55%),
+    radial-gradient(135% 120% at 50% 50%, transparent 62%, rgba(70, 52, 34, 0.1) 100%);
+  mix-blend-mode: multiply;
+}
+
+.acq-grano { fill: #fff; opacity: 0.05; pointer-events: none; }
+
+/* ---------- Tinta sepia ---------- */
+
+.acq-tinta,
+.acq-tinta path {
+  fill: none;
+  stroke: var(--acq-tinta);
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.82;
+  pointer-events: none;
+}
+
+/* Lindero: puntada de hilo (LA COSTURA — firma de marca, HelpIllustrations). */
+.acq-lindero {
+  fill: none;
+  stroke: var(--acq-tinta);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-dasharray: 7 8;
+  opacity: 0.55;
+}
+
+.acq-norte { opacity: 0.6; }
+
+/* ---------- Lavados de acuarela ---------- */
+
+.acq-lote { cursor: pointer; }
+.acq-lote:focus { outline: none; }
+
+.acq-sangrado {
+  fill: none;
+  stroke-width: 10;
+  stroke-linejoin: round;
+  opacity: 0.3;
+}
+
+.acq-cuerpo { opacity: 0.68; }
+
+.acq-charco {
+  fill: none;
+  stroke-width: 2.4;
+  opacity: 0.4;
+}
+
+/* El velo de vida: blanco cálido que respira SOBRE el lavado. */
+.acq-vida {
+  fill: #fff8e8;
+  pointer-events: none;
+}
+
+.acq-vida-late {
+  opacity: 0.12;
+  transform-box: fill-box;
+  transform-origin: center;
+  pointer-events: none;
+}
+
+/* Latido por salud. Sana: hondo y tranquilo (el pulso de la casa). */
+.acq-lote[data-salud='sana'] .acq-vida-late {
+  animation: acq-late var(--acq-beat) ease-in-out infinite;
+}
+/* Estrés: corto y superficial — respira con esfuerzo. */
+.acq-lote[data-salud='estres'] .acq-vida-late {
+  animation: acq-late-corto 3.4s ease-in-out infinite;
+}
+/* Alerta: el lote respira poco; el que grita es el punto rojo. */
+.acq-lote[data-salud='alerta'] .acq-vida-late {
+  animation: acq-late-corto 4.6s ease-in-out infinite;
+}
+
+@keyframes acq-late {
+  0%, 100% { opacity: 0.08; transform: scale(1); }
+  50% { opacity: 0.34; transform: scale(1.012); }
+}
+@keyframes acq-late-corto {
+  0%, 100% { opacity: 0.06; transform: scale(1); }
+  42%, 58% { opacity: 0.16; transform: scale(1.005); }
+}
+
+/* Tocado / foco de teclado: el lavado se aviva y el charco se marca. */
+.acq-lote.es-sel .acq-cuerpo,
+.acq-lote:focus-visible .acq-cuerpo { opacity: 0.88; }
+.acq-lote.es-sel .acq-charco,
+.acq-lote:focus-visible .acq-charco { opacity: 0.85; stroke-width: 3; }
+.acq-lote.es-sel .acq-rotulo-aro { fill: var(--acq-hoja); }
+
+.acq-hit { fill: transparent; stroke: none; }
+
+/* ---------- Rótulos ---------- */
+
+.acq-rotulo { pointer-events: none; }
+.acq-rotulo-aro {
+  fill: rgba(247, 240, 222, 0.85);
+  stroke: var(--acq-tinta);
+  stroke-width: 1.4;
+}
+.acq-rotulo-n {
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  fill: var(--acq-tinta);
+}
+.acq-rotulo-txt {
+  font-family: 'Nunito', system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 800;
+  fill: var(--acq-tinta);
+  paint-order: stroke;
+  stroke: rgba(247, 240, 222, 0.75);
+  stroke-width: 3;
+}
+.acq-rotulo-centro { pointer-events: none; }
+
+/* ---------- Agua, camino, casa ---------- */
+
+.acq-quebrada-agua {
+  fill: none;
+  stroke: url(#acq-g-agua);
+  stroke-width: 9;
+  stroke-linecap: round;
+  opacity: 0.75;
+}
+/* Flujo por dash (receta savia/micelio): la corriente baja. */
+.acq-quebrada-flujo {
+  fill: none;
+  stroke: #eaf6fa;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-dasharray: 7 12;
+  opacity: 0.65;
+  animation: acq-flujo 4.5s linear infinite;
+}
+@keyframes acq-flujo { to { stroke-dashoffset: -76; } }
+
+.acq-camino {
+  fill: none;
+  stroke: #d9bd8d;
+  stroke-width: 11;
+  stroke-linecap: round;
+  opacity: 0.8;
+}
+.acq-camino-huella {
+  fill: none;
+  stroke: var(--acq-tinta);
+  stroke-width: 1.4;
+  stroke-dasharray: 2 9;
+  opacity: 0.4;
+}
+
+.acq-copa { opacity: 0.7; }
+
+.acq-teja { fill: #c9805a; opacity: 0.7; }
+.acq-ventana { fill: #f3c76a; opacity: 0.95; }
+
+/* Humo del fogón: sube y se deshace (transform/opacity, nada más). */
+.acq-humo path {
+  fill: none;
+  stroke: rgba(91, 74, 54, 0.5);
+  stroke-width: 1.6;
+  stroke-linecap: round;
+}
+.acq-humo {
+  animation: acq-humo 5s ease-in-out infinite;
+}
+.acq-humo.h2 { animation-delay: 2.4s; }
+@keyframes acq-humo {
+  0% { opacity: 0; transform: translateY(2px); }
+  25% { opacity: 0.7; }
+  100% { opacity: 0; transform: translateY(-13px); }
+}
+
+/* ---------- Alerta (punto rojo) ---------- */
+
+.acq-alerta-punto {
+  fill: var(--acq-alerta);
+  stroke: #f7f0de;
+  stroke-width: 1.4;
+  animation: acq-alerta-late 2.2s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.acq-alerta-anillo {
+  fill: none;
+  stroke: var(--acq-alerta);
+  stroke-width: 1.6;
+  opacity: 0;
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: acq-anillo 2.2s ease-out infinite;
+}
+.acq-alerta-anillo.a2 { animation-delay: 1.1s; }
+@keyframes acq-alerta-late {
+  0%, 100% { transform: scale(1); }
+  12% { transform: scale(1.35); }
+  24% { transform: scale(1); }
+}
+@keyframes acq-anillo {
+  0% { opacity: 0.7; transform: scale(1); }
+  100% { opacity: 0; transform: scale(3.1); }
+}
+
+/* ---------- Mariposa (vida ambiental) ---------- */
+
+.acq-ala {
+  fill: #d98a4f;
+  opacity: 0.75;
+  transform-box: fill-box;
+}
+.acq-mariposa .acq-ala { transform-origin: right center; animation: acq-aleteo 0.5s ease-in-out infinite alternate; }
+.acq-mariposa .acq-ala.a2 { transform-origin: left center; }
+@keyframes acq-aleteo {
+  from { transform: scaleX(1); }
+  to { transform: scaleX(0.45); }
+}
+.acq-mariposa-vuelo {
+  animation: acq-cruza 26s ease-in-out infinite;
+  opacity: 0;
+}
+@keyframes acq-cruza {
+  0%, 55% { opacity: 0; transform: translate(60px, 330px); }
+  60% { opacity: 1; }
+  70% { transform: translate(150px, 200px); }
+  80% { transform: translate(255px, 235px); }
+  92% { opacity: 1; }
+  100% { opacity: 0; transform: translate(340px, 130px); }
+}
+
+/* ---------- Ficha (nota al margen) ---------- */
+
+.acq-ficha { min-height: 108px; }
+
+.acq-ficha-pista {
+  margin: 10px 4px 0;
+  font-size: 14px;
+  font-style: italic;
+  color: var(--acq-tinta-suave);
+  text-align: center;
+}
+
+.acq-ficha-nota {
+  background: var(--acq-hoja);
+  border-radius: 12px;
+  padding: 12px 14px;
+  border-left: 5px solid var(--acq-verde-hondo);
+  box-shadow: 0 6px 18px -12px rgba(70, 55, 42, 0.5);
+  animation: acq-nota-entra 0.28s cubic-bezier(0.32, 1.3, 0.4, 1);
+}
+.acq-ficha-nota[data-salud='estres'] { border-left-color: var(--acq-ocre-hondo); }
+.acq-ficha-nota[data-salud='alerta'] { border-left-color: var(--acq-alerta); }
+
+@keyframes acq-nota-entra {
+  from { opacity: 0; transform: translateY(7px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.acq-ficha-linea {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.acq-ficha-titulo {
+  margin: 0;
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-size: 17px;
+  color: #46372a;
+}
+
+.acq-ficha-cerrar {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(91, 74, 54, 0.08);
+  color: var(--acq-tinta);
+  font-size: 17px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.acq-ficha-meta {
+  margin: 3px 0 0;
+  font-size: 13.5px;
+  color: var(--acq-tinta-suave);
+}
+.acq-ficha-nota[data-salud='sana'] .acq-ficha-estado { color: var(--acq-verde-hondo); }
+.acq-ficha-nota[data-salud='estres'] .acq-ficha-estado { color: var(--acq-ocre-hondo); }
+.acq-ficha-nota[data-salud='alerta'] .acq-ficha-estado { color: var(--acq-alerta); }
+
+.acq-ficha-nota-txt {
+  margin: 7px 0 0;
+  font-size: 14.5px;
+  line-height: 1.45;
+}
+
+/* ---------- Leyenda ---------- */
+
+.acq-leyenda {
+  border-top: 1.5px dashed rgba(91, 74, 54, 0.3);
+  padding-top: 12px;
+}
+
+.acq-leyenda-titulo {
+  margin: 0 0 8px;
+  font-family: 'Baloo 2', 'Nunito', system-ui, sans-serif;
+  font-size: 14.5px;
+  color: #46372a;
+}
+
+.acq-leyenda-lista {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13.5px;
+}
+.acq-leyenda-lista li {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+/* Muestras de pigmento: gotitas irregulares (border-radius orgánico). */
+.acq-muestra {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 16px;
+  border-radius: 58% 42% 55% 45% / 52% 55% 45% 48%;
+  box-shadow: inset 0 0 0 1px rgba(91, 74, 54, 0.18);
+}
+.acq-muestra.sana {
+  background: radial-gradient(circle at 40% 35%, var(--acq-verde-claro), var(--acq-verde-hondo));
+  animation: acq-muestra-late var(--acq-beat) ease-in-out infinite;
+}
+.acq-muestra.estres {
+  background: radial-gradient(circle at 40% 35%, var(--acq-ocre-claro), var(--acq-ocre-hondo));
+  animation: acq-muestra-late-corto 3.4s ease-in-out infinite;
+}
+.acq-muestra.alerta {
+  background:
+    radial-gradient(circle at 50% 50%, var(--acq-alerta) 0 34%, transparent 38%),
+    radial-gradient(circle at 40% 35%, var(--acq-cafe-claro), var(--acq-cafe-hondo));
+}
+/* Las muestras de la leyenda laten SOLO en escala (a plena opacidad: son
+   chiquitas — los keyframes del velo del mapa las dejarían invisibles). */
+@keyframes acq-muestra-late {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.18); }
+}
+@keyframes acq-muestra-late-corto {
+  0%, 100% { transform: scale(1); }
+  42%, 58% { transform: scale(1.07); }
+}
+
+/* ---------- Responsive 320px ---------- */
+
+@media (max-width: 360px) {
+  .acq { padding: 10px 10px 22px; }
+  .acq-ficha-titulo { font-size: 15.5px; }
+  .acq-ficha-nota-txt { font-size: 13.5px; }
+  .acq-leyenda-lista { font-size: 12.5px; }
+}
+
+/* ---------- Reduced motion: fotograma final digno ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .acq-vida-late,
+  .acq-quebrada-flujo,
+  .acq-humo,
+  .acq-alerta-punto,
+  .acq-alerta-anillo,
+  .acq-mariposa .acq-ala,
+  .acq-mariposa-vuelo,
+  .acq-muestra.sana,
+  .acq-muestra.estres,
+  .acq-ficha-nota {
+    animation: none;
+  }
+  /* La acuarela queda como lámina terminada: velos a media luz,
+     el punto de alerta firme y visible, la mariposa posada en el potrero. */
+  .acq-vida-late { opacity: 0.18; }
+  .acq-alerta-anillo { opacity: 0.45; transform: scale(1.8); }
+  .acq-alerta-anillo.a2 { opacity: 0; }
+  .acq-mariposa-vuelo { opacity: 1; transform: translate(255px, 235px); }
+  .acq-humo { opacity: 0; }
+}


### PR DESCRIPTION
## Moonshot #5 — el croquis de la finca como acuarela viva

Mockup de galería (datos de muestra, sin gate ni sesión) que reemplaza la idea de mapa "de ingeniero" por el croquis que un campesino dibujaría en su cuaderno de campo: acuarela sobre papel kraft, tinta sepia encima, y los lotes **latiendo** según su salud.

### Qué se ve
- **5 lotes + casa + nacimiento + quebrada + camino**, todos tocables: papa (sana), maíz y frijol (estrés hídrico → ocre), huerta (sana), café con plátano (**alerta** → punto rojo con anillos), potrero en descanso.
- **Latido por salud**: verde vivo late hondo y tranquilo (5.2s, el pulso compartido de la finca-organismo); ocre late corto y superficial; la alerta pulsa rápido.
- **Ficha campesina** al tocar: "Lote 2 · Maíz y frijol · 65 días · Pide agua" + nota en usted cordial.
- **Leyenda cálida** con gotas de pigmento que laten igual que el mapa.
- Lindero cosido con la puntada de marca, velo de hora dorada + viñeta, humo del fogón, flujo de la quebrada, mariposa que cruza.

### Técnica (reglas de la casa)
- Acuarela = `feTurbulence` + `feDisplacementMap` **estáticos** por forma; el latido anima opacity/scale del `<g>` padre → el filtro rasteriza una sola vez, cero costo JS por frame (target Android gama baja).
- Solo transform/opacity animados; `prefers-reduced-motion` deja la lámina como fotograma terminado (alerta visible, mariposa posada).
- Hit-areas generosas, `role=button` + Enter/Espacio + `aria-pressed`, SVG con `aria-label` descriptivo.
- Reuso del catálogo gráfico: pulso compartido, la costura, velos/grades, vida ambiental, flujo por dash, receta kraft.

### Ruta y patrón
`#/mockups/mapa-acuarela` — mismo patrón de rutas mockup (lazy + bypass de sesión). Además: banners de instalación y fondo-foto de la app quedan excluidos en vistas `mockup_` (la lámina se evalúa aislada; el FAB ya venía excluido en la rama hermana).

### Verificación
- `npm run build` verde.
- Screenshots headless 390px y 320px: composición, leyenda, alerta y reduced-layout revisados.
- eslint: solo el warning i18n ADR-050 esperado en mockups (copy de muestra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)