### PR TITLE
PRUEBA-PATRÓN: librería visual reutilizable de personajes de fauna (src/visual/creatures)

### DIFF
--- a/src/mockups/MockupGuardianesNarrativos.jsx
+++ b/src/mockups/MockupGuardianesNarrativos.jsx
@@ -18,15 +18,22 @@
  *   - Mariposa pasionaria .. Dione juno (Nymphalidae, néctar de flores de la huerta)
  *   - Escarabajo estercolero Dichotomius belus (propio de Colombia, entierra el estiércol)
  *
+ * REUSO: los cuerpos de los guardianes YA NO se dibujan aquí — vienen de la
+ * librería visual `src/visual/creatures` (personajes de fauna reutilizables).
+ * Esta pantalla los consume en modo `inline` y solo aporta el ESCENARIO y la
+ * coreografía de LLEGADA. Si mejora un bicho, mejórelo en la librería.
+ *
  * TÉCNICA (catálogo 2026-07-10): SVG + CSS puros, cero deps; solo transform/
  * opacity animados (GPU, Android gama baja); glow feGaussianBlur+feMerge de la
  * familia GuardianEspiritu; acento que re-tiñe la escena (`--gn-acc`); transform
- * de posición en <g> externo y animación en <g> interno; prefers-reduced-motion
- * = fotograma final digno (los guardianes aparecen sin volar). Datos de muestra.
+ * de posición en <g> externo y ENTRADA en el <g> de la criatura;
+ * prefers-reduced-motion = fotograma final digno (los guardianes aparecen sin
+ * volar). Datos de muestra.
  *
  * Voz: usted-cordial colombiano, frases cortas (sin voseo).
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { AbejaAngelita, Colibri, Lombriz, Mariposa, Escarabajo } from '../visual/creatures';
 import './guardianes-narrativos.css';
 
 /* ─── ROSTER — fauna nativa REAL con binomio verificado ────────────────────── */
@@ -99,15 +106,11 @@ const ESTADOS = [
 
 const estadoById = (id) => ESTADOS.find((e) => e.id === id) || ESTADOS[0];
 
-/* ─── filtros SVG compartidos (glow + blur suave) — familia GuardianEspiritu ── */
+/* ─── filtros SVG del ESCENARIO — gradientes de agua/suelo. El glow de cada
+   guardián lo aporta ahora su propio componente de `src/visual/creatures`. ─── */
 function GnDefs() {
   return (
     <defs>
-      <filter id="gn-glow" x="-80%" y="-80%" width="260%" height="260%">
-        <feGaussianBlur stdDeviation="2.1" result="b" />
-        <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
-      </filter>
-      <filter id="gn-blur3"><feGaussianBlur stdDeviation="3" /></filter>
       <linearGradient id="gn-agua-grad" x1="0" y1="0" x2="0" y2="1">
         <stop offset="0" stopColor="#4fd8ff" stopOpacity="0.55" />
         <stop offset="1" stopColor="#2b7fbf" stopOpacity="0.15" />
@@ -120,158 +123,25 @@ function GnDefs() {
   );
 }
 
-/* ─── GUARDIANES ILUSTRADOS ─────────────────────────────────────────────────
-   Regla de la casa: transform de POSICIÓN en el <g> externo (lo pone el stage);
-   la ENTRADA en el <g> `.gn-anim`; la vida perpetua (aleteo) en el <g> interno. */
-
-/* Abeja angelita — cuerpo ámbar rayado, alitas de tul (Tetragonisca angustula) */
-function GuardianAbeja() {
-  return (
-    <g className="gn-anim gn-anim-flota">
-      <g filter="url(#gn-glow)">
-        <circle r="6" fill="#ffb54f" opacity="0.35" filter="url(#gn-blur3)" />
-        <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
-          style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
-        <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
-          stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
-        <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
-        <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
-        <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
-        <ellipse className="gn-ala" cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
-        <ellipse className="gn-ala" style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
-      </g>
-    </g>
-  );
-}
-
-/* Colibrí chillón — pico largo, garganta violeta, ala que bate (Colibri coruscans) */
-function GuardianColibri() {
-  return (
-    <g className="gn-anim gn-anim-vuela">
-      <g filter="url(#gn-glow)">
-        <circle r="6" fill="#2dffc4" opacity="0.35" filter="url(#gn-blur3)" />
-        {/* cola */}
-        <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
-        {/* cuerpo */}
-        <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
-        <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
-        {/* cabeza */}
-        <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
-        {/* garganta violeta iridiscente del chillón */}
-        <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
-        <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
-        <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
-        {/* pico largo y recto */}
-        <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
-        {/* alas que baten */}
-        <path className="gn-ala" d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
-        <path className="gn-ala" style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
-      </g>
-    </g>
-  );
-}
-
-/* Lombriz de tierra — cuerpo segmentado que ASOMA del suelo (Martiodrilus crassus) */
-function GuardianLombriz() {
-  return (
-    <g className="gn-anim gn-anim-sube">
-      <g filter="url(#gn-glow)">
-        {/* cuerpo curvo segmentado que sube */}
-        <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
-          fill="none" stroke="#c0715a" strokeWidth="7.4" strokeLinecap="round" />
-        <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
-          fill="none" stroke="#ff9d6a" strokeWidth="4.4" strokeLinecap="round" opacity="0.85" />
-        {/* anillos / segmentos */}
-        <g stroke="#7a3f2e" strokeWidth="0.9" opacity="0.65" strokeLinecap="round">
-          <path d="M-1.4,22 L1.4,20.5" /><path d="M-1.2,16.5 L2.2,15.5" />
-          <path d="M2.4,11.5 L5.6,11" /><path d="M3.4,5.5 L6.4,5.6" />
-          <path d="M2.8,-0.5 L5.6,-1.4" /><path d="M4.6,-6 L7.4,-7.6" />
-        </g>
-        {/* clitelo (banda clara característica) */}
-        <path d="M3.2,3 C2,-1 4,-4 6.6,-5" fill="none" stroke="#ffd9b0" strokeWidth="4.6" strokeLinecap="round" opacity="0.75" />
-        {/* cabecita */}
-        <circle cx="12.2" cy="-9.4" r="2.2" fill="#ff9d6a" />
-        <circle cx="13.2" cy="-10" r="0.6" fill="#3a1c12" opacity="0.7" />
-      </g>
-    </g>
-  );
-}
-
-/* Mariposa pasionaria — alas que abren y cierran (Dione juno) */
-function GuardianMariposa() {
-  return (
-    <g className="gn-anim gn-anim-mariposa">
-      <g filter="url(#gn-glow)">
-        {/* ala trasera izq/der */}
-        <g className="gn-mari-ala gn-mari-ala-izq">
-          <path d="M0,2 C-13,4 -18,12 -12,15 C-6,17 -1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
-          <circle cx="-9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
-        </g>
-        <g className="gn-mari-ala gn-mari-ala-der">
-          <path d="M0,2 C13,4 18,12 12,15 C6,17 1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
-          <circle cx="9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
-        </g>
-        {/* ala delantera izq/der (alas largas de Dione) */}
-        <g className="gn-mari-ala gn-mari-ala-izq">
-          <path d="M0,-2 C-16,-11 -24,-6 -22,0 C-20,5 -8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
-          <path d="M-20,-3 C-14,-2 -7,-1 -1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
-          <circle cx="-16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
-        </g>
-        <g className="gn-mari-ala gn-mari-ala-der">
-          <path d="M0,-2 C16,-11 24,-6 22,0 C20,5 8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
-          <path d="M20,-3 C14,-2 7,-1 1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
-          <circle cx="16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
-        </g>
-        {/* cuerpo + antenas */}
-        <ellipse cx="0" cy="2" rx="1.7" ry="9" fill="#2a1712" />
-        <circle cx="0" cy="-8" r="1.9" fill="#2a1712" />
-        <path d="M-0.8,-9.4 C-3,-13 -4.5,-14 -6,-13.6 M0.8,-9.4 C3,-13 4.5,-14 6,-13.6"
-          stroke="#2a1712" strokeWidth="0.8" fill="none" strokeLinecap="round" />
-        <circle cx="-6" cy="-13.6" r="0.9" fill="#ff6ad0" />
-        <circle cx="6" cy="-13.6" r="0.9" fill="#ff6ad0" />
-      </g>
-    </g>
-  );
-}
-
-/* Escarabajo estercolero — cuerpo negro brillante que rueda su bola (Dichotomius belus) */
-function GuardianEscarabajo() {
-  return (
-    <g className="gn-anim gn-anim-rueda">
-      {/* bola de abono que empuja (rueda) */}
-      <g className="gn-bola">
-        <circle cx="-13" cy="7" r="6.5" fill="#5a4230" />
-        <circle cx="-13" cy="7" r="6.5" fill="none" stroke="#3a2c1c" strokeWidth="1" />
-        <circle cx="-15" cy="5" r="1.5" fill="#6e5238" opacity="0.7" />
-        <circle cx="-11.5" cy="9" r="1.1" fill="#42301f" opacity="0.7" />
-      </g>
-      <g filter="url(#gn-glow)">
-        {/* patas que se mueven */}
-        <g className="gn-patas" stroke="#0c1206" strokeWidth="1.7" strokeLinecap="round">
-          <path d="M-4,4 L-9,10" /><path d="M0,5 L-1,11" /><path d="M4,4 L8,10" />
-        </g>
-        {/* élitros brillantes */}
-        <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="#141c10"
-          style={{ filter: 'drop-shadow(0 0 5px rgba(157,214,106,0.7))' }} />
-        <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="none" stroke="#9dd66a" strokeWidth="0.7" strokeOpacity="0.6" />
-        {/* sutura + brillo */}
-        <path d="M0,-5.6 L0,5.6" stroke="#0c1206" strokeWidth="0.8" />
-        <ellipse cx="-3.5" cy="-2.8" rx="2.6" ry="1.4" fill="#3d5a24" opacity="0.55" />
-        {/* cabeza + cuerno (Dichotomius) */}
-        <path d="M8,-3.4 C12,-3.8 13.4,-1 12.4,1.4 C11.4,3.6 9,3.6 8.2,2.6 C9.4,1 9.2,-1.4 8,-3.4 Z" fill="#0f150b" />
-        <path d="M11.2,-3.2 C12.6,-5 13.4,-4.4 13.2,-2.8" fill="none" stroke="#0f150b" strokeWidth="1.7" strokeLinecap="round" />
-        <circle cx="10.4" cy="-0.6" r="0.7" fill="#9dd66a" opacity="0.8" />
-      </g>
-    </g>
-  );
-}
-
+/* ─── GUARDIANES ILUSTRADOS — reusados de la librería `src/visual/creatures` ──
+   Regla de la escena: transform de POSICIÓN en el <g> externo (lo pone el
+   stage); la ENTRADA (`gn-anim-*`) viaja en el `className` de la criatura
+   `inline`; la vida perpetua (aleteo, alas, bola) la trae la propia criatura. */
 const CUERPO = {
-  abeja: GuardianAbeja,
-  colibri: GuardianColibri,
-  lombriz: GuardianLombriz,
-  mariposa: GuardianMariposa,
-  escarabajo: GuardianEscarabajo,
+  abeja: AbejaAngelita,
+  colibri: Colibri,
+  lombriz: Lombriz,
+  mariposa: Mariposa,
+  escarabajo: Escarabajo,
+};
+
+/* Coreografía de LLEGADA por guardián (definida en guardianes-narrativos.css). */
+const ENTRADA = {
+  abeja: 'gn-anim-flota',
+  colibri: 'gn-anim-vuela',
+  lombriz: 'gn-anim-sube',
+  mariposa: 'gn-anim-mariposa',
+  escarabajo: 'gn-anim-rueda',
 };
 
 /* Posición del guardián dentro del stage (viewBox 0 0 340 210). El colibrí y la
@@ -286,7 +156,7 @@ const POS = {
 
 /* ─── El STAGE: pequeña finca de noche con corte de suelo + hilo de agua ─────── */
 function Escena({ guardianId, keyTick }) {
-  const Cuerpo = CUERPO[guardianId] || GuardianAbeja;
+  const Cuerpo = CUERPO[guardianId] || AbejaAngelita;
   return (
     <svg className="gn-svg" viewBox="0 0 340 210" role="img"
       aria-label={`Escena: llegó ${GUARDIANES[guardianId].nombre}`}>
@@ -336,7 +206,7 @@ function Escena({ guardianId, keyTick }) {
       </g>
       {/* EL GUARDIÁN — remonta con key para re-disparar su entrada */}
       <g key={`g-${keyTick}`} transform={POS[guardianId]}>
-        <Cuerpo />
+        <Cuerpo inline className={`gn-anim ${ENTRADA[guardianId]}`} />
       </g>
     </svg>
   );

--- a/src/mockups/guardianes-narrativos.css
+++ b/src/mockups/guardianes-narrativos.css
@@ -1,6 +1,9 @@
 /* MOCKUP "Guardianes que aparecen" — SVG+CSS puros, solo transform/opacity.
    Familia visual GuardianEspiritu (glow neón orgánico). Acento por guardián
-   (--gn-acc / --gn-acc-rgb) re-tiñe la escena. reduced-motion = fotograma digno. */
+   (--gn-acc / --gn-acc-rgb) re-tiñe la escena. reduced-motion = fotograma digno.
+   NOTA: la VIDA PERPETUA de cada bicho (aleteo, alas, bola, patas) vive ahora
+   en `src/visual/creatures/creatures.css`. Aquí queda solo el ESCENARIO y la
+   coreografía de LLEGADA de los guardianes. */
 
 .gn-wrap {
   --gn-acc: #2dffc4;
@@ -173,7 +176,8 @@
 .gn-auto:focus-visible { outline: 2px solid var(--gn-acc); outline-offset: 2px; }
 .gn-auto.on { background: rgba(var(--gn-acc-rgb), 0.14); border-style: solid; }
 
-/* ═══ ENTRADAS ORGÁNICAS POR GUARDIÁN (posición en <g> externo, entrada aquí) ═══ */
+/* ═══ ENTRADAS ORGÁNICAS POR GUARDIÁN (posición en <g> externo, entrada aquí) ═══
+   La vida perpetua de cada bicho la trae la librería `src/visual/creatures`. */
 
 /* abeja / mariposa: flotan hacia su flor con un arco */
 .gn-anim-flota { animation: gn-in-flota 0.7s cubic-bezier(0.2, 0.8, 0.3, 1) both; }
@@ -213,20 +217,13 @@
   50% { transform: rotate(4deg); }
 }
 
-/* mariposa: entra en camino ondulado + alas que abren/cierran */
+/* mariposa: entra en camino ondulado (sus alas las bate la propia criatura) */
 .gn-anim-mariposa { animation: gn-in-mariposa 1s cubic-bezier(0.3, 0.7, 0.3, 1) both; }
 @keyframes gn-in-mariposa {
   0% { opacity: 0; transform: translate(40px, -26px) rotate(-8deg); }
   40% { opacity: 1; transform: translate(14px, 6px) rotate(6deg); }
   70% { transform: translate(-6px, -4px) rotate(-3deg); }
   100% { transform: none; }
-}
-.gn-mari-ala { transform-box: fill-box; transform-origin: center; animation: gn-aletea 0.5s ease-in-out infinite; }
-.gn-mari-ala-izq { transform-origin: right center; }
-.gn-mari-ala-der { transform-origin: left center; }
-@keyframes gn-aletea {
-  0%, 100% { transform: scaleX(1); }
-  50% { transform: scaleX(0.4); }
 }
 
 /* escarabajo: RUEDA su bola de abono entrando desde la derecha */
@@ -236,20 +233,6 @@
   60% { opacity: 1; }
   100% { transform: none; }
 }
-.gn-bola { transform-box: fill-box; transform-origin: center; animation: gn-rueda 1.1s linear infinite; }
-@keyframes gn-rueda { 0% { transform: rotate(0); } 100% { transform: rotate(-360deg); } }
-.gn-patas { animation: gn-pasos 0.5s ease-in-out infinite; }
-@keyframes gn-pasos {
-  0%, 100% { transform: translateX(0); }
-  50% { transform: translateX(-1.2px); }
-}
-
-/* alas genéricas (abeja/colibrí): batir rápido */
-.gn-ala { transform-box: fill-box; transform-origin: center bottom; animation: gn-batir 0.13s ease-in-out infinite alternate; }
-@keyframes gn-batir {
-  0% { transform: scaleY(1) scaleX(1); }
-  100% { transform: scaleY(0.6) scaleX(0.9); }
-}
 
 /* ═══ reduced-motion: los guardianes APARECEN sin volar (fotograma digno) ═══ */
 @media (prefers-reduced-motion: reduce) {
@@ -257,7 +240,7 @@
   .gn-stage.saliendo { transform: none; }
   .gn-anim-flota, .gn-anim-vuela, .gn-anim-sube, .gn-anim-mariposa, .gn-anim-rueda,
   .gn-anim-flota > g, .gn-anim-vuela > g, .gn-anim-sube > g,
-  .gn-mari-ala, .gn-bola, .gn-patas, .gn-ala, .gn-halo, .gn-agua-brillo {
+  .gn-halo, .gn-agua-brillo {
     animation: gn-solo-aparece 0.35s ease both !important;
   }
   @keyframes gn-solo-aparece { from { opacity: 0; } to { opacity: 1; } }

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,0 +1,61 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
+   Apis). Cuerpo ámbar rayado, cabeza clara, alitas de tul. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-15 -15 32 30';
+
+export function AbejaAngelita({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Abeja angelita',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#ffb54f" opacity="0.35" filter={`url(#${blur})`} />
+      <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
+        style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
+      <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
+        stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
+      <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
+      <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
+      <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
+      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="abeja-angelita">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default AbejaAngelita;

--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,0 +1,62 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Colibrí chillón — Colibri coruscans (nativo de los Andes). Pico largo y
+   recto, garganta violeta iridiscente, alas que baten. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-22 -28 58 52';
+
+export function Colibri({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Colibrí',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#2dffc4" opacity="0.35" filter={`url(#${blur})`} />
+      <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
+      <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
+      <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
+      <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
+      <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
+      <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
+      <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+      <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <path className={wing} d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
+      <path className={wing} style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="colibri">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="colibri" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Colibri;

--- a/src/visual/creatures/Escarabajo.jsx
+++ b/src/visual/creatures/Escarabajo.jsx
@@ -1,0 +1,73 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Escarabajo estercolero — Dichotomius belus (propio de Colombia). Élitros
+   negros brillantes con sutura, cabeza con cuerno, patas que caminan y la bola
+   de abono que rueda. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-23 -12 42 30';
+
+export function Escarabajo({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Escarabajo estercolero',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const bola = animated ? 'crt-ball' : undefined;
+  const patas = animated ? 'crt-legs' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const bolaG = (
+    <g className={bola}>
+      <circle cx="-13" cy="7" r="6.5" fill="#5a4230" />
+      <circle cx="-13" cy="7" r="6.5" fill="none" stroke="#3a2c1c" strokeWidth="1" />
+      <circle cx="-15" cy="5" r="1.5" fill="#6e5238" opacity="0.7" />
+      <circle cx="-11.5" cy="9" r="1.1" fill="#42301f" opacity="0.7" />
+    </g>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={patas} stroke="#0c1206" strokeWidth="1.7" strokeLinecap="round">
+        <path d="M-4,4 L-9,10" /><path d="M0,5 L-1,11" /><path d="M4,4 L8,10" />
+      </g>
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="#141c10"
+        style={{ filter: 'drop-shadow(0 0 5px rgba(157,214,106,0.7))' }} />
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="none" stroke="#9dd66a" strokeWidth="0.7" strokeOpacity="0.6" />
+      <path d="M0,-5.6 L0,5.6" stroke="#0c1206" strokeWidth="0.8" />
+      <ellipse cx="-3.5" cy="-2.8" rx="2.6" ry="1.4" fill="#3d5a24" opacity="0.55" />
+      <path d="M8,-3.4 C12,-3.8 13.4,-1 12.4,1.4 C11.4,3.6 9,3.6 8.2,2.6 C9.4,1 9.2,-1.4 8,-3.4 Z" fill="#0f150b" />
+      <path d="M11.2,-3.2 C12.6,-5 13.4,-4.4 13.2,-2.8" fill="none" stroke="#0f150b" strokeWidth="1.7" strokeLinecap="round" />
+      <circle cx="10.4" cy="-0.6" r="0.7" fill="#9dd66a" opacity="0.8" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="escarabajo">
+        {defs}
+        {bolaG}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="escarabajo" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {bolaG}
+      {body}
+    </svg>
+  );
+}
+
+export default Escarabajo;

--- a/src/visual/creatures/Lombriz.jsx
+++ b/src/visual/creatures/Lombriz.jsx
@@ -1,0 +1,64 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Lombriz de tierra — Martiodrilus crassus (lombriz gigante nativa de los
+   Andes). Cuerpo curvo segmentado con clitelo (banda clara) y cabecita.
+   Su movimiento en escena (asomar/mecerse) lo aporta la escena, no la
+   criatura. Versión canónica del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-8 -16 30 48';
+
+export function Lombriz({
+  size = 64,
+  className,
+  inline = false,
+  // eslint-disable-next-line no-unused-vars
+  animated = true,
+  title = 'Lombriz de tierra',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#c0715a" strokeWidth="7.4" strokeLinecap="round" />
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#ff9d6a" strokeWidth="4.4" strokeLinecap="round" opacity="0.85" />
+      <g stroke="#7a3f2e" strokeWidth="0.9" opacity="0.65" strokeLinecap="round">
+        <path d="M-1.4,22 L1.4,20.5" /><path d="M-1.2,16.5 L2.2,15.5" />
+        <path d="M2.4,11.5 L5.6,11" /><path d="M3.4,5.5 L6.4,5.6" />
+        <path d="M2.8,-0.5 L5.6,-1.4" /><path d="M4.6,-6 L7.4,-7.6" />
+      </g>
+      <path d="M3.2,3 C2,-1 4,-4 6.6,-5" fill="none" stroke="#ffd9b0" strokeWidth="4.6" strokeLinecap="round" opacity="0.75" />
+      <circle cx="12.2" cy="-9.4" r="2.2" fill="#ff9d6a" />
+      <circle cx="13.2" cy="-10" r="0.6" fill="#3a1c12" opacity="0.7" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="lombriz">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="lombriz" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Lombriz;

--- a/src/visual/creatures/Mariposa.jsx
+++ b/src/visual/creatures/Mariposa.jsx
@@ -1,0 +1,76 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Mariposa pasionaria — Dione juno (Nymphalidae, alas largas). Cuatro alas
+   independientes (delanteras + traseras, izq/der) que abren y cierran, cuerpo,
+   cabeza, antenas y ocelos. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-27 -18 54 40';
+
+export function Mariposa({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Mariposa',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const alaL = animated ? 'crt-fwing crt-fwing-l' : undefined;
+  const alaR = animated ? 'crt-fwing crt-fwing-r' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={alaL}>
+        <path d="M0,2 C-13,4 -18,12 -12,15 C-6,17 -1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="-9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,2 C13,4 18,12 12,15 C6,17 1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaL}>
+        <path d="M0,-2 C-16,-11 -24,-6 -22,0 C-20,5 -8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M-20,-3 C-14,-2 -7,-1 -1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="-16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,-2 C16,-11 24,-6 22,0 C20,5 8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M20,-3 C14,-2 7,-1 1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <ellipse cx="0" cy="2" rx="1.7" ry="9" fill="#2a1712" />
+      <circle cx="0" cy="-8" r="1.9" fill="#2a1712" />
+      <path d="M-0.8,-9.4 C-3,-13 -4.5,-14 -6,-13.6 M0.8,-9.4 C3,-13 4.5,-14 6,-13.6"
+        stroke="#2a1712" strokeWidth="0.8" fill="none" strokeLinecap="round" />
+      <circle cx="-6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+      <circle cx="6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="mariposa">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="mariposa" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Mariposa;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -1,0 +1,74 @@
+# `src/visual/creatures` — personajes de fauna reutilizables
+
+Librería de **personajes de fauna de la chagra** como componentes SVG limpios,
+parametrizables y sin dependencias nuevas. Nace para **dejar de redibujar el
+mismo bicho** en cada mockup/escena: hoy el colibrí, la abeja angelita, la
+lombriz, la mariposa y el escarabajo aparecían dibujados por separado en varios
+sitios (`mockups/MockupGuardianesNarrativos`, `dashboard/Scene*`,
+`FincaVivaHero`, `MundoVinetas`, `MundoSubsuelo`, avatares del colibrí…) con
+calidad dispar. Aquí vive la **versión canónica** de cada uno.
+
+## Regla de la casa
+
+> **Antes de dibujar un personaje de fauna, búscalo aquí.**
+> Si existe → **reúsalo** (y si podés, **mejorá** la versión canónica en su
+> archivo, para que todos hereden la mejora).
+> Si dibujás un personaje nuevo reutilizable → **agregalo aquí en el mismo PR**
+> (componente + entrada en `index.js` + fila en esta tabla).
+
+## Personajes
+
+| Componente | Especie (binomio verificado) | Notas |
+|---|---|---|
+| `AbejaAngelita` | *Tetragonisca angustula* | Meliponino nativo **SIN aguijón** — NO *Apis*. Alitas de tul que baten. |
+| `Colibri` | *Colibri coruscans* | Colibrí chillón andino. Pico largo, garganta violeta, alas que baten. |
+| `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
+| `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
+| `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
+
+## Props
+
+Todos comparten la misma firma:
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `size` | `number \| string` | `64` | Ancho/alto en modo standalone (`<svg>`). Ignorado en modo `inline`. |
+| `className` | `string` | — | Clase(s) del nodo raíz. En modo `inline` es donde la escena engancha su coreografía de entrada/posición. |
+| `inline` | `boolean` | `false` | `false` → `<svg>` autónomo (avatares, catálogo, botones). `true` → solo un `<g>` para incrustar en una escena SVG existente. |
+| `animated` | `boolean` | `true` | Activa la vida perpetua (aleteo, alas, bola, patas). `false` = quieto. Siempre reduced-motion-safe. |
+| `title` | `string` | nombre del bicho | `aria-label` + `<title>` accesible. |
+
+Props extra (`...rest`) se pasan al `<svg>` en modo standalone.
+
+## Uso
+
+```jsx
+import { Colibri, AbejaAngelita } from '@/visual/creatures';
+
+// Avatar / catálogo — SVG autónomo:
+<Colibri size={48} title="Colibrí chillón" />
+<AbejaAngelita size={40} animated={false} />
+
+// Dentro de una escena SVG propia (la escena pone posición y entrada):
+<svg viewBox="0 0 340 210">
+  {/* …fondo, suelo… */}
+  <g transform="translate(120 66)">
+    <Colibri inline className="mi-entrada-volando" />
+  </g>
+</svg>
+```
+
+Consumidor de referencia: **`src/mockups/MockupGuardianesNarrativos.jsx`**
+(usa las 5 criaturas en modo `inline`).
+
+## Técnica
+
+- SVG + CSS puros, **cero dependencias nuevas**; solo `transform`/`opacity`
+  (GPU, Android gama baja). Familia visual del glow de `GuardianEspiritu`.
+- Cada instancia genera **ids de filtro únicos** (`useId`), así se pueden
+  repetir muchas criaturas en una misma página sin colisión.
+- La **vida perpetua** vive en `creatures.css` (clases `crt-*`), es intrínseca
+  a la criatura y **reduced-motion-safe** (sin animación → fotograma digno).
+- La **coreografía de LLEGADA** (entrar volando, asomar del suelo, rodar) NO
+  vive aquí: es responsabilidad de la escena que consume la criatura, sobre el
+  `className` del modo `inline`.

--- a/src/visual/creatures/_filters.jsx
+++ b/src/visual/creatures/_filters.jsx
@@ -1,0 +1,23 @@
+/*
+ * Filtro SVG compartido de la familia visual "creatures": glow orgánico
+ * (feGaussianBlur + feMerge) heredado de GuardianEspiritu + blur suave.
+ * Cada criatura instancia estos filtros con ids ÚNICOS (useId) para poder
+ * repetirse muchas veces en una misma página sin colisión de ids.
+ * Interno de la librería — no se exporta desde el barrel.
+ */
+export function CreatureFilters({ glow, blur }) {
+  return (
+    <>
+      <filter id={glow} x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.1" result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      <filter id={blur}>
+        <feGaussianBlur stdDeviation="3" />
+      </filter>
+    </>
+  );
+}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1,0 +1,51 @@
+/* ─── Vida perpetua de las CREATURES — SVG + CSS puros, solo transform/opacity
+   (GPU, Android gama baja). Reutilizable en cualquier escena o avatar.
+   La coreografía de LLEGADA (entrar volando, asomar del suelo) NO vive aquí:
+   es responsabilidad de la escena que consume la criatura.
+   reduced-motion = criatura quieta en un fotograma digno. ─── */
+
+/* aleteo rápido (abeja / colibrí) */
+.crt-wing {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: crt-wingbeat 0.13s ease-in-out infinite alternate;
+}
+@keyframes crt-wingbeat {
+  0% { transform: scaleY(1) scaleX(1); }
+  100% { transform: scaleY(0.6) scaleX(0.9); }
+}
+
+/* alas de mariposa que abren y cierran */
+.crt-fwing {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-flutter 0.5s ease-in-out infinite;
+}
+.crt-fwing-l { transform-origin: right center; }
+.crt-fwing-r { transform-origin: left center; }
+@keyframes crt-flutter {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.4); }
+}
+
+/* bola de abono que rueda (escarabajo) */
+.crt-ball {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-roll 1.1s linear infinite;
+}
+@keyframes crt-roll {
+  0% { transform: rotate(0); }
+  100% { transform: rotate(-360deg); }
+}
+
+/* patas que dan pasos (escarabajo) */
+.crt-legs { animation: crt-step 0.5s ease-in-out infinite; }
+@keyframes crt-step {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-1.2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crt-wing, .crt-fwing, .crt-ball, .crt-legs { animation: none !important; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -1,0 +1,32 @@
+/*
+ * Librería visual de PERSONAJES DE FAUNA de la chagra (creatures).
+ * Fuente única y reutilizable. Antes de dibujar un bicho, búscalo aquí.
+ *
+ * Cada componente:
+ *   - Modo standalone (por defecto): renderiza su propio <svg> con viewBox,
+ *     dimensionado por `size` — ideal para avatares, catálogo, botones.
+ *   - Modo `inline`: renderiza solo el <g> para incrustarse en una escena SVG
+ *     que ya define su viewBox y su coreografía de entrada/posición.
+ *
+ * Props comunes: { size, className, inline, animated, title }.
+ */
+export { AbejaAngelita } from './AbejaAngelita.jsx';
+export { Colibri } from './Colibri.jsx';
+export { Lombriz } from './Lombriz.jsx';
+export { Mariposa } from './Mariposa.jsx';
+export { Escarabajo } from './Escarabajo.jsx';
+
+import AbejaAngelita from './AbejaAngelita.jsx';
+import Colibri from './Colibri.jsx';
+import Lombriz from './Lombriz.jsx';
+import Mariposa from './Mariposa.jsx';
+import Escarabajo from './Escarabajo.jsx';
+
+/* Registro consultable: slug → componente + binomio verificado. */
+export const CREATURES = {
+  'abeja-angelita': { Component: AbejaAngelita, nombre: 'Abeja angelita', cientifico: 'Tetragonisca angustula' },
+  colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
+  lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
+  mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
+  escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },
+};


### PR DESCRIPTION
## Qué es

Prueba del **patrón de librería visual**: en vez de que cada mockup redibuje la fauna desde cero, se extraen los personajes a una **librería importable** para reusar + mejorar. Alcance acotado a propósito (es la prueba del patrón, no refactorizar todo).

## Qué hace

- Nueva carpeta **`src/visual/creatures/`** con un componente SVG parametrizable por personaje:
  - `Colibri` — *Colibri coruscans*
  - `AbejaAngelita` — *Tetragonisca angustula* (meliponino sin aguijón, **no** *Apis*)
  - `Lombriz` — *Martiodrilus crassus*
  - `Mariposa` — *Dione juno*
  - `Escarabajo` — *Dichotomius belus* (estercolero, con su bola de abono)
- **`MockupGuardianesNarrativos.jsx` ahora IMPORTA** esos componentes en vez de tener el SVG inline (consumidor de referencia del patrón).
- **`index.js`** (barrel + registro `CREATURES`) y **`README.md`** con la regla: *búscalo aquí antes de dibujar; reusa + mejora; si creás uno nuevo reutilizable, agregalo aquí en el mismo PR*.

## Diseño

- Cada componente es **autocontenido**: modo standalone (`<svg>` dimensionado por `size`, para avatares/catálogo) o modo `inline` (`<g>` para incrustarse en una escena que aporta posición y coreografía de llegada).
- **Vida perpetua** (aleteo, alas, bola, patas) en `creatures.css` con clases `crt-*`, **reduced-motion-safe**.
- **Ids de filtro únicos por instancia** (`useId`) → varias criaturas en la misma página sin colisión.
- **Cero dependencias nuevas**. Props: `size` · `className` · `inline` · `animated` · `title`.

## De dónde se dedujo

Las 5 criaturas estaban redibujadas en `dashboard/Scene*`, `FincaVivaHero`, `MundoVinetas`, `MundoSubsuelo`, avatares del colibrí y otras, con calidad dispar (algunas foto/emoji). El set del mockup de guardianes era el más logrado y coherente → se toma como **versión canónica**. La migración de los demás consumidores es el **escalado** (va en PRs posteriores; este PR solo monta el patrón y deja un consumidor usándolo).

## Verificación

- `npm run build` **verde**.
- `eslint` de los archivos tocados **limpio**.
- **Arte SVG byte-idéntico** al original: los 31 `path d=` y todos los `fill` de las 5 criaturas coinciden 1:1 con el inline previo — la escena se ve igual, solo cambió el plumbing de ids/clases.

> Base del PR: rama `fable/mockup-guardianes-narrativos` (#2282), donde vive el consumidor. Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)