### PR TITLE
feat(visual): libreria de EFECTOS reutilizables (src/visual/effects)

### DIFF
--- a/src/components/dashboard/GuardianEspiritu.jsx
+++ b/src/components/dashboard/GuardianEspiritu.jsx
@@ -5,6 +5,7 @@
  */
 import { useCallback, useEffect, useState } from 'react';
 import { getGuardianEspecie, setGuardianEspecie } from '../../services/userProfileService';
+import { GlowFilter } from '../../visual/effects';
 import './guardian-espiritu.css';
 
 /**
@@ -82,13 +83,11 @@ const byId = (id) => ESPECIES.find((e) => e.id === id) || ESPECIES[0];
 /* filtros SVG compartidos (glow + blur), portados del mockup                  */
 /* ------------------------------------------------------------------------- */
 function GuardianDefs() {
+  // Glow + blur suelto compartidos (§13.16). Antes inline; ahora la versión
+  // canónica de src/visual/effects. Mismo markup (id/std/bounds) = cero regresión.
   return (
     <defs>
-      <filter id="ge-glow1" x="-80%" y="-80%" width="260%" height="260%">
-        <feGaussianBlur stdDeviation="2.2" result="b" />
-        <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
-      </filter>
-      <filter id="ge-blur3"><feGaussianBlur stdDeviation="3" /></filter>
+      <GlowFilter id="ge-glow1" std={2.2} blurId="ge-blur3" blurStd={3} />
     </defs>
   );
 }

--- a/src/visual/effects/AutoDibujo.jsx
+++ b/src/visual/effects/AutoDibujo.jsx
@@ -1,0 +1,35 @@
+/*
+ * AutoDibujo — el AUTO-DIBUJADO orquestado compartido (§13.11 del catálogo).
+ *
+ * La receta de SceneTrazoMinimal ("el trazo se dibuja solo al entrar"):
+ * `pathLength="1"` normalizado + `stroke-dashoffset` que va a 0 + etapas con
+ * delay escalonado. Aquí queda como helper para no re-cablear el dasharray a
+ * mano en cada lámina/onboarding/glifo.
+ *
+ * El movimiento vive en `effects.css` (clases `vfx-draw`, `vfx-fade`,
+ * `vfx-t1…vfx-t9`); este componente solo pega las clases correctas y pone
+ * `pathLength="1"` para que el draw-in sea independiente de la longitud real
+ * del trazo. Reduced-motion = el dibujo COMPLETO y quieto (lo garantiza el CSS).
+ *
+ * Recuerde importar el CSS una vez en la escena:  import '.../effects/effects.css'
+ *
+ * @param {object}  props
+ * @param {'path'|'line'|'polyline'|'circle'|'rect'|string} [props.as='path']
+ *        elemento SVG a renderizar.
+ * @param {number}  [props.stage]      etapa 1..9 (delay escalonado del dibujo).
+ * @param {boolean} [props.fade=false] `true` = aparece en fundido (opacity) en
+ *        vez de trazarse — para planos de color (sol, leyenda, humo).
+ * @param {string}  [props.className]  clases extra.
+ * Resto de props (`d`, `stroke`, `strokeWidth`, `fill`, `cx`…) se pasan tal cual.
+ */
+export function AutoDibujo({ as = 'path', stage, fade = false, className, ...rest }) {
+  const El = as;
+  const base = fade ? 'vfx-fade' : 'vfx-draw';
+  const stageClass = stage ? ` vfx-t${stage}` : '';
+  const cls = `${base}${stageClass}${className ? ` ${className}` : ''}`;
+  // pathLength normaliza el dashoffset a [0..1]; solo aplica al modo trazo.
+  const drawProps = fade ? {} : { pathLength: 1 };
+  return <El className={cls} {...drawProps} {...rest} />;
+}
+
+export default AutoDibujo;

--- a/src/visual/effects/FiltroAcuarela.jsx
+++ b/src/visual/effects/FiltroAcuarela.jsx
@@ -1,0 +1,58 @@
+/*
+ * FiltroAcuarela — el borde/relleno "pintado a la acuarela" compartido
+ * (feTurbulence + feDisplacementMap).
+ *
+ * Da a un trazo o relleno SVG el borde húmedo, irregular y sangrado de la
+ * acuarela: la turbulencia genera un ruido fractal y el displacement empuja los
+ * píxeles según ese ruido. Es la receta que dibuja los bordes del mapa-acuarela
+ * en vez de re-hilvanar un `<filter>` inline por mockup.
+ *
+ * Emite SOLO el `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y lo referencia con `filter={`url(#${id})`}`. Pasar ids únicos
+ * (`useId`) para repetir varios en la misma página sin colisión.
+ *
+ * Reduced-motion-safe por construcción: el filtro es ESTÁTICO (no anima), en
+ * línea con la regla de la casa "blur/filtros estáticos, solo transform/opacity
+ * animados".
+ *
+ * @param {object} props
+ * @param {string}  props.id                 id del filtro (obligatorio).
+ * @param {number} [props.frequency=0.012]   baseFrequency del ruido (más alto =
+ *                                           borde más nervioso/fino).
+ * @param {number} [props.scale=6]           fuerza del desplazamiento en px.
+ * @param {number} [props.octaves=2]         numOctaves del fractalNoise.
+ * @param {number} [props.seed=7]            semilla del ruido (determinista).
+ * @param {string} [props.bounds='-20%']     origen del box del filtro (x/y).
+ */
+export function FiltroAcuarela({
+  id,
+  frequency = 0.012,
+  scale = 6,
+  octaves = 2,
+  seed = 7,
+  bounds = '-20%',
+}) {
+  const off = parseFloat(bounds);
+  const size = `${100 - 2 * off}%`;
+  const noise = `${id}-noise`;
+  return (
+    <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+      <feTurbulence
+        type="fractalNoise"
+        baseFrequency={frequency}
+        numOctaves={octaves}
+        seed={seed}
+        result={noise}
+      />
+      <feDisplacementMap
+        in="SourceGraphic"
+        in2={noise}
+        scale={scale}
+        xChannelSelector="R"
+        yChannelSelector="G"
+      />
+    </filter>
+  );
+}
+
+export default FiltroAcuarela;

--- a/src/visual/effects/GlowFilter.jsx
+++ b/src/visual/effects/GlowFilter.jsx
@@ -1,0 +1,44 @@
+/*
+ * GlowFilter — el GLOW neón orgánico compartido de Chagra (§13.16 del catálogo).
+ *
+ * Es la MISMA receta que hoy está copiada como `<filter>` inline en varias
+ * escenas y en la librería de fauna (GuardianEspiritu `ge-glow1`, creatures
+ * `CreatureFilters`, SceneFincaOrganismo `fvo-glow1`…): un feGaussianBlur
+ * fundido con el original vía feMerge, más — opcionalmente — un blur suave
+ * suelto para halos/estelas. Aquí vive la versión canónica.
+ *
+ * Emite SOLO los `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y referencia por id. Como cada escena decide su id, se pueden repetir
+ * muchos glows en una misma página sin colisión (pasar ids únicos con `useId`).
+ *
+ * @param {object} props
+ * @param {string}  props.id              id del filtro de glow (obligatorio).
+ * @param {number} [props.std=2.1]        desenfoque del glow (stdDeviation).
+ * @param {string} [props.blurId]         si se pasa, emite además un blur suelto
+ *                                        con este id (para halos/estelas).
+ * @param {number} [props.blurStd=3]      desenfoque del blur suelto.
+ * @param {string} [props.bounds='-80%']  origen del box del filtro (x/y); el
+ *                                        ancho/alto se calculan como 100%-2*bounds.
+ */
+export function GlowFilter({ id, std = 2.1, blurId, blurStd = 3, bounds = '-80%' }) {
+  const off = parseFloat(bounds); // -80  → box de 260%
+  const size = `${100 - 2 * off}%`;
+  return (
+    <>
+      <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+        <feGaussianBlur stdDeviation={std} result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      {blurId ? (
+        <filter id={blurId}>
+          <feGaussianBlur stdDeviation={blurStd} />
+        </filter>
+      ) : null}
+    </>
+  );
+}
+
+export default GlowFilter;

--- a/src/visual/effects/README.md
+++ b/src/visual/effects/README.md
@@ -1,0 +1,118 @@
+# `src/visual/effects` — efectos visuales reutilizables
+
+Librería de las **técnicas de cine** de Chagra (las que dan el "wow": velos,
+viñeta, scrims, grades de luz por piso térmico, glow, pulso cardíaco,
+auto-dibujado, acuarela) como **CSS + helpers SVG limpios, parametrizables y sin
+dependencias nuevas**. Nace para **dejar de re-hilvanar el mismo efecto** en
+cada mockup/escena: hoy el velo neón, la viñeta, los grades `--mm2-*`, el glow
+`feMerge`, el latido `--fvo-beat`, el trazo que se dibuja solo y el filtro
+acuarela aparecían copiados/redibujados en `finca-viva-hero.css`,
+`scene-finca-organismo.css`, `scene-trazo-minimal.css`, `GuardianEspiritu`, los
+mockups de la Montaña y el mapa-acuarela. Aquí vive la **versión canónica**.
+
+Hermana de [`src/visual/creatures`](../creatures/README.md) (personajes de
+fauna): misma filosofía, mismo contrato de reuso.
+
+## Regla de la casa
+
+> **Antes de re-dibujar un efecto de cine, búsquelo aquí.**
+> Si existe → **reúselo** (y de ser posible, **mejore** la versión canónica,
+> para que todos hereden la mejora).
+> Si crea un efecto nuevo reutilizable → **agréguelo aquí en el mismo PR**
+> (clase/helper + entrada en `index.js` + fila en esta tabla).
+
+## Qué hay
+
+| Efecto | Cómo se usa | Catálogo | Semilla |
+|---|---|---|---|
+| **Velo atmosférico** neón | clase `.vfx-veil` (custom props `--vfx-veil-a/b/opacity`) | §13.5 / §13.16 | `finca-viva-hero` `.fvh-escena-wrap::after` |
+| **Viñeta** de cine | clase `.vfx-vignette` (`--vfx-vignette-strength`) | §13.5 | idem |
+| **Scrims** arriba/abajo | clases `.vfx-scrim-top` / `.vfx-scrim-bottom` (`--vfx-scrim-color/-h`) | §13.5 | idem |
+| **Grades de luz por piso térmico** | clase `.vfx-grade` + modificador `.vfx-grade--{glacial,paramo,frio,templado,calido,valle}`; tokens `--vfx-piso-*`; `--vfx-grade-fuerza` por dirección | §13.2 | los `--mm2-*` de Montaña |
+| **Glow** (feMerge) | helper `<GlowFilter id std blurId />` | §13.16 | unifica `ge-glow1` + `creatures/_filters` |
+| **Pulso cardíaco** | token `--vfx-beat` + clases `.vfx-beat`, `.vfx-beat-wave`, `.vfx-beat-glow` | §13.10 | `--fvo-beat` (SceneFincaOrganismo) |
+| **Auto-dibujado** | helper `<AutoDibujo stage fade />` + clases `.vfx-draw/.vfx-fade/.vfx-t1…t9` | §13.11 | SceneTrazoMinimal `fvm-t*` |
+| **Flujo por dash** | clase `.vfx-flow` (`--vfx-flow-dur/-len`) | §13.12 | `fvo-flow` / `adm-sap` |
+| **Filtro acuarela** | helper `<FiltroAcuarela id scale frequency />` | — | mapa-acuarela (feTurbulence+feDisplacementMap) |
+
+## Dos formas de consumir
+
+**1. CSS** (velos, viñeta, scrims, grades, latido, auto-dibujado, flujo).
+Importe el CSS una vez donde lo use y ponga las clases:
+
+```jsx
+import '../../visual/effects/effects.css';
+
+// una escena con cielo de biopunk y hora dorada en la finca:
+<div style={{ position: 'relative' }}>
+  <MiEscenaSVG />
+  <div className="vfx-grade vfx-grade--templado" />   {/* luz de la finca  */}
+  <div className="vfx-veil" />                          {/* velo neón        */}
+  <div className="vfx-scrim-bottom" />                  {/* para que el texto lea */}
+  <div className="vfx-vignette" />                      {/* enfoca el centro */}
+</div>
+```
+
+El pulso cardíaco sincroniza todo lo vivo con una sola variable:
+
+```jsx
+// el corazón late, la red se enciende en fase, la onda se expande:
+<g className="vfx-beat"><path d="…corazón…" /></g>
+<g className="vfx-beat-glow"><path d="…red micorrízica…" /></g>
+<circle className="vfx-beat-wave" r="8" />
+// para acelerar/frenar TODO junto:  style={{ '--vfx-beat': '4s' }} en un ancestro
+```
+
+**2. Helpers SVG** (glow, acuarela, auto-dibujado). Se montan en tu `<defs>` /
+tu SVG. Cada instancia usa **ids únicos** (`useId`) para repetirse sin colisión:
+
+```jsx
+import { useId } from 'react';
+import { GlowFilter, FiltroAcuarela, AutoDibujo } from '../../visual/effects';
+import '../../visual/effects/effects.css';
+
+function MiEscena() {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `glow-${uid}`;
+  const agua = `acuarela-${uid}`;
+  return (
+    <svg viewBox="0 0 390 486">
+      <defs>
+        <GlowFilter id={glow} std={2.2} blurId={`blur-${uid}`} />
+        <FiltroAcuarela id={agua} scale={7} frequency={0.014} />
+      </defs>
+
+      {/* glow neón sobre lo vivo */}
+      <g filter={`url(#${glow})`}>{/* … */}</g>
+
+      {/* un relieve/mancha con borde de acuarela */}
+      <path d="…" fill="#6f9a85" filter={`url(#${agua})`} />
+
+      {/* el trazo se dibuja solo, por etapas */}
+      <AutoDibujo d="M20,300 C120,260 …" stage={1} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo d="M60,300 L60,240 …" stage={3} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo as="circle" fade stage={6} cx="300" cy="90" r="26" fill="#cbb96a" />
+    </svg>
+  );
+}
+```
+
+Consumidor de referencia (convertido en este PR): **`dashboard/GuardianEspiritu.jsx`**
+— sus filtros `ge-glow1`/`ge-blur3`, antes inline, hoy salen de `<GlowFilter>`
+(mismo markup, cero regresión visual).
+
+## Técnica y reglas
+
+- **CSS + SVG puros, cero dependencias nuevas**; solo `transform`/`opacity`
+  animados, **blur/filtros ESTÁTICOS** (Android gama baja). Cero JS por frame.
+- Cada helper emite **solo el `<filter>`** (sin `<defs>` propio): el consumidor
+  lo mete en su `<defs>` y referencia por id. **Ids únicos** con `useId` para
+  repetir muchos en una misma página sin colisión.
+- **Reduced-motion-safe**: sin movimiento, el latido queda encendido, el trazo
+  COMPLETO, los planos visibles y velos/grades/viñeta quietos (son estáticos).
+- Las capas-overlay (`.vfx-veil/.vfx-vignette/.vfx-scrim-*/.vfx-grade`) se montan
+  dentro de un contenedor `position: relative`, no capturan toque y heredan el
+  radio del contenedor.
+- Los **grades por piso térmico** nacen tokenizados (`--vfx-piso-*`): cuando la
+  Montaña entre a prod, se re-tiñen desde `themes.css` sin tocar las escenas
+  (§13.2, promoción de los `--mm2-*` recomendada por el catálogo §14b).

--- a/src/visual/effects/effects.css
+++ b/src/visual/effects/effects.css
@@ -1,0 +1,190 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   src/visual/effects/effects.css — EFECTOS visuales reutilizables de Chagra.
+
+   Las TÉCNICAS DE CINE del catálogo (§13) que hoy están redibujadas/re-copiadas
+   en varios mockups y escenas, aquí una sola vez como clases `vfx-*` + custom
+   properties `--vfx-*`. Antes de re-hilvanar un velo/viñeta/grade/latido/trazo,
+   use esto.
+
+   Reglas de la casa respetadas:
+   · Solo `transform`/`opacity` animados; blur/filtros ESTÁTICOS (Android gama baja).
+   · `prefers-reduced-motion` = fotograma final digno (nada roto, nada en loop).
+   · Cero dependencias; cero JS por frame.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Base de las capas-overlay ───────────────────────────────────────────────
+   Todos los velos/viñetas/scrims/grades se montan como una capa absoluta dentro
+   de un contenedor `position: relative`. No capturan toque. Heredan el radio del
+   contenedor para no desbordar tarjetas redondeadas. */
+.vfx-overlay,
+.vfx-veil,
+.vfx-vignette,
+.vfx-scrim-top,
+.vfx-scrim-bottom,
+.vfx-grade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+/* ── 1. VELO atmosférico neón (§13.5 / §13.16) ──────────────────────────────
+   El velo radial teal/orquídea + tinte navy del modo biopunk (receta de
+   finca-viva-hero `.fvh-escena-wrap::after`). Tunéable por custom props para
+   re-teñir sin reescribir el gradiente. Los temas claros lo apagan poniendo
+   `--vfx-veil-opacity: 0`. */
+.vfx-veil {
+  z-index: 6;
+  opacity: var(--vfx-veil-opacity, 1);
+  background:
+    radial-gradient(120% 78% at 80% 12%, var(--vfx-veil-a, rgba(34, 211, 238, 0.26)), transparent 56%),
+    radial-gradient(110% 92% at 16% 92%, var(--vfx-veil-b, rgba(217, 70, 239, 0.22)), transparent 58%),
+    linear-gradient(180deg,
+      var(--vfx-veil-top, rgba(8, 16, 34, 0.42)) 0%,
+      rgba(8, 16, 34, 0.08) 40%,
+      var(--vfx-veil-bottom, rgba(10, 22, 44, 0.36)) 100%);
+  transition: opacity 0.5s ease;
+}
+
+/* ── 2. VIÑETA de cine (§13.5) ───────────────────────────────────────────────
+   Radial que hunde las esquinas para enfocar el centro y que la UI flote sin
+   cajas. `--vfx-vignette-strength` (0..1) modula cuánto oscurece el borde. */
+.vfx-vignette {
+  z-index: 7;
+  background: radial-gradient(120% 120% at 50% 45%,
+    transparent 52%,
+    rgba(0, 0, 0, calc(0.35 * var(--vfx-vignette-strength, 1))) 100%);
+}
+
+/* ── 3. SCRIMS arriba/abajo (§13.5) ──────────────────────────────────────────
+   Degradados en los bordes superior/inferior para que el texto SIEMPRE lea
+   sobre la escena (títulos arriba, compositor abajo). */
+.vfx-scrim-top {
+  z-index: 7;
+  background: linear-gradient(180deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 28%);
+  inset: 0 0 auto 0;
+}
+.vfx-scrim-bottom {
+  z-index: 7;
+  background: linear-gradient(0deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 34%);
+  inset: auto 0 0 0;
+}
+
+/* ── 4. GRADES de luz por PISO TÉRMICO (§13.2) ───────────────────────────────
+   Plano de color fijo al viewport, crossfade por opacity: la TEMPERATURA de la
+   luz cuenta la altura. Azul glacial (nevado) → cian páramo → neutro frío →
+   HORA DORADA (finca templada) → ámbar cálido → turquesa río. Portado de los
+   `--mm2-*` del mockup Montaña (§13.2), tokenizado para promoverse a prod.
+   `--vfx-grade-fuerza` modula la intensidad por dirección artística
+   (naturalista 1 · biopunk 0.45 · verde-vivo 0.75). */
+:root {
+  --vfx-piso-glacial:  rgba(180, 214, 240, 0.50); /* nevado 4.800m */
+  --vfx-piso-paramo:   rgba(120, 200, 210, 0.42); /* páramo */
+  --vfx-piso-frio:     rgba(150, 165, 172, 0.28); /* frío (neutro) */
+  --vfx-piso-templado: rgba(255, 200, 120, 0.34); /* finca ⭐ hora dorada */
+  --vfx-piso-calido:   rgba(255, 170,  90, 0.36); /* cálido ámbar */
+  --vfx-piso-valle:    rgba( 90, 200, 190, 0.40); /* río turquesa 400m */
+}
+.vfx-grade {
+  z-index: 5;
+  background: var(--vfx-grade-color, var(--vfx-piso-templado));
+  opacity: var(--vfx-grade-fuerza, 1);
+  transition: background 0.6s ease, opacity 0.6s ease;
+}
+.vfx-grade--glacial  { --vfx-grade-color: var(--vfx-piso-glacial); }
+.vfx-grade--paramo   { --vfx-grade-color: var(--vfx-piso-paramo); }
+.vfx-grade--frio     { --vfx-grade-color: var(--vfx-piso-frio); }
+.vfx-grade--templado { --vfx-grade-color: var(--vfx-piso-templado); }
+.vfx-grade--calido   { --vfx-grade-color: var(--vfx-piso-calido); }
+.vfx-grade--valle    { --vfx-grade-color: var(--vfx-piso-valle); }
+
+/* ── 5. PULSO CARDÍACO compartido (§13.10) ───────────────────────────────────
+   Una sola variable de duración (`--vfx-beat`) sincroniza TODO lo vivo: la
+   escena late como UN organismo. Es el `--fvo-beat` de SceneFincaOrganismo,
+   promovido a la librería (mismo valor 5.2s = `--motion-beat`). */
+:root { --vfx-beat: 5.2s; }
+
+/* el corazón: doble pulso como corazón real */
+.vfx-beat {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat var(--vfx-beat) ease-in-out infinite;
+}
+@keyframes vfx-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+/* onda que sale del latido */
+.vfx-beat-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat-wave var(--vfx-beat) ease-out infinite;
+}
+@keyframes vfx-beat-wave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red/savia/panel se ENCIENDE con cada latido (solo opacity) */
+.vfx-beat-glow { animation: vfx-beat-glow var(--vfx-beat) ease-in-out infinite; }
+@keyframes vfx-beat-glow {
+  0%, 100% { opacity: 0.55; }
+  8% { opacity: 1; }
+  16% { opacity: 0.7; }
+  22% { opacity: 0.9; }
+  34% { opacity: 0.55; }
+}
+
+/* ── 6. AUTO-DIBUJADO orquestado (§13.11) ────────────────────────────────────
+   `pathLength="1"` normalizado + stroke-dashoffset → 0 + etapas escalonadas.
+   El trazo/grafo/glifo se dibuja solo al entrar. (Receta de SceneTrazoMinimal;
+   el componente `AutoDibujo` pega estas clases y pone `pathLength`.) */
+.vfx-draw {
+  stroke-dasharray: 1 1;
+  stroke-dashoffset: 1;
+  animation: vfx-draw 1.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+@keyframes vfx-draw { to { stroke-dashoffset: 0; } }
+
+/* planos de color que aparecen en fundido (sol, leyenda, humo) */
+.vfx-fade { opacity: 0; animation: vfx-fade 1.1s ease forwards; }
+@keyframes vfx-fade { to { opacity: 1; } }
+
+/* etapas del dibujo — delay heredado por trazos y fundidos del grupo */
+.vfx-t1 .vfx-draw, .vfx-t1.vfx-draw, .vfx-t1 .vfx-fade, .vfx-t1.vfx-fade { animation-delay: 0.15s; }
+.vfx-t2 .vfx-draw, .vfx-t2.vfx-draw, .vfx-t2 .vfx-fade, .vfx-t2.vfx-fade { animation-delay: 0.40s; }
+.vfx-t3 .vfx-draw, .vfx-t3.vfx-draw, .vfx-t3 .vfx-fade, .vfx-t3.vfx-fade { animation-delay: 0.70s; }
+.vfx-t4 .vfx-draw, .vfx-t4.vfx-draw, .vfx-t4 .vfx-fade, .vfx-t4.vfx-fade { animation-delay: 0.95s; }
+.vfx-t5 .vfx-draw, .vfx-t5.vfx-draw, .vfx-t5 .vfx-fade, .vfx-t5.vfx-fade { animation-delay: 1.20s; }
+.vfx-t6 .vfx-draw, .vfx-t6.vfx-draw, .vfx-t6 .vfx-fade, .vfx-t6.vfx-fade { animation-delay: 1.50s; }
+.vfx-t7 .vfx-draw, .vfx-t7.vfx-draw, .vfx-t7 .vfx-fade, .vfx-t7.vfx-fade { animation-delay: 1.80s; }
+.vfx-t8 .vfx-draw, .vfx-t8.vfx-draw, .vfx-t8 .vfx-fade, .vfx-t8.vfx-fade { animation-delay: 2.10s; }
+.vfx-t9 .vfx-draw, .vfx-t9.vfx-draw, .vfx-t9 .vfx-fade, .vfx-t9.vfx-fade { animation-delay: 2.50s; }
+
+/* ── 7. FLUJO por dash (§13.12) ──────────────────────────────────────────────
+   Savia/agua/corriente/micelio: dasharray animado que corre por el trazo.
+   `--vfx-flow-dur` y `--vfx-flow-len` tunéan velocidad y avance. */
+.vfx-flow {
+  stroke-dasharray: 4 8;
+  animation: vfx-flow var(--vfx-flow-dur, 3.2s) linear infinite;
+}
+@keyframes vfx-flow { to { stroke-dashoffset: calc(-1 * var(--vfx-flow-len, 40px)); } }
+
+/* ── prefers-reduced-motion: fotograma final digno ───────────────────────────
+   Nada en loop; el dibujo COMPLETO, los planos visibles, velos/grades/viñeta
+   quietos (son estáticos de por sí). Regla de la casa §13.20. */
+@media (prefers-reduced-motion: reduce) {
+  .vfx-beat, .vfx-beat-wave, .vfx-beat-glow, .vfx-flow { animation: none !important; }
+  .vfx-beat, .vfx-beat-glow { opacity: 1; }
+  .vfx-beat-wave { opacity: 0; }              /* la onda no deja residuo */
+  .vfx-draw { animation: none !important; stroke-dashoffset: 0; }
+  .vfx-fade { animation: none !important; opacity: 1; }
+  .vfx-veil { transition: none; }
+}

--- a/src/visual/effects/index.js
+++ b/src/visual/effects/index.js
@@ -1,0 +1,35 @@
+/*
+ * Librería visual de EFECTOS de Chagra (effects) — las TÉCNICAS DE CINE del
+ * catálogo (§13), una sola vez y reutilizables. Antes de re-hilvanar un
+ * velo/viñeta/grade/glow/latido/auto-dibujado/acuarela, use esto.
+ *
+ * Dos piezas:
+ *   1. `effects.css` — clases `vfx-*` + custom properties `--vfx-*`
+ *      (velos, viñeta, scrims, grades por piso térmico, pulso cardíaco,
+ *      auto-dibujado, flujo por dash). Importalo UNA vez donde lo uses:
+ *          import '../../visual/effects/effects.css';
+ *   2. Helpers SVG (este barrel): `GlowFilter`, `FiltroAcuarela`, `AutoDibujo`.
+ *
+ * Reglas de la casa: solo transform/opacity animados; blur/filtros estáticos;
+ * reduced-motion = fotograma final digno; cero dependencias nuevas.
+ */
+export { GlowFilter } from './GlowFilter.jsx';
+export { FiltroAcuarela } from './FiltroAcuarela.jsx';
+export { AutoDibujo } from './AutoDibujo.jsx';
+
+/* Ritmo del latido/respiración compartido (= `--vfx-beat` en effects.css y
+   `--motion-beat`/`--fvo-beat` en el resto del repo). Útil desde JS cuando una
+   escena necesita sincronizar un timing sin leer el CSS. */
+export const VFX_BEAT_MS = 5200;
+
+/* Registro consultable de los pisos térmicos y su grade de luz (§13.2).
+   `token` = la custom property de effects.css; `clase` = la clase modificadora
+   de `.vfx-grade`. Orden de menor a mayor altura invertido: de nevado a río. */
+export const VFX_PISOS = [
+  { slug: 'glacial',  nombre: 'Nevado',   token: '--vfx-piso-glacial',  clase: 'vfx-grade--glacial',  luz: 'azul glacial' },
+  { slug: 'paramo',   nombre: 'Páramo',   token: '--vfx-piso-paramo',   clase: 'vfx-grade--paramo',   luz: 'cian páramo' },
+  { slug: 'frio',     nombre: 'Frío',     token: '--vfx-piso-frio',     clase: 'vfx-grade--frio',     luz: 'neutro frío' },
+  { slug: 'templado', nombre: 'Templado', token: '--vfx-piso-templado', clase: 'vfx-grade--templado', luz: 'hora dorada' },
+  { slug: 'calido',   nombre: 'Cálido',   token: '--vfx-piso-calido',   clase: 'vfx-grade--calido',   luz: 'ámbar cálido' },
+  { slug: 'valle',    nombre: 'Valle/río', token: '--vfx-piso-valle',   clase: 'vfx-grade--valle',    luz: 'turquesa río' },
+];


### PR DESCRIPTION
## Qué

Escala la librería reutilizable de Chagra extrayendo los **efectos visuales**
(las técnicas de cine del catálogo §13) a `src/visual/effects/`, hermana de
`src/visual/creatures/` y con el mismo contrato: utilidades reusables + `index` +
`README` con la regla de la casa, cero dependencias nuevas, reduced-motion-safe.

Hoy estos efectos estaban redibujados/re-copiados por mockup y escena
(`finca-viva-hero.css`, `scene-finca-organismo.css`, `scene-trazo-minimal.css`,
`GuardianEspiritu`, mockups de la Montaña, mapa-acuarela). Ahora hay una versión
canónica.

## Qué se extrajo

**CSS (`effects.css`, clases `vfx-*` + custom properties `--vfx-*`):**
- Velo atmosférico (`.vfx-veil`) + viñeta (`.vfx-vignette`) + scrims (`.vfx-scrim-top/-bottom`).
- Grades de luz por piso térmico (`.vfx-grade` + `.vfx-grade--{glacial,paramo,frio,templado,calido,valle}`, tokens `--vfx-piso-*`, `--vfx-grade-fuerza`) — los `--mm2-*` de Montaña, tokenizados.
- Pulso cardíaco (`--vfx-beat` = 5.2s + `.vfx-beat` / `.vfx-beat-wave` / `.vfx-beat-glow`) — el `--fvo-beat` de SceneFincaOrganismo.
- Auto-dibujado por etapas (`.vfx-draw` / `.vfx-fade` / `.vfx-t1…t9`) + flujo por dash (`.vfx-flow`).

**Helpers SVG:**
- `GlowFilter` — glow feMerge compartido; **unifica** el `ge-glow1` inline y el `creatures/_filters`.
- `FiltroAcuarela` — `feTurbulence` + `feDisplacementMap` (borde húmedo del mapa-acuarela).
- `AutoDibujo` — envuelve la receta `pathLength="1"` + dashoffset + etapa.

`index.js` exporta los helpers + `VFX_BEAT_MS` + `VFX_PISOS`. `README.md` documenta
la regla ("antes de re-dibujar un efecto, búsquelo aquí") y ejemplos de uso.

## Consumidor convertido (prueba)

`dashboard/GuardianEspiritu.jsx`: sus filtros `ge-glow1`/`ge-blur3`, antes inline,
ahora salen de `<GlowFilter id="ge-glow1" std={2.2} blurId="ge-blur3" />`. **Mismo
markup renderizado (id/std/bounds idénticos) → cero regresión visual.** No se migró
nada más (extracción, no refactor masivo).

## Verificación

- `npm run build` (vite) verde.
- `eslint` de los archivos nuevos + consumidor: limpio.
- Sin dependencias nuevas; solo `transform`/`opacity` animados, blur/filtros estáticos; reduced-motion = fotograma final digno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)