### PR TITLE
feat(visual): librería de láminas de cuaderno (src/visual/laminas)

### DIFF
--- a/src/components/TuberculosScreen.jsx
+++ b/src/components/TuberculosScreen.jsx
@@ -9,8 +9,7 @@ import {
   Shovel, Camera, Utensils, ExternalLink,
 } from 'lucide-react';
 import { TUBERCULOS, getTuberculo, tieneDato, DATO_EN_CAMINO, FUENTES_INSTITUCIONALES } from '../services/tuberculosData';
-import LaminaSiembra from './tuberculos/LaminaSiembra';
-import LaminaAporque from './tuberculos/LaminaAporque';
+import { LaminaSiembra, LaminaAporque } from '../visual/laminas';
 
 /**
  * TuberculosScreen — mini-app "Tubérculos y raíces" (mundo Cultivos y semillas).

--- a/src/visual/laminas/LaminaAporque.jsx
+++ b/src/visual/laminas/LaminaAporque.jsx
@@ -14,14 +14,17 @@ import React from 'react';
  * Es DECORATIVA (aria-hidden): ilustra la sección "Aporque" de la ficha; el
  * texto explica el porqué. Trazo redondeado, colores Tailwind sobre
  * currentColor por grupo para respirar con los temas.
+ *
+ * @param {Object} props
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
  */
-export default function LaminaAporque() {
+export default function LaminaAporque({ className } = {}) {
   return (
     <svg
       viewBox="0 0 360 120"
       role="img"
       aria-hidden="true"
-      className="w-full h-auto select-none"
+      className={['w-full h-auto select-none', className].filter(Boolean).join(' ')}
       data-testid="lamina-aporque"
     >
       {/* línea del nivel del suelo original (de referencia) */}

--- a/src/visual/laminas/LaminaCafeto.jsx
+++ b/src/visual/laminas/LaminaCafeto.jsx
@@ -1,0 +1,273 @@
+import React from 'react';
+
+/**
+ * LaminaCafeto — la lámina insignia del mundo "El café".
+ *
+ * SVG propio (nada de stock, nada rasterizado, sin dependencias) al estilo
+ * BOTÁNICO DE CUADERNO DE CAMPO: una "hoja de papel" color crema, con tinta
+ * sepia y verde, que dibuja la mata de café (Coffea arabica) y rotula sus
+ * partes en español campesino —
+ *
+ *   raíz · tallo (tronco) · rama · hoja · flor · cereza (madura / verde)
+ *
+ * y, en un recuadro "por dentro de la cereza", el corte que muestra la pulpa,
+ * el pergamino y el grano (la almendra) — los mismos términos que usa el
+ * mundo del beneficio (despulpado → pulpa; el grano seco = café pergamino;
+ * trillado = almendra).
+ *
+ * A diferencia de las láminas decorativas de Tubérculos, esta LLEVA rótulos
+ * con significado: por eso es role="img" con <title>/<desc> (accesible) en vez
+ * de aria-hidden. Va pensada para abrir la estación "Variedad y siembra" del
+ * mundo del café: la mata entera antes de contar su ciclo.
+ *
+ * Paleta FIJA (papel crema + tinta sepia/verde): es un pliego de cuaderno
+ * prendido dentro del mundo oscuro del café, así que conserva su aire de papel
+ * en todos los temas a propósito. Estática, GPU-nula, sin animación.
+ *
+ * Grounded (Cenicafé / FNC · catálogo species.coffea_arabica):
+ *   - arbusto de la familia Rubiaceae, hojas OPUESTAS, brillantes, acuminadas;
+ *   - flor blanca de 5 pétalos, en racimos (glomérulos) en las axilas;
+ *   - fruto en drupa ("la cereza"): verde -> rojo al madurar;
+ *   - por dentro, casi siempre 2 granos cara a cara, cada uno envuelto en el
+ *     pergamino (endocarpo); alrededor la pulpa (mesocarpo) y la baba (mucílago).
+ *
+ * @param {Object} props
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+
+/** Una hoja de café: elíptica, acuminada, con nervadura. Base en (0,0),
+ *  la punta sale a `len` en el eje X y el grupo se rota con `rot` grados. */
+function Hoja({ x, y, rot = 0, len = 30 }) {
+  const w = len * 0.34;
+  const cuerpo = `M0 0 Q ${0.34 * len} ${-w} ${len} 0 Q ${0.34 * len} ${w} 0 0 Z`;
+  const nervios = [0.32, 0.5, 0.68].flatMap((i) => [
+    `M${i * len} 0 Q ${i * len + 7} ${-w * 0.45} ${i * len + 0.14 * len} ${-w * 0.62}`,
+    `M${i * len} 0 Q ${i * len + 7} ${w * 0.45} ${i * len + 0.14 * len} ${w * 0.62}`,
+  ]);
+  return (
+    <g transform={`translate(${x} ${y}) rotate(${rot})`}>
+      <path d={cuerpo} fill="#5c7a3f" stroke="#39531f" strokeWidth="1.1" strokeLinejoin="round" />
+      {/* medio brillo de la lámina glossy */}
+      <path d={`M0 0 Q ${0.34 * len} ${-w * 0.9} ${len} 0`} fill="none" stroke="#7f9d57" strokeWidth="1.4" strokeLinecap="round" opacity="0.7" />
+      {/* nervadura */}
+      <path d={`M0 0 L ${len} 0`} fill="none" stroke="#39531f" strokeWidth="0.9" strokeLinecap="round" />
+      {nervios.map((d, k) => (
+        <path key={k} d={d} fill="none" stroke="#3f5b25" strokeWidth="0.6" opacity="0.8" />
+      ))}
+    </g>
+  );
+}
+
+/** Un botón de flor a escala de la mata (el detalle grande va en el recuadro). */
+function Flor({ x, y, r = 3.6 }) {
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      {[0, 72, 144, 216, 288].map((a) => (
+        <ellipse key={a} cx="0" cy={-r} rx={r * 0.6} ry={r} transform={`rotate(${a})`} fill="#fbf6e8" stroke="#d7c592" strokeWidth="0.5" />
+      ))}
+      <circle cx="0" cy="0" r={r * 0.42} fill="#e7c24a" />
+    </g>
+  );
+}
+
+/** Una cereza de café (drupa). `verde`=true la pinta sin madurar. */
+function Cereza({ x, y, r = 5, verde = false }) {
+  const relleno = verde ? '#93a84f' : '#b8402f';
+  const borde = verde ? '#6c8236' : '#8f2f22';
+  const brillo = verde ? '#c3d488' : '#e29079';
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <circle cx="0" cy="0" r={r} fill={relleno} stroke={borde} strokeWidth="0.9" />
+      <ellipse cx={-r * 0.34} cy={-r * 0.36} rx={r * 0.34} ry={r * 0.24} fill={brillo} opacity="0.85" />
+      {/* corona / ombligo del cáliz */}
+      <circle cx="0" cy={-r * 0.92} r="0.9" fill={borde} />
+    </g>
+  );
+}
+
+/** Rótulo con guía: una línea fina sepia con puntico en la parte señalada. */
+function Rotulo({ tx, ty, anchor = 'start', texto, nota, guia }) {
+  return (
+    <g>
+      {guia && <path d={guia.d} fill="none" stroke="#9a8355" strokeWidth="0.9" />}
+      {guia && <circle cx={guia.px} cy={guia.py} r="1.6" fill="#7a6540" />}
+      <text x={tx} y={ty} textAnchor={anchor} fontSize="11" fontWeight="700" fill="#4f3a20" letterSpacing="0.02em">
+        {texto}
+      </text>
+      {nota && (
+        <text x={tx} y={ty + 11} textAnchor={anchor} fontSize="8.5" fontStyle="italic" fill="#8a7350">
+          {nota}
+        </text>
+      )}
+    </g>
+  );
+}
+
+export default function LaminaCafeto({ className } = {}) {
+  return (
+    <svg
+      viewBox="0 0 420 300"
+      role="img"
+      aria-labelledby="lamcaf-t lamcaf-d"
+      className={['w-full h-auto select-none', className].filter(Boolean).join(' ')}
+      data-testid="lamina-cafeto"
+      style={{ fontFamily: 'ui-sans-serif, system-ui, sans-serif' }}
+    >
+      <title id="lamcaf-t">La mata de café (Coffea arabica) con sus partes rotuladas</title>
+      <desc id="lamcaf-d">
+        Lámina de cuaderno de campo: un cafeto dibujado a mano en tinta sepia y verde con la raíz,
+        el tallo o tronco, las ramas, las hojas opuestas y brillantes, la flor blanca de cinco pétalos
+        y las cerezas verdes y maduras. Un recuadro muestra el corte de la cereza por dentro: la pulpa,
+        el pergamino y el grano o almendra.
+      </desc>
+
+      {/* -- el pliego de papel del cuaderno -- */}
+      <rect x="2" y="2" width="416" height="296" rx="10" fill="#f4ead2" stroke="#d8c39a" strokeWidth="2" />
+      <rect x="8" y="8" width="404" height="284" rx="7" fill="none" stroke="#e0d0a8" strokeWidth="1" />
+      {/* esquina doblada (abajo-derecha) */}
+      <path d="M412 274 L392 292 L412 292 Z" fill="#e6d6ae" stroke="#d0bb8a" strokeWidth="0.8" />
+
+      {/* -- encabezado -- */}
+      <text x="16" y="24" fontSize="17" fontWeight="800" fill="#3f2d17">El cafeto</text>
+      <text x="97" y="24" fontSize="12.5" fontStyle="italic" fill="#6b4f2f" style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}>
+        Coffea arabica
+      </text>
+      <text x="404" y="16" textAnchor="end" fontSize="9" fontStyle="italic" fill="#9a8355">cuaderno de campo</text>
+      <text x="404" y="27" textAnchor="end" fontSize="9" fill="#8a7350">Fam. Rubiaceae</text>
+      <line x1="14" y1="32" x2="406" y2="32" stroke="#d8c39a" strokeWidth="1" />
+
+      {/* -----------------  LA MATA  ----------------- */}
+
+      {/* línea del suelo */}
+      <line x1="56" y1="234" x2="248" y2="234" stroke="#9a8355" strokeWidth="1.3" strokeDasharray="5 4" strokeLinecap="round" />
+
+      {/* raíz: pivotante + raicillas, bajo el suelo */}
+      <g stroke="#7a5836" fill="none" strokeLinecap="round">
+        <path d="M150 234 C 151 252 149 266 150 288" strokeWidth="3.4" />
+        <path d="M150 240 C 138 246 130 256 120 264" strokeWidth="2" />
+        <path d="M150 244 C 162 250 172 258 182 266" strokeWidth="2" />
+        <path d="M150 236 C 140 240 132 244 124 250" strokeWidth="1.5" />
+        <path d="M150 238 C 160 242 168 246 176 252" strokeWidth="1.5" />
+        <path d="M120 264 c -4 3 -6 5 -7 9 M182 266 c 4 3 6 5 7 9 M150 288 c -3 3 -4 5 -4 8" strokeWidth="1.1" />
+      </g>
+
+      {/* tallo / tronco leñoso */}
+      <path d="M150 234 C 149 190 152 150 149 110 C 148 96 147 86 146 78" fill="none" stroke="#6b4a2a" strokeWidth="6" strokeLinecap="round" />
+      <path d="M150 232 C 149 190 152 150 149 112 C 148 98 147 88 146 80" fill="none" stroke="#835d34" strokeWidth="2" strokeLinecap="round" opacity="0.7" />
+
+      {/* ramas plagiotrópicas (3 pisos) */}
+      <g fill="none" stroke="#6b4a2a" strokeWidth="3" strokeLinecap="round">
+        <path d="M148 104 C 120 100 100 96 86 92" />
+        <path d="M148 102 C 176 100 196 98 210 96" />
+        <path d="M149 150 C 118 148 96 152 82 158" />
+        <path d="M149 148 C 180 148 200 152 214 158" />
+        <path d="M150 194 C 116 194 96 200 84 208" />
+        <path d="M150 192 C 182 194 202 200 214 208" />
+      </g>
+
+      {/* hojas opuestas, brillantes */}
+      <Hoja x={146} y={78} rot={248} len={22} />
+      <Hoja x={146} y={78} rot={292} len={22} />
+      <Hoja x={104} y={96} rot={202} len={30} />
+      <Hoja x={112} y={90} rot={150} len={25} />
+      <Hoja x={86} y={92} rot={186} len={28} />
+      <Hoja x={100} y={152} rot={206} len={30} />
+      <Hoja x={86} y={158} rot={185} len={27} />
+      <Hoja x={102} y={200} rot={210} len={30} />
+      <Hoja x={86} y={208} rot={190} len={26} />
+      <Hoja x={204} y={152} rot={346} len={27} />
+      <Hoja x={208} y={202} rot={350} len={27} />
+      <Hoja x={206} y={96} rot={16} len={22} />
+
+      {/* flores en racimo (rama alta derecha) */}
+      <Flor x={170} y={102} />
+      <Flor x={182} y={99} />
+      <Flor x={194} y={98} />
+      <Flor x={205} y={97} />
+      <Flor x={200} y={105} />
+
+      {/* cerezas (rama media y baja derecha): maduras rojas + un par verdes */}
+      <Cereza x={186} y={150} />
+      <Cereza x={194} y={146} />
+      <Cereza x={202} y={153} verde />
+      <Cereza x={210} y={158} />
+      <Cereza x={176} y={155} verde />
+      <Cereza x={188} y={196} />
+      <Cereza x={199} y={201} />
+      <Cereza x={209} y={206} />
+
+      {/* -- conector: el detalle de la flor "es" esa flor de la mata -- */}
+      <path d="M322 60 C 288 74 250 88 210 96" fill="none" stroke="#b9a06a" strokeWidth="0.8" strokeDasharray="3 3" opacity="0.8" />
+
+      {/* -- rótulos de la mata -- */}
+      <Rotulo texto="hoja" nota="opuestas, brillantes" tx="12" ty="150"
+        guia={{ d: 'M40 150 C 60 150 78 152 92 152', px: 92, py: 152 }} />
+      <Rotulo texto="rama" tx="12" ty="196"
+        guia={{ d: 'M40 196 C 62 196 78 198 96 199', px: 96, py: 199 }} />
+      <Rotulo texto="tallo" nota="(tronco)" tx="12" ty="248"
+        guia={{ d: 'M40 246 C 80 244 116 224 148 210', px: 148, py: 210 }} />
+      <Rotulo texto="raíz" nota="pivotante + raicillas" tx="12" ty="278"
+        guia={{ d: 'M40 276 C 80 278 112 274 149 268', px: 149, py: 268 }} />
+
+      <Rotulo anchor="end" texto="cereza madura" nota="roja, lista pa' coger" tx="280" ty="140"
+        guia={{ d: 'M232 140 C 222 142 216 146 210 152', px: 210, py: 152 }} />
+      <Rotulo anchor="end" texto="cereza verde" nota="todavía biche" tx="280" ty="182"
+        guia={{ d: 'M232 176 C 222 168 214 160 204 154', px: 204, py: 154 }} />
+
+      {/* -----------  DETALLE 1 . la flor  ----------- */}
+      <circle cx="348" cy="60" r="27" fill="#faf3e0" stroke="#c9b483" strokeWidth="1.2" />
+      <g transform="translate(348 60)">
+        {[0, 72, 144, 216, 288].map((a) => (
+          <ellipse key={a} cx="0" cy="-15" rx="6.5" ry="15" transform={`rotate(${a})`} fill="#fbf7ec" stroke="#d7c592" strokeWidth="0.8" />
+        ))}
+        <circle cx="0" cy="0" r="6" fill="#eaca57" />
+        {[30, 100, 170, 240, 310].map((a) => (
+          <circle key={a} cx={5 * Math.cos((a * Math.PI) / 180)} cy={5 * Math.sin((a * Math.PI) / 180)} r="1.1" fill="#b98d2f" />
+        ))}
+      </g>
+      <text x="348" y="100" textAnchor="middle" fontSize="11" fontWeight="700" fill="#4f3a20">flor</text>
+      <text x="348" y="110" textAnchor="middle" fontSize="8.5" fontStyle="italic" fill="#8a7350">blanca · 5 pétalos · huele dulce</text>
+
+      {/* -----------  DETALLE 2 . por dentro de la cereza  ----------- */}
+      <rect x="286" y="118" width="124" height="170" rx="8" fill="#efe3c6" stroke="#d5c193" strokeWidth="1" />
+      <text x="348" y="134" textAnchor="middle" fontSize="10" fontWeight="800" fill="#5a3f22" letterSpacing="0.04em">POR DENTRO DE LA CEREZA</text>
+
+      {/* corte de la cereza: pulpa -> pergamino -> grano */}
+      <g transform="translate(340 205)">
+        {/* pulpa (piel + mesocarpo) */}
+        <circle cx="0" cy="0" r="40" fill="#bb4130" stroke="#8f2f22" strokeWidth="1.4" />
+        <circle cx="0" cy="0" r="40" fill="none" stroke="#e08a79" strokeWidth="1" opacity="0.5" />
+        {/* baba / mucílago: aro traslúcido */}
+        <circle cx="0" cy="0" r="33" fill="#e7b48f" opacity="0.55" />
+        {/* pergamino que envuelve los dos granos */}
+        <circle cx="0" cy="0" r="30" fill="#eaddba" stroke="#cbb684" strokeWidth="1.1" />
+        {/* dos granos cara a cara (almendra) */}
+        <path d="M-2 -28 A 28 28 0 0 0 -2 28 Q -14 0 -2 -28 Z" fill="#cdb98a" stroke="#a08a5b" strokeWidth="1" />
+        <path d="M2 -28 A 28 28 0 0 1 2 28 Q 14 0 2 -28 Z" fill="#c8b482" stroke="#a08a5b" strokeWidth="1" />
+        {/* surco central de cada grano */}
+        <path d="M-2 -22 Q -12 0 -2 22" fill="none" stroke="#9c855a" strokeWidth="1" />
+        <path d="M2 -22 Q 12 0 2 22" fill="none" stroke="#9c855a" strokeWidth="1" />
+      </g>
+
+      {/* rótulos del corte */}
+      <g stroke="#9a8355" strokeWidth="0.8" fill="none">
+        <path d="M300 158 C 308 168 314 174 322 182" />
+        <path d="M398 200 C 384 202 376 204 370 205" />
+        <path d="M340 262 L340 240" />
+      </g>
+      <circle cx="322" cy="182" r="1.5" fill="#7a6540" />
+      <circle cx="370" cy="205" r="1.5" fill="#7a6540" />
+      <circle cx="340" cy="240" r="1.5" fill="#7a6540" />
+      <text x="298" y="156" textAnchor="end" fontSize="9.5" fontWeight="700" fill="#7a2c1e">pulpa</text>
+      <text x="298" y="166" textAnchor="end" fontSize="8" fontStyle="italic" fill="#8a7350">&#8594; abono</text>
+      <text x="400" y="203" fontSize="9.5" fontWeight="700" fill="#8a6a2f">pergamino</text>
+      <text x="400" y="213" fontSize="8" fontStyle="italic" fill="#8a7350">se seca así</text>
+      <text x="340" y="277" textAnchor="middle" fontSize="9.5" fontWeight="700" fill="#6a5424">grano · almendra</text>
+
+      {/* firma de pie */}
+      <text x="16" y="288" fontSize="8.5" fontStyle="italic" fill="#9a8355">
+        Cenicafé / FNC · arbusto de sombrío, 2-3 m
+      </text>
+    </svg>
+  );
+}

--- a/src/visual/laminas/LaminaMaiz.jsx
+++ b/src/visual/laminas/LaminaMaiz.jsx
@@ -1,0 +1,332 @@
+import React, { useId } from 'react';
+
+/**
+ * LaminaMaiz — lámina de "cuaderno de campo" del mundo de la milpa: la mata de
+ * maíz (Zea mays) dibujada a mano, tinta sepia y verde sobre papel crema, con
+ * cada parte rotulada en habla campesina.
+ *
+ * Misma familia que tuberculos/LaminaSiembra: SVG 100% propio e inline (sin
+ * imágenes rasterizadas ni dependencias), pensado para acompañar el relato del
+ * mundo. A diferencia de LaminaSiembra (decorativa, aria-hidden), esta lámina
+ * SÍ enseña: lleva role="img" con descripción y sus rótulos son parte del
+ * contenido, así que el papel es de color fijo (crema), como una foto de una
+ * página de cuaderno pegada en la pantalla — no reacciona al tema, igual que el
+ * DiagramaMilpa de esta misma pantalla usa colores propios.
+ *
+ * Partes rotuladas (botánica correcta, nombre popular):
+ *   · Penacho / espiga — la flor macho, arriba de todo.
+ *   · Caña (tallo) con sus nudos.
+ *   · Hoja: lámina + vaina (con venas paralelas, propias de las gramíneas).
+ *   · Mazorca — la flor hembra, con sus barbas (el cabello) y los granos en hilera.
+ *   · Raíz fasciculada (en cabellera) + raíces de sostén (de soporte).
+ *   · Detalle ampliado del grano: pericarpio, endospermo y germen.
+ *
+ * Los ids de <defs> (papel, clip de la mazorca) se generan con useId para que
+ * la lámina se pueda repetir varias veces en una misma página sin colisión.
+ *
+ * @param {Object} props
+ * @param {string} [props.className] clases extra sobre el <figure> raíz.
+ */
+
+/* Paleta de la lámina: tinta sepia + verde botánico sobre papel crema.
+   Colores fijos a propósito (es una ilustración, no cromo de UI). */
+const TINTA = '#5c4326'; // sepia principal (trazo y rótulos)
+const TINTA_2 = '#8a6b40'; // sepia claro (rótulos secundarios, guías)
+const VERDE = '#6f8a3c'; // verde hoja
+const VERDE_OSC = '#55702c'; // verde de contornos/venas
+const GRANO = '#d8a93f'; // oro del grano
+const GRANO_OSC = '#b0822a'; // contorno del grano
+const BARBA = '#c98a56'; // barbas / cabello de la mazorca
+const TIERRA = '#7a5a34'; // suelo
+
+/** Un rótulo del cuaderno: línea guía fina con punto en el objetivo + texto
+ *  serif en itálica (letra de mano). `anchor` alinea el texto al margen. */
+function Rotulo({ x, y, tx, ty, texto, sub = null, anchor = 'start' }) {
+  return (
+    <g>
+      <line x1={x} y1={y} x2={tx} y2={ty} stroke={TINTA_2} strokeWidth="0.9" strokeLinecap="round" />
+      <circle cx={tx} cy={ty} r="1.7" fill={TINTA} />
+      <text
+        x={x}
+        y={y}
+        textAnchor={anchor}
+        fontFamily="'Georgia', 'Times New Roman', serif"
+        fontStyle="italic"
+        fontSize="13"
+        fontWeight="600"
+        fill={TINTA}
+      >
+        {texto}
+      </text>
+      {sub && (
+        <text
+          x={x}
+          y={y + 13}
+          textAnchor={anchor}
+          fontFamily="'Georgia', 'Times New Roman', serif"
+          fontStyle="italic"
+          fontSize="10.5"
+          fill={TINTA_2}
+        >
+          {sub}
+        </text>
+      )}
+    </g>
+  );
+}
+
+export default function LaminaMaiz({ className } = {}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const papelId = `lm-papel-${uid}`;
+  const mazorcaId = `lm-mazorca-${uid}`;
+  return (
+    <figure
+      className={['lamina-maiz relative rounded-2xl overflow-hidden border border-amber-900/30 shadow-md shadow-black/30', className].filter(Boolean).join(' ')}
+      data-testid="lamina-maiz"
+    >
+      <svg
+        viewBox="0 0 420 748"
+        className="w-full h-auto select-none"
+        role="img"
+        aria-labelledby="lamina-maiz-titulo lamina-maiz-desc"
+      >
+        <title id="lamina-maiz-titulo">Lámina de cuaderno: la mata de maíz (Zea mays) y sus partes</title>
+        <desc id="lamina-maiz-desc">
+          Dibujo botánico a mano en tinta sepia y verde sobre papel crema. Muestra la
+          planta de maíz completa con el penacho o flor macho arriba, la caña con sus
+          nudos, las hojas con lámina y vaina, la mazorca con sus barbas y los granos en
+          hilera, y las raíces fasciculadas y de sostén. Abajo, un detalle ampliado del
+          grano con su pericarpio, endospermo y germen.
+        </desc>
+
+        {/* ── Papel crema del cuaderno ─────────────────────────────────── */}
+        <defs>
+          <linearGradient id={papelId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#f6eed6" />
+            <stop offset="1" stopColor="#efe4c6" />
+          </linearGradient>
+        </defs>
+        <rect x="0" y="0" width="420" height="748" fill={`url(#${papelId})`} />
+        {/* marco interior tenue + margen del cuaderno (línea a la izquierda) */}
+        <rect x="8" y="8" width="404" height="732" fill="none" stroke={TINTA_2} strokeWidth="0.7" opacity="0.4" rx="6" />
+        <line x1="34" y1="8" x2="34" y2="740" stroke="#b98a72" strokeWidth="0.8" opacity="0.35" />
+        {/* pecas del papel (grano hecho a mano, determinista) */}
+        <g fill={TINTA_2} opacity="0.10">
+          <circle cx="70" cy="120" r="1.1" /><circle cx="360" cy="90" r="1" />
+          <circle cx="300" cy="250" r="1.2" /><circle cx="95" cy="360" r="1" />
+          <circle cx="380" cy="430" r="1.1" /><circle cx="55" cy="520" r="1" />
+          <circle cx="330" cy="560" r="1.2" /><circle cx="150" cy="640" r="1" />
+        </g>
+
+        {/* ── Encabezado: nombre científico como en el herbario ────────── */}
+        <text x="46" y="30" fontFamily="'Georgia', serif" fontSize="11" fontStyle="italic" letterSpacing="1.5" fill={TINTA_2}>
+          CUADERNO DE CAMPO · LA MILPA
+        </text>
+        <text x="46" y="52" fontFamily="'Georgia', serif" fontSize="22" fontStyle="italic" fontWeight="700" fill={TINTA}>
+          Zea mays
+        </text>
+        <text x="150" y="52" fontFamily="'Georgia', serif" fontSize="12" fill={TINTA_2}>L. — el maíz</text>
+        <text x="46" y="68" fontFamily="'Georgia', serif" fontSize="11.5" fontStyle="italic" fill={TINTA_2}>
+          Familia Poaceae (las gramíneas)
+        </text>
+
+        {/* ════════════ LA MATA ════════════ (caña centrada en x≈196) ══ */}
+
+        {/* Suelo con rayado bajo la línea de tierra */}
+        <line x1="60" y1="470" x2="332" y2="470" stroke={TIERRA} strokeWidth="1.6" strokeLinecap="round" />
+        <g stroke={TIERRA} strokeWidth="0.8" strokeLinecap="round" opacity="0.55">
+          <line x1="80" y1="474" x2="72" y2="484" /><line x1="110" y1="474" x2="102" y2="484" />
+          <line x1="150" y1="474" x2="142" y2="484" /><line x1="240" y1="474" x2="232" y2="484" />
+          <line x1="285" y1="474" x2="277" y2="484" /><line x1="315" y1="474" x2="307" y2="484" />
+        </g>
+
+        {/* ── RAÍCES ──────────────────────────────────────────────────── */}
+        {/* Fasciculada: cabellera de raicillas finas bajo la base */}
+        <g stroke={TINTA} strokeWidth="1" fill="none" strokeLinecap="round" opacity="0.9">
+          <path d="M196 470 q -6 22 -22 40" /><path d="M196 470 q -3 26 -12 46" />
+          <path d="M196 470 q 0 28 -2 50" /><path d="M196 470 q 3 27 8 47" />
+          <path d="M196 470 q 6 24 20 42" /><path d="M196 470 q 9 20 26 34" />
+          <path d="M196 470 q -9 20 -30 32" />
+          {/* raicillas de segundo orden */}
+          <path d="M180 500 q -6 6 -8 14" /><path d="M186 508 q 2 6 -2 12" />
+          <path d="M204 506 q 6 5 8 13" /><path d="M212 496 q 8 4 12 10" />
+        </g>
+
+        {/* De sostén (soporte): arcos gruesos que salen del nudo bajo y se
+            clavan en el suelo, como zancos */}
+        <g stroke={TINTA} strokeWidth="2.6" fill="none" strokeLinecap="round">
+          <path d="M190 442 C 170 452, 158 462, 150 476" />
+          <path d="M202 442 C 224 452, 236 462, 246 476" />
+          <path d="M193 450 C 182 460, 176 468, 172 478" opacity="0.85" />
+        </g>
+
+        {/* ── CAÑA (tallo) con nudos ───────────────────────────────────── */}
+        <path
+          d="M196 470 C 194 400, 199 320, 197 230 C 196 175, 198 152, 196 136"
+          fill="none"
+          stroke={VERDE_OSC}
+          strokeWidth="6.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M196 470 C 194 400, 199 320, 197 230 C 196 175, 198 152, 196 136"
+          fill="none"
+          stroke={VERDE}
+          strokeWidth="3.6"
+          strokeLinecap="round"
+        />
+        {/* nudos: anillos del tallo */}
+        <g stroke={TINTA} strokeWidth="1.5" strokeLinecap="round">
+          {[440, 392, 336, 288, 232, 180, 154].map((yy, i) => (
+            <line key={i} x1={190} y1={yy} x2={203} y2={yy} />
+          ))}
+        </g>
+
+        {/* ── HOJAS (lámina + vaina, venas paralelas) ──────────────────── */}
+        {/* Hoja 1 · abajo-izquierda */}
+        <g>
+          <path d="M196 392 C 150 386, 108 396, 70 430 C 110 402, 156 398, 196 400 Z" fill={VERDE} opacity="0.28" stroke={VERDE_OSC} strokeWidth="1.3" strokeLinejoin="round" />
+          <path d="M194 396 C 156 396, 116 404, 78 428" fill="none" stroke={VERDE_OSC} strokeWidth="1" opacity="0.7" />
+          <g stroke={VERDE_OSC} strokeWidth="0.6" opacity="0.5" fill="none">
+            <path d="M190 392 C 156 390, 120 398, 84 424" /><path d="M190 400 C 156 402, 122 410, 88 432" />
+          </g>
+          {/* vaina que abraza la caña */}
+          <path d="M196 402 q -10 -6 -8 -18 q 6 8 12 8 Z" fill={VERDE} opacity="0.4" stroke={VERDE_OSC} strokeWidth="1" />
+        </g>
+        {/* Hoja 2 · media-derecha (larga, arqueada) */}
+        <g>
+          <path d="M198 336 C 250 326, 300 332, 344 300 C 300 342, 248 348, 198 344 Z" fill={VERDE} opacity="0.3" stroke={VERDE_OSC} strokeWidth="1.3" strokeLinejoin="round" />
+          <path d="M200 340 C 250 338, 298 340, 340 304" fill="none" stroke={VERDE_OSC} strokeWidth="1" opacity="0.7" />
+          <g stroke={VERDE_OSC} strokeWidth="0.6" opacity="0.5" fill="none">
+            <path d="M202 336 C 250 330, 300 334, 338 300" /><path d="M202 344 C 250 344, 296 346, 336 310" />
+          </g>
+          <path d="M197 342 q 10 -6 8 -18 q -6 8 -12 8 Z" fill={VERDE} opacity="0.4" stroke={VERDE_OSC} strokeWidth="1" />
+        </g>
+        {/* Hoja 3 · media-izquierda */}
+        <g>
+          <path d="M196 268 C 150 256, 104 258, 62 224 C 104 266, 152 272, 196 276 Z" fill={VERDE} opacity="0.3" stroke={VERDE_OSC} strokeWidth="1.3" strokeLinejoin="round" />
+          <path d="M194 272 C 150 268, 106 266, 66 228" fill="none" stroke={VERDE_OSC} strokeWidth="1" opacity="0.7" />
+          <g stroke={VERDE_OSC} strokeWidth="0.6" opacity="0.5" fill="none">
+            <path d="M192 268 C 150 260, 108 258, 70 226" /><path d="M192 276 C 150 274, 110 272, 72 240" />
+          </g>
+          <path d="M195 274 q -10 -6 -8 -18 q 6 8 12 8 Z" fill={VERDE} opacity="0.4" stroke={VERDE_OSC} strokeWidth="1" />
+        </g>
+        {/* Hoja 4 · alta-derecha */}
+        <g>
+          <path d="M198 200 C 244 186, 286 184, 322 150 C 286 194, 244 200, 198 206 Z" fill={VERDE} opacity="0.3" stroke={VERDE_OSC} strokeWidth="1.3" strokeLinejoin="round" />
+          <path d="M200 204 C 244 196, 284 192, 318 154" fill="none" stroke={VERDE_OSC} strokeWidth="1" opacity="0.7" />
+          <path d="M197 205 q 10 -6 8 -18 q -6 8 -12 8 Z" fill={VERDE} opacity="0.4" stroke={VERDE_OSC} strokeWidth="1" />
+        </g>
+
+        {/* ── MAZORCA (flor hembra) al nudo medio, con barbas y granos ──── */}
+        <g>
+          {/* barbas / cabello: hilos finos que brotan de la punta */}
+          <g stroke={BARBA} strokeWidth="1" fill="none" strokeLinecap="round" opacity="0.9">
+            <path d="M250 300 q 10 -18 4 -36" /><path d="M256 302 q 16 -16 16 -36" />
+            <path d="M244 300 q 2 -20 -6 -38" /><path d="M260 304 q 22 -12 30 -30" />
+            <path d="M248 300 q 8 -22 2 -42" /><path d="M254 300 q 14 -20 10 -40" />
+          </g>
+          {/* mazorca: envuelta en hojas (capacho) y punta con granos a la vista */}
+          <path d="M232 366 C 224 340, 232 312, 250 300 C 268 312, 276 340, 268 366 C 258 376, 242 376, 232 366 Z" fill={VERDE} opacity="0.5" stroke={VERDE_OSC} strokeWidth="1.4" strokeLinejoin="round" />
+          {/* hojas del capacho abiertas dejando ver el grano */}
+          <path d="M250 300 C 240 316, 240 344, 246 366" fill="none" stroke={VERDE_OSC} strokeWidth="0.9" opacity="0.7" />
+          <path d="M250 300 C 260 316, 260 344, 254 366" fill="none" stroke={VERDE_OSC} strokeWidth="0.9" opacity="0.7" />
+          {/* granos en hilera (rejilla oro) en la parte baja destapada */}
+          <clipPath id={mazorcaId}>
+            <path d="M236 344 C 236 356, 244 372, 250 372 C 256 372, 264 356, 264 344 Z" />
+          </clipPath>
+          <g clipPath={`url(#${mazorcaId})`}>
+            <rect x="234" y="342" width="32" height="34" fill={GRANO} opacity="0.9" />
+            <g stroke={GRANO_OSC} strokeWidth="0.8">
+              <line x1="242" y1="342" x2="242" y2="376" /><line x1="250" y1="342" x2="250" y2="376" /><line x1="258" y1="342" x2="258" y2="376" />
+              <line x1="234" y1="350" x2="266" y2="350" /><line x1="234" y1="358" x2="266" y2="358" /><line x1="234" y1="366" x2="266" y2="366" />
+            </g>
+          </g>
+          <path d="M236 344 C 236 356, 244 372, 250 372 C 256 372, 264 356, 264 344" fill="none" stroke={GRANO_OSC} strokeWidth="1.1" />
+          {/* pedúnculo que la une al nudo de la caña */}
+          <path d="M232 360 C 222 356, 210 350, 200 344" fill="none" stroke={VERDE_OSC} strokeWidth="2.4" strokeLinecap="round" />
+        </g>
+
+        {/* ── PENACHO / espiga (flor macho) en la punta ────────────────── */}
+        <g stroke={TINTA} fill="none" strokeLinecap="round">
+          {/* raquis central */}
+          <path d="M196 136 C 197 122, 195 110, 196 98" strokeWidth="2" />
+          {/* ramas de la espiga, colgando */}
+          <g strokeWidth="1.2" opacity="0.9">
+            <path d="M196 130 C 184 122, 176 114, 172 102" /><path d="M196 126 C 208 118, 216 110, 222 100" />
+            <path d="M196 118 C 186 110, 180 102, 178 92" /><path d="M196 116 C 206 108, 212 100, 216 90" />
+            <path d="M196 106 C 190 98, 187 92, 188 84" /><path d="M196 104 C 202 96, 206 90, 208 82" />
+            <path d="M196 98 C 194 90, 195 86, 196 80" />
+          </g>
+          {/* anteras: puntitos de polen colgando de las ramas */}
+          <g fill={GRANO} stroke="none">
+            <circle cx="172" cy="102" r="1.5" /><circle cx="222" cy="100" r="1.5" /><circle cx="178" cy="92" r="1.5" />
+            <circle cx="216" cy="90" r="1.5" /><circle cx="188" cy="84" r="1.5" /><circle cx="208" cy="82" r="1.5" /><circle cx="196" cy="80" r="1.5" />
+          </g>
+        </g>
+
+        {/* ════════════ RÓTULOS de la mata ════════════ */}
+        {/* Izquierda (texto al margen, guía hacia la planta) */}
+        <Rotulo x="46" y="150" tx="182" ty="110" texto="Penacho" sub="la flor macho (espiga)" anchor="start" />
+        <Rotulo x="46" y="238" tx="120" ty="264" texto="Hoja" sub="lámina + vaina" anchor="start" />
+        <Rotulo x="46" y="360" tx="196" ty="336" texto="Caña (tallo)" sub="con sus nudos" anchor="start" />
+        <Rotulo x="46" y="452" tx="168" ty="458" texto="Raíces de sostén" sub="(de soporte)" anchor="start" />
+
+        {/* Derecha (texto al margen derecho) */}
+        <Rotulo x="378" y="256" tx="286" ty="266" texto="Barbas / cabello" sub="la flor hembra" anchor="end" />
+        <Rotulo x="378" y="326" tx="270" ty="330" texto="Mazorca" anchor="end" />
+        <Rotulo x="378" y="392" tx="256" ty="360" texto="Granos" sub="en hilera" anchor="end" />
+
+        {/* Raíz fasciculada: rótulo abajo, centrado */}
+        <Rotulo x="120" y="560" tx="182" ty="512" texto="Raíz fasciculada" sub="(en cabellera)" anchor="start" />
+
+        {/* ════════════ DETALLE: EL GRANO POR DENTRO ════════════ */}
+        <line x1="34" y1="590" x2="412" y2="590" stroke={TINTA_2} strokeWidth="0.7" opacity="0.4" strokeDasharray="3 3" />
+        <text x="46" y="612" fontFamily="'Georgia', serif" fontSize="14" fontStyle="italic" fontWeight="700" fill={TINTA}>
+          El grano por dentro
+        </text>
+        <text x="215" y="612" fontFamily="'Georgia', serif" fontSize="11" fontStyle="italic" fill={TINTA_2}>(ampliado)</text>
+
+        {/* grano ampliado, corte a lo largo (forma de diente) */}
+        <g>
+          {/* contorno del grano */}
+          <path
+            d="M96 632 C 118 628, 138 640, 138 668 C 138 682, 122 690, 104 690 C 86 690, 74 680, 74 662 C 74 646, 82 636, 96 632 Z"
+            fill={GRANO}
+            opacity="0.35"
+            stroke={GRANO_OSC}
+            strokeWidth="1.6"
+            strokeLinejoin="round"
+          />
+          {/* pericarpio: banda exterior delgada */}
+          <path
+            d="M96 632 C 118 628, 138 640, 138 668 C 138 682, 122 690, 104 690 C 86 690, 74 680, 74 662 C 74 646, 82 636, 96 632 Z"
+            fill="none"
+            stroke={TINTA}
+            strokeWidth="2.4"
+            strokeLinejoin="round"
+            opacity="0.75"
+          />
+          {/* endospermo: gran cuerpo harinoso */}
+          <path d="M100 640 C 120 638, 130 650, 130 666 C 130 678, 116 684, 104 683 C 92 682, 84 672, 86 658 C 88 648, 92 642, 100 640 Z" fill={GRANO} opacity="0.55" stroke={GRANO_OSC} strokeWidth="0.8" />
+          {/* germen: el embrión, en forma de escudo hacia la base */}
+          <path d="M104 654 C 96 654, 90 662, 92 672 C 94 682, 104 684, 110 680 C 108 672, 108 662, 104 654 Z" fill="#e9d9a6" stroke={VERDE_OSC} strokeWidth="1" />
+          {/* eje raíz-tallito dentro del germen */}
+          <path d="M101 660 C 99 666, 100 672, 103 677" fill="none" stroke={VERDE_OSC} strokeWidth="1" strokeLinecap="round" />
+        </g>
+
+        {/* rótulos del grano */}
+        <Rotulo x="200" y="636" tx="136" ty="646" texto="Pericarpio" sub="(la cáscara)" anchor="start" />
+        <Rotulo x="200" y="672" tx="128" ty="662" texto="Endospermo" sub="(la harina)" anchor="start" />
+        <Rotulo x="200" y="696" tx="106" ty="672" texto="Germen" sub="(de aquí nace la mata)" anchor="start" />
+      </svg>
+
+      <figcaption className="lamina-maiz-pie flex items-center justify-between gap-2 bg-[#e7dab8] px-3 py-1.5 text-[11px] font-semibold text-[#5c4326]">
+        <span className="italic">Zea mays · lámina de cuaderno de campo</span>
+        <span className="rounded bg-[#d8c79a] px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-[#6b4e2e]">
+          Ilustración
+        </span>
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/visual/laminas/LaminaMataEtapa.jsx
+++ b/src/visual/laminas/LaminaMataEtapa.jsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import './laminas.css';
+
+/**
+ * LaminaMataEtapa — la lámina VIVA de una mata individual.
+ *
+ * Misma familia que `LaminaSiembra`/`LaminaAporque` (cuaderno de campo: corte de
+ * suelo, trazo redondo, formas simples, colores de tinta sobre papel) pero aquí
+ * el dibujo NO es fijo: cambia según la ETAPA real de la mata. Cada etapa se
+ * compone distinta —
+ *
+ *   semilla    la semilla enterrada, con su radícula asomando          (bajo tierra)
+ *   plántula   el tallito que rompe el suelo: dos cotiledones + 1 hoja  (recién nacida)
+ *   juvenil    la mata que crece: varias hojas, sin flor                (creciendo)
+ *   adulta     la mata hecha, con su tutor y raíz honda                 (robusta)
+ *   floración  la misma mata, ahora con racimos de flor amarilla        (florece)
+ *   cosecha    los racimos cargados de tomate maduro colgando           (da fruto)
+ *
+ * Es DECORATIVA (aria-hidden): la ficha de al lado narra el estado real. El
+ * dibujo respira con las etapas — la raíz se hace honda, el tallo sube, la copa
+ * se llena — para que se LEA la evolución sin leer una palabra. Sin dependencia
+ * de las variables --c-* del tema: es una hoja de papel pegada encima, legible
+ * al sol sobre los cuatro temas. rsvg-safe (sin <text>, sin emoji-en-SVG).
+ *
+ * El ancho/alto de la lámina y la animación de crecimiento al cambiar de etapa
+ * viven en `laminas.css` (clases `lam-mata-svg` / `lam-mata-brota`), y son
+ * reduced-motion-safe (sin animación → fotograma final digno).
+ *
+ * @param {Object} props
+ * @param {'semilla'|'plantula'|'juvenil'|'adulto'|'floracion'|'cosecha'} props.etapa
+ * @param {string} [props.className]
+ */
+
+// ── Paleta de tinta (fija, para leerse al sol; no hereda del tema) ──────────────
+const C = {
+  cielo: '#f4f6ea',
+  sol: '#e9c33f',
+  tierra: '#e7dabb',
+  tierraHonda: '#d9c79c',
+  surco: '#b98a2f',
+  raiz: '#a9843f',
+  raizHonda: '#8a6a2f',
+  tallo: '#3f8f4e',
+  talloHondo: '#2f6b3a',
+  hoja: '#4a9b57',
+  hojaTierna: '#7cba5a',
+  vena: '#2f6b3a',
+  cotiledon: '#9ccb6a',
+  flor: '#f2c53d',
+  florCentro: '#c9962c',
+  frutoMaduro: '#cc4b37',
+  frutoVerde: '#8aa54e',
+  caliz: '#3f8f4e',
+};
+
+// Una hoja ovada con nervadura (apunta hacia arriba desde su base en 0,0).
+function Hoja({ rot = 0, escala = 1, tono = C.hoja }) {
+  return (
+    <g transform={`rotate(${rot}) scale(${escala})`}>
+      <path
+        d="M0 0 C -11 -9 -10 -25 0 -33 C 10 -25 11 -9 0 0 Z"
+        fill={tono}
+        stroke={C.talloHondo}
+        strokeWidth="0.8"
+        strokeLinejoin="round"
+      />
+      <g stroke={C.vena} strokeWidth="0.9" strokeLinecap="round" fill="none" opacity="0.55">
+        <path d="M0 -2 L0 -30" />
+        <path d="M0 -12 L-6 -17" />
+        <path d="M0 -12 L6 -17" />
+        <path d="M0 -20 L-5 -25" />
+        <path d="M0 -20 L5 -25" />
+      </g>
+    </g>
+  );
+}
+
+// Flor de tomate: cinco pétalos en estrella + centro ocre.
+function Flor({ x = 0, y = 0, escala = 1 }) {
+  const petalos = [0, 72, 144, 216, 288];
+  return (
+    <g transform={`translate(${x} ${y}) scale(${escala})`}>
+      {petalos.map((a) => (
+        <ellipse key={a} cx="0" cy="-6" rx="2.6" ry="5.2" fill={C.flor} stroke={C.florCentro} strokeWidth="0.5" transform={`rotate(${a})`} />
+      ))}
+      <circle cx="0" cy="0" r="2.4" fill={C.florCentro} />
+    </g>
+  );
+}
+
+// Tomate: fruto con brillo y su cáliz de estrella verde arriba.
+function Tomate({ x = 0, y = 0, r = 7, maduro = true }) {
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <circle cx="0" cy="0" r={r} fill={maduro ? C.frutoMaduro : C.frutoVerde} stroke={C.raizHonda} strokeWidth="0.6" />
+      <ellipse cx={-r * 0.32} cy={-r * 0.34} rx={r * 0.34} ry={r * 0.22} fill="#ffffff" opacity="0.35" />
+      <g stroke={C.caliz} strokeWidth="1.4" strokeLinecap="round" fill="none">
+        <path d={`M0 ${-r} l-3 -3`} />
+        <path d={`M0 ${-r} l0 -4`} />
+        <path d={`M0 ${-r} l3 -3`} />
+      </g>
+    </g>
+  );
+}
+
+// Raíces: pivotante honda + laterales. `hondura` en px marca cuánto baja.
+function Raices({ hondura = 40 }) {
+  const lat = Math.min(1, hondura / 80);
+  return (
+    <g stroke={C.raiz} fill="none" strokeLinecap="round">
+      <path d={`M0 0 q 4 ${hondura * 0.4} -2 ${hondura}`} strokeWidth="2.4" stroke={C.raizHonda} />
+      <path d={`M0 6 q -${18 * lat} 8 -${24 * lat} ${28 * lat}`} strokeWidth="1.6" />
+      <path d={`M0 12 q ${18 * lat} 8 ${26 * lat} ${30 * lat}`} strokeWidth="1.6" />
+      <path d={`M-2 ${hondura * 0.45} q -${10 * lat} 6 -${14 * lat} ${18 * lat}`} strokeWidth="1.2" />
+      <path d={`M0 ${hondura * 0.6} q ${10 * lat} 6 ${13 * lat} ${16 * lat}`} strokeWidth="1.2" />
+    </g>
+  );
+}
+
+// El tutor (estaca) con sus amarres, para la mata ya hecha.
+function Tutor() {
+  return (
+    <g>
+      <line x1="24" y1="2" x2="24" y2="-112" stroke={C.surco} strokeWidth="4" strokeLinecap="round" />
+      <g stroke={C.raizHonda} strokeWidth="1.4" strokeLinecap="round">
+        <path d="M24 -30 q -12 -3 -22 -1" fill="none" />
+        <path d="M24 -66 q -14 -3 -24 -2" fill="none" />
+        <path d="M24 -96 q -12 -2 -20 -2" fill="none" />
+      </g>
+    </g>
+  );
+}
+
+// ── Cada etapa dibuja su propia mata (arte por etapa) ───────────────────────────
+function MataPorEtapa({ etapa }) {
+  switch (etapa) {
+    case 'semilla':
+      return (
+        <g>
+          <Raices hondura={30} />
+          {/* la semilla enterrada, inclinada */}
+          <g transform="rotate(-18)">
+            <ellipse cx="0" cy="16" rx="12" ry="8" fill={C.tierraHonda} stroke={C.raiz} strokeWidth="1.2" />
+            <path d="M-7 16 q 7 -4 14 0" fill="none" stroke={C.raizHonda} strokeWidth="0.9" />
+          </g>
+          {/* radícula que empieza a bajar */}
+          <path d="M0 22 q 3 12 -2 24" fill="none" stroke={C.raizHonda} strokeWidth="1.8" strokeLinecap="round" />
+          {/* el ganchito del brote que va a asomar */}
+          <path d="M0 8 q -2 -8 2 -13" fill="none" stroke={C.hojaTierna} strokeWidth="2.4" strokeLinecap="round" />
+        </g>
+      );
+    case 'plantula':
+      return (
+        <g>
+          <Raices hondura={40} />
+          {/* tallito */}
+          <path d="M0 0 q -2 -22 0 -46" fill="none" stroke={C.tallo} strokeWidth="3" strokeLinecap="round" />
+          {/* dos cotiledones opuestos */}
+          <ellipse cx="-11" cy="-44" rx="10" ry="4.6" fill={C.cotiledon} stroke={C.talloHondo} strokeWidth="0.7" transform="rotate(-18 -11 -44)" />
+          <ellipse cx="11" cy="-44" rx="10" ry="4.6" fill={C.cotiledon} stroke={C.talloHondo} strokeWidth="0.7" transform="rotate(18 11 -44)" />
+          {/* la primera hoja verdadera, tiernita */}
+          <g transform="translate(0 -48)"><Hoja rot={0} escala={0.7} tono={C.hojaTierna} /></g>
+        </g>
+      );
+    case 'juvenil':
+      return (
+        <g>
+          <Raices hondura={58} />
+          <path d="M0 0 q -3 -40 1 -82" fill="none" stroke={C.tallo} strokeWidth="4" strokeLinecap="round" />
+          {/* hojas alternas subiendo */}
+          <g transform="translate(-2 -22)"><Hoja rot={-58} escala={0.9} /></g>
+          <g transform="translate(1 -40)"><Hoja rot={62} escala={0.95} /></g>
+          <g transform="translate(-1 -58)"><Hoja rot={-52} escala={0.9} /></g>
+          <g transform="translate(1 -72)"><Hoja rot={54} escala={0.85} /></g>
+          <g transform="translate(0 -82)"><Hoja rot={0} escala={0.8} /></g>
+        </g>
+      );
+    case 'adulto':
+      return (
+        <g>
+          <Raices hondura={78} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -24)"><Hoja rot={-62} escala={1.1} /></g>
+          <g transform="translate(2 -40)"><Hoja rot={64} escala={1.15} /></g>
+          <g transform="translate(-2 -58)"><Hoja rot={-58} escala={1.1} /></g>
+          <g transform="translate(3 -74)"><Hoja rot={60} escala={1.05} /></g>
+          <g transform="translate(-2 -90)"><Hoja rot={-54} escala={1} /></g>
+          <g transform="translate(2 -102)"><Hoja rot={40} escala={0.9} /></g>
+          <g transform="translate(0 -108)"><Hoja rot={0} escala={0.85} /></g>
+        </g>
+      );
+    case 'floracion':
+      return (
+        <g>
+          <Raices hondura={80} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -26)"><Hoja rot={-62} escala={1.1} /></g>
+          <g transform="translate(2 -44)"><Hoja rot={64} escala={1.1} /></g>
+          <g transform="translate(-2 -64)"><Hoja rot={-58} escala={1.05} /></g>
+          <g transform="translate(3 -82)"><Hoja rot={58} escala={1} /></g>
+          <g transform="translate(0 -100)"><Hoja rot={0} escala={0.85} /></g>
+          {/* racimos de flor amarilla colgando de los nudos */}
+          <path d="M-6 -38 q -10 4 -14 12" fill="none" stroke={C.talloHondo} strokeWidth="1.4" />
+          <Flor x={-16} y={-26} escala={0.85} />
+          <Flor x={-24} y={-22} escala={0.75} />
+          <path d="M8 -70 q 12 3 16 12" fill="none" stroke={C.talloHondo} strokeWidth="1.4" />
+          <Flor x={20} y={-56} escala={0.9} />
+          <Flor x={27} y={-50} escala={0.75} />
+          <Flor x={14} y={-52} escala={0.7} />
+        </g>
+      );
+    case 'cosecha':
+      return (
+        <g>
+          <Raices hondura={82} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -26)"><Hoja rot={-62} escala={1.05} /></g>
+          <g transform="translate(2 -46)"><Hoja rot={64} escala={1.05} /></g>
+          <g transform="translate(-2 -66)"><Hoja rot={-58} escala={1} /></g>
+          <g transform="translate(3 -84)"><Hoja rot={58} escala={0.95} /></g>
+          <g transform="translate(0 -100)"><Hoja rot={0} escala={0.8} /></g>
+          {/* racimo cargado a la izquierda: maduros + uno verde */}
+          <path d="M-6 -40 q -12 6 -16 16" fill="none" stroke={C.talloHondo} strokeWidth="1.6" />
+          <Tomate x={-22} y={-22} r={7} maduro />
+          <Tomate x={-12} y={-16} r={6.5} maduro />
+          <Tomate x={-26} y={-33} r={5.5} maduro={false} />
+          {/* racimo a la derecha */}
+          <path d="M8 -72 q 14 6 18 16" fill="none" stroke={C.talloHondo} strokeWidth="1.6" />
+          <Tomate x={26} y={-52} r={7} maduro />
+          <Tomate x={16} y={-46} r={6} maduro />
+          <Tomate x={30} y={-63} r={5.5} maduro={false} />
+        </g>
+      );
+    default:
+      return null;
+  }
+}
+
+export default function LaminaMataEtapa({ etapa = 'semilla', className = '' }) {
+  return (
+    <svg
+      viewBox="0 0 320 300"
+      role="img"
+      aria-hidden="true"
+      className={['lam-mata-svg', className].filter(Boolean).join(' ')}
+      data-testid="lamina-mata-etapa"
+      data-etapa={etapa}
+    >
+      {/* cielo tenue */}
+      <rect x="0" y="0" width="320" height="198" fill={C.cielo} />
+      {/* sol de cuaderno, arriba a la derecha */}
+      <g opacity="0.7">
+        <circle cx="272" cy="40" r="15" fill={C.sol} />
+        <g stroke={C.sol} strokeWidth="2.2" strokeLinecap="round">
+          <line x1="272" y1="14" x2="272" y2="6" />
+          <line x1="296" y1="40" x2="304" y2="40" />
+          <line x1="290" y1="22" x2="296" y2="16" />
+          <line x1="290" y1="58" x2="296" y2="64" />
+        </g>
+      </g>
+
+      {/* corte de suelo: superficie ondulada + cuerpo de tierra */}
+      <path d="M0 198 Q 80 192 160 197 T 320 195 L320 300 L0 300 Z" fill={C.tierra} />
+      <path d="M0 198 Q 80 192 160 197 T 320 195" fill="none" stroke={C.surco} strokeWidth="2.2" strokeLinecap="round" opacity="0.6" />
+      {/* motas de tierra (rsvg-safe, sin filtros) */}
+      <g fill={C.surco} opacity="0.32">
+        <circle cx="46" cy="232" r="2.1" />
+        <circle cx="92" cy="262" r="1.6" />
+        <circle cx="128" cy="240" r="1.9" />
+        <circle cx="214" cy="230" r="2" />
+        <circle cx="250" cy="264" r="1.7" />
+        <circle cx="286" cy="238" r="2.1" />
+        <circle cx="70" cy="284" r="1.5" />
+        <circle cx="190" cy="278" r="1.8" />
+      </g>
+
+      {/* la mata, re-montada por etapa para que reanime su crecimiento */}
+      <g key={etapa} transform="translate(160 197)" className="lam-mata-brota">
+        <MataPorEtapa etapa={etapa} />
+      </g>
+    </svg>
+  );
+}

--- a/src/visual/laminas/LaminaSiembra.jsx
+++ b/src/visual/laminas/LaminaSiembra.jsx
@@ -17,15 +17,19 @@ import React from 'react';
  *
  * Trazo: línea redondeada, formas simples, colores en clases Tailwind sobre
  * currentColor por grupo para respirar con los temas.
+ *
+ * @param {Object} props
+ * @param {'tuberculo'|'esqueje'|'colino'|null} [props.activo] forma resaltada.
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
  */
-export default function LaminaSiembra({ activo = null }) {
+export default function LaminaSiembra({ activo = null, className }) {
   const dim = (id) => (activo && activo !== id ? 'opacity-40' : 'opacity-100');
   return (
     <svg
       viewBox="0 0 360 120"
       role="img"
       aria-hidden="true"
-      className="w-full h-auto select-none"
+      className={['w-full h-auto select-none', className].filter(Boolean).join(' ')}
       data-testid="lamina-siembra"
     >
       {/* línea de tierra que une las tres formas */}

--- a/src/visual/laminas/README.md
+++ b/src/visual/laminas/README.md
@@ -1,0 +1,86 @@
+# `src/visual/laminas` — láminas de cuaderno de campo reutilizables
+
+Librería de **láminas de cuaderno de campo** como componentes SVG limpios,
+parametrizables y sin dependencias nuevas. Nace para **dejar de redibujar la
+misma lámina** en cada mundo/pantalla: la siembra y el aporque de los
+tubérculos, la mata de maíz, el cafeto y la mata "viva" por etapa vivían
+dibujadas por separado en `components/tuberculos`, `components/milpa`,
+`components/cafe` y `components/mockups`, con calidad dispar. Aquí vive la
+**versión canónica** de cada una.
+
+Es la hermana de [`src/visual/creatures`](../creatures/README.md): allí viven
+los **personajes** (íconos cuadrados de fauna); aquí las **láminas** (hojas de
+papel enteras, con su viewBox y su relación de aspecto). Por eso **no comparten
+la misma firma de props**: una lámina no tiene `size`/`inline` — se dibuja a
+`width:100%` y expone `className` + su propia prop de dominio.
+
+## Regla de la casa
+
+> **Antes de dibujar una lámina de cuaderno, búscala aquí.**
+> Si existe → **reúsala** (y si podés, **mejorá** la versión canónica en su
+> archivo, para que todos hereden la mejora).
+> Si dibujás una lámina nueva reutilizable → **agregala aquí en el mismo PR**
+> (componente + entrada en `index.js` + fila en esta tabla).
+
+## Láminas
+
+| Componente | Nombre común | Especie / mundo | Accesibilidad | Prop propia |
+|---|---|---|---|---|
+| `LaminaSiembra` | Formas de siembra | Tubérculos y raíces | decorativa (`aria-hidden`) | `activo` |
+| `LaminaAporque` | El aporque (en corte) | Tubérculos y raíces | decorativa (`aria-hidden`) | — |
+| `LaminaMaiz` | La mata de maíz | *Zea mays* | enseña (`role=img` + rótulos) | — |
+| `LaminaCafeto` | El cafeto | *Coffea arabica* | enseña (`role=img` + rótulos) | — |
+| `LaminaMataEtapa` | La mata por etapa (viva) | *Solanum lycopersicum* | decorativa (`aria-hidden`) | `etapa` |
+
+## Props
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `className` | `string` | — | Clase(s) extra sobre el nodo raíz. Se **añaden** a las clases base de la lámina (`w-full h-auto select-none` en las SVG, o `lam-mata-svg`), nunca las reemplazan. |
+| `activo` | `'tuberculo' \| 'esqueje' \| 'colino' \| null` | `null` | **Solo `LaminaSiembra`.** Resalta una de las tres formas y atenúa las otras. Sin valor, se ven las tres. |
+| `etapa` | `'semilla' \| 'plantula' \| 'juvenil' \| 'adulto' \| 'floracion' \| 'cosecha'` | `'semilla'` | **Solo `LaminaMataEtapa`.** Cambia el dibujo según la etapa real de la mata y reanima el crecimiento. |
+
+## Uso
+
+```jsx
+import { LaminaSiembra, LaminaMaiz } from '@/visual/laminas';
+
+// Decorativa, con una forma resaltada:
+<LaminaSiembra activo="esqueje" />
+
+// Lámina que enseña (trae sus propios rótulos):
+<LaminaMaiz className="max-w-md mx-auto" />
+
+// Lámina viva de una mata concreta:
+<LaminaMataEtapa etapa="floracion" />
+```
+
+Consumidor de referencia: **`src/components/TuberculosScreen.jsx`** (importa
+`LaminaSiembra` y `LaminaAporque` desde aquí).
+
+## Técnica
+
+- SVG puro, **cero dependencias nuevas**. Colores de tinta **fijos** en las
+  láminas que "enseñan" (maíz, cafeto): son un pliego de papel prendido a la
+  pantalla, legible al sol en los cuatro temas. Las decorativas de tubérculos
+  usan `currentColor` + clases Tailwind para respirar con el tema.
+- `LaminaMaiz` genera los ids de sus `<defs>` (papel, clip de la mazorca) con
+  **`useId`**, así se puede repetir varias veces en una misma página sin
+  colisión de ids.
+- La única animación (el crecimiento de `LaminaMataEtapa` al cambiar de etapa)
+  vive en `laminas.css` (`lam-mata-brota`) y es **reduced-motion-safe**.
+- Todas son **rsvg-safe** salvo por el `<text>` de rótulos (sin emoji-en-SVG,
+  sin filtros exóticos), aptas para captura de pantalla del harness visual.
+
+## Candidatos evaluados y **aún no** promovidos
+
+- **`EstiercolIlustraciones`** (rama `feat/mundo-estiercol-compost`, sin mergear
+  a `main`) es un módulo **mixto**, no una lámina limpia:
+  - `BiodigestorIlustracion` **sí** es una lámina de corte (parametrizable con
+    `llenado`) — es la candidata a promover **cuando su mundo llegue a `main`**,
+    trayéndose además sus animaciones `estiercol-*` a `laminas.css`.
+  - `CicloCorralAbono` usa **emoji-en-SVG** (🐖 🛢️ 💧 🌱), que **no es
+    rsvg-safe** ni cumple la regla de la casa → no entra tal cual.
+  - `AbonoGlifo` es un **glifo** de 44×44, no una lámina (más cerca de un ícono).
+  Se dejó fuera de este PR a propósito para no arrastrar un módulo a medio
+  mergear ni romper la garantía de arte byte-idéntico.

--- a/src/visual/laminas/index.js
+++ b/src/visual/laminas/index.js
@@ -1,0 +1,63 @@
+/*
+ * Librería visual de LÁMINAS DE CUADERNO DE CAMPO de la chagra.
+ * Fuente única y reutilizable. Antes de dibujar una lámina, búscala aquí.
+ *
+ * Una "lámina" es una hoja de papel entera (SVG propio, sin stock ni deps): la
+ * mata o la labor dibujada a mano, con su viewBox y su relación de aspecto —
+ * NO un ícono cuadrado (para eso está `src/visual/creatures`). Por eso NO
+ * comparten la firma size/inline de las criaturas: cada lámina se dibuja a
+ * `width:100%` y expone `className` + su propia prop de dominio.
+ *
+ * Props comunes:
+ *   - `className` (string): clases extra sobre el nodo raíz.
+ * Props propias por lámina:
+ *   - LaminaSiembra   → `activo`: 'tuberculo' | 'esqueje' | 'colino' | null
+ *   - LaminaMataEtapa → `etapa` : 'semilla' | 'plantula' | 'juvenil' | 'adulto'
+ *                                 | 'floracion' | 'cosecha'
+ */
+export { default as LaminaSiembra } from './LaminaSiembra.jsx';
+export { default as LaminaAporque } from './LaminaAporque.jsx';
+export { default as LaminaMaiz } from './LaminaMaiz.jsx';
+export { default as LaminaCafeto } from './LaminaCafeto.jsx';
+export { default as LaminaMataEtapa } from './LaminaMataEtapa.jsx';
+
+import LaminaSiembra from './LaminaSiembra.jsx';
+import LaminaAporque from './LaminaAporque.jsx';
+import LaminaMaiz from './LaminaMaiz.jsx';
+import LaminaCafeto from './LaminaCafeto.jsx';
+import LaminaMataEtapa from './LaminaMataEtapa.jsx';
+
+/* Registro consultable: slug → componente + nombre común + especie/mundo.
+   (accesible: aria-hidden = decorativa; role=img = enseña con rótulos). */
+export const LAMINAS = {
+  siembra: {
+    Component: LaminaSiembra,
+    nombre: 'Formas de siembra',
+    especie: 'Tubérculos y raíces (varias)',
+    accesible: 'decorativa',
+  },
+  aporque: {
+    Component: LaminaAporque,
+    nombre: 'El aporque (en corte)',
+    especie: 'Tubérculos y raíces (varias)',
+    accesible: 'decorativa',
+  },
+  maiz: {
+    Component: LaminaMaiz,
+    nombre: 'La mata de maíz',
+    especie: 'Zea mays',
+    accesible: 'enseña',
+  },
+  cafeto: {
+    Component: LaminaCafeto,
+    nombre: 'El cafeto',
+    especie: 'Coffea arabica',
+    accesible: 'enseña',
+  },
+  'mata-etapa': {
+    Component: LaminaMataEtapa,
+    nombre: 'La mata por etapa (viva)',
+    especie: 'Solanum lycopersicum',
+    accesible: 'decorativa',
+  },
+};

--- a/src/visual/laminas/laminas.css
+++ b/src/visual/laminas/laminas.css
@@ -1,0 +1,33 @@
+/*
+ * Estilos compartidos de la librería de LÁMINAS de cuaderno.
+ * Solo cubre lo que una lámina necesita como hoja de papel autónoma:
+ * el dimensionado responsivo y las (pocas) animaciones intrínsecas, todas
+ * reduced-motion-safe (sin animación → fotograma final digno). Trasplantado
+ * de `mockups/hoja-vida-mata.css` (clases `hvm-lamina-*`) al namespace propio
+ * `lam-*` para que la lámina no dependa de la CSS de ningún consumidor.
+ */
+
+/* LaminaMataEtapa — la hoja de papel: ancho completo, alto por aspecto. */
+.lam-mata-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 340px;
+  margin: 0 auto;
+  user-select: none;
+}
+
+/* LaminaMataEtapa — el crecimiento al cambiar de etapa (la mata "brota"). */
+.lam-mata-brota {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: lam-brota 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes lam-brota {
+  from { opacity: 0; transform: scaleY(0.82) translateY(4px); }
+  to   { opacity: 1; transform: scaleY(1) translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lam-mata-brota { animation: none; }
+}


### PR DESCRIPTION
## Qué

Escala la librería visual reutilizable de Chagra con un segundo cajón, hermano de `src/visual/creatures`: **`src/visual/laminas/`**, la versión canónica de las **láminas de cuaderno de campo** que hoy viven dispersas por varios mundos.

## Láminas extraídas (arte byte-idéntico)

| Componente | Origen | Accesibilidad |
|---|---|---|
| `LaminaSiembra` | `components/tuberculos` (main) | decorativa |
| `LaminaAporque` | `components/tuberculos` (main) | decorativa |
| `LaminaMaiz` | rama `fable/lamina-maiz-botanica` | enseña (rótulos) |
| `LaminaCafeto` | rama `fable/lamina-cafeto` | enseña (rótulos) |
| `LaminaMataEtapa` | rama `fable/mockup-hoja-vida-mata` | decorativa |

## Estructura (patrón de `creatures`)

- `index.js` — barrel + registro `LAMINAS` (slug → componente + nombre común + especie/mundo + accesibilidad).
- `README.md` — props + regla de la casa ("búscala aquí antes de dibujar") + tabla + candidatos evaluados.
- `laminas.css` — única animación intrínseca (crecimiento de `LaminaMataEtapa`), reduced-motion-safe.
- Convención propia de láminas: `className` + prop de dominio (`activo`, `etapa`). **No** heredan `size/inline` de las criaturas: una lámina es una hoja de papel entera, no un ícono cuadrado.

## Mejoras sobre la mejor versión

- `LaminaMaiz`: ids de `<defs>` (papel, clip de mazorca) pasan a `useId` → se puede repetir varias veces en una página sin colisión.
- Geometría byte-idéntica verificada por **coincidencia de paths** contra cada original (Siembra/Aporque/Cafeto/MataEtapa idénticos; Maíz idéntico salvo los ids ahora únicos).

## Consumidor convertido (prueba)

`src/components/TuberculosScreen.jsx` importa `LaminaSiembra`/`LaminaAporque` desde la librería; se eliminan los duplicados en `components/tuberculos`. (No se migra el resto — eso es el escalado.)

## `EstiercolIlustraciones`: evaluado, aún no

Módulo mixto en rama sin mergear: `BiodigestorIlustracion` sí es lámina (candidata a promover cuando su mundo llegue a main), pero `CicloCorralAbono` usa emoji-en-SVG (no rsvg-safe) y `AbonoGlifo` es un glifo. Se documenta en el README y se deja fuera a propósito.

## Verificación

- `npm run build`: verde (sin Playwright).
- `TuberculosScreen.test`: 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)