### PR TITLE
feat(mockup): entrada definitiva 3D "El valle de mi finca" (#/mockups/entrada-3d)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
         "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
         "jspdf": "^4.2.1",
         "leaflet": "^1.9.4",
@@ -20,6 +22,7 @@
         "react-dom": "^19.2.4",
         "react-leaflet": "^5.0.0",
         "react-virtuoso": "^4.18.6",
+        "three": "^0.180.0",
         "ulid": "^3.0.2",
         "zustand": "^5.0.12"
       },
@@ -1856,6 +1859,12 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -2279,6 +2288,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -2371,6 +2398,94 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3251,6 +3366,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -3285,6 +3406,12 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3350,6 +3477,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -3357,12 +3493,56 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -3884,7 +4064,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3933,7 +4112,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -4057,6 +4235,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4132,6 +4334,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4327,11 +4542,28 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4585,6 +4817,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4625,6 +4866,12 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5660,6 +5907,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5791,6 +6044,12 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -5836,7 +6095,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6225,6 +6483,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6404,7 +6668,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6444,6 +6707,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jackspeak": {
@@ -7226,6 +7501,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7303,6 +7588,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7685,7 +7985,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7984,6 +8283,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -8061,6 +8366,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/pump": {
@@ -8198,6 +8513,21 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-virtuoso": {
@@ -8375,7 +8705,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8712,7 +9041,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8725,7 +9053,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8975,6 +9302,32 @@
         "node": ">=0.1.14"
       }
     },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -9193,6 +9546,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
@@ -9366,6 +9728,44 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9500,6 +9900,36 @@
         "node": ">=20"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -9524,6 +9954,43 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {
@@ -9808,12 +10275,30 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/utrie": {
       "version": "1.0.2",
@@ -10047,6 +10532,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -10086,7 +10582,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
     "jspdf": "^4.2.1",
     "leaflet": "^1.9.4",
@@ -40,6 +42,7 @@
     "react-dom": "^19.2.4",
     "react-leaflet": "^5.0.0",
     "react-virtuoso": "^4.18.6",
+    "three": "^0.180.0",
     "ulid": "^3.0.2",
     "zustand": "^5.0.12"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,6 +89,11 @@ const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').
 // 2026-06-30. Se alcanza desde 'bodega' vía el botón "Auditoría y
 // reconciliación", o directo por hash (#auditoria-inventario).
 const InventoryPage = lazy(() => import('./pages/InventoryPage'));
+// Mockup dev "El valle de mi finca" (entrada definitiva #2, sin límites): un
+// diorama 3D isométrico de la finca (React-Three-Fiber sobre WebGL2, chunk
+// perezoso) donde los 4 sí-o-sí viven en el espacio. Ruta #/mockups/entrada-3d
+// — sin gate ni sesión (datos de muestra, degrada limpio a SVG sin WebGL).
+const EntradaValle3DMockup = lazy(() => import('./mockups/EntradaValle3D'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -418,6 +423,7 @@ const LoadingFallback = ({ view = null }) => {
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
 
 const HASH_VIEW_ROUTES = {
+  'mockups/entrada-3d': 'mockup_entrada_3d',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -915,6 +921,14 @@ export default function App() {
       return;
     }
 
+    // Mockups dev (#/mockups/*): vistas aisladas de decisión visual — se montan
+    // SIN sesión (datos de muestra, no tocan datos reales).
+    if (hash.startsWith('mockups/') && HASH_VIEW_ROUTES[hash]) {
+      const vistaMockup = HASH_VIEW_ROUTES[hash];
+      Promise.resolve().then(() => navigate(vistaMockup));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -943,6 +957,11 @@ export default function App() {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
+      // Mockups dev (#/mockups/*): sin gate de sesión.
+      if (routeView.startsWith('mockup_')) {
+        navigate(routeView);
+        return;
+      }
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
       if (routeView === 'extensionista' && !esExtensionistaActual()) {
         navigate('dashboard');
@@ -1265,6 +1284,18 @@ export default function App() {
               onConfirm={() => navigate(currentViewData?.next || 'dashboard')}
               onBack={() => navigate(currentViewData?.back || 'dashboard')}
             />
+          </ErrorBoundary>
+        );
+      case 'mockup_entrada_3d':
+        // Mockup "El valle de mi finca" (entrada definitiva #2): diorama 3D
+        // isométrico navegable (R3F/WebGL2, chunk perezoso) con los 4 sí-o-sí
+        // en el espacio. Full-screen, sin gate — decisión visual. Degrada a
+        // SVG sin WebGL. onBack vuelve al dashboard.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El valle de mi finca (3D)">
+              <EntradaValle3DMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'dashboard':
@@ -2563,7 +2594,7 @@ export default function App() {
           Tampoco en onboarding-perfil (tarea #16): el FAB se encimaba sobre el
           CTA "Explorar con finca de ejemplo" del footer y la usuaria nueva aún
           no conoce al agente — ruido en su primer flujo. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && <AgentFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && !currentView.startsWith('mockup_') && <AgentFab onNavigate={navigate} />}
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o
           pregunta al agente punta a punta por voz.

--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -1,0 +1,262 @@
+/*
+ * MOCKUP "El valle de mi finca" — ruta #/mockups/entrada-3d.
+ *
+ * LA ENTRADA DEFINITIVA, dirección #2 (sin límites) del DR
+ * DR-ENTRADA-DEFINITIVA-2026-07-10.md: un DIORAMA 3D ISOMÉTRICO del valle real
+ * de la finca, navegable, donde los 4 sí-o-sí de Chagra viven en el ESPACIO —
+ * no un menú, sino un lugar. "Bruno Simon, pero es su finca y sí sirve":
+ * spatial UI grounded con PROPÓSITO, no wow vacío.
+ *
+ * LOS 4 SÍ-O-SÍ, ANCLADOS EN EL VALLE
+ *   1. ALERTA / qué-hacer-hoy → un SOLO faro que brilla sobre el lugar donde
+ *      toca (el semillero). Tocarlo: el agente lo dice en voz y ofrece LA acción.
+ *   2. LOS MUNDOS → cada mundo (fuente real mundosFinca.js) es un LUGAR del
+ *      valle al que se VIAJA: la cámara vuela hasta él y se abre su panel.
+ *   3. AGENTE / VOZ → el colibrí (visual-lib) es un compañero presente que
+ *      flota sobre el foco y NARRA por voz (Web Speech API) al pasar.
+ *   4. ESTADO / CLIMA → el estado real (por la hora de la vereda) tiñe todo:
+ *      luz, niebla, cielo y estrellas de la escena 3D + grade DOM de effects.
+ *
+ * STACK (DR §2): React-Three-Fiber sobre WebGL 2 (línea base). La escena 3D se
+ * carga PEREZOSO y en su propio chunk (no infla el bundle base). WebGPU sería
+ * mejora opcional (nunca requisito). Si NO hay WebGL → degrada LIMPIO a una
+ * entrada digna en SVG+CSS (Valle2DFallback), con los mismos 4 sí-o-sí.
+ * Offline-first: cero GLTF/HDR/fuentes remotas, todo procedural.
+ *
+ * Copy de muestra en español Colombia (usted); si se productiza, migra a
+ * messages.js (ADR-050).
+ */
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import '../visual/effects/effects.css';
+import './entradaValle3D.css';
+import {
+  MUNDO_VALLE_BY_ID,
+  COSA_DEL_DIA,
+  CLIMAS,
+  ORDEN_CLIMA,
+  climaPorHora,
+  NARRACION,
+} from './valle/valleData';
+import Valle2DFallback from './valle/Valle2DFallback';
+
+// La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso.
+const Valle3D = lazy(() => import('./valle/Valle3D'));
+
+/** ¿El equipo soporta WebGL? (línea base del render 3D). */
+function soportaWebGL() {
+  if (typeof window === 'undefined') return false;
+  try {
+    const canvas = document.createElement('canvas');
+    return !!(
+      window.WebGLRenderingContext &&
+      (canvas.getContext('webgl2') || canvas.getContext('webgl'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+export default function EntradaValle3D({ onBack }) {
+  const [clima, setClima] = useState(() => climaPorHora());
+  const [focoId, setFocoId] = useState(null);
+  const [panel, setPanel] = useState(null); // null | 'alerta' | <mundoId>
+  const [voz, setVoz] = useState(true);
+  const [webgl] = useState(() => soportaWebGL());
+
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+
+  // ── Voz (Web Speech API): el agente DICE. Se calla si el equipo no la trae
+  //    o si el usuario apaga la voz. Prefiere una voz en español.
+  const hablar = useCallback(
+    (texto) => {
+      if (!voz || typeof window === 'undefined' || !window.speechSynthesis) return;
+      try {
+        window.speechSynthesis.cancel();
+        const u = new SpeechSynthesisUtterance(texto);
+        u.lang = 'es-CO';
+        u.rate = 0.98;
+        u.pitch = 1;
+        const esVoz = window.speechSynthesis
+          .getVoices()
+          .find((v) => v.lang && v.lang.toLowerCase().startsWith('es'));
+        if (esVoz) u.voice = esVoz;
+        window.speechSynthesis.speak(u);
+      } catch {
+        /* la voz es un plus, nunca bloquea */
+      }
+    },
+    [voz],
+  );
+
+  useEffect(
+    () => () => {
+      if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+    },
+    [],
+  );
+
+  // Saludo del compañero al entrar (una sola vez).
+  const saludado = useRef(false);
+  useEffect(() => {
+    if (saludado.current) return;
+    saludado.current = true;
+    const t = setTimeout(() => hablar(NARRACION.bienvenida), 900);
+    return () => clearTimeout(t);
+  }, [hablar]);
+
+  const entrarMundo = useCallback(
+    (id) => {
+      setFocoId(id);
+      setPanel(id);
+      hablar(NARRACION[id] || MUNDO_VALLE_BY_ID[id]?.lema || '');
+    },
+    [hablar],
+  );
+
+  const abrirAlerta = useCallback(() => {
+    setFocoId(COSA_DEL_DIA.anclaMundo);
+    setPanel('alerta');
+    hablar(COSA_DEL_DIA.vozTexto);
+  }, [hablar]);
+
+  const volverAlValle = useCallback(() => {
+    setFocoId(null);
+    setPanel(null);
+    if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+  }, []);
+
+  const mundoPanel = panel && panel !== 'alerta' ? MUNDO_VALLE_BY_ID[panel] : null;
+
+  return (
+    <div className="valle-root" data-clima={clima}>
+      {/* fondo/atmósfera 3D o su degradación 2D */}
+      <div className="valle-escena">
+        {webgl ? (
+          <Suspense fallback={<CargandoValle clima={clima} />}>
+            <Valle3D
+              clima={clima}
+              focoId={focoId}
+              onEntrar={entrarMundo}
+              onAlerta={abrirAlerta}
+              reducedMotion={reducedMotion}
+            />
+          </Suspense>
+        ) : (
+          <Valle2DFallback clima={clima} onEntrar={entrarMundo} onAlerta={abrirAlerta} />
+        )}
+      </div>
+
+      {/* ── Encabezado: el nombre del lugar + el selector de clima (estado) ── */}
+      <header className="valle-header">
+        <button type="button" className="valle-back" onClick={() => onBack?.()} aria-label="Volver">
+          ‹ Volver
+        </button>
+        <div className="valle-titulo">
+          <span className="valle-titulo__eyebrow">Su finca, hoy</span>
+          <h1>El valle de mi finca</h1>
+        </div>
+        <div className="valle-clima" role="group" aria-label="Estado del clima de la vereda">
+          {ORDEN_CLIMA.map((k) => (
+            <button
+              key={k}
+              type="button"
+              className={`valle-clima__chip${clima === k ? ' valle-clima__chip--on' : ''}`}
+              aria-pressed={clima === k}
+              onClick={() => setClima(k)}
+            >
+              {CLIMAS[k].etiqueta}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {/* ── Sin WebGL: aviso sobrio de que se ve la versión dibujada ── */}
+      {!webgl && (
+        <p className="valle-degradado" role="status">
+          Su equipo ve la versión dibujada del valle. La finca sigue completa.
+        </p>
+      )}
+
+      {/* ── Panel de la ALERTA (la cosa del día): UNA acción clara ── */}
+      {panel === 'alerta' && (
+        <aside className="valle-panel valle-panel--alerta" aria-live="polite">
+          <button type="button" className="valle-panel__x" onClick={volverAlValle} aria-label="Cerrar">×</button>
+          <span className="valle-panel__tag">⚠️ Lo del día</span>
+          <h2>{COSA_DEL_DIA.titulo}</h2>
+          <p>{COSA_DEL_DIA.detalle}</p>
+          <div className="valle-panel__acciones">
+            <button type="button" className="valle-cta">{COSA_DEL_DIA.accion.etiqueta}</button>
+            <button type="button" className="valle-ghost" onClick={() => hablar(COSA_DEL_DIA.vozTexto)}>
+              🔊 Escuchar
+            </button>
+          </div>
+        </aside>
+      )}
+
+      {/* ── Panel de un MUNDO (lugar al que se viajó) ── */}
+      {mundoPanel && (
+        <aside className="valle-panel valle-panel--mundo" aria-live="polite" style={{ '--m-tinte': mundoPanel.tinte[0] }}>
+          <button type="button" className="valle-panel__x" onClick={volverAlValle} aria-label="Cerrar">×</button>
+          <span className="valle-panel__tag">
+            <span aria-hidden="true">{mundoPanel.emoji}</span> Mundo
+          </span>
+          <h2>{mundoPanel.titulo}</h2>
+          <p>{mundoPanel.lema}</p>
+          <div className="valle-panel__acciones">
+            <button type="button" className="valle-cta">Entrar a este mundo</button>
+            <button type="button" className="valle-ghost" onClick={() => hablar(NARRACION[mundoPanel.id] || mundoPanel.lema)}>
+              🔊 Escuchar
+            </button>
+          </div>
+        </aside>
+      )}
+
+      {/* ── Barra del AGENTE: el compañero presente + voz + volver al valle ── */}
+      <footer className="valle-agente">
+        <button type="button" className="valle-agente__pregunte" aria-label="Pregúntele a Chagra">
+          <span className="valle-agente__punto" aria-hidden="true" />
+          Pregúntele a su finca…
+        </button>
+        <div className="valle-agente__ctrls">
+          {focoId && (
+            <button type="button" className="valle-agente__btn" onClick={volverAlValle}>
+              Ver todo el valle
+            </button>
+          )}
+          <button
+            type="button"
+            className={`valle-agente__btn valle-agente__voz${voz ? ' on' : ''}`}
+            aria-pressed={voz}
+            onClick={() => {
+              const n = !voz;
+              setVoz(n);
+              if (!n && typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+            }}
+          >
+            {voz ? '🔊 Voz' : '🔇 Voz'}
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+/* Placeholder mientras baja el chunk 3D: el cielo del clima + un latido. */
+function CargandoValle({ clima }) {
+  const c = CLIMAS[clima];
+  return (
+    <div
+      className="valle-cargando"
+      style={{ background: `linear-gradient(180deg, ${c.cielo[0]}, ${c.cielo[1]})` }}
+    >
+      <div className="valle-cargando__pulso" />
+      <p>Levantando su finca…</p>
+    </div>
+  );
+}

--- a/src/mockups/entradaValle3D.css
+++ b/src/mockups/entradaValle3D.css
@@ -1,0 +1,436 @@
+/*
+ * Estilos del mockup "El valle de mi finca" (#/mockups/entrada-3d).
+ * UI que FLOTA sobre el diorama (sin cajas duras): scrims de cine para que el
+ * texto siempre lea, targets táctiles > 48px (manos de trabajo), copy en usted.
+ * La escena vive detrás; el chrome DOM la conduce (accesible por teclado/voz).
+ */
+
+.valle-root {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  color: #fff;
+  font-family: 'Baloo 2', system-ui, sans-serif;
+  background: #0d1e2a;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.valle-escena {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.valle-canvas {
+  opacity: 0;
+  transition: opacity 0.9s ease;
+}
+.valle-canvas--listo { opacity: 1; }
+
+/* ── Placeholder de carga del chunk 3D ── */
+.valle-cargando {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+.valle-cargando__pulso {
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #ffe0a3, #ff9d4d);
+  animation: valle-pulso 1.6s ease-in-out infinite;
+  box-shadow: 0 0 40px 8px rgba(255, 180, 90, 0.5);
+}
+.valle-cargando p { font-size: 0.95rem; letter-spacing: 0.02em; }
+@keyframes valle-pulso {
+  0%, 100% { transform: scale(0.85); opacity: 0.7; }
+  50% { transform: scale(1.1); opacity: 1; }
+}
+
+/* ── Encabezado ── */
+.valle-header {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  z-index: 10;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem 2.4rem;
+  background: linear-gradient(180deg, rgba(6, 16, 26, 0.72) 0%, rgba(6, 16, 26, 0) 100%);
+  pointer-events: none;
+}
+.valle-header > * { pointer-events: auto; }
+
+.valle-back {
+  flex: 0 0 auto;
+  min-height: 44px;
+  padding: 0.4rem 0.7rem;
+  border: none;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+}
+.valle-back:hover { background: rgba(0, 0, 0, 0.5); }
+
+.valle-titulo { flex: 1 1 auto; min-width: 0; }
+.valle-titulo__eyebrow {
+  display: block;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.85;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+}
+.valle-titulo h1 {
+  margin: 0.1rem 0 0;
+  font-size: clamp(1.35rem, 5vw, 1.9rem);
+  font-weight: 800;
+  line-height: 1.05;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
+}
+
+.valle-clima {
+  position: absolute;
+  top: 4.4rem;
+  right: 1.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: flex-end;
+  max-width: 62vw;
+}
+.valle-clima__chip {
+  min-height: 40px;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.32);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  transition: background 0.2s, border-color 0.2s, transform 0.15s;
+}
+.valle-clima__chip:hover { background: rgba(0, 0, 0, 0.5); }
+.valle-clima__chip--on {
+  background: rgba(255, 214, 138, 0.92);
+  border-color: #ffd68a;
+  color: #3a2510;
+  box-shadow: 0 4px 14px rgba(255, 180, 90, 0.4);
+}
+
+/* ── Etiquetas espaciales dentro del 3D (drei <Html>) ── */
+.valle-poi {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 44px;
+  padding: 0.35rem 0.7rem 0.35rem 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  background: rgba(12, 22, 28, 0.72);
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+  backdrop-filter: blur(3px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+  transition: transform 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+  transform-origin: bottom center;
+}
+.valle-poi::before {
+  content: '';
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--poi-tinte, #7fd08a);
+  box-shadow: 0 0 10px 2px color-mix(in srgb, var(--poi-tinte, #7fd08a) 70%, transparent);
+  flex: 0 0 auto;
+}
+.valle-poi__emoji { font-size: 1.05rem; }
+.valle-poi:hover { transform: scale(1.06); background: rgba(12, 22, 28, 0.9); }
+.valle-poi--activo {
+  background: rgba(255, 255, 255, 0.94);
+  color: #1c2b1c;
+  border-color: #fff;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.4);
+}
+
+/* ── La cosa del día: el faro que grita (con mesura) ── */
+.valle-alerta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 46px;
+  padding: 0.4rem 0.85rem;
+  border: 2px solid #ffcf87;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 173, 71, 0.96), rgba(230, 130, 50, 0.96));
+  color: #3a2205;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 800;
+  white-space: nowrap;
+  cursor: pointer;
+  box-shadow: 0 6px 22px rgba(255, 150, 60, 0.55);
+  animation: valle-alerta-late 2.4s ease-in-out infinite;
+}
+.valle-alerta:hover { filter: brightness(1.06); }
+@keyframes valle-alerta-late {
+  0%, 100% { transform: scale(1); box-shadow: 0 6px 22px rgba(255, 150, 60, 0.5); }
+  50% { transform: scale(1.06); box-shadow: 0 8px 30px rgba(255, 170, 80, 0.75); }
+}
+
+/* ── El colibrí compañero (SVG de visual-lib) ── */
+.valle-colibri {
+  filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.4));
+  pointer-events: none;
+}
+
+/* ── Paneles (alerta / mundo): flotan abajo, una acción clara ── */
+.valle-panel {
+  position: absolute;
+  left: 50%;
+  bottom: 5.4rem;
+  transform: translateX(-50%);
+  z-index: 20;
+  width: min(92vw, 30rem);
+  padding: 1.1rem 1.2rem 1.2rem;
+  border-radius: 1.2rem;
+  background: rgba(15, 24, 30, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(10px);
+  animation: valle-panel-in 0.32s cubic-bezier(0.2, 0.9, 0.3, 1);
+}
+@keyframes valle-panel-in {
+  from { opacity: 0; transform: translate(-50%, 14px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+.valle-panel__x {
+  position: absolute;
+  top: 0.5rem; right: 0.6rem;
+  width: 40px; height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.valle-panel__x:hover { background: rgba(255, 255, 255, 0.2); }
+.valle-panel__tag {
+  display: inline-block;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+}
+.valle-panel--alerta .valle-panel__tag { background: rgba(255, 173, 71, 0.28); color: #ffd7a0; }
+.valle-panel--mundo .valle-panel__tag { background: color-mix(in srgb, var(--m-tinte, #7fd08a) 35%, transparent); }
+.valle-panel h2 {
+  margin: 0.55rem 0 0.35rem;
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+.valle-panel p {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.9);
+}
+.valle-panel__acciones {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+.valle-cta {
+  flex: 1 1 auto;
+  min-height: 52px;
+  padding: 0.7rem 1.1rem;
+  border: none;
+  border-radius: 0.9rem;
+  background: linear-gradient(180deg, #ffd88f, #ff9d4d);
+  color: #3a2205;
+  font-family: inherit;
+  font-size: 1.02rem;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(255, 150, 60, 0.45);
+}
+.valle-panel--mundo .valle-cta {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--m-tinte, #7fd08a) 78%, #fff),
+    var(--m-tinte, #4b8a52));
+  color: #10210f;
+}
+.valle-cta:hover { filter: brightness(1.05); }
+.valle-ghost {
+  min-height: 52px;
+  padding: 0.7rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 0.9rem;
+  background: transparent;
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.98rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+.valle-ghost:hover { background: rgba(255, 255, 255, 0.1); }
+
+/* ── Barra del agente (abajo, fija) ── */
+.valle-agente {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  z-index: 15;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 1rem calc(0.7rem + env(safe-area-inset-bottom, 0px));
+  background: linear-gradient(0deg, rgba(6, 16, 26, 0.85) 0%, rgba(6, 16, 26, 0) 100%);
+  pointer-events: none;
+}
+.valle-agente > * { pointer-events: auto; }
+.valle-agente__pregunte {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 52px;
+  padding: 0.6rem 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.92);
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+}
+.valle-agente__pregunte:hover { background: rgba(255, 255, 255, 0.16); }
+.valle-agente__punto {
+  width: 12px; height: 12px;
+  border-radius: 50%;
+  background: #7dffbe;
+  box-shadow: 0 0 10px 2px rgba(125, 255, 190, 0.7);
+  animation: valle-punto 2.2s ease-in-out infinite;
+}
+@keyframes valle-punto { 0%,100%{opacity:.6;transform:scale(.85);} 50%{opacity:1;transform:scale(1.1);} }
+.valle-agente__ctrls { display: flex; gap: 0.5rem; }
+.valle-agente__btn {
+  min-height: 52px;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  white-space: nowrap;
+}
+.valle-agente__btn:hover { background: rgba(0, 0, 0, 0.5); }
+.valle-agente__voz.on { border-color: #7dffbe; }
+
+.valle-degradado {
+  position: absolute;
+  top: 8.2rem; left: 1.1rem; right: 1.1rem;
+  z-index: 8;
+  margin: 0;
+  padding: 0.5rem 0.8rem;
+  border-radius: 0.7rem;
+  background: rgba(0, 0, 0, 0.4);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+/* ── Fallback 2D (sin WebGL) ── */
+.valle2d { position: absolute; inset: 0; }
+.valle2d__svg { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; }
+.valle2d__mundos { position: absolute; inset: 0; }
+.valle2d__poi {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 0.8rem;
+  background: rgba(12, 22, 28, 0.7);
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  backdrop-filter: blur(3px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+.valle2d__poi:hover { transform: translate(-50%, -54%); }
+.valle2d__emoji { font-size: 1.3rem; }
+.valle2d__nombre {
+  border-top: 2px solid var(--poi-tinte, #7fd08a);
+  padding-top: 0.1rem;
+}
+.valle2d__alerta {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.4rem 0.8rem;
+  border: 2px solid #ffcf87;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 173, 71, 0.96), rgba(230, 130, 50, 0.96));
+  color: #3a2205;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(255, 150, 60, 0.5);
+  animation: valle-alerta-late 2.4s ease-in-out infinite;
+}
+.valle2d__grade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: soft-light;
+  opacity: 0.7;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .valle-cargando__pulso,
+  .valle-alerta,
+  .valle2d__alerta,
+  .valle-agente__punto,
+  .valle-panel { animation: none; }
+}
+
+@media (max-width: 560px) {
+  .valle-clima { position: static; max-width: none; margin-top: 0.4rem; justify-content: flex-start; width: 100%; }
+  .valle-header { flex-wrap: wrap; }
+  .valle-titulo h1 { font-size: 1.3rem; }
+}

--- a/src/mockups/valle/Valle2DFallback.jsx
+++ b/src/mockups/valle/Valle2DFallback.jsx
@@ -1,0 +1,84 @@
+/*
+ * Valle2DFallback — la degradación LIMPIA cuando no hay WebGL (o el equipo es
+ * humilde). No es una pantalla de error: es una entrada digna en SVG+CSS (el
+ * músculo que Chagra ya domina, DR §0) con los MISMOS 4 sí-o-sí — un valle
+ * pintado, la cosa del día que brilla, los mundos como lugares tocables, y el
+ * clima que tiñe la escena vía las grades de effects. "Wow" se pierde; el
+ * PROPÓSITO no.
+ */
+import { MUNDOS_VALLE, COSA_DEL_DIA, CLIMAS } from './valleData';
+
+/* Proyección isométrica plana de las coordenadas del valle a la lámina SVG. */
+function iso(x, z) {
+  const cx = 200 + (x - z) * 30;
+  const cy = 150 + (x + z) * 15;
+  return { cx, cy };
+}
+
+export default function Valle2DFallback({ clima, onEntrar, onAlerta }) {
+  const c = CLIMAS[clima];
+  const ancla = MUNDOS_VALLE.find((m) => m.id === COSA_DEL_DIA.anclaMundo);
+  // Mundos ordenados de atrás hacia adelante para que se solapen bien.
+  const orden = [...MUNDOS_VALLE].sort((a, b) => a.pos[0] + a.pos[2] - (b.pos[0] + b.pos[2]));
+
+  return (
+    <div className="valle2d" data-clima={clima}>
+      <svg viewBox="0 0 400 340" className="valle2d__svg" role="img"
+        aria-label="El valle de su finca, dibujado. Toque un lugar para entrar.">
+        <defs>
+          <linearGradient id="v2d-cielo" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor={c.cielo[0]} />
+            <stop offset="1" stopColor={c.cielo[1]} />
+          </linearGradient>
+          <radialGradient id="v2d-suelo" cx="0.5" cy="0.35" r="0.9">
+            <stop offset="0" stopColor={clima === 'noche' ? '#2c4a34' : '#6a9a52'} />
+            <stop offset="1" stopColor={clima === 'noche' ? '#1a3324' : '#4b7a3c'} />
+          </radialGradient>
+        </defs>
+        <rect x="0" y="0" width="400" height="340" fill="url(#v2d-cielo)" />
+        {/* cordillera */}
+        <path d="M0,150 L70,80 L140,140 L210,70 L290,140 L360,90 L400,150 Z"
+          fill={clima === 'noche' ? '#33435c' : c.niebla} opacity="0.85" />
+        {/* piso del valle */}
+        <ellipse cx="200" cy="220" rx="230" ry="130" fill="url(#v2d-suelo)" />
+        {/* quebrada */}
+        <path d="M120,150 C160,180 180,210 200,250 C215,280 240,300 280,320"
+          stroke={clima === 'noche' ? '#2a4a6a' : '#5fb2c9'} strokeWidth="10"
+          fill="none" strokeLinecap="round" opacity="0.8" />
+      </svg>
+
+      {/* mundos como lugares tocables, posicionados sobre la lámina */}
+      <div className="valle2d__mundos">
+        {orden.map((m) => {
+          const { cx, cy } = iso(m.pos[0], m.pos[2]);
+          return (
+            <button key={m.id} type="button"
+              className="valle2d__poi"
+              style={{ left: `${(cx / 400) * 100}%`, top: `${(cy / 340) * 100}%`, '--poi-tinte': m.tinte[0] }}
+              onClick={() => onEntrar(m.id)}
+              aria-label={`Viajar al mundo ${m.titulo}. ${m.lema}`}>
+              <span className="valle2d__emoji" aria-hidden="true">{m.emoji}</span>
+              <span className="valle2d__nombre">{m.titulo}</span>
+            </button>
+          );
+        })}
+
+        {/* la cosa del día: un solo destello, anclado a su lugar */}
+        {ancla && (() => {
+          const { cx, cy } = iso(ancla.pos[0], ancla.pos[2]);
+          return (
+            <button type="button" className="valle2d__alerta"
+              style={{ left: `${(cx / 400) * 100}%`, top: `${((cy - 40) / 340) * 100}%` }}
+              onClick={onAlerta}
+              aria-label={`Alerta del día: ${COSA_DEL_DIA.titulo}. ${COSA_DEL_DIA.detalle}`}>
+              <span aria-hidden="true">⚠️</span> {COSA_DEL_DIA.titulo}
+            </button>
+          );
+        })()}
+      </div>
+
+      {/* el clima tiñe la escena: grade de luz de la librería de efectos */}
+      <div className={`valle2d__grade vfx-grade ${c.grade}`} aria-hidden="true" />
+    </div>
+  );
+}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -1,0 +1,483 @@
+/*
+ * Valle3D — la ESCENA 3D del mockup "El valle de mi finca".
+ *
+ * React-Three-Fiber sobre WebGL 2 (la línea base del DR §2). Se carga PEREZOSO
+ * (React.lazy en EntradaValle3D) para no inflar el bundle base: el chunk de
+ * three/fiber/drei solo baja cuando el equipo SÍ tiene WebGL y entra a la ruta.
+ *
+ * Todo es GEOMETRÍA PROCEDURAL (cero GLTF/HDR remotos) → offline-first y
+ * liviano. Estética "acuarela cálida" (Alba/Sorolla del DR), no neón frío.
+ * Solo se anima transform/opacity-equivalentes (rotación/posición/escala) por
+ * useFrame; `reducedMotion` congela el vaivén a un fotograma digno.
+ *
+ * Los 4 sí-o-sí viven en el espacio:
+ *   · MUNDOS  → landmarks navegables (MundoLugar) con etiqueta accesible.
+ *   · ALERTA  → Beacon pulsante anclado sobre el mundo 'suelo' (la cosa del día).
+ *   · AGENTE  → el Colibrí (visual-lib) flota sobre el foco activo.
+ *   · CLIMA   → luz/niebla/estrellas de la escena salen del estado `clima`.
+ */
+/* Nota: las props de three (position, args, intensity, castShadow, etc.) son
+   válidas en el reconciliador de R3F, no en el DOM — el config de ESLint del
+   repo no activa react/no-unknown-property, así que no requieren disable. */
+import { Suspense, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Html, Float, Stars, OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import * as THREE from 'three';
+import { Colibri } from '../../visual/creatures/Colibri.jsx';
+import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
+
+/* Altura del terreno por (x,z): un valle suave con ladera al fondo (+z) donde
+   suben las terrazas del café. Determinista → los landmarks se posan encima. */
+function alturaTerreno(x, z) {
+  const ladera = Math.max(0, (z + 2) * 0.16);
+  const ondul = Math.sin(x * 0.5) * 0.08 + Math.cos(z * 0.4) * 0.06;
+  const cauce = -0.28 * Math.exp(-((x - 0.6) ** 2) / 5) * Math.exp(-((z + 1) ** 2) / 40);
+  return ladera + ondul + cauce;
+}
+
+/* ── El suelo del valle: malla ondulada de bajo poligonaje, color tierra-verde
+      que se aclara al fondo (perspectiva aérea). ── */
+function Terreno({ colorBase }) {
+  const geo = useMemo(() => {
+    const g = new THREE.PlaneGeometry(30, 30, 48, 48);
+    g.rotateX(-Math.PI / 2);
+    const pos = g.attributes.position;
+    for (let i = 0; i < pos.count; i++) {
+      const x = pos.getX(i);
+      const z = pos.getZ(i);
+      pos.setY(i, alturaTerreno(x, z));
+    }
+    g.computeVertexNormals();
+    return g;
+  }, []);
+  return (
+    <mesh geometry={geo} receiveShadow>
+      <meshStandardMaterial color={colorBase} flatShading roughness={1} metalness={0} />
+    </mesh>
+  );
+}
+
+/* ── La cordillera de páramo al fondo: conos pálidos (perspectiva aérea). ── */
+function Cordillera({ color }) {
+  const picos = useMemo(
+    () => [
+      { x: -8, z: -12, h: 7, r: 5 },
+      { x: -2, z: -14, h: 9, r: 6 },
+      { x: 5, z: -12.5, h: 7.5, r: 5.2 },
+      { x: 11, z: -13, h: 6, r: 4.5 },
+    ],
+    [],
+  );
+  return (
+    <group>
+      {picos.map((p, i) => (
+        <mesh key={i} position={[p.x, p.h / 2 - 0.5, p.z]}>
+          <coneGeometry args={[p.r, p.h, 5]} />
+          <meshStandardMaterial color={color} flatShading roughness={1} opacity={0.9} transparent />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* ── La quebrada: una cinta de agua que serpentea por el cauce. ── */
+function Quebrada({ color, viva }) {
+  const ref = useRef();
+  useFrame((state) => {
+    if (viva && ref.current) {
+      ref.current.material.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 2) * 0.06;
+    }
+  });
+  const geo = useMemo(() => {
+    const curve = new THREE.CatmullRomCurve3([
+      new THREE.Vector3(-6, 0, -6),
+      new THREE.Vector3(-2, 0, -3),
+      new THREE.Vector3(0.6, 0, -1.4),
+      new THREE.Vector3(1.4, 0, 2),
+      new THREE.Vector3(3, 0, 6),
+    ]);
+    const g = new THREE.TubeGeometry(curve, 60, 0.42, 6, false);
+    return g;
+  }, []);
+  return (
+    <mesh geometry={geo} position={[0, 0.02, 0]}>
+      <meshStandardMaterial
+        ref={ref}
+        color={color}
+        transparent
+        opacity={0.78}
+        roughness={0.25}
+        metalness={0.35}
+      />
+    </mesh>
+  );
+}
+
+/* ── Materiales/paletas de cada landmark de mundo, por `tipo`. ── */
+function LandmarkGeom({ tipo, tinte }) {
+  const [fuerte, suave] = tinte;
+  switch (tipo) {
+    case 'milpa': // maíz: cañas altas con penacho
+      return (
+        <group>
+          {[-0.5, 0, 0.5, -0.25, 0.25].map((dx, i) => (
+            <group key={i} position={[dx, 0, (i % 2) * 0.4 - 0.2]}>
+              <mesh position={[0, 0.7, 0]} castShadow>
+                <cylinderGeometry args={[0.05, 0.08, 1.4, 5]} />
+                <meshStandardMaterial color={fuerte} flatShading />
+              </mesh>
+              <mesh position={[0, 1.45, 0]}>
+                <coneGeometry args={[0.12, 0.4, 5]} />
+                <meshStandardMaterial color="#e7c96b" flatShading />
+              </mesh>
+            </group>
+          ))}
+        </group>
+      );
+    case 'cafetal': // arbustos redondos en hilera
+      return (
+        <group>
+          {[-0.6, -0.2, 0.2, 0.6].map((dx, i) => (
+            <mesh key={i} position={[dx, 0.32, (i % 2) * 0.4]} castShadow>
+              <icosahedronGeometry args={[0.34, 0]} />
+              <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+            </mesh>
+          ))}
+        </group>
+      );
+    case 'era': // eras aradas con surcos (semillero)
+      return (
+        <group>
+          {[-0.35, 0, 0.35].map((dz, i) => (
+            <mesh key={i} position={[0, 0.08, dz]} castShadow receiveShadow>
+              <boxGeometry args={[1.3, 0.16, 0.22]} />
+              <meshStandardMaterial color="#5a3d28" flatShading roughness={1} />
+            </mesh>
+          ))}
+          {[-0.35, 0, 0.35].map((dz, i) => (
+            <mesh key={`b${i}`} position={[0, 0.24, dz]}>
+              <boxGeometry args={[1.2, 0.06, 0.14]} />
+              <meshStandardMaterial color={suave} flatShading />
+            </mesh>
+          ))}
+        </group>
+      );
+    case 'quebrada': // nacimiento: charca + juncos
+      return (
+        <group>
+          <mesh position={[0, 0.06, 0]}>
+            <cylinderGeometry args={[0.55, 0.6, 0.12, 16]} />
+            <meshStandardMaterial color="#3a7fa0" transparent opacity={0.85} metalness={0.4} roughness={0.2} />
+          </mesh>
+          {[-0.3, 0.1, 0.4].map((dx, i) => (
+            <mesh key={i} position={[dx, 0.4, 0.2]}>
+              <cylinderGeometry args={[0.03, 0.03, 0.7, 4]} />
+              <meshStandardMaterial color="#4e7d3f" flatShading />
+            </mesh>
+          ))}
+        </group>
+      );
+    case 'corral': // casita + cerca
+      return (
+        <group>
+          <mesh position={[0, 0.35, 0]} castShadow>
+            <boxGeometry args={[0.9, 0.7, 0.8]} />
+            <meshStandardMaterial color={suave} flatShading />
+          </mesh>
+          <mesh position={[0, 0.85, 0]} castShadow>
+            <coneGeometry args={[0.72, 0.5, 4]} rotation={[0, Math.PI / 4, 0]} />
+            <meshStandardMaterial color={fuerte} flatShading />
+          </mesh>
+          {[-0.9, -0.5, 0.9, 1.3].map((dx, i) => (
+            <mesh key={i} position={[dx, 0.2, 0.9]}>
+              <boxGeometry args={[0.06, 0.4, 0.06]} />
+              <meshStandardMaterial color="#8a6a44" flatShading />
+            </mesh>
+          ))}
+        </group>
+      );
+    case 'huerta': // camas elevadas de la huerta
+      return (
+        <group>
+          {[-0.4, 0.4].map((dx, i) => (
+            <group key={i} position={[dx, 0, 0]}>
+              <mesh position={[0, 0.12, 0]} castShadow>
+                <boxGeometry args={[0.6, 0.24, 1]} />
+                <meshStandardMaterial color="#6b4a30" flatShading />
+              </mesh>
+              <mesh position={[0, 0.32, 0]}>
+                <boxGeometry args={[0.5, 0.18, 0.9]} />
+                <meshStandardMaterial color={fuerte} flatShading />
+              </mesh>
+            </group>
+          ))}
+        </group>
+      );
+    case 'bosque': // arboleda: troncos + copas
+      return (
+        <group>
+          {[
+            [-0.5, 0, 0.9],
+            [0.4, 0.2, 1.15],
+            [0, -0.4, 0.8],
+          ].map(([dx, dz, h], i) => (
+            <group key={i} position={[dx, 0, dz]}>
+              <mesh position={[0, h * 0.35, 0]} castShadow>
+                <cylinderGeometry args={[0.09, 0.12, h * 0.7, 6]} />
+                <meshStandardMaterial color="#6b4a2e" flatShading />
+              </mesh>
+              <mesh position={[0, h * 0.8, 0]} castShadow>
+                <coneGeometry args={[0.5, h * 0.9, 7]} />
+                <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+              </mesh>
+            </group>
+          ))}
+        </group>
+      );
+    case 'veleta': // poste con veleta que gira con el viento
+      return <Veleta color={fuerte} />;
+    default:
+      return (
+        <mesh position={[0, 0.3, 0]}>
+          <icosahedronGeometry args={[0.4, 0]} />
+          <meshStandardMaterial color={fuerte} flatShading />
+        </mesh>
+      );
+  }
+}
+
+function Veleta({ color, reducedMotion }) {
+  const ref = useRef();
+  useFrame((state) => {
+    if (ref.current && !reducedMotion) ref.current.rotation.y = state.clock.elapsedTime * 0.4;
+  });
+  return (
+    <group>
+      <mesh position={[0, 0.55, 0]}>
+        <cylinderGeometry args={[0.05, 0.07, 1.1, 6]} />
+        <meshStandardMaterial color="#7c6a4c" flatShading />
+      </mesh>
+      <group ref={ref} position={[0, 1.15, 0]}>
+        <mesh>
+          <boxGeometry args={[0.7, 0.06, 0.06]} />
+          <meshStandardMaterial color={color} flatShading />
+        </mesh>
+        <mesh position={[0.42, 0, 0]}>
+          <coneGeometry args={[0.14, 0.3, 4]} rotation={[0, 0, -Math.PI / 2]} />
+          <meshStandardMaterial color={color} flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* ── Un mundo como LUGAR navegable: su geometría + una etiqueta accesible que,
+      al tocarse, viaja hasta él (la cámara) y lo selecciona. ── */
+function MundoLugar({ mundo, activo, onEntrar, reducedMotion }) {
+  const y = alturaTerreno(mundo.pos[0], mundo.pos[2]);
+  return (
+    <group position={[mundo.pos[0], y, mundo.pos[2]]} scale={mundo.escala}>
+      {mundo.tipo === 'veleta' ? (
+        <Veleta color={mundo.tinte[0]} reducedMotion={reducedMotion} />
+      ) : (
+        <LandmarkGeom tipo={mundo.tipo} tinte={mundo.tinte} />
+      )}
+      <Html center distanceFactor={11} position={[0, 1.7, 0]} zIndexRange={[20, 0]}>
+        <button
+          type="button"
+          className={`valle-poi${activo ? ' valle-poi--activo' : ''}`}
+          style={{ '--poi-tinte': mundo.tinte[0] }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onEntrar(mundo.id);
+          }}
+          aria-label={`Viajar al mundo ${mundo.titulo}. ${mundo.lema}`}
+        >
+          <span className="valle-poi__emoji" aria-hidden="true">{mundo.emoji}</span>
+          <span className="valle-poi__txt">{mundo.titulo}</span>
+        </button>
+      </Html>
+    </group>
+  );
+}
+
+/* ── La cosa del día: un faro pulsante anclado sobre su mundo. Un SOLO destello.
+      Toca la señal → onAlerta() (el agente lo dice y ofrece LA acción). ── */
+function Beacon({ onAlerta, reducedMotion }) {
+  const ancla = MUNDO_VALLE_BY_ID[COSA_DEL_DIA.anclaMundo];
+  const luz = useRef();
+  const halo = useRef();
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const p = (Math.sin(state.clock.elapsedTime * 1.6) + 1) / 2;
+    if (luz.current) luz.current.intensity = 1.4 + p * 2.6;
+    if (halo.current) {
+      const s = 1 + p * 0.5;
+      halo.current.scale.set(s, s, s);
+      halo.current.material.opacity = 0.5 - p * 0.35;
+    }
+  });
+  if (!ancla) return null;
+  const y = alturaTerreno(ancla.pos[0], ancla.pos[2]);
+  return (
+    <group position={[ancla.pos[0], y, ancla.pos[2]]}>
+      <pointLight ref={luz} position={[0, 1.6, 0]} color="#ffd28a" intensity={2.2} distance={7} />
+      <Float speed={reducedMotion ? 0 : 2} floatIntensity={reducedMotion ? 0 : 0.6} rotationIntensity={0}>
+        <mesh position={[0, 1.7, 0]}>
+          <octahedronGeometry args={[0.26, 0]} />
+          <meshStandardMaterial color="#ffd88f" emissive="#ffb24d" emissiveIntensity={1.4} flatShading />
+        </mesh>
+        <mesh ref={halo} position={[0, 1.7, 0]}>
+          <sphereGeometry args={[0.5, 16, 16]} />
+          <meshBasicMaterial color="#ffcf87" transparent opacity={0.4} />
+        </mesh>
+      </Float>
+      <Html center distanceFactor={10} position={[0, 2.7, 0]} zIndexRange={[30, 0]}>
+        <button
+          type="button"
+          className="valle-alerta"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAlerta();
+          }}
+          aria-label={`Alerta del día: ${COSA_DEL_DIA.titulo}. ${COSA_DEL_DIA.detalle}`}
+        >
+          <span className="valle-alerta__icono" aria-hidden="true">⚠️</span>
+          <span className="valle-alerta__txt">{COSA_DEL_DIA.titulo}</span>
+        </button>
+      </Html>
+    </group>
+  );
+}
+
+/* ── El compañero: el colibrí (visual-lib) flota sobre el foco activo y es la
+      cara del agente. Reusa el SVG canónico de creatures. ── */
+function CompaneroColibri({ foco, reducedMotion }) {
+  const ref = useRef();
+  useFrame((state) => {
+    if (!ref.current) return;
+    const t = state.clock.elapsedTime;
+    const bob = reducedMotion ? 0 : Math.sin(t * 2) * 0.15;
+    ref.current.position.lerp(
+      new THREE.Vector3(foco.x + 0.9, foco.y + 2.2 + bob, foco.z + 0.6),
+      0.05,
+    );
+  });
+  return (
+    <group ref={ref} position={[foco.x + 0.9, foco.y + 2.2, foco.z + 0.6]}>
+      <Html center distanceFactor={9} zIndexRange={[40, 10]}>
+        <div className="valle-colibri" aria-hidden="true">
+          <Colibri size={54} animated={!reducedMotion} />
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+/* ── Cámara: viaja suavemente hacia el foco (target) cuando cambia de mundo;
+      en reposo, deriva muy lento (auto-rotación calma). ── */
+function CamaraViajera({ foco, controls, autoOrbit }) {
+  useFrame(() => {
+    if (!controls.current) return;
+    controls.current.target.lerp(new THREE.Vector3(foco.x, foco.y + 0.6, foco.z), 0.06);
+    controls.current.update();
+  });
+  return (
+    <OrbitControls
+      ref={controls}
+      makeDefault
+      enablePan={false}
+      enableZoom
+      minDistance={6}
+      maxDistance={22}
+      minPolarAngle={0.5}
+      maxPolarAngle={1.15}
+      autoRotate={autoOrbit}
+      autoRotateSpeed={0.35}
+      enableDamping
+      dampingFactor={0.08}
+    />
+  );
+}
+
+/* ── Contenido de la escena (dentro del Canvas). ── */
+function Escena({ clima, focoId, onEntrar, onAlerta, reducedMotion }) {
+  const controls = useRef();
+  const c = CLIMAS[clima];
+  const foco = useMemo(() => {
+    const m = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;
+    if (!m) return new THREE.Vector3(0, 0.3, 0.5);
+    const y = alturaTerreno(m.pos[0], m.pos[2]);
+    return new THREE.Vector3(m.pos[0], y, m.pos[2]);
+  }, [focoId]);
+  const autoOrbit = !reducedMotion && !focoId;
+
+  return (
+    <>
+      <color attach="background" args={[c.cielo[1]]} />
+      <fog attach="fog" args={[c.niebla, 9, c.nieblaLejos]} />
+      <hemisphereLight intensity={c.intensidad * 0.55} color={c.cielo[0]} groundColor={c.ambiente} />
+      <ambientLight intensity={c.intensidad * 0.35} color={c.luz} />
+      <directionalLight
+        position={[6, 9, 4]}
+        intensity={c.intensidad}
+        color={c.luz}
+        castShadow
+        shadow-mapSize={[1024, 1024]}
+        shadow-camera-far={30}
+        shadow-camera-left={-12}
+        shadow-camera-right={12}
+        shadow-camera-top={12}
+        shadow-camera-bottom={-12}
+      />
+      {c.estrellas && (
+        <Stars radius={40} depth={20} count={900} factor={3} fade speed={reducedMotion ? 0 : 1} />
+      )}
+
+      <Terreno colorBase={clima === 'noche' ? '#22432f' : '#5a8a4a'} />
+      <Cordillera color={clima === 'noche' ? '#3a4a63' : c.niebla} />
+      <Quebrada color={clima === 'noche' ? '#2a4a6a' : '#5fb2c9'} viva={c.lluviaViva} />
+
+      {MUNDOS_VALLE.map((m) => (
+        <MundoLugar
+          key={m.id}
+          mundo={m}
+          activo={focoId === m.id}
+          onEntrar={onEntrar}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+
+      <Beacon onAlerta={onAlerta} reducedMotion={reducedMotion} />
+      <CompaneroColibri foco={foco} reducedMotion={reducedMotion} />
+
+      <CamaraViajera foco={foco} controls={controls} autoOrbit={autoOrbit} />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+export default function Valle3D({ clima, focoId, onEntrar, onAlerta, reducedMotion }) {
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`valle-canvas${listo ? ' valle-canvas--listo' : ''}`}
+      shadows
+      dpr={[1, 1.8]}
+      gl={{ antialias: true, powerPreference: 'high-performance' }}
+      camera={{ position: [9, 8, 11], fov: 42 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Suspense fallback={null}>
+        <Escena
+          clima={clima}
+          focoId={focoId}
+          onEntrar={onEntrar}
+          onAlerta={onAlerta}
+          reducedMotion={reducedMotion}
+        />
+      </Suspense>
+    </Canvas>
+  );
+}

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -1,0 +1,170 @@
+/*
+ * DATOS DE MUESTRA del mockup "El valle de mi finca" (#/mockups/entrada-3d).
+ *
+ * NO cablea sesión, farmOS ni Open-Meteo: es una DECISIÓN VISUAL. Todo lo de
+ * aquí es plausible para una finca andina (~2.400 m) pero inventado con cuidado
+ * para la demo. Si algún día se productiza, estos datos vienen del backend.
+ *
+ * Los 4 "sí-o-sí" de la entrada de Chagra viven en el ESPACIO del valle:
+ *   1. ALERTA / qué-hacer-hoy  → `COSA_DEL_DIA`, anclada sobre un lugar real.
+ *   2. LOS MUNDOS              → `MUNDOS_VALLE`: cada mundo es un LUGAR con
+ *                                coordenadas 3D por el que se viaja.
+ *   3. AGENTE / VOZ            → `NARRACION`: lo que el compañero dice al pasar.
+ *   4. ESTADO / CLIMA          → `CLIMAS`: tiñe el ambiente (grades de effects).
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- mockup dev con datos de
+   muestra (no UI de producto); si se productiza, el copy migra a messages.js
+   (ADR-050). */
+
+import { MUNDO_BY_ID } from '../../components/dashboard/mundosFinca';
+
+/* ── 2. LOS MUNDOS COMO LUGARES ─────────────────────────────────────────────
+ * Un subconjunto curado de los mundos reales (mundosFinca.js) colocados en el
+ * valle. `pos` = [x, y, z] en el terreno; `escala` y `tipo` deciden qué forma
+ * procedural los representa (sin GLTF: todo es geometría de three, offline y
+ * liviana). El título/emoji/tinte se LEEN del manifiesto real — no se duplican.
+ */
+const LUGARES = [
+  { id: 'cultivos', pos: [-3.2, 0, 1.6], escala: 1.15, tipo: 'milpa' },
+  { id: 'cafe', pos: [3.4, 0, 2.2], escala: 1, tipo: 'cafetal' },
+  { id: 'suelo', pos: [-1.1, 0, 3.6], escala: 1, tipo: 'era' },
+  { id: 'agua', pos: [0.6, 0, -1.4], escala: 1, tipo: 'quebrada' },
+  { id: 'animales', pos: [-4.6, 0, -1.8], escala: 1, tipo: 'corral' },
+  { id: 'sanidad', pos: [1.8, 0, 4.4], escala: 0.95, tipo: 'huerta' },
+  { id: 'disenio', pos: [4.8, 0, -2.6], escala: 1.1, tipo: 'bosque' },
+  { id: 'clima', pos: [-3.8, 0, -4.8], escala: 1, tipo: 'veleta' },
+];
+
+/**
+ * Mundos del valle, ya resueltos contra el manifiesto real. Cada uno trae su
+ * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar.
+ */
+export const MUNDOS_VALLE = LUGARES.map((l) => {
+  const real = MUNDO_BY_ID[l.id] || {};
+  return {
+    ...l,
+    titulo: real.titulo || l.id,
+    emoji: real.emoji || '📍',
+    lema: real.lema || '',
+    tinte: real.tinte || ['#3f8f4e', '#dcedc9'],
+  };
+});
+
+export const MUNDO_VALLE_BY_ID = Object.fromEntries(
+  MUNDOS_VALLE.map((m) => [m.id, m]),
+);
+
+/* ── 1. LA COSA DEL DÍA (una sola, anclada a un lugar) ───────────────────────
+ * Un único destello: la alerta del día aparece DONDE toca. Aquí, una helada
+ * nocturna sobre el semillero (el mundo 'suelo'/eras). Tocarla = el agente lo
+ * dice en voz alta y ofrece LA acción (no un tablero).
+ */
+export const COSA_DEL_DIA = {
+  anclaMundo: 'suelo',
+  tono: 'helada',
+  titulo: 'Helada esta noche',
+  detalle:
+    'En la parte alta puede helar de madrugada. Cubra el semillero antes de que caiga el sol.',
+  vozTexto:
+    'Ojo con la finca hoy: esta madrugada puede helar en la parte alta. Cúbrale el semillero antes de que caiga el sol, que el frío le quema la matica tierna.',
+  accion: { etiqueta: 'Ver cómo proteger del frío', view: 'hoy_finca' },
+};
+
+/* ── 4. EL CLIMA QUE TIÑE EL AMBIENTE ────────────────────────────────────────
+ * Reusa las grades de luz de la librería de efectos (src/visual/effects):
+ * `grade` = clase modificadora .vfx-grade--* aplicada a un velo DOM sobre el
+ * canvas; `cielo`/`luz`/`niebla` alimentan la iluminación de la escena 3D.
+ * Una sola geometría, varias "pieles" según el estado real de la vereda.
+ */
+export const CLIMAS = {
+  dorada: {
+    etiqueta: 'Hora dorada',
+    grade: 'vfx-grade--templado',
+    cielo: ['#f7c66b', '#e88a4a'],
+    luz: '#ffd79a',
+    ambiente: '#8a6b4a',
+    niebla: '#f0c98d',
+    nieblaLejos: 30,
+    intensidad: 1.15,
+    estrellas: false,
+  },
+  soleado: {
+    etiqueta: 'Soleado',
+    grade: 'vfx-grade--calido',
+    cielo: ['#8fd0e8', '#d7eef6'],
+    luz: '#fff4d6',
+    ambiente: '#9fb6a0',
+    niebla: '#d7eef6',
+    nieblaLejos: 38,
+    intensidad: 1.35,
+    estrellas: false,
+  },
+  niebla: {
+    etiqueta: 'Niebla',
+    grade: 'vfx-grade--paramo',
+    cielo: ['#b9c7cc', '#d7dee0'],
+    luz: '#cdd8da',
+    ambiente: '#8f9ea1',
+    niebla: '#c3cfd2',
+    nieblaLejos: 15,
+    intensidad: 0.85,
+    estrellas: false,
+  },
+  lluvia: {
+    etiqueta: 'Lluvia',
+    grade: 'vfx-grade--frio',
+    cielo: ['#5b6b74', '#8a99a0'],
+    luz: '#aab6bc',
+    ambiente: '#6c7a80',
+    niebla: '#7d8a90',
+    nieblaLejos: 20,
+    intensidad: 0.7,
+    lluviaViva: true,
+    estrellas: false,
+  },
+  noche: {
+    etiqueta: 'Noche',
+    grade: 'vfx-grade--glacial',
+    cielo: ['#0b1830', '#132a4e'],
+    luz: '#9fc2e8',
+    ambiente: '#26364f',
+    niebla: '#13203a',
+    nieblaLejos: 22,
+    intensidad: 0.5,
+    estrellas: true,
+  },
+};
+
+export const ORDEN_CLIMA = ['dorada', 'soleado', 'niebla', 'lluvia', 'noche'];
+
+/**
+ * Estado por defecto según la hora REAL del dispositivo (ancla de veracidad,
+ * como Apple Weather): madrugada/noche → noche; media mañana → soleado; tarde
+ * → hora dorada. Un dato verdadero, no decoración inventada.
+ */
+export function climaPorHora(fecha = new Date()) {
+  const h = fecha.getHours();
+  if (h >= 19 || h < 5) return 'noche';
+  if (h >= 16) return 'dorada';
+  if (h >= 11) return 'soleado';
+  return 'dorada';
+}
+
+/* ── 3. LO QUE EL AGENTE DICE AL PASAR ───────────────────────────────────────
+ * El compañero (colibrí) narra el mundo cuando la cámara viaja hacia él. Texto
+ * corto, cálido, en usted; se lee por voz (Web Speech API) si el equipo la trae.
+ */
+export const NARRACION = {
+  bienvenida:
+    'Bienvenido a su finca. Toque un lugar del valle para viajar hasta él, o toque la señal que brilla para saber qué toca hacer hoy.',
+  cultivos:
+    'Aquí está su milpa: maíz, fríjol y calabaza creciendo juntos como las tres hermanas.',
+  cafe: 'El cafetal en la ladera. Estas maticas ya están cargando para la próxima cosecha.',
+  suelo: 'Las eras y el semillero. La tierra de aquí es la que pide cuidado esta noche.',
+  agua: 'La quebrada que baja del monte. De aquí sale el agua para toda la finca.',
+  animales: 'El corral. Las gallinas y el ganado que cierran el ciclo del abono.',
+  sanidad:
+    'La huerta de la casa. Aquí es donde primero se ven las plagas, para atajarlas a tiempo.',
+  disenio: 'El monte y los árboles que sembró. La finca también es el bosque que la abraza.',
+  clima: 'Desde aquí se lee el cielo: lo que viene, y qué conviene hacer con la finca.',
+};

--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,0 +1,62 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Colibrí chillón — Colibri coruscans (nativo de los Andes). Pico largo y
+   recto, garganta violeta iridiscente, alas que baten. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-22 -28 58 52';
+
+export function Colibri({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Colibrí',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#2dffc4" opacity="0.35" filter={`url(#${blur})`} />
+      <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
+      <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
+      <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
+      <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
+      <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
+      <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
+      <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+      <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <path className={wing} d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
+      <path className={wing} style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="colibri">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="colibri" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Colibri;

--- a/src/visual/creatures/_filters.jsx
+++ b/src/visual/creatures/_filters.jsx
@@ -1,0 +1,23 @@
+/*
+ * Filtro SVG compartido de la familia visual "creatures": glow orgánico
+ * (feGaussianBlur + feMerge) heredado de GuardianEspiritu + blur suave.
+ * Cada criatura instancia estos filtros con ids ÚNICOS (useId) para poder
+ * repetirse muchas veces en una misma página sin colisión de ids.
+ * Interno de la librería — no se exporta desde el barrel.
+ */
+export function CreatureFilters({ glow, blur }) {
+  return (
+    <>
+      <filter id={glow} x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.1" result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      <filter id={blur}>
+        <feGaussianBlur stdDeviation="3" />
+      </filter>
+    </>
+  );
+}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1,0 +1,51 @@
+/* ─── Vida perpetua de las CREATURES — SVG + CSS puros, solo transform/opacity
+   (GPU, Android gama baja). Reutilizable en cualquier escena o avatar.
+   La coreografía de LLEGADA (entrar volando, asomar del suelo) NO vive aquí:
+   es responsabilidad de la escena que consume la criatura.
+   reduced-motion = criatura quieta en un fotograma digno. ─── */
+
+/* aleteo rápido (abeja / colibrí) */
+.crt-wing {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: crt-wingbeat 0.13s ease-in-out infinite alternate;
+}
+@keyframes crt-wingbeat {
+  0% { transform: scaleY(1) scaleX(1); }
+  100% { transform: scaleY(0.6) scaleX(0.9); }
+}
+
+/* alas de mariposa que abren y cierran */
+.crt-fwing {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-flutter 0.5s ease-in-out infinite;
+}
+.crt-fwing-l { transform-origin: right center; }
+.crt-fwing-r { transform-origin: left center; }
+@keyframes crt-flutter {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.4); }
+}
+
+/* bola de abono que rueda (escarabajo) */
+.crt-ball {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-roll 1.1s linear infinite;
+}
+@keyframes crt-roll {
+  0% { transform: rotate(0); }
+  100% { transform: rotate(-360deg); }
+}
+
+/* patas que dan pasos (escarabajo) */
+.crt-legs { animation: crt-step 0.5s ease-in-out infinite; }
+@keyframes crt-step {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-1.2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crt-wing, .crt-fwing, .crt-ball, .crt-legs { animation: none !important; }
+}

--- a/src/visual/effects/effects.css
+++ b/src/visual/effects/effects.css
@@ -1,0 +1,190 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   src/visual/effects/effects.css — EFECTOS visuales reutilizables de Chagra.
+
+   Las TÉCNICAS DE CINE del catálogo (§13) que hoy están redibujadas/re-copiadas
+   en varios mockups y escenas, aquí una sola vez como clases `vfx-*` + custom
+   properties `--vfx-*`. Antes de re-hilvanar un velo/viñeta/grade/latido/trazo,
+   use esto.
+
+   Reglas de la casa respetadas:
+   · Solo `transform`/`opacity` animados; blur/filtros ESTÁTICOS (Android gama baja).
+   · `prefers-reduced-motion` = fotograma final digno (nada roto, nada en loop).
+   · Cero dependencias; cero JS por frame.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Base de las capas-overlay ───────────────────────────────────────────────
+   Todos los velos/viñetas/scrims/grades se montan como una capa absoluta dentro
+   de un contenedor `position: relative`. No capturan toque. Heredan el radio del
+   contenedor para no desbordar tarjetas redondeadas. */
+.vfx-overlay,
+.vfx-veil,
+.vfx-vignette,
+.vfx-scrim-top,
+.vfx-scrim-bottom,
+.vfx-grade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+/* ── 1. VELO atmosférico neón (§13.5 / §13.16) ──────────────────────────────
+   El velo radial teal/orquídea + tinte navy del modo biopunk (receta de
+   finca-viva-hero `.fvh-escena-wrap::after`). Tunéable por custom props para
+   re-teñir sin reescribir el gradiente. Los temas claros lo apagan poniendo
+   `--vfx-veil-opacity: 0`. */
+.vfx-veil {
+  z-index: 6;
+  opacity: var(--vfx-veil-opacity, 1);
+  background:
+    radial-gradient(120% 78% at 80% 12%, var(--vfx-veil-a, rgba(34, 211, 238, 0.26)), transparent 56%),
+    radial-gradient(110% 92% at 16% 92%, var(--vfx-veil-b, rgba(217, 70, 239, 0.22)), transparent 58%),
+    linear-gradient(180deg,
+      var(--vfx-veil-top, rgba(8, 16, 34, 0.42)) 0%,
+      rgba(8, 16, 34, 0.08) 40%,
+      var(--vfx-veil-bottom, rgba(10, 22, 44, 0.36)) 100%);
+  transition: opacity 0.5s ease;
+}
+
+/* ── 2. VIÑETA de cine (§13.5) ───────────────────────────────────────────────
+   Radial que hunde las esquinas para enfocar el centro y que la UI flote sin
+   cajas. `--vfx-vignette-strength` (0..1) modula cuánto oscurece el borde. */
+.vfx-vignette {
+  z-index: 7;
+  background: radial-gradient(120% 120% at 50% 45%,
+    transparent 52%,
+    rgba(0, 0, 0, calc(0.35 * var(--vfx-vignette-strength, 1))) 100%);
+}
+
+/* ── 3. SCRIMS arriba/abajo (§13.5) ──────────────────────────────────────────
+   Degradados en los bordes superior/inferior para que el texto SIEMPRE lea
+   sobre la escena (títulos arriba, compositor abajo). */
+.vfx-scrim-top {
+  z-index: 7;
+  background: linear-gradient(180deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 28%);
+  inset: 0 0 auto 0;
+}
+.vfx-scrim-bottom {
+  z-index: 7;
+  background: linear-gradient(0deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 34%);
+  inset: auto 0 0 0;
+}
+
+/* ── 4. GRADES de luz por PISO TÉRMICO (§13.2) ───────────────────────────────
+   Plano de color fijo al viewport, crossfade por opacity: la TEMPERATURA de la
+   luz cuenta la altura. Azul glacial (nevado) → cian páramo → neutro frío →
+   HORA DORADA (finca templada) → ámbar cálido → turquesa río. Portado de los
+   `--mm2-*` del mockup Montaña (§13.2), tokenizado para promoverse a prod.
+   `--vfx-grade-fuerza` modula la intensidad por dirección artística
+   (naturalista 1 · biopunk 0.45 · verde-vivo 0.75). */
+:root {
+  --vfx-piso-glacial:  rgba(180, 214, 240, 0.50); /* nevado 4.800m */
+  --vfx-piso-paramo:   rgba(120, 200, 210, 0.42); /* páramo */
+  --vfx-piso-frio:     rgba(150, 165, 172, 0.28); /* frío (neutro) */
+  --vfx-piso-templado: rgba(255, 200, 120, 0.34); /* finca ⭐ hora dorada */
+  --vfx-piso-calido:   rgba(255, 170,  90, 0.36); /* cálido ámbar */
+  --vfx-piso-valle:    rgba( 90, 200, 190, 0.40); /* río turquesa 400m */
+}
+.vfx-grade {
+  z-index: 5;
+  background: var(--vfx-grade-color, var(--vfx-piso-templado));
+  opacity: var(--vfx-grade-fuerza, 1);
+  transition: background 0.6s ease, opacity 0.6s ease;
+}
+.vfx-grade--glacial  { --vfx-grade-color: var(--vfx-piso-glacial); }
+.vfx-grade--paramo   { --vfx-grade-color: var(--vfx-piso-paramo); }
+.vfx-grade--frio     { --vfx-grade-color: var(--vfx-piso-frio); }
+.vfx-grade--templado { --vfx-grade-color: var(--vfx-piso-templado); }
+.vfx-grade--calido   { --vfx-grade-color: var(--vfx-piso-calido); }
+.vfx-grade--valle    { --vfx-grade-color: var(--vfx-piso-valle); }
+
+/* ── 5. PULSO CARDÍACO compartido (§13.10) ───────────────────────────────────
+   Una sola variable de duración (`--vfx-beat`) sincroniza TODO lo vivo: la
+   escena late como UN organismo. Es el `--fvo-beat` de SceneFincaOrganismo,
+   promovido a la librería (mismo valor 5.2s = `--motion-beat`). */
+:root { --vfx-beat: 5.2s; }
+
+/* el corazón: doble pulso como corazón real */
+.vfx-beat {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat var(--vfx-beat) ease-in-out infinite;
+}
+@keyframes vfx-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+/* onda que sale del latido */
+.vfx-beat-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat-wave var(--vfx-beat) ease-out infinite;
+}
+@keyframes vfx-beat-wave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red/savia/panel se ENCIENDE con cada latido (solo opacity) */
+.vfx-beat-glow { animation: vfx-beat-glow var(--vfx-beat) ease-in-out infinite; }
+@keyframes vfx-beat-glow {
+  0%, 100% { opacity: 0.55; }
+  8% { opacity: 1; }
+  16% { opacity: 0.7; }
+  22% { opacity: 0.9; }
+  34% { opacity: 0.55; }
+}
+
+/* ── 6. AUTO-DIBUJADO orquestado (§13.11) ────────────────────────────────────
+   `pathLength="1"` normalizado + stroke-dashoffset → 0 + etapas escalonadas.
+   El trazo/grafo/glifo se dibuja solo al entrar. (Receta de SceneTrazoMinimal;
+   el componente `AutoDibujo` pega estas clases y pone `pathLength`.) */
+.vfx-draw {
+  stroke-dasharray: 1 1;
+  stroke-dashoffset: 1;
+  animation: vfx-draw 1.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+@keyframes vfx-draw { to { stroke-dashoffset: 0; } }
+
+/* planos de color que aparecen en fundido (sol, leyenda, humo) */
+.vfx-fade { opacity: 0; animation: vfx-fade 1.1s ease forwards; }
+@keyframes vfx-fade { to { opacity: 1; } }
+
+/* etapas del dibujo — delay heredado por trazos y fundidos del grupo */
+.vfx-t1 .vfx-draw, .vfx-t1.vfx-draw, .vfx-t1 .vfx-fade, .vfx-t1.vfx-fade { animation-delay: 0.15s; }
+.vfx-t2 .vfx-draw, .vfx-t2.vfx-draw, .vfx-t2 .vfx-fade, .vfx-t2.vfx-fade { animation-delay: 0.40s; }
+.vfx-t3 .vfx-draw, .vfx-t3.vfx-draw, .vfx-t3 .vfx-fade, .vfx-t3.vfx-fade { animation-delay: 0.70s; }
+.vfx-t4 .vfx-draw, .vfx-t4.vfx-draw, .vfx-t4 .vfx-fade, .vfx-t4.vfx-fade { animation-delay: 0.95s; }
+.vfx-t5 .vfx-draw, .vfx-t5.vfx-draw, .vfx-t5 .vfx-fade, .vfx-t5.vfx-fade { animation-delay: 1.20s; }
+.vfx-t6 .vfx-draw, .vfx-t6.vfx-draw, .vfx-t6 .vfx-fade, .vfx-t6.vfx-fade { animation-delay: 1.50s; }
+.vfx-t7 .vfx-draw, .vfx-t7.vfx-draw, .vfx-t7 .vfx-fade, .vfx-t7.vfx-fade { animation-delay: 1.80s; }
+.vfx-t8 .vfx-draw, .vfx-t8.vfx-draw, .vfx-t8 .vfx-fade, .vfx-t8.vfx-fade { animation-delay: 2.10s; }
+.vfx-t9 .vfx-draw, .vfx-t9.vfx-draw, .vfx-t9 .vfx-fade, .vfx-t9.vfx-fade { animation-delay: 2.50s; }
+
+/* ── 7. FLUJO por dash (§13.12) ──────────────────────────────────────────────
+   Savia/agua/corriente/micelio: dasharray animado que corre por el trazo.
+   `--vfx-flow-dur` y `--vfx-flow-len` tunéan velocidad y avance. */
+.vfx-flow {
+  stroke-dasharray: 4 8;
+  animation: vfx-flow var(--vfx-flow-dur, 3.2s) linear infinite;
+}
+@keyframes vfx-flow { to { stroke-dashoffset: calc(-1 * var(--vfx-flow-len, 40px)); } }
+
+/* ── prefers-reduced-motion: fotograma final digno ───────────────────────────
+   Nada en loop; el dibujo COMPLETO, los planos visibles, velos/grades/viñeta
+   quietos (son estáticos de por sí). Regla de la casa §13.20. */
+@media (prefers-reduced-motion: reduce) {
+  .vfx-beat, .vfx-beat-wave, .vfx-beat-glow, .vfx-flow { animation: none !important; }
+  .vfx-beat, .vfx-beat-glow { opacity: 1; }
+  .vfx-beat-wave { opacity: 0; }              /* la onda no deja residuo */
+  .vfx-draw { animation: none !important; stroke-dashoffset: 0; }
+  .vfx-fade { animation: none !important; opacity: 1; }
+  .vfx-veil { transition: none; }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -87,6 +87,12 @@ export default defineConfig({
           if (id.includes('node_modules/lucide-react')) {
             return 'vendor-icons';
           }
+          // three / @react-three (fiber + drei): SOLO lo usa el mockup 3D
+          // (#/mockups/entrada-3d), cargado perezoso. Agruparlo en un chunk
+          // aparte lo mantiene fuera del bundle base y cacheable por sí solo.
+          if (id.includes('node_modules/three') || id.includes('node_modules/@react-three')) {
+            return 'vendor-three';
+          }
         },
       },
     },


### PR DESCRIPTION
## Qué es

La **entrada definitiva de Chagra, dirección #2 (sin límites)** del DR `DR-ENTRADA-DEFINITIVA-2026-07-10`: un **diorama 3D isométrico navegable** del valle de la finca donde los 4 sí-o-sí viven en el **espacio**, no en un menú. "Bruno Simon, pero es su finca y sí sirve": spatial UI grounded con propósito, no wow vacío.

Ruta: **`#/mockups/entrada-3d`** — sin gate, sin sesión, datos de muestra (decisión visual pura).

## Los 4 sí-o-sí, anclados en el valle

- **Alerta / qué-hacer-hoy** → un **solo faro pulsante** sobre el lugar donde toca (el semillero). Tocarlo: el agente lo dice por voz y ofrece **la** acción.
- **Los mundos** → cada mundo (fuente real `mundosFinca.js`) es un **lugar** del valle al que la cámara **viaja**; landmark procedural + etiqueta accesible.
- **Agente / voz** → el **colibrí** (reusado de `src/visual`) flota sobre el foco y **narra por voz** (Web Speech API) al pasar.
- **Estado / clima** → el estado real por hora **tiñe** luz, niebla, cielo y estrellas de la escena 3D + un **grade DOM** reusado de la librería de efectos.

## Stack (DR §2)

- **React-Three-Fiber sobre WebGL 2** (línea base). WebGPU sería mejora opcional, nunca requisito.
- **Lazy-load + code-split**: la escena 3D y `three`/`@react-three` van en chunks propios (`vendor-three`, ~233 kB gzip) **fuera del bundle base** — el `index` no crece.
- **Degrada limpio** a una entrada digna en SVG+CSS (`Valle2DFallback`) cuando no hay WebGL, con los mismos 4 sí-o-sí.
- **Offline-first**: todo procedural, cero GLTF/HDR/fuentes remotas.

## Reuso

- `src/visual/creatures/Colibri` (compañero) y `src/visual/effects/effects.css` (grades de luz por clima). *Vendorizados aquí porque `feat/visual-lib-*` aún no está en main; solo los archivos importados.*
- `MUNDOS_FINCA` real (`mundosFinca.js`) como fuente de los mundos.

## Verificación

- `npm run build` ✅ verde. Base `index` sin cambios (293 kB); `vendor-three` aislado y async.
- `eslint` ✅ (lefthook pre-commit verde: secret-scan, voseo-scan, strategic-content-scan).
- **Sin Playwright / sin alpha.** Copy en español Colombia (usted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)