### PR TITLE
feat(mockup): el agente enseña dibujando — lámina que se dibuja sola

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,6 +107,9 @@ const CompostScreen = lazy(() => import('./components/CompostScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const OnboardingCondensado = lazy(() => import('./components/OnboardingCondensado'));
+// Galería de mockups (diseño): rutas públicas `#/mockups/<slug>`, sin auth ni
+// gate, datos de muestra. No cuentan como módulo de piloto. Ver MOCKUP_HASH_ROUTES.
+const EnsenaDibujandoMockup = lazy(() => import('./mockups/EnsenaDibujando'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const PlantaPorVozScreen = lazy(() => import('./components/PlantaPorVozScreen'));
@@ -416,6 +419,15 @@ const LoadingFallback = ({ view = null }) => {
 // viva (HERRAMIENTAS_TILES en DashboardLive). Las rutas `casos`/`caso_detail`/
 // `javier`/`usage_stats` siguen vivas en el router (más abajo) y por hash.
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
+
+// Rutas de MOCKUP de diseño (galería): PÚBLICAS — sin auth ni gate, datos de
+// muestra. Se resuelven ANTES del check de sesión (igual que el callback OAuth),
+// para que una lámina se pueda revisar sin cuenta. Patrón `#/mockups/<slug>` (el
+// hash se normaliza a `mockups/<slug>`). No entran en HASH_VIEW_ROUTES para dejar
+// explícito que NO pasan por los gates de sesión/rol.
+const MOCKUP_HASH_ROUTES = {
+  'mockups/ensena-dibujando': 'mockup_ensena_dibujando',
+};
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
@@ -915,6 +927,14 @@ export default function App() {
       return;
     }
 
+    // Mockups de diseño: públicos, sin auth. Se resuelven antes de
+    // isAuthenticated para que la galería (#/mockups/<slug>) abra sin cuenta.
+    const mockupView = MOCKUP_HASH_ROUTES[hash];
+    if (mockupView) {
+      Promise.resolve().then(() => navigate(mockupView));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -941,6 +961,12 @@ export default function App() {
   useEffect(() => {
     const handleHashRoute = () => {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
+      // Mockups públicos: navegar directo, sin pasar por auth ni gates.
+      const mockupView = MOCKUP_HASH_ROUTES[hash];
+      if (mockupView) {
+        navigate(mockupView);
+        return;
+      }
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
@@ -2487,6 +2513,17 @@ export default function App() {
                 onNavigate={navigate}
                 initialContext={currentViewData}
               />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_ensena_dibujando':
+        // Mockup de galería (público, datos de muestra): el agente responde con
+        // una LÁMINA que se dibuja sola (asociación / rotación / piso térmico)
+        // en vez de un párrafo. Ruta #/mockups/ensena-dibujando.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El agente enseña dibujando">
+              <EnsenaDibujandoMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/EnsenaDibujando.jsx
+++ b/src/mockups/EnsenaDibujando.jsx
@@ -1,0 +1,159 @@
+/*
+ * i18n (ADR-050): copy de campo en español Colombia (usted). Es un MOCKUP de
+ * galería con datos de muestra, sin gate ni auth; el copy final migraría a
+ * src/config/messages.js — mismo criterio que los otros mockups de la galería.
+ */
+import { useState } from 'react';
+import { ArrowLeft, RotateCcw, Sprout } from 'lucide-react';
+import LaminaMilpa from './laminas/LaminaMilpa.jsx';
+import LaminaRotacion from './laminas/LaminaRotacion.jsx';
+import LaminaPisoTermico from './laminas/LaminaPisoTermico.jsx';
+import '../visual/effects/effects.css';
+import './ensena-dibujando.css';
+
+/**
+ * EnsenaDibujando — MOONSHOT "el agente enseña dibujando".
+ *
+ * En vez de responder con un párrafo, el agente RESPONDE CON UNA LÁMINA que se
+ * dibuja sola frente al campesino, más dos o tres frases en habla de campo. El
+ * campesino pregunta ("¿por qué siembro el maíz con el frijol?") y ve nacer el
+ * dibujo: la milpa, la rotación de la era, o el piso térmico de su montaña.
+ *
+ * Reusa la librería de EFECTOS (`src/visual/effects`, auto-dibujado AutoDibujo +
+ * effects.css) y la casa de láminas de cuaderno de campo. El auto-dibujado se
+ * re-dispara al re-montar la lámina (cambiar de concepto o "dibujar otra vez").
+ *
+ * Dirección educativa de Chagra: se enseña a OBSERVAR, no a ganar puntos. Cada
+ * respuesta cierra invitando a mirar la mata, no a subir de nivel. Sin
+ * gamificación, sin medallas. Tono usted colombiano.
+ *
+ * Ruta pública `#/mockups/ensena-dibujando` (sin auth, datos de muestra).
+ *
+ * @param {Object} props
+ * @param {Function} [props.onBack] volver al dashboard.
+ */
+
+// Los tres conceptos de muestra. `pregunta` es lo que teclea/dice el campesino;
+// el agente responde con la `Lamina` (se dibuja sola) + `frases` + `observa`.
+const CONCEPTOS = [
+  {
+    id: 'asociacion',
+    chip: 'Asociación',
+    pregunta: '¿Por qué me dicen que siembre el maíz junto con el frijol?',
+    titulo: 'La milpa: tres que se ayudan',
+    Lamina: LaminaMilpa,
+    frases: [
+      'El maíz crece derecho y alto: le sirve de tutor al frijol para que trepe sin necesidad de vara.',
+      'El frijol, en sus raíces, agarra el nitrógeno del aire y se lo devuelve a la tierra que el maíz gasta.',
+      'La calabaza, con sus hojas anchas, tapa el suelo: guarda la humedad y no deja crecer la maleza.',
+    ],
+    observa: 'Fíjese cómo el frijol busca el tallo del maíz para subir. Esa sociedad la lleva haciendo la milpa desde hace siglos.',
+  },
+  {
+    id: 'rotacion',
+    chip: 'Rotación',
+    pregunta: 'Ya coseché el tomate en esta era, ¿qué siembro ahora ahí?',
+    titulo: 'La rotación: cambie de familia',
+    Lamina: LaminaRotacion,
+    frases: [
+      'No repita la misma familia en la era: cada cultivo le pide y le devuelve algo distinto al suelo.',
+      'Detrás de una de hoja o de fruto, que gastan mucho, siembre una leguminosa (fríjol, haba): esa repone el nitrógeno.',
+      'La de raíz, como la zanahoria, afloja la tierra en lo hondo y deja la era lista para la siguiente.',
+    ],
+    observa: 'Lleve el orden en la bitácora: mirando qué sembró antes en cada era, va aprendiendo cómo descansa su tierra.',
+  },
+  {
+    id: 'piso',
+    chip: 'Piso térmico',
+    pregunta: 'Mi finca está a 1.800 metros, ¿qué se da bien por aquí?',
+    titulo: 'El piso térmico: la altura manda',
+    Lamina: LaminaPisoTermico,
+    frases: [
+      'A esa altura usted está en piso templado: aquí se dan bien el café, los cítricos y el maíz.',
+      'Más abajo, en lo cálido, es tierra de plátano, yuca y cacao; más arriba, en lo frío, la papa, la cebolla y la arveja.',
+      'Pasando el páramo ya no se siembra: eso se cuida, porque es la fábrica de agua de todos.',
+    ],
+    observa: 'Camine su ladera: donde cambia el frío y la neblina, cambia lo que le va a prender. La altura se lo enseña.',
+  },
+];
+
+export default function EnsenaDibujando({ onBack } = {}) {
+  const [conceptoId, setConceptoId] = useState('asociacion');
+  // `nonce` re-monta la lámina para volver a dispararle el auto-dibujado sin
+  // cambiar de concepto ("dibujar otra vez").
+  const [nonce, setNonce] = useState(0);
+  const concepto = CONCEPTOS.find((c) => c.id === conceptoId) ?? CONCEPTOS[0];
+  const { Lamina } = concepto;
+
+  const elegir = (id) => {
+    setConceptoId(id);
+    setNonce((n) => n + 1);
+  };
+
+  return (
+    <div className="ed-root">
+      <header className="ed-top">
+        <button type="button" className="ed-back" onClick={onBack} aria-label="Volver">
+          <ArrowLeft size={18} aria-hidden="true" />
+          <span>Volver</span>
+        </button>
+        <div className="ed-title-wrap">
+          <h1 className="ed-title">El agente enseña dibujando</h1>
+          <p className="ed-sub">Usted pregunta; en vez de un párrafo, el agente le hace la lámina y se la va dibujando.</p>
+        </div>
+      </header>
+
+      {/* selector de concepto */}
+      <nav className="ed-chips" aria-label="Escoja qué le explican">
+        {CONCEPTOS.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            className={`ed-chip${c.id === conceptoId ? ' ed-chip--on' : ''}`}
+            aria-pressed={c.id === conceptoId}
+            onClick={() => elegir(c.id)}
+          >
+            {c.chip}
+          </button>
+        ))}
+      </nav>
+
+      {/* conversación */}
+      <div className="ed-chat">
+        {/* la pregunta del campesino */}
+        <div className="ed-msg ed-msg--user">
+          <div className="ed-bubble ed-bubble--user">{concepto.pregunta}</div>
+        </div>
+
+        {/* la respuesta del agente: la lámina que se dibuja sola + las frases */}
+        <div className="ed-msg ed-msg--agent">
+          <div className="ed-avatar" aria-hidden="true"><Sprout size={18} /></div>
+          <div className="ed-bubble ed-bubble--agent">
+            <p className="ed-lamina-tit">{concepto.titulo}</p>
+            <figure className="ed-lamina" key={`${concepto.id}-${nonce}`}>
+              <Lamina className="ed-lamina-svg" />
+            </figure>
+            <ul className="ed-frases">
+              {concepto.frases.map((f, i) => (
+                <li key={i}>{f}</li>
+              ))}
+            </ul>
+            <p className="ed-observa">
+              <span className="ed-observa-tag">Para observar</span>
+              {concepto.observa}
+            </p>
+            <button type="button" className="ed-redraw" onClick={() => setNonce((n) => n + 1)}>
+              <RotateCcw size={14} aria-hidden="true" />
+              Dibujar otra vez
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <footer className="ed-foot">
+        Chagra no le da puntos ni medallas por preguntar: le dibuja para que
+        <strong> aprenda mirando</strong>. La lámina es la excusa para ir al surco y observar.
+      </footer>
+    </div>
+  );
+}

--- a/src/mockups/ensena-dibujando.css
+++ b/src/mockups/ensena-dibujando.css
@@ -1,0 +1,235 @@
+/* ════════════════════════════════════════════════════════════════════════
+   ensena-dibujando.css — mockup "el agente enseña dibujando".
+
+   Estética de cuaderno de campo: papel crema, tinta sepia. Las láminas traen
+   sus propios colores fijos (ilustración que enseña), así que el envoltorio
+   solo pone el "escritorio de papel" donde nacen. Todo el prefijo `ed-`.
+   Responsive desde 320px; el movimiento (auto-dibujado) vive en effects.css y
+   ya respeta prefers-reduced-motion.
+   ════════════════════════════════════════════════════════════════════════ */
+
+.ed-root {
+  --ed-papel: #f3ead4;
+  --ed-papel-2: #ede0c4;
+  --ed-tinta: #5c4326;
+  --ed-tinta-2: #8a6b40;
+  --ed-linea: rgba(92, 67, 38, 0.18);
+  --ed-verde: #55702c;
+  min-height: 100%;
+  box-sizing: border-box;
+  padding: 16px clamp(12px, 4vw, 28px) 40px;
+  background:
+    radial-gradient(120% 80% at 50% 0%, #fbf5e6 0%, #f3ead4 60%, #ecdfc1 100%);
+  color: var(--ed-tinta);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* ── cabecera ─────────────────────────────────────────────────────────── */
+.ed-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  max-width: 640px;
+  margin: 0 auto 14px;
+}
+.ed-back {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border: 1.5px solid var(--ed-linea);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.4);
+  color: var(--ed-tinta);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ed-back:hover { background: rgba(255, 255, 255, 0.7); }
+.ed-title-wrap { min-width: 0; }
+.ed-title {
+  margin: 2px 0 2px;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  font-size: clamp(1.15rem, 5vw, 1.6rem);
+  font-weight: 700;
+  line-height: 1.15;
+}
+.ed-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ed-tinta-2);
+  line-height: 1.35;
+}
+
+/* ── selector de concepto ─────────────────────────────────────────────── */
+.ed-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  max-width: 640px;
+  margin: 0 auto 16px;
+}
+.ed-chip {
+  padding: 8px 16px;
+  border: 1.5px solid var(--ed-linea);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.45);
+  color: var(--ed-tinta);
+  font-size: 0.86rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.ed-chip:hover { background: rgba(255, 255, 255, 0.8); }
+.ed-chip--on {
+  background: var(--ed-tinta);
+  border-color: var(--ed-tinta);
+  color: var(--ed-papel);
+}
+
+/* ── conversación ─────────────────────────────────────────────────────── */
+.ed-chat {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.ed-msg { display: flex; gap: 8px; }
+.ed-msg--user { justify-content: flex-end; }
+.ed-msg--agent { justify-content: flex-start; }
+
+.ed-avatar {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  margin-top: 2px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--ed-verde);
+  color: #f3ead4;
+}
+
+.ed-bubble {
+  border-radius: 16px;
+  line-height: 1.4;
+  box-shadow: 0 1px 3px rgba(60, 42, 20, 0.08);
+}
+.ed-bubble--user {
+  max-width: 82%;
+  padding: 10px 14px;
+  background: var(--ed-tinta);
+  color: var(--ed-papel);
+  border-bottom-right-radius: 5px;
+  font-size: 0.94rem;
+}
+.ed-bubble--agent {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 14px;
+  background: var(--ed-papel);
+  border: 1.5px solid var(--ed-linea);
+  border-bottom-left-radius: 5px;
+}
+
+.ed-lamina-tit {
+  margin: 0 0 8px;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  font-style: italic;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ed-tinta);
+}
+
+/* el papel de la lámina */
+.ed-lamina {
+  margin: 0 0 12px;
+  padding: 8px;
+  border-radius: 10px;
+  background: #f7efdd;
+  border: 1px solid var(--ed-linea);
+  overflow: hidden;
+}
+.ed-lamina-svg { display: block; width: 100%; height: auto; }
+
+.ed-frases {
+  margin: 0 0 12px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ed-frases li {
+  position: relative;
+  padding-left: 18px;
+  font-size: 0.92rem;
+  line-height: 1.42;
+}
+.ed-frases li::before {
+  content: '';
+  position: absolute;
+  left: 3px;
+  top: 0.6em;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ed-verde);
+}
+
+.ed-observa {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border-left: 3px solid var(--ed-verde);
+  border-radius: 6px;
+  background: rgba(85, 112, 44, 0.08);
+  font-size: 0.88rem;
+  line-height: 1.4;
+  font-style: italic;
+  color: #43521f;
+}
+.ed-observa-tag {
+  display: block;
+  margin-bottom: 2px;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--ed-verde);
+}
+
+.ed-redraw {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 13px;
+  border: 1.5px solid var(--ed-linea);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.5);
+  color: var(--ed-tinta);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ed-redraw:hover { background: rgba(255, 255, 255, 0.85); }
+
+/* ── pie ──────────────────────────────────────────────────────────────── */
+.ed-foot {
+  max-width: 640px;
+  margin: 22px auto 0;
+  padding-top: 14px;
+  border-top: 1px dashed var(--ed-linea);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--ed-tinta-2);
+  text-align: center;
+}
+.ed-foot strong { color: var(--ed-verde); }
+
+@media (max-width: 380px) {
+  .ed-bubble--user { max-width: 90%; font-size: 0.9rem; }
+  .ed-avatar { width: 28px; height: 28px; }
+}

--- a/src/mockups/laminas/LaminaMilpa.jsx
+++ b/src/mockups/laminas/LaminaMilpa.jsx
@@ -1,0 +1,121 @@
+import { useId } from 'react';
+import { AutoDibujo } from '../../visual/effects';
+import {
+  Rotulo, TINTA, TINTA_2, VERDE, VERDE_OSC, VERDE_CLARO,
+  GRANO, GRANO_OSC, NARANJA, TIERRA, TIERRA_CLARA, ROJO,
+} from './_kit.jsx';
+
+/*
+ * LaminaMilpa — la MILPA (las "tres hermanas") dibujándose sola: el maíz que
+ * hace de tutor, el frijol que trepa y fija el nitrógeno, y la calabaza que
+ * tapa el suelo. Enseña la ASOCIACIÓN de cultivos.
+ *
+ * SVG propio e inline (sin imágenes ni deps nuevas). role="img" porque enseña:
+ * lleva rótulos que son contenido. Colores fijos (tinta sobre papel crema). El
+ * dibujo se traza solo con el auto-dibujado de effects (clases vfx-draw); en
+ * reduced-motion aparece completo y quieto (lo garantiza effects.css).
+ */
+export default function LaminaMilpa({ className } = {}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const suelo = 258; // línea del suelo
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 400 320"
+      role="img"
+      aria-label="La milpa: el maíz sirve de tutor al frijol, que fija el nitrógeno, mientras la calabaza tapa el suelo."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <title>La milpa: las tres hermanas</title>
+
+      {/* ── suelo en corte ─────────────────────────────────────────────── */}
+      <g className="vfx-t1">
+        <AutoDibujo as="line" x1="18" y1={suelo} x2="382" y2={suelo} stroke={TINTA} strokeWidth="2.4" strokeLinecap="round" />
+        <AutoDibujo as="path" fade fill={`${TIERRA_CLARA}22`} d={`M18 ${suelo} H382 V300 H18 Z`} stroke="none" />
+      </g>
+
+      {/* ── 1. MAÍZ (el tutor): caña central, hojas, penacho, mazorca ──── */}
+      <g fill="none" stroke={VERDE_OSC} strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round">
+        <g className="vfx-t2">
+          {/* caña */}
+          <AutoDibujo as="path" d={`M200 ${suelo} C198 210 202 150 200 70`} stroke={VERDE_OSC} strokeWidth="3" />
+          {/* nudos */}
+          <AutoDibujo as="line" x1="194" y1="210" x2="206" y2="210" strokeWidth="2" />
+          <AutoDibujo as="line" x1="195" y1="160" x2="205" y2="160" strokeWidth="2" />
+        </g>
+        <g className="vfx-t3">
+          {/* hojas del maíz (arqueadas) */}
+          <AutoDibujo as="path" d="M200 150 C168 138 150 152 132 176" stroke={VERDE} strokeWidth="3" />
+          <AutoDibujo as="path" d="M200 118 C232 108 252 124 268 150" stroke={VERDE} strokeWidth="3" />
+          <AutoDibujo as="path" d="M200 200 C172 196 156 210 142 232" stroke={VERDE} strokeWidth="3" />
+          {/* penacho (flor macho) */}
+          <AutoDibujo as="path" d="M200 70 C196 56 200 48 200 40" stroke={GRANO_OSC} strokeWidth="2" />
+          <AutoDibujo as="path" d="M200 62 C206 52 210 48 214 42" stroke={GRANO_OSC} strokeWidth="2" />
+          <AutoDibujo as="path" d="M200 60 C194 50 190 46 186 40" stroke={GRANO_OSC} strokeWidth="2" />
+        </g>
+        {/* mazorca */}
+        <g className="vfx-t4">
+          <AutoDibujo as="path" fade fill={GRANO} stroke={GRANO_OSC} strokeWidth="1.6"
+            d="M214 150 q16 4 18 26 q-10 12 -20 4 q-8 -18 2 -30 Z" />
+          <AutoDibujo as="path" d="M232 150 q6 -8 12 -8" stroke={ROJO} strokeWidth="1.6" /> {/* barbas */}
+        </g>
+      </g>
+
+      {/* ── 2. FRIJOL (fija N): guía que trepa por la caña + nódulos ────── */}
+      <g fill="none" stroke={VERDE_CLARO} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+        <g className="vfx-t5">
+          {/* enredadera espiralando la caña */}
+          <AutoDibujo as="path"
+            d={`M188 ${suelo} C176 236 214 224 210 204 C206 184 176 178 184 156 C190 138 218 138 208 116 C202 100 184 100 190 84`} />
+          {/* hojas trifoliadas simplificadas */}
+          <AutoDibujo as="path" fade fill={`${VERDE_CLARO}66`} stroke={VERDE} strokeWidth="1.2" d="M184 156 q-14 -6 -18 6 q10 8 18 -6 Z" />
+          <AutoDibujo as="path" fade fill={`${VERDE_CLARO}66`} stroke={VERDE} strokeWidth="1.2" d="M208 116 q14 -6 18 6 q-10 8 -18 -6 Z" />
+          <AutoDibujo as="path" fade fill={`${VERDE_CLARO}66`} stroke={VERDE} strokeWidth="1.2" d="M210 204 q14 -6 18 6 q-10 8 -18 -6 Z" />
+          {/* flor de frijol */}
+          <AutoDibujo as="circle" fade cx="190" cy="84" r="4" fill={ROJO} stroke={ROJO} strokeWidth="0.5" />
+        </g>
+        {/* nódulos que fijan nitrógeno (raíz del frijol) */}
+        <g className="vfx-t6">
+          <AutoDibujo as="path" d={`M188 ${suelo} C180 274 172 280 164 288`} stroke={TINTA_2} strokeWidth="1.6" />
+          <AutoDibujo as="circle" fade cx="176" cy="276" r="3.2" fill={ROJO} />
+          <AutoDibujo as="circle" fade cx="167" cy="285" r="3" fill={ROJO} />
+          <AutoDibujo as="circle" fade cx="182" cy="284" r="2.6" fill={ROJO} />
+          {/* N del aire → nódulos */}
+          <AutoDibujo as="path" fade d="M150 300 q6 -10 14 -12" stroke={TINTA_2} strokeWidth="1" markerEnd={`url(#flechaN-${uid})`} />
+        </g>
+        <text className="vfx-t6 vfx-fade" x="138" y="304" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="10" fill={TINTA_2}>N₂ del aire</text>
+      </g>
+
+      {/* ── 3. CALABAZA (tapa el suelo): hojas anchas + fruto + flor ────── */}
+      <g fill="none" stroke={VERDE_OSC} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <g className="vfx-t5">
+          {/* guía rastrera */}
+          <AutoDibujo as="path" d={`M212 ${suelo} C250 252 300 250 344 246`} stroke={VERDE} strokeWidth="2.2" />
+          {/* hojas anchas */}
+          <AutoDibujo as="path" fade fill={`${VERDE}55`} stroke={VERDE_OSC} strokeWidth="1.4" d="M272 248 q-16 -18 2 -30 q22 4 20 24 q-10 12 -22 6 Z" />
+          <AutoDibujo as="path" fade fill={`${VERDE}55`} stroke={VERDE_OSC} strokeWidth="1.4" d="M322 244 q-14 -16 4 -26 q20 4 18 22 q-10 10 -22 4 Z" />
+        </g>
+        <g className="vfx-t7">
+          {/* fruto de calabaza sobre el suelo */}
+          <AutoDibujo as="path" fade fill={NARANJA} stroke={GRANO_OSC} strokeWidth="1.6"
+            d="M300 250 q22 -6 30 8 q4 14 -16 16 q-22 0 -22 -12 q0 -8 8 -12 Z" />
+          <AutoDibujo as="path" d="M314 244 q0 20 0 22" stroke={GRANO_OSC} strokeWidth="1" />
+          {/* flor amarilla */}
+          <AutoDibujo as="circle" fade cx="352" cy="242" r="5" fill={GRANO} stroke={GRANO_OSC} strokeWidth="1" />
+        </g>
+      </g>
+
+      {/* ── rótulos que enseñan (usted colombiano) ─────────────────────── */}
+      <Rotulo stage={7} x="252" y="96" tx="204" ty="112" texto="El maíz: el tutor" sub="sube derecho, da la vara" />
+      <Rotulo stage={8} x="26" y="150" tx="186" ty="172" texto="El frijol trepa" sub="y fija el nitrógeno en la raíz" anchor="start" />
+      <Rotulo stage={9} x="250" y="296" tx="300" ty="264" texto="La calabaza tapa el suelo" sub="guarda humedad, ahoga la maleza" />
+
+      <defs>
+        <marker id={`flechaN-${uid}`} markerWidth="6" markerHeight="6" refX="4" refY="3" orient="auto">
+          <path d="M0 0 L6 3 L0 6 Z" fill={TINTA_2} />
+        </marker>
+      </defs>
+    </svg>
+  );
+}

--- a/src/mockups/laminas/LaminaPisoTermico.jsx
+++ b/src/mockups/laminas/LaminaPisoTermico.jsx
@@ -1,0 +1,106 @@
+import { AutoDibujo } from '../../visual/effects';
+import {
+  TINTA, TINTA_2, VERDE, VERDE_OSC, GRANO, GRANO_OSC, NARANJA, CIAN, ROJO,
+} from './_kit.jsx';
+
+/*
+ * LaminaPisoTermico — el PISO TÉRMICO dibujándose solo: una montaña en corte
+ * donde la ALTURA manda qué se da. De abajo hacia arriba: cálido (plátano,
+ * yuca, cacao) → templado (café, cítricos, maíz; el piso de la finca) → frío
+ * (papa, cebolla, arveja) → páramo (el frailejón: se cuida, no se siembra).
+ *
+ * SVG propio e inline. role="img" (enseña). Auto-dibujado de effects: primero
+ * se traza la montaña, luego se tiñen las franjas y aparecen los cultivos.
+ */
+export default function LaminaPisoTermico({ className } = {}) {
+  // franjas por altura (y de arriba=alto a abajo=bajo)
+  const bandas = [
+    { y: 26, h: 58, tint: `${CIAN}22`, msnm: '3.600 m', cy: 55 },
+    { y: 84, h: 58, tint: '#8a9a8e22', msnm: '2.600 m', cy: 113 },
+    { y: 142, h: 58, tint: `${GRANO}22`, msnm: '1.800 m', cy: 171 },
+    { y: 200, h: 58, tint: `${NARANJA}22`, msnm: '600 m', cy: 229 },
+  ];
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 420 300"
+      role="img"
+      aria-label="Corte de una montaña por pisos térmicos: cálido con plátano y cacao abajo, templado con café y maíz, frío con papa, y páramo con frailejón arriba."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <title>El piso térmico: la altura manda qué se da</title>
+
+      {/* ── franjas de altura (tinte) ──────────────────────────────────── */}
+      <g className="vfx-t2">
+        {bandas.map((b) => (
+          <AutoDibujo key={b.msnm} as="rect" fade x="52" y={b.y} width="352" height={b.h} fill={b.tint} />
+        ))}
+      </g>
+
+      {/* ── eje de altura (izquierda) ──────────────────────────────────── */}
+      <g className="vfx-t1">
+        <AutoDibujo as="line" x1="52" y1="26" x2="52" y2="258" stroke={TINTA_2} strokeWidth="1.4" strokeLinecap="round" />
+        {bandas.map((b) => (
+          <g key={b.msnm}>
+            <AutoDibujo as="line" x1="47" y1={b.cy} x2="52" y2={b.cy} stroke={TINTA_2} strokeWidth="1.2" />
+            <text className="vfx-fade" x="45" y={b.cy + 3} textAnchor="end" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="9.5" fill={TINTA_2}>{b.msnm}</text>
+          </g>
+        ))}
+      </g>
+
+      {/* ── silueta de la montaña ──────────────────────────────────────── */}
+      <g className="vfx-t1" fill="none" stroke={TINTA} strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="path" d="M60 258 L250 34 L404 258" stroke={TINTA} strokeWidth="2.6" />
+        {/* nevado en la cima */}
+        <AutoDibujo as="path" fade fill={`${CIAN}55`} stroke={CIAN} strokeWidth="1.2" d="M226 62 L250 34 L274 62 L262 56 L250 64 L238 56 Z" />
+      </g>
+      <AutoDibujo as="line" className="vfx-t2" x1="60" y1="258" x2="404" y2="258" stroke={TINTA} strokeWidth="2.4" strokeLinecap="round" />
+
+      {/* ── cultivos por piso ──────────────────────────────────────────── */}
+      {/* PÁRAMO — frailejón */}
+      <g className="vfx-t4" fill="none" stroke={VERDE_OSC} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="line" x1="150" y1="80" x2="150" y2="58" stroke={TINTA_2} strokeWidth="2.4" />
+        <AutoDibujo as="path" fade fill={`${VERDE}66`} stroke={VERDE_OSC} strokeWidth="1.2" d="M150 58 q-14 -4 -16 -12 M150 58 q14 -4 16 -12 M150 58 q-6 -12 -4 -18 M150 58 q6 -12 4 -18 M150 58 q0 -14 0 -18" />
+        <AutoDibujo as="circle" fade cx="150" cy="42" r="3.5" fill={GRANO} stroke={GRANO_OSC} strokeWidth="1" />
+      </g>
+      {/* FRÍO — papa (mata + tubérculos) */}
+      <g className="vfx-t5" fill="none" stroke={VERDE_OSC} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="path" d="M150 128 q-10 -8 -8 -16 M150 128 q10 -8 8 -16 M150 128 q0 -10 0 -18" strokeWidth="1.6" />
+        <AutoDibujo as="circle" fade cx="150" cy="112" r="2.5" fill={GRANO} />
+        <AutoDibujo as="circle" fade cx="144" cy="136" r="3.4" fill={GRANO_OSC} />
+        <AutoDibujo as="circle" fade cx="155" cy="138" r="3" fill={GRANO_OSC} />
+      </g>
+      {/* TEMPLADO — cafeto (rama con cerezas) */}
+      <g className="vfx-t6" fill="none" stroke={VERDE_OSC} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="path" d="M138 186 q14 -10 26 -6" stroke={VERDE_OSC} strokeWidth="1.8" />
+        <AutoDibujo as="path" fade fill={`${VERDE}66`} stroke={VERDE_OSC} strokeWidth="1" d="M148 182 q8 -6 12 0 q-6 6 -12 0 Z" />
+        <AutoDibujo as="circle" fade cx="150" cy="188" r="2.6" fill={ROJO} />
+        <AutoDibujo as="circle" fade cx="158" cy="186" r="2.6" fill={ROJO} />
+        <AutoDibujo as="circle" fade cx="142" cy="188" r="2.4" fill={ROJO} />
+      </g>
+      {/* CÁLIDO — plátano (hoja paleta) */}
+      <g className="vfx-t7" fill="none" stroke={VERDE_OSC} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="line" x1="150" y1="244" x2="150" y2="216" stroke={VERDE_OSC} strokeWidth="2" />
+        <AutoDibujo as="path" fade fill={`${VERDE}66`} stroke={VERDE_OSC} strokeWidth="1.2" d="M150 220 q-20 -6 -24 -20 q18 -2 24 12 q6 -14 24 -12 q-4 14 -24 20 Z" />
+        <AutoDibujo as="path" d="M150 220 q0 -14 0 -18" strokeWidth="1" />
+      </g>
+
+      {/* ── rótulos (derecha, usted colombiano) ───────────────────────── */}
+      <g className="vfx-t8">
+        {[
+          { y: 50, c: CIAN, t: 'Páramo', s: 'frailejón · aquí se cuida, no se siembra' },
+          { y: 108, c: TINTA_2, t: 'Frío', s: 'papa, cebolla, arveja' },
+          { y: 166, c: GRANO_OSC, t: 'Templado — su finca', s: 'café, cítricos, maíz' },
+          { y: 224, c: NARANJA, t: 'Cálido', s: 'plátano, yuca, cacao' },
+        ].map((r) => (
+          <g key={r.t}>
+            <rect className="vfx-fade" x="250" y={r.y - 9} width="9" height="9" rx="2" fill={r.c} />
+            <text className="vfx-fade" x="266" y={r.y} fontFamily="'Georgia', serif" fontStyle="italic" fontWeight="600" fontSize="12" fill={TINTA}>{r.t}</text>
+            <text className="vfx-fade" x="266" y={r.y + 13} fontFamily="'Georgia', serif" fontStyle="italic" fontSize="9.5" fill={TINTA_2}>{r.s}</text>
+          </g>
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/src/mockups/laminas/LaminaRotacion.jsx
+++ b/src/mockups/laminas/LaminaRotacion.jsx
@@ -1,0 +1,113 @@
+import { useId } from 'react';
+import { AutoDibujo } from '../../visual/effects';
+import {
+  TINTA, TINTA_2, VERDE, VERDE_OSC, VERDE_CLARO,
+  GRANO_OSC, NARANJA, TIERRA_CLARA, ROJO,
+} from './_kit.jsx';
+
+/*
+ * LaminaRotacion — la ROTACIÓN de cultivos como una rueda de cuatro eras que se
+ * dibuja sola: hoja → fruto → raíz → leguminosa → y vuelve a empezar. Cada
+ * familia le pide y le devuelve algo distinto al suelo; la leguminosa repone el
+ * nitrógeno que la de hoja gastó.
+ *
+ * SVG propio e inline. role="img" (enseña). Auto-dibujado de effects; las
+ * flechas del ciclo se trazan en orden con las etapas escalonadas.
+ */
+
+// Nodo de una era: disco de tierra + número + rótulo con lo que hace al suelo.
+// Declarado a nivel de módulo (no dentro del render) para no re-crear el
+// componente en cada dibujo.
+function Era({ cx, cy, num, titulo, familia, efecto, stage, children }) {
+  return (
+    <g className={`vfx-t${stage}`}>
+      <AutoDibujo as="ellipse" fade cx={cx} cy={cy + 26} rx="34" ry="9" fill={`${TIERRA_CLARA}33`} />
+      <AutoDibujo as="line" x1={cx - 30} y1={cy + 26} x2={cx + 30} y2={cy + 26} stroke={TINTA} strokeWidth="1.6" strokeLinecap="round" />
+      {children}
+      <circle className="vfx-fade" cx={cx - 40} cy={cy - 22} r="10" fill="#f3ead4" stroke={TINTA} strokeWidth="1.4" />
+      <text className="vfx-fade" x={cx - 40} y={cy - 18} textAnchor="middle" fontFamily="'Georgia', serif" fontWeight="700" fontSize="12" fill={TINTA}>{num}</text>
+      <text className="vfx-fade" x={cx} y={cy + 44} textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontWeight="600" fontSize="12" fill={TINTA}>{titulo}</text>
+      <text className="vfx-fade" x={cx} y={cy + 57} textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="9.5" fill={TINTA_2}>{familia}</text>
+      <text className="vfx-fade" x={cx} y={cy + 70} textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="9.5" fill={efecto.color}>{efecto.txt}</text>
+    </g>
+  );
+}
+
+export default function LaminaRotacion({ className } = {}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const flecha = `flechaRot-${uid}`;
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 400 350"
+      role="img"
+      aria-label="Rueda de rotación de cultivos: primero hoja, luego fruto, luego raíz, luego leguminosa que repone el nitrógeno, y se vuelve a empezar."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <title>La rotación: cambie de familia cada era</title>
+
+      {/* ── flechas del ciclo (horario) ────────────────────────────────── */}
+      <g fill="none" stroke={TINTA_2} strokeWidth="2" strokeLinecap="round">
+        <g className="vfx-t2"><AutoDibujo as="path" d="M250 70 A120 120 0 0 1 320 130" markerEnd={`url(#${flecha})`} /></g>
+        <g className="vfx-t4"><AutoDibujo as="path" d="M320 214 A120 120 0 0 1 250 276" markerEnd={`url(#${flecha})`} /></g>
+        <g className="vfx-t6"><AutoDibujo as="path" d="M150 276 A120 120 0 0 1 80 214" markerEnd={`url(#${flecha})`} /></g>
+        <g className="vfx-t8"><AutoDibujo as="path" d="M80 130 A120 120 0 0 1 150 70" markerEnd={`url(#${flecha})`} /></g>
+      </g>
+
+      {/* ── centro ─────────────────────────────────────────────────────── */}
+      <g className="vfx-t1">
+        <AutoDibujo as="circle" fade cx="200" cy="173" r="30" fill="#f3ead4" stroke={TINTA_2} strokeWidth="1.2" strokeDasharray="3 4" />
+        <text className="vfx-fade" x="200" y="168" textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontWeight="700" fontSize="12" fill={TINTA}>La era</text>
+        <text className="vfx-fade" x="200" y="184" textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="10" fill={TINTA_2}>descansa</text>
+        <text className="vfx-fade" x="200" y="196" textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="10" fill={TINTA_2}>cambiando</text>
+      </g>
+
+      {/* ── 1. HOJA (arriba) — lechuga: gasta nitrógeno ────────────────── */}
+      <Era cx={200} cy={44} num="1" titulo="Hoja" familia="lechuga, repollo" efecto={{ txt: 'gasta nitrógeno', color: ROJO }} stage={3}>
+        <g fill="none" stroke={VERDE_OSC} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <AutoDibujo as="path" fade fill={`${VERDE}55`} stroke={VERDE_OSC} strokeWidth="1.4" d="M200 66 q-22 -2 -20 -18 q20 -6 22 10 q2 -16 22 -10 q2 16 -20 18 Z" />
+          <AutoDibujo as="path" d="M200 66 q0 -14 0 -22" strokeWidth="1.4" />
+        </g>
+      </Era>
+
+      {/* ── 2. FRUTO (derecha) — tomate: pide suelo fértil ─────────────── */}
+      <Era cx={310} cy={148} num="2" titulo="Fruto" familia="tomate, ají" efecto={{ txt: 'pide suelo rico', color: TINTA_2 }} stage={5}>
+        <g fill="none" stroke={VERDE_OSC} strokeWidth="1.8" strokeLinecap="round">
+          <AutoDibujo as="path" d="M310 174 C308 162 312 156 310 148" strokeWidth="2" />
+          <AutoDibujo as="circle" fade cx="302" cy="160" r="4.5" fill={ROJO} />
+          <AutoDibujo as="circle" fade cx="318" cy="166" r="4" fill={ROJO} />
+          <AutoDibujo as="path" fade fill={`${VERDE}55`} stroke={VERDE_OSC} strokeWidth="1.2" d="M310 152 q10 -4 12 4 q-8 4 -12 -4 Z" />
+        </g>
+      </Era>
+
+      {/* ── 3. RAÍZ (abajo) — zanahoria: afloja hondo ──────────────────── */}
+      <Era cx={200} cy={252} num="3" titulo="Raíz" familia="zanahoria, remolacha" efecto={{ txt: 'afloja hondo', color: TINTA_2 }} stage={7}>
+        <g fill="none" stroke={GRANO_OSC} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <AutoDibujo as="path" fade fill={NARANJA} stroke={GRANO_OSC} strokeWidth="1.4" d="M192 278 L208 278 L200 300 Z" />
+          <AutoDibujo as="path" d="M200 278 q-8 -10 -6 -16" stroke={VERDE_OSC} strokeWidth="1.4" />
+          <AutoDibujo as="path" d="M200 278 q8 -10 6 -16" stroke={VERDE_OSC} strokeWidth="1.4" />
+          <AutoDibujo as="path" d="M200 278 q0 -12 0 -16" stroke={VERDE_OSC} strokeWidth="1.4" />
+        </g>
+      </Era>
+
+      {/* ── 4. LEGUMINOSA (izquierda) — fríjol/haba: repone nitrógeno ──── */}
+      <Era cx={90} cy={148} num="4" titulo="Leguminosa" familia="fríjol, haba, arveja" efecto={{ txt: 'repone nitrógeno', color: VERDE_OSC }} stage={9}>
+        <g fill="none" stroke={VERDE_CLARO} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <AutoDibujo as="path" d="M90 174 C88 162 92 156 90 148" strokeWidth="2" stroke={VERDE_OSC} />
+          {/* vaina */}
+          <AutoDibujo as="path" fade fill={`${VERDE_CLARO}88`} stroke={VERDE_OSC} strokeWidth="1.2" d="M96 152 q14 2 16 12 q-14 2 -16 -12 Z" />
+          {/* nódulos */}
+          <AutoDibujo as="circle" fade cx="84" cy="176" r="2.6" fill={ROJO} />
+          <AutoDibujo as="circle" fade cx="92" cy="178" r="2.2" fill={ROJO} />
+        </g>
+      </Era>
+
+      <defs>
+        <marker id={flecha} markerWidth="7" markerHeight="7" refX="4.5" refY="3.5" orient="auto">
+          <path d="M0 0 L7 3.5 L0 7 Z" fill={TINTA_2} />
+        </marker>
+      </defs>
+    </svg>
+  );
+}

--- a/src/mockups/laminas/_kit.jsx
+++ b/src/mockups/laminas/_kit.jsx
@@ -1,0 +1,65 @@
+/*
+ * _kit — utilería compartida de las láminas del mockup "el agente enseña
+ * dibujando". Sigue la casa de `src/visual/laminas` (tinta sobre papel crema,
+ * colores FIJOS porque es una ilustración que enseña, no cromo de UI) y usa el
+ * auto-dibujado canónico de `src/visual/effects` (AutoDibujo + effects.css).
+ *
+ * No es una lámina de producción: vive junto al mockup. Si alguna de estas tres
+ * (milpa / rotación / piso térmico) se estabiliza, se promovería a
+ * `src/visual/laminas` con su fila en el índice — misma regla de la casa.
+ */
+import { AutoDibujo } from '../../visual/effects';
+
+/* Paleta de tinta: sepia + verdes botánicos + tierras, sobre papel crema.
+   Fija a propósito (legible al sol, no reacciona al tema). */
+export const TINTA = '#5c4326'; // sepia principal (trazo y rótulos)
+export const TINTA_2 = '#8a6b40'; // sepia claro (guías, rótulos 2°)
+export const VERDE = '#6f8a3c'; // verde hoja
+export const VERDE_OSC = '#55702c'; // verde de contornos/venas
+export const VERDE_CLARO = '#9bb45f'; // verde tierno (frijol)
+export const GRANO = '#d8a93f'; // oro del grano / flor
+export const GRANO_OSC = '#b0822a'; // contorno del grano
+export const NARANJA = '#d98b3c'; // calabaza / fruto cálido
+export const TIERRA = '#7a5a34'; // suelo
+export const TIERRA_CLARA = '#a07d4e'; // suelo claro
+export const ROJO = '#a8443a'; // fruto / flor de frijol
+export const CIAN = '#4f9aa0'; // páramo / frío
+
+/* Rótulo de cuaderno: línea-guía que se DIBUJA sola + punto en el objetivo +
+   texto serif itálico (letra de mano) que aparece en fundido. Se agrupa en una
+   `etapa` (1..9) para escalonar su aparición con el resto de la lámina. */
+export function Rotulo({ x, y, tx, ty, texto, sub = null, anchor = 'start', stage = 6 }) {
+  return (
+    <g className={`vfx-t${stage}`}>
+      <AutoDibujo as="line" x1={tx} y1={ty} x2={x} y2={y} stroke={TINTA_2} strokeWidth="0.9" strokeLinecap="round" />
+      <circle className="vfx-fade" cx={tx} cy={ty} r="1.8" fill={TINTA} />
+      <text
+        className="vfx-fade"
+        x={x}
+        y={y}
+        textAnchor={anchor}
+        fontFamily="'Georgia', 'Times New Roman', serif"
+        fontStyle="italic"
+        fontSize="12.5"
+        fontWeight="600"
+        fill={TINTA}
+      >
+        {texto}
+      </text>
+      {sub && (
+        <text
+          className="vfx-fade"
+          x={x}
+          y={y + 13}
+          textAnchor={anchor}
+          fontFamily="'Georgia', 'Times New Roman', serif"
+          fontStyle="italic"
+          fontSize="10"
+          fill={TINTA_2}
+        >
+          {sub}
+        </text>
+      )}
+    </g>
+  );
+}

--- a/src/visual/effects/AutoDibujo.jsx
+++ b/src/visual/effects/AutoDibujo.jsx
@@ -1,0 +1,35 @@
+/*
+ * AutoDibujo — el AUTO-DIBUJADO orquestado compartido (§13.11 del catálogo).
+ *
+ * La receta de SceneTrazoMinimal ("el trazo se dibuja solo al entrar"):
+ * `pathLength="1"` normalizado + `stroke-dashoffset` que va a 0 + etapas con
+ * delay escalonado. Aquí queda como helper para no re-cablear el dasharray a
+ * mano en cada lámina/onboarding/glifo.
+ *
+ * El movimiento vive en `effects.css` (clases `vfx-draw`, `vfx-fade`,
+ * `vfx-t1…vfx-t9`); este componente solo pega las clases correctas y pone
+ * `pathLength="1"` para que el draw-in sea independiente de la longitud real
+ * del trazo. Reduced-motion = el dibujo COMPLETO y quieto (lo garantiza el CSS).
+ *
+ * Recuerde importar el CSS una vez en la escena:  import '.../effects/effects.css'
+ *
+ * @param {object}  props
+ * @param {'path'|'line'|'polyline'|'circle'|'rect'|string} [props.as='path']
+ *        elemento SVG a renderizar.
+ * @param {number}  [props.stage]      etapa 1..9 (delay escalonado del dibujo).
+ * @param {boolean} [props.fade=false] `true` = aparece en fundido (opacity) en
+ *        vez de trazarse — para planos de color (sol, leyenda, humo).
+ * @param {string}  [props.className]  clases extra.
+ * Resto de props (`d`, `stroke`, `strokeWidth`, `fill`, `cx`…) se pasan tal cual.
+ */
+export function AutoDibujo({ as = 'path', stage, fade = false, className, ...rest }) {
+  const El = as;
+  const base = fade ? 'vfx-fade' : 'vfx-draw';
+  const stageClass = stage ? ` vfx-t${stage}` : '';
+  const cls = `${base}${stageClass}${className ? ` ${className}` : ''}`;
+  // pathLength normaliza el dashoffset a [0..1]; solo aplica al modo trazo.
+  const drawProps = fade ? {} : { pathLength: 1 };
+  return <El className={cls} {...drawProps} {...rest} />;
+}
+
+export default AutoDibujo;

--- a/src/visual/effects/FiltroAcuarela.jsx
+++ b/src/visual/effects/FiltroAcuarela.jsx
@@ -1,0 +1,58 @@
+/*
+ * FiltroAcuarela — el borde/relleno "pintado a la acuarela" compartido
+ * (feTurbulence + feDisplacementMap).
+ *
+ * Da a un trazo o relleno SVG el borde húmedo, irregular y sangrado de la
+ * acuarela: la turbulencia genera un ruido fractal y el displacement empuja los
+ * píxeles según ese ruido. Es la receta que dibuja los bordes del mapa-acuarela
+ * en vez de re-hilvanar un `<filter>` inline por mockup.
+ *
+ * Emite SOLO el `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y lo referencia con `filter={`url(#${id})`}`. Pasar ids únicos
+ * (`useId`) para repetir varios en la misma página sin colisión.
+ *
+ * Reduced-motion-safe por construcción: el filtro es ESTÁTICO (no anima), en
+ * línea con la regla de la casa "blur/filtros estáticos, solo transform/opacity
+ * animados".
+ *
+ * @param {object} props
+ * @param {string}  props.id                 id del filtro (obligatorio).
+ * @param {number} [props.frequency=0.012]   baseFrequency del ruido (más alto =
+ *                                           borde más nervioso/fino).
+ * @param {number} [props.scale=6]           fuerza del desplazamiento en px.
+ * @param {number} [props.octaves=2]         numOctaves del fractalNoise.
+ * @param {number} [props.seed=7]            semilla del ruido (determinista).
+ * @param {string} [props.bounds='-20%']     origen del box del filtro (x/y).
+ */
+export function FiltroAcuarela({
+  id,
+  frequency = 0.012,
+  scale = 6,
+  octaves = 2,
+  seed = 7,
+  bounds = '-20%',
+}) {
+  const off = parseFloat(bounds);
+  const size = `${100 - 2 * off}%`;
+  const noise = `${id}-noise`;
+  return (
+    <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+      <feTurbulence
+        type="fractalNoise"
+        baseFrequency={frequency}
+        numOctaves={octaves}
+        seed={seed}
+        result={noise}
+      />
+      <feDisplacementMap
+        in="SourceGraphic"
+        in2={noise}
+        scale={scale}
+        xChannelSelector="R"
+        yChannelSelector="G"
+      />
+    </filter>
+  );
+}
+
+export default FiltroAcuarela;

--- a/src/visual/effects/GlowFilter.jsx
+++ b/src/visual/effects/GlowFilter.jsx
@@ -1,0 +1,44 @@
+/*
+ * GlowFilter — el GLOW neón orgánico compartido de Chagra (§13.16 del catálogo).
+ *
+ * Es la MISMA receta que hoy está copiada como `<filter>` inline en varias
+ * escenas y en la librería de fauna (GuardianEspiritu `ge-glow1`, creatures
+ * `CreatureFilters`, SceneFincaOrganismo `fvo-glow1`…): un feGaussianBlur
+ * fundido con el original vía feMerge, más — opcionalmente — un blur suave
+ * suelto para halos/estelas. Aquí vive la versión canónica.
+ *
+ * Emite SOLO los `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y referencia por id. Como cada escena decide su id, se pueden repetir
+ * muchos glows en una misma página sin colisión (pasar ids únicos con `useId`).
+ *
+ * @param {object} props
+ * @param {string}  props.id              id del filtro de glow (obligatorio).
+ * @param {number} [props.std=2.1]        desenfoque del glow (stdDeviation).
+ * @param {string} [props.blurId]         si se pasa, emite además un blur suelto
+ *                                        con este id (para halos/estelas).
+ * @param {number} [props.blurStd=3]      desenfoque del blur suelto.
+ * @param {string} [props.bounds='-80%']  origen del box del filtro (x/y); el
+ *                                        ancho/alto se calculan como 100%-2*bounds.
+ */
+export function GlowFilter({ id, std = 2.1, blurId, blurStd = 3, bounds = '-80%' }) {
+  const off = parseFloat(bounds); // -80  → box de 260%
+  const size = `${100 - 2 * off}%`;
+  return (
+    <>
+      <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+        <feGaussianBlur stdDeviation={std} result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      {blurId ? (
+        <filter id={blurId}>
+          <feGaussianBlur stdDeviation={blurStd} />
+        </filter>
+      ) : null}
+    </>
+  );
+}
+
+export default GlowFilter;

--- a/src/visual/effects/README.md
+++ b/src/visual/effects/README.md
@@ -1,0 +1,118 @@
+# `src/visual/effects` — efectos visuales reutilizables
+
+Librería de las **técnicas de cine** de Chagra (las que dan el "wow": velos,
+viñeta, scrims, grades de luz por piso térmico, glow, pulso cardíaco,
+auto-dibujado, acuarela) como **CSS + helpers SVG limpios, parametrizables y sin
+dependencias nuevas**. Nace para **dejar de re-hilvanar el mismo efecto** en
+cada mockup/escena: hoy el velo neón, la viñeta, los grades `--mm2-*`, el glow
+`feMerge`, el latido `--fvo-beat`, el trazo que se dibuja solo y el filtro
+acuarela aparecían copiados/redibujados en `finca-viva-hero.css`,
+`scene-finca-organismo.css`, `scene-trazo-minimal.css`, `GuardianEspiritu`, los
+mockups de la Montaña y el mapa-acuarela. Aquí vive la **versión canónica**.
+
+Hermana de [`src/visual/creatures`](../creatures/README.md) (personajes de
+fauna): misma filosofía, mismo contrato de reuso.
+
+## Regla de la casa
+
+> **Antes de re-dibujar un efecto de cine, búsquelo aquí.**
+> Si existe → **reúselo** (y de ser posible, **mejore** la versión canónica,
+> para que todos hereden la mejora).
+> Si crea un efecto nuevo reutilizable → **agréguelo aquí en el mismo PR**
+> (clase/helper + entrada en `index.js` + fila en esta tabla).
+
+## Qué hay
+
+| Efecto | Cómo se usa | Catálogo | Semilla |
+|---|---|---|---|
+| **Velo atmosférico** neón | clase `.vfx-veil` (custom props `--vfx-veil-a/b/opacity`) | §13.5 / §13.16 | `finca-viva-hero` `.fvh-escena-wrap::after` |
+| **Viñeta** de cine | clase `.vfx-vignette` (`--vfx-vignette-strength`) | §13.5 | idem |
+| **Scrims** arriba/abajo | clases `.vfx-scrim-top` / `.vfx-scrim-bottom` (`--vfx-scrim-color/-h`) | §13.5 | idem |
+| **Grades de luz por piso térmico** | clase `.vfx-grade` + modificador `.vfx-grade--{glacial,paramo,frio,templado,calido,valle}`; tokens `--vfx-piso-*`; `--vfx-grade-fuerza` por dirección | §13.2 | los `--mm2-*` de Montaña |
+| **Glow** (feMerge) | helper `<GlowFilter id std blurId />` | §13.16 | unifica `ge-glow1` + `creatures/_filters` |
+| **Pulso cardíaco** | token `--vfx-beat` + clases `.vfx-beat`, `.vfx-beat-wave`, `.vfx-beat-glow` | §13.10 | `--fvo-beat` (SceneFincaOrganismo) |
+| **Auto-dibujado** | helper `<AutoDibujo stage fade />` + clases `.vfx-draw/.vfx-fade/.vfx-t1…t9` | §13.11 | SceneTrazoMinimal `fvm-t*` |
+| **Flujo por dash** | clase `.vfx-flow` (`--vfx-flow-dur/-len`) | §13.12 | `fvo-flow` / `adm-sap` |
+| **Filtro acuarela** | helper `<FiltroAcuarela id scale frequency />` | — | mapa-acuarela (feTurbulence+feDisplacementMap) |
+
+## Dos formas de consumir
+
+**1. CSS** (velos, viñeta, scrims, grades, latido, auto-dibujado, flujo).
+Importe el CSS una vez donde lo use y ponga las clases:
+
+```jsx
+import '../../visual/effects/effects.css';
+
+// una escena con cielo de biopunk y hora dorada en la finca:
+<div style={{ position: 'relative' }}>
+  <MiEscenaSVG />
+  <div className="vfx-grade vfx-grade--templado" />   {/* luz de la finca  */}
+  <div className="vfx-veil" />                          {/* velo neón        */}
+  <div className="vfx-scrim-bottom" />                  {/* para que el texto lea */}
+  <div className="vfx-vignette" />                      {/* enfoca el centro */}
+</div>
+```
+
+El pulso cardíaco sincroniza todo lo vivo con una sola variable:
+
+```jsx
+// el corazón late, la red se enciende en fase, la onda se expande:
+<g className="vfx-beat"><path d="…corazón…" /></g>
+<g className="vfx-beat-glow"><path d="…red micorrízica…" /></g>
+<circle className="vfx-beat-wave" r="8" />
+// para acelerar/frenar TODO junto:  style={{ '--vfx-beat': '4s' }} en un ancestro
+```
+
+**2. Helpers SVG** (glow, acuarela, auto-dibujado). Se montan en tu `<defs>` /
+tu SVG. Cada instancia usa **ids únicos** (`useId`) para repetirse sin colisión:
+
+```jsx
+import { useId } from 'react';
+import { GlowFilter, FiltroAcuarela, AutoDibujo } from '../../visual/effects';
+import '../../visual/effects/effects.css';
+
+function MiEscena() {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `glow-${uid}`;
+  const agua = `acuarela-${uid}`;
+  return (
+    <svg viewBox="0 0 390 486">
+      <defs>
+        <GlowFilter id={glow} std={2.2} blurId={`blur-${uid}`} />
+        <FiltroAcuarela id={agua} scale={7} frequency={0.014} />
+      </defs>
+
+      {/* glow neón sobre lo vivo */}
+      <g filter={`url(#${glow})`}>{/* … */}</g>
+
+      {/* un relieve/mancha con borde de acuarela */}
+      <path d="…" fill="#6f9a85" filter={`url(#${agua})`} />
+
+      {/* el trazo se dibuja solo, por etapas */}
+      <AutoDibujo d="M20,300 C120,260 …" stage={1} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo d="M60,300 L60,240 …" stage={3} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo as="circle" fade stage={6} cx="300" cy="90" r="26" fill="#cbb96a" />
+    </svg>
+  );
+}
+```
+
+Consumidor de referencia (convertido en este PR): **`dashboard/GuardianEspiritu.jsx`**
+— sus filtros `ge-glow1`/`ge-blur3`, antes inline, hoy salen de `<GlowFilter>`
+(mismo markup, cero regresión visual).
+
+## Técnica y reglas
+
+- **CSS + SVG puros, cero dependencias nuevas**; solo `transform`/`opacity`
+  animados, **blur/filtros ESTÁTICOS** (Android gama baja). Cero JS por frame.
+- Cada helper emite **solo el `<filter>`** (sin `<defs>` propio): el consumidor
+  lo mete en su `<defs>` y referencia por id. **Ids únicos** con `useId` para
+  repetir muchos en una misma página sin colisión.
+- **Reduced-motion-safe**: sin movimiento, el latido queda encendido, el trazo
+  COMPLETO, los planos visibles y velos/grades/viñeta quietos (son estáticos).
+- Las capas-overlay (`.vfx-veil/.vfx-vignette/.vfx-scrim-*/.vfx-grade`) se montan
+  dentro de un contenedor `position: relative`, no capturan toque y heredan el
+  radio del contenedor.
+- Los **grades por piso térmico** nacen tokenizados (`--vfx-piso-*`): cuando la
+  Montaña entre a prod, se re-tiñen desde `themes.css` sin tocar las escenas
+  (§13.2, promoción de los `--mm2-*` recomendada por el catálogo §14b).

--- a/src/visual/effects/effects.css
+++ b/src/visual/effects/effects.css
@@ -1,0 +1,190 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   src/visual/effects/effects.css — EFECTOS visuales reutilizables de Chagra.
+
+   Las TÉCNICAS DE CINE del catálogo (§13) que hoy están redibujadas/re-copiadas
+   en varios mockups y escenas, aquí una sola vez como clases `vfx-*` + custom
+   properties `--vfx-*`. Antes de re-hilvanar un velo/viñeta/grade/latido/trazo,
+   use esto.
+
+   Reglas de la casa respetadas:
+   · Solo `transform`/`opacity` animados; blur/filtros ESTÁTICOS (Android gama baja).
+   · `prefers-reduced-motion` = fotograma final digno (nada roto, nada en loop).
+   · Cero dependencias; cero JS por frame.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Base de las capas-overlay ───────────────────────────────────────────────
+   Todos los velos/viñetas/scrims/grades se montan como una capa absoluta dentro
+   de un contenedor `position: relative`. No capturan toque. Heredan el radio del
+   contenedor para no desbordar tarjetas redondeadas. */
+.vfx-overlay,
+.vfx-veil,
+.vfx-vignette,
+.vfx-scrim-top,
+.vfx-scrim-bottom,
+.vfx-grade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+/* ── 1. VELO atmosférico neón (§13.5 / §13.16) ──────────────────────────────
+   El velo radial teal/orquídea + tinte navy del modo biopunk (receta de
+   finca-viva-hero `.fvh-escena-wrap::after`). Tunéable por custom props para
+   re-teñir sin reescribir el gradiente. Los temas claros lo apagan poniendo
+   `--vfx-veil-opacity: 0`. */
+.vfx-veil {
+  z-index: 6;
+  opacity: var(--vfx-veil-opacity, 1);
+  background:
+    radial-gradient(120% 78% at 80% 12%, var(--vfx-veil-a, rgba(34, 211, 238, 0.26)), transparent 56%),
+    radial-gradient(110% 92% at 16% 92%, var(--vfx-veil-b, rgba(217, 70, 239, 0.22)), transparent 58%),
+    linear-gradient(180deg,
+      var(--vfx-veil-top, rgba(8, 16, 34, 0.42)) 0%,
+      rgba(8, 16, 34, 0.08) 40%,
+      var(--vfx-veil-bottom, rgba(10, 22, 44, 0.36)) 100%);
+  transition: opacity 0.5s ease;
+}
+
+/* ── 2. VIÑETA de cine (§13.5) ───────────────────────────────────────────────
+   Radial que hunde las esquinas para enfocar el centro y que la UI flote sin
+   cajas. `--vfx-vignette-strength` (0..1) modula cuánto oscurece el borde. */
+.vfx-vignette {
+  z-index: 7;
+  background: radial-gradient(120% 120% at 50% 45%,
+    transparent 52%,
+    rgba(0, 0, 0, calc(0.35 * var(--vfx-vignette-strength, 1))) 100%);
+}
+
+/* ── 3. SCRIMS arriba/abajo (§13.5) ──────────────────────────────────────────
+   Degradados en los bordes superior/inferior para que el texto SIEMPRE lea
+   sobre la escena (títulos arriba, compositor abajo). */
+.vfx-scrim-top {
+  z-index: 7;
+  background: linear-gradient(180deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 28%);
+  inset: 0 0 auto 0;
+}
+.vfx-scrim-bottom {
+  z-index: 7;
+  background: linear-gradient(0deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 34%);
+  inset: auto 0 0 0;
+}
+
+/* ── 4. GRADES de luz por PISO TÉRMICO (§13.2) ───────────────────────────────
+   Plano de color fijo al viewport, crossfade por opacity: la TEMPERATURA de la
+   luz cuenta la altura. Azul glacial (nevado) → cian páramo → neutro frío →
+   HORA DORADA (finca templada) → ámbar cálido → turquesa río. Portado de los
+   `--mm2-*` del mockup Montaña (§13.2), tokenizado para promoverse a prod.
+   `--vfx-grade-fuerza` modula la intensidad por dirección artística
+   (naturalista 1 · biopunk 0.45 · verde-vivo 0.75). */
+:root {
+  --vfx-piso-glacial:  rgba(180, 214, 240, 0.50); /* nevado 4.800m */
+  --vfx-piso-paramo:   rgba(120, 200, 210, 0.42); /* páramo */
+  --vfx-piso-frio:     rgba(150, 165, 172, 0.28); /* frío (neutro) */
+  --vfx-piso-templado: rgba(255, 200, 120, 0.34); /* finca ⭐ hora dorada */
+  --vfx-piso-calido:   rgba(255, 170,  90, 0.36); /* cálido ámbar */
+  --vfx-piso-valle:    rgba( 90, 200, 190, 0.40); /* río turquesa 400m */
+}
+.vfx-grade {
+  z-index: 5;
+  background: var(--vfx-grade-color, var(--vfx-piso-templado));
+  opacity: var(--vfx-grade-fuerza, 1);
+  transition: background 0.6s ease, opacity 0.6s ease;
+}
+.vfx-grade--glacial  { --vfx-grade-color: var(--vfx-piso-glacial); }
+.vfx-grade--paramo   { --vfx-grade-color: var(--vfx-piso-paramo); }
+.vfx-grade--frio     { --vfx-grade-color: var(--vfx-piso-frio); }
+.vfx-grade--templado { --vfx-grade-color: var(--vfx-piso-templado); }
+.vfx-grade--calido   { --vfx-grade-color: var(--vfx-piso-calido); }
+.vfx-grade--valle    { --vfx-grade-color: var(--vfx-piso-valle); }
+
+/* ── 5. PULSO CARDÍACO compartido (§13.10) ───────────────────────────────────
+   Una sola variable de duración (`--vfx-beat`) sincroniza TODO lo vivo: la
+   escena late como UN organismo. Es el `--fvo-beat` de SceneFincaOrganismo,
+   promovido a la librería (mismo valor 5.2s = `--motion-beat`). */
+:root { --vfx-beat: 5.2s; }
+
+/* el corazón: doble pulso como corazón real */
+.vfx-beat {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat var(--vfx-beat) ease-in-out infinite;
+}
+@keyframes vfx-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+/* onda que sale del latido */
+.vfx-beat-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat-wave var(--vfx-beat) ease-out infinite;
+}
+@keyframes vfx-beat-wave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red/savia/panel se ENCIENDE con cada latido (solo opacity) */
+.vfx-beat-glow { animation: vfx-beat-glow var(--vfx-beat) ease-in-out infinite; }
+@keyframes vfx-beat-glow {
+  0%, 100% { opacity: 0.55; }
+  8% { opacity: 1; }
+  16% { opacity: 0.7; }
+  22% { opacity: 0.9; }
+  34% { opacity: 0.55; }
+}
+
+/* ── 6. AUTO-DIBUJADO orquestado (§13.11) ────────────────────────────────────
+   `pathLength="1"` normalizado + stroke-dashoffset → 0 + etapas escalonadas.
+   El trazo/grafo/glifo se dibuja solo al entrar. (Receta de SceneTrazoMinimal;
+   el componente `AutoDibujo` pega estas clases y pone `pathLength`.) */
+.vfx-draw {
+  stroke-dasharray: 1 1;
+  stroke-dashoffset: 1;
+  animation: vfx-draw 1.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+@keyframes vfx-draw { to { stroke-dashoffset: 0; } }
+
+/* planos de color que aparecen en fundido (sol, leyenda, humo) */
+.vfx-fade { opacity: 0; animation: vfx-fade 1.1s ease forwards; }
+@keyframes vfx-fade { to { opacity: 1; } }
+
+/* etapas del dibujo — delay heredado por trazos y fundidos del grupo */
+.vfx-t1 .vfx-draw, .vfx-t1.vfx-draw, .vfx-t1 .vfx-fade, .vfx-t1.vfx-fade { animation-delay: 0.15s; }
+.vfx-t2 .vfx-draw, .vfx-t2.vfx-draw, .vfx-t2 .vfx-fade, .vfx-t2.vfx-fade { animation-delay: 0.40s; }
+.vfx-t3 .vfx-draw, .vfx-t3.vfx-draw, .vfx-t3 .vfx-fade, .vfx-t3.vfx-fade { animation-delay: 0.70s; }
+.vfx-t4 .vfx-draw, .vfx-t4.vfx-draw, .vfx-t4 .vfx-fade, .vfx-t4.vfx-fade { animation-delay: 0.95s; }
+.vfx-t5 .vfx-draw, .vfx-t5.vfx-draw, .vfx-t5 .vfx-fade, .vfx-t5.vfx-fade { animation-delay: 1.20s; }
+.vfx-t6 .vfx-draw, .vfx-t6.vfx-draw, .vfx-t6 .vfx-fade, .vfx-t6.vfx-fade { animation-delay: 1.50s; }
+.vfx-t7 .vfx-draw, .vfx-t7.vfx-draw, .vfx-t7 .vfx-fade, .vfx-t7.vfx-fade { animation-delay: 1.80s; }
+.vfx-t8 .vfx-draw, .vfx-t8.vfx-draw, .vfx-t8 .vfx-fade, .vfx-t8.vfx-fade { animation-delay: 2.10s; }
+.vfx-t9 .vfx-draw, .vfx-t9.vfx-draw, .vfx-t9 .vfx-fade, .vfx-t9.vfx-fade { animation-delay: 2.50s; }
+
+/* ── 7. FLUJO por dash (§13.12) ──────────────────────────────────────────────
+   Savia/agua/corriente/micelio: dasharray animado que corre por el trazo.
+   `--vfx-flow-dur` y `--vfx-flow-len` tunéan velocidad y avance. */
+.vfx-flow {
+  stroke-dasharray: 4 8;
+  animation: vfx-flow var(--vfx-flow-dur, 3.2s) linear infinite;
+}
+@keyframes vfx-flow { to { stroke-dashoffset: calc(-1 * var(--vfx-flow-len, 40px)); } }
+
+/* ── prefers-reduced-motion: fotograma final digno ───────────────────────────
+   Nada en loop; el dibujo COMPLETO, los planos visibles, velos/grades/viñeta
+   quietos (son estáticos de por sí). Regla de la casa §13.20. */
+@media (prefers-reduced-motion: reduce) {
+  .vfx-beat, .vfx-beat-wave, .vfx-beat-glow, .vfx-flow { animation: none !important; }
+  .vfx-beat, .vfx-beat-glow { opacity: 1; }
+  .vfx-beat-wave { opacity: 0; }              /* la onda no deja residuo */
+  .vfx-draw { animation: none !important; stroke-dashoffset: 0; }
+  .vfx-fade { animation: none !important; opacity: 1; }
+  .vfx-veil { transition: none; }
+}

--- a/src/visual/effects/index.js
+++ b/src/visual/effects/index.js
@@ -1,0 +1,35 @@
+/*
+ * Librería visual de EFECTOS de Chagra (effects) — las TÉCNICAS DE CINE del
+ * catálogo (§13), una sola vez y reutilizables. Antes de re-hilvanar un
+ * velo/viñeta/grade/glow/latido/auto-dibujado/acuarela, use esto.
+ *
+ * Dos piezas:
+ *   1. `effects.css` — clases `vfx-*` + custom properties `--vfx-*`
+ *      (velos, viñeta, scrims, grades por piso térmico, pulso cardíaco,
+ *      auto-dibujado, flujo por dash). Importalo UNA vez donde lo uses:
+ *          import '../../visual/effects/effects.css';
+ *   2. Helpers SVG (este barrel): `GlowFilter`, `FiltroAcuarela`, `AutoDibujo`.
+ *
+ * Reglas de la casa: solo transform/opacity animados; blur/filtros estáticos;
+ * reduced-motion = fotograma final digno; cero dependencias nuevas.
+ */
+export { GlowFilter } from './GlowFilter.jsx';
+export { FiltroAcuarela } from './FiltroAcuarela.jsx';
+export { AutoDibujo } from './AutoDibujo.jsx';
+
+/* Ritmo del latido/respiración compartido (= `--vfx-beat` en effects.css y
+   `--motion-beat`/`--fvo-beat` en el resto del repo). Útil desde JS cuando una
+   escena necesita sincronizar un timing sin leer el CSS. */
+export const VFX_BEAT_MS = 5200;
+
+/* Registro consultable de los pisos térmicos y su grade de luz (§13.2).
+   `token` = la custom property de effects.css; `clase` = la clase modificadora
+   de `.vfx-grade`. Orden de menor a mayor altura invertido: de nevado a río. */
+export const VFX_PISOS = [
+  { slug: 'glacial',  nombre: 'Nevado',   token: '--vfx-piso-glacial',  clase: 'vfx-grade--glacial',  luz: 'azul glacial' },
+  { slug: 'paramo',   nombre: 'Páramo',   token: '--vfx-piso-paramo',   clase: 'vfx-grade--paramo',   luz: 'cian páramo' },
+  { slug: 'frio',     nombre: 'Frío',     token: '--vfx-piso-frio',     clase: 'vfx-grade--frio',     luz: 'neutro frío' },
+  { slug: 'templado', nombre: 'Templado', token: '--vfx-piso-templado', clase: 'vfx-grade--templado', luz: 'hora dorada' },
+  { slug: 'calido',   nombre: 'Cálido',   token: '--vfx-piso-calido',   clase: 'vfx-grade--calido',   luz: 'ámbar cálido' },
+  { slug: 'valle',    nombre: 'Valle/río', token: '--vfx-piso-valle',   clase: 'vfx-grade--valle',    luz: 'turquesa río' },
+];


### PR DESCRIPTION
## Moonshot #10 — el agente enseña dibujando

Ante una pregunta del campesino, el agente responde con una **lámina que se dibuja sola** frente a él, en vez de un párrafo. Un selector de tres conceptos muestra distinta lámina, cada una con dos o tres frases en **usted colombiano**.

- **Asociación** → la milpa (las tres hermanas): el maíz-tutor, el frijol que fija el nitrógeno, la calabaza que tapa el suelo.
- **Rotación** → rueda de cuatro eras (hoja → fruto → raíz → leguminosa) con lo que cada familia le pide y le devuelve al suelo.
- **Piso térmico** → montaña en corte con los cultivos por altura, del cálido al páramo.

## Reuso
Usa la librería de **efectos** (`src/visual/effects`: `AutoDibujo` + `effects.css`, auto-dibujado escalonado `vfx-draw`/`vfx-fade`), traída a esta rama desde la lib visual. El trazo se re-dispara al cambiar de concepto o con "dibujar otra vez" (re-montaje por `key`). `prefers-reduced-motion` = lámina completa y quieta (garantizado por `effects.css`).

Las tres láminas (`src/mockups/laminas/`) siguen la casa de `src/visual/laminas` (tinta sobre papel crema, `role="img"`, SVG propio sin deps); si se estabilizan, se promoverían allí.

## Dirección educativa
Enseña a **observar**, no a ganar puntos: sin gamificación ni medallas; cada respuesta cierra invitando a mirar el surco.

## Ruta
`#/mockups/ensena-dibujando` — pública (`MOCKUP_HASH_ROUTES`), sin auth ni gate, datos de muestra.

## Verificación
- `npm run build` verde · `eslint` limpio · responsive 320px · sin voseo · sin leaks.
- Sin Playwright ni cambios en alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)