### PR TITLE
feat(mockup): la voz con forma — iris orgánico como identidad visual de la voz

### DIFF
--- a/public/chagra-stats.json
+++ b/public/chagra-stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-09T15:26:08.643Z",
+  "generated_at": "2026-07-10T19:21:07.080Z",
   "schema_version": "1.1.0",
   "catalogo": {
     "especies": 581,

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-09T15:26:08.367Z",
+  "generated_at": "2026-07-10T19:21:06.913Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,6 +89,13 @@ const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').
 // 2026-06-30. Se alcanza desde 'bodega' vía el botón "Auditoría y
 // reconciliación", o directo por hash (#auditoria-inventario).
 const InventoryPage = lazy(() => import('./pages/InventoryPage'));
+// Mockup dev "La voz con forma": la identidad visual de la voz de Chagra —
+// cuando el campesino dice «hola, Chagra», en vez de un micrófono genérico
+// aparece un iris orgánico (anillos de agua/tronco + brasa) que respira,
+// reacciona al volumen y se aquieta al terminar. Ruta #/mockups/voz-con-forma
+// — sin gate ni sesión (datos de muestra, nivel simulado, no cablea el mic).
+// El primitivo reusable vive en src/visual/voz/IrisVoz.jsx.
+const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -418,6 +425,7 @@ const LoadingFallback = ({ view = null }) => {
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
 
 const HASH_VIEW_ROUTES = {
+  'mockups/voz-con-forma': 'mockup_voz_con_forma',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -915,6 +923,13 @@ export default function App() {
       return;
     }
 
+    // Mockups dev (#/mockups/*): vistas aisladas de decisión visual — se
+    // montan sin sesión (datos de muestra, no tocan datos reales).
+    if (hash === 'mockups/voz-con-forma') {
+      Promise.resolve().then(() => navigate(HASH_VIEW_ROUTES[hash]));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -943,6 +958,11 @@ export default function App() {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
+      // Mockups dev: sin gate ni sesión (datos de muestra).
+      if (routeView === 'mockup_voz_con_forma') {
+        navigate(routeView);
+        return;
+      }
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
       if (routeView === 'extensionista' && !esExtensionistaActual()) {
         navigate('dashboard');
@@ -1190,6 +1210,15 @@ export default function App() {
         return (
           <ErrorBoundary>
             <LoginScreen onLoginSuccess={() => navigate('dashboard')} onSave={showToast} />
+          </ErrorBoundary>
+        );
+      case 'mockup_voz_con_forma':
+        // Mockup "La voz con forma": el iris orgánico que es la identidad
+        // visual de la voz de Chagra (anillos de agua/tronco que respiran,
+        // reaccionan al volumen y se aquietan). Sin gate: datos de muestra.
+        return (
+          <ErrorBoundary>
+            <VozConFormaMockup />
           </ErrorBoundary>
         );
       case 'oauth-callback':

--- a/src/mockups/VozConForma.jsx
+++ b/src/mockups/VozConForma.jsx
@@ -1,0 +1,320 @@
+/**
+ * MOCKUP "La voz con forma" — ruta #/mockups/voz-con-forma.
+ *
+ * Cuando el campesino dice «hola, Chagra», en vez de un micrófono genérico
+ * aparece un IRIS orgánico que ES la identidad visual de la voz de Chagra:
+ * anillos concéntricos de agua/tronco que respiran, reaccionan al volumen
+ * y se aquietan al terminar. Cálido y de tierra — NO sci-fi (es el
+ * contrapunto deliberado al astrolabio holográfico de EscuchaOverlay).
+ *
+ * Datos DE MUESTRA (no cablea micrófono ni sesión): decisión visual pura.
+ * El primitivo reusable vive en `src/visual/voz/IrisVoz.jsx`, listo para
+ * producción (recibe el RMS real vía `getNivel`).
+ *
+ * Reusa de la librería visual (src/visual/effects):
+ *  - GlowFilter (el glow canónico, estático) — dentro de IrisVoz.
+ *  - --vfx-beat (5.2s): la respiración del iris late con el resto de la casa.
+ *  - Reglas de la casa: solo transform/opacity, cero setState por frame,
+ *    prefers-reduced-motion = fotograma digno, responsive hasta 320px.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- mockup dev con datos de
+   muestra (no UI de producto); si se productiza, el copy migra a messages.js
+   (ADR-050). */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import IrisVoz from '../visual/voz';
+import '../visual/effects/effects.css';
+import './vozConForma.css';
+
+/* ── La conversación de muestra (guion determinista) ─────────────────────────
+ * Un ciclo completo de la voz: quieta → la llaman → escucha → piensa →
+ * responde → se aquieta. Cada paso fija el estado del iris y qué se ve del
+ * hilo de conversación. Datos plausibles de finca fría (~2.900 m). */
+const GUION = [
+  {
+    estado: 'reposo',
+    dur: 2000,
+    nota: 'La finca está tranquila. La voz apenas respira.',
+  },
+  {
+    estado: 'escuchando',
+    dur: 1300,
+    nota: 'La oyó nombrar: el iris se enciende color miel.',
+    wake: true,
+  },
+  {
+    estado: 'escuchando',
+    dur: 4600,
+    nota: 'Las ondas viajan hacia adentro: su voz entra hasta la brasa.',
+    wake: true,
+    burbujas: 1,
+  },
+  {
+    estado: 'pensando',
+    dur: 2400,
+    nota: 'Los anillos se trenzan: agua dando vueltas antes de aclararse.',
+    wake: true,
+    burbujas: 1,
+  },
+  {
+    estado: 'hablando',
+    dur: 7000,
+    nota: 'Ahora las ondas nacen en la brasa y salen: la voz es de Chagra.',
+    wake: true,
+    burbujas: 2,
+  },
+  {
+    estado: 'reposo',
+    dur: 2600,
+    nota: 'La voz se aquieta hasta que usted la vuelva a llamar.',
+    wake: true,
+    burbujas: 2,
+  },
+];
+
+const BURBUJAS = [
+  {
+    quien: 'campesino',
+    nombre: 'Usted',
+    texto: '¿Cómo amaneció el tomate después del frío de anoche?',
+  },
+  {
+    quien: 'chagra',
+    nombre: 'Chagra',
+    texto:
+      'Anoche bajó a 4 grados en su vereda. Revise las hojas nuevas del lote dos: si amanecieron oscuras o vidriosas, riegue temprano y deje la poda para otro día.',
+  },
+];
+
+const ETIQUETAS = {
+  reposo: 'En reposo',
+  escuchando: 'Escuchando',
+  pensando: 'Pensando',
+  hablando: 'Hablando',
+};
+
+const ANUNCIOS = {
+  reposo: 'La voz está en reposo.',
+  escuchando: 'Chagra está escuchando.',
+  pensando: 'Chagra está pensando.',
+  hablando: 'Chagra está hablando.',
+};
+
+/* ── Anatomía: la regla de cada momento ────────────────────────────────────── */
+const MOMENTOS = [
+  {
+    estado: 'reposo',
+    titulo: 'Reposo',
+    regla: 'Apenas respira, al mismo ritmo que el resto de la casa. La brasa queda en rescoldo: está viva, pero no pide atención.',
+  },
+  {
+    estado: 'escuchando',
+    titulo: 'Escuchando',
+    regla: 'Las ondas viajan hacia adentro — su voz entra hasta el centro. El brillo sube y baja con el volumen real, nada es fingido.',
+  },
+  {
+    estado: 'pensando',
+    titulo: 'Pensando',
+    regla: 'Los anillos se trenzan y giran despacio, como el agua que da vueltas antes de aclararse. Sin nivel: la voz ya está adentro.',
+  },
+  {
+    estado: 'hablando',
+    titulo: 'Hablando',
+    regla: 'Las ondas nacen en la brasa y salen hacia afuera: ahora la voz es de Chagra, y trae el verde de lo que crece.',
+  },
+];
+
+export default function VozConForma() {
+  const [manual, setManual] = useState('reposo');
+  const [reproduciendo, setReproduciendo] = useState(false);
+  const [paso, setPaso] = useState(0);
+  const timerRef = useRef(null);
+
+  const pasoActual = GUION[paso] || GUION[0];
+  const estado = reproduciendo ? pasoActual.estado : manual;
+
+  /* Guion: cada paso agenda el siguiente; al final el ciclo se detiene solo
+     (la voz se aquieta — no dejamos un loop infinito pidiendo atención). */
+  useEffect(() => {
+    if (!reproduciendo) return undefined;
+    timerRef.current = setTimeout(() => {
+      if (paso >= GUION.length - 1) {
+        setReproduciendo(false);
+        setManual('reposo');
+      } else {
+        setPaso((p) => p + 1);
+      }
+    }, pasoActual.dur);
+    return () => clearTimeout(timerRef.current);
+  }, [reproduciendo, paso, pasoActual.dur]);
+
+  const reproducir = () => {
+    setPaso(0);
+    setReproduciendo(true);
+  };
+
+  const elegir = (est) => {
+    setReproduciendo(false);
+    setManual(est);
+  };
+
+  const notaViva = reproduciendo
+    ? pasoActual.nota
+    : MOMENTOS.find((m) => m.estado === estado)?.regla;
+
+  const burbujasVisibles = useMemo(
+    () => (reproduciendo ? BURBUJAS.slice(0, pasoActual.burbujas || 0) : []),
+    [reproduciendo, pasoActual.burbujas],
+  );
+
+  return (
+    <div className="vcf" data-estado={estado}>
+      <div className="vcf-luz" aria-hidden="true" />
+
+      <header className="vcf-cabecera">
+        <p className="vcf-eyebrow">Mockup de galería · decisión visual · datos de muestra</p>
+        <h1 className="vcf-titulo">La voz con forma</h1>
+        <p className="vcf-sub">
+          Cuando usted dice <b>«hola, Chagra»</b>, la app no le muestra un micrófono:
+          le muestra su voz — anillos de agua y de tronco alrededor de una brasa.
+        </p>
+      </header>
+
+      {/* ── El iris, en grande ───────────────────────────────────────────── */}
+      <section className="vcf-hero" aria-label="El iris de la voz">
+        <div className="vcf-escenario">
+          {pasoActual.wake && reproduciendo && (
+            <span className="vcf-wake" aria-hidden="true">«hola, Chagra»</span>
+          )}
+          <IrisVoz estado={estado} size={300} className="vcf-iris-hero" />
+          <p className="vcf-estado" aria-live="polite">
+            <span className="vcf-estado-punto" aria-hidden="true" />
+            {ANUNCIOS[estado]}
+          </p>
+          {notaViva && <p className="vcf-nota">{notaViva}</p>}
+        </div>
+
+        <div className="vcf-mando">
+          <button
+            type="button"
+            className="vcf-btn-demo"
+            onClick={reproducir}
+            disabled={reproduciendo}
+          >
+            {reproduciendo ? 'Conversando…' : 'Ver una conversación'}
+          </button>
+          <div className="vcf-estados" role="group" aria-label="Elegir estado del iris">
+            {MOMENTOS.map((m) => (
+              <button
+                key={m.estado}
+                type="button"
+                className="vcf-btn-estado"
+                aria-pressed={!reproduciendo && manual === m.estado}
+                onClick={() => elegir(m.estado)}
+              >
+                {ETIQUETAS[m.estado]}
+              </button>
+            ))}
+          </div>
+
+          <div className="vcf-hilo" aria-live="polite">
+            {burbujasVisibles.map((b) => (
+              <div key={b.quien} className={`vcf-burbuja vcf-burbuja-${b.quien}`}>
+                <span className="vcf-burbuja-quien">{b.nombre}</span>
+                <p>{b.texto}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Anatomía: un solo gesto, cuatro momentos ─────────────────────── */}
+      <section className="vcf-seccion">
+        <h2>Un solo gesto, cuatro momentos</h2>
+        <p className="vcf-seccion-sub">
+          La forma nunca cambia — cambia la vida que lleva adentro. El movimiento
+          tiene dirección con sentido: escuchar entra, hablar sale.
+        </p>
+        <div className="vcf-momentos">
+          {MOMENTOS.map((m) => (
+            <article key={m.estado} className="vcf-momento">
+              <IrisVoz estado={m.estado} size={104} />
+              <h3>{m.titulo}</h3>
+              <p>{m.regla}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* ── La identidad sobrevive en pequeño ────────────────────────────── */}
+      <section className="vcf-seccion">
+        <h2>La misma voz, en cualquier tamaño</h2>
+        <p className="vcf-seccion-sub">
+          Del chip de la barra al botón de manos libres: es siempre el mismo
+          iris, nunca "otro icono de micrófono".
+        </p>
+        <div className="vcf-tamanos">
+          <figure className="vcf-contexto">
+            <div className="vcf-falsa-barra">
+              <span className="vcf-falsa-marca">Chagra</span>
+              <span className="vcf-falso-chip">
+                <IrisVoz estado="escuchando" size={22} />
+                La estoy oyendo…
+              </span>
+            </div>
+            <figcaption>Chip de estado en la barra (22 px)</figcaption>
+          </figure>
+          <figure className="vcf-contexto">
+            <div className="vcf-falso-pie">
+              <span className="vcf-falsa-pestana">Hoy</span>
+              <span className="vcf-falso-fab">
+                <IrisVoz estado="reposo" size={56} />
+              </span>
+              <span className="vcf-falsa-pestana">Mi finca</span>
+            </div>
+            <figcaption>Botón de manos libres (56 px) — en reposo, apenas respira</figcaption>
+          </figure>
+          <figure className="vcf-contexto">
+            <div className="vcf-falsa-tarjeta">
+              <IrisVoz estado="hablando" size={72} />
+              <div>
+                <b>Chagra le está respondiendo</b>
+                <p>La respuesta también se lee aquí, por si prefiere el texto.</p>
+              </div>
+            </div>
+            <figcaption>Acompañando la respuesta hablada (72 px)</figcaption>
+          </figure>
+        </div>
+      </section>
+
+      {/* ── Nota de intención ────────────────────────────────────────────── */}
+      <section className="vcf-seccion vcf-intencion">
+        <h2>¿Por qué no un micrófono?</h2>
+        <p>
+          El micrófono es el aparato; la voz es la relación. Un icono de micrófono
+          dice "esto graba". El iris dice "esto <em>escucha</em>": se enciende con
+          usted, retiene un instante lo que oyó y se aquieta cuando terminan de
+          hablar. Sus anillos son los de las ondas en una totuma de agua y los del
+          tronco de un árbol viejo — la forma que el campo le da al tiempo y al sonido.
+        </p>
+        <ul className="vcf-fichas">
+          <li>
+            <b>Honesto:</b> el brillo responde al nivel real del micrófono
+            (aquí simulado); no hay animación fingida.
+          </li>
+          <li>
+            <b>De la casa:</b> respira al ritmo compartido (<code>--vfx-beat</code>)
+            y usa el glow canónico de <code>src/visual/effects</code>.
+          </li>
+          <li>
+            <b>Listo para producción:</b> el primitivo vive en
+            <code> src/visual/voz/IrisVoz.jsx</code> — estados, tamaños,
+            <code> getNivel</code> para el RMS real y reduced-motion digno.
+          </li>
+        </ul>
+        <p className="vcf-pie">
+          Ruta <code>#/mockups/voz-con-forma</code> · sin sesión · datos de muestra.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/mockups/vozConForma.css
+++ b/src/mockups/vozConForma.css
@@ -1,0 +1,476 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   vozConForma.css — mockup "La voz con forma" (#/mockups/voz-con-forma).
+
+   La página es una COCINA DE NOCHE: tierra oscura y cálida (nada de navy
+   sci-fi), donde la única fuente de luz es la voz. El fondo se re-tiñe
+   apenas con el estado del iris (la luz de la brasa alcanza la mesa):
+   miel al escuchar, cobre al pensar, musgo al hablar.
+
+   Tipografía: serif de libro viejo para lo dicho (Georgia — cero deps),
+   sans del sistema para la interfaz. Responsive hasta 320 px; solo
+   transform/opacity animados; prefers-reduced-motion sin coreografías.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.vcf {
+  --vcf-tierra: #211712;
+  --vcf-tierra-2: #2b1f17;
+  --vcf-crema: #f2e7d3;
+  --vcf-ceniza: #b7a48c;
+  --vcf-miel: #e9a94e;
+  --vcf-cobre: #c57a45;
+  --vcf-musgo: #b7c98a;
+  --vcf-linea: rgba(233, 169, 78, 0.16);
+  --vcf-luz-ambiente: rgba(217, 133, 73, 0.05);
+
+  position: relative;
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--vcf-tierra);
+  color: var(--vcf-crema);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.55;
+  padding: clamp(20px, 4vw, 56px) clamp(16px, 5vw, 64px) 72px;
+  overflow-x: hidden;
+}
+
+.vcf[data-estado='escuchando'] { --vcf-luz-ambiente: rgba(233, 169, 78, 0.09); }
+.vcf[data-estado='pensando'] { --vcf-luz-ambiente: rgba(197, 122, 69, 0.08); }
+.vcf[data-estado='hablando'] { --vcf-luz-ambiente: rgba(183, 201, 138, 0.08); }
+
+/* la luz que la voz le presta al cuarto (solo opacity/background, barato) */
+.vcf-luz {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(90% 60% at 50% 24%, var(--vcf-luz-ambiente), transparent 70%),
+    radial-gradient(120% 90% at 50% 110%, rgba(0, 0, 0, 0.5), transparent 55%);
+  transition: background 1.1s ease;
+}
+
+.vcf > * { position: relative; }
+
+/* ── cabecera ──────────────────────────────────────────────────────────────── */
+.vcf-cabecera {
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.vcf-eyebrow {
+  margin: 0 0 14px;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--vcf-ceniza);
+}
+
+.vcf-titulo {
+  margin: 0;
+  font-family: Georgia, 'Palatino Linotype', 'Times New Roman', serif;
+  font-weight: 400;
+  font-size: clamp(2.1rem, 6.5vw, 3.6rem);
+  letter-spacing: 0.01em;
+  color: var(--vcf-crema);
+}
+
+.vcf-sub {
+  margin: 14px auto 0;
+  max-width: 56ch;
+  color: var(--vcf-ceniza);
+  font-size: clamp(0.95rem, 2.6vw, 1.08rem);
+}
+
+.vcf-sub b { color: var(--vcf-miel); font-weight: 600; }
+
+/* ── hero: escenario + mando ───────────────────────────────────────────────── */
+.vcf-hero {
+  max-width: 1000px;
+  margin: clamp(28px, 5vw, 56px) auto 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  gap: clamp(20px, 4vw, 48px);
+  align-items: start;
+}
+
+.vcf-escenario {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+  padding-top: 8px;
+}
+
+.vcf-iris-hero {
+  width: clamp(200px, 62vw, 300px) !important;
+  height: auto !important;
+  aspect-ratio: 1;
+}
+
+/* «hola, Chagra»: el llamado flota sobre el iris mientras dura el ciclo */
+.vcf-wake {
+  font-family: Georgia, serif;
+  font-style: italic;
+  font-size: 1.02rem;
+  color: var(--vcf-miel);
+  opacity: 0;
+  animation: vcf-wake 0.9s ease forwards;
+}
+
+@keyframes vcf-wake {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.vcf-estado {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  margin: 4px 0 0;
+  font-size: 0.92rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--vcf-crema);
+}
+
+.vcf-estado-punto {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--vcf-miel);
+  transition: background 0.7s ease;
+}
+
+.vcf[data-estado='reposo'] .vcf-estado-punto { background: #8d6b4d; }
+.vcf[data-estado='pensando'] .vcf-estado-punto { background: var(--vcf-cobre); }
+.vcf[data-estado='hablando'] .vcf-estado-punto { background: var(--vcf-musgo); }
+
+.vcf-nota {
+  margin: 0;
+  max-width: 40ch;
+  min-height: 3.2em;
+  font-size: 0.88rem;
+  color: var(--vcf-ceniza);
+}
+
+/* ── mando: demo + estados + hilo ──────────────────────────────────────────── */
+.vcf-mando {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.vcf-btn-demo {
+  align-self: stretch;
+  padding: 14px 18px;
+  border: 1px solid var(--vcf-linea);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(233, 169, 78, 0.16), rgba(233, 169, 78, 0.07));
+  color: var(--vcf-crema);
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.3s ease;
+}
+
+.vcf-btn-demo:hover:not(:disabled) { transform: translateY(-1px); }
+.vcf-btn-demo:disabled { opacity: 0.75; cursor: default; }
+
+.vcf-estados {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+  gap: 8px;
+}
+
+.vcf-btn-estado {
+  padding: 10px 8px;
+  border: 1px solid var(--vcf-linea);
+  border-radius: 11px;
+  background: rgba(242, 231, 211, 0.04);
+  color: var(--vcf-ceniza);
+  font-size: 0.86rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+}
+
+.vcf-btn-estado:hover { color: var(--vcf-crema); }
+
+.vcf-btn-estado[aria-pressed='true'] {
+  color: var(--vcf-tierra);
+  background: var(--vcf-miel);
+  border-color: var(--vcf-miel);
+}
+
+.vcf-btn-demo:focus-visible,
+.vcf-btn-estado:focus-visible {
+  outline: 2px solid var(--vcf-miel);
+  outline-offset: 2px;
+}
+
+/* el hilo de la conversación de muestra */
+.vcf-hilo {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 148px;
+}
+
+.vcf-burbuja {
+  max-width: 92%;
+  padding: 12px 15px;
+  border-radius: 15px;
+  font-size: 0.92rem;
+  opacity: 0;
+  animation: vcf-burbuja 0.5s ease forwards;
+}
+
+@keyframes vcf-burbuja {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.vcf-burbuja p {
+  margin: 3px 0 0;
+  font-family: Georgia, serif;
+  font-size: 0.98rem;
+  line-height: 1.5;
+}
+
+.vcf-burbuja-quien {
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.vcf-burbuja-campesino {
+  align-self: flex-end;
+  background: rgba(233, 169, 78, 0.13);
+  border: 1px solid rgba(233, 169, 78, 0.22);
+  border-bottom-right-radius: 5px;
+}
+
+.vcf-burbuja-chagra {
+  align-self: flex-start;
+  background: rgba(183, 201, 138, 0.1);
+  border: 1px solid rgba(183, 201, 138, 0.2);
+  border-bottom-left-radius: 5px;
+}
+
+/* ── secciones ─────────────────────────────────────────────────────────────── */
+.vcf-seccion {
+  max-width: 1000px;
+  margin: clamp(48px, 8vw, 88px) auto 0;
+}
+
+.vcf-seccion h2 {
+  margin: 0;
+  font-family: Georgia, 'Palatino Linotype', serif;
+  font-weight: 400;
+  font-size: clamp(1.4rem, 4vw, 1.9rem);
+}
+
+.vcf-seccion-sub {
+  margin: 8px 0 0;
+  max-width: 62ch;
+  color: var(--vcf-ceniza);
+  font-size: 0.94rem;
+}
+
+/* anatomía: 4 momentos */
+.vcf-momentos {
+  margin-top: 26px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
+}
+
+.vcf-momento {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 10px;
+  padding: 22px 16px 20px;
+  border: 1px solid var(--vcf-linea);
+  border-radius: 18px;
+  background: linear-gradient(180deg, var(--vcf-tierra-2), rgba(43, 31, 23, 0.4));
+}
+
+.vcf-momento h3 {
+  margin: 2px 0 0;
+  font-size: 1rem;
+  letter-spacing: 0.03em;
+}
+
+.vcf-momento p {
+  margin: 0;
+  font-size: 0.84rem;
+  color: var(--vcf-ceniza);
+}
+
+/* ── la identidad en pequeño: contextos falsos ─────────────────────────────── */
+.vcf-tamanos {
+  margin-top: 26px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 14px;
+}
+
+.vcf-contexto {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.vcf-contexto figcaption {
+  font-size: 0.8rem;
+  color: var(--vcf-ceniza);
+  text-align: center;
+}
+
+.vcf-falsa-barra,
+.vcf-falso-pie,
+.vcf-falsa-tarjeta {
+  border: 1px solid var(--vcf-linea);
+  border-radius: 16px;
+  background: var(--vcf-tierra-2);
+  min-height: 84px;
+}
+
+.vcf-falsa-barra {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+}
+
+.vcf-falsa-marca {
+  font-family: Georgia, serif;
+  font-size: 1.05rem;
+  color: var(--vcf-crema);
+}
+
+.vcf-falso-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px 6px 7px;
+  border: 1px solid var(--vcf-linea);
+  border-radius: 999px;
+  font-size: 0.8rem;
+  color: var(--vcf-ceniza);
+  background: rgba(233, 169, 78, 0.07);
+}
+
+.vcf-falso-pie {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+}
+
+.vcf-falsa-pestana { font-size: 0.82rem; color: var(--vcf-ceniza); }
+
+.vcf-falso-fab {
+  display: grid;
+  place-items: center;
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  border: 1px solid var(--vcf-linea);
+  background: radial-gradient(circle at 50% 38%, rgba(233, 169, 78, 0.13), rgba(33, 23, 18, 0.9));
+  transform: translateY(-14px);
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.45);
+}
+
+.vcf-falsa-tarjeta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+}
+
+.vcf-falsa-tarjeta b { font-size: 0.9rem; }
+
+.vcf-falsa-tarjeta p {
+  margin: 3px 0 0;
+  font-size: 0.8rem;
+  color: var(--vcf-ceniza);
+}
+
+/* ── nota de intención ─────────────────────────────────────────────────────── */
+.vcf-intencion {
+  max-width: 720px;
+}
+
+.vcf-intencion > p {
+  margin: 14px 0 0;
+  font-family: Georgia, serif;
+  font-size: clamp(1rem, 2.8vw, 1.12rem);
+  line-height: 1.7;
+  color: var(--vcf-crema);
+}
+
+.vcf-intencion em { color: var(--vcf-miel); }
+
+.vcf-fichas {
+  margin: 20px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.vcf-fichas li {
+  padding: 12px 15px;
+  border: 1px solid var(--vcf-linea);
+  border-radius: 13px;
+  background: var(--vcf-tierra-2);
+  font-size: 0.88rem;
+  color: var(--vcf-ceniza);
+}
+
+.vcf-fichas b { color: var(--vcf-crema); }
+
+.vcf code {
+  font-family: ui-monospace, 'Cascadia Mono', Menlo, monospace;
+  font-size: 0.85em;
+  color: var(--vcf-miel);
+}
+
+.vcf-pie {
+  margin: 26px 0 0;
+  font-size: 0.8rem;
+  color: var(--vcf-ceniza);
+  text-align: center;
+}
+
+/* ── responsive ────────────────────────────────────────────────────────────── */
+@media (max-width: 780px) {
+  .vcf-hero { grid-template-columns: 1fr; }
+  .vcf-nota { min-height: 0; }
+  .vcf-hilo { min-height: 0; }
+}
+
+@media (max-width: 360px) {
+  .vcf { padding-left: 12px; padding-right: 12px; }
+  .vcf-estados { grid-template-columns: 1fr 1fr; }
+}
+
+/* ── prefers-reduced-motion: sin coreografías ──────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .vcf-wake,
+  .vcf-burbuja {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+  .vcf-luz { transition: none; }
+  .vcf-btn-demo,
+  .vcf-btn-estado { transition: none; }
+  .vcf-btn-demo:hover:not(:disabled) { transform: none; }
+}

--- a/src/visual/effects/AutoDibujo.jsx
+++ b/src/visual/effects/AutoDibujo.jsx
@@ -1,0 +1,35 @@
+/*
+ * AutoDibujo — el AUTO-DIBUJADO orquestado compartido (§13.11 del catálogo).
+ *
+ * La receta de SceneTrazoMinimal ("el trazo se dibuja solo al entrar"):
+ * `pathLength="1"` normalizado + `stroke-dashoffset` que va a 0 + etapas con
+ * delay escalonado. Aquí queda como helper para no re-cablear el dasharray a
+ * mano en cada lámina/onboarding/glifo.
+ *
+ * El movimiento vive en `effects.css` (clases `vfx-draw`, `vfx-fade`,
+ * `vfx-t1…vfx-t9`); este componente solo pega las clases correctas y pone
+ * `pathLength="1"` para que el draw-in sea independiente de la longitud real
+ * del trazo. Reduced-motion = el dibujo COMPLETO y quieto (lo garantiza el CSS).
+ *
+ * Recuerde importar el CSS una vez en la escena:  import '.../effects/effects.css'
+ *
+ * @param {object}  props
+ * @param {'path'|'line'|'polyline'|'circle'|'rect'|string} [props.as='path']
+ *        elemento SVG a renderizar.
+ * @param {number}  [props.stage]      etapa 1..9 (delay escalonado del dibujo).
+ * @param {boolean} [props.fade=false] `true` = aparece en fundido (opacity) en
+ *        vez de trazarse — para planos de color (sol, leyenda, humo).
+ * @param {string}  [props.className]  clases extra.
+ * Resto de props (`d`, `stroke`, `strokeWidth`, `fill`, `cx`…) se pasan tal cual.
+ */
+export function AutoDibujo({ as = 'path', stage, fade = false, className, ...rest }) {
+  const El = as;
+  const base = fade ? 'vfx-fade' : 'vfx-draw';
+  const stageClass = stage ? ` vfx-t${stage}` : '';
+  const cls = `${base}${stageClass}${className ? ` ${className}` : ''}`;
+  // pathLength normaliza el dashoffset a [0..1]; solo aplica al modo trazo.
+  const drawProps = fade ? {} : { pathLength: 1 };
+  return <El className={cls} {...drawProps} {...rest} />;
+}
+
+export default AutoDibujo;

--- a/src/visual/effects/FiltroAcuarela.jsx
+++ b/src/visual/effects/FiltroAcuarela.jsx
@@ -1,0 +1,58 @@
+/*
+ * FiltroAcuarela — el borde/relleno "pintado a la acuarela" compartido
+ * (feTurbulence + feDisplacementMap).
+ *
+ * Da a un trazo o relleno SVG el borde húmedo, irregular y sangrado de la
+ * acuarela: la turbulencia genera un ruido fractal y el displacement empuja los
+ * píxeles según ese ruido. Es la receta que dibuja los bordes del mapa-acuarela
+ * en vez de re-hilvanar un `<filter>` inline por mockup.
+ *
+ * Emite SOLO el `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y lo referencia con `filter={`url(#${id})`}`. Pasar ids únicos
+ * (`useId`) para repetir varios en la misma página sin colisión.
+ *
+ * Reduced-motion-safe por construcción: el filtro es ESTÁTICO (no anima), en
+ * línea con la regla de la casa "blur/filtros estáticos, solo transform/opacity
+ * animados".
+ *
+ * @param {object} props
+ * @param {string}  props.id                 id del filtro (obligatorio).
+ * @param {number} [props.frequency=0.012]   baseFrequency del ruido (más alto =
+ *                                           borde más nervioso/fino).
+ * @param {number} [props.scale=6]           fuerza del desplazamiento en px.
+ * @param {number} [props.octaves=2]         numOctaves del fractalNoise.
+ * @param {number} [props.seed=7]            semilla del ruido (determinista).
+ * @param {string} [props.bounds='-20%']     origen del box del filtro (x/y).
+ */
+export function FiltroAcuarela({
+  id,
+  frequency = 0.012,
+  scale = 6,
+  octaves = 2,
+  seed = 7,
+  bounds = '-20%',
+}) {
+  const off = parseFloat(bounds);
+  const size = `${100 - 2 * off}%`;
+  const noise = `${id}-noise`;
+  return (
+    <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+      <feTurbulence
+        type="fractalNoise"
+        baseFrequency={frequency}
+        numOctaves={octaves}
+        seed={seed}
+        result={noise}
+      />
+      <feDisplacementMap
+        in="SourceGraphic"
+        in2={noise}
+        scale={scale}
+        xChannelSelector="R"
+        yChannelSelector="G"
+      />
+    </filter>
+  );
+}
+
+export default FiltroAcuarela;

--- a/src/visual/effects/GlowFilter.jsx
+++ b/src/visual/effects/GlowFilter.jsx
@@ -1,0 +1,44 @@
+/*
+ * GlowFilter — el GLOW neón orgánico compartido de Chagra (§13.16 del catálogo).
+ *
+ * Es la MISMA receta que hoy está copiada como `<filter>` inline en varias
+ * escenas y en la librería de fauna (GuardianEspiritu `ge-glow1`, creatures
+ * `CreatureFilters`, SceneFincaOrganismo `fvo-glow1`…): un feGaussianBlur
+ * fundido con el original vía feMerge, más — opcionalmente — un blur suave
+ * suelto para halos/estelas. Aquí vive la versión canónica.
+ *
+ * Emite SOLO los `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y referencia por id. Como cada escena decide su id, se pueden repetir
+ * muchos glows en una misma página sin colisión (pasar ids únicos con `useId`).
+ *
+ * @param {object} props
+ * @param {string}  props.id              id del filtro de glow (obligatorio).
+ * @param {number} [props.std=2.1]        desenfoque del glow (stdDeviation).
+ * @param {string} [props.blurId]         si se pasa, emite además un blur suelto
+ *                                        con este id (para halos/estelas).
+ * @param {number} [props.blurStd=3]      desenfoque del blur suelto.
+ * @param {string} [props.bounds='-80%']  origen del box del filtro (x/y); el
+ *                                        ancho/alto se calculan como 100%-2*bounds.
+ */
+export function GlowFilter({ id, std = 2.1, blurId, blurStd = 3, bounds = '-80%' }) {
+  const off = parseFloat(bounds); // -80  → box de 260%
+  const size = `${100 - 2 * off}%`;
+  return (
+    <>
+      <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+        <feGaussianBlur stdDeviation={std} result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      {blurId ? (
+        <filter id={blurId}>
+          <feGaussianBlur stdDeviation={blurStd} />
+        </filter>
+      ) : null}
+    </>
+  );
+}
+
+export default GlowFilter;

--- a/src/visual/effects/README.md
+++ b/src/visual/effects/README.md
@@ -1,0 +1,118 @@
+# `src/visual/effects` — efectos visuales reutilizables
+
+Librería de las **técnicas de cine** de Chagra (las que dan el "wow": velos,
+viñeta, scrims, grades de luz por piso térmico, glow, pulso cardíaco,
+auto-dibujado, acuarela) como **CSS + helpers SVG limpios, parametrizables y sin
+dependencias nuevas**. Nace para **dejar de re-hilvanar el mismo efecto** en
+cada mockup/escena: hoy el velo neón, la viñeta, los grades `--mm2-*`, el glow
+`feMerge`, el latido `--fvo-beat`, el trazo que se dibuja solo y el filtro
+acuarela aparecían copiados/redibujados en `finca-viva-hero.css`,
+`scene-finca-organismo.css`, `scene-trazo-minimal.css`, `GuardianEspiritu`, los
+mockups de la Montaña y el mapa-acuarela. Aquí vive la **versión canónica**.
+
+Hermana de [`src/visual/creatures`](../creatures/README.md) (personajes de
+fauna): misma filosofía, mismo contrato de reuso.
+
+## Regla de la casa
+
+> **Antes de re-dibujar un efecto de cine, búsquelo aquí.**
+> Si existe → **reúselo** (y de ser posible, **mejore** la versión canónica,
+> para que todos hereden la mejora).
+> Si crea un efecto nuevo reutilizable → **agréguelo aquí en el mismo PR**
+> (clase/helper + entrada en `index.js` + fila en esta tabla).
+
+## Qué hay
+
+| Efecto | Cómo se usa | Catálogo | Semilla |
+|---|---|---|---|
+| **Velo atmosférico** neón | clase `.vfx-veil` (custom props `--vfx-veil-a/b/opacity`) | §13.5 / §13.16 | `finca-viva-hero` `.fvh-escena-wrap::after` |
+| **Viñeta** de cine | clase `.vfx-vignette` (`--vfx-vignette-strength`) | §13.5 | idem |
+| **Scrims** arriba/abajo | clases `.vfx-scrim-top` / `.vfx-scrim-bottom` (`--vfx-scrim-color/-h`) | §13.5 | idem |
+| **Grades de luz por piso térmico** | clase `.vfx-grade` + modificador `.vfx-grade--{glacial,paramo,frio,templado,calido,valle}`; tokens `--vfx-piso-*`; `--vfx-grade-fuerza` por dirección | §13.2 | los `--mm2-*` de Montaña |
+| **Glow** (feMerge) | helper `<GlowFilter id std blurId />` | §13.16 | unifica `ge-glow1` + `creatures/_filters` |
+| **Pulso cardíaco** | token `--vfx-beat` + clases `.vfx-beat`, `.vfx-beat-wave`, `.vfx-beat-glow` | §13.10 | `--fvo-beat` (SceneFincaOrganismo) |
+| **Auto-dibujado** | helper `<AutoDibujo stage fade />` + clases `.vfx-draw/.vfx-fade/.vfx-t1…t9` | §13.11 | SceneTrazoMinimal `fvm-t*` |
+| **Flujo por dash** | clase `.vfx-flow` (`--vfx-flow-dur/-len`) | §13.12 | `fvo-flow` / `adm-sap` |
+| **Filtro acuarela** | helper `<FiltroAcuarela id scale frequency />` | — | mapa-acuarela (feTurbulence+feDisplacementMap) |
+
+## Dos formas de consumir
+
+**1. CSS** (velos, viñeta, scrims, grades, latido, auto-dibujado, flujo).
+Importe el CSS una vez donde lo use y ponga las clases:
+
+```jsx
+import '../../visual/effects/effects.css';
+
+// una escena con cielo de biopunk y hora dorada en la finca:
+<div style={{ position: 'relative' }}>
+  <MiEscenaSVG />
+  <div className="vfx-grade vfx-grade--templado" />   {/* luz de la finca  */}
+  <div className="vfx-veil" />                          {/* velo neón        */}
+  <div className="vfx-scrim-bottom" />                  {/* para que el texto lea */}
+  <div className="vfx-vignette" />                      {/* enfoca el centro */}
+</div>
+```
+
+El pulso cardíaco sincroniza todo lo vivo con una sola variable:
+
+```jsx
+// el corazón late, la red se enciende en fase, la onda se expande:
+<g className="vfx-beat"><path d="…corazón…" /></g>
+<g className="vfx-beat-glow"><path d="…red micorrízica…" /></g>
+<circle className="vfx-beat-wave" r="8" />
+// para acelerar/frenar TODO junto:  style={{ '--vfx-beat': '4s' }} en un ancestro
+```
+
+**2. Helpers SVG** (glow, acuarela, auto-dibujado). Se montan en tu `<defs>` /
+tu SVG. Cada instancia usa **ids únicos** (`useId`) para repetirse sin colisión:
+
+```jsx
+import { useId } from 'react';
+import { GlowFilter, FiltroAcuarela, AutoDibujo } from '../../visual/effects';
+import '../../visual/effects/effects.css';
+
+function MiEscena() {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `glow-${uid}`;
+  const agua = `acuarela-${uid}`;
+  return (
+    <svg viewBox="0 0 390 486">
+      <defs>
+        <GlowFilter id={glow} std={2.2} blurId={`blur-${uid}`} />
+        <FiltroAcuarela id={agua} scale={7} frequency={0.014} />
+      </defs>
+
+      {/* glow neón sobre lo vivo */}
+      <g filter={`url(#${glow})`}>{/* … */}</g>
+
+      {/* un relieve/mancha con borde de acuarela */}
+      <path d="…" fill="#6f9a85" filter={`url(#${agua})`} />
+
+      {/* el trazo se dibuja solo, por etapas */}
+      <AutoDibujo d="M20,300 C120,260 …" stage={1} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo d="M60,300 L60,240 …" stage={3} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo as="circle" fade stage={6} cx="300" cy="90" r="26" fill="#cbb96a" />
+    </svg>
+  );
+}
+```
+
+Consumidor de referencia (convertido en este PR): **`dashboard/GuardianEspiritu.jsx`**
+— sus filtros `ge-glow1`/`ge-blur3`, antes inline, hoy salen de `<GlowFilter>`
+(mismo markup, cero regresión visual).
+
+## Técnica y reglas
+
+- **CSS + SVG puros, cero dependencias nuevas**; solo `transform`/`opacity`
+  animados, **blur/filtros ESTÁTICOS** (Android gama baja). Cero JS por frame.
+- Cada helper emite **solo el `<filter>`** (sin `<defs>` propio): el consumidor
+  lo mete en su `<defs>` y referencia por id. **Ids únicos** con `useId` para
+  repetir muchos en una misma página sin colisión.
+- **Reduced-motion-safe**: sin movimiento, el latido queda encendido, el trazo
+  COMPLETO, los planos visibles y velos/grades/viñeta quietos (son estáticos).
+- Las capas-overlay (`.vfx-veil/.vfx-vignette/.vfx-scrim-*/.vfx-grade`) se montan
+  dentro de un contenedor `position: relative`, no capturan toque y heredan el
+  radio del contenedor.
+- Los **grades por piso térmico** nacen tokenizados (`--vfx-piso-*`): cuando la
+  Montaña entre a prod, se re-tiñen desde `themes.css` sin tocar las escenas
+  (§13.2, promoción de los `--mm2-*` recomendada por el catálogo §14b).

--- a/src/visual/effects/effects.css
+++ b/src/visual/effects/effects.css
@@ -1,0 +1,190 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   src/visual/effects/effects.css — EFECTOS visuales reutilizables de Chagra.
+
+   Las TÉCNICAS DE CINE del catálogo (§13) que hoy están redibujadas/re-copiadas
+   en varios mockups y escenas, aquí una sola vez como clases `vfx-*` + custom
+   properties `--vfx-*`. Antes de re-hilvanar un velo/viñeta/grade/latido/trazo,
+   use esto.
+
+   Reglas de la casa respetadas:
+   · Solo `transform`/`opacity` animados; blur/filtros ESTÁTICOS (Android gama baja).
+   · `prefers-reduced-motion` = fotograma final digno (nada roto, nada en loop).
+   · Cero dependencias; cero JS por frame.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Base de las capas-overlay ───────────────────────────────────────────────
+   Todos los velos/viñetas/scrims/grades se montan como una capa absoluta dentro
+   de un contenedor `position: relative`. No capturan toque. Heredan el radio del
+   contenedor para no desbordar tarjetas redondeadas. */
+.vfx-overlay,
+.vfx-veil,
+.vfx-vignette,
+.vfx-scrim-top,
+.vfx-scrim-bottom,
+.vfx-grade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+/* ── 1. VELO atmosférico neón (§13.5 / §13.16) ──────────────────────────────
+   El velo radial teal/orquídea + tinte navy del modo biopunk (receta de
+   finca-viva-hero `.fvh-escena-wrap::after`). Tunéable por custom props para
+   re-teñir sin reescribir el gradiente. Los temas claros lo apagan poniendo
+   `--vfx-veil-opacity: 0`. */
+.vfx-veil {
+  z-index: 6;
+  opacity: var(--vfx-veil-opacity, 1);
+  background:
+    radial-gradient(120% 78% at 80% 12%, var(--vfx-veil-a, rgba(34, 211, 238, 0.26)), transparent 56%),
+    radial-gradient(110% 92% at 16% 92%, var(--vfx-veil-b, rgba(217, 70, 239, 0.22)), transparent 58%),
+    linear-gradient(180deg,
+      var(--vfx-veil-top, rgba(8, 16, 34, 0.42)) 0%,
+      rgba(8, 16, 34, 0.08) 40%,
+      var(--vfx-veil-bottom, rgba(10, 22, 44, 0.36)) 100%);
+  transition: opacity 0.5s ease;
+}
+
+/* ── 2. VIÑETA de cine (§13.5) ───────────────────────────────────────────────
+   Radial que hunde las esquinas para enfocar el centro y que la UI flote sin
+   cajas. `--vfx-vignette-strength` (0..1) modula cuánto oscurece el borde. */
+.vfx-vignette {
+  z-index: 7;
+  background: radial-gradient(120% 120% at 50% 45%,
+    transparent 52%,
+    rgba(0, 0, 0, calc(0.35 * var(--vfx-vignette-strength, 1))) 100%);
+}
+
+/* ── 3. SCRIMS arriba/abajo (§13.5) ──────────────────────────────────────────
+   Degradados en los bordes superior/inferior para que el texto SIEMPRE lea
+   sobre la escena (títulos arriba, compositor abajo). */
+.vfx-scrim-top {
+  z-index: 7;
+  background: linear-gradient(180deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 28%);
+  inset: 0 0 auto 0;
+}
+.vfx-scrim-bottom {
+  z-index: 7;
+  background: linear-gradient(0deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 34%);
+  inset: auto 0 0 0;
+}
+
+/* ── 4. GRADES de luz por PISO TÉRMICO (§13.2) ───────────────────────────────
+   Plano de color fijo al viewport, crossfade por opacity: la TEMPERATURA de la
+   luz cuenta la altura. Azul glacial (nevado) → cian páramo → neutro frío →
+   HORA DORADA (finca templada) → ámbar cálido → turquesa río. Portado de los
+   `--mm2-*` del mockup Montaña (§13.2), tokenizado para promoverse a prod.
+   `--vfx-grade-fuerza` modula la intensidad por dirección artística
+   (naturalista 1 · biopunk 0.45 · verde-vivo 0.75). */
+:root {
+  --vfx-piso-glacial:  rgba(180, 214, 240, 0.50); /* nevado 4.800m */
+  --vfx-piso-paramo:   rgba(120, 200, 210, 0.42); /* páramo */
+  --vfx-piso-frio:     rgba(150, 165, 172, 0.28); /* frío (neutro) */
+  --vfx-piso-templado: rgba(255, 200, 120, 0.34); /* finca ⭐ hora dorada */
+  --vfx-piso-calido:   rgba(255, 170,  90, 0.36); /* cálido ámbar */
+  --vfx-piso-valle:    rgba( 90, 200, 190, 0.40); /* río turquesa 400m */
+}
+.vfx-grade {
+  z-index: 5;
+  background: var(--vfx-grade-color, var(--vfx-piso-templado));
+  opacity: var(--vfx-grade-fuerza, 1);
+  transition: background 0.6s ease, opacity 0.6s ease;
+}
+.vfx-grade--glacial  { --vfx-grade-color: var(--vfx-piso-glacial); }
+.vfx-grade--paramo   { --vfx-grade-color: var(--vfx-piso-paramo); }
+.vfx-grade--frio     { --vfx-grade-color: var(--vfx-piso-frio); }
+.vfx-grade--templado { --vfx-grade-color: var(--vfx-piso-templado); }
+.vfx-grade--calido   { --vfx-grade-color: var(--vfx-piso-calido); }
+.vfx-grade--valle    { --vfx-grade-color: var(--vfx-piso-valle); }
+
+/* ── 5. PULSO CARDÍACO compartido (§13.10) ───────────────────────────────────
+   Una sola variable de duración (`--vfx-beat`) sincroniza TODO lo vivo: la
+   escena late como UN organismo. Es el `--fvo-beat` de SceneFincaOrganismo,
+   promovido a la librería (mismo valor 5.2s = `--motion-beat`). */
+:root { --vfx-beat: 5.2s; }
+
+/* el corazón: doble pulso como corazón real */
+.vfx-beat {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat var(--vfx-beat) ease-in-out infinite;
+}
+@keyframes vfx-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+/* onda que sale del latido */
+.vfx-beat-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat-wave var(--vfx-beat) ease-out infinite;
+}
+@keyframes vfx-beat-wave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red/savia/panel se ENCIENDE con cada latido (solo opacity) */
+.vfx-beat-glow { animation: vfx-beat-glow var(--vfx-beat) ease-in-out infinite; }
+@keyframes vfx-beat-glow {
+  0%, 100% { opacity: 0.55; }
+  8% { opacity: 1; }
+  16% { opacity: 0.7; }
+  22% { opacity: 0.9; }
+  34% { opacity: 0.55; }
+}
+
+/* ── 6. AUTO-DIBUJADO orquestado (§13.11) ────────────────────────────────────
+   `pathLength="1"` normalizado + stroke-dashoffset → 0 + etapas escalonadas.
+   El trazo/grafo/glifo se dibuja solo al entrar. (Receta de SceneTrazoMinimal;
+   el componente `AutoDibujo` pega estas clases y pone `pathLength`.) */
+.vfx-draw {
+  stroke-dasharray: 1 1;
+  stroke-dashoffset: 1;
+  animation: vfx-draw 1.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+@keyframes vfx-draw { to { stroke-dashoffset: 0; } }
+
+/* planos de color que aparecen en fundido (sol, leyenda, humo) */
+.vfx-fade { opacity: 0; animation: vfx-fade 1.1s ease forwards; }
+@keyframes vfx-fade { to { opacity: 1; } }
+
+/* etapas del dibujo — delay heredado por trazos y fundidos del grupo */
+.vfx-t1 .vfx-draw, .vfx-t1.vfx-draw, .vfx-t1 .vfx-fade, .vfx-t1.vfx-fade { animation-delay: 0.15s; }
+.vfx-t2 .vfx-draw, .vfx-t2.vfx-draw, .vfx-t2 .vfx-fade, .vfx-t2.vfx-fade { animation-delay: 0.40s; }
+.vfx-t3 .vfx-draw, .vfx-t3.vfx-draw, .vfx-t3 .vfx-fade, .vfx-t3.vfx-fade { animation-delay: 0.70s; }
+.vfx-t4 .vfx-draw, .vfx-t4.vfx-draw, .vfx-t4 .vfx-fade, .vfx-t4.vfx-fade { animation-delay: 0.95s; }
+.vfx-t5 .vfx-draw, .vfx-t5.vfx-draw, .vfx-t5 .vfx-fade, .vfx-t5.vfx-fade { animation-delay: 1.20s; }
+.vfx-t6 .vfx-draw, .vfx-t6.vfx-draw, .vfx-t6 .vfx-fade, .vfx-t6.vfx-fade { animation-delay: 1.50s; }
+.vfx-t7 .vfx-draw, .vfx-t7.vfx-draw, .vfx-t7 .vfx-fade, .vfx-t7.vfx-fade { animation-delay: 1.80s; }
+.vfx-t8 .vfx-draw, .vfx-t8.vfx-draw, .vfx-t8 .vfx-fade, .vfx-t8.vfx-fade { animation-delay: 2.10s; }
+.vfx-t9 .vfx-draw, .vfx-t9.vfx-draw, .vfx-t9 .vfx-fade, .vfx-t9.vfx-fade { animation-delay: 2.50s; }
+
+/* ── 7. FLUJO por dash (§13.12) ──────────────────────────────────────────────
+   Savia/agua/corriente/micelio: dasharray animado que corre por el trazo.
+   `--vfx-flow-dur` y `--vfx-flow-len` tunéan velocidad y avance. */
+.vfx-flow {
+  stroke-dasharray: 4 8;
+  animation: vfx-flow var(--vfx-flow-dur, 3.2s) linear infinite;
+}
+@keyframes vfx-flow { to { stroke-dashoffset: calc(-1 * var(--vfx-flow-len, 40px)); } }
+
+/* ── prefers-reduced-motion: fotograma final digno ───────────────────────────
+   Nada en loop; el dibujo COMPLETO, los planos visibles, velos/grades/viñeta
+   quietos (son estáticos de por sí). Regla de la casa §13.20. */
+@media (prefers-reduced-motion: reduce) {
+  .vfx-beat, .vfx-beat-wave, .vfx-beat-glow, .vfx-flow { animation: none !important; }
+  .vfx-beat, .vfx-beat-glow { opacity: 1; }
+  .vfx-beat-wave { opacity: 0; }              /* la onda no deja residuo */
+  .vfx-draw { animation: none !important; stroke-dashoffset: 0; }
+  .vfx-fade { animation: none !important; opacity: 1; }
+  .vfx-veil { transition: none; }
+}

--- a/src/visual/effects/index.js
+++ b/src/visual/effects/index.js
@@ -1,0 +1,35 @@
+/*
+ * Librería visual de EFECTOS de Chagra (effects) — las TÉCNICAS DE CINE del
+ * catálogo (§13), una sola vez y reutilizables. Antes de re-hilvanar un
+ * velo/viñeta/grade/glow/latido/auto-dibujado/acuarela, use esto.
+ *
+ * Dos piezas:
+ *   1. `effects.css` — clases `vfx-*` + custom properties `--vfx-*`
+ *      (velos, viñeta, scrims, grades por piso térmico, pulso cardíaco,
+ *      auto-dibujado, flujo por dash). Importalo UNA vez donde lo uses:
+ *          import '../../visual/effects/effects.css';
+ *   2. Helpers SVG (este barrel): `GlowFilter`, `FiltroAcuarela`, `AutoDibujo`.
+ *
+ * Reglas de la casa: solo transform/opacity animados; blur/filtros estáticos;
+ * reduced-motion = fotograma final digno; cero dependencias nuevas.
+ */
+export { GlowFilter } from './GlowFilter.jsx';
+export { FiltroAcuarela } from './FiltroAcuarela.jsx';
+export { AutoDibujo } from './AutoDibujo.jsx';
+
+/* Ritmo del latido/respiración compartido (= `--vfx-beat` en effects.css y
+   `--motion-beat`/`--fvo-beat` en el resto del repo). Útil desde JS cuando una
+   escena necesita sincronizar un timing sin leer el CSS. */
+export const VFX_BEAT_MS = 5200;
+
+/* Registro consultable de los pisos térmicos y su grade de luz (§13.2).
+   `token` = la custom property de effects.css; `clase` = la clase modificadora
+   de `.vfx-grade`. Orden de menor a mayor altura invertido: de nevado a río. */
+export const VFX_PISOS = [
+  { slug: 'glacial',  nombre: 'Nevado',   token: '--vfx-piso-glacial',  clase: 'vfx-grade--glacial',  luz: 'azul glacial' },
+  { slug: 'paramo',   nombre: 'Páramo',   token: '--vfx-piso-paramo',   clase: 'vfx-grade--paramo',   luz: 'cian páramo' },
+  { slug: 'frio',     nombre: 'Frío',     token: '--vfx-piso-frio',     clase: 'vfx-grade--frio',     luz: 'neutro frío' },
+  { slug: 'templado', nombre: 'Templado', token: '--vfx-piso-templado', clase: 'vfx-grade--templado', luz: 'hora dorada' },
+  { slug: 'calido',   nombre: 'Cálido',   token: '--vfx-piso-calido',   clase: 'vfx-grade--calido',   luz: 'ámbar cálido' },
+  { slug: 'valle',    nombre: 'Valle/río', token: '--vfx-piso-valle',   clase: 'vfx-grade--valle',    luz: 'turquesa río' },
+];

--- a/src/visual/voz/IrisVoz.jsx
+++ b/src/visual/voz/IrisVoz.jsx
@@ -1,0 +1,192 @@
+/*
+ * IrisVoz — LA VOZ CON FORMA: la identidad visual de la voz de Chagra.
+ *
+ * Cuando el campesino dice «hola, Chagra», la app no muestra un micrófono
+ * genérico: muestra ESTO — un iris orgánico de anillos concéntricos, mitad
+ * ondas de agua en una totuma, mitad anillos de crecimiento de un tronco.
+ * Cálido y de tierra (brasa, miel, musgo), NO sci-fi: es deliberadamente lo
+ * opuesto al astrolabio holográfico del overlay de escucha (EscuchaOverlay).
+ *
+ * LA REGLA DE ORO — el movimiento tiene dirección SEMÁNTICA:
+ *   · escuchando → las ondas viajan HACIA ADENTRO (la voz de usted entra
+ *     hasta la brasa; el anillo de afuera reacciona primero).
+ *   · hablando   → las ondas NACEN en la brasa y salen HACIA AFUERA
+ *     (ahora la voz es de Chagra).
+ *   · pensando   → los anillos se trenzan: dos grupos contra-rotan despacio,
+ *     como agua que da vueltas antes de aclararse.
+ *   · reposo     → apenas respira al ritmo de la casa (--vfx-beat) y la
+ *     brasa queda en rescoldo. Se aquieta; no pide atención.
+ *
+ * NADA DE ANIMACIÓN FINGIDA: el brillo y la escala reaccionan a un NIVEL
+ * (0..1). En producción se le pasa el RMS real del micrófono vía `getNivel`;
+ * sin él usa la simulación orgánica de vozViva.js (nivelSimulado).
+ *
+ * Reglas de la casa (src/visual/effects/README.md):
+ *   · Solo transform/opacity animados; el glow (GlowFilter) es estático.
+ *   · Cero setState por frame: un solo rAF escribe transform/opacity
+ *     imperativamente sobre refs (mismo patrón GPU-friendly del repo).
+ *   · prefers-reduced-motion: el rAF NO arranca y el CSS pinta un fotograma
+ *     estático digno por estado (color + opacidad cuentan el momento).
+ *
+ * Geometría y simulación (deterministas, sin React) en ./vozViva.js.
+ */
+import React, { useEffect, useId, useRef } from 'react';
+import { GlowFilter } from '../effects';
+import { ANILLOS_IRIS, IRIS_VB, IRIS_C, N_ANILLOS, nivelSimulado } from './vozViva';
+import './irisVoz.css';
+
+/**
+ * El iris. Decorativo por contrato (aria-hidden): el ESTADO se anuncia con
+ * texto fuera del iris (aria-live del consumidor), nunca solo con color.
+ *
+ * @param {object}   props
+ * @param {string}  [props.estado='reposo']  reposo | escuchando | pensando | hablando
+ * @param {number}  [props.size=180]         lado en px (la firma sobrevive desde ~22px)
+ * @param {Function}[props.getNivel]         () => 0..1 leído cada frame (RMS real del
+ *                                           mic en producción). Si no se pasa, usa la
+ *                                           simulación orgánica según el estado.
+ * @param {string}  [props.className]
+ */
+export default function IrisVoz({ estado = 'reposo', size = 180, getNivel, className = '' }) {
+  const uid = useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const anillosRef = useRef([]);
+  const brasaRef = useRef(null);
+  const auraRef = useRef(null);
+  const haloRef = useRef(null);
+
+  /* refs espejo: el rAF lee SIEMPRE lo último sin recrearse por render. */
+  const estadoRef = useRef(estado);
+  const getNivelRef = useRef(getNivel);
+  useEffect(() => { estadoRef.current = estado; }, [estado]);
+  useEffect(() => { getNivelRef.current = getNivel; }, [getNivel]);
+
+  useEffect(() => {
+    /* reduced-motion: sin rAF — el CSS pinta el fotograma estático por estado. */
+    if (typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return undefined;
+    }
+    const niveles = new Float32Array(N_ANILLOS);
+    let lead = 0;
+    let raf = 0;
+    const t0 = performance.now();
+
+    const tick = (now) => {
+      const t = (now - t0) / 1000;
+      const est = estadoRef.current;
+      const crudo = getNivelRef.current
+        ? (getNivelRef.current() || 0)
+        : nivelSimulado(t, est);
+      /* suavizado asimétrico: sube rápido con la voz, cae lento (el iris
+         "retiene" un instante lo que oyó — mismo gesto que EscuchaOverlay). */
+      lead += (crudo - lead) * (crudo > lead ? 0.32 : 0.1);
+
+      /* LA DIRECCIÓN: cada anillo persigue a su vecino. hablando → el de
+         adentro manda (la onda sale); resto → el de afuera manda (la voz
+         entra). El lag de la persecución ES el viaje de la onda. */
+      if (est === 'hablando') {
+        for (let i = 0; i < N_ANILLOS; i++) {
+          const objetivo = i === 0 ? lead : niveles[i - 1];
+          niveles[i] += (objetivo - niveles[i]) * 0.24;
+        }
+      } else {
+        for (let i = N_ANILLOS - 1; i >= 0; i--) {
+          const objetivo = i === N_ANILLOS - 1 ? lead : niveles[i + 1];
+          niveles[i] += (objetivo - niveles[i]) * 0.24;
+        }
+      }
+
+      for (let i = 0; i < N_ANILLOS; i++) {
+        const el = anillosRef.current[i];
+        if (!el) continue;
+        const a = ANILLOS_IRIS[i];
+        el.style.transform = `scale(${(1 + niveles[i] * a.amp).toFixed(4)})`;
+        el.style.opacity = Math.min(1, a.base + niveles[i] * 0.5).toFixed(3);
+      }
+      if (brasaRef.current) {
+        brasaRef.current.style.transform = `scale(${(1 + lead * 0.24).toFixed(4)})`;
+      }
+      if (auraRef.current) {
+        auraRef.current.style.opacity = (0.35 + lead * 0.6).toFixed(3);
+        auraRef.current.style.transform = `scale(${(1 + lead * 0.36).toFixed(4)})`;
+      }
+      if (haloRef.current) {
+        haloRef.current.style.opacity = (0.5 + lead * 0.5).toFixed(3);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div
+      className={`iris-voz ${className}`.trim()}
+      data-estado={estado}
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    >
+      <div className="iv-halo" ref={haloRef} />
+      <div className="iv-respira">
+        <svg viewBox={`0 0 ${IRIS_VB} ${IRIS_VB}`} focusable="false">
+          <defs>
+            <GlowFilter id={`${uid}-glow`} std={2.6} />
+            <radialGradient id={`${uid}-brasa`} cx="50%" cy="46%" r="55%">
+              <stop offset="0%" stopColor="var(--iris-brasa-luz)" />
+              <stop offset="62%" stopColor="var(--iris-brasa)" />
+              <stop offset="100%" stopColor="var(--iris-brasa-borde)" />
+            </radialGradient>
+          </defs>
+
+          {/* Anillos en dos grupos (pares/impares) que solo en `pensando`
+              contra-rotan — animation-play-state, así al salir del estado la
+              trenza se CONGELA donde iba (nada salta). */}
+          <g className="iv-giro iv-giro-a">
+            {ANILLOS_IRIS.map((a, i) => (i % 2 === 0 ? (
+              <path
+                key={i}
+                ref={(el) => { anillosRef.current[i] = el; }}
+                className="iv-anillo iv-anillo-par"
+                d={a.d}
+                style={{ '--iv-op-base': a.base }}
+                strokeWidth={a.grosor}
+              />
+            ) : null))}
+          </g>
+          <g className="iv-giro iv-giro-b">
+            {ANILLOS_IRIS.map((a, i) => (i % 2 === 1 ? (
+              <path
+                key={i}
+                ref={(el) => { anillosRef.current[i] = el; }}
+                className="iv-anillo iv-anillo-impar"
+                d={a.d}
+                style={{ '--iv-op-base': a.base }}
+                strokeWidth={a.grosor}
+              />
+            ) : null))}
+          </g>
+
+          {/* La brasa: el rescoldo donde la voz vive. Glow ESTÁTICO
+              (GlowFilter); lo que se anima es transform/opacity. */}
+          <g filter={`url(#${uid}-glow)`}>
+            <circle
+              ref={auraRef}
+              className="iv-brasa-aura"
+              cx={IRIS_C}
+              cy={IRIS_C}
+              r={17.5}
+            />
+            <circle
+              ref={brasaRef}
+              className="iv-brasa"
+              cx={IRIS_C}
+              cy={IRIS_C}
+              r={10}
+              fill={`url(#${uid}-brasa)`}
+            />
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/voz/README.md
+++ b/src/visual/voz/README.md
@@ -1,0 +1,42 @@
+# `src/visual/voz` — la voz con forma
+
+`IrisVoz` es la **identidad visual de la voz de Chagra**: un iris orgánico de
+anillos concéntricos (mitad ondas de agua en una totuma, mitad anillos de
+crecimiento de un tronco) con una brasa en el centro. Cálido y de tierra —
+deliberadamente lo opuesto al astrolabio holográfico de `EscuchaOverlay`.
+
+Mockup de decisión: `#/mockups/voz-con-forma` (`src/mockups/VozConForma.jsx`).
+
+## La regla de oro: el movimiento tiene dirección semántica
+
+| estado | qué hace | por qué |
+| --- | --- | --- |
+| `reposo` | apenas respira (`--vfx-beat`), brasa en rescoldo | se aquieta, no pide atención |
+| `escuchando` | las ondas viajan **hacia adentro**; el brillo sube con el nivel | la voz de usted entra hasta la brasa |
+| `pensando` | los anillos se **trenzan** (contra-rotación lentísima) | agua dando vueltas antes de aclararse |
+| `hablando` | las ondas **nacen en la brasa** y salen | ahora la voz es de Chagra |
+
+## Uso
+
+```jsx
+import IrisVoz from '../visual/voz';
+
+// producción: nivel = RMS real del micrófono, leído cada frame
+<IrisVoz estado="escuchando" size={220} getNivel={() => rmsRef.current} />
+
+// demo/onboarding: sin getNivel usa la pseudo-habla determinista incluida
+<IrisVoz estado="hablando" size={56} />
+```
+
+- **Decorativo por contrato** (`aria-hidden`): el estado se anuncia con texto
+  del consumidor (`aria-live`), nunca solo con color.
+- La firma sobrevive desde ~22 px (chip) hasta pantalla completa.
+
+## Reglas de la casa (heredadas de `src/visual/effects`)
+
+- Solo `transform`/`opacity` animados; el glow (`GlowFilter` de `effects`) es
+  filtro **estático**.
+- Cero setState por frame: un solo rAF escribe sobre refs.
+- `prefers-reduced-motion`: el rAF no arranca; el CSS pinta un fotograma
+  quieto pero legible por estado (color + opacidad cuentan el momento).
+- Geometría **determinista** (sin `Math.random`): el iris es una firma.

--- a/src/visual/voz/index.js
+++ b/src/visual/voz/index.js
@@ -1,0 +1,17 @@
+/*
+ * Librería visual de VOZ de Chagra — la identidad "la voz con forma".
+ *
+ * `IrisVoz` es el gesto único de la voz en toda la app: donde antes iría un
+ * micrófono genérico, va el iris (FAB, overlay de escucha, chip de estado,
+ * onboarding de voz). Un solo primitivo, cuatro estados, cualquier tamaño.
+ *
+ *   import IrisVoz, { nivelSimulado, ESTADOS_VOZ } from '.../visual/voz';
+ *
+ *   <IrisVoz estado="escuchando" size={220} getNivel={() => rmsRef.current} />
+ *
+ * `getNivel` en producción = RMS real del micrófono (useVoiceRecorder);
+ * sin él, IrisVoz usa `nivelSimulado` (pseudo-habla determinista) — útil
+ * para demos, onboarding y estados sin permiso de mic todavía.
+ */
+export { default, default as IrisVoz } from './IrisVoz.jsx';
+export { nivelSimulado, ESTADOS_VOZ, ANILLOS_IRIS } from './vozViva';

--- a/src/visual/voz/irisVoz.css
+++ b/src/visual/voz/irisVoz.css
@@ -1,0 +1,148 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   irisVoz.css — la piel de IrisVoz (LA VOZ CON FORMA).
+
+   Paleta de TIERRA, no de neón: la voz de Chagra es una brasa en una cocina
+   de leña, no un holograma. Cuatro estados = cuatro temperaturas del mismo
+   material (nunca cambia la forma, solo la vida que lleva adentro):
+
+     reposo      rescoldo   (pardo apagado — apenas se nota que está viva)
+     escuchando  miel       (ámbar cálido — la atención encendida)
+     pensando    cobre      (más hondo y quieto — el agua dando vueltas)
+     hablando    musgo+miel (verde vivo — la respuesta es cosa que crece)
+
+   Reglas de la casa: solo transform/opacity animados; el glow es filtro
+   ESTÁTICO; prefers-reduced-motion = fotograma quieto pero LEGIBLE por
+   estado (el color y la opacidad cuentan el momento sin loops).
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.iris-voz {
+  /* tinta por defecto = reposo (rescoldo) */
+  --iris-tinta: #8d6b4d;
+  --iris-tinta-2: #6f5844;
+  --iris-brasa-luz: #ffd9a8;
+  --iris-brasa: #d98549;
+  --iris-brasa-borde: rgba(140, 70, 30, 0);
+  --iris-halo: rgba(217, 133, 73, 0.14);
+  --iris-vida: 0;                 /* fotograma estático: cuánta vida extra */
+
+  position: relative;
+  display: inline-block;
+  flex: none;
+}
+
+.iris-voz[data-estado='escuchando'] {
+  --iris-tinta: #e9a94e;
+  --iris-tinta-2: #c98a54;
+  --iris-brasa-luz: #ffe3b0;
+  --iris-brasa: #f0a355;
+  --iris-halo: rgba(233, 169, 78, 0.22);
+  --iris-vida: 0.3;
+}
+
+.iris-voz[data-estado='pensando'] {
+  --iris-tinta: #c57a45;
+  --iris-tinta-2: #9a6a4a;
+  --iris-brasa-luz: #ffce96;
+  --iris-brasa: #d98549;
+  --iris-halo: rgba(197, 122, 69, 0.18);
+  --iris-vida: 0.16;
+}
+
+.iris-voz[data-estado='hablando'] {
+  --iris-tinta: #b7c98a;
+  --iris-tinta-2: #d8b06a;
+  --iris-brasa-luz: #f3e9b0;
+  --iris-brasa: #cabd62;
+  --iris-halo: rgba(183, 201, 138, 0.2);
+  --iris-vida: 0.34;
+}
+
+/* ── halo: la luz que la brasa le presta a la mesa ─────────────────────────── */
+.iv-halo {
+  position: absolute;
+  inset: -18%;
+  border-radius: 50%;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 50%, var(--iris-halo) 0%, transparent 62%);
+  opacity: 0.6;
+  transition: background 0.7s ease;
+}
+
+/* ── respiración: TODO el iris respira al ritmo de la casa ─────────────────── */
+.iv-respira {
+  width: 100%;
+  height: 100%;
+  animation: iv-respira var(--vfx-beat, 5.2s) ease-in-out infinite;
+}
+
+.iv-respira svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+@keyframes iv-respira {
+  0%, 100% { transform: scale(1); }
+  42% { transform: scale(1.022); }
+  58% { transform: scale(1.018); }
+}
+
+/* ── anillos de agua/tronco ────────────────────────────────────────────────── */
+.iv-anillo {
+  fill: none;
+  stroke: var(--iris-tinta);
+  stroke-linejoin: round;
+  opacity: calc(var(--iv-op-base, 0.4) + var(--iris-vida) * 0.5);
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: stroke 0.7s ease;
+}
+
+/* anillos alternos con la segunda tinta: la veta del tronco, no un arcoíris */
+.iv-anillo-impar { stroke: var(--iris-tinta-2); }
+
+/* ── la trenza de `pensando`: dos grupos contra-rotan lentísimo ──────────────
+   animation-play-state: al salir del estado la rotación se CONGELA donde va
+   (nada salta a cero). Solo transform ⇒ GPU-friendly. */
+.iv-giro {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: iv-giro 46s linear infinite;
+  animation-play-state: paused;
+}
+
+.iv-giro-b {
+  animation-name: iv-giro-contra;
+  animation-duration: 58s;
+}
+
+.iris-voz[data-estado='pensando'] .iv-giro { animation-play-state: running; }
+
+@keyframes iv-giro { to { transform: rotate(360deg); } }
+@keyframes iv-giro-contra { to { transform: rotate(-360deg); } }
+
+/* ── la brasa ──────────────────────────────────────────────────────────────── */
+.iv-brasa {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.iv-brasa-aura {
+  fill: var(--iris-brasa);
+  opacity: calc(0.3 + var(--iris-vida));
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: fill 0.7s ease;
+}
+
+/* ── prefers-reduced-motion: fotograma quieto y digno ────────────────────────
+   El rAF no arranca (lo decide IrisVoz.jsx), así que aquí solo apagamos los
+   loops CSS. El estado sigue LEYÉNDOSE: --iris-vida sube la opacidad de los
+   anillos y la aura cuando la voz está activa — color + luz, sin movimiento. */
+@media (prefers-reduced-motion: reduce) {
+  .iv-respira,
+  .iv-giro {
+    animation: none !important;
+  }
+}

--- a/src/visual/voz/vozViva.js
+++ b/src/visual/voz/vozViva.js
@@ -1,0 +1,68 @@
+/*
+ * vozViva.js — la parte VIVA (y sin React) de IrisVoz: geometría determinista
+ * de los anillos + simulación orgánica de nivel. Separado del componente para
+ * que IrisVoz.jsx solo exporte componentes (react-refresh) y para poder
+ * testear/reusar la matemática sin montar nada.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- 'reposo'/'escuchando'/
+   'pensando'/'hablando' son TOKENS de estado del primitivo (API interna),
+   no copy de UI; el texto visible vive en el consumidor. */
+
+export const ESTADOS_VOZ = ['reposo', 'escuchando', 'pensando', 'hablando'];
+
+export const IRIS_VB = 200;              // lado del viewBox
+export const IRIS_C = IRIS_VB / 2;       // centro
+export const N_ANILLOS = 6;              // anillos de agua/tronco
+const N_PTS = 72;                        // puntos por anillo (denso = suave)
+
+/* PRNG determinista (misma receta que el resto del repo visual). */
+const azar = (i, sal) => {
+  const x = Math.sin(i * 127.1 + sal * 311.7) * 43758.5453;
+  return x - Math.floor(x);
+};
+
+/* Anillos precomputados UNA vez: cada uno es un path cerrado cuyo radio
+ * ondula con dos senos de baja amplitud — el temblor de mano que separa un
+ * anillo de tronco de un círculo de compás. El de afuera tiembla más (la
+ * onda se deshace al alejarse de la brasa), y cada anillo trae su amplitud
+ * de reacción a la voz (`amp`) y su opacidad base (`base`). */
+export const ANILLOS_IRIS = Array.from({ length: N_ANILLOS }, (_, k) => {
+  const R = 30 + k * 11.4;                       // 30 → 87 (dentro de VB=200)
+  const w1 = 0.016 + azar(k, 1) * 0.016 + k * 0.0045;
+  const w2 = 0.009 + azar(k, 2) * 0.012;
+  const f1 = 3 + (k % 3);
+  const f2 = 6 + (k % 4);
+  const p1 = azar(k, 3) * Math.PI * 2;
+  const p2 = azar(k, 4) * Math.PI * 2;
+  let d = '';
+  for (let j = 0; j < N_PTS; j++) {
+    const a = (j / N_PTS) * Math.PI * 2;
+    const r = R * (1 + w1 * Math.sin(f1 * a + p1) + w2 * Math.sin(f2 * a + p2));
+    d += `${j === 0 ? 'M' : 'L'}${(IRIS_C + Math.cos(a) * r).toFixed(1)} ${(IRIS_C + Math.sin(a) * r).toFixed(1)}`;
+  }
+  return {
+    d: `${d}Z`,
+    amp: 0.05 + k * 0.016,          // cuánto se hincha con la voz
+    base: 0.5 - k * 0.055,          // opacidad base (se desvanece hacia afuera)
+    grosor: 1.9 - k * 0.18,         // trazo (grueso adentro, fino afuera)
+  };
+});
+
+/* ── Simulación orgánica de nivel (para mockups/demos) ───────────────────────
+ * Pseudo-habla determinista: una envolvente de FRASES (con pausas de aire),
+ * modulada por PALABRAS y SÍLABAS (senos incongruentes = cadencia creíble).
+ * `hablando` es un pelo más parejo (Chagra no duda); `pensando` es un pulso
+ * interior bajito; `reposo` es silencio. */
+export function nivelSimulado(t, estado) {
+  if (estado === 'escuchando' || estado === 'hablando') {
+    const lento = estado === 'hablando' ? 0.62 : 0.78;
+    const frase = Math.sin(t * lento + 0.6) * 0.5 + 0.5;      // 0..1, respiración de frase
+    if (frase < 0.22) return 0.04;                            // pausa para tomar aire
+    const palabra = 0.62 + 0.38 * Math.sin(t * 5.9) * Math.sin(t * 2.31 + 1.7);
+    const silaba = 0.78 + 0.22 * Math.sin(t * 13.7 + 0.4);
+    const piso = estado === 'hablando' ? 0.3 : 0.22;
+    return Math.max(0, Math.min(1, piso + 0.62 * frase * palabra * silaba));
+  }
+  if (estado === 'pensando') return 0.1 + 0.06 * Math.sin(t * 1.5);
+  return 0;
+}


### PR DESCRIPTION
## MOONSHOT #9 · La voz con forma

Cuando el campesino dice **«hola, Chagra»**, en vez de un micrófono genérico aparece un **iris orgánico** que ES la identidad visual de la voz de Chagra: anillos concéntricos de agua/tronco alrededor de una brasa — cálido y de tierra, contrapunto deliberado al astrolabio holográfico de `EscuchaOverlay`.

**Ruta:** `#/mockups/voz-con-forma` (sin gate ni sesión, datos de muestra).

### La regla de oro: el movimiento tiene dirección semántica
| estado | qué hace |
| --- | --- |
| reposo | apenas respira (`--vfx-beat`), brasa en rescoldo — se aquieta |
| escuchando | las ondas viajan **hacia adentro** (su voz entra); brillo = nivel |
| pensando | los anillos se **trenzan** (contra-rotación lentísima, se congela al salir) |
| hablando | las ondas **nacen en la brasa** y salen — ahora la voz es de Chagra |

### Primitivo reusable (listo para `src/visual/`)
- `src/visual/voz/IrisVoz.jsx` — un solo rAF imperativo sobre refs (cero setState por frame); `getNivel` para el RMS real del mic en producción.
- `src/visual/voz/vozViva.js` — geometría determinista + pseudo-habla (sin React, testeable).
- Reusa `src/visual/effects` (vendorizada byte a byte de `feat/visual-lib-effects` → merge limpio): `GlowFilter` canónico + `--vfx-beat`.

### Mockup de galería
Conversación guionada completa (reposo → «hola, Chagra» → escucha → piensa → responde → se aquieta), anatomía de los 4 momentos, la identidad en pequeño (chip 22 px / FAB 56 px / tarjeta 72 px) y nota de intención (por qué no un micrófono).

### Reglas de la casa
Solo transform/opacity animados (glow estático) · `prefers-reduced-motion` = fotograma quieto pero legible por estado · responsive 320 px · usted cordial CO · geometría determinista (el iris es una firma, no un efecto aleatorio).

**Verificación:** `vite build` verde · eslint limpio en archivos nuevos + `App.jsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)