### PR TITLE
feat(mockup): mercado.chagra.bio — mercado público de procedencia (#/mockups/mercado)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,6 +107,9 @@ const CompostScreen = lazy(() => import('./components/CompostScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const OnboardingCondensado = lazy(() => import('./components/OnboardingCondensado'));
+// Galería de mockups (diseño): rutas públicas `#/mockups/<slug>`, sin auth ni
+// gate, datos de muestra. No cuentan como módulo de piloto. Ver MOCKUP_HASH_ROUTES.
+const MercadoMockup = lazy(() => import('./mockups/Mercado'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const PlantaPorVozScreen = lazy(() => import('./components/PlantaPorVozScreen'));
@@ -416,6 +419,15 @@ const LoadingFallback = ({ view = null }) => {
 // viva (HERRAMIENTAS_TILES en DashboardLive). Las rutas `casos`/`caso_detail`/
 // `javier`/`usage_stats` siguen vivas en el router (más abajo) y por hash.
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
+
+// Rutas de MOCKUP de diseño (galería): PÚBLICAS — sin auth ni gate, datos de
+// muestra. Se resuelven ANTES del check de sesión (igual que el callback OAuth),
+// para que una lámina se pueda revisar sin cuenta. Patrón `#/mockups/<slug>` (el
+// hash se normaliza a `mockups/<slug>`). No entran en HASH_VIEW_ROUTES para dejar
+// explícito que NO pasan por los gates de sesión/rol.
+const MOCKUP_HASH_ROUTES = {
+  'mockups/mercado': 'mockup_mercado',
+};
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
@@ -915,6 +927,14 @@ export default function App() {
       return;
     }
 
+    // Mockups de diseño: públicos, sin auth. Se resuelven antes de
+    // isAuthenticated para que la galería (#/mockups/<slug>) abra sin cuenta.
+    const mockupView = MOCKUP_HASH_ROUTES[hash];
+    if (mockupView) {
+      Promise.resolve().then(() => navigate(mockupView));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -941,6 +961,12 @@ export default function App() {
   useEffect(() => {
     const handleHashRoute = () => {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
+      // Mockups públicos: navegar directo, sin pasar por auth ni gates.
+      const mockupView = MOCKUP_HASH_ROUTES[hash];
+      if (mockupView) {
+        navigate(mockupView);
+        return;
+      }
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
@@ -2487,6 +2513,18 @@ export default function App() {
                 onNavigate={navigate}
                 initialContext={currentViewData}
               />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mercado':
+        // Mockup de galería (público, datos de muestra): el mercado público
+        // mercado.chagra.bio, cuyo diferencial es la PROCEDENCIA — cada producto
+        // con la cara del productor, su finca, su vereda y su altitud/piso
+        // térmico. Ruta #/mockups/mercado.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mercado de procedencia">
+              <MercadoMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mercado.jsx
+++ b/src/mockups/Mercado.jsx
@@ -1,0 +1,302 @@
+/*
+ * i18n (ADR-050): copy de campo en español Colombia (usted). Es un MOCKUP de
+ * galería con datos de muestra, sin gate ni auth; el copy final migraría a
+ * src/config/messages.js — mismo criterio que los otros mockups de la galería.
+ */
+import { useEffect, useState } from 'react';
+import { ArrowLeft, X, Mountain, MapPin, Sprout, ShieldCheck, ScrollText } from 'lucide-react';
+import { Colibri } from '../visual/creatures/Colibri.jsx';
+import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
+import { Mariposa } from '../visual/creatures/Mariposa.jsx';
+import { Rostro } from './mercado/Rostro.jsx';
+import { ProductoIlustracion } from './mercado/ProductoIlustracion.jsx';
+import { CintaAltitud } from './mercado/CintaAltitud.jsx';
+import { PRODUCTOS, pisoDeAltitud, pesos } from './mercado/datos.js';
+import '../visual/effects/effects.css';
+import '../visual/creatures/creatures.css';
+import './mercado.css';
+
+/**
+ * Mercado — MOCKUP del mercado público mercado.chagra.bio.
+ *
+ * El diferencial es la PROCEDENCIA: cada producto se ubica en la montaña por su
+ * altitud y su piso térmico, con la cara de quien lo sembró, su finca y su
+ * vereda. Mercado campesino honesto, anti-postureo: pocas cosas, mucho aire,
+ * la confianza al centro (sellos de estampa + trazabilidad de la cosecha).
+ *
+ * Firma visual: "la cinta de altitud" (CintaAltitud) — la montaña con la cara
+ * de cada productor clavada a su altura real. Reusa la librería visual:
+ *   - creatures: colibrí (hero), abeja angelita (miel), mariposa (historia).
+ *   - effects: grade de luz por piso térmico (vfx-grade) en la historia.
+ *
+ * Ruta pública `#/mockups/mercado` (sin auth, datos de muestra).
+ *
+ * @param {Object} props
+ * @param {() => void} [props.onBack] volver al dashboard.
+ */
+export default function Mercado({ onBack }) {
+  const [piso, setPiso] = useState('todos');
+  const [abierta, setAbierta] = useState(null);
+
+  // Fincas para la cinta de altitud (1 finca por producto en el muestreo).
+  const fincas = PRODUCTOS.map((p) => ({
+    id: p.id,
+    nombre: p.finca.nombre,
+    productor: p.finca.productor,
+    altitud: p.finca.altitud,
+    rostro: p.finca.rostro,
+  }));
+
+  // Pisos térmicos presentes, de más alto a más templado, para los filtros.
+  const pisosPresentes = [];
+  for (const orden of ['paramo', 'frio', 'templado']) {
+    if (PRODUCTOS.some((p) => pisoDeAltitud(p.finca.altitud).slug === orden)) {
+      pisosPresentes.push(pisoDeAltitud(PRODUCTOS.find((p) => pisoDeAltitud(p.finca.altitud).slug === orden).finca.altitud));
+    }
+  }
+
+  const visibles =
+    piso === 'todos'
+      ? PRODUCTOS
+      : PRODUCTOS.filter((p) => pisoDeAltitud(p.finca.altitud).slug === piso);
+
+  const productoAbierto = PRODUCTOS.find((p) => p.id === abierta) || null;
+
+  // Cerrar la historia con Escape.
+  useEffect(() => {
+    if (!productoAbierto) return undefined;
+    const onKey = (e) => {
+      if (e.key === 'Escape') setAbierta(null);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [productoAbierto]);
+
+  return (
+    <div className="mrc-root">
+      <header className="mrc-top">
+        {onBack && (
+          <button type="button" className="mrc-back" onClick={onBack}>
+            <ArrowLeft size={16} aria-hidden="true" />
+            <span>Volver</span>
+          </button>
+        )}
+        <span className="mrc-marca">mercado.chagra.bio</span>
+      </header>
+
+      {/* ── HERO: la promesa de procedencia + la montaña con caras ────────── */}
+      <section className="mrc-hero">
+        <div className="mrc-hero__texto">
+          <p className="mrc-kicker">Mercado campesino de la montaña</p>
+          <h1 className="mrc-titulo">
+            Sepa a qué altura<br />crece su comida.
+          </h1>
+          <p className="mrc-lead">
+            Cada cosecha llega con la cara de quien la sembró, su finca y su vereda.
+            Toque un producto y conozca de dónde viene, hasta el metro.
+          </p>
+          <ul className="mrc-promesa">
+            <li><Sprout size={15} aria-hidden="true" /> Sin químicos, dicho por la finca</li>
+            <li><Mountain size={15} aria-hidden="true" /> Ubicado por su altitud real</li>
+            <li><ShieldCheck size={15} aria-hidden="true" /> Con la fecha de la cosecha</li>
+          </ul>
+        </div>
+        <div className="mrc-hero__monte">
+          <Colibri size={44} className="mrc-colibri" title="Colibrí de la montaña" />
+          <CintaAltitud fincas={fincas} onSelect={setAbierta} />
+        </div>
+      </section>
+
+      {/* ── FILTRO por piso térmico ───────────────────────────────────────── */}
+      <div className="mrc-filtros" role="group" aria-label="Filtrar por piso térmico">
+        <button
+          type="button"
+          className={`mrc-chip${piso === 'todos' ? ' is-on' : ''}`}
+          onClick={() => setPiso('todos')}
+          aria-pressed={piso === 'todos'}
+        >
+          Todos
+        </button>
+        {pisosPresentes.map((p) => (
+          <button
+            key={p.slug}
+            type="button"
+            className={`mrc-chip${piso === p.slug ? ' is-on' : ''}`}
+            onClick={() => setPiso(p.slug)}
+            aria-pressed={piso === p.slug}
+            style={{ '--chip-piso': p.hex }}
+          >
+            <span className="mrc-chip__punto" aria-hidden="true" />
+            {p.nombre}
+          </button>
+        ))}
+      </div>
+
+      {/* ── GRILLA de productos ───────────────────────────────────────────── */}
+      <section className="mrc-grid" aria-label="Productos del mercado">
+        {visibles.map((p) => (
+          <ProductoCard key={p.id} producto={p} onAbrir={() => setAbierta(p.id)} />
+        ))}
+      </section>
+
+      <footer className="mrc-pie">
+        <p>De la finca a su mesa, sin intermediarios y sin cuento. Trazabilidad de muestra.</p>
+      </footer>
+
+      {productoAbierto && (
+        <Historia producto={productoAbierto} fincas={fincas} onCerrar={() => setAbierta(null)} onVerFinca={setAbierta} />
+      )}
+    </div>
+  );
+}
+
+/* ── Tarjeta de producto ─────────────────────────────────────────────────── */
+function ProductoCard({ producto, onAbrir }) {
+  const { finca } = producto;
+  const piso = pisoDeAltitud(finca.altitud);
+  return (
+    <article className="mrc-card">
+      <button type="button" className="mrc-card__foto" onClick={onAbrir} aria-label={`Ver la historia de ${producto.nombre}, de ${finca.nombre}`} style={{ '--card-piso': piso.hex }}>
+        <ProductoIlustracion tipo={producto.ilustracion} size={120} title={producto.nombre} />
+        {producto.ilustracion === 'miel' && (
+          <AbejaAngelita size={30} className="mrc-card__bicho" title="Abeja angelita" />
+        )}
+      </button>
+
+      <div className="mrc-card__cuerpo">
+        <div className="mrc-card__cabeza">
+          <h3 className="mrc-card__nombre">{producto.nombre}</h3>
+          <p className="mrc-card__variedad">{producto.variedad}</p>
+        </div>
+
+        <p className="mrc-precio">
+          <span className="mrc-precio__val">{pesos(producto.precio)}</span>
+          <span className="mrc-precio__uni"> / {producto.unidad}</span>
+        </p>
+
+        {/* Bloque de PROCEDENCIA: la cara + finca + vereda + altitud/piso */}
+        <button type="button" className="mrc-proc" onClick={onAbrir}>
+          <Rostro seed={finca.rostro} size={44} title={`Productor de ${finca.nombre}`} />
+          <span className="mrc-proc__texto">
+            <span className="mrc-proc__finca">{finca.nombre}</span>
+            <span className="mrc-proc__ubi"><MapPin size={12} aria-hidden="true" /> vereda {finca.vereda}</span>
+            <span className="mrc-proc__alt">
+              <span className="mrc-proc__punto" style={{ background: piso.hex }} aria-hidden="true" />
+              {finca.altitud.toLocaleString('es-CO')} m · piso {piso.nombre.toLowerCase()}
+            </span>
+          </span>
+        </button>
+
+        <ul className="mrc-sellos">
+          {producto.sellos.map((s) => (
+            <SelloEstampa key={s} texto={s} />
+          ))}
+        </ul>
+      </div>
+    </article>
+  );
+}
+
+/* ── Sello de confianza estilo estampa de tinta ──────────────────────────── */
+function SelloEstampa({ texto, grande = false }) {
+  return (
+    <li className={`mrc-sello${grande ? ' mrc-sello--g' : ''}`}>
+      <ShieldCheck size={grande ? 15 : 12} aria-hidden="true" />
+      <span>{texto}</span>
+    </li>
+  );
+}
+
+/* ── Historia de la finca (pantalla de detalle) ──────────────────────────── */
+function Historia({ producto, fincas, onCerrar, onVerFinca }) {
+  const { finca } = producto;
+  const piso = pisoDeAltitud(finca.altitud);
+  return (
+    <div className="mrc-modal" role="dialog" aria-modal="true" aria-label={`Historia de ${finca.nombre}`}>
+      <button type="button" className="mrc-modal__fondo" aria-label="Cerrar" onClick={onCerrar} />
+      <div className="mrc-hoja">
+        <div className="mrc-hoja__barra">
+          <button type="button" className="mrc-back mrc-back--modal" onClick={onCerrar}>
+            <ArrowLeft size={16} aria-hidden="true" />
+            <span>Al mercado</span>
+          </button>
+          <button type="button" className="mrc-cerrar" onClick={onCerrar} aria-label="Cerrar">
+            <X size={18} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="mrc-hoja__scroll">
+          {/* Cabecera de finca: luz graduada por piso térmico (effects vfx-grade) */}
+          <div className="mrc-fincahead">
+            <div className={`vfx-grade vfx-grade--${piso.slug} mrc-fincahead__luz`} aria-hidden="true" />
+            <Mariposa size={40} className="mrc-mariposa" title="Mariposa" />
+            <div className="mrc-fincahead__cara">
+              <Rostro seed={finca.rostro} size={74} title={`Productor de ${finca.nombre}`} />
+            </div>
+            <div className="mrc-fincahead__id">
+              <p className="mrc-fincahead__quien">{finca.productor}</p>
+              <h2 className="mrc-fincahead__finca">{finca.nombre}</h2>
+              <p className="mrc-fincahead__ubi">
+                <MapPin size={13} aria-hidden="true" /> vereda {finca.vereda}
+              </p>
+              <p className="mrc-fincahead__alt">
+                <Mountain size={13} aria-hidden="true" />
+                <span className="mrc-alt-num">{finca.altitud.toLocaleString('es-CO')} m</span>
+                <span className="mrc-alt-piso" style={{ '--chip-piso': piso.hex }}>
+                  <span className="mrc-chip__punto" aria-hidden="true" /> piso {piso.nombre.toLowerCase()}
+                </span>
+              </p>
+            </div>
+          </div>
+
+          {/* Producto de esta finca */}
+          <div className="mrc-hoja__producto" style={{ '--card-piso': piso.hex }}>
+            <ProductoIlustracion tipo={producto.ilustracion} size={92} title={producto.nombre} />
+            <div>
+              <h3 className="mrc-hoja__prodnombre">{producto.nombre}</h3>
+              <p className="mrc-hoja__prodvar">{producto.variedad}</p>
+              <p className="mrc-precio mrc-precio--g">
+                <span className="mrc-precio__val">{pesos(producto.precio)}</span>
+                <span className="mrc-precio__uni"> / {producto.unidad}</span>
+              </p>
+            </div>
+          </div>
+
+          <p className="mrc-relato">
+            <ScrollText size={16} aria-hidden="true" className="mrc-relato__ico" />
+            {producto.historia}
+          </p>
+
+          {/* Sellos de confianza, grandes */}
+          <ul className="mrc-sellos mrc-sellos--g">
+            {producto.sellos.map((s) => (
+              <SelloEstampa key={s} texto={s} grande />
+            ))}
+          </ul>
+
+          {/* Trazabilidad: hitos de la cosecha, fechas en altímetro monoespaciado */}
+          <div className="mrc-traza">
+            <p className="mrc-traza__tit"><Sprout size={15} aria-hidden="true" /> Cómo se dio esta cosecha</p>
+            <ol className="mrc-traza__linea">
+              {producto.trazabilidad.map((t, i) => (
+                <li key={t.hito} className={`mrc-traza__hito${i === producto.trazabilidad.length - 1 ? ' is-fin' : ''}`}>
+                  <span className="mrc-traza__punto" aria-hidden="true" />
+                  <span className="mrc-traza__hitotxt">
+                    <span className="mrc-traza__que">{t.hito}</span>
+                    <span className="mrc-traza__cuando">{t.fecha}</span>
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          {/* Dónde queda en la montaña: reusa la cinta, con esta finca resaltada */}
+          <div className="mrc-donde">
+            <p className="mrc-donde__tit"><Mountain size={15} aria-hidden="true" /> Dónde queda en la montaña</p>
+            <CintaAltitud fincas={fincas} activaId={producto.id} onSelect={onVerFinca} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/mockups/mercado.css
+++ b/src/mockups/mercado.css
@@ -1,0 +1,722 @@
+/* ════════════════════════════════════════════════════════════════════════
+   mercado.css — mockup mercado.chagra.bio (mercado público de procedencia).
+
+   Identidad: "estraza de montaña". Papel kraft grisáceo (NO el cream saturado
+   de catálogo), tinta umbra, verde monte. El acento NO es un terracota fijo:
+   es FUNCIONAL, el espectro de PISO TÉRMICO (frío→templado). Los números —
+   altitud, precio, fechas de cosecha — van en monoespaciado, como la lectura
+   de un altímetro. Los sellos de confianza son estampas de tinta.
+
+   Firma: la "cinta de altitud" (.mrc-cinta) ubica la cara de cada productor a
+   su altura real en la montaña. Todo el prefijo `mrc-`. Mobile-first desde
+   320px. Movimiento mínimo y reduced-motion-safe.
+   ════════════════════════════════════════════════════════════════════════ */
+
+.mrc-root {
+  --mrc-papel: #e7ddc6;
+  --mrc-papel-2: #ddd1b4;
+  --mrc-tarjeta: #f4ecd9;
+  --mrc-tinta: #2c2418;
+  --mrc-tinta-2: #6d5c40;
+  --mrc-monte: #2f5233;
+  --mrc-sello: #a5432a;
+  --mrc-linea: rgba(44, 36, 24, 0.16);
+  --mrc-serif: Georgia, 'Iowan Old Style', 'Times New Roman', serif;
+  --mrc-sans: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --mrc-mono: ui-monospace, 'SF Mono', 'Cascadia Code', 'Roboto Mono', Menlo, Consolas, monospace;
+
+  min-height: 100%;
+  box-sizing: border-box;
+  padding: 14px clamp(12px, 4vw, 26px) 48px;
+  color: var(--mrc-tinta);
+  font-family: var(--mrc-sans);
+  background:
+    repeating-linear-gradient(0deg, rgba(44, 36, 24, 0.022) 0 2px, transparent 2px 5px),
+    radial-gradient(130% 70% at 50% -6%, #f2ead4 0%, var(--mrc-papel) 52%, #ddceb0 100%);
+  -webkit-tap-highlight-color: transparent;
+}
+.mrc-root *,
+.mrc-root *::before,
+.mrc-root *::after {
+  box-sizing: border-box;
+}
+
+/* ── barra superior ──────────────────────────────────────────────────────── */
+.mrc-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  max-width: 660px;
+  margin: 0 auto 6px;
+}
+.mrc-marca {
+  font-family: var(--mrc-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: var(--mrc-tinta-2);
+}
+.mrc-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.35);
+  color: var(--mrc-tinta);
+  font-family: var(--mrc-sans);
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+.mrc-back:hover { background: rgba(255, 255, 255, 0.6); }
+
+/* ── HERO ────────────────────────────────────────────────────────────────── */
+.mrc-hero {
+  max-width: 660px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  padding: 10px 0 6px;
+}
+.mrc-kicker {
+  margin: 0 0 10px;
+  font-family: var(--mrc-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--mrc-monte);
+}
+.mrc-titulo {
+  margin: 0 0 12px;
+  font-family: var(--mrc-serif);
+  font-weight: 700;
+  font-size: clamp(1.9rem, 8.5vw, 2.9rem);
+  line-height: 1.02;
+  letter-spacing: -0.01em;
+  color: var(--mrc-tinta);
+}
+.mrc-lead {
+  margin: 0 0 14px;
+  max-width: 34ch;
+  font-size: 0.98rem;
+  line-height: 1.5;
+  color: var(--mrc-tinta-2);
+}
+.mrc-promesa {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.mrc-promesa li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--mrc-tinta);
+}
+.mrc-promesa svg { color: var(--mrc-monte); flex: 0 0 auto; }
+
+.mrc-hero__monte { position: relative; }
+.mrc-colibri {
+  position: absolute;
+  top: -6px;
+  right: 4px;
+  z-index: 4;
+  filter: drop-shadow(0 3px 5px rgba(44, 36, 24, 0.25));
+}
+
+/* ── CINTA DE ALTITUD (firma) ────────────────────────────────────────────── */
+.mrc-cinta {
+  position: relative;
+  width: 100%;
+  height: clamp(330px, 82vw, 430px);
+  border: 1px solid var(--mrc-linea);
+  border-radius: 16px;
+  overflow: hidden;
+  background: #eceadd;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 6px 18px rgba(44, 36, 24, 0.1);
+}
+.mrc-cinta__cielo {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(63, 127, 158, 0.34) 0%,
+    rgba(80, 138, 140, 0.24) 34%,
+    rgba(150, 150, 120, 0.12) 60%,
+    rgba(193, 144, 47, 0.18) 84%,
+    rgba(193, 144, 47, 0.28) 100%
+  );
+}
+.mrc-cinta__monte {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+/* eje de altímetro */
+.mrc-tick {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.mrc-tick__num {
+  font-family: var(--mrc-mono);
+  font-size: 0.62rem;
+  color: var(--mrc-tinta-2);
+  background: rgba(236, 232, 220, 0.7);
+  padding: 0 3px;
+  border-radius: 3px;
+}
+.mrc-tick__linea {
+  flex: 1;
+  height: 0;
+  border-top: 1px dashed rgba(44, 36, 24, 0.2);
+}
+.mrc-cinta__unidad {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  font-family: var(--mrc-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  color: var(--mrc-tinta-2);
+}
+/* pines: la cara clavada a su altura */
+.mrc-pin {
+  position: absolute;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  max-width: 56%;
+  padding: 3px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  z-index: 3;
+}
+.mrc-pin--izq { left: 3%; }
+.mrc-pin--der { right: 3%; flex-direction: row-reverse; text-align: right; }
+.mrc-pin__cara {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  box-shadow: 0 0 0 2.5px var(--pin-piso, #2f5233), 0 3px 7px rgba(44, 36, 24, 0.3);
+  line-height: 0;
+  transition: transform 0.18s ease;
+}
+.mrc-pin__tag {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.15;
+  min-width: 0;
+}
+.mrc-pin__finca {
+  font-family: var(--mrc-serif);
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--mrc-tinta);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 15ch;
+}
+.mrc-pin__alt {
+  font-family: var(--mrc-mono);
+  font-size: 0.64rem;
+  color: var(--mrc-tinta-2);
+}
+.mrc-pin:hover .mrc-pin__cara,
+.mrc-pin:focus-visible .mrc-pin__cara { transform: scale(1.08); }
+.mrc-pin.is-activa { z-index: 5; }
+.mrc-pin.is-activa .mrc-pin__cara {
+  box-shadow: 0 0 0 3px var(--pin-piso, #2f5233), 0 5px 12px rgba(44, 36, 24, 0.4);
+}
+.mrc-pin.is-activa .mrc-pin__finca { font-size: 0.8rem; }
+.mrc-pin.is-atenua { opacity: 0.5; }
+.mrc-pin.is-atenua .mrc-pin__tag { display: none; }
+
+/* ── FILTROS por piso térmico ────────────────────────────────────────────── */
+.mrc-filtros {
+  max-width: 660px;
+  margin: 22px auto 4px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-bottom: 4px;
+}
+.mrc-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 13px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.3);
+  color: var(--mrc-tinta);
+  font-family: var(--mrc-sans);
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.mrc-chip__punto {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--chip-piso, var(--mrc-monte));
+}
+.mrc-chip:hover { border-color: rgba(44, 36, 24, 0.32); }
+.mrc-chip.is-on {
+  background: var(--mrc-tinta);
+  border-color: var(--mrc-tinta);
+  color: #f4ecd9;
+}
+.mrc-chip.is-on .mrc-chip__punto { box-shadow: 0 0 0 2px rgba(244, 236, 217, 0.35); }
+
+/* ── GRILLA de productos ─────────────────────────────────────────────────── */
+.mrc-grid {
+  max-width: 660px;
+  margin: 14px auto 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.mrc-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--mrc-tarjeta);
+  border: 1px solid var(--mrc-linea);
+  border-radius: 15px;
+  overflow: hidden;
+  box-shadow: 0 4px 14px rgba(44, 36, 24, 0.08);
+}
+.mrc-card__foto {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 150px;
+  border: 0;
+  border-bottom: 1px dashed var(--mrc-linea);
+  background: var(--mrc-papel-2);
+  cursor: pointer;
+  overflow: hidden;
+}
+.mrc-card__foto::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--card-piso, #2f5233);
+  opacity: 0.13;
+}
+.mrc-card__foto > svg { position: relative; z-index: 1; }
+.mrc-card__bicho {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  z-index: 2;
+  filter: drop-shadow(0 2px 3px rgba(44, 36, 24, 0.25));
+}
+
+.mrc-card__cuerpo {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 13px 14px 15px;
+}
+.mrc-card__cabeza { display: flex; flex-direction: column; gap: 1px; }
+.mrc-card__nombre {
+  margin: 0;
+  font-family: var(--mrc-serif);
+  font-size: 1.14rem;
+  font-weight: 700;
+  color: var(--mrc-tinta);
+}
+.mrc-card__variedad {
+  margin: 0;
+  font-size: 0.78rem;
+  font-style: italic;
+  color: var(--mrc-tinta-2);
+}
+
+.mrc-precio {
+  margin: 0;
+  font-family: var(--mrc-mono);
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+}
+.mrc-precio__val { font-size: 1.16rem; font-weight: 700; color: var(--mrc-tinta); letter-spacing: -0.01em; }
+.mrc-precio__uni { font-size: 0.74rem; color: var(--mrc-tinta-2); }
+.mrc-precio--g .mrc-precio__val { font-size: 1.3rem; }
+
+/* bloque de procedencia */
+.mrc-proc {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 11px;
+  background: rgba(255, 255, 255, 0.34);
+  cursor: pointer;
+  text-align: left;
+}
+.mrc-proc:hover { background: rgba(255, 255, 255, 0.6); }
+.mrc-proc > svg { flex: 0 0 auto; }
+.mrc-proc__texto { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.mrc-proc__finca {
+  font-family: var(--mrc-serif);
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--mrc-tinta);
+}
+.mrc-proc__ubi {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.76rem;
+  color: var(--mrc-tinta-2);
+}
+.mrc-proc__ubi svg { color: var(--mrc-tinta-2); }
+.mrc-proc__alt {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mrc-mono);
+  font-size: 0.72rem;
+  color: var(--mrc-tinta-2);
+}
+.mrc-proc__punto { width: 8px; height: 8px; border-radius: 999px; flex: 0 0 auto; }
+
+/* sellos de confianza (estampas de tinta) */
+.mrc-sellos {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.mrc-sello {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border: 1.5px dashed var(--mrc-sello);
+  border-radius: 7px;
+  color: var(--mrc-sello);
+  font-family: var(--mrc-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  transform: rotate(-1.4deg);
+  background: rgba(165, 67, 42, 0.05);
+}
+.mrc-sello:nth-child(even) { transform: rotate(1.1deg); }
+.mrc-sello svg { flex: 0 0 auto; }
+.mrc-sello--g { font-size: 0.72rem; padding: 5px 11px; }
+
+/* ── PIE ─────────────────────────────────────────────────────────────────── */
+.mrc-pie {
+  max-width: 660px;
+  margin: 30px auto 0;
+  padding-top: 16px;
+  border-top: 1px dashed var(--mrc-linea);
+  text-align: center;
+}
+.mrc-pie p { margin: 0; font-size: 0.78rem; color: var(--mrc-tinta-2); }
+
+/* ── HISTORIA (modal) ────────────────────────────────────────────────────── */
+.mrc-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  animation: mrc-modal-in 0.18s ease;
+}
+.mrc-modal__fondo {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  padding: 0;
+  background: rgba(28, 22, 12, 0.5);
+  cursor: pointer;
+}
+.mrc-hoja {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 560px;
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  background:
+    repeating-linear-gradient(0deg, rgba(44, 36, 24, 0.02) 0 2px, transparent 2px 5px),
+    linear-gradient(180deg, #f5eedb 0%, var(--mrc-papel) 100%);
+  border-radius: 18px 18px 0 0;
+  box-shadow: 0 -8px 40px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+.mrc-hoja__barra {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--mrc-linea);
+  background: rgba(245, 238, 219, 0.9);
+}
+.mrc-back--modal { background: rgba(255, 255, 255, 0.5); }
+.mrc-cerrar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.5);
+  color: var(--mrc-tinta);
+  cursor: pointer;
+}
+.mrc-hoja__scroll {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 14px clamp(13px, 4vw, 22px) 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* cabecera de finca */
+.mrc-fincahead {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 15px 15px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 14px;
+  background: var(--mrc-papel-2);
+  overflow: hidden;
+}
+.mrc-fincahead__luz {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+  opacity: 0.55;
+}
+.mrc-mariposa { position: absolute; top: 8px; right: 10px; z-index: 2; }
+.mrc-fincahead__cara {
+  position: relative;
+  z-index: 1;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  box-shadow: 0 3px 9px rgba(44, 36, 24, 0.28);
+  line-height: 0;
+}
+.mrc-fincahead__id { position: relative; z-index: 1; min-width: 0; }
+.mrc-fincahead__quien {
+  margin: 0 0 1px;
+  font-family: var(--mrc-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mrc-tinta-2);
+}
+.mrc-fincahead__finca {
+  margin: 0 0 4px;
+  font-family: var(--mrc-serif);
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1.05;
+  color: var(--mrc-tinta);
+}
+.mrc-fincahead__ubi {
+  margin: 0 0 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.82rem;
+  color: var(--mrc-tinta);
+}
+.mrc-fincahead__alt {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+.mrc-fincahead__alt svg { color: var(--mrc-monte); }
+.mrc-alt-num {
+  font-family: var(--mrc-mono);
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--mrc-tinta);
+}
+.mrc-alt-piso {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.74rem;
+  color: var(--mrc-tinta-2);
+}
+.mrc-alt-piso .mrc-chip__punto { width: 8px; height: 8px; background: var(--chip-piso, var(--mrc-monte)); }
+
+/* producto de la finca */
+.mrc-hoja__producto {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 13px;
+  background: var(--mrc-tarjeta);
+  overflow: hidden;
+}
+.mrc-hoja__producto::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--card-piso, #2f5233);
+  opacity: 0.08;
+}
+.mrc-hoja__producto > svg,
+.mrc-hoja__producto > div { position: relative; z-index: 1; }
+.mrc-hoja__prodnombre {
+  margin: 0;
+  font-family: var(--mrc-serif);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--mrc-tinta);
+}
+.mrc-hoja__prodvar {
+  margin: 1px 0 6px;
+  font-size: 0.78rem;
+  font-style: italic;
+  color: var(--mrc-tinta-2);
+}
+
+/* relato */
+.mrc-relato {
+  position: relative;
+  margin: 0;
+  padding-left: 26px;
+  font-family: var(--mrc-serif);
+  font-size: 1rem;
+  line-height: 1.62;
+  color: var(--mrc-tinta);
+}
+.mrc-relato__ico {
+  position: absolute;
+  left: 0;
+  top: 4px;
+  color: var(--mrc-monte);
+}
+
+/* trazabilidad */
+.mrc-traza {
+  padding: 14px 15px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 13px;
+  background: rgba(255, 255, 255, 0.28);
+}
+.mrc-traza__tit,
+.mrc-donde__tit {
+  margin: 0 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--mrc-sans);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--mrc-tinta);
+}
+.mrc-traza__tit svg,
+.mrc-donde__tit svg { color: var(--mrc-monte); }
+.mrc-traza__linea { list-style: none; margin: 0; padding: 0; }
+.mrc-traza__hito {
+  position: relative;
+  display: flex;
+  gap: 12px;
+  padding: 0 0 14px 4px;
+}
+.mrc-traza__hito::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 13px;
+  bottom: -1px;
+  width: 2px;
+  background: var(--mrc-linea);
+}
+.mrc-traza__hito.is-fin::before { display: none; }
+.mrc-traza__punto {
+  position: relative;
+  z-index: 1;
+  flex: 0 0 auto;
+  width: 11px;
+  height: 11px;
+  margin-top: 4px;
+  border-radius: 999px;
+  background: var(--mrc-papel);
+  border: 2.5px solid var(--mrc-monte);
+}
+.mrc-traza__hito.is-fin .mrc-traza__punto { background: var(--mrc-sello); border-color: var(--mrc-sello); }
+.mrc-traza__hitotxt { display: flex; flex-direction: column; gap: 1px; }
+.mrc-traza__que { font-family: var(--mrc-serif); font-size: 0.92rem; color: var(--mrc-tinta); }
+.mrc-traza__cuando { font-family: var(--mrc-mono); font-size: 0.72rem; color: var(--mrc-tinta-2); }
+
+/* dónde queda en la montaña */
+.mrc-donde .mrc-cinta { height: clamp(320px, 78vw, 400px); }
+
+@keyframes mrc-modal-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ── responsive ──────────────────────────────────────────────────────────── */
+@media (min-width: 560px) {
+  .mrc-grid { grid-template-columns: 1fr 1fr; }
+}
+@media (min-width: 700px) {
+  .mrc-hero {
+    grid-template-columns: 1.05fr 0.95fr;
+    align-items: center;
+    gap: 26px;
+    padding: 22px 0 12px;
+  }
+  .mrc-modal { align-items: center; padding: 24px; }
+  .mrc-hoja { border-radius: 18px; max-height: 92vh; box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4); }
+}
+
+/* ── accesibilidad ───────────────────────────────────────────────────────── */
+.mrc-root button:focus-visible,
+.mrc-modal button:focus-visible {
+  outline: 2.5px solid var(--mrc-monte);
+  outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mrc-modal { animation: none; }
+  .mrc-pin__cara,
+  .mrc-chip { transition: none; }
+  .mrc-pin:hover .mrc-pin__cara,
+  .mrc-pin:focus-visible .mrc-pin__cara { transform: none; }
+}

--- a/src/mockups/mercado/CintaAltitud.jsx
+++ b/src/mockups/mercado/CintaAltitud.jsx
@@ -1,0 +1,91 @@
+import { Rostro } from './Rostro.jsx';
+import { ALTITUD_MIN, ALTITUD_MAX, pisoDeAltitud } from './datos.js';
+
+/*
+ * CintaAltitud — el elemento FIRMA del mercado. La montaña con la cara de cada
+ * productor clavada a la ALTURA REAL de su finca. El eje vertical es metros
+ * sobre el nivel del mar; el color del cielo va graduado por piso térmico (frío
+ * y páramo arriba, templado abajo). No decora: ubica cada cosecha en su punto
+ * de la montaña.
+ *
+ * Se usa en dos modos:
+ *   - Panorama (hero): todas las fincas como pines; tocar uno abre su historia.
+ *   - Enfoque (historia): una finca resaltada, las demás de contexto tenue.
+ *
+ * Props:
+ *   fincas    [{ id, nombre, productor, altitud, rostro }]
+ *   activaId  id de la finca resaltada, o null (panorama).
+ *   onSelect  (id) => void — al tocar un pin.
+ *   ticks     metros a marcar en el eje. Defecto [3000,2500,2000,1500].
+ */
+const BANDA_TOP = 7; // % desde arriba donde empieza la banda útil
+const BANDA_ALTO = 84; // % de alto útil
+
+function porcentajeAltitud(altitud) {
+  const t = (ALTITUD_MAX - altitud) / (ALTITUD_MAX - ALTITUD_MIN);
+  return BANDA_TOP + Math.min(1, Math.max(0, t)) * BANDA_ALTO;
+}
+
+export function CintaAltitud({
+  fincas,
+  activaId = null,
+  onSelect,
+  ticks = [3000, 2500, 2000, 1500],
+}) {
+  // De más alto a más bajo, para asignar carriles alternos (izq/der) y que dos
+  // fincas de altitud parecida no se pisen.
+  const ordenadas = [...fincas].sort((a, b) => b.altitud - a.altitud);
+
+  return (
+    <div className="mrc-cinta" role="group" aria-label="Las fincas ubicadas por su altura en la montaña">
+      <div className="mrc-cinta__cielo" aria-hidden="true" />
+      <svg
+        className="mrc-cinta__monte"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <path d="M0,100 L0,66 L18,54 L34,62 L52,42 L70,56 L84,48 L100,60 L100,100 Z" fill="#2f5233" opacity="0.22" />
+        <path d="M0,100 L0,78 L22,70 L40,76 L60,62 L78,72 L100,68 L100,100 Z" fill="#2f5233" opacity="0.34" />
+      </svg>
+
+      {/* eje de altímetro: líneas y rótulos en metros */}
+      {ticks.map((m) => (
+        <div key={m} className="mrc-tick" style={{ top: `${porcentajeAltitud(m)}%` }} aria-hidden="true">
+          <span className="mrc-tick__num">{m.toLocaleString('es-CO')}</span>
+          <span className="mrc-tick__linea" />
+        </div>
+      ))}
+      <span className="mrc-cinta__unidad" aria-hidden="true">m s. n. m.</span>
+
+      {/* pines: la cara de cada productor a su altura */}
+      {ordenadas.map((f, i) => {
+        const lado = i % 2 === 0 ? 'izq' : 'der';
+        const activa = activaId === f.id;
+        const atenua = activaId != null && !activa;
+        const piso = pisoDeAltitud(f.altitud);
+        return (
+          <button
+            key={f.id}
+            type="button"
+            className={`mrc-pin mrc-pin--${lado}${activa ? ' is-activa' : ''}${atenua ? ' is-atenua' : ''}`}
+            style={{ top: `${porcentajeAltitud(f.altitud)}%`, '--pin-piso': piso.hex }}
+            onClick={() => onSelect && onSelect(f.id)}
+            aria-label={`${f.nombre}, a ${f.altitud.toLocaleString('es-CO')} metros, piso ${piso.nombre}`}
+            aria-pressed={activa}
+          >
+            <span className="mrc-pin__cara">
+              <Rostro seed={f.rostro} size={activa ? 52 : 40} title={`Productor de ${f.nombre}`} />
+            </span>
+            <span className="mrc-pin__tag">
+              <span className="mrc-pin__finca">{f.nombre}</span>
+              <span className="mrc-pin__alt">{f.altitud.toLocaleString('es-CO')} m</span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default CintaAltitud;

--- a/src/mockups/mercado/ProductoIlustracion.jsx
+++ b/src/mockups/mercado/ProductoIlustracion.jsx
@@ -1,0 +1,124 @@
+/*
+ * ProductoIlustracion — dibujos SVG propios de cada producto del mercado. Planos
+ * y cálidos, sobre fondo transparente (el color de la banda lo pone la tarjeta).
+ * Sin imágenes externas: todo trazo propio. Cada dibujo cabe en un viewBox
+ * 0 0 120 120 y se centra solo.
+ *
+ * Props:
+ *   tipo   'tomate' | 'mora' | 'papa' | 'cafe' | 'miel' | 'aguacate'
+ *   size   número (px). Defecto 120.
+ *   className, title.
+ */
+export function ProductoIlustracion({ tipo, size = 120, className = '', title = '' }) {
+  const dibujo = DIBUJOS[tipo] || DIBUJOS.tomate;
+  return (
+    <svg
+      viewBox="0 0 120 120"
+      width={size}
+      height={size}
+      className={className || undefined}
+      role="img"
+      aria-label={title || tipo}
+    >
+      <title>{title || tipo}</title>
+      {dibujo}
+    </svg>
+  );
+}
+
+const DIBUJOS = {
+  tomate: (
+    <g>
+      <ellipse cx="60" cy="92" rx="34" ry="6" fill="#2c2418" opacity="0.12" />
+      <path d="M60,32 C86,32 96,54 96,72 C96,92 80,104 60,104 C40,104 24,92 24,72 C24,54 34,32 60,32 Z" fill="#d23f28" />
+      <path d="M46,44 C36,50 32,62 33,74 C34,82 39,90 47,95 C34,92 26,80 27,66 C28,54 36,46 46,44 Z" fill="#ff6a4d" opacity="0.7" />
+      <ellipse cx="72" cy="58" rx="9" ry="13" fill="#ff8f6a" opacity="0.5" />
+      <path d="M60,36 l-9,-8 M60,36 l9,-8 M60,36 l0,-11 M60,36 l-12,-2 M60,36 l12,-2" stroke="#3f7f3a" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <circle cx="60" cy="34" r="4" fill="#4a8f3a" />
+    </g>
+  ),
+  mora: (
+    <g>
+      <ellipse cx="60" cy="100" rx="30" ry="5" fill="#2c2418" opacity="0.12" />
+      <path d="M60,26 C58,32 56,36 52,40" stroke="#3f7f3a" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <g fill="#3a1140">
+        <circle cx="52" cy="52" r="10" />
+        <circle cx="68" cy="52" r="10" />
+        <circle cx="44" cy="66" r="10" />
+        <circle cx="60" cy="66" r="11" />
+        <circle cx="76" cy="66" r="10" />
+        <circle cx="52" cy="82" r="10" />
+        <circle cx="68" cy="82" r="10" />
+        <circle cx="60" cy="95" r="9" />
+      </g>
+      <g fill="#6a2f78" opacity="0.75">
+        <circle cx="49" cy="49" r="3.4" />
+        <circle cx="65" cy="49" r="3.4" />
+        <circle cx="41" cy="63" r="3.4" />
+        <circle cx="57" cy="63" r="3.6" />
+        <circle cx="73" cy="63" r="3.4" />
+        <circle cx="49" cy="79" r="3.4" />
+        <circle cx="65" cy="79" r="3.4" />
+      </g>
+      <path d="M60,30 l-8,-6 M60,30 l8,-6 M60,30 l-2,-9" stroke="#4a8f3a" strokeWidth="3.4" strokeLinecap="round" fill="none" />
+    </g>
+  ),
+  papa: (
+    <g>
+      <ellipse cx="60" cy="96" rx="36" ry="7" fill="#2c2418" opacity="0.12" />
+      <ellipse cx="46" cy="62" rx="22" ry="18" fill="#e0a53a" transform="rotate(-12 46 62)" />
+      <ellipse cx="74" cy="72" rx="20" ry="16" fill="#d99a2e" transform="rotate(10 74 72)" />
+      <ellipse cx="60" cy="52" rx="18" ry="15" fill="#eab24a" transform="rotate(6 60 52)" />
+      <g fill="#a8781f" opacity="0.7">
+        <circle cx="40" cy="60" r="2.2" />
+        <circle cx="52" cy="66" r="2.2" />
+        <circle cx="66" cy="50" r="2.2" />
+        <circle cx="78" cy="70" r="2.2" />
+        <circle cx="70" cy="78" r="2.2" />
+        <circle cx="56" cy="54" r="2" />
+      </g>
+      <ellipse cx="54" cy="48" rx="6" ry="4" fill="#f6cf7a" opacity="0.6" />
+    </g>
+  ),
+  cafe: (
+    <g>
+      <ellipse cx="60" cy="100" rx="30" ry="5" fill="#2c2418" opacity="0.12" />
+      <path d="M60,24 C56,32 50,36 44,38" stroke="#3f7f3a" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M40,40 C30,42 26,52 34,56 C42,60 52,52 50,42 Z" fill="#4a8f3a" />
+      <g>
+        <circle cx="50" cy="60" r="14" fill="#c62f22" />
+        <circle cx="70" cy="52" r="14" fill="#d23f28" />
+        <circle cx="64" cy="76" r="14" fill="#b62a1e" />
+        <circle cx="46" cy="60" r="4" fill="#8a1f16" />
+        <circle cx="66" cy="52" r="4" fill="#8a1f16" />
+        <circle cx="60" cy="76" r="4" fill="#8a1f16" />
+      </g>
+      <ellipse cx="46" cy="54" rx="4" ry="6" fill="#ff7a5a" opacity="0.5" />
+      <ellipse cx="66" cy="46" rx="4" ry="6" fill="#ff7a5a" opacity="0.5" />
+    </g>
+  ),
+  miel: (
+    <g>
+      <ellipse cx="60" cy="104" rx="28" ry="5" fill="#2c2418" opacity="0.12" />
+      <rect x="46" y="20" width="28" height="10" rx="3" fill="#6f5a3c" />
+      <path d="M42,34 C42,32 44,30 46,30 L74,30 C76,30 78,32 78,34 L80,58 C82,64 82,70 80,78 L80,96 C80,100 76,102 72,102 L48,102 C44,102 40,100 40,96 L40,78 C38,70 38,64 40,58 Z" fill="#e8a72e" />
+      <path d="M45,64 C45,60 48,58 52,58 L68,58 C72,58 75,60 75,64 L75,92 C75,96 72,97 68,97 L52,97 C48,97 45,96 45,92 Z" fill="#f6cf7a" opacity="0.55" />
+      <rect x="44" y="44" width="32" height="14" rx="2" fill="#efe7d6" />
+      <path d="M52,51 l4,0 l2,-3 l2,6 l2,-3 l4,0" stroke="#c1902f" strokeWidth="1.6" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      <ellipse cx="50" cy="74" rx="4" ry="10" fill="#ffe6a0" opacity="0.7" />
+    </g>
+  ),
+  aguacate: (
+    <g>
+      <ellipse cx="60" cy="102" rx="30" ry="5" fill="#2c2418" opacity="0.12" />
+      <path d="M60,22 C58,28 58,32 60,36" stroke="#6f5a3c" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M60,34 C78,34 88,54 88,72 C88,92 76,104 60,104 C44,104 32,92 32,72 C32,54 42,34 60,34 Z" fill="#3f5a1f" />
+      <path d="M60,44 C72,44 80,58 80,74 C80,90 71,98 60,98 C49,98 40,90 40,74 C40,58 48,44 60,44 Z" fill="#c8d24a" />
+      <ellipse cx="60" cy="78" rx="13" ry="15" fill="#8a5a2c" />
+      <ellipse cx="56" cy="74" rx="5" ry="6" fill="#a5723a" opacity="0.7" />
+      <path d="M46,58 C50,54 54,52 58,52" stroke="#e6ee9a" strokeWidth="3" strokeLinecap="round" fill="none" opacity="0.7" />
+    </g>
+  ),
+};
+
+export default ProductoIlustracion;

--- a/src/mockups/mercado/Rostro.jsx
+++ b/src/mockups/mercado/Rostro.jsx
@@ -1,0 +1,133 @@
+import { useId } from 'react';
+
+/*
+ * Rostro — avatar ILUSTRADO (no foto) de un productor del mercado. Cara genérica
+ * y ficticia, construida por parámetros (piel, pelo, tocado), para poner "la
+ * cara de quien sembró" sin usar la imagen de ninguna persona real.
+ *
+ * Estética: retrato plano y cálido, de rótulo de mercado. Tocados campesinos
+ * (sombrero de paja, pañuelo, ruana) para variedad. Reduced-motion irrelevante:
+ * es estático.
+ *
+ * Props:
+ *   seed  { piel, pelo, tocado, tocadoColor } — describe la cara.
+ *   size  número (px). Defecto 56.
+ *   className, title.
+ */
+export function Rostro({ seed, size = 56, className = '', title = 'Productor de la finca' }) {
+  const s = seed || {};
+  const piel = s.piel || '#c98a5e';
+  const pelo = s.pelo || '#2b1d12';
+  const tocado = s.tocado || 'ninguno';
+  const tocadoColor = s.tocadoColor || '#c9a26a';
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const clip = `rostro-clip-${uid}`;
+
+  // Sombra suave de la piel para dar volumen sin degradados costosos.
+  const pielSombra = mezclar(piel, '#000000', 0.16);
+  const pielLuz = mezclar(piel, '#ffffff', 0.14);
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      width={size}
+      height={size}
+      className={className || undefined}
+      role="img"
+      aria-label={title}
+    >
+      <title>{title}</title>
+      <defs>
+        <clipPath id={clip}>
+          <circle cx="50" cy="50" r="48" />
+        </clipPath>
+      </defs>
+
+      {/* disco de fondo */}
+      <circle cx="50" cy="50" r="49" fill="#efe7d6" />
+      <circle cx="50" cy="50" r="49" fill="none" stroke="#2c2418" strokeWidth="2" opacity="0.28" />
+
+      <g clipPath={`url(#${clip})`}>
+        {/* hombros / ruana */}
+        <path
+          d="M14,100 C16,80 30,70 50,70 C70,70 84,80 86,100 Z"
+          fill={tocado === 'ruana' ? tocadoColor : '#6f5a3c'}
+        />
+        <path
+          d="M50,70 L44,100 L56,100 Z"
+          fill="#efe7d6"
+          opacity={tocado === 'ruana' ? 0.85 : 0}
+        />
+
+        {/* cuello */}
+        <rect x="43" y="60" width="14" height="16" rx="5" fill={pielSombra} />
+
+        {/* pelo (detrás de la cara) */}
+        {tocado !== 'panuelo' && (
+          <path d="M25,52 C24,28 40,18 50,18 C60,18 76,28 75,52 C70,44 60,40 50,40 C40,40 30,44 25,52 Z" fill={pelo} />
+        )}
+
+        {/* cara */}
+        <ellipse cx="50" cy="50" rx="23" ry="26" fill={piel} />
+        <ellipse cx="61" cy="52" rx="9" ry="18" fill={pielSombra} opacity="0.35" />
+        <ellipse cx="41" cy="46" rx="7" ry="11" fill={pielLuz} opacity="0.5" />
+
+        {/* orejas */}
+        <circle cx="27" cy="52" r="4.5" fill={piel} />
+        <circle cx="73" cy="52" r="4.5" fill={piel} />
+
+        {/* cejas + ojos */}
+        <path d="M37,44 q4,-3 9,-1" stroke={pelo} strokeWidth="2" fill="none" strokeLinecap="round" />
+        <path d="M54,43 q5,-2 9,1" stroke={pelo} strokeWidth="2" fill="none" strokeLinecap="round" />
+        <circle cx="42" cy="49" r="2.6" fill="#2c2418" />
+        <circle cx="58" cy="49" r="2.6" fill="#2c2418" />
+        <circle cx="42.9" cy="48.2" r="0.8" fill="#ffffff" />
+        <circle cx="58.9" cy="48.2" r="0.8" fill="#ffffff" />
+
+        {/* nariz + boca + mejillas */}
+        <path d="M50,52 q-3,6 0,8" stroke={pielSombra} strokeWidth="2" fill="none" strokeLinecap="round" />
+        <path d="M43,66 q7,6 14,0" stroke="#7a3f2a" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        <circle cx="36" cy="60" r="3.5" fill="#d98a6a" opacity="0.35" />
+        <circle cx="64" cy="60" r="3.5" fill="#d98a6a" opacity="0.35" />
+
+        {/* pañuelo (tapa el pelo y ata bajo el mentón) */}
+        {tocado === 'panuelo' && (
+          <g>
+            <path d="M24,50 C22,26 40,16 50,16 C60,16 78,26 76,50 C70,40 60,36 50,36 C40,36 30,40 24,50 Z" fill={tocadoColor} />
+            <path d="M27,52 q23,-14 46,0" stroke="#ffffff" strokeWidth="1.6" opacity="0.35" fill="none" />
+            <circle cx="34" cy="43" r="1.6" fill="#ffffff" opacity="0.6" />
+            <circle cx="50" cy="38" r="1.6" fill="#ffffff" opacity="0.6" />
+            <circle cx="66" cy="43" r="1.6" fill="#ffffff" opacity="0.6" />
+          </g>
+        )}
+      </g>
+
+      {/* sombrero de paja (por encima del clip para que el ala sobresalga) */}
+      {tocado === 'sombrero' && (
+        <g>
+          <ellipse cx="50" cy="34" rx="40" ry="11" fill={mezclar(tocadoColor, '#000000', 0.12)} />
+          <ellipse cx="50" cy="32" rx="40" ry="10" fill={tocadoColor} />
+          <path d="M31,32 C31,16 41,10 50,10 C59,10 69,16 69,32 Z" fill={mezclar(tocadoColor, '#ffffff', 0.1)} />
+          <path d="M31,31 q19,7 38,0" stroke={mezclar(tocadoColor, '#000000', 0.22)} strokeWidth="3" fill="none" opacity="0.7" />
+          <ellipse cx="50" cy="32" rx="40" ry="10" fill="none" stroke={mezclar(tocadoColor, '#000000', 0.2)} strokeWidth="1.4" opacity="0.5" />
+        </g>
+      )}
+    </svg>
+  );
+}
+
+/* Mezcla lineal de dos colores hex (#rrggbb). t=0 → a, t=1 → b. Para sombras y
+   luces del retrato sin degradados SVG. */
+function mezclar(a, b, t) {
+  const pa = hexAgb(a);
+  const pb = hexAgb(b);
+  const c = pa.map((v, i) => Math.round(v + (pb[i] - v) * t));
+  return `#${c.map((v) => v.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function hexAgb(hex) {
+  const h = hex.replace('#', '');
+  return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+}
+
+export default Rostro;

--- a/src/mockups/mercado/datos.js
+++ b/src/mockups/mercado/datos.js
@@ -1,0 +1,201 @@
+/*
+ * Datos de MUESTRA del mockup mercado.chagra.bio (galería de diseño, público,
+ * sin auth). Fincas, veredas y productores son FICTICIOS y genéricos — no
+ * corresponden a personas ni predios reales. El copy final migraría a
+ * src/config/messages.js igual que el resto de la galería. Español Colombia,
+ * usted.
+ *
+ * El diferencial del mercado es la PROCEDENCIA: cada producto se ubica en la
+ * montaña por su ALTITUD (metros s. n. m.) y su PISO TÉRMICO, con la cara de
+ * quien lo sembró, su finca y su vereda.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- seed de datos de MUESTRA
+   del mockup (galería): el copy final migraría a src/config/messages.js, mismo
+   criterio que src/data/marketplaceSeed.js y el resto de seeds. */
+
+/* Rango del eje de altitud del mockup (metros s. n. m.). Encima de la montaña
+   dibujada; las fincas caen dentro de este rango. */
+export const ALTITUD_MIN = 1400;
+export const ALTITUD_MAX = 3200;
+
+/* Pisos térmicos presentes en el mercado. `slug` engancha con el grade de luz
+   de la librería de efectos (vfx-grade--<slug>); `hex` es el acento funcional
+   para los chips (espectro frío→cálido). Orden: de más alto a más templado. */
+export const PISOS = {
+  paramo: { slug: 'paramo', nombre: 'Páramo', hex: '#3f7f9e', rango: 'sobre 3.000 m' },
+  frio: { slug: 'frio', nombre: 'Frío', hex: '#5f8f80', rango: '2.000 a 3.000 m' },
+  templado: { slug: 'templado', nombre: 'Templado', hex: '#c1902f', rango: '1.000 a 2.000 m' },
+};
+
+/* Clasifica una altitud (m s. n. m.) en su piso térmico. */
+export function pisoDeAltitud(altitud) {
+  if (altitud >= 3000) return PISOS.paramo;
+  if (altitud >= 2000) return PISOS.frio;
+  return PISOS.templado;
+}
+
+/*
+ * Catálogo de muestra. Cada producto trae su finca (procedencia), precio en
+ * pesos colombianos, sellos de confianza y la trazabilidad de la cosecha.
+ *
+ * - `ilustracion`: clave del dibujo SVG propio (ProductoIlustracion).
+ * - `rostro`: semilla del avatar del productor (Rostro) — cara ilustrada, no
+ *   foto; genérica y ficticia.
+ * - `precio`/`unidad`: se muestran como "$ 4.800 / libra".
+ * - `sellos`: sellos de confianza cortos (rótulo de estampa).
+ * - `trazabilidad`: hitos de la cosecha, en orden.
+ */
+export const PRODUCTOS = [
+  {
+    id: 'tomate-chonto',
+    nombre: 'Tomate chonto',
+    variedad: 'de rama, madurado en la mata',
+    ilustracion: 'tomate',
+    precio: 4800,
+    unidad: 'libra',
+    finca: {
+      nombre: 'Finca El Rocío',
+      vereda: 'La Esperanza',
+      altitud: 2180,
+      productor: 'Doña Emilia',
+      rostro: { piel: '#c98a5e', pelo: '#3a2a1c', tocado: 'panuelo', tocadoColor: '#b8452e' },
+    },
+    sellos: ['Sembrado sin químicos', 'Cosechado el 8 de julio'],
+    historia:
+      'En El Rocío el tomate se deja madurar en la mata, no en la bodega. Doña Emilia lo abona con el compost de sus propias camas y lo riega con el agua de la quebrada que baja del alto. Por eso llega blando, oloroso y con el color parejo del que maduró al sol.',
+    trazabilidad: [
+      { hito: 'Sembrado', fecha: '3 de abril' },
+      { hito: 'Abonado con compost de la finca', fecha: '2 de mayo' },
+      { hito: 'Deshierbado a mano', fecha: '10 de junio' },
+      { hito: 'Cosechado', fecha: '8 de julio' },
+    ],
+  },
+  {
+    id: 'mora-castilla',
+    nombre: 'Mora de Castilla',
+    variedad: 'recogida madura, una por una',
+    ilustracion: 'mora',
+    precio: 6500,
+    unidad: 'libra',
+    finca: {
+      nombre: 'Finca La Cabaña',
+      vereda: 'El Retiro',
+      altitud: 2640,
+      productor: 'Don Aurelio',
+      rostro: { piel: '#8a5a38', pelo: '#20140c', tocado: 'sombrero', tocadoColor: '#c9a26a' },
+    },
+    sellos: ['Recolección a mano', 'Cosechada el 9 de julio'],
+    historia:
+      'La mora de La Cabaña crece en el filo, donde el frío la pone dulce y firme. Don Aurelio la recoge una por una, solo la que ya está negra pareja, para que no llegue verde ni magullada. Nada de madurar en camino: la corta en la mañana y baja el mismo día.',
+    trazabilidad: [
+      { hito: 'Podada la mata', fecha: '15 de marzo' },
+      { hito: 'Abonada con gallinaza compostada', fecha: '20 de abril' },
+      { hito: 'Primera recolección', fecha: '28 de junio' },
+      { hito: 'Cosechada', fecha: '9 de julio' },
+    ],
+  },
+  {
+    id: 'papa-criolla',
+    nombre: 'Papa criolla',
+    variedad: 'amarilla, de tierra de páramo',
+    ilustracion: 'papa',
+    precio: 3900,
+    unidad: 'libra',
+    finca: {
+      nombre: 'Finca Los Helechos',
+      vereda: 'Peñas Blancas',
+      altitud: 3050,
+      productor: 'La familia Rueda',
+      rostro: { piel: '#b57a4c', pelo: '#2b1d12', tocado: 'ruana', tocadoColor: '#7a4a2c' },
+    },
+    sellos: ['Sin agroquímicos', 'Sacada el 7 de julio'],
+    historia:
+      'Arriba, en Peñas Blancas, la tierra negra del páramo le da a la papa criolla ese amarillo intenso por dentro. La familia Rueda la siembra en rotación con habas para no cansar el suelo, y la saca con azadón el mismo día que la despacha, con la tierra todavía fresca encima.',
+    trazabilidad: [
+      { hito: 'Sembrada', fecha: '10 de febrero' },
+      { hito: 'Aporcada', fecha: '25 de abril' },
+      { hito: 'Rotación con habas', fecha: 'ciclo anterior' },
+      { hito: 'Sacada', fecha: '7 de julio' },
+    ],
+  },
+  {
+    id: 'cafe-pergamino',
+    nombre: 'Café pergamino',
+    variedad: 'lavado, secado al sol',
+    ilustracion: 'cafe',
+    precio: 22000,
+    unidad: 'libra',
+    finca: {
+      nombre: 'Finca La Aurora',
+      vereda: 'El Silencio',
+      altitud: 1650,
+      productor: 'Don Fermín',
+      rostro: { piel: '#d29a68', pelo: '#4a3520', tocado: 'sombrero', tocadoColor: '#d8b878' },
+    },
+    sellos: ['Recogido grano rojo', 'Secado al sol'],
+    historia:
+      'En La Aurora solo se recoge el grano bien rojo, el que ya está de punto. Don Fermín lo despulpa el mismo día, lo lava con agua de nacimiento y lo seca al sol en marquesina, volteándolo a mano. Por eso el pergamino queda parejo y sin ese sabor a fermento apurado.',
+    trazabilidad: [
+      { hito: 'Floración', fecha: 'enero' },
+      { hito: 'Recolección selectiva', fecha: 'junio a julio' },
+      { hito: 'Lavado y despulpado', fecha: 'el mismo día' },
+      { hito: 'Secado al sol', fecha: 'julio' },
+    ],
+  },
+  {
+    id: 'miel-angelita',
+    nombre: 'Miel de angelita',
+    variedad: 'abeja nativa sin aguijón',
+    ilustracion: 'miel',
+    precio: 34000,
+    unidad: 'frasco de 250 g',
+    finca: {
+      nombre: 'Finca El Colibrí',
+      vereda: 'Aguas Claras',
+      altitud: 1950,
+      productor: 'Doña Rosalba',
+      rostro: { piel: '#a86a42', pelo: '#1c130b', tocado: 'panuelo', tocadoColor: '#3f7f5a' },
+    },
+    sellos: ['Meliponicultura nativa', 'Cosecha que no daña el nido'],
+    historia:
+      'La miel de El Colibrí la hacen abejas angelita, nativas y sin aguijón, que Doña Rosalba cría en cajones de madera bajo los árboles. Se cosecha poquito y con cuidado, sin destruir el nido, por eso rinde tan poco y sabe distinto: más ácida, casi como fruta.',
+    trazabilidad: [
+      { hito: 'División de colmenas', fecha: 'marzo' },
+      { hito: 'Floración del monte', fecha: 'abril a junio' },
+      { hito: 'Cosecha de potes', fecha: '2 de julio' },
+      { hito: 'Envasada a mano', fecha: '3 de julio' },
+    ],
+  },
+  {
+    id: 'aguacate-hass',
+    nombre: 'Aguacate Hass',
+    variedad: 'cortado de punto, no verde',
+    ilustracion: 'aguacate',
+    precio: 2500,
+    unidad: 'unidad',
+    finca: {
+      nombre: 'Finca La Palma',
+      vereda: 'El Progreso',
+      altitud: 1780,
+      productor: 'Don Isidro',
+      rostro: { piel: '#c98a5e', pelo: '#6b6b6b', tocado: 'sombrero', tocadoColor: '#c9a26a' },
+    },
+    sellos: ['Sin madurantes', 'Cortado el 6 de julio'],
+    historia:
+      'Don Isidro no tumba el aguacate al piso: lo corta con gancho cuando ya tiene el aceite hecho, ni antes ni después. En La Palma los árboles conviven con plátano y guamo que les dan sombra, así la fruta no se estresa y madura pareja en la casa, sin cámaras ni químicos.',
+    trazabilidad: [
+      { hito: 'Cuajado del fruto', fecha: 'febrero' },
+      { hito: 'Sombra con guamo y plátano', fecha: 'todo el ciclo' },
+      { hito: 'Prueba de aceite', fecha: 'inicio de julio' },
+      { hito: 'Cortado con gancho', fecha: '6 de julio' },
+    ],
+  },
+];
+
+/* Formatea un precio entero en pesos colombianos: 4800 → "$ 4.800". Punto de
+   miles a la colombiana, sin decimales. */
+export function pesos(valor) {
+  const entero = Math.round(valor);
+  const conMiles = String(entero).replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+  return `$ ${conMiles}`;
+}

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,0 +1,61 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
+   Apis). Cuerpo ámbar rayado, cabeza clara, alitas de tul. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-15 -15 32 30';
+
+export function AbejaAngelita({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Abeja angelita',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#ffb54f" opacity="0.35" filter={`url(#${blur})`} />
+      <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
+        style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
+      <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
+        stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
+      <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
+      <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
+      <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
+      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="abeja-angelita">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default AbejaAngelita;

--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,0 +1,62 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Colibrí chillón — Colibri coruscans (nativo de los Andes). Pico largo y
+   recto, garganta violeta iridiscente, alas que baten. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-22 -28 58 52';
+
+export function Colibri({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Colibrí',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#2dffc4" opacity="0.35" filter={`url(#${blur})`} />
+      <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
+      <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
+      <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
+      <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
+      <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
+      <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
+      <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+      <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <path className={wing} d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
+      <path className={wing} style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="colibri">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="colibri" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Colibri;

--- a/src/visual/creatures/Escarabajo.jsx
+++ b/src/visual/creatures/Escarabajo.jsx
@@ -1,0 +1,73 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Escarabajo estercolero — Dichotomius belus (propio de Colombia). Élitros
+   negros brillantes con sutura, cabeza con cuerno, patas que caminan y la bola
+   de abono que rueda. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-23 -12 42 30';
+
+export function Escarabajo({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Escarabajo estercolero',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const bola = animated ? 'crt-ball' : undefined;
+  const patas = animated ? 'crt-legs' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const bolaG = (
+    <g className={bola}>
+      <circle cx="-13" cy="7" r="6.5" fill="#5a4230" />
+      <circle cx="-13" cy="7" r="6.5" fill="none" stroke="#3a2c1c" strokeWidth="1" />
+      <circle cx="-15" cy="5" r="1.5" fill="#6e5238" opacity="0.7" />
+      <circle cx="-11.5" cy="9" r="1.1" fill="#42301f" opacity="0.7" />
+    </g>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={patas} stroke="#0c1206" strokeWidth="1.7" strokeLinecap="round">
+        <path d="M-4,4 L-9,10" /><path d="M0,5 L-1,11" /><path d="M4,4 L8,10" />
+      </g>
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="#141c10"
+        style={{ filter: 'drop-shadow(0 0 5px rgba(157,214,106,0.7))' }} />
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="none" stroke="#9dd66a" strokeWidth="0.7" strokeOpacity="0.6" />
+      <path d="M0,-5.6 L0,5.6" stroke="#0c1206" strokeWidth="0.8" />
+      <ellipse cx="-3.5" cy="-2.8" rx="2.6" ry="1.4" fill="#3d5a24" opacity="0.55" />
+      <path d="M8,-3.4 C12,-3.8 13.4,-1 12.4,1.4 C11.4,3.6 9,3.6 8.2,2.6 C9.4,1 9.2,-1.4 8,-3.4 Z" fill="#0f150b" />
+      <path d="M11.2,-3.2 C12.6,-5 13.4,-4.4 13.2,-2.8" fill="none" stroke="#0f150b" strokeWidth="1.7" strokeLinecap="round" />
+      <circle cx="10.4" cy="-0.6" r="0.7" fill="#9dd66a" opacity="0.8" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="escarabajo">
+        {defs}
+        {bolaG}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="escarabajo" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {bolaG}
+      {body}
+    </svg>
+  );
+}
+
+export default Escarabajo;

--- a/src/visual/creatures/Lombriz.jsx
+++ b/src/visual/creatures/Lombriz.jsx
@@ -1,0 +1,64 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Lombriz de tierra — Martiodrilus crassus (lombriz gigante nativa de los
+   Andes). Cuerpo curvo segmentado con clitelo (banda clara) y cabecita.
+   Su movimiento en escena (asomar/mecerse) lo aporta la escena, no la
+   criatura. Versión canónica del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-8 -16 30 48';
+
+export function Lombriz({
+  size = 64,
+  className,
+  inline = false,
+  // eslint-disable-next-line no-unused-vars
+  animated = true,
+  title = 'Lombriz de tierra',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#c0715a" strokeWidth="7.4" strokeLinecap="round" />
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#ff9d6a" strokeWidth="4.4" strokeLinecap="round" opacity="0.85" />
+      <g stroke="#7a3f2e" strokeWidth="0.9" opacity="0.65" strokeLinecap="round">
+        <path d="M-1.4,22 L1.4,20.5" /><path d="M-1.2,16.5 L2.2,15.5" />
+        <path d="M2.4,11.5 L5.6,11" /><path d="M3.4,5.5 L6.4,5.6" />
+        <path d="M2.8,-0.5 L5.6,-1.4" /><path d="M4.6,-6 L7.4,-7.6" />
+      </g>
+      <path d="M3.2,3 C2,-1 4,-4 6.6,-5" fill="none" stroke="#ffd9b0" strokeWidth="4.6" strokeLinecap="round" opacity="0.75" />
+      <circle cx="12.2" cy="-9.4" r="2.2" fill="#ff9d6a" />
+      <circle cx="13.2" cy="-10" r="0.6" fill="#3a1c12" opacity="0.7" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="lombriz">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="lombriz" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Lombriz;

--- a/src/visual/creatures/Mariposa.jsx
+++ b/src/visual/creatures/Mariposa.jsx
@@ -1,0 +1,76 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Mariposa pasionaria — Dione juno (Nymphalidae, alas largas). Cuatro alas
+   independientes (delanteras + traseras, izq/der) que abren y cierran, cuerpo,
+   cabeza, antenas y ocelos. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-27 -18 54 40';
+
+export function Mariposa({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Mariposa',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const alaL = animated ? 'crt-fwing crt-fwing-l' : undefined;
+  const alaR = animated ? 'crt-fwing crt-fwing-r' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={alaL}>
+        <path d="M0,2 C-13,4 -18,12 -12,15 C-6,17 -1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="-9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,2 C13,4 18,12 12,15 C6,17 1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaL}>
+        <path d="M0,-2 C-16,-11 -24,-6 -22,0 C-20,5 -8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M-20,-3 C-14,-2 -7,-1 -1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="-16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,-2 C16,-11 24,-6 22,0 C20,5 8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M20,-3 C14,-2 7,-1 1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <ellipse cx="0" cy="2" rx="1.7" ry="9" fill="#2a1712" />
+      <circle cx="0" cy="-8" r="1.9" fill="#2a1712" />
+      <path d="M-0.8,-9.4 C-3,-13 -4.5,-14 -6,-13.6 M0.8,-9.4 C3,-13 4.5,-14 6,-13.6"
+        stroke="#2a1712" strokeWidth="0.8" fill="none" strokeLinecap="round" />
+      <circle cx="-6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+      <circle cx="6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="mariposa">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="mariposa" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Mariposa;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -1,0 +1,74 @@
+# `src/visual/creatures` — personajes de fauna reutilizables
+
+Librería de **personajes de fauna de la chagra** como componentes SVG limpios,
+parametrizables y sin dependencias nuevas. Nace para **dejar de redibujar el
+mismo bicho** en cada mockup/escena: hoy el colibrí, la abeja angelita, la
+lombriz, la mariposa y el escarabajo aparecían dibujados por separado en varios
+sitios (`mockups/MockupGuardianesNarrativos`, `dashboard/Scene*`,
+`FincaVivaHero`, `MundoVinetas`, `MundoSubsuelo`, avatares del colibrí…) con
+calidad dispar. Aquí vive la **versión canónica** de cada uno.
+
+## Regla de la casa
+
+> **Antes de dibujar un personaje de fauna, búscalo aquí.**
+> Si existe → **reúsalo** (y si podés, **mejorá** la versión canónica en su
+> archivo, para que todos hereden la mejora).
+> Si dibujás un personaje nuevo reutilizable → **agregalo aquí en el mismo PR**
+> (componente + entrada en `index.js` + fila en esta tabla).
+
+## Personajes
+
+| Componente | Especie (binomio verificado) | Notas |
+|---|---|---|
+| `AbejaAngelita` | *Tetragonisca angustula* | Meliponino nativo **SIN aguijón** — NO *Apis*. Alitas de tul que baten. |
+| `Colibri` | *Colibri coruscans* | Colibrí chillón andino. Pico largo, garganta violeta, alas que baten. |
+| `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
+| `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
+| `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
+
+## Props
+
+Todos comparten la misma firma:
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `size` | `number \| string` | `64` | Ancho/alto en modo standalone (`<svg>`). Ignorado en modo `inline`. |
+| `className` | `string` | — | Clase(s) del nodo raíz. En modo `inline` es donde la escena engancha su coreografía de entrada/posición. |
+| `inline` | `boolean` | `false` | `false` → `<svg>` autónomo (avatares, catálogo, botones). `true` → solo un `<g>` para incrustar en una escena SVG existente. |
+| `animated` | `boolean` | `true` | Activa la vida perpetua (aleteo, alas, bola, patas). `false` = quieto. Siempre reduced-motion-safe. |
+| `title` | `string` | nombre del bicho | `aria-label` + `<title>` accesible. |
+
+Props extra (`...rest`) se pasan al `<svg>` en modo standalone.
+
+## Uso
+
+```jsx
+import { Colibri, AbejaAngelita } from '@/visual/creatures';
+
+// Avatar / catálogo — SVG autónomo:
+<Colibri size={48} title="Colibrí chillón" />
+<AbejaAngelita size={40} animated={false} />
+
+// Dentro de una escena SVG propia (la escena pone posición y entrada):
+<svg viewBox="0 0 340 210">
+  {/* …fondo, suelo… */}
+  <g transform="translate(120 66)">
+    <Colibri inline className="mi-entrada-volando" />
+  </g>
+</svg>
+```
+
+Consumidor de referencia: **`src/mockups/MockupGuardianesNarrativos.jsx`**
+(usa las 5 criaturas en modo `inline`).
+
+## Técnica
+
+- SVG + CSS puros, **cero dependencias nuevas**; solo `transform`/`opacity`
+  (GPU, Android gama baja). Familia visual del glow de `GuardianEspiritu`.
+- Cada instancia genera **ids de filtro únicos** (`useId`), así se pueden
+  repetir muchas criaturas en una misma página sin colisión.
+- La **vida perpetua** vive en `creatures.css` (clases `crt-*`), es intrínseca
+  a la criatura y **reduced-motion-safe** (sin animación → fotograma digno).
+- La **coreografía de LLEGADA** (entrar volando, asomar del suelo, rodar) NO
+  vive aquí: es responsabilidad de la escena que consume la criatura, sobre el
+  `className` del modo `inline`.

--- a/src/visual/creatures/_filters.jsx
+++ b/src/visual/creatures/_filters.jsx
@@ -1,0 +1,23 @@
+/*
+ * Filtro SVG compartido de la familia visual "creatures": glow orgánico
+ * (feGaussianBlur + feMerge) heredado de GuardianEspiritu + blur suave.
+ * Cada criatura instancia estos filtros con ids ÚNICOS (useId) para poder
+ * repetirse muchas veces en una misma página sin colisión de ids.
+ * Interno de la librería — no se exporta desde el barrel.
+ */
+export function CreatureFilters({ glow, blur }) {
+  return (
+    <>
+      <filter id={glow} x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.1" result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      <filter id={blur}>
+        <feGaussianBlur stdDeviation="3" />
+      </filter>
+    </>
+  );
+}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1,0 +1,51 @@
+/* ─── Vida perpetua de las CREATURES — SVG + CSS puros, solo transform/opacity
+   (GPU, Android gama baja). Reutilizable en cualquier escena o avatar.
+   La coreografía de LLEGADA (entrar volando, asomar del suelo) NO vive aquí:
+   es responsabilidad de la escena que consume la criatura.
+   reduced-motion = criatura quieta en un fotograma digno. ─── */
+
+/* aleteo rápido (abeja / colibrí) */
+.crt-wing {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: crt-wingbeat 0.13s ease-in-out infinite alternate;
+}
+@keyframes crt-wingbeat {
+  0% { transform: scaleY(1) scaleX(1); }
+  100% { transform: scaleY(0.6) scaleX(0.9); }
+}
+
+/* alas de mariposa que abren y cierran */
+.crt-fwing {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-flutter 0.5s ease-in-out infinite;
+}
+.crt-fwing-l { transform-origin: right center; }
+.crt-fwing-r { transform-origin: left center; }
+@keyframes crt-flutter {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.4); }
+}
+
+/* bola de abono que rueda (escarabajo) */
+.crt-ball {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-roll 1.1s linear infinite;
+}
+@keyframes crt-roll {
+  0% { transform: rotate(0); }
+  100% { transform: rotate(-360deg); }
+}
+
+/* patas que dan pasos (escarabajo) */
+.crt-legs { animation: crt-step 0.5s ease-in-out infinite; }
+@keyframes crt-step {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-1.2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crt-wing, .crt-fwing, .crt-ball, .crt-legs { animation: none !important; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -1,0 +1,32 @@
+/*
+ * Librería visual de PERSONAJES DE FAUNA de la chagra (creatures).
+ * Fuente única y reutilizable. Antes de dibujar un bicho, búscalo aquí.
+ *
+ * Cada componente:
+ *   - Modo standalone (por defecto): renderiza su propio <svg> con viewBox,
+ *     dimensionado por `size` — ideal para avatares, catálogo, botones.
+ *   - Modo `inline`: renderiza solo el <g> para incrustarse en una escena SVG
+ *     que ya define su viewBox y su coreografía de entrada/posición.
+ *
+ * Props comunes: { size, className, inline, animated, title }.
+ */
+export { AbejaAngelita } from './AbejaAngelita.jsx';
+export { Colibri } from './Colibri.jsx';
+export { Lombriz } from './Lombriz.jsx';
+export { Mariposa } from './Mariposa.jsx';
+export { Escarabajo } from './Escarabajo.jsx';
+
+import AbejaAngelita from './AbejaAngelita.jsx';
+import Colibri from './Colibri.jsx';
+import Lombriz from './Lombriz.jsx';
+import Mariposa from './Mariposa.jsx';
+import Escarabajo from './Escarabajo.jsx';
+
+/* Registro consultable: slug → componente + binomio verificado. */
+export const CREATURES = {
+  'abeja-angelita': { Component: AbejaAngelita, nombre: 'Abeja angelita', cientifico: 'Tetragonisca angustula' },
+  colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
+  lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
+  mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
+  escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },
+};

--- a/src/visual/effects/effects.css
+++ b/src/visual/effects/effects.css
@@ -1,0 +1,190 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   src/visual/effects/effects.css — EFECTOS visuales reutilizables de Chagra.
+
+   Las TÉCNICAS DE CINE del catálogo (§13) que hoy están redibujadas/re-copiadas
+   en varios mockups y escenas, aquí una sola vez como clases `vfx-*` + custom
+   properties `--vfx-*`. Antes de re-hilvanar un velo/viñeta/grade/latido/trazo,
+   use esto.
+
+   Reglas de la casa respetadas:
+   · Solo `transform`/`opacity` animados; blur/filtros ESTÁTICOS (Android gama baja).
+   · `prefers-reduced-motion` = fotograma final digno (nada roto, nada en loop).
+   · Cero dependencias; cero JS por frame.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Base de las capas-overlay ───────────────────────────────────────────────
+   Todos los velos/viñetas/scrims/grades se montan como una capa absoluta dentro
+   de un contenedor `position: relative`. No capturan toque. Heredan el radio del
+   contenedor para no desbordar tarjetas redondeadas. */
+.vfx-overlay,
+.vfx-veil,
+.vfx-vignette,
+.vfx-scrim-top,
+.vfx-scrim-bottom,
+.vfx-grade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+/* ── 1. VELO atmosférico neón (§13.5 / §13.16) ──────────────────────────────
+   El velo radial teal/orquídea + tinte navy del modo biopunk (receta de
+   finca-viva-hero `.fvh-escena-wrap::after`). Tunéable por custom props para
+   re-teñir sin reescribir el gradiente. Los temas claros lo apagan poniendo
+   `--vfx-veil-opacity: 0`. */
+.vfx-veil {
+  z-index: 6;
+  opacity: var(--vfx-veil-opacity, 1);
+  background:
+    radial-gradient(120% 78% at 80% 12%, var(--vfx-veil-a, rgba(34, 211, 238, 0.26)), transparent 56%),
+    radial-gradient(110% 92% at 16% 92%, var(--vfx-veil-b, rgba(217, 70, 239, 0.22)), transparent 58%),
+    linear-gradient(180deg,
+      var(--vfx-veil-top, rgba(8, 16, 34, 0.42)) 0%,
+      rgba(8, 16, 34, 0.08) 40%,
+      var(--vfx-veil-bottom, rgba(10, 22, 44, 0.36)) 100%);
+  transition: opacity 0.5s ease;
+}
+
+/* ── 2. VIÑETA de cine (§13.5) ───────────────────────────────────────────────
+   Radial que hunde las esquinas para enfocar el centro y que la UI flote sin
+   cajas. `--vfx-vignette-strength` (0..1) modula cuánto oscurece el borde. */
+.vfx-vignette {
+  z-index: 7;
+  background: radial-gradient(120% 120% at 50% 45%,
+    transparent 52%,
+    rgba(0, 0, 0, calc(0.35 * var(--vfx-vignette-strength, 1))) 100%);
+}
+
+/* ── 3. SCRIMS arriba/abajo (§13.5) ──────────────────────────────────────────
+   Degradados en los bordes superior/inferior para que el texto SIEMPRE lea
+   sobre la escena (títulos arriba, compositor abajo). */
+.vfx-scrim-top {
+  z-index: 7;
+  background: linear-gradient(180deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 28%);
+  inset: 0 0 auto 0;
+}
+.vfx-scrim-bottom {
+  z-index: 7;
+  background: linear-gradient(0deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 34%);
+  inset: auto 0 0 0;
+}
+
+/* ── 4. GRADES de luz por PISO TÉRMICO (§13.2) ───────────────────────────────
+   Plano de color fijo al viewport, crossfade por opacity: la TEMPERATURA de la
+   luz cuenta la altura. Azul glacial (nevado) → cian páramo → neutro frío →
+   HORA DORADA (finca templada) → ámbar cálido → turquesa río. Portado de los
+   `--mm2-*` del mockup Montaña (§13.2), tokenizado para promoverse a prod.
+   `--vfx-grade-fuerza` modula la intensidad por dirección artística
+   (naturalista 1 · biopunk 0.45 · verde-vivo 0.75). */
+:root {
+  --vfx-piso-glacial:  rgba(180, 214, 240, 0.50); /* nevado 4.800m */
+  --vfx-piso-paramo:   rgba(120, 200, 210, 0.42); /* páramo */
+  --vfx-piso-frio:     rgba(150, 165, 172, 0.28); /* frío (neutro) */
+  --vfx-piso-templado: rgba(255, 200, 120, 0.34); /* finca ⭐ hora dorada */
+  --vfx-piso-calido:   rgba(255, 170,  90, 0.36); /* cálido ámbar */
+  --vfx-piso-valle:    rgba( 90, 200, 190, 0.40); /* río turquesa 400m */
+}
+.vfx-grade {
+  z-index: 5;
+  background: var(--vfx-grade-color, var(--vfx-piso-templado));
+  opacity: var(--vfx-grade-fuerza, 1);
+  transition: background 0.6s ease, opacity 0.6s ease;
+}
+.vfx-grade--glacial  { --vfx-grade-color: var(--vfx-piso-glacial); }
+.vfx-grade--paramo   { --vfx-grade-color: var(--vfx-piso-paramo); }
+.vfx-grade--frio     { --vfx-grade-color: var(--vfx-piso-frio); }
+.vfx-grade--templado { --vfx-grade-color: var(--vfx-piso-templado); }
+.vfx-grade--calido   { --vfx-grade-color: var(--vfx-piso-calido); }
+.vfx-grade--valle    { --vfx-grade-color: var(--vfx-piso-valle); }
+
+/* ── 5. PULSO CARDÍACO compartido (§13.10) ───────────────────────────────────
+   Una sola variable de duración (`--vfx-beat`) sincroniza TODO lo vivo: la
+   escena late como UN organismo. Es el `--fvo-beat` de SceneFincaOrganismo,
+   promovido a la librería (mismo valor 5.2s = `--motion-beat`). */
+:root { --vfx-beat: 5.2s; }
+
+/* el corazón: doble pulso como corazón real */
+.vfx-beat {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat var(--vfx-beat) ease-in-out infinite;
+}
+@keyframes vfx-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+/* onda que sale del latido */
+.vfx-beat-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat-wave var(--vfx-beat) ease-out infinite;
+}
+@keyframes vfx-beat-wave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red/savia/panel se ENCIENDE con cada latido (solo opacity) */
+.vfx-beat-glow { animation: vfx-beat-glow var(--vfx-beat) ease-in-out infinite; }
+@keyframes vfx-beat-glow {
+  0%, 100% { opacity: 0.55; }
+  8% { opacity: 1; }
+  16% { opacity: 0.7; }
+  22% { opacity: 0.9; }
+  34% { opacity: 0.55; }
+}
+
+/* ── 6. AUTO-DIBUJADO orquestado (§13.11) ────────────────────────────────────
+   `pathLength="1"` normalizado + stroke-dashoffset → 0 + etapas escalonadas.
+   El trazo/grafo/glifo se dibuja solo al entrar. (Receta de SceneTrazoMinimal;
+   el componente `AutoDibujo` pega estas clases y pone `pathLength`.) */
+.vfx-draw {
+  stroke-dasharray: 1 1;
+  stroke-dashoffset: 1;
+  animation: vfx-draw 1.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+@keyframes vfx-draw { to { stroke-dashoffset: 0; } }
+
+/* planos de color que aparecen en fundido (sol, leyenda, humo) */
+.vfx-fade { opacity: 0; animation: vfx-fade 1.1s ease forwards; }
+@keyframes vfx-fade { to { opacity: 1; } }
+
+/* etapas del dibujo — delay heredado por trazos y fundidos del grupo */
+.vfx-t1 .vfx-draw, .vfx-t1.vfx-draw, .vfx-t1 .vfx-fade, .vfx-t1.vfx-fade { animation-delay: 0.15s; }
+.vfx-t2 .vfx-draw, .vfx-t2.vfx-draw, .vfx-t2 .vfx-fade, .vfx-t2.vfx-fade { animation-delay: 0.40s; }
+.vfx-t3 .vfx-draw, .vfx-t3.vfx-draw, .vfx-t3 .vfx-fade, .vfx-t3.vfx-fade { animation-delay: 0.70s; }
+.vfx-t4 .vfx-draw, .vfx-t4.vfx-draw, .vfx-t4 .vfx-fade, .vfx-t4.vfx-fade { animation-delay: 0.95s; }
+.vfx-t5 .vfx-draw, .vfx-t5.vfx-draw, .vfx-t5 .vfx-fade, .vfx-t5.vfx-fade { animation-delay: 1.20s; }
+.vfx-t6 .vfx-draw, .vfx-t6.vfx-draw, .vfx-t6 .vfx-fade, .vfx-t6.vfx-fade { animation-delay: 1.50s; }
+.vfx-t7 .vfx-draw, .vfx-t7.vfx-draw, .vfx-t7 .vfx-fade, .vfx-t7.vfx-fade { animation-delay: 1.80s; }
+.vfx-t8 .vfx-draw, .vfx-t8.vfx-draw, .vfx-t8 .vfx-fade, .vfx-t8.vfx-fade { animation-delay: 2.10s; }
+.vfx-t9 .vfx-draw, .vfx-t9.vfx-draw, .vfx-t9 .vfx-fade, .vfx-t9.vfx-fade { animation-delay: 2.50s; }
+
+/* ── 7. FLUJO por dash (§13.12) ──────────────────────────────────────────────
+   Savia/agua/corriente/micelio: dasharray animado que corre por el trazo.
+   `--vfx-flow-dur` y `--vfx-flow-len` tunéan velocidad y avance. */
+.vfx-flow {
+  stroke-dasharray: 4 8;
+  animation: vfx-flow var(--vfx-flow-dur, 3.2s) linear infinite;
+}
+@keyframes vfx-flow { to { stroke-dashoffset: calc(-1 * var(--vfx-flow-len, 40px)); } }
+
+/* ── prefers-reduced-motion: fotograma final digno ───────────────────────────
+   Nada en loop; el dibujo COMPLETO, los planos visibles, velos/grades/viñeta
+   quietos (son estáticos de por sí). Regla de la casa §13.20. */
+@media (prefers-reduced-motion: reduce) {
+  .vfx-beat, .vfx-beat-wave, .vfx-beat-glow, .vfx-flow { animation: none !important; }
+  .vfx-beat, .vfx-beat-glow { opacity: 1; }
+  .vfx-beat-wave { opacity: 0; }              /* la onda no deja residuo */
+  .vfx-draw { animation: none !important; stroke-dashoffset: 0; }
+  .vfx-fade { animation: none !important; opacity: 1; }
+  .vfx-veil { transition: none; }
+}


### PR DESCRIPTION
## Qué es

Mockup de galería (público, sin auth, datos de muestra) del **mercado público mercado.chagra.bio**. El diferencial es la **PROCEDENCIA**: cada producto se ubica en la montaña por su **altitud** y su **piso térmico**, con la cara ilustrada de quien lo sembró, su **finca** y su **vereda**. Mercado campesino honesto, anti-postureo: pocas cosas, mucho aire, la confianza al centro.

Ruta pública `#/mockups/mercado` vía `MOCKUP_HASH_ROUTES` en `src/App.jsx`, resuelta **antes** del check de sesión (mismo patrón que el resto de la galería de mockups). No entra en `HASH_VIEW_ROUTES`: no pasa por gates de sesión/rol.

## Dirección visual

Identidad "estraza de montaña" — deliberadamente lejos del default (cream + serif + terracota):
- **Estructura = información**: el eje vertical es la **altitud real** (metros s. n. m.). La comida no está en una grilla neutra, está ubicada en la montaña.
- **Acento funcional, no decorativo**: el color viene del **piso térmico** (espectro frío→templado), no de un terracota fijo. El rojo de tinta aparece solo en los sellos.
- **Tipo como instrumento**: altitud, precio y fechas de cosecha en monoespaciado, como lectura de altímetro; serif para los nombres de finca; sans para la UI.
- **Firma**: la **"cinta de altitud"** (`CintaAltitud`) — la montaña con la cara de cada productor clavada a su altura real; los pines abren la historia de la finca.

## Secciones

1. **Hero** con la promesa de procedencia + la cinta de altitud (panorama de las 6 fincas).
2. **Filtro** por piso térmico (derivado de los datos).
3. **Grilla** de tarjetas: ilustración SVG del producto, precio en pesos COL, y bloque de procedencia (avatar del productor + finca + vereda + altitud/piso).
4. **Historia de la finca** (pantalla/modal al tocar una tarjeta): relato de origen, **trazabilidad** de la cosecha (sembrado → abonado → deshierbado → cosechado), **sellos de confianza** de estampa ("sembrado sin químicos", "cosechado el …"), y la cinta con esa finca resaltada.

## Reuso de la librería visual

- **creatures**: `Colibri` (hero), `AbejaAngelita` (producto miel), `Mariposa` (historia) como detalles vivos. Se toman de la versión canónica de `src/visual/creatures/`.
- **effects**: `effects.css` — `vfx-grade--<piso>` gradúa la luz de la cabecera de finca según su piso térmico.

> `src/visual/creatures/` y `src/visual/effects/effects.css` aún no están en `main` (viven en las ramas de librería `feat/visual-lib-creatures` / `feat/visual-lib-effects`). Se traen aquí (vía `git checkout` de esas ramas) para que el mockup compile de forma autónoma; son verbatim de esas ramas y coincidirán cuando se mergeen. De effects solo se incluye `effects.css` (lo único que consume el mockup).

## Datos

Fincas, veredas y productores **ficticios y genéricos** (ej. "Finca El Rocío, vereda La Esperanza"). Sin nombres reales de terceros. Todo **self-contained**: SVG propio y CSS, sin imágenes ni enlaces externos.

## Verificación

- `npm run build` — **verde**, emite el chunk `Mercado-*.js` (30.4 kB) + `Mercado-*.css` (17.7 kB).
- `node scripts/tsc-check-gate.mjs` (`tsc:check` vs baseline) — **868 = 868**, cero errores de tipo nuevos. Los 7 errores que aparecían en la primera pasada se arreglaron con el tipo correcto (defaults de `className`/`title`, `onBack` como `() => void`), sin `any` ni `@ts-ignore`.
- `npx eslint src/mockups/Mercado.jsx` — **limpio** (0 errores, 0 warnings). El seed `mercado/datos.js` suprime la regla i18n a nivel de archivo (copy de muestra que migraría a `messages.js`), mismo criterio que `src/data/marketplaceSeed.js`.

## Cómo probar

Abrir `#/mockups/mercado` (sin cuenta). Mobile-first estricto (funciona a 320px). Tono español de Colombia, usted. `prefers-reduced-motion` respetado.
