### PR TITLE
feat(mockup): pantalla conversacional por voz "La conversación con la finca"

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,6 +107,9 @@ const CompostScreen = lazy(() => import('./components/CompostScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const OnboardingCondensado = lazy(() => import('./components/OnboardingCondensado'));
+// Galería de mockups (diseño): rutas públicas `#/mockups/<slug>`, sin auth ni
+// gate, datos de muestra. No cuentan como módulo de piloto. Ver MOCKUP_HASH_ROUTES.
+const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const PlantaPorVozScreen = lazy(() => import('./components/PlantaPorVozScreen'));
@@ -416,6 +419,15 @@ const LoadingFallback = ({ view = null }) => {
 // viva (HERRAMIENTAS_TILES en DashboardLive). Las rutas `casos`/`caso_detail`/
 // `javier`/`usage_stats` siguen vivas en el router (más abajo) y por hash.
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
+
+// Rutas de MOCKUP de diseño (galería): PÚBLICAS — sin auth ni gate, datos de
+// muestra. Se resuelven ANTES del check de sesión (igual que el callback OAuth),
+// para que una lámina/pantalla se pueda revisar sin cuenta. Patrón `#/mockups/<slug>`
+// (el hash se normaliza a `mockups/<slug>`). No entran en HASH_VIEW_ROUTES para
+// dejar explícito que NO pasan por los gates de sesión/rol.
+const MOCKUP_HASH_ROUTES = {
+  'mockups/conversacion-voz': 'mockup_conversacion_voz',
+};
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
@@ -915,6 +927,14 @@ export default function App() {
       return;
     }
 
+    // Mockups de diseño: públicos, sin auth. Se resuelven antes de isAuthenticated
+    // para que la galería (#/mockups/<slug>) abra sin cuenta.
+    const mockupView = MOCKUP_HASH_ROUTES[hash];
+    if (mockupView) {
+      Promise.resolve().then(() => navigate(mockupView));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -941,6 +961,12 @@ export default function App() {
   useEffect(() => {
     const handleHashRoute = () => {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
+      // Mockups públicos: navegar directo, sin pasar por auth ni gates.
+      const mockupView = MOCKUP_HASH_ROUTES[hash];
+      if (mockupView) {
+        navigate(mockupView);
+        return;
+      }
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
@@ -2487,6 +2513,17 @@ export default function App() {
                 onNavigate={navigate}
                 initialContext={currentViewData}
               />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_conversacion_voz':
+        // Mockup de galería (público, datos de muestra): la pantalla de diálogo
+        // por voz del agente — el IrisVoz como micrófono + hilo de conversación
+        // guionada con la finca. Ruta #/mockups/conversacion-voz.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="La conversación con la finca">
+              <ConversacionVozMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/ConversacionVoz.jsx
+++ b/src/mockups/ConversacionVoz.jsx
@@ -1,0 +1,271 @@
+/**
+ * MOCKUP "La conversación con la finca" — ruta #/mockups/conversacion-voz.
+ *
+ * La pantalla de diálogo POR VOZ del agente: el campesino le pregunta a su
+ * finca y la finca le responde. No es un chat con un botón de micrófono
+ * pegado — es una conversación alrededor de una brasa: el IrisVoz
+ * (src/visual/voz) es el protagonista y ÚNICO control de micrófono, y las
+ * palabras van quedando en el hilo como quedan en la memoria.
+ *
+ * Guion determinista (datos de muestra, sin micrófono real ni permisos):
+ * un ciclo completo de uso — reposo → «hola, Chagra» → pregunta por el
+ * tomate amarillo → la finca piensa → responde en usted con UNA acción
+ * concreta → repregunta del caldo de ortiga → respuesta + tarea apuntada
+ * en el cuaderno de campo.
+ *
+ * Reusa de la casa:
+ *  - IrisVoz (src/visual/voz): la identidad visual de la voz — escuchar
+ *    entra, hablar sale, pensar se trenza, reposo respira.
+ *  - src/visual/effects: GlowFilter (dentro del iris) + effects.css
+ *    (--vfx-beat sincroniza la respiración de pistas y wake-hint).
+ *  - Reglas: solo transform/opacity, cero setState por frame (el texto
+ *    "vivo" avanza por palabras a ~7/s, no por frame), reduced-motion =
+ *    fotograma legible por estado y texto completo sin coreografía.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- mockup dev con datos de
+   muestra (no UI de producto); si se productiza, el copy migra a messages.js
+   (ADR-050). */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import IrisVoz from '../visual/voz';
+import '../visual/effects/effects.css';
+import './conversacionVoz.css';
+
+/* ── El hilo de la conversación (datos de muestra) ─────────────────────────
+ * Finca fría (~2.800 m), tomate bajo cubierta. La finca responde en usted,
+ * corto, y SIEMPRE con una acción concreta que cabe en la mañana. */
+const HILO = [
+  {
+    tipo: 'campesino',
+    nombre: 'Usted',
+    texto: 'Hola, Chagra.',
+  },
+  {
+    tipo: 'campesino',
+    nombre: 'Usted',
+    texto: '¿Qué le hago al tomate que amaneció con las hojas amarillas?',
+  },
+  {
+    tipo: 'chagra',
+    nombre: 'Su finca',
+    texto:
+      'Mírele las hojas de abajo. Si el amarillo empezó por ahí, a esa mata le está faltando comida: échele hoy un puñado de compost maduro alrededor del tallo, sin arrimárselo, y riegue solo al pie, temprano.',
+  },
+  {
+    tipo: 'campesino',
+    nombre: 'Usted',
+    texto: '¿Le sirve el caldo de ortiga que tengo guardado?',
+  },
+  {
+    tipo: 'chagra',
+    nombre: 'Su finca',
+    texto:
+      'Sí señor, le sirve. Rebaje un litro de caldo en diez litros de agua y aplíquelo al pie mañana, antes de las nueve. Yo le dejo apuntado revisar el sábado si las hojas nuevas salen verdes.',
+  },
+  {
+    tipo: 'accion',
+    texto: 'Quedó en el cuaderno de campo — sábado: revisar que las hojas nuevas del tomate salgan verdes.',
+  },
+];
+
+/* ── El guion: qué hace la voz y qué se ve del hilo en cada paso ──────────── */
+const GUION = [
+  { estado: 'reposo', dur: 2000, visibles: 0 },
+  { estado: 'escuchando', dur: 1700, visibles: 1, wake: true },
+  { estado: 'escuchando', dur: 4400, visibles: 2 },
+  { estado: 'pensando', dur: 2400, visibles: 2, pensando: 'Revisando el cuaderno del lote y las últimas lluvias…' },
+  { estado: 'hablando', dur: 7200, visibles: 3 },
+  { estado: 'escuchando', dur: 3800, visibles: 4 },
+  { estado: 'pensando', dur: 2000, visibles: 4, pensando: 'Buscando la dosis del caldo de ortiga…' },
+  { estado: 'hablando', dur: 8400, visibles: 5 },
+  { estado: 'reposo', dur: 0, visibles: 6, fin: true },
+];
+
+/* Lo que la voz anuncia bajo el iris (aria-live: el estado NUNCA es solo color). */
+const VOZ_DICE = {
+  reposo: 'Quieta. Diga «hola, Chagra» cuando la necesite.',
+  escuchando: 'Escuchando…',
+  pensando: 'Pensando…',
+  hablando: 'Su finca le responde.',
+};
+
+/* ¿El usuario pidió quietud? Se lee una vez: gobierna guion y coreografías. */
+const prefiereQuieto = () =>
+  typeof window.matchMedia === 'function'
+  && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+/* ── TextoVivo: la transcripción aparece palabra por palabra ────────────────
+ * Todas las palabras se montan de una (cero reflow); solo cambia opacity.
+ * `vivo` = burbuja recién dicha: avanza a ~7 palabras/s con UN interval
+ * (nada por frame). Con reduced-motion o burbuja vieja: texto completo. */
+function TextoVivo({ texto, vivo }) {
+  const palabras = useMemo(() => texto.split(' '), [texto]);
+  const [dichas, setDichas] = useState(0);
+
+  useEffect(() => {
+    if (!vivo) return undefined;
+    const timer = setInterval(() => {
+      setDichas((n) => (n >= palabras.length ? n : n + 1));
+    }, 140);
+    return () => clearInterval(timer);
+  }, [vivo, palabras]);
+
+  /* derivado, no sincronizado: burbuja vieja (o quietud pedida) = texto entero */
+  const mostradas = vivo ? dichas : palabras.length;
+
+  return (
+    <>
+      {palabras.map((p, i) => (
+        <span key={`${i}-${p}`} className={`cvz-palabra${i < mostradas ? ' cvz-palabra--dicha' : ''}`}>
+          {p}
+          {i < palabras.length - 1 ? ' ' : ''}
+        </span>
+      ))}
+    </>
+  );
+}
+
+/* Check propio (SVG inline, cero assets externos) para la tarea apuntada. */
+function SelloCuaderno() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" className="cvz-accion-sello">
+      <circle cx="12" cy="12" r="10.4" fill="none" stroke="currentColor" strokeWidth="1.6" opacity="0.55" />
+      <path d="M7.6 12.4l3 3.1 5.8-6.6" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export default function ConversacionVoz() {
+  const [reproduciendo, setReproduciendo] = useState(false);
+  const [paso, setPaso] = useState(0);
+  const [termino, setTermino] = useState(false);
+  const hiloRef = useRef(null);
+  const quieto = useMemo(() => prefiereQuieto(), []);
+
+  const pasoActual = GUION[reproduciendo ? paso : (termino ? GUION.length - 1 : 0)];
+  const estado = reproduciendo ? pasoActual.estado : 'reposo';
+  const visibles = pasoActual.visibles;
+
+  /* El guion: cada paso agenda el siguiente dentro del timeout (nunca setState
+     en el cuerpo del efecto); al final la voz se aquieta sola — no dejamos
+     loop infinito pidiendo atención. */
+  useEffect(() => {
+    if (!reproduciendo) return undefined;
+    const esUltimo = paso >= GUION.length - 1;
+    const timer = setTimeout(() => {
+      if (esUltimo) {
+        setReproduciendo(false);
+        setTermino(true);
+      } else {
+        setPaso((p) => p + 1);
+      }
+    }, GUION[paso].dur || 400);
+    return () => clearTimeout(timer);
+  }, [reproduciendo, paso]);
+
+  /* El hilo acompaña la conversación: al aparecer algo, baja hasta lo último. */
+  useEffect(() => {
+    const el = hiloRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: quieto ? 'auto' : 'smooth' });
+  }, [visibles, pasoActual.pensando, quieto]);
+
+  const alternar = () => {
+    if (reproduciendo) {
+      /* Tocar el iris mientras habla = "ya, gracias": la voz se aquieta. */
+      setReproduciendo(false);
+      setTermino(true);
+      setPaso(GUION.length - 1);
+      return;
+    }
+    setTermino(false);
+    setPaso(0);
+    setReproduciendo(true);
+  };
+
+  const vozDice = termino && !reproduciendo
+    ? 'La finca queda pendiente de su tomate.'
+    : VOZ_DICE[estado];
+
+  return (
+    <div className="cvz" data-estado={estado}>
+      <div className="cvz-luz" aria-hidden="true" />
+
+      {/* ── cabecera: con quién habla usted ─────────────────────────────── */}
+      <header className="cvz-cab">
+        <div className="cvz-cab-finca">
+          <h1 className="cvz-cab-nombre">Finca El Recuerdo</h1>
+          <p className="cvz-cab-detalle">Lote 2 · tomate bajo cubierta · 2.800 m</p>
+        </div>
+        <p className="cvz-cab-estado">
+          <span className="cvz-cab-punto" aria-hidden="true" />
+          {estado === 'reposo' ? 'En reposo' : VOZ_DICE[estado].replace(/[.…]+$/, '')}
+        </p>
+      </header>
+      <p className="cvz-eyebrow">Mockup · conversación guionada · datos de muestra</p>
+
+      {/* ── el hilo: lo dicho va quedando ────────────────────────────────── */}
+      <main className="cvz-hilo" ref={hiloRef} aria-live="polite">
+        {visibles === 0 && (
+          <div className="cvz-vacio">
+            <p className="cvz-vacio-verso">
+              Su finca está despierta.
+              <br />
+              Pregúntele por sus matas como le pregunta a un vecino.
+            </p>
+            <span className="cvz-vacio-wake">«hola, Chagra»</span>
+          </div>
+        )}
+
+        {HILO.slice(0, visibles).map((b, i) =>
+          b.tipo === 'accion' ? (
+            <div key={b.texto} className="cvz-accion">
+              <SelloCuaderno />
+              <p>{b.texto}</p>
+            </div>
+          ) : (
+            <article key={b.texto} className={`cvz-burbuja cvz-burbuja--${b.tipo}`}>
+              <span className="cvz-burbuja-quien">{b.nombre}</span>
+              <p className="cvz-burbuja-texto">
+                <TextoVivo texto={b.texto} vivo={reproduciendo && !quieto && i === visibles - 1} />
+              </p>
+            </article>
+          ))}
+
+        {reproduciendo && pasoActual.pensando && (
+          <div className="cvz-pensando">
+            <span className="cvz-pensando-puntos" aria-hidden="true">
+              <i />
+              <i />
+              <i />
+            </span>
+            <p>{pasoActual.pensando}</p>
+          </div>
+        )}
+      </main>
+
+      {/* ── el fogón: la voz con forma ES el micrófono ───────────────────── */}
+      <footer className="cvz-fogon">
+        {reproduciendo && pasoActual.wake && (
+          <span className="cvz-wake" aria-hidden="true">«hola, Chagra»</span>
+        )}
+        <button
+          type="button"
+          className="cvz-iris-btn"
+          onClick={alternar}
+          aria-pressed={reproduciendo}
+          aria-label={reproduciendo
+            ? 'Detener la conversación de muestra'
+            : 'Oír una conversación de muestra con la finca'}
+        >
+          <IrisVoz estado={estado} size={168} className="cvz-iris" />
+        </button>
+        <p className="cvz-voz-dice" aria-live="polite">{vozDice}</p>
+        {!reproduciendo && (
+          <p className="cvz-pista">
+            {termino ? 'Toque el iris para oírla otra vez.' : 'O toque el iris para oír una conversación de muestra.'}
+          </p>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/src/mockups/conversacionVoz.css
+++ b/src/mockups/conversacionVoz.css
@@ -1,0 +1,365 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   conversacionVoz.css — mockup "La conversación con la finca"
+   (#/mockups/conversacion-voz).
+
+   Misma cocina de noche que "La voz con forma" (vozConForma.css): tierra
+   oscura y cálida donde la única fuente de luz es la voz. Aquí la cocina se
+   vuelve PANTALLA DE USO: cabecera de finca, hilo de burbujas que van
+   quedando, y abajo el fogón — el IrisVoz como único control de micrófono.
+
+   El cuarto se re-tiñe apenas con el estado del iris (miel al escuchar,
+   cobre al pensar, musgo al hablar). Tipografía: serif de libro viejo para
+   LO DICHO (Georgia — cero deps), sans del sistema para la interfaz.
+
+   Reglas de la casa: solo transform/opacity animados; la respiración usa
+   --vfx-beat (effects.css); prefers-reduced-motion = fotograma legible por
+   estado (el iris pinta el suyo; aquí se apagan coreografías y el texto
+   llega completo). Mobile-first, digno desde 320 px.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.cvz {
+  --cvz-tierra: #211712;
+  --cvz-tierra-2: #2b1f17;
+  --cvz-crema: #f2e7d3;
+  --cvz-ceniza: #b7a48c;
+  --cvz-miel: #e9a94e;
+  --cvz-cobre: #c57a45;
+  --cvz-musgo: #b7c98a;
+  --cvz-linea: rgba(233, 169, 78, 0.16);
+  --cvz-luz-ambiente: rgba(217, 133, 73, 0.05);
+  --cvz-punto: #8d6b4d;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  background: var(--cvz-tierra);
+  color: var(--cvz-crema);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.55;
+}
+
+.cvz[data-estado='escuchando'] { --cvz-luz-ambiente: rgba(233, 169, 78, 0.1); --cvz-punto: #e9a94e; }
+.cvz[data-estado='pensando'] { --cvz-luz-ambiente: rgba(197, 122, 69, 0.09); --cvz-punto: #c57a45; }
+.cvz[data-estado='hablando'] { --cvz-luz-ambiente: rgba(183, 201, 138, 0.09); --cvz-punto: #b7c98a; }
+
+/* la luz que la voz le presta al cuarto (solo background/opacity, barato) */
+.cvz-luz {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(110% 55% at 50% 100%, var(--cvz-luz-ambiente), transparent 70%),
+    radial-gradient(120% 60% at 50% -12%, rgba(0, 0, 0, 0.45), transparent 60%);
+  transition: background 1.1s ease;
+  z-index: 0;
+}
+
+.cvz > * { position: relative; z-index: 1; }
+
+/* ── cabecera: con quién habla usted ───────────────────────────────────────── */
+.cvz-cab {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: max(14px, env(safe-area-inset-top)) clamp(16px, 5vw, 28px) 10px;
+  border-bottom: 1px solid var(--cvz-linea);
+}
+
+.cvz-cab-nombre {
+  margin: 0;
+  font-family: Georgia, 'Palatino Linotype', 'Times New Roman', serif;
+  font-weight: 400;
+  font-size: clamp(1.15rem, 4.5vw, 1.5rem);
+  letter-spacing: 0.01em;
+}
+
+.cvz-cab-detalle {
+  margin: 2px 0 0;
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  color: var(--cvz-ceniza);
+}
+
+.cvz-cab-estado {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex: none;
+  font-size: 0.76rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--cvz-ceniza);
+}
+
+.cvz-cab-punto {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--cvz-punto);
+  transition: background 0.6s ease;
+  /* respira con la casa (--vfx-beat, effects.css) */
+  animation: vfx-beat var(--vfx-beat, 5.2s) ease-in-out infinite;
+}
+
+.cvz-eyebrow {
+  margin: 6px auto 0;
+  padding: 0 16px;
+  text-align: center;
+  font-size: 0.62rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(183, 164, 140, 0.55);
+}
+
+/* ── el hilo: lo dicho va quedando ─────────────────────────────────────────── */
+.cvz-hilo {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 18px clamp(14px, 4.5vw, 24px) 24px;
+  overscroll-behavior: contain;
+}
+
+/* invitación (antes de la primera palabra) */
+.cvz-vacio {
+  margin: auto;
+  text-align: center;
+  padding: 12px;
+}
+
+.cvz-vacio-verso {
+  margin: 0;
+  font-family: Georgia, 'Palatino Linotype', 'Times New Roman', serif;
+  font-size: clamp(1.15rem, 4.6vw, 1.5rem);
+  line-height: 1.6;
+  color: var(--cvz-ceniza);
+}
+
+.cvz-vacio-wake {
+  display: inline-block;
+  margin-top: 16px;
+  padding: 8px 18px;
+  border: 1px solid var(--cvz-linea);
+  border-radius: 999px;
+  font-family: Georgia, serif;
+  font-style: italic;
+  font-size: 1.02rem;
+  color: var(--cvz-miel);
+  animation: vfx-beat var(--vfx-beat, 5.2s) ease-in-out infinite;
+}
+
+/* burbujas — grandes y legibles: esto es lo que se dijo */
+.cvz-burbuja {
+  max-width: 88%;
+  padding: 11px 16px 13px;
+  border-radius: 18px;
+  animation: cvz-aparece 0.45s ease both;
+}
+
+.cvz-burbuja--campesino {
+  align-self: flex-end;
+  background: rgba(233, 169, 78, 0.13);
+  border: 1px solid rgba(233, 169, 78, 0.28);
+  border-bottom-right-radius: 6px;
+}
+
+.cvz-burbuja--chagra {
+  align-self: flex-start;
+  background: rgba(183, 201, 138, 0.09);
+  border: 1px solid rgba(183, 201, 138, 0.22);
+  border-bottom-left-radius: 6px;
+}
+
+.cvz-burbuja-quien {
+  display: block;
+  margin-bottom: 3px;
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--cvz-ceniza);
+}
+
+.cvz-burbuja--chagra .cvz-burbuja-quien { color: var(--cvz-musgo); }
+.cvz-burbuja--campesino .cvz-burbuja-quien { color: var(--cvz-miel); }
+
+.cvz-burbuja-texto {
+  margin: 0;
+  font-size: clamp(1.04rem, 3.4vw, 1.14rem);
+  line-height: 1.6;
+}
+
+/* lo que dice la finca es palabra de libro viejo */
+.cvz-burbuja--chagra .cvz-burbuja-texto {
+  font-family: Georgia, 'Palatino Linotype', 'Times New Roman', serif;
+}
+
+/* la transcripción viva: cada palabra ya está montada (cero reflow), solo
+   pasa de humo a tinta con opacity */
+.cvz-palabra { opacity: 0; transition: opacity 0.35s ease; }
+.cvz-palabra--dicha { opacity: 1; }
+
+/* pensando: tres brasitas que se turnan (solo opacity) */
+.cvz-pensando {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  color: var(--cvz-ceniza);
+  font-style: italic;
+  font-size: 0.92rem;
+  animation: cvz-aparece 0.45s ease both;
+}
+
+.cvz-pensando p { margin: 0; }
+
+.cvz-pensando-puntos { display: inline-flex; gap: 5px; flex: none; }
+
+.cvz-pensando-puntos i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--cvz-cobre);
+  animation: cvz-brasita 1.4s ease-in-out infinite;
+}
+
+.cvz-pensando-puntos i:nth-child(2) { animation-delay: 0.22s; }
+.cvz-pensando-puntos i:nth-child(3) { animation-delay: 0.44s; }
+
+/* la tarea que quedó apuntada: el valor de haber hablado */
+.cvz-accion {
+  align-self: center;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  max-width: 92%;
+  padding: 10px 16px;
+  border: 1px dashed rgba(183, 201, 138, 0.4);
+  border-radius: 14px;
+  background: rgba(183, 201, 138, 0.06);
+  color: var(--cvz-musgo);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  animation: cvz-aparece 0.6s ease both;
+}
+
+.cvz-accion p { margin: 0; }
+
+.cvz-accion-sello { flex: none; margin-top: 2px; }
+
+/* ── el fogón: el iris ES el micrófono ─────────────────────────────────────── */
+.cvz-fogon {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 16px max(14px, env(safe-area-inset-bottom));
+  border-top: 1px solid var(--cvz-linea);
+  background: linear-gradient(rgba(43, 31, 23, 0), var(--cvz-tierra-2));
+}
+
+.cvz-wake {
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 14px;
+  border-radius: 999px;
+  background: var(--cvz-tierra-2);
+  border: 1px solid var(--cvz-linea);
+  font-family: Georgia, serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--cvz-miel);
+  white-space: nowrap;
+  animation: cvz-sube 0.6s ease both;
+}
+
+.cvz-iris-btn {
+  margin: -6px 0;
+  padding: 6px;
+  border: none;
+  background: none;
+  border-radius: 50%;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.cvz-iris-btn:focus-visible {
+  outline: 2px solid var(--cvz-miel);
+  outline-offset: 4px;
+}
+
+.cvz-iris-btn:active .cvz-iris { transform: scale(0.96); }
+
+.cvz-iris { transition: transform 0.25s ease; }
+
+.cvz-voz-dice {
+  margin: 0;
+  min-height: 1.5em;
+  font-size: 0.95rem;
+  color: var(--cvz-crema);
+  text-align: center;
+}
+
+.cvz-pista {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--cvz-ceniza);
+  text-align: center;
+}
+
+/* ── coreografías (solo transform/opacity) ─────────────────────────────────── */
+@keyframes cvz-aparece {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes cvz-sube {
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+@keyframes cvz-brasita {
+  0%, 100% { opacity: 0.25; }
+  50% { opacity: 1; }
+}
+
+/* ── pantallas más anchas: la misma cocina, con más mesa ───────────────────── */
+@media (min-width: 720px) {
+  .cvz-hilo { gap: 16px; padding-top: 26px; }
+  .cvz-burbuja { max-width: 76%; }
+}
+
+/* ── quietud pedida: fotograma legible por estado ──────────────────────────
+   El iris pinta su propio fotograma (irisVoz.css). Aquí: nada respira, las
+   burbujas y la tarea llegan puestas (el texto completo lo garantiza el JS),
+   las brasitas de "pensando" quedan encendidas fijas. */
+@media (prefers-reduced-motion: reduce) {
+  .cvz-luz { transition: none; }
+  .cvz-cab-punto,
+  .cvz-vacio-wake,
+  .cvz-burbuja,
+  .cvz-pensando,
+  .cvz-accion,
+  .cvz-wake,
+  .cvz-pensando-puntos i {
+    animation: none;
+  }
+
+  .cvz-pensando-puntos i { opacity: 0.8; }
+  .cvz-palabra { opacity: 1; transition: none; }
+  .cvz-iris { transition: none; }
+}

--- a/src/visual/effects/AutoDibujo.jsx
+++ b/src/visual/effects/AutoDibujo.jsx
@@ -1,0 +1,37 @@
+/**
+ * AutoDibujo — el AUTO-DIBUJADO orquestado compartido (§13.11 del catálogo).
+ *
+ * La receta de SceneTrazoMinimal ("el trazo se dibuja solo al entrar"):
+ * `pathLength="1"` normalizado + `stroke-dashoffset` que va a 0 + etapas con
+ * delay escalonado. Aquí queda como helper para no re-cablear el dasharray a
+ * mano en cada lámina/onboarding/glifo.
+ *
+ * El movimiento vive en `effects.css` (clases `vfx-draw`, `vfx-fade`,
+ * `vfx-t1…vfx-t9`); este componente solo pega las clases correctas y pone
+ * `pathLength="1"` para que el draw-in sea independiente de la longitud real
+ * del trazo. Reduced-motion = el dibujo COMPLETO y quieto (lo garantiza el CSS).
+ *
+ * Recuerde importar el CSS una vez en la escena:  import '.../effects/effects.css'
+ *
+ * @param {object}  props
+ * @param {'path'|'line'|'polyline'|'circle'|'rect'|string} [props.as='path']
+ *        elemento SVG a renderizar.
+ * @param {number}  [props.stage]      etapa 1..9 (delay escalonado del dibujo).
+ * @param {boolean} [props.fade=false] `true` = aparece en fundido (opacity) en
+ *        vez de trazarse — para planos de color (sol, leyenda, humo).
+ * @param {string}  [props.className]  clases extra.
+ * Resto de props (`d`, `stroke`, `strokeWidth`, `fill`, `cx`…) se pasan tal cual.
+ */
+export function AutoDibujo({ as = 'path', stage, fade = false, className, ...rest }) {
+  /* El tag es dinámico: se asegura contra los intrínsecos SVG/HTML de JSX para
+     que TS resuelva los atributos (className, d, stroke…) del elemento real. */
+  const El = /** @type {keyof import('react').JSX.IntrinsicElements} */ (as);
+  const base = fade ? 'vfx-fade' : 'vfx-draw';
+  const stageClass = stage ? ` vfx-t${stage}` : '';
+  const cls = `${base}${stageClass}${className ? ` ${className}` : ''}`;
+  // pathLength normaliza el dashoffset a [0..1]; solo aplica al modo trazo.
+  const drawProps = fade ? {} : { pathLength: 1 };
+  return <El className={cls} {...drawProps} {...rest} />;
+}
+
+export default AutoDibujo;

--- a/src/visual/effects/FiltroAcuarela.jsx
+++ b/src/visual/effects/FiltroAcuarela.jsx
@@ -1,0 +1,58 @@
+/*
+ * FiltroAcuarela — el borde/relleno "pintado a la acuarela" compartido
+ * (feTurbulence + feDisplacementMap).
+ *
+ * Da a un trazo o relleno SVG el borde húmedo, irregular y sangrado de la
+ * acuarela: la turbulencia genera un ruido fractal y el displacement empuja los
+ * píxeles según ese ruido. Es la receta que dibuja los bordes del mapa-acuarela
+ * en vez de re-hilvanar un `<filter>` inline por mockup.
+ *
+ * Emite SOLO el `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y lo referencia con `filter={`url(#${id})`}`. Pasar ids únicos
+ * (`useId`) para repetir varios en la misma página sin colisión.
+ *
+ * Reduced-motion-safe por construcción: el filtro es ESTÁTICO (no anima), en
+ * línea con la regla de la casa "blur/filtros estáticos, solo transform/opacity
+ * animados".
+ *
+ * @param {object} props
+ * @param {string}  props.id                 id del filtro (obligatorio).
+ * @param {number} [props.frequency=0.012]   baseFrequency del ruido (más alto =
+ *                                           borde más nervioso/fino).
+ * @param {number} [props.scale=6]           fuerza del desplazamiento en px.
+ * @param {number} [props.octaves=2]         numOctaves del fractalNoise.
+ * @param {number} [props.seed=7]            semilla del ruido (determinista).
+ * @param {string} [props.bounds='-20%']     origen del box del filtro (x/y).
+ */
+export function FiltroAcuarela({
+  id,
+  frequency = 0.012,
+  scale = 6,
+  octaves = 2,
+  seed = 7,
+  bounds = '-20%',
+}) {
+  const off = parseFloat(bounds);
+  const size = `${100 - 2 * off}%`;
+  const noise = `${id}-noise`;
+  return (
+    <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+      <feTurbulence
+        type="fractalNoise"
+        baseFrequency={frequency}
+        numOctaves={octaves}
+        seed={seed}
+        result={noise}
+      />
+      <feDisplacementMap
+        in="SourceGraphic"
+        in2={noise}
+        scale={scale}
+        xChannelSelector="R"
+        yChannelSelector="G"
+      />
+    </filter>
+  );
+}
+
+export default FiltroAcuarela;

--- a/src/visual/effects/GlowFilter.jsx
+++ b/src/visual/effects/GlowFilter.jsx
@@ -1,0 +1,44 @@
+/**
+ * GlowFilter — el GLOW neón orgánico compartido de Chagra (§13.16 del catálogo).
+ *
+ * Es la MISMA receta que hoy está copiada como `<filter>` inline en varias
+ * escenas y en la librería de fauna (GuardianEspiritu `ge-glow1`, creatures
+ * `CreatureFilters`, SceneFincaOrganismo `fvo-glow1`…): un feGaussianBlur
+ * fundido con el original vía feMerge, más — opcionalmente — un blur suave
+ * suelto para halos/estelas. Aquí vive la versión canónica.
+ *
+ * Emite SOLO los `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y referencia por id. Como cada escena decide su id, se pueden repetir
+ * muchos glows en una misma página sin colisión (pasar ids únicos con `useId`).
+ *
+ * @param {object} props
+ * @param {string}  props.id              id del filtro de glow (obligatorio).
+ * @param {number} [props.std=2.1]        desenfoque del glow (stdDeviation).
+ * @param {string} [props.blurId]         si se pasa, emite además un blur suelto
+ *                                        con este id (para halos/estelas).
+ * @param {number} [props.blurStd=3]      desenfoque del blur suelto.
+ * @param {string} [props.bounds='-80%']  origen del box del filtro (x/y); el
+ *                                        ancho/alto se calculan como 100%-2*bounds.
+ */
+export function GlowFilter({ id, std = 2.1, blurId, blurStd = 3, bounds = '-80%' }) {
+  const off = parseFloat(bounds); // -80  → box de 260%
+  const size = `${100 - 2 * off}%`;
+  return (
+    <>
+      <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+        <feGaussianBlur stdDeviation={std} result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      {blurId ? (
+        <filter id={blurId}>
+          <feGaussianBlur stdDeviation={blurStd} />
+        </filter>
+      ) : null}
+    </>
+  );
+}
+
+export default GlowFilter;

--- a/src/visual/effects/README.md
+++ b/src/visual/effects/README.md
@@ -1,0 +1,118 @@
+# `src/visual/effects` — efectos visuales reutilizables
+
+Librería de las **técnicas de cine** de Chagra (las que dan el "wow": velos,
+viñeta, scrims, grades de luz por piso térmico, glow, pulso cardíaco,
+auto-dibujado, acuarela) como **CSS + helpers SVG limpios, parametrizables y sin
+dependencias nuevas**. Nace para **dejar de re-hilvanar el mismo efecto** en
+cada mockup/escena: hoy el velo neón, la viñeta, los grades `--mm2-*`, el glow
+`feMerge`, el latido `--fvo-beat`, el trazo que se dibuja solo y el filtro
+acuarela aparecían copiados/redibujados en `finca-viva-hero.css`,
+`scene-finca-organismo.css`, `scene-trazo-minimal.css`, `GuardianEspiritu`, los
+mockups de la Montaña y el mapa-acuarela. Aquí vive la **versión canónica**.
+
+Hermana de [`src/visual/creatures`](../creatures/README.md) (personajes de
+fauna): misma filosofía, mismo contrato de reuso.
+
+## Regla de la casa
+
+> **Antes de re-dibujar un efecto de cine, búsquelo aquí.**
+> Si existe → **reúselo** (y de ser posible, **mejore** la versión canónica,
+> para que todos hereden la mejora).
+> Si crea un efecto nuevo reutilizable → **agréguelo aquí en el mismo PR**
+> (clase/helper + entrada en `index.js` + fila en esta tabla).
+
+## Qué hay
+
+| Efecto | Cómo se usa | Catálogo | Semilla |
+|---|---|---|---|
+| **Velo atmosférico** neón | clase `.vfx-veil` (custom props `--vfx-veil-a/b/opacity`) | §13.5 / §13.16 | `finca-viva-hero` `.fvh-escena-wrap::after` |
+| **Viñeta** de cine | clase `.vfx-vignette` (`--vfx-vignette-strength`) | §13.5 | idem |
+| **Scrims** arriba/abajo | clases `.vfx-scrim-top` / `.vfx-scrim-bottom` (`--vfx-scrim-color/-h`) | §13.5 | idem |
+| **Grades de luz por piso térmico** | clase `.vfx-grade` + modificador `.vfx-grade--{glacial,paramo,frio,templado,calido,valle}`; tokens `--vfx-piso-*`; `--vfx-grade-fuerza` por dirección | §13.2 | los `--mm2-*` de Montaña |
+| **Glow** (feMerge) | helper `<GlowFilter id std blurId />` | §13.16 | unifica `ge-glow1` + `creatures/_filters` |
+| **Pulso cardíaco** | token `--vfx-beat` + clases `.vfx-beat`, `.vfx-beat-wave`, `.vfx-beat-glow` | §13.10 | `--fvo-beat` (SceneFincaOrganismo) |
+| **Auto-dibujado** | helper `<AutoDibujo stage fade />` + clases `.vfx-draw/.vfx-fade/.vfx-t1…t9` | §13.11 | SceneTrazoMinimal `fvm-t*` |
+| **Flujo por dash** | clase `.vfx-flow` (`--vfx-flow-dur/-len`) | §13.12 | `fvo-flow` / `adm-sap` |
+| **Filtro acuarela** | helper `<FiltroAcuarela id scale frequency />` | — | mapa-acuarela (feTurbulence+feDisplacementMap) |
+
+## Dos formas de consumir
+
+**1. CSS** (velos, viñeta, scrims, grades, latido, auto-dibujado, flujo).
+Importe el CSS una vez donde lo use y ponga las clases:
+
+```jsx
+import '../../visual/effects/effects.css';
+
+// una escena con cielo de biopunk y hora dorada en la finca:
+<div style={{ position: 'relative' }}>
+  <MiEscenaSVG />
+  <div className="vfx-grade vfx-grade--templado" />   {/* luz de la finca  */}
+  <div className="vfx-veil" />                          {/* velo neón        */}
+  <div className="vfx-scrim-bottom" />                  {/* para que el texto lea */}
+  <div className="vfx-vignette" />                      {/* enfoca el centro */}
+</div>
+```
+
+El pulso cardíaco sincroniza todo lo vivo con una sola variable:
+
+```jsx
+// el corazón late, la red se enciende en fase, la onda se expande:
+<g className="vfx-beat"><path d="…corazón…" /></g>
+<g className="vfx-beat-glow"><path d="…red micorrízica…" /></g>
+<circle className="vfx-beat-wave" r="8" />
+// para acelerar/frenar TODO junto:  style={{ '--vfx-beat': '4s' }} en un ancestro
+```
+
+**2. Helpers SVG** (glow, acuarela, auto-dibujado). Se montan en tu `<defs>` /
+tu SVG. Cada instancia usa **ids únicos** (`useId`) para repetirse sin colisión:
+
+```jsx
+import { useId } from 'react';
+import { GlowFilter, FiltroAcuarela, AutoDibujo } from '../../visual/effects';
+import '../../visual/effects/effects.css';
+
+function MiEscena() {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `glow-${uid}`;
+  const agua = `acuarela-${uid}`;
+  return (
+    <svg viewBox="0 0 390 486">
+      <defs>
+        <GlowFilter id={glow} std={2.2} blurId={`blur-${uid}`} />
+        <FiltroAcuarela id={agua} scale={7} frequency={0.014} />
+      </defs>
+
+      {/* glow neón sobre lo vivo */}
+      <g filter={`url(#${glow})`}>{/* … */}</g>
+
+      {/* un relieve/mancha con borde de acuarela */}
+      <path d="…" fill="#6f9a85" filter={`url(#${agua})`} />
+
+      {/* el trazo se dibuja solo, por etapas */}
+      <AutoDibujo d="M20,300 C120,260 …" stage={1} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo d="M60,300 L60,240 …" stage={3} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo as="circle" fade stage={6} cx="300" cy="90" r="26" fill="#cbb96a" />
+    </svg>
+  );
+}
+```
+
+Consumidor de referencia (convertido en este PR): **`dashboard/GuardianEspiritu.jsx`**
+— sus filtros `ge-glow1`/`ge-blur3`, antes inline, hoy salen de `<GlowFilter>`
+(mismo markup, cero regresión visual).
+
+## Técnica y reglas
+
+- **CSS + SVG puros, cero dependencias nuevas**; solo `transform`/`opacity`
+  animados, **blur/filtros ESTÁTICOS** (Android gama baja). Cero JS por frame.
+- Cada helper emite **solo el `<filter>`** (sin `<defs>` propio): el consumidor
+  lo mete en su `<defs>` y referencia por id. **Ids únicos** con `useId` para
+  repetir muchos en una misma página sin colisión.
+- **Reduced-motion-safe**: sin movimiento, el latido queda encendido, el trazo
+  COMPLETO, los planos visibles y velos/grades/viñeta quietos (son estáticos).
+- Las capas-overlay (`.vfx-veil/.vfx-vignette/.vfx-scrim-*/.vfx-grade`) se montan
+  dentro de un contenedor `position: relative`, no capturan toque y heredan el
+  radio del contenedor.
+- Los **grades por piso térmico** nacen tokenizados (`--vfx-piso-*`): cuando la
+  Montaña entre a prod, se re-tiñen desde `themes.css` sin tocar las escenas
+  (§13.2, promoción de los `--mm2-*` recomendada por el catálogo §14b).

--- a/src/visual/effects/effects.css
+++ b/src/visual/effects/effects.css
@@ -1,0 +1,190 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   src/visual/effects/effects.css — EFECTOS visuales reutilizables de Chagra.
+
+   Las TÉCNICAS DE CINE del catálogo (§13) que hoy están redibujadas/re-copiadas
+   en varios mockups y escenas, aquí una sola vez como clases `vfx-*` + custom
+   properties `--vfx-*`. Antes de re-hilvanar un velo/viñeta/grade/latido/trazo,
+   use esto.
+
+   Reglas de la casa respetadas:
+   · Solo `transform`/`opacity` animados; blur/filtros ESTÁTICOS (Android gama baja).
+   · `prefers-reduced-motion` = fotograma final digno (nada roto, nada en loop).
+   · Cero dependencias; cero JS por frame.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Base de las capas-overlay ───────────────────────────────────────────────
+   Todos los velos/viñetas/scrims/grades se montan como una capa absoluta dentro
+   de un contenedor `position: relative`. No capturan toque. Heredan el radio del
+   contenedor para no desbordar tarjetas redondeadas. */
+.vfx-overlay,
+.vfx-veil,
+.vfx-vignette,
+.vfx-scrim-top,
+.vfx-scrim-bottom,
+.vfx-grade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+/* ── 1. VELO atmosférico neón (§13.5 / §13.16) ──────────────────────────────
+   El velo radial teal/orquídea + tinte navy del modo biopunk (receta de
+   finca-viva-hero `.fvh-escena-wrap::after`). Tunéable por custom props para
+   re-teñir sin reescribir el gradiente. Los temas claros lo apagan poniendo
+   `--vfx-veil-opacity: 0`. */
+.vfx-veil {
+  z-index: 6;
+  opacity: var(--vfx-veil-opacity, 1);
+  background:
+    radial-gradient(120% 78% at 80% 12%, var(--vfx-veil-a, rgba(34, 211, 238, 0.26)), transparent 56%),
+    radial-gradient(110% 92% at 16% 92%, var(--vfx-veil-b, rgba(217, 70, 239, 0.22)), transparent 58%),
+    linear-gradient(180deg,
+      var(--vfx-veil-top, rgba(8, 16, 34, 0.42)) 0%,
+      rgba(8, 16, 34, 0.08) 40%,
+      var(--vfx-veil-bottom, rgba(10, 22, 44, 0.36)) 100%);
+  transition: opacity 0.5s ease;
+}
+
+/* ── 2. VIÑETA de cine (§13.5) ───────────────────────────────────────────────
+   Radial que hunde las esquinas para enfocar el centro y que la UI flote sin
+   cajas. `--vfx-vignette-strength` (0..1) modula cuánto oscurece el borde. */
+.vfx-vignette {
+  z-index: 7;
+  background: radial-gradient(120% 120% at 50% 45%,
+    transparent 52%,
+    rgba(0, 0, 0, calc(0.35 * var(--vfx-vignette-strength, 1))) 100%);
+}
+
+/* ── 3. SCRIMS arriba/abajo (§13.5) ──────────────────────────────────────────
+   Degradados en los bordes superior/inferior para que el texto SIEMPRE lea
+   sobre la escena (títulos arriba, compositor abajo). */
+.vfx-scrim-top {
+  z-index: 7;
+  background: linear-gradient(180deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 28%);
+  inset: 0 0 auto 0;
+}
+.vfx-scrim-bottom {
+  z-index: 7;
+  background: linear-gradient(0deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 34%);
+  inset: auto 0 0 0;
+}
+
+/* ── 4. GRADES de luz por PISO TÉRMICO (§13.2) ───────────────────────────────
+   Plano de color fijo al viewport, crossfade por opacity: la TEMPERATURA de la
+   luz cuenta la altura. Azul glacial (nevado) → cian páramo → neutro frío →
+   HORA DORADA (finca templada) → ámbar cálido → turquesa río. Portado de los
+   `--mm2-*` del mockup Montaña (§13.2), tokenizado para promoverse a prod.
+   `--vfx-grade-fuerza` modula la intensidad por dirección artística
+   (naturalista 1 · biopunk 0.45 · verde-vivo 0.75). */
+:root {
+  --vfx-piso-glacial:  rgba(180, 214, 240, 0.50); /* nevado 4.800m */
+  --vfx-piso-paramo:   rgba(120, 200, 210, 0.42); /* páramo */
+  --vfx-piso-frio:     rgba(150, 165, 172, 0.28); /* frío (neutro) */
+  --vfx-piso-templado: rgba(255, 200, 120, 0.34); /* finca ⭐ hora dorada */
+  --vfx-piso-calido:   rgba(255, 170,  90, 0.36); /* cálido ámbar */
+  --vfx-piso-valle:    rgba( 90, 200, 190, 0.40); /* río turquesa 400m */
+}
+.vfx-grade {
+  z-index: 5;
+  background: var(--vfx-grade-color, var(--vfx-piso-templado));
+  opacity: var(--vfx-grade-fuerza, 1);
+  transition: background 0.6s ease, opacity 0.6s ease;
+}
+.vfx-grade--glacial  { --vfx-grade-color: var(--vfx-piso-glacial); }
+.vfx-grade--paramo   { --vfx-grade-color: var(--vfx-piso-paramo); }
+.vfx-grade--frio     { --vfx-grade-color: var(--vfx-piso-frio); }
+.vfx-grade--templado { --vfx-grade-color: var(--vfx-piso-templado); }
+.vfx-grade--calido   { --vfx-grade-color: var(--vfx-piso-calido); }
+.vfx-grade--valle    { --vfx-grade-color: var(--vfx-piso-valle); }
+
+/* ── 5. PULSO CARDÍACO compartido (§13.10) ───────────────────────────────────
+   Una sola variable de duración (`--vfx-beat`) sincroniza TODO lo vivo: la
+   escena late como UN organismo. Es el `--fvo-beat` de SceneFincaOrganismo,
+   promovido a la librería (mismo valor 5.2s = `--motion-beat`). */
+:root { --vfx-beat: 5.2s; }
+
+/* el corazón: doble pulso como corazón real */
+.vfx-beat {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat var(--vfx-beat) ease-in-out infinite;
+}
+@keyframes vfx-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+/* onda que sale del latido */
+.vfx-beat-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat-wave var(--vfx-beat) ease-out infinite;
+}
+@keyframes vfx-beat-wave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red/savia/panel se ENCIENDE con cada latido (solo opacity) */
+.vfx-beat-glow { animation: vfx-beat-glow var(--vfx-beat) ease-in-out infinite; }
+@keyframes vfx-beat-glow {
+  0%, 100% { opacity: 0.55; }
+  8% { opacity: 1; }
+  16% { opacity: 0.7; }
+  22% { opacity: 0.9; }
+  34% { opacity: 0.55; }
+}
+
+/* ── 6. AUTO-DIBUJADO orquestado (§13.11) ────────────────────────────────────
+   `pathLength="1"` normalizado + stroke-dashoffset → 0 + etapas escalonadas.
+   El trazo/grafo/glifo se dibuja solo al entrar. (Receta de SceneTrazoMinimal;
+   el componente `AutoDibujo` pega estas clases y pone `pathLength`.) */
+.vfx-draw {
+  stroke-dasharray: 1 1;
+  stroke-dashoffset: 1;
+  animation: vfx-draw 1.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+@keyframes vfx-draw { to { stroke-dashoffset: 0; } }
+
+/* planos de color que aparecen en fundido (sol, leyenda, humo) */
+.vfx-fade { opacity: 0; animation: vfx-fade 1.1s ease forwards; }
+@keyframes vfx-fade { to { opacity: 1; } }
+
+/* etapas del dibujo — delay heredado por trazos y fundidos del grupo */
+.vfx-t1 .vfx-draw, .vfx-t1.vfx-draw, .vfx-t1 .vfx-fade, .vfx-t1.vfx-fade { animation-delay: 0.15s; }
+.vfx-t2 .vfx-draw, .vfx-t2.vfx-draw, .vfx-t2 .vfx-fade, .vfx-t2.vfx-fade { animation-delay: 0.40s; }
+.vfx-t3 .vfx-draw, .vfx-t3.vfx-draw, .vfx-t3 .vfx-fade, .vfx-t3.vfx-fade { animation-delay: 0.70s; }
+.vfx-t4 .vfx-draw, .vfx-t4.vfx-draw, .vfx-t4 .vfx-fade, .vfx-t4.vfx-fade { animation-delay: 0.95s; }
+.vfx-t5 .vfx-draw, .vfx-t5.vfx-draw, .vfx-t5 .vfx-fade, .vfx-t5.vfx-fade { animation-delay: 1.20s; }
+.vfx-t6 .vfx-draw, .vfx-t6.vfx-draw, .vfx-t6 .vfx-fade, .vfx-t6.vfx-fade { animation-delay: 1.50s; }
+.vfx-t7 .vfx-draw, .vfx-t7.vfx-draw, .vfx-t7 .vfx-fade, .vfx-t7.vfx-fade { animation-delay: 1.80s; }
+.vfx-t8 .vfx-draw, .vfx-t8.vfx-draw, .vfx-t8 .vfx-fade, .vfx-t8.vfx-fade { animation-delay: 2.10s; }
+.vfx-t9 .vfx-draw, .vfx-t9.vfx-draw, .vfx-t9 .vfx-fade, .vfx-t9.vfx-fade { animation-delay: 2.50s; }
+
+/* ── 7. FLUJO por dash (§13.12) ──────────────────────────────────────────────
+   Savia/agua/corriente/micelio: dasharray animado que corre por el trazo.
+   `--vfx-flow-dur` y `--vfx-flow-len` tunéan velocidad y avance. */
+.vfx-flow {
+  stroke-dasharray: 4 8;
+  animation: vfx-flow var(--vfx-flow-dur, 3.2s) linear infinite;
+}
+@keyframes vfx-flow { to { stroke-dashoffset: calc(-1 * var(--vfx-flow-len, 40px)); } }
+
+/* ── prefers-reduced-motion: fotograma final digno ───────────────────────────
+   Nada en loop; el dibujo COMPLETO, los planos visibles, velos/grades/viñeta
+   quietos (son estáticos de por sí). Regla de la casa §13.20. */
+@media (prefers-reduced-motion: reduce) {
+  .vfx-beat, .vfx-beat-wave, .vfx-beat-glow, .vfx-flow { animation: none !important; }
+  .vfx-beat, .vfx-beat-glow { opacity: 1; }
+  .vfx-beat-wave { opacity: 0; }              /* la onda no deja residuo */
+  .vfx-draw { animation: none !important; stroke-dashoffset: 0; }
+  .vfx-fade { animation: none !important; opacity: 1; }
+  .vfx-veil { transition: none; }
+}

--- a/src/visual/effects/index.js
+++ b/src/visual/effects/index.js
@@ -1,0 +1,35 @@
+/*
+ * Librería visual de EFECTOS de Chagra (effects) — las TÉCNICAS DE CINE del
+ * catálogo (§13), una sola vez y reutilizables. Antes de re-hilvanar un
+ * velo/viñeta/grade/glow/latido/auto-dibujado/acuarela, use esto.
+ *
+ * Dos piezas:
+ *   1. `effects.css` — clases `vfx-*` + custom properties `--vfx-*`
+ *      (velos, viñeta, scrims, grades por piso térmico, pulso cardíaco,
+ *      auto-dibujado, flujo por dash). Importalo UNA vez donde lo uses:
+ *          import '../../visual/effects/effects.css';
+ *   2. Helpers SVG (este barrel): `GlowFilter`, `FiltroAcuarela`, `AutoDibujo`.
+ *
+ * Reglas de la casa: solo transform/opacity animados; blur/filtros estáticos;
+ * reduced-motion = fotograma final digno; cero dependencias nuevas.
+ */
+export { GlowFilter } from './GlowFilter.jsx';
+export { FiltroAcuarela } from './FiltroAcuarela.jsx';
+export { AutoDibujo } from './AutoDibujo.jsx';
+
+/* Ritmo del latido/respiración compartido (= `--vfx-beat` en effects.css y
+   `--motion-beat`/`--fvo-beat` en el resto del repo). Útil desde JS cuando una
+   escena necesita sincronizar un timing sin leer el CSS. */
+export const VFX_BEAT_MS = 5200;
+
+/* Registro consultable de los pisos térmicos y su grade de luz (§13.2).
+   `token` = la custom property de effects.css; `clase` = la clase modificadora
+   de `.vfx-grade`. Orden de menor a mayor altura invertido: de nevado a río. */
+export const VFX_PISOS = [
+  { slug: 'glacial',  nombre: 'Nevado',   token: '--vfx-piso-glacial',  clase: 'vfx-grade--glacial',  luz: 'azul glacial' },
+  { slug: 'paramo',   nombre: 'Páramo',   token: '--vfx-piso-paramo',   clase: 'vfx-grade--paramo',   luz: 'cian páramo' },
+  { slug: 'frio',     nombre: 'Frío',     token: '--vfx-piso-frio',     clase: 'vfx-grade--frio',     luz: 'neutro frío' },
+  { slug: 'templado', nombre: 'Templado', token: '--vfx-piso-templado', clase: 'vfx-grade--templado', luz: 'hora dorada' },
+  { slug: 'calido',   nombre: 'Cálido',   token: '--vfx-piso-calido',   clase: 'vfx-grade--calido',   luz: 'ámbar cálido' },
+  { slug: 'valle',    nombre: 'Valle/río', token: '--vfx-piso-valle',   clase: 'vfx-grade--valle',    luz: 'turquesa río' },
+];

--- a/src/visual/voz/IrisVoz.jsx
+++ b/src/visual/voz/IrisVoz.jsx
@@ -1,0 +1,192 @@
+/*
+ * IrisVoz — LA VOZ CON FORMA: la identidad visual de la voz de Chagra.
+ *
+ * Cuando el campesino dice «hola, Chagra», la app no muestra un micrófono
+ * genérico: muestra ESTO — un iris orgánico de anillos concéntricos, mitad
+ * ondas de agua en una totuma, mitad anillos de crecimiento de un tronco.
+ * Cálido y de tierra (brasa, miel, musgo), NO sci-fi: es deliberadamente lo
+ * opuesto al astrolabio holográfico del overlay de escucha (EscuchaOverlay).
+ *
+ * LA REGLA DE ORO — el movimiento tiene dirección SEMÁNTICA:
+ *   · escuchando → las ondas viajan HACIA ADENTRO (la voz de usted entra
+ *     hasta la brasa; el anillo de afuera reacciona primero).
+ *   · hablando   → las ondas NACEN en la brasa y salen HACIA AFUERA
+ *     (ahora la voz es de Chagra).
+ *   · pensando   → los anillos se trenzan: dos grupos contra-rotan despacio,
+ *     como agua que da vueltas antes de aclararse.
+ *   · reposo     → apenas respira al ritmo de la casa (--vfx-beat) y la
+ *     brasa queda en rescoldo. Se aquieta; no pide atención.
+ *
+ * NADA DE ANIMACIÓN FINGIDA: el brillo y la escala reaccionan a un NIVEL
+ * (0..1). En producción se le pasa el RMS real del micrófono vía `getNivel`;
+ * sin él usa la simulación orgánica de vozViva.js (nivelSimulado).
+ *
+ * Reglas de la casa (src/visual/effects/README.md):
+ *   · Solo transform/opacity animados; el glow (GlowFilter) es estático.
+ *   · Cero setState por frame: un solo rAF escribe transform/opacity
+ *     imperativamente sobre refs (mismo patrón GPU-friendly del repo).
+ *   · prefers-reduced-motion: el rAF NO arranca y el CSS pinta un fotograma
+ *     estático digno por estado (color + opacidad cuentan el momento).
+ *
+ * Geometría y simulación (deterministas, sin React) en ./vozViva.js.
+ */
+import React, { useEffect, useId, useRef } from 'react';
+import { GlowFilter } from '../effects';
+import { ANILLOS_IRIS, IRIS_VB, IRIS_C, N_ANILLOS, nivelSimulado } from './vozViva';
+import './irisVoz.css';
+
+/**
+ * El iris. Decorativo por contrato (aria-hidden): el ESTADO se anuncia con
+ * texto fuera del iris (aria-live del consumidor), nunca solo con color.
+ *
+ * @param {object}   props
+ * @param {string}  [props.estado='reposo']  reposo | escuchando | pensando | hablando
+ * @param {number}  [props.size=180]         lado en px (la firma sobrevive desde ~22px)
+ * @param {Function}[props.getNivel]         () => 0..1 leído cada frame (RMS real del
+ *                                           mic en producción). Si no se pasa, usa la
+ *                                           simulación orgánica según el estado.
+ * @param {string}  [props.className]
+ */
+export default function IrisVoz({ estado = 'reposo', size = 180, getNivel, className = '' }) {
+  const uid = useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const anillosRef = useRef([]);
+  const brasaRef = useRef(null);
+  const auraRef = useRef(null);
+  const haloRef = useRef(null);
+
+  /* refs espejo: el rAF lee SIEMPRE lo último sin recrearse por render. */
+  const estadoRef = useRef(estado);
+  const getNivelRef = useRef(getNivel);
+  useEffect(() => { estadoRef.current = estado; }, [estado]);
+  useEffect(() => { getNivelRef.current = getNivel; }, [getNivel]);
+
+  useEffect(() => {
+    /* reduced-motion: sin rAF — el CSS pinta el fotograma estático por estado. */
+    if (typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return undefined;
+    }
+    const niveles = new Float32Array(N_ANILLOS);
+    let lead = 0;
+    let raf = 0;
+    const t0 = performance.now();
+
+    const tick = (now) => {
+      const t = (now - t0) / 1000;
+      const est = estadoRef.current;
+      const crudo = getNivelRef.current
+        ? (getNivelRef.current() || 0)
+        : nivelSimulado(t, est);
+      /* suavizado asimétrico: sube rápido con la voz, cae lento (el iris
+         "retiene" un instante lo que oyó — mismo gesto que EscuchaOverlay). */
+      lead += (crudo - lead) * (crudo > lead ? 0.32 : 0.1);
+
+      /* LA DIRECCIÓN: cada anillo persigue a su vecino. hablando → el de
+         adentro manda (la onda sale); resto → el de afuera manda (la voz
+         entra). El lag de la persecución ES el viaje de la onda. */
+      if (est === 'hablando') {
+        for (let i = 0; i < N_ANILLOS; i++) {
+          const objetivo = i === 0 ? lead : niveles[i - 1];
+          niveles[i] += (objetivo - niveles[i]) * 0.24;
+        }
+      } else {
+        for (let i = N_ANILLOS - 1; i >= 0; i--) {
+          const objetivo = i === N_ANILLOS - 1 ? lead : niveles[i + 1];
+          niveles[i] += (objetivo - niveles[i]) * 0.24;
+        }
+      }
+
+      for (let i = 0; i < N_ANILLOS; i++) {
+        const el = anillosRef.current[i];
+        if (!el) continue;
+        const a = ANILLOS_IRIS[i];
+        el.style.transform = `scale(${(1 + niveles[i] * a.amp).toFixed(4)})`;
+        el.style.opacity = Math.min(1, a.base + niveles[i] * 0.5).toFixed(3);
+      }
+      if (brasaRef.current) {
+        brasaRef.current.style.transform = `scale(${(1 + lead * 0.24).toFixed(4)})`;
+      }
+      if (auraRef.current) {
+        auraRef.current.style.opacity = (0.35 + lead * 0.6).toFixed(3);
+        auraRef.current.style.transform = `scale(${(1 + lead * 0.36).toFixed(4)})`;
+      }
+      if (haloRef.current) {
+        haloRef.current.style.opacity = (0.5 + lead * 0.5).toFixed(3);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div
+      className={`iris-voz ${className}`.trim()}
+      data-estado={estado}
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    >
+      <div className="iv-halo" ref={haloRef} />
+      <div className="iv-respira">
+        <svg viewBox={`0 0 ${IRIS_VB} ${IRIS_VB}`} focusable="false">
+          <defs>
+            <GlowFilter id={`${uid}-glow`} std={2.6} />
+            <radialGradient id={`${uid}-brasa`} cx="50%" cy="46%" r="55%">
+              <stop offset="0%" stopColor="var(--iris-brasa-luz)" />
+              <stop offset="62%" stopColor="var(--iris-brasa)" />
+              <stop offset="100%" stopColor="var(--iris-brasa-borde)" />
+            </radialGradient>
+          </defs>
+
+          {/* Anillos en dos grupos (pares/impares) que solo en `pensando`
+              contra-rotan — animation-play-state, así al salir del estado la
+              trenza se CONGELA donde iba (nada salta). */}
+          <g className="iv-giro iv-giro-a">
+            {ANILLOS_IRIS.map((a, i) => (i % 2 === 0 ? (
+              <path
+                key={i}
+                ref={(el) => { anillosRef.current[i] = el; }}
+                className="iv-anillo iv-anillo-par"
+                d={a.d}
+                style={{ '--iv-op-base': a.base }}
+                strokeWidth={a.grosor}
+              />
+            ) : null))}
+          </g>
+          <g className="iv-giro iv-giro-b">
+            {ANILLOS_IRIS.map((a, i) => (i % 2 === 1 ? (
+              <path
+                key={i}
+                ref={(el) => { anillosRef.current[i] = el; }}
+                className="iv-anillo iv-anillo-impar"
+                d={a.d}
+                style={{ '--iv-op-base': a.base }}
+                strokeWidth={a.grosor}
+              />
+            ) : null))}
+          </g>
+
+          {/* La brasa: el rescoldo donde la voz vive. Glow ESTÁTICO
+              (GlowFilter); lo que se anima es transform/opacity. */}
+          <g filter={`url(#${uid}-glow)`}>
+            <circle
+              ref={auraRef}
+              className="iv-brasa-aura"
+              cx={IRIS_C}
+              cy={IRIS_C}
+              r={17.5}
+            />
+            <circle
+              ref={brasaRef}
+              className="iv-brasa"
+              cx={IRIS_C}
+              cy={IRIS_C}
+              r={10}
+              fill={`url(#${uid}-brasa)`}
+            />
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/voz/README.md
+++ b/src/visual/voz/README.md
@@ -1,0 +1,42 @@
+# `src/visual/voz` — la voz con forma
+
+`IrisVoz` es la **identidad visual de la voz de Chagra**: un iris orgánico de
+anillos concéntricos (mitad ondas de agua en una totuma, mitad anillos de
+crecimiento de un tronco) con una brasa en el centro. Cálido y de tierra —
+deliberadamente lo opuesto al astrolabio holográfico de `EscuchaOverlay`.
+
+Mockup de decisión: `#/mockups/voz-con-forma` (`src/mockups/VozConForma.jsx`).
+
+## La regla de oro: el movimiento tiene dirección semántica
+
+| estado | qué hace | por qué |
+| --- | --- | --- |
+| `reposo` | apenas respira (`--vfx-beat`), brasa en rescoldo | se aquieta, no pide atención |
+| `escuchando` | las ondas viajan **hacia adentro**; el brillo sube con el nivel | la voz de usted entra hasta la brasa |
+| `pensando` | los anillos se **trenzan** (contra-rotación lentísima) | agua dando vueltas antes de aclararse |
+| `hablando` | las ondas **nacen en la brasa** y salen | ahora la voz es de Chagra |
+
+## Uso
+
+```jsx
+import IrisVoz from '../visual/voz';
+
+// producción: nivel = RMS real del micrófono, leído cada frame
+<IrisVoz estado="escuchando" size={220} getNivel={() => rmsRef.current} />
+
+// demo/onboarding: sin getNivel usa la pseudo-habla determinista incluida
+<IrisVoz estado="hablando" size={56} />
+```
+
+- **Decorativo por contrato** (`aria-hidden`): el estado se anuncia con texto
+  del consumidor (`aria-live`), nunca solo con color.
+- La firma sobrevive desde ~22 px (chip) hasta pantalla completa.
+
+## Reglas de la casa (heredadas de `src/visual/effects`)
+
+- Solo `transform`/`opacity` animados; el glow (`GlowFilter` de `effects`) es
+  filtro **estático**.
+- Cero setState por frame: un solo rAF escribe sobre refs.
+- `prefers-reduced-motion`: el rAF no arranca; el CSS pinta un fotograma
+  quieto pero legible por estado (color + opacidad cuentan el momento).
+- Geometría **determinista** (sin `Math.random`): el iris es una firma.

--- a/src/visual/voz/index.js
+++ b/src/visual/voz/index.js
@@ -1,0 +1,17 @@
+/*
+ * Librería visual de VOZ de Chagra — la identidad "la voz con forma".
+ *
+ * `IrisVoz` es el gesto único de la voz en toda la app: donde antes iría un
+ * micrófono genérico, va el iris (FAB, overlay de escucha, chip de estado,
+ * onboarding de voz). Un solo primitivo, cuatro estados, cualquier tamaño.
+ *
+ *   import IrisVoz, { nivelSimulado, ESTADOS_VOZ } from '.../visual/voz';
+ *
+ *   <IrisVoz estado="escuchando" size={220} getNivel={() => rmsRef.current} />
+ *
+ * `getNivel` en producción = RMS real del micrófono (useVoiceRecorder);
+ * sin él, IrisVoz usa `nivelSimulado` (pseudo-habla determinista) — útil
+ * para demos, onboarding y estados sin permiso de mic todavía.
+ */
+export { default, default as IrisVoz } from './IrisVoz.jsx';
+export { nivelSimulado, ESTADOS_VOZ, ANILLOS_IRIS } from './vozViva';

--- a/src/visual/voz/irisVoz.css
+++ b/src/visual/voz/irisVoz.css
@@ -1,0 +1,148 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   irisVoz.css — la piel de IrisVoz (LA VOZ CON FORMA).
+
+   Paleta de TIERRA, no de neón: la voz de Chagra es una brasa en una cocina
+   de leña, no un holograma. Cuatro estados = cuatro temperaturas del mismo
+   material (nunca cambia la forma, solo la vida que lleva adentro):
+
+     reposo      rescoldo   (pardo apagado — apenas se nota que está viva)
+     escuchando  miel       (ámbar cálido — la atención encendida)
+     pensando    cobre      (más hondo y quieto — el agua dando vueltas)
+     hablando    musgo+miel (verde vivo — la respuesta es cosa que crece)
+
+   Reglas de la casa: solo transform/opacity animados; el glow es filtro
+   ESTÁTICO; prefers-reduced-motion = fotograma quieto pero LEGIBLE por
+   estado (el color y la opacidad cuentan el momento sin loops).
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.iris-voz {
+  /* tinta por defecto = reposo (rescoldo) */
+  --iris-tinta: #8d6b4d;
+  --iris-tinta-2: #6f5844;
+  --iris-brasa-luz: #ffd9a8;
+  --iris-brasa: #d98549;
+  --iris-brasa-borde: rgba(140, 70, 30, 0);
+  --iris-halo: rgba(217, 133, 73, 0.14);
+  --iris-vida: 0;                 /* fotograma estático: cuánta vida extra */
+
+  position: relative;
+  display: inline-block;
+  flex: none;
+}
+
+.iris-voz[data-estado='escuchando'] {
+  --iris-tinta: #e9a94e;
+  --iris-tinta-2: #c98a54;
+  --iris-brasa-luz: #ffe3b0;
+  --iris-brasa: #f0a355;
+  --iris-halo: rgba(233, 169, 78, 0.22);
+  --iris-vida: 0.3;
+}
+
+.iris-voz[data-estado='pensando'] {
+  --iris-tinta: #c57a45;
+  --iris-tinta-2: #9a6a4a;
+  --iris-brasa-luz: #ffce96;
+  --iris-brasa: #d98549;
+  --iris-halo: rgba(197, 122, 69, 0.18);
+  --iris-vida: 0.16;
+}
+
+.iris-voz[data-estado='hablando'] {
+  --iris-tinta: #b7c98a;
+  --iris-tinta-2: #d8b06a;
+  --iris-brasa-luz: #f3e9b0;
+  --iris-brasa: #cabd62;
+  --iris-halo: rgba(183, 201, 138, 0.2);
+  --iris-vida: 0.34;
+}
+
+/* ── halo: la luz que la brasa le presta a la mesa ─────────────────────────── */
+.iv-halo {
+  position: absolute;
+  inset: -18%;
+  border-radius: 50%;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 50%, var(--iris-halo) 0%, transparent 62%);
+  opacity: 0.6;
+  transition: background 0.7s ease;
+}
+
+/* ── respiración: TODO el iris respira al ritmo de la casa ─────────────────── */
+.iv-respira {
+  width: 100%;
+  height: 100%;
+  animation: iv-respira var(--vfx-beat, 5.2s) ease-in-out infinite;
+}
+
+.iv-respira svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+@keyframes iv-respira {
+  0%, 100% { transform: scale(1); }
+  42% { transform: scale(1.022); }
+  58% { transform: scale(1.018); }
+}
+
+/* ── anillos de agua/tronco ────────────────────────────────────────────────── */
+.iv-anillo {
+  fill: none;
+  stroke: var(--iris-tinta);
+  stroke-linejoin: round;
+  opacity: calc(var(--iv-op-base, 0.4) + var(--iris-vida) * 0.5);
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: stroke 0.7s ease;
+}
+
+/* anillos alternos con la segunda tinta: la veta del tronco, no un arcoíris */
+.iv-anillo-impar { stroke: var(--iris-tinta-2); }
+
+/* ── la trenza de `pensando`: dos grupos contra-rotan lentísimo ──────────────
+   animation-play-state: al salir del estado la rotación se CONGELA donde va
+   (nada salta a cero). Solo transform ⇒ GPU-friendly. */
+.iv-giro {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: iv-giro 46s linear infinite;
+  animation-play-state: paused;
+}
+
+.iv-giro-b {
+  animation-name: iv-giro-contra;
+  animation-duration: 58s;
+}
+
+.iris-voz[data-estado='pensando'] .iv-giro { animation-play-state: running; }
+
+@keyframes iv-giro { to { transform: rotate(360deg); } }
+@keyframes iv-giro-contra { to { transform: rotate(-360deg); } }
+
+/* ── la brasa ──────────────────────────────────────────────────────────────── */
+.iv-brasa {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.iv-brasa-aura {
+  fill: var(--iris-brasa);
+  opacity: calc(0.3 + var(--iris-vida));
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: fill 0.7s ease;
+}
+
+/* ── prefers-reduced-motion: fotograma quieto y digno ────────────────────────
+   El rAF no arranca (lo decide IrisVoz.jsx), así que aquí solo apagamos los
+   loops CSS. El estado sigue LEYÉNDOSE: --iris-vida sube la opacidad de los
+   anillos y la aura cuando la voz está activa — color + luz, sin movimiento. */
+@media (prefers-reduced-motion: reduce) {
+  .iv-respira,
+  .iv-giro {
+    animation: none !important;
+  }
+}

--- a/src/visual/voz/vozViva.js
+++ b/src/visual/voz/vozViva.js
@@ -1,0 +1,68 @@
+/*
+ * vozViva.js — la parte VIVA (y sin React) de IrisVoz: geometría determinista
+ * de los anillos + simulación orgánica de nivel. Separado del componente para
+ * que IrisVoz.jsx solo exporte componentes (react-refresh) y para poder
+ * testear/reusar la matemática sin montar nada.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- 'reposo'/'escuchando'/
+   'pensando'/'hablando' son TOKENS de estado del primitivo (API interna),
+   no copy de UI; el texto visible vive en el consumidor. */
+
+export const ESTADOS_VOZ = ['reposo', 'escuchando', 'pensando', 'hablando'];
+
+export const IRIS_VB = 200;              // lado del viewBox
+export const IRIS_C = IRIS_VB / 2;       // centro
+export const N_ANILLOS = 6;              // anillos de agua/tronco
+const N_PTS = 72;                        // puntos por anillo (denso = suave)
+
+/* PRNG determinista (misma receta que el resto del repo visual). */
+const azar = (i, sal) => {
+  const x = Math.sin(i * 127.1 + sal * 311.7) * 43758.5453;
+  return x - Math.floor(x);
+};
+
+/* Anillos precomputados UNA vez: cada uno es un path cerrado cuyo radio
+ * ondula con dos senos de baja amplitud — el temblor de mano que separa un
+ * anillo de tronco de un círculo de compás. El de afuera tiembla más (la
+ * onda se deshace al alejarse de la brasa), y cada anillo trae su amplitud
+ * de reacción a la voz (`amp`) y su opacidad base (`base`). */
+export const ANILLOS_IRIS = Array.from({ length: N_ANILLOS }, (_, k) => {
+  const R = 30 + k * 11.4;                       // 30 → 87 (dentro de VB=200)
+  const w1 = 0.016 + azar(k, 1) * 0.016 + k * 0.0045;
+  const w2 = 0.009 + azar(k, 2) * 0.012;
+  const f1 = 3 + (k % 3);
+  const f2 = 6 + (k % 4);
+  const p1 = azar(k, 3) * Math.PI * 2;
+  const p2 = azar(k, 4) * Math.PI * 2;
+  let d = '';
+  for (let j = 0; j < N_PTS; j++) {
+    const a = (j / N_PTS) * Math.PI * 2;
+    const r = R * (1 + w1 * Math.sin(f1 * a + p1) + w2 * Math.sin(f2 * a + p2));
+    d += `${j === 0 ? 'M' : 'L'}${(IRIS_C + Math.cos(a) * r).toFixed(1)} ${(IRIS_C + Math.sin(a) * r).toFixed(1)}`;
+  }
+  return {
+    d: `${d}Z`,
+    amp: 0.05 + k * 0.016,          // cuánto se hincha con la voz
+    base: 0.5 - k * 0.055,          // opacidad base (se desvanece hacia afuera)
+    grosor: 1.9 - k * 0.18,         // trazo (grueso adentro, fino afuera)
+  };
+});
+
+/* ── Simulación orgánica de nivel (para mockups/demos) ───────────────────────
+ * Pseudo-habla determinista: una envolvente de FRASES (con pausas de aire),
+ * modulada por PALABRAS y SÍLABAS (senos incongruentes = cadencia creíble).
+ * `hablando` es un pelo más parejo (Chagra no duda); `pensando` es un pulso
+ * interior bajito; `reposo` es silencio. */
+export function nivelSimulado(t, estado) {
+  if (estado === 'escuchando' || estado === 'hablando') {
+    const lento = estado === 'hablando' ? 0.62 : 0.78;
+    const frase = Math.sin(t * lento + 0.6) * 0.5 + 0.5;      // 0..1, respiración de frase
+    if (frase < 0.22) return 0.04;                            // pausa para tomar aire
+    const palabra = 0.62 + 0.38 * Math.sin(t * 5.9) * Math.sin(t * 2.31 + 1.7);
+    const silaba = 0.78 + 0.22 * Math.sin(t * 13.7 + 0.4);
+    const piso = estado === 'hablando' ? 0.3 : 0.22;
+    return Math.max(0, Math.min(1, piso + 0.62 * frase * palabra * silaba));
+  }
+  if (estado === 'pensando') return 0.1 + 0.06 * Math.sin(t * 1.5);
+  return 0;
+}


### PR DESCRIPTION
## Qué es

Mockup net-new de galería: **la pantalla de diálogo por voz del agente**. Lleva la identidad visual de la voz (el primitivo **IrisVoz**) a una pantalla conversacional completa: el campesino le pregunta a su finca y la finca le responde en usted, corto, con una acción concreta.

**Ruta pública:** `#/mockups/conversacion-voz` (vía `MOCKUP_HASH_ROUTES` en `src/App.jsx`, resuelta antes del check de sesión — sin auth, datos de muestra).

## La conversación guionada

Un ciclo completo de uso, determinista (sin micrófono real ni permisos):

1. «Hola, Chagra.» → el iris se enciende (escuchando)
2. «¿Qué le hago al tomate que amaneció con las hojas amarillas?»
3. La finca piensa (anillos trenzados) y responde: revise las hojas de abajo, échele compost maduro al pie, riegue temprano.
4. «¿Le sirve el caldo de ortiga que tengo guardado?» → dosis concreta + tarea apuntada para el sábado.

## Reúso confirmado

- **IrisVoz** (`src/visual/voz`, traído de `origin/fable/mockup-voz-con-forma`): es la identidad de la voz y el **único** control de micrófono. Estados reposo → escuchando → pensando → hablando; escuchar entra, hablar sale.
- **effects** (`src/visual/effects`, traído de `origin/feat/visual-lib-effects`): `GlowFilter` dentro del iris + `--vfx-beat` para la respiración de las pistas y el hint «hola, Chagra».

## Detalles de UX

- Burbujas grandes y legibles; transcripción palabra-por-palabra (cero reflow: todas montadas, solo cambia `opacity`).
- Indicador "pensando…", hint «hola, Chagra», tarea que queda en el cuaderno de campo (el valor de haber hablado).
- Mobile-first 320px; `prefers-reduced-motion` = fotograma legible por estado (lo pinta el propio iris) + texto completo sin coreografía.
- Español de Colombia, usted cordial (revise, échele, aplíquelo, guarde). Todo self-contained: SVG propio, cero enlaces/imágenes externas, sin audio ni permisos.

## Verificación

- `npm run build`: **verde** — emite el chunk `ConversacionVoz-*.js` + su CSS.
- `npm run tsc:check`: **868 errores** = baseline (`actual ≤ 868`). Los primitivos traídos aportaban 2 errores nuevos, arreglados **con el tipo correcto** (sin `any`/`@ts-ignore`): JSDoc de bloque en `GlowFilter`/`AutoDibujo` y cast del tag dinámico de `AutoDibujo` a `keyof JSX.IntrinsicElements`. Mis archivos aportan 0 errores.
- `npx eslint src/mockups/ConversacionVoz.jsx`: **limpio**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)