### PR TITLE
fix(mundos): tono usted y vida visual en mundos a medias (ronda 2 UX)

### DIFF
--- a/src/components/Asociaciones.jsx
+++ b/src/components/Asociaciones.jsx
@@ -470,7 +470,7 @@ export default function Asociaciones({ profile = {}, esOperador = false }) {
         </div>
 
         <p className="mt-4 max-w-3xl text-base leading-relaxed text-emerald-50 border-t border-emerald-700 pt-4">
-          <strong>Elige tu cultivo</strong> y descubre qué sembrar con él, qué evitar, por qué funciona y cuánto puedes ganar.
+          <strong>Elija su cultivo</strong> y descubra qué sembrar con él, qué evitar, por qué funciona y cuánto puede ganar.
           Todo basado en <strong>investigación real</strong>, no en promesas.
         </p>
       </div>
@@ -483,7 +483,7 @@ export default function Asociaciones({ profile = {}, esOperador = false }) {
               <div className="grid h-8 w-8 place-items-center rounded-lg bg-emerald-100">
                 <Sprout className="h-5 w-5 text-emerald-700" />
               </div>
-              <span>¿Qué cultivo quieres planear?</span>
+              <span>¿Qué cultivo quiere planear?</span>
             </label>
             <select
               id="cultivo-asociaciones"
@@ -503,7 +503,7 @@ export default function Asociaciones({ profile = {}, esOperador = false }) {
           {tieneCultivosFinca && (
             <div className="rounded-lg border-2 border-emerald-200 bg-emerald-50 p-3 sm:text-right">
               <div className="flex items-center gap-2 mb-1">
-                <span className="text-xs font-bold uppercase text-emerald-700">Detectado en tu finca</span>
+                <span className="text-xs font-bold uppercase text-emerald-700">Detectado en su finca</span>
               </div>
               <div className="flex flex-wrap gap-1">
                 {cultivosFincaPrincipales.map((cultivo) => (
@@ -522,7 +522,7 @@ export default function Asociaciones({ profile = {}, esOperador = false }) {
                   // Resolver slug→cultivo igual que el resto del componente para que el match funcione.
                   const c = findCultivoInItems(arquetipos, slug);
                   return slug === selected || c?.id === selected || c?.nombre === selected;
-                }) ? '¡Ya tienes este cultivo!' : 'Selecciona uno para ver recomendaciones'}
+                }) ? '¡Ya tiene este cultivo!' : 'Seleccione uno para ver recomendaciones'}
               </p>
             </div>
           )}
@@ -541,7 +541,7 @@ export default function Asociaciones({ profile = {}, esOperador = false }) {
             Estamos trabajando en agregar más cultivos con bases científicas.
           </p>
           <div className="mt-4 rounded-lg bg-emerald-50 p-3 text-sm font-semibold text-emerald-900 border border-emerald-200">
-            💡 Prueba con maíz, café, cacao, frutales u hortalizas
+            💡 Pruebe con maíz, café, cacao, frutales u hortalizas
           </div>
         </div>
       ) : (

--- a/src/components/CicloNutrientesScreen.jsx
+++ b/src/components/CicloNutrientesScreen.jsx
@@ -4,6 +4,7 @@ import {
   ArrowDown, FlaskConical, Droplets, Mountain, Info, Trees,
 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
+import { Lombriz } from '../visual/creatures';
 
 /**
  * CicloNutrientesScreen — el CICLO CERRADO de nutrientes de la finca, VISIBLE.
@@ -145,7 +146,7 @@ const PASOS_PLAN = [
     momento: 'Mientras crece (≈día 15–25)',
     insumo: 'Biol foliar o al pie',
     propio: true,
-    nota: 'Refuerzo de nitrógeno en vegetativo. Aquí entra la boñiga de las vacas y la porcinaza de los cerdos, fermentadas en biol.',
+    nota: 'Refuerzo de nitrógeno cuando la mata está echando hojas (crecimiento vegetativo). Aquí entra la boñiga de las vacas y la porcinaza de los cerdos, fermentadas en biol.',
   },
   {
     momento: 'En floración, cuaje y llenado (≈día 45–60)',
@@ -190,14 +191,17 @@ export default function CicloNutrientesScreen({ onBack, onHome, onNavigate }) {
   return (
     <ScreenShell title="Ciclo de nutrientes" icon={Recycle} onBack={onBack} onHome={onHome}>
       <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
-        {/* Intro — la idea en campesino. */}
-        <p className="text-sm text-slate-300 leading-relaxed">
-          En una finca agroecológica nada se bota. Lo que sale de sus animales
-          vuelve a la tierra como comida para las plantas. Aquí ve el camino
-          completo, eslabón por eslabón: el estiércol del animal se transforma en
-          biopreparado y ese abono entra en el plan de alimentación de sus
-          cultivos.
-        </p>
+        {/* Intro — la idea en campesino, con la lombriz (la que hace tierra). */}
+        <div className="flex items-start gap-3 rounded-2xl border border-emerald-800/40 bg-emerald-950/20 p-3.5">
+          <Lombriz size={56} className="shrink-0 mt-0.5" title="La lombriz, que convierte los desechos en tierra viva" />
+          <p className="text-sm text-slate-300 leading-relaxed">
+            En una finca agroecológica nada se bota. Lo que sale de sus animales
+            vuelve a la tierra como comida para las plantas. Aquí ve el camino
+            completo, eslabón por eslabón: el estiércol del animal se transforma en
+            biopreparado y ese abono entra en el plan de alimentación de sus
+            cultivos.
+          </p>
+        </div>
 
         {/* Resumen del flujo en una cinta. */}
         <div className="rounded-2xl border border-emerald-700/40 bg-emerald-900/20 p-3.5">
@@ -350,16 +354,22 @@ export default function CicloNutrientesScreen({ onBack, onHome, onNavigate }) {
         {/* Lo que el abono propio NO reemplaza — destacado, sin sobre-afirmar. */}
         <div className="rounded-2xl border border-stone-500/50 bg-stone-800/30 p-3.5 flex gap-3">
           <Mountain size={20} className="shrink-0 text-stone-300 mt-0.5" aria-hidden="true" />
-          <p className="text-sm text-stone-100/90 leading-relaxed">
-            <span className="font-bold text-stone-200">Ojo:</span> no todo sale de
-            los animales. La <span className="font-bold">cal dolomítica</span> y la
-            {' '}<span className="font-bold">roca fosfórica</span> del primer paso
-            (corregir acidez y aportar fósforo) son enmiendas MINERALES que toca
-            comprar — no se producen con estiércol. Y los sulfatos del supermagro
-            también son un insumo mineral aparte. El abono de la finca cubre el
-            grueso de la nutrición, pero estos minerales se aportan según el
-            análisis de suelo.
-          </p>
+          <div className="text-sm text-stone-100/90 leading-snug">
+            <p className="font-bold text-stone-200">Ojo: no todo sale de los animales.</p>
+            <ul className="mt-2 flex flex-col gap-1.5">
+              <li>
+                • La <span className="font-bold">cal dolomítica</span> y la
+                {' '}<span className="font-bold">roca fosfórica</span> del primer paso
+                (corrigen la acidez y aportan fósforo) son enmiendas MINERALES: toca
+                comprarlas, no se producen con estiércol.
+              </li>
+              <li>• Los sulfatos del supermagro también son un insumo mineral aparte.</li>
+              <li>
+                • El abono de la finca cubre el grueso de la nutrición; estos
+                minerales se aportan según el análisis de suelo.
+              </li>
+            </ul>
+          </div>
         </div>
 
         {/* Cierre — invitar a registrar abono y enlazar a las pantallas. */}

--- a/src/components/CromatografiaScreen.jsx
+++ b/src/components/CromatografiaScreen.jsx
@@ -66,13 +66,13 @@ async function fileToBase64Thumb(file) {
 /* ──────────────── Contenido educativo: metodo Pfeiffer/Restrepo ──────────── */
 const PASOS_METODO = [
   {
-    titulo: 'Materiales que necesitas',
+    titulo: 'Materiales que necesita',
     icono: '📋',
     contenido: (
       <ul className="space-y-1.5">
         <li className="flex items-start gap-2">
           <span className="text-muzo-glow font-bold shrink-0">-</span>
-          <span>Papel filtro Whatman No. 1 (cortado en circulos de ~10 cm de diametro)</span>
+          <span>Papel filtro Whatman No. 1 (cortado en círculos de ~10 cm de diámetro)</span>
         </li>
         <li className="flex items-start gap-2">
           <span className="text-muzo-glow font-bold shrink-0">-</span>
@@ -80,11 +80,11 @@ const PASOS_METODO = [
         </li>
         <li className="flex items-start gap-2">
           <span className="text-muzo-glow font-bold shrink-0">-</span>
-          <span>Hidroxido de sodio (NaOH) al 1% (1 g en 100 ml de agua destilada)</span>
+          <span>Hidróxido de sodio (NaOH) al 1% (1 g en 100 ml de agua destilada)</span>
         </li>
         <li className="flex items-start gap-2">
           <span className="text-muzo-glow font-bold shrink-0">-</span>
-          <span>Muestra de suelo seco y cernido (sin piedras ni raices)</span>
+          <span>Muestra de suelo seco y cernido (sin piedras ni raíces)</span>
         </li>
         <li className="flex items-start gap-2">
           <span className="text-muzo-glow font-bold shrink-0">-</span>
@@ -103,12 +103,12 @@ const PASOS_METODO = [
     contenido: (
       <div className="space-y-2">
         <p>
-          En un lugar con poca luz (la luz descompone la plata), pon el circulo de
-          papel filtro sobre una caja petri limpia. Con el gotero, aplica el nitrato
+          En un lugar con poca luz (la luz descompone la plata), ponga el círculo de
+          papel filtro sobre una caja petri limpia. Con el gotero, aplique el nitrato
           de plata al 0.5% sobre el centro del papel: una sola gota basta para que se
-          expanda en circulos.
+          expanda en círculos.
         </p>
-        <p>Deja secar el papel en completa oscuridad. Puede tomar unos 15 a 20 minutos.</p>
+        <p>Deje secar el papel en completa oscuridad. Puede tomar unos 15 a 20 minutos.</p>
       </div>
     ),
   },
@@ -118,13 +118,13 @@ const PASOS_METODO = [
     contenido: (
       <div className="space-y-2">
         <p>
-          Mezcla una cucharadita de suelo seco y cernido con 5 ml de hidroxido de
-          sodio (NaOH) al <strong>1%</strong> en un frasco pequeno. Agita suavemente
+          Mezcle una cucharadita de suelo seco y cernido con 5 ml de hidróxido de
+          sodio (NaOH) al <strong>1%</strong> en un frasco pequeño. Agite suavemente
           durante un minuto.
         </p>
         <p>
-          Deja reposar la mezcla por 2 a 5 minutos para que las particulas gruesas se
-          asienten. El liquido que queda encima es el extracto que usaras.
+          Deje reposar la mezcla por 2 a 5 minutos para que las partículas gruesas se
+          asienten. El líquido que queda encima es el extracto que usará.
         </p>
       </div>
     ),
@@ -135,13 +135,13 @@ const PASOS_METODO = [
     contenido: (
       <div className="space-y-2">
         <p>
-          Con el papel ya seco e impregnado, pon una gota del extracto justo en el
-          centro. La gota debe ser pequena, no mas de 3 mm de diametro.
+          Con el papel ya seco e impregnado, ponga una gota del extracto justo en el
+          centro. La gota debe ser pequeña, no más de 3 mm de diámetro.
         </p>
         <p>
-          <strong>Deja el papel en oscuridad total</strong> para que la corrida
-          cromatografica avance. El liquido se expandira en circulos concentricos
-          arrastrando los componentes del suelo. Esto toma entre 1 y 3 horas segun
+          <strong>Deje el papel en oscuridad total</strong> para que la corrida
+          cromatográfica avance. El líquido se expandirá en círculos concéntricos
+          arrastrando los componentes del suelo. Esto toma entre 1 y 3 horas según
           la temperatura y la humedad.
         </p>
       </div>
@@ -153,13 +153,13 @@ const PASOS_METODO = [
     contenido: (
       <div className="space-y-2">
         <p>
-          Pasadas 1-3 horas en oscuridad, saca el papel a la luz natural (no directa
+          Pasadas 1-3 horas en oscuridad, saque el papel a la luz natural (no directa
           al sol fuerte). La plata reacciona con la luz y revela los anillos y colores
-          de la cromatografia.
+          de la cromatografía.
         </p>
         <p>
-          El revelado completo toma de 10 a 30 minutos. Veras aparecer zonas de
-          distintos colores: cafes, blancos, grises y a veces violetas o rosados.
+          El revelado completo toma de 10 a 30 minutos. Verá aparecer zonas de
+          distintos colores: cafés, blancos, grises y a veces violetas o rosados.
         </p>
       </div>
     ),
@@ -170,13 +170,13 @@ const PASOS_METODO = [
     contenido: (
       <div className="space-y-2">
         <p>
-          Una vez revelado, el cromatograma se seguira oscureciendo con el tiempo
-          porque la plata sigue reaccionando a la luz. Tomale una foto inmediatamente
-          para tu registro.
+          Una vez revelado, el cromatograma se seguirá oscureciendo con el tiempo
+          porque la plata sigue reaccionando a la luz. Tómele una foto de inmediato
+          para su registro.
         </p>
         <p>
-          Guarda el papel entre las paginas de un libro o en un sobre oscuro. Anota
-          la fecha, la zona de la finca de donde sacaste la muestra y tus
+          Guarde el papel entre las páginas de un libro o en un sobre oscuro. Anote
+          la fecha, la zona de la finca de donde sacó la muestra y sus
           observaciones.
         </p>
       </div>
@@ -188,66 +188,66 @@ const PRECAUCIONES = [
   {
     icono: '⚠️',
     texto:
-      'El nitrato de plata (AgNO₃) es toxico leve. Usa guantes al manipularlo y lava tus manos despues.',
+      'El nitrato de plata (AgNO₃) es tóxico leve. Use guantes al manipularlo y lávese las manos después.',
   },
   {
     icono: '👕',
     texto:
-      'El nitrato de plata mancha la piel y la ropa con manchas oscuras que no salen. Usa ropa vieja o un delantal.',
+      'El nitrato de plata mancha la piel y la ropa con manchas oscuras que no salen. Use ropa vieja o un delantal.',
   },
   {
     icono: '🧴',
     texto:
-      'El hidroxido de sodio (NaOH) al 1% es una base diluida. Aun asi, evita el contacto con ojos y piel. Si cae, lava con abundante agua.',
+      'El hidróxido de sodio (NaOH) al 1% es una base diluida. Aun así, evite el contacto con ojos y piel. Si cae, lave con abundante agua.',
   },
   {
     icono: '🌡️',
     texto:
-      'Trabaja en un lugar ventilado. No comas ni bebas durante la preparacion.',
+      'Trabaje en un lugar ventilado. No coma ni beba durante la preparación.',
   },
   {
     icono: '🗑️',
     texto:
-      'Los restos de la solucion de plata se deben guardar en frasco oscuro para desecho controlado. No los tires a la tierra o al agua.',
+      'Los restos de la solución de plata se deben guardar en frasco oscuro para desecho controlado. No los tire a la tierra ni al agua.',
   },
   {
     icono: '🧤',
     texto:
-      'Desecha los guantes y papeles usados en una bolsa aparte, no en la composta.',
+      'Deseche los guantes y papeles usados en una bolsa aparte, no en la compostera.',
   },
 ];
 
 /* ───────── Interpetacion por zonas (las 4 clasicas de Pfeiffer/Restrepo) ─── */
 const ZONAS = [
   {
-    nombre: 'Zona central o mineral',
+    nombre: 'Anillo del centro (los minerales)',
     posicion: 'Cerca del centro del cromatograma',
     color: 'border-amber-500',
     bg: 'bg-amber-950/30',
     texto: 'border-amber-800/60',
     icono: '🪨',
     queIndica:
-      'Muestra los minerales y las sales. Un centro claro o blanco indica buena reserva de minerales disponibles para las plantas. Un centro oscuro o manchado puede indicar exceso de sales o compactacion.',
+      'Muestra los minerales y las sales. Un centro claro o blanco indica buena reserva de minerales disponibles para las plantas. Un centro oscuro o manchado puede indicar exceso de sales o compactación.',
   },
   {
-    nombre: 'Zona media o proteica-humica',
+    nombre: 'Anillo del medio (la materia orgánica y el humus)',
     posicion: 'Anillo entre la zona central y la externa',
     color: 'border-amber-700',
     bg: 'bg-amber-900/20',
     texto: 'border-amber-700/60',
     icono: '🌱',
     queIndica:
-      'Representa la materia organica y el humus del suelo. Un anillo marron bien definido y ancho indica buena cantidad de humus estable. Si es muy delgado o ausente, hay poca materia organica o esta muy degradada.',
+      'Representa la materia orgánica y el humus del suelo. Un anillo marrón bien definido y ancho indica buena cantidad de humus estable. Si es muy delgado o ausente, hay poca materia orgánica o está muy degradada.',
   },
   {
-    nombre: 'Zona externa o enzimatica',
+    nombre: 'Anillo del borde (la vida y los microbios)',
     posicion: 'Anillo exterior antes de los picos del borde',
     color: 'border-violet-700',
     bg: 'bg-violet-950/20',
     texto: 'border-violet-700/60',
     icono: '🧬',
     queIndica:
-      'Refleja la actividad de los microorganismos y las enzimas. Un borde bien definido con tonalidades violetas o rosadas indica un suelo biologicamente activo, con buena vida microbiana. Si es difuso o palido, hay poca actividad.',
+      'Refleja la actividad de los microorganismos y las enzimas. Un borde bien definido con tonalidades violetas o rosadas indica un suelo biológicamente activo, con buena vida microbiana. Si es difuso o pálido, hay poca actividad.',
   },
   {
     nombre: 'Picos y radiaciones del borde',
@@ -257,7 +257,7 @@ const ZONAS = [
     texto: 'border-indigo-700/60',
     icono: '⚡',
     queIndica:
-      'Los picos o radiaciones que salen del borde indican vida y energia del suelo. Muchas radiaciones definidas y largas senalan un suelo vivo y equilibrado. Pocas o cortas pueden indicar un suelo cansado o con poca biodiversidad microbiana.',
+      'Los picos o radiaciones que salen del borde indican vida y energía del suelo. Muchas radiaciones definidas y largas señalan un suelo vivo y equilibrado. Pocas o cortas pueden indicar un suelo cansado o con poca biodiversidad microbiana.',
   },
 ];
 
@@ -265,37 +265,37 @@ const COLORES = [
   {
     color: 'Marrón oscuro / café',
     significado:
-      'Buena materia organica y humus estable. Es el color deseable en la zona media.',
+      'Buena materia orgánica y humus estable. Es el color deseable en la zona media.',
     clase: 'bg-amber-900 border-amber-700',
   },
   {
     color: 'Blanco o crema',
     significado:
-      'Sales minerales. En el centro indica minerales disponibles; en anillos externos puede indicar acumulacion de sales.',
+      'Sales minerales. En el centro indica minerales disponibles; en anillos externos puede indicar acumulación de sales.',
     clase: 'bg-stone-200 border-stone-400 text-slate-900',
   },
   {
     color: 'Gris / plomizo',
     significado:
-      'Suelo compactado, oxidado o con poca vida. Puede indicar exceso de humedad o anaerobiosis.',
+      'Suelo compactado, oxidado o con poca vida. Puede indicar exceso de humedad o falta de aire (anaerobiosis).',
     clase: 'bg-slate-500 border-slate-400',
   },
   {
     color: 'Violeta / lila',
     significado:
-      'Actividad enzimatica y microbiologica. Indica un suelo vivo y con buena mineralizacion.',
+      'Actividad enzimática y microbiológica. Indica un suelo vivo y con buena mineralización.',
     clase: 'bg-violet-800 border-violet-600',
   },
   {
     color: 'Rosado',
     significado:
-      'Actividad biologica de bacterias beneficiosas. Halos rosados son senal positiva.',
+      'Actividad biológica de bacterias beneficiosas. Los halos rosados son señal positiva.',
     clase: 'bg-pink-800 border-pink-600',
   },
   {
     color: 'Amarillo / dorado',
     significado:
-      'Puede indicar presencia de azufre o compuestos organicos especificos. Interpretar junto con las otras zonas.',
+      'Puede indicar presencia de azufre o compuestos orgánicos específicos. Interprete junto con las otras zonas.',
     clase: 'bg-yellow-700 border-yellow-500',
   },
 ];
@@ -476,13 +476,13 @@ export default function CromatografiaScreen({ onBack, onNavigate: _onNavigate })
               <FlaskConical size={24} className="text-emerald-300" />
             </div>
             <div className="text-sm text-emerald-200">
-              <p className="font-bold">Que es la cromatografia de suelo?</p>
+              <p className="font-bold">¿Qué es la cromatografía de suelo?</p>
               <p className="text-emerald-300/80 mt-1">
-                Es un metodo cualitativo creado por Ehrenfried Pfeiffer para ver
+                Es un método cualitativo creado por Ehrenfried Pfeiffer para ver
                 la salud del suelo. La mezcla de suelo reacciona con nitrato de
                 plata sobre papel filtro y revela con colores y anillos la vida,
-                los minerales y la materia organica de tu tierra. No da numeros
-                de laboratorio, pero te ayuda a entender y comparar tus suelos
+                los minerales y la materia orgánica de su tierra. No da números
+                de laboratorio, pero le ayuda a entender y comparar sus suelos
                 en el tiempo.
               </p>
             </div>
@@ -541,8 +541,8 @@ export default function CromatografiaScreen({ onBack, onNavigate: _onNavigate })
         {NavTabs({ activo: 'registro' })}
         <div className="px-4 pb-10 flex flex-col gap-4">
           <p className="text-sm text-slate-300">
-            Registra tus cromatografias con foto, fecha y la zona de la finca
-            de donde sacaste la muestra. Asi puedes comparar como mejora tu suelo
+            Registre sus cromatografías con foto, fecha y la zona de la finca
+            de donde sacó la muestra. Así puede comparar cómo mejora su suelo
             con el tiempo.
           </p>
 
@@ -937,8 +937,8 @@ export default function CromatografiaScreen({ onBack, onNavigate: _onNavigate })
             <div className="flex flex-col items-center justify-center gap-4 py-12 text-center">
               <Layers size={56} className="text-slate-600" />
               <p className="text-sm text-slate-400 max-w-xs">
-                No tienes cromatografias registradas. Cuando guardes al menos
-                una, podras compararlas entre si para ver como mejora tu suelo.
+                No tiene cromatografías registradas. Cuando guarde al menos
+                una, podrá compararlas entre sí para ver cómo mejora su suelo.
               </p>
               <button
                 type="button"

--- a/src/components/GallinasScreen.jsx
+++ b/src/components/GallinasScreen.jsx
@@ -3,6 +3,7 @@ import {
   Bird, Egg, HeartPulse, ShieldAlert, Sprout, Recycle, Info,
 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
+import FotoAnimal from './animales/FotoAnimal';
 import FuentesAnimal from './common/FuentesAnimal';
 import ChecklistManejo from './common/ChecklistManejo';
 
@@ -49,11 +50,15 @@ export default function GallinasScreen({ onBack, onHome }) {
   return (
     <ScreenShell title="Gallinas y aves" icon={Bird} onBack={onBack} onHome={onHome}>
       <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
-        <p className="text-sm text-slate-300 leading-relaxed">
-          Las gallinas te dan huevos, carne y un abono de primera (la gallinaza).
-          Bien manejadas, controlan plagas del suelo y cierran el ciclo de
-          nutrientes de tu finca.
-        </p>
+        {/* Hero photo-forward (mismo patrón que Conejos/Caprinos) */}
+        <FotoAnimal slug="gallinas" alt="Gallinas de campo picoteando en un patio" ratio="aspect-[16/9]" rounded="rounded-2xl" Fallback={Bird}>
+          <div className="absolute inset-x-0 bottom-0 p-4">
+            <h1 className="text-xl font-black text-white drop-shadow">Gallinas y aves</h1>
+            <p className="text-sm text-white/85 leading-snug drop-shadow">
+              Huevos, carne y gallinaza. Bien manejadas, controlan plagas y cierran el ciclo de nutrientes de la finca.
+            </p>
+          </div>
+        </FotoAnimal>
 
         {/* 1. Registro básico */}
         <SeccionCard
@@ -61,7 +66,7 @@ export default function GallinasScreen({ onBack, onHome }) {
           color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200' }}
           titulo="Registro básico"
         >
-          <p>Anota lo esencial de tu lote para hacerle seguimiento:</p>
+          <p>Anote lo esencial de su lote para hacerle seguimiento:</p>
           <ul className="space-y-1">
             <li>• <span className="font-bold">Cantidad</span> de aves.</li>
             <li>• <span className="font-bold">Raza o línea</span> (ver abajo).</li>
@@ -97,9 +102,9 @@ export default function GallinasScreen({ onBack, onHome }) {
           titulo="Sanidad"
         >
           <p>
-            Las enfermedades más serias de las aves en Colombia. No te damos
-            dosis: cada caso es distinto y la vacuna depende del lote. Si ves
-            varias aves enfermas o muertas, <span className="font-bold">consulta al técnico o al ICA.</span>
+            Las enfermedades más serias de las aves en Colombia. No le damos
+            dosis: cada caso es distinto y la vacuna depende del lote. Si ve
+            varias aves enfermas o muertas, <span className="font-bold">consulte al técnico o al ICA.</span>
           </p>
           <ul className="space-y-2">
             <li>
@@ -112,8 +117,8 @@ export default function GallinasScreen({ onBack, onHome }) {
               <span className="font-bold text-rose-100">Coccidiosis:</span> parásito del
               intestino (diarrea con sangre, aves erizadas, bajo consumo), sobre
               todo en pollos jóvenes con cama húmeda. Manejo: <span className="font-bold">cama seca</span>,
-              densidad baja y agua limpia. El tratamiento (coccidiostato) lo
-              define el técnico.
+              densidad baja y agua limpia. El tratamiento (un coccidiostato, el
+              remedio contra la coccidiosis) lo define el técnico.
             </li>
             <li>
               <span className="font-bold text-rose-100">Parásitos:</span> internos
@@ -125,8 +130,8 @@ export default function GallinasScreen({ onBack, onHome }) {
           </ul>
           <p className="flex items-start gap-2 mt-2 text-amber-200 font-semibold">
             <ShieldAlert size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
-            Bioseguridad: aves nuevas en cuarentena, no mezcles lotes de distinta
-            edad y desinfecta botas y manos al entrar al galpón.
+            Bioseguridad: aves nuevas en cuarentena, no mezcle lotes de distinta
+            edad y desinfecte botas y manos al entrar al galpón.
           </p>
         </SeccionCard>
 
@@ -141,16 +146,16 @@ export default function GallinasScreen({ onBack, onHome }) {
               <span className="font-bold text-emerald-100">Cama profunda:</span> capa
               gruesa de cascarilla, viruta o tamo seco en el piso. Absorbe el
               estiércol, se mantiene seca y al final se convierte en abono
-              (gallinaza compostada). Voltéala y agrega material seco si se humedece.
+              (gallinaza compostada). Voltéela y agregue material seco si se humedece.
             </li>
             <li>
-              <span className="font-bold text-emerald-100">Pastoreo rotacional / gallinas camperas:</span> mueve
+              <span className="font-bold text-emerald-100">Pastoreo rotacional / gallinas camperas:</span> mueva
               las aves por potreros o corrales rotativos. Comen pasto e insectos,
               abonan parejo y rompen el ciclo de plagas y parásitos del suelo.
             </li>
             <li>
               <span className="font-bold text-emerald-100">Sombra y agua fresca:</span> con
-              calor fuerte (&gt;32&nbsp;°C) las aves se asfixian. Dales sombra,
+              calor fuerte (&gt;32&nbsp;°C) las aves se asfixian. Deles sombra,
               ventilación y agua limpia siempre.
             </li>
           </ul>
@@ -165,13 +170,13 @@ export default function GallinasScreen({ onBack, onHome }) {
           <ul className="space-y-1.5">
             <li>
               <span className="font-bold text-amber-100">Huevos:</span> las ponedoras
-              arrancan alrededor de las 18–20 semanas. Recoge varias veces al día,
-              guarda en sitio fresco y limpio. Anota la postura para ver cómo va el lote.
+              arrancan alrededor de las 18–20 semanas. Recoja varias veces al día,
+              guarde en sitio fresco y limpio. Anote la postura para ver cómo va el lote.
             </li>
             <li>
               <span className="font-bold text-amber-100">Gallinaza:</span> es el abono
-              que producen. Recógela seca de la cama profunda. <span className="font-bold">Compóstala
-              o madúrala antes de usarla</span> (la gallinaza fresca quema las plantas
+              que producen. Recójala seca de la cama profunda. <span className="font-bold">Compóstela
+              o madúrela antes de usarla</span> (la gallinaza fresca quema las plantas
               y puede traer patógenos).
             </li>
           </ul>
@@ -181,12 +186,12 @@ export default function GallinasScreen({ onBack, onHome }) {
         <SeccionCard
           Icon={Recycle}
           color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200' }}
-          titulo="Aporte a tu finca"
+          titulo="Aporte a su finca"
         >
           <p>
             La <span className="font-bold">gallinaza</span> es ingrediente del
             <span className="font-bold"> bocashi</span>, el abono fermentado base del
-            plan de nutrición de tus plantas. Así se cierra el ciclo:
+            plan de nutrición de sus plantas. Así se cierra el ciclo:
           </p>
           <div className="flex flex-wrap items-center gap-2 text-xs font-bold my-1">
             <span className="px-2.5 py-1 rounded-full bg-amber-500/20 text-amber-200 border border-amber-500/40">Gallinas</span>
@@ -200,8 +205,8 @@ export default function GallinasScreen({ onBack, onHome }) {
             <span className="px-2.5 py-1 rounded-full bg-emerald-500/20 text-emerald-200 border border-emerald-500/40">Planta</span>
           </div>
           <p className="text-xs text-slate-300/80">
-            En campesino: la gallina come, abona la cama; esa gallinaza la mezclas
-            en el bocashi y ese abono alimenta el suelo y tus matas. Menos gasto en
+            En campesino: la gallina come, abona la cama; esa gallinaza la mezcla
+            en el bocashi y ese abono alimenta el suelo y sus matas. Menos gasto en
             abono comprado.
           </p>
         </SeccionCard>
@@ -225,7 +230,7 @@ export default function GallinasScreen({ onBack, onHome }) {
         {/* Fuentes / Saber más — enlaces públicos reales */}
         <FuentesAnimal
           claves={['fenavi', 'agrosavia', 'ica', 'cipav', 'sena']}
-          nota="Newcastle es enfermedad de notificación obligatoria al ICA. Ante dudas de tratamiento o dosis, consulta a un técnico o veterinario."
+          nota="Newcastle es enfermedad de notificación obligatoria al ICA. Ante dudas de tratamiento o dosis, consulte a un técnico o veterinario."
         />
       </div>
     </ScreenShell>

--- a/src/components/NutricionHumanaScreen.jsx
+++ b/src/components/NutricionHumanaScreen.jsx
@@ -158,7 +158,7 @@ function CultivoCard({ item, maximos, animar }) {
       {/* Gancho folk de la estrella */}
       {estrellaNutri && (
         <p className="px-4 pb-2 text-[13px] text-slate-200 leading-snug">
-          <span className="font-semibold text-slate-100">Qué te da:</span> {estrellaNutri.folk}
+          <span className="font-semibold text-slate-100">Qué le da:</span> {estrellaNutri.folk}
         </p>
       )}
 
@@ -285,7 +285,7 @@ export default function NutricionHumanaScreen({ onBack }) {
           <h1 className="text-lg font-bold leading-tight text-white flex items-center gap-1.5">
             <Utensils size={18} aria-hidden="true" /> La comida que alimenta
           </h1>
-          <p className="text-xs text-slate-400 leading-tight">Qué te da comer cada cultivo de tu finca</p>
+          <p className="text-xs text-slate-400 leading-tight">Qué le da de comer cada cultivo de su finca</p>
         </div>
       </header>
 
@@ -305,7 +305,7 @@ export default function NutricionHumanaScreen({ onBack }) {
             <section className="rounded-2xl border border-slate-700 bg-slate-900 overflow-hidden">
               <div className="p-4 pb-2"><PlatoIlustracion /></div>
               <div className="px-4 pb-4">
-                <p className="text-[13px] uppercase tracking-wide font-bold text-slate-400">Cada bocado te da algo</p>
+                <p className="text-[13px] uppercase tracking-wide font-bold text-slate-400">Cada bocado le da algo</p>
                 <p className="mt-1 text-[15px] text-slate-100 leading-snug">
                   Lo que usted siembra no solo llena: <span className="font-bold">alimenta</span>. Aquí ve, por cada
                   100&nbsp;gramos, la <span className="font-semibold">fuerza</span> (energía), el

--- a/src/components/ToxicologiaScreen.jsx
+++ b/src/components/ToxicologiaScreen.jsx
@@ -100,8 +100,8 @@ function ToxInsumos() {
       <div className="bg-slate-900 border border-slate-800 rounded-xl p-3 flex gap-2.5 text-sm text-slate-300">
         <ShieldAlert size={18} className="shrink-0 mt-0.5 text-amber-400" />
         <span>
-          Antes de preparar o aplicar un insumo, revisa su toxicidad y el equipo de protección
-          que necesitas. Los datos vienen del catálogo; donde no hay dato, manéjalo con precaución.
+          Antes de preparar o aplicar un insumo, revise su toxicidad y el equipo de protección
+          que necesita. Los datos vienen del catálogo; donde no hay dato, manéjelo con precaución.
         </span>
       </div>
 
@@ -156,7 +156,7 @@ function ToxInsumos() {
               ) : (
                 <div className="bg-slate-800/60 border border-slate-700 rounded-lg p-2.5 flex gap-2 text-xs text-slate-300">
                   <HelpCircle size={15} className="shrink-0 mt-0.5 text-slate-400" />
-                  <span>Sin advertencia toxicológica en el catálogo. Manéjalo con precaución y consulta a un técnico.</span>
+                  <span>Sin advertencia toxicológica en el catálogo. Manéjelo con precaución y consulte a un técnico.</span>
                 </div>
               )}
 
@@ -256,8 +256,8 @@ function ToxSuelo() {
         <div className="bg-emerald-950/40 border border-emerald-800/50 rounded-xl p-3 flex gap-2.5 text-sm text-emerald-100">
           <Sprout size={18} className="shrink-0 mt-0.5 text-emerald-400" />
           <span>
-            <span className="font-bold">Recuerda:</span> la cromatografía te muestra la VIDA de tu
-            suelo (microbiología, materia orgánica). Esta evaluación te alerta de los TÓXICOS.
+            <span className="font-bold">Recuerde:</span> la cromatografía le muestra la VIDA de su
+            suelo (microbiología, materia orgánica). Esta evaluación le alerta de los TÓXICOS.
             Son complementarias: una sana, la otra protege.
           </span>
         </div>
@@ -283,7 +283,7 @@ function ToxSuelo() {
         <Info size={18} className="shrink-0 mt-0.5 text-sky-400" />
         <span>
           Los tóxicos del suelo (metales pesados, plaguicidas) NO se miden sin laboratorio.
-          Responde estas preguntas y te diremos qué tan probable es que haya un problema, y qué hacer.
+          Responda estas preguntas y le diremos qué tan probable es que haya un problema, y qué hacer.
         </span>
       </div>
 

--- a/src/components/VacasScreen.jsx
+++ b/src/components/VacasScreen.jsx
@@ -3,6 +3,7 @@ import {
   Beef, Milk, HeartPulse, ShieldAlert, Sprout, Recycle, Info, Trees,
 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
+import FotoAnimal from './animales/FotoAnimal';
 import FuentesAnimal from './common/FuentesAnimal';
 import ChecklistManejo from './common/ChecklistManejo';
 
@@ -55,11 +56,15 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
   return (
     <ScreenShell title="Vacas y ganado" icon={Beef} onBack={onBack} onHome={onHome}>
       <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
-        <p className="text-sm text-slate-300 leading-relaxed">
-          Las vacas te dan leche y carne, y además la boñiga (bovinaza) es uno de
-          los mejores abonos de la finca. Bien manejadas, con árboles y pasto, el
-          ganado cuida el suelo en vez de dañarlo.
-        </p>
+        {/* Hero photo-forward (mismo patrón que Conejos/Caprinos) */}
+        <FotoAnimal slug="vacas" alt="Vacas pastando en un potrero con árboles" ratio="aspect-[16/9]" rounded="rounded-2xl" Fallback={Beef}>
+          <div className="absolute inset-x-0 bottom-0 p-4">
+            <h1 className="text-xl font-black text-white drop-shadow">Vacas y ganado</h1>
+            <p className="text-sm text-white/85 leading-snug drop-shadow">
+              Leche, carne y boñiga. Bien manejadas, con árboles y pasto, cuidan el suelo en vez de dañarlo.
+            </p>
+          </div>
+        </FotoAnimal>
 
         {/* 1. Registro básico */}
         <SeccionCard
@@ -67,7 +72,7 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
           color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200' }}
           titulo="Registro básico"
         >
-          <p>Anota lo esencial de tu ganado para hacerle seguimiento:</p>
+          <p>Anote lo esencial de su ganado para hacerle seguimiento:</p>
           <ul className="space-y-1">
             <li>• <span className="font-bold">Cantidad</span> de animales.</li>
             <li>• <span className="font-bold">Raza o cruce</span> (ver abajo).</li>
@@ -103,25 +108,25 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
           titulo="Sanidad"
         >
           <p>
-            Los problemas de salud más serios del ganado en Colombia. No te damos
+            Los problemas de salud más serios del ganado en Colombia. No le damos
             dosis: la vacuna y el tratamiento dependen del animal y de la zona. Si
-            ves varios animales enfermos, <span className="font-bold">consulta al técnico, al veterinario o al ICA.</span>
+            ve varios animales enfermos, <span className="font-bold">consulte al técnico, al veterinario o al ICA.</span>
           </p>
           <ul className="space-y-2">
             <li>
               <span className="font-bold text-rose-100">Fiebre aftosa:</span> virus
               muy contagioso (babeo, ampollas en boca, lengua y patas, cojera, baja
-              de leche). Colombia es país libre <span className="font-bold">con vacunación</span>: cumple
+              de leche). Colombia es país libre <span className="font-bold">con vacunación</span>: cumpla
               los ciclos de vacunación de la zona. Ante cualquier sospecha,
               <span className="font-bold"> es de notificación OBLIGATORIA e inmediata al ICA</span> — no
-              muevas los animales y avisa de una vez.
+              mueva los animales y avise de una vez.
             </li>
             <li>
               <span className="font-bold text-rose-100">Mastitis:</span> inflamación
               de la ubre (leche con grumos o sangre, ubre caliente e hinchada, baja
               de producción). Se previene con <span className="font-bold">ordeño limpio</span>: manos
               y pezones limpios, sellado del pezón y cama seca. El tratamiento lo
-              define el veterinario; respeta el tiempo de retiro de la leche.
+              define el veterinario; respete el tiempo de retiro de la leche.
             </li>
             <li>
               <span className="font-bold text-rose-100">Parásitos gastrointestinales y garrapatas:</span> lombrices
@@ -129,13 +134,13 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
               que chupan sangre y transmiten enfermedades (fiebre de garrapata).
               Manejo: <span className="font-bold">pastoreo rotacional</span> para cortar el ciclo,
               revisión periódica y desparasitación según indique el técnico (no
-              abuses de los químicos: crean resistencia).
+              abuse de los químicos: crean resistencia).
             </li>
           </ul>
           <p className="flex items-start gap-2 mt-2 text-amber-200 font-semibold">
             <ShieldAlert size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
             Animales nuevos en cuarentena, al día con vacunación (aftosa, brucelosis)
-            y con guía de movilización (ICA) al comprar o vender. Así proteges todo el hato.
+            y con guía de movilización (ICA) al comprar o vender. Así protege todo el hato.
           </p>
         </SeccionCard>
 
@@ -147,8 +152,8 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
         >
           <ul className="space-y-2">
             <li>
-              <span className="font-bold text-emerald-100">Pastoreo rotacional:</span> divide
-              el potrero y mueve el ganado por franjas. El pasto descansa y rebrota,
+              <span className="font-bold text-emerald-100">Pastoreo rotacional:</span> divida
+              el potrero y mueva el ganado por franjas. El pasto descansa y rebrota,
               comen parejo, el suelo no se compacta y se rompe el ciclo de parásitos.
             </li>
             <li>
@@ -168,8 +173,8 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
           >
             <Trees size={20} className="shrink-0 text-emerald-300" aria-hidden="true" />
             <span className="text-sm text-emerald-100 flex-1">
-              <span className="font-bold">Lleva tu silvopastoreo.</span> Inicia y haz
-              seguimiento al sistema de árboles, pasto y ganado de tu finca.
+              <span className="font-bold">Lleve su silvopastoreo.</span> Inicie y haga
+              seguimiento al sistema de árboles, pasto y ganado de su finca.
             </span>
           </button>
         </SeccionCard>
@@ -182,16 +187,16 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
         >
           <ul className="space-y-1.5">
             <li>
-              <span className="font-bold text-amber-100">Leche:</span> ordeña limpio
-              (ubre y manos lavadas), filtra y enfría pronto para que no se corte.
-              Anota los litros por día para ver cómo va cada vaca y el hato.
+              <span className="font-bold text-amber-100">Leche:</span> ordeñe limpio
+              (ubre y manos lavadas), filtre y enfríe pronto para que no se corte.
+              Anote los litros por día para ver cómo va cada vaca y el hato.
             </li>
             <li>
               <span className="font-bold text-amber-100">Bovinaza / boñiga:</span> el
-              estiércol de la vaca es un abono de primera. Recógela de los corrales y
-              de las áreas de descanso. <span className="font-bold">Madúrala o compóstala antes
+              estiércol de la vaca es un abono de primera. Recójala de los corrales y
+              de las áreas de descanso. <span className="font-bold">Madúrela o compóstela antes
               de aplicarla</span> (la boñiga fresca puede quemar y traer parásitos), o
-              úsala en el biol y el bocashi.
+              úsela en el biol y el bocashi.
             </li>
           </ul>
         </SeccionCard>
@@ -200,7 +205,7 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
         <SeccionCard
           Icon={Recycle}
           color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200' }}
-          titulo="Aporte a tu finca"
+          titulo="Aporte a su finca"
         >
           <p>
             La <span className="font-bold">boñiga (bovinaza)</span> es el estiércol clásico
@@ -221,8 +226,8 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
           </div>
           <p className="text-xs text-slate-300/80">
             En campesino: la vaca come pasto, suelta la boñiga; esa boñiga la
-            fermentas en el biol (y la metes al bocashi) y ese abono alimenta el
-            suelo y tus matas. Menos gasto en abono comprado y un suelo más vivo.
+            fermenta en el biol (y la mete al bocashi) y ese abono alimenta el
+            suelo y sus matas. Menos gasto en abono comprado y un suelo más vivo.
           </p>
         </SeccionCard>
 
@@ -245,7 +250,7 @@ export default function VacasScreen({ onBack, onHome, onNavigate }) {
         {/* Fuentes / Saber más — enlaces públicos reales */}
         <FuentesAnimal
           claves={['ica', 'agrosavia', 'fedegan', 'cipav', 'sena']}
-          nota="La fiebre aftosa es de notificación obligatoria e inmediata al ICA. Ante dudas de tratamiento o dosis, consulta a un técnico o veterinario."
+          nota="La fiebre aftosa es de notificación obligatoria e inmediata al ICA. Ante dudas de tratamiento o dosis, consulte a un técnico o veterinario."
         />
       </div>
     </ScreenShell>

--- a/src/components/__tests__/Asociaciones.test.jsx
+++ b/src/components/__tests__/Asociaciones.test.jsx
@@ -18,10 +18,10 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     expect(screen.getByRole('heading', { name: 'Asociaciones inteligentes' })).toBeInTheDocument();
 
     // Selector de cultivo
-    expect(screen.getByLabelText(/¿Qué cultivo quieres planear?/)).toHaveValue('maiz');
+    expect(screen.getByLabelText(/¿Qué cultivo quiere planear?/)).toHaveValue('maiz');
 
     // Verificar que el selector funcione
-    const selector = screen.getByLabelText(/¿Qué cultivo quieres planear?/);
+    const selector = screen.getByLabelText(/¿Qué cultivo quiere planear?/);
     expect(within(selector).getByRole('option', { name: 'maíz' })).toBeInTheDocument();
   });
 
@@ -70,7 +70,7 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     render(<Asociaciones profile={{ rol: 'campesino' }} />);
 
     // Cambiar a café
-    fireEvent.change(screen.getByLabelText(/¿Qué cultivo quieres planear?/), {
+    fireEvent.change(screen.getByLabelText(/¿Qué cultivo quiere planear?/), {
       target: { value: 'cafe' },
     });
 
@@ -101,9 +101,9 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     render(<Asociaciones profile={{ rol: 'campesino' }} />);
 
     // Verificar que se detecte el cultivo. "café" aparece también como opción
-    // del selector → acotamos al indicador "Detectado en tu finca".
-    expect(screen.getByLabelText(/¿Qué cultivo quieres planear?/)).toHaveValue('cafe');
-    const indicador = screen.getByText(/Detectado en tu finca/).closest('div').parentElement;
+    // del selector → acotamos al indicador "Detectado en su finca".
+    expect(screen.getByLabelText(/¿Qué cultivo quiere planear?/)).toHaveValue('cafe');
+    const indicador = screen.getByText(/Detectado en su finca/).closest('div').parentElement;
     expect(indicador).toBeInTheDocument();
     expect(within(indicador).getByText(/café/)).toBeInTheDocument();
   });
@@ -131,8 +131,8 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     render(<Asociaciones profile={{ rol: 'campesino' }} />);
 
     // Debería detectar ambos cultivos. Los nombres aparecen también como
-    // opciones del selector → acotamos al indicador "Detectado en tu finca".
-    const indicador = screen.getByText(/Detectado en tu finca/).closest('div').parentElement;
+    // opciones del selector → acotamos al indicador "Detectado en su finca".
+    const indicador = screen.getByText(/Detectado en su finca/).closest('div').parentElement;
     expect(within(indicador).getByText(/maíz/)).toBeInTheDocument();
     expect(within(indicador).getByText(/fríjol/)).toBeInTheDocument();
   });
@@ -142,7 +142,7 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     render(<Asociaciones profile={{ rol: 'campesino' }} />);
 
     // Cambiar a un cultivo sin asociaciones (si existe)
-    const selector = screen.getByLabelText(/¿Qué cultivo quieres planear?/);
+    const selector = screen.getByLabelText(/¿Qué cultivo quiere planear?/);
 
     // Verificar que si no hay recomendaciones se muestre el estado vacío
     // (Esto depende de los datos disponibles, pero verificamos la estructura)
@@ -153,7 +153,7 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     render(<Asociaciones profile={{ rol: 'urbano' }} />);
 
     // Usuario urbano debería ver hortalizas
-    const selector = screen.getByLabelText(/¿Qué cultivo quieres planear?/);
+    const selector = screen.getByLabelText(/¿Qué cultivo quiere planear?/);
     expect(within(selector).getByRole('option', { name: 'zanahoria' })).toBeInTheDocument();
 
     // Pero no debería ver café como opción principal
@@ -163,7 +163,7 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
   test('el operador ve todos los cultivos sin filtrar por rol', () => {
     render(<Asociaciones profile={{ rol: 'urbano' }} esOperador />);
 
-    const selector = screen.getByLabelText(/¿Qué cultivo quieres planear?/);
+    const selector = screen.getByLabelText(/¿Qué cultivo quiere planear?/);
 
     // El operador debería ver más opciones
     expect(within(selector).getByRole('option', { name: 'maíz' })).toBeInTheDocument();
@@ -188,7 +188,7 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     render(<Asociaciones profile={{ rol: 'campesino' }} />);
 
     // Cambiar a un cultivo que no tenga antagonistas (como frutal)
-    fireEvent.change(screen.getByLabelText(/¿Qué cultivo quieres planear?/), {
+    fireEvent.change(screen.getByLabelText(/¿Qué cultivo quiere planear?/), {
       target: { value: 'frutal' },
     });
 
@@ -244,9 +244,9 @@ describe('Asociaciones - Rediseño Útil y Accionable', () => {
     render(<Asociaciones profile={{ rol: 'campesino' }} />);
 
     // Debería seleccionar automáticamente el cultivo de la finca
-    expect(screen.getByLabelText(/¿Qué cultivo quieres planear?/)).toHaveValue('maiz');
+    expect(screen.getByLabelText(/¿Qué cultivo quiere planear?/)).toHaveValue('maiz');
 
     // Y mostrar el mensaje de que ya tiene el cultivo
-    expect(screen.getByText(/¡Ya tienes este cultivo!/)).toBeInTheDocument();
+    expect(screen.getByText(/¡Ya tiene este cultivo!/)).toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -240,7 +240,7 @@ export const MUNDOS_FINCA = [
             { view: 'mercado', label: 'Vender y comprar', desc: 'Directo entre fincas, sin intermediarios', emoji: '🤝' },
             { view: 'poscosecha', label: 'Poscosecha y despensa', desc: 'Cosechar en punto, guardar sin que se dañe y transformar', emoji: '🥕' },
             { view: 'almacenamiento', label: 'Almacenamiento y conservación', desc: 'Troja y silo, secar/salar/fermentar sin botulismo, plagas de almacén y micotoxinas', emoji: '📦' },
-            { view: 'nutricion', label: 'La comida que alimenta', desc: 'Qué te da comer cada cultivo: fuerza, cuerpo, sangre y defensas (ICBF)', emoji: '🍽️' },
+            { view: 'nutricion', label: 'La comida que alimenta', desc: 'Qué le da de comer cada cultivo: fuerza, cuerpo, sangre y defensas (ICBF)', emoji: '🍽️' },
             { view: 'bodega', label: 'Bodega de insumos', desc: 'Lo que tiene guardado y lo que se acaba', emoji: '🏚️' },
             { view: 'informes', label: 'Sacar reportes', desc: 'Para imprimir o llevar al banco o la cooperativa', emoji: '🖨️' },
             { view: 'fermentos', label: 'Fermentos de la cocina', desc: 'Masato, chicha y kéfir con sus vetos de seguridad', emoji: '🫙' },

--- a/src/data/toxicologia-suelo.js
+++ b/src/data/toxicologia-suelo.js
@@ -133,10 +133,10 @@ export const NIVELES_RIESGO = [
     icono: '🟢',
     resumen:
       'No aparecen señales fuertes de contaminación. Aun así, ningún cuestionario '
-      + 'reemplaza un análisis de laboratorio si vas a producir alimento para vender.',
+      + 'reemplaza un análisis de laboratorio si va a producir alimento para vender.',
     recomendacion_lab:
-      'No es urgente un análisis de metales pesados. Si más adelante quieres certificar '
-      + 'o vender, un laboratorio te da tranquilidad.',
+      'No es urgente un análisis de metales pesados. Si más adelante quiere certificar '
+      + 'o vender, un laboratorio le da tranquilidad.',
   },
   {
     id: 'medio',
@@ -145,11 +145,11 @@ export const NIVELES_RIESGO = [
     color: 'amber',
     icono: '🟡',
     resumen:
-      'Hay uno o más factores de riesgo. No quiere decir que tu suelo esté contaminado, '
+      'Hay uno o más factores de riesgo. No quiere decir que su suelo esté contaminado, '
       + 'pero sí que vale la pena tomar precauciones y considerar un análisis.',
     recomendacion_lab:
-      'Considera un análisis de laboratorio de metales pesados y/o residuos de plaguicidas, '
-      + 'sobre todo si vas a sembrar comestibles. Pregunta en la UMATA, el SENA o AGROSAVIA.',
+      'Considere un análisis de laboratorio de metales pesados y/o residuos de plaguicidas, '
+      + 'sobre todo si va a sembrar comestibles. Pregunte en la UMATA, el SENA o AGROSAVIA.',
   },
   {
     id: 'alto',
@@ -306,5 +306,5 @@ export const FUENTES_TOX_SUELO = {
   ],
   nota_limites:
     'Los límites numéricos de metales en suelo (ej. Cd, Pb) varían por norma y cultivo. '
-    + 'No los fijamos aquí: consulta la norma vigente con el laboratorio o la autoridad ambiental.',
+    + 'No los fijamos aquí: consulte la norma vigente con el laboratorio o la autoridad ambiental.',
 };

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,0 +1,61 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
+   Apis). Cuerpo ámbar rayado, cabeza clara, alitas de tul. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-15 -15 32 30';
+
+export function AbejaAngelita({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Abeja angelita',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#ffb54f" opacity="0.35" filter={`url(#${blur})`} />
+      <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
+        style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
+      <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
+        stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
+      <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
+      <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
+      <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
+      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="abeja-angelita">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default AbejaAngelita;

--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,0 +1,62 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Colibrí chillón — Colibri coruscans (nativo de los Andes). Pico largo y
+   recto, garganta violeta iridiscente, alas que baten. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-22 -28 58 52';
+
+export function Colibri({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Colibrí',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#2dffc4" opacity="0.35" filter={`url(#${blur})`} />
+      <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
+      <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
+      <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
+      <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
+      <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
+      <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
+      <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+      <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <path className={wing} d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
+      <path className={wing} style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="colibri">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="colibri" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Colibri;

--- a/src/visual/creatures/Escarabajo.jsx
+++ b/src/visual/creatures/Escarabajo.jsx
@@ -1,0 +1,73 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Escarabajo estercolero — Dichotomius belus (propio de Colombia). Élitros
+   negros brillantes con sutura, cabeza con cuerno, patas que caminan y la bola
+   de abono que rueda. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-23 -12 42 30';
+
+export function Escarabajo({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Escarabajo estercolero',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const bola = animated ? 'crt-ball' : undefined;
+  const patas = animated ? 'crt-legs' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const bolaG = (
+    <g className={bola}>
+      <circle cx="-13" cy="7" r="6.5" fill="#5a4230" />
+      <circle cx="-13" cy="7" r="6.5" fill="none" stroke="#3a2c1c" strokeWidth="1" />
+      <circle cx="-15" cy="5" r="1.5" fill="#6e5238" opacity="0.7" />
+      <circle cx="-11.5" cy="9" r="1.1" fill="#42301f" opacity="0.7" />
+    </g>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={patas} stroke="#0c1206" strokeWidth="1.7" strokeLinecap="round">
+        <path d="M-4,4 L-9,10" /><path d="M0,5 L-1,11" /><path d="M4,4 L8,10" />
+      </g>
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="#141c10"
+        style={{ filter: 'drop-shadow(0 0 5px rgba(157,214,106,0.7))' }} />
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="none" stroke="#9dd66a" strokeWidth="0.7" strokeOpacity="0.6" />
+      <path d="M0,-5.6 L0,5.6" stroke="#0c1206" strokeWidth="0.8" />
+      <ellipse cx="-3.5" cy="-2.8" rx="2.6" ry="1.4" fill="#3d5a24" opacity="0.55" />
+      <path d="M8,-3.4 C12,-3.8 13.4,-1 12.4,1.4 C11.4,3.6 9,3.6 8.2,2.6 C9.4,1 9.2,-1.4 8,-3.4 Z" fill="#0f150b" />
+      <path d="M11.2,-3.2 C12.6,-5 13.4,-4.4 13.2,-2.8" fill="none" stroke="#0f150b" strokeWidth="1.7" strokeLinecap="round" />
+      <circle cx="10.4" cy="-0.6" r="0.7" fill="#9dd66a" opacity="0.8" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="escarabajo">
+        {defs}
+        {bolaG}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="escarabajo" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {bolaG}
+      {body}
+    </svg>
+  );
+}
+
+export default Escarabajo;

--- a/src/visual/creatures/Lombriz.jsx
+++ b/src/visual/creatures/Lombriz.jsx
@@ -1,0 +1,64 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Lombriz de tierra — Martiodrilus crassus (lombriz gigante nativa de los
+   Andes). Cuerpo curvo segmentado con clitelo (banda clara) y cabecita.
+   Su movimiento en escena (asomar/mecerse) lo aporta la escena, no la
+   criatura. Versión canónica del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-8 -16 30 48';
+
+export function Lombriz({
+  size = 64,
+  className,
+  inline = false,
+  // eslint-disable-next-line no-unused-vars
+  animated = true,
+  title = 'Lombriz de tierra',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#c0715a" strokeWidth="7.4" strokeLinecap="round" />
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#ff9d6a" strokeWidth="4.4" strokeLinecap="round" opacity="0.85" />
+      <g stroke="#7a3f2e" strokeWidth="0.9" opacity="0.65" strokeLinecap="round">
+        <path d="M-1.4,22 L1.4,20.5" /><path d="M-1.2,16.5 L2.2,15.5" />
+        <path d="M2.4,11.5 L5.6,11" /><path d="M3.4,5.5 L6.4,5.6" />
+        <path d="M2.8,-0.5 L5.6,-1.4" /><path d="M4.6,-6 L7.4,-7.6" />
+      </g>
+      <path d="M3.2,3 C2,-1 4,-4 6.6,-5" fill="none" stroke="#ffd9b0" strokeWidth="4.6" strokeLinecap="round" opacity="0.75" />
+      <circle cx="12.2" cy="-9.4" r="2.2" fill="#ff9d6a" />
+      <circle cx="13.2" cy="-10" r="0.6" fill="#3a1c12" opacity="0.7" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="lombriz">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="lombriz" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Lombriz;

--- a/src/visual/creatures/Mariposa.jsx
+++ b/src/visual/creatures/Mariposa.jsx
@@ -1,0 +1,76 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Mariposa pasionaria — Dione juno (Nymphalidae, alas largas). Cuatro alas
+   independientes (delanteras + traseras, izq/der) que abren y cierran, cuerpo,
+   cabeza, antenas y ocelos. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-27 -18 54 40';
+
+export function Mariposa({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Mariposa',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const alaL = animated ? 'crt-fwing crt-fwing-l' : undefined;
+  const alaR = animated ? 'crt-fwing crt-fwing-r' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={alaL}>
+        <path d="M0,2 C-13,4 -18,12 -12,15 C-6,17 -1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="-9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,2 C13,4 18,12 12,15 C6,17 1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaL}>
+        <path d="M0,-2 C-16,-11 -24,-6 -22,0 C-20,5 -8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M-20,-3 C-14,-2 -7,-1 -1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="-16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,-2 C16,-11 24,-6 22,0 C20,5 8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M20,-3 C14,-2 7,-1 1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <ellipse cx="0" cy="2" rx="1.7" ry="9" fill="#2a1712" />
+      <circle cx="0" cy="-8" r="1.9" fill="#2a1712" />
+      <path d="M-0.8,-9.4 C-3,-13 -4.5,-14 -6,-13.6 M0.8,-9.4 C3,-13 4.5,-14 6,-13.6"
+        stroke="#2a1712" strokeWidth="0.8" fill="none" strokeLinecap="round" />
+      <circle cx="-6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+      <circle cx="6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="mariposa">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="mariposa" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Mariposa;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -1,0 +1,74 @@
+# `src/visual/creatures` — personajes de fauna reutilizables
+
+Librería de **personajes de fauna de la chagra** como componentes SVG limpios,
+parametrizables y sin dependencias nuevas. Nace para **dejar de redibujar el
+mismo bicho** en cada mockup/escena: hoy el colibrí, la abeja angelita, la
+lombriz, la mariposa y el escarabajo aparecían dibujados por separado en varios
+sitios (`mockups/MockupGuardianesNarrativos`, `dashboard/Scene*`,
+`FincaVivaHero`, `MundoVinetas`, `MundoSubsuelo`, avatares del colibrí…) con
+calidad dispar. Aquí vive la **versión canónica** de cada uno.
+
+## Regla de la casa
+
+> **Antes de dibujar un personaje de fauna, búscalo aquí.**
+> Si existe → **reúsalo** (y si podés, **mejorá** la versión canónica en su
+> archivo, para que todos hereden la mejora).
+> Si dibujás un personaje nuevo reutilizable → **agregalo aquí en el mismo PR**
+> (componente + entrada en `index.js` + fila en esta tabla).
+
+## Personajes
+
+| Componente | Especie (binomio verificado) | Notas |
+|---|---|---|
+| `AbejaAngelita` | *Tetragonisca angustula* | Meliponino nativo **SIN aguijón** — NO *Apis*. Alitas de tul que baten. |
+| `Colibri` | *Colibri coruscans* | Colibrí chillón andino. Pico largo, garganta violeta, alas que baten. |
+| `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
+| `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
+| `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
+
+## Props
+
+Todos comparten la misma firma:
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `size` | `number \| string` | `64` | Ancho/alto en modo standalone (`<svg>`). Ignorado en modo `inline`. |
+| `className` | `string` | — | Clase(s) del nodo raíz. En modo `inline` es donde la escena engancha su coreografía de entrada/posición. |
+| `inline` | `boolean` | `false` | `false` → `<svg>` autónomo (avatares, catálogo, botones). `true` → solo un `<g>` para incrustar en una escena SVG existente. |
+| `animated` | `boolean` | `true` | Activa la vida perpetua (aleteo, alas, bola, patas). `false` = quieto. Siempre reduced-motion-safe. |
+| `title` | `string` | nombre del bicho | `aria-label` + `<title>` accesible. |
+
+Props extra (`...rest`) se pasan al `<svg>` en modo standalone.
+
+## Uso
+
+```jsx
+import { Colibri, AbejaAngelita } from '@/visual/creatures';
+
+// Avatar / catálogo — SVG autónomo:
+<Colibri size={48} title="Colibrí chillón" />
+<AbejaAngelita size={40} animated={false} />
+
+// Dentro de una escena SVG propia (la escena pone posición y entrada):
+<svg viewBox="0 0 340 210">
+  {/* …fondo, suelo… */}
+  <g transform="translate(120 66)">
+    <Colibri inline className="mi-entrada-volando" />
+  </g>
+</svg>
+```
+
+Consumidor de referencia: **`src/mockups/MockupGuardianesNarrativos.jsx`**
+(usa las 5 criaturas en modo `inline`).
+
+## Técnica
+
+- SVG + CSS puros, **cero dependencias nuevas**; solo `transform`/`opacity`
+  (GPU, Android gama baja). Familia visual del glow de `GuardianEspiritu`.
+- Cada instancia genera **ids de filtro únicos** (`useId`), así se pueden
+  repetir muchas criaturas en una misma página sin colisión.
+- La **vida perpetua** vive en `creatures.css` (clases `crt-*`), es intrínseca
+  a la criatura y **reduced-motion-safe** (sin animación → fotograma digno).
+- La **coreografía de LLEGADA** (entrar volando, asomar del suelo, rodar) NO
+  vive aquí: es responsabilidad de la escena que consume la criatura, sobre el
+  `className` del modo `inline`.

--- a/src/visual/creatures/_filters.jsx
+++ b/src/visual/creatures/_filters.jsx
@@ -1,0 +1,23 @@
+/*
+ * Filtro SVG compartido de la familia visual "creatures": glow orgánico
+ * (feGaussianBlur + feMerge) heredado de GuardianEspiritu + blur suave.
+ * Cada criatura instancia estos filtros con ids ÚNICOS (useId) para poder
+ * repetirse muchas veces en una misma página sin colisión de ids.
+ * Interno de la librería — no se exporta desde el barrel.
+ */
+export function CreatureFilters({ glow, blur }) {
+  return (
+    <>
+      <filter id={glow} x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.1" result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      <filter id={blur}>
+        <feGaussianBlur stdDeviation="3" />
+      </filter>
+    </>
+  );
+}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1,0 +1,51 @@
+/* ─── Vida perpetua de las CREATURES — SVG + CSS puros, solo transform/opacity
+   (GPU, Android gama baja). Reutilizable en cualquier escena o avatar.
+   La coreografía de LLEGADA (entrar volando, asomar del suelo) NO vive aquí:
+   es responsabilidad de la escena que consume la criatura.
+   reduced-motion = criatura quieta en un fotograma digno. ─── */
+
+/* aleteo rápido (abeja / colibrí) */
+.crt-wing {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: crt-wingbeat 0.13s ease-in-out infinite alternate;
+}
+@keyframes crt-wingbeat {
+  0% { transform: scaleY(1) scaleX(1); }
+  100% { transform: scaleY(0.6) scaleX(0.9); }
+}
+
+/* alas de mariposa que abren y cierran */
+.crt-fwing {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-flutter 0.5s ease-in-out infinite;
+}
+.crt-fwing-l { transform-origin: right center; }
+.crt-fwing-r { transform-origin: left center; }
+@keyframes crt-flutter {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.4); }
+}
+
+/* bola de abono que rueda (escarabajo) */
+.crt-ball {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-roll 1.1s linear infinite;
+}
+@keyframes crt-roll {
+  0% { transform: rotate(0); }
+  100% { transform: rotate(-360deg); }
+}
+
+/* patas que dan pasos (escarabajo) */
+.crt-legs { animation: crt-step 0.5s ease-in-out infinite; }
+@keyframes crt-step {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-1.2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crt-wing, .crt-fwing, .crt-ball, .crt-legs { animation: none !important; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -1,0 +1,32 @@
+/*
+ * Librería visual de PERSONAJES DE FAUNA de la chagra (creatures).
+ * Fuente única y reutilizable. Antes de dibujar un bicho, búscalo aquí.
+ *
+ * Cada componente:
+ *   - Modo standalone (por defecto): renderiza su propio <svg> con viewBox,
+ *     dimensionado por `size` — ideal para avatares, catálogo, botones.
+ *   - Modo `inline`: renderiza solo el <g> para incrustarse en una escena SVG
+ *     que ya define su viewBox y su coreografía de entrada/posición.
+ *
+ * Props comunes: { size, className, inline, animated, title }.
+ */
+export { AbejaAngelita } from './AbejaAngelita.jsx';
+export { Colibri } from './Colibri.jsx';
+export { Lombriz } from './Lombriz.jsx';
+export { Mariposa } from './Mariposa.jsx';
+export { Escarabajo } from './Escarabajo.jsx';
+
+import AbejaAngelita from './AbejaAngelita.jsx';
+import Colibri from './Colibri.jsx';
+import Lombriz from './Lombriz.jsx';
+import Mariposa from './Mariposa.jsx';
+import Escarabajo from './Escarabajo.jsx';
+
+/* Registro consultable: slug → componente + binomio verificado. */
+export const CREATURES = {
+  'abeja-angelita': { Component: AbejaAngelita, nombre: 'Abeja angelita', cientifico: 'Tetragonisca angustula' },
+  colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
+  lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
+  mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
+  escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },
+};


### PR DESCRIPTION
## Ronda 2 — auditoría UX campesina de los "mundos" a medias

Segunda pasada sobre las pantallas temáticas ("mundos") que seguían "a medias" tras la ronda 1 (Suelo/Agua/Cítricos ya pulidos). El foco fue **cerrar el eje de tono** (voz partida usted/tú → usted cordial colombiano) y **dar vida visual** a los screens "de dato" sin ilustración. Cambios quirúrgicos de lenguaje y presentación: **no se toca ninguna cifra, dosis, fórmula ni contenido groundeado**.

### Cómo se auditó
Recorrido por código de `src/components/dashboard/mundosFinca.js` (15 mundos) y sus screens/data. Hallazgo transversal (confirmado por doble auditoría independiente): **voseo = 0**; la deuda real era **tuteo suelto** en varios screens y unos pocos **muros de dato sin ilustración**. Los 12 mundos-cultivo dedicados (café, aguacate, caña, mango, cítricos, botica, uchuva, quinua, fique, frutales, milpa, aromáticas) ya son photo-forward y quedaron **BIEN** — no se tocaron.

### Mundos auditados y veredicto
| Mundo / screen | Veredicto | Acción |
|---|---|---|
| Cromatografía (Suelo) | A MEDIAS | **Tocado** |
| Vacas (Animales) | A MEDIAS | **Tocado** |
| Gallinas (Animales) | A MEDIAS | **Tocado** |
| Toxicología (Sanidad) | A MEDIAS | **Tocado** |
| Ciclo de nutrientes (Suelo) | A MEDIAS | **Tocado** |
| Nutrición humana (Mercado) | A MEDIAS | **Tocado** |
| Asociaciones (Diseño) | A MEDIAS | **Tocado** |
| Café/Aguacate/Caña/Mango/Cítricos/Botica/Uchuva/Quinua/Fique/Frutales/Milpa/Aromáticas | BIEN | No tocado (photo-forward) |
| Conejos/Caprinos/Abejas/Compost/Estiércol/Almacenamiento/Poscosecha/Germinación/Restauración | BIEN | No tocado |

### Qué se tocó y qué fix (P0/P1)

**Cromatografía** (`CromatografiaScreen.jsx`) — Suelo
- **P0 tono/ortografía**: todo el bloque educativo (materiales, 5 pasos, precauciones, zonas, colores) estaba en **tuteo y sin tildes**, chocando con la UI nueva en usted. Pasado a **usted con tildes** ("ponga/aplique/deje/mezcle/agite/use/lávese…"). Sin cambiar química, dosis ni seguridad.
- **P1 jerga**: zonas renombradas de "proteica-húmica/enzimática" a lenguaje campesino: **"anillo del centro (los minerales)", "anillo del medio (la materia orgánica y el humus)", "anillo del borde (la vida y los microbios)"**.

**Vacas** (`VacasScreen.jsx`) y **Gallinas** (`GallinasScreen.jsx`) — Animales
- **P1 vida visual**: eran los únicos muros sin foto del módulo. Se cableó el **hero photo-forward `FotoAnimal`** (fotos `vacas.jpg`/`gallinas.jpg` que **ya existían en `public/animales` con crédito CC** pero nunca se usaban), igual que sus hermanos Conejos/Caprinos.
- **P0 tono**: voz partida tú→**usted** en todo el screen ("le dan/anote/consulte/mueva/avise/recoja/deles/madúrela…").
- **P1 jerga**: gloss de "coccidiostato" → "el remedio contra la coccidiosis".

**Toxicología** (`ToxicologiaScreen.jsx`) — Sanidad · **Nutrición** (`NutricionHumanaScreen.jsx`) — Mercado · **Asociaciones** (`Asociaciones.jsx`) — Diseño
- **P0 tono**: tuteo → usted ("revise/manéjelo/responda/le diremos/le da/elija/descubra/pruebe/¿qué cultivo quiere planear?/detectado en su finca…").

**Ciclo de nutrientes** (`CicloNutrientesScreen.jsx`) — Suelo
- **P1 vida visual (reuso de librería)**: era emoji puro. Se añadió la **creature `Lombriz`** (la que hace tierra) como ilustración de la intro.
- **P1 muro de texto**: el bloque "Ojo" (~7 líneas densas) partido en **entradilla + 3 bullets**.
- **P1 jerga**: gloss de "vegetativo" → "cuando la mata está echando hojas".

**Data de mundos**: `mundosFinca.js` (tarjeta Mercado "qué **le da de** comer") y `toxicologia-suelo.js` (resúmenes/notas del cuestionario del mundo Sanidad) — tuteo → usted.

### Reuso de la librería visual
- **`FotoAnimal`** + fotos ya presentes en `public/animales` (Vacas, Gallinas): 0 assets nuevos.
- **`src/visual/creatures`** incorporado verbatim de su rama (`feat/visual-lib-creatures`); se usa la creature **`Lombriz`** en Ciclo de nutrientes. SVG self-contained, sin dependencias ni imágenes externas.

### Verificación
- `npm run build` ✅ verde.
- `npm run tsc:check` ✅ **868** (= baseline, 0 errores de tipo nuevos).
- `npx eslint` ✅ limpio en todos los archivos tocados + `src/visual/creatures`.
- `Asociaciones.test.jsx` actualizado al nuevo tono → **15/15**. Ningún otro test asserta strings cambiados.
- Hook `voseo-scan` ✅ (sin voseo).

### Fuera de alcance (follow-up)
- Tuteo en `src/data/ayudaFunciones.js` (copy del sistema de **Ayuda**, no es un mundo) — anotado, no tocado para mantener el PR on-theme.
- Glosar MIP/HLB/antracnosis/Fusarium en los screens de cultivo ya ricos — amplio y de bajo riesgo/beneficio; se deja para otra pasada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
