### PR TITLE
feat(mockup): mercado.chagra.bio ronda 2 — detalle profundo, señales de confianza y orden por cercanía

### DIFF
--- a/src/mockups/Mercado.jsx
+++ b/src/mockups/Mercado.jsx
@@ -4,14 +4,14 @@
  * src/config/messages.js — mismo criterio que los otros mockups de la galería.
  */
 import { useEffect, useState } from 'react';
-import { ArrowLeft, X, Mountain, MapPin, Sprout, ShieldCheck, ScrollText } from 'lucide-react';
+import { ArrowLeft, X, Mountain, MapPin, Sprout, Leaf, ShieldCheck, ScrollText, PenLine } from 'lucide-react';
 import { Colibri } from '../visual/creatures/Colibri.jsx';
 import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
 import { Mariposa } from '../visual/creatures/Mariposa.jsx';
 import { Rostro } from './mercado/Rostro.jsx';
 import { ProductoIlustracion } from './mercado/ProductoIlustracion.jsx';
 import { CintaAltitud } from './mercado/CintaAltitud.jsx';
-import { PRODUCTOS, pisoDeAltitud, pesos } from './mercado/datos.js';
+import { PRODUCTOS, pisoDeAltitud, pesos, fincasUnicas } from './mercado/datos.js';
 import '../visual/effects/effects.css';
 import '../visual/creatures/creatures.css';
 import './mercado.css';
@@ -36,29 +36,33 @@ import './mercado.css';
  */
 export default function Mercado({ onBack }) {
   const [piso, setPiso] = useState('todos');
+  const [orden, setOrden] = useState('montana');
   const [abierta, setAbierta] = useState(null);
 
-  // Fincas para la cinta de altitud (1 finca por producto en el muestreo).
-  const fincas = PRODUCTOS.map((p) => ({
-    id: p.id,
-    nombre: p.finca.nombre,
-    productor: p.finca.productor,
-    altitud: p.finca.altitud,
-    rostro: p.finca.rostro,
-  }));
+  // Fincas ÚNICAS para la cinta de altitud (una finca puede tener 2 productos;
+  // el pin abre el primero).
+  const fincas = fincasUnicas();
 
   // Pisos térmicos presentes, de más alto a más templado, para los filtros.
   const pisosPresentes = [];
-  for (const orden of ['paramo', 'frio', 'templado']) {
-    if (PRODUCTOS.some((p) => pisoDeAltitud(p.finca.altitud).slug === orden)) {
-      pisosPresentes.push(pisoDeAltitud(PRODUCTOS.find((p) => pisoDeAltitud(p.finca.altitud).slug === orden).finca.altitud));
+  for (const slug of ['paramo', 'frio', 'templado']) {
+    if (PRODUCTOS.some((p) => pisoDeAltitud(p.finca.altitud).slug === slug)) {
+      pisosPresentes.push(pisoDeAltitud(PRODUCTOS.find((p) => pisoDeAltitud(p.finca.altitud).slug === slug).finca.altitud));
     }
   }
 
-  const visibles =
+  const filtrados =
     piso === 'todos'
       ? PRODUCTOS
       : PRODUCTOS.filter((p) => pisoDeAltitud(p.finca.altitud).slug === piso);
+
+  // Orden: "de la montaña abajo" (altitud, como se lee la cinta) o "más cerca
+  // de usted primero" (km reales, la señal de cercanía).
+  const visibles = [...filtrados].sort((a, b) =>
+    orden === 'cerca'
+      ? a.finca.distanciaKm - b.finca.distanciaKm
+      : b.finca.altitud - a.finca.altitud,
+  );
 
   const productoAbierto = PRODUCTOS.find((p) => p.id === abierta) || null;
 
@@ -103,11 +107,16 @@ export default function Mercado({ onBack }) {
         </div>
         <div className="mrc-hero__monte">
           <Colibri size={44} className="mrc-colibri" title="Colibrí de la montaña" />
-          <CintaAltitud fincas={fincas} onSelect={setAbierta} />
+          <CintaAltitud
+            fincas={fincas}
+            onSelect={setAbierta}
+            pisoFiltro={piso === 'todos' ? null : piso}
+          />
         </div>
       </section>
 
-      {/* ── FILTRO por piso térmico ───────────────────────────────────────── */}
+      {/* ── FILTRO por piso térmico (la cinta de arriba reacciona: atenúa las
+             fincas de otros pisos) + ORDEN ─────────────────────────────────── */}
       <div className="mrc-filtros" role="group" aria-label="Filtrar por piso térmico">
         <button
           type="button"
@@ -115,7 +124,7 @@ export default function Mercado({ onBack }) {
           onClick={() => setPiso('todos')}
           aria-pressed={piso === 'todos'}
         >
-          Todos
+          Toda la montaña
         </button>
         {pisosPresentes.map((p) => (
           <button
@@ -128,8 +137,29 @@ export default function Mercado({ onBack }) {
           >
             <span className="mrc-chip__punto" aria-hidden="true" />
             {p.nombre}
+            <span className="mrc-chip__rango">{p.rango}</span>
           </button>
         ))}
+      </div>
+
+      <div className="mrc-orden" role="group" aria-label="Ordenar los productos">
+        <span className="mrc-orden__rotulo">Ordenar:</span>
+        <button
+          type="button"
+          className={`mrc-orden__opt${orden === 'montana' ? ' is-on' : ''}`}
+          onClick={() => setOrden('montana')}
+          aria-pressed={orden === 'montana'}
+        >
+          <Mountain size={13} aria-hidden="true" /> De la montaña abajo
+        </button>
+        <button
+          type="button"
+          className={`mrc-orden__opt${orden === 'cerca' ? ' is-on' : ''}`}
+          onClick={() => setOrden('cerca')}
+          aria-pressed={orden === 'cerca'}
+        >
+          <MapPin size={13} aria-hidden="true" /> Más cerca de usted
+        </button>
       </div>
 
       {/* ── GRILLA de productos ───────────────────────────────────────────── */}
@@ -144,7 +174,13 @@ export default function Mercado({ onBack }) {
       </footer>
 
       {productoAbierto && (
-        <Historia producto={productoAbierto} fincas={fincas} onCerrar={() => setAbierta(null)} onVerFinca={setAbierta} />
+        <Historia
+          key={productoAbierto.id}
+          producto={productoAbierto}
+          fincas={fincas}
+          onCerrar={() => setAbierta(null)}
+          onVerFinca={setAbierta}
+        />
       )}
     </div>
   );
@@ -187,10 +223,16 @@ function ProductoCard({ producto, onAbrir }) {
           </span>
         </button>
 
+        {/* Señales de confianza: estampa roja = lo DECLARA la finca; tinta con
+            alfiler = dato medible (los km hasta usted). No se mezclan. */}
         <ul className="mrc-sellos">
           {producto.sellos.map((s) => (
             <SelloEstampa key={s} texto={s} />
           ))}
+          <li className="mrc-km">
+            <MapPin size={12} aria-hidden="true" />
+            <span>a {finca.distanciaKm} km de usted</span>
+          </li>
         </ul>
       </div>
     </article>
@@ -211,6 +253,10 @@ function SelloEstampa({ texto, grande = false }) {
 function Historia({ producto, fincas, onCerrar, onVerFinca }) {
   const { finca } = producto;
   const piso = pisoDeAltitud(finca.altitud);
+  // Otros productos de ESTA misma finca (El Rocío y Los Helechos tienen dos).
+  const delMismoTecho = PRODUCTOS.filter(
+    (p) => p.finca.nombre === finca.nombre && p.id !== producto.id,
+  );
   return (
     <div className="mrc-modal" role="dialog" aria-modal="true" aria-label={`Historia de ${finca.nombre}`}>
       <button type="button" className="mrc-modal__fondo" aria-label="Cerrar" onClick={onCerrar} />
@@ -237,7 +283,7 @@ function Historia({ producto, fincas, onCerrar, onVerFinca }) {
               <p className="mrc-fincahead__quien">{finca.productor}</p>
               <h2 className="mrc-fincahead__finca">{finca.nombre}</h2>
               <p className="mrc-fincahead__ubi">
-                <MapPin size={13} aria-hidden="true" /> vereda {finca.vereda}
+                <MapPin size={13} aria-hidden="true" /> vereda {finca.vereda} · a {finca.distanciaKm} km de usted
               </p>
               <p className="mrc-fincahead__alt">
                 <Mountain size={13} aria-hidden="true" />
@@ -267,16 +313,33 @@ function Historia({ producto, fincas, onCerrar, onVerFinca }) {
             {producto.historia}
           </p>
 
-          {/* Sellos de confianza, grandes */}
+          {/* Sellos de confianza, grandes + los km (dato medible, en tinta) */}
           <ul className="mrc-sellos mrc-sellos--g">
             {producto.sellos.map((s) => (
               <SelloEstampa key={s} texto={s} grande />
             ))}
+            <li className="mrc-km mrc-km--g">
+              <MapPin size={14} aria-hidden="true" />
+              <span>a {finca.distanciaKm} km de usted</span>
+            </li>
           </ul>
+
+          {/* Cómo se cultivó: la versión estructurada de la historia, por frentes */}
+          <div className="mrc-como">
+            <p className="mrc-traza__tit"><Leaf size={15} aria-hidden="true" /> Cómo se cultivó</p>
+            <ul className="mrc-como__lista">
+              {producto.practicas.map((pr) => (
+                <li key={pr.que} className="mrc-como__item">
+                  <span className="mrc-como__que">{pr.que}</span>
+                  <span className="mrc-como__detalle">{pr.como}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
 
           {/* Trazabilidad: hitos de la cosecha, fechas en altímetro monoespaciado */}
           <div className="mrc-traza">
-            <p className="mrc-traza__tit"><Sprout size={15} aria-hidden="true" /> Cómo se dio esta cosecha</p>
+            <p className="mrc-traza__tit"><Sprout size={15} aria-hidden="true" /> De la mata a su mesa</p>
             <ol className="mrc-traza__linea">
               {producto.trazabilidad.map((t, i) => (
                 <li key={t.hito} className={`mrc-traza__hito${i === producto.trazabilidad.length - 1 ? ' is-fin' : ''}`}>
@@ -288,12 +351,43 @@ function Historia({ producto, fincas, onCerrar, onVerFinca }) {
                 </li>
               ))}
             </ol>
+            <p className="mrc-traza__mesa">{producto.mataAMesa}</p>
           </div>
+
+          {/* La palabra de la finca: honestidad sin postureo — aquí no hay
+              certificado de laboratorio, hay nombre, cara y fecha. */}
+          <p className="mrc-palabra">
+            <PenLine size={14} aria-hidden="true" className="mrc-palabra__ico" />
+            Aquí no hay sello de laboratorio. Lo que usted lee es la palabra de{' '}
+            {finca.productor}, con nombre, finca y fecha. Y la finca queda a{' '}
+            {finca.distanciaKm} km: si quiere, puede ir y verlo con sus propios ojos.
+          </p>
+
+          {/* Otros productos de la misma finca */}
+          {delMismoTecho.length > 0 && (
+            <div className="mrc-tambien">
+              <p className="mrc-traza__tit"><Sprout size={15} aria-hidden="true" /> También de {finca.nombre}</p>
+              <div className="mrc-tambien__fila">
+                {delMismoTecho.map((p) => (
+                  <button
+                    key={p.id}
+                    type="button"
+                    className="mrc-tambien__card"
+                    onClick={() => onVerFinca(p.id)}
+                  >
+                    <ProductoIlustracion tipo={p.ilustracion} size={54} title={p.nombre} />
+                    <span className="mrc-tambien__nombre">{p.nombre}</span>
+                    <span className="mrc-tambien__precio">{pesos(p.precio)} / {p.unidad}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Dónde queda en la montaña: reusa la cinta, con esta finca resaltada */}
           <div className="mrc-donde">
             <p className="mrc-donde__tit"><Mountain size={15} aria-hidden="true" /> Dónde queda en la montaña</p>
-            <CintaAltitud fincas={fincas} activaId={producto.id} onSelect={onVerFinca} />
+            <CintaAltitud fincas={fincas} activaId={finca.nombre} onSelect={onVerFinca} />
           </div>
         </div>
       </div>

--- a/src/mockups/mercado.css
+++ b/src/mockups/mercado.css
@@ -281,6 +281,51 @@
   color: #f4ecd9;
 }
 .mrc-chip.is-on .mrc-chip__punto { box-shadow: 0 0 0 2px rgba(244, 236, 217, 0.35); }
+.mrc-chip__rango {
+  font-family: var(--mrc-mono);
+  font-size: 0.62rem;
+  color: var(--mrc-tinta-2);
+}
+.mrc-chip.is-on .mrc-chip__rango { color: rgba(244, 236, 217, 0.75); }
+
+/* ── ORDEN (de la montaña abajo / más cerca de usted) ────────────────────── */
+.mrc-orden {
+  max-width: 660px;
+  margin: 6px auto 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+}
+.mrc-orden__rotulo {
+  font-family: var(--mrc-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mrc-tinta-2);
+}
+.mrc-orden__opt {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 11px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--mrc-tinta-2);
+  font-family: var(--mrc-sans);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.mrc-orden__opt svg { color: currentColor; }
+.mrc-orden__opt:hover { border-color: rgba(44, 36, 24, 0.32); color: var(--mrc-tinta); }
+.mrc-orden__opt.is-on {
+  background: rgba(47, 82, 51, 0.12);
+  border-color: var(--mrc-monte);
+  color: var(--mrc-monte);
+  font-weight: 600;
+}
 
 /* ── GRILLA de productos ─────────────────────────────────────────────────── */
 .mrc-grid {
@@ -427,6 +472,24 @@
 .mrc-sello:nth-child(even) { transform: rotate(1.1deg); }
 .mrc-sello svg { flex: 0 0 auto; }
 .mrc-sello--g { font-size: 0.72rem; padding: 5px 11px; }
+
+/* dato MEDIBLE (km hasta usted): tinta y derecho, sin la inclinación de la
+   estampa — lo declarado se estampa, lo medido se anota. */
+.mrc-km {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border: 1px solid rgba(44, 36, 24, 0.4);
+  border-radius: 7px;
+  color: var(--mrc-tinta);
+  font-family: var(--mrc-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.01em;
+  background: rgba(255, 255, 255, 0.35);
+}
+.mrc-km svg { flex: 0 0 auto; color: var(--mrc-monte); }
+.mrc-km--g { font-size: 0.72rem; padding: 5px 11px; }
 
 /* ── PIE ─────────────────────────────────────────────────────────────────── */
 .mrc-pie {
@@ -629,6 +692,27 @@
   color: var(--mrc-monte);
 }
 
+/* cómo se cultivó (prácticas por frentes) */
+.mrc-como {
+  padding: 14px 15px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 13px;
+  background: rgba(47, 82, 51, 0.06);
+}
+.mrc-como__lista { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 9px; }
+.mrc-como__item { display: flex; gap: 10px; align-items: baseline; }
+.mrc-como__que {
+  flex: 0 0 auto;
+  min-width: 86px;
+  font-family: var(--mrc-mono);
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--mrc-monte);
+}
+.mrc-como__detalle { font-size: 0.88rem; line-height: 1.45; color: var(--mrc-tinta); }
+
 /* trazabilidad */
 .mrc-traza {
   padding: 14px 15px;
@@ -683,6 +767,54 @@
 .mrc-traza__hitotxt { display: flex; flex-direction: column; gap: 1px; }
 .mrc-traza__que { font-family: var(--mrc-serif); font-size: 0.92rem; color: var(--mrc-tinta); }
 .mrc-traza__cuando { font-family: var(--mrc-mono); font-size: 0.72rem; color: var(--mrc-tinta-2); }
+.mrc-traza__mesa {
+  margin: 4px 0 0;
+  padding-top: 10px;
+  border-top: 1px dashed var(--mrc-linea);
+  font-family: var(--mrc-serif);
+  font-style: italic;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: var(--mrc-tinta);
+}
+
+/* la palabra de la finca (nota de honestidad, manuscrita al margen) */
+.mrc-palabra {
+  position: relative;
+  margin: 0;
+  padding: 11px 13px 11px 34px;
+  border-left: 3px solid var(--mrc-sello);
+  border-radius: 0 10px 10px 0;
+  background: rgba(165, 67, 42, 0.06);
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--mrc-tinta);
+}
+.mrc-palabra__ico { position: absolute; left: 11px; top: 13px; color: var(--mrc-sello); }
+
+/* también de esta finca */
+.mrc-tambien__fila { display: flex; flex-wrap: wrap; gap: 10px; }
+.mrc-tambien__card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  min-width: 118px;
+  padding: 10px 12px;
+  border: 1px solid var(--mrc-linea);
+  border-radius: 12px;
+  background: var(--mrc-tarjeta);
+  cursor: pointer;
+  text-align: center;
+}
+.mrc-tambien__card:hover { background: rgba(255, 255, 255, 0.7); }
+.mrc-tambien__nombre {
+  font-family: var(--mrc-serif);
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--mrc-tinta);
+}
+.mrc-tambien__precio { font-family: var(--mrc-mono); font-size: 0.68rem; color: var(--mrc-tinta-2); }
 
 /* dónde queda en la montaña */
 .mrc-donde .mrc-cinta { height: clamp(320px, 78vw, 400px); }
@@ -693,6 +825,13 @@
 }
 
 /* ── responsive ──────────────────────────────────────────────────────────── */
+/* 320px: los chips de piso pierden el rango en metros (queda el punto de color
+   y el nombre) y el rótulo de orden pasa a su propia línea. */
+@media (max-width: 379px) {
+  .mrc-chip__rango { display: none; }
+  .mrc-orden__rotulo { flex-basis: 100%; }
+  .mrc-como__que { min-width: 72px; }
+}
 @media (min-width: 560px) {
   .mrc-grid { grid-template-columns: 1fr 1fr; }
 }
@@ -716,7 +855,8 @@
 @media (prefers-reduced-motion: reduce) {
   .mrc-modal { animation: none; }
   .mrc-pin__cara,
-  .mrc-chip { transition: none; }
+  .mrc-chip,
+  .mrc-orden__opt { transition: none; }
   .mrc-pin:hover .mrc-pin__cara,
   .mrc-pin:focus-visible .mrc-pin__cara { transform: none; }
 }

--- a/src/mockups/mercado/CintaAltitud.jsx
+++ b/src/mockups/mercado/CintaAltitud.jsx
@@ -13,10 +13,13 @@ import { ALTITUD_MIN, ALTITUD_MAX, pisoDeAltitud } from './datos.js';
  *   - Enfoque (historia): una finca resaltada, las demás de contexto tenue.
  *
  * Props:
- *   fincas    [{ id, nombre, productor, altitud, rostro }]
- *   activaId  id de la finca resaltada, o null (panorama).
- *   onSelect  (id) => void — al tocar un pin.
- *   ticks     metros a marcar en el eje. Defecto [3000,2500,2000,1500].
+ *   fincas      [{ id, nombre, productor, altitud, rostro, productoId? }]
+ *   activaId    id de la finca resaltada, o null (panorama).
+ *   onSelect    (id) => void — al tocar un pin. Recibe `productoId` si la finca
+ *               lo trae (fincas agrupadas), o `id` si no.
+ *   pisoFiltro  slug de piso térmico activo o null: los pines de otros pisos se
+ *               atenúan — la cinta ES la navegación del filtro.
+ *   ticks       metros a marcar en el eje. Defecto [3000,2500,2000,1500].
  */
 const BANDA_TOP = 7; // % desde arriba donde empieza la banda útil
 const BANDA_ALTO = 84; // % de alto útil
@@ -30,6 +33,7 @@ export function CintaAltitud({
   fincas,
   activaId = null,
   onSelect,
+  pisoFiltro = null,
   ticks = [3000, 2500, 2000, 1500],
 }) {
   // De más alto a más bajo, para asignar carriles alternos (izq/der) y que dos
@@ -62,15 +66,16 @@ export function CintaAltitud({
       {ordenadas.map((f, i) => {
         const lado = i % 2 === 0 ? 'izq' : 'der';
         const activa = activaId === f.id;
-        const atenua = activaId != null && !activa;
         const piso = pisoDeAltitud(f.altitud);
+        const fueraDePiso = pisoFiltro != null && piso.slug !== pisoFiltro;
+        const atenua = (activaId != null && !activa) || fueraDePiso;
         return (
           <button
             key={f.id}
             type="button"
             className={`mrc-pin mrc-pin--${lado}${activa ? ' is-activa' : ''}${atenua ? ' is-atenua' : ''}`}
             style={{ top: `${porcentajeAltitud(f.altitud)}%`, '--pin-piso': piso.hex }}
-            onClick={() => onSelect && onSelect(f.id)}
+            onClick={() => onSelect && onSelect(f.productoId ?? f.id)}
             aria-label={`${f.nombre}, a ${f.altitud.toLocaleString('es-CO')} metros, piso ${piso.nombre}`}
             aria-pressed={activa}
           >

--- a/src/mockups/mercado/ProductoIlustracion.jsx
+++ b/src/mockups/mercado/ProductoIlustracion.jsx
@@ -5,7 +5,8 @@
  * 0 0 120 120 y se centra solo.
  *
  * Props:
- *   tipo   'tomate' | 'mora' | 'papa' | 'cafe' | 'miel' | 'aguacate'
+ *   tipo   'tomate' | 'mora' | 'papa' | 'cafe' | 'miel' | 'aguacate' |
+ *          'cilantro' | 'haba'
  *   size   número (px). Defecto 120.
  *   className, title.
  */
@@ -117,6 +118,72 @@ const DIBUJOS = {
       <ellipse cx="60" cy="78" rx="13" ry="15" fill="#8a5a2c" />
       <ellipse cx="56" cy="74" rx="5" ry="6" fill="#a5723a" opacity="0.7" />
       <path d="M46,58 C50,54 54,52 58,52" stroke="#e6ee9a" strokeWidth="3" strokeLinecap="round" fill="none" opacity="0.7" />
+    </g>
+  ),
+  cilantro: (
+    <g>
+      <ellipse cx="60" cy="102" rx="26" ry="5" fill="#2c2418" opacity="0.12" />
+      {/* amarre del atado */}
+      <path d="M48,84 q12,6 24,0 l-2,8 q-10,5 -20,0 Z" fill="#c9a26a" />
+      <path d="M50,88 q10,5 20,0" stroke="#a8781f" strokeWidth="1.6" fill="none" opacity="0.7" />
+      {/* tallos */}
+      <g stroke="#4a8f3a" strokeWidth="3" strokeLinecap="round" fill="none">
+        <path d="M56,86 C54,70 50,56 42,44" />
+        <path d="M60,86 C60,68 60,52 60,38" />
+        <path d="M64,86 C66,70 70,56 78,44" />
+        <path d="M58,86 C55,72 50,62 46,56" opacity="0.7" />
+        <path d="M62,86 C65,72 70,62 74,56" opacity="0.7" />
+      </g>
+      {/* hojas: matas redondeadas de cilantro */}
+      <g fill="#3f7f3a">
+        <circle cx="40" cy="40" r="9" />
+        <circle cx="31" cy="46" r="7" />
+        <circle cx="48" cy="34" r="8" />
+        <circle cx="60" cy="30" r="9" />
+        <circle cx="52" cy="24" r="7" />
+        <circle cx="68" cy="24" r="7" />
+        <circle cx="72" cy="36" r="8" />
+        <circle cx="80" cy="40" r="9" />
+        <circle cx="88" cy="47" r="7" />
+        <circle cx="45" cy="52" r="7" />
+        <circle cx="75" cy="52" r="7" />
+      </g>
+      <g fill="#6fae4a" opacity="0.85">
+        <circle cx="44" cy="37" r="4" />
+        <circle cx="58" cy="27" r="4" />
+        <circle cx="70" cy="30" r="3.6" />
+        <circle cx="78" cy="43" r="4" />
+        <circle cx="36" cy="45" r="3.4" />
+      </g>
+      {/* raíces: cortado con raíz para que dure */}
+      <g stroke="#c9a26a" strokeWidth="2" strokeLinecap="round" fill="none">
+        <path d="M57,94 q-3,5 -6,7" />
+        <path d="M60,95 q0,5 1,8" />
+        <path d="M63,94 q3,5 6,6" />
+      </g>
+    </g>
+  ),
+  haba: (
+    <g>
+      <ellipse cx="60" cy="100" rx="32" ry="5" fill="#2c2418" opacity="0.12" />
+      {/* vaina de atrás */}
+      <path d="M30,42 C46,36 74,44 86,62 C90,68 88,74 82,74 C62,74 40,64 30,50 C27,46 27,43 30,42 Z" fill="#5a9a44" transform="rotate(9 58 58)" opacity="0.85" />
+      {/* vaina principal, gorda y en curva */}
+      <path d="M26,58 C42,50 74,56 88,76 C93,83 90,90 83,89 C60,88 38,80 27,66 C23,61 23,59 26,58 Z" fill="#6fae4a" />
+      {/* grano insinuado dentro de la vaina */}
+      <g fill="#8ec464" opacity="0.9">
+        <ellipse cx="43" cy="66" rx="8" ry="7" />
+        <ellipse cx="60" cy="71" rx="9" ry="7.5" />
+        <ellipse cx="77" cy="78" rx="8" ry="7" />
+      </g>
+      <path d="M28,60 C44,54 72,60 85,77" stroke="#4a8f3a" strokeWidth="2" fill="none" opacity="0.6" />
+      {/* pedúnculo */}
+      <path d="M26,58 C22,52 20,46 22,40" stroke="#3f7f3a" strokeWidth="3.4" strokeLinecap="round" fill="none" />
+      {/* dos granos sueltos, desgranados */}
+      <ellipse cx="88" cy="46" rx="10" ry="8" fill="#b9d47e" transform="rotate(-14 88 46)" />
+      <path d="M80,44 q3,-3 7,-3" stroke="#8aa653" strokeWidth="2" fill="none" strokeLinecap="round" />
+      <ellipse cx="74" cy="32" rx="9" ry="7" fill="#c8dd90" transform="rotate(10 74 32)" />
+      <path d="M67,31 q3,-3 6,-3" stroke="#9ab264" strokeWidth="2" fill="none" strokeLinecap="round" />
     </g>
   ),
 };

--- a/src/mockups/mercado/datos.js
+++ b/src/mockups/mercado/datos.js
@@ -42,8 +42,16 @@ export function pisoDeAltitud(altitud) {
  * - `rostro`: semilla del avatar del productor (Rostro) — cara ilustrada, no
  *   foto; genérica y ficticia.
  * - `precio`/`unidad`: se muestran como "$ 4.800 / libra".
- * - `sellos`: sellos de confianza cortos (rótulo de estampa).
+ * - `sellos`: sellos de confianza cortos (rótulo de estampa) — lo que la finca
+ *   DECLARA. La distancia (`finca.distanciaKm`) va aparte: es dato medible,
+ *   no declaración, y se pinta distinto.
+ * - `practicas`: cómo se cultivó, por frentes ({ que, como }) — la versión
+ *   estructurada de la historia, para leer de un vistazo.
  * - `trazabilidad`: hitos de la cosecha, en orden.
+ * - `mataAMesa`: cuánto pasó entre cosecha y entrega, dicho en plata blanca.
+ *
+ * Dos fincas tienen MÁS de un producto (El Rocío, Los Helechos): así el
+ * detalle puede mostrar "también de esta finca" y el pin de la cinta agrupa.
  */
 export const PRODUCTOS = [
   {
@@ -57,10 +65,16 @@ export const PRODUCTOS = [
       nombre: 'Finca El Rocío',
       vereda: 'La Esperanza',
       altitud: 2180,
+      distanciaKm: 12,
       productor: 'Doña Emilia',
       rostro: { piel: '#c98a5e', pelo: '#3a2a1c', tocado: 'panuelo', tocadoColor: '#b8452e' },
     },
     sellos: ['Sembrado sin químicos', 'Cosechado el 8 de julio'],
+    practicas: [
+      { que: 'Abono', como: 'compost de las camas de la propia finca' },
+      { que: 'Riego', como: 'agua de la quebrada que baja del alto' },
+      { que: 'Plagas', como: 'preparados de ají y ceniza, sin plaguicidas de síntesis' },
+    ],
     historia:
       'En El Rocío el tomate se deja madurar en la mata, no en la bodega. Doña Emilia lo abona con el compost de sus propias camas y lo riega con el agua de la quebrada que baja del alto. Por eso llega blando, oloroso y con el color parejo del que maduró al sol.',
     trazabilidad: [
@@ -69,6 +83,37 @@ export const PRODUCTOS = [
       { hito: 'Deshierbado a mano', fecha: '10 de junio' },
       { hito: 'Cosechado', fecha: '8 de julio' },
     ],
+    mataAMesa: 'Cosechado el miércoles, entregado el viernes: 2 días de la mata a su mesa.',
+  },
+  {
+    id: 'cilantro-rocio',
+    nombre: 'Cilantro',
+    variedad: 'en rama, cortado el día del despacho',
+    ilustracion: 'cilantro',
+    precio: 1800,
+    unidad: 'atado',
+    finca: {
+      nombre: 'Finca El Rocío',
+      vereda: 'La Esperanza',
+      altitud: 2180,
+      distanciaKm: 12,
+      productor: 'Doña Emilia',
+      rostro: { piel: '#c98a5e', pelo: '#3a2a1c', tocado: 'panuelo', tocadoColor: '#b8452e' },
+    },
+    sellos: ['Sembrado sin químicos', 'Cortado el 10 de julio'],
+    practicas: [
+      { que: 'Siembra', como: 'escalonada cada quince días, para que nunca falte' },
+      { que: 'Deshierbe', como: 'a mano, entre las mismas camas del tomate' },
+      { que: 'Corte', como: 'la madrugada del despacho, con raíz para que dure' },
+    ],
+    historia:
+      'El cilantro de El Rocío crece entre las camas del tomate, donde aprovecha el mismo compost. Doña Emilia lo corta de madrugada, con raíz y todo, el mismo día que lo despacha. Por eso llega erguido y oloroso, no acostado y amarillo como el que dio muchas vueltas.',
+    trazabilidad: [
+      { hito: 'Sembrado escalonado', fecha: '12 de junio' },
+      { hito: 'Deshierbado a mano', fecha: '28 de junio' },
+      { hito: 'Cortado con raíz', fecha: '10 de julio' },
+    ],
+    mataAMesa: 'Cortado de madrugada y entregado el mismo día: 0 días de espera.',
   },
   {
     id: 'mora-castilla',
@@ -81,10 +126,16 @@ export const PRODUCTOS = [
       nombre: 'Finca La Cabaña',
       vereda: 'El Retiro',
       altitud: 2640,
+      distanciaKm: 18,
       productor: 'Don Aurelio',
       rostro: { piel: '#8a5a38', pelo: '#20140c', tocado: 'sombrero', tocadoColor: '#c9a26a' },
     },
     sellos: ['Recolección a mano', 'Cosechada el 9 de julio'],
+    practicas: [
+      { que: 'Poda', como: 'de la mata en marzo, para que la fruta salga pareja' },
+      { que: 'Abono', como: 'gallinaza compostada, nada de químicos de bulto' },
+      { que: 'Recolección', como: 'a mano, una por una, solo la que está negra pareja' },
+    ],
     historia:
       'La mora de La Cabaña crece en el filo, donde el frío la pone dulce y firme. Don Aurelio la recoge una por una, solo la que ya está negra pareja, para que no llegue verde ni magullada. Nada de madurar en camino: la corta en la mañana y baja el mismo día.',
     trazabilidad: [
@@ -93,6 +144,7 @@ export const PRODUCTOS = [
       { hito: 'Primera recolección', fecha: '28 de junio' },
       { hito: 'Cosechada', fecha: '9 de julio' },
     ],
+    mataAMesa: 'Cortada en la mañana y abajo el mismo día: la mora no espera a nadie.',
   },
   {
     id: 'papa-criolla',
@@ -105,10 +157,16 @@ export const PRODUCTOS = [
       nombre: 'Finca Los Helechos',
       vereda: 'Peñas Blancas',
       altitud: 3050,
+      distanciaKm: 26,
       productor: 'La familia Rueda',
       rostro: { piel: '#b57a4c', pelo: '#2b1d12', tocado: 'ruana', tocadoColor: '#7a4a2c' },
     },
     sellos: ['Sin agroquímicos', 'Sacada el 7 de julio'],
+    practicas: [
+      { que: 'Suelo', como: 'rotación con habas, para no cansar la tierra del páramo' },
+      { que: 'Semilla', como: 'propia, escogida de la cosecha anterior' },
+      { que: 'Cosecha', como: 'con azadón el mismo día del despacho, tierra fresca encima' },
+    ],
     historia:
       'Arriba, en Peñas Blancas, la tierra negra del páramo le da a la papa criolla ese amarillo intenso por dentro. La familia Rueda la siembra en rotación con habas para no cansar el suelo, y la saca con azadón el mismo día que la despacha, con la tierra todavía fresca encima.',
     trazabilidad: [
@@ -117,6 +175,37 @@ export const PRODUCTOS = [
       { hito: 'Rotación con habas', fecha: 'ciclo anterior' },
       { hito: 'Sacada', fecha: '7 de julio' },
     ],
+    mataAMesa: 'Sacada con azadón el lunes, en su mesa el miércoles: 2 días.',
+  },
+  {
+    id: 'haba-helechos',
+    nombre: 'Haba verde',
+    variedad: 'de páramo, en vaina',
+    ilustracion: 'haba',
+    precio: 5200,
+    unidad: 'libra',
+    finca: {
+      nombre: 'Finca Los Helechos',
+      vereda: 'Peñas Blancas',
+      altitud: 3050,
+      distanciaKm: 26,
+      productor: 'La familia Rueda',
+      rostro: { piel: '#b57a4c', pelo: '#2b1d12', tocado: 'ruana', tocadoColor: '#7a4a2c' },
+    },
+    sellos: ['Sin agroquímicos', 'Cosechada el 8 de julio'],
+    practicas: [
+      { que: 'Rotación', como: 'es la misma haba que le descansa el suelo a la papa' },
+      { que: 'Abono', como: 'el rastrojo del ciclo anterior, incorporado al suelo' },
+      { que: 'Cosecha', como: 'en vaina llena pero verde, antes de que endurezca' },
+    ],
+    historia:
+      'La haba de Los Helechos no es un cultivo aparte: es la que le devuelve la fuerza al suelo entre papa y papa. La familia Rueda la cosecha en vaina, cuando el grano está lleno pero todavía tierno, que es cuando queda dulce al vapor y no harinosa.',
+    trazabilidad: [
+      { hito: 'Sembrada tras la papa', fecha: '20 de marzo' },
+      { hito: 'Floración', fecha: 'mediados de mayo' },
+      { hito: 'Cosechada en vaina', fecha: '8 de julio' },
+    ],
+    mataAMesa: 'Cosechada el miércoles, entregada el viernes: 2 días, todavía en vaina.',
   },
   {
     id: 'cafe-pergamino',
@@ -129,10 +218,16 @@ export const PRODUCTOS = [
       nombre: 'Finca La Aurora',
       vereda: 'El Silencio',
       altitud: 1650,
+      distanciaKm: 9,
       productor: 'Don Fermín',
       rostro: { piel: '#d29a68', pelo: '#4a3520', tocado: 'sombrero', tocadoColor: '#d8b878' },
     },
     sellos: ['Recogido grano rojo', 'Secado al sol'],
+    practicas: [
+      { que: 'Recolección', como: 'selectiva, solo el grano bien rojo' },
+      { que: 'Beneficio', como: 'despulpado el mismo día, lavado con agua de nacimiento' },
+      { que: 'Secado', como: 'al sol en marquesina, volteado a mano' },
+    ],
     historia:
       'En La Aurora solo se recoge el grano bien rojo, el que ya está de punto. Don Fermín lo despulpa el mismo día, lo lava con agua de nacimiento y lo seca al sol en marquesina, volteándolo a mano. Por eso el pergamino queda parejo y sin ese sabor a fermento apurado.',
     trazabilidad: [
@@ -141,6 +236,7 @@ export const PRODUCTOS = [
       { hito: 'Lavado y despulpado', fecha: 'el mismo día' },
       { hito: 'Secado al sol', fecha: 'julio' },
     ],
+    mataAMesa: 'El café no corre: 3 semanas de secado al sol antes de llegar a su taza.',
   },
   {
     id: 'miel-angelita',
@@ -153,10 +249,16 @@ export const PRODUCTOS = [
       nombre: 'Finca El Colibrí',
       vereda: 'Aguas Claras',
       altitud: 1950,
+      distanciaKm: 7,
       productor: 'Doña Rosalba',
       rostro: { piel: '#a86a42', pelo: '#1c130b', tocado: 'panuelo', tocadoColor: '#3f7f5a' },
     },
     sellos: ['Meliponicultura nativa', 'Cosecha que no daña el nido'],
+    practicas: [
+      { que: 'Cría', como: 'cajones de madera bajo los árboles del monte' },
+      { que: 'Cosecha', como: 'poquita y con jeringa, sin destruir el nido' },
+      { que: 'Envasado', como: 'a mano y sin calentar, para no matar la miel' },
+    ],
     historia:
       'La miel de El Colibrí la hacen abejas angelita, nativas y sin aguijón, que Doña Rosalba cría en cajones de madera bajo los árboles. Se cosecha poquito y con cuidado, sin destruir el nido, por eso rinde tan poco y sabe distinto: más ácida, casi como fruta.',
     trazabilidad: [
@@ -165,6 +267,7 @@ export const PRODUCTOS = [
       { hito: 'Cosecha de potes', fecha: '2 de julio' },
       { hito: 'Envasada a mano', fecha: '3 de julio' },
     ],
+    mataAMesa: 'Cosechada y envasada en la misma semana; la miel de angelita no se apura.',
   },
   {
     id: 'aguacate-hass',
@@ -177,10 +280,16 @@ export const PRODUCTOS = [
       nombre: 'Finca La Palma',
       vereda: 'El Progreso',
       altitud: 1780,
+      distanciaKm: 15,
       productor: 'Don Isidro',
       rostro: { piel: '#c98a5e', pelo: '#6b6b6b', tocado: 'sombrero', tocadoColor: '#c9a26a' },
     },
     sellos: ['Sin madurantes', 'Cortado el 6 de julio'],
+    practicas: [
+      { que: 'Sombra', como: 'los árboles conviven con plátano y guamo' },
+      { que: 'Corte', como: 'con gancho y prueba de aceite, nunca al piso' },
+      { que: 'Maduración', como: 'natural en la casa, sin cámaras ni químicos' },
+    ],
     historia:
       'Don Isidro no tumba el aguacate al piso: lo corta con gancho cuando ya tiene el aceite hecho, ni antes ni después. En La Palma los árboles conviven con plátano y guamo que les dan sombra, así la fruta no se estresa y madura pareja en la casa, sin cámaras ni químicos.',
     trazabilidad: [
@@ -189,8 +298,33 @@ export const PRODUCTOS = [
       { hito: 'Prueba de aceite', fecha: 'inicio de julio' },
       { hito: 'Cortado con gancho', fecha: '6 de julio' },
     ],
+    mataAMesa: 'Cortado de punto el lunes; madura solo en su casa, 3 a 4 días.',
   },
 ];
+
+/*
+ * Fincas ÚNICAS del mercado (una finca puede tener varios productos). Cada una
+ * lleva `productoId`: el primer producto de esa finca, para que el pin de la
+ * CintaAltitud sepa qué historia abrir.
+ */
+export function fincasUnicas(productos = PRODUCTOS) {
+  const porNombre = new Map();
+  for (const p of productos) {
+    if (!porNombre.has(p.finca.nombre)) {
+      porNombre.set(p.finca.nombre, {
+        id: p.finca.nombre,
+        productoId: p.id,
+        nombre: p.finca.nombre,
+        productor: p.finca.productor,
+        vereda: p.finca.vereda,
+        altitud: p.finca.altitud,
+        distanciaKm: p.finca.distanciaKm,
+        rostro: p.finca.rostro,
+      });
+    }
+  }
+  return [...porNombre.values()];
+}
 
 /* Formatea un precio entero en pesos colombianos: 4800 → "$ 4.800". Punto de
    miles a la colombiana, sin decimales. */


### PR DESCRIPTION
## Qué es

Ronda 2 del mockup `#/mockups/mercado` (mercado público de procedencia). **Base: `fable/mockup-mercado-bio`** (construye sobre la ronda 1, no sobre main).

## Qué agrega

### 1. Vista de detalle profundizada (Historia)
- **"Cómo se cultivó"**: la versión estructurada de la historia, por frentes (`Abono / Riego / Plagas…`), legible de un vistazo.
- **"De la mata a su mesa"**: la trazabilidad cierra con la línea honesta de cuánto pasó entre cosecha y entrega ("Cortado de madrugada y entregado el mismo día: 0 días de espera").
- **"La palabra de la finca"**: nota anti-postureo — *"Aquí no hay sello de laboratorio. Lo que usted lee es la palabra de Doña Emilia, con nombre, finca y fecha. Y la finca queda a 12 km: si quiere, puede ir y verlo con sus propios ojos."*
- **"También de esta finca"**: mini-tarjetas de los otros productos del mismo techo; al saltar, el detalle remonta con scroll arriba.

### 2. Señales de confianza en dos clases visuales
- **Estampa roja inclinada** = lo que la finca DECLARA (sin químicos, fecha de cosecha).
- **Chip de tinta, recto** = dato MEDIBLE ("a X km de usted"). Lo declarado se estampa; lo medido se anota.

### 3. Filtro + orden con la CintaAltitud como navegación
- El filtro de piso térmico ahora se refleja en la cinta del hero: las fincas de otros pisos se atenúan.
- Orden: **"De la montaña abajo"** (altitud, como se lee la cinta) o **"Más cerca de usted"** (km).
- Chips de piso muestran su rango en metros (se ocultan en 320px).

### 4. Datos y dibujos
- 2 productos nuevos en fincas EXISTENTES: cilantro en El Rocío y haba verde en Los Helechos (coherente con su rotación papa/haba declarada en ronda 1). Ilustraciones SVG propias (cilantro con raíz, vaina de haba).
- Pines de la cinta agrupados por finca única (una finca, un pin, varios productos).
- `distanciaKm`, `practicas` y `mataAMesa` en el seed de muestra (todo ficticio y genérico).

### 5. Responsive 320px
- Chips sin rango de metros, rótulo de orden a su propia línea, columna de prácticas más angosta.

## Verificación (corrida de verdad)
- `npm run build` ✅ verde (1m40s)
- `node scripts/tsc-check-gate.mjs` ✅ 868 = baseline 868, cero errores nuevos
- `npx eslint` ✅ limpio en los 5 archivos tocados
- lefthook pre-commit ✅ (voseo-scan, secret-scan, strategic-content-scan, eslint)

Sin imágenes ni enlaces externos; todo SVG propio. Datos de muestra ficticios. Español de Colombia, usted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)