### PR TITLE
feat(mockup): "La salud de mi finca" — la superficie de estado/salud

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,6 +107,9 @@ const CompostScreen = lazy(() => import('./components/CompostScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const OnboardingCondensado = lazy(() => import('./components/OnboardingCondensado'));
+// Galería de mockups (diseño): rutas públicas `#/mockups/<slug>`, sin auth ni
+// gate, datos de muestra. No cuentan como módulo de piloto. Ver MOCKUP_HASH_ROUTES.
+const SaludFincaMockup = lazy(() => import('./mockups/SaludFinca'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const PlantaPorVozScreen = lazy(() => import('./components/PlantaPorVozScreen'));
@@ -416,6 +419,15 @@ const LoadingFallback = ({ view = null }) => {
 // viva (HERRAMIENTAS_TILES en DashboardLive). Las rutas `casos`/`caso_detail`/
 // `javier`/`usage_stats` siguen vivas en el router (más abajo) y por hash.
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
+
+// Rutas de MOCKUP de diseño (galería): PÚBLICAS — sin auth ni gate, datos de
+// muestra. Se resuelven ANTES del check de sesión (igual que el callback OAuth),
+// para que una lámina se pueda revisar sin cuenta. Patrón `#/mockups/<slug>` (el
+// hash se normaliza a `mockups/<slug>`). No entran en HASH_VIEW_ROUTES para dejar
+// explícito que NO pasan por los gates de sesión/rol.
+const MOCKUP_HASH_ROUTES = {
+  'mockups/salud-finca': 'mockup_salud_finca',
+};
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
@@ -915,6 +927,14 @@ export default function App() {
       return;
     }
 
+    // Mockups de diseño: públicos, sin auth. Se resuelven antes de
+    // isAuthenticated para que la galería (#/mockups/<slug>) abra sin cuenta.
+    const mockupView = MOCKUP_HASH_ROUTES[hash];
+    if (mockupView) {
+      Promise.resolve().then(() => navigate(mockupView));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -941,6 +961,12 @@ export default function App() {
   useEffect(() => {
     const handleHashRoute = () => {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
+      // Mockups públicos: navegar directo, sin pasar por auth ni gates.
+      const mockupView = MOCKUP_HASH_ROUTES[hash];
+      if (mockupView) {
+        navigate(mockupView);
+        return;
+      }
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
@@ -2487,6 +2513,17 @@ export default function App() {
                 onNavigate={navigate}
                 initialContext={currentViewData}
               />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_salud_finca':
+        // Mockup de galería (público, datos de muestra): "La salud de mi finca",
+        // la superficie de ESTADO/SALUD — el panorama de cómo está la finca como
+        // organismo vivo (distinta de "qué hacer hoy"). Ruta #/mockups/salud-finca.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="La salud de mi finca">
+              <SaludFincaMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/SaludFinca.jsx
+++ b/src/mockups/SaludFinca.jsx
@@ -1,0 +1,410 @@
+/*
+ * i18n (ADR-050): copy de campo en español Colombia (usted). Es un MOCKUP de
+ * galería con datos de muestra, sin gate ni auth; TODO el copy es de muestra y
+ * migraría en bloque a src/config/messages.js — mismo criterio que los otros
+ * mockups de la galería. Por eso se apaga aquí la regla i18n (soft `warn`):
+ * el gate de pre-commit corre eslint con --max-warnings 0 y este archivo es,
+ * por definición, copy hardcodeado a propósito.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- mockup: copy de muestra (ver nota arriba) */
+import { ArrowLeft, CloudRain, Droplet, CalendarDays, Eye } from 'lucide-react';
+import CapaCielo from '../visual/scenes/CieloParametrico.jsx';
+import { cieloEscena } from '../visual/scenes/_cielo.js';
+import SceneFincaOrganismo from '../visual/scenes/SceneFincaOrganismo.jsx';
+import { Lombriz } from '../visual/creatures/Lombriz.jsx';
+import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
+import { Colibri } from '../visual/creatures/Colibri.jsx';
+import { Escarabajo } from '../visual/creatures/Escarabajo.jsx';
+import LaminaMataEtapa from '../visual/laminas/LaminaMataEtapa.jsx';
+import '../visual/scenes/scenes.css';
+import '../visual/scenes/scene-finca-organismo.css';
+import '../visual/creatures/creatures.css';
+import '../visual/laminas/laminas.css';
+import './salud-finca.css';
+
+/**
+ * SaludFinca — MOCKUP "La salud de mi finca": la superficie de ESTADO/SALUD.
+ *
+ * No es "qué hacer hoy": es el PANORAMA de cómo está la finca, leída como un
+ * organismo vivo. El diferencial es la CALMA: la observación no alarma, no hay
+ * puntos ni medallas ni rachas. El estado de lo vivo se lee por color funcional
+ * —savia (sana), miel (en observación), arcilla (pide una mirada), nunca rojo—.
+ *
+ * Firma visual: "el cantero vivo" (la finca vista como una cama de siembra desde
+ * arriba, cada mata un brote teñido por su bienestar, respirando al mismo pulso
+ * que el organismo del héroe). Reusa la librería visual `src/visual`:
+ *   - scenes: SceneFincaOrganismo (héroe que respira) + CapaCielo (el cielo de
+ *     la vereda al amanecer, nublado tras la lluvia).
+ *   - creatures: Lombriz, AbejaAngelita, Colibrí, Escarabajo (la vida del suelo).
+ *   - laminas: LaminaMataEtapa (la mata del foco de atención).
+ *
+ * Ruta pública `#/mockups/salud-finca` (sin auth, datos de muestra ficticios).
+ *
+ * @param {Object} props
+ * @param {() => void} [props.onBack] volver al dashboard.
+ */
+
+// ── Datos de muestra (finca y vereda ficticias) ─────────────────────────────
+const FINCA = { nombre: 'El Retoño', vereda: 'Aguas Claras', mirada: 'hoy, 6:40 a. m.' };
+
+// El cantero: 48 matas. La mayoría sanas; unas pocas en observación y dos que
+// piden una mirada — repartidas por la cama, no amontonadas (así se lee natural).
+const MIRADA = new Set([19, 42]);
+const OBS = new Set([3, 11, 22, 28, 34, 40, 45]);
+const MATAS = Array.from({ length: 48 }, (_, i) => ({
+  id: i,
+  estado: MIRADA.has(i) ? 'mirada' : OBS.has(i) ? 'obs' : 'sana',
+}));
+const CONTEO = {
+  sana: MATAS.filter((m) => m.estado === 'sana').length,
+  obs: MATAS.filter((m) => m.estado === 'obs').length,
+  mirada: MATAS.filter((m) => m.estado === 'mirada').length,
+};
+
+// Foco de atención: una mata o zona que pide mirada, sin alarmismo.
+const FOCOS = [
+  {
+    id: 'tomate',
+    estado: 'obs',
+    chip: 'En observación',
+    titulo: 'El tomate de la cama 3',
+    texto: 'Algunas hojas de abajo tienen puntos amarillos. Vale mirarlo con calma esta semana; puede ser falta de riego parejo.',
+    etapa: 'floracion',
+  },
+  {
+    id: 'zona-baja',
+    estado: 'mirada',
+    chip: 'Pide una mirada',
+    titulo: 'La zona baja, junto a la acequia',
+    texto: 'El agua se quedó parada dos días después de la lluvia. El surco no está drenando; conviene abrirle salida.',
+    etapa: null,
+  },
+  {
+    id: 'cafeto',
+    estado: 'obs',
+    chip: 'En observación',
+    titulo: 'El cafeto joven del lindero',
+    texto: 'Está creciendo despacio. Puede ser la sombra del aguacate vecino más que el suelo. Anótelo y compare en un mes.',
+    etapa: 'juvenil',
+  },
+];
+
+// La vida del suelo y los polinizadores: la sensación de finca-organismo.
+const VIDA = [
+  {
+    id: 'lombriz',
+    Fig: Lombriz,
+    nombre: 'Lombrices',
+    cientifico: 'Martiodrilus crassus',
+    texto: 'En una palada de tierra aparecieron seis. El suelo está suelto y huele a monte: buena señal de vida abajo.',
+  },
+  {
+    id: 'angelita',
+    Fig: AbejaAngelita,
+    nombre: 'Abejas angelita',
+    cientifico: 'Tetragonisca angustula',
+    texto: 'Entran y salen del cilantro que se dejó florecer. Cuando rondan tranquilas, la finca está polinizándose sola.',
+  },
+  {
+    id: 'colibri',
+    Fig: Colibri,
+    nombre: 'Colibrí',
+    cientifico: 'Colibri coruscans',
+    texto: 'Ronda las salvias desde temprano. Verlo volver cada mañana es una lectura sencilla de que hay flor y néctar.',
+  },
+  {
+    id: 'escarabajo',
+    Fig: Escarabajo,
+    nombre: 'Escarabajos estercoleros',
+    cientifico: 'Dichotomius belus',
+    texto: 'Rodaron el estiércol del corral y lo enterraron. El abono se recicla solo y el suelo se airea sin arar.',
+  },
+];
+
+// Geometría del cantero: cada mata cae en una cama de 8×6 con leve variación,
+// para que se lea como siembra a mano y no como una tabla fría.
+const COLS = 8;
+const ROWS = 6;
+function disponerCantero() {
+  return MATAS.map((m, i) => {
+    const col = i % COLS;
+    const row = Math.floor(i / COLS);
+    const jx = ((i * 37) % 11) - 5;
+    const jy = ((i * 53) % 9) - 4;
+    const x = 26 + col * ((294 - 26) / (COLS - 1)) + jx;
+    const y = 30 + row * ((134 - 30) / (ROWS - 1)) + jy;
+    const s = 0.82 + ((i * 29) % 40) / 100;
+    const r = ((i * 17) % 13) - 6;
+    return { ...m, x, y, s, r };
+  });
+}
+
+/** El cielo del amanecer en la vereda (nublado tras la lluvia). */
+function CieloVereda() {
+  const cielo = { luz: 'amanecer', condicion: 'nublado' };
+  const [alto, bajo] = cieloEscena(cielo, 'finca');
+  return (
+    <svg
+      className="slf-cielo-svg"
+      viewBox="0 0 390 300"
+      preserveAspectRatio="xMidYMid slice"
+      role="img"
+      aria-label="El cielo del amanecer en la vereda: nublado, con sol bajo tras la lluvia de la noche."
+    >
+      <defs>
+        <linearGradient id="slf-cielo-bg" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor={alto} />
+          <stop offset="1" stopColor={bajo} />
+        </linearGradient>
+      </defs>
+      <rect x="0" y="0" width="390" height="300" fill="url(#slf-cielo-bg)" />
+      <CapaCielo cielo={cielo} cx={286} cy={78} r={27} lluviaY={150} w={390} h={300} />
+    </svg>
+  );
+}
+
+/** El cantero vivo: la finca como cama de siembra, cada mata teñida por estado. */
+function Cantero() {
+  const brotes = disponerCantero();
+  return (
+    <svg
+      className="slf-cantero-svg"
+      viewBox="0 0 320 150"
+      role="img"
+      aria-label={`El cantero de la finca: ${CONTEO.sana} matas sanas, ${CONTEO.obs} en observación y ${CONTEO.mirada} que piden una mirada.`}
+    >
+      <defs>
+        {/* un brote: tallo + dos hojas + semilla, anclado en la base (0,0) */}
+        <g id="slf-brote-glifo">
+          <path
+            d="M0,0 C-0.6,-7 0.6,-11 0,-18"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+          <path
+            d="M0,-9 C-8,-9.5 -11.5,-14.5 -9,-20 C-3.2,-18 -0.6,-13.5 0,-10.5 Z"
+            fill="currentColor"
+            opacity="0.9"
+          />
+          <path
+            d="M0,-12 C8,-12.5 11.5,-17.5 9,-23 C3.2,-21 0.6,-16.5 0,-13.5 Z"
+            fill="currentColor"
+            opacity="0.72"
+          />
+          <circle cx="0" cy="1" r="1.5" fill="currentColor" opacity="0.55" />
+        </g>
+      </defs>
+      {/* surcos apenas insinuados, para que se lea "cama de siembra" */}
+      <g stroke="rgba(120, 90, 46, 0.16)" strokeWidth="1">
+        <path d="M8,52 H312" />
+        <path d="M8,86 H312" />
+        <path d="M8,120 H312" />
+      </g>
+      <g className="slf-cantero-aliento">
+        {brotes.map((b) => (
+          <use
+            key={b.id}
+            href="#slf-brote-glifo"
+            className={`slf-brote slf-brote--${b.estado}`}
+            transform={`translate(${b.x.toFixed(1)} ${b.y.toFixed(1)}) scale(${b.s.toFixed(2)}) rotate(${b.r})`}
+          />
+        ))}
+      </g>
+    </svg>
+  );
+}
+
+export default function SaludFinca({ onBack }) {
+  return (
+    <div className="slf-root">
+      <header className="slf-top">
+        <button type="button" className="slf-back" onClick={onBack} aria-label="Volver">
+          <ArrowLeft size={19} strokeWidth={2} aria-hidden="true" />
+        </button>
+        <div className="slf-titulo">
+          <p className="slf-eyebrow">El estado de la finca</p>
+          <h1 className="slf-h1">La salud de mi finca</h1>
+          <p className="slf-lugar">
+            Finca <b>{FINCA.nombre}</b> · vereda {FINCA.vereda} · última mirada {FINCA.mirada}
+          </p>
+        </div>
+      </header>
+
+      <div className="slf-wrap">
+        {/* Héroe: la finca como organismo que respira */}
+        <section className="slf-hero" aria-label="Su finca, vista como un organismo vivo">
+          <div className="slf-hero-escena">
+            <SceneFincaOrganismo />
+          </div>
+          <div className="slf-hero-velo" />
+          <div className="slf-hero-texto">
+            <p className="slf-hero-linea">Su finca está viva y respira tranquila.</p>
+            <p className="slf-hero-sub">
+              De un vistazo: la tierra está húmeda, la vida trabaja abajo y casi todas las matas
+              siguen su curso. Hay un par de cosas para mirar con calma.
+            </p>
+            <span className="slf-hero-pulso">
+              <span className="slf-hero-punto" aria-hidden="true" />
+              48 matas · pulso estable
+            </span>
+          </div>
+        </section>
+
+        {/* El cantero vivo (firma) */}
+        <section className="slf-sec" aria-labelledby="slf-cantero-tit">
+          <div className="slf-sec-cab">
+            <p className="slf-kicker">El pulso de las matas</p>
+            <h2 className="slf-sec-tit" id="slf-cantero-tit">El cantero, mata por mata</h2>
+            <p className="slf-sec-nota">
+              Cada brote es una mata de la finca. El color no juzga: solo dice si va bien, si conviene
+              observarla o si pide que usted se acerque a mirar.
+            </p>
+          </div>
+          <div className="slf-card">
+            <Cantero />
+            <div className="slf-conteos">
+              <div className="slf-conteo">
+                <span className="slf-conteo-num">
+                  <span className="slf-punto slf-punto--sana" aria-hidden="true" />
+                  {CONTEO.sana}
+                </span>
+                <span className="slf-conteo-lbl">van bien, siguen su curso</span>
+              </div>
+              <div className="slf-conteo">
+                <span className="slf-conteo-num">
+                  <span className="slf-punto slf-punto--obs" aria-hidden="true" />
+                  {CONTEO.obs}
+                </span>
+                <span className="slf-conteo-lbl">en observación</span>
+              </div>
+              <div className="slf-conteo">
+                <span className="slf-conteo-num">
+                  <span className="slf-punto slf-punto--mirada" aria-hidden="true" />
+                  {CONTEO.mirada}
+                </span>
+                <span className="slf-conteo-lbl">piden una mirada</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* El cielo y el agua como señales de salud */}
+        <section className="slf-sec" aria-labelledby="slf-cielo-tit">
+          <div className="slf-sec-cab">
+            <p className="slf-kicker">El cielo y el agua</p>
+            <h2 className="slf-sec-tit" id="slf-cielo-tit">De dónde viene el agua</h2>
+            <p className="slf-sec-nota">
+              La lluvia y la humedad del suelo son la primera señal de cómo va a estar la finca los
+              próximos días.
+            </p>
+          </div>
+          <div className="slf-card">
+            <div className="slf-cielo-fila">
+              <div className="slf-cielo-caja">
+                <CieloVereda />
+              </div>
+              <div className="slf-senales">
+                <div className="slf-senal">
+                  <CloudRain size={16} strokeWidth={2} color="var(--slf-agua)" aria-hidden="true" />
+                  <span className="slf-senal-lbl">Llovió</span>
+                  <span className="slf-senal-val">14 mm <small>hace 2 días</small></span>
+                </div>
+                <div className="slf-senal">
+                  <CalendarDays size={16} strokeWidth={2} color="var(--slf-agua)" aria-hidden="true" />
+                  <span className="slf-senal-lbl">Próxima</span>
+                  <span className="slf-senal-val"><small>probable en</small> 3 días</span>
+                </div>
+              </div>
+            </div>
+            <div className="slf-senal" style={{ marginTop: '12px' }}>
+              <Droplet size={16} strokeWidth={2} color="var(--slf-agua)" aria-hidden="true" />
+              <span className="slf-senal-lbl">Humedad</span>
+              <span className="slf-senal-val">buena <small>en el primer palmo</small></span>
+            </div>
+            <div className="slf-suelo-barra" role="img" aria-label="Humedad del suelo: buena, entre media y húmeda.">
+              <span className="slf-suelo-marca" style={{ left: '68%' }} />
+            </div>
+            <div className="slf-suelo-escala">
+              <span>seca</span>
+              <span>media</span>
+              <span>húmeda</span>
+            </div>
+          </div>
+        </section>
+
+        {/* Focos de atención — sin alarmismo */}
+        <section className="slf-sec" aria-labelledby="slf-focos-tit">
+          <div className="slf-sec-cab">
+            <p className="slf-kicker">
+              <Eye size={12} strokeWidth={2.4} style={{ verticalAlign: '-1px', marginRight: '4px' }} aria-hidden="true" />
+              Para mirar esta semana
+            </p>
+            <h2 className="slf-sec-tit" id="slf-focos-tit">Tres cosas que piden atención</h2>
+            <p className="slf-sec-nota">
+              Nada urgente. Son puntos para acercarse, observar y anotar; ninguno es una alarma.
+            </p>
+          </div>
+          <div className="slf-focos">
+            {FOCOS.map((f) => (
+              <article key={f.id} className={`slf-foco slf-foco--${f.estado}`}>
+                {f.etapa && (
+                  <div className="slf-foco-lam" aria-hidden="true">
+                    <LaminaMataEtapa etapa={f.etapa} />
+                  </div>
+                )}
+                <div className="slf-foco-cuerpo">
+                  <h3 className="slf-foco-tit">{f.titulo}</h3>
+                  <p className="slf-foco-txt">{f.texto}</p>
+                  <span className={`slf-chip slf-chip--${f.estado}`}>
+                    <span className={`slf-punto slf-punto--${f.estado}`} aria-hidden="true" />
+                    {f.chip}
+                  </span>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        {/* El suelo y la vida — finca-organismo */}
+        <section className="slf-sec" aria-labelledby="slf-vida-tit">
+          <div className="slf-sec-cab">
+            <p className="slf-kicker">El suelo y la vida</p>
+            <h2 className="slf-sec-tit" id="slf-vida-tit">Quiénes trabajan la finca con usted</h2>
+            <p className="slf-sec-nota">
+              La salud no está solo en las matas: está en la vida que se mueve alrededor. Cuando estos
+              vuelven cada día, la finca se está cuidando sola.
+            </p>
+          </div>
+          <div className="slf-card">
+            <div className="slf-vida">
+              {VIDA.map((v) => (
+                <div key={v.id} className="slf-bicho">
+                  <div className="slf-bicho-fig">
+                    <v.Fig size={46} title={v.nombre} className="slf-bicho-svg" />
+                  </div>
+                  <div className="slf-bicho-cuerpo">
+                    <p className="slf-bicho-nom">
+                      {v.nombre} <i>· {v.cientifico}</i>
+                    </p>
+                    <p className="slf-bicho-txt">{v.texto}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Cierre — la calma es el mensaje */}
+        <div className="slf-cierre">
+          <p>Esto es una lectura, no una alarma.</p>
+          <p>
+            La finca se observa con calma: mire, anote lo que vio y vuelva mañana. Con el tiempo, estas
+            miradas seguidas enseñan más que cualquier medición de un solo día.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/mockups/salud-finca.css
+++ b/src/mockups/salud-finca.css
@@ -1,0 +1,473 @@
+/* ════════════════════════════════════════════════════════════════════════
+   salud-finca.css — mockup "La salud de mi finca" (superficie de estado/salud).
+
+   NO es el tablero clínico de defecto (fondo cream + serif + terracota): es la
+   NIEBLA DEL AMANECER en el páramo. Fondo de neblina fría verde-grisácea, tinta
+   de corteza, y un ACENTO FUNCIONAL que NO es decorativo — es el ESTADO de lo
+   vivo: savia (sana), miel (en observación) y arcilla (pide una mirada). Nunca
+   rojo de alarma: la observación es calma.
+
+   Firma: "el cantero vivo" (.slf-cantero) — la finca vista como una cama de
+   siembra desde arriba, cada mata un brote teñido por su bienestar, que respira
+   al mismo pulso que el organismo del héroe. Los números —matas, milímetros,
+   humedad— van en monoespaciado, como la lectura de un instrumento de campo.
+
+   Todo el prefijo `slf-`. Mobile-first desde 320px. Movimiento mínimo y
+   reduced-motion-safe. Cero dependencias, cero enlaces externos.
+   ════════════════════════════════════════════════════════════════════════ */
+
+.slf-root {
+  --slf-mist: #e9efe7;
+  --slf-mist-2: #dde5d9;
+  --slf-card: #f5f8f2;
+  --slf-ink: #22301f;
+  --slf-ink-2: #5d6c53;
+  --slf-savia: #2f7d54;
+  --slf-savia-soft: #6ba379;
+  --slf-agua: #3a8698;
+  --slf-honey: #b8892f;
+  --slf-clay: #ab6543;
+  --slf-line: rgba(34, 48, 31, 0.13);
+  --slf-line-2: rgba(34, 48, 31, 0.07);
+  --slf-night: #0c1830;
+  --slf-beat: 5.2s;
+
+  --slf-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
+  --slf-sans: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --slf-mono: ui-monospace, 'SF Mono', 'Cascadia Code', 'Roboto Mono', Menlo, Consolas, monospace;
+
+  min-height: 100%;
+  box-sizing: border-box;
+  margin: 0 auto;
+  max-width: 520px;
+  padding: 0 0 46px;
+  color: var(--slf-ink);
+  font-family: var(--slf-sans);
+  /* niebla del páramo: veladura fría verde-grisácea, sin cream */
+  background:
+    radial-gradient(120% 60% at 50% -8%, #f1f5ee 0%, var(--slf-mist) 46%, var(--slf-mist-2) 100%);
+  -webkit-tap-highlight-color: transparent;
+}
+.slf-root *,
+.slf-root *::before,
+.slf-root *::after { box-sizing: border-box; }
+
+/* ── Encabezado ─────────────────────────────────────────────────────────── */
+.slf-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px clamp(14px, 4.5vw, 22px) 8px;
+}
+.slf-back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 auto;
+  border: 1px solid var(--slf-line);
+  border-radius: 50%;
+  background: var(--slf-card);
+  color: var(--slf-ink);
+  cursor: pointer;
+}
+.slf-back:active { transform: scale(0.94); }
+.slf-titulo { min-width: 0; }
+.slf-eyebrow {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--slf-savia);
+}
+.slf-h1 {
+  margin: 1px 0 0;
+  font-family: var(--slf-serif);
+  font-size: clamp(21px, 6.4vw, 27px);
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+}
+.slf-lugar {
+  margin: 2px 0 0;
+  font-size: 12.5px;
+  color: var(--slf-ink-2);
+}
+.slf-lugar b { font-weight: 600; color: var(--slf-ink); }
+
+.slf-wrap { padding: 0 clamp(14px, 4.5vw, 22px); }
+
+/* ── Héroe: el organismo que respira ────────────────────────────────────── */
+.slf-hero {
+  position: relative;
+  margin-top: 6px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: var(--slf-night);
+  box-shadow: 0 14px 34px -20px rgba(6, 14, 26, 0.7);
+  isolation: isolate;
+}
+.slf-hero-escena {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 390 / 300;
+  overflow: hidden;
+}
+.slf-hero-escena .fvo-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+/* velo para que el texto lea sobre el organismo, sin apagarlo */
+.slf-hero-velo {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(to top, rgba(6, 12, 24, 0.92) 4%, rgba(6, 12, 24, 0.34) 34%, rgba(6, 12, 24, 0) 62%);
+}
+.slf-hero-texto {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 16px clamp(15px, 5vw, 22px) 15px;
+  color: #eaf4ee;
+}
+.slf-hero-linea {
+  margin: 0;
+  font-family: var(--slf-serif);
+  font-size: clamp(18px, 5.4vw, 23px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  text-shadow: 0 1px 10px rgba(4, 10, 20, 0.55);
+}
+.slf-hero-sub {
+  margin: 5px 0 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: rgba(224, 240, 231, 0.82);
+  max-width: 32ch;
+}
+.slf-hero-pulso {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 10px;
+  padding: 5px 11px 5px 9px;
+  border-radius: 999px;
+  background: rgba(9, 26, 22, 0.5);
+  border: 1px solid rgba(120, 210, 170, 0.28);
+  font-size: 12px;
+  font-weight: 600;
+  color: #b9ecd2;
+}
+.slf-hero-punto {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #46e0a2;
+  box-shadow: 0 0 0 0 rgba(70, 224, 162, 0.55);
+  animation: slf-late var(--slf-beat) ease-in-out infinite;
+}
+@keyframes slf-late {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(70, 224, 162, 0.5); }
+  18% { box-shadow: 0 0 0 6px rgba(70, 224, 162, 0); }
+  40% { box-shadow: 0 0 0 0 rgba(70, 224, 162, 0); }
+}
+
+/* ── Secciones ──────────────────────────────────────────────────────────── */
+.slf-sec { margin-top: 26px; }
+.slf-sec-cab { margin-bottom: 11px; }
+.slf-kicker {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--slf-savia);
+}
+.slf-sec-tit {
+  margin: 3px 0 0;
+  font-family: var(--slf-serif);
+  font-size: clamp(18px, 5.2vw, 21px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.slf-sec-nota {
+  margin: 4px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--slf-ink-2);
+}
+
+.slf-card {
+  background: var(--slf-card);
+  border: 1px solid var(--slf-line);
+  border-radius: 16px;
+  padding: 15px;
+}
+
+/* ── El cantero vivo (firma) ────────────────────────────────────────────── */
+.slf-cantero-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 11px;
+  overflow: hidden;
+  background:
+    linear-gradient(to bottom, #efe7d5 0%, #e7dcc4 100%);
+}
+.slf-brote { transform-box: fill-box; transform-origin: 50% 100%; }
+.slf-brote--sana { color: var(--slf-savia); }
+.slf-brote--obs { color: var(--slf-honey); }
+.slf-brote--mirada { color: var(--slf-clay); }
+.slf-cantero-aliento { transform-box: fill-box; transform-origin: 50% 100%; }
+
+/* leyenda + conteos */
+.slf-conteos {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 9px;
+  margin-top: 13px;
+}
+.slf-conteo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 9px 10px;
+  border-radius: 11px;
+  background: var(--slf-mist);
+  border: 1px solid var(--slf-line-2);
+}
+.slf-conteo-num {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: var(--slf-mono);
+  font-size: 21px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--slf-ink);
+}
+.slf-punto {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  align-self: center;
+}
+.slf-punto--sana { background: var(--slf-savia); }
+.slf-punto--obs { background: var(--slf-honey); }
+.slf-punto--mirada { background: var(--slf-clay); }
+.slf-conteo-lbl {
+  font-size: 11.5px;
+  line-height: 1.25;
+  color: var(--slf-ink-2);
+}
+
+/* ── El cielo y el agua ─────────────────────────────────────────────────── */
+.slf-cielo-fila {
+  display: flex;
+  gap: 13px;
+  align-items: stretch;
+}
+.slf-cielo-caja {
+  flex: 0 0 108px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #0f1e34;
+  align-self: stretch;
+  min-height: 92px;
+}
+.slf-cielo-svg { display: block; width: 100%; height: 100%; }
+.slf-senales {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  min-width: 0;
+}
+.slf-senal {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.slf-senal-lbl {
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--slf-ink-2);
+  min-width: 74px;
+}
+.slf-senal-val {
+  font-family: var(--slf-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--slf-ink);
+}
+.slf-senal-val small {
+  font-family: var(--slf-sans);
+  font-weight: 500;
+  color: var(--slf-ink-2);
+}
+
+/* barra de humedad del suelo */
+.slf-suelo-barra {
+  position: relative;
+  height: 12px;
+  margin-top: 4px;
+  border-radius: 7px;
+  overflow: hidden;
+  background: linear-gradient(to right, #d9c39a 0%, #b98f5c 48%, #6f8a55 100%);
+  border: 1px solid var(--slf-line);
+}
+.slf-suelo-marca {
+  position: absolute;
+  top: -3px;
+  width: 3px;
+  height: 18px;
+  border-radius: 2px;
+  background: var(--slf-ink);
+  transform: translateX(-50%);
+  box-shadow: 0 0 0 2px var(--slf-card);
+}
+.slf-suelo-escala {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  font-size: 10.5px;
+  color: var(--slf-ink-2);
+}
+
+/* ── Para mirar esta semana (focos) ─────────────────────────────────────── */
+.slf-focos { display: flex; flex-direction: column; gap: 11px; }
+.slf-foco {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 13px;
+  border-radius: 15px;
+  background: var(--slf-card);
+  border: 1px solid var(--slf-line);
+  border-left: 4px solid var(--slf-savia-soft);
+}
+.slf-foco--obs { border-left-color: var(--slf-honey); }
+.slf-foco--mirada { border-left-color: var(--slf-clay); }
+.slf-foco-lam {
+  flex: 0 0 52px;
+  width: 52px;
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--slf-mist);
+  border: 1px solid var(--slf-line-2);
+}
+.slf-foco-lam svg { display: block; width: 100%; height: auto; }
+.slf-foco-cuerpo { min-width: 0; flex: 1 1 auto; }
+.slf-foco-tit {
+  margin: 0;
+  font-family: var(--slf-serif);
+  font-size: 15.5px;
+  font-weight: 600;
+  line-height: 1.15;
+}
+.slf-foco-txt {
+  margin: 4px 0 0;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--slf-ink-2);
+}
+.slf-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.slf-chip--obs {
+  color: #7a5a15;
+  background: rgba(184, 137, 47, 0.14);
+  border-color: rgba(184, 137, 47, 0.3);
+}
+.slf-chip--mirada {
+  color: #7e451f;
+  background: rgba(171, 101, 67, 0.14);
+  border-color: rgba(171, 101, 67, 0.3);
+}
+.slf-chip .slf-punto { width: 7px; height: 7px; }
+
+/* ── El suelo y la vida ─────────────────────────────────────────────────── */
+.slf-vida { display: flex; flex-direction: column; gap: 3px; }
+.slf-bicho {
+  display: flex;
+  gap: 13px;
+  align-items: center;
+  padding: 11px 2px;
+}
+.slf-bicho + .slf-bicho { border-top: 1px solid var(--slf-line-2); }
+.slf-bicho-fig {
+  flex: 0 0 48px;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.slf-bicho-svg { display: block; }
+.slf-bicho-cuerpo { min-width: 0; }
+.slf-bicho-nom {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+.slf-bicho-nom i { font-weight: 400; color: var(--slf-ink-2); font-size: 11.5px; }
+.slf-bicho-txt {
+  margin: 2px 0 0;
+  font-size: 12.5px;
+  line-height: 1.42;
+  color: var(--slf-ink-2);
+}
+
+/* ── Cierre ─────────────────────────────────────────────────────────────── */
+.slf-cierre {
+  margin-top: 24px;
+  padding: 15px 16px;
+  border-radius: 15px;
+  border: 1px dashed var(--slf-line);
+  background: transparent;
+}
+.slf-cierre p {
+  margin: 0;
+  font-family: var(--slf-serif);
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--slf-ink);
+}
+.slf-cierre p + p {
+  margin-top: 7px;
+  font-family: var(--slf-sans);
+  font-size: 12.5px;
+  color: var(--slf-ink-2);
+}
+
+/* ── Movimiento: respiro solo si el sistema lo permite ──────────────────── */
+@media (prefers-reduced-motion: no-preference) {
+  .slf-cantero-aliento { animation: slf-respira var(--slf-beat) ease-in-out infinite; }
+  @keyframes slf-respira {
+    0%, 100% { transform: scaleY(1) translateY(0); }
+    50% { transform: scaleY(1.012) translateY(-0.6px); }
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .slf-hero-punto { animation: none; }
+}

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,0 +1,61 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
+   Apis). Cuerpo ámbar rayado, cabeza clara, alitas de tul. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-15 -15 32 30';
+
+export function AbejaAngelita({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Abeja angelita',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#ffb54f" opacity="0.35" filter={`url(#${blur})`} />
+      <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
+        style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
+      <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
+        stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
+      <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
+      <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
+      <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
+      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="abeja-angelita">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default AbejaAngelita;

--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,0 +1,62 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Colibrí chillón — Colibri coruscans (nativo de los Andes). Pico largo y
+   recto, garganta violeta iridiscente, alas que baten. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-22 -28 58 52';
+
+export function Colibri({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Colibrí',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#2dffc4" opacity="0.35" filter={`url(#${blur})`} />
+      <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
+      <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
+      <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
+      <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
+      <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
+      <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
+      <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+      <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <path className={wing} d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
+      <path className={wing} style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="colibri">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="colibri" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Colibri;

--- a/src/visual/creatures/Escarabajo.jsx
+++ b/src/visual/creatures/Escarabajo.jsx
@@ -1,0 +1,73 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Escarabajo estercolero — Dichotomius belus (propio de Colombia). Élitros
+   negros brillantes con sutura, cabeza con cuerno, patas que caminan y la bola
+   de abono que rueda. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-23 -12 42 30';
+
+export function Escarabajo({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Escarabajo estercolero',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const bola = animated ? 'crt-ball' : undefined;
+  const patas = animated ? 'crt-legs' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const bolaG = (
+    <g className={bola}>
+      <circle cx="-13" cy="7" r="6.5" fill="#5a4230" />
+      <circle cx="-13" cy="7" r="6.5" fill="none" stroke="#3a2c1c" strokeWidth="1" />
+      <circle cx="-15" cy="5" r="1.5" fill="#6e5238" opacity="0.7" />
+      <circle cx="-11.5" cy="9" r="1.1" fill="#42301f" opacity="0.7" />
+    </g>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={patas} stroke="#0c1206" strokeWidth="1.7" strokeLinecap="round">
+        <path d="M-4,4 L-9,10" /><path d="M0,5 L-1,11" /><path d="M4,4 L8,10" />
+      </g>
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="#141c10"
+        style={{ filter: 'drop-shadow(0 0 5px rgba(157,214,106,0.7))' }} />
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="none" stroke="#9dd66a" strokeWidth="0.7" strokeOpacity="0.6" />
+      <path d="M0,-5.6 L0,5.6" stroke="#0c1206" strokeWidth="0.8" />
+      <ellipse cx="-3.5" cy="-2.8" rx="2.6" ry="1.4" fill="#3d5a24" opacity="0.55" />
+      <path d="M8,-3.4 C12,-3.8 13.4,-1 12.4,1.4 C11.4,3.6 9,3.6 8.2,2.6 C9.4,1 9.2,-1.4 8,-3.4 Z" fill="#0f150b" />
+      <path d="M11.2,-3.2 C12.6,-5 13.4,-4.4 13.2,-2.8" fill="none" stroke="#0f150b" strokeWidth="1.7" strokeLinecap="round" />
+      <circle cx="10.4" cy="-0.6" r="0.7" fill="#9dd66a" opacity="0.8" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="escarabajo">
+        {defs}
+        {bolaG}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="escarabajo" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {bolaG}
+      {body}
+    </svg>
+  );
+}
+
+export default Escarabajo;

--- a/src/visual/creatures/Lombriz.jsx
+++ b/src/visual/creatures/Lombriz.jsx
@@ -1,0 +1,64 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Lombriz de tierra — Martiodrilus crassus (lombriz gigante nativa de los
+   Andes). Cuerpo curvo segmentado con clitelo (banda clara) y cabecita.
+   Su movimiento en escena (asomar/mecerse) lo aporta la escena, no la
+   criatura. Versión canónica del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-8 -16 30 48';
+
+export function Lombriz({
+  size = 64,
+  className,
+  inline = false,
+  // eslint-disable-next-line no-unused-vars
+  animated = true,
+  title = 'Lombriz de tierra',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#c0715a" strokeWidth="7.4" strokeLinecap="round" />
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#ff9d6a" strokeWidth="4.4" strokeLinecap="round" opacity="0.85" />
+      <g stroke="#7a3f2e" strokeWidth="0.9" opacity="0.65" strokeLinecap="round">
+        <path d="M-1.4,22 L1.4,20.5" /><path d="M-1.2,16.5 L2.2,15.5" />
+        <path d="M2.4,11.5 L5.6,11" /><path d="M3.4,5.5 L6.4,5.6" />
+        <path d="M2.8,-0.5 L5.6,-1.4" /><path d="M4.6,-6 L7.4,-7.6" />
+      </g>
+      <path d="M3.2,3 C2,-1 4,-4 6.6,-5" fill="none" stroke="#ffd9b0" strokeWidth="4.6" strokeLinecap="round" opacity="0.75" />
+      <circle cx="12.2" cy="-9.4" r="2.2" fill="#ff9d6a" />
+      <circle cx="13.2" cy="-10" r="0.6" fill="#3a1c12" opacity="0.7" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="lombriz">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="lombriz" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Lombriz;

--- a/src/visual/creatures/_filters.jsx
+++ b/src/visual/creatures/_filters.jsx
@@ -1,0 +1,23 @@
+/*
+ * Filtro SVG compartido de la familia visual "creatures": glow orgánico
+ * (feGaussianBlur + feMerge) heredado de GuardianEspiritu + blur suave.
+ * Cada criatura instancia estos filtros con ids ÚNICOS (useId) para poder
+ * repetirse muchas veces en una misma página sin colisión de ids.
+ * Interno de la librería — no se exporta desde el barrel.
+ */
+export function CreatureFilters({ glow, blur }) {
+  return (
+    <>
+      <filter id={glow} x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.1" result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      <filter id={blur}>
+        <feGaussianBlur stdDeviation="3" />
+      </filter>
+    </>
+  );
+}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1,0 +1,51 @@
+/* ─── Vida perpetua de las CREATURES — SVG + CSS puros, solo transform/opacity
+   (GPU, Android gama baja). Reutilizable en cualquier escena o avatar.
+   La coreografía de LLEGADA (entrar volando, asomar del suelo) NO vive aquí:
+   es responsabilidad de la escena que consume la criatura.
+   reduced-motion = criatura quieta en un fotograma digno. ─── */
+
+/* aleteo rápido (abeja / colibrí) */
+.crt-wing {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: crt-wingbeat 0.13s ease-in-out infinite alternate;
+}
+@keyframes crt-wingbeat {
+  0% { transform: scaleY(1) scaleX(1); }
+  100% { transform: scaleY(0.6) scaleX(0.9); }
+}
+
+/* alas de mariposa que abren y cierran */
+.crt-fwing {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-flutter 0.5s ease-in-out infinite;
+}
+.crt-fwing-l { transform-origin: right center; }
+.crt-fwing-r { transform-origin: left center; }
+@keyframes crt-flutter {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.4); }
+}
+
+/* bola de abono que rueda (escarabajo) */
+.crt-ball {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-roll 1.1s linear infinite;
+}
+@keyframes crt-roll {
+  0% { transform: rotate(0); }
+  100% { transform: rotate(-360deg); }
+}
+
+/* patas que dan pasos (escarabajo) */
+.crt-legs { animation: crt-step 0.5s ease-in-out infinite; }
+@keyframes crt-step {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-1.2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crt-wing, .crt-fwing, .crt-ball, .crt-legs { animation: none !important; }
+}

--- a/src/visual/laminas/LaminaMataEtapa.jsx
+++ b/src/visual/laminas/LaminaMataEtapa.jsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import './laminas.css';
+
+/**
+ * LaminaMataEtapa — la lámina VIVA de una mata individual.
+ *
+ * Misma familia que `LaminaSiembra`/`LaminaAporque` (cuaderno de campo: corte de
+ * suelo, trazo redondo, formas simples, colores de tinta sobre papel) pero aquí
+ * el dibujo NO es fijo: cambia según la ETAPA real de la mata. Cada etapa se
+ * compone distinta —
+ *
+ *   semilla    la semilla enterrada, con su radícula asomando          (bajo tierra)
+ *   plántula   el tallito que rompe el suelo: dos cotiledones + 1 hoja  (recién nacida)
+ *   juvenil    la mata que crece: varias hojas, sin flor                (creciendo)
+ *   adulta     la mata hecha, con su tutor y raíz honda                 (robusta)
+ *   floración  la misma mata, ahora con racimos de flor amarilla        (florece)
+ *   cosecha    los racimos cargados de tomate maduro colgando           (da fruto)
+ *
+ * Es DECORATIVA (aria-hidden): la ficha de al lado narra el estado real. El
+ * dibujo respira con las etapas — la raíz se hace honda, el tallo sube, la copa
+ * se llena — para que se LEA la evolución sin leer una palabra. Sin dependencia
+ * de las variables --c-* del tema: es una hoja de papel pegada encima, legible
+ * al sol sobre los cuatro temas. rsvg-safe (sin <text>, sin emoji-en-SVG).
+ *
+ * El ancho/alto de la lámina y la animación de crecimiento al cambiar de etapa
+ * viven en `laminas.css` (clases `lam-mata-svg` / `lam-mata-brota`), y son
+ * reduced-motion-safe (sin animación → fotograma final digno).
+ *
+ * @param {Object} props
+ * @param {'semilla'|'plantula'|'juvenil'|'adulto'|'floracion'|'cosecha'} props.etapa
+ * @param {string} [props.className]
+ */
+
+// ── Paleta de tinta (fija, para leerse al sol; no hereda del tema) ──────────────
+const C = {
+  cielo: '#f4f6ea',
+  sol: '#e9c33f',
+  tierra: '#e7dabb',
+  tierraHonda: '#d9c79c',
+  surco: '#b98a2f',
+  raiz: '#a9843f',
+  raizHonda: '#8a6a2f',
+  tallo: '#3f8f4e',
+  talloHondo: '#2f6b3a',
+  hoja: '#4a9b57',
+  hojaTierna: '#7cba5a',
+  vena: '#2f6b3a',
+  cotiledon: '#9ccb6a',
+  flor: '#f2c53d',
+  florCentro: '#c9962c',
+  frutoMaduro: '#cc4b37',
+  frutoVerde: '#8aa54e',
+  caliz: '#3f8f4e',
+};
+
+// Una hoja ovada con nervadura (apunta hacia arriba desde su base en 0,0).
+function Hoja({ rot = 0, escala = 1, tono = C.hoja }) {
+  return (
+    <g transform={`rotate(${rot}) scale(${escala})`}>
+      <path
+        d="M0 0 C -11 -9 -10 -25 0 -33 C 10 -25 11 -9 0 0 Z"
+        fill={tono}
+        stroke={C.talloHondo}
+        strokeWidth="0.8"
+        strokeLinejoin="round"
+      />
+      <g stroke={C.vena} strokeWidth="0.9" strokeLinecap="round" fill="none" opacity="0.55">
+        <path d="M0 -2 L0 -30" />
+        <path d="M0 -12 L-6 -17" />
+        <path d="M0 -12 L6 -17" />
+        <path d="M0 -20 L-5 -25" />
+        <path d="M0 -20 L5 -25" />
+      </g>
+    </g>
+  );
+}
+
+// Flor de tomate: cinco pétalos en estrella + centro ocre.
+function Flor({ x = 0, y = 0, escala = 1 }) {
+  const petalos = [0, 72, 144, 216, 288];
+  return (
+    <g transform={`translate(${x} ${y}) scale(${escala})`}>
+      {petalos.map((a) => (
+        <ellipse key={a} cx="0" cy="-6" rx="2.6" ry="5.2" fill={C.flor} stroke={C.florCentro} strokeWidth="0.5" transform={`rotate(${a})`} />
+      ))}
+      <circle cx="0" cy="0" r="2.4" fill={C.florCentro} />
+    </g>
+  );
+}
+
+// Tomate: fruto con brillo y su cáliz de estrella verde arriba.
+function Tomate({ x = 0, y = 0, r = 7, maduro = true }) {
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <circle cx="0" cy="0" r={r} fill={maduro ? C.frutoMaduro : C.frutoVerde} stroke={C.raizHonda} strokeWidth="0.6" />
+      <ellipse cx={-r * 0.32} cy={-r * 0.34} rx={r * 0.34} ry={r * 0.22} fill="#ffffff" opacity="0.35" />
+      <g stroke={C.caliz} strokeWidth="1.4" strokeLinecap="round" fill="none">
+        <path d={`M0 ${-r} l-3 -3`} />
+        <path d={`M0 ${-r} l0 -4`} />
+        <path d={`M0 ${-r} l3 -3`} />
+      </g>
+    </g>
+  );
+}
+
+// Raíces: pivotante honda + laterales. `hondura` en px marca cuánto baja.
+function Raices({ hondura = 40 }) {
+  const lat = Math.min(1, hondura / 80);
+  return (
+    <g stroke={C.raiz} fill="none" strokeLinecap="round">
+      <path d={`M0 0 q 4 ${hondura * 0.4} -2 ${hondura}`} strokeWidth="2.4" stroke={C.raizHonda} />
+      <path d={`M0 6 q -${18 * lat} 8 -${24 * lat} ${28 * lat}`} strokeWidth="1.6" />
+      <path d={`M0 12 q ${18 * lat} 8 ${26 * lat} ${30 * lat}`} strokeWidth="1.6" />
+      <path d={`M-2 ${hondura * 0.45} q -${10 * lat} 6 -${14 * lat} ${18 * lat}`} strokeWidth="1.2" />
+      <path d={`M0 ${hondura * 0.6} q ${10 * lat} 6 ${13 * lat} ${16 * lat}`} strokeWidth="1.2" />
+    </g>
+  );
+}
+
+// El tutor (estaca) con sus amarres, para la mata ya hecha.
+function Tutor() {
+  return (
+    <g>
+      <line x1="24" y1="2" x2="24" y2="-112" stroke={C.surco} strokeWidth="4" strokeLinecap="round" />
+      <g stroke={C.raizHonda} strokeWidth="1.4" strokeLinecap="round">
+        <path d="M24 -30 q -12 -3 -22 -1" fill="none" />
+        <path d="M24 -66 q -14 -3 -24 -2" fill="none" />
+        <path d="M24 -96 q -12 -2 -20 -2" fill="none" />
+      </g>
+    </g>
+  );
+}
+
+// ── Cada etapa dibuja su propia mata (arte por etapa) ───────────────────────────
+function MataPorEtapa({ etapa }) {
+  switch (etapa) {
+    case 'semilla':
+      return (
+        <g>
+          <Raices hondura={30} />
+          {/* la semilla enterrada, inclinada */}
+          <g transform="rotate(-18)">
+            <ellipse cx="0" cy="16" rx="12" ry="8" fill={C.tierraHonda} stroke={C.raiz} strokeWidth="1.2" />
+            <path d="M-7 16 q 7 -4 14 0" fill="none" stroke={C.raizHonda} strokeWidth="0.9" />
+          </g>
+          {/* radícula que empieza a bajar */}
+          <path d="M0 22 q 3 12 -2 24" fill="none" stroke={C.raizHonda} strokeWidth="1.8" strokeLinecap="round" />
+          {/* el ganchito del brote que va a asomar */}
+          <path d="M0 8 q -2 -8 2 -13" fill="none" stroke={C.hojaTierna} strokeWidth="2.4" strokeLinecap="round" />
+        </g>
+      );
+    case 'plantula':
+      return (
+        <g>
+          <Raices hondura={40} />
+          {/* tallito */}
+          <path d="M0 0 q -2 -22 0 -46" fill="none" stroke={C.tallo} strokeWidth="3" strokeLinecap="round" />
+          {/* dos cotiledones opuestos */}
+          <ellipse cx="-11" cy="-44" rx="10" ry="4.6" fill={C.cotiledon} stroke={C.talloHondo} strokeWidth="0.7" transform="rotate(-18 -11 -44)" />
+          <ellipse cx="11" cy="-44" rx="10" ry="4.6" fill={C.cotiledon} stroke={C.talloHondo} strokeWidth="0.7" transform="rotate(18 11 -44)" />
+          {/* la primera hoja verdadera, tiernita */}
+          <g transform="translate(0 -48)"><Hoja rot={0} escala={0.7} tono={C.hojaTierna} /></g>
+        </g>
+      );
+    case 'juvenil':
+      return (
+        <g>
+          <Raices hondura={58} />
+          <path d="M0 0 q -3 -40 1 -82" fill="none" stroke={C.tallo} strokeWidth="4" strokeLinecap="round" />
+          {/* hojas alternas subiendo */}
+          <g transform="translate(-2 -22)"><Hoja rot={-58} escala={0.9} /></g>
+          <g transform="translate(1 -40)"><Hoja rot={62} escala={0.95} /></g>
+          <g transform="translate(-1 -58)"><Hoja rot={-52} escala={0.9} /></g>
+          <g transform="translate(1 -72)"><Hoja rot={54} escala={0.85} /></g>
+          <g transform="translate(0 -82)"><Hoja rot={0} escala={0.8} /></g>
+        </g>
+      );
+    case 'adulto':
+      return (
+        <g>
+          <Raices hondura={78} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -24)"><Hoja rot={-62} escala={1.1} /></g>
+          <g transform="translate(2 -40)"><Hoja rot={64} escala={1.15} /></g>
+          <g transform="translate(-2 -58)"><Hoja rot={-58} escala={1.1} /></g>
+          <g transform="translate(3 -74)"><Hoja rot={60} escala={1.05} /></g>
+          <g transform="translate(-2 -90)"><Hoja rot={-54} escala={1} /></g>
+          <g transform="translate(2 -102)"><Hoja rot={40} escala={0.9} /></g>
+          <g transform="translate(0 -108)"><Hoja rot={0} escala={0.85} /></g>
+        </g>
+      );
+    case 'floracion':
+      return (
+        <g>
+          <Raices hondura={80} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -26)"><Hoja rot={-62} escala={1.1} /></g>
+          <g transform="translate(2 -44)"><Hoja rot={64} escala={1.1} /></g>
+          <g transform="translate(-2 -64)"><Hoja rot={-58} escala={1.05} /></g>
+          <g transform="translate(3 -82)"><Hoja rot={58} escala={1} /></g>
+          <g transform="translate(0 -100)"><Hoja rot={0} escala={0.85} /></g>
+          {/* racimos de flor amarilla colgando de los nudos */}
+          <path d="M-6 -38 q -10 4 -14 12" fill="none" stroke={C.talloHondo} strokeWidth="1.4" />
+          <Flor x={-16} y={-26} escala={0.85} />
+          <Flor x={-24} y={-22} escala={0.75} />
+          <path d="M8 -70 q 12 3 16 12" fill="none" stroke={C.talloHondo} strokeWidth="1.4" />
+          <Flor x={20} y={-56} escala={0.9} />
+          <Flor x={27} y={-50} escala={0.75} />
+          <Flor x={14} y={-52} escala={0.7} />
+        </g>
+      );
+    case 'cosecha':
+      return (
+        <g>
+          <Raices hondura={82} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -26)"><Hoja rot={-62} escala={1.05} /></g>
+          <g transform="translate(2 -46)"><Hoja rot={64} escala={1.05} /></g>
+          <g transform="translate(-2 -66)"><Hoja rot={-58} escala={1} /></g>
+          <g transform="translate(3 -84)"><Hoja rot={58} escala={0.95} /></g>
+          <g transform="translate(0 -100)"><Hoja rot={0} escala={0.8} /></g>
+          {/* racimo cargado a la izquierda: maduros + uno verde */}
+          <path d="M-6 -40 q -12 6 -16 16" fill="none" stroke={C.talloHondo} strokeWidth="1.6" />
+          <Tomate x={-22} y={-22} r={7} maduro />
+          <Tomate x={-12} y={-16} r={6.5} maduro />
+          <Tomate x={-26} y={-33} r={5.5} maduro={false} />
+          {/* racimo a la derecha */}
+          <path d="M8 -72 q 14 6 18 16" fill="none" stroke={C.talloHondo} strokeWidth="1.6" />
+          <Tomate x={26} y={-52} r={7} maduro />
+          <Tomate x={16} y={-46} r={6} maduro />
+          <Tomate x={30} y={-63} r={5.5} maduro={false} />
+        </g>
+      );
+    default:
+      return null;
+  }
+}
+
+export default function LaminaMataEtapa({ etapa = 'semilla', className = '' }) {
+  return (
+    <svg
+      viewBox="0 0 320 300"
+      role="img"
+      aria-hidden="true"
+      className={['lam-mata-svg', className].filter(Boolean).join(' ')}
+      data-testid="lamina-mata-etapa"
+      data-etapa={etapa}
+    >
+      {/* cielo tenue */}
+      <rect x="0" y="0" width="320" height="198" fill={C.cielo} />
+      {/* sol de cuaderno, arriba a la derecha */}
+      <g opacity="0.7">
+        <circle cx="272" cy="40" r="15" fill={C.sol} />
+        <g stroke={C.sol} strokeWidth="2.2" strokeLinecap="round">
+          <line x1="272" y1="14" x2="272" y2="6" />
+          <line x1="296" y1="40" x2="304" y2="40" />
+          <line x1="290" y1="22" x2="296" y2="16" />
+          <line x1="290" y1="58" x2="296" y2="64" />
+        </g>
+      </g>
+
+      {/* corte de suelo: superficie ondulada + cuerpo de tierra */}
+      <path d="M0 198 Q 80 192 160 197 T 320 195 L320 300 L0 300 Z" fill={C.tierra} />
+      <path d="M0 198 Q 80 192 160 197 T 320 195" fill="none" stroke={C.surco} strokeWidth="2.2" strokeLinecap="round" opacity="0.6" />
+      {/* motas de tierra (rsvg-safe, sin filtros) */}
+      <g fill={C.surco} opacity="0.32">
+        <circle cx="46" cy="232" r="2.1" />
+        <circle cx="92" cy="262" r="1.6" />
+        <circle cx="128" cy="240" r="1.9" />
+        <circle cx="214" cy="230" r="2" />
+        <circle cx="250" cy="264" r="1.7" />
+        <circle cx="286" cy="238" r="2.1" />
+        <circle cx="70" cy="284" r="1.5" />
+        <circle cx="190" cy="278" r="1.8" />
+      </g>
+
+      {/* la mata, re-montada por etapa para que reanime su crecimiento */}
+      <g key={etapa} transform="translate(160 197)" className="lam-mata-brota">
+        <MataPorEtapa etapa={etapa} />
+      </g>
+    </svg>
+  );
+}

--- a/src/visual/laminas/laminas.css
+++ b/src/visual/laminas/laminas.css
@@ -1,0 +1,33 @@
+/*
+ * Estilos compartidos de la librería de LÁMINAS de cuaderno.
+ * Solo cubre lo que una lámina necesita como hoja de papel autónoma:
+ * el dimensionado responsivo y las (pocas) animaciones intrínsecas, todas
+ * reduced-motion-safe (sin animación → fotograma final digno). Trasplantado
+ * de `mockups/hoja-vida-mata.css` (clases `hvm-lamina-*`) al namespace propio
+ * `lam-*` para que la lámina no dependa de la CSS de ningún consumidor.
+ */
+
+/* LaminaMataEtapa — la hoja de papel: ancho completo, alto por aspecto. */
+.lam-mata-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 340px;
+  margin: 0 auto;
+  user-select: none;
+}
+
+/* LaminaMataEtapa — el crecimiento al cambiar de etapa (la mata "brota"). */
+.lam-mata-brota {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: lam-brota 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes lam-brota {
+  from { opacity: 0; transform: scaleY(0.82) translateY(4px); }
+  to   { opacity: 1; transform: scaleY(1) translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lam-mata-brota { animation: none; }
+}

--- a/src/visual/scenes/CieloParametrico.jsx
+++ b/src/visual/scenes/CieloParametrico.jsx
@@ -1,0 +1,212 @@
+/*
+ * CapaCielo — la CAPA DE CIELO PARAMÉTRICA, compartida por las escenas de finca.
+ * Extraída fiel del subcomponente `Sky` de FincaVivaHero (la "capa de cielo
+ * compartida por las 3 escenas"): sol que respira de día (bajo y ámbar al
+ * amanecer/atardecer), luna con halo + estrellas + estrella fugaz de noche,
+ * nubes/niebla/lluvia según el clima real. rsvg-safe (sin filtros: halos por
+ * círculos concéntricos, lluvia por trazos), cero JS por frame.
+ *
+ * El cielo NO lee atributos del DOM: recibe un objeto `cielo` con la atmósfera
+ * ya resuelta (`{ luz, condicion, tema }`, misma forma que produce
+ * atmosphereService + useTheme). El shell del hero sigue publicando
+ * `data-luz`/`data-clima` para su gradiente CSS; esta capa es el arte SVG.
+ *
+ * Se monta como hijos de un `<svg>` que la escena ya define (con su viewBox):
+ * emite su `<defs>` (gradientes del sol, ids únicos por instancia) + el grupo
+ * del cielo. Importá `./scenes.css` una vez donde la uses.
+ */
+import { useId } from 'react';
+import { esNoche, esCubierto, tonoLuz } from './_cielo.js';
+import './scenes.css';
+
+/**
+ * Gradientes del sol — el dorado de mediodía, el ámbar del sol bajo (amanecer/
+ * atardecer) y la veladura cálida. Ids parametrizables para repetir sin colisión.
+ */
+export function CieloDefs({ solId, solWarmId, washId }) {
+  return (
+    <>
+      <radialGradient id={solId} cx="50%" cy="45%" r="60%">
+        <stop offset="0" stopColor="#fff3c4" />
+        <stop offset="70%" stopColor="#ffe08a" />
+        <stop offset="100%" stopColor="#ffd24d" />
+      </radialGradient>
+      <radialGradient id={solWarmId} cx="50%" cy="45%" r="60%">
+        <stop offset="0" stopColor="#fff0c0" />
+        <stop offset="60%" stopColor="#ffc266" />
+        <stop offset="100%" stopColor="#ff9a4d" />
+      </radialGradient>
+      {/* veladura cálida del sol bajo — baña la escena al amanecer/atardecer */}
+      <linearGradient id={washId} x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stopColor="#ff9a4d" stopOpacity="0.30" />
+        <stop offset="55%" stopColor="#ffb35c" stopOpacity="0.10" />
+        <stop offset="100%" stopColor="#ffb35c" stopOpacity="0" />
+      </linearGradient>
+    </>
+  );
+}
+
+/**
+ * Sky — el grupo del cielo (astro + clima). Recibe la geometría del astro
+ * (cx, cy, r) para encajar en cada escena, y los ids de los gradientes del sol
+ * (los emite `CieloDefs`).
+ */
+export function Sky({ cielo, cx, cy, r, lluviaY = 150, solId, solWarmId }) {
+  const noche = esNoche(cielo);
+  const cubierto = esCubierto(cielo);
+  const lluvia = cielo?.condicion === 'lluvia';
+  const niebla = cielo?.condicion === 'niebla';
+  const tono = tonoLuz(cielo);
+  const solBajo = tono === 'amanecer' || tono === 'atardecer';
+  // Al amanecer/atardecer el sol cuelga más bajo y se enciende en ámbar.
+  const cyEf = solBajo ? cy + r * 1.5 : cy;
+  const gradSol = solBajo ? `url(#${solWarmId})` : `url(#${solId})`;
+  const halo = solBajo ? '#ffb35c' : '#ffe08a';
+  return (
+    <g aria-hidden="true">
+      {noche ? (
+        <g className="scn-sky-noche">
+          {/* estrellas — constelación generosa, con titileo escalonado */}
+          <g fill="#fdf6d8" className="scn-estrellas">
+            <circle cx={cx - 120} cy={cy - 14} r="1.4" />
+            <circle cx={cx - 88} cy={cy + 22} r="1" />
+            <circle cx={cx - 150} cy={cy + 36} r="1.2" />
+            <circle cx={cx - 40} cy={cy - 26} r="1" />
+            <circle cx={cx + 18} cy={cy + 30} r="1.3" />
+            <circle cx={cx - 196} cy={cy + 6} r="1" />
+            <circle cx={cx + 30} cy={cy - 10} r="0.9" />
+            <circle cx={cx - 244} cy={cy - 22} r="1.1" />
+            <circle cx={cx - 270} cy={cy + 30} r="0.9" />
+            <circle cx={cx - 172} cy={cy - 30} r="0.8" />
+            <circle cx={cx - 64} cy={cy + 44} r="1" />
+            <circle cx={cx - 220} cy={cy + 52} r="1.2" />
+          </g>
+          {/* estrella fugaz ocasional (trazo que cruza y se apaga) */}
+          <line
+            className="scn-fugaz"
+            x1={cx - 210} y1={cy - 28} x2={cx - 174} y2={cy - 12}
+            stroke="#fdf6d8" strokeWidth="1.4" strokeLinecap="round"
+          />
+          {/* luna creciente con halo doble */}
+          <g transform={`translate(${cx} ${cy})`}>
+            <circle r={r * 1.5} fill="#e8edf7" opacity="0.1" />
+            <circle r={r * 0.92} fill="#e8edf7" opacity="0.25" />
+            <circle r={r * 0.7} fill="#f4f1e0" />
+            <circle cx={r * 0.32} cy={-r * 0.12} r={r * 0.6} fill="#1d2b4a" />
+            <circle cx={-r * 0.18} cy={r * 0.14} r={r * 0.07} fill="#dcd6bc" opacity="0.6" />
+            <circle cx={-r * 0.3} cy={-r * 0.18} r={r * 0.05} fill="#dcd6bc" opacity="0.5" />
+          </g>
+        </g>
+      ) : (
+        <g transform={`translate(${cx} ${cyEf})`}>
+          {/* halo exterior suave (respira) + anillo de calor con el sol bajo */}
+          <circle r={r * 1.4} fill={halo} opacity={cubierto ? 0.18 : (solBajo ? 0.42 : 0.35)}>
+            <animate attributeName="r" values={`${r * 1.4};${r * 1.6};${r * 1.4}`} dur="6s" repeatCount="indefinite" />
+          </circle>
+          {solBajo && !cubierto && (
+            <circle r={r * 2.1} fill="none" stroke={halo} strokeWidth="1.5" opacity="0.3" />
+          )}
+          <circle r={r} fill={gradSol} opacity={cubierto ? 0.7 : 1} />
+        </g>
+      )}
+
+      {/* NUBES densas cuando está cubierto — dos masas con brillo superior */}
+      {cubierto && (
+        <g fill={noche ? '#9aa6bb' : '#f3f6f4'} opacity={noche ? 0.7 : 0.92}>
+          <g className="scn-nube-a">
+            <ellipse cx={cx - 30} cy={cy + 4} rx="30" ry="14" />
+            <ellipse cx={cx - 4} cy={cy} rx="22" ry="14" />
+            <ellipse cx={cx - 52} cy={cy} rx="18" ry="12" />
+            <ellipse cx={cx - 30} cy={cy - 8} rx="16" ry="10" opacity=".9" />
+          </g>
+          <g className="scn-nube-b" opacity=".8">
+            <ellipse cx={cx - 168} cy={cy + 26} rx="24" ry="11" />
+            <ellipse cx={cx - 146} cy={cy + 22} rx="16" ry="10" />
+            <ellipse cx={cx - 188} cy={cy + 23} rx="13" ry="9" />
+          </g>
+        </g>
+      )}
+
+      {/* NIEBLA — bancos horizontales que derivan despacio (rsvg-safe). Tres
+          alturas: horizonte, media ladera y un velo bajo sobre la escena. */}
+      {niebla && (
+        <g fill={noche ? '#8b9bb3' : '#ffffff'}>
+          <ellipse className="scn-neblina-a" cx={cx - 120} cy={lluviaY + 2} rx="190" ry="22" opacity={noche ? 0.4 : 0.62} />
+          <ellipse className="scn-neblina-b" cx={cx - 30} cy={lluviaY + 30} rx="220" ry="18" opacity={noche ? 0.3 : 0.5} />
+          <ellipse className="scn-neblina-a" cx={cx - 190} cy={lluviaY + 74} rx="200" ry="20" opacity={noche ? 0.22 : 0.36} />
+        </g>
+      )}
+
+      {/* LLUVIA — cortina ancha de trazos diagonales en dos alturas
+          (rsvg-safe, sin filtros) */}
+      {lluvia && (
+        <g className="scn-lluvia" stroke={noche ? '#aebfe0' : '#4e7d9a'} strokeWidth="2.4" strokeLinecap="round" opacity="0.8">
+          <line x1={cx - 90} y1={lluviaY} x2={cx - 97} y2={lluviaY + 22} />
+          <line x1={cx - 50} y1={lluviaY + 8} x2={cx - 57} y2={lluviaY + 30} />
+          <line x1={cx - 10} y1={lluviaY} x2={cx - 17} y2={lluviaY + 22} />
+          <line x1={cx + 28} y1={lluviaY + 6} x2={cx + 21} y2={lluviaY + 28} />
+          <line x1={cx + 64} y1={lluviaY} x2={cx + 57} y2={lluviaY + 22} />
+          <line x1={cx - 130} y1={lluviaY + 4} x2={cx - 137} y2={lluviaY + 26} />
+          <line x1={cx - 170} y1={lluviaY + 10} x2={cx - 177} y2={lluviaY + 32} />
+          <line x1={cx - 210} y1={lluviaY + 2} x2={cx - 217} y2={lluviaY + 24} />
+          <line x1={cx - 250} y1={lluviaY + 8} x2={cx - 257} y2={lluviaY + 30} />
+          <line x1={cx - 286} y1={lluviaY + 2} x2={cx - 293} y2={lluviaY + 24} />
+          <line x1={cx - 70} y1={lluviaY + 34} x2={cx - 77} y2={lluviaY + 56} />
+          <line x1={cx - 150} y1={lluviaY + 40} x2={cx - 157} y2={lluviaY + 62} />
+          <line x1={cx - 230} y1={lluviaY + 36} x2={cx - 237} y2={lluviaY + 58} />
+          <line x1={cx + 10} y1={lluviaY + 42} x2={cx + 3} y2={lluviaY + 64} />
+          <line x1={cx + 46} y1={lluviaY + 34} x2={cx + 39} y2={lluviaY + 56} />
+        </g>
+      )}
+    </g>
+  );
+}
+
+/**
+ * Veladura cálida de sol bajo — rect a pantalla completa de la escena que tiñe
+ * TODO (cielo, lomas, plantas) de ámbar al amanecer/atardecer, como la luz
+ * rasante real. De día/noche no pinta nada.
+ */
+export function WashSolBajo({ cielo, w = 390, h = 360, washId }) {
+  const tono = tonoLuz(cielo);
+  if (tono !== 'amanecer' && tono !== 'atardecer') return null;
+  return (
+    <rect
+      x="0" y="0" width={w} height={h}
+      fill={`url(#${washId})`}
+      opacity={tono === 'atardecer' ? 0.9 : 0.7}
+      pointerEvents="none"
+    />
+  );
+}
+
+/**
+ * CapaCielo — compone `<defs>` (gradientes del sol, ids únicos por instancia) +
+ * el grupo del cielo + la veladura de sol bajo. Se monta como hijos de un `<svg>`
+ * que la escena ya define con su viewBox.
+ *
+ * @param {Object}  props
+ * @param {{luz?:string, condicion?:string, tema?:string}} props.cielo  atmósfera resuelta.
+ * @param {number}  props.cx        centro X del astro (en coords del viewBox).
+ * @param {number}  props.cy        centro Y del astro.
+ * @param {number}  props.r         radio del astro.
+ * @param {number}  [props.lluviaY] altura desde donde cae la lluvia/niebla (150).
+ * @param {number}  [props.w]       ancho de la veladura de sol bajo (390).
+ * @param {number}  [props.h]       alto de la veladura de sol bajo (360).
+ * @param {boolean} [props.wash]    montar la veladura cálida de sol bajo (true).
+ */
+export default function CapaCielo({ cielo, cx, cy, r, lluviaY = 150, w = 390, h = 360, wash = true }) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const solId = `scn-sol-${uid}`;
+  const solWarmId = `scn-sol-warm-${uid}`;
+  const washId = `scn-wash-${uid}`;
+  return (
+    <>
+      <defs>
+        <CieloDefs solId={solId} solWarmId={solWarmId} washId={washId} />
+      </defs>
+      <Sky cielo={cielo} cx={cx} cy={cy} r={r} lluviaY={lluviaY} solId={solId} solWarmId={solWarmId} />
+      {wash && <WashSolBajo cielo={cielo} w={w} h={h} washId={washId} />}
+    </>
+  );
+}

--- a/src/visual/scenes/SceneFincaOrganismo.jsx
+++ b/src/visual/scenes/SceneFincaOrganismo.jsx
@@ -1,0 +1,1039 @@
+/**
+ * SceneFincaOrganismo — la escena "FINCA ORGANISMO" del tema BIOPUNK
+ * (port fiel del mockup aprobado escena-home-biopunk-v2: la finca campesina
+ * de noche convertida en organismo bioluminiscente).
+ *
+ * Qué dibuja (todo animado por CSS, cero JS por frame):
+ *   · CORAZÓN-SEMILLA germinando bajo tierra que LATE (doble pulso cardíaco);
+ *     de él nacen los cuellos de raíz y la RED MICORRÍZICA (hifas con flujo de
+ *     savia + nutrientes viajando por motion-path hasta cada planta).
+ *   · INVERNADERO-CÉLULA que respira: cúpula-membrana con paneles geodésicos
+ *     que laten, lámpara-reactor, organelas flotando y camas de plántulas.
+ *   · MILPA de savia neón (maíz + frijol + auyama), cafetales con cerezas
+ *     neón, casita campesina con fogón (brasas), campesino con ruana +
+ *     farol + perro criollo, frailejones que exhalan luz, luna verde
+ *     bioluminiscente, cocuyos, aurora de páramo, niebla y hongos con esporas.
+ *   · QUEBRADA bioluminiscente que baja de la montaña por las terrazas y
+ *     remansa en un pocito que se filtra hacia la red micorrízica; platanera
+ *     con racimo neón junto a la casita; polillas rondando el farol y una
+ *     cordillera lejana + rayo del astro que dan profundidad de capas.
+ *   · POTRERO con VACA bioluminiscente (respira, pasta y espanta con la
+ *     cola) + 3 GALLINAS que picotean: es la ENTRADA VIVA al mundo de los
+ *     animales — si `onAnimales` llega, el grupo es un botón (tap/Enter)
+ *     que navega al módulo; sin handler queda como arte decorativo (el
+ *     MISMO gate por perfil que esconde el mundo Animales en el home).
+ *
+ * Solo se monta con el tema biopunk (lo decide FincaVivaHero); los demás
+ * temas conservan sus escenas isométricas intactas. Las clases/ids llevan
+ * prefijo `fvo-` para no chocar con el resto del hero. Sus animaciones viven
+ * en scene-finca-organismo.css y respetan prefers-reduced-motion con un
+ * estado estático digno (misma receta que el mockup).
+ *
+ * @param {Object} props
+ * @param {{tiene:boolean, forma:?string}} [props.estructura] estructura de
+ *   cubierta declarada en el perfil (#34): si el usuario declaró invernadero,
+ *   el invernadero-célula de la escena lleva el data-testid/data-forma del
+ *   contrato de FincaVivaHero.estructura.test.jsx (misma semántica que
+ *   SceneFinca: el marcador aparece SOLO si la estructura está declarada).
+ * @param {?() => void} [props.onAnimales] al tocar el potrero (vaca +
+ *   gallinas) navega al mundo de los animales. `null`/ausente = el perfil no
+ *   ve ese mundo (gate `mostrarAnimales` del home) y el potrero queda
+ *   decorativo, sin rol ni foco.
+ * @param {?() => void} [props.onPregunte] al tocar el CORAZÓN-SEMILLA abre el
+ *   agente ("Pregunte"): la metáfora central de la escena deja de ser
+ *   decoración y se vuelve LA acción principal (usabilidad campesina #4).
+ *   Sin handler, el corazón queda como arte (sin rol ni foco).
+ */
+export default function SceneFincaOrganismo({ estructura, onAnimales, onPregunte }) {
+  const conEstructura = !!estructura?.tiene;
+  const conAnimales = typeof onAnimales === 'function';
+  const conPregunte = typeof onPregunte === 'function';
+  const ariaEscena =
+    'Su finca convertida en organismo bioluminiscente, con el sol o la luna según la hora y el cielo real de su vereda: un corazón-semilla late bajo la tierra y su red de micorrizas conecta las raíces de cada planta, con lombrices y bichitos trabajando el suelo; una quebrada baja de la montaña, cultivos con savia de neón, invernadero-célula que respira, potrero con vaca y gallinas, campesino con su perro y colibrí de luz.';
+  return (
+    <svg
+      className="fvo-svg"
+      viewBox="0 0 390 486"
+      preserveAspectRatio="xMidYMid slice"
+      /* con el potrero y/o el corazón tappables el SVG deja de ser imagen
+         plana: role="img" volvería PRESENTACIONALES a sus hijos y los botones
+         (animales y "Pregunte") no existirían para lectores de pantalla. */
+      role={conAnimales || conPregunte ? 'group' : 'img'}
+      aria-label={ariaEscena}
+      data-testid="fvo-escena"
+    >
+      <defs>
+        <linearGradient id="fvo-cielo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#020412" />
+          <stop offset=".55" stopColor="#071030" />
+          <stop offset="1" stopColor="#0d1e44" />
+        </linearGradient>
+        <linearGradient id="fvo-suelo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#0c1026" />
+          <stop offset="1" stopColor="#04060f" />
+        </linearGradient>
+        <radialGradient id="fvo-luna" cx=".38" cy=".35" r="1">
+          <stop offset="0" stopColor="#eafff6" />
+          <stop offset=".7" stopColor="#a8e8d4" />
+          <stop offset="1" stopColor="#6fc4b0" />
+        </radialGradient>
+        {/* sol bioluminiscente + velos de cielo diurno/crepuscular (la escena
+            sigue la atmósfera REAL: data-luz/data-clima en .fvh, ver CSS) */}
+        <radialGradient id="fvo-sol" cx=".42" cy=".4" r="1">
+          <stop offset="0" stopColor="#fff9e0" />
+          <stop offset=".55" stopColor="#ffd76a" />
+          <stop offset="1" stopColor="#ff9d3f" />
+        </radialGradient>
+        <linearGradient id="fvo-cielo-dia-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#11506b" />
+          <stop offset=".55" stopColor="#177082" />
+          <stop offset="1" stopColor="#1a7a6a" />
+        </linearGradient>
+        <linearGradient id="fvo-cielo-crep-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#241338" />
+          <stop offset=".6" stopColor="#4a1e4e" />
+          <stop offset="1" stopColor="#8a4a2c" />
+        </linearGradient>
+        <radialGradient id="fvo-bulbo" cx=".5" cy=".5" r=".5">
+          <stop offset="0" stopColor="#2dffc4" stopOpacity=".9" />
+          <stop offset=".55" stopColor="#2dffc4" stopOpacity=".25" />
+          <stop offset="1" stopColor="#2dffc4" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient id="fvo-corazon" cx=".5" cy=".5" r=".5">
+          <stop offset="0" stopColor="#eafff6" />
+          <stop offset=".35" stopColor="#2dffc4" />
+          <stop offset=".8" stopColor="#0a9f74" stopOpacity=".4" />
+          <stop offset="1" stopColor="#0a9f74" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="fvo-membrana" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#2dffc4" stopOpacity=".22" />
+          <stop offset="1" stopColor="#4fd8ff" stopOpacity=".05" />
+        </linearGradient>
+        <linearGradient id="fvo-tallo" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0" stopColor="#0f8f6c" />
+          <stop offset="1" stopColor="#9dff3f" />
+        </linearGradient>
+        {/* agua de la quebrada: azul profundo que se enciende hacia el remanso */}
+        <linearGradient id="fvo-agua-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#0a2b4a" />
+          <stop offset="1" stopColor="#12466e" />
+        </linearGradient>
+        {/* rayo del astro: cae en diagonal sobre la finca y se disuelve */}
+        <linearGradient id="fvo-rayo-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#eafff6" stopOpacity=".14" />
+          <stop offset="1" stopColor="#eafff6" stopOpacity="0" />
+        </linearGradient>
+        <filter id="fvo-blur8"><feGaussianBlur stdDeviation="8" /></filter>
+        <filter id="fvo-blur3"><feGaussianBlur stdDeviation="3" /></filter>
+        <filter id="fvo-glow1" x="-80%" y="-80%" width="260%" height="260%">
+          <feGaussianBlur stdDeviation="2.2" result="b" />
+          <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+        </filter>
+      </defs>
+
+      {/* ============ CIELO ============ */}
+      <rect width="390" height="486" fill="url(#fvo-cielo)" />
+      {/* velos atmosféricos: se encienden por data-luz (día / amanecer-atardecer).
+          Van bajo montañas y terrazas — solo aclaran el cielo, no la finca. */}
+      <rect className="fvo-cielo-dia" width="390" height="486" fill="url(#fvo-cielo-dia-grad)" />
+      <rect className="fvo-cielo-crep" width="390" height="486" fill="url(#fvo-cielo-crep-grad)" />
+
+      {/* aurora de páramo */}
+      <path
+        className="fvo-aurora"
+        d="M-10,150 C70,110 150,140 230,105 C300,78 350,110 400,88 L400,160 C310,140 240,168 150,152 C80,140 30,166 -10,158 Z"
+        fill="#2dffc4" opacity=".14" filter="url(#fvo-blur8)"
+      />
+      <path
+        className="fvo-aurora" style={{ animationDelay: '-7s' }}
+        d="M-10,120 C90,95 170,125 260,92 L400,70 L400,120 C300,105 200,138 90,124 Z"
+        fill="#b28dff" opacity=".08" filter="url(#fvo-blur8)"
+      />
+
+      {/* estrellas */}
+      <g fill="#dfeffc">
+        <circle className="fvo-tw" cx="30" cy="34" r="1.2" />
+        <circle className="fvo-tw" style={{ animationDelay: '-1s' }} cx="74" cy="60" r=".9" />
+        <circle className="fvo-tw" style={{ animationDelay: '-2.2s' }} cx="120" cy="28" r="1.1" />
+        <circle className="fvo-tw" style={{ animationDelay: '-.6s' }} cx="168" cy="52" r=".8" />
+        <circle className="fvo-tw" style={{ animationDelay: '-1.7s' }} cx="212" cy="24" r="1.2" />
+        <circle className="fvo-tw" style={{ animationDelay: '-2.9s' }} cx="252" cy="58" r=".9" />
+        <circle className="fvo-tw" style={{ animationDelay: '-.3s' }} cx="356" cy="30" r="1.1" />
+        <circle className="fvo-tw" style={{ animationDelay: '-1.4s' }} cx="146" cy="86" r=".8" />
+        <circle className="fvo-tw" style={{ animationDelay: '-2.5s' }} cx="52" cy="104" r="1" />
+        <circle className="fvo-tw" style={{ animationDelay: '-.9s' }} cx="238" cy="96" r=".8" />
+        <circle className="fvo-tw" style={{ animationDelay: '-1.9s' }} cx="330" cy="72" r=".9" fill="#2dffc4" />
+        <circle className="fvo-tw" style={{ animationDelay: '-3.1s' }} cx="96" cy="42" r=".7" fill="#ff4fd8" />
+        <circle className="fvo-tw" style={{ animationDelay: '-2s' }} cx="288" cy="40" r=".8" fill="#9dff3f" />
+      </g>
+
+      {/* luna bioluminiscente (solo de noche — data-luz la gobierna en CSS) */}
+      <g className="fvo-astro fvo-luna-g">
+        <circle cx="318" cy="64" r="54" fill="#2dffc4" opacity=".045" filter="url(#fvo-blur8)" />
+        <circle cx="318" cy="64" r="40" fill="#a8e8d4" opacity=".08" filter="url(#fvo-blur8)" />
+        <circle className="fvo-halo" cx="318" cy="64" r="34" fill="none" stroke="#2dffc4" strokeWidth="1" opacity=".45" />
+        <circle cx="318" cy="64" r="21" fill="url(#fvo-luna)" />
+        <circle cx="318" cy="64" r="21" fill="none" stroke="#eafff6" strokeWidth=".7" opacity=".45" />
+        <circle cx="326" cy="58" r="19.2" fill="#061027" opacity=".94" />
+        <circle cx="309" cy="71" r="2.3" fill="#5fb89e" opacity=".4" />
+        <circle cx="305" cy="63" r="1.4" fill="#5fb89e" opacity=".35" />
+        <circle cx="312.5" cy="76" r="1" fill="#5fb89e" opacity=".3" />
+      </g>
+
+      {/* sol bioluminiscente (día / amanecer / atardecer — mismo lugar del
+          cielo que la luna; el CSS muestra UNO según la atmósfera real) */}
+      <g className="fvo-astro fvo-sol-g">
+        <circle cx="318" cy="64" r="54" fill="#ffb54f" opacity=".07" filter="url(#fvo-blur8)" />
+        <circle cx="318" cy="64" r="40" fill="#ffd76a" opacity=".1" filter="url(#fvo-blur8)" />
+        <circle className="fvo-halo" cx="318" cy="64" r="34" fill="none" stroke="#ffb54f" strokeWidth="1" opacity=".5" />
+        <circle cx="318" cy="64" r="21" fill="url(#fvo-sol)" />
+        <circle cx="318" cy="64" r="21" fill="none" stroke="#fff3c9" strokeWidth=".7" opacity=".6" />
+        {/* corona de rayos que respira */}
+        <g className="fvo-corona" stroke="#ffd76a" strokeWidth="1.4" strokeLinecap="round" fill="none">
+          <path d="M318,34 L318,26" /><path d="M318,94 L318,102" />
+          <path d="M288,64 L280,64" /><path d="M348,64 L356,64" />
+          <path d="M297,43 L291,37" /><path d="M339,85 L345,91" />
+          <path d="M339,43 L345,37" /><path d="M297,85 L291,91" />
+        </g>
+      </g>
+
+      {/* nubes de clima: aparecen con nublado/lluvia/niebla (data-clima) y
+          velan el astro — el cielo de la escena cuenta el clima REAL */}
+      <g className="fvo-nubes">
+        <g className="fvo-fog">
+          <ellipse cx="310" cy="58" rx="46" ry="12" fill="#8fa8bd" opacity=".38" filter="url(#fvo-blur8)" />
+          <ellipse cx="286" cy="72" rx="34" ry="10" fill="#7d95ab" opacity=".3" filter="url(#fvo-blur8)" />
+        </g>
+        <g className="fvo-fog fvo-g2">
+          <ellipse cx="120" cy="66" rx="52" ry="12" fill="#8fa8bd" opacity=".3" filter="url(#fvo-blur8)" />
+          <ellipse cx="152" cy="78" rx="36" ry="9" fill="#7d95ab" opacity=".24" filter="url(#fvo-blur8)" />
+        </g>
+      </g>
+
+      {/* estrella fugaz + aves lejanas */}
+      <g className="fvo-shoot">
+        <line x1="60" y1="40" x2="45" y2="33.5" stroke="#eafff6" strokeWidth="1.3" strokeLinecap="round" opacity=".85" />
+        <circle cx="61" cy="40.5" r="1.4" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 4px #bfffe9)' }} />
+      </g>
+      <g className="fvo-vbird" fill="none" stroke="#7f9db0" strokeWidth="1" strokeLinecap="round" opacity=".5">
+        <path className="fvo-flap" d="M150,92 l4,-2.6 4,2.6" />
+        <path className="fvo-flap" style={{ animationDelay: '-.4s' }} d="M161,87 l3.4,-2 3.4,2" />
+        <path className="fvo-flap" style={{ animationDelay: '-.8s' }} d="M143,97 l3,-1.8 3,1.8" />
+      </g>
+
+      {/* ============ COLIBRÍ DE LUZ (ser de luz, protagonista alado) ============ */}
+      <g className="fvo-colibri">
+        <circle className="fvo-estela" r="5" fill="#2dffc4" opacity=".5" filter="url(#fvo-blur3)" />
+        <circle className="fvo-estela fvo-e2" r="4" fill="#ff4fd8" opacity=".4" filter="url(#fvo-blur3)" />
+        <circle className="fvo-estela fvo-e3" r="3" fill="#4fd8ff" opacity=".4" filter="url(#fvo-blur3)" />
+        <g filter="url(#fvo-glow1)">
+          {/* cola bifurcada */}
+          <path d="M-4,-.4 L-12,-3.2 L-8.5,0 L-12,3 Z" fill="#1f9f86" />
+          {/* cuerpo */}
+          <path d="M-4.5,0 C0,-4.6 7,-4.2 10,-1 C12.2,.7 12.2,2.2 10,3.3 C6,5.8 0,5.4 -4.5,1 Z" fill="#2dffc4" />
+          {/* vientre claro */}
+          <path d="M-2.5,2.2 C2,3.8 7,3.6 10,1.8 C7,4.9 1,5.1 -3.4,1.6 Z" fill="#bfffe9" opacity=".7" />
+          {/* gorguera iridiscente */}
+          <path d="M6.6,1.4 C8.6,.2 10.8,1.2 11.4,2.6 C10,3.7 7.6,3.3 6.4,2.1 Z" fill="#ff4fd8" />
+          {/* cabeza */}
+          <circle cx="9" cy="-1.6" r="2.9" fill="#9dff3f" />
+          {/* cresta */}
+          <path d="M8,-3.9 L9.1,-6.4 L10.4,-3.6 Z" fill="#4fd8ff" />
+          {/* ojo */}
+          <circle cx="9.7" cy="-2" r=".85" fill="#04160f" />
+          <circle cx="10" cy="-2.3" r=".3" fill="#eafff6" />
+          {/* pico largo curvo */}
+          <path d="M11.6,-1.1 C15,-1.5 18,-2 20.8,-3.1" stroke="#eafff6" strokeWidth="1" fill="none" strokeLinecap="round" />
+          {/* ala superior (bate) */}
+          <path className="fvo-ala" d="M3,-1 C-3,-11.5 7.5,-16.5 12.5,-10 C10.4,-4 6,-1 3,-1 Z" fill="#ff4fd8" opacity=".85" />
+          {/* ala inferior (bate, desfasada) */}
+          <path className="fvo-ala" style={{ animationDelay: '-.06s' }} d="M4,1.2 C0,9.5 9.5,12.5 12.5,7 C10.2,3 7,1.2 4,1.2 Z" fill="#b28dff" opacity=".5" />
+        </g>
+      </g>
+
+      {/* ============ MONTAÑAS (3 capas = profundidad) ============ */}
+      {/* cordillera LEJANA: la capa nueva de atrás, casi cielo — con la niebla
+          que deriva entre capas la escena gana paralaje sin mover montañas */}
+      <path d="M0,196 C55,162 130,186 210,164 C285,146 340,172 390,152 L390,262 L0,262 Z" fill="#071126" />
+      <ellipse className="fvo-fog fvo-g3" cx="180" cy="196" rx="170" ry="13" fill="#9fd4ff" opacity=".05" filter="url(#fvo-blur8)" />
+      <path d="M0,206 C60,176 122,196 190,180 C258,166 322,192 390,174 L390,262 L0,262 Z" fill="#0a1734" />
+      <path d="M0,234 C70,208 150,228 232,212 C302,200 352,220 390,208 L390,282 L0,282 Z" fill="#0d1e40" />
+
+      {/* rayo del astro: la luz de la luna/el sol cae en diagonal sobre la
+          finca (respira suave; da volumen de iluminación a toda la escena) */}
+      <path className="fvo-rayo" d="M292,88 L188,336 L390,336 L346,86 Z" fill="url(#fvo-rayo-grad)" />
+
+      {/* frailejones que exhalan luz (páramo) */}
+      <g className="fvo-frailejon" strokeLinecap="round">
+        <rect x="44" y="212" width="3" height="12" rx="1.5" fill="#123024" />
+        <g stroke="#9dff3f" strokeWidth="1.6" opacity=".9">
+          <path d="M45.5,212 L38,202" /><path d="M45.5,212 L42,200" /><path d="M45.5,212 L46,199" />
+          <path d="M45.5,212 L50,200" /><path d="M45.5,212 L53,203" />
+        </g>
+        <circle cx="38" cy="201" r="1.4" fill="#d8ff6a" /><circle cx="46" cy="198" r="1.4" fill="#d8ff6a" />
+        <circle cx="53" cy="202" r="1.4" fill="#d8ff6a" />
+      </g>
+      <g className="fvo-frailejon fvo-fr2" strokeLinecap="round">
+        <rect x="76" y="220" width="2.6" height="9" rx="1.3" fill="#123024" />
+        <g stroke="#9dff3f" strokeWidth="1.4" opacity=".85">
+          <path d="M77,220 L71,212" /><path d="M77,220 L76,210" /><path d="M77,220 L82,212" />
+        </g>
+        <circle cx="71" cy="211" r="1.2" fill="#d8ff6a" /><circle cx="82" cy="211" r="1.2" fill="#d8ff6a" />
+      </g>
+      <g className="fvo-frailejon" style={{ animationDelay: '-1.8s' }} strokeLinecap="round">
+        <rect x="364" y="206" width="2.6" height="10" rx="1.3" fill="#123024" />
+        <g stroke="#9dff3f" strokeWidth="1.4" opacity=".85">
+          <path d="M365,206 L359,198" /><path d="M365,206 L364,196" /><path d="M365,206 L370,198" />
+        </g>
+        <circle cx="364" cy="195" r="1.2" fill="#d8ff6a" /><circle cx="370" cy="197" r="1.2" fill="#d8ff6a" />
+      </g>
+
+      {/* ============ FINCA (respira) ============ */}
+      <g className="fvo-breathe">
+        {/* terrazas: curvas de nivel bioluminiscentes */}
+        <path d="M0,258 C80,246 180,256 262,246 C320,240 360,248 390,242 L390,296 L0,296 Z" fill="#102a48" />
+        <path d="M0,258 C80,246 180,256 262,246 C320,240 360,248 390,242" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".4" />
+        <path d="M0,296 C90,286 190,296 280,288 C330,284 364,290 390,284 L390,336 L0,336 Z" fill="#123354" />
+        <path d="M0,296 C90,286 190,296 280,288 C330,284 364,290 390,284" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".5" />
+
+        {/* ============ QUEBRADA BIOLUMINISCENTE (el agua de la finca) ============
+            Baja de la montaña por el costado izquierdo, salta las terrazas en
+            dos cascaditas y remansa en un pocito al pie de la milpa. El flujo
+            es el mismo truco de las hifas (dash que corre); el remanso ondea. */}
+        <g aria-hidden="true">
+          {/* cauce (lecho oscuro + agua) */}
+          <path d="M14,232 C6,248 24,262 14,278 C4,294 22,308 12,320 C9,326 5,331 2,334" fill="none" stroke="#0a2b4a" strokeWidth="9" strokeLinecap="round" />
+          <path d="M14,232 C6,248 24,262 14,278 C4,294 22,308 12,320 C9,326 5,331 2,334" fill="none" stroke="#123f66" strokeWidth="6" strokeLinecap="round" />
+          {/* corriente neón (dos hilos desfasados) */}
+          <path className="fvo-agua" d="M14,232 C6,248 24,262 14,278 C4,294 22,308 12,320 C9,326 5,331 2,334" fill="none" stroke="#4fd8ff" strokeWidth="1.8" strokeLinecap="round" opacity=".8" style={{ filter: 'drop-shadow(0 0 3px rgba(79,216,255,.6))' }} />
+          <path className="fvo-agua fvo-a2" d="M16,234 C9,249 25,263 16,279 C7,294 23,308 14,320" fill="none" stroke="#bfeaff" strokeWidth=".9" strokeLinecap="round" opacity=".6" />
+          {/* cascaditas donde el agua salta cada terraza */}
+          <line className="fvo-destello" x1="15" y1="256" x2="14" y2="262" stroke="#bfeaff" strokeWidth="2.2" strokeLinecap="round" opacity=".8" />
+          <line className="fvo-destello" style={{ animationDelay: '-1.3s' }} x1="13" y1="294" x2="12" y2="300" stroke="#bfeaff" strokeWidth="2" strokeLinecap="round" opacity=".75" />
+          {/* pocito / remanso (refleja la luz del cielo y ondea) */}
+          <ellipse cx="18" cy="331" rx="19" ry="4.4" fill="url(#fvo-agua-grad)" />
+          <ellipse cx="18" cy="331" rx="19" ry="4.4" fill="none" stroke="#4fd8ff" strokeWidth=".9" opacity=".7" />
+          <ellipse className="fvo-reflejo" cx="12" cy="330.4" rx="6.5" ry="1.3" fill="#bfeaff" opacity=".45" />
+          <ellipse className="fvo-onda" cx="18" cy="331" rx="6" ry="1.6" fill="none" stroke="#4fd8ff" strokeWidth=".8" />
+          <ellipse className="fvo-onda fvo-on2" cx="18" cy="331" rx="6" ry="1.6" fill="none" stroke="#bfeaff" strokeWidth=".6" />
+          {/* juncos de la orilla + luciérnaga de agua */}
+          <g stroke="#0f8f6c" strokeWidth="1.2" strokeLinecap="round" fill="none">
+            <path className="fvo-sap fvo-s3" d="M33,330 C33,324 34,320 33,316" />
+            <path className="fvo-sap fvo-s5" d="M36,331 C36,326 37,323 36.5,319" />
+          </g>
+          <circle cx="33" cy="315" r="1.2" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+          <circle className="fvo-fly fvo-f5" cx="26" cy="320" r="1.2" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 4px #4fd8ff)' }} />
+        </g>
+
+        {/* casita campesina con fogón */}
+        <g>
+          <rect x="52" y="250" width="26" height="17" rx="1.5" fill="#160f2e" />
+          <path d="M49,251 L65,238 L81,251 Z" fill="#1e1440" />
+          <path d="M49,251 L65,238 L81,251" fill="none" stroke="#ff4fd8" strokeWidth="1" opacity=".55" />
+          <rect className="fvo-ventana" x="59" y="255" width="5.5" height="7" rx="1" fill="#ffb54f" style={{ filter: 'drop-shadow(0 0 5px #ff9d3f)' }} />
+          <rect x="69" y="256" width="4.5" height="11" rx="1" fill="#0b0820" />
+          <rect x="72.5" y="240" width="3.5" height="9" fill="#160f2e" />
+          <circle className="fvo-brasa" cx="74" cy="238" r="1.5" fill="#ff7a3d" />
+          <circle className="fvo-brasa fvo-br2" cx="75.5" cy="238" r="1.1" fill="#ffb54f" />
+          <circle className="fvo-brasa fvo-br3" cx="73" cy="238" r=".9" fill="#ff4fd8" />
+          {/* la puerta abierta derrama luz cálida al patio */}
+          <ellipse className="fvo-ventana" cx="71.5" cy="268.5" rx="6.5" ry="1.8" fill="#ffb54f" opacity=".16" />
+        </g>
+
+        {/* platanera del patio: hojas que arquean con venas de savia y un
+            racimo con su bellota neón (queda medio detrás del cafetal — capa) */}
+        <g aria-hidden="true">
+          <path d="M92,296 C92,284 91,274 92,266" fill="none" stroke="#14503c" strokeWidth="3" strokeLinecap="round" />
+          <path className="fvo-sap fvo-s2" d="M92,294 C92,284 91.4,274 92,267" fill="none" stroke="#2dffc4" strokeWidth=".8" opacity=".6" strokeLinecap="round" />
+          <path d="M92,266 C83,264 76,257.5 74,250 C80.5,250 89,255.5 92,262 Z" fill="#14503c" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          <path d="M92,266 C101,264 108,257.5 110,250 C103.5,250 95,255.5 92,262 Z" fill="#14503c" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          <path d="M92,264 C86,258 84,250 86.5,243 C90.5,247.5 93,256 92.4,262 Z" fill="#186047" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          <path d="M92,264 C98,258 100,250 97.5,243 C93.5,247.5 91,256 91.6,262 Z" fill="#186047" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          {/* venas de las hojas (laten con la savia) */}
+          <g className="fvo-sap fvo-s4" fill="none" stroke="#9dff3f" strokeWidth=".6" opacity=".65" strokeLinecap="round">
+            <path d="M92,264 C86,260 81,255 78,251" />
+            <path d="M92,264 C98,260 103,255 106,251" />
+            <path d="M91.6,262 C90,255 88.6,250 87.6,246" />
+            <path d="M92.4,262 C94,255 95.4,250 96.4,246" />
+          </g>
+          {/* racimo + bellota (flor) colgando */}
+          <path d="M92,268 C89.6,269.5 88.4,271.5 88.6,274" fill="none" stroke="#0f8f6c" strokeWidth="1" />
+          <circle className="fvo-berry fvo-b2" cx="89.6" cy="269.6" r="1.3" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 3px #ffb54f)' }} />
+          <circle className="fvo-berry fvo-b4" cx="88" cy="271.6" r="1.3" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 3px #ffb54f)' }} />
+          <path d="M88.6,274 L87.4,277.6 L90,277.2 Z" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+        </g>
+
+        {/* cafetales con cerezas neón (terraza alta) */}
+        <g>
+          <g transform="translate(108,252)">
+            <path d="M0,14 L0,4" stroke="#0f8f6c" strokeWidth="2" />
+            <circle cx="0" cy="2" r="7" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="-5" cy="6" r="5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="5" cy="6" r="5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle className="fvo-berry" cx="-4" cy="2" r="1.6" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+            <circle className="fvo-berry fvo-b2" cx="3" cy="-1" r="1.6" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+            <circle className="fvo-berry fvo-b3" cx="6" cy="5" r="1.4" fill="#ff9d3f" style={{ filter: 'drop-shadow(0 0 3px #ff9d3f)' }} />
+          </g>
+          <g transform="translate(146,250)">
+            <path d="M0,14 L0,4" stroke="#0f8f6c" strokeWidth="2" />
+            <circle cx="0" cy="2" r="6" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="-4" cy="6" r="4.5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="4.5" cy="5.5" r="4.5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle className="fvo-berry fvo-b4" cx="-3" cy="1" r="1.5" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+            <circle className="fvo-berry fvo-b2" cx="4" cy="3" r="1.5" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+          </g>
+          <g transform="translate(182,249)">
+            <path d="M0,13 L0,4" stroke="#0f8f6c" strokeWidth="2" />
+            <circle cx="0" cy="1" r="6" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="-4.5" cy="5" r="4.5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="4.5" cy="5" r="4.5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle className="fvo-berry fvo-b3" cx="2" cy="-2" r="1.5" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+            <circle className="fvo-berry" cx="-4" cy="4" r="1.4" fill="#ff9d3f" style={{ filter: 'drop-shadow(0 0 3px #ff9d3f)' }} />
+          </g>
+        </g>
+
+        {/* ============ INVERNADERO-CÉLULA (bio-cúpula viva, protagónico) ============
+            Si el perfil declaró estructura de cubierta (#34), este grupo lleva el
+            marcador del contrato de tests (fvh-estructura + data-forma). */}
+        <g
+          className="fvo-dome"
+          {...(conEstructura
+            ? { 'data-testid': 'fvh-estructura', 'data-forma': estructura.forma || 'generica' }
+            : {})}
+        >
+          {/* halo de vida */}
+          <ellipse cx="298" cy="292" rx="66" ry="58" fill="#2dffc4" opacity=".10" filter="url(#fvo-blur8)" />
+          {/* membrana / vidrio vivo */}
+          <path d="M248,330 C248,282 266,244 298,244 C330,244 348,282 348,330 Z" fill="url(#fvo-membrana)" />
+          {/* paneles geodésicos (latido) */}
+          <g fill="none" stroke="#2dffc4" strokeLinecap="round">
+            <g className="fvo-panel" strokeWidth="1.5" opacity=".7" style={{ filter: 'drop-shadow(0 0 4px rgba(45,255,196,.55))' }}>
+              <path d="M298,244 L298,330" />
+              <path d="M298,244 C280,272 270,300 264,330" />
+              <path d="M298,244 C316,272 326,300 332,330" />
+            </g>
+            <g className="fvo-panel fvo-pa2" strokeWidth="1.3" opacity=".55" style={{ filter: 'drop-shadow(0 0 3px rgba(45,255,196,.5))' }}>
+              <path d="M298,244 C288,272 282,302 278,330" />
+              <path d="M298,244 C308,272 314,302 318,330" />
+            </g>
+            <g className="fvo-panel fvo-pa3" strokeWidth="1.2" opacity=".5" stroke="#4fd8ff">
+              <path d="M267,266 Q298,257 329,266" />
+              <path d="M256,294 Q298,285 340,294" />
+              <path d="M250,318 Q298,309 346,318" />
+            </g>
+          </g>
+          {/* contorno brillante */}
+          <path
+            d="M248,330 C248,282 266,244 298,244 C330,244 348,282 348,330" fill="none"
+            stroke="#2dffc4" strokeWidth="1.8" opacity=".9"
+            style={{ filter: 'drop-shadow(0 0 6px rgba(45,255,196,.7))' }}
+          />
+
+          {/* caballete / venteo del techo + antenas-cilio */}
+          <g className="fvo-vent" stroke="#9dff3f" strokeWidth="1.3" strokeLinecap="round" fill="none">
+            <path d="M290,246 L288,239 L300,236" />
+            <path d="M298,240 L298,231" /><path d="M306,242 L311,235" />
+          </g>
+          <circle className="fvo-vent" cx="298" cy="230" r="1.6" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 4px #9dff3f)' }} />
+          <circle className="fvo-vent" cx="311" cy="234" r="1.2" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+
+          {/* lámpara-reactor colgada del ápice (grow-light que late) */}
+          <path className="fvo-lamplight" d="M298,276 L280,330 L316,330 Z" fill="#2dffc4" opacity=".22" />
+          <line x1="298" y1="250" x2="298" y2="268" stroke="#2dffc4" strokeWidth="1" opacity=".6" />
+          <circle cx="298" cy="276" r="18" fill="#2dffc4" opacity=".16" filter="url(#fvo-blur3)" />
+          <circle className="fvo-reactor" cx="298" cy="276" r="10" fill="#bfffe9" style={{ filter: 'drop-shadow(0 0 10px #2dffc4)' }} />
+          <circle className="fvo-reactor" cx="298" cy="276" r="3.2" fill="#ff8fe4" />
+
+          {/* pólenes / organelas flotando */}
+          <circle className="fvo-organela" cx="268" cy="290" r="2.6" fill="#9dff3f" opacity=".7" />
+          <circle className="fvo-organela fvo-o2" cx="330" cy="298" r="2.2" fill="#4fd8ff" opacity=".7" />
+          <circle className="fvo-organela fvo-o3" cx="284" cy="262" r="1.8" fill="#ff8fe4" opacity=".6" />
+          <circle className="fvo-organela fvo-o2" cx="316" cy="266" r="1.8" fill="#2dffc4" opacity=".5" />
+
+          {/* camas de siembra + plántulas en hilera (dentro) */}
+          <path d="M254,324 L288,324 M308,324 L342,324" stroke="#0e3324" strokeWidth="3.4" strokeLinecap="round" />
+          <g stroke="url(#fvo-tallo)" strokeWidth="1.5" strokeLinecap="round" fill="none">
+            <path className="fvo-sap" d="M260,323 C260,318 258,315 257,312" />
+            <path className="fvo-sap fvo-s2" d="M268,323 C268,317 270,314 271,311" />
+            <path className="fvo-sap fvo-s3" d="M277,323 C277,318 275,315 274,312" />
+            <path className="fvo-sap fvo-s4" d="M319,323 C319,317 321,314 322,311" />
+            <path className="fvo-sap fvo-s2" d="M328,323 C328,318 326,315 325,312" />
+            <path className="fvo-sap fvo-s3" d="M337,323 C337,318 339,315 340,312" />
+          </g>
+          <circle cx="257" cy="311" r="1.5" fill="#d8ff6a" /><circle cx="271" cy="310" r="1.5" fill="#d8ff6a" />
+          <circle cx="274" cy="311" r="1.5" fill="#d8ff6a" /><circle cx="322" cy="310" r="1.5" fill="#d8ff6a" />
+          <circle cx="325" cy="311" r="1.5" fill="#d8ff6a" /><circle cx="340" cy="311" r="1.5" fill="#d8ff6a" />
+
+          {/* puerta / entrada con luz cálida */}
+          <path d="M289,330 L289,309 Q298,301 307,309 L307,330 Z" fill="#0a2018" />
+          <path d="M289,330 L289,309 Q298,301 307,309 L307,330" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".8" />
+          <path className="fvo-ventana" d="M292,330 L292,311 Q298,305 304,311 L304,330 Z" fill="#9dff3f" opacity=".5" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          {/* base / cimiento luminoso */}
+          <rect x="247" y="328" width="102" height="5" rx="2.5" fill="#0c2a20" />
+          <rect x="247" y="328" width="102" height="1.6" rx="1" fill="#2dffc4" opacity=".7" />
+        </g>
+
+        {/* ============ POTRERO: VACA + 3 GALLINAS = ENTRADA AL MUNDO ANIMALES ============
+            El grupo entero es la puerta viva al módulo de animales: con
+            `onAnimales` es un botón (tap / Enter / Espacio) con halo-invitación
+            y etiqueta; sin handler (gate por perfil) queda como arte. La vaca
+            respira, pasta y espanta con la cola; las gallinas picotean. */}
+        <g
+          className="fvo-animales"
+          data-testid="fvo-animales"
+          {...(conAnimales
+            ? {
+                role: 'button',
+                tabIndex: 0,
+                'data-tap': '1',
+                'aria-label': 'Los animales de su finca: la vaca y las gallinas. Toque para entrar al mundo de los animales.',
+                onClick: () => onAnimales(),
+                onKeyDown: (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onAnimales();
+                  }
+                },
+              }
+            : { 'aria-hidden': true })}
+        >
+          {/* pasto del potrero */}
+          <ellipse cx="222" cy="278" rx="31" ry="5.5" fill="#16405a" opacity=".5" />
+          <g stroke="#9dff3f" strokeWidth=".8" strokeLinecap="round" opacity=".6" fill="none">
+            <path d="M197,278 L196,274.4" /><path d="M199.5,278.4 L199.5,275" />
+            <path d="M246,276 L245,272.6" /><path d="M248.5,276.4 L249,273.2" />
+            <path d="M215,282 L214.4,279" /><path d="M231,282.4 L231.6,279.4" />
+          </g>
+
+          {/* cerca viva del potrero (madera oscura + hilos neón) */}
+          <g>
+            <g fill="#241c3e">
+              <rect x="194.2" y="244.5" width="1.8" height="10.5" rx=".9" />
+              <rect x="208.2" y="243.8" width="1.8" height="10.5" rx=".9" />
+              <rect x="222.2" y="243.5" width="1.8" height="10.5" rx=".9" />
+              <rect x="236.2" y="243.8" width="1.8" height="10.5" rx=".9" />
+              <rect x="250.2" y="244.5" width="1.8" height="10.5" rx=".9" />
+            </g>
+            <path d="M194,247.4 C208,246.2 238,246.2 252,247.4" fill="none" stroke="#b28dff" strokeWidth=".9" opacity=".55" />
+            <path d="M194,251.4 C208,250.2 238,250.2 252,251.4" fill="none" stroke="#2dffc4" strokeWidth=".9" opacity=".5" />
+            <circle className="fvo-nodo" cx="223.1" cy="243.2" r="1" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+          </g>
+
+          {/* VACA bioluminiscente (mira hacia la casa; el organismo la abraza:
+              sus manchas laten con el MISMO pulso de la red micorrízica) */}
+          <g className="fvo-vaca">
+            <ellipse cx="221" cy="280" rx="18" ry="3" fill="#000" opacity=".35" />
+            {/* cola (espanta de a ratos) + borla-cocuyo */}
+            <g className="fvo-vaca-cola">
+              <path d="M236.5,258 C240.5,262 241.5,268 239.5,274" fill="none" stroke="#241c3e" strokeWidth="1.6" strokeLinecap="round" />
+              <circle cx="239.5" cy="275" r="1.9" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px #2dffc4)' }} />
+            </g>
+            {/* patas con pezuñas de luz */}
+            <g stroke="#241c3e" strokeWidth="3" strokeLinecap="round">
+              <path d="M210,271 L209.4,279" /><path d="M215.5,272.5 L215.5,279.6" />
+              <path d="M228.5,272.5 L228.5,279.6" /><path d="M234,271 L234.6,279" />
+            </g>
+            <g fill="#b28dff" opacity=".8">
+              <circle cx="209.4" cy="279.6" r=".9" /><circle cx="215.5" cy="280.2" r=".9" />
+              <circle cx="228.5" cy="280.2" r=".9" /><circle cx="234.6" cy="279.6" r=".9" />
+            </g>
+            {/* cuerpo (respira) con manchas que laten al pulso del corazón */}
+            <g className="fvo-vaca-cuerpo">
+              <ellipse cx="222" cy="264" rx="16" ry="9.5" fill="#241c3e" stroke="#b28dff" strokeWidth=".8" strokeOpacity=".45" />
+              <path className="fvo-mancha" d="M210,259 C215,255.5 221,256 223.5,260 C221,264.5 213.5,265.5 209.5,262.5 Z" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px rgba(45,255,196,.7))' }} />
+              <path className="fvo-mancha fvo-m2" d="M229,266 C233.5,264 237,266 236,269.5 C233,271.5 228.5,270.5 227.5,268 Z" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 3px rgba(79,216,255,.7))' }} />
+              <circle className="fvo-mancha fvo-m3" cx="216" cy="269" r="2.4" fill="#ff8fe4" style={{ filter: 'drop-shadow(0 0 3px rgba(255,143,228,.7))' }} />
+              {/* ubre con su lucecita (la leche también es vida) */}
+              <path d="M226.5,272.5 a3.2,2.6 0 0 0 6.2,0 Z" fill="#ff9ee8" opacity=".85" />
+            </g>
+            {/* cabeza: pasta y se alza a mirar; orejas que espantan */}
+            <g className="fvo-vaca-cabeza">
+              <path d="M209,258 L213,260" stroke="#241c3e" strokeWidth="5" strokeLinecap="round" />
+              <ellipse cx="204.5" cy="257" rx="6.2" ry="5" fill="#241c3e" stroke="#b28dff" strokeWidth=".7" strokeOpacity=".4" />
+              {/* cachos de luna */}
+              <g fill="none" stroke="#e8dcff" strokeWidth="1.2" strokeLinecap="round">
+                <path d="M201.5,252.6 C200,250 200.8,248.4 202.8,247.8" />
+                <path d="M207.5,252.4 C209,250 208.4,248.2 206.4,247.8" />
+              </g>
+              <path className="fvo-vaca-oreja" d="M209.5,254 Q212.5,251.5 213.5,253.5 Q212,256 209.8,256 Z" fill="#3a2f52" />
+              {/* hocico + ollar */}
+              <ellipse cx="200" cy="259.5" rx="3.4" ry="2.5" fill="#3a2f52" />
+              <circle cx="198.8" cy="259.3" r=".5" fill="#0a0618" />
+              {/* ojo de cocuyo */}
+              <circle cx="206" cy="255.8" r="1.05" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 3px #2dffc4)' }} />
+              <circle cx="206.35" cy="255.45" r=".35" fill="#eafff6" />
+              {/* mancha de la frente */}
+              <path className="fvo-mancha fvo-m2" d="M203,253.6 C204.6,252.6 206.4,253 206.8,254.4 C205.6,255.6 203.6,255.4 203,253.6 Z" fill="#2dffc4" opacity=".7" />
+            </g>
+          </g>
+
+          {/* 3 GALLINAS que picotean (cada una con su color y su ritmo) */}
+          <GallinaLuz x={205} y={281} cuerpo="#ffb54f" cola="#ff9d3f" clase="" />
+          <GallinaLuz x={220.5} y={283.5} cuerpo="#ff8fe4" cola="#d86ac0" clase="fvo-ga2" espejo />
+          <GallinaLuz x={237} y={281} cuerpo="#8fc8ef" cola="#5a9fd4" clase="fvo-ga3" />
+
+          {/* halo-invitación + etiqueta (solo cuando el potrero es la puerta
+              al módulo; el anillo de foco lo enciende :focus-visible) */}
+          {conAnimales && (
+            <g>
+              <ellipse className="fvo-cta-halo" cx="222" cy="264" rx="34" ry="22" fill="none" stroke="#ffb54f" strokeWidth="1" />
+              <ellipse className="fvo-cta-anillo" cx="222" cy="264" rx="34" ry="22" fill="none" stroke="#ffd76a" strokeWidth="1.4" opacity="0" />
+              <text
+                className="fvo-cta-tag"
+                x="222"
+                y="238"
+                fill="#ffb54f"
+                fontFamily="ui-monospace,monospace"
+                fontSize="7"
+                letterSpacing="1.5"
+                textAnchor="middle"
+              >
+                LOS ANIMALES ▸
+              </text>
+              {/* zona de tap generosa (invisible) sobre todo el potrero.
+                  OJO: sin <title> a propósito — un <title> en el subárbol
+                  aporta un rect degenerado en el origen del SVG y Chromium
+                  infla el boundingClientRect del botón hasta cubrir media
+                  escena (el aria-label del grupo ya cubre accesibilidad). */}
+              <rect x="190" y="230" width="66" height="58" fill="#000" opacity="0" style={{ pointerEvents: 'all' }} />
+            </g>
+          )}
+        </g>
+
+        {/* ============ MILPA FRONTAL: maíz de savia neón ============ */}
+        <g strokeLinecap="round" fill="none">
+          <g className="fvo-sap">
+            <path d="M40,336 C40,318 38,306 40,294" stroke="url(#fvo-tallo)" strokeWidth="2.4" />
+            <path d="M40,318 C33,314 28,308 27,300" stroke="#9dff3f" strokeWidth="1.6" opacity=".9" />
+            <path d="M40,310 C47,306 52,300 53,293" stroke="#9dff3f" strokeWidth="1.6" opacity=".9" />
+            <ellipse cx="40" cy="291" rx="3" ry="5" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          </g>
+          <g className="fvo-sap fvo-s2">
+            <path d="M78,338 C78,318 80,304 78,292" stroke="url(#fvo-tallo)" strokeWidth="2.6" />
+            <path d="M78,320 C70,316 65,309 64,301" stroke="#9dff3f" strokeWidth="1.7" opacity=".9" />
+            <path d="M78,312 C86,308 91,302 92,294" stroke="#9dff3f" strokeWidth="1.7" opacity=".9" />
+            <ellipse cx="78" cy="289" rx="3.2" ry="5.4" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          </g>
+          <g className="fvo-sap fvo-s3">
+            <path d="M118,337 C118,316 116,304 118,290" stroke="url(#fvo-tallo)" strokeWidth="2.6" />
+            <path d="M118,318 C110,314 105,307 104,299" stroke="#9dff3f" strokeWidth="1.7" opacity=".9" />
+            <path d="M118,309 C126,305 131,299 132,291" stroke="#9dff3f" strokeWidth="1.7" opacity=".9" />
+            <ellipse cx="118" cy="287" rx="3.2" ry="5.4" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          </g>
+          <g className="fvo-sap fvo-s4">
+            <path d="M156,338 C156,320 158,308 156,296" stroke="url(#fvo-tallo)" strokeWidth="2.4" />
+            <path d="M156,320 C149,316 144,310 143,302" stroke="#9dff3f" strokeWidth="1.6" opacity=".9" />
+            <path d="M156,313 C163,309 168,303 169,296" stroke="#9dff3f" strokeWidth="1.6" opacity=".9" />
+            <ellipse cx="156" cy="293" rx="3" ry="5" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          </g>
+          {/* frijol enredado (milpa) */}
+          <path className="fvo-sap fvo-s5" d="M92,336 C88,328 96,324 92,316 C88,308 96,304 93,297" stroke="#4fd8ff" strokeWidth="1.4" opacity=".85" />
+          <circle cx="93" cy="296" r="1.6" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 3px #4fd8ff)' }} />
+          {/* auyama que late */}
+          <g className="fvo-sap fvo-s2">
+            <path d="M196,336 C202,330 212,330 218,334" stroke="#0f8f6c" strokeWidth="1.6" />
+            <ellipse cx="210" cy="331" rx="7" ry="5.4" fill="#132c1e" stroke="#ffb54f" strokeWidth="1.2" style={{ filter: 'drop-shadow(0 0 5px rgba(255,181,79,.7))' }} />
+            <path d="M210,326 C210,323 212,322 213,321" stroke="#9dff3f" strokeWidth="1.2" />
+          </g>
+        </g>
+
+        {/* penachos (flor del maíz) que laten */}
+        <g stroke="#d8ff6a" strokeWidth="1" strokeLinecap="round" fill="none" opacity=".9">
+          <g className="fvo-sap"><path d="M40,286 L36,280" /><path d="M40,286 L40,279" /><path d="M40,286 L44,281" /></g>
+          <g className="fvo-sap fvo-s2"><path d="M78,284 L74,278" /><path d="M78,284 L78,277" /><path d="M78,284 L82,279" /></g>
+          <g className="fvo-sap fvo-s3"><path d="M118,282 L114,276" /><path d="M118,282 L118,275" /><path d="M118,282 L122,277" /></g>
+          <g className="fvo-sap fvo-s4"><path d="M156,288 L152,282" /><path d="M156,288 L156,281" /><path d="M156,288 L160,283" /></g>
+        </g>
+        <circle className="fvo-berry" cx="40" cy="279" r="1.1" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 3px #d8ff6a)' }} />
+        <circle className="fvo-berry fvo-b3" cx="78" cy="277" r="1.1" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 3px #d8ff6a)' }} />
+        <circle className="fvo-berry fvo-b2" cx="118" cy="275" r="1.1" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 3px #d8ff6a)' }} />
+
+        {/* ============ PERSONAJES: campesino con su perro criollo ============ */}
+        {/* pool de luz del farol */}
+        <ellipse className="fvo-lantpool" cx="240" cy="335" rx="17" ry="4.4" fill="#2dffc4" opacity=".4" filter="url(#fvo-blur3)" />
+
+        <g className="fvo-campesino">
+          <ellipse cx="222" cy="336" rx="12" ry="2.6" fill="#000" opacity=".35" />
+          {/* botas */}
+          <path d="M217,325 L216,335" stroke="#0f1424" strokeWidth="4" strokeLinecap="round" />
+          <path d="M226,325 L227,335" stroke="#0f1424" strokeWidth="4" strokeLinecap="round" />
+          <ellipse cx="214.5" cy="335" rx="3" ry="1.5" fill="#0f1424" />
+          <ellipse cx="228.5" cy="335" rx="3" ry="1.5" fill="#0f1424" />
+          {/* brazo trasero */}
+          <path d="M219,312 C214,316 213,320 215,324" stroke="#7a3a24" strokeWidth="3" strokeLinecap="round" fill="none" />
+          {/* ruana / poncho */}
+          <path d="M222,305 L209,328 L235,328 Z" fill="#a85a34" />
+          <path d="M222,305 L209,328 L235,328 Z" fill="none" stroke="#2dffc4" strokeWidth=".6" opacity=".4" />
+          <path d="M214,322 L230,322" stroke="#ffb54f" strokeWidth="1.3" opacity=".85" />
+          <path d="M216,318 L228,318" stroke="#2dffc4" strokeWidth="1" opacity=".7" />
+          <path d="M218,314 L226,314" stroke="#ff8fe4" strokeWidth=".8" opacity=".6" />
+          {/* fleco */}
+          <g stroke="#8a4a2c" strokeWidth=".7" opacity=".9">
+            <path d="M211,328 L210,331" /><path d="M216,328 L216,331.5" /><path d="M222,328 L222,332" />
+            <path d="M228,328 L228,331.5" /><path d="M233,328 L234,331" />
+          </g>
+          {/* cuello */}
+          <rect x="219.4" y="302" width="5.2" height="6" rx="2.2" fill="#7a3a24" />
+          {/* cabeza */}
+          <g className="fvo-head-c">
+            <circle cx="222" cy="302" r="4.2" fill="#d99a6c" />
+            <path d="M220.2,303.4 Q222,305 223.8,303.4" stroke="#7a3a24" strokeWidth=".7" fill="none" strokeLinecap="round" />
+            <circle cx="220.4" cy="301.4" r=".55" fill="#3a2416" /><circle cx="223.6" cy="301.4" r=".55" fill="#3a2416" />
+            {/* sombrero aguadeño */}
+            <path d="M217,298.5 Q222,290.5 227,298.5 Z" fill="#cdb87a" />
+            <path d="M217.6,297.6 L226.4,297.6" stroke="#a8935a" strokeWidth=".9" />
+            <ellipse cx="222" cy="299" rx="9.5" ry="2.7" fill="#d8c48a" />
+            <ellipse cx="222" cy="299" rx="9.5" ry="2.7" fill="none" stroke="#2dffc4" strokeWidth=".5" opacity=".45" />
+            <ellipse cx="222" cy="298.4" rx="9.5" ry="2.4" fill="#e2d199" opacity=".5" />
+          </g>
+          {/* brazo delantero con el farol (se mece) */}
+          <g className="fvo-lantern">
+            <path d="M224,309 C230,309 235,311 237,314" stroke="#7a3a24" strokeWidth="3" strokeLinecap="round" fill="none" />
+            <line x1="237.5" y1="312.5" x2="238" y2="321" stroke="#5a3020" strokeWidth="1" />
+            <path d="M234,325 A4.2,4.2 0 0 1 242,325" fill="none" stroke="#0e3324" strokeWidth=".7" />
+            <circle className="fvo-lantorb" cx="238" cy="325.5" r="4.4" fill="#bfffe9" style={{ filter: 'drop-shadow(0 0 9px #2dffc4)' }} />
+            <circle cx="238" cy="325.5" r="1.9" fill="#eafff6" />
+            <line x1="238" y1="321" x2="238" y2="330" stroke="#0e3324" strokeWidth=".55" opacity=".8" />
+          </g>
+        </g>
+
+        {/* perro criollo */}
+        <g className="fvo-dog">
+          <ellipse cx="248" cy="336" rx="8" ry="1.8" fill="#000" opacity=".3" />
+          <path d="M244,331 L244,335.5" stroke="#8a5a34" strokeWidth="1.7" strokeLinecap="round" />
+          <path d="M251,331 L251,335.5" stroke="#8a5a34" strokeWidth="1.7" strokeLinecap="round" />
+          <path className="fvo-tail" d="M241,329 C236,327 235,330.5 237,332.5" stroke="#a56b3c" strokeWidth="1.8" fill="none" strokeLinecap="round" />
+          <ellipse cx="246" cy="330" rx="6.2" ry="3.3" fill="#a56b3c" />
+          <circle cx="252.5" cy="327.5" r="3.1" fill="#b5763f" />
+          <path className="fvo-earw" d="M251,325 Q249,321.5 251.2,320.6 Q253,323 252,326 Z" fill="#7f5230" />
+          <path d="M254.5,328 L258,328.6 L254.5,330.2 Z" fill="#7f5230" />
+          <circle cx="257.4" cy="328.7" r=".8" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 2px #2dffc4)' }} />
+          <circle cx="253.4" cy="326.8" r=".55" fill="#2a1a10" />
+          <path d="M250,329.5 Q252.5,331.4 255,329.4" stroke="#2dffc4" strokeWidth=".8" fill="none" opacity=".8" />
+        </g>
+
+        {/* polillas rondando el farol (la luz siempre convoca su corte) */}
+        <circle className="fvo-polilla" cx="233" cy="318" r="1" fill="#eafff6" opacity=".8" />
+        <circle className="fvo-polilla fvo-po2" cx="244" cy="321" r=".8" fill="#ffe6c9" opacity=".75" />
+
+        {/* cocuyos */}
+        <circle className="fvo-fly" cx="100" cy="272" r="1.7" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 4px #d8ff6a)' }} />
+        <circle className="fvo-fly fvo-f2" cx="210" cy="258" r="1.5" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px #2dffc4)' }} />
+        <circle className="fvo-fly fvo-f3" cx="172" cy="300" r="1.4" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 4px #ff4fd8)' }} />
+        <circle className="fvo-fly fvo-f4" cx="248" cy="318" r="1.6" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 4px #d8ff6a)' }} />
+        <circle className="fvo-fly fvo-f5" cx="30" cy="290" r="1.4" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 4px #4fd8ff)' }} />
+        <circle className="fvo-fly fvo-f2" style={{ animationDelay: '-6s, -1.8s', filter: 'drop-shadow(0 0 4px #d8ff6a)' }} cx="140" cy="264" r="1.3" fill="#d8ff6a" />
+        <circle className="fvo-fly fvo-f3" style={{ animationDelay: '-2.4s, -1.1s', filter: 'drop-shadow(0 0 4px #ff8fe4)' }} cx="356" cy="304" r="1.4" fill="#ff8fe4" />
+      </g>
+
+      {/* niebla de páramo */}
+      <g>
+        <ellipse className="fvo-fog" cx="90" cy="250" rx="120" ry="16" fill="#9fd4ff" opacity=".07" filter="url(#fvo-blur8)" />
+        <ellipse className="fvo-fog fvo-g2" cx="270" cy="240" rx="140" ry="14" fill="#b28dff" opacity=".06" filter="url(#fvo-blur8)" />
+        <ellipse className="fvo-fog fvo-g3" cx="180" cy="262" rx="150" ry="12" fill="#eafff6" opacity=".05" filter="url(#fvo-blur8)" />
+      </g>
+
+      {/* ============ CORTE DE SUELO: LA RED VIVA ============ */}
+      <rect y="336" width="390" height="150" fill="url(#fvo-suelo)" />
+      {/* borde del suelo: interfase viva */}
+      <path d="M0,336 L390,336" stroke="#2dffc4" strokeWidth="1.4" opacity=".55" />
+      <path d="M0,338.5 L390,338.5" stroke="#ff4fd8" strokeWidth=".7" opacity=".25" />
+
+      {/* piedras */}
+      <ellipse cx="60" cy="392" rx="13" ry="8" fill="#0d1226" />
+      <ellipse cx="330" cy="380" rx="10" ry="6.5" fill="#0d1226" />
+      <ellipse cx="140" cy="440" rx="15" ry="9" fill="#0b0f20" />
+      <ellipse cx="285" cy="448" rx="11" ry="7" fill="#0b0f20" />
+
+      <g className="fvo-net">
+        {/* hifas principales (desde el corazón) */}
+        <g fill="none" stroke="#2dffc4" strokeWidth="1.5" opacity=".8" style={{ filter: 'drop-shadow(0 0 3px rgba(45,255,196,.5))' }}>
+          <path className="fvo-hypha" d="M195,405 C160,392 120,380 78,352" />
+          <path className="fvo-hypha fvo-slow" d="M195,405 C230,388 268,375 300,350" />
+          <path className="fvo-hypha" d="M195,405 C185,378 172,360 150,344" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M195,405 C205,382 220,362 240,348" />
+          <path className="fvo-hypha fvo-rev" d="M195,405 C240,420 300,432 368,424" />
+          <path className="fvo-hypha fvo-slow" d="M195,405 C150,428 90,440 24,430" />
+          <path className="fvo-hypha" d="M195,405 C196,432 190,455 178,474" />
+        </g>
+        {/* hifas secundarias */}
+        <g fill="none" stroke="#4fd8ff" strokeWidth=".9" opacity=".5">
+          <path className="fvo-hypha fvo-slow" d="M78,352 C60,348 45,342 38,338" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M78,352 C86,346 100,342 116,340" />
+          <path className="fvo-hypha fvo-slow" d="M300,350 C315,344 330,340 344,338" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M300,350 C290,344 278,341 264,339" />
+          <path className="fvo-hypha fvo-slow" d="M240,348 C246,344 252,341 258,339" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M150,344 C140,341 130,339 120,338" />
+          <path className="fvo-hypha fvo-slow" d="M368,424 C376,418 382,410 386,400" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M24,430 C18,422 14,412 12,402" />
+        </g>
+        {/* hifas profundas magenta */}
+        <g fill="none" stroke="#ff4fd8" strokeWidth=".8" opacity=".4">
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M178,474 C150,468 120,466 92,470" />
+          <path className="fvo-hypha fvo-slow" d="M178,474 C210,468 250,466 286,470" />
+          <path className="fvo-hypha fvo-slow" d="M195,440 C160,450 130,452 104,448" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M195,440 C235,450 270,452 300,446" />
+        </g>
+
+        {/* micelio FINO: la trama dendrítica de verdad — hifas delgadas que se
+            ramifican en Y desde las troncales y tejen el suelo entero (así se
+            ve una red micorrízica real, no solo cables gruesos) */}
+        <g className="fvo-micelio" fill="none" stroke="#2dffc4" strokeWidth=".6" opacity=".38" strokeLinecap="round">
+          <path d="M160,392 C150,388 142,382 138,374 M138,374 C134,368 128,364 120,362 M138,374 C142,366 140,358 136,352" />
+          <path d="M230,390 C242,384 250,376 254,366 M254,366 C258,358 266,354 274,352 M254,366 C250,356 252,348 258,342" />
+          <path d="M195,428 C186,434 176,438 164,440 M164,440 C154,442 146,448 142,456 M164,440 C160,448 162,456 168,462" />
+          <path d="M195,428 C206,434 216,438 228,440 M228,440 C240,442 248,448 252,456 M228,440 C234,448 232,456 226,462" />
+          <path d="M120,404 C108,400 98,400 88,404 M88,404 C78,408 70,406 62,400 M88,404 C84,412 78,416 70,418" />
+          <path d="M270,406 C282,402 292,402 302,406 M302,406 C312,410 320,408 328,402 M302,406 C306,414 312,418 320,420" />
+          <path d="M78,352 C74,362 68,370 60,376 M60,376 C54,380 50,386 48,394" />
+          <path d="M300,350 C304,360 310,368 318,374 M318,374 C324,378 328,384 330,392" />
+          <path d="M156,350 C152,358 146,364 138,368 M138,368 C132,371 128,376 126,382" />
+          <path d="M240,348 C244,356 250,362 258,366 M258,366 C264,369 268,374 270,380" />
+          <path d="M40,348 C38,358 34,366 28,372" />
+          <path d="M118,349 C120,358 124,366 130,372" />
+        </g>
+
+        {/* bulbos de raíz (bajo cada planta) */}
+        <g>
+          <circle cx="40" cy="348" r="9" fill="url(#fvo-bulbo)" /><circle cx="40" cy="348" r="2.2" fill="#bfffe9" />
+          <circle cx="78" cy="352" r="10" fill="url(#fvo-bulbo)" /><circle cx="78" cy="352" r="2.4" fill="#bfffe9" />
+          <circle cx="118" cy="349" r="9" fill="url(#fvo-bulbo)" /><circle cx="118" cy="349" r="2.2" fill="#bfffe9" />
+          <circle cx="156" cy="350" r="8" fill="url(#fvo-bulbo)" /><circle cx="156" cy="350" r="2" fill="#bfffe9" />
+          <circle cx="240" cy="348" r="8" fill="url(#fvo-bulbo)" /><circle cx="240" cy="348" r="2" fill="#bfffe9" />
+          <circle cx="300" cy="350" r="11" fill="url(#fvo-bulbo)" /><circle cx="300" cy="350" r="2.6" fill="#bfffe9" />
+        </g>
+        {/* raíces cortas planta→bulbo */}
+        <g stroke="#2dffc4" strokeWidth="1" opacity=".55" fill="none">
+          <path d="M40,336 L40,346" /><path d="M78,338 L78,350" /><path d="M118,337 L118,347" />
+          <path d="M156,338 L156,348" /><path d="M210,336 C214,340 222,344 240,347" />
+          <path d="M298,332 C298,338 299,344 300,348" />
+        </g>
+        {/* raíces LATERALES de cada planta: el bulbo no flota — la raíz se
+            ramifica y la hifa la encuentra en la punta (micorriza real) */}
+        <g stroke="#9dff3f" strokeWidth=".8" opacity=".5" fill="none" strokeLinecap="round">
+          <path d="M40,346 C36,352 32,356 26,358 M40,346 C44,352 48,355 54,356" />
+          <path d="M78,350 C72,356 66,360 58,362 M78,350 C84,356 90,359 98,360" />
+          <path d="M118,347 C112,353 106,357 98,359 M118,347 C124,353 130,356 138,357" />
+          <path d="M156,348 C151,354 146,357 140,359 M156,348 C161,354 166,357 172,358" />
+          <path d="M240,347 C235,353 230,356 224,358 M240,347 C245,353 250,356 256,357" />
+          <path d="M300,348 C294,355 287,359 278,361 M300,348 C306,355 313,359 322,361" />
+        </g>
+        {/* nodos micorrízicos: el punto donde la hifa abraza la punta de la
+            raíz e intercambia azúcar por nutrientes (titilan suave) */}
+        <g fill="#bfffe9">
+          <circle className="fvo-nodo" cx="26" cy="358" r="1" />
+          <circle className="fvo-nodo fvo-n2" cx="58" cy="362" r="1.1" />
+          <circle className="fvo-nodo fvo-n3" cx="98" cy="359.5" r="1" />
+          <circle className="fvo-nodo" cx="140" cy="359" r="1" />
+          <circle className="fvo-nodo fvo-n2" cx="224" cy="358" r="1" />
+          <circle className="fvo-nodo fvo-n3" cx="278" cy="361" r="1.1" />
+          <circle className="fvo-nodo fvo-n2" cx="322" cy="361" r="1.1" />
+        </g>
+      </g>
+
+      {/* ============ LA VIDA DEL SUELO: lombrices y bichitos ============ */}
+      {/* lombriz de tierra (rosada, segmentada, con clitelo) que avanza */}
+      <g className="fvo-lombriz">
+        <path d="M96,432 C104,428 112,432 118,428 C124,424 130,427 134,432" fill="none" stroke="#ff8fb0" strokeWidth="3.4" strokeLinecap="round" opacity=".85" />
+        <path d="M96,432 C104,428 112,432 118,428 C124,424 130,427 134,432" fill="none" stroke="#ffd0dc" strokeWidth="1" strokeLinecap="round" opacity=".5" />
+        {/* segmentos */}
+        <g stroke="#e06a8e" strokeWidth=".7" opacity=".6">
+          <path d="M102,428.6 L102.6,431.6" /><path d="M108,429 L108,432" /><path d="M122,426.4 L122.6,429.2" /><path d="M128,426.6 L128,429.6" />
+        </g>
+        {/* clitelo (el anillo grueso) */}
+        <path d="M112,430.4 L116,429" stroke="#ff6f8a" strokeWidth="3.8" strokeLinecap="round" />
+      </g>
+      <g className="fvo-lombriz fvo-l2">
+        <path d="M330,472 C324,468 318,471 312,468 C306,465 300,468 296,472" fill="none" stroke="#ff8fb0" strokeWidth="3" strokeLinecap="round" opacity=".8" />
+        <path d="M314,469.4 L310,468.4" stroke="#ff6f8a" strokeWidth="3.4" strokeLinecap="round" />
+        <g stroke="#e06a8e" strokeWidth=".6" opacity=".55">
+          <path d="M324,469 L324,471.6" /><path d="M304,467 L304,469.6" />
+        </g>
+      </g>
+
+      {/* escarabajo del suelo (camina despacio entre las piedras) */}
+      <g className="fvo-bicho">
+        <ellipse cx="66" cy="416" rx="3.4" ry="2.3" fill="#4fd8ff" opacity=".75" />
+        <circle cx="70" cy="415.4" r="1.3" fill="#2f9fc4" />
+        <path d="M63,414.6 Q66,413.2 69,414.4" stroke="#bfeaff" strokeWidth=".5" fill="none" opacity=".7" />
+        <g stroke="#4fd8ff" strokeWidth=".6" opacity=".7" fill="none">
+          <path d="M64,418 L62,420" /><path d="M66,418.4 L65,421" /><path d="M68,418 L69,420.6" />
+        </g>
+      </g>
+      {/* colémbolo (bichito saltarín, descompone la hojarasca) */}
+      <g className="fvo-bicho fvo-bi2">
+        <ellipse cx="330" cy="446" rx="2.6" ry="1.7" fill="#d8ff6a" opacity=".8" />
+        <circle cx="332.6" cy="445.4" r=".9" fill="#9dff3f" />
+        <path d="M327.6,445.4 Q326,444 325.2,442.6" stroke="#d8ff6a" strokeWidth=".7" fill="none" opacity=".8" />
+      </g>
+
+      {/* ============ CORAZÓN-SEMILLA MICORRÍZICO (la vida bajo la tierra) ============
+          Con `onPregunte` el corazón entero es un BOTÓN (tap / Enter / Espacio)
+          que abre el agente — el mismo patrón del potrero→animales: la metáfora
+          central deja de ser decoración y pasa a ser LA acción de preguntar.
+          Sin handler queda como arte (aria-hidden, sin foco). */}
+      <g
+        className={`fvo-corazon-grupo${conPregunte ? ' fvo-corazon-tap' : ''}`}
+        data-testid="fvo-corazon"
+        {...(conPregunte
+          ? {
+              role: 'button',
+              tabIndex: 0,
+              'aria-label': 'El corazón de su finca: toque y pregúntele a Chagra con su voz.',
+              onClick: () => onPregunte(),
+              onKeyDown: (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onPregunte();
+                }
+              },
+            }
+          : { 'aria-hidden': true })}
+      >
+      {/* cámara de suelo: da contexto y contraste al órgano */}
+      <ellipse cx="195" cy="406" rx="42" ry="36" fill="#02040c" opacity=".55" />
+      <ellipse cx="195" cy="406" rx="42" ry="36" fill="none" stroke="#0f3a30" strokeWidth="1" opacity=".55" />
+      {/* halo-invitación del tap (solo cuando el corazón es botón) */}
+      {conPregunte && (
+        <circle className="fvo-corazon-halo" cx="195" cy="406" r="32" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".5" />
+      )}
+      {/* ondas de latido */}
+      <circle className="fvo-heart-wave" cx="195" cy="406" r="24" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
+      <circle className="fvo-heart-wave" style={{ animationDelay: '.6s' }} cx="195" cy="406" r="24" fill="none" stroke="#ff4fd8" strokeWidth="1" />
+      {/* resplandor contenido */}
+      <circle className="fvo-heart" cx="195" cy="406" r="15" fill="url(#fvo-corazon)" />
+
+      {/* cuellos de raíz gruesos: las micorrizas nacen visiblemente de la semilla */}
+      <g className="fvo-net" stroke="#2dffc4" strokeLinecap="round" fill="none" style={{ filter: 'drop-shadow(0 0 4px rgba(45,255,196,.6))' }}>
+        <path strokeWidth="3" d="M195,406 L182,399" />
+        <path strokeWidth="3" d="M195,406 L208,399" />
+        <path strokeWidth="2.6" d="M195,406 L187,395" />
+        <path strokeWidth="2.6" d="M195,406 L204,395" />
+        <path strokeWidth="2.6" d="M195,406 L210,407" />
+        <path strokeWidth="2.6" d="M195,406 L180,408" />
+        <path strokeWidth="2.6" d="M195,406 L192,420" />
+      </g>
+
+      {/* SEMILLA que germina: forma reconocible = origen de la vida */}
+      {/* radícula (taproot) hacia abajo */}
+      <path d="M195,423 C195,431 193,437 189,443" stroke="#2dffc4" strokeWidth="1.5" fill="none" strokeLinecap="round" opacity=".85" style={{ filter: 'drop-shadow(0 0 3px #2dffc4)' }} />
+      <path d="M195,428 C197,431 200,432 203,432" stroke="#2dffc4" strokeWidth="1" fill="none" strokeLinecap="round" opacity=".7" />
+      {/* brote hacia la superficie */}
+      <path d="M195,390 C195,383 193,379 189,376" stroke="#9dff3f" strokeWidth="1.7" fill="none" strokeLinecap="round" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+      <path d="M195,384 C198,381 201,380 204,381" stroke="#9dff3f" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <circle cx="188.6" cy="375.6" r="1.5" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+      <circle cx="204.3" cy="380.6" r="1.3" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+      {/* cuerpo de la semilla (late) */}
+      <g className="fvo-heart">
+        <path d="M195,390 C206,396 206,416 195,424 C184,416 184,396 195,390 Z" fill="#0e5a44" stroke="#2dffc4" strokeWidth="1.5" style={{ filter: 'drop-shadow(0 0 6px rgba(45,255,196,.55))' }} />
+        <path d="M195,392 L195,422" stroke="#2dffc4" strokeWidth=".8" opacity=".55" />
+        <circle cx="195" cy="407" r="9.5" fill="#bfffe9" opacity=".3" />
+        <circle cx="195" cy="407" r="5.2" fill="#eafff6" />
+        <circle cx="195" cy="407" r="2.2" fill="#ff8fe4" />
+      </g>
+      {/* cierre del grupo tappable del corazón (la etiqueta va aparte, abajo) */}
+      </g>
+
+      {/* nutrientes viajando */}
+      <circle className="fvo-spark fvo-p1" r="2.2" fill="#bfffe9" />
+      <circle className="fvo-spark fvo-p2" r="2.2" fill="#bfffe9" />
+      <circle className="fvo-spark fvo-p3" r="1.9" fill="#d8ff6a" />
+      <circle className="fvo-spark fvo-p4" r="1.9" fill="#ffb54f" />
+      <circle className="fvo-spark fvo-p5" r="1.9" fill="#ff9ee8" />
+      <circle className="fvo-spark fvo-p6" r="2.2" fill="#bfffe9" />
+
+      {/* el pocito se FILTRA: el agua alimenta la red micorrízica (gotea al
+          bulbo más cercano — la quebrada también es parte del organismo) */}
+      <g aria-hidden="true">
+        <path className="fvo-hypha fvo-slow" d="M20,336 C26,342 32,346 38,348" fill="none" stroke="#4fd8ff" strokeWidth=".9" opacity=".5" />
+        <g stroke="#4fd8ff" strokeWidth=".8" strokeLinecap="round" opacity=".35">
+          <path d="M10,338 L9,344" /><path d="M18,339 L17.4,346" /><path d="M27,338 L26.4,343" />
+        </g>
+      </g>
+
+      {/* hongos bioluminiscentes en el borde del corte */}
+      <g>
+        <g transform="translate(58,336)">
+          <path d="M0,0 L0,-7" stroke="#9fd4ff" strokeWidth="2" strokeLinecap="round" opacity=".8" />
+          <path className="fvo-cap" d="M-7,-6 A7,4.6 0 0 1 7,-6 Z" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 6px #4fd8ff)' }} />
+          <path d="M4,0 L4,-5" stroke="#9fd4ff" strokeWidth="1.6" strokeLinecap="round" opacity=".7" />
+          <path className="fvo-cap fvo-c2" d="M-.5,-4.4 A4.5,3 0 0 1 8.5,-4.4 Z" fill="#b28dff" style={{ filter: 'drop-shadow(0 0 5px #b28dff)' }} />
+          <circle className="fvo-spore" cx="0" cy="-10" r="1" fill="#bfeaff" />
+          <circle className="fvo-spore fvo-sp2" cx="4" cy="-9" r=".8" fill="#dcc9ff" />
+          <circle className="fvo-spore fvo-sp3" cx="-3" cy="-9" r=".8" fill="#bfeaff" />
+        </g>
+        <g transform="translate(356,336)">
+          <path d="M0,0 L0,-8" stroke="#ff9ee8" strokeWidth="2" strokeLinecap="round" opacity=".8" />
+          <path className="fvo-cap fvo-c2" d="M-8,-7 A8,5 0 0 1 8,-7 Z" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 6px #ff4fd8)' }} />
+          <path d="M-5,0 L-5,-5" stroke="#ff9ee8" strokeWidth="1.5" strokeLinecap="round" opacity=".7" />
+          <path className="fvo-cap" d="M-9,-4.4 A4.4,3 0 0 1 -.6,-4.4 Z" fill="#ffb54f" style={{ filter: 'drop-shadow(0 0 5px #ffb54f)' }} />
+          <circle className="fvo-spore fvo-sp2" cx="0" cy="-11" r="1" fill="#ffd9f4" />
+          <circle className="fvo-spore" cx="-5" cy="-9" r=".8" fill="#ffe6c9" />
+          <circle className="fvo-spore fvo-sp3" cx="3" cy="-10" r=".8" fill="#ffd9f4" />
+        </g>
+      </g>
+
+      {/* etiqueta viva — con el corazón tappable invita a la acción (y deja
+          la jerga de laboratorio: "micorrízica" no es palabra del campo) */}
+      <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity=".65" aria-hidden="true">
+        <text x="195" y="452" fill="#2dffc4" textAnchor="middle">CORAZÓN DE LA FINCA · VIVO</text>
+        <text x="195" y="464" fill="#5b7f93" textAnchor="middle" letterSpacing="1">
+          {conPregunte ? 'toque el corazón y pregúntele a Chagra' : 'las raíces de su finca están conectadas'}
+        </text>
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * GallinaLuz — gallina criolla bioluminiscente del potrero. Picotea con el
+ * ritmo de su clase (`fvo-gallina` + variante) — la animación vive en
+ * scene-finca-organismo.css. Coordenadas locales: el (0,0) es el piso bajo
+ * el cuerpo; mira a la DERECHA salvo `espejo` (que también invierte el
+ * sentido del picoteo vía la clase `fvo-ga-esp`).
+ *
+ * @param {Object} props
+ * @param {number} props.x posición (viewBox) del piso bajo la gallina.
+ * @param {number} props.y ídem.
+ * @param {string} props.cuerpo color del plumaje.
+ * @param {string} props.cola color de la cola/ala (más oscuro).
+ * @param {string} [props.clase] variante de ritmo (fvo-ga2 / fvo-ga3).
+ * @param {boolean} [props.espejo] mirar a la izquierda.
+ */
+function GallinaLuz({ x, y, cuerpo, cola, clase = '', espejo = false }) {
+  return (
+    /* el translate vive en su PROPIO <g>: la animación CSS (transform) del
+       picoteo PISARÍA el atributo transform si compartieran elemento y la
+       gallina se iría al origen del SVG (bug real de la 1.ª pasada). */
+    <g transform={`translate(${x},${y})`} aria-hidden="true">
+      <ellipse cx="0" cy=".6" rx="4.2" ry="1" fill="#000" opacity=".3" />
+      <g className={`fvo-gallina ${clase}${espejo ? ' fvo-ga-esp' : ''}`.trim()}>
+        <g transform={espejo ? 'scale(-1,1)' : undefined}>
+          {/* patas */}
+          <g stroke="#d8ff6a" strokeWidth=".9" strokeLinecap="round" opacity=".9">
+            <path d="M-1.2,-2.2 L-1.4,0" /><path d="M1.4,-2.2 L1.6,0" />
+          </g>
+          {/* cola */}
+          <path d="M-4.2,-6.5 Q-7.6,-9.5 -6.6,-12 Q-3.6,-10 -3.2,-7 Z" fill={cola} />
+          {/* cuerpo */}
+          <path
+            d="M-4.8,-5.5 C-4.6,-8.6 -1.6,-10.2 1.2,-9.6 C4.4,-9 5.6,-6.4 4.4,-4 C3.2,-1.8 -1.2,-1.4 -3.4,-3 C-4.4,-3.8 -4.9,-4.5 -4.8,-5.5 Z"
+            fill={cuerpo}
+            stroke="#eafff6"
+            strokeWidth=".4"
+            strokeOpacity=".3"
+          />
+          {/* ala */}
+          <path d="M-2.8,-6 Q-.4,-8 2,-6.2 Q-.2,-4.6 -2.8,-6 Z" fill={cola} opacity=".85" />
+          {/* cabeza con cresta neón */}
+          <circle cx="4.6" cy="-10.6" r="2.2" fill={cuerpo} />
+          <path d="M3.6,-12.6 Q3.9,-14.4 5.2,-14 Q5.6,-12.6 4.9,-12.2 Z" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 2px #ff4fd8)' }} />
+          <path d="M6.7,-10.8 L9,-10 L6.7,-9.4 Z" fill="#ffd76a" />
+          <circle cx="5.9" cy="-9" r=".7" fill="#ff4fd8" opacity=".8" />
+          <circle cx="5.2" cy="-11" r=".55" fill="#0a0618" />
+          <circle cx="5.4" cy="-11.2" r=".2" fill="#eafff6" />
+        </g>
+      </g>
+    </g>
+  );
+}

--- a/src/visual/scenes/_cielo.js
+++ b/src/visual/scenes/_cielo.js
@@ -1,0 +1,100 @@
+/*
+ * Helpers y tablas de la capa cielo paramétrica (interno de la librería). Vive
+ * aparte del componente para no romper el fast-refresh de Vite (un archivo con
+ * componente no debe exportar también funciones). Lo consume `CieloParametrico`
+ * y se re-exporta desde el barrel.
+ */
+
+/** ¿Es de noche? (luna + estrellas en vez de sol). */
+export function esNoche(cielo) { return cielo?.luz === 'noche'; }
+
+/** ¿Cielo cubierto/lluvia? (velo + nubes densas). */
+export function esCubierto(cielo) {
+  return cielo?.condicion === 'nublado' || cielo?.condicion === 'lluvia' || cielo?.condicion === 'niebla';
+}
+
+/**
+ * Tono de luz de la escena: cada tono tiene su cielo (el amanecer y el atardecer
+ * —las horas más bellas del campo— dejan de pintarse como mediodía). Mismo dato
+ * de siempre (deriveAtmosphere → luz), sin motor nuevo.
+ * @returns {'dia'|'noche'|'amanecer'|'atardecer'}
+ */
+export function tonoLuz(cielo) {
+  const l = cielo?.luz;
+  return (l === 'noche' || l === 'amanecer' || l === 'atardecer') ? l : 'dia';
+}
+
+/**
+ * Cielos por escena y por tono de luz [stop alto, stop bajo]. El degradado de la
+ * escena acompaña la hora real: dorado al amanecer, brasa al atardecer, fresco
+ * al mediodía, navy profundo de noche.
+ */
+export const CIELOS_ESCENA = {
+  finca: {
+    dia: ['#7ac3da', '#c8e8cb'],
+    amanecer: ['#e9a06c', '#fbe9c2'],
+    atardecer: ['#d97a4e', '#f6d99e'],
+    noche: ['#121f3d', '#3d5560'],
+  },
+  balcon: {
+    dia: ['#8fd0e8', '#dff0e3'],
+    amanecer: ['#eeb083', '#fdeccb'],
+    atardecer: ['#e08a5c', '#f9dfae'],
+    noche: ['#1d2b4a', '#46566b'],
+  },
+  invernadero: {
+    dia: ['#90cce0', '#d4ecd6'],
+    amanecer: ['#edac7e', '#fceac6'],
+    atardecer: ['#df845a', '#f8dda8'],
+    noche: ['#1d2b4a', '#465a64'],
+  },
+};
+
+/**
+ * CIELOS POR TEMA — la piel del tema DENTRO de la escena. Cada tema fija el cielo
+ * interno por tono de luz; se aplica ANTES que la tabla por escena (fallback sin
+ * tema). El grade/textura por tema del CSS completa la piel.
+ */
+export const CIELOS_TEMA = {
+  biopunk: {
+    dia: ['#16324f', '#2b5a63'],
+    amanecer: ['#3b2f5e', '#b06a55'],
+    atardecer: ['#3a2440', '#c25c4a'],
+    noche: ['#0c1830', '#26404d'],
+  },
+  // biopunk2 comparte la piel biopunk (mismo cielo interno).
+  biopunk2: {
+    dia: ['#16324f', '#2b5a63'],
+    amanecer: ['#3b2f5e', '#b06a55'],
+    atardecer: ['#3a2440', '#c25c4a'],
+    noche: ['#0c1830', '#26404d'],
+  },
+  'verde-vivo': {
+    dia: ['#79c9b7', '#e2f0cf'],
+    amanecer: ['#ecb27a', '#f6ecc4'],
+    atardecer: ['#dd8455', '#f3d99b'],
+    noche: ['#183253', '#3e5a63'],
+  },
+  nature: {
+    dia: ['#d9c493', '#f2e8cd'],
+    amanecer: ['#e0a066', '#f7e6c0'],
+    atardecer: ['#c97a45', '#efd6a0'],
+    noche: ['#26243d', '#5a4a58'],
+  },
+  minimalista: {
+    dia: ['#cfdcd2', '#f3f1e8'],
+    amanecer: ['#e3c3a3', '#f5eddd'],
+    atardecer: ['#d8a887', '#f0e2c8'],
+    noche: ['#31394a', '#5d6672'],
+  },
+};
+
+/** Stops [alto, bajo] del degradado de cielo para una escena y su hora/tema. */
+export function cieloEscena(cielo, escena) {
+  const tono = tonoLuz(cielo);
+  // Piel por tema primero (cielo.tema lo inyecta el hero desde useTheme).
+  const porTema = CIELOS_TEMA[cielo?.tema]?.[tono];
+  if (porTema) return porTema;
+  const mapa = CIELOS_ESCENA[escena] || CIELOS_ESCENA.finca;
+  return mapa[tono] || mapa.dia;
+}

--- a/src/visual/scenes/scene-finca-organismo.css
+++ b/src/visual/scenes/scene-finca-organismo.css
@@ -1,0 +1,554 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   SCENE "FINCA ORGANISMO" (tema biopunk) — animaciones del port fiel del
+   mockup aprobado escena-home-biopunk-v2.html. Todo es CSS/SVG declarativo
+   (cero JS por frame). Prefijo `fvo-` en clases y keyframes para no chocar
+   con el resto del hero. prefers-reduced-motion = estado estático digno
+   (misma receta del mockup: red encendida, chispas plantadas, sin ondas).
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.fvo-svg {
+  /* ritmo cardíaco compartido: corazón, red, savia, paneles y reactor laten
+     al MISMO pulso (la finca es UN organismo) */
+  --fvo-beat: 5.2s;
+}
+
+/* estrellas que titilan */
+.fvo-tw { animation: fvo-tw 3.4s ease-in-out infinite; }
+@keyframes fvo-tw { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
+
+/* halo lunar que respira */
+.fvo-halo { transform-box: fill-box; transform-origin: center; animation: fvo-halo 8s ease-in-out infinite; }
+@keyframes fvo-halo { 0%, 100% { transform: scale(1); opacity: 0.5; } 50% { transform: scale(1.12); opacity: 0.9; } }
+
+/* aurora de páramo */
+.fvo-aurora { animation: fvo-aurora 14s ease-in-out infinite alternate; }
+@keyframes fvo-aurora { from { opacity: 0.10; transform: translateX(-8px); } to { opacity: 0.28; transform: translateX(10px); } }
+
+/* respiración de toda la finca */
+.fvo-breathe { transform-box: fill-box; transform-origin: 50% 100%; animation: fvo-breathe 7s ease-in-out infinite; }
+@keyframes fvo-breathe { 0%, 100% { transform: scaleY(1); } 50% { transform: scaleY(1.012); } }
+
+/* latido del corazón micorrízico (doble pulso, como corazón real) */
+.fvo-heart { transform-box: fill-box; transform-origin: center; animation: fvo-beat var(--fvo-beat) ease-in-out infinite; }
+@keyframes fvo-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+.fvo-heart-wave { transform-box: fill-box; transform-origin: center; animation: fvo-hwave var(--fvo-beat) ease-out infinite; }
+@keyframes fvo-hwave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red entera se enciende con cada latido */
+.fvo-net { animation: fvo-netglow var(--fvo-beat) ease-in-out infinite; }
+@keyframes fvo-netglow { 0%, 100% { opacity: 0.55; } 8% { opacity: 1; } 16% { opacity: 0.7; } 22% { opacity: 0.9; } 34% { opacity: 0.55; } }
+
+/* flujo de savia por las hifas */
+.fvo-hypha { stroke-dasharray: 5 9; animation: fvo-flow 2.6s linear infinite; }
+.fvo-hypha.fvo-slow { animation-duration: 4.5s; stroke-dasharray: 3 11; }
+.fvo-hypha.fvo-rev { animation-direction: reverse; }
+@keyframes fvo-flow { to { stroke-dashoffset: -56; } }
+
+/* nutrientes viajando (motion path) */
+.fvo-spark {
+  offset-rotate: 0deg;
+  animation: fvo-travel 6s linear infinite;
+  filter: drop-shadow(0 0 4px #2dffc4);
+}
+.fvo-spark.fvo-p1 { offset-path: path('M195,405 C160,392 120,380 78,352'); animation-delay: 0s; }
+.fvo-spark.fvo-p2 { offset-path: path('M195,405 C230,388 268,375 300,350'); animation-delay: 1.6s; animation-duration: 5s; }
+.fvo-spark.fvo-p3 { offset-path: path('M195,405 C185,378 172,360 150,344'); animation-delay: 3.1s; animation-duration: 4.2s; }
+.fvo-spark.fvo-p4 { offset-path: path('M195,405 C240,420 300,432 368,424'); animation-delay: 2.2s; animation-duration: 7s; }
+.fvo-spark.fvo-p5 { offset-path: path('M195,405 C150,428 90,440 24,430'); animation-delay: 4.4s; animation-duration: 7s; }
+.fvo-spark.fvo-p6 { offset-path: path('M295,352 C295,320 295,300 295,278'); animation-delay: 0.8s; animation-duration: 3.6s; }
+@keyframes fvo-travel {
+  0% { offset-distance: 0%; opacity: 0; }
+  12% { opacity: 1; }
+  82% { opacity: 1; }
+  100% { offset-distance: 100%; opacity: 0; }
+}
+
+/* colibrí de luz (vuela por el cielo y se queda libando en el aire) */
+.fvo-colibri {
+  offset-path: path('M-30,118 C70,74 140,148 198,104 C246,70 268,138 342,112 C300,96 250,150 198,104');
+  offset-rotate: 0deg;
+  animation: fvo-vuelo 22s ease-in-out infinite;
+}
+@keyframes fvo-vuelo {
+  0% { offset-distance: 0%; }
+  30% { offset-distance: 38%; }
+  40% { offset-distance: 41%; }
+  68% { offset-distance: 62%; }
+  78% { offset-distance: 64%; }
+  100% { offset-distance: 100%; }
+}
+.fvo-ala { transform-box: fill-box; transform-origin: 20% 90%; animation: fvo-ala 0.12s ease-in-out infinite alternate; }
+@keyframes fvo-ala { from { transform: rotate(-26deg); } to { transform: rotate(34deg); } }
+.fvo-estela { transform-box: fill-box; transform-origin: center; animation: fvo-estela 1.1s ease-out infinite; }
+.fvo-estela.fvo-e2 { animation-delay: 0.35s; }
+.fvo-estela.fvo-e3 { animation-delay: 0.7s; }
+@keyframes fvo-estela { 0% { transform: scale(0.4); opacity: 0.9; } 100% { transform: scale(2.4); opacity: 0; } }
+
+/* cocuyos (luciérnagas) */
+.fvo-fly { animation: fvo-fly 9s ease-in-out infinite alternate, fvo-blink 2.3s ease-in-out infinite; }
+.fvo-fly.fvo-f2 { animation-duration: 11s, 3.1s; animation-delay: -3s, -1s; }
+.fvo-fly.fvo-f3 { animation-duration: 8s, 1.9s; animation-delay: -5s, -0.4s; }
+.fvo-fly.fvo-f4 { animation-duration: 13s, 2.7s; animation-delay: -8s, -1.7s; }
+.fvo-fly.fvo-f5 { animation-duration: 10s, 2.1s; animation-delay: -2s, -0.9s; }
+@keyframes fvo-fly {
+  from { transform: translate(0, 0); }
+  33% { transform: translate(14px, -10px); }
+  66% { transform: translate(-8px, 6px); }
+  to { transform: translate(10px, -14px); }
+}
+@keyframes fvo-blink { 0%, 100% { opacity: 0.1; } 45%, 55% { opacity: 1; } }
+
+/* niebla de páramo */
+.fvo-fog { animation: fvo-fog 36s ease-in-out infinite alternate; }
+.fvo-fog.fvo-g2 { animation-duration: 46s; animation-delay: -18s; }
+.fvo-fog.fvo-g3 { animation-duration: 28s; animation-delay: -9s; }
+@keyframes fvo-fog { from { transform: translateX(-26px); } to { transform: translateX(30px); } }
+
+/* cúpula-célula: respira */
+.fvo-dome { transform-box: fill-box; transform-origin: 50% 100%; animation: fvo-dome 6s ease-in-out infinite; }
+@keyframes fvo-dome { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.035, 1.05); } }
+.fvo-organela { transform-box: fill-box; transform-origin: center; animation: fvo-orga 12s ease-in-out infinite alternate; }
+.fvo-organela.fvo-o2 { animation-duration: 15s; animation-delay: -6s; }
+.fvo-organela.fvo-o3 { animation-duration: 9s; animation-delay: -3s; }
+@keyframes fvo-orga {
+  from { transform: translate(0, 0); }
+  50% { transform: translate(-9px, 6px); }
+  to { transform: translate(7px, -8px); }
+}
+
+/* plantas: savia que late */
+.fvo-sap { animation: fvo-sap var(--fvo-beat) ease-in-out infinite; }
+.fvo-sap.fvo-s2 { animation-delay: 0.35s; }
+.fvo-sap.fvo-s3 { animation-delay: 0.7s; }
+.fvo-sap.fvo-s4 { animation-delay: 1.05s; }
+.fvo-sap.fvo-s5 { animation-delay: 1.4s; }
+@keyframes fvo-sap { 0%, 100% { opacity: 0.55; } 10% { opacity: 1; } 20% { opacity: 0.65; } 26% { opacity: 0.9; } 40% { opacity: 0.55; } }
+.fvo-berry { transform-box: fill-box; transform-origin: center; animation: fvo-berry 3.8s ease-in-out infinite; }
+.fvo-berry.fvo-b2 { animation-delay: -1.2s; }
+.fvo-berry.fvo-b3 { animation-delay: -2.4s; }
+.fvo-berry.fvo-b4 { animation-delay: -0.6s; }
+@keyframes fvo-berry { 0%, 100% { opacity: 0.5; transform: scale(1); } 50% { opacity: 1; transform: scale(1.35); } }
+
+/* frailejón que exhala luz */
+.fvo-frailejon { animation: fvo-frail 6.5s ease-in-out infinite; }
+.fvo-frailejon.fvo-fr2 { animation-delay: -3s; }
+@keyframes fvo-frail { 0%, 100% { opacity: 0.6; } 50% { opacity: 1; } }
+
+/* hongos + esporas */
+.fvo-cap { animation: fvo-cap 4.4s ease-in-out infinite; }
+.fvo-cap.fvo-c2 { animation-delay: -2.2s; }
+@keyframes fvo-cap { 0%, 100% { opacity: 0.7; } 50% { opacity: 1; } }
+.fvo-spore { animation: fvo-spore 6s linear infinite; }
+.fvo-spore.fvo-sp2 { animation-delay: -2s; }
+.fvo-spore.fvo-sp3 { animation-delay: -4s; }
+@keyframes fvo-spore {
+  0% { transform: translateY(0); opacity: 0; }
+  15% { opacity: 0.9; }
+  100% { transform: translateY(-46px); opacity: 0; }
+}
+
+/* brasas del fogón */
+.fvo-brasa { animation: fvo-brasa 4.2s linear infinite; }
+.fvo-brasa.fvo-br2 { animation-delay: -1.4s; }
+.fvo-brasa.fvo-br3 { animation-delay: -2.8s; }
+@keyframes fvo-brasa {
+  0% { transform: translate(0, 0); opacity: 0; }
+  12% { opacity: 1; }
+  60% { transform: translate(5px, -30px); opacity: 0.7; }
+  100% { transform: translate(-3px, -52px); opacity: 0; }
+}
+.fvo-ventana { animation: fvo-ventana 3.2s ease-in-out infinite; }
+@keyframes fvo-ventana { 0%, 100% { opacity: 0.75; } 50% { opacity: 1; } }
+
+/* invernadero-célula: paneles + reactor que late */
+.fvo-panel { animation: fvo-panel var(--fvo-beat) ease-in-out infinite; }
+.fvo-panel.fvo-pa2 { animation-delay: 0.3s; }
+.fvo-panel.fvo-pa3 { animation-delay: 0.6s; }
+@keyframes fvo-panel { 0%, 100% { opacity: 0.45; } 9% { opacity: 0.85; } 18% { opacity: 0.55; } 26% { opacity: 0.7; } }
+.fvo-reactor { transform-box: fill-box; transform-origin: center; animation: fvo-reactor var(--fvo-beat) ease-in-out infinite; }
+@keyframes fvo-reactor {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  8% { transform: scale(1.2); filter: brightness(1.7); }
+  16% { transform: scale(1); }
+}
+.fvo-lamplight { animation: fvo-lamplight var(--fvo-beat) ease-in-out infinite; }
+@keyframes fvo-lamplight { 0%, 100% { opacity: 0.22; } 8% { opacity: 0.5; } 18% { opacity: 0.28; } }
+.fvo-vent { animation: fvo-ventpulse 3.4s ease-in-out infinite; }
+@keyframes fvo-ventpulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
+
+/* campesino con alma */
+.fvo-campesino { transform-box: fill-box; transform-origin: 50% 100%; animation: fvo-campe 6.5s ease-in-out infinite; }
+@keyframes fvo-campe { 0%, 100% { transform: translateY(0) rotate(0deg); } 50% { transform: translateY(-0.7px) rotate(0.5deg); } }
+.fvo-head-c { transform-box: fill-box; transform-origin: 50% 88%; animation: fvo-headlook 11s ease-in-out infinite; }
+@keyframes fvo-headlook { 0%, 60%, 100% { transform: rotate(0); } 72%, 86% { transform: rotate(-7deg); } }
+.fvo-lantern { transform-box: fill-box; transform-origin: 50% 4%; animation: fvo-lantsway 4.6s ease-in-out infinite; }
+@keyframes fvo-lantsway { 0%, 100% { transform: rotate(-4.5deg); } 50% { transform: rotate(4.5deg); } }
+.fvo-lantorb { transform-box: fill-box; transform-origin: center; animation: fvo-lantorb 2.8s ease-in-out infinite; }
+@keyframes fvo-lantorb { 0%, 100% { opacity: 0.8; transform: scale(1); } 50% { opacity: 1; transform: scale(1.12); } }
+.fvo-lantpool { animation: fvo-lantpool 2.8s ease-in-out infinite; }
+@keyframes fvo-lantpool { 0%, 100% { opacity: 0.35; } 50% { opacity: 0.62; } }
+
+/* perro criollo */
+.fvo-dog { transform-box: fill-box; transform-origin: 50% 100%; animation: fvo-dogbob 3.1s ease-in-out infinite; }
+@keyframes fvo-dogbob { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-0.5px); } }
+.fvo-tail { transform-box: fill-box; transform-origin: 100% 100%; animation: fvo-tail 0.42s ease-in-out infinite alternate; }
+@keyframes fvo-tail { from { transform: rotate(-20deg); } to { transform: rotate(28deg); } }
+.fvo-earw { transform-box: fill-box; transform-origin: 50% 0; animation: fvo-earw 2.4s ease-in-out infinite; }
+@keyframes fvo-earw { 0%, 100% { transform: rotate(0); } 50% { transform: rotate(-9deg); } }
+
+/* estrella fugaz + aves lejanas */
+.fvo-shoot { animation: fvo-shoot 9s ease-in infinite; }
+@keyframes fvo-shoot {
+  0%, 66% { opacity: 0; transform: translate(0, 0); }
+  68% { opacity: 1; }
+  78% { opacity: 1; }
+  85% { opacity: 0; transform: translate(66px, 30px); }
+  100% { opacity: 0; transform: translate(66px, 30px); }
+}
+.fvo-vbird { animation: fvo-vbird 26s linear infinite; }
+@keyframes fvo-vbird {
+  from { transform: translate(0, 0); }
+  50% { transform: translate(-22px, 4px); }
+  to { transform: translate(-44px, 0); }
+}
+.fvo-flap { transform-box: fill-box; transform-origin: center; animation: fvo-flap 1.6s ease-in-out infinite; }
+@keyframes fvo-flap { 0%, 100% { transform: scaleY(1); } 50% { transform: scaleY(0.55); } }
+
+/* ── SOL Y LUNA según la atmósfera real ────────────────────────────────────
+   FincaVivaHero estampa data-luz (amanecer|dia|atardecer|noche) y data-clima
+   (despejado|nublado|lluvia|niebla) en .fvh (atmosphereService, offline-first
+   por efemérides). La escena ya no es "siempre de noche": de día sale el sol
+   biopunk, al amanecer/atardecer el cielo se enciende cálido y de noche vuelve
+   la luna. Sin data-luz (sin señal) la escena conserva su identidad nocturna. */
+.fvo-cielo-dia,
+.fvo-cielo-crep { opacity: 0; transition: opacity 1.2s ease; }
+.fvo-sol-g { display: none; }
+
+.fvh[data-luz='dia'] .fvo-sol-g,
+.fvh[data-luz='amanecer'] .fvo-sol-g,
+.fvh[data-luz='atardecer'] .fvo-sol-g { display: inline; }
+
+.fvh[data-luz='dia'] .fvo-luna-g,
+.fvh[data-luz='amanecer'] .fvo-luna-g,
+.fvh[data-luz='atardecer'] .fvo-luna-g { display: none; }
+
+.fvh[data-luz='dia'] .fvo-cielo-dia { opacity: 0.68; }
+
+.fvh[data-luz='amanecer'] .fvo-cielo-crep,
+.fvh[data-luz='atardecer'] .fvo-cielo-crep { opacity: 0.5; }
+
+/* al amanecer/atardecer el sol anda BAJO, cerca del filo de la montaña */
+.fvh[data-luz='amanecer'] .fvo-sol-g,
+.fvh[data-luz='atardecer'] .fvo-sol-g { transform: translateY(26px); }
+
+/* de día las estrellas descansan; en el crepúsculo apenas se insinúan */
+.fvh[data-luz='dia'] .fvo-tw,
+.fvh[data-luz='dia'] .fvo-shoot { display: none; }
+
+.fvh[data-luz='amanecer'] .fvo-tw,
+.fvh[data-luz='atardecer'] .fvo-tw { animation: none; opacity: 0.3; }
+
+/* clima: nublado/lluvia/niebla traen nubes y velan el astro (honesto: el
+   cielo de la escena cuenta el clima que el piloto ve por la ventana) */
+.fvo-nubes { display: none; }
+
+.fvh[data-clima='nublado'] .fvo-nubes,
+.fvh[data-clima='lluvia'] .fvo-nubes,
+.fvh[data-clima='niebla'] .fvo-nubes { display: inline; }
+
+.fvh[data-clima='nublado'] .fvo-astro { opacity: 0.45; }
+.fvh[data-clima='lluvia'] .fvo-astro { opacity: 0.3; }
+.fvh[data-clima='niebla'] .fvo-astro { opacity: 0.55; }
+
+/* corona del sol: respira (transform+opacity, GPU) */
+.fvo-corona {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-corona 5s ease-in-out infinite;
+}
+
+@keyframes fvo-corona {
+  0%, 100% { transform: scale(1); opacity: 0.55; }
+  50% { transform: scale(1.06); opacity: 0.9; }
+}
+
+/* ── LA VIDA DEL SUELO: micelio fino, nodos, lombrices y bichitos ──────────
+   El micelio fino respira con el mismo latido de la red; los nodos
+   micorrízicos titilan (intercambio azúcar↔nutrientes); las lombrices se
+   estiran y encogen al avanzar; el colémbolo pega brinquitos. Todo
+   transform/opacity — cero blur/filtro animado. */
+.fvo-micelio {
+  animation: fvo-netglow var(--fvo-beat) ease-in-out infinite;
+  animation-delay: -0.4s;
+}
+
+.fvo-nodo { animation: fvo-tw 3.8s ease-in-out infinite; }
+.fvo-nodo.fvo-n2 { animation-delay: -1.3s; }
+.fvo-nodo.fvo-n3 { animation-delay: -2.4s; }
+
+.fvo-lombriz {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-lombriz 7s ease-in-out infinite;
+}
+
+.fvo-lombriz.fvo-l2 { animation-delay: -3.2s; animation-duration: 8.5s; }
+
+@keyframes fvo-lombriz {
+  0%, 100% { transform: translateX(0) scaleX(1); }
+  50% { transform: translateX(3px) scaleX(0.94); }
+}
+
+.fvo-bicho {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-bicho 9s ease-in-out infinite;
+}
+
+@keyframes fvo-bicho {
+  0%, 100% { transform: translateX(0); }
+  45%, 55% { transform: translateX(-6px); }
+}
+
+.fvo-bicho.fvo-bi2 { animation: fvo-brinco 4.6s ease-in-out infinite; }
+
+@keyframes fvo-brinco {
+  0%, 86%, 100% { transform: translate(0, 0); }
+  90% { transform: translate(-3px, -6px); }
+  94% { transform: translate(-5px, 0); }
+}
+
+/* ── QUEBRADA: el agua corre, cae en cascaditas y ondea en el pocito ───────
+   La corriente es el mismo truco de las hifas (dash que corre); los destellos
+   de cascada titilan; el remanso emite ondas concéntricas. Todo dash/opacity/
+   transform — nada de filtros animados. */
+.fvo-agua { stroke-dasharray: 8 5; animation: fvo-aguaflow 1.9s linear infinite; }
+.fvo-agua.fvo-a2 { stroke-dasharray: 4 8; animation-duration: 2.7s; animation-delay: -0.8s; }
+@keyframes fvo-aguaflow { to { stroke-dashoffset: -52; } }
+
+.fvo-destello { animation: fvo-tw 2.6s ease-in-out infinite; }
+
+.fvo-onda {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-onda 4.2s ease-out infinite;
+}
+
+.fvo-onda.fvo-on2 { animation-delay: -2.1s; }
+
+@keyframes fvo-onda {
+  0% { transform: scale(0.3); opacity: 0.8; }
+  70%, 100% { transform: scale(1.7); opacity: 0; }
+}
+
+.fvo-reflejo { animation: fvo-reflejo 5s ease-in-out infinite; }
+@keyframes fvo-reflejo { 0%, 100% { opacity: 0.25; } 50% { opacity: 0.6; } }
+
+/* ── RAYO DEL ASTRO: la luz cae en diagonal y respira ── */
+.fvo-rayo { animation: fvo-rayo 9s ease-in-out infinite; }
+@keyframes fvo-rayo { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
+
+/* ── POTRERO: LA VACA ──────────────────────────────────────────────────────
+   Respira con la panza (scaleY desde el vientre), pasta de a ratos (la
+   cabeza baja y vuelve), espanta con la cola y las manchas bioluminiscentes
+   laten con el MISMO pulso var(--fvo-beat) de la red — la vaca es parte del
+   organismo, no un sticker encima. */
+.fvo-vaca-cuerpo {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: fvo-vacabreathe 3.8s ease-in-out infinite;
+}
+
+@keyframes fvo-vacabreathe {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.04); }
+}
+
+.fvo-vaca-cabeza {
+  transform-box: fill-box;
+  transform-origin: 92% 42%;
+  animation: fvo-vacapasta 11s ease-in-out infinite;
+}
+
+@keyframes fvo-vacapasta {
+  0%, 36%, 100% { transform: rotate(0deg); }
+  44%, 66% { transform: rotate(13deg); }
+  52% { transform: rotate(11deg); }
+  76% { transform: rotate(-2deg); }
+  84% { transform: rotate(0deg); }
+}
+
+.fvo-vaca-cola {
+  transform-box: fill-box;
+  transform-origin: 20% 6%;
+  animation: fvo-vacacola 6.5s ease-in-out infinite;
+}
+
+@keyframes fvo-vacacola {
+  0%, 52%, 100% { transform: rotate(0deg); }
+  60% { transform: rotate(18deg); }
+  70% { transform: rotate(-12deg); }
+  80% { transform: rotate(9deg); }
+  88% { transform: rotate(0deg); }
+}
+
+.fvo-vaca-oreja {
+  transform-box: fill-box;
+  transform-origin: 10% 90%;
+  animation: fvo-vacaoreja 7s ease-in-out infinite;
+}
+
+@keyframes fvo-vacaoreja {
+  0%, 78%, 100% { transform: rotate(0deg); }
+  84% { transform: rotate(-16deg); }
+  90% { transform: rotate(4deg); }
+}
+
+/* manchas de la vaca: laten con el corazón de la finca */
+.fvo-mancha { animation: fvo-mancha var(--fvo-beat) ease-in-out infinite; }
+.fvo-mancha.fvo-m2 { animation-delay: 0.3s; }
+.fvo-mancha.fvo-m3 { animation-delay: 0.6s; }
+@keyframes fvo-mancha { 0%, 100% { opacity: 0.45; } 8% { opacity: 1; } 16% { opacity: 0.6; } 24% { opacity: 0.85; } 36% { opacity: 0.45; } }
+
+/* ── POTRERO: LAS GALLINAS pican el pasto (doble picoteo con pausa; cada
+   una a su ritmo). La espejada (mira a la izquierda) picotea al revés. */
+.fvo-gallina {
+  transform-box: fill-box;
+  transform-origin: 64% 100%;
+  animation: fvo-picoteo 3.6s ease-in-out infinite;
+}
+
+.fvo-gallina.fvo-ga2 { animation-duration: 4.4s; animation-delay: -1.3s; }
+.fvo-gallina.fvo-ga3 { animation-duration: 3.1s; animation-delay: -2.2s; }
+
+@keyframes fvo-picoteo {
+  0%, 34%, 100% { transform: rotate(0deg); }
+  40% { transform: rotate(24deg); }
+  46% { transform: rotate(5deg); }
+  52% { transform: rotate(26deg); }
+  58% { transform: rotate(0deg); }
+}
+
+.fvo-gallina.fvo-ga-esp {
+  transform-origin: 36% 100%;
+  animation-name: fvo-picoteo-esp;
+}
+
+@keyframes fvo-picoteo-esp {
+  0%, 34%, 100% { transform: rotate(0deg); }
+  40% { transform: rotate(-24deg); }
+  46% { transform: rotate(-5deg); }
+  52% { transform: rotate(-26deg); }
+  58% { transform: rotate(0deg); }
+}
+
+/* ── POTRERO como PUERTA al mundo de los animales ──────────────────────────
+   Con data-tap el grupo es un botón: cursor, halo-invitación que emana cada
+   6s, etiqueta que respira y anillo de foco accesible (:focus-visible). */
+.fvo-animales[data-tap='1'] { cursor: pointer; outline: none; }
+
+.fvo-cta-halo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-ctahalo 6s ease-out infinite;
+  opacity: 0;
+}
+
+@keyframes fvo-ctahalo {
+  0%, 55% { transform: scale(0.55); opacity: 0; }
+  62% { opacity: 0.7; }
+  100% { transform: scale(1.12); opacity: 0; }
+}
+
+.fvo-cta-tag { animation: fvo-ctatag 6s ease-in-out infinite; }
+@keyframes fvo-ctatag { 0%, 100% { opacity: 0.55; } 60% { opacity: 1; } }
+
+.fvo-animales[data-tap='1']:focus-visible .fvo-cta-anillo { opacity: 1; }
+.fvo-animales[data-tap='1']:hover .fvo-cta-tag { opacity: 1; animation: none; }
+
+/* ── polillas del farol (revolotean cortico y titilan) ── */
+.fvo-polilla {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-polilla 3.4s ease-in-out infinite alternate, fvo-blink 1.7s ease-in-out infinite;
+}
+
+.fvo-polilla.fvo-po2 { animation-duration: 2.6s, 2.3s; animation-delay: -1.3s, -0.6s; }
+
+@keyframes fvo-polilla {
+  from { transform: translate(0, 0); }
+  33% { transform: translate(-4px, -5px); }
+  66% { transform: translate(3px, -2px); }
+  to { transform: translate(-2px, 3px); }
+}
+
+/* ── reduced motion: estado estático DIGNO (como el mockup) ────────────────
+   El apagado global de animaciones ya lo hace finca-viva-hero.css
+   (`.fvh * { animation: none !important }`); aquí se compone la foto fija:
+   red encendida, chispas plantadas a mitad de camino, colibrí libando,
+   sin ondas de latido ni estelas ni estrella fugaz. */
+@media (prefers-reduced-motion: reduce) {
+  .fvo-svg * { animation: none !important; }
+  .fvo-hypha { stroke-dasharray: none; }
+  .fvo-spark { offset-distance: 55%; opacity: 0.9; }
+  .fvo-colibri { offset-distance: 40%; }
+  .fvo-heart-wave,
+  .fvo-estela { opacity: 0; }
+  .fvo-fly { opacity: 0.8; }
+  .fvo-net { opacity: 0.85; }
+  .fvo-shoot { opacity: 0; }
+  .fvo-panel { opacity: 0.7; }
+  .fvo-lamplight { opacity: 0.3; }
+  .fvo-lantpool { opacity: 0.5; }
+  /* la vida del suelo queda quieta pero visible (foto fija digna) */
+  .fvo-micelio { opacity: 0.38; }
+  .fvo-nodo { opacity: 0.85; }
+  /* la quebrada queda llena (sin dash), el remanso quieto y brillante */
+  .fvo-agua { stroke-dasharray: none; }
+  .fvo-onda { opacity: 0; }
+  .fvo-reflejo { opacity: 0.5; }
+  .fvo-destello { opacity: 0.7; }
+  .fvo-rayo { opacity: 0.7; }
+  /* el potrero posa: vaca erguida, manchas encendidas, gallinas de pie;
+     la invitación al mundo animales queda como etiqueta fija visible */
+  .fvo-mancha { opacity: 0.85; }
+  .fvo-cta-halo { opacity: 0; }
+  .fvo-cta-tag { opacity: 0.9; }
+  .fvo-polilla { opacity: 0.7; }
+}
+
+/* ── CORAZÓN TAPPABLE = "PREGUNTE" (usabilidad campesina #4) ───────────────
+   Cuando FincaVivaHero pasa onPregunte, el corazón-semilla es un botón que
+   abre el agente. Cursor, foco visible para teclado y un halo-invitación que
+   respira (se apaga con prefers-reduced-motion, quedando el halo fijo). */
+.fvo-corazon-tap {
+  cursor: pointer;
+  outline: none;
+}
+.fvo-corazon-tap:focus-visible ellipse:first-of-type {
+  stroke: #eafff6;
+  stroke-width: 2;
+  opacity: 0.9;
+}
+.fvo-corazon-tap:active .fvo-heart { opacity: 0.85; }
+.fvo-corazon-halo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-corazon-invita 2.4s ease-out infinite;
+}
+@keyframes fvo-corazon-invita {
+  0% { transform: scale(0.8); opacity: 0.55; }
+  70%, 100% { transform: scale(1.35); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fvo-corazon-halo { animation: none !important; opacity: 0.4; }
+}

--- a/src/visual/scenes/scenes.css
+++ b/src/visual/scenes/scenes.css
@@ -1,0 +1,172 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   src/visual/scenes — hoja compartida de las ESCENAS BASE reutilizables.
+
+   Clases `scn-*` + custom properties `--scn-*`, cero dependencias nuevas. Es la
+   versión CANÓNICA de las recetas que antes se re-armaban en cada escena:
+     · animaciones del CIELO paramétrico (estrellas, lluvia, nubes, niebla,
+       estrella fugaz) — semilla `finca-viva-hero.css` (`.fvh-estrellas`…).
+     · PULSO cardíaco de la finca-organismo (corazón, ondas, red) — semilla
+       `scene-finca-organismo.css` (`--fvo-beat`).
+     · textura de PAPEL KRAFT — semilla `finca-viva-hero.css` (grano nature).
+     · base del motor PARALLAX multicapa — semilla `MontanaMundosCine`
+       (`.mm2-capa`).
+     · glow + flotación del GUARDIÁN-ESPÍRITU — semilla `guardian-espiritu.css`.
+
+   Reglas de la casa (iguales a creatures/effects): solo transform/opacity
+   animados; blur/filtros ESTÁTICOS; reduced-motion = fotograma final digno;
+   importe esta hoja UNA vez donde use las clases.
+
+   NOTA de dedupe (cuando `src/visual/effects` entre a main): el pulso de aquí
+   equivale a `--vfx-beat`, el glow a `<GlowFilter>` y las veladuras/grades a las
+   clases `.vfx-*`. Reusar effects donde aplique en vez de re-declarar.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── CIELO PARAMÉTRICO — animaciones del <CapaCielo> (rsvg-safe) ───────────── */
+/* estrellas que titilan (titileo escalonado) */
+.scn-estrellas circle { animation: scn-titila 3.4s ease-in-out infinite; }
+.scn-estrellas circle:nth-child(2n) { animation-delay: 1.2s; }
+.scn-estrellas circle:nth-child(3n) { animation-delay: 2.1s; }
+@keyframes scn-titila { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* lluvia: trazos que caen */
+.scn-lluvia line { animation: scn-cae 0.9s linear infinite; }
+.scn-lluvia line:nth-child(2n) { animation-delay: 0.3s; }
+.scn-lluvia line:nth-child(3n) { animation-delay: 0.6s; }
+@keyframes scn-cae { 0% { transform: translateY(-8px); opacity: 0; } 30% { opacity: 0.95; } 100% { transform: translateY(20px); opacity: 0; } }
+
+/* nubes densas (clima cubierto) — derivan en contrafase */
+.scn-nube-a { animation: scn-nube 24s ease-in-out infinite; }
+.scn-nube-b { animation: scn-nube 30s ease-in-out infinite reverse; }
+@keyframes scn-nube { 0%, 100% { transform: translateX(0); } 50% { transform: translateX(18px); } }
+
+/* estrella fugaz — casi siempre invisible; cada ~9s cruza y se apaga */
+.scn-fugaz { opacity: 0; animation: scn-fugaz 9s ease-in 2s infinite; }
+@keyframes scn-fugaz {
+  0%, 86%  { opacity: 0; transform: translate(0, 0); }
+  88%      { opacity: 0.9; }
+  94%      { opacity: 0; transform: translate(-46px, 22px); }
+  100%     { opacity: 0; transform: translate(-46px, 22px); }
+}
+
+/* bancos de niebla — derivan en contrafase (condición niebla) */
+.scn-neblina-a { animation: scn-neblina 18s ease-in-out infinite; }
+.scn-neblina-b { animation: scn-neblina 24s ease-in-out infinite reverse; }
+@keyframes scn-neblina { 0%, 100% { transform: translateX(0); } 50% { transform: translateX(30px); } }
+
+/* ── PULSO CARDÍACO de la finca-organismo ─────────────────────────────────────
+   Un solo ritmo `--scn-beat` sincroniza todo lo vivo (la finca es UN organismo).
+   Para acelerar/frenar TODO junto: `style={{ '--scn-beat': '4s' }}` en un ancestro. */
+.scn-heart {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: scn-beat var(--scn-beat, 5.2s) ease-in-out infinite;
+}
+@keyframes scn-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+.scn-heart-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: scn-hwave var(--scn-beat, 5.2s) ease-out infinite;
+}
+@keyframes scn-hwave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red entera se enciende con cada latido */
+.scn-net { animation: scn-netglow var(--scn-beat, 5.2s) ease-in-out infinite; }
+@keyframes scn-netglow { 0%, 100% { opacity: 0.55; } 8% { opacity: 1; } 16% { opacity: 0.7; } 22% { opacity: 0.9; } 34% { opacity: 0.55; } }
+
+/* ── PAPEL KRAFT — textura de grano por líneas repetidas (sin imagen/noise) ───
+   Parametrizable: ángulo (0deg = grano horizontal kraft; 90deg = trama vertical
+   fina de papel), color y paso. Se monta sobre un contenedor `position:relative`
+   (o como capa que no captura toque). */
+.scn-kraft {
+  --scn-kraft-angle: 0deg;
+  --scn-kraft-color: rgba(122, 82, 48, 0.05);
+  --scn-kraft-grano: 2px;   /* grosor de la línea */
+  --scn-kraft-paso: 6px;    /* período de repetición */
+  background-image: repeating-linear-gradient(
+    var(--scn-kraft-angle),
+    var(--scn-kraft-color) 0 var(--scn-kraft-grano),
+    transparent var(--scn-kraft-grano) var(--scn-kraft-paso)
+  );
+  pointer-events: none;
+}
+/* trama vertical finísima de papel (piel minimalista) */
+.scn-kraft--fino {
+  --scn-kraft-angle: 90deg;
+  --scn-kraft-color: rgba(60, 70, 60, 0.035);
+  --scn-kraft-grano: 1px;
+  --scn-kraft-paso: 8px;
+}
+
+/* ── PARALLAX MULTICAPA — base del <Parallax> (motor de MontanaMundosCine) ─────
+   Cada capa viaja a su velocidad (transform inline desde React) por composición
+   GPU pura (solo transform). La INERCIA por capa (duraciones/curvas distintas)
+   la afina la escena con sus propias clases modificadoras. */
+.scn-parallax { position: relative; overflow: hidden; }
+.scn-capa {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  transform-origin: 0 0;
+  will-change: transform;
+  transition: transform 0.95s cubic-bezier(0.3, 0.86, 0.24, 1.02), opacity 0.7s ease;
+  pointer-events: none;
+}
+/* la capa principal (la que lleva los mundos tocables) sí recibe toque */
+.scn-capa--interactiva { pointer-events: auto; }
+
+/* ── GUARDIÁN-ESPÍRITU base — glow por acento + flotación perpetua ────────────
+   El acento (--scn-acc / --scn-acc-rgb) lo re-tiñe el espíritu elegido. */
+.scn-espiritu-halo {
+  --scn-acc: #ffb54f;
+  --scn-acc-rgb: 255, 181, 79;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 36%, rgba(var(--scn-acc-rgb), 0.28), rgba(var(--scn-acc-rgb), 0.02) 70%);
+}
+.scn-espiritu-halo svg { width: 100%; height: 100%; }
+
+.scn-av-vuela { animation: scn-vuela 3.4s ease-in-out infinite; transform-origin: center; }
+.scn-av-flota { animation: scn-flota 3.8s ease-in-out infinite; transform-origin: center; }
+.scn-ala { animation: scn-ala 0.28s ease-in-out infinite alternate; transform-origin: 4px 0; }
+.scn-aleteo { animation: scn-aleteo 0.16s ease-in-out infinite alternate; transform-origin: -1px -5px; }
+@keyframes scn-vuela { 0%, 100% { transform: translateY(0) rotate(-1.5deg); } 50% { transform: translateY(-3px) rotate(1.5deg); } }
+@keyframes scn-flota { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-2.5px); } }
+@keyframes scn-ala { from { transform: scaleY(0.72) rotate(-6deg); } to { transform: scaleY(1) rotate(4deg); } }
+@keyframes scn-aleteo { from { transform: scaleX(0.55); opacity: 0.5; } to { transform: scaleX(1); opacity: 0.8; } }
+
+/* ── REDUCED-MOTION — fotograma final digno (nada se mueve) ───────────────────
+   El cielo queda quieto, el corazón encendido y en reposo (sin ondas), la red
+   ENCENDIDA, el parallax fijo y el espíritu flotando detenido. */
+@media (prefers-reduced-motion: reduce) {
+  .scn-estrellas circle,
+  .scn-lluvia line,
+  .scn-nube-a,
+  .scn-nube-b,
+  .scn-fugaz,
+  .scn-neblina-a,
+  .scn-neblina-b,
+  .scn-heart,
+  .scn-heart-wave,
+  .scn-net,
+  .scn-capa,
+  .scn-av-vuela,
+  .scn-av-flota,
+  .scn-ala,
+  .scn-aleteo {
+    animation: none !important;
+    transition: none !important;
+  }
+  .scn-heart-wave { opacity: 0; }     /* sin ondas expansivas */
+  .scn-net { opacity: 1; }            /* la red queda encendida */
+}


### PR DESCRIPTION
## Qué es

Mockup net-new de galería: **"La salud de mi finca"** — la superficie de **estado/salud**, el PANORAMA de cómo está la finca leída como **organismo vivo** (distinta de "qué hacer hoy": esta no es la lista de tareas, es cómo está el campo).

Ruta pública **`#/mockups/salud-finca`** vía `MOCKUP_HASH_ROUTES` en `src/App.jsx` (sin auth ni gate, datos de muestra ficticios), mismo patrón que el resto de la galería de mockups.

## Diferencial: la calma

- Sin alarmismo: la observación no asusta. El estado de lo vivo se lee por **color funcional** — savia (sana), miel (en observación), arcilla (pide una mirada). **Nunca rojo de alarma.**
- Anti-gamificación: sin puntos, medallas ni rachas.
- Español de Colombia, **usted** cordial. Sin voseo.

## Contiene (los 5 pedidos)

1. **Pulso/panorama general** — el héroe es la finca-organismo que **respira** (`SceneFincaOrganismo`), con un panorama de 48 matas.
2. **El cantero vivo (firma)** — la finca vista como una cama de siembra desde arriba: cada mata es un brote teñido por su bienestar. Respira al mismo pulso que el organismo. No es una tabla fría.
3. **El cielo y el agua** como señales de salud — lluvia reciente, humedad del suelo, próxima lluvia, con el **cielo real del amanecer** de la vereda (`CapaCielo`).
4. **Tres focos de atención** sin alarmismo (una mata / una zona que pide mirada), con su estado.
5. **El suelo y la vida** — lombrices, abejas angelita, colibrí, escarabajos: la sensación de finca-organismo.

## Reúso de la librería visual (`src/visual`)

Traído **solo lo usado** de sus ramas (no dibujado de cero):

| Pieza | De | Uso |
|---|---|---|
| `SceneFincaOrganismo`, `CapaCielo` (`CieloParametrico` + `_cielo`) | `feat/visual-lib-scenes` | héroe que respira + cielo del amanecer |
| `Lombriz`, `AbejaAngelita`, `Colibri`, `Escarabajo` | `feat/visual-lib-creatures` | la vida del suelo y los polinizadores |
| `LaminaMataEtapa` | `feat/visual-lib-laminas` | la mata del foco de atención |

_(Las ramas de la librería aún no están en `main`, así que se vendorizaron los archivos importados. No se trajo `effects/` ni las láminas/escenas/criaturas que no se usan, para no arrastrar sus errores de tipo ni ampliar el diff.)_

## Verificación

- `npm run build` **verde** — emite el chunk `SaludFinca` (JS 90.4 kB / CSS 29 kB).
- `node scripts/tsc-check-gate.mjs` — **868 = 868** baseline, cero errores nuevos.
- `npx eslint --max-warnings 0 src/mockups/SaludFinca.jsx` — **limpio**.

Mobile-first desde 320px, reduced-motion-safe, self-contained (cero enlaces/imágenes externas). Persona OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)