### PR TITLE
feat(mockup): "El camino del primer cultivo" — onboarding aspiracional (#/mockups/primer-cultivo)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,6 +107,9 @@ const CompostScreen = lazy(() => import('./components/CompostScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const OnboardingCondensado = lazy(() => import('./components/OnboardingCondensado'));
+// Galería de mockups (diseño): rutas públicas `#/mockups/<slug>`, sin auth ni
+// gate, datos de muestra. No cuentan como módulo de piloto. Ver MOCKUP_HASH_ROUTES.
+const PrimerCultivoMockup = lazy(() => import('./mockups/PrimerCultivo'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const PlantaPorVozScreen = lazy(() => import('./components/PlantaPorVozScreen'));
@@ -416,6 +419,15 @@ const LoadingFallback = ({ view = null }) => {
 // viva (HERRAMIENTAS_TILES en DashboardLive). Las rutas `casos`/`caso_detail`/
 // `javier`/`usage_stats` siguen vivas en el router (más abajo) y por hash.
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
+
+// Rutas de MOCKUP de diseño (galería): PÚBLICAS — sin auth ni gate, datos de
+// muestra. Se resuelven ANTES del check de sesión (igual que el callback OAuth),
+// para que una lámina se pueda revisar sin cuenta. Patrón `#/mockups/<slug>` (el
+// hash se normaliza a `mockups/<slug>`). No entran en HASH_VIEW_ROUTES para dejar
+// explícito que NO pasan por los gates de sesión/rol.
+const MOCKUP_HASH_ROUTES = {
+  'mockups/primer-cultivo': 'mockup_primer_cultivo',
+};
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
@@ -915,6 +927,14 @@ export default function App() {
       return;
     }
 
+    // Mockups de diseño: públicos, sin auth. Se resuelven antes de
+    // isAuthenticated para que la galería (#/mockups/<slug>) abra sin cuenta.
+    const mockupView = MOCKUP_HASH_ROUTES[hash];
+    if (mockupView) {
+      Promise.resolve().then(() => navigate(mockupView));
+      return;
+    }
+
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         navigate('login');
@@ -941,6 +961,12 @@ export default function App() {
   useEffect(() => {
     const handleHashRoute = () => {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
+      // Mockups públicos: navegar directo, sin pasar por auth ni gates.
+      const mockupView = MOCKUP_HASH_ROUTES[hash];
+      if (mockupView) {
+        navigate(mockupView);
+        return;
+      }
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
       // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
@@ -2487,6 +2513,19 @@ export default function App() {
                 onNavigate={navigate}
                 initialContext={currentViewData}
               />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_primer_cultivo':
+        // Mockup de galería (público, datos de muestra): "El camino del primer
+        // cultivo" — el acompañamiento aspiracional a quien siembra su primera
+        // mata: elegir según el clima, preparar el sitio, el gesto de sembrar,
+        // qué observar y la paciencia. Anti-gamificación (sin puntos ni rachas).
+        // Ruta #/mockups/primer-cultivo.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El camino del primer cultivo">
+              <PrimerCultivoMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/PrimerCultivo.jsx
+++ b/src/mockups/PrimerCultivo.jsx
@@ -1,0 +1,578 @@
+/*
+ * MOCKUP DEV (#/mockups/primer-cultivo): copy de muestra en español de
+ * Colombia (usted) para el onboarding aspiracional del primer cultivo. No es
+ * UI de producción; si se adopta, sus textos migran a src/config/messages.js
+ * (ADR-050).
+ */
+/**
+ * PrimerCultivo.jsx — MOCKUP DEV · "EL CAMINO DEL PRIMER CULTIVO"
+ * (#/mockups/primer-cultivo, sin gate ni sesión — datos de muestra).
+ *
+ * Concepto: "ACOMPAÑAR LA PRIMERA SIEMBRA REAL, NO ENSEÑAR UNA APP".
+ *   Quien nunca ha sembrado abre esta pantalla y un mentor campesino lo lleva
+ *   de la mano por su PRIMERA MATA, honesto de principio a fin: qué se da en su
+ *   clima (con la expectativa REAL, sin promesas mágicas), cómo escoger el
+ *   sitio con lo mínimo, el gesto concreto de sembrar (hondura, distancia), qué
+ *   MIRAR los próximos días (y qué es normal y qué no) y — el corazón del
+ *   asunto — la PACIENCIA: si no asoma, no falló usted; así se aprende.
+ *
+ * Alineado con la dirección educativa de Chagra (observación + fracaso +
+ * paciencia). ANTI-GAMIFICACIÓN ESTRICTA: no hay puntos, medallas, rachas ni
+ * barra de "progreso/sube de nivel". El "camino" es un MAPA de cinco pasos por
+ * el que se puede ir y volver sin afán — nunca un medidor de logro; ningún paso
+ * se "completa" ni se premia. El único registro posible es la memoria del
+ * cuaderno, no un trofeo.
+ *
+ * Cinco pasos (un pulgar, mentor que acompaña):
+ *   1. ELEGIR — mire el cielo de su vereda; escoja según su clima y su época,
+ *      con la espera real por delante (no todo se da en todas partes).
+ *   2. EL SITIO — un pedazo de tierra bien escogido: sol, agua que escurra y
+ *      suelo suelto. Lo MÍNIMO indispensable; no hay que comprar nada.
+ *   3. SEMBRAR — el gesto: a qué hondura y a qué distancia va la semilla.
+ *   4. OBSERVAR — qué mirar los próximos días: en cuánto asoma, qué es normal
+ *      y qué sí es para ponerle ojo. Mirar despacio también es trabajo.
+ *   5. ESPERAR — la paciencia y el reencuadre del fracaso: la primera mata no
+ *      se mide en cosecha, se mide en lo que usted aprendió mirándola.
+ *
+ * Stack: SVG + CSS, cero deps nuevas. REUSA la librería visual: CapaCielo
+ * (scenes) para el cielo real de la vereda, la clase .scn-kraft (scenes.css)
+ * para el papel, los efectos vfx-grade por piso térmico / vfx-scrim-bottom /
+ * vfx-draw + el helper AutoDibujo (effects) para el brote que se dibuja solo,
+ * las láminas LaminaSiembra / LaminaAporque / LaminaCafeto (laminas) y la fauna
+ * Lombriz / Mariposa / Colibri (creatures). Offline-trivial. Usted cordial.
+ *
+ * Es un MOCKUP HONESTO: los toques muestran "aquí se abre X" y NO navegan.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { CapaCielo } from '../visual/scenes';
+import { Lombriz, Mariposa, Colibri } from '../visual/creatures';
+import { LaminaSiembra, LaminaAporque, LaminaCafeto } from '../visual/laminas';
+import { AutoDibujo } from '../visual/effects';
+import '../visual/scenes/scenes.css';
+import '../visual/effects/effects.css';
+import './primer-cultivo.css';
+
+// ── Finca de muestra (ficticia; los reales saldrían del perfil) ───────────────
+const FINCA = {
+  vereda: 'Vereda La Esperanza',
+};
+
+// ── El clima manda: qué se da, la mata para empezar y su ESPERA real ──────────
+// Tres pisos térmicos, tres matas para el primer intento, cada una con su forma
+// de siembra (la lámina LaminaSiembra resalta esa forma). La expectativa es
+// HONESTA: la papa da en meses, la yuca casi un año, el café siembra futuro.
+const CLIMAS = {
+  frio: {
+    id: 'frio',
+    nombre: 'Tierra fría',
+    rango: '2.400 a 2.800 metros',
+    sena: 'Amanece con neblina y la ruana no sobra.',
+    grade: 'vfx-grade--frio',
+    cielo: { luz: 'dia', condicion: 'nublado' },
+    tambien: [
+      { nombre: 'La arveja', nota: 'rápida y noble' },
+      { nombre: 'El cubio', nota: 'de la casa' },
+      { nombre: 'La cebolla larga', nota: 'siempre a la mano' },
+    ],
+    maduraLamina: null,
+    mata: {
+      nombre: 'La papa',
+      binomio: 'Solanum tuberosum',
+      forma: 'tuberculo',
+      formaNombre: 'una papa-semilla (un tubérculo con ojos)',
+      porque: 'En su clima la papa se cría bien, y con pocas matas ya come la familia.',
+      espera: 'No es de afán: de la siembra a la cosecha pasan de 4 a 5 meses.',
+      epoca: 'Siémbrela cuando entren las lluvias buenas, no en plena seca.',
+      asoma: 'El brote asoma por la tierra entre los 15 y los 25 días.',
+      profundidad: 'Entierre la papa-semilla a un jeme (como 15 cm), con los ojos hacia arriba.',
+      distancia: 'Deje una cuarta y media (30 a 40 cm) de una mata a la otra.',
+      normal: 'Los primeros días no ve nada por fuera: abajo está echando raíz. Eso es normal.',
+      ojo: 'Si el surco se encharca y la tierra huele agrio, afloje y deje escurrir: se le puede pudrir.',
+    },
+  },
+  templado: {
+    id: 'templado',
+    nombre: 'Tierra templada',
+    rango: '1.400 a 2.000 metros',
+    sena: 'Da gusto estar afuera: ni frío ni bochorno.',
+    grade: 'vfx-grade--templado',
+    cielo: { luz: 'dia', condicion: 'despejado' },
+    tambien: [
+      { nombre: 'El maíz', nota: 'el de siempre' },
+      { nombre: 'El fríjol', nota: 'trepa y da rápido' },
+      { nombre: 'El tomate', nota: 'pide más cuidado' },
+    ],
+    maduraLamina: 'cafeto',
+    mata: {
+      nombre: 'El café',
+      binomio: 'Coffea arabica',
+      forma: 'colino',
+      formaNombre: 'un colino (una matica de vivero, ya con sus hojas)',
+      porque: 'Es el cultivo bandera de estas lomas y enseña la paciencia como ninguno.',
+      espera: 'El que siembra café siembra futuro: da su primera cosecha de verdad a los dos años.',
+      epoca: 'Lleve el colino al hueco al entrar las lluvias, para que no sufra de sed.',
+      asoma: 'El colino ya viene con hojas; en 3 o 4 semanas echa raíz nueva y se afirma.',
+      profundidad: 'Va a la misma altura que traía en la bolsa, ni más hondo. Que el cuello no quede enterrado.',
+      distancia: 'Un metro largo entre mata y mata, para que cada una tenga su aire.',
+      normal: 'Puede soltar una hoja o dos del trasplante y quedarse quieto un tiempo. Es normal, está pegando.',
+      ojo: 'Si se pone amarillo y suelta todas las hojas, revise: quedó muy hondo o le falta sombra.',
+    },
+  },
+  calido: {
+    id: 'calido',
+    nombre: 'Tierra caliente',
+    rango: 'menos de 1.400 metros',
+    sena: 'El sol pega duro y la camisa se pega al cuerpo.',
+    grade: 'vfx-grade--calido',
+    cielo: { luz: 'dia', condicion: 'despejado' },
+    tambien: [
+      { nombre: 'El plátano', nota: 'sombra y comida' },
+      { nombre: 'El maíz', nota: 'el de siempre' },
+      { nombre: 'La ahuyama', nota: 'se riega sola' },
+    ],
+    maduraLamina: null,
+    mata: {
+      nombre: 'La yuca',
+      binomio: 'Manihot esculenta',
+      forma: 'esqueje',
+      formaNombre: 'un cangre (un pedazo de tallo con sus yemas)',
+      porque: 'Aguanta el calor y la seca mejor que casi todo, y de un solo palo salen muchas.',
+      espera: 'Es larga pero segura: se arranca de los 8 a los 10 meses.',
+      epoca: 'Clávela al empezar las lluvias; el cangre necesita humedad para prender.',
+      asoma: 'El cangre prende y saca sus primeros cogollos entre los 10 y los 20 días.',
+      profundidad: 'Clave el cangre medio inclinado, dejando dos yemas por fuera de la tierra.',
+      distancia: 'Un metro entre mata y mata: la yuca baja mucha raíz.',
+      normal: 'Al principio solo ve el palo clavado. Tenga fe: abajo echa raíz antes de brotar.',
+      ojo: 'Si el cangre se ablanda y se pone baboso, no prendió: saque otro de un tallo sano.',
+    },
+  },
+};
+
+// ── Los cinco pasos del camino (mapa, NO barra de progreso) ────────────────────
+const PASOS = [
+  { id: 'elegir', mojon: 'Elegir', titulo: 'Qué va a sembrar' },
+  { id: 'sitio', mojon: 'El sitio', titulo: 'Dónde va a quedar' },
+  { id: 'sembrar', mojon: 'Sembrar', titulo: 'El gesto de sembrar' },
+  { id: 'observar', mojon: 'Observar', titulo: 'Los próximos días' },
+  { id: 'esperar', mojon: 'Esperar', titulo: 'La paciencia' },
+];
+
+// ── Lo MÍNIMO indispensable del sitio (paso 2): sin comprar nada ──────────────
+const NECESIDADES = [
+  {
+    icono: '☀️',
+    titulo: 'Sol, pero no todo el día',
+    texto: 'Con medio día de sol le basta. Ni a la sombra total ni al sol que raja piedras de sol a sol.',
+  },
+  {
+    icono: '💧',
+    titulo: 'Que el agua escurra',
+    texto: 'Después de un aguacero, mire: si queda un charco que dura, busque otro puesto. La raíz se ahoga en agua parada.',
+  },
+  {
+    icono: '🪏',
+    titulo: 'Tierra suelta',
+    texto: 'Afloje con azadón hasta donde entra la mano. Quítele piedras y raíces viejas. Nada más.',
+  },
+];
+
+// ── El brote que se dibuja solo (paso 4): AutoDibujo de la librería effects ────
+// Una semilla que abre raíz hacia abajo y cotiledón hacia arriba: el trazo se
+// dibuja al entrar (vfx-draw), y en reduced-motion aparece completo y quieto.
+function BroteDibujado() {
+  return (
+    <svg className="pc-brote" viewBox="0 0 120 120" role="img" aria-label="El primer brote asomando de la semilla">
+      {/* la línea de la tierra */}
+      <AutoDibujo as="line" stage={1} x1="14" y1="70" x2="106" y2="70" stroke="var(--pc-ocre)" strokeWidth="2.5" strokeLinecap="round" />
+      {/* la semilla */}
+      <AutoDibujo as="path" stage={2} d="M60 70 q-9 4 -9 12 q0 8 9 8 q9 0 9 -8 q0 -8 -9 -12 Z" stroke="var(--pc-tinta)" strokeWidth="2.5" fill="none" strokeLinejoin="round" />
+      {/* la raíz que baja */}
+      <AutoDibujo as="path" stage={3} d="M60 90 q-3 12 -8 20 M60 90 q3 10 7 16" stroke="var(--pc-tinta2)" strokeWidth="2" fill="none" strokeLinecap="round" />
+      {/* el tallito que sube */}
+      <AutoDibujo as="path" stage={4} d="M60 70 q-1 -18 0 -30" stroke="var(--pc-verde)" strokeWidth="2.6" fill="none" strokeLinecap="round" />
+      {/* los dos cotiledones */}
+      <AutoDibujo as="path" stage={5} d="M60 42 q-13 -3 -18 -12 q11 -2 18 6 Z" stroke="var(--pc-verde)" strokeWidth="2.4" fill="var(--pc-verde-suave)" strokeLinejoin="round" />
+      <AutoDibujo as="path" stage={6} d="M60 42 q13 -3 18 -12 q-11 -2 -18 6 Z" stroke="var(--pc-verde)" strokeWidth="2.4" fill="var(--pc-verde-suave)" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// ── Escena del camino: cielo real de la vereda + la loma con el sendero ───────
+// El cielo (CapaCielo) responde al clima elegido; encima, el grade de luz por
+// piso térmico (vfx-grade) tiñe la hora. El sendero que sube la loma ES la
+// metáfora: un camino que se recorre paso a paso, no una carrera.
+function EscenaCamino({ clima, paso }) {
+  const madurando = paso === 'esperar';
+  const buenTiempo = paso === 'elegir' || paso === 'sembrar';
+  return (
+    <div className="pc-escena-wrap">
+      <svg className="pc-escena" viewBox="0 0 390 200" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+        <CapaCielo cielo={clima.cielo} cx={318} cy={50} r={19} lluviaY={70} w={390} h={200} />
+
+        {/* lomas de la vereda */}
+        <path fill="var(--pc-loma-lejos)" d="M0 120 L64 96 L128 114 L196 84 L262 108 L326 88 L390 104 L390 200 L0 200 Z" />
+        <path fill="var(--pc-loma)" d="M0 150 L80 122 L156 144 L242 118 L318 142 L390 126 L390 200 L0 200 Z" />
+        <rect x="0" y="170" width="390" height="30" fill="var(--pc-pasto)" />
+
+        {/* el sendero que sube: mojones de piedra hacia la loma */}
+        <path className="pc-sendero" d="M40 196 Q150 176 210 150 T330 96" fill="none" stroke="var(--pc-sendero-c)" strokeWidth="7" strokeLinecap="round" strokeDasharray="1 13" />
+
+        {/* la matica sembrada en primer plano (crece en el paso de esperar) */}
+        <g transform="translate(52 176)">
+          <path d="M0 0 q-2 -10 0 -18" fill="none" stroke="var(--pc-verde-hondo)" strokeWidth={madurando ? 3 : 2.4} strokeLinecap="round" />
+          {madurando && (
+            <>
+              <path d="M0 -18 q-9 -2 -13 -9 q8 -1 13 4 Z" fill="var(--pc-verde)" />
+              <path d="M0 -18 q9 -2 13 -9 q-8 -1 -13 4 Z" fill="var(--pc-verde)" />
+              <path d="M0 -10 q-8 -1 -12 -7 q7 -1 12 3 Z" fill="var(--pc-verde-hondo)" />
+            </>
+          )}
+        </g>
+
+        {/* fauna de la librería: revolotea con buen tiempo */}
+        {buenTiempo && (
+          <g transform="translate(150 70) scale(0.7)">
+            <g className="pc-av-flota">
+              <Mariposa inline size={0} animated title="" />
+            </g>
+          </g>
+        )}
+      </svg>
+      <div className={`vfx-grade ${clima.grade} pc-grade`} aria-hidden="true" />
+      <div className="vfx-scrim-bottom pc-scrim" aria-hidden="true" />
+    </div>
+  );
+}
+
+/** @param {{onBack?: () => void}} [props] */
+export default function PrimerCultivo({ onBack = undefined } = {}) {
+  const [climaId, setClimaId] = useState('templado');
+  const [pasoIx, setPasoIx] = useState(0);
+  const [aviso, setAviso] = useState(null);
+  const avisoTimer = useRef(null);
+  const shellRef = useRef(null);
+
+  const clima = CLIMAS[climaId];
+  const mata = clima.mata;
+  const paso = PASOS[pasoIx];
+
+  const avisar = (t) => {
+    setAviso(t);
+    if (avisoTimer.current) clearTimeout(avisoTimer.current);
+    avisoTimer.current = setTimeout(() => setAviso(null), 3000);
+  };
+  useEffect(() => () => { if (avisoTimer.current) clearTimeout(avisoTimer.current); }, []);
+
+  const irA = (ix) => {
+    setPasoIx(ix);
+    // Subir la vista al empezar el paso (el camino no es un scroll infinito).
+    if (typeof shellRef.current?.scrollIntoView === 'function') {
+      shellRef.current.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    }
+  };
+
+  // 🔊 Leer el paso en voz alta (baja alfabetización / manos en la tierra).
+  const textoLectura = useMemo(() => {
+    switch (paso.id) {
+      case 'elegir':
+        return `Primero, mire el cielo de su vereda. En ${clima.nombre}, para empezar, siembre ${mata.nombre.toLowerCase()}. ${mata.porque} ${mata.espera}`;
+      case 'sitio':
+        return `La primera mata no necesita finca, necesita un pedazo de tierra bien escogido. ${NECESIDADES.map((n) => n.texto).join(' ')}`;
+      case 'sembrar':
+        return `Llegó el momento. Con ${mata.formaNombre} en la mano: ${mata.profundidad} ${mata.distancia}`;
+      case 'observar':
+        return `Ya sembró. Ahora aprenda a mirar. ${mata.asoma} Esto es normal: ${mata.normal} Póngale ojo si: ${mata.ojo}`;
+      case 'esperar':
+        return 'Puede que asome, puede que no. Si no asoma, no falló usted: así se aprende. La primera mata no se mide en cosecha, se mide en lo que usted aprendió mirándola.';
+      default:
+        return '';
+    }
+  }, [paso.id, clima.nombre, mata]);
+
+  const escuchar = () => {
+    try {
+      const u = new SpeechSynthesisUtterance(textoLectura);
+      u.lang = 'es-CO';
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(u);
+    } catch {
+      avisar('Aquí Chagra le lee el paso en voz alta.');
+    }
+  };
+
+  return (
+    <div className="pc" data-clima={climaId} data-paso={paso.id} data-testid="mockup-primer-cultivo">
+      {/* ── Barra del mockup (NO es parte del diseño propuesto) ── */}
+      <div className="pc-mockbar">
+        {typeof onBack === 'function' && (
+          <button type="button" className="pc-mockchip" onClick={onBack}>← Salir</button>
+        )}
+        <span className="pc-mocknota">MOCKUP · datos de muestra · no navega</span>
+      </div>
+
+      <main className="pc-shell" ref={shellRef}>
+        {/* ── El cielo de la vereda + el sendero ── */}
+        <header className="pc-cielo">
+          <EscenaCamino clima={clima} paso={paso.id} />
+          <div className="pc-cielo-txt">
+            <p className="pc-kicker">El camino del primer cultivo</p>
+            <h1 className="pc-titulo">{paso.titulo}</h1>
+            <p className="pc-lugar">{FINCA.vereda} · {clima.nombre}</p>
+          </div>
+        </header>
+
+        {/* ── El sendero: mapa de cinco pasos (NO barra de progreso) ── */}
+        <nav className="pc-mapa" aria-label="Los cinco pasos del camino">
+          <ol className="pc-mojones">
+            {PASOS.map((p, ix) => (
+              <li key={p.id} className="pc-mojon-li">
+                <button
+                  type="button"
+                  className={`pc-mojon ${ix === pasoIx ? 'on' : ''}`}
+                  aria-current={ix === pasoIx ? 'step' : undefined}
+                  aria-label={`Paso ${ix + 1}: ${p.mojon}`}
+                  onClick={() => irA(ix)}
+                >
+                  <span className="pc-mojon-punto" aria-hidden="true" />
+                  <span className="pc-mojon-txt">{p.mojon}</span>
+                </button>
+              </li>
+            ))}
+          </ol>
+          <p className="pc-mapa-nota">Cinco pasos. Sin afán: puede ir y volver cuando quiera.</p>
+        </nav>
+
+        {/* ── El cuerpo del paso, sobre el papel del cuaderno ── */}
+        <section className="scn-kraft pc-pagina" aria-live="polite">
+
+          {/* ── 1. ELEGIR ── */}
+          {paso.id === 'elegir' && (
+            <div className="pc-paso">
+              <p className="pc-lead">
+                Antes de meter la mano en la tierra, mire el cielo de su vereda. No todo se da en
+                todas partes, y está bien. Empiece por lo que su clima cría fácil.
+              </p>
+
+              <p className="pc-ceja">¿Cómo es el clima donde usted vive?</p>
+              <div className="pc-climas" role="group" aria-label="Escoja su clima">
+                {Object.values(CLIMAS).map((c) => (
+                  <button
+                    key={c.id}
+                    type="button"
+                    className={`pc-clima ${c.id === climaId ? 'on' : ''}`}
+                    aria-pressed={c.id === climaId}
+                    onClick={() => setClimaId(c.id)}
+                  >
+                    <span className="pc-clima-nombre">{c.nombre}</span>
+                    <span className="pc-clima-rango">{c.rango}</span>
+                    <span className="pc-clima-sena">{c.sena}</span>
+                  </button>
+                ))}
+              </div>
+
+              <article className="pc-carta pc-carta-mata">
+                <p className="pc-carta-ceja">Para empezar, siembre</p>
+                <h2 className="pc-carta-tit">
+                  {mata.nombre} <em className="pc-binomio">{mata.binomio}</em>
+                </h2>
+                <p className="pc-carta-txt">{mata.porque}</p>
+
+                {clima.maduraLamina === 'cafeto' && (
+                  <div className="pc-carta-lamina">
+                    <LaminaCafeto className="pc-lamina" />
+                  </div>
+                )}
+
+                <ul className="pc-tambien" aria-label="Otras que también se dan en su clima">
+                  <li className="pc-tambien-lbl">En su clima también se dan:</li>
+                  {clima.tambien.map((t) => (
+                    <li key={t.nombre} className="pc-tambien-it">
+                      <span className="pc-tambien-n">{t.nombre}</span>
+                      <span className="pc-tambien-nota"> — {t.nota}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="pc-espera">
+                  <p><span className="pc-espera-lbl">La espera:</span> {mata.espera}</p>
+                  <p><span className="pc-espera-lbl">La época:</span> {mata.epoca}</p>
+                </div>
+              </article>
+            </div>
+          )}
+
+          {/* ── 2. EL SITIO ── */}
+          {paso.id === 'sitio' && (
+            <div className="pc-paso">
+              <p className="pc-lead">
+                La primera mata no necesita finca: necesita un pedazo de tierra bien escogido.
+                No compre nada todavía. Con esto basta para empezar.
+              </p>
+
+              {NECESIDADES.map((n) => (
+                <article key={n.titulo} className="pc-carta pc-carta-menor">
+                  <span className="pc-menor-icono" aria-hidden="true">{n.icono}</span>
+                  <div className="pc-menor-cuerpo">
+                    <h3 className="pc-menor-tit">{n.titulo}</h3>
+                    <p className="pc-menor-txt">{n.texto}</p>
+                  </div>
+                </article>
+              ))}
+
+              <article className="pc-carta pc-carta-suelo">
+                <div className="pc-suelo-lamina" aria-hidden="true">
+                  <LaminaAporque className="pc-lamina" />
+                </div>
+                <div className="pc-suelo-txt">
+                  <h3 className="pc-menor-tit">Así se ve una tierra viva</h3>
+                  <p className="pc-menor-txt">
+                    Al aflojar, mírela por dentro: oscura, que huele a tierra mojada, sin encharcar.
+                  </p>
+                  <p className="pc-suelo-lombriz">
+                    <span className="pc-lombriz-icono" aria-hidden="true">
+                      <Lombriz size={40} title="Lombriz de tierra" />
+                    </span>
+                    Si salen lombrices, alégrese: esa tierra está viva y le va a criar bien la mata.
+                  </p>
+                </div>
+              </article>
+            </div>
+          )}
+
+          {/* ── 3. SEMBRAR ── */}
+          {paso.id === 'sembrar' && (
+            <div className="pc-paso">
+              <p className="pc-lead">
+                Llegó el momento. Con {mata.formaNombre} en la mano, esto es lo único que tiene que
+                hacer bien:
+              </p>
+
+              <div className="pc-siembra-lamina">
+                <LaminaSiembra activo={mata.forma} className="pc-lamina" />
+                <p className="pc-lamina-pie">La forma de sembrar {mata.nombre.toLowerCase()}</p>
+              </div>
+
+              <div className="pc-gestos">
+                <article className="pc-gesto">
+                  <span className="pc-gesto-lbl">A qué hondura</span>
+                  <p className="pc-gesto-txt">{mata.profundidad}</p>
+                </article>
+                <article className="pc-gesto">
+                  <span className="pc-gesto-lbl">A qué distancia</span>
+                  <p className="pc-gesto-txt">{mata.distancia}</p>
+                </article>
+              </div>
+
+              <p className="pc-consejo">
+                <span className="pc-consejo-lbl">Un consejo de viejo:</span> el error más común es
+                enterrar muy hondo por miedo. Si duda, más bien poquito.
+              </p>
+              <p className="pc-nota-epoca">{mata.epoca}</p>
+            </div>
+          )}
+
+          {/* ── 4. OBSERVAR ── */}
+          {paso.id === 'observar' && (
+            <div className="pc-paso">
+              <p className="pc-lead">
+                Ya sembró. Ahora empieza lo más difícil: no hacer casi nada y aprender a mirar.
+              </p>
+
+              <div className="pc-observar-brote">
+                <BroteDibujado />
+                <p className="pc-asoma">{mata.asoma}</p>
+              </div>
+
+              <div className="pc-dos">
+                <article className="pc-carta pc-carta-normal">
+                  <h3 className="pc-dos-tit">Esto es normal</h3>
+                  <p className="pc-menor-txt">{mata.normal}</p>
+                </article>
+                <article className="pc-carta pc-carta-ojo">
+                  <h3 className="pc-dos-tit">Esto sí es para ponerle ojo</h3>
+                  <p className="pc-menor-txt">{mata.ojo}</p>
+                </article>
+              </div>
+
+              <p className="pc-consejo">
+                <span className="pc-consejo-lbl">La costumbre que vale:</span> pase todos los días,
+                aunque sea un momento. No para apurarla — para conocerla. La mata le va enseñando.
+              </p>
+            </div>
+          )}
+
+          {/* ── 5. ESPERAR (el corazón: paciencia + reencuadre del fracaso) ── */}
+          {paso.id === 'esperar' && (
+            <div className="pc-paso pc-paso-esperar">
+              <div className="pc-esperar-fauna" aria-hidden="true">
+                <span className="pc-fauna-a"><Colibri size={46} animated title="" /></span>
+                <span className="pc-fauna-b"><Mariposa size={40} animated title="" /></span>
+              </div>
+
+              <p className="pc-lead pc-lead-hondo">
+                Puede que asome. Puede que no.
+              </p>
+              <p className="pc-esperar-txt">
+                Si no asoma, <strong>no falló usted</strong>: falló esa semilla, o el clima, o la
+                tierra — y así se aprende. El campo no es de una sola vez. Guarde otra, vuelva a
+                sembrar, y anote qué cambió.
+              </p>
+              <p className="pc-remate">
+                La primera mata no se mide en cosecha. Se mide en lo que usted aprendió mirándola.
+              </p>
+
+              <button
+                type="button"
+                className="pc-anotar"
+                data-testid="pc-anotar"
+                onClick={() => avisar('Aquí usted le cuenta a Chagra con su voz cómo le fue, y queda en su cuaderno.')}
+              >
+                🎙️ Cuéntele a Chagra cómo le fue
+              </button>
+
+              <p className="pc-cierre">
+                Ese es el camino. No hay más premio que la mata misma — y lo que usted aprendió.
+              </p>
+              <button type="button" className="pc-reinicio" onClick={() => irA(0)}>
+                Volver al principio del camino
+              </button>
+            </div>
+          )}
+
+        </section>
+
+        {/* ── Avanzar / retroceder + oír el paso ── */}
+        <nav className="pc-pies" aria-label="Moverse por el camino">
+          <button
+            type="button"
+            className="pc-pie pc-atras"
+            disabled={pasoIx === 0}
+            onClick={() => irA(Math.max(0, pasoIx - 1))}
+          >
+            ← Atrás
+          </button>
+          <button type="button" className="pc-oir" aria-label="Escuchar este paso" onClick={escuchar}>
+            🔊 Oír
+          </button>
+          {pasoIx < PASOS.length - 1 ? (
+            <button
+              type="button"
+              className="pc-pie pc-siguiente"
+              data-testid="pc-siguiente"
+              onClick={() => irA(Math.min(PASOS.length - 1, pasoIx + 1))}
+            >
+              Siguiente →
+            </button>
+          ) : (
+            <button type="button" className="pc-pie pc-siguiente pc-fin" onClick={() => irA(0)}>
+              Recomenzar
+            </button>
+          )}
+        </nav>
+      </main>
+
+      {aviso && <div className="pc-aviso" role="status">{aviso}</div>}
+    </div>
+  );
+}

--- a/src/mockups/__tests__/PrimerCultivo.smoke.test.jsx
+++ b/src/mockups/__tests__/PrimerCultivo.smoke.test.jsx
@@ -1,0 +1,48 @@
+/**
+ * Smoke test del mockup "El camino del primer cultivo" (#/mockups/primer-cultivo).
+ * Verifica que el onboarding aspiracional monta, que el clima manda lo que se
+ * recomienda sembrar (con su ESPERA real), que el camino se recorre paso a paso
+ * y que el corazón educativo (paciencia + reencuadre del fracaso) llega intacto
+ * y SIN gamificación (ni puntos, ni medallas, ni "completado").
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import PrimerCultivo from '../PrimerCultivo.jsx';
+
+describe('PrimerCultivo (mockup)', () => {
+  test('monta el primer paso y recomienda según el clima por defecto (templado → café)', () => {
+    render(<PrimerCultivo />);
+    expect(screen.getByTestId('mockup-primer-cultivo')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Qué va a sembrar');
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('El café');
+    // La expectativa es honesta, sin promesas mágicas.
+    expect(screen.getByText(/da su primera cosecha de verdad a los dos años/)).toBeInTheDocument();
+  });
+
+  test('el clima manda: escoger tierra fría cambia la mata a la papa y su espera', () => {
+    render(<PrimerCultivo />);
+    fireEvent.click(screen.getByRole('button', { name: /Tierra fría/ }));
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('La papa');
+    expect(screen.getByText(/de 4 a 5 meses/)).toBeInTheDocument();
+  });
+
+  test('el camino se recorre paso a paso hasta el gesto de sembrar', () => {
+    render(<PrimerCultivo />);
+    // Saltar directo al paso "Sembrar" por el mapa de mojones.
+    fireEvent.click(screen.getByRole('button', { name: /Paso 3: Sembrar/ }));
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('El gesto de sembrar');
+    // El gesto concreto: hondura y distancia.
+    expect(screen.getByText('A qué hondura')).toBeInTheDocument();
+    expect(screen.getByText('A qué distancia')).toBeInTheDocument();
+  });
+
+  test('el corazón: paciencia + "no falló usted", sin premio ni "completado"', () => {
+    render(<PrimerCultivo />);
+    fireEvent.click(screen.getByRole('button', { name: /Paso 5: Esperar/ }));
+    expect(screen.getByText(/no falló usted/i)).toBeInTheDocument();
+    expect(screen.getByText(/no se mide en cosecha/i)).toBeInTheDocument();
+    // Anti-gamificación: nada de puntos, medallas, rachas ni "completado".
+    const paso = screen.getByTestId('mockup-primer-cultivo');
+    expect(within(paso).queryByText(/completad|felicit|medalla|puntos|racha|nivel/i)).toBeNull();
+  });
+});

--- a/src/mockups/primer-cultivo.css
+++ b/src/mockups/primer-cultivo.css
@@ -1,0 +1,502 @@
+/*
+ * primer-cultivo.css — MOCKUP DEV · "El camino del primer cultivo"
+ * (#/mockups/primer-cultivo)
+ *
+ * El cuaderno de campo de quien siembra por primera vez. Paleta de TINTA sobre
+ * papel crema, tomada de la familia de las láminas (sepia, verde tallo, ocre
+ * surco, rojo fruto SOLO para la señal de "ponerle ojo"). El cielo y las lomas
+ * cambian con el clima elegido ([data-clima]); el resto es papel quieto.
+ * Tipografía: serifa de cuaderno para lo que se lee despacio (títulos, leads),
+ * sans del sistema para lo que se opera (chips, botones). Sin fuentes externas.
+ * Mobile-first 320px. Reduced-motion: la librería ya cae a fotograma digno; las
+ * animaciones propias de esta hoja se apagan al final.
+ */
+
+.pc {
+  --pc-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, 'Times New Roman', serif;
+  --pc-sans: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+
+  --pc-papel: #ece1c4;         /* la página kraft */
+  --pc-carta: #fbf6e6;         /* cada carta de papel */
+  --pc-carta-borde: rgba(70, 56, 31, 0.16);
+  --pc-tinta: #46381f;         /* tinta sepia */
+  --pc-tinta2: #7d6b47;        /* tinta aguada */
+  --pc-verde: #3f8f4e;         /* tallo (láminas) */
+  --pc-verde-suave: #cfe6c4;
+  --pc-verde-hondo: #2f6b3a;
+  --pc-ocre: #b98a2f;          /* surco (láminas) */
+  --pc-alerta: #b6432f;        /* fruto maduro: SOLO "ponerle ojo" */
+  --pc-sendero-c: #efe4c6;
+
+  min-height: 100dvh;
+  background: var(--pc-papel);
+  color: var(--pc-tinta);
+  font-family: var(--pc-sans);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* ── Loma/pasto por clima (acompañan el cielo de la librería) ── */
+.pc[data-clima='frio'] {
+  --pc-loma-lejos: #8ea3a0; --pc-loma: #6f8a6a; --pc-pasto: #59794f;
+}
+.pc[data-clima='templado'] {
+  --pc-loma-lejos: #8fb98a; --pc-loma: #689a5a; --pc-pasto: #4d7f43;
+}
+.pc[data-clima='calido'] {
+  --pc-loma-lejos: #b0a663; --pc-loma: #8f9a4e; --pc-pasto: #6f8a3f;
+}
+
+/* ── Barra del mockup (no es parte del diseño propuesto) ── */
+.pc-mockbar {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 30;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  pointer-events: none;
+}
+.pc-mockbar > * { pointer-events: auto; }
+.pc-mockchip {
+  min-height: 34px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(70, 56, 31, 0.35);
+  background: rgba(251, 246, 230, 0.86);
+  color: var(--pc-tinta);
+  font: 700 0.8rem/1 var(--pc-sans);
+  cursor: pointer;
+}
+.pc-mocknota {
+  font: 600 0.62rem/1 var(--pc-sans);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(70, 56, 31, 0.62);
+  background: rgba(251, 246, 230, 0.7);
+  padding: 5px 9px;
+  border-radius: 999px;
+}
+
+.pc-shell {
+  max-width: 430px;
+  margin: 0 auto;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── El cielo de la vereda ── */
+.pc-cielo { position: relative; overflow: hidden; }
+.pc-escena-wrap { position: relative; height: 200px; }
+.pc-escena { display: block; width: 100%; height: 200px; }
+.pc-grade { position: absolute; inset: 0; pointer-events: none; }
+.pc-scrim { position: absolute; left: 0; right: 0; bottom: 0; height: 74%; pointer-events: none; }
+.pc-sendero { opacity: 0.9; }
+
+.pc-cielo-txt {
+  position: absolute;
+  left: 16px; right: 16px; bottom: 12px;
+  color: #fbf6e6;
+  text-shadow: 0 1px 8px rgba(20, 14, 4, 0.55);
+}
+.pc-kicker {
+  margin: 0 0 2px;
+  font: 700 0.72rem/1.1 var(--pc-sans);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.92;
+}
+.pc-titulo {
+  margin: 0;
+  font: 700 1.62rem/1.08 var(--pc-serif);
+}
+.pc-lugar {
+  margin: 3px 0 0;
+  font: 500 0.82rem/1.2 var(--pc-sans);
+  opacity: 0.9;
+}
+
+/* ── El mapa de cinco pasos (NO barra de progreso) ── */
+.pc-mapa {
+  padding: 12px 10px 4px;
+}
+.pc-mojones {
+  list-style: none;
+  margin: 0; padding: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  position: relative;
+}
+/* el sendero de fondo que une los mojones (hilo del cuaderno) */
+.pc-mojones::before {
+  content: '';
+  position: absolute;
+  top: 9px; left: 12%; right: 12%;
+  height: 0;
+  border-top: 2px dashed rgba(70, 56, 31, 0.28);
+}
+.pc-mojon-li { flex: 1 1 0; display: flex; justify-content: center; }
+.pc-mojon {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: 0;
+  padding: 2px 2px 4px;
+  cursor: pointer;
+  color: var(--pc-tinta2);
+  font: 600 0.62rem/1.1 var(--pc-sans);
+  min-width: 44px;
+}
+.pc-mojon-punto {
+  width: 14px; height: 14px;
+  border-radius: 999px;
+  background: var(--pc-papel);
+  border: 2px solid rgba(70, 56, 31, 0.4);
+  box-shadow: 0 0 0 3px var(--pc-papel);
+}
+.pc-mojon-txt { text-align: center; }
+.pc-mojon.on {
+  color: var(--pc-tinta);
+  font-weight: 800;
+}
+.pc-mojon.on .pc-mojon-punto {
+  background: var(--pc-verde-hondo);
+  border-color: var(--pc-verde-hondo);
+  transform: scale(1.18);
+}
+.pc-mapa-nota {
+  margin: 6px 2px 0;
+  text-align: center;
+  font: italic 500 0.76rem/1.3 var(--pc-serif);
+  color: var(--pc-tinta2);
+}
+
+/* ── El cuerpo del paso, sobre el papel ── */
+.pc-pagina {
+  position: relative;
+  flex: 1;
+  margin: 8px 10px 0;
+  padding: 16px 14px 18px;
+  border-radius: 14px 14px 0 0;
+  background-color: var(--pc-carta);
+  --scn-kraft-color: rgba(122, 82, 48, 0.05);
+  box-shadow: 0 -1px 0 rgba(70, 56, 31, 0.08) inset;
+}
+.pc-paso { position: relative; z-index: 1; }
+
+.pc-lead {
+  margin: 0 0 14px;
+  font: 500 1.02rem/1.5 var(--pc-serif);
+  color: var(--pc-tinta);
+}
+.pc-lead-hondo { font-size: 1.3rem; font-weight: 700; margin-bottom: 8px; }
+
+.pc-ceja {
+  margin: 16px 0 8px;
+  font: 700 0.72rem/1.1 var(--pc-sans);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--pc-tinta2);
+}
+
+/* ── Paso 1: escoger clima ── */
+.pc-climas { display: flex; flex-direction: column; gap: 8px; }
+.pc-clima {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1.5px solid var(--pc-carta-borde);
+  background: rgba(255, 253, 246, 0.6);
+  cursor: pointer;
+  color: var(--pc-tinta);
+}
+.pc-clima.on {
+  border-color: var(--pc-verde-hondo);
+  background: rgba(63, 143, 78, 0.1);
+  box-shadow: 0 1px 0 rgba(47, 107, 58, 0.15);
+}
+.pc-clima-nombre { font: 700 1rem/1.2 var(--pc-serif); }
+.pc-clima-rango { font: 600 0.76rem/1.2 var(--pc-sans); color: var(--pc-tinta2); }
+.pc-clima-sena { font: italic 500 0.82rem/1.3 var(--pc-serif); color: var(--pc-tinta2); }
+
+/* ── Cartas de papel ── */
+.pc-carta {
+  margin: 14px 0 0;
+  padding: 14px;
+  border-radius: 12px;
+  background: #fffdf6;
+  border: 1px solid var(--pc-carta-borde);
+  box-shadow: 0 1px 3px rgba(70, 56, 31, 0.06);
+}
+.pc-carta-ceja {
+  margin: 0 0 2px;
+  font: 700 0.7rem/1.1 var(--pc-sans);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--pc-tinta2);
+}
+.pc-carta-tit {
+  margin: 0 0 6px;
+  font: 700 1.35rem/1.12 var(--pc-serif);
+  color: var(--pc-tinta);
+}
+.pc-binomio {
+  display: inline-block;
+  font: italic 500 0.86rem/1 var(--pc-serif);
+  color: var(--pc-tinta2);
+}
+.pc-carta-txt { margin: 0; font: 500 0.96rem/1.45 var(--pc-serif); }
+
+.pc-carta-lamina {
+  margin: 12px auto 4px;
+  max-width: 230px;
+}
+.pc-lamina { display: block; width: 100%; height: auto; }
+
+.pc-tambien {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(122, 82, 48, 0.06);
+}
+.pc-tambien-lbl {
+  font: 700 0.72rem/1.1 var(--pc-sans);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pc-tinta2);
+  margin-bottom: 5px;
+}
+.pc-tambien-it { font: 500 0.9rem/1.5 var(--pc-serif); }
+.pc-tambien-n { font-weight: 700; }
+.pc-tambien-nota { color: var(--pc-tinta2); }
+
+.pc-espera {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--pc-carta-borde);
+}
+.pc-espera p { margin: 0 0 6px; font: 500 0.92rem/1.4 var(--pc-serif); }
+.pc-espera p:last-child { margin-bottom: 0; }
+.pc-espera-lbl { font-weight: 800; color: var(--pc-verde-hondo); }
+
+/* ── Cartas menores (paso 2) ── */
+.pc-carta-menor { display: flex; gap: 12px; align-items: flex-start; }
+.pc-menor-icono { font-size: 1.7rem; line-height: 1; flex: 0 0 auto; }
+.pc-menor-cuerpo { flex: 1; }
+.pc-menor-tit { margin: 0 0 3px; font: 700 1.02rem/1.2 var(--pc-serif); }
+.pc-menor-txt { margin: 0; font: 500 0.92rem/1.45 var(--pc-serif); color: var(--pc-tinta); }
+
+.pc-carta-suelo { display: flex; flex-direction: column; gap: 12px; }
+.pc-suelo-lamina { max-width: 260px; margin: 0 auto; }
+.pc-suelo-lombriz {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding-top: 10px;
+  border-top: 1px dashed var(--pc-carta-borde);
+  font: 500 0.9rem/1.4 var(--pc-serif);
+}
+.pc-lombriz-icono { flex: 0 0 auto; line-height: 0; }
+
+/* ── Paso 3: sembrar ── */
+.pc-siembra-lamina {
+  margin: 4px auto 14px;
+  max-width: 300px;
+  text-align: center;
+}
+.pc-lamina-pie {
+  margin: 6px 0 0;
+  font: italic 500 0.82rem/1.3 var(--pc-serif);
+  color: var(--pc-tinta2);
+}
+.pc-gestos { display: flex; flex-direction: column; gap: 10px; }
+.pc-gesto {
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #fffdf6;
+  border: 1px solid var(--pc-carta-borde);
+  border-left: 4px solid var(--pc-ocre);
+}
+.pc-gesto-lbl {
+  display: block;
+  font: 700 0.72rem/1.1 var(--pc-sans);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--pc-tinta2);
+  margin-bottom: 4px;
+}
+.pc-gesto-txt { margin: 0; font: 500 0.98rem/1.4 var(--pc-serif); }
+
+.pc-consejo {
+  margin: 14px 0 0;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(63, 143, 78, 0.09);
+  font: 500 0.94rem/1.45 var(--pc-serif);
+}
+.pc-consejo-lbl { font-weight: 800; color: var(--pc-verde-hondo); }
+.pc-nota-epoca {
+  margin: 12px 2px 0;
+  font: italic 500 0.88rem/1.4 var(--pc-serif);
+  color: var(--pc-tinta2);
+}
+
+/* ── Paso 4: observar ── */
+.pc-observar-brote {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 4px 0 14px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #fffdf6;
+  border: 1px solid var(--pc-carta-borde);
+}
+.pc-brote { flex: 0 0 84px; width: 84px; height: 84px; }
+.pc-asoma { margin: 0; font: 600 0.98rem/1.4 var(--pc-serif); }
+
+.pc-dos { display: flex; flex-direction: column; gap: 10px; }
+.pc-dos-tit { margin: 0 0 4px; font: 700 0.96rem/1.2 var(--pc-serif); }
+.pc-carta-normal { border-left: 4px solid var(--pc-verde); }
+.pc-carta-ojo { border-left: 4px solid var(--pc-alerta); }
+.pc-carta-ojo .pc-dos-tit { color: var(--pc-alerta); }
+
+/* ── Paso 5: esperar ── */
+.pc-paso-esperar { text-align: center; }
+.pc-esperar-fauna {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 24px;
+  margin: 2px 0 10px;
+  min-height: 52px;
+}
+.pc-fauna-a { animation: pc-flota 6s ease-in-out infinite; }
+.pc-fauna-b { animation: pc-flota 5.2s ease-in-out infinite reverse; }
+.pc-esperar-txt {
+  margin: 0 auto 12px;
+  max-width: 34ch;
+  font: 500 1.02rem/1.5 var(--pc-serif);
+}
+.pc-esperar-txt strong { color: var(--pc-verde-hondo); }
+.pc-remate {
+  margin: 0 auto 16px;
+  max-width: 32ch;
+  font: italic 600 1.06rem/1.45 var(--pc-serif);
+  color: var(--pc-tinta);
+}
+.pc-anotar {
+  min-height: 46px;
+  padding: 11px 18px;
+  border-radius: 999px;
+  border: 1.5px solid var(--pc-verde-hondo);
+  background: rgba(63, 143, 78, 0.1);
+  color: var(--pc-verde-hondo);
+  font: 700 0.94rem/1 var(--pc-sans);
+  cursor: pointer;
+}
+.pc-cierre {
+  margin: 18px auto 10px;
+  max-width: 32ch;
+  font: 500 0.9rem/1.45 var(--pc-serif);
+  color: var(--pc-tinta2);
+}
+.pc-reinicio {
+  background: none;
+  border: 0;
+  color: var(--pc-tinta2);
+  font: 600 0.86rem/1.2 var(--pc-sans);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  padding: 6px;
+}
+
+/* ── Pie: atrás / oír / siguiente ── */
+.pc-pies {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  padding: 10px;
+  background: linear-gradient(to top, var(--pc-papel) 72%, rgba(236, 225, 196, 0));
+}
+.pc-pie {
+  min-height: 46px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1.5px solid var(--pc-carta-borde);
+  background: var(--pc-carta);
+  color: var(--pc-tinta);
+  font: 700 0.94rem/1 var(--pc-sans);
+  cursor: pointer;
+}
+.pc-atras { flex: 0 0 auto; }
+.pc-atras:disabled { opacity: 0.4; cursor: default; }
+.pc-oir {
+  flex: 0 0 auto;
+  min-height: 46px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1.5px solid var(--pc-carta-borde);
+  background: rgba(251, 246, 230, 0.9);
+  color: var(--pc-tinta);
+  font: 700 0.9rem/1 var(--pc-sans);
+  cursor: pointer;
+}
+.pc-siguiente {
+  flex: 1;
+  background: var(--pc-verde-hondo);
+  border-color: var(--pc-verde-hondo);
+  color: #fbf6e6;
+}
+.pc-fin { background: var(--pc-tinta); border-color: var(--pc-tinta); }
+
+/* ── Aviso efímero (memoria del cuaderno, no premio) ── */
+.pc-aviso {
+  position: fixed;
+  left: 50%;
+  bottom: 76px;
+  transform: translateX(-50%);
+  z-index: 40;
+  max-width: 300px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  background: var(--pc-tinta);
+  color: var(--pc-carta);
+  font: 500 0.88rem/1.35 var(--pc-serif);
+  text-align: center;
+  box-shadow: 0 6px 20px rgba(20, 14, 4, 0.3);
+}
+
+@keyframes pc-flota {
+  0%, 100% { transform: translateY(0) rotate(-2deg); }
+  50% { transform: translateY(-7px) rotate(2deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pc-fauna-a, .pc-fauna-b { animation: none; }
+  .pc-mojon.on .pc-mojon-punto { transform: none; }
+}
+
+/* Pantallitas muy angostas (320px): que nada se salga ni se apriete de más. */
+@media (max-width: 340px) {
+  .pc-titulo { font-size: 1.42rem; }
+  .pc-mojon { font-size: 0.56rem; min-width: 40px; }
+  .pc-oir { padding: 10px 10px; }
+  .pc-pie { padding: 10px 12px; }
+}

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,0 +1,61 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
+   Apis). Cuerpo ámbar rayado, cabeza clara, alitas de tul. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-15 -15 32 30';
+
+export function AbejaAngelita({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Abeja angelita',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#ffb54f" opacity="0.35" filter={`url(#${blur})`} />
+      <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
+        style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
+      <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
+        stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
+      <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
+      <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
+      <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
+      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="abeja-angelita">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default AbejaAngelita;

--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,0 +1,62 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Colibrí chillón — Colibri coruscans (nativo de los Andes). Pico largo y
+   recto, garganta violeta iridiscente, alas que baten. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-22 -28 58 52';
+
+export function Colibri({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Colibrí',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#2dffc4" opacity="0.35" filter={`url(#${blur})`} />
+      <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
+      <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
+      <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
+      <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
+      <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
+      <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
+      <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
+      <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <path className={wing} d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
+      <path className={wing} style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="colibri">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="colibri" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Colibri;

--- a/src/visual/creatures/Escarabajo.jsx
+++ b/src/visual/creatures/Escarabajo.jsx
@@ -1,0 +1,73 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Escarabajo estercolero — Dichotomius belus (propio de Colombia). Élitros
+   negros brillantes con sutura, cabeza con cuerno, patas que caminan y la bola
+   de abono que rueda. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-23 -12 42 30';
+
+export function Escarabajo({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Escarabajo estercolero',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const bola = animated ? 'crt-ball' : undefined;
+  const patas = animated ? 'crt-legs' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const bolaG = (
+    <g className={bola}>
+      <circle cx="-13" cy="7" r="6.5" fill="#5a4230" />
+      <circle cx="-13" cy="7" r="6.5" fill="none" stroke="#3a2c1c" strokeWidth="1" />
+      <circle cx="-15" cy="5" r="1.5" fill="#6e5238" opacity="0.7" />
+      <circle cx="-11.5" cy="9" r="1.1" fill="#42301f" opacity="0.7" />
+    </g>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={patas} stroke="#0c1206" strokeWidth="1.7" strokeLinecap="round">
+        <path d="M-4,4 L-9,10" /><path d="M0,5 L-1,11" /><path d="M4,4 L8,10" />
+      </g>
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="#141c10"
+        style={{ filter: 'drop-shadow(0 0 5px rgba(157,214,106,0.7))' }} />
+      <ellipse cx="0" cy="0" rx="9" ry="6.4" fill="none" stroke="#9dd66a" strokeWidth="0.7" strokeOpacity="0.6" />
+      <path d="M0,-5.6 L0,5.6" stroke="#0c1206" strokeWidth="0.8" />
+      <ellipse cx="-3.5" cy="-2.8" rx="2.6" ry="1.4" fill="#3d5a24" opacity="0.55" />
+      <path d="M8,-3.4 C12,-3.8 13.4,-1 12.4,1.4 C11.4,3.6 9,3.6 8.2,2.6 C9.4,1 9.2,-1.4 8,-3.4 Z" fill="#0f150b" />
+      <path d="M11.2,-3.2 C12.6,-5 13.4,-4.4 13.2,-2.8" fill="none" stroke="#0f150b" strokeWidth="1.7" strokeLinecap="round" />
+      <circle cx="10.4" cy="-0.6" r="0.7" fill="#9dd66a" opacity="0.8" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="escarabajo">
+        {defs}
+        {bolaG}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="escarabajo" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {bolaG}
+      {body}
+    </svg>
+  );
+}
+
+export default Escarabajo;

--- a/src/visual/creatures/Lombriz.jsx
+++ b/src/visual/creatures/Lombriz.jsx
@@ -1,0 +1,64 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Lombriz de tierra — Martiodrilus crassus (lombriz gigante nativa de los
+   Andes). Cuerpo curvo segmentado con clitelo (banda clara) y cabecita.
+   Su movimiento en escena (asomar/mecerse) lo aporta la escena, no la
+   criatura. Versión canónica del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-8 -16 30 48';
+
+export function Lombriz({
+  size = 64,
+  className,
+  inline = false,
+  // eslint-disable-next-line no-unused-vars
+  animated = true,
+  title = 'Lombriz de tierra',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#c0715a" strokeWidth="7.4" strokeLinecap="round" />
+      <path d="M0,26 C-2,14 6,10 4,0 C2.5,-7 8,-11 12,-9"
+        fill="none" stroke="#ff9d6a" strokeWidth="4.4" strokeLinecap="round" opacity="0.85" />
+      <g stroke="#7a3f2e" strokeWidth="0.9" opacity="0.65" strokeLinecap="round">
+        <path d="M-1.4,22 L1.4,20.5" /><path d="M-1.2,16.5 L2.2,15.5" />
+        <path d="M2.4,11.5 L5.6,11" /><path d="M3.4,5.5 L6.4,5.6" />
+        <path d="M2.8,-0.5 L5.6,-1.4" /><path d="M4.6,-6 L7.4,-7.6" />
+      </g>
+      <path d="M3.2,3 C2,-1 4,-4 6.6,-5" fill="none" stroke="#ffd9b0" strokeWidth="4.6" strokeLinecap="round" opacity="0.75" />
+      <circle cx="12.2" cy="-9.4" r="2.2" fill="#ff9d6a" />
+      <circle cx="13.2" cy="-10" r="0.6" fill="#3a1c12" opacity="0.7" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="lombriz">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="lombriz" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Lombriz;

--- a/src/visual/creatures/Mariposa.jsx
+++ b/src/visual/creatures/Mariposa.jsx
@@ -1,0 +1,76 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Mariposa pasionaria — Dione juno (Nymphalidae, alas largas). Cuatro alas
+   independientes (delanteras + traseras, izq/der) que abren y cierran, cuerpo,
+   cabeza, antenas y ocelos. Versión canónica del mockup "Guardianes". */
+const VIEWBOX = '-27 -18 54 40';
+
+export function Mariposa({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Mariposa',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const alaL = animated ? 'crt-fwing crt-fwing-l' : undefined;
+  const alaR = animated ? 'crt-fwing crt-fwing-r' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <g className={alaL}>
+        <path d="M0,2 C-13,4 -18,12 -12,15 C-6,17 -1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="-9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,2 C13,4 18,12 12,15 C6,17 1,10 0,4 Z" fill="#d24a1e" opacity="0.9" />
+        <circle cx="9" cy="11" r="1.3" fill="#2a0f06" opacity="0.7" />
+      </g>
+      <g className={alaL}>
+        <path d="M0,-2 C-16,-11 -24,-6 -22,0 C-20,5 -8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M-20,-3 C-14,-2 -7,-1 -1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="-16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <g className={alaR}>
+        <path d="M0,-2 C16,-11 24,-6 22,0 C20,5 8,3 0,1 Z" fill="#ff6ad0" opacity="0.92" />
+        <path d="M20,-3 C14,-2 7,-1 1,0" fill="none" stroke="#eafff6" strokeWidth="0.8" opacity="0.6" />
+        <circle cx="16" cy="-4" r="1.1" fill="#eafff6" opacity="0.85" />
+      </g>
+      <ellipse cx="0" cy="2" rx="1.7" ry="9" fill="#2a1712" />
+      <circle cx="0" cy="-8" r="1.9" fill="#2a1712" />
+      <path d="M-0.8,-9.4 C-3,-13 -4.5,-14 -6,-13.6 M0.8,-9.4 C3,-13 4.5,-14 6,-13.6"
+        stroke="#2a1712" strokeWidth="0.8" fill="none" strokeLinecap="round" />
+      <circle cx="-6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+      <circle cx="6" cy="-13.6" r="0.9" fill="#ff6ad0" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="mariposa">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="mariposa" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Mariposa;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -1,0 +1,74 @@
+# `src/visual/creatures` — personajes de fauna reutilizables
+
+Librería de **personajes de fauna de la chagra** como componentes SVG limpios,
+parametrizables y sin dependencias nuevas. Nace para **dejar de redibujar el
+mismo bicho** en cada mockup/escena: hoy el colibrí, la abeja angelita, la
+lombriz, la mariposa y el escarabajo aparecían dibujados por separado en varios
+sitios (`mockups/MockupGuardianesNarrativos`, `dashboard/Scene*`,
+`FincaVivaHero`, `MundoVinetas`, `MundoSubsuelo`, avatares del colibrí…) con
+calidad dispar. Aquí vive la **versión canónica** de cada uno.
+
+## Regla de la casa
+
+> **Antes de dibujar un personaje de fauna, búscalo aquí.**
+> Si existe → **reúsalo** (y si podés, **mejorá** la versión canónica en su
+> archivo, para que todos hereden la mejora).
+> Si dibujás un personaje nuevo reutilizable → **agregalo aquí en el mismo PR**
+> (componente + entrada en `index.js` + fila en esta tabla).
+
+## Personajes
+
+| Componente | Especie (binomio verificado) | Notas |
+|---|---|---|
+| `AbejaAngelita` | *Tetragonisca angustula* | Meliponino nativo **SIN aguijón** — NO *Apis*. Alitas de tul que baten. |
+| `Colibri` | *Colibri coruscans* | Colibrí chillón andino. Pico largo, garganta violeta, alas que baten. |
+| `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
+| `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
+| `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
+
+## Props
+
+Todos comparten la misma firma:
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `size` | `number \| string` | `64` | Ancho/alto en modo standalone (`<svg>`). Ignorado en modo `inline`. |
+| `className` | `string` | — | Clase(s) del nodo raíz. En modo `inline` es donde la escena engancha su coreografía de entrada/posición. |
+| `inline` | `boolean` | `false` | `false` → `<svg>` autónomo (avatares, catálogo, botones). `true` → solo un `<g>` para incrustar en una escena SVG existente. |
+| `animated` | `boolean` | `true` | Activa la vida perpetua (aleteo, alas, bola, patas). `false` = quieto. Siempre reduced-motion-safe. |
+| `title` | `string` | nombre del bicho | `aria-label` + `<title>` accesible. |
+
+Props extra (`...rest`) se pasan al `<svg>` en modo standalone.
+
+## Uso
+
+```jsx
+import { Colibri, AbejaAngelita } from '@/visual/creatures';
+
+// Avatar / catálogo — SVG autónomo:
+<Colibri size={48} title="Colibrí chillón" />
+<AbejaAngelita size={40} animated={false} />
+
+// Dentro de una escena SVG propia (la escena pone posición y entrada):
+<svg viewBox="0 0 340 210">
+  {/* …fondo, suelo… */}
+  <g transform="translate(120 66)">
+    <Colibri inline className="mi-entrada-volando" />
+  </g>
+</svg>
+```
+
+Consumidor de referencia: **`src/mockups/MockupGuardianesNarrativos.jsx`**
+(usa las 5 criaturas en modo `inline`).
+
+## Técnica
+
+- SVG + CSS puros, **cero dependencias nuevas**; solo `transform`/`opacity`
+  (GPU, Android gama baja). Familia visual del glow de `GuardianEspiritu`.
+- Cada instancia genera **ids de filtro únicos** (`useId`), así se pueden
+  repetir muchas criaturas en una misma página sin colisión.
+- La **vida perpetua** vive en `creatures.css` (clases `crt-*`), es intrínseca
+  a la criatura y **reduced-motion-safe** (sin animación → fotograma digno).
+- La **coreografía de LLEGADA** (entrar volando, asomar del suelo, rodar) NO
+  vive aquí: es responsabilidad de la escena que consume la criatura, sobre el
+  `className` del modo `inline`.

--- a/src/visual/creatures/_filters.jsx
+++ b/src/visual/creatures/_filters.jsx
@@ -1,0 +1,23 @@
+/*
+ * Filtro SVG compartido de la familia visual "creatures": glow orgánico
+ * (feGaussianBlur + feMerge) heredado de GuardianEspiritu + blur suave.
+ * Cada criatura instancia estos filtros con ids ÚNICOS (useId) para poder
+ * repetirse muchas veces en una misma página sin colisión de ids.
+ * Interno de la librería — no se exporta desde el barrel.
+ */
+export function CreatureFilters({ glow, blur }) {
+  return (
+    <>
+      <filter id={glow} x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.1" result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      <filter id={blur}>
+        <feGaussianBlur stdDeviation="3" />
+      </filter>
+    </>
+  );
+}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1,0 +1,51 @@
+/* ─── Vida perpetua de las CREATURES — SVG + CSS puros, solo transform/opacity
+   (GPU, Android gama baja). Reutilizable en cualquier escena o avatar.
+   La coreografía de LLEGADA (entrar volando, asomar del suelo) NO vive aquí:
+   es responsabilidad de la escena que consume la criatura.
+   reduced-motion = criatura quieta en un fotograma digno. ─── */
+
+/* aleteo rápido (abeja / colibrí) */
+.crt-wing {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: crt-wingbeat 0.13s ease-in-out infinite alternate;
+}
+@keyframes crt-wingbeat {
+  0% { transform: scaleY(1) scaleX(1); }
+  100% { transform: scaleY(0.6) scaleX(0.9); }
+}
+
+/* alas de mariposa que abren y cierran */
+.crt-fwing {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-flutter 0.5s ease-in-out infinite;
+}
+.crt-fwing-l { transform-origin: right center; }
+.crt-fwing-r { transform-origin: left center; }
+@keyframes crt-flutter {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.4); }
+}
+
+/* bola de abono que rueda (escarabajo) */
+.crt-ball {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crt-roll 1.1s linear infinite;
+}
+@keyframes crt-roll {
+  0% { transform: rotate(0); }
+  100% { transform: rotate(-360deg); }
+}
+
+/* patas que dan pasos (escarabajo) */
+.crt-legs { animation: crt-step 0.5s ease-in-out infinite; }
+@keyframes crt-step {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-1.2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crt-wing, .crt-fwing, .crt-ball, .crt-legs { animation: none !important; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -1,0 +1,32 @@
+/*
+ * Librería visual de PERSONAJES DE FAUNA de la chagra (creatures).
+ * Fuente única y reutilizable. Antes de dibujar un bicho, búscalo aquí.
+ *
+ * Cada componente:
+ *   - Modo standalone (por defecto): renderiza su propio <svg> con viewBox,
+ *     dimensionado por `size` — ideal para avatares, catálogo, botones.
+ *   - Modo `inline`: renderiza solo el <g> para incrustarse en una escena SVG
+ *     que ya define su viewBox y su coreografía de entrada/posición.
+ *
+ * Props comunes: { size, className, inline, animated, title }.
+ */
+export { AbejaAngelita } from './AbejaAngelita.jsx';
+export { Colibri } from './Colibri.jsx';
+export { Lombriz } from './Lombriz.jsx';
+export { Mariposa } from './Mariposa.jsx';
+export { Escarabajo } from './Escarabajo.jsx';
+
+import AbejaAngelita from './AbejaAngelita.jsx';
+import Colibri from './Colibri.jsx';
+import Lombriz from './Lombriz.jsx';
+import Mariposa from './Mariposa.jsx';
+import Escarabajo from './Escarabajo.jsx';
+
+/* Registro consultable: slug → componente + binomio verificado. */
+export const CREATURES = {
+  'abeja-angelita': { Component: AbejaAngelita, nombre: 'Abeja angelita', cientifico: 'Tetragonisca angustula' },
+  colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
+  lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
+  mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
+  escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },
+};

--- a/src/visual/effects/AutoDibujo.jsx
+++ b/src/visual/effects/AutoDibujo.jsx
@@ -1,0 +1,35 @@
+/*
+ * AutoDibujo — el AUTO-DIBUJADO orquestado compartido (§13.11 del catálogo).
+ *
+ * La receta de SceneTrazoMinimal ("el trazo se dibuja solo al entrar"):
+ * `pathLength="1"` normalizado + `stroke-dashoffset` que va a 0 + etapas con
+ * delay escalonado. Aquí queda como helper para no re-cablear el dasharray a
+ * mano en cada lámina/onboarding/glifo.
+ *
+ * El movimiento vive en `effects.css` (clases `vfx-draw`, `vfx-fade`,
+ * `vfx-t1…vfx-t9`); este componente solo pega las clases correctas y pone
+ * `pathLength="1"` para que el draw-in sea independiente de la longitud real
+ * del trazo. Reduced-motion = el dibujo COMPLETO y quieto (lo garantiza el CSS).
+ *
+ * Recuerde importar el CSS una vez en la escena:  import '.../effects/effects.css'
+ *
+ * @param {object}  props
+ * @param {'path'|'line'|'polyline'|'circle'|'rect'|string} [props.as='path']
+ *        elemento SVG a renderizar.
+ * @param {number}  [props.stage]      etapa 1..9 (delay escalonado del dibujo).
+ * @param {boolean} [props.fade=false] `true` = aparece en fundido (opacity) en
+ *        vez de trazarse — para planos de color (sol, leyenda, humo).
+ * @param {string}  [props.className]  clases extra.
+ * Resto de props (`d`, `stroke`, `strokeWidth`, `fill`, `cx`…) se pasan tal cual.
+ */
+export function AutoDibujo({ as = 'path', stage, fade = false, className, ...rest }) {
+  const El = as;
+  const base = fade ? 'vfx-fade' : 'vfx-draw';
+  const stageClass = stage ? ` vfx-t${stage}` : '';
+  const cls = `${base}${stageClass}${className ? ` ${className}` : ''}`;
+  // pathLength normaliza el dashoffset a [0..1]; solo aplica al modo trazo.
+  const drawProps = fade ? {} : { pathLength: 1 };
+  return <El className={cls} {...drawProps} {...rest} />;
+}
+
+export default AutoDibujo;

--- a/src/visual/effects/FiltroAcuarela.jsx
+++ b/src/visual/effects/FiltroAcuarela.jsx
@@ -1,0 +1,58 @@
+/*
+ * FiltroAcuarela — el borde/relleno "pintado a la acuarela" compartido
+ * (feTurbulence + feDisplacementMap).
+ *
+ * Da a un trazo o relleno SVG el borde húmedo, irregular y sangrado de la
+ * acuarela: la turbulencia genera un ruido fractal y el displacement empuja los
+ * píxeles según ese ruido. Es la receta que dibuja los bordes del mapa-acuarela
+ * en vez de re-hilvanar un `<filter>` inline por mockup.
+ *
+ * Emite SOLO el `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y lo referencia con `filter={`url(#${id})`}`. Pasar ids únicos
+ * (`useId`) para repetir varios en la misma página sin colisión.
+ *
+ * Reduced-motion-safe por construcción: el filtro es ESTÁTICO (no anima), en
+ * línea con la regla de la casa "blur/filtros estáticos, solo transform/opacity
+ * animados".
+ *
+ * @param {object} props
+ * @param {string}  props.id                 id del filtro (obligatorio).
+ * @param {number} [props.frequency=0.012]   baseFrequency del ruido (más alto =
+ *                                           borde más nervioso/fino).
+ * @param {number} [props.scale=6]           fuerza del desplazamiento en px.
+ * @param {number} [props.octaves=2]         numOctaves del fractalNoise.
+ * @param {number} [props.seed=7]            semilla del ruido (determinista).
+ * @param {string} [props.bounds='-20%']     origen del box del filtro (x/y).
+ */
+export function FiltroAcuarela({
+  id,
+  frequency = 0.012,
+  scale = 6,
+  octaves = 2,
+  seed = 7,
+  bounds = '-20%',
+}) {
+  const off = parseFloat(bounds);
+  const size = `${100 - 2 * off}%`;
+  const noise = `${id}-noise`;
+  return (
+    <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+      <feTurbulence
+        type="fractalNoise"
+        baseFrequency={frequency}
+        numOctaves={octaves}
+        seed={seed}
+        result={noise}
+      />
+      <feDisplacementMap
+        in="SourceGraphic"
+        in2={noise}
+        scale={scale}
+        xChannelSelector="R"
+        yChannelSelector="G"
+      />
+    </filter>
+  );
+}
+
+export default FiltroAcuarela;

--- a/src/visual/effects/GlowFilter.jsx
+++ b/src/visual/effects/GlowFilter.jsx
@@ -1,0 +1,44 @@
+/*
+ * GlowFilter — el GLOW neón orgánico compartido de Chagra (§13.16 del catálogo).
+ *
+ * Es la MISMA receta que hoy está copiada como `<filter>` inline en varias
+ * escenas y en la librería de fauna (GuardianEspiritu `ge-glow1`, creatures
+ * `CreatureFilters`, SceneFincaOrganismo `fvo-glow1`…): un feGaussianBlur
+ * fundido con el original vía feMerge, más — opcionalmente — un blur suave
+ * suelto para halos/estelas. Aquí vive la versión canónica.
+ *
+ * Emite SOLO los `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y referencia por id. Como cada escena decide su id, se pueden repetir
+ * muchos glows en una misma página sin colisión (pasar ids únicos con `useId`).
+ *
+ * @param {object} props
+ * @param {string}  props.id              id del filtro de glow (obligatorio).
+ * @param {number} [props.std=2.1]        desenfoque del glow (stdDeviation).
+ * @param {string} [props.blurId]         si se pasa, emite además un blur suelto
+ *                                        con este id (para halos/estelas).
+ * @param {number} [props.blurStd=3]      desenfoque del blur suelto.
+ * @param {string} [props.bounds='-80%']  origen del box del filtro (x/y); el
+ *                                        ancho/alto se calculan como 100%-2*bounds.
+ */
+export function GlowFilter({ id, std = 2.1, blurId, blurStd = 3, bounds = '-80%' }) {
+  const off = parseFloat(bounds); // -80  → box de 260%
+  const size = `${100 - 2 * off}%`;
+  return (
+    <>
+      <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+        <feGaussianBlur stdDeviation={std} result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      {blurId ? (
+        <filter id={blurId}>
+          <feGaussianBlur stdDeviation={blurStd} />
+        </filter>
+      ) : null}
+    </>
+  );
+}
+
+export default GlowFilter;

--- a/src/visual/effects/README.md
+++ b/src/visual/effects/README.md
@@ -1,0 +1,118 @@
+# `src/visual/effects` — efectos visuales reutilizables
+
+Librería de las **técnicas de cine** de Chagra (las que dan el "wow": velos,
+viñeta, scrims, grades de luz por piso térmico, glow, pulso cardíaco,
+auto-dibujado, acuarela) como **CSS + helpers SVG limpios, parametrizables y sin
+dependencias nuevas**. Nace para **dejar de re-hilvanar el mismo efecto** en
+cada mockup/escena: hoy el velo neón, la viñeta, los grades `--mm2-*`, el glow
+`feMerge`, el latido `--fvo-beat`, el trazo que se dibuja solo y el filtro
+acuarela aparecían copiados/redibujados en `finca-viva-hero.css`,
+`scene-finca-organismo.css`, `scene-trazo-minimal.css`, `GuardianEspiritu`, los
+mockups de la Montaña y el mapa-acuarela. Aquí vive la **versión canónica**.
+
+Hermana de [`src/visual/creatures`](../creatures/README.md) (personajes de
+fauna): misma filosofía, mismo contrato de reuso.
+
+## Regla de la casa
+
+> **Antes de re-dibujar un efecto de cine, búsquelo aquí.**
+> Si existe → **reúselo** (y de ser posible, **mejore** la versión canónica,
+> para que todos hereden la mejora).
+> Si crea un efecto nuevo reutilizable → **agréguelo aquí en el mismo PR**
+> (clase/helper + entrada en `index.js` + fila en esta tabla).
+
+## Qué hay
+
+| Efecto | Cómo se usa | Catálogo | Semilla |
+|---|---|---|---|
+| **Velo atmosférico** neón | clase `.vfx-veil` (custom props `--vfx-veil-a/b/opacity`) | §13.5 / §13.16 | `finca-viva-hero` `.fvh-escena-wrap::after` |
+| **Viñeta** de cine | clase `.vfx-vignette` (`--vfx-vignette-strength`) | §13.5 | idem |
+| **Scrims** arriba/abajo | clases `.vfx-scrim-top` / `.vfx-scrim-bottom` (`--vfx-scrim-color/-h`) | §13.5 | idem |
+| **Grades de luz por piso térmico** | clase `.vfx-grade` + modificador `.vfx-grade--{glacial,paramo,frio,templado,calido,valle}`; tokens `--vfx-piso-*`; `--vfx-grade-fuerza` por dirección | §13.2 | los `--mm2-*` de Montaña |
+| **Glow** (feMerge) | helper `<GlowFilter id std blurId />` | §13.16 | unifica `ge-glow1` + `creatures/_filters` |
+| **Pulso cardíaco** | token `--vfx-beat` + clases `.vfx-beat`, `.vfx-beat-wave`, `.vfx-beat-glow` | §13.10 | `--fvo-beat` (SceneFincaOrganismo) |
+| **Auto-dibujado** | helper `<AutoDibujo stage fade />` + clases `.vfx-draw/.vfx-fade/.vfx-t1…t9` | §13.11 | SceneTrazoMinimal `fvm-t*` |
+| **Flujo por dash** | clase `.vfx-flow` (`--vfx-flow-dur/-len`) | §13.12 | `fvo-flow` / `adm-sap` |
+| **Filtro acuarela** | helper `<FiltroAcuarela id scale frequency />` | — | mapa-acuarela (feTurbulence+feDisplacementMap) |
+
+## Dos formas de consumir
+
+**1. CSS** (velos, viñeta, scrims, grades, latido, auto-dibujado, flujo).
+Importe el CSS una vez donde lo use y ponga las clases:
+
+```jsx
+import '../../visual/effects/effects.css';
+
+// una escena con cielo de biopunk y hora dorada en la finca:
+<div style={{ position: 'relative' }}>
+  <MiEscenaSVG />
+  <div className="vfx-grade vfx-grade--templado" />   {/* luz de la finca  */}
+  <div className="vfx-veil" />                          {/* velo neón        */}
+  <div className="vfx-scrim-bottom" />                  {/* para que el texto lea */}
+  <div className="vfx-vignette" />                      {/* enfoca el centro */}
+</div>
+```
+
+El pulso cardíaco sincroniza todo lo vivo con una sola variable:
+
+```jsx
+// el corazón late, la red se enciende en fase, la onda se expande:
+<g className="vfx-beat"><path d="…corazón…" /></g>
+<g className="vfx-beat-glow"><path d="…red micorrízica…" /></g>
+<circle className="vfx-beat-wave" r="8" />
+// para acelerar/frenar TODO junto:  style={{ '--vfx-beat': '4s' }} en un ancestro
+```
+
+**2. Helpers SVG** (glow, acuarela, auto-dibujado). Se montan en tu `<defs>` /
+tu SVG. Cada instancia usa **ids únicos** (`useId`) para repetirse sin colisión:
+
+```jsx
+import { useId } from 'react';
+import { GlowFilter, FiltroAcuarela, AutoDibujo } from '../../visual/effects';
+import '../../visual/effects/effects.css';
+
+function MiEscena() {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `glow-${uid}`;
+  const agua = `acuarela-${uid}`;
+  return (
+    <svg viewBox="0 0 390 486">
+      <defs>
+        <GlowFilter id={glow} std={2.2} blurId={`blur-${uid}`} />
+        <FiltroAcuarela id={agua} scale={7} frequency={0.014} />
+      </defs>
+
+      {/* glow neón sobre lo vivo */}
+      <g filter={`url(#${glow})`}>{/* … */}</g>
+
+      {/* un relieve/mancha con borde de acuarela */}
+      <path d="…" fill="#6f9a85" filter={`url(#${agua})`} />
+
+      {/* el trazo se dibuja solo, por etapas */}
+      <AutoDibujo d="M20,300 C120,260 …" stage={1} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo d="M60,300 L60,240 …" stage={3} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo as="circle" fade stage={6} cx="300" cy="90" r="26" fill="#cbb96a" />
+    </svg>
+  );
+}
+```
+
+Consumidor de referencia (convertido en este PR): **`dashboard/GuardianEspiritu.jsx`**
+— sus filtros `ge-glow1`/`ge-blur3`, antes inline, hoy salen de `<GlowFilter>`
+(mismo markup, cero regresión visual).
+
+## Técnica y reglas
+
+- **CSS + SVG puros, cero dependencias nuevas**; solo `transform`/`opacity`
+  animados, **blur/filtros ESTÁTICOS** (Android gama baja). Cero JS por frame.
+- Cada helper emite **solo el `<filter>`** (sin `<defs>` propio): el consumidor
+  lo mete en su `<defs>` y referencia por id. **Ids únicos** con `useId` para
+  repetir muchos en una misma página sin colisión.
+- **Reduced-motion-safe**: sin movimiento, el latido queda encendido, el trazo
+  COMPLETO, los planos visibles y velos/grades/viñeta quietos (son estáticos).
+- Las capas-overlay (`.vfx-veil/.vfx-vignette/.vfx-scrim-*/.vfx-grade`) se montan
+  dentro de un contenedor `position: relative`, no capturan toque y heredan el
+  radio del contenedor.
+- Los **grades por piso térmico** nacen tokenizados (`--vfx-piso-*`): cuando la
+  Montaña entre a prod, se re-tiñen desde `themes.css` sin tocar las escenas
+  (§13.2, promoción de los `--mm2-*` recomendada por el catálogo §14b).

--- a/src/visual/effects/effects.css
+++ b/src/visual/effects/effects.css
@@ -1,0 +1,190 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   src/visual/effects/effects.css — EFECTOS visuales reutilizables de Chagra.
+
+   Las TÉCNICAS DE CINE del catálogo (§13) que hoy están redibujadas/re-copiadas
+   en varios mockups y escenas, aquí una sola vez como clases `vfx-*` + custom
+   properties `--vfx-*`. Antes de re-hilvanar un velo/viñeta/grade/latido/trazo,
+   use esto.
+
+   Reglas de la casa respetadas:
+   · Solo `transform`/`opacity` animados; blur/filtros ESTÁTICOS (Android gama baja).
+   · `prefers-reduced-motion` = fotograma final digno (nada roto, nada en loop).
+   · Cero dependencias; cero JS por frame.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Base de las capas-overlay ───────────────────────────────────────────────
+   Todos los velos/viñetas/scrims/grades se montan como una capa absoluta dentro
+   de un contenedor `position: relative`. No capturan toque. Heredan el radio del
+   contenedor para no desbordar tarjetas redondeadas. */
+.vfx-overlay,
+.vfx-veil,
+.vfx-vignette,
+.vfx-scrim-top,
+.vfx-scrim-bottom,
+.vfx-grade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+/* ── 1. VELO atmosférico neón (§13.5 / §13.16) ──────────────────────────────
+   El velo radial teal/orquídea + tinte navy del modo biopunk (receta de
+   finca-viva-hero `.fvh-escena-wrap::after`). Tunéable por custom props para
+   re-teñir sin reescribir el gradiente. Los temas claros lo apagan poniendo
+   `--vfx-veil-opacity: 0`. */
+.vfx-veil {
+  z-index: 6;
+  opacity: var(--vfx-veil-opacity, 1);
+  background:
+    radial-gradient(120% 78% at 80% 12%, var(--vfx-veil-a, rgba(34, 211, 238, 0.26)), transparent 56%),
+    radial-gradient(110% 92% at 16% 92%, var(--vfx-veil-b, rgba(217, 70, 239, 0.22)), transparent 58%),
+    linear-gradient(180deg,
+      var(--vfx-veil-top, rgba(8, 16, 34, 0.42)) 0%,
+      rgba(8, 16, 34, 0.08) 40%,
+      var(--vfx-veil-bottom, rgba(10, 22, 44, 0.36)) 100%);
+  transition: opacity 0.5s ease;
+}
+
+/* ── 2. VIÑETA de cine (§13.5) ───────────────────────────────────────────────
+   Radial que hunde las esquinas para enfocar el centro y que la UI flote sin
+   cajas. `--vfx-vignette-strength` (0..1) modula cuánto oscurece el borde. */
+.vfx-vignette {
+  z-index: 7;
+  background: radial-gradient(120% 120% at 50% 45%,
+    transparent 52%,
+    rgba(0, 0, 0, calc(0.35 * var(--vfx-vignette-strength, 1))) 100%);
+}
+
+/* ── 3. SCRIMS arriba/abajo (§13.5) ──────────────────────────────────────────
+   Degradados en los bordes superior/inferior para que el texto SIEMPRE lea
+   sobre la escena (títulos arriba, compositor abajo). */
+.vfx-scrim-top {
+  z-index: 7;
+  background: linear-gradient(180deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 28%);
+  inset: 0 0 auto 0;
+}
+.vfx-scrim-bottom {
+  z-index: 7;
+  background: linear-gradient(0deg,
+    var(--vfx-scrim-color, rgba(6, 12, 26, 0.55)) 0%, transparent 100%);
+  height: var(--vfx-scrim-h, 34%);
+  inset: auto 0 0 0;
+}
+
+/* ── 4. GRADES de luz por PISO TÉRMICO (§13.2) ───────────────────────────────
+   Plano de color fijo al viewport, crossfade por opacity: la TEMPERATURA de la
+   luz cuenta la altura. Azul glacial (nevado) → cian páramo → neutro frío →
+   HORA DORADA (finca templada) → ámbar cálido → turquesa río. Portado de los
+   `--mm2-*` del mockup Montaña (§13.2), tokenizado para promoverse a prod.
+   `--vfx-grade-fuerza` modula la intensidad por dirección artística
+   (naturalista 1 · biopunk 0.45 · verde-vivo 0.75). */
+:root {
+  --vfx-piso-glacial:  rgba(180, 214, 240, 0.50); /* nevado 4.800m */
+  --vfx-piso-paramo:   rgba(120, 200, 210, 0.42); /* páramo */
+  --vfx-piso-frio:     rgba(150, 165, 172, 0.28); /* frío (neutro) */
+  --vfx-piso-templado: rgba(255, 200, 120, 0.34); /* finca ⭐ hora dorada */
+  --vfx-piso-calido:   rgba(255, 170,  90, 0.36); /* cálido ámbar */
+  --vfx-piso-valle:    rgba( 90, 200, 190, 0.40); /* río turquesa 400m */
+}
+.vfx-grade {
+  z-index: 5;
+  background: var(--vfx-grade-color, var(--vfx-piso-templado));
+  opacity: var(--vfx-grade-fuerza, 1);
+  transition: background 0.6s ease, opacity 0.6s ease;
+}
+.vfx-grade--glacial  { --vfx-grade-color: var(--vfx-piso-glacial); }
+.vfx-grade--paramo   { --vfx-grade-color: var(--vfx-piso-paramo); }
+.vfx-grade--frio     { --vfx-grade-color: var(--vfx-piso-frio); }
+.vfx-grade--templado { --vfx-grade-color: var(--vfx-piso-templado); }
+.vfx-grade--calido   { --vfx-grade-color: var(--vfx-piso-calido); }
+.vfx-grade--valle    { --vfx-grade-color: var(--vfx-piso-valle); }
+
+/* ── 5. PULSO CARDÍACO compartido (§13.10) ───────────────────────────────────
+   Una sola variable de duración (`--vfx-beat`) sincroniza TODO lo vivo: la
+   escena late como UN organismo. Es el `--fvo-beat` de SceneFincaOrganismo,
+   promovido a la librería (mismo valor 5.2s = `--motion-beat`). */
+:root { --vfx-beat: 5.2s; }
+
+/* el corazón: doble pulso como corazón real */
+.vfx-beat {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat var(--vfx-beat) ease-in-out infinite;
+}
+@keyframes vfx-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+/* onda que sale del latido */
+.vfx-beat-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: vfx-beat-wave var(--vfx-beat) ease-out infinite;
+}
+@keyframes vfx-beat-wave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red/savia/panel se ENCIENDE con cada latido (solo opacity) */
+.vfx-beat-glow { animation: vfx-beat-glow var(--vfx-beat) ease-in-out infinite; }
+@keyframes vfx-beat-glow {
+  0%, 100% { opacity: 0.55; }
+  8% { opacity: 1; }
+  16% { opacity: 0.7; }
+  22% { opacity: 0.9; }
+  34% { opacity: 0.55; }
+}
+
+/* ── 6. AUTO-DIBUJADO orquestado (§13.11) ────────────────────────────────────
+   `pathLength="1"` normalizado + stroke-dashoffset → 0 + etapas escalonadas.
+   El trazo/grafo/glifo se dibuja solo al entrar. (Receta de SceneTrazoMinimal;
+   el componente `AutoDibujo` pega estas clases y pone `pathLength`.) */
+.vfx-draw {
+  stroke-dasharray: 1 1;
+  stroke-dashoffset: 1;
+  animation: vfx-draw 1.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+@keyframes vfx-draw { to { stroke-dashoffset: 0; } }
+
+/* planos de color que aparecen en fundido (sol, leyenda, humo) */
+.vfx-fade { opacity: 0; animation: vfx-fade 1.1s ease forwards; }
+@keyframes vfx-fade { to { opacity: 1; } }
+
+/* etapas del dibujo — delay heredado por trazos y fundidos del grupo */
+.vfx-t1 .vfx-draw, .vfx-t1.vfx-draw, .vfx-t1 .vfx-fade, .vfx-t1.vfx-fade { animation-delay: 0.15s; }
+.vfx-t2 .vfx-draw, .vfx-t2.vfx-draw, .vfx-t2 .vfx-fade, .vfx-t2.vfx-fade { animation-delay: 0.40s; }
+.vfx-t3 .vfx-draw, .vfx-t3.vfx-draw, .vfx-t3 .vfx-fade, .vfx-t3.vfx-fade { animation-delay: 0.70s; }
+.vfx-t4 .vfx-draw, .vfx-t4.vfx-draw, .vfx-t4 .vfx-fade, .vfx-t4.vfx-fade { animation-delay: 0.95s; }
+.vfx-t5 .vfx-draw, .vfx-t5.vfx-draw, .vfx-t5 .vfx-fade, .vfx-t5.vfx-fade { animation-delay: 1.20s; }
+.vfx-t6 .vfx-draw, .vfx-t6.vfx-draw, .vfx-t6 .vfx-fade, .vfx-t6.vfx-fade { animation-delay: 1.50s; }
+.vfx-t7 .vfx-draw, .vfx-t7.vfx-draw, .vfx-t7 .vfx-fade, .vfx-t7.vfx-fade { animation-delay: 1.80s; }
+.vfx-t8 .vfx-draw, .vfx-t8.vfx-draw, .vfx-t8 .vfx-fade, .vfx-t8.vfx-fade { animation-delay: 2.10s; }
+.vfx-t9 .vfx-draw, .vfx-t9.vfx-draw, .vfx-t9 .vfx-fade, .vfx-t9.vfx-fade { animation-delay: 2.50s; }
+
+/* ── 7. FLUJO por dash (§13.12) ──────────────────────────────────────────────
+   Savia/agua/corriente/micelio: dasharray animado que corre por el trazo.
+   `--vfx-flow-dur` y `--vfx-flow-len` tunéan velocidad y avance. */
+.vfx-flow {
+  stroke-dasharray: 4 8;
+  animation: vfx-flow var(--vfx-flow-dur, 3.2s) linear infinite;
+}
+@keyframes vfx-flow { to { stroke-dashoffset: calc(-1 * var(--vfx-flow-len, 40px)); } }
+
+/* ── prefers-reduced-motion: fotograma final digno ───────────────────────────
+   Nada en loop; el dibujo COMPLETO, los planos visibles, velos/grades/viñeta
+   quietos (son estáticos de por sí). Regla de la casa §13.20. */
+@media (prefers-reduced-motion: reduce) {
+  .vfx-beat, .vfx-beat-wave, .vfx-beat-glow, .vfx-flow { animation: none !important; }
+  .vfx-beat, .vfx-beat-glow { opacity: 1; }
+  .vfx-beat-wave { opacity: 0; }              /* la onda no deja residuo */
+  .vfx-draw { animation: none !important; stroke-dashoffset: 0; }
+  .vfx-fade { animation: none !important; opacity: 1; }
+  .vfx-veil { transition: none; }
+}

--- a/src/visual/effects/index.js
+++ b/src/visual/effects/index.js
@@ -1,0 +1,35 @@
+/*
+ * Librería visual de EFECTOS de Chagra (effects) — las TÉCNICAS DE CINE del
+ * catálogo (§13), una sola vez y reutilizables. Antes de re-hilvanar un
+ * velo/viñeta/grade/glow/latido/auto-dibujado/acuarela, use esto.
+ *
+ * Dos piezas:
+ *   1. `effects.css` — clases `vfx-*` + custom properties `--vfx-*`
+ *      (velos, viñeta, scrims, grades por piso térmico, pulso cardíaco,
+ *      auto-dibujado, flujo por dash). Importalo UNA vez donde lo uses:
+ *          import '../../visual/effects/effects.css';
+ *   2. Helpers SVG (este barrel): `GlowFilter`, `FiltroAcuarela`, `AutoDibujo`.
+ *
+ * Reglas de la casa: solo transform/opacity animados; blur/filtros estáticos;
+ * reduced-motion = fotograma final digno; cero dependencias nuevas.
+ */
+export { GlowFilter } from './GlowFilter.jsx';
+export { FiltroAcuarela } from './FiltroAcuarela.jsx';
+export { AutoDibujo } from './AutoDibujo.jsx';
+
+/* Ritmo del latido/respiración compartido (= `--vfx-beat` en effects.css y
+   `--motion-beat`/`--fvo-beat` en el resto del repo). Útil desde JS cuando una
+   escena necesita sincronizar un timing sin leer el CSS. */
+export const VFX_BEAT_MS = 5200;
+
+/* Registro consultable de los pisos térmicos y su grade de luz (§13.2).
+   `token` = la custom property de effects.css; `clase` = la clase modificadora
+   de `.vfx-grade`. Orden de menor a mayor altura invertido: de nevado a río. */
+export const VFX_PISOS = [
+  { slug: 'glacial',  nombre: 'Nevado',   token: '--vfx-piso-glacial',  clase: 'vfx-grade--glacial',  luz: 'azul glacial' },
+  { slug: 'paramo',   nombre: 'Páramo',   token: '--vfx-piso-paramo',   clase: 'vfx-grade--paramo',   luz: 'cian páramo' },
+  { slug: 'frio',     nombre: 'Frío',     token: '--vfx-piso-frio',     clase: 'vfx-grade--frio',     luz: 'neutro frío' },
+  { slug: 'templado', nombre: 'Templado', token: '--vfx-piso-templado', clase: 'vfx-grade--templado', luz: 'hora dorada' },
+  { slug: 'calido',   nombre: 'Cálido',   token: '--vfx-piso-calido',   clase: 'vfx-grade--calido',   luz: 'ámbar cálido' },
+  { slug: 'valle',    nombre: 'Valle/río', token: '--vfx-piso-valle',   clase: 'vfx-grade--valle',    luz: 'turquesa río' },
+];

--- a/src/visual/laminas/LaminaAporque.jsx
+++ b/src/visual/laminas/LaminaAporque.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+/**
+ * LaminaAporque — lámina en CORTE del aporque, la labor propia de los
+ * tubérculos. SVG propio de cuaderno de campo: se ve la finca "por dentro",
+ * como si cortáramos el surco con una pala.
+ *
+ *   ANTES  →  la mata con el cuello descubierto y un par de tubérculos
+ *             asomando (los que se enverdecen al sol).
+ *   APORQUE → se arrima tierra al pie tapando el cuello (la flecha).
+ *   DESPUÉS →  el camellón alto: los tubérculos engordan tapados, a oscuras,
+ *             lejos del sol y con menos paso para la polilla.
+ *
+ * Es DECORATIVA (aria-hidden): ilustra la sección "Aporque" de la ficha; el
+ * texto explica el porqué. Trazo redondeado, colores Tailwind sobre
+ * currentColor por grupo para respirar con los temas.
+ *
+ * @param {Object} props
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+export default function LaminaAporque({ className } = {}) {
+  return (
+    <svg
+      viewBox="0 0 360 120"
+      role="img"
+      aria-hidden="true"
+      className={['w-full h-auto select-none', className].filter(Boolean).join(' ')}
+      data-testid="lamina-aporque"
+    >
+      {/* línea del nivel del suelo original (de referencia) */}
+      <line
+        x1="6" y1="70" x2="354" y2="70"
+        stroke="currentColor" strokeWidth="1.5" strokeDasharray="4 5"
+        strokeLinecap="round" className="text-amber-700/50"
+      />
+
+      {/* ── ANTES · cuello descubierto ── */}
+      <g>
+        {/* terrón bajo, plano */}
+        <path d="M14 70 q 44 -6 88 0 v 40 h -88 z" fill="currentColor" className="text-amber-900/45" />
+        {/* la mata */}
+        <g stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" fill="none" className="text-lime-400">
+          <line x1="58" y1="70" x2="58" y2="40" />
+          <path d="M58 56 q -12 -3 -17 -13" />
+          <path d="M58 50 q 12 -3 17 -13" />
+        </g>
+        {/* tubérculos: uno tapado, uno asomando (verde al sol) */}
+        <ellipse cx="44" cy="86" rx="8" ry="5.5" fill="currentColor" className="text-amber-300/85" />
+        <ellipse cx="70" cy="70" rx="8" ry="5.5" fill="currentColor" className="text-lime-500/80" />
+        {/* solecito que enverdece al descubierto */}
+        <g className="text-amber-300" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+          <circle cx="90" cy="30" r="6" fill="currentColor" opacity="0.9" />
+          <line x1="90" y1="18" x2="90" y2="14" />
+          <line x1="101" y1="24" x2="104" y2="21" />
+          <line x1="79" y1="24" x2="76" y2="21" />
+        </g>
+      </g>
+
+      {/* ── FLECHA · se arrima tierra al pie ── */}
+      <g className="text-slate-300" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" fill="none">
+        <path d="M150 52 q 30 -10 60 0" />
+        <path d="M198 45 l 14 7 l -13 8" />
+      </g>
+      <text x="180" y="34" textAnchor="middle" className="fill-current text-slate-400" fontSize="11">aporque</text>
+
+      {/* ── DESPUÉS · camellón alto, cuello tapado ── */}
+      <g>
+        {/* camellón alto (más tierra arrimada) */}
+        <path d="M244 70 q 52 -34 104 0 v 44 h -104 z" fill="currentColor" className="text-amber-800/55" />
+        {/* la mata, ahora con el cuello enterrado */}
+        <g stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" fill="none" className="text-lime-400">
+          <line x1="296" y1="44" x2="296" y2="18" />
+          <path d="M296 32 q -12 -3 -17 -13" />
+          <path d="M296 26 q 12 -3 17 -13" />
+        </g>
+        {/* varios tubérculos engordando tapados, a oscuras */}
+        <g className="text-amber-300/85">
+          <ellipse cx="278" cy="84" rx="8" ry="5.5" fill="currentColor" />
+          <ellipse cx="300" cy="92" rx="9" ry="6" fill="currentColor" />
+          <ellipse cx="316" cy="82" rx="7.5" ry="5" fill="currentColor" />
+        </g>
+        {/* rótulos de la ganancia */}
+        <text x="296" y="112" textAnchor="middle" className="fill-current text-emerald-400/90" fontSize="9">tapados · a oscuras</text>
+      </g>
+    </svg>
+  );
+}

--- a/src/visual/laminas/LaminaCafeto.jsx
+++ b/src/visual/laminas/LaminaCafeto.jsx
@@ -1,0 +1,273 @@
+import React from 'react';
+
+/**
+ * LaminaCafeto — la lámina insignia del mundo "El café".
+ *
+ * SVG propio (nada de stock, nada rasterizado, sin dependencias) al estilo
+ * BOTÁNICO DE CUADERNO DE CAMPO: una "hoja de papel" color crema, con tinta
+ * sepia y verde, que dibuja la mata de café (Coffea arabica) y rotula sus
+ * partes en español campesino —
+ *
+ *   raíz · tallo (tronco) · rama · hoja · flor · cereza (madura / verde)
+ *
+ * y, en un recuadro "por dentro de la cereza", el corte que muestra la pulpa,
+ * el pergamino y el grano (la almendra) — los mismos términos que usa el
+ * mundo del beneficio (despulpado → pulpa; el grano seco = café pergamino;
+ * trillado = almendra).
+ *
+ * A diferencia de las láminas decorativas de Tubérculos, esta LLEVA rótulos
+ * con significado: por eso es role="img" con <title>/<desc> (accesible) en vez
+ * de aria-hidden. Va pensada para abrir la estación "Variedad y siembra" del
+ * mundo del café: la mata entera antes de contar su ciclo.
+ *
+ * Paleta FIJA (papel crema + tinta sepia/verde): es un pliego de cuaderno
+ * prendido dentro del mundo oscuro del café, así que conserva su aire de papel
+ * en todos los temas a propósito. Estática, GPU-nula, sin animación.
+ *
+ * Grounded (Cenicafé / FNC · catálogo species.coffea_arabica):
+ *   - arbusto de la familia Rubiaceae, hojas OPUESTAS, brillantes, acuminadas;
+ *   - flor blanca de 5 pétalos, en racimos (glomérulos) en las axilas;
+ *   - fruto en drupa ("la cereza"): verde -> rojo al madurar;
+ *   - por dentro, casi siempre 2 granos cara a cara, cada uno envuelto en el
+ *     pergamino (endocarpo); alrededor la pulpa (mesocarpo) y la baba (mucílago).
+ *
+ * @param {Object} props
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+
+/** Una hoja de café: elíptica, acuminada, con nervadura. Base en (0,0),
+ *  la punta sale a `len` en el eje X y el grupo se rota con `rot` grados. */
+function Hoja({ x, y, rot = 0, len = 30 }) {
+  const w = len * 0.34;
+  const cuerpo = `M0 0 Q ${0.34 * len} ${-w} ${len} 0 Q ${0.34 * len} ${w} 0 0 Z`;
+  const nervios = [0.32, 0.5, 0.68].flatMap((i) => [
+    `M${i * len} 0 Q ${i * len + 7} ${-w * 0.45} ${i * len + 0.14 * len} ${-w * 0.62}`,
+    `M${i * len} 0 Q ${i * len + 7} ${w * 0.45} ${i * len + 0.14 * len} ${w * 0.62}`,
+  ]);
+  return (
+    <g transform={`translate(${x} ${y}) rotate(${rot})`}>
+      <path d={cuerpo} fill="#5c7a3f" stroke="#39531f" strokeWidth="1.1" strokeLinejoin="round" />
+      {/* medio brillo de la lámina glossy */}
+      <path d={`M0 0 Q ${0.34 * len} ${-w * 0.9} ${len} 0`} fill="none" stroke="#7f9d57" strokeWidth="1.4" strokeLinecap="round" opacity="0.7" />
+      {/* nervadura */}
+      <path d={`M0 0 L ${len} 0`} fill="none" stroke="#39531f" strokeWidth="0.9" strokeLinecap="round" />
+      {nervios.map((d, k) => (
+        <path key={k} d={d} fill="none" stroke="#3f5b25" strokeWidth="0.6" opacity="0.8" />
+      ))}
+    </g>
+  );
+}
+
+/** Un botón de flor a escala de la mata (el detalle grande va en el recuadro). */
+function Flor({ x, y, r = 3.6 }) {
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      {[0, 72, 144, 216, 288].map((a) => (
+        <ellipse key={a} cx="0" cy={-r} rx={r * 0.6} ry={r} transform={`rotate(${a})`} fill="#fbf6e8" stroke="#d7c592" strokeWidth="0.5" />
+      ))}
+      <circle cx="0" cy="0" r={r * 0.42} fill="#e7c24a" />
+    </g>
+  );
+}
+
+/** Una cereza de café (drupa). `verde`=true la pinta sin madurar. */
+function Cereza({ x, y, r = 5, verde = false }) {
+  const relleno = verde ? '#93a84f' : '#b8402f';
+  const borde = verde ? '#6c8236' : '#8f2f22';
+  const brillo = verde ? '#c3d488' : '#e29079';
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <circle cx="0" cy="0" r={r} fill={relleno} stroke={borde} strokeWidth="0.9" />
+      <ellipse cx={-r * 0.34} cy={-r * 0.36} rx={r * 0.34} ry={r * 0.24} fill={brillo} opacity="0.85" />
+      {/* corona / ombligo del cáliz */}
+      <circle cx="0" cy={-r * 0.92} r="0.9" fill={borde} />
+    </g>
+  );
+}
+
+/** Rótulo con guía: una línea fina sepia con puntico en la parte señalada. */
+function Rotulo({ tx, ty, anchor = 'start', texto, nota, guia }) {
+  return (
+    <g>
+      {guia && <path d={guia.d} fill="none" stroke="#9a8355" strokeWidth="0.9" />}
+      {guia && <circle cx={guia.px} cy={guia.py} r="1.6" fill="#7a6540" />}
+      <text x={tx} y={ty} textAnchor={anchor} fontSize="11" fontWeight="700" fill="#4f3a20" letterSpacing="0.02em">
+        {texto}
+      </text>
+      {nota && (
+        <text x={tx} y={ty + 11} textAnchor={anchor} fontSize="8.5" fontStyle="italic" fill="#8a7350">
+          {nota}
+        </text>
+      )}
+    </g>
+  );
+}
+
+export default function LaminaCafeto({ className } = {}) {
+  return (
+    <svg
+      viewBox="0 0 420 300"
+      role="img"
+      aria-labelledby="lamcaf-t lamcaf-d"
+      className={['w-full h-auto select-none', className].filter(Boolean).join(' ')}
+      data-testid="lamina-cafeto"
+      style={{ fontFamily: 'ui-sans-serif, system-ui, sans-serif' }}
+    >
+      <title id="lamcaf-t">La mata de café (Coffea arabica) con sus partes rotuladas</title>
+      <desc id="lamcaf-d">
+        Lámina de cuaderno de campo: un cafeto dibujado a mano en tinta sepia y verde con la raíz,
+        el tallo o tronco, las ramas, las hojas opuestas y brillantes, la flor blanca de cinco pétalos
+        y las cerezas verdes y maduras. Un recuadro muestra el corte de la cereza por dentro: la pulpa,
+        el pergamino y el grano o almendra.
+      </desc>
+
+      {/* -- el pliego de papel del cuaderno -- */}
+      <rect x="2" y="2" width="416" height="296" rx="10" fill="#f4ead2" stroke="#d8c39a" strokeWidth="2" />
+      <rect x="8" y="8" width="404" height="284" rx="7" fill="none" stroke="#e0d0a8" strokeWidth="1" />
+      {/* esquina doblada (abajo-derecha) */}
+      <path d="M412 274 L392 292 L412 292 Z" fill="#e6d6ae" stroke="#d0bb8a" strokeWidth="0.8" />
+
+      {/* -- encabezado -- */}
+      <text x="16" y="24" fontSize="17" fontWeight="800" fill="#3f2d17">El cafeto</text>
+      <text x="97" y="24" fontSize="12.5" fontStyle="italic" fill="#6b4f2f" style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}>
+        Coffea arabica
+      </text>
+      <text x="404" y="16" textAnchor="end" fontSize="9" fontStyle="italic" fill="#9a8355">cuaderno de campo</text>
+      <text x="404" y="27" textAnchor="end" fontSize="9" fill="#8a7350">Fam. Rubiaceae</text>
+      <line x1="14" y1="32" x2="406" y2="32" stroke="#d8c39a" strokeWidth="1" />
+
+      {/* -----------------  LA MATA  ----------------- */}
+
+      {/* línea del suelo */}
+      <line x1="56" y1="234" x2="248" y2="234" stroke="#9a8355" strokeWidth="1.3" strokeDasharray="5 4" strokeLinecap="round" />
+
+      {/* raíz: pivotante + raicillas, bajo el suelo */}
+      <g stroke="#7a5836" fill="none" strokeLinecap="round">
+        <path d="M150 234 C 151 252 149 266 150 288" strokeWidth="3.4" />
+        <path d="M150 240 C 138 246 130 256 120 264" strokeWidth="2" />
+        <path d="M150 244 C 162 250 172 258 182 266" strokeWidth="2" />
+        <path d="M150 236 C 140 240 132 244 124 250" strokeWidth="1.5" />
+        <path d="M150 238 C 160 242 168 246 176 252" strokeWidth="1.5" />
+        <path d="M120 264 c -4 3 -6 5 -7 9 M182 266 c 4 3 6 5 7 9 M150 288 c -3 3 -4 5 -4 8" strokeWidth="1.1" />
+      </g>
+
+      {/* tallo / tronco leñoso */}
+      <path d="M150 234 C 149 190 152 150 149 110 C 148 96 147 86 146 78" fill="none" stroke="#6b4a2a" strokeWidth="6" strokeLinecap="round" />
+      <path d="M150 232 C 149 190 152 150 149 112 C 148 98 147 88 146 80" fill="none" stroke="#835d34" strokeWidth="2" strokeLinecap="round" opacity="0.7" />
+
+      {/* ramas plagiotrópicas (3 pisos) */}
+      <g fill="none" stroke="#6b4a2a" strokeWidth="3" strokeLinecap="round">
+        <path d="M148 104 C 120 100 100 96 86 92" />
+        <path d="M148 102 C 176 100 196 98 210 96" />
+        <path d="M149 150 C 118 148 96 152 82 158" />
+        <path d="M149 148 C 180 148 200 152 214 158" />
+        <path d="M150 194 C 116 194 96 200 84 208" />
+        <path d="M150 192 C 182 194 202 200 214 208" />
+      </g>
+
+      {/* hojas opuestas, brillantes */}
+      <Hoja x={146} y={78} rot={248} len={22} />
+      <Hoja x={146} y={78} rot={292} len={22} />
+      <Hoja x={104} y={96} rot={202} len={30} />
+      <Hoja x={112} y={90} rot={150} len={25} />
+      <Hoja x={86} y={92} rot={186} len={28} />
+      <Hoja x={100} y={152} rot={206} len={30} />
+      <Hoja x={86} y={158} rot={185} len={27} />
+      <Hoja x={102} y={200} rot={210} len={30} />
+      <Hoja x={86} y={208} rot={190} len={26} />
+      <Hoja x={204} y={152} rot={346} len={27} />
+      <Hoja x={208} y={202} rot={350} len={27} />
+      <Hoja x={206} y={96} rot={16} len={22} />
+
+      {/* flores en racimo (rama alta derecha) */}
+      <Flor x={170} y={102} />
+      <Flor x={182} y={99} />
+      <Flor x={194} y={98} />
+      <Flor x={205} y={97} />
+      <Flor x={200} y={105} />
+
+      {/* cerezas (rama media y baja derecha): maduras rojas + un par verdes */}
+      <Cereza x={186} y={150} />
+      <Cereza x={194} y={146} />
+      <Cereza x={202} y={153} verde />
+      <Cereza x={210} y={158} />
+      <Cereza x={176} y={155} verde />
+      <Cereza x={188} y={196} />
+      <Cereza x={199} y={201} />
+      <Cereza x={209} y={206} />
+
+      {/* -- conector: el detalle de la flor "es" esa flor de la mata -- */}
+      <path d="M322 60 C 288 74 250 88 210 96" fill="none" stroke="#b9a06a" strokeWidth="0.8" strokeDasharray="3 3" opacity="0.8" />
+
+      {/* -- rótulos de la mata -- */}
+      <Rotulo texto="hoja" nota="opuestas, brillantes" tx="12" ty="150"
+        guia={{ d: 'M40 150 C 60 150 78 152 92 152', px: 92, py: 152 }} />
+      <Rotulo texto="rama" tx="12" ty="196"
+        guia={{ d: 'M40 196 C 62 196 78 198 96 199', px: 96, py: 199 }} />
+      <Rotulo texto="tallo" nota="(tronco)" tx="12" ty="248"
+        guia={{ d: 'M40 246 C 80 244 116 224 148 210', px: 148, py: 210 }} />
+      <Rotulo texto="raíz" nota="pivotante + raicillas" tx="12" ty="278"
+        guia={{ d: 'M40 276 C 80 278 112 274 149 268', px: 149, py: 268 }} />
+
+      <Rotulo anchor="end" texto="cereza madura" nota="roja, lista pa' coger" tx="280" ty="140"
+        guia={{ d: 'M232 140 C 222 142 216 146 210 152', px: 210, py: 152 }} />
+      <Rotulo anchor="end" texto="cereza verde" nota="todavía biche" tx="280" ty="182"
+        guia={{ d: 'M232 176 C 222 168 214 160 204 154', px: 204, py: 154 }} />
+
+      {/* -----------  DETALLE 1 . la flor  ----------- */}
+      <circle cx="348" cy="60" r="27" fill="#faf3e0" stroke="#c9b483" strokeWidth="1.2" />
+      <g transform="translate(348 60)">
+        {[0, 72, 144, 216, 288].map((a) => (
+          <ellipse key={a} cx="0" cy="-15" rx="6.5" ry="15" transform={`rotate(${a})`} fill="#fbf7ec" stroke="#d7c592" strokeWidth="0.8" />
+        ))}
+        <circle cx="0" cy="0" r="6" fill="#eaca57" />
+        {[30, 100, 170, 240, 310].map((a) => (
+          <circle key={a} cx={5 * Math.cos((a * Math.PI) / 180)} cy={5 * Math.sin((a * Math.PI) / 180)} r="1.1" fill="#b98d2f" />
+        ))}
+      </g>
+      <text x="348" y="100" textAnchor="middle" fontSize="11" fontWeight="700" fill="#4f3a20">flor</text>
+      <text x="348" y="110" textAnchor="middle" fontSize="8.5" fontStyle="italic" fill="#8a7350">blanca · 5 pétalos · huele dulce</text>
+
+      {/* -----------  DETALLE 2 . por dentro de la cereza  ----------- */}
+      <rect x="286" y="118" width="124" height="170" rx="8" fill="#efe3c6" stroke="#d5c193" strokeWidth="1" />
+      <text x="348" y="134" textAnchor="middle" fontSize="10" fontWeight="800" fill="#5a3f22" letterSpacing="0.04em">POR DENTRO DE LA CEREZA</text>
+
+      {/* corte de la cereza: pulpa -> pergamino -> grano */}
+      <g transform="translate(340 205)">
+        {/* pulpa (piel + mesocarpo) */}
+        <circle cx="0" cy="0" r="40" fill="#bb4130" stroke="#8f2f22" strokeWidth="1.4" />
+        <circle cx="0" cy="0" r="40" fill="none" stroke="#e08a79" strokeWidth="1" opacity="0.5" />
+        {/* baba / mucílago: aro traslúcido */}
+        <circle cx="0" cy="0" r="33" fill="#e7b48f" opacity="0.55" />
+        {/* pergamino que envuelve los dos granos */}
+        <circle cx="0" cy="0" r="30" fill="#eaddba" stroke="#cbb684" strokeWidth="1.1" />
+        {/* dos granos cara a cara (almendra) */}
+        <path d="M-2 -28 A 28 28 0 0 0 -2 28 Q -14 0 -2 -28 Z" fill="#cdb98a" stroke="#a08a5b" strokeWidth="1" />
+        <path d="M2 -28 A 28 28 0 0 1 2 28 Q 14 0 2 -28 Z" fill="#c8b482" stroke="#a08a5b" strokeWidth="1" />
+        {/* surco central de cada grano */}
+        <path d="M-2 -22 Q -12 0 -2 22" fill="none" stroke="#9c855a" strokeWidth="1" />
+        <path d="M2 -22 Q 12 0 2 22" fill="none" stroke="#9c855a" strokeWidth="1" />
+      </g>
+
+      {/* rótulos del corte */}
+      <g stroke="#9a8355" strokeWidth="0.8" fill="none">
+        <path d="M300 158 C 308 168 314 174 322 182" />
+        <path d="M398 200 C 384 202 376 204 370 205" />
+        <path d="M340 262 L340 240" />
+      </g>
+      <circle cx="322" cy="182" r="1.5" fill="#7a6540" />
+      <circle cx="370" cy="205" r="1.5" fill="#7a6540" />
+      <circle cx="340" cy="240" r="1.5" fill="#7a6540" />
+      <text x="298" y="156" textAnchor="end" fontSize="9.5" fontWeight="700" fill="#7a2c1e">pulpa</text>
+      <text x="298" y="166" textAnchor="end" fontSize="8" fontStyle="italic" fill="#8a7350">&#8594; abono</text>
+      <text x="400" y="203" fontSize="9.5" fontWeight="700" fill="#8a6a2f">pergamino</text>
+      <text x="400" y="213" fontSize="8" fontStyle="italic" fill="#8a7350">se seca así</text>
+      <text x="340" y="277" textAnchor="middle" fontSize="9.5" fontWeight="700" fill="#6a5424">grano · almendra</text>
+
+      {/* firma de pie */}
+      <text x="16" y="288" fontSize="8.5" fontStyle="italic" fill="#9a8355">
+        Cenicafé / FNC · arbusto de sombrío, 2-3 m
+      </text>
+    </svg>
+  );
+}

--- a/src/visual/laminas/LaminaMaiz.jsx
+++ b/src/visual/laminas/LaminaMaiz.jsx
@@ -1,0 +1,332 @@
+import React, { useId } from 'react';
+
+/**
+ * LaminaMaiz — lámina de "cuaderno de campo" del mundo de la milpa: la mata de
+ * maíz (Zea mays) dibujada a mano, tinta sepia y verde sobre papel crema, con
+ * cada parte rotulada en habla campesina.
+ *
+ * Misma familia que tuberculos/LaminaSiembra: SVG 100% propio e inline (sin
+ * imágenes rasterizadas ni dependencias), pensado para acompañar el relato del
+ * mundo. A diferencia de LaminaSiembra (decorativa, aria-hidden), esta lámina
+ * SÍ enseña: lleva role="img" con descripción y sus rótulos son parte del
+ * contenido, así que el papel es de color fijo (crema), como una foto de una
+ * página de cuaderno pegada en la pantalla — no reacciona al tema, igual que el
+ * DiagramaMilpa de esta misma pantalla usa colores propios.
+ *
+ * Partes rotuladas (botánica correcta, nombre popular):
+ *   · Penacho / espiga — la flor macho, arriba de todo.
+ *   · Caña (tallo) con sus nudos.
+ *   · Hoja: lámina + vaina (con venas paralelas, propias de las gramíneas).
+ *   · Mazorca — la flor hembra, con sus barbas (el cabello) y los granos en hilera.
+ *   · Raíz fasciculada (en cabellera) + raíces de sostén (de soporte).
+ *   · Detalle ampliado del grano: pericarpio, endospermo y germen.
+ *
+ * Los ids de <defs> (papel, clip de la mazorca) se generan con useId para que
+ * la lámina se pueda repetir varias veces en una misma página sin colisión.
+ *
+ * @param {Object} props
+ * @param {string} [props.className] clases extra sobre el <figure> raíz.
+ */
+
+/* Paleta de la lámina: tinta sepia + verde botánico sobre papel crema.
+   Colores fijos a propósito (es una ilustración, no cromo de UI). */
+const TINTA = '#5c4326'; // sepia principal (trazo y rótulos)
+const TINTA_2 = '#8a6b40'; // sepia claro (rótulos secundarios, guías)
+const VERDE = '#6f8a3c'; // verde hoja
+const VERDE_OSC = '#55702c'; // verde de contornos/venas
+const GRANO = '#d8a93f'; // oro del grano
+const GRANO_OSC = '#b0822a'; // contorno del grano
+const BARBA = '#c98a56'; // barbas / cabello de la mazorca
+const TIERRA = '#7a5a34'; // suelo
+
+/** Un rótulo del cuaderno: línea guía fina con punto en el objetivo + texto
+ *  serif en itálica (letra de mano). `anchor` alinea el texto al margen. */
+function Rotulo({ x, y, tx, ty, texto, sub = null, anchor = 'start' }) {
+  return (
+    <g>
+      <line x1={x} y1={y} x2={tx} y2={ty} stroke={TINTA_2} strokeWidth="0.9" strokeLinecap="round" />
+      <circle cx={tx} cy={ty} r="1.7" fill={TINTA} />
+      <text
+        x={x}
+        y={y}
+        textAnchor={anchor}
+        fontFamily="'Georgia', 'Times New Roman', serif"
+        fontStyle="italic"
+        fontSize="13"
+        fontWeight="600"
+        fill={TINTA}
+      >
+        {texto}
+      </text>
+      {sub && (
+        <text
+          x={x}
+          y={y + 13}
+          textAnchor={anchor}
+          fontFamily="'Georgia', 'Times New Roman', serif"
+          fontStyle="italic"
+          fontSize="10.5"
+          fill={TINTA_2}
+        >
+          {sub}
+        </text>
+      )}
+    </g>
+  );
+}
+
+export default function LaminaMaiz({ className } = {}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const papelId = `lm-papel-${uid}`;
+  const mazorcaId = `lm-mazorca-${uid}`;
+  return (
+    <figure
+      className={['lamina-maiz relative rounded-2xl overflow-hidden border border-amber-900/30 shadow-md shadow-black/30', className].filter(Boolean).join(' ')}
+      data-testid="lamina-maiz"
+    >
+      <svg
+        viewBox="0 0 420 748"
+        className="w-full h-auto select-none"
+        role="img"
+        aria-labelledby="lamina-maiz-titulo lamina-maiz-desc"
+      >
+        <title id="lamina-maiz-titulo">Lámina de cuaderno: la mata de maíz (Zea mays) y sus partes</title>
+        <desc id="lamina-maiz-desc">
+          Dibujo botánico a mano en tinta sepia y verde sobre papel crema. Muestra la
+          planta de maíz completa con el penacho o flor macho arriba, la caña con sus
+          nudos, las hojas con lámina y vaina, la mazorca con sus barbas y los granos en
+          hilera, y las raíces fasciculadas y de sostén. Abajo, un detalle ampliado del
+          grano con su pericarpio, endospermo y germen.
+        </desc>
+
+        {/* ── Papel crema del cuaderno ─────────────────────────────────── */}
+        <defs>
+          <linearGradient id={papelId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#f6eed6" />
+            <stop offset="1" stopColor="#efe4c6" />
+          </linearGradient>
+        </defs>
+        <rect x="0" y="0" width="420" height="748" fill={`url(#${papelId})`} />
+        {/* marco interior tenue + margen del cuaderno (línea a la izquierda) */}
+        <rect x="8" y="8" width="404" height="732" fill="none" stroke={TINTA_2} strokeWidth="0.7" opacity="0.4" rx="6" />
+        <line x1="34" y1="8" x2="34" y2="740" stroke="#b98a72" strokeWidth="0.8" opacity="0.35" />
+        {/* pecas del papel (grano hecho a mano, determinista) */}
+        <g fill={TINTA_2} opacity="0.10">
+          <circle cx="70" cy="120" r="1.1" /><circle cx="360" cy="90" r="1" />
+          <circle cx="300" cy="250" r="1.2" /><circle cx="95" cy="360" r="1" />
+          <circle cx="380" cy="430" r="1.1" /><circle cx="55" cy="520" r="1" />
+          <circle cx="330" cy="560" r="1.2" /><circle cx="150" cy="640" r="1" />
+        </g>
+
+        {/* ── Encabezado: nombre científico como en el herbario ────────── */}
+        <text x="46" y="30" fontFamily="'Georgia', serif" fontSize="11" fontStyle="italic" letterSpacing="1.5" fill={TINTA_2}>
+          CUADERNO DE CAMPO · LA MILPA
+        </text>
+        <text x="46" y="52" fontFamily="'Georgia', serif" fontSize="22" fontStyle="italic" fontWeight="700" fill={TINTA}>
+          Zea mays
+        </text>
+        <text x="150" y="52" fontFamily="'Georgia', serif" fontSize="12" fill={TINTA_2}>L. — el maíz</text>
+        <text x="46" y="68" fontFamily="'Georgia', serif" fontSize="11.5" fontStyle="italic" fill={TINTA_2}>
+          Familia Poaceae (las gramíneas)
+        </text>
+
+        {/* ════════════ LA MATA ════════════ (caña centrada en x≈196) ══ */}
+
+        {/* Suelo con rayado bajo la línea de tierra */}
+        <line x1="60" y1="470" x2="332" y2="470" stroke={TIERRA} strokeWidth="1.6" strokeLinecap="round" />
+        <g stroke={TIERRA} strokeWidth="0.8" strokeLinecap="round" opacity="0.55">
+          <line x1="80" y1="474" x2="72" y2="484" /><line x1="110" y1="474" x2="102" y2="484" />
+          <line x1="150" y1="474" x2="142" y2="484" /><line x1="240" y1="474" x2="232" y2="484" />
+          <line x1="285" y1="474" x2="277" y2="484" /><line x1="315" y1="474" x2="307" y2="484" />
+        </g>
+
+        {/* ── RAÍCES ──────────────────────────────────────────────────── */}
+        {/* Fasciculada: cabellera de raicillas finas bajo la base */}
+        <g stroke={TINTA} strokeWidth="1" fill="none" strokeLinecap="round" opacity="0.9">
+          <path d="M196 470 q -6 22 -22 40" /><path d="M196 470 q -3 26 -12 46" />
+          <path d="M196 470 q 0 28 -2 50" /><path d="M196 470 q 3 27 8 47" />
+          <path d="M196 470 q 6 24 20 42" /><path d="M196 470 q 9 20 26 34" />
+          <path d="M196 470 q -9 20 -30 32" />
+          {/* raicillas de segundo orden */}
+          <path d="M180 500 q -6 6 -8 14" /><path d="M186 508 q 2 6 -2 12" />
+          <path d="M204 506 q 6 5 8 13" /><path d="M212 496 q 8 4 12 10" />
+        </g>
+
+        {/* De sostén (soporte): arcos gruesos que salen del nudo bajo y se
+            clavan en el suelo, como zancos */}
+        <g stroke={TINTA} strokeWidth="2.6" fill="none" strokeLinecap="round">
+          <path d="M190 442 C 170 452, 158 462, 150 476" />
+          <path d="M202 442 C 224 452, 236 462, 246 476" />
+          <path d="M193 450 C 182 460, 176 468, 172 478" opacity="0.85" />
+        </g>
+
+        {/* ── CAÑA (tallo) con nudos ───────────────────────────────────── */}
+        <path
+          d="M196 470 C 194 400, 199 320, 197 230 C 196 175, 198 152, 196 136"
+          fill="none"
+          stroke={VERDE_OSC}
+          strokeWidth="6.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M196 470 C 194 400, 199 320, 197 230 C 196 175, 198 152, 196 136"
+          fill="none"
+          stroke={VERDE}
+          strokeWidth="3.6"
+          strokeLinecap="round"
+        />
+        {/* nudos: anillos del tallo */}
+        <g stroke={TINTA} strokeWidth="1.5" strokeLinecap="round">
+          {[440, 392, 336, 288, 232, 180, 154].map((yy, i) => (
+            <line key={i} x1={190} y1={yy} x2={203} y2={yy} />
+          ))}
+        </g>
+
+        {/* ── HOJAS (lámina + vaina, venas paralelas) ──────────────────── */}
+        {/* Hoja 1 · abajo-izquierda */}
+        <g>
+          <path d="M196 392 C 150 386, 108 396, 70 430 C 110 402, 156 398, 196 400 Z" fill={VERDE} opacity="0.28" stroke={VERDE_OSC} strokeWidth="1.3" strokeLinejoin="round" />
+          <path d="M194 396 C 156 396, 116 404, 78 428" fill="none" stroke={VERDE_OSC} strokeWidth="1" opacity="0.7" />
+          <g stroke={VERDE_OSC} strokeWidth="0.6" opacity="0.5" fill="none">
+            <path d="M190 392 C 156 390, 120 398, 84 424" /><path d="M190 400 C 156 402, 122 410, 88 432" />
+          </g>
+          {/* vaina que abraza la caña */}
+          <path d="M196 402 q -10 -6 -8 -18 q 6 8 12 8 Z" fill={VERDE} opacity="0.4" stroke={VERDE_OSC} strokeWidth="1" />
+        </g>
+        {/* Hoja 2 · media-derecha (larga, arqueada) */}
+        <g>
+          <path d="M198 336 C 250 326, 300 332, 344 300 C 300 342, 248 348, 198 344 Z" fill={VERDE} opacity="0.3" stroke={VERDE_OSC} strokeWidth="1.3" strokeLinejoin="round" />
+          <path d="M200 340 C 250 338, 298 340, 340 304" fill="none" stroke={VERDE_OSC} strokeWidth="1" opacity="0.7" />
+          <g stroke={VERDE_OSC} strokeWidth="0.6" opacity="0.5" fill="none">
+            <path d="M202 336 C 250 330, 300 334, 338 300" /><path d="M202 344 C 250 344, 296 346, 336 310" />
+          </g>
+          <path d="M197 342 q 10 -6 8 -18 q -6 8 -12 8 Z" fill={VERDE} opacity="0.4" stroke={VERDE_OSC} strokeWidth="1" />
+        </g>
+        {/* Hoja 3 · media-izquierda */}
+        <g>
+          <path d="M196 268 C 150 256, 104 258, 62 224 C 104 266, 152 272, 196 276 Z" fill={VERDE} opacity="0.3" stroke={VERDE_OSC} strokeWidth="1.3" strokeLinejoin="round" />
+          <path d="M194 272 C 150 268, 106 266, 66 228" fill="none" stroke={VERDE_OSC} strokeWidth="1" opacity="0.7" />
+          <g stroke={VERDE_OSC} strokeWidth="0.6" opacity="0.5" fill="none">
+            <path d="M192 268 C 150 260, 108 258, 70 226" /><path d="M192 276 C 150 274, 110 272, 72 240" />
+          </g>
+          <path d="M195 274 q -10 -6 -8 -18 q 6 8 12 8 Z" fill={VERDE} opacity="0.4" stroke={VERDE_OSC} strokeWidth="1" />
+        </g>
+        {/* Hoja 4 · alta-derecha */}
+        <g>
+          <path d="M198 200 C 244 186, 286 184, 322 150 C 286 194, 244 200, 198 206 Z" fill={VERDE} opacity="0.3" stroke={VERDE_OSC} strokeWidth="1.3" strokeLinejoin="round" />
+          <path d="M200 204 C 244 196, 284 192, 318 154" fill="none" stroke={VERDE_OSC} strokeWidth="1" opacity="0.7" />
+          <path d="M197 205 q 10 -6 8 -18 q -6 8 -12 8 Z" fill={VERDE} opacity="0.4" stroke={VERDE_OSC} strokeWidth="1" />
+        </g>
+
+        {/* ── MAZORCA (flor hembra) al nudo medio, con barbas y granos ──── */}
+        <g>
+          {/* barbas / cabello: hilos finos que brotan de la punta */}
+          <g stroke={BARBA} strokeWidth="1" fill="none" strokeLinecap="round" opacity="0.9">
+            <path d="M250 300 q 10 -18 4 -36" /><path d="M256 302 q 16 -16 16 -36" />
+            <path d="M244 300 q 2 -20 -6 -38" /><path d="M260 304 q 22 -12 30 -30" />
+            <path d="M248 300 q 8 -22 2 -42" /><path d="M254 300 q 14 -20 10 -40" />
+          </g>
+          {/* mazorca: envuelta en hojas (capacho) y punta con granos a la vista */}
+          <path d="M232 366 C 224 340, 232 312, 250 300 C 268 312, 276 340, 268 366 C 258 376, 242 376, 232 366 Z" fill={VERDE} opacity="0.5" stroke={VERDE_OSC} strokeWidth="1.4" strokeLinejoin="round" />
+          {/* hojas del capacho abiertas dejando ver el grano */}
+          <path d="M250 300 C 240 316, 240 344, 246 366" fill="none" stroke={VERDE_OSC} strokeWidth="0.9" opacity="0.7" />
+          <path d="M250 300 C 260 316, 260 344, 254 366" fill="none" stroke={VERDE_OSC} strokeWidth="0.9" opacity="0.7" />
+          {/* granos en hilera (rejilla oro) en la parte baja destapada */}
+          <clipPath id={mazorcaId}>
+            <path d="M236 344 C 236 356, 244 372, 250 372 C 256 372, 264 356, 264 344 Z" />
+          </clipPath>
+          <g clipPath={`url(#${mazorcaId})`}>
+            <rect x="234" y="342" width="32" height="34" fill={GRANO} opacity="0.9" />
+            <g stroke={GRANO_OSC} strokeWidth="0.8">
+              <line x1="242" y1="342" x2="242" y2="376" /><line x1="250" y1="342" x2="250" y2="376" /><line x1="258" y1="342" x2="258" y2="376" />
+              <line x1="234" y1="350" x2="266" y2="350" /><line x1="234" y1="358" x2="266" y2="358" /><line x1="234" y1="366" x2="266" y2="366" />
+            </g>
+          </g>
+          <path d="M236 344 C 236 356, 244 372, 250 372 C 256 372, 264 356, 264 344" fill="none" stroke={GRANO_OSC} strokeWidth="1.1" />
+          {/* pedúnculo que la une al nudo de la caña */}
+          <path d="M232 360 C 222 356, 210 350, 200 344" fill="none" stroke={VERDE_OSC} strokeWidth="2.4" strokeLinecap="round" />
+        </g>
+
+        {/* ── PENACHO / espiga (flor macho) en la punta ────────────────── */}
+        <g stroke={TINTA} fill="none" strokeLinecap="round">
+          {/* raquis central */}
+          <path d="M196 136 C 197 122, 195 110, 196 98" strokeWidth="2" />
+          {/* ramas de la espiga, colgando */}
+          <g strokeWidth="1.2" opacity="0.9">
+            <path d="M196 130 C 184 122, 176 114, 172 102" /><path d="M196 126 C 208 118, 216 110, 222 100" />
+            <path d="M196 118 C 186 110, 180 102, 178 92" /><path d="M196 116 C 206 108, 212 100, 216 90" />
+            <path d="M196 106 C 190 98, 187 92, 188 84" /><path d="M196 104 C 202 96, 206 90, 208 82" />
+            <path d="M196 98 C 194 90, 195 86, 196 80" />
+          </g>
+          {/* anteras: puntitos de polen colgando de las ramas */}
+          <g fill={GRANO} stroke="none">
+            <circle cx="172" cy="102" r="1.5" /><circle cx="222" cy="100" r="1.5" /><circle cx="178" cy="92" r="1.5" />
+            <circle cx="216" cy="90" r="1.5" /><circle cx="188" cy="84" r="1.5" /><circle cx="208" cy="82" r="1.5" /><circle cx="196" cy="80" r="1.5" />
+          </g>
+        </g>
+
+        {/* ════════════ RÓTULOS de la mata ════════════ */}
+        {/* Izquierda (texto al margen, guía hacia la planta) */}
+        <Rotulo x="46" y="150" tx="182" ty="110" texto="Penacho" sub="la flor macho (espiga)" anchor="start" />
+        <Rotulo x="46" y="238" tx="120" ty="264" texto="Hoja" sub="lámina + vaina" anchor="start" />
+        <Rotulo x="46" y="360" tx="196" ty="336" texto="Caña (tallo)" sub="con sus nudos" anchor="start" />
+        <Rotulo x="46" y="452" tx="168" ty="458" texto="Raíces de sostén" sub="(de soporte)" anchor="start" />
+
+        {/* Derecha (texto al margen derecho) */}
+        <Rotulo x="378" y="256" tx="286" ty="266" texto="Barbas / cabello" sub="la flor hembra" anchor="end" />
+        <Rotulo x="378" y="326" tx="270" ty="330" texto="Mazorca" anchor="end" />
+        <Rotulo x="378" y="392" tx="256" ty="360" texto="Granos" sub="en hilera" anchor="end" />
+
+        {/* Raíz fasciculada: rótulo abajo, centrado */}
+        <Rotulo x="120" y="560" tx="182" ty="512" texto="Raíz fasciculada" sub="(en cabellera)" anchor="start" />
+
+        {/* ════════════ DETALLE: EL GRANO POR DENTRO ════════════ */}
+        <line x1="34" y1="590" x2="412" y2="590" stroke={TINTA_2} strokeWidth="0.7" opacity="0.4" strokeDasharray="3 3" />
+        <text x="46" y="612" fontFamily="'Georgia', serif" fontSize="14" fontStyle="italic" fontWeight="700" fill={TINTA}>
+          El grano por dentro
+        </text>
+        <text x="215" y="612" fontFamily="'Georgia', serif" fontSize="11" fontStyle="italic" fill={TINTA_2}>(ampliado)</text>
+
+        {/* grano ampliado, corte a lo largo (forma de diente) */}
+        <g>
+          {/* contorno del grano */}
+          <path
+            d="M96 632 C 118 628, 138 640, 138 668 C 138 682, 122 690, 104 690 C 86 690, 74 680, 74 662 C 74 646, 82 636, 96 632 Z"
+            fill={GRANO}
+            opacity="0.35"
+            stroke={GRANO_OSC}
+            strokeWidth="1.6"
+            strokeLinejoin="round"
+          />
+          {/* pericarpio: banda exterior delgada */}
+          <path
+            d="M96 632 C 118 628, 138 640, 138 668 C 138 682, 122 690, 104 690 C 86 690, 74 680, 74 662 C 74 646, 82 636, 96 632 Z"
+            fill="none"
+            stroke={TINTA}
+            strokeWidth="2.4"
+            strokeLinejoin="round"
+            opacity="0.75"
+          />
+          {/* endospermo: gran cuerpo harinoso */}
+          <path d="M100 640 C 120 638, 130 650, 130 666 C 130 678, 116 684, 104 683 C 92 682, 84 672, 86 658 C 88 648, 92 642, 100 640 Z" fill={GRANO} opacity="0.55" stroke={GRANO_OSC} strokeWidth="0.8" />
+          {/* germen: el embrión, en forma de escudo hacia la base */}
+          <path d="M104 654 C 96 654, 90 662, 92 672 C 94 682, 104 684, 110 680 C 108 672, 108 662, 104 654 Z" fill="#e9d9a6" stroke={VERDE_OSC} strokeWidth="1" />
+          {/* eje raíz-tallito dentro del germen */}
+          <path d="M101 660 C 99 666, 100 672, 103 677" fill="none" stroke={VERDE_OSC} strokeWidth="1" strokeLinecap="round" />
+        </g>
+
+        {/* rótulos del grano */}
+        <Rotulo x="200" y="636" tx="136" ty="646" texto="Pericarpio" sub="(la cáscara)" anchor="start" />
+        <Rotulo x="200" y="672" tx="128" ty="662" texto="Endospermo" sub="(la harina)" anchor="start" />
+        <Rotulo x="200" y="696" tx="106" ty="672" texto="Germen" sub="(de aquí nace la mata)" anchor="start" />
+      </svg>
+
+      <figcaption className="lamina-maiz-pie flex items-center justify-between gap-2 bg-[#e7dab8] px-3 py-1.5 text-[11px] font-semibold text-[#5c4326]">
+        <span className="italic">Zea mays · lámina de cuaderno de campo</span>
+        <span className="rounded bg-[#d8c79a] px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-[#6b4e2e]">
+          Ilustración
+        </span>
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/visual/laminas/LaminaMataEtapa.jsx
+++ b/src/visual/laminas/LaminaMataEtapa.jsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import './laminas.css';
+
+/**
+ * LaminaMataEtapa — la lámina VIVA de una mata individual.
+ *
+ * Misma familia que `LaminaSiembra`/`LaminaAporque` (cuaderno de campo: corte de
+ * suelo, trazo redondo, formas simples, colores de tinta sobre papel) pero aquí
+ * el dibujo NO es fijo: cambia según la ETAPA real de la mata. Cada etapa se
+ * compone distinta —
+ *
+ *   semilla    la semilla enterrada, con su radícula asomando          (bajo tierra)
+ *   plántula   el tallito que rompe el suelo: dos cotiledones + 1 hoja  (recién nacida)
+ *   juvenil    la mata que crece: varias hojas, sin flor                (creciendo)
+ *   adulta     la mata hecha, con su tutor y raíz honda                 (robusta)
+ *   floración  la misma mata, ahora con racimos de flor amarilla        (florece)
+ *   cosecha    los racimos cargados de tomate maduro colgando           (da fruto)
+ *
+ * Es DECORATIVA (aria-hidden): la ficha de al lado narra el estado real. El
+ * dibujo respira con las etapas — la raíz se hace honda, el tallo sube, la copa
+ * se llena — para que se LEA la evolución sin leer una palabra. Sin dependencia
+ * de las variables --c-* del tema: es una hoja de papel pegada encima, legible
+ * al sol sobre los cuatro temas. rsvg-safe (sin <text>, sin emoji-en-SVG).
+ *
+ * El ancho/alto de la lámina y la animación de crecimiento al cambiar de etapa
+ * viven en `laminas.css` (clases `lam-mata-svg` / `lam-mata-brota`), y son
+ * reduced-motion-safe (sin animación → fotograma final digno).
+ *
+ * @param {Object} props
+ * @param {'semilla'|'plantula'|'juvenil'|'adulto'|'floracion'|'cosecha'} props.etapa
+ * @param {string} [props.className]
+ */
+
+// ── Paleta de tinta (fija, para leerse al sol; no hereda del tema) ──────────────
+const C = {
+  cielo: '#f4f6ea',
+  sol: '#e9c33f',
+  tierra: '#e7dabb',
+  tierraHonda: '#d9c79c',
+  surco: '#b98a2f',
+  raiz: '#a9843f',
+  raizHonda: '#8a6a2f',
+  tallo: '#3f8f4e',
+  talloHondo: '#2f6b3a',
+  hoja: '#4a9b57',
+  hojaTierna: '#7cba5a',
+  vena: '#2f6b3a',
+  cotiledon: '#9ccb6a',
+  flor: '#f2c53d',
+  florCentro: '#c9962c',
+  frutoMaduro: '#cc4b37',
+  frutoVerde: '#8aa54e',
+  caliz: '#3f8f4e',
+};
+
+// Una hoja ovada con nervadura (apunta hacia arriba desde su base en 0,0).
+function Hoja({ rot = 0, escala = 1, tono = C.hoja }) {
+  return (
+    <g transform={`rotate(${rot}) scale(${escala})`}>
+      <path
+        d="M0 0 C -11 -9 -10 -25 0 -33 C 10 -25 11 -9 0 0 Z"
+        fill={tono}
+        stroke={C.talloHondo}
+        strokeWidth="0.8"
+        strokeLinejoin="round"
+      />
+      <g stroke={C.vena} strokeWidth="0.9" strokeLinecap="round" fill="none" opacity="0.55">
+        <path d="M0 -2 L0 -30" />
+        <path d="M0 -12 L-6 -17" />
+        <path d="M0 -12 L6 -17" />
+        <path d="M0 -20 L-5 -25" />
+        <path d="M0 -20 L5 -25" />
+      </g>
+    </g>
+  );
+}
+
+// Flor de tomate: cinco pétalos en estrella + centro ocre.
+function Flor({ x = 0, y = 0, escala = 1 }) {
+  const petalos = [0, 72, 144, 216, 288];
+  return (
+    <g transform={`translate(${x} ${y}) scale(${escala})`}>
+      {petalos.map((a) => (
+        <ellipse key={a} cx="0" cy="-6" rx="2.6" ry="5.2" fill={C.flor} stroke={C.florCentro} strokeWidth="0.5" transform={`rotate(${a})`} />
+      ))}
+      <circle cx="0" cy="0" r="2.4" fill={C.florCentro} />
+    </g>
+  );
+}
+
+// Tomate: fruto con brillo y su cáliz de estrella verde arriba.
+function Tomate({ x = 0, y = 0, r = 7, maduro = true }) {
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <circle cx="0" cy="0" r={r} fill={maduro ? C.frutoMaduro : C.frutoVerde} stroke={C.raizHonda} strokeWidth="0.6" />
+      <ellipse cx={-r * 0.32} cy={-r * 0.34} rx={r * 0.34} ry={r * 0.22} fill="#ffffff" opacity="0.35" />
+      <g stroke={C.caliz} strokeWidth="1.4" strokeLinecap="round" fill="none">
+        <path d={`M0 ${-r} l-3 -3`} />
+        <path d={`M0 ${-r} l0 -4`} />
+        <path d={`M0 ${-r} l3 -3`} />
+      </g>
+    </g>
+  );
+}
+
+// Raíces: pivotante honda + laterales. `hondura` en px marca cuánto baja.
+function Raices({ hondura = 40 }) {
+  const lat = Math.min(1, hondura / 80);
+  return (
+    <g stroke={C.raiz} fill="none" strokeLinecap="round">
+      <path d={`M0 0 q 4 ${hondura * 0.4} -2 ${hondura}`} strokeWidth="2.4" stroke={C.raizHonda} />
+      <path d={`M0 6 q -${18 * lat} 8 -${24 * lat} ${28 * lat}`} strokeWidth="1.6" />
+      <path d={`M0 12 q ${18 * lat} 8 ${26 * lat} ${30 * lat}`} strokeWidth="1.6" />
+      <path d={`M-2 ${hondura * 0.45} q -${10 * lat} 6 -${14 * lat} ${18 * lat}`} strokeWidth="1.2" />
+      <path d={`M0 ${hondura * 0.6} q ${10 * lat} 6 ${13 * lat} ${16 * lat}`} strokeWidth="1.2" />
+    </g>
+  );
+}
+
+// El tutor (estaca) con sus amarres, para la mata ya hecha.
+function Tutor() {
+  return (
+    <g>
+      <line x1="24" y1="2" x2="24" y2="-112" stroke={C.surco} strokeWidth="4" strokeLinecap="round" />
+      <g stroke={C.raizHonda} strokeWidth="1.4" strokeLinecap="round">
+        <path d="M24 -30 q -12 -3 -22 -1" fill="none" />
+        <path d="M24 -66 q -14 -3 -24 -2" fill="none" />
+        <path d="M24 -96 q -12 -2 -20 -2" fill="none" />
+      </g>
+    </g>
+  );
+}
+
+// ── Cada etapa dibuja su propia mata (arte por etapa) ───────────────────────────
+function MataPorEtapa({ etapa }) {
+  switch (etapa) {
+    case 'semilla':
+      return (
+        <g>
+          <Raices hondura={30} />
+          {/* la semilla enterrada, inclinada */}
+          <g transform="rotate(-18)">
+            <ellipse cx="0" cy="16" rx="12" ry="8" fill={C.tierraHonda} stroke={C.raiz} strokeWidth="1.2" />
+            <path d="M-7 16 q 7 -4 14 0" fill="none" stroke={C.raizHonda} strokeWidth="0.9" />
+          </g>
+          {/* radícula que empieza a bajar */}
+          <path d="M0 22 q 3 12 -2 24" fill="none" stroke={C.raizHonda} strokeWidth="1.8" strokeLinecap="round" />
+          {/* el ganchito del brote que va a asomar */}
+          <path d="M0 8 q -2 -8 2 -13" fill="none" stroke={C.hojaTierna} strokeWidth="2.4" strokeLinecap="round" />
+        </g>
+      );
+    case 'plantula':
+      return (
+        <g>
+          <Raices hondura={40} />
+          {/* tallito */}
+          <path d="M0 0 q -2 -22 0 -46" fill="none" stroke={C.tallo} strokeWidth="3" strokeLinecap="round" />
+          {/* dos cotiledones opuestos */}
+          <ellipse cx="-11" cy="-44" rx="10" ry="4.6" fill={C.cotiledon} stroke={C.talloHondo} strokeWidth="0.7" transform="rotate(-18 -11 -44)" />
+          <ellipse cx="11" cy="-44" rx="10" ry="4.6" fill={C.cotiledon} stroke={C.talloHondo} strokeWidth="0.7" transform="rotate(18 11 -44)" />
+          {/* la primera hoja verdadera, tiernita */}
+          <g transform="translate(0 -48)"><Hoja rot={0} escala={0.7} tono={C.hojaTierna} /></g>
+        </g>
+      );
+    case 'juvenil':
+      return (
+        <g>
+          <Raices hondura={58} />
+          <path d="M0 0 q -3 -40 1 -82" fill="none" stroke={C.tallo} strokeWidth="4" strokeLinecap="round" />
+          {/* hojas alternas subiendo */}
+          <g transform="translate(-2 -22)"><Hoja rot={-58} escala={0.9} /></g>
+          <g transform="translate(1 -40)"><Hoja rot={62} escala={0.95} /></g>
+          <g transform="translate(-1 -58)"><Hoja rot={-52} escala={0.9} /></g>
+          <g transform="translate(1 -72)"><Hoja rot={54} escala={0.85} /></g>
+          <g transform="translate(0 -82)"><Hoja rot={0} escala={0.8} /></g>
+        </g>
+      );
+    case 'adulto':
+      return (
+        <g>
+          <Raices hondura={78} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -24)"><Hoja rot={-62} escala={1.1} /></g>
+          <g transform="translate(2 -40)"><Hoja rot={64} escala={1.15} /></g>
+          <g transform="translate(-2 -58)"><Hoja rot={-58} escala={1.1} /></g>
+          <g transform="translate(3 -74)"><Hoja rot={60} escala={1.05} /></g>
+          <g transform="translate(-2 -90)"><Hoja rot={-54} escala={1} /></g>
+          <g transform="translate(2 -102)"><Hoja rot={40} escala={0.9} /></g>
+          <g transform="translate(0 -108)"><Hoja rot={0} escala={0.85} /></g>
+        </g>
+      );
+    case 'floracion':
+      return (
+        <g>
+          <Raices hondura={80} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -26)"><Hoja rot={-62} escala={1.1} /></g>
+          <g transform="translate(2 -44)"><Hoja rot={64} escala={1.1} /></g>
+          <g transform="translate(-2 -64)"><Hoja rot={-58} escala={1.05} /></g>
+          <g transform="translate(3 -82)"><Hoja rot={58} escala={1} /></g>
+          <g transform="translate(0 -100)"><Hoja rot={0} escala={0.85} /></g>
+          {/* racimos de flor amarilla colgando de los nudos */}
+          <path d="M-6 -38 q -10 4 -14 12" fill="none" stroke={C.talloHondo} strokeWidth="1.4" />
+          <Flor x={-16} y={-26} escala={0.85} />
+          <Flor x={-24} y={-22} escala={0.75} />
+          <path d="M8 -70 q 12 3 16 12" fill="none" stroke={C.talloHondo} strokeWidth="1.4" />
+          <Flor x={20} y={-56} escala={0.9} />
+          <Flor x={27} y={-50} escala={0.75} />
+          <Flor x={14} y={-52} escala={0.7} />
+        </g>
+      );
+    case 'cosecha':
+      return (
+        <g>
+          <Raices hondura={82} />
+          <Tutor />
+          <path d="M0 0 q -4 -54 2 -108" fill="none" stroke={C.talloHondo} strokeWidth="5" strokeLinecap="round" />
+          <g transform="translate(-3 -26)"><Hoja rot={-62} escala={1.05} /></g>
+          <g transform="translate(2 -46)"><Hoja rot={64} escala={1.05} /></g>
+          <g transform="translate(-2 -66)"><Hoja rot={-58} escala={1} /></g>
+          <g transform="translate(3 -84)"><Hoja rot={58} escala={0.95} /></g>
+          <g transform="translate(0 -100)"><Hoja rot={0} escala={0.8} /></g>
+          {/* racimo cargado a la izquierda: maduros + uno verde */}
+          <path d="M-6 -40 q -12 6 -16 16" fill="none" stroke={C.talloHondo} strokeWidth="1.6" />
+          <Tomate x={-22} y={-22} r={7} maduro />
+          <Tomate x={-12} y={-16} r={6.5} maduro />
+          <Tomate x={-26} y={-33} r={5.5} maduro={false} />
+          {/* racimo a la derecha */}
+          <path d="M8 -72 q 14 6 18 16" fill="none" stroke={C.talloHondo} strokeWidth="1.6" />
+          <Tomate x={26} y={-52} r={7} maduro />
+          <Tomate x={16} y={-46} r={6} maduro />
+          <Tomate x={30} y={-63} r={5.5} maduro={false} />
+        </g>
+      );
+    default:
+      return null;
+  }
+}
+
+export default function LaminaMataEtapa({ etapa = 'semilla', className = '' }) {
+  return (
+    <svg
+      viewBox="0 0 320 300"
+      role="img"
+      aria-hidden="true"
+      className={['lam-mata-svg', className].filter(Boolean).join(' ')}
+      data-testid="lamina-mata-etapa"
+      data-etapa={etapa}
+    >
+      {/* cielo tenue */}
+      <rect x="0" y="0" width="320" height="198" fill={C.cielo} />
+      {/* sol de cuaderno, arriba a la derecha */}
+      <g opacity="0.7">
+        <circle cx="272" cy="40" r="15" fill={C.sol} />
+        <g stroke={C.sol} strokeWidth="2.2" strokeLinecap="round">
+          <line x1="272" y1="14" x2="272" y2="6" />
+          <line x1="296" y1="40" x2="304" y2="40" />
+          <line x1="290" y1="22" x2="296" y2="16" />
+          <line x1="290" y1="58" x2="296" y2="64" />
+        </g>
+      </g>
+
+      {/* corte de suelo: superficie ondulada + cuerpo de tierra */}
+      <path d="M0 198 Q 80 192 160 197 T 320 195 L320 300 L0 300 Z" fill={C.tierra} />
+      <path d="M0 198 Q 80 192 160 197 T 320 195" fill="none" stroke={C.surco} strokeWidth="2.2" strokeLinecap="round" opacity="0.6" />
+      {/* motas de tierra (rsvg-safe, sin filtros) */}
+      <g fill={C.surco} opacity="0.32">
+        <circle cx="46" cy="232" r="2.1" />
+        <circle cx="92" cy="262" r="1.6" />
+        <circle cx="128" cy="240" r="1.9" />
+        <circle cx="214" cy="230" r="2" />
+        <circle cx="250" cy="264" r="1.7" />
+        <circle cx="286" cy="238" r="2.1" />
+        <circle cx="70" cy="284" r="1.5" />
+        <circle cx="190" cy="278" r="1.8" />
+      </g>
+
+      {/* la mata, re-montada por etapa para que reanime su crecimiento */}
+      <g key={etapa} transform="translate(160 197)" className="lam-mata-brota">
+        <MataPorEtapa etapa={etapa} />
+      </g>
+    </svg>
+  );
+}

--- a/src/visual/laminas/LaminaSiembra.jsx
+++ b/src/visual/laminas/LaminaSiembra.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+/**
+ * LaminaSiembra — la ilustración insignia del mundo "Tubérculos y raíces".
+ *
+ * SVG propio (nada de stock), de cuaderno de campo: las TRES formas de sembrar
+ * un tubérculo o raíz, de izquierda a derecha —
+ *
+ *   TUBÉRCULO-SEMILLA  una papa brotada enterrada en el surco   (papa, oca…)
+ *   ESQUEJE / ESTACA   un trozo de tallo (cangre) inclinado     (yuca, batata)
+ *   COLINO (HIJUELO)   el hijuelo del cuello de la mata madre   (arracacha)
+ *
+ * Es DECORATIVA (aria-hidden): acompaña al explicador "casi ninguno se siembra
+ * de semilla" del hub; las tarjetas de al lado son la navegación real. La forma
+ * que se quiera resaltar sube su opacidad y baja la de las otras (prop `activo`),
+ * igual que CaminoDelAgua en el mundo Agua; sin `activo` se ven las tres parejas.
+ *
+ * Trazo: línea redondeada, formas simples, colores en clases Tailwind sobre
+ * currentColor por grupo para respirar con los temas.
+ *
+ * @param {Object} props
+ * @param {'tuberculo'|'esqueje'|'colino'|null} [props.activo] forma resaltada.
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+export default function LaminaSiembra({ activo = null, className }) {
+  const dim = (id) => (activo && activo !== id ? 'opacity-40' : 'opacity-100');
+  return (
+    <svg
+      viewBox="0 0 360 120"
+      role="img"
+      aria-hidden="true"
+      className={['w-full h-auto select-none', className].filter(Boolean).join(' ')}
+      data-testid="lamina-siembra"
+    >
+      {/* línea de tierra que une las tres formas */}
+      <path
+        d="M6 84 Q 90 79 180 84 T 354 82"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        className="text-amber-700/60"
+      />
+
+      {/* ── FORMA 1 · tubérculo-semilla: papa brotada en el surco ── */}
+      <g className={`transition-opacity duration-300 ${dim('tuberculo')}`}>
+        {/* montículo de tierra */}
+        <path d="M18 84 q 30 -20 60 0 z" fill="currentColor" className="text-amber-900/40" />
+        {/* la papa-semilla enterrada */}
+        <ellipse cx="48" cy="80" rx="15" ry="10" fill="currentColor" className="text-amber-300/80" />
+        {/* ojos de la papa */}
+        <g className="text-amber-800/70">
+          <circle cx="42" cy="78" r="1.4" fill="currentColor" />
+          <circle cx="52" cy="82" r="1.4" fill="currentColor" />
+          <circle cx="55" cy="76" r="1.4" fill="currentColor" />
+        </g>
+        {/* brotes que salen a la superficie */}
+        <g stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" fill="none" className="text-lime-400">
+          <path d="M45 71 q -3 -14 -8 -22" />
+          <path d="M40 55 q -7 -2 -10 -8" />
+          <path d="M51 71 q 3 -12 9 -18" />
+          <path d="M58 57 q 7 -2 10 -7" />
+        </g>
+      </g>
+
+      {/* ── FORMA 2 · esqueje / estaca: cangre de yuca inclinado ── */}
+      <g className={`transition-opacity duration-300 ${dim('esqueje')}`}>
+        {/* montículo */}
+        <path d="M150 84 q 30 -18 60 0 z" fill="currentColor" className="text-amber-900/40" />
+        {/* la estaca (trozo de tallo) enterrada 2/3, inclinada */}
+        <line x1="168" y1="92" x2="196" y2="44" stroke="currentColor" strokeWidth="6" strokeLinecap="round" className="text-amber-700/80" />
+        {/* nudos / yemas del cangre */}
+        <g className="text-lime-300">
+          <circle cx="176" cy="78" r="2.2" fill="currentColor" />
+          <circle cx="184" cy="64" r="2.2" fill="currentColor" />
+          <circle cx="192" cy="50" r="2.2" fill="currentColor" />
+        </g>
+        {/* brote de la yema de arriba */}
+        <path d="M192 50 q 8 -3 12 -11" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" className="text-lime-400" />
+        {/* raicillas que salen de la parte enterrada */}
+        <g stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" fill="none" className="text-amber-200/70">
+          <path d="M170 86 q -6 5 -8 12" />
+          <path d="M174 88 q 2 7 -1 13" />
+          <path d="M178 88 q 7 5 8 12" />
+        </g>
+      </g>
+
+      {/* ── FORMA 3 · colino: hijuelo del cuello de la mata madre ── */}
+      <g className={`transition-opacity duration-300 ${dim('colino')}`}>
+        {/* montículo */}
+        <path d="M282 84 q 30 -18 60 0 z" fill="currentColor" className="text-amber-900/40" />
+        {/* la cepa / cuello de la arracacha (media enterrada) */}
+        <path d="M300 84 q 12 -16 24 0 z" fill="currentColor" className="text-amber-400/70" />
+        {/* el colino (hijuelo) que se separa, inclinado con su yema arriba */}
+        <line x1="312" y1="72" x2="322" y2="46" stroke="currentColor" strokeWidth="5" strokeLinecap="round" className="text-lime-600/80" />
+        <circle cx="322" cy="45" r="2.6" fill="currentColor" className="text-lime-300" />
+        {/* hojas de la mata madre saliendo del cuello */}
+        <g stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" fill="none" className="text-emerald-400">
+          <path d="M308 70 q -6 -14 -12 -20" />
+          <path d="M312 68 q 0 -16 -2 -24" />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/visual/laminas/README.md
+++ b/src/visual/laminas/README.md
@@ -1,0 +1,86 @@
+# `src/visual/laminas` — láminas de cuaderno de campo reutilizables
+
+Librería de **láminas de cuaderno de campo** como componentes SVG limpios,
+parametrizables y sin dependencias nuevas. Nace para **dejar de redibujar la
+misma lámina** en cada mundo/pantalla: la siembra y el aporque de los
+tubérculos, la mata de maíz, el cafeto y la mata "viva" por etapa vivían
+dibujadas por separado en `components/tuberculos`, `components/milpa`,
+`components/cafe` y `components/mockups`, con calidad dispar. Aquí vive la
+**versión canónica** de cada una.
+
+Es la hermana de [`src/visual/creatures`](../creatures/README.md): allí viven
+los **personajes** (íconos cuadrados de fauna); aquí las **láminas** (hojas de
+papel enteras, con su viewBox y su relación de aspecto). Por eso **no comparten
+la misma firma de props**: una lámina no tiene `size`/`inline` — se dibuja a
+`width:100%` y expone `className` + su propia prop de dominio.
+
+## Regla de la casa
+
+> **Antes de dibujar una lámina de cuaderno, búscala aquí.**
+> Si existe → **reúsala** (y si podés, **mejorá** la versión canónica en su
+> archivo, para que todos hereden la mejora).
+> Si dibujás una lámina nueva reutilizable → **agregala aquí en el mismo PR**
+> (componente + entrada en `index.js` + fila en esta tabla).
+
+## Láminas
+
+| Componente | Nombre común | Especie / mundo | Accesibilidad | Prop propia |
+|---|---|---|---|---|
+| `LaminaSiembra` | Formas de siembra | Tubérculos y raíces | decorativa (`aria-hidden`) | `activo` |
+| `LaminaAporque` | El aporque (en corte) | Tubérculos y raíces | decorativa (`aria-hidden`) | — |
+| `LaminaMaiz` | La mata de maíz | *Zea mays* | enseña (`role=img` + rótulos) | — |
+| `LaminaCafeto` | El cafeto | *Coffea arabica* | enseña (`role=img` + rótulos) | — |
+| `LaminaMataEtapa` | La mata por etapa (viva) | *Solanum lycopersicum* | decorativa (`aria-hidden`) | `etapa` |
+
+## Props
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `className` | `string` | — | Clase(s) extra sobre el nodo raíz. Se **añaden** a las clases base de la lámina (`w-full h-auto select-none` en las SVG, o `lam-mata-svg`), nunca las reemplazan. |
+| `activo` | `'tuberculo' \| 'esqueje' \| 'colino' \| null` | `null` | **Solo `LaminaSiembra`.** Resalta una de las tres formas y atenúa las otras. Sin valor, se ven las tres. |
+| `etapa` | `'semilla' \| 'plantula' \| 'juvenil' \| 'adulto' \| 'floracion' \| 'cosecha'` | `'semilla'` | **Solo `LaminaMataEtapa`.** Cambia el dibujo según la etapa real de la mata y reanima el crecimiento. |
+
+## Uso
+
+```jsx
+import { LaminaSiembra, LaminaMaiz } from '@/visual/laminas';
+
+// Decorativa, con una forma resaltada:
+<LaminaSiembra activo="esqueje" />
+
+// Lámina que enseña (trae sus propios rótulos):
+<LaminaMaiz className="max-w-md mx-auto" />
+
+// Lámina viva de una mata concreta:
+<LaminaMataEtapa etapa="floracion" />
+```
+
+Consumidor de referencia: **`src/components/TuberculosScreen.jsx`** (importa
+`LaminaSiembra` y `LaminaAporque` desde aquí).
+
+## Técnica
+
+- SVG puro, **cero dependencias nuevas**. Colores de tinta **fijos** en las
+  láminas que "enseñan" (maíz, cafeto): son un pliego de papel prendido a la
+  pantalla, legible al sol en los cuatro temas. Las decorativas de tubérculos
+  usan `currentColor` + clases Tailwind para respirar con el tema.
+- `LaminaMaiz` genera los ids de sus `<defs>` (papel, clip de la mazorca) con
+  **`useId`**, así se puede repetir varias veces en una misma página sin
+  colisión de ids.
+- La única animación (el crecimiento de `LaminaMataEtapa` al cambiar de etapa)
+  vive en `laminas.css` (`lam-mata-brota`) y es **reduced-motion-safe**.
+- Todas son **rsvg-safe** salvo por el `<text>` de rótulos (sin emoji-en-SVG,
+  sin filtros exóticos), aptas para captura de pantalla del harness visual.
+
+## Candidatos evaluados y **aún no** promovidos
+
+- **`EstiercolIlustraciones`** (rama `feat/mundo-estiercol-compost`, sin mergear
+  a `main`) es un módulo **mixto**, no una lámina limpia:
+  - `BiodigestorIlustracion` **sí** es una lámina de corte (parametrizable con
+    `llenado`) — es la candidata a promover **cuando su mundo llegue a `main`**,
+    trayéndose además sus animaciones `estiercol-*` a `laminas.css`.
+  - `CicloCorralAbono` usa **emoji-en-SVG** (🐖 🛢️ 💧 🌱), que **no es
+    rsvg-safe** ni cumple la regla de la casa → no entra tal cual.
+  - `AbonoGlifo` es un **glifo** de 44×44, no una lámina (más cerca de un ícono).
+  Se dejó fuera de este PR a propósito para no arrastrar un módulo a medio
+  mergear ni romper la garantía de arte byte-idéntico.

--- a/src/visual/laminas/index.js
+++ b/src/visual/laminas/index.js
@@ -1,0 +1,63 @@
+/*
+ * Librería visual de LÁMINAS DE CUADERNO DE CAMPO de la chagra.
+ * Fuente única y reutilizable. Antes de dibujar una lámina, búscala aquí.
+ *
+ * Una "lámina" es una hoja de papel entera (SVG propio, sin stock ni deps): la
+ * mata o la labor dibujada a mano, con su viewBox y su relación de aspecto —
+ * NO un ícono cuadrado (para eso está `src/visual/creatures`). Por eso NO
+ * comparten la firma size/inline de las criaturas: cada lámina se dibuja a
+ * `width:100%` y expone `className` + su propia prop de dominio.
+ *
+ * Props comunes:
+ *   - `className` (string): clases extra sobre el nodo raíz.
+ * Props propias por lámina:
+ *   - LaminaSiembra   → `activo`: 'tuberculo' | 'esqueje' | 'colino' | null
+ *   - LaminaMataEtapa → `etapa` : 'semilla' | 'plantula' | 'juvenil' | 'adulto'
+ *                                 | 'floracion' | 'cosecha'
+ */
+export { default as LaminaSiembra } from './LaminaSiembra.jsx';
+export { default as LaminaAporque } from './LaminaAporque.jsx';
+export { default as LaminaMaiz } from './LaminaMaiz.jsx';
+export { default as LaminaCafeto } from './LaminaCafeto.jsx';
+export { default as LaminaMataEtapa } from './LaminaMataEtapa.jsx';
+
+import LaminaSiembra from './LaminaSiembra.jsx';
+import LaminaAporque from './LaminaAporque.jsx';
+import LaminaMaiz from './LaminaMaiz.jsx';
+import LaminaCafeto from './LaminaCafeto.jsx';
+import LaminaMataEtapa from './LaminaMataEtapa.jsx';
+
+/* Registro consultable: slug → componente + nombre común + especie/mundo.
+   (accesible: aria-hidden = decorativa; role=img = enseña con rótulos). */
+export const LAMINAS = {
+  siembra: {
+    Component: LaminaSiembra,
+    nombre: 'Formas de siembra',
+    especie: 'Tubérculos y raíces (varias)',
+    accesible: 'decorativa',
+  },
+  aporque: {
+    Component: LaminaAporque,
+    nombre: 'El aporque (en corte)',
+    especie: 'Tubérculos y raíces (varias)',
+    accesible: 'decorativa',
+  },
+  maiz: {
+    Component: LaminaMaiz,
+    nombre: 'La mata de maíz',
+    especie: 'Zea mays',
+    accesible: 'enseña',
+  },
+  cafeto: {
+    Component: LaminaCafeto,
+    nombre: 'El cafeto',
+    especie: 'Coffea arabica',
+    accesible: 'enseña',
+  },
+  'mata-etapa': {
+    Component: LaminaMataEtapa,
+    nombre: 'La mata por etapa (viva)',
+    especie: 'Solanum lycopersicum',
+    accesible: 'decorativa',
+  },
+};

--- a/src/visual/laminas/laminas.css
+++ b/src/visual/laminas/laminas.css
@@ -1,0 +1,33 @@
+/*
+ * Estilos compartidos de la librería de LÁMINAS de cuaderno.
+ * Solo cubre lo que una lámina necesita como hoja de papel autónoma:
+ * el dimensionado responsivo y las (pocas) animaciones intrínsecas, todas
+ * reduced-motion-safe (sin animación → fotograma final digno). Trasplantado
+ * de `mockups/hoja-vida-mata.css` (clases `hvm-lamina-*`) al namespace propio
+ * `lam-*` para que la lámina no dependa de la CSS de ningún consumidor.
+ */
+
+/* LaminaMataEtapa — la hoja de papel: ancho completo, alto por aspecto. */
+.lam-mata-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 340px;
+  margin: 0 auto;
+  user-select: none;
+}
+
+/* LaminaMataEtapa — el crecimiento al cambiar de etapa (la mata "brota"). */
+.lam-mata-brota {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: lam-brota 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes lam-brota {
+  from { opacity: 0; transform: scaleY(0.82) translateY(4px); }
+  to   { opacity: 1; transform: scaleY(1) translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lam-mata-brota { animation: none; }
+}

--- a/src/visual/scenes/CieloParametrico.jsx
+++ b/src/visual/scenes/CieloParametrico.jsx
@@ -1,0 +1,212 @@
+/*
+ * CapaCielo — la CAPA DE CIELO PARAMÉTRICA, compartida por las escenas de finca.
+ * Extraída fiel del subcomponente `Sky` de FincaVivaHero (la "capa de cielo
+ * compartida por las 3 escenas"): sol que respira de día (bajo y ámbar al
+ * amanecer/atardecer), luna con halo + estrellas + estrella fugaz de noche,
+ * nubes/niebla/lluvia según el clima real. rsvg-safe (sin filtros: halos por
+ * círculos concéntricos, lluvia por trazos), cero JS por frame.
+ *
+ * El cielo NO lee atributos del DOM: recibe un objeto `cielo` con la atmósfera
+ * ya resuelta (`{ luz, condicion, tema }`, misma forma que produce
+ * atmosphereService + useTheme). El shell del hero sigue publicando
+ * `data-luz`/`data-clima` para su gradiente CSS; esta capa es el arte SVG.
+ *
+ * Se monta como hijos de un `<svg>` que la escena ya define (con su viewBox):
+ * emite su `<defs>` (gradientes del sol, ids únicos por instancia) + el grupo
+ * del cielo. Importá `./scenes.css` una vez donde la uses.
+ */
+import { useId } from 'react';
+import { esNoche, esCubierto, tonoLuz } from './_cielo.js';
+import './scenes.css';
+
+/**
+ * Gradientes del sol — el dorado de mediodía, el ámbar del sol bajo (amanecer/
+ * atardecer) y la veladura cálida. Ids parametrizables para repetir sin colisión.
+ */
+export function CieloDefs({ solId, solWarmId, washId }) {
+  return (
+    <>
+      <radialGradient id={solId} cx="50%" cy="45%" r="60%">
+        <stop offset="0" stopColor="#fff3c4" />
+        <stop offset="70%" stopColor="#ffe08a" />
+        <stop offset="100%" stopColor="#ffd24d" />
+      </radialGradient>
+      <radialGradient id={solWarmId} cx="50%" cy="45%" r="60%">
+        <stop offset="0" stopColor="#fff0c0" />
+        <stop offset="60%" stopColor="#ffc266" />
+        <stop offset="100%" stopColor="#ff9a4d" />
+      </radialGradient>
+      {/* veladura cálida del sol bajo — baña la escena al amanecer/atardecer */}
+      <linearGradient id={washId} x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stopColor="#ff9a4d" stopOpacity="0.30" />
+        <stop offset="55%" stopColor="#ffb35c" stopOpacity="0.10" />
+        <stop offset="100%" stopColor="#ffb35c" stopOpacity="0" />
+      </linearGradient>
+    </>
+  );
+}
+
+/**
+ * Sky — el grupo del cielo (astro + clima). Recibe la geometría del astro
+ * (cx, cy, r) para encajar en cada escena, y los ids de los gradientes del sol
+ * (los emite `CieloDefs`).
+ */
+export function Sky({ cielo, cx, cy, r, lluviaY = 150, solId, solWarmId }) {
+  const noche = esNoche(cielo);
+  const cubierto = esCubierto(cielo);
+  const lluvia = cielo?.condicion === 'lluvia';
+  const niebla = cielo?.condicion === 'niebla';
+  const tono = tonoLuz(cielo);
+  const solBajo = tono === 'amanecer' || tono === 'atardecer';
+  // Al amanecer/atardecer el sol cuelga más bajo y se enciende en ámbar.
+  const cyEf = solBajo ? cy + r * 1.5 : cy;
+  const gradSol = solBajo ? `url(#${solWarmId})` : `url(#${solId})`;
+  const halo = solBajo ? '#ffb35c' : '#ffe08a';
+  return (
+    <g aria-hidden="true">
+      {noche ? (
+        <g className="scn-sky-noche">
+          {/* estrellas — constelación generosa, con titileo escalonado */}
+          <g fill="#fdf6d8" className="scn-estrellas">
+            <circle cx={cx - 120} cy={cy - 14} r="1.4" />
+            <circle cx={cx - 88} cy={cy + 22} r="1" />
+            <circle cx={cx - 150} cy={cy + 36} r="1.2" />
+            <circle cx={cx - 40} cy={cy - 26} r="1" />
+            <circle cx={cx + 18} cy={cy + 30} r="1.3" />
+            <circle cx={cx - 196} cy={cy + 6} r="1" />
+            <circle cx={cx + 30} cy={cy - 10} r="0.9" />
+            <circle cx={cx - 244} cy={cy - 22} r="1.1" />
+            <circle cx={cx - 270} cy={cy + 30} r="0.9" />
+            <circle cx={cx - 172} cy={cy - 30} r="0.8" />
+            <circle cx={cx - 64} cy={cy + 44} r="1" />
+            <circle cx={cx - 220} cy={cy + 52} r="1.2" />
+          </g>
+          {/* estrella fugaz ocasional (trazo que cruza y se apaga) */}
+          <line
+            className="scn-fugaz"
+            x1={cx - 210} y1={cy - 28} x2={cx - 174} y2={cy - 12}
+            stroke="#fdf6d8" strokeWidth="1.4" strokeLinecap="round"
+          />
+          {/* luna creciente con halo doble */}
+          <g transform={`translate(${cx} ${cy})`}>
+            <circle r={r * 1.5} fill="#e8edf7" opacity="0.1" />
+            <circle r={r * 0.92} fill="#e8edf7" opacity="0.25" />
+            <circle r={r * 0.7} fill="#f4f1e0" />
+            <circle cx={r * 0.32} cy={-r * 0.12} r={r * 0.6} fill="#1d2b4a" />
+            <circle cx={-r * 0.18} cy={r * 0.14} r={r * 0.07} fill="#dcd6bc" opacity="0.6" />
+            <circle cx={-r * 0.3} cy={-r * 0.18} r={r * 0.05} fill="#dcd6bc" opacity="0.5" />
+          </g>
+        </g>
+      ) : (
+        <g transform={`translate(${cx} ${cyEf})`}>
+          {/* halo exterior suave (respira) + anillo de calor con el sol bajo */}
+          <circle r={r * 1.4} fill={halo} opacity={cubierto ? 0.18 : (solBajo ? 0.42 : 0.35)}>
+            <animate attributeName="r" values={`${r * 1.4};${r * 1.6};${r * 1.4}`} dur="6s" repeatCount="indefinite" />
+          </circle>
+          {solBajo && !cubierto && (
+            <circle r={r * 2.1} fill="none" stroke={halo} strokeWidth="1.5" opacity="0.3" />
+          )}
+          <circle r={r} fill={gradSol} opacity={cubierto ? 0.7 : 1} />
+        </g>
+      )}
+
+      {/* NUBES densas cuando está cubierto — dos masas con brillo superior */}
+      {cubierto && (
+        <g fill={noche ? '#9aa6bb' : '#f3f6f4'} opacity={noche ? 0.7 : 0.92}>
+          <g className="scn-nube-a">
+            <ellipse cx={cx - 30} cy={cy + 4} rx="30" ry="14" />
+            <ellipse cx={cx - 4} cy={cy} rx="22" ry="14" />
+            <ellipse cx={cx - 52} cy={cy} rx="18" ry="12" />
+            <ellipse cx={cx - 30} cy={cy - 8} rx="16" ry="10" opacity=".9" />
+          </g>
+          <g className="scn-nube-b" opacity=".8">
+            <ellipse cx={cx - 168} cy={cy + 26} rx="24" ry="11" />
+            <ellipse cx={cx - 146} cy={cy + 22} rx="16" ry="10" />
+            <ellipse cx={cx - 188} cy={cy + 23} rx="13" ry="9" />
+          </g>
+        </g>
+      )}
+
+      {/* NIEBLA — bancos horizontales que derivan despacio (rsvg-safe). Tres
+          alturas: horizonte, media ladera y un velo bajo sobre la escena. */}
+      {niebla && (
+        <g fill={noche ? '#8b9bb3' : '#ffffff'}>
+          <ellipse className="scn-neblina-a" cx={cx - 120} cy={lluviaY + 2} rx="190" ry="22" opacity={noche ? 0.4 : 0.62} />
+          <ellipse className="scn-neblina-b" cx={cx - 30} cy={lluviaY + 30} rx="220" ry="18" opacity={noche ? 0.3 : 0.5} />
+          <ellipse className="scn-neblina-a" cx={cx - 190} cy={lluviaY + 74} rx="200" ry="20" opacity={noche ? 0.22 : 0.36} />
+        </g>
+      )}
+
+      {/* LLUVIA — cortina ancha de trazos diagonales en dos alturas
+          (rsvg-safe, sin filtros) */}
+      {lluvia && (
+        <g className="scn-lluvia" stroke={noche ? '#aebfe0' : '#4e7d9a'} strokeWidth="2.4" strokeLinecap="round" opacity="0.8">
+          <line x1={cx - 90} y1={lluviaY} x2={cx - 97} y2={lluviaY + 22} />
+          <line x1={cx - 50} y1={lluviaY + 8} x2={cx - 57} y2={lluviaY + 30} />
+          <line x1={cx - 10} y1={lluviaY} x2={cx - 17} y2={lluviaY + 22} />
+          <line x1={cx + 28} y1={lluviaY + 6} x2={cx + 21} y2={lluviaY + 28} />
+          <line x1={cx + 64} y1={lluviaY} x2={cx + 57} y2={lluviaY + 22} />
+          <line x1={cx - 130} y1={lluviaY + 4} x2={cx - 137} y2={lluviaY + 26} />
+          <line x1={cx - 170} y1={lluviaY + 10} x2={cx - 177} y2={lluviaY + 32} />
+          <line x1={cx - 210} y1={lluviaY + 2} x2={cx - 217} y2={lluviaY + 24} />
+          <line x1={cx - 250} y1={lluviaY + 8} x2={cx - 257} y2={lluviaY + 30} />
+          <line x1={cx - 286} y1={lluviaY + 2} x2={cx - 293} y2={lluviaY + 24} />
+          <line x1={cx - 70} y1={lluviaY + 34} x2={cx - 77} y2={lluviaY + 56} />
+          <line x1={cx - 150} y1={lluviaY + 40} x2={cx - 157} y2={lluviaY + 62} />
+          <line x1={cx - 230} y1={lluviaY + 36} x2={cx - 237} y2={lluviaY + 58} />
+          <line x1={cx + 10} y1={lluviaY + 42} x2={cx + 3} y2={lluviaY + 64} />
+          <line x1={cx + 46} y1={lluviaY + 34} x2={cx + 39} y2={lluviaY + 56} />
+        </g>
+      )}
+    </g>
+  );
+}
+
+/**
+ * Veladura cálida de sol bajo — rect a pantalla completa de la escena que tiñe
+ * TODO (cielo, lomas, plantas) de ámbar al amanecer/atardecer, como la luz
+ * rasante real. De día/noche no pinta nada.
+ */
+export function WashSolBajo({ cielo, w = 390, h = 360, washId }) {
+  const tono = tonoLuz(cielo);
+  if (tono !== 'amanecer' && tono !== 'atardecer') return null;
+  return (
+    <rect
+      x="0" y="0" width={w} height={h}
+      fill={`url(#${washId})`}
+      opacity={tono === 'atardecer' ? 0.9 : 0.7}
+      pointerEvents="none"
+    />
+  );
+}
+
+/**
+ * CapaCielo — compone `<defs>` (gradientes del sol, ids únicos por instancia) +
+ * el grupo del cielo + la veladura de sol bajo. Se monta como hijos de un `<svg>`
+ * que la escena ya define con su viewBox.
+ *
+ * @param {Object}  props
+ * @param {{luz?:string, condicion?:string, tema?:string}} props.cielo  atmósfera resuelta.
+ * @param {number}  props.cx        centro X del astro (en coords del viewBox).
+ * @param {number}  props.cy        centro Y del astro.
+ * @param {number}  props.r         radio del astro.
+ * @param {number}  [props.lluviaY] altura desde donde cae la lluvia/niebla (150).
+ * @param {number}  [props.w]       ancho de la veladura de sol bajo (390).
+ * @param {number}  [props.h]       alto de la veladura de sol bajo (360).
+ * @param {boolean} [props.wash]    montar la veladura cálida de sol bajo (true).
+ */
+export default function CapaCielo({ cielo, cx, cy, r, lluviaY = 150, w = 390, h = 360, wash = true }) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const solId = `scn-sol-${uid}`;
+  const solWarmId = `scn-sol-warm-${uid}`;
+  const washId = `scn-wash-${uid}`;
+  return (
+    <>
+      <defs>
+        <CieloDefs solId={solId} solWarmId={solWarmId} washId={washId} />
+      </defs>
+      <Sky cielo={cielo} cx={cx} cy={cy} r={r} lluviaY={lluviaY} solId={solId} solWarmId={solWarmId} />
+      {wash && <WashSolBajo cielo={cielo} w={w} h={h} washId={washId} />}
+    </>
+  );
+}

--- a/src/visual/scenes/GuardianEspirituBase.jsx
+++ b/src/visual/scenes/GuardianEspirituBase.jsx
@@ -1,0 +1,82 @@
+/*
+ * GuardianEspirituBase — la BASE reutilizable del guardián-espíritu de la finca,
+ * extraída de `GuardianEspiritu` (mockup avatar-biopunk aprobado). Monta un
+ * avatar de fauna como ESPÍRITU: su disco con halo por acento + los filtros SVG
+ * de glow/blur compartidos. Aquí vive SOLO el marco reutilizable; el roster de
+ * especies grounded, la persistencia y el selector siguen en el consumidor
+ * (`dashboard/GuardianEspiritu`).
+ *
+ * El avatar en sí (los `<g>` de cada especie) es del dominio del consumidor: se
+ * pasa como `children` y filtra su glow con `url(#${glowId})`/`url(#${blurId})`
+ * (los ids que emite `EspirituDefs`, canónicos por defecto). Reduced-motion-safe.
+ *
+ * NOTA de dedupe (cuando `src/visual/effects` entre a main): `EspirituDefs` es el
+ * mismo glow `feMerge` que expone `<GlowFilter>`; usarlo en vez de re-declarar.
+ *
+ * Importá `./scenes.css` una vez donde lo uses.
+ */
+import './scenes.css';
+
+/**
+ * Filtros SVG compartidos del espíritu: glow (`feMerge`) + blur para estelas.
+ * Ids canónicos por defecto; parametrizables para repetir sin colisión.
+ */
+export function EspirituDefs({ glowId = 'scn-ge-glow', blurId = 'scn-ge-blur' }) {
+  return (
+    <defs>
+      <filter id={glowId} x="-80%" y="-80%" width="260%" height="260%">
+        <feGaussianBlur stdDeviation="2.2" result="b" />
+        <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+      </filter>
+      <filter id={blurId}><feGaussianBlur stdDeviation="3" /></filter>
+    </defs>
+  );
+}
+
+/**
+ * GuardianEspirituBase — el avatar-espíritu en su disco con halo por acento.
+ *
+ * @param {Object}  props
+ * @param {import('react').ReactNode} props.children  el `<g>` del avatar de fauna
+ *   (filtra su glow con `url(#scn-ge-glow)` salvo que pases `glowId`).
+ * @param {number|string} [props.size]     lado del disco/SVG en px (78).
+ * @param {string}  [props.acc]            color de acento del halo (#ffb54f).
+ * @param {string}  [props.accRgb]         el mismo acento en "r, g, b" (para el halo translúcido).
+ * @param {string}  [props.viewBox]        viewBox del SVG del avatar ("-26 -24 52 46").
+ * @param {string}  [props.glowId]         id del filtro glow ("scn-ge-glow").
+ * @param {string}  [props.blurId]         id del filtro blur ("scn-ge-blur").
+ * @param {string}  [props.className]      clases extra del disco.
+ * @param {string}  [props.title]          rótulo accesible; sin él, decorativo (aria-hidden).
+ */
+export default function GuardianEspirituBase({
+  children,
+  size = 78,
+  acc = '#ffb54f',
+  accRgb = '255, 181, 79',
+  viewBox = '-26 -24 52 46',
+  glowId = 'scn-ge-glow',
+  blurId = 'scn-ge-blur',
+  className = '',
+  title,
+}) {
+  return (
+    <span
+      className={`scn-espiritu-halo ${className}`.trim()}
+      style={{ width: size, height: size, '--scn-acc': acc, '--scn-acc-rgb': accRgb }}
+    >
+      <svg
+        viewBox={viewBox}
+        width={size}
+        height={size}
+        role={title ? 'img' : undefined}
+        aria-hidden={title ? undefined : true}
+        aria-label={title || undefined}
+        focusable="false"
+      >
+        {title && <title>{title}</title>}
+        <EspirituDefs glowId={glowId} blurId={blurId} />
+        {children}
+      </svg>
+    </span>
+  );
+}

--- a/src/visual/scenes/Parallax.jsx
+++ b/src/visual/scenes/Parallax.jsx
@@ -1,0 +1,50 @@
+/*
+ * Parallax — el MOTOR de cámara multicapa, distilado de `MontanaMundosCine`
+ * (la "Montaña de los Mundos", pasada cinematográfica). Apila capas SVG/DOM que
+ * viajan a distinta velocidad respecto a la cámara base: las lejanas amortiguadas
+ * (f < 1), las cercanas adelantadas (f > 1). Composición GPU pura (solo
+ * `transform`), reduced-motion-safe.
+ *
+ * Reparto de responsabilidades (a propósito): este motor NO decide la geometría
+ * de la escena (pisos térmicos, encuadre, gestos) — eso es del consumidor, que
+ * calcula la cámara base `{ tx, ty, s }` con su propio dominio y se la pasa. Aquí
+ * vive lo REUTILIZABLE: los factores por capa, la fórmula del transform, el hook
+ * de viewport y el apilado de capas con su inercia base (`.scn-capa`).
+ *
+ * Importá `./scenes.css` una vez donde lo uses.
+ */
+import { transformCapa } from './_parallax.js';
+import './scenes.css';
+
+/**
+ * Parallax — apila las capas (de lejos a cerca). Cada capa:
+ *   { id?, f, contenido, clase?, interactiva?, style? }
+ * `f` es su factor (use `CAPAS_PARALLAX.*` o el propio). `interactiva:true` deja
+ * pasar el toque (la capa con los mundos tocables); el resto es decorativo.
+ *
+ * @param {Object}  props
+ * @param {{tx:number, ty:number, s:number}} props.camara  cámara base (la calcula la escena).
+ * @param {Array}   props.capas        capas a apilar (orden = z-order, de fondo a frente).
+ * @param {number}  [props.alturaCapa] alto en px de cada capa (= alto de la escena escalada).
+ * @param {string}  [props.className]  clases extra del contenedor.
+ */
+export default function Parallax({ camara, capas = [], alturaCapa, className = '', children, ...rest }) {
+  return (
+    <div className={`scn-parallax ${className}`.trim()} {...rest}>
+      {capas.map((c, i) => (
+        <div
+          key={c.id ?? i}
+          className={`scn-capa ${c.interactiva ? 'scn-capa--interactiva' : ''} ${c.clase || ''}`.trim()}
+          style={{
+            ...(alturaCapa ? { height: `${alturaCapa}px` } : null),
+            transform: transformCapa(camara, c.f),
+            ...c.style,
+          }}
+        >
+          {c.contenido}
+        </div>
+      ))}
+      {children}
+    </div>
+  );
+}

--- a/src/visual/scenes/README.md
+++ b/src/visual/scenes/README.md
@@ -1,0 +1,154 @@
+# `src/visual/scenes` — escenas base reutilizables
+
+Librería de los **decorados base** de Chagra (las "escenas" que se repiten en el
+home vivo y los mockups) como componentes SVG/DOM limpios, parametrizables y sin
+dependencias nuevas. Nace para **dejar de re-armar el mismo decorado** en cada
+escena: hoy la capa de cielo por hora/clima, el parallax de la Montaña, el marco
+del guardián-espíritu, el grano de papel kraft y la finca-organismo con su
+latido aparecían dibujados/hilvanados por separado en `FincaVivaHero`,
+`MontanaMundosCine`, `GuardianEspiritu` y las escenas del home. Aquí vive la
+**versión canónica** de cada uno.
+
+Hermana de [`src/visual/creatures`](../creatures/README.md) (fauna) y
+[`src/visual/effects`](../effects/README.md) (técnicas de cine): misma filosofía,
+mismo contrato de reuso.
+
+## Regla de la casa
+
+> **Antes de re-armar una escena base, búscala aquí.**
+> Si existe → **reúsela** (y de ser posible, **mejore** la versión canónica en su
+> archivo, para que todos hereden la mejora).
+> Si arma una escena base nueva reutilizable → **agréguela aquí en el mismo PR**
+> (componente + entrada en `index.js` + fila en esta tabla).
+
+## Qué hay
+
+| Escena | Componente | Clave | Salió de |
+|---|---|---|---|
+| **Capa cielo paramétrica** | `CapaCielo` | sol/luna/estrellas/nubes/niebla/lluvia por **hora y clima reales** | `FincaVivaHero` (subcomponente `Sky`, compartido por las 3 escenas) |
+| **Parallax multicapa** | `Parallax` | motor de cámara por capas (`f<1` lejos, `f>1` cerca) | `MontanaMundosCine` (Montaña de los Mundos, pasada cine) |
+| **Guardián-espíritu base** | `GuardianEspirituBase` | avatar de fauna como espíritu, glow por acento | `GuardianEspiritu` (mockup avatar-biopunk) |
+| **Papel kraft** | clase `.scn-kraft` | grano de papel por líneas repetidas (sin imagen/noise) | `finca-viva-hero.css` (grano nature/minimalista) |
+| **Finca organismo** | `SceneFincaOrganismo` | finca bioluminiscente con corazón-semilla que **late** | `SceneFincaOrganismo` (escena-home-biopunk-v2) |
+
+## Props
+
+### `CapaCielo`
+Se monta como hijos de un `<svg>` que la escena ya define (con su `viewBox`).
+Emite su `<defs>` (gradientes del sol, **ids únicos por instancia** con `useId`)
++ el grupo del cielo + la veladura de sol bajo.
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `cielo` | `{ luz?, condicion?, tema? }` | — | atmósfera ya resuelta (misma forma que `atmosphereService` + `useTheme`). **No lee el DOM.** |
+| `cx` / `cy` / `r` | `number` | — | centro y radio del astro en coords del `viewBox`. |
+| `lluviaY` | `number` | `150` | altura desde donde caen lluvia/niebla. |
+| `w` / `h` | `number` | `390` / `360` | tamaño de la veladura de sol bajo. |
+| `wash` | `boolean` | `true` | montar la veladura cálida de amanecer/atardecer. |
+
+Helpers exportados: `Sky`, `CieloDefs`, `WashSolBajo` (piezas sueltas), y
+`cieloEscena(cielo, escena)`, `tonoLuz`, `esNoche`, `esCubierto`, más las tablas
+`CIELOS_ESCENA` / `CIELOS_TEMA`.
+
+### `Parallax`
+El **motor** apila capas; la **geometría de la escena** (pisos, encuadre, gestos)
+la calcula el consumidor y le pasa la cámara base `{ tx, ty, s }`.
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `camara` | `{ tx, ty, s }` | — | cámara base; la escena la calcula con su dominio. |
+| `capas` | `Array<{ id?, f, contenido, clase?, interactiva?, style? }>` | `[]` | capas de fondo a frente; `f` = factor (use `CAPAS_PARALLAX.*`), `interactiva:true` deja pasar el toque. |
+| `alturaCapa` | `number` | — | alto en px de cada capa (= alto de la escena escalada). |
+
+Helpers: `CAPAS_PARALLAX` (factores por capa), `transformCapa(camara, f)`,
+`useViewport(ref)`.
+
+### `GuardianEspirituBase`
+El avatar-espíritu en su disco con halo por acento + los filtros glow/blur. El
+avatar (los `<g>` de cada especie) es del dominio del consumidor: se pasa como
+`children` y filtra su glow con `url(#scn-ge-glow)`.
+
+| Prop | Tipo | Defecto | Qué hace |
+|---|---|---|---|
+| `children` | `ReactNode` | — | el `<g>` del avatar de fauna. |
+| `size` | `number\|string` | `78` | lado del disco/SVG. |
+| `acc` / `accRgb` | `string` | ámbar | color de acento del halo (hex + `"r, g, b"`). |
+| `viewBox` | `string` | `"-26 -24 52 46"` | viewBox del avatar. |
+| `glowId` / `blurId` | `string` | `scn-ge-glow` / `scn-ge-blur` | ids de los filtros (override para repetir sin colisión). |
+| `title` | `string` | — | rótulo accesible; sin él, decorativo (`aria-hidden`). |
+
+### `SceneFincaOrganismo`
+La escena completa de la finca-organismo (biopunk). Props: `estructura`
+(`{ tiene, forma }`), `onAnimales` (potrero tappable), `onPregunte` (corazón
+tappable). Su CSS (`scene-finca-organismo.css`) se importa donde se use, igual
+que la hoja de `effects`.
+
+### Papel kraft — clase `.scn-kraft`
+Textura de grano por `repeating-linear-gradient` (cero imagen/`feTurbulence`).
+Se re-tiñe con custom props; el modificador `.scn-kraft--fino` da la trama
+vertical finísima de papel.
+
+```jsx
+import { SCN_KRAFT_CLASS } from '@/visual/scenes';
+import '@/visual/scenes/scenes.css';
+
+// grano horizontal de papel kraft (nature), sobre un contenedor position:relative:
+<div className="scn-kraft" style={{ position: 'absolute', inset: 0,
+  '--scn-kraft-color': 'rgba(122, 82, 48, 0.06)' }} />
+```
+
+## Uso
+
+```jsx
+import { CapaCielo, Parallax, CAPAS_PARALLAX, GuardianEspirituBase, SceneFincaOrganismo } from '@/visual/scenes';
+import '@/visual/scenes/scenes.css';
+
+// 1. Cielo real por hora/clima dentro de una escena SVG propia:
+<svg viewBox="0 0 390 360" preserveAspectRatio="xMidYMid slice">
+  <CapaCielo cielo={{ luz: 'noche', condicion: 'despejado', tema: 'biopunk' }} cx={300} cy={70} r={26} />
+  {/* …tus lomas, plantas, animales… */}
+</svg>
+
+// 2. Parallax: la escena calcula la cámara y declara sus capas:
+<Parallax
+  camara={camara}                 // { tx, ty, s } de tu geometría de pisos
+  alturaCapa={escenaH}
+  capas={[
+    { id: 'cielo', f: CAPAS_PARALLAX.cielo, contenido: <CieloSvg /> },
+    { id: 'lejos', f: CAPAS_PARALLAX.lejos, contenido: <CordilleraSvg /> },
+    { id: 'principal', f: CAPAS_PARALLAX.principal, interactiva: true, contenido: <MontanaSvg /> },
+    { id: 'cerca', f: CAPAS_PARALLAX.cerca, contenido: <PrimerPlanoSvg /> },
+  ]}
+/>
+
+// 3. Un avatar de fauna como espíritu de la finca:
+<GuardianEspirituBase size={78} acc="#2dffc4" accRgb="45, 255, 196" title="Chivito de páramo">
+  <g filter="url(#scn-ge-glow)">{/* …el avatar… */}</g>
+</GuardianEspirituBase>
+```
+
+Consumidor de referencia (convertido en este PR): **`dashboard/FincaVivaHero.jsx`**
+— la portada del home consume `SceneFincaOrganismo` desde esta librería (la
+escena se movió aquí byte-idéntica; el hero solo cambió su `import`).
+
+## Técnica y reglas
+
+- **SVG + CSS puros, cero dependencias nuevas**; solo `transform`/`opacity`
+  animados, **blur/filtros ESTÁTICOS** (Android gama baja). Cero JS por frame
+  (el `Parallax` solo mide el viewport en `resize`).
+- Ids de gradiente/filtro **únicos** con `useId` (`CapaCielo`), para repetir
+  muchas escenas en una misma página sin colisión.
+- **Reduced-motion-safe**: el cielo queda quieto, el corazón encendido y en
+  reposo (sin ondas), la red ENCENDIDA, el parallax fijo, el espíritu detenido.
+- El **pulso** de la finca-organismo sincroniza todo lo vivo con una sola
+  variable `--scn-beat` (5.2s); póngala en un ancestro para acelerar/frenar todo.
+
+## Dedupe con `effects` (cuando entre a main)
+
+Esta librería nace **antes** de que `src/visual/effects` esté en `main`, así que
+carga su propia receta. Cuando effects entre, reusarlo donde aplique en vez de
+re-declarar:
+
+- **pulso** `--scn-beat` / `.scn-heart*` → equivale a `--vfx-beat` / `.vfx-beat*`.
+- **glow** `EspirituDefs` (`feMerge`) → equivale al helper `<GlowFilter>`.
+- **veladuras / grades** del cielo por tema → equivalen a `.vfx-veil` / `.vfx-grade`.

--- a/src/visual/scenes/SceneFincaOrganismo.jsx
+++ b/src/visual/scenes/SceneFincaOrganismo.jsx
@@ -1,0 +1,1039 @@
+/**
+ * SceneFincaOrganismo — la escena "FINCA ORGANISMO" del tema BIOPUNK
+ * (port fiel del mockup aprobado escena-home-biopunk-v2: la finca campesina
+ * de noche convertida en organismo bioluminiscente).
+ *
+ * Qué dibuja (todo animado por CSS, cero JS por frame):
+ *   · CORAZÓN-SEMILLA germinando bajo tierra que LATE (doble pulso cardíaco);
+ *     de él nacen los cuellos de raíz y la RED MICORRÍZICA (hifas con flujo de
+ *     savia + nutrientes viajando por motion-path hasta cada planta).
+ *   · INVERNADERO-CÉLULA que respira: cúpula-membrana con paneles geodésicos
+ *     que laten, lámpara-reactor, organelas flotando y camas de plántulas.
+ *   · MILPA de savia neón (maíz + frijol + auyama), cafetales con cerezas
+ *     neón, casita campesina con fogón (brasas), campesino con ruana +
+ *     farol + perro criollo, frailejones que exhalan luz, luna verde
+ *     bioluminiscente, cocuyos, aurora de páramo, niebla y hongos con esporas.
+ *   · QUEBRADA bioluminiscente que baja de la montaña por las terrazas y
+ *     remansa en un pocito que se filtra hacia la red micorrízica; platanera
+ *     con racimo neón junto a la casita; polillas rondando el farol y una
+ *     cordillera lejana + rayo del astro que dan profundidad de capas.
+ *   · POTRERO con VACA bioluminiscente (respira, pasta y espanta con la
+ *     cola) + 3 GALLINAS que picotean: es la ENTRADA VIVA al mundo de los
+ *     animales — si `onAnimales` llega, el grupo es un botón (tap/Enter)
+ *     que navega al módulo; sin handler queda como arte decorativo (el
+ *     MISMO gate por perfil que esconde el mundo Animales en el home).
+ *
+ * Solo se monta con el tema biopunk (lo decide FincaVivaHero); los demás
+ * temas conservan sus escenas isométricas intactas. Las clases/ids llevan
+ * prefijo `fvo-` para no chocar con el resto del hero. Sus animaciones viven
+ * en scene-finca-organismo.css y respetan prefers-reduced-motion con un
+ * estado estático digno (misma receta que el mockup).
+ *
+ * @param {Object} props
+ * @param {{tiene:boolean, forma:?string}} [props.estructura] estructura de
+ *   cubierta declarada en el perfil (#34): si el usuario declaró invernadero,
+ *   el invernadero-célula de la escena lleva el data-testid/data-forma del
+ *   contrato de FincaVivaHero.estructura.test.jsx (misma semántica que
+ *   SceneFinca: el marcador aparece SOLO si la estructura está declarada).
+ * @param {?() => void} [props.onAnimales] al tocar el potrero (vaca +
+ *   gallinas) navega al mundo de los animales. `null`/ausente = el perfil no
+ *   ve ese mundo (gate `mostrarAnimales` del home) y el potrero queda
+ *   decorativo, sin rol ni foco.
+ * @param {?() => void} [props.onPregunte] al tocar el CORAZÓN-SEMILLA abre el
+ *   agente ("Pregunte"): la metáfora central de la escena deja de ser
+ *   decoración y se vuelve LA acción principal (usabilidad campesina #4).
+ *   Sin handler, el corazón queda como arte (sin rol ni foco).
+ */
+export default function SceneFincaOrganismo({ estructura, onAnimales, onPregunte }) {
+  const conEstructura = !!estructura?.tiene;
+  const conAnimales = typeof onAnimales === 'function';
+  const conPregunte = typeof onPregunte === 'function';
+  const ariaEscena =
+    'Su finca convertida en organismo bioluminiscente, con el sol o la luna según la hora y el cielo real de su vereda: un corazón-semilla late bajo la tierra y su red de micorrizas conecta las raíces de cada planta, con lombrices y bichitos trabajando el suelo; una quebrada baja de la montaña, cultivos con savia de neón, invernadero-célula que respira, potrero con vaca y gallinas, campesino con su perro y colibrí de luz.';
+  return (
+    <svg
+      className="fvo-svg"
+      viewBox="0 0 390 486"
+      preserveAspectRatio="xMidYMid slice"
+      /* con el potrero y/o el corazón tappables el SVG deja de ser imagen
+         plana: role="img" volvería PRESENTACIONALES a sus hijos y los botones
+         (animales y "Pregunte") no existirían para lectores de pantalla. */
+      role={conAnimales || conPregunte ? 'group' : 'img'}
+      aria-label={ariaEscena}
+      data-testid="fvo-escena"
+    >
+      <defs>
+        <linearGradient id="fvo-cielo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#020412" />
+          <stop offset=".55" stopColor="#071030" />
+          <stop offset="1" stopColor="#0d1e44" />
+        </linearGradient>
+        <linearGradient id="fvo-suelo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#0c1026" />
+          <stop offset="1" stopColor="#04060f" />
+        </linearGradient>
+        <radialGradient id="fvo-luna" cx=".38" cy=".35" r="1">
+          <stop offset="0" stopColor="#eafff6" />
+          <stop offset=".7" stopColor="#a8e8d4" />
+          <stop offset="1" stopColor="#6fc4b0" />
+        </radialGradient>
+        {/* sol bioluminiscente + velos de cielo diurno/crepuscular (la escena
+            sigue la atmósfera REAL: data-luz/data-clima en .fvh, ver CSS) */}
+        <radialGradient id="fvo-sol" cx=".42" cy=".4" r="1">
+          <stop offset="0" stopColor="#fff9e0" />
+          <stop offset=".55" stopColor="#ffd76a" />
+          <stop offset="1" stopColor="#ff9d3f" />
+        </radialGradient>
+        <linearGradient id="fvo-cielo-dia-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#11506b" />
+          <stop offset=".55" stopColor="#177082" />
+          <stop offset="1" stopColor="#1a7a6a" />
+        </linearGradient>
+        <linearGradient id="fvo-cielo-crep-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#241338" />
+          <stop offset=".6" stopColor="#4a1e4e" />
+          <stop offset="1" stopColor="#8a4a2c" />
+        </linearGradient>
+        <radialGradient id="fvo-bulbo" cx=".5" cy=".5" r=".5">
+          <stop offset="0" stopColor="#2dffc4" stopOpacity=".9" />
+          <stop offset=".55" stopColor="#2dffc4" stopOpacity=".25" />
+          <stop offset="1" stopColor="#2dffc4" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient id="fvo-corazon" cx=".5" cy=".5" r=".5">
+          <stop offset="0" stopColor="#eafff6" />
+          <stop offset=".35" stopColor="#2dffc4" />
+          <stop offset=".8" stopColor="#0a9f74" stopOpacity=".4" />
+          <stop offset="1" stopColor="#0a9f74" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="fvo-membrana" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#2dffc4" stopOpacity=".22" />
+          <stop offset="1" stopColor="#4fd8ff" stopOpacity=".05" />
+        </linearGradient>
+        <linearGradient id="fvo-tallo" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0" stopColor="#0f8f6c" />
+          <stop offset="1" stopColor="#9dff3f" />
+        </linearGradient>
+        {/* agua de la quebrada: azul profundo que se enciende hacia el remanso */}
+        <linearGradient id="fvo-agua-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#0a2b4a" />
+          <stop offset="1" stopColor="#12466e" />
+        </linearGradient>
+        {/* rayo del astro: cae en diagonal sobre la finca y se disuelve */}
+        <linearGradient id="fvo-rayo-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#eafff6" stopOpacity=".14" />
+          <stop offset="1" stopColor="#eafff6" stopOpacity="0" />
+        </linearGradient>
+        <filter id="fvo-blur8"><feGaussianBlur stdDeviation="8" /></filter>
+        <filter id="fvo-blur3"><feGaussianBlur stdDeviation="3" /></filter>
+        <filter id="fvo-glow1" x="-80%" y="-80%" width="260%" height="260%">
+          <feGaussianBlur stdDeviation="2.2" result="b" />
+          <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+        </filter>
+      </defs>
+
+      {/* ============ CIELO ============ */}
+      <rect width="390" height="486" fill="url(#fvo-cielo)" />
+      {/* velos atmosféricos: se encienden por data-luz (día / amanecer-atardecer).
+          Van bajo montañas y terrazas — solo aclaran el cielo, no la finca. */}
+      <rect className="fvo-cielo-dia" width="390" height="486" fill="url(#fvo-cielo-dia-grad)" />
+      <rect className="fvo-cielo-crep" width="390" height="486" fill="url(#fvo-cielo-crep-grad)" />
+
+      {/* aurora de páramo */}
+      <path
+        className="fvo-aurora"
+        d="M-10,150 C70,110 150,140 230,105 C300,78 350,110 400,88 L400,160 C310,140 240,168 150,152 C80,140 30,166 -10,158 Z"
+        fill="#2dffc4" opacity=".14" filter="url(#fvo-blur8)"
+      />
+      <path
+        className="fvo-aurora" style={{ animationDelay: '-7s' }}
+        d="M-10,120 C90,95 170,125 260,92 L400,70 L400,120 C300,105 200,138 90,124 Z"
+        fill="#b28dff" opacity=".08" filter="url(#fvo-blur8)"
+      />
+
+      {/* estrellas */}
+      <g fill="#dfeffc">
+        <circle className="fvo-tw" cx="30" cy="34" r="1.2" />
+        <circle className="fvo-tw" style={{ animationDelay: '-1s' }} cx="74" cy="60" r=".9" />
+        <circle className="fvo-tw" style={{ animationDelay: '-2.2s' }} cx="120" cy="28" r="1.1" />
+        <circle className="fvo-tw" style={{ animationDelay: '-.6s' }} cx="168" cy="52" r=".8" />
+        <circle className="fvo-tw" style={{ animationDelay: '-1.7s' }} cx="212" cy="24" r="1.2" />
+        <circle className="fvo-tw" style={{ animationDelay: '-2.9s' }} cx="252" cy="58" r=".9" />
+        <circle className="fvo-tw" style={{ animationDelay: '-.3s' }} cx="356" cy="30" r="1.1" />
+        <circle className="fvo-tw" style={{ animationDelay: '-1.4s' }} cx="146" cy="86" r=".8" />
+        <circle className="fvo-tw" style={{ animationDelay: '-2.5s' }} cx="52" cy="104" r="1" />
+        <circle className="fvo-tw" style={{ animationDelay: '-.9s' }} cx="238" cy="96" r=".8" />
+        <circle className="fvo-tw" style={{ animationDelay: '-1.9s' }} cx="330" cy="72" r=".9" fill="#2dffc4" />
+        <circle className="fvo-tw" style={{ animationDelay: '-3.1s' }} cx="96" cy="42" r=".7" fill="#ff4fd8" />
+        <circle className="fvo-tw" style={{ animationDelay: '-2s' }} cx="288" cy="40" r=".8" fill="#9dff3f" />
+      </g>
+
+      {/* luna bioluminiscente (solo de noche — data-luz la gobierna en CSS) */}
+      <g className="fvo-astro fvo-luna-g">
+        <circle cx="318" cy="64" r="54" fill="#2dffc4" opacity=".045" filter="url(#fvo-blur8)" />
+        <circle cx="318" cy="64" r="40" fill="#a8e8d4" opacity=".08" filter="url(#fvo-blur8)" />
+        <circle className="fvo-halo" cx="318" cy="64" r="34" fill="none" stroke="#2dffc4" strokeWidth="1" opacity=".45" />
+        <circle cx="318" cy="64" r="21" fill="url(#fvo-luna)" />
+        <circle cx="318" cy="64" r="21" fill="none" stroke="#eafff6" strokeWidth=".7" opacity=".45" />
+        <circle cx="326" cy="58" r="19.2" fill="#061027" opacity=".94" />
+        <circle cx="309" cy="71" r="2.3" fill="#5fb89e" opacity=".4" />
+        <circle cx="305" cy="63" r="1.4" fill="#5fb89e" opacity=".35" />
+        <circle cx="312.5" cy="76" r="1" fill="#5fb89e" opacity=".3" />
+      </g>
+
+      {/* sol bioluminiscente (día / amanecer / atardecer — mismo lugar del
+          cielo que la luna; el CSS muestra UNO según la atmósfera real) */}
+      <g className="fvo-astro fvo-sol-g">
+        <circle cx="318" cy="64" r="54" fill="#ffb54f" opacity=".07" filter="url(#fvo-blur8)" />
+        <circle cx="318" cy="64" r="40" fill="#ffd76a" opacity=".1" filter="url(#fvo-blur8)" />
+        <circle className="fvo-halo" cx="318" cy="64" r="34" fill="none" stroke="#ffb54f" strokeWidth="1" opacity=".5" />
+        <circle cx="318" cy="64" r="21" fill="url(#fvo-sol)" />
+        <circle cx="318" cy="64" r="21" fill="none" stroke="#fff3c9" strokeWidth=".7" opacity=".6" />
+        {/* corona de rayos que respira */}
+        <g className="fvo-corona" stroke="#ffd76a" strokeWidth="1.4" strokeLinecap="round" fill="none">
+          <path d="M318,34 L318,26" /><path d="M318,94 L318,102" />
+          <path d="M288,64 L280,64" /><path d="M348,64 L356,64" />
+          <path d="M297,43 L291,37" /><path d="M339,85 L345,91" />
+          <path d="M339,43 L345,37" /><path d="M297,85 L291,91" />
+        </g>
+      </g>
+
+      {/* nubes de clima: aparecen con nublado/lluvia/niebla (data-clima) y
+          velan el astro — el cielo de la escena cuenta el clima REAL */}
+      <g className="fvo-nubes">
+        <g className="fvo-fog">
+          <ellipse cx="310" cy="58" rx="46" ry="12" fill="#8fa8bd" opacity=".38" filter="url(#fvo-blur8)" />
+          <ellipse cx="286" cy="72" rx="34" ry="10" fill="#7d95ab" opacity=".3" filter="url(#fvo-blur8)" />
+        </g>
+        <g className="fvo-fog fvo-g2">
+          <ellipse cx="120" cy="66" rx="52" ry="12" fill="#8fa8bd" opacity=".3" filter="url(#fvo-blur8)" />
+          <ellipse cx="152" cy="78" rx="36" ry="9" fill="#7d95ab" opacity=".24" filter="url(#fvo-blur8)" />
+        </g>
+      </g>
+
+      {/* estrella fugaz + aves lejanas */}
+      <g className="fvo-shoot">
+        <line x1="60" y1="40" x2="45" y2="33.5" stroke="#eafff6" strokeWidth="1.3" strokeLinecap="round" opacity=".85" />
+        <circle cx="61" cy="40.5" r="1.4" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 4px #bfffe9)' }} />
+      </g>
+      <g className="fvo-vbird" fill="none" stroke="#7f9db0" strokeWidth="1" strokeLinecap="round" opacity=".5">
+        <path className="fvo-flap" d="M150,92 l4,-2.6 4,2.6" />
+        <path className="fvo-flap" style={{ animationDelay: '-.4s' }} d="M161,87 l3.4,-2 3.4,2" />
+        <path className="fvo-flap" style={{ animationDelay: '-.8s' }} d="M143,97 l3,-1.8 3,1.8" />
+      </g>
+
+      {/* ============ COLIBRÍ DE LUZ (ser de luz, protagonista alado) ============ */}
+      <g className="fvo-colibri">
+        <circle className="fvo-estela" r="5" fill="#2dffc4" opacity=".5" filter="url(#fvo-blur3)" />
+        <circle className="fvo-estela fvo-e2" r="4" fill="#ff4fd8" opacity=".4" filter="url(#fvo-blur3)" />
+        <circle className="fvo-estela fvo-e3" r="3" fill="#4fd8ff" opacity=".4" filter="url(#fvo-blur3)" />
+        <g filter="url(#fvo-glow1)">
+          {/* cola bifurcada */}
+          <path d="M-4,-.4 L-12,-3.2 L-8.5,0 L-12,3 Z" fill="#1f9f86" />
+          {/* cuerpo */}
+          <path d="M-4.5,0 C0,-4.6 7,-4.2 10,-1 C12.2,.7 12.2,2.2 10,3.3 C6,5.8 0,5.4 -4.5,1 Z" fill="#2dffc4" />
+          {/* vientre claro */}
+          <path d="M-2.5,2.2 C2,3.8 7,3.6 10,1.8 C7,4.9 1,5.1 -3.4,1.6 Z" fill="#bfffe9" opacity=".7" />
+          {/* gorguera iridiscente */}
+          <path d="M6.6,1.4 C8.6,.2 10.8,1.2 11.4,2.6 C10,3.7 7.6,3.3 6.4,2.1 Z" fill="#ff4fd8" />
+          {/* cabeza */}
+          <circle cx="9" cy="-1.6" r="2.9" fill="#9dff3f" />
+          {/* cresta */}
+          <path d="M8,-3.9 L9.1,-6.4 L10.4,-3.6 Z" fill="#4fd8ff" />
+          {/* ojo */}
+          <circle cx="9.7" cy="-2" r=".85" fill="#04160f" />
+          <circle cx="10" cy="-2.3" r=".3" fill="#eafff6" />
+          {/* pico largo curvo */}
+          <path d="M11.6,-1.1 C15,-1.5 18,-2 20.8,-3.1" stroke="#eafff6" strokeWidth="1" fill="none" strokeLinecap="round" />
+          {/* ala superior (bate) */}
+          <path className="fvo-ala" d="M3,-1 C-3,-11.5 7.5,-16.5 12.5,-10 C10.4,-4 6,-1 3,-1 Z" fill="#ff4fd8" opacity=".85" />
+          {/* ala inferior (bate, desfasada) */}
+          <path className="fvo-ala" style={{ animationDelay: '-.06s' }} d="M4,1.2 C0,9.5 9.5,12.5 12.5,7 C10.2,3 7,1.2 4,1.2 Z" fill="#b28dff" opacity=".5" />
+        </g>
+      </g>
+
+      {/* ============ MONTAÑAS (3 capas = profundidad) ============ */}
+      {/* cordillera LEJANA: la capa nueva de atrás, casi cielo — con la niebla
+          que deriva entre capas la escena gana paralaje sin mover montañas */}
+      <path d="M0,196 C55,162 130,186 210,164 C285,146 340,172 390,152 L390,262 L0,262 Z" fill="#071126" />
+      <ellipse className="fvo-fog fvo-g3" cx="180" cy="196" rx="170" ry="13" fill="#9fd4ff" opacity=".05" filter="url(#fvo-blur8)" />
+      <path d="M0,206 C60,176 122,196 190,180 C258,166 322,192 390,174 L390,262 L0,262 Z" fill="#0a1734" />
+      <path d="M0,234 C70,208 150,228 232,212 C302,200 352,220 390,208 L390,282 L0,282 Z" fill="#0d1e40" />
+
+      {/* rayo del astro: la luz de la luna/el sol cae en diagonal sobre la
+          finca (respira suave; da volumen de iluminación a toda la escena) */}
+      <path className="fvo-rayo" d="M292,88 L188,336 L390,336 L346,86 Z" fill="url(#fvo-rayo-grad)" />
+
+      {/* frailejones que exhalan luz (páramo) */}
+      <g className="fvo-frailejon" strokeLinecap="round">
+        <rect x="44" y="212" width="3" height="12" rx="1.5" fill="#123024" />
+        <g stroke="#9dff3f" strokeWidth="1.6" opacity=".9">
+          <path d="M45.5,212 L38,202" /><path d="M45.5,212 L42,200" /><path d="M45.5,212 L46,199" />
+          <path d="M45.5,212 L50,200" /><path d="M45.5,212 L53,203" />
+        </g>
+        <circle cx="38" cy="201" r="1.4" fill="#d8ff6a" /><circle cx="46" cy="198" r="1.4" fill="#d8ff6a" />
+        <circle cx="53" cy="202" r="1.4" fill="#d8ff6a" />
+      </g>
+      <g className="fvo-frailejon fvo-fr2" strokeLinecap="round">
+        <rect x="76" y="220" width="2.6" height="9" rx="1.3" fill="#123024" />
+        <g stroke="#9dff3f" strokeWidth="1.4" opacity=".85">
+          <path d="M77,220 L71,212" /><path d="M77,220 L76,210" /><path d="M77,220 L82,212" />
+        </g>
+        <circle cx="71" cy="211" r="1.2" fill="#d8ff6a" /><circle cx="82" cy="211" r="1.2" fill="#d8ff6a" />
+      </g>
+      <g className="fvo-frailejon" style={{ animationDelay: '-1.8s' }} strokeLinecap="round">
+        <rect x="364" y="206" width="2.6" height="10" rx="1.3" fill="#123024" />
+        <g stroke="#9dff3f" strokeWidth="1.4" opacity=".85">
+          <path d="M365,206 L359,198" /><path d="M365,206 L364,196" /><path d="M365,206 L370,198" />
+        </g>
+        <circle cx="364" cy="195" r="1.2" fill="#d8ff6a" /><circle cx="370" cy="197" r="1.2" fill="#d8ff6a" />
+      </g>
+
+      {/* ============ FINCA (respira) ============ */}
+      <g className="fvo-breathe">
+        {/* terrazas: curvas de nivel bioluminiscentes */}
+        <path d="M0,258 C80,246 180,256 262,246 C320,240 360,248 390,242 L390,296 L0,296 Z" fill="#102a48" />
+        <path d="M0,258 C80,246 180,256 262,246 C320,240 360,248 390,242" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".4" />
+        <path d="M0,296 C90,286 190,296 280,288 C330,284 364,290 390,284 L390,336 L0,336 Z" fill="#123354" />
+        <path d="M0,296 C90,286 190,296 280,288 C330,284 364,290 390,284" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".5" />
+
+        {/* ============ QUEBRADA BIOLUMINISCENTE (el agua de la finca) ============
+            Baja de la montaña por el costado izquierdo, salta las terrazas en
+            dos cascaditas y remansa en un pocito al pie de la milpa. El flujo
+            es el mismo truco de las hifas (dash que corre); el remanso ondea. */}
+        <g aria-hidden="true">
+          {/* cauce (lecho oscuro + agua) */}
+          <path d="M14,232 C6,248 24,262 14,278 C4,294 22,308 12,320 C9,326 5,331 2,334" fill="none" stroke="#0a2b4a" strokeWidth="9" strokeLinecap="round" />
+          <path d="M14,232 C6,248 24,262 14,278 C4,294 22,308 12,320 C9,326 5,331 2,334" fill="none" stroke="#123f66" strokeWidth="6" strokeLinecap="round" />
+          {/* corriente neón (dos hilos desfasados) */}
+          <path className="fvo-agua" d="M14,232 C6,248 24,262 14,278 C4,294 22,308 12,320 C9,326 5,331 2,334" fill="none" stroke="#4fd8ff" strokeWidth="1.8" strokeLinecap="round" opacity=".8" style={{ filter: 'drop-shadow(0 0 3px rgba(79,216,255,.6))' }} />
+          <path className="fvo-agua fvo-a2" d="M16,234 C9,249 25,263 16,279 C7,294 23,308 14,320" fill="none" stroke="#bfeaff" strokeWidth=".9" strokeLinecap="round" opacity=".6" />
+          {/* cascaditas donde el agua salta cada terraza */}
+          <line className="fvo-destello" x1="15" y1="256" x2="14" y2="262" stroke="#bfeaff" strokeWidth="2.2" strokeLinecap="round" opacity=".8" />
+          <line className="fvo-destello" style={{ animationDelay: '-1.3s' }} x1="13" y1="294" x2="12" y2="300" stroke="#bfeaff" strokeWidth="2" strokeLinecap="round" opacity=".75" />
+          {/* pocito / remanso (refleja la luz del cielo y ondea) */}
+          <ellipse cx="18" cy="331" rx="19" ry="4.4" fill="url(#fvo-agua-grad)" />
+          <ellipse cx="18" cy="331" rx="19" ry="4.4" fill="none" stroke="#4fd8ff" strokeWidth=".9" opacity=".7" />
+          <ellipse className="fvo-reflejo" cx="12" cy="330.4" rx="6.5" ry="1.3" fill="#bfeaff" opacity=".45" />
+          <ellipse className="fvo-onda" cx="18" cy="331" rx="6" ry="1.6" fill="none" stroke="#4fd8ff" strokeWidth=".8" />
+          <ellipse className="fvo-onda fvo-on2" cx="18" cy="331" rx="6" ry="1.6" fill="none" stroke="#bfeaff" strokeWidth=".6" />
+          {/* juncos de la orilla + luciérnaga de agua */}
+          <g stroke="#0f8f6c" strokeWidth="1.2" strokeLinecap="round" fill="none">
+            <path className="fvo-sap fvo-s3" d="M33,330 C33,324 34,320 33,316" />
+            <path className="fvo-sap fvo-s5" d="M36,331 C36,326 37,323 36.5,319" />
+          </g>
+          <circle cx="33" cy="315" r="1.2" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+          <circle className="fvo-fly fvo-f5" cx="26" cy="320" r="1.2" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 4px #4fd8ff)' }} />
+        </g>
+
+        {/* casita campesina con fogón */}
+        <g>
+          <rect x="52" y="250" width="26" height="17" rx="1.5" fill="#160f2e" />
+          <path d="M49,251 L65,238 L81,251 Z" fill="#1e1440" />
+          <path d="M49,251 L65,238 L81,251" fill="none" stroke="#ff4fd8" strokeWidth="1" opacity=".55" />
+          <rect className="fvo-ventana" x="59" y="255" width="5.5" height="7" rx="1" fill="#ffb54f" style={{ filter: 'drop-shadow(0 0 5px #ff9d3f)' }} />
+          <rect x="69" y="256" width="4.5" height="11" rx="1" fill="#0b0820" />
+          <rect x="72.5" y="240" width="3.5" height="9" fill="#160f2e" />
+          <circle className="fvo-brasa" cx="74" cy="238" r="1.5" fill="#ff7a3d" />
+          <circle className="fvo-brasa fvo-br2" cx="75.5" cy="238" r="1.1" fill="#ffb54f" />
+          <circle className="fvo-brasa fvo-br3" cx="73" cy="238" r=".9" fill="#ff4fd8" />
+          {/* la puerta abierta derrama luz cálida al patio */}
+          <ellipse className="fvo-ventana" cx="71.5" cy="268.5" rx="6.5" ry="1.8" fill="#ffb54f" opacity=".16" />
+        </g>
+
+        {/* platanera del patio: hojas que arquean con venas de savia y un
+            racimo con su bellota neón (queda medio detrás del cafetal — capa) */}
+        <g aria-hidden="true">
+          <path d="M92,296 C92,284 91,274 92,266" fill="none" stroke="#14503c" strokeWidth="3" strokeLinecap="round" />
+          <path className="fvo-sap fvo-s2" d="M92,294 C92,284 91.4,274 92,267" fill="none" stroke="#2dffc4" strokeWidth=".8" opacity=".6" strokeLinecap="round" />
+          <path d="M92,266 C83,264 76,257.5 74,250 C80.5,250 89,255.5 92,262 Z" fill="#14503c" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          <path d="M92,266 C101,264 108,257.5 110,250 C103.5,250 95,255.5 92,262 Z" fill="#14503c" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          <path d="M92,264 C86,258 84,250 86.5,243 C90.5,247.5 93,256 92.4,262 Z" fill="#186047" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          <path d="M92,264 C98,258 100,250 97.5,243 C93.5,247.5 91,256 91.6,262 Z" fill="#186047" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+          {/* venas de las hojas (laten con la savia) */}
+          <g className="fvo-sap fvo-s4" fill="none" stroke="#9dff3f" strokeWidth=".6" opacity=".65" strokeLinecap="round">
+            <path d="M92,264 C86,260 81,255 78,251" />
+            <path d="M92,264 C98,260 103,255 106,251" />
+            <path d="M91.6,262 C90,255 88.6,250 87.6,246" />
+            <path d="M92.4,262 C94,255 95.4,250 96.4,246" />
+          </g>
+          {/* racimo + bellota (flor) colgando */}
+          <path d="M92,268 C89.6,269.5 88.4,271.5 88.6,274" fill="none" stroke="#0f8f6c" strokeWidth="1" />
+          <circle className="fvo-berry fvo-b2" cx="89.6" cy="269.6" r="1.3" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 3px #ffb54f)' }} />
+          <circle className="fvo-berry fvo-b4" cx="88" cy="271.6" r="1.3" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 3px #ffb54f)' }} />
+          <path d="M88.6,274 L87.4,277.6 L90,277.2 Z" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+        </g>
+
+        {/* cafetales con cerezas neón (terraza alta) */}
+        <g>
+          <g transform="translate(108,252)">
+            <path d="M0,14 L0,4" stroke="#0f8f6c" strokeWidth="2" />
+            <circle cx="0" cy="2" r="7" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="-5" cy="6" r="5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="5" cy="6" r="5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle className="fvo-berry" cx="-4" cy="2" r="1.6" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+            <circle className="fvo-berry fvo-b2" cx="3" cy="-1" r="1.6" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+            <circle className="fvo-berry fvo-b3" cx="6" cy="5" r="1.4" fill="#ff9d3f" style={{ filter: 'drop-shadow(0 0 3px #ff9d3f)' }} />
+          </g>
+          <g transform="translate(146,250)">
+            <path d="M0,14 L0,4" stroke="#0f8f6c" strokeWidth="2" />
+            <circle cx="0" cy="2" r="6" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="-4" cy="6" r="4.5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="4.5" cy="5.5" r="4.5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle className="fvo-berry fvo-b4" cx="-3" cy="1" r="1.5" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+            <circle className="fvo-berry fvo-b2" cx="4" cy="3" r="1.5" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+          </g>
+          <g transform="translate(182,249)">
+            <path d="M0,13 L0,4" stroke="#0f8f6c" strokeWidth="2" />
+            <circle cx="0" cy="1" r="6" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="-4.5" cy="5" r="4.5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle cx="4.5" cy="5" r="4.5" fill="#14402f" stroke="#2dffc4" strokeWidth=".5" strokeOpacity=".35" />
+            <circle className="fvo-berry fvo-b3" cx="2" cy="-2" r="1.5" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 3px #ff4fd8)' }} />
+            <circle className="fvo-berry" cx="-4" cy="4" r="1.4" fill="#ff9d3f" style={{ filter: 'drop-shadow(0 0 3px #ff9d3f)' }} />
+          </g>
+        </g>
+
+        {/* ============ INVERNADERO-CÉLULA (bio-cúpula viva, protagónico) ============
+            Si el perfil declaró estructura de cubierta (#34), este grupo lleva el
+            marcador del contrato de tests (fvh-estructura + data-forma). */}
+        <g
+          className="fvo-dome"
+          {...(conEstructura
+            ? { 'data-testid': 'fvh-estructura', 'data-forma': estructura.forma || 'generica' }
+            : {})}
+        >
+          {/* halo de vida */}
+          <ellipse cx="298" cy="292" rx="66" ry="58" fill="#2dffc4" opacity=".10" filter="url(#fvo-blur8)" />
+          {/* membrana / vidrio vivo */}
+          <path d="M248,330 C248,282 266,244 298,244 C330,244 348,282 348,330 Z" fill="url(#fvo-membrana)" />
+          {/* paneles geodésicos (latido) */}
+          <g fill="none" stroke="#2dffc4" strokeLinecap="round">
+            <g className="fvo-panel" strokeWidth="1.5" opacity=".7" style={{ filter: 'drop-shadow(0 0 4px rgba(45,255,196,.55))' }}>
+              <path d="M298,244 L298,330" />
+              <path d="M298,244 C280,272 270,300 264,330" />
+              <path d="M298,244 C316,272 326,300 332,330" />
+            </g>
+            <g className="fvo-panel fvo-pa2" strokeWidth="1.3" opacity=".55" style={{ filter: 'drop-shadow(0 0 3px rgba(45,255,196,.5))' }}>
+              <path d="M298,244 C288,272 282,302 278,330" />
+              <path d="M298,244 C308,272 314,302 318,330" />
+            </g>
+            <g className="fvo-panel fvo-pa3" strokeWidth="1.2" opacity=".5" stroke="#4fd8ff">
+              <path d="M267,266 Q298,257 329,266" />
+              <path d="M256,294 Q298,285 340,294" />
+              <path d="M250,318 Q298,309 346,318" />
+            </g>
+          </g>
+          {/* contorno brillante */}
+          <path
+            d="M248,330 C248,282 266,244 298,244 C330,244 348,282 348,330" fill="none"
+            stroke="#2dffc4" strokeWidth="1.8" opacity=".9"
+            style={{ filter: 'drop-shadow(0 0 6px rgba(45,255,196,.7))' }}
+          />
+
+          {/* caballete / venteo del techo + antenas-cilio */}
+          <g className="fvo-vent" stroke="#9dff3f" strokeWidth="1.3" strokeLinecap="round" fill="none">
+            <path d="M290,246 L288,239 L300,236" />
+            <path d="M298,240 L298,231" /><path d="M306,242 L311,235" />
+          </g>
+          <circle className="fvo-vent" cx="298" cy="230" r="1.6" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 4px #9dff3f)' }} />
+          <circle className="fvo-vent" cx="311" cy="234" r="1.2" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+
+          {/* lámpara-reactor colgada del ápice (grow-light que late) */}
+          <path className="fvo-lamplight" d="M298,276 L280,330 L316,330 Z" fill="#2dffc4" opacity=".22" />
+          <line x1="298" y1="250" x2="298" y2="268" stroke="#2dffc4" strokeWidth="1" opacity=".6" />
+          <circle cx="298" cy="276" r="18" fill="#2dffc4" opacity=".16" filter="url(#fvo-blur3)" />
+          <circle className="fvo-reactor" cx="298" cy="276" r="10" fill="#bfffe9" style={{ filter: 'drop-shadow(0 0 10px #2dffc4)' }} />
+          <circle className="fvo-reactor" cx="298" cy="276" r="3.2" fill="#ff8fe4" />
+
+          {/* pólenes / organelas flotando */}
+          <circle className="fvo-organela" cx="268" cy="290" r="2.6" fill="#9dff3f" opacity=".7" />
+          <circle className="fvo-organela fvo-o2" cx="330" cy="298" r="2.2" fill="#4fd8ff" opacity=".7" />
+          <circle className="fvo-organela fvo-o3" cx="284" cy="262" r="1.8" fill="#ff8fe4" opacity=".6" />
+          <circle className="fvo-organela fvo-o2" cx="316" cy="266" r="1.8" fill="#2dffc4" opacity=".5" />
+
+          {/* camas de siembra + plántulas en hilera (dentro) */}
+          <path d="M254,324 L288,324 M308,324 L342,324" stroke="#0e3324" strokeWidth="3.4" strokeLinecap="round" />
+          <g stroke="url(#fvo-tallo)" strokeWidth="1.5" strokeLinecap="round" fill="none">
+            <path className="fvo-sap" d="M260,323 C260,318 258,315 257,312" />
+            <path className="fvo-sap fvo-s2" d="M268,323 C268,317 270,314 271,311" />
+            <path className="fvo-sap fvo-s3" d="M277,323 C277,318 275,315 274,312" />
+            <path className="fvo-sap fvo-s4" d="M319,323 C319,317 321,314 322,311" />
+            <path className="fvo-sap fvo-s2" d="M328,323 C328,318 326,315 325,312" />
+            <path className="fvo-sap fvo-s3" d="M337,323 C337,318 339,315 340,312" />
+          </g>
+          <circle cx="257" cy="311" r="1.5" fill="#d8ff6a" /><circle cx="271" cy="310" r="1.5" fill="#d8ff6a" />
+          <circle cx="274" cy="311" r="1.5" fill="#d8ff6a" /><circle cx="322" cy="310" r="1.5" fill="#d8ff6a" />
+          <circle cx="325" cy="311" r="1.5" fill="#d8ff6a" /><circle cx="340" cy="311" r="1.5" fill="#d8ff6a" />
+
+          {/* puerta / entrada con luz cálida */}
+          <path d="M289,330 L289,309 Q298,301 307,309 L307,330 Z" fill="#0a2018" />
+          <path d="M289,330 L289,309 Q298,301 307,309 L307,330" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".8" />
+          <path className="fvo-ventana" d="M292,330 L292,311 Q298,305 304,311 L304,330 Z" fill="#9dff3f" opacity=".5" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          {/* base / cimiento luminoso */}
+          <rect x="247" y="328" width="102" height="5" rx="2.5" fill="#0c2a20" />
+          <rect x="247" y="328" width="102" height="1.6" rx="1" fill="#2dffc4" opacity=".7" />
+        </g>
+
+        {/* ============ POTRERO: VACA + 3 GALLINAS = ENTRADA AL MUNDO ANIMALES ============
+            El grupo entero es la puerta viva al módulo de animales: con
+            `onAnimales` es un botón (tap / Enter / Espacio) con halo-invitación
+            y etiqueta; sin handler (gate por perfil) queda como arte. La vaca
+            respira, pasta y espanta con la cola; las gallinas picotean. */}
+        <g
+          className="fvo-animales"
+          data-testid="fvo-animales"
+          {...(conAnimales
+            ? {
+                role: 'button',
+                tabIndex: 0,
+                'data-tap': '1',
+                'aria-label': 'Los animales de su finca: la vaca y las gallinas. Toque para entrar al mundo de los animales.',
+                onClick: () => onAnimales(),
+                onKeyDown: (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onAnimales();
+                  }
+                },
+              }
+            : { 'aria-hidden': true })}
+        >
+          {/* pasto del potrero */}
+          <ellipse cx="222" cy="278" rx="31" ry="5.5" fill="#16405a" opacity=".5" />
+          <g stroke="#9dff3f" strokeWidth=".8" strokeLinecap="round" opacity=".6" fill="none">
+            <path d="M197,278 L196,274.4" /><path d="M199.5,278.4 L199.5,275" />
+            <path d="M246,276 L245,272.6" /><path d="M248.5,276.4 L249,273.2" />
+            <path d="M215,282 L214.4,279" /><path d="M231,282.4 L231.6,279.4" />
+          </g>
+
+          {/* cerca viva del potrero (madera oscura + hilos neón) */}
+          <g>
+            <g fill="#241c3e">
+              <rect x="194.2" y="244.5" width="1.8" height="10.5" rx=".9" />
+              <rect x="208.2" y="243.8" width="1.8" height="10.5" rx=".9" />
+              <rect x="222.2" y="243.5" width="1.8" height="10.5" rx=".9" />
+              <rect x="236.2" y="243.8" width="1.8" height="10.5" rx=".9" />
+              <rect x="250.2" y="244.5" width="1.8" height="10.5" rx=".9" />
+            </g>
+            <path d="M194,247.4 C208,246.2 238,246.2 252,247.4" fill="none" stroke="#b28dff" strokeWidth=".9" opacity=".55" />
+            <path d="M194,251.4 C208,250.2 238,250.2 252,251.4" fill="none" stroke="#2dffc4" strokeWidth=".9" opacity=".5" />
+            <circle className="fvo-nodo" cx="223.1" cy="243.2" r="1" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+          </g>
+
+          {/* VACA bioluminiscente (mira hacia la casa; el organismo la abraza:
+              sus manchas laten con el MISMO pulso de la red micorrízica) */}
+          <g className="fvo-vaca">
+            <ellipse cx="221" cy="280" rx="18" ry="3" fill="#000" opacity=".35" />
+            {/* cola (espanta de a ratos) + borla-cocuyo */}
+            <g className="fvo-vaca-cola">
+              <path d="M236.5,258 C240.5,262 241.5,268 239.5,274" fill="none" stroke="#241c3e" strokeWidth="1.6" strokeLinecap="round" />
+              <circle cx="239.5" cy="275" r="1.9" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px #2dffc4)' }} />
+            </g>
+            {/* patas con pezuñas de luz */}
+            <g stroke="#241c3e" strokeWidth="3" strokeLinecap="round">
+              <path d="M210,271 L209.4,279" /><path d="M215.5,272.5 L215.5,279.6" />
+              <path d="M228.5,272.5 L228.5,279.6" /><path d="M234,271 L234.6,279" />
+            </g>
+            <g fill="#b28dff" opacity=".8">
+              <circle cx="209.4" cy="279.6" r=".9" /><circle cx="215.5" cy="280.2" r=".9" />
+              <circle cx="228.5" cy="280.2" r=".9" /><circle cx="234.6" cy="279.6" r=".9" />
+            </g>
+            {/* cuerpo (respira) con manchas que laten al pulso del corazón */}
+            <g className="fvo-vaca-cuerpo">
+              <ellipse cx="222" cy="264" rx="16" ry="9.5" fill="#241c3e" stroke="#b28dff" strokeWidth=".8" strokeOpacity=".45" />
+              <path className="fvo-mancha" d="M210,259 C215,255.5 221,256 223.5,260 C221,264.5 213.5,265.5 209.5,262.5 Z" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px rgba(45,255,196,.7))' }} />
+              <path className="fvo-mancha fvo-m2" d="M229,266 C233.5,264 237,266 236,269.5 C233,271.5 228.5,270.5 227.5,268 Z" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 3px rgba(79,216,255,.7))' }} />
+              <circle className="fvo-mancha fvo-m3" cx="216" cy="269" r="2.4" fill="#ff8fe4" style={{ filter: 'drop-shadow(0 0 3px rgba(255,143,228,.7))' }} />
+              {/* ubre con su lucecita (la leche también es vida) */}
+              <path d="M226.5,272.5 a3.2,2.6 0 0 0 6.2,0 Z" fill="#ff9ee8" opacity=".85" />
+            </g>
+            {/* cabeza: pasta y se alza a mirar; orejas que espantan */}
+            <g className="fvo-vaca-cabeza">
+              <path d="M209,258 L213,260" stroke="#241c3e" strokeWidth="5" strokeLinecap="round" />
+              <ellipse cx="204.5" cy="257" rx="6.2" ry="5" fill="#241c3e" stroke="#b28dff" strokeWidth=".7" strokeOpacity=".4" />
+              {/* cachos de luna */}
+              <g fill="none" stroke="#e8dcff" strokeWidth="1.2" strokeLinecap="round">
+                <path d="M201.5,252.6 C200,250 200.8,248.4 202.8,247.8" />
+                <path d="M207.5,252.4 C209,250 208.4,248.2 206.4,247.8" />
+              </g>
+              <path className="fvo-vaca-oreja" d="M209.5,254 Q212.5,251.5 213.5,253.5 Q212,256 209.8,256 Z" fill="#3a2f52" />
+              {/* hocico + ollar */}
+              <ellipse cx="200" cy="259.5" rx="3.4" ry="2.5" fill="#3a2f52" />
+              <circle cx="198.8" cy="259.3" r=".5" fill="#0a0618" />
+              {/* ojo de cocuyo */}
+              <circle cx="206" cy="255.8" r="1.05" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 3px #2dffc4)' }} />
+              <circle cx="206.35" cy="255.45" r=".35" fill="#eafff6" />
+              {/* mancha de la frente */}
+              <path className="fvo-mancha fvo-m2" d="M203,253.6 C204.6,252.6 206.4,253 206.8,254.4 C205.6,255.6 203.6,255.4 203,253.6 Z" fill="#2dffc4" opacity=".7" />
+            </g>
+          </g>
+
+          {/* 3 GALLINAS que picotean (cada una con su color y su ritmo) */}
+          <GallinaLuz x={205} y={281} cuerpo="#ffb54f" cola="#ff9d3f" clase="" />
+          <GallinaLuz x={220.5} y={283.5} cuerpo="#ff8fe4" cola="#d86ac0" clase="fvo-ga2" espejo />
+          <GallinaLuz x={237} y={281} cuerpo="#8fc8ef" cola="#5a9fd4" clase="fvo-ga3" />
+
+          {/* halo-invitación + etiqueta (solo cuando el potrero es la puerta
+              al módulo; el anillo de foco lo enciende :focus-visible) */}
+          {conAnimales && (
+            <g>
+              <ellipse className="fvo-cta-halo" cx="222" cy="264" rx="34" ry="22" fill="none" stroke="#ffb54f" strokeWidth="1" />
+              <ellipse className="fvo-cta-anillo" cx="222" cy="264" rx="34" ry="22" fill="none" stroke="#ffd76a" strokeWidth="1.4" opacity="0" />
+              <text
+                className="fvo-cta-tag"
+                x="222"
+                y="238"
+                fill="#ffb54f"
+                fontFamily="ui-monospace,monospace"
+                fontSize="7"
+                letterSpacing="1.5"
+                textAnchor="middle"
+              >
+                LOS ANIMALES ▸
+              </text>
+              {/* zona de tap generosa (invisible) sobre todo el potrero.
+                  OJO: sin <title> a propósito — un <title> en el subárbol
+                  aporta un rect degenerado en el origen del SVG y Chromium
+                  infla el boundingClientRect del botón hasta cubrir media
+                  escena (el aria-label del grupo ya cubre accesibilidad). */}
+              <rect x="190" y="230" width="66" height="58" fill="#000" opacity="0" style={{ pointerEvents: 'all' }} />
+            </g>
+          )}
+        </g>
+
+        {/* ============ MILPA FRONTAL: maíz de savia neón ============ */}
+        <g strokeLinecap="round" fill="none">
+          <g className="fvo-sap">
+            <path d="M40,336 C40,318 38,306 40,294" stroke="url(#fvo-tallo)" strokeWidth="2.4" />
+            <path d="M40,318 C33,314 28,308 27,300" stroke="#9dff3f" strokeWidth="1.6" opacity=".9" />
+            <path d="M40,310 C47,306 52,300 53,293" stroke="#9dff3f" strokeWidth="1.6" opacity=".9" />
+            <ellipse cx="40" cy="291" rx="3" ry="5" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          </g>
+          <g className="fvo-sap fvo-s2">
+            <path d="M78,338 C78,318 80,304 78,292" stroke="url(#fvo-tallo)" strokeWidth="2.6" />
+            <path d="M78,320 C70,316 65,309 64,301" stroke="#9dff3f" strokeWidth="1.7" opacity=".9" />
+            <path d="M78,312 C86,308 91,302 92,294" stroke="#9dff3f" strokeWidth="1.7" opacity=".9" />
+            <ellipse cx="78" cy="289" rx="3.2" ry="5.4" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          </g>
+          <g className="fvo-sap fvo-s3">
+            <path d="M118,337 C118,316 116,304 118,290" stroke="url(#fvo-tallo)" strokeWidth="2.6" />
+            <path d="M118,318 C110,314 105,307 104,299" stroke="#9dff3f" strokeWidth="1.7" opacity=".9" />
+            <path d="M118,309 C126,305 131,299 132,291" stroke="#9dff3f" strokeWidth="1.7" opacity=".9" />
+            <ellipse cx="118" cy="287" rx="3.2" ry="5.4" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          </g>
+          <g className="fvo-sap fvo-s4">
+            <path d="M156,338 C156,320 158,308 156,296" stroke="url(#fvo-tallo)" strokeWidth="2.4" />
+            <path d="M156,320 C149,316 144,310 143,302" stroke="#9dff3f" strokeWidth="1.6" opacity=".9" />
+            <path d="M156,313 C163,309 168,303 169,296" stroke="#9dff3f" strokeWidth="1.6" opacity=".9" />
+            <ellipse cx="156" cy="293" rx="3" ry="5" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 5px #9dff3f)' }} />
+          </g>
+          {/* frijol enredado (milpa) */}
+          <path className="fvo-sap fvo-s5" d="M92,336 C88,328 96,324 92,316 C88,308 96,304 93,297" stroke="#4fd8ff" strokeWidth="1.4" opacity=".85" />
+          <circle cx="93" cy="296" r="1.6" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 3px #4fd8ff)' }} />
+          {/* auyama que late */}
+          <g className="fvo-sap fvo-s2">
+            <path d="M196,336 C202,330 212,330 218,334" stroke="#0f8f6c" strokeWidth="1.6" />
+            <ellipse cx="210" cy="331" rx="7" ry="5.4" fill="#132c1e" stroke="#ffb54f" strokeWidth="1.2" style={{ filter: 'drop-shadow(0 0 5px rgba(255,181,79,.7))' }} />
+            <path d="M210,326 C210,323 212,322 213,321" stroke="#9dff3f" strokeWidth="1.2" />
+          </g>
+        </g>
+
+        {/* penachos (flor del maíz) que laten */}
+        <g stroke="#d8ff6a" strokeWidth="1" strokeLinecap="round" fill="none" opacity=".9">
+          <g className="fvo-sap"><path d="M40,286 L36,280" /><path d="M40,286 L40,279" /><path d="M40,286 L44,281" /></g>
+          <g className="fvo-sap fvo-s2"><path d="M78,284 L74,278" /><path d="M78,284 L78,277" /><path d="M78,284 L82,279" /></g>
+          <g className="fvo-sap fvo-s3"><path d="M118,282 L114,276" /><path d="M118,282 L118,275" /><path d="M118,282 L122,277" /></g>
+          <g className="fvo-sap fvo-s4"><path d="M156,288 L152,282" /><path d="M156,288 L156,281" /><path d="M156,288 L160,283" /></g>
+        </g>
+        <circle className="fvo-berry" cx="40" cy="279" r="1.1" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 3px #d8ff6a)' }} />
+        <circle className="fvo-berry fvo-b3" cx="78" cy="277" r="1.1" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 3px #d8ff6a)' }} />
+        <circle className="fvo-berry fvo-b2" cx="118" cy="275" r="1.1" fill="#eafff6" style={{ filter: 'drop-shadow(0 0 3px #d8ff6a)' }} />
+
+        {/* ============ PERSONAJES: campesino con su perro criollo ============ */}
+        {/* pool de luz del farol */}
+        <ellipse className="fvo-lantpool" cx="240" cy="335" rx="17" ry="4.4" fill="#2dffc4" opacity=".4" filter="url(#fvo-blur3)" />
+
+        <g className="fvo-campesino">
+          <ellipse cx="222" cy="336" rx="12" ry="2.6" fill="#000" opacity=".35" />
+          {/* botas */}
+          <path d="M217,325 L216,335" stroke="#0f1424" strokeWidth="4" strokeLinecap="round" />
+          <path d="M226,325 L227,335" stroke="#0f1424" strokeWidth="4" strokeLinecap="round" />
+          <ellipse cx="214.5" cy="335" rx="3" ry="1.5" fill="#0f1424" />
+          <ellipse cx="228.5" cy="335" rx="3" ry="1.5" fill="#0f1424" />
+          {/* brazo trasero */}
+          <path d="M219,312 C214,316 213,320 215,324" stroke="#7a3a24" strokeWidth="3" strokeLinecap="round" fill="none" />
+          {/* ruana / poncho */}
+          <path d="M222,305 L209,328 L235,328 Z" fill="#a85a34" />
+          <path d="M222,305 L209,328 L235,328 Z" fill="none" stroke="#2dffc4" strokeWidth=".6" opacity=".4" />
+          <path d="M214,322 L230,322" stroke="#ffb54f" strokeWidth="1.3" opacity=".85" />
+          <path d="M216,318 L228,318" stroke="#2dffc4" strokeWidth="1" opacity=".7" />
+          <path d="M218,314 L226,314" stroke="#ff8fe4" strokeWidth=".8" opacity=".6" />
+          {/* fleco */}
+          <g stroke="#8a4a2c" strokeWidth=".7" opacity=".9">
+            <path d="M211,328 L210,331" /><path d="M216,328 L216,331.5" /><path d="M222,328 L222,332" />
+            <path d="M228,328 L228,331.5" /><path d="M233,328 L234,331" />
+          </g>
+          {/* cuello */}
+          <rect x="219.4" y="302" width="5.2" height="6" rx="2.2" fill="#7a3a24" />
+          {/* cabeza */}
+          <g className="fvo-head-c">
+            <circle cx="222" cy="302" r="4.2" fill="#d99a6c" />
+            <path d="M220.2,303.4 Q222,305 223.8,303.4" stroke="#7a3a24" strokeWidth=".7" fill="none" strokeLinecap="round" />
+            <circle cx="220.4" cy="301.4" r=".55" fill="#3a2416" /><circle cx="223.6" cy="301.4" r=".55" fill="#3a2416" />
+            {/* sombrero aguadeño */}
+            <path d="M217,298.5 Q222,290.5 227,298.5 Z" fill="#cdb87a" />
+            <path d="M217.6,297.6 L226.4,297.6" stroke="#a8935a" strokeWidth=".9" />
+            <ellipse cx="222" cy="299" rx="9.5" ry="2.7" fill="#d8c48a" />
+            <ellipse cx="222" cy="299" rx="9.5" ry="2.7" fill="none" stroke="#2dffc4" strokeWidth=".5" opacity=".45" />
+            <ellipse cx="222" cy="298.4" rx="9.5" ry="2.4" fill="#e2d199" opacity=".5" />
+          </g>
+          {/* brazo delantero con el farol (se mece) */}
+          <g className="fvo-lantern">
+            <path d="M224,309 C230,309 235,311 237,314" stroke="#7a3a24" strokeWidth="3" strokeLinecap="round" fill="none" />
+            <line x1="237.5" y1="312.5" x2="238" y2="321" stroke="#5a3020" strokeWidth="1" />
+            <path d="M234,325 A4.2,4.2 0 0 1 242,325" fill="none" stroke="#0e3324" strokeWidth=".7" />
+            <circle className="fvo-lantorb" cx="238" cy="325.5" r="4.4" fill="#bfffe9" style={{ filter: 'drop-shadow(0 0 9px #2dffc4)' }} />
+            <circle cx="238" cy="325.5" r="1.9" fill="#eafff6" />
+            <line x1="238" y1="321" x2="238" y2="330" stroke="#0e3324" strokeWidth=".55" opacity=".8" />
+          </g>
+        </g>
+
+        {/* perro criollo */}
+        <g className="fvo-dog">
+          <ellipse cx="248" cy="336" rx="8" ry="1.8" fill="#000" opacity=".3" />
+          <path d="M244,331 L244,335.5" stroke="#8a5a34" strokeWidth="1.7" strokeLinecap="round" />
+          <path d="M251,331 L251,335.5" stroke="#8a5a34" strokeWidth="1.7" strokeLinecap="round" />
+          <path className="fvo-tail" d="M241,329 C236,327 235,330.5 237,332.5" stroke="#a56b3c" strokeWidth="1.8" fill="none" strokeLinecap="round" />
+          <ellipse cx="246" cy="330" rx="6.2" ry="3.3" fill="#a56b3c" />
+          <circle cx="252.5" cy="327.5" r="3.1" fill="#b5763f" />
+          <path className="fvo-earw" d="M251,325 Q249,321.5 251.2,320.6 Q253,323 252,326 Z" fill="#7f5230" />
+          <path d="M254.5,328 L258,328.6 L254.5,330.2 Z" fill="#7f5230" />
+          <circle cx="257.4" cy="328.7" r=".8" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 2px #2dffc4)' }} />
+          <circle cx="253.4" cy="326.8" r=".55" fill="#2a1a10" />
+          <path d="M250,329.5 Q252.5,331.4 255,329.4" stroke="#2dffc4" strokeWidth=".8" fill="none" opacity=".8" />
+        </g>
+
+        {/* polillas rondando el farol (la luz siempre convoca su corte) */}
+        <circle className="fvo-polilla" cx="233" cy="318" r="1" fill="#eafff6" opacity=".8" />
+        <circle className="fvo-polilla fvo-po2" cx="244" cy="321" r=".8" fill="#ffe6c9" opacity=".75" />
+
+        {/* cocuyos */}
+        <circle className="fvo-fly" cx="100" cy="272" r="1.7" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 4px #d8ff6a)' }} />
+        <circle className="fvo-fly fvo-f2" cx="210" cy="258" r="1.5" fill="#2dffc4" style={{ filter: 'drop-shadow(0 0 4px #2dffc4)' }} />
+        <circle className="fvo-fly fvo-f3" cx="172" cy="300" r="1.4" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 4px #ff4fd8)' }} />
+        <circle className="fvo-fly fvo-f4" cx="248" cy="318" r="1.6" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 4px #d8ff6a)' }} />
+        <circle className="fvo-fly fvo-f5" cx="30" cy="290" r="1.4" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 4px #4fd8ff)' }} />
+        <circle className="fvo-fly fvo-f2" style={{ animationDelay: '-6s, -1.8s', filter: 'drop-shadow(0 0 4px #d8ff6a)' }} cx="140" cy="264" r="1.3" fill="#d8ff6a" />
+        <circle className="fvo-fly fvo-f3" style={{ animationDelay: '-2.4s, -1.1s', filter: 'drop-shadow(0 0 4px #ff8fe4)' }} cx="356" cy="304" r="1.4" fill="#ff8fe4" />
+      </g>
+
+      {/* niebla de páramo */}
+      <g>
+        <ellipse className="fvo-fog" cx="90" cy="250" rx="120" ry="16" fill="#9fd4ff" opacity=".07" filter="url(#fvo-blur8)" />
+        <ellipse className="fvo-fog fvo-g2" cx="270" cy="240" rx="140" ry="14" fill="#b28dff" opacity=".06" filter="url(#fvo-blur8)" />
+        <ellipse className="fvo-fog fvo-g3" cx="180" cy="262" rx="150" ry="12" fill="#eafff6" opacity=".05" filter="url(#fvo-blur8)" />
+      </g>
+
+      {/* ============ CORTE DE SUELO: LA RED VIVA ============ */}
+      <rect y="336" width="390" height="150" fill="url(#fvo-suelo)" />
+      {/* borde del suelo: interfase viva */}
+      <path d="M0,336 L390,336" stroke="#2dffc4" strokeWidth="1.4" opacity=".55" />
+      <path d="M0,338.5 L390,338.5" stroke="#ff4fd8" strokeWidth=".7" opacity=".25" />
+
+      {/* piedras */}
+      <ellipse cx="60" cy="392" rx="13" ry="8" fill="#0d1226" />
+      <ellipse cx="330" cy="380" rx="10" ry="6.5" fill="#0d1226" />
+      <ellipse cx="140" cy="440" rx="15" ry="9" fill="#0b0f20" />
+      <ellipse cx="285" cy="448" rx="11" ry="7" fill="#0b0f20" />
+
+      <g className="fvo-net">
+        {/* hifas principales (desde el corazón) */}
+        <g fill="none" stroke="#2dffc4" strokeWidth="1.5" opacity=".8" style={{ filter: 'drop-shadow(0 0 3px rgba(45,255,196,.5))' }}>
+          <path className="fvo-hypha" d="M195,405 C160,392 120,380 78,352" />
+          <path className="fvo-hypha fvo-slow" d="M195,405 C230,388 268,375 300,350" />
+          <path className="fvo-hypha" d="M195,405 C185,378 172,360 150,344" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M195,405 C205,382 220,362 240,348" />
+          <path className="fvo-hypha fvo-rev" d="M195,405 C240,420 300,432 368,424" />
+          <path className="fvo-hypha fvo-slow" d="M195,405 C150,428 90,440 24,430" />
+          <path className="fvo-hypha" d="M195,405 C196,432 190,455 178,474" />
+        </g>
+        {/* hifas secundarias */}
+        <g fill="none" stroke="#4fd8ff" strokeWidth=".9" opacity=".5">
+          <path className="fvo-hypha fvo-slow" d="M78,352 C60,348 45,342 38,338" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M78,352 C86,346 100,342 116,340" />
+          <path className="fvo-hypha fvo-slow" d="M300,350 C315,344 330,340 344,338" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M300,350 C290,344 278,341 264,339" />
+          <path className="fvo-hypha fvo-slow" d="M240,348 C246,344 252,341 258,339" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M150,344 C140,341 130,339 120,338" />
+          <path className="fvo-hypha fvo-slow" d="M368,424 C376,418 382,410 386,400" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M24,430 C18,422 14,412 12,402" />
+        </g>
+        {/* hifas profundas magenta */}
+        <g fill="none" stroke="#ff4fd8" strokeWidth=".8" opacity=".4">
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M178,474 C150,468 120,466 92,470" />
+          <path className="fvo-hypha fvo-slow" d="M178,474 C210,468 250,466 286,470" />
+          <path className="fvo-hypha fvo-slow" d="M195,440 C160,450 130,452 104,448" />
+          <path className="fvo-hypha fvo-slow fvo-rev" d="M195,440 C235,450 270,452 300,446" />
+        </g>
+
+        {/* micelio FINO: la trama dendrítica de verdad — hifas delgadas que se
+            ramifican en Y desde las troncales y tejen el suelo entero (así se
+            ve una red micorrízica real, no solo cables gruesos) */}
+        <g className="fvo-micelio" fill="none" stroke="#2dffc4" strokeWidth=".6" opacity=".38" strokeLinecap="round">
+          <path d="M160,392 C150,388 142,382 138,374 M138,374 C134,368 128,364 120,362 M138,374 C142,366 140,358 136,352" />
+          <path d="M230,390 C242,384 250,376 254,366 M254,366 C258,358 266,354 274,352 M254,366 C250,356 252,348 258,342" />
+          <path d="M195,428 C186,434 176,438 164,440 M164,440 C154,442 146,448 142,456 M164,440 C160,448 162,456 168,462" />
+          <path d="M195,428 C206,434 216,438 228,440 M228,440 C240,442 248,448 252,456 M228,440 C234,448 232,456 226,462" />
+          <path d="M120,404 C108,400 98,400 88,404 M88,404 C78,408 70,406 62,400 M88,404 C84,412 78,416 70,418" />
+          <path d="M270,406 C282,402 292,402 302,406 M302,406 C312,410 320,408 328,402 M302,406 C306,414 312,418 320,420" />
+          <path d="M78,352 C74,362 68,370 60,376 M60,376 C54,380 50,386 48,394" />
+          <path d="M300,350 C304,360 310,368 318,374 M318,374 C324,378 328,384 330,392" />
+          <path d="M156,350 C152,358 146,364 138,368 M138,368 C132,371 128,376 126,382" />
+          <path d="M240,348 C244,356 250,362 258,366 M258,366 C264,369 268,374 270,380" />
+          <path d="M40,348 C38,358 34,366 28,372" />
+          <path d="M118,349 C120,358 124,366 130,372" />
+        </g>
+
+        {/* bulbos de raíz (bajo cada planta) */}
+        <g>
+          <circle cx="40" cy="348" r="9" fill="url(#fvo-bulbo)" /><circle cx="40" cy="348" r="2.2" fill="#bfffe9" />
+          <circle cx="78" cy="352" r="10" fill="url(#fvo-bulbo)" /><circle cx="78" cy="352" r="2.4" fill="#bfffe9" />
+          <circle cx="118" cy="349" r="9" fill="url(#fvo-bulbo)" /><circle cx="118" cy="349" r="2.2" fill="#bfffe9" />
+          <circle cx="156" cy="350" r="8" fill="url(#fvo-bulbo)" /><circle cx="156" cy="350" r="2" fill="#bfffe9" />
+          <circle cx="240" cy="348" r="8" fill="url(#fvo-bulbo)" /><circle cx="240" cy="348" r="2" fill="#bfffe9" />
+          <circle cx="300" cy="350" r="11" fill="url(#fvo-bulbo)" /><circle cx="300" cy="350" r="2.6" fill="#bfffe9" />
+        </g>
+        {/* raíces cortas planta→bulbo */}
+        <g stroke="#2dffc4" strokeWidth="1" opacity=".55" fill="none">
+          <path d="M40,336 L40,346" /><path d="M78,338 L78,350" /><path d="M118,337 L118,347" />
+          <path d="M156,338 L156,348" /><path d="M210,336 C214,340 222,344 240,347" />
+          <path d="M298,332 C298,338 299,344 300,348" />
+        </g>
+        {/* raíces LATERALES de cada planta: el bulbo no flota — la raíz se
+            ramifica y la hifa la encuentra en la punta (micorriza real) */}
+        <g stroke="#9dff3f" strokeWidth=".8" opacity=".5" fill="none" strokeLinecap="round">
+          <path d="M40,346 C36,352 32,356 26,358 M40,346 C44,352 48,355 54,356" />
+          <path d="M78,350 C72,356 66,360 58,362 M78,350 C84,356 90,359 98,360" />
+          <path d="M118,347 C112,353 106,357 98,359 M118,347 C124,353 130,356 138,357" />
+          <path d="M156,348 C151,354 146,357 140,359 M156,348 C161,354 166,357 172,358" />
+          <path d="M240,347 C235,353 230,356 224,358 M240,347 C245,353 250,356 256,357" />
+          <path d="M300,348 C294,355 287,359 278,361 M300,348 C306,355 313,359 322,361" />
+        </g>
+        {/* nodos micorrízicos: el punto donde la hifa abraza la punta de la
+            raíz e intercambia azúcar por nutrientes (titilan suave) */}
+        <g fill="#bfffe9">
+          <circle className="fvo-nodo" cx="26" cy="358" r="1" />
+          <circle className="fvo-nodo fvo-n2" cx="58" cy="362" r="1.1" />
+          <circle className="fvo-nodo fvo-n3" cx="98" cy="359.5" r="1" />
+          <circle className="fvo-nodo" cx="140" cy="359" r="1" />
+          <circle className="fvo-nodo fvo-n2" cx="224" cy="358" r="1" />
+          <circle className="fvo-nodo fvo-n3" cx="278" cy="361" r="1.1" />
+          <circle className="fvo-nodo fvo-n2" cx="322" cy="361" r="1.1" />
+        </g>
+      </g>
+
+      {/* ============ LA VIDA DEL SUELO: lombrices y bichitos ============ */}
+      {/* lombriz de tierra (rosada, segmentada, con clitelo) que avanza */}
+      <g className="fvo-lombriz">
+        <path d="M96,432 C104,428 112,432 118,428 C124,424 130,427 134,432" fill="none" stroke="#ff8fb0" strokeWidth="3.4" strokeLinecap="round" opacity=".85" />
+        <path d="M96,432 C104,428 112,432 118,428 C124,424 130,427 134,432" fill="none" stroke="#ffd0dc" strokeWidth="1" strokeLinecap="round" opacity=".5" />
+        {/* segmentos */}
+        <g stroke="#e06a8e" strokeWidth=".7" opacity=".6">
+          <path d="M102,428.6 L102.6,431.6" /><path d="M108,429 L108,432" /><path d="M122,426.4 L122.6,429.2" /><path d="M128,426.6 L128,429.6" />
+        </g>
+        {/* clitelo (el anillo grueso) */}
+        <path d="M112,430.4 L116,429" stroke="#ff6f8a" strokeWidth="3.8" strokeLinecap="round" />
+      </g>
+      <g className="fvo-lombriz fvo-l2">
+        <path d="M330,472 C324,468 318,471 312,468 C306,465 300,468 296,472" fill="none" stroke="#ff8fb0" strokeWidth="3" strokeLinecap="round" opacity=".8" />
+        <path d="M314,469.4 L310,468.4" stroke="#ff6f8a" strokeWidth="3.4" strokeLinecap="round" />
+        <g stroke="#e06a8e" strokeWidth=".6" opacity=".55">
+          <path d="M324,469 L324,471.6" /><path d="M304,467 L304,469.6" />
+        </g>
+      </g>
+
+      {/* escarabajo del suelo (camina despacio entre las piedras) */}
+      <g className="fvo-bicho">
+        <ellipse cx="66" cy="416" rx="3.4" ry="2.3" fill="#4fd8ff" opacity=".75" />
+        <circle cx="70" cy="415.4" r="1.3" fill="#2f9fc4" />
+        <path d="M63,414.6 Q66,413.2 69,414.4" stroke="#bfeaff" strokeWidth=".5" fill="none" opacity=".7" />
+        <g stroke="#4fd8ff" strokeWidth=".6" opacity=".7" fill="none">
+          <path d="M64,418 L62,420" /><path d="M66,418.4 L65,421" /><path d="M68,418 L69,420.6" />
+        </g>
+      </g>
+      {/* colémbolo (bichito saltarín, descompone la hojarasca) */}
+      <g className="fvo-bicho fvo-bi2">
+        <ellipse cx="330" cy="446" rx="2.6" ry="1.7" fill="#d8ff6a" opacity=".8" />
+        <circle cx="332.6" cy="445.4" r=".9" fill="#9dff3f" />
+        <path d="M327.6,445.4 Q326,444 325.2,442.6" stroke="#d8ff6a" strokeWidth=".7" fill="none" opacity=".8" />
+      </g>
+
+      {/* ============ CORAZÓN-SEMILLA MICORRÍZICO (la vida bajo la tierra) ============
+          Con `onPregunte` el corazón entero es un BOTÓN (tap / Enter / Espacio)
+          que abre el agente — el mismo patrón del potrero→animales: la metáfora
+          central deja de ser decoración y pasa a ser LA acción de preguntar.
+          Sin handler queda como arte (aria-hidden, sin foco). */}
+      <g
+        className={`fvo-corazon-grupo${conPregunte ? ' fvo-corazon-tap' : ''}`}
+        data-testid="fvo-corazon"
+        {...(conPregunte
+          ? {
+              role: 'button',
+              tabIndex: 0,
+              'aria-label': 'El corazón de su finca: toque y pregúntele a Chagra con su voz.',
+              onClick: () => onPregunte(),
+              onKeyDown: (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onPregunte();
+                }
+              },
+            }
+          : { 'aria-hidden': true })}
+      >
+      {/* cámara de suelo: da contexto y contraste al órgano */}
+      <ellipse cx="195" cy="406" rx="42" ry="36" fill="#02040c" opacity=".55" />
+      <ellipse cx="195" cy="406" rx="42" ry="36" fill="none" stroke="#0f3a30" strokeWidth="1" opacity=".55" />
+      {/* halo-invitación del tap (solo cuando el corazón es botón) */}
+      {conPregunte && (
+        <circle className="fvo-corazon-halo" cx="195" cy="406" r="32" fill="none" stroke="#2dffc4" strokeWidth="1.2" opacity=".5" />
+      )}
+      {/* ondas de latido */}
+      <circle className="fvo-heart-wave" cx="195" cy="406" r="24" fill="none" stroke="#2dffc4" strokeWidth="1.6" />
+      <circle className="fvo-heart-wave" style={{ animationDelay: '.6s' }} cx="195" cy="406" r="24" fill="none" stroke="#ff4fd8" strokeWidth="1" />
+      {/* resplandor contenido */}
+      <circle className="fvo-heart" cx="195" cy="406" r="15" fill="url(#fvo-corazon)" />
+
+      {/* cuellos de raíz gruesos: las micorrizas nacen visiblemente de la semilla */}
+      <g className="fvo-net" stroke="#2dffc4" strokeLinecap="round" fill="none" style={{ filter: 'drop-shadow(0 0 4px rgba(45,255,196,.6))' }}>
+        <path strokeWidth="3" d="M195,406 L182,399" />
+        <path strokeWidth="3" d="M195,406 L208,399" />
+        <path strokeWidth="2.6" d="M195,406 L187,395" />
+        <path strokeWidth="2.6" d="M195,406 L204,395" />
+        <path strokeWidth="2.6" d="M195,406 L210,407" />
+        <path strokeWidth="2.6" d="M195,406 L180,408" />
+        <path strokeWidth="2.6" d="M195,406 L192,420" />
+      </g>
+
+      {/* SEMILLA que germina: forma reconocible = origen de la vida */}
+      {/* radícula (taproot) hacia abajo */}
+      <path d="M195,423 C195,431 193,437 189,443" stroke="#2dffc4" strokeWidth="1.5" fill="none" strokeLinecap="round" opacity=".85" style={{ filter: 'drop-shadow(0 0 3px #2dffc4)' }} />
+      <path d="M195,428 C197,431 200,432 203,432" stroke="#2dffc4" strokeWidth="1" fill="none" strokeLinecap="round" opacity=".7" />
+      {/* brote hacia la superficie */}
+      <path d="M195,390 C195,383 193,379 189,376" stroke="#9dff3f" strokeWidth="1.7" fill="none" strokeLinecap="round" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+      <path d="M195,384 C198,381 201,380 204,381" stroke="#9dff3f" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <circle cx="188.6" cy="375.6" r="1.5" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+      <circle cx="204.3" cy="380.6" r="1.3" fill="#d8ff6a" style={{ filter: 'drop-shadow(0 0 3px #9dff3f)' }} />
+      {/* cuerpo de la semilla (late) */}
+      <g className="fvo-heart">
+        <path d="M195,390 C206,396 206,416 195,424 C184,416 184,396 195,390 Z" fill="#0e5a44" stroke="#2dffc4" strokeWidth="1.5" style={{ filter: 'drop-shadow(0 0 6px rgba(45,255,196,.55))' }} />
+        <path d="M195,392 L195,422" stroke="#2dffc4" strokeWidth=".8" opacity=".55" />
+        <circle cx="195" cy="407" r="9.5" fill="#bfffe9" opacity=".3" />
+        <circle cx="195" cy="407" r="5.2" fill="#eafff6" />
+        <circle cx="195" cy="407" r="2.2" fill="#ff8fe4" />
+      </g>
+      {/* cierre del grupo tappable del corazón (la etiqueta va aparte, abajo) */}
+      </g>
+
+      {/* nutrientes viajando */}
+      <circle className="fvo-spark fvo-p1" r="2.2" fill="#bfffe9" />
+      <circle className="fvo-spark fvo-p2" r="2.2" fill="#bfffe9" />
+      <circle className="fvo-spark fvo-p3" r="1.9" fill="#d8ff6a" />
+      <circle className="fvo-spark fvo-p4" r="1.9" fill="#ffb54f" />
+      <circle className="fvo-spark fvo-p5" r="1.9" fill="#ff9ee8" />
+      <circle className="fvo-spark fvo-p6" r="2.2" fill="#bfffe9" />
+
+      {/* el pocito se FILTRA: el agua alimenta la red micorrízica (gotea al
+          bulbo más cercano — la quebrada también es parte del organismo) */}
+      <g aria-hidden="true">
+        <path className="fvo-hypha fvo-slow" d="M20,336 C26,342 32,346 38,348" fill="none" stroke="#4fd8ff" strokeWidth=".9" opacity=".5" />
+        <g stroke="#4fd8ff" strokeWidth=".8" strokeLinecap="round" opacity=".35">
+          <path d="M10,338 L9,344" /><path d="M18,339 L17.4,346" /><path d="M27,338 L26.4,343" />
+        </g>
+      </g>
+
+      {/* hongos bioluminiscentes en el borde del corte */}
+      <g>
+        <g transform="translate(58,336)">
+          <path d="M0,0 L0,-7" stroke="#9fd4ff" strokeWidth="2" strokeLinecap="round" opacity=".8" />
+          <path className="fvo-cap" d="M-7,-6 A7,4.6 0 0 1 7,-6 Z" fill="#4fd8ff" style={{ filter: 'drop-shadow(0 0 6px #4fd8ff)' }} />
+          <path d="M4,0 L4,-5" stroke="#9fd4ff" strokeWidth="1.6" strokeLinecap="round" opacity=".7" />
+          <path className="fvo-cap fvo-c2" d="M-.5,-4.4 A4.5,3 0 0 1 8.5,-4.4 Z" fill="#b28dff" style={{ filter: 'drop-shadow(0 0 5px #b28dff)' }} />
+          <circle className="fvo-spore" cx="0" cy="-10" r="1" fill="#bfeaff" />
+          <circle className="fvo-spore fvo-sp2" cx="4" cy="-9" r=".8" fill="#dcc9ff" />
+          <circle className="fvo-spore fvo-sp3" cx="-3" cy="-9" r=".8" fill="#bfeaff" />
+        </g>
+        <g transform="translate(356,336)">
+          <path d="M0,0 L0,-8" stroke="#ff9ee8" strokeWidth="2" strokeLinecap="round" opacity=".8" />
+          <path className="fvo-cap fvo-c2" d="M-8,-7 A8,5 0 0 1 8,-7 Z" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 6px #ff4fd8)' }} />
+          <path d="M-5,0 L-5,-5" stroke="#ff9ee8" strokeWidth="1.5" strokeLinecap="round" opacity=".7" />
+          <path className="fvo-cap" d="M-9,-4.4 A4.4,3 0 0 1 -.6,-4.4 Z" fill="#ffb54f" style={{ filter: 'drop-shadow(0 0 5px #ffb54f)' }} />
+          <circle className="fvo-spore fvo-sp2" cx="0" cy="-11" r="1" fill="#ffd9f4" />
+          <circle className="fvo-spore" cx="-5" cy="-9" r=".8" fill="#ffe6c9" />
+          <circle className="fvo-spore fvo-sp3" cx="3" cy="-10" r=".8" fill="#ffd9f4" />
+        </g>
+      </g>
+
+      {/* etiqueta viva — con el corazón tappable invita a la acción (y deja
+          la jerga de laboratorio: "micorrízica" no es palabra del campo) */}
+      <g fontFamily="ui-monospace,monospace" fontSize="7.5" letterSpacing="2" opacity=".65" aria-hidden="true">
+        <text x="195" y="452" fill="#2dffc4" textAnchor="middle">CORAZÓN DE LA FINCA · VIVO</text>
+        <text x="195" y="464" fill="#5b7f93" textAnchor="middle" letterSpacing="1">
+          {conPregunte ? 'toque el corazón y pregúntele a Chagra' : 'las raíces de su finca están conectadas'}
+        </text>
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * GallinaLuz — gallina criolla bioluminiscente del potrero. Picotea con el
+ * ritmo de su clase (`fvo-gallina` + variante) — la animación vive en
+ * scene-finca-organismo.css. Coordenadas locales: el (0,0) es el piso bajo
+ * el cuerpo; mira a la DERECHA salvo `espejo` (que también invierte el
+ * sentido del picoteo vía la clase `fvo-ga-esp`).
+ *
+ * @param {Object} props
+ * @param {number} props.x posición (viewBox) del piso bajo la gallina.
+ * @param {number} props.y ídem.
+ * @param {string} props.cuerpo color del plumaje.
+ * @param {string} props.cola color de la cola/ala (más oscuro).
+ * @param {string} [props.clase] variante de ritmo (fvo-ga2 / fvo-ga3).
+ * @param {boolean} [props.espejo] mirar a la izquierda.
+ */
+function GallinaLuz({ x, y, cuerpo, cola, clase = '', espejo = false }) {
+  return (
+    /* el translate vive en su PROPIO <g>: la animación CSS (transform) del
+       picoteo PISARÍA el atributo transform si compartieran elemento y la
+       gallina se iría al origen del SVG (bug real de la 1.ª pasada). */
+    <g transform={`translate(${x},${y})`} aria-hidden="true">
+      <ellipse cx="0" cy=".6" rx="4.2" ry="1" fill="#000" opacity=".3" />
+      <g className={`fvo-gallina ${clase}${espejo ? ' fvo-ga-esp' : ''}`.trim()}>
+        <g transform={espejo ? 'scale(-1,1)' : undefined}>
+          {/* patas */}
+          <g stroke="#d8ff6a" strokeWidth=".9" strokeLinecap="round" opacity=".9">
+            <path d="M-1.2,-2.2 L-1.4,0" /><path d="M1.4,-2.2 L1.6,0" />
+          </g>
+          {/* cola */}
+          <path d="M-4.2,-6.5 Q-7.6,-9.5 -6.6,-12 Q-3.6,-10 -3.2,-7 Z" fill={cola} />
+          {/* cuerpo */}
+          <path
+            d="M-4.8,-5.5 C-4.6,-8.6 -1.6,-10.2 1.2,-9.6 C4.4,-9 5.6,-6.4 4.4,-4 C3.2,-1.8 -1.2,-1.4 -3.4,-3 C-4.4,-3.8 -4.9,-4.5 -4.8,-5.5 Z"
+            fill={cuerpo}
+            stroke="#eafff6"
+            strokeWidth=".4"
+            strokeOpacity=".3"
+          />
+          {/* ala */}
+          <path d="M-2.8,-6 Q-.4,-8 2,-6.2 Q-.2,-4.6 -2.8,-6 Z" fill={cola} opacity=".85" />
+          {/* cabeza con cresta neón */}
+          <circle cx="4.6" cy="-10.6" r="2.2" fill={cuerpo} />
+          <path d="M3.6,-12.6 Q3.9,-14.4 5.2,-14 Q5.6,-12.6 4.9,-12.2 Z" fill="#ff4fd8" style={{ filter: 'drop-shadow(0 0 2px #ff4fd8)' }} />
+          <path d="M6.7,-10.8 L9,-10 L6.7,-9.4 Z" fill="#ffd76a" />
+          <circle cx="5.9" cy="-9" r=".7" fill="#ff4fd8" opacity=".8" />
+          <circle cx="5.2" cy="-11" r=".55" fill="#0a0618" />
+          <circle cx="5.4" cy="-11.2" r=".2" fill="#eafff6" />
+        </g>
+      </g>
+    </g>
+  );
+}

--- a/src/visual/scenes/__tests__/scenes.smoke.test.jsx
+++ b/src/visual/scenes/__tests__/scenes.smoke.test.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import {
+  CapaCielo,
+  Parallax,
+  CAPAS_PARALLAX,
+  transformCapa,
+  cieloEscena,
+  tonoLuz,
+  GuardianEspirituBase,
+  SceneFincaOrganismo,
+  SCENES,
+  SCN_BEAT_MS,
+  SCN_KRAFT_CLASS,
+} from '../index.js';
+
+afterEach(() => cleanup());
+
+describe('src/visual/scenes — smoke de las escenas base', () => {
+  test('CapaCielo monta dentro de un <svg> (noche y día) sin romper', () => {
+    const { container, rerender } = render(
+      <svg viewBox="0 0 390 360">
+        <CapaCielo cielo={{ luz: 'noche', condicion: 'despejado', tema: 'biopunk' }} cx={300} cy={70} r={26} />
+      </svg>,
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    // de día con lluvia: aparece la cortina de lluvia
+    rerender(
+      <svg viewBox="0 0 390 360">
+        <CapaCielo cielo={{ luz: 'dia', condicion: 'lluvia' }} cx={300} cy={70} r={26} />
+      </svg>,
+    );
+    expect(container.querySelector('.scn-lluvia')).toBeInTheDocument();
+  });
+
+  test('Parallax apila una capa por cada entrada con su transform', () => {
+    const camara = { tx: 10, ty: 20, s: 1.1 };
+    const { getByTestId } = render(
+      <Parallax
+        camara={camara}
+        alturaCapa={700}
+        data-testid="px"
+        capas={[
+          { id: 'cielo', f: CAPAS_PARALLAX.cielo, contenido: <div className="c-cielo" /> },
+          { id: 'principal', f: CAPAS_PARALLAX.principal, interactiva: true, contenido: <div className="c-pral" /> },
+        ]}
+      />,
+    );
+    const capas = getByTestId('px').querySelectorAll('.scn-capa');
+    expect(capas).toHaveLength(2);
+    expect(capas[0].style.transform).toBe(transformCapa(camara, CAPAS_PARALLAX.cielo));
+    expect(capas[1].className).toContain('scn-capa--interactiva');
+  });
+
+  test('GuardianEspirituBase monta el disco con glow y su avatar hijo', () => {
+    const { container } = render(
+      <GuardianEspirituBase acc="#2dffc4" accRgb="45, 255, 196" title="Chivito de páramo">
+        <g className="mi-avatar" filter="url(#scn-ge-glow)"><circle r="4" /></g>
+      </GuardianEspirituBase>,
+    );
+    expect(container.querySelector('.scn-espiritu-halo')).toBeInTheDocument();
+    expect(container.querySelector('#scn-ge-glow')).toBeInTheDocument();
+    expect(container.querySelector('.mi-avatar')).toBeInTheDocument();
+  });
+
+  test('SceneFincaOrganismo (re-exportada desde el barrel) monta el corazón', () => {
+    const { getByTestId } = render(<SceneFincaOrganismo estructura={{ tiene: false }} />);
+    expect(getByTestId('fvo-corazon')).toBeInTheDocument();
+  });
+
+  test('helpers puros: tonoLuz y cieloEscena resuelven la hora/tema', () => {
+    expect(tonoLuz({ luz: 'atardecer' })).toBe('atardecer');
+    expect(tonoLuz({ luz: 'nada-raro' })).toBe('dia');
+    expect(cieloEscena({ luz: 'noche', tema: 'biopunk' }, 'finca')).toEqual(['#0c1830', '#26404d']);
+    expect(cieloEscena({ luz: 'dia' }, 'finca')).toEqual(['#7ac3da', '#c8e8cb']);
+  });
+
+  test('registro SCENES y constantes exportadas', () => {
+    expect(Object.keys(SCENES)).toEqual(
+      expect.arrayContaining(['capa-cielo', 'parallax', 'guardian-espiritu', 'finca-organismo']),
+    );
+    expect(SCN_BEAT_MS).toBe(5200);
+    expect(SCN_KRAFT_CLASS).toBe('scn-kraft');
+  });
+});

--- a/src/visual/scenes/_cielo.js
+++ b/src/visual/scenes/_cielo.js
@@ -1,0 +1,100 @@
+/*
+ * Helpers y tablas de la capa cielo paramétrica (interno de la librería). Vive
+ * aparte del componente para no romper el fast-refresh de Vite (un archivo con
+ * componente no debe exportar también funciones). Lo consume `CieloParametrico`
+ * y se re-exporta desde el barrel.
+ */
+
+/** ¿Es de noche? (luna + estrellas en vez de sol). */
+export function esNoche(cielo) { return cielo?.luz === 'noche'; }
+
+/** ¿Cielo cubierto/lluvia? (velo + nubes densas). */
+export function esCubierto(cielo) {
+  return cielo?.condicion === 'nublado' || cielo?.condicion === 'lluvia' || cielo?.condicion === 'niebla';
+}
+
+/**
+ * Tono de luz de la escena: cada tono tiene su cielo (el amanecer y el atardecer
+ * —las horas más bellas del campo— dejan de pintarse como mediodía). Mismo dato
+ * de siempre (deriveAtmosphere → luz), sin motor nuevo.
+ * @returns {'dia'|'noche'|'amanecer'|'atardecer'}
+ */
+export function tonoLuz(cielo) {
+  const l = cielo?.luz;
+  return (l === 'noche' || l === 'amanecer' || l === 'atardecer') ? l : 'dia';
+}
+
+/**
+ * Cielos por escena y por tono de luz [stop alto, stop bajo]. El degradado de la
+ * escena acompaña la hora real: dorado al amanecer, brasa al atardecer, fresco
+ * al mediodía, navy profundo de noche.
+ */
+export const CIELOS_ESCENA = {
+  finca: {
+    dia: ['#7ac3da', '#c8e8cb'],
+    amanecer: ['#e9a06c', '#fbe9c2'],
+    atardecer: ['#d97a4e', '#f6d99e'],
+    noche: ['#121f3d', '#3d5560'],
+  },
+  balcon: {
+    dia: ['#8fd0e8', '#dff0e3'],
+    amanecer: ['#eeb083', '#fdeccb'],
+    atardecer: ['#e08a5c', '#f9dfae'],
+    noche: ['#1d2b4a', '#46566b'],
+  },
+  invernadero: {
+    dia: ['#90cce0', '#d4ecd6'],
+    amanecer: ['#edac7e', '#fceac6'],
+    atardecer: ['#df845a', '#f8dda8'],
+    noche: ['#1d2b4a', '#465a64'],
+  },
+};
+
+/**
+ * CIELOS POR TEMA — la piel del tema DENTRO de la escena. Cada tema fija el cielo
+ * interno por tono de luz; se aplica ANTES que la tabla por escena (fallback sin
+ * tema). El grade/textura por tema del CSS completa la piel.
+ */
+export const CIELOS_TEMA = {
+  biopunk: {
+    dia: ['#16324f', '#2b5a63'],
+    amanecer: ['#3b2f5e', '#b06a55'],
+    atardecer: ['#3a2440', '#c25c4a'],
+    noche: ['#0c1830', '#26404d'],
+  },
+  // biopunk2 comparte la piel biopunk (mismo cielo interno).
+  biopunk2: {
+    dia: ['#16324f', '#2b5a63'],
+    amanecer: ['#3b2f5e', '#b06a55'],
+    atardecer: ['#3a2440', '#c25c4a'],
+    noche: ['#0c1830', '#26404d'],
+  },
+  'verde-vivo': {
+    dia: ['#79c9b7', '#e2f0cf'],
+    amanecer: ['#ecb27a', '#f6ecc4'],
+    atardecer: ['#dd8455', '#f3d99b'],
+    noche: ['#183253', '#3e5a63'],
+  },
+  nature: {
+    dia: ['#d9c493', '#f2e8cd'],
+    amanecer: ['#e0a066', '#f7e6c0'],
+    atardecer: ['#c97a45', '#efd6a0'],
+    noche: ['#26243d', '#5a4a58'],
+  },
+  minimalista: {
+    dia: ['#cfdcd2', '#f3f1e8'],
+    amanecer: ['#e3c3a3', '#f5eddd'],
+    atardecer: ['#d8a887', '#f0e2c8'],
+    noche: ['#31394a', '#5d6672'],
+  },
+};
+
+/** Stops [alto, bajo] del degradado de cielo para una escena y su hora/tema. */
+export function cieloEscena(cielo, escena) {
+  const tono = tonoLuz(cielo);
+  // Piel por tema primero (cielo.tema lo inyecta el hero desde useTheme).
+  const porTema = CIELOS_TEMA[cielo?.tema]?.[tono];
+  if (porTema) return porTema;
+  const mapa = CIELOS_ESCENA[escena] || CIELOS_ESCENA.finca;
+  return mapa[tono] || mapa.dia;
+}

--- a/src/visual/scenes/_parallax.js
+++ b/src/visual/scenes/_parallax.js
@@ -1,0 +1,49 @@
+/*
+ * Helpers del motor de parallax (interno de la librería). Vive aparte del
+ * componente para no romper el fast-refresh de Vite. Lo consume `Parallax` y se
+ * re-exporta desde el barrel.
+ */
+import { useEffect, useState } from 'react';
+
+/**
+ * Factores de parallax por capa (semilla MontanaMundosCine): cuánto viaja cada
+ * capa respecto a la principal. `< 1` = lejos (se mueve menos) · `> 1` = más
+ * cerca que el plano principal. De lejos a cerca.
+ */
+export const CAPAS_PARALLAX = {
+  cielo: 0.1,
+  lejos: 0.22,
+  medio: 0.45,
+  principal: 1,
+  niebla: 1.12,
+  cerca: 1.3,
+};
+
+/**
+ * Transform de una capa dada la cámara base `{ tx, ty, s }` y su factor `f`.
+ * La cámara viaja completa (f = 1); cada capa la sigue multiplicada por su
+ * factor en el eje Y — el efecto parallax. `translate3d` fuerza capa GPU.
+ */
+export function transformCapa(camara, f) {
+  return `translate3d(${camara.tx}px, ${camara.ty * f}px, 0) scale(${camara.s})`;
+}
+
+/**
+ * Mide el viewport de un contenedor (para que el consumidor calcule la cámara).
+ * Reacciona a `resize`. Devuelve `{ w, h }`.
+ * @param {import('react').RefObject<HTMLElement>} ref
+ * @param {{w:number, h:number}} [inicial]
+ */
+export function useViewport(ref, inicial = { w: 390, h: 700 }) {
+  const [vp, setVp] = useState(inicial);
+  useEffect(() => {
+    const medir = () => {
+      const el = ref.current;
+      if (el) setVp({ w: el.clientWidth, h: el.clientHeight });
+    };
+    medir();
+    window.addEventListener('resize', medir);
+    return () => window.removeEventListener('resize', medir);
+  }, [ref]);
+  return vp;
+}

--- a/src/visual/scenes/index.js
+++ b/src/visual/scenes/index.js
@@ -1,0 +1,81 @@
+/*
+ * Librería visual de ESCENAS BASE de Chagra (scenes). Fuente única y reutilizable
+ * de los "decorados" que se repiten en el home vivo y los mockups. Antes de
+ * re-armar una capa de cielo, un parallax, el guardián-espíritu, el papel kraft
+ * o la finca-organismo, búscalo aquí.
+ *
+ * Hermana de `src/visual/creatures` (fauna) y `src/visual/effects` (técnicas de
+ * cine): misma filosofía y mismo contrato de reuso (componente parametrizable +
+ * este barrel + README + `scenes.css` compartida, cero dependencias nuevas, ids
+ * `useId`, reduced-motion-safe).
+ *
+ * Piezas:
+ *   1. `scenes.css` — clases `scn-*` + custom props `--scn-*` (cielo, pulso,
+ *      kraft, parallax, guardián). Importala UNA vez donde la uses.
+ *   2. Componentes (este barrel): `CapaCielo`, `Parallax`, `GuardianEspirituBase`,
+ *      `SceneFincaOrganismo`, + sus helpers.
+ */
+
+// ── Capa cielo paramétrica ───────────────────────────────────────────────────
+export { default as CapaCielo, Sky, CieloDefs, WashSolBajo } from './CieloParametrico.jsx';
+export {
+  cieloEscena,
+  tonoLuz,
+  esNoche,
+  esCubierto,
+  CIELOS_ESCENA,
+  CIELOS_TEMA,
+} from './_cielo.js';
+
+// ── Parallax multicapa (motor de MontanaMundosCine) ──────────────────────────
+export { default as Parallax } from './Parallax.jsx';
+export { CAPAS_PARALLAX, transformCapa, useViewport } from './_parallax.js';
+
+// ── Guardián-espíritu base ───────────────────────────────────────────────────
+export { default as GuardianEspirituBase, EspirituDefs } from './GuardianEspirituBase.jsx';
+
+// ── Escena finca-organismo (con pulso) ───────────────────────────────────────
+export { default as SceneFincaOrganismo } from './SceneFincaOrganismo.jsx';
+
+/* Ritmo del latido/respiración de la finca-organismo (= `--scn-beat` en
+   scenes.css y `--fvo-beat`/`--motion-beat` en el resto del repo). Útil desde JS
+   cuando una escena necesita sincronizar un timing sin leer el CSS. */
+export const SCN_BEAT_MS = 5200;
+
+/* Receta de papel kraft: la clase compartida de `scenes.css`. Se re-tiñe con las
+   custom props `--scn-kraft-angle/-color/-grano/-paso`; el modificador
+   `.scn-kraft--fino` da la trama vertical finísima de papel. */
+export const SCN_KRAFT_CLASS = 'scn-kraft';
+
+import CapaCielo from './CieloParametrico.jsx';
+import Parallax from './Parallax.jsx';
+import GuardianEspirituBase from './GuardianEspirituBase.jsx';
+import SceneFincaOrganismo from './SceneFincaOrganismo.jsx';
+
+/* Registro consultable: slug → componente + qué es + de dónde salió. */
+export const SCENES = {
+  'capa-cielo': {
+    Component: CapaCielo,
+    nombre: 'Capa cielo paramétrica',
+    clave: 'sol/luna/estrellas/nubes/niebla/lluvia por hora y clima reales',
+    origen: 'FincaVivaHero (subcomponente Sky, compartido por las 3 escenas)',
+  },
+  parallax: {
+    Component: Parallax,
+    nombre: 'Parallax multicapa',
+    clave: 'motor de cámara por capas (f<1 lejos, f>1 cerca)',
+    origen: 'MontanaMundosCine (Montaña de los Mundos, pasada cine)',
+  },
+  'guardian-espiritu': {
+    Component: GuardianEspirituBase,
+    nombre: 'Guardián-espíritu base',
+    clave: 'avatar de fauna como espíritu, con glow por acento',
+    origen: 'GuardianEspiritu (mockup avatar-biopunk)',
+  },
+  'finca-organismo': {
+    Component: SceneFincaOrganismo,
+    nombre: 'Finca organismo',
+    clave: 'finca bioluminiscente con corazón-semilla que late',
+    origen: 'SceneFincaOrganismo (escena-home-biopunk-v2)',
+  },
+};

--- a/src/visual/scenes/scene-finca-organismo.css
+++ b/src/visual/scenes/scene-finca-organismo.css
@@ -1,0 +1,554 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   SCENE "FINCA ORGANISMO" (tema biopunk) — animaciones del port fiel del
+   mockup aprobado escena-home-biopunk-v2.html. Todo es CSS/SVG declarativo
+   (cero JS por frame). Prefijo `fvo-` en clases y keyframes para no chocar
+   con el resto del hero. prefers-reduced-motion = estado estático digno
+   (misma receta del mockup: red encendida, chispas plantadas, sin ondas).
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.fvo-svg {
+  /* ritmo cardíaco compartido: corazón, red, savia, paneles y reactor laten
+     al MISMO pulso (la finca es UN organismo) */
+  --fvo-beat: 5.2s;
+}
+
+/* estrellas que titilan */
+.fvo-tw { animation: fvo-tw 3.4s ease-in-out infinite; }
+@keyframes fvo-tw { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
+
+/* halo lunar que respira */
+.fvo-halo { transform-box: fill-box; transform-origin: center; animation: fvo-halo 8s ease-in-out infinite; }
+@keyframes fvo-halo { 0%, 100% { transform: scale(1); opacity: 0.5; } 50% { transform: scale(1.12); opacity: 0.9; } }
+
+/* aurora de páramo */
+.fvo-aurora { animation: fvo-aurora 14s ease-in-out infinite alternate; }
+@keyframes fvo-aurora { from { opacity: 0.10; transform: translateX(-8px); } to { opacity: 0.28; transform: translateX(10px); } }
+
+/* respiración de toda la finca */
+.fvo-breathe { transform-box: fill-box; transform-origin: 50% 100%; animation: fvo-breathe 7s ease-in-out infinite; }
+@keyframes fvo-breathe { 0%, 100% { transform: scaleY(1); } 50% { transform: scaleY(1.012); } }
+
+/* latido del corazón micorrízico (doble pulso, como corazón real) */
+.fvo-heart { transform-box: fill-box; transform-origin: center; animation: fvo-beat var(--fvo-beat) ease-in-out infinite; }
+@keyframes fvo-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+.fvo-heart-wave { transform-box: fill-box; transform-origin: center; animation: fvo-hwave var(--fvo-beat) ease-out infinite; }
+@keyframes fvo-hwave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red entera se enciende con cada latido */
+.fvo-net { animation: fvo-netglow var(--fvo-beat) ease-in-out infinite; }
+@keyframes fvo-netglow { 0%, 100% { opacity: 0.55; } 8% { opacity: 1; } 16% { opacity: 0.7; } 22% { opacity: 0.9; } 34% { opacity: 0.55; } }
+
+/* flujo de savia por las hifas */
+.fvo-hypha { stroke-dasharray: 5 9; animation: fvo-flow 2.6s linear infinite; }
+.fvo-hypha.fvo-slow { animation-duration: 4.5s; stroke-dasharray: 3 11; }
+.fvo-hypha.fvo-rev { animation-direction: reverse; }
+@keyframes fvo-flow { to { stroke-dashoffset: -56; } }
+
+/* nutrientes viajando (motion path) */
+.fvo-spark {
+  offset-rotate: 0deg;
+  animation: fvo-travel 6s linear infinite;
+  filter: drop-shadow(0 0 4px #2dffc4);
+}
+.fvo-spark.fvo-p1 { offset-path: path('M195,405 C160,392 120,380 78,352'); animation-delay: 0s; }
+.fvo-spark.fvo-p2 { offset-path: path('M195,405 C230,388 268,375 300,350'); animation-delay: 1.6s; animation-duration: 5s; }
+.fvo-spark.fvo-p3 { offset-path: path('M195,405 C185,378 172,360 150,344'); animation-delay: 3.1s; animation-duration: 4.2s; }
+.fvo-spark.fvo-p4 { offset-path: path('M195,405 C240,420 300,432 368,424'); animation-delay: 2.2s; animation-duration: 7s; }
+.fvo-spark.fvo-p5 { offset-path: path('M195,405 C150,428 90,440 24,430'); animation-delay: 4.4s; animation-duration: 7s; }
+.fvo-spark.fvo-p6 { offset-path: path('M295,352 C295,320 295,300 295,278'); animation-delay: 0.8s; animation-duration: 3.6s; }
+@keyframes fvo-travel {
+  0% { offset-distance: 0%; opacity: 0; }
+  12% { opacity: 1; }
+  82% { opacity: 1; }
+  100% { offset-distance: 100%; opacity: 0; }
+}
+
+/* colibrí de luz (vuela por el cielo y se queda libando en el aire) */
+.fvo-colibri {
+  offset-path: path('M-30,118 C70,74 140,148 198,104 C246,70 268,138 342,112 C300,96 250,150 198,104');
+  offset-rotate: 0deg;
+  animation: fvo-vuelo 22s ease-in-out infinite;
+}
+@keyframes fvo-vuelo {
+  0% { offset-distance: 0%; }
+  30% { offset-distance: 38%; }
+  40% { offset-distance: 41%; }
+  68% { offset-distance: 62%; }
+  78% { offset-distance: 64%; }
+  100% { offset-distance: 100%; }
+}
+.fvo-ala { transform-box: fill-box; transform-origin: 20% 90%; animation: fvo-ala 0.12s ease-in-out infinite alternate; }
+@keyframes fvo-ala { from { transform: rotate(-26deg); } to { transform: rotate(34deg); } }
+.fvo-estela { transform-box: fill-box; transform-origin: center; animation: fvo-estela 1.1s ease-out infinite; }
+.fvo-estela.fvo-e2 { animation-delay: 0.35s; }
+.fvo-estela.fvo-e3 { animation-delay: 0.7s; }
+@keyframes fvo-estela { 0% { transform: scale(0.4); opacity: 0.9; } 100% { transform: scale(2.4); opacity: 0; } }
+
+/* cocuyos (luciérnagas) */
+.fvo-fly { animation: fvo-fly 9s ease-in-out infinite alternate, fvo-blink 2.3s ease-in-out infinite; }
+.fvo-fly.fvo-f2 { animation-duration: 11s, 3.1s; animation-delay: -3s, -1s; }
+.fvo-fly.fvo-f3 { animation-duration: 8s, 1.9s; animation-delay: -5s, -0.4s; }
+.fvo-fly.fvo-f4 { animation-duration: 13s, 2.7s; animation-delay: -8s, -1.7s; }
+.fvo-fly.fvo-f5 { animation-duration: 10s, 2.1s; animation-delay: -2s, -0.9s; }
+@keyframes fvo-fly {
+  from { transform: translate(0, 0); }
+  33% { transform: translate(14px, -10px); }
+  66% { transform: translate(-8px, 6px); }
+  to { transform: translate(10px, -14px); }
+}
+@keyframes fvo-blink { 0%, 100% { opacity: 0.1; } 45%, 55% { opacity: 1; } }
+
+/* niebla de páramo */
+.fvo-fog { animation: fvo-fog 36s ease-in-out infinite alternate; }
+.fvo-fog.fvo-g2 { animation-duration: 46s; animation-delay: -18s; }
+.fvo-fog.fvo-g3 { animation-duration: 28s; animation-delay: -9s; }
+@keyframes fvo-fog { from { transform: translateX(-26px); } to { transform: translateX(30px); } }
+
+/* cúpula-célula: respira */
+.fvo-dome { transform-box: fill-box; transform-origin: 50% 100%; animation: fvo-dome 6s ease-in-out infinite; }
+@keyframes fvo-dome { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.035, 1.05); } }
+.fvo-organela { transform-box: fill-box; transform-origin: center; animation: fvo-orga 12s ease-in-out infinite alternate; }
+.fvo-organela.fvo-o2 { animation-duration: 15s; animation-delay: -6s; }
+.fvo-organela.fvo-o3 { animation-duration: 9s; animation-delay: -3s; }
+@keyframes fvo-orga {
+  from { transform: translate(0, 0); }
+  50% { transform: translate(-9px, 6px); }
+  to { transform: translate(7px, -8px); }
+}
+
+/* plantas: savia que late */
+.fvo-sap { animation: fvo-sap var(--fvo-beat) ease-in-out infinite; }
+.fvo-sap.fvo-s2 { animation-delay: 0.35s; }
+.fvo-sap.fvo-s3 { animation-delay: 0.7s; }
+.fvo-sap.fvo-s4 { animation-delay: 1.05s; }
+.fvo-sap.fvo-s5 { animation-delay: 1.4s; }
+@keyframes fvo-sap { 0%, 100% { opacity: 0.55; } 10% { opacity: 1; } 20% { opacity: 0.65; } 26% { opacity: 0.9; } 40% { opacity: 0.55; } }
+.fvo-berry { transform-box: fill-box; transform-origin: center; animation: fvo-berry 3.8s ease-in-out infinite; }
+.fvo-berry.fvo-b2 { animation-delay: -1.2s; }
+.fvo-berry.fvo-b3 { animation-delay: -2.4s; }
+.fvo-berry.fvo-b4 { animation-delay: -0.6s; }
+@keyframes fvo-berry { 0%, 100% { opacity: 0.5; transform: scale(1); } 50% { opacity: 1; transform: scale(1.35); } }
+
+/* frailejón que exhala luz */
+.fvo-frailejon { animation: fvo-frail 6.5s ease-in-out infinite; }
+.fvo-frailejon.fvo-fr2 { animation-delay: -3s; }
+@keyframes fvo-frail { 0%, 100% { opacity: 0.6; } 50% { opacity: 1; } }
+
+/* hongos + esporas */
+.fvo-cap { animation: fvo-cap 4.4s ease-in-out infinite; }
+.fvo-cap.fvo-c2 { animation-delay: -2.2s; }
+@keyframes fvo-cap { 0%, 100% { opacity: 0.7; } 50% { opacity: 1; } }
+.fvo-spore { animation: fvo-spore 6s linear infinite; }
+.fvo-spore.fvo-sp2 { animation-delay: -2s; }
+.fvo-spore.fvo-sp3 { animation-delay: -4s; }
+@keyframes fvo-spore {
+  0% { transform: translateY(0); opacity: 0; }
+  15% { opacity: 0.9; }
+  100% { transform: translateY(-46px); opacity: 0; }
+}
+
+/* brasas del fogón */
+.fvo-brasa { animation: fvo-brasa 4.2s linear infinite; }
+.fvo-brasa.fvo-br2 { animation-delay: -1.4s; }
+.fvo-brasa.fvo-br3 { animation-delay: -2.8s; }
+@keyframes fvo-brasa {
+  0% { transform: translate(0, 0); opacity: 0; }
+  12% { opacity: 1; }
+  60% { transform: translate(5px, -30px); opacity: 0.7; }
+  100% { transform: translate(-3px, -52px); opacity: 0; }
+}
+.fvo-ventana { animation: fvo-ventana 3.2s ease-in-out infinite; }
+@keyframes fvo-ventana { 0%, 100% { opacity: 0.75; } 50% { opacity: 1; } }
+
+/* invernadero-célula: paneles + reactor que late */
+.fvo-panel { animation: fvo-panel var(--fvo-beat) ease-in-out infinite; }
+.fvo-panel.fvo-pa2 { animation-delay: 0.3s; }
+.fvo-panel.fvo-pa3 { animation-delay: 0.6s; }
+@keyframes fvo-panel { 0%, 100% { opacity: 0.45; } 9% { opacity: 0.85; } 18% { opacity: 0.55; } 26% { opacity: 0.7; } }
+.fvo-reactor { transform-box: fill-box; transform-origin: center; animation: fvo-reactor var(--fvo-beat) ease-in-out infinite; }
+@keyframes fvo-reactor {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  8% { transform: scale(1.2); filter: brightness(1.7); }
+  16% { transform: scale(1); }
+}
+.fvo-lamplight { animation: fvo-lamplight var(--fvo-beat) ease-in-out infinite; }
+@keyframes fvo-lamplight { 0%, 100% { opacity: 0.22; } 8% { opacity: 0.5; } 18% { opacity: 0.28; } }
+.fvo-vent { animation: fvo-ventpulse 3.4s ease-in-out infinite; }
+@keyframes fvo-ventpulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
+
+/* campesino con alma */
+.fvo-campesino { transform-box: fill-box; transform-origin: 50% 100%; animation: fvo-campe 6.5s ease-in-out infinite; }
+@keyframes fvo-campe { 0%, 100% { transform: translateY(0) rotate(0deg); } 50% { transform: translateY(-0.7px) rotate(0.5deg); } }
+.fvo-head-c { transform-box: fill-box; transform-origin: 50% 88%; animation: fvo-headlook 11s ease-in-out infinite; }
+@keyframes fvo-headlook { 0%, 60%, 100% { transform: rotate(0); } 72%, 86% { transform: rotate(-7deg); } }
+.fvo-lantern { transform-box: fill-box; transform-origin: 50% 4%; animation: fvo-lantsway 4.6s ease-in-out infinite; }
+@keyframes fvo-lantsway { 0%, 100% { transform: rotate(-4.5deg); } 50% { transform: rotate(4.5deg); } }
+.fvo-lantorb { transform-box: fill-box; transform-origin: center; animation: fvo-lantorb 2.8s ease-in-out infinite; }
+@keyframes fvo-lantorb { 0%, 100% { opacity: 0.8; transform: scale(1); } 50% { opacity: 1; transform: scale(1.12); } }
+.fvo-lantpool { animation: fvo-lantpool 2.8s ease-in-out infinite; }
+@keyframes fvo-lantpool { 0%, 100% { opacity: 0.35; } 50% { opacity: 0.62; } }
+
+/* perro criollo */
+.fvo-dog { transform-box: fill-box; transform-origin: 50% 100%; animation: fvo-dogbob 3.1s ease-in-out infinite; }
+@keyframes fvo-dogbob { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-0.5px); } }
+.fvo-tail { transform-box: fill-box; transform-origin: 100% 100%; animation: fvo-tail 0.42s ease-in-out infinite alternate; }
+@keyframes fvo-tail { from { transform: rotate(-20deg); } to { transform: rotate(28deg); } }
+.fvo-earw { transform-box: fill-box; transform-origin: 50% 0; animation: fvo-earw 2.4s ease-in-out infinite; }
+@keyframes fvo-earw { 0%, 100% { transform: rotate(0); } 50% { transform: rotate(-9deg); } }
+
+/* estrella fugaz + aves lejanas */
+.fvo-shoot { animation: fvo-shoot 9s ease-in infinite; }
+@keyframes fvo-shoot {
+  0%, 66% { opacity: 0; transform: translate(0, 0); }
+  68% { opacity: 1; }
+  78% { opacity: 1; }
+  85% { opacity: 0; transform: translate(66px, 30px); }
+  100% { opacity: 0; transform: translate(66px, 30px); }
+}
+.fvo-vbird { animation: fvo-vbird 26s linear infinite; }
+@keyframes fvo-vbird {
+  from { transform: translate(0, 0); }
+  50% { transform: translate(-22px, 4px); }
+  to { transform: translate(-44px, 0); }
+}
+.fvo-flap { transform-box: fill-box; transform-origin: center; animation: fvo-flap 1.6s ease-in-out infinite; }
+@keyframes fvo-flap { 0%, 100% { transform: scaleY(1); } 50% { transform: scaleY(0.55); } }
+
+/* ── SOL Y LUNA según la atmósfera real ────────────────────────────────────
+   FincaVivaHero estampa data-luz (amanecer|dia|atardecer|noche) y data-clima
+   (despejado|nublado|lluvia|niebla) en .fvh (atmosphereService, offline-first
+   por efemérides). La escena ya no es "siempre de noche": de día sale el sol
+   biopunk, al amanecer/atardecer el cielo se enciende cálido y de noche vuelve
+   la luna. Sin data-luz (sin señal) la escena conserva su identidad nocturna. */
+.fvo-cielo-dia,
+.fvo-cielo-crep { opacity: 0; transition: opacity 1.2s ease; }
+.fvo-sol-g { display: none; }
+
+.fvh[data-luz='dia'] .fvo-sol-g,
+.fvh[data-luz='amanecer'] .fvo-sol-g,
+.fvh[data-luz='atardecer'] .fvo-sol-g { display: inline; }
+
+.fvh[data-luz='dia'] .fvo-luna-g,
+.fvh[data-luz='amanecer'] .fvo-luna-g,
+.fvh[data-luz='atardecer'] .fvo-luna-g { display: none; }
+
+.fvh[data-luz='dia'] .fvo-cielo-dia { opacity: 0.68; }
+
+.fvh[data-luz='amanecer'] .fvo-cielo-crep,
+.fvh[data-luz='atardecer'] .fvo-cielo-crep { opacity: 0.5; }
+
+/* al amanecer/atardecer el sol anda BAJO, cerca del filo de la montaña */
+.fvh[data-luz='amanecer'] .fvo-sol-g,
+.fvh[data-luz='atardecer'] .fvo-sol-g { transform: translateY(26px); }
+
+/* de día las estrellas descansan; en el crepúsculo apenas se insinúan */
+.fvh[data-luz='dia'] .fvo-tw,
+.fvh[data-luz='dia'] .fvo-shoot { display: none; }
+
+.fvh[data-luz='amanecer'] .fvo-tw,
+.fvh[data-luz='atardecer'] .fvo-tw { animation: none; opacity: 0.3; }
+
+/* clima: nublado/lluvia/niebla traen nubes y velan el astro (honesto: el
+   cielo de la escena cuenta el clima que el piloto ve por la ventana) */
+.fvo-nubes { display: none; }
+
+.fvh[data-clima='nublado'] .fvo-nubes,
+.fvh[data-clima='lluvia'] .fvo-nubes,
+.fvh[data-clima='niebla'] .fvo-nubes { display: inline; }
+
+.fvh[data-clima='nublado'] .fvo-astro { opacity: 0.45; }
+.fvh[data-clima='lluvia'] .fvo-astro { opacity: 0.3; }
+.fvh[data-clima='niebla'] .fvo-astro { opacity: 0.55; }
+
+/* corona del sol: respira (transform+opacity, GPU) */
+.fvo-corona {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-corona 5s ease-in-out infinite;
+}
+
+@keyframes fvo-corona {
+  0%, 100% { transform: scale(1); opacity: 0.55; }
+  50% { transform: scale(1.06); opacity: 0.9; }
+}
+
+/* ── LA VIDA DEL SUELO: micelio fino, nodos, lombrices y bichitos ──────────
+   El micelio fino respira con el mismo latido de la red; los nodos
+   micorrízicos titilan (intercambio azúcar↔nutrientes); las lombrices se
+   estiran y encogen al avanzar; el colémbolo pega brinquitos. Todo
+   transform/opacity — cero blur/filtro animado. */
+.fvo-micelio {
+  animation: fvo-netglow var(--fvo-beat) ease-in-out infinite;
+  animation-delay: -0.4s;
+}
+
+.fvo-nodo { animation: fvo-tw 3.8s ease-in-out infinite; }
+.fvo-nodo.fvo-n2 { animation-delay: -1.3s; }
+.fvo-nodo.fvo-n3 { animation-delay: -2.4s; }
+
+.fvo-lombriz {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-lombriz 7s ease-in-out infinite;
+}
+
+.fvo-lombriz.fvo-l2 { animation-delay: -3.2s; animation-duration: 8.5s; }
+
+@keyframes fvo-lombriz {
+  0%, 100% { transform: translateX(0) scaleX(1); }
+  50% { transform: translateX(3px) scaleX(0.94); }
+}
+
+.fvo-bicho {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-bicho 9s ease-in-out infinite;
+}
+
+@keyframes fvo-bicho {
+  0%, 100% { transform: translateX(0); }
+  45%, 55% { transform: translateX(-6px); }
+}
+
+.fvo-bicho.fvo-bi2 { animation: fvo-brinco 4.6s ease-in-out infinite; }
+
+@keyframes fvo-brinco {
+  0%, 86%, 100% { transform: translate(0, 0); }
+  90% { transform: translate(-3px, -6px); }
+  94% { transform: translate(-5px, 0); }
+}
+
+/* ── QUEBRADA: el agua corre, cae en cascaditas y ondea en el pocito ───────
+   La corriente es el mismo truco de las hifas (dash que corre); los destellos
+   de cascada titilan; el remanso emite ondas concéntricas. Todo dash/opacity/
+   transform — nada de filtros animados. */
+.fvo-agua { stroke-dasharray: 8 5; animation: fvo-aguaflow 1.9s linear infinite; }
+.fvo-agua.fvo-a2 { stroke-dasharray: 4 8; animation-duration: 2.7s; animation-delay: -0.8s; }
+@keyframes fvo-aguaflow { to { stroke-dashoffset: -52; } }
+
+.fvo-destello { animation: fvo-tw 2.6s ease-in-out infinite; }
+
+.fvo-onda {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-onda 4.2s ease-out infinite;
+}
+
+.fvo-onda.fvo-on2 { animation-delay: -2.1s; }
+
+@keyframes fvo-onda {
+  0% { transform: scale(0.3); opacity: 0.8; }
+  70%, 100% { transform: scale(1.7); opacity: 0; }
+}
+
+.fvo-reflejo { animation: fvo-reflejo 5s ease-in-out infinite; }
+@keyframes fvo-reflejo { 0%, 100% { opacity: 0.25; } 50% { opacity: 0.6; } }
+
+/* ── RAYO DEL ASTRO: la luz cae en diagonal y respira ── */
+.fvo-rayo { animation: fvo-rayo 9s ease-in-out infinite; }
+@keyframes fvo-rayo { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
+
+/* ── POTRERO: LA VACA ──────────────────────────────────────────────────────
+   Respira con la panza (scaleY desde el vientre), pasta de a ratos (la
+   cabeza baja y vuelve), espanta con la cola y las manchas bioluminiscentes
+   laten con el MISMO pulso var(--fvo-beat) de la red — la vaca es parte del
+   organismo, no un sticker encima. */
+.fvo-vaca-cuerpo {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: fvo-vacabreathe 3.8s ease-in-out infinite;
+}
+
+@keyframes fvo-vacabreathe {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.04); }
+}
+
+.fvo-vaca-cabeza {
+  transform-box: fill-box;
+  transform-origin: 92% 42%;
+  animation: fvo-vacapasta 11s ease-in-out infinite;
+}
+
+@keyframes fvo-vacapasta {
+  0%, 36%, 100% { transform: rotate(0deg); }
+  44%, 66% { transform: rotate(13deg); }
+  52% { transform: rotate(11deg); }
+  76% { transform: rotate(-2deg); }
+  84% { transform: rotate(0deg); }
+}
+
+.fvo-vaca-cola {
+  transform-box: fill-box;
+  transform-origin: 20% 6%;
+  animation: fvo-vacacola 6.5s ease-in-out infinite;
+}
+
+@keyframes fvo-vacacola {
+  0%, 52%, 100% { transform: rotate(0deg); }
+  60% { transform: rotate(18deg); }
+  70% { transform: rotate(-12deg); }
+  80% { transform: rotate(9deg); }
+  88% { transform: rotate(0deg); }
+}
+
+.fvo-vaca-oreja {
+  transform-box: fill-box;
+  transform-origin: 10% 90%;
+  animation: fvo-vacaoreja 7s ease-in-out infinite;
+}
+
+@keyframes fvo-vacaoreja {
+  0%, 78%, 100% { transform: rotate(0deg); }
+  84% { transform: rotate(-16deg); }
+  90% { transform: rotate(4deg); }
+}
+
+/* manchas de la vaca: laten con el corazón de la finca */
+.fvo-mancha { animation: fvo-mancha var(--fvo-beat) ease-in-out infinite; }
+.fvo-mancha.fvo-m2 { animation-delay: 0.3s; }
+.fvo-mancha.fvo-m3 { animation-delay: 0.6s; }
+@keyframes fvo-mancha { 0%, 100% { opacity: 0.45; } 8% { opacity: 1; } 16% { opacity: 0.6; } 24% { opacity: 0.85; } 36% { opacity: 0.45; } }
+
+/* ── POTRERO: LAS GALLINAS pican el pasto (doble picoteo con pausa; cada
+   una a su ritmo). La espejada (mira a la izquierda) picotea al revés. */
+.fvo-gallina {
+  transform-box: fill-box;
+  transform-origin: 64% 100%;
+  animation: fvo-picoteo 3.6s ease-in-out infinite;
+}
+
+.fvo-gallina.fvo-ga2 { animation-duration: 4.4s; animation-delay: -1.3s; }
+.fvo-gallina.fvo-ga3 { animation-duration: 3.1s; animation-delay: -2.2s; }
+
+@keyframes fvo-picoteo {
+  0%, 34%, 100% { transform: rotate(0deg); }
+  40% { transform: rotate(24deg); }
+  46% { transform: rotate(5deg); }
+  52% { transform: rotate(26deg); }
+  58% { transform: rotate(0deg); }
+}
+
+.fvo-gallina.fvo-ga-esp {
+  transform-origin: 36% 100%;
+  animation-name: fvo-picoteo-esp;
+}
+
+@keyframes fvo-picoteo-esp {
+  0%, 34%, 100% { transform: rotate(0deg); }
+  40% { transform: rotate(-24deg); }
+  46% { transform: rotate(-5deg); }
+  52% { transform: rotate(-26deg); }
+  58% { transform: rotate(0deg); }
+}
+
+/* ── POTRERO como PUERTA al mundo de los animales ──────────────────────────
+   Con data-tap el grupo es un botón: cursor, halo-invitación que emana cada
+   6s, etiqueta que respira y anillo de foco accesible (:focus-visible). */
+.fvo-animales[data-tap='1'] { cursor: pointer; outline: none; }
+
+.fvo-cta-halo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-ctahalo 6s ease-out infinite;
+  opacity: 0;
+}
+
+@keyframes fvo-ctahalo {
+  0%, 55% { transform: scale(0.55); opacity: 0; }
+  62% { opacity: 0.7; }
+  100% { transform: scale(1.12); opacity: 0; }
+}
+
+.fvo-cta-tag { animation: fvo-ctatag 6s ease-in-out infinite; }
+@keyframes fvo-ctatag { 0%, 100% { opacity: 0.55; } 60% { opacity: 1; } }
+
+.fvo-animales[data-tap='1']:focus-visible .fvo-cta-anillo { opacity: 1; }
+.fvo-animales[data-tap='1']:hover .fvo-cta-tag { opacity: 1; animation: none; }
+
+/* ── polillas del farol (revolotean cortico y titilan) ── */
+.fvo-polilla {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-polilla 3.4s ease-in-out infinite alternate, fvo-blink 1.7s ease-in-out infinite;
+}
+
+.fvo-polilla.fvo-po2 { animation-duration: 2.6s, 2.3s; animation-delay: -1.3s, -0.6s; }
+
+@keyframes fvo-polilla {
+  from { transform: translate(0, 0); }
+  33% { transform: translate(-4px, -5px); }
+  66% { transform: translate(3px, -2px); }
+  to { transform: translate(-2px, 3px); }
+}
+
+/* ── reduced motion: estado estático DIGNO (como el mockup) ────────────────
+   El apagado global de animaciones ya lo hace finca-viva-hero.css
+   (`.fvh * { animation: none !important }`); aquí se compone la foto fija:
+   red encendida, chispas plantadas a mitad de camino, colibrí libando,
+   sin ondas de latido ni estelas ni estrella fugaz. */
+@media (prefers-reduced-motion: reduce) {
+  .fvo-svg * { animation: none !important; }
+  .fvo-hypha { stroke-dasharray: none; }
+  .fvo-spark { offset-distance: 55%; opacity: 0.9; }
+  .fvo-colibri { offset-distance: 40%; }
+  .fvo-heart-wave,
+  .fvo-estela { opacity: 0; }
+  .fvo-fly { opacity: 0.8; }
+  .fvo-net { opacity: 0.85; }
+  .fvo-shoot { opacity: 0; }
+  .fvo-panel { opacity: 0.7; }
+  .fvo-lamplight { opacity: 0.3; }
+  .fvo-lantpool { opacity: 0.5; }
+  /* la vida del suelo queda quieta pero visible (foto fija digna) */
+  .fvo-micelio { opacity: 0.38; }
+  .fvo-nodo { opacity: 0.85; }
+  /* la quebrada queda llena (sin dash), el remanso quieto y brillante */
+  .fvo-agua { stroke-dasharray: none; }
+  .fvo-onda { opacity: 0; }
+  .fvo-reflejo { opacity: 0.5; }
+  .fvo-destello { opacity: 0.7; }
+  .fvo-rayo { opacity: 0.7; }
+  /* el potrero posa: vaca erguida, manchas encendidas, gallinas de pie;
+     la invitación al mundo animales queda como etiqueta fija visible */
+  .fvo-mancha { opacity: 0.85; }
+  .fvo-cta-halo { opacity: 0; }
+  .fvo-cta-tag { opacity: 0.9; }
+  .fvo-polilla { opacity: 0.7; }
+}
+
+/* ── CORAZÓN TAPPABLE = "PREGUNTE" (usabilidad campesina #4) ───────────────
+   Cuando FincaVivaHero pasa onPregunte, el corazón-semilla es un botón que
+   abre el agente. Cursor, foco visible para teclado y un halo-invitación que
+   respira (se apaga con prefers-reduced-motion, quedando el halo fijo). */
+.fvo-corazon-tap {
+  cursor: pointer;
+  outline: none;
+}
+.fvo-corazon-tap:focus-visible ellipse:first-of-type {
+  stroke: #eafff6;
+  stroke-width: 2;
+  opacity: 0.9;
+}
+.fvo-corazon-tap:active .fvo-heart { opacity: 0.85; }
+.fvo-corazon-halo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: fvo-corazon-invita 2.4s ease-out infinite;
+}
+@keyframes fvo-corazon-invita {
+  0% { transform: scale(0.8); opacity: 0.55; }
+  70%, 100% { transform: scale(1.35); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fvo-corazon-halo { animation: none !important; opacity: 0.4; }
+}

--- a/src/visual/scenes/scenes.css
+++ b/src/visual/scenes/scenes.css
@@ -1,0 +1,172 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   src/visual/scenes — hoja compartida de las ESCENAS BASE reutilizables.
+
+   Clases `scn-*` + custom properties `--scn-*`, cero dependencias nuevas. Es la
+   versión CANÓNICA de las recetas que antes se re-armaban en cada escena:
+     · animaciones del CIELO paramétrico (estrellas, lluvia, nubes, niebla,
+       estrella fugaz) — semilla `finca-viva-hero.css` (`.fvh-estrellas`…).
+     · PULSO cardíaco de la finca-organismo (corazón, ondas, red) — semilla
+       `scene-finca-organismo.css` (`--fvo-beat`).
+     · textura de PAPEL KRAFT — semilla `finca-viva-hero.css` (grano nature).
+     · base del motor PARALLAX multicapa — semilla `MontanaMundosCine`
+       (`.mm2-capa`).
+     · glow + flotación del GUARDIÁN-ESPÍRITU — semilla `guardian-espiritu.css`.
+
+   Reglas de la casa (iguales a creatures/effects): solo transform/opacity
+   animados; blur/filtros ESTÁTICOS; reduced-motion = fotograma final digno;
+   importe esta hoja UNA vez donde use las clases.
+
+   NOTA de dedupe (cuando `src/visual/effects` entre a main): el pulso de aquí
+   equivale a `--vfx-beat`, el glow a `<GlowFilter>` y las veladuras/grades a las
+   clases `.vfx-*`. Reusar effects donde aplique en vez de re-declarar.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── CIELO PARAMÉTRICO — animaciones del <CapaCielo> (rsvg-safe) ───────────── */
+/* estrellas que titilan (titileo escalonado) */
+.scn-estrellas circle { animation: scn-titila 3.4s ease-in-out infinite; }
+.scn-estrellas circle:nth-child(2n) { animation-delay: 1.2s; }
+.scn-estrellas circle:nth-child(3n) { animation-delay: 2.1s; }
+@keyframes scn-titila { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* lluvia: trazos que caen */
+.scn-lluvia line { animation: scn-cae 0.9s linear infinite; }
+.scn-lluvia line:nth-child(2n) { animation-delay: 0.3s; }
+.scn-lluvia line:nth-child(3n) { animation-delay: 0.6s; }
+@keyframes scn-cae { 0% { transform: translateY(-8px); opacity: 0; } 30% { opacity: 0.95; } 100% { transform: translateY(20px); opacity: 0; } }
+
+/* nubes densas (clima cubierto) — derivan en contrafase */
+.scn-nube-a { animation: scn-nube 24s ease-in-out infinite; }
+.scn-nube-b { animation: scn-nube 30s ease-in-out infinite reverse; }
+@keyframes scn-nube { 0%, 100% { transform: translateX(0); } 50% { transform: translateX(18px); } }
+
+/* estrella fugaz — casi siempre invisible; cada ~9s cruza y se apaga */
+.scn-fugaz { opacity: 0; animation: scn-fugaz 9s ease-in 2s infinite; }
+@keyframes scn-fugaz {
+  0%, 86%  { opacity: 0; transform: translate(0, 0); }
+  88%      { opacity: 0.9; }
+  94%      { opacity: 0; transform: translate(-46px, 22px); }
+  100%     { opacity: 0; transform: translate(-46px, 22px); }
+}
+
+/* bancos de niebla — derivan en contrafase (condición niebla) */
+.scn-neblina-a { animation: scn-neblina 18s ease-in-out infinite; }
+.scn-neblina-b { animation: scn-neblina 24s ease-in-out infinite reverse; }
+@keyframes scn-neblina { 0%, 100% { transform: translateX(0); } 50% { transform: translateX(30px); } }
+
+/* ── PULSO CARDÍACO de la finca-organismo ─────────────────────────────────────
+   Un solo ritmo `--scn-beat` sincroniza todo lo vivo (la finca es UN organismo).
+   Para acelerar/frenar TODO junto: `style={{ '--scn-beat': '4s' }}` en un ancestro. */
+.scn-heart {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: scn-beat var(--scn-beat, 5.2s) ease-in-out infinite;
+}
+@keyframes scn-beat {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  6% { transform: scale(1.35); filter: brightness(2.2); }
+  12% { transform: scale(1); }
+  18% { transform: scale(1.22); filter: brightness(1.7); }
+  26% { transform: scale(1); filter: brightness(1); }
+}
+.scn-heart-wave {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: scn-hwave var(--scn-beat, 5.2s) ease-out infinite;
+}
+@keyframes scn-hwave {
+  0% { transform: scale(0.2); opacity: 0.7; }
+  45% { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+/* la red entera se enciende con cada latido */
+.scn-net { animation: scn-netglow var(--scn-beat, 5.2s) ease-in-out infinite; }
+@keyframes scn-netglow { 0%, 100% { opacity: 0.55; } 8% { opacity: 1; } 16% { opacity: 0.7; } 22% { opacity: 0.9; } 34% { opacity: 0.55; } }
+
+/* ── PAPEL KRAFT — textura de grano por líneas repetidas (sin imagen/noise) ───
+   Parametrizable: ángulo (0deg = grano horizontal kraft; 90deg = trama vertical
+   fina de papel), color y paso. Se monta sobre un contenedor `position:relative`
+   (o como capa que no captura toque). */
+.scn-kraft {
+  --scn-kraft-angle: 0deg;
+  --scn-kraft-color: rgba(122, 82, 48, 0.05);
+  --scn-kraft-grano: 2px;   /* grosor de la línea */
+  --scn-kraft-paso: 6px;    /* período de repetición */
+  background-image: repeating-linear-gradient(
+    var(--scn-kraft-angle),
+    var(--scn-kraft-color) 0 var(--scn-kraft-grano),
+    transparent var(--scn-kraft-grano) var(--scn-kraft-paso)
+  );
+  pointer-events: none;
+}
+/* trama vertical finísima de papel (piel minimalista) */
+.scn-kraft--fino {
+  --scn-kraft-angle: 90deg;
+  --scn-kraft-color: rgba(60, 70, 60, 0.035);
+  --scn-kraft-grano: 1px;
+  --scn-kraft-paso: 8px;
+}
+
+/* ── PARALLAX MULTICAPA — base del <Parallax> (motor de MontanaMundosCine) ─────
+   Cada capa viaja a su velocidad (transform inline desde React) por composición
+   GPU pura (solo transform). La INERCIA por capa (duraciones/curvas distintas)
+   la afina la escena con sus propias clases modificadoras. */
+.scn-parallax { position: relative; overflow: hidden; }
+.scn-capa {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  transform-origin: 0 0;
+  will-change: transform;
+  transition: transform 0.95s cubic-bezier(0.3, 0.86, 0.24, 1.02), opacity 0.7s ease;
+  pointer-events: none;
+}
+/* la capa principal (la que lleva los mundos tocables) sí recibe toque */
+.scn-capa--interactiva { pointer-events: auto; }
+
+/* ── GUARDIÁN-ESPÍRITU base — glow por acento + flotación perpetua ────────────
+   El acento (--scn-acc / --scn-acc-rgb) lo re-tiñe el espíritu elegido. */
+.scn-espiritu-halo {
+  --scn-acc: #ffb54f;
+  --scn-acc-rgb: 255, 181, 79;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 36%, rgba(var(--scn-acc-rgb), 0.28), rgba(var(--scn-acc-rgb), 0.02) 70%);
+}
+.scn-espiritu-halo svg { width: 100%; height: 100%; }
+
+.scn-av-vuela { animation: scn-vuela 3.4s ease-in-out infinite; transform-origin: center; }
+.scn-av-flota { animation: scn-flota 3.8s ease-in-out infinite; transform-origin: center; }
+.scn-ala { animation: scn-ala 0.28s ease-in-out infinite alternate; transform-origin: 4px 0; }
+.scn-aleteo { animation: scn-aleteo 0.16s ease-in-out infinite alternate; transform-origin: -1px -5px; }
+@keyframes scn-vuela { 0%, 100% { transform: translateY(0) rotate(-1.5deg); } 50% { transform: translateY(-3px) rotate(1.5deg); } }
+@keyframes scn-flota { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-2.5px); } }
+@keyframes scn-ala { from { transform: scaleY(0.72) rotate(-6deg); } to { transform: scaleY(1) rotate(4deg); } }
+@keyframes scn-aleteo { from { transform: scaleX(0.55); opacity: 0.5; } to { transform: scaleX(1); opacity: 0.8; } }
+
+/* ── REDUCED-MOTION — fotograma final digno (nada se mueve) ───────────────────
+   El cielo queda quieto, el corazón encendido y en reposo (sin ondas), la red
+   ENCENDIDA, el parallax fijo y el espíritu flotando detenido. */
+@media (prefers-reduced-motion: reduce) {
+  .scn-estrellas circle,
+  .scn-lluvia line,
+  .scn-nube-a,
+  .scn-nube-b,
+  .scn-fugaz,
+  .scn-neblina-a,
+  .scn-neblina-b,
+  .scn-heart,
+  .scn-heart-wave,
+  .scn-net,
+  .scn-capa,
+  .scn-av-vuela,
+  .scn-av-flota,
+  .scn-ala,
+  .scn-aleteo {
+    animation: none !important;
+    transition: none !important;
+  }
+  .scn-heart-wave { opacity: 0; }     /* sin ondas expansivas */
+  .scn-net { opacity: 1; }            /* la red queda encendida */
+}


### PR DESCRIPTION
## Qué es

Mockup de galería **"El camino del primer cultivo"** — onboarding **aspiracional** que acompaña a quien siembra su **primera mata**, alineado con la dirección educativa de Chagra (**observación + fracaso + paciencia**). No es un tutorial de app: es un mentor campesino guiando la primera siembra real.

**Ruta pública:** `#/mockups/primer-cultivo` (vía `MOCKUP_HASH_ROUTES` en `src/App.jsx`, sin gate ni sesión, datos de muestra ficticios). Se resuelve antes del check de auth, igual que los otros mockups de la galería.

## Anti-gamificación (deliberada)

Sin puntos, medallas, rachas ni barra de "progreso/sube de nivel". El "camino" es un **mapa de cinco pasos** por el que se puede **ir y volver sin afán** — nunca un medidor de logro; ningún paso se "completa" ni se premia. El único registro posible es la memoria del cuaderno, no un trofeo.

## Los cinco pasos

1. **Elegir** — mire el cielo de su vereda; escoja según su **clima y época**, con la **espera real** por delante (papa/frío ~4-5 meses · café/templado ~2 años · yuca/cálido ~8-10 meses). No todo se da en todas partes, y está bien.
2. **El sitio** — lo **mínimo indispensable**: sol (medio día), agua que escurra, tierra suelta. Sin comprar nada.
3. **Sembrar** — el gesto concreto: **hondura y distancia** en medidas campesinas (jeme, cuarta), con la forma de siembra según la mata.
4. **Observar** — qué mirar los próximos días: en cuánto asoma, qué es normal y qué **sí** es para ponerle ojo.
5. **Esperar** — la **paciencia** + reencuadre del fracaso: *"si no asoma, no falló usted; así se aprende. La primera mata no se mide en cosecha, se mide en lo que usted aprendió mirándola."*

Español de Colombia, usted cordial. Botón de "oír el paso" (voz) para baja alfabetización.

## Qué reusa de la librería visual (byte-idéntica, no redibuja)

- **scenes** — `CapaCielo` (cielo real de la vereda por clima) + clase `.scn-kraft` (papel del cuaderno).
- **effects** — `vfx-grade` (luz por piso térmico) · `vfx-scrim-bottom` · `vfx-draw` + el helper `AutoDibujo` para el brote que se dibuja solo.
- **laminas** — `LaminaSiembra` (resalta la forma: tubérculo/colino/esqueje) · `LaminaAporque` (la tierra por dentro) · `LaminaCafeto`.
- **creatures** — `Lombriz` (tierra viva) · `Mariposa` · `Colibri`.

## Archivos

- `src/mockups/PrimerCultivo.jsx` + `src/mockups/primer-cultivo.css` (mobile-first 320px)
- `src/mockups/__tests__/PrimerCultivo.smoke.test.jsx`
- Cableado en `src/App.jsx` (lazy import + `MOCKUP_HASH_ROUTES` + resolución en ambos efectos de hash + `case` del render)
- Librería visual canónica que consume (creatures/laminas/effects/scenes) traída de sus ramas — aún no está en `main`, igual que en los otros branches de mockup.

## Verificación

- `npm run build` verde — emite chunk `PrimerCultivo` (44.5 kB JS + 19 kB CSS).
- `npx eslint src/mockups/PrimerCultivo.jsx` limpio.
- Smoke test 4/4 (onboarding monta · el clima manda la mata y su espera · el camino se recorre paso a paso · el corazón anti-gamificación sin "completado").
- Gate `tsc-check-gate` (baseline 868): no introduce tipos nuevos (jsx/css con JSDoc, librería visual byte-idéntica de sus ramas). El gate corría lento por contención de CPU en la caja compartida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)