### PR TITLE
fix(a11y): accesibilidad AA + barrido 320px en pantallas de producción

### DIFF
--- a/src/components/ActionConfirmModal.jsx
+++ b/src/components/ActionConfirmModal.jsx
@@ -49,9 +49,15 @@ export default function ActionConfirmModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleReject} />
-      
-      <div className="relative w-full max-w-md bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden">
+      {/* Backdrop decorativo: el cierre accesible es el botón X (con teclado). */}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleReject} aria-hidden="true" />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Confirmar acción del agente"
+        className="relative w-full max-w-md bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden"
+      >
         <div className="flex items-center justify-between px-6 py-4 border-b border-slate-800 bg-slate-950/50">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-amber-500/20 rounded-lg">
@@ -65,10 +71,12 @@ export default function ActionConfirmModal({
             </div>
           </div>
           <button
+            type="button"
             onClick={handleReject}
+            aria-label="Cerrar y rechazar la acción"
             className="p-2 rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200"
           >
-            <X size={20} />
+            <X size={20} aria-hidden="true" />
           </button>
         </div>
 

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3946,6 +3946,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
                       : activePlaceholder
               }
               disabled={queuePending.length >= 1}
+              aria-label="Escriba su mensaje para Chagra"
               data-testid="agent-input"
               className="w-full bg-transparent resize-none px-3 py-3 text-sm text-white placeholder-slate-500 focus:outline-none leading-snug"
               style={{ minHeight: '44px', maxHeight: '140px' }}

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -522,7 +522,9 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
           ) : !isUser && !isStreaming ? (
             <AgentMarkdown content={message.content} />
           ) : (
-            <p className="text-[15px] leading-relaxed whitespace-pre-wrap">{message.content}</p>
+            /* break-words: sin esto una URL o palabra larga sin espacios
+               desborda la burbuja en horizontal a 320px. */
+            <p className="text-[15px] leading-relaxed whitespace-pre-wrap break-words">{message.content}</p>
           )}
           {/* UX-1 (#284): badge "beta" permanente cerca de cualquier respuesta
               IA del agente. NO reemplaza a SourceBadge (que es la fuente

--- a/src/components/FeedbackConsentModal.jsx
+++ b/src/components/FeedbackConsentModal.jsx
@@ -30,9 +30,15 @@ export default function FeedbackConsentModal({ isOpen, onAccept, onDecline }) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleDecline} />
-      
-      <div className="relative w-full max-w-md bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden">
+      {/* Backdrop decorativo: el cierre accesible es el botón X (con teclado). */}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleDecline} aria-hidden="true" />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Consentimiento para mejorar Chagra"
+        className="relative w-full max-w-md bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden"
+      >
         <div className="flex items-center justify-between px-6 py-4 border-b border-slate-800 bg-slate-950/50">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-emerald-500/20 rounded-lg">
@@ -46,10 +52,12 @@ export default function FeedbackConsentModal({ isOpen, onAccept, onDecline }) {
             </div>
           </div>
           <button
+            type="button"
             onClick={handleDecline}
+            aria-label="Cerrar sin aceptar"
             className="p-2 rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200"
           >
-            <X size={20} />
+            <X size={20} aria-hidden="true" />
           </button>
         </div>
 

--- a/src/components/InputLogForm.jsx
+++ b/src/components/InputLogForm.jsx
@@ -112,10 +112,11 @@ export const InputLogForm = ({ assetId, onComplete }) => {
       <div className="space-y-3">
         {/* Selector de Material */}
         <div className="flex flex-col gap-1">
-          <label className="text-[10px] text-slate-500 font-bold uppercase">
+          <label htmlFor="input-log-material" className="text-[10px] text-slate-400 font-bold uppercase">
             Biopreparado / Insumo
           </label>
           <select
+            id="input-log-material"
             value={formData.material}
             onChange={(e) => setFormData({ ...formData, material: e.target.value })}
             className="bg-slate-800 border border-slate-700 rounded-lg text-sm p-2.5 text-white focus:ring-1 focus:ring-blue-500 outline-none"
@@ -139,8 +140,9 @@ export const InputLogForm = ({ assetId, onComplete }) => {
         <div className="grid grid-cols-2 gap-3">
           {/* Cantidad */}
           <div className="flex flex-col gap-1">
-            <label className="text-[10px] text-slate-500 font-bold uppercase">Cantidad</label>
+            <label htmlFor="input-log-cantidad" className="text-[10px] text-slate-400 font-bold uppercase">Cantidad</label>
             <input
+              id="input-log-cantidad"
               type="number"
               step="0.01"
               min="0"
@@ -154,8 +156,9 @@ export const InputLogForm = ({ assetId, onComplete }) => {
 
           {/* Unidad */}
           <div className="flex flex-col gap-1">
-            <label className="text-[10px] text-slate-500 font-bold uppercase">Unidad</label>
+            <label htmlFor="input-log-unidad" className="text-[10px] text-slate-400 font-bold uppercase">Unidad</label>
             <select
+              id="input-log-unidad"
               value={formData.unit}
               onChange={(e) => setFormData({ ...formData, unit: e.target.value })}
               className="bg-slate-800 border border-slate-700 rounded-lg text-sm p-2.5 text-white outline-none"
@@ -171,10 +174,11 @@ export const InputLogForm = ({ assetId, onComplete }) => {
 
         {/* Notas */}
         <div className="flex flex-col gap-1">
-          <label className="text-[10px] text-slate-500 font-bold uppercase">
+          <label htmlFor="input-log-notas" className="text-[10px] text-slate-400 font-bold uppercase">
             Observaciones Técnicas
           </label>
           <textarea
+            id="input-log-notas"
             rows="2"
             value={formData.notes}
             onChange={(e) => setFormData({ ...formData, notes: e.target.value })}

--- a/src/components/InventoryAuditDashboard.jsx
+++ b/src/components/InventoryAuditDashboard.jsx
@@ -138,10 +138,12 @@ export default function InventoryAuditDashboard() {
                         {isDiffOnly ? 'Ver Todos' : 'Ver solo discrepancias'}
                     </button>
                     <button
+                        type="button"
                         onClick={loadData}
+                        aria-label="Recargar datos de auditoría"
                         className="p-2.5 rounded-xl bg-slate-800 border border-slate-700 text-slate-300 hover:bg-slate-700 active:scale-95 transition-all"
                     >
-                        <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
+                        <RefreshCw size={18} aria-hidden="true" className={loading ? 'animate-spin' : ''} />
                     </button>
                 </div>
             </header>

--- a/src/components/OnboardingCondensado.jsx
+++ b/src/components/OnboardingCondensado.jsx
@@ -196,6 +196,7 @@ function VeredaPicker({ vereda, opciones, onSelect, onFreeText }) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={hasDataset ? 'Busque su vereda…' : 'Escriba su vereda'}
+          aria-label="Vereda de su finca"
           className="w-full pl-9 pr-3 py-2.5 text-base rounded-xl bg-slate-900 border border-slate-600 text-white placeholder-slate-500 focus:outline-none focus:border-emerald-500/60"
           data-testid="onb2-vereda-input"
         />
@@ -678,6 +679,7 @@ export default function OnboardingCondensado({
                     <select
                       value={manualDpto}
                       onChange={(e) => setManualDpto(e.target.value)}
+                      aria-label="Departamento"
                       className="w-full px-3 py-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white"
                       data-testid="onb2-dpto"
                     >
@@ -695,6 +697,7 @@ export default function OnboardingCondensado({
                           const m = getMunicipios(manualDpto).find((x) => x.name === e.target.value);
                           if (m) escogerMunicipioManual(m, manualDpto);
                         }}
+                        aria-label="Municipio"
                         className="w-full px-3 py-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white"
                         data-testid="onb2-municipio"
                       >

--- a/src/components/OnboardingHero.jsx
+++ b/src/components/OnboardingHero.jsx
@@ -234,7 +234,7 @@ export default function OnboardingHero({ onNavigate, compact = false }) {
               {cta.emoji}
             </span>
             <span className="text-2xl font-black">{cta.label}</span>
-            <span className="text-xs text-slate-500">{cta.desc}</span>
+            <span className="text-xs text-slate-400">{cta.desc}</span>
           </button>
         ))}
       </div>

--- a/src/components/PhotoViewer.jsx
+++ b/src/components/PhotoViewer.jsx
@@ -33,7 +33,11 @@ export default function PhotoViewer({
         ref={containerRef}
         className="fixed inset-0 z-[100] bg-black flex items-center justify-center"
         onClick={handleTap}
-        role="presentation"
+        /* a11y: visor a pantalla completa = diálogo modal (antes role=presentation,
+           invisible para el lector de pantalla). El cierre accesible es el botón X. */
+        role="dialog"
+        aria-modal="true"
+        aria-label={alt || 'Foto ampliada'}
       >
         <img
           src={src}

--- a/src/components/SpeciesCombobox.jsx
+++ b/src/components/SpeciesCombobox.jsx
@@ -168,6 +168,21 @@ export const SpeciesCombobox = ({
       <div
         className="w-full flex items-center gap-2 p-4 rounded-xl bg-slate-900 border border-slate-700 cursor-pointer min-h-[64px]"
         onClick={() => setOpen(true)}
+        /* a11y (teclado): cerrado, la caja ES el botón que abre el combobox.
+           Abierto, el rol lo lleva el input interior (sin role duplicado). */
+        {...(!open ? {
+          role: 'button',
+          tabIndex: 0,
+          'aria-haspopup': 'listbox',
+          'aria-expanded': false,
+          'aria-label': `${label}: abrir buscador de especies`,
+          onKeyDown: (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setOpen(true);
+            }
+          },
+        } : {})}
       >
         <Search size={18} className="text-slate-500 shrink-0" aria-hidden="true" />
         {open ? (
@@ -179,6 +194,7 @@ export const SpeciesCombobox = ({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={placeholder}
+            aria-label={`Buscar especie para ${label}`}
             className="flex-1 bg-transparent text-white text-lg outline-none placeholder-slate-500"
             onClick={(e) => e.stopPropagation()}
             data-testid="species-combobox-input"

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -410,8 +410,23 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
       <div
         className="w-full flex items-center gap-2 p-3 rounded-xl bg-slate-800 border border-slate-700 cursor-pointer"
         onClick={() => setOpen(true)}
+        /* a11y (teclado): cerrado, la caja ES el botón que abre el buscador.
+           Abierto, el foco vive en el input interior. */
+        {...(!open ? {
+          role: 'button',
+          tabIndex: 0,
+          'aria-haspopup': 'listbox',
+          'aria-expanded': false,
+          'aria-label': 'Seleccionar especie: abrir buscador',
+          onKeyDown: (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setOpen(true);
+            }
+          },
+        } : {})}
       >
-        <Search size={16} className="text-slate-500 shrink-0" />
+        <Search size={16} className="text-slate-500 shrink-0" aria-hidden="true" />
         {open ? (
           <input
             ref={queryInputRef}
@@ -420,6 +435,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Buscar especie… (ej: gulpa, café, mora)"
+            aria-label="Buscar especie"
             className="flex-1 bg-transparent text-white text-sm outline-none"
             onClick={(e) => e.stopPropagation()}
           />
@@ -432,9 +448,10 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); handleClear(); }}
+            aria-label="Quitar especie seleccionada"
             className="p-1 hover:bg-slate-700 rounded text-slate-400"
           >
-            <X size={14} />
+            <X size={14} aria-hidden="true" />
           </button>
         )}
         <ChevronDown size={16} className={`text-slate-500 transition-transform ${open ? 'rotate-180' : ''}`} />

--- a/src/components/WelcomeStatsHero.jsx
+++ b/src/components/WelcomeStatsHero.jsx
@@ -457,7 +457,7 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate = und
           </h2>
           <div className="flex items-center gap-2 shrink-0">
             {isPreLogin && !collapsed && (
-              <span className="text-[10px] text-slate-500 italic hidden sm:inline">
+              <span className="text-[10px] text-slate-400 italic hidden sm:inline">
                 {fincasActivas} {fincasActivas === 1 ? 'finca' : 'fincas'} · red Chagra
               </span>
             )}
@@ -540,7 +540,7 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate = und
                   </div>
                 )}
                 {current.caption && (
-                  <div className="text-[10px] sm:text-[11px] text-slate-500 mt-1.5 leading-snug italic">
+                  <div className="text-[10px] sm:text-[11px] text-slate-400 mt-1.5 leading-snug italic">
                     {current.caption}
                   </div>
                 )}
@@ -576,7 +576,7 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate = und
               <div className="text-lg font-black text-lime-300 leading-tight">
                 {isPreLogin ? GLOBAL_FEDERATION_FALLBACK.plantasRegistradas : plantsCount}
               </div>
-              <div className="text-[9px] text-slate-500 truncate">
+              <div className="text-[9px] text-slate-400 truncate">
                 {isPreLogin ? MSG.welcomeStats.plantasRegistradas : (plantsCount === 1 ? MSG.welcomeStats.plantaTuya : MSG.welcomeStats.plantasTuyas)}
               </div>
             </div>
@@ -585,14 +585,14 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate = und
             <BookOpen className="w-3.5 h-3.5 text-violet-400 shrink-0" />
             <div className="min-w-0">
               <div className="text-lg font-black text-violet-300 leading-tight">{catalogStats.ragDocs}</div>
-              <div className="text-[9px] text-slate-500 truncate">Fichas IA</div>
+              <div className="text-[9px] text-slate-400 truncate">Fichas IA</div>
             </div>
           </div>
           <div className="bg-slate-800/30 border border-slate-700/40 rounded-lg p-2 flex items-center gap-2 col-span-2 sm:col-span-1">
             <Leaf className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
             <div className="min-w-0">
               <div className="text-lg font-black text-emerald-300 leading-tight">{catalogStats.species}</div>
-              <div className="text-[9px] text-slate-500 truncate">Especies catálogo</div>
+              <div className="text-[9px] text-slate-400 truncate">Especies catálogo</div>
             </div>
           </div>
         </div>)}
@@ -656,7 +656,7 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate = und
                       </div>
                     )}
                     {stat.caption && (
-                      <div className="text-[11px] text-slate-500 mt-2 leading-snug italic">
+                      <div className="text-[11px] text-slate-400 mt-2 leading-snug italic">
                         {stat.caption}
                       </div>
                     )}
@@ -671,7 +671,7 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate = und
               })}
             </div>
 
-            <div className="text-[11px] text-slate-500 italic text-center pt-2 pb-6">
+            <div className="text-[11px] text-slate-400 italic text-center pt-2 pb-6">
               Soberanía alimentaria · agroecología campesina colombiana · código abierto AGPL-3.0
             </div>
           </div>

--- a/src/components/cosecha/MiCosechaScreen.jsx
+++ b/src/components/cosecha/MiCosechaScreen.jsx
@@ -208,20 +208,23 @@ function BarrasPorCultivo({ byCrop }) {
       )}
       <details className="mc-table">
         <summary>Ver los números en tabla</summary>
-        <table>
-          <thead>
-            <tr><th scope="col">Cultivo</th><th scope="col">Cosechas</th><th scope="col">Total</th></tr>
-          </thead>
-          <tbody>
-            {byCrop.map((c) => (
-              <tr key={c.cropKey}>
-                <td>{c.crop}</td>
-                <td>{nf0.format(c.harvestCount)}</td>
-                <td>{c.totalKg > 0 ? `${fmtCant(c.totalKg)} kg` : `${nf0.format(c.totalCount)} und`}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        {/* 320px: la tabla scrollea dentro de su propio contenedor, nunca la página. */}
+        <div className="overflow-x-auto">
+          <table>
+            <thead>
+              <tr><th scope="col">Cultivo</th><th scope="col">Cosechas</th><th scope="col">Total</th></tr>
+            </thead>
+            <tbody>
+              {byCrop.map((c) => (
+                <tr key={c.cropKey}>
+                  <td>{c.crop}</td>
+                  <td>{nf0.format(c.harvestCount)}</td>
+                  <td>{c.totalKg > 0 ? `${fmtCant(c.totalKg)} kg` : `${nf0.format(c.totalCount)} und`}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </details>
     </section>
   );
@@ -312,20 +315,23 @@ function Tendencia({ trend, season }) {
           )}
           <details className="mc-table">
             <summary>Ver los números en tabla</summary>
-            <table>
-              <thead>
-                <tr><th scope="col">Mes</th><th scope="col">Cosechas</th><th scope="col">Total</th></tr>
-              </thead>
-              <tbody>
-                {serie.map((s) => (
-                  <tr key={s.period}>
-                    <td>{mesLabel(s.period)}</td>
-                    <td>{nf0.format(s.harvestCount)}</td>
-                    <td>{`${fmtCant(valorDe(s, usesKg))} ${unidad}`}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            {/* 320px: la tabla scrollea dentro de su propio contenedor. */}
+            <div className="overflow-x-auto">
+              <table>
+                <thead>
+                  <tr><th scope="col">Mes</th><th scope="col">Cosechas</th><th scope="col">Total</th></tr>
+                </thead>
+                <tbody>
+                  {serie.map((s) => (
+                    <tr key={s.period}>
+                      <td>{mesLabel(s.period)}</td>
+                      <td>{nf0.format(s.harvestCount)}</td>
+                      <td>{`${fmtCant(valorDe(s, usesKg))} ${unidad}`}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </details>
         </>
       ) : (

--- a/src/components/dashboard/ClimaStrip.jsx
+++ b/src/components/dashboard/ClimaStrip.jsx
@@ -533,7 +533,9 @@ export default function ClimaStrip({ onNavigate, embedded = false }) {
                 exactamente lo que la consolidación recorta (los íconos ya se
                 explican solos con el title por día). */}
             {!embedded && (
-                <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
+                // 320px: con 3 columnas fijas "Helada ≤ 0 °C" se truncaba;
+                // a 2 columnas en pantallas angostas la leyenda respira.
+                <div className="mt-3 grid grid-cols-2 min-[400px]:grid-cols-3 gap-2 text-xs">
                     <div className="flex items-center gap-1.5 text-slate-300">
                         <Thermometer size={14} className="text-rose-400" />
                         <span className="truncate">Máx/Mín</span>

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -602,7 +602,9 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
         >
             <tile.icon size={large ? 30 : 24} strokeWidth={2} className={`${large ? 'mb-2' : 'mb-1.5'} ${tile.accent.split(' ')[0]}`} aria-hidden="true" />
             <span className={`${large ? 'text-base' : 'text-sm'} font-black block leading-tight fvh-tile-label ${tile.accent.split(' ')[0]}`}>{tileLabel(tile)}</span>
-            <span className={`${large ? 'text-xs mt-1 leading-snug' : 'text-2xs mt-0.5 leading-tight'} block fvh-tile-desc ${fincaVivaFlag ? '' : (large ? 'text-slate-400' : 'text-slate-500')}`}>{tileDesc(tile)}</span>
+            {/* a11y AA: la desc era text-slate-500 sobre slate-900 (~3.4:1, falla
+                contraste en texto pequeño). slate-400 da ~7:1 sin cambiar jerarquía. */}
+            <span className={`${large ? 'text-xs mt-1 leading-snug' : 'text-2xs mt-0.5 leading-tight'} block fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-400'}`}>{tileDesc(tile)}</span>
         </button>
     );
 
@@ -620,7 +622,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     <MERCADO_TILE.icon size={26} strokeWidth={2} className={`${MERCADO_TILE.accent.split(' ')[0]} shrink-0`} aria-hidden="true" />
                     <span className="flex-1 min-w-0">
                         <span className={`text-sm font-black block leading-tight fvh-tile-label ${MERCADO_TILE.accent.split(' ')[0]}`}>{MERCADO_TILE.label}</span>
-                        <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-500'}`}>{MERCADO_TILE.desc}</span>
+                        <span className={`text-2xs block mt-0.5 leading-tight fvh-tile-desc ${fincaVivaFlag ? '' : 'text-slate-400'}`}>{MERCADO_TILE.desc}</span>
                     </span>
                     <ChevronRight size={18} className={`shrink-0 ${MERCADO_TILE.accent.split(' ')[0]} opacity-70`} aria-hidden="true" />
                 </button>
@@ -879,12 +881,12 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                                 </span>
                                 <ChevronRight size={22} className="shrink-0 text-slate-500" aria-hidden="true" />
                             </button>
-                            <div className="grid grid-cols-3 gap-3 mt-3" data-testid="gestion-tiles">
+                            <div className="grid grid-cols-2 min-[400px]:grid-cols-3 gap-3 mt-3" data-testid="gestion-tiles">
                                 {GESTION_TILES.filter((t) => t.view === 'germinacion').map((tile, i) => renderTile(tile, { i }))}
                             </div>
                         </>
                     ) : (
-                        <div className="grid grid-cols-3 gap-3" data-testid="gestion-tiles">
+                        <div className="grid grid-cols-2 min-[400px]:grid-cols-3 gap-3" data-testid="gestion-tiles">
                             {GESTION_TILES.map((tile, i) => renderTile(tile, { i }))}
                         </div>
                     )}
@@ -1038,7 +1040,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
             {/* APRENDER — hub único de contenido (con OFF SÍ incluye 'aprende'). */}
             <div className="px-4 pt-3">
                 {blockLabel('Aprender', 'from-emerald-400 to-teal-400')}
-                <div className="grid grid-cols-3 gap-3" data-testid="aprender-tiles">
+                <div className="grid grid-cols-2 min-[400px]:grid-cols-3 gap-3" data-testid="aprender-tiles">
                     {APRENDER_TILES.map((tile, i) => renderTile(tile, { i }))}
                 </div>
             </div>
@@ -1051,7 +1053,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                 className="px-4 pt-3"
             >
                 {blockLabel('Mi finca · gestión', 'from-sky-400 to-emerald-400')}
-                <div className="grid grid-cols-3 gap-3" data-testid="gestion-tiles">
+                <div className="grid grid-cols-2 min-[400px]:grid-cols-3 gap-3" data-testid="gestion-tiles">
                     {GESTION_TILES.map((tile, i) => renderTile(tile, { i }))}
                 </div>
             </div>
@@ -1099,8 +1101,10 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     </SortableContext>
                 </DndContext>
 
-                <p className="text-[10px] text-center mt-4 italic text-slate-600">
-                    Mantén presionado el ⋮⋮ para reorganizar a tu gusto
+                {/* a11y AA: slate-600 a 10px daba ~2.7:1 de contraste. slate-400
+                    + 11px mantiene el tono discreto pero legible. */}
+                <p className="text-[11px] text-center mt-4 italic text-slate-400">
+                    Mantenga presionado el ⋮⋮ para reorganizar a su gusto
                 </p>
 
                 {/* AIStatusFooter — barra inferior con status proactivo IA. */}

--- a/src/components/hoy/HoyEnFincaScreen.jsx
+++ b/src/components/hoy/HoyEnFincaScreen.jsx
@@ -414,7 +414,7 @@ export default function HoyEnFincaScreen({ onBack, onHome, onNavigate }) {
                                     )}
                                 </button>
                             ))}
-                            <p className="text-[10px] text-slate-500 leading-snug">
+                            <p className="text-[10px] text-slate-400 leading-snug">
                                 Labores sugeridas por la etapa del cultivo
                                 {ensoPhase !== 'neutral' ? ' y el estado del clima (NOAA/IDEAM)' : ''}.
                                 No reemplazan el ojo del campesino.

--- a/src/index.css
+++ b/src/index.css
@@ -539,6 +539,10 @@
    * limpia para campesino/niña: negritas marcadas, viñetas reales con punto,
    * títulos legibles — CERO asteriscos a la vista. El HTML viene sanitizado por
    * renderAgentMarkdown (escape + DOMPurify allow-list). */
+  .agent-md {
+    /* 320px: una URL o palabra larga del modelo no debe desbordar la burbuja. */
+    overflow-wrap: break-word;
+  }
   .agent-md > :first-child {
     margin-top: 0;
   }


### PR DESCRIPTION
Auditoría de accesibilidad (WCAG AA) + barrido responsive a 320px sobre las pantallas REALES de producción (`src/components/`, sin tocar `src/mockups/`). Fixes P0/P1 quirúrgicos: aria/labels/roles faltantes, contraste AA y overflows a 320px. Sin rediseños.

## Tabla de hallazgos y fixes

| Pantalla / componente | Hallazgo | Severidad | Fix |
|---|---|---|---|
| SpeciesCombobox (registro de plantas) | Disparador del selector era `<div onClick>` sin role/tabIndex/teclado: imposible abrirlo sin mouse/touch | **P0** | `role="button"` + `tabIndex` + Enter/Espacio (condicional al estado cerrado) + `aria-haspopup/expanded` + aria-label en el input de búsqueda |
| SpeciesSelect (registro/formularios) | Mismo patrón `<div onClick>` sin teclado; botón X de limpiar sin nombre accesible | **P0** | Igual que arriba + `aria-label="Quitar especie seleccionada"` |
| DashboardLive (dashboard clásico, flag OFF) | Grids `grid-cols-3` fijos (Aprender / Mi finca · gestión / gestión F2): a 320px cada tile queda con ~64px de texto — cortado e ilegible | **P1** | `grid-cols-2 min-[400px]:grid-cols-3` (a ≥400px queda idéntico a hoy) |
| DashboardLive | Descripciones de tiles `text-slate-500/600` sobre `slate-900` (~3.4:1) y hint de reordenar `text-slate-600` a 10px (~2.7:1) — fallan AA 4.5:1 | **P1** | `text-slate-400` (~7:1); hint a 11px. De paso el hint pasó de tuteo a usted |
| AgentScreen (chat del agente) | `<textarea>` principal sin nombre accesible (solo placeholder) | **P1** | `aria-label="Escriba su mensaje para Chagra"` |
| AgentScreen / ChatBubble + `.agent-md` | `whitespace-pre-wrap` sin `break-words`: una URL o palabra larga desborda la burbuja en horizontal a 320px | **P1** | `break-words` en la burbuja + `overflow-wrap: break-word` en `.agent-md` (index.css) |
| ActionConfirmModal (confirmación de acciones del agente) | Overlay sin `role="dialog"`/`aria-modal`; botón X sin aria-label | **P1** | `role="dialog"` + `aria-modal` + `aria-label`; X etiquetada; backdrop `aria-hidden` |
| FeedbackConsentModal | Ídem | **P1** | Ídem |
| PhotoViewer (visor de fotos fullscreen) | `role="presentation"` en un modal fullscreen: invisible para lector de pantalla | **P1** | `role="dialog"` + `aria-modal` + `aria-label` |
| InputLogForm (registro de aplicación de insumos) | 4 campos (`select` material, cantidad, `select` unidad, observaciones) con `<label>` hermano sin `htmlFor`/`id`; labels en `slate-500` a 10px | **P1** | `htmlFor`+`id` en los 4 pares; labels a `slate-400` |
| OnboardingCondensado (onboarding) | Input de búsqueda de vereda y selects de departamento/municipio sin nombre accesible | **P1** | `aria-label` en los tres |
| InventoryAuditDashboard | Botón de recargar solo-ícono (`RefreshCw`) sin aria-label ni `type` | **P1** | `type="button"` + `aria-label="Recargar datos de auditoría"` |
| WelcomeStatsHero (portada del login) | 7 captions de estadísticas en `text-slate-500` a 9-11px (~4.2:1, bajo AA) | **P1** | `text-slate-400` |
| OnboardingHero (primer uso del home) | Descripción de los 3 CTAs en `slate-500` sobre `slate-950` | **P1** | `text-slate-400` |
| ClimaStrip (leyenda clima 7 días) | `grid-cols-3` fijo truncaba "Helada ≤ 0 °C" a 320px | **P2** | `grid-cols-2 min-[400px]:grid-cols-3` |
| MiCosechaScreen (tablas "ver los números") | 2 tablas sin contenedor `overflow-x-auto`: riesgo de scroll horizontal de página a 320px | **P2** | Wrapper `overflow-x-auto` (scrollea la tabla, no la página) |
| HoyEnFincaScreen | Caption de labores sugeridas en `slate-500` a 10px | **P2** | `text-slate-400` |

## Verificado como correcto (sin cambios)

- `index.html` con `lang="es"`; anillo de foco global `focus-visible` (index.css:381-388) sobre button/a/input/select/textarea; `prefers-reduced-motion` global.
- Cero `<img>` sin `alt` en producción (incluidos tags multilínea).
- TopBar, ScreenShell, LoginScreen, MundoScreen, AgentHero, OnboardingModal, MultiFincaModal, PlantCemeteryModal: targets ≥44px, labels asociados, roles de diálogo/menú correctos.
- Tablas de inventario/animales ya con `overflow-x-auto`; `NotificationsBell` responsive a 320px.

## Deuda anotada (P2, no aplicada — fuera del criterio quirúrgico)

- Backdrops `div onClick` de EscuchaOverlay, CicloVivoFullView, InventoryDashboard y BackgroundSelector: patrón backdrop-decorativo (no focusable, hay botón de cierre); se puede homogeneizar con `aria-hidden` en un follow-up.
- `cacao/CacaoScreen.jsx:649` tablist `grid-cols-5` (~56px/celda a 320px): cambiarlo altera la navegación por pestañas; requiere decisión de diseño.
- Drag handle de secciones del dashboard (~22px): tiene alternativa de teclado (dnd-kit KeyboardSensor); ampliarlo compite con el ancho de las cards.
- `LegalLinks.jsx` tabla 2 columnas: el texto envuelve, riesgo real bajo.

## Verificación

- `npm run build` verde.
- `node scripts/tsc-check-gate.mjs`: baseline 868, cero errores nuevos.
- `npx eslint` sobre los 17 archivos: **cero errores nuevos en las líneas modificadas**. Los pocos errores que reporta ESLint (react-hooks setState-in-effect, `Date.now` en render, un import sin usar) están en líneas preexistentes que este PR no toca (deuda de lint del repo, análoga al baseline de 868 de tsc); verificado cotejando los rangos de hunk contra las líneas señaladas.
- Suites de dashboard / hoy / WelcomeStatsHero en verde. Los 3 fallos observados en la corrida completa son ajenos a este PR (probado con `git stash` contra `origin/main`): 2 de `DashboardLive.glaciarBanner` fallan idénticos en baseline (crash de `getGuardianEspecie()` sin mockear en GuardianEspiritu, no tocado) y 1 de `FincaVivaResto.noSolapa` es un timeout-flake bajo carga que pasa 5/5 en aislamiento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
