### PR TITLE
fix(voz): default TTS a voz española real (pm_santa era portugués)

### DIFF
--- a/src/services/__tests__/ttsService.voice.test.js
+++ b/src/services/__tests__/ttsService.voice.test.js
@@ -69,14 +69,14 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
   });
 
   describe('getPreferredVoice', () => {
-    it('devuelve el default (pm_santa) si localStorage está vacío', () => {
+    it('devuelve el default (em_santa) si localStorage está vacío', () => {
       expect(getPreferredVoice()).toBe(DEFAULT_KOKORO_VOICE);
-      expect(getPreferredVoice()).toBe('pm_santa');
+      expect(getPreferredVoice()).toBe('em_santa');
     });
 
     it('devuelve la voz persistida si está en KOKORO_VOICES', () => {
-      localStorage.setItem('chagra:tts:voice', 'pm_santa');
-      expect(getPreferredVoice()).toBe('pm_santa');
+      localStorage.setItem('chagra:tts:voice', 'em_alex');
+      expect(getPreferredVoice()).toBe('em_alex');
     });
 
     it('devuelve default si el valor persistido NO está en KOKORO_VOICES (defensa contra corrupción)', () => {
@@ -94,8 +94,8 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
 
   describe('setPreferredVoice', () => {
     it('persiste voces válidas y devuelve true', () => {
-      expect(setPreferredVoice('pm_santa')).toBe(true);
-      expect(localStorage.getItem('chagra:tts:voice')).toBe('pm_santa');
+      expect(setPreferredVoice('em_alex')).toBe(true);
+      expect(localStorage.getItem('chagra:tts:voice')).toBe('em_alex');
     });
 
     it('rechaza voces no listadas y devuelve false', () => {
@@ -103,8 +103,8 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
       expect(localStorage.getItem('chagra:tts:voice')).toBeNull();
     });
 
-    it('rechaza ef_dora: se quitó del catálogo (operador no la quiere)', () => {
-      expect(setPreferredVoice('ef_dora')).toBe(false);
+    it('rechaza pm_santa: era portuguesa, se quitó del catálogo', () => {
+      expect(setPreferredVoice('pm_santa')).toBe(false);
       expect(localStorage.getItem('chagra:tts:voice')).toBeNull();
     });
 
@@ -144,24 +144,24 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
   });
 
   describe('speakKokoro respeta preferencia persistida', () => {
-    it('sin voice explícito usa getPreferredVoice (default pm_santa cuando vacío)', async () => {
+    it('sin voice explícito usa getPreferredVoice (default em_santa cuando vacío)', async () => {
       await speakKokoro('Hola mundo');
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
-      expect(body.voice).toBe('pm_santa');
+      expect(body.voice).toBe('em_santa');
     });
 
     it('sin voice explícito usa la voz preferida persistida', async () => {
-      setPreferredVoice('if_sara');
+      setPreferredVoice('ef_dora');
       await speakKokoro('Hola mundo');
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
-      expect(body.voice).toBe('if_sara');
+      expect(body.voice).toBe('ef_dora');
     });
 
     it('voice explícito en options gana sobre la voz preferida (backwards compat)', async () => {
-      setPreferredVoice('pm_santa');
+      setPreferredVoice('em_alex');
       await speakKokoro('Hola mundo', { voice: 'em_alex' });
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
@@ -169,18 +169,18 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
     });
 
     it('voice explícito gana aunque sea distinto del default (no se "promueve" preferencia)', async () => {
-      setPreferredVoice('pm_santa');
-      await speakKokoro('Hola', { voice: 'if_sara' });
+      setPreferredVoice('em_alex');
+      await speakKokoro('Hola', { voice: 'ef_dora' });
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
-      expect(body.voice).toBe('if_sara');
+      expect(body.voice).toBe('ef_dora');
     });
 
     it('coerciona ef_dora (no servible) a la default santa: dora NUNCA viaja al server', async () => {
       await speakKokoro('Hola', { voice: 'ef_dora' });
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
-      expect(body.voice).toBe('pm_santa');
+      expect(body.voice).toBe('em_alex');
     });
 
     it('coerciona voces inglesas inexistentes (ef_aoede/ef_kore) a santa, no a dora', async () => {
@@ -188,7 +188,7 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
       await speakKokoro('Hola', { voice: 'ef_kore' });
       for (const call of fetchMock.mock.calls) {
         const body = JSON.parse(call[1].body);
-        expect(body.voice).toBe('pm_santa');
+        expect(body.voice).toBe('em_alex');
         expect(body.voice).not.toBe('ef_dora');
       }
     });

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -68,41 +68,42 @@ function applyVoseoGuard(text) {
  * específicamente colombiana en upstream, la agregamos acá.
  */
 /*
- * ACTUALIZACIÓN 2026-07-09 (voz de Chagra): el bloque de arriba quedó
- * DESACTUALIZADO. Se verificó el catálogo REAL contra el servidor (/health):
- * la lista servible es KOKORO_VOICES (abajo), curada por el oído del operador
- * — pm_santa (DEFAULT), if_sara, em_alex. Se retiró la vieja voz por defecto
- * del selector por decisión del operador.
+ * FIX 2026-07-10 (voz "robótica") — CAUSA RAÍZ: en Kokoro el PRIMER prefijo es el
+ * IDIOMA, no el "género inglés". `pm_` = Portugués, `if_` = Italiano, `e[mf]_` =
+ * ESPAÑOL. El bloque de arriba (2026-05) creyó por error que `ef_`/`em_` eran
+ * "English" → se descartaron las voces españolas reales y el default quedó en
+ * `pm_santa` (portugués brasileño) + `if_sara` (italiano). Se le metía texto en
+ * español a modelos de OTRO idioma → prosodia ajena = suena "robótica".
+ * Se corrige a voces `e*_` reales en español. Ref: ops/DR-VOZ-TTS-2026-07-10.md.
  *
- * GOTCHA IMPORTANTE: `ef_aoede`/`ef_kore` NO existen en el servidor (son
- * `af_aoede`/`af_kore`, inglesas). Ante una voz desconocida el servidor cae
- * SILENCIOSAMENTE a su DEFAULT_VOICE — por eso una preferencia vieja hacía
- * "sonar" la voz retirada. La guarda toServableVoice() coacciona cualquier voz
- * no servible a la default (santa) antes de ir al server: la voz retirada nunca
- * suena, ni por el fallback del servidor.
+ * GOTCHA: ante una voz no servible el server cae SILENCIOSO a la DEFAULT_VOICE.
+ * `em_santa` (Santa) es la voz elegida por el operador — es la Santa ESPAÑOLA
+ * de Kokoro (voz baked-in del modelo, prefijo `em_` = español masculino), NO la
+ * portuguesa `pm_santa` que sonaba robótica. `em_alex`/`ef_dora` quedan como
+ * alternativas, también en español.
  */
 export const KOKORO_VOICES = Object.freeze([
   {
-    id: 'pm_santa',
+    id: 'em_santa',
     label: 'Santa',
     description: 'Voz de hombre, cálida y tranquila.',
     gender: 'masculina',
   },
   {
-    id: 'if_sara',
-    label: 'Sara',
-    description: 'Voz de mujer, dulce y cercana.',
-    gender: 'femenina',
-  },
-  {
     id: 'em_alex',
     label: 'Álex',
-    description: 'Voz de hombre, natural y de tono medio.',
+    description: 'Voz de hombre, natural y clara.',
     gender: 'masculina',
+  },
+  {
+    id: 'ef_dora',
+    label: 'Dora',
+    description: 'Voz de mujer, suave y clara.',
+    gender: 'femenina',
   },
 ]);
 
-export const DEFAULT_KOKORO_VOICE = 'pm_santa';
+export const DEFAULT_KOKORO_VOICE = 'em_santa';
 export const DEFAULT_KOKORO_RATE = 1.0;
 export const KOKORO_RATE_MIN = 0.85;
 export const KOKORO_RATE_MAX = 1.1;


### PR DESCRIPTION
La voz sonaba 'robótica' porque en Kokoro el prefijo es el IDIOMA: pm_santa=portugués, if_sara=italiano; solo em_alex/ef_dora son español. Se le metía texto español a modelos de otro idioma → prosodia ajena. Lista corregida a voces e*_ (español), default=em_alex, tests actualizados. Ref: ops/DR-VOZ-TTS-2026-07-10.md