### PR TITLE
feat(mockup): valle 3D ronda 2 — abeja-avatar, entrar al mundo, device-tiering

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -35,33 +35,79 @@ import {
   CLIMAS,
   ORDEN_CLIMA,
   climaPorHora,
+  animoDeFinca,
   NARRACION,
 } from './valle/valleData';
 import Valle2DFallback from './valle/Valle2DFallback';
+import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
 
 // La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso.
 const Valle3D = lazy(() => import('./valle/Valle3D'));
 
-/** ¿El equipo soporta WebGL? (línea base del render 3D). */
-function soportaWebGL() {
-  if (typeof window === 'undefined') return false;
+/**
+ * DEVICE-TIERING REAL. La 3D es ASPIRACIONAL (gama media+). No basta con
+ * preguntar "¿hay WebGL?": un teléfono humilde tiene WebGL pero sufre jank y
+ * calor. Entonces degradamos a la 2D DIGNA también por señales de equipo débil:
+ * poca RAM, pocos núcleos, ahorro de datos o preferencia de menos movimiento.
+ * Devuelve { modo: '2d' | '3d', motivo } — el motivo ajusta el aviso al usuario.
+ */
+function decidirRender() {
+  if (typeof window === 'undefined') return { modo: '2d', motivo: 'ssr' };
+  /* `deviceMemory` y `connection` son APIs experimentales que la lib de tipos
+     del DOM aún no declara; se tipan aquí como opcionales (sin `any`). */
+  const nav =
+    /** @type {Navigator & { deviceMemory?: number, connection?: { saveData?: boolean }, mozConnection?: { saveData?: boolean }, webkitConnection?: { saveData?: boolean } }} */ (
+      window.navigator
+    );
+
+  // 1) WebGL es requisito DURO del render 3D.
+  let webgl = false;
   try {
     const canvas = document.createElement('canvas');
-    return !!(
+    webgl = !!(
       window.WebGLRenderingContext &&
       (canvas.getContext('webgl2') || canvas.getContext('webgl'))
     );
   } catch {
-    return false;
+    webgl = false;
   }
+  if (!webgl) return { modo: '2d', motivo: 'sin-webgl' };
+
+  // 2) Equipos humildes → 2D (no los ponemos a sudar la GPU).
+  const mem = nav.deviceMemory; // GiB aprox. (Chrome/Android); undefined en otros
+  if (typeof mem === 'number' && mem > 0 && mem <= 3) return { modo: '2d', motivo: 'equipo' };
+
+  const nucleos = nav.hardwareConcurrency;
+  if (typeof nucleos === 'number' && nucleos > 0 && nucleos <= 4) {
+    return { modo: '2d', motivo: 'equipo' };
+  }
+
+  // 3) El usuario pidió ahorrar datos o menos movimiento → respetarlo.
+  const conn = nav.connection || nav.mozConnection || nav.webkitConnection;
+  if (conn && conn.saveData) return { modo: '2d', motivo: 'ahorro' };
+
+  const menosMov =
+    window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (menosMov) return { modo: '2d', motivo: 'calma' };
+
+  return { modo: '3d', motivo: 'ok' };
 }
+
+/* Aviso sobrio de por qué se ve la versión dibujada (nunca "error"). */
+const MENSAJE_DEGRADADO = {
+  calma: 'Le mostramos el valle en calma, sin movimiento. La finca sigue completa.',
+  ahorro: 'Modo ahorro de datos: le mostramos el valle dibujado. La finca sigue completa.',
+  default: 'Su equipo ve la versión dibujada del valle. La finca sigue completa.',
+};
 
 export default function EntradaValle3D({ onBack }) {
   const [clima, setClima] = useState(() => climaPorHora());
   const [focoId, setFocoId] = useState(null);
   const [panel, setPanel] = useState(null); // null | 'alerta' | <mundoId>
   const [voz, setVoz] = useState(true);
-  const [webgl] = useState(() => soportaWebGL());
+  const [alertaVista, setAlertaVista] = useState(false); // ¿ya atendió lo del día?
+  const [render] = useState(decidirRender);
+  const usa3D = render.modo === '3d';
 
   const reducedMotion = useMemo(
     () =>
@@ -69,6 +115,14 @@ export default function EntradaValle3D({ onBack }) {
       window.matchMedia &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches,
     [],
+  );
+
+  // ── El compañero (Angelita): su ánimo/energía salen del estado REAL de la
+  //    finca + el clima + si lo del día sigue sin atender. Cuidar la alerta la
+  //    calma (bucle de cuidado, sin puntos ni medallas).
+  const companero = useMemo(
+    () => animoDeFinca(clima, { hayAlerta: !alertaVista }),
+    [clima, alertaVista],
   );
 
   // ── Voz (Web Speech API): el agente DICE. Se calla si el equipo no la trae
@@ -122,6 +176,7 @@ export default function EntradaValle3D({ onBack }) {
   const abrirAlerta = useCallback(() => {
     setFocoId(COSA_DEL_DIA.anclaMundo);
     setPanel('alerta');
+    setAlertaVista(true); // atender lo del día calma a la abeja
     hablar(COSA_DEL_DIA.vozTexto);
   }, [hablar]);
 
@@ -135,20 +190,30 @@ export default function EntradaValle3D({ onBack }) {
 
   return (
     <div className="valle-root" data-clima={clima}>
-      {/* fondo/atmósfera 3D o su degradación 2D */}
+      {/* fondo/atmósfera 3D o su degradación 2D (según el tiering del equipo) */}
       <div className="valle-escena">
-        {webgl ? (
+        {usa3D ? (
           <Suspense fallback={<CargandoValle clima={clima} />}>
             <Valle3D
               clima={clima}
               focoId={focoId}
+              animo={companero.animo}
+              energia={companero.energia}
               onEntrar={entrarMundo}
               onAlerta={abrirAlerta}
               reducedMotion={reducedMotion}
             />
           </Suspense>
         ) : (
-          <Valle2DFallback clima={clima} onEntrar={entrarMundo} onAlerta={abrirAlerta} />
+          <Valle2DFallback
+            clima={clima}
+            focoId={focoId}
+            animo={companero.animo}
+            energia={companero.energia}
+            reducedMotion={reducedMotion}
+            onEntrar={entrarMundo}
+            onAlerta={abrirAlerta}
+          />
         )}
       </div>
 
@@ -176,11 +241,23 @@ export default function EntradaValle3D({ onBack }) {
         </div>
       </header>
 
-      {/* ── Sin WebGL: aviso sobrio de que se ve la versión dibujada ── */}
-      {!webgl && (
+      {/* ── Modo dibujado (tiering): aviso sobrio, nunca "error" ── */}
+      {!usa3D && (
         <p className="valle-degradado" role="status">
-          Su equipo ve la versión dibujada del valle. La finca sigue completa.
+          {MENSAJE_DEGRADADO[render.motivo] || MENSAJE_DEGRADADO.default}
         </p>
+      )}
+
+      {/* ── El compañero: Angelita en una sola línea puntual (imagen-first).
+              Es el ser al que se cuida; su cara refleja el ánimo real. Se
+              esconde si hay un panel abierto — una cosa clara a la vez. ── */}
+      {!panel && (
+        <div className="valle-companero" role="status" aria-live="polite">
+          <span className="valle-companero__cara" aria-hidden="true">
+            <AbejaAngelita size={34} animo={companero.animo} energia={companero.energia} animated={!reducedMotion} />
+          </span>
+          <span className="valle-companero__txt">{companero.frase}</span>
+        </div>
       )}
 
       {/* ── Panel de la ALERTA (la cosa del día): UNA acción clara ── */}

--- a/src/mockups/entradaValle3D.css
+++ b/src/mockups/entradaValle3D.css
@@ -193,10 +193,55 @@
   50% { transform: scale(1.06); box-shadow: 0 8px 30px rgba(255, 170, 80, 0.75); }
 }
 
-/* ── El colibrí compañero (SVG de visual-lib) ── */
-.valle-colibri {
+/* ── Angelita, la abeja: el avatar-jugador dentro del 3D (drei <Html>) ── */
+.valle-abeja {
   filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.4));
   pointer-events: none;
+  will-change: transform;
+}
+.valle-abeja__cara {
+  transition: transform 0.25s ease; /* voltea hacia donde vuela */
+  transform-origin: center;
+}
+
+/* ── El compañero como TARJETA puntual (imagen-first, una sola línea) ──
+      El ser al que se cuida vive también en el DOM: su cara refleja el ánimo. */
+.valle-companero {
+  position: absolute;
+  left: 1.1rem;
+  bottom: 5.1rem;
+  z-index: 14;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: min(74vw, 22rem);
+  padding: 0.35rem 0.8rem 0.35rem 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(15, 24, 30, 0.7);
+  color: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.32);
+  animation: valle-companero-in 0.5s ease both;
+}
+.valle-companero__cara {
+  flex: 0 0 auto;
+  display: inline-flex;
+  filter: drop-shadow(0 2px 5px rgba(0, 0, 0, 0.35));
+}
+.valle-companero__txt {
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+@keyframes valle-companero-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* ── Paneles (alerta / mundo): flotan abajo, una acción clara ── */
@@ -366,10 +411,38 @@
   text-align: center;
 }
 
-/* ── Fallback 2D (sin WebGL) ── */
-.valle2d { position: absolute; inset: 0; }
+/* ── Fallback 2D (equipos humildes) ── */
+.valle2d { position: absolute; inset: 0; overflow: hidden; }
+/* cámara-lámina: se acerca hacia el lugar tocado (mismo "entrar" del 3D) */
+.valle2d__cam {
+  position: absolute;
+  inset: 0;
+  transition: transform 0.7s cubic-bezier(0.22, 0.9, 0.3, 1);
+  will-change: transform;
+}
 .valle2d__svg { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; }
 .valle2d__mundos { position: absolute; inset: 0; }
+
+/* Angelita en el 2D: el avatar que vuela hacia el lugar al entrar */
+.valle2d__abeja {
+  position: absolute;
+  transform: translate(-50%, -60%);
+  pointer-events: none;
+  filter: drop-shadow(0 3px 8px rgba(0, 0, 0, 0.4));
+  transition: left 0.8s cubic-bezier(0.3, 0.7, 0.3, 1), top 0.8s cubic-bezier(0.3, 0.7, 0.3, 1);
+  will-change: left, top;
+  animation: valle2d-abeja-flota 3.4s ease-in-out infinite;
+}
+.valle2d__abeja--entrando { animation: none; }
+@keyframes valle2d-abeja-flota {
+  0%, 100% { transform: translate(-50%, -60%); }
+  50% { transform: translate(-50%, -68%); }
+}
+.valle2d__poi--activo {
+  background: rgba(255, 255, 255, 0.94);
+  color: #1c2b1c;
+  border-color: #fff;
+}
 .valle2d__poi {
   position: absolute;
   transform: translate(-50%, -50%);
@@ -425,8 +498,13 @@
   .valle-cargando__pulso,
   .valle-alerta,
   .valle2d__alerta,
+  .valle2d__abeja,
   .valle-agente__punto,
+  .valle-companero,
   .valle-panel { animation: none; }
+  .valle2d__cam,
+  .valle2d__abeja,
+  .valle-abeja__cara { transition: none; }
 }
 
 @media (max-width: 560px) {

--- a/src/mockups/valle/Valle2DFallback.jsx
+++ b/src/mockups/valle/Valle2DFallback.jsx
@@ -1,12 +1,15 @@
 /*
- * Valle2DFallback — la degradación LIMPIA cuando no hay WebGL (o el equipo es
- * humilde). No es una pantalla de error: es una entrada digna en SVG+CSS (el
- * músculo que Chagra ya domina, DR §0) con los MISMOS 4 sí-o-sí — un valle
- * pintado, la cosa del día que brilla, los mundos como lugares tocables, y el
- * clima que tiñe la escena vía las grades de effects. "Wow" se pierde; el
- * PROPÓSITO no.
+ * Valle2DFallback — la degradación LIMPIA cuando el equipo es humilde (sin
+ * WebGL, poca RAM/CPU, ahorro de datos o "menos movimiento"). No es una pantalla
+ * de error: es una entrada digna en SVG+CSS (el músculo que Chagra ya domina,
+ * DR §0) con los MISMOS sí-o-sí — un valle pintado, la cosa del día que brilla,
+ * los mundos como lugares tocables, el clima que tiñe la escena, y Angelita (la
+ * abeja) como avatar-compañero. Al tocar un mundo, la lámina se ACERCA y la
+ * abeja VUELA hasta el lugar: el mismo "entrar al mundo" del 3D, dibujado.
+ * "Wow" 3D se pierde; el PROPÓSITO no.
  */
-import { MUNDOS_VALLE, COSA_DEL_DIA, CLIMAS } from './valleData';
+import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
+import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 
 /* Proyección isométrica plana de las coordenadas del valle a la lámina SVG. */
 function iso(x, z) {
@@ -15,66 +18,105 @@ function iso(x, z) {
   return { cx, cy };
 }
 
-export default function Valle2DFallback({ clima, onEntrar, onAlerta }) {
+/* Posición en % dentro de la lámina (para posicionar botones/abeja en CSS). */
+function pct(x, z) {
+  const { cx, cy } = iso(x, z);
+  return { left: (cx / 400) * 100, top: (cy / 340) * 100 };
+}
+
+export default function Valle2DFallback({
+  clima,
+  focoId,
+  animo = 'sereno',
+  energia = 1,
+  reducedMotion = false,
+  onEntrar,
+  onAlerta,
+}) {
   const c = CLIMAS[clima];
   const ancla = MUNDOS_VALLE.find((m) => m.id === COSA_DEL_DIA.anclaMundo);
   // Mundos ordenados de atrás hacia adelante para que se solapen bien.
   const orden = [...MUNDOS_VALLE].sort((a, b) => a.pos[0] + a.pos[2] - (b.pos[0] + b.pos[2]));
 
+  // "Entrar al mundo": la lámina se acerca hacia el lugar tocado y la abeja
+  // vuela hasta él. Sin foco, la abeja ronda el centro del valle.
+  const foco = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;
+  const camPos = foco ? pct(foco.pos[0], foco.pos[2]) : { left: 50, top: 50 };
+  const abejaPos = foco ? pct(foco.pos[0], foco.pos[2]) : { left: 52, top: 46 };
+
   return (
-    <div className="valle2d" data-clima={clima}>
-      <svg viewBox="0 0 400 340" className="valle2d__svg" role="img"
-        aria-label="El valle de su finca, dibujado. Toque un lugar para entrar.">
-        <defs>
-          <linearGradient id="v2d-cielo" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0" stopColor={c.cielo[0]} />
-            <stop offset="1" stopColor={c.cielo[1]} />
-          </linearGradient>
-          <radialGradient id="v2d-suelo" cx="0.5" cy="0.35" r="0.9">
-            <stop offset="0" stopColor={clima === 'noche' ? '#2c4a34' : '#6a9a52'} />
-            <stop offset="1" stopColor={clima === 'noche' ? '#1a3324' : '#4b7a3c'} />
-          </radialGradient>
-        </defs>
-        <rect x="0" y="0" width="400" height="340" fill="url(#v2d-cielo)" />
-        {/* cordillera */}
-        <path d="M0,150 L70,80 L140,140 L210,70 L290,140 L360,90 L400,150 Z"
-          fill={clima === 'noche' ? '#33435c' : c.niebla} opacity="0.85" />
-        {/* piso del valle */}
-        <ellipse cx="200" cy="220" rx="230" ry="130" fill="url(#v2d-suelo)" />
-        {/* quebrada */}
-        <path d="M120,150 C160,180 180,210 200,250 C215,280 240,300 280,320"
-          stroke={clima === 'noche' ? '#2a4a6a' : '#5fb2c9'} strokeWidth="10"
-          fill="none" strokeLinecap="round" opacity="0.8" />
-      </svg>
+    <div className="valle2d" data-clima={clima} data-entrando={foco ? 'si' : 'no'}>
+      {/* cámara-lámina: se acerca al lugar tocado (transform-origin en el POI) */}
+      <div
+        className="valle2d__cam"
+        style={{
+          transformOrigin: `${camPos.left}% ${camPos.top}%`,
+          transform: foco ? 'scale(1.32)' : 'scale(1)',
+        }}
+      >
+        <svg viewBox="0 0 400 340" className="valle2d__svg" role="img"
+          aria-label="El valle de su finca, dibujado. Toque un lugar para entrar.">
+          <defs>
+            <linearGradient id="v2d-cielo" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stopColor={c.cielo[0]} />
+              <stop offset="1" stopColor={c.cielo[1]} />
+            </linearGradient>
+            <radialGradient id="v2d-suelo" cx="0.5" cy="0.35" r="0.9">
+              <stop offset="0" stopColor={clima === 'noche' ? '#2c4a34' : '#6a9a52'} />
+              <stop offset="1" stopColor={clima === 'noche' ? '#1a3324' : '#4b7a3c'} />
+            </radialGradient>
+          </defs>
+          <rect x="0" y="0" width="400" height="340" fill="url(#v2d-cielo)" />
+          {/* cordillera */}
+          <path d="M0,150 L70,80 L140,140 L210,70 L290,140 L360,90 L400,150 Z"
+            fill={clima === 'noche' ? '#33435c' : c.niebla} opacity="0.85" />
+          {/* piso del valle */}
+          <ellipse cx="200" cy="220" rx="230" ry="130" fill="url(#v2d-suelo)" />
+          {/* quebrada */}
+          <path d="M120,150 C160,180 180,210 200,250 C215,280 240,300 280,320"
+            stroke={clima === 'noche' ? '#2a4a6a' : '#5fb2c9'} strokeWidth="10"
+            fill="none" strokeLinecap="round" opacity="0.8" />
+        </svg>
 
-      {/* mundos como lugares tocables, posicionados sobre la lámina */}
-      <div className="valle2d__mundos">
-        {orden.map((m) => {
-          const { cx, cy } = iso(m.pos[0], m.pos[2]);
-          return (
-            <button key={m.id} type="button"
-              className="valle2d__poi"
-              style={{ left: `${(cx / 400) * 100}%`, top: `${(cy / 340) * 100}%`, '--poi-tinte': m.tinte[0] }}
-              onClick={() => onEntrar(m.id)}
-              aria-label={`Viajar al mundo ${m.titulo}. ${m.lema}`}>
-              <span className="valle2d__emoji" aria-hidden="true">{m.emoji}</span>
-              <span className="valle2d__nombre">{m.titulo}</span>
-            </button>
-          );
-        })}
+        {/* mundos como lugares tocables, posicionados sobre la lámina */}
+        <div className="valle2d__mundos">
+          {orden.map((m) => {
+            const p = pct(m.pos[0], m.pos[2]);
+            const activo = focoId === m.id;
+            return (
+              <button key={m.id} type="button"
+                className={`valle2d__poi${activo ? ' valle2d__poi--activo' : ''}`}
+                style={{ left: `${p.left}%`, top: `${p.top}%`, '--poi-tinte': m.tinte[0] }}
+                onClick={() => onEntrar(m.id)}
+                aria-label={`Viajar al mundo ${m.titulo}. ${m.lema}`}>
+                <span className="valle2d__emoji" aria-hidden="true">{m.emoji}</span>
+                <span className="valle2d__nombre">{m.titulo}</span>
+              </button>
+            );
+          })}
 
-        {/* la cosa del día: un solo destello, anclado a su lugar */}
-        {ancla && (() => {
-          const { cx, cy } = iso(ancla.pos[0], ancla.pos[2]);
-          return (
-            <button type="button" className="valle2d__alerta"
-              style={{ left: `${(cx / 400) * 100}%`, top: `${((cy - 40) / 340) * 100}%` }}
-              onClick={onAlerta}
-              aria-label={`Alerta del día: ${COSA_DEL_DIA.titulo}. ${COSA_DEL_DIA.detalle}`}>
-              <span aria-hidden="true">⚠️</span> {COSA_DEL_DIA.titulo}
-            </button>
-          );
-        })()}
+          {/* la cosa del día: un solo destello, anclado a su lugar */}
+          {ancla && (() => {
+            const p = pct(ancla.pos[0], ancla.pos[2]);
+            return (
+              <button type="button" className="valle2d__alerta"
+                style={{ left: `${p.left}%`, top: `${p.top - 12}%` }}
+                onClick={onAlerta}
+                aria-label={`Alerta del día: ${COSA_DEL_DIA.titulo}. ${COSA_DEL_DIA.detalle}`}>
+                <span aria-hidden="true">⚠️</span> {COSA_DEL_DIA.titulo}
+              </button>
+            );
+          })()}
+
+          {/* Angelita: el avatar-compañero. Vuela hacia el lugar al entrar. */}
+          <div
+            className={`valle2d__abeja${foco ? ' valle2d__abeja--entrando' : ''}`}
+            style={{ left: `${abejaPos.left}%`, top: `${abejaPos.top}%` }}
+            aria-hidden="true"
+          >
+            <AbejaAngelita size={foco ? 40 : 46} animo={animo} energia={energia} animated={!reducedMotion} />
+          </div>
+        </div>
       </div>
 
       {/* el clima tiñe la escena: grade de luz de la librería de efectos */}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -13,7 +13,9 @@
  * Los 4 sí-o-sí viven en el espacio:
  *   · MUNDOS  → landmarks navegables (MundoLugar) con etiqueta accesible.
  *   · ALERTA  → Beacon pulsante anclado sobre el mundo 'suelo' (la cosa del día).
- *   · AGENTE  → el Colibrí (visual-lib) flota sobre el foco activo.
+ *   · COMPAÑERO → Angelita, la abeja (visual-lib) es el avatar-jugador: vuela
+ *                por el valle y ENTRA al mundo que se toca; su ánimo/energía
+ *                reflejan la salud real de la finca.
  *   · CLIMA   → luz/niebla/estrellas de la escena salen del estado `clima`.
  */
 /* Nota: las props de three (position, args, intensity, castShadow, etc.) son
@@ -23,7 +25,7 @@ import { Suspense, useMemo, useRef, useState } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Html, Float, Stars, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
-import { Colibri } from '../../visual/creatures/Colibri.jsx';
+import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
 
 /* Altura del terreno por (x,z): un valle suave con ladera al fondo (+z) donde
@@ -82,7 +84,7 @@ function Cordillera({ color }) {
 
 /* ── La quebrada: una cinta de agua que serpentea por el cauce. ── */
 function Quebrada({ color, viva }) {
-  const ref = useRef();
+  const ref = useRef(null);
   useFrame((state) => {
     if (viva && ref.current) {
       ref.current.material.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 2) * 0.06;
@@ -184,8 +186,8 @@ function LandmarkGeom({ tipo, tinte }) {
             <boxGeometry args={[0.9, 0.7, 0.8]} />
             <meshStandardMaterial color={suave} flatShading />
           </mesh>
-          <mesh position={[0, 0.85, 0]} castShadow>
-            <coneGeometry args={[0.72, 0.5, 4]} rotation={[0, Math.PI / 4, 0]} />
+          <mesh position={[0, 0.85, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+            <coneGeometry args={[0.72, 0.5, 4]} />
             <meshStandardMaterial color={fuerte} flatShading />
           </mesh>
           {[-0.9, -0.5, 0.9, 1.3].map((dx, i) => (
@@ -246,8 +248,8 @@ function LandmarkGeom({ tipo, tinte }) {
   }
 }
 
-function Veleta({ color, reducedMotion }) {
-  const ref = useRef();
+function Veleta({ color, reducedMotion = false }) {
+  const ref = useRef(null);
   useFrame((state) => {
     if (ref.current && !reducedMotion) ref.current.rotation.y = state.clock.elapsedTime * 0.4;
   });
@@ -262,8 +264,8 @@ function Veleta({ color, reducedMotion }) {
           <boxGeometry args={[0.7, 0.06, 0.06]} />
           <meshStandardMaterial color={color} flatShading />
         </mesh>
-        <mesh position={[0.42, 0, 0]}>
-          <coneGeometry args={[0.14, 0.3, 4]} rotation={[0, 0, -Math.PI / 2]} />
+        <mesh position={[0.42, 0, 0]} rotation={[0, 0, -Math.PI / 2]}>
+          <coneGeometry args={[0.14, 0.3, 4]} />
           <meshStandardMaterial color={color} flatShading />
         </mesh>
       </group>
@@ -305,8 +307,8 @@ function MundoLugar({ mundo, activo, onEntrar, reducedMotion }) {
       Toca la señal → onAlerta() (el agente lo dice y ofrece LA acción). ── */
 function Beacon({ onAlerta, reducedMotion }) {
   const ancla = MUNDO_VALLE_BY_ID[COSA_DEL_DIA.anclaMundo];
-  const luz = useRef();
-  const halo = useRef();
+  const luz = useRef(null);
+  const halo = useRef(null);
   useFrame((state) => {
     if (reducedMotion) return;
     const p = (Math.sin(state.clock.elapsedTime * 1.6) + 1) / 2;
@@ -350,37 +352,74 @@ function Beacon({ onAlerta, reducedMotion }) {
   );
 }
 
-/* ── El compañero: el colibrí (visual-lib) flota sobre el foco activo y es la
-      cara del agente. Reusa el SVG canónico de creatures. ── */
-function CompaneroColibri({ foco, reducedMotion }) {
-  const ref = useRef();
+/* ── El COMPAÑERO-JUGADOR: Angelita, la abeja. Es el avatar que vuela por el
+      valle. Al reposo, ronda sobre el valle con vaivén vivo; cuando se toca un
+      mundo (`entrando`), BAJA y se acerca al lugar — "entra" al mundo, y la
+      cámara la acompaña. Su ánimo/energía (salud real de la finca) tiñen su
+      color, su aura y qué tan vivo es su vuelo. Mira hacia donde viaja. ── */
+function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion }) {
+  const ref = useRef(null);
+  const caraRef = useRef(null);
+  const prevX = useRef(foco.x);
   useFrame((state) => {
     if (!ref.current) return;
     const t = state.clock.elapsedTime;
-    const bob = reducedMotion ? 0 : Math.sin(t * 2) * 0.15;
-    ref.current.position.lerp(
-      new THREE.Vector3(foco.x + 0.9, foco.y + 2.2 + bob, foco.z + 0.6),
-      0.05,
+    const brio = 0.35 + 0.65 * energia; // la energía anima el vuelo
+    const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.1 + 0.16 * brio);
+    // Al reposo deriva en un círculo calmo; al entrar se posa junto al lugar.
+    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.9;
+    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.6;
+    const dest = new THREE.Vector3(
+      foco.x + (entrando ? 0.55 : 0.4 + vagarX),
+      foco.y + (entrando ? 1.05 : 2.3) + bob,
+      foco.z + (entrando ? 0.7 : 0.6 + vagarZ),
     );
+    ref.current.position.lerp(dest, entrando ? 0.05 : 0.045);
+    if (caraRef.current) {
+      const vx = ref.current.position.x - prevX.current;
+      if (Math.abs(vx) > 0.0015) caraRef.current.style.transform = `scaleX(${vx < 0 ? -1 : 1})`;
+      prevX.current = ref.current.position.x;
+    }
   });
+  const size = 44 + Math.round(energia * 14);
   return (
-    <group ref={ref} position={[foco.x + 0.9, foco.y + 2.2, foco.z + 0.6]}>
+    <group ref={ref} position={[foco.x + 0.4, foco.y + 2.3, foco.z + 0.6]}>
       <Html center distanceFactor={9} zIndexRange={[40, 10]}>
-        <div className="valle-colibri" aria-hidden="true">
-          <Colibri size={54} animated={!reducedMotion} />
+        <div className="valle-abeja" aria-hidden="true">
+          <div ref={caraRef} className="valle-abeja__cara">
+            <AbejaAngelita size={size} animo={animo} energia={energia} animated={!reducedMotion} />
+          </div>
         </div>
       </Html>
     </group>
   );
 }
 
-/* ── Cámara: viaja suavemente hacia el foco (target) cuando cambia de mundo;
-      en reposo, deriva muy lento (auto-rotación calma). ── */
-function CamaraViajera({ foco, controls, autoOrbit }) {
+/* ── Cámara: viaja suavemente hacia el foco (target) cuando cambia de mundo Y
+      HACE ZOOM hacia el lugar — la sensación de ENTRAR con la abeja, no un modal
+      plano. El acercamiento solo se fuerza durante la transición (una vez llega,
+      suelta el control para que el usuario siga haciendo zoom a mano). ── */
+function CamaraViajera({ foco, focoKey, controls, autoOrbit }) {
+  const trans = useRef(0);
+  const prevKey = useRef(focoKey);
+  const entrando = focoKey !== 'valle';
   useFrame(() => {
     if (!controls.current) return;
-    controls.current.target.lerp(new THREE.Vector3(foco.x, foco.y + 0.6, foco.z), 0.06);
-    controls.current.update();
+    const c = controls.current;
+    if (focoKey !== prevKey.current) {
+      trans.current = 1; // arrancó una nueva "entrada": acompañar el zoom
+      prevKey.current = focoKey;
+    }
+    c.target.lerp(new THREE.Vector3(foco.x, foco.y + 0.6, foco.z), 0.06);
+    if (trans.current > 0) {
+      const cam = c.object;
+      const dir = cam.position.clone().sub(c.target);
+      const deseada = entrando ? 8.5 : 15; // acercarse al entrar, abrir al volver
+      dir.setLength(THREE.MathUtils.lerp(dir.length(), deseada, 0.06));
+      cam.position.copy(c.target.clone().add(dir));
+      trans.current = Math.max(0, trans.current - 0.012);
+    }
+    c.update();
   });
   return (
     <OrbitControls
@@ -392,7 +431,7 @@ function CamaraViajera({ foco, controls, autoOrbit }) {
       maxDistance={22}
       minPolarAngle={0.5}
       maxPolarAngle={1.15}
-      autoRotate={autoOrbit}
+      autoRotate={autoOrbit && !entrando}
       autoRotateSpeed={0.35}
       enableDamping
       dampingFactor={0.08}
@@ -401,8 +440,8 @@ function CamaraViajera({ foco, controls, autoOrbit }) {
 }
 
 /* ── Contenido de la escena (dentro del Canvas). ── */
-function Escena({ clima, focoId, onEntrar, onAlerta, reducedMotion }) {
-  const controls = useRef();
+function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion }) {
+  const controls = useRef(null);
   const c = CLIMAS[clima];
   const foco = useMemo(() => {
     const m = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;
@@ -411,6 +450,7 @@ function Escena({ clima, focoId, onEntrar, onAlerta, reducedMotion }) {
     return new THREE.Vector3(m.pos[0], y, m.pos[2]);
   }, [focoId]);
   const autoOrbit = !reducedMotion && !focoId;
+  const entrando = !!focoId;
 
   return (
     <>
@@ -449,15 +489,34 @@ function Escena({ clima, focoId, onEntrar, onAlerta, reducedMotion }) {
       ))}
 
       <Beacon onAlerta={onAlerta} reducedMotion={reducedMotion} />
-      <CompaneroColibri foco={foco} reducedMotion={reducedMotion} />
+      <CompaneroAbeja
+        foco={foco}
+        entrando={entrando}
+        animo={animo}
+        energia={energia}
+        reducedMotion={reducedMotion}
+      />
 
-      <CamaraViajera foco={foco} controls={controls} autoOrbit={autoOrbit} />
+      <CamaraViajera
+        foco={foco}
+        focoKey={focoId || 'valle'}
+        controls={controls}
+        autoOrbit={autoOrbit}
+      />
       <AdaptiveDpr pixelated />
     </>
   );
 }
 
-export default function Valle3D({ clima, focoId, onEntrar, onAlerta, reducedMotion }) {
+export default function Valle3D({
+  clima,
+  focoId,
+  animo = 'sereno',
+  energia = 1,
+  onEntrar,
+  onAlerta,
+  reducedMotion,
+}) {
   const [listo, setListo] = useState(false);
   return (
     <Canvas
@@ -473,6 +532,8 @@ export default function Valle3D({ clima, focoId, onEntrar, onAlerta, reducedMoti
         <Escena
           clima={clima}
           focoId={focoId}
+          animo={animo}
+          energia={energia}
           onEntrar={onEntrar}
           onAlerta={onAlerta}
           reducedMotion={reducedMotion}

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -40,6 +40,7 @@ const LUGARES = [
  * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar.
  */
 export const MUNDOS_VALLE = LUGARES.map((l) => {
+  /** @type {{ titulo?: string, emoji?: string, lema?: string, tinte?: string[] }} */
   const real = MUNDO_BY_ID[l.id] || {};
   return {
     ...l,
@@ -69,6 +70,64 @@ export const COSA_DEL_DIA = {
     'Ojo con la finca hoy: esta madrugada puede helar en la parte alta. Cúbrale el semillero antes de que caiga el sol, que el frío le quema la matica tierna.',
   accion: { etiqueta: 'Ver cómo proteger del frío', view: 'hoy_finca' },
 };
+
+/* ── EL COMPAÑERO: ANGELITA, LA ABEJA DE LA FINCA ────────────────────────────
+ * El avatar-jugador del valle. No es un widget: es un ser al que se cuida (ref
+ * Finch). Su ÁNIMO y su ENERGÍA salen del ESTADO REAL de la finca — cuántas
+ * matas están vivas, cómo está el agua, y qué clima hace. Datos de MUESTRA: si
+ * se productiza, `SALUD_FINCA` viene del backend (logs de matas + Open-Meteo).
+ */
+export const SALUD_FINCA = {
+  matasVivas: 34,
+  matasTotal: 41,
+  agua: 0.72, // 0..1 — humedad/reserva de la quebrada y el tanque
+};
+
+/**
+ * Ánimo de la abeja según cómo está la finca hoy. Devuelve el ánimo (piel de la
+ * creature), la energía (0..1, vivacidad del vuelo/aura) y una frase corta en
+ * usted — puntual, sin muros de texto. Prioridad: alerta > sed > clima > salud.
+ */
+export function animoDeFinca(clima, { hayAlerta = false, salud = SALUD_FINCA } = {}) {
+  const vivas = salud.matasTotal > 0 ? salud.matasVivas / salud.matasTotal : 1;
+  // Energía base: mezcla de matas vivas y agua, atenuada por el clima duro.
+  const climaFactor = clima === 'noche' ? 0.55 : clima === 'lluvia' ? 0.8 : 1;
+  const energia = Math.max(0.35, Math.min(1, (vivas * 0.65 + salud.agua * 0.35) * climaFactor));
+
+  if (hayAlerta) {
+    return {
+      animo: 'atento',
+      energia,
+      frase: 'Angelita anda pendiente: hay algo que atender hoy.',
+    };
+  }
+  if (salud.agua < 0.35) {
+    return {
+      animo: 'sediento',
+      energia,
+      frase: 'La abeja la ve con sed: a la finca le hace falta agua.',
+    };
+  }
+  if (clima === 'noche') {
+    return {
+      animo: 'descansa',
+      energia,
+      frase: 'Angelita descansa; la finca duerme tranquila esta noche.',
+    };
+  }
+  if (vivas >= 0.85 && salud.agua >= 0.55) {
+    return {
+      animo: 'pleno',
+      energia,
+      frase: 'Angelita anda contenta: sus matas están vivas y con agua.',
+    };
+  }
+  return {
+    animo: 'sereno',
+    energia,
+    frase: 'La abeja anda serena, echándole ojo a la finca.',
+  };
+}
 
 /* ── 4. EL CLIMA QUE TIÑE EL AMBIENTE ────────────────────────────────────────
  * Reusa las grades de luz de la librería de efectos (src/visual/effects):

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,0 +1,111 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Abeja angelita — Tetragonisca angustula, la abeja NATIVA sin aguijón de los
+   Andes (mansa, dorada, guardiana de la finca). Es el COMPAÑERO-JUGADOR del
+   valle: vuela por el mundo y "entra" a cada lugar. No es un mascota infantil —
+   es un ser al que se cuida (ref Finch): su ÁNIMO y su ENERGÍA cambian el color,
+   el aura y la vivacidad según cómo está la finca de verdad.
+
+   Coreografía de vuelo/llegada = de la ESCENA que la consume (Valle3D / 2D).
+   Aquí solo vive el cuerpo: SVG + CSS puros, solo transform/opacity (GPU,
+   Android gama baja), aleteo reutilizando .crt-wing de creatures.css. */
+const VIEWBOX = '-16 -15 34 30';
+
+/* Paletas por ánimo (estado real de la finca leído en el valle). Maduras,
+   cálidas — nunca chillonas. `aura` es el halo; `cuerpo`/`banda` el insecto. */
+const ANIMOS = {
+  pleno: { cuerpo: '#f3b229', banda: '#7a4a12', aura: '#ffd772', vida: 1 },
+  sereno: { cuerpo: '#e6a637', banda: '#7a4a12', aura: '#f4c66a', vida: 0.82 },
+  atento: { cuerpo: '#f0a233', banda: '#6f3d10', aura: '#ffb352', vida: 0.9 },
+  sediento: { cuerpo: '#cdae6e', banda: '#6b5330', aura: '#cfe0d6', vida: 0.6 },
+  descansa: { cuerpo: '#c9a24a', banda: '#5a4526', aura: '#9fb6d6', vida: 0.45 },
+};
+
+export function AbejaAngelita({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  animo = 'sereno',
+  energia = 1,
+  title = 'Angelita, la abeja de su finca',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const clip = `crt-clip-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const a = ANIMOS[animo] || ANIMOS.sereno;
+  const e = Math.max(0.35, Math.min(1, energia));
+  // El aura respira con la energía; la vitalidad del ánimo la matiza.
+  const auraOp = 0.16 + 0.34 * e * a.vida;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      <clipPath id={clip}>
+        {/* abdomen: la elipse que recorta las bandas para que no se desborden */}
+        <ellipse cx="-1.5" cy="1.5" rx="8.5" ry="6" />
+      </clipPath>
+    </defs>
+  );
+
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      {/* aura viva: el halo que refleja el ánimo/energía de la finca */}
+      <circle r="12" cx="-1" cy="1" fill={a.aura} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* alas translúcidas que baten (arriba del tórax) */}
+      <ellipse className={wing} cx="1.5" cy="-6.5" rx="5.5" ry="3.4" fill="#dff3ff" opacity="0.72"
+        transform="rotate(-24 1.5 -6.5)" />
+      <ellipse className={wing} style={{ animationDelay: '-0.05s' }} cx="4.5" cy="-6" rx="4.6" ry="3"
+        fill="#c8e8ff" opacity="0.5" transform="rotate(-6 4.5 -6)" />
+
+      {/* patas finas bajo el cuerpo (quietas, dan peso) */}
+      <path d="M-3,6 L-4.5,9 M0,6.5 L0.5,9.6 M3,6 L4.8,8.8" stroke={a.banda} strokeWidth="0.8"
+        fill="none" strokeLinecap="round" opacity="0.85" />
+
+      {/* abdomen dorado con bandas (recortadas al contorno) */}
+      <ellipse cx="-1.5" cy="1.5" rx="8.5" ry="6" fill={a.cuerpo} />
+      <g clipPath={`url(#${clip})`}>
+        <rect x="-6.5" y="-5" width="2.6" height="14" rx="1.3" fill={a.banda} opacity="0.9"
+          transform="rotate(12 -5 1.5)" />
+        <rect x="-1.6" y="-5" width="2.8" height="14" rx="1.4" fill={a.banda} opacity="0.92"
+          transform="rotate(12 -0.2 1.5)" />
+      </g>
+      {/* brillo suave del lomo */}
+      <ellipse cx="-2.5" cy="-1.2" rx="4.2" ry="2" fill="#fff2c8" opacity="0.5" />
+
+      {/* cabeza (a la derecha = hacia donde vuela) + ojo */}
+      <circle cx="7.6" cy="-0.6" r="3.6" fill={a.banda} />
+      <circle cx="8.9" cy="-1.4" r="1.15" fill="#1b1205" />
+      <circle cx="9.3" cy="-1.8" r="0.4" fill="#fff6e2" />
+      {/* antenas */}
+      <path d="M9.4,-3.2 C11.4,-5 12.6,-5.4 13.6,-6.6 M8.4,-3.6 C9.6,-6 10.4,-6.8 10.9,-8.4"
+        stroke={a.banda} strokeWidth="0.85" fill="none" strokeLinecap="round" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="abeja-angelita">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default AbejaAngelita;


### PR DESCRIPTION
Ronda 2 de la entrada 3D **"El valle de mi finca"**, apilada sobre #2289. Sube desde el 7/10 con feedback de campo (diseñadora/field-tester + operador). Quirúrgico: no rompe lo que ya gusta.

Norte: **menos colapso** (puntual, imagen-first) + la finca como **mundo-juego vivo**.

## Qué se agregó

**1. Angelita, la abeja = el avatar-jugador** (`src/visual/creatures/AbejaAngelita.jsx`, nueva)
- Abeja nativa sin aguijón (Tetragonisca angustula), SVG procedural siguiendo el patrón canónico de `Colibri` (mismos filtros/CSS, solo transform/opacity — GPU, Android gama baja).
- Su **ánimo y energía reflejan el estado REAL de la finca**: matas vivas, agua y clima (`animoDeFinca()` en `valleData.js`) tiñen su color, su aura y qué tan vivo es su vuelo. Ánimos: pleno / sereno / atento / sediento / descansa.
- Es un **ser al que se cuida** (ref Finch): atender "lo del día" la calma. Sin puntos, medallas ni rachas.
- Vive en el 3D (vuela por el valle), en el fallback 2D (vuela al lugar) y como **chip puntual** de estado (imagen-first, una línea).

**2. "Entrar al mundo" — moverse en el mundo, no un modal plano**
- 3D: al tocar un lugar, la abeja vuela hasta él y la **cámara hace dolly-in** acompañándola (se acerca y luego suelta el control para que el usuario siga con zoom a mano).
- 2D: la lámina se **acerca** hacia el POI tocado (transform-origin en el lugar) y la abeja vuela hasta ahí.

**3. Menos colapso**
- El chip del compañero se **esconde con cualquier panel abierto** (una cosa clara a la vez).
- Todo imagen-first (íconos/emoji + la abeja); cero muros de texto nuevos.

**4. Device-tiering REAL** (hueco de la ronda 1)
- El gate deja de ser binario `¿hay WebGL?`. Ahora degrada a la **2D digna** también en equipos humildes: `deviceMemory<=3`, `hardwareConcurrency<=4`, `Save-Data`, `prefers-reduced-motion`.
- La 3D es **aspiracional** para gama media+. El teléfono humilde cae a la 2D digna, no a jank/calor. Aviso sobrio según el motivo (nunca "error").

## Qué se reusó
- `Colibri.jsx` / `creatures.css` / `_filters.jsx` como molde de la abeja (misma familia visual).
- Toda la escena 3D de ronda 1 (`Valle3D`, terreno, mundos, beacon, clima) y el fallback 2D — solo se extendió.
- El manifiesto real de mundos (`mundosFinca`) sigue siendo la fuente de títulos/tinte.

## Verificación (corrida de verdad)
- `npm run build` verde (three sigue en chunk perezoso propio `vendor-three`).
- `node scripts/tsc-check-gate.mjs` = **868 / 868**, cero nuevos (incluye limpieza de tipos pre-existentes de los archivos del mockup: `useRef` init, `rotation` movida al mesh, navigator experimental tipado, defaults de props).
- `npx eslint` limpio en lo tocado.
- Español de Colombia (usted), sin voseo. Sin enlaces/imágenes externas. Anti-gamificación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)