### PR TITLE
feat(mockup): mundo 3D "el suelo vivo" (cutaway) + framework MUNDO_3D

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,6 +94,11 @@ const InventoryPage = lazy(() => import('./pages/InventoryPage'));
 // perezoso) donde los 4 sí-o-sí viven en el espacio. Ruta #/mockups/entrada-3d
 // — sin gate ni sesión (datos de muestra, degrada limpio a SVG sin WebGL).
 const EntradaValle3DMockup = lazy(() => import('./mockups/EntradaValle3D'));
+// Mockup dev "Mundo 3D — el suelo vivo": el PROTOTIPO del framework de mundos-3D
+// (DR-MUNDOS-3D-FRAMEWORK). La escena-mundo `cutaway` del suelo — un corte de
+// tierra que se puebla de vida con el score del motor existente. Ruta
+// #/mockups/mundo3d-suelo — sin gate, degrada a lámina SVG en gama baja/sin-WebGL.
+const EntradaMundo3DMockup = lazy(() => import('./mockups/EntradaMundo3D'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -424,6 +429,7 @@ const LoadingFallback = ({ view = null }) => {
 
 const HASH_VIEW_ROUTES = {
   'mockups/entrada-3d': 'mockup_entrada_3d',
+  'mockups/mundo3d-suelo': 'mockup_mundo3d_suelo',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -1295,6 +1301,22 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El valle de mi finca (3D)">
               <EntradaValle3DMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_suelo':
+        // Mockup "Mundo 3D — el suelo vivo" (prototipo del framework de mundos-3D):
+        // la escena-mundo `cutaway` del suelo. Full-screen, sin gate — decisión
+        // visual. Degrada a lámina SVG sin WebGL/gama baja. Los hotspots re-rutean
+        // a vistas 2D REALES (subsuelo, salud_suelo, cromatografia) vía navigate.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mundo 3D — el suelo vivo">
+              <EntradaMundo3DMockup
+                mundoId="suelo"
+                onBack={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/EntradaMundo3D.jsx
+++ b/src/mockups/EntradaMundo3D.jsx
@@ -1,0 +1,174 @@
+/*
+ * MOCKUP "Mundo 3D — el suelo vivo" — ruta #/mockups/mundo3d-suelo.
+ *
+ * El PROTOTIPO del framework de mundos-3D (DR-MUNDOS-3D-FRAMEWORK-2026-07-10):
+ * la escena-mundo `cutaway` del SUELO, la primera "capa cercana" del valle. Un
+ * corte de tierra que se PUEBLA de vida (lombrices, raíces, hifas) a medida que
+ * la tierra revive — "lo invisible hecho visible", el caso de libro del 3D
+ * pedagógico. Reusa el motor existente (mundoSubsueloEngine) para el `score`.
+ *
+ * ESTE ARCHIVO ES SOLO EL HOST (la "página"): decide 3D vs lámina 2D con el
+ * gate de device-tiering, narra por voz (nombra el tema primero), y RE-RUTEA
+ * cada hotspot a su pantalla 2D REAL (nunca la reimplementa). La escena, los
+ * arquetipos y los datos viven en src/mockups/valle/*.
+ *
+ * Copy de muestra en español Colombia (usted); si se productiza migra a
+ * messages.js (ADR-050).
+ */
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import '../visual/effects/effects.css';
+import './valle/mundo3d.css';
+import { decidirRender } from './valle/decidirRender';
+import { metaMundo, MUNDO_3D } from './valle/mundo3dData';
+import { NARRACION } from './valle/valleData';
+import Mundo2D from './valle/Mundo2D';
+import { BASE_SOIL_LIFE } from '../components/juego/mundoSubsueloData';
+import { evaluarSubsuelo } from '../services/mundoSubsueloEngine';
+
+// La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso.
+const Mundo3D = lazy(() => import('./valle/Mundo3D'));
+
+export default function EntradaMundo3D({ mundoId = 'suelo', onBack, onNavigate }) {
+  const meta = useMemo(() => metaMundo(mundoId), [mundoId]);
+  const datos = MUNDO_3D[mundoId];
+
+  // El gate de device-tiering decide una sola vez al montar.
+  const [gate] = useState(() => decidirRender());
+  const [voz, setVoz] = useState(true);
+
+  // "Vida del suelo" (0–100) del motor existente → controla cuánta vida se ve.
+  const [vidaPct, setVidaPct] = useState(BASE_SOIL_LIFE);
+  const est = useMemo(() => evaluarSubsuelo(vidaPct), [vidaPct]);
+  const vida01 = est.vida / 100;
+
+  // ── Voz (Web Speech API): nombra el tema PRIMERO. Plus, nunca bloquea. ──
+  const hablar = useCallback(
+    (texto) => {
+      if (!voz || !texto || typeof window === 'undefined' || !window.speechSynthesis) return;
+      try {
+        window.speechSynthesis.cancel();
+        const u = new SpeechSynthesisUtterance(texto);
+        u.lang = 'es-CO';
+        u.rate = 0.98;
+        const esVoz = window.speechSynthesis
+          .getVoices()
+          .find((v) => v.lang && v.lang.toLowerCase().startsWith('es'));
+        if (esVoz) u.voice = esVoz;
+        window.speechSynthesis.speak(u);
+      } catch {
+        /* la voz es un plus, nunca bloquea */
+      }
+    },
+    [voz],
+  );
+
+  useEffect(
+    () => () => {
+      if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+    },
+    [],
+  );
+
+  // Al entrar: la voz nombra el tema (NARRACION[narra]) una sola vez.
+  const saludado = useRef(false);
+  useEffect(() => {
+    if (saludado.current) return;
+    saludado.current = true;
+    const texto = NARRACION[datos?.entrada?.narra] || meta.lema;
+    const t = setTimeout(() => hablar(texto), 900);
+    return () => clearTimeout(t);
+  }, [hablar, datos, meta.lema]);
+
+  // Cada hotspot RE-RUTEA a su pantalla 2D real (regla de oro: no reimplementa).
+  const irAHotspot = useCallback(
+    (view, data) => {
+      if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+      if (view && onNavigate) onNavigate(view, data);
+    },
+    [onNavigate],
+  );
+
+  const etapaLabel = est.etapa; // 'cansado' | 'en cuidado' | 'despertando' | 'vivo'
+
+  return (
+    <div className="mundo3d-root" style={{ '--m-tinte': meta.tinte[0], '--m-tinte-suave': meta.tinte[1] }}>
+      {/* fondo/atmósfera 3D o su lámina 2D digna */}
+      <div className="mundo3d-escena">
+        {gate.render3d ? (
+          <Suspense fallback={<CargandoMundo />}>
+            <Mundo3D
+              mundoId={mundoId}
+              tier={gate.tier}
+              reducedMotion={gate.reducedMotion}
+              vida01={vida01}
+              onHotspot={irAHotspot}
+            />
+          </Suspense>
+        ) : (
+          <Mundo2D mundoId={mundoId} vida01={vida01} onHotspot={irAHotspot} />
+        )}
+      </div>
+
+      {/* ── Encabezado: el nombre del mundo + Volver ── */}
+      <header className="mundo3d-header">
+        <button type="button" className="mundo3d-back" onClick={() => onBack?.()} aria-label="Volver">
+          ‹ Volver
+        </button>
+        <div className="mundo3d-titulo">
+          <span className="mundo3d-titulo__eyebrow">
+            <span aria-hidden="true">{meta.emoji}</span> Su suelo, por dentro
+          </span>
+          <h1>{meta.titulo}</h1>
+        </div>
+        <button
+          type="button"
+          className={`mundo3d-voz${voz ? ' on' : ''}`}
+          aria-pressed={voz}
+          onClick={() => {
+            const n = !voz;
+            setVoz(n);
+            if (!n && typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+          }}
+        >
+          {voz ? '🔊 Voz' : '🔇 Voz'}
+        </button>
+      </header>
+
+      {/* ── Sin 3D: aviso sobrio de que se ve la versión dibujada ── */}
+      {!gate.render3d && (
+        <p className="mundo3d-degradado" role="status">
+          Su equipo ve la versión dibujada del corte. El suelo sigue completo.
+        </p>
+      )}
+
+      {/* ── Control: la vida del suelo (mismo concepto del juego) puebla el corte ── */}
+      <aside className="mundo3d-control" aria-label="Vida del suelo">
+        <div className="mundo3d-control__cab">
+          <span className="mundo3d-control__lbl">Vida del suelo</span>
+          <span className="mundo3d-control__etapa" data-etapa={etapaLabel}>{etapaLabel}</span>
+        </div>
+        <input
+          type="range"
+          min="0"
+          max="100"
+          value={vidaPct}
+          onChange={(e) => setVidaPct(Number(e.target.value))}
+          aria-label="Mueva para ver cómo despierta o se cansa la vida del suelo"
+        />
+        <p className="mundo3d-control__ayuda">
+          Al abonar, cubrir y no labrar, la tierra revive y aparece la vida bajo el suelo.
+        </p>
+      </aside>
+    </div>
+  );
+}
+
+/* Placeholder mientras baja el chunk 3D. */
+function CargandoMundo() {
+  return (
+    <div className="mundo3d-cargando">
+      <div className="mundo3d-cargando__pulso" />
+      <p>Abriendo el corte de su suelo…</p>
+    </div>
+  );
+}

--- a/src/mockups/valle/Mundo2D.jsx
+++ b/src/mockups/valle/Mundo2D.jsx
@@ -1,0 +1,23 @@
+/*
+ * Mundo2D — el enrutador de LÁMINAS 2D del framework (DR §4.4).
+ *
+ * Cuando un mundo cae al 2D (tier bajo / sin WebGL / reduced-motion), lee su
+ * `fallback2d` del registro y monta la lámina SVG espejo con los MISMOS
+ * hotspots. Un mundo sin lámina cae a su pantalla 2D real (`ruta2d`) — de eso se
+ * encarga el host; aquí, sin lámina → null (nunca un error).
+ */
+import { LaminaCutaway } from './laminas/LaminaCutaway.jsx';
+import { MUNDO_3D, metaMundo } from './mundo3dData';
+
+/* Registro de láminas espejo. Sumar una = una entrada aquí (como los arquetipos). */
+const LAMINAS = {
+  'lamina-cutaway': LaminaCutaway,
+};
+
+export default function Mundo2D({ mundoId, vida01 = 0.5, onHotspot }) {
+  const d = MUNDO_3D[mundoId];
+  const Lamina = d && d.fallback2d ? LAMINAS[d.fallback2d] : null;
+  if (!Lamina) return null;
+  const meta = metaMundo(mundoId);
+  return <Lamina hotspots={d.hotspots} tinte={meta.tinte} vida01={vida01} onHotspot={onHotspot} />;
+}

--- a/src/mockups/valle/Mundo3D.jsx
+++ b/src/mockups/valle/Mundo3D.jsx
@@ -1,0 +1,89 @@
+/*
+ * Mundo3D — la ESCENA-MUNDO genérica, elegida por DATOS (DR §4.3).
+ *
+ * Lee `MUNDO_3D[mundoId]`, elige el ARQUETIPO por `escena` de un registro
+ * CERRADO (`ESCENAS`) y lo monta dentro de un <Canvas> frugal. No tiene lógica
+ * de negocio: solo cablea datos → arquetipo. Sumar un mundo SÍ-3D que reusa un
+ * arquetipo NO toca este archivo: solo se añade una entrada en `mundo3dData`.
+ * Se toca `ESCENAS` SOLO cuando aparece una metáfora espacial nueva.
+ *
+ * Presupuesto de rendimiento (DR §6): sin sombras, DPR≤1.5 (≤1.25 en tier medio),
+ * AdaptiveDpr, `frameloop='demand'` si reducedMotion, materiales Lambert/Basic.
+ * El chunk de three/fiber/drei baja PEREZOSO (lo importa el host con React.lazy).
+ */
+import { Suspense, useMemo } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { AdaptiveDpr, OrbitControls } from '@react-three/drei';
+import { EscenaCutaway } from './escenas/EscenaCutaway.jsx';
+import { MUNDO_3D } from './mundo3dData';
+
+/* Registro CERRADO de arquetipos. Solo `cutaway` está construido (el prototipo);
+   flujo/recinto/estratos se añaden aquí cuando se construyan (una sola vez). */
+const ESCENAS = {
+  cutaway: EscenaCutaway,
+};
+
+export default function Mundo3D({
+  mundoId,
+  tier = 'alto',
+  reducedMotion = false,
+  clima = 'soleado',
+  vida01 = 0.5,
+  onHotspot,
+}) {
+  const d = MUNDO_3D[mundoId];
+  const Escena = d && d.escena ? ESCENAS[d.escena] : null;
+
+  // Altura del corte (para encuadrar la cámara) y distancia desde `entrada.zoom`.
+  const { camPos, target } = useMemo(() => {
+    const capas = d?.params?.capas || [];
+    const alto = capas.reduce((s, c) => s + (c.alto || 0), 0) || 2.8;
+    const dist = d?.entrada?.zoom || 6.5;
+    /** @type {[number, number, number]} */
+    const camPosT = [0, alto * 0.7, dist];
+    /** @type {[number, number, number]} */
+    const targetT = [0, alto * 0.5, 0];
+    return { camPos: camPosT, target: targetT };
+  }, [d]);
+
+  // escena===null (o arquetipo aún no construido) → el host cae al 2D.
+  if (!Escena) return null;
+
+  const rm = reducedMotion || tier === 'bajo';
+  const dprMax = tier === 'medio' ? 1.25 : 1.5;
+
+  return (
+    <Canvas
+      className="mundo3d-canvas"
+      dpr={[1, dprMax]}
+      gl={{ antialias: tier !== 'medio', powerPreference: 'high-performance' }}
+      camera={{ position: camPos, fov: 42 }}
+      frameloop={rm ? 'demand' : 'always'}
+    >
+      <Suspense fallback={null}>
+        <Escena
+          params={d.params}
+          hotspots={d.hotspots}
+          entrada={d.entrada}
+          clima={clima}
+          vida01={vida01}
+          reducedMotion={rm}
+          onHotspot={onHotspot}
+        />
+        <OrbitControls
+          makeDefault
+          target={target}
+          enablePan={false}
+          enableZoom
+          minDistance={4}
+          maxDistance={12}
+          minPolarAngle={0.35}
+          maxPolarAngle={1.3}
+          enableDamping
+          dampingFactor={0.08}
+        />
+        <AdaptiveDpr pixelated />
+      </Suspense>
+    </Canvas>
+  );
+}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -24,6 +24,7 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { Html, Float, Stars, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
 import { Colibri } from '../../visual/creatures/Colibri.jsx';
+import { LandmarkPorTipo } from './mundo3dLandmarks.jsx';
 import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
 
 /* Altura del terreno por (x,z): un valle suave con ladera al fondo (+z) donde
@@ -82,7 +83,7 @@ function Cordillera({ color }) {
 
 /* ── La quebrada: una cinta de agua que serpentea por el cauce. ── */
 function Quebrada({ color, viva }) {
-  const ref = useRef();
+  const ref = useRef(null);
   useFrame((state) => {
     if (viva && ref.current) {
       ref.current.material.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 2) * 0.06;
@@ -113,163 +114,6 @@ function Quebrada({ color, viva }) {
   );
 }
 
-/* ── Materiales/paletas de cada landmark de mundo, por `tipo`. ── */
-function LandmarkGeom({ tipo, tinte }) {
-  const [fuerte, suave] = tinte;
-  switch (tipo) {
-    case 'milpa': // maíz: cañas altas con penacho
-      return (
-        <group>
-          {[-0.5, 0, 0.5, -0.25, 0.25].map((dx, i) => (
-            <group key={i} position={[dx, 0, (i % 2) * 0.4 - 0.2]}>
-              <mesh position={[0, 0.7, 0]} castShadow>
-                <cylinderGeometry args={[0.05, 0.08, 1.4, 5]} />
-                <meshStandardMaterial color={fuerte} flatShading />
-              </mesh>
-              <mesh position={[0, 1.45, 0]}>
-                <coneGeometry args={[0.12, 0.4, 5]} />
-                <meshStandardMaterial color="#e7c96b" flatShading />
-              </mesh>
-            </group>
-          ))}
-        </group>
-      );
-    case 'cafetal': // arbustos redondos en hilera
-      return (
-        <group>
-          {[-0.6, -0.2, 0.2, 0.6].map((dx, i) => (
-            <mesh key={i} position={[dx, 0.32, (i % 2) * 0.4]} castShadow>
-              <icosahedronGeometry args={[0.34, 0]} />
-              <meshStandardMaterial color={fuerte} flatShading roughness={1} />
-            </mesh>
-          ))}
-        </group>
-      );
-    case 'era': // eras aradas con surcos (semillero)
-      return (
-        <group>
-          {[-0.35, 0, 0.35].map((dz, i) => (
-            <mesh key={i} position={[0, 0.08, dz]} castShadow receiveShadow>
-              <boxGeometry args={[1.3, 0.16, 0.22]} />
-              <meshStandardMaterial color="#5a3d28" flatShading roughness={1} />
-            </mesh>
-          ))}
-          {[-0.35, 0, 0.35].map((dz, i) => (
-            <mesh key={`b${i}`} position={[0, 0.24, dz]}>
-              <boxGeometry args={[1.2, 0.06, 0.14]} />
-              <meshStandardMaterial color={suave} flatShading />
-            </mesh>
-          ))}
-        </group>
-      );
-    case 'quebrada': // nacimiento: charca + juncos
-      return (
-        <group>
-          <mesh position={[0, 0.06, 0]}>
-            <cylinderGeometry args={[0.55, 0.6, 0.12, 16]} />
-            <meshStandardMaterial color="#3a7fa0" transparent opacity={0.85} metalness={0.4} roughness={0.2} />
-          </mesh>
-          {[-0.3, 0.1, 0.4].map((dx, i) => (
-            <mesh key={i} position={[dx, 0.4, 0.2]}>
-              <cylinderGeometry args={[0.03, 0.03, 0.7, 4]} />
-              <meshStandardMaterial color="#4e7d3f" flatShading />
-            </mesh>
-          ))}
-        </group>
-      );
-    case 'corral': // casita + cerca
-      return (
-        <group>
-          <mesh position={[0, 0.35, 0]} castShadow>
-            <boxGeometry args={[0.9, 0.7, 0.8]} />
-            <meshStandardMaterial color={suave} flatShading />
-          </mesh>
-          <mesh position={[0, 0.85, 0]} castShadow>
-            <coneGeometry args={[0.72, 0.5, 4]} rotation={[0, Math.PI / 4, 0]} />
-            <meshStandardMaterial color={fuerte} flatShading />
-          </mesh>
-          {[-0.9, -0.5, 0.9, 1.3].map((dx, i) => (
-            <mesh key={i} position={[dx, 0.2, 0.9]}>
-              <boxGeometry args={[0.06, 0.4, 0.06]} />
-              <meshStandardMaterial color="#8a6a44" flatShading />
-            </mesh>
-          ))}
-        </group>
-      );
-    case 'huerta': // camas elevadas de la huerta
-      return (
-        <group>
-          {[-0.4, 0.4].map((dx, i) => (
-            <group key={i} position={[dx, 0, 0]}>
-              <mesh position={[0, 0.12, 0]} castShadow>
-                <boxGeometry args={[0.6, 0.24, 1]} />
-                <meshStandardMaterial color="#6b4a30" flatShading />
-              </mesh>
-              <mesh position={[0, 0.32, 0]}>
-                <boxGeometry args={[0.5, 0.18, 0.9]} />
-                <meshStandardMaterial color={fuerte} flatShading />
-              </mesh>
-            </group>
-          ))}
-        </group>
-      );
-    case 'bosque': // arboleda: troncos + copas
-      return (
-        <group>
-          {[
-            [-0.5, 0, 0.9],
-            [0.4, 0.2, 1.15],
-            [0, -0.4, 0.8],
-          ].map(([dx, dz, h], i) => (
-            <group key={i} position={[dx, 0, dz]}>
-              <mesh position={[0, h * 0.35, 0]} castShadow>
-                <cylinderGeometry args={[0.09, 0.12, h * 0.7, 6]} />
-                <meshStandardMaterial color="#6b4a2e" flatShading />
-              </mesh>
-              <mesh position={[0, h * 0.8, 0]} castShadow>
-                <coneGeometry args={[0.5, h * 0.9, 7]} />
-                <meshStandardMaterial color={fuerte} flatShading roughness={1} />
-              </mesh>
-            </group>
-          ))}
-        </group>
-      );
-    case 'veleta': // poste con veleta que gira con el viento
-      return <Veleta color={fuerte} />;
-    default:
-      return (
-        <mesh position={[0, 0.3, 0]}>
-          <icosahedronGeometry args={[0.4, 0]} />
-          <meshStandardMaterial color={fuerte} flatShading />
-        </mesh>
-      );
-  }
-}
-
-function Veleta({ color, reducedMotion }) {
-  const ref = useRef();
-  useFrame((state) => {
-    if (ref.current && !reducedMotion) ref.current.rotation.y = state.clock.elapsedTime * 0.4;
-  });
-  return (
-    <group>
-      <mesh position={[0, 0.55, 0]}>
-        <cylinderGeometry args={[0.05, 0.07, 1.1, 6]} />
-        <meshStandardMaterial color="#7c6a4c" flatShading />
-      </mesh>
-      <group ref={ref} position={[0, 1.15, 0]}>
-        <mesh>
-          <boxGeometry args={[0.7, 0.06, 0.06]} />
-          <meshStandardMaterial color={color} flatShading />
-        </mesh>
-        <mesh position={[0.42, 0, 0]}>
-          <coneGeometry args={[0.14, 0.3, 4]} rotation={[0, 0, -Math.PI / 2]} />
-          <meshStandardMaterial color={color} flatShading />
-        </mesh>
-      </group>
-    </group>
-  );
-}
 
 /* ── Un mundo como LUGAR navegable: su geometría + una etiqueta accesible que,
       al tocarse, viaja hasta él (la cámara) y lo selecciona. ── */
@@ -277,11 +121,9 @@ function MundoLugar({ mundo, activo, onEntrar, reducedMotion }) {
   const y = alturaTerreno(mundo.pos[0], mundo.pos[2]);
   return (
     <group position={[mundo.pos[0], y, mundo.pos[2]]} scale={mundo.escala}>
-      {mundo.tipo === 'veleta' ? (
-        <Veleta color={mundo.tinte[0]} reducedMotion={reducedMotion} />
-      ) : (
-        <LandmarkGeom tipo={mundo.tipo} tinte={mundo.tinte} />
-      )}
+      {/* La forma del landmark ya no es un switch inline: la resuelve el
+          registro LANDMARKS[tipo] del framework (mundo3dLandmarks). */}
+      <LandmarkPorTipo tipo={mundo.tipo} tinte={mundo.tinte} reducedMotion={reducedMotion} />
       <Html center distanceFactor={11} position={[0, 1.7, 0]} zIndexRange={[20, 0]}>
         <button
           type="button"
@@ -305,8 +147,8 @@ function MundoLugar({ mundo, activo, onEntrar, reducedMotion }) {
       Toca la señal → onAlerta() (el agente lo dice y ofrece LA acción). ── */
 function Beacon({ onAlerta, reducedMotion }) {
   const ancla = MUNDO_VALLE_BY_ID[COSA_DEL_DIA.anclaMundo];
-  const luz = useRef();
-  const halo = useRef();
+  const luz = useRef(null);
+  const halo = useRef(null);
   useFrame((state) => {
     if (reducedMotion) return;
     const p = (Math.sin(state.clock.elapsedTime * 1.6) + 1) / 2;
@@ -353,7 +195,7 @@ function Beacon({ onAlerta, reducedMotion }) {
 /* ── El compañero: el colibrí (visual-lib) flota sobre el foco activo y es la
       cara del agente. Reusa el SVG canónico de creatures. ── */
 function CompaneroColibri({ foco, reducedMotion }) {
-  const ref = useRef();
+  const ref = useRef(null);
   useFrame((state) => {
     if (!ref.current) return;
     const t = state.clock.elapsedTime;
@@ -367,7 +209,7 @@ function CompaneroColibri({ foco, reducedMotion }) {
     <group ref={ref} position={[foco.x + 0.9, foco.y + 2.2, foco.z + 0.6]}>
       <Html center distanceFactor={9} zIndexRange={[40, 10]}>
         <div className="valle-colibri" aria-hidden="true">
-          <Colibri size={54} animated={!reducedMotion} />
+          <Colibri size={54} animated={!reducedMotion} className="" />
         </div>
       </Html>
     </group>
@@ -402,7 +244,7 @@ function CamaraViajera({ foco, controls, autoOrbit }) {
 
 /* ── Contenido de la escena (dentro del Canvas). ── */
 function Escena({ clima, focoId, onEntrar, onAlerta, reducedMotion }) {
-  const controls = useRef();
+  const controls = useRef(null);
   const c = CLIMAS[clima];
   const foco = useMemo(() => {
     const m = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;

--- a/src/mockups/valle/decidirRender.js
+++ b/src/mockups/valle/decidirRender.js
@@ -1,0 +1,86 @@
+/*
+ * decidirRender — el GATE de device-tiering del framework de mundos-3D.
+ *
+ * El campesino promedio trae un teléfono de gama baja-media (DR §2, filtro nº2).
+ * El 3D es ASPIRACIONAL: solo se enciende cuando el equipo lo aguanta; si no,
+ * cae a la lámina 2D digna (nunca a un error). Este módulo decide, con señales
+ * baratas del navegador, si un mundo se pinta en 3D y con qué frugalidad.
+ *
+ *   tier 'alto'  → 3D pleno (sombras suaves permitidas en el valle-hero).
+ *   tier 'medio' → 3D frugal (sin sombras, sin post-proceso, DPR≤1.5, Lambert).
+ *   tier 'bajo'  → NADA de 3D → lámina 2D (misma que sin WebGL).
+ *
+ * Señales (DR §3.1 / §4.4): WebGL como requisito duro + degradación por
+ * `deviceMemory ≤ 3`, `hardwareConcurrency ≤ 4`, `saveData`, `reduced-motion`.
+ */
+
+/** ¿El equipo soporta WebGL? (línea base dura del render 3D). */
+export function soportaWebGL() {
+  if (typeof window === 'undefined') return false;
+  try {
+    const canvas = document.createElement('canvas');
+    return !!(
+      window.WebGLRenderingContext &&
+      (canvas.getContext('webgl2') || canvas.getContext('webgl'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** ¿El usuario pidió menos movimiento? (accesibilidad + señal de equipo débil). */
+export function prefiereMenosMovimiento() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+/**
+ * Clasifica el equipo en un tier a partir de señales del navegador. No mide FPS
+ * (caro y tardío): usa proxies de hardware conocidos por ser buenos indicadores
+ * en gama baja. Conservador por diseño — ante la duda, baja el tier.
+ *
+ * @returns {'alto'|'medio'|'bajo'}
+ */
+export function decidirTier() {
+  if (typeof navigator === 'undefined') return 'medio';
+  // `deviceMemory` y `connection` no están en la lib.dom estándar (son extensiones
+  // de navegadores móviles). Se declaran opcionales para leerlas sin romper tipos.
+  /** @type {Navigator & { deviceMemory?: number, connection?: { saveData?: boolean } }} */
+  const nav = navigator;
+  const mem = typeof nav.deviceMemory === 'number' ? nav.deviceMemory : null;
+  const nucleos =
+    typeof nav.hardwareConcurrency === 'number' ? nav.hardwareConcurrency : null;
+  const ahorroDatos = !!(nav.connection && nav.connection.saveData);
+
+  // Señales de equipo humilde → 3D no vale la pena: mejor la lámina.
+  if (ahorroDatos) return 'bajo';
+  if (mem !== null && mem <= 3) return 'bajo';
+  if (nucleos !== null && nucleos <= 4) return 'bajo';
+
+  // Gama media declarada: 3D frugal.
+  if ((mem !== null && mem <= 6) || (nucleos !== null && nucleos <= 6)) return 'medio';
+
+  // Sin señales negativas → asumimos gama alta (pero el AdaptiveDpr protege).
+  return 'alto';
+}
+
+/**
+ * Decide, de una, cómo montar un mundo: en 3D o en su lámina 2D. Es el único
+ * punto que consulta el navegador; el resto del framework solo lee este objeto.
+ *
+ * @returns {{
+ *   webgl:boolean, tier:'alto'|'medio'|'bajo', reducedMotion:boolean,
+ *   render3d:boolean,
+ * }}
+ */
+export function decidirRender() {
+  const webgl = soportaWebGL();
+  const reducedMotion = prefiereMenosMovimiento();
+  const tier = webgl ? decidirTier() : 'bajo';
+  // 3D solo si hay WebGL Y el tier lo aguanta. 'bajo' o sin-WebGL → lámina 2D.
+  const render3d = webgl && tier !== 'bajo';
+  return { webgl, tier, reducedMotion, render3d };
+}

--- a/src/mockups/valle/escenas/EscenaCutaway.jsx
+++ b/src/mockups/valle/escenas/EscenaCutaway.jsx
@@ -1,0 +1,217 @@
+/*
+ * EscenaCutaway — el ARQUETIPO de escena-mundo "corte de tierra" (DR §5).
+ *
+ * Un bloque de suelo CORTADO que muestra sus CAPAS (hojarasca / suelo negro /
+ * subsuelo) y la VIDA que de otro modo es invisible: lombrices, raíces y el
+ * "internet de los hongos" (hifas). La cantidad de vida visible sigue el `score`
+ * del motor existente (mundoSubsueloEngine) → el corte se PUEBLA cuando la
+ * tierra revive y se despuebla cuando se cansa. "Lo invisible hecho visible".
+ *
+ * Contrato uniforme de arquetipo (DR §4.4):
+ *   props = { params, hotspots, entrada, tinte, reducedMotion, onHotspot, onSalir }
+ *   + `vida01` (0..1) y `clima` que le pasa el host/<Mundo3D>.
+ * Es CONTENIDO de escena (vive dentro del <Canvas> de Mundo3D). Solo geometría
+ * procedural, materiales frugales (Lambert/Basic), sin sombras (DR §6).
+ */
+/* Nota: las props de three (position, args, rotation, intensity, etc.) son
+   válidas en el reconciliador de R3F, no en el DOM. */
+import { useMemo } from 'react';
+import { Html } from '@react-three/drei';
+import { AbejaAngelita } from '../../../visual/creatures/AbejaAngelita.jsx';
+import { useEntradaAbeja } from '../useEntradaAbeja';
+import { CLIMAS } from '../valleData';
+
+const ANCHO = 3.4; // ancho del bloque de tierra (eje x)
+const PROF = 2.0; // profundidad (eje z); la cara frontal expuesta es el "corte"
+const FRONT_Z = PROF / 2; // z de la cara cortada, mirando a la cámara
+
+/** RNG determinista (mulberry32) → posiciones estables, sin parpadeo por frame. */
+function rng(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Bandas verticales de cada capa, apiladas de arriba (hojarasca) hacia abajo. */
+function calcularBandas(capas) {
+  const total = capas.reduce((s, c) => s + c.alto, 0);
+  let topY = total;
+  return {
+    total,
+    bandas: capas.map((c) => {
+      const y1 = topY;
+      const y0 = topY - c.alto;
+      topY = y0;
+      return { ...c, y0, y1, centroY: (y0 + y1) / 2 };
+    }),
+  };
+}
+
+/** Semilleros deterministas de vida (se recortan por `vida01` → poblar/despoblar). */
+function useVidaSemillas(bandas) {
+  return useMemo(() => {
+    const r = rng(20260710);
+    const lombrices = [];
+    const raices = [];
+    const hifas = [];
+    const pasto = [];
+
+    bandas.forEach((b) => {
+      // Lombrices: en hojarasca y suelo negro, curvadas contra la cara cortada.
+      if (b.bichos.includes('lombriz')) {
+        const n = b.nombre === 'suelo negro' ? 6 : 3;
+        for (let i = 0; i < n; i++) {
+          lombrices.push({
+            x: (r() - 0.5) * (ANCHO - 0.7),
+            y: b.y0 + 0.18 + r() * (b.alto - 0.36),
+            rot: (r() - 0.5) * 1.4,
+          });
+        }
+      }
+      // Raíces: descienden desde arriba de la banda hacia el subsuelo.
+      if (b.bichos.includes('raiz')) {
+        const n = b.nombre === 'subsuelo' ? 3 : 4;
+        for (let i = 0; i < n; i++) {
+          raices.push({
+            x: (r() - 0.5) * (ANCHO - 0.9),
+            yTop: b.y1 - 0.05,
+            largo: 0.45 + r() * (b.alto * 0.8),
+            grosor: 0.03 + r() * 0.035,
+          });
+        }
+      }
+      // Hifas: red fina, solo en el suelo negro (donde vive el "internet").
+      if (b.bichos.includes('hifa')) {
+        for (let i = 0; i < 10; i++) {
+          hifas.push({
+            x: (r() - 0.5) * (ANCHO - 0.5),
+            y: b.y0 + 0.15 + r() * (b.alto - 0.3),
+            rot: (r() - 0.5) * 2.6,
+            largo: 0.3 + r() * 0.5,
+          });
+        }
+      }
+    });
+
+    // Pasto sobre la superficie: crece cuando la tierra está viva.
+    for (let i = 0; i < 12; i++) {
+      pasto.push({ x: (r() - 0.5) * (ANCHO - 0.4), z: (r() - 0.5) * (PROF - 0.4), alto: 0.16 + r() * 0.18 });
+    }
+
+    return { lombrices, raices, hifas, pasto };
+  }, [bandas]);
+}
+
+/** Toma los primeros `round(n * vida)` elementos: poblar/despoblar suave. */
+function porVida(arr, vida01) {
+  const n = Math.round(arr.length * Math.max(0, Math.min(1, vida01)));
+  return arr.slice(0, n);
+}
+
+export function EscenaCutaway({
+  params,
+  hotspots = [],
+  clima = 'soleado',
+  vida01 = 0.5,
+  reducedMotion = false,
+  onHotspot,
+}) {
+  const { total, bandas } = useMemo(() => calcularBandas(params?.capas || []), [params]);
+  const vida = useVidaSemillas(bandas);
+
+  // La abeja entra hacia el centro de la cara cortada.
+  const foco = useMemo(() => ({ x: 0, y: total * 0.55, z: FRONT_Z }), [total]);
+  const abejaRef = useEntradaAbeja(foco, { reducedMotion });
+
+  const c = CLIMAS[clima] || CLIMAS.soleado;
+
+  return (
+    <>
+      {/* Cielo/luz del clima (reusa la paleta del valle), sin sombras. */}
+      <color attach="background" args={[c.cielo[1]]} />
+      <fog attach="fog" args={[c.niebla, 8, c.nieblaLejos]} />
+      <hemisphereLight intensity={c.intensidad * 0.7} color={c.cielo[0]} groundColor={c.ambiente} />
+      <ambientLight intensity={c.intensidad * 0.5} color={c.luz} />
+      <directionalLight position={[4, 7, 6]} intensity={c.intensidad * 0.9} color={c.luz} />
+
+      {/* ── El bloque de tierra cortado: una franja por capa ── */}
+      <group>
+        {bandas.map((b) => (
+          <mesh key={b.nombre} position={[0, b.centroY, 0]}>
+            <boxGeometry args={[ANCHO, b.alto, PROF]} />
+            <meshLambertMaterial color={b.color} />
+          </mesh>
+        ))}
+
+        {/* Pasto en la superficie: crece con la vida del suelo. */}
+        {porVida(vida.pasto, vida01).map((p, i) => (
+          <mesh key={`g${i}`} position={[p.x, total + p.alto / 2, p.z]}>
+            <coneGeometry args={[0.05, p.alto, 4]} />
+            <meshLambertMaterial color="#5f9a45" />
+          </mesh>
+        ))}
+
+        {/* Raíces: descienden por la cara cortada hacia el subsuelo. */}
+        {porVida(vida.raices, Math.max(vida01, 0.12)).map((rz, i) => (
+          <mesh
+            key={`r${i}`}
+            position={[rz.x, rz.yTop - rz.largo / 2, FRONT_Z - 0.04]}
+          >
+            <cylinderGeometry args={[rz.grosor * 0.4, rz.grosor, rz.largo, 5]} />
+            <meshLambertMaterial color="#c9a36a" />
+          </mesh>
+        ))}
+
+        {/* Hifas: la red fina de hongos ("internet del suelo"). */}
+        {porVida(vida.hifas, vida01).map((h, i) => (
+          <mesh key={`h${i}`} position={[h.x, h.y, FRONT_Z - 0.02]} rotation={[0, 0, h.rot]}>
+            <cylinderGeometry args={[0.008, 0.008, h.largo, 3]} />
+            <meshBasicMaterial color="#eae3cf" transparent opacity={0.75} />
+          </mesh>
+        ))}
+
+        {/* Lombrices: curvadas contra el corte, salmón. */}
+        {porVida(vida.lombrices, vida01).map((l, i) => (
+          <mesh key={`l${i}`} position={[l.x, l.y, FRONT_Z + 0.02]} rotation={[0, 0, l.rot]}>
+            <capsuleGeometry args={[0.055, 0.28, 3, 6]} />
+            <meshLambertMaterial color="#d98a86" />
+          </mesh>
+        ))}
+      </group>
+
+      {/* ── Hotspots: billboards tocables; cada uno re-rutea a una vista 2D real ── */}
+      {hotspots.map((h) => (
+        <Html key={h.id} center distanceFactor={8} position={h.pos} zIndexRange={[20, 0]}>
+          <button
+            type="button"
+            className="mundo3d-hotspot"
+            onClick={(e) => {
+              e.stopPropagation();
+              onHotspot?.(h.view, h.data);
+            }}
+            aria-label={h.label}
+          >
+            <span className="mundo3d-hotspot__emoji" aria-hidden="true">{h.emoji}</span>
+            <span className="mundo3d-hotspot__txt">{h.label}</span>
+          </button>
+        </Html>
+      ))}
+
+      {/* ── La abeja Angelita: baja y se posa junto al corte (hook compartido) ── */}
+      <group ref={abejaRef}>
+        <Html center distanceFactor={7} zIndexRange={[40, 10]}>
+          <div className="mundo3d-abeja" aria-hidden="true">
+            <AbejaAngelita size={54} animated={!reducedMotion} className="mundo3d-abeja__svg" />
+          </div>
+        </Html>
+      </group>
+    </>
+  );
+}
+
+export default EscenaCutaway;

--- a/src/mockups/valle/laminas/LaminaCutaway.jsx
+++ b/src/mockups/valle/laminas/LaminaCutaway.jsx
@@ -1,0 +1,156 @@
+/*
+ * LaminaCutaway — la degradación 2D DIGNA del arquetipo `cutaway` (DR §4.4/§5).
+ *
+ * Cuando el equipo no aguanta 3D (tier bajo / sin WebGL / reduced-motion), el
+ * corte de tierra se pinta en SVG+CSS — el músculo que Chagra ya domina — con
+ * las MISMAS capas, la MISMA vida (que se puebla/despuebla con `vida01`) y los
+ * MISMOS hotspots como botones posicionados. No es "modo degradado feo": es la
+ * misma lección sin el peso. "Wow" se pierde; el PROPÓSITO no.
+ */
+
+const V_W = 400;
+const V_H = 300;
+const SUELO_TOP = 96; // y donde empieza la tierra (arriba = cielo)
+
+/** RNG determinista → posiciones estables de la vida dibujada. */
+function rng(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function LaminaCutaway({ hotspots = [], tinte = ['#8a5a38', '#f0e2c8'], vida01 = 0.5, onHotspot }) {
+  const v = Math.max(0, Math.min(1, vida01));
+
+  // Bandas de tierra (mismo orden que el 3D: hojarasca / suelo negro / subsuelo).
+  const bandas = [
+    { color: '#6b4a2e', y0: SUELO_TOP, y1: SUELO_TOP + 46 },
+    { color: '#3a2a1a', y0: SUELO_TOP + 46, y1: SUELO_TOP + 138 },
+    { color: '#8a6a44', y0: SUELO_TOP + 138, y1: V_H },
+  ];
+
+  // Vida determinista, recortada por `v`.
+  const r = rng(20260710);
+  const lombrices = Array.from({ length: 8 }, () => ({
+    x: 30 + r() * (V_W - 60),
+    y: SUELO_TOP + 30 + r() * 120,
+    rot: (r() - 0.5) * 50,
+  })).slice(0, Math.round(8 * v));
+  const raices = Array.from({ length: 6 }, () => ({
+    x: 40 + r() * (V_W - 80),
+    largo: 40 + r() * 90,
+  })).slice(0, Math.round(6 * Math.max(v, 0.14)));
+  const hifas = Array.from({ length: 10 }, () => ({
+    x1: 30 + r() * (V_W - 60),
+    y1: SUELO_TOP + 60 + r() * 70,
+    dx: (r() - 0.5) * 60,
+    dy: (r() - 0.5) * 40,
+  })).slice(0, Math.round(10 * v));
+  const pasto = Array.from({ length: 14 }, () => ({ x: 20 + r() * (V_W - 40), alto: 8 + r() * 12 })).slice(
+    0,
+    Math.round(14 * v),
+  );
+
+  return (
+    <div className="mundo3d-lamina" style={{ '--m-tinte': tinte[0] }}>
+      <svg
+        viewBox={`0 0 ${V_W} ${V_H}`}
+        className="mundo3d-lamina__svg"
+        role="img"
+        aria-label="Un corte de su suelo, dibujado: las capas y la vida que hay bajo la tierra. Toque un punto para entrar."
+      >
+        <defs>
+          <linearGradient id="mc-cielo" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#bfe3f0" />
+            <stop offset="1" stopColor="#e8f3d9" />
+          </linearGradient>
+        </defs>
+
+        {/* cielo sobre la superficie */}
+        <rect x="0" y="0" width={V_W} height={SUELO_TOP} fill="url(#mc-cielo)" />
+
+        {/* las capas de tierra */}
+        {bandas.map((b) => (
+          <rect key={b.color} x="0" y={b.y0} width={V_W} height={b.y1 - b.y0} fill={b.color} />
+        ))}
+
+        {/* pasto en la superficie (crece con la vida) */}
+        {pasto.map((p, i) => (
+          <line
+            key={`g${i}`}
+            x1={p.x}
+            y1={SUELO_TOP}
+            x2={p.x + (i % 2 ? 3 : -3)}
+            y2={SUELO_TOP - p.alto}
+            stroke="#5f9a45"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+          />
+        ))}
+
+        {/* raíces que bajan */}
+        {raices.map((rz, i) => (
+          <line
+            key={`r${i}`}
+            x1={rz.x}
+            y1={SUELO_TOP + 8}
+            x2={rz.x + (i % 2 ? 10 : -10)}
+            y2={SUELO_TOP + 8 + rz.largo}
+            stroke="#c9a36a"
+            strokeWidth="2.6"
+            strokeLinecap="round"
+          />
+        ))}
+
+        {/* hifas: la red fina de hongos */}
+        {hifas.map((h, i) => (
+          <line
+            key={`h${i}`}
+            x1={h.x1}
+            y1={h.y1}
+            x2={h.x1 + h.dx}
+            y2={h.y1 + h.dy}
+            stroke="#eae3cf"
+            strokeWidth="1"
+            opacity="0.7"
+          />
+        ))}
+
+        {/* lombrices: cápsulas curvas */}
+        {lombrices.map((l, i) => (
+          <g key={`l${i}`} transform={`translate(${l.x} ${l.y}) rotate(${l.rot})`}>
+            <path d="M-9,0 q9,-7 18,0" fill="none" stroke="#d98a86" strokeWidth="5" strokeLinecap="round" />
+          </g>
+        ))}
+      </svg>
+
+      {/* hotspots como botones posicionados (mismos `view` que el 3D) */}
+      <div className="mundo3d-lamina__hotspots">
+        {hotspots.map((h) => {
+          const leftPct = 50 + (h.pos[0] / 1.7) * 30;
+          const topPct = 70 - h.pos[1] * 14;
+          return (
+            <button
+              key={h.id}
+              type="button"
+              className="mundo3d-hotspot mundo3d-hotspot--2d"
+              style={{ left: `${leftPct}%`, top: `${topPct}%` }}
+              onClick={() => onHotspot?.(h.view, h.data)}
+              aria-label={h.label}
+            >
+              <span className="mundo3d-hotspot__emoji" aria-hidden="true">{h.emoji}</span>
+              <span className="mundo3d-hotspot__txt">{h.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default LaminaCutaway;

--- a/src/mockups/valle/mundo3d.css
+++ b/src/mockups/valle/mundo3d.css
@@ -1,0 +1,233 @@
+/*
+ * mundo3d.css — estilos del framework de mundos-3D (host + hotspots + lámina).
+ * Estética cálida, "menos colapso": una cosa clara a la vez, sin HUD saturado.
+ * Copy y colores de muestra; si se productiza, migra a tokens del design system.
+ */
+
+.mundo3d-root {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  background: #10221a;
+  color: #f4efe4;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --m-tinte: #8a5a38;
+  --m-tinte-suave: #f0e2c8;
+}
+
+.mundo3d-escena {
+  position: absolute;
+  inset: 0;
+}
+
+.mundo3d-canvas {
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+  touch-action: none;
+}
+
+/* ── Cargando ── */
+.mundo3d-cargando {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.9rem;
+  background: linear-gradient(180deg, #bfe3f0, #6b4a2e);
+  color: #23160c;
+}
+.mundo3d-cargando__pulso {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: var(--m-tinte, #8a5a38);
+  animation: mundo3d-latido 1.4s ease-in-out infinite;
+}
+@keyframes mundo3d-latido {
+  0%, 100% { transform: scale(0.82); opacity: 0.6; }
+  50% { transform: scale(1.05); opacity: 1; }
+}
+
+/* ── Encabezado ── */
+.mundo3d-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.9rem 1rem;
+  background: linear-gradient(180deg, rgba(10, 20, 15, 0.55), rgba(10, 20, 15, 0));
+  pointer-events: none;
+}
+.mundo3d-header > * {
+  pointer-events: auto;
+}
+.mundo3d-titulo {
+  text-align: center;
+  flex: 1;
+}
+.mundo3d-titulo__eyebrow {
+  display: block;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.82;
+}
+.mundo3d-titulo h1 {
+  margin: 0.1rem 0 0;
+  font-size: 1.18rem;
+  font-weight: 700;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+}
+.mundo3d-back,
+.mundo3d-voz {
+  border: none;
+  border-radius: 999px;
+  padding: 0.42rem 0.85rem;
+  font-size: 0.86rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+  backdrop-filter: blur(6px);
+}
+.mundo3d-voz.on {
+  background: rgba(255, 220, 150, 0.28);
+}
+
+/* ── Hotspot (billboard 3D o botón 2D): botón real, accesible ── */
+.mundo3d-hotspot {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 2px solid color-mix(in srgb, var(--m-tinte, #8a5a38) 60%, #fff);
+  border-radius: 999px;
+  padding: 0.34rem 0.7rem 0.34rem 0.4rem;
+  background: rgba(255, 250, 240, 0.94);
+  color: #2a1c10;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.28);
+  transition: transform 0.12s ease;
+}
+.mundo3d-hotspot:hover,
+.mundo3d-hotspot:focus-visible {
+  transform: translateY(-2px);
+  outline: 3px solid rgba(255, 214, 128, 0.9);
+  outline-offset: 2px;
+}
+.mundo3d-hotspot__emoji {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--m-tinte, #8a5a38) 22%, #fff);
+  font-size: 1rem;
+}
+.mundo3d-hotspot--2d {
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+.mundo3d-hotspot--2d:hover,
+.mundo3d-hotspot--2d:focus-visible {
+  transform: translate(-50%, -50%) translateY(-2px);
+}
+
+/* ── La abeja Angelita flotando en la escena ── */
+.mundo3d-abeja {
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
+  pointer-events: none;
+}
+
+/* ── Lámina 2D (fallback) ── */
+.mundo3d-lamina {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+.mundo3d-lamina__svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.mundo3d-lamina__hotspots {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.mundo3d-lamina__hotspots > * {
+  pointer-events: auto;
+}
+
+.mundo3d-degradado {
+  position: absolute;
+  top: 4.4rem;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.5);
+  font-size: 0.8rem;
+}
+
+/* ── Control de "vida del suelo" (puebla/despuebla el corte) ── */
+.mundo3d-control {
+  position: absolute;
+  left: 50%;
+  bottom: 1.1rem;
+  transform: translateX(-50%);
+  width: min(92vw, 420px);
+  padding: 0.8rem 1rem 0.95rem;
+  border-radius: 18px;
+  background: rgba(18, 30, 22, 0.82);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+}
+.mundo3d-control__cab {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+.mundo3d-control__lbl {
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+.mundo3d-control__etapa {
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.16rem 0.6rem;
+  border-radius: 999px;
+  text-transform: capitalize;
+  background: #6b5330;
+  color: #ffe9c2;
+}
+.mundo3d-control__etapa[data-etapa='despertando'] { background: #7a6a25; }
+.mundo3d-control__etapa[data-etapa='vivo'] { background: #2f6a34; color: #d7f5cf; }
+.mundo3d-control__etapa[data-etapa='cansado'] { background: #6a3a2a; color: #ffd9c9; }
+.mundo3d-control input[type='range'] {
+  width: 100%;
+  accent-color: var(--m-tinte, #8a5a38);
+}
+.mundo3d-control__ayuda {
+  margin: 0.5rem 0 0;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  opacity: 0.82;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mundo3d-cargando__pulso {
+    animation: none;
+  }
+}

--- a/src/mockups/valle/mundo3dData.js
+++ b/src/mockups/valle/mundo3dData.js
@@ -1,0 +1,105 @@
+/*
+ * mundo3dData — el REGISTRO data-driven del framework de mundos-3D (DR §4.2).
+ *
+ * Una entrada por mundo. TODO lo específico de un mundo es DATOS, no código:
+ *   · `valle`   → el landmark en la capa lejana (lo que hoy hace valleData).
+ *   · `escena`  → el ARQUETIPO de escena-mundo ('cutaway'|'flujo'|…|null).
+ *   · `params`  → props del arquetipo (low-poly, deterministas).
+ *   · `hotspots`→ 3-5 puntos tocables; cada uno RE-RUTEA a una vista 2D REAL
+ *                 (regla de oro: el 3D nunca reimplementa la pantalla).
+ *   · `entrada` → coreografía de la abeja + narración (voz nombra el tema 1º).
+ *   · `fallback2d` → qué lámina SVG usa el tier 2D (o `ruta2d` directa al 2D).
+ *
+ * SUMAR UN MUNDO SÍ-3D = una entrada aquí (+ opcional una lámina espejo). NO se
+ * escribe R3F salvo que aparezca una metáfora espacial genuinamente nueva.
+ *
+ * El título/emoji/tinte NO se duplican: se resuelven del manifiesto real
+ * (mundosFinca.js) vía `metaMundo(id)`, igual que valleData hoy.
+ */
+
+import { MUNDO_BY_ID } from '../../components/dashboard/mundosFinca';
+
+/* ── El registro. Solo `suelo` trae escena 3D en esta pasada (el prototipo);
+      el resto queda declarado para que el próximo mundo sea "solo datos". ── */
+export const MUNDO_3D = {
+  // 🌱 EL SUELO VIVO — prototipo `cutaway`: lo invisible hecho visible.
+  suelo: {
+    // ── capa lejana: el landmark en el valle ──
+    valle: { tipo: 'era', pos: [-1.1, 0, 3.6], escala: 1 },
+
+    // ── capa cercana: la escena-mundo al entrar ──
+    escena: 'cutaway',
+    params: {
+      // Franjas horizontales del corte de tierra (de arriba hacia abajo).
+      capas: [
+        { nombre: 'hojarasca', color: '#6b4a2e', alto: 0.55, bichos: ['lombriz'] },
+        { nombre: 'suelo negro', color: '#3a2a1a', alto: 1.25, bichos: ['lombriz', 'raiz', 'hifa'] },
+        { nombre: 'subsuelo', color: '#8a6a44', alto: 1.05, bichos: ['raiz'] },
+      ],
+      // El motor existente decide cuánta vida se ve (0..1): reusa mundoSubsueloEngine.
+      vidaFrom: 'mundoSubsueloEngine',
+    },
+
+    // ── hotspots: cada `view` es un case REAL de App.jsx (reachability) ──
+    hotspots: [
+      { id: 'juego', pos: [0, 1.55, 1.25], emoji: '🪱', label: 'Despierte su suelo', view: 'subsuelo' },
+      { id: 'cuaderno', pos: [1.55, 1.15, 1.1], emoji: '📓', label: 'Cuaderno del suelo', view: 'salud_suelo' },
+      { id: 'crom', pos: [-1.55, 1.15, 1.1], emoji: '🎯', label: 'Cromatografía', view: 'cromatografia' },
+    ],
+
+    // ── entrada de la abeja + narración (la voz nombra el tema primero) ──
+    entrada: { zoom: 6.5, narra: 'suelo' },
+
+    // ── degradación: la lámina SVG espejo del tier 2D ──
+    fallback2d: 'lamina-cutaway',
+  },
+
+  // ── Declarados para el framework (aún sin escena 3D construida): así el
+  //    próximo mundo SÍ-3D nace como "una entrada de datos". Hoy caen al 2D. ──
+  agua: {
+    valle: { tipo: 'quebrada', pos: [0.6, 0, -1.4], escala: 1 },
+    escena: null, // 'flujo' cuando se construya EscenaFlujo
+    ruta2d: { view: 'agua' },
+  },
+  animales: {
+    valle: { tipo: 'corral', pos: [-4.6, 0, -1.8], escala: 1 },
+    escena: null, // 'recinto' cuando se construya EscenaRecinto
+    ruta2d: { view: 'animales' },
+    gate: 'animales',
+  },
+  disenio: {
+    valle: { tipo: 'bosque', pos: [4.8, 0, -2.6], escala: 1.1 },
+    escena: null, // 'estratos' cuando se construya EscenaEstratos
+    ruta2d: { view: 'disenio' },
+  },
+
+  // ── HÍBRIDO / NO-3D: sin escena propia → landmark en el valle + directo al 2D ──
+  cultivos: { valle: { tipo: 'milpa', pos: [-3.2, 0, 1.6], escala: 1.15 }, escena: null, ruta2d: { view: 'mundo_cultivos' } },
+  cafe: { valle: { tipo: 'cafetal', pos: [3.4, 0, 2.2], escala: 1 }, escena: null, ruta2d: { view: 'cafe' } },
+  clima: { valle: { tipo: 'veleta', pos: [-3.8, 0, -4.8], escala: 1 }, escena: null, ruta2d: { view: 'hoy_finca' }, ambiental: true },
+};
+
+/**
+ * Resuelve título/emoji/lema/tinte de un mundo desde el manifiesto REAL
+ * (mundosFinca.js). No los duplica: si el manifiesto cambia, esto lo sigue.
+ *
+ * @param {string} mundoId
+ * @returns {{ id:string, titulo:string, emoji:string, lema:string, tinte:string[] }}
+ */
+export function metaMundo(mundoId) {
+  /** @type {{ titulo?: string, emoji?: string, lema?: string, tinte?: string[] }} */
+  const real = MUNDO_BY_ID[mundoId] || {};
+  return {
+    id: mundoId,
+    titulo: real.titulo || mundoId,
+    emoji: real.emoji || '📍',
+    lema: real.lema || '',
+    tinte: real.tinte || ['#3f8f4e', '#dcedc9'],
+  };
+}
+
+/** ¿El mundo tiene una escena-mundo 3D construida (no solo un landmark)? */
+export function tieneEscena3d(mundoId) {
+  const d = MUNDO_3D[mundoId];
+  return !!(d && d.escena);
+}

--- a/src/mockups/valle/mundo3dLandmarks.jsx
+++ b/src/mockups/valle/mundo3dLandmarks.jsx
@@ -1,0 +1,215 @@
+/*
+ * mundo3dLandmarks — el REGISTRO de formas procedurales de cada landmark.
+ *
+ * Antes, el `switch (tipo)` de `LandmarkGeom` vivía HARDCODEADO dentro de
+ * `Valle3D`. El framework de mundos-3D (DR §4.4, §7-1) lo saca a un MAPA de
+ * datos: `LANDMARKS[tipo]` → un componente de geometría low-poly. Así:
+ *   · el valle (capa lejana) resuelve su forma por `tipo` sin un switch inline;
+ *   · sumar un mundo nuevo NO toca este archivo salvo que traiga una forma nueva.
+ *
+ * Todo es GEOMETRÍA PROCEDURAL (cajas/conos/cilindros/icosaedros — cero GLTF/HDR
+ * remotos) → offline-first y liviano, igual que el resto del valle.
+ */
+/* Nota: las props de three (position, args, rotation, etc.) son válidas en el
+   reconciliador de R3F, no en el DOM — el config de ESLint del repo no activa
+   react/no-unknown-property, así que no requieren disable. */
+import { useFrame } from '@react-three/fiber';
+import { useRef } from 'react';
+
+/* La veleta gira con el viento; su propia coreografía (no depende del valle). */
+export function Veleta({ color, reducedMotion }) {
+  const ref = useRef(null);
+  useFrame((state) => {
+    if (ref.current && !reducedMotion) ref.current.rotation.y = state.clock.elapsedTime * 0.4;
+  });
+  return (
+    <group>
+      <mesh position={[0, 0.55, 0]}>
+        <cylinderGeometry args={[0.05, 0.07, 1.1, 6]} />
+        <meshStandardMaterial color="#7c6a4c" flatShading />
+      </mesh>
+      <group ref={ref} position={[0, 1.15, 0]}>
+        <mesh>
+          <boxGeometry args={[0.7, 0.06, 0.06]} />
+          <meshStandardMaterial color={color} flatShading />
+        </mesh>
+        <mesh position={[0.42, 0, 0]} rotation={[0, 0, -Math.PI / 2]}>
+          <coneGeometry args={[0.14, 0.3, 4]} />
+          <meshStandardMaterial color={color} flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+function Milpa({ tinte }) {
+  const [fuerte] = tinte;
+  return (
+    <group>
+      {[-0.5, 0, 0.5, -0.25, 0.25].map((dx, i) => (
+        <group key={i} position={[dx, 0, (i % 2) * 0.4 - 0.2]}>
+          <mesh position={[0, 0.7, 0]} castShadow>
+            <cylinderGeometry args={[0.05, 0.08, 1.4, 5]} />
+            <meshStandardMaterial color={fuerte} flatShading />
+          </mesh>
+          <mesh position={[0, 1.45, 0]}>
+            <coneGeometry args={[0.12, 0.4, 5]} />
+            <meshStandardMaterial color="#e7c96b" flatShading />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
+function Cafetal({ tinte }) {
+  const [fuerte] = tinte;
+  return (
+    <group>
+      {[-0.6, -0.2, 0.2, 0.6].map((dx, i) => (
+        <mesh key={i} position={[dx, 0.32, (i % 2) * 0.4]} castShadow>
+          <icosahedronGeometry args={[0.34, 0]} />
+          <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function Era({ tinte }) {
+  const [, suave] = tinte;
+  return (
+    <group>
+      {[-0.35, 0, 0.35].map((dz, i) => (
+        <mesh key={i} position={[0, 0.08, dz]} castShadow receiveShadow>
+          <boxGeometry args={[1.3, 0.16, 0.22]} />
+          <meshStandardMaterial color="#5a3d28" flatShading roughness={1} />
+        </mesh>
+      ))}
+      {[-0.35, 0, 0.35].map((dz, i) => (
+        <mesh key={`b${i}`} position={[0, 0.24, dz]}>
+          <boxGeometry args={[1.2, 0.06, 0.14]} />
+          <meshStandardMaterial color={suave} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function Quebrada() {
+  return (
+    <group>
+      <mesh position={[0, 0.06, 0]}>
+        <cylinderGeometry args={[0.55, 0.6, 0.12, 16]} />
+        <meshStandardMaterial color="#3a7fa0" transparent opacity={0.85} metalness={0.4} roughness={0.2} />
+      </mesh>
+      {[-0.3, 0.1, 0.4].map((dx, i) => (
+        <mesh key={i} position={[dx, 0.4, 0.2]}>
+          <cylinderGeometry args={[0.03, 0.03, 0.7, 4]} />
+          <meshStandardMaterial color="#4e7d3f" flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function Corral({ tinte }) {
+  const [fuerte, suave] = tinte;
+  return (
+    <group>
+      <mesh position={[0, 0.35, 0]} castShadow>
+        <boxGeometry args={[0.9, 0.7, 0.8]} />
+        <meshStandardMaterial color={suave} flatShading />
+      </mesh>
+      <mesh position={[0, 0.85, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+        <coneGeometry args={[0.72, 0.5, 4]} />
+        <meshStandardMaterial color={fuerte} flatShading />
+      </mesh>
+      {[-0.9, -0.5, 0.9, 1.3].map((dx, i) => (
+        <mesh key={i} position={[dx, 0.2, 0.9]}>
+          <boxGeometry args={[0.06, 0.4, 0.06]} />
+          <meshStandardMaterial color="#8a6a44" flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function Huerta({ tinte }) {
+  const [fuerte] = tinte;
+  return (
+    <group>
+      {[-0.4, 0.4].map((dx, i) => (
+        <group key={i} position={[dx, 0, 0]}>
+          <mesh position={[0, 0.12, 0]} castShadow>
+            <boxGeometry args={[0.6, 0.24, 1]} />
+            <meshStandardMaterial color="#6b4a30" flatShading />
+          </mesh>
+          <mesh position={[0, 0.32, 0]}>
+            <boxGeometry args={[0.5, 0.18, 0.9]} />
+            <meshStandardMaterial color={fuerte} flatShading />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
+function Bosque({ tinte }) {
+  const [fuerte] = tinte;
+  return (
+    <group>
+      {[
+        [-0.5, 0, 0.9],
+        [0.4, 0.2, 1.15],
+        [0, -0.4, 0.8],
+      ].map(([dx, dz, h], i) => (
+        <group key={i} position={[dx, 0, dz]}>
+          <mesh position={[0, h * 0.35, 0]} castShadow>
+            <cylinderGeometry args={[0.09, 0.12, h * 0.7, 6]} />
+            <meshStandardMaterial color="#6b4a2e" flatShading />
+          </mesh>
+          <mesh position={[0, h * 0.8, 0]} castShadow>
+            <coneGeometry args={[0.5, h * 0.9, 7]} />
+            <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
+function LandmarkDefault({ tinte }) {
+  const [fuerte] = tinte;
+  return (
+    <mesh position={[0, 0.3, 0]}>
+      <icosahedronGeometry args={[0.4, 0]} />
+      <meshStandardMaterial color={fuerte} flatShading />
+    </mesh>
+  );
+}
+
+/* El REGISTRO: `tipo` → componente de geometría. Sumar una forma nueva = añadir
+   una entrada aquí (la única vez que se escribe geometría de un landmark).
+   Interno: el resto del framework lo consume vía `LandmarkPorTipo`. */
+const LANDMARKS = {
+  milpa: Milpa,
+  cafetal: Cafetal,
+  era: Era,
+  quebrada: Quebrada,
+  corral: Corral,
+  huerta: Huerta,
+  bosque: Bosque,
+  veleta: Veleta,
+};
+
+/**
+ * Resuelve la geometría de un landmark por `tipo`, con la `veleta` como caso que
+ * necesita `reducedMotion` para su giro. Cae a un icosaedro digno si el tipo es
+ * desconocido — nunca un error.
+ */
+export function LandmarkPorTipo({ tipo, tinte, reducedMotion }) {
+  if (tipo === 'veleta') return <Veleta color={tinte[0]} reducedMotion={reducedMotion} />;
+  const Forma = LANDMARKS[tipo] || LandmarkDefault;
+  return <Forma tinte={tinte} />;
+}

--- a/src/mockups/valle/useEntradaAbeja.js
+++ b/src/mockups/valle/useEntradaAbeja.js
@@ -1,0 +1,65 @@
+/*
+ * useEntradaAbeja — la COREOGRAFÍA compartida de "la abeja baja y entra".
+ *
+ * Contrato del framework (DR §4.4): la ESCENA posee la coreografía, la CREATURE
+ * (AbejaAngelita) posee el cuerpo. Este hook centraliza el vuelo para que TODA
+ * escena-mundo herede la misma entrada sin reescribirla: la abeja aparece alto y
+ * lejos, y desciende con un easing suave hasta posarse junto al foco, donde
+ * queda flotando con un leve vaivén. `reducedMotion` la posa de una, quieta.
+ *
+ * Uso:
+ *   const abejaRef = useEntradaAbeja(foco, { entrando, reducedMotion });
+ *   <group ref={abejaRef}><Html><AbejaAngelita/></Html></group>
+ *
+ * Devuelve un ref para colgar de un <group>; el hook mueve ese grupo cada frame.
+ */
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+/** Ease-out cúbico: rápido al inicio, calmo al final (aterrizaje suave). */
+function easeOut(t) {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+/**
+ * @param {{x:number,y:number,z:number}} foco  punto al que la abeja se acerca.
+ * @param {object} [opts]
+ * @param {boolean} [opts.entrando=true]     si false, la abeja no avanza la entrada.
+ * @param {boolean} [opts.reducedMotion=false] posa quieta, sin vaivén.
+ * @param {number}  [opts.velocidad=0.55]    qué tan rápido completa la entrada.
+ * @returns {import('react').MutableRefObject} ref para un <group>.
+ */
+export function useEntradaAbeja(foco, opts = {}) {
+  const { entrando = true, reducedMotion = false, velocidad = 0.55 } = opts;
+  const ref = useRef(null);
+  const progreso = useRef(0); // 0 = alto y lejos, 1 = posada junto al foco.
+  const desde = useRef(new THREE.Vector3());
+  const hasta = useRef(new THREE.Vector3());
+
+  useFrame((state, delta) => {
+    const g = ref.current;
+    if (!g) return;
+
+    if (reducedMotion) {
+      progreso.current = 1;
+    } else if (entrando && progreso.current < 1) {
+      progreso.current = Math.min(1, progreso.current + delta * velocidad);
+    }
+
+    const p = easeOut(progreso.current);
+    const t = state.clock.elapsedTime;
+    const bob = reducedMotion ? 0 : Math.sin(t * 2) * 0.12;
+
+    // Punto de aparición: arriba y en diagonal respecto al foco.
+    desde.current.set(foco.x + 2.6, foco.y + 3.4, foco.z + 2.4);
+    // Punto de reposo: posada al lado del foco, flotando levemente.
+    hasta.current.set(foco.x + 0.85, foco.y + 1.05 + bob, foco.z + 0.7);
+
+    g.position.lerpVectors(desde.current, hasta.current, p);
+  });
+
+  return ref;
+}
+
+export default useEntradaAbeja;

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -40,6 +40,7 @@ const LUGARES = [
  * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar.
  */
 export const MUNDOS_VALLE = LUGARES.map((l) => {
+  /** @type {{ titulo?: string, emoji?: string, lema?: string, tinte?: string[] }} */
   const real = MUNDO_BY_ID[l.id] || {};
   return {
     ...l,

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,0 +1,61 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
+   Apis). Cuerpo ámbar rayado, cabeza clara, alitas de tul. Versión canónica
+   deducida del mockup "Guardianes que aparecen". */
+const VIEWBOX = '-15 -15 32 30';
+
+export function AbejaAngelita({
+  size = 64,
+  className,
+  inline = false,
+  animated = true,
+  title = 'Abeja angelita',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      <circle r="6" fill="#ffb54f" opacity="0.35" filter={`url(#${blur})`} />
+      <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
+        style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
+      <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
+        stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
+      <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
+      <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
+      <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
+      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="abeja-angelita">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default AbejaAngelita;


### PR DESCRIPTION
## Qué es

Ejecuta el **DR-MUNDOS-3D-FRAMEWORK**: lleva el primer mundo de la finca a una **escena-mundo 3D** (el arquetipo `cutaway` del suelo) y deja el **esqueleto data-driven** para sumar los siguientes con **solo datos**. Prototipo del "llevar un mundo a 3D".

Stacked sobre #2289 (`fable/entrada-definitiva-3d`) — base = esa rama, así el diff es solo el delta del mundo3d.

Ruta: `#/mockups/mundo3d-suelo`

## El contrato del framework (sumar el próximo mundo = una entrada de datos)

`MUNDO_3D[mundoId] = { valle, escena, params, hotspots[], entrada, fallback2d | ruta2d }`

- `<Mundo3D mundoId tier reducedMotion vida01 onHotspot/>` elige el **arquetipo** por `escena` de un registro **cerrado** (`ESCENAS`) y lo monta en un `<Canvas>` frugal. `escena===null` o `tier==='bajo'`/sin-WebGL → el host cae a `<Mundo2D>` (SVG).
- **Sumar un mundo SÍ-3D que reusa arquetipo** = una entrada en `mundo3dData.js` + (opcional) una lámina SVG espejo. **Cero código 3D nuevo.**
- **Sumar un arquetipo nuevo** (raro) = un componente `Escena*` + una línea en `ESCENAS`. La única vez que se escribe R3F.
- **Hotspot** `{ id, pos, emoji, label, view }`: cada `view` es un **case real de App.jsx** (regla de oro: el 3D **re-rutea**, nunca reimplementa la pantalla).
- **`useEntradaAbeja`**: hook compartido con la coreografía "la abeja baja y entra" — la escena posee la coreografía, `AbejaAngelita` posee el cuerpo.
- **`decidirRender()`**: gate de device-tiering (WebGL duro + `deviceMemory`/núcleos/`saveData`/reduced-motion) → `alto|medio|bajo`.

## Prototipo — arquetipo `cutaway` (el suelo vivo)

Un corte de tierra low-poly con capas (hojarasca / suelo negro / subsuelo) y **vida** (lombrices, raíces, hifas, pasto) cuya densidad sigue el `score` del **motor existente** (`mundoSubsueloEngine`). *Lo invisible hecho visible.* La abeja Angelita entra volando y se posa junto al corte. Un control de "vida del suelo" (el mismo concepto del juego, etapa cansado→vivo) puebla/despuebla el corte en vivo.

## Qué se reusó (NO se reescribió)

- `Valle3D` / `valleData` (CLIMAS, cámara, patrón lazy) — el `switch` de `LandmarkGeom` se sacó a `LANDMARKS[tipo]` (`mundo3dLandmarks`), Valle3D ahora lo consume vía `LandmarkPorTipo` **sin cambio visual**.
- `AbejaAngelita` (avatar) y el motor + datos del subsuelo (`mundoSubsueloEngine`, `mundoSubsueloData`) — el 3D es una **piel** sobre esa lógica.

## Criterios de aceptación (DR §5)

1. El corte se puebla/despuebla al cambiar el `score` ✅
2. Los 3 hotspots re-rutean a vistas reales (`subsuelo`, `salud_suelo`, `cromatografia`) sin reimplementarlas ✅
3. Tier bajo / sin-WebGL cae a la lámina SVG con los mismos hotspots ✅
4. 0 assets remotos, todo procedural (three en chunk perezoso, no entra al bundle base) ✅
5. Copy en español Colombia *usted* ✅

## Verificación

- `npm run build` verde (three en chunk `Mundo3D` perezoso; base no lo referencia).
- `node scripts/tsc-check-gate.mjs` → **868/868, cero nuevos** (incluí el tipado de los archivos del valle sobre los que construí).
- `npx eslint` limpio en lo tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)