### PR TITLE
feat(mockup): mundo 3D del «hola, Chagra» — el valle que despierta y oye

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,6 +94,12 @@ const InventoryPage = lazy(() => import('./pages/InventoryPage'));
 // perezoso) donde los 4 sí-o-sí viven en el espacio. Ruta #/mockups/entrada-3d
 // — sin gate ni sesión (datos de muestra, degrada limpio a SVG sin WebGL).
 const EntradaValle3DMockup = lazy(() => import('./mockups/EntradaValle3D'));
+// Mockup dev "Hola, Chagra" (el mundo 3D del wake-word): el valle 3D en reposo
+// despierta cuando el campesino dice «hola, Chagra» — la abeja vuela al centro,
+// la voz toma forma (IrisVoz) y el agente responde en voz. Ruta
+// #/mockups/hola-chagra-3d — sin gate ni sesión (demo guionada, sin micrófono;
+// device-tiering real: gama baja ve la misma coreografía sobre el valle SVG).
+const HolaChagra3DMockup = lazy(() => import('./mockups/HolaChagra3D'));
 const BiopreparadosScreen = lazy(() => import('./components/biopreparados/BiopreparadosScreen'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
@@ -424,6 +430,7 @@ const LoadingFallback = ({ view = null }) => {
 
 const HASH_VIEW_ROUTES = {
   'mockups/entrada-3d': 'mockup_entrada_3d',
+  'mockups/hola-chagra-3d': 'mockup_hola_chagra_3d',
   agente: 'agente',
   'ciclo-vivo': 'ciclo_vivo',
   faq: 'faq',
@@ -1295,6 +1302,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El valle de mi finca (3D)">
               <EntradaValle3DMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_hola_chagra_3d':
+        // Mockup "Hola, Chagra": el momento del wake-word como escena 3D viva
+        // — valle en reposo → la abeja despierta y vuela al centro → la voz
+        // toma forma (IrisVoz) → el agente responde en voz → la respuesta cae
+        // como una acción concreta. Full-screen, sin gate. Degrada a SVG (la
+        // misma coreografía) en gama baja o sin WebGL.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Hola, Chagra (mundo 3D)">
+              <HolaChagra3DMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/HolaChagra3D.jsx
+++ b/src/mockups/HolaChagra3D.jsx
@@ -1,0 +1,303 @@
+/*
+ * MOCKUP "Hola, Chagra" — el mundo 3D del wake-word. Ruta #/mockups/hola-chagra-3d.
+ *
+ * Chagra es voice-first: el campesino no "abre un micrófono", le HABLA a su
+ * finca. Este mockup une dos piezas que ya existen en el momento exacto de
+ * hablarle: el VALLE 3D (el mundo — mockups/valle, reusado de la entrada
+ * definitiva 3D) y la IDENTIDAD DE LA VOZ (el IrisVoz de visual/voz — la voz
+ * con forma), con la ABEJA ANGELITA (visual/creatures) como el ser del mundo
+ * que despierta primero.
+ *
+ * EL GUION (demostración guionada, SIN micrófono real):
+ *   1. reposo      → el valle respira solo; UNA cosa en pantalla: el hint
+ *                    «diga: "hola, Chagra"» (tocarlo = decirlo).
+ *   2. saludo      → la abeja despierta y vuela al centro; el mundo se recoge
+ *                    (velo), la cámara se acerca: el valle ESCUCHA.
+ *   3. escuchando  → aparece el iris (ondas hacia adentro) y la pregunta del
+ *                    campesino se transcribe palabra a palabra.
+ *   4. pensando    → el iris se trenza: Chagra mira los datos de la finca.
+ *   5. hablando    → Chagra responde corto, en usted, con su voz real
+ *                    (ttsService → Kokoro, voz Santa; si el server no está,
+ *                    el momento sigue completo en silencio).
+ *   6. accion      → la respuesta CAE como una acción concreta (un panel, un
+ *                    botón). No un chat: una cosa clara que hacer.
+ *
+ * DEVICE-TIERING REAL (decidirRender): WebGL + equipo con aire → escena 3D en
+ * su chunk perezoso (three no toca el bundle base); gama baja o sin WebGL →
+ * la MISMA coreografía sobre el valle dibujado (Valle2DFallback, SVG+CSS) con
+ * la abeja volando en DOM. El iris, los textos y la acción son DOM compartido
+ * entre ambos niveles — la coreografía es UNA sola.
+ *
+ * Copy de muestra en español de Colombia (usted); si se productiza migra a
+ * messages.js (ADR-050). reduced-motion: sin vuelos ni tipeo — fotogramas
+ * dignos y tiempos cortos.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- mockup dev con copy de
+   muestra (no UI de producto); si se productiza, el copy migra a messages.js
+   (ADR-050). */
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import '../visual/effects/effects.css';
+import './entradaValle3D.css';
+import './holaChagra3D.css';
+import IrisVoz from '../visual/voz';
+import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
+import Valle2DFallback from './valle/Valle2DFallback';
+import { CLIMAS, climaPorHora, COSA_DEL_DIA } from './valle/valleData';
+import {
+  speakKokoro,
+  onSpeakingChange,
+  stop as pararVoz,
+  DEFAULT_KOKORO_VOICE,
+} from '../services/ttsService';
+
+import { decidirRender } from './valle/decidirRender';
+
+// La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso — solo
+// baja si decidirRender() dice '3d' y se entra a la ruta.
+const Escena3D = lazy(() => import('./valle/HolaChagraEscena3D'));
+
+/* ── El guion (copy de muestra, atado a la cosa del día real del valle) ── */
+const PREGUNTA = '¿Cómo protejo el semillero de la helada de esta noche?';
+const RESPUESTA =
+  'Esta madrugada puede helar en la parte alta. Cubra el semillero con costales antes de que caiga el sol; el frío quema la matica tierna.';
+
+/* Lo que el lector de pantalla oye en cada fase (el iris es decorativo por
+   contrato: el estado SIEMPRE se anuncia con texto fuera del iris). */
+const ESTADO_SR = {
+  reposo: 'El valle está en reposo. Toque la frase para decir: hola, Chagra.',
+  saludo: 'Usted dijo: hola, Chagra. La abeja despierta y el mundo lo escucha.',
+  escuchando: 'La finca lo está escuchando.',
+  pensando: 'Chagra está mirando cómo está su finca.',
+  hablando: `Chagra responde: ${RESPUESTA}`,
+  accion: 'La respuesta quedó como una acción concreta: cubra el semillero.',
+};
+
+/* fase → estado del iris (la voz con forma). En reposo/acción, rescoldo. */
+const IRIS_POR_FASE = {
+  saludo: 'escuchando',
+  escuchando: 'escuchando',
+  pensando: 'pensando',
+  hablando: 'hablando',
+  accion: 'reposo',
+};
+
+function nada() {}
+
+export default function HolaChagra3D({ onBack }) {
+  const [fase, setFase] = useState('reposo');
+  const [clima] = useState(() => climaPorHora());
+  const [tier] = useState(() => decidirRender());
+  const [nPalabras, setNPalabras] = useState(0);
+
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+
+  const palabras = useMemo(() => PREGUNTA.split(' '), []);
+  const despierta = fase !== 'reposo';
+
+  /* El campesino "dice" el wake-word (mockup guionado: tocar = decir). */
+  const despertar = useCallback(() => {
+    setNPalabras(0);
+    setFase((f) => (f === 'reposo' ? 'saludo' : f));
+  }, []);
+
+  /* Volver al reposo: el mundo se aquieta, la voz se calla. */
+  const repetir = useCallback(() => {
+    pararVoz();
+    setNPalabras(0);
+    setFase('reposo');
+  }, []);
+
+  /* Al salir de la ruta, nunca dejar voz sonando. */
+  useEffect(() => () => pararVoz(), []);
+
+  /* ── saludo → escuchando · pensando → hablando (tiempos del rito) ── */
+  useEffect(() => {
+    if (fase === 'saludo') {
+      const t = setTimeout(() => setFase('escuchando'), reducedMotion ? 600 : 2000);
+      return () => clearTimeout(t);
+    }
+    if (fase === 'pensando') {
+      const t = setTimeout(() => setFase('hablando'), reducedMotion ? 900 : 1800);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [fase, reducedMotion]);
+
+  /* ── escuchando: la pregunta se transcribe palabra a palabra. El estado solo
+        avanza en callbacks de timers (el reset del conteo vive en despertar/
+        repetir); con reduced-motion no hay tipeo — el render deriva la
+        pregunta completa. ── */
+  useEffect(() => {
+    if (fase !== 'escuchando') return undefined;
+    if (reducedMotion) {
+      const t = setTimeout(() => setFase('pensando'), 1600);
+      return () => clearTimeout(t);
+    }
+    const iv = setInterval(
+      () => setNPalabras((n) => Math.min(palabras.length, n + 1)),
+      180,
+    );
+    const t = setTimeout(() => setFase('pensando'), 700 + palabras.length * 180 + 900);
+    return () => {
+      clearInterval(iv);
+      clearTimeout(t);
+    };
+  }, [fase, reducedMotion, palabras]);
+
+  /* ── hablando: la respuesta suena con la VOZ REAL de Chagra (Kokoro, voz
+        Santa — DEFAULT_KOKORO_VOICE). Si el audio arranca, la fase avanza al
+        TERMINAR el audio (onSpeakingChange); si el server de voz no está
+        (silencio consistente del ttsService), un respaldo por tiempo mantiene
+        el momento completo. ── */
+  useEffect(() => {
+    if (fase !== 'hablando') return undefined;
+    let hablo = false;
+    const off = onSpeakingChange((sonando) => {
+      if (sonando) {
+        hablo = true;
+        return;
+      }
+      if (hablo) setFase('accion');
+    });
+    speakKokoro(RESPUESTA, { voice: DEFAULT_KOKORO_VOICE }).catch(nada);
+    const respaldo = setTimeout(
+      () => setFase('accion'),
+      reducedMotion ? 2600 : 6000,
+    );
+    return () => {
+      off();
+      clearTimeout(respaldo);
+    };
+  }, [fase, reducedMotion]);
+
+  const irisEstado = IRIS_POR_FASE[fase] || 'reposo';
+  const c = CLIMAS[clima];
+
+  return (
+    <div className="valle-root hc3d" data-clima={clima} data-fase={fase}>
+      {/* ── El mundo: valle 3D (chunk perezoso) o valle dibujado (gama baja).
+            Inerte durante el rito: aquí no se navega, se habla. ── */}
+      <div className="valle-escena hc3d__escena" aria-hidden="true" inert>
+        {tier === '3d' ? (
+          <>
+            <Suspense fallback={<CargandoMundo clima={clima} />}>
+              <Escena3D clima={clima} despierta={despierta} reducedMotion={reducedMotion} />
+            </Suspense>
+            {/* el clima tiñe el momento: grade de luz de la librería de
+                efectos (el tier 2D ya trae el suyo en Valle2DFallback) */}
+            <div className={`hc3d__grade vfx-grade ${c.grade}`} />
+          </>
+        ) : (
+          <div className="hc3d__escena2d">
+            <Valle2DFallback clima={clima} onEntrar={nada} onAlerta={nada} />
+            {/* La abeja del tier 2D: el mismo ser, volando en DOM (solo
+                transform; reduced-motion la posa directo en su destino). */}
+            <div className={`hc3d-abeja2d${despierta ? ' hc3d-abeja2d--centro' : ''}`}>
+              <AbejaAngelita
+                size={56}
+                animated={!reducedMotion}
+                animo={despierta ? 'pleno' : 'descansa'}
+                energia={despierta ? 1 : 0.5}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Velo de escucha: al despertar, el mundo se recoge hacia el centro. */}
+      <div className="hc3d__velo" aria-hidden="true" />
+
+      <header className="valle-header hc3d__header">
+        <button type="button" className="valle-back" onClick={() => onBack?.()} aria-label="Volver">
+          ‹ Volver
+        </button>
+        <div className="valle-titulo">
+          <span className="valle-titulo__eyebrow">El mundo que lo oye</span>
+          <h1>Hola, Chagra</h1>
+        </div>
+      </header>
+
+      {/* Estado anunciado en texto (el iris es decorativo por contrato). */}
+      <p className="hc3d-sr" aria-live="polite">
+        {ESTADO_SR[fase]}
+      </p>
+
+      {/* ── reposo: UNA cosa clara — el hint del wake-word ── */}
+      {fase === 'reposo' && (
+        <div className="hc3d__hint">
+          <button type="button" className="hc3d__hint-btn" onClick={despertar}>
+            <span className="hc3d__hint-di">Diga:</span>
+            <span className="hc3d__hint-frase">«hola, Chagra»</span>
+          </button>
+          <p className="hc3d__hint-nota">
+            Demostración guionada: toque la frase para decirla. No usa el micrófono.
+          </p>
+        </div>
+      )}
+
+      {/* ── el momento: el iris (la voz con forma) + lo que se dice ── */}
+      {despierta && (
+        <div className="hc3d__momento">
+          <div className="hc3d__iris">
+            <IrisVoz estado={irisEstado} size={172} />
+          </div>
+
+          {fase === 'saludo' && (
+            <p className="hc3d__dicho">«hola, Chagra»</p>
+          )}
+
+          {fase === 'escuchando' && (
+            <p className="hc3d__transcripcion">
+              {palabras.slice(0, reducedMotion ? palabras.length : nPalabras).join(' ')}
+              <span className="hc3d__cursor" aria-hidden="true" />
+            </p>
+          )}
+
+          {fase === 'pensando' && (
+            <p className="hc3d__estado-txt">Mirando cómo está su finca…</p>
+          )}
+
+          {fase === 'hablando' && (
+            <p className="hc3d__respuesta">{RESPUESTA}</p>
+          )}
+        </div>
+      )}
+
+      {/* ── la respuesta cae como UNA acción concreta ── */}
+      {fase === 'accion' && (
+        <aside className="valle-panel valle-panel--alerta hc3d__accion" aria-live="polite">
+          <span className="valle-panel__tag">Lo que sigue</span>
+          <h2>Cubra el semillero hoy</h2>
+          <p>{RESPUESTA}</p>
+          <div className="valle-panel__acciones">
+            <button type="button" className="valle-cta">{COSA_DEL_DIA.accion.etiqueta}</button>
+            <button type="button" className="valle-ghost" onClick={repetir}>
+              Repetir el momento
+            </button>
+          </div>
+        </aside>
+      )}
+    </div>
+  );
+}
+
+/* Placeholder mientras baja el chunk 3D: el cielo del clima + un latido
+   (reusa la piel .valle-cargando de la entrada 3D). */
+function CargandoMundo({ clima }) {
+  const c = CLIMAS[clima];
+  return (
+    <div
+      className="valle-cargando"
+      style={{ background: `linear-gradient(180deg, ${c.cielo[0]}, ${c.cielo[1]})` }}
+    >
+      <div className="valle-cargando__pulso" />
+      <p>Despertando su finca…</p>
+    </div>
+  );
+}

--- a/src/mockups/holaChagra3D.css
+++ b/src/mockups/holaChagra3D.css
@@ -1,0 +1,263 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   holaChagra3D.css — la piel del momento «hola, Chagra» (#/mockups/hola-chagra-3d).
+
+   Hereda la base del valle (entradaValle3D.css: .valle-root, .valle-header,
+   .valle-panel, .valle2d, .valle-cargando) y solo agrega la coreografía del
+   despertar: el velo de escucha, el hint del wake-word, el iris con su
+   conversación, y el vuelo de la abeja del tier 2D.
+
+   Reglas de la casa: solo transform/opacity animados; prefers-reduced-motion
+   apaga vuelos/tipeo/latidos y deja fotogramas dignos.
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.hc3d {
+  overflow: hidden;
+}
+
+.hc3d__escena {
+  position: absolute;
+  inset: 0;
+}
+
+.hc3d__escena2d {
+  position: absolute;
+  inset: 0;
+}
+
+/* Durante el rito el mundo no se navega: los lugares del valle dibujado son
+   paisaje, no botones (el wrapper además va inert + aria-hidden). */
+.hc3d__escena2d .valle2d__poi,
+.hc3d__escena2d .valle2d__alerta {
+  pointer-events: none;
+}
+
+.hc3d__grade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* ── El velo de escucha: al despertar, el mundo se recoge hacia el centro
+      (una sola cosa a la vez — el borde se aquieta, el centro queda vivo). ── */
+.hc3d__velo {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 1.4s ease;
+  background: radial-gradient(
+    ellipse at 50% 44%,
+    transparent 32%,
+    rgba(10, 16, 13, 0.52) 100%
+  );
+}
+
+.hc3d:not([data-fase='reposo']) .hc3d__velo {
+  opacity: 1;
+}
+
+/* ── Texto solo para lectores de pantalla (estado del rito) ── */
+.hc3d-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── El hint del wake-word: UNA cosa clara en reposo ── */
+.hc3d__hint {
+  position: absolute;
+  left: 50%;
+  bottom: max(9vh, 3.5rem);
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  width: min(92vw, 30rem);
+  text-align: center;
+}
+
+.hc3d__hint-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 1rem 2.2rem 1.15rem;
+  border-radius: 1.6rem;
+  border: 1px solid rgba(255, 224, 176, 0.4);
+  background: rgba(14, 22, 18, 0.62);
+  color: #fff6e6;
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  animation: hc3d-hint-late var(--vfx-beat, 5.2s) ease-in-out infinite;
+  transition: transform 0.25s ease;
+}
+
+.hc3d__hint-btn:hover,
+.hc3d__hint-btn:focus-visible {
+  transform: scale(1.04);
+}
+
+.hc3d__hint-di {
+  font-size: 0.82rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.hc3d__hint-frase {
+  font-size: clamp(1.35rem, 5.4vw, 1.8rem);
+  font-weight: 650;
+  letter-spacing: 0.01em;
+}
+
+.hc3d__hint-nota {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(255, 246, 230, 0.72);
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.5);
+}
+
+@keyframes hc3d-hint-late {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.018); }
+}
+
+/* ── El momento: iris + lo dicho, centrados donde el mundo mira ── */
+.hc3d__momento {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.1rem;
+  padding: 0 1.25rem;
+  pointer-events: none;
+  text-align: center;
+}
+
+.hc3d__iris {
+  transition: transform 0.7s ease;
+  animation: hc3d-iris-entra 0.9s ease both;
+}
+
+/* Cuando la respuesta cae como acción, el iris se hace a un lado (rescoldo). */
+.hc3d[data-fase='accion'] .hc3d__iris {
+  transform: scale(0.55) translateY(-38%);
+}
+
+@keyframes hc3d-iris-entra {
+  from { opacity: 0; transform: scale(0.86); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.hc3d__dicho,
+.hc3d__transcripcion,
+.hc3d__estado-txt,
+.hc3d__respuesta {
+  margin: 0;
+  max-width: min(92vw, 34rem);
+  color: #fff6e6;
+  text-shadow: 0 1px 10px rgba(0, 0, 0, 0.55);
+}
+
+.hc3d__dicho {
+  font-size: clamp(1.25rem, 5vw, 1.6rem);
+  font-weight: 650;
+  animation: hc3d-sube 0.6s ease both;
+}
+
+.hc3d__transcripcion {
+  font-size: clamp(1.05rem, 4.2vw, 1.35rem);
+  font-weight: 550;
+  min-height: 2.6em;
+}
+
+.hc3d__cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  margin-left: 3px;
+  vertical-align: -0.12em;
+  background: #ffd9a0;
+  animation: hc3d-cursor 0.9s steps(1) infinite;
+}
+
+@keyframes hc3d-cursor {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+.hc3d__estado-txt {
+  font-size: 1rem;
+  color: rgba(255, 232, 200, 0.85);
+  animation: hc3d-sube 0.5s ease both;
+}
+
+.hc3d__respuesta {
+  font-size: clamp(1.02rem, 4vw, 1.25rem);
+  line-height: 1.5;
+  animation: hc3d-sube 0.7s ease both;
+}
+
+@keyframes hc3d-sube {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── La acción concreta: reusa .valle-panel; aquí solo la posamos abajo ── */
+.hc3d__accion {
+  bottom: max(4.5vh, 1.5rem);
+}
+
+/* ── La abeja (Html del canvas 3D): transición de ánimo suave ── */
+.hc3d-abeja {
+  transition: transform 0.8s ease;
+  transform: scale(0.82);
+}
+
+.hc3d-abeja--despierta {
+  transform: scale(1);
+}
+
+/* ── La abeja del tier 2D: mismo ser, vuelo en DOM (solo transform).
+      Duerme abajo a la derecha (cerca de la huerta del valle dibujado) y al
+      despertar vuela al centro, un poco por encima del iris. ── */
+.hc3d-abeja2d {
+  position: absolute;
+  left: 50%;
+  top: 42%;
+  transform: translate(calc(-50% + 26vw), calc(-50% + 27vh)) scale(0.8);
+  transition: transform 1.9s cubic-bezier(0.22, 0.8, 0.3, 1);
+  will-change: transform;
+}
+
+.hc3d-abeja2d--centro {
+  transform: translate(-50%, calc(-50% - 8.5rem)) scale(1.1);
+}
+
+/* ── reduced-motion: fotogramas dignos, sin vuelos ni latidos ── */
+@media (prefers-reduced-motion: reduce) {
+  .hc3d__velo,
+  .hc3d__iris,
+  .hc3d-abeja,
+  .hc3d-abeja2d {
+    transition: none;
+  }
+
+  .hc3d__hint-btn,
+  .hc3d__cursor,
+  .hc3d__dicho,
+  .hc3d__estado-txt,
+  .hc3d__respuesta,
+  .hc3d__iris {
+    animation: none;
+  }
+}

--- a/src/mockups/valle/HolaChagraEscena3D.jsx
+++ b/src/mockups/valle/HolaChagraEscena3D.jsx
@@ -1,0 +1,222 @@
+/*
+ * HolaChagraEscena3D — la ESCENA 3D del momento «hola, Chagra»
+ * (mockup #/mockups/hola-chagra-3d).
+ *
+ * NO redibuja el mundo: COMPONE el valle real de Valle3D (Terreno, Cordillera,
+ * Quebrada, LandmarkGeom, Veleta, alturaTerreno — exports nombrados) con una
+ * coreografía distinta. Aquí el valle no es un menú de lugares tocables: es el
+ * mundo EN REPOSO que despierta cuando el campesino le habla. "Menos colapso":
+ * cero POIs, cero paneles dentro del canvas — una sola cosa pasa a la vez.
+ *
+ *   · reposo    → la cámara deriva lentísimo (auto-órbita), la abeja angelita
+ *                 (visual-lib/creatures) dormita posada sobre la huerta.
+ *   · despierta → la abeja se aviva y VUELA al centro del valle; la cámara se
+ *                 acerca (dolly suave) y una luz cálida se enciende donde la
+ *                 voz va a tomar forma (el IrisVoz vive en el DOM, encima).
+ *
+ * Reglas de la casa: mismo presupuesto que Valle3D (chunk perezoso de
+ * three/fiber/drei, geometría procedural, AdaptiveDpr) y reducedMotion
+ * congela vaivén/vuelo a un fotograma digno (la abeja aparece en su destino).
+ */
+import { Suspense, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Html, Stars, OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import * as THREE from 'three';
+import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
+import {
+  Terreno,
+  Cordillera,
+  Quebrada,
+  LandmarkGeom,
+  Veleta,
+} from './Valle3D';
+import { MUNDOS_VALLE, CLIMAS, alturaTerreno } from './valleData';
+
+/* El centro del valle: donde la voz toma forma (el iris DOM queda encima). */
+const CENTRO = new THREE.Vector3(0, 0.6, 0.5);
+
+/* ── Los lugares del valle como PAISAJE (sin botones): la misma geometría de
+      Valle3D, pero aquí nadie navega — el mundo solo ESTÁ, vivo. ── */
+function Lugares({ reducedMotion }) {
+  return (
+    <group>
+      {MUNDOS_VALLE.map((m) => {
+        const y = alturaTerreno(m.pos[0], m.pos[2]);
+        return (
+          <group key={m.id} position={[m.pos[0], y, m.pos[2]]} scale={m.escala}>
+            {m.tipo === 'veleta' ? (
+              <Veleta color={m.tinte[0]} reducedMotion={reducedMotion} />
+            ) : (
+              <LandmarkGeom tipo={m.tipo} tinte={m.tinte} />
+            )}
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
+/* ── La abeja angelita EN el mundo: dormita posada junto a la huerta; al
+      despertar vuela (lerp con bob de aleteo) hasta el centro del valle.
+      El cuerpo es el SVG canónico de creatures (cero redibujo). ── */
+function Abeja3D({ despierta, reducedMotion }) {
+  const ref = useRef(/** @type {any} */ (null));
+  const percha = useMemo(() => {
+    const m = MUNDOS_VALLE.find((x) => x.id === 'sanidad') || MUNDOS_VALLE[0];
+    const y = alturaTerreno(m.pos[0], m.pos[2]);
+    return new THREE.Vector3(m.pos[0] + 0.35, y + 0.85, m.pos[2] + 0.3);
+  }, []);
+  const destinoCentro = useMemo(
+    () => new THREE.Vector3(CENTRO.x, CENTRO.y + 1.9, CENTRO.z + 0.4),
+    [],
+  );
+  useFrame((state) => {
+    if (!ref.current) return;
+    const t = state.clock.elapsedTime;
+    const destino = despierta ? destinoCentro : percha;
+    if (reducedMotion) {
+      ref.current.position.copy(destino);
+      return;
+    }
+    // Bob: dormida apenas respira; despierta zumba más vivo.
+    const bob = Math.sin(t * (despierta ? 2.6 : 1.1)) * (despierta ? 0.12 : 0.04);
+    ref.current.position.lerp(
+      new THREE.Vector3(destino.x, destino.y + bob, destino.z),
+      0.035,
+    );
+  });
+  return (
+    <group ref={ref} position={[percha.x, percha.y, percha.z]}>
+      <Html center distanceFactor={9} zIndexRange={[40, 10]}>
+        <div
+          className={`hc3d-abeja${despierta ? ' hc3d-abeja--despierta' : ''}`}
+          aria-hidden="true"
+        >
+          <AbejaAngelita
+            size={62}
+            animated={!reducedMotion}
+            animo={despierta ? 'pleno' : 'descansa'}
+            energia={despierta ? 1 : 0.5}
+          />
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+/* ── La luz de la escucha: cuando el mundo despierta, una luz cálida (miel,
+      la misma familia del iris) se enciende sobre el centro — el valle
+      "mira" hacia donde la voz está tomando forma. ── */
+function LuzEscucha({ despierta, reducedMotion }) {
+  const ref = useRef(/** @type {any} */ (null));
+  useFrame((state) => {
+    if (!ref.current) return;
+    const objetivo = despierta ? 2.6 : 0;
+    ref.current.intensity += (objetivo - ref.current.intensity) * 0.05;
+    if (despierta && !reducedMotion) {
+      ref.current.intensity += Math.sin(state.clock.elapsedTime * 2.1) * 0.04;
+    }
+  });
+  return (
+    <pointLight
+      ref={ref}
+      position={[CENTRO.x, CENTRO.y + 1.6, CENTRO.z]}
+      color="#ffd9a0"
+      intensity={0}
+      distance={9}
+    />
+  );
+}
+
+/* ── Cámara guionada: en reposo deriva (auto-órbita calma); al despertar la
+      deriva PARA y la cámara se acerca al centro (dolly suave) — entrar al
+      momento, no solo mirarlo. Sin zoom/pan del usuario: es un rito corto. ── */
+function CamaraGuionada({ despierta, reducedMotion }) {
+  const controls = useRef(/** @type {any} */ (null));
+  useFrame((state) => {
+    const c = controls.current;
+    if (!c) return;
+    c.target.lerp(CENTRO, 0.05);
+    const cam = state.camera;
+    const dist = cam.position.distanceTo(c.target);
+    const deseada = despierta ? 8.6 : 11.5;
+    if (dist > 0.001) {
+      const nueva = reducedMotion ? deseada : dist + (deseada - dist) * 0.035;
+      cam.position.sub(c.target).multiplyScalar(nueva / dist).add(c.target);
+    }
+    c.update();
+  });
+  return (
+    <OrbitControls
+      ref={controls}
+      makeDefault
+      enablePan={false}
+      enableZoom={false}
+      minPolarAngle={0.5}
+      maxPolarAngle={1.15}
+      autoRotate={!reducedMotion && !despierta}
+      autoRotateSpeed={0.3}
+      enableDamping
+      dampingFactor={0.08}
+    />
+  );
+}
+
+/* ── Contenido de la escena (dentro del Canvas): el MISMO ambiente de Valle3D
+      (clima → cielo/niebla/luces/estrellas) + la coreografía del despertar. ── */
+function Escena({ clima, despierta, reducedMotion }) {
+  const c = CLIMAS[clima];
+  return (
+    <>
+      <color attach="background" args={[c.cielo[1]]} />
+      <fog attach="fog" args={[c.niebla, 9, c.nieblaLejos]} />
+      <hemisphereLight intensity={c.intensidad * 0.55} color={c.cielo[0]} groundColor={c.ambiente} />
+      <ambientLight intensity={c.intensidad * 0.35} color={c.luz} />
+      <directionalLight
+        position={[6, 9, 4]}
+        intensity={c.intensidad}
+        color={c.luz}
+        castShadow
+        shadow-mapSize={[1024, 1024]}
+        shadow-camera-far={30}
+        shadow-camera-left={-12}
+        shadow-camera-right={12}
+        shadow-camera-top={12}
+        shadow-camera-bottom={-12}
+      />
+      {c.estrellas && (
+        <Stars radius={40} depth={20} count={900} factor={3} fade speed={reducedMotion ? 0 : 1} />
+      )}
+
+      <Terreno colorBase={clima === 'noche' ? '#22432f' : '#5a8a4a'} />
+      <Cordillera color={clima === 'noche' ? '#3a4a63' : c.niebla} />
+      <Quebrada color={clima === 'noche' ? '#2a4a6a' : '#5fb2c9'} viva={!!c.lluviaViva} />
+      <Lugares reducedMotion={reducedMotion} />
+
+      <LuzEscucha despierta={despierta} reducedMotion={reducedMotion} />
+      <Abeja3D despierta={despierta} reducedMotion={reducedMotion} />
+
+      <CamaraGuionada despierta={despierta} reducedMotion={reducedMotion} />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+export default function HolaChagraEscena3D({ clima, despierta, reducedMotion }) {
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`valle-canvas${listo ? ' valle-canvas--listo' : ''}`}
+      shadows
+      dpr={[1, 1.8]}
+      gl={{ antialias: true, powerPreference: 'high-performance' }}
+      camera={{ position: [9, 8, 11], fov: 42 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Suspense fallback={null}>
+        <Escena clima={clima} despierta={despierta} reducedMotion={reducedMotion} />
+      </Suspense>
+    </Canvas>
+  );
+}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -24,20 +24,16 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { Html, Float, Stars, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
 import { Colibri } from '../../visual/creatures/Colibri.jsx';
-import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
+import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS, alturaTerreno } from './valleData';
 
-/* Altura del terreno por (x,z): un valle suave con ladera al fondo (+z) donde
-   suben las terrazas del café. Determinista → los landmarks se posan encima. */
-function alturaTerreno(x, z) {
-  const ladera = Math.max(0, (z + 2) * 0.16);
-  const ondul = Math.sin(x * 0.5) * 0.08 + Math.cos(z * 0.4) * 0.06;
-  const cauce = -0.28 * Math.exp(-((x - 0.6) ** 2) / 5) * Math.exp(-((z + 1) ** 2) / 40);
-  return ladera + ondul + cauce;
-}
+/* alturaTerreno vive en valleData.js (compartida con HolaChagraEscena3D sin
+   romper react-refresh). Los componentes del mundo (Terreno, Cordillera,
+   Quebrada, LandmarkGeom, Veleta) se exportan para que otras escenas del
+   valle COMPONGAN el mismo mundo sin redibujarlo. */
 
 /* ── El suelo del valle: malla ondulada de bajo poligonaje, color tierra-verde
       que se aclara al fondo (perspectiva aérea). ── */
-function Terreno({ colorBase }) {
+export function Terreno({ colorBase }) {
   const geo = useMemo(() => {
     const g = new THREE.PlaneGeometry(30, 30, 48, 48);
     g.rotateX(-Math.PI / 2);
@@ -58,7 +54,7 @@ function Terreno({ colorBase }) {
 }
 
 /* ── La cordillera de páramo al fondo: conos pálidos (perspectiva aérea). ── */
-function Cordillera({ color }) {
+export function Cordillera({ color }) {
   const picos = useMemo(
     () => [
       { x: -8, z: -12, h: 7, r: 5 },
@@ -81,8 +77,8 @@ function Cordillera({ color }) {
 }
 
 /* ── La quebrada: una cinta de agua que serpentea por el cauce. ── */
-function Quebrada({ color, viva }) {
-  const ref = useRef();
+export function Quebrada({ color, viva }) {
+  const ref = useRef(/** @type {any} */ (null));
   useFrame((state) => {
     if (viva && ref.current) {
       ref.current.material.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 2) * 0.06;
@@ -114,7 +110,7 @@ function Quebrada({ color, viva }) {
 }
 
 /* ── Materiales/paletas de cada landmark de mundo, por `tipo`. ── */
-function LandmarkGeom({ tipo, tinte }) {
+export function LandmarkGeom({ tipo, tinte }) {
   const [fuerte, suave] = tinte;
   switch (tipo) {
     case 'milpa': // maíz: cañas altas con penacho
@@ -184,8 +180,8 @@ function LandmarkGeom({ tipo, tinte }) {
             <boxGeometry args={[0.9, 0.7, 0.8]} />
             <meshStandardMaterial color={suave} flatShading />
           </mesh>
-          <mesh position={[0, 0.85, 0]} castShadow>
-            <coneGeometry args={[0.72, 0.5, 4]} rotation={[0, Math.PI / 4, 0]} />
+          <mesh position={[0, 0.85, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+            <coneGeometry args={[0.72, 0.5, 4]} />
             <meshStandardMaterial color={fuerte} flatShading />
           </mesh>
           {[-0.9, -0.5, 0.9, 1.3].map((dx, i) => (
@@ -235,7 +231,7 @@ function LandmarkGeom({ tipo, tinte }) {
         </group>
       );
     case 'veleta': // poste con veleta que gira con el viento
-      return <Veleta color={fuerte} />;
+      return <Veleta color={fuerte} reducedMotion={false} />;
     default:
       return (
         <mesh position={[0, 0.3, 0]}>
@@ -246,8 +242,8 @@ function LandmarkGeom({ tipo, tinte }) {
   }
 }
 
-function Veleta({ color, reducedMotion }) {
-  const ref = useRef();
+export function Veleta({ color, reducedMotion = false }) {
+  const ref = useRef(/** @type {any} */ (null));
   useFrame((state) => {
     if (ref.current && !reducedMotion) ref.current.rotation.y = state.clock.elapsedTime * 0.4;
   });
@@ -262,8 +258,8 @@ function Veleta({ color, reducedMotion }) {
           <boxGeometry args={[0.7, 0.06, 0.06]} />
           <meshStandardMaterial color={color} flatShading />
         </mesh>
-        <mesh position={[0.42, 0, 0]}>
-          <coneGeometry args={[0.14, 0.3, 4]} rotation={[0, 0, -Math.PI / 2]} />
+        <mesh position={[0.42, 0, 0]} rotation={[0, 0, -Math.PI / 2]}>
+          <coneGeometry args={[0.14, 0.3, 4]} />
           <meshStandardMaterial color={color} flatShading />
         </mesh>
       </group>
@@ -305,8 +301,8 @@ function MundoLugar({ mundo, activo, onEntrar, reducedMotion }) {
       Toca la señal → onAlerta() (el agente lo dice y ofrece LA acción). ── */
 function Beacon({ onAlerta, reducedMotion }) {
   const ancla = MUNDO_VALLE_BY_ID[COSA_DEL_DIA.anclaMundo];
-  const luz = useRef();
-  const halo = useRef();
+  const luz = useRef(/** @type {any} */ (null));
+  const halo = useRef(/** @type {any} */ (null));
   useFrame((state) => {
     if (reducedMotion) return;
     const p = (Math.sin(state.clock.elapsedTime * 1.6) + 1) / 2;
@@ -353,7 +349,7 @@ function Beacon({ onAlerta, reducedMotion }) {
 /* ── El compañero: el colibrí (visual-lib) flota sobre el foco activo y es la
       cara del agente. Reusa el SVG canónico de creatures. ── */
 function CompaneroColibri({ foco, reducedMotion }) {
-  const ref = useRef();
+  const ref = useRef(/** @type {any} */ (null));
   useFrame((state) => {
     if (!ref.current) return;
     const t = state.clock.elapsedTime;
@@ -367,7 +363,7 @@ function CompaneroColibri({ foco, reducedMotion }) {
     <group ref={ref} position={[foco.x + 0.9, foco.y + 2.2, foco.z + 0.6]}>
       <Html center distanceFactor={9} zIndexRange={[40, 10]}>
         <div className="valle-colibri" aria-hidden="true">
-          <Colibri size={54} animated={!reducedMotion} />
+          <Colibri size={54} animated={!reducedMotion} className="" />
         </div>
       </Html>
     </group>
@@ -402,7 +398,7 @@ function CamaraViajera({ foco, controls, autoOrbit }) {
 
 /* ── Contenido de la escena (dentro del Canvas). ── */
 function Escena({ clima, focoId, onEntrar, onAlerta, reducedMotion }) {
-  const controls = useRef();
+  const controls = useRef(/** @type {any} */ (null));
   const c = CLIMAS[clima];
   const foco = useMemo(() => {
     const m = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;

--- a/src/mockups/valle/decidirRender.js
+++ b/src/mockups/valle/decidirRender.js
@@ -1,0 +1,30 @@
+/**
+ * decidirRender — device-tiering REAL del mundo 3D (mockup «hola, Chagra»).
+ *
+ * Decide el nivel de render UNA vez al montar. Gama baja no recibe un valle
+ * roto ni un spinner eterno: recibe la versión dibujada (SVG+CSS) con la
+ * MISMA coreografía. Vive en su propio módulo (sin componentes) para no
+ * romper react-refresh en los archivos de escena.
+ *
+ *   '3d' → hay WebGL y el equipo tiene aire (memoria/núcleos reportados).
+ *   '2d' → sin WebGL, o equipo humilde (≤2 GB reportados o ≤2 núcleos).
+ *
+ * @returns {'3d'|'2d'}
+ */
+export function decidirRender() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return '2d';
+  let gl = null;
+  try {
+    const canvas = document.createElement('canvas');
+    gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+  } catch {
+    return '2d';
+  }
+  if (!gl) return '2d';
+  const nav = /** @type {any} */ (typeof navigator !== 'undefined' ? navigator : null);
+  const memoria = nav && typeof nav.deviceMemory === 'number' ? nav.deviceMemory : null;
+  const nucleos = nav && typeof nav.hardwareConcurrency === 'number' ? nav.hardwareConcurrency : null;
+  if (memoria !== null && memoria <= 2) return '2d';
+  if (nucleos !== null && nucleos <= 2) return '2d';
+  return '3d';
+}

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -18,6 +18,19 @@
 
 import { MUNDO_BY_ID } from '../../components/dashboard/mundosFinca';
 
+/* ── EL TERRENO DEL VALLE (compartido por las escenas 3D) ────────────────────
+ * Altura del terreno por (x,z): un valle suave con ladera al fondo (+z) donde
+ * suben las terrazas del café. Determinista → los landmarks se posan encima.
+ * Vive aquí (módulo sin componentes) para que Valle3D y HolaChagraEscena3D la
+ * compartan sin romper react-refresh (only-export-components).
+ */
+export function alturaTerreno(x, z) {
+  const ladera = Math.max(0, (z + 2) * 0.16);
+  const ondul = Math.sin(x * 0.5) * 0.08 + Math.cos(z * 0.4) * 0.06;
+  const cauce = -0.28 * Math.exp(-((x - 0.6) ** 2) / 5) * Math.exp(-((z + 1) ** 2) / 40);
+  return ladera + ondul + cauce;
+}
+
 /* ── 2. LOS MUNDOS COMO LUGARES ─────────────────────────────────────────────
  * Un subconjunto curado de los mundos reales (mundosFinca.js) colocados en el
  * valle. `pos` = [x, y, z] en el terreno; `escala` y `tipo` deciden qué forma
@@ -40,7 +53,9 @@ const LUGARES = [
  * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar.
  */
 export const MUNDOS_VALLE = LUGARES.map((l) => {
-  const real = MUNDO_BY_ID[l.id] || {};
+  const real =
+    MUNDO_BY_ID[l.id] ||
+    /** @type {{ titulo?: string, emoji?: string, lema?: string, tinte?: string[] }} */ ({});
   return {
     ...l,
     titulo: real.titulo || l.id,

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,0 +1,111 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/* Abeja angelita — Tetragonisca angustula, la abeja NATIVA sin aguijón de los
+   Andes (mansa, dorada, guardiana de la finca). Es el COMPAÑERO-JUGADOR del
+   valle: vuela por el mundo y "entra" a cada lugar. No es un mascota infantil —
+   es un ser al que se cuida (ref Finch): su ÁNIMO y su ENERGÍA cambian el color,
+   el aura y la vivacidad según cómo está la finca de verdad.
+
+   Coreografía de vuelo/llegada = de la ESCENA que la consume (Valle3D / 2D).
+   Aquí solo vive el cuerpo: SVG + CSS puros, solo transform/opacity (GPU,
+   Android gama baja), aleteo reutilizando .crt-wing de creatures.css. */
+const VIEWBOX = '-16 -15 34 30';
+
+/* Paletas por ánimo (estado real de la finca leído en el valle). Maduras,
+   cálidas — nunca chillonas. `aura` es el halo; `cuerpo`/`banda` el insecto. */
+const ANIMOS = {
+  pleno: { cuerpo: '#f3b229', banda: '#7a4a12', aura: '#ffd772', vida: 1 },
+  sereno: { cuerpo: '#e6a637', banda: '#7a4a12', aura: '#f4c66a', vida: 0.82 },
+  atento: { cuerpo: '#f0a233', banda: '#6f3d10', aura: '#ffb352', vida: 0.9 },
+  sediento: { cuerpo: '#cdae6e', banda: '#6b5330', aura: '#cfe0d6', vida: 0.6 },
+  descansa: { cuerpo: '#c9a24a', banda: '#5a4526', aura: '#9fb6d6', vida: 0.45 },
+};
+
+export function AbejaAngelita({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  animo = 'sereno',
+  energia = 1,
+  title = 'Angelita, la abeja de su finca',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const clip = `crt-clip-${uid}`;
+  const wing = animated ? 'crt-wing' : undefined;
+
+  const a = ANIMOS[animo] || ANIMOS.sereno;
+  const e = Math.max(0.35, Math.min(1, energia));
+  // El aura respira con la energía; la vitalidad del ánimo la matiza.
+  const auraOp = 0.16 + 0.34 * e * a.vida;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      <clipPath id={clip}>
+        {/* abdomen: la elipse que recorta las bandas para que no se desborden */}
+        <ellipse cx="-1.5" cy="1.5" rx="8.5" ry="6" />
+      </clipPath>
+    </defs>
+  );
+
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      {/* aura viva: el halo que refleja el ánimo/energía de la finca */}
+      <circle r="12" cx="-1" cy="1" fill={a.aura} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* alas translúcidas que baten (arriba del tórax) */}
+      <ellipse className={wing} cx="1.5" cy="-6.5" rx="5.5" ry="3.4" fill="#dff3ff" opacity="0.72"
+        transform="rotate(-24 1.5 -6.5)" />
+      <ellipse className={wing} style={{ animationDelay: '-0.05s' }} cx="4.5" cy="-6" rx="4.6" ry="3"
+        fill="#c8e8ff" opacity="0.5" transform="rotate(-6 4.5 -6)" />
+
+      {/* patas finas bajo el cuerpo (quietas, dan peso) */}
+      <path d="M-3,6 L-4.5,9 M0,6.5 L0.5,9.6 M3,6 L4.8,8.8" stroke={a.banda} strokeWidth="0.8"
+        fill="none" strokeLinecap="round" opacity="0.85" />
+
+      {/* abdomen dorado con bandas (recortadas al contorno) */}
+      <ellipse cx="-1.5" cy="1.5" rx="8.5" ry="6" fill={a.cuerpo} />
+      <g clipPath={`url(#${clip})`}>
+        <rect x="-6.5" y="-5" width="2.6" height="14" rx="1.3" fill={a.banda} opacity="0.9"
+          transform="rotate(12 -5 1.5)" />
+        <rect x="-1.6" y="-5" width="2.8" height="14" rx="1.4" fill={a.banda} opacity="0.92"
+          transform="rotate(12 -0.2 1.5)" />
+      </g>
+      {/* brillo suave del lomo */}
+      <ellipse cx="-2.5" cy="-1.2" rx="4.2" ry="2" fill="#fff2c8" opacity="0.5" />
+
+      {/* cabeza (a la derecha = hacia donde vuela) + ojo */}
+      <circle cx="7.6" cy="-0.6" r="3.6" fill={a.banda} />
+      <circle cx="8.9" cy="-1.4" r="1.15" fill="#1b1205" />
+      <circle cx="9.3" cy="-1.8" r="0.4" fill="#fff6e2" />
+      {/* antenas */}
+      <path d="M9.4,-3.2 C11.4,-5 12.6,-5.4 13.6,-6.6 M8.4,-3.6 C9.6,-6 10.4,-6.8 10.9,-8.4"
+        stroke={a.banda} strokeWidth="0.85" fill="none" strokeLinecap="round" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="abeja-angelita">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default AbejaAngelita;

--- a/src/visual/effects/AutoDibujo.jsx
+++ b/src/visual/effects/AutoDibujo.jsx
@@ -1,0 +1,37 @@
+/*
+ * AutoDibujo — el AUTO-DIBUJADO orquestado compartido (§13.11 del catálogo).
+ *
+ * La receta de SceneTrazoMinimal ("el trazo se dibuja solo al entrar"):
+ * `pathLength="1"` normalizado + `stroke-dashoffset` que va a 0 + etapas con
+ * delay escalonado. Aquí queda como helper para no re-cablear el dasharray a
+ * mano en cada lámina/onboarding/glifo.
+ *
+ * El movimiento vive en `effects.css` (clases `vfx-draw`, `vfx-fade`,
+ * `vfx-t1…vfx-t9`); este componente solo pega las clases correctas y pone
+ * `pathLength="1"` para que el draw-in sea independiente de la longitud real
+ * del trazo. Reduced-motion = el dibujo COMPLETO y quieto (lo garantiza el CSS).
+ *
+ * Recuerde importar el CSS una vez en la escena:  import '.../effects/effects.css'
+ *
+ * @param {object}  props
+ * @param {'path'|'line'|'polyline'|'circle'|'rect'|string} [props.as='path']
+ *        elemento SVG a renderizar.
+ * @param {number}  [props.stage]      etapa 1..9 (delay escalonado del dibujo).
+ * @param {boolean} [props.fade=false] `true` = aparece en fundido (opacity) en
+ *        vez de trazarse — para planos de color (sol, leyenda, humo).
+ * @param {string}  [props.className]  clases extra.
+ * Resto de props (`d`, `stroke`, `strokeWidth`, `fill`, `cx`…) se pasan tal cual.
+ */
+export function AutoDibujo({ as = 'path', stage, fade = false, className, ...rest }) {
+  // Tag dinámico: TS no puede probar que el string es un tag SVG válido —
+  // cast puntual (irreducible sin enumerar todos los tags).
+  const El = /** @type {any} */ (as);
+  const base = fade ? 'vfx-fade' : 'vfx-draw';
+  const stageClass = stage ? ` vfx-t${stage}` : '';
+  const cls = `${base}${stageClass}${className ? ` ${className}` : ''}`;
+  // pathLength normaliza el dashoffset a [0..1]; solo aplica al modo trazo.
+  const drawProps = fade ? {} : { pathLength: 1 };
+  return <El className={cls} {...drawProps} {...rest} />;
+}
+
+export default AutoDibujo;

--- a/src/visual/effects/FiltroAcuarela.jsx
+++ b/src/visual/effects/FiltroAcuarela.jsx
@@ -1,0 +1,58 @@
+/*
+ * FiltroAcuarela — el borde/relleno "pintado a la acuarela" compartido
+ * (feTurbulence + feDisplacementMap).
+ *
+ * Da a un trazo o relleno SVG el borde húmedo, irregular y sangrado de la
+ * acuarela: la turbulencia genera un ruido fractal y el displacement empuja los
+ * píxeles según ese ruido. Es la receta que dibuja los bordes del mapa-acuarela
+ * en vez de re-hilvanar un `<filter>` inline por mockup.
+ *
+ * Emite SOLO el `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y lo referencia con `filter={`url(#${id})`}`. Pasar ids únicos
+ * (`useId`) para repetir varios en la misma página sin colisión.
+ *
+ * Reduced-motion-safe por construcción: el filtro es ESTÁTICO (no anima), en
+ * línea con la regla de la casa "blur/filtros estáticos, solo transform/opacity
+ * animados".
+ *
+ * @param {object} props
+ * @param {string}  props.id                 id del filtro (obligatorio).
+ * @param {number} [props.frequency=0.012]   baseFrequency del ruido (más alto =
+ *                                           borde más nervioso/fino).
+ * @param {number} [props.scale=6]           fuerza del desplazamiento en px.
+ * @param {number} [props.octaves=2]         numOctaves del fractalNoise.
+ * @param {number} [props.seed=7]            semilla del ruido (determinista).
+ * @param {string} [props.bounds='-20%']     origen del box del filtro (x/y).
+ */
+export function FiltroAcuarela({
+  id,
+  frequency = 0.012,
+  scale = 6,
+  octaves = 2,
+  seed = 7,
+  bounds = '-20%',
+}) {
+  const off = parseFloat(bounds);
+  const size = `${100 - 2 * off}%`;
+  const noise = `${id}-noise`;
+  return (
+    <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+      <feTurbulence
+        type="fractalNoise"
+        baseFrequency={frequency}
+        numOctaves={octaves}
+        seed={seed}
+        result={noise}
+      />
+      <feDisplacementMap
+        in="SourceGraphic"
+        in2={noise}
+        scale={scale}
+        xChannelSelector="R"
+        yChannelSelector="G"
+      />
+    </filter>
+  );
+}
+
+export default FiltroAcuarela;

--- a/src/visual/effects/GlowFilter.jsx
+++ b/src/visual/effects/GlowFilter.jsx
@@ -1,0 +1,44 @@
+/*
+ * GlowFilter — el GLOW neón orgánico compartido de Chagra (§13.16 del catálogo).
+ *
+ * Es la MISMA receta que hoy está copiada como `<filter>` inline en varias
+ * escenas y en la librería de fauna (GuardianEspiritu `ge-glow1`, creatures
+ * `CreatureFilters`, SceneFincaOrganismo `fvo-glow1`…): un feGaussianBlur
+ * fundido con el original vía feMerge, más — opcionalmente — un blur suave
+ * suelto para halos/estelas. Aquí vive la versión canónica.
+ *
+ * Emite SOLO los `<filter>` (sin `<defs>`): el consumidor lo mete en su propio
+ * `<defs>` y referencia por id. Como cada escena decide su id, se pueden repetir
+ * muchos glows en una misma página sin colisión (pasar ids únicos con `useId`).
+ *
+ * @param {object} props
+ * @param {string}  props.id              id del filtro de glow (obligatorio).
+ * @param {number} [props.std=2.1]        desenfoque del glow (stdDeviation).
+ * @param {string} [props.blurId]         si se pasa, emite además un blur suelto
+ *                                        con este id (para halos/estelas).
+ * @param {number} [props.blurStd=3]      desenfoque del blur suelto.
+ * @param {string} [props.bounds='-80%']  origen del box del filtro (x/y); el
+ *                                        ancho/alto se calculan como 100%-2*bounds.
+ */
+export function GlowFilter({ id, std = 2.1, blurId = '', blurStd = 3, bounds = '-80%' }) {
+  const off = parseFloat(bounds); // -80  → box de 260%
+  const size = `${100 - 2 * off}%`;
+  return (
+    <>
+      <filter id={id} x={bounds} y={bounds} width={size} height={size}>
+        <feGaussianBlur stdDeviation={std} result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      {blurId ? (
+        <filter id={blurId}>
+          <feGaussianBlur stdDeviation={blurStd} />
+        </filter>
+      ) : null}
+    </>
+  );
+}
+
+export default GlowFilter;

--- a/src/visual/effects/README.md
+++ b/src/visual/effects/README.md
@@ -1,0 +1,118 @@
+# `src/visual/effects` — efectos visuales reutilizables
+
+Librería de las **técnicas de cine** de Chagra (las que dan el "wow": velos,
+viñeta, scrims, grades de luz por piso térmico, glow, pulso cardíaco,
+auto-dibujado, acuarela) como **CSS + helpers SVG limpios, parametrizables y sin
+dependencias nuevas**. Nace para **dejar de re-hilvanar el mismo efecto** en
+cada mockup/escena: hoy el velo neón, la viñeta, los grades `--mm2-*`, el glow
+`feMerge`, el latido `--fvo-beat`, el trazo que se dibuja solo y el filtro
+acuarela aparecían copiados/redibujados en `finca-viva-hero.css`,
+`scene-finca-organismo.css`, `scene-trazo-minimal.css`, `GuardianEspiritu`, los
+mockups de la Montaña y el mapa-acuarela. Aquí vive la **versión canónica**.
+
+Hermana de [`src/visual/creatures`](../creatures/README.md) (personajes de
+fauna): misma filosofía, mismo contrato de reuso.
+
+## Regla de la casa
+
+> **Antes de re-dibujar un efecto de cine, búsquelo aquí.**
+> Si existe → **reúselo** (y de ser posible, **mejore** la versión canónica,
+> para que todos hereden la mejora).
+> Si crea un efecto nuevo reutilizable → **agréguelo aquí en el mismo PR**
+> (clase/helper + entrada en `index.js` + fila en esta tabla).
+
+## Qué hay
+
+| Efecto | Cómo se usa | Catálogo | Semilla |
+|---|---|---|---|
+| **Velo atmosférico** neón | clase `.vfx-veil` (custom props `--vfx-veil-a/b/opacity`) | §13.5 / §13.16 | `finca-viva-hero` `.fvh-escena-wrap::after` |
+| **Viñeta** de cine | clase `.vfx-vignette` (`--vfx-vignette-strength`) | §13.5 | idem |
+| **Scrims** arriba/abajo | clases `.vfx-scrim-top` / `.vfx-scrim-bottom` (`--vfx-scrim-color/-h`) | §13.5 | idem |
+| **Grades de luz por piso térmico** | clase `.vfx-grade` + modificador `.vfx-grade--{glacial,paramo,frio,templado,calido,valle}`; tokens `--vfx-piso-*`; `--vfx-grade-fuerza` por dirección | §13.2 | los `--mm2-*` de Montaña |
+| **Glow** (feMerge) | helper `<GlowFilter id std blurId />` | §13.16 | unifica `ge-glow1` + `creatures/_filters` |
+| **Pulso cardíaco** | token `--vfx-beat` + clases `.vfx-beat`, `.vfx-beat-wave`, `.vfx-beat-glow` | §13.10 | `--fvo-beat` (SceneFincaOrganismo) |
+| **Auto-dibujado** | helper `<AutoDibujo stage fade />` + clases `.vfx-draw/.vfx-fade/.vfx-t1…t9` | §13.11 | SceneTrazoMinimal `fvm-t*` |
+| **Flujo por dash** | clase `.vfx-flow` (`--vfx-flow-dur/-len`) | §13.12 | `fvo-flow` / `adm-sap` |
+| **Filtro acuarela** | helper `<FiltroAcuarela id scale frequency />` | — | mapa-acuarela (feTurbulence+feDisplacementMap) |
+
+## Dos formas de consumir
+
+**1. CSS** (velos, viñeta, scrims, grades, latido, auto-dibujado, flujo).
+Importe el CSS una vez donde lo use y ponga las clases:
+
+```jsx
+import '../../visual/effects/effects.css';
+
+// una escena con cielo de biopunk y hora dorada en la finca:
+<div style={{ position: 'relative' }}>
+  <MiEscenaSVG />
+  <div className="vfx-grade vfx-grade--templado" />   {/* luz de la finca  */}
+  <div className="vfx-veil" />                          {/* velo neón        */}
+  <div className="vfx-scrim-bottom" />                  {/* para que el texto lea */}
+  <div className="vfx-vignette" />                      {/* enfoca el centro */}
+</div>
+```
+
+El pulso cardíaco sincroniza todo lo vivo con una sola variable:
+
+```jsx
+// el corazón late, la red se enciende en fase, la onda se expande:
+<g className="vfx-beat"><path d="…corazón…" /></g>
+<g className="vfx-beat-glow"><path d="…red micorrízica…" /></g>
+<circle className="vfx-beat-wave" r="8" />
+// para acelerar/frenar TODO junto:  style={{ '--vfx-beat': '4s' }} en un ancestro
+```
+
+**2. Helpers SVG** (glow, acuarela, auto-dibujado). Se montan en tu `<defs>` /
+tu SVG. Cada instancia usa **ids únicos** (`useId`) para repetirse sin colisión:
+
+```jsx
+import { useId } from 'react';
+import { GlowFilter, FiltroAcuarela, AutoDibujo } from '../../visual/effects';
+import '../../visual/effects/effects.css';
+
+function MiEscena() {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `glow-${uid}`;
+  const agua = `acuarela-${uid}`;
+  return (
+    <svg viewBox="0 0 390 486">
+      <defs>
+        <GlowFilter id={glow} std={2.2} blurId={`blur-${uid}`} />
+        <FiltroAcuarela id={agua} scale={7} frequency={0.014} />
+      </defs>
+
+      {/* glow neón sobre lo vivo */}
+      <g filter={`url(#${glow})`}>{/* … */}</g>
+
+      {/* un relieve/mancha con borde de acuarela */}
+      <path d="…" fill="#6f9a85" filter={`url(#${agua})`} />
+
+      {/* el trazo se dibuja solo, por etapas */}
+      <AutoDibujo d="M20,300 C120,260 …" stage={1} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo d="M60,300 L60,240 …" stage={3} stroke="#414b42" strokeWidth="2.5" fill="none" />
+      <AutoDibujo as="circle" fade stage={6} cx="300" cy="90" r="26" fill="#cbb96a" />
+    </svg>
+  );
+}
+```
+
+Consumidor de referencia (convertido en este PR): **`dashboard/GuardianEspiritu.jsx`**
+— sus filtros `ge-glow1`/`ge-blur3`, antes inline, hoy salen de `<GlowFilter>`
+(mismo markup, cero regresión visual).
+
+## Técnica y reglas
+
+- **CSS + SVG puros, cero dependencias nuevas**; solo `transform`/`opacity`
+  animados, **blur/filtros ESTÁTICOS** (Android gama baja). Cero JS por frame.
+- Cada helper emite **solo el `<filter>`** (sin `<defs>` propio): el consumidor
+  lo mete en su `<defs>` y referencia por id. **Ids únicos** con `useId` para
+  repetir muchos en una misma página sin colisión.
+- **Reduced-motion-safe**: sin movimiento, el latido queda encendido, el trazo
+  COMPLETO, los planos visibles y velos/grades/viñeta quietos (son estáticos).
+- Las capas-overlay (`.vfx-veil/.vfx-vignette/.vfx-scrim-*/.vfx-grade`) se montan
+  dentro de un contenedor `position: relative`, no capturan toque y heredan el
+  radio del contenedor.
+- Los **grades por piso térmico** nacen tokenizados (`--vfx-piso-*`): cuando la
+  Montaña entre a prod, se re-tiñen desde `themes.css` sin tocar las escenas
+  (§13.2, promoción de los `--mm2-*` recomendada por el catálogo §14b).

--- a/src/visual/effects/index.js
+++ b/src/visual/effects/index.js
@@ -1,0 +1,35 @@
+/*
+ * Librería visual de EFECTOS de Chagra (effects) — las TÉCNICAS DE CINE del
+ * catálogo (§13), una sola vez y reutilizables. Antes de re-hilvanar un
+ * velo/viñeta/grade/glow/latido/auto-dibujado/acuarela, use esto.
+ *
+ * Dos piezas:
+ *   1. `effects.css` — clases `vfx-*` + custom properties `--vfx-*`
+ *      (velos, viñeta, scrims, grades por piso térmico, pulso cardíaco,
+ *      auto-dibujado, flujo por dash). Importalo UNA vez donde lo uses:
+ *          import '../../visual/effects/effects.css';
+ *   2. Helpers SVG (este barrel): `GlowFilter`, `FiltroAcuarela`, `AutoDibujo`.
+ *
+ * Reglas de la casa: solo transform/opacity animados; blur/filtros estáticos;
+ * reduced-motion = fotograma final digno; cero dependencias nuevas.
+ */
+export { GlowFilter } from './GlowFilter.jsx';
+export { FiltroAcuarela } from './FiltroAcuarela.jsx';
+export { AutoDibujo } from './AutoDibujo.jsx';
+
+/* Ritmo del latido/respiración compartido (= `--vfx-beat` en effects.css y
+   `--motion-beat`/`--fvo-beat` en el resto del repo). Útil desde JS cuando una
+   escena necesita sincronizar un timing sin leer el CSS. */
+export const VFX_BEAT_MS = 5200;
+
+/* Registro consultable de los pisos térmicos y su grade de luz (§13.2).
+   `token` = la custom property de effects.css; `clase` = la clase modificadora
+   de `.vfx-grade`. Orden de menor a mayor altura invertido: de nevado a río. */
+export const VFX_PISOS = [
+  { slug: 'glacial',  nombre: 'Nevado',   token: '--vfx-piso-glacial',  clase: 'vfx-grade--glacial',  luz: 'azul glacial' },
+  { slug: 'paramo',   nombre: 'Páramo',   token: '--vfx-piso-paramo',   clase: 'vfx-grade--paramo',   luz: 'cian páramo' },
+  { slug: 'frio',     nombre: 'Frío',     token: '--vfx-piso-frio',     clase: 'vfx-grade--frio',     luz: 'neutro frío' },
+  { slug: 'templado', nombre: 'Templado', token: '--vfx-piso-templado', clase: 'vfx-grade--templado', luz: 'hora dorada' },
+  { slug: 'calido',   nombre: 'Cálido',   token: '--vfx-piso-calido',   clase: 'vfx-grade--calido',   luz: 'ámbar cálido' },
+  { slug: 'valle',    nombre: 'Valle/río', token: '--vfx-piso-valle',   clase: 'vfx-grade--valle',    luz: 'turquesa río' },
+];

--- a/src/visual/voz/IrisVoz.jsx
+++ b/src/visual/voz/IrisVoz.jsx
@@ -1,0 +1,192 @@
+/*
+ * IrisVoz — LA VOZ CON FORMA: la identidad visual de la voz de Chagra.
+ *
+ * Cuando el campesino dice «hola, Chagra», la app no muestra un micrófono
+ * genérico: muestra ESTO — un iris orgánico de anillos concéntricos, mitad
+ * ondas de agua en una totuma, mitad anillos de crecimiento de un tronco.
+ * Cálido y de tierra (brasa, miel, musgo), NO sci-fi: es deliberadamente lo
+ * opuesto al astrolabio holográfico del overlay de escucha (EscuchaOverlay).
+ *
+ * LA REGLA DE ORO — el movimiento tiene dirección SEMÁNTICA:
+ *   · escuchando → las ondas viajan HACIA ADENTRO (la voz de usted entra
+ *     hasta la brasa; el anillo de afuera reacciona primero).
+ *   · hablando   → las ondas NACEN en la brasa y salen HACIA AFUERA
+ *     (ahora la voz es de Chagra).
+ *   · pensando   → los anillos se trenzan: dos grupos contra-rotan despacio,
+ *     como agua que da vueltas antes de aclararse.
+ *   · reposo     → apenas respira al ritmo de la casa (--vfx-beat) y la
+ *     brasa queda en rescoldo. Se aquieta; no pide atención.
+ *
+ * NADA DE ANIMACIÓN FINGIDA: el brillo y la escala reaccionan a un NIVEL
+ * (0..1). En producción se le pasa el RMS real del micrófono vía `getNivel`;
+ * sin él usa la simulación orgánica de vozViva.js (nivelSimulado).
+ *
+ * Reglas de la casa (src/visual/effects/README.md):
+ *   · Solo transform/opacity animados; el glow (GlowFilter) es estático.
+ *   · Cero setState por frame: un solo rAF escribe transform/opacity
+ *     imperativamente sobre refs (mismo patrón GPU-friendly del repo).
+ *   · prefers-reduced-motion: el rAF NO arranca y el CSS pinta un fotograma
+ *     estático digno por estado (color + opacidad cuentan el momento).
+ *
+ * Geometría y simulación (deterministas, sin React) en ./vozViva.js.
+ */
+import React, { useEffect, useId, useRef } from 'react';
+import { GlowFilter } from '../effects';
+import { ANILLOS_IRIS, IRIS_VB, IRIS_C, N_ANILLOS, nivelSimulado } from './vozViva';
+import './irisVoz.css';
+
+/**
+ * El iris. Decorativo por contrato (aria-hidden): el ESTADO se anuncia con
+ * texto fuera del iris (aria-live del consumidor), nunca solo con color.
+ *
+ * @param {object}   props
+ * @param {string}  [props.estado='reposo']  reposo | escuchando | pensando | hablando
+ * @param {number}  [props.size=180]         lado en px (la firma sobrevive desde ~22px)
+ * @param {Function}[props.getNivel]         () => 0..1 leído cada frame (RMS real del
+ *                                           mic en producción). Si no se pasa, usa la
+ *                                           simulación orgánica según el estado.
+ * @param {string}  [props.className]
+ */
+export default function IrisVoz({ estado = 'reposo', size = 180, getNivel, className = '' }) {
+  const uid = useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const anillosRef = useRef([]);
+  const brasaRef = useRef(null);
+  const auraRef = useRef(null);
+  const haloRef = useRef(null);
+
+  /* refs espejo: el rAF lee SIEMPRE lo último sin recrearse por render. */
+  const estadoRef = useRef(estado);
+  const getNivelRef = useRef(getNivel);
+  useEffect(() => { estadoRef.current = estado; }, [estado]);
+  useEffect(() => { getNivelRef.current = getNivel; }, [getNivel]);
+
+  useEffect(() => {
+    /* reduced-motion: sin rAF — el CSS pinta el fotograma estático por estado. */
+    if (typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return undefined;
+    }
+    const niveles = new Float32Array(N_ANILLOS);
+    let lead = 0;
+    let raf = 0;
+    const t0 = performance.now();
+
+    const tick = (now) => {
+      const t = (now - t0) / 1000;
+      const est = estadoRef.current;
+      const crudo = getNivelRef.current
+        ? (getNivelRef.current() || 0)
+        : nivelSimulado(t, est);
+      /* suavizado asimétrico: sube rápido con la voz, cae lento (el iris
+         "retiene" un instante lo que oyó — mismo gesto que EscuchaOverlay). */
+      lead += (crudo - lead) * (crudo > lead ? 0.32 : 0.1);
+
+      /* LA DIRECCIÓN: cada anillo persigue a su vecino. hablando → el de
+         adentro manda (la onda sale); resto → el de afuera manda (la voz
+         entra). El lag de la persecución ES el viaje de la onda. */
+      if (est === 'hablando') {
+        for (let i = 0; i < N_ANILLOS; i++) {
+          const objetivo = i === 0 ? lead : niveles[i - 1];
+          niveles[i] += (objetivo - niveles[i]) * 0.24;
+        }
+      } else {
+        for (let i = N_ANILLOS - 1; i >= 0; i--) {
+          const objetivo = i === N_ANILLOS - 1 ? lead : niveles[i + 1];
+          niveles[i] += (objetivo - niveles[i]) * 0.24;
+        }
+      }
+
+      for (let i = 0; i < N_ANILLOS; i++) {
+        const el = anillosRef.current[i];
+        if (!el) continue;
+        const a = ANILLOS_IRIS[i];
+        el.style.transform = `scale(${(1 + niveles[i] * a.amp).toFixed(4)})`;
+        el.style.opacity = Math.min(1, a.base + niveles[i] * 0.5).toFixed(3);
+      }
+      if (brasaRef.current) {
+        brasaRef.current.style.transform = `scale(${(1 + lead * 0.24).toFixed(4)})`;
+      }
+      if (auraRef.current) {
+        auraRef.current.style.opacity = (0.35 + lead * 0.6).toFixed(3);
+        auraRef.current.style.transform = `scale(${(1 + lead * 0.36).toFixed(4)})`;
+      }
+      if (haloRef.current) {
+        haloRef.current.style.opacity = (0.5 + lead * 0.5).toFixed(3);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div
+      className={`iris-voz ${className}`.trim()}
+      data-estado={estado}
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    >
+      <div className="iv-halo" ref={haloRef} />
+      <div className="iv-respira">
+        <svg viewBox={`0 0 ${IRIS_VB} ${IRIS_VB}`} focusable="false">
+          <defs>
+            <GlowFilter id={`${uid}-glow`} std={2.6} />
+            <radialGradient id={`${uid}-brasa`} cx="50%" cy="46%" r="55%">
+              <stop offset="0%" stopColor="var(--iris-brasa-luz)" />
+              <stop offset="62%" stopColor="var(--iris-brasa)" />
+              <stop offset="100%" stopColor="var(--iris-brasa-borde)" />
+            </radialGradient>
+          </defs>
+
+          {/* Anillos en dos grupos (pares/impares) que solo en `pensando`
+              contra-rotan — animation-play-state, así al salir del estado la
+              trenza se CONGELA donde iba (nada salta). */}
+          <g className="iv-giro iv-giro-a">
+            {ANILLOS_IRIS.map((a, i) => (i % 2 === 0 ? (
+              <path
+                key={i}
+                ref={(el) => { anillosRef.current[i] = el; }}
+                className="iv-anillo iv-anillo-par"
+                d={a.d}
+                style={{ '--iv-op-base': a.base }}
+                strokeWidth={a.grosor}
+              />
+            ) : null))}
+          </g>
+          <g className="iv-giro iv-giro-b">
+            {ANILLOS_IRIS.map((a, i) => (i % 2 === 1 ? (
+              <path
+                key={i}
+                ref={(el) => { anillosRef.current[i] = el; }}
+                className="iv-anillo iv-anillo-impar"
+                d={a.d}
+                style={{ '--iv-op-base': a.base }}
+                strokeWidth={a.grosor}
+              />
+            ) : null))}
+          </g>
+
+          {/* La brasa: el rescoldo donde la voz vive. Glow ESTÁTICO
+              (GlowFilter); lo que se anima es transform/opacity. */}
+          <g filter={`url(#${uid}-glow)`}>
+            <circle
+              ref={auraRef}
+              className="iv-brasa-aura"
+              cx={IRIS_C}
+              cy={IRIS_C}
+              r={17.5}
+            />
+            <circle
+              ref={brasaRef}
+              className="iv-brasa"
+              cx={IRIS_C}
+              cy={IRIS_C}
+              r={10}
+              fill={`url(#${uid}-brasa)`}
+            />
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/voz/README.md
+++ b/src/visual/voz/README.md
@@ -1,0 +1,42 @@
+# `src/visual/voz` — la voz con forma
+
+`IrisVoz` es la **identidad visual de la voz de Chagra**: un iris orgánico de
+anillos concéntricos (mitad ondas de agua en una totuma, mitad anillos de
+crecimiento de un tronco) con una brasa en el centro. Cálido y de tierra —
+deliberadamente lo opuesto al astrolabio holográfico de `EscuchaOverlay`.
+
+Mockup de decisión: `#/mockups/voz-con-forma` (`src/mockups/VozConForma.jsx`).
+
+## La regla de oro: el movimiento tiene dirección semántica
+
+| estado | qué hace | por qué |
+| --- | --- | --- |
+| `reposo` | apenas respira (`--vfx-beat`), brasa en rescoldo | se aquieta, no pide atención |
+| `escuchando` | las ondas viajan **hacia adentro**; el brillo sube con el nivel | la voz de usted entra hasta la brasa |
+| `pensando` | los anillos se **trenzan** (contra-rotación lentísima) | agua dando vueltas antes de aclararse |
+| `hablando` | las ondas **nacen en la brasa** y salen | ahora la voz es de Chagra |
+
+## Uso
+
+```jsx
+import IrisVoz from '../visual/voz';
+
+// producción: nivel = RMS real del micrófono, leído cada frame
+<IrisVoz estado="escuchando" size={220} getNivel={() => rmsRef.current} />
+
+// demo/onboarding: sin getNivel usa la pseudo-habla determinista incluida
+<IrisVoz estado="hablando" size={56} />
+```
+
+- **Decorativo por contrato** (`aria-hidden`): el estado se anuncia con texto
+  del consumidor (`aria-live`), nunca solo con color.
+- La firma sobrevive desde ~22 px (chip) hasta pantalla completa.
+
+## Reglas de la casa (heredadas de `src/visual/effects`)
+
+- Solo `transform`/`opacity` animados; el glow (`GlowFilter` de `effects`) es
+  filtro **estático**.
+- Cero setState por frame: un solo rAF escribe sobre refs.
+- `prefers-reduced-motion`: el rAF no arranca; el CSS pinta un fotograma
+  quieto pero legible por estado (color + opacidad cuentan el momento).
+- Geometría **determinista** (sin `Math.random`): el iris es una firma.

--- a/src/visual/voz/index.js
+++ b/src/visual/voz/index.js
@@ -1,0 +1,17 @@
+/*
+ * Librería visual de VOZ de Chagra — la identidad "la voz con forma".
+ *
+ * `IrisVoz` es el gesto único de la voz en toda la app: donde antes iría un
+ * micrófono genérico, va el iris (FAB, overlay de escucha, chip de estado,
+ * onboarding de voz). Un solo primitivo, cuatro estados, cualquier tamaño.
+ *
+ *   import IrisVoz, { nivelSimulado, ESTADOS_VOZ } from '.../visual/voz';
+ *
+ *   <IrisVoz estado="escuchando" size={220} getNivel={() => rmsRef.current} />
+ *
+ * `getNivel` en producción = RMS real del micrófono (useVoiceRecorder);
+ * sin él, IrisVoz usa `nivelSimulado` (pseudo-habla determinista) — útil
+ * para demos, onboarding y estados sin permiso de mic todavía.
+ */
+export { default, default as IrisVoz } from './IrisVoz.jsx';
+export { nivelSimulado, ESTADOS_VOZ, ANILLOS_IRIS } from './vozViva';

--- a/src/visual/voz/irisVoz.css
+++ b/src/visual/voz/irisVoz.css
@@ -1,0 +1,148 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   irisVoz.css — la piel de IrisVoz (LA VOZ CON FORMA).
+
+   Paleta de TIERRA, no de neón: la voz de Chagra es una brasa en una cocina
+   de leña, no un holograma. Cuatro estados = cuatro temperaturas del mismo
+   material (nunca cambia la forma, solo la vida que lleva adentro):
+
+     reposo      rescoldo   (pardo apagado — apenas se nota que está viva)
+     escuchando  miel       (ámbar cálido — la atención encendida)
+     pensando    cobre      (más hondo y quieto — el agua dando vueltas)
+     hablando    musgo+miel (verde vivo — la respuesta es cosa que crece)
+
+   Reglas de la casa: solo transform/opacity animados; el glow es filtro
+   ESTÁTICO; prefers-reduced-motion = fotograma quieto pero LEGIBLE por
+   estado (el color y la opacidad cuentan el momento sin loops).
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.iris-voz {
+  /* tinta por defecto = reposo (rescoldo) */
+  --iris-tinta: #8d6b4d;
+  --iris-tinta-2: #6f5844;
+  --iris-brasa-luz: #ffd9a8;
+  --iris-brasa: #d98549;
+  --iris-brasa-borde: rgba(140, 70, 30, 0);
+  --iris-halo: rgba(217, 133, 73, 0.14);
+  --iris-vida: 0;                 /* fotograma estático: cuánta vida extra */
+
+  position: relative;
+  display: inline-block;
+  flex: none;
+}
+
+.iris-voz[data-estado='escuchando'] {
+  --iris-tinta: #e9a94e;
+  --iris-tinta-2: #c98a54;
+  --iris-brasa-luz: #ffe3b0;
+  --iris-brasa: #f0a355;
+  --iris-halo: rgba(233, 169, 78, 0.22);
+  --iris-vida: 0.3;
+}
+
+.iris-voz[data-estado='pensando'] {
+  --iris-tinta: #c57a45;
+  --iris-tinta-2: #9a6a4a;
+  --iris-brasa-luz: #ffce96;
+  --iris-brasa: #d98549;
+  --iris-halo: rgba(197, 122, 69, 0.18);
+  --iris-vida: 0.16;
+}
+
+.iris-voz[data-estado='hablando'] {
+  --iris-tinta: #b7c98a;
+  --iris-tinta-2: #d8b06a;
+  --iris-brasa-luz: #f3e9b0;
+  --iris-brasa: #cabd62;
+  --iris-halo: rgba(183, 201, 138, 0.2);
+  --iris-vida: 0.34;
+}
+
+/* ── halo: la luz que la brasa le presta a la mesa ─────────────────────────── */
+.iv-halo {
+  position: absolute;
+  inset: -18%;
+  border-radius: 50%;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 50%, var(--iris-halo) 0%, transparent 62%);
+  opacity: 0.6;
+  transition: background 0.7s ease;
+}
+
+/* ── respiración: TODO el iris respira al ritmo de la casa ─────────────────── */
+.iv-respira {
+  width: 100%;
+  height: 100%;
+  animation: iv-respira var(--vfx-beat, 5.2s) ease-in-out infinite;
+}
+
+.iv-respira svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+@keyframes iv-respira {
+  0%, 100% { transform: scale(1); }
+  42% { transform: scale(1.022); }
+  58% { transform: scale(1.018); }
+}
+
+/* ── anillos de agua/tronco ────────────────────────────────────────────────── */
+.iv-anillo {
+  fill: none;
+  stroke: var(--iris-tinta);
+  stroke-linejoin: round;
+  opacity: calc(var(--iv-op-base, 0.4) + var(--iris-vida) * 0.5);
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: stroke 0.7s ease;
+}
+
+/* anillos alternos con la segunda tinta: la veta del tronco, no un arcoíris */
+.iv-anillo-impar { stroke: var(--iris-tinta-2); }
+
+/* ── la trenza de `pensando`: dos grupos contra-rotan lentísimo ──────────────
+   animation-play-state: al salir del estado la rotación se CONGELA donde va
+   (nada salta a cero). Solo transform ⇒ GPU-friendly. */
+.iv-giro {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: iv-giro 46s linear infinite;
+  animation-play-state: paused;
+}
+
+.iv-giro-b {
+  animation-name: iv-giro-contra;
+  animation-duration: 58s;
+}
+
+.iris-voz[data-estado='pensando'] .iv-giro { animation-play-state: running; }
+
+@keyframes iv-giro { to { transform: rotate(360deg); } }
+@keyframes iv-giro-contra { to { transform: rotate(-360deg); } }
+
+/* ── la brasa ──────────────────────────────────────────────────────────────── */
+.iv-brasa {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.iv-brasa-aura {
+  fill: var(--iris-brasa);
+  opacity: calc(0.3 + var(--iris-vida));
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: fill 0.7s ease;
+}
+
+/* ── prefers-reduced-motion: fotograma quieto y digno ────────────────────────
+   El rAF no arranca (lo decide IrisVoz.jsx), así que aquí solo apagamos los
+   loops CSS. El estado sigue LEYÉNDOSE: --iris-vida sube la opacidad de los
+   anillos y la aura cuando la voz está activa — color + luz, sin movimiento. */
+@media (prefers-reduced-motion: reduce) {
+  .iv-respira,
+  .iv-giro {
+    animation: none !important;
+  }
+}

--- a/src/visual/voz/vozViva.js
+++ b/src/visual/voz/vozViva.js
@@ -1,0 +1,68 @@
+/*
+ * vozViva.js — la parte VIVA (y sin React) de IrisVoz: geometría determinista
+ * de los anillos + simulación orgánica de nivel. Separado del componente para
+ * que IrisVoz.jsx solo exporte componentes (react-refresh) y para poder
+ * testear/reusar la matemática sin montar nada.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- 'reposo'/'escuchando'/
+   'pensando'/'hablando' son TOKENS de estado del primitivo (API interna),
+   no copy de UI; el texto visible vive en el consumidor. */
+
+export const ESTADOS_VOZ = ['reposo', 'escuchando', 'pensando', 'hablando'];
+
+export const IRIS_VB = 200;              // lado del viewBox
+export const IRIS_C = IRIS_VB / 2;       // centro
+export const N_ANILLOS = 6;              // anillos de agua/tronco
+const N_PTS = 72;                        // puntos por anillo (denso = suave)
+
+/* PRNG determinista (misma receta que el resto del repo visual). */
+const azar = (i, sal) => {
+  const x = Math.sin(i * 127.1 + sal * 311.7) * 43758.5453;
+  return x - Math.floor(x);
+};
+
+/* Anillos precomputados UNA vez: cada uno es un path cerrado cuyo radio
+ * ondula con dos senos de baja amplitud — el temblor de mano que separa un
+ * anillo de tronco de un círculo de compás. El de afuera tiembla más (la
+ * onda se deshace al alejarse de la brasa), y cada anillo trae su amplitud
+ * de reacción a la voz (`amp`) y su opacidad base (`base`). */
+export const ANILLOS_IRIS = Array.from({ length: N_ANILLOS }, (_, k) => {
+  const R = 30 + k * 11.4;                       // 30 → 87 (dentro de VB=200)
+  const w1 = 0.016 + azar(k, 1) * 0.016 + k * 0.0045;
+  const w2 = 0.009 + azar(k, 2) * 0.012;
+  const f1 = 3 + (k % 3);
+  const f2 = 6 + (k % 4);
+  const p1 = azar(k, 3) * Math.PI * 2;
+  const p2 = azar(k, 4) * Math.PI * 2;
+  let d = '';
+  for (let j = 0; j < N_PTS; j++) {
+    const a = (j / N_PTS) * Math.PI * 2;
+    const r = R * (1 + w1 * Math.sin(f1 * a + p1) + w2 * Math.sin(f2 * a + p2));
+    d += `${j === 0 ? 'M' : 'L'}${(IRIS_C + Math.cos(a) * r).toFixed(1)} ${(IRIS_C + Math.sin(a) * r).toFixed(1)}`;
+  }
+  return {
+    d: `${d}Z`,
+    amp: 0.05 + k * 0.016,          // cuánto se hincha con la voz
+    base: 0.5 - k * 0.055,          // opacidad base (se desvanece hacia afuera)
+    grosor: 1.9 - k * 0.18,         // trazo (grueso adentro, fino afuera)
+  };
+});
+
+/* ── Simulación orgánica de nivel (para mockups/demos) ───────────────────────
+ * Pseudo-habla determinista: una envolvente de FRASES (con pausas de aire),
+ * modulada por PALABRAS y SÍLABAS (senos incongruentes = cadencia creíble).
+ * `hablando` es un pelo más parejo (Chagra no duda); `pensando` es un pulso
+ * interior bajito; `reposo` es silencio. */
+export function nivelSimulado(t, estado) {
+  if (estado === 'escuchando' || estado === 'hablando') {
+    const lento = estado === 'hablando' ? 0.62 : 0.78;
+    const frase = Math.sin(t * lento + 0.6) * 0.5 + 0.5;      // 0..1, respiración de frase
+    if (frase < 0.22) return 0.04;                            // pausa para tomar aire
+    const palabra = 0.62 + 0.38 * Math.sin(t * 5.9) * Math.sin(t * 2.31 + 1.7);
+    const silaba = 0.78 + 0.22 * Math.sin(t * 13.7 + 0.4);
+    const piso = estado === 'hablando' ? 0.3 : 0.22;
+    return Math.max(0, Math.min(1, piso + 0.62 * frase * palabra * silaba));
+  }
+  if (estado === 'pensando') return 0.1 + 0.06 * Math.sin(t * 1.5);
+  return 0;
+}


### PR DESCRIPTION
## Qué es

El momento del wake-word **«hola, Chagra»** convertido en escena 3D viva — ruta pública `#/mockups/hola-chagra-3d` (sin gate). El campesino le habla a su finca y el mundo le responde: no un micrófono frío, un valle que lo oye.

**El guion** (demo guionada, sin micrófono real):
1. Valle en reposo, respirando (auto-órbita calma) — un solo hint: *diga «hola, Chagra»* (tocarlo = decirlo).
2. La **abeja angelita despierta y vuela al centro**; la cámara se acerca; un velo recoge el mundo hacia el centro.
3. Aparece el **IrisVoz** en «escuchando» (ondas hacia adentro) y la pregunta se transcribe palabra a palabra.
4. Iris «pensando» → «hablando»: el agente responde corto, en usted, con la **voz real de Chagra** (ttsService → Kokoro, voz Santa; si el server de voz no está, el momento sigue completo en silencio).
5. La respuesta **cae como UNA acción concreta** (panel + botón), no un chat.

## Reúso (cero redibujo)
- **El valle 3D** de la entrada definitiva (base de esta rama): `Terreno/Cordillera/Quebrada/LandmarkGeom/Veleta` ahora exportados de `Valle3D.jsx` y **compuestos** en `HolaChagraEscena3D.jsx` (chunk perezoso propio — three no toca el bundle base). `alturaTerreno` movida a `valleData.js` (react-refresh only-export-components).
- **La abeja**: `AbejaAngelita` (visual-lib/creatures, traída de `fable/valle-3d-ronda2`) — en el mundo 3D vía `Html`, y volando en DOM (solo transform) en el tier 2D.
- **La identidad de la voz**: `IrisVoz` + `vozViva` + librería `effects` (GlowFilter/FiltroAcuarela/AutoDibujo), traídos de `fable/mockup-voz-con-forma`.
- **La voz**: `ttsService.speakKokoro` (voz Santa, `DEFAULT_KOKORO_VOICE`) + `onSpeakingChange` para que la fase «hablando» dure lo que dura el audio real.
- **Tier bajo**: `Valle2DFallback` como mundo dibujado — `decidirRender()` real (WebGL + deviceMemory/hardwareConcurrency): gama baja ve **la misma coreografía** en SVG/CSS. reduced-motion: sin vuelos ni tipeo, fotogramas dignos.

## De paso (para dejar el gate en cero nuevos)
16 errores de tipo arreglados de raíz en los archivos tocados/traídos: `useRef()` sin argumento, **`rotation` puesto en la geometría en vez del mesh (bug real: la rotación se ignoraba silenciosamente)**, props sin default (`Veleta`, `GlowFilter`), fallback `{}` sin tipo en `valleData`, tag dinámico en `AutoDibujo`.

## Verificación (corrida de verdad)
- `npm run build` verde (chunks: `HolaChagra3D` propio + `HolaChagraEscena3D` propio; three sigue en `vendor-three`).
- `node scripts/tsc-check-gate.mjs` → **868 = baseline, cero nuevos**.
- `npx eslint src/mockups src/visual/voz src/visual/effects src/App.jsx` limpio (0 errores, 0 warnings).

> **Base del PR**: `fable/entrada-definitiva-3d` (apilado — el valle aún no está en main; así el diff es solo este trabajo). Si la entrada 3D se mergea primero, GitHub retargetea solo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)