### PR TITLE
feat(visual): mundo 3D del agua — recorrido completo por datos + vitrina pública

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
         "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
         "jspdf": "^4.2.1",
         "leaflet": "^1.9.4",
@@ -20,6 +22,7 @@
         "react-dom": "^19.2.4",
         "react-leaflet": "^5.0.0",
         "react-virtuoso": "^4.18.6",
+        "three": "^0.180.0",
         "ulid": "^3.0.2",
         "zustand": "^5.0.12"
       },
@@ -1856,6 +1859,12 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -2279,6 +2288,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -2371,6 +2398,94 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3251,6 +3366,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -3285,6 +3406,12 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3350,6 +3477,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -3357,12 +3493,56 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -3884,7 +4064,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3933,7 +4112,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -4057,6 +4235,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4132,6 +4334,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4327,11 +4542,28 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4585,6 +4817,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4625,6 +4866,12 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5660,6 +5907,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5791,6 +6044,12 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -5836,7 +6095,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6225,6 +6483,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6404,7 +6668,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6444,6 +6707,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jackspeak": {
@@ -7226,6 +7501,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7303,6 +7588,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7685,7 +7985,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7984,6 +8283,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -8061,6 +8366,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/pump": {
@@ -8198,6 +8513,21 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-virtuoso": {
@@ -8375,7 +8705,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8712,7 +9041,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8725,7 +9053,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8975,6 +9302,32 @@
         "node": ">=0.1.14"
       }
     },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -9193,6 +9546,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
@@ -9366,6 +9728,44 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9500,6 +9900,36 @@
         "node": ">=20"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -9524,6 +9954,43 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {
@@ -9808,12 +10275,30 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/utrie": {
       "version": "1.0.2",
@@ -10047,6 +10532,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -10086,7 +10582,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
     "jspdf": "^4.2.1",
     "leaflet": "^1.9.4",
@@ -40,6 +42,7 @@
     "react-dom": "^19.2.4",
     "react-leaflet": "^5.0.0",
     "react-virtuoso": "^4.18.6",
+    "three": "^0.180.0",
     "ulid": "^3.0.2",
     "zustand": "^5.0.12"
   },

--- a/scripts/check-perf-budget.mjs
+++ b/scripts/check-perf-budget.mjs
@@ -24,6 +24,19 @@ const LAZY_EXCLUDED_PREFIXES = [
   join(DIST, 'models', 'hola-chagra'),
 ];
 
+// three.js + @react-three (#2309, mundos 3D): el 3D es ASPIRACIONAL y se carga
+// PEREZOSO — `<Mundo>`/el storybook hacen dynamic import de los dioramas, que
+// Vite agrupa en el chunk `vendor-three` (dist/assets/vendor-three-*.js). Ese
+// chunk NUNCA se referencia en index.html (solo lo hacen los chunks de entrada),
+// así que el SW NO lo precachea en install (parsea index.html para el shell; el
+// resto es cache-on-use vía el fetch handler cache-first). No pesa en el arranque
+// → se excluye del techo total y del cap por-chunk (three son ~850KB irreducibles,
+// no divisibles bajo 500KB sin romper la lib). Mismo espíritu que el modo campo.
+const LAZY_VENDOR_CHUNK_PREFIXES = ['vendor-three'];
+function isLazyVendorChunk(filename) {
+  return LAZY_VENDOR_CHUNK_PREFIXES.some((p) => filename.startsWith(p));
+}
+
 function formatSize(bytes) {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -50,6 +63,8 @@ function getDirSize(dir) {
     const full = join(dir, entry.name);
     // Assets lazy del modo campo (#2088): no cuentan al techo de arranque.
     if (isLazyExcluded(full)) continue;
+    // Chunk vendor-three lazy (#2309): tampoco cuenta al arranque (cache-on-use).
+    if (entry.isFile() && isLazyVendorChunk(entry.name)) continue;
     if (entry.isFile()) total += statSync(full).size;
     else if (entry.isDirectory()) total += getDirSize(full);
   }
@@ -77,6 +92,7 @@ function checkBudget() {
   }
 
   let mainBundleSize = 0;
+  let lazyVendorExcluded = 0;
   const chunkSizes = [];
   for (const f of readdirSync(ASSETS)) {
     const fp = join(ASSETS, f);
@@ -85,12 +101,16 @@ function checkBudget() {
     const size = statSync(fp).size;
     chunkSizes.push({ file: f, size });
     if (f.startsWith('index-') && size > mainBundleSize) mainBundleSize = size;
+    if (isLazyVendorChunk(f)) lazyVendorExcluded += size;
   }
 
   if (mainBundleSize > THRESHOLDS.mainBundleMax) {
     errors.push('MAIN bundle exceeds 300KB: ' + formatSize(mainBundleSize));
   }
   for (const { file, size } of chunkSizes) {
+    // vendor-three (#2309): chunk vendor lazy, exento del cap por-chunk (three es
+    // irreducible ~850KB; cache-on-use, no en el arranque).
+    if (isLazyVendorChunk(file)) continue;
     if (size > THRESHOLDS.chunkMax) {
       errors.push('CHUNK "' + file + '" exceeds 500KB: ' + formatSize(size));
     }
@@ -99,6 +119,9 @@ function checkBudget() {
   console.log('Total dist (arranque, budget): ' + formatSize(totalSize) + ' / ' + formatSize(THRESHOLDS.totalMax));
   if (lazyExcluded > 0) {
     console.log('Excluido lazy (modo campo #2088): ' + formatSize(lazyExcluded) + ' (cache-on-use, no en arranque)');
+  }
+  if (lazyVendorExcluded > 0) {
+    console.log('Excluido lazy (vendor-three #2309): ' + formatSize(lazyVendorExcluded) + ' (cache-on-use, no en arranque)');
   }
   console.log('Main bundle: ' + formatSize(mainBundleSize));
   console.log('Chunk count: ' + chunkSizes.length);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,6 +73,9 @@ const OAuthCallback = lazy(() => import('./components/OAuthCallback'));
 // Vitrina pública de la librería visual reutilizable (`src/visual/`). Ruta
 // #/mockups/visual-lib, resuelta ANTES del check de sesión (no requiere auth).
 const VisualLib = lazy(() => import('./mockups/VisualLib'));
+// Vitrina pública del MUNDO DEL AGUA (framework src/visual/mundo3d). Ruta
+// #/mockups/mundo3d-agua, también pre-auth. El 3D va perezoso (vendor-three).
+const Mundo3DAgua = lazy(() => import('./mockups/Mundo3DAgua'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -425,7 +428,14 @@ const LoadingFallback = ({ view = null }) => {
 // #onboarding-piloto. El hash llega ya normalizado (sin `#`/`#/`).
 const MOCKUP_HASH_ROUTES = {
   'mockups/visual-lib': 'mockup_visual_lib',
+  'mockups/mundo3d-agua': 'mockup_mundo3d_agua',
 };
+
+// ¿La vista actual es una vitrina pública de mockups? Son páginas
+// autocontenidas: sin fondo de app, banners de instalación/datos, FABs ni
+// atajos globales encima. Helper de módulo (no reactivo) para que los guards
+// de render/efectos lo usen sin pelear con exhaustive-deps.
+const esVistaMockup = (v) => Object.values(MOCKUP_HASH_ROUTES).includes(v);
 
 const HASH_VIEW_ROUTES = {
   agente: 'agente',
@@ -793,7 +803,7 @@ export default function App() {
       clearTimeout(bootSync);
     };
   }, []);
-  useGlobalKeyboardShortcuts({ enabled: currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'mockup_visual_lib' });
+  useGlobalKeyboardShortcuts({ enabled: currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !esVistaMockup(currentView) });
   const [currentViewData, setCurrentViewData] = useState(null);
   const [toast, setToast] = useState(null);
   const [lastLogMessage, setLastLogMessage] = useState('');
@@ -1121,7 +1131,7 @@ export default function App() {
   // loading. Body className toggled según currentView. Estilos en
   // src/index.css clase .app-bg-biodiversidad (nombre histórico).
   useEffect(() => {
-    const showBg = currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'mockup_visual_lib';
+    const showBg = currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !esVistaMockup(currentView);
     if (showBg) {
       document.body.classList.add('app-bg-biodiversidad');
     } else {
@@ -1238,6 +1248,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Librería visual">
               <VisualLib />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_agua':
+        // Vitrina pública del MUNDO DEL AGUA: monta <Mundo mundoId="agua"> del
+        // framework (src/visual/mundo3d) con device-tiering real. Ruta
+        // #/mockups/mundo3d-agua, sin auth. El recorrido del agua de la finca:
+        // nacimiento → ronda → quebrada → cuidado → toma → huerta regada.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del agua">
+              <Mundo3DAgua />
             </ErrorFallback>
           </ErrorBoundary>
         );
@@ -2541,9 +2563,9 @@ export default function App() {
     currentView === 'loading' ||
     currentView === 'login' ||
     currentView === 'oauth-callback' ||
-    // La vitrina de la librería visual es una página pública autocontenida:
+    // Las vitrinas de mockups son páginas públicas autocontenidas:
     // sin banners de instalación/datos ni FABs encima.
-    currentView === 'mockup_visual_lib';
+    esVistaMockup(currentView);
 
   return (
     <>
@@ -2569,10 +2591,10 @@ export default function App() {
           detectamos huella `chagra:had-data-once` en localStorage + IDB
           vacío. NO se muestra en loading/login para no asustar antes de
           que la app pueda confirmar estado. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'mockup_visual_lib' && <DataLossBanner />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !esVistaMockup(currentView) && <DataLossBanner />}
       {/* #315 — banner crítico global: surfacea alertas graves (helada, sensor
           crítico) sin abrir la campana. Imposible de ignorar. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'mockup_visual_lib' && <CriticalAlertBanner onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !esVistaMockup(currentView) && <CriticalAlertBanner onNavigate={navigate} />}
       {/* Entrada de pantalla: el swap de vista era SECO (desmonta/monta sin
           transición). El wrapper con key remonta en cada cambio de vista y
           dispara un fade corto (motion.css .anim-screen-enter — solo opacidad,
@@ -2601,7 +2623,7 @@ export default function App() {
           Tampoco en onboarding-perfil (tarea #16): el FAB se encimaba sobre el
           CTA "Explorar con finca de ejemplo" del footer y la usuaria nueva aún
           no conoce al agente — ruido en su primer flujo. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'mockup_visual_lib' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && <AgentFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !esVistaMockup(currentView) && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && <AgentFab onNavigate={navigate} />}
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o
           pregunta al agente punta a punta por voz.
@@ -2615,9 +2637,9 @@ export default function App() {
           Para re-habilitar el tap: descomentar el import de EscuchaFab (arriba)
           y la línea del render de abajo. */}
       {/* {!['loading', 'login', 'oauth-callback', 'onboarding-perfil', 'ubicacion-detectada', 'dashboard', 'agente', 'voz', 'voz_planta', 'registro_voz'].includes(currentView) && <EscuchaFab />} */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'mockup_visual_lib' && <EscuchaOverlay />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !esVistaMockup(currentView) && <EscuchaOverlay />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'mockup_visual_lib' && <SyncProgressIndicator />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !esVistaMockup(currentView) && <SyncProgressIndicator />}
       {toast && (
         <div
           role={toast.isError ? 'alert' : 'status'}

--- a/src/mockups/Mundo3DAgua.css
+++ b/src/mockups/Mundo3DAgua.css
@@ -1,0 +1,151 @@
+/*
+ * Mundo3DAgua.css — vitrina pública del mundo del agua (#/mockups/mundo3d-agua).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Solo opacity/transform animables; reduced-motion las apaga.
+ */
+
+.m3da {
+  --m3da-a: #2f7fa3;
+  --m3da-b: #d7ecf3;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3da-b) 0%, #f4f0e4 42%, #efe8d6 100%);
+  color: #23303a;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3da__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3da__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3da-a);
+}
+.m3da__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #17323f;
+}
+.m3da__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3da__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3da__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(47, 127, 163, 0.25);
+  box-shadow: 0 10px 28px rgba(23, 50, 63, 0.12);
+}
+.m3da__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fdfaf2;
+}
+
+.m3da__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3da__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3da__toggle {
+  border: 1.5px solid var(--m3da-a);
+  background: #fff;
+  color: var(--m3da-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3da__toggle:hover,
+.m3da__toggle:focus-visible {
+  background: var(--m3da-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3da__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.75);
+  border-left: 3px solid var(--m3da-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3da__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3da__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #17323f;
+}
+.m3da__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3da__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3da__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(47, 127, 163, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3da__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3da__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #17323f;
+}
+.m3da__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3da__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #2c4a3a;
+}

--- a/src/mockups/Mundo3DAgua.jsx
+++ b/src/mockups/Mundo3DAgua.jsx
@@ -1,0 +1,128 @@
+/*
+ * Mundo3DAgua — vitrina pública del MUNDO DEL AGUA (ruta #/mockups/mundo3d-agua).
+ *
+ * El recorrido del agua de la finca, de punta a punta: dónde nace, la ronda de
+ * monte que lo protege, la quebrada viva, el punto donde se cuida de no
+ * contaminarla, la toma con su tanque y la huerta que se riega con medida.
+ * Didáctico y esperanzador — menos colapso, finca viva.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="agua">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento" activado) se ve el gemelo 2D digno; en
+ * gama media/alta, el diorama 3D low-poly (chunk perezoso `vendor-three`) con
+ * la abeja Angelita entrando al mundo. Los puntos del recorrido son las mismas
+ * puertas del registro: aquí (vitrina sin sesión) muestran a qué pantalla real
+ * de la app llevan, en vez de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import './Mundo3DAgua.css';
+
+const TINTE = ['#2f7fa3', '#d7ecf3'];
+
+/* El recorrido, punto por punto — la misma data del registro (mundoData.js),
+   contada en una leyenda didáctica. */
+const LEYENDA = [
+  { emoji: '💧', titulo: 'Donde nace', texto: 'El nacimiento es el corazón del agua de su finca: si él está bien, todo lo demás recibe.' },
+  { emoji: '🌳', titulo: 'La ronda que lo protege', texto: 'La franja de monte alrededor del nacimiento y la quebrada guarda el agua fresca y firme el año entero.' },
+  { emoji: '🐟', titulo: 'La quebrada viva', texto: 'Si en la quebrada hay peces, ranas y libélulas, el agua está contando que viene sana.' },
+  { emoji: '⚠️', titulo: 'Donde se cuida', texto: 'Ni lavar la bomba ni botar sobras cerca de la quebrada: ese cuidado de hoy es el agua de mañana.' },
+  { emoji: '🚰', titulo: 'La toma y el tanque', texto: 'La bocatoma toma solo lo que se necesita y el tanque lo guarda para la casa y el riego.' },
+  { emoji: '🥕', titulo: 'La huerta regada', texto: 'El agua termina su recorrido volviéndose comida: riego con medida, cosecha segura.' },
+];
+
+export default function Mundo3DAgua() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // En la vitrina (sin sesión) un punto del recorrido no navega: cuenta a qué
+  // pantalla real de la app lleva esa puerta.
+  const [puerta, setPuerta] = useState(null);
+  const onHotspot = (view, data) => {
+    const hs = (MUNDO.agua.hotspots || []).find(
+      (h) => h.view === view && (h.data === data || (!h.data && !data)),
+    ) || (MUNDO.agua.hotspots || []).find((h) => h.view === view);
+    setPuerta({ label: hs?.label || view, view });
+  };
+
+  return (
+    <main
+      className="m3da"
+      style={{ '--m3da-a': TINTE[0], '--m3da-b': TINTE[1] }}
+    >
+      <header className="m3da__head">
+        <p className="m3da__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo del agua</h1>
+        <p className="m3da__lema">
+          Recorra el camino del agua: dónde nace, por dónde baja, dónde se
+          cuida y qué riega. Menos colapso, finca viva.
+        </p>
+      </header>
+
+      <section className="m3da__escena" aria-label="El recorrido del agua de la finca">
+        <Mundo
+          mundoId="agua"
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          onSalir={null}
+          animo="sereno"
+          energia={0.85}
+        />
+        <div className="m3da__barra">
+          <p className="m3da__tier">
+            {tier === 'bajo'
+              ? 'Está viendo el dibujo del recorrido (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3da__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver el dibujo 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3da__nota" role="status" aria-live="polite">
+          {puerta
+            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+            : 'Toque un punto del recorrido para ver a dónde lo lleva.'}
+        </p>
+      </section>
+
+      <section className="m3da__leyenda" aria-label="El recorrido, punto por punto">
+        <h2>El recorrido, punto por punto</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3da__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3da__cierre">
+          Cuidar el agua no es una carga: es la finca entera trabajando a su
+          favor. Empiece por un punto — el que usted tenga más a la mano.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/VisualLib.css
+++ b/src/mockups/VisualLib.css
@@ -430,3 +430,80 @@
 @media (prefers-reduced-motion: reduce) {
   .vlib-nav { backdrop-filter: none; }
 }
+
+/* ── Sección 3D / Voz (añadido por el framework de mundos) ─────────────────── */
+.vlib-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-left: auto;
+}
+.vlib-tag {
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  padding: 0.12em 0.5em;
+  border-radius: 999px;
+  border: 1px solid rgba(60, 46, 24, 0.25);
+  color: #4a3a22;
+  background: #fffdf6;
+}
+.vlib-tag--dim-3d { background: #2f6b3a; color: #fff; border-color: transparent; }
+.vlib-tag--dim-2d { background: #e7efe0; color: #2f5f34; }
+.vlib-tag--role { background: #f0e6d2; color: #6a5330; }
+.vlib-tag--capaz { background: #ffd772; color: #4a3a12; border-color: transparent; }
+
+.vlib-stage--voz {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 150px;
+  padding: 0.6rem;
+}
+
+.vlib-stage--mundo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.6rem;
+}
+.vlib-mundo3d-canvas {
+  position: relative;
+  width: 100%;
+  height: 260px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #ece0c7;
+}
+.vlib-mundo3d-cargando {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #4a3a22;
+  font-size: 0.9rem;
+}
+.vlib-mundo3d-toggle {
+  align-self: flex-start;
+  padding: 0.45em 0.9em;
+  font: inherit;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: #fff;
+  background: #2f6b3a;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.vlib-mundo3d-toggle:focus-visible {
+  outline: 2px solid #ffd772;
+  outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .vlib-tag { background: #2a2823; color: #ece7da; border-color: #3a382f; }
+  .vlib-tag--dim-2d { background: #24402a; color: #c8e6cf; }
+  .vlib-tag--role { background: #3a352a; color: #e0d4b8; }
+}

--- a/src/mockups/VisualLib.jsx
+++ b/src/mockups/VisualLib.jsx
@@ -12,11 +12,25 @@
  * Estética: cuaderno de laboratorio. Mobile-first (320px), aprovecha desktop.
  * Autocontenido: cero enlaces/imágenes externas, todo SVG propio de la librería.
  */
-import { useId } from 'react';
+import { lazy, Suspense, useId, useState } from 'react';
 import { VISUAL_REGISTRY, VISUAL_CATEGORIES, VISUAL_COUNTS } from '../visual/registry.js';
 import { Colibri } from '../visual/creatures/index.js';
 import { cieloEscena } from '../visual/scenes/index.js';
 import { CAPAS_PARALLAX } from '../visual/scenes/_parallax.js';
+// Arquetipos 2D (three-free) para la vista previa de los mundos 3D: se dibuja el
+// ESPEJO 2D como poster; el diorama 3D se monta a demanda (chunk perezoso).
+import LaminaMundo from '../visual/mundo3d/laminas2d/LaminaMundo.jsx';
+import MundoValle2D from '../visual/mundo3d/laminas2d/MundoValle2D.jsx';
+
+// Dioramas 3D declarados a nivel de MÓDULO (los componentes lazy no pueden
+// crearse en render). three/@react-three viven en `vendor-three` (perezoso).
+const ESCENAS_LAZY = {
+  cutaway: lazy(() => import('../visual/mundo3d/escenas/EscenaCutaway.jsx')),
+  flujo: lazy(() => import('../visual/mundo3d/escenas/EscenaFlujo.jsx')),
+  recinto: lazy(() => import('../visual/mundo3d/escenas/EscenaRecinto.jsx')),
+  estratos: lazy(() => import('../visual/mundo3d/escenas/EscenaEstratos.jsx')),
+  valle: lazy(() => import('../visual/mundo3d/escenas/EscenaValle.jsx')),
+};
 
 // La vitrina es el único consumidor que monta primitivos de las 4 categorías a
 // la vez, así que carga aquí los CSS que cada familia necesita (las creatures
@@ -26,6 +40,8 @@ import '../visual/effects/effects.css';
 import '../visual/laminas/laminas.css';
 import '../visual/scenes/scenes.css';
 import '../visual/scenes/scene-finca-organismo.css';
+import '../visual/voz/irisVoz.css';
+import '../visual/mundo3d/mundo.css';
 import './VisualLib.css';
 
 const TOTAL = VISUAL_CATEGORIES.reduce((n, k) => n + VISUAL_COUNTS[k], 0);
@@ -155,7 +171,73 @@ function PrimitiveDemo({ categoria, item, variante }) {
     );
   }
 
+  if (render === 'voz') {
+    // IrisVoz: SVG + rAF puro (reduced-motion pinta un fotograma). Un estado por variante.
+    return (
+      <div className="vlib-stage vlib-stage--voz">
+        <Component estado={props.estado || 'reposo'} size={props.size || 132} />
+      </div>
+    );
+  }
+
+  if (render === 'mundo') {
+    return <Mundo3DDemo item={item} />;
+  }
+
   return <div className="vlib-stage vlib-stage--vacio">Sin vista previa</div>;
+}
+
+/* ── Demo de un ARQUETIPO 3D: poster 2D (espejo) + "Ver en 3D" perezoso ─────
+   El storybook respeta el mismo principio del framework: el 2D es primera
+   clase (poster siempre visible) y el 3D es aspiracional (se monta a demanda,
+   trayendo el chunk `vendor-three` solo cuando el usuario lo pide). */
+function Mundo3DDemo({ item }) {
+  const [ver3d, setVer3d] = useState(false);
+  const Escena = ESCENAS_LAZY[item.slug] || null;
+  const noop = () => {};
+
+  const Poster =
+    item.espejo === 'valle2d' ? (
+      <MundoValle2D params={{ clima: 'soleado' }} entrada={item.entrada} onHotspot={noop} />
+    ) : (
+      <LaminaMundo
+        params={item.params}
+        hotspots={item.hotspots}
+        tinte={item.tinte}
+        motivo={item.motivo}
+        onHotspot={noop}
+        titulo={item.nombre}
+      />
+    );
+
+  return (
+    <div className="vlib-stage vlib-stage--mundo">
+      {ver3d && Escena ? (
+        <div className="vlib-mundo3d-canvas">
+          <Suspense fallback={<div className="vlib-mundo3d-cargando">Levantando el diorama 3D…</div>}>
+            <Escena
+              params={item.params}
+              hotspots={item.hotspots}
+              entrada={item.entrada}
+              tinte={item.tinte}
+              reducedMotion={false}
+              onHotspot={noop}
+            />
+          </Suspense>
+        </div>
+      ) : (
+        Poster
+      )}
+      <button
+        type="button"
+        className="vlib-mundo3d-toggle"
+        aria-pressed={ver3d}
+        onClick={() => setVer3d((v) => !v)}
+      >
+        {ver3d ? '‹ Ver el espejo 2D' : 'Ver en 3D ›'}
+      </button>
+    </div>
+  );
 }
 
 /* ── Tabla de props de un primitivo ───────────────────────────────────────── */
@@ -196,6 +278,13 @@ function PrimitiveCard({ categoria, item }) {
       <header className="vlib-card-head">
         <h3 className="vlib-card-name">{item.nombre}</h3>
         {item.cientifico && <span className="vlib-card-sci">{item.cientifico}</span>}
+        <span className="vlib-tags" aria-label="Etiquetas de la pieza">
+          {item.dim && (
+            <span className={`vlib-tag vlib-tag--dim-${item.dim}`}>{item.dim.toUpperCase()}</span>
+          )}
+          {item.role && <span className="vlib-tag vlib-tag--role">{item.role}</span>}
+          {item.capaz3d && <span className="vlib-tag vlib-tag--capaz">3D-capaz</span>}
+        </span>
       </header>
       {item.descripcion && <p className="vlib-card-desc">{item.descripcion}</p>}
 

--- a/src/mockups/__tests__/mundo3dAgua.smoke.test.jsx
+++ b/src/mockups/__tests__/mundo3dAgua.smoke.test.jsx
@@ -1,0 +1,38 @@
+/*
+ * Vitrina #/mockups/mundo3d-agua — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y la vitrina
+ * monta el GEMELO 2D del recorrido (three-free): exactamente el camino del
+ * device-tiering real en gama baja. Se congela que:
+ *   · la página renderiza título + leyenda sin tocar three;
+ *   · el gemelo trae los 6 puntos del recorrido como botones;
+ *   · tocar una puerta cuenta a qué pantalla real de la app lleva (sin sesión
+ *     la vitrina NO navega).
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import Mundo3DAgua from '../Mundo3DAgua.jsx';
+
+afterEach(() => cleanup());
+
+describe('vitrina del mundo del agua (mockups/mundo3d-agua)', () => {
+  test('renderiza el mundo en 2D digno con su leyenda didáctica', () => {
+    const { container } = render(<Mundo3DAgua />);
+    expect(screen.getByRole('heading', { level: 1, name: 'El mundo del agua' })).toBeInTheDocument();
+    // jsdom no tiene WebGL → gemelo 2D (three-free), nunca pantalla rota
+    expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('.mundo2d__hotspot').length).toBe(6);
+    // la leyenda cuenta el recorrido punto por punto (esperanzadora, no alarmista)
+    expect(screen.getByText('El recorrido, punto por punto')).toBeInTheDocument();
+    expect(screen.getByText('La ronda que lo protege', { selector: 'b' })).toBeInTheDocument();
+  });
+
+  test('tocar una puerta del recorrido cuenta a qué pantalla real lleva', () => {
+    render(<Mundo3DAgua />);
+    fireEvent.click(screen.getByRole('button', { name: 'La quebrada viva' }));
+    expect(screen.getByRole('status')).toHaveTextContent('«biodiversidad»');
+  });
+});

--- a/src/mockups/__tests__/visualLib.smoke.test.jsx
+++ b/src/mockups/__tests__/visualLib.smoke.test.jsx
@@ -4,7 +4,9 @@ import '@testing-library/jest-dom';
 import { describe, test, expect, afterEach } from 'vitest';
 
 import VisualLib from '../VisualLib.jsx';
-import { VISUAL_REGISTRY, VISUAL_CATEGORIES, VISUAL_COUNTS } from '../../visual/registry.js';
+import {
+  VISUAL_REGISTRY, VISUAL_CATEGORIES, VISUAL_COUNTS, piezas3D, piezasCapaces3D,
+} from '../../visual/registry.js';
 
 afterEach(() => cleanup());
 
@@ -21,14 +23,39 @@ describe('VisualLib storybook', () => {
     expect(cards).toHaveLength(total);
   });
 
-  test('el registro consolidado cubre las 4 categorías con items', () => {
-    expect(VISUAL_CATEGORIES).toEqual(['creatures', 'effects', 'laminas', 'scenes']);
+  test('el registro cubre las categorías base + voz + mundos 3D, todas con items', () => {
+    // Las 4 base siguen primero; el framework suma voz + mundo3d.
+    expect(VISUAL_CATEGORIES.slice(0, 4)).toEqual(['creatures', 'effects', 'laminas', 'scenes']);
+    expect(VISUAL_CATEGORIES).toContain('voz');
+    expect(VISUAL_CATEGORIES).toContain('mundo3d');
     VISUAL_CATEGORIES.forEach((k) => {
       expect(VISUAL_REGISTRY[k].items.length).toBeGreaterThan(0);
       VISUAL_REGISTRY[k].items.forEach((item) => {
-        expect(item.Component).toBeTruthy();
+        // Todo item declara metadatos filtrables + su forma de dibujarse.
+        expect(item.dim === '2d' || item.dim === '3d').toBe(true);
+        expect(typeof item.role).toBe('string');
+        expect(typeof item.render).toBe('string');
         expect(Array.isArray(item.variantes)).toBe(true);
+        // Los items 2D dibujan un Component directo; los 3D se cargan perezoso.
+        if (item.dim === '2d' && item.render === 'component') {
+          expect(item.Component).toBeTruthy();
+        }
+        if (item.dim === '3d') {
+          expect(typeof item.cargar3d).toBe('function');
+        }
       });
     });
+  });
+
+  test('piezas3D() filtra los 5 arquetipos de escena (dim 3d)', () => {
+    const tresD = piezas3D();
+    expect(tresD.map((p) => p.slug).sort()).toEqual(
+      ['cutaway', 'estratos', 'flujo', 'recinto', 'valle'],
+    );
+    tresD.forEach((p) => expect(p.dim).toBe('3d'));
+    // Los 3D-capaces suman la abeja avatar + la voz a los arquetipos.
+    const capaces = piezasCapaces3D().map((p) => p.slug);
+    expect(capaces).toContain('abeja-angelita');
+    expect(capaces).toContain('iris-voz');
   });
 });

--- a/src/mockups/valle/Valle2DFallback.jsx
+++ b/src/mockups/valle/Valle2DFallback.jsx
@@ -1,0 +1,126 @@
+/*
+ * Valle2DFallback — la degradación LIMPIA cuando el equipo es humilde (sin
+ * WebGL, poca RAM/CPU, ahorro de datos o "menos movimiento"). No es una pantalla
+ * de error: es una entrada digna en SVG+CSS (el músculo que Chagra ya domina,
+ * DR §0) con los MISMOS sí-o-sí — un valle pintado, la cosa del día que brilla,
+ * los mundos como lugares tocables, el clima que tiñe la escena, y Angelita (la
+ * abeja) como avatar-compañero. Al tocar un mundo, la lámina se ACERCA y la
+ * abeja VUELA hasta el lugar: el mismo "entrar al mundo" del 3D, dibujado.
+ * "Wow" 3D se pierde; el PROPÓSITO no.
+ */
+import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
+import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
+
+/* Proyección isométrica plana de las coordenadas del valle a la lámina SVG. */
+function iso(x, z) {
+  const cx = 200 + (x - z) * 30;
+  const cy = 150 + (x + z) * 15;
+  return { cx, cy };
+}
+
+/* Posición en % dentro de la lámina (para posicionar botones/abeja en CSS). */
+function pct(x, z) {
+  const { cx, cy } = iso(x, z);
+  return { left: (cx / 400) * 100, top: (cy / 340) * 100 };
+}
+
+export default function Valle2DFallback({
+  clima,
+  focoId,
+  animo = 'sereno',
+  energia = 1,
+  reducedMotion = false,
+  onEntrar,
+  onAlerta,
+}) {
+  const c = CLIMAS[clima];
+  const ancla = MUNDOS_VALLE.find((m) => m.id === COSA_DEL_DIA.anclaMundo);
+  // Mundos ordenados de atrás hacia adelante para que se solapen bien.
+  const orden = [...MUNDOS_VALLE].sort((a, b) => a.pos[0] + a.pos[2] - (b.pos[0] + b.pos[2]));
+
+  // "Entrar al mundo": la lámina se acerca hacia el lugar tocado y la abeja
+  // vuela hasta él. Sin foco, la abeja ronda el centro del valle.
+  const foco = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;
+  const camPos = foco ? pct(foco.pos[0], foco.pos[2]) : { left: 50, top: 50 };
+  const abejaPos = foco ? pct(foco.pos[0], foco.pos[2]) : { left: 52, top: 46 };
+
+  return (
+    <div className="valle2d" data-clima={clima} data-entrando={foco ? 'si' : 'no'}>
+      {/* cámara-lámina: se acerca al lugar tocado (transform-origin en el POI) */}
+      <div
+        className="valle2d__cam"
+        style={{
+          transformOrigin: `${camPos.left}% ${camPos.top}%`,
+          transform: foco ? 'scale(1.32)' : 'scale(1)',
+        }}
+      >
+        <svg viewBox="0 0 400 340" className="valle2d__svg" role="img"
+          aria-label="El valle de su finca, dibujado. Toque un lugar para entrar.">
+          <defs>
+            <linearGradient id="v2d-cielo" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stopColor={c.cielo[0]} />
+              <stop offset="1" stopColor={c.cielo[1]} />
+            </linearGradient>
+            <radialGradient id="v2d-suelo" cx="0.5" cy="0.35" r="0.9">
+              <stop offset="0" stopColor={clima === 'noche' ? '#2c4a34' : '#6a9a52'} />
+              <stop offset="1" stopColor={clima === 'noche' ? '#1a3324' : '#4b7a3c'} />
+            </radialGradient>
+          </defs>
+          <rect x="0" y="0" width="400" height="340" fill="url(#v2d-cielo)" />
+          {/* cordillera */}
+          <path d="M0,150 L70,80 L140,140 L210,70 L290,140 L360,90 L400,150 Z"
+            fill={clima === 'noche' ? '#33435c' : c.niebla} opacity="0.85" />
+          {/* piso del valle */}
+          <ellipse cx="200" cy="220" rx="230" ry="130" fill="url(#v2d-suelo)" />
+          {/* quebrada */}
+          <path d="M120,150 C160,180 180,210 200,250 C215,280 240,300 280,320"
+            stroke={clima === 'noche' ? '#2a4a6a' : '#5fb2c9'} strokeWidth="10"
+            fill="none" strokeLinecap="round" opacity="0.8" />
+        </svg>
+
+        {/* mundos como lugares tocables, posicionados sobre la lámina */}
+        <div className="valle2d__mundos">
+          {orden.map((m) => {
+            const p = pct(m.pos[0], m.pos[2]);
+            const activo = focoId === m.id;
+            return (
+              <button key={m.id} type="button"
+                className={`valle2d__poi${activo ? ' valle2d__poi--activo' : ''}`}
+                style={{ left: `${p.left}%`, top: `${p.top}%`, '--poi-tinte': m.tinte[0] }}
+                onClick={() => onEntrar(m.id)}
+                aria-label={`Viajar al mundo ${m.titulo}. ${m.lema}`}>
+                <span className="valle2d__emoji" aria-hidden="true">{m.emoji}</span>
+                <span className="valle2d__nombre">{m.titulo}</span>
+              </button>
+            );
+          })}
+
+          {/* la cosa del día: un solo destello, anclado a su lugar */}
+          {ancla && (() => {
+            const p = pct(ancla.pos[0], ancla.pos[2]);
+            return (
+              <button type="button" className="valle2d__alerta"
+                style={{ left: `${p.left}%`, top: `${p.top - 12}%` }}
+                onClick={onAlerta}
+                aria-label={`Alerta del día: ${COSA_DEL_DIA.titulo}. ${COSA_DEL_DIA.detalle}`}>
+                <span aria-hidden="true">⚠️</span> {COSA_DEL_DIA.titulo}
+              </button>
+            );
+          })()}
+
+          {/* Angelita: el avatar-compañero. Vuela hacia el lugar al entrar. */}
+          <div
+            className={`valle2d__abeja${foco ? ' valle2d__abeja--entrando' : ''}`}
+            style={{ left: `${abejaPos.left}%`, top: `${abejaPos.top}%` }}
+            aria-hidden="true"
+          >
+            <AbejaAngelita size={foco ? 40 : 46} animo={animo} energia={energia} animated={!reducedMotion} />
+          </div>
+        </div>
+      </div>
+
+      {/* el clima tiñe la escena: grade de luz de la librería de efectos */}
+      <div className={`valle2d__grade vfx-grade ${c.grade}`} aria-hidden="true" />
+    </div>
+  );
+}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -1,0 +1,544 @@
+/*
+ * Valle3D — la ESCENA 3D del mockup "El valle de mi finca".
+ *
+ * React-Three-Fiber sobre WebGL 2 (la línea base del DR §2). Se carga PEREZOSO
+ * (React.lazy en EntradaValle3D) para no inflar el bundle base: el chunk de
+ * three/fiber/drei solo baja cuando el equipo SÍ tiene WebGL y entra a la ruta.
+ *
+ * Todo es GEOMETRÍA PROCEDURAL (cero GLTF/HDR remotos) → offline-first y
+ * liviano. Estética "acuarela cálida" (Alba/Sorolla del DR), no neón frío.
+ * Solo se anima transform/opacity-equivalentes (rotación/posición/escala) por
+ * useFrame; `reducedMotion` congela el vaivén a un fotograma digno.
+ *
+ * Los 4 sí-o-sí viven en el espacio:
+ *   · MUNDOS  → landmarks navegables (MundoLugar) con etiqueta accesible.
+ *   · ALERTA  → Beacon pulsante anclado sobre el mundo 'suelo' (la cosa del día).
+ *   · COMPAÑERO → Angelita, la abeja (visual-lib) es el avatar-jugador: vuela
+ *                por el valle y ENTRA al mundo que se toca; su ánimo/energía
+ *                reflejan la salud real de la finca.
+ *   · CLIMA   → luz/niebla/estrellas de la escena salen del estado `clima`.
+ */
+/* Nota: las props de three (position, args, intensity, castShadow, etc.) son
+   válidas en el reconciliador de R3F, no en el DOM — el config de ESLint del
+   repo no activa react/no-unknown-property, así que no requieren disable. */
+import { Suspense, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Html, Float, Stars, OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import * as THREE from 'three';
+import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
+import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
+
+/* Altura del terreno por (x,z): un valle suave con ladera al fondo (+z) donde
+   suben las terrazas del café. Determinista → los landmarks se posan encima. */
+function alturaTerreno(x, z) {
+  const ladera = Math.max(0, (z + 2) * 0.16);
+  const ondul = Math.sin(x * 0.5) * 0.08 + Math.cos(z * 0.4) * 0.06;
+  const cauce = -0.28 * Math.exp(-((x - 0.6) ** 2) / 5) * Math.exp(-((z + 1) ** 2) / 40);
+  return ladera + ondul + cauce;
+}
+
+/* ── El suelo del valle: malla ondulada de bajo poligonaje, color tierra-verde
+      que se aclara al fondo (perspectiva aérea). ── */
+function Terreno({ colorBase }) {
+  const geo = useMemo(() => {
+    const g = new THREE.PlaneGeometry(30, 30, 48, 48);
+    g.rotateX(-Math.PI / 2);
+    const pos = g.attributes.position;
+    for (let i = 0; i < pos.count; i++) {
+      const x = pos.getX(i);
+      const z = pos.getZ(i);
+      pos.setY(i, alturaTerreno(x, z));
+    }
+    g.computeVertexNormals();
+    return g;
+  }, []);
+  return (
+    <mesh geometry={geo} receiveShadow>
+      <meshStandardMaterial color={colorBase} flatShading roughness={1} metalness={0} />
+    </mesh>
+  );
+}
+
+/* ── La cordillera de páramo al fondo: conos pálidos (perspectiva aérea). ── */
+function Cordillera({ color }) {
+  const picos = useMemo(
+    () => [
+      { x: -8, z: -12, h: 7, r: 5 },
+      { x: -2, z: -14, h: 9, r: 6 },
+      { x: 5, z: -12.5, h: 7.5, r: 5.2 },
+      { x: 11, z: -13, h: 6, r: 4.5 },
+    ],
+    [],
+  );
+  return (
+    <group>
+      {picos.map((p, i) => (
+        <mesh key={i} position={[p.x, p.h / 2 - 0.5, p.z]}>
+          <coneGeometry args={[p.r, p.h, 5]} />
+          <meshStandardMaterial color={color} flatShading roughness={1} opacity={0.9} transparent />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* ── La quebrada: una cinta de agua que serpentea por el cauce. ── */
+function Quebrada({ color, viva }) {
+  const ref = useRef(null);
+  useFrame((state) => {
+    if (viva && ref.current) {
+      ref.current.material.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 2) * 0.06;
+    }
+  });
+  const geo = useMemo(() => {
+    const curve = new THREE.CatmullRomCurve3([
+      new THREE.Vector3(-6, 0, -6),
+      new THREE.Vector3(-2, 0, -3),
+      new THREE.Vector3(0.6, 0, -1.4),
+      new THREE.Vector3(1.4, 0, 2),
+      new THREE.Vector3(3, 0, 6),
+    ]);
+    const g = new THREE.TubeGeometry(curve, 60, 0.42, 6, false);
+    return g;
+  }, []);
+  return (
+    <mesh geometry={geo} position={[0, 0.02, 0]}>
+      <meshStandardMaterial
+        ref={ref}
+        color={color}
+        transparent
+        opacity={0.78}
+        roughness={0.25}
+        metalness={0.35}
+      />
+    </mesh>
+  );
+}
+
+/* ── Materiales/paletas de cada landmark de mundo, por `tipo`. ── */
+function LandmarkGeom({ tipo, tinte }) {
+  const [fuerte, suave] = tinte;
+  switch (tipo) {
+    case 'milpa': // maíz: cañas altas con penacho
+      return (
+        <group>
+          {[-0.5, 0, 0.5, -0.25, 0.25].map((dx, i) => (
+            <group key={i} position={[dx, 0, (i % 2) * 0.4 - 0.2]}>
+              <mesh position={[0, 0.7, 0]} castShadow>
+                <cylinderGeometry args={[0.05, 0.08, 1.4, 5]} />
+                <meshStandardMaterial color={fuerte} flatShading />
+              </mesh>
+              <mesh position={[0, 1.45, 0]}>
+                <coneGeometry args={[0.12, 0.4, 5]} />
+                <meshStandardMaterial color="#e7c96b" flatShading />
+              </mesh>
+            </group>
+          ))}
+        </group>
+      );
+    case 'cafetal': // arbustos redondos en hilera
+      return (
+        <group>
+          {[-0.6, -0.2, 0.2, 0.6].map((dx, i) => (
+            <mesh key={i} position={[dx, 0.32, (i % 2) * 0.4]} castShadow>
+              <icosahedronGeometry args={[0.34, 0]} />
+              <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+            </mesh>
+          ))}
+        </group>
+      );
+    case 'era': // eras aradas con surcos (semillero)
+      return (
+        <group>
+          {[-0.35, 0, 0.35].map((dz, i) => (
+            <mesh key={i} position={[0, 0.08, dz]} castShadow receiveShadow>
+              <boxGeometry args={[1.3, 0.16, 0.22]} />
+              <meshStandardMaterial color="#5a3d28" flatShading roughness={1} />
+            </mesh>
+          ))}
+          {[-0.35, 0, 0.35].map((dz, i) => (
+            <mesh key={`b${i}`} position={[0, 0.24, dz]}>
+              <boxGeometry args={[1.2, 0.06, 0.14]} />
+              <meshStandardMaterial color={suave} flatShading />
+            </mesh>
+          ))}
+        </group>
+      );
+    case 'quebrada': // nacimiento: charca + juncos
+      return (
+        <group>
+          <mesh position={[0, 0.06, 0]}>
+            <cylinderGeometry args={[0.55, 0.6, 0.12, 16]} />
+            <meshStandardMaterial color="#3a7fa0" transparent opacity={0.85} metalness={0.4} roughness={0.2} />
+          </mesh>
+          {[-0.3, 0.1, 0.4].map((dx, i) => (
+            <mesh key={i} position={[dx, 0.4, 0.2]}>
+              <cylinderGeometry args={[0.03, 0.03, 0.7, 4]} />
+              <meshStandardMaterial color="#4e7d3f" flatShading />
+            </mesh>
+          ))}
+        </group>
+      );
+    case 'corral': // casita + cerca
+      return (
+        <group>
+          <mesh position={[0, 0.35, 0]} castShadow>
+            <boxGeometry args={[0.9, 0.7, 0.8]} />
+            <meshStandardMaterial color={suave} flatShading />
+          </mesh>
+          <mesh position={[0, 0.85, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+            <coneGeometry args={[0.72, 0.5, 4]} />
+            <meshStandardMaterial color={fuerte} flatShading />
+          </mesh>
+          {[-0.9, -0.5, 0.9, 1.3].map((dx, i) => (
+            <mesh key={i} position={[dx, 0.2, 0.9]}>
+              <boxGeometry args={[0.06, 0.4, 0.06]} />
+              <meshStandardMaterial color="#8a6a44" flatShading />
+            </mesh>
+          ))}
+        </group>
+      );
+    case 'huerta': // camas elevadas de la huerta
+      return (
+        <group>
+          {[-0.4, 0.4].map((dx, i) => (
+            <group key={i} position={[dx, 0, 0]}>
+              <mesh position={[0, 0.12, 0]} castShadow>
+                <boxGeometry args={[0.6, 0.24, 1]} />
+                <meshStandardMaterial color="#6b4a30" flatShading />
+              </mesh>
+              <mesh position={[0, 0.32, 0]}>
+                <boxGeometry args={[0.5, 0.18, 0.9]} />
+                <meshStandardMaterial color={fuerte} flatShading />
+              </mesh>
+            </group>
+          ))}
+        </group>
+      );
+    case 'bosque': // arboleda: troncos + copas
+      return (
+        <group>
+          {[
+            [-0.5, 0, 0.9],
+            [0.4, 0.2, 1.15],
+            [0, -0.4, 0.8],
+          ].map(([dx, dz, h], i) => (
+            <group key={i} position={[dx, 0, dz]}>
+              <mesh position={[0, h * 0.35, 0]} castShadow>
+                <cylinderGeometry args={[0.09, 0.12, h * 0.7, 6]} />
+                <meshStandardMaterial color="#6b4a2e" flatShading />
+              </mesh>
+              <mesh position={[0, h * 0.8, 0]} castShadow>
+                <coneGeometry args={[0.5, h * 0.9, 7]} />
+                <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+              </mesh>
+            </group>
+          ))}
+        </group>
+      );
+    case 'veleta': // poste con veleta que gira con el viento
+      return <Veleta color={fuerte} />;
+    default:
+      return (
+        <mesh position={[0, 0.3, 0]}>
+          <icosahedronGeometry args={[0.4, 0]} />
+          <meshStandardMaterial color={fuerte} flatShading />
+        </mesh>
+      );
+  }
+}
+
+function Veleta({ color, reducedMotion = false }) {
+  const ref = useRef(null);
+  useFrame((state) => {
+    if (ref.current && !reducedMotion) ref.current.rotation.y = state.clock.elapsedTime * 0.4;
+  });
+  return (
+    <group>
+      <mesh position={[0, 0.55, 0]}>
+        <cylinderGeometry args={[0.05, 0.07, 1.1, 6]} />
+        <meshStandardMaterial color="#7c6a4c" flatShading />
+      </mesh>
+      <group ref={ref} position={[0, 1.15, 0]}>
+        <mesh>
+          <boxGeometry args={[0.7, 0.06, 0.06]} />
+          <meshStandardMaterial color={color} flatShading />
+        </mesh>
+        <mesh position={[0.42, 0, 0]} rotation={[0, 0, -Math.PI / 2]}>
+          <coneGeometry args={[0.14, 0.3, 4]} />
+          <meshStandardMaterial color={color} flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* ── Un mundo como LUGAR navegable: su geometría + una etiqueta accesible que,
+      al tocarse, viaja hasta él (la cámara) y lo selecciona. ── */
+function MundoLugar({ mundo, activo, onEntrar, reducedMotion }) {
+  const y = alturaTerreno(mundo.pos[0], mundo.pos[2]);
+  return (
+    <group position={[mundo.pos[0], y, mundo.pos[2]]} scale={mundo.escala}>
+      {mundo.tipo === 'veleta' ? (
+        <Veleta color={mundo.tinte[0]} reducedMotion={reducedMotion} />
+      ) : (
+        <LandmarkGeom tipo={mundo.tipo} tinte={mundo.tinte} />
+      )}
+      <Html center distanceFactor={11} position={[0, 1.7, 0]} zIndexRange={[20, 0]}>
+        <button
+          type="button"
+          className={`valle-poi${activo ? ' valle-poi--activo' : ''}`}
+          style={{ '--poi-tinte': mundo.tinte[0] }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onEntrar(mundo.id);
+          }}
+          aria-label={`Viajar al mundo ${mundo.titulo}. ${mundo.lema}`}
+        >
+          <span className="valle-poi__emoji" aria-hidden="true">{mundo.emoji}</span>
+          <span className="valle-poi__txt">{mundo.titulo}</span>
+        </button>
+      </Html>
+    </group>
+  );
+}
+
+/* ── La cosa del día: un faro pulsante anclado sobre su mundo. Un SOLO destello.
+      Toca la señal → onAlerta() (el agente lo dice y ofrece LA acción). ── */
+function Beacon({ onAlerta, reducedMotion }) {
+  const ancla = MUNDO_VALLE_BY_ID[COSA_DEL_DIA.anclaMundo];
+  const luz = useRef(null);
+  const halo = useRef(null);
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const p = (Math.sin(state.clock.elapsedTime * 1.6) + 1) / 2;
+    if (luz.current) luz.current.intensity = 1.4 + p * 2.6;
+    if (halo.current) {
+      const s = 1 + p * 0.5;
+      halo.current.scale.set(s, s, s);
+      halo.current.material.opacity = 0.5 - p * 0.35;
+    }
+  });
+  if (!ancla) return null;
+  const y = alturaTerreno(ancla.pos[0], ancla.pos[2]);
+  return (
+    <group position={[ancla.pos[0], y, ancla.pos[2]]}>
+      <pointLight ref={luz} position={[0, 1.6, 0]} color="#ffd28a" intensity={2.2} distance={7} />
+      <Float speed={reducedMotion ? 0 : 2} floatIntensity={reducedMotion ? 0 : 0.6} rotationIntensity={0}>
+        <mesh position={[0, 1.7, 0]}>
+          <octahedronGeometry args={[0.26, 0]} />
+          <meshStandardMaterial color="#ffd88f" emissive="#ffb24d" emissiveIntensity={1.4} flatShading />
+        </mesh>
+        <mesh ref={halo} position={[0, 1.7, 0]}>
+          <sphereGeometry args={[0.5, 16, 16]} />
+          <meshBasicMaterial color="#ffcf87" transparent opacity={0.4} />
+        </mesh>
+      </Float>
+      <Html center distanceFactor={10} position={[0, 2.7, 0]} zIndexRange={[30, 0]}>
+        <button
+          type="button"
+          className="valle-alerta"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAlerta();
+          }}
+          aria-label={`Alerta del día: ${COSA_DEL_DIA.titulo}. ${COSA_DEL_DIA.detalle}`}
+        >
+          <span className="valle-alerta__icono" aria-hidden="true">⚠️</span>
+          <span className="valle-alerta__txt">{COSA_DEL_DIA.titulo}</span>
+        </button>
+      </Html>
+    </group>
+  );
+}
+
+/* ── El COMPAÑERO-JUGADOR: Angelita, la abeja. Es el avatar que vuela por el
+      valle. Al reposo, ronda sobre el valle con vaivén vivo; cuando se toca un
+      mundo (`entrando`), BAJA y se acerca al lugar — "entra" al mundo, y la
+      cámara la acompaña. Su ánimo/energía (salud real de la finca) tiñen su
+      color, su aura y qué tan vivo es su vuelo. Mira hacia donde viaja. ── */
+function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion }) {
+  const ref = useRef(null);
+  const caraRef = useRef(null);
+  const prevX = useRef(foco.x);
+  useFrame((state) => {
+    if (!ref.current) return;
+    const t = state.clock.elapsedTime;
+    const brio = 0.35 + 0.65 * energia; // la energía anima el vuelo
+    const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.1 + 0.16 * brio);
+    // Al reposo deriva en un círculo calmo; al entrar se posa junto al lugar.
+    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.9;
+    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.6;
+    const dest = new THREE.Vector3(
+      foco.x + (entrando ? 0.55 : 0.4 + vagarX),
+      foco.y + (entrando ? 1.05 : 2.3) + bob,
+      foco.z + (entrando ? 0.7 : 0.6 + vagarZ),
+    );
+    ref.current.position.lerp(dest, entrando ? 0.05 : 0.045);
+    if (caraRef.current) {
+      const vx = ref.current.position.x - prevX.current;
+      if (Math.abs(vx) > 0.0015) caraRef.current.style.transform = `scaleX(${vx < 0 ? -1 : 1})`;
+      prevX.current = ref.current.position.x;
+    }
+  });
+  const size = 44 + Math.round(energia * 14);
+  return (
+    <group ref={ref} position={[foco.x + 0.4, foco.y + 2.3, foco.z + 0.6]}>
+      <Html center distanceFactor={9} zIndexRange={[40, 10]}>
+        <div className="valle-abeja" aria-hidden="true">
+          <div ref={caraRef} className="valle-abeja__cara">
+            <AbejaAngelita size={size} animo={animo} energia={energia} animated={!reducedMotion} />
+          </div>
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+/* ── Cámara: viaja suavemente hacia el foco (target) cuando cambia de mundo Y
+      HACE ZOOM hacia el lugar — la sensación de ENTRAR con la abeja, no un modal
+      plano. El acercamiento solo se fuerza durante la transición (una vez llega,
+      suelta el control para que el usuario siga haciendo zoom a mano). ── */
+function CamaraViajera({ foco, focoKey, controls, autoOrbit }) {
+  const trans = useRef(0);
+  const prevKey = useRef(focoKey);
+  const entrando = focoKey !== 'valle';
+  useFrame(() => {
+    if (!controls.current) return;
+    const c = controls.current;
+    if (focoKey !== prevKey.current) {
+      trans.current = 1; // arrancó una nueva "entrada": acompañar el zoom
+      prevKey.current = focoKey;
+    }
+    c.target.lerp(new THREE.Vector3(foco.x, foco.y + 0.6, foco.z), 0.06);
+    if (trans.current > 0) {
+      const cam = c.object;
+      const dir = cam.position.clone().sub(c.target);
+      const deseada = entrando ? 8.5 : 15; // acercarse al entrar, abrir al volver
+      dir.setLength(THREE.MathUtils.lerp(dir.length(), deseada, 0.06));
+      cam.position.copy(c.target.clone().add(dir));
+      trans.current = Math.max(0, trans.current - 0.012);
+    }
+    c.update();
+  });
+  return (
+    <OrbitControls
+      ref={controls}
+      makeDefault
+      enablePan={false}
+      enableZoom
+      minDistance={6}
+      maxDistance={22}
+      minPolarAngle={0.5}
+      maxPolarAngle={1.15}
+      autoRotate={autoOrbit && !entrando}
+      autoRotateSpeed={0.35}
+      enableDamping
+      dampingFactor={0.08}
+    />
+  );
+}
+
+/* ── Contenido de la escena (dentro del Canvas). ── */
+function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion }) {
+  const controls = useRef(null);
+  const c = CLIMAS[clima];
+  const foco = useMemo(() => {
+    const m = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;
+    if (!m) return new THREE.Vector3(0, 0.3, 0.5);
+    const y = alturaTerreno(m.pos[0], m.pos[2]);
+    return new THREE.Vector3(m.pos[0], y, m.pos[2]);
+  }, [focoId]);
+  const autoOrbit = !reducedMotion && !focoId;
+  const entrando = !!focoId;
+
+  return (
+    <>
+      <color attach="background" args={[c.cielo[1]]} />
+      <fog attach="fog" args={[c.niebla, 9, c.nieblaLejos]} />
+      <hemisphereLight intensity={c.intensidad * 0.55} color={c.cielo[0]} groundColor={c.ambiente} />
+      <ambientLight intensity={c.intensidad * 0.35} color={c.luz} />
+      <directionalLight
+        position={[6, 9, 4]}
+        intensity={c.intensidad}
+        color={c.luz}
+        castShadow
+        shadow-mapSize={[1024, 1024]}
+        shadow-camera-far={30}
+        shadow-camera-left={-12}
+        shadow-camera-right={12}
+        shadow-camera-top={12}
+        shadow-camera-bottom={-12}
+      />
+      {c.estrellas && (
+        <Stars radius={40} depth={20} count={900} factor={3} fade speed={reducedMotion ? 0 : 1} />
+      )}
+
+      <Terreno colorBase={clima === 'noche' ? '#22432f' : '#5a8a4a'} />
+      <Cordillera color={clima === 'noche' ? '#3a4a63' : c.niebla} />
+      <Quebrada color={clima === 'noche' ? '#2a4a6a' : '#5fb2c9'} viva={c.lluviaViva} />
+
+      {MUNDOS_VALLE.map((m) => (
+        <MundoLugar
+          key={m.id}
+          mundo={m}
+          activo={focoId === m.id}
+          onEntrar={onEntrar}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+
+      <Beacon onAlerta={onAlerta} reducedMotion={reducedMotion} />
+      <CompaneroAbeja
+        foco={foco}
+        entrando={entrando}
+        animo={animo}
+        energia={energia}
+        reducedMotion={reducedMotion}
+      />
+
+      <CamaraViajera
+        foco={foco}
+        focoKey={focoId || 'valle'}
+        controls={controls}
+        autoOrbit={autoOrbit}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+export default function Valle3D({
+  clima,
+  focoId,
+  animo = 'sereno',
+  energia = 1,
+  onEntrar,
+  onAlerta,
+  reducedMotion,
+}) {
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`valle-canvas${listo ? ' valle-canvas--listo' : ''}`}
+      shadows
+      dpr={[1, 1.8]}
+      gl={{ antialias: true, powerPreference: 'high-performance' }}
+      camera={{ position: [9, 8, 11], fov: 42 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Suspense fallback={null}>
+        <Escena
+          clima={clima}
+          focoId={focoId}
+          animo={animo}
+          energia={energia}
+          onEntrar={onEntrar}
+          onAlerta={onAlerta}
+          reducedMotion={reducedMotion}
+        />
+      </Suspense>
+    </Canvas>
+  );
+}

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -1,0 +1,229 @@
+/*
+ * DATOS DE MUESTRA del mockup "El valle de mi finca" (#/mockups/entrada-3d).
+ *
+ * NO cablea sesión, farmOS ni Open-Meteo: es una DECISIÓN VISUAL. Todo lo de
+ * aquí es plausible para una finca andina (~2.400 m) pero inventado con cuidado
+ * para la demo. Si algún día se productiza, estos datos vienen del backend.
+ *
+ * Los 4 "sí-o-sí" de la entrada de Chagra viven en el ESPACIO del valle:
+ *   1. ALERTA / qué-hacer-hoy  → `COSA_DEL_DIA`, anclada sobre un lugar real.
+ *   2. LOS MUNDOS              → `MUNDOS_VALLE`: cada mundo es un LUGAR con
+ *                                coordenadas 3D por el que se viaja.
+ *   3. AGENTE / VOZ            → `NARRACION`: lo que el compañero dice al pasar.
+ *   4. ESTADO / CLIMA          → `CLIMAS`: tiñe el ambiente (grades de effects).
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- mockup dev con datos de
+   muestra (no UI de producto); si se productiza, el copy migra a messages.js
+   (ADR-050). */
+
+import { MUNDO_BY_ID } from '../../components/dashboard/mundosFinca';
+
+/* ── 2. LOS MUNDOS COMO LUGARES ─────────────────────────────────────────────
+ * Un subconjunto curado de los mundos reales (mundosFinca.js) colocados en el
+ * valle. `pos` = [x, y, z] en el terreno; `escala` y `tipo` deciden qué forma
+ * procedural los representa (sin GLTF: todo es geometría de three, offline y
+ * liviana). El título/emoji/tinte se LEEN del manifiesto real — no se duplican.
+ */
+const LUGARES = [
+  { id: 'cultivos', pos: [-3.2, 0, 1.6], escala: 1.15, tipo: 'milpa' },
+  { id: 'cafe', pos: [3.4, 0, 2.2], escala: 1, tipo: 'cafetal' },
+  { id: 'suelo', pos: [-1.1, 0, 3.6], escala: 1, tipo: 'era' },
+  { id: 'agua', pos: [0.6, 0, -1.4], escala: 1, tipo: 'quebrada' },
+  { id: 'animales', pos: [-4.6, 0, -1.8], escala: 1, tipo: 'corral' },
+  { id: 'sanidad', pos: [1.8, 0, 4.4], escala: 0.95, tipo: 'huerta' },
+  { id: 'disenio', pos: [4.8, 0, -2.6], escala: 1.1, tipo: 'bosque' },
+  { id: 'clima', pos: [-3.8, 0, -4.8], escala: 1, tipo: 'veleta' },
+];
+
+/**
+ * Mundos del valle, ya resueltos contra el manifiesto real. Cada uno trae su
+ * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar.
+ */
+export const MUNDOS_VALLE = LUGARES.map((l) => {
+  /** @type {{ titulo?: string, emoji?: string, lema?: string, tinte?: string[] }} */
+  const real = MUNDO_BY_ID[l.id] || {};
+  return {
+    ...l,
+    titulo: real.titulo || l.id,
+    emoji: real.emoji || '📍',
+    lema: real.lema || '',
+    tinte: real.tinte || ['#3f8f4e', '#dcedc9'],
+  };
+});
+
+export const MUNDO_VALLE_BY_ID = Object.fromEntries(
+  MUNDOS_VALLE.map((m) => [m.id, m]),
+);
+
+/* ── 1. LA COSA DEL DÍA (una sola, anclada a un lugar) ───────────────────────
+ * Un único destello: la alerta del día aparece DONDE toca. Aquí, una helada
+ * nocturna sobre el semillero (el mundo 'suelo'/eras). Tocarla = el agente lo
+ * dice en voz alta y ofrece LA acción (no un tablero).
+ */
+export const COSA_DEL_DIA = {
+  anclaMundo: 'suelo',
+  tono: 'helada',
+  titulo: 'Helada esta noche',
+  detalle:
+    'En la parte alta puede helar de madrugada. Cubra el semillero antes de que caiga el sol.',
+  vozTexto:
+    'Ojo con la finca hoy: esta madrugada puede helar en la parte alta. Cúbrale el semillero antes de que caiga el sol, que el frío le quema la matica tierna.',
+  accion: { etiqueta: 'Ver cómo proteger del frío', view: 'hoy_finca' },
+};
+
+/* ── EL COMPAÑERO: ANGELITA, LA ABEJA DE LA FINCA ────────────────────────────
+ * El avatar-jugador del valle. No es un widget: es un ser al que se cuida (ref
+ * Finch). Su ÁNIMO y su ENERGÍA salen del ESTADO REAL de la finca — cuántas
+ * matas están vivas, cómo está el agua, y qué clima hace. Datos de MUESTRA: si
+ * se productiza, `SALUD_FINCA` viene del backend (logs de matas + Open-Meteo).
+ */
+export const SALUD_FINCA = {
+  matasVivas: 34,
+  matasTotal: 41,
+  agua: 0.72, // 0..1 — humedad/reserva de la quebrada y el tanque
+};
+
+/**
+ * Ánimo de la abeja según cómo está la finca hoy. Devuelve el ánimo (piel de la
+ * creature), la energía (0..1, vivacidad del vuelo/aura) y una frase corta en
+ * usted — puntual, sin muros de texto. Prioridad: alerta > sed > clima > salud.
+ */
+export function animoDeFinca(clima, { hayAlerta = false, salud = SALUD_FINCA } = {}) {
+  const vivas = salud.matasTotal > 0 ? salud.matasVivas / salud.matasTotal : 1;
+  // Energía base: mezcla de matas vivas y agua, atenuada por el clima duro.
+  const climaFactor = clima === 'noche' ? 0.55 : clima === 'lluvia' ? 0.8 : 1;
+  const energia = Math.max(0.35, Math.min(1, (vivas * 0.65 + salud.agua * 0.35) * climaFactor));
+
+  if (hayAlerta) {
+    return {
+      animo: 'atento',
+      energia,
+      frase: 'Angelita anda pendiente: hay algo que atender hoy.',
+    };
+  }
+  if (salud.agua < 0.35) {
+    return {
+      animo: 'sediento',
+      energia,
+      frase: 'La abeja la ve con sed: a la finca le hace falta agua.',
+    };
+  }
+  if (clima === 'noche') {
+    return {
+      animo: 'descansa',
+      energia,
+      frase: 'Angelita descansa; la finca duerme tranquila esta noche.',
+    };
+  }
+  if (vivas >= 0.85 && salud.agua >= 0.55) {
+    return {
+      animo: 'pleno',
+      energia,
+      frase: 'Angelita anda contenta: sus matas están vivas y con agua.',
+    };
+  }
+  return {
+    animo: 'sereno',
+    energia,
+    frase: 'La abeja anda serena, echándole ojo a la finca.',
+  };
+}
+
+/* ── 4. EL CLIMA QUE TIÑE EL AMBIENTE ────────────────────────────────────────
+ * Reusa las grades de luz de la librería de efectos (src/visual/effects):
+ * `grade` = clase modificadora .vfx-grade--* aplicada a un velo DOM sobre el
+ * canvas; `cielo`/`luz`/`niebla` alimentan la iluminación de la escena 3D.
+ * Una sola geometría, varias "pieles" según el estado real de la vereda.
+ */
+export const CLIMAS = {
+  dorada: {
+    etiqueta: 'Hora dorada',
+    grade: 'vfx-grade--templado',
+    cielo: ['#f7c66b', '#e88a4a'],
+    luz: '#ffd79a',
+    ambiente: '#8a6b4a',
+    niebla: '#f0c98d',
+    nieblaLejos: 30,
+    intensidad: 1.15,
+    estrellas: false,
+  },
+  soleado: {
+    etiqueta: 'Soleado',
+    grade: 'vfx-grade--calido',
+    cielo: ['#8fd0e8', '#d7eef6'],
+    luz: '#fff4d6',
+    ambiente: '#9fb6a0',
+    niebla: '#d7eef6',
+    nieblaLejos: 38,
+    intensidad: 1.35,
+    estrellas: false,
+  },
+  niebla: {
+    etiqueta: 'Niebla',
+    grade: 'vfx-grade--paramo',
+    cielo: ['#b9c7cc', '#d7dee0'],
+    luz: '#cdd8da',
+    ambiente: '#8f9ea1',
+    niebla: '#c3cfd2',
+    nieblaLejos: 15,
+    intensidad: 0.85,
+    estrellas: false,
+  },
+  lluvia: {
+    etiqueta: 'Lluvia',
+    grade: 'vfx-grade--frio',
+    cielo: ['#5b6b74', '#8a99a0'],
+    luz: '#aab6bc',
+    ambiente: '#6c7a80',
+    niebla: '#7d8a90',
+    nieblaLejos: 20,
+    intensidad: 0.7,
+    lluviaViva: true,
+    estrellas: false,
+  },
+  noche: {
+    etiqueta: 'Noche',
+    grade: 'vfx-grade--glacial',
+    cielo: ['#0b1830', '#132a4e'],
+    luz: '#9fc2e8',
+    ambiente: '#26364f',
+    niebla: '#13203a',
+    nieblaLejos: 22,
+    intensidad: 0.5,
+    estrellas: true,
+  },
+};
+
+export const ORDEN_CLIMA = ['dorada', 'soleado', 'niebla', 'lluvia', 'noche'];
+
+/**
+ * Estado por defecto según la hora REAL del dispositivo (ancla de veracidad,
+ * como Apple Weather): madrugada/noche → noche; media mañana → soleado; tarde
+ * → hora dorada. Un dato verdadero, no decoración inventada.
+ */
+export function climaPorHora(fecha = new Date()) {
+  const h = fecha.getHours();
+  if (h >= 19 || h < 5) return 'noche';
+  if (h >= 16) return 'dorada';
+  if (h >= 11) return 'soleado';
+  return 'dorada';
+}
+
+/* ── 3. LO QUE EL AGENTE DICE AL PASAR ───────────────────────────────────────
+ * El compañero (colibrí) narra el mundo cuando la cámara viaja hacia él. Texto
+ * corto, cálido, en usted; se lee por voz (Web Speech API) si el equipo la trae.
+ */
+export const NARRACION = {
+  bienvenida:
+    'Bienvenido a su finca. Toque un lugar del valle para viajar hasta él, o toque la señal que brilla para saber qué toca hacer hoy.',
+  cultivos:
+    'Aquí está su milpa: maíz, fríjol y calabaza creciendo juntos como las tres hermanas.',
+  cafe: 'El cafetal en la ladera. Estas maticas ya están cargando para la próxima cosecha.',
+  suelo: 'Las eras y el semillero. La tierra de aquí es la que pide cuidado esta noche.',
+  agua: 'La quebrada que baja del monte. De aquí sale el agua para toda la finca.',
+  animales: 'El corral. Las gallinas y el ganado que cierran el ciclo del abono.',
+  sanidad:
+    'La huerta de la casa. Aquí es donde primero se ven las plagas, para atajarlas a tiempo.',
+  disenio: 'El monte y los árboles que sembró. La finca también es el bosque que la abraza.',
+  clima: 'Desde aquí se lee el cielo: lo que viene, y qué conviene hacer con la finca.',
+};

--- a/src/visual/README.md
+++ b/src/visual/README.md
@@ -1,0 +1,78 @@
+# `src/visual` — la librería visual reutilizable de Chagra
+
+Fuente **única** de las piezas visuales del repo, para **dejar de redibujar** lo
+mismo en cada pantalla/mockup. Se consulta viva en la vitrina
+`#/mockups/visual-lib` (storybook), alimentada por el registro consolidado
+[`registry.js`](./registry.js).
+
+## La regla de la casa (reuso)
+
+> **Antes de dibujar cualquier cosa — un bicho, un velo, una lámina, un cielo,
+> un mundo — búsquela aquí primero.**
+> - Si existe → **reúsela** (y si puede, **mejore** la versión canónica en su
+>   archivo, para que todos hereden la mejora).
+> - Si dibuja algo nuevo reutilizable → **agréguelo en el mismo PR** (componente +
+>   su barrel `index.js` + su fila en `registry.js` con sus **tags**).
+
+Reglas duras compartidas: SVG/geometría **propia** (cero stock, cero
+dependencias nuevas ni assets remotos — offline-first); solo `transform`/`opacity`
+animados, filtros estáticos; ids con `useId`; `prefers-reduced-motion` con un
+fotograma final digno; copy en **español Colombia (usted)**, sin voseo.
+
+## Las familias
+
+| Carpeta | Qué vive ahí | `dim` · `role` |
+| --- | --- | --- |
+| [`creatures/`](./creatures) | Fauna de la chagra (abeja, colibrí, lombriz…). | `2d` · `creature` |
+| [`effects/`](./effects) | Técnicas de cine: glow, acuarela, auto-dibujo, grades. | `2d` · `effect` |
+| [`laminas/`](./laminas) | Hojas de cuaderno: la mata o la labor dibujada. | `2d` · `lamina` |
+| [`scenes/`](./scenes) | Decorados base: cielo, parallax, guardián, finca-organismo. | `2d` · `scene` |
+| [`voz/`](./voz) | `IrisVoz` — la identidad de la voz con forma. | `2d` · `voz` |
+| [`mundo3d/`](./mundo3d) | **El framework de MUNDOS** (2D + 3D data-driven). | `3d`/`2d` · `mundo3d-archetype`… |
+
+## Tags filtrables en el registro
+
+Cada pieza de `registry.js` declara metadatos filtrables — al menos
+`dim: '2d' | '3d'` y `role`. Helpers exportados:
+
+```js
+import { piezas3D, piezasCapaces3D, piezasPorRole } from 'src/visual/registry.js';
+
+piezas3D();          // los 5 arquetipos de escena (dim === '3d')
+piezasCapaces3D();   // + la abeja (avatar) e IrisVoz (capaz3d)
+piezasPorRole('lamina');
+```
+
+## El framework de MUNDOS (2D + 3D por datos)
+
+`mundo3d/` es la pieza clave: **un solo host `<Mundo>`** que construye cualquier
+mundo de la finca eligiendo un **arquetipo** por datos y cruzándolo con el
+device-tier del equipo. Sumar un mundo = **una entrada de datos + assets de esta
+librería**, sin código de escena nuevo.
+
+**Sumar un mundo NUEVO (2D o 3D) — el contrato en 3 pasos:**
+
+1. **Escoja un arquetipo YA existente** en `mundo3d/arquetipos.js`:
+   - **3D** (dioramas): `cutaway` (suelo/compost), `flujo` (agua), `recinto`
+     (animales), `estratos` (bosque/diseño), `valle` (el mapa).
+   - **2D de primera clase**: `lamina` (reusa `src/visual/laminas`), `infografia`
+     (dato/cifras), `ficha` (especie), `mirror` (espejo 2D de un 3D), `valle2d`.
+2. **Agregue UNA entrada** en `mundo3d/mundoData.js`:
+   ```js
+   miMundo: {
+     escena: 'cutaway',              // arquetipo (3D o 2D) — o null para ir directo al 2D real
+     params: { /* capas, cifras, lamina… propias del arquetipo */ },
+     hotspots: [                     // 3-5 puntos; cada `view` es una vista REAL de App.jsx
+       { id: 'x', pos: [0, 0.6, 0.3], emoji: '🪱', label: 'Abrir…', view: 'subsuelo' },
+     ],
+     entrada: { zoom: 6.5, narra: 'miMundo' },
+   },
+   ```
+3. **Nada más.** No se toca `<Mundo>`, ni los arquetipos, ni R3F. El
+   device-tier decide 3D vs 2D; en equipo humilde el 3D cae a su **espejo 2D
+   digno** con los mismos hotspots. Título/emoji/tinte se resuelven del
+   manifiesto real (`mundosFinca.js`), no se duplican.
+
+Solo se escribe R3F/SVG de escena cuando aparece una **metáfora espacial
+genuinamente nueva** (rarísimo): se añade UN arquetipo `Escena*` al mapa y queda
+reutilizable por todos. Detalle completo en [`mundo3d/README.md`](./mundo3d/README.md).

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -2,41 +2,91 @@ import { useId } from 'react';
 import './creatures.css';
 import { CreatureFilters } from './_filters.jsx';
 
-/* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
-   Apis). Cuerpo ámbar rayado, cabeza clara, alitas de tul. Versión canónica
-   deducida del mockup "Guardianes que aparecen". */
-const VIEWBOX = '-15 -15 32 30';
+/* Abeja angelita — Tetragonisca angustula, la abeja NATIVA sin aguijón de los
+   Andes (mansa, dorada, guardiana de la finca). Es el COMPAÑERO-JUGADOR del
+   valle: vuela por el mundo y "entra" a cada lugar. No es un mascota infantil —
+   es un ser al que se cuida (ref Finch): su ÁNIMO y su ENERGÍA cambian el color,
+   el aura y la vivacidad según cómo está la finca de verdad.
+
+   Coreografía de vuelo/llegada = de la ESCENA que la consume (Valle3D / 2D).
+   Aquí solo vive el cuerpo: SVG + CSS puros, solo transform/opacity (GPU,
+   Android gama baja), aleteo reutilizando .crt-wing de creatures.css. */
+const VIEWBOX = '-16 -15 34 30';
+
+/* Paletas por ánimo (estado real de la finca leído en el valle). Maduras,
+   cálidas — nunca chillonas. `aura` es el halo; `cuerpo`/`banda` el insecto. */
+const ANIMOS = {
+  pleno: { cuerpo: '#f3b229', banda: '#7a4a12', aura: '#ffd772', vida: 1 },
+  sereno: { cuerpo: '#e6a637', banda: '#7a4a12', aura: '#f4c66a', vida: 0.82 },
+  atento: { cuerpo: '#f0a233', banda: '#6f3d10', aura: '#ffb352', vida: 0.9 },
+  sediento: { cuerpo: '#cdae6e', banda: '#6b5330', aura: '#cfe0d6', vida: 0.6 },
+  descansa: { cuerpo: '#c9a24a', banda: '#5a4526', aura: '#9fb6d6', vida: 0.45 },
+};
 
 export function AbejaAngelita({
   size = 64,
-  className,
+  className = '',
   inline = false,
   animated = true,
-  title = 'Abeja angelita',
+  animo = 'sereno',
+  energia = 1,
+  title = 'Angelita, la abeja de su finca',
   ...rest
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   const glow = `crt-glow-${uid}`;
   const blur = `crt-blur-${uid}`;
+  const clip = `crt-clip-${uid}`;
   const wing = animated ? 'crt-wing' : undefined;
+
+  const a = ANIMOS[animo] || ANIMOS.sereno;
+  const e = Math.max(0.35, Math.min(1, energia));
+  // El aura respira con la energía; la vitalidad del ánimo la matiza.
+  const auraOp = 0.16 + 0.34 * e * a.vida;
 
   const defs = (
     <defs>
       <CreatureFilters glow={glow} blur={blur} />
+      <clipPath id={clip}>
+        {/* abdomen: la elipse que recorta las bandas para que no se desborden */}
+        <ellipse cx="-1.5" cy="1.5" rx="8.5" ry="6" />
+      </clipPath>
     </defs>
   );
+
   const body = (
     <g className="crt-body" filter={`url(#${glow})`}>
-      <circle r="6" fill="#ffb54f" opacity="0.35" filter={`url(#${blur})`} />
-      <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
-        style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
-      <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
-        stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
-      <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
-      <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
-      <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
-      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
-      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+      {/* aura viva: el halo que refleja el ánimo/energía de la finca */}
+      <circle r="12" cx="-1" cy="1" fill={a.aura} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* alas translúcidas que baten (arriba del tórax) */}
+      <ellipse className={wing} cx="1.5" cy="-6.5" rx="5.5" ry="3.4" fill="#dff3ff" opacity="0.72"
+        transform="rotate(-24 1.5 -6.5)" />
+      <ellipse className={wing} style={{ animationDelay: '-0.05s' }} cx="4.5" cy="-6" rx="4.6" ry="3"
+        fill="#c8e8ff" opacity="0.5" transform="rotate(-6 4.5 -6)" />
+
+      {/* patas finas bajo el cuerpo (quietas, dan peso) */}
+      <path d="M-3,6 L-4.5,9 M0,6.5 L0.5,9.6 M3,6 L4.8,8.8" stroke={a.banda} strokeWidth="0.8"
+        fill="none" strokeLinecap="round" opacity="0.85" />
+
+      {/* abdomen dorado con bandas (recortadas al contorno) */}
+      <ellipse cx="-1.5" cy="1.5" rx="8.5" ry="6" fill={a.cuerpo} />
+      <g clipPath={`url(#${clip})`}>
+        <rect x="-6.5" y="-5" width="2.6" height="14" rx="1.3" fill={a.banda} opacity="0.9"
+          transform="rotate(12 -5 1.5)" />
+        <rect x="-1.6" y="-5" width="2.8" height="14" rx="1.4" fill={a.banda} opacity="0.92"
+          transform="rotate(12 -0.2 1.5)" />
+      </g>
+      {/* brillo suave del lomo */}
+      <ellipse cx="-2.5" cy="-1.2" rx="4.2" ry="2" fill="#fff2c8" opacity="0.5" />
+
+      {/* cabeza (a la derecha = hacia donde vuela) + ojo */}
+      <circle cx="7.6" cy="-0.6" r="3.6" fill={a.banda} />
+      <circle cx="8.9" cy="-1.4" r="1.15" fill="#1b1205" />
+      <circle cx="9.3" cy="-1.8" r="0.4" fill="#fff6e2" />
+      {/* antenas */}
+      <path d="M9.4,-3.2 C11.4,-5 12.6,-5.4 13.6,-6.6 M8.4,-3.6 C9.6,-6 10.4,-6.8 10.9,-8.4"
+        stroke={a.banda} strokeWidth="0.85" fill="none" strokeLinecap="round" />
     </g>
   );
 

--- a/src/visual/effects/AutoDibujo.jsx
+++ b/src/visual/effects/AutoDibujo.jsx
@@ -23,7 +23,11 @@
  * Resto de props (`d`, `stroke`, `strokeWidth`, `fill`, `cx`…) se pasan tal cual.
  */
 export function AutoDibujo({ as = 'path', stage, fade = false, className, ...rest }) {
-  const El = /** @type {import('react').ElementType} */ (as);
+  /* `any` irreducible: la augmentación GLOBAL de JSX de @react-three/fiber (que
+     entra al programa vía las escenas 3D de src/visual/mundo3d) rompe el tipado
+     de un elemento DINÁMICO (className→never en un ElementType genérico). El
+     runtime es idéntico; solo se relaja el chequeo de tipos de este `<El>`. */
+  const El = /** @type {any} */ (as);
   const base = fade ? 'vfx-fade' : 'vfx-draw';
   const stageClass = stage ? ` vfx-t${stage}` : '';
   const cls = `${base}${stageClass}${className ? ` ${className}` : ''}`;

--- a/src/visual/effects/GlowFilter.jsx
+++ b/src/visual/effects/GlowFilter.jsx
@@ -20,7 +20,7 @@
  * @param {string} [props.bounds='-80%']  origen del box del filtro (x/y); el
  *                                        ancho/alto se calculan como 100%-2*bounds.
  */
-export function GlowFilter({ id, std = 2.1, blurId, blurStd = 3, bounds = '-80%' }) {
+export function GlowFilter({ id, std = 2.1, blurId = '', blurStd = 3, bounds = '-80%' }) {
   const off = parseFloat(bounds); // -80  → box de 260%
   const size = `${100 - 2 * off}%`;
   return (

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -1,0 +1,97 @@
+/*
+ * <Mundo> — EL HOST ÚNICO del framework de mundos (2D + 3D en una sola pieza).
+ *
+ *   <Mundo mundoId tier reducedMotion onHotspot onSalir animo energia />
+ *
+ * Lee el registro `MUNDO[mundoId]`, resuelve el PLAN con `resolverMundo` (que
+ * cruza el arquetipo con el device-tier) y monta lo que toca:
+ *   · 3D  → el diorama del arquetipo (chunk perezoso `vendor-three`).
+ *   · 2D  → el arquetipo 2D (de primera clase o el espejo de un 3D degradado).
+ *   · ruta→ escena:null: no monta nada; el host debe navegar a `plan.ruta.view`
+ *           (regla de oro: el mundo NUNCA reimplementa la pantalla 2D, la re-rutea).
+ *
+ * Nada de lógica de negocio adentro: solo lee datos y elige arquetipo. Sumar un
+ * mundo = una entrada en `mundoData.js`, sin tocar este archivo.
+ */
+import { lazy, Suspense } from 'react';
+import { resolverMundo, tinteDeMundo } from './resolverMundo.js';
+import Mundo2D from './Mundo2D.jsx';
+import './mundo.css';
+
+/* Los dioramas 3D se cargan PEREZOSO: three/@react-three viven en su propio
+   chunk (`vendor-three`, vite.config), fuera del bundle base. */
+const ESCENAS_3D = {
+  cutaway: lazy(() => import('./escenas/EscenaCutaway.jsx')),
+  flujo: lazy(() => import('./escenas/EscenaFlujo.jsx')),
+  recinto: lazy(() => import('./escenas/EscenaRecinto.jsx')),
+  estratos: lazy(() => import('./escenas/EscenaEstratos.jsx')),
+  valle: lazy(() => import('./escenas/EscenaValle.jsx')),
+};
+
+function MundoCargando({ tinte }) {
+  return (
+    <div className="mundo-cargando" style={{ '--m-tinte': (tinte && tinte[0]) || '#3f8f4e' }}>
+      <div className="mundo-cargando__pulso" />
+      <p>Levantando el mundo…</p>
+    </div>
+  );
+}
+
+function SalirBtn({ onSalir }) {
+  if (!onSalir) return null;
+  return (
+    <button type="button" className="mundo-salir" onClick={() => onSalir()} aria-label="Volver al valle">
+      ‹ Volver
+    </button>
+  );
+}
+
+export default function Mundo({
+  mundoId, tier = 'alto', reducedMotion = false, onHotspot, onSalir, animo = 'sereno', energia = 1,
+}) {
+  const plan = resolverMundo(mundoId, tier);
+  const tinte = tinteDeMundo(mundoId);
+
+  // Sin escena o mundo ausente: el host navega al 2D real (no montamos nada).
+  if (plan.modo === 'ausente' || plan.modo === 'ruta') return null;
+
+  if (plan.modo === '3d') {
+    const Escena = ESCENAS_3D[plan.escena];
+    if (!Escena) return null;
+    return (
+      <div className="mundo-root" data-dim="3d" data-mundo={mundoId}>
+        <Suspense fallback={<MundoCargando tinte={tinte} />}>
+          <Escena
+            params={plan.entrada.params}
+            hotspots={plan.entrada.hotspots}
+            entrada={plan.entrada.entrada}
+            tinte={tinte}
+            reducedMotion={reducedMotion}
+            onHotspot={onHotspot}
+            onSalir={onSalir}
+            animo={animo}
+            energia={energia}
+          />
+        </Suspense>
+        <SalirBtn onSalir={onSalir} />
+      </div>
+    );
+  }
+
+  // 2D
+  return (
+    <div className="mundo-root" data-dim="2d" data-mundo={mundoId}>
+      <Mundo2D
+        escena={plan.escena}
+        motivo={plan.motivo}
+        entrada={plan.entrada}
+        tinte={tinte}
+        reducedMotion={reducedMotion}
+        onHotspot={onHotspot}
+        animo={animo}
+        energia={energia}
+      />
+      <SalirBtn onSalir={onSalir} />
+    </div>
+  );
+}

--- a/src/visual/mundo3d/Mundo2D.jsx
+++ b/src/visual/mundo3d/Mundo2D.jsx
@@ -1,0 +1,44 @@
+/*
+ * Mundo2D — el HOST de los arquetipos 2D (SVG/DOM, three-free).
+ *
+ * Monta el arquetipo 2D resuelto por `resolverMundo`: sea un arquetipo de primera
+ * clase (mercado→`infografia`, cultivo→`lamina`, especie→`ficha`) o el ESPEJO de
+ * un diorama 3D degradado (`mirror` con su `motivo`, o `valle2d`). Es el "piso
+ * digno" garantizado: sin WebGL, sin three, siempre renderiza.
+ *
+ * NO importa nada de `three`/`@react-three` — por eso el 2D es fiable y liviano.
+ */
+import LaminaMundo from './laminas2d/LaminaMundo.jsx';
+import Infografia from './laminas2d/Infografia.jsx';
+import Ficha from './laminas2d/Ficha.jsx';
+import LaminaCultivo from './laminas2d/LaminaCultivo.jsx';
+import MundoValle2D from './laminas2d/MundoValle2D.jsx';
+
+const MAPA_2D = {
+  mirror: LaminaMundo,
+  infografia: Infografia,
+  ficha: Ficha,
+  lamina: LaminaCultivo,
+  valle2d: MundoValle2D,
+};
+
+export default function Mundo2D({
+  escena, entrada, motivo, tinte, reducedMotion, onHotspot, animo, energia,
+}) {
+  const Comp = MAPA_2D[escena];
+  if (!Comp) return null;
+  return (
+    <Comp
+      params={entrada?.params}
+      hotspots={entrada?.hotspots}
+      entrada={entrada}
+      tinte={tinte}
+      motivo={motivo}
+      reducedMotion={reducedMotion}
+      onHotspot={onHotspot}
+      animo={animo}
+      energia={energia}
+      titulo={entrada?.titulo}
+    />
+  );
+}

--- a/src/visual/mundo3d/README.md
+++ b/src/visual/mundo3d/README.md
@@ -1,0 +1,108 @@
+# `src/visual/mundo3d` — el framework de MUNDOS (2D + 3D data-driven)
+
+Un solo host **`<Mundo>`** construye cualquier mundo de la finca eligiendo un
+**arquetipo** por datos y cruzándolo con el **device-tier** del equipo. El
+objetivo (DR-MUNDOS-3D-FRAMEWORK): **sumar un mundo = una entrada de datos +
+assets de la librería visual; nunca código de escena desde cero.**
+
+Un principio, dos dimensiones de PRIMERA CLASE:
+
+- **3D** cuando el espacio ENSEÑA (lo invisible del subsuelo, la pendiente del
+  agua, la verticalidad del bosque, el ciclo del corral, el mapa del valle).
+- **2D** cuando el valor ES el dato/foto/diagnóstico (mercado, sanidad, fichas de
+  cultivo). No es "el fallback tonto": es un arquetipo que un mundo declara
+  DIRECTO. Y todo diorama 3D cae a un **espejo 2D digno** en equipos humildes.
+
+## El contrato de `<Mundo>`
+
+```jsx
+import Mundo from 'src/visual/mundo3d';
+
+<Mundo
+  mundoId="suelo"        // clave de MUNDO[] (mundoData.js)
+  tier="alto"            // 'alto'|'medio'|'bajo'|'2d' — de decidirTier()
+  reducedMotion={false}
+  onHotspot={(view, data) => onNavigate(view, data)}  // re-rutea a una vista 2D REAL
+  onSalir={() => volverAlValle()}
+  animo="sereno" energia={0.8}   // de la salud real de la finca (la abeja)
+/>
+```
+
+- **Regla de oro (reachability):** todo `hotspot.view` es un `case` real de
+  `App.jsx`. El mundo **nunca** reimplementa la pantalla 2D — la **re-rutea**.
+- **Nada de lógica de negocio** dentro de `<Mundo>`: solo lee datos y elige
+  arquetipo. Sumar un mundo no toca este componente.
+
+## Las capas (archivos)
+
+| Archivo | Qué es |
+| --- | --- |
+| `mundoData.js` | **El registro `MUNDO[id]`** — una entrada por mundo (el corazón). |
+| `arquetipos.js` | El set CERRADO y filtrable de arquetipos (`dim`, `role`, espejo). |
+| `resolverMundo.js` | Función pura: `(mundoId, tier) → plan { modo, escena, entrada }`. |
+| `deviceTier.js` | `decidirTier()` — device-tiering heredado del valle (alto/medio/bajo). |
+| `Mundo.jsx` | El host: 2D estático + 3D **perezoso** adentro. |
+| `Mundo2D.jsx` | Host de los arquetipos 2D (three-free, siempre fiable). |
+| `escenas/` | Los dioramas 3D (`vendor-three`, cargados perezoso). |
+| `laminas2d/` | Los arquetipos 2D (mirror, infografia, ficha, lamina, valle2d). |
+
+## Los arquetipos
+
+**3D (dioramas low-poly, `escenas/`):**
+
+| clave | qué enseña | espejo 2D | mundos |
+| --- | --- | --- | --- |
+| `cutaway` | el corte del suelo/compost (vida invisible) | `mirror` | suelo, abono |
+| `flujo` | el camino del agua (gravedad y pendiente) | `mirror` | agua |
+| `recinto` | el corral y su ciclo cerrado del abono | `mirror` | animales |
+| `estratos` | la verticalidad del bosque comestible | `mirror` | disenio |
+| `valle` | el mapa navegable (reusa `Valle3D`) | `valle2d` | valle |
+
+**2D de primera clase (`laminas2d/`):**
+
+| clave | qué es | mundos |
+| --- | --- | --- |
+| `lamina` | ficha ilustrada, reusa `src/visual/laminas` | cultivos, cafe |
+| `infografia` | dato/cifras/dosis | mercado, sanidad |
+| `ficha` | tarjeta de especie foto-secuencial | frutales |
+| `mirror` | el espejo 2D SVG de un diorama 3D degradado | (auto) |
+| `valle2d` | el mapa isométrico SVG (`Valle2DFallback`) | (auto) |
+
+## Cómo se ve "sumar un mundo"
+
+**1) Mundo 2D-dato** (otra ficha/tabla) — minutos:
+```js
+mercado: {
+  escena: 'infografia',
+  params: { titulo: 'Mercado y despensa', cifras: [...], notas: [...] },
+  hotspots: [{ id: 'vender', emoji: '🤝', label: 'Vender y comprar', view: 'mercado' }],
+},
+```
+
+**2) Mundo SÍ-3D que reusa arquetipo** (p. ej. compost → `cutaway`) — una
+entrada de datos, **cero código 3D**:
+```js
+abono: {
+  escena: 'cutaway',
+  params: { vida: 0.55, capas: [ { nombre:'cobertura', color:'#8a6a3a', alto:0.5, bichos:['hifa'] }, … ] },
+  hotspots: [{ id:'compost', pos:[0,0.6,0.6], emoji:'🍂', label:'El compost, paso a paso', view:'compost' }],
+  entrada: { zoom: 6, narra: 'abono' },
+},
+```
+
+**3) Mundo con metáfora NUEVA** (raro) — se añade UN arquetipo `Escena*` a
+`escenas/` (la única vez que se escribe R3F) componiendo `EscenaBase3D`, y queda
+reutilizable por todos.
+
+## Rendimiento y offline (DR §6)
+
+- Dioramas **frugales**: `MeshLambert`/`MeshBasic`, **sin sombras**, sin
+  post-proceso, `dpr={[1,1.5]}`, `AdaptiveDpr`, `frameloop='demand'` con
+  reduced-motion. Geometría **100% procedural** — cero GLTF/HDR/fuentes remotas.
+- `three`/`@react-three` viven en el chunk **`vendor-three`** (perezoso). El
+  barrel de este framework **no** los importa; los dioramas se cargan a demanda
+  desde `<Mundo>`. El 2D **nunca** toca `three` → es el piso digno garantizado.
+- La abeja **Angelita** (`src/visual/creatures`) es el avatar-jugador; su
+  coreografía de entrada la comparte `escenas/useEntradaAbeja.jsx` (la creature
+  posee el cuerpo, la escena posee la coreografía). `IrisVoz` (`src/visual/voz`)
+  es la voz que nombra el mundo al entrar.

--- a/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
+++ b/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import Mundo from '../Mundo.jsx';
+import { resolverMundo } from '../resolverMundo.js';
+import { MUNDO } from '../mundoData.js';
+import { ARQUETIPOS, ARQUETIPOS_3D, ARQUETIPOS_2D } from '../arquetipos.js';
+
+afterEach(() => cleanup());
+
+describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
+  test('arquetipos: 5 dioramas 3D + arquetipos 2D de primera clase', () => {
+    expect(ARQUETIPOS_3D.sort()).toEqual(['cutaway', 'estratos', 'flujo', 'recinto', 'valle']);
+    ['lamina', 'infografia', 'ficha', 'mirror', 'valle2d'].forEach((k) => {
+      expect(ARQUETIPOS_2D).toContain(k);
+      expect(ARQUETIPOS[k].dim).toBe('2d');
+    });
+  });
+
+  test('tier decide 3D vs 2D para un mundo SÍ-3D (suelo → cutaway)', () => {
+    const alto = resolverMundo('suelo', 'alto');
+    expect(alto.modo).toBe('3d');
+    expect(alto.escena).toBe('cutaway');
+    // equipo humilde → cae al espejo 2D del arquetipo, con su motivo
+    const bajo = resolverMundo('suelo', 'bajo');
+    expect(bajo.modo).toBe('2d');
+    expect(bajo.escena).toBe('mirror');
+    expect(bajo.motivo).toBe('cutaway');
+  });
+
+  test('un mundo 2D-dato declara su arquetipo DIRECTO (mercado → infografia)', () => {
+    const r = resolverMundo('mercado', 'alto'); // aun en tier alto sigue 2D
+    expect(r.modo).toBe('2d');
+    expect(r.escena).toBe('infografia');
+  });
+
+  test('escena:null salta directo a la vista 2D real (clima → hoy_finca)', () => {
+    const r = resolverMundo('clima', 'alto');
+    expect(r.modo).toBe('ruta');
+    expect(r.ruta.view).toBe('hoy_finca');
+  });
+
+  test('todo hotspot.view existe (reachability básica del registro)', () => {
+    Object.values(MUNDO).forEach((d) => {
+      (d.hotspots || []).forEach((h) => {
+        expect(typeof h.view).toBe('string');
+        expect(h.view.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  test('<Mundo> monta un mundo 2D sin lanzar (sin three, three-free)', () => {
+    // mercado es 2D nativo; no monta Canvas → seguro en jsdom.
+    const { container } = render(
+      <Mundo mundoId="mercado" tier="alto" onHotspot={() => {}} onSalir={() => {}} />,
+    );
+    expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+    // el espejo 2D de un 3D degradado también es three-free:
+    cleanup();
+    const { container: c2 } = render(
+      <Mundo mundoId="suelo" tier="bajo" onHotspot={() => {}} onSalir={() => {}} />,
+    );
+    expect(c2.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+  });
+});

--- a/src/visual/mundo3d/__tests__/mundoAgua.test.jsx
+++ b/src/visual/mundo3d/__tests__/mundoAgua.test.jsx
@@ -1,0 +1,91 @@
+/*
+ * EL MUNDO DEL AGUA — contrato del recorrido (feat mundo3d-agua).
+ *
+ * El mundo del agua es UNA entrada de datos del registro (mundoData.js) sobre
+ * el arquetipo `flujo`. Este test congela sus sí-o-sí:
+ *   1. Los 6 puntos del recorrido existen (nacimiento, ronda, quebrada,
+ *      riesgo/cuidado, bocatoma, cultivo regado) y cada `view` es un case REAL
+ *      de App.jsx (regla de oro: re-rutear, nunca reimplementar).
+ *   2. El device-tiering cae al gemelo 2D (`mirror`, motivo `flujo`) con los
+ *      MISMOS params (curva + hitos): el dibujo cuenta el mismo recorrido.
+ *   3. El gemelo 2D monta three-free en jsdom y sus puntos re-rutean de verdad.
+ */
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+import Mundo from '../Mundo.jsx';
+import { MUNDO } from '../mundoData.js';
+import { resolverMundo } from '../resolverMundo.js';
+
+afterEach(() => cleanup());
+
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+const appSrc = fs.readFileSync(path.resolve(__dir, '../../../App.jsx'), 'utf8');
+
+const agua = MUNDO.agua;
+
+describe('mundo del agua — el recorrido completo como datos', () => {
+  test('es el arquetipo flujo, con landmark en el valle y entrada de la abeja', () => {
+    expect(agua.escena).toBe('flujo');
+    expect(agua.valle?.tipo).toBe('quebrada');
+    expect(agua.entrada?.narra).toBe('agua');
+    expect(typeof agua.entrada?.zoom).toBe('number');
+  });
+
+  test('los 6 puntos del recorrido están y cada view existe en App.jsx', () => {
+    const ids = (agua.hotspots || []).map((h) => h.id);
+    ['nacimiento', 'ronda', 'quebrada', 'riesgo', 'bocatoma', 'cultivo'].forEach((id) => {
+      expect(ids, `falta el punto '${id}' del recorrido`).toContain(id);
+    });
+    for (const h of agua.hotspots) {
+      expect(
+        appSrc.includes(`case '${h.view}':`),
+        `la vista '${h.view}' del punto '${h.id}' no existe en App.jsx`,
+      ).toBe(true);
+    }
+  });
+
+  test('la curva y los hitos son datos compartidos por el 3D y su gemelo 2D', () => {
+    expect(Array.isArray(agua.params.curva)).toBe(true);
+    expect(agua.params.curva.length).toBeGreaterThanOrEqual(4);
+    const hitos = agua.params.hitos;
+    expect(hitos.ronda?.arboles).toBeGreaterThan(0);
+    expect(hitos.riesgo?.t).toBeGreaterThan(0);
+    expect(hitos.bocatoma?.t).toBeGreaterThan(hitos.riesgo.t); // la toma va aguas abajo del cuidado
+    expect(Array.isArray(hitos.cultivo?.pos)).toBe(true);
+  });
+
+  test('tier alto → diorama 3D flujo; equipo humilde → gemelo mirror con los mismos params', () => {
+    const alto = resolverMundo('agua', 'alto');
+    expect(alto.modo).toBe('3d');
+    expect(alto.escena).toBe('flujo');
+
+    const bajo = resolverMundo('agua', 'bajo');
+    expect(bajo.modo).toBe('2d');
+    expect(bajo.escena).toBe('mirror'); // el fallback2d declarado
+    expect(bajo.motivo).toBe('flujo');
+    // el gemelo recibe la MISMA data del recorrido
+    expect(bajo.entrada.params.hitos).toEqual(agua.params.hitos);
+    expect(bajo.entrada.params.curva).toEqual(agua.params.curva);
+  });
+
+  test('el gemelo 2D monta three-free y sus 6 puertas re-rutean', () => {
+    const onHotspot = vi.fn();
+    const { container } = render(
+      <Mundo mundoId="agua" tier="bajo" onHotspot={onHotspot} onSalir={() => {}} />,
+    );
+    expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+    // los 6 puntos del recorrido son botones reales
+    const botones = container.querySelectorAll('.mundo2d__hotspot');
+    expect(botones.length).toBe(6);
+    fireEvent.click(screen.getByRole('button', { name: 'La huerta regada' }));
+    expect(onHotspot).toHaveBeenCalledWith('hortalizas', undefined);
+    fireEvent.click(screen.getByRole('button', { name: 'Donde nace el agua' }));
+    expect(onHotspot).toHaveBeenCalledWith('agua', { tema: 'nacimiento' });
+  });
+});

--- a/src/visual/mundo3d/arquetipos.js
+++ b/src/visual/mundo3d/arquetipos.js
@@ -1,0 +1,82 @@
+/*
+ * ARQUETIPOS — el conjunto CERRADO y filtrable de clases de escena del framework
+ * de mundos.
+ *
+ * Un mundo (`MUNDO[id].escena`) apunta a un arquetipo por su clave. Cada
+ * arquetipo declara su DIMENSIÓN (`dim: '2d' | '3d'`) — el eje que decide todo:
+ *
+ *   · dim '3d' → diorama espacial (cutaway/flujo/recinto/estratos/valle). Se monta
+ *     SOLO si el equipo aguanta 3D (device-tier); si no, cae a su ESPEJO 2D.
+ *   · dim '2d' → arquetipo 2D de PRIMERA CLASE (mirror/lamina/infografia/ficha/
+ *     valle2d). No es "el fallback tonto": un mundo-dato (mercado, toxicología,
+ *     ficha de cultivo) lo declara DIRECTO, porque su valor ES el dato/foto.
+ *
+ * Sumar un mundo NO toca este mapa: se añade una entrada de datos que apunta a un
+ * arquetipo YA existente. Se toca AQUÍ solo cuando aparece una metáfora espacial
+ * genuinamente nueva (rarísimo) — la única vez que se escribe R3F/SVG de escena.
+ */
+
+/** @typedef {'2d'|'3d'} Dim */
+
+export const ARQUETIPOS = {
+  // ── Arquetipos 3D (dioramas) ─────────────────────────────────────────────
+  cutaway: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'cutaway', espejo: 'mirror',
+    nombre: 'Corte de suelo', clave: 'lo invisible del subsuelo, hecho visible',
+    ejemplo: 'suelo', tambien: ['abono'],
+  },
+  flujo: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'flujo', espejo: 'mirror',
+    nombre: 'Camino del agua', clave: 'gravedad y pendiente: por dónde baja el agua',
+    ejemplo: 'agua', tambien: [],
+  },
+  recinto: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'recinto', espejo: 'mirror',
+    nombre: 'El corral', clave: 'el ciclo cerrado del abono como anillo espacial',
+    ejemplo: 'animales', tambien: [],
+  },
+  estratos: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'estratos', espejo: 'mirror',
+    nombre: 'Estratos del bosque', clave: 'la verticalidad de los 7 estratos comestibles',
+    ejemplo: 'disenio', tambien: [],
+  },
+  valle: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'valle', espejo: 'valle2d',
+    nombre: 'El valle (mapa)', clave: 'la finca como mapa navegable; cada mundo es un lugar',
+    ejemplo: 'valle', tambien: [],
+  },
+
+  // ── Arquetipos 2D (primera clase) ────────────────────────────────────────
+  mirror: {
+    dim: '2d', role: 'mundo2d-archetype',
+    nombre: 'Lámina espejo', clave: 'el dibujo 2D digno de un diorama 3D (mismos datos + hotspots)',
+  },
+  lamina: {
+    dim: '2d', role: 'mundo2d-archetype',
+    nombre: 'Ficha ilustrada', clave: 'reusa src/visual/laminas (maíz, cafeto, mata por etapa)',
+  },
+  infografia: {
+    dim: '2d', role: 'mundo2d-archetype',
+    nombre: 'Infografía de datos', clave: 'cifras/dosis/precios (mercado, toxicología, boletín)',
+  },
+  ficha: {
+    dim: '2d', role: 'mundo2d-archetype',
+    nombre: 'Tarjeta de especie', clave: 'ficha foto-secuencial (frutales, botica, café)',
+  },
+  valle2d: {
+    dim: '2d', role: 'mundo2d-archetype',
+    nombre: 'Valle dibujado', clave: 'el mapa isométrico SVG (espejo 2D del valle)',
+  },
+};
+
+/** Claves de todos los arquetipos, en orden canónico. */
+export const ARQUETIPOS_KEYS = Object.keys(ARQUETIPOS);
+
+/** ¿Es un arquetipo de dimensión 3D? */
+export const esArquetipo3D = (key) => ARQUETIPOS[key]?.dim === '3d';
+
+/** Solo los arquetipos 3D (para el device-tiering y el filtro `piezas3D`). */
+export const ARQUETIPOS_3D = ARQUETIPOS_KEYS.filter(esArquetipo3D);
+
+/** Solo los arquetipos 2D (primera clase + espejos). */
+export const ARQUETIPOS_2D = ARQUETIPOS_KEYS.filter((k) => ARQUETIPOS[k].dim === '2d');

--- a/src/visual/mundo3d/deviceTier.js
+++ b/src/visual/mundo3d/deviceTier.js
@@ -1,0 +1,66 @@
+/*
+ * deviceTier — el DEVICE-TIERING del framework (heredado del valle, DR §4.4).
+ *
+ * La 3D es ASPIRACIONAL (gama media+). No basta con "¿hay WebGL?": un teléfono
+ * humilde lo tiene pero sufre jank y calor. Se degrada por señales de equipo
+ * débil: poca RAM, pocos núcleos, ahorro de datos o menos-movimiento. Devuelve un
+ * `tier` que el host `<Mundo>` usa para decidir 3D vs 2D:
+ *
+ *   'alto'  → 3D pleno.
+ *   'medio' → 3D frugal (los arquetipos ya son frugales por contrato: sin
+ *             sombras, MeshLambert/Basic, DPR≤1.5 — DR §6).
+ *   'bajo'  → 2D digno (sin-WebGL, poca RAM/CPU, saveData, reduced-motion).
+ *
+ * Misma lógica que `decidirRender()` del mockup del valle, pero graduada en tres
+ * niveles (aquel decide binario 2d/3d). Es la fuente de verdad del framework.
+ */
+
+/** @returns {{ tier: 'alto'|'medio'|'bajo', motivo: string }} */
+export function decidirTier() {
+  if (typeof window === 'undefined') return { tier: 'bajo', motivo: 'ssr' };
+
+  /* `deviceMemory`/`connection` son APIs experimentales que la lib de tipos del
+     DOM aún no declara; se tipan aquí como opcionales (sin `any`). */
+  const nav =
+    /** @type {Navigator & { deviceMemory?: number, connection?: { saveData?: boolean }, mozConnection?: { saveData?: boolean }, webkitConnection?: { saveData?: boolean } }} */ (
+      window.navigator
+    );
+
+  // 1) WebGL es requisito DURO del 3D.
+  let webgl = false;
+  try {
+    const canvas = document.createElement('canvas');
+    webgl = !!(
+      window.WebGLRenderingContext &&
+      (canvas.getContext('webgl2') || canvas.getContext('webgl'))
+    );
+  } catch {
+    webgl = false;
+  }
+  if (!webgl) return { tier: 'bajo', motivo: 'sin-webgl' };
+
+  // 2) El usuario pidió ahorrar datos o menos movimiento → respetarlo.
+  const conn = nav.connection || nav.mozConnection || nav.webkitConnection;
+  if (conn && conn.saveData) return { tier: 'bajo', motivo: 'ahorro' };
+  const menosMov =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (menosMov) return { tier: 'bajo', motivo: 'calma' };
+
+  // 3) Equipos humildes → 2D (no los ponemos a sudar la GPU).
+  const mem = nav.deviceMemory; // GiB aprox. (Chrome/Android); undefined en otros
+  if (typeof mem === 'number' && mem > 0 && mem <= 3) return { tier: 'bajo', motivo: 'equipo' };
+  const nucleos = nav.hardwareConcurrency;
+  if (typeof nucleos === 'number' && nucleos > 0 && nucleos <= 4) {
+    return { tier: 'bajo', motivo: 'equipo' };
+  }
+
+  // 4) Gama media declarada → 3D frugal; el resto, 3D pleno.
+  if ((typeof mem === 'number' && mem <= 6) || (typeof nucleos === 'number' && nucleos <= 6)) {
+    return { tier: 'medio', motivo: 'ok' };
+  }
+  return { tier: 'alto', motivo: 'ok' };
+}
+
+/** ¿Este tier puede montar una escena 3D? (bajo y '2d' forzado → no). */
+export const permite3D = (tier) => tier === 'alto' || tier === 'medio';

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -1,0 +1,126 @@
+/*
+ * EscenaBase3D — el ANDAMIAJE 3D compartido por todos los arquetipos de escena.
+ *
+ * El DR (§4.4, §6) pide que cada arquetipo sea SOLO su diorama; el resto (Canvas,
+ * luz frugal, cámara, hotspots, la abeja) se hereda. Aquí vive ese resto: un
+ * `<Canvas>` austero (DPR ≤ 1.5, SIN sombras, SIN post-proceso, `frameloop`
+ * a demanda si hay reduced-motion), luz de ambiente + hemisferio (barata, para
+ * `MeshLambert`/`MeshBasic`), `OrbitControls` acotado, los `hotspots` como
+ * botones-billboard accesibles que re-rutean a vistas 2D reales, y Angelita con
+ * su coreografía compartida. El arquetipo pasa su geometría como `children`.
+ *
+ * CONTRATO uniforme (idéntico para cutaway/flujo/recinto/estratos):
+ *   { params, hotspots, entrada, tinte, reducedMotion, onHotspot, onSalir,
+ *     animo, energia, cielo?, camara?, children }
+ */
+import { Suspense, useRef, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import * as THREE from 'three';
+import { AbejaEscena } from './useEntradaAbeja.jsx';
+
+/* Cielo cálido "acuarela" por defecto (la estética heredada del valle). El
+   arquetipo puede pasar su propio `cielo` para teñir su ambiente. */
+const CIELO_DEFAULT = { fondo: '#ece0c7', cielo: '#f5e9d2', suelo: '#b49873', intensidad: 1 };
+
+function Contenido({
+  params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, children,
+}) {
+  const controls = useRef(null);
+  const [activo, setActivo] = useState(null);
+  const c = cielo || CIELO_DEFAULT;
+  const zoom = entrada?.zoom ?? 6.5;
+  const acento = (tinte && tinte[0]) || '#3f8f4e';
+  const centro = entrada?.centro || [0, (params?.alto ?? 1.1) * 0.5, 0];
+
+  // foco = el hotspot activo (o el centro del diorama). Barato: un Vector3 por
+  // render; la abeja lo persigue con `lerp` en useEntradaAbeja.
+  const hAct = activo && hotspots ? hotspots.find((x) => x.id === activo) : null;
+  const p = hAct ? hAct.pos : centro;
+  const foco = new THREE.Vector3(p[0], p[1], p[2]);
+
+  return (
+    <>
+      <color attach="background" args={[c.fondo]} />
+      <hemisphereLight intensity={0.95 * c.intensidad} color={c.cielo} groundColor={c.suelo} />
+      <ambientLight intensity={0.45 * c.intensidad} color={c.cielo} />
+
+      {children}
+
+      {(hotspots || []).map((h) => (
+        <group key={h.id} position={h.pos}>
+          <Html center distanceFactor={zoom + 2} zIndexRange={[30, 0]}>
+            <button
+              type="button"
+              className={`mundo-hotspot${activo === h.id ? ' mundo-hotspot--activo' : ''}`}
+              style={{ '--hs-tinte': acento }}
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                setActivo(h.id);
+                onHotspot?.(h.view, h.data);
+              }}
+              aria-label={h.label}
+            >
+              <span className="mundo-hotspot__emoji" aria-hidden="true">{h.emoji}</span>
+              <span className="mundo-hotspot__txt">{h.label}</span>
+            </button>
+          </Html>
+        </group>
+      ))}
+
+      <AbejaEscena foco={foco} entrando animo={animo} energia={energia} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        ref={controls}
+        makeDefault
+        enablePan={false}
+        enableZoom
+        minDistance={zoom * 0.7}
+        maxDistance={zoom * 2.6}
+        minPolarAngle={0.35}
+        maxPolarAngle={1.35}
+        enableDamping
+        dampingFactor={0.09}
+        autoRotate={!reducedMotion && !activo}
+        autoRotateSpeed={0.25}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+export default function EscenaBase3D({
+  params, hotspots, entrada, tinte, reducedMotion,
+  onHotspot, cielo, animo = 'sereno', energia = 1, camara, children,
+}) {
+  const [listo, setListo] = useState(false);
+  const zoom = entrada?.zoom ?? 6.5;
+  const cam = camara || { position: [zoom * 0.55, zoom * 0.5, zoom], fov: 42 };
+  return (
+    <Canvas
+      className={`mundo-canvas${listo ? ' mundo-canvas--listo' : ''}`}
+      dpr={[1, 1.5]}
+      gl={{ antialias: true, powerPreference: 'high-performance' }}
+      camera={cam}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Suspense fallback={null}>
+        <Contenido
+          params={params}
+          hotspots={hotspots}
+          entrada={entrada}
+          tinte={tinte}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          cielo={cielo}
+          animo={animo}
+          energia={energia}
+        >
+          {children}
+        </Contenido>
+      </Suspense>
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/escenas/EscenaCutaway.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCutaway.jsx
@@ -1,0 +1,127 @@
+/*
+ * EscenaCutaway — ARQUETIPO `cutaway`: el CORTE de tierra (el suelo vivo).
+ *
+ * El prototipo del DR (§5): "lo invisible hecho visible". Un bloque de tierra
+ * cortado en capas horizontales (hojarasca / suelo negro / subsuelo); sobre y
+ * entre ellas, VIDA low-poly — lombrices, raíces que descienden, "internet de
+ * hongos" (hifas). La CANTIDAD de vida = `params.vida` (0..1), que en producción
+ * lee el `mundoSubsueloEngine` (score de salud del suelo): cansado → casi pelado;
+ * vivo → lleno. Reusable por `abono` (corte de la pila de compost) sin código.
+ *
+ * Perf (DR §6): SOLO `MeshLambert`/`MeshBasic`, sin sombras, geometría acotada.
+ */
+import { useMemo } from 'react';
+import EscenaBase3D from './EscenaBase3D.jsx';
+
+const ANCHO = 4.4;
+const PROF = 2.2;
+
+/* PRNG determinista (mismo corte siempre, sin GLTF ni azar por frame). */
+function rng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+function clamp01(n) {
+  return Math.max(0, Math.min(1, typeof n === 'number' ? n : 0.6));
+}
+
+/* Una lombriz: cápsula curvada (toro parcial) tumbada, tono claro. */
+function Lombriz({ pos, giro }) {
+  return (
+    <mesh position={pos} rotation={[Math.PI / 2, giro, 0]}>
+      <torusGeometry args={[0.12, 0.045, 6, 10, Math.PI * 1.2]} />
+      <meshLambertMaterial color="#e8b6a6" />
+    </mesh>
+  );
+}
+
+/* Una raíz: cono fino que desciende desde su capa. */
+function Raiz({ pos, largo }) {
+  return (
+    <mesh position={pos}>
+      <coneGeometry args={[0.05, largo, 5]} />
+      <meshLambertMaterial color="#c9a86a" />
+    </mesh>
+  );
+}
+
+/* Una hifa: línea finísima blanca (la red de micorrizas). */
+function Hifa({ pos, giro }) {
+  return (
+    <mesh position={pos} rotation={[0, 0, giro]}>
+      <cylinderGeometry args={[0.008, 0.008, 0.5, 3]} />
+      <meshBasicMaterial color="#f2ece0" />
+    </mesh>
+  );
+}
+
+function Diorama({ params }) {
+  const vida = clamp01(params?.vida);
+
+  const { bloques, bichos, total } = useMemo(() => {
+    const capas = params?.capas || [];
+    const alturaTotal = capas.reduce((s, c) => s + (c.alto || 0.6), 0) || 1;
+    const bloq = [];
+    const vid = [];
+    const r = rng(97);
+    let top = alturaTotal; // arranca por la superficie
+    capas.forEach((capa, ci) => {
+      const alto = capa.alto || 0.6;
+      const cy = top - alto / 2;
+      bloq.push({ key: `c${ci}`, cy, alto, color: capa.color || '#5a3d28' });
+      // vida por capa según qué bichos declara y cuánta vida hay
+      const tipos = capa.bichos || [];
+      const n = Math.round(vida * 6);
+      for (let i = 0; i < n; i++) {
+        const tipo = tipos[i % Math.max(1, tipos.length)] || 'raiz';
+        const x = (r() - 0.5) * (ANCHO - 0.6);
+        const z = PROF / 2 - 0.02 - r() * 0.15; // pegados a la cara cortada (frente)
+        const y = cy + (r() - 0.5) * alto * 0.6;
+        vid.push({ key: `${ci}-${i}`, tipo, pos: [x, y, z], giro: r() * Math.PI, largo: 0.3 + r() * alto });
+      }
+      top -= alto;
+    });
+    return { bloques: bloq, bichos: vid, total: alturaTotal };
+  }, [params, vida]);
+
+  return (
+    <group position={[0, -total / 2, 0]}>
+      {/* las capas: cajas apiladas, cara frontal expuesta (el corte) */}
+      {bloques.map((b) => (
+        <mesh key={b.key} position={[0, b.cy, 0]}>
+          <boxGeometry args={[ANCHO, b.alto, PROF]} />
+          <meshLambertMaterial color={b.color} flatShading />
+        </mesh>
+      ))}
+      {/* borde de pasto sobre la superficie */}
+      <mesh position={[0, total + 0.03, 0]}>
+        <boxGeometry args={[ANCHO, 0.08, PROF]} />
+        <meshLambertMaterial color="#6f9a45" flatShading />
+      </mesh>
+      {/* la vida del suelo, tanta como diga `vida` */}
+      {bichos.map((v) => {
+        if (v.tipo === 'lombriz') return <Lombriz key={v.key} pos={v.pos} giro={v.giro} />;
+        if (v.tipo === 'hifa') return <Hifa key={v.key} pos={v.pos} giro={v.giro} />;
+        return <Raiz key={v.key} pos={[v.pos[0], v.pos[1], v.pos[2]]} largo={v.largo} />;
+      })}
+    </group>
+  );
+}
+
+export default function EscenaCutaway(props) {
+  const alto = (props.params?.capas || []).reduce((s, c) => s + (c.alto || 0.6), 0) || 1.5;
+  const cielo = { fondo: '#e7d7ba', cielo: '#f3e6cc', suelo: '#7a5a38', intensidad: 1.05 };
+  return (
+    <EscenaBase3D
+      {...props}
+      cielo={cielo}
+      entrada={{ ...props.entrada, centro: [0, alto * 0.2, 0.6] }}
+    >
+      <Diorama params={props.params} />
+    </EscenaBase3D>
+  );
+}

--- a/src/visual/mundo3d/escenas/EscenaEstratos.jsx
+++ b/src/visual/mundo3d/escenas/EscenaEstratos.jsx
@@ -1,0 +1,81 @@
+/*
+ * EscenaEstratos — ARQUETIPO `estratos`: la VERTICALIDAD del bosque comestible.
+ *
+ * Los 7 estratos (emergente → dosel → sub-dosel → arbusto → herbáceo → rastrero
+ * → raíz) son verticales POR DEFINICIÓN: la verticalidad ES la lección, y una
+ * lista plana la mata. Aquí cada estrato es una banda de altura con su vegetación
+ * low-poly repetida (troncos + copas / matas). Con muchos árboles el DR pide
+ * `InstancedMesh`; este arquetipo usa un conteo acotado por estrato y `MeshLambert`
+ * sin sombras (DR §6) — el que "estresa" el framework más allá del cutaway.
+ */
+import { useMemo } from 'react';
+import EscenaBase3D from './EscenaBase3D.jsx';
+
+const ESTRATOS_DEF = [
+  { nombre: 'emergente', alto: 3.4, color: '#2f5f34', r: 0.6 },
+  { nombre: 'dosel', alto: 2.6, color: '#3a6f3f', r: 0.7 },
+  { nombre: 'sub-dosel', alto: 1.9, color: '#4a7d45', r: 0.6 },
+  { nombre: 'arbusto', alto: 1.2, color: '#5f8a3f', r: 0.5 },
+  { nombre: 'herbáceo', alto: 0.7, color: '#7aa24a', r: 0.4 },
+  { nombre: 'rastrero', alto: 0.35, color: '#8fae55', r: 0.5 },
+  { nombre: 'raíz', alto: 0.15, color: '#8a6a44', r: 0.4 },
+];
+
+function Planta({ x, z, alto, color, r }) {
+  return (
+    <group position={[x, 0, z]}>
+      <mesh position={[0, alto * 0.35, 0]}>
+        <cylinderGeometry args={[0.06, 0.09, alto * 0.7, 5]} />
+        <meshLambertMaterial color="#6b4a2e" flatShading />
+      </mesh>
+      <mesh position={[0, alto * 0.78, 0]}>
+        <coneGeometry args={[r, alto * 0.7, 7]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+function Diorama({ params }) {
+  const estratos = params?.estratos || ESTRATOS_DEF;
+  const plantas = useMemo(() => {
+    const out = [];
+    let s = 7;
+    estratos.forEach((e, ei) => {
+      const cuenta = ei < 2 ? 2 : 3;
+      for (let i = 0; i < cuenta; i++) {
+        s = (s * 1103515245 + 12345) >>> 0;
+        const x = ((s % 1000) / 1000 - 0.5) * 3.8;
+        s = (s * 1103515245 + 12345) >>> 0;
+        const z = ((s % 1000) / 1000 - 0.5) * 2.4 - 0.4;
+        out.push({ key: `${ei}-${i}`, x, z, alto: e.alto, color: e.color, r: e.r });
+      }
+    });
+    return out;
+  }, [estratos]);
+  return (
+    <group position={[0, 0, 0]}>
+      <mesh position={[0, -0.03, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[2.6, 30]} />
+        <meshLambertMaterial color="#6d5030" />
+      </mesh>
+      {plantas.map((p) => (
+        <Planta key={p.key} x={p.x} z={p.z} alto={p.alto} color={p.color} r={p.r} />
+      ))}
+    </group>
+  );
+}
+
+export default function EscenaEstratos(props) {
+  const cielo = { fondo: '#d7e6c9', cielo: '#eaf2df', suelo: '#5f4a2e', intensidad: 1.1 };
+  return (
+    <EscenaBase3D
+      {...props}
+      cielo={cielo}
+      camara={{ position: [3.5, 3, 6], fov: 44 }}
+      entrada={{ ...props.entrada, centro: [0, 1.4, 0] }}
+    >
+      <Diorama params={props.params} />
+    </EscenaBase3D>
+  );
+}

--- a/src/visual/mundo3d/escenas/EscenaFlujo.jsx
+++ b/src/visual/mundo3d/escenas/EscenaFlujo.jsx
@@ -1,0 +1,69 @@
+/*
+ * EscenaFlujo — ARQUETIPO `flujo`: el CAMINO del agua (gravedad y pendiente).
+ *
+ * El agua se entiende por dónde BAJA: nacimiento → quebrada → tanque → riego.
+ * Una cinta-tubo que desciende por una curva (la pendiente ES la lección) y un
+ * tanque que la recibe; la cinta respira su opacidad (agua viva). Reusa
+ * `MeshLambert`/`MeshBasic`, sin sombras.
+ */
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import EscenaBase3D from './EscenaBase3D.jsx';
+
+function Cinta({ curva, color, reducedMotion }) {
+  const ref = useRef(null);
+  useFrame((state) => {
+    if (reducedMotion || !ref.current) return;
+    ref.current.material.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 2) * 0.08;
+  });
+  const geo = useMemo(() => {
+    const pts = (curva || [
+      [-1.8, 2.2, 0.4], [-0.9, 1.4, 0.1], [0, 0.7, -0.2], [0.7, 0.1, 0.1], [1.4, -0.2, 0.5],
+    ]).map((p) => new THREE.Vector3(p[0], p[1], p[2]));
+    const c = new THREE.CatmullRomCurve3(pts);
+    return new THREE.TubeGeometry(c, 48, 0.16, 6, false);
+  }, [curva]);
+  return (
+    <mesh geometry={geo}>
+      <meshLambertMaterial ref={ref} color={color} transparent opacity={0.78} />
+    </mesh>
+  );
+}
+
+function Diorama({ params, tinte, reducedMotion }) {
+  const color = params?.agua || (tinte && tinte[0]) || '#3f8fb0';
+  return (
+    <group>
+      {/* la ladera por la que baja el agua */}
+      <mesh position={[-0.4, 0.6, -0.3]} rotation={[0, 0, -0.5]}>
+        <boxGeometry args={[3.6, 0.5, 2.4]} />
+        <meshLambertMaterial color="#7d9a5c" flatShading />
+      </mesh>
+      {/* el nacimiento arriba */}
+      <mesh position={[-1.8, 2.25, 0.4]}>
+        <cylinderGeometry args={[0.34, 0.4, 0.16, 14]} />
+        <meshLambertMaterial color={color} transparent opacity={0.85} />
+      </mesh>
+      <Cinta curva={params?.curva} color={color} reducedMotion={reducedMotion} />
+      {/* el tanque que recibe el agua */}
+      <mesh position={[1.5, -0.1, 0.5]}>
+        <cylinderGeometry args={[0.55, 0.6, 0.7, 18]} />
+        <meshLambertMaterial color="#9a8b74" flatShading />
+      </mesh>
+      <mesh position={[1.5, 0.1, 0.5]}>
+        <cylinderGeometry args={[0.5, 0.5, 0.12, 18]} />
+        <meshLambertMaterial color={color} transparent opacity={0.8} />
+      </mesh>
+    </group>
+  );
+}
+
+export default function EscenaFlujo(props) {
+  const cielo = { fondo: '#d9e8ec', cielo: '#eaf3f5', suelo: '#7f9270', intensidad: 1.1 };
+  return (
+    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.9, 0.3] }}>
+      <Diorama params={props.params} tinte={props.tinte} reducedMotion={props.reducedMotion} />
+    </EscenaBase3D>
+  );
+}

--- a/src/visual/mundo3d/escenas/EscenaFlujo.jsx
+++ b/src/visual/mundo3d/escenas/EscenaFlujo.jsx
@@ -1,29 +1,35 @@
 /*
  * EscenaFlujo — ARQUETIPO `flujo`: el CAMINO del agua (gravedad y pendiente).
  *
- * El agua se entiende por dónde BAJA: nacimiento → quebrada → tanque → riego.
- * Una cinta-tubo que desciende por una curva (la pendiente ES la lección) y un
- * tanque que la recibe; la cinta respira su opacidad (agua viva). Reusa
- * `MeshLambert`/`MeshBasic`, sin sombras.
+ * El agua se entiende por dónde BAJA: nacimiento → quebrada → toma → riego.
+ * Una cinta-tubo que desciende por una curva (la pendiente ES la lección), un
+ * tanque que la recibe, y — si el mundo los declara en `params.hitos` — los
+ * HITOS del recorrido, todos por DATOS y anclados a la curva por su fracción t:
+ *
+ *   · ronda    { tramo:[t0,t1], arboles }  franja de monte que protege el nacimiento
+ *   · riesgo   { t, lado }                 punto de CUIDADO (ámbar, didáctico — no alarma)
+ *   · bocatoma { t }                       la cajilla que toma el agua
+ *   · cultivo  { pos:[x,y,z], surcos }     la huerta regada, con su canalito desde el tanque
+ *
+ * Sin `hitos` el diorama clásico sigue idéntico (nacimiento + cinta + tanque).
+ * Todo primitivas low-poly (`MeshLambert`/`MeshBasic`), sin sombras, sin GLTF.
  */
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import EscenaBase3D from './EscenaBase3D.jsx';
 
-function Cinta({ curva, color, reducedMotion }) {
+const CURVA_DEFAULT = [
+  [-1.8, 2.2, 0.4], [-0.9, 1.4, 0.1], [0, 0.7, -0.2], [0.7, 0.1, 0.1], [1.4, -0.2, 0.5],
+];
+
+function Cinta({ curva3, color, reducedMotion }) {
   const ref = useRef(null);
   useFrame((state) => {
     if (reducedMotion || !ref.current) return;
     ref.current.material.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 2) * 0.08;
   });
-  const geo = useMemo(() => {
-    const pts = (curva || [
-      [-1.8, 2.2, 0.4], [-0.9, 1.4, 0.1], [0, 0.7, -0.2], [0.7, 0.1, 0.1], [1.4, -0.2, 0.5],
-    ]).map((p) => new THREE.Vector3(p[0], p[1], p[2]));
-    const c = new THREE.CatmullRomCurve3(pts);
-    return new THREE.TubeGeometry(c, 48, 0.16, 6, false);
-  }, [curva]);
+  const geo = useMemo(() => new THREE.TubeGeometry(curva3, 48, 0.16, 6, false), [curva3]);
   return (
     <mesh geometry={geo}>
       <meshLambertMaterial ref={ref} color={color} transparent opacity={0.78} />
@@ -31,8 +37,167 @@ function Cinta({ curva, color, reducedMotion }) {
   );
 }
 
+/* Gotas que VIAJAN por la curva: el recorrido se ve, no se adivina. Con
+   reduced-motion quedan quietas en su fracción t (escena digna, no muerta). */
+function Gotas({ curva3, color, reducedMotion }) {
+  const refs = useRef([]);
+  const bases = [0.15, 0.5, 0.85];
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const t = state.clock.elapsedTime * 0.08;
+    refs.current.forEach((m, i) => {
+      if (!m) return;
+      const p = curva3.getPoint((bases[i] + t) % 1);
+      m.position.set(p.x, p.y + 0.06, p.z);
+    });
+  });
+  return (
+    <group>
+      {bases.map((b, i) => {
+        const p = curva3.getPoint(b);
+        return (
+          <mesh
+            key={b}
+            ref={(el) => { refs.current[i] = el; }}
+            position={[p.x, p.y + 0.06, p.z]}
+          >
+            <sphereGeometry args={[0.09, 8, 6]} />
+            <meshBasicMaterial color={color} transparent opacity={0.9} />
+          </mesh>
+        );
+      })}
+    </group>
+  );
+}
+
+/* Un arbolito low-poly (tronco + dos conos). La ronda hídrica los siembra. */
+function Arbolito({ pos, escala = 1 }) {
+  return (
+    <group position={pos} scale={escala}>
+      <mesh position={[0, 0.18, 0]}>
+        <cylinderGeometry args={[0.05, 0.07, 0.36, 6]} />
+        <meshLambertMaterial color="#7a5a38" flatShading />
+      </mesh>
+      <mesh position={[0, 0.5, 0]}>
+        <coneGeometry args={[0.28, 0.5, 7]} />
+        <meshLambertMaterial color="#3f6f3a" flatShading />
+      </mesh>
+      <mesh position={[0, 0.78, 0]}>
+        <coneGeometry args={[0.18, 0.34, 7]} />
+        <meshLambertMaterial color="#4d7f42" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* La RONDA hídrica: arbolitos sembrados a ambos lados del tramo alto de la
+   curva. Determinista: mismo dato, mismo monte. */
+function Ronda({ curva3, tramo = [0, 0.35], arboles = 5 }) {
+  const puestos = useMemo(() => {
+    const [t0, t1] = tramo;
+    return Array.from({ length: arboles }, (_, i) => {
+      const t = t0 + ((t1 - t0) * i) / Math.max(1, arboles - 1);
+      const p = curva3.getPoint(t);
+      const lado = i % 2 === 0 ? 1 : -1;
+      return {
+        key: i,
+        pos: [p.x + lado * 0.42, p.y - 0.05, p.z + lado * 0.5],
+        escala: 0.8 + (i % 3) * 0.18,
+      };
+    });
+  }, [curva3, tramo, arboles]);
+  return (
+    <group>
+      {puestos.map((a) => <Arbolito key={a.key} pos={a.pos} escala={a.escala} />)}
+    </group>
+  );
+}
+
+/* La BOCATOMA: la cajilla de concreto que toma el agua sobre la quebrada. */
+function Bocatoma({ curva3, t = 0.68, color }) {
+  const p = curva3.getPoint(t);
+  return (
+    <group position={[p.x, p.y, p.z]}>
+      <mesh position={[0, 0.1, 0]}>
+        <boxGeometry args={[0.42, 0.3, 0.42]} />
+        <meshLambertMaterial color="#a8a094" flatShading />
+      </mesh>
+      <mesh position={[0, 0.26, 0]}>
+        <boxGeometry args={[0.34, 0.06, 0.34]} />
+        <meshLambertMaterial color={color} transparent opacity={0.8} />
+      </mesh>
+    </group>
+  );
+}
+
+/* El punto de CUIDADO: un barril y una señal ámbar junto a la quebrada. Didáctico
+   ("aquí se cuida el agua"), nunca catástrofe: ni rojo, ni humo, ni calavera. */
+function PuntoCuidado({ curva3, t = 0.46, lado = 0.8 }) {
+  const p = curva3.getPoint(t);
+  return (
+    <group position={[p.x + lado * 0.4, p.y - 0.02, p.z + lado]}>
+      <mesh position={[0, 0.16, 0]}>
+        <cylinderGeometry args={[0.14, 0.14, 0.32, 10]} />
+        <meshLambertMaterial color="#8b8b8b" flatShading />
+      </mesh>
+      <mesh position={[0.28, 0.3, 0]}>
+        <cylinderGeometry args={[0.02, 0.02, 0.6, 5]} />
+        <meshLambertMaterial color="#7a5a38" />
+      </mesh>
+      <mesh position={[0.28, 0.62, 0]}>
+        <boxGeometry args={[0.3, 0.2, 0.04]} />
+        <meshLambertMaterial color="#d9a13b" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* La HUERTA regada: la cama de tierra, sus surcos verdes y el canalito que le
+   trae el agua desde el tanque — el final feliz del recorrido. */
+function Cultivo({ pos = [2.3, -0.3, -0.55], surcos = 4, desde, color }) {
+  const surcosArr = Array.from({ length: surcos }, (_, i) => i);
+  const canal = useMemo(() => {
+    if (!desde) return null;
+    const a = new THREE.Vector3(desde[0], desde[1], desde[2]);
+    const b = new THREE.Vector3(pos[0], pos[1] + 0.05, pos[2]);
+    const medio = a.clone().lerp(b, 0.5);
+    const largo = a.distanceTo(b);
+    const angulo = Math.atan2(b.x - a.x, b.z - a.z);
+    return { medio, largo, angulo };
+  }, [desde, pos]);
+  return (
+    <group>
+      {canal && (
+        <mesh position={canal.medio} rotation={[0, canal.angulo, 0]}>
+          <boxGeometry args={[0.1, 0.06, canal.largo]} />
+          <meshLambertMaterial color={color} transparent opacity={0.75} />
+        </mesh>
+      )}
+      <group position={[pos[0], pos[1], pos[2]]}>
+        <mesh position={[0, 0.06, 0]}>
+          <boxGeometry args={[1.5, 0.16, 1.1]} />
+          <meshLambertMaterial color="#6b4a2e" flatShading />
+        </mesh>
+        {surcosArr.map((i) => (
+          <mesh key={i} position={[0, 0.17, -0.42 + (0.84 * i) / Math.max(1, surcos - 1)]}>
+            <boxGeometry args={[1.3, 0.1, 0.14]} />
+            <meshLambertMaterial color="#5f8a3f" flatShading />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  );
+}
+
 function Diorama({ params, tinte, reducedMotion }) {
   const color = params?.agua || (tinte && tinte[0]) || '#3f8fb0';
+  const hitos = params?.hitos;
+  const curva3 = useMemo(() => {
+    const pts = (params?.curva || CURVA_DEFAULT).map((p) => new THREE.Vector3(p[0], p[1], p[2]));
+    return new THREE.CatmullRomCurve3(pts);
+  }, [params?.curva]);
+  const inicio = curva3.getPoint(0);
+  const fin = curva3.getPoint(1);
   return (
     <group>
       {/* la ladera por la que baja el agua */}
@@ -40,21 +205,34 @@ function Diorama({ params, tinte, reducedMotion }) {
         <boxGeometry args={[3.6, 0.5, 2.4]} />
         <meshLambertMaterial color="#7d9a5c" flatShading />
       </mesh>
-      {/* el nacimiento arriba */}
-      <mesh position={[-1.8, 2.25, 0.4]}>
+      {/* el nacimiento arriba (donde arranca la curva) */}
+      <mesh position={[inicio.x, inicio.y + 0.05, inicio.z]}>
         <cylinderGeometry args={[0.34, 0.4, 0.16, 14]} />
         <meshLambertMaterial color={color} transparent opacity={0.85} />
       </mesh>
-      <Cinta curva={params?.curva} color={color} reducedMotion={reducedMotion} />
-      {/* el tanque que recibe el agua */}
-      <mesh position={[1.5, -0.1, 0.5]}>
+      <Cinta curva3={curva3} color={color} reducedMotion={reducedMotion} />
+      <Gotas curva3={curva3} color={color} reducedMotion={reducedMotion} />
+      {/* el tanque que recibe el agua (donde termina la curva) */}
+      <mesh position={[fin.x + 0.1, fin.y + 0.05, fin.z]}>
         <cylinderGeometry args={[0.55, 0.6, 0.7, 18]} />
         <meshLambertMaterial color="#9a8b74" flatShading />
       </mesh>
-      <mesh position={[1.5, 0.1, 0.5]}>
+      <mesh position={[fin.x + 0.1, fin.y + 0.25, fin.z]}>
         <cylinderGeometry args={[0.5, 0.5, 0.12, 18]} />
         <meshLambertMaterial color={color} transparent opacity={0.8} />
       </mesh>
+      {/* los hitos del recorrido (por datos; opcionales) */}
+      {hitos?.ronda && <Ronda curva3={curva3} tramo={hitos.ronda.tramo} arboles={hitos.ronda.arboles} />}
+      {hitos?.riesgo && <PuntoCuidado curva3={curva3} t={hitos.riesgo.t} lado={hitos.riesgo.lado} />}
+      {hitos?.bocatoma && <Bocatoma curva3={curva3} t={hitos.bocatoma.t} color={color} />}
+      {hitos?.cultivo && (
+        <Cultivo
+          pos={hitos.cultivo.pos}
+          surcos={hitos.cultivo.surcos}
+          desde={[fin.x + 0.1, fin.y + 0.1, fin.z]}
+          color={color}
+        />
+      )}
     </group>
   );
 }

--- a/src/visual/mundo3d/escenas/EscenaRecinto.jsx
+++ b/src/visual/mundo3d/escenas/EscenaRecinto.jsx
@@ -1,0 +1,80 @@
+/*
+ * EscenaRecinto — ARQUETIPO `recinto`: el CORRAL y su ciclo cerrado.
+ *
+ * El corral es un LUGAR reconocible, y el ciclo (animal → estiércol → suelo →
+ * planta → animal) es una FORMA que se camina: un anillo espacial. Aquí: un piso
+ * circular cercado, animales low-poly (`params.animales`), y un aro de "ciclo"
+ * (torus) que ancla la idea de cerrar el ciclo del abono. `MeshLambert`/`Basic`,
+ * sin sombras.
+ */
+import { useMemo } from 'react';
+import EscenaBase3D from './EscenaBase3D.jsx';
+
+/* Un animal esquemático: cuerpo + cabeza, tono propio. */
+function Animalito({ pos, color }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.28, 0]}>
+        <capsuleGeometry args={[0.18, 0.34, 4, 8]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+      <mesh position={[0.24, 0.42, 0]}>
+        <sphereGeometry args={[0.14, 8, 8]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+function Diorama({ params }) {
+  const animales = params?.animales || [
+    { color: '#e7d9c2', pos: [-0.7, 0, 0.4] },
+    { color: '#c98a5a', pos: [0.6, 0, -0.3] },
+    { color: '#d8c49a', pos: [0.1, 0, 0.7] },
+  ];
+  const postes = useMemo(() => {
+    const n = 12;
+    return Array.from({ length: n }, (_, i) => {
+      const a = (i / n) * Math.PI * 2;
+      return /** @type {[number, number, number]} */ ([Math.cos(a) * 1.9, 0.2, Math.sin(a) * 1.9]);
+    });
+  }, []);
+  return (
+    <group>
+      {/* piso del corral */}
+      <mesh position={[0, -0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[2, 28]} />
+        <meshLambertMaterial color="#a98a5c" />
+      </mesh>
+      {/* la cerca: postes en anillo */}
+      {postes.map((p, i) => (
+        <mesh key={i} position={p}>
+          <cylinderGeometry args={[0.05, 0.06, 0.5, 5]} />
+          <meshLambertMaterial color="#8a6a44" flatShading />
+        </mesh>
+      ))}
+      {/* el aro del CICLO cerrado (abono que vuelve) */}
+      <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[1.25, 0.05, 8, 40]} />
+        <meshBasicMaterial color="#7a9a3f" transparent opacity={0.7} />
+      </mesh>
+      {/* pila de estiércol/abono al centro (cierre del ciclo) */}
+      <mesh position={[0, 0.14, 0]}>
+        <coneGeometry args={[0.4, 0.28, 10]} />
+        <meshLambertMaterial color="#5a4326" flatShading />
+      </mesh>
+      {animales.map((a, i) => (
+        <Animalito key={i} pos={a.pos} color={a.color} />
+      ))}
+    </group>
+  );
+}
+
+export default function EscenaRecinto(props) {
+  const cielo = { fondo: '#ecdcc2', cielo: '#f6ead2', suelo: '#8a6a44', intensidad: 1.05 };
+  return (
+    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.4, 0] }}>
+      <Diorama params={props.params} />
+    </EscenaBase3D>
+  );
+}

--- a/src/visual/mundo3d/escenas/EscenaValle.jsx
+++ b/src/visual/mundo3d/escenas/EscenaValle.jsx
@@ -1,0 +1,30 @@
+/*
+ * EscenaValle — ARQUETIPO `valle`: el MAPA de la finca (la capa lejana).
+ *
+ * A diferencia de los otros arquetipos (dioramas enfocados que comparten
+ * `EscenaBase3D`), el valle YA es una escena-mapa completa y autocontenida:
+ * `Valle3D` (traído byte-fiel del mockup "El valle de mi finca"). Este arquetipo
+ * es un ADAPTADOR: traduce el contrato uniforme del framework a las props de
+ * `Valle3D`, para que el mapa sea "un mundo más" del registro. Tocar un landmark
+ * (un mundo del valle) sale por `onHotspot('mundo', { mundoId })` — el host
+ * decide si abre ese mundo con `<Mundo>` o navega a su 2D.
+ *
+ * El componente físico vive en `src/mockups/valle` (el mockup del mapa); aquí solo
+ * se adapta, sin redibujarlo — misma geometría procedural, mismo chunk perezoso.
+ */
+import Valle3D from '../../../mockups/valle/Valle3D.jsx';
+
+export default function EscenaValle({ params, entrada, reducedMotion = false, onHotspot, animo = 'sereno', energia = 1 }) {
+  const clima = params?.clima || entrada?.clima || 'soleado';
+  return (
+    <Valle3D
+      clima={clima}
+      focoId={null}
+      animo={animo}
+      energia={energia}
+      reducedMotion={reducedMotion}
+      onEntrar={(id) => onHotspot?.('mundo', { mundoId: id })}
+      onAlerta={() => onHotspot?.(entrada?.alertaView || 'hoy_finca')}
+    />
+  );
+}

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -1,0 +1,81 @@
+/*
+ * useEntradaAbeja + AbejaEscena — LA COREOGRAFÍA COMPARTIDA de Angelita.
+ *
+ * El DR de mundos-3D pide que "la abeja baja y entra" viva UNA sola vez y la
+ * herede toda escena-mundo (§4.4). Aquí está: extraída del `CompaneroAbeja` del
+ * valle (Valle3D), generalizada para cualquier arquetipo. La ESCENA solo le pasa
+ * el `foco` (posición del hotspot activo o el centro del diorama); el hook mueve
+ * a Angelita con `lerp` hacia él, la hace flotar según su energía, y la voltea a
+ * mirar hacia donde viaja. El CUERPO siempre es `<AbejaAngelita>` (la creature
+ * de la librería): la escena POSEE la coreografía, la creature POSEE el cuerpo.
+ *
+ * Vive dentro de escenas/ (chunk perezoso `vendor-three`): importa @react-three
+ * y three, así que NUNCA se importa desde el barrel base del framework.
+ */
+/* eslint-disable react-refresh/only-export-components -- este módulo (hook de
+   coreografía + su componente de escena) se importa SIEMPRE perezoso dentro de
+   un <Canvas> vía EscenaBase3D; no es hot-reload-sensible. Van juntos a propósito:
+   la creature posee el cuerpo, la escena posee la coreografía (contrato del DR). */
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import * as THREE from 'three';
+import { AbejaAngelita } from '../../creatures/AbejaAngelita.jsx';
+
+/**
+ * Devuelve `{ ref, caraRef }` para colgar del `<group>` de la abeja y de su cara
+ * (para el volteo). Corre `useFrame` (debe usarse DENTRO de un `<Canvas>`).
+ *
+ * @param {THREE.Vector3} foco  a dónde va la abeja (hotspot activo o centro).
+ * @param {object} [opts]
+ * @param {boolean} [opts.entrando=true]  entrando = se posa junto al foco; si no, ronda.
+ * @param {number}  [opts.energia=1]      0..1 — vivacidad del vuelo (de la salud real).
+ * @param {boolean} [opts.reducedMotion=false]  congela el vaivén a un fotograma.
+ */
+export function useEntradaAbeja(foco, { entrando = true, energia = 1, reducedMotion = false } = {}) {
+  const ref = useRef(null);
+  const caraRef = useRef(null);
+  const prevX = useRef(foco.x);
+  useFrame((state) => {
+    if (!ref.current) return;
+    const t = state.clock.elapsedTime;
+    const brio = 0.35 + 0.65 * energia; // la energía anima el vuelo
+    const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.06 + 0.12 * brio);
+    // Al reposo deriva en un círculo calmo; al entrar se posa junto al lugar.
+    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.6;
+    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.4;
+    const dest = new THREE.Vector3(
+      foco.x + (entrando ? 0.45 : 0.35 + vagarX),
+      foco.y + (entrando ? 0.85 : 1.6) + bob,
+      foco.z + (entrando ? 0.6 : 0.55 + vagarZ),
+    );
+    ref.current.position.lerp(dest, entrando ? 0.06 : 0.05);
+    if (caraRef.current) {
+      const vx = ref.current.position.x - prevX.current;
+      if (Math.abs(vx) > 0.0015) caraRef.current.style.transform = `scaleX(${vx < 0 ? -1 : 1})`;
+      prevX.current = ref.current.position.x;
+    }
+  });
+  return { ref, caraRef };
+}
+
+/**
+ * Angelita ya montada en una escena: usa `useEntradaAbeja` para la coreografía y
+ * dibuja el cuerpo (`AbejaAngelita`) como billboard `<Html>`. Cualquier arquetipo
+ * la coloca con `<AbejaEscena foco=… animo=… energia=… reducedMotion=… />`.
+ */
+export function AbejaEscena({ foco, entrando = true, animo = 'sereno', energia = 1, reducedMotion = false }) {
+  const { ref, caraRef } = useEntradaAbeja(foco, { entrando, energia, reducedMotion });
+  const size = 40 + Math.round(energia * 12);
+  return (
+    <group ref={ref} position={[foco.x + 0.45, foco.y + 0.85, foco.z + 0.6]}>
+      <Html center distanceFactor={7} zIndexRange={[40, 10]}>
+        <div className="mundo-abeja" aria-hidden="true">
+          <div ref={caraRef} className="mundo-abeja__cara">
+            <AbejaAngelita size={size} animo={animo} energia={energia} animated={!reducedMotion} />
+          </div>
+        </div>
+      </Html>
+    </group>
+  );
+}

--- a/src/visual/mundo3d/index.js
+++ b/src/visual/mundo3d/index.js
@@ -1,0 +1,30 @@
+/*
+ * src/visual/mundo3d — EL FRAMEWORK DE MUNDOS (2D + 3D data-driven).
+ *
+ * Un solo host `<Mundo>` monta CUALQUIER mundo de la finca eligiendo un ARQUETIPO
+ * por datos y cruzándolo con el device-tier: dioramas 3D (cutaway/flujo/recinto/
+ * estratos/valle) o arquetipos 2D de primera clase (mirror/lamina/infografia/
+ * ficha/valle2d). Sumar un mundo = una entrada en `mundoData.js` + assets de la
+ * librería visual; NUNCA código de escena nuevo.
+ *
+ *   import Mundo, { MUNDO, ARQUETIPOS, resolverMundo, decidirTier } from '.../visual/mundo3d';
+ *
+ * IMPORTANTE (code-split): este barrel NO importa `three`/`@react-three`. Los
+ * dioramas 3D (carpeta `escenas/`) y su hook `useEntradaAbeja` se cargan PEREZOSO
+ * desde `<Mundo>` (chunk `vendor-three`), así que importar el barrel NO infla el
+ * bundle base. Para montar un arquetipo 3D suelto (p. ej. el storybook), impórtelo
+ * con `React.lazy(() => import('.../mundo3d/escenas/EscenaCutaway.jsx'))`.
+ */
+
+// El host (2D estático + 3D perezoso adentro).
+export { default } from './Mundo.jsx';
+export { default as Mundo } from './Mundo.jsx';
+export { default as Mundo2D } from './Mundo2D.jsx';
+
+// Datos + arquetipos + resolución (three-free, seguros en el bundle base).
+export { MUNDO, MUNDO_IDS } from './mundoData.js';
+export {
+  ARQUETIPOS, ARQUETIPOS_KEYS, ARQUETIPOS_3D, ARQUETIPOS_2D, esArquetipo3D,
+} from './arquetipos.js';
+export { resolverMundo, tinteDeMundo, tituloDeMundo } from './resolverMundo.js';
+export { decidirTier, permite3D } from './deviceTier.js';

--- a/src/visual/mundo3d/laminas2d/Ficha.jsx
+++ b/src/visual/mundo3d/laminas2d/Ficha.jsx
@@ -1,0 +1,52 @@
+/*
+ * Ficha — ARQUETIPO 2D `ficha` (dim '2d'): la TARJETA DE ESPECIE.
+ *
+ * Para los mundos que son fichas foto-secuenciales (frutales, botica, café): el
+ * espacio 3D no agrega (DR §3.3) y el mundo declara este arquetipo. Cabecera
+ * (emoji + nombre común + binomio), hechos en lista, y hotspots. Puede incrustar
+ * una lámina de la librería (`params.lamina`) o una creature como retrato.
+ */
+export default function Ficha({ params, hotspots = [], tinte, onHotspot, titulo, retrato }) {
+  const acento = (tinte && tinte[0]) || '#3f7d4e';
+  const hechos = params?.hechos || [];
+  return (
+    <div className="mundo2d mundo2d--ficha" style={{ '--m2d-tinte': acento }}>
+      <header className="mundo2d__ficha-head">
+        {retrato ? <div className="mundo2d__retrato">{retrato}</div> : (
+          <span className="mundo2d__ficha-emoji" aria-hidden="true">{params?.emoji || '🌱'}</span>
+        )}
+        <div>
+          <h3 className="mundo2d__titulo">{titulo || params?.nombre || 'Especie'}</h3>
+          {params?.cientifico && <p className="mundo2d__sci">{params.cientifico}</p>}
+        </div>
+      </header>
+      {hechos.length > 0 && (
+        <dl className="mundo2d__hechos">
+          {hechos.map((h, i) => (
+            <div key={i} className="mundo2d__hecho">
+              <dt>{h.clave}</dt>
+              <dd>{h.valor}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {hotspots.length > 0 && (
+        <div className="mundo2d__hotspots mundo2d__hotspots--info">
+          {hotspots.map((h) => (
+            <button
+              key={h.id}
+              type="button"
+              className="mundo2d__hotspot"
+              style={{ '--hs-tinte': acento }}
+              onClick={() => onHotspot?.(h.view, h.data)}
+              aria-label={h.label}
+            >
+              <span className="mundo2d__emoji" aria-hidden="true">{h.emoji}</span>
+              <span className="mundo2d__txt">{h.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/visual/mundo3d/laminas2d/Infografia.jsx
+++ b/src/visual/mundo3d/laminas2d/Infografia.jsx
@@ -1,0 +1,56 @@
+/*
+ * Infografia — ARQUETIPO 2D `infografia` (dim '2d'): DATO / CIFRAS de PRIMERA
+ * CLASE, no un fallback.
+ *
+ * Para los mundos cuyo valor ES el dato/dosis/precio/diagnóstico (mercado,
+ * toxicología, boletín del clima): el 3D sería ruido (DR §3.3), así que el mundo
+ * declara DIRECTO este arquetipo. Una tarjeta con cifras grandes + notas + los
+ * hotspots como accesos. Todo por datos: `params.cifras`, `params.notas`.
+ */
+export default function Infografia({ params, hotspots = [], tinte, onHotspot, titulo }) {
+  const acento = (tinte && tinte[0]) || '#b98a2f';
+  const cifras = params?.cifras || [];
+  const notas = params?.notas || [];
+  return (
+    <div className="mundo2d mundo2d--info" style={{ '--m2d-tinte': acento }}>
+      {(titulo || params?.titulo) && <h3 className="mundo2d__titulo">{titulo || params.titulo}</h3>}
+      {cifras.length > 0 && (
+        <ul className="mundo2d__cifras">
+          {cifras.map((c, i) => (
+            <li key={i} className="mundo2d__cifra">
+              <span className="mundo2d__valor">
+                {c.valor}
+                {c.unidad ? <span className="mundo2d__unidad">{c.unidad}</span> : null}
+              </span>
+              <span className="mundo2d__cifra-label">{c.label}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {notas.length > 0 && (
+        <ul className="mundo2d__notas">
+          {notas.map((n, i) => (
+            <li key={i}>{n}</li>
+          ))}
+        </ul>
+      )}
+      {hotspots.length > 0 && (
+        <div className="mundo2d__hotspots mundo2d__hotspots--info">
+          {hotspots.map((h) => (
+            <button
+              key={h.id}
+              type="button"
+              className="mundo2d__hotspot"
+              style={{ '--hs-tinte': acento }}
+              onClick={() => onHotspot?.(h.view, h.data)}
+              aria-label={h.label}
+            >
+              <span className="mundo2d__emoji" aria-hidden="true">{h.emoji}</span>
+              <span className="mundo2d__txt">{h.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/visual/mundo3d/laminas2d/LaminaCultivo.jsx
+++ b/src/visual/mundo3d/laminas2d/LaminaCultivo.jsx
@@ -1,0 +1,44 @@
+/*
+ * LaminaCultivo — ARQUETIPO 2D `lamina` (dim '2d'): la FICHA ILUSTRADA que REUSA
+ * `src/visual/laminas`.
+ *
+ * El caso de reuso de libro: un mundo-cultivo (maíz, cafeto, mata por etapa)
+ * muestra la lámina dibujada a mano de la librería visual, elegida por datos
+ * (`params.lamina` = slug del registro LAMINAS) con sus props de dominio
+ * (`params.laminaProps`), + los hotspots. Sumar un mundo así = un slug + hotspots.
+ */
+import { LAMINAS } from '../../laminas/index.js';
+
+export default function LaminaCultivo({ params, hotspots = [], tinte, onHotspot, titulo }) {
+  const acento = (tinte && tinte[0]) || '#3f8f4e';
+  const slug = params?.lamina;
+  const entry = slug ? LAMINAS[slug] : null;
+  const Lamina = entry?.Component;
+  return (
+    <div className="mundo2d mundo2d--lamina" style={{ '--m2d-tinte': acento }}>
+      {(titulo || entry?.nombre) && <h3 className="mundo2d__titulo">{titulo || entry.nombre}</h3>}
+      <div className="mundo2d__lamina-stage">
+        {Lamina ? <Lamina {...(params?.laminaProps || {})} /> : (
+          <p className="mundo2d__vacio">Lámina no encontrada: <code>{String(slug)}</code></p>
+        )}
+      </div>
+      {hotspots.length > 0 && (
+        <div className="mundo2d__hotspots">
+          {hotspots.map((h) => (
+            <button
+              key={h.id}
+              type="button"
+              className="mundo2d__hotspot"
+              style={{ '--hs-tinte': acento }}
+              onClick={() => onHotspot?.(h.view, h.data)}
+              aria-label={h.label}
+            >
+              <span className="mundo2d__emoji" aria-hidden="true">{h.emoji}</span>
+              <span className="mundo2d__txt">{h.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
+++ b/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
@@ -1,0 +1,129 @@
+/*
+ * LaminaMundo — el ESPEJO 2D de los arquetipos 3D (dim '2d').
+ *
+ * Cuando el equipo es humilde (tier bajo/sin-WebGL) o el mundo se pide en 2D, el
+ * diorama 3D cae AQUÍ: una lámina SVG dibujada del mismo motivo (corte de suelo,
+ * camino del agua, corral, estratos), con los MISMOS hotspots como botones
+ * reales. Es el "piso digno" del DR (§4.4): nunca una pantalla de error. Lee los
+ * MISMOS `params` que el arquetipo 3D (capas/curva/animales/estratos) + los
+ * hotspots, así que sumar el espejo de un mundo no cuesta datos nuevos.
+ */
+
+/* Fondo SVG por motivo. Cada uno usa el `tinte` del mundo para no desentonar. */
+function FondoCutaway({ params, acento }) {
+  const capas = params?.capas || [];
+  const vida = Math.max(0, Math.min(1, params?.vida ?? 0.6));
+  // offsets acumulados sin reasignar (immutabilidad en render)
+  const alturas = capas.map((c) => 24 + (c.alto || 0.6) * 22);
+  const tops = alturas.reduce(
+    (acc, h, i) => [...acc, acc[i] + h],
+    [26],
+  );
+  const bandas = capas.map((c, i) => ({
+    key: i, y: tops[i], h: alturas[i], color: c.color || '#5a3d28', bichos: c.bichos || [],
+  }));
+  const n = Math.round(vida * 4);
+  const bichos = bandas.flatMap((b, bi) =>
+    Array.from({ length: n }, (_, i) => ({
+      key: `${bi}-${i}`,
+      tipo: b.bichos[i % Math.max(1, b.bichos.length)] || 'raiz',
+      bx: 30 + ((i * 47 + bi * 23) % 240),
+      by: b.y + 8 + ((i * 13) % Math.max(6, b.h - 12)),
+    })),
+  );
+  return (
+    <g>
+      <rect x="0" y="0" width="300" height="26" fill="#6f9a45" />
+      {bandas.map((b) => (
+        <rect key={b.key} x="0" y={b.y} width="300" height={b.h} fill={b.color} />
+      ))}
+      {bichos.map((v) =>
+        v.tipo === 'lombriz' ? (
+          <path key={v.key} d={`M${v.bx},${v.by} q6,-5 12,0 q6,5 12,0`} stroke="#e8b6a6" strokeWidth="3" fill="none" strokeLinecap="round" />
+        ) : v.tipo === 'hifa' ? (
+          <line key={v.key} x1={v.bx} y1={v.by} x2={v.bx + 10} y2={v.by + 12} stroke="#f2ece0" strokeWidth="1" />
+        ) : (
+          <path key={v.key} d={`M${v.bx},${v.by} l3,14 l-2,10`} stroke="#c9a86a" strokeWidth="2" fill="none" strokeLinecap="round" />
+        ),
+      )}
+      <rect x="0" y="0" width="300" height="200" fill="none" stroke={acento} strokeWidth="2" opacity="0.4" />
+    </g>
+  );
+}
+
+function FondoFlujo({ acento }) {
+  return (
+    <g>
+      <rect x="0" y="0" width="300" height="200" fill="#eaf3f5" />
+      <path d="M0,150 L120,150 L300,70 L300,200 L0,200 Z" fill="#8ba56a" />
+      <circle cx="40" cy="40" r="16" fill={acento} opacity="0.85" />
+      <path d="M40,52 C80,90 140,110 200,150 C230,168 250,175 270,178" stroke={acento} strokeWidth="7" fill="none" strokeLinecap="round" opacity="0.8" />
+      <rect x="245" y="150" width="44" height="34" rx="4" fill="#9a8b74" />
+      <rect x="249" y="150" width="36" height="8" fill={acento} opacity="0.8" />
+    </g>
+  );
+}
+
+function FondoRecinto({ acento }) {
+  return (
+    <g>
+      <rect x="0" y="0" width="300" height="200" fill="#f2e6cf" />
+      <ellipse cx="150" cy="120" rx="120" ry="60" fill="#a98a5c" />
+      <ellipse cx="150" cy="120" rx="90" ry="44" fill="none" stroke={acento} strokeWidth="3" strokeDasharray="6 5" opacity="0.7" />
+      <path d="M135,120 l30,0 l-15,-18 Z" fill="#5a4326" />
+      <ellipse cx="110" cy="118" rx="16" ry="11" fill="#e7d9c2" />
+      <ellipse cx="188" cy="126" rx="15" ry="10" fill="#c98a5a" />
+    </g>
+  );
+}
+
+function FondoEstratos({ params, acento }) {
+  const estratos = params?.estratos || [
+    { color: '#2f5f34' }, { color: '#3a6f3f' }, { color: '#4a7d45' }, { color: '#5f8a3f' },
+    { color: '#7aa24a' }, { color: '#8fae55' }, { color: '#8a6a44' },
+  ];
+  const n = estratos.length;
+  return (
+    <g>
+      <rect x="0" y="0" width="300" height="200" fill="#eaf2df" />
+      {estratos.map((e, i) => {
+        const bandH = 200 / n;
+        const y = i * bandH;
+        return <rect key={i} x="0" y={y} width="300" height={bandH} fill={e.color} opacity={0.9 - i * 0.02} />;
+      })}
+      <line x1="150" y1="0" x2="150" y2="200" stroke={acento} strokeWidth="1.5" strokeDasharray="4 4" opacity="0.5" />
+    </g>
+  );
+}
+
+const FONDOS = { cutaway: FondoCutaway, flujo: FondoFlujo, recinto: FondoRecinto, estratos: FondoEstratos };
+
+export default function LaminaMundo({ params, hotspots = [], tinte, onHotspot, motivo = 'cutaway', titulo }) {
+  const acento = (tinte && tinte[0]) || '#3f8f4e';
+  const Fondo = FONDOS[motivo] || FondoCutaway;
+  return (
+    <div className="mundo2d" style={{ '--m2d-tinte': acento }}>
+      <div className="mundo2d__lienzo">
+        <svg viewBox="0 0 300 200" className="mundo2d__svg" role="img"
+          aria-label={titulo || `Lámina del mundo (${motivo})`}>
+          <Fondo params={params} acento={acento} />
+        </svg>
+        <div className="mundo2d__hotspots">
+          {hotspots.map((h) => (
+            <button
+              key={h.id}
+              type="button"
+              className="mundo2d__hotspot"
+              style={{ '--hs-tinte': acento }}
+              onClick={() => onHotspot?.(h.view, h.data)}
+              aria-label={h.label}
+            >
+              <span className="mundo2d__emoji" aria-hidden="true">{h.emoji}</span>
+              <span className="mundo2d__txt">{h.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
+++ b/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
@@ -51,15 +51,63 @@ function FondoCutaway({ params, acento }) {
   );
 }
 
-function FondoFlujo({ acento }) {
+/* Un arbolito SVG (la ronda hídrica del gemelo 2D). */
+function Arbolito2D({ x, y, s = 1 }) {
+  return (
+    <g transform={`translate(${x},${y}) scale(${s})`}>
+      <rect x="-1.6" y="0" width="3.2" height="7" fill="#7a5a38" />
+      <path d="M0,-16 L9,2 L-9,2 Z" fill="#3f6f3a" />
+      <path d="M0,-22 L6,-8 L-6,-8 Z" fill="#4d7f42" />
+    </g>
+  );
+}
+
+function FondoFlujo({ params, acento }) {
+  const hitos = params?.hitos;
   return (
     <g>
       <rect x="0" y="0" width="300" height="200" fill="#eaf3f5" />
       <path d="M0,150 L120,150 L300,70 L300,200 L0,200 Z" fill="#8ba56a" />
+      {/* la ronda que protege el nacimiento (misma data que el diorama 3D) */}
+      {hitos?.ronda && (
+        <g>
+          <ellipse cx="52" cy="52" rx="46" ry="30" fill="#4d7f42" opacity="0.18" />
+          {Array.from({ length: hitos.ronda.arboles || 5 }, (_, i) => (
+            <Arbolito2D key={i} x={22 + i * 16} y={38 + (i % 2) * 18} s={0.8 + (i % 3) * 0.2} />
+          ))}
+        </g>
+      )}
+      {/* el nacimiento y la quebrada que baja */}
       <circle cx="40" cy="40" r="16" fill={acento} opacity="0.85" />
       <path d="M40,52 C80,90 140,110 200,150 C230,168 250,175 270,178" stroke={acento} strokeWidth="7" fill="none" strokeLinecap="round" opacity="0.8" />
+      {/* el punto de CUIDADO: barril y señal ámbar, didáctico — no catástrofe */}
+      {hitos?.riesgo && (
+        <g>
+          <rect x="128" y="88" width="12" height="14" rx="2" fill="#8b8b8b" />
+          <line x1="148" y1="102" x2="148" y2="80" stroke="#7a5a38" strokeWidth="2" />
+          <rect x="148" y="78" width="16" height="10" rx="1.5" fill="#d9a13b" />
+        </g>
+      )}
+      {/* la bocatoma sobre la quebrada */}
+      {hitos?.bocatoma && (
+        <g>
+          <rect x="188" y="134" width="18" height="14" rx="2" fill="#a8a094" />
+          <rect x="190" y="134" width="14" height="4" fill={acento} opacity="0.8" />
+        </g>
+      )}
+      {/* el tanque que recibe el agua */}
       <rect x="245" y="150" width="44" height="34" rx="4" fill="#9a8b74" />
       <rect x="249" y="150" width="36" height="8" fill={acento} opacity="0.8" />
+      {/* la huerta regada: surcos + canalito desde el tanque (el final feliz) */}
+      {hitos?.cultivo && (
+        <g>
+          <line x1="245" y1="172" x2="212" y2="182" stroke={acento} strokeWidth="3" opacity="0.75" strokeLinecap="round" />
+          <rect x="160" y="172" width="54" height="24" rx="3" fill="#6b4a2e" />
+          {Array.from({ length: hitos.cultivo.surcos || 4 }, (_, i) => (
+            <rect key={i} x="164" y={175 + i * 5.4} width="46" height="3" rx="1.5" fill="#5f8a3f" />
+          ))}
+        </g>
+      )}
     </g>
   );
 }

--- a/src/visual/mundo3d/laminas2d/MundoValle2D.jsx
+++ b/src/visual/mundo3d/laminas2d/MundoValle2D.jsx
@@ -1,0 +1,25 @@
+/*
+ * MundoValle2D — el ESPEJO 2D del arquetipo `valle` (dim '2d').
+ *
+ * Cuando el mapa se pide en 2D (tier bajo/sin-WebGL), cae al `Valle2DFallback`
+ * traído byte-fiel del mockup del valle: proyección isométrica SVG con los
+ * mismos mundos tocables, la alerta, la abeja y el clima que tiñe. Este adaptador
+ * traduce el contrato del framework a sus props (igual que `EscenaValle` con el
+ * 3D). El componente físico vive en `src/mockups/valle`; aquí solo se adapta.
+ */
+import Valle2DFallback from '../../../mockups/valle/Valle2DFallback.jsx';
+
+export default function MundoValle2D({ params, entrada, reducedMotion = false, onHotspot, animo = 'sereno', energia = 1 }) {
+  const clima = params?.clima || entrada?.clima || 'soleado';
+  return (
+    <Valle2DFallback
+      clima={clima}
+      focoId={null}
+      animo={animo}
+      energia={energia}
+      reducedMotion={reducedMotion}
+      onEntrar={(id) => onHotspot?.('mundo', { mundoId: id })}
+      onAlerta={() => onHotspot?.(entrada?.alertaView || 'hoy_finca')}
+    />
+  );
+}

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -1,0 +1,231 @@
+/*
+ * mundo.css — estilos del framework de mundos (host 3D/2D, hotspots, abeja,
+ * arquetipos 2D). Autocontenido: cero imágenes/fuentes externas. Solo
+ * transform/opacity animados; reduced-motion las apaga.
+ */
+
+.mundo-root {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  display: flex;
+  overflow: hidden;
+  background: #ece0c7;
+  border-radius: 14px;
+}
+.mundo-root[data-dim='2d'] {
+  background: transparent;
+}
+
+.mundo-canvas {
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+.mundo-canvas--listo {
+  opacity: 1;
+}
+
+/* ── Hotspot 3D: botón-billboard accesible sobre el diorama ─────────────── */
+.mundo-hotspot {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.34em 0.7em 0.34em 0.4em;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #2a2016;
+  background: rgba(255, 251, 242, 0.94);
+  border: 2px solid var(--hs-tinte, #3f8f4e);
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  box-shadow: 0 3px 10px rgba(40, 30, 10, 0.22);
+  transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+.mundo-hotspot:hover,
+.mundo-hotspot:focus-visible {
+  transform: translateY(-2px) scale(1.04);
+  box-shadow: 0 6px 16px rgba(40, 30, 10, 0.28);
+  outline: none;
+}
+.mundo-hotspot--activo {
+  background: var(--hs-tinte, #3f8f4e);
+  color: #fff;
+}
+.mundo-hotspot__emoji {
+  font-size: 1.15em;
+  line-height: 1;
+}
+
+/* ── Angelita dentro de la escena (billboard) ──────────────────────────── */
+.mundo-abeja {
+  pointer-events: none;
+  filter: drop-shadow(0 4px 8px rgba(40, 30, 10, 0.28));
+}
+.mundo-abeja__cara {
+  transition: transform 0.2s ease;
+  transform-origin: center;
+}
+
+/* ── Cargando (mientras baja el chunk 3D) ──────────────────────────────── */
+.mundo-cargando {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  color: #4a3a22;
+  background: color-mix(in srgb, var(--m-tinte, #3f8f4e) 16%, #f2e8d6);
+}
+.mundo-cargando__pulso {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--m-tinte, #3f8f4e);
+  animation: mundo-pulso 1.4s ease-in-out infinite;
+}
+@keyframes mundo-pulso {
+  0%, 100% { transform: scale(0.7); opacity: 0.55; }
+  50% { transform: scale(1); opacity: 1; }
+}
+
+/* ── Botón salir ───────────────────────────────────────────────────────── */
+.mundo-salir {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 5;
+  padding: 0.4em 0.9em;
+  font: inherit;
+  font-weight: 600;
+  color: #2a2016;
+  background: rgba(255, 251, 242, 0.92);
+  border: 1px solid rgba(60, 46, 24, 0.25);
+  border-radius: 999px;
+  cursor: pointer;
+}
+.mundo-salir:focus-visible {
+  outline: 2px solid #3f8f4e;
+  outline-offset: 2px;
+}
+
+/* ── Arquetipos 2D (mirror / infografia / ficha / lamina) ──────────────── */
+.mundo2d {
+  width: 100%;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  color: #2a2016;
+}
+.mundo2d__lienzo {
+  position: relative;
+}
+.mundo2d__svg {
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  display: block;
+}
+.mundo2d__titulo {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+.mundo2d__sci {
+  margin: 0.1rem 0 0;
+  font-style: italic;
+  opacity: 0.7;
+  font-size: 0.85rem;
+}
+
+.mundo2d__hotspots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.mundo2d__hotspots--info {
+  margin-top: 0.2rem;
+}
+.mundo2d__hotspot {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.5em 0.9em;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #2a2016;
+  background: #fffdf7;
+  border: 2px solid var(--hs-tinte, #3f8f4e);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+.mundo2d__hotspot:hover,
+.mundo2d__hotspot:focus-visible {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--hs-tinte, #3f8f4e) 12%, #fffdf7);
+  outline: none;
+}
+.mundo2d__emoji { font-size: 1.15em; line-height: 1; }
+
+/* infografía */
+.mundo2d__cifras {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 0.7rem;
+}
+.mundo2d__cifra {
+  padding: 0.8rem;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--m2d-tinte, #b98a2f) 12%, #fffaf0);
+  border: 1px solid color-mix(in srgb, var(--m2d-tinte, #b98a2f) 30%, transparent);
+}
+.mundo2d__valor {
+  display: block;
+  font-size: 1.6rem;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--m2d-tinte, #b98a2f);
+}
+.mundo2d__unidad { font-size: 0.9rem; font-weight: 600; margin-left: 0.2em; }
+.mundo2d__cifra-label { display: block; margin-top: 0.35rem; font-size: 0.82rem; opacity: 0.85; }
+.mundo2d__notas {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+/* ficha */
+.mundo2d__ficha-head { display: flex; align-items: center; gap: 0.8rem; }
+.mundo2d__ficha-emoji { font-size: 2.6rem; line-height: 1; }
+.mundo2d__retrato { width: 64px; height: 64px; }
+.mundo2d__hechos { margin: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.mundo2d__hecho { display: flex; flex-direction: column; }
+.mundo2d__hecho dt { font-weight: 700; font-size: 0.8rem; opacity: 0.7; }
+.mundo2d__hecho dd { margin: 0.1rem 0 0; font-size: 0.95rem; }
+
+/* lamina */
+.mundo2d__lamina-stage { width: 100%; max-width: 420px; margin: 0 auto; }
+.mundo2d__vacio { text-align: center; opacity: 0.7; }
+
+@media (prefers-reduced-motion: reduce) {
+  .mundo-canvas { transition: none; }
+  .mundo-cargando__pulso { animation: none; }
+  .mundo-hotspot,
+  .mundo2d__hotspot { transition: none; }
+}

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -1,0 +1,225 @@
+/*
+ * MUNDO — el REGISTRO DATA-DRIVEN de los mundos de la finca.
+ *
+ * EL CORAZÓN DEL FRAMEWORK (DR §4.2, ajustado a 2D+3D de primera clase). Una
+ * entrada por mundo; TODO lo específico es datos, no código:
+ *
+ *   MUNDO[id] = {
+ *     escena,     // clave de ARQUETIPOS (3D o 2D) — o null (salta directo al 2D real)
+ *     params,     // props del arquetipo (deterministas; se comparten 2D↔3D donde aplica)
+ *     hotspots,   // 3-5 puntos tocables; cada `view` es una vista REAL de App.jsx
+ *     entrada,    // { zoom, narra, clima… } — cómo entra la abeja / narra la voz
+ *     fallback2d, // (opcional) { escena, params } del arquetipo 2D si el 3D degrada
+ *     ruta2d,     // (escena:null) navegar directo a la vista 2D real
+ *     valle,      // (opcional) landmark en el mapa del valle: { tipo, pos, escala }
+ *     gate,       // (opcional) perfil requerido (p.ej. 'animales')
+ *     ambiental,  // (opcional) el clima ya vive en el ambiente del valle
+ *   }
+ *
+ * Sumar un mundo = UNA de estas entradas + assets de la librería (lámina/creature/
+ * geometría de arquetipo ya existente). Cero código de escena nuevo.
+ *
+ * Título/emoji/tinte NO se duplican: se resuelven contra el manifiesto real
+ * (mundosFinca.js) en `resolverTinte`/`tituloMundo` (mundo host).
+ */
+
+export const MUNDO = {
+  // ── SÍ-3D: el espacio mismo enseña ───────────────────────────────────────
+
+  // 🌱 EL SUELO VIVO — el PROTOTIPO del DR (cutaway). Reusa mundoSubsueloEngine
+  //    para la densidad de vida (`params.vida` 0..1; aquí, valor de muestra).
+  suelo: {
+    escena: 'cutaway',
+    valle: { tipo: 'era', pos: [-1.1, 0, 3.6], escala: 1 },
+    params: {
+      vida: 0.7,
+      vidaFrom: 'mundoSubsueloEngine',
+      capas: [
+        { nombre: 'hojarasca', color: '#6b4a2e', alto: 0.5, bichos: ['lombriz'] },
+        { nombre: 'suelo negro', color: '#3a2a1a', alto: 1.2, bichos: ['lombriz', 'raiz', 'hifa'] },
+        { nombre: 'subsuelo', color: '#8a6a44', alto: 1.0, bichos: ['raiz'] },
+      ],
+    },
+    hotspots: [
+      { id: 'juego', pos: [0, 0.6, 0.6], emoji: '🪱', label: 'Despierte su suelo', view: 'subsuelo' },
+      { id: 'cuaderno', pos: [1.3, 0.2, 0.4], emoji: '📓', label: 'Cuaderno del suelo', view: 'salud_suelo' },
+      { id: 'crom', pos: [-1.3, 0.2, 0.4], emoji: '🎯', label: 'Cromatografía', view: 'cromatografia' },
+    ],
+    entrada: { zoom: 6.5, narra: 'suelo' },
+  },
+
+  // 💧 EL AGUA — el camino de la gravedad (flujo).
+  agua: {
+    escena: 'flujo',
+    valle: { tipo: 'quebrada', pos: [0.6, 0, -1.4], escala: 1 },
+    params: {},
+    hotspots: [
+      { id: 'agua', pos: [1.5, 0.3, 0.5], emoji: '💧', label: 'El agua de mi finca', view: 'agua' },
+      { id: 'hoy', pos: [-1.8, 2.5, 0.4], emoji: '🌤️', label: 'Lluvia de hoy', view: 'hoy_finca' },
+    ],
+    entrada: { zoom: 7, narra: 'agua' },
+  },
+
+  // 🐔 LOS ANIMALES — el ciclo cerrado (recinto). Gated por perfil (como hoy).
+  animales: {
+    escena: 'recinto',
+    valle: { tipo: 'corral', pos: [-4.6, 0, -1.8], escala: 1 },
+    gate: 'animales',
+    params: {
+      animales: [
+        { color: '#e7d9c2', pos: [-0.7, 0, 0.4] },
+        { color: '#c98a5a', pos: [0.6, 0, -0.3] },
+        { color: '#d8c49a', pos: [0.1, 0, 0.7] },
+      ],
+    },
+    hotspots: [
+      { id: 'todos', pos: [0, 0.5, 1.2], emoji: '🐮', label: 'Todos los animales', view: 'animales' },
+      { id: 'gallinas', pos: [1.4, 0.4, 0.2], emoji: '🐔', label: 'Gallinas', view: 'animales_gallinas' },
+      { id: 'abono', pos: [-1.4, 0.4, 0.2], emoji: '💩', label: 'Del corral al abono', view: 'estiercol' },
+    ],
+    entrada: { zoom: 7, narra: 'animales' },
+  },
+
+  // 🌳 DISEÑO DE LA FINCA — la verticalidad del bosque comestible (estratos).
+  disenio: {
+    escena: 'estratos',
+    valle: { tipo: 'bosque', pos: [4.8, 0, -2.6], escala: 1.1 },
+    params: {},
+    hotspots: [
+      { id: 'restaura', pos: [0, 3.4, 0.3], emoji: '🌳', label: 'Restauración y bosque de alimentos', view: 'restauracion' },
+      { id: 'vecinas', pos: [1.6, 0.7, 0.4], emoji: '🌻', label: 'Buenas vecinas', view: 'asociaciones' },
+      { id: 'monte', pos: [-1.6, 1.9, 0.4], emoji: '🦜', label: 'El monte de la finca', view: 'biodiversidad' },
+    ],
+    entrada: { zoom: 8, narra: 'disenio' },
+  },
+
+  // 🗺️ EL VALLE — el mapa navegable (valle). Es "un mundo más" del registro: su
+  //    escena ES el mapa entero; sus hotspots son los demás mundos.
+  valle: {
+    escena: 'valle',
+    params: { clima: 'soleado' },
+    entrada: { narra: 'bienvenida', clima: 'soleado', alertaView: 'hoy_finca' },
+  },
+
+  // ── HÍBRIDO / SÍ-3D por reuso barato ─────────────────────────────────────
+
+  // 🐄 ESTIÉRCOL Y COMPOST — REUSA `cutaway` para el corte de la pila (capas
+  //    café/verde, calor). Prueba viva de "sumar un SÍ-3D = datos, sin código".
+  abono: {
+    escena: 'cutaway',
+    valle: { tipo: 'huerta', pos: [1.8, 0, 4.4], escala: 0.95 },
+    params: {
+      vida: 0.55,
+      capas: [
+        { nombre: 'cobertura seca', color: '#8a6a3a', alto: 0.5, bichos: ['hifa'] },
+        { nombre: 'verde fresco', color: '#5a6a2e', alto: 0.9, bichos: ['lombriz', 'hifa'] },
+        { nombre: 'tierra negra', color: '#2f2418', alto: 0.9, bichos: ['lombriz', 'raiz'] },
+      ],
+    },
+    hotspots: [
+      { id: 'compost', pos: [0, 0.6, 0.6], emoji: '🍂', label: 'El compost, paso a paso', view: 'compost' },
+      { id: 'estiercol', pos: [1.3, 0.2, 0.4], emoji: '🐄', label: 'Del corral al abono', view: 'estiercol' },
+    ],
+    entrada: { zoom: 6, narra: 'abono' },
+  },
+
+  // ── 2D de primera clase: el dato/foto ES el valor ────────────────────────
+
+  // 🌾 CULTIVOS — arquetipo `lamina`: reusa la lámina de maíz de la librería.
+  cultivos: {
+    escena: 'lamina',
+    valle: { tipo: 'milpa', pos: [-3.2, 0, 1.6], escala: 1.15 },
+    params: { lamina: 'maiz' },
+    hotspots: [
+      { id: 'milpa', pos: [], emoji: '🌽', label: 'La milpa', view: 'milpa_cultivo' },
+      { id: 'que', pos: [], emoji: '🌱', label: 'Qué puedo sembrar', view: 'directorio' },
+      { id: 'cal', pos: [], emoji: '🗓️', label: 'Calendario de la finca', view: 'calendario_finca' },
+    ],
+    entrada: { narra: 'cultivos' },
+  },
+
+  // ☕ EL CAFÉ — arquetipo `lamina`: la lámina del cafeto.
+  cafe: {
+    escena: 'lamina',
+    valle: { tipo: 'cafetal', pos: [3.4, 0, 2.2], escala: 1 },
+    params: { lamina: 'cafeto' },
+    hotspots: [
+      { id: 'cafe', pos: [], emoji: '☕', label: 'El café, paso a paso', view: 'cafe' },
+    ],
+    entrada: { narra: 'cafe' },
+  },
+
+  // 🍊 FRUTALES — arquetipo `ficha`: tarjeta de especie foto-secuencial.
+  frutales: {
+    escena: 'ficha',
+    params: {
+      nombre: 'Frutales de la finca',
+      emoji: '🍊',
+      hechos: [
+        { clave: 'Propagación', valor: 'injerto y semilla según especie' },
+        { clave: 'Piso térmico', valor: 'de cálido (cítricos, mango) a frío (mora, tomate de árbol)' },
+        { clave: 'Sin veneno', valor: 'trampas, poda sanitaria y control biológico' },
+      ],
+    },
+    hotspots: [
+      { id: 'frutales', pos: [], emoji: '🍊', label: 'Ficha de frutales', view: 'frutales' },
+    ],
+    entrada: {},
+  },
+
+  // 🧺 MERCADO Y DESPENSA — arquetipo `infografia`: dato/precio/reporte (NO-3D).
+  mercado: {
+    escena: 'infografia',
+    params: {
+      titulo: 'Mercado y despensa',
+      cifras: [
+        { valor: 'Directo', unidad: '', label: 'venta entre fincas, sin intermediario' },
+        { valor: '7', unidad: 'días', label: 'guardar sin que se dañe (poscosecha)' },
+      ],
+      notas: [
+        'Precios de referencia y cuentas para el banco o la cooperativa.',
+        'Almacene sin micotoxinas: troja/silo, secar/salar/fermentar con seguridad.',
+      ],
+    },
+    hotspots: [
+      { id: 'vender', pos: [], emoji: '🤝', label: 'Vender y comprar', view: 'mercado' },
+      { id: 'posc', pos: [], emoji: '🥕', label: 'Poscosecha y despensa', view: 'poscosecha' },
+      { id: 'inf', pos: [], emoji: '🖨️', label: 'Sacar reportes', view: 'informes' },
+    ],
+    entrada: {},
+  },
+
+  // 🐞 SANIDAD — arquetipo `infografia`: diagnóstico por síntoma/foto (NO-3D).
+  sanidad: {
+    escena: 'infografia',
+    valle: { tipo: 'huerta', pos: [1.8, 0, 4.4], escala: 0.95 },
+    params: {
+      titulo: 'Sanidad de la mata',
+      notas: [
+        'Diga qué le ve ("gota", "polvillo", "amarilla") y sepa qué es y cómo manejarla sin veneno.',
+        'Reconozca el bicho por foto: a qué le pega, cómo se ve y su manejo.',
+      ],
+    },
+    hotspots: [
+      { id: 'sintoma', pos: [], emoji: '🩺', label: 'Mi mata está enferma', view: 'sanidad_sintoma' },
+      { id: 'plagas', pos: [], emoji: '🐛', label: 'Directorio de plagas', view: 'plagas' },
+      { id: 'bio', pos: [], emoji: '🧪', label: 'Biopreparados', view: 'biopreparados' },
+    ],
+    entrada: {},
+  },
+
+  // ── NULL: sin escena propia → la tarjeta navega directo al 2D real ───────
+
+  // ⛅ EL CLIMA — YA es 3D ambiental (el cielo del valle); su diorama sería
+  //    redundante (DR §3.2). escena:null → va directo al boletín 2D.
+  clima: {
+    escena: null,
+    valle: { tipo: 'veleta', pos: [-3.8, 0, -4.8], escala: 1 },
+    ambiental: true,
+    ruta2d: { view: 'hoy_finca' },
+    entrada: { narra: 'clima' },
+  },
+};
+
+/** Ids de todos los mundos registrados. */
+export const MUNDO_IDS = Object.keys(MUNDO);

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -48,16 +48,40 @@ export const MUNDO = {
     entrada: { zoom: 6.5, narra: 'suelo' },
   },
 
-  // 💧 EL AGUA — el camino de la gravedad (flujo).
+  // 💧 EL AGUA — el RECORRIDO completo del agua por la pendiente (flujo).
+  //    El campesino ve de dónde nace, por dónde baja, dónde se toma, qué riega,
+  //    dónde se cuida (ronda) y dónde toca tener cuidado de no contaminarla.
+  //    Didáctico y esperanzador: cada punto es una puerta a una pantalla REAL.
+  //    Todo es DATOS: la curva de la quebrada + los hitos del recorrido los
+  //    leen por igual el diorama 3D (EscenaFlujo) y su gemelo 2D (FondoFlujo).
   agua: {
     escena: 'flujo',
     valle: { tipo: 'quebrada', pos: [0.6, 0, -1.4], escala: 1 },
-    params: {},
+    params: {
+      // La quebrada baja del nacimiento (arriba-izquierda) al tanque (abajo).
+      curva: [
+        [-2.1, 2.3, 0.3], [-1.1, 1.5, 0], [-0.1, 0.8, -0.25], [0.7, 0.25, 0], [1.5, -0.15, 0.5],
+      ],
+      // Los hitos del recorrido, anclados a la curva por su fracción t (0..1)
+      // o por posición propia. El arquetipo los dibuja; el gemelo 2D también.
+      hitos: {
+        ronda: { tramo: [0.02, 0.34], arboles: 5 },   // franja de monte que protege el nacimiento
+        riesgo: { t: 0.46, lado: 0.8 },               // donde se cuida: ni lavar bombas ni echar sobras
+        bocatoma: { t: 0.68 },                        // la cajilla que toma el agua para la casa
+        cultivo: { pos: [2.3, -0.3, -0.55], surcos: 4 }, // la huerta que se riega con medida
+      },
+    },
     hotspots: [
-      { id: 'agua', pos: [1.5, 0.3, 0.5], emoji: '💧', label: 'El agua de mi finca', view: 'agua' },
-      { id: 'hoy', pos: [-1.8, 2.5, 0.4], emoji: '🌤️', label: 'Lluvia de hoy', view: 'hoy_finca' },
+      { id: 'nacimiento', pos: [-2.1, 2.95, 0.3], emoji: '💧', label: 'Donde nace el agua', view: 'agua', data: { tema: 'nacimiento' } },
+      { id: 'ronda', pos: [-1.15, 2.45, -0.65], emoji: '🌳', label: 'La ronda que lo protege', view: 'restauracion' },
+      { id: 'quebrada', pos: [-0.1, 1.4, -0.3], emoji: '🐟', label: 'La quebrada viva', view: 'biodiversidad' },
+      { id: 'riesgo', pos: [0.3, 1.1, 0.9], emoji: '⚠️', label: 'Aquí se cuida el agua', view: 'toxicologia' },
+      { id: 'bocatoma', pos: [0.75, 0.9, 0.05], emoji: '🚰', label: 'La toma y el tanque', view: 'agua', data: { tema: 'riego' } },
+      { id: 'cultivo', pos: [2.3, 0.45, -0.55], emoji: '🥕', label: 'La huerta regada', view: 'hortalizas' },
     ],
     entrada: { zoom: 7, narra: 'agua' },
+    // El gemelo 2D digno (flujo-2D): mismo motivo, MISMOS params e hitos.
+    fallback2d: { escena: 'mirror' },
   },
 
   // 🐔 LOS ANIMALES — el ciclo cerrado (recinto). Gated por perfil (como hoy).

--- a/src/visual/mundo3d/resolverMundo.js
+++ b/src/visual/mundo3d/resolverMundo.js
@@ -1,0 +1,46 @@
+/*
+ * resolverMundo — la DECISIÓN 2D/3D del framework, en una función pura.
+ *
+ * Dado un `mundoId` y un `tier` de equipo, decide QUÉ montar. Es el único punto
+ * donde vive la regla "device-tier decide 3D-vs-2D, pero un mundo NO-3D declara
+ * un arquetipo 2D directo". Devuelve un PLAN que el host `<Mundo>` ejecuta:
+ *
+ *   { modo: '3d',    escena, entrada }                 → montar diorama 3D
+ *   { modo: '2d',    escena, motivo?, entrada }        → montar arquetipo 2D
+ *   { modo: 'ruta',  ruta, entrada }                   → navegar a vista 2D real (escena:null)
+ *   { modo: 'ausente', mundoId }                       → el mundo no está registrado
+ */
+import { MUNDO } from './mundoData.js';
+import { ARQUETIPOS, esArquetipo3D } from './arquetipos.js';
+import { permite3D } from './deviceTier.js';
+import { MUNDO_BY_ID } from '../../components/dashboard/mundosFinca.js';
+
+export function resolverMundo(mundoId, tier = 'alto') {
+  const d = MUNDO[mundoId];
+  if (!d) return { modo: 'ausente', mundoId };
+  if (!d.escena) return { modo: 'ruta', ruta: d.ruta2d || null, entrada: d };
+
+  const arq = ARQUETIPOS[d.escena];
+  if (!arq) return { modo: 'ruta', ruta: d.ruta2d || null, entrada: d };
+
+  if (esArquetipo3D(d.escena)) {
+    if (permite3D(tier)) return { modo: '3d', escena: d.escena, entrada: d };
+    // el equipo no aguanta 3D → cae al ESPEJO 2D del arquetipo (o al declarado)
+    const esp = d.fallback2d || { escena: arq.espejo, params: {} };
+    return {
+      modo: '2d',
+      escena: esp.escena,
+      motivo: arq.motivo,
+      entrada: { ...d, params: { ...(d.params || {}), ...(esp.params || {}) } },
+    };
+  }
+
+  // arquetipo 2D declarado DIRECTO (mercado, sanidad, ficha de cultivo…)
+  return { modo: '2d', escena: d.escena, entrada: d };
+}
+
+/** Tinte [fuerte, suave] del mundo, resuelto del manifiesto real (no duplicado). */
+export const tinteDeMundo = (id) => MUNDO_BY_ID[id]?.tinte || ['#3f8f4e', '#dcedc9'];
+
+/** Título del mundo, resuelto del manifiesto real. */
+export const tituloDeMundo = (id) => MUNDO_BY_ID[id]?.titulo || id;

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -15,6 +15,10 @@
  * Cada item expone además `variantes`: 1-3 juegos de props etiquetados para que
  * la vitrina dibuje el primitivo en varios estados sin adivinar su contrato.
  */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- este archivo es el CATÁLOGO
+   de la librería: sus descripciones/props/estados (incluye 'pensando' de la voz)
+   son metadata dev-facing de la vitrina, no copy de UI de producto; no van a
+   src/config/messages.js (ADR-050). Mismo patrón que src/visual/scenes/index.js. */
 import { CREATURES } from './creatures/index.js';
 import { GlowFilter, FiltroAcuarela, AutoDibujo, VFX_PISOS, VFX_BEAT_MS } from './effects/index.js';
 import { LAMINAS } from './laminas/index.js';
@@ -23,6 +27,12 @@ import Parallax from './scenes/Parallax.jsx';
 import GuardianEspirituBase from './scenes/GuardianEspirituBase.jsx';
 import SceneFincaOrganismo from './scenes/SceneFincaOrganismo.jsx';
 import { SCENES, CAPAS_PARALLAX, SCN_BEAT_MS } from './scenes/index.js';
+import IrisVoz, { ESTADOS_VOZ } from './voz/index.js';
+// Framework de mundos: metadatos three-free (arquetipos + registro + tinte). Los
+// dioramas 3D (carpeta escenas/) NO se importan aquí — se cargan perezoso.
+import { ARQUETIPOS, ARQUETIPOS_3D } from './mundo3d/arquetipos.js';
+import { MUNDO } from './mundo3d/mundoData.js';
+import { tinteDeMundo } from './mundo3d/resolverMundo.js';
 
 /* ── Props comunes de las creatures (contrato del barrel de creatures) ────── */
 const PROPS_CREATURE = [
@@ -227,6 +237,11 @@ const ITEMS_CREATURES = Object.entries(CREATURES).map(([slug, meta]) => ({
   cientifico: meta.cientifico,
   Component: meta.Component,
   render: 'component',
+  dim: '2d',
+  role: 'creature',
+  // Angelita es 2D (SVG) pero es el AVATAR del framework 3D: la abeja que "entra"
+  // a cada mundo. `capaz3d` la marca como pieza 3D-capaz sin cambiar su `dim`.
+  capaz3d: slug === 'abeja-angelita',
   descripcion: NOTAS_CREATURE[slug] || '',
   props: PROPS_CREATURE,
   variantes: VARIANTES_CREATURE,
@@ -238,6 +253,8 @@ const ITEMS_LAMINAS = Object.entries(LAMINAS).map(([slug, meta]) => ({
   cientifico: meta.especie,
   Component: meta.Component,
   render: 'component',
+  dim: '2d',
+  role: 'lamina',
   descripcion:
     meta.accesible === 'enseña'
       ? `Lámina que enseña con rótulos (role=img) — ${meta.especie}.`
@@ -252,10 +269,82 @@ const ITEMS_SCENES = Object.entries(SCENES).map(([slug, meta]) => ({
   cientifico: meta.origen,
   Component: SCENE_COMPONENTS[slug],
   render: SCENE_RENDER[slug] || 'component',
+  dim: '2d',
+  role: 'scene',
   descripcion: NOTAS_SCENE[slug] || meta.clave || '',
   props: PROPS_SCENE[slug] || [],
   variantes: VARIANTES_SCENE[slug] || [{ label: 'base', props: {} }],
 }));
+
+/* ── Effects: se etiquetan 2D/effect sobre los literales de arriba ─────────── */
+const ITEMS_EFFECTS_TAG = ITEMS_EFFECTS.map((it) => ({ dim: '2d', role: 'effect', ...it }));
+
+/* ── Voz: IrisVoz, la identidad "la voz con forma" ────────────────────────── */
+const PROPS_VOZ = [
+  { nombre: 'estado', tipo: "'reposo'|'escuchando'|'pensando'|'hablando'", defecto: "'reposo'", que: 'dirección semántica del movimiento (ondas entran/salen/se trenzan)' },
+  { nombre: 'size', tipo: 'number', defecto: '180', que: 'lado en px (la firma sobrevive desde ~22px)' },
+  { nombre: 'getNivel', tipo: '() => number', defecto: '—', que: 'RMS real del micrófono (0..1) leído cada frame; sin él usa pseudo-habla determinista' },
+  { nombre: 'className', tipo: 'string', defecto: '—', que: 'clases extra sobre el nodo raíz' },
+];
+const ITEMS_VOZ = [
+  {
+    slug: 'iris-voz',
+    nombre: 'IrisVoz',
+    cientifico: 'la voz con forma',
+    Component: IrisVoz,
+    render: 'voz',
+    dim: '2d',
+    role: 'voz',
+    capaz3d: true, // la identidad de la voz que acompaña a los mundos (2D+3D)
+    descripcion:
+      'La IDENTIDAD de la voz de Chagra: un iris de anillos concéntricos (ondas de agua + anillos de tronco) con una brasa. El movimiento tiene dirección semántica: escuchando entra, hablando sale, pensando se trenza.',
+    props: PROPS_VOZ,
+    variantes: ESTADOS_VOZ.map((estado) => ({ label: estado, props: { estado, size: 132 } })),
+  },
+];
+
+/* ── Mundos 3D: los ARQUETIPOS de escena del framework `src/visual/mundo3d` ─── */
+const PROPS_MUNDO3D = [
+  { nombre: 'mundoId', tipo: 'string', defecto: '(requerida)', que: 'clave del registro MUNDO[] que este arquetipo dibuja' },
+  { nombre: 'tier', tipo: "'alto'|'medio'|'bajo'|'2d'", defecto: "'alto'", que: 'device-tier: bajo/2d cae al espejo 2D del arquetipo' },
+  { nombre: 'reducedMotion', tipo: 'boolean', defecto: 'false', que: 'congela el useFrame a un fotograma digno' },
+  { nombre: 'onHotspot', tipo: '(view, data) => void', defecto: '—', que: 're-rutea a una vista 2D real de App.jsx (regla de oro: nunca reimplementa)' },
+  { nombre: 'onSalir', tipo: '() => void', defecto: '—', que: 'volver al valle' },
+];
+/* Cargadores PEREZOSOS de cada diorama 3D (three vive en `vendor-three`, fuera del
+   bundle base; el storybook los monta a demanda con el botón "Ver en 3D"). */
+const CARGAR_ESCENA_3D = {
+  cutaway: () => import('./mundo3d/escenas/EscenaCutaway.jsx'),
+  flujo: () => import('./mundo3d/escenas/EscenaFlujo.jsx'),
+  recinto: () => import('./mundo3d/escenas/EscenaRecinto.jsx'),
+  estratos: () => import('./mundo3d/escenas/EscenaEstratos.jsx'),
+  valle: () => import('./mundo3d/escenas/EscenaValle.jsx'),
+};
+const ITEMS_MUNDO3D = ARQUETIPOS_3D.map((slug) => {
+  const a = ARQUETIPOS[slug];
+  const ejemplo = a.ejemplo;
+  const m = MUNDO[ejemplo] || {};
+  return {
+    slug,
+    nombre: a.nombre,
+    cientifico: `espejo 2D: ${a.espejo}`,
+    render: 'mundo',
+    dim: '3d',
+    role: 'mundo3d-archetype',
+    descripcion: a.clave,
+    motivo: a.motivo,
+    ejemplo,
+    espejo: a.espejo,
+    tambien: a.tambien || [],
+    cargar3d: CARGAR_ESCENA_3D[slug],
+    params: m.params || {},
+    hotspots: m.hotspots || [],
+    entrada: m.entrada || {},
+    tinte: tinteDeMundo(ejemplo),
+    props: PROPS_MUNDO3D,
+    variantes: [{ label: `espejo 2D (${a.espejo})`, props: {} }],
+  };
+});
 
 /* ── El índice único que consume la vitrina ───────────────────────────────── */
 export const VISUAL_REGISTRY = {
@@ -277,7 +366,7 @@ export const VISUAL_REGISTRY = {
     importa: "import { GlowFilter } from 'src/visual/effects';",
     descripcion:
       'Las técnicas reutilizables del catálogo: glow, acuarela y auto-dibujado como helpers SVG; velos/viñetas/grades/pulso como clases vfx-* en effects.css. Solo transform/opacity animados; filtros estáticos.',
-    items: ITEMS_EFFECTS,
+    items: ITEMS_EFFECTS_TAG,
     extras: {
       titulo: 'Pisos térmicos (vfx-grade)',
       nota: 'Grade de luz por piso térmico, de nevado a río (clases modificadoras de .vfx-grade).',
@@ -311,15 +400,64 @@ export const VISUAL_REGISTRY = {
       capasParallax: CAPAS_PARALLAX,
     },
   },
+  voz: {
+    titulo: 'Voz',
+    subtitulo: 'La voz con forma',
+    ancla: 'voz',
+    barrel: 'src/visual/voz',
+    importa: "import IrisVoz from 'src/visual/voz';",
+    descripcion:
+      'La identidad visual de la voz de Chagra: un solo primitivo (IrisVoz), cuatro estados con dirección semántica. Es el gesto de la voz que acompaña a los mundos (2D y 3D).',
+    items: ITEMS_VOZ,
+  },
+  mundo3d: {
+    titulo: 'Mundos 3D',
+    subtitulo: 'Arquetipos de escena (framework)',
+    ancla: 'mundo3d',
+    barrel: 'src/visual/mundo3d',
+    importa: "import Mundo, { MUNDO } from 'src/visual/mundo3d';",
+    descripcion:
+      'Los ARQUETIPOS de escena del framework de mundos: dioramas 3D low-poly (cutaway/flujo/recinto/estratos/valle) que un mundo elige POR DATOS. Cada uno cae a su espejo 2D digno en equipos humildes. Se previsualiza el espejo 2D; toque "Ver en 3D" para montar el diorama (chunk perezoso). Sus compañeros: la abeja Angelita (Creatures, avatar 3D-capaz) e IrisVoz (Voz).',
+    items: ITEMS_MUNDO3D,
+  },
 };
 
 /* Orden canónico de las categorías en la vitrina y la navegación por anclas. */
-export const VISUAL_CATEGORIES = ['creatures', 'effects', 'laminas', 'scenes'];
+export const VISUAL_CATEGORIES = ['creatures', 'effects', 'laminas', 'scenes', 'voz', 'mundo3d'];
 
 /* Conteo de primitivos por categoría (para el encabezado de la vitrina y el PR). */
 export const VISUAL_COUNTS = VISUAL_CATEGORIES.reduce((acc, key) => {
   acc[key] = VISUAL_REGISTRY[key].items.length;
   return acc;
 }, /** @type {Record<string, number>} */ ({}));
+
+/* ── Filtros por TAG ──────────────────────────────────────────────────────
+   Los metadatos filtrables (`dim: '2d'|'3d'`, `role`, `capaz3d`) dejan que el
+   framework y el storybook listen "lo 3D-capaz" sin adivinar. */
+
+/** Todos los items del registro, aplanados con su categoría. */
+export function piezas(filtro) {
+  const out = [];
+  VISUAL_CATEGORIES.forEach((categoria) => {
+    VISUAL_REGISTRY[categoria].items.forEach((item) => {
+      if (!filtro || filtro(item, categoria)) out.push({ categoria, ...item });
+    });
+  });
+  return out;
+}
+
+/** Piezas de dimensión 3D (los arquetipos de escena del framework de mundos). */
+export function piezas3D() {
+  return piezas((item) => item.dim === '3d');
+}
+
+/** Piezas que PARTICIPAN del framework 3D: los arquetipos + los 3D-capaces
+    (la abeja avatar, la voz). Útil para la sección "3D" del storybook. */
+export function piezasCapaces3D() {
+  return piezas((item) => item.dim === '3d' || item.capaz3d === true);
+}
+
+/** Piezas por `role` (creature|effect|lamina|scene|voz|mundo3d-archetype). */
+export const piezasPorRole = (role) => piezas((item) => item.role === role);
 
 export default VISUAL_REGISTRY;

--- a/src/visual/voz/IrisVoz.jsx
+++ b/src/visual/voz/IrisVoz.jsx
@@ -1,0 +1,192 @@
+/*
+ * IrisVoz — LA VOZ CON FORMA: la identidad visual de la voz de Chagra.
+ *
+ * Cuando el campesino dice «hola, Chagra», la app no muestra un micrófono
+ * genérico: muestra ESTO — un iris orgánico de anillos concéntricos, mitad
+ * ondas de agua en una totuma, mitad anillos de crecimiento de un tronco.
+ * Cálido y de tierra (brasa, miel, musgo), NO sci-fi: es deliberadamente lo
+ * opuesto al astrolabio holográfico del overlay de escucha (EscuchaOverlay).
+ *
+ * LA REGLA DE ORO — el movimiento tiene dirección SEMÁNTICA:
+ *   · escuchando → las ondas viajan HACIA ADENTRO (la voz de usted entra
+ *     hasta la brasa; el anillo de afuera reacciona primero).
+ *   · hablando   → las ondas NACEN en la brasa y salen HACIA AFUERA
+ *     (ahora la voz es de Chagra).
+ *   · pensando   → los anillos se trenzan: dos grupos contra-rotan despacio,
+ *     como agua que da vueltas antes de aclararse.
+ *   · reposo     → apenas respira al ritmo de la casa (--vfx-beat) y la
+ *     brasa queda en rescoldo. Se aquieta; no pide atención.
+ *
+ * NADA DE ANIMACIÓN FINGIDA: el brillo y la escala reaccionan a un NIVEL
+ * (0..1). En producción se le pasa el RMS real del micrófono vía `getNivel`;
+ * sin él usa la simulación orgánica de vozViva.js (nivelSimulado).
+ *
+ * Reglas de la casa (src/visual/effects/README.md):
+ *   · Solo transform/opacity animados; el glow (GlowFilter) es estático.
+ *   · Cero setState por frame: un solo rAF escribe transform/opacity
+ *     imperativamente sobre refs (mismo patrón GPU-friendly del repo).
+ *   · prefers-reduced-motion: el rAF NO arranca y el CSS pinta un fotograma
+ *     estático digno por estado (color + opacidad cuentan el momento).
+ *
+ * Geometría y simulación (deterministas, sin React) en ./vozViva.js.
+ */
+import React, { useEffect, useId, useRef } from 'react';
+import { GlowFilter } from '../effects';
+import { ANILLOS_IRIS, IRIS_VB, IRIS_C, N_ANILLOS, nivelSimulado } from './vozViva';
+import './irisVoz.css';
+
+/**
+ * El iris. Decorativo por contrato (aria-hidden): el ESTADO se anuncia con
+ * texto fuera del iris (aria-live del consumidor), nunca solo con color.
+ *
+ * @param {object}   props
+ * @param {string}  [props.estado='reposo']  reposo | escuchando | pensando | hablando
+ * @param {number}  [props.size=180]         lado en px (la firma sobrevive desde ~22px)
+ * @param {Function}[props.getNivel]         () => 0..1 leído cada frame (RMS real del
+ *                                           mic en producción). Si no se pasa, usa la
+ *                                           simulación orgánica según el estado.
+ * @param {string}  [props.className]
+ */
+export default function IrisVoz({ estado = 'reposo', size = 180, getNivel, className = '' }) {
+  const uid = useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const anillosRef = useRef([]);
+  const brasaRef = useRef(null);
+  const auraRef = useRef(null);
+  const haloRef = useRef(null);
+
+  /* refs espejo: el rAF lee SIEMPRE lo último sin recrearse por render. */
+  const estadoRef = useRef(estado);
+  const getNivelRef = useRef(getNivel);
+  useEffect(() => { estadoRef.current = estado; }, [estado]);
+  useEffect(() => { getNivelRef.current = getNivel; }, [getNivel]);
+
+  useEffect(() => {
+    /* reduced-motion: sin rAF — el CSS pinta el fotograma estático por estado. */
+    if (typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return undefined;
+    }
+    const niveles = new Float32Array(N_ANILLOS);
+    let lead = 0;
+    let raf = 0;
+    const t0 = performance.now();
+
+    const tick = (now) => {
+      const t = (now - t0) / 1000;
+      const est = estadoRef.current;
+      const crudo = getNivelRef.current
+        ? (getNivelRef.current() || 0)
+        : nivelSimulado(t, est);
+      /* suavizado asimétrico: sube rápido con la voz, cae lento (el iris
+         "retiene" un instante lo que oyó — mismo gesto que EscuchaOverlay). */
+      lead += (crudo - lead) * (crudo > lead ? 0.32 : 0.1);
+
+      /* LA DIRECCIÓN: cada anillo persigue a su vecino. hablando → el de
+         adentro manda (la onda sale); resto → el de afuera manda (la voz
+         entra). El lag de la persecución ES el viaje de la onda. */
+      if (est === 'hablando') {
+        for (let i = 0; i < N_ANILLOS; i++) {
+          const objetivo = i === 0 ? lead : niveles[i - 1];
+          niveles[i] += (objetivo - niveles[i]) * 0.24;
+        }
+      } else {
+        for (let i = N_ANILLOS - 1; i >= 0; i--) {
+          const objetivo = i === N_ANILLOS - 1 ? lead : niveles[i + 1];
+          niveles[i] += (objetivo - niveles[i]) * 0.24;
+        }
+      }
+
+      for (let i = 0; i < N_ANILLOS; i++) {
+        const el = anillosRef.current[i];
+        if (!el) continue;
+        const a = ANILLOS_IRIS[i];
+        el.style.transform = `scale(${(1 + niveles[i] * a.amp).toFixed(4)})`;
+        el.style.opacity = Math.min(1, a.base + niveles[i] * 0.5).toFixed(3);
+      }
+      if (brasaRef.current) {
+        brasaRef.current.style.transform = `scale(${(1 + lead * 0.24).toFixed(4)})`;
+      }
+      if (auraRef.current) {
+        auraRef.current.style.opacity = (0.35 + lead * 0.6).toFixed(3);
+        auraRef.current.style.transform = `scale(${(1 + lead * 0.36).toFixed(4)})`;
+      }
+      if (haloRef.current) {
+        haloRef.current.style.opacity = (0.5 + lead * 0.5).toFixed(3);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div
+      className={`iris-voz ${className}`.trim()}
+      data-estado={estado}
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    >
+      <div className="iv-halo" ref={haloRef} />
+      <div className="iv-respira">
+        <svg viewBox={`0 0 ${IRIS_VB} ${IRIS_VB}`} focusable="false">
+          <defs>
+            <GlowFilter id={`${uid}-glow`} std={2.6} />
+            <radialGradient id={`${uid}-brasa`} cx="50%" cy="46%" r="55%">
+              <stop offset="0%" stopColor="var(--iris-brasa-luz)" />
+              <stop offset="62%" stopColor="var(--iris-brasa)" />
+              <stop offset="100%" stopColor="var(--iris-brasa-borde)" />
+            </radialGradient>
+          </defs>
+
+          {/* Anillos en dos grupos (pares/impares) que solo en `pensando`
+              contra-rotan — animation-play-state, así al salir del estado la
+              trenza se CONGELA donde iba (nada salta). */}
+          <g className="iv-giro iv-giro-a">
+            {ANILLOS_IRIS.map((a, i) => (i % 2 === 0 ? (
+              <path
+                key={i}
+                ref={(el) => { anillosRef.current[i] = el; }}
+                className="iv-anillo iv-anillo-par"
+                d={a.d}
+                style={{ '--iv-op-base': a.base }}
+                strokeWidth={a.grosor}
+              />
+            ) : null))}
+          </g>
+          <g className="iv-giro iv-giro-b">
+            {ANILLOS_IRIS.map((a, i) => (i % 2 === 1 ? (
+              <path
+                key={i}
+                ref={(el) => { anillosRef.current[i] = el; }}
+                className="iv-anillo iv-anillo-impar"
+                d={a.d}
+                style={{ '--iv-op-base': a.base }}
+                strokeWidth={a.grosor}
+              />
+            ) : null))}
+          </g>
+
+          {/* La brasa: el rescoldo donde la voz vive. Glow ESTÁTICO
+              (GlowFilter); lo que se anima es transform/opacity. */}
+          <g filter={`url(#${uid}-glow)`}>
+            <circle
+              ref={auraRef}
+              className="iv-brasa-aura"
+              cx={IRIS_C}
+              cy={IRIS_C}
+              r={17.5}
+            />
+            <circle
+              ref={brasaRef}
+              className="iv-brasa"
+              cx={IRIS_C}
+              cy={IRIS_C}
+              r={10}
+              fill={`url(#${uid}-brasa)`}
+            />
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/voz/README.md
+++ b/src/visual/voz/README.md
@@ -1,0 +1,42 @@
+# `src/visual/voz` — la voz con forma
+
+`IrisVoz` es la **identidad visual de la voz de Chagra**: un iris orgánico de
+anillos concéntricos (mitad ondas de agua en una totuma, mitad anillos de
+crecimiento de un tronco) con una brasa en el centro. Cálido y de tierra —
+deliberadamente lo opuesto al astrolabio holográfico de `EscuchaOverlay`.
+
+Mockup de decisión: `#/mockups/voz-con-forma` (`src/mockups/VozConForma.jsx`).
+
+## La regla de oro: el movimiento tiene dirección semántica
+
+| estado | qué hace | por qué |
+| --- | --- | --- |
+| `reposo` | apenas respira (`--vfx-beat`), brasa en rescoldo | se aquieta, no pide atención |
+| `escuchando` | las ondas viajan **hacia adentro**; el brillo sube con el nivel | la voz de usted entra hasta la brasa |
+| `pensando` | los anillos se **trenzan** (contra-rotación lentísima) | agua dando vueltas antes de aclararse |
+| `hablando` | las ondas **nacen en la brasa** y salen | ahora la voz es de Chagra |
+
+## Uso
+
+```jsx
+import IrisVoz from '../visual/voz';
+
+// producción: nivel = RMS real del micrófono, leído cada frame
+<IrisVoz estado="escuchando" size={220} getNivel={() => rmsRef.current} />
+
+// demo/onboarding: sin getNivel usa la pseudo-habla determinista incluida
+<IrisVoz estado="hablando" size={56} />
+```
+
+- **Decorativo por contrato** (`aria-hidden`): el estado se anuncia con texto
+  del consumidor (`aria-live`), nunca solo con color.
+- La firma sobrevive desde ~22 px (chip) hasta pantalla completa.
+
+## Reglas de la casa (heredadas de `src/visual/effects`)
+
+- Solo `transform`/`opacity` animados; el glow (`GlowFilter` de `effects`) es
+  filtro **estático**.
+- Cero setState por frame: un solo rAF escribe sobre refs.
+- `prefers-reduced-motion`: el rAF no arranca; el CSS pinta un fotograma
+  quieto pero legible por estado (color + opacidad cuentan el momento).
+- Geometría **determinista** (sin `Math.random`): el iris es una firma.

--- a/src/visual/voz/index.js
+++ b/src/visual/voz/index.js
@@ -1,0 +1,17 @@
+/*
+ * Librería visual de VOZ de Chagra — la identidad "la voz con forma".
+ *
+ * `IrisVoz` es el gesto único de la voz en toda la app: donde antes iría un
+ * micrófono genérico, va el iris (FAB, overlay de escucha, chip de estado,
+ * onboarding de voz). Un solo primitivo, cuatro estados, cualquier tamaño.
+ *
+ *   import IrisVoz, { nivelSimulado, ESTADOS_VOZ } from '.../visual/voz';
+ *
+ *   <IrisVoz estado="escuchando" size={220} getNivel={() => rmsRef.current} />
+ *
+ * `getNivel` en producción = RMS real del micrófono (useVoiceRecorder);
+ * sin él, IrisVoz usa `nivelSimulado` (pseudo-habla determinista) — útil
+ * para demos, onboarding y estados sin permiso de mic todavía.
+ */
+export { default, default as IrisVoz } from './IrisVoz.jsx';
+export { nivelSimulado, ESTADOS_VOZ, ANILLOS_IRIS } from './vozViva';

--- a/src/visual/voz/irisVoz.css
+++ b/src/visual/voz/irisVoz.css
@@ -1,0 +1,148 @@
+/* ════════════════════════════════════════════════════════════════════════════
+   irisVoz.css — la piel de IrisVoz (LA VOZ CON FORMA).
+
+   Paleta de TIERRA, no de neón: la voz de Chagra es una brasa en una cocina
+   de leña, no un holograma. Cuatro estados = cuatro temperaturas del mismo
+   material (nunca cambia la forma, solo la vida que lleva adentro):
+
+     reposo      rescoldo   (pardo apagado — apenas se nota que está viva)
+     escuchando  miel       (ámbar cálido — la atención encendida)
+     pensando    cobre      (más hondo y quieto — el agua dando vueltas)
+     hablando    musgo+miel (verde vivo — la respuesta es cosa que crece)
+
+   Reglas de la casa: solo transform/opacity animados; el glow es filtro
+   ESTÁTICO; prefers-reduced-motion = fotograma quieto pero LEGIBLE por
+   estado (el color y la opacidad cuentan el momento sin loops).
+   ════════════════════════════════════════════════════════════════════════════ */
+
+.iris-voz {
+  /* tinta por defecto = reposo (rescoldo) */
+  --iris-tinta: #8d6b4d;
+  --iris-tinta-2: #6f5844;
+  --iris-brasa-luz: #ffd9a8;
+  --iris-brasa: #d98549;
+  --iris-brasa-borde: rgba(140, 70, 30, 0);
+  --iris-halo: rgba(217, 133, 73, 0.14);
+  --iris-vida: 0;                 /* fotograma estático: cuánta vida extra */
+
+  position: relative;
+  display: inline-block;
+  flex: none;
+}
+
+.iris-voz[data-estado='escuchando'] {
+  --iris-tinta: #e9a94e;
+  --iris-tinta-2: #c98a54;
+  --iris-brasa-luz: #ffe3b0;
+  --iris-brasa: #f0a355;
+  --iris-halo: rgba(233, 169, 78, 0.22);
+  --iris-vida: 0.3;
+}
+
+.iris-voz[data-estado='pensando'] {
+  --iris-tinta: #c57a45;
+  --iris-tinta-2: #9a6a4a;
+  --iris-brasa-luz: #ffce96;
+  --iris-brasa: #d98549;
+  --iris-halo: rgba(197, 122, 69, 0.18);
+  --iris-vida: 0.16;
+}
+
+.iris-voz[data-estado='hablando'] {
+  --iris-tinta: #b7c98a;
+  --iris-tinta-2: #d8b06a;
+  --iris-brasa-luz: #f3e9b0;
+  --iris-brasa: #cabd62;
+  --iris-halo: rgba(183, 201, 138, 0.2);
+  --iris-vida: 0.34;
+}
+
+/* ── halo: la luz que la brasa le presta a la mesa ─────────────────────────── */
+.iv-halo {
+  position: absolute;
+  inset: -18%;
+  border-radius: 50%;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 50%, var(--iris-halo) 0%, transparent 62%);
+  opacity: 0.6;
+  transition: background 0.7s ease;
+}
+
+/* ── respiración: TODO el iris respira al ritmo de la casa ─────────────────── */
+.iv-respira {
+  width: 100%;
+  height: 100%;
+  animation: iv-respira var(--vfx-beat, 5.2s) ease-in-out infinite;
+}
+
+.iv-respira svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+@keyframes iv-respira {
+  0%, 100% { transform: scale(1); }
+  42% { transform: scale(1.022); }
+  58% { transform: scale(1.018); }
+}
+
+/* ── anillos de agua/tronco ────────────────────────────────────────────────── */
+.iv-anillo {
+  fill: none;
+  stroke: var(--iris-tinta);
+  stroke-linejoin: round;
+  opacity: calc(var(--iv-op-base, 0.4) + var(--iris-vida) * 0.5);
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: stroke 0.7s ease;
+}
+
+/* anillos alternos con la segunda tinta: la veta del tronco, no un arcoíris */
+.iv-anillo-impar { stroke: var(--iris-tinta-2); }
+
+/* ── la trenza de `pensando`: dos grupos contra-rotan lentísimo ──────────────
+   animation-play-state: al salir del estado la rotación se CONGELA donde va
+   (nada salta a cero). Solo transform ⇒ GPU-friendly. */
+.iv-giro {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: iv-giro 46s linear infinite;
+  animation-play-state: paused;
+}
+
+.iv-giro-b {
+  animation-name: iv-giro-contra;
+  animation-duration: 58s;
+}
+
+.iris-voz[data-estado='pensando'] .iv-giro { animation-play-state: running; }
+
+@keyframes iv-giro { to { transform: rotate(360deg); } }
+@keyframes iv-giro-contra { to { transform: rotate(-360deg); } }
+
+/* ── la brasa ──────────────────────────────────────────────────────────────── */
+.iv-brasa {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.iv-brasa-aura {
+  fill: var(--iris-brasa);
+  opacity: calc(0.3 + var(--iris-vida));
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: fill 0.7s ease;
+}
+
+/* ── prefers-reduced-motion: fotograma quieto y digno ────────────────────────
+   El rAF no arranca (lo decide IrisVoz.jsx), así que aquí solo apagamos los
+   loops CSS. El estado sigue LEYÉNDOSE: --iris-vida sube la opacidad de los
+   anillos y la aura cuando la voz está activa — color + luz, sin movimiento. */
+@media (prefers-reduced-motion: reduce) {
+  .iv-respira,
+  .iv-giro {
+    animation: none !important;
+  }
+}

--- a/src/visual/voz/vozViva.js
+++ b/src/visual/voz/vozViva.js
@@ -1,0 +1,68 @@
+/*
+ * vozViva.js — la parte VIVA (y sin React) de IrisVoz: geometría determinista
+ * de los anillos + simulación orgánica de nivel. Separado del componente para
+ * que IrisVoz.jsx solo exporte componentes (react-refresh) y para poder
+ * testear/reusar la matemática sin montar nada.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- 'reposo'/'escuchando'/
+   'pensando'/'hablando' son TOKENS de estado del primitivo (API interna),
+   no copy de UI; el texto visible vive en el consumidor. */
+
+export const ESTADOS_VOZ = ['reposo', 'escuchando', 'pensando', 'hablando'];
+
+export const IRIS_VB = 200;              // lado del viewBox
+export const IRIS_C = IRIS_VB / 2;       // centro
+export const N_ANILLOS = 6;              // anillos de agua/tronco
+const N_PTS = 72;                        // puntos por anillo (denso = suave)
+
+/* PRNG determinista (misma receta que el resto del repo visual). */
+const azar = (i, sal) => {
+  const x = Math.sin(i * 127.1 + sal * 311.7) * 43758.5453;
+  return x - Math.floor(x);
+};
+
+/* Anillos precomputados UNA vez: cada uno es un path cerrado cuyo radio
+ * ondula con dos senos de baja amplitud — el temblor de mano que separa un
+ * anillo de tronco de un círculo de compás. El de afuera tiembla más (la
+ * onda se deshace al alejarse de la brasa), y cada anillo trae su amplitud
+ * de reacción a la voz (`amp`) y su opacidad base (`base`). */
+export const ANILLOS_IRIS = Array.from({ length: N_ANILLOS }, (_, k) => {
+  const R = 30 + k * 11.4;                       // 30 → 87 (dentro de VB=200)
+  const w1 = 0.016 + azar(k, 1) * 0.016 + k * 0.0045;
+  const w2 = 0.009 + azar(k, 2) * 0.012;
+  const f1 = 3 + (k % 3);
+  const f2 = 6 + (k % 4);
+  const p1 = azar(k, 3) * Math.PI * 2;
+  const p2 = azar(k, 4) * Math.PI * 2;
+  let d = '';
+  for (let j = 0; j < N_PTS; j++) {
+    const a = (j / N_PTS) * Math.PI * 2;
+    const r = R * (1 + w1 * Math.sin(f1 * a + p1) + w2 * Math.sin(f2 * a + p2));
+    d += `${j === 0 ? 'M' : 'L'}${(IRIS_C + Math.cos(a) * r).toFixed(1)} ${(IRIS_C + Math.sin(a) * r).toFixed(1)}`;
+  }
+  return {
+    d: `${d}Z`,
+    amp: 0.05 + k * 0.016,          // cuánto se hincha con la voz
+    base: 0.5 - k * 0.055,          // opacidad base (se desvanece hacia afuera)
+    grosor: 1.9 - k * 0.18,         // trazo (grueso adentro, fino afuera)
+  };
+});
+
+/* ── Simulación orgánica de nivel (para mockups/demos) ───────────────────────
+ * Pseudo-habla determinista: una envolvente de FRASES (con pausas de aire),
+ * modulada por PALABRAS y SÍLABAS (senos incongruentes = cadencia creíble).
+ * `hablando` es un pelo más parejo (Chagra no duda); `pensando` es un pulso
+ * interior bajito; `reposo` es silencio. */
+export function nivelSimulado(t, estado) {
+  if (estado === 'escuchando' || estado === 'hablando') {
+    const lento = estado === 'hablando' ? 0.62 : 0.78;
+    const frase = Math.sin(t * lento + 0.6) * 0.5 + 0.5;      // 0..1, respiración de frase
+    if (frase < 0.22) return 0.04;                            // pausa para tomar aire
+    const palabra = 0.62 + 0.38 * Math.sin(t * 5.9) * Math.sin(t * 2.31 + 1.7);
+    const silaba = 0.78 + 0.22 * Math.sin(t * 13.7 + 0.4);
+    const piso = estado === 'hablando' ? 0.3 : 0.22;
+    return Math.max(0, Math.min(1, piso + 0.62 * frase * palabra * silaba));
+  }
+  if (estado === 'pensando') return 0.1 + 0.06 * Math.sin(t * 1.5);
+  return 0;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -87,6 +87,12 @@ export default defineConfig({
           if (id.includes('node_modules/lucide-react')) {
             return 'vendor-icons';
           }
+          // three / @react-three (fiber + drei): SOLO lo usa el mockup 3D
+          // (#/mockups/entrada-3d), cargado perezoso. Agruparlo en un chunk
+          // aparte lo mantiene fuera del bundle base y cacheable por sí solo.
+          if (id.includes('node_modules/three') || id.includes('node_modules/@react-three')) {
+            return 'vendor-three';
+          }
         },
       },
     },


### PR DESCRIPTION
> **Apilado sobre #2309** (el framework de mundos aún no está en `main`). Base = `feat/visual-lib-completa-3d`; cuando el keystone mergee y su rama se borre, GitHub retargetea este PR a `main` solo. El diff de abajo es únicamente el mundo del agua.

## Qué es

El **MUNDO 3D DEL AGUA** de la finca: el campesino ve el RECORRIDO del agua por la pendiente — dónde nace, la ronda de monte que lo protege, la quebrada viva, dónde se cuida de no contaminarla, la toma con su tanque y la huerta regada. Didáctico y esperanzador: *menos colapso, finca viva*. Ruta pública: `#/mockups/mundo3d-agua`.

## Cómo (el contrato del framework, sin romperlo)

- **`mundoData.js`** — la entrada `agua` pasa de placeholder a recorrido completo, TODO por datos: `curva` de la quebrada + `hitos` (ronda/riesgo/bocatoma/cultivo anclados a la curva por fracción `t`) + **6 hotspots** que re-rutean a pantallas REALES (`agua`, `restauracion`, `biodiversidad`, `toxicologia`, `hortalizas`) + `entrada` (la abeja Angelita entra vía `useEntradaAbeja`, heredado de `EscenaBase3D`) + `fallback2d` explícito (gemelo `mirror`/flujo-2D).
- **`EscenaFlujo.jsx`** (el arquetipo, no código por-mundo) — aprende a dibujar los hitos POR DATOS: ronda de arbolitos, punto de cuidado (barril + señal **ámbar** — didáctico, nunca catástrofe), bocatoma, huerta con surcos + canalito, y gotas que viajan la curva (quietas y dignas con `prefers-reduced-motion`). Sin `hitos`, el diorama clásico queda idéntico. 100% primitivas (cajas/cilindros/conos/tubo), sin GLTF, `MeshLambert/Basic`, sin sombras.
- **`LaminaMundo.jsx` (FondoFlujo)** — el gemelo 2D lee los MISMOS `params` y dibuja los mismos sí-o-sí. Es el piso digno de gama baja (device-tiering real vía `decidirTier`).
- **`Mundo3DAgua.jsx` + CSS** — vitrina pública pre-auth (patrón `visual-lib`): monta `<Mundo mundoId="agua">` con tiering real, toggle 3D↔2D, panel `aria-live` que cuenta a qué pantalla real lleva cada puerta, y leyenda del recorrido. Móvil-first 320px, autocontenida, español CO en "usted".
- **`App.jsx`** — ruta `mockups/mundo3d-agua` + case; los 8 guards repetidos de `'mockup_visual_lib'` se unifican en `esVistaMockup()` (helper de módulo, sin pelear con exhaustive-deps).

## Verificación (salidas reales)

**`node scripts/tsc-check-gate.mjs`** — sin errores nuevos vs baseline 868:
```
tsc:check — actual: 868 errores, baseline: 868 errores
OK — sin errores nuevos respecto al baseline.
```

**`npm run build`** + `vendor-three` lazy (0 refs en `dist/index.html`):
```
dist/assets/vendor-three-BH5INK5o.js               876.00 kB │ gzip: 233.37 kB
✓ built in 1m 9s
$ node scripts/check-perf-budget.mjs
Excluido lazy (vendor-three #2309): 855.5 KB (cache-on-use, no en arranque)
All budgets within thresholds.
```

**eslint** (archivos tocados, `--max-warnings 0`):
```
ESLINT OK
```

**Tests** (nuevos + impactados):
```
src/visual/mundo3d/__tests__/ + mockups/mundo3dAgua.smoke  →  3 files, 13 tests PASSED
MundosDeMiFinca.reachability + visualLib.smoke             →  2 files, 12 tests PASSED
src/__tests__/ (rutas de App, serializado)                 →  9 files, 28 tests PASSED
```
Nota: `src/__tests__/` en paralelo flaquea por contención de la máquina (timeouts con transform frío); verificado con bisect que NO es este diff — la misma corrida pasa serializada y en verde 9/9.

## Sí-o-sí cumplidos

- Arquetipo `flujo` reusado; sumar el mundo = UNA entrada de datos (regla de oro del framework intacta).
- Reachability: cada `hotspot.view` es un `case` real de `App.jsx` (test lo congela leyendo el source).
- `prefers-reduced-motion` → tier `bajo` → gemelo 2D quieto y digno; en 3D, gotas y cinta congeladas.
- Gama baja / sin WebGL / ahorro de datos → gemelo 2D (device-tiering real, no simulado).
- Sin CDN/externos, sin Playwright, sin secretos ni nombres de terceros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
