### PR TITLE
feat(visual): agente dibuja - laminas fiables + AgentLamina

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,6 +73,9 @@ const OAuthCallback = lazy(() => import('./components/OAuthCallback'));
 // Vitrina pública de la librería visual reutilizable (`src/visual/`). Ruta
 // #/mockups/visual-lib, resuelta ANTES del check de sesión (no requiere auth).
 const VisualLib = lazy(() => import('./mockups/VisualLib'));
+// #/mockups/agente-dibuja — vitrina "el agente dibuja en sus respuestas de
+// forma fiable" (DR 2026-07-11), también pública/sin auth.
+const AgenteDibuja = lazy(() => import('./mockups/AgenteDibuja'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -425,6 +428,7 @@ const LoadingFallback = ({ view = null }) => {
 // #onboarding-piloto. El hash llega ya normalizado (sin `#`/`#/`).
 const MOCKUP_HASH_ROUTES = {
   'mockups/visual-lib': 'mockup_visual_lib',
+  'mockups/agente-dibuja': 'mockup_agente_dibuja',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1238,6 +1242,17 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Librería visual">
               <VisualLib />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_agente_dibuja':
+        // Vitrina pública "el agente dibuja en sus respuestas de forma fiable".
+        // Ruta #/mockups/agente-dibuja, sin auth: muestra respuestas del agente
+        // con su lámina (del conjunto cerrado LAMINAS_FIABLES) dibujándose sola.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El agente dibuja">
+              <AgenteDibuja onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -11,6 +11,7 @@ import FeedbackButtons from '../FeedbackButtons';
 import AIBetaBadge from '../AIBetaBadge';
 import SemaforoConfianza from './SemaforoConfianza';
 import AgentMarkdown from './AgentMarkdown';
+import AgentLamina from '../../visual/laminas/AgentLamina';
 
 function formatTime(timestamp) {
   if (!timestamp) return '';
@@ -525,6 +526,26 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
             /* break-words: sin esto una URL o palabra larga sin espacios
                desborda la burbuja en horizontal a 320px. */
             <p className="text-[15px] leading-relaxed whitespace-pre-wrap break-words">{message.content}</p>
+          )}
+          {/* ═══ LÁMINA QUE SE DIBUJA SOLA (DR "el agente dibuja fiable") ═══
+              HOOK DEL BACKEND: el agente inyecta en el turno assistant un
+              `metadata.lamina = { slug, props }` — slug de un conjunto CERRADO
+              (LAMINAS_FIABLES) + prop de enum cerrado. AgentLamina lo lee y
+              monta la lámina LOCAL con su auto-dibujado; si el slug no es fiable
+              o la prop no calza, AgentLamina degrada a NULL → solo texto. El
+              modelo NUNCA emite SVG. El GATE DE GROUNDING (regla #3: que la
+              especie/proposición esté aterrizada en la evidencia del turno) lo
+              cablea el agente aguas arriba, NO este componente — aquí solo se
+              renderiza lo que ya venga validado en metadata.lamina.
+              TODO(agente): poblar message.metadata.lamina desde el handler de
+              `dibujar_lamina` tras revalidar el gate contra resolvedEntities. */}
+          {!isUser && !isStreaming && !message._orphan_recovery && message.metadata?.lamina?.slug && (
+            <div className="mt-2" data-chat-dark="true">
+              <AgentLamina
+                slug={message.metadata.lamina.slug}
+                props={message.metadata.lamina.props}
+              />
+            </div>
           )}
           {/* UX-1 (#284): badge "beta" permanente cerca de cualquier respuesta
               IA del agente. NO reemplaza a SourceBadge (que es la fuente

--- a/src/mockups/AgenteDibuja.jsx
+++ b/src/mockups/AgenteDibuja.jsx
@@ -1,0 +1,217 @@
+/*
+ * i18n (ADR-050): copy de campo en español Colombia (usted). Es un MOCKUP de
+ * galería con datos de muestra, sin gate ni auth; el copy final migraría a
+ * src/config/messages.js — mismo criterio que los otros mockups de la galería.
+ */
+import { useState } from 'react';
+import { ArrowLeft, RotateCcw, Sprout } from 'lucide-react';
+import AgentLamina from '../visual/laminas/AgentLamina.jsx';
+import '../visual/effects/effects.css';
+import './agente-dibuja.css';
+
+/**
+ * AgenteDibuja — vitrina de "el agente DIBUJA en sus respuestas de forma
+ * FIABLE" (DR 2026-07-11). Muestra respuestas reales del agente donde, además
+ * del texto, viaja un adjunto de lámina que SE DIBUJA SOLA.
+ *
+ * La pieza clave: cada turno del agente trae un `metadata.lamina = { slug,
+ * props }` — EXACTAMENTE el contrato que el backend inyectará. El frontend
+ * (AgentLamina) solo lee ese metadata y monta la lámina del conjunto CERRADO
+ * `LAMINAS_FIABLES`. El modelo NUNCA emite SVG: elige un slug + una prop de
+ * enum. Si el slug no es fiable o la prop no calza, AgentLamina degrada a
+ * NADA → la respuesta queda como solo texto (último turno de la demo).
+ *
+ * Reusa la librería de EFECTOS (auto-dibujado) y la casa de láminas de
+ * cuaderno de campo, con la estética del mockup ensena-dibujando.
+ *
+ * Dirección educativa de Chagra: se enseña a OBSERVAR, no a ganar puntos.
+ * Sin gamificación. Tono usted colombiano.
+ *
+ * Ruta pública `#/mockups/agente-dibuja` (sin auth, datos de muestra).
+ *
+ * @param {Object} props
+ * @param {Function} [props.onBack] volver al dashboard.
+ */
+
+// Turnos de muestra. Cada uno imita un mensaje `assistant` REAL: `pregunta`
+// (lo que dijo el campesino) + `frases`/`observa` (el texto) + `metadata`
+// (donde el backend inyecta `lamina`). El adjunto se dibuja leyendo
+// `metadata.lamina` — el mismo camino que tomará ChatBubble en producción.
+const TURNOS = [
+  {
+    id: 'milpa',
+    chip: 'Asociación',
+    pregunta: '¿Por qué me dicen que siembre el maíz junto con el frijol?',
+    frases: [
+      'El maíz crece derecho y alto: le sirve de tutor al frijol para que trepe sin necesidad de vara.',
+      'El frijol, en sus raíces, agarra el nitrógeno del aire y se lo devuelve a la tierra que el maíz gasta.',
+      'La calabaza, con sus hojas anchas, tapa el suelo: guarda la humedad y no deja crecer la maleza.',
+    ],
+    observa: 'Fíjese cómo el frijol busca el tallo del maíz para subir. Esa sociedad la lleva haciendo la milpa desde hace siglos.',
+    metadata: { lamina: { slug: 'milpa', props: {} } },
+  },
+  {
+    id: 'rotacion',
+    chip: 'Rotación',
+    pregunta: 'Ya coseché el tomate en esta era, ¿qué siembro ahora ahí?',
+    frases: [
+      'No repita la misma familia en la era: cada cultivo le pide y le devuelve algo distinto al suelo.',
+      'Detrás de una de hoja o de fruto, que gastan mucho, siembre una leguminosa (fríjol, haba): esa repone el nitrógeno.',
+      'La de raíz, como la zanahoria, afloja la tierra en lo hondo y deja la era lista para la siguiente.',
+    ],
+    observa: 'Lleve el orden en la bitácora: mirando qué sembró antes en cada era, va aprendiendo cómo descansa su tierra.',
+    metadata: { lamina: { slug: 'rotacion', props: {} } },
+  },
+  {
+    id: 'piso',
+    chip: 'Piso térmico',
+    pregunta: 'Mi finca está a 1.800 metros, ¿qué se da bien por aquí?',
+    frases: [
+      'A esa altura usted está en piso templado: aquí se dan bien el café, los cítricos y el maíz.',
+      'Más abajo, en lo cálido, es tierra de plátano, yuca y cacao; más arriba, en lo frío, la papa, la cebolla y la arveja.',
+      'Pasando el páramo ya no se siembra: eso se cuida, porque es la fábrica de agua de todos.',
+    ],
+    observa: 'Camine su ladera: donde cambia el frío y la neblina, cambia lo que le va a prender. La altura se lo enseña.',
+    metadata: { lamina: { slug: 'piso-termico', props: {} } },
+  },
+  {
+    id: 'maiz',
+    chip: 'Morfología',
+    pregunta: '¿Cuáles son las partes de la mata de maíz?',
+    frases: [
+      'Arriba de todo va el penacho o espiga: es la flor macho, la que suelta el polen.',
+      'La mazorca es la flor hembra; sus barbas (el cabello) atrapan ese polen para que cada grano cuaje.',
+      'La caña sube por nudos y las hojas la abrazan con su vaina; abajo, dos clases de raíz la sostienen.',
+    ],
+    observa: 'Salga a mirar una mata al sol: cuente los nudos y siga una barba hasta su grano. Ahí entiende cómo se hace la mazorca.',
+    metadata: { lamina: { slug: 'maiz', props: {} } },
+  },
+  {
+    id: 'mata-etapa',
+    chip: 'Ciclo de vida',
+    pregunta: 'Mi mata de tomate ya está cargada de fruto, ¿en qué etapa va?',
+    frases: [
+      'Su mata está en cosecha: la etapa en que los racimos ya cuelgan con el tomate maduro.',
+      'Mírela completa: la raíz está honda, el tallo alto y la copa ancha para sostener el peso del fruto.',
+      'Coseche parejo y siga observando: cuando afloje la carga, la mata empieza a cerrar su ciclo.',
+    ],
+    observa: 'Compare esta mata con una juvenil de su misma era: la diferencia entre las dos etapas se la enseña la planta, no el calendario.',
+    metadata: { lamina: { slug: 'mata-etapa', props: { etapa: 'cosecha' } } },
+  },
+  {
+    id: 'siembra',
+    chip: 'Propagación',
+    pregunta: 'Voy a sembrar papa, ¿cómo se pone en la tierra?',
+    frases: [
+      'La papa se siembra por tubérculo-semilla: entierra la papa entera (o un trozo con sus yemas) y de ahí brota la mata nueva.',
+      'No es como la yuca (que va por esqueje) ni como el plátano (que va por colino): cada cultivo tiene su forma.',
+      'Deje que el tubérculo verdee unos días antes: con las yemas despiertas, prende más parejo.',
+    ],
+    observa: 'Marque en la bitácora la fecha de siembra y desentierre una en tres semanas: verá las raíces y los primeros tubérculos formándose.',
+    metadata: { lamina: { slug: 'siembra', props: { activo: 'tuberculo' } } },
+  },
+  {
+    id: 'degrada',
+    chip: 'Sin lámina',
+    pregunta: '¿Cómo se injerta un aguacate?',
+    frases: [
+      'El injerto de aguacate se hace uniendo una púa de la variedad que usted quiere sobre un patrón resistente.',
+      'De esto todavía no tengo una lámina verificada, así que se lo cuento con palabras y le queda mejor verlo con su técnico.',
+    ],
+    observa: 'Cuando tengamos la lámina del injerto dibujada y revisada, se la mostraré. Por ahora, mejor que un dibujo dudoso es un buen consejo hablado.',
+    // El backend pediría 'injerto-aguacate', que NO está en LAMINAS_FIABLES:
+    // AgentLamina devuelve null y la respuesta queda como SOLO TEXTO. Es la
+    // degradación segura — el agente no inventa un dibujo que no tiene.
+    metadata: { lamina: { slug: 'injerto-aguacate', props: {} } },
+  },
+];
+
+// Un turno del agente: la pregunta del campesino + la respuesta con su lámina.
+// `nonce` re-monta la lámina para re-disparar el auto-dibujado ("dibujar otra
+// vez") sin tocar el resto del turno.
+function Turno({ turno }) {
+  const [nonce, setNonce] = useState(0);
+  const lamina = turno.metadata?.lamina;
+
+  return (
+    <section className="ad-turno" aria-label={`Respuesta: ${turno.chip}`}>
+      <div className="ad-msg ad-msg--user">
+        <div className="ad-bubble ad-bubble--user">{turno.pregunta}</div>
+      </div>
+
+      <div className="ad-msg ad-msg--agent">
+        <div className="ad-avatar" aria-hidden="true"><Sprout size={18} /></div>
+        <div className="ad-bubble ad-bubble--agent" data-chat-dark="true">
+          {/* El adjunto de lámina: se monta SOLO desde metadata.lamina, igual
+              que lo hará ChatBubble en producción. Si el slug no es fiable
+              (último turno), AgentLamina renderiza null → solo texto. */}
+          {lamina && (
+            <AgentLamina
+              slug={lamina.slug}
+              props={lamina.props}
+              drawKey={`${turno.id}-${nonce}`}
+              className="ad-lamina"
+            />
+          )}
+
+          <ul className="ad-frases">
+            {turno.frases.map((f, i) => (
+              <li key={i}>{f}</li>
+            ))}
+          </ul>
+
+          <p className="ad-observa">
+            <span className="ad-observa-tag">Para observar</span>
+            {turno.observa}
+          </p>
+
+          {/* El contrato que consume el frontend, a la vista del operador. */}
+          <p className="ad-meta">
+            <span className="ad-meta-tag">metadata.lamina</span>
+            <code>{JSON.stringify(lamina)}</code>
+          </p>
+
+          {lamina && (
+            <button type="button" className="ad-redraw" onClick={() => setNonce((n) => n + 1)}>
+              <RotateCcw size={14} aria-hidden="true" />
+              Dibujar otra vez
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function AgenteDibuja({ onBack } = {}) {
+  return (
+    <div className="ad-root">
+      <header className="ad-top">
+        <button type="button" className="ad-back" onClick={onBack} aria-label="Volver">
+          <ArrowLeft size={18} aria-hidden="true" />
+          <span>Volver</span>
+        </button>
+        <div className="ad-title-wrap">
+          <h1 className="ad-title">El agente dibuja en sus respuestas</h1>
+          <p className="ad-sub">
+            Cuando lo que usted pregunta tiene una lámina verificada, el agente
+            se la adjunta y se la va dibujando. Nunca inventa el dibujo: elige de
+            un conjunto cerrado o no dibuja nada.
+          </p>
+        </div>
+      </header>
+
+      <div className="ad-chat">
+        {TURNOS.map((t) => (
+          <Turno key={t.id} turno={t} />
+        ))}
+      </div>
+
+      <footer className="ad-foot">
+        Chagra no le da puntos ni medallas por preguntar: le dibuja para que
+        <strong> aprenda mirando</strong>. Y si no tiene la lámina verificada,
+        se lo dice con palabras — <strong>antes que dibujarle algo dudoso</strong>.
+      </footer>
+    </div>
+  );
+}

--- a/src/mockups/agente-dibuja.css
+++ b/src/mockups/agente-dibuja.css
@@ -1,0 +1,236 @@
+/* ════════════════════════════════════════════════════════════════════════
+   agente-dibuja.css — vitrina "el agente dibuja en sus respuestas".
+
+   A diferencia del mockup ensena-dibujando (burbuja crema), aquí la burbuja del
+   AGENTE es OSCURA como el chat real (v3-card): así el operador ve cómo el
+   papel-crema de la lámina se incrusta dentro de la burbuja de producción. El
+   escritorio sigue siendo de papel (cálido). Todo el prefijo `ad-`.
+   Responsive desde 320px; el auto-dibujado vive en effects.css (ya respeta
+   prefers-reduced-motion). Contraste AA en ambas burbujas.
+   ════════════════════════════════════════════════════════════════════════ */
+
+.ad-root {
+  --ad-papel: #f3ead4;
+  --ad-tinta: #5c4326;
+  --ad-tinta-2: #8a6b40;
+  --ad-linea: rgba(92, 67, 38, 0.18);
+  --ad-verde: #55702c;
+  /* burbuja del agente = chat real (slate verdoso oscuro) */
+  --ad-agent-bg: #1f2a25;
+  --ad-agent-borde: rgba(120, 170, 140, 0.28);
+  --ad-agent-txt: #e8ece6;
+  --ad-agent-txt-2: #b9c6bd;
+  min-height: 100%;
+  box-sizing: border-box;
+  padding: 16px clamp(12px, 4vw, 28px) 40px;
+  background:
+    radial-gradient(120% 80% at 50% 0%, #fbf5e6 0%, #f3ead4 60%, #ecdfc1 100%);
+  color: var(--ad-tinta);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* ── cabecera ─────────────────────────────────────────────────────────── */
+.ad-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  max-width: 640px;
+  margin: 0 auto 14px;
+}
+.ad-back {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border: 1.5px solid var(--ad-linea);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.4);
+  color: var(--ad-tinta);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 40px;
+}
+.ad-back:hover { background: rgba(255, 255, 255, 0.7); }
+.ad-title-wrap { min-width: 0; }
+.ad-title {
+  margin: 2px 0 4px;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  font-size: clamp(1.15rem, 5vw, 1.6rem);
+  font-weight: 700;
+  line-height: 1.15;
+}
+.ad-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ad-tinta-2);
+  line-height: 1.4;
+}
+
+/* ── conversación (feed de turnos) ────────────────────────────────────── */
+.ad-chat {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+.ad-turno {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.ad-msg { display: flex; gap: 8px; }
+.ad-msg--user { justify-content: flex-end; }
+.ad-msg--agent { justify-content: flex-start; }
+
+.ad-avatar {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  margin-top: 2px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--ad-verde);
+  color: #f3ead4;
+}
+
+.ad-bubble {
+  border-radius: 16px;
+  line-height: 1.4;
+  box-shadow: 0 1px 3px rgba(60, 42, 20, 0.1);
+}
+.ad-bubble--user {
+  max-width: 82%;
+  padding: 10px 14px;
+  background: var(--ad-tinta);
+  color: var(--ad-papel);
+  border-bottom-right-radius: 5px;
+  font-size: 0.94rem;
+}
+.ad-bubble--agent {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 14px;
+  background: var(--ad-agent-bg);
+  border: 1.5px solid var(--ad-agent-borde);
+  border-bottom-left-radius: 5px;
+  color: var(--ad-agent-txt);
+}
+
+/* la lámina adjunta (el envoltorio lam-agente pinta su propio papel crema) */
+.ad-lamina { margin: 0 0 12px; }
+
+.ad-frases {
+  margin: 0 0 12px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ad-frases li {
+  position: relative;
+  padding-left: 18px;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  color: var(--ad-agent-txt);
+}
+.ad-frases li::before {
+  content: '';
+  position: absolute;
+  left: 3px;
+  top: 0.6em;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #7fae86;
+}
+
+.ad-observa {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border-left: 3px solid #7fae86;
+  border-radius: 6px;
+  background: rgba(127, 174, 134, 0.12);
+  font-size: 0.88rem;
+  line-height: 1.45;
+  font-style: italic;
+  color: #d6e2d5;
+}
+.ad-observa-tag {
+  display: block;
+  margin-bottom: 2px;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: #9ecb9f;
+}
+
+/* el contrato metadata.lamina, a la vista (hook del backend) */
+.ad-meta {
+  margin: 0 0 12px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+}
+.ad-meta-tag {
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ad-agent-txt-2);
+}
+.ad-meta code {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, monospace;
+  font-size: 0.76rem;
+  color: #cfe3d2;
+  white-space: nowrap;
+}
+
+.ad-redraw {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 13px;
+  border: 1.5px solid var(--ad-agent-borde);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ad-agent-txt);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 40px;
+}
+.ad-redraw:hover { background: rgba(255, 255, 255, 0.12); }
+
+/* ── pie ──────────────────────────────────────────────────────────────── */
+.ad-foot {
+  max-width: 640px;
+  margin: 24px auto 0;
+  padding-top: 14px;
+  border-top: 1px dashed var(--ad-linea);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--ad-tinta-2);
+  text-align: center;
+}
+.ad-foot strong { color: var(--ad-verde); }
+
+@media (max-width: 380px) {
+  .ad-bubble--user { max-width: 90%; font-size: 0.9rem; }
+  .ad-avatar { width: 28px; height: 28px; }
+}

--- a/src/visual/laminas/AgentLamina.jsx
+++ b/src/visual/laminas/AgentLamina.jsx
@@ -1,0 +1,68 @@
+import { resolveLaminaFiable } from './laminasFiables.js';
+import '../effects/effects.css';
+import './laminas.css';
+
+/*
+ * AgentLamina — el ADJUNTO de lámina que el agente incrusta en una respuesta
+ * (DR "el agente dibuja de forma fiable", 2026-07-11). Recibe un `slug` del
+ * conjunto CERRADO `LAMINAS_FIABLES` + `props` de enum cerrado y monta la
+ * lámina LOCAL correspondiente, envuelta en el auto-dibujado ("se dibuja
+ * sola") de `src/visual/effects`.
+ *
+ * CONTRATO CLAVE (degradación segura): si el `slug` NO está en el registro, o
+ * si `props` trae algo fuera del enum, `resolveLaminaFiable` devuelve null y
+ * AgentLamina renderiza NADA → la burbuja queda como solo texto. Nunca llega
+ * un byte de SVG desde el modelo: el arte es 100% local y verificado a mano.
+ *
+ * Este componente valida SOLO reglas #1 y #2 del gate (slug ∈ registro, prop ∈
+ * enum). La regla #3 (que la especie/proposición esté ATERRIZADA en la
+ * evidencia del turno) la revalida el handler del agente aguas arriba — el arte
+ * no sabe de grounding. Ver `resolveLaminaFiable`.
+ *
+ * Móvil-first (ancho completo, 320px), self-contained (sin CDN), contraste AA
+ * (tinta sepia sobre papel crema). `prefers-reduced-motion` = lámina completa y
+ * quieta en su fotograma final (lo garantiza effects.css / laminas.css).
+ *
+ * @param {Object} props
+ * @param {string} props.slug - Slug de LAMINAS_FIABLES (p.ej. 'milpa', 'maiz').
+ * @param {Record<string, string>} [props.props] - Props de dominio (enum
+ *   cerrado): p.ej. `{ activo: 'tuberculo' }` o `{ etapa: 'cosecha' }`.
+ * @param {string} [props.titulo] - Título opcional sobre la lámina (letra de
+ *   cuaderno). Si se omite, se usa el `nombre` del registro.
+ * @param {boolean} [props.mostrarTitulo=true] - Mostrar el título/rótulo.
+ * @param {string|number} [props.drawKey] - Cambiarlo re-monta la lámina para
+ *   re-disparar el auto-dibujado ("dibujar otra vez"). Opcional.
+ * @param {string} [props.className] - Clases extra sobre el contenedor.
+ */
+export default function AgentLamina({
+  slug,
+  props: laminaProps = {},
+  titulo,
+  mostrarTitulo = true,
+  drawKey,
+  className,
+}) {
+  const resolved = resolveLaminaFiable(slug, laminaProps);
+  // Regla del contrato: slug inválido o prop fuera de enum → no dibuja nada.
+  if (!resolved) return null;
+
+  const { Component, props: safeProps, meta } = resolved;
+  const rotulo = titulo || meta.nombre;
+
+  return (
+    <figure
+      className={['lam-agente', className].filter(Boolean).join(' ')}
+      data-testid="agent-lamina"
+      data-lamina-slug={slug}
+    >
+      {mostrarTitulo && rotulo && (
+        <figcaption className="lam-agente-tit">{rotulo}</figcaption>
+      )}
+      {/* `key` re-monta la lámina cuando cambia drawKey → el auto-dibujado se
+          vuelve a disparar. En el chat, el turno es estable: dibuja una vez. */}
+      <div className="lam-agente-hoja" key={drawKey ?? slug}>
+        <Component {...safeProps} className="lam-agente-svg" />
+      </div>
+    </figure>
+  );
+}

--- a/src/visual/laminas/LaminaMilpa.jsx
+++ b/src/visual/laminas/LaminaMilpa.jsx
@@ -1,0 +1,127 @@
+import { useId } from 'react';
+import { AutoDibujo } from '../effects';
+import {
+  Rotulo, TINTA, TINTA_2, VERDE, VERDE_OSC, VERDE_CLARO,
+  GRANO, GRANO_OSC, NARANJA, TIERRA_CLARA, ROJO,
+} from './_kit.jsx';
+
+/*
+ * LaminaMilpa — la MILPA (las "tres hermanas") dibujándose sola: el maíz que
+ * hace de tutor, el frijol que trepa y fija el nitrógeno, y la calabaza que
+ * tapa el suelo. Enseña la ASOCIACIÓN de cultivos.
+ *
+ * PROPOSICIÓN-LOCKED: dibuja UNA proposición concreta (maíz + frijol +
+ * calabaza). No se generaliza a "asociación de 3 especies cualquiera".
+ *
+ * SVG propio e inline (sin imágenes ni deps nuevas). role="img" porque enseña:
+ * lleva rótulos que son contenido. Colores fijos (tinta sobre papel crema). El
+ * dibujo se traza solo con el auto-dibujado de effects (clases vfx-draw); en
+ * reduced-motion aparece completo y quieto (lo garantiza effects.css).
+ *
+ * @param {Object} [props]
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+export default function LaminaMilpa({ className } = {}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const suelo = 258; // línea del suelo
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 400 320"
+      role="img"
+      aria-label="La milpa: el maíz sirve de tutor al frijol, que fija el nitrógeno, mientras la calabaza tapa el suelo."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <title>La milpa: las tres hermanas</title>
+
+      {/* ── suelo en corte ─────────────────────────────────────────────── */}
+      <g className="vfx-t1">
+        <AutoDibujo as="line" x1="18" y1={suelo} x2="382" y2={suelo} stroke={TINTA} strokeWidth="2.4" strokeLinecap="round" />
+        <AutoDibujo as="path" fade fill={`${TIERRA_CLARA}22`} d={`M18 ${suelo} H382 V300 H18 Z`} stroke="none" />
+      </g>
+
+      {/* ── 1. MAÍZ (el tutor): caña central, hojas, penacho, mazorca ──── */}
+      <g fill="none" stroke={VERDE_OSC} strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round">
+        <g className="vfx-t2">
+          {/* caña */}
+          <AutoDibujo as="path" d={`M200 ${suelo} C198 210 202 150 200 70`} stroke={VERDE_OSC} strokeWidth="3" />
+          {/* nudos */}
+          <AutoDibujo as="line" x1="194" y1="210" x2="206" y2="210" strokeWidth="2" />
+          <AutoDibujo as="line" x1="195" y1="160" x2="205" y2="160" strokeWidth="2" />
+        </g>
+        <g className="vfx-t3">
+          {/* hojas del maíz (arqueadas) */}
+          <AutoDibujo as="path" d="M200 150 C168 138 150 152 132 176" stroke={VERDE} strokeWidth="3" />
+          <AutoDibujo as="path" d="M200 118 C232 108 252 124 268 150" stroke={VERDE} strokeWidth="3" />
+          <AutoDibujo as="path" d="M200 200 C172 196 156 210 142 232" stroke={VERDE} strokeWidth="3" />
+          {/* penacho (flor macho) */}
+          <AutoDibujo as="path" d="M200 70 C196 56 200 48 200 40" stroke={GRANO_OSC} strokeWidth="2" />
+          <AutoDibujo as="path" d="M200 62 C206 52 210 48 214 42" stroke={GRANO_OSC} strokeWidth="2" />
+          <AutoDibujo as="path" d="M200 60 C194 50 190 46 186 40" stroke={GRANO_OSC} strokeWidth="2" />
+        </g>
+        {/* mazorca */}
+        <g className="vfx-t4">
+          <AutoDibujo as="path" fade fill={GRANO} stroke={GRANO_OSC} strokeWidth="1.6"
+            d="M214 150 q16 4 18 26 q-10 12 -20 4 q-8 -18 2 -30 Z" />
+          <AutoDibujo as="path" d="M232 150 q6 -8 12 -8" stroke={ROJO} strokeWidth="1.6" /> {/* barbas */}
+        </g>
+      </g>
+
+      {/* ── 2. FRIJOL (fija N): guía que trepa por la caña + nódulos ────── */}
+      <g fill="none" stroke={VERDE_CLARO} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+        <g className="vfx-t5">
+          {/* enredadera espiralando la caña */}
+          <AutoDibujo as="path"
+            d={`M188 ${suelo} C176 236 214 224 210 204 C206 184 176 178 184 156 C190 138 218 138 208 116 C202 100 184 100 190 84`} />
+          {/* hojas trifoliadas simplificadas */}
+          <AutoDibujo as="path" fade fill={`${VERDE_CLARO}66`} stroke={VERDE} strokeWidth="1.2" d="M184 156 q-14 -6 -18 6 q10 8 18 -6 Z" />
+          <AutoDibujo as="path" fade fill={`${VERDE_CLARO}66`} stroke={VERDE} strokeWidth="1.2" d="M208 116 q14 -6 18 6 q-10 8 -18 -6 Z" />
+          <AutoDibujo as="path" fade fill={`${VERDE_CLARO}66`} stroke={VERDE} strokeWidth="1.2" d="M210 204 q14 -6 18 6 q-10 8 -18 -6 Z" />
+          {/* flor de frijol */}
+          <AutoDibujo as="circle" fade cx="190" cy="84" r="4" fill={ROJO} stroke={ROJO} strokeWidth="0.5" />
+        </g>
+        {/* nódulos que fijan nitrógeno (raíz del frijol) */}
+        <g className="vfx-t6">
+          <AutoDibujo as="path" d={`M188 ${suelo} C180 274 172 280 164 288`} stroke={TINTA_2} strokeWidth="1.6" />
+          <AutoDibujo as="circle" fade cx="176" cy="276" r="3.2" fill={ROJO} />
+          <AutoDibujo as="circle" fade cx="167" cy="285" r="3" fill={ROJO} />
+          <AutoDibujo as="circle" fade cx="182" cy="284" r="2.6" fill={ROJO} />
+          {/* N del aire → nódulos */}
+          <AutoDibujo as="path" fade d="M150 300 q6 -10 14 -12" stroke={TINTA_2} strokeWidth="1" markerEnd={`url(#flechaN-${uid})`} />
+        </g>
+        <text className="vfx-t6 vfx-fade" x="138" y="304" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="10" fill={TINTA_2}>N₂ del aire</text>
+      </g>
+
+      {/* ── 3. CALABAZA (tapa el suelo): hojas anchas + fruto + flor ────── */}
+      <g fill="none" stroke={VERDE_OSC} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <g className="vfx-t5">
+          {/* guía rastrera */}
+          <AutoDibujo as="path" d={`M212 ${suelo} C250 252 300 250 344 246`} stroke={VERDE} strokeWidth="2.2" />
+          {/* hojas anchas */}
+          <AutoDibujo as="path" fade fill={`${VERDE}55`} stroke={VERDE_OSC} strokeWidth="1.4" d="M272 248 q-16 -18 2 -30 q22 4 20 24 q-10 12 -22 6 Z" />
+          <AutoDibujo as="path" fade fill={`${VERDE}55`} stroke={VERDE_OSC} strokeWidth="1.4" d="M322 244 q-14 -16 4 -26 q20 4 18 22 q-10 10 -22 4 Z" />
+        </g>
+        <g className="vfx-t7">
+          {/* fruto de calabaza sobre el suelo */}
+          <AutoDibujo as="path" fade fill={NARANJA} stroke={GRANO_OSC} strokeWidth="1.6"
+            d="M300 250 q22 -6 30 8 q4 14 -16 16 q-22 0 -22 -12 q0 -8 8 -12 Z" />
+          <AutoDibujo as="path" d="M314 244 q0 20 0 22" stroke={GRANO_OSC} strokeWidth="1" />
+          {/* flor amarilla */}
+          <AutoDibujo as="circle" fade cx="352" cy="242" r="5" fill={GRANO} stroke={GRANO_OSC} strokeWidth="1" />
+        </g>
+      </g>
+
+      {/* ── rótulos que enseñan (usted colombiano) ─────────────────────── */}
+      <Rotulo stage={7} x="252" y="96" tx="204" ty="112" texto="El maíz: el tutor" sub="sube derecho, da la vara" />
+      <Rotulo stage={8} x="26" y="150" tx="186" ty="172" texto="El frijol trepa" sub="y fija el nitrógeno en la raíz" anchor="start" />
+      <Rotulo stage={9} x="250" y="296" tx="300" ty="264" texto="La calabaza tapa el suelo" sub="guarda humedad, ahoga la maleza" />
+
+      <defs>
+        <marker id={`flechaN-${uid}`} markerWidth="6" markerHeight="6" refX="4" refY="3" orient="auto">
+          <path d="M0 0 L6 3 L0 6 Z" fill={TINTA_2} />
+        </marker>
+      </defs>
+    </svg>
+  );
+}

--- a/src/visual/laminas/LaminaPisoTermico.jsx
+++ b/src/visual/laminas/LaminaPisoTermico.jsx
@@ -1,0 +1,112 @@
+import { AutoDibujo } from '../effects';
+import {
+  TINTA, TINTA_2, VERDE, VERDE_OSC, GRANO, GRANO_OSC, NARANJA, CIAN, ROJO,
+} from './_kit.jsx';
+
+/*
+ * LaminaPisoTermico — el PISO TÉRMICO dibujándose solo: una montaña en corte
+ * donde la ALTURA manda qué se da. De abajo hacia arriba: cálido (plátano,
+ * yuca, cacao) → templado (café, cítricos, maíz; el piso de la finca) → frío
+ * (papa, cebolla, arveja) → páramo (el frailejón: se cuida, no se siembra).
+ *
+ * PROPOSICIÓN-LOCKED: dibuja el gradiente cálido→páramo de la cordillera. No se
+ * generaliza a otra columna de altura.
+ *
+ * SVG propio e inline. role="img" (enseña). Auto-dibujado de effects: primero
+ * se traza la montaña, luego se tiñen las franjas y aparecen los cultivos.
+ *
+ * @param {Object} [props]
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+export default function LaminaPisoTermico({ className } = {}) {
+  // franjas por altura (y de arriba=alto a abajo=bajo)
+  const bandas = [
+    { y: 26, h: 58, tint: `${CIAN}22`, msnm: '3.600 m', cy: 55 },
+    { y: 84, h: 58, tint: '#8a9a8e22', msnm: '2.600 m', cy: 113 },
+    { y: 142, h: 58, tint: `${GRANO}22`, msnm: '1.800 m', cy: 171 },
+    { y: 200, h: 58, tint: `${NARANJA}22`, msnm: '600 m', cy: 229 },
+  ];
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 420 300"
+      role="img"
+      aria-label="Corte de una montaña por pisos térmicos: cálido con plátano y cacao abajo, templado con café y maíz, frío con papa, y páramo con frailejón arriba."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <title>El piso térmico: la altura manda qué se da</title>
+
+      {/* ── franjas de altura (tinte) ──────────────────────────────────── */}
+      <g className="vfx-t2">
+        {bandas.map((b) => (
+          <AutoDibujo key={b.msnm} as="rect" fade x="52" y={b.y} width="352" height={b.h} fill={b.tint} />
+        ))}
+      </g>
+
+      {/* ── eje de altura (izquierda) ──────────────────────────────────── */}
+      <g className="vfx-t1">
+        <AutoDibujo as="line" x1="52" y1="26" x2="52" y2="258" stroke={TINTA_2} strokeWidth="1.4" strokeLinecap="round" />
+        {bandas.map((b) => (
+          <g key={b.msnm}>
+            <AutoDibujo as="line" x1="47" y1={b.cy} x2="52" y2={b.cy} stroke={TINTA_2} strokeWidth="1.2" />
+            <text className="vfx-fade" x="45" y={b.cy + 3} textAnchor="end" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="9.5" fill={TINTA_2}>{b.msnm}</text>
+          </g>
+        ))}
+      </g>
+
+      {/* ── silueta de la montaña ──────────────────────────────────────── */}
+      <g className="vfx-t1" fill="none" stroke={TINTA} strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="path" d="M60 258 L250 34 L404 258" stroke={TINTA} strokeWidth="2.6" />
+        {/* nevado en la cima */}
+        <AutoDibujo as="path" fade fill={`${CIAN}55`} stroke={CIAN} strokeWidth="1.2" d="M226 62 L250 34 L274 62 L262 56 L250 64 L238 56 Z" />
+      </g>
+      <AutoDibujo as="line" className="vfx-t2" x1="60" y1="258" x2="404" y2="258" stroke={TINTA} strokeWidth="2.4" strokeLinecap="round" />
+
+      {/* ── cultivos por piso ──────────────────────────────────────────── */}
+      {/* PÁRAMO — frailejón */}
+      <g className="vfx-t4" fill="none" stroke={VERDE_OSC} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="line" x1="150" y1="80" x2="150" y2="58" stroke={TINTA_2} strokeWidth="2.4" />
+        <AutoDibujo as="path" fade fill={`${VERDE}66`} stroke={VERDE_OSC} strokeWidth="1.2" d="M150 58 q-14 -4 -16 -12 M150 58 q14 -4 16 -12 M150 58 q-6 -12 -4 -18 M150 58 q6 -12 4 -18 M150 58 q0 -14 0 -18" />
+        <AutoDibujo as="circle" fade cx="150" cy="42" r="3.5" fill={GRANO} stroke={GRANO_OSC} strokeWidth="1" />
+      </g>
+      {/* FRÍO — papa (mata + tubérculos) */}
+      <g className="vfx-t5" fill="none" stroke={VERDE_OSC} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="path" d="M150 128 q-10 -8 -8 -16 M150 128 q10 -8 8 -16 M150 128 q0 -10 0 -18" strokeWidth="1.6" />
+        <AutoDibujo as="circle" fade cx="150" cy="112" r="2.5" fill={GRANO} />
+        <AutoDibujo as="circle" fade cx="144" cy="136" r="3.4" fill={GRANO_OSC} />
+        <AutoDibujo as="circle" fade cx="155" cy="138" r="3" fill={GRANO_OSC} />
+      </g>
+      {/* TEMPLADO — cafeto (rama con cerezas) */}
+      <g className="vfx-t6" fill="none" stroke={VERDE_OSC} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="path" d="M138 186 q14 -10 26 -6" stroke={VERDE_OSC} strokeWidth="1.8" />
+        <AutoDibujo as="path" fade fill={`${VERDE}66`} stroke={VERDE_OSC} strokeWidth="1" d="M148 182 q8 -6 12 0 q-6 6 -12 0 Z" />
+        <AutoDibujo as="circle" fade cx="150" cy="188" r="2.6" fill={ROJO} />
+        <AutoDibujo as="circle" fade cx="158" cy="186" r="2.6" fill={ROJO} />
+        <AutoDibujo as="circle" fade cx="142" cy="188" r="2.4" fill={ROJO} />
+      </g>
+      {/* CÁLIDO — plátano (hoja paleta) */}
+      <g className="vfx-t7" fill="none" stroke={VERDE_OSC} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <AutoDibujo as="line" x1="150" y1="244" x2="150" y2="216" stroke={VERDE_OSC} strokeWidth="2" />
+        <AutoDibujo as="path" fade fill={`${VERDE}66`} stroke={VERDE_OSC} strokeWidth="1.2" d="M150 220 q-20 -6 -24 -20 q18 -2 24 12 q6 -14 24 -12 q-4 14 -24 20 Z" />
+        <AutoDibujo as="path" d="M150 220 q0 -14 0 -18" strokeWidth="1" />
+      </g>
+
+      {/* ── rótulos (derecha, usted colombiano) ───────────────────────── */}
+      <g className="vfx-t8">
+        {[
+          { y: 50, c: CIAN, t: 'Páramo', s: 'frailejón · aquí se cuida, no se siembra' },
+          { y: 108, c: TINTA_2, t: 'Frío', s: 'papa, cebolla, arveja' },
+          { y: 166, c: GRANO_OSC, t: 'Templado — su finca', s: 'café, cítricos, maíz' },
+          { y: 224, c: NARANJA, t: 'Cálido', s: 'plátano, yuca, cacao' },
+        ].map((r) => (
+          <g key={r.t}>
+            <rect className="vfx-fade" x="250" y={r.y - 9} width="9" height="9" rx="2" fill={r.c} />
+            <text className="vfx-fade" x="266" y={r.y} fontFamily="'Georgia', serif" fontStyle="italic" fontWeight="600" fontSize="12" fill={TINTA}>{r.t}</text>
+            <text className="vfx-fade" x="266" y={r.y + 13} fontFamily="'Georgia', serif" fontStyle="italic" fontSize="9.5" fill={TINTA_2}>{r.s}</text>
+          </g>
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/src/visual/laminas/LaminaRotacion.jsx
+++ b/src/visual/laminas/LaminaRotacion.jsx
@@ -1,0 +1,119 @@
+import { useId } from 'react';
+import { AutoDibujo } from '../effects';
+import {
+  TINTA, TINTA_2, VERDE, VERDE_OSC, VERDE_CLARO,
+  GRANO_OSC, NARANJA, TIERRA_CLARA, ROJO,
+} from './_kit.jsx';
+
+/*
+ * LaminaRotacion — la ROTACIÓN de cultivos como una rueda de cuatro eras que se
+ * dibuja sola: hoja → fruto → raíz → leguminosa → y vuelve a empezar. Cada
+ * familia le pide y le devuelve algo distinto al suelo; la leguminosa repone el
+ * nitrógeno que la de hoja gastó.
+ *
+ * PROPOSICIÓN-LOCKED: dibuja la rueda hoja→fruto→raíz→leguminosa. No se
+ * generaliza a otra secuencia de rotación.
+ *
+ * SVG propio e inline. role="img" (enseña). Auto-dibujado de effects; las
+ * flechas del ciclo se trazan en orden con las etapas escalonadas.
+ *
+ * @param {Object} [props]
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+
+// Nodo de una era: disco de tierra + número + rótulo con lo que hace al suelo.
+// Declarado a nivel de módulo (no dentro del render) para no re-crear el
+// componente en cada dibujo.
+function Era({ cx, cy, num, titulo, familia, efecto, stage, children }) {
+  return (
+    <g className={`vfx-t${stage}`}>
+      <AutoDibujo as="ellipse" fade cx={cx} cy={cy + 26} rx="34" ry="9" fill={`${TIERRA_CLARA}33`} />
+      <AutoDibujo as="line" x1={cx - 30} y1={cy + 26} x2={cx + 30} y2={cy + 26} stroke={TINTA} strokeWidth="1.6" strokeLinecap="round" />
+      {children}
+      <circle className="vfx-fade" cx={cx - 40} cy={cy - 22} r="10" fill="#f3ead4" stroke={TINTA} strokeWidth="1.4" />
+      <text className="vfx-fade" x={cx - 40} y={cy - 18} textAnchor="middle" fontFamily="'Georgia', serif" fontWeight="700" fontSize="12" fill={TINTA}>{num}</text>
+      <text className="vfx-fade" x={cx} y={cy + 44} textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontWeight="600" fontSize="12" fill={TINTA}>{titulo}</text>
+      <text className="vfx-fade" x={cx} y={cy + 57} textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="9.5" fill={TINTA_2}>{familia}</text>
+      <text className="vfx-fade" x={cx} y={cy + 70} textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="9.5" fill={efecto.color}>{efecto.txt}</text>
+    </g>
+  );
+}
+
+export default function LaminaRotacion({ className } = {}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const flecha = `flechaRot-${uid}`;
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 400 350"
+      role="img"
+      aria-label="Rueda de rotación de cultivos: primero hoja, luego fruto, luego raíz, luego leguminosa que repone el nitrógeno, y se vuelve a empezar."
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <title>La rotación: cambie de familia cada era</title>
+
+      {/* ── flechas del ciclo (horario) ────────────────────────────────── */}
+      <g fill="none" stroke={TINTA_2} strokeWidth="2" strokeLinecap="round">
+        <g className="vfx-t2"><AutoDibujo as="path" d="M250 70 A120 120 0 0 1 320 130" markerEnd={`url(#${flecha})`} /></g>
+        <g className="vfx-t4"><AutoDibujo as="path" d="M320 214 A120 120 0 0 1 250 276" markerEnd={`url(#${flecha})`} /></g>
+        <g className="vfx-t6"><AutoDibujo as="path" d="M150 276 A120 120 0 0 1 80 214" markerEnd={`url(#${flecha})`} /></g>
+        <g className="vfx-t8"><AutoDibujo as="path" d="M80 130 A120 120 0 0 1 150 70" markerEnd={`url(#${flecha})`} /></g>
+      </g>
+
+      {/* ── centro ─────────────────────────────────────────────────────── */}
+      <g className="vfx-t1">
+        <AutoDibujo as="circle" fade cx="200" cy="173" r="30" fill="#f3ead4" stroke={TINTA_2} strokeWidth="1.2" strokeDasharray="3 4" />
+        <text className="vfx-fade" x="200" y="168" textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontWeight="700" fontSize="12" fill={TINTA}>La era</text>
+        <text className="vfx-fade" x="200" y="184" textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="10" fill={TINTA_2}>descansa</text>
+        <text className="vfx-fade" x="200" y="196" textAnchor="middle" fontFamily="'Georgia', serif" fontStyle="italic" fontSize="10" fill={TINTA_2}>cambiando</text>
+      </g>
+
+      {/* ── 1. HOJA (arriba) — lechuga: gasta nitrógeno ────────────────── */}
+      <Era cx={200} cy={44} num="1" titulo="Hoja" familia="lechuga, repollo" efecto={{ txt: 'gasta nitrógeno', color: ROJO }} stage={3}>
+        <g fill="none" stroke={VERDE_OSC} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <AutoDibujo as="path" fade fill={`${VERDE}55`} stroke={VERDE_OSC} strokeWidth="1.4" d="M200 66 q-22 -2 -20 -18 q20 -6 22 10 q2 -16 22 -10 q2 16 -20 18 Z" />
+          <AutoDibujo as="path" d="M200 66 q0 -14 0 -22" strokeWidth="1.4" />
+        </g>
+      </Era>
+
+      {/* ── 2. FRUTO (derecha) — tomate: pide suelo fértil ─────────────── */}
+      <Era cx={310} cy={148} num="2" titulo="Fruto" familia="tomate, ají" efecto={{ txt: 'pide suelo rico', color: TINTA_2 }} stage={5}>
+        <g fill="none" stroke={VERDE_OSC} strokeWidth="1.8" strokeLinecap="round">
+          <AutoDibujo as="path" d="M310 174 C308 162 312 156 310 148" strokeWidth="2" />
+          <AutoDibujo as="circle" fade cx="302" cy="160" r="4.5" fill={ROJO} />
+          <AutoDibujo as="circle" fade cx="318" cy="166" r="4" fill={ROJO} />
+          <AutoDibujo as="path" fade fill={`${VERDE}55`} stroke={VERDE_OSC} strokeWidth="1.2" d="M310 152 q10 -4 12 4 q-8 4 -12 -4 Z" />
+        </g>
+      </Era>
+
+      {/* ── 3. RAÍZ (abajo) — zanahoria: afloja hondo ──────────────────── */}
+      <Era cx={200} cy={252} num="3" titulo="Raíz" familia="zanahoria, remolacha" efecto={{ txt: 'afloja hondo', color: TINTA_2 }} stage={7}>
+        <g fill="none" stroke={GRANO_OSC} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <AutoDibujo as="path" fade fill={NARANJA} stroke={GRANO_OSC} strokeWidth="1.4" d="M192 278 L208 278 L200 300 Z" />
+          <AutoDibujo as="path" d="M200 278 q-8 -10 -6 -16" stroke={VERDE_OSC} strokeWidth="1.4" />
+          <AutoDibujo as="path" d="M200 278 q8 -10 6 -16" stroke={VERDE_OSC} strokeWidth="1.4" />
+          <AutoDibujo as="path" d="M200 278 q0 -12 0 -16" stroke={VERDE_OSC} strokeWidth="1.4" />
+        </g>
+      </Era>
+
+      {/* ── 4. LEGUMINOSA (izquierda) — fríjol/haba: repone nitrógeno ──── */}
+      <Era cx={90} cy={148} num="4" titulo="Leguminosa" familia="fríjol, haba, arveja" efecto={{ txt: 'repone nitrógeno', color: VERDE_OSC }} stage={9}>
+        <g fill="none" stroke={VERDE_CLARO} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <AutoDibujo as="path" d="M90 174 C88 162 92 156 90 148" strokeWidth="2" stroke={VERDE_OSC} />
+          {/* vaina */}
+          <AutoDibujo as="path" fade fill={`${VERDE_CLARO}88`} stroke={VERDE_OSC} strokeWidth="1.2" d="M96 152 q14 2 16 12 q-14 2 -16 -12 Z" />
+          {/* nódulos */}
+          <AutoDibujo as="circle" fade cx="84" cy="176" r="2.6" fill={ROJO} />
+          <AutoDibujo as="circle" fade cx="92" cy="178" r="2.2" fill={ROJO} />
+        </g>
+      </Era>
+
+      <defs>
+        <marker id={flecha} markerWidth="7" markerHeight="7" refX="4.5" refY="3.5" orient="auto">
+          <path d="M0 0 L7 3.5 L0 7 Z" fill={TINTA_2} />
+        </marker>
+      </defs>
+    </svg>
+  );
+}

--- a/src/visual/laminas/README.md
+++ b/src/visual/laminas/README.md
@@ -31,6 +31,16 @@ la misma firma de props**: una lámina no tiene `size`/`inline` — se dibuja a
 | `LaminaMaiz` | La mata de maíz | *Zea mays* | enseña (`role=img` + rótulos) | — |
 | `LaminaCafeto` | El cafeto | *Coffea arabica* | enseña (`role=img` + rótulos) | — |
 | `LaminaMataEtapa` | La mata por etapa (viva) | *Solanum lycopersicum* | decorativa (`aria-hidden`) | `etapa` |
+| `LaminaMilpa` | La milpa (las tres hermanas) | Asociación: maíz + frijol + calabaza | enseña (`role=img` + rótulos) | — |
+| `LaminaRotacion` | La rotación por eras | Rueda: hoja → fruto → raíz → leguminosa | enseña (`role=img` + rótulos) | — |
+| `LaminaPisoTermico` | El piso térmico (en corte) | Gradiente de altura: cálido → páramo | enseña (`role=img` + rótulos) | — |
+
+Las tres últimas se promovieron desde el mockup `ensena-dibujando` (usan el
+auto-dibujado de [`src/visual/effects`](../effects/README.md): se **dibujan
+solas** al montarse) y comparten paleta + el rótulo de cuaderno en `_kit.jsx`.
+Son **proposición-locked**: dibujan UNA proposición concreta (la milpa =
+maíz+frijol+calabaza, la rueda de 4 eras, el gradiente cálido→páramo) y **no se
+generalizan** a otra.
 
 ## Props
 
@@ -57,6 +67,47 @@ import { LaminaSiembra, LaminaMaiz } from '@/visual/laminas';
 
 Consumidor de referencia: **`src/components/TuberculosScreen.jsx`** (importa
 `LaminaSiembra` y `LaminaAporque` desde aquí).
+
+## El conjunto CERRADO que el agente puede dibujar (`LAMINAS_FIABLES`)
+
+Extensión para el DR **"el agente dibuja en sus respuestas de forma fiable"**
+(2026-07-11). El agente productivo **NO genera SVG**: **SELECCIONA** un `slug` de
+un registro cerrado y, a lo sumo, una **prop de enum cerrado**. Todo lo demás es
+arte fijo, ya verificado a mano. La superficie de alucinación pasa de "un
+espacio infinito de SVG" a "un `enum` de N slugs × M props".
+
+- **`LAMINAS_FIABLES`** (en `index.js`) — el registro cerrado: `slug →
+  { Component, nombre, dim:'2d', lock, aplica_a, props, accesible }`. Cada
+  plantilla está **locked** a su especie (`Maiz`→*Zea mays*) o a su proposición
+  (`milpa`→maíz+frijol+calabaza). `props` declara los **enums permitidos**
+  (p.ej. `siembra` → `activo`, `mata-etapa` → `etapa`).
+- **`resolveLaminaFiable(slug, props)`** — el validador del frontend. Aplica
+  **solo las reglas #1 y #2** del gate: *slug ∈ registro* y *prop ∈ enum*. Si
+  algo no calza → `null`. La **regla #3** (que la especie/proposición esté
+  **aterrizada** en la evidencia del turno) la revalida el **handler del
+  agente**, no el arte.
+- **`<AgentLamina slug props />`** — el adjunto de chat: monta la lámina por
+  slug+prop con el auto-dibujado, pensado para incrustarse en una `ChatBubble`.
+  Si `resolveLaminaFiable` devuelve `null` → **no renderiza nada** (la respuesta
+  degrada a solo texto). Móvil-first (320px), self-contained, AA,
+  reduced-motion-safe.
+
+```jsx
+import { AgentLamina } from '@/visual/laminas';
+
+// El backend inyecta metadata.lamina = { slug, props }; el chat solo lo lee:
+<AgentLamina slug="milpa" props={{}} />                 // proposición-locked
+<AgentLamina slug="mata-etapa" props={{ etapa: 'cosecha' }} /> // especie + prop
+<AgentLamina slug="papaya" props={{}} />                // no fiable → null (texto)
+```
+
+**Cómo se incrusta en el chat:** `ChatBubble` lee `message.metadata?.lamina`
+(`{ slug, props }`) y monta `<AgentLamina>` como un adjunto más (igual que
+`imageUrl` o el semáforo de confianza). El **gate de grounding** que decide
+*si* se dibuja lo cablea el agente aguas arriba (tool `dibujar_lamina` +
+revalidación contra `resolvedEntities`/`toolEvidence`) — el frontend solo
+renderiza lo que ya venga validado. Vitrina pública:
+**`#/mockups/agente-dibuja`** (`src/mockups/AgenteDibuja.jsx`).
 
 ## Técnica
 

--- a/src/visual/laminas/_kit.jsx
+++ b/src/visual/laminas/_kit.jsx
@@ -1,0 +1,69 @@
+/*
+ * _kit — utilería compartida de las láminas PROPOSICIÓN-LOCKED de cuaderno
+ * (milpa / rotación / piso térmico). Promovido desde el mockup "el agente
+ * enseña dibujando" a la librería canónica (misma regla de la casa: si una
+ * lámina reutilizable se estabiliza, vive aquí con su fila en el índice).
+ *
+ * Sigue la casa de `src/visual/laminas` (tinta sobre papel crema, colores
+ * FIJOS porque es una ilustración que enseña, no cromo de UI) y usa el
+ * auto-dibujado canónico de `src/visual/effects` (AutoDibujo + effects.css).
+ *
+ * No es una lámina en sí: es paleta + el rótulo de cuaderno que comparten las
+ * tres proposiciones. Las láminas locked-a-especie (Maíz, Cafeto, MataEtapa)
+ * inlinean su propia paleta; estas tres comparten la de aquí.
+ */
+import { AutoDibujo } from '../effects';
+
+/* Paleta de tinta: sepia + verdes botánicos + tierras, sobre papel crema.
+   Fija a propósito (legible al sol, no reacciona al tema). */
+export const TINTA = '#5c4326'; // sepia principal (trazo y rótulos)
+export const TINTA_2 = '#8a6b40'; // sepia claro (guías, rótulos 2°)
+export const VERDE = '#6f8a3c'; // verde hoja
+export const VERDE_OSC = '#55702c'; // verde de contornos/venas
+export const VERDE_CLARO = '#9bb45f'; // verde tierno (frijol)
+export const GRANO = '#d8a93f'; // oro del grano / flor
+export const GRANO_OSC = '#b0822a'; // contorno del grano
+export const NARANJA = '#d98b3c'; // calabaza / fruto cálido
+export const TIERRA = '#7a5a34'; // suelo
+export const TIERRA_CLARA = '#a07d4e'; // suelo claro
+export const ROJO = '#a8443a'; // fruto / flor de frijol
+export const CIAN = '#4f9aa0'; // páramo / frío
+
+/* Rótulo de cuaderno: línea-guía que se DIBUJA sola + punto en el objetivo +
+   texto serif itálico (letra de mano) que aparece en fundido. Se agrupa en una
+   `etapa` (1..9) para escalonar su aparición con el resto de la lámina. */
+export function Rotulo({ x, y, tx, ty, texto, sub = null, anchor = 'start', stage = 6 }) {
+  return (
+    <g className={`vfx-t${stage}`}>
+      <AutoDibujo as="line" x1={tx} y1={ty} x2={x} y2={y} stroke={TINTA_2} strokeWidth="0.9" strokeLinecap="round" />
+      <circle className="vfx-fade" cx={tx} cy={ty} r="1.8" fill={TINTA} />
+      <text
+        className="vfx-fade"
+        x={x}
+        y={y}
+        textAnchor={anchor}
+        fontFamily="'Georgia', 'Times New Roman', serif"
+        fontStyle="italic"
+        fontSize="12.5"
+        fontWeight="600"
+        fill={TINTA}
+      >
+        {texto}
+      </text>
+      {sub && (
+        <text
+          className="vfx-fade"
+          x={x}
+          y={y + 13}
+          textAnchor={anchor}
+          fontFamily="'Georgia', 'Times New Roman', serif"
+          fontStyle="italic"
+          fontSize="10"
+          fill={TINTA_2}
+        >
+          {sub}
+        </text>
+      )}
+    </g>
+  );
+}

--- a/src/visual/laminas/index.js
+++ b/src/visual/laminas/index.js
@@ -20,12 +20,22 @@ export { default as LaminaAporque } from './LaminaAporque.jsx';
 export { default as LaminaMaiz } from './LaminaMaiz.jsx';
 export { default as LaminaCafeto } from './LaminaCafeto.jsx';
 export { default as LaminaMataEtapa } from './LaminaMataEtapa.jsx';
+export { default as LaminaMilpa } from './LaminaMilpa.jsx';
+export { default as LaminaRotacion } from './LaminaRotacion.jsx';
+export { default as LaminaPisoTermico } from './LaminaPisoTermico.jsx';
+/* El adjunto de chat que monta una lámina por slug+prop (degrada a null si no
+   es fiable). Importa `resolveLaminaFiable` de este barrel; el uso es a nivel
+   de render, así que el ciclo de import es inocuo. */
+export { default as AgentLamina } from './AgentLamina.jsx';
 
 import LaminaSiembra from './LaminaSiembra.jsx';
 import LaminaAporque from './LaminaAporque.jsx';
 import LaminaMaiz from './LaminaMaiz.jsx';
 import LaminaCafeto from './LaminaCafeto.jsx';
 import LaminaMataEtapa from './LaminaMataEtapa.jsx';
+import LaminaMilpa from './LaminaMilpa.jsx';
+import LaminaRotacion from './LaminaRotacion.jsx';
+import LaminaPisoTermico from './LaminaPisoTermico.jsx';
 
 /* Registro consultable: slug → componente + nombre común + especie/mundo.
    (accesible: aria-hidden = decorativa; role=img = enseña con rótulos). */
@@ -60,4 +70,27 @@ export const LAMINAS = {
     especie: 'Solanum lycopersicum',
     accesible: 'decorativa',
   },
+  milpa: {
+    Component: LaminaMilpa,
+    nombre: 'La milpa (las tres hermanas)',
+    especie: 'Asociación: maíz + frijol + calabaza',
+    accesible: 'enseña',
+  },
+  rotacion: {
+    Component: LaminaRotacion,
+    nombre: 'La rotación por eras',
+    especie: 'Rueda: hoja → fruto → raíz → leguminosa',
+    accesible: 'enseña',
+  },
+  'piso-termico': {
+    Component: LaminaPisoTermico,
+    nombre: 'El piso térmico (en corte)',
+    especie: 'Gradiente de altura: cálido → páramo',
+    accesible: 'enseña',
+  },
 };
+
+/* Conjunto CERRADO que el agente puede ADJUNTAR (DR "el agente dibuja fiable",
+   2026-07-11) + su validador. Vive en `laminasFiables.js` (módulo hoja, sin
+   ciclo con AgentLamina); se re-exporta aquí para el import ergonómico. */
+export { LAMINAS_FIABLES, resolveLaminaFiable, esLaminaFiable } from './laminasFiables.js';

--- a/src/visual/laminas/laminas.css
+++ b/src/visual/laminas/laminas.css
@@ -31,3 +31,59 @@
 @media (prefers-reduced-motion: reduce) {
   .lam-mata-brota { animation: none; }
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+   AgentLamina — el ADJUNTO de lámina que el agente incrusta en el chat.
+   La lámina trae sus propios colores fijos (ilustración que enseña, tinta
+   sepia). El envoltorio solo pone el "papel de cuaderno" (crema) para que el
+   arte tenga contraste AA tanto en una burbuja oscura (chat) como sobre el
+   escritorio claro del mockup. Todo bajo el namespace `lam-agente-*`.
+   Responsive desde 320px; el auto-dibujado del trazo vive en effects.css.
+   ════════════════════════════════════════════════════════════════════════ */
+.lam-agente {
+  margin: 0;
+  width: 100%;
+}
+.lam-agente-tit {
+  margin: 0 0 6px;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  font-style: italic;
+  font-weight: 700;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  /* Rótulo sobre papel de cuaderno: sepia oscuro (AA sobre crema y legible
+     sobre burbuja oscura, donde el título va encima de un chip claro). */
+  color: #5c4326;
+}
+/* la hoja de papel donde nace la lámina (crema fijo → contraste con la tinta) */
+.lam-agente-hoja {
+  padding: 8px;
+  border-radius: 10px;
+  background: #f7efdd;
+  border: 1px solid rgba(92, 67, 38, 0.22);
+  overflow: hidden;
+  /* entrada suave del papel (el trazo interior lo dibuja effects.css). */
+  animation: lam-agente-entra 0.45s ease both;
+}
+.lam-agente-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  user-select: none;
+}
+@keyframes lam-agente-entra {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Cuando el rótulo va sobre burbuja OSCURA, el título del papel-crema debe
+   pintarse claro para no perderse. El chat marca el contenedor con
+   data-chat-dark; el mockup (fondo claro) no. */
+[data-chat-dark] .lam-agente-tit {
+  color: #e7dab8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* reduced-motion: la lámina aparece completa y quieta, sin entrada. */
+  .lam-agente-hoja { animation: none; }
+}

--- a/src/visual/laminas/laminasFiables.js
+++ b/src/visual/laminas/laminasFiables.js
@@ -1,0 +1,162 @@
+/*
+ * LAMINAS_FIABLES — el CONJUNTO CERRADO de láminas que el agente puede
+ * ADJUNTAR a una respuesta (DR "el agente dibuja de forma fiable", 2026-07-11).
+ *
+ * Vive en su propio módulo (no en index.js) para que `AgentLamina` pueda
+ * importar el validador sin crear un ciclo con el barrel. index.js re-exporta
+ * desde aquí para conservar el import ergonómico `@/visual/laminas`.
+ *
+ * El agente NUNCA genera SVG: SELECCIONA un `slug` de este registro y, a lo
+ * sumo, una `prop de enum cerrado` (`activo`, `etapa`). Todo lo demás es arte
+ * fijo, ya verificado a mano. Cada plantilla está LOCKED a su especie o a su
+ * proposición: `LaminaMaiz` dibuja maíz, `LaminaMilpa` dibuja la milpa
+ * (maíz+frijol+calabaza) — no se generalizan.
+ *
+ * Cada fila declara:
+ *   - `Component`  el componente de la lámina (arte local, self-contained).
+ *   - `nombre`     título humano (usted colombiano).
+ *   - `dim`        '2d' — todas las láminas de cuaderno son 2D (contrato del DR).
+ *   - `lock`       'especie' | 'proposicion' | 'parametrica'  (naturaleza del lock).
+ *   - `aplica_a`   binomio (locked-a-especie) o proposición (proposición-locked)
+ *                  o dominio (paramétrica). Lo consume el GATE DE GROUNDING del
+ *                  agente (regla #3) — NO el frontend.
+ *   - `props`      enums CERRADOS permitidos por prop de dominio. `{}` = sin prop.
+ *   - `accesible`  'decorativa' (aria-hidden) | 'enseña' (role=img con rótulos).
+ *
+ * REPARTO DE RESPONSABILIDAD (importante):
+ *   - El FRONTEND (`resolveLaminaFiable`) valida SOLO reglas #1 y #2 del gate:
+ *     slug ∈ registro  y  prop ∈ enum. Si algo no calza → devuelve null → la
+ *     lámina no se dibuja (degrada a solo texto).
+ *   - La regla #3 (la especie/proposición de la lámina coincide con una entidad
+ *     ATERRIZADA del turno) la revalida el HANDLER del agente contra
+ *     resolvedEntities/toolEvidence. Eso NO vive aquí — el arte no sabe de
+ *     grounding, solo de "este slug+prop es dibujable".
+ */
+import LaminaSiembra from './LaminaSiembra.jsx';
+import LaminaAporque from './LaminaAporque.jsx';
+import LaminaMaiz from './LaminaMaiz.jsx';
+import LaminaCafeto from './LaminaCafeto.jsx';
+import LaminaMataEtapa from './LaminaMataEtapa.jsx';
+import LaminaMilpa from './LaminaMilpa.jsx';
+import LaminaRotacion from './LaminaRotacion.jsx';
+import LaminaPisoTermico from './LaminaPisoTermico.jsx';
+
+export const LAMINAS_FIABLES = {
+  siembra: {
+    Component: LaminaSiembra,
+    nombre: 'Formas de siembra',
+    dim: '2d',
+    lock: 'parametrica',
+    aplica_a: 'propagacion-vegetativa', // tubérculos/esquejes/colinos
+    props: { activo: ['tuberculo', 'esqueje', 'colino'] },
+    accesible: 'decorativa',
+  },
+  aporque: {
+    Component: LaminaAporque,
+    nombre: 'El aporque (en corte)',
+    dim: '2d',
+    lock: 'parametrica',
+    aplica_a: 'tuberculos-y-raices',
+    props: {},
+    accesible: 'decorativa',
+  },
+  maiz: {
+    Component: LaminaMaiz,
+    nombre: 'La mata de maíz',
+    dim: '2d',
+    lock: 'especie',
+    aplica_a: 'Zea mays',
+    props: {},
+    accesible: 'enseña',
+  },
+  cafeto: {
+    Component: LaminaCafeto,
+    nombre: 'El cafeto',
+    dim: '2d',
+    lock: 'especie',
+    aplica_a: 'Coffea arabica',
+    props: {},
+    accesible: 'enseña',
+  },
+  'mata-etapa': {
+    Component: LaminaMataEtapa,
+    nombre: 'La mata por etapa (viva)',
+    dim: '2d',
+    lock: 'especie',
+    aplica_a: 'Solanum lycopersicum',
+    props: { etapa: ['semilla', 'plantula', 'juvenil', 'adulto', 'floracion', 'cosecha'] },
+    accesible: 'decorativa',
+  },
+  milpa: {
+    Component: LaminaMilpa,
+    nombre: 'La milpa (las tres hermanas)',
+    dim: '2d',
+    lock: 'proposicion',
+    aplica_a: 'milpa: Zea mays + Phaseolus vulgaris + Cucurbita',
+    props: {},
+    accesible: 'enseña',
+  },
+  rotacion: {
+    Component: LaminaRotacion,
+    nombre: 'La rotación por eras',
+    dim: '2d',
+    lock: 'proposicion',
+    aplica_a: 'rotacion: hoja → fruto → raíz → leguminosa',
+    props: {},
+    accesible: 'enseña',
+  },
+  'piso-termico': {
+    Component: LaminaPisoTermico,
+    nombre: 'El piso térmico (en corte)',
+    dim: '2d',
+    lock: 'proposicion',
+    aplica_a: 'piso-termico: gradiente cálido → páramo',
+    props: {},
+    accesible: 'enseña',
+  },
+};
+
+/**
+ * Valida (reglas #1 y #2 del gate) un `slug` + `props` contra el registro
+ * cerrado y devuelve lo dibujable, o `null` si algo no calza.
+ *
+ * Conservador a propósito: rechaza slugs desconocidos, props no declaradas
+ * para esa lámina y valores fuera del enum. Ante la duda → `null` (no dibuja).
+ * NO valida grounding (regla #3): eso lo hace el handler del agente.
+ *
+ * @param {string} slug
+ * @param {Record<string, unknown>} [props]
+ * @returns {{ slug: string, Component: import('react').ComponentType<any>,
+ *   props: Record<string, string>, meta: (typeof LAMINAS_FIABLES)[string] } | null}
+ */
+export function resolveLaminaFiable(slug, props = {}) {
+  if (typeof slug !== 'string' || !Object.prototype.hasOwnProperty.call(LAMINAS_FIABLES, slug)) {
+    return null;
+  }
+  const meta = LAMINAS_FIABLES[slug];
+  const allowed = meta.props || {};
+  const clean = /** @type {Record<string, string>} */ ({});
+
+  if (props && typeof props === 'object') {
+    for (const key of Object.keys(props)) {
+      // Prop no declarada para esta lámina → rechazo total (conservador).
+      if (!Object.prototype.hasOwnProperty.call(allowed, key)) return null;
+      const value = props[key];
+      // Valor fuera del enum cerrado → rechazo total.
+      if (typeof value !== 'string' || !allowed[key].includes(value)) return null;
+      clean[key] = value;
+    }
+  }
+
+  return { slug, Component: meta.Component, props: clean, meta };
+}
+
+/**
+ * ¿Es `slug` un miembro del conjunto cerrado de láminas fiables?
+ * @param {unknown} slug
+ * @returns {boolean}
+ */
+export function esLaminaFiable(slug) {
+  return typeof slug === 'string'
+    && Object.prototype.hasOwnProperty.call(LAMINAS_FIABLES, slug);
+}

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -82,6 +82,11 @@ const VARIANTES_LAMINA = {
     { label: 'juvenil', props: { etapa: 'juvenil' } },
     { label: 'cosecha', props: { etapa: 'cosecha' } },
   ],
+  // Promovidas del mockup ensena-dibujando (proposición-locked, sin prop de
+  // dominio): una sola vista, se dibujan solas al montar.
+  milpa: [{ label: 'las tres hermanas', props: {} }],
+  rotacion: [{ label: 'la rueda de 4 eras', props: {} }],
+  'piso-termico': [{ label: 'en corte', props: {} }],
 };
 
 /* ── Effects: los tres helpers SVG del barrel, declarados a mano ──────────── */


### PR DESCRIPTION
Parte VISUAL de 'el agente dibuja en respuestas' (DR-AGENTE-DIBUJA-FIABLE). Set LAMINAS_FIABLES + AgentLamina por slug+enum + demo #/mockups/agente-dibuja. Rescatado del fable (se detuvo antes de commitear). El tool dibujar_lamina + gate de grounding + harness de auditoria van aparte (codex/glm + review Opus).

Generated with Claude Code