### PR TITLE
feat(mundo3d): navegacion valle<->mundos (las entradas ya sirven)

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -40,6 +40,16 @@ import {
 } from './valle/valleData';
 import Valle2DFallback from './valle/Valle2DFallback';
 import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
+/* El framework de MUNDOS (three-free en el barrel; los dioramas 3D bajan
+   perezosos en `vendor-three`): tocar un lugar del valle ENTRA de verdad. */
+import Mundo, {
+  MUNDO,
+  decidirTier,
+  tinteDeMundo,
+  tituloDeMundo,
+  useNavegacionMundos,
+  TransicionMundo,
+} from '../visual/mundo3d/index.js';
 
 // La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso.
 const Valle3D = lazy(() => import('./valle/Valle3D'));
@@ -109,6 +119,10 @@ export default function EntradaValle3D({ onBack }) {
   const [render] = useState(decidirRender);
   const usa3D = render.modo === '3d';
 
+  // ── NAVEGACIÓN valle ↔ mundos: la máquina de fases vive en el framework.
+  //    (reduced-motion la vuelve corte simple, sin overlay de viaje).
+  const [puerta, setPuerta] = useState(null); // puerta tocada DENTRO de un mundo
+
   const reducedMotion = useMemo(
     () =>
       typeof window !== 'undefined' &&
@@ -116,6 +130,10 @@ export default function EntradaValle3D({ onBack }) {
       window.matchMedia('(prefers-reduced-motion: reduce)').matches,
     [],
   );
+
+  const nav = useNavegacionMundos({ reducedMotion });
+  // El tier del framework decide 3D-vs-2D DENTRO de cada mundo (una vez).
+  const tierMundo = useMemo(() => decidirTier().tier, []);
 
   // ── El compañero (Angelita): su ánimo/energía salen del estado REAL de la
   //    finca + el clima + si lo del día sigue sin atender. Cuidar la alerta la
@@ -186,38 +204,117 @@ export default function EntradaValle3D({ onBack }) {
     if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
   }, []);
 
+  // ── ENTRAR a un mundo (tarea del viaje): cierra el panel, la abeja guía la
+  //    transición y el framework monta la escena del mundo. Si el mundo aún no
+  //    tiene escena montable, `viajarAlMundo` no viaja (el panel ya degradó a
+  //    "pronto", así que aquí solo se guarda la coherencia).
+  const entrarAlMundo = useCallback(
+    (id) => {
+      if (!nav.viajarAlMundo(id)) return;
+      setPanel(null);
+      setPuerta(null);
+      hablar(`Angelita lo lleva a ${tituloDeMundo(id)}.`);
+    },
+    [nav, hablar],
+  );
+
+  // ── VOLVER del mundo al valle (misma transición, en reversa).
+  const salirDelMundo = useCallback(() => {
+    setPuerta(null);
+    nav.volverAlValle();
+    hablar('De vuelta al valle de su finca.');
+  }, [nav, hablar]);
+
+  // ── Una puerta tocada DENTRO del mundo: en la vitrina (sin sesión) no
+  //    navega — cuenta a qué pantalla real de la app lleva (regla de oro).
+  const onPuertaMundo = useCallback(
+    (view, data) => {
+      const puertas = MUNDO[nav.mundoId]?.hotspots || [];
+      const hs =
+        puertas.find((h) => h.view === view && (h.data === data || (!h.data && !data))) ||
+        puertas.find((h) => h.view === view);
+      setPuerta({ label: hs?.label || view, view });
+    },
+    [nav.mundoId],
+  );
+
   const mundoPanel = panel && panel !== 'alerta' ? MUNDO_VALLE_BY_ID[panel] : null;
 
   return (
     <div className="valle-root" data-clima={clima}>
-      {/* fondo/atmósfera 3D o su degradación 2D (según el tiering del equipo) */}
+      {/* fondo/atmósfera 3D o su degradación 2D (según el tiering del equipo).
+          Mientras se está DENTRO de un mundo, el valle descansa (se desmonta:
+          nada de dos escenas sudando la GPU a la vez en un teléfono). */}
       <div className="valle-escena">
-        {usa3D ? (
-          <Suspense fallback={<CargandoValle clima={clima} />}>
-            <Valle3D
+        {!nav.enMundo &&
+          (usa3D ? (
+            <Suspense fallback={<CargandoValle clima={clima} />}>
+              <Valle3D
+                clima={clima}
+                focoId={focoId}
+                animo={companero.animo}
+                energia={companero.energia}
+                onEntrar={entrarMundo}
+                onAlerta={abrirAlerta}
+                reducedMotion={reducedMotion}
+              />
+            </Suspense>
+          ) : (
+            <Valle2DFallback
               clima={clima}
               focoId={focoId}
               animo={companero.animo}
               energia={companero.energia}
+              reducedMotion={reducedMotion}
               onEntrar={entrarMundo}
               onAlerta={abrirAlerta}
-              reducedMotion={reducedMotion}
             />
-          </Suspense>
-        ) : (
-          <Valle2DFallback
-            clima={clima}
-            focoId={focoId}
-            animo={companero.animo}
-            energia={companero.energia}
-            reducedMotion={reducedMotion}
-            onEntrar={entrarMundo}
-            onAlerta={abrirAlerta}
-          />
-        )}
+          ))}
       </div>
 
-      {/* ── Encabezado: el nombre del lugar + el selector de clima (estado) ── */}
+      {/* ── El MUNDO abierto: el framework monta la escena (3D perezoso o su
+              2D digno) con su miga "‹ El valle" siempre visible. ── */}
+      {nav.enMundo && nav.mundoId && (
+        <section
+          className="valle-mundo"
+          data-mundo={nav.mundoId}
+          style={{ '--vm-tinte': tinteDeMundo(nav.mundoId)[0] }}
+          aria-label={`Mundo ${tituloDeMundo(nav.mundoId)}`}
+        >
+          <Mundo
+            mundoId={nav.mundoId}
+            tier={tierMundo}
+            reducedMotion={reducedMotion}
+            onHotspot={onPuertaMundo}
+            onSalir={salirDelMundo}
+            animo={companero.animo}
+            energia={companero.energia}
+          />
+          <p className="valle-mundo__puerta" role="status" aria-live="polite">
+            {puerta
+              ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+              : 'Toque un punto del mundo para ver a dónde lo lleva, o vuelva al valle cuando quiera.'}
+          </p>
+        </section>
+      )}
+
+      {/* ── El VIAJE (ida o vuelta): la abeja guía; al terminar, el intercambio
+              de escena ocurre debajo del velo. Con reduced-motion ni se monta
+              (el hook corta directo). ── */}
+      {nav.enViaje && nav.mundoId && (
+        <TransicionMundo
+          mundoId={nav.mundoId}
+          sentido={nav.fase === 'viajando' ? 'entrar' : 'volver'}
+          animo={companero.animo}
+          energia={companero.energia}
+          reducedMotion={reducedMotion}
+          onFin={nav.completarViaje}
+        />
+      )}
+
+      {/* ── Encabezado: el nombre del lugar + el selector de clima (estado).
+              Dentro de un mundo se esconde: manda la miga del mundo. ── */}
+      {!nav.enMundo && (
       <header className="valle-header">
         <button type="button" className="valle-back" onClick={() => onBack?.()} aria-label="Volver">
           ‹ Volver
@@ -240,9 +337,10 @@ export default function EntradaValle3D({ onBack }) {
           ))}
         </div>
       </header>
+      )}
 
       {/* ── Modo dibujado (tiering): aviso sobrio, nunca "error" ── */}
-      {!usa3D && (
+      {!usa3D && !nav.enMundo && (
         <p className="valle-degradado" role="status">
           {MENSAJE_DEGRADADO[render.motivo] || MENSAJE_DEGRADADO.default}
         </p>
@@ -251,7 +349,7 @@ export default function EntradaValle3D({ onBack }) {
       {/* ── El compañero: Angelita en una sola línea puntual (imagen-first).
               Es el ser al que se cuida; su cara refleja el ánimo real. Se
               esconde si hay un panel abierto — una cosa clara a la vez. ── */}
-      {!panel && (
+      {!panel && !nav.enMundo && (
         <div className="valle-companero" role="status" aria-live="polite">
           <span className="valle-companero__cara" aria-hidden="true">
             <AbejaAngelita size={34} animo={companero.animo} energia={companero.energia} animated={!reducedMotion} />
@@ -286,7 +384,17 @@ export default function EntradaValle3D({ onBack }) {
           <h2>{mundoPanel.titulo}</h2>
           <p>{mundoPanel.lema}</p>
           <div className="valle-panel__acciones">
-            <button type="button" className="valle-cta">Entrar a este mundo</button>
+            {nav.puedeEntrar(mundoPanel.id) ? (
+              <button type="button" className="valle-cta" onClick={() => entrarAlMundo(mundoPanel.id)}>
+                Entrar a este mundo
+              </button>
+            ) : (
+              /* Degradación elegante: este mundo aún no tiene escena montable
+                 (p. ej. el clima, que YA es el cielo del valle). */
+              <p className="valle-panel__pronto" role="status">
+                Este mundo abre pronto su propia puerta. Por ahora se vive desde el valle.
+              </p>
+            )}
             <button type="button" className="valle-ghost" onClick={() => hablar(NARRACION[mundoPanel.id] || mundoPanel.lema)}>
               🔊 Escuchar
             </button>
@@ -294,7 +402,10 @@ export default function EntradaValle3D({ onBack }) {
         </aside>
       )}
 
-      {/* ── Barra del AGENTE: el compañero presente + voz + volver al valle ── */}
+      {/* ── Barra del AGENTE: el compañero presente + voz + volver al valle.
+              Dentro de un mundo se esconde (la miga del mundo ya trae el
+              volver; una cosa clara a la vez). ── */}
+      {!nav.enMundo && (
       <footer className="valle-agente">
         <button type="button" className="valle-agente__pregunte" aria-label="Pregúntele a Chagra">
           <span className="valle-agente__punto" aria-hidden="true" />
@@ -320,6 +431,7 @@ export default function EntradaValle3D({ onBack }) {
           </button>
         </div>
       </footer>
+      )}
     </div>
   );
 }

--- a/src/mockups/__tests__/entradaValle3D.nav.test.jsx
+++ b/src/mockups/__tests__/entradaValle3D.nav.test.jsx
@@ -1,0 +1,84 @@
+/*
+ * Entrada #/mockups/entrada-3d — NAVEGACIÓN valle ↔ mundos, punta a punta.
+ *
+ * En jsdom no hay WebGL: el valle monta su 2D digno (Valle2DFallback) y los
+ * mundos caen a su gemelo 2D (three-free) — exactamente el camino de un equipo
+ * humilde. Se congela el ciclo entero:
+ *   · tocar un lugar del valle → panel del mundo → "Entrar a este mundo";
+ *   · el viaje (Angelita guía) → la escena del mundo con su miga "‹ El valle";
+ *   · una puerta DENTRO del mundo cuenta a qué pantalla real lleva;
+ *   · "Volver al valle" → viaje en reversa → el valle otra vez;
+ *   · un mundo sin escena montable (clima) degrada elegante a "pronto".
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach, vi } from 'vitest';
+
+import EntradaValle3D from '../EntradaValle3D.jsx';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+/* El viaje dura ~1.05s; con timers falsos lo cumplimos determinista. */
+const cumplirViaje = () => act(() => vi.advanceTimersByTime(1200));
+
+describe('entrada-3d — navegable de punta a punta (valle ↔ mundos)', () => {
+  test('entra al mundo del agua, toca una puerta y vuelve al valle', () => {
+    vi.useFakeTimers();
+    const { container } = render(<EntradaValle3D onBack={() => {}} />);
+
+    // 1) EL VALLE: tocar un lugar abre su panel con la puerta de entrada.
+    fireEvent.click(screen.getByRole('button', { name: /Viajar al mundo El agua/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Entrar a este mundo' }));
+
+    // 2) EL VIAJE: Angelita guía; el valle sigue debajo del velo.
+    expect(screen.getByText('Angelita lo lleva a El agua…')).toBeInTheDocument();
+    cumplirViaje();
+
+    // 3) DENTRO DEL MUNDO: la escena del framework (gemelo 2D en jsdom) con
+    //    su miga consistente: volver + dónde-estoy.
+    expect(container.querySelector('.valle-mundo[data-mundo="agua"]')).toBeInTheDocument();
+    expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: 'Usted está aquí' })).toHaveTextContent('El agua');
+    // el chrome del valle descansa mientras se está dentro
+    expect(screen.queryByRole('heading', { level: 1, name: 'El valle de mi finca' })).not.toBeInTheDocument();
+
+    // 4) UNA PUERTA del mundo: en la vitrina cuenta a qué pantalla real lleva.
+    fireEvent.click(screen.getByRole('button', { name: 'La quebrada viva' }));
+    expect(container.querySelector('.valle-mundo__puerta')).toHaveTextContent('«biodiversidad»');
+
+    // 5) VOLVER: viaje en reversa → el valle completo otra vez.
+    fireEvent.click(screen.getByRole('button', { name: 'Volver al valle' }));
+    expect(screen.getByText('De vuelta al valle…')).toBeInTheDocument();
+    cumplirViaje();
+    expect(container.querySelector('.valle-mundo')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Viajar al mundo El agua/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'El valle de mi finca' })).toBeInTheDocument();
+  });
+
+  test('un segundo mundo (el suelo vivo) también se entra y se vuelve', () => {
+    vi.useFakeTimers();
+    const { container } = render(<EntradaValle3D onBack={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Viajar al mundo El suelo vivo/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Entrar a este mundo' }));
+    cumplirViaje();
+    expect(container.querySelector('.valle-mundo[data-mundo="suelo"]')).toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: 'Usted está aquí' })).toHaveTextContent('El suelo vivo');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Volver al valle' }));
+    cumplirViaje();
+    expect(container.querySelector('.valle-mundo')).not.toBeInTheDocument();
+  });
+
+  test('mundo sin escena montable (el clima) degrada elegante a "pronto"', () => {
+    render(<EntradaValle3D onBack={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /Viajar al mundo El clima/ }));
+    // sin puerta de entrada: aviso sobrio, nunca un botón muerto
+    expect(screen.queryByRole('button', { name: 'Entrar a este mundo' })).not.toBeInTheDocument();
+    expect(screen.getByText(/abre pronto su propia puerta/)).toBeInTheDocument();
+  });
+});

--- a/src/mockups/entradaValle3D.css
+++ b/src/mockups/entradaValle3D.css
@@ -512,3 +512,44 @@
   .valle-header { flex-wrap: wrap; }
   .valle-titulo h1 { font-size: 1.3rem; }
 }
+
+/* ── NAVEGACIÓN valle ↔ mundos: un MUNDO abierto dentro de la entrada ──────
+ * El framework (`src/visual/mundo3d`) pinta la escena y su miga "‹ El valle";
+ * aquí solo vive el marco del host: fondo legible para los arquetipos 2D,
+ * scroll propio en 320px y la nota de la puerta tocada. */
+.valle-mundo {
+  position: absolute;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  background: color-mix(in srgb, var(--vm-tinte, #3f8f4e) 14%, #f2e8d6);
+  color: #2a2016;
+}
+.valle-mundo .mundo-root {
+  flex: 1 1 auto;
+  min-height: min(72vh, 520px);
+  border-radius: 0;
+}
+.valle-mundo__puerta {
+  margin: 0;
+  padding: 0.7rem 1rem calc(0.7rem + env(safe-area-inset-bottom, 0px));
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: #4a3a22;
+  background: rgba(255, 251, 242, 0.92);
+  border-top: 1px solid rgba(60, 46, 24, 0.15);
+}
+
+/* La degradación elegante del panel: mundo sin escena montable aún. */
+.valle-panel__pronto {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 0.7rem 0.9rem;
+  border-radius: 0.9rem;
+  border: 1px dashed rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.92rem;
+  line-height: 1.35;
+}

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -14,7 +14,7 @@
  * mundo = una entrada en `mundoData.js`, sin tocar este archivo.
  */
 import { lazy, Suspense } from 'react';
-import { resolverMundo, tinteDeMundo } from './resolverMundo.js';
+import { resolverMundo, tinteDeMundo, tituloDeMundo, emojiDeMundo } from './resolverMundo.js';
 import Mundo2D from './Mundo2D.jsx';
 import './mundo.css';
 
@@ -37,12 +37,19 @@ function MundoCargando({ tinte }) {
   );
 }
 
-function SalirBtn({ onSalir }) {
+/* La MIGA: dónde-estoy + volver al valle, SIEMPRE visible y consistente en
+   todo mundo (el host solo pasa `onSalir`; el framework pinta lo mismo). */
+function MigaVolver({ onSalir, mundoId }) {
   if (!onSalir) return null;
   return (
-    <button type="button" className="mundo-salir" onClick={() => onSalir()} aria-label="Volver al valle">
-      ‹ Volver
-    </button>
+    <nav className="mundo-miga" aria-label="Usted está aquí">
+      <button type="button" className="mundo-salir" onClick={() => onSalir()} aria-label="Volver al valle">
+        ‹ El valle
+      </button>
+      <span className="mundo-miga__aqui">
+        <span aria-hidden="true">{emojiDeMundo(mundoId)}</span> {tituloDeMundo(mundoId)}
+      </span>
+    </nav>
   );
 }
 
@@ -73,7 +80,7 @@ export default function Mundo({
             energia={energia}
           />
         </Suspense>
-        <SalirBtn onSalir={onSalir} />
+        <MigaVolver onSalir={onSalir} mundoId={mundoId} />
       </div>
     );
   }
@@ -91,7 +98,7 @@ export default function Mundo({
         animo={animo}
         energia={energia}
       />
-      <SalirBtn onSalir={onSalir} />
+      <MigaVolver onSalir={onSalir} mundoId={mundoId} />
     </div>
   );
 }

--- a/src/visual/mundo3d/TransicionMundo.jsx
+++ b/src/visual/mundo3d/TransicionMundo.jsx
@@ -1,0 +1,73 @@
+/*
+ * TransicionMundo — el VIAJE entre el valle y un mundo, guiado por Angelita.
+ *
+ * Overlay DOM puro (CERO three): un velo con la luz del mundo destino que se
+ * cierra con profundidad mientras la abeja vuela hacia adentro (entrar) o de
+ * regreso hacia usted (volver). Por ser DOM funciona IGUAL sobre el valle 3D,
+ * el valle 2D o cualquier arquetipo — y no toca el chunk `vendor-three`.
+ *
+ * El tiempo lo maneja un timer (no `animationend`): determinista, testeable y
+ * a prueba de pestañas en segundo plano. Al cumplirse llama `onFin` UNA vez —
+ * ahí el host (via `useNavegacionMundos.completarViaje`) hace el intercambio
+ * de escena DEBAJO del velo.
+ *
+ * `prefers-reduced-motion`: no dibuja nada y llama `onFin` de inmediato
+ * (corte simple). Normalmente ni se monta: el hook ya salta las fases.
+ */
+import { useEffect, useRef } from 'react';
+import { AbejaAngelita } from '../creatures/AbejaAngelita.jsx';
+import { tinteDeMundo, tituloDeMundo } from './resolverMundo.js';
+import './mundo.css';
+
+/** Duración del viaje (ms) — igual a las keyframes de `mundo.css`. */
+export const VIAJE_MS = 1050;
+
+export default function TransicionMundo({
+  mundoId,
+  sentido = 'entrar', // 'entrar' (valle → mundo) | 'volver' (mundo → valle)
+  animo = 'sereno',
+  energia = 1,
+  reducedMotion = false,
+  onFin,
+}) {
+  const finRef = useRef(onFin);
+  finRef.current = onFin;
+
+  useEffect(() => {
+    let hecho = false;
+    const t = setTimeout(
+      () => {
+        if (!hecho) {
+          hecho = true;
+          finRef.current?.();
+        }
+      },
+      reducedMotion ? 0 : VIAJE_MS,
+    );
+    return () => {
+      hecho = true;
+      clearTimeout(t);
+    };
+  }, [mundoId, sentido, reducedMotion]);
+
+  if (reducedMotion) return null;
+
+  const tinte = tinteDeMundo(mundoId);
+  const entra = sentido === 'entrar';
+  return (
+    <div
+      className={`mundo-viaje mundo-viaje--${entra ? 'entrar' : 'volver'}`}
+      style={{ '--mv-a': tinte[0], '--mv-b': tinte[1] }}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="mundo-viaje__velo" aria-hidden="true" />
+      <div className="mundo-viaje__abeja" aria-hidden="true">
+        <AbejaAngelita size={72} animo={animo} energia={energia} animated />
+      </div>
+      <p className="mundo-viaje__txt">
+        {entra ? `Angelita lo lleva a ${tituloDeMundo(mundoId)}…` : 'De vuelta al valle…'}
+      </p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/__tests__/navegacion.test.jsx
+++ b/src/visual/mundo3d/__tests__/navegacion.test.jsx
@@ -1,0 +1,112 @@
+/*
+ * Navegación valle ↔ mundos — la máquina de fases + el viaje (three-free).
+ *
+ * Congela el contrato del framework:
+ *   · el ciclo completo: valle → viajando → mundo → regresando → valle;
+ *   · reduced-motion = corte simple (sin fases de viaje, sin overlay);
+ *   · un mundo sin escena montable (clima, escena:null) NO viaja → `pronto`;
+ *   · TransicionMundo llama `onFin` UNA vez al cumplirse el viaje.
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach, vi } from 'vitest';
+
+import { useNavegacionMundos } from '../useNavegacionMundos.js';
+import TransicionMundo, { VIAJE_MS } from '../TransicionMundo.jsx';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+/* Sonda mínima: expone la máquina del hook como DOM para poder conducirla. */
+function Sonda({ reducedMotion = false }) {
+  const nav = useNavegacionMundos({ reducedMotion });
+  return (
+    <div>
+      <output data-testid="fase">{nav.fase}</output>
+      <output data-testid="mundo">{nav.mundoId || '-'}</output>
+      <output data-testid="pronto">{nav.pronto || '-'}</output>
+      <button type="button" onClick={() => nav.viajarAlMundo('agua')}>ir-agua</button>
+      <button type="button" onClick={() => nav.viajarAlMundo('clima')}>ir-clima</button>
+      <button type="button" onClick={() => nav.volverAlValle()}>volver</button>
+      <button type="button" onClick={() => nav.completarViaje()}>completar</button>
+    </div>
+  );
+}
+
+const fase = () => screen.getByTestId('fase').textContent;
+
+describe('useNavegacionMundos — la máquina valle ↔ mundo', () => {
+  test('ciclo completo: valle → viajando → mundo → regresando → valle', () => {
+    render(<Sonda />);
+    expect(fase()).toBe('valle');
+
+    fireEvent.click(screen.getByText('ir-agua'));
+    expect(fase()).toBe('viajando');
+    expect(screen.getByTestId('mundo')).toHaveTextContent('agua');
+
+    fireEvent.click(screen.getByText('completar'));
+    expect(fase()).toBe('mundo');
+
+    fireEvent.click(screen.getByText('volver'));
+    expect(fase()).toBe('regresando');
+    // saliendo, el mundo SIGUE montado debajo del velo
+    expect(screen.getByTestId('mundo')).toHaveTextContent('agua');
+
+    fireEvent.click(screen.getByText('completar'));
+    expect(fase()).toBe('valle');
+    expect(screen.getByTestId('mundo')).toHaveTextContent('-');
+  });
+
+  test('reduced-motion = corte simple: sin fases de viaje', () => {
+    render(<Sonda reducedMotion />);
+    fireEvent.click(screen.getByText('ir-agua'));
+    expect(fase()).toBe('mundo'); // directo, sin 'viajando'
+    fireEvent.click(screen.getByText('volver'));
+    expect(fase()).toBe('valle'); // directo, sin 'regresando'
+  });
+
+  test('mundo sin escena montable (clima) degrada: no viaja y marca `pronto`', () => {
+    render(<Sonda />);
+    fireEvent.click(screen.getByText('ir-clima'));
+    expect(fase()).toBe('valle'); // no viajó
+    expect(screen.getByTestId('pronto')).toHaveTextContent('clima');
+  });
+
+  test('volverAlValle en el valle es inofensivo (no cambia de fase)', () => {
+    render(<Sonda />);
+    fireEvent.click(screen.getByText('volver'));
+    expect(fase()).toBe('valle');
+  });
+});
+
+describe('TransicionMundo — el viaje guiado por Angelita', () => {
+  test('anuncia el destino y llama onFin UNA vez al cumplirse el viaje', () => {
+    vi.useFakeTimers();
+    const onFin = vi.fn();
+    render(<TransicionMundo mundoId="agua" sentido="entrar" onFin={onFin} />);
+    expect(screen.getByRole('status')).toHaveTextContent('Angelita lo lleva a El agua…');
+    expect(onFin).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(VIAJE_MS + 50));
+    expect(onFin).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(VIAJE_MS * 2));
+    expect(onFin).toHaveBeenCalledTimes(1);
+  });
+
+  test('de vuelta anuncia el valle; con reduced-motion no dibuja y corta ya', () => {
+    vi.useFakeTimers();
+    render(<TransicionMundo mundoId="suelo" sentido="volver" onFin={() => {}} />);
+    expect(screen.getByRole('status')).toHaveTextContent('De vuelta al valle…');
+    cleanup();
+
+    const onFin = vi.fn();
+    const { container } = render(
+      <TransicionMundo mundoId="suelo" sentido="entrar" reducedMotion onFin={onFin} />,
+    );
+    expect(container).toBeEmptyDOMElement(); // corte simple: nada que animar
+    act(() => vi.advanceTimersByTime(1));
+    expect(onFin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/visual/mundo3d/index.js
+++ b/src/visual/mundo3d/index.js
@@ -26,5 +26,9 @@ export { MUNDO, MUNDO_IDS } from './mundoData.js';
 export {
   ARQUETIPOS, ARQUETIPOS_KEYS, ARQUETIPOS_3D, ARQUETIPOS_2D, esArquetipo3D,
 } from './arquetipos.js';
-export { resolverMundo, tinteDeMundo, tituloDeMundo } from './resolverMundo.js';
+export { resolverMundo, tinteDeMundo, tituloDeMundo, emojiDeMundo } from './resolverMundo.js';
 export { decidirTier, permite3D } from './deviceTier.js';
+
+// Navegación valle ↔ mundos (three-free): la máquina de fases + el viaje DOM.
+export { useNavegacionMundos, puedeEntrarAlMundo } from './useNavegacionMundos.js';
+export { default as TransicionMundo, VIAJE_MS } from './TransicionMundo.jsx';

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -95,12 +95,35 @@
   50% { transform: scale(1); opacity: 1; }
 }
 
-/* ── Botón salir ───────────────────────────────────────────────────────── */
-.mundo-salir {
+/* ── La miga: volver al valle + dónde-estoy (consistente en todo mundo) ── */
+.mundo-miga {
   position: absolute;
   top: 12px;
   left: 12px;
+  right: 12px;
   z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  pointer-events: none;
+}
+.mundo-miga > * {
+  pointer-events: auto;
+}
+.mundo-miga__aqui {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0.4em 0.9em;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #fffdf7;
+  background: rgba(42, 32, 22, 0.72);
+  border-radius: 999px;
+}
+.mundo-salir {
+  flex: none;
   padding: 0.4em 0.9em;
   font: inherit;
   font-weight: 600;
@@ -223,9 +246,74 @@
 .mundo2d__lamina-stage { width: 100%; max-width: 420px; margin: 0 auto; }
 .mundo2d__vacio { text-align: center; opacity: 0.7; }
 
+/* ── El viaje valle ↔ mundo (overlay DOM: la abeja guía; cero three) ────── */
+.mundo-viaje {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  overflow: hidden;
+}
+.mundo-viaje__velo {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at 50% 60%,
+    var(--mv-b, #dcedc9) 0%,
+    var(--mv-a, #3f8f4e) 62%,
+    color-mix(in srgb, var(--mv-a, #3f8f4e) 70%, #0a141d) 100%
+  );
+}
+.mundo-viaje--entrar .mundo-viaje__velo { animation: mundo-velo-entra 1.05s ease-in-out both; }
+.mundo-viaje--volver .mundo-viaje__velo { animation: mundo-velo-vuelve 1.05s ease-in-out both; }
+.mundo-viaje__abeja {
+  position: relative;
+  z-index: 1;
+  filter: drop-shadow(0 6px 14px rgba(20, 30, 15, 0.4));
+}
+.mundo-viaje--entrar .mundo-viaje__abeja { animation: mundo-abeja-entra 1.05s ease-in both; }
+.mundo-viaje--volver .mundo-viaje__abeja { animation: mundo-abeja-vuelve 1.05s ease-out both; }
+.mundo-viaje__txt {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: 0 1rem;
+  font-weight: 700;
+  text-align: center;
+  color: #fff;
+  text-shadow: 0 1px 8px rgba(10, 20, 10, 0.5);
+}
+/* Profundidad sin post-proceso: el velo escala (acercarse/alejarse) y la abeja
+   viaja del frente hacia el fondo (entrar) o del fondo hacia usted (volver). */
+@keyframes mundo-velo-entra {
+  from { opacity: 0; transform: scale(1.3); }
+  35% { opacity: 1; }
+  to { opacity: 1; transform: scale(1); }
+}
+@keyframes mundo-velo-vuelve {
+  from { opacity: 0; transform: scale(1); }
+  35% { opacity: 1; }
+  to { opacity: 1; transform: scale(1.22); }
+}
+@keyframes mundo-abeja-entra {
+  from { transform: translateY(42vh) scale(1.9); opacity: 0; }
+  30% { opacity: 1; }
+  to { transform: translateY(-1vh) scale(0.55); opacity: 0.95; }
+}
+@keyframes mundo-abeja-vuelve {
+  from { transform: translateY(-1vh) scale(0.55); opacity: 0.6; }
+  to { transform: translateY(5vh) scale(1.7); opacity: 1; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mundo-canvas { transition: none; }
   .mundo-cargando__pulso { animation: none; }
   .mundo-hotspot,
   .mundo2d__hotspot { transition: none; }
+  .mundo-viaje__velo,
+  .mundo-viaje__abeja { animation: none; }
 }

--- a/src/visual/mundo3d/resolverMundo.js
+++ b/src/visual/mundo3d/resolverMundo.js
@@ -44,3 +44,6 @@ export const tinteDeMundo = (id) => MUNDO_BY_ID[id]?.tinte || ['#3f8f4e', '#dced
 
 /** Título del mundo, resuelto del manifiesto real. */
 export const tituloDeMundo = (id) => MUNDO_BY_ID[id]?.titulo || id;
+
+/** Emoji del mundo, resuelto del manifiesto real. */
+export const emojiDeMundo = (id) => MUNDO_BY_ID[id]?.emoji || '🌱';

--- a/src/visual/mundo3d/useNavegacionMundos.js
+++ b/src/visual/mundo3d/useNavegacionMundos.js
@@ -1,0 +1,100 @@
+/*
+ * useNavegacionMundos — LA MÁQUINA DE NAVEGACIÓN valle ↔ mundos (three-free).
+ *
+ * El framework de mundos monta CUALQUIER mundo (`<Mundo>`), pero el VIAJE entre
+ * el valle y un mundo — entrar, transicionar, volver — vive aquí, UNA sola vez,
+ * para que todo host (el mockup de la entrada, la app real) navegue igual.
+ *
+ * Cuatro fases, un ciclo:
+ *
+ *   'valle' ──viajarAlMundo(id)──▶ 'viajando' ──completarViaje()──▶ 'mundo'
+ *      ▲                                                               │
+ *      └──completarViaje()── 'regresando' ◀──────volverAlValle()───────┘
+ *
+ * - `viajarAlMundo(id)` valida contra el REGISTRO (`resolverMundo`): si el mundo
+ *   aún no tiene escena montable (no registrado, o `escena:null` → ruta 2D real),
+ *   NO viaja: marca `pronto` para que el host degrade elegante ("pronto") y
+ *   devuelve `false`.
+ * - Con `reducedMotion` las fases de viaje se SALTAN (corte simple, sin animar):
+ *   valle → mundo y mundo → valle directos, sin overlay.
+ * - `completarViaje()` lo llama la transición (TransicionMundo) al terminar.
+ *
+ * Sin three, sin DOM: puro estado. Seguro en el bundle base.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { resolverMundo } from './resolverMundo.js';
+
+/** ¿Este mundo tiene una escena montable (3D o 2D) en el registro? */
+export function puedeEntrarAlMundo(mundoId) {
+  const plan = resolverMundo(mundoId, 'alto');
+  return plan.modo === '3d' || plan.modo === '2d';
+}
+
+/**
+ * @param {object} [opts]
+ * @param {boolean} [opts.reducedMotion=false]  corte simple: sin fases de viaje.
+ * @returns {{
+ *   fase: 'valle'|'viajando'|'mundo'|'regresando',
+ *   mundoId: string|null,
+ *   enViaje: boolean, enMundo: boolean,
+ *   pronto: string|null,
+ *   viajarAlMundo: (id: string) => boolean,
+ *   volverAlValle: () => void,
+ *   completarViaje: () => void,
+ *   puedeEntrar: (id: string) => boolean,
+ * }}
+ */
+export function useNavegacionMundos({ reducedMotion = false } = {}) {
+  const [estado, setEstado] = useState({ fase: 'valle', mundoId: null });
+  // El mundo que aún no abre su puerta (para el aviso "pronto" del host).
+  const [pronto, setPronto] = useState(null);
+  const prontoTimer = useRef(null);
+
+  useEffect(() => () => clearTimeout(prontoTimer.current), []);
+
+  const viajarAlMundo = useCallback(
+    (mundoId) => {
+      if (!puedeEntrarAlMundo(mundoId)) {
+        setPronto(mundoId);
+        clearTimeout(prontoTimer.current);
+        prontoTimer.current = setTimeout(() => setPronto(null), 3200);
+        return false;
+      }
+      setPronto(null);
+      setEstado(reducedMotion ? { fase: 'mundo', mundoId } : { fase: 'viajando', mundoId });
+      return true;
+    },
+    [reducedMotion],
+  );
+
+  const volverAlValle = useCallback(() => {
+    setEstado((e) => {
+      if (!e.mundoId) return e;
+      return reducedMotion
+        ? { fase: 'valle', mundoId: null }
+        : { fase: 'regresando', mundoId: e.mundoId };
+    });
+  }, [reducedMotion]);
+
+  const completarViaje = useCallback(() => {
+    setEstado((e) => {
+      if (e.fase === 'viajando') return { fase: 'mundo', mundoId: e.mundoId };
+      if (e.fase === 'regresando') return { fase: 'valle', mundoId: null };
+      return e;
+    });
+  }, []);
+
+  return {
+    fase: estado.fase,
+    mundoId: estado.mundoId,
+    /** Hay overlay de viaje en pantalla (ida o vuelta). */
+    enViaje: estado.fase === 'viajando' || estado.fase === 'regresando',
+    /** El mundo está (o sigue) montado: dentro, o saliendo bajo el velo. */
+    enMundo: estado.fase === 'mundo' || estado.fase === 'regresando',
+    pronto,
+    viajarAlMundo,
+    volverAlValle,
+    completarViaje,
+    puedeEntrar: puedeEntrarAlMundo,
+  };
+}


### PR DESCRIPTION
Cablea el valle con los mundos: tap 'Entrar a este mundo' -> maquina de estados valle->viajando->mundo->regresando (useNavegacionMundos) + transicion guiada por la abeja + breadcrump de vuelta. No toca Valle3D/valleData. 17/17 tests, build verde. Sobre el framework de dev (1bc57f63).

Generated with Claude Code