### PR TITLE
feat(mundo3d): mundo 3D del suelo (cutaway) + vitrina #/mockups/mundo3d-suelo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,6 +82,7 @@ const EntradaValle3DMockup = lazy(() => import('./mockups/EntradaValle3D'));
 // 3D: "El mundo del agua" — monta <Mundo mundoId="agua"> del framework
 // (src/visual/mundo3d) con device-tiering real. El 3D va perezoso (vendor-three).
 const Mundo3DAguaMockup = lazy(() => import('./mockups/Mundo3DAgua'));
+const Mundo3DSueloMockup = lazy(() => import('./mockups/Mundo3DSuelo'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -465,6 +466,7 @@ const MOCKUP_HASH_ROUTES = {
   // Galería aspiracional (3D + voz + superficies definitivas + piezas de diseño).
   'mockups/entrada-3d': 'mockup_entrada_3d',
   'mockups/mundo3d-agua': 'mockup_mundo3d_agua',
+  'mockups/mundo3d-suelo': 'mockup_mundo3d_suelo',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
   'mockups/ensena-dibujando': 'mockup_ensena_dibujando',
@@ -1324,6 +1326,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del agua">
               <Mundo3DAguaMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_suelo':
+        // Vitrina pública del MUNDO DEL SUELO: monta <Mundo mundoId="suelo"> del
+        // framework (src/visual/mundo3d) con device-tiering real. Ruta
+        // #/mockups/mundo3d-suelo, sin auth. El corte del suelo vivo de la finca:
+        // hojarasca → suelo negro → subsuelo, con raíces, micorrizas y bichos.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del suelo">
+              <Mundo3DSueloMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mundo3DSuelo.css
+++ b/src/mockups/Mundo3DSuelo.css
@@ -1,0 +1,151 @@
+/*
+ * Mundo3DSuelo.css — vitrina pública del mundo del suelo (#/mockups/mundo3d-suelo).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Solo opacity/transform animables; reduced-motion las apaga.
+ */
+
+.m3ds {
+  --m3ds-a: #8a5a38;
+  --m3ds-b: #f0e2c8;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3ds-b) 0%, #f4ecdb 44%, #ead9bd 100%);
+  color: #33261a;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3ds__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3ds__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3ds-a);
+}
+.m3ds__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #4a3116;
+}
+.m3ds__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3ds__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3ds__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(138, 90, 56, 0.28);
+  box-shadow: 0 10px 28px rgba(58, 38, 20, 0.14);
+}
+.m3ds__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fdf7ec;
+}
+
+.m3ds__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3ds__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3ds__toggle {
+  border: 1.5px solid var(--m3ds-a);
+  background: #fff;
+  color: var(--m3ds-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3ds__toggle:hover,
+.m3ds__toggle:focus-visible {
+  background: var(--m3ds-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3ds__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.78);
+  border-left: 3px solid var(--m3ds-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3ds__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3ds__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #4a3116;
+}
+.m3ds__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3ds__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3ds__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid rgba(138, 90, 56, 0.18);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3ds__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3ds__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #4a3116;
+}
+.m3ds__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3ds__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #3f2f1c;
+}

--- a/src/mockups/Mundo3DSuelo.jsx
+++ b/src/mockups/Mundo3DSuelo.jsx
@@ -1,0 +1,131 @@
+/*
+ * Mundo3DSuelo — vitrina pública del MUNDO DEL SUELO (ruta #/mockups/mundo3d-suelo).
+ *
+ * El corte de tierra donde la vida invisible del subsuelo se hace visible: las
+ * tres capas reales (hojarasca → suelo negro → subsuelo) y, entre ellas, las
+ * raíces que bajan, el "internet de hongos" (micorrizas) y las criaturas que
+ * cuentan que la tierra está viva — la lombriz que asoma, el escarabajo que
+ * trabaja la hojarasca. Entre más vivo el suelo, más vida se ve. Didáctico y
+ * esperanzador — menos colapso, finca viva.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="suelo">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento" activado) se ve el gemelo 2D digno; en
+ * gama media/alta, el diorama 3D low-poly (chunk perezoso `vendor-three`) con
+ * la abeja Angelita entrando al mundo. Los puntos del corte son las mismas
+ * puertas del registro: aquí (vitrina sin sesión) muestran a qué pantalla real
+ * de la app llevan, en vez de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import './Mundo3DSuelo.css';
+
+const TINTE = ['#8a5a38', '#f0e2c8'];
+
+/* El corte, capa por capa y vida por vida — la misma verdad del registro
+   (mundoData.js), contada en una leyenda didáctica y verificada. */
+const LEYENDA = [
+  { emoji: '🍂', titulo: 'La hojarasca', texto: 'Las hojas y el rastrojo que caen y se pudren arriba: la cobija que abriga la tierra y le devuelve el alimento.' },
+  { emoji: '🌑', titulo: 'El suelo negro', texto: 'La capa de materia orgánica, oscura y esponjosa: ahí vive casi toda la vida y ahí guarda la tierra su fuerza.' },
+  { emoji: '⛰️', titulo: 'El subsuelo', texto: 'La reserva de abajo, más clara y firme: hasta allá bajan las raíces profundas a buscar agua y minerales.' },
+  { emoji: '🪱', titulo: 'Las lombrices', texto: 'Cuando hay lombrices, la tierra está viva: airean, mezclan y dejan un abono fino. Son el mejor termómetro de un suelo sano.' },
+  { emoji: '🕸️', titulo: 'El internet de hongos', texto: 'Las micorrizas son hilos de hongo que se enlazan con las raíces y les llevan agua y minerales de lejos. Una red que no se ve, pero sostiene.' },
+];
+
+export default function Mundo3DSuelo() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // En la vitrina (sin sesión) un punto del corte no navega: cuenta a qué
+  // pantalla real de la app lleva esa puerta.
+  const [puerta, setPuerta] = useState(null);
+  const onHotspot = (view, data) => {
+    const hs = (MUNDO.suelo.hotspots || []).find(
+      (h) => h.view === view && (h.data === data || (!h.data && !data)),
+    ) || (MUNDO.suelo.hotspots || []).find((h) => h.view === view);
+    setPuerta({ label: hs?.label || view, view });
+  };
+
+  return (
+    <main
+      className="m3ds"
+      style={{ '--m3ds-a': TINTE[0], '--m3ds-b': TINTE[1] }}
+    >
+      <header className="m3ds__head">
+        <p className="m3ds__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo del suelo</h1>
+        <p className="m3ds__lema">
+          Asómese al corte de la tierra: las capas, las raíces y la vida que no
+          se ve. Entre más vivo el suelo, más lombrices, más raíces, más hongos.
+          Menos colapso, finca viva.
+        </p>
+      </header>
+
+      <section className="m3ds__escena" aria-label="El corte del suelo vivo de la finca">
+        <Mundo
+          mundoId="suelo"
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          onSalir={null}
+          animo="sereno"
+          energia={0.85}
+        />
+        <div className="m3ds__barra">
+          <p className="m3ds__tier">
+            {tier === 'bajo'
+              ? 'Está viendo el dibujo del corte (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3ds__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver el dibujo 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3ds__nota" role="status" aria-live="polite">
+          {puerta
+            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+            : 'Toque un punto del corte para ver a dónde lo lleva.'}
+        </p>
+      </section>
+
+      <section className="m3ds__leyenda" aria-label="El suelo, capa por capa">
+        <h2>El suelo, capa por capa</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3ds__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3ds__cierre">
+          Un suelo vivo no se compra: se cría. Devuélvale la hojarasca, no lo
+          deje desnudo y déjelo descansar — la vida vuelve sola. Empiece por
+          mirar su tierra: color, olor y tacto ya le cuentan cómo está.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/__tests__/mundo3dSuelo.smoke.test.jsx
+++ b/src/mockups/__tests__/mundo3dSuelo.smoke.test.jsx
@@ -1,0 +1,38 @@
+/*
+ * Vitrina #/mockups/mundo3d-suelo — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y la vitrina
+ * monta el GEMELO 2D del corte (three-free): exactamente el camino del
+ * device-tiering real en gama baja. Se congela que:
+ *   · la página renderiza título + leyenda sin tocar three;
+ *   · el gemelo trae los 3 puntos del corte como botones;
+ *   · tocar una puerta cuenta a qué pantalla real de la app lleva (sin sesión
+ *     la vitrina NO navega).
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import Mundo3DSuelo from '../Mundo3DSuelo.jsx';
+
+afterEach(() => cleanup());
+
+describe('vitrina del mundo del suelo (mockups/mundo3d-suelo)', () => {
+  test('renderiza el mundo en 2D digno con su leyenda didáctica', () => {
+    const { container } = render(<Mundo3DSuelo />);
+    expect(screen.getByRole('heading', { level: 1, name: 'El mundo del suelo' })).toBeInTheDocument();
+    // jsdom no tiene WebGL → gemelo 2D (three-free), nunca pantalla rota
+    expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('.mundo2d__hotspot').length).toBe(3);
+    // la leyenda enseña el corte capa por capa (esperanzadora, no alarmista)
+    expect(screen.getByText('El suelo, capa por capa')).toBeInTheDocument();
+    expect(screen.getByText('Las lombrices', { selector: 'b' })).toBeInTheDocument();
+  });
+
+  test('tocar una puerta del corte cuenta a qué pantalla real lleva', () => {
+    render(<Mundo3DSuelo />);
+    fireEvent.click(screen.getByRole('button', { name: 'Despierte su suelo' }));
+    expect(screen.getByRole('status')).toHaveTextContent('«subsuelo»');
+  });
+});

--- a/src/visual/mundo3d/escenas/EscenaCutaway.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCutaway.jsx
@@ -3,18 +3,30 @@
  *
  * El prototipo del DR (§5): "lo invisible hecho visible". Un bloque de tierra
  * cortado en capas horizontales (hojarasca / suelo negro / subsuelo); sobre y
- * entre ellas, VIDA low-poly — lombrices, raíces que descienden, "internet de
- * hongos" (hifas). La CANTIDAD de vida = `params.vida` (0..1), que en producción
- * lee el `mundoSubsueloEngine` (score de salud del suelo): cansado → casi pelado;
- * vivo → lleno. Reusable por `abono` (corte de la pila de compost) sin código.
+ * entre ellas, VIDA low-poly — raíces que descienden y ramifican, el "internet
+ * de hongos" (hifas/micorrizas) y las criaturas reales de la librería (una
+ * lombriz que asoma por el corte, un escarabajo que camina la hojarasca). La
+ * CANTIDAD de vida = `params.vida` (0..1), que en producción lee el
+ * `mundoSubsueloEngine` (score de salud del suelo): cansado → casi pelado, con
+ * la tierra desnuda; vivo → lleno de raíces, hifas y bichos. La densidad manda:
+ * más vivo = más vida, pero con AIRE (nunca amontonado — feedback del valle).
  *
- * Perf (DR §6): SOLO `MeshLambert`/`MeshBasic`, sin sombras, geometría acotada.
+ * Reusable por `abono` (corte de la pila de compost) sin código: es todo datos
+ * (`params.capas` + `params.vida`). La lombriz de tierra es *Martiodrilus
+ * crassus* (verificada, indicador real de suelo vivo); el escarabajo estercolero
+ * *Dichotomius belus*. Perf (DR §6): SOLO `MeshLambert`/`MeshBasic`, sin sombras,
+ * geometría 100% procedural; las criaturas son billboards SVG (three-free).
  */
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
 import EscenaBase3D from './EscenaBase3D.jsx';
+import { Lombriz } from '../../creatures/Lombriz.jsx';
+import { Escarabajo } from '../../creatures/Escarabajo.jsx';
 
 const ANCHO = 4.4;
 const PROF = 2.2;
+const CARA = PROF / 2; // el plano del corte (la cara frontal expuesta)
 
 /* PRNG determinista (mismo corte siempre, sin GLTF ni azar por frame). */
 function rng(seed) {
@@ -29,85 +41,186 @@ function clamp01(n) {
   return Math.max(0, Math.min(1, typeof n === 'number' ? n : 0.6));
 }
 
-/* Una lombriz: cápsula curvada (toro parcial) tumbada, tono claro. */
-function Lombriz({ pos, giro }) {
-  return (
-    <mesh position={pos} rotation={[Math.PI / 2, giro, 0]}>
-      <torusGeometry args={[0.12, 0.045, 6, 10, Math.PI * 1.2]} />
-      <meshLambertMaterial color="#e8b6a6" />
-    </mesh>
-  );
-}
-
-/* Una raíz: cono fino que desciende desde su capa. */
-function Raiz({ pos, largo }) {
+/* Un terrón: grumo low-poly (esfera de pocos lados, flat) que rompe la cara
+   plana del corte — la "textura de acuario de tierra", sin cajas. */
+function Terron({ pos, r, color }) {
   return (
     <mesh position={pos}>
-      <coneGeometry args={[0.05, largo, 5]} />
-      <meshLambertMaterial color="#c9a86a" />
+      <sphereGeometry args={[r, 5, 4]} />
+      <meshLambertMaterial color={color} flatShading />
     </mesh>
   );
 }
 
-/* Una hifa: línea finísima blanca (la red de micorrizas). */
-function Hifa({ pos, giro }) {
+/* Una raíz: cono principal que desciende + un par de raicillas laterales finas.
+   Orgánica (conos afilados), no una caja — baja buscando agua y minerales. */
+function Raiz({ pos, largo }) {
+  return (
+    <group position={pos}>
+      <mesh>
+        <coneGeometry args={[0.055, largo, 6]} />
+        <meshLambertMaterial color="#c9a86a" flatShading />
+      </mesh>
+      <mesh position={[0.07, -largo * 0.18, 0]} rotation={[0, 0, -0.7]}>
+        <coneGeometry args={[0.022, largo * 0.55, 5]} />
+        <meshLambertMaterial color="#bd9a5a" flatShading />
+      </mesh>
+      <mesh position={[-0.06, -largo * 0.32, 0.02]} rotation={[0, 0, 0.8]}>
+        <coneGeometry args={[0.018, largo * 0.42, 5]} />
+        <meshLambertMaterial color="#bd9a5a" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* Una hifa: hebra finísima blanca. Se siembran cruzadas = la red de micorrizas,
+   el "internet de hongos" que enlaza las raíces con el agua y los minerales. */
+function Hifa({ pos, giro, largo }) {
   return (
     <mesh position={pos} rotation={[0, 0, giro]}>
-      <cylinderGeometry args={[0.008, 0.008, 0.5, 3]} />
+      <cylinderGeometry args={[0.007, 0.007, largo, 3]} />
       <meshBasicMaterial color="#f2ece0" />
     </mesh>
   );
 }
 
-function Diorama({ params }) {
+/* Una brizna de pasto sobre la superficie: cono verde fino, vida sin peso. */
+function Brizna({ pos, alto, giro }) {
+  return (
+    <mesh position={pos} rotation={[0, giro, 0.08]}>
+      <coneGeometry args={[0.03, alto, 4]} />
+      <meshLambertMaterial color="#6f9a45" flatShading />
+    </mesh>
+  );
+}
+
+/* Una criatura de la librería como BILLBOARD SVG (three-free) que respira/asoma.
+   Con reduced-motion se congela en su fotograma (escena digna, no muerta). */
+function Fauna({ base, phase, deriva = 0, asomo = 0.05, reducedMotion, children }) {
+  const ref = useRef(null);
+  useFrame((state) => {
+    if (reducedMotion || !ref.current) return;
+    const t = state.clock.elapsedTime;
+    ref.current.position.y = base[1] + Math.sin(t * 1.1 + phase) * asomo;
+    if (deriva) ref.current.position.x = base[0] + Math.sin(t * 0.32 + phase) * deriva;
+  });
+  return (
+    <group ref={ref} position={base}>
+      <Html center distanceFactor={5.4} zIndexRange={[24, 6]}>
+        <div className="mundo-fauna" aria-hidden="true">{children}</div>
+      </Html>
+    </group>
+  );
+}
+
+function Diorama({ params, reducedMotion }) {
   const vida = clamp01(params?.vida);
 
-  const { bloques, bichos, total } = useMemo(() => {
+  const { bloques, ambiente, terrones, briznas, lombrices, escarabajo, total } = useMemo(() => {
     const capas = params?.capas || [];
     const alturaTotal = capas.reduce((s, c) => s + (c.alto || 0.6), 0) || 1;
     const bloq = [];
-    const vid = [];
+    const amb = []; // raíces + hifas (geometría de fondo, "vida textura")
+    const terr = []; // grumos en la cara del corte
+    const worms = []; // lombrices de la librería (asoman por el corte)
     const r = rng(97);
     let top = alturaTotal; // arranca por la superficie
+
     capas.forEach((capa, ci) => {
       const alto = capa.alto || 0.6;
       const cy = top - alto / 2;
-      bloq.push({ key: `c${ci}`, cy, alto, color: capa.color || '#5a3d28' });
-      // vida por capa según qué bichos declara y cuánta vida hay
-      const tipos = capa.bichos || [];
-      const n = Math.round(vida * 6);
+      const color = capa.color || '#5a3d28';
+      bloq.push({ key: `c${ci}`, cy, alto, color });
+
+      // grumos que rompen la cara plana (pocos, siempre; textura de tierra)
+      const nT = 2 + Math.round(alto * 2);
+      for (let i = 0; i < nT; i++) {
+        terr.push({
+          key: `t${ci}-${i}`,
+          pos: [(r() - 0.5) * (ANCHO - 0.5), cy + (r() - 0.5) * alto * 0.7, CARA - 0.04],
+          rr: 0.09 + r() * 0.08,
+          color,
+        });
+      }
+
+      // vida-textura por capa: raíces y hifas, tanta como diga `vida`, con aire
+      const tipos = (capa.bichos || []).filter((b) => b === 'raiz' || b === 'hifa');
+      const n = Math.round(vida * (1.5 + alto * 2.2));
       for (let i = 0; i < n; i++) {
-        const tipo = tipos[i % Math.max(1, tipos.length)] || 'raiz';
-        const x = (r() - 0.5) * (ANCHO - 0.6);
-        const z = PROF / 2 - 0.02 - r() * 0.15; // pegados a la cara cortada (frente)
-        const y = cy + (r() - 0.5) * alto * 0.6;
-        vid.push({ key: `${ci}-${i}`, tipo, pos: [x, y, z], giro: r() * Math.PI, largo: 0.3 + r() * alto });
+        const tipo = tipos.length ? tipos[i % tipos.length] : 'raiz';
+        const x = (r() - 0.5) * (ANCHO - 0.8);
+        const z = CARA - 0.03 - r() * 0.12; // pegada a la cara cortada (frente)
+        const y = cy + (r() - 0.5) * alto * 0.55;
+        if (tipo === 'hifa') {
+          amb.push({ key: `h${ci}-${i}`, tipo, pos: [x, y, z], giro: (r() - 0.5) * 2.2, largo: 0.3 + r() * 0.4 });
+        } else {
+          amb.push({ key: `r${ci}-${i}`, tipo, pos: [x, y, z], largo: 0.32 + r() * alto });
+        }
+      }
+
+      // lombriz de librería: asoma por el corte de las capas que la declaran
+      // (suelo negro / tierra viva). Máx 2 en total → "vida, no relleno".
+      if ((capa.bichos || []).includes('lombriz') && worms.length < 2 && vida > 0.22) {
+        worms.push({
+          key: `w${ci}`,
+          base: [(r() - 0.5) * (ANCHO - 1.4), cy + 0.02, CARA + 0.06],
+          phase: r() * Math.PI * 2,
+        });
       }
       top -= alto;
     });
-    return { bloques: bloq, bichos: vid, total: alturaTotal };
+
+    // briznas de pasto sobre la superficie (pocas, más con vida)
+    const nB = 1 + Math.round(vida * 3);
+    const briz = Array.from({ length: nB }, (_, i) => ({
+      key: `b${i}`,
+      pos: [(r() - 0.5) * (ANCHO - 1), alturaTotal + 0.12, (r() - 0.5) * (PROF - 0.6)],
+      alto: 0.16 + r() * 0.12,
+      giro: r() * Math.PI,
+    }));
+
+    // escarabajo estercolero caminando la hojarasca (solo si el suelo está vivo)
+    const beetle = vida >= 0.4
+      ? { base: [(r() - 0.5) * 1.2, alturaTotal + 0.24, CARA - 0.25], phase: r() * Math.PI * 2 }
+      : null;
+
+    return { bloques: bloq, ambiente: amb, terrones: terr, briznas: briz, lombrices: worms, escarabajo: beetle, total: alturaTotal };
   }, [params, vida]);
 
   return (
     <group position={[0, -total / 2, 0]}>
-      {/* las capas: cajas apiladas, cara frontal expuesta (el corte) */}
+      {/* las capas: bloques apilados, cara frontal expuesta (el corte) */}
       {bloques.map((b) => (
         <mesh key={b.key} position={[0, b.cy, 0]}>
           <boxGeometry args={[ANCHO, b.alto, PROF]} />
           <meshLambertMaterial color={b.color} flatShading />
         </mesh>
       ))}
-      {/* borde de pasto sobre la superficie */}
+      {/* grumos que quiebran la cara plana del corte */}
+      {terrones.map((t) => <Terron key={t.key} pos={t.pos} r={t.rr} color={t.color} />)}
+      {/* el borde de pasto sobre la superficie */}
       <mesh position={[0, total + 0.03, 0]}>
         <boxGeometry args={[ANCHO, 0.08, PROF]} />
         <meshLambertMaterial color="#6f9a45" flatShading />
       </mesh>
-      {/* la vida del suelo, tanta como diga `vida` */}
-      {bichos.map((v) => {
-        if (v.tipo === 'lombriz') return <Lombriz key={v.key} pos={v.pos} giro={v.giro} />;
-        if (v.tipo === 'hifa') return <Hifa key={v.key} pos={v.pos} giro={v.giro} />;
-        return <Raiz key={v.key} pos={[v.pos[0], v.pos[1], v.pos[2]]} largo={v.largo} />;
-      })}
+      {briznas.map((b) => <Brizna key={b.key} pos={b.pos} alto={b.alto} giro={b.giro} />)}
+      {/* la vida-textura del suelo: raíces que bajan y la red de hifas */}
+      {ambiente.map((v) =>
+        v.tipo === 'hifa'
+          ? <Hifa key={v.key} pos={v.pos} giro={v.giro} largo={v.largo} />
+          : <Raiz key={v.key} pos={v.pos} largo={v.largo} />,
+      )}
+      {/* las criaturas reales de la librería (billboards SVG, three-free) */}
+      {lombrices.map((w) => (
+        <Fauna key={w.key} base={w.base} phase={w.phase} asomo={0.06} reducedMotion={reducedMotion}>
+          <Lombriz size={40} animated={!reducedMotion} />
+        </Fauna>
+      ))}
+      {escarabajo && (
+        <Fauna base={escarabajo.base} phase={escarabajo.phase} deriva={0.9} asomo={0.03} reducedMotion={reducedMotion}>
+          <Escarabajo size={42} animated={!reducedMotion} />
+        </Fauna>
+      )}
     </group>
   );
 }
@@ -121,7 +234,7 @@ export default function EscenaCutaway(props) {
       cielo={cielo}
       entrada={{ ...props.entrada, centro: [0, alto * 0.2, 0.6] }}
     >
-      <Diorama params={props.params} />
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -71,6 +71,12 @@
   transform-origin: center;
 }
 
+/* ── Criaturas de la librería dentro de la escena (billboard SVG) ───────── */
+.mundo-fauna {
+  pointer-events: none;
+  filter: drop-shadow(0 3px 6px rgba(40, 30, 10, 0.3));
+}
+
 /* ── Cargando (mientras baja el chunk 3D) ──────────────────────────────── */
 .mundo-cargando {
   position: absolute;


### PR DESCRIPTION
## Qué

Construye el **mundo 3D del suelo** (arquetipo `cutaway`) al nivel de calidad del mundo del agua, y publica su **vitrina pública** en `#/mockups/mundo3d-suelo` (sin auth).

Concepto: la vida invisible del subsuelo hecha visible — entre más vivo el suelo, más lombrices, raíces e hifas. Registro emocional **menos colapso, finca viva** (nada de alarma/rojo/catástrofe).

Ramificado desde `origin/dev` (framework mundo3d + mundo del agua como patrón de calidad).

## Cambios

- **`EscenaCutaway.jsx`** (pulido, sigue reusable por `abono` sin código):
  - Primitivas más orgánicas: `Terron` (grumos low-poly que quiebran la cara del corte), `Raiz` ramificada (cono + raicillas laterales), `Hifa` (red de micorrizas, el "internet de hongos"), `Brizna` de pasto.
  - Criaturas reales de la librería como **billboards SVG animados**: `Lombriz` (*Martiodrilus crassus*) que asoma por el corte + `Escarabajo` (*Dichotomius belus*) que camina la hojarasca.
  - **Densidad = `params.vida`** con aire (no amontonar); **PRNG determinista**; **reduced-motion** congela el fotograma.
- **`Mundo3DSuelo.jsx` + `.css`** (vitrina): paleta de tierra, `decidirTier()` real, toggle 3D/2D, gemelo 2D digno, leyenda didáctica de las 3 capas verificadas (hojarasca → suelo negro → subsuelo) + la vida (lombrices = indicador de suelo vivo, micorrizas). Copy **usted-CO**, móvil-first 320px, self-contained.
- **`App.jsx`**: ruta pública `mockups/mundo3d-suelo` → `mockup_mundo3d_suelo` (lazy, dentro de ErrorBoundary/ErrorFallback).
- **`mundo.css`**: clase `.mundo-fauna` para los billboards de criaturas.
- **Smoke test** del gemelo 2D (3 puertas del corte: subsuelo / salud_suelo / cromatografia).

## Datos agronómicos (verificados)

- 3 capas reales O/A/B: hojarasca (materia orgánica) → suelo negro → subsuelo.
- Lombriz = indicador real de suelo vivo; micorrizas = red de hongos que enlaza raíces con agua/minerales.

## Duras cumplidas

R3F low-poly de primitivas orgánicas · layout por datos (`params.vida` + `capas`) · three perezoso (`vendor-three`) · fallback 2D digno (`mirror`) · usted-CO · self-contained (cero CDN) · móvil 320px · prefers-reduced-motion · persona OFF.

## Verificación

`npm run build` → ✓ built (vendor-three sale en su chunk perezoso). tsc-gate/eslint los corre Opus en review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)