### PR TITLE
feat(mundo3d): mundo del café — beneficio de la cereza a la taza (arquetipo flujo)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,6 +82,7 @@ const EntradaValle3DMockup = lazy(() => import('./mockups/EntradaValle3D'));
 // 3D: "El mundo del agua" — monta <Mundo mundoId="agua"> del framework
 // (src/visual/mundo3d) con device-tiering real. El 3D va perezoso (vendor-three).
 const Mundo3DAguaMockup = lazy(() => import('./mockups/Mundo3DAgua'));
+const Mundo3DCafeMockup = lazy(() => import('./mockups/Mundo3DCafe'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -465,6 +466,7 @@ const MOCKUP_HASH_ROUTES = {
   // Galería aspiracional (3D + voz + superficies definitivas + piezas de diseño).
   'mockups/entrada-3d': 'mockup_entrada_3d',
   'mockups/mundo3d-agua': 'mockup_mundo3d_agua',
+  'mockups/mundo3d-cafe': 'mockup_mundo3d_cafe',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
   'mockups/ensena-dibujando': 'mockup_ensena_dibujando',
@@ -1324,6 +1326,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del agua">
               <Mundo3DAguaMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_cafe':
+        // Vitrina pública del MUNDO DEL CAFÉ: monta <Mundo mundoId="cafe"> del
+        // framework (src/visual/mundo3d) REUSANDO el arquetipo `flujo` del agua
+        // con device-tiering real. Ruta #/mockups/mundo3d-cafe, sin auth. El
+        // beneficio de la cereza a la taza: cereza → despulpado → fermento →
+        // lavado → secado → taza, a la sombra y sin veneno para la broca.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del café">
+              <Mundo3DCafeMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mundo3DCafe.css
+++ b/src/mockups/Mundo3DCafe.css
@@ -1,0 +1,180 @@
+/*
+ * Mundo3DCafe.css — vitrina pública del mundo del café (#/mockups/mundo3d-cafe).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Solo opacity/transform animables; reduced-motion las apaga.
+ */
+
+.m3dc {
+  --m3dc-a: #7a4a24;
+  --m3dc-b: #efe0cf;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3dc-b) 0%, #f4efe2 44%, #ece2cf 100%);
+  color: #2f2418;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3dc__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3dc__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3dc-a);
+}
+.m3dc__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #3f2814;
+}
+.m3dc__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3dc__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3dc__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(122, 74, 36, 0.28);
+  box-shadow: 0 10px 28px rgba(47, 36, 24, 0.14);
+}
+.m3dc__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fdf8ee;
+}
+
+.m3dc__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3dc__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3dc__toggle {
+  border: 1.5px solid var(--m3dc-a);
+  background: #fff;
+  color: var(--m3dc-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3dc__toggle:hover,
+.m3dc__toggle:focus-visible {
+  background: var(--m3dc-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3dc__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.78);
+  border-left: 3px solid var(--m3dc-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+/* La mata de café (LaminaCafeto): un pliego de cuaderno prendido en la vitrina. */
+.m3dc__mata {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3dc__mata h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.4rem;
+  color: #3f2814;
+}
+.m3dc__mata-txt {
+  margin: 0 0 0.8rem;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+.m3dc__lamina {
+  max-width: 30rem;
+  margin: 0 auto;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 22px rgba(47, 36, 24, 0.16);
+}
+.m3dc__lamina svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.m3dc__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3dc__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #3f2814;
+}
+.m3dc__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3dc__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3dc__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid rgba(122, 74, 36, 0.18);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3dc__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3dc__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #3f2814;
+}
+.m3dc__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3dc__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #4a3320;
+}

--- a/src/mockups/Mundo3DCafe.jsx
+++ b/src/mockups/Mundo3DCafe.jsx
@@ -1,0 +1,141 @@
+/*
+ * Mundo3DCafe — vitrina pública del MUNDO DEL CAFÉ (ruta #/mockups/mundo3d-cafe).
+ *
+ * De la cereza a la taza: el beneficio del café como un proceso que baja por
+ * gravedad y agua —cereza → despulpado → fermento → lavado → secado → taza—,
+ * bajo la sombra de los guamos, con la broca manejada sin veneno. Didáctico y
+ * esperanzador: menos colapso, finca viva.
+ *
+ * NO reimplementa nada: REUSA el arquetipo `flujo` (el mundo del agua es el
+ * gold-standard) montando `<Mundo mundoId="cafe">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento" activado) se ve el gemelo 2D digno; en gama
+ * media/alta, el diorama 3D low-poly (chunk perezoso `vendor-three`) con las
+ * cerezas en los cafetos, el colibrí que poliniza y la abeja Angelita entrando.
+ * Los puntos son las mismas puertas del registro: aquí (vitrina sin sesión)
+ * cuentan a qué pantalla real de la app llevan, en vez de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas (la mata la dibuja LaminaCafeto en
+ * SVG propio). Móvil-first (320px). Copy en español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import LaminaCafeto from '../visual/laminas/LaminaCafeto.jsx';
+import './Mundo3DCafe.css';
+
+const TINTE = ['#7a4a24', '#efe0cf'];
+
+/* El beneficio, paso por paso — la misma verdad agronómica que ordena la data
+   del registro (mundoData.js), contada en una leyenda didáctica. */
+const LEYENDA = [
+  { emoji: '🍒', titulo: 'La cereza madura', texto: 'Se coge solo la cereza roja, madurita: ahí está el café bueno. La verde y la seca se dejan o se apartan.' },
+  { emoji: '🌳', titulo: 'A la sombra del guamo', texto: 'El café se da mejor bajo sombra (guamo, nogal cafetero, aliso): menos sol pica, suelo más vivo y el guamo hasta le regala nitrógeno.' },
+  { emoji: '⚙️', titulo: 'Despulpado', texto: 'La despulpadora le quita la cáscara y la pulpa a la cereza. Esa pulpa no se bota: se vuelve abono.' },
+  { emoji: '🫧', titulo: 'Fermento y lavado', texto: 'El grano con su baba (mucílago) reposa en el tanque y luego se lava con agua limpia. Ese punto es el que le da la taza.' },
+  { emoji: '☀️', titulo: 'Secado', texto: 'Al sol en marquesina o patio hasta que queda en pergamino, con la humedad justa para guardarlo sin que se dañe.' },
+  { emoji: '☕', titulo: 'Hasta la taza', texto: 'Trillado, tostado y molido: el recorrido termina en una taza. De su finca, sin intermediario, con historia.' },
+];
+
+export default function Mundo3DCafe() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // En la vitrina (sin sesión) un punto del recorrido no navega: cuenta a qué
+  // pantalla real de la app lleva esa puerta.
+  const [puerta, setPuerta] = useState(null);
+  const onHotspot = (view, data) => {
+    const hs = (MUNDO.cafe.hotspots || []).find(
+      (h) => h.view === view && (h.data === data || (!h.data && !data)),
+    ) || (MUNDO.cafe.hotspots || []).find((h) => h.view === view);
+    setPuerta({ label: hs?.label || view, view });
+  };
+
+  return (
+    <main className="m3dc" style={{ '--m3dc-a': TINTE[0], '--m3dc-b': TINTE[1] }}>
+      <header className="m3dc__head">
+        <p className="m3dc__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo del café</h1>
+        <p className="m3dc__lema">
+          De la cereza a la taza: el beneficio que baja por gravedad y agua,
+          a la sombra de los guamos y sin veneno para la broca. Menos colapso,
+          finca viva.
+        </p>
+      </header>
+
+      <section className="m3dc__escena" aria-label="El beneficio del café, de la cereza a la taza">
+        <Mundo
+          mundoId="cafe"
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          onSalir={null}
+          animo="sereno"
+          energia={0.85}
+        />
+        <div className="m3dc__barra">
+          <p className="m3dc__tier">
+            {tier === 'bajo'
+              ? 'Está viendo el dibujo del beneficio (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3dc__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver el dibujo 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3dc__nota" role="status" aria-live="polite">
+          {puerta
+            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+            : 'Toque un punto del beneficio para ver a dónde lo lleva.'}
+        </p>
+      </section>
+
+      <section className="m3dc__mata" aria-label="La mata de café por dentro">
+        <h2>Conozca su cafeto</h2>
+        <p className="m3dc__mata-txt">
+          Antes de contar el beneficio, la mata entera: sus hojas, su flor
+          blanca y la cereza que —por dentro— guarda la pulpa, el pergamino y el
+          grano. Son los mismos nombres que usa el recorrido de arriba.
+        </p>
+        <div className="m3dc__lamina">
+          <LaminaCafeto />
+        </div>
+      </section>
+
+      <section className="m3dc__leyenda" aria-label="El beneficio, paso por paso">
+        <h2>El beneficio, paso por paso</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3dc__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3dc__cierre">
+          Un cafetal con sombra y bien beneficiado es una finca que se defiende
+          sola: más viva, menos frágil. Empiece por el paso que usted tenga hoy
+          entre manos.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/__tests__/mundo3dCafe.smoke.test.jsx
+++ b/src/mockups/__tests__/mundo3dCafe.smoke.test.jsx
@@ -1,0 +1,40 @@
+/*
+ * Vitrina #/mockups/mundo3d-cafe — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y la vitrina monta
+ * el GEMELO 2D del beneficio (three-free): exactamente el camino del
+ * device-tiering real en gama baja. Se congela que:
+ *   · la página renderiza título + leyenda + la lámina del cafeto sin tocar three;
+ *   · el gemelo trae los 4 puntos del beneficio como botones;
+ *   · tocar una puerta cuenta a qué pantalla real de la app lleva (sin sesión la
+ *     vitrina NO navega).
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import Mundo3DCafe from '../Mundo3DCafe.jsx';
+
+afterEach(() => cleanup());
+
+describe('vitrina del mundo del café (mockups/mundo3d-cafe)', () => {
+  test('renderiza el mundo en 2D digno con su leyenda y la lámina del cafeto', () => {
+    const { container } = render(<Mundo3DCafe />);
+    expect(screen.getByRole('heading', { level: 1, name: 'El mundo del café' })).toBeInTheDocument();
+    // jsdom no tiene WebGL → gemelo 2D (three-free), nunca pantalla rota
+    expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('.mundo2d__hotspot').length).toBe(4);
+    // la leyenda cuenta el beneficio paso por paso (esperanzadora, no alarmista)
+    expect(screen.getByText('El beneficio, paso por paso')).toBeInTheDocument();
+    expect(screen.getByText('A la sombra del guamo', { selector: 'b' })).toBeInTheDocument();
+    // REUSA LaminaCafeto: la mata dibujada en SVG propio, sin imágenes externas
+    expect(container.querySelector('[data-testid="lamina-cafeto"]')).toBeInTheDocument();
+  });
+
+  test('tocar una puerta del beneficio cuenta a qué pantalla real lleva', () => {
+    render(<Mundo3DCafe />);
+    fireEvent.click(screen.getByRole('button', { name: 'Broca sin veneno' }));
+    expect(screen.getByRole('status')).toHaveTextContent('«biopreparados»');
+  });
+});

--- a/src/visual/mundo3d/__tests__/mundoCafe.test.jsx
+++ b/src/visual/mundo3d/__tests__/mundoCafe.test.jsx
@@ -1,0 +1,94 @@
+/*
+ * EL MUNDO DEL CAFÉ — contrato del beneficio (feat mundo3d-cafe).
+ *
+ * El mundo del café es UNA entrada de datos del registro (mundoData.js) que
+ * REUSA el arquetipo `flujo` del mundo del agua (el beneficio húmedo ES un
+ * proceso de gravedad + agua). Este test congela sus sí-o-sí:
+ *   1. Es el arquetipo `flujo`, con landmark de cafetal en el valle.
+ *   2. Sus puntos (café, cereza, sombra, broca) existen y cada `view` es un
+ *      case REAL de App.jsx (regla de oro: re-rutear, nunca reimplementar).
+ *   3. La curva del beneficio y sus hitos (incl. cerezas, taza y fauna) son
+ *      datos; el device-tiering cae al gemelo `mirror` con los MISMOS params.
+ *   4. El gemelo 2D monta three-free en jsdom y sus puertas re-rutean de verdad.
+ */
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+import Mundo from '../Mundo.jsx';
+import { MUNDO } from '../mundoData.js';
+import { resolverMundo } from '../resolverMundo.js';
+
+afterEach(() => cleanup());
+
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+const appSrc = fs.readFileSync(path.resolve(__dir, '../../../App.jsx'), 'utf8');
+
+const cafe = MUNDO.cafe;
+
+describe('mundo del café — el beneficio como datos sobre el arquetipo flujo', () => {
+  test('REUSA el arquetipo flujo, con landmark de cafetal y entrada de la abeja', () => {
+    expect(cafe.escena).toBe('flujo');
+    expect(cafe.valle?.tipo).toBe('cafetal');
+    expect(cafe.entrada?.narra).toBe('cafe');
+    expect(typeof cafe.entrada?.zoom).toBe('number');
+  });
+
+  test('los puntos del beneficio están y cada view existe en App.jsx', () => {
+    const ids = (cafe.hotspots || []).map((h) => h.id);
+    ['cafe', 'cereza', 'sombra', 'broca'].forEach((id) => {
+      expect(ids, `falta el punto '${id}' del beneficio`).toContain(id);
+    });
+    for (const h of cafe.hotspots) {
+      expect(
+        appSrc.includes(`case '${h.view}':`),
+        `la vista '${h.view}' del punto '${h.id}' no existe en App.jsx`,
+      ).toBe(true);
+    }
+  });
+
+  test('la curva y los hitos del beneficio son datos compartidos 3D ↔ 2D', () => {
+    expect(Array.isArray(cafe.params.curva)).toBe(true);
+    expect(cafe.params.curva.length).toBeGreaterThanOrEqual(4);
+    const hitos = cafe.params.hitos;
+    expect(hitos.ronda?.arboles).toBeGreaterThan(0);        // los árboles de sombra
+    expect(hitos.cerezas?.n).toBeGreaterThan(0);            // las cerezas en los cafetos
+    expect(hitos.riesgo?.t).toBeGreaterThan(0);             // la broca sin veneno (ámbar)
+    expect(hitos.bocatoma?.t).toBeGreaterThan(hitos.riesgo.t); // la despulpadora va aguas abajo
+    expect(Array.isArray(hitos.cultivo?.pos)).toBe(true);
+    expect(Array.isArray(hitos.taza?.pos)).toBe(true);      // de la cereza a la taza
+    expect(hitos.fauna?.some((f) => f.tipo === 'colibri')).toBe(true); // el colibrí poliniza
+  });
+
+  test('tier alto → diorama 3D flujo; equipo humilde → gemelo mirror con los mismos params', () => {
+    const alto = resolverMundo('cafe', 'alto');
+    expect(alto.modo).toBe('3d');
+    expect(alto.escena).toBe('flujo');
+
+    const bajo = resolverMundo('cafe', 'bajo');
+    expect(bajo.modo).toBe('2d');
+    expect(bajo.escena).toBe('mirror'); // el fallback2d declarado
+    expect(bajo.motivo).toBe('flujo');
+    // el gemelo recibe la MISMA data del beneficio
+    expect(bajo.entrada.params.hitos).toEqual(cafe.params.hitos);
+    expect(bajo.entrada.params.curva).toEqual(cafe.params.curva);
+  });
+
+  test('el gemelo 2D monta three-free y sus puertas re-rutean', () => {
+    const onHotspot = vi.fn();
+    const { container } = render(
+      <Mundo mundoId="cafe" tier="bajo" onHotspot={onHotspot} onSalir={() => {}} />,
+    );
+    expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+    const botones = container.querySelectorAll('.mundo2d__hotspot');
+    expect(botones.length).toBe(4);
+    fireEvent.click(screen.getByRole('button', { name: 'Sombra y guamos' }));
+    expect(onHotspot).toHaveBeenCalledWith('asociaciones', undefined);
+    fireEvent.click(screen.getByRole('button', { name: 'La cereza por dentro' }));
+    expect(onHotspot).toHaveBeenCalledWith('cafe', { tema: 'cereza' });
+  });
+});

--- a/src/visual/mundo3d/escenas/EscenaFlujo.jsx
+++ b/src/visual/mundo3d/escenas/EscenaFlujo.jsx
@@ -1,23 +1,35 @@
 /*
- * EscenaFlujo — ARQUETIPO `flujo`: el CAMINO del agua (gravedad y pendiente).
+ * EscenaFlujo — ARQUETIPO `flujo`: un PROCESO que baja por gravedad y agua.
  *
- * El agua se entiende por dónde BAJA: nacimiento → quebrada → toma → riego.
- * Una cinta-tubo que desciende por una curva (la pendiente ES la lección), un
- * tanque que la recibe, y — si el mundo los declara en `params.hitos` — los
- * HITOS del recorrido, todos por DATOS y anclados a la curva por su fracción t:
+ * El arquetipo gold-standard del mundo del agua (nacimiento → quebrada → toma →
+ * riego). Una cinta-tubo que desciende por una curva (la pendiente ES la
+ * lección), un tanque que la recibe, y — si el mundo los declara en
+ * `params.hitos` — los HITOS del recorrido, todos por DATOS y anclados a la
+ * curva por su fracción t:
  *
- *   · ronda    { tramo:[t0,t1], arboles }  franja de monte que protege el nacimiento
+ *   · ronda    { tramo:[t0,t1], arboles }  franja de monte / árboles de sombra
  *   · riesgo   { t, lado }                 punto de CUIDADO (ámbar, didáctico — no alarma)
- *   · bocatoma { t }                       la cajilla que toma el agua
- *   · cultivo  { pos:[x,y,z], surcos }     la huerta regada, con su canalito desde el tanque
+ *   · bocatoma { t }                       la cajilla que toma / la despulpadora
+ *   · cultivo  { pos:[x,y,z], surcos }     la huerta o el cafetal en surcos
+ *   · cerezas  { tramo:[t0,t1], n }        (café) las cerezas maduras en los cafetos
+ *   · taza     { pos:[x,y,z] }             (café) el final feliz: de la cereza a la taza
+ *   · fauna    [{ tipo, pos, escala }]     criaturas de la librería (colibrí, mariposa)
  *
- * Sin `hitos` el diorama clásico sigue idéntico (nacimiento + cinta + tanque).
+ * El MISMO arquetipo sirve al agua (el recorrido de la quebrada) y al café (el
+ * beneficio húmedo: cereza → despulpado → fermento → lavado → secado → taza,
+ * verdad agronómica de gravedad + agua). Un mundo lo reparametriza con datos:
+ * `params.cielo` tiñe el ambiente y `params.flujo` el color de lo que baja
+ * (agua azul o miel-café). Sin esos datos, el mundo del agua queda idéntico.
+ *
  * Todo primitivas low-poly (`MeshLambert`/`MeshBasic`), sin sombras, sin GLTF.
  */
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import EscenaBase3D from './EscenaBase3D.jsx';
+import { Colibri } from '../../creatures/Colibri.jsx';
+import { Mariposa } from '../../creatures/Mariposa.jsx';
 
 const CURVA_DEFAULT = [
   [-1.8, 2.2, 0.4], [-0.9, 1.4, 0.1], [0, 0.7, -0.2], [0.7, 0.1, 0.1], [1.4, -0.2, 0.5],
@@ -189,8 +201,96 @@ function Cultivo({ pos = [2.3, -0.3, -0.55], surcos = 4, desde, color }) {
   );
 }
 
+/* CEREZAS de café sembradas sobre los cafetos del tramo alto (donde va la
+   sombra). Determinista: mismo dato, misma cosecha. Unas verdes (biches), casi
+   todas maduras (rojas) — la señal de que ya se pueden coger. */
+function Cerezas({ curva3, tramo = [0.06, 0.5], n = 10 }) {
+  const puestas = useMemo(() => {
+    const [t0, t1] = tramo;
+    return Array.from({ length: n }, (_, i) => {
+      const t = t0 + ((t1 - t0) * i) / Math.max(1, n - 1);
+      const p = curva3.getPoint(t);
+      const lado = i % 2 === 0 ? 1 : -1;
+      return {
+        key: i,
+        pos: [
+          p.x + lado * (0.5 + (i % 3) * 0.12),
+          p.y + 0.02 + (i % 2) * 0.14,
+          p.z + lado * (0.55 + (i % 2) * 0.1),
+        ],
+        verde: i % 4 === 0,
+        r: 0.07 + (i % 3) * 0.012,
+      };
+    });
+  }, [curva3, tramo, n]);
+  return (
+    <group>
+      {puestas.map((c) => (
+        <mesh key={c.key} position={c.pos}>
+          <sphereGeometry args={[c.r, 8, 6]} />
+          <meshLambertMaterial color={c.verde ? '#8fae4e' : '#c0402c'} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* La TAZA al final del recorrido: el beneficio termina volviéndose café. Un
+   pocillo de cerámica (cono truncado) con su asa (torus), el café adentro y su
+   platico — "de la cereza a la taza". Primitivas blandas, cero cajas. */
+function Taza({ pos = [1.75, -0.12, 0.55] }) {
+  return (
+    <group position={pos}>
+      {/* el platico */}
+      <mesh position={[0, 0.02, 0]}>
+        <cylinderGeometry args={[0.3, 0.32, 0.05, 20]} />
+        <meshLambertMaterial color="#f3ece0" flatShading />
+      </mesh>
+      {/* el pocillo (cono truncado) */}
+      <mesh position={[0, 0.19, 0]}>
+        <cylinderGeometry args={[0.22, 0.17, 0.28, 20]} />
+        <meshLambertMaterial color="#f6efe4" flatShading />
+      </mesh>
+      {/* el café adentro */}
+      <mesh position={[0, 0.32, 0]}>
+        <cylinderGeometry args={[0.2, 0.2, 0.02, 20]} />
+        <meshLambertMaterial color="#3f2412" />
+      </mesh>
+      {/* el asa */}
+      <mesh position={[0.24, 0.19, 0]} rotation={[Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[0.09, 0.025, 8, 16]} />
+        <meshLambertMaterial color="#f0e6d6" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* FAUNA de la librería posada en la escena (colibrí que poliniza la flor del
+   café, mariposa que visita). Billboards `<Html>` con las creatures reales; con
+   reduced-motion se congelan (`animated=false`), escena digna, no muerta. */
+function FaunaFlujo({ fauna = [], reducedMotion }) {
+  return (
+    <group>
+      {fauna.map((f, i) => {
+        const Bicho = f.tipo === 'mariposa' ? Mariposa : Colibri;
+        const base = f.tipo === 'mariposa' ? 44 : 52;
+        const size = Math.round(base * (f.escala || 1));
+        return (
+          <group key={i} position={f.pos}>
+            <Html center distanceFactor={7} zIndexRange={[22, 6]}>
+              <div className="mundo-fauna" aria-hidden="true" style={{ pointerEvents: 'none' }}>
+                <Bicho size={size} animated={!reducedMotion} />
+              </div>
+            </Html>
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
 function Diorama({ params, tinte, reducedMotion }) {
-  const color = params?.agua || (tinte && tinte[0]) || '#3f8fb0';
+  const color = params?.flujo || params?.agua || (tinte && tinte[0]) || '#3f8fb0';
   const hitos = params?.hitos;
   const curva3 = useMemo(() => {
     const pts = (params?.curva || CURVA_DEFAULT).map((p) => new THREE.Vector3(p[0], p[1], p[2]));
@@ -233,12 +333,20 @@ function Diorama({ params, tinte, reducedMotion }) {
           color={color}
         />
       )}
+      {/* enriquecimientos por datos (café): cerezas, la taza y la fauna */}
+      {hitos?.cerezas && <Cerezas curva3={curva3} tramo={hitos.cerezas.tramo} n={hitos.cerezas.n} />}
+      {hitos?.taza && <Taza pos={hitos.taza.pos} />}
+      {hitos?.fauna && <FaunaFlujo fauna={hitos.fauna} reducedMotion={reducedMotion} />}
     </group>
   );
 }
 
 export default function EscenaFlujo(props) {
-  const cielo = { fondo: '#d9e8ec', cielo: '#eaf3f5', suelo: '#7f9270', intensidad: 1.1 };
+  // El agua trae su cielo azulado por defecto; un mundo (p. ej. el café) puede
+  // teñir el ambiente cálido/verde de montaña con `params.cielo`.
+  const cielo = props.params?.cielo || {
+    fondo: '#d9e8ec', cielo: '#eaf3f5', suelo: '#7f9270', intensidad: 1.1,
+  };
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.9, 0.3] }}>
       <Diorama params={props.params} tinte={props.tinte} reducedMotion={props.reducedMotion} />

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -71,6 +71,13 @@
   transform-origin: center;
 }
 
+/* Fauna de la librería posada en un diorama (colibrí, mariposa): no intercepta
+   el puntero (los hotspots quedan tocables) y lleva su sombrita suave. */
+.mundo-fauna {
+  pointer-events: none;
+  filter: drop-shadow(0 3px 6px rgba(40, 30, 10, 0.24));
+}
+
 /* ── Cargando (mientras baja el chunk 3D) ──────────────────────────────── */
 .mundo-cargando {
   position: absolute;

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -162,15 +162,48 @@ export const MUNDO = {
     entrada: { narra: 'cultivos' },
   },
 
-  // ☕ EL CAFÉ — arquetipo `lamina`: la lámina del cafeto.
+  // ☕ EL CAFÉ — REUSA el arquetipo `flujo` del mundo del agua: el beneficio
+  //    húmedo ES un proceso de gravedad + agua que BAJA — de la cereza a la
+  //    taza (cereza → despulpado → fermento → lavado → secado → taza). Verdad
+  //    agronómica (Coffea arabica 1500–2000 msnm, piso templado, café de
+  //    SOMBRA con guamo/nogal/aliso; broca sin veneno con Beauveria bassiana) +
+  //    máximo reúso del gold-standard. Todo son DATOS: la curva del beneficio +
+  //    sus hitos los leen igual el diorama 3D (EscenaFlujo) y su gemelo 2D.
   cafe: {
-    escena: 'lamina',
+    escena: 'flujo',
     valle: { tipo: 'cafetal', pos: [3.4, 0, 2.2], escala: 1 },
-    params: { lamina: 'cafeto' },
+    params: {
+      // El ambiente cálido/verde de montaña templada y el color miel-café de lo
+      // que baja (el mucílago con agua), en vez del azul del agua.
+      cielo: { fondo: '#e9ead0', cielo: '#f1f0d8', suelo: '#6d7c48', intensidad: 1.05 },
+      flujo: '#b07a44',
+      // El beneficio baja por gravedad, igual que la quebrada.
+      curva: [
+        [-2.1, 2.3, 0.3], [-1.1, 1.5, 0], [-0.1, 0.8, -0.25], [0.7, 0.25, 0], [1.5, -0.15, 0.5],
+      ],
+      hitos: {
+        ronda: { tramo: [0.02, 0.32], arboles: 5 },       // los árboles de sombra sobre el cafetal
+        cerezas: { tramo: [0.06, 0.5], n: 10 },            // las cerezas maduras en los cafetos
+        riesgo: { t: 0.44, lado: 0.85 },                   // la broca se maneja SIN veneno (Beauveria)
+        bocatoma: { t: 0.64 },                             // la despulpadora del beneficio
+        cultivo: { pos: [2.25, -0.28, -0.55], surcos: 4 }, // el cafetal en surcos / el secadero
+        taza: { pos: [1.75, -0.12, 0.55] },                // de la cereza a la taza
+        fauna: [
+          { tipo: 'colibri', pos: [-1.25, 1.95, 0.6], escala: 1 },   // poliniza la flor del café
+          { tipo: 'mariposa', pos: [0.35, 1.15, 0.7], escala: 0.9 }, // visita el cafetal
+        ],
+      },
+    },
     hotspots: [
-      { id: 'cafe', pos: [], emoji: '☕', label: 'El café, paso a paso', view: 'cafe' },
+      { id: 'cafe', pos: [-1.1, 1.55, 0.05], emoji: '☕', label: 'El café, paso a paso', view: 'cafe' },
+      { id: 'cereza', pos: [-0.35, 1.3, 0.7], emoji: '🍒', label: 'La cereza por dentro', view: 'cafe', data: { tema: 'cereza' } },
+      { id: 'sombra', pos: [-1.7, 2.5, -0.55], emoji: '🌳', label: 'Sombra y guamos', view: 'asociaciones' },
+      { id: 'broca', pos: [0.35, 1.15, 1], emoji: '🐛', label: 'Broca sin veneno', view: 'biopreparados' },
     ],
-    entrada: { narra: 'cafe' },
+    entrada: { zoom: 7, narra: 'cafe' },
+    // El gemelo 2D digno: el mismo motivo de flujo (mirror), con los MISMOS
+    // hitos, teñido con el café del mundo.
+    fallback2d: { escena: 'mirror' },
   },
 
   // 🍊 FRUTALES — arquetipo `ficha`: tarjeta de especie foto-secuencial.


### PR DESCRIPTION
## Mundo 3D del café (#3 del batch)

De la cereza a la taza: el **beneficio** del café como un proceso que baja por **gravedad y agua**. REUSA el arquetipo gold-standard `flujo` del mundo del agua (`#/mockups/mundo3d-agua`) — el beneficio húmedo ES un proceso gravedad+agua con canales, así que es verdad agronómica *y* máximo reúso.

**Ruta:** `#/mockups/mundo3d-cafe` (vitrina pública, sin auth).

### Qué trae
- **UNA entrada de datos** en `mundoData.js`: `cafe` pasa de `lamina` a `flujo`, con la curva del beneficio + hitos (sombra guamo/nogal/aliso, cerezas en los cafetos, broca sin veneno en ámbar, despulpadora, cafetal/secadero, taza y fauna).
- **`EscenaFlujo` extendida por DATOS y retro-compatible**: `params.cielo`/`params.flujo` tiñen ambiente y flujo; `hitos.cerezas`/`taza`/`fauna` son opcionales → **el mundo del agua queda idéntico** (13 tests de agua/framework verdes). Colibrí que poliniza + mariposa como billboards de la librería de creatures.
- **Gemelo 2D digno** (`mirror` motivo `flujo`) y **`LaminaCafeto` reusada** en la vitrina.
- La abeja **Angelita** entra (`useEntradaAbeja`).

### Duras cumplidas
R3F low-poly (conos/cilindros/esferas/torus, sin cajas nuevas), layout por datos, three lazy (`vendor-three`), fallback 2D, **usted-CO**, self-contained (SVG propio, cero CDN), móvil 320px, `prefers-reduced-motion` (fauna congelada), sin Playwright.

### Dato agronómico verificado
*Coffea arabica* 1500–2000 msnm, piso templado; café de **sombra** (guamo *Inga edulis* fija N, nogal cafetero, aliso); broca (*Hypothenemus hampei*) manejada **sin veneno** con *Beauveria bassiana*. "Menos colapso, finca viva."

### Verificación
- `npm run build` ✅ (2m 37s, sin errores)
- Tests nuevos: `mundoCafe.test.jsx` + `mundo3dCafe.smoke.test.jsx` (7/7) ✅
- No-regresión agua + framework (13/13) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)