### PR TITLE
fix(mundo3d): atmósfera de hora dorada + sombras de contacto en todos los mundos (B5/B6)

### DIFF
--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -2,48 +2,116 @@
  * EscenaBase3D — el ANDAMIAJE 3D compartido por todos los arquetipos de escena.
  *
  * El DR (§4.4, §6) pide que cada arquetipo sea SOLO su diorama; el resto (Canvas,
- * luz frugal, cámara, hotspots, la abeja) se hereda. Aquí vive ese resto: un
- * `<Canvas>` austero (DPR ≤ 1.5, SIN sombras, SIN post-proceso, `frameloop`
- * a demanda si hay reduced-motion), luz de ambiente + hemisferio (barata, para
- * `MeshLambert`/`MeshBasic`), `OrbitControls` acotado, los `hotspots` como
- * botones-billboard accesibles que re-rutean a vistas 2D reales, y Angelita con
- * su coreografía compartida. El arquetipo pasa su geometría como `children`.
+ * luz, atmósfera, cámara, hotspots, la abeja) se hereda. Aquí vive ese resto: un
+ * `<Canvas>` austero (DPR ≤ 1.5, SIN shadow-maps, SIN post-proceso, `frameloop`
+ * a demanda si hay reduced-motion), la ATMÓSFERA DE HORA DORADA compartida con
+ * el valle (auditoría 3D B5/B6: sol direccional cálido + relleno frío tenue +
+ * niebla sutil + sombras de contacto falsas — forma y peso sin pagar sombras
+ * reales), `OrbitControls` acotado, los `hotspots` como botones-billboard
+ * accesibles que re-rutean a vistas 2D reales, y Angelita con su coreografía
+ * compartida. El arquetipo pasa su geometría como `children`.
  *
  * CONTRATO uniforme (idéntico para cutaway/flujo/recinto/estratos):
  *   { params, hotspots, entrada, tinte, reducedMotion, onHotspot, onSalir,
- *     animo, energia, cielo?, camara?, children }
+ *     animo, energia, cielo?, camara?, piso?, children }
+ *
+ * `cielo` del arquetipo ya NO reemplaza la atmósfera: se MEZCLA hacia la paleta
+ * dorada del valle (cohesión valle↔mundo — entrar debe sentirse como acercarse,
+ * no como abrir otra app). `piso` (y del suelo, default 0) posa la alfombra y
+ * las sombras de contacto; solo cutaway lo necesita (su bloque centra en 0).
  */
-import { Suspense, useRef, useState } from 'react';
+import { Suspense, useMemo, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaEscena } from './useEntradaAbeja.jsx';
+import { SombraContacto } from './SombraContacto.jsx';
 
 /* Cielo cálido "acuarela" por defecto (la estética heredada del valle). El
    arquetipo puede pasar su propio `cielo` para teñir su ambiente. */
 const CIELO_DEFAULT = { fondo: '#ece0c7', cielo: '#f5e9d2', suelo: '#b49873', intensidad: 1 };
 
+/* La hora dorada del valle (CLIMAS.dorada de valleData): la atmósfera base que
+   TODOS los mundos heredan. El `cielo` propio del arquetipo solo la tiñe. */
+const ATMOSFERA = {
+  fondo: '#f2d9a8', // fondo cálido de tarde
+  cielo: '#f7c66b', // domo dorado (hemisferio, arriba)
+  suelo: '#8a6b4a', // rebote tierra (hemisferio, abajo)
+  luz: '#ffd79a', // el sol bajo, dorado (direccional principal)
+  relleno: '#9db8d9', // relleno frío de cielo abierto (direccional opuesta, tenue)
+  niebla: '#f0c98d', // la niebla dorada del valle
+  sombra: '#3a2a18', // tinte de las sombras de contacto
+};
+
+/* Mezcla dos hex hacia `t` (0 = a, 1 = b). Barato y memoizado por quien llama. */
+function mezclar(a, b, t) {
+  return `#${new THREE.Color(a).lerp(new THREE.Color(b), t).getHexString()}`;
+}
+
 function Contenido({
-  params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, children,
+  params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
+  children,
 }) {
   const controls = useRef(null);
   const [activo, setActivo] = useState(null);
-  const c = cielo || CIELO_DEFAULT;
   const zoom = entrada?.zoom ?? 6.5;
   const acento = (tinte && tinte[0]) || '#3f8f4e';
   const centro = entrada?.centro || [0, (params?.alto ?? 1.1) * 0.5, 0];
 
-  // foco = el hotspot activo (o el centro del diorama). Barato: un Vector3 por
-  // render; la abeja lo persigue con `lerp` en useEntradaAbeja.
+  // La atmósfera del mundo: su `cielo` propio MEZCLADO 60% hacia la hora dorada
+  // del valle (B6 — hoy entrar a un mundo "aplana" porque cada escena fija un
+  // cielo frío propio). Memoizado: THREE.Color solo cuando cambia el cielo.
+  const c = useMemo(() => {
+    const propio = cielo || CIELO_DEFAULT;
+    return {
+      fondo: mezclar(propio.fondo, ATMOSFERA.fondo, 0.6),
+      cielo: mezclar(propio.cielo, ATMOSFERA.cielo, 0.6),
+      suelo: mezclar(propio.suelo, ATMOSFERA.suelo, 0.6),
+      niebla: mezclar(propio.fondo, ATMOSFERA.niebla, 0.7),
+      alfombra: mezclar(propio.suelo, ATMOSFERA.suelo, 0.5),
+      intensidad: propio.intensidad ?? 1,
+    };
+  }, [cielo]);
+
+  // foco = el hotspot activo (o el centro del diorama). Memoizado (auditoría
+  // B11: antes era un Vector3 nuevo POR RENDER — basura de GC en el hilo
+  // caliente); la abeja lo persigue con `lerp` en useEntradaAbeja.
   const hAct = activo && hotspots ? hotspots.find((x) => x.id === activo) : null;
   const p = hAct ? hAct.pos : centro;
-  const foco = new THREE.Vector3(p[0], p[1], p[2]);
+  const foco = useMemo(() => new THREE.Vector3(p[0], p[1], p[2]), [p[0], p[1], p[2]]);
 
   return (
     <>
       <color attach="background" args={[c.fondo]} />
-      <hemisphereLight intensity={0.95 * c.intensidad} color={c.cielo} groundColor={c.suelo} />
-      <ambientLight intensity={0.45 * c.intensidad} color={c.cielo} />
+      {/* Niebla sutil: profundidad atmosférica sin lavar el diorama (arranca
+          detrás de él y se funde con la niebla dorada del valle). */}
+      <fog attach="fog" args={[c.niebla, zoom * 1.4, zoom * 4.6]} />
+      <hemisphereLight intensity={0.55 * c.intensidad} color={c.cielo} groundColor={c.suelo} />
+      <ambientLight intensity={0.28 * c.intensidad} color={ATMOSFERA.luz} />
+      {/* El sol de la hora dorada — MISMA dirección que el valle ([6,9,4]) para
+          que el lenguaje de sombreado no cambie al entrar. Sin castShadow:
+          Lambert + sombras de contacto falsas dan la forma, gratis. */}
+      <directionalLight position={[6, 9, 4]} intensity={0.9 * c.intensidad} color={ATMOSFERA.luz} />
+      {/* Relleno frío tenue desde el lado opuesto: despega los volúmenes del
+          fondo cálido sin matar el contraste (clave del look claymation). */}
+      <directionalLight position={[-5, 4, -6]} intensity={0.22} color={ATMOSFERA.relleno} />
+
+      {/* La alfombra de suelo + el anillo de contacto: posan el diorama en un
+          piso en vez de dejarlo a la deriva sobre el color de fondo. */}
+      <SombraContacto
+        pos={[0, piso + 0.008, 0]}
+        radio={zoom * 0.68}
+        color={c.alfombra}
+        opacidad={0.5}
+        orden={1}
+      />
+      <SombraContacto
+        pos={[0, piso + 0.02, 0]}
+        radio={zoom * 0.4}
+        color={ATMOSFERA.sombra}
+        opacidad={0.3}
+        orden={2}
+      />
 
       {children}
 
@@ -69,7 +137,7 @@ function Contenido({
         </group>
       ))}
 
-      <AbejaEscena foco={foco} entrando animo={animo} energia={energia} reducedMotion={reducedMotion} />
+      <AbejaEscena foco={foco} entrando animo={animo} energia={energia} reducedMotion={reducedMotion} piso={piso} />
 
       <OrbitControls
         ref={controls}
@@ -92,7 +160,7 @@ function Contenido({
 
 export default function EscenaBase3D({
   params, hotspots, entrada, tinte, reducedMotion,
-  onHotspot, cielo, animo = 'sereno', energia = 1, camara, children,
+  onHotspot, cielo, animo = 'sereno', energia = 1, camara, piso = 0, children,
 }) {
   const [listo, setListo] = useState(false);
   const zoom = entrada?.zoom ?? 6.5;
@@ -117,6 +185,7 @@ export default function EscenaBase3D({
           cielo={cielo}
           animo={animo}
           energia={energia}
+          piso={piso}
         >
           {children}
         </Contenido>

--- a/src/visual/mundo3d/escenas/EscenaCutaway.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCutaway.jsx
@@ -233,6 +233,7 @@ export default function EscenaCutaway(props) {
       {...props}
       cielo={cielo}
       entrada={{ ...props.entrada, centro: [0, alto * 0.2, 0.6] }}
+      piso={-alto / 2}
     >
       <Diorama params={props.params} reducedMotion={props.reducedMotion} />
     </EscenaBase3D>

--- a/src/visual/mundo3d/escenas/SombraContacto.jsx
+++ b/src/visual/mundo3d/escenas/SombraContacto.jsx
@@ -1,0 +1,52 @@
+/*
+ * SombraContacto — la sombra de contacto FALSA (AO barato) del framework 3D.
+ *
+ * Los DRs de auditoría 3D (B5/B6, 2026-07-11) piden que los mundos dejen de
+ * verse "a la deriva" SIN pagar shadow-maps reales en teléfono. Esto es el
+ * truco claymation clásico: un plano horizontal con un degradado radial que
+ * se desvanece a transparente. Una sola CanvasTexture (128px, cacheada a nivel
+ * de módulo, blanca → tintable con `color`) sirve para TODO: la alfombra de
+ * suelo bajo el diorama, el anillo de sombra que lo "posa", y la sombrita que
+ * persigue a la abeja. Cero luces extra, cero render targets, cero por-frame
+ * (salvo quien mueva el mesh vía `refExt`, como hace useEntradaAbeja).
+ *
+ * `depthWrite: false` + `renderOrder` para que los velos se apilen sin pelear
+ * por el z-buffer; el depth-TEST queda activo, así el diorama los ocluye
+ * correctamente cuando corresponde.
+ */
+import * as THREE from 'three';
+
+let _tex = null;
+function texturaRadial() {
+  if (!_tex) {
+    const c = document.createElement('canvas');
+    c.width = 128;
+    c.height = 128;
+    const g = c.getContext('2d');
+    const grad = g.createRadialGradient(64, 64, 6, 64, 64, 62);
+    grad.addColorStop(0, 'rgba(255,255,255,1)');
+    grad.addColorStop(0.55, 'rgba(255,255,255,0.45)');
+    grad.addColorStop(1, 'rgba(255,255,255,0)');
+    g.fillStyle = grad;
+    g.fillRect(0, 0, 128, 128);
+    _tex = new THREE.CanvasTexture(c);
+  }
+  return _tex;
+}
+
+export function SombraContacto({
+  refExt, pos = [0, 0, 0], radio = 0.5, color = '#2e2012', opacidad = 0.35, orden = 2,
+}) {
+  return (
+    <mesh ref={refExt} position={pos} rotation={[-Math.PI / 2, 0, 0]} renderOrder={orden}>
+      <planeGeometry args={[radio * 2, radio * 2]} />
+      <meshBasicMaterial
+        map={texturaRadial()}
+        color={color}
+        transparent
+        opacity={opacidad}
+        depthWrite={false}
+      />
+    </mesh>
+  );
+}

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -21,20 +21,27 @@ import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaAngelita } from '../../creatures/AbejaAngelita.jsx';
+import { SombraContacto } from './SombraContacto.jsx';
 
 /**
- * Devuelve `{ ref, caraRef }` para colgar del `<group>` de la abeja y de su cara
- * (para el volteo). Corre `useFrame` (debe usarse DENTRO de un `<Canvas>`).
+ * Devuelve `{ ref, caraRef, sombraRef }` para colgar del `<group>` de la abeja,
+ * de su cara (para el volteo) y de su sombra de contacto (el blob que la sigue
+ * por el piso — auditoría 3D: la abeja no debe volar "a la deriva").
+ * Corre `useFrame` (debe usarse DENTRO de un `<Canvas>`).
  *
  * @param {THREE.Vector3} foco  a dónde va la abeja (hotspot activo o centro).
  * @param {object} [opts]
  * @param {boolean} [opts.entrando=true]  entrando = se posa junto al foco; si no, ronda.
  * @param {number}  [opts.energia=1]      0..1 — vivacidad del vuelo (de la salud real).
  * @param {boolean} [opts.reducedMotion=false]  congela el vaivén a un fotograma.
+ * @param {number}  [opts.piso=0]  y del suelo donde se proyecta la sombra.
  */
-export function useEntradaAbeja(foco, { entrando = true, energia = 1, reducedMotion = false } = {}) {
+export function useEntradaAbeja(foco, {
+  entrando = true, energia = 1, reducedMotion = false, piso = 0,
+} = {}) {
   const ref = useRef(null);
   const caraRef = useRef(null);
+  const sombraRef = useRef(null);
   const prevX = useRef(foco.x);
   useFrame((state) => {
     if (!ref.current) return;
@@ -55,8 +62,17 @@ export function useEntradaAbeja(foco, { entrando = true, energia = 1, reducedMot
       if (Math.abs(vx) > 0.0015) caraRef.current.style.transform = `scaleX(${vx < 0 ? -1 : 1})`;
       prevX.current = ref.current.position.x;
     }
+    // La sombra de contacto la sigue por el piso: más alto vuela, más ancha y
+    // más tenue (peso visual sin shadow-maps). Mismo frame, cero loops extra.
+    if (sombraRef.current) {
+      const pos = ref.current.position;
+      const h = Math.max(0, pos.y - piso);
+      sombraRef.current.position.set(pos.x, piso + 0.03, pos.z);
+      sombraRef.current.scale.setScalar(1 + h * 0.15);
+      sombraRef.current.material.opacity = Math.max(0.06, 0.3 - h * 0.06);
+    }
   });
-  return { ref, caraRef };
+  return { ref, caraRef, sombraRef };
 }
 
 /**
@@ -64,18 +80,32 @@ export function useEntradaAbeja(foco, { entrando = true, energia = 1, reducedMot
  * dibuja el cuerpo (`AbejaAngelita`) como billboard `<Html>`. Cualquier arquetipo
  * la coloca con `<AbejaEscena foco=… animo=… energia=… reducedMotion=… />`.
  */
-export function AbejaEscena({ foco, entrando = true, animo = 'sereno', energia = 1, reducedMotion = false }) {
-  const { ref, caraRef } = useEntradaAbeja(foco, { entrando, energia, reducedMotion });
+export function AbejaEscena({
+  foco, entrando = true, animo = 'sereno', energia = 1, reducedMotion = false, piso = 0,
+}) {
+  const { ref, caraRef, sombraRef } = useEntradaAbeja(foco, {
+    entrando, energia, reducedMotion, piso,
+  });
   const size = 40 + Math.round(energia * 12);
   return (
-    <group ref={ref} position={[foco.x + 0.45, foco.y + 0.85, foco.z + 0.6]}>
-      <Html center distanceFactor={7} zIndexRange={[40, 10]}>
-        <div className="mundo-abeja" aria-hidden="true">
-          <div ref={caraRef} className="mundo-abeja__cara">
-            <AbejaAngelita size={size} animo={animo} energia={energia} animated={!reducedMotion} />
+    <>
+      <group ref={ref} position={[foco.x + 0.45, foco.y + 0.85, foco.z + 0.6]}>
+        <Html center distanceFactor={7} zIndexRange={[40, 10]}>
+          <div className="mundo-abeja" aria-hidden="true">
+            <div ref={caraRef} className="mundo-abeja__cara">
+              <AbejaAngelita size={size} animo={animo} energia={energia} animated={!reducedMotion} />
+            </div>
           </div>
-        </div>
-      </Html>
-    </group>
+        </Html>
+      </group>
+      {/* Su sombra: hermana (NO hija) del group — vive en el piso, no vuela. */}
+      <SombraContacto
+        refExt={sombraRef}
+        pos={[foco.x + 0.45, piso + 0.03, foco.z + 0.6]}
+        radio={0.3}
+        opacidad={0.24}
+        orden={3}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Qué arregla

Bug #1 de los DRs de auditoría 3D (juego + UX, 2026-07-11): **los mundos 3D se ven planos y a la deriva**. `EscenaBase3D` (base de TODOS los arquetipos) solo tenía hemisferio+ambiente — sin luz direccional, sin sombras, sin niebla — y cada escena fijaba su propio cielo frío, incoherente con el valle (PBR dorado). Entrar a un mundo se sentía como un downgrade (hallazgos B5, B6, S7).

## Cómo (todo en la base → todos los mundos suben de golpe)

- **Sol de hora dorada** (`#ffd79a`, misma dirección `[6,9,4]` que el valle) + **relleno frío tenue** (`#9db8d9`, opuesto): forma y volumen en los Lambert mate (claymation) sin cambiar ningún material de escena.
- **Niebla sutil** (arranca detrás del diorama, se funde con la niebla dorada del valle): profundidad atmosférica sin lavar el primer plano.
- **Cohesión valle↔mundo**: el `cielo` propio de cada arquetipo ya no reemplaza la atmósfera — se **mezcla 60% hacia la paleta dorada** del valle. Cada mundo conserva un tinte de identidad.
- **`SombraContacto` nuevo**: AO fake — una sola `CanvasTexture` radial de 128px cacheada a nivel de módulo, tintable. Alfombra de suelo + anillo de contacto bajo el diorama + **sombrita que persigue a la abeja** por el piso (actualizada en su `useFrame` existente, cero loops nuevos). **Cero shadow-maps, cero render targets** — apto teléfono.
- Bonus B11: `foco` memoizado (antes: `Vector3` nuevo por render en el hilo caliente).
- `piso` prop (default 0): solo Cutaway lo pasa (`-alto/2`, su bloque centra en y=0).

## Qué NO toca

Navegación, `mundoData`, geometría/materiales de las escenas individuales (única edición: 1 línea en Cutaway para el nivel de piso).

## Duras verificadas

- Self-contained (textura generada en canvas, cero assets remotos)
- three sigue perezoso en `vendor-three`
- `prefers-reduced-motion`: luces/niebla estáticas; la sombra de la abeja va en el frame loop ya existente (demand)
- Móvil: 2 direccionales extra sobre Lambert + 3 planos transparentes = costo despreciable
- `npm run build` verde (2m57s)

DRs: `Chagra-strategy/ops/DR-AUDIT-JUEGO-3D-2026-07-11.md` (B5, B6, B11, S7) + `DR-AUDIT-UX-CAMPESINO-AGENTE-3D-2026-07-11.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)