### PR TITLE
fix(mundo3d): caída digna al 2D en carga colgada + coach-mark del primer ingreso sin voz

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -50,6 +50,8 @@ import Mundo, {
   useNavegacionMundos,
   TransicionMundo,
 } from '../visual/mundo3d/index.js';
+/* Coach-mark del primer ingreso (visual, NO depende de la voz — iOS la muda). */
+import CoachMarkToque from '../visual/mundo3d/CoachMarkToque.jsx';
 
 // La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso.
 const Valle3D = lazy(() => import('./valle/Valle3D'));
@@ -271,6 +273,9 @@ export default function EntradaValle3D({ onBack }) {
             />
           ))}
       </div>
+
+      {/* ── Onboarding de 3 s SIN voz: pista táctil del primer ingreso. ── */}
+      {!nav.enMundo && <CoachMarkToque reducedMotion={reducedMotion} />}
 
       {/* ── El MUNDO abierto: el framework monta la escena (3D perezoso o su
               2D digno) con su miga "‹ El valle" siempre visible. ── */}

--- a/src/visual/mundo3d/CoachMarkToque.jsx
+++ b/src/visual/mundo3d/CoachMarkToque.jsx
@@ -1,0 +1,78 @@
+/*
+ * CoachMarkToque — el onboarding de 3 segundos SIN voz (B2/B3 del DR de juego,
+ * SPEC-UX-04 del DR de UX campesino).
+ *
+ * Hoy toda la guía del primer ingreso va por `speechSynthesis`, que iOS Safari
+ * bloquea sin gesto de usuario (y que cualquier teléfono en silencio no suena).
+ * Este coach-mark es la pista VISUAL que no depende del audio: un pulso sobre
+ * la zona de los lugares + "Toque un lugar para entrar".
+ *
+ *   · Solo el PRIMER ingreso (localStorage `chagra:coach:valle-toque:v1`).
+ *   · Se descarta al primer toque/tecla o solo, a los ~4 s.
+ *   · `prefers-reduced-motion` (o la prop) → anillo ESTÁTICO, sin pulso.
+ *   · `pointer-events: none`: jamás roba el toque que está invitando a dar.
+ *   · Autocontenido y three-free: DOM + CSS propio, cero assets remotos.
+ *
+ * Copy en español Colombia (usted); si se productiza, migra a messages.js
+ * (ADR-050).
+ */
+import { useEffect, useState } from 'react';
+import './coachMark.css';
+
+const LS_KEY = 'chagra:coach:valle-toque:v1';
+export const COACH_TOQUE_MS = 4200;
+
+function yaVisto() {
+  if (typeof window === 'undefined') return true;
+  try {
+    return window.localStorage.getItem(LS_KEY) === '1';
+  } catch {
+    return false; // sin storage (modo privado): mostrarlo igual, es efímero
+  }
+}
+
+function marcarVisto() {
+  try {
+    window.localStorage.setItem(LS_KEY, '1');
+  } catch {
+    /* sin storage no pasa nada: solo se repetiría la próxima vez */
+  }
+}
+
+export default function CoachMarkToque({
+  reducedMotion = false,
+  texto = 'Toque un lugar para entrar',
+}) {
+  const [visible, setVisible] = useState(() => !yaVisto());
+
+  useEffect(() => {
+    if (!visible) return undefined;
+    const cerrar = () => {
+      marcarVisto();
+      setVisible(false);
+    };
+    // El primer gesto (el que el propio coach pide) lo descarta; si no llega,
+    // se despide solo — es una pista, no un tutorial que estorba.
+    const t = setTimeout(cerrar, COACH_TOQUE_MS);
+    window.addEventListener('pointerdown', cerrar, { capture: true });
+    window.addEventListener('keydown', cerrar, { capture: true });
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener('pointerdown', cerrar, { capture: true });
+      window.removeEventListener('keydown', cerrar, { capture: true });
+    };
+  }, [visible]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className={`coach-toque${reducedMotion ? ' coach-toque--calmo' : ''}`}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="coach-toque__pulso" aria-hidden="true" />
+      <p className="coach-toque__txt">{texto}</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -13,26 +13,61 @@
  * Nada de lógica de negocio adentro: solo lee datos y elige arquetipo. Sumar un
  * mundo = una entrada en `mundoData.js`, sin tocar este archivo.
  */
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { resolverMundo, tinteDeMundo, tituloDeMundo, emojiDeMundo } from './resolverMundo.js';
 import Mundo2D from './Mundo2D.jsx';
 import './mundo.css';
 
 /* Los dioramas 3D se cargan PEREZOSO: three/@react-three viven en su propio
-   chunk (`vendor-three`, vite.config), fuera del bundle base. */
-const ESCENAS_3D = {
-  cutaway: lazy(() => import('./escenas/EscenaCutaway.jsx')),
-  flujo: lazy(() => import('./escenas/EscenaFlujo.jsx')),
-  recinto: lazy(() => import('./escenas/EscenaRecinto.jsx')),
-  estratos: lazy(() => import('./escenas/EscenaEstratos.jsx')),
-  valle: lazy(() => import('./escenas/EscenaValle.jsx')),
+   chunk (`vendor-three`, vite.config), fuera del bundle base. Los importadores
+   viven aparte de los `lazy` para poder REINTENTAR con un import() fresco
+   (un `lazy` cachea su promesa para siempre — colgada incluida). */
+const IMPORTA_ESCENA = {
+  cutaway: () => import('./escenas/EscenaCutaway.jsx'),
+  flujo: () => import('./escenas/EscenaFlujo.jsx'),
+  recinto: () => import('./escenas/EscenaRecinto.jsx'),
+  estratos: () => import('./escenas/EscenaEstratos.jsx'),
+  valle: () => import('./escenas/EscenaValle.jsx'),
 };
+const ESCENAS_3D = Object.fromEntries(
+  Object.entries(IMPORTA_ESCENA).map(([k, importa]) => [k, lazy(importa)]),
+);
 
-function MundoCargando({ tinte }) {
+/* Cuánto esperamos el chunk 3D antes de la CAÍDA DIGNA al 2D. Con señal
+   intermitente (el caso normal del campo) un fetch colgado NO lanza error —
+   el ErrorBoundary nunca lo ve; este timeout sí. */
+export const CARGA_3D_TIMEOUT_MS = 9000;
+
+function MundoCargando({ tinte, onTimeout }) {
+  /* El fallback vive SOLO mientras Suspense espera el chunk: si el chunk llega,
+     el desmonte limpia el timer; si no llega, avisa al host para caer al 2D. */
+  useEffect(() => {
+    if (!onTimeout) return undefined;
+    const t = setTimeout(onTimeout, CARGA_3D_TIMEOUT_MS);
+    return () => clearTimeout(t);
+  }, [onTimeout]);
   return (
-    <div className="mundo-cargando" style={{ '--m-tinte': (tinte && tinte[0]) || '#3f8f4e' }}>
+    <div
+      className="mundo-cargando"
+      style={{ '--m-tinte': (tinte && tinte[0]) || '#3f8f4e' }}
+      role="status"
+    >
       <div className="mundo-cargando__pulso" />
       <p>Levantando el mundo…</p>
+    </div>
+  );
+}
+
+/* Aviso de la caída digna: nunca "error", siempre un camino de vuelta. */
+function AvisoCaida3D({ tinte, onReintentar }) {
+  return (
+    <div className="mundo-caida" role="status" style={{ '--m-tinte': (tinte && tinte[0]) || '#3f8f4e' }}>
+      <p className="mundo-caida__txt">
+        El mundo en 3D no bajó con esta señal. Le mostramos la versión ligera; la finca sigue completa.
+      </p>
+      <button type="button" className="mundo-caida__btn" onClick={onReintentar}>
+        Reintentar 3D
+      </button>
     </div>
   );
 }
@@ -53,21 +88,64 @@ function MigaVolver({ onSalir, mundoId }) {
   );
 }
 
-export default function Mundo({
+function MundoInterno({
   mundoId, tier = 'alto', reducedMotion = false, onHotspot, onSalir, animo = 'sereno', energia = 1,
 }) {
+  /* CAÍDA DIGNA (BUG-UX-05 / SPEC-UX-05): si el chunk 3D no baja en
+     CARGA_3D_TIMEOUT_MS, caemos al espejo 2D del mundo. `intento` fabrica un
+     `lazy` nuevo al reintentar (import() fresco, no la promesa colgada). */
+  const [caido3d, setCaido3d] = useState(false);
+  const [intento, setIntento] = useState(0);
+
   const plan = resolverMundo(mundoId, tier);
   const tinte = tinteDeMundo(mundoId);
+
+  const alTimeout3D = useCallback(() => setCaido3d(true), []);
+  const reintentar3D = useCallback(() => {
+    setIntento((n) => n + 1);
+    setCaido3d(false);
+  }, []);
+
+  const Escena = useMemo(() => {
+    if (plan.modo !== '3d') return null;
+    const importa = IMPORTA_ESCENA[plan.escena];
+    if (!importa) return null;
+    // 1er intento: el lazy compartido (cachea el chunk). Reintentos: lazy fresco.
+    return intento === 0 ? ESCENAS_3D[plan.escena] : lazy(importa);
+  }, [plan.modo, plan.escena, intento]);
 
   // Sin escena o mundo ausente: el host navega al 2D real (no montamos nada).
   if (plan.modo === 'ausente' || plan.modo === 'ruta') return null;
 
+  if (plan.modo === '3d' && caido3d) {
+    /* El espejo 2D del mismo mundo (el plan que este equipo vería en tier
+       'bajo'): la lección sigue, la señal decide después. */
+    const espejo = resolverMundo(mundoId, 'bajo');
+    return (
+      <div className="mundo-root" data-dim="2d" data-mundo={mundoId} data-caida3d="1">
+        {espejo.modo === '2d' && (
+          <Mundo2D
+            escena={espejo.escena}
+            motivo={espejo.motivo}
+            entrada={espejo.entrada}
+            tinte={tinte}
+            reducedMotion={reducedMotion}
+            onHotspot={onHotspot}
+            animo={animo}
+            energia={energia}
+          />
+        )}
+        <AvisoCaida3D tinte={tinte} onReintentar={reintentar3D} />
+        <MigaVolver onSalir={onSalir} mundoId={mundoId} />
+      </div>
+    );
+  }
+
   if (plan.modo === '3d') {
-    const Escena = ESCENAS_3D[plan.escena];
     if (!Escena) return null;
     return (
       <div className="mundo-root" data-dim="3d" data-mundo={mundoId}>
-        <Suspense fallback={<MundoCargando tinte={tinte} />}>
+        <Suspense fallback={<MundoCargando tinte={tinte} onTimeout={alTimeout3D} />}>
           <Escena
             params={plan.entrada.params}
             hotspots={plan.entrada.hotspots}
@@ -101,4 +179,10 @@ export default function Mundo({
       <MigaVolver onSalir={onSalir} mundoId={mundoId} />
     </div>
   );
+}
+
+/* El host público: `key={mundoId}` resetea la caída/reintentos al cambiar de
+   mundo (que un timeout viejo no persiga al mundo siguiente). */
+export default function Mundo(props) {
+  return <MundoInterno key={props.mundoId} {...props} />;
 }

--- a/src/visual/mundo3d/coachMark.css
+++ b/src/visual/mundo3d/coachMark.css
@@ -1,0 +1,88 @@
+/*
+ * coachMark.css — estilos del coach-mark del primer ingreso (CoachMarkToque).
+ * Archivo propio (no mundo.css) para no chocar con otros frentes de trabajo.
+ * Autocontenido: cero imágenes/fuentes externas; solo transform/opacity.
+ */
+
+.coach-toque {
+  position: absolute;
+  inset: 0;
+  z-index: 30; /* sobre la escena, debajo del viaje (40) */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.9rem;
+  pointer-events: none; /* jamás roba el toque que está invitando a dar */
+  animation: coach-toque-entra 0.5s ease-out both;
+}
+
+/* El pulso: un anillo que respira sobre la zona de los lugares del valle
+   (los landmarks viven hacia el centro-bajo del encuadre). */
+.coach-toque__pulso {
+  position: relative;
+  width: 58px;
+  height: 58px;
+  margin-top: 12vh;
+  border: 3px solid #fffdf7;
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 2px rgba(42, 32, 22, 0.35),
+    inset 0 0 0 2px rgba(42, 32, 22, 0.35);
+  animation: coach-toque-late 1.6s ease-in-out infinite;
+}
+.coach-toque__pulso::after {
+  content: '';
+  position: absolute;
+  inset: -3px;
+  border: 3px solid rgba(255, 253, 247, 0.8);
+  border-radius: 50%;
+  animation: coach-toque-onda 1.6s ease-out infinite;
+}
+
+.coach-toque__txt {
+  margin: 0;
+  max-width: min(86vw, 22rem);
+  padding: 0.55em 1.1em;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.3;
+  text-align: center;
+  color: #fffdf7;
+  background: rgba(42, 32, 22, 0.78);
+  border-radius: 999px;
+  text-shadow: 0 1px 4px rgba(10, 20, 10, 0.4);
+}
+
+@keyframes coach-toque-entra {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes coach-toque-late {
+  0%, 100% { transform: scale(0.9); }
+  50% { transform: scale(1.05); }
+}
+@keyframes coach-toque-onda {
+  0% { transform: scale(1); opacity: 0.9; }
+  100% { transform: scale(1.9); opacity: 0; }
+}
+
+/* Calma: anillo estático, sin pulso ni onda (por media query o por prop). */
+@media (prefers-reduced-motion: reduce) {
+  .coach-toque,
+  .coach-toque__pulso {
+    animation: none;
+  }
+  .coach-toque__pulso::after {
+    animation: none;
+    opacity: 0;
+  }
+}
+.coach-toque--calmo,
+.coach-toque--calmo .coach-toque__pulso {
+  animation: none;
+}
+.coach-toque--calmo .coach-toque__pulso::after {
+  animation: none;
+  opacity: 0;
+}

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -101,6 +101,53 @@
   50% { transform: scale(1); opacity: 1; }
 }
 
+/* ── Caída digna: el chunk 3D no bajó (señal intermitente) → espejo 2D ──── */
+.mundo-caida {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 6;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.8rem;
+  padding: 0.6rem 0.8rem;
+  color: #2a2016;
+  background: rgba(255, 251, 242, 0.95);
+  border: 1px solid color-mix(in srgb, var(--m-tinte, #3f8f4e) 45%, transparent);
+  border-radius: 12px;
+  box-shadow: 0 4px 14px rgba(40, 30, 10, 0.18);
+}
+.mundo-caida__txt {
+  margin: 0;
+  flex: 1 1 14ch;
+  min-width: 0;
+  font-size: 0.85rem;
+  line-height: 1.35;
+}
+.mundo-caida__btn {
+  flex: none;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0.45em 1.1em;
+  font: inherit;
+  font-weight: 700;
+  color: #fffdf7;
+  background: var(--m-tinte, #3f8f4e);
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.mundo-caida__btn:focus-visible {
+  outline: 2px solid #2a2016;
+  outline-offset: 2px;
+}
+/* que el aviso no tape el final del espejo 2D en pantallas de 320px */
+.mundo-root[data-caida3d='1'] .mundo2d {
+  padding-bottom: 7.5rem;
+}
+
 /* ── La miga: volver al valle + dónde-estoy (consistente en todo mundo) ── */
 .mundo-miga {
   position: absolute;


### PR DESCRIPTION
## Qué arregla (2 bugs de las auditorías 3D del 2026-07-11)

### 1. Spinner infinito → caída digna al 2D (BUG-UX-05 / SPEC-UX-05)
`Levantando el mundo…` giraba para siempre si el chunk `vendor-three` no bajaba (señal intermitente — el caso normal del campo). El ErrorBoundary no atrapa un fetch colgado: no es un throw, es una promesa que nunca resuelve.

- `Mundo.jsx`: timeout de **9 s** en el fallback de Suspense → cae al **espejo 2D del mismo mundo** (`resolverMundo(mundoId, 'bajo')`) con aviso sobrio en usted-CO ("Le mostramos la versión ligera; la finca sigue completa") + botón **Reintentar 3D** (≥44px táctil).
- El reintento fabrica un `lazy` con `import()` fresco — no reusa la promesa colgada que `React.lazy` cachea para siempre.
- `key={mundoId}` en el host: la caída/reintentos de un mundo no persiguen al siguiente.

### 2. Onboarding de 3 s SIN voz (B2/B3 · SPEC-UX-04)
Toda la guía del primer ingreso iba por `speechSynthesis`, muda en iOS (bloqueo de autoplay sin gesto) y en cualquier teléfono en silencio.

- **`CoachMarkToque.jsx` (nuevo, autocontenido, three-free)**: pulso visual + "Toque un lugar para entrar". Se descarta al primer toque/tecla o solo a los ~4 s; una sola vez por equipo (`localStorage chagra:coach:valle-toque:v1`); `prefers-reduced-motion` (media query **y** prop) = anillo estático; `pointer-events: none` (jamás roba el toque que invita a dar).
- CSS en archivo propio (`coachMark.css`) para no chocar con otros frentes.

## Alcance respetado
- **NO** se tocó `EscenaBase3D.jsx` ni las escenas; en `EntradaValle3D.jsx` solo el punto de montaje mínimo del coach-mark (import + 1 línea).
- Móvil 320px (aviso con flex-wrap + padding de resguardo), cero assets remotos, copy usted-CO sin voseo.

## Verificación
- `npm run build` verde (2m35s). Warnings de chunk >500 kB preexistentes (`vendor-three`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)