### PR TITLE
fix(valle3d): piso táctil ≥44px + etiquetas por foco/proximidad con occlude y anti-colisión

### DIFF
--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -11,7 +11,9 @@
  * useFrame; `reducedMotion` congela el vaivén a un fotograma digno.
  *
  * Los 4 sí-o-sí viven en el espacio:
- *   · MUNDOS  → landmarks navegables (MundoLugar) con etiqueta accesible.
+ *   · MUNDOS  → landmarks navegables (MundoLugar, geometría) con etiquetas
+ *               accesibles de tamaño táctil FIJO en píxeles (RotulosLugares):
+ *               por foco/proximidad, con occlude y anti-colisión en pantalla.
  *   · ALERTA  → Beacon pulsante anclado sobre el mundo 'suelo' (la cosa del día).
  *   · COMPAÑERO → Angelita, la abeja (visual-lib) es el avatar-jugador: vuela
  *                por el valle y ENTRA al mundo que se toca; su ánimo/energía
@@ -31,6 +33,7 @@ import { Mariposa } from '../../visual/creatures/Mariposa.jsx';
 import { Escarabajo } from '../../visual/creatures/Escarabajo.jsx';
 import { Lombriz } from '../../visual/creatures/Lombriz.jsx';
 import AnimalesDeFinca from './animales.jsx';
+import './rotulosValle3D.css';
 import {
   MUNDOS_VALLE,
   MUNDO_VALLE_BY_ID,
@@ -91,7 +94,7 @@ function colorSueloEnZ(z, alto, nocturno, out) {
       según el piso térmico de cada franja (páramo frío arriba → tierra caliente
       abajo). El color sale de PISOS_TERMICOS: franjas de altitud legibles, con
       la cresta apenas más clara para dar relieve. ── */
-function Terreno({ nocturno }) {
+function Terreno({ nocturno, innerRef }) {
   const geo = useMemo(() => {
     const g = new THREE.PlaneGeometry(34, 34, 56, 56);
     g.rotateX(-Math.PI / 2);
@@ -115,7 +118,7 @@ function Terreno({ nocturno }) {
     return g;
   }, [nocturno]);
   return (
-    <mesh geometry={geo} receiveShadow>
+    <mesh ref={innerRef} geometry={geo} receiveShadow>
       <meshStandardMaterial vertexColors flatShading roughness={1} metalness={0} />
     </mesh>
   );
@@ -124,7 +127,7 @@ function Terreno({ nocturno }) {
 /* ── La cordillera de páramo al fondo: conos pálidos que EMERGEN de la ladera
       alta (perspectiva aérea). Su base se posa sobre el terreno del páramo
       (que ya subió a ~5) y las cumbres coronan la escena. ── */
-function Cordillera({ color }) {
+function Cordillera({ color, innerRef }) {
   const picos = useMemo(
     () => [
       { x: -9, z: -15.5, h: 7, r: 5, base: 4.2 },
@@ -135,7 +138,7 @@ function Cordillera({ color }) {
     [],
   );
   return (
-    <group>
+    <group ref={innerRef}>
       {picos.map((p, i) => (
         <mesh key={i} position={[p.x, p.base + p.h / 2, p.z]}>
           <coneGeometry args={[p.r, p.h, 6]} />
@@ -491,9 +494,9 @@ function CriaturasValle({ reducedMotion }) {
   );
 }
 
-/* ── Un mundo como LUGAR navegable: su geometría + una etiqueta accesible que,
-      al tocarse, viaja hasta él (la cámara) y lo selecciona. ── */
-function MundoLugar({ mundo, activo, onEntrar, reducedMotion }) {
+/* ── Un mundo como LUGAR navegable: SOLO su geometría. Su etiqueta táctil vive
+      en <RotulosLugares/> (piso en píxeles + foco/proximidad + anti-colisión). ── */
+function MundoLugar({ mundo, reducedMotion }) {
   const y = alturaTerreno(mundo.pos[0], mundo.pos[2]);
   return (
     <group position={[mundo.pos[0], y, mundo.pos[2]]} scale={mundo.escala}>
@@ -502,23 +505,158 @@ function MundoLugar({ mundo, activo, onEntrar, reducedMotion }) {
       ) : (
         <LandmarkGeom tipo={mundo.tipo} tinte={mundo.tinte} reducedMotion={reducedMotion} />
       )}
-      <Html center distanceFactor={11} position={[0, 1.7, 0]} zIndexRange={[20, 0]}>
+    </group>
+  );
+}
+
+/* ── Las etiquetas de los lugares, con juicio (SPEC-UX-01 + S6/B4 de los DRs):
+ *   · SIN `distanceFactor` → tamaño en píxeles CONSTANTE: el piso táctil ≥44px
+ *     NO depende de la distancia de la cámara (WCAG 2.5.5/2.5.8);
+ *   · por FOCO/PROXIMIDAD: solo la etiqueta apuntada (la más cercana al centro
+ *     del encuadre) o la del mundo activo muestra su nombre completo; las demás
+ *     se calman a un punto-chip con su emoji y tinte — menos-pero-legible;
+ *   · ANTI-COLISIÓN en pantalla: si dos rótulos se pisan, cede el más lejano
+ *     del centro (data-modo='oculto'); la alerta del día siempre gana su lugar;
+ *   · `occlude` contra el terreno y la cordillera: un rótulo detrás de la loma
+ *     no la atraviesa (data-tapado='1').
+ * Todo se escribe imperativo sobre `dataset` (cero re-render por frame); el CSS
+ * de los modos vive en rotulosValle3D.css. Los botones siguen entrando a los
+ * mundos en cualquiera de los dos modos visibles — la navegación no cambia. ── */
+const _proj = new THREE.Vector3();
+
+function RotulosLugares({ mundos, focoId, onEntrar, occluders }) {
+  const botones = useRef({});
+  const tapados = useRef({});
+  const plena = useRef(null);
+  const tick = useRef(0);
+
+  // Anclas en el mundo: misma altura que tenía la etiqueta original (1.7 dentro
+  // del group escalado del landmark → 1.7 × escala en coordenadas del valle).
+  const anclas = useMemo(
+    () =>
+      mundos.map((m) => ({
+        m,
+        pos: new THREE.Vector3(
+          m.pos[0],
+          alturaTerreno(m.pos[0], m.pos[2]) + 1.7 * (m.escala || 1),
+          m.pos[2],
+        ),
+      })),
+    [mundos],
+  );
+
+  // La alerta del día (el faro) siempre se reserva su espacio en pantalla.
+  const anclaAlerta = useMemo(() => {
+    const a = MUNDO_VALLE_BY_ID[COSA_DEL_DIA.anclaMundo];
+    if (!a) return null;
+    return new THREE.Vector3(a.pos[0], alturaTerreno(a.pos[0], a.pos[2]) + 2.7, a.pos[2]);
+  }, []);
+
+  useFrame(({ camera, size }) => {
+    // ~12 pasadas/s alcanzan para rótulos; corre en el PRIMER frame (importa
+    // con frameloop='demand' de reduced-motion, que renderiza pocos frames).
+    if (tick.current++ % 5 !== 0) return;
+
+    const enPantalla = (v) => {
+      _proj.copy(v).project(camera);
+      return {
+        x: (_proj.x * 0.5 + 0.5) * size.width,
+        y: (0.5 - _proj.y * 0.5) * size.height,
+        detras: _proj.z > 1,
+      };
+    };
+
+    const pts = anclas.map(({ m, pos }) => {
+      const p = enPantalla(pos);
+      return {
+        id: m.id,
+        titulo: m.titulo || '',
+        ...p,
+        dc: Math.hypot(p.x - size.width / 2, p.y - size.height / 2),
+        elegible: !p.detras && !tapados.current[m.id],
+      };
+    });
+
+    // Foco/proximidad: manda el mundo activo; si no, la etiqueta más apuntada,
+    // con histéresis (solo cambia si otra queda 20% más centrada) anti-parpadeo.
+    let candidata = null;
+    if (focoId && pts.some((p) => p.id === focoId)) {
+      candidata = focoId;
+    } else {
+      const previa = pts.find((p) => p.id === plena.current && p.elegible);
+      const cercana = pts.filter((p) => p.elegible).sort((a, b) => a.dc - b.dc)[0];
+      candidata = previa && cercana && cercana.dc > previa.dc * 0.8 ? previa.id : (cercana?.id ?? null);
+    }
+    plena.current = candidata;
+
+    // Anti-colisión: la alerta primero, la plena después, los puntos por
+    // cercanía al centro; quien pisa un espacio ya tomado, cede.
+    const MARGEN = 8;
+    const tomados = [];
+    const rectoDe = (x, y, w, h) => ({
+      x0: x - w / 2 - MARGEN,
+      x1: x + w / 2 + MARGEN,
+      y0: y - h / 2 - MARGEN,
+      y1: y + h / 2 + MARGEN,
+    });
+    const pisa = (r) => tomados.some((o) => r.x0 < o.x1 && r.x1 > o.x0 && r.y0 < o.y1 && r.y1 > o.y0);
+    if (anclaAlerta) {
+      const a = enPantalla(anclaAlerta);
+      if (!a.detras) tomados.push(rectoDe(a.x, a.y, 64 + COSA_DEL_DIA.titulo.length * 9, 52));
+    }
+    const orden = [...pts].sort((a, b) =>
+      a.id === candidata ? -1 : b.id === candidata ? 1 : a.dc - b.dc,
+    );
+    for (const p of orden) {
+      let modo = 'oculto';
+      if (p.elegible) {
+        const esPlena = p.id === candidata;
+        const r = esPlena
+          ? rectoDe(p.x, p.y, 76 + p.titulo.length * 9, 48)
+          : rectoDe(p.x, p.y, 44, 44);
+        if (!pisa(r)) {
+          tomados.push(r);
+          modo = esPlena ? 'plena' : 'punto';
+        }
+      }
+      const btn = botones.current[p.id];
+      if (btn && btn.dataset.modo !== modo) btn.dataset.modo = modo;
+    }
+  });
+
+  return anclas.map(({ m, pos }) => (
+    <group key={m.id} position={pos.toArray()}>
+      <Html
+        center
+        zIndexRange={[20, 0]}
+        occlude={occluders}
+        onOcclude={(tapado) => {
+          tapados.current[m.id] = tapado;
+          const btn = botones.current[m.id];
+          if (btn) btn.dataset.tapado = tapado ? '1' : '0';
+          return null;
+        }}
+      >
         <button
+          ref={(el) => {
+            botones.current[m.id] = el;
+          }}
           type="button"
-          className={`valle-poi${activo ? ' valle-poi--activo' : ''}`}
-          style={{ '--poi-tinte': mundo.tinte[0] }}
+          data-modo={m.id === focoId ? 'plena' : 'punto'}
+          className={`valle-poi v3d-poi${focoId === m.id ? ' valle-poi--activo' : ''}`}
+          style={{ '--poi-tinte': m.tinte[0] }}
           onClick={(e) => {
             e.stopPropagation();
-            onEntrar(mundo.id);
+            onEntrar(m.id);
           }}
-          aria-label={`Viajar al mundo ${mundo.titulo}. ${mundo.lema}`}
+          aria-label={`Viajar al mundo ${m.titulo}. ${m.lema}`}
         >
-          <span className="valle-poi__emoji" aria-hidden="true">{mundo.emoji}</span>
-          <span className="valle-poi__txt">{mundo.titulo}</span>
+          <span className="valle-poi__emoji" aria-hidden="true">{m.emoji}</span>
+          <span className="valle-poi__txt">{m.titulo}</span>
         </button>
       </Html>
     </group>
-  );
+  ));
 }
 
 /* ── La cosa del día: un faro pulsante anclado sobre su mundo. Un SOLO destello.
@@ -552,10 +690,11 @@ function Beacon({ onAlerta, reducedMotion }) {
           <meshBasicMaterial color="#ffcf87" transparent opacity={0.4} />
         </mesh>
       </Float>
-      <Html center distanceFactor={10} position={[0, 2.7, 0]} zIndexRange={[30, 0]}>
+      {/* Sin distanceFactor: la alerta mantiene su tamaño táctil en píxeles. */}
+      <Html center position={[0, 2.7, 0]} zIndexRange={[30, 0]}>
         <button
           type="button"
-          className="valle-alerta"
+          className="valle-alerta v3d-alerta"
           onClick={(e) => {
             e.stopPropagation();
             onAlerta();
@@ -660,6 +799,11 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit }) {
 /* ── Contenido de la escena (dentro del Canvas). ── */
 function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion }) {
   const controls = useRef(null);
+  // Occluders de los rótulos: solo terreno + cordillera (raycast barato y es
+  // exactamente lo que las etiquetas no deben atravesar).
+  const terrenoRef = useRef(null);
+  const cordilleraRef = useRef(null);
+  const occluders = useMemo(() => [terrenoRef, cordilleraRef], []);
   const c = CLIMAS[clima];
   const foco = useMemo(() => {
     const m = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;
@@ -695,20 +839,20 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         <Stars radius={40} depth={20} count={900} factor={3} fade speed={reducedMotion ? 0 : 1} />
       )}
 
-      <Terreno nocturno={nocturno} />
-      <Cordillera color={nocturno ? '#3a4a63' : c.niebla} />
+      <Terreno nocturno={nocturno} innerRef={terrenoRef} />
+      <Cordillera color={nocturno ? '#3a4a63' : c.niebla} innerRef={cordilleraRef} />
       <Quebrada color={nocturno ? '#2a4a6a' : '#5fb2c9'} viva={c.lluviaViva} />
       <VegetacionPisos nocturno={nocturno} />
 
       {MUNDOS_VALLE.map((m) => (
-        <MundoLugar
-          key={m.id}
-          mundo={m}
-          activo={focoId === m.id}
-          onEntrar={onEntrar}
-          reducedMotion={reducedMotion}
-        />
+        <MundoLugar key={m.id} mundo={m} reducedMotion={reducedMotion} />
       ))}
+      <RotulosLugares
+        mundos={MUNDOS_VALLE}
+        focoId={focoId}
+        onEntrar={onEntrar}
+        occluders={occluders}
+      />
 
       <CriaturasValle reducedMotion={reducedMotion} />
       <Beacon onAlerta={onAlerta} reducedMotion={reducedMotion} />

--- a/src/mockups/valle/rotulosValle3D.css
+++ b/src/mockups/valle/rotulosValle3D.css
@@ -1,0 +1,88 @@
+/*
+ * rotulosValle3D.css — los MODOS de las etiquetas espaciales del valle 3D
+ * (Valle3D.jsx · RotulosLugares). Compone SOBRE .valle-poi/.valle-alerta sin
+ * redefinirlos (ese archivo es de la entrada; este viaja con el componente):
+ *
+ *   · piso táctil en píxeles: ≥44px reales (WCAG 2.5.5) — al quitar el
+ *     distanceFactor del <Html>, la cámara ya NO encoge estos tamaños;
+ *   · data-modo='plena'  → nombre completo (la apuntada o la del mundo activo);
+ *   · data-modo='punto'  → chip calmo de 44px con emoji + anillo del tinte;
+ *   · data-modo='oculto' → cedió su espacio (anti-colisión en pantalla);
+ *   · data-tapado='1'    → detrás del terreno (occlude): no atraviesa la loma.
+ *
+ * Autocontenido: cero imágenes/fuentes externas. Solo se transiciona
+ * opacity/visibility; prefers-reduced-motion las apaga. El texto plena hereda
+ * blanco sobre fondo oscuro translúcido (≥4.5:1 aun sobre cielo claro → AA).
+ */
+
+.v3d-poi {
+  position: relative;
+  min-width: 44px;
+  min-height: 44px;
+  transition: opacity 0.18s ease, visibility 0.18s ease;
+}
+
+/* Hit-slop: el área de toque es más generosa que lo visual (dedo de campo). */
+.v3d-poi::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 999px;
+}
+
+/* Punto-chip: menos-pero-legible. Emoji grande + anillo del tinte del mundo;
+   mismo botón, misma navegación — solo se calma lo visual. */
+.v3d-poi[data-modo='punto'] {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  gap: 0;
+  justify-content: center;
+  border: 2px solid var(--poi-tinte, #7fd08a);
+}
+.v3d-poi[data-modo='punto']::before,
+.v3d-poi[data-modo='punto'] .valle-poi__txt {
+  display: none;
+}
+.v3d-poi[data-modo='punto'] .valle-poi__emoji {
+  font-size: 1.35rem;
+}
+
+/* Cedió el espacio a un rótulo más cercano (anti-colisión), o quedó detrás
+   del terreno (occlude). visibility saca al botón del tab-order y del árbol
+   de accesibilidad mientras no se ve. */
+.v3d-poi[data-modo='oculto'],
+.v3d-poi[data-tapado='1'] {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Teclado: el rótulo enfocado SIEMPRE se muestra completo y visible
+   (estas reglas van de últimas para ganar a los modos de arriba). */
+.v3d-poi:focus-visible {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  width: auto;
+  height: auto;
+  gap: 0.4rem;
+  padding: 0.35rem 0.7rem 0.35rem 0.55rem;
+  outline: 3px solid #ffd68a;
+  outline-offset: 2px;
+}
+.v3d-poi:focus-visible .valle-poi__txt {
+  display: inline;
+}
+
+/* La alerta del día también con piso táctil real (sin distanceFactor). */
+.v3d-alerta {
+  min-width: 44px;
+  min-height: 48px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .v3d-poi {
+    transition: none;
+  }
+}

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -28,14 +28,20 @@
   opacity: 1;
 }
 
-/* ── Hotspot 3D: botón-billboard accesible sobre el diorama ─────────────── */
+/* ── Hotspot 3D: botón-billboard accesible sobre el diorama ───────────────
+      Piso táctil ≥44px en AMBOS ejes (WCAG 2.5.5: dedo de campo, con guante)
+      + hit-slop invisible que agranda el toque sin engordar lo visual. */
 .mundo-hotspot {
+  position: relative;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.4em;
-  padding: 0.34em 0.7em 0.34em 0.4em;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.4em 0.85em 0.4em 0.5em;
   font: inherit;
-  font-size: 0.82rem;
+  font-size: 0.95rem;
   font-weight: 600;
   color: #2a2016;
   background: rgba(255, 251, 242, 0.94);
@@ -46,15 +52,27 @@
   box-shadow: 0 3px 10px rgba(40, 30, 10, 0.22);
   transition: transform 0.16s ease, box-shadow 0.16s ease;
 }
+/* hit-slop: área de toque más generosa que la píldora visible */
+.mundo-hotspot::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 999px;
+}
 .mundo-hotspot:hover,
 .mundo-hotspot:focus-visible {
   transform: translateY(-2px) scale(1.04);
   box-shadow: 0 6px 16px rgba(40, 30, 10, 0.28);
   outline: none;
 }
+/* Activo: texto oscuro sobre tinte CLARO (≥4.5:1, AA) + doble anillo — la
+   señal no es solo color (BUG-UX-02). */
 .mundo-hotspot--activo {
-  background: var(--hs-tinte, #3f8f4e);
-  color: #fff;
+  background: color-mix(in srgb, var(--hs-tinte, #3f8f4e) 18%, #fffdf7);
+  color: #2a2016;
+  box-shadow:
+    0 3px 10px rgba(40, 30, 10, 0.22),
+    0 0 0 3px color-mix(in srgb, var(--hs-tinte, #3f8f4e) 45%, #2a2016);
 }
 .mundo-hotspot__emoji {
   font-size: 1.15em;
@@ -118,6 +136,9 @@
 }
 .mundo-miga__aqui {
   min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -130,7 +151,11 @@
 }
 .mundo-salir {
   flex: none;
-  padding: 0.4em 0.9em;
+  display: inline-flex;
+  align-items: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.4em 1em;
   font: inherit;
   font-weight: 600;
   color: #2a2016;
@@ -187,6 +212,8 @@
   display: inline-flex;
   align-items: center;
   gap: 0.4em;
+  min-width: 44px;
+  min-height: 44px;
   padding: 0.5em 0.9em;
   font: inherit;
   font-weight: 600;


### PR DESCRIPTION
## Qué arregla

**BUG-UX-01/SPEC-UX-01 + B4/S6** de los DRs de auditoría 3D (`DR-AUDIT-UX-CAMPESINO-AGENTE-3D-2026-07-11` y `DR-AUDIT-JUEGO-3D-2026-07-11`).

### 1. Táctil ≥44px con piso en píxeles
- Los rótulos del valle (`Valle3D.jsx`) pierden el `distanceFactor`: en drei 10.7.7, sin ese prop la escala CSS es exactamente 1 → **tamaño en píxeles constante** que la cámara NO encoge (antes: 44px nominales × ~0.54 al alejarse ≈ 24px). Aplica a los 8 lugares y a la alerta del día.
- `.v3d-poi`: mínimo 44×44px + hit-slop invisible de 6px (dedo de campo, con guante).
- `mundo.css`: `.mundo-hotspot` de ~24-26px a mínimo 44×44px + hit-slop y fuente 0.95rem; `.mundo2d__hotspot`, `.mundo-salir` y `.mundo-miga__aqui` a ≥44px (BUG-UX-07).
- De paso, `.mundo-hotspot--activo` deja el blanco-sobre-tinte que fallaba AA (3.6-4.0:1): ahora texto oscuro sobre tinte claro (≥4.5:1) + doble anillo como señal no-cromática (BUG-UX-02).

### 2. Etiquetas por foco/proximidad + anti-colisión
Nuevo `RotulosLugares` en `Valle3D.jsx` (las 8 etiquetas salen de `MundoLugar`, que queda solo con geometría):
- **Foco/proximidad**: solo la etiqueta apuntada (la más cercana al centro del encuadre, con histéresis anti-parpadeo) o la del mundo activo muestra el nombre completo; las demás se calman a un punto-chip de 44px con emoji + anillo del tinte. Menos-pero-legible en 320px.
- **Anti-colisión en pantalla**: greedy por prioridad (alerta del día → plena → puntos por cercanía); quien pisa un espacio ya tomado cede (`data-modo='oculto'`, `visibility:hidden` = fuera del tab-order y del árbol de a11y).
- **`occlude`** contra terreno + cordillera (refs explícitos, raycast acotado): un rótulo detrás de la loma no la atraviesa (`data-tapado`).
- Todo imperativo sobre `dataset` a ~12 pasadas/s: **cero re-render por frame**; corre desde el primer frame (compatible con `frameloop='demand'` de reduced-motion).
- **La navegación no cambia**: plena y punto son el mismo `<button>` con el mismo `onEntrar` y el mismo `aria-label`; el foco de teclado siempre muestra el rótulo completo y visible.

CSS de los modos en `rotulosValle3D.css` nuevo, importado por `Valle3D.jsx` (compone sobre `.valle-poi` sin tocar `entradaValle3D.css`, que es de otro carril).

## Alcance deliberadamente acotado
- **NO toca** `EscenaBase3D.jsx` ni `EntradaValle3D.jsx` (otros carriles en curso). Por eso el encogimiento por `distanceFactor` de los hotspots DENTRO de los mundos (`EscenaBase3D` L52) queda pendiente para ese carril — este PR les sube el piso base a 44px vía `mundo.css`, que ya elimina el caso medido de 24-26px a distancia nominal.

## Duras verificadas
- Self-contained: cero assets/fuentes externas.
- 320px: 1 etiqueta plena + chips de 44px + alerta; lo que se pisa, cede.
- Contraste AA: plena blanco sobre `rgba(12,22,28,.72)` ≈5.3:1 en el peor cielo; activo de mundo.css ahora ≥4.5:1.
- `prefers-reduced-motion`: transiciones apagadas; la lógica corre igual con `frameloop='demand'`.
- Tono usted-CO en todo copy/comentario; sin cambios de strings user-facing (aria-labels idénticos).

## Verificación
- `npm run build` verde (1m45s), sin errores nuevos (warnings de chunk-size preexistentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)