### PR TITLE
fix(valle3d): botón del agente vivo + Angelita con vida + clima sin chips debug

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -33,7 +33,6 @@ import {
   MUNDO_VALLE_BY_ID,
   COSA_DEL_DIA,
   CLIMAS,
-  ORDEN_CLIMA,
   climaPorHora,
   animoDeFinca,
   NARRACION,
@@ -112,6 +111,14 @@ const MENSAJE_DEGRADADO = {
 
 export default function EntradaValle3D({ onBack }) {
   const [clima, setClima] = useState(() => climaPorHora());
+
+  // ── El clima es ATMÓSFERA, no un selector (auditoría B8/S8): los chips de
+  //    debug se quitaron de la UI. El valle sigue la hora real de la vereda y
+  //    se re-evalúa solo — amanece, atardece y anochece sin botonera.
+  useEffect(() => {
+    const t = setInterval(() => setClima(climaPorHora()), 5 * 60 * 1000);
+    return () => clearInterval(t);
+  }, []);
   const [focoId, setFocoId] = useState(null);
   const [panel, setPanel] = useState(null); // null | 'alerta' | <mundoId>
   const [voz, setVoz] = useState(true);
@@ -142,6 +149,41 @@ export default function EntradaValle3D({ onBack }) {
     () => animoDeFinca(clima, { hayAlerta: !alertaVista }),
     [clima, alertaVista],
   );
+
+  // ── Angelita VIVA (auditoría S5): además del idle (respira/flota, en CSS),
+  //    la abeja tiene MICRO-REACCIONES: celebra al llegar a un mundo (una
+  //    vuelta de campana) y se acurruca cuando el valle queda en reposo.
+  //    Con reduced-motion el CSS congela todo en un fotograma digno.
+  const [gesto, setGesto] = useState(null); // null | 'celebra' | 'reposo'
+  const estuvoEnMundo = useRef(false);
+
+  // Celebración: solo en el flanco de ENTRADA al mundo; se apaga sola.
+  useEffect(() => {
+    if (nav.enMundo && !estuvoEnMundo.current) {
+      estuvoEnMundo.current = true;
+      setGesto('celebra');
+      const t = setTimeout(() => setGesto((g) => (g === 'celebra' ? null : g)), 2400);
+      return () => clearTimeout(t);
+    }
+    if (!nav.enMundo && estuvoEnMundo.current) {
+      estuvoEnMundo.current = false;
+      setGesto((g) => (g === 'celebra' ? null : g));
+    }
+    return undefined;
+  }, [nav.enMundo]);
+
+  // Reposo: un rato sin tocar nada en el valle → se acurruca. Cualquier
+  // interacción que cambie el foco/panel re-arma el temporizador; un toque
+  // en la escena la despierta (ver onPointerDown del root).
+  useEffect(() => {
+    if (panel || nav.enMundo || gesto === 'celebra') return undefined;
+    const t = setTimeout(() => setGesto('reposo'), 24000);
+    return () => clearTimeout(t);
+  }, [panel, nav.enMundo, focoId, clima, gesto]);
+
+  const despertarAngelita = useCallback(() => {
+    setGesto((g) => (g === 'reposo' ? null : g));
+  }, []);
 
   // ── Voz (Web Speech API): el agente DICE. Se calla si el equipo no la trae
   //    o si el usuario apaga la voz. Prefiere una voz en español.
@@ -204,6 +246,17 @@ export default function EntradaValle3D({ onBack }) {
     if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
   }, []);
 
+  // ── "Pregúntele a su finca…" ABRE el flujo real del agente (auditoría
+  //    BUG-CAMP-01: era un botón muerto). Mismo camino desacoplado que usan
+  //    AgentFab y EscuchaOverlay: el evento global `chagraNavigate`, que
+  //    App.jsx escucha para montar la conversación (vista 'agente') — funciona
+  //    desde cualquier pantalla, incluida esta vitrina, sin acoplar el mockup.
+  const preguntarAlAgente = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    if (window.speechSynthesis) window.speechSynthesis.cancel();
+    window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'agente' } }));
+  }, []);
+
   // ── ENTRAR a un mundo (tarea del viaje): cierra el panel, la abeja guía la
   //    transición y el framework monta la escena del mundo. Si el mundo aún no
   //    tiene escena montable, `viajarAlMundo` no viaja (el panel ya degradó a
@@ -241,7 +294,7 @@ export default function EntradaValle3D({ onBack }) {
   const mundoPanel = panel && panel !== 'alerta' ? MUNDO_VALLE_BY_ID[panel] : null;
 
   return (
-    <div className="valle-root" data-clima={clima}>
+    <div className="valle-root" data-clima={clima} onPointerDown={despertarAngelita}>
       {/* fondo/atmósfera 3D o su degradación 2D (según el tiering del equipo).
           Mientras se está DENTRO de un mundo, el valle descansa (se desmonta:
           nada de dos escenas sudando la GPU a la vez en un teléfono). */}
@@ -312,7 +365,8 @@ export default function EntradaValle3D({ onBack }) {
         />
       )}
 
-      {/* ── Encabezado: el nombre del lugar + el selector de clima (estado).
+      {/* ── Encabezado: el nombre del lugar. El clima NO tiene selector: es
+              la atmósfera real por la hora de la vereda (auditoría B8/S8).
               Dentro de un mundo se esconde: manda la miga del mundo. ── */}
       {!nav.enMundo && (
       <header className="valle-header">
@@ -322,19 +376,6 @@ export default function EntradaValle3D({ onBack }) {
         <div className="valle-titulo">
           <span className="valle-titulo__eyebrow">Su finca, hoy</span>
           <h1>El valle de mi finca</h1>
-        </div>
-        <div className="valle-clima" role="group" aria-label="Estado del clima de la vereda">
-          {ORDEN_CLIMA.map((k) => (
-            <button
-              key={k}
-              type="button"
-              className={`valle-clima__chip${clima === k ? ' valle-clima__chip--on' : ''}`}
-              aria-pressed={clima === k}
-              onClick={() => setClima(k)}
-            >
-              {CLIMAS[k].etiqueta}
-            </button>
-          ))}
         </div>
       </header>
       )}
@@ -348,13 +389,27 @@ export default function EntradaValle3D({ onBack }) {
 
       {/* ── El compañero: Angelita en una sola línea puntual (imagen-first).
               Es el ser al que se cuida; su cara refleja el ánimo real. Se
-              esconde si hay un panel abierto — una cosa clara a la vez. ── */}
-      {!panel && !nav.enMundo && (
-        <div className="valle-companero" role="status" aria-live="polite">
+              esconde si hay un panel abierto — una cosa clara a la vez.
+              DENTRO de un mundo sigue presente (compacta, sin frase): así se
+              ve su celebración al llegar y no abandona a quien la sigue. ── */}
+      {!panel && (
+        <div
+          className={`valle-companero${nav.enMundo ? ' valle-companero--mundo' : ''}`}
+          data-gesto={gesto || undefined}
+          role="status"
+          aria-live="polite"
+        >
           <span className="valle-companero__cara" aria-hidden="true">
-            <AbejaAngelita size={34} animo={companero.animo} energia={companero.energia} animated={!reducedMotion} />
+            <AbejaAngelita
+              size={34}
+              pose={gesto || 'vuela'}
+              animo={companero.animo}
+              energia={companero.energia}
+              animated={!reducedMotion}
+            />
+            <i className="valle-companero__sombra" />
           </span>
-          <span className="valle-companero__txt">{companero.frase}</span>
+          {!nav.enMundo && <span className="valle-companero__txt">{companero.frase}</span>}
         </div>
       )}
 
@@ -407,7 +462,12 @@ export default function EntradaValle3D({ onBack }) {
               volver; una cosa clara a la vez). ── */}
       {!nav.enMundo && (
       <footer className="valle-agente">
-        <button type="button" className="valle-agente__pregunte" aria-label="Pregúntele a Chagra">
+        <button
+          type="button"
+          className="valle-agente__pregunte"
+          aria-label="Pregúntele a Chagra"
+          onClick={preguntarAlAgente}
+        >
           <span className="valle-agente__punto" aria-hidden="true" />
           Pregúntele a su finca…
         </button>

--- a/src/mockups/entradaValle3D.css
+++ b/src/mockups/entradaValle3D.css
@@ -98,36 +98,8 @@
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
 }
 
-.valle-clima {
-  position: absolute;
-  top: 4.4rem;
-  right: 1.1rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  justify-content: flex-end;
-  max-width: 62vw;
-}
-.valle-clima__chip {
-  min-height: 40px;
-  padding: 0.3rem 0.7rem;
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  border-radius: 999px;
-  background: rgba(0, 0, 0, 0.32);
-  color: #fff;
-  font-size: 0.82rem;
-  font-weight: 600;
-  cursor: pointer;
-  backdrop-filter: blur(4px);
-  transition: background 0.2s, border-color 0.2s, transform 0.15s;
-}
-.valle-clima__chip:hover { background: rgba(0, 0, 0, 0.5); }
-.valle-clima__chip--on {
-  background: rgba(255, 214, 138, 0.92);
-  border-color: #ffd68a;
-  color: #3a2510;
-  box-shadow: 0 4px 14px rgba(255, 180, 90, 0.4);
-}
+/* (El selector de clima se quitó: el clima es atmósfera automática por la
+   hora de la vereda — auditoría B8/S8 —, no una botonera de debug.) */
 
 /* ── Etiquetas espaciales dentro del 3D (drei <Html>) ── */
 .valle-poi {
@@ -233,10 +205,73 @@
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.32);
   animation: valle-companero-in 0.5s ease both;
 }
+/* La cara vive: la abeja FLOTA/respira y proyecta una sombra de CONTACTO en
+   el "piso" del chip (separada del cuerpo — antes el drop-shadow se leía
+   pegoteado al sprite). La sombra encoge/aclara cuando la abeja sube. */
 .valle-companero__cara {
   flex: 0 0 auto;
+  position: relative;
   display: inline-flex;
-  filter: drop-shadow(0 2px 5px rgba(0, 0, 0, 0.35));
+  padding-bottom: 5px; /* aire para la sombra de contacto */
+}
+.valle-companero__cara [data-creature='abeja-angelita'] {
+  animation: valle-angelita-flota 3.4s ease-in-out infinite;
+  will-change: transform;
+}
+@keyframes valle-angelita-flota {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-3px) scale(1.04); }
+}
+.valle-companero__sombra {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 18px;
+  height: 5px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.45), transparent 70%);
+  transform: translateX(-50%);
+  animation: valle-angelita-sombra 3.4s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes valle-angelita-sombra {
+  0%, 100% { transform: translateX(-50%) scaleX(1); opacity: 0.6; }
+  50% { transform: translateX(-50%) scaleX(0.7); opacity: 0.32; }
+}
+
+/* Micro-reacciones (data-gesto en el chip):
+   celebra → vuelta de campana al LLEGAR a un mundo (dos vueltas y sigue);
+   reposo  → se acurruca: baja, se ladea y solo respira. */
+.valle-companero[data-gesto='celebra'] .valle-companero__cara [data-creature='abeja-angelita'] {
+  animation: valle-angelita-celebra 1.2s cubic-bezier(0.45, 0.1, 0.4, 1) 2;
+}
+@keyframes valle-angelita-celebra {
+  0% { transform: translateY(0) rotate(0deg); }
+  35% { transform: translateY(-8px) rotate(-170deg); }
+  70% { transform: translateY(-2px) rotate(-320deg); }
+  100% { transform: translateY(0) rotate(-360deg); }
+}
+.valle-companero[data-gesto='reposo'] .valle-companero__cara [data-creature='abeja-angelita'] {
+  animation: valle-angelita-reposo 4.8s ease-in-out infinite;
+}
+@keyframes valle-angelita-reposo {
+  0%, 100% { transform: translateY(2px) rotate(9deg) scale(0.95); }
+  50% { transform: translateY(2px) rotate(9deg) scale(1.01); }
+}
+/* acurrucada: la sombra queda asentada (contacto pleno, sin latido) */
+.valle-companero[data-gesto='reposo'] .valle-companero__sombra {
+  animation: none;
+  opacity: 0.65;
+  transform: translateX(-50%) scaleX(1.08);
+}
+
+/* Dentro de un mundo: presencia compacta (solo la abeja, sin frase), por
+   ENCIMA de la escena del mundo (z 30) sin tapar la miga ni los hotspots. */
+.valle-companero--mundo {
+  z-index: 35;
+  bottom: 4.8rem;
+  padding: 0.3rem 0.4rem;
+  background: rgba(15, 24, 30, 0.55);
 }
 .valle-companero__txt {
   font-size: 0.85rem;
@@ -511,13 +546,16 @@
   .valle-agente__punto,
   .valle-companero,
   .valle-panel { animation: none; }
+  /* Angelita en calma: un fotograma digno, sombra asentada, cero vueltas. */
+  .valle-companero__cara [data-creature='abeja-angelita'],
+  .valle-companero__sombra { animation: none !important; }
+  .valle-companero__sombra { opacity: 0.55; }
   .valle2d__cam,
   .valle2d__abeja,
   .valle-abeja__cara { transition: none; }
 }
 
 @media (max-width: 560px) {
-  .valle-clima { position: static; max-width: none; margin-top: 0.4rem; justify-content: flex-start; width: 100%; }
   .valle-header { flex-wrap: wrap; }
   .valle-titulo h1 { font-size: 1.3rem; }
 }

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -13,6 +13,11 @@ export function AbejaAngelita({
   inline = false,
   animated = true,
   title = 'Abeja angelita',
+  /* Pose de VIDA (idle-life): 'vuela' (default, aleteo normal) | 'celebra'
+     (aleteo rápido, la escena puede darle la vuelta de campana) | 'reposo'
+     (alitas plegadas que respiran despacio). Solo cambia CSS por data-pose:
+     los consumidores existentes no notan nada. */
+  pose = 'vuela',
   ...rest
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
@@ -42,7 +47,7 @@ export function AbejaAngelita({
 
   if (inline) {
     return (
-      <g className={className} data-creature="abeja-angelita">
+      <g className={className} data-creature="abeja-angelita" data-pose={pose}>
         {defs}
         {body}
       </g>
@@ -50,7 +55,7 @@ export function AbejaAngelita({
   }
   return (
     <svg viewBox={VIEWBOX} width={size} height={size} className={className}
-      role="img" aria-label={title} data-creature="abeja-angelita" {...rest}>
+      role="img" aria-label={title} data-creature="abeja-angelita" data-pose={pose} {...rest}>
       <title>{title}</title>
       {defs}
       {body}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -46,6 +46,20 @@
   50% { transform: translateX(-1.2px); }
 }
 
+/* ── Poses de VIDA de la abeja angelita (data-pose, opcional) ──
+   'celebra' → aleteo acelerado (la escena pone la vuelta de campana);
+   'reposo'  → alitas plegadas que respiran despacio (acurrucada). */
+[data-creature='abeja-angelita'][data-pose='celebra'] .crt-wing {
+  animation-duration: 0.09s;
+}
+[data-creature='abeja-angelita'][data-pose='reposo'] .crt-wing {
+  animation: crt-wing-reposo 3.6s ease-in-out infinite alternate;
+}
+@keyframes crt-wing-reposo {
+  0% { transform: scaleY(0.4) scaleX(0.86); }
+  100% { transform: scaleY(0.5) scaleX(0.9); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .crt-wing, .crt-fwing, .crt-ball, .crt-legs { animation: none !important; }
 }


### PR DESCRIPTION
Tres fixes de las auditorías `DR-AUDIT-JUEGO-3D-2026-07-11` y `DR-AUDIT-UX-CAMPESINO-AGENTE-3D-2026-07-11` sobre la entrada del valle (`#/mockups/entrada-3d`). Alcance acotado a `EntradaValle3D.jsx` (+ su CSS) y al componente `AbejaAngelita` para no chocar con otras ramas en vuelo.

## 1. BUG-CAMP-01 — "Pregúntele a su finca…" ya no es un botón muerto
El botón central del agente no tenía `onClick`. Ahora abre el flujo real de la conversación por el mismo camino desacoplado que usan `AgentFab` y `EscuchaOverlay`: despacha el evento global `chagraNavigate` con `view: 'agente'`, que `App.jsx` ya escucha (funciona desde la vitrina sin acoplar el mockup ni tocar `App.jsx`). Cancela el TTS en curso antes de navegar.

## 2. S5 — Angelita viva (idle + micro-reacciones + sombra de contacto)
- **Idle**: flota/respira en un ciclo suave permanente (CSS, solo transform/opacity).
- **Celebra**: vuelta de campana al LLEGAR a un mundo (flanco de entrada, se apaga sola). Dentro del mundo queda presente en versión compacta (solo la abeja, sin frase) para que la celebración se vea y no abandone a quien la sigue — sin tapar la miga ni los hotspots.
- **Reposo**: tras ~24 s sin interacción en el valle se acurruca (alitas plegadas respirando despacio); cualquier toque la despierta.
- **Sombra de contacto**: elipse en el piso del chip, separada del sprite y animada en contrafase con el flote (antes el `drop-shadow` se leía pegoteado al cuerpo).
- `AbejaAngelita` gana la prop opcional `pose` (`vuela`/`celebra`/`reposo`) que solo emite `data-pose` — los consumidores existentes no cambian.

## 3. B8/S8 — clima como atmósfera, no selector de debug
Fuera los 5 chips (Hora dorada/Soleado/Niebla/Lluvia/Noche) del header. El valle sigue la hora real de la vereda con `climaPorHora()` y se re-evalúa automáticamente cada 5 minutos: amanece, atardece y anochece solo.

## Duras verificadas
- Self-contained: cero assets/URLs remotas nuevas.
- Móvil 320px: el header queda más limpio sin los chips; el chip del compañero ya usaba `max-width: min(74vw, 22rem)`.
- `prefers-reduced-motion`: Angelita queda en fotograma digno (sin flote, sin vueltas, sombra asentada); ya cubría el resto de la pantalla.
- Copy en usted (CO), sin cambios de navegación ni hotspots (el test `entradaValle3D.nav.test.jsx` no toca los chips del header).
- Gate acordado: `npm run build` síncrono en verde (solo warnings preexistentes de tamaño de chunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)