### PR TITLE
feat(mundo3d): mundo de los animales — corral y ciclo cerrado del abono

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,6 +83,9 @@ const EntradaValle3DMockup = lazy(() => import('./mockups/EntradaValle3D'));
 // (src/visual/mundo3d) con device-tiering real. El 3D va perezoso (vendor-three).
 const Mundo3DAguaMockup = lazy(() => import('./mockups/Mundo3DAgua'));
 const Mundo3DSueloMockup = lazy(() => import('./mockups/Mundo3DSuelo'));
+// 3D: "El mundo de los animales" — monta <Mundo mundoId="animales"> del framework
+// (recinto: el corral y su ciclo cerrado del abono). 3D perezoso (vendor-three).
+const Mundo3DAnimalesMockup = lazy(() => import('./mockups/Mundo3DAnimales'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -467,6 +470,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/entrada-3d': 'mockup_entrada_3d',
   'mockups/mundo3d-agua': 'mockup_mundo3d_agua',
   'mockups/mundo3d-suelo': 'mockup_mundo3d_suelo',
+  'mockups/mundo3d-animales': 'mockup_mundo3d_animales',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
   'mockups/ensena-dibujando': 'mockup_ensena_dibujando',
@@ -1338,6 +1342,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del suelo">
               <Mundo3DSueloMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_animales':
+        // Vitrina pública del MUNDO DE LOS ANIMALES: monta <Mundo mundoId="animales">
+        // del framework (src/visual/mundo3d, arquetipo recinto) con device-tiering
+        // real. Ruta #/mockups/mundo3d-animales, sin auth. El corral y su ciclo
+        // cerrado del abono: animal → estiércol → compost → suelo → planta → animal.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo de los animales">
+              <Mundo3DAnimalesMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mundo3DAnimales.css
+++ b/src/mockups/Mundo3DAnimales.css
@@ -1,0 +1,152 @@
+/*
+ * Mundo3DAnimales.css — vitrina pública del mundo de los animales
+ * (#/mockups/mundo3d-animales). Autocontenida: sin fuentes/imágenes externas.
+ * Móvil-first desde 320px. Solo opacity/transform animables; reduced-motion las
+ * apaga. Paleta cálida de tierra del corral (ámbar/crema), nunca rojo de alarma.
+ */
+
+.m3dan {
+  --m3dan-a: #a86a3a;
+  --m3dan-b: #f3e3cf;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3dan-b) 0%, #f6efe0 44%, #efe6d4 100%);
+  color: #3a2e22;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3dan__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3dan__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3dan-a);
+}
+.m3dan__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #4a2f16;
+}
+.m3dan__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3dan__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3dan__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(168, 106, 58, 0.28);
+  box-shadow: 0 10px 28px rgba(74, 47, 22, 0.14);
+}
+.m3dan__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fdf8ee;
+}
+
+.m3dan__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3dan__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3dan__toggle {
+  border: 1.5px solid var(--m3dan-a);
+  background: #fff;
+  color: var(--m3dan-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3dan__toggle:hover,
+.m3dan__toggle:focus-visible {
+  background: var(--m3dan-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3dan__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.75);
+  border-left: 3px solid var(--m3dan-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3dan__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3dan__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #4a2f16;
+}
+.m3dan__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3dan__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3dan__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(168, 106, 58, 0.18);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3dan__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3dan__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #4a2f16;
+}
+.m3dan__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3dan__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #5a3a1e;
+}

--- a/src/mockups/Mundo3DAnimales.jsx
+++ b/src/mockups/Mundo3DAnimales.jsx
@@ -1,0 +1,133 @@
+/*
+ * Mundo3DAnimales — vitrina pública del MUNDO DE LOS ANIMALES (ruta
+ * #/mockups/mundo3d-animales).
+ *
+ * El corral como LUGAR y el ciclo cerrado del abono como un anillo virtuoso que
+ * se camina: animal → estiércol → compost → suelo → planta → de vuelta al animal.
+ * Gallinas ponedoras, la vaca, la oveja; el escarabajo estercolero que entierra
+ * la bosta y cierra el ciclo. Didáctico y esperanzador — menos colapso, finca
+ * viva. Nada de catástrofe: el corral vivo trabajando a favor de la finca.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="animales">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento" activado) se ve el gemelo 2D digno; en
+ * gama media/alta, el diorama 3D low-poly (chunk perezoso `vendor-three`) con
+ * los animales diferenciados (gallina, vaca de cuerpo capsular, oveja de vellón)
+ * y la abeja Angelita entrando al mundo. Los puntos del corral son las mismas
+ * puertas del registro: aquí (vitrina sin sesión) muestran a qué pantalla real
+ * de la app llevan, en vez de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import './Mundo3DAnimales.css';
+
+const TINTE = ['#a86a3a', '#f3e3cf'];
+
+/* El anillo del abono, eslabón por eslabón — la misma verdad del registro
+   (mundoData.js), contada en una leyenda didáctica y verificada. */
+const LEYENDA = [
+  { emoji: '🐮', titulo: 'El corral vivo', texto: 'La vaca, la oveja y las gallinas no son solo comida: son el motor que mueve el abono de la finca. Pocos animales bien tenidos, con su espacio.' },
+  { emoji: '🐔', titulo: 'Las gallinas ponedoras', texto: 'La ponedora se da bien en clima frío si tiene abrigo y comida; además de los huevos, su gallinaza es de los abonos más fuertes que hay.' },
+  { emoji: '💩', titulo: 'Del corral, el estiércol', texto: 'La bosta y la gallinaza no son basura ni problema: son la materia prima del abono. Recogerlas es empezar a cerrar el ciclo.' },
+  { emoji: '🍂', titulo: 'El estiércol se hace compost', texto: 'Amontonado con hojarasca y volteado, el estiércol se calienta, madura y se vuelve tierra buena, negra y sin olor: compost listo para la huerta.' },
+  { emoji: '🌱', titulo: 'Vuelve al cultivo', texto: 'Ese abono alimenta las matas, que dan comida y rastrojo, que vuelve a los animales. El anillo se cierra y la finca casi no necesita comprar nada de afuera.' },
+  { emoji: '🪲', titulo: 'El escarabajo estercolero', texto: 'El cucarrón que rueda la bolita de bosta y la entierra hace gratis un trabajo enorme: incorpora el abono al suelo y limpia el potrero. Vida que trabaja.' },
+];
+
+export default function Mundo3DAnimales() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // En la vitrina (sin sesión) un punto del corral no navega: cuenta a qué
+  // pantalla real de la app lleva esa puerta.
+  const [puerta, setPuerta] = useState(null);
+  const onHotspot = (view, data) => {
+    const hs = (MUNDO.animales.hotspots || []).find(
+      (h) => h.view === view && (h.data === data || (!h.data && !data)),
+    ) || (MUNDO.animales.hotspots || []).find((h) => h.view === view);
+    setPuerta({ label: hs?.label || view, view });
+  };
+
+  return (
+    <main
+      className="m3dan"
+      style={{ '--m3dan-a': TINTE[0], '--m3dan-b': TINTE[1] }}
+    >
+      <header className="m3dan__head">
+        <p className="m3dan__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo de los animales</h1>
+        <p className="m3dan__lema">
+          Entre al corral y camine el ciclo del abono: del animal al estiércol,
+          del estiércol al compost, del compost a la mata y de vuelta al animal.
+          Un anillo que se cierra solo. Menos colapso, finca viva.
+        </p>
+      </header>
+
+      <section className="m3dan__escena" aria-label="El corral y el ciclo del abono de la finca">
+        <Mundo
+          mundoId="animales"
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          onSalir={null}
+          animo="sereno"
+          energia={0.85}
+        />
+        <div className="m3dan__barra">
+          <p className="m3dan__tier">
+            {tier === 'bajo'
+              ? 'Está viendo el dibujo del corral (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3dan__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver el dibujo 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3dan__nota" role="status" aria-live="polite">
+          {puerta
+            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+            : 'Toque un punto del corral para ver a dónde lo lleva.'}
+        </p>
+      </section>
+
+      <section className="m3dan__leyenda" aria-label="El ciclo del abono, eslabón por eslabón">
+        <h2>El ciclo del abono, eslabón por eslabón</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3dan__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3dan__cierre">
+          Una finca con animales bien tenidos no bota nada: lo que sale del corral
+          vuelve a la tierra hecho fuerza. Empiece por recoger el estiércol y
+          armar su primera pila de compost — el anillo arranca ahí.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/__tests__/mundo3dAnimales.smoke.test.jsx
+++ b/src/mockups/__tests__/mundo3dAnimales.smoke.test.jsx
@@ -1,0 +1,38 @@
+/*
+ * Vitrina #/mockups/mundo3d-animales — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y la vitrina
+ * monta el GEMELO 2D del corral (three-free): exactamente el camino del
+ * device-tiering real en gama baja. Se congela que:
+ *   · la página renderiza título + leyenda sin tocar three;
+ *   · el gemelo trae los 3 puntos del corral como botones;
+ *   · tocar una puerta cuenta a qué pantalla real de la app lleva (sin sesión
+ *     la vitrina NO navega).
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import Mundo3DAnimales from '../Mundo3DAnimales.jsx';
+
+afterEach(() => cleanup());
+
+describe('vitrina del mundo de los animales (mockups/mundo3d-animales)', () => {
+  test('renderiza el mundo en 2D digno con su leyenda didáctica', () => {
+    const { container } = render(<Mundo3DAnimales />);
+    expect(screen.getByRole('heading', { level: 1, name: 'El mundo de los animales' })).toBeInTheDocument();
+    // jsdom no tiene WebGL → gemelo 2D (three-free), nunca pantalla rota
+    expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('.mundo2d__hotspot').length).toBe(3);
+    // la leyenda enseña el ciclo del abono (esperanzadora, no alarmista)
+    expect(screen.getByText('El ciclo del abono, eslabón por eslabón')).toBeInTheDocument();
+    expect(screen.getByText('El escarabajo estercolero', { selector: 'b' })).toBeInTheDocument();
+  });
+
+  test('tocar una puerta del corral cuenta a qué pantalla real lleva', () => {
+    render(<Mundo3DAnimales />);
+    fireEvent.click(screen.getByRole('button', { name: 'Del corral al abono' }));
+    expect(screen.getByRole('status')).toHaveTextContent('«estiercol»');
+  });
+});

--- a/src/visual/mundo3d/escenas/EscenaRecinto.jsx
+++ b/src/visual/mundo3d/escenas/EscenaRecinto.jsx
@@ -3,9 +3,11 @@
  *
  * El corral es un LUGAR reconocible, y el ciclo (animal → estiércol → suelo →
  * planta → animal) es una FORMA que se camina: un anillo espacial. Aquí: un piso
- * circular cercado, animales low-poly (`params.animales`), y un aro de "ciclo"
- * (torus) que ancla la idea de cerrar el ciclo del abono. `MeshLambert`/`Basic`,
- * sin sombras.
+ * circular cercado, animales low-poly DIFERENCIADOS por especie (gallina, vaca de
+ * cuerpo capsular, oveja de vellón facetado) según `params.animales[].tipo`, y un
+ * aro de "ciclo" (torus) que ancla la idea de cerrar el ciclo del abono. Cada
+ * animal es primitivas orgánicas (esferas/conos/cápsulas), nunca cajas; con `tipo`
+ * desconocido cae al esquemático (retrocompat). `MeshLambert`/`Basic`, sin sombras.
  */
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
@@ -20,7 +22,9 @@ const FAUNA_RECINTO = [
   { tipo: 'mariposa', base: [1.0, 0.62, 0.85], patron: 'revoloteo', size: 28, fase: 2.6 },
 ];
 
-/* Un animal esquemático: cuerpo + cabeza, tono propio. */
+/* Un animal esquemático: cuerpo + cabeza, tono propio. Es el FALLBACK
+   retrocompatible: si un dato viejo trae solo {color, pos} sin `tipo`, se dibuja
+   así (nunca una caja huérfana). Los datos nuevos traen especie diferenciada. */
 function Animalito({ pos, color }) {
   return (
     <group position={pos}>
@@ -36,11 +40,137 @@ function Animalito({ pos, color }) {
   );
 }
 
+/* La gallina ponedora: cuerpo ovalado, cola alzada, cresta y pico. Primitivas
+   orgánicas (esferas/conos), nada de cajas — mira hacia +x. */
+function Gallina({ pos, color = '#e7d9c2' }) {
+  return (
+    <group position={pos}>
+      {/* cuerpo ovalado */}
+      <mesh position={[0, 0.2, 0]} scale={[1.25, 1, 1]}>
+        <sphereGeometry args={[0.16, 8, 6]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+      {/* cola alzada */}
+      <mesh position={[-0.16, 0.28, 0]} rotation={[0, 0, 0.9]}>
+        <coneGeometry args={[0.09, 0.2, 5]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+      {/* cabeza */}
+      <mesh position={[0.17, 0.34, 0]}>
+        <sphereGeometry args={[0.09, 8, 6]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+      {/* cresta (terracota natural, jamás rojo de alarma) */}
+      <mesh position={[0.17, 0.45, 0]}>
+        <coneGeometry args={[0.05, 0.1, 4]} />
+        <meshLambertMaterial color="#c85a44" flatShading />
+      </mesh>
+      {/* pico */}
+      <mesh position={[0.27, 0.33, 0]} rotation={[0, 0, -Math.PI / 2]}>
+        <coneGeometry args={[0.03, 0.09, 4]} />
+        <meshLambertMaterial color="#e0a63a" flatShading />
+      </mesh>
+      {/* patas */}
+      {[0.06, -0.06].map((z) => (
+        <mesh key={z} position={[0.04, 0.05, z]}>
+          <cylinderGeometry args={[0.015, 0.015, 0.14, 4]} />
+          <meshLambertMaterial color="#e0a63a" flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* La vaca de finca: cuerpo CAPSULAR horizontal, cabeza con hocico y orejas,
+   cuatro patas y cola. Cápsula tumbada (rotación z) — el "cuerpo capsular" del DR. */
+function Vaca({ pos, color = '#c9a06a' }) {
+  return (
+    <group position={pos}>
+      {/* cuerpo capsular horizontal */}
+      <mesh position={[0, 0.46, 0]} rotation={[0, 0, Math.PI / 2]}>
+        <capsuleGeometry args={[0.22, 0.42, 4, 8]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+      {/* cabeza */}
+      <mesh position={[0.44, 0.5, 0]}>
+        <sphereGeometry args={[0.15, 8, 6]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+      {/* hocico */}
+      <mesh position={[0.56, 0.44, 0]}>
+        <sphereGeometry args={[0.09, 8, 6]} />
+        <meshLambertMaterial color="#e8d3bf" flatShading />
+      </mesh>
+      {/* orejas */}
+      {[0.12, -0.12].map((z) => (
+        <mesh key={z} position={[0.4, 0.62, z]} rotation={[z > 0 ? 0.5 : -0.5, 0, 0]}>
+          <coneGeometry args={[0.05, 0.12, 4]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+      ))}
+      {/* patas */}
+      {[[0.28, 0.13], [0.28, -0.13], [-0.28, 0.13], [-0.28, -0.13]].map(([x, z], i) => (
+        <mesh key={i} position={[x, 0.18, z]}>
+          <cylinderGeometry args={[0.045, 0.04, 0.36, 5]} />
+          <meshLambertMaterial color="#8a6a44" flatShading />
+        </mesh>
+      ))}
+      {/* cola */}
+      <mesh position={[-0.42, 0.34, 0]} rotation={[0, 0, 0.4]}>
+        <cylinderGeometry args={[0.02, 0.02, 0.34, 4]} />
+        <meshLambertMaterial color="#8a6a44" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* La oveja: vellón como cuerpo FACETADO (icosaedro low-poly = lana), cabeza y
+   patas oscuras. El facetado es la lana, sin texturas ni cajas. */
+function Oveja({ pos, color = '#efe7d8' }) {
+  return (
+    <group position={pos}>
+      {/* vellón (icosaedro low-poly, flatShading = lana) */}
+      <mesh position={[0, 0.34, 0]} scale={[1.2, 1, 1]}>
+        <icosahedronGeometry args={[0.22, 0]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+      {/* cabeza oscura */}
+      <mesh position={[0.28, 0.36, 0]}>
+        <sphereGeometry args={[0.1, 8, 6]} />
+        <meshLambertMaterial color="#5a4a3e" flatShading />
+      </mesh>
+      {/* orejas */}
+      {[0.08, -0.08].map((z) => (
+        <mesh key={z} position={[0.28, 0.44, z]} rotation={[0, 0, z > 0 ? -0.6 : 0.6]}>
+          <coneGeometry args={[0.03, 0.1, 4]} />
+          <meshLambertMaterial color="#5a4a3e" flatShading />
+        </mesh>
+      ))}
+      {/* patas */}
+      {[[0.14, 0.1], [0.14, -0.1], [-0.14, 0.1], [-0.14, -0.1]].map(([x, z], i) => (
+        <mesh key={i} position={[x, 0.12, z]}>
+          <cylinderGeometry args={[0.03, 0.03, 0.24, 4]} />
+          <meshLambertMaterial color="#5a4a3e" flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Dispatcher por especie: cada animal se dibuja según su `tipo`; si no se
+   reconoce, cae al esquemático `Animalito` (retrocompat, nunca una caja). */
+const ANIMALES_CORRAL = { gallina: Gallina, vaca: Vaca, oveja: Oveja };
+function AnimalDeCorral({ tipo, pos, color }) {
+  const Comp = ANIMALES_CORRAL[tipo];
+  return Comp ? <Comp pos={pos} color={color} /> : <Animalito pos={pos} color={color} />;
+}
+
 function Diorama({ params, reducedMotion }) {
   const animales = params?.animales || [
-    { color: '#e7d9c2', pos: [-0.7, 0, 0.4] },
-    { color: '#c98a5a', pos: [0.6, 0, -0.3] },
-    { color: '#d8c49a', pos: [0.1, 0, 0.7] },
+    { tipo: 'vaca', color: '#c9a06a', pos: [-1.05, 0, -0.4] },
+    { tipo: 'gallina', color: '#e7d9c2', pos: [1.1, 0, 0.5] },
+    { tipo: 'gallina', color: '#d8b58a', pos: [0.7, 0, 1.05] },
+    { tipo: 'oveja', color: '#efe7d8', pos: [-0.35, 0, 1.15] },
   ];
   const postes = useMemo(() => {
     const n = 12;
@@ -74,7 +204,7 @@ function Diorama({ params, reducedMotion }) {
         <meshLambertMaterial color="#5a4326" flatShading />
       </mesh>
       {animales.map((a, i) => (
-        <Animalito key={i} pos={a.pos} color={a.color} />
+        <AnimalDeCorral key={i} tipo={a.tipo} pos={a.pos} color={a.color} />
       ))}
       {/* aves e insectos que animan el corral (escarabajo en el abono) */}
       <Fauna items={FAUNA_RECINTO} reducedMotion={reducedMotion} />

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -84,16 +84,21 @@ export const MUNDO = {
     fallback2d: { escena: 'mirror' },
   },
 
-  // 🐔 LOS ANIMALES — el ciclo cerrado (recinto). Gated por perfil (como hoy).
+  // 🐔 LOS ANIMALES — el corral y su CICLO CERRADO del abono (recinto): animal →
+  //    estiércol → compost → suelo → planta → animal, un anillo virtuoso. Gated
+  //    por perfil (como hoy). Animales reales de finca andina, DIFERENCIADOS por
+  //    `tipo` (gallina ponedora de clima frío, vaca de cuerpo capsular, oveja de
+  //    vellón): pocos y bien espaciados (más aire, no rebaño), poblado de verdad.
   animales: {
     escena: 'recinto',
     valle: { tipo: 'corral', pos: [-4.6, 0, -1.8], escala: 1 },
     gate: 'animales',
     params: {
       animales: [
-        { color: '#e7d9c2', pos: [-0.7, 0, 0.4] },
-        { color: '#c98a5a', pos: [0.6, 0, -0.3] },
-        { color: '#d8c49a', pos: [0.1, 0, 0.7] },
+        { tipo: 'vaca', color: '#c9a06a', pos: [-1.05, 0, -0.4] },
+        { tipo: 'gallina', color: '#e7d9c2', pos: [1.1, 0, 0.5] },
+        { tipo: 'gallina', color: '#d8b58a', pos: [0.7, 0, 1.05] },
+        { tipo: 'oveja', color: '#efe7d8', pos: [-0.35, 0, 1.15] },
       ],
     },
     hotspots: [


### PR DESCRIPTION
## Qué

MUNDO 3D DE LOS ANIMALES (batch DR-MUNDOS-3D, mundo #2). Vitrina pública `#/mockups/mundo3d-animales` que monta `<Mundo mundoId="animales">` del framework `src/visual/mundo3d` (arquetipo `recinto`) con device-tiering real y gemelo 2D digno.

**Concepto:** el corral como LUGAR y el ciclo cerrado del abono como anillo virtuoso que se camina — animal → estiércol → compost → suelo → planta → de vuelta al animal. "Menos colapso, finca viva".

## Cambios

- **`EscenaRecinto`**: reemplaza el `Animalito` genérico por animales low-poly **diferenciados por especie** (gallina ponedora, vaca de cuerpo capsular, oveja de vellón facetado) de primitivas orgánicas (esferas/conos/cápsulas/icosaedro) — nunca cajas. `Animalito` queda como fallback retrocompatible para datos sin `tipo`.
- **`mundoData.js`**: enriquece `params.animales` del registro **existente** `animales` (mundo #2, "ya existe — poblar de verdad") a 4 especies bien espaciadas (más aire, no rebaño). Sin reordenar ni tocar otros mundos. La abeja Angelita entra vía `useEntradaAbeja` (heredado de `EscenaBase3D`).
- **`Mundo3DAnimales.jsx` + `.css`**: mockup autocontenido, móvil 320px, `usted`-CO, `prefers-reduced-motion`. Leyenda del anillo del abono con datos verificados (gallina ponedora clima frío, estiércol→compost, escarabajo estercolero como servicio ecosistémico).
- **`App.jsx`**: ruta cableada en su propio bloque (import lazy + `MOCKUP_HASH_ROUTES` + case de render).
- **Smoke test** 2D (jsdom = equipo humilde): título, 3 hotspots, la puerta cuenta a la pantalla real.

## Duras verificadas

R3F low-poly primitivas orgánicas · layout por datos · three perezoso (`vendor-three`) · fallback 2D (`recinto`→`mirror`) · usted-CO · self-contained · móvil 320px · prefers-reduced-motion · sin Playwright · persona OFF.

Hotspots = cases reales de App.jsx: `animales`, `animales_gallinas`, `estiercol`.

## Verificación

- `npm run build` ✓ (2m 52s, verde; advertencias de chunk/dynamic-import preexistentes y ajenas).
- Smoke test `mundo3dAnimales.smoke.test.jsx` ✓ (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)