### PR TITLE
feat(mundo3d): mundo de la milpa — las tres hermanas en corte (cutaway)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,6 +83,7 @@ const EntradaValle3DMockup = lazy(() => import('./mockups/EntradaValle3D'));
 // (src/visual/mundo3d) con device-tiering real. El 3D va perezoso (vendor-three).
 const Mundo3DAguaMockup = lazy(() => import('./mockups/Mundo3DAgua'));
 const Mundo3DSueloMockup = lazy(() => import('./mockups/Mundo3DSuelo'));
+const Mundo3DMilpaMockup = lazy(() => import('./mockups/Mundo3DMilpa'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -467,6 +468,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/entrada-3d': 'mockup_entrada_3d',
   'mockups/mundo3d-agua': 'mockup_mundo3d_agua',
   'mockups/mundo3d-suelo': 'mockup_mundo3d_suelo',
+  'mockups/mundo3d-milpa': 'mockup_mundo3d_milpa',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
   'mockups/ensena-dibujando': 'mockup_ensena_dibujando',
@@ -1338,6 +1340,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del suelo">
               <Mundo3DSueloMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_milpa':
+        // Vitrina pública del MUNDO DE LA MILPA: monta <Mundo mundoId="milpa"> del
+        // framework (src/visual/mundo3d) con device-tiering real. Ruta
+        // #/mockups/mundo3d-milpa, sin auth. Las tres hermanas en corte: arriba la
+        // asociación (maíz-fríjol-calabaza), abajo los nódulos de N del fríjol.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo de la milpa">
+              <Mundo3DMilpaMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mundo3DMilpa.css
+++ b/src/mockups/Mundo3DMilpa.css
@@ -1,0 +1,151 @@
+/*
+ * Mundo3DMilpa.css — vitrina pública del mundo de la milpa (#/mockups/mundo3d-milpa).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Solo opacity/transform animables; reduced-motion las apaga.
+ */
+
+.m3dm {
+  --m3dm-a: #5f8f3f;
+  --m3dm-b: #eef0cf;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3dm-b) 0%, #f3f2da 44%, #e6e3bf 100%);
+  color: #2f3320;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3dm__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3dm__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3dm-a);
+}
+.m3dm__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #3c4a1e;
+}
+.m3dm__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3dm__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3dm__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(95, 143, 63, 0.3);
+  box-shadow: 0 10px 28px rgba(47, 51, 32, 0.14);
+}
+.m3dm__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fbfaee;
+}
+
+.m3dm__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3dm__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3dm__toggle {
+  border: 1.5px solid var(--m3dm-a);
+  background: #fff;
+  color: var(--m3dm-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3dm__toggle:hover,
+.m3dm__toggle:focus-visible {
+  background: var(--m3dm-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3dm__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.82);
+  border-left: 3px solid var(--m3dm-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3dm__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3dm__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #3c4a1e;
+}
+.m3dm__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3dm__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3dm__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(95, 143, 63, 0.2);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3dm__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3dm__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #3c4a1e;
+}
+.m3dm__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3dm__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #35401c;
+}

--- a/src/mockups/Mundo3DMilpa.jsx
+++ b/src/mockups/Mundo3DMilpa.jsx
@@ -1,0 +1,133 @@
+/*
+ * Mundo3DMilpa — vitrina pública del MUNDO DE LA MILPA (ruta #/mockups/mundo3d-milpa).
+ *
+ * Las TRES HERMANAS en un solo corte: sobre la cama, el maíz da la vara, el
+ * fríjol sube por ella y la calabaza cubre el suelo; bajo tierra, lo invisible
+ * hecho visible — los NÓDULOS de Rhizobium en las raíces del fríjol, que fijan
+ * entre 50 y 80 kg de nitrógeno por hectárea (abono gratis para las tres). No es
+ * monocultivo: sembradas juntas rinden más y se cuidan (push-pull). Didáctico y
+ * esperanzador — menos colapso, finca viva.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="milpa">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento") se ve el gemelo 2D digno con las mismas tres
+ * hermanas y los mismos nódulos; en gama media/alta, el diorama 3D low-poly
+ * (chunk perezoso `vendor-three`) con la abeja Angelita entrando al mundo. Los
+ * puntos del corte son las mismas puertas del registro: aquí (vitrina sin sesión)
+ * muestran a qué pantalla real de la app llevan, en vez de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import './Mundo3DMilpa.css';
+
+const TINTE = ['#5f8f3f', '#eef0cf'];
+
+/* La milpa, hermana por hermana y raíz por raíz — la misma verdad del registro
+   (mundoData.js), contada en una leyenda didáctica y verificada (catálogo:
+   companions recíprocos maíz↔fríjol↔calabaza; fijación biológica de N). */
+const LEYENDA = [
+  { emoji: '🌽', titulo: 'El maíz da la vara', texto: 'El maíz crece derecho y firme: es el tutor vivo por donde el fríjol trepa, sin gastar estacas ni alambre.' },
+  { emoji: '🫘', titulo: 'El fríjol sube y abona', texto: 'Se enreda en la caña y, bajo tierra, sus raíces guardan bacterias (Rhizobium) que fijan el nitrógeno del aire: entre 50 y 80 kilos por hectárea, abono para las tres.' },
+  { emoji: '🎃', titulo: 'La calabaza tapa el suelo', texto: 'Sus hojas anchas se riegan por el suelo: guardan la humedad, le hacen sombra a la maleza y su flor amarilla llama a las abejas.' },
+  { emoji: '🌸', titulo: 'Los nódulos: el nitrógeno que se ve', texto: 'Esas pelotitas rosadas en la raíz del fríjol son fábricas de nitrógeno. Lo que no se ve bajo la tierra, en el corte se ve.' },
+  { emoji: '🐛', titulo: 'Juntas se defienden', texto: 'Revueltas (no en monocultivo) confunden y reparten las plagas, como el cogollero; se maneja con Bt o la avispita Cotesia, sin veneno.' },
+];
+
+export default function Mundo3DMilpa() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // En la vitrina (sin sesión) un punto del corte no navega: cuenta a qué
+  // pantalla real de la app lleva esa puerta.
+  const [puerta, setPuerta] = useState(null);
+  const onHotspot = (view, data) => {
+    const hs = (MUNDO.milpa.hotspots || []).find(
+      (h) => h.view === view && (h.data === data || (!h.data && !data)),
+    ) || (MUNDO.milpa.hotspots || []).find((h) => h.view === view);
+    setPuerta({ label: hs?.label || view, view });
+  };
+
+  return (
+    <main
+      className="m3dm"
+      style={{ '--m3dm-a': TINTE[0], '--m3dm-b': TINTE[1] }}
+    >
+      <header className="m3dm__head">
+        <p className="m3dm__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo de la milpa</h1>
+        <p className="m3dm__lema">
+          Las tres hermanas en una sola cama: el maíz da la vara, el fríjol sube
+          y regala nitrógeno, la calabaza tapa el suelo. Asómese al corte y vea
+          arriba la asociación y abajo los nódulos que abonan la tierra. Menos
+          colapso, finca viva.
+        </p>
+      </header>
+
+      <section className="m3dm__escena" aria-label="El corte de la milpa: las tres hermanas y los nódulos de nitrógeno">
+        <Mundo
+          mundoId="milpa"
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          onSalir={null}
+          animo="sereno"
+          energia={0.9}
+        />
+        <div className="m3dm__barra">
+          <p className="m3dm__tier">
+            {tier === 'bajo'
+              ? 'Está viendo el dibujo del corte (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3dm__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver el dibujo 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3dm__nota" role="status" aria-live="polite">
+          {puerta
+            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+            : 'Toque un punto del corte para ver a dónde lo lleva.'}
+        </p>
+      </section>
+
+      <section className="m3dm__leyenda" aria-label="La milpa, hermana por hermana">
+        <h2>La milpa, hermana por hermana</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3dm__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3dm__cierre">
+          No es revolver por revolver: es un trato viejo y sabio entre tres
+          plantas. Siémbrelas juntas y déle de comer al suelo mientras cosecha —
+          la milpa alimenta a la familia y a la tierra.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/visual/mundo3d/escenas/EscenaCutaway.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCutaway.jsx
@@ -23,6 +23,7 @@ import { Html } from '@react-three/drei';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Lombriz } from '../../creatures/Lombriz.jsx';
 import { Escarabajo } from '../../creatures/Escarabajo.jsx';
+import { Mariposa } from '../../creatures/Mariposa.jsx';
 
 const ANCHO = 4.4;
 const PROF = 2.2;
@@ -109,6 +110,175 @@ function Fauna({ base, phase, deriva = 0, asomo = 0.05, reducedMotion, children 
       <Html center distanceFactor={5.4} zIndexRange={[24, 6]}>
         <div className="mundo-fauna" aria-hidden="true">{children}</div>
       </Html>
+    </group>
+  );
+}
+
+/* ── LA MILPA (las tres hermanas) — primitivas de planta menores ────────────
+   Cuando el corte declara `params.milpa`, sobre la superficie crece el módulo de
+   las tres hermanas y, en la cara del corte, se ven las RAÍCES DEL FRÍJOL con sus
+   nódulos rosados: el nitrógeno que se fija bajo tierra, hecho visible (50–80 kg
+   N/ha vía Rhizobium — dato verificado). El maíz da la vara, el fríjol sube por
+   ella y abona, la calabaza cubre el suelo. Todas low-poly (cono/cilindro/esfera),
+   sin cajas; no toca el corte de suelo/abono (va detrás de `params.milpa`). */
+
+/* MataMaiz: la caña = el tutor vivo. Cilindro + hojas cono + mazorca cápsula. */
+function MataMaiz({ base, alto = 1.7 }) {
+  const [x, y, z] = base;
+  const hojas = [0.34, 0.52, 0.7, 0.86];
+  return (
+    <group position={[x, y, z]}>
+      <mesh position={[0, alto / 2, 0]}>
+        <cylinderGeometry args={[0.045, 0.075, alto, 7]} />
+        <meshLambertMaterial color="#88a24a" flatShading />
+      </mesh>
+      {hojas.map((f, i) => {
+        const lado = i % 2 === 0 ? 1 : -1;
+        return (
+          <mesh key={f} position={[lado * 0.11, alto * f, 0]} rotation={[0, i * 1.4, lado * -0.95]}>
+            <coneGeometry args={[0.05, 0.62, 4]} />
+            <meshLambertMaterial color="#6f9a45" flatShading />
+          </mesh>
+        );
+      })}
+      {/* la mazorca: cápsula crema arrimada a la caña */}
+      <mesh position={[0.12, alto * 0.5, 0.05]} rotation={[0, 0, 0.5]}>
+        <capsuleGeometry args={[0.075, 0.2, 3, 7]} />
+        <meshLambertMaterial color="#ecd98f" flatShading />
+      </mesh>
+      {/* el penacho de arriba (la flor del maíz) */}
+      <mesh position={[0, alto + 0.14, 0]}>
+        <coneGeometry args={[0.06, 0.28, 5]} />
+        <meshLambertMaterial color="#d8c98a" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* GuiaFrijol: espiral fino que sube ciñéndose a la caña del maíz. */
+function GuiaFrijol({ base, alto = 1.5, vueltas = 4 }) {
+  const [x, y, z] = base;
+  const N = 20;
+  const cuentas = Array.from({ length: N }, (_, i) => {
+    const f = i / (N - 1);
+    const ang = f * vueltas * Math.PI * 2;
+    const r = 0.1 + 0.02 * (1 - f);
+    return { key: i, pos: [Math.cos(ang) * r, alto * f + 0.06, Math.sin(ang) * r], hoja: i % 5 === 2, ang };
+  });
+  return (
+    <group position={[x, y, z]}>
+      {cuentas.map((c) => (
+        <group key={c.key}>
+          <mesh position={c.pos}>
+            <sphereGeometry args={[0.026, 5, 4]} />
+            <meshLambertMaterial color="#4f8a34" flatShading />
+          </mesh>
+          {c.hoja && (
+            <mesh position={c.pos} rotation={[0, -c.ang, 0.6]}>
+              <coneGeometry args={[0.04, 0.15, 4]} />
+              <meshLambertMaterial color="#5f9a3f" flatShading />
+            </mesh>
+          )}
+        </group>
+      ))}
+    </group>
+  );
+}
+
+/* Calabaza: hojas rastreras (conos aplanados sobre el suelo) + fruto ocre + flor
+   amarilla (donde poliniza la abeja). Cobertura viva que sombrea el suelo. */
+function Calabaza({ base }) {
+  const [x, y, z] = base;
+  const hojas = [
+    { p: [0, 0.03, 0], r: 0.3, rot: 0.2 },
+    { p: [0.36, 0.03, 0.12], r: 0.24, rot: -0.5 },
+    { p: [0.62, 0.03, -0.1], r: 0.26, rot: 0.9 },
+    { p: [0.28, 0.03, -0.3], r: 0.22, rot: 1.6 },
+    { p: [-0.3, 0.03, 0.2], r: 0.2, rot: 2.3 },
+  ];
+  return (
+    <group position={[x, y, z]}>
+      {hojas.map((h) => (
+        <mesh key={`${h.p[0]}-${h.p[2]}`} position={h.p} rotation={[-Math.PI / 2, 0, h.rot]}>
+          <coneGeometry args={[h.r, 0.06, 5]} />
+          <meshLambertMaterial color="#5f8a3f" flatShading />
+        </mesh>
+      ))}
+      {/* el fruto: esfera achatada, color ahuyama */}
+      <mesh position={[0.5, 0.16, 0.05]} scale={[1, 0.72, 1]}>
+        <sphereGeometry args={[0.2, 8, 6]} />
+        <meshLambertMaterial color="#cf8f3c" flatShading />
+      </mesh>
+      {/* la flor amarilla que llama a la abeja */}
+      <group position={[-0.12, 0.12, 0.28]}>
+        <mesh rotation={[0.5, 0, 0]}>
+          <coneGeometry args={[0.09, 0.16, 6]} />
+          <meshLambertMaterial color="#e8c34a" flatShading />
+        </mesh>
+        <mesh position={[0, 0.03, 0.03]}>
+          <sphereGeometry args={[0.032, 5, 4]} />
+          <meshBasicMaterial color="#f0d878" />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* RaizNodulos: la raíz pivotante del fríjol que baja por la cara del corte, con
+   sus NÓDULOS = esferitas rosadas (Rhizobium fijando nitrógeno del aire). Lo
+   invisible del subsuelo, hecho visible: aquí se ve el abono que el fríjol regala. */
+function RaizNodulos({ base, largo = 1.4 }) {
+  const [x, y, z] = base;
+  const M = 7;
+  const nodulos = Array.from({ length: M }, (_, i) => {
+    const f = 0.18 + (i / M) * 0.78;
+    const lado = i % 2 === 0 ? 1 : -1;
+    return { key: i, pos: [lado * (0.04 + (i % 3) * 0.05), -largo * f, 0.02 * lado], r: 0.038 + (i % 2) * 0.014 };
+  });
+  return (
+    <group position={[x, y, z]}>
+      {/* raíz pivotante: cono que se afina hacia abajo */}
+      <mesh position={[0, -largo / 2, 0]} rotation={[Math.PI, 0, 0]}>
+        <coneGeometry args={[0.06, largo, 6]} />
+        <meshLambertMaterial color="#c9a86a" flatShading />
+      </mesh>
+      <mesh position={[0.12, -largo * 0.36, 0]} rotation={[0, 0, -0.9]}>
+        <coneGeometry args={[0.025, largo * 0.5, 5]} />
+        <meshLambertMaterial color="#bd9a5a" flatShading />
+      </mesh>
+      <mesh position={[-0.12, -largo * 0.56, 0]} rotation={[0, 0, 0.9]}>
+        <coneGeometry args={[0.022, largo * 0.44, 5]} />
+        <meshLambertMaterial color="#bd9a5a" flatShading />
+      </mesh>
+      {nodulos.map((nd) => (
+        <mesh key={nd.key} position={nd.pos}>
+          <sphereGeometry args={[nd.r, 6, 5]} />
+          <meshLambertMaterial color="#e0a3ad" flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* El módulo de las tres hermanas, compuesto sobre la cara del corte. */
+function Milpa({ total, config, reducedMotion }) {
+  const cfg = config === true ? {} : (config || {});
+  const zF = CARA - 0.16; // el frente del corte, donde crecen las plantas
+  const zRaiz = CARA - 0.05; // pegado a la cara: las raíces se ven en el corte
+  const maizX = cfg.maiz?.x ?? -0.25;
+  const maizAlto = cfg.maiz?.alto ?? 1.7;
+  const calX = cfg.calabaza?.x ?? 0.7;
+  const vueltas = cfg.frijol?.vueltas ?? 4;
+  return (
+    <group>
+      <MataMaiz base={[maizX, total, zF]} alto={maizAlto} />
+      <GuiaFrijol base={[maizX, total, zF]} alto={maizAlto * 0.9} vueltas={vueltas} />
+      <RaizNodulos base={[maizX, total, zRaiz]} largo={total * 0.62} />
+      <Calabaza base={[calX, total, zF - 0.05]} />
+      {/* la mariposa que visita la flor de la calabaza (vida, no relleno) */}
+      <Fauna base={[calX - 0.15, total + 0.5, zF + 0.12]} phase={1.7} deriva={0.5} asomo={0.05} reducedMotion={reducedMotion}>
+        <Mariposa size={38} animated={!reducedMotion} />
+      </Fauna>
     </group>
   );
 }
@@ -221,6 +391,8 @@ function Diorama({ params, reducedMotion }) {
           <Escarabajo size={42} animated={!reducedMotion} />
         </Fauna>
       )}
+      {/* la milpa: las tres hermanas arriba y los nódulos de N abajo (opt-in) */}
+      {params?.milpa && <Milpa total={total} config={params.milpa} reducedMotion={reducedMotion} />}
     </group>
   );
 }

--- a/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
+++ b/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
@@ -46,7 +46,44 @@ function FondoCutaway({ params, acento }) {
           <path key={v.key} d={`M${v.bx},${v.by} l3,14 l-2,10`} stroke="#c9a86a" strokeWidth="2" fill="none" strokeLinecap="round" />
         ),
       )}
+      {/* las TRES HERMANAS (opt-in): maíz-fríjol-calabaza arriba y, abajo, los
+          nódulos rosados del fríjol = el nitrógeno que se ve. Misma lección 2D. */}
+      {params?.milpa && <MilpaCutaway acento={acento} sueloY={tops[0]} />}
       <rect x="0" y="0" width="300" height="200" fill="none" stroke={acento} strokeWidth="2" opacity="0.4" />
+    </g>
+  );
+}
+
+/* El módulo de la milpa dibujado sobre el corte (gemelo 2D del diorama 3D). */
+function MilpaCutaway({ sueloY = 26 }) {
+  const gx = 132; // eje del maíz
+  const nod = [
+    [gx - 3, sueloY + 12], [gx + 4, sueloY + 20], [gx - 2, sueloY + 29],
+    [gx + 3, sueloY + 38], [gx - 4, sueloY + 46],
+  ];
+  return (
+    <g>
+      {/* el maíz: la vara viva (tutor) */}
+      <line x1={gx} y1={sueloY} x2={gx} y2="6" stroke="#6f9a45" strokeWidth="3.2" strokeLinecap="round" />
+      <path d={`M${gx},18 l12,-6`} stroke="#6f9a45" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+      <path d={`M${gx},12 l-11,-5`} stroke="#6f9a45" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+      <ellipse cx={gx + 4} cy="16" rx="3.2" ry="5.5" fill="#ecd98f" />
+      {/* el fríjol: se enreda subiendo por la caña */}
+      <path
+        d={`M${gx},${sueloY} C${gx - 9},${sueloY - 8} ${gx + 9},${sueloY - 16} ${gx},${sueloY - 24} C${gx - 8},${sueloY - 30} ${gx + 8},${sueloY - 38} ${gx},${sueloY - 44}`}
+        stroke="#4f8a34" strokeWidth="2" fill="none" strokeLinecap="round"
+      />
+      {/* la calabaza: hojas rastreras + fruto ocre + flor amarilla */}
+      <ellipse cx={gx + 34} cy={sueloY - 3} rx="12" ry="6" fill="#5f8a3f" />
+      <ellipse cx={gx + 52} cy={sueloY - 2} rx="9" ry="5" fill="#5f8a3f" />
+      <ellipse cx={gx + 44} cy={sueloY - 5} rx="7" ry="5.4" fill="#cf8f3c" />
+      <circle cx={gx + 60} cy={sueloY - 6} r="3" fill="#e8c34a" />
+      {/* la raíz del fríjol con sus NÓDULOS rosados (el nitrógeno visible) */}
+      <path d={`M${gx},${sueloY} l0,52`} stroke="#c9a86a" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+      <path d={`M${gx},${sueloY + 22} l10,10`} stroke="#c9a86a" strokeWidth="1.6" fill="none" strokeLinecap="round" />
+      {nod.map((n) => (
+        <circle key={`${n[0]}-${n[1]}`} cx={n[0]} cy={n[1]} r="2.6" fill="#e0a3ad" stroke="#c98494" strokeWidth="0.6" />
+      ))}
     </g>
   );
 }

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -243,6 +243,40 @@ export const MUNDO = {
     ruta2d: { view: 'hoy_finca' },
     entrada: { narra: 'clima' },
   },
+
+  // 🌽 LA MILPA — las TRES HERMANAS en corte (cutaway). Sobre la superficie, la
+  //    asociación viva (maíz=vara, fríjol que trepa y abona, calabaza que cubre);
+  //    bajo tierra, lo invisible hecho visible: los NÓDULOS de Rhizobium en las
+  //    raíces del fríjol fijando 50–80 kg N/ha (dato verificado). Reusa el
+  //    arquetipo `cutaway` (mismas capas + vida) y enciende el módulo `milpa`.
+  //    Policultivo, no monocultivo: juntas rinden más y se cuidan (push-pull).
+  milpa: {
+    escena: 'cutaway',
+    params: {
+      vida: 0.5,
+      capas: [
+        { nombre: 'superficie viva', color: '#6b4a2e', alto: 0.4, bichos: ['raiz'] },
+        { nombre: 'suelo negro', color: '#3a2a1a', alto: 1.05, bichos: ['raiz', 'hifa'] },
+        { nombre: 'subsuelo', color: '#8a6a44', alto: 0.85, bichos: ['raiz'] },
+      ],
+      // el módulo de las tres hermanas (arriba la asociación, abajo los nódulos)
+      milpa: {
+        maiz: { x: -0.25, alto: 1.7 },
+        frijol: { vueltas: 4 },
+        calabaza: { x: 0.7 },
+        nitrogeno: '50–80 kg N/ha',
+      },
+    },
+    hotspots: [
+      { id: 'milpa', pos: [-0.25, 1.9, 0.9], emoji: '🌽', label: 'La milpa paso a paso', view: 'milpa_cultivo' },
+      { id: 'frijol', pos: [-0.25, 0.1, 1.0], emoji: '🫘', label: 'El fríjol que abona', view: 'asociaciones' },
+      { id: 'asocio', pos: [1.4, 0.5, 0.4], emoji: '🌱', label: 'Qué asocio', view: 'directorio' },
+      { id: 'cuando', pos: [-1.4, 0.5, 0.4], emoji: '🗓️', label: 'Cuándo siembro', view: 'calendario_finca' },
+    ],
+    entrada: { zoom: 7, narra: 'milpa' },
+    // El gemelo 2D digno: el mismo corte con las tres hermanas y los nódulos.
+    fallback2d: { escena: 'mirror' },
+  },
 };
 
 /** Ids de todos los mundos registrados. */


### PR DESCRIPTION
## Mundo 3D de la milpa (mundo #5 del batch)

Reusa el arquetipo `cutaway` para contar **las tres hermanas**: sobre la cama, la asociación viva; bajo tierra, **lo invisible hecho visible** — los nódulos de *Rhizobium* en las raíces del fríjol fijando N.

### Concepto (verificado)
- **Maíz** = tutor vivo (la vara por donde trepa el fríjol).
- **Fríjol** = trepa + fija **50–80 kg N/ha** vía *Rhizobium* → nódulos rosados visibles en el corte.
- **Calabaza** = cobertura rastrera (sombrea el suelo, guarda humedad, su flor llama a la abeja).
- Policultivo **push-pull**, no monocultivo.

### Cómo
- **UNA entrada** `milpa` en `mundoData.js` (cutaway + módulo `params.milpa`), en bloque propio al final, sin reordenar lo existente.
- Primitivas de planta menores en `EscenaCutaway` (opt-in por `params.milpa`, **no toca** suelo/abono): `MataMaiz`, `GuiaFrijol`, `Calabaza`, `RaizNodulos`.
- **Gemelo 2D digno**: las tres hermanas + nódulos en `FondoCutaway` (mismo dato, misma lección para gama baja).
- Vitrina pública `Mundo3DMilpa` + ruta `#/mockups/mundo3d-milpa`.

### Duras
R3F low-poly primitivas orgánicas (cono/cilindro/esfera, sin cajas) · layout por datos · `three` lazy (`vendor-three`) · fallback 2D · móvil 320px · `prefers-reduced-motion` (fauna congelada) · self-contained (cero CDN) · usted-CO. Hotspots re-rutean a vistas reales: `milpa_cultivo` / `asociaciones` / `directorio` / `calendario_finca`. La abeja Angelita entra + mariposa en la flor de calabaza.

### Cierre
`npm run build` verde (exit 0, `vendor-three` en su propio chunk). Sin tsc-gate/eslint por regla de cierre del turno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)