### PR TITLE
feat(mundo3d): mundo de la ladera / pisos térmicos (arquetipo estratos)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,6 +83,7 @@ const EntradaValle3DMockup = lazy(() => import('./mockups/EntradaValle3D'));
 // (src/visual/mundo3d) con device-tiering real. El 3D va perezoso (vendor-three).
 const Mundo3DAguaMockup = lazy(() => import('./mockups/Mundo3DAgua'));
 const Mundo3DSueloMockup = lazy(() => import('./mockups/Mundo3DSuelo'));
+const Mundo3DBosqueMockup = lazy(() => import('./mockups/Mundo3DBosque'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -467,6 +468,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/entrada-3d': 'mockup_entrada_3d',
   'mockups/mundo3d-agua': 'mockup_mundo3d_agua',
   'mockups/mundo3d-suelo': 'mockup_mundo3d_suelo',
+  'mockups/mundo3d-bosque': 'mockup_mundo3d_bosque',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
   'mockups/ensena-dibujando': 'mockup_ensena_dibujando',
@@ -1338,6 +1340,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del suelo">
               <Mundo3DSueloMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_bosque':
+        // Vitrina pública de la LADERA / PISOS TÉRMICOS: monta <Mundo mundoId="pisos">
+        // del framework (src/visual/mundo3d) sobre el arquetipo `estratos`
+        // reparametrizado, con device-tiering real. Ruta #/mockups/mundo3d-bosque,
+        // sin auth. La ladera andina en corte: cálido → templado → frío → páramo,
+        // con la señal sutil de que los pisos suben (termofilización), sin catástrofe.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="La ladera y sus pisos">
+              <Mundo3DBosqueMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mundo3DBosque.css
+++ b/src/mockups/Mundo3DBosque.css
@@ -1,0 +1,152 @@
+/*
+ * Mundo3DBosque.css — vitrina pública de la ladera / pisos térmicos
+ * (#/mockups/mundo3d-bosque). Autocontenida: sin fuentes/imágenes externas.
+ * Móvil-first desde 320px. El fondo evoca el gradiente térmico (niebla azul
+ * arriba → dorado cálido abajo). Solo opacity/transform animables.
+ */
+
+.m3db {
+  --m3db-a: #4f8f7d;
+  --m3db-b: #e6efe9;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3db-b) 0%, #eef1e2 46%, #f2e6cf 100%);
+  color: #253028;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3db__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3db__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3db-a);
+}
+.m3db__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #1c3a30;
+}
+.m3db__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3db__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3db__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(79, 143, 125, 0.25);
+  box-shadow: 0 10px 28px rgba(28, 58, 48, 0.12);
+}
+.m3db__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fdfaf2;
+}
+
+.m3db__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3db__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3db__toggle {
+  border: 1.5px solid var(--m3db-a);
+  background: #fff;
+  color: var(--m3db-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3db__toggle:hover,
+.m3db__toggle:focus-visible {
+  background: var(--m3db-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3db__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.75);
+  border-left: 3px solid var(--m3db-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3db__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3db__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #1c3a30;
+}
+.m3db__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3db__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3db__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(79, 143, 125, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3db__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3db__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #1c3a30;
+}
+.m3db__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3db__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #2c4a3a;
+}

--- a/src/mockups/Mundo3DBosque.jsx
+++ b/src/mockups/Mundo3DBosque.jsx
@@ -1,0 +1,132 @@
+/*
+ * Mundo3DBosque — vitrina pública de la LADERA ANDINA / PISOS TÉRMICOS
+ * (ruta #/mockups/mundo3d-bosque).
+ *
+ * La montaña en corte vertical: se sube del cálido al páramo y en cada piso
+ * crece lo suyo — la altura manda. Cálido (plátano y frutales) → templado (café
+ * y maíz) → frío (papa) → páramo (frailejón y la niebla que capta agua, zona que
+ * se cuida, no se ara). Trae una señal SUTIL de cambio climático: los pisos
+ * suben de a poco (termofilización), sin catástrofe. Didáctico y esperanzador —
+ * menos colapso, finca viva.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="pisos">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`) sobre el
+ * arquetipo `estratos` reparametrizado a 4 pisos. En equipo humilde (o con
+ * "menos movimiento") se ve el gemelo 2D digno con las mismas bandas térmicas;
+ * en gama media/alta, el diorama 3D low-poly (chunk perezoso `vendor-three`) con
+ * la abeja Angelita entrando al mundo. Los puntos de la ladera son las mismas
+ * puertas del registro: aquí (vitrina sin sesión) muestran a qué pantalla real
+ * de la app llevan, en vez de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import './Mundo3DBosque.css';
+
+const TINTE = ['#4f8f7d', '#e6efe9'];
+
+/* La ladera, piso por piso — la misma data del registro (mundoData.js), contada
+   en una leyenda didáctica y verificada. */
+const LEYENDA = [
+  { emoji: '🌴', titulo: 'Cálido · 0–1.000 m', texto: 'Lo bajo y caliente: plátano, cacao, cítricos y ahuyama. El calor abundante manda; se cosecha casi todo el año.' },
+  { emoji: '☕', titulo: 'Templado · 1.000–2.000 m', texto: 'El piso del café de sombra, el aguacate y la caña. Ni mucho calor ni mucho frío: aquí la finca da lo más conocido.' },
+  { emoji: '🥔', titulo: 'Frío · 2.000–3.000 m', texto: 'La papa, el maíz criollo, el fríjol, la uchuva y la mora. Fresco y de noches largas: sabores que sólo dan en la altura.' },
+  { emoji: '🏔️', titulo: 'Páramo · 3.000–4.200 m', texto: 'El frailejón y la niebla que capta el agua para toda la finca de abajo. No se ara: se cuida. Es la fábrica de agua de la montaña.' },
+  { emoji: '🌡️', titulo: 'Los pisos suben', texto: 'Con el calentamiento, cada piso trepa de a poco: lo que hoy da en su altura, mañana da un poco más arriba. No es catástrofe — es una señal para observar y acompañar el páramo.' },
+];
+
+export default function Mundo3DBosque() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // En la vitrina (sin sesión) un punto de la ladera no navega: cuenta a qué
+  // pantalla real de la app lleva esa puerta.
+  const [puerta, setPuerta] = useState(null);
+  const onHotspot = (view, data) => {
+    const hs = (MUNDO.pisos.hotspots || []).find(
+      (h) => h.view === view && (h.data === data || (!h.data && !data)),
+    ) || (MUNDO.pisos.hotspots || []).find((h) => h.view === view);
+    setPuerta({ label: hs?.label || view, view });
+  };
+
+  return (
+    <main
+      className="m3db"
+      style={{ '--m3db-a': TINTE[0], '--m3db-b': TINTE[1] }}
+    >
+      <header className="m3db__head">
+        <p className="m3db__kicker">Los mundos de su finca · vitrina</p>
+        <h1>La ladera y sus pisos</h1>
+        <p className="m3db__lema">
+          Suba por la montaña: del cálido al páramo, cada piso con lo suyo. La
+          altura manda qué se siembra. Menos colapso, finca viva.
+        </p>
+      </header>
+
+      <section className="m3db__escena" aria-label="La ladera andina y sus pisos térmicos">
+        <Mundo
+          mundoId="pisos"
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          onSalir={null}
+          animo="sereno"
+          energia={0.85}
+        />
+        <div className="m3db__barra">
+          <p className="m3db__tier">
+            {tier === 'bajo'
+              ? 'Está viendo el dibujo de la ladera (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3db__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver el dibujo 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3db__nota" role="status" aria-live="polite">
+          {puerta
+            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+            : 'Toque un piso de la ladera para ver a dónde lo lleva.'}
+        </p>
+      </section>
+
+      <section className="m3db__leyenda" aria-label="La ladera, piso por piso">
+        <h2>La ladera, piso por piso</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3db__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3db__cierre">
+          No pelee con la altura: acompáñela. Mire a qué piso pertenece su finca y
+          siembre lo que ese piso pide — y cuide el páramo de arriba, que es el que
+          le manda el agua. Empiece por saber su altura.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/visual/mundo3d/escenas/EscenaEstratos.jsx
+++ b/src/visual/mundo3d/escenas/EscenaEstratos.jsx
@@ -1,12 +1,19 @@
 /*
- * EscenaEstratos — ARQUETIPO `estratos`: la VERTICALIDAD del bosque comestible.
+ * EscenaEstratos — ARQUETIPO `estratos`: la VERTICALIDAD como lección.
  *
- * Los 7 estratos (emergente → dosel → sub-dosel → arbusto → herbáceo → rastrero
- * → raíz) son verticales POR DEFINICIÓN: la verticalidad ES la lección, y una
- * lista plana la mata. Aquí cada estrato es una banda de altura con su vegetación
- * low-poly repetida (troncos + copas / matas). Con muchos árboles el DR pide
- * `InstancedMesh`; este arquetipo usa un conteo acotado por estrato y `MeshLambert`
- * sin sombras (DR §6) — el que "estresa" el framework más allá del cutaway.
+ * Sirve DOS mundos con la MISMA geometría, elegidos por datos (DR §4.2, "una
+ * entrada = un mundo; cero código de escena nuevo"):
+ *
+ *   · `disenio`  → params.estratos: los 7 estratos del BOSQUE COMESTIBLE (dosel
+ *                  → raíz). La verticalidad ES el diseño de la finca.
+ *   · `pisos`    → params.pisos: la LADERA ANDINA en corte, el gradiente
+ *                  ALTITUDINAL (cálido → templado → frío → páramo). La altura
+ *                  manda: en cada piso crece lo suyo. Señal SUTIL de cambio
+ *                  climático (termofilización: los pisos suben), sin catástrofe.
+ *
+ * Bandas/terrazas con vegetación low-poly repetida y `MeshLambert` sin sombras
+ * (DR §6). Con `params.pisos` presente se dibuja la ladera; si no, el bosque
+ * comestible de siempre (retro-compatible byte a byte para `disenio`).
  */
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
@@ -46,7 +53,8 @@ function Planta({ x, z, alto, color, r }) {
   );
 }
 
-function Diorama({ params, reducedMotion }) {
+/* ── El bosque comestible (mundo `disenio`) — sin cambios ─────────────────── */
+function DioramaEstratos({ params, reducedMotion }) {
   const estratos = params?.estratos || ESTRATOS_DEF;
   const plantas = useMemo(() => {
     const out = [];
@@ -78,16 +86,252 @@ function Diorama({ params, reducedMotion }) {
   );
 }
 
+/* ═══ LA LADERA ANDINA (mundo `pisos`) ════════════════════════════════════════
+ * Cuatro terrazas que suben del cálido al páramo, cada una con su cultivo
+ * emblemático low-poly y su color térmico (dorado abajo → azul-frío/blanco
+ * arriba). Vida sólo donde de veras vive: colibrí y mariposa en templado/frío;
+ * el páramo va sin bichos (honestidad ecológica) y con niebla que capta agua.
+ */
+
+/* Cuánto sube y cuánto se mete al fondo cada piso (staircase de ladera). */
+const PISO_SUBE = 1.15;
+const PISO_FONDO = 0.7;
+const pisoY = (i) => 0.2 + i * PISO_SUBE; // superficie de la terraza i
+const pisoZ = (i) => 0.6 - i * PISO_FONDO; // se recede al subir (profundidad)
+
+/* Fauna de la ladera: en el aire templado/frío; NADA en el páramo. */
+const FAUNA_PISOS = [
+  { tipo: 'mariposa', base: [-0.7, pisoY(1) + 0.55, pisoZ(1) + 0.5], patron: 'revoloteo', size: 30, fase: 1.4 },
+  { tipo: 'colibri', base: [0.7, pisoY(2) + 0.55, pisoZ(2) + 0.4], patron: 'revoloteo', size: 28, fase: 0.6 },
+];
+
+/* Plátano/frutal (piso cálido): pseudotallo verde + hojas grandes colgantes. */
+function Platano() {
+  return (
+    <group>
+      <mesh position={[0, 0.38, 0]}>
+        <cylinderGeometry args={[0.05, 0.08, 0.76, 6]} />
+        <meshLambertMaterial color="#7d8a3e" flatShading />
+      </mesh>
+      {[0, 1, 2, 3, 4].map((k) => (
+        <mesh
+          key={k}
+          position={[Math.cos((k / 5) * Math.PI * 2) * 0.16, 0.74, Math.sin((k / 5) * Math.PI * 2) * 0.16]}
+          rotation={[Math.PI * 0.42, (k / 5) * Math.PI * 2, 0]}
+          scale={[0.5, 1, 1]}
+        >
+          <coneGeometry args={[0.1, 0.62, 4]} />
+          <meshLambertMaterial color="#4f7a34" flatShading />
+        </mesh>
+      ))}
+      {/* racimo (fruto) */}
+      <mesh position={[0.1, 0.5, 0.08]} scale={[0.6, 1, 0.6]}>
+        <sphereGeometry args={[0.12, 6, 5]} />
+        <meshLambertMaterial color="#b9c24a" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* Cafeto de sombra (piso templado): arbusto redondo + cerezas rojas. */
+function Cafeto() {
+  return (
+    <group>
+      <mesh position={[0, 0.13, 0]}>
+        <cylinderGeometry args={[0.035, 0.05, 0.26, 5]} />
+        <meshLambertMaterial color="#6b4a2e" flatShading />
+      </mesh>
+      <mesh position={[0, 0.42, 0]} scale={[1, 0.95, 1]}>
+        <sphereGeometry args={[0.28, 7, 6]} />
+        <meshLambertMaterial color="#3f6f3a" flatShading />
+      </mesh>
+      {[0, 1, 2, 3].map((k) => (
+        <mesh
+          key={k}
+          position={[Math.cos((k / 4) * Math.PI * 2) * 0.24, 0.42 + (k % 2) * 0.08, Math.sin((k / 4) * Math.PI * 2) * 0.24]}
+        >
+          <sphereGeometry args={[0.04, 5, 4]} />
+          <meshLambertMaterial color="#c0392b" flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Papa (piso frío): mata baja y matoja + flores lilas. */
+function Papa() {
+  return (
+    <group>
+      <mesh position={[0, 0.14, 0]} scale={[1, 0.55, 1]}>
+        <sphereGeometry args={[0.3, 7, 6]} />
+        <meshLambertMaterial color="#5f8a3f" flatShading />
+      </mesh>
+      <mesh position={[0.22, 0.11, 0.14]} scale={[1, 0.5, 1]}>
+        <sphereGeometry args={[0.18, 6, 5]} />
+        <meshLambertMaterial color="#6d9748" flatShading />
+      </mesh>
+      {[[-0.1, 0.3, 0.08], [0.14, 0.28, -0.05]].map((p, k) => (
+        <mesh key={k} position={p}>
+          <sphereGeometry args={[0.035, 5, 4]} />
+          <meshLambertMaterial color="#d3c2e6" flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Frailejón (páramo): tronco de hojas viejas + roseta plateada que sube. NO es
+   cultivo: es conservación (el páramo se cuida, no se ara). */
+function Frailejon() {
+  return (
+    <group>
+      <mesh position={[0, 0.32, 0]}>
+        <cylinderGeometry args={[0.1, 0.13, 0.64, 7]} />
+        <meshLambertMaterial color="#7a6a52" flatShading />
+      </mesh>
+      {Array.from({ length: 8 }, (_, k) => (
+        <mesh
+          key={k}
+          position={[Math.cos((k / 8) * Math.PI * 2) * 0.11, 0.66, Math.sin((k / 8) * Math.PI * 2) * 0.11]}
+          rotation={[Math.PI * 0.28, (k / 8) * Math.PI * 2, 0]}
+        >
+          <coneGeometry args={[0.05, 0.34, 4]} />
+          <meshLambertMaterial color="#9fb090" flatShading />
+        </mesh>
+      ))}
+      <mesh position={[0, 0.78, 0]}>
+        <coneGeometry args={[0.11, 0.2, 6]} />
+        <meshLambertMaterial color="#c7d2bd" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+const CULTIVOS = { platano: Platano, cafe: Cafeto, papa: Papa, frailejon: Frailejon };
+
+function SiluetaCultivo({ tipo, x, y, z }) {
+  const Comp = CULTIVOS[tipo];
+  if (!Comp) return null;
+  return (
+    <group position={[x, y, z]}>
+      <Comp />
+    </group>
+  );
+}
+
+/* Puf de niebla del páramo (capta agua): esfera achatada, translúcida, quieta
+   (digna con reduced-motion: no se mueve, no desaparece). */
+function Niebla({ x, y, z, r = 0.5 }) {
+  return (
+    <mesh position={[x, y, z]} scale={[1, 0.34, 1]}>
+      <sphereGeometry args={[r, 8, 6]} />
+      <meshBasicMaterial color="#eef4f4" transparent opacity={0.5} />
+    </mesh>
+  );
+}
+
+function DioramaPisos({ params, reducedMotion }) {
+  const pisos = params?.pisos || [];
+  // Cultivos por terraza, con aire (2 por piso, jitter determinista).
+  const siembra = useMemo(() => {
+    const out = [];
+    let s = 11;
+    pisos.forEach((p, i) => {
+      const cuenta = p.cultivo === 'frailejon' ? 2 : 2;
+      for (let j = 0; j < cuenta; j++) {
+        s = (s * 1103515245 + 12345) >>> 0;
+        const x = ((s % 1000) / 1000 - 0.5) * 1.5 + (j === 0 ? -0.45 : 0.5);
+        s = (s * 1103515245 + 12345) >>> 0;
+        const z = pisoZ(i) + ((s % 1000) / 1000 - 0.5) * 0.5;
+        out.push({ key: `${i}-${j}`, tipo: p.cultivo, x, y: pisoY(i) + 0.07, z });
+      }
+    });
+    return out;
+  }, [pisos]);
+
+  return (
+    <group position={[0, 0, 0]}>
+      {/* la ladera al fondo: silueta de montaña por capas (profundidad) */}
+      <mesh position={[-0.6, 1.3, -3.4]}>
+        <coneGeometry args={[3.3, 4.6, 5]} />
+        <meshLambertMaterial color="#9fb4bc" flatShading />
+      </mesh>
+      <mesh position={[1.4, 1.0, -3.0]}>
+        <coneGeometry args={[2.6, 3.7, 5]} />
+        <meshLambertMaterial color="#adc0c6" flatShading />
+      </mesh>
+
+      {/* las cuatro terrazas que suben, cada una con su color térmico */}
+      {pisos.map((p, i) => (
+        <group key={p.id}>
+          <mesh position={[0, pisoY(i), pisoZ(i)]}>
+            <cylinderGeometry args={[1.28 - i * 0.13, 1.34 - i * 0.13, 0.16, 24]} />
+            <meshLambertMaterial color={p.color} flatShading />
+          </mesh>
+          {/* faldón sombreado del escalón: da la sensación de pendiente */}
+          {i > 0 && (
+            <mesh position={[0, pisoY(i) - 0.5, pisoZ(i) + 0.28]}>
+              <cylinderGeometry args={[0.14, 0.14, 0.86, 6]} />
+              <meshLambertMaterial color="#6b5a3e" flatShading />
+            </mesh>
+          )}
+        </group>
+      ))}
+
+      {/* la vegetación emblemática de cada piso */}
+      {siembra.map((c) => (
+        <SiluetaCultivo key={c.key} tipo={c.tipo} x={c.x} y={c.y} z={c.z} />
+      ))}
+
+      {/* niebla del páramo (piso más alto): capta agua, quieta y digna */}
+      {pisos.map((p, i) =>
+        p.niebla ? (
+          <group key={`n-${p.id}`}>
+            <Niebla x={-0.4} y={pisoY(i) + 0.7} z={pisoZ(i) + 0.2} r={0.55} />
+            <Niebla x={0.55} y={pisoY(i) + 0.55} z={pisoZ(i) - 0.15} r={0.45} />
+            <Niebla x={0.1} y={pisoY(i) + 0.9} z={pisoZ(i) + 0.35} r={0.4} />
+          </group>
+        ) : null,
+      )}
+
+      {/* señal SUTIL de que los pisos suben (termofilización): flecha ámbar
+          tenue al costado — cuidado, nunca alarma (norte "finca viva"). */}
+      <group position={[1.85, pisoY(2), pisoZ(2) + 0.2]}>
+        <mesh position={[0, 0, 0]}>
+          <cylinderGeometry args={[0.016, 0.016, 0.9, 5]} />
+          <meshBasicMaterial color="#d9a13b" transparent opacity={0.5} />
+        </mesh>
+        <mesh position={[0, 0.55, 0]}>
+          <coneGeometry args={[0.08, 0.2, 5]} />
+          <meshBasicMaterial color="#d9a13b" transparent opacity={0.55} />
+        </mesh>
+      </group>
+
+      {/* vida sólo donde vive: mariposa (templado), colibrí (frío/templado) */}
+      <Fauna items={FAUNA_PISOS} reducedMotion={reducedMotion} />
+    </group>
+  );
+}
+
 export default function EscenaEstratos(props) {
-  const cielo = { fondo: '#d7e6c9', cielo: '#eaf2df', suelo: '#5f4a2e', intensidad: 1.1 };
+  const esPisos = Array.isArray(props.params?.pisos);
+  const cielo = esPisos
+    ? { fondo: '#cfe0e6', cielo: '#e8f0ee', suelo: '#6b5236', intensidad: 1.12 }
+    : { fondo: '#d7e6c9', cielo: '#eaf2df', suelo: '#5f4a2e', intensidad: 1.1 };
+  const camara = esPisos ? { position: [4.4, 3.7, 6.4], fov: 46 } : { position: [3.5, 3, 6], fov: 44 };
+  const centro = esPisos ? [0, 1.95, -0.4] : [0, 1.4, 0];
   return (
     <EscenaBase3D
       {...props}
       cielo={cielo}
-      camara={{ position: [3.5, 3, 6], fov: 44 }}
-      entrada={{ ...props.entrada, centro: [0, 1.4, 0] }}
+      camara={camara}
+      entrada={{ ...props.entrada, centro }}
     >
-      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+      {esPisos ? (
+        <DioramaPisos params={props.params} reducedMotion={props.reducedMotion} />
+      ) : (
+        <DioramaEstratos params={props.params} reducedMotion={props.reducedMotion} />
+      )}
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
+++ b/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
@@ -125,7 +125,47 @@ function FondoRecinto({ acento }) {
   );
 }
 
+/* La LADERA ANDINA en 2D (mundo `pisos`): las mismas 4 bandas térmicas del
+   diorama 3D, del páramo (arriba) al cálido (abajo), con su rótulo de altura,
+   la niebla del páramo y la flecha ámbar de que los pisos suben (termofilización,
+   señal sutil — nunca alarma). Mismo dato del registro; piso digno garantizado. */
+function FondoPisos({ pisos }) {
+  const n = pisos.length || 1;
+  const bandH = 200 / n;
+  // arriba = el piso más alto (páramo); el array viene de bajo (cálido) a alto.
+  const orden = [...pisos].reverse();
+  return (
+    <g>
+      <rect x="0" y="0" width="300" height="200" fill="#e7f0ee" />
+      {orden.map((p, i) => {
+        const y = i * bandH;
+        return (
+          <g key={p.id || i}>
+            <rect x="0" y={y} width="300" height={bandH} fill={p.color} opacity="0.94" />
+            <text x="12" y={y + bandH / 2 - 2} fontSize="12" fontWeight="700" fill="#1f2a24">{p.nombre}</text>
+            <text x="12" y={y + bandH / 2 + 13} fontSize="10" fill="#33413a">{p.rango}</text>
+          </g>
+        );
+      })}
+      {/* niebla del páramo (banda de arriba): capta agua */}
+      {orden[0]?.niebla && (
+        <g fill="#f4f9f8" opacity="0.75">
+          <ellipse cx="210" cy={bandH * 0.4} rx="34" ry="10" />
+          <ellipse cx="255" cy={bandH * 0.62} rx="26" ry="8" />
+          <ellipse cx="180" cy={bandH * 0.66} rx="22" ry="7" />
+        </g>
+      )}
+      {/* los pisos suben: flecha ámbar tenue al costado (cuidado, no catástrofe) */}
+      <g stroke="#d9a13b" strokeWidth="3" fill="none" opacity="0.6" strokeLinecap="round">
+        <line x1="284" y1="176" x2="284" y2="34" />
+        <path d="M278,44 L284,30 L290,44" strokeLinejoin="round" />
+      </g>
+    </g>
+  );
+}
+
 function FondoEstratos({ params, acento }) {
+  if (Array.isArray(params?.pisos)) return <FondoPisos pisos={params.pisos} />;
   const estratos = params?.estratos || [
     { color: '#2f5f34' }, { color: '#3a6f3f' }, { color: '#4a7d45' }, { color: '#5f8a3f' },
     { color: '#7aa24a' }, { color: '#8fae55' }, { color: '#8a6a44' },

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -243,6 +243,36 @@ export const MUNDO = {
     ruta2d: { view: 'hoy_finca' },
     entrada: { narra: 'clima' },
   },
+
+  // 🌡️ PISOS TÉRMICOS / LADERA ANDINA — la altura manda (arquetipo `estratos`
+  //    reparametrizado). Se sube del cálido al páramo y en cada piso crece lo
+  //    suyo. Señal SUTIL de cambio climático: los pisos suben (termofilización),
+  //    sin catástrofe (norte "menos colapso, finca viva"). NO duplica `disenio`
+  //    (ese usa `estratos` para los 7 estratos del bosque comestible); aquí es el
+  //    gradiente ALTITUDINAL, que vive en `params.pisos` (de bajo a alto) y lo
+  //    leen por igual el diorama 3D y su gemelo 2D. Vitrina: #/mockups/mundo3d-bosque.
+  pisos: {
+    escena: 'estratos',
+    params: {
+      // Pisos de bajo (cálido) a alto (páramo). Verificado (catálogo thermal_zones
+      // + clasificación de Caldas). Color térmico: dorado abajo → azul-frío/blanco
+      // páramo arriba. El páramo se PROTEGE (frailejón, niebla que capta agua),
+      // no se ara.
+      pisos: [
+        { id: 'calido', nombre: 'Cálido', rango: '0–1000 m', color: '#cba04a', cultivo: 'platano' },
+        { id: 'templado', nombre: 'Templado', rango: '1000–2000 m', color: '#6f9e4a', cultivo: 'cafe' },
+        { id: 'frio', nombre: 'Frío', rango: '2000–3000 m', color: '#4f8f7d', cultivo: 'papa' },
+        { id: 'paramo', nombre: 'Páramo', rango: '3000–4200 m', color: '#aec7cf', cultivo: 'frailejon', niebla: true, protege: true },
+      ],
+    },
+    hotspots: [
+      { id: 'directorio', pos: [-1.4, 1.7, 0.7], emoji: '🌡️', label: 'Qué siembro según mi altura', view: 'directorio' },
+      { id: 'cafe', pos: [1.0, 1.75, 0.15], emoji: '☕', label: 'El piso del café', view: 'cafe' },
+      { id: 'papa', pos: [-1.0, 2.9, -0.35], emoji: '🥔', label: 'El piso de la papa', view: 'tuberculos' },
+      { id: 'paramo', pos: [0.7, 4.0, -0.9], emoji: '🏔️', label: 'El páramo se cuida', view: 'restauracion' },
+    ],
+    entrada: { zoom: 8, narra: 'pisos' },
+  },
 };
 
 /** Ids de todos los mundos registrados. */


### PR DESCRIPTION
## Qué

Mundo #4 del batch 3D: la **ladera andina / pisos térmicos** sobre el arquetipo `estratos` reusado. Se sube del cálido al páramo y en cada piso crece lo suyo — la altura manda.

**Concepto:** cálido (plátano/frutales) → templado (café/maíz) → frío (papa) → páramo (frailejón + niebla que capta agua, zona que se cuida, no se ara). Señal **sutil** de cambio climático: los pisos suben (termofilización), sin catástrofe. Norte: *menos colapso, finca viva*.

## Cómo (data-driven, cero escena nueva)

- **`EscenaEstratos`**: rama nueva gateada por `params.pisos` (terrazas que suben en escalón, cultivos low-poly por piso, frailejón con roseta, niebla del páramo, montaña de fondo, fauna sólo donde vive: mariposa/colibrí en templado-frío, nada en páramo). El render clásico de `disenio` (7 estratos del bosque comestible) queda **intacto**.
- **`LaminaMundo`**: gemelo 2D `FondoPisos` — mismas bandas térmicas del páramo (arriba) al cálido (abajo), rótulos de altura, niebla y flecha ámbar de termofilización.
- **`mundoData`**: UNA entrada `pisos` (4 pisos verificados vs catálogo `thermal_zones` + clasificación de Caldas), hotspots reales: 🌡️ `directorio` · ☕ `cafe` · 🥔 `tuberculos` · 🏔️ `restauracion`.
- **Vitrina** `Mundo3DBosque` + ruta pública `#/mockups/mundo3d-bosque`.

## Duras

R3F low-poly primitivas orgánicas · layout por datos · three/@react-three perezoso (`vendor-three`) · fallback 2D digno · usted-CO · self-contained · móvil 320px · `prefers-reduced-motion` (niebla/insectos se congelan) · sin Playwright.

## Verificación

`npm run build` verde (`✓ built in 3m 15s`, `vendor-three` en chunk aparte). Sin tsc-gate/eslint por regla de cierre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)