### PR TITLE
feat(mundo3d): mundo del clima — la bóveda del cielo (arquetipo boveda)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,6 +83,9 @@ const EntradaValle3DMockup = lazy(() => import('./mockups/EntradaValle3D'));
 // (src/visual/mundo3d) con device-tiering real. El 3D va perezoso (vendor-three).
 const Mundo3DAguaMockup = lazy(() => import('./mockups/Mundo3DAgua'));
 const Mundo3DSueloMockup = lazy(() => import('./mockups/Mundo3DSuelo'));
+// 3D: "El mundo del clima" — monta <Mundo mundoId="clima"> del framework: la
+// bóveda del cielo (arquetipo nuevo `boveda`). El 3D va perezoso (vendor-three).
+const Mundo3DClimaMockup = lazy(() => import('./mockups/Mundo3DClima'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -467,6 +470,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/entrada-3d': 'mockup_entrada_3d',
   'mockups/mundo3d-agua': 'mockup_mundo3d_agua',
   'mockups/mundo3d-suelo': 'mockup_mundo3d_suelo',
+  'mockups/mundo3d-clima': 'mockup_mundo3d_clima',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
   'mockups/ensena-dibujando': 'mockup_ensena_dibujando',
@@ -1338,6 +1342,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del suelo">
               <Mundo3DSueloMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_clima':
+        // Vitrina pública del MUNDO DEL CLIMA: monta <Mundo mundoId="clima"> del
+        // framework (src/visual/mundo3d) con device-tiering real. Ruta
+        // #/mockups/mundo3d-clima, sin auth. La bóveda del cielo de la finca:
+        // hora del día + temporada bimodal andina + niebla del páramo + la
+        // montaña de pisos con el hielo que se va (conciencia, no alarma).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del clima">
+              <Mundo3DClimaMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mundo3DClima.css
+++ b/src/mockups/Mundo3DClima.css
@@ -1,0 +1,151 @@
+/*
+ * Mundo3DClima.css — vitrina pública del mundo del clima (#/mockups/mundo3d-clima).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Solo opacity/transform animables; reduced-motion las apaga.
+ */
+
+.m3dc {
+  --m3dc-a: #4c7fa0;
+  --m3dc-b: #dce9f2;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3dc-b) 0%, #f4f0e4 46%, #efe8d6 100%);
+  color: #23303a;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3dc__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3dc__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3dc-a);
+}
+.m3dc__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #1a3140;
+}
+.m3dc__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3dc__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3dc__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(76, 127, 160, 0.25);
+  box-shadow: 0 10px 28px rgba(23, 50, 63, 0.12);
+}
+.m3dc__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fdfaf2;
+}
+
+.m3dc__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3dc__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3dc__toggle {
+  border: 1.5px solid var(--m3dc-a);
+  background: #fff;
+  color: var(--m3dc-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3dc__toggle:hover,
+.m3dc__toggle:focus-visible {
+  background: var(--m3dc-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3dc__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.75);
+  border-left: 3px solid var(--m3dc-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3dc__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3dc__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #1a3140;
+}
+.m3dc__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3dc__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3dc__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(76, 127, 160, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3dc__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3dc__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #1a3140;
+}
+.m3dc__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3dc__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #2c4a3a;
+}

--- a/src/mockups/Mundo3DClima.jsx
+++ b/src/mockups/Mundo3DClima.jsx
@@ -1,0 +1,129 @@
+/*
+ * Mundo3DClima — vitrina pública del MUNDO DEL CLIMA (ruta #/mockups/mundo3d-clima).
+ *
+ * El cielo bajo el que vive la finca: la hora del día (el sol que arquea), la
+ * temporada bimodal andina (dos lluvias / dos secas, no cuatro estaciones
+ * europeas), la niebla del páramo que el frailejón vuelve agua, y la montaña de
+ * pisos térmicos con su casquete de hielo. Del hielo hablamos con conciencia,
+ * no con miedo: Colombia perdió casi todo su glaciar y los nevados se apagan —
+ * pero el páramo sigue siendo la fábrica de agua, y cuidarlo es la esperanza.
+ * Menos colapso, finca viva.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="clima">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento") se ve el gemelo 2D digno del cielo; en gama
+ * media/alta, la bóveda 3D low-poly (chunk perezoso `vendor-three`) con la abeja
+ * Angelita entrando. Los puntos del cielo son las mismas puertas del registro:
+ * aquí (vitrina sin sesión) cuentan a qué pantalla real de la app llevan.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import './Mundo3DClima.css';
+
+const TINTE = ['#4c7fa0', '#dce9f2'];
+
+/* El cielo, punto por punto — la misma verdad andina del registro, contada en
+   una leyenda didáctica y esperanzadora. */
+const LEYENDA = [
+  { emoji: '⛅', titulo: 'La hora del día', texto: 'El sol arquea de la mañana a la tarde: por dónde sale y dónde se pone le dice cuándo regar, cuándo cosechar y cuándo guardar.' },
+  { emoji: '🌧️', titulo: 'Dos lluvias, dos secas', texto: 'En los Andes no hay cuatro estaciones: el año va en dos temporadas de lluvia y dos de seca. Sembrar con ese compás es media cosecha ganada.' },
+  { emoji: '🌫️', titulo: 'La niebla que da agua', texto: 'En el páramo el frailejón le peina el agua a la nube y la entrega despacio al suelo. Esa niebla es la que llena su quebrada en el verano.' },
+  { emoji: '🏔️', titulo: 'El hielo que se va', texto: 'La línea ámbar marca hasta dónde llegaba el hielo. Colombia ya perdió casi todo su glaciar; por eso el páramo, la fábrica de agua, se cuida hoy.' },
+  { emoji: '🌡️', titulo: 'Cada piso, su clima', texto: 'La montaña sube del cálido al páramo y en cada piso el clima manda qué crece. La altura es el primer dato del tiempo de su finca.' },
+  { emoji: '❄️', titulo: 'La helada avisa', texto: 'En los pisos fríos la helada llega de madrugada con cielo despejado. Leerla a tiempo salva la papa y la mora de una mala noche.' },
+];
+
+export default function Mundo3DClima() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // En la vitrina (sin sesión) un punto del cielo no navega: cuenta a qué
+  // pantalla real de la app lleva esa puerta.
+  const [puerta, setPuerta] = useState(null);
+  const onHotspot = (view, data) => {
+    const hs =
+      (MUNDO.clima.hotspots || []).find(
+        (h) => h.view === view && (h.data === data || (!h.data && !data)),
+      ) || (MUNDO.clima.hotspots || []).find((h) => h.view === view);
+    setPuerta({ label: hs?.label || view, view });
+  };
+
+  return (
+    <main className="m3dc" style={{ '--m3dc-a': TINTE[0], '--m3dc-b': TINTE[1] }}>
+      <header className="m3dc__head">
+        <p className="m3dc__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo del clima</h1>
+        <p className="m3dc__lema">
+          El cielo bajo el que vive su finca: la hora del día, las dos lluvias y
+          las dos secas, la niebla del páramo y el hielo que se va. Menos
+          colapso, finca viva.
+        </p>
+      </header>
+
+      <section className="m3dc__escena" aria-label="El cielo de la finca">
+        <Mundo
+          mundoId="clima"
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          onSalir={null}
+          animo="sereno"
+          energia={0.85}
+        />
+        <div className="m3dc__barra">
+          <p className="m3dc__tier">
+            {tier === 'bajo'
+              ? 'Está viendo el dibujo del cielo (va parejo en cualquier equipo).'
+              : 'Está viendo la bóveda 3D. Puede girarla con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3dc__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver el dibujo 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3dc__nota" role="status" aria-live="polite">
+          {puerta
+            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+            : 'Toque un punto del cielo para ver a dónde lo lleva.'}
+        </p>
+      </section>
+
+      <section className="m3dc__leyenda" aria-label="El cielo, punto por punto">
+        <h2>El cielo, punto por punto</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3dc__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3dc__cierre">
+          El clima no es un enemigo: es el compás de su finca. Aprenda a leerlo y
+          cuide el páramo que le da el agua — ahí está la esperanza, no el miedo.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/__tests__/entradaValle3D.nav.test.jsx
+++ b/src/mockups/__tests__/entradaValle3D.nav.test.jsx
@@ -8,7 +8,7 @@
  *   · el viaje (Angelita guía) → la escena del mundo con su miga "‹ El valle";
  *   · una puerta DENTRO del mundo cuenta a qué pantalla real lleva;
  *   · "Volver al valle" → viaje en reversa → el valle otra vez;
- *   · un mundo sin escena montable (clima) degrada elegante a "pronto".
+ *   · el clima ya es un mundo montable (bóveda): se entra y se vuelve igual.
  */
 import React from 'react';
 import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
@@ -74,11 +74,19 @@ describe('entrada-3d — navegable de punta a punta (valle ↔ mundos)', () => {
     expect(container.querySelector('.valle-mundo')).not.toBeInTheDocument();
   });
 
-  test('mundo sin escena montable (el clima) degrada elegante a "pronto"', () => {
-    render(<EntradaValle3D onBack={() => {}} />);
+  test('el clima ya es un mundo montable (bóveda): se entra y se vuelve', () => {
+    vi.useFakeTimers();
+    const { container } = render(<EntradaValle3D onBack={() => {}} />);
+
     fireEvent.click(screen.getByRole('button', { name: /Viajar al mundo El clima/ }));
-    // sin puerta de entrada: aviso sobrio, nunca un botón muerto
-    expect(screen.queryByRole('button', { name: 'Entrar a este mundo' })).not.toBeInTheDocument();
-    expect(screen.getByText(/abre pronto su propia puerta/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Entrar a este mundo' }));
+    cumplirViaje();
+    // en jsdom cae a su gemelo 2D digno (three-free): el cielo dibujado
+    expect(container.querySelector('.valle-mundo[data-mundo="clima"]')).toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: 'Usted está aquí' })).toHaveTextContent('El clima');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Volver al valle' }));
+    cumplirViaje();
+    expect(container.querySelector('.valle-mundo')).not.toBeInTheDocument();
   });
 });

--- a/src/mockups/__tests__/mundo3dClima.smoke.test.jsx
+++ b/src/mockups/__tests__/mundo3dClima.smoke.test.jsx
@@ -1,0 +1,47 @@
+/*
+ * Vitrina #/mockups/mundo3d-clima — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y la vitrina monta
+ * el GEMELO 2D del cielo (three-free): exactamente el camino del device-tiering
+ * real en gama baja. Se congela que:
+ *   · la página renderiza título + leyenda sin tocar three;
+ *   · el gemelo trae los 3 puntos del cielo como botones;
+ *   · tocar una puerta cuenta a qué pantalla real de la app lleva (sin sesión
+ *     la vitrina NO navega);
+ *   · el registro sube el clima al arquetipo 3D nuevo `boveda` (no `null`).
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import Mundo3DClima from '../Mundo3DClima.jsx';
+import { MUNDO } from '../../visual/mundo3d/index.js';
+
+afterEach(() => cleanup());
+
+describe('vitrina del mundo del clima (mockups/mundo3d-clima)', () => {
+  test('renderiza el cielo en 2D digno con su leyenda didáctica', () => {
+    const { container } = render(<Mundo3DClima />);
+    expect(screen.getByRole('heading', { level: 1, name: 'El mundo del clima' })).toBeInTheDocument();
+    // jsdom no tiene WebGL → gemelo 2D (three-free), nunca pantalla rota
+    expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('.mundo2d__hotspot').length).toBe(3);
+    // la leyenda cuenta el cielo (esperanzadora, no alarmista)
+    expect(screen.getByText('El cielo, punto por punto')).toBeInTheDocument();
+    expect(screen.getByText('Dos lluvias, dos secas', { selector: 'b' })).toBeInTheDocument();
+  });
+
+  test('tocar una puerta del cielo cuenta a qué pantalla real lleva', () => {
+    render(<Mundo3DClima />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cuándo llueve' }));
+    expect(screen.getByRole('status')).toHaveTextContent('«calendario_finca»');
+  });
+
+  test('el registro sube el clima al arquetipo nuevo boveda', () => {
+    expect(MUNDO.clima.escena).toBe('boveda');
+    expect(MUNDO.clima.hotspots.map((h) => h.view)).toEqual([
+      'hoy_finca', 'almanaque', 'calendario_finca',
+    ]);
+  });
+});

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -26,6 +26,7 @@ const ESCENAS_3D = {
   recinto: lazy(() => import('./escenas/EscenaRecinto.jsx')),
   estratos: lazy(() => import('./escenas/EscenaEstratos.jsx')),
   valle: lazy(() => import('./escenas/EscenaValle.jsx')),
+  boveda: lazy(() => import('./escenas/EscenaBoveda.jsx')),
 };
 
 function MundoCargando({ tinte }) {

--- a/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
+++ b/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
@@ -12,7 +12,7 @@ afterEach(() => cleanup());
 
 describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
   test('arquetipos: 5 dioramas 3D + arquetipos 2D de primera clase', () => {
-    expect(ARQUETIPOS_3D.sort()).toEqual(['cutaway', 'estratos', 'flujo', 'recinto', 'valle']);
+    expect(ARQUETIPOS_3D.sort()).toEqual(['boveda', 'cutaway', 'estratos', 'flujo', 'recinto', 'valle']);
     ['lamina', 'infografia', 'ficha', 'mirror', 'valle2d'].forEach((k) => {
       expect(ARQUETIPOS_2D).toContain(k);
       expect(ARQUETIPOS[k].dim).toBe('2d');
@@ -36,10 +36,15 @@ describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
     expect(r.escena).toBe('infografia');
   });
 
-  test('escena:null salta directo a la vista 2D real (clima → hoy_finca)', () => {
-    const r = resolverMundo('clima', 'alto');
-    expect(r.modo).toBe('ruta');
-    expect(r.ruta.view).toBe('hoy_finca');
+  test('el clima sube al arquetipo 3D nuevo `boveda` (y degrada a su espejo 2D)', () => {
+    const alto = resolverMundo('clima', 'alto');
+    expect(alto.modo).toBe('3d');
+    expect(alto.escena).toBe('boveda');
+    // equipo humilde → cae al espejo 2D (mirror con motivo `boveda`)
+    const bajo = resolverMundo('clima', 'bajo');
+    expect(bajo.modo).toBe('2d');
+    expect(bajo.escena).toBe('mirror');
+    expect(bajo.motivo).toBe('boveda');
   });
 
   test('todo hotspot.view existe (reachability básica del registro)', () => {

--- a/src/visual/mundo3d/__tests__/navegacion.test.jsx
+++ b/src/visual/mundo3d/__tests__/navegacion.test.jsx
@@ -4,7 +4,8 @@
  * Congela el contrato del framework:
  *   · el ciclo completo: valle → viajando → mundo → regresando → valle;
  *   · reduced-motion = corte simple (sin fases de viaje, sin overlay);
- *   · un mundo sin escena montable (clima, escena:null) NO viaja → `pronto`;
+ *   · un mundo sin escena montable (id no registrado) NO viaja → `pronto`;
+ *     (el clima YA es montable: arquetipo `boveda`, así que sí viaja);
  *   · TransicionMundo llama `onFin` UNA vez al cumplirse el viaje.
  */
 import React from 'react';
@@ -30,6 +31,7 @@ function Sonda({ reducedMotion = false }) {
       <output data-testid="pronto">{nav.pronto || '-'}</output>
       <button type="button" onClick={() => nav.viajarAlMundo('agua')}>ir-agua</button>
       <button type="button" onClick={() => nav.viajarAlMundo('clima')}>ir-clima</button>
+      <button type="button" onClick={() => nav.viajarAlMundo('__fantasma__')}>ir-fantasma</button>
       <button type="button" onClick={() => nav.volverAlValle()}>volver</button>
       <button type="button" onClick={() => nav.completarViaje()}>completar</button>
     </div>
@@ -68,11 +70,18 @@ describe('useNavegacionMundos — la máquina valle ↔ mundo', () => {
     expect(fase()).toBe('valle'); // directo, sin 'regresando'
   });
 
-  test('mundo sin escena montable (clima) degrada: no viaja y marca `pronto`', () => {
+  test('el clima YA es montable (arquetipo boveda): sí viaja', () => {
     render(<Sonda />);
     fireEvent.click(screen.getByText('ir-clima'));
+    expect(fase()).toBe('viajando'); // viajó como cualquier mundo con escena
+    expect(screen.getByTestId('mundo')).toHaveTextContent('clima');
+  });
+
+  test('mundo sin escena montable (id no registrado) degrada: no viaja y marca `pronto`', () => {
+    render(<Sonda />);
+    fireEvent.click(screen.getByText('ir-fantasma'));
     expect(fase()).toBe('valle'); // no viajó
-    expect(screen.getByTestId('pronto')).toHaveTextContent('clima');
+    expect(screen.getByTestId('pronto')).toHaveTextContent('__fantasma__');
   });
 
   test('volverAlValle en el valle es inofensivo (no cambia de fase)', () => {

--- a/src/visual/mundo3d/arquetipos.js
+++ b/src/visual/mundo3d/arquetipos.js
@@ -45,6 +45,13 @@ export const ARQUETIPOS = {
     nombre: 'El valle (mapa)', clave: 'la finca como mapa navegable; cada mundo es un lugar',
     ejemplo: 'valle', tambien: [],
   },
+  // La ÚNICA metáfora espacial nueva del batch (README §case-3): la bóveda de
+  // cielo. Su espejo 2D es una lámina de cielo (motivo `boveda` en LaminaMundo).
+  boveda: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'boveda', espejo: 'mirror',
+    nombre: 'La bóveda del cielo', clave: 'el cielo de la finca: hora del día + temporada bimodal andina',
+    ejemplo: 'clima', tambien: [],
+  },
 
   // ── Arquetipos 2D (primera clase) ────────────────────────────────────────
   mirror: {

--- a/src/visual/mundo3d/escenas/EscenaBoveda.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBoveda.jsx
@@ -1,0 +1,371 @@
+/*
+ * EscenaBoveda — ARQUETIPO `boveda`: EL CIELO bajo el que vive la finca.
+ *
+ * La ÚNICA metáfora espacial nueva del batch (README §case-3): la vez que se
+ * escribe R3F de escena nuevo. Todo lo demás (Canvas, luz, cámara, hotspots, la
+ * abeja) lo hereda de EscenaBase3D como los otros arquetipos.
+ *
+ * Qué enseña, por DATOS (`params`), no por código:
+ *   · hora        0..1  → el SOL que arquea (amanecer→mediodía→tarde) y el tinte
+ *                         del cielo. La luna acompaña, quieta, como el otro turno.
+ *   · temporada   'lluvia'|'seca' → el RÉGIMEN BIMODAL andino (dos lluvias / dos
+ *                         secas; NO cuatro estaciones europeas). En lluvia: nubes
+ *                         más llenas + aguacero suave. En seca: cielo despejado.
+ *   · niebla      0..1  → la NIEBLA del páramo que el frailejón peina para dar agua.
+ *   · pisos       [...] → la MONTAÑA en cuatro pisos térmicos (misma paleta del
+ *                         mundo #4): cálido→templado→frío→páramo, apilados.
+ *   · glaciar     {...} → el casquete de hielo + la línea ámbar de hasta dónde
+ *                         llegaba (retroceso). NOTA DE CONCIENCIA, jamás alarma:
+ *                         se pinta ÁMBAR de "cuídelo", nunca rojo de catástrofe.
+ *                         El páramo es la fábrica de agua; ahí está la esperanza.
+ *
+ * Todo primitivas low-poly (`MeshLambert`/`MeshBasic`), sin sombras, sin GLTF,
+ * sin post. Reduced-motion = escena digna, no muerta: el sol, las nubes, la
+ * lluvia y la niebla se CONGELAN en su fotograma (nunca desaparecen). PRNG
+ * determinista: mismo dato → mismo cielo.
+ */
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import EscenaBase3D from './EscenaBase3D.jsx';
+import { Fauna } from './FaunaEscena.jsx';
+
+const R_BOVEDA = 9;
+
+/* PRNG determinista (LCG), como en EscenaEstratos: mismo dato, mismo cielo. */
+function prng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1103515245 + 12345) >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
+/* Paleta del cielo por hora: keyframes andinos (amanecer cálido → mediodía
+   claro → tarde dorada → anochecer índigo). Se interpola en el color. */
+const CLAVES_CIELO = [
+  { t: 0.0, h: '#f6c9a0', z: '#3f4f80' }, // amanecer
+  { t: 0.5, h: '#dcedf6', z: '#5aa0d6' }, // mediodía
+  { t: 0.74, h: '#f4c489', z: '#6f6cb2' }, // tarde dorada
+  { t: 1.0, h: '#26325a', z: '#0d1330' }, // anochecer
+];
+
+function paletaCielo(hora) {
+  const t = Math.min(1, Math.max(0, hora));
+  let a = CLAVES_CIELO[0];
+  let b = CLAVES_CIELO[CLAVES_CIELO.length - 1];
+  for (let i = 0; i < CLAVES_CIELO.length - 1; i++) {
+    if (t >= CLAVES_CIELO[i].t && t <= CLAVES_CIELO[i + 1].t) {
+      a = CLAVES_CIELO[i];
+      b = CLAVES_CIELO[i + 1];
+      break;
+    }
+  }
+  const span = Math.max(1e-4, b.t - a.t);
+  const k = (t - a.t) / span;
+  const horizonte = new THREE.Color(a.h).lerp(new THREE.Color(b.h), k);
+  const zenit = new THREE.Color(a.z).lerp(new THREE.Color(b.z), k);
+  return { horizonte, zenit };
+}
+
+/* LA BÓVEDA: media esfera con gradiente vertical horizonte→cenit por color de
+   vértice (barato, low-poly, un gradiente de verdad sin shaders). BackSide para
+   verla por dentro. Es el fondo; no escribe profundidad. */
+function Boveda({ hora }) {
+  const geo = useMemo(() => {
+    const g = new THREE.SphereGeometry(R_BOVEDA, 24, 12, 0, Math.PI * 2, 0, Math.PI * 0.52);
+    const { horizonte, zenit } = paletaCielo(hora);
+    const pos = g.attributes.position;
+    const tmp = new THREE.Color();
+    const colors = new Float32Array(pos.count * 3);
+    for (let i = 0; i < pos.count; i++) {
+      const t = Math.min(1, Math.max(0, pos.getY(i) / R_BOVEDA));
+      tmp.copy(horizonte).lerp(zenit, t ** 0.8);
+      colors[i * 3] = tmp.r;
+      colors[i * 3 + 1] = tmp.g;
+      colors[i * 3 + 2] = tmp.b;
+    }
+    g.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    return g;
+  }, [hora]);
+  return (
+    <mesh geometry={geo} renderOrder={-10}>
+      <meshBasicMaterial vertexColors side={THREE.BackSide} depthWrite={false} />
+    </mesh>
+  );
+}
+
+/* Posición del sol en su arco (p 0..1 = este→cenit→oeste). */
+function arcoSol(p) {
+  const x = (p - 0.5) * 12.4;
+  const y = Math.sin(Math.max(0, Math.min(1, p)) * Math.PI) * 5.1 + 0.25;
+  return [x, y, -2.6];
+}
+
+/* EL SOL que arquea, con su resplandor (halo aditivo — el "glow" en 3D). Con
+   reduced-motion queda quieto en la `hora` (un fotograma digno, no muerto). */
+function Sol({ hora, reducedMotion }) {
+  const ref = useRef(null);
+  const [x0, y0, z0] = arcoSol(hora);
+  useFrame((state) => {
+    if (reducedMotion || !ref.current) return;
+    const p = (hora + state.clock.elapsedTime * 0.012) % 1;
+    const [x, y, z] = arcoSol(p);
+    ref.current.position.set(x, y, z);
+  });
+  return (
+    <group ref={ref} position={[x0, y0, z0]}>
+      <mesh>
+        <sphereGeometry args={[0.62, 16, 12]} />
+        <meshBasicMaterial color="#ffe6a3" />
+      </mesh>
+      <mesh>
+        <sphereGeometry args={[1.05, 16, 12]} />
+        <meshBasicMaterial color="#ffd27a" transparent opacity={0.35} blending={THREE.AdditiveBlending} depthWrite={false} />
+      </mesh>
+      <mesh>
+        <sphereGeometry args={[1.7, 16, 12]} />
+        <meshBasicMaterial color="#ffbf5c" transparent opacity={0.16} blending={THREE.AdditiveBlending} depthWrite={false} />
+      </mesh>
+    </group>
+  );
+}
+
+/* La luna: un disco pálido, quieto en su rincón. El cielo también tiene noche. */
+function Luna() {
+  return (
+    <mesh position={[-4.6, 4.4, -3.2]}>
+      <sphereGeometry args={[0.5, 14, 10]} />
+      <meshBasicMaterial color="#eef1f6" transparent opacity={0.85} />
+    </mesh>
+  );
+}
+
+/* Una nube = racimo de esferas achatadas (nada de cajas). Deriva lento en x y da
+   la vuelta; en seca es blanca y liviana, en lluvia más llena y gris suave. */
+function Nube({ base, escala = 1, gris = false, reducedMotion }) {
+  const ref = useRef(null);
+  const bultos = useMemo(() => {
+    const r = prng(Math.round((base[0] + 7) * 131 + base[1] * 17));
+    return Array.from({ length: 4 }, (_, i) => ({
+      key: i,
+      x: (i - 1.5) * 0.62 + (r() - 0.5) * 0.2,
+      y: (r() - 0.5) * 0.22,
+      s: 0.5 + r() * 0.42,
+    }));
+  }, [base]);
+  useFrame((state) => {
+    if (reducedMotion || !ref.current) return;
+    const dx = ((state.clock.elapsedTime * 0.14 + base[0] + 7) % 14) - 7;
+    ref.current.position.x = dx;
+  });
+  const color = gris ? '#cfd6dd' : '#f7fbff';
+  return (
+    <group ref={ref} position={base} scale={escala}>
+      {bultos.map((b) => (
+        <mesh key={b.key} position={[b.x, b.y, 0]} scale={[1, 0.62, 0.8]}>
+          <sphereGeometry args={[b.s, 12, 8]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Aguacero suave bajo una nube (solo en temporada de lluvia). Líneas que caen y
+   se reciclan; reduced-motion las deja quietas (digno, no alarma: llovizna, no
+   tormenta). Determinista. */
+function Lluvia({ base = [-2.6, 3.4, 0.2], reducedMotion }) {
+  const refs = useRef([]);
+  const gotas = useMemo(() => {
+    const r = prng(4231);
+    return Array.from({ length: 14 }, (_, i) => ({
+      key: i,
+      x: base[0] + (r() - 0.5) * 1.9,
+      z: base[2] + (r() - 0.5) * 0.9,
+      y0: base[1] - 0.5 - r() * 2.4,
+      fase: r(),
+    }));
+  }, [base]);
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const caida = 2.2;
+    gotas.forEach((g, i) => {
+      const m = refs.current[i];
+      if (!m) return;
+      const y = base[1] - 0.5 - ((g.fase + state.clock.elapsedTime * 0.4) % 1) * caida;
+      m.position.y = y;
+    });
+  });
+  return (
+    <group>
+      {gotas.map((g, i) => (
+        <mesh
+          key={g.key}
+          ref={(el) => { refs.current[i] = el; }}
+          position={[g.x, g.y0, g.z]}
+        >
+          <cylinderGeometry args={[0.016, 0.016, 0.34, 4]} />
+          <meshBasicMaterial color="#bcd6e6" transparent opacity={0.72} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Un jirón de niebla de páramo: disco plano translúcido que respira despacio.
+   El frailejón peina estas gotas y las vuelve agua (la esponja del páramo). */
+function Jiron({ base, escala, fase, reducedMotion }) {
+  const ref = useRef(null);
+  useFrame((state) => {
+    if (reducedMotion || !ref.current) return;
+    const s = escala * (1 + Math.sin(state.clock.elapsedTime * 0.5 + fase) * 0.06);
+    ref.current.scale.set(s, s * 0.4, s);
+    ref.current.material.opacity = 0.22 + Math.sin(state.clock.elapsedTime * 0.5 + fase) * 0.06;
+  });
+  return (
+    <mesh ref={ref} position={base} scale={[escala, escala * 0.4, escala]}>
+      <sphereGeometry args={[1, 12, 8]} />
+      <meshBasicMaterial color="#eef4f6" transparent opacity={0.26} depthWrite={false} />
+    </mesh>
+  );
+}
+
+function NieblaParamo({ niebla = 0.6, cima = 3.6, reducedMotion }) {
+  const jirones = useMemo(() => {
+    const r = prng(909);
+    const n = 1 + Math.round(niebla * 3);
+    return Array.from({ length: n }, (_, i) => ({
+      key: i,
+      base: [(r() - 0.5) * 2.2, cima - 0.6 - r() * 0.7, 0.6 + r() * 0.6],
+      escala: 0.7 + r() * 0.6,
+      fase: r() * 6,
+    }));
+  }, [niebla, cima]);
+  return (
+    <group>
+      {jirones.map((j) => (
+        <Jiron key={j.key} base={j.base} escala={j.escala} fase={j.fase} reducedMotion={reducedMotion} />
+      ))}
+    </group>
+  );
+}
+
+const PISOS_DEF = [
+  { nombre: 'cálido', color: '#c7a24b', h: 0.95, r0: 2.4, r1: 1.95 },
+  { nombre: 'templado', color: '#8fae55', h: 0.9, r1: 1.42 },
+  { nombre: 'frío', color: '#6f9a72', h: 0.85, r1: 0.9 },
+  { nombre: 'páramo', color: '#9fb6bf', h: 0.8, r1: 0.42 },
+];
+
+/* LA MONTAÑA: los cuatro pisos térmicos apilados como troncos de cono (paleta
+   del mundo #4). Corona: el casquete de hielo + la LÍNEA ÁMBAR de hasta dónde
+   llegaba el hielo (retroceso glaciar) — nota de conciencia, esperanza no colapso. */
+function Montana({ pisos = PISOS_DEF, glaciar = {} }) {
+  const bandas = useMemo(() => {
+    let y = 0;
+    let rAbajo = pisos[0]?.r0 ?? 2.4;
+    return pisos.map((p, i) => {
+      const rArriba = p.r1 ?? rAbajo * 0.7;
+      const b = { key: i, nombre: p.nombre, color: p.color, h: p.h, rAbajo, rArriba, y };
+      y += p.h;
+      rAbajo = rArriba;
+      return b;
+    });
+  }, [pisos]);
+  const cima = bandas.reduce((acc, b) => acc + b.h, 0);
+  const rCima = bandas[bandas.length - 1]?.rArriba ?? 0.42;
+  const nieve = Math.max(0, Math.min(1, glaciar.nieve ?? 0.32));
+  const retroceso = Math.max(0, Math.min(1, glaciar.retroceso ?? 0.7));
+  // La línea de nieve de antes: sube con el retroceso (más retroceso = casquete
+  // más chico y la marca ámbar más abajo, "hasta aquí llegaba").
+  const yAntes = cima - 0.35 - retroceso * 0.55;
+  const rAntes = rCima + 0.5 + retroceso * 0.45;
+  return (
+    <group position={[0, 0, -0.4]}>
+      {bandas.map((b) => (
+        <mesh key={b.key} position={[0, b.y + b.h / 2, 0]}>
+          <cylinderGeometry args={[b.rArriba, b.rAbajo, b.h, 7]} />
+          <meshLambertMaterial color={b.color} flatShading />
+        </mesh>
+      ))}
+      {/* el casquete de hielo de hoy (más pequeño de lo que fue) */}
+      <mesh position={[0, cima + nieve * 0.28, 0]}>
+        <coneGeometry args={[rCima + 0.05, 0.35 + nieve * 0.55, 7]} />
+        <meshLambertMaterial color="#eef4f7" flatShading />
+      </mesh>
+      {/* la línea ámbar: hasta aquí llegaba el hielo (cuidado, no alarma) */}
+      <mesh position={[0, yAntes, 0]} rotation={[Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[rAntes, 0.028, 6, 24]} />
+        <meshBasicMaterial color="#d9a13b" transparent opacity={0.75} />
+      </mesh>
+    </group>
+  );
+}
+
+/* La vida del cielo de día: un colibrí y una mariposa cerca de la ladera. De
+   noche no se siembra fauna (honestidad ecológica). */
+const FAUNA_DIA = [
+  { tipo: 'colibri', base: [2.2, 1.5, 1.4], patron: 'revoloteo', size: 28, fase: 0.6 },
+  { tipo: 'mariposa', base: [-1.7, 0.9, 1.6], patron: 'revoloteo', size: 30, fase: 2.2 },
+];
+
+function Diorama({ params, reducedMotion }) {
+  const hora = params?.hora ?? 0.62;
+  const temporada = params?.temporada ?? 'lluvia';
+  const niebla = params?.niebla ?? 0.6;
+  const pisos = params?.pisos || PISOS_DEF;
+  const glaciar = params?.glaciar || {};
+  const esDia = hora > 0.06 && hora < 0.9;
+  const cima = pisos.reduce((acc, p) => acc + (p.h ?? 0.85), 0);
+  return (
+    <group>
+      <Boveda hora={hora} />
+      {/* el piso de la finca (un disco de tierra bajo el cielo) */}
+      <mesh position={[0, -0.04, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[5.6, 36]} />
+        <meshLambertMaterial color="#7f925f" />
+      </mesh>
+
+      <Sol hora={hora} reducedMotion={reducedMotion} />
+      {!esDia && <Luna />}
+      {esDia && hora < 0.55 && <Luna />}
+
+      <Montana pisos={pisos} glaciar={glaciar} />
+      <NieblaParamo niebla={niebla} cima={cima} reducedMotion={reducedMotion} />
+
+      {/* el cielo con su temporada: nubes siempre; aguacero solo en lluvia */}
+      <Nube base={[-2.6, 3.5, 0.2]} escala={1.15} gris={temporada === 'lluvia'} reducedMotion={reducedMotion} />
+      <Nube base={[2.4, 4.1, -0.6]} escala={0.9} gris={false} reducedMotion={reducedMotion} />
+      {temporada === 'lluvia' && (
+        <>
+          <Nube base={[0.2, 4.3, 0.4]} escala={1.0} gris reducedMotion={reducedMotion} />
+          <Lluvia base={[-2.6, 3.2, 0.2]} reducedMotion={reducedMotion} />
+        </>
+      )}
+
+      {esDia && <Fauna items={FAUNA_DIA} reducedMotion={reducedMotion} />}
+    </group>
+  );
+}
+
+export default function EscenaBoveda(props) {
+  const hora = props.params?.hora ?? 0.62;
+  const { horizonte } = paletaCielo(hora);
+  const cielo = {
+    fondo: `#${horizonte.getHexString()}`,
+    cielo: '#eef4f6',
+    suelo: '#6f7f52',
+    intensidad: 1.05,
+  };
+  return (
+    <EscenaBase3D
+      {...props}
+      cielo={cielo}
+      camara={{ position: [4.6, 3.1, 8.6], fov: 46 }}
+      entrada={{ ...props.entrada, zoom: props.entrada?.zoom ?? 7.5, centro: [0, 2.2, 0] }}
+    >
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+    </EscenaBase3D>
+  );
+}

--- a/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
+++ b/src/visual/mundo3d/laminas2d/LaminaMundo.jsx
@@ -144,7 +144,71 @@ function FondoEstratos({ params, acento }) {
   );
 }
 
-const FONDOS = { cutaway: FondoCutaway, flujo: FondoFlujo, recinto: FondoRecinto, estratos: FondoEstratos };
+/* El espejo 2D de la BÓVEDA: el cielo de la finca con su sol, una nube (y
+   lluvia en temporada), y la montaña de pisos térmicos con su casquete y la
+   línea ámbar del hielo que fue (cuidado, no alarma). Lee los mismos `params`
+   que el diorama 3D. */
+function FondoBoveda({ params, acento }) {
+  const temporada = params?.temporada ?? 'lluvia';
+  const niebla = Math.max(0, Math.min(1, params?.niebla ?? 0.6));
+  const pisos = params?.pisos || [
+    { color: '#c7a24b' }, { color: '#8fae55' }, { color: '#6f9a72' }, { color: '#9fb6bf' },
+  ];
+  // pico central: bandas de piso apiladas como un triángulo escalonado
+  const bandas = pisos.map((p, i) => {
+    const n = pisos.length;
+    const yTop = 176 - ((i + 1) / n) * 120;
+    const yBot = 176 - (i / n) * 120;
+    const half = 96 * (1 - i / n) + 10;
+    return { key: i, color: p.color, yTop, yBot, half };
+  });
+  return (
+    <g>
+      {/* cielo con gradiente sencillo día andino */}
+      <defs>
+        <linearGradient id="mb-cielo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#6f9cc9" />
+          <stop offset="100%" stopColor="#dcecf5" />
+        </linearGradient>
+      </defs>
+      <rect x="0" y="0" width="300" height="200" fill="url(#mb-cielo)" />
+      {/* el sol con su resplandor */}
+      <circle cx="228" cy="48" r="26" fill="#ffd27a" opacity="0.35" />
+      <circle cx="228" cy="48" r="15" fill="#ffe6a3" />
+      {/* la luna, quieta en su rincón */}
+      <circle cx="58" cy="40" r="9" fill="#eef1f6" opacity="0.85" />
+      {/* la montaña de pisos térmicos */}
+      {bandas.map((b) => (
+        <polygon
+          key={b.key}
+          points={`${150 - b.half},${b.yBot} ${150 + b.half},${b.yBot} ${150 + b.half * 0.72},${b.yTop} ${150 - b.half * 0.72},${b.yTop}`}
+          fill={b.color}
+        />
+      ))}
+      {/* casquete de hielo + línea ámbar de hasta dónde llegaba (retroceso) */}
+      <polygon points="140,60 160,60 150,44" fill="#eef4f7" />
+      <path d="M126,64 Q150,58 174,64" stroke="#d9a13b" strokeWidth="2" fill="none" strokeDasharray="4 3" opacity="0.8" />
+      {/* niebla del páramo (el frailejón peina el agua de la nube) */}
+      {niebla > 0.2 && (
+        <ellipse cx="150" cy="74" rx={26 + niebla * 16} ry="7" fill="#eef4f6" opacity="0.5" />
+      )}
+      {/* una nube; en lluvia, aguacero suave debajo */}
+      <g>
+        <ellipse cx="86" cy="70" rx="26" ry="13" fill={temporada === 'lluvia' ? '#cfd6dd' : '#f7fbff'} />
+        <ellipse cx="104" cy="66" rx="18" ry="12" fill={temporada === 'lluvia' ? '#cfd6dd' : '#f7fbff'} />
+        {temporada === 'lluvia' &&
+          [0, 1, 2, 3].map((i) => (
+            <line key={i} x1={72 + i * 12} y1="84" x2={69 + i * 12} y2="98" stroke="#bcd6e6" strokeWidth="2" opacity="0.75" strokeLinecap="round" />
+          ))}
+      </g>
+      <rect x="0" y="0" width="300" height="200" fill="none" stroke={acento} strokeWidth="2" opacity="0.35" />
+    </g>
+  );
+}
+
+const FONDOS = {
+  cutaway: FondoCutaway, flujo: FondoFlujo, recinto: FondoRecinto, estratos: FondoEstratos, boveda: FondoBoveda,
+};
 
 export default function LaminaMundo({ params, hotspots = [], tinte, onHotspot, motivo = 'cutaway', titulo }) {
   const acento = (tinte && tinte[0]) || '#3f8f4e';

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -232,16 +232,43 @@ export const MUNDO = {
     entrada: {},
   },
 
-  // ── NULL: sin escena propia → la tarjeta navega directo al 2D real ───────
+  // ── SÍ-3D nuevo: la ÚNICA metáfora de escena nueva del batch ─────────────
 
-  // ⛅ EL CLIMA — YA es 3D ambiental (el cielo del valle); su diorama sería
-  //    redundante (DR §3.2). escena:null → va directo al boletín 2D.
+  // ⛅ EL CLIMA — la BÓVEDA del cielo bajo el que vive la finca (arquetipo nuevo
+  //    `boveda`, README §case-3). Verdad andina, por DATOS: la HORA del día (el
+  //    sol que arquea) + la temporada BIMODAL (dos lluvias / dos secas, NO cuatro
+  //    estaciones europeas) + la niebla del páramo que el frailejón vuelve agua +
+  //    la montaña de pisos térmicos con su casquete de hielo y la línea ÁMBAR de
+  //    hasta dónde llegaba (Colombia perdió ~90% del hielo; los nevados se apagan
+  //    hacia 2040–2050). NOTA DE CONCIENCIA, esperanza no colapso: el páramo es la
+  //    fábrica de agua. En equipo humilde cae al gemelo 2D (mirror → cielo).
   clima: {
-    escena: null,
+    escena: 'boveda',
     valle: { tipo: 'veleta', pos: [-3.8, 0, -4.8], escala: 1 },
     ambiental: true,
-    ruta2d: { view: 'hoy_finca' },
-    entrada: { narra: 'clima' },
+    params: {
+      hora: 0.62,           // media tarde andina (0 amanece · 0.5 mediodía · 1 anochece)
+      temporada: 'lluvia',  // régimen BIMODAL andino: dos lluvias / dos secas
+      niebla: 0.6,          // niebla del páramo: el frailejón peina el agua de la nube
+      // La montaña en cuatro pisos térmicos (misma paleta del mundo #4).
+      pisos: [
+        { nombre: 'cálido', color: '#c7a24b', h: 0.95, r0: 2.4, r1: 1.95 },
+        { nombre: 'templado', color: '#8fae55', h: 0.9, r1: 1.42 },
+        { nombre: 'frío', color: '#6f9a72', h: 0.85, r1: 0.9 },
+        { nombre: 'páramo', color: '#9fb6bf', h: 0.8, r1: 0.42 },
+      ],
+      // El hielo de hoy + la línea de hasta dónde llegaba (retroceso). Ámbar de
+      // "cuídelo", jamás rojo de catástrofe.
+      glaciar: { nieve: 0.32, retroceso: 0.7 },
+    },
+    hotspots: [
+      { id: 'hoy', pos: [2.7, 3.4, 0.6], emoji: '⛅', label: 'El tiempo hoy', view: 'hoy_finca' },
+      { id: 'almanaque', pos: [0, 1.7, 1.9], emoji: '🗓️', label: 'Almanaque de la finca', view: 'almanaque' },
+      { id: 'lluvia', pos: [-2.7, 3.1, 0.5], emoji: '🌧️', label: 'Cuándo llueve', view: 'calendario_finca' },
+    ],
+    entrada: { zoom: 7.5, narra: 'clima' },
+    // Gemelo 2D digno (mirror → motivo `boveda`): mismo cielo, mismos hotspots.
+    fallback2d: { escena: 'mirror' },
   },
 };
 


### PR DESCRIPTION
## Mundo #7 — el clima (la bóveda del cielo)

El cielo bajo el que vive la finca, el mundo #7 del batch de mundos 3D. Es la **única metáfora de escena nueva** (README §case-3): un arquetipo `boveda` low-poly (R3F perezoso en `vendor-three`) que hereda el andamiaje de `EscenaBase3D` como los demás.

Todo por **datos** (una entrada en `mundoData.js`):

- **Hora del día** — el sol arquea de mañana a tarde con su resplandor (halo aditivo); la luna acompaña.
- **Temporada bimodal andina** — dos lluvias / dos secas (no cuatro estaciones europeas). En lluvia: nubes más llenas + aguacero suave.
- **Niebla del páramo** — jirones que respiran; el frailejón peina el agua de la nube (la esponja del páramo).
- **Montaña de pisos térmicos** — cálido→templado→frío→páramo (paleta del mundo #4), con casquete de hielo y la **línea ámbar** de hasta dónde llegaba (retroceso glaciar).

**Anti-alarmismo:** nota de conciencia, esperanza no colapso. El páramo es la fábrica de agua; el cuidado se pinta ámbar (`#d9a13b`), jamás rojo de catástrofe. Colombia perdió casi todo su hielo y los nevados se apagan hacia 2040–2050 — se cuenta de forma evocadora pero correcta (verificado en el DR de clima del fanout).

## Qué trae

- Arquetipo `boveda` (espejo 2D `mirror` → motivo `boveda`) + escena `EscenaBoveda.jsx`.
- Gemelo 2D digno: `FondoBoveda` en `LaminaMundo` (cielo dibujado, three-free) para equipo humilde.
- Vitrina `#/mockups/mundo3d-clima` con device-tiering real, toggle 3D/2D y leyenda esperanzadora.
- Hotspots reachables: `hoy_finca`, `almanaque`, `calendario_finca`.
- La abeja Angelita entra (`useEntradaAbeja`), fauna de día (colibrí + mariposa).

## Duras

usted-CO · self-contained (cero CDN) · móvil 320px · `prefers-reduced-motion` (sol, nubes, lluvia y niebla se congelan en su fotograma) · fallback 2D · PRNG determinista · three perezoso.

## Tests / build

- `npm run build` verde (exit 0).
- Tests de contrato actualizados: el clima deja de ser `escena:null` y pasa a ser un mundo montable (`boveda`); la ruta de degradado "pronto" se prueba ahora con un id no registrado. 19/19 tests verdes en los archivos tocados + 3 smoke nuevos del clima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)