### PR TITLE
fix(canary): B0b sube la foto por el flujo file--file de dos pasos (ruta real de farmOS)

### DIFF
--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -380,17 +380,33 @@ async function runPlantaFoto(ctx) {
   if (!created.ok && rels.location) { delete rels.location; created = await farmosWrite(base, token, '/api/asset/plant', { data: { type: 'asset--plant', attributes: { name: `CANARIO planta ${target} ${stamp}`, status: 'active' }, relationships: rels } }); }
   const plantId = created.ok ? created.json?.data?.id : null;
 
-  // Subir la foto al campo image de la planta (JSON:API binario, ruta correcta).
+  // Subir la foto al campo `image` de la planta por el flujo NATIVO de farmOS 4.x /
+  // Drupal 10 — el MISMO que usa el cliente real (uploadBinaryToFarmOS en
+  // src/services/apiService.js). Es en DOS pasos:
+  //   A) POST /api/{entity}/{bundle}/{field} (octet-stream) crea un file--file NUEVO
+  //      y devuelve su UUID. OJO: la forma con el UUID en la ruta
+  //      (/api/asset/plant/{id}/image) NO EXISTE en este farmOS (404 sin auth → 500
+  //      con token; verificado 2026-07-11) y ningún código de producción la usa.
+  //   B) PATCH del plant relacionando el file, para que persista (un file--file sin
+  //      referencia queda temporal y el cron de Drupal lo borra ~6 h).
   let fileId = null; let uploadStatus = null;
   if (plantId) {
     const bytes = Buffer.from(CANARY_JPEG_B64, 'base64');
-    const up = await httpFetch(`${base}/api/asset/plant/${plantId}/image`, {
+    const up = await httpFetch(`${base}/api/asset/plant/image`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/octet-stream', 'Content-Disposition': `file; filename="CANARIO-${target}-${dateStr}.jpg"`, Accept: 'application/vnd.api+json' },
       body: bytes, timeoutMs: 45000,
     });
     uploadStatus = up.status;
-    if (up.ok && up.json?.data?.id) fileId = up.json.data.id;
+    if (up.ok && up.json?.data?.id) {
+      fileId = up.json.data.id;
+      // Paso B: adjuntar el file al plant (lo vuelve permanente). El campo `image`
+      // de asset--plant es multivaluado en farmOS; si esta build lo tuviera como
+      // single, reintentar con forma de objeto.
+      let rel = await farmosWrite(base, token, `/api/asset/plant/${plantId}`, { data: { type: 'asset--plant', id: plantId, relationships: { image: { data: [{ type: 'file--file', id: fileId }] } } } }, 'PATCH');
+      if (!rel.ok) rel = await farmosWrite(base, token, `/api/asset/plant/${plantId}`, { data: { type: 'asset--plant', id: plantId, relationships: { image: { data: { type: 'file--file', id: fileId } } } } }, 'PATCH');
+      if (!rel.ok) uploadStatus = rel.status;
+    }
   }
 
   // Verificar persistencia: releer la planta y confirmar la relación image.


### PR DESCRIPTION
## Qué falla
Check **B0b** (Guardar planta con foto) da **HTTP 500** al subir la foto, de forma **persistente** en dev y prod (2026-07-08, 07-10, 07-11), incluso con el backend **sano** (D5 sidecar UP, login OK, B0c/D1–D5 PASS). No es transitorio.

## Causa raíz (verificada en vivo el 2026-07-11)
El canario subía a `POST /api/asset/plant/{id}/image` (UUID en la ruta). Sondeo sin credenciales contra dev:

| Endpoint | Resultado |
|---|---|
| `POST /api/asset/plant/{uuid}/image` (canario) | **404** — la ruta no existe |
| `POST /api/asset/plant/image` (dos pasos) | 403 — existe (pide auth) |
| `POST /api/log/observation/file` (cliente real) | 403 — existe |

Con token, esa ruta inexistente da **500**. Ningún código de `src/` la usa.

## Fix
Alinear B0b al flujo **NATIVO de farmOS 4.x / Drupal 10** que ya usa el cliente real (`uploadBinaryToFarmOS`, `src/services/apiService.js:390`):
1. `POST /api/asset/plant/image` (octet-stream) → crea un `file--file`, devuelve UUID.
2. `PATCH /api/asset/plant/{id}` relacionando `image` → lo vuelve permanente (un `file--file` sin referencia lo borra el cron de Drupal ~6 h).

Fallback de cardinalidad (array/objeto) por si `image` fuera single en alguna build. Así B0b prueba fielmente lo que hace el usuario real y deja de dar falso rojo.

## Verificación
- `node --check` OK · pre-commit (secret-scan/voseo/conventional) OK · diff quirúrgico (19+/3-, solo el bloque de subida).
- La verificación de comportamiento (B0b en verde) ocurre en la **próxima corrida nocturna** contra el farmOS en vivo — no se puede correr el canario end-to-end desde stg sin token/sesión.

Fix del canario nocturno (categoría (c) planta/foto/farmOS). Base `feat/nightly-canary` porque el canario aún no está en `main` (el runner corre esa rama; ver `chagra-canary-run.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)