### PR TITLE
feat(mundo3d): háptica móvil sincronizada al toque (spec S4)

### DIFF
--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import {
   User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2, Wrench,
   Sprout, ChevronRight, ChevronLeft, Bell, Users, Camera, Trash2, Shield,
-  Archive, LifeBuoy, LayoutGrid, GraduationCap,
+  Archive, LifeBuoy, LayoutGrid, GraduationCap, Vibrate,
 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { esExtensionistaActual } from '../config/extensionistaAccess';
@@ -695,6 +695,9 @@ export default function ProfileScreen({ onBack, onHome }) {
                 aparece con VITE_MODO_CAMPO=true (dev/piloto), ver
                 src/config/modoCampoFlag.js. Vive junto a los ajustes de voz. */}
             {modoCampoDisponible() && <ModoCampoPanel />}
+
+            {/* DR-3D-HAPTICA: vibración táctil de los mundos 3D (tri-estado). */}
+            <HapticsSection />
           </div>
         )}
 
@@ -1092,6 +1095,73 @@ function AgentVoiceSection() {
           />
         </button>
       </label>
+    </div>
+  );
+}
+
+/**
+ * HapticsSection — DR-3D-HAPTICA (2026-07-11).
+ *
+ * Toggle tri-estado "Vibración" persistido en usePrefsStore (key
+ * `chagra:prefs:haptics`). Controla los pulsos táctiles del framework de
+ * mundos 3D (tap en hotspot, la abeja posándose, viajes valle↔mundo):
+ *   - Automática (default): vibra si el equipo lo soporta y no hay
+ *     preferencia de movimiento reducido en el sistema.
+ *   - Siempre: vibra aunque haya movimiento reducido (respeta al usuario
+ *     que SÍ quiere el feedback táctil).
+ *   - Nunca: apagado total.
+ * En equipos sin API de vibración (iPhone/iPad, Firefox) no hay pérdida:
+ * cada pulso solo acompaña un momento que ya es visible en pantalla.
+ */
+const HAPTICS_OPTIONS = [
+  { id: 'auto', label: 'Automática' },
+  { id: 'on', label: 'Siempre' },
+  { id: 'off', label: 'Nunca' },
+];
+
+function HapticsSection() {
+  const haptics = usePrefsStore((s) => s.haptics ?? 'auto');
+  const setHaptics = usePrefsStore((s) => s.setHaptics);
+  const soportada = typeof navigator !== 'undefined' && 'vibrate' in navigator;
+
+  return (
+    <div className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
+      <div className="flex items-center gap-2 px-1">
+        <Vibrate size={18} className="text-amber-400" />
+        <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Vibración</h3>
+      </div>
+
+      <p className="text-xs text-slate-400 leading-snug px-1">
+        Pulsos táctiles sutiles al explorar los mundos 3D de la finca: tocar un
+        punto de interés, la abeja posándose, entrar y volver de un mundo.
+      </p>
+
+      <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Vibración de los mundos 3D">
+        {HAPTICS_OPTIONS.map((opt) => (
+          <button
+            key={opt.id}
+            type="button"
+            role="radio"
+            aria-checked={haptics === opt.id}
+            onClick={() => setHaptics(opt.id)}
+            className={`tap-target px-3 py-2 rounded-xl text-xs font-bold transition-colors ${
+              haptics === opt.id
+                ? 'bg-amber-600/80 text-white'
+                : 'bg-slate-800/50 text-slate-400 hover:bg-slate-800'
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {!soportada && (
+        <p className="text-[11px] text-slate-500 leading-snug px-1">
+          Este equipo no admite vibración desde el navegador (por ejemplo,
+          iPhone o iPad). No se pierde información: cada pulso solo acompaña
+          algo que ya se ve en pantalla.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/store/usePrefsStore.js
+++ b/src/store/usePrefsStore.js
@@ -12,6 +12,11 @@ const STORAGE_KEY_TTS_ENABLED = 'chagra:prefs:tts-enabled';
 // verificado". Operadores en modo "expert" pueden ocultarlos para reducir
 // ruido visual sin perder la información (queda en metadata del turn).
 const STORAGE_KEY_SOURCE_BADGES = 'chagra:prefs:show-source-badges';
+// DR-3D-HAPTICA (2026-07-11): vibración táctil del framework de mundos 3D.
+// Tri-estado: 'auto' (default — vibra si hay soporte y no hay
+// prefers-reduced-motion) | 'on' (siempre que haya soporte) | 'off' (nunca).
+const STORAGE_KEY_HAPTICS = 'chagra:prefs:haptics';
+const HAPTICS_MODES = ['auto', 'on', 'off'];
 
 function load(key, fallback) {
   try {
@@ -31,6 +36,7 @@ const usePrefsStore = create((set, _get) => ({
   voiceRegionIntensity: load(STORAGE_KEY_VOICE_INTENSITY, 1),
   ttsEnabled: load(STORAGE_KEY_TTS_ENABLED, true),
   showSourceBadges: load(STORAGE_KEY_SOURCE_BADGES, true),
+  haptics: load(STORAGE_KEY_HAPTICS, 'auto'),
 
   setVoiceRegion: (region) => {
     save(STORAGE_KEY_VOICE_REGION, region);
@@ -52,6 +58,12 @@ const usePrefsStore = create((set, _get) => ({
     const bool = Boolean(flag);
     save(STORAGE_KEY_SOURCE_BADGES, bool);
     set({ showSourceBadges: bool });
+  },
+
+  setHaptics: (mode) => {
+    const valid = HAPTICS_MODES.includes(mode) ? mode : 'auto';
+    save(STORAGE_KEY_HAPTICS, valid);
+    set({ haptics: valid });
   },
 }));
 

--- a/src/visual/mundo3d/__tests__/useHaptics.test.jsx
+++ b/src/visual/mundo3d/__tests__/useHaptics.test.jsx
@@ -1,0 +1,114 @@
+/*
+ * useHaptics — pruebas del contrato DR-3D-HAPTICA (§9):
+ * patrones exactos del catálogo, gate triple (soporte + pref + reduced-motion),
+ * throttle de 120 ms, y no-op sin throw cuando no hay Vibration API.
+ */
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import usePrefsStore from '../../../store/usePrefsStore.js';
+
+// La detección de soporte se captura al CARGAR el módulo: instalamos el mock
+// de navigator.vibrate ANTES del import dinámico del hook.
+const vibrate = vi.fn(() => true);
+Object.defineProperty(navigator, 'vibrate', {
+  value: vibrate, configurable: true, writable: true,
+});
+const { default: useHaptics, PATRONES_HAPTICOS } = await import('../useHaptics.js');
+
+beforeEach(() => {
+  vibrate.mockClear();
+  act(() => { usePrefsStore.setState({ haptics: 'auto' }); });
+});
+
+describe('useHaptics — catálogo y disparo', () => {
+  it('cada método dispara su patrón exacto (cancel-then-fire)', () => {
+    const { result } = renderHook(() => useHaptics({ reducedMotion: false }));
+    expect(result.current.supported).toBe(true);
+    expect(result.current.enabled).toBe(true);
+
+    const casos = [
+      ['tap', PATRONES_HAPTICOS.tap],
+      ['abeja', PATRONES_HAPTICOS.abeja],
+      ['viajeEntrar', PATRONES_HAPTICOS.viajeEntrar],
+      ['viajeVolver', PATRONES_HAPTICOS.viajeVolver],
+      ['descubrimiento', PATRONES_HAPTICOS.descubrimiento],
+      ['error', PATRONES_HAPTICOS.error],
+    ];
+    for (const [metodo, patron] of casos) {
+      vibrate.mockClear();
+      result.current[metodo]();
+      // cancel-then-fire: primero vibrate(0), luego el patrón del catálogo.
+      expect(vibrate).toHaveBeenNthCalledWith(1, 0);
+      expect(vibrate).toHaveBeenNthCalledWith(2, patron);
+    }
+  });
+
+  it('fire() acepta clave del catálogo o patrón crudo; stop() cancela', () => {
+    const { result } = renderHook(() => useHaptics({ reducedMotion: false }));
+    result.current.fire('tap');
+    expect(vibrate).toHaveBeenLastCalledWith(PATRONES_HAPTICOS.tap);
+    result.current.fire([12, 40, 12]);
+    expect(vibrate).toHaveBeenLastCalledWith([12, 40, 12]);
+    vibrate.mockClear();
+    result.current.stop();
+    expect(vibrate).toHaveBeenCalledWith(0);
+  });
+
+  it('throttle: el mismo evento dentro de 120 ms se ignora', () => {
+    const { result } = renderHook(() => useHaptics({ reducedMotion: false }));
+    result.current.tap();
+    result.current.tap(); // inmediato → dentro de la ventana de 120 ms
+    const disparosTap = vibrate.mock.calls.filter(
+      (c) => c[0] === PATRONES_HAPTICOS.tap,
+    );
+    expect(disparosTap).toHaveLength(1);
+  });
+});
+
+describe('useHaptics — gate triple', () => {
+  it("pref 'off' → nunca vibra", () => {
+    act(() => { usePrefsStore.setState({ haptics: 'off' }); });
+    const { result } = renderHook(() => useHaptics({ reducedMotion: false }));
+    expect(result.current.enabled).toBe(false);
+    result.current.tap();
+    expect(vibrate).not.toHaveBeenCalled();
+  });
+
+  it("'auto' + reduced-motion → apagada", () => {
+    const { result } = renderHook(() => useHaptics({ reducedMotion: true }));
+    expect(result.current.enabled).toBe(false);
+    result.current.viajeEntrar();
+    expect(vibrate).not.toHaveBeenCalled();
+  });
+
+  it("'on' + reduced-motion → SÍ vibra (el usuario sensorial manda)", () => {
+    act(() => { usePrefsStore.setState({ haptics: 'on' }); });
+    const { result } = renderHook(() => useHaptics({ reducedMotion: true }));
+    expect(result.current.enabled).toBe(true);
+    result.current.viajeEntrar();
+    expect(vibrate).toHaveBeenLastCalledWith(PATRONES_HAPTICOS.viajeEntrar);
+  });
+});
+
+describe('useHaptics — sin Vibration API (iOS/Safari, Firefox 129+)', () => {
+  it('todos los métodos son no-op silenciosos, sin throw', async () => {
+    vi.resetModules();
+    // Simular plataforma sin la API ANTES de recargar el módulo.
+    delete navigator.vibrate;
+    const { default: useHapticsSinAPI } = await import('../useHaptics.js');
+    const { result } = renderHook(() => useHapticsSinAPI({ reducedMotion: false }));
+    expect(result.current.supported).toBe(false);
+    expect(result.current.enabled).toBe(false);
+    expect(() => {
+      result.current.tap();
+      result.current.abeja();
+      result.current.stop();
+    }).not.toThrow();
+    // Restaurar para otros archivos de test.
+    Object.defineProperty(navigator, 'vibrate', {
+      value: vibrate, configurable: true, writable: true,
+    });
+  });
+});

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -26,6 +26,7 @@ import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaEscena } from './useEntradaAbeja.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
+import useHaptics from '../useHaptics.js';
 
 /* Cielo cálido "acuarela" por defecto (la estética heredada del valle). El
    arquetipo puede pasar su propio `cielo` para teñir su ambiente. */
@@ -54,6 +55,9 @@ function Contenido({
 }) {
   const controls = useRef(null);
   const [activo, setActivo] = useState(null);
+  // Háptica del tap (DR-3D-HAPTICA): un tick seco al tocar un hotspot —
+  // "toqué algo vivo, respondió". Gate triple interno; no-op en iOS.
+  const haptics = useHaptics({ reducedMotion });
   const zoom = entrada?.zoom ?? 6.5;
   const acento = (tinte && tinte[0]) || '#3f8f4e';
   const centro = entrada?.centro || [0, (params?.alto ?? 1.1) * 0.5, 0];
@@ -125,6 +129,7 @@ function Contenido({
               onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => {
                 e.stopPropagation();
+                haptics.tap();
                 setActivo(h.id);
                 onHotspot?.(h.view, h.data);
               }}

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -22,6 +22,7 @@ import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaAngelita } from '../../creatures/AbejaAngelita.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
+import useHaptics from '../useHaptics.js';
 
 /**
  * Devuelve `{ ref, caraRef, sombraRef }` para colgar del `<group>` de la abeja,
@@ -43,6 +44,11 @@ export function useEntradaAbeja(foco, {
   const caraRef = useRef(null);
   const sombraRef = useRef(null);
   const prevX = useRef(foco.x);
+  // Háptica de "posarse" (DR-3D-HAPTICA): UNA sola vez por foco, al cruzar el
+  // umbral de llegada. El foco solo cambia por tap del usuario (hotspot) o al
+  // montar la escena (que nace de un tap para entrar al mundo) → gesto-derivado.
+  const haptics = useHaptics({ reducedMotion });
+  const posadaEn = useRef(null); // el foco ya celebrado (no repetir por frame)
   useFrame((state) => {
     if (!ref.current) return;
     const t = state.clock.elapsedTime;
@@ -57,6 +63,13 @@ export function useEntradaAbeja(foco, {
       foco.z + (entrando ? 0.6 : 0.55 + vagarZ),
     );
     ref.current.position.lerp(dest, entrando ? 0.06 : 0.05);
+    // Angelita se posa: al cruzar el umbral de llegada al foco, un roce háptico
+    // (una vez por foco — el ref evita repetir por frame; el gate del hook
+    // apaga todo con reduced-motion, pref 'off' o sin soporte).
+    if (entrando && posadaEn.current !== foco && ref.current.position.distanceTo(dest) < 0.3) {
+      posadaEn.current = foco;
+      haptics.abeja();
+    }
     if (caraRef.current) {
       const vx = ref.current.position.x - prevX.current;
       if (Math.abs(vx) > 0.0015) caraRef.current.style.transform = `scaleX(${vx < 0 ? -1 : 1})`;

--- a/src/visual/mundo3d/index.js
+++ b/src/visual/mundo3d/index.js
@@ -32,3 +32,7 @@ export { decidirTier, permite3D } from './deviceTier.js';
 // Navegación valle ↔ mundos (three-free): la máquina de fases + el viaje DOM.
 export { useNavegacionMundos, puedeEntrarAlMundo } from './useNavegacionMundos.js';
 export { default as TransicionMundo, VIAJE_MS } from './TransicionMundo.jsx';
+
+// Háptica táctil (three-free, DR-3D-HAPTICA): pulsos semánticos por evento del
+// framework — no-op silencioso donde no hay Vibration API (iOS/Safari, FF129+).
+export { default as useHaptics, PATRONES_HAPTICOS } from './useHaptics.js';

--- a/src/visual/mundo3d/useHaptics.js
+++ b/src/visual/mundo3d/useHaptics.js
@@ -1,0 +1,108 @@
+/*
+ * useHaptics — LA CAPA TÁCTIL del framework de mundos (spec S4, DR-3D-HAPTICA).
+ *
+ * Un pulso háptico sutil que ACOMPAÑA momentos que ya son visibles/audibles
+ * (tap en hotspot, la abeja posándose, el velo de viaje valle↔mundo). Nunca
+ * lleva información sola: en iOS/Safari y Firefox 129+ (sin Vibration API)
+ * todo es no-op silencioso y el usuario no pierde nada.
+ *
+ * Reglas inviolables del DR:
+ *  - Gate triple: soportado && habilitadoPorPref && !reducedMotion (en 'auto').
+ *  - Solo tras gesto del usuario; un pulso por acción (throttle 120 ms,
+ *    cancel-then-fire para no encolar patrones).
+ *  - Presupuesto: pulsos <40 ms, patrón total <150 ms. Sin zumbidos.
+ *  - SSR-safe, cero dependencias, offline, jamás throw.
+ *
+ * Preferencia persistida en usePrefsStore (clave `chagra:prefs:haptics`):
+ *   'auto' (default) → vibra si hay soporte y NO hay prefers-reduced-motion.
+ *   'on'             → vibra aunque haya reduced-motion (el usuario sensorial
+ *                      que SÍ quiere el feedback táctil manda).
+ *   'off'            → nunca.
+ *
+ * Three-free: seguro en el bundle base (lo importan useNavegacionMundos y
+ * las escenas perezosas por igual).
+ */
+import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
+import usePrefsStore from '../../store/usePrefsStore.js';
+
+/* Catálogo semántico (ms). Unidad de diseño: el "tick" de 10 ms. La Vibration
+   API no controla amplitud, solo on/off: la "rampa" del viaje se simula con
+   anchos de pulso crecientes (entrar) o decrecientes (volver = aterrizar). */
+export const PATRONES_HAPTICOS = {
+  tap: 10, // hotspot: "toqué algo vivo, respondió"
+  abeja: [12, 55, 20], // posarse: roce, respiro, asiento cálido
+  viajeEntrar: [8, 28, 14, 28, 20], // absorción ascendente (~98 ms)
+  viajeVolver: [16, 28, 8], // aterrizaje suave, descendente (~52 ms)
+  descubrimiento: [10, 45, 10, 45, 22], // "ta-da" contenido (~132 ms)
+  error: [22, 45, 22], // doble golpe sordo: "por aquí no" (~89 ms)
+};
+
+const THROTTLE_MS = 120;
+
+const SOPORTA = typeof navigator !== 'undefined' && 'vibrate' in navigator;
+
+/* Suscripción viva a prefers-reduced-motion, sin dependencias. */
+function subRM(cb) {
+  if (typeof window === 'undefined' || !window.matchMedia) return () => {};
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+  mq.addEventListener?.('change', cb);
+  return () => mq.removeEventListener?.('change', cb);
+}
+function getRM() {
+  return typeof window !== 'undefined'
+    && Boolean(window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches);
+}
+
+/**
+ * @param {object} [opts]
+ * @param {boolean} [opts.reducedMotion]  override explícito del host (el árbol
+ *   de mundos ya propaga `reducedMotion` como prop); si se omite, el hook
+ *   escucha `prefers-reduced-motion` por su cuenta.
+ * @returns {{
+ *   supported: boolean, enabled: boolean,
+ *   fire: (clave: string|number|number[]) => void, stop: () => void,
+ *   tap: () => void, abeja: () => void,
+ *   viajeEntrar: () => void, viajeVolver: () => void,
+ *   descubrimiento: () => void, error: () => void,
+ * }}
+ */
+export default function useHaptics({ reducedMotion } = {}) {
+  const pref = usePrefsStore((s) => s.haptics ?? 'auto'); // 'auto' | 'on' | 'off'
+  const rm = useSyncExternalStore(subRM, getRM, () => false);
+  const menosMov = reducedMotion ?? rm;
+  const ultimo = useRef({ clave: null, t: 0 });
+
+  const enabled = useMemo(() => {
+    if (!SOPORTA || pref === 'off') return false;
+    if (pref === 'on') return true;
+    return !menosMov; // 'auto'
+  }, [pref, menosMov]);
+
+  const fire = useCallback((clave) => {
+    if (!enabled) return;
+    const patron = typeof clave === 'string' ? PATRONES_HAPTICOS[clave] : clave;
+    if (patron == null) return;
+    const ahora = Date.now();
+    const nombre = typeof clave === 'string' ? clave : 'crudo';
+    // Un pulso por acción: el mismo evento dentro de 120 ms se ignora.
+    if (ultimo.current.clave === nombre && ahora - ultimo.current.t < THROTTLE_MS) return;
+    ultimo.current = { clave: nombre, t: ahora };
+    try {
+      navigator.vibrate(0); // cancel-then-fire: no encolar sobre lo que suene
+      navigator.vibrate(patron);
+    } catch { /* jamás throw: la háptica es realce, no requisito */ }
+  }, [enabled]);
+
+  return useMemo(() => ({
+    supported: SOPORTA,
+    enabled,
+    fire,
+    stop: () => { try { navigator.vibrate(0); } catch { /* noop */ } },
+    tap: () => fire('tap'),
+    abeja: () => fire('abeja'),
+    viajeEntrar: () => fire('viajeEntrar'),
+    viajeVolver: () => fire('viajeVolver'),
+    descubrimiento: () => fire('descubrimiento'),
+    error: () => fire('error'),
+  }), [enabled, fire]);
+}

--- a/src/visual/mundo3d/useNavegacionMundos.js
+++ b/src/visual/mundo3d/useNavegacionMundos.js
@@ -23,6 +23,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { resolverMundo } from './resolverMundo.js';
+import useHaptics from './useHaptics.js';
 
 /** ¿Este mundo tiene una escena montable (3D o 2D) en el registro? */
 export function puedeEntrarAlMundo(mundoId) {
@@ -49,6 +50,15 @@ export function useNavegacionMundos({ reducedMotion = false } = {}) {
   // El mundo que aún no abre su puerta (para el aviso "pronto" del host).
   const [pronto, setPronto] = useState(null);
   const prontoTimer = useRef(null);
+  // Háptica del viaje (DR-3D-HAPTICA): entrar absorbe, volver aterriza,
+  // "pronto" marca el borde. Gate triple interno (soporte + pref + rm);
+  // el reducedMotion del host manda para que el gate sea coherente con
+  // el resto del árbol de mundos.
+  const haptics = useHaptics({ reducedMotion });
+  // Espejo de la fase actual para disparar hápticas FUERA del updater de
+  // estado (los updaters deben ser puros — StrictMode los corre dos veces).
+  const faseRef = useRef(estado.fase);
+  faseRef.current = estado.fase;
 
   useEffect(() => () => clearTimeout(prontoTimer.current), []);
 
@@ -58,31 +68,39 @@ export function useNavegacionMundos({ reducedMotion = false } = {}) {
         setPronto(mundoId);
         clearTimeout(prontoTimer.current);
         prontoTimer.current = setTimeout(() => setPronto(null), 3200);
+        haptics.error(); // "por aquí no" — dobla el aviso visual "pronto"
         return false;
       }
       setPronto(null);
       setEstado(reducedMotion ? { fase: 'mundo', mundoId } : { fase: 'viajando', mundoId });
+      haptics.viajeEntrar(); // absorción: nace del tap del usuario
       return true;
     },
-    [reducedMotion],
+    [reducedMotion, haptics],
   );
 
   const volverAlValle = useCallback(() => {
+    // Con reducedMotion el corte es directo a 'valle' (sin fase 'regresando'
+    // ni completarViaje), así que el aterrizaje suena aquí; sin reducedMotion
+    // suena al completar el viaje. Pulso solo si de verdad hay mundo abierto.
+    if (reducedMotion && faseRef.current !== 'valle') haptics.viajeVolver();
     setEstado((e) => {
       if (!e.mundoId) return e;
       return reducedMotion
         ? { fase: 'valle', mundoId: null }
         : { fase: 'regresando', mundoId: e.mundoId };
     });
-  }, [reducedMotion]);
+  }, [reducedMotion, haptics]);
 
   const completarViaje = useCallback(() => {
+    // Aterrizar en casa: solo la vuelta vibra aquí (la ida ya sonó al zarpar).
+    if (faseRef.current === 'regresando') haptics.viajeVolver();
     setEstado((e) => {
       if (e.fase === 'viajando') return { fase: 'mundo', mundoId: e.mundoId };
       if (e.fase === 'regresando') return { fase: 'valle', mundoId: null };
       return e;
     });
-  }, []);
+  }, [haptics]);
 
   return {
     fase: estado.fase,


### PR DESCRIPTION
## Qué hace

Implementa la capa háptica del framework de mundos 3D según `DR-3D-HAPTICA-2026-07-11` (spec S4 del audit de game-feel): pulsos táctiles sutiles que **acompañan** momentos que ya son visibles — nunca información solo-háptica.

## Hook `src/visual/mundo3d/useHaptics.js`

- `navigator.vibrate` con feature-detect; **no-op silencioso** en iOS/Safari y Firefox 129+ (sin pérdida de información).
- **Gate triple**: `soportado && pref && !reducedMotion`. SSR-safe, cero dependencias, jamás throw.
- Throttle 120 ms (un pulso por acción) + cancel-then-fire (no encola patrones).
- Catálogo semántico <150 ms: `tap` (10), `abeja` [12,55,20], `viajeEntrar` [8,28,14,28,20], `viajeVolver` [16,28,8], `descubrimiento` [10,45,10,45,22], `error` [22,45,22].
- Exportado en el barrel (three-free, seguro en el bundle base).

## Cableado

| Evento | Dónde |
|---|---|
| Tap en hotspot | `escenas/EscenaBase3D.jsx` — `onClick` del botón `.mundo-hotspot` |
| Abeja se posa | `escenas/useEntradaAbeja.jsx` — al cruzar el umbral de llegada al foco, una vez por foco |
| Entrar a un mundo | `useNavegacionMundos.js` — `viajarAlMundo()` exitoso |
| Volver al valle | `useNavegacionMundos.js` — `completarViaje()` en la rama `regresando→valle` (con reduced-motion, en el corte directo de `volverAlValle()`) |
| Mundo "pronto" | `useNavegacionMundos.js` — rama que retorna `false` |

## Preferencia + toggle

- `usePrefsStore`: clave `chagra:prefs:haptics` tri-estado `auto | on | off` (default `auto` = activa en móvil con soporte, apagada con reduced-motion).
- `ProfileScreen`: sección "Vibración" (Automática / Siempre / Nunca) junto a los ajustes de voz, con nota cuando el equipo no admite vibración (WCAG 2.3.3, opt-out en pantalla).

## Verificación

- `npm run build` verde (1m11s, solo warnings preexistentes de chunk-size).
- Vitest: 19/19 — contrato del hook nuevo (patrones exactos, gate triple, throttle, sin-API no-op) + `navegacion.test.jsx` + `usePrefsStore.test.js` sin regresión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)