### PR TITLE
fix(valle3d): agente y voz persisten dentro del mundo — cuarto mudo (BUG-AG-02)

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -12,8 +12,10 @@
  *      toca (el semillero). Tocarlo: el agente lo dice en voz y ofrece LA acción.
  *   2. LOS MUNDOS → cada mundo (fuente real mundosFinca.js) es un LUGAR del
  *      valle al que se VIAJA: la cámara vuela hasta él y se abre su panel.
- *   3. AGENTE / VOZ → el colibrí (visual-lib) es un compañero presente que
- *      flota sobre el foco y NARRA por voz (Web Speech API) al pasar.
+ *   3. AGENTE / VOZ → Angelita es un compañero presente que flota sobre el
+ *      foco y NARRA por voz (Web Speech API) al pasar. PERSISTE dentro de los
+ *      mundos (auditoría BUG-AG-02: antes el mundo era un "cuarto mudo") y si
+ *      la voz falta o está apagada, ESCRIBE (burbuja de texto) — nunca mudo.
  *   4. ESTADO / CLIMA → el estado real (por la hora de la vereda) tiñe todo:
  *      luz, niebla, cielo y estrellas de la escena 3D + grade DOM de effects.
  *
@@ -130,8 +132,6 @@ export default function EntradaValle3D({ onBack }) {
 
   // ── NAVEGACIÓN valle ↔ mundos: la máquina de fases vive en el framework.
   //    (reduced-motion la vuelve corte simple, sin overlay de viaje).
-  const [puerta, setPuerta] = useState(null); // puerta tocada DENTRO de un mundo
-
   const reducedMotion = useMemo(
     () =>
       typeof window !== 'undefined' &&
@@ -187,27 +187,78 @@ export default function EntradaValle3D({ onBack }) {
     setGesto((g) => (g === 'reposo' ? null : g));
   }, []);
 
+  // Asentir: micro-reacción corta de Angelita cuando el usuario toca una
+  // puerta dentro del mundo — el agente ACUSA el toque (no decoración muda).
+  const gestoTimer = useRef(null);
+  const asentir = useCallback(() => {
+    setGesto('asiente');
+    if (gestoTimer.current) clearTimeout(gestoTimer.current);
+    gestoTimer.current = setTimeout(() => setGesto((g) => (g === 'asiente' ? null : g)), 1600);
+  }, []);
+  useEffect(
+    () => () => {
+      if (gestoTimer.current) clearTimeout(gestoTimer.current);
+    },
+    [],
+  );
+
   // ── Voz (Web Speech API): el agente DICE. Se calla si el equipo no la trae
   //    o si el usuario apaga la voz. Prefiere una voz en español.
-  const hablar = useCallback(
+  //    (Si esto se productiza, la voz real es Kokoro vía ttsService — default
+  //    `em_santa`; aquí la vitrina usa la del navegador.)
+  const vozDisponible = useMemo(
+    () => typeof window !== 'undefined' && 'speechSynthesis' in window,
+    [],
+  );
+
+  // El toggle vive en un ref para que `hablar`/`decir` sean ESTABLES: prender
+  // o apagar la voz no debe re-disparar los efectos que narran.
+  const vozRef = useRef(voz);
+  useEffect(() => {
+    vozRef.current = voz;
+  }, [voz]);
+
+  const hablar = useCallback((texto) => {
+    if (!vozRef.current || typeof window === 'undefined' || !window.speechSynthesis) return;
+    try {
+      window.speechSynthesis.cancel();
+      const u = new SpeechSynthesisUtterance(texto);
+      u.lang = 'es-CO';
+      u.rate = 0.98;
+      u.pitch = 1;
+      const esVoz = window.speechSynthesis
+        .getVoices()
+        .find((v) => v.lang && v.lang.toLowerCase().startsWith('es'));
+      if (esVoz) u.voice = esVoz;
+      window.speechSynthesis.speak(u);
+    } catch {
+      /* la voz es un plus, nunca bloquea */
+    }
+  }, []);
+
+  // ── Angelita DICE (voz + burbuja): el texto SIEMPRE acompaña a la voz en la
+  //    burbuja del compañero (aria-live). Si el equipo no trae voz o el
+  //    usuario la apagó, la burbuja ES la voz — la pantalla nunca queda muda.
+  const [dicho, setDicho] = useState(null);
+  const dichoTimer = useRef(null);
+  const decir = useCallback(
     (texto) => {
-      if (!voz || typeof window === 'undefined' || !window.speechSynthesis) return;
-      try {
-        window.speechSynthesis.cancel();
-        const u = new SpeechSynthesisUtterance(texto);
-        u.lang = 'es-CO';
-        u.rate = 0.98;
-        u.pitch = 1;
-        const esVoz = window.speechSynthesis
-          .getVoices()
-          .find((v) => v.lang && v.lang.toLowerCase().startsWith('es'));
-        if (esVoz) u.voice = esVoz;
-        window.speechSynthesis.speak(u);
-      } catch {
-        /* la voz es un plus, nunca bloquea */
-      }
+      if (!texto) return;
+      setDicho(texto);
+      if (dichoTimer.current) clearTimeout(dichoTimer.current);
+      dichoTimer.current = setTimeout(
+        () => setDicho(null),
+        Math.min(14000, 4000 + texto.length * 55),
+      );
+      hablar(texto);
     },
-    [voz],
+    [hablar],
+  );
+  useEffect(
+    () => () => {
+      if (dichoTimer.current) clearTimeout(dichoTimer.current);
+    },
+    [],
   );
 
   useEffect(
@@ -217,14 +268,14 @@ export default function EntradaValle3D({ onBack }) {
     [],
   );
 
-  // Saludo del compañero al entrar (una sola vez).
+  // Saludo del compañero al entrar (una sola vez): voz + burbuja.
   const saludado = useRef(false);
   useEffect(() => {
     if (saludado.current) return;
     saludado.current = true;
-    const t = setTimeout(() => hablar(NARRACION.bienvenida), 900);
+    const t = setTimeout(() => decir(NARRACION.bienvenida), 900);
     return () => clearTimeout(t);
-  }, [hablar]);
+  }, [decir]);
 
   const entrarMundo = useCallback(
     (id) => {
@@ -267,7 +318,6 @@ export default function EntradaValle3D({ onBack }) {
     (id) => {
       if (!nav.viajarAlMundo(id)) return;
       setPanel(null);
-      setPuerta(null);
       hablar(`Angelita lo lleva a ${tituloDeMundo(id)}.`);
     },
     [nav, hablar],
@@ -275,22 +325,45 @@ export default function EntradaValle3D({ onBack }) {
 
   // ── VOLVER del mundo al valle (misma transición, en reversa).
   const salirDelMundo = useCallback(() => {
-    setPuerta(null);
     nav.volverAlValle();
-    hablar('De vuelta al valle de su finca.');
-  }, [nav, hablar]);
+    decir('De vuelta al valle de su finca.');
+  }, [nav, decir]);
+
+  // ── EL MUNDO HABLA (BUG-AG-02, el "cuarto mudo"): al llegar a un mundo,
+  //    Angelita lo narra consumiendo `entrada.narra` del registro (BUG-AG-01:
+  //    el dato existía y nadie lo leía) y deja la pista de las puertas.
+  //    Voz si hay y está prendida; burbuja de texto siempre.
+  useEffect(() => {
+    if (!nav.enMundo || !nav.mundoId) return undefined;
+    const clave = MUNDO[nav.mundoId]?.entrada?.narra;
+    const texto =
+      (clave && NARRACION[clave]) ||
+      NARRACION[nav.mundoId] ||
+      MUNDO_VALLE_BY_ID[nav.mundoId]?.lema ||
+      `Está en ${tituloDeMundo(nav.mundoId)}.`;
+    const t = setTimeout(
+      () => decir(`${texto} Toque un punto para ver a dónde lo lleva.`),
+      700,
+    );
+    return () => clearTimeout(t);
+  }, [nav.enMundo, nav.mundoId, decir]);
 
   // ── Una puerta tocada DENTRO del mundo: en la vitrina (sin sesión) no
-  //    navega — cuenta a qué pantalla real de la app lleva (regla de oro).
+  //    navega — ANGELITA la nombra (voz + burbuja) y asiente: el agente
+  //    reacciona al hotspot en vez de dejar un letrero suelto (regla de oro:
+  //    cuenta a qué pantalla real de la app lleva).
   const onPuertaMundo = useCallback(
     (view, data) => {
       const puertas = MUNDO[nav.mundoId]?.hotspots || [];
       const hs =
         puertas.find((h) => h.view === view && (h.data === data || (!h.data && !data))) ||
         puertas.find((h) => h.view === view);
-      setPuerta({ label: hs?.label || view, view });
+      asentir();
+      decir(
+        `«${hs?.label || view}» es una puerta real: dentro de la app abre la pantalla «${view}».`,
+      );
     },
-    [nav.mundoId],
+    [nav.mundoId, decir, asentir],
   );
 
   const mundoPanel = panel && panel !== 'alerta' ? MUNDO_VALLE_BY_ID[panel] : null;
@@ -348,11 +421,6 @@ export default function EntradaValle3D({ onBack }) {
             animo={companero.animo}
             energia={companero.energia}
           />
-          <p className="valle-mundo__puerta" role="status" aria-live="polite">
-            {puerta
-              ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
-              : 'Toque un punto del mundo para ver a dónde lo lleva, o vuelva al valle cuando quiera.'}
-          </p>
         </section>
       )}
 
@@ -395,8 +463,10 @@ export default function EntradaValle3D({ onBack }) {
       {/* ── El compañero: Angelita en una sola línea puntual (imagen-first).
               Es el ser al que se cuida; su cara refleja el ánimo real. Se
               esconde si hay un panel abierto — una cosa clara a la vez.
-              DENTRO de un mundo sigue presente (compacta, sin frase): así se
-              ve su celebración al llegar y no abandona a quien la sigue. ── */}
+              DENTRO de un mundo sigue presente y HABLA: narra el lugar y
+              nombra las puertas. Lo que dice (`dicho`) va SIEMPRE en su
+              burbuja de texto (aria-live) — si la voz falta o está apagada,
+              la burbuja es la voz. ── */}
       {!panel && (
         <div
           className={`valle-companero${nav.enMundo ? ' valle-companero--mundo' : ''}`}
@@ -414,7 +484,9 @@ export default function EntradaValle3D({ onBack }) {
             />
             <i className="valle-companero__sombra" />
           </span>
-          {!nav.enMundo && <span className="valle-companero__txt">{companero.frase}</span>}
+          {(dicho || !nav.enMundo) && (
+            <span className="valle-companero__txt">{dicho || companero.frase}</span>
+          )}
         </div>
       )}
 
@@ -462,11 +534,13 @@ export default function EntradaValle3D({ onBack }) {
         </aside>
       )}
 
-      {/* ── Barra del AGENTE: el compañero presente + voz + volver al valle.
-              Dentro de un mundo se esconde (la miga del mundo ya trae el
-              volver; una cosa clara a la vez). ── */}
-      {!nav.enMundo && (
-      <footer className="valle-agente">
+      {/* ── Barra del AGENTE: el compañero presente + voz. PERSISTE dentro
+              del mundo (BUG-AG-02: antes se ocultaba y el diorama quedaba
+              mudo, sin cómo preguntar ni prender/apagar la voz). Adentro va
+              compacta, flotando sobre la escena; la miga del mundo ya trae
+              el volver. Sin voz en el equipo, el estado lo dice claro:
+              Angelita le escribe. ── */}
+      <footer className={`valle-agente${nav.enMundo ? ' valle-agente--mundo' : ''}`}>
         <button
           type="button"
           className="valle-agente__pregunte"
@@ -477,26 +551,29 @@ export default function EntradaValle3D({ onBack }) {
           Pregúntele a su finca…
         </button>
         <div className="valle-agente__ctrls">
-          {focoId && (
+          {!nav.enMundo && focoId && (
             <button type="button" className="valle-agente__btn" onClick={volverAlValle}>
               Ver todo el valle
             </button>
           )}
           <button
             type="button"
-            className={`valle-agente__btn valle-agente__voz${voz ? ' on' : ''}`}
-            aria-pressed={voz}
+            className={`valle-agente__btn valle-agente__voz${voz && vozDisponible ? ' on' : ''}`}
+            aria-pressed={voz && vozDisponible}
+            disabled={!vozDisponible}
+            title={
+              vozDisponible ? undefined : 'Este equipo no trae voz: Angelita le escribe.'
+            }
             onClick={() => {
               const n = !voz;
               setVoz(n);
               if (!n && typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
             }}
           >
-            {voz ? '🔊 Voz' : '🔇 Voz'}
+            {!vozDisponible ? '💬 Texto' : voz ? '🔊 Voz' : '🔇 Voz'}
           </button>
         </div>
       </footer>
-      )}
     </div>
   );
 }

--- a/src/mockups/__tests__/entradaValle3D.nav.test.jsx
+++ b/src/mockups/__tests__/entradaValle3D.nav.test.jsx
@@ -6,7 +6,10 @@
  * humilde. Se congela el ciclo entero:
  *   · tocar un lugar del valle → panel del mundo → "Entrar a este mundo";
  *   · el viaje (Angelita guía) → la escena del mundo con su miga "‹ El valle";
- *   · una puerta DENTRO del mundo cuenta a qué pantalla real lleva;
+ *   · DENTRO del mundo el agente PERSISTE (BUG-AG-02, el "cuarto mudo"):
+ *     la barra "Pregúntele…" + estado de voz siguen, y Angelita narra el
+ *     lugar en su burbuja (sin speechSynthesis en jsdom = el texto ES la voz);
+ *   · una puerta DENTRO del mundo: Angelita cuenta a qué pantalla real lleva;
  *   · "Volver al valle" → viaje en reversa → el valle otra vez;
  *   · un mundo sin escena montable (clima) degrada elegante a "pronto".
  */
@@ -46,9 +49,20 @@ describe('entrada-3d — navegable de punta a punta (valle ↔ mundos)', () => {
     // el chrome del valle descansa mientras se está dentro
     expect(screen.queryByRole('heading', { level: 1, name: 'El valle de mi finca' })).not.toBeInTheDocument();
 
-    // 4) UNA PUERTA del mundo: en la vitrina cuenta a qué pantalla real lleva.
+    // 3b) EL MUNDO NO ES MUDO (BUG-AG-02): la barra del agente PERSISTE
+    //     (preguntar + estado de voz) y Angelita narra el lugar en su burbuja
+    //     (jsdom no trae speechSynthesis → el texto ES la voz, nunca mudo).
+    expect(screen.getByRole('button', { name: 'Pregúntele a Chagra' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Texto|Voz/ })).toBeInTheDocument();
+    act(() => vi.advanceTimersByTime(800)); // la narración entra con una pausita
+    expect(container.querySelector('.valle-companero')).toHaveTextContent(
+      /sale el agua para toda la finca/,
+    );
+
+    // 4) UNA PUERTA del mundo: ANGELITA la nombra — en la vitrina cuenta a
+    //    qué pantalla real lleva.
     fireEvent.click(screen.getByRole('button', { name: 'La quebrada viva' }));
-    expect(container.querySelector('.valle-mundo__puerta')).toHaveTextContent('«biodiversidad»');
+    expect(container.querySelector('.valle-companero')).toHaveTextContent('«biodiversidad»');
 
     // 5) VOLVER: viaje en reversa → el valle completo otra vez.
     fireEvent.click(screen.getByRole('button', { name: 'Volver al valle' }));

--- a/src/mockups/entradaValle3D.css
+++ b/src/mockups/entradaValle3D.css
@@ -265,13 +265,24 @@
   transform: translateX(-50%) scaleX(1.08);
 }
 
-/* Dentro de un mundo: presencia compacta (solo la abeja, sin frase), por
-   ENCIMA de la escena del mundo (z 30) sin tapar la miga ni los hotspots. */
+/* Dentro de un mundo: presencia compacta por ENCIMA de la escena del mundo
+   (z 30) sin tapar la miga ni los hotspots. Cuando Angelita DICE algo, la
+   burbuja de texto se abre a su lado (voz y texto son la misma frase). */
 .valle-companero--mundo {
   z-index: 35;
-  bottom: 4.8rem;
-  padding: 0.3rem 0.4rem;
-  background: rgba(15, 24, 30, 0.55);
+  bottom: 4.9rem;
+  padding: 0.3rem 0.75rem 0.3rem 0.4rem;
+  background: rgba(15, 24, 30, 0.62);
+}
+
+/* Asiente: brinquito corto al tocar una puerta — el agente acusa el toque. */
+.valle-companero[data-gesto='asiente'] .valle-companero__cara [data-creature='abeja-angelita'] {
+  animation: valle-angelita-asiente 0.75s ease-in-out 2;
+}
+@keyframes valle-angelita-asiente {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  40% { transform: translateY(-6px) rotate(-8deg); }
+  70% { transform: translateY(-1px) rotate(5deg); }
 }
 .valle-companero__txt {
   font-size: 0.85rem;
@@ -441,7 +452,25 @@
   white-space: nowrap;
 }
 .valle-agente__btn:hover { background: rgba(0, 0, 0, 0.5); }
+.valle-agente__btn:disabled { opacity: 0.8; cursor: default; }
 .valle-agente__voz.on { border-color: #7dffbe; }
+
+/* DENTRO de un mundo la barra del agente PERSISTE (BUG-AG-02), compacta y
+   flotando sobre el diorama (el mundo es z 30). Táctil se mantiene ≥44px. */
+.valle-agente--mundo {
+  z-index: 40;
+  padding: 0.45rem 0.8rem calc(0.45rem + env(safe-area-inset-bottom, 0px));
+  background: linear-gradient(0deg, rgba(26, 20, 12, 0.8) 0%, rgba(26, 20, 12, 0) 100%);
+}
+.valle-agente--mundo .valle-agente__pregunte {
+  min-height: 44px;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.92rem;
+}
+.valle-agente--mundo .valle-agente__btn {
+  min-height: 44px;
+  font-size: 0.85rem;
+}
 
 .valle-degradado {
   position: absolute;
@@ -571,6 +600,8 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  /* aire abajo para la barra del agente persistente (valle-agente--mundo) */
+  padding-bottom: calc(3.9rem + env(safe-area-inset-bottom, 0px));
   background: color-mix(in srgb, var(--vm-tinte, #3f8f4e) 14%, #f2e8d6);
   color: #2a2016;
 }
@@ -578,15 +609,6 @@
   flex: 1 1 auto;
   min-height: min(72vh, 520px);
   border-radius: 0;
-}
-.valle-mundo__puerta {
-  margin: 0;
-  padding: 0.7rem 1rem calc(0.7rem + env(safe-area-inset-bottom, 0px));
-  font-size: 0.9rem;
-  line-height: 1.4;
-  color: #4a3a22;
-  background: rgba(255, 251, 242, 0.92);
-  border-top: 1px solid rgba(60, 46, 24, 0.15);
 }
 
 /* La degradación elegante del panel: mundo sin escena montable aún. */


### PR DESCRIPTION
## Qué arregla

**BUG-AG-02 (el más grave de la auditoría agente-3D): al entrar a un mundo, el agente y la voz desaparecían por completo** — `{!nav.enMundo && …}` ocultaba la barra "Pregúntele…", el toggle de voz y toda narración. El diorama era un cuarto mudo.

## Cómo

- **Barra del agente PERSISTENTE dentro del mundo** (SPEC-AG-02): "Pregúntele a su finca…" + estado de voz siguen adentro, compactos (táctil ≥44px), flotando sobre el diorama (`valle-agente--mundo`, z sobre la escena). La miga "‹ El valle" sigue mandando el volver.
- **Angelita = cuerpo del agente adentro** (SPEC-AG-01): al llegar **narra el mundo consumiendo `entrada.narra`** del registro (BUG-AG-01: era dato muerto) + pista de puertas. Reacciona a los hotspots: gesto "asiente" + los nombra por voz. Su idle (flota/respira) y micro-reacciones ya existentes persisten; en escena ya perseguía el foco.
- **Nunca pantalla muda**: `decir()` = voz + burbuja de texto de Angelita (aria-live). Si el equipo no trae `speechSynthesis`, el toggle degrada a «💬 Texto» y la burbuja ES la voz.
- El letrero suelto `valle-mundo__puerta` lo asume Angelita (el agente habla, no un cartel).
- `hablar()` estable vía ref del toggle: prender/apagar la voz no re-dispara narraciones.
- Voz por defecto: sin cambios necesarios — `ttsService.js` ya tiene `DEFAULT_KOKORO_VOICE = 'em_santa'` (`pm_santa` solo queda en comentarios históricos y tests que verifican su rechazo).

## Verificación

- `vitest` `entradaValle3D.nav.test.jsx` → 3/3 en verde (test actualizado: asserta barra persistente + narración de Angelita + puerta nombrada en su burbuja).
- `npm run build` → verde (1m12s).
- Reduced-motion: el bloque existente congela también el gesto nuevo.

Refs: DR-AUDIT-UX-CAMPESINO-AGENTE-3D-2026-07-11 (BUG-AG-01/02/03, SPEC-AG-01/02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)