### PR TITLE
feat(mundo3d): mundo Sanidad 3D — huerta-clínica de manejo sin veneno

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -91,6 +91,10 @@ const Mundo3DBosqueMockup = lazy(() => import('./mockups/Mundo3DBosque'));
 // 3D: "El mundo del clima" — monta <Mundo mundoId="clima"> del framework: la
 // bóveda del cielo (arquetipo nuevo `boveda`). El 3D va perezoso (vendor-three).
 const Mundo3DClimaMockup = lazy(() => import('./mockups/Mundo3DClima'));
+// 3D: "El mundo de la sanidad" — monta <Mundo mundoId="sanidad"> del framework:
+// la huerta-clínica (arquetipo nuevo `sanidad`, familia recinto): trampas,
+// biocontrol y enemigos naturales. El 3D va perezoso (vendor-three).
+const Mundo3DSanidadMockup = lazy(() => import('./mockups/Mundo3DSanidad'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -502,6 +506,8 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/evidencia-ilustrada': 'mockup_evidencia_ilustrada',
   'mockups/guardianes-narrativos': 'mockup_guardianes',
   'mockups/hoja-vida-mata': 'mockup_hoja_vida_mata',
+  // (anti-conflicto de merge) rutas nuevas SIEMPRE al final del bloque:
+  'mockups/mundo3d-sanidad': 'mockup_mundo3d_sanidad',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1584,6 +1590,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Hoja de vida de la mata">
               <HojaVidaMataMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      // (anti-conflicto de merge) cases de mockup nuevos SIEMPRE al final del grupo:
+      case 'mockup_mundo3d_sanidad':
+        // Vitrina pública del MUNDO DE LA SANIDAD: monta <Mundo mundoId="sanidad">
+        // del framework (src/visual/mundo3d) con device-tiering real. Ruta
+        // #/mockups/mundo3d-sanidad, sin auth. La huerta-clínica: manejo de plagas
+        // sin veneno — trampas cromáticas, biocontrol (Beauveria/Metarhizium),
+        // borde push-pull y enemigos naturales (mariquita, carábido).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo de la sanidad">
+              <Mundo3DSanidadMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mundo3DSanidad.css
+++ b/src/mockups/Mundo3DSanidad.css
@@ -1,0 +1,152 @@
+/*
+ * Mundo3DSanidad.css — vitrina pública del mundo de la sanidad
+ * (#/mockups/mundo3d-sanidad). Autocontenida: sin fuentes/imágenes externas.
+ * Móvil-first desde 320px. Solo opacity/transform animables; reduced-motion las
+ * apaga.
+ */
+
+.m3dsan {
+  --m3dsan-a: #b0532f;
+  --m3dsan-b: #f6ded1;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3dsan-b) 0%, #f7eee6 44%, #f0d3c1 100%);
+  color: #3a2418;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3dsan__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3dsan__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3dsan-a);
+}
+.m3dsan__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #5a2b16;
+}
+.m3dsan__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3dsan__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3dsan__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(176, 83, 47, 0.28);
+  box-shadow: 0 10px 28px rgba(58, 36, 24, 0.14);
+}
+.m3dsan__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fdf3ec;
+}
+
+.m3dsan__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3dsan__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3dsan__toggle {
+  border: 1.5px solid var(--m3dsan-a);
+  background: #fff;
+  color: var(--m3dsan-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3dsan__toggle:hover,
+.m3dsan__toggle:focus-visible {
+  background: var(--m3dsan-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3dsan__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.78);
+  border-left: 3px solid var(--m3dsan-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3dsan__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3dsan__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #5a2b16;
+}
+.m3dsan__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3dsan__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3dsan__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid rgba(176, 83, 47, 0.18);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3dsan__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3dsan__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #5a2b16;
+}
+.m3dsan__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3dsan__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #4a2c1a;
+}

--- a/src/mockups/Mundo3DSanidad.jsx
+++ b/src/mockups/Mundo3DSanidad.jsx
@@ -1,0 +1,155 @@
+/*
+ * Mundo3DSanidad — vitrina pública del MUNDO DE LA SANIDAD (ruta
+ * #/mockups/mundo3d-sanidad).
+ *
+ * La huerta-clínica de la finca andina: cómo se cuida la mata SIN veneno. El
+ * diorama enseña el manejo agroecológico de plagas con lo que de verdad
+ * funciona en finca — las trampas cromáticas que llaman al bicho, la estación
+ * de biocontrol con hongos que enferman al insecto (Beauveria/Metarhizium), el
+ * borde de flores aromáticas que empuja la plaga y jala a sus enemigos, y los
+ * enemigos naturales (la mariquita que come pulgón, el carábido del suelo). Nada
+ * de recetas de químicos: manejo vivo, esperanzador. Finca sana, no envenenada.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="sanidad">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento") se ve la infografía 2D digna; en gama
+ * media/alta, el diorama 3D low-poly (chunk perezoso `vendor-three`) con la
+ * abeja Angelita entrando al mundo. Los puntos del recinto son las mismas
+ * puertas del registro: aquí (vitrina sin sesión) muestran a qué pantalla real
+ * de la app llevan, en vez de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import './Mundo3DSanidad.css';
+
+const TINTE = ['#b0532f', '#f6ded1'];
+
+/* Lo que se ve en el recinto, contado en una leyenda didáctica y verificada:
+   manejo agroecológico real de plagas (control biológico + trampas + push-pull),
+   sin una sola receta química. */
+const LEYENDA = [
+  {
+    emoji: '🍅',
+    titulo: 'Las matas sanas',
+    texto: 'En el centro, lo que se protege. Una mata bien nutrida y sin estrés se defiende sola: el mejor control de plagas empieza por un suelo vivo y una planta fuerte.',
+  },
+  {
+    emoji: '🎯',
+    titulo: 'Las trampas cromáticas',
+    texto: 'Tarjetas pegajosas de color: la amarilla llama a la mosca blanca y al minador; la azul, a los trips. Sirven para vigilar cuánto bicho hay y para bajar la población, sin echar nada.',
+  },
+  {
+    emoji: '🧫',
+    titulo: 'El biocontrol con hongos',
+    texto: 'La estación con hongos entomopatógenos (Beauveria bassiana y Metarhizium): esporas que se pegan al insecto y lo enferman. Un aliado vivo que no le hace daño a usted ni a los polinizadores.',
+  },
+  {
+    emoji: '🌼',
+    titulo: 'El borde que empuja y jala (push-pull)',
+    texto: 'La orla de flores aromáticas como la caléndula: repele a la plaga (la empuja) y aloja a sus enemigos naturales (los jala). Sembrar compañía es defender la huerta con plantas.',
+  },
+  {
+    emoji: '🐞',
+    titulo: 'Los enemigos naturales',
+    texto: 'La mariquita y su larva comen cientos de pulgones; el escarabajo del suelo caza larvas de noche; avispitas y moscas ayudan también. Cuidarlos es tener una cuadrilla que trabaja gratis.',
+  },
+];
+
+export default function Mundo3DSanidad() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // En la vitrina (sin sesión) un punto del recinto no navega: cuenta a qué
+  // pantalla real de la app lleva esa puerta.
+  const [puerta, setPuerta] = useState(null);
+  const onHotspot = (view, data) => {
+    const hs = (MUNDO.sanidad.hotspots || []).find(
+      (h) => h.view === view && (h.data === data || (!h.data && !data)),
+    ) || (MUNDO.sanidad.hotspots || []).find((h) => h.view === view);
+    setPuerta({ label: hs?.label || view, view });
+  };
+
+  return (
+    <main
+      className="m3dsan"
+      style={{ '--m3dsan-a': TINTE[0], '--m3dsan-b': TINTE[1] }}
+    >
+      <header className="m3dsan__head">
+        <p className="m3dsan__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo de la sanidad</h1>
+        <p className="m3dsan__lema">
+          Asómese a la huerta-clínica: cómo se cuida la mata sin veneno. Trampas
+          que llaman al bicho, hongos que lo enferman, flores que lo espantan y
+          los enemigos naturales que lo cazan. Finca sana, no envenenada.
+        </p>
+      </header>
+
+      <section className="m3dsan__escena" aria-label="La huerta-clínica de la finca">
+        <Mundo
+          mundoId="sanidad"
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          onSalir={null}
+          animo="atento"
+          energia={0.9}
+        />
+        <div className="m3dsan__barra">
+          <p className="m3dsan__tier">
+            {tier === 'bajo'
+              ? 'Está viendo la ficha de la sanidad (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3dsan__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver la ficha 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3dsan__nota" role="status" aria-live="polite">
+          {puerta
+            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+            : 'Toque un punto del recinto para ver a dónde lo lleva.'}
+        </p>
+      </section>
+
+      <section className="m3dsan__leyenda" aria-label="La sanidad, pieza por pieza">
+        <h2>La huerta-clínica, pieza por pieza</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3dsan__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3dsan__cierre">
+          La sanidad no se compra en un frasco: se cría. Suelo vivo, plantas
+          fuertes, compañía florida y bichos buenos cuidados — y la plaga deja de
+          mandar. Antes de reaccionar, mire: revise el envés de la hoja, cuente
+          en la trampa y decida con cabeza. Menos veneno, más finca viva.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -29,6 +29,7 @@ const IMPORTA_ESCENA = {
   estratos: () => import('./escenas/EscenaEstratos.jsx'),
   valle: () => import('./escenas/EscenaValle.jsx'),
   boveda: () => import('./escenas/EscenaBoveda.jsx'),
+  sanidad: () => import('./escenas/EscenaSanidad.jsx'),
 };
 const ESCENAS_3D = Object.fromEntries(
   Object.entries(IMPORTA_ESCENA).map(([k, importa]) => [k, lazy(importa)]),

--- a/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
+++ b/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
@@ -12,7 +12,7 @@ afterEach(() => cleanup());
 
 describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
   test('arquetipos: 5 dioramas 3D + arquetipos 2D de primera clase', () => {
-    expect(ARQUETIPOS_3D.sort()).toEqual(['boveda', 'cutaway', 'estratos', 'flujo', 'recinto', 'valle']);
+    expect(ARQUETIPOS_3D.sort()).toEqual(['boveda', 'cutaway', 'estratos', 'flujo', 'recinto', 'sanidad', 'valle']);
     ['lamina', 'infografia', 'ficha', 'mirror', 'valle2d'].forEach((k) => {
       expect(ARQUETIPOS_2D).toContain(k);
       expect(ARQUETIPOS[k].dim).toBe('2d');

--- a/src/visual/mundo3d/arquetipos.js
+++ b/src/visual/mundo3d/arquetipos.js
@@ -52,6 +52,15 @@ export const ARQUETIPOS = {
     nombre: 'La bóveda del cielo', clave: 'el cielo de la finca: hora del día + temporada bimodal andina',
     ejemplo: 'clima', tambien: [],
   },
+  // La huerta-clínica: la familia del `recinto` (un lugar cercado que se
+  // camina), pero su lección es el manejo SIN veneno — trampas cromáticas,
+  // biocontrol (Beauveria/Metarhizium), borde push-pull y enemigos naturales.
+  // En equipo humilde cae a su ficha 2D (infografía de la sanidad).
+  sanidad: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'sanidad', espejo: 'mirror',
+    nombre: 'La huerta-clínica', clave: 'el manejo agroecológico de plagas: trampas, biocontrol y enemigos naturales',
+    ejemplo: 'sanidad', tambien: [],
+  },
 
   // ── Arquetipos 2D (primera clase) ────────────────────────────────────────
   mirror: {

--- a/src/visual/mundo3d/escenas/EscenaSanidad.jsx
+++ b/src/visual/mundo3d/escenas/EscenaSanidad.jsx
@@ -1,0 +1,235 @@
+/*
+ * EscenaSanidad — ARQUETIPO `sanidad`: la HUERTA-CLÍNICA y su manejo sin veneno.
+ *
+ * De la familia del `recinto` (un lugar cercado que se camina), pero su lección
+ * NO es el ciclo del abono: es cómo se CUIDA la mata sin químicos. El espacio
+ * mismo enseña el manejo agroecológico de plagas de la finca andina:
+ *
+ *   · las matas sanas al centro (lo que se protege);
+ *   · las TRAMPAS CROMÁTICAS en estacas — la amarilla llama a la mosca blanca y
+ *     el minador, la azul llama a los trips (monitoreo + captura, sin veneno);
+ *   · la ESTACIÓN DE BIOCONTROL — el recipiente con hongos entomopatógenos
+ *     (Beauveria bassiana clara, Metarhizium verdosa) que enferman al insecto;
+ *   · el BORDE "empuja-jala" (push-pull) — la orla de flores aromáticas
+ *     (caléndula) que repele y aloja enemigos naturales;
+ *   · los ENEMIGOS NATURALES — la mariquita que come pulgón, el carábido del
+ *     suelo, la mariposa y el colibrí que polinizan y suman vida.
+ *
+ * Todo `MeshLambert`/`Basic`, sin sombras (contrato de EscenaBase3D). Geometría
+ * de primitivas: cero GLTF, offline y liviano.
+ */
+import { useMemo } from 'react';
+import EscenaBase3D from './EscenaBase3D.jsx';
+import { Fauna } from './FaunaEscena.jsx';
+
+/* La fauna BENÉFICA que acompaña la huerta-clínica: la mariposa polinizadora en
+   la orla de flores, el colibrí que sobrevuela, y el escarabajo (carábido)
+   depredador que anda a ras cazando larvas en el suelo. Pocas y por criterio
+   ecológico (contrato del DR: vida, no enjambre). */
+const FAUNA_SANIDAD = [
+  { tipo: 'mariposa', base: [1.05, 0.66, 0.78], patron: 'revoloteo', size: 28, fase: 0.4 },
+  { tipo: 'colibri', base: [-0.85, 1.12, 0.42], patron: 'revoloteo', size: 30, fase: 1.6 },
+  { tipo: 'escarabajo', base: [0.28, 0.16, -0.52], patron: 'reptar', size: 28, fase: 2.4 },
+];
+
+/* Una MARIQUITA low-poly (Coccinellidae) — el enemigo natural insignia: una sola
+   larva o adulto come cientos de pulgones. Media esfera roja + cabeza + puntos. */
+function Mariquita({ pos, escala = 1 }) {
+  const puntos = [
+    [0.035, -0.02], [-0.035, -0.02], [0.03, 0.035], [-0.03, 0.035],
+  ];
+  return (
+    <group position={pos} scale={escala}>
+      {/* élitros: media esfera roja */}
+      <mesh position={[0, 0.06, 0]}>
+        <sphereGeometry args={[0.09, 12, 8, 0, Math.PI * 2, 0, Math.PI / 2]} />
+        <meshLambertMaterial color="#c0392b" flatShading />
+      </mesh>
+      {/* la línea que parte los élitros */}
+      <mesh position={[0, 0.066, 0]}>
+        <boxGeometry args={[0.006, 0.02, 0.17]} />
+        <meshLambertMaterial color="#241812" />
+      </mesh>
+      {/* cabeza */}
+      <mesh position={[0, 0.05, 0.088]}>
+        <sphereGeometry args={[0.038, 8, 8]} />
+        <meshLambertMaterial color="#241812" flatShading />
+      </mesh>
+      {/* puntos negros */}
+      {puntos.map(([x, z], i) => (
+        <mesh key={i} position={[x, 0.108, z]}>
+          <sphereGeometry args={[0.013, 6, 6]} />
+          <meshLambertMaterial color="#241812" />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Una TRAMPA CROMÁTICA: estaca + tarjeta pegajosa de color. El color no es
+   decorativo — decide a qué insecto llama (amarillo: mosca blanca/minador;
+   azul: trips). */
+function Trampa({ pos, color = '#f2c531' }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.34, 0]}>
+        <cylinderGeometry args={[0.02, 0.026, 0.68, 5]} />
+        <meshLambertMaterial color="#7a5a38" flatShading />
+      </mesh>
+      <mesh position={[0, 0.62, 0]}>
+        <boxGeometry args={[0.22, 0.28, 0.02]} />
+        <meshLambertMaterial color={color} />
+      </mesh>
+    </group>
+  );
+}
+
+/* Una MATA sana: tallo + hojas redondeadas. El verde firme cuenta salud. */
+function Mata({ pos, color = '#4e8f3f' }) {
+  const hojas = [
+    [0, 0.44, 0, 0.17], [0.13, 0.35, 0.05, 0.12], [-0.12, 0.37, -0.05, 0.12],
+  ];
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.2, 0]}>
+        <cylinderGeometry args={[0.03, 0.05, 0.42, 5]} />
+        <meshLambertMaterial color="#5a6a2e" flatShading />
+      </mesh>
+      {hojas.map(([x, y, z, r], i) => (
+        <mesh key={i} position={[x, y, z]}>
+          <sphereGeometry args={[r, 8, 7]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* La ESTACIÓN DE BIOCONTROL: poste + recipiente con el polvo de esporas de los
+   hongos entomopatógenos (Beauveria/Metarhizium) que enferman al insecto. */
+function EstacionBio({ pos }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.22, 0]}>
+        <cylinderGeometry args={[0.04, 0.05, 0.44, 6]} />
+        <meshLambertMaterial color="#8a6a44" flatShading />
+      </mesh>
+      {/* el recipiente */}
+      <mesh position={[0, 0.49, 0]}>
+        <cylinderGeometry args={[0.13, 0.1, 0.13, 10]} />
+        <meshLambertMaterial color="#e8e4d0" flatShading />
+      </mesh>
+      {/* el polvo de esporas (verdoso Metarhizium / claro Beauveria) */}
+      <mesh position={[0, 0.56, 0]}>
+        <sphereGeometry args={[0.1, 10, 6, 0, Math.PI * 2, 0, Math.PI / 2]} />
+        <meshLambertMaterial color="#b9c88a" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* Una FLOR del borde push-pull (caléndula/aromática): repele plagas y aloja
+   enemigos naturales. Tallo + botón anaranjado. */
+function FlorBorde({ pos }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.12, 0]}>
+        <cylinderGeometry args={[0.015, 0.02, 0.24, 5]} />
+        <meshLambertMaterial color="#4e7d3f" flatShading />
+      </mesh>
+      <mesh position={[0, 0.26, 0]}>
+        <sphereGeometry args={[0.06, 8, 6]} />
+        <meshLambertMaterial color="#e8963f" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+function Diorama({ params, reducedMotion }) {
+  const matas = params?.matas || [
+    { color: '#4e8f3f', pos: [-0.5, 0, 0.35] },
+    { color: '#57993f', pos: [0.55, 0, 0.1] },
+    { color: '#468637', pos: [0.05, 0, -0.55] },
+  ];
+  const trampas = params?.trampas || [
+    { color: '#f2c531', pos: [1.35, 0, 0.35] }, // amarilla: mosca blanca / minador
+    { color: '#3f77c7', pos: [-1.25, 0, -0.5] }, // azul: trips
+  ];
+
+  // La cerca: postes en anillo (reconocible como "recinto"), en tono madera.
+  const postes = useMemo(() => {
+    const n = 12;
+    return Array.from({ length: n }, (_, i) => {
+      const a = (i / n) * Math.PI * 2;
+      return /** @type {[number, number, number]} */ ([Math.cos(a) * 1.9, 0.2, Math.sin(a) * 1.9]);
+    });
+  }, []);
+
+  // El borde "empuja-jala": orla de flores aromáticas repartida en el anillo.
+  const flores = useMemo(() => {
+    const n = 8;
+    return Array.from({ length: n }, (_, i) => {
+      const a = (i / n) * Math.PI * 2 + 0.26;
+      return /** @type {[number, number, number]} */ ([Math.cos(a) * 1.62, 0, Math.sin(a) * 1.62]);
+    });
+  }, []);
+
+  return (
+    <group>
+      {/* piso de la huerta-clínica */}
+      <mesh position={[0, -0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[2, 28]} />
+        <meshLambertMaterial color="#7f8a4e" />
+      </mesh>
+      {/* cama de siembra al centro (lomo de tierra) */}
+      <mesh position={[0, 0.06, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[0.95, 24]} />
+        <meshLambertMaterial color="#6b5636" />
+      </mesh>
+      {/* la cerca */}
+      {postes.map((p, i) => (
+        <mesh key={i} position={p}>
+          <cylinderGeometry args={[0.05, 0.06, 0.5, 5]} />
+          <meshLambertMaterial color="#8a6a44" flatShading />
+        </mesh>
+      ))}
+      {/* el anillo verde del manejo: el borde vivo que rodea y defiende */}
+      <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[1.55, 0.045, 8, 44]} />
+        <meshBasicMaterial color="#7a9a3f" transparent opacity={0.7} />
+      </mesh>
+
+      {/* las matas sanas que se protegen */}
+      {matas.map((m, i) => (
+        <Mata key={i} pos={m.pos} color={m.color} />
+      ))}
+      {/* las trampas cromáticas */}
+      {trampas.map((t, i) => (
+        <Trampa key={i} pos={t.pos} color={t.color} />
+      ))}
+      {/* la estación de biocontrol (hongos entomopatógenos) */}
+      <EstacionBio pos={[1.05, 0, -0.75]} />
+      {/* el borde push-pull de flores aromáticas */}
+      {flores.map((p, i) => (
+        <FlorBorde key={i} pos={p} />
+      ))}
+
+      {/* los enemigos naturales insignia: dos mariquitas sobre las matas */}
+      <Mariquita pos={[-0.42, 0.5, 0.42]} escala={1} />
+      <Mariquita pos={[0.6, 0.32, 0.12]} escala={0.85} />
+
+      {/* la fauna benéfica que anima la escena (mariposa/colibrí/carábido) */}
+      <Fauna items={FAUNA_SANIDAD} reducedMotion={reducedMotion} />
+    </group>
+  );
+}
+
+export default function EscenaSanidad(props) {
+  // Cielo fresco y sano de huerta (se mezcla igual hacia la hora dorada del valle).
+  const cielo = { fondo: '#dbe7c4', cielo: '#eef4dc', suelo: '#7e8a4a', intensidad: 1.05 };
+  return (
+    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.45, 0] }}>
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+    </EscenaBase3D>
+  );
+}

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -218,23 +218,50 @@ export const MUNDO = {
     entrada: {},
   },
 
-  // 🐞 SANIDAD — arquetipo `infografia`: diagnóstico por síntoma/foto (NO-3D).
+  // 🐞 SANIDAD — arquetipo SÍ-3D `sanidad`: la HUERTA-CLÍNICA, el manejo de
+  //    plagas SIN veneno hecho lugar. El recinto muestra lo que de verdad cuida
+  //    la mata en finca andina: las TRAMPAS CROMÁTICAS (amarilla → mosca blanca/
+  //    minador, azul → trips), la ESTACIÓN DE BIOCONTROL (Beauveria/Metarhizium),
+  //    el BORDE push-pull de flores aromáticas y los ENEMIGOS NATURALES
+  //    (mariquita, carábido). Cada punto es una puerta a una pantalla REAL. En
+  //    equipo humilde cae a su ficha 2D digna (la infografía de la sanidad).
   sanidad: {
-    escena: 'infografia',
-    valle: { tipo: 'huerta', pos: [1.8, 0, 4.4], escala: 0.95 },
+    escena: 'sanidad',
+    valle: { tipo: 'huerta', pos: [3.8, 0, 4.9], escala: 0.95 },
     params: {
-      titulo: 'Sanidad de la mata',
-      notas: [
-        'Diga qué le ve ("gota", "polvillo", "amarilla") y sepa qué es y cómo manejarla sin veneno.',
-        'Reconozca el bicho por foto: a qué le pega, cómo se ve y su manejo.',
+      // El diorama tiene defaults propios; aquí solo los hacemos explícitos y
+      // deterministas (mismas matas y trampas 2D↔3D).
+      matas: [
+        { color: '#4e8f3f', pos: [-0.5, 0, 0.35] },
+        { color: '#57993f', pos: [0.55, 0, 0.1] },
+        { color: '#468637', pos: [0.05, 0, -0.55] },
+      ],
+      trampas: [
+        { color: '#f2c531', pos: [1.35, 0, 0.35] }, // amarilla: mosca blanca / minador
+        { color: '#3f77c7', pos: [-1.25, 0, -0.5] }, // azul: trips
       ],
     },
     hotspots: [
-      { id: 'sintoma', pos: [], emoji: '🩺', label: 'Mi mata está enferma', view: 'sanidad_sintoma' },
-      { id: 'plagas', pos: [], emoji: '🐛', label: 'Directorio de plagas', view: 'plagas' },
-      { id: 'bio', pos: [], emoji: '🧪', label: 'Biopreparados', view: 'biopreparados' },
+      { id: 'sintoma', pos: [0, 0.7, 0.5], emoji: '🩺', label: 'Mi mata está enferma', view: 'sanidad_sintoma' },
+      { id: 'plagas', pos: [1.35, 0.92, 0.35], emoji: '🐛', label: 'Directorio de plagas', view: 'plagas' },
+      { id: 'defensores', pos: [-0.55, 0.78, 0.5], emoji: '🐞', label: 'Defensores de la finca', view: 'defensores' },
+      { id: 'bio', pos: [1.05, 0.78, -0.75], emoji: '🧪', label: 'Biopreparados', view: 'biopreparados' },
+      { id: 'tox', pos: [-1.25, 0.92, -0.5], emoji: '⚠️', label: 'Seguridad con insumos', view: 'toxicologia' },
     ],
-    entrada: {},
+    entrada: { zoom: 7, narra: 'sanidad' },
+    // El gemelo 2D digno: la ficha de la sanidad (misma copia didáctica de
+    // antes, con sus MISMOS hotspots como accesos).
+    fallback2d: {
+      escena: 'infografia',
+      params: {
+        titulo: 'Sanidad de la mata',
+        notas: [
+          'Diga qué le ve ("gota", "polvillo", "amarilla") y sepa qué es y cómo manejarla sin veneno.',
+          'Reconozca el bicho por foto: a qué le pega, cómo se ve y su manejo.',
+          'Cuide sus aliados: trampas de color, hongos de biocontrol y enemigos naturales como la mariquita.',
+        ],
+      },
+    },
   },
 
   // ── SÍ-3D nuevo: la ÚNICA metáfora de escena nueva del batch ─────────────


### PR DESCRIPTION
## Mundo Sanidad 3D — la huerta-clínica

Sube el mundo **Sanidad** de infografía 2D a diorama **SÍ-3D** con un arquetipo
nuevo `sanidad` (familia `recinto`: un lugar cercado que se camina), siguiendo
el precedente reciente de `boveda` (clima).

### Qué contiene el mundo
El espacio mismo enseña el **manejo agroecológico de plagas** de la finca andina
—control biológico + trampas + push-pull, **sin recetas químicas de dosis**:

- 🍅 **Matas sanas** al centro (lo que se protege).
- 🎯 **Trampas cromáticas** en estacas: la amarilla llama a la mosca blanca/
  minador; la azul, a los trips (monitoreo + captura, sin veneno).
- 🧫 **Estación de biocontrol** con hongos entomopatógenos (Beauveria bassiana
  clara / Metarhizium verdosa) que enferman al insecto.
- 🌼 **Borde push-pull** de flores aromáticas (caléndula): empuja la plaga y
  jala a sus enemigos naturales.
- 🐞 **Enemigos naturales**: mariquita (come pulgón), carábido del suelo,
  mariposa/colibrí que polinizan (reusa `FaunaEscena`).

Cada hotspot es puerta a una pantalla **real**: `sanidad_sintoma`, `plagas`,
`defensores`, `biopreparados`, `toxicologia`. En equipo humilde cae a su **ficha
2D digna** (la infografía de la sanidad, con su copia didáctica de siempre).

### Cambios
- `escenas/EscenaSanidad.jsx` — diorama low-poly (primitivas, `MeshLambert`/
  `Basic`, sin sombras; contrato de `EscenaBase3D`).
- Registro en `Mundo.jsx` (`IMPORTA_ESCENA`) y `arquetipos.js` (dim `3d`).
- `mundoData.js`: `sanidad.escena` `'infografia'` → `'sanidad'` + `fallback2d`
  infografía; hotspots con posiciones 3D; `valle` alineado con `valleData`.
- Vitrina pública `#/mockups/mundo3d-sanidad` (`Mundo3DSanidad.jsx` + `.css`),
  device-tiering real, calcada de `Mundo3DSuelo`.
- Ruta y `case` añadidos **al FINAL** de sus bloques en `App.jsx`
  (**anti-conflicto de merge**: no se reordena ni se tocan líneas ajenas).
- `mundo.smoke.test.jsx`: `ARQUETIPOS_3D` ahora incluye `'sanidad'`.

El landmark `sanidad` del valle (ya presente en `valleData.js`) ahora abre el
diorama 3D en vez de la infografía.

### Verificación
- `npm run build` ✅ (verde, 1m 2s). Sin tsc-gate ni eslint (según indicación).
- Artefactos de build (`public/chagra-stats.json`, `cycle-content/manifest.json`)
  revertidos: fuera del PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
