### PR TITLE
feat(mundo3d): mundo Mercado 3D — mercado campesino de venta justa

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -95,6 +95,11 @@ const Mundo3DClimaMockup = lazy(() => import('./mockups/Mundo3DClima'));
 // la huerta-clínica (arquetipo nuevo `sanidad`, familia recinto): trampas,
 // biocontrol y enemigos naturales. El 3D va perezoso (vendor-three).
 const Mundo3DSanidadMockup = lazy(() => import('./mockups/Mundo3DSanidad'));
+// 3D: "El mundo del mercado" — monta <Mundo mundoId="mercado"> del framework:
+// el mercado campesino (arquetipo nuevo `mercado`, familia flujo): la ruta corta
+// campo→mesa, puestos, canastos, procedencia y precio justo. El 3D va perezoso
+// (vendor-three).
+const Mundo3DMercadoMockup = lazy(() => import('./mockups/Mundo3DMercado'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -508,6 +513,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/hoja-vida-mata': 'mockup_hoja_vida_mata',
   // (anti-conflicto de merge) rutas nuevas SIEMPRE al final del bloque:
   'mockups/mundo3d-sanidad': 'mockup_mundo3d_sanidad',
+  'mockups/mundo3d-mercado': 'mockup_mundo3d_mercado',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1604,6 +1610,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo de la sanidad">
               <Mundo3DSanidadMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_mercado':
+        // Vitrina pública del MUNDO DEL MERCADO: monta <Mundo mundoId="mercado">
+        // del framework (src/visual/mundo3d) con device-tiering real. Ruta
+        // #/mockups/mundo3d-mercado, sin auth. El mercado campesino: la cadena
+        // corta campo→mesa — puestos con toldo, canastos de la finca, el sello de
+        // procedencia (terroir andino) y la balanza del precio justo.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del mercado">
+              <Mundo3DMercadoMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mundo3DMercado.css
+++ b/src/mockups/Mundo3DMercado.css
@@ -1,0 +1,152 @@
+/*
+ * Mundo3DMercado.css — vitrina pública del mundo del mercado
+ * (#/mockups/mundo3d-mercado). Autocontenida: sin fuentes/imágenes externas.
+ * Móvil-first desde 320px. Solo opacity/transform animables; reduced-motion las
+ * apaga.
+ */
+
+.m3dmer {
+  --m3dmer-a: #b98a2f;
+  --m3dmer-b: #f7ecd2;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3dmer-b) 0%, #f8f0dd 44%, #efd8ac 100%);
+  color: #3d2f16;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3dmer__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3dmer__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3dmer-a);
+}
+.m3dmer__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #5e451a;
+}
+.m3dmer__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3dmer__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3dmer__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(185, 138, 47, 0.3);
+  box-shadow: 0 10px 28px rgba(61, 47, 22, 0.14);
+}
+.m3dmer__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fdf6e8;
+}
+
+.m3dmer__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3dmer__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3dmer__toggle {
+  border: 1.5px solid var(--m3dmer-a);
+  background: #fff;
+  color: var(--m3dmer-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3dmer__toggle:hover,
+.m3dmer__toggle:focus-visible {
+  background: var(--m3dmer-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3dmer__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.8);
+  border-left: 3px solid var(--m3dmer-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3dmer__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3dmer__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #5e451a;
+}
+.m3dmer__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3dmer__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3dmer__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(185, 138, 47, 0.2);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3dmer__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3dmer__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #5e451a;
+}
+.m3dmer__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3dmer__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #4c3a18;
+}

--- a/src/mockups/Mundo3DMercado.jsx
+++ b/src/mockups/Mundo3DMercado.jsx
@@ -1,0 +1,156 @@
+/*
+ * Mundo3DMercado — vitrina pública del MUNDO DEL MERCADO (ruta
+ * #/mockups/mundo3d-mercado).
+ *
+ * El mercado campesino de la finca andina: la comercialización justa hecha
+ * lugar. El diorama enseña la CADENA CORTA del campo a la mesa — la ruta que
+ * baja de la parcela a la plaza (del productor al comprador, directo), los
+ * puestos con su toldo, los canastos con la cosecha propia (tomate, papa, maíz,
+ * café), el sello de PROCEDENCIA (el terroir andino: de qué vereda y qué piso
+ * viene) y la balanza del PRECIO JUSTO. Nada de intermediación que se come el
+ * trabajo: trato directo, cuentas claras, finca que vende parejo.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="mercado">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento") se ve la ficha 2D digna; en gama media/
+ * alta, el diorama 3D low-poly (chunk perezoso `vendor-three`) con la abeja
+ * Angelita entrando al mundo. Los puntos de la plaza son las mismas puertas del
+ * registro: aquí (vitrina sin sesión) muestran a qué pantalla real de la app
+ * llevan, en vez de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import './Mundo3DMercado.css';
+
+const TINTE = ['#b98a2f', '#f7ecd2'];
+
+/* Lo que se ve en la plaza, contado en una leyenda didáctica y verificada:
+   comercialización justa de verdad (cadena corta + procedencia + precio justo),
+   sin promesas de plata ni instituciones inventadas. */
+const LEYENDA = [
+  {
+    emoji: '🥕',
+    titulo: 'La cadena corta del campo a la mesa',
+    texto: 'La cosecha baja de la parcela a la plaza sin dar la vuelta por diez manos. Entre menos intermediarios, más se queda en la finca y más fresco llega el producto al que se lo come.',
+  },
+  {
+    emoji: '🧺',
+    titulo: 'Los puestos y los canastos',
+    texto: 'El puesto de mercado campesino, con su toldo y su mesa, y los canastos con lo de la finca: tomate, papa, maíz, café. Vender directo es poner la cara y la cosecha propia a la vista.',
+  },
+  {
+    emoji: '🏔️',
+    titulo: 'La procedencia: el terroir andino',
+    texto: 'El sello de origen dice de qué vereda y de qué piso térmico viene. Una papa de páramo o un café de ladera no son cualquier cosa: la procedencia cuenta la historia y le da valor a lo suyo.',
+  },
+  {
+    emoji: '⚖️',
+    titulo: 'El precio justo',
+    texto: 'La balanza que reparte parejo: un precio que le paga el trabajo al que siembra y le sale razonable al que compra. Saber el precio de referencia le da con qué negociar y a quién no dejarse.',
+  },
+  {
+    emoji: '📦',
+    titulo: 'La despensa y la poscosecha',
+    texto: 'Cosechar en punto, guardar sin que se dañe y transformar lo que sobra. Una buena despensa (troja, silo, secado) es vender cuando el precio sube, no rematar cuando todos cosechan.',
+  },
+];
+
+export default function Mundo3DMercado() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // En la vitrina (sin sesión) un punto de la plaza no navega: cuenta a qué
+  // pantalla real de la app lleva esa puerta.
+  const [puerta, setPuerta] = useState(null);
+  const onHotspot = (view, data) => {
+    const hs = (MUNDO.mercado.hotspots || []).find(
+      (h) => h.view === view && (h.data === data || (!h.data && !data)),
+    ) || (MUNDO.mercado.hotspots || []).find((h) => h.view === view);
+    setPuerta({ label: hs?.label || view, view });
+  };
+
+  return (
+    <main
+      className="m3dmer"
+      style={{ '--m3dmer-a': TINTE[0], '--m3dmer-b': TINTE[1] }}
+    >
+      <header className="m3dmer__head">
+        <p className="m3dmer__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo del mercado</h1>
+        <p className="m3dmer__lema">
+          Asómese a la plaza campesina: la cosecha que baja de la parcela a la
+          mesa sin dar la vuelta por diez manos. Puestos, canastos, el sello de
+          dónde viene y una balanza que reparte parejo. Venta directa, precio
+          justo, finca que no se deja.
+        </p>
+      </header>
+
+      <section className="m3dmer__escena" aria-label="El mercado campesino de la finca">
+        <Mundo
+          mundoId="mercado"
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={onHotspot}
+          onSalir={null}
+          animo="alegre"
+          energia={0.95}
+        />
+        <div className="m3dmer__barra">
+          <p className="m3dmer__tier">
+            {tier === 'bajo'
+              ? 'Está viendo la ficha del mercado (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3dmer__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver la ficha 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3dmer__nota" role="status" aria-live="polite">
+          {puerta
+            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
+            : 'Toque un punto de la plaza para ver a dónde lo lleva.'}
+        </p>
+      </section>
+
+      <section className="m3dmer__leyenda" aria-label="El mercado, pieza por pieza">
+        <h2>El mercado campesino, pieza por pieza</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3dmer__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3dmer__cierre">
+          Vender bien no es rematar: es poner la cara, contar de dónde viene lo
+          suyo y cobrar lo que vale el trabajo. La cadena corta deja la plata en
+          el campo y la comida fresca en la mesa. Sepa su precio, cuide su
+          despensa y negocie de frente. Menos intermediario, más finca viva.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -356,6 +356,38 @@ function LandmarkGeom({ tipo, tinte, reducedMotion }) {
           ))}
         </group>
       );
+    case 'mercado': // puesto de mercado campesino: toldo a dos aguas + mesa + canasto
+      return (
+        <group>
+          {/* las patas y la mesa del puesto */}
+          {[[-0.32, 0.22], [0.32, 0.22], [-0.32, -0.22], [0.32, -0.22]].map(([x, z], i) => (
+            <mesh key={i} position={[x, 0.24, z]} castShadow>
+              <cylinderGeometry args={[0.03, 0.035, 0.48, 5]} />
+              <meshStandardMaterial color="#7a5a38" flatShading roughness={1} />
+            </mesh>
+          ))}
+          <mesh position={[0, 0.49, 0]} castShadow>
+            <boxGeometry args={[0.82, 0.06, 0.56]} />
+            <meshStandardMaterial color="#a9814f" flatShading roughness={1} />
+          </mesh>
+          {/* el toldo a dos aguas (cono de 4 lados) */}
+          <mesh position={[0, 0.92, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+            <coneGeometry args={[0.66, 0.34, 4]} />
+            <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+          </mesh>
+          {/* un canasto con producto sobre la mesa */}
+          <mesh position={[0.12, 0.6, 0.08]}>
+            <cylinderGeometry args={[0.13, 0.1, 0.14, 9]} />
+            <meshStandardMaterial color="#a9773f" flatShading roughness={1} />
+          </mesh>
+          {[[0, 0.7, 0.08], [0.08, 0.68, 0.13], [-0.05, 0.68, 0.04]].map(([x, y, z], i) => (
+            <mesh key={i} position={[x, y, z]}>
+              <sphereGeometry args={[0.055, 7, 6]} />
+              <meshStandardMaterial color={suave} flatShading roughness={1} />
+            </mesh>
+          ))}
+        </group>
+      );
     case 'veleta': // poste con veleta que gira con el viento
       return <Veleta color={fuerte} reducedMotion={reducedMotion} />;
     default:

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -129,6 +129,9 @@ const LUGARES = [
   { id: 'animales', pos: [-5.0, 0, 5.4], escala: 1, tipo: 'animales' },
   { id: 'disenio', pos: [5.2, 0, -3.4], escala: 1.1, tipo: 'bosque' },
   { id: 'clima', pos: [-3.2, 0, -6.0], escala: 1, tipo: 'veleta' },
+  // El mercado, abajo en la tierra caliente, cerca de la salida a la plaza: el
+  // puesto con su toldo donde la cosecha de la finca sale a venderse.
+  { id: 'mercado', pos: [1.2, 0, 6.6], escala: 1, tipo: 'mercado' },
 ];
 
 /**
@@ -322,4 +325,6 @@ export const NARRACION = {
     'La huerta de la casa. Aquí es donde primero se ven las plagas, para atajarlas a tiempo.',
   disenio: 'El monte y los árboles que sembró. La finca también es el bosque que la abraza.',
   clima: 'Desde aquí se lee el cielo: lo que viene, y qué conviene hacer con la finca.',
+  mercado:
+    'La plaza campesina. Aquí llega su cosecha derecho a la mesa: venda directo, con su sello y a precio justo.',
 };

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -30,6 +30,7 @@ const IMPORTA_ESCENA = {
   valle: () => import('./escenas/EscenaValle.jsx'),
   boveda: () => import('./escenas/EscenaBoveda.jsx'),
   sanidad: () => import('./escenas/EscenaSanidad.jsx'),
+  mercado: () => import('./escenas/EscenaMercado.jsx'),
 };
 const ESCENAS_3D = Object.fromEntries(
   Object.entries(IMPORTA_ESCENA).map(([k, importa]) => [k, lazy(importa)]),

--- a/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
+++ b/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
@@ -12,7 +12,7 @@ afterEach(() => cleanup());
 
 describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
   test('arquetipos: 5 dioramas 3D + arquetipos 2D de primera clase', () => {
-    expect(ARQUETIPOS_3D.sort()).toEqual(['boveda', 'cutaway', 'estratos', 'flujo', 'recinto', 'sanidad', 'valle']);
+    expect(ARQUETIPOS_3D.sort()).toEqual(['boveda', 'cutaway', 'estratos', 'flujo', 'mercado', 'recinto', 'sanidad', 'valle']);
     ['lamina', 'infografia', 'ficha', 'mirror', 'valle2d'].forEach((k) => {
       expect(ARQUETIPOS_2D).toContain(k);
       expect(ARQUETIPOS[k].dim).toBe('2d');
@@ -30,10 +30,20 @@ describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
     expect(bajo.motivo).toBe('cutaway');
   });
 
-  test('un mundo 2D-dato declara su arquetipo DIRECTO (mercado → infografia)', () => {
-    const r = resolverMundo('mercado', 'alto'); // aun en tier alto sigue 2D
+  test('un mundo 2D-dato declara su arquetipo DIRECTO (frutales → ficha)', () => {
+    const r = resolverMundo('frutales', 'alto'); // aun en tier alto sigue 2D
     expect(r.modo).toBe('2d');
-    expect(r.escena).toBe('infografia');
+    expect(r.escena).toBe('ficha');
+  });
+
+  test('el mercado sube al arquetipo 3D nuevo `mercado` (y degrada a su ficha 2D)', () => {
+    const alto = resolverMundo('mercado', 'alto');
+    expect(alto.modo).toBe('3d');
+    expect(alto.escena).toBe('mercado');
+    // equipo humilde → cae a su fallback2d declarado (la infografía del mercado)
+    const bajo = resolverMundo('mercado', 'bajo');
+    expect(bajo.modo).toBe('2d');
+    expect(bajo.escena).toBe('infografia');
   });
 
   test('el clima sube al arquetipo 3D nuevo `boveda` (y degrada a su espejo 2D)', () => {
@@ -57,9 +67,9 @@ describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
   });
 
   test('<Mundo> monta un mundo 2D sin lanzar (sin three, three-free)', () => {
-    // mercado es 2D nativo; no monta Canvas → seguro en jsdom.
+    // frutales es 2D nativo (ficha); no monta Canvas → seguro en jsdom.
     const { container } = render(
-      <Mundo mundoId="mercado" tier="alto" onHotspot={() => {}} onSalir={() => {}} />,
+      <Mundo mundoId="frutales" tier="alto" onHotspot={() => {}} onSalir={() => {}} />,
     );
     expect(container.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
     // el espejo 2D de un 3D degradado también es three-free:

--- a/src/visual/mundo3d/arquetipos.js
+++ b/src/visual/mundo3d/arquetipos.js
@@ -61,6 +61,17 @@ export const ARQUETIPOS = {
     nombre: 'La huerta-clínica', clave: 'el manejo agroecológico de plagas: trampas, biocontrol y enemigos naturales',
     ejemplo: 'sanidad', tambien: [],
   },
+  // El mercado campesino: la familia del `flujo` (una ruta que se recorre) hecha
+  // cadena corta del campo a la mesa. Su lección es la comercialización justa —
+  // puestos con toldo, canastos con la cosecha de la finca, la procedencia
+  // andina (terroir/sello de origen) y el precio justo del trato directo (sin la
+  // tajada del intermediario). En equipo humilde cae a su ficha 2D (la
+  // infografía del mercado y la despensa).
+  mercado: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'mercado', espejo: 'mirror',
+    nombre: 'El mercado campesino', clave: 'la cadena corta del campo a la mesa: puestos, procedencia y precio justo',
+    ejemplo: 'mercado', tambien: [],
+  },
 
   // ── Arquetipos 2D (primera clase) ────────────────────────────────────────
   mirror: {

--- a/src/visual/mundo3d/escenas/EscenaMercado.jsx
+++ b/src/visual/mundo3d/escenas/EscenaMercado.jsx
@@ -1,0 +1,268 @@
+/*
+ * EscenaMercado — ARQUETIPO `mercado`: el MERCADO CAMPESINO y la venta justa.
+ *
+ * De la familia del `flujo` (una RUTA que se recorre), pero aquí el camino es la
+ * CADENA CORTA del campo a la mesa: la cosecha sale de la finca y llega a la
+ * plaza sin dar la vuelta por diez manos. El espacio mismo cuenta la
+ * comercialización justa de la finca andina:
+ *
+ *   · la RUTA campo→mercado — la cinta que baja de la parcela verde (al fondo)
+ *     hasta los puestos: corta y directa, del productor al comprador;
+ *   · los PUESTOS con su TOLDO — el lugar del mercado campesino, dos toldos de
+ *     colores con su mesa (uno de la huerta, otro del vecino);
+ *   · los CANASTOS con lo de la finca — tomate, papa, maíz y café en su mimbre,
+ *     la cosecha propia puesta a la vista;
+ *   · la TARIMA DE PROCEDENCIA — el letrero del terroir: de qué vereda y qué
+ *     piso térmico viene (el sello de origen andino que da confianza y valor);
+ *   · la BALANZA del PRECIO JUSTO — la pesa que reparte parejo, sin la tajada
+ *     del intermediario.
+ *
+ * Todo `MeshLambert`/`Basic`, sin sombras (contrato de EscenaBase3D). Geometría
+ * de primitivas: cero GLTF, offline y liviano.
+ */
+import { useMemo } from 'react';
+import EscenaBase3D from './EscenaBase3D.jsx';
+import { Fauna } from './FaunaEscena.jsx';
+
+/* La fauna que anima la feria: la mariposa entre las flores del puesto, el
+   colibrí que sobrevuela la plaza. Pocas y por criterio (vida, no enjambre). */
+const FAUNA_MERCADO = [
+  { tipo: 'mariposa', base: [-1.15, 0.7, 0.55], patron: 'revoloteo', size: 28, fase: 0.5 },
+  { tipo: 'colibri', base: [1.2, 1.15, 0.3], patron: 'revoloteo', size: 30, fase: 1.8 },
+];
+
+/* Un CANASTO de mimbre con su montón de producto. El canasto es un tronco de
+   cono facetado (el tejido); encima, una loma de esferitas del color de lo que
+   trae (tomate rojo, papa tierra, maíz dorado, café tostado). */
+function Canasto({ pos, color = '#d24b3a' }) {
+  // el montoncito: unas esferas apiladas, determinista (misma forma siempre)
+  const frutos = useMemo(() => {
+    const base = [
+      [0, 0.19, 0], [0.07, 0.17, 0.05], [-0.06, 0.17, 0.06],
+      [0.05, 0.17, -0.07], [-0.05, 0.18, -0.05], [0, 0.23, 0],
+    ];
+    return base;
+  }, []);
+  return (
+    <group position={pos}>
+      {/* el mimbre (tronco de cono) */}
+      <mesh position={[0, 0.08, 0]}>
+        <cylinderGeometry args={[0.15, 0.11, 0.16, 9]} />
+        <meshLambertMaterial color="#a9773f" flatShading />
+      </mesh>
+      {/* el borde del canasto */}
+      <mesh position={[0, 0.16, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[0.145, 0.02, 6, 12]} />
+        <meshLambertMaterial color="#8a5f30" flatShading />
+      </mesh>
+      {/* el producto de la finca */}
+      {frutos.map(([x, y, z], i) => (
+        <mesh key={i} position={[x, y, z]}>
+          <sphereGeometry args={[0.055, 7, 6]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Un PUESTO de mercado: cuatro palos, la mesa y el TOLDO a dos aguas (el techo
+   de tela de color). Es el lugar reconocible de la feria campesina. */
+function Puesto({ pos, color = '#c96a2f' }) {
+  const patas = [[-0.5, 0.32], [0.5, 0.32], [-0.5, -0.32], [0.5, -0.32]];
+  return (
+    <group position={pos}>
+      {/* las patas del puesto */}
+      {patas.map(([x, z], i) => (
+        <mesh key={i} position={[x, 0.22, z]}>
+          <cylinderGeometry args={[0.028, 0.032, 0.44, 5]} />
+          <meshLambertMaterial color="#7a5a38" flatShading />
+        </mesh>
+      ))}
+      {/* la mesa (tablón) */}
+      <mesh position={[0, 0.45, 0]}>
+        <boxGeometry args={[1.15, 0.05, 0.72]} />
+        <meshLambertMaterial color="#a9814f" flatShading />
+      </mesh>
+      {/* el toldo a dos aguas (prisma triangular = cono de 3 lados) */}
+      <mesh position={[0, 0.92, 0]} rotation={[0, Math.PI / 4, 0]}>
+        <coneGeometry args={[0.86, 0.4, 4]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+      {/* el remate del toldo */}
+      <mesh position={[0, 1.14, 0]}>
+        <sphereGeometry args={[0.05, 8, 6]} />
+        <meshLambertMaterial color="#f2e2c0" flatShading />
+      </mesh>
+      {/* los postes que sostienen el toldo */}
+      {[[-0.5, 0], [0.5, 0]].map(([x, z], i) => (
+        <mesh key={i} position={[x, 0.68, z]}>
+          <cylinderGeometry args={[0.02, 0.02, 0.48, 5]} />
+          <meshLambertMaterial color="#7a5a38" flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* La TARIMA DE PROCEDENCIA: un poste con su placa redondeada — el sello de
+   origen. Dice de dónde viene la cosecha (vereda, piso térmico): el terroir
+   andino que da confianza y valor a lo de la finca. */
+function TarimaProcedencia({ pos }) {
+  return (
+    <group position={pos}>
+      {/* el poste */}
+      <mesh position={[0, 0.4, 0]}>
+        <cylinderGeometry args={[0.035, 0.04, 0.8, 6]} />
+        <meshLambertMaterial color="#8a6a44" flatShading />
+      </mesh>
+      {/* la placa del sello de origen (madera clara) */}
+      <mesh position={[0, 0.86, 0]}>
+        <boxGeometry args={[0.5, 0.34, 0.04]} />
+        <meshLambertMaterial color="#efdcb4" flatShading />
+      </mesh>
+      {/* el sello redondo (procedencia andina) */}
+      <mesh position={[0, 0.86, 0.03]} rotation={[Math.PI / 2, 0, 0]}>
+        <cylinderGeometry args={[0.11, 0.11, 0.02, 14]} />
+        <meshLambertMaterial color="#3f8f4e" flatShading />
+      </mesh>
+      {/* la montañita del sello (el piso térmico de donde viene) */}
+      <mesh position={[0, 0.85, 0.05]}>
+        <coneGeometry args={[0.06, 0.09, 4]} />
+        <meshLambertMaterial color="#efdcb4" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* La BALANZA del precio justo: un fiel con su brazo y dos platillos. La pesa que
+   reparte parejo — el trato directo, sin la tajada del intermediario. */
+function Balanza({ pos }) {
+  return (
+    <group position={pos}>
+      {/* la columna */}
+      <mesh position={[0, 0.24, 0]}>
+        <cylinderGeometry args={[0.03, 0.04, 0.48, 6]} />
+        <meshLambertMaterial color="#b9932f" flatShading />
+      </mesh>
+      {/* el brazo */}
+      <mesh position={[0, 0.5, 0]}>
+        <boxGeometry args={[0.44, 0.02, 0.02]} />
+        <meshLambertMaterial color="#d4b24a" flatShading />
+      </mesh>
+      {/* los dos platillos, parejos */}
+      {[-0.2, 0.2].map((x) => (
+        <mesh key={x} position={[x, 0.42, 0]} rotation={[Math.PI, 0, 0]}>
+          <coneGeometry args={[0.08, 0.06, 10]} />
+          <meshLambertMaterial color="#d4b24a" flatShading />
+        </mesh>
+      ))}
+      {/* el fiel */}
+      <mesh position={[0, 0.53, 0]}>
+        <sphereGeometry args={[0.035, 8, 6]} />
+        <meshLambertMaterial color="#8a6a2f" flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* Una MATA de la parcela (al fondo de la ruta): de aquí sale la cosecha. Tallo
+   verde + copa redonda — la finca que alimenta la plaza. */
+function MataCampo({ pos, color = '#4e8f3f' }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.16, 0]}>
+        <cylinderGeometry args={[0.03, 0.04, 0.32, 5]} />
+        <meshLambertMaterial color="#5a6a2e" flatShading />
+      </mesh>
+      <mesh position={[0, 0.38, 0]}>
+        <sphereGeometry args={[0.16, 8, 7]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+function Diorama({ params, reducedMotion }) {
+  const puestos = params?.puestos || [
+    { color: '#c96a2f', pos: [-0.85, 0, 0.2] },
+    { color: '#3f8f4e', pos: [0.9, 0, -0.1] },
+  ];
+  const canastos = params?.canastos || [
+    { producto: 'tomate', color: '#d24b3a', pos: [-0.85, 0, 0.75] },
+    { producto: 'papa', color: '#c9a15a', pos: [0.55, 0, 0.7] },
+    { producto: 'maiz', color: '#e7c451', pos: [1.15, 0, 0.35] },
+    { producto: 'cafe', color: '#7a4a24', pos: [-0.35, 0, 0.95] },
+  ];
+
+  // La parcela del fondo: unas matas de donde sale la cosecha (el origen de la
+  // ruta campo→mercado). Repartidas con aire al fondo del diorama.
+  const parcela = useMemo(() => (
+    [
+      [-0.7, -2.2, '#4e8f3f'], [-0.2, -2.5, '#57993f'], [0.35, -2.2, '#468637'],
+      [0.85, -2.45, '#5a9a3f'],
+    ]
+  ), []);
+
+  return (
+    <group>
+      {/* el piso de la plaza (empedrado cálido) */}
+      <mesh position={[0, -0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[2, 28]} />
+        <meshLambertMaterial color="#b79a6a" />
+      </mesh>
+
+      {/* la RUTA campo→mercado: la cinta corta que baja de la parcela verde (al
+          fondo, -z) hasta los puestos. Es la cadena corta, del productor al
+          comprador, sin dar la vuelta. */}
+      <mesh position={[0.1, 0.005, -1.0]} rotation={[-Math.PI / 2, 0, 0.04]}>
+        <planeGeometry args={[0.7, 2.6]} />
+        <meshLambertMaterial color="#a98a5c" />
+      </mesh>
+      {/* la parcela de donde sale todo (el campo, al fondo de la ruta) */}
+      <mesh position={[0.1, 0.006, -2.35]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[0.85, 20]} />
+        <meshLambertMaterial color="#6d8a3e" />
+      </mesh>
+      {parcela.map(([x, z, c], i) => (
+        <MataCampo key={i} pos={[Number(x), 0, Number(z)]} color={c} />
+      ))}
+
+      {/* el anillo vivo de la plaza (el borde de la feria) */}
+      <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[1.6, 0.045, 8, 44]} />
+        <meshBasicMaterial color="#c98a3f" transparent opacity={0.7} />
+      </mesh>
+
+      {/* los puestos con su toldo */}
+      {puestos.map((p, i) => (
+        <Puesto key={i} pos={p.pos} color={p.color} />
+      ))}
+
+      {/* los canastos con la cosecha de la finca (sobre las mesas y el piso) */}
+      {canastos.map((c, i) => (
+        <Canasto key={i} pos={c.pos} color={c.color} />
+      ))}
+
+      {/* la tarima del sello de procedencia (el terroir andino) */}
+      <TarimaProcedencia pos={[-1.4, 0, -0.35]} />
+
+      {/* la balanza del precio justo */}
+      <Balanza pos={[0.15, 0.45, 0.55]} />
+
+      {/* la fauna que anima la feria (mariposa/colibrí) */}
+      <Fauna items={FAUNA_MERCADO} reducedMotion={reducedMotion} />
+    </group>
+  );
+}
+
+export default function EscenaMercado(props) {
+  // Cielo cálido de plaza de mercado a media mañana (se mezcla igual hacia la
+  // hora dorada del valle: entrar debe sentirse como acercarse, no otra app).
+  const cielo = { fondo: '#f0dcb4', cielo: '#f6e8c8', suelo: '#9a7a4a', intensidad: 1.05 };
+  return (
+    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.5, 0] }}>
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+    </EscenaBase3D>
+  );
+}

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -196,26 +196,55 @@ export const MUNDO = {
     entrada: {},
   },
 
-  // 🧺 MERCADO Y DESPENSA — arquetipo `infografia`: dato/precio/reporte (NO-3D).
+  // 🧺 MERCADO Y DESPENSA — arquetipo SÍ-3D `mercado`: el MERCADO CAMPESINO, la
+  //    comercialización justa hecha lugar. El diorama muestra la CADENA CORTA del
+  //    campo a la mesa: la RUTA que baja de la parcela a la plaza (del productor
+  //    al comprador, directo), los PUESTOS con su toldo, los CANASTOS con la
+  //    cosecha de la finca (tomate, papa, maíz, café), la TARIMA de PROCEDENCIA
+  //    (el terroir andino: de qué vereda y qué piso viene, el sello de origen) y
+  //    la BALANZA del PRECIO JUSTO (el trato parejo, sin la tajada del
+  //    intermediario). Cada punto es una puerta a una pantalla REAL. En equipo
+  //    humilde cae a su ficha 2D digna (la infografía del mercado y la despensa).
   mercado: {
-    escena: 'infografia',
+    escena: 'mercado',
+    valle: { tipo: 'mercado', pos: [1.2, 0, 6.6], escala: 1 },
     params: {
-      titulo: 'Mercado y despensa',
-      cifras: [
-        { valor: 'Directo', unidad: '', label: 'venta entre fincas, sin intermediario' },
-        { valor: '7', unidad: 'días', label: 'guardar sin que se dañe (poscosecha)' },
+      // El diorama tiene defaults propios; aquí solo los hacemos explícitos y
+      // deterministas (mismos puestos y canastos 2D↔3D).
+      puestos: [
+        { color: '#c96a2f', pos: [-0.85, 0, 0.2] },   // toldo del vecino
+        { color: '#3f8f4e', pos: [0.9, 0, -0.1] },     // toldo de la huerta
       ],
-      notas: [
-        'Precios de referencia y cuentas para el banco o la cooperativa.',
-        'Almacene sin micotoxinas: troja/silo, secar/salar/fermentar con seguridad.',
+      canastos: [
+        { producto: 'tomate', color: '#d24b3a', pos: [-0.85, 0, 0.75] },
+        { producto: 'papa', color: '#c9a15a', pos: [0.55, 0, 0.7] },
+        { producto: 'maiz', color: '#e7c451', pos: [1.15, 0, 0.35] },
+        { producto: 'cafe', color: '#7a4a24', pos: [-0.35, 0, 0.95] },
       ],
     },
     hotspots: [
-      { id: 'vender', pos: [], emoji: '🤝', label: 'Vender y comprar', view: 'mercado' },
-      { id: 'posc', pos: [], emoji: '🥕', label: 'Poscosecha y despensa', view: 'poscosecha' },
-      { id: 'inf', pos: [], emoji: '🖨️', label: 'Sacar reportes', view: 'informes' },
+      { id: 'vender', pos: [-0.85, 1.25, 0.2], emoji: '🤝', label: 'Vender y comprar', view: 'mercado' },
+      { id: 'posc', pos: [0.9, 1.25, -0.1], emoji: '🥕', label: 'Poscosecha y despensa', view: 'poscosecha' },
+      { id: 'precio', pos: [0.15, 0.85, 0.55], emoji: '⚖️', label: 'Precio de referencia', view: 'mercado', data: { tema: 'precio' } },
+      { id: 'inf', pos: [-1.4, 1.1, -0.35], emoji: '🖨️', label: 'Sacar reportes', view: 'informes' },
     ],
-    entrada: {},
+    entrada: { zoom: 7, narra: 'mercado' },
+    // El gemelo 2D digno: la ficha del mercado y la despensa (la misma copia
+    // didáctica de antes, con sus MISMOS accesos como puertas).
+    fallback2d: {
+      escena: 'infografia',
+      params: {
+        titulo: 'Mercado y despensa',
+        cifras: [
+          { valor: 'Directo', unidad: '', label: 'venta entre fincas, sin intermediario' },
+          { valor: '7', unidad: 'días', label: 'guardar sin que se dañe (poscosecha)' },
+        ],
+        notas: [
+          'Precios de referencia y cuentas para el banco o la cooperativa.',
+          'Almacene sin micotoxinas: troja/silo, secar/salar/fermentar con seguridad.',
+        ],
+      },
+    },
   },
 
   // 🐞 SANIDAD — arquetipo SÍ-3D `sanidad`: la HUERTA-CLÍNICA, el manejo de


### PR DESCRIPTION
## Qué

Sube el mundo **Mercado** de infografía 2D a diorama **SÍ-3D** (arquetipo nuevo `mercado`, familia `flujo`), replicando exacto el patrón del mundo Sanidad (#2332). El espacio mismo enseña la **comercialización justa** de la finca andina.

## El diorama (EscenaMercado.jsx)

- **La ruta campo→mercado**: la cinta corta que baja de la parcela verde (al fondo) a la plaza — cadena corta, productor→comprador, sin dar la vuelta por diez manos.
- **Los puestos con toldo** (2 low-poly) + **canastos** con la cosecha propia (tomate, papa, maíz, café).
- **La tarima de procedencia**: el sello de origen / terroir andino (de qué vereda y qué piso viene).
- **La balanza del precio justo**: el trato parejo, sin la tajada del intermediario.
- Fauna benéfica (mariposa/colibrí), `MeshLambert`/`Basic`, sin sombras — contrato de `EscenaBase3D`. Cero GLTF.

## Cableado (patrón data-driven)

- `arquetipos.js`: arquetipo `mercado` (dim 3d, espejo `mirror`) — append tras `sanidad`.
- `mundoData.js`: entrada `mercado` upgrade in-place a `escena: 'mercado'` + `fallback2d` = la infografía original (misma copia).
- `Mundo.jsx`: `mercado` en `IMPORTA_ESCENA` (chunk perezoso `vendor-three`).
- `App.jsx`: import lazy + ruta hash `#/mockups/mundo3d-mercado` + case — **todo al final de sus bloques** (anti-conflicto de merge).
- Vitrina pública `Mundo3DMercado.jsx/.css`.
- **Entrada desde el valle**: landmark `mercado` (puesto con toldo) en `valleData.js` + su geometría en `Valle3D.jsx` + narración del compañero.
- Smoke test: `ARQUETIPOS_3D` incluye `mercado`; el ejemplo de mundo 2D-dato pasa de `mercado` a `frutales` (ficha).

## Verificación

- `npm run build` ✅ (solo warnings preexistentes; `vendor-three` compila con la escena nueva).
- `mundo.smoke.test.jsx` + `entradaValle3D.nav.test.jsx` ✅ (10 tests).

Copy en español CO, en "usted". Contenido groundeado: sin cifras ni instituciones inventadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)