### PR TITLE
feat(mundo3d): atmósfera madre — cohesión visual de los mundos 3D

### DIFF
--- a/src/visual/mundo3d/atmosferaMadre.js
+++ b/src/visual/mundo3d/atmosferaMadre.js
@@ -1,0 +1,89 @@
+/*
+ * atmosferaMadre — la DIRECCIÓN DE ARTE compartida de todos los mundos 3D.
+ *
+ * Antes cada escena inventaba su cielo con hexes sueltos y EscenaBase3D
+ * guardaba la hora dorada encerrada en una constante local: nueve mundos que
+ * se sentían de nueve juegos. Este módulo es la fuente única de esa atmósfera
+ * (la misma `CLIMAS.dorada` de valleData — el valle ES la hora madre) para que
+ * entrar a cualquier mundo se sienta como ACERCARSE dentro del mismo atardecer,
+ * no como abrir otra app.
+ *
+ * Tres piezas, tres responsabilidades:
+ *   - ATMOSFERA : la hora dorada (sol, relleno frío, niebla, sombra). La aplica
+ *                 EscenaBase3D; ningún arquetipo la toca.
+ *   - CIELOS    : el tinte propio de cada FAMILIA de mundo (agua fresca, plaza
+ *                 tibia, páramo brumoso…). Es el 40% de identidad que sobrevive
+ *                 a la mezcla del 60% hacia la madre en EscenaBase3D. Los que
+ *                 eran francamente fríos (agua, ladera, alba) vienen ya
+ *                 entibiados: identidad sí, choque no.
+ *   - PALETA    : los materiales low-poly canónicos (madera, tierra, follaje…)
+ *                 que se repiten entre dioramas. Un solo marrón de madera en
+ *                 todo el juego = el ojo lee "mismo lugar". Los grises fabriles
+ *                 puros no existen aquí a propósito: bajo un sol dorado hasta
+ *                 el concreto se tiñe (concreto/lamina son grises CÁLIDOS).
+ *
+ * Rendimiento: solo constantes y una mezcla de Color memoizable — nada de esto
+ * cuesta por frame ni rompe el device-tier (la base decide qué enciende).
+ */
+import * as THREE from 'three';
+
+/* La hora dorada del valle (CLIMAS.dorada de valleData): la atmósfera base que
+   TODOS los mundos heredan. El `cielo` propio del arquetipo solo la tiñe. */
+export const ATMOSFERA = {
+  fondo: '#f2d9a8', // fondo cálido de tarde
+  cielo: '#f7c66b', // domo dorado (hemisferio, arriba)
+  suelo: '#8a6b4a', // rebote tierra (hemisferio, abajo)
+  luz: '#ffd79a', // el sol bajo, dorado (direccional principal)
+  relleno: '#9db8d9', // relleno frío de cielo abierto (direccional opuesta, tenue)
+  niebla: '#f0c98d', // la niebla dorada del valle
+  sombra: '#3a2a18', // tinte de las sombras de contacto
+};
+
+/* Mezcla dos hex hacia `t` (0 = a, 1 = b). Barato; memoizar en quien llama. */
+export function mezclar(a, b, t) {
+  return `#${new THREE.Color(a).lerp(new THREE.Color(b), t).getHexString()}`;
+}
+
+/* El cielo propio de cada familia de mundo. EscenaBase3D lo MEZCLA 60% hacia
+   ATMOSFERA, así que estos valores son el acento, no el resultado final.
+   `alba` no trae `fondo`: la bóveda lo calcula por hora del día (veracidad). */
+export const CIELOS = {
+  /* la acuarela neutra heredada del valle (default si el arquetipo no elige) */
+  neutro: { fondo: '#ece0c7', cielo: '#f5e9d2', suelo: '#b49873', intensidad: 1 },
+  /* agua viva: fresco pero ya no azul-gris — salvia que dora bien */
+  agua: { fondo: '#dfe6d5', cielo: '#ecf2e0', suelo: '#7f9270', intensidad: 1.1 },
+  /* el perfil de suelo: tierra abierta, cálida de entrada */
+  tierra: { fondo: '#e7d7ba', cielo: '#f3e6cc', suelo: '#7a5a38', intensidad: 1.05 },
+  /* corral y cafetal: tarde de finca */
+  corral: { fondo: '#ecdcc2', cielo: '#f6ead2', suelo: '#8a6a44', intensidad: 1.05 },
+  /* plaza de mercado a media mañana */
+  plaza: { fondo: '#f0dcb4', cielo: '#f6e8c8', suelo: '#9a7a4a', intensidad: 1.05 },
+  /* huerta sana: verde fresco que la mezcla entibia sola */
+  huerta: { fondo: '#dbe7c4', cielo: '#eef4dc', suelo: '#7e8a4a', intensidad: 1.05 },
+  /* sotobosque de la milpa/bosque: verde hondo */
+  sotobosque: { fondo: '#d7e6c9', cielo: '#eaf2df', suelo: '#5f4a2e', intensidad: 1.1 },
+  /* la ladera del páramo: bruma sí, pero verde-plata, no celeste frío */
+  ladera: { fondo: '#d6e0d2', cielo: '#eaf0e2', suelo: '#6b5236', intensidad: 1.12 },
+  /* la bóveda del clima: hemisferio marfil tibio; el fondo lo pone la hora */
+  alba: { cielo: '#f2f0e0', suelo: '#757c54', intensidad: 1.05 },
+};
+
+/* Los materiales low-poly canónicos (para `MeshLambert` + flatShading). Sacados
+   de los tonos que los dioramas ya compartían de facto — esto los vuelve LEY.
+   Si un mundo nuevo necesita madera, es ESTA madera. */
+export const PALETA = {
+  madera: '#7a5a38', // tronco, poste, mango de herramienta
+  maderaClara: '#a98a5c', // tabla curada, mesón de mercado
+  maderaOscura: '#5a4326', // viga vieja, estaca húmeda
+  tierra: '#6b4a2e', // cama de siembra, tierra removida
+  tierraClara: '#8a6a44', // suelo seco, camino
+  follaje: '#5f8a3f', // el verde de trabajo (surco, mata)
+  follajeClaro: '#7a9a3f', // brote, pasto al sol
+  follajeOscuro: '#3f6f3a', // copa en sombra, monte
+  agua: '#3f8fb0', // el agua viva (acento; el único azul con permiso)
+  piedra: '#9a8b74', // tanque, roca de río (gris pardo)
+  concreto: '#a89a84', // bocatoma, obra civil — gris CÁLIDO, nunca neutro
+  lamina: '#8b8578', // barril, zinc, herraje — ídem
+  ambar: '#d9a13b', // señal, fruto seco, alerta amable (nunca rojo catástrofe)
+  cal: '#efe7d8', // pared encalada
+};

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -27,27 +27,10 @@ import * as THREE from 'three';
 import { AbejaEscena } from './useEntradaAbeja.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
 import useHaptics from '../useHaptics.js';
-
-/* Cielo cálido "acuarela" por defecto (la estética heredada del valle). El
-   arquetipo puede pasar su propio `cielo` para teñir su ambiente. */
-const CIELO_DEFAULT = { fondo: '#ece0c7', cielo: '#f5e9d2', suelo: '#b49873', intensidad: 1 };
-
-/* La hora dorada del valle (CLIMAS.dorada de valleData): la atmósfera base que
-   TODOS los mundos heredan. El `cielo` propio del arquetipo solo la tiñe. */
-const ATMOSFERA = {
-  fondo: '#f2d9a8', // fondo cálido de tarde
-  cielo: '#f7c66b', // domo dorado (hemisferio, arriba)
-  suelo: '#8a6b4a', // rebote tierra (hemisferio, abajo)
-  luz: '#ffd79a', // el sol bajo, dorado (direccional principal)
-  relleno: '#9db8d9', // relleno frío de cielo abierto (direccional opuesta, tenue)
-  niebla: '#f0c98d', // la niebla dorada del valle
-  sombra: '#3a2a18', // tinte de las sombras de contacto
-};
-
-/* Mezcla dos hex hacia `t` (0 = a, 1 = b). Barato y memoizado por quien llama. */
-function mezclar(a, b, t) {
-  return `#${new THREE.Color(a).lerp(new THREE.Color(b), t).getHexString()}`;
-}
+/* La dirección de arte compartida (hora dorada + cielos por familia) vive en
+   un módulo propio: los arquetipos eligen su CIELOS.<familia>, esta base la
+   mezcla hacia ATMOSFERA. Una sola fuente, cero hexes sueltos. */
+import { ATMOSFERA, CIELOS, mezclar } from '../atmosferaMadre.js';
 
 function Contenido({
   params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
@@ -67,7 +50,7 @@ function Contenido({
   // del valle (B6 — hoy entrar a un mundo "aplana" porque cada escena fija un
   // cielo frío propio). Memoizado: THREE.Color solo cuando cambia el cielo.
   const c = useMemo(() => {
-    const propio = cielo || CIELO_DEFAULT;
+    const propio = { ...CIELOS.neutro, ...(cielo || {}) };
     return {
       fondo: mezclar(propio.fondo, ATMOSFERA.fondo, 0.6),
       cielo: mezclar(propio.cielo, ATMOSFERA.cielo, 0.6),
@@ -82,8 +65,8 @@ function Contenido({
   // B11: antes era un Vector3 nuevo POR RENDER — basura de GC en el hilo
   // caliente); la abeja lo persigue con `lerp` en useEntradaAbeja.
   const hAct = activo && hotspots ? hotspots.find((x) => x.id === activo) : null;
-  const p = hAct ? hAct.pos : centro;
-  const foco = useMemo(() => new THREE.Vector3(p[0], p[1], p[2]), [p[0], p[1], p[2]]);
+  const [px, py, pz] = hAct ? hAct.pos : centro;
+  const foco = useMemo(() => new THREE.Vector3(px, py, pz), [px, py, pz]);
 
   return (
     <>

--- a/src/visual/mundo3d/escenas/EscenaBoveda.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBoveda.jsx
@@ -29,6 +29,7 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
 const R_BOVEDA = 9;
 
@@ -263,15 +264,19 @@ const PISOS_DEF = [
    llegaba el hielo (retroceso glaciar) — nota de conciencia, esperanza no colapso. */
 function Montana({ pisos = PISOS_DEF, glaciar = {} }) {
   const bandas = useMemo(() => {
+    // for-loop plano (sin closure que capture los acumuladores): la regla
+    // react-hooks/immutability prohíbe reasignar variables desde callbacks.
+    const out = [];
     let y = 0;
     let rAbajo = pisos[0]?.r0 ?? 2.4;
-    return pisos.map((p, i) => {
+    for (let i = 0; i < pisos.length; i += 1) {
+      const p = pisos[i];
       const rArriba = p.r1 ?? rAbajo * 0.7;
-      const b = { key: i, nombre: p.nombre, color: p.color, h: p.h, rAbajo, rArriba, y };
+      out.push({ key: i, nombre: p.nombre, color: p.color, h: p.h, rAbajo, rArriba, y });
       y += p.h;
       rAbajo = rArriba;
-      return b;
-    });
+    }
+    return out;
   }, [pisos]);
   const cima = bandas.reduce((acc, b) => acc + b.h, 0);
   const rCima = bandas[bandas.length - 1]?.rArriba ?? 0.42;
@@ -297,7 +302,7 @@ function Montana({ pisos = PISOS_DEF, glaciar = {} }) {
       {/* la línea ámbar: hasta aquí llegaba el hielo (cuidado, no alarma) */}
       <mesh position={[0, yAntes, 0]} rotation={[Math.PI / 2, 0, 0]}>
         <torusGeometry args={[rAntes, 0.028, 6, 24]} />
-        <meshBasicMaterial color="#d9a13b" transparent opacity={0.75} />
+        <meshBasicMaterial color={PALETA.ambar} transparent opacity={0.75} />
       </mesh>
     </group>
   );
@@ -352,12 +357,9 @@ function Diorama({ params, reducedMotion }) {
 export default function EscenaBoveda(props) {
   const hora = props.params?.hora ?? 0.62;
   const { horizonte } = paletaCielo(hora);
-  const cielo = {
-    fondo: `#${horizonte.getHexString()}`,
-    cielo: '#eef4f6',
-    suelo: '#6f7f52',
-    intensidad: 1.05,
-  };
+  // El fondo lo dicta la HORA real (veracidad); el hemisferio viene del preset
+  // alba de la atmósfera madre (marfil tibio, ya no blanco frío).
+  const cielo = { ...CIELOS.alba, fondo: `#${horizonte.getHexString()}` };
   return (
     <EscenaBase3D
       {...props}

--- a/src/visual/mundo3d/escenas/EscenaCutaway.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCutaway.jsx
@@ -24,6 +24,7 @@ import EscenaBase3D from './EscenaBase3D.jsx';
 import { Lombriz } from '../../creatures/Lombriz.jsx';
 import { Escarabajo } from '../../creatures/Escarabajo.jsx';
 import { Mariposa } from '../../creatures/Mariposa.jsx';
+import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
 const ANCHO = 4.4;
 const PROF = 2.2;
@@ -201,7 +202,7 @@ function Calabaza({ base }) {
       {hojas.map((h) => (
         <mesh key={`${h.p[0]}-${h.p[2]}`} position={h.p} rotation={[-Math.PI / 2, 0, h.rot]}>
           <coneGeometry args={[h.r, 0.06, 5]} />
-          <meshLambertMaterial color="#5f8a3f" flatShading />
+          <meshLambertMaterial color={PALETA.follaje} flatShading />
         </mesh>
       ))}
       {/* el fruto: esfera achatada, color ahuyama */}
@@ -399,7 +400,7 @@ function Diorama({ params, reducedMotion }) {
 
 export default function EscenaCutaway(props) {
   const alto = (props.params?.capas || []).reduce((s, c) => s + (c.alto || 0.6), 0) || 1.5;
-  const cielo = { fondo: '#e7d7ba', cielo: '#f3e6cc', suelo: '#7a5a38', intensidad: 1.05 };
+  const cielo = CIELOS.tierra;
   return (
     <EscenaBase3D
       {...props}

--- a/src/visual/mundo3d/escenas/EscenaEstratos.jsx
+++ b/src/visual/mundo3d/escenas/EscenaEstratos.jsx
@@ -18,6 +18,7 @@
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
 /* Fauna POR ESTRATO: la verticalidad manda. El colibrí arriba (dosel), la
    mariposa a media altura (arbustos/herbáceas) y el escarabajo a ras (rastrero/
@@ -43,7 +44,7 @@ function Planta({ x, z, alto, color, r }) {
     <group position={[x, 0, z]}>
       <mesh position={[0, alto * 0.35, 0]}>
         <cylinderGeometry args={[0.06, 0.09, alto * 0.7, 5]} />
-        <meshLambertMaterial color="#6b4a2e" flatShading />
+        <meshLambertMaterial color={PALETA.tierra} flatShading />
       </mesh>
       <mesh position={[0, alto * 0.78, 0]}>
         <coneGeometry args={[r, alto * 0.7, 7]} />
@@ -139,11 +140,11 @@ function Cafeto() {
     <group>
       <mesh position={[0, 0.13, 0]}>
         <cylinderGeometry args={[0.035, 0.05, 0.26, 5]} />
-        <meshLambertMaterial color="#6b4a2e" flatShading />
+        <meshLambertMaterial color={PALETA.tierra} flatShading />
       </mesh>
       <mesh position={[0, 0.42, 0]} scale={[1, 0.95, 1]}>
         <sphereGeometry args={[0.28, 7, 6]} />
-        <meshLambertMaterial color="#3f6f3a" flatShading />
+        <meshLambertMaterial color={PALETA.follajeOscuro} flatShading />
       </mesh>
       {[0, 1, 2, 3].map((k) => (
         <mesh
@@ -164,7 +165,7 @@ function Papa() {
     <group>
       <mesh position={[0, 0.14, 0]} scale={[1, 0.55, 1]}>
         <sphereGeometry args={[0.3, 7, 6]} />
-        <meshLambertMaterial color="#5f8a3f" flatShading />
+        <meshLambertMaterial color={PALETA.follaje} flatShading />
       </mesh>
       <mesh position={[0.22, 0.11, 0.14]} scale={[1, 0.5, 1]}>
         <sphereGeometry args={[0.18, 6, 5]} />
@@ -326,11 +327,11 @@ function DioramaPisos({ params, reducedMotion }) {
       <group position={[1.85, pisoY(2), pisoZ(2) + 0.2]}>
         <mesh position={[0, 0, 0]}>
           <cylinderGeometry args={[0.016, 0.016, 0.9, 5]} />
-          <meshBasicMaterial color="#d9a13b" transparent opacity={0.5} />
+          <meshBasicMaterial color={PALETA.ambar} transparent opacity={0.5} />
         </mesh>
         <mesh position={[0, 0.55, 0]}>
           <coneGeometry args={[0.08, 0.2, 5]} />
-          <meshBasicMaterial color="#d9a13b" transparent opacity={0.55} />
+          <meshBasicMaterial color={PALETA.ambar} transparent opacity={0.55} />
         </mesh>
       </group>
 
@@ -342,9 +343,7 @@ function DioramaPisos({ params, reducedMotion }) {
 
 export default function EscenaEstratos(props) {
   const esPisos = Array.isArray(props.params?.pisos);
-  const cielo = esPisos
-    ? { fondo: '#cfe0e6', cielo: '#e8f0ee', suelo: '#6b5236', intensidad: 1.12 }
-    : { fondo: '#d7e6c9', cielo: '#eaf2df', suelo: '#5f4a2e', intensidad: 1.1 };
+  const cielo = esPisos ? CIELOS.ladera : CIELOS.sotobosque;
   const camara = esPisos ? { position: [4.4, 3.7, 6.4], fov: 46 } : { position: [3.5, 3, 6], fov: 44 };
   const centro = esPisos ? [0, 1.95, -0.4] : [0, 1.4, 0];
   return (

--- a/src/visual/mundo3d/escenas/EscenaFlujo.jsx
+++ b/src/visual/mundo3d/escenas/EscenaFlujo.jsx
@@ -19,6 +19,7 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
 /* La vida del agua, por criterio ecológico: mariposas revoloteando sobre la
    quebrada, un colibrí en las flores de la ribera (junto a la ronda de monte),
@@ -86,11 +87,11 @@ function Arbolito({ pos, escala = 1 }) {
     <group position={pos} scale={escala}>
       <mesh position={[0, 0.18, 0]}>
         <cylinderGeometry args={[0.05, 0.07, 0.36, 6]} />
-        <meshLambertMaterial color="#7a5a38" flatShading />
+        <meshLambertMaterial color={PALETA.madera} flatShading />
       </mesh>
       <mesh position={[0, 0.5, 0]}>
         <coneGeometry args={[0.28, 0.5, 7]} />
-        <meshLambertMaterial color="#3f6f3a" flatShading />
+        <meshLambertMaterial color={PALETA.follajeOscuro} flatShading />
       </mesh>
       <mesh position={[0, 0.78, 0]}>
         <coneGeometry args={[0.18, 0.34, 7]} />
@@ -130,7 +131,7 @@ function Bocatoma({ curva3, t = 0.68, color }) {
     <group position={[p.x, p.y, p.z]}>
       <mesh position={[0, 0.1, 0]}>
         <boxGeometry args={[0.42, 0.3, 0.42]} />
-        <meshLambertMaterial color="#a8a094" flatShading />
+        <meshLambertMaterial color={PALETA.concreto} flatShading />
       </mesh>
       <mesh position={[0, 0.26, 0]}>
         <boxGeometry args={[0.34, 0.06, 0.34]} />
@@ -148,15 +149,15 @@ function PuntoCuidado({ curva3, t = 0.46, lado = 0.8 }) {
     <group position={[p.x + lado * 0.4, p.y - 0.02, p.z + lado]}>
       <mesh position={[0, 0.16, 0]}>
         <cylinderGeometry args={[0.14, 0.14, 0.32, 10]} />
-        <meshLambertMaterial color="#8b8b8b" flatShading />
+        <meshLambertMaterial color={PALETA.lamina} flatShading />
       </mesh>
       <mesh position={[0.28, 0.3, 0]}>
         <cylinderGeometry args={[0.02, 0.02, 0.6, 5]} />
-        <meshLambertMaterial color="#7a5a38" />
+        <meshLambertMaterial color={PALETA.madera} />
       </mesh>
       <mesh position={[0.28, 0.62, 0]}>
         <boxGeometry args={[0.3, 0.2, 0.04]} />
-        <meshLambertMaterial color="#d9a13b" flatShading />
+        <meshLambertMaterial color={PALETA.ambar} flatShading />
       </mesh>
     </group>
   );
@@ -186,12 +187,12 @@ function Cultivo({ pos = [2.3, -0.3, -0.55], surcos = 4, desde, color }) {
       <group position={[pos[0], pos[1], pos[2]]}>
         <mesh position={[0, 0.06, 0]}>
           <boxGeometry args={[1.5, 0.16, 1.1]} />
-          <meshLambertMaterial color="#6b4a2e" flatShading />
+          <meshLambertMaterial color={PALETA.tierra} flatShading />
         </mesh>
         {surcosArr.map((i) => (
           <mesh key={i} position={[0, 0.17, -0.42 + (0.84 * i) / Math.max(1, surcos - 1)]}>
             <boxGeometry args={[1.3, 0.1, 0.14]} />
-            <meshLambertMaterial color="#5f8a3f" flatShading />
+            <meshLambertMaterial color={PALETA.follaje} flatShading />
           </mesh>
         ))}
       </group>
@@ -225,7 +226,7 @@ function Diorama({ params, tinte, reducedMotion }) {
       {/* el tanque que recibe el agua (donde termina la curva) */}
       <mesh position={[fin.x + 0.1, fin.y + 0.05, fin.z]}>
         <cylinderGeometry args={[0.55, 0.6, 0.7, 18]} />
-        <meshLambertMaterial color="#9a8b74" flatShading />
+        <meshLambertMaterial color={PALETA.piedra} flatShading />
       </mesh>
       <mesh position={[fin.x + 0.1, fin.y + 0.25, fin.z]}>
         <cylinderGeometry args={[0.5, 0.5, 0.12, 18]} />
@@ -250,7 +251,7 @@ function Diorama({ params, tinte, reducedMotion }) {
 }
 
 export default function EscenaFlujo(props) {
-  const cielo = { fondo: '#d9e8ec', cielo: '#eaf3f5', suelo: '#7f9270', intensidad: 1.1 };
+  const cielo = CIELOS.agua;
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.9, 0.3] }}>
       <Diorama params={props.params} tinte={props.tinte} reducedMotion={props.reducedMotion} />

--- a/src/visual/mundo3d/escenas/EscenaMercado.jsx
+++ b/src/visual/mundo3d/escenas/EscenaMercado.jsx
@@ -23,6 +23,7 @@
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
 /* La fauna que anima la feria: la mariposa entre las flores del puesto, el
    colibrí que sobrevuela la plaza. Pocas y por criterio (vida, no enjambre). */
@@ -76,7 +77,7 @@ function Puesto({ pos, color = '#c96a2f' }) {
       {patas.map(([x, z], i) => (
         <mesh key={i} position={[x, 0.22, z]}>
           <cylinderGeometry args={[0.028, 0.032, 0.44, 5]} />
-          <meshLambertMaterial color="#7a5a38" flatShading />
+          <meshLambertMaterial color={PALETA.madera} flatShading />
         </mesh>
       ))}
       {/* la mesa (tablón) */}
@@ -98,7 +99,7 @@ function Puesto({ pos, color = '#c96a2f' }) {
       {[[-0.5, 0], [0.5, 0]].map(([x, z], i) => (
         <mesh key={i} position={[x, 0.68, z]}>
           <cylinderGeometry args={[0.02, 0.02, 0.48, 5]} />
-          <meshLambertMaterial color="#7a5a38" flatShading />
+          <meshLambertMaterial color={PALETA.madera} flatShading />
         </mesh>
       ))}
     </group>
@@ -114,7 +115,7 @@ function TarimaProcedencia({ pos }) {
       {/* el poste */}
       <mesh position={[0, 0.4, 0]}>
         <cylinderGeometry args={[0.035, 0.04, 0.8, 6]} />
-        <meshLambertMaterial color="#8a6a44" flatShading />
+        <meshLambertMaterial color={PALETA.tierraClara} flatShading />
       </mesh>
       {/* la placa del sello de origen (madera clara) */}
       <mesh position={[0, 0.86, 0]}>
@@ -217,7 +218,7 @@ function Diorama({ params, reducedMotion }) {
           comprador, sin dar la vuelta. */}
       <mesh position={[0.1, 0.005, -1.0]} rotation={[-Math.PI / 2, 0, 0.04]}>
         <planeGeometry args={[0.7, 2.6]} />
-        <meshLambertMaterial color="#a98a5c" />
+        <meshLambertMaterial color={PALETA.maderaClara} />
       </mesh>
       {/* la parcela de donde sale todo (el campo, al fondo de la ruta) */}
       <mesh position={[0.1, 0.006, -2.35]} rotation={[-Math.PI / 2, 0, 0]}>
@@ -259,7 +260,7 @@ function Diorama({ params, reducedMotion }) {
 export default function EscenaMercado(props) {
   // Cielo cálido de plaza de mercado a media mañana (se mezcla igual hacia la
   // hora dorada del valle: entrar debe sentirse como acercarse, no otra app).
-  const cielo = { fondo: '#f0dcb4', cielo: '#f6e8c8', suelo: '#9a7a4a', intensidad: 1.05 };
+  const cielo = CIELOS.plaza;
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.5, 0] }}>
       <Diorama params={props.params} reducedMotion={props.reducedMotion} />

--- a/src/visual/mundo3d/escenas/EscenaRecinto.jsx
+++ b/src/visual/mundo3d/escenas/EscenaRecinto.jsx
@@ -12,6 +12,7 @@
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
 /* La fauna que acompaña el corral: el escarabajo estercolero junto a la pila de
    estiércol (cierra el ciclo del abono, literal), un colibrí que sobrevuela y
@@ -112,13 +113,13 @@ function Vaca({ pos, color = '#c9a06a' }) {
       {[[0.28, 0.13], [0.28, -0.13], [-0.28, 0.13], [-0.28, -0.13]].map(([x, z], i) => (
         <mesh key={i} position={[x, 0.18, z]}>
           <cylinderGeometry args={[0.045, 0.04, 0.36, 5]} />
-          <meshLambertMaterial color="#8a6a44" flatShading />
+          <meshLambertMaterial color={PALETA.tierraClara} flatShading />
         </mesh>
       ))}
       {/* cola */}
       <mesh position={[-0.42, 0.34, 0]} rotation={[0, 0, 0.4]}>
         <cylinderGeometry args={[0.02, 0.02, 0.34, 4]} />
-        <meshLambertMaterial color="#8a6a44" flatShading />
+        <meshLambertMaterial color={PALETA.tierraClara} flatShading />
       </mesh>
     </group>
   );
@@ -184,24 +185,24 @@ function Diorama({ params, reducedMotion }) {
       {/* piso del corral */}
       <mesh position={[0, -0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
         <circleGeometry args={[2, 28]} />
-        <meshLambertMaterial color="#a98a5c" />
+        <meshLambertMaterial color={PALETA.maderaClara} />
       </mesh>
       {/* la cerca: postes en anillo */}
       {postes.map((p, i) => (
         <mesh key={i} position={p}>
           <cylinderGeometry args={[0.05, 0.06, 0.5, 5]} />
-          <meshLambertMaterial color="#8a6a44" flatShading />
+          <meshLambertMaterial color={PALETA.tierraClara} flatShading />
         </mesh>
       ))}
       {/* el aro del CICLO cerrado (abono que vuelve) */}
       <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
         <torusGeometry args={[1.25, 0.05, 8, 40]} />
-        <meshBasicMaterial color="#7a9a3f" transparent opacity={0.7} />
+        <meshBasicMaterial color={PALETA.follajeClaro} transparent opacity={0.7} />
       </mesh>
       {/* pila de estiércol/abono al centro (cierre del ciclo) */}
       <mesh position={[0, 0.14, 0]}>
         <coneGeometry args={[0.4, 0.28, 10]} />
-        <meshLambertMaterial color="#5a4326" flatShading />
+        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
       </mesh>
       {animales.map((a, i) => (
         <AnimalDeCorral key={i} tipo={a.tipo} pos={a.pos} color={a.color} />
@@ -213,7 +214,7 @@ function Diorama({ params, reducedMotion }) {
 }
 
 export default function EscenaRecinto(props) {
-  const cielo = { fondo: '#ecdcc2', cielo: '#f6ead2', suelo: '#8a6a44', intensidad: 1.05 };
+  const cielo = CIELOS.corral;
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.4, 0] }}>
       <Diorama params={props.params} reducedMotion={props.reducedMotion} />

--- a/src/visual/mundo3d/escenas/EscenaSanidad.jsx
+++ b/src/visual/mundo3d/escenas/EscenaSanidad.jsx
@@ -21,6 +21,7 @@
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
 /* La fauna BENÉFICA que acompaña la huerta-clínica: la mariposa polinizadora en
    la orla de flores, el colibrí que sobrevuela, y el escarabajo (carábido)
@@ -74,7 +75,7 @@ function Trampa({ pos, color = '#f2c531' }) {
     <group position={pos}>
       <mesh position={[0, 0.34, 0]}>
         <cylinderGeometry args={[0.02, 0.026, 0.68, 5]} />
-        <meshLambertMaterial color="#7a5a38" flatShading />
+        <meshLambertMaterial color={PALETA.madera} flatShading />
       </mesh>
       <mesh position={[0, 0.62, 0]}>
         <boxGeometry args={[0.22, 0.28, 0.02]} />
@@ -112,7 +113,7 @@ function EstacionBio({ pos }) {
     <group position={pos}>
       <mesh position={[0, 0.22, 0]}>
         <cylinderGeometry args={[0.04, 0.05, 0.44, 6]} />
-        <meshLambertMaterial color="#8a6a44" flatShading />
+        <meshLambertMaterial color={PALETA.tierraClara} flatShading />
       </mesh>
       {/* el recipiente */}
       <mesh position={[0, 0.49, 0]}>
@@ -190,13 +191,13 @@ function Diorama({ params, reducedMotion }) {
       {postes.map((p, i) => (
         <mesh key={i} position={p}>
           <cylinderGeometry args={[0.05, 0.06, 0.5, 5]} />
-          <meshLambertMaterial color="#8a6a44" flatShading />
+          <meshLambertMaterial color={PALETA.tierraClara} flatShading />
         </mesh>
       ))}
       {/* el anillo verde del manejo: el borde vivo que rodea y defiende */}
       <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
         <torusGeometry args={[1.55, 0.045, 8, 44]} />
-        <meshBasicMaterial color="#7a9a3f" transparent opacity={0.7} />
+        <meshBasicMaterial color={PALETA.follajeClaro} transparent opacity={0.7} />
       </mesh>
 
       {/* las matas sanas que se protegen */}
@@ -226,7 +227,7 @@ function Diorama({ params, reducedMotion }) {
 
 export default function EscenaSanidad(props) {
   // Cielo fresco y sano de huerta (se mezcla igual hacia la hora dorada del valle).
-  const cielo = { fondo: '#dbe7c4', cielo: '#eef4dc', suelo: '#7e8a4a', intensidad: 1.05 };
+  const cielo = CIELOS.huerta;
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.45, 0] }}>
       <Diorama params={props.params} reducedMotion={props.reducedMotion} />


### PR DESCRIPTION
## Qué hace

Dirección de arte: los ~9 mundos 3D ahora comparten UNA atmósfera madre (la hora dorada del valle) desde un módulo único, para que el conjunto se sienta un solo juego cálido y no escenas sueltas.

### Módulo nuevo: `src/visual/mundo3d/atmosferaMadre.js`
- **ATMOSFERA**: la hora dorada (sol dorado `#ffd79a`, relleno frío tenue, niebla `#f0c98d`, sombra `#3a2a18`) — antes vivía encerrada como constante local de `EscenaBase3D`; ahora es fuente única compartida (espejo de `CLIMAS.dorada` del valle).
- **CIELOS**: preset por familia de mundo (agua, tierra, corral, plaza, huerta, sotobosque, ladera, alba). Los arquetipos ya no inventan hexes inline. Tres cielos francamente fríos se entibian sin perder identidad:
  - agua (Flujo): azul-gris `#d9e8ec` → salvia `#dfe6d5`
  - ladera (Pisos/páramo): celeste `#cfe0e6` → verde-plata `#d6e0d2`
  - alba (Bóveda): hemisferio blanco frío `#eef4f6` → marfil tibio `#f2f0e0` (el fondo sigue dinámico por hora real)
- **PALETA**: materiales low-poly canónicos (madera/tierra/follaje/piedra/ámbar/cal). Los tonos que los dioramas ya compartían de facto ahora son ley importada — un solo marrón de madera en todo el juego. Únicos cambios de valor: los grises fabriles neutros de Flujo (bocatoma `#a8a094`→`#a89a84`, barril `#8b8b8b`→`#8b8578`) se calientan — bajo sol dorado todo se tiñe.

### Escenas tocadas
Las 7 que heredan `EscenaBase3D` (Flujo, Cutaway, Recinto, Mercado, Sanidad, Estratos, Bóveda): import del preset + adopción de PALETA. El valle no se toca (él ES la hora madre; la base ya mezcla 60% hacia ella).

### Extra (lint staged con max-warnings 0)
- Montaña de la bóveda: acumuladores del `map` → for-loop plano (`react-hooks/immutability` preexistente).
- Base: foco del useMemo desestructurado a escalares (`exhaustive-deps` preexistente).

## Qué NO hace
- No cambia navegación ni contenido (solo color/luz/atmósfera).
- No rompe el device-tier de #2331: la base sigue apagando niebla/alfombras en gama baja; el módulo son constantes, costo cero por frame.

## Verificación
- `npm run build` verde (16.7s, warnings de chunks preexistentes).
- lefthook pre-commit (eslint max-warnings 0 + scans anti-leak) verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)