### PR TITLE
fix(voz): asegurar narración visible y audio estable

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -181,9 +181,29 @@ export default function EntradaValle3D({ onBack }) {
   // El toggle vive en un ref para que `hablar`/`decir` sean ESTABLES: prender
   // o apagar la voz no debe re-disparar los efectos que narran.
   const vozRef = useRef(voz);
+  const vocesRef = useRef([]);
   useEffect(() => {
     vozRef.current = voz;
   }, [voz]);
+
+  useEffect(() => {
+    if (!vozDisponible) return undefined;
+    const synth = window.speechSynthesis;
+    const actualizarVoces = () => {
+      const voces = synth.getVoices();
+      if (voces.length) vocesRef.current = voces;
+    };
+    actualizarVoces();
+    if (synth.addEventListener) {
+      synth.addEventListener('voiceschanged', actualizarVoces);
+      return () => synth.removeEventListener('voiceschanged', actualizarVoces);
+    }
+    const anterior = synth.onvoiceschanged;
+    synth.onvoiceschanged = actualizarVoces;
+    return () => {
+      if (synth.onvoiceschanged === actualizarVoces) synth.onvoiceschanged = anterior;
+    };
+  }, [vozDisponible]);
 
   const hablar = useCallback((texto) => {
     if (!vozRef.current || typeof window === 'undefined' || !window.speechSynthesis) return;
@@ -193,10 +213,13 @@ export default function EntradaValle3D({ onBack }) {
       u.lang = 'es-CO';
       u.rate = 0.98;
       u.pitch = 1;
-      const esVoz = window.speechSynthesis
-        .getVoices()
-        .find((v) => v.lang && v.lang.toLowerCase().startsWith('es'));
-      if (esVoz) u.voice = esVoz;
+      const esVoz = vocesRef.current.find(
+        (v) => v.lang && v.lang.toLowerCase().startsWith('es'),
+      );
+      // Si el navegador todavía no publicó sus voces, conservamos la
+      // burbuja y evitamos que el saludo salga con la voz inglesa por defecto.
+      if (!esVoz) return;
+      u.voice = esVoz;
       window.speechSynthesis.speak(u);
     } catch {
       /* la voz es un plus, nunca bloquea */
@@ -235,30 +258,38 @@ export default function EntradaValle3D({ onBack }) {
     [],
   );
 
-  // Saludo del compañero al entrar (una sola vez): voz + burbuja.
+  // Saludo del compañero al primer gesto (una sola vez): voz + burbuja. Así
+  // iOS permite la síntesis y la entrada nunca depende de autoplay.
   const saludado = useRef(false);
   useEffect(() => {
-    if (saludado.current) return;
-    saludado.current = true;
-    const t = setTimeout(() => decir(NARRACION.bienvenida), 900);
-    return () => clearTimeout(t);
+    const saludar = () => {
+      if (saludado.current) return;
+      saludado.current = true;
+      decir(NARRACION.bienvenida);
+    };
+    window.addEventListener('pointerdown', saludar, { once: true, capture: true });
+    window.addEventListener('keydown', saludar, { once: true, capture: true });
+    return () => {
+      window.removeEventListener('pointerdown', saludar, { capture: true });
+      window.removeEventListener('keydown', saludar, { capture: true });
+    };
   }, [decir]);
 
   const entrarMundo = useCallback(
     (id) => {
       setFocoId(id);
       setPanel(id);
-      hablar(NARRACION[id] || MUNDO_VALLE_BY_ID[id]?.lema || '');
+      decir(NARRACION[id] || MUNDO_VALLE_BY_ID[id]?.lema || '');
     },
-    [hablar],
+    [decir],
   );
 
   const abrirAlerta = useCallback(() => {
     setFocoId(COSA_DEL_DIA.anclaMundo);
     setPanel('alerta');
     setAlertaVista(true); // atender lo del día calma a la abeja
-    hablar(COSA_DEL_DIA.vozTexto);
-  }, [hablar]);
+    decir(COSA_DEL_DIA.vozTexto);
+  }, [decir]);
 
   const volverAlValle = useCallback(() => {
     setFocoId(null);
@@ -285,9 +316,9 @@ export default function EntradaValle3D({ onBack }) {
     (id) => {
       if (!nav.viajarAlMundo(id)) return;
       setPanel(null);
-      hablar(`Angelita lo lleva a ${tituloDeMundo(id)}.`);
+      decir(`Angelita lo lleva a ${tituloDeMundo(id)}.`);
     },
-    [nav, hablar],
+    [nav, decir],
   );
 
   // ── VOLVER del mundo al valle (misma transición, en reversa).
@@ -435,7 +466,7 @@ export default function EntradaValle3D({ onBack }) {
               nombra las puertas. Lo que dice (`dicho`) va SIEMPRE en su
               burbuja de texto (aria-live) — si la voz falta o está apagada,
               la burbuja es la voz. ── */}
-      {!panel && (
+      {(!panel || dicho) && (
         <div
           className={`valle-companero${nav.enMundo ? ' valle-companero--mundo' : ''}`}
           data-gesto={gesto || undefined}
@@ -467,7 +498,7 @@ export default function EntradaValle3D({ onBack }) {
           <p>{COSA_DEL_DIA.detalle}</p>
           <div className="valle-panel__acciones">
             <button type="button" className="valle-cta">{COSA_DEL_DIA.accion.etiqueta}</button>
-            <button type="button" className="valle-ghost" onClick={() => hablar(COSA_DEL_DIA.vozTexto)}>
+            <button type="button" className="valle-ghost" onClick={() => decir(COSA_DEL_DIA.vozTexto)}>
               🔊 Escuchar
             </button>
           </div>
@@ -495,7 +526,7 @@ export default function EntradaValle3D({ onBack }) {
                 Este mundo abre pronto su propia puerta. Por ahora se vive desde el valle.
               </p>
             )}
-            <button type="button" className="valle-ghost" onClick={() => hablar(NARRACION[mundoPanel.id] || mundoPanel.lema)}>
+            <button type="button" className="valle-ghost" onClick={() => decir(NARRACION[mundoPanel.id] || mundoPanel.lema)}>
               🔊 Escuchar
             </button>
           </div>

--- a/src/mockups/__tests__/entradaValle3D.nav.test.jsx
+++ b/src/mockups/__tests__/entradaValle3D.nav.test.jsx
@@ -23,6 +23,9 @@ import EntradaValle3D from '../EntradaValle3D.jsx';
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  delete window.speechSynthesis;
+  delete window.SpeechSynthesisUtterance;
+  delete globalThis.SpeechSynthesisUtterance;
 });
 
 /* El viaje dura ~1.05s; con timers falsos lo cumplimos determinista. */
@@ -102,5 +105,49 @@ describe('entrada-3d — navegable de punta a punta (valle ↔ mundos)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Volver al valle' }));
     cumplirViaje();
     expect(container.querySelector('.valle-mundo')).not.toBeInTheDocument();
+  });
+});
+
+describe('entrada-3d — voz con respaldo visible', () => {
+  test('saluda solo después del primer gesto y escribe la bienvenida', () => {
+    vi.useFakeTimers();
+    const { container } = render(<EntradaValle3D onBack={() => {}} />);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(container.querySelector('.valle-companero')).not.toHaveTextContent(/Bienvenido/i);
+
+    fireEvent.pointerDown(container.querySelector('.valle-root'));
+    expect(container.querySelector('.valle-companero')).toHaveTextContent(/Bienvenido/i);
+  });
+
+  test('espera voiceschanged y usa la voz en español en la primera lectura', () => {
+    let voces = [];
+    const eventos = new EventTarget();
+    const synth = {
+      cancel: vi.fn(),
+      speak: vi.fn(),
+      getVoices: vi.fn(() => voces),
+      addEventListener: eventos.addEventListener.bind(eventos),
+      removeEventListener: eventos.removeEventListener.bind(eventos),
+    };
+    class Utterance {
+      constructor(text) { this.text = text; }
+    }
+    window.speechSynthesis = synth;
+    window.SpeechSynthesisUtterance = Utterance;
+    globalThis.SpeechSynthesisUtterance = Utterance;
+
+    const { container } = render(<EntradaValle3D onBack={() => {}} />);
+    fireEvent.pointerDown(container.querySelector('.valle-root'));
+    expect(synth.speak).not.toHaveBeenCalled();
+
+    const vozEspanol = { lang: 'es-CO', name: 'Angelita' };
+    voces = [vozEspanol];
+    act(() => eventos.dispatchEvent(new Event('voiceschanged')));
+    fireEvent.click(screen.getByRole('button', { name: /Viajar al mundo El agua/ }));
+
+    expect(synth.speak).toHaveBeenCalledTimes(1);
+    expect(synth.speak.mock.calls[0][0].voice).toBe(vozEspanol);
+    expect(container.querySelector('.valle-companero')).toHaveTextContent(/sale el agua/i);
   });
 });

--- a/src/visual/mundo3d/__tests__/useAudioMundo.test.jsx
+++ b/src/visual/mundo3d/__tests__/useAudioMundo.test.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest';
+
+const buses = [];
+let master;
+
+const parametro = () => ({
+  value: 0,
+  setValueAtTime: vi.fn(),
+  setTargetAtTime: vi.fn(),
+  exponentialRampToValueAtTime: vi.fn(),
+});
+
+const nodo = () => ({
+  connect: vi.fn(function conectar() { return this; }),
+  disconnect: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+});
+
+class AudioContextMock {
+  constructor() {
+    this.currentTime = 0;
+    this.sampleRate = 20;
+    this.state = 'running';
+    this.destination = nodo();
+  }
+
+  createDynamicsCompressor() {
+    return { ...nodo(), threshold: parametro(), ratio: parametro() };
+  }
+
+  createGain() {
+    const gain = parametro();
+    const gainNode = { ...nodo(), gain };
+    if (!master) master = gainNode;
+    else if (gain.setTargetAtTime) buses.push(gainNode);
+    return gainNode;
+  }
+
+  createBuffer() {
+    return { getChannelData: () => new Float32Array(50) };
+  }
+
+  createBufferSource() { return { ...nodo(), buffer: null, loop: false }; }
+
+  createBiquadFilter() {
+    return { ...nodo(), frequency: parametro(), Q: parametro(), type: '' };
+  }
+
+  createOscillator() {
+    return { ...nodo(), frequency: parametro(), type: '' };
+  }
+
+  resume() { return Promise.resolve(); }
+}
+
+async function cargar() {
+  vi.resetModules();
+  const [{ default: useAudioMundo }, { default: usePrefsStore }] = await Promise.all([
+    import('../useAudioMundo.js'),
+    import('../../../store/usePrefsStore.js'),
+  ]);
+  return { useAudioMundo, usePrefsStore };
+}
+
+beforeEach(() => {
+  buses.length = 0;
+  master = null;
+  window.AudioContext = AudioContextMock;
+  localStorage.clear();
+});
+
+afterEach(() => {
+  delete window.AudioContext;
+  vi.useRealTimers();
+});
+
+describe('useAudioMundo', () => {
+  it('cubre pila, preferencia apagada y reduced-motion', async () => {
+    vi.useFakeTimers();
+    const timer = vi.spyOn(globalThis, 'setTimeout');
+    const { useAudioMundo, usePrefsStore } = await cargar();
+    act(() => usePrefsStore.setState({ sonido: 'on' }));
+    function Host({ agua }) {
+      useAudioMundo({ mundoId: 'valle', reducedMotion: true });
+      return agua ? <Agua /> : null;
+    }
+    function Agua() {
+      useAudioMundo({ mundoId: 'agua', reducedMotion: true });
+      return null;
+    }
+
+    const vista = render(<Host agua={false} />);
+    act(() => window.dispatchEvent(new Event('pointerdown')));
+    expect(timer).not.toHaveBeenCalled();
+    const capasTrasValle = buses.filter((n) =>
+      n.gain.setTargetAtTime.mock.calls.some(([valor]) => valor === 1)).length;
+
+    vista.rerender(<Host agua />);
+    const capasTrasAgua = buses.filter((n) =>
+      n.gain.setTargetAtTime.mock.calls.some(([valor]) => valor === 1)).length;
+    vista.rerender(<Host agua={false} />);
+    const capasTrasLiberar = buses.filter((n) =>
+      n.gain.setTargetAtTime.mock.calls.some(([valor]) => valor === 1)).length;
+
+    expect([capasTrasValle, capasTrasAgua, capasTrasLiberar]).toEqual([1, 2, 3]);
+    act(() => usePrefsStore.setState({ sonido: 'off' }));
+    expect(master.gain.setTargetAtTime).toHaveBeenLastCalledWith(0, 0, 0.4);
+  });
+});


### PR DESCRIPTION
## Summary
- enruta las acciones narradas por `decir()` para conservar la burbuja cuando la voz no está disponible o está apagada
- carga y actualiza la caché de voces con `voiceschanged`, exige una voz en español y mueve el saludo al primer gesto
- agrega pruebas de voz y humo para la pila, preferencia apagada y reduced-motion del motor de audio

## Test plan
- `npx vitest run src/visual/mundo3d src/mockups/__tests__` (43 pruebas pasan)
- `npx eslint . --max-warnings=0` (pasa)
- `npm run build` (pasa)
- `npx vitest run` (suite completa: 20 fallas preexistentes fuera del alcance en sidecar, jornada 48h, NGSI, perfiles, temas, iOS y otros módulos)