### PR TITLE
fix(mundo3d): calidez y game-feel de la auditoría triple (7 arreglos visuales)

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -388,6 +388,7 @@ export default function EntradaValle3D({ onBack }) {
             onSalir={salirDelMundo}
             animo={companero.animo}
             energia={companero.energia}
+            hablando={!!dicho}
           />
         </section>
       )}
@@ -435,23 +436,28 @@ export default function EntradaValle3D({ onBack }) {
               nombra las puertas. Lo que dice (`dicho`) va SIEMPRE en su
               burbuja de texto (aria-live) — si la voz falta o está apagada,
               la burbuja es la voz. ── */}
-      {!panel && (
+      {!panel && (!nav.enMundo || dicho) && (
         <div
           className={`valle-companero${nav.enMundo ? ' valle-companero--mundo' : ''}`}
           data-gesto={gesto || undefined}
           role="status"
           aria-live="polite"
         >
-          <span className="valle-companero__cara" aria-hidden="true">
-            <AbejaAngelita
-              size={34}
-              pose={gesto || 'vuela'}
-              animo={companero.animo}
-              energia={companero.energia}
-              animated={!reducedMotion}
-            />
-            <i className="valle-companero__sombra" />
-          </span>
+          {/* DENTRO de un mundo Angelita vive en la ESCENA (una sola compañera,
+              no dos abejas): aquí el chip queda solo como su burbuja de voz. En
+              el valle sí lleva su cara (la tarjeta puntual imagen-first). */}
+          {!nav.enMundo && (
+            <span className="valle-companero__cara" aria-hidden="true">
+              <AbejaAngelita
+                size={34}
+                pose={gesto || 'vuela'}
+                animo={companero.animo}
+                energia={companero.energia}
+                animated={!reducedMotion}
+              />
+              <i className="valle-companero__sombra" />
+            </span>
+          )}
           {(dicho || !nav.enMundo) && (
             <span className="valle-companero__txt">{dicho || companero.frase}</span>
           )}

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -309,7 +309,7 @@ export function climaPorHora(fecha = new Date()) {
 }
 
 /* ── 3. LO QUE EL AGENTE DICE AL PASAR ───────────────────────────────────────
- * El compañero (colibrí) narra el mundo cuando la cámara viaja hacia él. Texto
+ * El compañero (abeja) narra el mundo cuando la cámara viaja hacia él. Texto
  * corto, cálido, en usted; se lee por voz (Web Speech API) si el equipo la trae.
  */
 export const NARRACION = {

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -94,6 +94,7 @@ function MigaVolver({ onSalir, mundoId }) {
 
 function MundoInterno({
   mundoId, tier = 'alto', reducedMotion = false, onHotspot, onSalir, animo = 'sereno', energia = 1,
+  hablando = false,
 }) {
   /* CAÍDA DIGNA (BUG-UX-05 / SPEC-UX-05): si el chunk 3D no baja en
      CARGA_3D_TIMEOUT_MS, caemos al espejo 2D del mundo. `intento` fabrica un
@@ -166,6 +167,7 @@ function MundoInterno({
             onSalir={onSalir}
             animo={animo}
             energia={energia}
+            hablando={hablando}
           />
         </Suspense>
         <MigaVolver onSalir={onSalir} mundoId={mundoId} />

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -34,11 +34,14 @@ import { ATMOSFERA, CIELOS, mezclar } from '../atmosferaMadre.js';
 
 function Contenido({
   params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
-  frugal = false,
+  frugal = false, hablando = false,
   children,
 }) {
   const controls = useRef(null);
   const [activo, setActivo] = useState(null);
+  // `rebote`: cada toque de hotspot lo incrementa → Angelita da un microrrebote
+  // (carácter de compañera, ref. el zorro de Ori / el ganso de Untitled Goose).
+  const [rebote, setRebote] = useState(0);
   // Háptica del tap (DR-3D-HAPTICA): un tick seco al tocar un hotspot —
   // "toqué algo vivo, respondió". Gate triple interno; no-op en iOS.
   const haptics = useHaptics({ reducedMotion });
@@ -121,6 +124,7 @@ function Contenido({
                 e.stopPropagation();
                 haptics.tap();
                 setActivo(h.id);
+                setRebote((n) => n + 1);
                 onHotspot?.(h.view, h.data);
               }}
               aria-label={h.label}
@@ -132,7 +136,20 @@ function Contenido({
         </group>
       ))}
 
-      <AbejaEscena foco={foco} entrando animo={animo} energia={energia} reducedMotion={reducedMotion} piso={piso} />
+      {/* Angelita: una sola por mundo (la del footer se oculta dentro). `entrando`
+          vive AHORA en si hay hotspot activo — con foco se posa junto a la puerta,
+          sin foco RONDA (idle propio, ya no un fotograma clavado). `hablando` la
+          hace pulsar cuando el agente narra; `rebote` es el microrrebote del toque. */}
+      <AbejaEscena
+        foco={foco}
+        entrando={!!activo}
+        hablando={hablando}
+        rebote={rebote}
+        animo={animo}
+        energia={energia}
+        reducedMotion={reducedMotion}
+        piso={piso}
+      />
 
       <OrbitControls
         ref={controls}
@@ -155,7 +172,8 @@ function Contenido({
 
 export default function EscenaBase3D({
   params, hotspots, entrada, tinte, reducedMotion,
-  onHotspot, cielo, animo = 'sereno', energia = 1, camara, piso = 0, tier = 'alto', children,
+  onHotspot, cielo, animo = 'sereno', energia = 1, camara, piso = 0, tier = 'alto',
+  hablando = false, children,
 }) {
   const [listo, setListo] = useState(false);
   const zoom = entrada?.zoom ?? 6.5;
@@ -187,6 +205,7 @@ export default function EscenaBase3D({
           energia={energia}
           piso={piso}
           frugal={frugal}
+          hablando={hablando}
         >
           {children}
         </Contenido>

--- a/src/visual/mundo3d/escenas/EscenaBoveda.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBoveda.jsx
@@ -24,12 +24,13 @@
  * lluvia y la niebla se CONGELAN en su fotograma (nunca desaparecen). PRNG
  * determinista: mismo dato → mismo cielo.
  */
-import { useMemo, useRef } from 'react';
-import { useFrame } from '@react-three/fiber';
+import { useMemo, useRef, useState } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
-import { CIELOS, PALETA } from '../atmosferaMadre.js';
+import { ATMOSFERA, CIELOS, PALETA } from '../atmosferaMadre.js';
 
 const R_BOVEDA = 9;
 
@@ -130,6 +131,45 @@ function Sol({ hora, reducedMotion }) {
       </mesh>
     </group>
   );
+}
+
+/* CIELO VIVO: el color de FONDO y del HEMISFERIO siguen la p VIVA del sol (la
+   misma que anima su arco), no la hora fija. El gradiente de la BÓVEDA (malla)
+   se queda memoizado —regenerarlo por frame sería caro—; esto es barato: solo
+   muta el <color> de fondo y el color de la luz de cielo. Así "el color del
+   cielo ES la hora": al avanzar el sol, el fondo y la luz atardecen con él.
+   Con reduced-motion no toca nada (la base ya fijó el fotograma digno). */
+function CieloVivo({ hora, reducedMotion }) {
+  const { scene } = useThree();
+  const hemiRef = useRef(null);
+  // colores de trabajo precomputados: cero asignaciones por frame.
+  const fondoMadre = useRef(new THREE.Color(ATMOSFERA.fondo));
+  // el hemisferio parte de la MISMA mezcla que EscenaBase3D (alba 40% + madre
+  // 60%) y solo se tiñe un poco hacia el cenit de la hora viva.
+  const baseCielo = useRef(
+    new THREE.Color(CIELOS.alba.cielo).lerp(new THREE.Color(ATMOSFERA.cielo), 0.6),
+  );
+  const tmpCielo = useRef(new THREE.Color());
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const p = (hora + state.clock.elapsedTime * 0.012) % 1;
+    const { horizonte, zenit } = paletaCielo(p);
+    // fondo vivo = horizonte de la hora, mezclado 60% hacia la hora dorada madre
+    // (misma receta que la base, pero con la p viva del sol).
+    if (scene.background && scene.background.isColor) {
+      scene.background.copy(horizonte).lerp(fondoMadre.current, 0.6);
+    }
+    // hemisferio: cachea la luz una vez y tiñe su color de cielo un tercio hacia
+    // el cenit vivo (sin tocar intensidad ni groundColor: los fija la base).
+    if (!hemiRef.current) {
+      hemiRef.current = scene.getObjectByProperty('isHemisphereLight', true) || null;
+    }
+    if (hemiRef.current) {
+      tmpCielo.current.copy(baseCielo.current).lerp(zenit, 0.3);
+      hemiRef.current.color.copy(tmpCielo.current);
+    }
+  });
+  return null;
 }
 
 /* La luna: un disco pálido, quieto en su rincón. El cielo también tiene noche. */
@@ -259,6 +299,36 @@ const PISOS_DEF = [
   { nombre: 'páramo', color: '#9fb6bf', h: 0.8, r1: 0.42 },
 ];
 
+/* MICRO-RÓTULO tocable de la línea ámbar: le pone PALABRAS al retroceso glaciar
+   (un campesino no decodifica "aro ámbar = el hielo bajó"). Discreto —un punto
+   ámbar con su nota— y al tocarlo abre la consecuencia: con el calor los pisos
+   térmicos suben. Se ancla al frente del aro (hacia la cámara). Cuidado, no
+   alarma: el texto habla de "hasta aquí llegaba", nunca de catástrofe. */
+function RotuloHielo({ yAntes, rAntes }) {
+  const [abierto, setAbierto] = useState(false);
+  return (
+    <group position={[0, yAntes + 0.04, rAntes]}>
+      <Html center distanceFactor={9} zIndexRange={[16, 0]}>
+        <button
+          type="button"
+          className={`mundo-rotulo${abierto ? ' mundo-rotulo--abierto' : ''}`}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => { e.stopPropagation(); setAbierto((v) => !v); }}
+          aria-expanded={abierto}
+        >
+          <span className="mundo-rotulo__marca" aria-hidden="true" />
+          <span className="mundo-rotulo__txt">
+            Hasta aquí llegaba el hielo
+            {abierto && (
+              <em className="mundo-rotulo__mas"> — con el calor, los pisos térmicos suben.</em>
+            )}
+          </span>
+        </button>
+      </Html>
+    </group>
+  );
+}
+
 /* LA MONTAÑA: los cuatro pisos térmicos apilados como troncos de cono (paleta
    del mundo #4). Corona: el casquete de hielo + la LÍNEA ÁMBAR de hasta dónde
    llegaba el hielo (retroceso glaciar) — nota de conciencia, esperanza no colapso. */
@@ -304,6 +374,8 @@ function Montana({ pisos = PISOS_DEF, glaciar = {} }) {
         <torusGeometry args={[rAntes, 0.028, 6, 24]} />
         <meshBasicMaterial color={PALETA.ambar} transparent opacity={0.75} />
       </mesh>
+      {/* su rótulo tocable: le pone palabras a la línea ámbar */}
+      <RotuloHielo yAntes={yAntes} rAntes={rAntes} />
     </group>
   );
 }
@@ -333,6 +405,8 @@ function Diorama({ params, reducedMotion }) {
       </mesh>
 
       <Sol hora={hora} reducedMotion={reducedMotion} />
+      {/* el fondo y la luz de cielo atardecen con el sol (no en hora fija) */}
+      <CieloVivo hora={hora} reducedMotion={reducedMotion} />
       {!esDia && <Luna />}
       {esDia && hora < 0.55 && <Luna />}
 

--- a/src/visual/mundo3d/escenas/EscenaMercado.jsx
+++ b/src/visual/mundo3d/escenas/EscenaMercado.jsx
@@ -248,8 +248,9 @@ function Diorama({ params, reducedMotion }) {
       {/* la tarima del sello de procedencia (el terroir andino) */}
       <TarimaProcedencia pos={[-1.4, 0, -0.35]} />
 
-      {/* la balanza del precio justo */}
-      <Balanza pos={[0.15, 0.45, 0.55]} />
+      {/* la balanza del precio justo — posada en el empedrado (antes flotaba
+          ~0.45 sobre el piso sin mesa que la sostuviera). */}
+      <Balanza pos={[0.15, 0, 0.55]} />
 
       {/* la fauna que anima la feria (mariposa/colibrí) */}
       <Fauna items={FAUNA_MERCADO} reducedMotion={reducedMotion} />

--- a/src/visual/mundo3d/escenas/EscenaRecinto.jsx
+++ b/src/visual/mundo3d/escenas/EscenaRecinto.jsx
@@ -9,10 +9,38 @@
  * animal es primitivas orgánicas (esferas/conos/cápsulas), nunca cajas; con `tipo`
  * desconocido cae al esquemático (retrocompat). `MeshLambert`/`Basic`, sin sombras.
  */
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
 import { CIELOS, PALETA } from '../atmosferaMadre.js';
+
+/* Idle sutil de los animales del corral —el SUJETO del mundo—: reusa el mismo
+   patrón que `FaunaEscena.deriva` (useFrame + amplitudes chicas, vida no
+   espectáculo) pero sobre las MALLAS low-poly en vez de billboards. Cada especie
+   tiene su gesto: la gallina PICOTEA (zambullida corta hacia el suelo), la vaca
+   RESPIRA (escala y ±2%), la oveja se BALANCEA (mecerse lento). Gateado por
+   reduced-motion (frameloop='demand' ya congela; el gate lo hace explícito). El
+   `fase` desincroniza los animales para que no latan a la par. */
+function useIdlePecuario(kind, fase, reducedMotion) {
+  const ref = useRef(null);
+  useFrame((state) => {
+    if (reducedMotion || !ref.current) return;
+    const t = state.clock.elapsedTime;
+    if (kind === 'picotea') {
+      // la mayor parte del tiempo erguida; una zambullida breve del pico al suelo
+      const p = Math.max(0, Math.sin(t * 1.6 + fase));
+      ref.current.rotation.z = -(p ** 6) * 0.5;
+    } else if (kind === 'respira') {
+      // el fuelle del costillar: la altura del cuerpo late apenas (±2%)
+      ref.current.scale.y = 1 + Math.sin(t * 0.9 + fase) * 0.02;
+    } else if (kind === 'balancea') {
+      // el peso del vellón mece a la oveja de un lado a otro, muy lento
+      ref.current.rotation.z = Math.sin(t * 0.8 + fase) * 0.05;
+    }
+  });
+  return ref;
+}
 
 /* La fauna que acompaña el corral: el escarabajo estercolero junto a la pila de
    estiércol (cierra el ciclo del abono, literal), un colibrí que sobrevuela y
@@ -43,35 +71,39 @@ function Animalito({ pos, color }) {
 
 /* La gallina ponedora: cuerpo ovalado, cola alzada, cresta y pico. Primitivas
    orgánicas (esferas/conos), nada de cajas — mira hacia +x. */
-function Gallina({ pos, color = '#e7d9c2' }) {
+function Gallina({ pos, color = '#e7d9c2', reducedMotion = false, fase = 0 }) {
+  // el cuerpo picotea sobre las patas fijas (pivote en la base = raíz del grupo)
+  const ref = useIdlePecuario('picotea', fase, reducedMotion);
   return (
     <group position={pos}>
-      {/* cuerpo ovalado */}
-      <mesh position={[0, 0.2, 0]} scale={[1.25, 1, 1]}>
-        <sphereGeometry args={[0.16, 8, 6]} />
-        <meshLambertMaterial color={color} flatShading />
-      </mesh>
-      {/* cola alzada */}
-      <mesh position={[-0.16, 0.28, 0]} rotation={[0, 0, 0.9]}>
-        <coneGeometry args={[0.09, 0.2, 5]} />
-        <meshLambertMaterial color={color} flatShading />
-      </mesh>
-      {/* cabeza */}
-      <mesh position={[0.17, 0.34, 0]}>
-        <sphereGeometry args={[0.09, 8, 6]} />
-        <meshLambertMaterial color={color} flatShading />
-      </mesh>
-      {/* cresta (terracota natural, jamás rojo de alarma) */}
-      <mesh position={[0.17, 0.45, 0]}>
-        <coneGeometry args={[0.05, 0.1, 4]} />
-        <meshLambertMaterial color="#c85a44" flatShading />
-      </mesh>
-      {/* pico */}
-      <mesh position={[0.27, 0.33, 0]} rotation={[0, 0, -Math.PI / 2]}>
-        <coneGeometry args={[0.03, 0.09, 4]} />
-        <meshLambertMaterial color="#e0a63a" flatShading />
-      </mesh>
-      {/* patas */}
+      <group ref={ref}>
+        {/* cuerpo ovalado */}
+        <mesh position={[0, 0.2, 0]} scale={[1.25, 1, 1]}>
+          <sphereGeometry args={[0.16, 8, 6]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+        {/* cola alzada */}
+        <mesh position={[-0.16, 0.28, 0]} rotation={[0, 0, 0.9]}>
+          <coneGeometry args={[0.09, 0.2, 5]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+        {/* cabeza */}
+        <mesh position={[0.17, 0.34, 0]}>
+          <sphereGeometry args={[0.09, 8, 6]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+        {/* cresta (terracota natural, jamás rojo de alarma) */}
+        <mesh position={[0.17, 0.45, 0]}>
+          <coneGeometry args={[0.05, 0.1, 4]} />
+          <meshLambertMaterial color="#c85a44" flatShading />
+        </mesh>
+        {/* pico */}
+        <mesh position={[0.27, 0.33, 0]} rotation={[0, 0, -Math.PI / 2]}>
+          <coneGeometry args={[0.03, 0.09, 4]} />
+          <meshLambertMaterial color="#e0a63a" flatShading />
+        </mesh>
+      </group>
+      {/* patas (plantadas: el picoteo pivota sobre ellas) */}
       {[0.06, -0.06].map((z) => (
         <mesh key={z} position={[0.04, 0.05, z]}>
           <cylinderGeometry args={[0.015, 0.015, 0.14, 4]} />
@@ -84,70 +116,78 @@ function Gallina({ pos, color = '#e7d9c2' }) {
 
 /* La vaca de finca: cuerpo CAPSULAR horizontal, cabeza con hocico y orejas,
    cuatro patas y cola. Cápsula tumbada (rotación z) — el "cuerpo capsular" del DR. */
-function Vaca({ pos, color = '#c9a06a' }) {
+function Vaca({ pos, color = '#c9a06a', reducedMotion = false, fase = 0 }) {
+  // el costillar respira: la altura del cuerpo late ±2% (patas fijas al piso)
+  const ref = useIdlePecuario('respira', fase, reducedMotion);
   return (
     <group position={pos}>
-      {/* cuerpo capsular horizontal */}
-      <mesh position={[0, 0.46, 0]} rotation={[0, 0, Math.PI / 2]}>
-        <capsuleGeometry args={[0.22, 0.42, 4, 8]} />
-        <meshLambertMaterial color={color} flatShading />
-      </mesh>
-      {/* cabeza */}
-      <mesh position={[0.44, 0.5, 0]}>
-        <sphereGeometry args={[0.15, 8, 6]} />
-        <meshLambertMaterial color={color} flatShading />
-      </mesh>
-      {/* hocico */}
-      <mesh position={[0.56, 0.44, 0]}>
-        <sphereGeometry args={[0.09, 8, 6]} />
-        <meshLambertMaterial color="#e8d3bf" flatShading />
-      </mesh>
-      {/* orejas */}
-      {[0.12, -0.12].map((z) => (
-        <mesh key={z} position={[0.4, 0.62, z]} rotation={[z > 0 ? 0.5 : -0.5, 0, 0]}>
-          <coneGeometry args={[0.05, 0.12, 4]} />
+      <group ref={ref}>
+        {/* cuerpo capsular horizontal */}
+        <mesh position={[0, 0.46, 0]} rotation={[0, 0, Math.PI / 2]}>
+          <capsuleGeometry args={[0.22, 0.42, 4, 8]} />
           <meshLambertMaterial color={color} flatShading />
         </mesh>
-      ))}
-      {/* patas */}
+        {/* cabeza */}
+        <mesh position={[0.44, 0.5, 0]}>
+          <sphereGeometry args={[0.15, 8, 6]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+        {/* hocico */}
+        <mesh position={[0.56, 0.44, 0]}>
+          <sphereGeometry args={[0.09, 8, 6]} />
+          <meshLambertMaterial color="#e8d3bf" flatShading />
+        </mesh>
+        {/* orejas */}
+        {[0.12, -0.12].map((z) => (
+          <mesh key={z} position={[0.4, 0.62, z]} rotation={[z > 0 ? 0.5 : -0.5, 0, 0]}>
+            <coneGeometry args={[0.05, 0.12, 4]} />
+            <meshLambertMaterial color={color} flatShading />
+          </mesh>
+        ))}
+        {/* cola */}
+        <mesh position={[-0.42, 0.34, 0]} rotation={[0, 0, 0.4]}>
+          <cylinderGeometry args={[0.02, 0.02, 0.34, 4]} />
+          <meshLambertMaterial color={PALETA.tierraClara} flatShading />
+        </mesh>
+      </group>
+      {/* patas (plantadas mientras el cuerpo respira) */}
       {[[0.28, 0.13], [0.28, -0.13], [-0.28, 0.13], [-0.28, -0.13]].map(([x, z], i) => (
         <mesh key={i} position={[x, 0.18, z]}>
           <cylinderGeometry args={[0.045, 0.04, 0.36, 5]} />
           <meshLambertMaterial color={PALETA.tierraClara} flatShading />
         </mesh>
       ))}
-      {/* cola */}
-      <mesh position={[-0.42, 0.34, 0]} rotation={[0, 0, 0.4]}>
-        <cylinderGeometry args={[0.02, 0.02, 0.34, 4]} />
-        <meshLambertMaterial color={PALETA.tierraClara} flatShading />
-      </mesh>
     </group>
   );
 }
 
 /* La oveja: vellón como cuerpo FACETADO (icosaedro low-poly = lana), cabeza y
    patas oscuras. El facetado es la lana, sin texturas ni cajas. */
-function Oveja({ pos, color = '#efe7d8' }) {
+function Oveja({ pos, color = '#efe7d8', reducedMotion = false, fase = 0 }) {
+  // el peso del vellón la mece lento de lado a lado (patas fijas)
+  const ref = useIdlePecuario('balancea', fase, reducedMotion);
   return (
     <group position={pos}>
-      {/* vellón (icosaedro low-poly, flatShading = lana) */}
-      <mesh position={[0, 0.34, 0]} scale={[1.2, 1, 1]}>
-        <icosahedronGeometry args={[0.22, 0]} />
-        <meshLambertMaterial color={color} flatShading />
-      </mesh>
-      {/* cabeza oscura */}
-      <mesh position={[0.28, 0.36, 0]}>
-        <sphereGeometry args={[0.1, 8, 6]} />
-        <meshLambertMaterial color="#5a4a3e" flatShading />
-      </mesh>
-      {/* orejas */}
-      {[0.08, -0.08].map((z) => (
-        <mesh key={z} position={[0.28, 0.44, z]} rotation={[0, 0, z > 0 ? -0.6 : 0.6]}>
-          <coneGeometry args={[0.03, 0.1, 4]} />
+      <group ref={ref}>
+        {/* vellón (icosaedro low-poly, flatShading = lana) */}
+        <mesh position={[0, 0.34, 0]} scale={[1.2, 1, 1]}>
+          <icosahedronGeometry args={[0.22, 0]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+        {/* cabeza oscura */}
+        <mesh position={[0.28, 0.36, 0]}>
+          <sphereGeometry args={[0.1, 8, 6]} />
           <meshLambertMaterial color="#5a4a3e" flatShading />
         </mesh>
-      ))}
-      {/* patas */}
+        {/* orejas */}
+        {[0.08, -0.08].map((z) => (
+          <mesh key={z} position={[0.28, 0.44, z]} rotation={[0, 0, z > 0 ? -0.6 : 0.6]}>
+            <coneGeometry args={[0.03, 0.1, 4]} />
+            <meshLambertMaterial color="#5a4a3e" flatShading />
+          </mesh>
+        ))}
+      </group>
+      {/* patas (plantadas mientras el vellón se mece) */}
       {[[0.14, 0.1], [0.14, -0.1], [-0.14, 0.1], [-0.14, -0.1]].map(([x, z], i) => (
         <mesh key={i} position={[x, 0.12, z]}>
           <cylinderGeometry args={[0.03, 0.03, 0.24, 4]} />
@@ -161,9 +201,11 @@ function Oveja({ pos, color = '#efe7d8' }) {
 /* Dispatcher por especie: cada animal se dibuja según su `tipo`; si no se
    reconoce, cae al esquemático `Animalito` (retrocompat, nunca una caja). */
 const ANIMALES_CORRAL = { gallina: Gallina, vaca: Vaca, oveja: Oveja };
-function AnimalDeCorral({ tipo, pos, color }) {
+function AnimalDeCorral({ tipo, pos, color, reducedMotion, fase }) {
   const Comp = ANIMALES_CORRAL[tipo];
-  return Comp ? <Comp pos={pos} color={color} /> : <Animalito pos={pos} color={color} />;
+  return Comp
+    ? <Comp pos={pos} color={color} reducedMotion={reducedMotion} fase={fase} />
+    : <Animalito pos={pos} color={color} />;
 }
 
 function Diorama({ params, reducedMotion }) {
@@ -205,7 +247,14 @@ function Diorama({ params, reducedMotion }) {
         <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
       </mesh>
       {animales.map((a, i) => (
-        <AnimalDeCorral key={i} tipo={a.tipo} pos={a.pos} color={a.color} />
+        <AnimalDeCorral
+          key={i}
+          tipo={a.tipo}
+          pos={a.pos}
+          color={a.color}
+          reducedMotion={reducedMotion}
+          fase={i * 1.7}
+        />
       ))}
       {/* aves e insectos que animan el corral (escarabajo en el abono) */}
       <Fauna items={FAUNA_RECINTO} reducedMotion={reducedMotion} />

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -16,7 +16,7 @@
    coreografía + su componente de escena) se importa SIEMPRE perezoso dentro de
    un <Canvas> vía EscenaBase3D; no es hot-reload-sensible. Van juntos a propósito:
    la creature posee el cuerpo, la escena posee la coreografía (contrato del DR). */
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import * as THREE from 'three';
@@ -90,23 +90,48 @@ export function useEntradaAbeja(foco, {
 
 /**
  * Angelita ya montada en una escena: usa `useEntradaAbeja` para la coreografía y
- * dibuja el cuerpo (`AbejaAngelita`) como billboard `<Html>`. Cualquier arquetipo
- * la coloca con `<AbejaEscena foco=… animo=… energia=… reducedMotion=… />`.
+ * dibuja el cuerpo (`AbejaAngelita`) como billboard `<Html>`. Es la ÚNICA abeja
+ * dentro de un mundo (la del footer se oculta): por eso REFLEJA EL HABLA —pulsa
+ * cuando el agente narra (`hablando`)— y da un microrrebote al tocar un hotspot
+ * (`rebote`, un contador que sube por toque). Tres transformaciones en tres capas
+ * DOM que no se pisan: pulso (raíz), rebote (medio), volteo scaleX (cara, que el
+ * useFrame maneja imperativo). Cualquier arquetipo la coloca con
+ * `<AbejaEscena foco=… animo=… energia=… hablando=… rebote=… reducedMotion=… />`.
  */
 export function AbejaEscena({
   foco, entrando = true, animo = 'sereno', energia = 1, reducedMotion = false, piso = 0,
+  hablando = false, rebote = 0,
 }) {
   const { ref, caraRef, sombraRef } = useEntradaAbeja(foco, {
     entrando, energia, reducedMotion, piso,
   });
+  // Microrrebote: cada toque de hotspot sube `rebote`; reiniciamos la animación
+  // CSS (quitar → reflow → poner) para que dispare aun en toques seguidos. El
+  // gate reduced-motion la deja quieta.
+  const reboteRef = useRef(null);
+  useEffect(() => {
+    if (reducedMotion || rebote === 0 || !reboteRef.current) return undefined;
+    const el = reboteRef.current;
+    el.removeAttribute('data-rebote');
+    void el.offsetWidth; // fuerza reflow → reinicia el keyframe
+    el.setAttribute('data-rebote', '1');
+    const t = setTimeout(() => el.removeAttribute('data-rebote'), 640);
+    return () => clearTimeout(t);
+  }, [rebote, reducedMotion]);
   const size = 40 + Math.round(energia * 12);
   return (
     <>
       <group ref={ref} position={[foco.x + 0.45, foco.y + 0.85, foco.z + 0.6]}>
         <Html center distanceFactor={7} zIndexRange={[40, 10]}>
-          <div className="mundo-abeja" aria-hidden="true">
-            <div ref={caraRef} className="mundo-abeja__cara">
-              <AbejaAngelita size={size} animo={animo} energia={energia} animated={!reducedMotion} />
+          <div
+            className="mundo-abeja"
+            aria-hidden="true"
+            data-hablando={hablando && !reducedMotion ? '1' : undefined}
+          >
+            <div ref={reboteRef} className="mundo-abeja__rebote">
+              <div ref={caraRef} className="mundo-abeja__cara">
+                <AbejaAngelita size={size} animo={animo} energia={energia} animated={!reducedMotion} />
+              </div>
             </div>
           </div>
         </Html>

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -80,13 +80,81 @@
 }
 
 /* ── Angelita dentro de la escena (billboard) ──────────────────────────── */
+/* Tres capas para tres gestos que NO se pisan: la raíz PULSA al narrar, la capa
+   media REBOTA al toque, la cara VOLTEA (scaleX imperativo por frame). */
 .mundo-abeja {
   pointer-events: none;
   filter: drop-shadow(0 4px 8px rgba(40, 30, 10, 0.28));
+  transform-origin: center bottom;
+}
+.mundo-abeja__rebote {
+  transform-origin: center bottom;
 }
 .mundo-abeja__cara {
   transition: transform 0.2s ease;
   transform-origin: center;
+}
+/* Habla: mientras el agente narra, la única abeja del mundo PULSA suave —refleja
+   la voz en la escena, ya no una abeja muda de adorno (una compañera = una voz). */
+.mundo-abeja[data-hablando='1'] {
+  animation: mundo-abeja-habla 0.62s ease-in-out infinite;
+}
+@keyframes mundo-abeja-habla {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.09); }
+}
+/* Microrrebote: brinquito con squash al tocar un hotspot (carácter de compañera:
+   acusa el toque, ref. el zorro de Ori / el ganso de Untitled Goose). */
+.mundo-abeja__rebote[data-rebote='1'] {
+  animation: mundo-abeja-rebote 0.64s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes mundo-abeja-rebote {
+  0% { transform: translateY(0) scale(1, 1); }
+  30% { transform: translateY(-8px) scale(1.12, 0.9); }
+  55% { transform: translateY(0) scale(0.94, 1.08); }
+  78% { transform: translateY(-2px) scale(1.02, 0.98); }
+  100% { transform: translateY(0) scale(1, 1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mundo-abeja[data-hablando='1'],
+  .mundo-abeja__rebote[data-rebote='1'] { animation: none; }
+}
+
+/* ── Micro-rótulo tocable del retroceso glaciar (bóveda) ────────────────── */
+/* Le pone PALABRAS a la línea ámbar del hielo: discreto (un punto ámbar + nota),
+   y al tocarlo abre la consecuencia (los pisos térmicos suben). Cuidado, no
+   alarma: ámbar cálido, jamás rojo. */
+.mundo-rotulo {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: 12rem;
+  padding: 0.18rem 0.5rem 0.18rem 0.34rem;
+  border: 1px solid rgba(217, 161, 59, 0.55);
+  border-radius: 999px;
+  background: rgba(28, 22, 12, 0.66);
+  color: #f4e2bf;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.15;
+  text-align: left;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.32);
+}
+.mundo-rotulo__marca {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #d9a13b;
+  box-shadow: 0 0 6px rgba(217, 161, 59, 0.8);
+}
+.mundo-rotulo__mas {
+  font-style: normal;
+  font-weight: 500;
+  opacity: 0.9;
 }
 
 /* ── Fauna de la librería sembrada en la escena (billboard decorativo) ───── */


### PR DESCRIPTION
Arreglos VISUALES / game-feel de la auditoría triple de los mundos 3D. Todo gateado por reduced-motion; verificado con `npm run build` (verde).

## Qué se arregló

1. **Corral estático (P2)** — `EscenaRecinto`: los animales del corral (el SUJETO del mundo) eran geometría muerta mientras la fauna incidental se movía. Ahora tienen idle sutil reusando el patrón `FaunaEscena` (`useFrame` + amplitudes chicas): la **gallina picotea** (zambullida del pico), la **vaca respira** (escala y ±2%), la **oveja se balancea**. Patas fijas; el cuerpo pivota. `fase` desincroniza.
2. **Doble Angelita (P2)** — dentro de un mundo se veían DOS abejas (la decorativa de escena + el compañero del footer). Fusionadas: la abeja de **escena** es la única compañera y **pulsa al narrar**; la del footer se **oculta** dentro del mundo (el chip queda como su burbuja de voz). Se enhebra `hablando` valle → `Mundo` → escena.
3. **Carácter de Angelita (spec S2)** — **microrrebote** al tocar un hotspot + **idle propio** cuando no hay foco (`entrando` dejó de estar hardcodeado en `EscenaBase3D`: con foco se posa junto a la puerta, sin foco ronda). Tres transformaciones DOM en capas que no se pisan (pulso / rebote / volteo).
4. **Cielo desincronizado (P2)** — `EscenaBoveda`: el sol auto-avanzaba su arco pero el fondo/hemisferio estaban en hora fija memoizada. Nuevo `CieloVivo`: el `<color>` de fondo y el color de la luz de cielo siguen la **p viva del sol** (barato, no regenera la malla del gradiente). "El color del cielo ES la hora".
5. **Balanza flotando (P2)** — `EscenaMercado`: la balanza flotaba ~0.45 sobre el empedrado sin mesa. Bajada a `y=0` (posada en el piso).
6. **Clima sin rótulo (P2)** — micro-rótulo **tocable** en la línea ámbar del retroceso glaciar ("Hasta aquí llegaba el hielo"); al abrir explica que **los pisos térmicos suben** con el calor. Antes era señal muda que un campesino no decodifica. Cuidado, no alarma (ámbar, jamás rojo).
7. **Comentario stale (P3)** — `valleData.js`: el compañero es **abeja**, no colibrí.

## Notas
- Reduced-motion: todo idle/pulso/rebote/cielo-vivo se congela (gate explícito además del `frameloop='demand'`).
- Sin geometría regenerada por frame; sin GLTF/post/sombras (contrato de `EscenaBase3D` intacto).
- El test `entradaValle3D.nav.test.jsx` sigue verde: consulta `.valle-companero` solo tras dispararse la narración (`dicho` presente), y el chip in-mundo se mantiene como burbuja de voz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)