### PR TITLE
fix(mundo3d): reduced-motion en equipo alto monta 3D quieto, no 2D plano

### DIFF
--- a/src/visual/mundo3d/deviceTier.js
+++ b/src/visual/mundo3d/deviceTier.js
@@ -6,18 +6,29 @@
  * débil: poca RAM, pocos núcleos, ahorro de datos o menos-movimiento. Devuelve un
  * `tier` que el host `<Mundo>` usa para decidir 3D vs 2D:
  *
- *   'alto'  → 3D pleno.
+ *   'alto'  → 3D pleno. Con `prefers-reduced-motion` NO cae a 2D: monta el 3D
+ *             QUIETO (cada escena ya tiene su gate `if (reducedMotion)` que
+ *             apaga Sol/Lluvia/Nube/Gotas/abeja; el diorama queda congelado).
  *   'medio' → 3D frugal (los arquetipos ya son frugales por contrato: sin
  *             sombras, MeshLambert/Basic, DPR≤1.5 — DR §6).
- *   'bajo'  → 2D digno (sin-WebGL, poca RAM/CPU, saveData, reduced-motion).
+ *   'bajo'  → 2D digno (sin-WebGL, poca RAM/CPU, saveData; o reduced-motion
+ *             en equipo que no llega a 'alto').
+ *
+ * REDUCED-MOTION ≠ EQUIPO DÉBIL: pedir calma es una preferencia de
+ * accesibilidad, no una señal de hardware. Colapsarla a 'bajo' forzaba al
+ * usuario a11y con equipo capaz al 2D plano y dejaba MUERTO el manejo
+ * reduced-motion dentro de las escenas 3D. Ahora el tier se decide por el
+ * equipo y `reducedMotion` viaja como flag aparte: en 'alto' el 3D monta
+ * congelado; en gama media/baja se mantiene el 2D digno (el 3D frugal igual
+ * exige GPU sostenida y el 2D calmo ya cumple la preferencia).
  *
  * Misma lógica que `decidirRender()` del mockup del valle, pero graduada en tres
  * niveles (aquel decide binario 2d/3d). Es la fuente de verdad del framework.
  */
 
-/** @returns {{ tier: 'alto'|'medio'|'bajo', motivo: string }} */
+/** @returns {{ tier: 'alto'|'medio'|'bajo', motivo: string, reducedMotion: boolean }} */
 export function decidirTier() {
-  if (typeof window === 'undefined') return { tier: 'bajo', motivo: 'ssr' };
+  if (typeof window === 'undefined') return { tier: 'bajo', motivo: 'ssr', reducedMotion: false };
 
   /* `deviceMemory`/`connection` son APIs experimentales que la lib de tipos del
      DOM aún no declara; se tipan aquí como opcionales (sin `any`). */
@@ -25,6 +36,12 @@ export function decidirTier() {
     /** @type {Navigator & { deviceMemory?: number, connection?: { saveData?: boolean }, mozConnection?: { saveData?: boolean }, webkitConnection?: { saveData?: boolean } }} */ (
       window.navigator
     );
+
+  // La preferencia de calma se detecta UNA vez y viaja en el resultado: es
+  // insumo de ruteo (abajo) y flag para el host (que la pasa a `<Mundo>`).
+  const menosMov =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   // 1) WebGL es requisito DURO del 3D.
   let webgl = false;
@@ -37,29 +54,35 @@ export function decidirTier() {
   } catch {
     webgl = false;
   }
-  if (!webgl) return { tier: 'bajo', motivo: 'sin-webgl' };
+  if (!webgl) return { tier: 'bajo', motivo: 'sin-webgl', reducedMotion: menosMov };
 
-  // 2) El usuario pidió ahorrar datos o menos movimiento → respetarlo.
+  // 2) El usuario pidió ahorrar datos → respetarlo (el chunk 3D pesa; esto sí
+  //    es de recursos, no de movimiento).
   const conn = nav.connection || nav.mozConnection || nav.webkitConnection;
-  if (conn && conn.saveData) return { tier: 'bajo', motivo: 'ahorro' };
-  const menosMov =
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (menosMov) return { tier: 'bajo', motivo: 'calma' };
+  if (conn && conn.saveData) return { tier: 'bajo', motivo: 'ahorro', reducedMotion: menosMov };
 
   // 3) Equipos humildes → 2D (no los ponemos a sudar la GPU).
   const mem = nav.deviceMemory; // GiB aprox. (Chrome/Android); undefined en otros
-  if (typeof mem === 'number' && mem > 0 && mem <= 3) return { tier: 'bajo', motivo: 'equipo' };
+  if (typeof mem === 'number' && mem > 0 && mem <= 3) {
+    return { tier: 'bajo', motivo: 'equipo', reducedMotion: menosMov };
+  }
   const nucleos = nav.hardwareConcurrency;
   if (typeof nucleos === 'number' && nucleos > 0 && nucleos <= 4) {
-    return { tier: 'bajo', motivo: 'equipo' };
+    return { tier: 'bajo', motivo: 'equipo', reducedMotion: menosMov };
   }
 
   // 4) Gama media declarada → 3D frugal; el resto, 3D pleno.
-  if ((typeof mem === 'number' && mem <= 6) || (typeof nucleos === 'number' && nucleos <= 6)) {
-    return { tier: 'medio', motivo: 'ok' };
+  const tierEquipo =
+    (typeof mem === 'number' && mem <= 6) || (typeof nucleos === 'number' && nucleos <= 6)
+      ? 'medio'
+      : 'alto';
+
+  // 5) Menos movimiento: en equipo 'alto' el 3D monta QUIETO (las escenas ya
+  //    se congelan solas con el flag); en gama media, 2D digno y calmo.
+  if (menosMov && tierEquipo !== 'alto') {
+    return { tier: 'bajo', motivo: 'calma', reducedMotion: true };
   }
-  return { tier: 'alto', motivo: 'ok' };
+  return { tier: tierEquipo, motivo: menosMov ? 'calma' : 'ok', reducedMotion: menosMov };
 }
 
 /** ¿Este tier puede montar una escena 3D? (bajo y '2d' forzado → no). */


### PR DESCRIPTION
## Bug P1 (auditoría triple)

`decidirTier()` colapsaba a `'bajo'` (2D plano) a todo usuario con `prefers-reduced-motion`, sin mirar el equipo. Consecuencias:

- Los gates `if (reducedMotion) return` dentro de las escenas 3D (Sol/Lluvia/Nube/Gotas/abeja) eran **código muerto** — con el flag activo nunca se montaba una escena 3D.
- Un usuario de accesibilidad con equipo capaz quedaba forzado al 2D plano, en vez del **3D congelado** (sin animación) que ya está implementado.
- El botón "Ver en 3D" desaparecía (`puede3D=false`) para esos usuarios.

## Fix

Reduced-motion ≠ equipo débil: el tier se decide por el hardware y la calma viaja como flag aparte.

- Equipo **'alto'** + reduced-motion → `{ tier: 'alto', motivo: 'calma', reducedMotion: true }`: la escena 3D monta **quieta** (las animaciones se auto-desactivan por los gates existentes) y el botón "Ver en 3D" reaparece.
- Gama **media/baja**, `saveData` o sin WebGL → 2D digno, igual que antes (el 3D frugal igual exige GPU sostenida; el 2D calmo cumple la preferencia).
- `decidirTier()` ahora retorna también `reducedMotion: boolean`; los hosts existentes ya calculan y propagan el flag a `<Mundo>`, así que no requieren cambios.

## Verificación

- `npm run build` verde (11.98s; warnings de chunks preexistentes).
- Smoke tests de vitrinas intactos: en jsdom el tier sigue cayendo por `sin-webgl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)