### PR TITLE
fix(mockups): vitrinas 3D con capa acompañante — Angelita narra, nunca mudas

### DIFF
--- a/src/mockups/Mundo3DAgua.jsx
+++ b/src/mockups/Mundo3DAgua.jsx
@@ -18,7 +18,8 @@
  * español de Colombia, en "usted".
  */
 import { useMemo, useState } from 'react';
-import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
 import './Mundo3DAgua.css';
 
 const TINTE = ['#2f7fa3', '#d7ecf3'];
@@ -48,15 +49,10 @@ export default function Mundo3DAgua() {
   const [ver2d, setVer2d] = useState(false);
   const tier = ver2d ? 'bajo' : decision.tier;
 
-  // En la vitrina (sin sesión) un punto del recorrido no navega: cuenta a qué
-  // pantalla real de la app lleva esa puerta.
-  const [puerta, setPuerta] = useState(null);
-  const onHotspot = (view, data) => {
-    const hs = (MUNDO.agua.hotspots || []).find(
-      (h) => h.view === view && (h.data === data || (!h.data && !data)),
-    ) || (MUNDO.agua.hotspots || []).find((h) => h.view === view);
-    setPuerta({ label: hs?.label || view, view });
-  };
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('agua');
 
   return (
     <main
@@ -73,15 +69,18 @@ export default function Mundo3DAgua() {
       </header>
 
       <section className="m3da__escena" aria-label="El recorrido del agua de la finca">
-        <Mundo
-          mundoId="agua"
-          tier={tier}
-          reducedMotion={reducedMotion}
-          onHotspot={onHotspot}
-          onSalir={null}
-          animo="sereno"
-          energia={0.85}
-        />
+        <AcompananteMundo mundoId="agua" acompanante={acompanante}>
+          <Mundo
+            mundoId="agua"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="sereno"
+            energia={0.85}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
         <div className="m3da__barra">
           <p className="m3da__tier">
             {tier === 'bajo'
@@ -98,11 +97,7 @@ export default function Mundo3DAgua() {
             </button>
           )}
         </div>
-        <p className="m3da__nota" role="status" aria-live="polite">
-          {puerta
-            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
-            : 'Toque un punto del recorrido para ver a dónde lo lleva.'}
-        </p>
+        <p className="m3da__nota">Toque un punto del recorrido para ver a dónde lo lleva.</p>
       </section>
 
       <section className="m3da__leyenda" aria-label="El recorrido, punto por punto">

--- a/src/mockups/Mundo3DAnimales.jsx
+++ b/src/mockups/Mundo3DAnimales.jsx
@@ -21,7 +21,8 @@
  * español de Colombia, en "usted".
  */
 import { useMemo, useState } from 'react';
-import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
 import './Mundo3DAnimales.css';
 
 const TINTE = ['#a86a3a', '#f3e3cf'];
@@ -51,15 +52,10 @@ export default function Mundo3DAnimales() {
   const [ver2d, setVer2d] = useState(false);
   const tier = ver2d ? 'bajo' : decision.tier;
 
-  // En la vitrina (sin sesión) un punto del corral no navega: cuenta a qué
-  // pantalla real de la app lleva esa puerta.
-  const [puerta, setPuerta] = useState(null);
-  const onHotspot = (view, data) => {
-    const hs = (MUNDO.animales.hotspots || []).find(
-      (h) => h.view === view && (h.data === data || (!h.data && !data)),
-    ) || (MUNDO.animales.hotspots || []).find((h) => h.view === view);
-    setPuerta({ label: hs?.label || view, view });
-  };
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('animales');
 
   return (
     <main
@@ -77,15 +73,18 @@ export default function Mundo3DAnimales() {
       </header>
 
       <section className="m3dan__escena" aria-label="El corral y el ciclo del abono de la finca">
-        <Mundo
-          mundoId="animales"
-          tier={tier}
-          reducedMotion={reducedMotion}
-          onHotspot={onHotspot}
-          onSalir={null}
-          animo="sereno"
-          energia={0.85}
-        />
+        <AcompananteMundo mundoId="animales" acompanante={acompanante}>
+          <Mundo
+            mundoId="animales"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="sereno"
+            energia={0.85}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
         <div className="m3dan__barra">
           <p className="m3dan__tier">
             {tier === 'bajo'
@@ -102,11 +101,7 @@ export default function Mundo3DAnimales() {
             </button>
           )}
         </div>
-        <p className="m3dan__nota" role="status" aria-live="polite">
-          {puerta
-            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
-            : 'Toque un punto del corral para ver a dónde lo lleva.'}
-        </p>
+        <p className="m3dan__nota">Toque un punto del corral para ver a dónde lo lleva.</p>
       </section>
 
       <section className="m3dan__leyenda" aria-label="El ciclo del abono, eslabón por eslabón">

--- a/src/mockups/Mundo3DBosque.jsx
+++ b/src/mockups/Mundo3DBosque.jsx
@@ -22,7 +22,8 @@
  * español de Colombia, en "usted".
  */
 import { useMemo, useState } from 'react';
-import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
 import './Mundo3DBosque.css';
 
 const TINTE = ['#4f8f7d', '#e6efe9'];
@@ -51,15 +52,10 @@ export default function Mundo3DBosque() {
   const [ver2d, setVer2d] = useState(false);
   const tier = ver2d ? 'bajo' : decision.tier;
 
-  // En la vitrina (sin sesión) un punto de la ladera no navega: cuenta a qué
-  // pantalla real de la app lleva esa puerta.
-  const [puerta, setPuerta] = useState(null);
-  const onHotspot = (view, data) => {
-    const hs = (MUNDO.pisos.hotspots || []).find(
-      (h) => h.view === view && (h.data === data || (!h.data && !data)),
-    ) || (MUNDO.pisos.hotspots || []).find((h) => h.view === view);
-    setPuerta({ label: hs?.label || view, view });
-  };
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('pisos');
 
   return (
     <main
@@ -76,15 +72,18 @@ export default function Mundo3DBosque() {
       </header>
 
       <section className="m3db__escena" aria-label="La ladera andina y sus pisos térmicos">
-        <Mundo
-          mundoId="pisos"
-          tier={tier}
-          reducedMotion={reducedMotion}
-          onHotspot={onHotspot}
-          onSalir={null}
-          animo="sereno"
-          energia={0.85}
-        />
+        <AcompananteMundo mundoId="pisos" acompanante={acompanante}>
+          <Mundo
+            mundoId="pisos"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="sereno"
+            energia={0.85}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
         <div className="m3db__barra">
           <p className="m3db__tier">
             {tier === 'bajo'
@@ -101,11 +100,7 @@ export default function Mundo3DBosque() {
             </button>
           )}
         </div>
-        <p className="m3db__nota" role="status" aria-live="polite">
-          {puerta
-            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
-            : 'Toque un piso de la ladera para ver a dónde lo lleva.'}
-        </p>
+        <p className="m3db__nota">Toque un piso de la ladera para ver a dónde lo lleva.</p>
       </section>
 
       <section className="m3db__leyenda" aria-label="La ladera, piso por piso">

--- a/src/mockups/Mundo3DClima.jsx
+++ b/src/mockups/Mundo3DClima.jsx
@@ -20,7 +20,8 @@
  * español de Colombia, en "usted".
  */
 import { useMemo, useState } from 'react';
-import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
 import './Mundo3DClima.css';
 
 const TINTE = ['#4c7fa0', '#dce9f2'];
@@ -50,16 +51,10 @@ export default function Mundo3DClima() {
   const [ver2d, setVer2d] = useState(false);
   const tier = ver2d ? 'bajo' : decision.tier;
 
-  // En la vitrina (sin sesión) un punto del cielo no navega: cuenta a qué
-  // pantalla real de la app lleva esa puerta.
-  const [puerta, setPuerta] = useState(null);
-  const onHotspot = (view, data) => {
-    const hs =
-      (MUNDO.clima.hotspots || []).find(
-        (h) => h.view === view && (h.data === data || (!h.data && !data)),
-      ) || (MUNDO.clima.hotspots || []).find((h) => h.view === view);
-    setPuerta({ label: hs?.label || view, view });
-  };
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('clima');
 
   return (
     <main className="m3dc" style={{ '--m3dc-a': TINTE[0], '--m3dc-b': TINTE[1] }}>
@@ -74,15 +69,18 @@ export default function Mundo3DClima() {
       </header>
 
       <section className="m3dc__escena" aria-label="El cielo de la finca">
-        <Mundo
-          mundoId="clima"
-          tier={tier}
-          reducedMotion={reducedMotion}
-          onHotspot={onHotspot}
-          onSalir={null}
-          animo="sereno"
-          energia={0.85}
-        />
+        <AcompananteMundo mundoId="clima" acompanante={acompanante}>
+          <Mundo
+            mundoId="clima"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="sereno"
+            energia={0.85}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
         <div className="m3dc__barra">
           <p className="m3dc__tier">
             {tier === 'bajo'
@@ -99,11 +97,7 @@ export default function Mundo3DClima() {
             </button>
           )}
         </div>
-        <p className="m3dc__nota" role="status" aria-live="polite">
-          {puerta
-            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
-            : 'Toque un punto del cielo para ver a dónde lo lleva.'}
-        </p>
+        <p className="m3dc__nota">Toque un punto del cielo para ver a dónde lo lleva.</p>
       </section>
 
       <section className="m3dc__leyenda" aria-label="El cielo, punto por punto">

--- a/src/mockups/Mundo3DMercado.jsx
+++ b/src/mockups/Mundo3DMercado.jsx
@@ -22,7 +22,8 @@
  * español de Colombia, en "usted".
  */
 import { useMemo, useState } from 'react';
-import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
 import './Mundo3DMercado.css';
 
 const TINTE = ['#b98a2f', '#f7ecd2'];
@@ -72,15 +73,10 @@ export default function Mundo3DMercado() {
   const [ver2d, setVer2d] = useState(false);
   const tier = ver2d ? 'bajo' : decision.tier;
 
-  // En la vitrina (sin sesión) un punto de la plaza no navega: cuenta a qué
-  // pantalla real de la app lleva esa puerta.
-  const [puerta, setPuerta] = useState(null);
-  const onHotspot = (view, data) => {
-    const hs = (MUNDO.mercado.hotspots || []).find(
-      (h) => h.view === view && (h.data === data || (!h.data && !data)),
-    ) || (MUNDO.mercado.hotspots || []).find((h) => h.view === view);
-    setPuerta({ label: hs?.label || view, view });
-  };
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('mercado');
 
   return (
     <main
@@ -99,15 +95,18 @@ export default function Mundo3DMercado() {
       </header>
 
       <section className="m3dmer__escena" aria-label="El mercado campesino de la finca">
-        <Mundo
-          mundoId="mercado"
-          tier={tier}
-          reducedMotion={reducedMotion}
-          onHotspot={onHotspot}
-          onSalir={null}
-          animo="alegre"
-          energia={0.95}
-        />
+        <AcompananteMundo mundoId="mercado" acompanante={acompanante}>
+          <Mundo
+            mundoId="mercado"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="alegre"
+            energia={0.95}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
         <div className="m3dmer__barra">
           <p className="m3dmer__tier">
             {tier === 'bajo'
@@ -124,11 +123,7 @@ export default function Mundo3DMercado() {
             </button>
           )}
         </div>
-        <p className="m3dmer__nota" role="status" aria-live="polite">
-          {puerta
-            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
-            : 'Toque un punto de la plaza para ver a dónde lo lleva.'}
-        </p>
+        <p className="m3dmer__nota">Toque un punto de la plaza para ver a dónde lo lleva.</p>
       </section>
 
       <section className="m3dmer__leyenda" aria-label="El mercado, pieza por pieza">

--- a/src/mockups/Mundo3DMilpa.jsx
+++ b/src/mockups/Mundo3DMilpa.jsx
@@ -20,7 +20,8 @@
  * español de Colombia, en "usted".
  */
 import { useMemo, useState } from 'react';
-import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
 import './Mundo3DMilpa.css';
 
 const TINTE = ['#5f8f3f', '#eef0cf'];
@@ -50,15 +51,10 @@ export default function Mundo3DMilpa() {
   const [ver2d, setVer2d] = useState(false);
   const tier = ver2d ? 'bajo' : decision.tier;
 
-  // En la vitrina (sin sesión) un punto del corte no navega: cuenta a qué
-  // pantalla real de la app lleva esa puerta.
-  const [puerta, setPuerta] = useState(null);
-  const onHotspot = (view, data) => {
-    const hs = (MUNDO.milpa.hotspots || []).find(
-      (h) => h.view === view && (h.data === data || (!h.data && !data)),
-    ) || (MUNDO.milpa.hotspots || []).find((h) => h.view === view);
-    setPuerta({ label: hs?.label || view, view });
-  };
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('milpa');
 
   return (
     <main
@@ -77,15 +73,18 @@ export default function Mundo3DMilpa() {
       </header>
 
       <section className="m3dm__escena" aria-label="El corte de la milpa: las tres hermanas y los nódulos de nitrógeno">
-        <Mundo
-          mundoId="milpa"
-          tier={tier}
-          reducedMotion={reducedMotion}
-          onHotspot={onHotspot}
-          onSalir={null}
-          animo="sereno"
-          energia={0.9}
-        />
+        <AcompananteMundo mundoId="milpa" acompanante={acompanante}>
+          <Mundo
+            mundoId="milpa"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="sereno"
+            energia={0.9}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
         <div className="m3dm__barra">
           <p className="m3dm__tier">
             {tier === 'bajo'
@@ -102,11 +101,7 @@ export default function Mundo3DMilpa() {
             </button>
           )}
         </div>
-        <p className="m3dm__nota" role="status" aria-live="polite">
-          {puerta
-            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
-            : 'Toque un punto del corte para ver a dónde lo lleva.'}
-        </p>
+        <p className="m3dm__nota">Toque un punto del corte para ver a dónde lo lleva.</p>
       </section>
 
       <section className="m3dm__leyenda" aria-label="La milpa, hermana por hermana">

--- a/src/mockups/Mundo3DSanidad.jsx
+++ b/src/mockups/Mundo3DSanidad.jsx
@@ -22,7 +22,8 @@
  * español de Colombia, en "usted".
  */
 import { useMemo, useState } from 'react';
-import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
 import './Mundo3DSanidad.css';
 
 const TINTE = ['#b0532f', '#f6ded1'];
@@ -72,15 +73,10 @@ export default function Mundo3DSanidad() {
   const [ver2d, setVer2d] = useState(false);
   const tier = ver2d ? 'bajo' : decision.tier;
 
-  // En la vitrina (sin sesión) un punto del recinto no navega: cuenta a qué
-  // pantalla real de la app lleva esa puerta.
-  const [puerta, setPuerta] = useState(null);
-  const onHotspot = (view, data) => {
-    const hs = (MUNDO.sanidad.hotspots || []).find(
-      (h) => h.view === view && (h.data === data || (!h.data && !data)),
-    ) || (MUNDO.sanidad.hotspots || []).find((h) => h.view === view);
-    setPuerta({ label: hs?.label || view, view });
-  };
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('sanidad');
 
   return (
     <main
@@ -98,15 +94,18 @@ export default function Mundo3DSanidad() {
       </header>
 
       <section className="m3dsan__escena" aria-label="La huerta-clínica de la finca">
-        <Mundo
-          mundoId="sanidad"
-          tier={tier}
-          reducedMotion={reducedMotion}
-          onHotspot={onHotspot}
-          onSalir={null}
-          animo="atento"
-          energia={0.9}
-        />
+        <AcompananteMundo mundoId="sanidad" acompanante={acompanante}>
+          <Mundo
+            mundoId="sanidad"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="atento"
+            energia={0.9}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
         <div className="m3dsan__barra">
           <p className="m3dsan__tier">
             {tier === 'bajo'
@@ -123,11 +122,7 @@ export default function Mundo3DSanidad() {
             </button>
           )}
         </div>
-        <p className="m3dsan__nota" role="status" aria-live="polite">
-          {puerta
-            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
-            : 'Toque un punto del recinto para ver a dónde lo lleva.'}
-        </p>
+        <p className="m3dsan__nota">Toque un punto del recinto para ver a dónde lo lleva.</p>
       </section>
 
       <section className="m3dsan__leyenda" aria-label="La sanidad, pieza por pieza">

--- a/src/mockups/Mundo3DSuelo.jsx
+++ b/src/mockups/Mundo3DSuelo.jsx
@@ -20,7 +20,8 @@
  * español de Colombia, en "usted".
  */
 import { useMemo, useState } from 'react';
-import Mundo, { MUNDO, decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
 import './Mundo3DSuelo.css';
 
 const TINTE = ['#8a5a38', '#f0e2c8'];
@@ -49,15 +50,10 @@ export default function Mundo3DSuelo() {
   const [ver2d, setVer2d] = useState(false);
   const tier = ver2d ? 'bajo' : decision.tier;
 
-  // En la vitrina (sin sesión) un punto del corte no navega: cuenta a qué
-  // pantalla real de la app lleva esa puerta.
-  const [puerta, setPuerta] = useState(null);
-  const onHotspot = (view, data) => {
-    const hs = (MUNDO.suelo.hotspots || []).find(
-      (h) => h.view === view && (h.data === data || (!h.data && !data)),
-    ) || (MUNDO.suelo.hotspots || []).find((h) => h.view === view);
-    setPuerta({ label: hs?.label || view, view });
-  };
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('suelo');
 
   return (
     <main
@@ -75,15 +71,18 @@ export default function Mundo3DSuelo() {
       </header>
 
       <section className="m3ds__escena" aria-label="El corte del suelo vivo de la finca">
-        <Mundo
-          mundoId="suelo"
-          tier={tier}
-          reducedMotion={reducedMotion}
-          onHotspot={onHotspot}
-          onSalir={null}
-          animo="sereno"
-          energia={0.85}
-        />
+        <AcompananteMundo mundoId="suelo" acompanante={acompanante}>
+          <Mundo
+            mundoId="suelo"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="sereno"
+            energia={0.85}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
         <div className="m3ds__barra">
           <p className="m3ds__tier">
             {tier === 'bajo'
@@ -100,11 +99,7 @@ export default function Mundo3DSuelo() {
             </button>
           )}
         </div>
-        <p className="m3ds__nota" role="status" aria-live="polite">
-          {puerta
-            ? `«${puerta.label}» es una puerta real: dentro de la app abre la pantalla «${puerta.view}».`
-            : 'Toque un punto del corte para ver a dónde lo lleva.'}
-        </p>
+        <p className="m3ds__nota">Toque un punto del corte para ver a dónde lo lleva.</p>
       </section>
 
       <section className="m3ds__leyenda" aria-label="El suelo, capa por capa">

--- a/src/mockups/valle/AcompananteMundo.jsx
+++ b/src/mockups/valle/AcompananteMundo.jsx
@@ -1,0 +1,242 @@
+/*
+ * AcompananteMundo — la CAPA ACOMPAÑANTE reutilizable de las vitrinas 3D.
+ *
+ * BUG P1 (auditoría triple, "vitrinas mudas"): las rutas de demo
+ * #/mockups/mundo3d-* montaban `<Mundo>` a pelo, SIN el shell de
+ * EntradaValle3D — sin voz, sin narración de Angelita y sin la barra del
+ * agente. Cuartos mudos justo donde se muestra la tesis "3D + agente = un
+ * cuerpo". Esta capa extrae del shell lo que hace que un mundo HABLE:
+ *
+ *   · useAcompanante(mundoId) — la voz (Web Speech API, es-CO) + `decir()`
+ *     (voz + burbuja SIEMPRE: si el equipo no trae voz o el usuario la apaga,
+ *     la burbuja ES la voz — nunca mudo) + la narración de ENTRADA del mundo
+ *     (consume `MUNDO[id].entrada.narra` → NARRACION, el mismo dato que narra
+ *     el shell; BUG-AG-01/BUG-AG-02) + `decirPuerta()` para que Angelita
+ *     acuse los hotspots.
+ *   · <AcompananteMundo> — el marco visual: envuelve al `<Mundo>` de la
+ *     vitrina, flota la burbuja de Angelita sobre la escena y pinta la barra
+ *     del agente ("Pregúntele a su finca…" + 🔊 Escuchar + toggle de voz).
+ *
+ * UNA SOLA ABEJA (#2341): Angelita ya vive DENTRO de la escena del mundo
+ * (3D y lámina 2D reciben animo/energia). Aquí NO se pinta otra abeja: la
+ * capa es solo su burbuja de voz + los controles — el mismo reparto que usa
+ * el shell dentro de un mundo (`valle-companero--mundo`).
+ *
+ * Device-tier: cero costo para gama baja — puro DOM ligero, sin three, sin
+ * assets; la voz es un plus que nunca bloquea. Copy en español de Colombia
+ * ("usted"); si se productiza, migra a messages.js (ADR-050) y la voz real
+ * es Kokoro vía ttsService.
+ */
+/* eslint-disable react-refresh/only-export-components -- capa acompañante:
+   el hook (useAcompanante) y su marco (<AcompananteMundo>) son UNA pieza —
+   la vitrina necesita ambos juntos; separarlos duplicaría el contexto (patrón
+   useEntradaAbeja.jsx). Es un mockup: sin HMR-state que preservar. */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { MUNDO, tituloDeMundo, tinteDeMundo } from '../../visual/mundo3d/index.js';
+import { NARRACION, MUNDO_VALLE_BY_ID } from './valleData';
+import './acompananteMundo.css';
+
+/* La narración de un mundo, con la MISMA cadena de fallbacks del shell:
+   la clave `entrada.narra` del registro → la del propio id → el lema del
+   valle → un "está aquí" digno. Nunca vacío. */
+export function narracionDeMundo(mundoId) {
+  const clave = MUNDO[mundoId]?.entrada?.narra;
+  return (
+    (clave && NARRACION[clave]) ||
+    NARRACION[mundoId] ||
+    MUNDO_VALLE_BY_ID[mundoId]?.lema ||
+    `Está en ${tituloDeMundo(mundoId)}.`
+  );
+}
+
+/**
+ * El acompañante de una vitrina: voz + burbuja + narración de entrada.
+ * La vitrina pasa `hablando` al `<Mundo>` (la abeja de la escena gesticula
+ * mientras Angelita habla) y `decirPuerta` a `onHotspot`.
+ */
+export function useAcompanante(mundoId) {
+  const [voz, setVoz] = useState(true);
+
+  const vozDisponible = useMemo(
+    () => typeof window !== 'undefined' && 'speechSynthesis' in window,
+    [],
+  );
+
+  // El toggle vive en un ref para que `hablar`/`decir` sean ESTABLES (mismo
+  // patrón del shell): prender/apagar la voz no re-dispara la narración.
+  const vozRef = useRef(voz);
+  const vocesRef = useRef([]);
+  useEffect(() => {
+    vozRef.current = voz;
+  }, [voz]);
+
+  useEffect(() => {
+    if (!vozDisponible) return undefined;
+    const synth = window.speechSynthesis;
+    const actualizarVoces = () => {
+      const voces = synth.getVoices();
+      if (voces.length) vocesRef.current = voces;
+    };
+    actualizarVoces();
+    if (synth.addEventListener) {
+      synth.addEventListener('voiceschanged', actualizarVoces);
+      return () => synth.removeEventListener('voiceschanged', actualizarVoces);
+    }
+    const anterior = synth.onvoiceschanged;
+    synth.onvoiceschanged = actualizarVoces;
+    return () => {
+      if (synth.onvoiceschanged === actualizarVoces) synth.onvoiceschanged = anterior;
+    };
+  }, [vozDisponible]);
+
+  const hablar = useCallback((texto) => {
+    if (!vozRef.current || typeof window === 'undefined' || !window.speechSynthesis) return;
+    try {
+      window.speechSynthesis.cancel();
+      const u = new SpeechSynthesisUtterance(texto);
+      u.lang = 'es-CO';
+      u.rate = 0.98;
+      u.pitch = 1;
+      const esVoz = vocesRef.current.find(
+        (v) => v.lang && v.lang.toLowerCase().startsWith('es'),
+      );
+      // Sin voz en español publicada aún: queda la burbuja (mejor callada la
+      // voz que un saludo con acento inglés por defecto).
+      if (!esVoz) return;
+      u.voice = esVoz;
+      window.speechSynthesis.speak(u);
+    } catch {
+      /* la voz es un plus, nunca bloquea */
+    }
+  }, []);
+
+  // ── Angelita DICE (voz + burbuja): el texto SIEMPRE va a la burbuja
+  //    (aria-live). Sin voz (equipo o toggle), la burbuja es la voz.
+  const [dicho, setDicho] = useState(null);
+  const dichoTimer = useRef(null);
+  const decir = useCallback(
+    (texto) => {
+      if (!texto) return;
+      setDicho(texto);
+      if (dichoTimer.current) clearTimeout(dichoTimer.current);
+      dichoTimer.current = setTimeout(
+        () => setDicho(null),
+        Math.min(14000, 4000 + texto.length * 55),
+      );
+      hablar(texto);
+    },
+    [hablar],
+  );
+  useEffect(
+    () => () => {
+      if (dichoTimer.current) clearTimeout(dichoTimer.current);
+      if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+    },
+    [],
+  );
+
+  // ── LA ENTRADA HABLA (el corazón del fix): al montar la vitrina, Angelita
+  //    narra el mundo — misma pauta y misma pista de puertas que el shell.
+  //    La voz puede quedar bloqueada por autoplay hasta el primer gesto
+  //    (iOS/Chrome): la burbuja sale igual, y "🔊 Escuchar" es el camino
+  //    con gesto para oírla.
+  useEffect(() => {
+    const t = setTimeout(
+      () => decir(`${narracionDeMundo(mundoId)} Toque un punto para ver a dónde lo lleva.`),
+      900,
+    );
+    return () => clearTimeout(t);
+  }, [mundoId, decir]);
+
+  // Re-narrar bajo demanda (botón 🔊 Escuchar — gesto real, la voz ya puede).
+  const narrar = useCallback(() => decir(narracionDeMundo(mundoId)), [mundoId, decir]);
+
+  // ── Una puerta tocada: en la vitrina (sin sesión) no navega — Angelita la
+  //    NOMBRA (voz + burbuja) y cuenta a qué pantalla real de la app lleva
+  //    (regla de oro del framework). Firma compatible con `onHotspot`.
+  const decirPuerta = useCallback(
+    (view, data) => {
+      const puertas = MUNDO[mundoId]?.hotspots || [];
+      const hs =
+        puertas.find((h) => h.view === view && (h.data === data || (!h.data && !data))) ||
+        puertas.find((h) => h.view === view);
+      decir(
+        `«${hs?.label || view}» es una puerta real: dentro de la app abre la pantalla «${view}».`,
+      );
+    },
+    [mundoId, decir],
+  );
+
+  return { dicho, hablando: !!dicho, decir, narrar, decirPuerta, voz, setVoz, vozDisponible };
+}
+
+/**
+ * El marco acompañado: envuelve al `<Mundo>` de la vitrina (children), flota
+ * la burbuja de Angelita sobre la escena y pinta la barra del agente debajo.
+ *
+ *   const acompanante = useAcompanante('agua');
+ *   <AcompananteMundo mundoId="agua" acompanante={acompanante}>
+ *     <Mundo mundoId="agua" … hablando={acompanante.hablando} onHotspot={acompanante.decirPuerta} />
+ *   </AcompananteMundo>
+ */
+export default function AcompananteMundo({ mundoId, acompanante, children }) {
+  const { dicho, narrar, voz, setVoz, vozDisponible } = acompanante;
+  const tinte = tinteDeMundo(mundoId);
+
+  // "Pregúntele a su finca…" abre el flujo REAL del agente por el mismo
+  // camino desacoplado del shell (BUG-CAMP-01): el evento global
+  // `chagraNavigate` que App.jsx escucha desde cualquier pantalla.
+  const preguntarAlAgente = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    if (window.speechSynthesis) window.speechSynthesis.cancel();
+    window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'agente' } }));
+  }, []);
+
+  return (
+    <div className="acomp" style={{ '--acomp-tinte': (tinte && tinte[0]) || '#3f8f4e' }}>
+      <div className="acomp__marco">
+        {children}
+        {/* La burbuja de Angelita: SU voz escrita (la abeja vive en la escena
+            — una sola compañera, #2341). aria-live: también es la voz de los
+            lectores de pantalla. */}
+        {dicho && (
+          <div className="acomp__burbuja" role="status" aria-live="polite">
+            {dicho}
+          </div>
+        )}
+      </div>
+      <footer className="acomp__agente">
+        <button
+          type="button"
+          className="acomp__pregunte"
+          aria-label="Pregúntele a Chagra"
+          onClick={preguntarAlAgente}
+        >
+          <span className="acomp__punto" aria-hidden="true" />
+          Pregúntele a su finca…
+        </button>
+        <div className="acomp__ctrls">
+          <button type="button" className="acomp__btn" onClick={narrar}>
+            🔊 Escuchar
+          </button>
+          <button
+            type="button"
+            className={`acomp__btn acomp__voz${voz && vozDisponible ? ' on' : ''}`}
+            aria-pressed={voz && vozDisponible}
+            disabled={!vozDisponible}
+            title={vozDisponible ? undefined : 'Este equipo no trae voz: Angelita le escribe.'}
+            onClick={() => {
+              const n = !voz;
+              setVoz(n);
+              if (!n && typeof window !== 'undefined' && window.speechSynthesis) {
+                window.speechSynthesis.cancel();
+              }
+            }}
+          >
+            {!vozDisponible ? '💬 Texto' : voz ? '🔊 Voz' : '🔇 Voz'}
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/mockups/valle/acompananteMundo.css
+++ b/src/mockups/valle/acompananteMundo.css
@@ -1,0 +1,141 @@
+/*
+ * acompananteMundo.css — la capa acompañante de las vitrinas 3D (BUG P1
+ * "vitrinas mudas"): la burbuja de voz de Angelita sobre la escena + la
+ * barra del agente debajo del marco. Autocontenida (sin fuentes/imágenes
+ * externas), móvil-first desde 320px. Solo opacity/transform animables;
+ * reduced-motion las apaga.
+ */
+
+.acomp {
+  --acomp-tinte: #3f8f4e;
+}
+
+/* El marco: ancla la burbuja sobre el <Mundo> que envuelve. */
+.acomp__marco {
+  position: relative;
+}
+
+/* ── La burbuja de Angelita (su voz escrita; la abeja vive en la escena) ── */
+.acomp__burbuja {
+  position: absolute;
+  left: 0.6rem;
+  right: 0.6rem;
+  bottom: 0.6rem;
+  z-index: 6;
+  margin: 0 auto;
+  max-width: 30rem;
+  width: fit-content;
+  padding: 0.55rem 0.85rem;
+  border-radius: 0.9rem;
+  /* fallback primero: si el navegador no trae color-mix, queda el borde suave */
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-color: color-mix(in srgb, var(--acomp-tinte) 45%, transparent);
+  background: rgba(20, 28, 24, 0.82);
+  color: #f4efe2;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+  pointer-events: none; /* nunca estorba el gesto de girar el diorama */
+  animation: acomp-burbuja-in 0.4s ease both;
+}
+
+@keyframes acomp-burbuja-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── La barra del agente: presente bajo el marco, como en el shell ── */
+.acomp__agente {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.55rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 0.9rem;
+  background: rgba(20, 28, 24, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-color: color-mix(in srgb, var(--acomp-tinte) 40%, transparent);
+}
+
+.acomp__pregunte {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.08);
+  color: #f4efe2;
+  font-size: 0.9rem;
+  text-align: left;
+  padding: 0.5rem 0.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.acomp__pregunte:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.acomp__punto {
+  width: 0.55rem;
+  height: 0.55rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--acomp-tinte);
+  box-shadow: 0 0 8px var(--acomp-tinte);
+  animation: acomp-punto 2.4s ease-in-out infinite;
+}
+
+@keyframes acomp-punto {
+  0%,
+  100% {
+    opacity: 0.7;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.25);
+  }
+}
+
+.acomp__ctrls {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.acomp__btn {
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.35);
+  color: #f4efe2;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.acomp__btn:hover {
+  background: rgba(0, 0, 0, 0.5);
+}
+.acomp__btn:disabled {
+  opacity: 0.8;
+  cursor: default;
+}
+.acomp__voz.on {
+  border-color: #7dffbe;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .acomp__burbuja,
+  .acomp__punto {
+    animation: none !important;
+  }
+}

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -317,6 +317,8 @@ export const NARRACION = {
     'Bienvenido a su finca. Toque un lugar del valle para viajar hasta él, o toque la señal que brilla para saber qué toca hacer hoy.',
   cultivos:
     'Aquí está su milpa: maíz, fríjol y calabaza creciendo juntos como las tres hermanas.',
+  milpa:
+    'La milpa: maíz, fríjol y calabaza sembrados juntos — las tres hermanas que se cuidan entre ellas. El maíz presta el tutor, el fríjol abona y la calabaza tapa el suelo.',
   cafe: 'El cafetal en la ladera. Estas maticas ya están cargando para la próxima cosecha.',
   suelo: 'Las eras y el semillero. La tierra de aquí es la que pide cuidado esta noche.',
   agua: 'La quebrada que baja del monte. De aquí sale el agua para toda la finca.',


### PR DESCRIPTION
## BUG P1 (auditoría triple): las vitrinas públicas mudas

Las rutas de demo `#/mockups/mundo3d-*` montaban `<Mundo>` directo, SIN el shell de `EntradaValle3D` → sin voz, sin narración de Angelita y sin la barra del agente: "cuartos mudos" justo donde se muestra la tesis **3D + agente = un cuerpo**.

## Qué hace

Extrae del shell una **capa acompañante reutilizable** — `src/mockups/valle/AcompananteMundo.jsx` + `acompananteMundo.css`:

- **`useAcompanante(mundoId)`**: voz Web Speech (es-CO) + `decir()` con burbuja de texto SIEMPRE (si el equipo no trae voz o está apagada, la burbuja ES la voz — nunca mudo) + **narración de ENTRADA** desde `MUNDO[id].entrada.narra` → `NARRACION` (la misma cadena de fallbacks del shell) + `decirPuerta()` para que Angelita acuse los hotspots tocados.
- **`<AcompananteMundo>`**: envuelve al `<Mundo>` de la vitrina, flota la burbuja sobre la escena y pinta la barra del agente ("Pregúntele a su finca…" vía `chagraNavigate` + 🔊 Escuchar + toggle de voz — mismo reparto del shell).

Montada en las **8 vitrinas**: `Mundo3DAgua`, `Mundo3DAnimales`, `Mundo3DBosque` (pisos), `Mundo3DClima`, `Mundo3DMercado`, `Mundo3DMilpa`, `Mundo3DSanidad`, `Mundo3DSuelo`. Al entrar, Angelita narra el mundo; los hotspots ahora los nombra ella (voz + burbuja) en lugar del letrero `aria-live` suelto; `hablando=` anima la abeja de la escena mientras habla. La voz puede quedar bloqueada por autoplay hasta el primer gesto (iOS/Chrome): la burbuja sale igual y "🔊 Escuchar" es el camino con gesto.

## Guardas respetadas

- **Una-sola-abeja (#2341)**: Angelita ya vive DENTRO de la escena (3D y lámina 2D reciben `animo`/`energia`); la capa NO pinta otra abeja — solo su burbuja + controles, igual que el shell dentro de un mundo.
- **Device-tier**: cero costo para gama baja — puro DOM ligero, sin three ni assets nuevos; fallback de borde para navegadores sin `color-mix`; `prefers-reduced-motion` apaga las animaciones.
- `NARRACION` gana la clave `milpa` (faltaba: caía al fallback genérico).

## Verificación

- `npm run build` verde (12.2s).
- `eslint` sobre los archivos tocados: 0 errores (2 warnings i18n preexistentes del copy de vitrina).

🤖 Generated with [Claude Code](https://claude.com/claude-code)