### PR TITLE
feat(mundos): invitación de primer uso del sonido ambiental

### DIFF
--- a/src/visual/mundo3d/InvitacionAudioMundo.jsx
+++ b/src/visual/mundo3d/InvitacionAudioMundo.jsx
@@ -1,0 +1,97 @@
+/*
+ * InvitacionAudioMundo — la invitación de PRIMER USO del sonido ambiental.
+ *
+ * El motor 0-KB (useAudioMundo, spec S3) nació opt-in (`sonido:'off'`) y su
+ * único control vive en Perfil → casi nadie lo descubre, y en las vitrinas
+ * ni siquiera hay Perfil. Esta tarjeta invita UNA sola vez, al entrar al
+ * primer mundo: "¿Quiere oír el campo?" con Sí / Ahora no.
+ *
+ *   · El "Sí" hace DOS cosas en el MISMO toque: prende la preferencia
+ *     (usePrefsStore sonido → 'suave') y satisface el gesto que la política
+ *     de autoplay exige (activarAudioPorGesto crea/reanuda el AudioContext
+ *     síncrono dentro del handler) — el campo suena de una, sin segundo toque.
+ *   · "Ahora no" cierra y no vuelve a preguntar (el toggle de Perfil queda).
+ *   · UNA sola vez (localStorage `chagra:invitacion:audio-mundo:v1`): quedar
+ *     mostrada ya la gasta — es una invitación, no una insistencia. Quien ya
+ *     prendió el sonido por su cuenta tampoco la ve.
+ *   · Discreta: tarjeta abajo, no bloquea la escena; con reduced-motion (prop
+ *     del host o media query) aparece sin animación.
+ *   · Sin WebAudio en el equipo, no pregunta lo que no puede cumplir.
+ *
+ * Copy en español Colombia (usted); si se productiza, migra a messages.js
+ * (ADR-050). Autocontenido y three-free (DOM + CSS propio, cero assets).
+ */
+import { useEffect, useState } from 'react';
+import usePrefsStore from '../../store/usePrefsStore.js';
+import { activarAudioPorGesto, soportaAudio } from './useAudioMundo.js';
+import './invitacionAudio.css';
+
+const LS_KEY = 'chagra:invitacion:audio-mundo:v1';
+
+function yaVisto() {
+  if (typeof window === 'undefined') return true;
+  try {
+    return window.localStorage.getItem(LS_KEY) === '1';
+  } catch {
+    return false; // sin storage (modo privado): se muestra igual, es efímera
+  }
+}
+
+function marcarVisto() {
+  try {
+    window.localStorage.setItem(LS_KEY, '1');
+  } catch {
+    /* sin storage no pasa nada: solo se repetiría la próxima vez */
+  }
+}
+
+export default function InvitacionAudioMundo({ reducedMotion = false, tinte }) {
+  const sonido = usePrefsStore((s) => s.sonido ?? 'off');
+  const setSonido = usePrefsStore((s) => s.setSonido);
+  const [visible, setVisible] = useState(
+    () => soportaAudio && !yaVisto() && sonido === 'off',
+  );
+
+  // La invitación se gasta al mostrarse (una sola vez, jamás insiste) y
+  // también la gasta quien ya prendió el sonido por su cuenta en Perfil.
+  useEffect(() => {
+    if (visible || sonido !== 'off') marcarVisto();
+  }, [visible, sonido]);
+
+  if (!visible) return null;
+
+  // El MISMO toque del "Sí": gesto para el AudioContext (síncrono, dentro del
+  // handler) + preferencia 'suave' → el hook del host sincroniza y ya suena.
+  const aceptar = () => {
+    activarAudioPorGesto();
+    setSonido('suave');
+    setVisible(false);
+  };
+
+  const ahoraNo = () => setVisible(false);
+
+  return (
+    <div
+      className={`mundo-invita${reducedMotion ? ' mundo-invita--calma' : ''}`}
+      style={{ '--m-tinte': (tinte && tinte[0]) || '#3f8f4e' }}
+      role="group"
+      aria-label="Invitación de sonido ambiental"
+    >
+      <p className="mundo-invita__txt">
+        <span aria-hidden="true">🐦</span>{' '}
+        <strong className="mundo-invita__pregunta">¿Quiere oír el campo?</strong>{' '}
+        <span className="mundo-invita__nota">
+          Un ambiente suave de viento, agua y aves. Lo puede apagar cuando quiera.
+        </span>
+      </p>
+      <div className="mundo-invita__botones">
+        <button type="button" className="mundo-invita__si" onClick={aceptar}>
+          Sí
+        </button>
+        <button type="button" className="mundo-invita__luego" onClick={ahoraNo}>
+          Ahora no
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -17,6 +17,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react
 import { resolverMundo, tinteDeMundo, tituloDeMundo, emojiDeMundo } from './resolverMundo.js';
 import Mundo2D from './Mundo2D.jsx';
 import useAudioMundo from './useAudioMundo.js';
+import InvitacionAudioMundo from './InvitacionAudioMundo.jsx';
 import './mundo.css';
 
 /* Los dioramas 3D se cargan PEREZOSO: three/@react-three viven en su propio
@@ -145,6 +146,8 @@ function MundoInterno({
             energia={energia}
           />
         )}
+        {/* Sin invitación de audio acá: el aviso de caída ya ocupa ese lugar
+            (señal mala ≠ momento de invitar); queda para la próxima entrada. */}
         <AvisoCaida3D tinte={tinte} onReintentar={reintentar3D} />
         <MigaVolver onSalir={onSalir} mundoId={mundoId} />
       </div>
@@ -170,6 +173,9 @@ function MundoInterno({
             hablando={hablando}
           />
         </Suspense>
+        {/* Invitación de PRIMER USO del sonido ambiental (una sola vez): vive
+            en el host para cubrir app y vitrinas por igual (allá no hay Perfil). */}
+        <InvitacionAudioMundo reducedMotion={reducedMotion} tinte={tinte} />
         <MigaVolver onSalir={onSalir} mundoId={mundoId} />
       </div>
     );
@@ -188,6 +194,7 @@ function MundoInterno({
         animo={animo}
         energia={energia}
       />
+      <InvitacionAudioMundo reducedMotion={reducedMotion} tinte={tinte} />
       <MigaVolver onSalir={onSalir} mundoId={mundoId} />
     </div>
   );

--- a/src/visual/mundo3d/index.js
+++ b/src/visual/mundo3d/index.js
@@ -40,4 +40,10 @@ export { default as useHaptics, PATRONES_HAPTICOS } from './useHaptics.js';
 // Sonido ambiental 0-KB (three-free, spec S3): paletas sonoras por mundo
 // sintetizadas con WebAudio — sin assets. Opt-in (default OFF), solo tras
 // gesto del usuario; bajo reduced-motion queda el lecho estático, sin eventos.
-export { default as useAudioMundo, PALETAS_SONORAS } from './useAudioMundo.js';
+export {
+  default as useAudioMundo, PALETAS_SONORAS, activarAudioPorGesto, soportaAudio,
+} from './useAudioMundo.js';
+
+// Invitación de PRIMER USO del sonido (three-free): ya vive dentro del host
+// <Mundo> (app y vitrinas por igual); se exporta por si un mockup la monta suelta.
+export { default as InvitacionAudioMundo } from './InvitacionAudioMundo.jsx';

--- a/src/visual/mundo3d/invitacionAudio.css
+++ b/src/visual/mundo3d/invitacionAudio.css
@@ -1,0 +1,89 @@
+/*
+ * invitacionAudio.css — la invitación de primer uso del sonido ambiental.
+ * Tarjeta discreta abajo del mundo (misma familia visual de .mundo-caida):
+ * no bloquea la escena, entra con un fade corto y reduced-motion la apaga.
+ */
+.mundo-invita {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 7;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.8rem;
+  padding: 0.6rem 0.8rem;
+  color: #2a2016;
+  background: rgba(255, 251, 242, 0.95);
+  border: 1px solid rgba(60, 46, 24, 0.25);
+  border-radius: 12px;
+  box-shadow: 0 4px 14px rgba(40, 30, 10, 0.18);
+  animation: mundo-invita-entra 0.4s ease-out both;
+}
+.mundo-invita__txt {
+  margin: 0;
+  flex: 1 1 14ch;
+  min-width: 0;
+  font-size: 0.85rem;
+  line-height: 1.35;
+}
+.mundo-invita__pregunta {
+  font-weight: 700;
+}
+.mundo-invita__nota {
+  opacity: 0.8;
+}
+.mundo-invita__botones {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.mundo-invita__si {
+  flex: none;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0.45em 1.3em;
+  font: inherit;
+  font-weight: 700;
+  color: #fffdf7;
+  background: var(--m-tinte, #3f8f4e);
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.mundo-invita__luego {
+  flex: none;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0.45em 1em;
+  font: inherit;
+  font-weight: 600;
+  color: #2a2016;
+  background: transparent;
+  border: 1px solid rgba(60, 46, 24, 0.3);
+  border-radius: 999px;
+  cursor: pointer;
+}
+.mundo-invita__si:focus-visible,
+.mundo-invita__luego:focus-visible {
+  outline: 2px solid #2a2016;
+  outline-offset: 2px;
+}
+
+@keyframes mundo-invita-entra {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: none; }
+}
+
+/* Sin animación intrusiva: ni para quien lo pide el sistema, ni para quien
+   lo pide el host (prop reducedMotion → .mundo-invita--calma). */
+.mundo-invita--calma {
+  animation: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mundo-invita {
+    animation: none;
+  }
+}

--- a/src/visual/mundo3d/useAudioMundo.js
+++ b/src/visual/mundo3d/useAudioMundo.js
@@ -522,6 +522,23 @@ function escucharGesto() {
   window.addEventListener('keydown', alGesto, { passive: true, capture: true });
 }
 
+/* ¿Hay WebAudio en este equipo? (para que la invitación de primer uso no
+   pregunte donde la respuesta "Sí" no podría sonar). SSR-safe: false. */
+export const soportaAudio = SOPORTA;
+
+/* Gesto EXPLÍCITO de opt-in (el "Sí" de la invitación de primer uso): el MISMO
+   toque que prende la preferencia debe satisfacer la política de autoplay.
+   Llamar SÍNCRONO dentro del handler del gesto: crea/reanuda el AudioContext
+   ahí mismo y marca `gestoOk`; el cambio de pref (setSonido) dispara después
+   sincronizar() vía el hook y el ambiente arranca de una, sin segundo toque. */
+export function activarAudioPorGesto() {
+  if (!SOPORTA) return;
+  motor.gestoOk = true;
+  asegurarCtx();
+  if (motor.ctx?.state === 'suspended') motor.ctx.resume().catch(() => {});
+  sincronizar();
+}
+
 /* ── Suscripción viva a prefers-reduced-motion (mismo patrón de useHaptics) ── */
 function subRM(cb) {
   if (typeof window === 'undefined' || !window.matchMedia) return () => {};


### PR DESCRIPTION
## Qué hace

El motor de audio ambiental 0-KB (`useAudioMundo`, spec S3) quedó opt-in (`sonido:'off'`) con su único control en Perfil: casi nadie lo descubre, y en las vitrinas Mundo3D* ni siquiera hay Perfil. Este PR agrega la **invitación de primer uso**: al entrar al primer mundo (una sola vez, flag `chagra:invitacion:audio-mundo:v1` en localStorage) aparece una tarjeta discreta abajo:

> 🐦 **¿Quiere oír el campo?** Un ambiente suave de viento, agua y aves. Lo puede apagar cuando quiera. — [Sí] [Ahora no]

## Cómo se cablea el gesto + la pref (lo delicado)

El **"Sí" hace dos cosas en el MISMO toque**:
1. `activarAudioPorGesto()` (export nuevo de `useAudioMundo.js`) corre **síncrono dentro del handler del click**: marca `gestoOk`, crea/reanuda el `AudioContext` ahí mismo → la política de autoplay queda satisfecha por ese toque.
2. `setSonido('suave')` (usePrefsStore) → el effect del hook en el host ve el cambio de pref y sincroniza el motor → **el ambiente suena de una, sin segundo toque**.

## Decisiones

- **Vive en el host `<Mundo>`** (ramas 3D y 2D): cubre la app y las 8 vitrinas sin tocarlas.
- **"Ahora no"** cierra y no vuelve a preguntar; el toggle de Perfil sigue disponible.
- **Una sola vez de verdad**: mostrarse ya gasta el flag (invitación, no insistencia). Quien ya prendió el sonido por su cuenta tampoco la ve.
- **reduced-motion** (prop del host o media query): sin animación de entrada.
- **Sin WebAudio** (`soportaAudio`): no pregunta lo que no puede cumplir.
- **Caída digna 3D**: no se muestra (el aviso de caída ocupa ese lugar); queda para la próxima entrada.
- Botones ≥44px (WCAG 2.5.5), español CO en usted, tinte del mundo via `--m-tinte`.

## Verificación

- `npm run build` verde (1m02s, solo warnings pre-existentes de chunk size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)