### PR TITLE
feat(mundo-cafe): cafetal bajo sombra 3D (arquetipo cafe)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,6 +100,11 @@ const Mundo3DSanidadMockup = lazy(() => import('./mockups/Mundo3DSanidad'));
 // campo→mesa, puestos, canastos, procedencia y precio justo. El 3D va perezoso
 // (vendor-three).
 const Mundo3DMercadoMockup = lazy(() => import('./mockups/Mundo3DMercado'));
+// 3D: "El mundo del café" — monta <Mundo mundoId="cafe"> del framework: el
+// cafetal bajo sombra (arquetipo nuevo `cafe`, familia recinto): café de sombra
+// (guamo/nogal), el grano cereza→pergamino→oro (sin tostar en finca), roya/broca
+// con manejo agroecológico y el beneficio. El 3D va perezoso (vendor-three).
+const Mundo3DCafeMockup = lazy(() => import('./mockups/Mundo3DCafe'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -514,6 +519,7 @@ const MOCKUP_HASH_ROUTES = {
   // (anti-conflicto de merge) rutas nuevas SIEMPRE al final del bloque:
   'mockups/mundo3d-sanidad': 'mockup_mundo3d_sanidad',
   'mockups/mundo3d-mercado': 'mockup_mundo3d_mercado',
+  'mockups/mundo3d-cafe': 'mockup_mundo3d_cafe',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1623,6 +1629,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del mercado">
               <Mundo3DMercadoMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_cafe':
+        // Vitrina pública del MUNDO DEL CAFÉ: monta <Mundo mundoId="cafe"> del
+        // framework (src/visual/mundo3d) con device-tiering real. Ruta
+        // #/mockups/mundo3d-cafe, sin auth. El cafetal bajo sombra: café de
+        // sombra (guamo/nogal), el grano cereza→pergamino→oro (sin tostar en la
+        // finca), roya (Hemileia vastatrix) y broca (Hypothenemus hampei) con
+        // manejo agroecológico, y el beneficio (despulpar, fermentar, secar).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del café">
+              <Mundo3DCafeMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Mundo3DCafe.css
+++ b/src/mockups/Mundo3DCafe.css
@@ -1,0 +1,152 @@
+/*
+ * Mundo3DCafe.css — vitrina pública del mundo del café
+ * (#/mockups/mundo3d-cafe). Autocontenida: sin fuentes/imágenes externas.
+ * Móvil-first desde 320px. Solo opacity/transform animables; reduced-motion las
+ * apaga.
+ */
+
+.m3dcaf {
+  --m3dcaf-a: #7a4a24;
+  --m3dcaf-b: #efe0cf;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3dcaf-b) 0%, #f3e6d5 44%, #d9bd97 100%);
+  color: #3a2a18;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3dcaf__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3dcaf__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3dcaf-a);
+}
+.m3dcaf__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #5a3418;
+}
+.m3dcaf__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3dcaf__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3dcaf__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(122, 74, 36, 0.3);
+  box-shadow: 0 10px 28px rgba(58, 42, 24, 0.14);
+}
+.m3dcaf__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #fbf3e6;
+}
+
+.m3dcaf__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3dcaf__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3dcaf__toggle {
+  border: 1.5px solid var(--m3dcaf-a);
+  background: #fff;
+  color: var(--m3dcaf-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3dcaf__toggle:hover,
+.m3dcaf__toggle:focus-visible {
+  background: var(--m3dcaf-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3dcaf__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.8);
+  border-left: 3px solid var(--m3dcaf-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3dcaf__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3dcaf__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #5a3418;
+}
+.m3dcaf__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3dcaf__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3dcaf__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(122, 74, 36, 0.2);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3dcaf__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3dcaf__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #5a3418;
+}
+.m3dcaf__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3dcaf__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #48331c;
+}

--- a/src/mockups/Mundo3DCafe.jsx
+++ b/src/mockups/Mundo3DCafe.jsx
@@ -1,0 +1,152 @@
+/*
+ * Mundo3DCafe — vitrina pública del MUNDO DEL CAFÉ (ruta #/mockups/mundo3d-cafe).
+ *
+ * El cafetal bajo sombra de la finca andina: el cultivo bandera hecho lugar. El
+ * diorama enseña lo que de verdad es una finca cafetera — la SOMBRA de guamo y
+ * nogal que le hace techo al cultivo (café de sombra = café con aves, no potrero
+ * de sol), los CAFETOS cargados de cereza roja, el GRANO en sus tres estados sin
+ * tostar en la finca (cereza → pergamino → oro), la ROYA (Hemileia vastatrix) y
+ * la BROCA (Hypothenemus hampei) manejadas con criterio, y el BENEFICIO del
+ * rincón (despulpar, fermentar, secar). Del árbol a la taza pasando por el campo,
+ * sin recetas de veneno ni humo de tostión en la parcela.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="cafe">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento") se ve la ficha 2D digna; en gama media/
+ * alta, el diorama 3D low-poly (chunk perezoso `vendor-three`) con la abeja
+ * Angelita entrando al mundo. Los puntos del cafetal son las mismas puertas del
+ * registro: aquí (vitrina sin sesión) muestran a qué pantalla real de la app
+ * llevan, en vez de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
+import './Mundo3DCafe.css';
+
+const TINTE = ['#7a4a24', '#efe0cf'];
+
+/* Lo que se ve en el cafetal, contado en una leyenda didáctica y verificada:
+   café real del país (sombra + grano + sanidad + beneficio), sin promesas de
+   plata ni recetas químicas de dosis. */
+const LEYENDA = [
+  {
+    emoji: '🌳',
+    titulo: 'El café bajo sombra',
+    texto: 'El cafeto no es de pleno sol: crece mejor debajo del guamo y el nogal. La sombra le baja el calor, le guarda la humedad, le abona con la hoja que cae y le devuelve las aves. Café de sombra es café con vida, no potrero pelado.',
+  },
+  {
+    emoji: '☕',
+    titulo: 'El grano: cereza, pergamino y oro',
+    texto: 'La cereza roja madura es el fruto. Se despulpa y seca hasta el pergamino (el grano en su cascarilla) y se trilla hasta el oro (el grano verde que se vende). En la finca NO se tuesta: el tueste es del otro lado. Lo suyo es entregar oro parejo.',
+  },
+  {
+    emoji: '📏',
+    titulo: 'El piso del café',
+    texto: 'En la ladera andina el café da mejor entre los 1200 y 1800 metros. Más abajo se acalora y más arriba se enfría. Conocer su altura le dice qué variedad le sirve y cuándo le va a florecer y cargar.',
+  },
+  {
+    emoji: '🍂',
+    titulo: 'La roya y la broca, con criterio',
+    texto: 'La roya (Hemileia vastatrix) es el polvillo naranja bajo la hoja; la broca (Hypothenemus hampei) es el gorgojo que perfora la cereza. Se manejan con variedad resistente, cosecha bien recogida, trampas y hongos de biocontrol — no con recetas de veneno.',
+  },
+  {
+    emoji: '💧',
+    titulo: 'El beneficio: despulpar, fermentar, secar',
+    texto: 'Despulpe la cereza el mismo día, fermente el mucílago en el tanque y seque el grano despacio al sol (paseo o parabólico). Un buen beneficio es la mitad de la taza: ahí se gana o se pierde el precio.',
+  },
+];
+
+export default function Mundo3DCafe() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('cafe');
+
+  return (
+    <main
+      className="m3dcaf"
+      style={{ '--m3dcaf-a': TINTE[0], '--m3dcaf-b': TINTE[1] }}
+    >
+      <header className="m3dcaf__head">
+        <p className="m3dcaf__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo del café</h1>
+        <p className="m3dcaf__lema">
+          Métase al cafetal de la ladera: el arbusto que vive bajo la sombra del
+          guamo, la cereza que se vuelve pergamino y oro sin pasar por el
+          tostador, la roya y la broca manejadas con criterio, y el beneficio que
+          convierte el fruto en grano de vender. Café con sombra, con aves y con
+          precio justo.
+        </p>
+      </header>
+
+      <section className="m3dcaf__escena" aria-label="El cafetal bajo sombra de la finca">
+        <AcompananteMundo mundoId="cafe" acompanante={acompanante}>
+          <Mundo
+            mundoId="cafe"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="sereno"
+            energia={0.9}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
+        <div className="m3dcaf__barra">
+          <p className="m3dcaf__tier">
+            {tier === 'bajo'
+              ? 'Está viendo la ficha del café (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3dcaf__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver la ficha 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3dcaf__nota">Toque un punto del cafetal para ver a dónde lo lleva.</p>
+      </section>
+
+      <section className="m3dcaf__leyenda" aria-label="El café, pieza por pieza">
+        <h2>El cafetal, pieza por pieza</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3dcaf__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3dcaf__cierre">
+          El buen café no sale de una receta de bulto: sale de la sombra que lo
+          cuida, de la cereza recogida en su punto, de la roya atajada a tiempo y
+          del beneficio hecho con paciencia. Cuide el árbol, cuide el grano y
+          entregue oro parejo — ahí está el valor de lo suyo.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -319,7 +319,7 @@ export const NARRACION = {
     'Aquí está su milpa: maíz, fríjol y calabaza creciendo juntos como las tres hermanas.',
   milpa:
     'La milpa: maíz, fríjol y calabaza sembrados juntos — las tres hermanas que se cuidan entre ellas. El maíz presta el tutor, el fríjol abona y la calabaza tapa el suelo.',
-  cafe: 'El cafetal en la ladera. Estas maticas ya están cargando para la próxima cosecha.',
+  cafe: 'El cafetal bajo sombra. El café vive debajo del guamo, cargado de cereza roja. De ahí sale el grano: cereza, pergamino y oro. En la finca no se tuesta.',
   suelo: 'Las eras y el semillero. La tierra de aquí es la que pide cuidado esta noche.',
   agua: 'La quebrada que baja del monte. De aquí sale el agua para toda la finca.',
   animales: 'El corral. Las gallinas y el ganado que cierran el ciclo del abono.',

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -32,6 +32,8 @@ const IMPORTA_ESCENA = {
   boveda: () => import('./escenas/EscenaBoveda.jsx'),
   sanidad: () => import('./escenas/EscenaSanidad.jsx'),
   mercado: () => import('./escenas/EscenaMercado.jsx'),
+  // (anti-conflicto de merge) importadores de escena nuevos SIEMPRE al final:
+  cafe: () => import('./escenas/EscenaCafe.jsx'),
 };
 const ESCENAS_3D = Object.fromEntries(
   Object.entries(IMPORTA_ESCENA).map(([k, importa]) => [k, lazy(importa)]),

--- a/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
+++ b/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
@@ -12,7 +12,7 @@ afterEach(() => cleanup());
 
 describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
   test('arquetipos: 5 dioramas 3D + arquetipos 2D de primera clase', () => {
-    expect(ARQUETIPOS_3D.sort()).toEqual(['boveda', 'cutaway', 'estratos', 'flujo', 'mercado', 'recinto', 'sanidad', 'valle']);
+    expect(ARQUETIPOS_3D.sort()).toEqual(['boveda', 'cafe', 'cutaway', 'estratos', 'flujo', 'mercado', 'recinto', 'sanidad', 'valle']);
     ['lamina', 'infografia', 'ficha', 'mirror', 'valle2d'].forEach((k) => {
       expect(ARQUETIPOS_2D).toContain(k);
       expect(ARQUETIPOS[k].dim).toBe('2d');
@@ -42,6 +42,16 @@ describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
     expect(alto.escena).toBe('mercado');
     // equipo humilde → cae a su fallback2d declarado (la infografía del mercado)
     const bajo = resolverMundo('mercado', 'bajo');
+    expect(bajo.modo).toBe('2d');
+    expect(bajo.escena).toBe('infografia');
+  });
+
+  test('el café sube al arquetipo 3D nuevo `cafe` (y degrada a su ficha 2D)', () => {
+    const alto = resolverMundo('cafe', 'alto');
+    expect(alto.modo).toBe('3d');
+    expect(alto.escena).toBe('cafe');
+    // equipo humilde → cae a su fallback2d declarado (la infografía del café)
+    const bajo = resolverMundo('cafe', 'bajo');
     expect(bajo.modo).toBe('2d');
     expect(bajo.escena).toBe('infografia');
   });

--- a/src/visual/mundo3d/arquetipos.js
+++ b/src/visual/mundo3d/arquetipos.js
@@ -72,6 +72,17 @@ export const ARQUETIPOS = {
     nombre: 'El mercado campesino', clave: 'la cadena corta del campo a la mesa: puestos, procedencia y precio justo',
     ejemplo: 'mercado', tambien: [],
   },
+  // El cafetal bajo sombra: la familia del `recinto` (un lugar que se camina)
+  // hecha CULTIVO BANDERA. Su lección es el café real del país — el arbusto que
+  // vive BAJO el techo de guamo/nogal, la cereza que se vuelve pergamino y oro
+  // (sin tostar en la finca), la roya y la broca manejadas con criterio, y el
+  // beneficio (despulpar, fermentar, secar). En equipo humilde cae a su ficha 2D
+  // (la infografía del café). (anti-conflicto: arquetipo 3D nuevo al final del bloque.)
+  cafe: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'cafe', espejo: 'mirror',
+    nombre: 'El cafetal bajo sombra', clave: 'el cultivo bandera: café de sombra, el grano cereza→pergamino→oro, roya/broca y beneficio',
+    ejemplo: 'cafe', tambien: [],
+  },
 
   // ── Arquetipos 2D (primera clase) ────────────────────────────────────────
   mirror: {

--- a/src/visual/mundo3d/escenas/EscenaCafe.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCafe.jsx
@@ -1,0 +1,261 @@
+/*
+ * EscenaCafe — ARQUETIPO `cafe`: el CAFETAL BAJO SOMBRA de la ladera andina.
+ *
+ * De la familia del `recinto` (un lugar que se camina), pero su lección es el
+ * CULTIVO BANDERA hecho espacio: el café no crece solo ni a pleno rayo — vive
+ * ABAJO, bajo el techo de árboles altos que lo cuidan. El diorama enseña lo que
+ * de verdad es una finca cafetera del país:
+ *
+ *   · la SOMBRA arriba — el guamo (Inga) y el nogal cafetero que le hacen techo
+ *     al cultivo: menos sol quemante, más humedad, hoja que cae y abona, y monte
+ *     donde vuelven las aves (café de sombra = café con vida, no potrero de sol);
+ *   · los CAFETOS abajo — los arbustos cargados de CEREZA roja madura (el fruto);
+ *   · el GRANO en sus tres estados, SIN tostar en la finca — cereza (el fruto
+ *     rojo) → pergamino (el grano seco en su cascarilla) → oro (el grano verde
+ *     ya trillado, listo para vender); el tueste es del otro lado, no del campo;
+ *   · la ROYA (Hemileia vastatrix, el polvillo naranja bajo la hoja) y la BROCA
+ *     (Hypothenemus hampei, el gorgojo que perfora la cereza) — señaladas sin
+ *     drama, porque se manejan con criterio, no con recetas de veneno;
+ *   · el BENEFICIO en el rincón — despulpar, fermentar en el tanque y secar al
+ *     sol en el paseo/parabólico: el paso del fruto al grano vendible.
+ *
+ * Todo `MeshLambert`/`Basic`, sin sombras (contrato de EscenaBase3D). Geometría
+ * de primitivas: cero GLTF, offline y liviano.
+ */
+import { useMemo } from 'react';
+import EscenaBase3D from './EscenaBase3D.jsx';
+import { Fauna } from './FaunaEscena.jsx';
+import { CIELOS, PALETA } from '../atmosferaMadre.js';
+
+/* La fauna que delata el CAFÉ DE SOMBRA: bajo el techo de guamo vuelven las
+   aves y las mariposas (el café a pleno sol las espanta). Pocas y por criterio
+   ecológico (contrato del DR: vida, no enjambre) — la sombra ES el hábitat. */
+const FAUNA_CAFE = [
+  { tipo: 'colibri', base: [-1.15, 1.45, 0.35], patron: 'revoloteo', size: 30, fase: 0.5 },
+  { tipo: 'mariposa', base: [0.9, 0.82, 0.7], patron: 'revoloteo', size: 26, fase: 1.8 },
+  { tipo: 'colibri', base: [1.25, 1.55, -0.5], patron: 'revoloteo', size: 26, fase: 2.6 },
+];
+
+/* Un ÁRBOL DE SOMBRA (guamo/nogal cafetero): tronco alto de madera + copa ancha
+   y aireada en varias esferas. Le hace TECHO al cafetal — es lo primero que se
+   lee "el café vive debajo". */
+function ArbolSombra({ pos, color = '#3f6b39', alto = 2.1 }) {
+  const copa = [
+    [0, alto, 0, 0.72], [0.5, alto - 0.22, 0.1, 0.5], [-0.46, alto - 0.18, -0.08, 0.52],
+    [0.12, alto + 0.34, -0.3, 0.46], [-0.2, alto + 0.28, 0.32, 0.42],
+  ];
+  return (
+    <group position={pos}>
+      {/* el tronco alto */}
+      <mesh position={[0, alto * 0.5, 0]}>
+        <cylinderGeometry args={[0.09, 0.14, alto, 6]} />
+        <meshLambertMaterial color={PALETA.madera} flatShading />
+      </mesh>
+      {/* la copa ancha y aireada que da la sombra */}
+      {copa.map(([x, y, z, r], i) => (
+        <mesh key={i} position={[x, y, z]}>
+          <sphereGeometry args={[r, 9, 7]} />
+          <meshLambertMaterial color={i % 2 ? PALETA.follajeOscuro : color} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Un CAFETO: arbusto cargado. Tallo + follaje verde firme + CEREZAS rojas (el
+   fruto maduro que se cosecha grano a grano). `roya` le pinta la mancha naranja
+   del polvillo bajo una hoja (Hemileia vastatrix) — la señal, sin alarma. */
+function Cafeto({ pos, color = '#3f6f3a', cerezas = 5, roya = false }) {
+  const hojas = [
+    [0, 0.56, 0, 0.2], [0.16, 0.44, 0.06, 0.15], [-0.15, 0.46, -0.06, 0.15],
+    [0.05, 0.66, -0.12, 0.14],
+  ];
+  // Las cerezas maduras repartidas por el follaje (deterministas por índice).
+  const frutos = useMemo(() => {
+    return Array.from({ length: cerezas }, (_, i) => {
+      const a = (i / cerezas) * Math.PI * 2 + 0.4;
+      const r = 0.18 + (i % 2) * 0.05;
+      return /** @type {[number, number, number]} */ ([
+        Math.cos(a) * r, 0.42 + (i % 3) * 0.09, Math.sin(a) * r,
+      ]);
+    });
+  }, [cerezas]);
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.26, 0]}>
+        <cylinderGeometry args={[0.035, 0.06, 0.52, 5]} />
+        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+      </mesh>
+      {hojas.map(([x, y, z, r], i) => (
+        <mesh key={i} position={[x, y, z]}>
+          <sphereGeometry args={[r, 8, 7]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+      ))}
+      {/* las cerezas rojas: el fruto que se recoge maduro */}
+      {frutos.map((p, i) => (
+        <mesh key={i} position={p}>
+          <sphereGeometry args={[0.035, 7, 6]} />
+          <meshLambertMaterial color="#b8342a" flatShading />
+        </mesh>
+      ))}
+      {/* la roya: la mancha naranja del polvillo bajo la hoja (señal, no drama) */}
+      {roya && (
+        <mesh position={[0.16, 0.4, 0.16]}>
+          <sphereGeometry args={[0.06, 8, 6]} />
+          <meshLambertMaterial color={PALETA.ambar} flatShading />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+/* Un ESTADO DEL GRANO en una bandeja: el paso cereza → pergamino → oro (NUNCA
+   tostado en la finca). Tabla baja + montón de grano del color de su estado. */
+function GranoEstado({ pos, color = '#b8342a' }) {
+  return (
+    <group position={pos}>
+      {/* la bandeja/zaranda de madera clara */}
+      <mesh position={[0, 0.05, 0]}>
+        <cylinderGeometry args={[0.17, 0.17, 0.05, 12]} />
+        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+      </mesh>
+      {/* el montón de grano de este estado */}
+      <mesh position={[0, 0.085, 0]}>
+        <sphereGeometry args={[0.13, 12, 6, 0, Math.PI * 2, 0, Math.PI / 2]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* El BENEFICIO en su rincón: la DESPULPADORA (tolva + cuerpo con manija), el
+   TANQUE DE FERMENTACIÓN (recipiente abierto con el agua del mucílago) y el
+   SECADERO (paseo/parabólico: cama elevada con la capa de grano al sol). El paso
+   del fruto rojo al grano vendible, sin química. */
+function Beneficio({ pos }) {
+  return (
+    <group position={pos}>
+      {/* la despulpadora: cuerpo + tolva + manija */}
+      <mesh position={[0, 0.28, 0]}>
+        <boxGeometry args={[0.34, 0.4, 0.28]} />
+        <meshLambertMaterial color={PALETA.lamina} flatShading />
+      </mesh>
+      <mesh position={[0, 0.54, 0]} rotation={[0, 0, Math.PI]}>
+        <cylinderGeometry args={[0.05, 0.19, 0.2, 4]} />
+        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+      </mesh>
+      <mesh position={[0.24, 0.3, 0]} rotation={[Math.PI / 2, 0, 0]}>
+        <cylinderGeometry args={[0.02, 0.02, 0.16, 6]} />
+        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+      </mesh>
+
+      {/* el tanque de fermentación: recipiente abierto con agua del mucílago */}
+      <mesh position={[0.62, 0.18, 0.2]}>
+        <cylinderGeometry args={[0.19, 0.16, 0.36, 12]} />
+        <meshLambertMaterial color={PALETA.concreto} flatShading />
+      </mesh>
+      <mesh position={[0.62, 0.31, 0.2]}>
+        <cylinderGeometry args={[0.165, 0.165, 0.04, 12]} />
+        <meshLambertMaterial color={PALETA.agua} flatShading />
+      </mesh>
+
+      {/* el secadero (paseo/parabólico): cama elevada con la capa de grano al sol */}
+      <group position={[0.3, 0, 0.72]}>
+        {[[-0.28, 0.16, -0.16], [0.28, 0.16, -0.16], [-0.28, 0.16, 0.16], [0.28, 0.16, 0.16]].map((p, i) => (
+          <mesh key={i} position={p}>
+            <cylinderGeometry args={[0.02, 0.02, 0.32, 5]} />
+            <meshLambertMaterial color={PALETA.madera} flatShading />
+          </mesh>
+        ))}
+        <mesh position={[0, 0.33, 0]}>
+          <boxGeometry args={[0.66, 0.03, 0.44]} />
+          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+        </mesh>
+        {/* la capa de grano en pergamino secándose */}
+        <mesh position={[0, 0.36, 0]}>
+          <boxGeometry args={[0.6, 0.03, 0.38]} />
+          <meshLambertMaterial color="#d4c199" flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+function Diorama({ params, reducedMotion }) {
+  const cafetos = params?.cafetos || [
+    { color: '#3f6f3a', pos: [-0.55, 0, 0.42], cerezas: 6 },
+    { color: '#468637', pos: [0.5, 0, 0.12], cerezas: 5 },
+    { color: '#3f6f3a', pos: [0.02, 0, -0.5], cerezas: 4, roya: true },
+    { color: '#457d38', pos: [-0.78, 0, -0.32], cerezas: 5 },
+  ];
+  const sombra = params?.sombra || [
+    { pos: [-1.65, 0, -0.95], color: '#4b7a3a', alto: 2.2 }, // guamo
+    { pos: [1.7, 0, -0.8], color: '#3f6b39', alto: 2.0 },    // nogal cafetero
+  ];
+  // El grano en sus tres estados (cereza→pergamino→oro), SIN tostar en finca.
+  const granos = params?.granos || [
+    { estado: 'cereza', color: '#b8342a', pos: [-1.5, 0, 0.75] },
+    { estado: 'pergamino', color: '#d4c199', pos: [-1.15, 0, 1.05] },
+    { estado: 'oro', color: '#9fae5a', pos: [-0.72, 0, 1.2] },
+  ];
+
+  // El surco del cafetal en la ladera: hilera curva que ordena las matas (café
+  // sembrado a curva de nivel, no ladera abajo — cuida el suelo del aguacero).
+  const surcos = useMemo(() => {
+    const n = 3;
+    return Array.from({ length: n }, (_, i) => {
+      const z = -0.75 + i * 0.62;
+      return /** @type {[number, number, number]} */ ([0, 0.03, z]);
+    });
+  }, []);
+
+  return (
+    <group>
+      {/* piso del cafetal (ladera) */}
+      <mesh position={[0, -0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[2.1, 30]} />
+        <meshLambertMaterial color="#7a6a3e" />
+      </mesh>
+      {/* los surcos a curva de nivel (lomos de tierra que ordenan el cafetal) */}
+      {surcos.map((p, i) => (
+        <mesh key={i} position={p} rotation={[-Math.PI / 2, 0, 0]}>
+          <ringGeometry args={[0.55 + i * 0.02, 1.65, 40, 1, 0.6, 1.9]} />
+          <meshLambertMaterial color="#6b5636" />
+        </mesh>
+      ))}
+
+      {/* la SOMBRA arriba: los árboles altos que le hacen techo al café */}
+      {sombra.map((a, i) => (
+        <ArbolSombra key={i} pos={a.pos} color={a.color} alto={a.alto} />
+      ))}
+
+      {/* los CAFETOS cargados de cereza (uno con la señal de roya) */}
+      {cafetos.map((c, i) => (
+        <Cafeto key={i} pos={c.pos} color={c.color} cerezas={c.cerezas} roya={c.roya} />
+      ))}
+
+      {/* el GRANO en sus tres estados, SIN tostar (cereza→pergamino→oro) */}
+      {granos.map((g, i) => (
+        <GranoEstado key={i} pos={g.pos} color={g.color} />
+      ))}
+
+      {/* el BENEFICIO: despulpar, fermentar, secar (el paso al grano vendible) */}
+      <Beneficio pos={[1.0, 0, 0.55]} />
+
+      {/* la vida que trae la sombra: colibríes y mariposa (café con hábitat) */}
+      <Fauna items={FAUNA_CAFE} reducedMotion={reducedMotion} />
+    </group>
+  );
+}
+
+export default function EscenaCafe(props) {
+  // Cielo de "corral y cafetal: tarde de finca" (atmosferaMadre) — la mezcla lo
+  // entibia igual hacia la hora dorada del valle.
+  const cielo = CIELOS.corral;
+  return (
+    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.7, 0] }}>
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+    </EscenaBase3D>
+  );
+}

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -167,15 +167,62 @@ export const MUNDO = {
     entrada: { narra: 'cultivos' },
   },
 
-  // ☕ EL CAFÉ — arquetipo `lamina`: la lámina del cafeto.
+  // ☕ EL CAFÉ — arquetipo SÍ-3D `cafe`: el CAFETAL BAJO SOMBRA, el cultivo
+  //    bandera hecho lugar. El diorama muestra lo que de verdad es una finca
+  //    cafetera andina: la SOMBRA de guamo/nogal que le hace techo al cultivo
+  //    (café de sombra = café con aves, no potrero de sol), los CAFETOS cargados
+  //    de CEREZA roja, el GRANO en sus tres estados SIN tostar en la finca
+  //    (cereza→pergamino→oro), la ROYA (Hemileia vastatrix) y la BROCA
+  //    (Hypothenemus hampei) señaladas para manejarlas con criterio (no recetas
+  //    de veneno), y el BENEFICIO en el rincón (despulpar, fermentar, secar).
+  //    Cada punto es una puerta a una pantalla REAL. En equipo humilde cae a su
+  //    ficha 2D digna (la infografía del café).
   cafe: {
-    escena: 'lamina',
+    escena: 'cafe',
     valle: { tipo: 'cafetal', pos: [3.4, 0, 2.2], escala: 1 },
-    params: { lamina: 'cafeto' },
+    params: {
+      // El diorama tiene defaults propios; aquí los hacemos explícitos y
+      // deterministas (mismos cafetos, sombra y estados del grano).
+      cafetos: [
+        { color: '#3f6f3a', pos: [-0.55, 0, 0.42], cerezas: 6 },
+        { color: '#468637', pos: [0.5, 0, 0.12], cerezas: 5 },
+        { color: '#3f6f3a', pos: [0.02, 0, -0.5], cerezas: 4, roya: true },
+        { color: '#457d38', pos: [-0.78, 0, -0.32], cerezas: 5 },
+      ],
+      sombra: [
+        { pos: [-1.65, 0, -0.95], color: '#4b7a3a', alto: 2.2 }, // guamo (Inga)
+        { pos: [1.7, 0, -0.8], color: '#3f6b39', alto: 2.0 },    // nogal cafetero
+      ],
+      granos: [
+        { estado: 'cereza', color: '#b8342a', pos: [-1.5, 0, 0.75] },
+        { estado: 'pergamino', color: '#d4c199', pos: [-1.15, 0, 1.05] },
+        { estado: 'oro', color: '#9fae5a', pos: [-0.72, 0, 1.2] },
+      ],
+    },
     hotspots: [
-      { id: 'cafe', pos: [], emoji: '☕', label: 'El café, paso a paso', view: 'cafe' },
+      { id: 'grano', pos: [-0.55, 0.9, 0.42], emoji: '☕', label: 'El grano, paso a paso', view: 'cafe' },
+      { id: 'sombra', pos: [-1.65, 2.5, -0.95], emoji: '🌳', label: 'El café bajo sombra', view: 'biodiversidad' },
+      { id: 'roya', pos: [0.02, 0.85, -0.5], emoji: '🍂', label: 'La roya y la broca', view: 'plagas' },
+      { id: 'manejo', pos: [0.5, 0.82, 0.12], emoji: '🐞', label: 'Manejo sin veneno', view: 'biopreparados' },
+      { id: 'beneficio', pos: [1.0, 0.7, 0.55], emoji: '💧', label: 'Despulpar, fermentar, secar', view: 'poscosecha' },
     ],
-    entrada: { narra: 'cafe' },
+    entrada: { zoom: 7.5, narra: 'cafe' },
+    // El gemelo 2D digno: la ficha del café (misma lección, en cifras y notas).
+    fallback2d: {
+      escena: 'infografia',
+      params: {
+        titulo: 'El café de la finca',
+        cifras: [
+          { valor: '1200–1800', unidad: 'm', label: 'la altura donde da mejor el café en la ladera andina' },
+          { valor: '3', unidad: 'estados', label: 'del grano SIN tostar en la finca: cereza → pergamino → oro' },
+        ],
+        notas: [
+          'Siémbrelo bajo sombra de guamo o nogal: cuida el suelo, guarda humedad y le vuelven las aves.',
+          'Roya (el polvillo naranja) y broca (el gorgojo de la cereza) se manejan con criterio: variedad resistente, recoja bien la cereza, trampas y hongos de biocontrol — no con recetas de veneno.',
+          'Beneficio: despulpe el mismo día, fermente en el tanque y seque despacio. El tueste es de otro lado, no del campo.',
+        ],
+      },
+    },
   },
 
   // 🍊 FRUTALES — arquetipo `ficha`: tarjeta de especie foto-secuencial.


### PR DESCRIPTION
## Qué

Reconstruye **el mundo del CAFÉ en 3D limpio desde `dev`** (una rama previa se revirtió 2× por conflictos en `App.jsx`; esta se hizo de cero con el patrón anti-conflicto). Sube el café de lámina 2D a un **diorama SÍ-3D** del framework de mundos (`src/visual/mundo3d`), replicando EXACTO el patrón de **sanidad** y **mercado**.

## Contenido (cafetal andino real)

- **Café bajo sombra** (guamo/nogal): el arbusto vive DEBAJO del techo de árboles altos — café de sombra = café con aves, no potrero de sol.
- **El grano en 3 estados, SIN tostar en la finca**: cereza (fruto rojo) → pergamino (grano en cascarilla) → oro (grano verde de vender). El tueste es de otro lado.
- **Roya** (*Hemileia vastatrix*) y **broca** (*Hypothenemus hampei*) señaladas para **manejo agroecológico** (variedad resistente, cosecha bien recogida, trampas, hongos de biocontrol) — sin recetas químicas de dosis.
- **Beneficio**: despulpar, fermentar en el tanque, secar al sol.
- **Piso del café** (1200–1800 m) en la ficha 2D.
- Fauna del café de sombra (colibrí/mariposa).

## Patrón replicado (idéntico a sanidad/mercado)

- `src/visual/mundo3d/escenas/EscenaCafe.jsx` — diorama low-poly (Lambert, sin sombras, cero GLTF) sobre `EscenaBase3D`.
- Arquetipo `cafe` (dim 3d, familia recinto) en `arquetipos.js`.
- Importador de escena en `Mundo.jsx` (`IMPORTA_ESCENA`).
- Entrada `MUNDO.cafe` en `mundoData.js`: params deterministas + hotspots (puertas reales: `cafe`/`biodiversidad`/`plagas`/`biopreparados`/`poscosecha`) + `fallback2d` infografía.
- Vitrina `src/mockups/Mundo3DCafe.jsx` + `.css` con la capa **AcompananteMundo** (Angelita) — ruta `#/mockups/mundo3d-cafe`.
- Ruta + case en `App.jsx` con device-tiering real y `ErrorBoundary`.
- Entrada desde el valle: el landmark `cafetal` y la narración ya existían; narración enriquecida.

## Anti-conflicto (rompió el build 3×)

Arquetipo, importador de escena, ruta+case de `App.jsx` y el set del smoke test se añadieron **AL FINAL** de sus bloques (marcadores "al final del bloque"); la entrada de `mundoData` se editó en su **propio bloque aislado**. Sin reordenar líneas ajenas.

## Verificación

- `npm run build` ✅ (chunks `EscenaCafe-*.js` y `Mundo3DCafe-*.{js,css}` emitidos).
- Smoke test del framework ✅ 8/8 (incluye el caso nuevo `cafe → 3d` / degrada a `infografia`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)